### PR TITLE
add DEBUG flag for saving of loaded entity as proxy

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/bytecode/internal/bytebuddy/ByteBuddyState.java
+++ b/hibernate-core/src/main/java/org/hibernate/bytecode/internal/bytebuddy/ByteBuddyState.java
@@ -125,9 +125,18 @@ public final class ByteBuddyState {
 	 * @return The loaded generated class.
 	 */
 	public Class<?> load(Class<?> referenceClass, Function<ByteBuddy, DynamicType.Builder<?>> makeClassFunction) {
-		return make( makeClassFunction.apply( byteBuddy ) )
-				.load( referenceClass.getClassLoader(), resolveClassLoadingStrategy( referenceClass ) )
-				.getLoaded();
+		Unloaded<?> result =
+		make( makeClassFunction.apply( byteBuddy ) );
+		if (DEBUG) {
+			try {
+				result.saveIn( new File( System.getProperty( "java.io.tmpdir" ) + "/bytebuddy/" ) );
+			}
+			catch (IOException e) {
+				LOG.warn( "Unable to save generated class %1$s", result.getTypeDescription().getName(), e );
+			}
+		}
+		return result.load( referenceClass.getClassLoader(), resolveClassLoadingStrategy( referenceClass ) )
+		.getLoaded();
 	}
 
 	/**


### PR DESCRIPTION
Signed-off-by: Scott Marlow <smarlow@redhat.com>

I happen to be working on understanding https://issues.redhat.com/browse/WFLY-16974 + https://hibernate.atlassian.net/browse/HHH-15514 and this change helps me to see loaded entity as generated proxies.  The same change should be made to upstream also.