### PR TITLE
HHH-15426 ASTUtil.generateTokenNameCache fails on instrumented classes

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/hql/internal/ast/util/ASTUtil.java
+++ b/hibernate-core/src/main/java/org/hibernate/hql/internal/ast/util/ASTUtil.java
@@ -386,8 +386,9 @@ public final class ASTUtil {
 
 	/**
 	 * Method to generate a map of token type names, keyed by their token type values.
+	 * Synthetic fields are ignored.
 	 *
-	 * @param tokenTypeInterface The *TokenTypes interface (or implementor of said interface).
+	 * @param tokenTypeInterface The *TokenTypes interface
 	 *
 	 * @return A compact map int -> tokenName in array format
 	 */
@@ -398,7 +399,7 @@ public final class ASTUtil {
 		//and this is all run at boot so at worst would fail fast.
 		final String[] names = new String[ fields.length + 2 ];
 		for ( final Field field : fields ) {
-			if ( Modifier.isStatic( field.getModifiers() ) ) {
+			if ( Modifier.isStatic( field.getModifiers() ) && ! field.isSynthetic() ) {
 				int idx = 0;
 				try {
 					idx = field.getInt( null );

--- a/hibernate-core/src/main/java/org/hibernate/tool/schema/ast/SqlScriptParser.java
+++ b/hibernate-core/src/main/java/org/hibernate/tool/schema/ast/SqlScriptParser.java
@@ -23,8 +23,6 @@ import antlr.TokenStream;
  * @author Steve Ebersole
  */
 public class SqlScriptParser extends GeneratedSqlScriptParser {
-	private static String[] TOKEN_NAMES = ASTUtil.generateTokenNameCache( GeneratedSqlScriptParserTokenTypes .class );
-
 	public static List<String> extractCommands(Reader reader) {
 		final List<String> statementList = new ArrayList<>();
 

--- a/hibernate-core/src/test/java/org/hibernate/hql/internal/ast/util/ASTUtilTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/hql/internal/ast/util/ASTUtilTest.java
@@ -1,0 +1,45 @@
+package org.hibernate.hql.internal.ast.util;
+
+import net.bytebuddy.ByteBuddy;
+import net.bytebuddy.description.modifier.FieldManifestation;
+import net.bytebuddy.description.modifier.Ownership;
+import net.bytebuddy.description.modifier.SyntheticState;
+import net.bytebuddy.description.modifier.Visibility;
+import net.bytebuddy.dynamic.DynamicType;
+import net.bytebuddy.dynamic.scaffold.subclass.ConstructorStrategy;
+import org.assertj.core.api.Assertions;
+import org.hibernate.testing.junit4.BaseUnitTestCase;
+import org.hibernate.tool.schema.ast.GeneratedSqlScriptParserTokenTypes;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class ASTUtilTest extends BaseUnitTestCase {
+
+    @Test
+    public void generateTokenNameCacheWithImplementator() {
+        // create an instrumented interface with a synthetic field
+        final DynamicType.Loaded<GeneratedSqlScriptParserTokenTypes> generatedClass = new ByteBuddy()
+                .subclass(GeneratedSqlScriptParserTokenTypes.class)
+                .defineField("$$customField$$", int[].class, Ownership.STATIC,
+                        SyntheticState.SYNTHETIC, Visibility.PUBLIC, FieldManifestation.FINAL)
+                .make()
+                .load(getClass().getClassLoader());
+
+        // compute 'normal' result
+        final String[] fieldsOrigin = ASTUtil.generateTokenNameCache(GeneratedSqlScriptParserTokenTypes.class);
+        // compute 'instrumented' result
+        final String[] fieldsImplementator = ASTUtil.generateTokenNameCache(generatedClass.getLoaded());
+        // even though size might vary, assert that known indexes are valid even with additional fields
+        Assertions.assertThat(fieldsImplementator)
+                .hasSizeGreaterThanOrEqualTo(fieldsOrigin.length)
+                .startsWith(fieldsOrigin);
+    }
+
+    @Test
+    public void generateTokenNameCache() {
+        // HHH-15426 : this test failed when run with code coverage under some IDEs.
+        final String[] fieldsByValue = ASTUtil.generateTokenNameCache(GeneratedSqlScriptParserTokenTypes.class);
+        Assert.assertEquals("BLOCK_COMMENT", fieldsByValue[GeneratedSqlScriptParserTokenTypes.BLOCK_COMMENT]);
+    }
+
+}


### PR DESCRIPTION
-exclude synthetic fields from generateTokenNameCache computation.
-fix javadoc to states that, and forbid 'implementor' that might be an invalid input
-remove unused private static TOKEN_NAMES from SqlScriptParser