### PR TITLE
HHH-15425 org.hibernate.QueryException: could not resolve property is thrown when Hibernate criteria tries to select the id of an association annotated with @NotFound

### DIFF
--- a/documentation/src/main/asciidoc/userguide/chapters/domain/associations.adoc
+++ b/documentation/src/main/asciidoc/userguide/chapters/domain/associations.adoc
@@ -417,20 +417,38 @@ include::{extrasdir}/associations-many-to-many-bidirectional-with-link-entity-li
 There is only one delete statement executed because, this time, the association is controlled by the `@ManyToOne` side which only has to monitor the state of the underlying foreign key relationship to trigger the right DML statement.
 
 [[associations-not-found]]
-==== `@NotFound` association mapping
+==== `@NotFound`
 
-When dealing with associations which are not enforced by a Foreign Key,
-it's possible to bump into inconsistencies if the child record cannot reference a parent entity.
+When dealing with associations which are not enforced by a physical foreign-key, it is possible
+for a non-null foreign-key value to point to a non-existent value on the associated entity's table.
 
-By default, Hibernate will complain whenever a child association references a non-existing parent record.
-However, you can configure this behavior so that Hibernate can ignore such an Exception and simply assign `null` as a parent object referenced.
-
-To ignore non-existing parent entity references, even though not really recommended, it's possible to use the annotation `org.hibernate.annotation.NotFound` annotation with a value of `org.hibernate.annotations.NotFoundAction.IGNORE`.
-
-[NOTE]
+[WARNING]
 ====
-The `@ManyToOne` and `@OneToOne` associations that are annotated with `@NotFound(action = NotFoundAction.IGNORE)` are always fetched eagerly even if the `fetch` strategy is set to `FetchType.LAZY`.
+Not enforcing physical foreign-keys at the database level is highly discouraged.
 ====
+
+Hibernate provides support for such models using the `@NotFound` annotation, which accepts a
+`NotFoundAction` value which indicates how Hibernate should behave when such broken foreign-keys
+are encountered -
+
+EXCEPTION:: (default) Hibernate will throw an exception (`FetchNotFoundException`)
+IGNORE:: the association will be treated as `null`
+
+Both `@NotFound(IGNORE)` and `@NotFound(EXCEPTION)` cause Hibernate to assume that there is
+no physical foreign-key.
+
+`@ManyToOne` and `@OneToOne` associations annotated with `@NotFound` are always fetched eagerly even
+if the `fetch` strategy is set to `FetchType.LAZY`.
+
+
+[TIP]
+====
+If the application itself manages the referential integrity and can guarantee that there are no
+broken foreign-keys, `jakarta.persistence.ForeignKey(NO_CONSTRAINT)` can be used instead.
+This will force Hibernate to not export physical foreign-keys, but still behave as if there is
+in terms of avoiding the downsides to `@NotFound`.
+====
+
 
 Considering the following `City` and `Person` entity mappings:
 
