### PR TITLE
HHH-15486 fix Regression caused by one-to-one L2 cache support

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/type/OneToOneType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/OneToOneType.java
@@ -152,19 +152,12 @@ public class OneToOneType extends EntityType {
 
 	@Override
 	public boolean isDirty(Object old, Object current, SharedSessionContractImplementor session) {
-		if ( isSame( old, current ) ) {
-			return false;
-		}
-
-		Object oldid = getIdentifier( old, session );
-		Object newid = getIdentifier( current, session );
-
-		return getIdentifierType( session ).isDirty( oldid, newid, session );
+		return false;
 	}
 
 	@Override
 	public boolean isDirty(Object old, Object current, boolean[] checkable, SharedSessionContractImplementor session) {
-		return isDirty(old, current, session);
+		return false;
 	}
 
 	@Override
@@ -233,6 +226,6 @@ public class OneToOneType extends EntityType {
 	
 	@Override
 	public boolean isAlwaysDirtyChecked() {
-		return true;
+		return false;
 	}
 }


### PR DESCRIPTION
This commit to fix caching of OneToOneType from second level cache caused a regression ; OneToOneType.isDirty is not working correctly and causes IllegalArgumentException for oneToOne with embeddedId types. 
pr : https://github.com/hibernate/hibernate-orm/pull/3590/commits
jira : https://hibernate.atlassian.net/browse/HHH-14216

There was an attempt to fix this regression (https://hibernate.atlassian.net/browse/HHH-14826) but it was later reverted in https://hibernate.atlassian.net/browse/HHH-15044 (see comments)




Caused by: javax.persistence.PersistenceException: org.hibernate.property.access.spi.PropertyAccessException: Error accessing field [private java.lang.String org.hibernate.bugs.AssociationId.id] by reflection for persistent property [org.hibernate.bugs.AssociationId#id] : org.hibernate.bugs.OwnerId@39652a30
at org.hibernate.internal.ExceptionConverterImpl.convert(ExceptionConverterImpl.java:154)
at org.hibernate.internal.ExceptionConverterImpl.convert(ExceptionConverterImpl.java:181)
at org.hibernate.internal.ExceptionConverterImpl.convertCommitException(ExceptionConverterImpl.java:65)
... 72 more
Caused by: org.hibernate.property.access.spi.PropertyAccessException: Error accessing field [private java.lang.String org.hibernate.bugs.AssociationId.id] by reflection for persistent property [org.hibernate.bugs.AssociationId#id] : org.hibernate.bugs.OwnerId@39652a30
at org.hibernate.property.access.spi.GetterFieldImpl.get(GetterFieldImpl.java:75)
at org.hibernate.tuple.component.AbstractComponentTuplizer.getPropertyValue(AbstractComponentTuplizer.java:59)
at org.hibernate.type.ComponentType.getPropertyValue(ComponentType.java:419)
at org.hibernate.type.ComponentType.isDirty(ComponentType.java:262)
at org.hibernate.type.OneToOneType.isDirty(OneToOneType.java:162)
at org.hibernate.type.OneToOneType.isDirty(OneToOneType.java:167)
at org.hibernate.type.TypeHelper.findDirty(TypeHelper.java:330)
at org.hibernate.persister.entity.AbstractEntityPersister.findDirty(AbstractEntityPersister.java:4739)
at org.hibernate.event.internal.DefaultFlushEntityEventListener.dirtyCheck(DefaultFlushEntityEventListener.java:584)
at org.hibernate.event.internal.DefaultFlushEntityEventListener.isUpdateNecessary(DefaultFlushEntityEventListener.java:245)
at org.hibernate.event.internal.DefaultFlushEntityEventListener.onFlushEntity(DefaultFlushEntityEventListener.java:170)
at org.hibernate.event.service.internal.EventListenerGroupImpl.fireEventOnEachListener(EventListenerGroupImpl.java:107)
at org.hibernate.event.internal.AbstractFlushingEventListener.flushEntities(AbstractFlushingEventListener.java:229)
at org.hibernate.event.internal.AbstractFlushingEventListener.flushEverythingToExecutions(AbstractFlushingEventListener.java:93)
at org.hibernate.event.internal.DefaultFlushEventListener.onFlush(DefaultFlushEventListener.java:39)
at org.hibernate.event.service.internal.EventListenerGroupImpl.fireEventOnEachListener(EventListenerGroupImpl.java:107)
at org.hibernate.internal.SessionImpl.doFlush(SessionImpl.java:1407)
at org.hibernate.internal.SessionImpl.managedFlush(SessionImpl.java:489)
at org.hibernate.internal.SessionImpl.flushBeforeTransactionCompletion(SessionImpl.java:3290)
at org.hibernate.internal.SessionImpl.beforeTransactionCompletion(SessionImpl.java:2425)
at org.hibernate.engine.jdbc.internal.JdbcCoordinatorImpl.beforeTransactionCompletion(JdbcCoordinatorImpl.java:449)
at org.hibernate.resource.transaction.backend.jdbc.internal.JdbcResourceLocalTransactionCoordinatorImpl.beforeCompletionCallback(JdbcResourceLocalTransactionCoordinatorImpl.java:183)
at org.hibernate.resource.transaction.backend.jdbc.internal.JdbcResourceLocalTransactionCoordinatorImpl.access$300(JdbcResourceLocalTransactionCoordinatorImpl.java:40)
at org.hibernate.resource.transaction.backend.jdbc.internal.JdbcResourceLocalTransactionCoordinatorImpl$TransactionDriverControlImpl.commit(JdbcResourceLocalTransactionCoordinatorImpl.java:281)
at org.hibernate.engine.transaction.internal.TransactionImpl.commit(TransactionImpl.java:101)
... 71 more
Caused by: java.lang.IllegalArgumentException: Can not set java.lang.String field org.hibernate.bugs.AssociationId.id to org.hibernate.bugs.OwnerId
at sun.reflect.UnsafeFieldAccessorImpl.throwSetIllegalArgumentException(UnsafeFieldAccessorImpl.java:167)
at sun.reflect.UnsafeFieldAccessorImpl.throwSetIllegalArgumentException(UnsafeFieldAccessorImpl.java:171)
at sun.reflect.UnsafeFieldAccessorImpl.ensureObj(UnsafeFieldAccessorImpl.java:58)
at sun.reflect.UnsafeObjectFieldAccessorImpl.get(UnsafeObjectFieldAccessorImpl.java:36)
at java.lang.reflect.Field.get(Field.java:393)
at org.hibernate.property.access.spi.GetterFieldImpl.get(GetterFieldImpl.java:71)
... 95 more