### PR TITLE
[on hold] experimental new time/datetime handling

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/dialect/Dialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/Dialect.java
@@ -174,42 +174,7 @@ import jakarta.persistence.TemporalType;
 import static java.lang.Math.ceil;
 import static java.lang.Math.log;
 import static org.hibernate.internal.util.StringHelper.parseCommaSeparatedString;
-import static org.hibernate.type.SqlTypes.ARRAY;
-import static org.hibernate.type.SqlTypes.BIGINT;
-import static org.hibernate.type.SqlTypes.BINARY;
-import static org.hibernate.type.SqlTypes.BLOB;
-import static org.hibernate.type.SqlTypes.BOOLEAN;
-import static org.hibernate.type.SqlTypes.CHAR;
-import static org.hibernate.type.SqlTypes.CLOB;
-import static org.hibernate.type.SqlTypes.DATE;
-import static org.hibernate.type.SqlTypes.DECIMAL;
-import static org.hibernate.type.SqlTypes.DOUBLE;
-import static org.hibernate.type.SqlTypes.FLOAT;
-import static org.hibernate.type.SqlTypes.INTEGER;
-import static org.hibernate.type.SqlTypes.LONG32NVARCHAR;
-import static org.hibernate.type.SqlTypes.LONG32VARBINARY;
-import static org.hibernate.type.SqlTypes.LONG32VARCHAR;
-import static org.hibernate.type.SqlTypes.NCHAR;
-import static org.hibernate.type.SqlTypes.NCLOB;
-import static org.hibernate.type.SqlTypes.NUMERIC;
-import static org.hibernate.type.SqlTypes.NVARCHAR;
-import static org.hibernate.type.SqlTypes.REAL;
-import static org.hibernate.type.SqlTypes.SMALLINT;
-import static org.hibernate.type.SqlTypes.TIME;
-import static org.hibernate.type.SqlTypes.TIMESTAMP;
-import static org.hibernate.type.SqlTypes.TIMESTAMP_UTC;
-import static org.hibernate.type.SqlTypes.TIMESTAMP_WITH_TIMEZONE;
-import static org.hibernate.type.SqlTypes.TIME_WITH_TIMEZONE;
-import static org.hibernate.type.SqlTypes.TINYINT;
-import static org.hibernate.type.SqlTypes.VARBINARY;
-import static org.hibernate.type.SqlTypes.VARCHAR;
-import static org.hibernate.type.SqlTypes.isCharacterType;
-import static org.hibernate.type.SqlTypes.isFloatOrRealOrDouble;
-import static org.hibernate.type.SqlTypes.isIntegral;
-import static org.hibernate.type.SqlTypes.isNumericOrDecimal;
-import static org.hibernate.type.SqlTypes.isNumericType;
-import static org.hibernate.type.SqlTypes.isVarbinaryType;
-import static org.hibernate.type.SqlTypes.isVarcharType;
+import static org.hibernate.type.SqlTypes.*;
 import static org.hibernate.type.descriptor.DateTimeUtils.JDBC_ESCAPE_END;
 import static org.hibernate.type.descriptor.DateTimeUtils.JDBC_ESCAPE_START_DATE;
 import static org.hibernate.type.descriptor.DateTimeUtils.JDBC_ESCAPE_START_TIME;
@@ -3965,25 +3930,25 @@ public abstract class Dialect implements ConversionContext {
 			}
 
 			switch ( jdbcTypeCode ) {
-				case SqlTypes.BIT:
-				case SqlTypes.CHAR:
-				case SqlTypes.NCHAR:
-				case SqlTypes.VARCHAR:
-				case SqlTypes.NVARCHAR:
-				case SqlTypes.BINARY:
-				case SqlTypes.VARBINARY:
-				case SqlTypes.CLOB:
-				case SqlTypes.BLOB:
+				case BIT:
+				case CHAR:
+				case NCHAR:
+				case VARCHAR:
+				case NVARCHAR:
+				case BINARY:
+				case VARBINARY:
+				case CLOB:
+				case BLOB:
 					size.setLength( javaType.getDefaultSqlLength( Dialect.this, jdbcType ) );
 					break;
-				case SqlTypes.LONGVARCHAR:
-				case SqlTypes.LONGNVARCHAR:
-				case SqlTypes.LONGVARBINARY:
+				case LONGVARCHAR:
+				case LONGNVARCHAR:
+				case LONGVARBINARY:
 					size.setLength( javaType.getLongSqlLength() );
 					break;
-				case SqlTypes.FLOAT:
-				case SqlTypes.DOUBLE:
-				case SqlTypes.REAL:
+				case FLOAT:
+				case DOUBLE:
+				case REAL:
 					// this is almost always the thing we use:
 					length = null;
 					size.setPrecision( javaType.getDefaultSqlPrecision( Dialect.this, jdbcType ) );
@@ -3997,18 +3962,21 @@ public abstract class Dialect implements ConversionContext {
 						precision = (int) ceil( precision * LOG_BASE2OF10 );
 					}
 					break;
-				case SqlTypes.TIMESTAMP:
-				case SqlTypes.TIMESTAMP_WITH_TIMEZONE:
-				case SqlTypes.TIMESTAMP_UTC:
+				case TIMESTAMP:
+				case TIMESTAMP_WITH_TIMEZONE:
+				case TIMESTAMP_UTC:
+				case LOCAL_DATE_TIME:
+				case ZONED_DATE_TIME:
+				case OFFSET_DATE_TIME:
 					length = null;
 					size.setPrecision( javaType.getDefaultSqlPrecision( Dialect.this, jdbcType ) );
 					if ( scale != null && scale != 0 ) {
 						throw new IllegalArgumentException("scale has no meaning for timestamps");
 					}
 					break;
-				case SqlTypes.NUMERIC:
-				case SqlTypes.DECIMAL:
-				case SqlTypes.INTERVAL_SECOND:
+				case NUMERIC:
+				case DECIMAL:
+				case INTERVAL_SECOND:
 					size.setPrecision( javaType.getDefaultSqlPrecision( Dialect.this, jdbcType ) );
 					break;
 			}

