### PR TITLE
Correction to the native sql queries section

### DIFF
--- a/documentation/src/main/asciidoc/userguide/chapters/query/native/Native.adoc
+++ b/documentation/src/main/asciidoc/userguide/chapters/query/native/Native.adoc
@@ -185,12 +185,12 @@ As seen in the associated SQL query, Hibernate manages to construct the entity h
 Even when using the `addJoin()` method, the result list will only contain the root entity.
 Joined entities will only be present for their respective association.
 
-[[sql-hibernate-entity-associations-query-many-to-one-join-result-transformer-example]]
-.Hibernate native query selecting entities with joined many-to-one association and `ResultTransformer`
+[[sql-hibernate-entity-associations-query-many-to-one-join-tuple-transformer-example]]
+.Hibernate native query selecting entities with joined many-to-one association and `TupleTransformer`
 ====
 [source, JAVA, indent=0]
 ----
-include::{sourcedir}/SQLTest.java[tags=sql-hibernate-entity-associations-query-many-to-one-join-result-transformer-example]
+include::{sourcedir}/SQLTest.java[tags=sql-hibernate-entity-associations-query-many-to-one-join-tuple-transformer-example]
 ----
 ====
 

--- a/documentation/src/main/asciidoc/userguide/chapters/schema/Schema.adoc
+++ b/documentation/src/main/asciidoc/userguide/chapters/schema/Schema.adoc
@@ -22,7 +22,7 @@ Considering the following Domain Model:
 ====
 [source, JAVA, indent=0]
 ----
-include::{sourcedir}/SchemaGenerationTest.java[tags=schema-generation-domain-model-example]
+include::{sourcedir}/BaseSchemaGeneratorTest.java[tags=schema-generation-domain-model-example]
 ----
 ====
 

--- a/documentation/src/test/java/org/hibernate/userguide/sql/SQLTest.java
+++ b/documentation/src/test/java/org/hibernate/userguide/sql/SQLTest.java
@@ -18,6 +18,7 @@ import org.hibernate.dialect.PostgreSQLDialect;
 import org.hibernate.orm.test.jpa.BaseEntityManagerFunctionalTestCase;
 import org.hibernate.loader.NonUniqueDiscoveredSqlAliasException;
 import org.hibernate.proxy.HibernateProxy;
+import org.hibernate.query.TupleTransformer;
 import org.hibernate.transform.Transformers;
 import org.hibernate.type.StandardBasicTypes;
 import org.hibernate.userguide.model.Account;
@@ -373,19 +374,20 @@ public class SQLTest extends BaseEntityManagerFunctionalTestCase {
 	public void test_sql_hibernate_entity_associations_query_many_to_one_join_result_transformer_example() {
 		doInJPA(this::entityManagerFactory, entityManager -> {
 			Session session = entityManager.unwrap(Session.class);
-			//tag::sql-hibernate-entity-associations-query-many-to-one-join-result-transformer-example[]
+			//tag::sql-hibernate-entity-associations-query-many-to-one-join-tuple-transformer-example[]
 			List<Phone> phones = session.createNativeQuery(
-				"SELECT {ph.*}, {pr.*} " +
-				"FROM Phone ph " +
-				"JOIN Person pr ON ph.person_id = pr.id")
-			.addEntity("ph", Phone.class)
-			.addJoin("pr", "ph.person")
-			.list();
+							"SELECT {ph.*}, {pr.*} " +
+									"FROM Phone ph " +
+									"JOIN Person pr ON ph.person_id = pr.id")
+					.addEntity("ph", Phone.class)
+					.addJoin("pr", "ph.person")
+					.setTupleTransformer( (TupleTransformer<Phone>) (tuple, aliases) -> (Phone) tuple[0] )
+					.list();
 
 			for (Phone person : phones) {
 				person.getPerson();
 			}
-			//end::sql-hibernate-entity-associations-query-many-to-one-join-result-transformer-example[]
+			//end::sql-hibernate-entity-associations-query-many-to-one-join-tuple-transformer-example[]
 			assertEquals(3, phones.size());
 		});
 	}


### PR DESCRIPTION
The result transformer-part that is mentioned in the doc has disappeared from the test, rendering it effectively identical to the `sql-hibernate-entity-associations-query-many-to-one-join-example` test just above it, so I suggest removing the duplicate. 