### PR TITLE
Refactored NoCachingTransactionSynchronizationImpl to avoid timestamp…

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/cache/internal/NoCachingRegionFactory.java
+++ b/hibernate-core/src/main/java/org/hibernate/cache/internal/NoCachingRegionFactory.java
@@ -69,7 +69,7 @@ public class NoCachingRegionFactory implements RegionFactory {
 
 	@Override
 	public CacheTransactionSynchronization createTransactionContext(SharedSessionContractImplementor session) {
-		return new NoCachingTransactionSynchronizationImpl( this );
+		return NoCachingTransactionSynchronizationImpl.INSTANCE;
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/cache/internal/NoCachingTransactionSynchronizationImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/cache/internal/NoCachingTransactionSynchronizationImpl.java
@@ -6,14 +6,35 @@
  */
 package org.hibernate.cache.internal;
 
-import org.hibernate.cache.spi.AbstractCacheTransactionSynchronization;
-import org.hibernate.cache.spi.RegionFactory;
+import org.hibernate.cache.spi.CacheTransactionSynchronization;
 
 /**
  * @author Steve Ebersole
  */
-public class NoCachingTransactionSynchronizationImpl extends AbstractCacheTransactionSynchronization {
-	public NoCachingTransactionSynchronizationImpl(RegionFactory regionFactory) {
-		super( regionFactory );
+public class NoCachingTransactionSynchronizationImpl implements CacheTransactionSynchronization {
+	public static final NoCachingTransactionSynchronizationImpl INSTANCE = new NoCachingTransactionSynchronizationImpl();
+
+	private NoCachingTransactionSynchronizationImpl() {
+
+	}
+
+	@Override
+	public long getCachingTimestamp() {
+		throw new UnsupportedOperationException("Method not supported when 2LC is not enabled");
+	}
+
+	@Override
+	public void transactionJoined() {
+
+	}
+
+	@Override
+	public void transactionCompleting() {
+
+	}
+
+	@Override
+	public void transactionCompleted(boolean successful) {
+
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/cache/internal/QueryResultsCacheImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/cache/internal/QueryResultsCacheImpl.java
@@ -15,7 +15,6 @@ import org.hibernate.HibernateException;
 import org.hibernate.cache.spi.QueryKey;
 import org.hibernate.cache.spi.QueryResultsCache;
 import org.hibernate.cache.spi.QueryResultsRegion;
-import org.hibernate.cache.spi.SecondLevelCacheLogger;
 import org.hibernate.cache.spi.TimestampsCache;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
 
@@ -53,11 +52,11 @@ public class QueryResultsCacheImpl implements QueryResultsCache {
 			final List<?> results,
 			final SharedSessionContractImplementor session) throws HibernateException {
 		if ( DEBUG_ENABLED ) {
-			L2CACHE_LOGGER.debugf( "Caching query results in region: %s; timestamp=%s", cacheRegion.getName(), session.getTransactionStartTimestamp() );
+			L2CACHE_LOGGER.debugf( "Caching query results in region: %s; timestamp=%s", cacheRegion.getName(), session.getCacheTransactionSynchronization().getCachingTimestamp() );
 		}
 
 		final CacheItem cacheItem = new CacheItem(
-				session.getTransactionStartTimestamp(),
+				session.getCacheTransactionSynchronization().getCachingTimestamp(),
 				deepCopy( results )
 		);
 

--- a/hibernate-core/src/main/java/org/hibernate/cache/spi/AbstractCacheTransactionSynchronization.java
+++ b/hibernate-core/src/main/java/org/hibernate/cache/spi/AbstractCacheTransactionSynchronization.java
@@ -21,7 +21,7 @@ public abstract class AbstractCacheTransactionSynchronization implements CacheTr
 	}
 
 	@Override
-	public long getCurrentTransactionStartTimestamp() {
+	public long getCachingTimestamp() {
 		return lastTransactionCompletionTimestamp;
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/cache/spi/CacheTransactionSynchronization.java
+++ b/hibernate-core/src/main/java/org/hibernate/cache/spi/CacheTransactionSynchronization.java
@@ -48,8 +48,10 @@ public interface CacheTransactionSynchronization {
 	 *
 	 * @implSpec This "timestamp" need not be related to timestamp in the Java
 	 * Date/millisecond sense.  It just needs to be an incrementing value.
+	 *
+	 * An UnsupportedOperationException is thrown if 2LC has not enabled
 	 */
-	long getCurrentTransactionStartTimestamp();
+	long getCachingTimestamp();
 
 	/**
 	 * Callback that owning Session has become joined to a resource transaction.

--- a/hibernate-core/src/main/java/org/hibernate/cache/spi/support/AbstractReadWriteAccess.java
+++ b/hibernate-core/src/main/java/org/hibernate/cache/spi/support/AbstractReadWriteAccess.java
@@ -15,7 +15,6 @@ import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 import org.hibernate.cache.spi.DomainDataRegion;
-import org.hibernate.cache.spi.SecondLevelCacheLogger;
 import org.hibernate.cache.spi.access.SoftLock;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
 
@@ -75,7 +74,7 @@ public abstract class AbstractReadWriteAccess extends AbstractCachedDomainDataAc
 				return null;
 			}
 
-			boolean readable = item.isReadable( session.getTransactionStartTimestamp() );
+			boolean readable = item.isReadable( session.getCacheTransactionSynchronization().getCachingTimestamp() );
 			if ( readable ) {
 				log.debugf( "Cache hit : region = `%s`, key = `%s`", getRegion().getName(), key );
 				return item.getValue();
@@ -101,11 +100,11 @@ public abstract class AbstractReadWriteAccess extends AbstractCachedDomainDataAc
 			writeLock.lock();
 			Lockable item = (Lockable) getStorageAccess().getFromCache( key, session );
 
-			boolean writable = item == null || item.isWriteable( session.getTransactionStartTimestamp(), version, getVersionComparator() );
+			boolean writable = item == null || item.isWriteable( session.getCacheTransactionSynchronization().getCachingTimestamp(), version, getVersionComparator() );
 			if ( writable ) {
 				getStorageAccess().putIntoCache(
 						key,
-						new Item( value, version, session.getTransactionStartTimestamp() ),
+						new Item( value, version, session.getCacheTransactionSynchronization().getCachingTimestamp() ),
 						session
 				);
 				return true;

--- a/hibernate-core/src/main/java/org/hibernate/engine/spi/SessionDelegatorBaseImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/spi/SessionDelegatorBaseImpl.java
@@ -236,11 +236,6 @@ public class SessionDelegatorBaseImpl implements SessionImplementor {
 	}
 
 	@Override
-	public long getTransactionStartTimestamp() {
-		return delegate.getTransactionStartTimestamp();
-	}
-
-	@Override
 	public FlushModeType getFlushMode() {
 		return delegate.getFlushMode();
 	}

--- a/hibernate-core/src/main/java/org/hibernate/engine/spi/SharedSessionContractImplementor.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/spi/SharedSessionContractImplementor.java
@@ -184,15 +184,6 @@ public interface SharedSessionContractImplementor
 	void markForRollbackOnly();
 
 	/**
-	 * A "timestamp" at or before the start of the current transaction.
-	 *
-	 * @apiNote This "timestamp" need not be related to timestamp in the Java Date/millisecond
-	 * sense.  It just needs to be an incrementing value.  See
-	 * {@link CacheTransactionSynchronization#getCurrentTransactionStartTimestamp()}
-	 */
-	long getTransactionStartTimestamp();
-
-	/**
 	 * The current CacheTransactionContext associated with the Session.  This may
 	 * return {@code null} when the Session is not currently part of a transaction.
 	 */

--- a/hibernate-core/src/main/java/org/hibernate/internal/AbstractSharedSessionContract.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/AbstractSharedSessionContract.java
@@ -498,11 +498,6 @@ public abstract class AbstractSharedSessionContract implements SharedSessionCont
 	}
 
 	@Override
-	public long getTransactionStartTimestamp() {
-		return getCacheTransactionSynchronization().getCurrentTransactionStartTimestamp();
-	}
-
-	@Override
 	public Transaction beginTransaction() {
 		checkOpen();
 

--- a/hibernate-core/src/main/java/org/hibernate/internal/SessionImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/SessionImpl.java
@@ -274,7 +274,7 @@ public class SessionImpl
 		}
 
 		if ( log.isTraceEnabled() ) {
-			log.tracef( "Opened Session [%s] at timestamp: %s", getSessionIdentifier(), getTransactionStartTimestamp() );
+			log.tracef( "Opened Session [%s] at timestamp: %s", getSessionIdentifier(), System.currentTimeMillis() );
 		}
 	}
 


### PR DESCRIPTION
… creation, Renamed CacheTransactionSynchronization#getCurrentTransactionStartTimestamp method to getCachingTimestamp and removed SharedSessionContractImplementor#getTransactionStartTimestamp method

https://hibernate.atlassian.net/browse/HHH-15502

