### PR TITLE
HHH-15216 Cannot change MetadataProvider implementation because JPAXMLOverriddenMetadataProvider is final and precisely expected by a cast operator

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/boot/internal/BootstrapContextImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/internal/BootstrapContextImpl.java
@@ -30,7 +30,7 @@ import org.hibernate.boot.spi.BootstrapContext;
 import org.hibernate.boot.spi.ClassLoaderAccess;
 import org.hibernate.boot.spi.MetadataBuildingOptions;
 import org.hibernate.cfg.AvailableSettings;
-import org.hibernate.cfg.annotations.reflection.internal.JPAXMLOverriddenMetadataProvider;
+import org.hibernate.cfg.annotations.reflection.JPAXMLOverriddenMetadataProvider;
 import org.hibernate.dialect.function.SQLFunction;
 import org.hibernate.engine.config.spi.ConfigurationService;
 import org.hibernate.jpa.internal.MutableJpaComplianceImpl;

--- a/hibernate-core/src/main/java/org/hibernate/boot/model/source/internal/annotations/AnnotationMetadataSourceProcessorImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/source/internal/annotations/AnnotationMetadataSourceProcessorImpl.java
@@ -34,7 +34,7 @@ import org.hibernate.boot.spi.MetadataBuildingOptions;
 import org.hibernate.cfg.AnnotationBinder;
 import org.hibernate.cfg.InheritanceState;
 import org.hibernate.cfg.annotations.reflection.AttributeConverterDefinitionCollector;
-import org.hibernate.cfg.annotations.reflection.internal.JPAXMLOverriddenMetadataProvider;
+import org.hibernate.cfg.annotations.reflection.JPAXMLOverriddenMetadataProvider;
 import org.hibernate.internal.util.StringHelper;
 import org.hibernate.internal.util.collections.CollectionHelper;
 

--- a/hibernate-core/src/main/java/org/hibernate/cfg/annotations/reflection/JPAXMLOverriddenAnnotationReader.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/annotations/reflection/JPAXMLOverriddenAnnotationReader.java
@@ -4,7 +4,7 @@
  * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
  * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
  */
-package org.hibernate.cfg.annotations.reflection.internal;
+package org.hibernate.cfg.annotations.reflection;
 
 import java.beans.Introspector;
 import java.lang.annotation.Annotation;
@@ -187,7 +187,7 @@ import org.hibernate.boot.jaxb.mapping.spi.ManagedType;
 import org.hibernate.boot.registry.classloading.spi.ClassLoadingException;
 import org.hibernate.boot.spi.BootstrapContext;
 import org.hibernate.boot.spi.ClassLoaderAccess;
-import org.hibernate.cfg.annotations.reflection.PersistentAttributeFilter;
+import org.hibernate.cfg.annotations.reflection.internal.PropertyMappingElementCollector;
 import org.hibernate.internal.CoreLogging;
 import org.hibernate.internal.CoreMessageLogger;
 import org.hibernate.internal.util.StringHelper;

--- a/hibernate-core/src/main/java/org/hibernate/cfg/annotations/reflection/JPAXMLOverriddenMetadataProvider.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/annotations/reflection/JPAXMLOverriddenMetadataProvider.java
@@ -4,7 +4,7 @@
  * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
  * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
  */
-package org.hibernate.cfg.annotations.reflection.internal;
+package org.hibernate.cfg.annotations.reflection;
 
 import java.lang.reflect.AnnotatedElement;
 import java.util.ArrayList;
@@ -36,7 +36,7 @@ import org.hibernate.boot.spi.ClassLoaderAccess;
  * @author Emmanuel Bernard
  */
 @SuppressWarnings("unchecked")
