### PR TITLE
HHH-15564 add @SecondaryRow and HHH-15565 remove zombie code

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/annotations/SecondaryRow.java
+++ b/hibernate-core/src/main/java/org/hibernate/annotations/SecondaryRow.java
@@ -1,0 +1,48 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.annotations;
+
+import java.lang.annotation.Repeatable;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * Specifies how the row of a {@link jakarta.persistence.SecondaryTable} should be managed.
+ *
+ * @see jakarta.persistence.SecondaryTable
+ *
+ * @author Gavin King
+ */
+@Target(TYPE)
+@Retention(RUNTIME)
+@Repeatable(SecondaryRows.class)
+public @interface SecondaryRow {
+	/**
+	 * The name of the secondary table, as specified by
+	 * {@link jakarta.persistence.SecondaryTable#name()}.
+	 */
+	String table() default "";
+
+	/**
+	 * If enabled, Hibernate will never insert or update the columns of the secondary table.
+	 * <p>
+	 * This setting is useful if data in the secondary table belongs to some other entity,
+	 * or if it is maintained externally to Hibernate.
+	 */
+	boolean owned() default true;
+
+	/**
+	 * Unless disabled, specifies that no row should be inserted in the secondary table if
+	 * all the columns of the secondary table would be null. Furthermore, an outer join will
+	 * always be used to read the row. Thus, by default, Hibernate avoids creating a row
+	 * containing only null column values.
+	 */
+	boolean optional() default true;
+}

--- a/hibernate-core/src/main/java/org/hibernate/annotations/SecondaryRows.java
+++ b/hibernate-core/src/main/java/org/hibernate/annotations/SecondaryRows.java
@@ -13,15 +13,12 @@ import static java.lang.annotation.ElementType.TYPE;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 /**
- * A grouping of {@link Table}s.
+ * A grouping of {@link SecondaryRows}.
  *
- * @author Emmanuel Bernard
+ * @author Gavin King
  */
 @Target(TYPE)
 @Retention(RUNTIME)
