### PR TITLE
HHH-15735 Fix JDBC Connection leak in ExtractionContext #getQueryResults

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/tool/schema/extract/spi/ExtractionContext.java
+++ b/hibernate-core/src/main/java/org/hibernate/tool/schema/extract/spi/ExtractionContext.java
@@ -40,7 +40,8 @@ public interface ExtractionContext {
 			String queryString,
 			Object[] positionalParameters,
 			ResultSetProcessor<T> resultSetProcessor) throws SQLException {
-		try (PreparedStatement statement = getJdbcConnection().prepareStatement( queryString )) {
+		try (Connection jdbcConnection = getJdbcConnection();
+			 PreparedStatement statement = jdbcConnection.prepareStatement( queryString )) {
 			if ( positionalParameters != null ) {
 				for ( int i = 0 ; i < positionalParameters.length ; i++ ) {
 					statement.setObject( i + 1, positionalParameters[i] );


### PR DESCRIPTION
Fixed JDBC `Connection` leak. Simple fix, just add the `Connection` to the `try-with-resources` block.