### PR TITLE
HHH-15582 SpannerDialect, schema update tries to create existing tables

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/dialect/SpannerDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/SpannerDialect.java
@@ -631,8 +631,8 @@ public class SpannerDialect extends Dialect {
 
 	@Override
 	public SchemaNameResolver getSchemaNameResolver() {
-		throw new UnsupportedOperationException(
-				"No schema name resolver supported by " + getClass().getName() );
+		// Spanner does not have a notion of database name schemas, so return "".
+		return (connection, dialect) -> "";
 	}
 
 	@Override


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-15582
throwing the exception causes the `JdbcEnvironmentInitiator` to initialize the `JdbcEnvironmentImpl` without using the JDBC metadata causing an issue to determine the correct `IdentifierCaseStrategy`, this lead to not being able to correctly compare the name coming from the database metadata during the schema update.