--- a/hibernate-core/src/main/java/org/hibernate/type/SqlTypes.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/SqlTypes.java
@@ -166,6 +166,11 @@ public class SqlTypes {
 	 */
 	public final static int TIME = Types.TIME;
 
+	public final static int LOCAL_TIME = 5001;
+	public final static int LOCAL_DATE_TIME = 5002;
+	public final static int OFFSET_DATE_TIME = 5003;
+	public final static int ZONED_DATE_TIME = 5004;
+
 	/**
 	 * <P>The constant in the Java programming language, sometimes referred
 	 * to as a type code, that identifies the generic SQL type
@@ -611,7 +616,11 @@ public class SqlTypes {
 			|| typeCode == TIME
 			|| typeCode == TIMESTAMP
 			|| typeCode == TIMESTAMP_WITH_TIMEZONE
-			|| typeCode == TIMESTAMP_UTC;
+			|| typeCode == TIMESTAMP_UTC
+			|| typeCode == LOCAL_TIME
+			|| typeCode == LOCAL_DATE_TIME
+			|| typeCode == OFFSET_DATE_TIME
+			|| typeCode == ZONED_DATE_TIME;
 	}
 
 	/**
@@ -629,7 +638,10 @@ public class SqlTypes {
 		return typeCode == DATE
 			|| typeCode == TIMESTAMP
 			|| typeCode == TIMESTAMP_WITH_TIMEZONE
-			|| typeCode == TIMESTAMP_UTC;
+			|| typeCode == TIMESTAMP_UTC
+			|| typeCode == LOCAL_DATE_TIME
+			|| typeCode == OFFSET_DATE_TIME
+			|| typeCode == ZONED_DATE_TIME;
 	}
 
 	/**
@@ -640,6 +652,10 @@ public class SqlTypes {
 		return typeCode == TIME
 			|| typeCode == TIMESTAMP
 			|| typeCode == TIMESTAMP_WITH_TIMEZONE
-			|| typeCode == TIMESTAMP_UTC;
+			|| typeCode == TIMESTAMP_UTC
+			|| typeCode == LOCAL_TIME
+			|| typeCode == LOCAL_DATE_TIME
+			|| typeCode == OFFSET_DATE_TIME
+			|| typeCode == ZONED_DATE_TIME;
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/type/StandardBasicTypes.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/StandardBasicTypes.java
@@ -362,7 +362,7 @@ public final class StandardBasicTypes {
 	public static final BasicTypeReference<LocalDateTime> LOCAL_DATE_TIME = new BasicTypeReference<>(
 			"LocalDateTime",
 			LocalDateTime.class,
-			SqlTypes.TIMESTAMP
+			SqlTypes.LOCAL_DATE_TIME
 	);
 
 	/**
@@ -380,7 +380,7 @@ public final class StandardBasicTypes {
 	public static final BasicTypeReference<LocalTime> LOCAL_TIME = new BasicTypeReference<>(
 			"LocalTime",
 			LocalTime.class,
-			SqlTypes.TIME
+			SqlTypes.LOCAL_TIME
 	);
 
 	/**
@@ -390,7 +390,7 @@ public final class StandardBasicTypes {
 	public static final BasicTypeReference<OffsetDateTime> OFFSET_DATE_TIME = new BasicTypeReference<>(
 			"OffsetDateTime",
 			OffsetDateTime.class,
-			SqlTypes.TIMESTAMP_WITH_TIMEZONE
+			SqlTypes.OFFSET_DATE_TIME
 	);
 
 	/**
@@ -400,7 +400,7 @@ public final class StandardBasicTypes {
 	public static final BasicTypeReference<OffsetDateTime> OFFSET_DATE_TIME_WITH_TIMEZONE = new BasicTypeReference<>(
 			"OffsetDateTimeWithTimezone",
 			OffsetDateTime.class,
-			SqlTypes.TIMESTAMP_WITH_TIMEZONE
+			SqlTypes.OFFSET_DATE_TIME
 	);
 	/**
 	 * The standard Hibernate type for mapping {@link OffsetDateTime} to JDBC {@link org.hibernate.type.SqlTypes#TIMESTAMP TIMESTAMP}.
@@ -409,7 +409,7 @@ public final class StandardBasicTypes {
 	public static final BasicTypeReference<OffsetDateTime> OFFSET_DATE_TIME_WITHOUT_TIMEZONE = new BasicTypeReference<>(
 			"OffsetDateTimeWithoutTimezone",
 			OffsetDateTime.class,
-			SqlTypes.TIMESTAMP
+			SqlTypes.LOCAL_DATE_TIME
 	);
 
 	/**
@@ -419,7 +419,7 @@ public final class StandardBasicTypes {
 			"OffsetTime",
 			OffsetTime.class,
 			// todo (6.0): why not TIME_WITH_TIMEZONE ?
-			SqlTypes.TIME
+			SqlTypes.LOCAL_TIME
 	);
 
 	/**
@@ -429,7 +429,7 @@ public final class StandardBasicTypes {
 	public static final BasicTypeReference<ZonedDateTime> ZONED_DATE_TIME = new BasicTypeReference<>(
 			"ZonedDateTime",
 			ZonedDateTime.class,
-			SqlTypes.TIMESTAMP_WITH_TIMEZONE
+			SqlTypes.ZONED_DATE_TIME
 	);
 
 	/**
@@ -439,7 +439,7 @@ public final class StandardBasicTypes {
 	public static final BasicTypeReference<ZonedDateTime> ZONED_DATE_TIME_WITH_TIMEZONE = new BasicTypeReference<>(
 			"ZonedDateTimeWithTimezone",
 			ZonedDateTime.class,
-			SqlTypes.TIMESTAMP_WITH_TIMEZONE
+			SqlTypes.ZONED_DATE_TIME
 	);
 
 	/**
@@ -449,7 +449,7 @@ public final class StandardBasicTypes {
 	public static final BasicTypeReference<ZonedDateTime> ZONED_DATE_TIME_WITHOUT_TIMEZONE = new BasicTypeReference<>(
 			"ZonedDateTimeWithoutTimezone",
 			ZonedDateTime.class,
-			SqlTypes.TIMESTAMP
+			SqlTypes.LOCAL_DATE_TIME
 	);
 
 	/**

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/LocalDateTimeJavaType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/LocalDateTimeJavaType.java
@@ -7,7 +7,6 @@
 package org.hibernate.type.descriptor.java;
 
 import java.sql.Timestamp;
-import java.sql.Types;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
@@ -20,6 +19,7 @@ import jakarta.persistence.TemporalType;
 
 import org.hibernate.dialect.Dialect;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
+import org.hibernate.type.SqlTypes;
 import org.hibernate.type.descriptor.WrapperOptions;
 import org.hibernate.type.descriptor.jdbc.JdbcType;
 import org.hibernate.type.descriptor.jdbc.JdbcTypeIndicators;
@@ -48,7 +48,7 @@ public class LocalDateTimeJavaType extends AbstractTemporalJavaType<LocalDateTim
 
 	@Override
 	public JdbcType getRecommendedJdbcType(JdbcTypeIndicators context) {
-		return context.getTypeConfiguration().getJdbcTypeRegistry().getDescriptor( Types.TIMESTAMP );
+		return context.getTypeConfiguration().getJdbcTypeRegistry().getDescriptor( SqlTypes.LOCAL_DATE_TIME );
 	}
 
 	@Override
@@ -149,7 +149,7 @@ public class LocalDateTimeJavaType extends AbstractTemporalJavaType<LocalDateTim
 		}
 
 		if (value instanceof Date) {
-			final Timestamp ts = (Timestamp) value;
+			final Date ts = (Date) value;
 			final Instant instant = Instant.ofEpochMilli( ts.getTime() );
 			return LocalDateTime.ofInstant( instant, ZoneId.systemDefault() );
 		}

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/LocalTimeJavaType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/LocalTimeJavaType.java
@@ -23,6 +23,7 @@ import java.util.GregorianCalendar;
 import jakarta.persistence.TemporalType;
 
 import org.hibernate.dialect.Dialect;
+import org.hibernate.type.SqlTypes;
 import org.hibernate.type.descriptor.WrapperOptions;
 import org.hibernate.type.descriptor.jdbc.JdbcType;
 import org.hibernate.type.descriptor.jdbc.JdbcTypeIndicators;
@@ -50,7 +51,7 @@ public class LocalTimeJavaType extends AbstractTemporalJavaType<LocalTime> {
 
 	@Override
 	public JdbcType getRecommendedJdbcType(JdbcTypeIndicators context) {
-		return context.getTypeConfiguration().getJdbcTypeRegistry().getDescriptor( Types.TIME );
+		return context.getTypeConfiguration().getJdbcTypeRegistry().getDescriptor( SqlTypes.LOCAL_TIME );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/OffsetDateTimeJavaType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/OffsetDateTimeJavaType.java
@@ -9,6 +9,7 @@ package org.hibernate.type.descriptor.java;
 import java.sql.Timestamp;
 import java.sql.Types;
 import java.time.Instant;
+import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
@@ -58,11 +59,11 @@ public class OffsetDateTimeJavaType extends AbstractTemporalJavaType<OffsetDateT
 		if ( temporalPrecision == null || temporalPrecision == TemporalType.TIMESTAMP ) {
 			switch ( stdIndicators.getDefaultTimeZoneStorageStrategy() ) {
 				case NORMALIZE:
-					return jdbcTypeRegistry.getDescriptor( Types.TIMESTAMP );
+					return jdbcTypeRegistry.getDescriptor( SqlTypes.TIMESTAMP );
 				case NORMALIZE_UTC:
 					return jdbcTypeRegistry.getDescriptor( SqlTypes.TIMESTAMP_UTC );
 				default:
-					return jdbcTypeRegistry.getDescriptor( SqlTypes.OFFSET_DATE_TIME );
+					return jdbcTypeRegistry.getDescriptor( SqlTypes.TIMESTAMP_WITH_TIMEZONE );
 			}
 		}
 
@@ -108,6 +109,10 @@ public class OffsetDateTimeJavaType extends AbstractTemporalJavaType<OffsetDateT
 
 		if ( ZonedDateTime.class.isAssignableFrom( type ) ) {
 			return (X) offsetDateTime.toZonedDateTime();
+		}
+
+		if (LocalDateTime.class.isAssignableFrom( type ) ) {
+			return (X) offsetDateTime.atZoneSameInstant( ZoneId.systemDefault() ).toLocalDateTime();
 		}
 
 		if ( Instant.class.isAssignableFrom( type ) ) {
@@ -171,6 +176,11 @@ public class OffsetDateTimeJavaType extends AbstractTemporalJavaType<OffsetDateT
 		if (value instanceof ZonedDateTime) {
 			ZonedDateTime zonedDateTime = (ZonedDateTime) value;
 			return OffsetDateTime.of( zonedDateTime.toLocalDateTime(), zonedDateTime.getOffset() );
+		}
+
+		if (value instanceof LocalDateTime) {
+			LocalDateTime localDateTime = (LocalDateTime) value;
+			return OffsetDateTime.of( localDateTime, OffsetDateTime.now().getOffset() );
 		}
 
 		if (value instanceof Instant) {

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/OffsetDateTimeJavaType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/OffsetDateTimeJavaType.java
@@ -62,7 +62,7 @@ public class OffsetDateTimeJavaType extends AbstractTemporalJavaType<OffsetDateT
 				case NORMALIZE_UTC:
 					return jdbcTypeRegistry.getDescriptor( SqlTypes.TIMESTAMP_UTC );
 				default:
-					return jdbcTypeRegistry.getDescriptor( Types.TIMESTAMP_WITH_TIMEZONE );
+					return jdbcTypeRegistry.getDescriptor( SqlTypes.OFFSET_DATE_TIME );
 			}
 		}
 

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/OffsetTimeJavaType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/OffsetTimeJavaType.java
@@ -11,10 +11,10 @@ import java.sql.Timestamp;
 import java.sql.Types;
 import java.time.Instant;
 import java.time.LocalDate;
+import java.time.LocalTime;
 import java.time.OffsetDateTime;
 import java.time.OffsetTime;
 import java.time.ZoneOffset;
-import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.Calendar;
 import java.util.Date;
@@ -76,31 +76,44 @@ public class OffsetTimeJavaType extends AbstractTemporalJavaType<OffsetTime> {
 			return null;
 		}
 
+		// for java.time types, we assume that the JDBC timezone, if any, is ignored
+
 		if ( OffsetTime.class.isAssignableFrom( type ) ) {
 			return (X) offsetTime;
 		}
 
-		if ( Time.class.isAssignableFrom( type ) ) {
-			return (X) Time.valueOf( offsetTime.toLocalTime() );
+		if ( LocalTime.class.isAssignableFrom( type ) ) {
+			return (X) offsetTime.withOffsetSameInstant( getCurrentSystemOffset() ).toLocalTime();
 		}
 
-		final ZonedDateTime zonedDateTime = offsetTime.atDate( LocalDate.of( 1970, 1, 1 ) ).toZonedDateTime();
+		// for legacy types, we assume that the JDBC timezone is passed to JDBC
+
+		final OffsetTime jdbcOffsetTime = offsetTime.withOffsetSameInstant( getCurrentJdbcOffset(options) );
+
+		if ( Time.class.isAssignableFrom( type ) ) {
+			return (X) Time.valueOf( jdbcOffsetTime.toLocalTime() );
+		}
+
+		final OffsetDateTime jdbcOffsetDateTime = jdbcOffsetTime.atDate( LocalDate.EPOCH );
 
 		if ( Timestamp.class.isAssignableFrom( type ) ) {
 			/*
 			 * Workaround for HHH-13266 (JDK-8061577).
-			 * Ideally we'd want to use Timestamp.from( offsetDateTime.toInstant() ), but this won't always work.
-			 * Timestamp.from() assumes the number of milliseconds since the epoch
-			 * means the same thing in Timestamp and Instant, but it doesn't, in particular before 1900.
+			 * Ideally we'd want to use Timestamp.from( jdbcOffsetDateTime.toInstant() ),
+			 * but this won't always work since Timestamp.from() assumes the number of
+			 * milliseconds since the epoch means the same thing in Timestamp and Instant,
+			 * but it doesn't, in particular before 1900.
 			 */
-			return (X) Timestamp.valueOf( zonedDateTime.toLocalDateTime() );
+			return (X) Timestamp.valueOf( jdbcOffsetDateTime.toLocalDateTime() );
 		}
 
 		if ( Calendar.class.isAssignableFrom( type ) ) {
-			return (X) GregorianCalendar.from( zonedDateTime );
+			return (X) GregorianCalendar.from( jdbcOffsetDateTime.toZonedDateTime() );
 		}
 
