### PR TITLE
HHH-15515/HHH-15516 make pi and log(b,x) portable in HQL

### DIFF
--- a/documentation/src/main/asciidoc/userguide/chapters/query/hql/QueryLanguage.adoc
+++ b/documentation/src/main/asciidoc/userguide/chapters/query/hql/QueryLanguage.adoc
@@ -1023,6 +1023,7 @@ Next, functions for working with numeric values:
 | `power()` | Exponentiation | `power(x,y)` | Universal in SQL dialects
 | `ln()` | Natural logarithm | `ln(x)` | Very common in SQL dialects
 | `log10()` | Base-10 logarithm | `log10(x)` | Very common in SQL dialects
+| `log()` | Arbitrary-base logarithm | `log(b,x)` | Very common in SQL dialects
 | `pi` | &#960; | `pi` | Very common in SQL dialects
 | `sin()`, `cos()`, `tan()`, `asin()`, `acos()`, `atan()`, `atan2()` | Basic trigonometric functions | `sin(theta)`, `cos(theta)`, `atan2(opposite, adjacent)` | Very common in SQL dialects
 | `round()` | Numeric rounding | As usual: `round(number, places)` | Very common in SQL dialects

--- a/documentation/src/main/asciidoc/userguide/chapters/query/hql/QueryLanguage.adoc
+++ b/documentation/src/main/asciidoc/userguide/chapters/query/hql/QueryLanguage.adoc
@@ -1023,6 +1023,7 @@ Next, functions for working with numeric values:
 | `power()` | Exponentiation | `power(x,y)` | Universal in SQL dialects
 | `ln()` | Natural logarithm | `ln(x)` | Very common in SQL dialects
 | `log10()` | Base-10 logarithm | `log10(x)` | Very common in SQL dialects
+| `pi` | &#960; | `pi` | Very common in SQL dialects
 | `sin()`, `cos()`, `tan()`, `asin()`, `acos()`, `atan()`, `atan2()` | Basic trigonometric functions | `sin(theta)`, `cos(theta)`, `atan2(opposite, adjacent)` | Very common in SQL dialects
 | `round()` | Numeric rounding | As usual: `round(number, places)` | Very common in SQL dialects
 | `floor()` | Floor function | `floor(x)` | Universal in SQL dialects

--- a/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/CockroachLegacyDialect.java
+++ b/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/CockroachLegacyDialect.java
@@ -12,7 +12,6 @@ import java.sql.Types;
 import java.time.temporal.TemporalAccessor;
 import java.util.Calendar;
 import java.util.Date;
-import java.util.Iterator;
 import java.util.Map;
 import java.util.TimeZone;
 
