### PR TITLE
HHH-15591 Unidirectional @OneToMany with @OrderColumn still throwing ConstraintViolationException (unique index violation)

### DIFF
--- a/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/mapping/UnidirectionalOneToManyOrderColumnTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/mapping/UnidirectionalOneToManyOrderColumnTest.java
@@ -180,6 +180,59 @@ public class UnidirectionalOneToManyOrderColumnTest {
 		);
 	}
 
+	@Test
+	public void testSwapElementsAtZeroAndOne(EntityManagerFactoryScope scope) {
+		long parentId = scope.fromTransaction(
+				entityManager -> {
+					ParentData parent = new ParentData();
+					entityManager.persist( parent );
+
+					String[] childrenStr = new String[] {"One", "Two"};
+					for ( String str : childrenStr ) {
+						ChildData child = new ChildData( str );
+						entityManager.persist( child );
+						parent.getChildren().add( child );
+					}
+
+					entityManager.flush();
+
+					List<ChildData> children = parent.getChildren();
+					ChildData child0 = children.get( 0 );
+					ChildData child1 = children.get( 1 );
+					children.set(0, child1);
+					children.set(1, child0);
+					
+					return parent.id;
+				}
+		);
+		// if the above works, then test on {"Two", "One"}
+	}
+
+	@Test
+	public void testAddAtZeroDeleteAtTwo(EntityManagerFactoryScope scope) {
+		long parentId = scope.fromTransaction(
+				entityManager -> {
+					ParentData parent = new ParentData();
+					entityManager.persist( parent );
+
+					String[] childrenStr = new String[] {"One", "Two"};
+					for ( String str : childrenStr ) {
+						ChildData child = new ChildData( str );
+						entityManager.persist( child );
+						parent.getChildren().add( child );
+					}
+
+					entityManager.flush();
+
+					List<ChildData> children = parent.getChildren();
+					children.add( 0, new ChildData( "Zero" ) );
+					children.remove( 2 );
+					return parent.id;
+				}
+		);
+		// if the above works, then test on {"Zero", "One"}
+	}
+
 	@Entity(name = "ParentData")
 	@Table(name = "PARENT")
 	public static class ParentData {


### PR DESCRIPTION
added two tests in `UnidirectionalOneToManyOrderColumnTest`, namely `testSwapElementsAtZeroAndOne` and `testAddAtZeroDeleteAtTwo`

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-15591
<!-- Hibernate GitHub Bot issue links end -->