### PR TITLE
Add back the MutableIdentifierGeneratorFactory

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/boot/internal/MetadataBuilderImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/internal/MetadataBuilderImpl.java
@@ -64,6 +64,7 @@ import org.hibernate.engine.jdbc.connections.spi.MultiTenantConnectionProvider;
 import org.hibernate.engine.jdbc.spi.JdbcServices;
 import org.hibernate.id.factory.IdentifierGeneratorFactory;
 import org.hibernate.id.factory.internal.StandardIdentifierGeneratorFactory;
+import org.hibernate.id.factory.spi.MutableIdentifierGeneratorFactory;
 import org.hibernate.internal.CoreLogging;
 import org.hibernate.internal.CoreMessageLogger;
 import org.hibernate.internal.log.DeprecationLogger;
@@ -567,7 +568,7 @@ public class MetadataBuilderImpl implements MetadataBuilderImplementor, TypeCont
 
 		public MetadataBuildingOptionsImpl(StandardServiceRegistry serviceRegistry) {
 			this.serviceRegistry = serviceRegistry;
-			this.identifierGeneratorFactory = new StandardIdentifierGeneratorFactory( serviceRegistry );
+			this.identifierGeneratorFactory = serviceRegistry.getService( MutableIdentifierGeneratorFactory.class );
 
 			final StrategySelector strategySelector = serviceRegistry.getService( StrategySelector.class );
 			final ConfigurationService configService = serviceRegistry.getService( ConfigurationService.class );

--- a/hibernate-core/src/main/java/org/hibernate/id/factory/internal/MutableIdentifierGeneratorFactoryInitiator.java
+++ b/hibernate-core/src/main/java/org/hibernate/id/factory/internal/MutableIdentifierGeneratorFactoryInitiator.java
@@ -1,0 +1,27 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.id.factory.internal;
+
+import java.util.Map;
+
+import org.hibernate.boot.registry.StandardServiceInitiator;
+import org.hibernate.id.factory.spi.MutableIdentifierGeneratorFactory;
+import org.hibernate.service.spi.ServiceRegistryImplementor;
+
+public class MutableIdentifierGeneratorFactoryInitiator implements StandardServiceInitiator<MutableIdentifierGeneratorFactory> {
+	public static final MutableIdentifierGeneratorFactoryInitiator INSTANCE = new MutableIdentifierGeneratorFactoryInitiator();
+
+	@Override
+	public Class<MutableIdentifierGeneratorFactory> getServiceInitiated() {
+		return MutableIdentifierGeneratorFactory.class;
+	}
+
+	@Override
+	public MutableIdentifierGeneratorFactory initiateService(Map configurationValues, ServiceRegistryImplementor registry) {
+		return new StandardIdentifierGeneratorFactory( registry );
+	}
+}

--- a/hibernate-core/src/main/java/org/hibernate/id/factory/internal/StandardIdentifierGeneratorFactory.java
+++ b/hibernate-core/src/main/java/org/hibernate/id/factory/internal/StandardIdentifierGeneratorFactory.java
@@ -37,6 +37,7 @@ import org.hibernate.id.factory.IdentifierGeneratorFactory;
 import org.hibernate.id.factory.spi.GenerationTypeStrategy;
 import org.hibernate.id.factory.spi.GenerationTypeStrategyRegistration;
 import org.hibernate.id.factory.spi.GeneratorDefinitionResolver;
+import org.hibernate.id.factory.spi.MutableIdentifierGeneratorFactory;
 import org.hibernate.id.factory.spi.StandardGenerator;
 import org.hibernate.internal.log.DeprecationLogger;
 import org.hibernate.jpa.spi.IdentifierGeneratorStrategyProvider;
@@ -58,7 +59,7 @@ import static org.hibernate.id.factory.IdGenFactoryLogging.ID_GEN_FAC_LOGGER;
  */
 @SuppressWarnings( { "deprecation" ,"rawtypes" } )
 public class StandardIdentifierGeneratorFactory
-		implements IdentifierGeneratorFactory, BeanContainer.LifecycleOptions, Serializable {
+		implements IdentifierGeneratorFactory, MutableIdentifierGeneratorFactory, BeanContainer.LifecycleOptions, Serializable {
 
 	private final ConcurrentHashMap<GenerationType, GenerationTypeStrategy> generatorTypeStrategyMap = new ConcurrentHashMap<>();
 	private final ConcurrentHashMap<String, Class<? extends IdentifierGenerator>> legacyGeneratorClassNameMap = new ConcurrentHashMap<>();
@@ -156,7 +157,8 @@ public class StandardIdentifierGeneratorFactory
 		}
 	}
 
-	private void register(String strategy, Class<? extends IdentifierGenerator> generatorClass) {
+	@Override
+	public void register(String strategy, Class<? extends IdentifierGenerator> generatorClass) {
 		ID_GEN_FAC_LOGGER.debugf( "Registering IdentifierGenerator strategy [%s] -> [%s]", strategy, generatorClass.getName() );
 		final Class previous = legacyGeneratorClassNameMap.put( strategy, generatorClass );
 		if ( previous != null && ID_GEN_FAC_LOGGER.isDebugEnabled() ) {

--- a/hibernate-core/src/main/java/org/hibernate/id/factory/spi/MutableIdentifierGeneratorFactory.java
+++ b/hibernate-core/src/main/java/org/hibernate/id/factory/spi/MutableIdentifierGeneratorFactory.java
@@ -1,0 +1,18 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.id.factory.spi;
+
+import org.hibernate.id.IdentifierGenerator;
+import org.hibernate.id.factory.IdentifierGeneratorFactory;
+import org.hibernate.service.Service;
+
+/**
+ * Let people register strategies
+ */
+public interface MutableIdentifierGeneratorFactory extends IdentifierGeneratorFactory, Service {
+	void register(String strategy, Class<? extends IdentifierGenerator> generatorClass);
+}

--- a/hibernate-core/src/main/java/org/hibernate/service/StandardServiceInitiators.java
+++ b/hibernate-core/src/main/java/org/hibernate/service/StandardServiceInitiators.java
@@ -29,6 +29,7 @@ import org.hibernate.engine.jndi.internal.JndiServiceInitiator;
 import org.hibernate.engine.transaction.jta.platform.internal.JtaPlatformInitiator;
 import org.hibernate.engine.transaction.jta.platform.internal.JtaPlatformResolverInitiator;
 import org.hibernate.event.internal.EntityCopyObserverFactoryInitiator;
+import org.hibernate.id.factory.internal.MutableIdentifierGeneratorFactoryInitiator;
 import org.hibernate.persister.internal.PersisterClassResolverInitiator;
 import org.hibernate.persister.internal.PersisterFactoryInitiator;
 import org.hibernate.property.access.internal.PropertyAccessStrategyResolverInitiator;
@@ -53,6 +54,8 @@ public final class StandardServiceInitiators {
 		final ArrayList<StandardServiceInitiator<?>> serviceInitiators = new ArrayList<>();
 
 		serviceInitiators.add( DefaultSessionFactoryBuilderInitiator.INSTANCE );
+
+		serviceInitiators.add( MutableIdentifierGeneratorFactoryInitiator.INSTANCE);
 
 		serviceInitiators.add( BytecodeProviderInitiator.INSTANCE );
 		serviceInitiators.add( ProxyFactoryFactoryInitiator.INSTANCE );


### PR DESCRIPTION
Fix [HHH-15746](https://hibernate.atlassian.net/browse/HHH-15746)

Hibernate Reactive needs to be able to register its own generators.
This interface was in ORM 5 and I'm just adding it back.