-		final Instant instant = zonedDateTime.toInstant();
+		// for instants, we assume that the JDBC timezone, if any, is ignored
+
+		final Instant instant = offsetTime.atDate( LocalDate.EPOCH ).toInstant();
 
 		if ( Long.class.isAssignableFrom( type ) ) {
 			return (X) Long.valueOf( instant.toEpochMilli() );
@@ -119,8 +132,14 @@ public class OffsetTimeJavaType extends AbstractTemporalJavaType<OffsetTime> {
 			return null;
 		}
 
+		// for java.time types, we assume that the JDBC timezone, if any, is ignored
+
 		if (value instanceof OffsetTime) {
 			return (OffsetTime) value;
+		}
+
+		if (value instanceof LocalTime) {
+			return ((LocalTime) value).atOffset( getCurrentSystemOffset() );
 		}
 
 		/*
@@ -137,30 +156,38 @@ public class OffsetTimeJavaType extends AbstractTemporalJavaType<OffsetTime> {
 		 * Of course none of this would be a problem if we just stored the offset in the database,
 		 * but I guess there are historical reasons that explain why we don't.
 		 */
-		ZoneOffset offset = OffsetDateTime.now().getOffset();
+
+		// for legacy types, we assume that the JDBC timezone is passed to JDBC
 
 		if (value instanceof Time) {
-			return ( (Time) value ).toLocalTime().atOffset( offset );
+			final Time time = (Time) value;
+			return time.toLocalTime().atOffset( getCurrentJdbcOffset(options) )
+					.withOffsetSameInstant( getCurrentSystemOffset() );
 		}
 
 		if (value instanceof Timestamp) {
 			final Timestamp ts = (Timestamp) value;
 			/*
 			 * Workaround for HHH-13266 (JDK-8061577).
-			 * Ideally we'd want to use OffsetDateTime.ofInstant( ts.toInstant(), ... ), but this won't always work.
-			 * ts.toInstant() assumes the number of milliseconds since the epoch
-			 * means the same thing in Timestamp and Instant, but it doesn't, in particular before 1900.
+			 * Ideally we'd want to use OffsetDateTime.ofInstant( ts.toInstant(), ... ),
+			 * but this won't always work since ts.toInstant() assumes the number of
+			 * milliseconds since the epoch means the same thing in Timestamp and Instant,
+			 * but it doesn't, in particular before 1900.
 			 */
-			return ts.toLocalDateTime().toLocalTime().atOffset( offset );
+			return ts.toLocalDateTime().toLocalTime().atOffset( getCurrentJdbcOffset(options) )
+					.withOffsetSameInstant( getCurrentSystemOffset() );
 		}
 
 		if (value instanceof Date) {
 			final Date date = (Date) value;
-			return OffsetTime.ofInstant( date.toInstant(), offset );
+			return OffsetTime.ofInstant( date.toInstant(), getCurrentSystemOffset() );
 		}
 
+		// for instants, we assume that the JDBC timezone, if any, is ignored
+
 		if (value instanceof Long) {
-			return OffsetTime.ofInstant( Instant.ofEpochMilli( (Long) value ), offset );
+			final long millis = (Long) value;
+			return OffsetTime.ofInstant( Instant.ofEpochMilli(millis), getCurrentSystemOffset() );
 		}
 
 		if (value instanceof Calendar) {
@@ -169,6 +196,19 @@ public class OffsetTimeJavaType extends AbstractTemporalJavaType<OffsetTime> {
 		}
 
 		throw unknownWrap( value.getClass() );
+	}
+
+	private static ZoneOffset getCurrentJdbcOffset(WrapperOptions options) {
+		if (  options.getJdbcTimeZone() != null ) {
+			return OffsetDateTime.now().atZoneSameInstant( options.getJdbcTimeZone().toZoneId() ).getOffset();
+		}
+		else {
+			return getCurrentSystemOffset();
+		}
+	}
+
+	private static ZoneOffset getCurrentSystemOffset() {
+		return OffsetDateTime.now().getOffset();
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/OffsetTimeJavaType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/OffsetTimeJavaType.java
@@ -8,7 +8,6 @@ package org.hibernate.type.descriptor.java;
 
 import java.sql.Time;
 import java.sql.Timestamp;
-import java.sql.Types;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalTime;
@@ -23,6 +22,7 @@ import java.util.GregorianCalendar;
 import jakarta.persistence.TemporalType;
 
 import org.hibernate.dialect.Dialect;
+import org.hibernate.type.SqlTypes;
 import org.hibernate.type.descriptor.WrapperOptions;
 import org.hibernate.type.descriptor.jdbc.JdbcType;
 import org.hibernate.type.descriptor.jdbc.JdbcTypeIndicators;
@@ -50,7 +50,7 @@ public class OffsetTimeJavaType extends AbstractTemporalJavaType<OffsetTime> {
 
 	@Override
 	public JdbcType getRecommendedJdbcType(JdbcTypeIndicators context) {
-		return context.getTypeConfiguration().getJdbcTypeRegistry().getDescriptor( Types.TIME );
+		return context.getTypeConfiguration().getJdbcTypeRegistry().getDescriptor( SqlTypes.LOCAL_TIME );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/ZonedDateTimeJavaType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/ZonedDateTimeJavaType.java
@@ -58,11 +58,11 @@ public class ZonedDateTimeJavaType extends AbstractTemporalJavaType<ZonedDateTim
 		if ( temporalPrecision == null || temporalPrecision == TemporalType.TIMESTAMP ) {
 			switch ( stdIndicators.getDefaultTimeZoneStorageStrategy() ) {
 				case NORMALIZE:
-					return jdbcTypeRegistry.getDescriptor( Types.TIMESTAMP );
+					return jdbcTypeRegistry.getDescriptor( SqlTypes.TIMESTAMP );
 				case NORMALIZE_UTC:
 					return jdbcTypeRegistry.getDescriptor( SqlTypes.TIMESTAMP_UTC );
 				default:
-					return jdbcTypeRegistry.getDescriptor( SqlTypes.ZONED_DATE_TIME );
+					return jdbcTypeRegistry.getDescriptor( SqlTypes.TIMESTAMP_WITH_TIMEZONE );
 			}
 		}
 

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/ZonedDateTimeJavaType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/ZonedDateTimeJavaType.java
@@ -62,7 +62,7 @@ public class ZonedDateTimeJavaType extends AbstractTemporalJavaType<ZonedDateTim
 				case NORMALIZE_UTC:
 					return jdbcTypeRegistry.getDescriptor( SqlTypes.TIMESTAMP_UTC );
 				default:
-					return jdbcTypeRegistry.getDescriptor( Types.TIMESTAMP_WITH_TIMEZONE );
+					return jdbcTypeRegistry.getDescriptor( SqlTypes.ZONED_DATE_TIME );
 			}
 		}
 

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/jdbc/JdbcType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/jdbc/JdbcType.java
@@ -185,10 +185,14 @@ public interface JdbcType extends Serializable {
 			case Types.DATE:
 				return CastType.DATE;
 			case Types.TIME:
+			case SqlTypes.LOCAL_TIME:
 				return CastType.TIME;
 			case Types.TIMESTAMP:
+			case SqlTypes.LOCAL_DATE_TIME:
 				return CastType.TIMESTAMP;
 			case Types.TIMESTAMP_WITH_TIMEZONE:
+			case SqlTypes.OFFSET_DATE_TIME:
+			case SqlTypes.ZONED_DATE_TIME:
 				return CastType.OFFSET_TIMESTAMP;
 			case Types.NULL:
 				return CastType.NULL;

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/jdbc/LocalDateTimeJdbcType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/jdbc/LocalDateTimeJdbcType.java
@@ -1,0 +1,105 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.type.descriptor.jdbc;
+
+import jakarta.persistence.TemporalType;
+import org.hibernate.type.descriptor.ValueBinder;
+import org.hibernate.type.descriptor.ValueExtractor;
+import org.hibernate.type.descriptor.WrapperOptions;
+import org.hibernate.type.descriptor.java.BasicJavaType;
+import org.hibernate.type.descriptor.java.JavaType;
+import org.hibernate.type.descriptor.jdbc.internal.JdbcLiteralFormatterTemporal;
+import org.hibernate.type.spi.TypeConfiguration;
+
+import java.sql.CallableStatement;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Types;
+import java.time.LocalDateTime;
+
+/**
+ * Descriptor for {@link Types#TIMESTAMP TIMESTAMP} handling.
+ *
+ * @author Steve Ebersole
+ */
+public class LocalDateTimeJdbcType implements JdbcType {
+	public static final LocalDateTimeJdbcType INSTANCE = new LocalDateTimeJdbcType();
+
+	public LocalDateTimeJdbcType() {
+	}
+
+	@Override
+	public int getJdbcTypeCode() {
+		return Types.TIMESTAMP;
+	}
+
+	@Override
+	public String getFriendlyName() {
+		return "LOCAL_DATE_TIME";
+	}
+
+	@Override
+	public String toString() {
+		return "LocalDateTimeTypeDescriptor";
+	}
+
+	@Override
+	public <T> BasicJavaType<T> getJdbcRecommendedJavaTypeMapping(
+			Integer length,
+			Integer scale,
+			TypeConfiguration typeConfiguration) {
+		return (BasicJavaType<T>) typeConfiguration.getJavaTypeRegistry().getDescriptor( LocalDateTime.class );
+	}
+
+	@Override
+	public <T> JdbcLiteralFormatter<T> getJdbcLiteralFormatter(JavaType<T> javaType) {
+		return new JdbcLiteralFormatterTemporal<>( javaType, TemporalType.TIMESTAMP );
+	}
+
+	@Override
+	public Class<?> getPreferredJavaTypeClass(WrapperOptions options) {
+		return LocalDateTime.class;
+	}
+
+	@Override
+	public <X> ValueBinder<X> getBinder(final JavaType<X> javaType) {
+		return new BasicBinder<>( javaType, this ) {
+			@Override
+			protected void doBind(PreparedStatement st, X value, int index, WrapperOptions options) throws SQLException {
+				final LocalDateTime dateTime = javaType.unwrap( value, LocalDateTime.class, options );
+				st.setObject( index, dateTime, Types.TIMESTAMP );
+			}
+
+			@Override
+			protected void doBind(CallableStatement st, X value, String name, WrapperOptions options) throws SQLException {
+				final LocalDateTime dateTime = javaType.unwrap( value, LocalDateTime.class, options );
+				st.setObject( name, dateTime, Types.TIMESTAMP );
+			}
+		};
+	}
+
+	@Override
+	public <X> ValueExtractor<X> getExtractor(final JavaType<X> javaType) {
+		return new BasicExtractor<>( javaType, this ) {
+			@Override
+			protected X doExtract(ResultSet rs, int paramIndex, WrapperOptions options) throws SQLException {
+				return javaType.wrap( rs.getObject( paramIndex, LocalDateTime.class ), options );
+			}
+
+			@Override
+			protected X doExtract(CallableStatement statement, int index, WrapperOptions options) throws SQLException {
+				return javaType.wrap( statement.getObject( index, LocalDateTime.class ), options );
+			}
+
+			@Override
+			protected X doExtract(CallableStatement statement, String name, WrapperOptions options) throws SQLException {
+				return javaType.wrap( statement.getObject( name, LocalDateTime.class ), options );
+			}
+		};
+	}
+}

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/jdbc/LocalDateTimeJdbcType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/jdbc/LocalDateTimeJdbcType.java
@@ -18,6 +18,7 @@ import org.hibernate.type.spi.TypeConfiguration;
 import java.sql.CallableStatement;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
+import java.sql.SQLDataException;
 import java.sql.SQLException;
 import java.sql.Types;
 import java.time.LocalDateTime;
@@ -72,13 +73,23 @@ public class LocalDateTimeJdbcType implements JdbcType {
 			@Override
 			protected void doBind(PreparedStatement st, X value, int index, WrapperOptions options) throws SQLException {
 				final LocalDateTime dateTime = javaType.unwrap( value, LocalDateTime.class, options );
-				st.setObject( index, dateTime, Types.TIMESTAMP );
+				try {
+					st.setObject( index, dateTime, Types.TIMESTAMP );
+				}
+				catch (SQLDataException sde) {
+					st.setObject( index, dateTime );
+				}
 			}
 
 			@Override
 			protected void doBind(CallableStatement st, X value, String name, WrapperOptions options) throws SQLException {
 				final LocalDateTime dateTime = javaType.unwrap( value, LocalDateTime.class, options );
-				st.setObject( name, dateTime, Types.TIMESTAMP );
+				try {
+					st.setObject( name, dateTime, Types.TIMESTAMP );
+				}
+				catch (SQLDataException sde) {
+					st.setObject( name, dateTime );
+				}
 			}
 		};
 	}

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/jdbc/LocalTimeJdbcType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/jdbc/LocalTimeJdbcType.java
@@ -1,0 +1,105 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.type.descriptor.jdbc;
+
+import jakarta.persistence.TemporalType;
+import org.hibernate.type.descriptor.ValueBinder;
+import org.hibernate.type.descriptor.ValueExtractor;
+import org.hibernate.type.descriptor.WrapperOptions;
+import org.hibernate.type.descriptor.java.BasicJavaType;
+import org.hibernate.type.descriptor.java.JavaType;
+import org.hibernate.type.descriptor.jdbc.internal.JdbcLiteralFormatterTemporal;
+import org.hibernate.type.spi.TypeConfiguration;
+
+import java.sql.CallableStatement;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Types;
+import java.time.LocalTime;
+
+/**
+ * Descriptor for {@link Types#TIME TIME} handling.
+ *
+ * @author Steve Ebersole
+ */
+public class LocalTimeJdbcType implements JdbcType {
+	public static final LocalTimeJdbcType INSTANCE = new LocalTimeJdbcType();
+
+	public LocalTimeJdbcType() {
+	}
+
+	@Override
+	public int getJdbcTypeCode() {
+		return Types.TIME;
+	}
+
+	@Override
+	public String getFriendlyName() {
+		return "LOCAL_TIME";
+	}
+
+	@Override
+	public String toString() {
+		return "LocalTimeTypeDescriptor";
+	}
+
+	@Override
+	public <T> BasicJavaType<T> getJdbcRecommendedJavaTypeMapping(
+			Integer length,
+			Integer scale,
+			TypeConfiguration typeConfiguration) {
+		return (BasicJavaType<T>) typeConfiguration.getJavaTypeRegistry().getDescriptor( LocalTime.class );
+	}
+
+	@Override
+	public <T> JdbcLiteralFormatter<T> getJdbcLiteralFormatter(JavaType<T> javaType) {
+		return new JdbcLiteralFormatterTemporal<>( javaType, TemporalType.TIME );
+	}
+
+	@Override
+	public Class<?> getPreferredJavaTypeClass(WrapperOptions options) {
+		return LocalTime.class;
+	}
+
+	@Override
+	public <X> ValueBinder<X> getBinder(final JavaType<X> javaType) {
+		return new BasicBinder<>( javaType, this ) {
+			@Override
+			protected void doBind(PreparedStatement st, X value, int index, WrapperOptions options) throws SQLException {
+				final LocalTime time = javaType.unwrap( value, LocalTime.class, options );
+				st.setObject( index, time, Types.TIME );
+			}
+
+			@Override
+			protected void doBind(CallableStatement st, X value, String name, WrapperOptions options) throws SQLException {
+				final LocalTime time = javaType.unwrap( value, LocalTime.class, options );
+				st.setObject( name, time, Types.TIME );
+			}
+		};
+	}
+
+	@Override
+	public <X> ValueExtractor<X> getExtractor(final JavaType<X> javaType) {
+		return new BasicExtractor<>( javaType, this ) {
+			@Override
+			protected X doExtract(ResultSet rs, int paramIndex, WrapperOptions options) throws SQLException {
+				return javaType.wrap( rs.getObject( paramIndex, LocalTime.class ), options );
+			}
+
+			@Override
+			protected X doExtract(CallableStatement statement, int index, WrapperOptions options) throws SQLException {
+				return javaType.wrap( statement.getObject( index, LocalTime.class ), options );
+			}
+
+			@Override
+			protected X doExtract(CallableStatement statement, String name, WrapperOptions options) throws SQLException {
+				return javaType.wrap( statement.getObject( name, LocalTime.class ), options );
+			}
+		};
+	}
+}

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/jdbc/LocalTimeJdbcType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/jdbc/LocalTimeJdbcType.java
@@ -18,6 +18,7 @@ import org.hibernate.type.spi.TypeConfiguration;
 import java.sql.CallableStatement;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
+import java.sql.SQLDataException;
 import java.sql.SQLException;
 import java.sql.Types;
 import java.time.LocalTime;
@@ -72,13 +73,23 @@ public class LocalTimeJdbcType implements JdbcType {
 			@Override
 			protected void doBind(PreparedStatement st, X value, int index, WrapperOptions options) throws SQLException {
 				final LocalTime time = javaType.unwrap( value, LocalTime.class, options );
-				st.setObject( index, time, Types.TIME );
+				try {
+					st.setObject( index, time, Types.TIME );
+				}
+				catch (SQLDataException sde) {
+					st.setObject( index, time );
+				}
 			}
 
 			@Override
 			protected void doBind(CallableStatement st, X value, String name, WrapperOptions options) throws SQLException {
 				final LocalTime time = javaType.unwrap( value, LocalTime.class, options );
-				st.setObject( name, time, Types.TIME );
+				try {
+					st.setObject( name, time, Types.TIME );
+				}
+				catch (SQLDataException sde) {
+					st.setObject( name, time );
+				}
 			}
 		};
 	}

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/jdbc/OffsetDateTimeJdbcType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/jdbc/OffsetDateTimeJdbcType.java
@@ -72,13 +72,23 @@ public class OffsetDateTimeJdbcType implements JdbcType {
 			@Override
 			protected void doBind(PreparedStatement st, X value, int index, WrapperOptions options) throws SQLException {
 				final OffsetDateTime dateTime = javaType.unwrap( value, OffsetDateTime.class, options );
-				st.setObject( index, dateTime, Types.TIMESTAMP_WITH_TIMEZONE );
+				try {
+					st.setObject( index, dateTime, Types.TIMESTAMP_WITH_TIMEZONE );
+				}
+				catch (SQLException sqle) {
+					st.setObject( index, dateTime );
+				}
 			}
 
 			@Override
 			protected void doBind(CallableStatement st, X value, String name, WrapperOptions options) throws SQLException {
 				final OffsetDateTime dateTime = javaType.unwrap( value, OffsetDateTime.class, options );
-				st.setObject( name, dateTime, Types.TIMESTAMP_WITH_TIMEZONE );
+				try {
+					st.setObject( name, dateTime, Types.TIMESTAMP_WITH_TIMEZONE );
+				}
+				catch (SQLException sqle) {
+					st.setObject( name, dateTime );
+				}
 			}
 		};
 	}

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/jdbc/OffsetDateTimeJdbcType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/jdbc/OffsetDateTimeJdbcType.java
@@ -1,0 +1,105 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.type.descriptor.jdbc;
+
+import jakarta.persistence.TemporalType;
+import org.hibernate.type.descriptor.ValueBinder;
+import org.hibernate.type.descriptor.ValueExtractor;
+import org.hibernate.type.descriptor.WrapperOptions;
+import org.hibernate.type.descriptor.java.BasicJavaType;
+import org.hibernate.type.descriptor.java.JavaType;
+import org.hibernate.type.descriptor.jdbc.internal.JdbcLiteralFormatterTemporal;
+import org.hibernate.type.spi.TypeConfiguration;
+
+import java.sql.CallableStatement;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Types;
+import java.time.OffsetDateTime;
+
+/**
+ * Descriptor for {@link Types#TIMESTAMP TIMESTAMP} handling.
+ *
+ * @author Steve Ebersole
+ */
+public class OffsetDateTimeJdbcType implements JdbcType {
+	public static final OffsetDateTimeJdbcType INSTANCE = new OffsetDateTimeJdbcType();
+
+	public OffsetDateTimeJdbcType() {
+	}
+
+	@Override
+	public int getJdbcTypeCode() {
+		return Types.TIMESTAMP_WITH_TIMEZONE;
+	}
+
+	@Override
+	public String getFriendlyName() {
+		return "OFFSET_DATE_TIME";
+	}
+
+	@Override
+	public String toString() {
+		return "OffsetDateTimeTypeDescriptor";
+	}
+
+	@Override
+	public <T> BasicJavaType<T> getJdbcRecommendedJavaTypeMapping(
+			Integer length,
+			Integer scale,
+			TypeConfiguration typeConfiguration) {
+		return (BasicJavaType<T>) typeConfiguration.getJavaTypeRegistry().getDescriptor( OffsetDateTime.class );
+	}
+
+	@Override
+	public <T> JdbcLiteralFormatter<T> getJdbcLiteralFormatter(JavaType<T> javaType) {
+		return new JdbcLiteralFormatterTemporal<>( javaType, TemporalType.TIMESTAMP );
+	}
+
+	@Override
+	public Class<?> getPreferredJavaTypeClass(WrapperOptions options) {
+		return OffsetDateTime.class;
+	}
+
+	@Override
+	public <X> ValueBinder<X> getBinder(final JavaType<X> javaType) {
+		return new BasicBinder<>( javaType, this ) {
+			@Override
+			protected void doBind(PreparedStatement st, X value, int index, WrapperOptions options) throws SQLException {
+				final OffsetDateTime dateTime = javaType.unwrap( value, OffsetDateTime.class, options );
+				st.setObject( index, dateTime, Types.TIMESTAMP_WITH_TIMEZONE );
+			}
+
+			@Override
+			protected void doBind(CallableStatement st, X value, String name, WrapperOptions options) throws SQLException {
+				final OffsetDateTime dateTime = javaType.unwrap( value, OffsetDateTime.class, options );
+				st.setObject( name, dateTime, Types.TIMESTAMP_WITH_TIMEZONE );
+			}
+		};
+	}
+
+	@Override
+	public <X> ValueExtractor<X> getExtractor(final JavaType<X> javaType) {
+		return new BasicExtractor<>( javaType, this ) {
+			@Override
+			protected X doExtract(ResultSet rs, int paramIndex, WrapperOptions options) throws SQLException {
+				return javaType.wrap( rs.getObject( paramIndex, OffsetDateTime.class ), options );
+			}
+
+			@Override
+			protected X doExtract(CallableStatement statement, int index, WrapperOptions options) throws SQLException {
+				return javaType.wrap( statement.getObject( index, OffsetDateTime.class ), options );
+			}
+
+			@Override
+			protected X doExtract(CallableStatement statement, String name, WrapperOptions options) throws SQLException {
+				return javaType.wrap( statement.getObject( name, OffsetDateTime.class ), options );
+			}
+		};
+	}
+}

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/jdbc/ZonedDateTimeJdbcType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/jdbc/ZonedDateTimeJdbcType.java
@@ -1,0 +1,105 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.type.descriptor.jdbc;
+
+import jakarta.persistence.TemporalType;
+import org.hibernate.type.descriptor.ValueBinder;
+import org.hibernate.type.descriptor.ValueExtractor;
+import org.hibernate.type.descriptor.WrapperOptions;
+import org.hibernate.type.descriptor.java.BasicJavaType;
+import org.hibernate.type.descriptor.java.JavaType;
+import org.hibernate.type.descriptor.jdbc.internal.JdbcLiteralFormatterTemporal;
+import org.hibernate.type.spi.TypeConfiguration;
+
+import java.sql.CallableStatement;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Types;
+import java.time.ZonedDateTime;
+
+/**
+ * Descriptor for {@link Types#TIMESTAMP TIMESTAMP} handling.
+ *
+ * @author Steve Ebersole
+ */
+public class ZonedDateTimeJdbcType implements JdbcType {
+	public static final ZonedDateTimeJdbcType INSTANCE = new ZonedDateTimeJdbcType();
+
+	public ZonedDateTimeJdbcType() {
+	}
+
+	@Override
+	public int getJdbcTypeCode() {
+		return Types.TIMESTAMP_WITH_TIMEZONE;
+	}
+
+	@Override
+	public String getFriendlyName() {
+		return "ZONED_DATE_TIME";
+	}
+
+	@Override
+	public String toString() {
+		return "ZonedDateTimeTypeDescriptor";
+	}
+
+	@Override
+	public <T> BasicJavaType<T> getJdbcRecommendedJavaTypeMapping(
+			Integer length,
+			Integer scale,
+			TypeConfiguration typeConfiguration) {
+		return (BasicJavaType<T>) typeConfiguration.getJavaTypeRegistry().getDescriptor( ZonedDateTime.class );
+	}
+
+	@Override
+	public <T> JdbcLiteralFormatter<T> getJdbcLiteralFormatter(JavaType<T> javaType) {
+		return new JdbcLiteralFormatterTemporal<>( javaType, TemporalType.TIMESTAMP );
+	}
+
+	@Override
+	public Class<?> getPreferredJavaTypeClass(WrapperOptions options) {
+		return ZonedDateTime.class;
+	}
+
+	@Override
+	public <X> ValueBinder<X> getBinder(final JavaType<X> javaType) {
+		return new BasicBinder<>( javaType, this ) {
+			@Override
+			protected void doBind(PreparedStatement st, X value, int index, WrapperOptions options) throws SQLException {
+				final ZonedDateTime dateTime = javaType.unwrap( value, ZonedDateTime.class, options );
+				st.setObject( index, dateTime, Types.TIMESTAMP_WITH_TIMEZONE );
+			}
+
+			@Override
+			protected void doBind(CallableStatement st, X value, String name, WrapperOptions options) throws SQLException {
+				final ZonedDateTime dateTime = javaType.unwrap( value, ZonedDateTime.class, options );
+				st.setObject( name, dateTime, Types.TIMESTAMP_WITH_TIMEZONE );
+			}
+		};
+	}
+
+	@Override
+	public <X> ValueExtractor<X> getExtractor(final JavaType<X> javaType) {
+		return new BasicExtractor<>( javaType, this ) {
+			@Override
+			protected X doExtract(ResultSet rs, int paramIndex, WrapperOptions options) throws SQLException {
+				return javaType.wrap( rs.getObject( paramIndex, ZonedDateTime.class ), options );
+			}
+
+			@Override
+			protected X doExtract(CallableStatement statement, int index, WrapperOptions options) throws SQLException {
+				return javaType.wrap( statement.getObject( index, ZonedDateTime.class ), options );
+			}
+
+			@Override
+			protected X doExtract(CallableStatement statement, String name, WrapperOptions options) throws SQLException {
+				return javaType.wrap( statement.getObject( name, ZonedDateTime.class ), options );
+			}
+		};
+	}
+}

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/jdbc/ZonedDateTimeJdbcType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/jdbc/ZonedDateTimeJdbcType.java
@@ -72,13 +72,23 @@ public class ZonedDateTimeJdbcType implements JdbcType {
 			@Override
 			protected void doBind(PreparedStatement st, X value, int index, WrapperOptions options) throws SQLException {
 				final ZonedDateTime dateTime = javaType.unwrap( value, ZonedDateTime.class, options );
-				st.setObject( index, dateTime, Types.TIMESTAMP_WITH_TIMEZONE );
+				try {
+					st.setObject( index, dateTime, Types.TIMESTAMP_WITH_TIMEZONE );
+				}
+				catch (SQLException sqle) {
+					st.setObject( index, dateTime );
+				}
 			}
 
 			@Override
 			protected void doBind(CallableStatement st, X value, String name, WrapperOptions options) throws SQLException {
 				final ZonedDateTime dateTime = javaType.unwrap( value, ZonedDateTime.class, options );
-				st.setObject( name, dateTime, Types.TIMESTAMP_WITH_TIMEZONE );
+				try {
+					st.setObject( name, dateTime, Types.TIMESTAMP_WITH_TIMEZONE );
+				}
+				catch (SQLException sqle) {
+					st.setObject( name, dateTime );
+				}
 			}
 		};
 	}

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/jdbc/internal/JdbcTypeBaseline.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/jdbc/internal/JdbcTypeBaseline.java
@@ -21,6 +21,10 @@ import org.hibernate.type.descriptor.jdbc.DoubleJdbcType;
 import org.hibernate.type.descriptor.jdbc.FloatJdbcType;
 import org.hibernate.type.descriptor.jdbc.IntegerJdbcType;
 import org.hibernate.type.descriptor.jdbc.JdbcType;
