### PR TITLE
HHH-15484: Add description to GraalVM Feature implementations

### DIFF
--- a/hibernate-graalvm/src/main/java/org/hibernate/graalvm/internal/GraalVMStaticAutofeature.java
+++ b/hibernate-graalvm/src/main/java/org/hibernate/graalvm/internal/GraalVMStaticAutofeature.java
@@ -37,21 +37,25 @@ public class GraalVMStaticAutofeature implements Feature {
 
 	public void beforeAnalysis(Feature.BeforeAnalysisAccess before) {
 		final Class<?>[] needsHavingSimpleConstructors = StaticClassLists.typesNeedingDefaultConstructorAccessible();
-		final Class[] neddingAllConstructorsAccessible = StaticClassLists.typesNeedingAllConstructorsAccessible();
+		final Class<?>[] needingAllConstructorsAccessible = StaticClassLists.typesNeedingAllConstructorsAccessible();
 		//Size formula is just a reasonable guess:
-		ArrayList<Executable> executables = new ArrayList<>( needsHavingSimpleConstructors.length + neddingAllConstructorsAccessible.length * 3 );
-		for ( Class c : needsHavingSimpleConstructors ) {
+		ArrayList<Executable> executables = new ArrayList<>( needsHavingSimpleConstructors.length + needingAllConstructorsAccessible.length * 3 );
+		for ( Class<?> c : needsHavingSimpleConstructors ) {
 			executables.add( ReflectHelper.getDefaultConstructor( c ) );
 		}
-		for ( Class c : neddingAllConstructorsAccessible ) {
-			for ( Constructor declaredConstructor : c.getDeclaredConstructors() ) {
+		for ( Class<?> c : needingAllConstructorsAccessible) {
+			for ( Constructor<?> declaredConstructor : c.getDeclaredConstructors() ) {
 				executables.add( declaredConstructor );
 			}
 		}
 		RuntimeReflection.register( needsHavingSimpleConstructors );
-		RuntimeReflection.register( neddingAllConstructorsAccessible );
+		RuntimeReflection.register( needingAllConstructorsAccessible );
 		RuntimeReflection.register( StaticClassLists.typesNeedingArrayCopy() );
 		RuntimeReflection.register( executables.toArray(new Executable[0]) );
 	}
 
+	@Override
+	public String getDescription() {
+		return "Hibernate ORM GraalVM static reflection registration";
+	}
 }

--- a/hibernate-graalvm/src/main/java/org/hibernate/graalvm/internal/QueryParsingSupport.java
+++ b/hibernate-graalvm/src/main/java/org/hibernate/graalvm/internal/QueryParsingSupport.java
@@ -49,6 +49,11 @@ public final class QueryParsingSupport implements Feature {
 		access.registerReachabilityHandler(this::enableHQLSupport, parserClazz);
 	}
 
+	@Override
+	public String getDescription() {
+		return "Hibernate ORM HQL Parser Support";
+	}
+
 	@AllowSysOut
 	private void enableHQLSupport(DuringAnalysisAccess duringAnalysisAccess) {
 		final boolean needsEnablingYet = triggered.compareAndSet( false, true );


### PR DESCRIPTION
Follow-up to HHH-15484. This is displayed during the Native image generation. E.g.:

```
========================================================================================================================
GraalVM Native Image: Generating 'quarkus-registry-app-999-SNAPSHOT-runner' (executable)...
========================================================================================================================
[1/7] Initializing...                                                                                   (10.7s @ 0.21GB)
 Version info: 'GraalVM 22.2.0 Java 17 CE'
 Java version info: '17.0.4+8-jvmci-22.2-b06'
 C compiler: cc (apple, arm64, 14.0.0)
 Garbage collector: Serial GC
 10 user-specific feature(s)
 - io.quarkus.caffeine.runtime.graal.CacheConstructorsFeature
 - io.quarkus.hibernate.orm.runtime.graal.DisableLoggingFeature: Disables INFO logging during the analysis phase for the [org.hibernate.Version,
org.hibernate.annotations.common.Version, org.hibernate.dialect.Dialect] categories
 - io.quarkus.hibernate.validator.runtime.DisableLoggingFeature: Disables INFO logging during the analysis phase for the [org.hibernate.validator.internal.util.Version]
categories
 - io.quarkus.jdbc.postgresql.runtime.graal.SQLXMLFeature
 - io.quarkus.runner.Feature: Auto-generated class by Quarkus from the existing extensions
 - io.quarkus.runtime.graal.DisableLoggingFeature: Disables INFO logging during the analysis phase for the [org.jboss.threads] categories
 - io.quarkus.runtime.graal.ResourcesFeature: Register each line in META-INF/quarkus-native-resources.txt as a resource on Substrate VM
 - org.graalvm.home.HomeFinderFeature: Finds GraalVM paths and its version number
 - org.hibernate.graalvm.internal.GraalVMStaticAutofeature
 - org.hibernate.graalvm.internal.QueryParsingSupport
```