### PR TITLE
HHH-15655 HHH-15656 ByteBuddyState should use privileged action when defining classes and same for calling ScheduledExecutorService.shutdown

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/bytecode/internal/bytebuddy/ByteBuddyState.java
+++ b/hibernate-core/src/main/java/org/hibernate/bytecode/internal/bytebuddy/ByteBuddyState.java
@@ -189,10 +189,24 @@ public final class ByteBuddyState {
 		return cache.findOrInsert(
 				referenceClass.getClassLoader(),
 				cacheKey,
-				() -> make( makeProxyFunction.apply( byteBuddy ) )
-						.load( referenceClass.getClassLoader(), resolveClassLoadingStrategy( referenceClass ) )
-						.getLoaded(),
-				cache );
+				() -> {
+					PrivilegedAction<Class<?>> delegateToPrivilegedAction = new PrivilegedAction<Class<?>>() {
+						@Override
+						public Class<?> run() {
+							return make( makeProxyFunction.apply( byteBuddy ) )
+									.load(
+											referenceClass.getClassLoader(),
+											resolveClassLoadingStrategy( referenceClass )
+									)
+									.getLoaded();
+						}
+					};
+					return SystemSecurityManager.isSecurityManagerEnabled() ? AccessController.doPrivileged(
+							delegateToPrivilegedAction ) :
+							delegateToPrivilegedAction.run();
+				},
+				cache
+		);
 	}
 
 	public Unloaded<?> make(Function<ByteBuddy, DynamicType.Builder<?>> makeProxyFunction) {


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-15656
https://hibernate.atlassian.net/browse/HHH-15655
https://issues.redhat.com/browse/WFLY-17196

Add security manager privileged operation for:

> [javatest.batch] Caused by: java.lang.IllegalStateException: java.security.AccessControlException: WFSM000001: Permission check failed (permission "("java.lang.RuntimePermission" "defineClass")" in code source "(vfs:/content/jpa_core_entityManager_vehicles.ear/jpa_core_entityManager_pmservlet_vehicle_web.war/WEB-INF/classes <no signer certificates>)" of "ModuleClassLoader for Module "deployment.jpa_core_entityManager_vehicles.ear.jpa_core_entityManager_pmservlet_vehicle_web.war" from Service Module Loader")
> [javatest.batch]        at net.bytebuddy//net.bytebuddy.dynamic.loading.ClassInjector$UsingLookup.injectRaw(ClassInjector.java:1640)
> [javatest.batch]        at net.bytebuddy//net.bytebuddy.dynamic.loading.ClassInjector$AbstractBase.inject(ClassInjector.java:118)
> [javatest.batch]        at net.bytebuddy//net.bytebuddy.dynamic.loading.ClassLoadingStrategy$UsingLookup.load(ClassLoadingStrategy.java:519)
> [javatest.batch]        at net.bytebuddy//net.bytebuddy.dynamic.TypeResolutionStrategy$Passive.initialize(TypeResolutionStrategy.java:101)
> [javatest.batch]        at net.bytebuddy//net.bytebuddy.dynamic.DynamicType$Default$Unloaded.load(DynamicType.java:6317)
> [javatest.batch]        at org.hibernate@6.1.5.Final//org.hibernate.bytecode.internal.bytebuddy.ByteBuddyState.lambda$load$0(ByteBuddyState.java:193)
> [javatest.batch]        at net.bytebuddy//net.bytebuddy.TypeCache.findOrInsert(TypeCache.java:168)
> [javatest.batch]        ... 86 more
> [javatest.batch] Caused by: java.security.AccessControlException: WFSM000001: Permission check failed (permission "("java.lang.RuntimePermission" "defineClass")" in code source "(vfs:/content/jpa_core_entityManager_vehicles.ear/jpa_core_entityManager_pmservlet_vehicle_web.war/WEB-INF/classes <no signer certificates>)" of "ModuleClassLoader for Module "deployment.jpa_core_entityManager_vehicles.ear.jpa_core_entityManager_pmservlet_vehicle_web.war" from Service Module Loader")
> [javatest.batch]        at org.wildfly.security.elytron-base@2.0.0.Final//org.wildfly.security.manager.WildFlySecurityManager.checkPermission(WildFlySecurityManager.java:309)
> [javatest.batch]        at org.wildfly.security.elytron-base@2.0.0.Final//org.wildfly.security.manager.WildFlySecurityManager.checkPermission(WildFlySecurityManager.java:201)
> [javatest.batch]        at java.base/java.lang.invoke.MethodHandles$Lookup.defineClass(MethodHandles.java:926)
> [javatest.batch]        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
> [javatest.batch]        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
> [javatest.batch]        at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
> [javatest.batch]        at java.base/java.lang.reflect.Method.invoke(Method.java:566)
> [javatest.batch]        at net.bytebuddy.utility.Invoker$Dispatcher.invoke(Unknown Source)
> [javatest.batch]        at net.bytebuddy//net.bytebuddy.utility.dispatcher.JavaDispatcher$Dispatcher$ForNonStaticMethod.invoke(JavaDispatcher.java:1032)
> [javatest.batch]        at net.bytebuddy//net.bytebuddy.utility.dispatcher.JavaDispatcher$ProxiedInvocationHandler.invoke(JavaDispatcher.java:1162)
> [javatest.batch]        at net.bytebuddy//com.sun.proxy.$Proxy82.defineClass(Unknown Source)
> [javatest.batch]        at net.bytebuddy//net.bytebuddy.dynamic.loading.ClassInjector$UsingLookup.injectRaw(ClassInjector.java:1638)
> [javatest.batch]        ... 92 more
> [