### PR TITLE
fix(sec): upgrade org.hibernate:hibernate-core to 5.4.24.Final

### DIFF
--- a/documentation/src/main/asciidoc/quickstart/tutorials/entitymanager/pom.xml
+++ b/documentation/src/main/asciidoc/quickstart/tutorials/entitymanager/pom.xml
@@ -4,8 +4,7 @@
   ~
   ~ License: GNU Lesser General Public License (LGPL), version 2.1 or later.
   ~ See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
-  -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  --><project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
     <modelVersion>4.0.0</modelVersion>
 
@@ -29,7 +28,7 @@
         <dependency>
             <groupId>org.hibernate</groupId>
             <artifactId>hibernate-core</artifactId>
-            <version>$version</version>
+            <version>5.4.24.Final</version>
         </dependency>
     </dependencies>
 

--- a/documentation/src/main/asciidoc/quickstart/tutorials/pom.xml
+++ b/documentation/src/main/asciidoc/quickstart/tutorials/pom.xml
@@ -4,8 +4,7 @@
   ~
   ~ License: GNU Lesser General Public License (LGPL), version 2.1 or later.
   ~ See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
-  -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  --><project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
     <modelVersion>4.0.0</modelVersion>
 
@@ -31,7 +30,7 @@
         <dependency>
             <groupId>org.hibernate</groupId>
             <artifactId>hibernate-core</artifactId>
-            <version>$version</version>
+            <version>5.4.24.Final</version>
         </dependency>
 
         <!-- Hibernate uses jboss-logging for logging, for the tutorials we will use the sl4fj-simple backend -->


### PR DESCRIPTION
### What happened？
There are 2 security vulnerabilities found in org.hibernate:hibernate-core $version
- [CVE-2020-25638](https://www.oscs1024.com/hd/CVE-2020-25638)
- [CVE-2019-14900](https://www.oscs1024.com/hd/CVE-2019-14900)


### What did I do？
Upgrade org.hibernate:hibernate-core from $version to 5.4.24.Final for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS