### PR TITLE
HHH-15665 - Mariadb is missing identifier quote on SEQUENCE QUERY

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/tool/schema/extract/internal/SequenceInformationExtractorMariaDBDatabaseImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/tool/schema/extract/internal/SequenceInformationExtractorMariaDBDatabaseImpl.java
@@ -28,7 +28,7 @@ public class SequenceInformationExtractorMariaDBDatabaseImpl extends SequenceInf
 
 	// SQL to get metadata from individual sequence
 	private static final String SQL_SEQUENCE_QUERY =
-			"SELECT '%1$s' as sequence_name, minimum_value, maximum_value, start_value, increment, cache_size FROM %1$s ";
+			"SELECT '%1$s' as sequence_name, minimum_value, maximum_value, start_value, increment, cache_size FROM `%1$s` ";
 
 	private static final String UNION_ALL =
 			"UNION ALL ";


### PR DESCRIPTION
MariaDB is missing identifier quote on SEQUENCE QUERY:
https://hibernate.atlassian.net/browse/HHH-15665