### PR TITLE
HHH-15443 Allow JdbcType to wrap read and write expressions

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -2,10 +2,10 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [ 'main' ]
+    branches: [ '6.2' ]
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [ 'main' ]
+    branches: [ '6.2' ]
   schedule:
     - cron: '34 11 * * 4'
 

--- a/.github/workflows/contributor-build.yml
+++ b/.github/workflows/contributor-build.yml
@@ -9,10 +9,10 @@ name: Hibernate ORM build
 on:
   push:
     branches:
-      - 'main'
+      - '6.2'
   pull_request:
     branches:
-      - 'main'
+      - '6.2'
       
 permissions: {} # none
 

--- a/README.adoc
+++ b/README.adoc
@@ -5,7 +5,7 @@ It also provides an implementation of the JPA specification, which is the standa
 
 This is the repository of its source code; see https://hibernate.org/orm/[Hibernate.org] for additional information.
 
-image:https://ci.hibernate.org/job/hibernate-orm-pipeline/job/main/badge/icon[Build Status,link=https://ci.hibernate.org/job/hibernate-orm-pipeline/job/main/]
+image:https://ci.hibernate.org/job/hibernate-orm-pipeline/job/6.2/badge/icon[Build Status,link=https://ci.hibernate.org/job/hibernate-orm-pipeline/job/6.2/]
 image:https://img.shields.io/badge/Revved%20up%20by-Gradle%20Enterprise-06A0CE?logo=Gradle&labelColor=02303A[link=https://ge.hibernate.org/scans]
 
 == Continuous Integration

--- a/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/CockroachLegacyDialect.java
+++ b/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/CockroachLegacyDialect.java
@@ -30,6 +30,9 @@ import org.hibernate.boot.model.TypeContributions;
 import org.hibernate.dialect.DatabaseVersion;
 import org.hibernate.dialect.Dialect;
 import org.hibernate.dialect.NationalizationSupport;
+import org.hibernate.dialect.PostgreSQLCastingInetJdbcType;
+import org.hibernate.dialect.PostgreSQLCastingIntervalSecondJdbcType;
+import org.hibernate.dialect.PostgreSQLCastingJsonJdbcType;
 import org.hibernate.dialect.PostgreSQLDriverKind;
 import org.hibernate.dialect.PostgreSQLInetJdbcType;
 import org.hibernate.dialect.PostgreSQLIntervalSecondJdbcType;
@@ -228,19 +231,17 @@ public class CockroachLegacyDialect extends Dialect {
 		final DdlTypeRegistry ddlTypeRegistry = typeContributions.getTypeConfiguration().getDdlTypeRegistry();
 
 		ddlTypeRegistry.addDescriptor( new DdlTypeImpl( UUID, "uuid", this ) );
-		if ( PostgreSQLPGObjectJdbcType.isUsable() ) {
-			ddlTypeRegistry.addDescriptor( new DdlTypeImpl( GEOMETRY, "geometry", this ) );
-			ddlTypeRegistry.addDescriptor( new DdlTypeImpl( GEOGRAPHY, "geography", this ) );
-			ddlTypeRegistry.addDescriptor( new Scale6IntervalSecondDdlType( this ) );
+		ddlTypeRegistry.addDescriptor( new DdlTypeImpl( GEOMETRY, "geometry", this ) );
+		ddlTypeRegistry.addDescriptor( new DdlTypeImpl( GEOGRAPHY, "geography", this ) );
+		ddlTypeRegistry.addDescriptor( new Scale6IntervalSecondDdlType( this ) );
 
-			// Prefer jsonb if possible
-			if ( getVersion().isSameOrAfter( 20 ) ) {
-				ddlTypeRegistry.addDescriptor( new DdlTypeImpl( INET, "inet", this ) );
-				ddlTypeRegistry.addDescriptor( new DdlTypeImpl( JSON, "jsonb", this ) );
-			}
-			else {
-				ddlTypeRegistry.addDescriptor( new DdlTypeImpl( JSON, "json", this ) );
-			}
+		// Prefer jsonb if possible
+		if ( getVersion().isSameOrAfter( 20 ) ) {
+			ddlTypeRegistry.addDescriptor( new DdlTypeImpl( INET, "inet", this ) );
+			ddlTypeRegistry.addDescriptor( new DdlTypeImpl( JSON, "jsonb", this ) );
+		}
+		else {
+			ddlTypeRegistry.addDescriptor( new DdlTypeImpl( JSON, "json", this ) );
 		}
 	}
 
@@ -337,6 +338,27 @@ public class CockroachLegacyDialect extends Dialect {
 				else {
 					jdbcTypeRegistry.addDescriptorIfAbsent( PostgreSQLJsonJdbcType.INSTANCE );
 				}
+			}
+			else {
+				jdbcTypeRegistry.addDescriptorIfAbsent( PostgreSQLCastingIntervalSecondJdbcType.INSTANCE );
+				if ( getVersion().isSameOrAfter( 20, 0 ) ) {
+					jdbcTypeRegistry.addDescriptorIfAbsent( PostgreSQLCastingInetJdbcType.INSTANCE );
+					jdbcTypeRegistry.addDescriptorIfAbsent( PostgreSQLCastingJsonJdbcType.JSONB_INSTANCE );
+				}
+				else {
+					jdbcTypeRegistry.addDescriptorIfAbsent( PostgreSQLCastingJsonJdbcType.JSON_INSTANCE );
+				}
+			}
+		}
+		else {
+			jdbcTypeRegistry.addDescriptorIfAbsent( UUIDJdbcType.INSTANCE );
+			jdbcTypeRegistry.addDescriptorIfAbsent( PostgreSQLCastingIntervalSecondJdbcType.INSTANCE );
+			if ( getVersion().isSameOrAfter( 20, 0 ) ) {
+				jdbcTypeRegistry.addDescriptorIfAbsent( PostgreSQLCastingInetJdbcType.INSTANCE );
+				jdbcTypeRegistry.addDescriptorIfAbsent( PostgreSQLCastingJsonJdbcType.JSONB_INSTANCE );
+			}
+			else {
+				jdbcTypeRegistry.addDescriptorIfAbsent( PostgreSQLCastingJsonJdbcType.JSON_INSTANCE );
 			}
 		}
 

--- a/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/MariaDBLegacyDialect.java
+++ b/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/MariaDBLegacyDialect.java
@@ -34,8 +34,10 @@ import org.hibernate.sql.ast.tree.Statement;
 import org.hibernate.sql.exec.spi.JdbcOperation;
 import org.hibernate.tool.schema.extract.internal.SequenceInformationExtractorMariaDBDatabaseImpl;
 import org.hibernate.tool.schema.extract.spi.SequenceInformationExtractor;
+import org.hibernate.type.SqlTypes;
 import org.hibernate.type.StandardBasicTypes;
 import org.hibernate.type.descriptor.jdbc.JdbcType;
+import org.hibernate.type.descriptor.jdbc.JsonJdbcType;
 import org.hibernate.type.descriptor.jdbc.spi.JdbcTypeRegistry;
 import org.hibernate.type.descriptor.sql.internal.DdlTypeImpl;
 import org.hibernate.type.descriptor.sql.spi.DdlTypeRegistry;
