### PR TITLE
HHH-15100 Limitation of metamodel imports cache causes severe performance drops in large projects

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/boot/internal/SessionFactoryOptionsBuilder.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/internal/SessionFactoryOptionsBuilder.java
@@ -100,6 +100,7 @@ import static org.hibernate.cfg.AvailableSettings.JPA_CALLBACKS_ENABLED;
 import static org.hibernate.cfg.AvailableSettings.JTA_TRACK_BY_THREAD;
 import static org.hibernate.cfg.AvailableSettings.LOG_SESSION_METRICS;
 import static org.hibernate.cfg.AvailableSettings.MAX_FETCH_DEPTH;
+import static org.hibernate.cfg.AvailableSettings.METAMODEL_NEGATIVE_IMPORTS_DEACTIVATION_THRESHOLD;
 import static org.hibernate.cfg.AvailableSettings.MULTI_TENANT_IDENTIFIER_RESOLVER;
 import static org.hibernate.cfg.AvailableSettings.NATIVE_EXCEPTION_HANDLING_51_COMPLIANCE;
 import static org.hibernate.cfg.AvailableSettings.OMIT_JOIN_OF_SUPERCLASS_TABLES;
@@ -216,6 +217,7 @@ public class SessionFactoryOptionsBuilder implements SessionFactoryOptions {
 	private final boolean collectionJoinSubqueryRewriteEnabled;
 	private boolean jdbcStyleParamsZeroBased;
 	private final boolean omitJoinOfSuperclassTablesEnabled;
+	private final int metamodelNegativeImportsDeactivationThreshold;
 
 	// Caching
 	private boolean secondLevelCacheEnabled;
@@ -376,6 +378,7 @@ public class SessionFactoryOptionsBuilder implements SessionFactoryOptions {
 		this.procedureParameterNullPassingEnabled = cfgService.getSetting( PROCEDURE_NULL_PARAM_PASSING, BOOLEAN, false );
 		this.collectionJoinSubqueryRewriteEnabled = cfgService.getSetting( COLLECTION_JOIN_SUBQUERY, BOOLEAN, true );
 		this.omitJoinOfSuperclassTablesEnabled = cfgService.getSetting( OMIT_JOIN_OF_SUPERCLASS_TABLES, BOOLEAN, true );
+		this.metamodelNegativeImportsDeactivationThreshold = cfgService.getSetting(METAMODEL_NEGATIVE_IMPORTS_DEACTIVATION_THRESHOLD, Integer.TYPE, 1000);
 
 		final RegionFactory regionFactory = serviceRegistry.getService( RegionFactory.class );
 		if ( !NoCachingRegionFactory.class.isInstance( regionFactory ) ) {
@@ -1111,6 +1114,11 @@ public class SessionFactoryOptionsBuilder implements SessionFactoryOptions {
 	@Override
 	public boolean isOmitJoinOfSuperclassTablesEnabled() {
 		return omitJoinOfSuperclassTablesEnabled;
+	}
+
+	@Override
+	public int getMetamodelNegativeImportsDeactivationThreshold() {
+		return metamodelNegativeImportsDeactivationThreshold;
 	}
 
 	// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/hibernate-core/src/main/java/org/hibernate/boot/internal/SessionFactoryOptionsBuilder.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/internal/SessionFactoryOptionsBuilder.java
@@ -378,7 +378,7 @@ public class SessionFactoryOptionsBuilder implements SessionFactoryOptions {
 		this.procedureParameterNullPassingEnabled = cfgService.getSetting( PROCEDURE_NULL_PARAM_PASSING, BOOLEAN, false );
 		this.collectionJoinSubqueryRewriteEnabled = cfgService.getSetting( COLLECTION_JOIN_SUBQUERY, BOOLEAN, true );
 		this.omitJoinOfSuperclassTablesEnabled = cfgService.getSetting( OMIT_JOIN_OF_SUPERCLASS_TABLES, BOOLEAN, true );
-		this.metamodelNegativeImportsDeactivationThreshold = cfgService.getSetting(METAMODEL_NEGATIVE_IMPORTS_DEACTIVATION_THRESHOLD, Integer.TYPE, 1000);
+		this.metamodelNegativeImportsDeactivationThreshold = cfgService.getSetting(METAMODEL_NEGATIVE_IMPORTS_DEACTIVATION_THRESHOLD, Integer.class, 1000);
 
 		final RegionFactory regionFactory = serviceRegistry.getService( RegionFactory.class );
 		if ( !NoCachingRegionFactory.class.isInstance( regionFactory ) ) {

--- a/hibernate-core/src/main/java/org/hibernate/boot/spi/AbstractDelegatingSessionFactoryOptions.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/spi/AbstractDelegatingSessionFactoryOptions.java
@@ -467,4 +467,9 @@ public class AbstractDelegatingSessionFactoryOptions implements SessionFactoryOp
 	public boolean isOmitJoinOfSuperclassTablesEnabled() {
 		return delegate.isOmitJoinOfSuperclassTablesEnabled();
 	}
+
+	@Override
+	public int getMetamodelNegativeImportsDeactivationThreshold() {
+		return delegate.getMetamodelNegativeImportsDeactivationThreshold();
+	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/boot/spi/SessionFactoryOptions.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/spi/SessionFactoryOptions.java
@@ -352,4 +352,6 @@ public interface SessionFactoryOptions {
 	}
 
 	boolean isOmitJoinOfSuperclassTablesEnabled();
+
+	int getMetamodelNegativeImportsDeactivationThreshold();
 }

--- a/hibernate-core/src/main/java/org/hibernate/cfg/AvailableSettings.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/AvailableSettings.java
@@ -2512,6 +2512,33 @@ public interface AvailableSettings extends org.hibernate.jpa.AvailableSettings {
 	String OMIT_JOIN_OF_SUPERCLASS_TABLES = "hibernate.query.omit_join_of_superclass_tables";
 
 	/**
+	 * <p>
+	 * When queries are parsed, some string tokens can be aliases of class names.
+	 * </p>
+	 * <p>
+	 * For this kind of token, {@link org.hibernate.Metamodel} will first look for its matching class in a cache.
+	 * If the token is not found in the cache, {@link org.hibernate.Metamodel} will try to find the matching class
+	 * using {@link Class#forName(String)}. If {@link Class#forName(String)} fails with {@link ClassNotFoundException}, the
+	 * token will be added to the cache without any matching class to short circuit any future lookup for the same
+	 * token.
+	 * </p>
+	 * <p>
+	 * On some applications, token values can be nondeterministic. This can lead to a memory leak caused by the
+	 * unbounded cache.
+	 * </p>
+	 * <p>
+	 * This setting allows to configure the size of the cache from which the non-matching tokens must stop being cached.
+	 * </p>
+	 * <p>A low value preserves memory but could lead to bad performance.</p>
+	 * <p>A high enhance performance but increase the memory consumption of the cache.</p>
+	 * <p>A negative value means the threshold is disabled.</p>
+	 * <p>The default value is 1000.</p>
+	 *
+	 * @since 5.6
+	 */
+	String METAMODEL_NEGATIVE_IMPORTS_DEACTIVATION_THRESHOLD = "hibernate.metamodel.negative_imports_deactivation_threshold";
+
+	/**
 	 * @deprecated Support for JACC will be removed in 6.0
 	 */
 	@Deprecated

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/internal/MetamodelImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/internal/MetamodelImpl.java
@@ -632,11 +632,13 @@ public class MetamodelImpl implements MetamodelImplementor, Serializable {
 				return className;
 			}
 			catch ( ClassLoadingException cnfe ) {
-				// This check doesn't necessarily mean that the map can't exceed 1000 elements because
-				// new entries might be added _while_ performing the check (making it 1000+ since size() isn't
+				int negativeThreshold = sessionFactory.getSessionFactoryOptions()
+						.getMetamodelNegativeImportsDeactivationThreshold();
+				// This check doesn't necessarily mean that the map can't exceed negativeThreshold elements because
+				// new entries might be added _while_ performing the check (making it negativeThreshold+ since size() isn't
 				// synchronized). Regardless, this would pass as "good enough" to prevent the map from growing
 				// above a certain threshold, thus, avoiding memory issues.
-				if ( imports.size() < 1_000 ) {
+				if (negativeThreshold < 0 || imports.size() < negativeThreshold) {
 					imports.put( className, INVALID_IMPORT );
 				}
 				return null;

--- a/hibernate-core/src/test/java/org/hibernate/test/hql/QuerySplitterTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/hql/QuerySplitterTest.java
@@ -55,7 +55,9 @@ public class QuerySplitterTest extends BaseNonConfigCoreFunctionalTestCase {
 	@TestForIssue(jiraKey = "HHH-14948")
 	public void testMemoryConsumptionOfFailedImportsCache() throws NoSuchFieldException, IllegalAccessException {
 
-		IntStream.range( 0, 1001 )
+		int threshold = sessionFactory().getSessionFactoryOptions()
+				.getMetamodelNegativeImportsDeactivationThreshold();
+		IntStream.range( 0, threshold + 1 )
 				.forEach( i -> QuerySplitter.concreteQueries(
 						"from Employee e join e.company" + i,
 						sessionFactory()
@@ -69,9 +71,7 @@ public class QuerySplitterTest extends BaseNonConfigCoreFunctionalTestCase {
 		//noinspection unchecked
 		Map<String, String> imports = (Map<String, String>) field.get( metamodel );
 
-		// VERY hard-coded, but considering the possibility of a regression of a memory-related issue,
-		// it should be worth it
-		assertEquals( 1000, imports.size() );
+		assertEquals( threshold, imports.size() );
 	}
 
 	@Test


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-15100