### PR TITLE
HHH-15584 use count_big() on Sybase and SQL Server

### DIFF
--- a/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/SQLServerLegacyDialect.java
+++ b/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/SQLServerLegacyDialect.java
@@ -239,6 +239,7 @@ public class SQLServerLegacyDialect extends AbstractTransactSQLDialect {
 						this,
 						queryEngine.getTypeConfiguration(),
 						SqlAstNodeRenderingMode.DEFAULT,
+						"count_big",
 						"+",
 						"varchar(max)",
 						false

--- a/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/SybaseLegacyDialect.java
+++ b/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/SybaseLegacyDialect.java
@@ -212,6 +212,7 @@ public class SybaseLegacyDialect extends AbstractTransactSQLDialect {
 						this,
 						queryEngine.getTypeConfiguration(),
 						SqlAstNodeRenderingMode.DEFAULT,
+						"count_big",
 						"+",
 						"varchar(16384)",
 						false

--- a/hibernate-core/src/main/java/org/hibernate/dialect/SQLServerDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/SQLServerDialect.java
@@ -257,6 +257,7 @@ public class SQLServerDialect extends AbstractTransactSQLDialect {
 						this,
 						queryEngine.getTypeConfiguration(),
 						SqlAstNodeRenderingMode.DEFAULT,
+						"count_big",
 						"+",
 						"varchar(max)",
 						false

--- a/hibernate-core/src/main/java/org/hibernate/dialect/SybaseDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/SybaseDialect.java
@@ -215,6 +215,7 @@ public class SybaseDialect extends AbstractTransactSQLDialect {
 						this,
 						queryEngine.getTypeConfiguration(),
 						SqlAstNodeRenderingMode.DEFAULT,
+						"count_big",
 						"+",
 						"varchar(16384)",
 						false

--- a/hibernate-core/src/main/java/org/hibernate/dialect/function/CountFunction.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/function/CountFunction.java
@@ -44,6 +44,7 @@ public class CountFunction extends AbstractSqmSelfRenderingFunctionDescriptor {
 
 	private final Dialect dialect;
 	private final SqlAstNodeRenderingMode defaultArgumentRenderingMode;
+	private final String countFunctionName;
 	private final String concatOperator;
 	private final String concatArgumentCastType;
 	private final boolean castDistinctStringConcat;
@@ -63,6 +64,25 @@ public class CountFunction extends AbstractSqmSelfRenderingFunctionDescriptor {
 			String concatOperator,
 			String concatArgumentCastType,
 			boolean castDistinctStringConcat) {
+		this(
+				dialect,
+				typeConfiguration,
+				defaultArgumentRenderingMode,
+				"count",
+				concatOperator,
+				concatArgumentCastType,
+				castDistinctStringConcat
+		);
+	}
+
+	public CountFunction(
+			Dialect dialect,
+			TypeConfiguration typeConfiguration,
+			SqlAstNodeRenderingMode defaultArgumentRenderingMode,
+			String countFunctionName,
+			String concatOperator,
+			String concatArgumentCastType,
+			boolean castDistinctStringConcat) {
 		super(
 				"count",
 				FunctionKind.AGGREGATE,
@@ -74,6 +94,7 @@ public class CountFunction extends AbstractSqmSelfRenderingFunctionDescriptor {
 		);
 		this.dialect = dialect;
 		this.defaultArgumentRenderingMode = defaultArgumentRenderingMode;
+		this.countFunctionName = countFunctionName;
 		this.concatOperator = concatOperator;
 		this.concatArgumentCastType = concatArgumentCastType;
 		this.castDistinctStringConcat = castDistinctStringConcat;
@@ -92,7 +113,8 @@ public class CountFunction extends AbstractSqmSelfRenderingFunctionDescriptor {
 			SqlAstTranslator<?> translator) {
 		final boolean caseWrapper = filter != null && !translator.supportsFilterClause();
 		final SqlAstNode arg = sqlAstArguments.get( 0 );
-		sqlAppender.appendSql( "count(" );
+		sqlAppender.appendSql( countFunctionName );
+		sqlAppender.appendSql( '(' );
 		final SqlTuple tuple;
 		if ( arg instanceof Distinct ) {
 			sqlAppender.appendSql( "distinct " );


### PR DESCRIPTION
The HQL `count()` function has type `Long`, which maps naturally to `count_big()` in TSQL.