-public final class JPAXMLOverriddenMetadataProvider implements MetadataProvider {
+public class JPAXMLOverriddenMetadataProvider implements MetadataProvider {
 
 	private static final MetadataProvider STATELESS_BASE_DELEGATE = new JavaMetadataProvider();
 

--- a/hibernate-core/src/main/java/org/hibernate/cfg/annotations/reflection/XMLContext.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/annotations/reflection/XMLContext.java
@@ -4,7 +4,7 @@
  * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
  * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
  */
-package org.hibernate.cfg.annotations.reflection.internal;
+package org.hibernate.cfg.annotations.reflection;
 
 import java.io.Serializable;
 import java.util.ArrayList;
@@ -30,7 +30,6 @@ import org.hibernate.boot.model.convert.spi.ConverterDescriptor;
 import org.hibernate.boot.registry.classloading.spi.ClassLoadingException;
 import org.hibernate.boot.spi.BootstrapContext;
 import org.hibernate.boot.spi.ClassLoaderAccess;
-import org.hibernate.cfg.annotations.reflection.AttributeConverterDefinitionCollector;
 import org.hibernate.internal.CoreLogging;
 import org.hibernate.internal.CoreMessageLogger;
 import org.hibernate.internal.util.StringHelper;

--- a/hibernate-core/src/main/java/org/hibernate/cfg/annotations/reflection/internal/PropertyMappingElementCollector.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/annotations/reflection/internal/PropertyMappingElementCollector.java
@@ -33,7 +33,7 @@ import org.hibernate.boot.jaxb.mapping.spi.JaxbTransient;
 import org.hibernate.boot.jaxb.mapping.spi.JaxbVersion;
 import org.hibernate.boot.jaxb.mapping.spi.LifecycleCallback;
 import org.hibernate.boot.jaxb.mapping.spi.LifecycleCallbackContainer;
-import org.hibernate.boot.jaxb.mapping.spi.PersistentAttribute;
+import org.hibernate.boot.jaxb.mapping.spi.PersistentAttribute;import org.hibernate.cfg.annotations.reflection.JPAXMLOverriddenAnnotationReader;
 
 /**
  * Reproduces what we used to do with a {@code List<Element>} in {@link JPAXMLOverriddenAnnotationReader},
@@ -43,9 +43,9 @@ import org.hibernate.boot.jaxb.mapping.spi.PersistentAttribute;
  *     <li>Only create lists if we actually have elements (most lists should be empty in most cases)</li>
  * </ul>
  */
-final class PropertyMappingElementCollector {
-	static final Function<PersistentAttribute, String> PERSISTENT_ATTRIBUTE_NAME = PersistentAttribute::getName;
-	static final Function<JaxbTransient, String> JAXB_TRANSIENT_NAME = JaxbTransient::getName;
+public final class PropertyMappingElementCollector {
+	public static final Function<PersistentAttribute, String> PERSISTENT_ATTRIBUTE_NAME = PersistentAttribute::getName;
+	public static final Function<JaxbTransient, String> JAXB_TRANSIENT_NAME = JaxbTransient::getName;
 	static final Function<LifecycleCallback, String> LIFECYCLE_CALLBACK_NAME = LifecycleCallback::getMethodName;
 
 	private final String propertyName;
@@ -70,7 +70,7 @@ final class PropertyMappingElementCollector {
 	private List<JaxbPostUpdate> postUpdate;
 	private List<JaxbPostLoad> postLoad;
 
-	PropertyMappingElementCollector(String propertyName) {
+	public PropertyMappingElementCollector(String propertyName) {
 		this.propertyName = propertyName;
 	}
 

--- a/hibernate-core/src/test/java/org/hibernate/test/annotations/reflection/JPAXMLOverriddenAnnotationReaderTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/annotations/reflection/JPAXMLOverriddenAnnotationReaderTest.java
@@ -8,8 +8,8 @@ package org.hibernate.test.annotations.reflection;
 
 import org.hibernate.annotations.Columns;
 import org.hibernate.boot.jaxb.mapping.spi.JaxbEntityMappings;
-import org.hibernate.cfg.annotations.reflection.internal.JPAXMLOverriddenAnnotationReader;
-import org.hibernate.cfg.annotations.reflection.internal.XMLContext;
+import org.hibernate.cfg.annotations.reflection.JPAXMLOverriddenAnnotationReader;
+import org.hibernate.cfg.annotations.reflection.XMLContext;
 import org.hibernate.internal.util.xml.XMLMappingHelper;
 
 import org.hibernate.testing.boot.BootstrapContextImpl;

--- a/hibernate-core/src/test/java/org/hibernate/test/annotations/reflection/XMLContextTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/annotations/reflection/XMLContextTest.java
@@ -7,7 +7,7 @@
 package org.hibernate.test.annotations.reflection;
 
 import org.hibernate.boot.jaxb.mapping.spi.JaxbEntityMappings;
-import org.hibernate.cfg.annotations.reflection.internal.XMLContext;
+import org.hibernate.cfg.annotations.reflection.XMLContext;
 import org.hibernate.internal.util.xml.XMLMappingHelper;
 
 import org.hibernate.testing.TestForIssue;

--- a/hibernate-core/src/test/java/org/hibernate/test/annotations/xml/ejb3/Ejb3XmlTestCase.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/annotations/xml/ejb3/Ejb3XmlTestCase.java
@@ -11,8 +11,8 @@ import java.lang.annotation.Annotation;
 import java.lang.reflect.AnnotatedElement;
 
 import org.hibernate.boot.jaxb.mapping.spi.JaxbEntityMappings;
-import org.hibernate.cfg.annotations.reflection.internal.JPAXMLOverriddenAnnotationReader;
-import org.hibernate.cfg.annotations.reflection.internal.XMLContext;
+import org.hibernate.cfg.annotations.reflection.JPAXMLOverriddenAnnotationReader;
+import org.hibernate.cfg.annotations.reflection.XMLContext;
 import org.hibernate.internal.util.xml.XMLMappingHelper;
 
 import org.hibernate.testing.boot.BootstrapContextImpl;


### PR DESCRIPTION
Backport of #4976 to branch 5.6