### PR TITLE
HHH-19841 test demoing bug in test or fix for HHH-11209

### DIFF
--- a/hibernate-core/src/test/java/org/hibernate/orm/test/collection/delayedOperation/DetachedBagDelayedOperationTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/collection/delayedOperation/DetachedBagDelayedOperationTest.java
@@ -166,6 +166,8 @@ public class DetachedBagDelayedOperationTest {
 					assertFalse( opDetachedWatcher.wasTriggered() );
 					assertFalse( opRollbackWatcher.wasTriggered() );
 
+					session.find( Parent.class, 1L );
+
 					return p;
 				}
 		);


### PR DESCRIPTION
Either the test or the fix for HHH-11209 is bogus, because it leaves stuff hanging around in the action queue.

The test only passes by accident.