### PR TITLE
Fix incorrectly reported deprecated setting

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/boot/internal/MetadataBuilderImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/internal/MetadataBuilderImpl.java
@@ -66,7 +66,6 @@ import org.hibernate.id.factory.IdentifierGeneratorFactory;
 import org.hibernate.id.factory.internal.StandardIdentifierGeneratorFactory;
 import org.hibernate.internal.CoreLogging;
 import org.hibernate.internal.CoreMessageLogger;
-import org.hibernate.internal.log.DeprecationLogger;
 import org.hibernate.internal.util.StringHelper;
 import org.hibernate.internal.util.collections.CollectionHelper;
 import org.hibernate.metamodel.CollectionClassification;
@@ -622,11 +621,6 @@ public class MetadataBuilderImpl implements MetadataBuilderImplementor, TypeCont
 								if ( value == null ) {
 									return null;
 								}
-
-								DeprecationLogger.DEPRECATION_LOGGER.deprecatedSetting(
-										AvailableSettings.JPA_SHARED_CACHE_MODE,
-										AvailableSettings.JAKARTA_SHARED_CACHE_MODE
-								);
 
 								if ( value instanceof SharedCacheMode ) {
 									return (SharedCacheMode) value;


### PR DESCRIPTION
The `javax.persistence.sharedCache.mode` setting reported here is not set by the user but [by Hibernate itself](https://github.com/hibernate/hibernate-orm/blob/ba48130c3f58acf64fa7069205f67a68eeb747ba/hibernate-core/src/main/java/org/hibernate/jpa/boot/internal/EntityManagerFactoryBuilderImpl.java#L610) . User settings would already be reported [here](https://github.com/hibernate/hibernate-orm/blob/ba48130c3f58acf64fa7069205f67a68eeb747ba/hibernate-core/src/main/java/org/hibernate/jpa/boot/internal/EntityManagerFactoryBuilderImpl.java#L606).