### PR TITLE
HHH-15526 Add Revved up by Gradle Enterprise Badge

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -7,6 +7,7 @@ This is the repository of its source code; see https://hibernate.org/orm/[Hibern
 
 image:https://ci.hibernate.org/job/hibernate-orm-main-h2-main/badge/icon[Build Status,link=https://ci.hibernate.org/job/hibernate-orm-main-h2-main/]
 image:https://img.shields.io/lgtm/grade/java/g/hibernate/hibernate-orm.svg?logo=lgtm&logoWidth=18[Language grade: Java,link=https://lgtm.com/projects/g/hibernate/hibernate-orm/context:java]
+image:https://img.shields.io/badge/Revved%20up%20by-Gradle%20Enterprise-06A0CE?logo=Gradle&labelColor=02303A[link=https://ge.hibernate.org/scans]
 
 == Continuous Integration
 


### PR DESCRIPTION
This is the standard badge to point to the Gradle Enterprise instance associated with the Hibernate project so that contributors can easily browse build scans related to the project.