### PR TITLE
Improve ListresultConsumer duplication check method performance

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/query/spi/DelegatingQueryOptions.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/spi/DelegatingQueryOptions.java
@@ -16,6 +16,7 @@ import org.hibernate.LockOptions;
 import org.hibernate.graph.spi.AppliedGraph;
 import org.hibernate.query.ResultListTransformer;
 import org.hibernate.query.TupleTransformer;
+import org.hibernate.sql.results.spi.ListResultsConsumer;
 
 /**
  * @author Christian Beikov
@@ -126,5 +127,10 @@ public class DelegatingQueryOptions implements QueryOptions {
 	@Override
 	public boolean hasLimit() {
 		return queryOptions.hasLimit();
+	}
+
+	@Override
+	public ListResultsConsumer.UniqueSemantic getUniqueSemantic() {
+		return queryOptions.getUniqueSemantic();
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/query/spi/QueryOptions.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/spi/QueryOptions.java
@@ -17,6 +17,7 @@ import org.hibernate.LockOptions;
 import org.hibernate.graph.spi.AppliedGraph;
 import org.hibernate.query.ResultListTransformer;
 import org.hibernate.query.TupleTransformer;
+import org.hibernate.sql.results.spi.ListResultsConsumer;
 
 /**
  * Encapsulates options for the execution of a HQL/Criteria/native query
@@ -171,6 +172,9 @@ public interface QueryOptions {
 			&& (limit.getFirstRow() != null || limit.getMaxRows() != null);
 	}
 
+	default ListResultsConsumer.UniqueSemantic getUniqueSemantic(){
+		return null;
+	}
 	/**
 	 * Singleton access
 	 */

--- a/hibernate-core/src/main/java/org/hibernate/query/sql/internal/NativeSelectQueryPlanImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sql/internal/NativeSelectQueryPlanImpl.java
@@ -19,6 +19,7 @@ import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.internal.EmptyScrollableResults;
 import org.hibernate.query.results.ResultSetMapping;
 import org.hibernate.query.spi.DomainQueryExecutionContext;
+import org.hibernate.query.spi.QueryOptions;
 import org.hibernate.query.spi.QueryParameterBindings;
 import org.hibernate.query.spi.ScrollableResultsImplementor;
 import org.hibernate.query.sql.spi.NativeSelectQueryPlan;
@@ -64,7 +65,8 @@ public class NativeSelectQueryPlanImpl<R> implements NativeSelectQueryPlan<R> {
 
 	@Override
 	public List<R> performList(DomainQueryExecutionContext executionContext) {
-		if ( executionContext.getQueryOptions().getEffectiveLimit().getMaxRowsJpa() == 0 ) {
+		final QueryOptions queryOptions = executionContext.getQueryOptions();
+		if ( queryOptions.getEffectiveLimit().getMaxRowsJpa() == 0 ) {
 			return Collections.emptyList();
 		}
 		final List<JdbcParameterBinder> jdbcParameterBinders;
@@ -105,7 +107,9 @@ public class NativeSelectQueryPlanImpl<R> implements NativeSelectQueryPlan<R> {
 				jdbcParameterBindings,
 				SqmJdbcExecutionContextAdapter.usingLockingAndPaging( executionContext ),
 				null,
-				ListResultsConsumer.UniqueSemantic.NEVER
+				queryOptions.getUniqueSemantic() == null ?
+						ListResultsConsumer.UniqueSemantic.NEVER :
+						queryOptions.getUniqueSemantic()
 		);
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/spi/ListResultsConsumer.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/spi/ListResultsConsumer.java
@@ -191,7 +191,7 @@ public class ListResultsConsumer<R> implements ResultsConsumer<List<R>, R> {
 			}
 
 			final Results<R> results;
-			if ( isEnityResultType ) {
+			if ( ( uniqueSemantic == UniqueSemantic.ALLOW || uniqueSemantic == UniqueSemantic.FILTER ) && isEnityResultType ) {
 				results = new EntityResult<>( domainResultJavaType );
 			}
 			else {


### PR DESCRIPTION
just an attempt to address the potential perf issue mentioned in the https://github.com/hibernate/hibernate-orm/pull/4924 discussion.

https://hibernate.atlassian.net/browse/HHH-15479