+import org.hibernate.type.descriptor.jdbc.LocalDateTimeJdbcType;
+import org.hibernate.type.descriptor.jdbc.OffsetDateTimeJdbcType;
+import org.hibernate.type.descriptor.jdbc.ZonedDateTimeJdbcType;
+import org.hibernate.type.descriptor.jdbc.LocalTimeJdbcType;
 import org.hibernate.type.descriptor.jdbc.LongVarbinaryJdbcType;
 import org.hibernate.type.descriptor.jdbc.LongVarcharJdbcType;
 import org.hibernate.type.descriptor.jdbc.NumericJdbcType;
@@ -63,6 +67,11 @@ public class JdbcTypeBaseline {
 		target.addDescriptor( TimestampJdbcType.INSTANCE );
 		target.addDescriptor( TimestampWithTimeZoneJdbcType.INSTANCE );
 		target.addDescriptor( TimeJdbcType.INSTANCE );
+
+		target.addDescriptor( SqlTypes.LOCAL_TIME, LocalTimeJdbcType.INSTANCE );
+		target.addDescriptor( SqlTypes.LOCAL_DATE_TIME, LocalDateTimeJdbcType.INSTANCE );
+		target.addDescriptor( SqlTypes.OFFSET_DATE_TIME, OffsetDateTimeJdbcType.INSTANCE );
+		target.addDescriptor( SqlTypes.ZONED_DATE_TIME, ZonedDateTimeJdbcType.INSTANCE );
 
 		target.addDescriptor( BinaryJdbcType.INSTANCE );
 		target.addDescriptor( VarbinaryJdbcType.INSTANCE );

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/compliance/LocalTimeTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/compliance/LocalTimeTest.java
@@ -9,6 +9,7 @@ package org.hibernate.orm.test.jpa.compliance;
 import java.time.LocalTime;
 import java.time.OffsetTime;
 import java.time.ZoneOffset;
+import java.time.temporal.ChronoUnit;
 import java.util.List;
 
 import org.hibernate.testing.orm.junit.EntityManagerFactoryScope;
@@ -29,7 +30,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 )
 public class LocalTimeTest {
 
-	private static final LocalTime LOCAL_TIME = LocalTime.now();
+	private static final LocalTime LOCAL_TIME = LocalTime.now()
+			.truncatedTo(ChronoUnit.SECONDS); //TODO: understand why this is needed in h2
 
 	private static final OffsetTime OFFSET_TIME = OffsetTime.of( LOCAL_TIME, ZoneOffset.ofHours( 2 ) );
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/type/AbstractJavaTimeTypeTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/type/AbstractJavaTimeTypeTest.java
@@ -25,7 +25,6 @@ import java.util.function.Predicate;
 import org.hibernate.boot.model.TypeContributions;
 import org.hibernate.cfg.AvailableSettings;
 import org.hibernate.cfg.Configuration;
-import org.hibernate.dialect.DatabaseVersion;
 import org.hibernate.dialect.Dialect;
 import org.hibernate.dialect.H2Dialect;
 import org.hibernate.service.ServiceRegistry;
@@ -125,9 +124,10 @@ public abstract class AbstractJavaTimeTypeTest<T, E> extends BaseCoreFunctionalT
 			} );
 			inTransaction( session -> {
 				T read = getActualPropertyValue( session.find( getEntityType(), 1 ) );
+				T expected = getExpectedPropertyValueAfterHibernateRead();
 				assertEquals(
 						"Writing then reading a value should return the original value",
-						getExpectedPropertyValueAfterHibernateRead(), read
+						expected, read
 				);
 			} );
 		} );
