### PR TITLE
HHH-15336 Deprecate SharedSessionContractImplementor#getTransactionStartTimestamp() and CacheTransactionSynchronization#getCurrentTransactionStartTimestamp()

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/cache/internal/NoCachingTransactionSynchronizationImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/cache/internal/NoCachingTransactionSynchronizationImpl.java
@@ -16,4 +16,9 @@ public class NoCachingTransactionSynchronizationImpl extends AbstractCacheTransa
 	public NoCachingTransactionSynchronizationImpl(RegionFactory regionFactory) {
 		super( regionFactory );
 	}
+
+	@Override
+	public long getCachingTimestamp() {
+		throw new UnsupportedOperationException( "Method not supported when 2LC is not enabled" );
+	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/cache/spi/CacheTransactionSynchronization.java
+++ b/hibernate-core/src/main/java/org/hibernate/cache/spi/CacheTransactionSynchronization.java
@@ -48,8 +48,28 @@ public interface CacheTransactionSynchronization {
 	 *
 	 * @implSpec This "timestamp" need not be related to timestamp in the Java
 	 * Date/millisecond sense.  It just needs to be an incrementing value.
+	 *
+	 * @deprecated Use {@link CacheTransactionSynchronization#getCachingTimestamp()} instead.
 	 */
+	@Deprecated
 	long getCurrentTransactionStartTimestamp();
+
+	/**
+	 * What is the start time of this context object?
+	 *
+	 * @apiNote If not currently joined to a transaction, the timestamp from
+	 * the last transaction is safe to use.  If not ever/yet joined to a
+	 * transaction, a timestamp at the time the Session/CacheTransactionSynchronization
+	 * were created should be returned.
+	 *
+	 * @implSpec This "timestamp" need not be related to timestamp in the Java
+	 * Date/millisecond sense.  It just needs to be an incrementing value.
+	 *
+	 * An UnsupportedOperationException is thrown if the Second Level Cache has not been enabled
+	 */
+	default long getCachingTimestamp(){
+		return getCurrentTransactionStartTimestamp();
+	}
 
 	/**
 	 * Callback that owning Session has become joined to a resource transaction.

--- a/hibernate-core/src/main/java/org/hibernate/engine/spi/SharedSessionContractImplementor.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/spi/SharedSessionContractImplementor.java
@@ -167,7 +167,10 @@ public interface SharedSessionContractImplementor
 	 * @apiNote This "timestamp" need not be related to timestamp in the Java Date/millisecond
 	 * sense.  It just needs to be an incrementing value.  See
 	 * {@link CacheTransactionSynchronization#getCurrentTransactionStartTimestamp()}
+	 *
+	 * @deprecated no longer supported, when the Second Level Cache is enabled {{@link CacheTransactionSynchronization#getCachingTimestamp()}} can be used.
 	 */
+	@Deprecated
 	long getTransactionStartTimestamp();
 
 	/**


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-15536