### PR TITLE
Backport snapshot-publish.Jenkinsfile to branch 5.6

### DIFF
--- a/ci/snapshot-publish.Jenkinsfile
+++ b/ci/snapshot-publish.Jenkinsfile
@@ -1,0 +1,51 @@
+/*
+ * See https://github.com/hibernate/hibernate-jenkins-pipeline-helpers
+ */
+@Library('hibernate-jenkins-pipeline-helpers@1.5') _
+
+// Avoid running the pipeline on branch indexing
+if (currentBuild.getBuildCauses().toString().contains('BranchIndexingCause')) {
+  print "INFO: Build skipped due to trigger being Branch Indexing"
+  currentBuild.result = 'ABORTED'
+  return
+}
+
+pipeline {
+    agent {
+        label 'Fedora'
+    }
+    tools {
+        jdk 'OpenJDK 8 Latest'
+    }
+    options {
+  		rateLimitBuilds(throttle: [count: 1, durationName: 'hour', userBoost: true])
+        buildDiscarder(logRotator(numToKeepStr: '3', artifactNumToKeepStr: '3'))
+        disableConcurrentBuilds(abortPrevious: true)
+    }
+	stages {
+        stage('Checkout') {
+        	steps {
+				checkout scm
+			}
+		}
+		stage('Publish') {
+			steps {
+        configFileProvider([
+          configFile(fileId: 'ci-hibernate.deploy.settings.maven', variable: 'MAVEN_SETTINGS_PATH')
+        ]) {
+					sh '''./gradlew clean publishPublishedArtifactsPublicationToJboss-snapshots-repositoryRepository \
+						-Dmaven.settings=$MAVEN_SETTINGS_PATH \
+						--no-scan
+					'''
+				}
+			}
+        }
+    }
+    post {
+        always {
+    		configFileProvider([configFile(fileId: 'job-configuration.yaml', variable: 'JOB_CONFIGURATION_FILE')]) {
+            	notifyBuildResult maintainers: (String) readYaml(file: env.JOB_CONFIGURATION_FILE).notification?.email?.recipients
+            }
+        }
+    }
+}


### PR DESCRIPTION
I'm not *completely* sure that's the right command/settings, but from what I gathered from disabled (and probably obsolete...) Jenkins jobs, that should be close. Let's try, worst case the CI run will just fail?