### PR TITLE
HHH-15678, HHH-15677, HHH-15676 add two methods to SessionFactory and deprecate one

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/engine/spi/SessionFactoryDelegatingImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/spi/SessionFactoryDelegatingImpl.java
@@ -36,8 +36,6 @@ import org.hibernate.event.spi.EventEngine;
 import org.hibernate.graph.spi.RootGraphImplementor;
 import org.hibernate.id.IdentifierGenerator;
 import org.hibernate.internal.FastSessionServices;
-import org.hibernate.metadata.ClassMetadata;
-import org.hibernate.metadata.CollectionMetadata;
 import org.hibernate.metamodel.model.domain.spi.JpaMetamodelImplementor;
 import org.hibernate.metamodel.spi.MetamodelImplementor;
 import org.hibernate.metamodel.spi.RuntimeMetamodelsImplementor;
@@ -167,6 +165,11 @@ public class SessionFactoryDelegatingImpl implements SessionFactoryImplementor, 
 	@Override
 	public boolean containsFetchProfileDefinition(String name) {
 		return delegate.containsFetchProfileDefinition( name );
+	}
+
+	@Override
+	public Set<String> getDefinedFetchProfileNames() {
+		return delegate.getDefinedFetchProfileNames();
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/internal/SessionFactoryImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/SessionFactoryImpl.java
@@ -89,7 +89,6 @@ import org.hibernate.jpa.internal.PersistenceUnitUtilImpl;
 import org.hibernate.mapping.Collection;
 import org.hibernate.mapping.PersistentClass;
 import org.hibernate.mapping.RootClass;
-import org.hibernate.metadata.ClassMetadata;
 import org.hibernate.metadata.CollectionMetadata;
 import org.hibernate.metamodel.internal.RuntimeMetamodelsImpl;
 import org.hibernate.metamodel.model.domain.spi.JpaMetamodelImplementor;
@@ -128,6 +127,8 @@ import org.hibernate.type.descriptor.WrapperOptions;
 import org.hibernate.type.spi.TypeConfiguration;
 
 import org.jboss.logging.Logger;
+
+import static java.util.Collections.unmodifiableSet;
 
 
 /**
@@ -970,7 +971,12 @@ public class SessionFactoryImpl implements SessionFactoryImplementor {
 	}
 
 	public Set<String> getDefinedFilterNames() {
-		return filters.keySet();
+		return unmodifiableSet( filters.keySet() );
+	}
+
+	@Override
+	public Set<String> getDefinedFetchProfileNames() {
+		return unmodifiableSet( fetchProfiles.keySet() );
 	}
 
 	public IdentifierGenerator getIdentifierGenerator(String rootEntityName) {


### PR DESCRIPTION
- added `getDefinedFetchProfileNames()` for consistency
- added `findEntityGraphByName()` which already existed but was not exposed
- deprecated `getFilterDefinition()` since it's a layer-breaker
- improved+added some Javadoc

See HHH-15678, HHH-15677, and HHH-15676.