### PR TITLE
HHH-15680, HHH-15681, HHH-15682, HHH-15683, HHH-15684 lock options and lock scopes

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/LockMode.java
+++ b/hibernate-core/src/main/java/org/hibernate/LockMode.java
@@ -24,14 +24,15 @@ import jakarta.persistence.LockModeType;
  */
 public enum LockMode {
 	/**
-	 * No lock required. If an object is requested with this lock
-	 * mode, a {@link #READ} lock will be obtained if it is
-	 * necessary to actually read the state from the database,
+	 * No lock required. If an object is requested with this
+	 * lock mode, a {@link #READ} lock will be obtained if it
+	 * is necessary to actually read the state from the database,
 	 * rather than pull it from a cache.
 	 * <p>
 	 * This is the "default" lock mode.
 	 */
 	NONE( 0, "none" ),
+
 	/**
 	 * A shared lock. Objects in this lock mode were read from
 	 * the database in the current transaction, rather than being
@@ -40,31 +41,34 @@ public enum LockMode {
 	READ( 5, "read" ),
 
 	/**
-	 * Optimistically assume that transaction will not experience contention for
-	 * entities.  The entity version will be verified near the transaction end.
+	 * Optimistically assume that transaction will not experience
+	 * contention for an entity. The version will be verified near
+	 * the transaction end.
 	 */
 	OPTIMISTIC( 6, "optimistic" ),
 
 	/**
-	 * Optimistically assume that transaction will not experience contention for
-	 * entities.  The entity version will be verified and incremented near the transaction end.
+	 * Optimistically assume that transaction will not experience
+	 * contention for an entity. The version will be verified and
+	 * incremented near the transaction end.
 	 */
 	OPTIMISTIC_FORCE_INCREMENT( 7, "optimistic_force_increment" ),
 
 	/**
-	 * A {@code WRITE} lock is obtained when an object is updated or inserted.
-	 *
-	 * This lock mode is for internal use only and is not a valid mode for
-	 * {@code load()} or {@code lock()}, both of which throw exceptions if
-	 * {@code WRITE} is specified.
+	 * A {@code WRITE} lock is obtained when an object is updated
+	 * or inserted.
+	 * <p>
+	 * This lock mode is for internal use only and is not a valid
+	 * argument to {@code load()} or {@code lock()}. These method
+	 * throw an exception if {@code WRITE} given as an argument.
 	 */
 	@Internal
 	WRITE( 10, "write" ),
 
 	/**
 	 * Attempt to obtain an upgrade lock, using an Oracle-style
-	 * {@code select for update nowait}. The semantics of
-	 * this lock mode, once obtained, are the same as
+	 * {@code select for update nowait}. The semantics of this
+	 * lock mode, once obtained, are the same as
 	 * {@link #PESSIMISTIC_WRITE}.
 	 */
 	UPGRADE_NOWAIT( 10, "upgrade-nowait" ),
@@ -78,7 +82,7 @@ public enum LockMode {
 	UPGRADE_SKIPLOCKED( 10, "upgrade-skiplocked" ),
 
 	/**
-	 * Implemented as PESSIMISTIC_WRITE.
+	 * Implemented as {@link #PESSIMISTIC_WRITE}.
 	 */
 	PESSIMISTIC_READ( 12, "pessimistic_read" ),
 

--- a/hibernate-core/src/main/java/org/hibernate/LockMode.java
+++ b/hibernate-core/src/main/java/org/hibernate/LockMode.java
@@ -12,87 +12,136 @@ import jakarta.persistence.LockModeType;
 
 /**
  * Instances represent a lock mode for a row of a relational
- * database table. It is not intended that users spend much
- * time worrying about locking since Hibernate usually
- * obtains exactly the right lock level automatically.
- * Some "advanced" users may wish to explicitly specify lock
- * levels.
+ * database table. It is not intended that users spend much time
+ * worrying about locking since Hibernate usually obtains exactly
+ * the right lock level automatically. Some "advanced" users may
+ * wish to explicitly specify lock levels.
+ * <p>
+ * This enumeration of lock modes competes with the JPA-defined
+ * {@link LockModeType}, but offers additional options, including
+ * {@link #UPGRADE_NOWAIT} and {@link #UPGRADE_SKIPLOCKED}.
  *
  * @author Gavin King
  *
  * @see Session#lock(Object, LockMode)
+ * @see LockModeType
+ * @see LockOptions
  */
 public enum LockMode {
 	/**
-	 * No lock required. If an object is requested with this
-	 * lock mode, a {@link #READ} lock will be obtained if it
-	 * is necessary to actually read the state from the database,
+	 * No lock required. If an object is requested with this lock
+	 * mode, a {@link #READ} lock will be obtained if it turns out
+	 * to be necessary to actually read the state from the database,
 	 * rather than pull it from a cache.
 	 * <p>
-	 * This is the "default" lock mode.
+	 * This is the "default" lock mode, the mode requested by calling
+	 * {@link Session#get(Class, Object)} without passing an explicit
+	 * mode. It permits the state of an object to be retrieved from
+	 * the cache without the cost of database access.
+	 *
+	 * @see LockModeType#NONE
 	 */
 	NONE( 0, "none" ),
 
 	/**
-	 * A shared lock. Objects in this lock mode were read from
-	 * the database in the current transaction, rather than being
-	 * pulled from a cache.
+	 * A shared lock. Objects in this lock mode were read from the
+	 * database in the current transaction, rather than being pulled
+	 * from a cache.
+	 * <p>
+	 * Note that this lock mode is the same as the JPA-defined modes
+	 * {@link LockModeType#READ} and {@link LockModeType#OPTIMISTIC}.
+	 *
+	 * @see LockModeType#OPTIMISTIC
 	 */
 	READ( 5, "read" ),
 
 	/**
-	 * Optimistically assume that transaction will not experience
-	 * contention for an entity. The version will be verified near
-	 * the transaction end.
+	 * A shared optimistic lock. Assumes that the current transaction
+	 * will not experience contention for the state of an entity. The
+	 * version will be checked near the end of the transaction, to
+	 * verify that this was indeed the case.
+	 * <p>
+	 * Note that, despite the similar names this lock mode is not the
+	 * same as the JPA-defined mode {@link LockModeType#OPTIMISTIC}.
 	 */
 	OPTIMISTIC( 6, "optimistic" ),
 
 	/**
-	 * Optimistically assume that transaction will not experience
-	 * contention for an entity. The version will be verified and
-	 * incremented near the transaction end.
+	 * A kind of exclusive optimistic lock. Assumes that the current
+	 * transaction will not experience contention for the state of an
+	 * entity. The version will be checked and incremented near the
+	 * end of the transaction, to verify that this was indeed the
+	 * case, and to signal to concurrent optimistic readers that their
+	 * optimistic locks have failed.
+	 *
+	 * @see LockModeType#OPTIMISTIC_FORCE_INCREMENT
 	 */
 	OPTIMISTIC_FORCE_INCREMENT( 7, "optimistic_force_increment" ),
 
 	/**
-	 * A {@code WRITE} lock is obtained when an object is updated
-	 * or inserted.
+	 * An exclusive write lock. Objects in this lock mode were updated
+	 * or inserted in the database in the current transaction.
 	 * <p>
-	 * This lock mode is for internal use only and is not a valid
-	 * argument to {@code load()} or {@code lock()}. These method
-	 * throw an exception if {@code WRITE} given as an argument.
+	 * This lock mode is for internal use only and is not a legal
+	 * argument to {@link Session#get(Class, Object, LockMode)},
+	 * {@link Session#refresh(Object, LockMode)}, or
+	 * {@link Session#lock(Object, LockMode)}. These methods throw
+	 * an exception if {@code WRITE} is given as an argument.
+	 * <p>
+	 * Note that, despite the similar names, this lock mode is not
+	 * the same as the JPA-defined mode {@link LockModeType#WRITE}.
 	 */
 	@Internal
 	WRITE( 10, "write" ),
 
 	/**
-	 * Attempt to obtain an upgrade lock, using an Oracle-style
+	 * A pessimistic upgrade lock, obtained using an Oracle-style
 	 * {@code select for update nowait}. The semantics of this
-	 * lock mode, once obtained, are the same as
-	 * {@link #PESSIMISTIC_WRITE}.
+	 * lock mode, if the lock is successfully obtained, are the same
+	 * as {@link #PESSIMISTIC_WRITE}. If the lock is not immediately
+	 * available, an exception occurs.
 	 */
 	UPGRADE_NOWAIT( 10, "upgrade-nowait" ),
 
 	/**
-	 * Attempt to obtain an upgrade lock, using an Oracle-style
-	 * {@code select for update skip locked}. The semantics of
-	 * this lock mode, once obtained, are the same as
-	 * {@link #PESSIMISTIC_WRITE}.
+	 * A pessimistic upgrade lock, obtained using an Oracle-style
+	 * {@code select for update skip locked}. The semantics of this
+	 * lock mode, if the lock is successfully obtained, are the same
+	 * as {@link #PESSIMISTIC_WRITE}. But if the lock is not
+	 * immediately available, no exception occurs, but the locked
+	 * row is not returned from the database.
 	 */
 	UPGRADE_SKIPLOCKED( 10, "upgrade-skiplocked" ),
 
 	/**
-	 * Implemented as {@link #PESSIMISTIC_WRITE}.
+	 * A pessimistic shared lock, which prevents concurrent
+	 * transactions from writing the locked object. Obtained via
+	 * a {@code select for share} statement in dialects where this
+	 * syntax is supported, and via {@code select for update} in
+	 * other dialects.
+	 * <p>
+	 * On databases which do not support {@code for share}, this
+	 * lock mode is equivalent to {@link #PESSIMISTIC_WRITE}.
+	 *
+	 * @see LockModeType#PESSIMISTIC_READ
 	 */
 	PESSIMISTIC_READ( 12, "pessimistic_read" ),
 
 	/**
-	 * Transaction will obtain a database lock immediately.
+	 * A pessimistic upgrade lock, which prevents concurrent
+	 * transactions from reading or writing the locked object.
+	 * Obtained via a {@code select for update} statement.
+	 *
+	 * @see LockModeType#PESSIMISTIC_WRITE
 	 */
 	PESSIMISTIC_WRITE( 13, "pessimistic_write" ),
 
 	/**
-	 * Transaction will immediately increment the entity version.
+	 * A pessimistic write lock which immediately increments
+	 * the version of the locked object. Obtained by immediate
+	 * execution of an {@code update} statement.
+	 *
+	 * @see LockModeType#PESSIMISTIC_FORCE_INCREMENT
 	 */
 	PESSIMISTIC_FORCE_INCREMENT( 17, "pessimistic_force_increment" );
 

--- a/hibernate-core/src/main/java/org/hibernate/LockOptions.java
+++ b/hibernate-core/src/main/java/org/hibernate/LockOptions.java
@@ -432,8 +432,18 @@ public class LockOptions implements Serializable {
 		return copy;
 	}
 
+	/**
+	 * Copy the given lock options into this instance,
+	 * merging the alias-specific lock modes.
+	 */
 	public void overlay(LockOptions lockOptions) {
-		copy( lockOptions, this );
+		setLockMode( lockOptions.getLockMode() );
+		setScope( lockOptions.getScope() );
+		setTimeOut( lockOptions.getTimeOut() );
+		if ( lockOptions.aliasSpecificLockModes != null ) {
+			lockOptions.aliasSpecificLockModes.forEach(this::setAliasSpecificLockMode);
+		}
+		setFollowOnLocking( lockOptions.getFollowOnLocking() );
 	}
 
 	/**

--- a/hibernate-core/src/main/java/org/hibernate/LockOptions.java
+++ b/hibernate-core/src/main/java/org/hibernate/LockOptions.java
@@ -12,98 +12,130 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.Objects;
 
+import jakarta.persistence.PessimisticLockScope;
 import org.hibernate.query.Query;
+import org.hibernate.query.spi.QueryOptions;
+
+import static java.util.Collections.emptyList;
 
 /**
- * Contains locking details (LockMode, Timeout and Scope).
- * 
+ * Contains a set of options describing how a row of a database table
+ * mapped by an entity should be locked. For
+ * {@link Session#buildLockRequest(LockOptions)},
+ * {@link Session#get(Class, Object, LockOptions)}, or
+ * {@link Session#refresh(Object, LockOptions)}, the relevant options
+ * are:
+ * <ul>
+ * <li>the {@link #getLockMode() lock mode},
+ * <li>the {@link #getTimeOut() pessimistic lock timeout}, and
+ * <li>the {@link #getLockScope() lock scope}, that is, whether the
+ *     lock extends to rows of owned collections.
+ * </ul>
+ * In HQL and criteria queries, lock modes can be defined in an even
+ * more granular fashion, with the option to specify a lock mode that
+ * {@linkplain #setAliasSpecificLockMode(String, LockMode) applies
+ * only to a certain query alias}.
+ *
  * @author Scott Marlow
  */
 public class LockOptions implements Serializable {
 	/**
-	 * Represents LockMode.NONE (timeout + scope do not apply).
+	 * Represents {@link LockMode#NONE}, where timeout and scope are
+	 * not applicable.
 	 */
 	public static final LockOptions NONE = new LockOptions(LockMode.NONE);
 
 	/**
-	 * Represents LockMode.READ (timeout + scope do not apply).
+	 * Represents {@link LockMode#READ}, where timeout and scope are
+	 * not applicable.
 	 */
 	public static final LockOptions READ = new LockOptions(LockMode.READ);
 
 	/**
-	 * Represents LockMode.UPGRADE (will wait forever for lock and scope of false meaning only entity is locked).
+	 * Represents {@link LockMode#PESSIMISTIC_WRITE} with
+	 * {@linkplain #WAIT_FOREVER no timeout}, and
+	 * {@linkplain PessimisticLockScope#NORMAL no extension of the
+	 * lock to owned collections}.
 	 */
 	public static final LockOptions UPGRADE = new LockOptions(LockMode.PESSIMISTIC_WRITE);
 
 	/**
-	 * Indicates that the database should not wait at all to acquire the pessimistic lock.
+	 * Indicates that the database should not wait at all to acquire
+	 * a pessimistic lock which is not immediately available.
+	 *
 	 * @see #getTimeOut
 	 */
 	public static final int NO_WAIT = 0;
 
 	/**
-	 * Indicates that there is no timeout for the acquisition.
+	 * Indicates that there is no timeout for the lock acquisition.
+	 *
 	 * @see #getTimeOut
 	 */
 	public static final int WAIT_FOREVER = -1;
 
 	/**
-	 * Indicates that rows that are already locked should be skipped.
+	 * Indicates that rows which are already locked should be skipped.
+	 *
 	 * @see #getTimeOut()
 	 */
 	public static final int SKIP_LOCKED = -2;
 
 	private LockMode lockMode = LockMode.NONE;
 	private int timeout = WAIT_FOREVER;
+	private boolean scope;
 
 	private Map<String,LockMode> aliasSpecificLockModes;
 
 	private Boolean followOnLocking;
 
 	/**
-	 * Constructs a LockOptions with all default options.
+	 * Constructs an instance with all default options.
 	 */
 	public LockOptions() {
 	}
 
 	/**
-	 * Constructs a LockOptions with the given lock mode.
+	 * Constructs an instance with the given {@linkplain LockMode
+	 * lock mode}.
 	 *
 	 * @param lockMode The lock mode to use
 	 */
-	public LockOptions( LockMode lockMode) {
+	public LockOptions(LockMode lockMode) {
 		this.lockMode = lockMode;
 	}
 
 	/**
-	 * Returns whether the lock options are empty.
+	 * Determine of the lock options are empty.
 	 *
-	 * @return If the lock options is equivalent to {@link LockOptions#NONE}.
+	 * @return {@code true} if the lock options are equivalent to
+	 *         {@link LockOptions#NONE}.
 	 */
 	public boolean isEmpty() {
-		return lockMode == LockMode.NONE && timeout == WAIT_FOREVER && followOnLocking == null && !scope && !hasAliasSpecificLockModes();
+		return lockMode == LockMode.NONE
+			&& timeout == WAIT_FOREVER
+			&& followOnLocking == null
+			&& !scope
+			&& !hasAliasSpecificLockModes();
 	}
 
 	/**
 	 * Retrieve the overall lock mode in effect for this set of options.
-	 * <p/>
-	 * In certain contexts (hql and criteria), lock-modes can be defined in an
-	 * even more granular {@link #setAliasSpecificLockMode(String, LockMode) per-alias} fashion
 	 *
-	 * @return The overall lock mode.
+	 * @return the overall lock mode
 	 */
 	public LockMode getLockMode() {
 		return lockMode;
 	}
 
 	/**
-	 * Set the overall {@link LockMode} to be used.  The default is
-	 * {@link LockMode#NONE}
+	 * Set the overall {@linkplain LockMode lock mode}. The default is
+	 * {@link LockMode#NONE}, that is, no locking at all.
 	 *
-	 * @param lockMode The new overall lock mode to use.
-	 *
-	 * @return this (for method chaining).
+	 * @param lockMode the new overall lock mode
+	 * @return {@code this} for method chaining
 	 */
 	public LockOptions setLockMode(LockMode lockMode) {
 		this.lockMode = lockMode;
@@ -111,11 +143,11 @@ public class LockOptions implements Serializable {
 	}
 
 	/**
-	 * Specify the {@link LockMode} to be used for a specific query alias.
+	 * Specify the {@link LockMode} to be used for the given query alias.
 	 *
-	 * @param alias used to reference the LockMode.
-	 * @param lockMode The lock mode to apply to the given alias
-	 * @return this LockRequest instance for operation chaining.
+	 * @param alias the query alias to which the lock mode applies
+	 * @param lockMode the lock mode to apply to the given alias
+	 * @return {@code this} for method chaining
 	 *
 	 * @see Query#setLockMode(String, LockMode)
 	 */
@@ -133,34 +165,30 @@ public class LockOptions implements Serializable {
 	}
 
 	/**
-	 * Get the {@link LockMode} explicitly specified for the given alias via
-	 * {@link #setAliasSpecificLockMode}
-	 * <p/>
-	 * Differs from {@link #getEffectiveLockMode} in that here we only return
-	 * explicitly specified alias-specific lock modes.
+	 * Get the {@link LockMode} explicitly specified for the given alias
+	 * via {@link #setAliasSpecificLockMode(String, LockMode)}.
+	 * <p>
+	 * Differs from {@link #getEffectiveLockMode(String)} in that here we
+	 * only return an explicitly specified alias-specific lock mode.
 	 *
 	 * @param alias The alias for which to locate the explicit lock mode.
-	 *
 	 * @return The explicit lock mode for that alias.
 	 */
 	public LockMode getAliasSpecificLockMode(String alias) {
-		if ( aliasSpecificLockModes == null ) {
-			return null;
-		}
-		return aliasSpecificLockModes.get( alias );
+		return aliasSpecificLockModes == null ? null : aliasSpecificLockModes.get( alias );
 	}
 
 	/**
-	 * Determine the {@link LockMode} to apply to the given alias.  If no
-	 * mode was explicitly {@linkplain #setAliasSpecificLockMode set}, the
-	 * {@linkplain #getLockMode overall mode} is returned.  If the overall
-	 * lock mode is {@code null} as well, {@link LockMode#NONE} is returned.
-	 * <p/>
-	 * Differs from {@link #getAliasSpecificLockMode} in that here we fallback to we only return
-	 * the overall lock mode.
+	 * Determine the {@link LockMode} to apply to the given alias. If no
+	 * mode was {@linkplain #setAliasSpecificLockMode(String, LockMode)}
+	 * explicitly set}, the {@linkplain #getLockMode()}  overall mode} is
+	 * returned. If the overall lock mode is also {@code null},
+	 * {@link LockMode#NONE} is returned.
+	 * <p>
+	 * Differs from {@link #getAliasSpecificLockMode(String)} in that here
+	 * we fall back to only returning the overall lock mode.
 	 *
 	 * @param alias The alias for which to locate the effective lock mode.
-	 *
 	 * @return The effective lock mode.
 	 */
 	public LockMode getEffectiveLockMode(String alias) {
@@ -172,31 +200,31 @@ public class LockOptions implements Serializable {
 	}
 
 	/**
-	 * Does this {@code LockOptions} instance define alias-specific lock modes?
+	 * Does this {@code LockOptions} instance define alias-specific lock
+	 * modes?
 	 *
-	 * @return {@code true} if this object defines alias-specific lock modes; {@code false} otherwise.
+	 * @return {@code true} if this object defines alias-specific lock modes;
+	 *        {@code false} otherwise.
 	 */
 	public boolean hasAliasSpecificLockModes() {
 		return aliasSpecificLockModes != null
-				&& ! aliasSpecificLockModes.isEmpty();
+			&& ! aliasSpecificLockModes.isEmpty();
 	}
 
 	/**
-	 * Get the number of aliases that have specific lock modes defined.
+	 * The number of aliases that have alias-specific lock modes specified.
 	 *
 	 * @return the number of explicitly defined alias lock modes.
 	 */
 	public int getAliasLockCount() {
-		if ( aliasSpecificLockModes == null ) {
-			return 0;
-		}
-		return aliasSpecificLockModes.size();
+		return aliasSpecificLockModes == null ? 0 : aliasSpecificLockModes.size();
 	}
 
 	/**
-	 * Iterator for accessing Alias (key) and LockMode (value) as Map.Entry.
+	 * Iterator over {@link Map.Entry}s, each containing an alias and its
+	 * {@link LockMode}.
 	 *
-	 * @return Iterator for accessing the Map.Entry's
+	 * @return an iterator over the {@link Map.Entry}s
 	 * @deprecated use {@link #getAliasSpecificLocks()}
 	 */
 	@Deprecated
@@ -205,15 +233,13 @@ public class LockOptions implements Serializable {
 	}
 
 	/**
-	 * Iterable access to alias (key) and LockMode (value) as Map.Entry.
+	 * Iterable with {@link Map.Entry}s, each containing an alias and its
+	 * {@link LockMode}.
 	 *
-	 * @return Iterable for accessing the Map.Entry's
+	 * @return an iterable with the {@link Map.Entry}s
 	 */
 	public Iterable<Map.Entry<String,LockMode>> getAliasSpecificLocks() {
-		if ( aliasSpecificLockModes == null ) {
-			return Collections.emptyList();
-		}
-		return aliasSpecificLockModes.entrySet();
+		return aliasSpecificLockModes == null ? emptyList() : aliasSpecificLockModes.entrySet();
 	}
 
 	/**
@@ -241,27 +267,30 @@ public class LockOptions implements Serializable {
 	}
 
 	/**
-	 * Retrieve the current timeout setting.
-	 * <p/>
-	 * The timeout is the amount of time, in milliseconds, we should instruct the database
-	 * to wait for any requested pessimistic lock acquisition.
-	 * <p/>
-	 * {@link #NO_WAIT}, {@link #WAIT_FOREVER} or {@link #SKIP_LOCKED} represent 3 "magic" values.
+	 * The current timeout, a maximum amount of time in milliseconds
+	 * that the database should wait to obtain a pessimistic lock before
+	 * returning an error to the client.
+	 * <p>
+	 * {@link #NO_WAIT}, {@link #WAIT_FOREVER}, or {@link #SKIP_LOCKED}
+	 * represent 3 "magic" values.
 	 *
-	 * @return timeout in milliseconds, {@link #NO_WAIT}, {@link #WAIT_FOREVER} or {@link #SKIP_LOCKED}
+	 * @return a timeout in milliseconds, {@link #NO_WAIT},
+	 *         {@link #WAIT_FOREVER}, or {@link #SKIP_LOCKED}
 	 */
 	public int getTimeOut() {
 		return timeout;
 	}
 
 	/**
-	 * Set the timeout setting.
-	 * <p/>
-	 * See {@link #getTimeOut} for a discussion of meaning.
+	 * Set the timeout, that is, the maximum amount of time in milliseconds
+	 * that the database should wait to obtain a pessimistic lock before
+	 * returning an error to the client.
+	 * <p>
+	 * {@link #NO_WAIT}, {@link #WAIT_FOREVER}, or {@link #SKIP_LOCKED}
+	 * represent 3 "magic" values.
 	 *
-	 * @param timeout The new timeout setting, in milliseconds
-	 *
-	 * @return this (for method chaining).
+	 * @param timeout the new timeout setting, in milliseconds
+	 * @return {@code this} for method chaining
 	 *
 	 * @see #getTimeOut
 	 */
@@ -270,44 +299,93 @@ public class LockOptions implements Serializable {
 		return this;
 	}
 
-	private boolean scope;
+	/**
+	 * The current lock scope:
+	 * <ul>
+	 * <li>{@link PessimisticLockScope#EXTENDED} means the lock
+	 *     extends to rows of owned collections, but
+	 * <li>{@link PessimisticLockScope#NORMAL} means only the entity
+	 *     table and secondary tables are locked.
+	 * </ul>
+	 *
+	 * @return the current {@link PessimisticLockScope}
+	 */
+	public PessimisticLockScope getLockScope() {
+		return scope ? PessimisticLockScope.EXTENDED : PessimisticLockScope.NORMAL;
+	}
 
 	/**
-	 * Retrieve the current lock scope setting.
-	 * <p/>
-	 * "scope" is a JPA defined term.  It is basically a cascading of the lock to associations.
+	 * Set the lock scope:
+	 * <ul>
+	 * <li>{@link PessimisticLockScope#EXTENDED} means the lock
+	 *     extends to rows of owned collections, but
+	 * <li>{@link PessimisticLockScope#NORMAL} means only the entity
+	 *     table and secondary tables are locked.
+	 * </ul>
 	 *
-	 * @return true if locking will be extended to owned associations
+	 * @param scope the new {@link PessimisticLockScope}
+	 * @return {@code this} for method chaining
 	 */
+	public LockOptions setLockScope(PessimisticLockScope scope) {
+		return setScope(scope==PessimisticLockScope.EXTENDED);
+	}
+
+	/**
+	 * The current lock scope setting:
+	 * <ul>
+	 * <li>{@code true} means the lock extends to rows of owned
+	 *     collections, but
+	 * <li>{@code false} means only the entity table and secondary
+	 *     tables are locked.
+	 * </ul>
+	 *
+	 * @return {@code true} if the lock extends to owned associations
+	 *
+	 * @deprecated use {@link #getLockScope()}
+	 */
+	@Deprecated(since = "6.2")
 	public boolean getScope() {
 		return scope;
 	}
 
 	/**
-	 * Set the scope.
+	 * Set the lock scope setting:
+	 * <ul>
+	 * <li>{@code true} means the lock extends to rows of owned
+	 *     collections, but
+	 * <li>{@code false} means only the entity table and secondary
+	 *     tables are locked.
+	 * </ul>
 	 *
-	 * @param scope The new scope setting
+	 * @param scope the new scope setting
+	 * @return {@code this} for method chaining
 	 *
-	 * @return this (for method chaining).
+	 * @deprecated use {@link #setLockScope(PessimisticLockScope)}
 	 */
+	@Deprecated(since = "6.2")
 	public LockOptions setScope(boolean scope) {
 		this.scope = scope;
 		return this;
 	}
 
 	/**
-	 * Retrieve the current follow-on-locking setting.
+	 * The current follow-on locking setting.
 	 *
-	 * @return true if follow-on-locking is enabled
+	 * @return {@code true} if follow-on locking is enabled
+	 *
+	 * @see org.hibernate.dialect.Dialect#useFollowOnLocking(String, QueryOptions)
 	 */
 	public Boolean getFollowOnLocking() {
 		return followOnLocking;
 	}
 
 	/**
-	 * Set the follow-on-locking setting.
-	 * @param followOnLocking The new follow-on-locking setting
-	 * @return this (for method chaining).
+	 * Set the follow-on locking setting.
+	 *
+	 * @param followOnLocking The new follow-on locking setting
+	 * @return {@code this} for method chaining
+	 *
+	 * @see org.hibernate.dialect.Dialect#useFollowOnLocking(String, QueryOptions)
 	 */
 	public LockOptions setFollowOnLocking(Boolean followOnLocking) {
 		this.followOnLocking = followOnLocking;
@@ -330,7 +408,8 @@ public class LockOptions implements Serializable {
 	}
 
 	/**
-	 * Perform a shallow copy.
+	 * Copy the options in the first given instance of
+	 * {@code LockOptions} to the second given instance.
 	 *
 	 * @param source Source for the copy (copied from)
 	 * @param destination Destination for the copy (copied to)
@@ -349,40 +428,25 @@ public class LockOptions implements Serializable {
 	}
 
 	@Override
-	public boolean equals(Object o) {
-		if ( this == o ) {
+	public boolean equals(Object object) {
+		if ( this == object ) {
 			return true;
 		}
-		if ( o == null || getClass() != o.getClass() ) {
+		else if ( !(object instanceof LockOptions) ) {
 			return false;
 		}
-
-		LockOptions that = (LockOptions) o;
-
-		if ( timeout != that.timeout ) {
-			return false;
+		else {
+			final LockOptions that = (LockOptions) object;
+			return timeout == that.timeout
+				&& scope == that.scope
+				&& lockMode == that.lockMode
+				&& Objects.equals( aliasSpecificLockModes, that.aliasSpecificLockModes )
+				&& Objects.equals( followOnLocking, that.followOnLocking );
 		}
-		if ( scope != that.scope ) {
-			return false;
-		}
-		if ( lockMode != that.lockMode ) {
-			return false;
-		}
-		if ( aliasSpecificLockModes != null ?
-				!aliasSpecificLockModes.equals( that.aliasSpecificLockModes ) :
-				that.aliasSpecificLockModes != null ) {
-			return false;
-		}
-		return followOnLocking != null ? followOnLocking.equals( that.followOnLocking ) : that.followOnLocking == null;
 	}
 
 	@Override
 	public int hashCode() {
-		int result = lockMode != null ? lockMode.hashCode() : 0;
-		result = 31 * result + timeout;
-		result = 31 * result + ( aliasSpecificLockModes != null ? aliasSpecificLockModes.hashCode() : 0 );
-		result = 31 * result + ( followOnLocking != null ? followOnLocking.hashCode() : 0 );
-		result = 31 * result + ( scope ? 1 : 0 );
-		return result;
+		return Objects.hash( lockMode, timeout, aliasSpecificLockModes, followOnLocking, scope );
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/LockOptions.java
+++ b/hibernate-core/src/main/java/org/hibernate/LockOptions.java
@@ -66,7 +66,8 @@ public class LockOptions implements Serializable {
 
 	/**
 	 * Indicates that the database should not wait at all to acquire
-	 * a pessimistic lock which is not immediately available.
+	 * a pessimistic lock which is not immediately available. This
+	 * has the same effect as {@link LockMode#UPGRADE_NOWAIT}.
 	 *
 	 * @see #getTimeOut
 	 */
@@ -85,7 +86,10 @@ public class LockOptions implements Serializable {
 	 * Indicates that rows which are already locked should be skipped.
 	 *
 	 * @see #getTimeOut()
+	 *
+	 * @deprecated use {@link LockMode#UPGRADE_SKIPLOCKED}
 	 */
+	@Deprecated
 	public static final int SKIP_LOCKED = -2;
 
 	private LockMode lockMode = LockMode.NONE;

--- a/hibernate-core/src/main/java/org/hibernate/LockOptions.java
+++ b/hibernate-core/src/main/java/org/hibernate/LockOptions.java
@@ -48,13 +48,13 @@ public class LockOptions implements Serializable {
 	 * Represents {@link LockMode#NONE}, to which timeout and scope are
 	 * not applicable.
 	 */
-	public static final LockOptions NONE = new LockOptions(LockMode.NONE);
+	public static final LockOptions NONE = new ImmutableLockOptions(LockMode.NONE);
 
 	/**
 	 * Represents {@link LockMode#READ}, to which timeout and scope are
 	 * not applicable.
 	 */
-	public static final LockOptions READ = new LockOptions(LockMode.READ);
+	public static final LockOptions READ = new ImmutableLockOptions(LockMode.READ);
 
 	/**
 	 * Represents {@link LockMode#PESSIMISTIC_WRITE} with
@@ -62,7 +62,7 @@ public class LockOptions implements Serializable {
 	 * {@linkplain PessimisticLockScope#NORMAL no extension of the
 	 * lock to owned collections}.
 	 */
-	public static final LockOptions UPGRADE = new LockOptions(LockMode.PESSIMISTIC_WRITE);
+	public static final LockOptions UPGRADE = new ImmutableLockOptions(LockMode.PESSIMISTIC_WRITE);
 
 	/**
 	 * Indicates that the database should not wait at all to acquire
@@ -477,5 +477,41 @@ public class LockOptions implements Serializable {
 	@Override
 	public int hashCode() {
 		return Objects.hash( lockMode, timeout, aliasSpecificLockModes, followOnLocking, scope );
+	}
+
+	private static class ImmutableLockOptions extends LockOptions {
+		private ImmutableLockOptions(LockMode lockMode) {
+			super(lockMode);
+		}
+
+		@Override
+		public LockOptions setLockMode(LockMode lockMode) {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public LockOptions setLockScope(PessimisticLockScope scope) {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public LockOptions setFollowOnLocking(Boolean followOnLocking) {
+			return super.setFollowOnLocking(followOnLocking);
+		}
+
+		@Override
+		public LockOptions setTimeOut(int timeout) {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public LockOptions setAliasSpecificLockMode(String alias, LockMode lockMode) {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public LockOptions setScope(boolean scope) {
+			throw new UnsupportedOperationException();
+		}
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/Session.java
+++ b/hibernate-core/src/main/java/org/hibernate/Session.java
@@ -651,68 +651,82 @@ public interface Session extends SharedSessionContract, EntityManager {
 	void delete(String entityName, Object object);
 
 	/**
-	 * Obtain the specified lock level on the given managed instance association with
-	 * this session. This may be used to:
+	 * Obtain the specified lock level on the given managed instance associated
+	 * with this session. This may be used to:
 	 * <ul>
 	 * <li>perform a version check with {@link LockMode#READ}, or
 	 * <li>upgrade to a pessimistic lock with {@link LockMode#PESSIMISTIC_WRITE}).
 	 * </ul>
-	 * This operation cascades to associated instances if the association is mapped
-	 * with {@link org.hibernate.annotations.CascadeType#LOCK}.
-	 * <p>
-	 * Convenient form of {@link LockRequest#lock(Object)} via
-	 * {@link #buildLockRequest(LockOptions)}
+	 * This operation cascades to associated instances if the association is
+	 * mapped with {@link org.hibernate.annotations.CascadeType#LOCK}.
 	 *
 	 * @param object a persistent or transient instance
 	 * @param lockMode the lock level
-	 *
-	 * @see #buildLockRequest(LockOptions)
-	 * @see LockRequest#lock(Object)
 	 */
 	void lock(Object object, LockMode lockMode);
 
 	/**
-	 * Obtain the specified lock level on the given managed instance association with
-	 * this session. This may be used to:
+	 * Obtain a lock on the given managed instance associated with this session,
+	 * using the given {@link LockOptions lock options}.
+	 * <p>
+	 * This operation cascades to associated instances if the association is
+	 * mapped with {@link org.hibernate.annotations.CascadeType#LOCK}.
+	 *
+	 * @param object a persistent or transient instance
+	 * @param lockOptions the lock options
+	 */
+	void lock(Object object, LockOptions lockOptions);
+
+	/**
+	 * Obtain the specified lock level on the given managed instance associated
+	 * with this session. This may be used to:
 	 * <ul>
 	 * <li>perform a version check with {@link LockMode#READ}, or
 	 * <li>upgrade to a pessimistic lock with {@link LockMode#PESSIMISTIC_WRITE}).
 	 * </ul>
-	 * This operation cascades to associated instances if the association is mapped
-	 * with {@link org.hibernate.annotations.CascadeType#LOCK}.
-	 * <p>
-	 * Convenient form of {@link LockRequest#lock(String, Object)} via
-	 * {@link #buildLockRequest(LockOptions)}
+	 * This operation cascades to associated instances if the association is
+	 * mapped with {@link org.hibernate.annotations.CascadeType#LOCK}.
 	 *
 	 * @param entityName the name of the entity
 	 * @param object a persistent or transient instance
 	 * @param lockMode the lock level
-	 *
-	 * @see #buildLockRequest(LockOptions)
-	 * @see LockRequest#lock(String, Object)
 	 */
 	void lock(String entityName, Object object, LockMode lockMode);
+
+	/**
+	 * Obtain a lock on the given managed instance associated with this session,
+	 * using the given {@link LockOptions lock options}.
+	 * <p>
+	 * This operation cascades to associated instances if the association is
+	 * mapped with {@link org.hibernate.annotations.CascadeType#LOCK}.
+	 *
+	 * @param entityName the name of the entity
+	 * @param lockOptions the lock options
+	 */
+	void lock(String entityName, Object object, LockOptions lockOptions);
 
 	/**
 	 * Build a new {@link LockRequest lock request} that specifies:
 	 * <ul>
 	 * <li>the {@link LockMode} to use,
-	 * <li>the pessimistic lock timeout, and
-	 * <li>the {@linkplain LockRequest#setScope(boolean) scope} of the lock.
+	 * <li>the {@linkplain LockRequest#setTimeOut(int) pessimistic lock timeout},
+	 *     and
+	 * <li>the {@linkplain LockRequest#setLockScope(PessimisticLockScope) scope}
+	 *     that is, whether the lock extends to rows of owned collections.
 	 * </ul>
-	 * Timeout and scope are ignored if the specified {@code LockMode} represents a
-	 * form of {@linkplain LockMode#OPTIMISTIC optimistic} locking.
+	 * Timeout and scope are ignored if the specified {@code LockMode} represents
+	 * a flavor of {@linkplain LockMode#OPTIMISTIC optimistic} locking.
 	 * <p>
 	 * Call {@link LockRequest#lock(Object)} to actually obtain the requested lock
 	 * on a managed entity instance.
-	 * <p>
-	 * Example usage:
-	 * {@code session.buildLockRequest().setLockMode(LockMode.PESSIMISTIC_WRITE).setTimeOut(60000).lock(entity);}
 	 *
 	 * @param lockOptions contains the lock level
 	 *
 	 * @return a {@link LockRequest} that can be used to lock any given object.
+	 *
+	 * @deprecated use {@link #lock(Object, LockOptions)}
 	 */
+	@Deprecated(since = "6.2")
 	LockRequest buildLockRequest(LockOptions lockOptions);
 
 	/**
@@ -720,8 +734,10 @@ public interface Session extends SharedSessionContract, EntityManager {
 	 * from the underlying database. This may be useful:
 	 * <ul>
 	 * <li>when a database trigger alters the object state upon insert or update
-	 * <li>after {@linkplain #createMutationQuery(String) executing} any HQL update or delete statement
-	 * <li>after {@linkplain #createNativeMutationQuery(String) executing} a native SQL statement
+	 * <li>after {@linkplain #createMutationQuery(String) executing} any HQL update
+	 *     or delete statement
+	 * <li>after {@linkplain #createNativeMutationQuery(String) executing} a native
+	 *     SQL statement
 	 * <li>after inserting a {@link java.sql.Blob} or {@link java.sql.Clob}
 	 * </ul>
 	 * This operation cascades to associated instances if the association is mapped
@@ -736,8 +752,10 @@ public interface Session extends SharedSessionContract, EntityManager {
 	 * from the underlying database. This may be useful:
 	 * <ul>
 	 * <li>when a database trigger alters the object state upon insert or update
-	 * <li>after {@linkplain #createMutationQuery(String) executing} any HQL update or delete statement
-	 * <li>after {@linkplain #createNativeMutationQuery(String) executing} a native SQL statement
+	 * <li>after {@linkplain #createMutationQuery(String) executing} any HQL update
+	 *     or delete statement
+	 * <li>after {@linkplain #createNativeMutationQuery(String) executing} a native
+	 *     SQL statement
 	 * <li>after inserting a {@link java.sql.Blob} or {@link java.sql.Clob}
 	 * </ul>
 	 * This operation cascades to associated instances if the association is mapped
@@ -1206,19 +1224,26 @@ public interface Session extends SharedSessionContract, EntityManager {
 	SharedSessionBuilder sessionWithOptions();
 
 	/**
-	 * Contains locking details (LockMode, Timeout and Scope).
+	 * A set of {@linkplain LockOptions locking options} attached
+	 * to the session.
+	 *
+	 * @deprecated simply construct a {@link LockOptions} and pass
+	 *             it to {@link #lock(Object, LockOptions)}.
 	 */
+	@Deprecated(since = "6.2")
 	interface LockRequest {
 		/**
-		 * Constant usable as a timeout value indicating that no wait semantics should
-		 * be used in attempting to acquire locks.
+		 * A timeout value indicating that the database should not
+		 * wait at all to acquire a pessimistic lock which is not
+		 * immediately available.
 		 */
-		int PESSIMISTIC_NO_WAIT = 0;
+		int PESSIMISTIC_NO_WAIT = LockOptions.NO_WAIT;
+
 		/**
-		 * Constant usable as a timeout value indicating that attempting to acquire
-		 * locks should be allowed to wait forever, that is, that there's no timeout.
+		 * A timeout value indicating that attempting to acquire
+		 * that there is no timeout for the lock acquisition.
 		 */
-		int PESSIMISTIC_WAIT_FOREVER = -1;
+		int PESSIMISTIC_WAIT_FOREVER = LockOptions.WAIT_FOREVER;
 
 		/**
 		 * Get the lock mode.

--- a/hibernate-core/src/main/java/org/hibernate/Session.java
+++ b/hibernate-core/src/main/java/org/hibernate/Session.java
@@ -8,6 +8,7 @@ package org.hibernate;
 
 import java.util.List;
 
+import jakarta.persistence.PessimisticLockScope;
 import org.hibernate.graph.RootGraph;
 import org.hibernate.query.Query;
 import org.hibernate.stat.SessionStatistics;
@@ -1209,13 +1210,13 @@ public interface Session extends SharedSessionContract, EntityManager {
 	 */
 	interface LockRequest {
 		/**
-		 * Constant usable as a time out value that indicates no wait semantics should
+		 * Constant usable as a timeout value indicating that no wait semantics should
 		 * be used in attempting to acquire locks.
 		 */
 		int PESSIMISTIC_NO_WAIT = 0;
 		/**
-		 * Constant usable as a time out value that indicates that attempting to acquire
-		 * locks should be allowed to wait forever (apply no timeout).
+		 * Constant usable as a timeout value indicating that attempting to acquire
+		 * locks should be allowed to wait forever, that is, that there's no timeout.
 		 */
 		int PESSIMISTIC_WAIT_FOREVER = -1;
 
@@ -1243,9 +1244,10 @@ public interface Session extends SharedSessionContract, EntityManager {
 		int getTimeOut();
 
 		/**
-		 * Specify the pessimistic lock timeout. The default pessimistic lock behavior
-		 * is to wait forever for the lock. Lock timeout support is not available in
-		 * all {@link org.hibernate.dialect.Dialect SQL dialects}.
+		 * Specify the pessimistic lock timeout. The default pessimistic lock
+		 * behavior is to wait forever for the lock. Lock timeout support is
+		 * not available in every {@link org.hibernate.dialect.Dialect dialect}
+		 * of SQL.
 		 *
 		 * @param timeout is time in milliseconds to wait for lock.
 		 *                -1 means wait forever and 0 means no wait.
@@ -1255,23 +1257,42 @@ public interface Session extends SharedSessionContract, EntityManager {
 		LockRequest setTimeOut(int timeout);
 
 		/**
-		 * Check if locking is cascaded to owned collections and associated entities.
+		 * Check if locking extends to owned collections and associated entities.
 		 *
 		 * @return true if locking will be extended to owned collections and associated entities
+		 *
+		 * @deprecated use {@link #getLockScope()}
 		 */
+		@Deprecated(since = "6.2")
 		boolean getScope();
 
 		/**
-		 * Specify whether the {@link LockMode} should be cascaded to owned collections
+		 * Check if locking extends to owned collections and associated entities.
+		 *
+		 * @return true if locking will be extended to owned collections and associated entities
+		 */
+		default PessimisticLockScope getLockScope() {
+			return getScope() ? PessimisticLockScope.EXTENDED : PessimisticLockScope.NORMAL;
+		}
+
+		/**
+		 * Specify whether the {@link LockMode} should extend to owned collections
 		 * and associated entities. An association must be mapped with
-		 * {@link org.hibernate.annotations.CascadeType#LOCK} for this setting to have
-		 * any effect.
+		 * {@link org.hibernate.annotations.CascadeType#LOCK} for this setting to
+		 * have any effect.
 		 *
 		 * @param scope {@code true} to cascade locks; {@code false} to not.
 		 *
 		 * @return {@code this}, for method chaining
+		 *
+		 * @deprecated use {@link #setLockScope(PessimisticLockScope)}
 		 */
+		@Deprecated(since = "6.2")
 		LockRequest setScope(boolean scope);
+
+		default LockRequest setLockScope(PessimisticLockScope scope) {
+			return setScope( scope == PessimisticLockScope.EXTENDED );
+		}
 
 		/**
 		 * Perform the requested locking.

--- a/hibernate-core/src/main/java/org/hibernate/Session.java
+++ b/hibernate-core/src/main/java/org/hibernate/Session.java
@@ -742,6 +742,9 @@ public interface Session extends SharedSessionContract, EntityManager {
 	 * </ul>
 	 * This operation cascades to associated instances if the association is mapped
 	 * with {@link jakarta.persistence.CascadeType#REFRESH}.
+	 * <p>
+	 * This operation requests {@link LockMode#READ}. To obtain a stronger lock,
+	 * call {@link #refresh(Object, LockMode)}.
 	 *
 	 * @param object a persistent or detached instance
 	 */
@@ -844,9 +847,24 @@ public interface Session extends SharedSessionContract, EntityManager {
 	/**
 	 * Return the persistent instance of the given entity class with the given identifier,
 	 * or null if there is no such persistent instance. If the instance is already associated
-	 * with the session, return that instance. This method never returns an uninitialized instance.
+	 * with the session, return that instance. This method never returns an uninitialized
+	 * instance.
 	 * <p>
 	 * This operation is very similar to {@link #find(Class, Object)}.
+	 * <p>
+	 * This operation requests {@link LockMode#NONE}, that is, no lock, allowing the object
+	 * to be retrieved from the cache without the cost of database access. However, if it is
+	 * necessary to read the state from the database, the object will be returned with the
+	 * lock mode {@link LockMode#READ}.
+	 * <p>
+	 * To bypass the second-level cache, and ensure that the state is read from the database,
+	 * either:
+	 * <ul>
+	 * <li>call {@link #get(Class, Object, LockMode)} with the explicit lock mode
+	 *     {@link LockMode#READ}, or
+	 * <li>{@linkplain #setCacheMode(CacheMode) set the cache mode} to {@link CacheMode#IGNORE}
+	 *     before calling this method.
+	 * </ul>
 	 *
 	 * @param entityType the entity type
 	 * @param id an identifier
@@ -858,8 +876,8 @@ public interface Session extends SharedSessionContract, EntityManager {
 	/**
 	 * Return the persistent instance of the given entity class with the given identifier,
 	 * or null if there is no such persistent instance. If the instance is already associated
-	 * with the session, return that instance. This method never returns an uninitialized instance.
-	 * Obtain the specified lock mode if the instance exists.
+	 * with the session, return that instance. This method never returns an uninitialized
+	 * instance. Obtain the specified lock mode if the instance exists.
 	 * <p>
 	 * Convenient form of {@link #get(Class, Object, LockOptions)}.
 	 * <p>
@@ -878,8 +896,8 @@ public interface Session extends SharedSessionContract, EntityManager {
 	/**
 	 * Return the persistent instance of the given entity class with the given identifier,
 	 * or null if there is no such persistent instance. If the instance is already associated
-	 * with the session, return that instance. This method never returns an uninitialized instance.
-	 * Obtain the specified lock mode if the instance exists.
+	 * with the session, return that instance. This method never returns an uninitialized
+	 * instance. Obtain the specified lock mode if the instance exists.
 	 *
 	 * @param entityType the entity type
 	 * @param id an identifier
@@ -892,7 +910,8 @@ public interface Session extends SharedSessionContract, EntityManager {
 	/**
 	 * Return the persistent instance of the given named entity with the given identifier,
 	 * or null if there is no such persistent instance. If the instance is already associated
-	 * with the session, return that instance. This method never returns an uninitialized instance.
+	 * with the session, return that instance. This method never returns an uninitialized
+	 * instance.
 	 *
 	 * @param entityName the entity name
 	 * @param id an identifier
@@ -903,9 +922,9 @@ public interface Session extends SharedSessionContract, EntityManager {
 
 	/**
 	 * Return the persistent instance of the given entity class with the given identifier,
-	 * or null if there is no such persistent instance. (If the instance is already associated
-	 * with the session, return that instance. This method never returns an uninitialized instance.)
-	 * Obtain the specified lock mode if the instance exists.
+	 * or null if there is no such persistent instance. If the instance is already associated
+	 * with the session, return that instance. This method never returns an uninitialized
+	 * instance. Obtain the specified lock mode if the instance exists.
 	 * <p/>
 	 * Convenient form of {@link #get(String, Object, LockOptions)}
 	 *
@@ -922,8 +941,8 @@ public interface Session extends SharedSessionContract, EntityManager {
 	/**
 	 * Return the persistent instance of the given entity class with the given identifier,
 	 * or null if there is no such persistent instance. If the instance is already associated
-	 * with the session, return that instance. This method never returns an uninitialized instance.
-	 * Obtain the specified lock mode if the instance exists.
+	 * with the session, return that instance. This method never returns an uninitialized
+	 * instance. Obtain the specified lock mode if the instance exists.
 	 *
 	 * @param entityName the entity name
 	 * @param id an identifier
@@ -1235,7 +1254,8 @@ public interface Session extends SharedSessionContract, EntityManager {
 		/**
 		 * A timeout value indicating that the database should not
 		 * wait at all to acquire a pessimistic lock which is not
-		 * immediately available.
+		 * immediately available. This has the same effect as
+		 * {@link LockMode#UPGRADE_NOWAIT}.
 		 */
 		int PESSIMISTIC_NO_WAIT = LockOptions.NO_WAIT;
 

--- a/hibernate-core/src/main/java/org/hibernate/dialect/Dialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/Dialect.java
@@ -1874,10 +1874,10 @@ public abstract class Dialect implements ConversionContext {
 	}
 
 	/**
-	 * Get the {@code FOR UPDATE OF column_list} fragment appropriate for this
-	 * dialect given the aliases of the columns to be write locked.
+	 * Get the {@code FOR UPDATE OF} or {@code FOR SHARE OF} fragment appropriate
+	 * for this dialect given the aliases of the columns to be locked.
 	 *
-	 * @param aliases The columns to be write locked.
+	 * @param aliases The columns to be locked.
 	 * @param lockOptions the lock options to apply
 	 * @return The appropriate {@code FOR UPDATE OF column_list} clause string.
 	 */

--- a/hibernate-core/src/main/java/org/hibernate/dialect/Dialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/Dialect.java
@@ -3258,7 +3258,7 @@ public abstract class Dialect implements ConversionContext {
 	}
 
 	/**
-	 * Get the UniqueDelegate supported by this dialect
+	 * Get the {@link UniqueDelegate} supported by this dialect
 	 *
 	 * @return The UniqueDelegate
 	 */

--- a/hibernate-core/src/main/java/org/hibernate/dialect/PostgreSQLDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/PostgreSQLDialect.java
@@ -691,9 +691,7 @@ public class PostgreSQLDialect extends Dialect {
 
 	@Override
 	public String getForUpdateString(String aliases, LockOptions lockOptions) {
-		/*
-		 * Parent's implementation for (aliases, lockOptions) ignores aliases.
-		 */
+		// parent's implementation for (aliases, lockOptions) ignores aliases
 		if ( aliases.isEmpty() ) {
 			LockMode lockMode = lockOptions.getLockMode();
 			for ( Map.Entry<String, LockMode> entry : lockOptions.getAliasSpecificLocks() ) {

--- a/hibernate-core/src/main/java/org/hibernate/dialect/lock/OptimisticForceIncrementLockingStrategy.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/lock/OptimisticForceIncrementLockingStrategy.java
@@ -15,10 +15,11 @@ import org.hibernate.event.spi.EventSource;
 import org.hibernate.persister.entity.Lockable;
 
 /**
- * An optimistic locking strategy that forces an increment of the version (after verifying that version hasn't changed).
- * This takes place just prior to transaction commit.
- * <p/>
- * This strategy is valid for LockMode.OPTIMISTIC_FORCE_INCREMENT
+ * An optimistic locking strategy that verifies that the version
+ * has not changed and then forces an increment of the version,
+ * just before committing the transaction.
+ * <p>
+ * This strategy is valid for {@link LockMode#OPTIMISTIC_FORCE_INCREMENT}.
  *
  * @author Scott Marlow
  * @since 3.5

--- a/hibernate-core/src/main/java/org/hibernate/dialect/lock/OptimisticLockingStrategy.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/lock/OptimisticLockingStrategy.java
@@ -14,9 +14,10 @@ import org.hibernate.event.spi.EventSource;
 import org.hibernate.persister.entity.Lockable;
 
 /**
- * An optimistic locking strategy that verifies that the version hasn't changed (prior to transaction commit).
+ * An optimistic locking strategy that simply verifies that the
+ * version has not changed, just before committing the transaction.
  * <p/>
- * This strategy is valid for LockMode.OPTIMISTIC
+ * This strategy is valid for {@link LockMode#OPTIMISTIC}.
  *
  * @author Scott Marlow
  * @since 3.5

--- a/hibernate-core/src/main/java/org/hibernate/dialect/lock/PessimisticForceIncrementLockingStrategy.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/lock/PessimisticForceIncrementLockingStrategy.java
@@ -14,9 +14,10 @@ import org.hibernate.persister.entity.EntityPersister;
 import org.hibernate.persister.entity.Lockable;
 
 /**
- * A pessimistic locking strategy that increments the version immediately (obtaining an exclusive write lock).
- * <p/>
- * This strategy is valid for LockMode.PESSIMISTIC_FORCE_INCREMENT
+ * A pessimistic locking strategy where a lock is obtained by incrementing
+ * the version immediately, obtaining an exclusive write lock by side effect.
+ * <p>
+ * This strategy is valid for {@link LockMode#PESSIMISTIC_FORCE_INCREMENT}.
  *
  * @author Scott Marlow
  * @since 3.5

--- a/hibernate-core/src/main/java/org/hibernate/dialect/lock/PessimisticReadSelectLockingStrategy.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/lock/PessimisticReadSelectLockingStrategy.java
@@ -23,14 +23,15 @@ import org.hibernate.sql.SimpleSelect;
 import org.hibernate.stat.spi.StatisticsImplementor;
 
 /**
- * A pessimistic locking strategy where the locks are obtained through select statements.
- * <p/>
- * For non-read locks, this is achieved through the Dialect's specific
- * SELECT ... FOR UPDATE syntax.
- *
- * This strategy is valid for LockMode.PESSIMISTIC_READ
- *
- * This class is a clone of SelectLockingStrategy.
+ * A pessimistic locking strategy where a lock is obtained via a
+ * select statements.
+ * <p>
+ * For non-read locks, this is achieved through the dialect's native
+ * {@code SELECT ... FOR UPDATE} syntax.
+ * <p>
+ * This strategy is valid for {@link LockMode#PESSIMISTIC_READ}.
+ * <p>
+ * This class is a clone of {@link SelectLockingStrategy}.
  *
  * @author Steve Ebersole
  * @author Scott Marlow

--- a/hibernate-core/src/main/java/org/hibernate/dialect/lock/PessimisticReadUpdateLockingStrategy.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/lock/PessimisticReadUpdateLockingStrategy.java
@@ -25,11 +25,12 @@ import org.hibernate.stat.spi.StatisticsImplementor;
 import org.jboss.logging.Logger;
 
 /**
- * A pessimistic locking strategy where the locks are obtained through update statements.
- * <p/>
- * This strategy is valid for LockMode.PESSIMISTIC_READ
- *
- * This class is a clone of UpdateLockingStrategy.
+ * A pessimistic locking strategy where a lock is obtained via
+ * an update statement.
+ * <p>
+ * This strategy is valid for {@link LockMode#PESSIMISTIC_READ}.
+ * <p>
+ * This class is a clone of {@link UpdateLockingStrategy}.
  *
  * @author Steve Ebersole
  * @author Scott Marlow

--- a/hibernate-core/src/main/java/org/hibernate/dialect/lock/PessimisticWriteSelectLockingStrategy.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/lock/PessimisticWriteSelectLockingStrategy.java
@@ -23,14 +23,15 @@ import org.hibernate.sql.SimpleSelect;
 import org.hibernate.stat.spi.StatisticsImplementor;
 
 /**
- * A pessimistic locking strategy where the locks are obtained through select statements.
- * <p/>
- * For non-read locks, this is achieved through the Dialect's specific
- * SELECT ... FOR UPDATE syntax.
- *
- * This strategy is valid for LockMode.PESSIMISTIC_WRITE
- *
- * This class is a clone of SelectLockingStrategy.
+ * A pessimistic locking strategy where a lock is obtained via a
+ * select statement.
+ * <p>
+ * For non-read locks, this is achieved through the dialect's native
+ * {@code SELECT ... FOR UPDATE} syntax.
+ * <p>
+ * This strategy is valid for {@link LockMode#PESSIMISTIC_WRITE}.
+ * <p>
+ * This class is a clone of {@link SelectLockingStrategy}.
  *
  * @see org.hibernate.dialect.Dialect#getForUpdateString(LockMode)
  * @see org.hibernate.dialect.Dialect#appendLockHint(LockOptions, String)

--- a/hibernate-core/src/main/java/org/hibernate/dialect/lock/PessimisticWriteUpdateLockingStrategy.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/lock/PessimisticWriteUpdateLockingStrategy.java
@@ -25,11 +25,12 @@ import org.hibernate.stat.spi.StatisticsImplementor;
 import org.jboss.logging.Logger;
 
 /**
- * A pessimistic locking strategy where the locks are obtained through update statements.
- * <p/>
- * This strategy is valid for LockMode.PESSIMISTIC_WRITE
- *
- * This class is a clone of UpdateLockingStrategy.
+ * A pessimistic locking strategy where a lock is obtained via
+ * an update statement.
+ * <p>
+ * This strategy is valid for {@link LockMode#PESSIMISTIC_WRITE}.
+ * <p>
+ * This class is a clone of {@link UpdateLockingStrategy}.
  *
  * @author Steve Ebersole
  * @author Scott Marlow

--- a/hibernate-core/src/main/java/org/hibernate/dialect/lock/SelectLockingStrategy.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/lock/SelectLockingStrategy.java
@@ -23,10 +23,10 @@ import org.hibernate.sql.SimpleSelect;
 import org.hibernate.stat.spi.StatisticsImplementor;
 
 /**
- * A locking strategy where the locks are obtained through select statements.
+ * A locking strategy where a lock is obtained via a select statement.
  * <p/>
- * For non-read locks, this is achieved through the Dialect's specific
- * SELECT ... FOR UPDATE syntax.
+ * For non-read locks, this is achieved through the dialect's native
+ * {@code SELECT ... FOR UPDATE} syntax.
  *
  * @see org.hibernate.dialect.Dialect#getForUpdateString(LockMode)
  * @see org.hibernate.dialect.Dialect#appendLockHint(LockOptions, String)

--- a/hibernate-core/src/main/java/org/hibernate/dialect/lock/UpdateLockingStrategy.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/lock/UpdateLockingStrategy.java
@@ -27,8 +27,8 @@ import org.hibernate.type.Type;
 import org.jboss.logging.Logger;
 
 /**
- * A locking strategy where the locks are obtained through update statements.
- * <p/>
+ * A locking strategy where a lock is obtained via an update statement.
+ * <p>
  * This strategy is not valid for read style locks.
  *
  * @author Steve Ebersole

--- a/hibernate-core/src/main/java/org/hibernate/engine/spi/SessionDelegatorBaseImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/spi/SessionDelegatorBaseImpl.java
@@ -882,6 +882,16 @@ public class SessionDelegatorBaseImpl implements SessionImplementor {
 	}
 
 	@Override
+	public void lock(String entityName, Object object, LockOptions lockOptions) {
+		delegate.lock( entityName, object, lockOptions );
+	}
+
+	@Override
+	public void lock(Object object, LockOptions lockOptions) {
+		delegate.lock( object, lockOptions );
+	}
+
+	@Override @Deprecated
 	public LockRequest buildLockRequest(LockOptions lockOptions) {
 		return delegate.buildLockRequest( lockOptions );
 	}

--- a/hibernate-core/src/main/java/org/hibernate/engine/spi/SessionLazyDelegator.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/spi/SessionLazyDelegator.java
@@ -281,6 +281,17 @@ public class SessionLazyDelegator implements Session {
 	}
 
 	@Override
+	public void lock(Object object, LockOptions lockOptions) {
+		this.lazySession.get().lock( object, lockOptions );
+	}
+
+	@Override
+	public void lock(String entityName, Object object, LockOptions lockOptions) {
+		this.lazySession.get().lock( entityName, object, lockOptions );
+	}
+
+	@Override
+	@Deprecated
 	public LockRequest buildLockRequest(LockOptions lockOptions) {
 		return this.lazySession.get().buildLockRequest( lockOptions );
 	}

--- a/hibernate-core/src/main/java/org/hibernate/event/spi/RefreshEvent.java
+++ b/hibernate-core/src/main/java/org/hibernate/event/spi/RefreshEvent.java
@@ -19,7 +19,7 @@ public class RefreshEvent extends AbstractEvent {
 	private final Object object;
 	private String entityName;
 
-	private LockOptions lockOptions = new LockOptions().setLockMode(LockMode.READ);
+	private LockOptions lockOptions = new LockOptions(LockMode.READ);
 
 	public RefreshEvent(Object object, EventSource source) {
 		super(source);

--- a/hibernate-core/src/main/java/org/hibernate/internal/SessionImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/SessionImpl.java
@@ -675,11 +675,21 @@ public class SessionImpl
 	// lock() operations ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 	@Override
+	public void lock(Object object, LockOptions lockOptions) {
+		fireLock( new LockEvent( object, lockOptions, this ) );
+	}
+
+	@Override
+	public void lock(String entityName, Object object, LockOptions lockOptions) {
+		fireLock( new LockEvent( entityName, object, lockOptions, this ) );
+	}
+
+	@Override
 	public void lock(String entityName, Object object, LockMode lockMode) throws HibernateException {
 		fireLock( new LockEvent( entityName, object, lockMode, this ) );
 	}
 
-	@Override
+	@Override @Deprecated
 	public LockRequest buildLockRequest(LockOptions lockOptions) {
 		return new LockRequestImpl( lockOptions );
 	}
@@ -2109,6 +2119,7 @@ public class SessionImpl
 		}
 	}
 
+	@Deprecated
 	private class LockRequestImpl implements LockRequest {
 		private final LockOptions lockOptions;
 

--- a/hibernate-core/src/main/java/org/hibernate/procedure/internal/ProcedureCallImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/procedure/internal/ProcedureCallImpl.java
@@ -23,6 +23,7 @@ import java.util.stream.Stream;
 
 import org.hibernate.HibernateException;
 import org.hibernate.LockMode;
+import org.hibernate.LockOptions;
 import org.hibernate.ScrollMode;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
@@ -327,11 +328,6 @@ public class ProcedureCallImpl<R>
 	@Override
 	public MutableQueryOptions getQueryOptions() {
 		return queryOptions;
-	}
-
-	@Override
-	public QueryImplementor<R> setLockMode(String alias, LockMode lockMode) {
-		throw new IllegalStateException( "Cannot set LockMode on a procedure-call" );
 	}
 
 	@Override
@@ -1086,13 +1082,23 @@ public class ProcedureCallImpl<R>
 	}
 
 	@Override
+	public QueryImplementor<R> setLockMode(String alias, LockMode lockMode) {
+		throw new UnsupportedOperationException( "setLockMode does not apply to procedure calls" );
+	}
+
+	@Override
 	public ProcedureCallImplementor<R> setLockMode(LockModeType lockMode) {
-		throw new IllegalStateException("jakarta.persistence.Query.setLockMode not valid on jakarta.persistence.StoredProcedureQuery" );
+		throw new UnsupportedOperationException( "setLockMode does not apply to procedure calls" );
 	}
 
 	@Override
 	public LockModeType getLockMode() {
-		throw new IllegalStateException( "jakarta.persistence.Query.getHibernateFlushMode not valid on jakarta.persistence.StoredProcedureQuery" );
+		throw new UnsupportedOperationException( "getLockMode does not apply to procedure calls" );
+	}
+
+	@Override
+	public QueryImplementor<R> setLockOptions(LockOptions lockOptions) {
+		throw new UnsupportedOperationException( "setLockOptions does not apply to procedure calls" );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/query/NativeQuery.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/NativeQuery.java
@@ -39,9 +39,9 @@ import org.hibernate.type.BasicTypeReference;
  *     </li>
  *     <li>
  *         Tables used via {@link #addSynchronizedQuerySpace}, {@link #addSynchronizedEntityName} and
- *         {@link org.hibernate.query.SynchronizeableQuery#addSynchronizedEntityClass}.  This allows Hibernate to know how to properly deal with
- *         auto-flush checking as well as cached query results if the results of the query are being
- *         cached.
+ *         {@link org.hibernate.query.SynchronizeableQuery#addSynchronizedEntityClass}.  This allows
+ *         Hibernate to know how to properly deal with auto-flush checking as well as cached query
+ *         results if the results of the query are being cached.
  *     </li>
  * </ul>
  *
@@ -51,7 +51,8 @@ import org.hibernate.type.BasicTypeReference;
  *         of its metadata
  *     </li>
  *     <li>
- *         A pre-defined (defined in metadata and named) mapping can be associated via {@link org.hibernate.Session#createNativeQuery(String, String)}
+ *         A pre-defined (defined in metadata and named) mapping can be associated via
+ *         {@link org.hibernate.Session#createNativeQuery(String, String)}
  *     </li>
  *     <li>
  *         Defined locally per the various {@link #addEntity}, {@link #addRoot}, {@link #addJoin},

--- a/hibernate-core/src/main/java/org/hibernate/query/Query.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/Query.java
@@ -317,22 +317,22 @@ public interface Query<R> extends SelectionQuery<R>, MutationQuery, TypedQuery<R
 	/**
 	 * Obtains the {@link LockOptions} in effect for this query.
 	 *
-	 * @return The LockOptions
+	 * @return The {@link LockOptions} currently in effect
 	 *
 	 * @see LockOptions
 	 */
+	@Override
 	LockOptions getLockOptions();
 
 	/**
-	 * Set the lock options for the query.
-	 * <p>
-	 * Only the following options are taken into consideration:
-	 * <ol>
-	 * <li>{@link LockOptions#getLockMode()}</li>
-	 * <li>{@link LockOptions#getScope()}</li>
-	 * <li>{@link LockOptions#getTimeOut()}</li>
-	 * </ol>
-	 * For alias-specific locking, use {@link #setLockMode(String, LockMode)}.
+	 * Apply the given {@linkplain LockOptions lock options} to this
+	 * query. Alias-specific lock modes in the given lock options are
+	 * merged with any alias-specific lock mode which have already been
+	 * {@linkplain #setAliasSpecificLockMode(String, LockMode) set}. If
+	 * a lock mode has already been specified for an alias that is among
+	 * the aliases in the given lock options, the lock mode specified in
+	 * the given lock options overrides the lock mode that was already
+	 * set.
 	 *
 	 * @param lockOptions The lock options to apply to the query.
 	 *
@@ -353,13 +353,14 @@ public interface Query<R> extends SelectionQuery<R>, MutationQuery, TypedQuery<R
 	 * driver and database. For maximum portability, the given lock
 	 * mode should be {@link LockMode#PESSIMISTIC_WRITE}.
 	 *
-	 * @param alias a query alias, or {@code "this"} for a collection filter
+	 * @param alias a query alias, or {@code this} for a collection filter
 	 * @param lockMode The lock mode to apply.
 	 *
 	 * @return {@code this}, for method chaining
 	 *
 	 * @see #getLockOptions()
 	 */
+	@Override
 	Query<R> setLockMode(String alias, LockMode lockMode);
 
 	/**

--- a/hibernate-core/src/main/java/org/hibernate/query/SelectionQuery.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/SelectionQuery.java
@@ -21,6 +21,7 @@ import org.hibernate.Incubating;
 import org.hibernate.LockMode;
 import org.hibernate.LockOptions;
 import org.hibernate.NonUniqueResultException;
+import org.hibernate.Remove;
 import org.hibernate.ScrollMode;
 import org.hibernate.ScrollableResults;
 import org.hibernate.Session;
@@ -324,25 +325,33 @@ public interface SelectionQuery<R> extends CommonQueryContract {
 	SelectionQuery<R> setCacheRegion(String cacheRegion);
 
 	/**
-	 * The LockOptions currently in effect for the query
+	 * The {@link LockOptions} currently in effect for the query
 	 */
 	LockOptions getLockOptions();
 
 	/**
-	 * Specify the root LockModeType for the query
+	 * Specify the root {@link LockModeType} for the query
 	 *
 	 * @see #setHibernateLockMode
 	 */
 	SelectionQuery<R> setLockMode(LockModeType lockMode);
 
 	/**
-	 * Specify the root LockMode for the query
+	 * Specify the root {@link LockMode} for the query
 	 */
 	SelectionQuery<R> setHibernateLockMode(LockMode lockMode);
 
 	/**
-	 * Specify a LockMode to apply to a specific alias defined in the query
+	 * Specify a {@link LockMode} to apply to a specific alias defined in the query
 	 */
+	SelectionQuery<R> setLockMode(String alias, LockMode lockMode);
+
+	/**
+	 * Specify a {@link LockMode} to apply to a specific alias defined in the query
+	 *
+	 * @deprecated use {@link #setLockMode(String, LockMode)}
+	 */
+	@Deprecated(since = "6.2") @Remove
 	SelectionQuery<R> setAliasSpecificLockMode(String alias, LockMode lockMode);
 
 	/**

--- a/hibernate-core/src/main/java/org/hibernate/query/spi/AbstractQuery.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/spi/AbstractQuery.java
@@ -247,16 +247,12 @@ public abstract class AbstractQuery<R>
 	@Override
 	public LockModeType getLockMode() {
 		getSession().checkOpen( false );
-
 		return LockModeTypeHelper.getLockModeType( getQueryOptions().getLockOptions().getLockMode() );
 	}
 
 	@Override
 	public QueryImplementor<R> setLockOptions(LockOptions lockOptions) {
-		getQueryOptions().getLockOptions().setLockMode( lockOptions.getLockMode() );
-		getQueryOptions().getLockOptions().setScope( lockOptions.getScope() );
-		getQueryOptions().getLockOptions().setTimeOut( lockOptions.getTimeOut() );
-		getQueryOptions().getLockOptions().setFollowOnLocking( lockOptions.getFollowOnLocking() );
+		getQueryOptions().getLockOptions().overlay( lockOptions );
 		return this;
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/query/spi/AbstractSelectionQuery.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/spi/AbstractSelectionQuery.java
@@ -585,7 +585,10 @@ public abstract class AbstractSelectionQuery<R>
 
 	/**
 	 * Specify a LockMode to apply to a specific alias defined in the query
+	 *
+	 * @deprecated use {{@link #setLockMode(String, LockMode)}}
 	 */
+	@Override @Deprecated
 	public SelectionQuery<R> setAliasSpecificLockMode(String alias, LockMode lockMode) {
 		getLockOptions().setAliasSpecificLockMode( alias, lockMode );
 		return this;

--- a/hibernate-core/src/main/java/org/hibernate/query/spi/QueryOptionsAdapter.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/spi/QueryOptionsAdapter.java
@@ -37,7 +37,7 @@ public abstract class QueryOptionsAdapter implements QueryOptions {
 
 	@Override
 	public LockOptions getLockOptions() {
-		return LockOptions.NONE;
+		return new LockOptions();
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/query/sql/internal/NativeQueryImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sql/internal/NativeQueryImpl.java
@@ -472,24 +472,22 @@ public class NativeQueryImpl<R>
 
 	@Override
 	public LockModeType getLockMode() {
-		throw new IllegalStateException( "Illegal attempt to get lock mode on a native-query" );
+		throw new UnsupportedOperationException( "Illegal attempt to get lock mode on a native-query" );
 	}
 
 	@Override
 	public NativeQueryImplementor<R> setLockOptions(LockOptions lockOptions) {
-		super.setLockOptions( lockOptions );
-		return this;
+		throw new UnsupportedOperationException( "Illegal attempt to set lock options for a native query" );
 	}
 
 	@Override
 	public NativeQueryImplementor<R> setLockMode(String alias, LockMode lockMode) {
-		super.setLockMode( alias, lockMode );
-		return this;
+		throw new UnsupportedOperationException( "Illegal attempt to set lock mode for a native query" );
 	}
 
 	@Override
 	public NativeQueryImplementor<R> setLockMode(LockModeType lockModeType) {
-		throw new IllegalStateException( "Illegal attempt to set lock mode on a native-query" );
+		throw new UnsupportedOperationException( "Illegal attempt to set lock mode for a native query" );
 	}
 
 	@Override
@@ -599,10 +597,8 @@ public class NativeQueryImpl<R>
 	private SelectQueryPlan<R> resolveSelectQueryPlan() {
 		final QueryInterpretationCache.Key cacheKey = generateSelectInterpretationsKey( resultSetMapping );
 		if ( cacheKey != null ) {
-			return getSession().getFactory().getQueryEngine().getInterpretationCache().resolveSelectQueryPlan(
-					cacheKey,
-					() -> createQueryPlan( resultSetMapping )
-			);
+			return getSession().getFactory().getQueryEngine().getInterpretationCache()
+					.resolveSelectQueryPlan( cacheKey, () -> createQueryPlan( resultSetMapping ) );
 		}
 		else {
 			return createQueryPlan( resultSetMapping );

--- a/hibernate-core/src/main/java/org/hibernate/query/sql/spi/NativeQueryImplementor.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sql/spi/NativeQueryImplementor.java
@@ -43,14 +43,10 @@ import jakarta.persistence.metamodel.SingularAttribute;
 public interface NativeQueryImplementor<R> extends QueryImplementor<R>, NativeQuery<R>, NameableQuery {
 
 	@Override
-	default LockOptions getLockOptions() {
-		return null;
-	}
+	LockOptions getLockOptions();
 
 	@Override
-	default LockModeType getLockMode() {
-		return null;
-	}
+	LockModeType getLockMode();
 
 	/**
 	 * Best guess whether this is a select query.  {@code null}

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/internal/SqmSelectionQueryImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/internal/SqmSelectionQueryImpl.java
@@ -456,7 +456,7 @@ public class SqmSelectionQueryImpl<R> extends AbstractSelectionQuery<R> implemen
 	}
 
 	/**
-	 * Specify the root LockMode for the query
+	 * Specify the root {@link LockMode} for the query
 	 */
 	@Override
 	public SqmSelectionQuery<R> setHibernateLockMode(LockMode lockMode) {
@@ -465,10 +465,21 @@ public class SqmSelectionQueryImpl<R> extends AbstractSelectionQuery<R> implemen
 	}
 
 	/**
-	 * Specify a LockMode to apply to a specific alias defined in the query
+	 * Specify a {@link LockMode} to apply to a specific alias defined in the query
+	 *
+	 * @deprecated use {{@link #setLockMode(String, LockMode)}}
+	 */
+	@Override @Deprecated
+	public SqmSelectionQuery<R> setAliasSpecificLockMode(String alias, LockMode lockMode) {
+		getLockOptions().setAliasSpecificLockMode( alias, lockMode );
+		return this;
+	}
+
+	/**
+	 * Specify a {@link LockMode} to apply to a specific alias defined in the query
 	 */
 	@Override
-	public SqmSelectionQuery<R> setAliasSpecificLockMode(String alias, LockMode lockMode) {
+	public SqmSelectionQuery<R> setLockMode(String alias, LockMode lockMode) {
 		getLockOptions().setAliasSpecificLockMode( alias, lockMode );
 		return this;
 	}

--- a/hibernate-core/src/main/java/org/hibernate/sql/SimpleSelect.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/SimpleSelect.java
@@ -43,7 +43,7 @@ public class SimpleSelect {
 
 	protected LockOptions lockOptions = new LockOptions( LockMode.READ );
 
-	private Dialect dialect;
+	private final Dialect dialect;
 
 
 	public SimpleSelect addColumns(String[] columnNames, String[] columnAliases) {
@@ -189,7 +189,7 @@ public class SimpleSelect {
 		}
 
 		if ( lockOptions != null ) {
-			buf = new StringBuilder(dialect.applyLocksToSql( buf.toString(), lockOptions, null ) );
+			buf = new StringBuilder( dialect.applyLocksToSql( buf.toString(), lockOptions, null ) );
 		}
 
 		return dialect.transformSelectString( buf.toString() );

--- a/hibernate-core/src/main/java/org/hibernate/sql/exec/internal/JdbcSelectExecutorStandardImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/exec/internal/JdbcSelectExecutorStandardImpl.java
@@ -421,9 +421,9 @@ public class JdbcSelectExecutorStandardImpl implements JdbcSelectExecutor {
 
 		final RowReader<R> rowReader = ResultsHelper.createRowReader(
 				executionContext,
-				// If follow on locking is used, we must omit the lock options here,
+				// If follow-on locking is used, we must omit the lock options here,
 				// because these lock options are only for Initializers.
-				// If we wouldn't omit this, the follow on lock requests would be no-ops,
+				// If we wouldn't omit this, the follow-on lock requests would be no-ops,
 				// because the EntityEntrys would already have the desired lock mode
 				deferredResultSetAccess.usesFollowOnLocking()
 						? LockOptions.NONE

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/lock/QueryLockingTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/lock/QueryLockingTest.java
@@ -120,7 +120,7 @@ public class QueryLockingTest extends BaseEntityManagerFunctionalTestCase {
 			query.setLockMode( LockModeType.READ );
 			fail( "Should have failed" );
 		}
-		catch (IllegalStateException expected) {
+		catch (UnsupportedOperationException expected) {
 		}
 
 		// however, we should be able to set it using hints


### PR DESCRIPTION
- deprecate `LockRequest` and `buildLockRequest()`, and have `lock()` accept `LockOptions`
- `LockOptions.scope` should be a `PessimisticLockScope`, not `boolean`
- static final instances of `LockOptions` are mutable (!)
- also a bunch of Javadoc improvement for `LockOptions` and friends
- also add some convenience constructors to `LockOptions`
- deprecate `SelectionQuery.setAliasSpecificLockMode()` in favor of `setLockMode()` overload
- clean up the handling and documentation of `setLockOptions()` for queries, with a change to semantics of `LockOptions.overlay()`