### PR TITLE
HHH-15500 Cache key is huge since migration to 6

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/cache/internal/ComponentCacheKeyValueDescriptor.java
+++ b/hibernate-core/src/main/java/org/hibernate/cache/internal/ComponentCacheKeyValueDescriptor.java
@@ -20,14 +20,17 @@ import org.hibernate.type.descriptor.java.JavaType;
  * @see CustomComponentCacheKeyValueDescriptor
  */
 public class ComponentCacheKeyValueDescriptor implements CacheKeyValueDescriptor {
-	private final NavigableRole role;
+	private final String role;
 	private final SessionFactoryImplementor sessionFactory;
 
 	private transient EmbeddableValuedModelPart embeddedMapping;
 
-	public ComponentCacheKeyValueDescriptor(NavigableRole role, SessionFactoryImplementor sessionFactory) {
-		this.role = role;
+	public ComponentCacheKeyValueDescriptor(
+			EmbeddableValuedModelPart embeddedMapping,
+			SessionFactoryImplementor sessionFactory) {
+		this.role = embeddedMapping.getNavigableRole().getFullPath();
 		this.sessionFactory = sessionFactory;
+		this.embeddedMapping = embeddedMapping;
 	}
 
 	@Override
@@ -82,10 +85,12 @@ public class ComponentCacheKeyValueDescriptor implements CacheKeyValueDescriptor
 		}
 	}
 
-
 	private EmbeddableValuedModelPart getEmbeddedMapping() {
+		EmbeddableValuedModelPart embeddedMapping = this.embeddedMapping;
 		if ( embeddedMapping == null ) {
-			embeddedMapping = sessionFactory.getRuntimeMetamodels().getEmbedded( role );
+			this.embeddedMapping = embeddedMapping = sessionFactory.getRuntimeMetamodels().getEmbedded(
+					new NavigableRole( role )
+			);
 		}
 		return embeddedMapping;
 	}

--- a/hibernate-core/src/main/java/org/hibernate/cache/internal/CustomComponentCacheKeyValueDescriptor.java
+++ b/hibernate-core/src/main/java/org/hibernate/cache/internal/CustomComponentCacheKeyValueDescriptor.java
@@ -6,20 +6,15 @@
  */
 package org.hibernate.cache.internal;
 
