### PR TITLE
HHH-15449 @ManyToOne associations not loaded correctly with default EAGER and batch fetch property set when using TypedQuery.resultStream

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/internal/ScrollableResultsImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/ScrollableResultsImpl.java
@@ -21,6 +21,7 @@ import org.hibernate.sql.results.spi.RowReader;
  */
 public class ScrollableResultsImpl<R> extends AbstractScrollableResults<R> {
 	private R currentRow;
+	private final boolean isForwardOnly;
 
 	public ScrollableResultsImpl(
 			JdbcValues jdbcValues,
@@ -28,6 +29,25 @@ public class ScrollableResultsImpl<R> extends AbstractScrollableResults<R> {
 			JdbcValuesSourceProcessingStateStandardImpl jdbcValuesSourceProcessingState,
 			RowProcessingStateStandardImpl rowProcessingState,
 			RowReader<R> rowReader,
+			SharedSessionContractImplementor persistenceContext) {
+		this(
+				jdbcValues,
+				processingOptions,
+				jdbcValuesSourceProcessingState,
+				rowProcessingState,
+				rowReader,
+				false,
+				persistenceContext
+		);
+	}
+
+	public ScrollableResultsImpl(
+			JdbcValues jdbcValues,
+			JdbcValuesSourceProcessingOptions processingOptions,
+			JdbcValuesSourceProcessingStateStandardImpl jdbcValuesSourceProcessingState,
+			RowProcessingStateStandardImpl rowProcessingState,
+			RowReader<R> rowReader,
+			boolean forwardOnly,
 			SharedSessionContractImplementor persistenceContext) {
 		super(
 				jdbcValues,
@@ -37,6 +57,7 @@ public class ScrollableResultsImpl<R> extends AbstractScrollableResults<R> {
 				rowReader,
 				persistenceContext
 		);
+		isForwardOnly = forwardOnly;
 	}
 
 	@Override
@@ -119,6 +140,9 @@ public class ScrollableResultsImpl<R> extends AbstractScrollableResults<R> {
 	private void prepareCurrentRow(boolean underlyingScrollSuccessful) {
 		if ( !underlyingScrollSuccessful ) {
 			currentRow = null;
+			if ( isForwardOnly ) {
+				close();
+			}
 			return;
 		}
 

--- a/hibernate-core/src/main/java/org/hibernate/sql/exec/internal/JdbcSelectExecutorStandardImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/exec/internal/JdbcSelectExecutorStandardImpl.java
@@ -58,6 +58,7 @@ import org.hibernate.sql.results.jdbc.spi.JdbcValuesMapping;
 import org.hibernate.sql.results.jdbc.spi.JdbcValuesMappingProducer;
 import org.hibernate.sql.results.jdbc.spi.JdbcValuesMetadata;
 import org.hibernate.sql.results.jdbc.spi.JdbcValuesSourceProcessingOptions;
+import org.hibernate.sql.results.spi.ForwardOnlyScrollableResultConsumer;
 import org.hibernate.sql.results.spi.ListResultsConsumer;
 import org.hibernate.sql.results.spi.ResultsConsumer;
 import org.hibernate.sql.results.spi.RowReader;
@@ -122,7 +123,9 @@ public class JdbcSelectExecutorStandardImpl implements JdbcSelectExecutor {
 						false,
 						scrollMode
 				),
-				ScrollableResultsConsumer.instance()
+				scrollMode == ScrollMode.FORWARD_ONLY ?
+						ForwardOnlyScrollableResultConsumer.instance() :
+						ScrollableResultsConsumer.instance()
 		);
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/spi/ForwardOnlyScrollableResultConsumer.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/spi/ForwardOnlyScrollableResultConsumer.java
@@ -1,0 +1,88 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html
+ */
+package org.hibernate.sql.results.spi;
+
+import java.util.List;
+
+import org.hibernate.engine.spi.SharedSessionContractImplementor;
+import org.hibernate.internal.FetchingScrollableResultsImpl;
+import org.hibernate.internal.ScrollableResultsImpl;
+import org.hibernate.query.spi.ScrollableResultsImplementor;
+import org.hibernate.sql.results.graph.DomainResult;
+import org.hibernate.sql.results.graph.Fetch;
+import org.hibernate.sql.results.graph.collection.internal.EagerCollectionFetch;
+import org.hibernate.sql.results.graph.entity.EntityResult;
+import org.hibernate.sql.results.internal.RowProcessingStateStandardImpl;
+import org.hibernate.sql.results.jdbc.internal.JdbcValuesSourceProcessingStateStandardImpl;
+import org.hibernate.sql.results.jdbc.spi.JdbcValues;
+import org.hibernate.sql.results.jdbc.spi.JdbcValuesMapping;
+import org.hibernate.sql.results.jdbc.spi.JdbcValuesSourceProcessingOptions;
+
+public class ForwardOnlyScrollableResultConsumer<R> implements ResultsConsumer<ScrollableResultsImplementor<R>, R> {
+	/**
+	 * Singleton access to the standard scrollable-results consumer instance
+	 */
+	public static final ForwardOnlyScrollableResultConsumer INSTANCE = new ForwardOnlyScrollableResultConsumer();
+
+	@SuppressWarnings("unchecked")
+	public static <R> ForwardOnlyScrollableResultConsumer<R> instance() {
+		return INSTANCE;
+	}
+
+	@Override
+	public ScrollableResultsImplementor<R> consume(
+			JdbcValues jdbcValues,
+			SharedSessionContractImplementor session,
+			JdbcValuesSourceProcessingOptions processingOptions,
+			JdbcValuesSourceProcessingStateStandardImpl jdbcValuesSourceProcessingState,
+			RowProcessingStateStandardImpl rowProcessingState,
+			RowReader<R> rowReader) {
+		session.getPersistenceContext().getLoadContexts().register( jdbcValuesSourceProcessingState );
+		if ( containsCollectionFetches( jdbcValues.getValuesMapping() ) ) {
+			return new FetchingScrollableResultsImpl<>(
+					jdbcValues,
+					processingOptions,
+					jdbcValuesSourceProcessingState,
+					rowProcessingState,
+					rowReader,
+					session
+			);
+		}
+		else {
+			return new ScrollableResultsImpl<>(
+					jdbcValues,
+					processingOptions,
+					jdbcValuesSourceProcessingState,
+					rowProcessingState,
+					rowReader,
+					true,
+					session
+			);
+		}
+	}
+
+	@Override
+	public boolean canResultsBeCached() {
+		return false;
+	}
+
+	private boolean containsCollectionFetches( JdbcValuesMapping valuesMapping) {
+		final List<DomainResult<?>> domainResults = valuesMapping.getDomainResults();
+		for ( DomainResult domainResult : domainResults ) {
+			if ( domainResult instanceof EntityResult ) {
+				EntityResult entityResult = (EntityResult) domainResult;
+				final List<Fetch> fetches = entityResult.getFetches();
+				for ( Fetch fetch : fetches ) {
+					if ( fetch instanceof EagerCollectionFetch ) {
+						return true;
+					}
+				}
+			}
+		}
+		return false;
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/batchfetch/StreamTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/batchfetch/StreamTest.java
@@ -1,0 +1,120 @@
+package org.hibernate.orm.test.batchfetch;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.hibernate.cfg.AvailableSettings;
+import org.hibernate.query.spi.QueryImplementor;
+
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.JiraKey;
+import org.hibernate.testing.orm.junit.ServiceRegistry;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.hibernate.testing.orm.junit.Setting;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+@DomainModel(
+		annotatedClasses = { StreamTest.Child.class, StreamTest.Parent.class }
+)
+@SessionFactory
+@ServiceRegistry(settings = @Setting(name = AvailableSettings.DEFAULT_BATCH_FETCH_SIZE, value = "2"))
+@JiraKey("HHH-15449")
+public class StreamTest {
+
+	public static final String FIELD_VALUE = "afield";
+
+	@BeforeEach
+	public void setUp(SessionFactoryScope scope) {
+		scope.inTransaction(
+				session -> {
+					Parent parent = new Parent( FIELD_VALUE );
+					session.persist( parent );
+					session.persist( new Child( parent ) );
+				}
+		);
+	}
+
+	@Test
+	public void testGetResultStream(SessionFactoryScope scope) {
+		scope.inTransaction(
+				session -> {
+					QueryImplementor<Child> query = session
+							.createQuery( "select c from Child as c where c.parent.someField=:someField", Child.class )
+							.setParameter( "someField", FIELD_VALUE );
+					Stream<Child> resultStream = query.getResultStream();
+					List<Child> children = resultStream.collect( Collectors.toList() );
+					assertThat( children.size() ).isEqualTo( 1 );
+
+					assertThat( children.get( 0 ).getParent() ).isNotNull();
+				}
+		);
+	}
+
+	@Entity(name = "Child")
+	@Table(name = "CHILD_TABLE")
+	public static class Child {
+
+		@Id
+		@GeneratedValue
+		private Long id;
+
+		@ManyToOne
+		@JoinColumn(name = "parent_id", nullable = false, updatable = false)
+		private Parent parent;
+
+		public Child() {
+		}
+
+		public Child(Parent parent) {
+			this.parent = parent;
+		}
+
+		public Parent getParent() {
+			return parent;
+		}
+
+		public Long getId() {
+			return id;
+		}
+	}
+
+	@Entity(name = "Parent")
+	@Table(name = "PARENT_TABLE")
+	public static class Parent {
+		@Id
+		@GeneratedValue
+		private Long id;
+
+		private String someField;
+
+		public Parent() {
+		}
+
+		public Parent(String someField) {
+			this.someField = someField;
+		}
+
+		public String getSomeField() {
+			return someField;
+		}
+
+		public Long getId() {
+			return id;
+		}
+
+	}
+
+
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/stream/basic/BasicStreamTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/stream/basic/BasicStreamTest.java
@@ -55,7 +55,7 @@ public class BasicStreamTest {
 						assertThat( session.getJdbcCoordinator()
 											.getLogicalConnection()
 											.getResourceRegistry()
-											.hasRegisteredResources(), is( true ) );
+											.hasRegisteredResources(), is( false ) );
 					}
 					finally {
 						stream.close();
@@ -172,7 +172,7 @@ public class BasicStreamTest {
 						assertThat( session.getJdbcCoordinator()
 											.getLogicalConnection()
 											.getResourceRegistry()
-											.hasRegisteredResources(), is( true ) );
+											.hasRegisteredResources(), is( false ) );
 					}
 
 					assertThat( session.getJdbcCoordinator()


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-15449

When `hibernate.default_batch_fetch_size` is set a `BatchEntitySelectFetchInitializer` is used that initialise the instanced only when the `endLoading` method is called and in case of a Steam this happens only when the stream is closed.

In case of stream a `FORWARD_ONLY` scroll mode is used, so one solution for forward only scroll mode can be to close the stream when the last element is reached.