### PR TITLE
HHH-15344 - Ability to apply testing annotations at method-level

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/integrator/spi/Integrator.java
+++ b/hibernate-core/src/main/java/org/hibernate/integrator/spi/Integrator.java
@@ -45,8 +45,6 @@ public interface Integrator {
 	 * @param metadata The fully initialized boot-time mapping model
 	 * @param bootstrapContext The context for bootstrapping of the SessionFactory
 	 * @param sessionFactory The SessionFactory being created
-	 *
-	 * todo (6.0) : why pass the `serviceRegistry`?  Why not just grab it from the SessionFactory?
 	 */
 	@Incubating
 	default void integrate(

--- a/hibernate-testing/README.adoc
+++ b/hibernate-testing/README.adoc
@@ -1,4 +1,7 @@
 The `hibernate-testing` module of Hibernate ORM defines utilities for writing
-tests easier....
+tests easier.
 
-// todo : write more (duh)
+This documentation focuses on the JUnit 5 & annotation based testing support...
+
+
+// todo (6.1) : write more (duh)

--- a/hibernate-testing/README.adoc
+++ b/hibernate-testing/README.adoc
@@ -1,0 +1,4 @@
+The `hibernate-testing` module of Hibernate ORM defines utilities for writing
+tests easier....
+
+// todo : write more (duh)

--- a/hibernate-testing/src/main/java/org/hibernate/testing/orm/junit/BootstrapServiceRegistry.java
+++ b/hibernate-testing/src/main/java/org/hibernate/testing/orm/junit/BootstrapServiceRegistry.java
@@ -18,8 +18,8 @@ import org.hibernate.integrator.spi.Integrator;
  * Used to define the bootstrap ServiceRegistry to be used for testing.
  */
 @Inherited
-@Target( ElementType.TYPE )
-@Retention( RetentionPolicy.RUNTIME )
+@Target({ElementType.TYPE, ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
 
 @ServiceRegistryFunctionalTesting
 public @interface BootstrapServiceRegistry {

--- a/hibernate-testing/src/main/java/org/hibernate/testing/orm/junit/DomainModel.java
+++ b/hibernate-testing/src/main/java/org/hibernate/testing/orm/junit/DomainModel.java
@@ -12,8 +12,6 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-import jakarta.persistence.SharedCacheMode;
-
 import org.hibernate.boot.model.TypeContributor;
 import org.hibernate.cache.spi.access.AccessType;
 
@@ -21,6 +19,8 @@ import org.hibernate.testing.orm.domain.DomainModelDescriptor;
 import org.hibernate.testing.orm.domain.StandardDomainModel;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.extension.ExtendWith;
+
+import jakarta.persistence.SharedCacheMode;
 
 /**
  * @asciidoc
@@ -81,7 +81,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
  * @author Steve Ebersole
  */
 @Inherited
-@Target(ElementType.TYPE)
+@Target({ElementType.TYPE, ElementType.METHOD})
 @Retention(RetentionPolicy.RUNTIME)
 
 @TestInstance( TestInstance.Lifecycle.PER_CLASS )

--- a/hibernate-testing/src/main/java/org/hibernate/testing/orm/junit/DomainModelExtension.java
+++ b/hibernate-testing/src/main/java/org/hibernate/testing/orm/junit/DomainModelExtension.java
@@ -99,7 +99,7 @@ public class DomainModelExtension
 	}
 
 	private static ExtensionContext.Store locateExtensionStore(Object testInstance, ExtensionContext context) {
-		return JUnitHelper.locateExtensionStore( ServiceRegistryExtension.class, context, testInstance );
+		return JUnitHelper.locateExtensionStore( DomainModelExtension.class, context, testInstance );
 	}
 
 	private static DomainModelScope createDomainModelScope(
@@ -199,27 +199,13 @@ public class DomainModelExtension
 	}
 
 	public static DomainModelScope findDomainModelScope(Object testInstance, ExtensionContext context) {
-		// todo : allow for method-level
-
 		final ExtensionContext.Store store = locateExtensionStore( testInstance, context );
 		final DomainModelScope existing = (DomainModelScope) store.get( MODEL_KEY );
 		if ( existing != null ) {
 			return existing;
 		}
 
-		final Optional<DomainModel> domainModelAnnRef = AnnotationSupport.findAnnotation(
-				context.getElement().get(),
-				DomainModel.class
-		);
-
-		if ( domainModelAnnRef.isEmpty() ) {
-			throw new RuntimeException( "Could not locate @DomainModel annotation : " + context.getDisplayName() );
-		}
-
-		final DomainModelScope created = createDomainModelScope( testInstance, domainModelAnnRef, context );
-		locateExtensionStore( testInstance, context ).put( MODEL_KEY, created );
-
-		return created;
+		throw new RuntimeException( "Could not locate @DomainModel annotation : " + context.getDisplayName() );
 	}
 
 	protected static void applyCacheSettings(Metadata metadata, boolean overrideCacheStrategy, String cacheConcurrencyStrategy) {

--- a/hibernate-testing/src/main/java/org/hibernate/testing/orm/junit/DomainModelFunctionalTesting.java
+++ b/hibernate-testing/src/main/java/org/hibernate/testing/orm/junit/DomainModelFunctionalTesting.java
@@ -20,12 +20,9 @@ import org.junit.jupiter.api.extension.ExtendWith;
  */
 @Inherited
 @Retention( RetentionPolicy.RUNTIME )
-@Target({ElementType.TYPE, ElementType.ANNOTATION_TYPE})
+@Target({ElementType.TYPE, ElementType.METHOD})
 
 @TestInstance( TestInstance.Lifecycle.PER_CLASS )
-
-//@ExtendWith( ServiceRegistryExtension.class )
-//@ExtendWith( ServiceRegistryParameterResolver.class )
 
 @ServiceRegistryFunctionalTesting
 

--- a/hibernate-testing/src/main/java/org/hibernate/testing/orm/junit/FailureExpected.java
+++ b/hibernate-testing/src/main/java/org/hibernate/testing/orm/junit/FailureExpected.java
@@ -13,7 +13,6 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
@@ -24,7 +23,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
  * @author Steve Ebersole
  */
 @Inherited
-@Target({ElementType.TYPE, ElementType.METHOD, ElementType.ANNOTATION_TYPE})
+@Target({ElementType.TYPE, ElementType.METHOD})
 @Retention(RetentionPolicy.RUNTIME)
 @Repeatable( FailureExpectedGroup.class )
 

--- a/hibernate-testing/src/main/java/org/hibernate/testing/orm/junit/FailureExpectedGroup.java
+++ b/hibernate-testing/src/main/java/org/hibernate/testing/orm/junit/FailureExpectedGroup.java
@@ -12,14 +12,13 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * @author Steve Ebersole
  */
 @Inherited
-@Target({ElementType.TYPE, ElementType.METHOD, ElementType.ANNOTATION_TYPE})
+@Target({ElementType.TYPE, ElementType.METHOD})
 @Retention(RetentionPolicy.RUNTIME)
 
 @ExtendWith( FailureExpectedExtension.class )

--- a/hibernate-testing/src/main/java/org/hibernate/testing/orm/junit/FunctionalEntityManagerFactoryTesting.java
+++ b/hibernate-testing/src/main/java/org/hibernate/testing/orm/junit/FunctionalEntityManagerFactoryTesting.java
@@ -32,7 +32,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
  * @author Chris Cranford
  */
 @Retention(RetentionPolicy.RUNTIME)
-@Target(ElementType.TYPE)
+@Target({ElementType.TYPE, ElementType.METHOD})
 @Inherited
 @TestInstance(TestInstance.Lifecycle.PER_CLASS )
 @ExtendWith(EntityManagerFactoryScopeExtension.class)

--- a/hibernate-testing/src/main/java/org/hibernate/testing/orm/junit/LoggingInspections.java
+++ b/hibernate-testing/src/main/java/org/hibernate/testing/orm/junit/LoggingInspections.java
@@ -23,7 +23,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
  * better option.
  */
 @Inherited
-@Target({ ElementType.TYPE, ElementType.ANNOTATION_TYPE})
+@Target({ElementType.TYPE})
 @Retention(RetentionPolicy.RUNTIME)
 
 @ExtendWith( LoggingInspectionsExtension.class )

--- a/hibernate-testing/src/main/java/org/hibernate/testing/orm/junit/MessageKeyInspection.java
+++ b/hibernate-testing/src/main/java/org/hibernate/testing/orm/junit/MessageKeyInspection.java
@@ -20,7 +20,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
  * For watching a multiple message-keys, see {@link LoggingInspections}
  */
 @Inherited
-@Target({ ElementType.TYPE, ElementType.ANNOTATION_TYPE, ElementType.METHOD })
+@Target({ ElementType.TYPE, ElementType.METHOD })
 @Retention(RetentionPolicy.RUNTIME)
 
 @ExtendWith( MessageKeyInspectionExtension.class )

--- a/hibernate-testing/src/main/java/org/hibernate/testing/orm/junit/RequiresDialect.java
+++ b/hibernate-testing/src/main/java/org/hibernate/testing/orm/junit/RequiresDialect.java
@@ -25,7 +25,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
  */
 @Inherited
 @Retention( RetentionPolicy.RUNTIME )
-@Target({ElementType.TYPE, ElementType.METHOD, ElementType.ANNOTATION_TYPE})
+@Target({ElementType.TYPE, ElementType.METHOD})
 @Repeatable( RequiresDialects.class )
 
 @ExtendWith( DialectFilterExtension.class )

--- a/hibernate-testing/src/main/java/org/hibernate/testing/orm/junit/RequiresDialectFeature.java
+++ b/hibernate-testing/src/main/java/org/hibernate/testing/orm/junit/RequiresDialectFeature.java
@@ -23,7 +23,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
  */
 @Inherited
 @Retention( RetentionPolicy.RUNTIME )
-@Target({ ElementType.TYPE, ElementType.METHOD, ElementType.ANNOTATION_TYPE})
+@Target({ ElementType.TYPE, ElementType.METHOD})
 @Repeatable( RequiresDialectFeatureGroup.class  )
 
 @ExtendWith( DialectFilterExtension.class )

--- a/hibernate-testing/src/main/java/org/hibernate/testing/orm/junit/RequiresDialectFeatureGroup.java
+++ b/hibernate-testing/src/main/java/org/hibernate/testing/orm/junit/RequiresDialectFeatureGroup.java
@@ -22,7 +22,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
  */
 @Inherited
 @Retention( RetentionPolicy.RUNTIME )
-@Target({ ElementType.TYPE, ElementType.METHOD, ElementType.ANNOTATION_TYPE})
+@Target({ ElementType.TYPE, ElementType.METHOD})
 
 @ExtendWith( DialectFilterExtension.class )
 public @interface RequiresDialectFeatureGroup {

--- a/hibernate-testing/src/main/java/org/hibernate/testing/orm/junit/RequiresDialects.java
+++ b/hibernate-testing/src/main/java/org/hibernate/testing/orm/junit/RequiresDialects.java
@@ -19,7 +19,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
  */
 @Inherited
 @Retention(RetentionPolicy.RUNTIME)
-@Target({ ElementType.TYPE, ElementType.METHOD, ElementType.ANNOTATION_TYPE })
+@Target({ ElementType.TYPE, ElementType.METHOD})
 
 @ExtendWith( DialectFilterExtension.class )
 public @interface RequiresDialects {

--- a/hibernate-testing/src/main/java/org/hibernate/testing/orm/junit/ServiceRegistry.java
+++ b/hibernate-testing/src/main/java/org/hibernate/testing/orm/junit/ServiceRegistry.java
@@ -62,7 +62,7 @@ import org.hibernate.service.spi.ServiceContributor;
  * @author Steve Ebersole
  */
 @Inherited
-@Target( ElementType.TYPE )
+@Target({ElementType.TYPE, ElementType.METHOD})
 @Retention( RetentionPolicy.RUNTIME )
 
 @ServiceRegistryFunctionalTesting

--- a/hibernate-testing/src/main/java/org/hibernate/testing/orm/junit/ServiceRegistryExtension.java
+++ b/hibernate-testing/src/main/java/org/hibernate/testing/orm/junit/ServiceRegistryExtension.java
@@ -22,7 +22,7 @@ import org.hibernate.service.spi.ServiceContributor;
 
 import org.hibernate.testing.boot.ExtraJavaServicesClassLoaderService;
 import org.hibernate.testing.boot.ExtraJavaServicesClassLoaderService.JavaServiceDescriptor;
-import org.junit.jupiter.api.extension.AfterAllCallback;
+import org.junit.jupiter.api.extension.BeforeEachCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.extension.TestExecutionExceptionHandler;
 import org.junit.jupiter.api.extension.TestInstancePostProcessor;
@@ -37,14 +37,84 @@ import org.jboss.logging.Logger;
  * @author Steve Ebersole
  */
 public class ServiceRegistryExtension
-		implements TestInstancePostProcessor, AfterAllCallback, TestExecutionExceptionHandler {
+		implements TestInstancePostProcessor, BeforeEachCallback, TestExecutionExceptionHandler {
 	private static final Logger log = Logger.getLogger( ServiceRegistryExtension.class );
 	private static final String REGISTRY_KEY = ServiceRegistryScope.class.getName();
 
-	public static StandardServiceRegistry findServiceRegistry(
-			Object testInstance,
-			ExtensionContext context) {
-		return findServiceRegistryScope( testInstance, context ).getRegistry();
+	@Override
+	public void postProcessTestInstance(Object testInstance, ExtensionContext context) {
+		log.tracef( "#postProcessTestInstance(%s, %s)", testInstance, context.getDisplayName() );
+
+		assert context.getTestClass().isPresent();
+
+		final Optional<BootstrapServiceRegistry> bsrAnnRef = AnnotationSupport.findAnnotation(
+				context.getElement().get(),
+				BootstrapServiceRegistry.class
+		);
+		final Optional<ServiceRegistry> ssrAnnRef = AnnotationSupport.findAnnotation(
+				context.getElement().get(),
+				ServiceRegistry.class
+		);
+
+		final ServiceRegistryScope created = createServiceRegistryScope( testInstance, bsrAnnRef, ssrAnnRef, context );
+		locateExtensionStore( testInstance, context ).put( REGISTRY_KEY, created );
+	}
+
+	@Override
+	public void beforeEach(ExtensionContext context) throws Exception {
+		assert context.getTestMethod().isPresent();
+		assert context.getRequiredTestMethod() == context.getElement().get();
+
+		Optional<BootstrapServiceRegistry> bsrAnnRef = AnnotationSupport.findAnnotation(
+				context.getElement().get(),
+				BootstrapServiceRegistry.class
+		);
+		Optional<ServiceRegistry> ssrAnnRef = AnnotationSupport.findAnnotation(
+				context.getElement().get(),
+				ServiceRegistry.class
+		);
+
+		if ( bsrAnnRef.isEmpty() && ssrAnnRef.isEmpty() ) {
+			// assume the annotations are defined on the class-level...
+			// will be validated by the parameter-resolver or consuming extension
+			return;
+		}
+		else if ( bsrAnnRef.isPresent() && ssrAnnRef.isPresent() ) {
+			// the method has both - use them -> fall through
+		}
+		else if ( bsrAnnRef.isPresent() ) {
+			// the method has BootstrapServiceRegistry but not ServiceRegistry
+			//
+			// see if there is a ServiceRegistry at the class-level:
+			//		yes -> use this class-level one
+			//		no -> treat it as implicit
+
+			ssrAnnRef = AnnotationSupport.findAnnotation(
+					context.getRequiredTestClass(),
+					ServiceRegistry.class
+			);
+		}
+		else if ( ssrAnnRef.isPresent() ) {
+			// the method has ServiceRegistry but not BootstrapServiceRegistry
+			//
+			// see if there is a BootstrapServiceRegistry at the class-level:
+			//		yes -> use this class-level one
+			//		no -> treat it as implicit
+
+			bsrAnnRef = AnnotationSupport.findAnnotation(
+					context.getRequiredTestClass(),
+					BootstrapServiceRegistry.class
+			);
+		}
+		else {
+			throw new RuntimeException( "Some clever text" );
+		}
+
+		final Object testInstance = context.getRequiredTestInstance();
+
+		final ServiceRegistryScope created = createServiceRegistryScope( testInstance, bsrAnnRef, ssrAnnRef, context );
+		final ExtensionContext.Store extensionStore = locateExtensionStore( testInstance, context );
+		extensionStore.put( REGISTRY_KEY, created );
 	}
 
 	private static ExtensionContext.Store locateExtensionStore(
@@ -57,62 +127,62 @@ public class ServiceRegistryExtension
 		log.tracef( "#findServiceRegistryScope(%s, %s)", testInstance, context.getDisplayName() );
 
 		final ExtensionContext.Store store = locateExtensionStore( testInstance, context );
-
-		ServiceRegistryScopeImpl existingScope = (ServiceRegistryScopeImpl) store.get( REGISTRY_KEY );
+		final ServiceRegistryScopeImpl existingScope = (ServiceRegistryScopeImpl) store.get( REGISTRY_KEY );
 
 		if ( existingScope == null ) {
-			log.debugf( "Creating ServiceRegistryScope - %s", context.getDisplayName() );
-
-			final BootstrapServiceRegistryProducer bsrProducer;
-
-			final Optional<BootstrapServiceRegistry> bsrAnnWrapper = AnnotationSupport.findAnnotation(
-					context.getElement().get(),
-					BootstrapServiceRegistry.class
-			);
-
-			if ( bsrAnnWrapper.isPresent() ) {
-				bsrProducer = bsrBuilder -> {
-					final BootstrapServiceRegistry bsrAnn = bsrAnnWrapper.get();
-					configureJavaServices( bsrAnn, bsrBuilder );
-					configureIntegrators( bsrAnn, bsrBuilder );
-
-					return bsrBuilder.enableAutoClose().build();
-				};
-			}
-			else {
-				bsrProducer = BootstrapServiceRegistryBuilder::build;
-			}
-
-			final ServiceRegistryProducer ssrProducer;
-
-			if ( testInstance instanceof ServiceRegistryProducer ) {
-				ssrProducer = (ServiceRegistryProducer) testInstance;
-			}
-			else {
-				ssrProducer = new ServiceRegistryProducerImpl(context);
-			}
-
-			final ServiceRegistryScopeImpl scope = new ServiceRegistryScopeImpl( bsrProducer, ssrProducer );
-			scope.getRegistry();
-
-			locateExtensionStore( testInstance, context ).put( REGISTRY_KEY, scope );
-
-			if ( testInstance instanceof ServiceRegistryScopeAware ) {
-				( (ServiceRegistryScopeAware) testInstance ).injectServiceRegistryScope( scope );
-			}
-			return scope;
+			throw new RuntimeException( "No ServiceRegistryScope known in context" );
 		}
 
 		return existingScope;
 	}
 
+	private static ServiceRegistryScopeImpl createServiceRegistryScope(
+			Object testInstance,
+			Optional<BootstrapServiceRegistry> bsrAnnRef,
+			Optional<ServiceRegistry> ssrAnnRef,
+			ExtensionContext context) {
+		log.debugf( "Creating ServiceRegistryScope - %s", context.getDisplayName() );
+
+		final BootstrapServiceRegistryProducer bsrProducer;
+
+		//noinspection OptionalIsPresent
+		if ( bsrAnnRef.isPresent() ) {
+			bsrProducer = bsrBuilder -> {
+				final BootstrapServiceRegistry bsrAnn = bsrAnnRef.get();
+				configureJavaServices( bsrAnn, bsrBuilder );
+				configureIntegrators( bsrAnn, bsrBuilder );
+
+				return bsrBuilder.enableAutoClose().build();
+			};
+		}
+		else {
+			bsrProducer = BootstrapServiceRegistryBuilder::build;
+		}
+
+		final ServiceRegistryProducer ssrProducer;
+
+		if ( testInstance instanceof ServiceRegistryProducer ) {
+			ssrProducer = (ServiceRegistryProducer) testInstance;
+		}
+		else {
+			ssrProducer = new ServiceRegistryProducerImpl( ssrAnnRef );
+		}
+
+		final ServiceRegistryScopeImpl scope = new ServiceRegistryScopeImpl( bsrProducer, ssrProducer );
+		scope.getRegistry();
+
+		if ( testInstance instanceof ServiceRegistryScopeAware ) {
+			( (ServiceRegistryScopeAware) testInstance ).injectServiceRegistryScope( scope );
+		}
+
+		return scope;
+	}
+
 	private static class ServiceRegistryProducerImpl implements ServiceRegistryProducer{
-		private final ExtensionContext context;
-		public ServiceRegistryProducerImpl(ExtensionContext context) {
-			this.context = context;
-			if ( !context.getElement().isPresent() ) {
-				throw new RuntimeException( "Unable to determine how to handle given ExtensionContext : " + context.getDisplayName() );
-			}
+		private final Optional<ServiceRegistry> ssrAnnRef;
+
+		public ServiceRegistryProducerImpl(Optional<ServiceRegistry> ssrAnnRef) {
+			this.ssrAnnRef = ssrAnnRef;
 		}
 
 		@Override
@@ -120,13 +190,8 @@ public class ServiceRegistryExtension
 			// set some baseline test settings
 			ssrb.applySetting( AvailableSettings.STATEMENT_INSPECTOR, org.hibernate.testing.jdbc.SQLStatementInspector.class );
 
-			final Optional<ServiceRegistry> ssrAnnWrapper = AnnotationSupport.findAnnotation(
-					context.getElement().get(),
-					ServiceRegistry.class
-			);
-
-			if ( ssrAnnWrapper.isPresent() ) {
-				final ServiceRegistry serviceRegistryAnn = ssrAnnWrapper.get();
+			if ( ssrAnnRef.isPresent() ) {
+				final ServiceRegistry serviceRegistryAnn = ssrAnnRef.get();
 				configureServices( serviceRegistryAnn, ssrb );
 			}
 
@@ -218,28 +283,22 @@ public class ServiceRegistryExtension
 		}
 	}
 
-	@Override
-	public void postProcessTestInstance(Object testInstance, ExtensionContext context) {
-		log.tracef( "#postProcessTestInstance(%s, %s)", testInstance, context.getDisplayName() );
-		findServiceRegistryScope( testInstance, context );
-	}
-
-	@Override
-	public void afterAll(ExtensionContext context) {
-		log.tracef( "#afterAll(%s)", context.getDisplayName() );
-
-		final Object testInstance = context.getRequiredTestInstance();
-
-		if ( testInstance instanceof ServiceRegistryScopeAware ) {
-			( (ServiceRegistryScopeAware) testInstance ).injectServiceRegistryScope( null );
-		}
-
-		final ExtensionContext.Store store = locateExtensionStore( testInstance, context );
-		final ServiceRegistryScopeImpl scope = (ServiceRegistryScopeImpl) store.remove( REGISTRY_KEY );
-		if ( scope != null ) {
-			scope.close();
-		}
-	}
+//	@Override
+//	public void afterAll(ExtensionContext context) {
+//		log.tracef( "#afterAll(%s)", context.getDisplayName() );
+//
+//		final Object testInstance = context.getRequiredTestInstance();
+//
+//		if ( testInstance instanceof ServiceRegistryScopeAware ) {
+//			( (ServiceRegistryScopeAware) testInstance ).injectServiceRegistryScope( null );
+//		}
+//
+//		final ExtensionContext.Store store = locateExtensionStore( testInstance, context );
+//		final ServiceRegistryScopeImpl scope = (ServiceRegistryScopeImpl) store.remove( REGISTRY_KEY );
+//		if ( scope != null ) {
+//			scope.close();
+//		}
+//	}
 
 	@Override
 	public void handleTestExecutionException(ExtensionContext context, Throwable throwable) throws Throwable {

--- a/hibernate-testing/src/main/java/org/hibernate/testing/orm/junit/ServiceRegistryExtension.java
+++ b/hibernate-testing/src/main/java/org/hibernate/testing/orm/junit/ServiceRegistryExtension.java
@@ -61,10 +61,7 @@ public class ServiceRegistryExtension
 	}
 
 	@Override
-	public void beforeEach(ExtensionContext context) throws Exception {
-		assert context.getTestMethod().isPresent();
-		assert context.getRequiredTestMethod() == context.getElement().get();
-
+	public void beforeEach(ExtensionContext context) {
 		Optional<BootstrapServiceRegistry> bsrAnnRef = AnnotationSupport.findAnnotation(
 				context.getElement().get(),
 				BootstrapServiceRegistry.class

--- a/hibernate-testing/src/main/java/org/hibernate/testing/orm/junit/ServiceRegistryFunctionalTesting.java
+++ b/hibernate-testing/src/main/java/org/hibernate/testing/orm/junit/ServiceRegistryFunctionalTesting.java
@@ -23,7 +23,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
  */
 @Inherited
 @Retention( RetentionPolicy.RUNTIME )
-@Target({ElementType.TYPE, ElementType.ANNOTATION_TYPE})
+@Target({ElementType.TYPE, ElementType.METHOD})
 
 @TestInstance( TestInstance.Lifecycle.PER_CLASS )
 

--- a/hibernate-testing/src/main/java/org/hibernate/testing/orm/junit/SessionFactory.java
+++ b/hibernate-testing/src/main/java/org/hibernate/testing/orm/junit/SessionFactory.java
@@ -23,7 +23,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
  * @author Steve Ebersole
  */
 @Inherited
-@Target( ElementType.TYPE )
+@Target({ElementType.TYPE, ElementType.METHOD})
 @Retention( RetentionPolicy.RUNTIME )
 
 @TestInstance( TestInstance.Lifecycle.PER_CLASS )

--- a/hibernate-testing/src/main/java/org/hibernate/testing/orm/junit/SessionFactoryFunctionalTesting.java
+++ b/hibernate-testing/src/main/java/org/hibernate/testing/orm/junit/SessionFactoryFunctionalTesting.java
@@ -33,7 +33,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
  */
 @Inherited
 @Retention( RetentionPolicy.RUNTIME )
-@Target({ElementType.TYPE, ElementType.ANNOTATION_TYPE})
+@Target({ElementType.TYPE, ElementType.METHOD})
 
 @TestInstance( TestInstance.Lifecycle.PER_CLASS )
 

--- a/hibernate-testing/src/main/java/org/hibernate/testing/orm/junit/SkipForDialect.java
+++ b/hibernate-testing/src/main/java/org/hibernate/testing/orm/junit/SkipForDialect.java
@@ -29,7 +29,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
  */
 @Inherited
 @Retention( RetentionPolicy.RUNTIME )
-@Target({ElementType.TYPE, ElementType.METHOD, ElementType.ANNOTATION_TYPE})
+@Target({ElementType.TYPE, ElementType.METHOD})
 @Repeatable( SkipForDialectGroup.class  )
 
 @ExtendWith( DialectFilterExtension.class )

--- a/hibernate-testing/src/test/java/org/hibernate/testing/annotations/AnotherEntity.java
+++ b/hibernate-testing/src/test/java/org/hibernate/testing/annotations/AnotherEntity.java
@@ -1,0 +1,43 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html.
+ */
+package org.hibernate.testing.annotations;
+
+import jakarta.persistence.Basic;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+
+/**
+ * @author Steve Ebersole
+ */
+@Entity
+public class AnotherEntity {
+	@Id
+	private Integer id;
+	@Basic
+	private String name;
+
+	private AnotherEntity() {
+		// for Hibernate use
+	}
+
+	public AnotherEntity(Integer id, String name) {
+		this.id = id;
+		this.name = name;
+	}
+
+	public Integer getId() {
+		return id;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+}

--- a/hibernate-testing/src/test/java/org/hibernate/testing/annotations/methods/DomainModelTesting.java
+++ b/hibernate-testing/src/test/java/org/hibernate/testing/annotations/methods/DomainModelTesting.java
@@ -1,0 +1,83 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html.
+ */
+package org.hibernate.testing.annotations.methods;
+
+import org.hibernate.boot.spi.MetadataImplementor;
+import org.hibernate.engine.config.spi.ConfigurationService;
+
+import org.hibernate.testing.annotations.AnEntity;
+import org.hibernate.testing.annotations.AnotherEntity;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.DomainModelScope;
+import org.hibernate.testing.orm.junit.ServiceRegistry;
+import org.hibernate.testing.orm.junit.Setting;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Steve Ebersole
+ */
+@ServiceRegistry( settings = @Setting( name = "simple", value = "simple-value"))
+@DomainModel( annotatedClasses = AnEntity.class )
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+public class DomainModelTesting {
+	private int executingTestOrder;
+
+	@Test
+	@Order( 2 )
+	public void testClassLevelAnnotations(DomainModelScope scope) {
+		executingTestOrder = 2;
+		classLevelAssertions( scope );
+	}
+
+	private void classLevelAssertions(DomainModelScope scope) {
+		assertThat( scope.getDomainModel().getEntityBinding( AnEntity.class.getName() ) ).isNotNull();
+		assertThat( scope.getDomainModel().getEntityBinding( AnotherEntity.class.getName() ) ).isNull();
+
+		settingAssertions( scope );
+	}
+
+	private void settingAssertions(DomainModelScope scope) {
+		final org.hibernate.service.ServiceRegistry serviceRegistry = ( (MetadataImplementor) scope.getDomainModel() )
+				.getTypeConfiguration()
+				.getServiceRegistry();
+		final ConfigurationService configurationService = serviceRegistry.getService( ConfigurationService.class );
+		assertThat( configurationService.getSettings().get( "simple" ) ).isEqualTo( "simple-value" );
+	}
+
+	@Test
+	@DomainModel( annotatedClasses = AnotherEntity.class )
+	@Order( 1 )
+	public void testMethodLevelAnnotations(DomainModelScope scope) {
+		executingTestOrder = 1;
+		methodLevelAssertions( scope );
+	}
+
+	private void methodLevelAssertions(DomainModelScope scope) {
+		assertThat( scope.getDomainModel().getEntityBinding( AnEntity.class.getName() ) ).isNull();
+		assertThat( scope.getDomainModel().getEntityBinding( AnotherEntity.class.getName() ) ).isNotNull();
+		settingAssertions( scope );
+	}
+
+	@AfterEach
+	public void doStuffAfter(DomainModelScope scope) {
+		if ( executingTestOrder == 1 ) {
+			methodLevelAssertions( scope );
+		}
+		else if ( executingTestOrder == 2 ) {
+			classLevelAssertions( scope );
+		}
+		else {
+			throw new RuntimeException( "boom" );
+		}
+	}
+}

--- a/hibernate-testing/src/test/java/org/hibernate/testing/annotations/methods/ServiceRegistryTesting.java
+++ b/hibernate-testing/src/test/java/org/hibernate/testing/annotations/methods/ServiceRegistryTesting.java
@@ -1,0 +1,87 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html.
+ */
+package org.hibernate.testing.annotations.methods;
+
+import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
+import org.hibernate.engine.config.spi.ConfigurationService;
+import org.hibernate.service.spi.ServiceContributor;
+
+import org.hibernate.testing.orm.junit.BootstrapServiceRegistry;
+import org.hibernate.testing.orm.junit.ServiceRegistry;
+import org.hibernate.testing.orm.junit.ServiceRegistryScope;
+import org.hibernate.testing.orm.junit.Setting;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Steve Ebersole
+ */
+@BootstrapServiceRegistry(javaServices = @BootstrapServiceRegistry.JavaService(
+		role = ServiceContributor.class,
+		impl = ServiceRegistryTesting.ServiceContributor1.class
+))
+@ServiceRegistry( settings = @Setting( name = "setting", value = "class-level"))
+public class ServiceRegistryTesting {
+
+	@Test
+	public void testClassLevel(ServiceRegistryScope scope) {
+		scope.withService( ConfigurationService.class, (configurationService) -> {
+			assertThat( configurationService.getSettings().get( "setting" ) ).isEqualTo( "class-level" );
+			assertThat( configurationService.getSettings().get( "contributed" ) ).isEqualTo( "contributed-1" );
+		} );
+	}
+
+	@Test
+	@BootstrapServiceRegistry(javaServices = @BootstrapServiceRegistry.JavaService(
+			role = ServiceContributor.class,
+			impl = ServiceRegistryTesting.ServiceContributor2.class
+	))
+	@ServiceRegistry( settings = @Setting( name = "setting", value = "method-level"))
+	public void testMethodLevel(ServiceRegistryScope scope) {
+		scope.withService( ConfigurationService.class, (configurationService) -> {
+			assertThat( configurationService.getSettings().get( "setting" ) ).isEqualTo( "method-level" );
+			assertThat( configurationService.getSettings().get( "contributed" ) ).isEqualTo( "contributed-2" );
+		} );
+	}
+
+	@Test
+	@ServiceRegistry( settings = @Setting( name = "setting", value = "mixed"))
+	public void testMethodLevelImplicitBootstrap(ServiceRegistryScope scope) {
+		scope.withService( ConfigurationService.class, (configurationService) -> {
+			assertThat( configurationService.getSettings().get( "setting" ) ).isEqualTo( "mixed" );
+			assertThat( configurationService.getSettings().get( "contributed" ) ).isEqualTo( "contributed-1" );
+		} );
+
+	}
+
+	@Test
+	@BootstrapServiceRegistry(javaServices = @BootstrapServiceRegistry.JavaService(
+			role = ServiceContributor.class,
+			impl = ServiceRegistryTesting.ServiceContributor2.class
+	))
+	public void testMethodLevelImplicitStandard(ServiceRegistryScope scope) {
+		scope.withService( ConfigurationService.class, (configurationService) -> {
+			assertThat( configurationService.getSettings().get( "setting" ) ).isEqualTo( "class-level" );
+			assertThat( configurationService.getSettings().get( "contributed" ) ).isEqualTo( "contributed-2" );
+		} );
+	}
+
+	public static class ServiceContributor1 implements ServiceContributor {
+		@Override
+		public void contribute(StandardServiceRegistryBuilder serviceRegistryBuilder) {
+			serviceRegistryBuilder.getSettings().put( "contributed", "contributed-1" );
+		}
+	}
+
+	public static class ServiceContributor2 implements ServiceContributor {
+		@Override
+		public void contribute(StandardServiceRegistryBuilder serviceRegistryBuilder) {
+			serviceRegistryBuilder.getSettings().put( "contributed", "contributed-2" );
+		}
+	}
+}

--- a/hibernate-testing/src/test/java/org/hibernate/testing/annotations/methods/SessionFactoryTesting.java
+++ b/hibernate-testing/src/test/java/org/hibernate/testing/annotations/methods/SessionFactoryTesting.java
@@ -1,0 +1,37 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html.
+ */
+package org.hibernate.testing.annotations.methods;
+
+import org.hibernate.stat.spi.StatisticsImplementor;
+
+import org.hibernate.testing.annotations.AnEntity;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Steve Ebersole
+ */
+@DomainModel( annotatedClasses = AnEntity.class )
+@SessionFactory( generateStatistics = true )
+public class SessionFactoryTesting {
+	@Test
+	public void testClassLevelAnnotations(SessionFactoryScope scope) {
+		final StatisticsImplementor statistics = scope.getSessionFactory().getStatistics();
+		assertThat( statistics.isStatisticsEnabled() ).isTrue();
+	}
+
+	@Test
+	@SessionFactory()
+	public void testMethodLevelAnnotations(SessionFactoryScope scope) {
+		final StatisticsImplementor statistics = scope.getSessionFactory().getStatistics();
+		assertThat( statistics.isStatisticsEnabled() ).isFalse();
+	}
+}

--- a/hibernate-testing/src/test/java/org/hibernate/testing/annotations/methods/package-info.java
+++ b/hibernate-testing/src/test/java/org/hibernate/testing/annotations/methods/package-info.java
@@ -1,0 +1,15 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html.
+ */
+
+/**
+ * Testing the ability to apply testing annotations at method-level
+ *
+ * See https://hibernate.atlassian.net/browse/HHH-15344
+ *
+ * @author Steve Ebersole
+ */
+package org.hibernate.testing.annotations.methods;


### PR DESCRIPTION
HHH-15344 - Ability to apply testing annotations at method-level

https://hibernate.atlassian.net/browse/HHH-15344

Ability to apply `@BootstrapServiceRegistry`, `@ServiceRegistry`, `@DomainModel` and `@SessionFactory on methods in addition to classes including natural mixing as well as "hiding"