### PR TITLE
HHH-15613 remove 'lateral' from fromRoot rule

### DIFF
--- a/hibernate-core/src/main/antlr/org/hibernate/grammars/hql/HqlParser.g4
+++ b/hibernate-core/src/main/antlr/org/hibernate/grammars/hql/HqlParser.g4
@@ -176,8 +176,8 @@ entityWithJoins
  * A root entity declaration in the 'from' clause, with optional identification variable
  */
 fromRoot
-	: entityName variable?									# RootEntity
-	| LATERAL? LEFT_PAREN subquery RIGHT_PAREN variable?	# RootSubquery
+	: entityName variable?							# RootEntity
+	| LEFT_PAREN subquery RIGHT_PAREN variable?		# RootSubquery
 	;
 
 /**

--- a/hibernate-core/src/main/java/org/hibernate/query/criteria/JpaDerivedFrom.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/criteria/JpaDerivedFrom.java
@@ -18,12 +18,5 @@ public interface JpaDerivedFrom<T> extends JpaFrom<T,T> {
 	 * The subquery part for this derived from node.
 	 */
 	JpaSubQuery<T> getQueryPart();
-
-	/**
-	 * Specifies whether the subquery part can access previous from node aliases.
-	 * Normally, subqueries in the from clause are unable to access other from nodes,
-	 * but when specifying them as lateral, they are allowed to do so.
-	 * Refer to the SQL standard definition of LATERAL for more details.
-	 */
-	boolean isLateral();
+	
 }

--- a/hibernate-core/src/main/java/org/hibernate/query/criteria/JpaDerivedJoin.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/criteria/JpaDerivedJoin.java
@@ -15,4 +15,12 @@ import org.hibernate.query.sqm.tree.from.SqmQualifiedJoin;
 @Incubating
 public interface JpaDerivedJoin<T> extends JpaDerivedFrom<T>, SqmQualifiedJoin<T,T>, JpaJoinedFrom<T,T> {
 
+	/**
+	 * Specifies whether the subquery part can access previous from node aliases.
+	 * Normally, subqueries in the from clause are unable to access other from nodes,
+	 * but when specifying them as lateral, they are allowed to do so.
+	 * Refer to the SQL standard definition of LATERAL for more details.
+	 */
+	boolean isLateral();
+
 }

--- a/hibernate-core/src/main/java/org/hibernate/query/criteria/JpaSelectCriteria.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/criteria/JpaSelectCriteria.java
@@ -38,26 +38,6 @@ public interface JpaSelectCriteria<T> extends AbstractQuery<T>, JpaCriteriaBase 
 	 */
 	<X> JpaDerivedRoot<X> from(Subquery<X> subquery);
 
-	/**
-	 * Create and add a query root corresponding to the given lateral subquery,
-	 * forming a cartesian product with any existing roots.
-	 *
-	 * @param subquery  the subquery
-	 * @return query root corresponding to the given subquery
-	 */
-	<X> JpaDerivedRoot<X> fromLateral(Subquery<X> subquery);
-
-	/**
-	 * Create and add a query root corresponding to the given subquery,
-	 * forming a cartesian product with any existing roots.
-	 * If the subquery is marked as lateral, it may access previous from elements.
-	 *
-	 * @param subquery  the subquery
-	 * @param lateral whether to allow access to previous from elements in the subquery
-	 * @return query root corresponding to the given subquery
-	 */
-	<X> JpaDerivedRoot<X> from(Subquery<X> subquery, boolean lateral);
-
 	@Override
 	JpaSelectCriteria<T> distinct(boolean distinct);
 

--- a/hibernate-core/src/main/java/org/hibernate/query/hql/internal/QuerySplitter.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/hql/internal/QuerySplitter.java
@@ -400,8 +400,7 @@ public class QuerySplitter {
 			}
 			final SqmDerivedRoot<?> copy = new SqmDerivedRoot<>(
 					(SqmSubQuery<?>) sqmRoot.getQueryPart().accept( this ),
-					sqmRoot.getExplicitAlias(),
-					sqmRoot.isLateral()
+					sqmRoot.getExplicitAlias()
 			);
 			getProcessingStateStack().getCurrent().getPathRegistry().register( copy );
 			sqmFromCopyMap.put( sqmRoot, copy );

--- a/hibernate-core/src/main/java/org/hibernate/query/hql/internal/SemanticQueryBuilder.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/hql/internal/SemanticQueryBuilder.java
@@ -1661,10 +1661,8 @@ public class SemanticQueryBuilder<R> extends HqlParserBaseVisitor<Object> implem
 					StrictJpaComplianceViolation.Type.FROM_SUBQUERY
 			);
 		}