@@ -152,10 +152,10 @@ public abstract class AbstractJavaTimeTypeTest<T, E> extends BaseCoreFunctionalT
 						try (ResultSet resultSet = statement.getResultSet()) {
 							resultSet.next();
 							Object nativeRead = getActualJdbcValue( resultSet, 1 );
+							Object expected = getExpectedJdbcValueAfterHibernateWrite();
 							assertEquals(
 									"Values written by Hibernate ORM should match the original value (same day, hour, ...)",
-									getExpectedJdbcValueAfterHibernateWrite(),
-									nativeRead
+									expected, nativeRead
 							);
 						}
 					}
@@ -184,9 +184,10 @@ public abstract class AbstractJavaTimeTypeTest<T, E> extends BaseCoreFunctionalT
 			} );
 			inTransaction( session -> {
 				T read = getActualPropertyValue( session.find( getEntityType(), 1 ) );
+				T expected = getExpectedPropertyValueAfterHibernateRead();
 				assertEquals(
 						"Values written without Hibernate ORM should be read correctly by Hibernate ORM",
-						getExpectedPropertyValueAfterHibernateRead(), read
+						expected, read
 				);
 			} );
 		} );

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/type/LocalDateTimeTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/type/LocalDateTimeTest.java
@@ -9,11 +9,12 @@ package org.hibernate.orm.test.type;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.sql.Timestamp;
+import java.sql.Types;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.util.Arrays;
 import java.util.List;
+
 import jakarta.persistence.Basic;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -145,20 +146,17 @@ public class LocalDateTimeTest extends AbstractJavaTimeTypeTest<LocalDateTime, L
 
 	@Override
 	protected void setJdbcValueForNonHibernateWrite(PreparedStatement statement, int parameterIndex) throws SQLException {
-		statement.setTimestamp( parameterIndex, getExpectedJdbcValueAfterHibernateWrite() );
+		statement.setObject( parameterIndex, getExpectedJdbcValueAfterHibernateWrite(), Types.TIMESTAMP );
 	}
 
 	@Override
-	protected Timestamp getExpectedJdbcValueAfterHibernateWrite() {
-		return new Timestamp(
-				year - 1900, month - 1, day,
-				hour, minute, second, nanosecond
-		);
+	protected LocalDateTime getExpectedJdbcValueAfterHibernateWrite() {
+		return LocalDateTime.of( year, month, day, hour, minute, second, nanosecond );
 	}
 
 	@Override
 	protected Object getActualJdbcValue(ResultSet resultSet, int columnIndex) throws SQLException {
-		return resultSet.getTimestamp( columnIndex );
+		return resultSet.getObject( columnIndex, LocalDateTime.class );
 	}
 
 	@Entity(name = ENTITY_NAME)

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/type/LocalTimeTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/type/LocalTimeTest.java
@@ -65,7 +65,7 @@ public class LocalTimeTest extends AbstractJavaTimeTypeTest<LocalTime, LocalTime
 			// that prevents our explicit JDBC timezones from being recognized
 			// See https://hibernate.atlassian.net/browse/HHH-13581
 			// See https://jira.mariadb.org/browse/CONJ-724
-			if ( MariaDBDialect.class.isInstance( getDialect() ) ) {
+			if ( getDialect() instanceof MariaDBDialect ) {
 				return Collections.emptySet();
 			}
 			return super.getHibernateJdbcTimeZonesToTest();


### PR DESCRIPTION
The idea here is to get away from `java.sql.Time`, `java.sql.Timestamp` and use `java.time` types all the way to JDBC.

Let's see how many JDBC drivers this breaks.