@@ -457,35 +475,91 @@ include::{sourcedir}/NotFoundTest.java[tags=associations-not-found-persist-examp
 When loading the `Person` entity, Hibernate is able to locate the associated `City` parent entity:
 
 [[associations-not-found-find-example]]
-.`@NotFound` find existing entity example
+.`@NotFound` - find existing entity example
 ====
 [source,java]
 ----
-include::{sourcedir}/NotFoundTest.java[tags=associations-not-found-find-example,indent=0]
+include::{sourcedir}/NotFoundTest.java[tags=associations-not-found-find-baseline,indent=0]
 ----
 ====
 
-However, if we change the `cityName` attribute to a non-existing city's name:
+However, if we break the foreign-key:
 
 [[associations-not-found-non-existing-persist-example]]
-.`@NotFound` change to non-existing City example
+.Break the foreign-key
 ====
 [source,java]
 ----
-include::{sourcedir}/NotFoundTest.java[tags=associations-not-found-non-existing-persist-example,indent=0]
+include::{sourcedir}/NotFoundTest.java[tags=associations-not-found-break-fk,indent=0]
 ----
 ====
 
 Hibernate is not going to throw any exception, and it will assign a value of `null` for the non-existing `City` entity reference:
 
 [[associations-not-found-non-existing-find-example]]
-.`@NotFound` find non-existing City example
+.`@NotFound` - find non-existing City example
 ====
 [source,java]
 ----
 include::{sourcedir}/NotFoundTest.java[tags=associations-not-found-non-existing-find-example,indent=0]
 ----
 ====
+
+`@NotFound` also affects how the association is treated as "implicit joins" in HQL and Criteria.
+When there is a physical foreign-key, Hibernate can safely assume that the value in the foreign-key's
+key-column(s) will match the value in the target-column(s) because the database makes sure that
+is the case.  However, `@NotFound` forces Hibernate to perform a physical join for implicit joins
+when it might not be needed otherwise.
+
+Using the `Person` / `City` model, consider the query `from Person p where p.city.id is null`.
+
+Normally Hibernate would not need the join between the `Person` table and the `City` table because
+a physical foreign-key would ensure that any non-null value in the `Person.cityName` column
+has a matching non-null value in the `City.name` column.
+
+However, with `@NotFound` mappings it is possible to have a broken association because there is no
+physical foreign-key enforcing the relation.  As seen in <<associations-not-found-non-existing-persist-example>>,
+the `Person.cityName` column for John Doe has been changed from "New York" to "Atlantis" even though
+there is no `City` in the database named "Atlantis".  Hibernate is not able to trust the referring
+foreign-key value ("Atlantis") has a matching target value, so it must join to the `City` table to
+resolve the `city.id` value.
+
+
+[[associations-not-found-implicit-join-example]]
+.Implicit join example
+====
+[source,java]
+----
+include::{sourcedir}/NotFoundTest.java[tags=associations-not-found-implicit-join-example,indent=0]
+----
+====
+
+Neither result includes a match for "John Doe" because the inner-join filters out that row.
+
+Hibernate does support a means to refer specifically to the key column (`Person.cityName`) in a query
+using the special `fk(..)` function.  E.g.
+
+[[associations-not-found-implicit-join-example]]
+.Implicit join example
+====
+[source,java]
+----
+include::{sourcedir}/NotFoundTest.java[tags=associations-not-found-fk-function-example,indent=0]
+----
+====
+
+With Hibernate Criteria it is possible to use `Projections.fk(...)`  to select the foreign key value of an association
+and `Restrictions.fkEq(...)`, `Restrictions.fkNe(...)`, `Restrictions.fkIsNotNull(...)` and ``Restrictions.fkIsNull(...)`, E.g.
+
+[[associations-not-found-implicit-join-example]]
+.Implicit join example
+====
+[source,java]
+----
+include::{sourcedir}/NotFoundTest.java[tags=associations-not-found-fk-criteria-example,indent=0]
+----
+====
+
 
 [[associations-any]]
 ==== `@Any` mapping

--- a/documentation/src/test/java/org/hibernate/userguide/associations/NotFoundTest.java
+++ b/documentation/src/test/java/org/hibernate/userguide/associations/NotFoundTest.java
@@ -1,21 +1,35 @@
 package org.hibernate.userguide.associations;
 
 import java.io.Serializable;
+import java.util.List;
+import java.util.Map;
+
 import javax.persistence.Entity;
-import javax.persistence.FetchType;
-import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import javax.persistence.Table;
 
+import org.hibernate.Criteria;
+import org.hibernate.Session;
 import org.hibernate.annotations.NotFound;
 import org.hibernate.annotations.NotFoundAction;
+import org.hibernate.criterion.ForeignKeyExpression;
+import org.hibernate.criterion.ForeingKeyProjection;
+import org.hibernate.criterion.ProjectionList;
+import org.hibernate.criterion.Projections;
+import org.hibernate.criterion.PropertyProjection;
+import org.hibernate.criterion.Restrictions;
 import org.hibernate.jpa.test.BaseEntityManagerFunctionalTestCase;
 
+import org.hibernate.testing.jdbc.SQLStatementInterceptor;
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.hibernate.testing.transaction.TransactionUtil.doInJPA;
+import static org.hibernate.testing.transaction.TransactionUtil2.inTransaction;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 
@@ -23,6 +37,13 @@ import static org.junit.Assert.assertNull;
  * @author Fábio Ueno
  */
 public class NotFoundTest extends BaseEntityManagerFunctionalTestCase {
+
+	private SQLStatementInterceptor sqlStatementInterceptor;
+
+	@Override
+	protected void addConfigOptions(Map options) {
+		sqlStatementInterceptor = new SQLStatementInterceptor( options );
+	}
 
 	@Override
 	protected Class<?>[] getAnnotatedClasses() {
@@ -32,75 +53,182 @@ public class NotFoundTest extends BaseEntityManagerFunctionalTestCase {
 		};
 	}
 
-	@Test
-	public void test() {
-		doInJPA( this::entityManagerFactory, entityManager -> {
+	@Before
+	public void createTestData() {
+		inTransaction( entityManagerFactory(), (entityManager) -> {
 			//tag::associations-not-found-persist-example[]
-			City _NewYork = new City();
-			_NewYork.setName( "New York" );
-			entityManager.persist( _NewYork );
+			City newYork = new City( 1, "New York" );
+			entityManager.persist( newYork );
 
-			Person person = new Person();
-			person.setId( 1L );
-			person.setName( "John Doe" );
-			person.setCityName( "New York" );
+			Person person = new Person( 1, "John Doe", newYork );
 			entityManager.persist( person );
 			//end::associations-not-found-persist-example[]
 		} );
+	}
 
-		doInJPA( this::entityManagerFactory, entityManager -> {
-			//tag::associations-not-found-find-example[]
-			Person person = entityManager.find( Person.class, 1L );
-			assertEquals( "New York", person.getCity().getName() );
-			//end::associations-not-found-find-example[]
-
-			//tag::associations-not-found-non-existing-persist-example[]
-			person.setCityName( "Atlantis" );
-			//end::associations-not-found-non-existing-persist-example[]
-
+	@After
+	public void dropTestData() {
+		inTransaction( entityManagerFactory(), (em) -> {
+			em.createQuery( "delete Person" ).executeUpdate();
+			em.createQuery( "delete City" ).executeUpdate();
 		} );
+	}
 
-		doInJPA( this::entityManagerFactory, entityManager -> {
+	@Test
+	public void test() {
+		doInJPA(this::entityManagerFactory, entityManager -> {
+			//tag::associations-not-found-find-baseline[]
+			Person person = entityManager.find(Person.class, 1);
+			assertEquals("New York", person.getCity().getName());
+			//end::associations-not-found-find-baseline[]
+		});
+
+		breakForeignKey();
+
+		doInJPA(this::entityManagerFactory, entityManager -> {
 			//tag::associations-not-found-non-existing-find-example[]
-			Person person = entityManager.find( Person.class, 1L );
+			Person person = entityManager.find(Person.class, 1);
 
-			assertEquals( "Atlantis", person.getCityName() );
-			assertNull( null, person.getCity() );
+			assertNull(null, person.getCity());
 			//end::associations-not-found-non-existing-find-example[]
+		});
+	}
+
+	private void breakForeignKey() {
+		inTransaction( entityManagerFactory(), (em) -> {
+			//tag::associations-not-found-break-fk[]
+			// the database allows this because there is no physical foreign-key
+			em.createQuery( "delete City" ).executeUpdate();
+			//end::associations-not-found-break-fk[]
+		} );
+	}
+
+	@Test
+	public void queryTest() {
+		breakForeignKey();
+
+		inTransaction( entityManagerFactory(), (entityManager) -> {
+			//tag::associations-not-found-implicit-join-example[]
+			final List<Person> nullResults = entityManager
+					.createQuery( "from Person p where p.city.id is null", Person.class )
+					.list();
+			assertThat( nullResults ).isEmpty();
+
+			final List<Person> nonNullResults = entityManager
+					.createQuery( "from Person p where p.city.id is not null", Person.class )
+					.list();
+			assertThat( nonNullResults ).isEmpty();
+			//end::associations-not-found-implicit-join-example[]
+		} );
+	}
+
+	@Test
+	public void queryTestFk() {
+		breakForeignKey();
+
+		inTransaction( entityManagerFactory(), (entityManager) -> {
+			sqlStatementInterceptor.clear();
+			//tag::associations-not-found-fk-function-example[]
+			final List<String> nullResults = entityManager
+					.createQuery( "select p.name from Person p where fk( p.city ) is null", String.class )
+					.list();
+
+			assertThat( nullResults ).isEmpty();
+
+			final List<String> nonNullResults = entityManager
+					.createQuery( "select p.name from Person p where fk( p.city ) is not null", String.class )
+					.list();
+			assertThat( nonNullResults ).hasSize( 1 );
+			assertThat( nonNullResults.get( 0 ) ).isEqualTo( "John Doe" );
+			//end::associations-not-found-fk-function-example[]
+
+			// In addition, make sure that the two executed queries do not create a join
+			assertThat( sqlStatementInterceptor.getQueryCount() ).isEqualTo( 2 );
+			assertThat( sqlStatementInterceptor.getSqlQueries().get( 0 ) ).doesNotContain( " join " );
+			assertThat( sqlStatementInterceptor.getSqlQueries().get( 1 ) ).doesNotContain( " join " );
+		} );
+	}
+
+	@Test
+	public void cirteriaTestFk() {
+		breakForeignKey();
+
+		inTransaction( entityManagerFactory(), (entityManager) -> {
+			sqlStatementInterceptor.clear();
+			Session session = entityManager.unwrap( Session.class );
+			//tag::associations-not-found-fk-criteria-example[]
+			Criteria criteria = session.createCriteria( Person.class );
+			ProjectionList projList = Projections.projectionList();
+			projList.add( Projections.property( "name" ) );
+			criteria.setProjection( projList );
+			criteria.add( Restrictions.fkIsNull( "city" ) );
+			final List<Integer> nullResults = criteria.list();
+
+			assertThat( nullResults ).isEmpty();
+
+			criteria = session.createCriteria( Person.class );
+			projList = Projections.projectionList();
+			projList.add( Projections.property( "name" ) );
+			criteria.setProjection( projList );
+			criteria.add( Restrictions.fkIsNotNull( "city" ) );
+			final List<String> nonNullResults = criteria.list();
+
+			assertThat( nonNullResults ).hasSize( 1 );
+			assertThat( nonNullResults.get( 0 ) ).isEqualTo( "John Doe" );
+
+			// selecting Person -> city Foreign key
+			criteria = session.createCriteria( Person.class );
+			projList = Projections.projectionList();
+			projList.add( Projections.fk( "city" ) );
+			criteria.setProjection( projList );
+			criteria.add( Restrictions.fkIsNotNull( "city" ) );
+
+			final List<Integer> foreigKeyResults = criteria.list();
+			assertThat( foreigKeyResults ).hasSize( 1 );
+			assertThat( foreigKeyResults.get( 0 ) ).isEqualTo( 1 );
+			//end::associations-not-found-fk-criteria-example[]
+
+			// In addition, make sure that the two executed queries do not create a join
+			assertThat( sqlStatementInterceptor.getQueryCount() ).isEqualTo( 3 );
+			assertThat( sqlStatementInterceptor.getSqlQueries().get( 0 ) ).doesNotContain( " join " );
+			assertThat( sqlStatementInterceptor.getSqlQueries().get( 1 ) ).doesNotContain( " join " );
+			assertThat( sqlStatementInterceptor.getSqlQueries().get( 2 ) ).doesNotContain( " join " );
 		} );
 	}
 
 	//tag::associations-not-found-domain-model-example[]
-	@Entity
-	@Table( name = "Person" )
+	@Entity(name = "Person")
+	@Table(name = "Person")
 	public static class Person {
 
 		@Id
-		private Long id;
-
+		private Integer id;
 		private String name;
 
-		private String cityName;
-
 		@ManyToOne
-		@NotFound ( action = NotFoundAction.IGNORE )
-		@JoinColumn(
-			name = "cityName",
-			referencedColumnName = "name",
-			insertable = false,
-			updatable = false
-		)
+		@NotFound(action = NotFoundAction.IGNORE)
+		@JoinColumn(name = "city_fk", referencedColumnName = "id")
 		private City city;
 
 		//Getters and setters are omitted for brevity
 
-	//end::associations-not-found-domain-model-example[]
+		//end::associations-not-found-domain-model-example[]
 
-		public Long getId() {
+
+		public Person() {
+		}
+
+		public Person(Integer id, String name, City city) {
+			this.id = id;
+			this.name = name;
+			this.city = city;
+		}
+
+		public Integer getId() {
 			return id;
 		}
 
-		public void setId(Long id) {
+		public void setId(Integer id) {
 			this.id = id;
 		}
 
@@ -110,42 +238,41 @@ public class NotFoundTest extends BaseEntityManagerFunctionalTestCase {
 
 		public void setName(String name) {
 			this.name = name;
-		}
-
-		public String getCityName() {
-			return cityName;
-		}
-
-		public void setCityName(String cityName) {
-			this.cityName = cityName;
-			this.city = null;
 		}
 
 		public City getCity() {
 			return city;
 		}
-	//tag::associations-not-found-domain-model-example[]
+		//tag::associations-not-found-domain-model-example[]
 	}
 
-	@Entity
-	@Table( name = "City" )
+	@Entity(name = "City")
+	@Table(name = "City")
 	public static class City implements Serializable {
 
 		@Id
-		@GeneratedValue
-		private Long id;
+		private Integer id;
 
 		private String name;
 
 		//Getters and setters are omitted for brevity
 
-	//end::associations-not-found-domain-model-example[]
+		//end::associations-not-found-domain-model-example[]
 
-		public Long getId() {
+
+		public City() {
+		}
+
+		public City(Integer id, String name) {
+			this.id = id;
+			this.name = name;
+		}
+
+		public Integer getId() {
 			return id;
 		}
 
-		public void setId(Long id) {
+		public void setId(Integer id) {
 			this.id = id;
 		}
 
@@ -156,7 +283,7 @@ public class NotFoundTest extends BaseEntityManagerFunctionalTestCase {
 		public void setName(String name) {
 			this.name = name;
 		}
-	//tag::associations-not-found-domain-model-example[]
+		//tag::associations-not-found-domain-model-example[]
 	}
 	//end::associations-not-found-domain-model-example[]
 }

--- a/hibernate-core/src/main/java/org/hibernate/criterion/CriteriaQuery.java
+++ b/hibernate-core/src/main/java/org/hibernate/criterion/CriteriaQuery.java
@@ -8,6 +8,7 @@ package org.hibernate.criterion;
 
 import org.hibernate.Criteria;
 import org.hibernate.HibernateException;
+import org.hibernate.cfg.NotYetImplementedException;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.engine.spi.TypedValue;
 import org.hibernate.type.Type;
@@ -200,4 +201,16 @@ public interface CriteriaQuery {
 	 * @return The generated alias
 	 */
 	public String generateSQLAlias();
+
+	default Type getForeignKeyType(Criteria criteria, String associationPropertyName){
+		throw new NotYetImplementedException("CriteriaQuery#getForeignKeyType() has not been yet implemented!");
+	}
+
+	default String[] getForeignKeyColumns(Criteria criteria, String associationPropertyName){
+		throw new NotYetImplementedException("CriteriaQuery#getForeignKeyColumns() has not been yet implemented!");
+	}
+
+	default TypedValue getForeignKeyTypeValue(Criteria criteria, String associationPropertyName, Object value){
+		throw new NotYetImplementedException("CriteriaQuery#getForeignKeyTypeValue() has not been yet implemented!");
+	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/criterion/ForeignKeyExpression.java
+++ b/hibernate-core/src/main/java/org/hibernate/criterion/ForeignKeyExpression.java
@@ -1,0 +1,40 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.criterion;
+
+import org.hibernate.Criteria;
+import org.hibernate.engine.spi.TypedValue;
+import org.hibernate.internal.util.StringHelper;
+
+public class ForeignKeyExpression implements Criterion {
+	private final String associationPropertyName;
+	private final Object value;
+	private final String operator;
+
+	public ForeignKeyExpression(String associationPropertyName, Object value, String operator) {
+		this.associationPropertyName = associationPropertyName;
+		this.value = value;
+		this.operator = operator;
+	}
+
+	@Override
+	public String toSqlString(Criteria criteria, CriteriaQuery criteriaQuery) {
+		final String[] columns = criteriaQuery.getForeignKeyColumns( criteria, associationPropertyName );
+
+		String result = String.join( " and ", StringHelper.suffix( columns, operator + "  ?" ) );
+		if ( columns.length > 1 ) {
+			result = '(' + result + ')';
+		}
+		return result;
+	}
+
+	@Override
+	public TypedValue[] getTypedValues(Criteria criteria, CriteriaQuery criteriaQuery) {
+		return new TypedValue[] { criteriaQuery.getForeignKeyTypeValue( criteria, associationPropertyName, value ) };
+	}
+
+}

--- a/hibernate-core/src/main/java/org/hibernate/criterion/ForeignKeyNullExpression.java
+++ b/hibernate-core/src/main/java/org/hibernate/criterion/ForeignKeyNullExpression.java
@@ -1,0 +1,52 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.criterion;
+
+import org.hibernate.Criteria;
+import org.hibernate.engine.spi.TypedValue;
+import org.hibernate.internal.util.StringHelper;
+
+public class ForeignKeyNullExpression implements Criterion {
+	private static final TypedValue[] NO_VALUES = new TypedValue[0];
+
+	private final String associationPropertyName;
+	private final boolean negated;
+
+	public ForeignKeyNullExpression(String associationPropertyName) {
+		this.associationPropertyName = associationPropertyName;
+		this.negated = false;
+	}
+
+	public ForeignKeyNullExpression(String associationPropertyName, boolean negated) {
+		this.associationPropertyName = associationPropertyName;
+		this.negated = negated;
+	}
+
+	@Override
+	public String toSqlString(Criteria criteria, CriteriaQuery criteriaQuery) {
+		final String[] columns = criteriaQuery.getForeignKeyColumns( criteria, associationPropertyName );
+
+		String result = String.join( " and ", StringHelper.suffix( columns, getSuffix() ) );
+		if ( columns.length > 1 ) {
+			result = '(' + result + ')';
+		}
+		return result;
+	}
+
+	private String getSuffix() {
+		if ( negated ) {
+			return " is not null";
+		}
+		return " is null";
+	}
+
+	@Override
+	public TypedValue[] getTypedValues(Criteria criteria, CriteriaQuery criteriaQuery) {
+		return NO_VALUES;
+	}
+
+}

--- a/hibernate-core/src/main/java/org/hibernate/criterion/ForeingKeyProjection.java
+++ b/hibernate-core/src/main/java/org/hibernate/criterion/ForeingKeyProjection.java
@@ -1,0 +1,55 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.criterion;
+
+import org.hibernate.Criteria;
+import org.hibernate.type.Type;
+
+public class ForeingKeyProjection extends SimpleProjection {
+	private String associationPropertyName;
+
+	protected ForeingKeyProjection(String associationPropertyName) {
+		this.associationPropertyName = associationPropertyName;
+	}
+
+	@Override
+	public Type[] getTypes(Criteria criteria, CriteriaQuery criteriaQuery) {
+		return new Type[] { criteriaQuery.getForeignKeyType( criteria, associationPropertyName ) };
+	}
+
+	@Override
+	public String toSqlString(Criteria criteria, int position, CriteriaQuery criteriaQuery) {
+		final StringBuilder buf = new StringBuilder();
+		final String[] cols = criteriaQuery.getForeignKeyColumns( criteria, associationPropertyName );
+		for ( int i = 0; i < cols.length; i++ ) {
+			buf.append( cols[i] )
+					.append( " as y" )
+					.append( position + i )
+					.append( '_' );
+			if ( i < cols.length - 1 ) {
+				buf.append( ", " );
+			}
+		}
+		return buf.toString();
+	}
+
+	@Override
+	public boolean isGrouped() {
+		return false;
+	}
+
+	@Override
+	public String toGroupSqlString(Criteria criteria, CriteriaQuery criteriaQuery) {
+		return super.toGroupSqlString( criteria, criteriaQuery );
+	}
+
+	@Override
+	public String toString() {
+		return "fk";
+	}
+
+}

--- a/hibernate-core/src/main/java/org/hibernate/criterion/Projections.java
+++ b/hibernate-core/src/main/java/org/hibernate/criterion/Projections.java
@@ -61,6 +61,16 @@ public final class Projections {
 		return new IdentifierProjection();
 	}
 
+	/*
+	 * An foreign key value projection.
+	 *
+	 * @return The foreign key projection
+	 *
+	 */
+	public static ForeingKeyProjection fk(String associationPropertyName) {
+		return new ForeingKeyProjection(associationPropertyName);
+	}
+
 	/**
 	 * Create a distinct projection from a projection.
 	 *

--- a/hibernate-core/src/main/java/org/hibernate/criterion/Restrictions.java
+++ b/hibernate-core/src/main/java/org/hibernate/criterion/Restrictions.java
@@ -36,6 +36,22 @@ public class Restrictions {
 	public static Criterion idEq(Object value) {
 		return new IdentifierEqExpression( value );
 	}
+
+	public static Criterion fkEq(String associationPropertyName, Object value) {
+		return new ForeignKeyExpression( associationPropertyName, value, "=" );
+	}
+
+	public static Criterion fkNe(String associationPropertyName, Object value) {
+		return new ForeignKeyExpression( associationPropertyName, value, "<>" );
+	}
+
+	public static Criterion fkIsNotNull(String associationPropertyName) {
+		return new ForeignKeyNullExpression( associationPropertyName, true);
+	}
+
+	public static Criterion fkIsNull(String associationPropertyName) {
+		return new ForeignKeyNullExpression( associationPropertyName );
+	}
 	/**
 	 * Apply an "equal" constraint to the named property
 	 *

--- a/hibernate-core/src/main/java/org/hibernate/persister/entity/AbstractPropertyMapping.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/entity/AbstractPropertyMapping.java
@@ -406,13 +406,15 @@ public abstract class AbstractPropertyMapping implements PropertyMapping {
 			}
 		}
 
-		if ( (! etype.isNullable() ) && idPropName != null ) {
-			String idpath2 = extendPath( path, idPropName );
-			addPropertyPath( idpath2, idtype, columns, columnReaders, columnReaderTemplates, formulaTemplates, factory );
-			initPropertyPaths( idpath2, idtype, columns, columnReaders, columnReaderTemplates, formulaTemplates, factory );
-		}
-		else if ( (! etype.isNullable() ) && idtype.isComponentType() && idtype instanceof EmbeddedComponentType ) {
-			initComponentPropertyPaths( path, (CompositeType) idtype, columns, columnReaders, columnReaderTemplates, formulaTemplates, factory );
+		if ( ( !etype.isNullable() ) ) {
+			if ( idPropName != null ) {
+				String idpath2 = extendPath( path, idPropName );
+				addPropertyPath( idpath2, idtype, columns, columnReaders, columnReaderTemplates, formulaTemplates, factory );
+				initPropertyPaths( idpath2, idtype, columns, columnReaders, columnReaderTemplates, formulaTemplates, factory );
+			}
+			else if ( idtype.isComponentType() && idtype instanceof EmbeddedComponentType ) {
+				initComponentPropertyPaths( path, (CompositeType) idtype, columns, columnReaders, columnReaderTemplates, formulaTemplates, factory );
+			}
 		}
 	}
 

--- a/hibernate-core/src/test/java/org/hibernate/test/annotations/notfound/CriteriaTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/annotations/notfound/CriteriaTest.java
@@ -1,0 +1,150 @@
+package org.hibernate.test.annotations.notfound;
+
+import java.util.List;
+import javax.persistence.ConstraintMode;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.ForeignKey;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.OneToOne;
+import javax.persistence.Table;
+
+import org.hibernate.Criteria;
+import org.hibernate.annotations.NotFound;
+import org.hibernate.annotations.NotFoundAction;
+import org.hibernate.criterion.ProjectionList;
+import org.hibernate.criterion.Projections;
+import org.hibernate.criterion.PropertyProjection;
+import org.hibernate.criterion.Restrictions;
+
+import org.hibernate.testing.junit4.BaseCoreFunctionalTestCase;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class CriteriaTest extends BaseCoreFunctionalTestCase {
+
+	private Long personId = 1l;
+	private Long addressId = 2l;
+
+	@Override
+	protected Class<?>[] getAnnotatedClasses() {
+		return new Class[] { Person.class, Address.class };
+	}
+
+	@Before
+	public void setUp() {
+		inTransaction(
+				session -> {
+					Address address = new Address( addressId, "Lollard Street, London" );
+					Person person = new Person( personId, "andrea", address );
+
+					session.save( address );
+					session.save( person );
+				}
+		);
+
+		inTransaction(
+				session ->
+						session.createNativeQuery( "update PERSON_TABLE set address_id = 100" ).executeUpdate()
+		);
+	}
+
+	@After
+	public void tearDown() {
+		inTransaction(
+				session -> {
+					session.createQuery( "delete from Person" ).executeUpdate();
+					session.createQuery( "delete from Address" ).executeUpdate();
+				}
+		);
+	}
+
+	@Test
+	public void selectAssociationId() {
+		inTransaction(
+				session -> {
+					Criteria criteria = session.createCriteria( Person.class, "p" );
+					ProjectionList projList = Projections.projectionList();
+					PropertyProjection property = Projections.property( "address.id" );
+					projList.add( property );
+					criteria.setProjection( projList );
+
+					List results = criteria.list();
+					assertThat( results.size(), is( 0 ) );
+				}
+		);
+	}
+
+
+	@Test
+	public void selectAssociationIdWithRestiction() {
+		inTransaction(
+				session -> {
+					Criteria criteria = session.createCriteria( Person.class, "p" );
+					ProjectionList projList = Projections.projectionList();
+					PropertyProjection property = Projections.property( "address.id" );
+					projList.add( property );
+					criteria.setProjection( projList );
+					criteria.add( Restrictions.eq( "address.id", 1L ) );
+
+					criteria.list();
+				}
+		);
+	}
+
+	@Test
+	public void testRestrictionOnAssociationId() {
+		inTransaction(
+				session -> {
+					Criteria criteria = session.createCriteria( Person.class, "p" );
+					criteria.add( Restrictions.eq( "address.id", 1L ) );
+					criteria.list();
+				}
+		);
+	}
+
+	@Entity(name = "Person")
+	@Table(name = "PERSON_TABLE")
+	public static class Person {
+		@Id
+		Long id;
+
+		String name;
+
+		@OneToOne(fetch = FetchType.LAZY)
+		@NotFound(action = NotFoundAction.IGNORE)
+		@JoinColumn(foreignKey = @ForeignKey(value = ConstraintMode.NO_CONSTRAINT))
+		public Address address;
+
+		public Person() {
+		}
+
+		public Person(Long id, String name, Address address) {
+			this.id = id;
+			this.name = name;
+			this.address = address;
+		}
+	}
+
+	@Entity(name = "Address")
+	@Table(name = "ADDRESS_TABLE")
+	public static class Address {
+		@Id
+		private Long id;
+
+		String address;
+
+		public Address() {
+		}
+
+		public Address(Long id, String address) {
+			this.id = id;
+			this.address = address;
+		}
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/test/annotations/notfound/CriteriaTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/annotations/notfound/CriteriaTest.java
@@ -13,6 +13,7 @@ import javax.persistence.Table;
 import org.hibernate.Criteria;
 import org.hibernate.annotations.NotFound;
 import org.hibernate.annotations.NotFoundAction;
+import org.hibernate.criterion.ForeingKeyProjection;
 import org.hibernate.criterion.ProjectionList;
 import org.hibernate.criterion.Projections;
 import org.hibernate.criterion.PropertyProjection;
@@ -82,7 +83,7 @@ public class CriteriaTest extends BaseCoreFunctionalTestCase {
 
 
 	@Test
-	public void selectAssociationIdWithRestiction() {
+	public void selectAssociationIdWithRestrictions() {
 		inTransaction(
 				session -> {
 					Criteria criteria = session.createCriteria( Person.class, "p" );
@@ -104,6 +105,35 @@ public class CriteriaTest extends BaseCoreFunctionalTestCase {
 					Criteria criteria = session.createCriteria( Person.class, "p" );
 					criteria.add( Restrictions.eq( "address.id", 1L ) );
 					criteria.list();
+				}
+		);
+	}
+
+	@Test
+	public void selectAssociationFKTest() {
+		inTransaction(
+				session -> {
+					Criteria criteria = session.createCriteria( Person.class, "p" );
+					ProjectionList projList = Projections.projectionList();
+					ForeingKeyProjection property = Projections.fk( "address" );
+					projList.add( property );
+					criteria.setProjection( projList );
+
+					List results = criteria.list();
+					assertThat( results.size(), is( 1 ) );
+				}
+		);
+	}
+
+	@Test
+	public void fkEqRestictionTest() {
+		inTransaction(
+				session -> {
+					Criteria criteria = session.createCriteria( Person.class, "p" );
+					criteria.add( Restrictions.fkEq( "address", 100L ) );
+
+					List results = criteria.list();
+					assertThat( results.size(), is( 1 ) );
 				}
 		);
 	}


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-15425.

This approach is an https://github.com/hibernate/hibernate-orm/pull/5190 alternative solution,it adds to the sql query a inner join like it happens with HQL and JPA Criteria.

This Pr also adds to Hibernate Criteria `Projections.fk()` and `Restrictions.fkEq()`