### PR TITLE
HHH-12930 much more flexible handling of associations on non-primary keys

### DIFF
--- a/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/refcolnames/basics/BasicsRefColNamesTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/refcolnames/basics/BasicsRefColNamesTest.java
@@ -1,0 +1,36 @@
+package org.hibernate.orm.test.annotations.refcolnames.basics;
+
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+@DomainModel(annotatedClasses = {Region.class, Town.class})
+@SessionFactory
+public class BasicsRefColNamesTest {
+    @Test
+    public void test(SessionFactoryScope scope) {
+        Region region = new Region();
+        PostalCode postalCode = new PostalCode();
+        postalCode.countryCode = "ES";
+        postalCode.zipCode = 69;
+        region.countryCode = postalCode.countryCode;
+        region.zipCode = postalCode.zipCode;
+        Town town = new Town();
+        TownCode townCode = new TownCode();
+        townCode.town = "Barcelona";
+        townCode.countryCode = "ES";
+        townCode.zipCode = 69;
+        town.region = region;
+        town.townCode = townCode;
+        scope.inTransaction(s -> {
+            s.persist(region);
+            s.persist(town);
+        });
+        scope.inTransaction(s -> {
+            Town t = s.createQuery("from Town join fetch region", Town.class).getSingleResult();
+            Assertions.assertNotNull(t);
+        });
+    }
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/refcolnames/basics/PostalCode.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/refcolnames/basics/PostalCode.java
@@ -1,0 +1,13 @@
+package org.hibernate.orm.test.annotations.refcolnames.basics;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import jakarta.persistence.MappedSuperclass;
+
+@Embeddable @MappedSuperclass
+class PostalCode {
+    @Column(name="country_code", nullable = false)
+    String countryCode;
+    @Column(name="zip_code", nullable = false)
+    int zipCode;
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/refcolnames/basics/Region.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/refcolnames/basics/Region.java
@@ -1,0 +1,28 @@
+package org.hibernate.orm.test.annotations.refcolnames.basics;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import org.hibernate.annotations.NaturalId;
+
+@Entity
+class Region {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    @Column(name = "id", nullable = false)
+    int id;
+
+    String name;
+
+    @NaturalId
+    @Column(name = "country_code", nullable = false)
+    String countryCode;
+
+    @NaturalId
+    @Column(name = "zip_code", nullable = false)
+    int zipCode;
+
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/refcolnames/basics/Town.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/refcolnames/basics/Town.java
@@ -1,0 +1,31 @@
+package org.hibernate.orm.test.annotations.refcolnames.basics;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embedded;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import org.hibernate.annotations.NaturalId;
+
+@Entity
+class Town {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    @Column(name = "id", nullable = false)
+    Integer id;
+
+    String name;
+
+    @NaturalId
+    @Embedded
+    TownCode townCode;
+
+    @ManyToOne
+    @JoinColumn(name = "country_code", referencedColumnName = "country_code", nullable = false, insertable = false, updatable = false)
+    @JoinColumn(name = "zip_code", referencedColumnName = "zip_code", nullable = false, insertable = false, updatable = false)
+    Region region;
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/refcolnames/basics/TownCode.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/refcolnames/basics/TownCode.java
@@ -1,0 +1,8 @@
+package org.hibernate.orm.test.annotations.refcolnames.basics;
+
+import jakarta.persistence.Embeddable;
+
+@Embeddable
+class TownCode extends PostalCode {
+    String town;
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/refcolnames/embedded/EmbeddedRefColNamesTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/refcolnames/embedded/EmbeddedRefColNamesTest.java
@@ -1,0 +1,35 @@
+package org.hibernate.orm.test.annotations.refcolnames.embedded;
+
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+@DomainModel(annotatedClasses = {Region.class, Town.class})
+@SessionFactory
+public class EmbeddedRefColNamesTest {
+    @Test
+    public void test(SessionFactoryScope scope) {
+        Region region = new Region();
+        PostalCode postalCode = new PostalCode();
+        postalCode.countryCode = "ES";
+        postalCode.zipCode = 69;
+        region.postalCode = postalCode;
+        Town town = new Town();
+        TownCode townCode = new TownCode();
+        townCode.town = "Barcelona";
+        townCode.countryCode = "ES";
+        townCode.zipCode = 69;
+        town.region = region;
+        town.townCode = townCode;
+        scope.inTransaction(s -> {
+            s.persist(region);
+            s.persist(town);
+        });
+        scope.inTransaction(s -> {
+            Town t = s.createQuery("from Town join fetch region", Town.class).getSingleResult();
+            Assertions.assertNotNull(t);
+        });
+    }
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/refcolnames/embedded/PostalCode.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/refcolnames/embedded/PostalCode.java
@@ -1,0 +1,13 @@
+package org.hibernate.orm.test.annotations.refcolnames.embedded;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import jakarta.persistence.MappedSuperclass;
+
+@Embeddable @MappedSuperclass
+class PostalCode {
+    @Column(name="country_code", nullable = false)
+    String countryCode;
+    @Column(name="zip_code", nullable = false)
+    int zipCode;
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/refcolnames/embedded/Region.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/refcolnames/embedded/Region.java
@@ -1,0 +1,25 @@
+package org.hibernate.orm.test.annotations.refcolnames.embedded;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embedded;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import org.hibernate.annotations.NaturalId;
+
+@Entity
+class Region {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    @Column(name = "id", nullable = false)
+    int id;
+
+    String name;
+
+    @NaturalId
+    @Embedded
+    PostalCode postalCode;
+
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/refcolnames/embedded/Town.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/refcolnames/embedded/Town.java
@@ -1,0 +1,31 @@
+package org.hibernate.orm.test.annotations.refcolnames.embedded;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embedded;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import org.hibernate.annotations.NaturalId;
+
+@Entity
+class Town {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    @Column(name = "id", nullable = false)
+    Integer id;
+
+    String name;
+
+    @NaturalId
+    @Embedded
+    TownCode townCode;
+
+    @ManyToOne
+    @JoinColumn(name = "country_code", referencedColumnName = "country_code", nullable = false, insertable = false, updatable = false)
+    @JoinColumn(name = "zip_code", referencedColumnName = "zip_code", nullable = false, insertable = false, updatable = false)
+    Region region;
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/refcolnames/embedded/TownCode.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/refcolnames/embedded/TownCode.java
@@ -1,0 +1,8 @@
+package org.hibernate.orm.test.annotations.refcolnames.embedded;
+
+import jakarta.persistence.Embeddable;
+
+@Embeddable
+class TownCode extends PostalCode {
+    String town;
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/refcolnames/embeddedid/EmbeddedIdRefColNamesTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/refcolnames/embeddedid/EmbeddedIdRefColNamesTest.java
@@ -1,0 +1,35 @@
+package org.hibernate.orm.test.annotations.refcolnames.embeddedid;
+
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+@DomainModel(annotatedClasses = {Region.class, Town.class})
+@SessionFactory
+public class EmbeddedIdRefColNamesTest {
+    @Test
+    public void test(SessionFactoryScope scope) {
+        Region region = new Region();
+        PostalCode postalCode = new PostalCode();
+        postalCode.countryCode = "ES";
+        postalCode.zipCode = 69;
+        region.postalCode = postalCode;
+        Town town = new Town();
+        TownCode townCode = new TownCode();
+        townCode.town = "Barcelona";
+        townCode.countryCode = "ES";
+        townCode.zipCode = 69;
+        town.region = region;
+        town.townCode = townCode;
+        scope.inTransaction(s -> {
+            s.persist(region);
+            s.persist(town);
+        });
+        scope.inTransaction(s -> {
+            Town t = s.createQuery("from Town join fetch region", Town.class).getSingleResult();
+            Assertions.assertNotNull(t);
+        });
+    }
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/refcolnames/embeddedid/PostalCode.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/refcolnames/embeddedid/PostalCode.java
@@ -1,0 +1,13 @@
+package org.hibernate.orm.test.annotations.refcolnames.embeddedid;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import jakarta.persistence.MappedSuperclass;
+
+@Embeddable @MappedSuperclass
+class PostalCode {
+    @Column(name="country_code")
+    String countryCode;
+    @Column(name="zip_code")
+    int zipCode;
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/refcolnames/embeddedid/Region.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/refcolnames/embeddedid/Region.java
@@ -1,0 +1,10 @@
+package org.hibernate.orm.test.annotations.refcolnames.embeddedid;
+
+import jakarta.persistence.EmbeddedId;
+import jakarta.persistence.Entity;
+
+@Entity
+class Region {
+    @EmbeddedId
+    PostalCode postalCode;
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/refcolnames/embeddedid/Town.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/refcolnames/embeddedid/Town.java
@@ -1,0 +1,17 @@
+package org.hibernate.orm.test.annotations.refcolnames.embeddedid;
+
+import jakarta.persistence.EmbeddedId;
+import jakarta.persistence.Entity;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+
+@Entity
+class Town {
+    @EmbeddedId
+    TownCode townCode;
+
+    @ManyToOne
+    @JoinColumn(name = "zip_code", referencedColumnName = "zip_code", insertable = false, updatable = false)
+    @JoinColumn(name = "country_code", referencedColumnName = "country_code", insertable = false, updatable = false)
+    Region region;
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/refcolnames/embeddedid/TownCode.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/refcolnames/embeddedid/TownCode.java
@@ -1,0 +1,8 @@
+package org.hibernate.orm.test.annotations.refcolnames.embeddedid;
+
+import jakarta.persistence.Embeddable;
+
+@Embeddable
+class TownCode extends PostalCode {
+    String town;
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/refcolnames/mixed/MixedRefColNamesTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/refcolnames/mixed/MixedRefColNamesTest.java
@@ -1,0 +1,36 @@
+package org.hibernate.orm.test.annotations.refcolnames.mixed;
+
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+@DomainModel(annotatedClasses = {Region.class, Town.class})
+@SessionFactory
+public class MixedRefColNamesTest {
+    @Test
+    public void test(SessionFactoryScope scope) {
+        Region region = new Region();
+        PostalCode postalCode = new PostalCode();
+        postalCode.countryCode = "ES";
+        postalCode.zipCode = 69;
+        region.postalCode = postalCode;
+        Town town = new Town();
+        TownCode townCode = new TownCode();
+        townCode.town = "Barcelona";
+        townCode.countryCode = "ES";
+        townCode.zipCode = 69;
+        town.region = region;
+        town.townCode = townCode;
+        scope.inTransaction(s -> {
+            s.persist(region);
+            town.regionId = region.id;
+            s.persist(town);
+        });
+        scope.inTransaction(s -> {
+            Town t = s.createQuery("from Town join fetch region", Town.class).getSingleResult();
+            Assertions.assertNotNull(t);
+        });
+    }
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/refcolnames/mixed/PostalCode.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/refcolnames/mixed/PostalCode.java
@@ -1,0 +1,13 @@
+package org.hibernate.orm.test.annotations.refcolnames.mixed;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import jakarta.persistence.MappedSuperclass;
+
+@Embeddable @MappedSuperclass
+class PostalCode {
+    @Column(name="country_code", nullable = false)
+    String countryCode;
+    @Column(name="zip_code", nullable = false)
+    int zipCode;
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/refcolnames/mixed/Region.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/refcolnames/mixed/Region.java
@@ -1,0 +1,25 @@
+package org.hibernate.orm.test.annotations.refcolnames.mixed;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embedded;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import org.hibernate.annotations.NaturalId;
+
+@Entity
+class Region {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    @Column(name = "id", nullable = false)
+    int id;
+
+    String name;
+
+    @NaturalId
+    @Embedded
+    PostalCode postalCode;
+
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/refcolnames/mixed/Town.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/refcolnames/mixed/Town.java
@@ -1,0 +1,35 @@
+package org.hibernate.orm.test.annotations.refcolnames.mixed;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embedded;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import org.hibernate.annotations.NaturalId;
+
+@Entity
+class Town {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    @Column(name = "id", nullable = false)
+    Integer id;
+
+    String name;
+
+    @NaturalId
+    @Embedded
+    TownCode townCode;
+
+    @Column(name = "region_id", nullable = false)
+    int regionId;
+
+    @ManyToOne
+    @JoinColumn(name = "region_id", referencedColumnName = "id", nullable = false, insertable = false, updatable = false)
+    @JoinColumn(name = "country_code", referencedColumnName = "country_code", nullable = false, insertable = false, updatable = false)
+    @JoinColumn(name = "zip_code", referencedColumnName = "zip_code", nullable = false, insertable = false, updatable = false)
+    Region region;
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/refcolnames/mixed/TownCode.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/refcolnames/mixed/TownCode.java
@@ -1,0 +1,8 @@
+package org.hibernate.orm.test.annotations.refcolnames.mixed;
+
+import jakarta.persistence.Embeddable;
+
+@Embeddable
+class TownCode extends PostalCode {
+    String town;
+}


### PR DESCRIPTION
So this was *really* tricky to get right, but now:

- we handle embeddables forming part of the unique key in the target entity
- error messages are *much* improved (the previous error was incomprehensible)
- the code is *much* more robust and easier to understand
- I have left *copious* comments in the code explaining WFT is going on, because it was previously really difficult to understand