### PR TITLE
HHH-15497 Count query when counting polymorphic subclasses by type fails when run twice

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/query/internal/QueryParameterBindingImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/internal/QueryParameterBindingImpl.java
@@ -51,9 +51,7 @@ public class QueryParameterBindingImpl<T> implements QueryParameterBinding<T>, J
 	protected QueryParameterBindingImpl(
 			QueryParameter<T> queryParameter,
 			SessionFactoryImplementor sessionFactory) {
-		this.queryParameter = queryParameter;
-		this.sessionFactory = sessionFactory;
-		this.bindType = queryParameter.getHibernateType();
+		this( queryParameter, sessionFactory, queryParameter.getHibernateType() );
 	}
 
 	/**

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/sql/BaseSqmToSqlAstConverter.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/sql/BaseSqmToSqlAstConverter.java
@@ -181,6 +181,7 @@ import org.hibernate.query.sqm.tree.domain.SqmPluralPartJoin;
 import org.hibernate.query.sqm.tree.domain.SqmPluralValuedSimplePath;
 import org.hibernate.query.sqm.tree.domain.SqmTreatedPath;
 import org.hibernate.query.sqm.tree.domain.SqmTreatedRoot;
+import org.hibernate.query.sqm.tree.expression.AbstractSqmExpression;
 import org.hibernate.query.sqm.tree.expression.Conversion;
 import org.hibernate.query.sqm.tree.expression.JpaCriteriaParameter;
 import org.hibernate.query.sqm.tree.expression.SqmAliasedNodeRef;
@@ -4890,11 +4891,8 @@ public abstract class BaseSqmToSqlAstConverter<T extends Statement> extends Base
 		final QueryParameterImplementor<?> queryParameter = domainParameterXref.getQueryParameter( sqmParameter );
 		final QueryParameterBinding binding = domainParameterBindings.getBinding( queryParameter );
 		if ( binding.setType( valueMapping ) ) {
-			replaceJdbcParametersType(
-					sqmParameter,
-					domainParameterXref.getSqmParameters( queryParameter ),
-					valueMapping
-			);
+			// Align the SqmParameter expressible type with the binding type
+			( (AbstractSqmExpression) sqmParameter ).forceInferableType( (SqmExpressible<?>) binding.getBindType() );
 		}
 		return new SqmParameterInterpretation(
 				sqmParameter,
@@ -6802,6 +6800,8 @@ public abstract class BaseSqmToSqlAstConverter<T extends Statement> extends Base
 
 		if ( !iterator.hasNext() ) {
 			domainParamBinding.setType( (MappingModelExpressible) determineValueMapping( sqmPredicate.getTestExpression(), fromClauseIndex ) );
+			// Align the SqmParameter expressible type with the binding type
+			( (AbstractSqmExpression) sqmParameter ).forceInferableType( (SqmExpressible<?>) domainParamBinding.getBindType() );
 			return inListPredicate;
 		}
 

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/expression/AbstractSqmExpression.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/expression/AbstractSqmExpression.java
@@ -156,4 +156,8 @@ public abstract class AbstractSqmExpression<T> extends AbstractJpaSelection<T> i
 	public JavaType<T> getJavaTypeDescriptor() {
 		return getNodeType() == null ? null : getNodeType().getExpressibleJavaType();
 	}
+
+	public void forceInferableType(SqmExpressible<?> type){
+		setExpressibleType( type );
+	}
 }


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-15497,

When a query is executed a second time the binding type adjustment is not executes, so aligning the SqmParameter expressible type with the binding type while converting SQM->AST will ensure that even for the following query execution the binding type will be correct one 