### PR TITLE
HHH-15466 Compatibility with Jandex 3.0.0

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/boot/archive/scan/spi/ClassFileArchiveEntryHandler.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/archive/scan/spi/ClassFileArchiveEntryHandler.java
@@ -61,8 +61,9 @@ public class ClassFileArchiveEntryHandler implements ArchiveEntryHandler {
 	private ClassDescriptor toClassDescriptor(ArchiveEntry entry) {
 		try (InputStream inputStream = entry.getStreamAccess().accessInputStream()) {
 			Indexer indexer = new Indexer();
-			ClassInfo classInfo = indexer.index( inputStream );
+			indexer.index( inputStream );
 			Index index = indexer.complete();
+			ClassInfo classInfo = index.getKnownClasses().iterator().next();
 			return toClassDescriptor( classInfo, index, entry );
 		}
 		catch (IOException e) {

--- a/local-build-plugins/src/main/java/org/hibernate/orm/post/IndexManager.java
+++ b/local-build-plugins/src/main/java/org/hibernate/orm/post/IndexManager.java
@@ -169,12 +169,7 @@ public class IndexManager {
 
 							if ( relativePath.getPathString().endsWith( ".class" ) ) {
 								try ( final FileInputStream stream = new FileInputStream( details.getFile() ) ) {
-									final ClassInfo indexedClassInfo = indexer.index( stream );
-									if ( indexedClassInfo == null ) {
-										project.getLogger()
-												.lifecycle( "Problem indexing class file - " + details.getFile()
-														.getAbsolutePath() );
-									}
+									indexer.index( stream );
 								}
 								catch (FileNotFoundException e) {
 									throw new RuntimeException( "Problem locating project class file - " + details.getFile()


### PR DESCRIPTION
The only change in Jandex 3.0.0 relevant to Hibernate ORM is that
`Indexer.index()` used to return `ClassInfo`, but now returns `void`.
This is a breaking change, but Jandex 3.0.0 has a synthetic bridge
method with the old signature for binary compatibility -- except
it always return `null`. Therefore, with this commit, Hibernate ORM
simply ignores the return value completely, which makes it compatible
with Jandex 3.0.0 at runtime, even though it is still compiled against
Jandex 2.4. The code is also source-compatible with Jandex 3.0.0 if
that is ever needed.