-		final ParseTree firstChild = ctx.getChild( 0 );
-		final boolean lateral = ( (TerminalNode) firstChild ).getSymbol().getType() == HqlParser.LATERAL;
-		final int subqueryIndex = lateral ? 2 : 1;
-		final SqmSubQuery<?> subQuery = (SqmSubQuery<?>) ctx.getChild( subqueryIndex ).accept( this );
+
+		final SqmSubQuery<?> subQuery = (SqmSubQuery<?>) ctx.getChild(1).accept( this );
 
 		final ParseTree lastChild = ctx.getChild( ctx.getChildCount() - 1 );
 		final HqlParser.VariableContext identificationVariableDefContext;
@@ -1680,7 +1678,7 @@ public class SemanticQueryBuilder<R> extends HqlParserBaseVisitor<Object> implem
 
 		final SqmCreationProcessingState processingState = processingStateStack.getCurrent();
 		final SqmPathRegistry pathRegistry = processingState.getPathRegistry();
-		final SqmRoot<?> sqmRoot = new SqmDerivedRoot<>( subQuery, alias, lateral );
+		final SqmRoot<?> sqmRoot = new SqmDerivedRoot<>( subQuery, alias );
 
 		pathRegistry.register( sqmRoot );
 

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/sql/BaseSqmToSqlAstConverter.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/sql/BaseSqmToSqlAstConverter.java
@@ -2562,7 +2562,7 @@ public abstract class BaseSqmToSqlAstConverter<T extends Statement> extends Base
 					identifierVariable,
 					columnNames,
 					tableGroupProducer.getCompatibleTableExpressions(),
-					derivedRoot.isLateral(),
+					false,
 					true,
 					creationContext.getSessionFactory()
 			);

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/domain/SqmDerivedRoot.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/domain/SqmDerivedRoot.java
@@ -28,16 +28,13 @@ import org.hibernate.spi.NavigablePath;
 public class SqmDerivedRoot<T> extends SqmRoot<T> implements JpaDerivedRoot<T> {
 
 	private final SqmSubQuery<T> subQuery;
-	private final boolean lateral;
 
 	public SqmDerivedRoot(
 			SqmSubQuery<T> subQuery,
-			String alias,
-			boolean lateral) {
+			String alias) {
 		this(
 				SqmCreationHelper.buildRootNavigablePath( "<<derived>>", alias ),
 				subQuery,
-				lateral,
 				new AnonymousTupleType<>( subQuery ),
 				alias
 		);
@@ -46,7 +43,6 @@ public class SqmDerivedRoot<T> extends SqmRoot<T> implements JpaDerivedRoot<T> {
 	protected SqmDerivedRoot(
 			NavigablePath navigablePath,
 			SqmSubQuery<T> subQuery,
-			boolean lateral,
 			SqmPathSource<T> pathSource,
 			String alias) {
 		super(
@@ -57,7 +53,6 @@ public class SqmDerivedRoot<T> extends SqmRoot<T> implements JpaDerivedRoot<T> {
 				subQuery.nodeBuilder()
 		);
 		this.subQuery = subQuery;
-		this.lateral = lateral;
 	}
 
 	@Override
@@ -71,7 +66,6 @@ public class SqmDerivedRoot<T> extends SqmRoot<T> implements JpaDerivedRoot<T> {
 				new SqmDerivedRoot<>(
 						getNavigablePath(),
 						getQueryPart().copy( context ),
-						isLateral(),
 						getReferencedPathSource(),
 						getExplicitAlias()
 				)
@@ -83,11 +77,6 @@ public class SqmDerivedRoot<T> extends SqmRoot<T> implements JpaDerivedRoot<T> {
 	@Override
 	public SqmSubQuery<T> getQueryPart() {
 		return subQuery;
-	}
-
-	@Override
-	public boolean isLateral() {
-		return lateral;
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/select/AbstractSqmSelectQuery.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/select/AbstractSqmSelectQuery.java
@@ -143,18 +143,8 @@ public abstract class AbstractSqmSelectQuery<T>
 
 	@Override
 	public <X> SqmDerivedRoot<X> from(Subquery<X> subquery) {
-		return from( subquery, false );
-	}
-
-	@Override
-	public <X> SqmDerivedRoot<X> fromLateral(Subquery<X> subquery) {
-		return from( subquery, true );
-	}
-
-	@Override
-	public <X> SqmDerivedRoot<X> from(Subquery<X> subquery, boolean lateral) {
 		validateComplianceFromSubQuery();
-		final SqmDerivedRoot<X> root = new SqmDerivedRoot<>( (SqmSubQuery<X>) subquery, null, lateral );
+		final SqmDerivedRoot<X> root = new SqmDerivedRoot<>( (SqmSubQuery<X>) subquery, null );
 		addRoot( root );
 		return root;
 	}


### PR DESCRIPTION
This is currently ignored by HQL, is undocumented, and untested, and anyway would be a synonym for `join lateral`.

Also squash some warnings in `SemanticQueryBuilder`.