### PR TITLE
fix(sec): upgrade com.h2database:h2 to 2.1.210

### DIFF
--- a/documentation/src/main/asciidoc/quickstart/tutorials/pom.xml
+++ b/documentation/src/main/asciidoc/quickstart/tutorials/pom.xml
@@ -52,7 +52,7 @@
         <dependency>
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>
-            <version>$h2</version>
+            <version>2.1.210</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
### What happened？
There are 2 security vulnerabilities found in com.h2database:h2 $h2
- [CVE-2022-23221](https://www.oscs1024.com/hd/CVE-2022-23221)
- [MPS-2022-52737](https://www.oscs1024.com/hd/MPS-2022-52737)


### What did I do？
Upgrade com.h2database:h2 from $h2 to 2.1.210 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS