### PR TITLE
Backporting HHH-15484

### DIFF
--- a/gradle/libraries.gradle
+++ b/gradle/libraries.gradle
@@ -46,7 +46,7 @@ ext {
     jakartaJaxbRuntimeVersion = '3.0.0'
 
     //GraalVM
-    graalvmVersion = '21.3.0'
+    graalvmVersion = '22.2.0'
 
     micrometerVersion = '1.9.3'
 
@@ -197,7 +197,7 @@ ext {
             jboss_ejb_spec_jar          : 'org.jboss.spec.javax.ejb:jboss-ejb-api_3.2_spec:1.0.0.Final',
             jboss_annotation_spec_jar   : 'org.jboss.spec.javax.annotation:jboss-annotations-api_1.2_spec:1.0.0.Final',
 
-            graalvm_nativeimage         : "org.graalvm.nativeimage:svm:${graalvmVersion}"
+            graalvm_nativeimage         : "org.graalvm.sdk:graal-sdk:${graalvmVersion}"
         ]
 }
 

--- a/hibernate-graalvm/src/main/java/org/hibernate/graalvm/internal/GraalVMStaticAutofeature.java
+++ b/hibernate-graalvm/src/main/java/org/hibernate/graalvm/internal/GraalVMStaticAutofeature.java
@@ -12,7 +12,6 @@ import java.util.ArrayList;
 
 import org.hibernate.internal.util.ReflectHelper;
 
-import com.oracle.svm.core.annotate.AutomaticFeature;
 import org.graalvm.nativeimage.hosted.Feature;
 import org.graalvm.nativeimage.hosted.RuntimeReflection;
 
@@ -34,7 +33,6 @@ import org.graalvm.nativeimage.hosted.RuntimeReflection;
  * </p>
  * @author Sanne Grinovero
  */
-@AutomaticFeature
 public class GraalVMStaticAutofeature implements Feature {
 
 	public void beforeAnalysis(Feature.BeforeAnalysisAccess before) {

--- a/hibernate-graalvm/src/main/java/org/hibernate/graalvm/internal/GraalVMStaticAutofeature.java
+++ b/hibernate-graalvm/src/main/java/org/hibernate/graalvm/internal/GraalVMStaticAutofeature.java
@@ -37,21 +37,25 @@ public class GraalVMStaticAutofeature implements Feature {
 
 	public void beforeAnalysis(Feature.BeforeAnalysisAccess before) {
 		final Class<?>[] needsHavingSimpleConstructors = StaticClassLists.typesNeedingDefaultConstructorAccessible();
-		final Class[] neddingAllConstructorsAccessible = StaticClassLists.typesNeedingAllConstructorsAccessible();
+		final Class<?>[] needingAllConstructorsAccessible = StaticClassLists.typesNeedingAllConstructorsAccessible();
 		//Size formula is just a reasonable guess:
-		ArrayList<Executable> executables = new ArrayList<>( needsHavingSimpleConstructors.length + neddingAllConstructorsAccessible.length * 3 );
-		for ( Class c : needsHavingSimpleConstructors ) {
+		ArrayList<Executable> executables = new ArrayList<>( needsHavingSimpleConstructors.length + needingAllConstructorsAccessible.length * 3 );
+		for ( Class<?> c : needsHavingSimpleConstructors ) {
 			executables.add( ReflectHelper.getDefaultConstructor( c ) );
 		}
-		for ( Class c : neddingAllConstructorsAccessible ) {
-			for ( Constructor declaredConstructor : c.getDeclaredConstructors() ) {
+		for ( Class<?> c : needingAllConstructorsAccessible) {
+			for ( Constructor<?> declaredConstructor : c.getDeclaredConstructors() ) {
 				executables.add( declaredConstructor );
 			}
 		}
 		RuntimeReflection.register( needsHavingSimpleConstructors );
-		RuntimeReflection.register( neddingAllConstructorsAccessible );
+		RuntimeReflection.register( needingAllConstructorsAccessible );
 		RuntimeReflection.register( StaticClassLists.typesNeedingArrayCopy() );
 		RuntimeReflection.register( executables.toArray(new Executable[0]) );
 	}
 
+	@Override
+	public String getDescription() {
+		return "Hibernate ORM GraalVM static reflection registration";
+	}
 }

--- a/hibernate-graalvm/src/main/java/org/hibernate/graalvm/internal/GraalVMStaticFeature.java
+++ b/hibernate-graalvm/src/main/java/org/hibernate/graalvm/internal/GraalVMStaticFeature.java
@@ -33,7 +33,7 @@ import org.graalvm.nativeimage.hosted.RuntimeReflection;
  * </p>
  * @author Sanne Grinovero
  */
-public class GraalVMStaticAutofeature implements Feature {
+public class GraalVMStaticFeature implements Feature {
 
 	public void beforeAnalysis(Feature.BeforeAnalysisAccess before) {
 		final Class<?>[] needsHavingSimpleConstructors = StaticClassLists.typesNeedingDefaultConstructorAccessible();
@@ -56,6 +56,6 @@ public class GraalVMStaticAutofeature implements Feature {
 
 	@Override
 	public String getDescription() {
-		return "Hibernate ORM GraalVM static reflection registration";
+		return "Hibernate ORM's static reflection registrations for GraalVM";
 	}
 }

--- a/hibernate-graalvm/src/main/java/org/hibernate/graalvm/internal/QueryParsingSupport.java
+++ b/hibernate-graalvm/src/main/java/org/hibernate/graalvm/internal/QueryParsingSupport.java
@@ -14,7 +14,6 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import org.hibernate.internal.build.AllowSysOut;
 import org.hibernate.internal.util.ReflectHelper;
 
-import com.oracle.svm.core.annotate.AutomaticFeature;
 import org.graalvm.nativeimage.hosted.Feature;
 import org.graalvm.nativeimage.hosted.RuntimeReflection;
 
@@ -33,7 +32,6 @@ import org.graalvm.nativeimage.hosted.RuntimeReflection;
  *
  * @author Sanne Grinovero
  */
-@AutomaticFeature
 public final class QueryParsingSupport implements Feature {
 
 	private final AtomicBoolean triggered = new AtomicBoolean( false);

--- a/hibernate-graalvm/src/main/java/org/hibernate/graalvm/internal/QueryParsingSupport.java
+++ b/hibernate-graalvm/src/main/java/org/hibernate/graalvm/internal/QueryParsingSupport.java
@@ -49,6 +49,11 @@ public final class QueryParsingSupport implements Feature {
 		access.registerReachabilityHandler(this::enableHQLSupport, parserClazz);
 	}
 
+	@Override
+	public String getDescription() {
+		return "Hibernate ORM HQL Parser Support";
+	}
+
 	@AllowSysOut
 	private void enableHQLSupport(DuringAnalysisAccess duringAnalysisAccess) {
 		final boolean needsEnablingYet = triggered.compareAndSet( false, true );

--- a/hibernate-graalvm/src/main/java/org/hibernate/graalvm/internal/QueryParsingSupport.java
+++ b/hibernate-graalvm/src/main/java/org/hibernate/graalvm/internal/QueryParsingSupport.java
@@ -20,7 +20,7 @@ import org.graalvm.nativeimage.hosted.RuntimeReflection;
 /**
  * This registers all ANTLR parser nodes for reflection, something that is necessary
  * as the HQL parser's inner workings are based on reflection.
- * This is different than the "static" registrations of {@link GraalVMStaticAutofeature}
+ * This is different than the "static" registrations of {@link GraalVMStaticFeature}
  * as we only register these if the HQL parser is actually reachable: some particularly
  * simple applications might not need dynamic queries being expressed in string form,
  * and for such cases the reflective registrations can be skipped.
@@ -51,7 +51,7 @@ public final class QueryParsingSupport implements Feature {
 
 	@Override
 	public String getDescription() {
-		return "Hibernate ORM HQL Parser Support";
+		return "Hibernate ORM's support for HQL Parser in GraalVM";
 	}
 
 	@AllowSysOut


### PR DESCRIPTION
The GraalVM dependency changed from `org.graalvm.nativeimage:svm` to `org.graalvm.sdk:graal-sdk`.

We don't typically allow dependency changes in a micro release, but consider that this is a module clearly flagged as experimental and the `svm` artifact is deprecated we'll need this.

Also good to know: this used to be an "AutomaticFeature" (aka it would activate automatically by just having it on classpath; but automatic features are also deprecated, so now the features included in our `hibernate-graalvm` module will need to be explicitly activated.