### PR TITLE
HHH-15549 remove mapping of NUMBER(1,0) to BOOLEAN on Oracle

### DIFF
--- a/documentation/src/test/java/org/hibernate/userguide/sql/OracleStoredProcedureTest.java
+++ b/documentation/src/test/java/org/hibernate/userguide/sql/OracleStoredProcedureTest.java
@@ -56,7 +56,7 @@ public class OracleStoredProcedureTest {
         scope.inTransaction( entityManager -> {
             Session session = entityManager.unwrap(Session.class);
             session.doWork(connection -> {
-                try(Statement statement = connection.createStatement()) {
+                try (Statement statement = connection.createStatement()) {
                     statement.executeUpdate(
                         "CREATE OR REPLACE PROCEDURE sp_count_phones ( " +
                         "   personId IN NUMBER,  " +
@@ -67,7 +67,7 @@ public class OracleStoredProcedureTest {
                         "    FROM phone  " +
                         "    WHERE person_id = personId; " +
                         "END;"
-                   );
+                    );
                     //tag::sql-sp-ref-cursor-oracle-example[]
                     statement.executeUpdate(
                         "CREATE OR REPLACE PROCEDURE sp_person_phones (" +
@@ -80,7 +80,7 @@ public class OracleStoredProcedureTest {
                         "    FROM phone " +
                         "    WHERE person_id = personId; " +
                         "END;"
-                   );
+                    );
                     //end::sql-sp-ref-cursor-oracle-example[]
                     statement.executeUpdate(
                         "CREATE OR REPLACE FUNCTION fn_count_phones (" +
@@ -94,7 +94,7 @@ public class OracleStoredProcedureTest {
                         "    WHERE person_id = personId; " +
                         "    RETURN(phoneCount); " +
                         "END;"
-                   );
+                    );
                 }
 			});
         });
@@ -222,11 +222,11 @@ public class OracleStoredProcedureTest {
     @Test
     public void testStoredProcedureReturnValue(EntityManagerFactoryScope scope) {
         scope.inTransaction( entityManager -> {
-            BigDecimal phoneCount = (BigDecimal) entityManager
+            Integer phoneCount = (Integer) entityManager
                     .createNativeQuery( "SELECT fn_count_phones(:personId) FROM DUAL" )
                     .setParameter( "personId", 1 )
                     .getSingleResult();
-            assertEquals( BigDecimal.valueOf( 2 ), phoneCount );
+            assertEquals( 2, phoneCount );
         } );
     }
 }

--- a/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/OracleLegacyDialect.java
+++ b/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/OracleLegacyDialect.java
@@ -666,39 +666,36 @@ public class OracleLegacyDialect extends Dialect {
 			int precision,
 			int scale,
 			JdbcTypeRegistry jdbcTypeRegistry) {
-		// This is the reverse of what registerNumericTypeMappings registers
 		switch ( jdbcTypeCode ) {
 			case Types.NUMERIC:
-				// For some reason, the Oracle JDBC driver reports floats as numerics with scale -127
 				if ( scale == -127 ) {
+					// For some reason, the Oracle JDBC driver reports FLOAT
+					// as NUMERIC with scale -127
 					if ( precision <= getFloatPrecision() ) {
 						return jdbcTypeRegistry.getDescriptor( Types.FLOAT );
 					}
 					return jdbcTypeRegistry.getDescriptor( Types.DOUBLE );
 				}
+				//intentional fall-through:
 			case Types.DECIMAL:
 				if ( scale == 0 ) {
-					switch ( precision ) {
-						case 1:
-							return jdbcTypeRegistry.getDescriptor( Types.BOOLEAN );
-						case 3:
-							return jdbcTypeRegistry.getDescriptor( Types.TINYINT );
-						case 5:
-							return jdbcTypeRegistry.getDescriptor( Types.SMALLINT );
-						case 10:
-							return jdbcTypeRegistry.getDescriptor( Types.INTEGER );
-						case 19:
-							return jdbcTypeRegistry.getDescriptor( Types.BIGINT );
+					// Don't infer TINYINT or SMALLINT on Oracle, since the
+					// range of values of a NUMBER(3,0) or NUMBER(5,0) just
+					// doesn't really match naturally.
+					if ( precision <= 10 ) {
+						// A NUMBER(10,0) might not fit in a 32-bit integer,
+						// but it's still pretty safe to use INTEGER here,
+						// since we can assume the most likely reason to find
+						// a column of type NUMBER(10,0) in an Oracle database
+						// is that it's intended to store an integer.
+						return jdbcTypeRegistry.getDescriptor( Types.INTEGER );
+					}
+					else if ( precision <= 19 ) {
+						return jdbcTypeRegistry.getDescriptor( Types.BIGINT );
 					}
 				}
 		}
-		return super.resolveSqlTypeDescriptor(
-				columnTypeName,
-				jdbcTypeCode,
-				precision,
-				scale,
-				jdbcTypeRegistry
-		);
+		return super.resolveSqlTypeDescriptor( columnTypeName, jdbcTypeCode, precision, scale, jdbcTypeRegistry );
 	}
 
 	/**

--- a/hibernate-core/src/main/java/org/hibernate/dialect/Dialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/Dialect.java
@@ -572,7 +572,7 @@ public abstract class Dialect implements ConversionContext {
 	 * @param columnTypeName the column type name
 	 * @param jdbcTypeCode the {@link SqlTypes type code}
 	 * @param precision the precision or 0
-	 * @param scale the scale of 0
+	 * @param scale the scale or 0
 	 * @return an appropriate instance of {@link JdbcType}
 	 */
 	public JdbcType resolveSqlTypeDescriptor(

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/query/NativeQueryResultTypeAutoDiscoveryTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/query/NativeQueryResultTypeAutoDiscoveryTest.java
@@ -95,22 +95,32 @@ public class NativeQueryResultTypeAutoDiscoveryTest {
 	}
 
 	@Test
-	public void commonNumericTypes() {
+	@SkipForDialect(value=OracleDialect.class, comment="Oracle maps integer types to number")
+	public void smallintType() {
+		createEntityManagerFactory(SmallintEntity.class);
+		doTest( SmallintEntity.class, (short)32767 );
+	}
+
+	@Test
+	public void integerTypes() {
 		createEntityManagerFactory(
 				BigintEntity.class,
-				IntegerEntity.class,
-				SmallintEntity.class,
-				DoubleEntity.class
+				IntegerEntity.class
 		);
 
 		doTest( BigintEntity.class, 9223372036854775807L );
 		doTest( IntegerEntity.class, 2147483647 );
-		doTest( SmallintEntity.class, (short)32767 );
+	}
+
+	@Test
+	public void doubleType() {
+		createEntityManagerFactory( DoubleEntity.class );
 		doTest( DoubleEntity.class, 445146115151.45845 );
 	}
 
 	@Test
 	@SkipForDialect(value = SybaseDialect.class, comment = "No support for the bit datatype so we use tinyint")
+	@SkipForDialect(value = OracleDialect.class, comment = "No support for the bit datatype so we use number(1,0)")
 	public void booleanType() {
 		createEntityManagerFactory( BooleanEntity.class );
 		doTest( BooleanEntity.class, true );
@@ -118,6 +128,7 @@ public class NativeQueryResultTypeAutoDiscoveryTest {
 
 	@Test
 	@SkipForDialect(value = SybaseDialect.class, comment = "No support for the bit datatype so we use tinyint")
+	@SkipForDialect(value = OracleDialect.class, comment = "No support for the bit datatype so we use number(1,0)")
 	public void bitType() {
 		createEntityManagerFactory( BitEntity.class );
 		doTest( BitEntity.class, false );
@@ -129,6 +140,7 @@ public class NativeQueryResultTypeAutoDiscoveryTest {
 	@SkipForDialect(value = DB2Dialect.class, comment = "No support for the tinyint datatype so we use smallint")
 	@SkipForDialect(value = AbstractTransactSQLDialect.class, comment = "No support for the tinyint datatype so we use smallint")
 	@SkipForDialect(value = AbstractHANADialect.class, comment = "No support for the tinyint datatype so we use smallint")
+	@SkipForDialect(value = OracleDialect.class, comment="Oracle maps tinyint to number")
 	public void tinyintType() {
 		createEntityManagerFactory( TinyintEntity.class );
 		doTest( TinyintEntity.class, (byte)127 );

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/procedure/OracleStoredProcedureTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/procedure/OracleStoredProcedureTest.java
@@ -6,7 +6,6 @@
  */
 package org.hibernate.orm.test.procedure;
 
-import java.math.BigDecimal;
 import java.sql.CallableStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -188,11 +187,11 @@ public class OracleStoredProcedureTest {
 	public void testStoredProcedureReturnValue(EntityManagerFactoryScope scope) {
 		scope.inTransaction(
 				entityManager -> {
-					BigDecimal phoneCount = (BigDecimal) entityManager
+					Integer phoneCount = (Integer) entityManager
 							.createNativeQuery( "SELECT fn_count_phones(:personId) FROM DUAL" )
 							.setParameter( "personId", person1.getId() )
 							.getSingleResult();
-					assertEquals( BigDecimal.valueOf( 2 ), phoneCount );
+					assertEquals( 2, phoneCount );
 				}
 		);
 	}

--- a/migration-guide.adoc
+++ b/migration-guide.adoc
@@ -31,3 +31,10 @@ Due to this change, schema validation errors could occur on existing databases.
 The migration to `uuid` requires a migration expression like `cast(old as uuid)`.
 
 To retain backwards compatibility, configure the setting `hibernate.type.preferred_uuid_jdbc_type` to `BINARY`.
+
+=== Column type inference for `number(n,0)` in native SQL queries on Oracle
+
+Previously, since Hibernate 6.0, columns of type `number` with scale 0 on Oracle were interpreted as `boolean`, `tinyint`, `smallint`, `int`, or `bigint`,
+depending on the precision.
+
+Now, columns of type `number` with scale 0 are interpreted as `int` or `bigint` depending on the precision.


### PR DESCRIPTION
This just seems wrong to me. We have no way to say that a `NUMBER(1,0)` column isn't a single-digit number.

I mean, we might just as well say that every `CHAR(1)` column is a boolean, but we don't.