@@ -639,12 +638,9 @@ public class CockroachLegacyDialect extends Dialect {
 		 */
 		if ( aliases.isEmpty() ) {
 			LockMode lockMode = lockOptions.getLockMode();
-			final Iterator<Map.Entry<String, LockMode>> itr = lockOptions.getAliasLockIterator();
-			while ( itr.hasNext() ) {
+			for ( Map.Entry<String, LockMode> entry : lockOptions.getAliasSpecificLocks() ) {
 				// seek the highest lock mode
-				final Map.Entry<String, LockMode> entry = itr.next();
-				final LockMode lm = entry.getValue();
-				if ( lm.greaterThan( lockMode ) ) {
+				if ( entry.getValue().greaterThan(lockMode) ) {
 					aliases = entry.getKey();
 				}
 			}

--- a/hibernate-core/src/main/java/org/hibernate/LockOptions.java
+++ b/hibernate-core/src/main/java/org/hibernate/LockOptions.java
@@ -34,7 +34,6 @@ public class LockOptions implements Serializable {
 	/**
 	 * Represents LockMode.UPGRADE (will wait forever for lock and scope of false meaning only entity is locked).
 	 */
-	@SuppressWarnings("deprecation")
 	public static final LockOptions UPGRADE = new LockOptions(LockMode.PESSIMISTIC_WRITE);
 
 	/**
@@ -198,7 +197,9 @@ public class LockOptions implements Serializable {
 	 * Iterator for accessing Alias (key) and LockMode (value) as Map.Entry.
 	 *
 	 * @return Iterator for accessing the Map.Entry's
+	 * @deprecated use {@link #getAliasSpecificLocks()}
 	 */
+	@Deprecated
 	public Iterator<Map.Entry<String,LockMode>> getAliasLockIterator() {
 		return getAliasSpecificLocks().iterator();
 	}

--- a/hibernate-core/src/main/java/org/hibernate/dialect/AbstractTransactSQLDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/AbstractTransactSQLDialect.java
@@ -127,8 +127,8 @@ public abstract class AbstractTransactSQLDialect extends Dialect {
 
 		CommonFunctionFactory functionFactory = new CommonFunctionFactory(queryEngine);
 		functionFactory.cot();
-		functionFactory.log();
 		functionFactory.ln_log();
+		functionFactory.log_loglog();
 		functionFactory.log10();
 		functionFactory.atan2_atn2();
 		functionFactory.mod_operator();

--- a/hibernate-core/src/main/java/org/hibernate/dialect/AbstractTransactSQLDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/AbstractTransactSQLDialect.java
@@ -38,7 +38,6 @@ import java.sql.CallableStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Types;
-import java.util.Iterator;
 import java.util.Map;
 
 import static org.hibernate.type.SqlTypes.*;
@@ -219,14 +218,11 @@ public abstract class AbstractTransactSQLDialect extends Dialect {
 	@Override
 	public String applyLocksToSql(String sql, LockOptions aliasedLockOptions, Map<String, String[]> keyColumnNames) {
 		// TODO:  merge additional lock options support in Dialect.applyLocksToSql
-		final Iterator itr = aliasedLockOptions.getAliasLockIterator();
 		final StringBuilder buffer = new StringBuilder( sql );
-
-		while ( itr.hasNext() ) {
-			final Map.Entry entry = (Map.Entry) itr.next();
-			final LockMode lockMode = (LockMode) entry.getValue();
+		for ( Map.Entry<String, LockMode> entry: aliasedLockOptions.getAliasSpecificLocks() ) {
+			final LockMode lockMode = entry.getValue();
 			if ( lockMode.greaterThan( LockMode.READ ) ) {
-				final String alias = (String) entry.getKey();
+				final String alias = entry.getKey();
 				int start = -1;
 				int end = -1;
 				if ( sql.endsWith( " " + alias ) ) {

--- a/hibernate-core/src/main/java/org/hibernate/dialect/CockroachDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/CockroachDialect.java
@@ -12,7 +12,6 @@ import java.sql.Types;
 import java.time.temporal.TemporalAccessor;
 import java.util.Calendar;
 import java.util.Date;
-import java.util.Iterator;
 import java.util.Map;
 import java.util.TimeZone;
 
@@ -636,12 +635,9 @@ public class CockroachDialect extends Dialect {
 		 */
 		if ( aliases.isEmpty() ) {
 			LockMode lockMode = lockOptions.getLockMode();
-			final Iterator<Map.Entry<String, LockMode>> itr = lockOptions.getAliasLockIterator();
-			while ( itr.hasNext() ) {
+			for ( Map.Entry<String, LockMode> entry : lockOptions.getAliasSpecificLocks() ) {
 				// seek the highest lock mode
-				final Map.Entry<String, LockMode> entry = itr.next();
-				final LockMode lm = entry.getValue();
-				if ( lm.greaterThan( lockMode ) ) {
+				if ( entry.getValue().greaterThan(lockMode) ) {
 					aliases = entry.getKey();
 				}
 			}

--- a/hibernate-core/src/main/java/org/hibernate/dialect/DB2Dialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/DB2Dialect.java
@@ -207,7 +207,6 @@ public class DB2Dialect extends Dialect {
 
 		functionFactory.cot();
 		functionFactory.degrees();
-		functionFactory.log();
 		functionFactory.log10();
 		functionFactory.radians();
 		functionFactory.rand();

--- a/hibernate-core/src/main/java/org/hibernate/dialect/DerbyDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/DerbyDialect.java
@@ -256,7 +256,6 @@ public class DerbyDialect extends Dialect {
 
 		functionFactory.concat_pipeOperator();
 		functionFactory.cot();
-		functionFactory.chr_char();
 		functionFactory.degrees();
 		functionFactory.radians();
 		functionFactory.log10();

--- a/hibernate-core/src/main/java/org/hibernate/dialect/Dialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/Dialect.java
@@ -652,124 +652,126 @@ public abstract class Dialect implements ConversionContext {
 	 * query language specification:
 	 *
 	 * <ul>
-	 * <li> avg(arg)							- aggregate function
-	 * <li> count([distinct ]arg)				- aggregate function
-	 * <li> max(arg)							- aggregate function
-	 * <li> min(arg)							- aggregate function
-	 * <li> sum(arg)							- aggregate function
+	 * <li> <code>avg(arg)</code>						- aggregate function
+	 * <li> <code>count([distinct ]arg)</code>			- aggregate function
+	 * <li> <code>max(arg)</code>						- aggregate function
+	 * <li> <code>min(arg)</code>						- aggregate function
+	 * <li> <code>sum(arg)</code>						- aggregate function
 	 * </ul>
 	 *
 	 * <ul>
-	 * <li> coalesce(arg0, arg1, ...)
-	 * <li> nullif(arg0, arg1)
+	 * <li> <code>coalesce(arg0, arg1, ...)</code>
+	 * <li> <code>nullif(arg0, arg1)</code>
 	 * </ul>
 	 *
 	 * <ul>
-	 * <li> lower(arg)
-	 * <li> upper(arg)
-	 * <li> length(arg)
-	 * <li> concat(arg0, arg1, ...)
-	 * <li> locate(pattern, string[, start])
-	 * <li> substring(string, start[, length])
-	 * <li> trim([[spec ][character ]from] string)
+	 * <li> <code>lower(arg)</code>
+	 * <li> <code>upper(arg)</code>
+	 * <li> <code>length(arg)</code>
+	 * <li> <code>concat(arg0, arg1, ...)</code>
+	 * <li> <code>locate(pattern, string[, start])</code>
+	 * <li> <code>substring(string, start[, length])</code>
+	 * <li> <code>trim([[spec ][character ]from] string)</code>
 	 * </ul>
 	 *
 	 * <ul>
-	 * <li> abs(arg)
-	 * <li> mod(arg0, arg1)
-	 * <li> sqrt(arg)
+	 * <li> <code>abs(arg)</code>
+	 * <li> <code>mod(arg0, arg1)</code>
+	 * <li> <code>sqrt(arg)</code>
 	 * </ul>
 	 *
 	 * <ul>
-	 * <li> current date
-	 * <li> current time
-	 * <li> current timestamp
+	 * <li> <code>current date</code>
+	 * <li> <code>current time</code>
+	 * <li> <code>current timestamp</code>
 	 * </ul>
 	 *
 	 * Along with an additional set of functions defined by ANSI SQL:
 	 *
 	 * <ul>
-	 * <li> any(arg)							- aggregate function
-	 * <li> every(arg)							- aggregate function
+	 * <li> <code>any(arg)</code>						- aggregate function
+	 * <li> <code>every(arg)</code>						- aggregate function
 	 * </ul>
 	 *
 	 * <ul>
-	 * <li> cast(arg as Type)
-	 * <li> extract(field from arg)
+	 * <li> <code>cast(arg as Type)</code>
+	 * <li> <code>extract(field from arg)</code>
 	 * </ul>
 	 *
 	 * <ul>
-	 * <li> ln(arg)
-	 * <li> exp(arg)
-	 * <li> power(arg0, arg1)
-	 * <li> floor(arg)
-	 * <li> ceiling(arg)
+	 * <li> <code>ln(arg)</code>
+	 * <li> <code>exp(arg)</code>
+	 * <li> <code>power(arg0, arg1)</code>
+	 * <li> <code>floor(arg)</code>
+	 * <li> <code>ceiling(arg)</code>
 	 * </ul>
 	 *
 	 * <ul>
-	 * <li> position(pattern in string)
-	 * <li> substring(string from start[ for length])
-	 * <li> overlay(string placing replacement from start[ for length])
+	 * <li> <code>position(pattern in string)</code>
+	 * <li> <code>substring(string from start[ for length])</code>
+	 * <li> <code>overlay(string placing replacement from start[ for length])</code>
 	 * </ul>
 	 *
-	 * And the following functions for working with java.time types:
+	 * And the following functions for working with <code>java.time</code>
+	 * types:
 	 *
 	 * <ul>
-	 * <li> local date
-	 * <li> local time
-	 * <li> local datetime
-	 * <li> offset datetime
-	 * <li> instant
+	 * <li> <code>local date</code>
+	 * <li> <code>local time</code>
+	 * <li> <code>local datetime</code>
+	 * <li> <code>offset datetime</code>
+	 * <li> <code>instant</code>
 	 * </ul>
 	 *
 	 * And a number of additional "standard" functions:
 	 *
 	 * <ul>
-	 * <li> left(string, length)
-	 * <li> right(string, length)
-	 * <li> replace(string, pattern, replacement)
-	 * <li> pad(string with length spec[ character])
+	 * <li> <code>left(string, length)</code>
+	 * <li> <code>right(string, length)</code>
+	 * <li> <code>replace(string, pattern, replacement)</code>
+	 * <li> <code>pad(string with length spec[ character])</code>
 	 * </ul>
 	 *
 	 * <ul>
-	 * <li> log10(arg)
-	 * <li> sign(arg)
-	 * <li> sin(arg)
-	 * <li> cos(arg)
-	 * <li> tan(arg)
-	 * <li> asin(arg)
-	 * <li> acos(arg)
-	 * <li> atan(arg)
-	 * <li> atan2(arg0, arg1)
-	 * <li> round(arg0, arg1)
-	 * <li> least(arg0, arg1, ...)
-	 * <li> greatest(arg0, arg1, ...)
+	 * <li> <code>pi</code>
+	 * <li> <code>log10(arg)</code>
+	 * <li> <code>sign(arg)</code>
+	 * <li> <code>sin(arg)</code>
+	 * <li> <code>cos(arg)</code>
+	 * <li> <code>tan(arg)</code>
+	 * <li> <code>asin(arg)</code>
+	 * <li> <code>acos(arg)</code>
+	 * <li> <code>atan(arg)</code>
+	 * <li> <code>atan2(arg0, arg1)</code>
+	 * <li> <code>round(arg0, arg1)</code>
+	 * <li> <code>least(arg0, arg1, ...)</code>
+	 * <li> <code>greatest(arg0, arg1, ...)</code>
 	 * </ul>
 	 *
 	 * <ul>
-	 * <li> format(datetime as pattern)
-	 * <li> collate(string as collation)
-	 * <li> str(arg)					- synonym of cast(a as String)
-	 * <li> ifnull(arg0, arg1)			- synonym of coalesce(a, b)
+	 * <li> <code>format(datetime as pattern)</code>
+	 * <li> <code>collate(string as collation)</code>
+	 * <li> <code>str(arg)</code>						- synonym of <code>cast(a as String)</code>
+	 * <li> <code>ifnull(arg0, arg1)</code>				- synonym of <code>coalesce(a, b)</code>
 	 * </ul>
 	 *
-	 * Finally, the following functions are defined as abbreviations
-	 * for extract(), and desugared by the parser:
+	 * Finally, the following functions are defined as abbreviations for
+	 * <code>extract()</code>, and desugared by the parser:
 	 *
 	 * <ul>
-	 * <li> second(arg)					- synonym of extract(second from a)
-	 * <li> minute(arg)					- synonym of extract(minute from a)
-	 * <li> hour(arg)					- synonym of extract(hour from a)
-	 * <li> day(arg)					- synonym of extract(day from a)
-	 * <li> month(arg)					- synonym of extract(month from a)
-	 * <li> year(arg)					- synonym of extract(year from a)
+	 * <li> <code>second(arg)</code>					- synonym of <code>extract(second from a)</code>
+	 * <li> <code>minute(arg)</code>					- synonym of <code>extract(minute from a)</code>
+	 * <li> <code>hour(arg)</code>						- synonym of <code>extract(hour from a)</code>
+	 * <li> <code>day(arg)</code>						- synonym of <code>extract(day from a)</code>
+	 * <li> <code>month(arg)</code>						- synonym of <code>extract(month from a)</code>
+	 * <li> <code>year(arg)</code>						- synonym of <code>extract(year from a)</code>
 	 * </ul>
 	 *
-	 * Note that according to this definition, the second() function returns
-	 * a floating point value, contrary to the integer type returned by the
-	 * native function with this name on many databases. Thus, we don't just
-	 * naively map these HQL functions to the native SQL functions with the
-	 * same names.
+	 * Note that according to this definition, the <code>second()</code>
+	 * function returns a floating point value, contrary to the integer
+	 * type returned by the native function with this name on many databases.
+	 * Thus, we don't just naively map these HQL functions to the native SQL
+	 * functions with the same names.
 	 */
 	public void initializeFunctionRegistry(QueryEngine queryEngine) {
 		final TypeConfiguration typeConfiguration = queryEngine.getTypeConfiguration();
@@ -810,6 +812,10 @@ public abstract class Dialect implements ConversionContext {
 		//trig functions supported on almost every database
 
 		functionFactory.trigonometry();
+
+		//pi supported on most databases, but emulate it here
+
+		functionFactory.pi_acos();
 
 		//coalesce() function, supported by most databases, must be emulated
 		//in terms of nvl() for platforms which don't support it natively

--- a/hibernate-core/src/main/java/org/hibernate/dialect/Dialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/Dialect.java
@@ -29,7 +29,6 @@ import java.time.temporal.TemporalAccessor;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;

--- a/hibernate-core/src/main/java/org/hibernate/dialect/Dialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/Dialect.java
@@ -1821,12 +1821,10 @@ public abstract class Dialect implements ConversionContext {
 	 */
 	public String getForUpdateString(String aliases, LockOptions lockOptions) {
 		LockMode lockMode = lockOptions.getLockMode();
-		final Iterator<Map.Entry<String, LockMode>> itr = lockOptions.getAliasLockIterator();
-		while ( itr.hasNext() ) {
+		for ( Map.Entry<String, LockMode> entry : lockOptions.getAliasSpecificLocks() ) {
 			// seek the highest lock mode
-			final Map.Entry<String, LockMode>entry = itr.next();
 			final LockMode lm = entry.getValue();
-			if ( lm.greaterThan( lockMode ) ) {
+			if ( lm.greaterThan(lockMode) ) {
 				lockMode = lm;
 			}
 		}

--- a/hibernate-core/src/main/java/org/hibernate/dialect/Dialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/Dialect.java
@@ -735,6 +735,7 @@ public abstract class Dialect implements ConversionContext {
 	 * <ul>
 	 * <li> <code>pi</code>
 	 * <li> <code>log10(arg)</code>
+	 * <li> <code>log(base, arg)</code>
 	 * <li> <code>sign(arg)</code>
 	 * <li> <code>sin(arg)</code>
 	 * <li> <code>cos(arg)</code>
@@ -816,6 +817,10 @@ public abstract class Dialect implements ConversionContext {
 		//pi supported on most databases, but emulate it here
 
 		functionFactory.pi_acos();
+
+		//log(base, arg) supported on most databases, but emulate it here
+
+		functionFactory.log_ln();
 
 		//coalesce() function, supported by most databases, must be emulated
 		//in terms of nvl() for platforms which don't support it natively

--- a/hibernate-core/src/main/java/org/hibernate/dialect/MySQLDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/MySQLDialect.java
@@ -54,6 +54,7 @@ import org.hibernate.query.sqm.mutation.internal.temptable.LocalTemporaryTableMu
 import org.hibernate.dialect.temptable.TemporaryTableKind;
 import org.hibernate.query.sqm.mutation.spi.SqmMultiTableInsertStrategy;
 import org.hibernate.query.sqm.mutation.spi.SqmMultiTableMutationStrategy;
+import org.hibernate.query.sqm.produce.function.FunctionParameterType;
 import org.hibernate.service.ServiceRegistry;
 import org.hibernate.sql.ast.SqlAstTranslator;
 import org.hibernate.sql.ast.SqlAstTranslatorFactory;
@@ -470,7 +471,6 @@ public class MySQLDialect extends Dialect {
 		functionFactory.bitLength();
 		functionFactory.octetLength();
 		functionFactory.ascii();
-		functionFactory.chr_char();
 		functionFactory.instr();
 		functionFactory.substr();
 		//also natively supports ANSI-style substring()
@@ -501,6 +501,12 @@ public class MySQLDialect extends Dialect {
 				.setInvariantType(basicTypeRegistry.resolve( StandardBasicTypes.DOUBLE ))
 				.setExactArgumentCount(0)
 				.setArgumentListSignature("")
+				.register();
+
+		queryEngine.getSqmFunctionRegistry().patternDescriptorBuilder( "chr", "char(?1 using ascii)" )
+				.setInvariantType(basicTypeRegistry.resolve( StandardBasicTypes.CHARACTER ))
+				.setExactArgumentCount(1)
+				.setParameterTypes(FunctionParameterType.INTEGER)
 				.register();
 
 		// MySQL timestamp type defaults to precision 0 (seconds) but

--- a/hibernate-core/src/main/java/org/hibernate/dialect/MySQLDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/MySQLDialect.java
@@ -444,7 +444,6 @@ public class MySQLDialect extends Dialect {
 		functionFactory.log();
 		functionFactory.log2();
 		functionFactory.log10();
-		functionFactory.pi();
 		functionFactory.trim2();
 		functionFactory.octetLength();
 		functionFactory.reverse();
@@ -496,6 +495,12 @@ public class MySQLDialect extends Dialect {
 		queryEngine.getSqmFunctionRegistry().noArgsBuilder( "localtime" )
 				.setInvariantType(basicTypeRegistry.resolve( StandardBasicTypes.TIMESTAMP ))
 				.setUseParenthesesWhenNoArgs( false )
+				.register();
+
+		queryEngine.getSqmFunctionRegistry().patternDescriptorBuilder( "pi", "cast(pi() as double)" )
+				.setInvariantType(basicTypeRegistry.resolve( StandardBasicTypes.DOUBLE ))
+				.setExactArgumentCount(0)
+				.setArgumentListSignature("")
 				.register();
 
 		// MySQL timestamp type defaults to precision 0 (seconds) but

--- a/hibernate-core/src/main/java/org/hibernate/dialect/OracleDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/OracleDialect.java
@@ -15,7 +15,6 @@ import java.util.Locale;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import org.hibernate.HibernateException;
 import org.hibernate.LockOptions;
 import org.hibernate.QueryTimeoutException;
 import org.hibernate.boot.model.TypeContributions;
@@ -141,6 +140,8 @@ public class OracleDialect extends Dialect {
 		final TypeConfiguration typeConfiguration = queryEngine.getTypeConfiguration();
 
 		CommonFunctionFactory functionFactory = new CommonFunctionFactory(queryEngine);
+		functionFactory.ascii();
+		functionFactory.char_chr();
 		functionFactory.cosh();
 		functionFactory.sinh();
 		functionFactory.tanh();

--- a/hibernate-core/src/main/java/org/hibernate/dialect/PostgreSQLDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/PostgreSQLDialect.java
@@ -14,9 +14,7 @@ import java.sql.Types;
 import java.time.temporal.TemporalAccessor;
 import java.util.Calendar;
 import java.util.Date;
-import java.util.Iterator;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
 import java.util.TimeZone;
 import jakarta.persistence.TemporalType;
@@ -636,12 +634,9 @@ public class PostgreSQLDialect extends Dialect {
 		 */
 		if ( aliases.isEmpty() ) {
 			LockMode lockMode = lockOptions.getLockMode();
-			final Iterator<Map.Entry<String, LockMode>> itr = lockOptions.getAliasLockIterator();
-			while ( itr.hasNext() ) {
+			for ( Map.Entry<String, LockMode> entry : lockOptions.getAliasSpecificLocks() ) {
 				// seek the highest lock mode
-				final Map.Entry<String, LockMode> entry = itr.next();
-				final LockMode lm = entry.getValue();
-				if ( lm.greaterThan( lockMode ) ) {
+				if ( entry.getValue().greaterThan(lockMode) ) {
 					aliases = entry.getKey();
 				}
 			}

--- a/hibernate-core/src/main/java/org/hibernate/dialect/SQLServerDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/SQLServerDialect.java
@@ -265,6 +265,8 @@ public class SQLServerDialect extends AbstractTransactSQLDialect {
 		// AVG by default uses the input type, so we possibly need to cast the argument type, hence a special function
 		functionFactory.avg_castingNonDoubleArguments( this, SqlAstNodeRenderingMode.DEFAULT );
 
+		functionFactory.log_log();
+
 		functionFactory.truncate_round();
 		functionFactory.everyAny_minMaxIif();
 		functionFactory.octetLength_pattern( "datalength(?1)" );

--- a/hibernate-core/src/main/java/org/hibernate/dialect/function/CommonFunctionFactory.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/function/CommonFunctionFactory.java
@@ -388,6 +388,13 @@ public class CommonFunctionFactory {
 				.register();
 	}
 
+	public void pi_acos() {
+		functionRegistry.patternDescriptorBuilder( "pi", "acos(-1)" )
+				.setInvariantType(doubleType)
+				.setExactArgumentCount(0)
+				.register();
+	}
+
 	// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 	// character functions
 

--- a/hibernate-core/src/main/java/org/hibernate/dialect/function/CommonFunctionFactory.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/function/CommonFunctionFactory.java
@@ -88,6 +88,9 @@ public class CommonFunctionFactory {
 				.register();
 	}
 
+	/**
+	 * For databases where the first parameter is the base
+	 */
 	public void log() {
 		functionRegistry.namedDescriptorBuilder( "log" )
 				.setArgumentCountBetween( 1, 2 )
@@ -96,6 +99,42 @@ public class CommonFunctionFactory {
 				.register();
 	}
 
+	public void log_ln() {
+		functionRegistry.patternDescriptorBuilder( "log", "ln(?2)/ln(?1)" )
+				.setExactArgumentCount( 2 )
+				.setParameterTypes(NUMERIC, NUMERIC)
+				.setInvariantType(doubleType)
+				.setArgumentListSignature("(NUMERIC base, NUMERIC arg)")
+				.register();
+	}
+
+	/**
+	 * SQL Server defines parameters in reverse order
+	 */
+	public void log_log() {
+		functionRegistry.patternDescriptorBuilder( "log", "log(?2,?1)" )
+				.setExactArgumentCount( 2 )
+				.setParameterTypes(NUMERIC, NUMERIC)
+				.setInvariantType(doubleType)
+				.setArgumentListSignature("(NUMERIC base, NUMERIC arg)")
+				.register();
+	}
+
+	/**
+	 * For Sybase
+	 */
+	public void log_loglog() {
+		functionRegistry.patternDescriptorBuilder( "log", "log(?2)/log(?1)" )
+				.setExactArgumentCount( 2 )
+				.setParameterTypes(NUMERIC, NUMERIC)
+				.setInvariantType(doubleType)
+				.setArgumentListSignature("(NUMERIC base, NUMERIC arg)")
+				.register();
+	}
+
+	/**
+	 * For SQL Server and Sybase
+	 */
 	public void ln_log() {
 		functionRegistry.namedDescriptorBuilder( "ln", "log" )
 				.setInvariantType(doubleType)
@@ -385,6 +424,7 @@ public class CommonFunctionFactory {
 		functionRegistry.noArgsBuilder( "pi" )
 				.setInvariantType(doubleType)
 				.setUseParenthesesWhenNoArgs( true )
+				.setArgumentListSignature("")
 				.register();
 	}
 
@@ -392,6 +432,7 @@ public class CommonFunctionFactory {
 		functionRegistry.patternDescriptorBuilder( "pi", "acos(-1)" )
 				.setInvariantType(doubleType)
 				.setExactArgumentCount(0)
+				.setArgumentListSignature("")
 				.register();
 	}
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/query/hql/FunctionTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/query/hql/FunctionTests.java
@@ -331,6 +331,9 @@ public class FunctionTests {
 							.list();
 					session.createQuery("from EntityOfBasics e where chr(120) = 'z'")
 							.list();
+
+					assertThat( session.createQuery("select chr(65)").getSingleResult(), is('A') );
+					assertThat( session.createQuery("select ascii('A')").getSingleResult(), is(65) );
 				}
 		);
 	}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/query/hql/StandardFunctionTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/query/hql/StandardFunctionTests.java
@@ -12,6 +12,7 @@ import java.sql.Timestamp;
 import java.time.LocalDate;
 import java.time.LocalTime;
 
+import org.hamcrest.number.IsCloseTo;
 import org.hibernate.testing.orm.domain.StandardDomainModel;
 import org.hibernate.testing.orm.domain.gambit.EntityOfBasics;
 import org.hibernate.testing.orm.junit.DialectFeatureChecks;
@@ -913,8 +914,24 @@ public class StandardFunctionTests {
 		scope.inTransaction(
 				session -> {
 					assertThat(
-						session.createQuery("select pi").getSingleResult(),
-							is( Math.PI )
+							session.createQuery("select pi", Double.class).getSingleResult(),
+							IsCloseTo.closeTo( Math.PI, 1e-9 )
+					);
+				}
+		);
+	}
+
+	@Test
+	public void testLog(SessionFactoryScope scope) {
+		scope.inTransaction(
+				session -> {
+					assertThat(
+							session.createQuery("select log(3,9)", Double.class).getSingleResult(),
+							IsCloseTo.closeTo( 2d, 1e-9 )
+					);
+					assertThat(
+							session.createQuery("select log(10,1e12)", Double.class).getSingleResult(),
+							IsCloseTo.closeTo( 12d, 1e-9 )
 					);
 				}
 		);

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/query/hql/StandardFunctionTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/query/hql/StandardFunctionTests.java
@@ -907,4 +907,16 @@ public class StandardFunctionTests {
 				}
 		);
 	}
+
+	@Test
+	public void testPi(SessionFactoryScope scope) {
+		scope.inTransaction(
+				session -> {
+					assertThat(
+						session.createQuery("select pi").getSingleResult(),
+							is( Math.PI )
+					);
+				}
+		);
+	}
 }


### PR DESCRIPTION
Add `pi` to the list of "standard" functions (emulating it using `acos(-1)`).

Add `<code>` blocks to the function list.

UPDATE: also adds `log(base, x)`.