@@ -141,9 +143,11 @@ public class MariaDBLegacyDialect extends MySQLLegacyDialect {
 
 	@Override
 	public void contributeTypes(TypeContributions typeContributions, ServiceRegistry serviceRegistry) {
+		final JdbcTypeRegistry jdbcTypeRegistry = typeContributions.getTypeConfiguration().getJdbcTypeRegistry();
+		// Make sure we register the JSON type descriptor before calling super, because MariaDB does not need casting
+		jdbcTypeRegistry.addDescriptorIfAbsent( SqlTypes.JSON, JsonJdbcType.INSTANCE );
+
 		super.contributeTypes( typeContributions, serviceRegistry );
-		final JdbcTypeRegistry jdbcTypeRegistry = typeContributions.getTypeConfiguration()
-				.getJdbcTypeRegistry();
 		if ( getVersion().isSameOrAfter( 10, 7 ) ) {
 			jdbcTypeRegistry.addDescriptorIfAbsent( VarcharUUIDJdbcType.INSTANCE );
 		}

--- a/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/MySQLLegacyDialect.java
+++ b/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/MySQLLegacyDialect.java
@@ -21,6 +21,7 @@ import org.hibernate.dialect.DatabaseVersion;
 import org.hibernate.dialect.Dialect;
 import org.hibernate.dialect.InnoDBStorageEngine;
 import org.hibernate.dialect.MyISAMStorageEngine;
+import org.hibernate.dialect.MySQLCastingJsonJdbcType;
 import org.hibernate.dialect.MySQLServerConfiguration;
 import org.hibernate.dialect.MySQLStorageEngine;
 import org.hibernate.dialect.Replacer;
@@ -630,11 +631,10 @@ public class MySQLLegacyDialect extends Dialect {
 	public void contributeTypes(TypeContributions typeContributions, ServiceRegistry serviceRegistry) {
 		super.contributeTypes( typeContributions, serviceRegistry );
 
-		final JdbcTypeRegistry jdbcTypeRegistry = typeContributions.getTypeConfiguration()
-				.getJdbcTypeRegistry();
+		final JdbcTypeRegistry jdbcTypeRegistry = typeContributions.getTypeConfiguration().getJdbcTypeRegistry();
 
 		if ( getMySQLVersion().isSameOrAfter( 5, 7 ) ) {
-			jdbcTypeRegistry.addDescriptorIfAbsent( SqlTypes.JSON, JsonJdbcType.INSTANCE );
+			jdbcTypeRegistry.addDescriptorIfAbsent( SqlTypes.JSON, MySQLCastingJsonJdbcType.INSTANCE );
 		}
 
 		// MySQL requires a custom binder for binding untyped nulls with the NULL type

--- a/hibernate-core/src/main/java/org/hibernate/boot/model/process/spi/MetadataBuildingProcess.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/process/spi/MetadataBuildingProcess.java
@@ -64,6 +64,7 @@ import org.hibernate.type.BasicTypeRegistry;
 import org.hibernate.type.SqlTypes;
 import org.hibernate.type.descriptor.java.spi.JavaTypeRegistry;
 import org.hibernate.type.descriptor.jdbc.JdbcType;
+import org.hibernate.type.descriptor.jdbc.JsonAsStringJdbcType;
 import org.hibernate.type.descriptor.jdbc.JsonJdbcType;
 import org.hibernate.type.descriptor.jdbc.XmlAsStringJdbcType;
 import org.hibernate.type.descriptor.jdbc.spi.JdbcTypeRegistry;
@@ -661,29 +662,14 @@ public class MetadataBuildingProcess {
 		addFallbackIfNecessary( jdbcTypeRegistry, SqlTypes.POINT, SqlTypes.VARBINARY );
 		addFallbackIfNecessary( jdbcTypeRegistry, SqlTypes.GEOGRAPHY, SqlTypes.GEOMETRY );
 
-		jdbcTypeRegistry.addDescriptorIfAbsent( JsonJdbcType.INSTANCE );
-		jdbcTypeRegistry.addDescriptorIfAbsent( XmlAsStringJdbcType.INSTANCE );
+		jdbcTypeRegistry.addDescriptorIfAbsent( JsonAsStringJdbcType.VARCHAR_INSTANCE );
+		jdbcTypeRegistry.addDescriptorIfAbsent( XmlAsStringJdbcType.VARCHAR_INSTANCE );
 
 		addFallbackIfNecessary( jdbcTypeRegistry, SqlTypes.MATERIALIZED_BLOB, SqlTypes.BLOB );
 		addFallbackIfNecessary( jdbcTypeRegistry, SqlTypes.MATERIALIZED_CLOB, SqlTypes.CLOB );
 		addFallbackIfNecessary( jdbcTypeRegistry, SqlTypes.MATERIALIZED_NCLOB, SqlTypes.NCLOB );
 
 		final DdlTypeRegistry ddlTypeRegistry = typeConfiguration.getDdlTypeRegistry();
-		// Fallback to the biggest varchar DdlType when json is requested
-		ddlTypeRegistry.addDescriptorIfAbsent(
-				new DdlTypeImpl(
-						SqlTypes.JSON,
-						ddlTypeRegistry.getTypeName( SqlTypes.VARCHAR, null, null, null ),
-						dialect
-				)
-		);
-		ddlTypeRegistry.addDescriptorIfAbsent(
-				new DdlTypeImpl(
-						SqlTypes.SQLXML,
-						ddlTypeRegistry.getTypeName( SqlTypes.VARCHAR, null, null, null ),
-						dialect
-				)
-		);
 		// Fallback to the geometry DdlType when geography is requested
 		final DdlType geometryType = ddlTypeRegistry.getDescriptor( SqlTypes.GEOMETRY );
 		if ( geometryType != null ) {

--- a/hibernate-core/src/main/java/org/hibernate/dialect/CockroachDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/CockroachDialect.java
@@ -244,16 +244,16 @@ public class CockroachDialect extends Dialect {
 		final DdlTypeRegistry ddlTypeRegistry = typeContributions.getTypeConfiguration().getDdlTypeRegistry();
 
 		ddlTypeRegistry.addDescriptor( new DdlTypeImpl( UUID, "uuid", this ) );
-		if ( PostgreSQLPGObjectJdbcType.isUsable() ) {
-			// The following DDL types require that the PGobject class is usable/visible
-			ddlTypeRegistry.addDescriptor( new DdlTypeImpl( GEOMETRY, "geometry", this ) );
-			ddlTypeRegistry.addDescriptor( new DdlTypeImpl( GEOGRAPHY, "geography", this ) );
-			ddlTypeRegistry.addDescriptor( new Scale6IntervalSecondDdlType( this ) );
 
-			// Prefer jsonb if possible
-			ddlTypeRegistry.addDescriptor( new DdlTypeImpl( INET, "inet", this ) );
-			ddlTypeRegistry.addDescriptor( new DdlTypeImpl( JSON, "jsonb", this ) );
-		}
+		// The following DDL types require that the PGobject class is usable/visible,
+		// or that a special JDBC type implementation exists, that supports wrapping read/write expressions
+		ddlTypeRegistry.addDescriptor( new DdlTypeImpl( GEOMETRY, "geometry", this ) );
+		ddlTypeRegistry.addDescriptor( new DdlTypeImpl( GEOGRAPHY, "geography", this ) );
+		ddlTypeRegistry.addDescriptor( new Scale6IntervalSecondDdlType( this ) );
+
+		// Prefer jsonb if possible
+		ddlTypeRegistry.addDescriptor( new DdlTypeImpl( INET, "inet", this ) );
+		ddlTypeRegistry.addDescriptor( new DdlTypeImpl( JSON, "jsonb", this ) );
 	}
 
 	@Override
@@ -344,6 +344,17 @@ public class CockroachDialect extends Dialect {
 				jdbcTypeRegistry.addDescriptorIfAbsent( PostgreSQLInetJdbcType.INSTANCE );
 				jdbcTypeRegistry.addDescriptorIfAbsent( PostgreSQLJsonbJdbcType.INSTANCE );
 			}
+			else {
+				jdbcTypeRegistry.addDescriptorIfAbsent( PostgreSQLCastingIntervalSecondJdbcType.INSTANCE );
+				jdbcTypeRegistry.addDescriptorIfAbsent( PostgreSQLCastingInetJdbcType.INSTANCE );
+				jdbcTypeRegistry.addDescriptorIfAbsent( PostgreSQLCastingJsonJdbcType.JSONB_INSTANCE );
+			}
+		}
+		else {
+			jdbcTypeRegistry.addDescriptorIfAbsent( UUIDJdbcType.INSTANCE );
+			jdbcTypeRegistry.addDescriptorIfAbsent( PostgreSQLCastingInetJdbcType.INSTANCE );
+			jdbcTypeRegistry.addDescriptorIfAbsent( PostgreSQLCastingIntervalSecondJdbcType.INSTANCE );
+			jdbcTypeRegistry.addDescriptorIfAbsent( PostgreSQLCastingJsonJdbcType.JSONB_INSTANCE );
 		}
 
 		// Force Blob binding to byte[] for CockroachDB

--- a/hibernate-core/src/main/java/org/hibernate/dialect/MariaDBDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/MariaDBDialect.java
@@ -27,8 +27,10 @@ import org.hibernate.sql.ast.tree.Statement;
 import org.hibernate.sql.exec.spi.JdbcOperation;
 import org.hibernate.tool.schema.extract.internal.SequenceInformationExtractorMariaDBDatabaseImpl;
 import org.hibernate.tool.schema.extract.spi.SequenceInformationExtractor;
+import org.hibernate.type.SqlTypes;
 import org.hibernate.type.StandardBasicTypes;
 import org.hibernate.type.descriptor.jdbc.JdbcType;
+import org.hibernate.type.descriptor.jdbc.JsonJdbcType;
 import org.hibernate.type.descriptor.jdbc.spi.JdbcTypeRegistry;
 import org.hibernate.type.descriptor.sql.internal.DdlTypeImpl;
 import org.hibernate.type.descriptor.sql.spi.DdlTypeRegistry;
@@ -133,9 +135,11 @@ public class MariaDBDialect extends MySQLDialect {
 
 	@Override
 	public void contributeTypes(TypeContributions typeContributions, ServiceRegistry serviceRegistry) {
+		final JdbcTypeRegistry jdbcTypeRegistry = typeContributions.getTypeConfiguration().getJdbcTypeRegistry();
+		// Make sure we register the JSON type descriptor before calling super, because MariaDB does not need casting
+		jdbcTypeRegistry.addDescriptorIfAbsent( SqlTypes.JSON, JsonJdbcType.INSTANCE );
+
 		super.contributeTypes( typeContributions, serviceRegistry );
-		final JdbcTypeRegistry jdbcTypeRegistry = typeContributions.getTypeConfiguration()
-				.getJdbcTypeRegistry();
 		if ( getVersion().isSameOrAfter( 10, 7 ) ) {
 			jdbcTypeRegistry.addDescriptorIfAbsent( VarcharUUIDJdbcType.INSTANCE );
 		}

--- a/hibernate-core/src/main/java/org/hibernate/dialect/MySQLCastingJsonJdbcType.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/MySQLCastingJsonJdbcType.java
@@ -1,0 +1,45 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.dialect;
+
+import org.hibernate.metamodel.mapping.EmbeddableMappingType;
+import org.hibernate.metamodel.spi.RuntimeModelCreationContext;
+import org.hibernate.sql.ast.spi.SqlAppender;
+import org.hibernate.type.descriptor.jdbc.AggregateJdbcType;
+import org.hibernate.type.descriptor.jdbc.JsonJdbcType;
+
+/**
+ * @author Christian Beikov
+ */
+public class MySQLCastingJsonJdbcType extends JsonJdbcType {
+	/**
+	 * Singleton access
+	 */
+	public static final JsonJdbcType INSTANCE = new MySQLCastingJsonJdbcType( null );
+
+	public MySQLCastingJsonJdbcType(EmbeddableMappingType embeddableMappingType) {
+		super( embeddableMappingType );
+	}
+
+	@Override
+	public AggregateJdbcType resolveAggregateJdbcType(
+			EmbeddableMappingType mappingType,
+			String sqlType,
+			RuntimeModelCreationContext creationContext) {
+		return new MySQLCastingJsonJdbcType( mappingType );
+	}
+
+	@Override
+	public void appendWriteExpression(
+			String writeExpression,
+			SqlAppender appender,
+			Dialect dialect) {
+		appender.append( "cast(" );
+		appender.append( writeExpression );
+		appender.append( " as json)" );
+	}
+}

--- a/hibernate-core/src/main/java/org/hibernate/dialect/MySQLDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/MySQLDialect.java
@@ -627,10 +627,9 @@ public class MySQLDialect extends Dialect {
 	public void contributeTypes(TypeContributions typeContributions, ServiceRegistry serviceRegistry) {
 		super.contributeTypes( typeContributions, serviceRegistry );
 
-		final JdbcTypeRegistry jdbcTypeRegistry = typeContributions.getTypeConfiguration()
-				.getJdbcTypeRegistry();
+		final JdbcTypeRegistry jdbcTypeRegistry = typeContributions.getTypeConfiguration().getJdbcTypeRegistry();
 
-		jdbcTypeRegistry.addDescriptorIfAbsent( SqlTypes.JSON, JsonJdbcType.INSTANCE );
+		jdbcTypeRegistry.addDescriptorIfAbsent( SqlTypes.JSON, MySQLCastingJsonJdbcType.INSTANCE );
 
 		// MySQL requires a custom binder for binding untyped nulls with the NULL type
 		typeContributions.contributeJdbcType( NullJdbcType.INSTANCE );

--- a/hibernate-core/src/main/java/org/hibernate/dialect/PostgreSQLCastingInetJdbcType.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/PostgreSQLCastingInetJdbcType.java
@@ -1,0 +1,111 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.dialect;
+
+import java.net.InetAddress;
+import java.sql.CallableStatement;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+import org.hibernate.sql.ast.spi.SqlAppender;
+import org.hibernate.type.SqlTypes;
+import org.hibernate.type.descriptor.ValueBinder;
+import org.hibernate.type.descriptor.ValueExtractor;
+import org.hibernate.type.descriptor.WrapperOptions;
+import org.hibernate.type.descriptor.java.JavaType;
+import org.hibernate.type.descriptor.jdbc.BasicBinder;
+import org.hibernate.type.descriptor.jdbc.BasicExtractor;
+import org.hibernate.type.descriptor.jdbc.JdbcLiteralFormatter;
+import org.hibernate.type.descriptor.jdbc.JdbcType;
+
+/**
+ * @author Christian Beikov
+ */
+public class PostgreSQLCastingInetJdbcType implements JdbcType {
+
+	public static final PostgreSQLCastingInetJdbcType INSTANCE = new PostgreSQLCastingInetJdbcType();
+
+	@Override
+	public void appendWriteExpression(
+			String writeExpression,
+			SqlAppender appender,
+			Dialect dialect) {
+		appender.append( "cast(" );
+		appender.append( writeExpression );
+		appender.append( " as inet)" );
+	}
+
+	@Override
+	public int getJdbcTypeCode() {
+		return SqlTypes.VARBINARY;
+	}
+
+	@Override
+	public int getDefaultSqlTypeCode() {
+		return SqlTypes.INET;
+	}
+
+	@Override
+	public String toString() {
+		return "InetSecondJdbcType";
+	}
+
+	@Override
+	public <T> JdbcLiteralFormatter<T> getJdbcLiteralFormatter(JavaType<T> javaType) {
+		// No literal support for now
+		return null;
+	}
+
+	@Override
+	public <X> ValueBinder<X> getBinder(JavaType<X> javaType) {
+		return new BasicBinder<>( javaType, this ) {
+			@Override
+			protected void doBind(PreparedStatement st, X value, int index, WrapperOptions options)
+					throws SQLException {
+				st.setString( index, getStringValue( value, options ) );
+			}
+
+			@Override
+			protected void doBind(CallableStatement st, X value, String name, WrapperOptions options)
+					throws SQLException {
+				st.setString( name, getStringValue( value, options ) );
+			}
+
+			private String getStringValue(X value, WrapperOptions options) {
+				return getJavaType().unwrap( value, InetAddress.class, options ).getHostAddress();
+			}
+		};
+	}
+
+	@Override
+	public <X> ValueExtractor<X> getExtractor(JavaType<X> javaType) {
+		return new BasicExtractor<>( javaType, this ) {
+			@Override
+			protected X doExtract(ResultSet rs, int paramIndex, WrapperOptions options) throws SQLException {
+				return getObject( rs.getString( paramIndex ), options );
+			}
+
+			@Override
+			protected X doExtract(CallableStatement statement, int index, WrapperOptions options) throws SQLException {
+				return getObject( statement.getString( index ), options );
+			}
+
+			@Override
+			protected X doExtract(CallableStatement statement, String name, WrapperOptions options) throws SQLException {
+				return getObject( statement.getString( name ), options );
+			}
+
+			private X getObject(String inetString, WrapperOptions options) throws SQLException {
+				if ( inetString == null ) {
+					return null;
+				}
+				return getJavaType().wrap( inetString, options );
+			}
+		};
+	}
+}

--- a/hibernate-core/src/main/java/org/hibernate/dialect/PostgreSQLCastingIntervalSecondJdbcType.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/PostgreSQLCastingIntervalSecondJdbcType.java
@@ -1,0 +1,162 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.dialect;
+
+import java.math.BigDecimal;
+import java.sql.CallableStatement;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+import org.hibernate.engine.jdbc.spi.JdbcServices;
+import org.hibernate.engine.spi.SessionFactoryImplementor;
+import org.hibernate.metamodel.mapping.JdbcMappingContainer;
+import org.hibernate.sql.ast.SqlAstTranslator;
+import org.hibernate.sql.ast.spi.SqlAppender;
+import org.hibernate.sql.ast.tree.expression.Expression;
+import org.hibernate.sql.ast.tree.expression.SelfRenderingExpression;
+import org.hibernate.type.SqlTypes;
+import org.hibernate.type.descriptor.ValueBinder;
+import org.hibernate.type.descriptor.ValueExtractor;
+import org.hibernate.type.descriptor.WrapperOptions;
+import org.hibernate.type.descriptor.java.JavaType;
+import org.hibernate.type.descriptor.jdbc.AdjustableJdbcType;
+import org.hibernate.type.descriptor.jdbc.BasicBinder;
+import org.hibernate.type.descriptor.jdbc.BasicExtractor;
+import org.hibernate.type.descriptor.jdbc.JdbcLiteralFormatter;
+import org.hibernate.type.descriptor.jdbc.JdbcType;
+import org.hibernate.type.descriptor.jdbc.JdbcTypeIndicators;
+
+/**
+ * @author Christian Beikov
+ */
+public class PostgreSQLCastingIntervalSecondJdbcType implements AdjustableJdbcType {
+
+	public static final PostgreSQLCastingIntervalSecondJdbcType INSTANCE = new PostgreSQLCastingIntervalSecondJdbcType();
+
+	@Override
+	public JdbcType resolveIndicatedType(JdbcTypeIndicators indicators, JavaType<?> domainJtd) {
+		final int scale;
+		if ( indicators.getColumnScale() == JdbcTypeIndicators.NO_COLUMN_SCALE ) {
+			scale = domainJtd.getDefaultSqlScale(
+					indicators.getTypeConfiguration()
+							.getServiceRegistry()
+							.getService( JdbcServices.class )
+							.getDialect(),
+					this
+			);
+		}
+		else {
+			scale = indicators.getColumnScale();
+		}
+		if ( scale > 6 ) {
+			// Since the maximum allowed scale on PostgreSQL is 6 (microsecond precision),
+			// we have to switch to the numeric type if the value is greater
+			return indicators.getTypeConfiguration().getJdbcTypeRegistry().getDescriptor( SqlTypes.NUMERIC );
+		}
+		return this;
+	}
+
+	@Override
+	public Expression wrapTopLevelSelectionExpression(Expression expression) {
+		return new SelfRenderingExpression() {
+			@Override
+			public void renderToSql(
+					SqlAppender sqlAppender,
+					SqlAstTranslator<?> walker,
+					SessionFactoryImplementor sessionFactory) {
+				sqlAppender.append( "extract(epoch from " );
+				expression.accept( walker );
+				sqlAppender.append( ')' );
+			}
+
+			@Override
+			public JdbcMappingContainer getExpressionType() {
+				return expression.getExpressionType();
+			}
+		};
+	}
+
+	@Override
+	public void appendWriteExpression(
+			String writeExpression,
+			SqlAppender appender,
+			Dialect dialect) {
+		appender.append( '(' );
+		appender.append( writeExpression );
+		appender.append( "*interval'1 second)" );
+	}
+
+	@Override
+	public int getJdbcTypeCode() {
+		return SqlTypes.NUMERIC;
+	}
+
+	@Override
+	public int getDefaultSqlTypeCode() {
+		return SqlTypes.INTERVAL_SECOND;
+	}
+
+	@Override
+	public String toString() {
+		return "IntervalSecondJdbcType";
+	}
+
+	@Override
+	public <T> JdbcLiteralFormatter<T> getJdbcLiteralFormatter(JavaType<T> javaType) {
+		// No literal support for now
+		return null;
+	}
+
+	@Override
+	public <X> ValueBinder<X> getBinder(JavaType<X> javaType) {
+		return new BasicBinder<>( javaType, this ) {
+			@Override
+			protected void doBind(PreparedStatement st, X value, int index, WrapperOptions options)
+					throws SQLException {
+				st.setBigDecimal( index, getBigDecimalValue( value, options ) );
+			}
+
+			@Override
+			protected void doBind(CallableStatement st, X value, String name, WrapperOptions options)
+					throws SQLException {
+				st.setBigDecimal( name, getBigDecimalValue( value, options ) );
+			}
+
+			private BigDecimal getBigDecimalValue(X value, WrapperOptions options) {
+				return getJavaType().unwrap( value, BigDecimal.class, options ).movePointLeft( 9 );
+			}
+		};
+	}
+
+	@Override
+	public <X> ValueExtractor<X> getExtractor(JavaType<X> javaType) {
+		return new BasicExtractor<>( javaType, this ) {
+			@Override
+			protected X doExtract(ResultSet rs, int paramIndex, WrapperOptions options) throws SQLException {
+				return getObject( rs.getBigDecimal( paramIndex ), options );
+			}
+
+			@Override
+			protected X doExtract(CallableStatement statement, int index, WrapperOptions options) throws SQLException {
+				return getObject( statement.getBigDecimal( index ), options );
+			}
+
+			@Override
+			protected X doExtract(CallableStatement statement, String name, WrapperOptions options) throws SQLException {
+				return getObject( statement.getBigDecimal( name ), options );
+			}
+
+			private X getObject(BigDecimal bigDecimal, WrapperOptions options) throws SQLException {
+				if ( bigDecimal == null ) {
+					return null;
+				}
+				return getJavaType().wrap( bigDecimal.movePointRight( 9 ), options );
+			}
+		};
+	}
+}

--- a/hibernate-core/src/main/java/org/hibernate/dialect/PostgreSQLCastingJsonJdbcType.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/PostgreSQLCastingJsonJdbcType.java
@@ -1,0 +1,59 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.dialect;
+
+import org.hibernate.metamodel.mapping.EmbeddableMappingType;
+import org.hibernate.metamodel.spi.RuntimeModelCreationContext;
+import org.hibernate.sql.ast.spi.SqlAppender;
+import org.hibernate.type.SqlTypes;
+import org.hibernate.type.descriptor.jdbc.AggregateJdbcType;
+import org.hibernate.type.descriptor.jdbc.JsonJdbcType;
+
+/**
+ * @author Christian Beikov
+ */
+public class PostgreSQLCastingJsonJdbcType extends JsonJdbcType {
+
+	public static final PostgreSQLCastingJsonJdbcType JSON_INSTANCE = new PostgreSQLCastingJsonJdbcType( false, null );
+	public static final PostgreSQLCastingJsonJdbcType JSONB_INSTANCE = new PostgreSQLCastingJsonJdbcType( true, null );
+
+	private final boolean jsonb;
+
+	public PostgreSQLCastingJsonJdbcType(boolean jsonb, EmbeddableMappingType embeddableMappingType) {
+		super( embeddableMappingType );
+		this.jsonb = jsonb;
+	}
+
+	@Override
+	public int getDdlTypeCode() {
+		return SqlTypes.JSON;
+	}
+
+	@Override
+	public AggregateJdbcType resolveAggregateJdbcType(
+			EmbeddableMappingType mappingType,
+			String sqlType,
+			RuntimeModelCreationContext creationContext) {
+		return new PostgreSQLCastingJsonJdbcType( jsonb, mappingType );
+	}
+
+	@Override
+	public void appendWriteExpression(
+			String writeExpression,
+			SqlAppender appender,
+			Dialect dialect) {
+		appender.append( "cast(" );
+		appender.append( writeExpression );
+		appender.append( " as " );
+		if ( jsonb ) {
+			appender.append( "jsonb)" );
+		}
+		else {
+			appender.append( "json)" );
+		}
+	}
+}

--- a/hibernate-core/src/main/java/org/hibernate/dialect/PostgreSQLCastingStructJdbcType.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/PostgreSQLCastingStructJdbcType.java
@@ -1,0 +1,91 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.dialect;
+
+import java.sql.CallableStatement;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+
+import org.hibernate.boot.model.naming.Identifier;
+import org.hibernate.metamodel.mapping.EmbeddableMappingType;
+import org.hibernate.metamodel.spi.RuntimeModelCreationContext;
+import org.hibernate.sql.ast.spi.SqlAppender;
+import org.hibernate.type.descriptor.ValueBinder;
+import org.hibernate.type.descriptor.WrapperOptions;
+import org.hibernate.type.descriptor.java.JavaType;
+import org.hibernate.type.descriptor.jdbc.AggregateJdbcType;
+import org.hibernate.type.descriptor.jdbc.BasicBinder;
+
+/**
+ * @author Christian Beikov
+ */
+public class PostgreSQLCastingStructJdbcType extends PostgreSQLStructJdbcType {
+
+	public static final PostgreSQLCastingStructJdbcType INSTANCE = new PostgreSQLCastingStructJdbcType( null, null, null );
+
+	public PostgreSQLCastingStructJdbcType(
+			EmbeddableMappingType embeddableMappingType,
+			String typeName,
+			int[] orderMapping) {
+		super( embeddableMappingType, typeName, orderMapping );
+	}
+
+	@Override
+	public AggregateJdbcType resolveAggregateJdbcType(
+			EmbeddableMappingType mappingType,
+			String sqlType,
+			RuntimeModelCreationContext creationContext) {
+		return new PostgreSQLCastingStructJdbcType(
+				mappingType,
+				sqlType,
+				creationContext.getBootModel()
+						.getDatabase()
+						.getDefaultNamespace()
+						.locateUserDefinedType( Identifier.toIdentifier( sqlType ) )
+						.getOrderMapping()
+		);
+	}
+
+	@Override
+	public void appendWriteExpression(
+			String writeExpression,
+			SqlAppender appender,
+			Dialect dialect) {
+		appender.append( "cast(" );
+		appender.append( writeExpression );
+		appender.append( " as " );
+		appender.append( getTypeName() );
+		appender.append( ')' );
+	}
+
+	@Override
+	public <X> ValueBinder<X> getBinder(JavaType<X> javaType) {
+		return new BasicBinder<>( javaType, this ) {
+			@Override
+			protected void doBind(PreparedStatement st, X value, int index, WrapperOptions options)
+					throws SQLException {
+				final String stringValue = ( (PostgreSQLCastingStructJdbcType) getJdbcType() ).toString(
+						value,
+						getJavaType(),
+						options
+				);
+				st.setString( index, stringValue );
+			}
+
+			@Override
+			protected void doBind(CallableStatement st, X value, String name, WrapperOptions options)
+					throws SQLException {
+				final String stringValue = ( (PostgreSQLCastingStructJdbcType) getJdbcType() ).toString(
+						value,
+						getJavaType(),
+						options
+				);
+				st.setString( name, stringValue );
+			}
+		};
+	}
+}

--- a/hibernate-core/src/main/java/org/hibernate/dialect/PostgreSQLDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/PostgreSQLDialect.java
@@ -248,16 +248,13 @@ public class PostgreSQLDialect extends Dialect {
 
 		ddlTypeRegistry.addDescriptor( new DdlTypeImpl( SQLXML, "xml", this ) );
 		ddlTypeRegistry.addDescriptor( new DdlTypeImpl( UUID, "uuid", this ) );
-		if ( PostgreSQLPGObjectJdbcType.isUsable() ) {
-			// The following DDL types require that the PGobject class is usable/visible
-			ddlTypeRegistry.addDescriptor( new DdlTypeImpl( INET, "inet", this ) );
-			ddlTypeRegistry.addDescriptor( new DdlTypeImpl( GEOMETRY, "geometry", this ) );
-			ddlTypeRegistry.addDescriptor( new DdlTypeImpl( GEOGRAPHY, "geography", this ) );
-			ddlTypeRegistry.addDescriptor( new Scale6IntervalSecondDdlType( this ) );
+		ddlTypeRegistry.addDescriptor( new DdlTypeImpl( INET, "inet", this ) );
+		ddlTypeRegistry.addDescriptor( new DdlTypeImpl( GEOMETRY, "geometry", this ) );
+		ddlTypeRegistry.addDescriptor( new DdlTypeImpl( GEOGRAPHY, "geography", this ) );
+		ddlTypeRegistry.addDescriptor( new Scale6IntervalSecondDdlType( this ) );
 
-			// Prefer jsonb if possible
-			ddlTypeRegistry.addDescriptor( new DdlTypeImpl( JSON, "jsonb", this ) );
-		}
+		// Prefer jsonb if possible
+		ddlTypeRegistry.addDescriptor( new DdlTypeImpl( JSON, "jsonb", this ) );
 	}
 
 	@Override
@@ -1316,17 +1313,27 @@ public class PostgreSQLDialect extends Dialect {
 		jdbcTypeRegistry.addDescriptor( XmlJdbcType.INSTANCE );
 
 		if ( driverKind == PostgreSQLDriverKind.PG_JDBC ) {
+			// HHH-9562
+			jdbcTypeRegistry.addDescriptorIfAbsent( UUIDJdbcType.INSTANCE );
 			if ( PostgreSQLPGObjectJdbcType.isUsable() ) {
 				jdbcTypeRegistry.addDescriptorIfAbsent( PostgreSQLInetJdbcType.INSTANCE );
 				jdbcTypeRegistry.addDescriptorIfAbsent( PostgreSQLIntervalSecondJdbcType.INSTANCE );
 				jdbcTypeRegistry.addDescriptorIfAbsent( PostgreSQLStructJdbcType.INSTANCE );
-			}
-
-			// HHH-9562
-			jdbcTypeRegistry.addDescriptorIfAbsent( UUIDJdbcType.INSTANCE );
-			if ( PostgreSQLPGObjectJdbcType.isUsable() ) {
 				jdbcTypeRegistry.addDescriptorIfAbsent( PostgreSQLJsonbJdbcType.INSTANCE );
 			}
+			else {
+				jdbcTypeRegistry.addDescriptorIfAbsent( PostgreSQLCastingInetJdbcType.INSTANCE );
+				jdbcTypeRegistry.addDescriptorIfAbsent( PostgreSQLCastingIntervalSecondJdbcType.INSTANCE );
+				jdbcTypeRegistry.addDescriptorIfAbsent( PostgreSQLCastingStructJdbcType.INSTANCE );
+				jdbcTypeRegistry.addDescriptorIfAbsent( PostgreSQLCastingJsonJdbcType.JSONB_INSTANCE );
+			}
+		}
+		else {
+			jdbcTypeRegistry.addDescriptorIfAbsent( UUIDJdbcType.INSTANCE );
+			jdbcTypeRegistry.addDescriptorIfAbsent( PostgreSQLCastingInetJdbcType.INSTANCE );
+			jdbcTypeRegistry.addDescriptorIfAbsent( PostgreSQLCastingIntervalSecondJdbcType.INSTANCE );
+			jdbcTypeRegistry.addDescriptorIfAbsent( PostgreSQLCastingStructJdbcType.INSTANCE );
+			jdbcTypeRegistry.addDescriptorIfAbsent( PostgreSQLCastingJsonJdbcType.JSONB_INSTANCE );
 		}
 
 		// PostgreSQL requires a custom binder for binding untyped nulls as VARBINARY

--- a/hibernate-core/src/main/java/org/hibernate/dialect/PostgreSQLStructJdbcType.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/PostgreSQLStructJdbcType.java
@@ -56,7 +56,7 @@ import static org.hibernate.type.descriptor.DateTimeUtils.appendAsTimestampWithM
  */
 public class PostgreSQLStructJdbcType extends PostgreSQLPGObjectJdbcType implements AggregateJdbcType {
 
-	public static final PostgreSQLStructJdbcType INSTANCE = new PostgreSQLStructJdbcType();
+	public static final PostgreSQLStructJdbcType INSTANCE = new PostgreSQLStructJdbcType( null, null, null );
 
 	private static final DateTimeFormatter LOCAL_DATE_TIME;
 	static {
@@ -88,11 +88,6 @@ public class PostgreSQLStructJdbcType extends PostgreSQLPGObjectJdbcType impleme
 	private final int[] inverseOrderMapping;
 	private final EmbeddableMappingType embeddableMappingType;
 	private final ValueExtractor<Object[]> objectArrayExtractor;
-
-	private PostgreSQLStructJdbcType() {
-		// The default instance is for reading only and will return an Object[]
-		this( null, null, null );
-	}
 
 	public PostgreSQLStructJdbcType(EmbeddableMappingType embeddableMappingType, String typeName, int[] orderMapping) {
 		super( typeName, SqlTypes.STRUCT );

--- a/hibernate-core/src/main/java/org/hibernate/dialect/function/AggregateWindowEmulationQueryTransformer.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/function/AggregateWindowEmulationQueryTransformer.java
@@ -122,7 +122,6 @@ public class AggregateWindowEmulationQueryTransformer implements QueryTransforme
 					columnName,
 					false,
 					null,
-					null,
 					mapping.getJdbcMapping()
 			);
 			final Expression expression = subSelections.get( i ).getExpression();
@@ -190,7 +189,6 @@ public class AggregateWindowEmulationQueryTransformer implements QueryTransforme
 							columnName,
 							false,
 							null,
-							null,
 							jdbcMapping
 					);
 					final int subValuesPosition = subSelectClause.getSqlSelections().size();
@@ -252,7 +250,6 @@ public class AggregateWindowEmulationQueryTransformer implements QueryTransforme
 									columnName,
 									false,
 									null,
-									null,
 									jdbcMapping
 							);
 							final int subValuesPosition = subSelectClause.getSqlSelections().size();
@@ -311,7 +308,6 @@ public class AggregateWindowEmulationQueryTransformer implements QueryTransforme
 								columnName,
 								false,
 								null,
-								null,
 								jdbcMapping
 						);
 						final int subValuesPosition = subSelectClause.getSqlSelections().size();
@@ -367,7 +363,6 @@ public class AggregateWindowEmulationQueryTransformer implements QueryTransforme
 							identifierVariable,
 							columnName,
 							false,
-							null,
 							null,
 							mapping.getJdbcMapping()
 					)

--- a/hibernate-core/src/main/java/org/hibernate/id/ExportableColumn.java
+++ b/hibernate-core/src/main/java/org/hibernate/id/ExportableColumn.java
@@ -13,6 +13,7 @@ import java.util.NoSuchElementException;
 import org.hibernate.FetchMode;
 import org.hibernate.MappingException;
 import org.hibernate.boot.model.relational.Database;
+import org.hibernate.boot.spi.MetadataBuildingContext;
 import org.hibernate.engine.spi.Mapping;
 import org.hibernate.internal.util.collections.ArrayHelper;
 import org.hibernate.mapping.Column;
@@ -185,6 +186,11 @@ public class ExportableColumn extends Column {
 		@Override
 		public boolean isColumnUpdateable(int index) {
 			return true;
+		}
+
+		@Override
+		public MetadataBuildingContext getBuildingContext() {
+			return table.getIdentifierValue().getBuildingContext();
 		}
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/mapping/Collection.java
+++ b/hibernate-core/src/main/java/org/hibernate/mapping/Collection.java
@@ -170,6 +170,7 @@ public abstract class Collection implements Fetchable, Value, Filterable {
 		this.loaderName = original.loaderName;
 	}
 
+	@Override
 	public MetadataBuildingContext getBuildingContext() {
 		return buildingContext;
 	}

--- a/hibernate-core/src/main/java/org/hibernate/mapping/Column.java
+++ b/hibernate-core/src/main/java/org/hibernate/mapping/Column.java
@@ -560,6 +560,7 @@ public class Column implements Selectable, Serializable, Cloneable, ColumnTypeIn
 		return hasCustomRead() ? customRead : getQuotedName( dialect );
 	}
 
+	@Override
 	public String getWriteExpr() {
 		return customWrite != null && customWrite.length() > 0 ? customWrite : "?";
 	}

--- a/hibernate-core/src/main/java/org/hibernate/mapping/OneToMany.java
+++ b/hibernate-core/src/main/java/org/hibernate/mapping/OneToMany.java
@@ -51,6 +51,7 @@ public class OneToMany implements Value {
 		return new OneToMany( this );
 	}
 
+	@Override
 	public MetadataBuildingContext getBuildingContext() {
 		return buildingContext;
 	}

--- a/hibernate-core/src/main/java/org/hibernate/mapping/Selectable.java
+++ b/hibernate-core/src/main/java/org/hibernate/mapping/Selectable.java
@@ -6,8 +6,12 @@
  */
 package org.hibernate.mapping;
 
+import org.hibernate.Incubating;
 import org.hibernate.dialect.Dialect;
+import org.hibernate.engine.spi.SessionFactoryImplementor;
+import org.hibernate.metamodel.mapping.JdbcMapping;
 import org.hibernate.query.sqm.function.SqmFunctionRegistry;
+import org.hibernate.type.descriptor.jdbc.JdbcType;
 import org.hibernate.type.spi.TypeConfiguration;
 
 /**
@@ -62,4 +66,17 @@ public interface Selectable {
 	String getAlias(Dialect dialect, Table table);
 
 	String getTemplate(Dialect dialect, TypeConfiguration typeConfiguration, SqmFunctionRegistry functionRegistry);
+
+	@Incubating
+	default String getWriteExpr() {
+		final String customWriteExpression = getCustomWriteExpression();
+		return customWriteExpression == null || customWriteExpression.isEmpty()
+				? "?"
+				: customWriteExpression;
+	}
+
+	@Incubating
+	default String getWriteExpr(JdbcMapping jdbcMapping, Dialect dialect) {
+		return jdbcMapping.getJdbcType().wrapWriteExpression( getWriteExpr(), dialect );
+	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/mapping/SimpleValue.java
+++ b/hibernate-core/src/main/java/org/hibernate/mapping/SimpleValue.java
@@ -142,6 +142,7 @@ public abstract class SimpleValue implements KeyValue {
 		this.generator = original.generator;
 	}
 
+	@Override
 	public MetadataBuildingContext getBuildingContext() {
 		return buildingContext;
 	}

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/AbstractEmbeddableMapping.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/AbstractEmbeddableMapping.java
@@ -306,7 +306,7 @@ public abstract class AbstractEmbeddableMapping implements EmbeddableMappingType
 						selectablePath,
 						selectable.isFormula(),
 						selectable.getCustomReadExpression(),
-						selectable.getCustomWriteExpression(),
+						selectable.getWriteExpr( ( (BasicType<?>) subtype ).getJdbcMapping(), dialect ),
 						columnDefinition,
 						length,
 						precision,

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/BasicAttributeMapping.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/BasicAttributeMapping.java
@@ -251,6 +251,11 @@ public class BasicAttributeMapping
 	}
 
 	@Override
+	public String getWriteExpression() {
+		return customWriteExpression;
+	}
+
+	@Override
 	public String getColumnDefinition() {
 		return columnDefinition;
 	}

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/CaseStatementDiscriminatorMappingImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/CaseStatementDiscriminatorMappingImpl.java
@@ -150,7 +150,6 @@ public class CaseStatementDiscriminatorMappingImpl extends AbstractDiscriminator
 												tableDiscriminatorDetails.getCheckColumnName(),
 												false,
 												null,
-												null,
 												getJdbcMapping()
 										),
 										true

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/EmbeddableMappingTypeImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/EmbeddableMappingTypeImpl.java
@@ -420,7 +420,7 @@ public class EmbeddableMappingTypeImpl extends AbstractEmbeddableMapping impleme
 						selectablePath,
 						selectable.isFormula(),
 						selectable.getCustomReadExpression(),
-						selectable.getCustomWriteExpression(),
+						selectable.getWriteExpr( ( (BasicType<?>) subtype ).getJdbcMapping(), dialect ),
 						columnDefinition,
 						length,
 						precision,

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/SelectableMappingImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/SelectableMappingImpl.java
@@ -16,6 +16,7 @@ import org.hibernate.metamodel.mapping.JdbcMapping;
 import org.hibernate.metamodel.mapping.SelectableMapping;
 import org.hibernate.metamodel.mapping.SelectablePath;
 import org.hibernate.query.sqm.function.SqmFunctionRegistry;
+import org.hibernate.type.BasicType;
 import org.hibernate.type.spi.TypeConfiguration;
 
 /**
@@ -57,7 +58,7 @@ public class SelectableMappingImpl extends SqlTypedMappingImpl implements Select
 		this.selectionExpression = selectionExpression.intern();
 		this.selectablePath = selectablePath == null ? new SelectablePath( selectionExpression ) : selectablePath;
 		this.customReadExpression = customReadExpression == null ? null : customReadExpression.intern();
-		this.customWriteExpression = customWriteExpression == null ? null : customWriteExpression.intern();
+		this.customWriteExpression = customWriteExpression == null || isFormula ? null : customWriteExpression.intern();
 		this.nullable = nullable;
 		this.insertable = insertable;
 		this.updateable = updateable;
@@ -160,7 +161,7 @@ public class SelectableMappingImpl extends SqlTypedMappingImpl implements Select
 						? null
 						: parentPath.append( selectableName ),
 				selectable.getCustomReadExpression(),
-				selectable.getCustomWriteExpression(),
+				selectable.getWriteExpr( jdbcMapping, dialect ),
 				columnDefinition,
 				length,
 				precision,
@@ -211,6 +212,11 @@ public class SelectableMappingImpl extends SqlTypedMappingImpl implements Select
 
 	@Override
 	public String getCustomWriteExpression() {
+		return customWriteExpression;
+	}
+
+	@Override
+	public String getWriteExpression() {
 		return customWriteExpression;
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/ordering/ast/ColumnReference.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/ordering/ast/ColumnReference.java
@@ -67,7 +67,6 @@ public class ColumnReference implements OrderingExpression, SequencePart {
 						// because these ordering fragments are only ever part of the order-by clause, there
 						//		is no need for the JdbcMapping
 						null,
-						null,
 						null
 				)
 		);

--- a/hibernate-core/src/main/java/org/hibernate/persister/collection/AbstractCollectionPersister.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/collection/AbstractCollectionPersister.java
@@ -128,6 +128,7 @@ import org.hibernate.sql.model.jdbc.JdbcMutationOperation;
 import org.hibernate.sql.results.graph.DomainResult;
 import org.hibernate.sql.results.graph.internal.ImmutableFetchList;
 import org.hibernate.sql.results.internal.SqlSelectionImpl;
+import org.hibernate.type.AssociationType;
 import org.hibernate.type.CollectionType;
 import org.hibernate.type.CompositeType;
 import org.hibernate.type.EntityType;
@@ -397,7 +398,7 @@ public abstract class AbstractCollectionPersister
 			else {
 				Column col = (Column) selectable;
 				elementColumnNames[j] = col.getQuotedName( dialect );
-				elementColumnWriters[j] = col.getWriteExpr();
+				elementColumnWriters[j] = col.getWriteExpr( elementBootDescriptor.getSelectableType( factory, j ), dialect );
 				elementColumnReaders[j] = col.getReadExpr( dialect );
 				elementColumnReaderTemplates[j] = col.getTemplate(
 						dialect,

--- a/hibernate-core/src/main/java/org/hibernate/persister/entity/AbstractEntityPersister.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/entity/AbstractEntityPersister.java
@@ -662,7 +662,7 @@ public abstract class AbstractEntityPersister
 				else {
 					final Column column = (Column) selectable;
 					colNames[k] = column.getQuotedName( dialect );
-					colWriters[k] = column.getWriteExpr();
+					colWriters[k] = column.getWriteExpr( prop.getValue().getSelectableType( factory, k ), dialect );
 				}
 			}
 			propertyColumnNames[i] = colNames;
@@ -1326,7 +1326,6 @@ public abstract class AbstractEntityPersister
 									rootPkColumnName,
 									false,
 									null,
-									null,
 									selection.getJdbcMapping()
 							)
 					);
@@ -1338,7 +1337,6 @@ public abstract class AbstractEntityPersister
 									joinedTableReference.getIdentificationVariable(),
 									fkColumnName,
 									false,
-									null,
 									null,
 									selection.getJdbcMapping()
 							)
@@ -3061,7 +3059,6 @@ public abstract class AbstractEntityPersister
 						alias,
 						discriminatorExpression,
 						isDiscriminatorFormula(),
-						null,
 						null,
 						discriminatorType.getJdbcMapping()
 				)
@@ -5301,7 +5298,7 @@ public abstract class AbstractEntityPersister
 					null,
 					false,
 					null,
-					null,
+					"?",
 					column.getSqlType(),
 					column.getLength(),
 					column.getPrecision(),
@@ -5330,7 +5327,7 @@ public abstract class AbstractEntityPersister
 				attrColumnExpression = attrColumnNames[0];
 				isAttrColumnExpressionFormula = false;
 				customReadExpr = null;
-				customWriteExpr = null;
+				customWriteExpr = "?";
 				Column column = value.getColumns().get( 0 );
 				columnDefinition = column.getSqlType();
 				length = column.getLength();
@@ -5356,7 +5353,7 @@ public abstract class AbstractEntityPersister
 							creationContext.getTypeConfiguration(),
 							creationContext.getFunctionRegistry()
 					);
-					customWriteExpr = selectable.getCustomWriteExpression();
+					customWriteExpr = selectable.getWriteExpr( (JdbcMapping) attrType, creationContext.getDialect() );
 					Column column = value.getColumns().get( 0 );
 					columnDefinition = column.getSqlType();
 					length = column.getLength();

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/mutation/internal/cte/CteInsertHandler.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/mutation/internal/cte/CteInsertHandler.java
@@ -268,7 +268,6 @@ public class CteInsertHandler implements InsertHandler {
 									rowNumberColumn.getColumnExpression(),
 									false,
 									null,
-									null,
 									rowNumberColumn.getJdbcMapping()
 							);
 							insertStatement.getTargetColumns().set(
@@ -322,7 +321,6 @@ public class CteInsertHandler implements InsertHandler {
 													columnReference.getColumnExpression(),
 													false,
 													null,
-													null,
 													columnReference.getJdbcMapping()
 									)
 							)
@@ -352,7 +350,6 @@ public class CteInsertHandler implements InsertHandler {
 					(String) null,
 					rowNumberColumn.getColumnExpression(),
 					false,
-					null,
 					null,
 					rowNumberColumn.getJdbcMapping()
 			);
@@ -390,7 +387,6 @@ public class CteInsertHandler implements InsertHandler {
 					"e",
 					rowNumberColumn.getColumnExpression(),
 					false,
-					null,
 					null,
 					rowNumberColumn.getJdbcMapping()
 			);
@@ -498,7 +494,6 @@ public class CteInsertHandler implements InsertHandler {
 												rowNumberColumn.getColumnExpression(),
 												false,
 												null,
-												null,
 												rowNumberColumn.getJdbcMapping()
 										)
 								)
@@ -515,7 +510,6 @@ public class CteInsertHandler implements InsertHandler {
 												idColumn.getColumnExpression(),
 												false,
 												null,
-												null,
 												idColumn.getJdbcMapping()
 										),
 										BinaryArithmeticOperator.ADD,
@@ -526,7 +520,6 @@ public class CteInsertHandler implements InsertHandler {
 														"t",
 														rowNumberColumn.getColumnExpression(),
 														false,
-														null,
 														null,
 														rowNumberColumn.getJdbcMapping()
 												),
@@ -559,7 +552,6 @@ public class CteInsertHandler implements InsertHandler {
 											"e",
 											cteColumn.getColumnExpression(),
 											false,
-											null,
 											null,
 											cteColumn.getJdbcMapping()
 									)
@@ -822,7 +814,6 @@ public class CteInsertHandler implements InsertHandler {
 						rowNumberColumn.getColumnExpression(),
 						false,
 						null,
-						null,
 						rowNumberColumn.getJdbcMapping()
 				);
 				// Insert in the same order as the original tuples came
@@ -842,7 +833,6 @@ public class CteInsertHandler implements InsertHandler {
 									dmlTableReference,
 									keyColumns[j],
 									false,
-									null,
 									null,
 									null
 							)
@@ -878,7 +868,6 @@ public class CteInsertHandler implements InsertHandler {
 												rowNumberColumn.getColumnExpression(),
 												false,
 												null,
-												null,
 												rowNumberColumn.getJdbcMapping()
 										)
 								)
@@ -897,7 +886,6 @@ public class CteInsertHandler implements InsertHandler {
 										idCteColumn.getColumnExpression(),
 										false,
 										null,
-										null,
 										idCteColumn.getJdbcMapping()
 								)
 						)
@@ -913,7 +901,6 @@ public class CteInsertHandler implements InsertHandler {
 											"e",
 											cteColumn.getColumnExpression(),
 											false,
-											null,
 											null,
 											cteColumn.getJdbcMapping()
 									)
@@ -943,7 +930,6 @@ public class CteInsertHandler implements InsertHandler {
 						"e",
 						idCteColumn.getColumnExpression(),
 						false,
-						null,
 						null,
 						idCteColumn.getJdbcMapping()
 				);
@@ -998,7 +984,6 @@ public class CteInsertHandler implements InsertHandler {
 									keyColumns[j],
 									false,
 									null,
-									null,
 									null
 							)
 					);
@@ -1010,7 +995,6 @@ public class CteInsertHandler implements InsertHandler {
 											"e",
 											rootKeyColumns[j],
 											false,
-											null,
 											null,
 											null
 									)
@@ -1045,7 +1029,6 @@ public class CteInsertHandler implements InsertHandler {
 												"e",
 												entry.getKey().get( j ).getColumnExpression(),
 												columnReference.isColumnExpressionFormula(),
-												null,
 												null,
 												columnReference.getJdbcMapping()
 										)

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/mutation/internal/inline/InPredicateRestrictionProducer.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/mutation/internal/inline/InPredicateRestrictionProducer.java
@@ -74,7 +74,6 @@ public class InPredicateRestrictionProducer implements MatchingIdRestrictionProd
 					// id columns cannot be formulas and cannot have custom read and write expressions
 					false,
 					null,
-					null,
 					basicIdMapping.getJdbcMapping()
 			);
 			predicate = new InListPredicate( inFixture );

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/mutation/internal/inline/InlineUpdateHandler.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/mutation/internal/inline/InlineUpdateHandler.java
@@ -452,7 +452,6 @@ public class InlineUpdateHandler implements UpdateHandler {
 									columnReference.getColumnExpression(),
 									false,
 									null,
-									null,
 									columnReference.getJdbcMapping()
 							);
 							columnNames.add( columnReference.getColumnExpression() );
@@ -462,7 +461,6 @@ public class InlineUpdateHandler implements UpdateHandler {
 											rootTableGroup.getPrimaryTableReference(),
 											selectableMapping.getSelectionExpression(),
 											false,
-											null,
 											null,
 											columnReference.getJdbcMapping()
 									)
@@ -485,7 +483,6 @@ public class InlineUpdateHandler implements UpdateHandler {
 						columnReference.getColumnExpression(),
 						false,
 						null,
-						null,
 						columnReference.getJdbcMapping()
 				);
 				columnNames = Collections.singletonList( columnReference.getColumnExpression() );
@@ -496,7 +493,6 @@ public class InlineUpdateHandler implements UpdateHandler {
 								rootTableGroup.getPrimaryTableReference(),
 								( (BasicEntityIdentifierMapping) entityDescriptor.getIdentifierMapping() ).getSelectionExpression(),
 								false,
-								null,
 								null,
 								columnReference.getJdbcMapping()
 						)

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/mutation/internal/temptable/ExecuteWithTemporaryTableHelper.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/mutation/internal/temptable/ExecuteWithTemporaryTableHelper.java
@@ -80,7 +80,6 @@ public final class ExecuteWithTemporaryTableHelper {
 							// id columns cannot be formulas and cannot have custom read and write expressions
 							false,
 							null,
-							null,
 							column.getJdbcMapping()
 					)
 			);
@@ -230,7 +229,6 @@ public final class ExecuteWithTemporaryTableHelper {
 											temporaryTableColumn.getColumnName(),
 											false,
 											null,
-											null,
 											temporaryTableColumn.getJdbcMapping()
 									)
 							)
@@ -249,7 +247,6 @@ public final class ExecuteWithTemporaryTableHelper {
 												tableReference,
 												selectableMapping.getSelectionExpression(),
 												false,
-												null,
 												null,
 												selectableMapping.getJdbcMapping()
 										)
@@ -273,7 +270,6 @@ public final class ExecuteWithTemporaryTableHelper {
 									idTableReference,
 									idTable.getSessionUidColumn().getColumnName(),
 									false,
-									null,
 									null,
 									idTable.getSessionUidColumn().getJdbcMapping()
 							),

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/mutation/internal/temptable/InsertExecutionDelegate.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/mutation/internal/temptable/InsertExecutionDelegate.java
@@ -22,7 +22,6 @@ import org.hibernate.engine.FetchTiming;
 import org.hibernate.engine.jdbc.spi.JdbcServices;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
-import org.hibernate.generator.EventType;
 import org.hibernate.id.BulkInsertionCapableIdentifierGenerator;
 import org.hibernate.id.OptimizableGenerator;
 import org.hibernate.id.PostInsertIdentityPersister;
@@ -348,7 +347,6 @@ public class InsertExecutionDelegate implements TableBasedInsertHandler.Executio
 											columnReference.getColumnExpression(),
 											false,
 											null,
-											null,
 											columnReference.getJdbcMapping()
 									)
 							)
@@ -368,7 +366,6 @@ public class InsertExecutionDelegate implements TableBasedInsertHandler.Executio
 					(String) null,
 					TemporaryTable.ENTITY_TABLE_IDENTITY_COLUMN,
 					false,
-					null,
 					null,
 					identifierMapping.getJdbcMapping()
 			);
@@ -453,7 +450,6 @@ public class InsertExecutionDelegate implements TableBasedInsertHandler.Executio
 									sessionUidColumn.getColumnName(),
 									false,
 									null,
-									null,
 									sessionUidColumn.getJdbcMapping()
 							),
 							ComparisonOperator.EQUAL,
@@ -469,7 +465,6 @@ public class InsertExecutionDelegate implements TableBasedInsertHandler.Executio
 											(String) null,
 											rowNumberColumn.getColumnName(),
 											false,
-											null,
 											null,
 											rowNumberColumn.getJdbcMapping()
 									),
@@ -529,7 +524,6 @@ public class InsertExecutionDelegate implements TableBasedInsertHandler.Executio
 								keyColumns[0],
 								false,
 								null,
-								null,
 								identifierMapping.getJdbcMapping()
 						)
 				);
@@ -541,7 +535,6 @@ public class InsertExecutionDelegate implements TableBasedInsertHandler.Executio
 										updatingTableReference.getIdentificationVariable(),
 										idColumnReference.getColumnExpression(),
 										false,
-										null,
 										null,
 										idColumnReference.getJdbcMapping()
 								)
@@ -598,7 +591,6 @@ public class InsertExecutionDelegate implements TableBasedInsertHandler.Executio
 									(String) null,
 									TemporaryTable.ENTITY_TABLE_IDENTITY_COLUMN,
 									false,
-									null,
 									null,
 									identifierMapping.getJdbcMapping()
 							),
@@ -706,7 +698,6 @@ public class InsertExecutionDelegate implements TableBasedInsertHandler.Executio
 											columnReference.getColumnExpression(),
 											false,
 											null,
-											null,
 											columnReference.getJdbcMapping()
 									)
 							)
@@ -739,7 +730,6 @@ public class InsertExecutionDelegate implements TableBasedInsertHandler.Executio
 							dmlTargetTableReference.getIdentificationVariable(),
 							targetKeyColumnName,
 							false,
-							null,
 							null,
 							identifierMapping.getJdbcMapping()
 					)

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/mutation/internal/temptable/TableBasedInsertHandler.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/mutation/internal/temptable/TableBasedInsertHandler.java
@@ -189,7 +189,6 @@ public class TableBasedInsertHandler implements InsertHandler {
 									rowNumberColumn.getColumnName(),
 									false,
 									null,
-									null,
 									rowNumberColumn.getJdbcMapping()
 							);
 							insertStatement.getTargetColumns().set(
@@ -214,7 +213,6 @@ public class TableBasedInsertHandler implements InsertHandler {
 										rowNumberColumn.getColumnName(),
 										false,
 										null,
-										null,
 										rowNumberColumn.getJdbcMapping()
 								);
 								insertStatement.getTargetColumns().add( columnReference );
@@ -236,7 +234,6 @@ public class TableBasedInsertHandler implements InsertHandler {
 									(String) null,
 									sessionUidColumn.getColumnName(),
 									false,
-									null,
 									null,
 									sessionUidColumn.getJdbcMapping()
 							);
@@ -267,7 +264,6 @@ public class TableBasedInsertHandler implements InsertHandler {
 							rowNumberColumn.getColumnName(),
 							false,
 							null,
-							null,
 							rowNumberColumn.getJdbcMapping()
 					);
 					insertStatement.getTargetColumns().add( columnReference );
@@ -285,7 +281,6 @@ public class TableBasedInsertHandler implements InsertHandler {
 						(String) null,
 						sessionUidColumn.getColumnName(),
 						false,
-						null,
 						null,
 						sessionUidColumn.getJdbcMapping()
 				);

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/sql/BaseSqmToSqlAstConverter.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/sql/BaseSqmToSqlAstConverter.java
@@ -96,6 +96,8 @@ import org.hibernate.metamodel.model.domain.EntityDomainType;
 import org.hibernate.metamodel.model.domain.PluralPersistentAttribute;
 import org.hibernate.metamodel.model.domain.internal.AnyDiscriminatorSqmPath;
 import org.hibernate.metamodel.model.domain.internal.AnyDiscriminatorSqmPathSource;
+import org.hibernate.query.derived.AnonymousTupleTableGroupProducer;
+import org.hibernate.query.derived.AnonymousTupleType;
 import org.hibernate.metamodel.model.domain.internal.BasicSqmPathSource;
 import org.hibernate.metamodel.model.domain.internal.CompositeSqmPathSource;
 import org.hibernate.metamodel.model.domain.internal.DiscriminatorSqmPath;
@@ -113,8 +115,6 @@ import org.hibernate.query.criteria.JpaCteCriteriaAttribute;
 import org.hibernate.query.criteria.JpaPath;
 import org.hibernate.query.criteria.JpaSearchOrder;
 import org.hibernate.query.derived.AnonymousTupleEntityValuedModelPart;
-import org.hibernate.query.derived.AnonymousTupleTableGroupProducer;
-import org.hibernate.query.derived.AnonymousTupleType;
 import org.hibernate.query.spi.QueryEngine;
 import org.hibernate.query.spi.QueryOptions;
 import org.hibernate.query.spi.QueryParameterBinding;
@@ -4611,7 +4611,6 @@ public abstract class BaseSqmToSqlAstConverter<T extends Statement> extends Base
 										columnNames.get( i ),
 										false,
 										null,
-										null,
 										subQueryColumns.get( i ).getJdbcMapping()
 								)
 						);
@@ -4653,7 +4652,6 @@ public abstract class BaseSqmToSqlAstConverter<T extends Statement> extends Base
 									identifierVariable,
 									columnNames.get( 0 ),
 									false,
-									null,
 									null,
 									expression.getExpressionType().getSingleJdbcMapping()
 							)
@@ -4757,7 +4755,6 @@ public abstract class BaseSqmToSqlAstConverter<T extends Statement> extends Base
 									tableReference.getColumnNames().get( 0 ),
 									false,
 									null,
-									null,
 									sqlSelections.get( 0 ).getExpressionType().getSingleJdbcMapping()
 							)
 					),
@@ -4773,7 +4770,6 @@ public abstract class BaseSqmToSqlAstConverter<T extends Statement> extends Base
 									identifierVariable,
 									tableReference.getColumnNames().get( selectionIndex ),
 									false,
-									null,
 									null,
 									selectionMapping.getJdbcMapping()
 							)

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/sql/internal/SqlAstQueryPartProcessingStateImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/sql/internal/SqlAstQueryPartProcessingStateImpl.java
@@ -147,12 +147,23 @@ public class SqlAstQueryPartProcessingStateImpl
 
 		final SelectClause selectClause = ( (QuerySpec) queryPart ).getSelectClause();
 		final int valuesArrayPosition = selectClause.getSqlSelections().size();
-		final SqlSelection sqlSelection = expression.createSqlSelection(
-				valuesArrayPosition + 1,
-				valuesArrayPosition,
-				javaType,
-				typeConfiguration
-		);
+		final SqlSelection sqlSelection;
+		if ( isTopLevel() ) {
+			sqlSelection = expression.createDomainResultSqlSelection(
+					valuesArrayPosition + 1,
+					valuesArrayPosition,
+					javaType,
+					typeConfiguration
+			);
+		}
+		else {
+			sqlSelection = expression.createSqlSelection(
+					valuesArrayPosition + 1,
+					valuesArrayPosition,
+					javaType,
+					typeConfiguration
+			);
+		}
 
 		selectClause.addSqlSelection( sqlSelection );
 

--- a/hibernate-core/src/main/java/org/hibernate/sql/ast/spi/AbstractSqlAstTranslator.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/ast/spi/AbstractSqlAstTranslator.java
@@ -1977,7 +1977,6 @@ public abstract class AbstractSqlAstTranslator<T extends JdbcOperation> implemen
 								currentCteStatement.getCycleMarkColumn().getColumnExpression(),
 								false,
 								null,
-								null,
 								currentCteStatement.getCycleMarkColumn().getJdbcMapping()
 						);
 						if ( currentCteStatement.getCycleValue().getJdbcMapping() == getBooleanType()
@@ -2020,7 +2019,6 @@ public abstract class AbstractSqlAstTranslator<T extends JdbcOperation> implemen
 						depthColumnName,
 						false,
 						null,
-						null,
 						integerType
 				);
 				visitColumnReference( depthColumnReference );
@@ -2051,7 +2049,6 @@ public abstract class AbstractSqlAstTranslator<T extends JdbcOperation> implemen
 								recursiveTableReference,
 								currentCteStatement.getSearchColumn().getColumnExpression(),
 								false,
-								null,
 								null,
 								currentCteStatement.getSearchColumn().getJdbcMapping()
 						)
@@ -2164,7 +2161,6 @@ public abstract class AbstractSqlAstTranslator<T extends JdbcOperation> implemen
 						depthColumnName,
 						false,
 						null,
-						null,
 						integerType
 				);
 				visitColumnReference( depthColumnReference );
@@ -2207,7 +2203,6 @@ public abstract class AbstractSqlAstTranslator<T extends JdbcOperation> implemen
 								recursiveTableReference,
 								currentCteStatement.getSearchColumn().getColumnExpression(),
 								false,
-								null,
 								null,
 								currentCteStatement.getSearchColumn().getJdbcMapping()
 						)
@@ -2352,7 +2347,6 @@ public abstract class AbstractSqlAstTranslator<T extends JdbcOperation> implemen
 					recursiveTableReference,
 					cyclePathColumnName,
 					false,
-					null,
 					null,
 					stringType
 			);
@@ -2499,7 +2493,6 @@ public abstract class AbstractSqlAstTranslator<T extends JdbcOperation> implemen
 					recursiveTableReference,
 					cyclePathColumnName,
 					false,
-					null,
 					null,
 					stringType
 			);
@@ -2919,7 +2912,6 @@ public abstract class AbstractSqlAstTranslator<T extends JdbcOperation> implemen
 											"c" + i,
 											false,
 											null,
-											null,
 											getIntegerType()
 									)
 							)
@@ -3143,7 +3135,6 @@ public abstract class AbstractSqlAstTranslator<T extends JdbcOperation> implemen
 				(String) null,
 				"c" + index,
 				false,
-				null,
 				null,
 				expression.getExpressionType().getSingleJdbcMapping()
 		);
@@ -5608,7 +5599,6 @@ public abstract class AbstractSqlAstTranslator<T extends JdbcOperation> implemen
 								columnName,
 								false,
 								null,
-								null,
 								null
 						)
 				);
@@ -5677,7 +5667,6 @@ public abstract class AbstractSqlAstTranslator<T extends JdbcOperation> implemen
 									subTableGroup.getPrimaryTableReference(),
 									columnName,
 									false,
-									null,
 									null,
 									null
 							)
@@ -5802,7 +5791,6 @@ public abstract class AbstractSqlAstTranslator<T extends JdbcOperation> implemen
 							tableReference,
 							"sort_col_" + i,
 							false,
-							null,
 							null,
 							null
 					);
@@ -6193,7 +6181,11 @@ public abstract class AbstractSqlAstTranslator<T extends JdbcOperation> implemen
 				break;
 			case DEFAULT:
 			default:
-				appendSql( PARAM_MARKER );
+				jdbcParameter.getExpressionType()
+						.getJdbcMappings()
+						.get( 0 )
+						.getJdbcType()
+						.appendWriteExpression( "?", this, getDialect() );
 
 				parameterBinders.add( jdbcParameter.getParameterBinder() );
 				jdbcParameters.addParameter( jdbcParameter );

--- a/hibernate-core/src/main/java/org/hibernate/sql/ast/spi/SqlAstProcessingState.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/ast/spi/SqlAstProcessingState.java
@@ -18,4 +18,8 @@ public interface SqlAstProcessingState {
 	SqlExpressionResolver getSqlExpressionResolver();
 
 	SqlAstCreationState getSqlAstCreationState();
+
+	default boolean isTopLevel() {//todo: naming
+		return getParentState() == null;
+	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/sql/ast/tree/expression/ColumnReference.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/ast/tree/expression/ColumnReference.java
@@ -37,7 +37,6 @@ public class ColumnReference implements Expression, Assignable {
 	private final SelectablePath selectablePath;
 	private final boolean isFormula;
 	private final String readExpression;
-	private final String customWriteExpression;
 	private final JdbcMapping jdbcMapping;
 
 	public ColumnReference(TableReference tableReference, SelectableMapping selectableMapping) {
@@ -47,7 +46,6 @@ public class ColumnReference implements Expression, Assignable {
 				selectableMapping.getSelectablePath(),
 				selectableMapping.isFormula(),
 				selectableMapping.getCustomReadExpression(),
-				selectableMapping.getCustomWriteExpression(),
 				selectableMapping.getJdbcMapping()
 		);
 	}
@@ -58,7 +56,6 @@ public class ColumnReference implements Expression, Assignable {
 				mapping,
 				null,
 				false,
-				null,
 				null,
 				jdbcMapping
 		);
@@ -71,7 +68,6 @@ public class ColumnReference implements Expression, Assignable {
 				selectableMapping.getSelectablePath(),
 				selectableMapping.isFormula(),
 				selectableMapping.getCustomReadExpression(),
-				selectableMapping.getCustomWriteExpression(),
 				selectableMapping.getJdbcMapping()
 		);
 	}
@@ -83,7 +79,6 @@ public class ColumnReference implements Expression, Assignable {
 				selectableMapping.getSelectablePath(),
 				selectableMapping.isFormula(),
 				selectableMapping.getCustomReadExpression(),
-				selectableMapping.getCustomWriteExpression(),
 				jdbcMapping
 		);
 	}
@@ -93,7 +88,6 @@ public class ColumnReference implements Expression, Assignable {
 			String columnExpression,
 			boolean isFormula,
 			String customReadExpression,
-			String customWriteExpression,
 			JdbcMapping jdbcMapping) {
 		this(
 				tableReference.getIdentificationVariable(),
@@ -101,7 +95,6 @@ public class ColumnReference implements Expression, Assignable {
 				null,
 				isFormula,
 				customReadExpression,
-				customWriteExpression,
 				jdbcMapping
 		);
 	}
@@ -111,9 +104,8 @@ public class ColumnReference implements Expression, Assignable {
 			String columnExpression,
 			boolean isFormula,
 			String customReadExpression,
-			String customWriteExpression,
 			JdbcMapping jdbcMapping) {
-		this( qualifier, columnExpression, null, isFormula, customReadExpression, customWriteExpression, jdbcMapping );
+		this( qualifier, columnExpression, null, isFormula, customReadExpression, jdbcMapping );
 	}
 
 	public ColumnReference(
@@ -122,7 +114,6 @@ public class ColumnReference implements Expression, Assignable {
 			SelectablePath selectablePath,
 			boolean isFormula,
 			String customReadExpression,
-			String customWriteExpression,
 			JdbcMapping jdbcMapping) {
 		this.qualifier = StringHelper.nullIfEmpty( qualifier );
 
@@ -142,15 +133,6 @@ public class ColumnReference implements Expression, Assignable {
 
 		this.isFormula = isFormula;
 		this.readExpression = customReadExpression;
-
-		//TODO: writeExpression is never used, can it be removed?
-		if ( !isFormula && customWriteExpression != null ) {
-			this.customWriteExpression = customWriteExpression;
-		}
-		else {
-			this.customWriteExpression = null;
-		}
-
 		this.jdbcMapping = jdbcMapping;
 	}
 
@@ -173,10 +155,6 @@ public class ColumnReference implements Expression, Assignable {
 
 	public SelectablePath getSelectablePath() {
 		return selectablePath;
-	}
-
-	public String getCustomWriteExpression() {
-		return customWriteExpression;
 	}
 
 	public boolean isColumnExpressionFormula() {

--- a/hibernate-core/src/main/java/org/hibernate/sql/ast/tree/expression/Expression.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/ast/tree/expression/Expression.java
@@ -42,4 +42,23 @@ public interface Expression extends SqlAstNode, SqlSelectionProducer {
 				this
 		);
 	}
+
+	default SqlSelection createDomainResultSqlSelection(
+			int jdbcPosition,
+			int valuesArrayPosition,
+			JavaType javaType,
+			TypeConfiguration typeConfiguration) {
+		// Apply possible jdbc type wrapping
+		final Expression expression;
+		final JdbcMappingContainer expressionType = getExpressionType();
+		if ( expressionType == null ) {
+			expression = this;
+		}
+		else {
+			expression = expressionType.getJdbcMappings().get( 0 ).getJdbcType().wrapTopLevelSelectionExpression( this );
+		}
+		return expression == this
+			? createSqlSelection( jdbcPosition, valuesArrayPosition, javaType, typeConfiguration )
+			: new SqlSelectionImpl( jdbcPosition, valuesArrayPosition, expression );
+	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/jdbc/JdbcType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/jdbc/JdbcType.java
@@ -15,11 +15,13 @@ import org.hibernate.Incubating;
 import org.hibernate.dialect.Dialect;
 import org.hibernate.engine.jdbc.Size;
 import org.hibernate.query.sqm.CastType;
+import org.hibernate.sql.ast.spi.SqlAppender;
+import org.hibernate.sql.ast.spi.StringBuilderSqlAppender;
+import org.hibernate.sql.ast.tree.expression.Expression;
 import org.hibernate.type.SqlTypes;
 import org.hibernate.type.descriptor.ValueBinder;
 import org.hibernate.type.descriptor.ValueExtractor;
 import org.hibernate.type.descriptor.WrapperOptions;
-import org.hibernate.type.descriptor.java.BasicJavaType;
 import org.hibernate.type.descriptor.java.JavaType;
 import org.hibernate.type.descriptor.sql.spi.DdlTypeRegistry;
 import org.hibernate.type.spi.TypeConfiguration;
@@ -158,6 +160,35 @@ public interface JdbcType extends Serializable {
 	 */
 	default String getCheckCondition(String columnName, JavaType<?> javaType, Dialect dialect) {
 		return null;
+	}
+
+	/**
+	 * Wraps the top level selection expression to be able to read values with this JdbcType's ValueExtractor.
+	 * @since 6.2
+	 */
+	@Incubating
+	default Expression wrapTopLevelSelectionExpression(Expression expression) {
+		return expression;
+	}
+
+	/**
+	 * Wraps the write expression to be able to write values with this JdbcType's ValueBinder.
+	 * @since 6.2
+	 */
+	@Incubating
+	default String wrapWriteExpression(String writeExpression, Dialect dialect) {
+		final StringBuilder sb = new StringBuilder( writeExpression.length() );
+		appendWriteExpression( writeExpression, new StringBuilderSqlAppender( sb ), dialect );
+		return sb.toString();
+	}
+
+	/**
+	 * Append the write expression wrapped in a way to be able to write values with this JdbcType's ValueBinder.
+	 * @since 6.2
+	 */
+	@Incubating
+	default void appendWriteExpression(String writeExpression, SqlAppender appender, Dialect dialect) {
+		appender.append( writeExpression );
 	}
 
 	default boolean isInteger() {

--- a/hibernate-spatial/src/main/java/org/hibernate/spatial/dialect/cockroachdb/CockroachDbContributor.java
+++ b/hibernate-spatial/src/main/java/org/hibernate/spatial/dialect/cockroachdb/CockroachDbContributor.java
@@ -9,11 +9,14 @@ package org.hibernate.spatial.dialect.cockroachdb;
 
 import org.hibernate.boot.model.FunctionContributions;
 import org.hibernate.boot.model.TypeContributions;
+import org.hibernate.dialect.PostgreSQLPGObjectJdbcType;
 import org.hibernate.query.sqm.function.SqmFunctionRegistry;
 import org.hibernate.service.ServiceRegistry;
 import org.hibernate.spatial.FunctionKey;
 import org.hibernate.spatial.HSMessageLogger;
 import org.hibernate.spatial.contributor.ContributorImplementor;
+import org.hibernate.spatial.dialect.postgis.PGCastingGeographyJdbcType;
+import org.hibernate.spatial.dialect.postgis.PGCastingGeometryJdbcType;
 import org.hibernate.spatial.dialect.postgis.PGGeographyJdbcType;
 import org.hibernate.spatial.dialect.postgis.PGGeometryJdbcType;
 import org.hibernate.spatial.dialect.postgis.PostgisSqmFunctionDescriptors;
@@ -29,8 +32,14 @@ public class CockroachDbContributor implements ContributorImplementor {
 	@Override
 	public void contributeJdbcTypes(TypeContributions typeContributions) {
 		HSMessageLogger.SPATIAL_MSG_LOGGER.typeContributions( this.getClass().getCanonicalName() );
-		typeContributions.contributeJdbcType( PGGeometryJdbcType.INSTANCE_WKB_2 );
-		typeContributions.contributeJdbcType( PGGeographyJdbcType.INSTANCE_WKB_2 );
+		if ( PostgreSQLPGObjectJdbcType.isUsable() ) {
+			typeContributions.contributeJdbcType( PGGeometryJdbcType.INSTANCE_WKB_2 );
+			typeContributions.contributeJdbcType( PGGeographyJdbcType.INSTANCE_WKB_2 );
+		}
+		else {
+			typeContributions.contributeJdbcType( PGCastingGeometryJdbcType.INSTANCE_WKB_2 );
+			typeContributions.contributeJdbcType( PGCastingGeographyJdbcType.INSTANCE_WKB_2 );
+		}
 	}
 
 	@Override

--- a/hibernate-spatial/src/main/java/org/hibernate/spatial/dialect/postgis/AbstractCastingPostGISJdbcType.java
+++ b/hibernate-spatial/src/main/java/org/hibernate/spatial/dialect/postgis/AbstractCastingPostGISJdbcType.java
@@ -1,0 +1,161 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+
+package org.hibernate.spatial.dialect.postgis;
+
+import java.sql.CallableStatement;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Types;
+
+import org.hibernate.dialect.Dialect;
+import org.hibernate.spatial.GeometryLiteralFormatter;
+import org.hibernate.sql.ast.spi.SqlAppender;
+import org.hibernate.type.descriptor.ValueBinder;
+import org.hibernate.type.descriptor.ValueExtractor;
+import org.hibernate.type.descriptor.WrapperOptions;
+import org.hibernate.type.descriptor.java.JavaType;
+import org.hibernate.type.descriptor.jdbc.BasicBinder;
+import org.hibernate.type.descriptor.jdbc.BasicExtractor;
+import org.hibernate.type.descriptor.jdbc.JdbcLiteralFormatter;
+import org.hibernate.type.descriptor.jdbc.JdbcType;
+
+import org.geolatte.geom.ByteBuffer;
+import org.geolatte.geom.Geometry;
+import org.geolatte.geom.codec.Wkb;
+import org.geolatte.geom.codec.WkbDecoder;
+import org.geolatte.geom.codec.Wkt;
+import org.geolatte.geom.codec.WktDecoder;
+import org.geolatte.geom.codec.WktEncoder;
+
+/**
+ * Type Descriptor for the Postgis Geometry type
+ *
+ * @author Karel Maesen, Geovise BVBA
+ */
+public abstract class AbstractCastingPostGISJdbcType implements JdbcType {
+
+	private final Wkb.Dialect wkbDialect;
+
+	AbstractCastingPostGISJdbcType(Wkb.Dialect dialect) {
+		wkbDialect = dialect;
+	}
+
+	@Override
+	public <T> JdbcLiteralFormatter<T> getJdbcLiteralFormatter(JavaType<T> javaType) {
+		return new PGGeometryLiteralFormatter<>( getConstructorFunction(), javaType );
+	}
+
+	@Override
+	public abstract int getDefaultSqlTypeCode();
+
+	protected abstract String getConstructorFunction();
+
+	@Override
+	public void appendWriteExpression(
+			String writeExpression,
+			SqlAppender appender,
+			Dialect dialect) {
+		appender.append( getConstructorFunction() );
+		appender.append( '(' );
+		appender.append( writeExpression );
+		appender.append( ')' );
+	}
+
+	public Geometry<?> toGeometry(String wkt) {
+		if ( wkt == null ) {
+			return null;
+		}
+		if ( wkt.startsWith( "00" ) || wkt.startsWith( "01" ) ) {
+			//we have a WKB because this wkt starts with the bit-order byte
+
+			ByteBuffer buffer = ByteBuffer.from( wkt );
+			final WkbDecoder decoder = Wkb.newDecoder( wkbDialect );
+			return decoder.decode( buffer );
+		}
+		else {
+			return parseWkt( wkt );
+		}
+	}
+
+	private static Geometry<?> parseWkt(String pgValue) {
+		final WktDecoder decoder = Wkt.newDecoder( Wkt.Dialect.POSTGIS_EWKT_1 );
+		return decoder.decode( pgValue );
+	}
+
+	@Override
+	public int getJdbcTypeCode() {
+		return Types.VARCHAR;
+	}
+
+	@Override
+	public <X> ValueBinder<X> getBinder(final JavaType<X> javaType) {
+		return new BasicBinder<X>( javaType, this ) {
+			@Override
+			protected void doBind(PreparedStatement st, X value, int index, WrapperOptions options)
+					throws SQLException {
+				st.setString( index, toWkt( value, options ) );
+			}
+
+			@Override
+			protected void doBind(CallableStatement st, X value, String name, WrapperOptions options)
+					throws SQLException {
+				st.setString( name, toWkt( value, options ) );
+			}
+
+			private String toWkt(X value, WrapperOptions options) throws SQLException {
+				final WktEncoder encoder = Wkt.newEncoder( Wkt.Dialect.POSTGIS_EWKT_1 );
+				final Geometry<?> geometry = getJavaType().unwrap( value, Geometry.class, options );
+				return encoder.encode( geometry );
+			}
+
+		};
+	}
+
+	@Override
+	public <X> ValueExtractor<X> getExtractor(final JavaType<X> javaType) {
+		return new BasicExtractor<X>( javaType, this ) {
+
+
+			@Override
+			protected X doExtract(ResultSet rs, int paramIndex, WrapperOptions options) throws SQLException {
+				return getJavaType().wrap( toGeometry( rs.getString( paramIndex ) ), options );
+			}
+
+			@Override
+			protected X doExtract(CallableStatement statement, int index, WrapperOptions options) throws SQLException {
+				return getJavaType().wrap( toGeometry( statement.getString( index ) ), options );
+			}
+
+			@Override
+			protected X doExtract(CallableStatement statement, String name, WrapperOptions options)
+					throws SQLException {
+				return getJavaType().wrap( toGeometry( statement.getString( name ) ), options );
+			}
+		};
+	}
+
+	static class PGGeometryLiteralFormatter<T> extends GeometryLiteralFormatter<T> {
+
+		private final String constructorFunction;
+
+		public PGGeometryLiteralFormatter(String constructorFunction, JavaType<T> javaType) {
+			super( javaType, Wkt.Dialect.POSTGIS_EWKT_1, "" );
+			this.constructorFunction = constructorFunction;
+		}
+
+		@Override
+		public void appendJdbcLiteral(SqlAppender appender, T value, Dialect dialect, WrapperOptions wrapperOptions) {
+			Geometry<?> geom = javaType.unwrap( value, Geometry.class, wrapperOptions );
+			appender.append( constructorFunction );
+			appender.appendSql( "('" );
+			appender.appendSql( Wkt.toWkt( geom, wktDialect ) );
+			appender.appendSql( "')" );
+		}
+	}
+}

--- a/hibernate-spatial/src/main/java/org/hibernate/spatial/dialect/postgis/PGCastingGeographyJdbcType.java
+++ b/hibernate-spatial/src/main/java/org/hibernate/spatial/dialect/postgis/PGCastingGeographyJdbcType.java
@@ -1,0 +1,38 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+
+package org.hibernate.spatial.dialect.postgis;
+
+import org.hibernate.type.SqlTypes;
+
+import org.geolatte.geom.codec.Wkb;
+
+/**
+ * Type Descriptor for the Postgis Geography type
+ *
+ * @author Karel Maesen, Geovise BVBA
+ */
+public class PGCastingGeographyJdbcType extends AbstractCastingPostGISJdbcType {
+
+	// Type descriptor instance using EWKB v2 (postgis versions >= 2.2.2, see: https://trac.osgeo.org/postgis/ticket/3181)
+	public static final PGCastingGeographyJdbcType INSTANCE_WKB_2 = new PGCastingGeographyJdbcType( Wkb.Dialect.POSTGIS_EWKB_2 );
+
+	private PGCastingGeographyJdbcType(Wkb.Dialect dialect) {
+		super( dialect );
+	}
+
+	@Override
+	public int getDefaultSqlTypeCode() {
+		return SqlTypes.GEOGRAPHY;
+	}
+
+	@Override
+	protected String getConstructorFunction() {
+		return "st_geogfromtext";
+	}
+
+}

--- a/hibernate-spatial/src/main/java/org/hibernate/spatial/dialect/postgis/PGCastingGeometryJdbcType.java
+++ b/hibernate-spatial/src/main/java/org/hibernate/spatial/dialect/postgis/PGCastingGeometryJdbcType.java
@@ -1,0 +1,38 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+
+package org.hibernate.spatial.dialect.postgis;
+
+import org.hibernate.type.SqlTypes;
+
+import org.geolatte.geom.codec.Wkb;
+
+/**
+ * Type Descriptor for the Postgis Geometry type
+ *
+ * @author Karel Maesen, Geovise BVBA
+ */
+public class PGCastingGeometryJdbcType extends AbstractCastingPostGISJdbcType {
+
+	// Type descriptor instance using EWKB v2 (postgis versions >= 2.2.2, see: https://trac.osgeo.org/postgis/ticket/3181)
+	public static final PGCastingGeometryJdbcType INSTANCE_WKB_2 = new PGCastingGeometryJdbcType( Wkb.Dialect.POSTGIS_EWKB_2 );
+
+	private PGCastingGeometryJdbcType(Wkb.Dialect dialect) {
+		super( dialect );
+	}
+
+	@Override
+	public int getDefaultSqlTypeCode() {
+		return SqlTypes.GEOMETRY;
+	}
+
+	@Override
+	protected String getConstructorFunction() {
+		return "st_geomfromewkt";
+	}
+
+}

--- a/hibernate-spatial/src/main/java/org/hibernate/spatial/dialect/postgis/PostgisDialectContributor.java
+++ b/hibernate-spatial/src/main/java/org/hibernate/spatial/dialect/postgis/PostgisDialectContributor.java
@@ -9,6 +9,7 @@ package org.hibernate.spatial.dialect.postgis;
 
 import org.hibernate.boot.model.FunctionContributions;
 import org.hibernate.boot.model.TypeContributions;
+import org.hibernate.dialect.PostgreSQLPGObjectJdbcType;
 import org.hibernate.query.sqm.function.SqmFunctionRegistry;
 import org.hibernate.service.ServiceRegistry;
 import org.hibernate.spatial.HSMessageLogger;
@@ -25,8 +26,14 @@ public class PostgisDialectContributor implements ContributorImplementor {
 	@Override
 	public void contributeJdbcTypes(TypeContributions typeContributions) {
 		HSMessageLogger.SPATIAL_MSG_LOGGER.typeContributions( this.getClass().getCanonicalName() );
-		typeContributions.contributeJdbcType( PGGeometryJdbcType.INSTANCE_WKB_2 );
-		typeContributions.contributeJdbcType( PGGeographyJdbcType.INSTANCE_WKB_2 );
+		if ( PostgreSQLPGObjectJdbcType.isUsable() ) {
+			typeContributions.contributeJdbcType( PGGeometryJdbcType.INSTANCE_WKB_2 );
+			typeContributions.contributeJdbcType( PGGeographyJdbcType.INSTANCE_WKB_2 );
+		}
+		else {
+			typeContributions.contributeJdbcType( PGCastingGeometryJdbcType.INSTANCE_WKB_2 );
+			typeContributions.contributeJdbcType( PGCastingGeographyJdbcType.INSTANCE_WKB_2 );
+		}
 	}
 
 	@Override


### PR DESCRIPTION
# JdbcType can now wrap read and write expressions for columns
The main motivation for this is to allow implementing support for SQL types, like JSONB, when the JDBC driver lacks support for binding/extracting values of that type or the driver classes are not visible.
Use cases are:

1. Wildfly might not expose JDBC driver classes, so we would have to use these special JDBC types
2. Driver does not support binding/extracting values of such types (e.g. Vertx or federation driver)

## Write expression wrapping
To wrap the write expression through a JdbcType, we have to determine the JdbcMapping for columns
 => hence Value#getSelectableType was introduced
 
Column writer wrapping is only necessary for parameters in inserts and when inferring the type from context
 
## Read expression wrapping
For top level SqlSelection (DomainResult), we have to apply column read expression wrapping, so SqlAstQueryPartProcessingStateImpl#resolveSqlSelection
will now call Expression#createDomainResultSqlSelection for top level selections, which does the wrapping.

https://hibernate.atlassian.net/browse/HHH-15443