-public @interface Tables {
-	/**
-	 * The table grouping.
-	 */
-	Table[] value();
+public @interface SecondaryRows {
+	SecondaryRow[] value();
 }

--- a/hibernate-core/src/main/java/org/hibernate/annotations/SelectBeforeUpdate.java
+++ b/hibernate-core/src/main/java/org/hibernate/annotations/SelectBeforeUpdate.java
@@ -17,10 +17,13 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  * should be fetched from the database when the entity is reattached using
  * {@link org.hibernate.Session#update(Object)}.
  *
+ * @deprecated Since {@link org.hibernate.Session#update(Object)} is deprecated
+ *
  * @author Steve Ebersole
  */
 @Target( TYPE )
 @Retention( RUNTIME )
+@Deprecated(since = "6.2")
 public @interface SelectBeforeUpdate {
 	/**
 	 * @deprecated When {@code false}, this annotation has no effect.

--- a/hibernate-core/src/main/java/org/hibernate/annotations/Table.java
+++ b/hibernate-core/src/main/java/org/hibernate/annotations/Table.java
@@ -68,26 +68,19 @@ public @interface Table {
 	ForeignKey foreignKey() default @ForeignKey( name="" );
 
 	/**
-	 * Defines a fetching strategy for the secondary table.
-	 * <ul>
-	 * <li>If set to {@link FetchMode#JOIN}, the default, Hibernate will use an inner join to
-	 * retrieve a secondary table defined by a class or its superclasses and an outer join for
-	 * a secondary table defined by a subclass.
-	 * <li>If set to {@link FetchMode#SELECT} then Hibernate will use a sequential select for
-	 * a secondary table defined on a subclass, which will be issued only if a row turns out
-	 * to represent an instance of the subclass. Inner joins will still be used to retrieve a
-	 * secondary table defined by the class and its superclasses.
-	 * </ul>
-	 * <p>
-	 * <em>Only applies to secondary tables.</em>
+	 * @deprecated This setting has no effect in Hibernate 6
 	 */
+	@Deprecated(since = "6.2")
 	FetchMode fetch() default FetchMode.JOIN;
 
 	/**
 	 * If enabled, Hibernate will never insert or update the columns of the secondary table.
 	 * <p>
 	 * <em>Only applies to secondary tables.</em>
+	 *
+	 * @deprecated use {@link SecondaryRow#owned()}
 	 */
+	@Deprecated(since = "6.2")
 	boolean inverse() default false;
 
 	/**
@@ -96,7 +89,10 @@ public @interface Table {
 	 * by default, Hibernate avoids creating a row of null values.
 	 * <p>
 	 * <em>Only applies to secondary tables.</em>
+	 *
+	 * @deprecated use {@link SecondaryRow#optional()}
 	 */
+	@Deprecated(since = "6.2")
 	boolean optional() default true;
 
 	/**

--- a/hibernate-core/src/main/java/org/hibernate/boot/model/source/internal/hbm/ModelBinder.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/source/internal/hbm/ModelBinder.java
@@ -1741,7 +1741,6 @@ public class ModelBinder {
 
 		bindCustomSql( secondaryTableSource, secondaryTableJoin );
 
-		secondaryTableJoin.setSequentialSelect( secondaryTableSource.getFetchStyle() == FetchStyle.SELECT );
 		secondaryTableJoin.setInverse( secondaryTableSource.isInverse() );
 		secondaryTableJoin.setOptional( secondaryTableSource.isOptional() );
 

--- a/hibernate-core/src/main/java/org/hibernate/cfg/OneToOneSecondPass.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/OneToOneSecondPass.java
@@ -279,7 +279,6 @@ public class OneToOneSecondPass implements SecondPass {
 
 		//TODO support @ForeignKey
 		join.setKey( key );
-		join.setSequentialSelect( false );
 		//TODO support for inverse and optional
 		join.setOptional( true ); //perhaps not quite per-spec, but a Good Thing anyway
 		key.setCascadeDeleteEnabled( false );

--- a/hibernate-core/src/main/java/org/hibernate/mapping/Join.java
+++ b/hibernate-core/src/main/java/org/hibernate/mapping/Join.java
@@ -26,7 +26,6 @@ public class Join implements AttributeContainer, Serializable {
 	private Table table;
 	private KeyValue key;
 	private PersistentClass persistentClass;
-	private boolean sequentialSelect;
 	private boolean inverse;
 	private boolean optional;
 	private boolean disableForeignKeyCreation;
@@ -174,13 +173,6 @@ public class Join implements AttributeContainer, Serializable {
 
 	public ExecuteUpdateResultCheckStyle getCustomSQLDeleteCheckStyle() {
 		return deleteCheckStyle;
-	}
-
-	public boolean isSequentialSelect() {
-		return sequentialSelect;
-	}
-	public void setSequentialSelect(boolean deferred) {
-		this.sequentialSelect = deferred;
 	}
 
 	public boolean isInverse() {

--- a/hibernate-core/src/main/java/org/hibernate/persister/entity/JoinedSubclassEntityPersister.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/entity/JoinedSubclassEntityPersister.java
@@ -121,7 +121,7 @@ public class JoinedSubclassEntityPersister extends AbstractEntityPersister {
 //	private final int[] subclassFormulaTableNumberClosure;
 	private final String[] subclassColumnClosure;
 
-	private final boolean[] subclassTableSequentialSelect;
+//	private final boolean[] subclassTableSequentialSelect;
 //	private final boolean[] subclassTableIsLazyClosure;
 	private final boolean[] isInverseSubclassTable;
 	private final boolean[] isNullableSubclassTable;
@@ -311,7 +311,7 @@ public class JoinedSubclassEntityPersister extends AbstractEntityPersister {
 
 		ArrayList<String> subclassTableNames = new ArrayList<>();
 		ArrayList<Boolean> isConcretes = new ArrayList<>();
-		ArrayList<Boolean> isDeferreds = new ArrayList<>();
+//		ArrayList<Boolean> isDeferreds = new ArrayList<>();
 //		ArrayList<Boolean> isLazies = new ArrayList<>();
 		ArrayList<Boolean> isInverses = new ArrayList<>();
 		ArrayList<Boolean> isNullables = new ArrayList<>();
@@ -319,10 +319,10 @@ public class JoinedSubclassEntityPersister extends AbstractEntityPersister {
 		keyColumns = new ArrayList<>();
 		for ( Table table : persistentClass.getSubclassTableClosure() ) {
 			isConcretes.add( persistentClass.isClassOrSuperclassTable( table ) );
-			isDeferreds.add( Boolean.FALSE );
-//			isLazies.add( Boolean.FALSE );
-			isInverses.add( Boolean.FALSE );
-			isNullables.add( Boolean.FALSE );
+//			isDeferreds.add( false );
+//			isLazies.add( false );
+			isInverses.add( false );
+			isNullables.add( false );
 			final String tableName = determineTableName( table );
 			subclassTableNames.add( tableName );
 			String[] key = new String[idColumnSpan];
@@ -338,7 +338,7 @@ public class JoinedSubclassEntityPersister extends AbstractEntityPersister {
 			final Table joinTable = join.getTable();
 
 			isConcretes.add( persistentClass.isClassOrSuperclassTable( joinTable ) );
-			isDeferreds.add( join.isSequentialSelect() );
+//			isDeferreds.add( join.isSequentialSelect() );
 			isInverses.add( join.isInverse() );
 			isNullables.add( join.isOptional() );
 //			isLazies.add( join.isLazy() );
@@ -356,7 +356,7 @@ public class JoinedSubclassEntityPersister extends AbstractEntityPersister {
 		String[] naturalOrderSubclassTableNameClosure = ArrayHelper.toStringArray( subclassTableNames );
 		String[][] naturalOrderSubclassTableKeyColumnClosure = ArrayHelper.to2DStringArray( keyColumns );
 		isClassOrSuperclassTable = ArrayHelper.toBooleanArray( isConcretes );
-		subclassTableSequentialSelect = ArrayHelper.toBooleanArray( isDeferreds );
+//		subclassTableSequentialSelect = ArrayHelper.toBooleanArray( isDeferreds );
 //		subclassTableIsLazyClosure = ArrayHelper.toBooleanArray( isLazies );
 		isInverseSubclassTable = ArrayHelper.toBooleanArray( isInverses );
 		isNullableSubclassTable = ArrayHelper.toBooleanArray( isNullables );
@@ -729,10 +729,10 @@ public class JoinedSubclassEntityPersister extends AbstractEntityPersister {
 		return isInverseTable[j];
 	}
 
-	@Override
-	protected boolean isSubclassTableSequentialSelect(int j) {
-		return subclassTableSequentialSelect[j] && !isClassOrSuperclassTable[j];
-	}
+//	@Override
+//	protected boolean isSubclassTableSequentialSelect(int j) {
+//		return subclassTableSequentialSelect[j] && !isClassOrSuperclassTable[j];
+//	}
 
 	/*public void postInstantiate() throws MappingException {
 		super.postInstantiate();

--- a/hibernate-core/src/main/java/org/hibernate/persister/entity/SingleTableEntityPersister.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/entity/SingleTableEntityPersister.java
@@ -93,7 +93,7 @@ public class SingleTableEntityPersister extends AbstractEntityPersister {
 //	private final boolean[] subclassTableIsLazyClosure;
 	private final boolean[] isInverseSubclassTable;
 	private final boolean[] isNullableSubclassTable;
-	private final boolean[] subclassTableSequentialSelect;
+//	private final boolean[] subclassTableSequentialSelect;
 	private final String[][] subclassTableKeyColumnClosure;
 	private final boolean[] isClassOrSuperclassTable;
 	private final boolean[] isClassOrSuperclassJoin;
@@ -252,7 +252,7 @@ public class SingleTableEntityPersister extends AbstractEntityPersister {
 		ArrayList<String[]> joinKeyColumns = new ArrayList<>();
 		ArrayList<Boolean> isConcretes = new ArrayList<>();
 		ArrayList<Boolean> isClassOrSuperclassJoins = new ArrayList<>();
-		ArrayList<Boolean> isDeferreds = new ArrayList<>();
+//		ArrayList<Boolean> isDeferreds = new ArrayList<>();
 		ArrayList<Boolean> isInverses = new ArrayList<>();
 		ArrayList<Boolean> isNullables = new ArrayList<>();
 //		ArrayList<Boolean> isLazies = new ArrayList<>();
@@ -260,7 +260,7 @@ public class SingleTableEntityPersister extends AbstractEntityPersister {
 		joinKeyColumns.add( getIdentifierColumnNames() );
 		isConcretes.add( Boolean.TRUE );
 		isClassOrSuperclassJoins.add( Boolean.TRUE );
-		isDeferreds.add( Boolean.FALSE );
+//		isDeferreds.add( Boolean.FALSE );
 		isInverses.add( Boolean.FALSE );
 		isNullables.add( Boolean.FALSE );
 //		isLazies.add( Boolean.FALSE );
@@ -271,8 +271,8 @@ public class SingleTableEntityPersister extends AbstractEntityPersister {
 			isNullables.add( join.isOptional() );
 //			isLazies.add( lazyAvailable && join.isLazy() );
 
-			boolean isDeferred = join.isSequentialSelect() && !persistentClass.isClassOrSuperclassJoin( join ) ;
-			isDeferreds.add( isDeferred );
+//			boolean isDeferred = join.isSequentialSelect() && !persistentClass.isClassOrSuperclassJoin( join ) ;
+//			isDeferreds.add( isDeferred );
 
 			String joinTableName = determineTableName( join.getTable() );
 			subclassTables.add( joinTableName );
@@ -286,7 +286,7 @@ public class SingleTableEntityPersister extends AbstractEntityPersister {
 			joinKeyColumns.add( keyCols );
 		}
 
-		subclassTableSequentialSelect = ArrayHelper.toBooleanArray( isDeferreds );
+//		subclassTableSequentialSelect = ArrayHelper.toBooleanArray( isDeferreds );
 		subclassTableNameClosure = ArrayHelper.toStringArray( subclassTables );
 //		subclassTableIsLazyClosure = ArrayHelper.toBooleanArray( isLazies );
 		subclassTableKeyColumnClosure = ArrayHelper.to2DStringArray( joinKeyColumns );
@@ -568,10 +568,10 @@ public class SingleTableEntityPersister extends AbstractEntityPersister {
 		return propertyTableNumbers[property] == j;
 	}
 
-	@Override
-	protected boolean isSubclassTableSequentialSelect(int j) {
-		return subclassTableSequentialSelect[j] && !isClassOrSuperclassTable[j];
-	}
+//	@Override
+//	protected boolean isSubclassTableSequentialSelect(int j) {
+//		return subclassTableSequentialSelect[j] && !isClassOrSuperclassTable[j];
+//	}
 
 	// Execute the SQL:
 

--- a/hibernate-core/src/main/java/org/hibernate/resource/jdbc/spi/StatementInspector.java
+++ b/hibernate-core/src/main/java/org/hibernate/resource/jdbc/spi/StatementInspector.java
@@ -20,8 +20,9 @@ import java.io.Serializable;
  */
 public interface StatementInspector extends Serializable {
 	/**
-	 * Inspect the given SQL, possibly returning a different SQL to be used instead.  Note that returning {@code null}
-	 * is interpreted as returning the same SQL as was passed.
+	 * Inspect the given SQL, possibly returning a different SQL to be used instead.
+	 * Note that returning {@code null} is interpreted as returning the same SQL as
+	 * was passed.
 	 *
 	 * @param sql The SQL to inspect
 	 *

--- a/hibernate-core/src/main/java/org/hibernate/tuple/entity/EntityMetamodel.java
+++ b/hibernate-core/src/main/java/org/hibernate/tuple/entity/EntityMetamodel.java
@@ -129,7 +129,7 @@ public class EntityMetamodel implements Serializable {
 	private final boolean inherited;
 	private final boolean hasSubclasses;
 	private final Set<String> subclassEntityNames;
-	private final Map<Class<?>,String> entityNameByInheritenceClassMap;
+	private final Map<Class<?>,String> entityNameByInheritanceClassMap;
 
 	private final BytecodeEnhancementMetadata bytecodeEnhancementMetadata;
 
@@ -439,7 +439,7 @@ public class EntityMetamodel implements Serializable {
 				entityNameByInheritanceClassMapLocal.put( subclass.getMappedClass(), subclass.getEntityName() );
 			}
 		}
-		entityNameByInheritenceClassMap = CollectionHelper.toSmallMap( entityNameByInheritanceClassMapLocal );
+		entityNameByInheritanceClassMap = CollectionHelper.toSmallMap( entityNameByInheritanceClassMapLocal );
 	}
 
 	private static GenerationStrategyPair buildGenerationStrategyPair(
@@ -1002,7 +1002,7 @@ public class EntityMetamodel implements Serializable {
 	 * @return The mapped entity-name, or null if no such mapping was found.
 	 */
 	public String findEntityNameByEntityClass(Class<?> inheritanceClass) {
-		return entityNameByInheritenceClassMap.get( inheritanceClass );
+		return entityNameByInheritanceClassMap.get( inheritanceClass );
 	}
 
 	@Override

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/secondarytable/Record.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/secondarytable/Record.java
@@ -1,0 +1,26 @@
+package org.hibernate.orm.test.secondarytable;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.SecondaryTable;
+import jakarta.persistence.SequenceGenerator;
+import jakarta.persistence.Table;
+import org.hibernate.annotations.SecondaryRow;
+
+@Entity
+@Table(name = "Overview")
+@SecondaryTable(name = "Details")
+@SecondaryTable(name = "Extras")
+@SecondaryRow(table = "Details", optional = false)
+@SecondaryRow(table = "Extras", optional = true)
+@SequenceGenerator(name="RecordSeq", sequenceName = "RecordId", allocationSize = 1)
+public class Record {
+    @Id @GeneratedValue(generator = "RecordSeq")  long id;
+    String name;
+    @Column(table = "Details") String text;
+    @Column(table = "Details") boolean enabled;
+    @Column(table = "Extras", name="`comment`") String comment;
+}
+

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/secondarytable/SecondaryRowTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/secondarytable/SecondaryRowTest.java
@@ -1,0 +1,100 @@
+package org.hibernate.orm.test.secondarytable;
+
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@DomainModel(annotatedClasses = {Record.class,SpecialRecord.class})
+@SessionFactory
+public class SecondaryRowTest {
+	@Test
+	public void testSecondaryRow(SessionFactoryScope scope) {
+		int seq = scope.getSessionFactory().getJdbcServices().getDialect().getSequenceSupport().supportsSequences()
+				? 1 : 0;
+
+		Record record = new Record();
+		record.enabled = true;
+		record.text = "Hello World!";
+		scope.inTransaction(s -> s.persist(record));
+		scope.getCollectingStatementInspector().assertExecutedCount(2+seq);
+		scope.getCollectingStatementInspector().clear();
+
+		Record record2 = new Record();
+		record2.enabled = true;
+		record2.text = "Hello World!";
+		record2.comment = "Goodbye";
+		scope.inTransaction(s -> s.persist(record2));
+		scope.getCollectingStatementInspector().assertExecutedCount(3+seq);
+		scope.getCollectingStatementInspector().clear();
+
+		SpecialRecord specialRecord = new SpecialRecord();
+		specialRecord.enabled = true;
+		specialRecord.text = "Hello World!";
+		specialRecord.validated = LocalDateTime.now();
+		scope.inTransaction(s -> s.persist(specialRecord));
+		scope.getCollectingStatementInspector().assertExecutedCount(3+seq);
+		scope.getCollectingStatementInspector().clear();
+
+		scope.inTransaction(s -> assertNotNull(s.find(Record.class, record.id)));
+		scope.getCollectingStatementInspector().assertExecutedCount(1);
+		scope.getCollectingStatementInspector().clear();
+
+		scope.inTransaction(s -> assertNotNull(s.find(Record.class, record2.id)));
+		scope.getCollectingStatementInspector().assertExecutedCount(1);
+		scope.getCollectingStatementInspector().clear();
+
+		scope.inTransaction(s -> assertNotNull(s.find(Record.class, specialRecord.id)));
+		scope.getCollectingStatementInspector().assertExecutedCount(1);
+		scope.getCollectingStatementInspector().clear();
+
+		scope.inTransaction(s -> assertEquals(3, s.createQuery("from Record").getResultList().size()));
+		scope.getCollectingStatementInspector().assertExecutedCount(1);
+		scope.getCollectingStatementInspector().clear();
+
+		scope.inTransaction(s -> assertEquals(1, s.createQuery("from SpecialRecord").getResultList().size()));
+		scope.getCollectingStatementInspector().assertExecutedCount(1);
+		scope.getCollectingStatementInspector().clear();
+
+		scope.inTransaction(s -> {
+			Record r = s.find(Record.class, record.id);
+			r.text = "new text";
+			r.comment = "the comment";
+		});
+		scope.getCollectingStatementInspector().assertExecutedCount(3);
+		assertTrue( scope.getCollectingStatementInspector().getSqlQueries().get(1).startsWith("update ") );
+		assertTrue( scope.getCollectingStatementInspector().getSqlQueries().get(2).startsWith("insert ") );
+		scope.getCollectingStatementInspector().clear();
+
+		scope.inTransaction(s -> {
+			Record r = s.find(Record.class, record.id);
+			r.comment = "new comment";
+		});
+		scope.getCollectingStatementInspector().assertExecutedCount(2);
+		assertTrue( scope.getCollectingStatementInspector().getSqlQueries().get(1).startsWith("update ") );
+		scope.getCollectingStatementInspector().clear();
+
+		scope.inTransaction(s -> {
+			Record r = s.find(Record.class, record2.id);
+			r.comment = null;
+		});
+		scope.getCollectingStatementInspector().assertExecutedCount(2);
+		assertTrue( scope.getCollectingStatementInspector().getSqlQueries().get(1).startsWith("delete ") );
+		scope.getCollectingStatementInspector().clear();
+
+		scope.inTransaction(s -> {
+			SpecialRecord r = s.find(SpecialRecord.class, specialRecord.id);
+			r.validated = null;
+			r.timestamp = System.currentTimeMillis();
+		});
+		scope.getCollectingStatementInspector().assertExecutedCount(2);
+		assertTrue( scope.getCollectingStatementInspector().getSqlQueries().get(1).startsWith("delete ") );
+		scope.getCollectingStatementInspector().clear();
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/secondarytable/SpecialRecord.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/secondarytable/SpecialRecord.java
@@ -1,0 +1,19 @@
+package org.hibernate.orm.test.secondarytable;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.SecondaryTable;
+import org.hibernate.annotations.SecondaryRow;
+
+import java.time.LocalDateTime;
+
+@Entity
+@SecondaryTable(name = "Options")
+@SecondaryTable(name = "`View`")
+@SecondaryRow(table = "`View`", owned = false)
+public class SpecialRecord extends Record {
+    @Column(table = "Options")
+    LocalDateTime validated;
+    @Column(table = "`View`", name="`timestamp`")
+    Long timestamp;
+}


### PR DESCRIPTION
Apparently, the code underlying `@Table(fetch=SELECT)` was removed in H6, but the `fetch` member was not deprecated, and some cruft was left lying around.