-import org.hibernate.metamodel.model.domain.NavigableRole;
 import org.hibernate.usertype.CompositeUserType;
 
 /**
  * CacheKeyValueDescriptor used to describe CompositeUserType mappings
  */
 public class CustomComponentCacheKeyValueDescriptor implements CacheKeyValueDescriptor {
-	private final NavigableRole role;
 	private final CompositeUserType<Object> compositeUserType;
 
-	public CustomComponentCacheKeyValueDescriptor(
-			NavigableRole role,
-			CompositeUserType<Object> compositeUserType) {
-		this.role = role;
+	public CustomComponentCacheKeyValueDescriptor(CompositeUserType<Object> compositeUserType) {
 		this.compositeUserType = compositeUserType;
 	}
 
@@ -33,8 +28,4 @@ public class CustomComponentCacheKeyValueDescriptor implements CacheKeyValueDesc
 		return compositeUserType.equals( key1, key2 );
 	}
 
-	@Override
-	public String toString() {
-		return "CustomComponentCacheKeyValueDescriptor(" + role + ")";
-	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/cache/internal/DefaultCacheKeyValueDescriptor.java
+++ b/hibernate-core/src/main/java/org/hibernate/cache/internal/DefaultCacheKeyValueDescriptor.java
@@ -1,0 +1,23 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.cache.internal;
+
+import java.util.Objects;
+
+public class DefaultCacheKeyValueDescriptor implements CacheKeyValueDescriptor {
+	public static final DefaultCacheKeyValueDescriptor INSTANCE = new DefaultCacheKeyValueDescriptor();
+
+	@Override
+	public int getHashCode(Object key) {
+		return key.hashCode();
+	}
+
+	@Override
+	public boolean isEqual(Object key1, Object key2) {
+		return Objects.equals( key1, key2 );
+	}
+}

--- a/hibernate-core/src/main/java/org/hibernate/cache/internal/JavaTypeCacheKeyValueDescriptor.java
+++ b/hibernate-core/src/main/java/org/hibernate/cache/internal/JavaTypeCacheKeyValueDescriptor.java
@@ -1,0 +1,28 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.cache.internal;
+
+import org.hibernate.type.descriptor.java.JavaType;
+
+public class JavaTypeCacheKeyValueDescriptor implements CacheKeyValueDescriptor {
+	private final JavaType<Object> javaType;
+
+	public JavaTypeCacheKeyValueDescriptor(JavaType<?> javaType) {
+		//noinspection unchecked
+		this.javaType = (JavaType<Object>) javaType;
+	}
+
+	@Override
+	public int getHashCode(Object key) {
+		return javaType.extractHashCode( key );
+	}
+
+	@Override
+	public boolean isEqual(Object key1, Object key2) {
+		return javaType.areEqual( key1, key2 );
+	}
+}

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/AbstractEmbeddableMapping.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/AbstractEmbeddableMapping.java
@@ -60,18 +60,12 @@ import org.hibernate.type.spi.TypeConfiguration;
  * Base support for EmbeddableMappingType implementations
  */
 public abstract class AbstractEmbeddableMapping implements EmbeddableMappingType {
-	protected final SessionFactoryImplementor sessionFactory;
 
 	public AbstractEmbeddableMapping(MappingModelCreationProcess creationProcess) {
 		this( creationProcess.getCreationContext() );
 	}
 
 	public AbstractEmbeddableMapping(RuntimeModelCreationContext creationContext) {
-		this( creationContext.getSessionFactory() );
-	}
-
-	protected AbstractEmbeddableMapping(SessionFactoryImplementor sessionFactory) {
-		this.sessionFactory = sessionFactory;
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/EmbeddableMappingTypeImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/EmbeddableMappingTypeImpl.java
@@ -143,7 +143,7 @@ public class EmbeddableMappingTypeImpl extends AbstractEmbeddableMapping impleme
 		this.embeddableJtd = representationStrategy.getMappedJavaType();
 		this.valueMapping = embeddedPartBuilder.apply( this );
 
-		final ConfigurationService cs = sessionFactory.getServiceRegistry()
+		final ConfigurationService cs = creationContext.getSessionFactory().getServiceRegistry()
 				.getService(ConfigurationService.class);
 
 		this.createEmptyCompositesEnabled = ConfigurationHelper.getBoolean(

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/IdClassEmbeddable.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/IdClassEmbeddable.java
@@ -84,7 +84,7 @@ public class IdClassEmbeddable extends AbstractEmbeddableMapping implements Iden
 		this.idMapping = idMapping;
 		this.virtualIdEmbeddable = virtualIdEmbeddable;
 
-		this.javaType = sessionFactory.getTypeConfiguration()
+		this.javaType = creationProcess.getCreationContext().getSessionFactory().getTypeConfiguration()
 				.getJavaTypeRegistry()
 				.resolveManagedTypeDescriptor( idClassSource.getComponentClass() );
 
@@ -176,7 +176,7 @@ public class IdClassEmbeddable extends AbstractEmbeddableMapping implements Iden
 	public Object getIdentifier(Object entity, SharedSessionContractImplementor session) {
 		final Object id = representationStrategy.getInstantiator().instantiate(
 				null,
-				sessionFactory
+				session.getSessionFactory()
 		);
 
 		final List<AttributeMapping> virtualIdAttribute = virtualIdEmbeddable.getAttributeMappings();

--- a/hibernate-core/src/main/java/org/hibernate/type/ComponentType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/ComponentType.java
@@ -67,7 +67,7 @@ public class ComponentType extends AbstractType implements CompositeTypeImplemen
 	private final CompositeUserType<Object> compositeUserType;
 
 	private EmbeddableValuedModelPart mappingModelPart;
-	private CacheKeyValueDescriptor cacheKeyValueDescriptor;
+	private transient CacheKeyValueDescriptor cacheKeyValueDescriptor;
 
 	public ComponentType(Component component, int[] originalPropertyOrder, MetadataBuildingContext buildingContext) {
 		this.componentClass = component.isDynamic()
@@ -705,19 +705,15 @@ public class ComponentType extends AbstractType implements CompositeTypeImplemen
 
 	@Override
 	public CacheKeyValueDescriptor toCacheKeyDescriptor(SessionFactoryImplementor sessionFactory) {
+		CacheKeyValueDescriptor cacheKeyValueDescriptor = this.cacheKeyValueDescriptor;
 		if ( cacheKeyValueDescriptor == null ) {
 			if ( compositeUserType != null ) {
-				cacheKeyValueDescriptor = new CustomComponentCacheKeyValueDescriptor(
-						mappingModelPart.getNavigableRole(),
-						compositeUserType
-				);
+				cacheKeyValueDescriptor = new CustomComponentCacheKeyValueDescriptor( compositeUserType );
 			}
 			else {
-				cacheKeyValueDescriptor = new ComponentCacheKeyValueDescriptor(
-						mappingModelPart.getNavigableRole(),
-						sessionFactory
-				);
+				cacheKeyValueDescriptor = new ComponentCacheKeyValueDescriptor( mappingModelPart, sessionFactory );
 			}
+			this.cacheKeyValueDescriptor = cacheKeyValueDescriptor;
 		}
 
 		return cacheKeyValueDescriptor;

--- a/hibernate-core/src/main/java/org/hibernate/type/CustomType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/CustomType.java
@@ -15,6 +15,7 @@ import java.util.Map;
 
 import org.hibernate.HibernateException;
 import org.hibernate.MappingException;
+import org.hibernate.cache.internal.CacheKeyValueDescriptor;
 import org.hibernate.engine.spi.Mapping;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
@@ -65,6 +66,8 @@ public class CustomType<J>
 	private final ValueExtractor<J> valueExtractor;
 	private final ValueBinder<J> valueBinder;
 	private final JdbcLiteralFormatter<J> jdbcLiteralFormatter;
+
+	private transient CacheKeyValueDescriptor cacheKeyValueDescriptor;
 
 	public CustomType(UserType<J> userType, TypeConfiguration typeConfiguration) throws MappingException {
 		this( userType, ArrayHelper.EMPTY_STRING_ARRAY, typeConfiguration );
@@ -387,5 +390,33 @@ public class CustomType<J>
 	@Override
 	public BasicValueConverter<J, Object> getValueConverter() {
 		return userType.getValueConverter();
+	}
+
+	@Override
+	public CacheKeyValueDescriptor toCacheKeyDescriptor(SessionFactoryImplementor sessionFactory) {
+		CacheKeyValueDescriptor cacheKeyValueDescriptor = this.cacheKeyValueDescriptor;
+		if ( cacheKeyValueDescriptor == null ) {
+			this.cacheKeyValueDescriptor = cacheKeyValueDescriptor = new CustomTypeCacheKeyValueDescriptor( getUserType() );
+		}
+		return cacheKeyValueDescriptor;
+	}
+
+	private static final class CustomTypeCacheKeyValueDescriptor implements CacheKeyValueDescriptor {
+		private final UserType<Object> userType;
+
+		public CustomTypeCacheKeyValueDescriptor(UserType<?> userType) {
+			//noinspection unchecked
+			this.userType = (UserType<Object>) userType;
+		}
+
+		@Override
+		public int getHashCode(Object key) {
+			return userType.hashCode( key );
+		}
+
+		@Override
+		public boolean isEqual(Object key1, Object key2) {
+			return userType.equals( key1, key2 );
+		}
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/BigDecimalJavaType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/BigDecimalJavaType.java
@@ -10,7 +10,9 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.Locale;
 
+import org.hibernate.cache.internal.CacheKeyValueDescriptor;
 import org.hibernate.dialect.Dialect;
+import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.type.descriptor.WrapperOptions;
 import org.hibernate.type.descriptor.jdbc.JdbcType;
 
@@ -42,6 +44,11 @@ public class BigDecimalJavaType extends AbstractClassJavaType<BigDecimal> {
 	@Override
 	public int extractHashCode(BigDecimal value) {
 		return value.intValue();
+	}
+
+	@Override
+	public CacheKeyValueDescriptor toCacheKeyDescriptor(SessionFactoryImplementor sessionFactory) {
+		return BigNumberCacheKeyValueDescriptor.INSTANCE;
 	}
 
 	@SuppressWarnings("unchecked")

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/BigIntegerJavaType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/BigIntegerJavaType.java
@@ -10,7 +10,9 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.Locale;
 
+import org.hibernate.cache.internal.CacheKeyValueDescriptor;
 import org.hibernate.dialect.Dialect;
+import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.type.descriptor.WrapperOptions;
 import org.hibernate.type.descriptor.jdbc.JdbcType;
 
@@ -44,6 +46,11 @@ public class BigIntegerJavaType extends AbstractClassJavaType<BigInteger> {
 	@Override
 	public boolean areEqual(BigInteger one, BigInteger another) {
 		return one == another || ( one != null && another != null && one.compareTo( another ) == 0 );
+	}
+
+	@Override
+	public CacheKeyValueDescriptor toCacheKeyDescriptor(SessionFactoryImplementor sessionFactory) {
+		return BigNumberCacheKeyValueDescriptor.INSTANCE;
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/BigNumberCacheKeyValueDescriptor.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/BigNumberCacheKeyValueDescriptor.java
@@ -1,0 +1,24 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.type.descriptor.java;
+
+import org.hibernate.cache.internal.CacheKeyValueDescriptor;
+
+final class BigNumberCacheKeyValueDescriptor implements CacheKeyValueDescriptor {
+	static final BigNumberCacheKeyValueDescriptor INSTANCE = new BigNumberCacheKeyValueDescriptor();
+
+	@Override
+	public int getHashCode(Object key) {
+		return ( (Number) key ).intValue();
+	}
+
+	@Override
+	public boolean isEqual(Object key1, Object key2) {
+		//noinspection unchecked
+		return ( key1 == key2 ) || ( key1 != null && key2 != null && ( (Comparable<Object>) key1 ).compareTo( key2 ) == 0 );
+	}
+}

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/BooleanJavaType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/BooleanJavaType.java
@@ -6,7 +6,10 @@
  */
 package org.hibernate.type.descriptor.java;
 
+import org.hibernate.cache.internal.CacheKeyValueDescriptor;
+import org.hibernate.cache.internal.DefaultCacheKeyValueDescriptor;
 import org.hibernate.dialect.Dialect;
+import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.type.descriptor.WrapperOptions;
 import org.hibernate.type.descriptor.java.spi.PrimitiveJavaType;
 import org.hibernate.type.descriptor.jdbc.JdbcType;
@@ -175,6 +178,11 @@ public class BooleanJavaType extends AbstractClassJavaType<Boolean> implements
 				characterValueFalse,
 				characterValueTrue
 		);
+	}
+
+	@Override
+	public CacheKeyValueDescriptor toCacheKeyDescriptor(SessionFactoryImplementor sessionFactory) {
+		return DefaultCacheKeyValueDescriptor.INSTANCE;
 	}
 
 }

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/ByteJavaType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/ByteJavaType.java
@@ -9,7 +9,10 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.Locale;
 
+import org.hibernate.cache.internal.CacheKeyValueDescriptor;
+import org.hibernate.cache.internal.DefaultCacheKeyValueDescriptor;
 import org.hibernate.dialect.Dialect;
+import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.type.descriptor.WrapperOptions;
 import org.hibernate.type.descriptor.java.spi.PrimitiveJavaType;
@@ -190,5 +193,10 @@ public class ByteJavaType extends AbstractClassJavaType<Byte>
 			Long length,
 			Integer precision, Integer scale, SharedSessionContractImplementor session) {
 		return ZERO;
+	}
+
+	@Override
+	public CacheKeyValueDescriptor toCacheKeyDescriptor(SessionFactoryImplementor sessionFactory) {
+		return DefaultCacheKeyValueDescriptor.INSTANCE;
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/CalendarDateJavaType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/CalendarDateJavaType.java
@@ -13,7 +13,9 @@ import java.util.GregorianCalendar;
 
 import jakarta.persistence.TemporalType;
 
+import org.hibernate.cache.internal.CacheKeyValueDescriptor;
 import org.hibernate.dialect.Dialect;
+import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.internal.util.compare.CalendarComparator;
 import org.hibernate.type.descriptor.WrapperOptions;
 import org.hibernate.type.descriptor.jdbc.JdbcType;
@@ -27,6 +29,18 @@ import org.hibernate.type.spi.TypeConfiguration;
  */
 public class CalendarDateJavaType extends AbstractTemporalJavaType<Calendar> {
 	public static final CalendarDateJavaType INSTANCE = new CalendarDateJavaType();
+
+	private static final CacheKeyValueDescriptor CACHE_KEY_VALUE_DESCRIPTOR = new CacheKeyValueDescriptor() {
+		@Override
+		public int getHashCode(Object key) {
+			return INSTANCE.extractHashCode( (Calendar) key );
+		}
+
+		@Override
+		public boolean isEqual(Object key1, Object key2) {
+			return INSTANCE.areEqual( (Calendar) key1, (Calendar) key2 );
+		}
+	};
 
 	protected CalendarDateJavaType() {
 		super( Calendar.class, CalendarJavaType.CalendarMutabilityPlan.INSTANCE, CalendarComparator.INSTANCE );
@@ -91,6 +105,11 @@ public class CalendarDateJavaType extends AbstractTemporalJavaType<Calendar> {
 		hashCode = 31 * hashCode + value.get(Calendar.MONTH);
 		hashCode = 31 * hashCode + value.get(Calendar.YEAR);
 		return hashCode;
+	}
+
+	@Override
+	public CacheKeyValueDescriptor toCacheKeyDescriptor(SessionFactoryImplementor sessionFactory) {
+		return CACHE_KEY_VALUE_DESCRIPTOR;
 	}
 
 	@SuppressWarnings("unchecked")

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/CalendarJavaType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/CalendarJavaType.java
@@ -14,7 +14,9 @@ import java.util.GregorianCalendar;
 
 import jakarta.persistence.TemporalType;
 
+import org.hibernate.cache.internal.CacheKeyValueDescriptor;
 import org.hibernate.dialect.Dialect;
+import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.internal.util.compare.CalendarComparator;
 import org.hibernate.type.descriptor.WrapperOptions;
@@ -37,6 +39,18 @@ public class CalendarJavaType extends AbstractTemporalJavaType<Calendar> impleme
 			return (Calendar) value.clone();
 		}
 	}
+
+	private static final CacheKeyValueDescriptor CACHE_KEY_VALUE_DESCRIPTOR = new CacheKeyValueDescriptor() {
+		@Override
+		public int getHashCode(Object key) {
+			return INSTANCE.extractHashCode( (Calendar) key );
+		}
+
+		@Override
+		public boolean isEqual(Object key1, Object key2) {
+			return INSTANCE.areEqual( (Calendar) key1, (Calendar) key2 );
+		}
+	};
 
 	protected CalendarJavaType() {
 		super( Calendar.class, CalendarMutabilityPlan.INSTANCE, CalendarComparator.INSTANCE );
@@ -109,6 +123,11 @@ public class CalendarJavaType extends AbstractTemporalJavaType<Calendar> impleme
 		hashCode = 31 * hashCode + value.get(Calendar.MONTH);
 		hashCode = 31 * hashCode + value.get(Calendar.YEAR);
 		return hashCode;
+	}
+
+	@Override
+	public CacheKeyValueDescriptor toCacheKeyDescriptor(SessionFactoryImplementor sessionFactory) {
+		return CACHE_KEY_VALUE_DESCRIPTOR;
 	}
 
 	@SuppressWarnings("unchecked")

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/CalendarTimeJavaType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/CalendarTimeJavaType.java
@@ -13,7 +13,9 @@ import java.util.GregorianCalendar;
 
 import jakarta.persistence.TemporalType;
 
+import org.hibernate.cache.internal.CacheKeyValueDescriptor;
 import org.hibernate.dialect.Dialect;
+import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.internal.util.compare.CalendarComparator;
 import org.hibernate.type.descriptor.WrapperOptions;
 import org.hibernate.type.descriptor.jdbc.JdbcType;
@@ -27,6 +29,18 @@ import org.hibernate.type.spi.TypeConfiguration;
  */
 public class CalendarTimeJavaType extends AbstractTemporalJavaType<Calendar> {
 	public static final CalendarTimeJavaType INSTANCE = new CalendarTimeJavaType();
+
+	private static final CacheKeyValueDescriptor CACHE_KEY_VALUE_DESCRIPTOR = new CacheKeyValueDescriptor() {
+		@Override
+		public int getHashCode(Object key) {
+			return INSTANCE.extractHashCode( (Calendar) key );
+		}
+
+		@Override
+		public boolean isEqual(Object key1, Object key2) {
+			return INSTANCE.areEqual( (Calendar) key1, (Calendar) key2 );
+		}
+	};
 
 	protected CalendarTimeJavaType() {
 		super( Calendar.class, CalendarJavaType.CalendarMutabilityPlan.INSTANCE, CalendarComparator.INSTANCE );
@@ -91,6 +105,11 @@ public class CalendarTimeJavaType extends AbstractTemporalJavaType<Calendar> {
 		hashCode = 31 * hashCode + value.get(Calendar.MONTH);
 		hashCode = 31 * hashCode + value.get(Calendar.YEAR);
 		return hashCode;
+	}
+
+	@Override
+	public CacheKeyValueDescriptor toCacheKeyDescriptor(SessionFactoryImplementor sessionFactory) {
+		return CACHE_KEY_VALUE_DESCRIPTOR;
 	}
 
 	@SuppressWarnings("unchecked")

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/CharacterJavaType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/CharacterJavaType.java
@@ -7,7 +7,10 @@
 package org.hibernate.type.descriptor.java;
 
 import org.hibernate.HibernateException;
+import org.hibernate.cache.internal.CacheKeyValueDescriptor;
+import org.hibernate.cache.internal.DefaultCacheKeyValueDescriptor;
 import org.hibernate.dialect.Dialect;
+import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.type.descriptor.WrapperOptions;
 import org.hibernate.type.descriptor.java.spi.PrimitiveJavaType;
 import org.hibernate.type.descriptor.jdbc.JdbcType;
@@ -109,5 +112,10 @@ public class CharacterJavaType extends AbstractClassJavaType<Character> implemen
 	@Override
 	public int getDefaultSqlScale(Dialect dialect, JdbcType jdbcType) {
 		return 0;
+	}
+
+	@Override
+	public CacheKeyValueDescriptor toCacheKeyDescriptor(SessionFactoryImplementor sessionFactory) {
+		return DefaultCacheKeyValueDescriptor.INSTANCE;
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/ClassJavaType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/ClassJavaType.java
@@ -5,7 +5,11 @@
  * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
  */
 package org.hibernate.type.descriptor.java;
+
 import org.hibernate.HibernateException;
+import org.hibernate.cache.internal.CacheKeyValueDescriptor;
+import org.hibernate.cache.internal.DefaultCacheKeyValueDescriptor;
+import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.internal.util.ReflectHelper;
 import org.hibernate.type.descriptor.WrapperOptions;
 
@@ -63,5 +67,10 @@ public class ClassJavaType extends AbstractClassJavaType<Class> {
 			return fromString( (CharSequence) value );
 		}
 		throw unknownWrap( value.getClass() );
+	}
+
+	@Override
+	public CacheKeyValueDescriptor toCacheKeyDescriptor(SessionFactoryImplementor sessionFactory) {
+		return DefaultCacheKeyValueDescriptor.INSTANCE;
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/CurrencyJavaType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/CurrencyJavaType.java
@@ -8,7 +8,10 @@ package org.hibernate.type.descriptor.java;
 
 import java.util.Currency;
 
+import org.hibernate.cache.internal.CacheKeyValueDescriptor;
+import org.hibernate.cache.internal.DefaultCacheKeyValueDescriptor;
 import org.hibernate.dialect.Dialect;
+import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.type.descriptor.WrapperOptions;
 import org.hibernate.type.descriptor.jdbc.JdbcType;
 
@@ -59,5 +62,10 @@ public class CurrencyJavaType extends AbstractClassJavaType<Currency> {
 	@Override
 	public long getDefaultSqlLength(Dialect dialect, JdbcType jdbcType) {
 		return 3;
+	}
+
+	@Override
+	public CacheKeyValueDescriptor toCacheKeyDescriptor(SessionFactoryImplementor sessionFactory) {
+		return DefaultCacheKeyValueDescriptor.INSTANCE;
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/DateJavaType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/DateJavaType.java
@@ -17,7 +17,9 @@ import java.util.GregorianCalendar;
 import jakarta.persistence.TemporalType;
 
 import org.hibernate.HibernateException;
+import org.hibernate.cache.internal.CacheKeyValueDescriptor;
 import org.hibernate.dialect.Dialect;
+import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.type.descriptor.WrapperOptions;
 import org.hibernate.type.descriptor.jdbc.JdbcType;
@@ -40,6 +42,18 @@ public class DateJavaType extends AbstractTemporalJavaType<Date> implements Vers
 			return new Date( value.getTime() );
 		}
 	}
+
+	private static final CacheKeyValueDescriptor CACHE_KEY_VALUE_DESCRIPTOR = new CacheKeyValueDescriptor() {
+		@Override
+		public int getHashCode(Object key) {
+			return INSTANCE.extractHashCode( (Date) key );
+		}
+
+		@Override
+		public boolean isEqual(Object key1, Object key2) {
+			return INSTANCE.areEqual( (Date) key1, (Date) key2 );
+		}
+	};
 
 	public DateJavaType() {
 		super( Date.class, DateMutabilityPlan.INSTANCE );
@@ -106,6 +120,11 @@ public class DateJavaType extends AbstractTemporalJavaType<Date> implements Vers
 		Calendar calendar = Calendar.getInstance();
 		calendar.setTime( value );
 		return CalendarJavaType.INSTANCE.extractHashCode( calendar );
+	}
+
+	@Override
+	public CacheKeyValueDescriptor toCacheKeyDescriptor(SessionFactoryImplementor sessionFactory) {
+		return CACHE_KEY_VALUE_DESCRIPTOR;
 	}
 
 	@SuppressWarnings("unchecked")

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/DbTimestampJavaType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/DbTimestampJavaType.java
@@ -14,7 +14,9 @@ import java.sql.SQLException;
 import java.sql.Timestamp;
 import java.util.Comparator;
 
+import org.hibernate.cache.internal.CacheKeyValueDescriptor;
 import org.hibernate.dialect.Dialect;
+import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.internal.CoreMessageLogger;
 import org.hibernate.type.descriptor.WrapperOptions;
@@ -255,5 +257,10 @@ public class DbTimestampJavaType<T> implements VersionJavaType<T>, TemporalJavaT
 			TemporalType precision,
 			TypeConfiguration typeConfiguration) {
 		return delegate.resolveTypeForPrecision( precision, typeConfiguration );
+	}
+
+	@Override
+	public CacheKeyValueDescriptor toCacheKeyDescriptor(SessionFactoryImplementor sessionFactory) {
+		return delegate.toCacheKeyDescriptor( sessionFactory );
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/DoubleJavaType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/DoubleJavaType.java
@@ -10,7 +10,10 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.Locale;
 
+import org.hibernate.cache.internal.CacheKeyValueDescriptor;
+import org.hibernate.cache.internal.DefaultCacheKeyValueDescriptor;
 import org.hibernate.dialect.Dialect;
+import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.type.descriptor.WrapperOptions;
 import org.hibernate.type.descriptor.java.spi.PrimitiveJavaType;
 import org.hibernate.type.descriptor.jdbc.DoubleJdbcType;
@@ -206,6 +209,11 @@ public class DoubleJavaType extends AbstractClassJavaType<Double> implements
 						value.getClass().getName()
 				)
 		);
+	}
+
+	@Override
+	public CacheKeyValueDescriptor toCacheKeyDescriptor(SessionFactoryImplementor sessionFactory) {
+		return DefaultCacheKeyValueDescriptor.INSTANCE;
 	}
 
 }

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/EnumJavaType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/EnumJavaType.java
@@ -9,7 +9,10 @@ package org.hibernate.type.descriptor.java;
 import java.sql.Types;
 import jakarta.persistence.EnumType;
 
+import org.hibernate.cache.internal.CacheKeyValueDescriptor;
+import org.hibernate.cache.internal.DefaultCacheKeyValueDescriptor;
 import org.hibernate.dialect.Dialect;
+import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.type.SqlTypes;
 import org.hibernate.type.descriptor.WrapperOptions;
 import org.hibernate.type.descriptor.jdbc.JdbcType;
@@ -218,5 +221,10 @@ public class EnumJavaType<T extends Enum<T>> extends AbstractClassJavaType<T> {
 	@Override
 	public String getCheckCondition(String columnName, JdbcType jdbcType, Dialect dialect) {
 		return dialect.getEnumCheckCondition( columnName, jdbcType.getJdbcTypeCode(), getJavaTypeClass() );
+	}
+
+	@Override
+	public CacheKeyValueDescriptor toCacheKeyDescriptor(SessionFactoryImplementor sessionFactory) {
+		return DefaultCacheKeyValueDescriptor.INSTANCE;
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/FloatJavaType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/FloatJavaType.java
@@ -10,7 +10,10 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.Locale;
 
+import org.hibernate.cache.internal.CacheKeyValueDescriptor;
+import org.hibernate.cache.internal.DefaultCacheKeyValueDescriptor;
 import org.hibernate.dialect.Dialect;
+import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.type.SqlTypes;
 import org.hibernate.type.descriptor.WrapperOptions;
 import org.hibernate.type.descriptor.java.spi.PrimitiveJavaType;
@@ -201,5 +204,10 @@ public class FloatJavaType extends AbstractClassJavaType<Float> implements Primi
 						value.getClass().getName()
 				)
 		);
+	}
+
+	@Override
+	public CacheKeyValueDescriptor toCacheKeyDescriptor(SessionFactoryImplementor sessionFactory) {
+		return DefaultCacheKeyValueDescriptor.INSTANCE;
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/InetAddressJavaType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/InetAddressJavaType.java
@@ -9,7 +9,10 @@ package org.hibernate.type.descriptor.java;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 
+import org.hibernate.cache.internal.CacheKeyValueDescriptor;
+import org.hibernate.cache.internal.DefaultCacheKeyValueDescriptor;
 import org.hibernate.dialect.Dialect;
+import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.type.SqlTypes;
 import org.hibernate.type.descriptor.WrapperOptions;
 import org.hibernate.type.descriptor.jdbc.JdbcType;
@@ -96,6 +99,11 @@ public class InetAddressJavaType extends AbstractClassJavaType<InetAddress> {
 	@Override
 	public long getDefaultSqlLength(Dialect dialect, JdbcType jdbcType) {
 		return 19;
+	}
+
+	@Override
+	public CacheKeyValueDescriptor toCacheKeyDescriptor(SessionFactoryImplementor sessionFactory) {
+		return DefaultCacheKeyValueDescriptor.INSTANCE;
 	}
 
 }

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/InstantJavaType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/InstantJavaType.java
@@ -19,7 +19,10 @@ import java.util.GregorianCalendar;
 
 import jakarta.persistence.TemporalType;
 
+import org.hibernate.cache.internal.CacheKeyValueDescriptor;
+import org.hibernate.cache.internal.DefaultCacheKeyValueDescriptor;
 import org.hibernate.dialect.Dialect;
+import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.type.SqlTypes;
 import org.hibernate.type.descriptor.WrapperOptions;
@@ -207,6 +210,11 @@ public class InstantJavaType extends AbstractTemporalJavaType<Instant>
 			Integer scale,
 			SharedSessionContractImplementor session) {
 		return Instant.now( ClockHelper.forPrecision( precision, session ) );
+	}
+
+	@Override
+	public CacheKeyValueDescriptor toCacheKeyDescriptor(SessionFactoryImplementor sessionFactory) {
+		return DefaultCacheKeyValueDescriptor.INSTANCE;
 	}
 
 }

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/IntegerJavaType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/IntegerJavaType.java
@@ -10,7 +10,10 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.Locale;
 
+import org.hibernate.cache.internal.CacheKeyValueDescriptor;
+import org.hibernate.cache.internal.DefaultCacheKeyValueDescriptor;
 import org.hibernate.dialect.Dialect;
+import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.type.descriptor.WrapperOptions;
 import org.hibernate.type.descriptor.java.spi.PrimitiveJavaType;
@@ -207,6 +210,11 @@ public class IntegerJavaType extends AbstractClassJavaType<Integer>
 			Integer precision,
 			Integer scale, SharedSessionContractImplementor session) {
 		return current + 1;
+	}
+
+	@Override
+	public CacheKeyValueDescriptor toCacheKeyDescriptor(SessionFactoryImplementor sessionFactory) {
+		return DefaultCacheKeyValueDescriptor.INSTANCE;
 	}
 
 }

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/JavaType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/JavaType.java
@@ -12,9 +12,13 @@ import java.lang.reflect.Type;
 import java.util.Comparator;
 import java.util.Objects;
 
+import org.hibernate.HibernateException;
 import org.hibernate.Incubating;
+import org.hibernate.cache.internal.CacheKeyValueDescriptor;
+import org.hibernate.cache.internal.JavaTypeCacheKeyValueDescriptor;
 import org.hibernate.dialect.Dialect;
 import org.hibernate.engine.jdbc.Size;
+import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.internal.util.ReflectHelper;
 import org.hibernate.internal.util.compare.ComparableComparator;
@@ -273,5 +277,13 @@ public interface JavaType<T> extends Serializable {
 			ParameterizedType parameterizedType,
 			TypeConfiguration typeConfiguration) {
 		return createJavaType( parameterizedType );
+	}
+
+	default CacheKeyValueDescriptor toCacheKeyDescriptor(SessionFactoryImplementor sessionFactory) {
+		if ( this instanceof CacheKeyValueDescriptor ) {
+			return (CacheKeyValueDescriptor) this;
+		}
+
+		return new JavaTypeCacheKeyValueDescriptor( this );
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/JdbcDateJavaType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/JdbcDateJavaType.java
@@ -16,6 +16,8 @@ import java.util.Date;
 import java.util.GregorianCalendar;
 
 import org.hibernate.HibernateException;
+import org.hibernate.cache.internal.CacheKeyValueDescriptor;
+import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.type.descriptor.WrapperOptions;
 import org.hibernate.type.descriptor.jdbc.JdbcType;
 import org.hibernate.type.descriptor.jdbc.JdbcTypeIndicators;
@@ -43,6 +45,18 @@ public class JdbcDateJavaType extends AbstractTemporalJavaType<Date> {
 	 */
 	@SuppressWarnings("unused")
 	public static final DateTimeFormatter LITERAL_FORMATTER = DateTimeFormatter.ISO_LOCAL_DATE;
+
+	private static final CacheKeyValueDescriptor CACHE_KEY_VALUE_DESCRIPTOR = new CacheKeyValueDescriptor() {
+		@Override
+		public int getHashCode(Object key) {
+			return INSTANCE.extractHashCode( (Date) key );
+		}
+
+		@Override
+		public boolean isEqual(Object key1, Object key2) {
+			return INSTANCE.areEqual( (Date) key1, (Date) key2 );
+		}
+	};
 
 	public JdbcDateJavaType() {
 		super( java.sql.Date.class, DateMutabilityPlan.INSTANCE );
@@ -93,6 +107,11 @@ public class JdbcDateJavaType extends AbstractTemporalJavaType<Date> {
 		hashCode = 31 * hashCode + calendar.get( Calendar.DAY_OF_MONTH );
 		hashCode = 31 * hashCode + calendar.get( Calendar.YEAR );
 		return hashCode;
+	}
+
+	@Override
+	public CacheKeyValueDescriptor toCacheKeyDescriptor(SessionFactoryImplementor sessionFactory) {
+		return CACHE_KEY_VALUE_DESCRIPTOR;
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/JdbcTimeJavaType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/JdbcTimeJavaType.java
@@ -17,7 +17,9 @@ import java.util.Date;
 import java.util.GregorianCalendar;
 
 import org.hibernate.HibernateException;
+import org.hibernate.cache.internal.CacheKeyValueDescriptor;
 import org.hibernate.dialect.Dialect;
+import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.type.descriptor.WrapperOptions;
 import org.hibernate.type.descriptor.jdbc.JdbcType;
 import org.hibernate.type.descriptor.jdbc.JdbcTypeIndicators;
@@ -49,6 +51,18 @@ public class JdbcTimeJavaType extends AbstractTemporalJavaType<Date> {
 	 */
 	@SuppressWarnings("unused")
 	public static final DateTimeFormatter LOGGABLE_FORMATTER = DateTimeFormatter.ISO_LOCAL_TIME;
+
+	private static final CacheKeyValueDescriptor CACHE_KEY_VALUE_DESCRIPTOR = new CacheKeyValueDescriptor() {
+		@Override
+		public int getHashCode(Object key) {
+			return INSTANCE.extractHashCode( (Date) key );
+		}
+
+		@Override
+		public boolean isEqual(Object key1, Object key2) {
+			return INSTANCE.areEqual( (Date) key1, (Date) key2 );
+		}
+	};
 
 	public JdbcTimeJavaType() {
 		super( Time.class, TimeMutabilityPlan.INSTANCE );
@@ -101,6 +115,11 @@ public class JdbcTimeJavaType extends AbstractTemporalJavaType<Date> {
 				&& calendar1.get( Calendar.MINUTE ) == calendar2.get( Calendar.MINUTE )
 				&& calendar1.get( Calendar.SECOND ) == calendar2.get( Calendar.SECOND )
 				&& calendar1.get( Calendar.MILLISECOND ) == calendar2.get( Calendar.MILLISECOND );
+	}
+
+	@Override
+	public CacheKeyValueDescriptor toCacheKeyDescriptor(SessionFactoryImplementor sessionFactory) {
+		return CACHE_KEY_VALUE_DESCRIPTOR;
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/JdbcTimestampJavaType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/JdbcTimestampJavaType.java
@@ -21,7 +21,9 @@ import java.util.GregorianCalendar;
 import jakarta.persistence.TemporalType;
 
 import org.hibernate.HibernateException;
+import org.hibernate.cache.internal.CacheKeyValueDescriptor;
 import org.hibernate.dialect.Dialect;
+import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.type.descriptor.WrapperOptions;
 import org.hibernate.type.descriptor.jdbc.JdbcType;
@@ -49,6 +51,18 @@ public class JdbcTimestampJavaType extends AbstractTemporalJavaType<Date> implem
 	@SuppressWarnings("unused")
 	public static final DateTimeFormatter LITERAL_FORMATTER = DateTimeFormatter.ofPattern( TIMESTAMP_FORMAT )
 			.withZone( ZoneId.from( ZoneOffset.UTC ) );
+
+	private static final CacheKeyValueDescriptor CACHE_KEY_VALUE_DESCRIPTOR = new CacheKeyValueDescriptor() {
+		@Override
+		public int getHashCode(Object key) {
+			return INSTANCE.extractHashCode( (Date) key );
+		}
+
+		@Override
+		public boolean isEqual(Object key1, Object key2) {
+			return INSTANCE.areEqual( (Date) key1, (Date) key2 );
+		}
+	};
 
 	public JdbcTimestampJavaType() {
 		super( Timestamp.class, TimestampMutabilityPlan.INSTANCE );
@@ -102,6 +116,11 @@ public class JdbcTimestampJavaType extends AbstractTemporalJavaType<Date> implem
 	@Override
 	public int extractHashCode(Date value) {
 		return Long.valueOf( value.getTime() / 1000 ).hashCode();
+	}
+
+	@Override
+	public CacheKeyValueDescriptor toCacheKeyDescriptor(SessionFactoryImplementor sessionFactory) {
+		return CACHE_KEY_VALUE_DESCRIPTOR;
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/LocalDateJavaType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/LocalDateJavaType.java
@@ -20,6 +20,9 @@ import java.util.GregorianCalendar;
 
 import jakarta.persistence.TemporalType;
 
+import org.hibernate.cache.internal.CacheKeyValueDescriptor;
+import org.hibernate.cache.internal.DefaultCacheKeyValueDescriptor;
+import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.type.descriptor.WrapperOptions;
 import org.hibernate.type.descriptor.jdbc.JdbcType;
 import org.hibernate.type.descriptor.jdbc.JdbcTypeIndicators;
@@ -165,6 +168,11 @@ public class LocalDateJavaType extends AbstractTemporalJavaType<LocalDate> {
 			default:
 				return false;
 		}
+	}
+
+	@Override
+	public CacheKeyValueDescriptor toCacheKeyDescriptor(SessionFactoryImplementor sessionFactory) {
+		return DefaultCacheKeyValueDescriptor.INSTANCE;
 	}
 
 }

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/LocalDateTimeJavaType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/LocalDateTimeJavaType.java
@@ -18,7 +18,10 @@ import java.util.GregorianCalendar;
 
 import jakarta.persistence.TemporalType;
 
+import org.hibernate.cache.internal.CacheKeyValueDescriptor;
+import org.hibernate.cache.internal.DefaultCacheKeyValueDescriptor;
 import org.hibernate.dialect.Dialect;
+import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.type.descriptor.WrapperOptions;
 import org.hibernate.type.descriptor.jdbc.JdbcType;
@@ -188,5 +191,10 @@ public class LocalDateTimeJavaType extends AbstractTemporalJavaType<LocalDateTim
 			Integer scale,
 			SharedSessionContractImplementor session) {
 		return LocalDateTime.now( ClockHelper.forPrecision( precision, session ) );
+	}
+
+	@Override
+	public CacheKeyValueDescriptor toCacheKeyDescriptor(SessionFactoryImplementor sessionFactory) {
+		return DefaultCacheKeyValueDescriptor.INSTANCE;
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/LocalTimeJavaType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/LocalTimeJavaType.java
@@ -22,7 +22,10 @@ import java.util.GregorianCalendar;
 
 import jakarta.persistence.TemporalType;
 
+import org.hibernate.cache.internal.CacheKeyValueDescriptor;
+import org.hibernate.cache.internal.DefaultCacheKeyValueDescriptor;
 import org.hibernate.dialect.Dialect;
+import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.type.descriptor.WrapperOptions;
 import org.hibernate.type.descriptor.jdbc.JdbcType;
 import org.hibernate.type.descriptor.jdbc.JdbcTypeIndicators;
@@ -159,5 +162,10 @@ public class LocalTimeJavaType extends AbstractTemporalJavaType<LocalTime> {
 	@Override
 	public int getDefaultSqlPrecision(Dialect dialect, JdbcType jdbcType) {
 		return 0;
+	}
+
+	@Override
+	public CacheKeyValueDescriptor toCacheKeyDescriptor(SessionFactoryImplementor sessionFactory) {
+		return DefaultCacheKeyValueDescriptor.INSTANCE;
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/LocaleJavaType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/LocaleJavaType.java
@@ -9,6 +9,9 @@ package org.hibernate.type.descriptor.java;
 import java.util.Comparator;
 import java.util.Locale;
 
+import org.hibernate.cache.internal.CacheKeyValueDescriptor;
+import org.hibernate.cache.internal.DefaultCacheKeyValueDescriptor;
+import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.type.descriptor.WrapperOptions;
 
 /**
@@ -105,5 +108,10 @@ public class LocaleJavaType extends AbstractClassJavaType<Locale> {
 			return fromString( (CharSequence) value );
 		}
 		throw unknownWrap( value.getClass() );
+	}
+
+	@Override
+	public CacheKeyValueDescriptor toCacheKeyDescriptor(SessionFactoryImplementor sessionFactory) {
+		return DefaultCacheKeyValueDescriptor.INSTANCE;
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/LongJavaType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/LongJavaType.java
@@ -10,7 +10,10 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.Locale;
 
+import org.hibernate.cache.internal.CacheKeyValueDescriptor;
+import org.hibernate.cache.internal.DefaultCacheKeyValueDescriptor;
 import org.hibernate.dialect.Dialect;
+import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.type.descriptor.WrapperOptions;
 import org.hibernate.type.descriptor.java.spi.PrimitiveJavaType;
@@ -211,5 +214,10 @@ public class LongJavaType extends AbstractClassJavaType<Long>
 			Long length,
 			Integer precision, Integer scale, SharedSessionContractImplementor session) {
 		return ZERO;
+	}
+
+	@Override
+	public CacheKeyValueDescriptor toCacheKeyDescriptor(SessionFactoryImplementor sessionFactory) {
+		return DefaultCacheKeyValueDescriptor.INSTANCE;
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/ObjectJavaType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/ObjectJavaType.java
@@ -6,6 +6,9 @@
  */
 package org.hibernate.type.descriptor.java;
 
+import org.hibernate.cache.internal.CacheKeyValueDescriptor;
+import org.hibernate.cache.internal.DefaultCacheKeyValueDescriptor;
+import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.type.descriptor.WrapperOptions;
 
 /**
@@ -30,5 +33,10 @@ public class ObjectJavaType extends AbstractClassJavaType<Object> {
 	@Override
 	public <X> Object wrap(X value, WrapperOptions options) {
 		return value;
+	}
+
+	@Override
+	public CacheKeyValueDescriptor toCacheKeyDescriptor(SessionFactoryImplementor sessionFactory) {
+		return DefaultCacheKeyValueDescriptor.INSTANCE;
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/OffsetDateTimeJavaType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/OffsetDateTimeJavaType.java
@@ -21,7 +21,10 @@ import java.util.GregorianCalendar;
 import jakarta.persistence.TemporalType;
 
 import org.hibernate.TimeZoneStorageStrategy;
+import org.hibernate.cache.internal.CacheKeyValueDescriptor;
+import org.hibernate.cache.internal.DefaultCacheKeyValueDescriptor;
 import org.hibernate.dialect.Dialect;
+import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.type.SqlTypes;
 import org.hibernate.type.descriptor.WrapperOptions;
@@ -238,5 +241,10 @@ public class OffsetDateTimeJavaType extends AbstractTemporalJavaType<OffsetDateT
 			Integer scale,
 			SharedSessionContractImplementor session) {
 		return OffsetDateTime.now( ClockHelper.forPrecision( precision, session ) );
+	}
+
+	@Override
+	public CacheKeyValueDescriptor toCacheKeyDescriptor(SessionFactoryImplementor sessionFactory) {
+		return DefaultCacheKeyValueDescriptor.INSTANCE;
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/OffsetTimeJavaType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/OffsetTimeJavaType.java
@@ -22,7 +22,10 @@ import java.util.GregorianCalendar;
 
 import jakarta.persistence.TemporalType;
 
+import org.hibernate.cache.internal.CacheKeyValueDescriptor;
+import org.hibernate.cache.internal.DefaultCacheKeyValueDescriptor;
 import org.hibernate.dialect.Dialect;
+import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.type.descriptor.WrapperOptions;
 import org.hibernate.type.descriptor.jdbc.JdbcType;
 import org.hibernate.type.descriptor.jdbc.JdbcTypeIndicators;
@@ -174,5 +177,10 @@ public class OffsetTimeJavaType extends AbstractTemporalJavaType<OffsetTime> {
 	@Override
 	public int getDefaultSqlPrecision(Dialect dialect, JdbcType jdbcType) {
 		return 0;
+	}
+
+	@Override
+	public CacheKeyValueDescriptor toCacheKeyDescriptor(SessionFactoryImplementor sessionFactory) {
+		return DefaultCacheKeyValueDescriptor.INSTANCE;
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/ShortJavaType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/ShortJavaType.java
@@ -9,7 +9,10 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.Locale;
 
+import org.hibernate.cache.internal.CacheKeyValueDescriptor;
+import org.hibernate.cache.internal.DefaultCacheKeyValueDescriptor;
 import org.hibernate.dialect.Dialect;
+import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.type.descriptor.WrapperOptions;
 import org.hibernate.type.descriptor.java.spi.PrimitiveJavaType;
@@ -198,5 +201,10 @@ public class ShortJavaType extends AbstractClassJavaType<Short>
 			Integer scale,
 			SharedSessionContractImplementor session) {
 		return (short) ( current + 1 );
+	}
+
+	@Override
+	public CacheKeyValueDescriptor toCacheKeyDescriptor(SessionFactoryImplementor sessionFactory) {
+		return DefaultCacheKeyValueDescriptor.INSTANCE;
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/StringJavaType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/StringJavaType.java
@@ -11,8 +11,11 @@ import java.io.StringReader;
 import java.sql.Clob;
 import java.sql.Types;
 
+import org.hibernate.cache.internal.CacheKeyValueDescriptor;
+import org.hibernate.cache.internal.DefaultCacheKeyValueDescriptor;
 import org.hibernate.engine.jdbc.CharacterStream;
 import org.hibernate.engine.jdbc.internal.CharacterStreamImpl;
+import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.type.descriptor.WrapperOptions;
 import org.hibernate.type.descriptor.jdbc.JdbcType;
 import org.hibernate.type.descriptor.jdbc.JdbcTypeIndicators;
@@ -111,5 +114,10 @@ public class StringJavaType extends AbstractClassJavaType<String> {
 			default:
 				return false;
 		}
+	}
+
+	@Override
+	public CacheKeyValueDescriptor toCacheKeyDescriptor(SessionFactoryImplementor sessionFactory) {
+		return DefaultCacheKeyValueDescriptor.INSTANCE;
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/TimeZoneJavaType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/TimeZoneJavaType.java
@@ -9,6 +9,9 @@ package org.hibernate.type.descriptor.java;
 import java.util.Comparator;
 import java.util.TimeZone;
 
+import org.hibernate.cache.internal.CacheKeyValueDescriptor;
+import org.hibernate.cache.internal.DefaultCacheKeyValueDescriptor;
+import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.type.descriptor.WrapperOptions;
 
 /**
@@ -58,5 +61,10 @@ public class TimeZoneJavaType extends AbstractClassJavaType<TimeZone> {
 			return fromString( (CharSequence) value );
 		}
 		throw unknownWrap( value.getClass() );
+	}
+
+	@Override
+	public CacheKeyValueDescriptor toCacheKeyDescriptor(SessionFactoryImplementor sessionFactory) {
+		return DefaultCacheKeyValueDescriptor.INSTANCE;
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/UUIDJavaType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/UUIDJavaType.java
@@ -9,7 +9,10 @@ package org.hibernate.type.descriptor.java;
 import java.io.Serializable;
 import java.util.UUID;
 
+import org.hibernate.cache.internal.CacheKeyValueDescriptor;
+import org.hibernate.cache.internal.DefaultCacheKeyValueDescriptor;
 import org.hibernate.dialect.Dialect;
+import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.internal.util.BytesHelper;
 import org.hibernate.type.descriptor.WrapperOptions;
 import org.hibernate.type.descriptor.jdbc.JdbcType;
@@ -154,5 +157,10 @@ public class UUIDJavaType extends AbstractClassJavaType<UUID> {
 			byte[] bytea = (byte[]) value;
 			return new UUID( BytesHelper.asLong( bytea, 0 ), BytesHelper.asLong( bytea, 8 ) );
 		}
+	}
+
+	@Override
+	public CacheKeyValueDescriptor toCacheKeyDescriptor(SessionFactoryImplementor sessionFactory) {
+		return DefaultCacheKeyValueDescriptor.INSTANCE;
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/UrlJavaType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/UrlJavaType.java
@@ -10,6 +10,9 @@ import java.net.MalformedURLException;
 import java.net.URL;
 
 import org.hibernate.HibernateException;
+import org.hibernate.cache.internal.CacheKeyValueDescriptor;
+import org.hibernate.cache.internal.DefaultCacheKeyValueDescriptor;
+import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.type.SqlTypes;
 import org.hibernate.type.descriptor.WrapperOptions;
 import org.hibernate.type.descriptor.jdbc.JdbcType;
@@ -64,5 +67,10 @@ public class UrlJavaType extends AbstractClassJavaType<URL> {
 			return fromString( (CharSequence) value );
 		}
 		throw unknownWrap( value.getClass() );
+	}
+
+	@Override
+	public CacheKeyValueDescriptor toCacheKeyDescriptor(SessionFactoryImplementor sessionFactory) {
+		return DefaultCacheKeyValueDescriptor.INSTANCE;
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/YearJavaType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/YearJavaType.java
@@ -10,6 +10,9 @@ import java.sql.Types;
 import java.time.Year;
 import java.time.format.DateTimeFormatter;
 
+import org.hibernate.cache.internal.CacheKeyValueDescriptor;
+import org.hibernate.cache.internal.DefaultCacheKeyValueDescriptor;
+import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.type.descriptor.WrapperOptions;
 import org.hibernate.type.descriptor.jdbc.JdbcType;
 import org.hibernate.type.descriptor.jdbc.JdbcTypeIndicators;
@@ -81,5 +84,10 @@ public class YearJavaType extends AbstractClassJavaType<Year> {
 		}
 
 		throw unknownWrap( value.getClass() );
+	}
+
+	@Override
+	public CacheKeyValueDescriptor toCacheKeyDescriptor(SessionFactoryImplementor sessionFactory) {
+		return DefaultCacheKeyValueDescriptor.INSTANCE;
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/ZoneIdJavaType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/ZoneIdJavaType.java
@@ -9,6 +9,9 @@ package org.hibernate.type.descriptor.java;
 import java.sql.Types;
 import java.time.ZoneId;
 
+import org.hibernate.cache.internal.CacheKeyValueDescriptor;
+import org.hibernate.cache.internal.DefaultCacheKeyValueDescriptor;
+import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.type.descriptor.WrapperOptions;
 import org.hibernate.type.descriptor.jdbc.JdbcType;
 import org.hibernate.type.descriptor.jdbc.JdbcTypeIndicators;
@@ -66,5 +69,10 @@ public class ZoneIdJavaType extends AbstractClassJavaType<ZoneId> {
 		}
 
 		throw unknownWrap( value.getClass() );
+	}
+
+	@Override
+	public CacheKeyValueDescriptor toCacheKeyDescriptor(SessionFactoryImplementor sessionFactory) {
+		return DefaultCacheKeyValueDescriptor.INSTANCE;
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/ZonedDateTimeJavaType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/ZonedDateTimeJavaType.java
@@ -21,7 +21,10 @@ import java.util.GregorianCalendar;
 import jakarta.persistence.TemporalType;
 
 import org.hibernate.TimeZoneStorageStrategy;
+import org.hibernate.cache.internal.CacheKeyValueDescriptor;
+import org.hibernate.cache.internal.DefaultCacheKeyValueDescriptor;
 import org.hibernate.dialect.Dialect;
+import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.internal.util.ZonedDateTimeComparator;
 import org.hibernate.type.SqlTypes;
@@ -234,5 +237,10 @@ public class ZonedDateTimeJavaType extends AbstractTemporalJavaType<ZonedDateTim
 			Integer scale,
 			SharedSessionContractImplementor session) {
 		return ZonedDateTime.now( ClockHelper.forPrecision( precision, session ) );
+	}
+
+	@Override
+	public CacheKeyValueDescriptor toCacheKeyDescriptor(SessionFactoryImplementor sessionFactory) {
+		return DefaultCacheKeyValueDescriptor.INSTANCE;
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/spi/JavaTypeBasicAdaptor.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/spi/JavaTypeBasicAdaptor.java
@@ -6,6 +6,9 @@
  */
 package org.hibernate.type.descriptor.java.spi;
 
+import org.hibernate.cache.internal.CacheKeyValueDescriptor;
+import org.hibernate.cache.internal.DefaultCacheKeyValueDescriptor;
+import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.type.descriptor.WrapperOptions;
 import org.hibernate.type.descriptor.java.AbstractClassJavaType;
 import org.hibernate.type.descriptor.java.MutabilityPlan;
@@ -58,6 +61,11 @@ public class JavaTypeBasicAdaptor<T> extends AbstractClassJavaType<T> {
 		throw new UnsupportedOperationException(
 				"Wrap strategy not known for this Java type : " + getJavaType().getTypeName()
 		);
+	}
+
+	@Override
+	public CacheKeyValueDescriptor toCacheKeyDescriptor(SessionFactoryImplementor sessionFactory) {
+		return DefaultCacheKeyValueDescriptor.INSTANCE;
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/type/internal/BasicTypeImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/internal/BasicTypeImpl.java
@@ -8,6 +8,8 @@ package org.hibernate.type.internal;
 
 import java.util.Locale;
 
+import org.hibernate.cache.internal.CacheKeyValueDescriptor;
+import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.internal.util.collections.ArrayHelper;
 import org.hibernate.type.AbstractSingleColumnStandardBasicType;
 import org.hibernate.type.AdjustableBasicType;
@@ -24,6 +26,8 @@ public class BasicTypeImpl<J> extends AbstractSingleColumnStandardBasicType<J> i
 	private static int count;
 
 	private final String name;
+
+	private transient CacheKeyValueDescriptor cacheKeyValueDescriptor;
 
 	public BasicTypeImpl(JavaType<J> jtd, JdbcType std) {
 		super( std, jtd );
@@ -69,5 +73,14 @@ public class BasicTypeImpl<J> extends AbstractSingleColumnStandardBasicType<J> i
 	@Override
 	public String toString() {
 		return name;
+	}
+
+	@Override
+	public CacheKeyValueDescriptor toCacheKeyDescriptor(SessionFactoryImplementor sessionFactory) {
+		CacheKeyValueDescriptor cacheKeyValueDescriptor = this.cacheKeyValueDescriptor;
+		if ( cacheKeyValueDescriptor == null ) {
+			this.cacheKeyValueDescriptor = cacheKeyValueDescriptor = getMappedJavaType().toCacheKeyDescriptor( sessionFactory );
+		}
+		return cacheKeyValueDescriptor;
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/type/internal/ConvertedBasicTypeImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/internal/ConvertedBasicTypeImpl.java
@@ -19,6 +19,7 @@ import org.hibernate.Hibernate;
 import org.hibernate.HibernateException;
 import org.hibernate.MappingException;
 import org.hibernate.bytecode.enhance.spi.LazyPropertyInitializer;
+import org.hibernate.cache.internal.CacheKeyValueDescriptor;
 import org.hibernate.engine.spi.Mapping;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
@@ -34,7 +35,6 @@ import org.hibernate.type.TrueFalseConverter;
 import org.hibernate.type.YesNoConverter;
 import org.hibernate.type.descriptor.ValueBinder;
 import org.hibernate.type.descriptor.ValueExtractor;
-import org.hibernate.type.descriptor.WrapperOptions;
 import org.hibernate.type.descriptor.java.JavaType;
 import org.hibernate.type.descriptor.java.MutabilityPlan;
 import org.hibernate.type.descriptor.jdbc.JdbcLiteralFormatter;
@@ -58,6 +58,8 @@ public class ConvertedBasicTypeImpl<J> implements ConvertedBasicType<J>,
 	private final ValueBinder<J> jdbcValueBinder;
 	private final ValueExtractor<J> jdbcValueExtractor;
 	private final JdbcLiteralFormatter<J> jdbcLiteralFormatter;
+
+	private transient CacheKeyValueDescriptor cacheKeyValueDescriptor;
 
 	public ConvertedBasicTypeImpl(
 			String name,
@@ -415,5 +417,14 @@ public class ConvertedBasicTypeImpl<J> implements ConvertedBasicType<J>,
 	@Override
 	public String toString() {
 		return description;
+	}
+
+	@Override
+	public CacheKeyValueDescriptor toCacheKeyDescriptor(SessionFactoryImplementor sessionFactory) {
+		CacheKeyValueDescriptor cacheKeyValueDescriptor = this.cacheKeyValueDescriptor;
+		if ( cacheKeyValueDescriptor == null ) {
+			this.cacheKeyValueDescriptor = cacheKeyValueDescriptor = converter.getDomainJavaType().toCacheKeyDescriptor( sessionFactory );
+		}
+		return cacheKeyValueDescriptor;
 	}
 }


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-15500

Alternative to https://github.com/hibernate/hibernate-orm/pull/5295

The main motivation for the alternative is to not change existing contracts and thus keep backwards compatibility. In https://github.com/hibernate/hibernate-orm/pull/5295 `BasicType` does not implement `CacheKeyValueDescriptor` anymore and all subtypes of `AbstractStandardBasicType` now return a `JavaTypeCacheKeyValueDescriptor`.

This implementation instead implements delegation to a new `JavaType#toCacheKeyDescriptor` method in the concrete `BasicType` implementations, as well as some racy caching. Certain java types that might be used as primary key types have been adapted to return constant `CacheKeyValueDescriptor` instances, to reduce the serialization footprint of cache keys.

Another optimization has been implemented which reduces serialization footprint even further and also removes a megamorphic call site in the most common case, which is when the `CacheKeyValueDescriptor` is `DefaultCacheKeyValueDescriptor.INSTANCE`, in which case we initialize `null` for `CacheKeyImplementation#cacheKeyValueDescriptor`. The code was adapted to use standard `equals`/`hashCode` methods when that is `null`.