### PR TITLE
HHH-15581 Changes for the integration between Hibernate Reactive and ORM 6

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/action/internal/ComparableEntityAction.java
+++ b/hibernate-core/src/main/java/org/hibernate/action/internal/ComparableEntityAction.java
@@ -1,0 +1,17 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.action.internal;
+
+/**
+ * With this interface we can compare entity actions in the queue
+ * even if the implementation doesn't extend {@link EntityAction}.
+ */
+public interface ComparableEntityAction extends Comparable<ComparableEntityAction> {
+	String getEntityName();
+
+	Object getId();
+}

--- a/hibernate-core/src/main/java/org/hibernate/action/internal/EntityAction.java
+++ b/hibernate-core/src/main/java/org/hibernate/action/internal/EntityAction.java
@@ -27,7 +27,7 @@ import org.hibernate.pretty.MessageHelper;
  * @author Gavin King
  */
 public abstract class EntityAction
-		implements Executable, Serializable, Comparable<EntityAction>, AfterTransactionCompletionProcess {
+		implements ComparableEntityAction, Executable, Serializable, AfterTransactionCompletionProcess {
 
 	private final String entityName;
 	private final Object id;
@@ -152,12 +152,13 @@ public abstract class EntityAction
 	}
 
 	@Override
-	public int compareTo(EntityAction action) {
+	public int compareTo(ComparableEntityAction action) {
 		//sort first by entity name
-		final int roleComparison = entityName.compareTo( action.entityName );
-		return roleComparison != 0 ? roleComparison
+		final int roleComparison = entityName.compareTo( action.getEntityName() );
+		return roleComparison != 0
+				? roleComparison
 				//then by id
-				: persister.getIdentifierType().compare( id, action.id );
+				: persister.getIdentifierType().compare( id, action.getId() );
 	}
 
 	/**

--- a/hibernate-core/src/main/java/org/hibernate/action/internal/EntityUpdateAction.java
+++ b/hibernate-core/src/main/java/org/hibernate/action/internal/EntityUpdateAction.java
@@ -112,16 +112,43 @@ public class EntityUpdateAction extends EntityAction {
 				: naturalIdMapping.extractNaturalIdFromEntityState( previousState, session );
 	}
 
-	public Object[] getState() {
+	protected Object[] getState() {
 		return state;
 	}
 
-	public Object[] getPreviousState() {
+	protected Object[] getPreviousState() {
 		return previousState;
+	}
+
+	protected Object getNextVersion() {
+		return nextVersion;
+	}
+
+	protected int[] getDirtyFields() {
+		return dirtyFields;
+	}
+	protected boolean hasDirtyCollection() {
+		return hasDirtyCollection;
+	}
+
+	protected NaturalIdMapping getNaturalIdMapping() {
+		return naturalIdMapping;
+	}
+
+	protected Object getPreviousNaturalIdValues() {
+		return previousNaturalIdValues;
 	}
 
 	public Object getRowId() {
 		return rowId;
+	}
+
+	protected void setLock(SoftLock lock) {
+		this.lock = lock;
+	}
+
+	protected void setCacheEntry(Object cacheEntry) {
+		this.cacheEntry = cacheEntry;
 	}
 
 	@Override
@@ -229,7 +256,7 @@ public class EntityUpdateAction extends EntityAction {
 		}
 	}
 
-	private Object getPreviousVersion() {
+	protected Object getPreviousVersion() {
 		final EntityPersister persister = getPersister();
 		if ( persister.isVersionPropertyGenerated() ) {
 			// we need to grab the version value from the entity, otherwise

--- a/hibernate-core/src/main/java/org/hibernate/event/internal/AbstractVisitor.java
+++ b/hibernate-core/src/main/java/org/hibernate/event/internal/AbstractVisitor.java
@@ -133,7 +133,7 @@ public abstract class AbstractVisitor {
 		return null;
 	}
 
-	final EventSource getSession() {
+	protected final EventSource getSession() {
 		return session;
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/event/internal/DefaultMergeEventListener.java
+++ b/hibernate-core/src/main/java/org/hibernate/event/internal/DefaultMergeEventListener.java
@@ -266,7 +266,7 @@ public class DefaultMergeEventListener
 			super( entity, id, session );
 		}
 		@Override
-		Object processCollection(Object collection, CollectionType collectionType) throws HibernateException {
+		protected Object processCollection(Object collection, CollectionType collectionType) throws HibernateException {
 			if ( collection instanceof PersistentCollection ) {
 				final PersistentCollection<?> coll = (PersistentCollection<?>) collection;
 				final CollectionPersister persister = getSession().getFactory()

--- a/hibernate-core/src/main/java/org/hibernate/event/internal/EventUtil.java
+++ b/hibernate-core/src/main/java/org/hibernate/event/internal/EventUtil.java
@@ -6,7 +6,7 @@
  */
 package org.hibernate.event.internal;
 
-class EventUtil {
+public class EventUtil {
 	public static String getLoggableName(String entityName, Object entity) {
 		return entityName == null ? entity.getClass().getName() : entityName;
 	}

--- a/hibernate-core/src/main/java/org/hibernate/event/internal/WrapVisitor.java
+++ b/hibernate-core/src/main/java/org/hibernate/event/internal/WrapVisitor.java
@@ -52,7 +52,7 @@ public class WrapVisitor extends ProxyVisitor {
 	}
 
 	@Override
-	Object processCollection(Object collection, CollectionType collectionType)
+	protected Object processCollection(Object collection, CollectionType collectionType)
 			throws HibernateException {
 
 		if ( collection == null || collection == LazyPropertyInitializer.UNFETCHED_PROPERTY ) {
@@ -146,7 +146,7 @@ public class WrapVisitor extends ProxyVisitor {
 	}
 
 	@Override
-	void processValue(int i, Object[] values, Type[] types) {
+	protected void processValue(int i, Object[] values, Type[] types) {
 		Object result = processValue( values[i], types[i] );
 		if ( result != null ) {
 			substitute = true;
@@ -155,7 +155,7 @@ public class WrapVisitor extends ProxyVisitor {
 	}
 
 	@Override
-	Object processComponent(Object component, CompositeType componentType) throws HibernateException {
+	protected Object processComponent(Object component, CompositeType componentType) throws HibernateException {
 		if ( component != null ) {
 			Object[] values = componentType.getPropertyValues( component, getSession() );
 			Type[] types = componentType.getSubtypes();

--- a/hibernate-core/src/main/java/org/hibernate/loader/ast/internal/SingleIdLoadPlan.java
+++ b/hibernate-core/src/main/java/org/hibernate/loader/ast/internal/SingleIdLoadPlan.java
@@ -75,6 +75,14 @@ public class SingleIdLoadPlan<T> implements SingleEntityLoadPlan {
 				);
 	}
 
+	protected LockOptions getLockOptions() {
+		return lockOptions;
+	}
+
+	protected List<JdbcParameter> getJdbcParameters() {
+		return jdbcParameters;
+	}
+
 	@Override
 	public Loadable getLoadable() {
 		return persister;

--- a/hibernate-core/src/main/java/org/hibernate/persister/entity/AbstractEntityPersister.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/entity/AbstractEntityPersister.java
@@ -580,15 +580,15 @@ public abstract class AbstractEntityPersister
 		return sqlLazyUpdateStrings;
 	}
 
-	protected ExecuteUpdateResultCheckStyle[] getInsertResultCheckStyles() {
+	public ExecuteUpdateResultCheckStyle[] getInsertResultCheckStyles() {
 		return insertResultCheckStyles;
 	}
 
-	protected ExecuteUpdateResultCheckStyle[] getUpdateResultCheckStyles() {
+	public ExecuteUpdateResultCheckStyle[] getUpdateResultCheckStyles() {
 		return updateResultCheckStyles;
 	}
 
-	protected ExecuteUpdateResultCheckStyle[] getDeleteResultCheckStyles() {
+	public ExecuteUpdateResultCheckStyle[] getDeleteResultCheckStyles() {
 		return deleteResultCheckStyles;
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/sql/exec/internal/JdbcSelectExecutorStandardImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/exec/internal/JdbcSelectExecutorStandardImpl.java
@@ -469,7 +469,7 @@ public class JdbcSelectExecutorStandardImpl implements JdbcSelectExecutor {
 		return -1;
 	}
 
-	private JdbcValues resolveJdbcValuesSource(
+	public JdbcValues resolveJdbcValuesSource(
 			String queryIdentifier,
 			JdbcSelect jdbcSelect,
 			boolean canBeCached,
@@ -588,7 +588,7 @@ public class JdbcSelectExecutorStandardImpl implements JdbcSelectExecutor {
 		}
 	}
 
-	private static class CapturingJdbcValuesMetadata implements JdbcValuesMetadata {
+	public static class CapturingJdbcValuesMetadata implements JdbcValuesMetadata {
 		private final ResultSetAccess resultSetAccess;
 		private String[] columnNames;
 		private BasicType<?>[] types;

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/internal/ResultsHelper.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/internal/ResultsHelper.java
@@ -28,6 +28,7 @@ import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.internal.CoreLogging;
 import org.hibernate.internal.CoreMessageLogger;
+import org.hibernate.metamodel.mapping.JdbcMapping;
 import org.hibernate.metamodel.mapping.ModelPart;
 import org.hibernate.metamodel.mapping.PluralAttributeMapping;
 import org.hibernate.persister.collection.CollectionPersister;
@@ -42,6 +43,7 @@ import org.hibernate.sql.results.graph.AssemblerCreationState;
 import org.hibernate.sql.results.graph.DomainResultAssembler;
 import org.hibernate.sql.results.graph.Initializer;
 import org.hibernate.sql.results.jdbc.spi.JdbcValues;
+import org.hibernate.sql.results.jdbc.spi.JdbcValuesMapping;
 import org.hibernate.sql.results.spi.RowReader;
 import org.hibernate.sql.results.spi.RowTransformer;
 import org.hibernate.stat.spi.StatisticsImplementor;
@@ -59,12 +61,21 @@ public class ResultsHelper {
 			RowTransformer<R> rowTransformer,
 			Class<R> transformedResultJavaType,
 			JdbcValues jdbcValues) {
+		return createRowReader( executionContext, lockOptions, rowTransformer, transformedResultJavaType, jdbcValues.getValuesMapping());
+	}
+
+	public static <R> RowReader<R> createRowReader(
+			ExecutionContext executionContext,
+			LockOptions lockOptions,
+			RowTransformer<R> rowTransformer,
+			Class<R> transformedResultJavaType,
+			JdbcValuesMapping jdbcValuesMapping) {
 		final SessionFactoryImplementor sessionFactory = executionContext.getSession().getFactory();
 
 		final Map<NavigablePath, Initializer> initializerMap = new LinkedHashMap<>();
 		final List<Initializer> initializers = new ArrayList<>();
 
-		final List<DomainResultAssembler<?>> assemblers = jdbcValues.getValuesMapping().resolveAssemblers(
+		final List<DomainResultAssembler<?>> assemblers = jdbcValuesMapping.resolveAssemblers(
 				new AssemblerCreationState() {
 
 					@Override

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/jdbc/internal/DeferredResultSetAccess.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/jdbc/internal/DeferredResultSetAccess.java
@@ -140,6 +140,14 @@ public class DeferredResultSetAccess extends AbstractResultSetAccess {
 		}
 	}
 
+	public LimitHandler getLimitHandler() {
+		return limitHandler;
+	}
+
+	public Limit getLimit() {
+		return limit;
+	}
+
 	@Override
 	public ResultSet getResultSet() {
 		if ( resultSet == null ) {


### PR DESCRIPTION
A list of changes I need to make ORM 6 work with Hibernate Reactive.

I had to add a new interface so that I can create different actions for the insert operations: https://github.com/hibernate/hibernate-orm/commit/d098526e3d78f7f223b76e843d8ae7705526723d and https://github.com/hibernate/hibernate-orm/commit/076006120149b80ce97db435f0ecf8cb9613d32f

That's because in Hibernate Reactive we have an  interface `ReactiveEntityInsertAction` and it wasn't possible to add it to the queue when there was only using `Comparable<EntityAction>` (if somebody has a solution, I'm listening).

All the other changes make it possible for Hibernate Reactive to reuse or overrides some methods.

I've pushed the Hibernate Reactive branch upstream: https://github.com/hibernate/hibernate-reactive/tree/wip/ORM-6

I haven't created a JIRA yet, but if we agree with these changes I'm going to create one.

Thanks