### PR TITLE
HHH-15668 Fix CockroachDB test failure

### DIFF
--- a/docker_db.sh
+++ b/docker_db.sh
@@ -606,8 +606,8 @@ sinks:
     redact: false
     exit-on-error: true
 "
-  $CONTAINER_CLI run -d --name=cockroach -m 3g -p 26257:26257 -p 8080:8080 docker.io/cockroachdb/cockroach:v22.1.10 start-single-node \
-    --insecure --store=type=mem,size=640MiB --advertise-addr=localhost --log="$LOG_CONFIG"
+  $CONTAINER_CLI run -d --name=cockroach -m 3g -p 26257:26257 -p 8080:8080 docker.io/cockroachdb/cockroach:v22.1.11 start-single-node \
+    --insecure --store=type=mem,size=0.25 --advertise-addr=localhost --log="$LOG_CONFIG"
   OUTPUT=
   while [[ $OUTPUT != *"CockroachDB node starting"* ]]; do
         echo "Waiting for CockroachDB to start..."
@@ -616,7 +616,7 @@ sinks:
         OUTPUT=$($CONTAINER_CLI logs cockroach 2>&1)
   done
   echo "Enabling experimental box2d operators and some optimized settings for running the tests"
-  #settings documented in https://www.cockroachlabs.com/docs/v21.2/local-testing.html#use-a-local-single-node-cluster-with-in-memory-storage
+  #settings documented in https://www.cockroachlabs.com/docs/v22.1/local-testing.html#use-a-local-single-node-cluster-with-in-memory-storage
   $CONTAINER_CLI exec cockroach bash -c "cat <<EOF | ./cockroach sql --insecure
 SET CLUSTER SETTING sql.spatial.experimental_box2d_comparison_operators.enabled = on;
 SET CLUSTER SETTING kv.raft_log.disable_synchronization_unsafe = true;
@@ -624,15 +624,11 @@ SET CLUSTER SETTING kv.range_merge.queue_interval = '50ms';
 SET CLUSTER SETTING jobs.registry.interval.gc = '30s';
 SET CLUSTER SETTING jobs.registry.interval.cancel = '180s';
 SET CLUSTER SETTING jobs.retention_time = '15s';
-SET CLUSTER SETTING schemachanger.backfiller.buffer_increment = '128 KiB';
 SET CLUSTER SETTING sql.stats.automatic_collection.enabled = false;
 SET CLUSTER SETTING kv.range_split.by_load_merge_delay = '5s';
-SET CLUSTER SETTING timeseries.storage.enabled = false;
-SET CLUSTER SETTING timeseries.storage.resolution_10s.ttl = '0s';
-SET CLUSTER SETTING timeseries.storage.resolution_30m.ttl = '0s';
-ALTER RANGE default CONFIGURE ZONE USING \"gc.ttlseconds\" = 10;
-ALTER DATABASE system CONFIGURE ZONE USING \"gc.ttlseconds\" = 10;
-ALTER DATABASE defaultdb CONFIGURE ZONE USING \"gc.ttlseconds\" = 10;
+ALTER RANGE default CONFIGURE ZONE USING "gc.ttlseconds" = 600;
+ALTER DATABASE system CONFIGURE ZONE USING "gc.ttlseconds" = 600;
+
 quit
 EOF
 "

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/batch/BatchOptimisticLockingTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/batch/BatchOptimisticLockingTest.java
@@ -34,7 +34,6 @@ import static org.junit.Assert.fail;
 /**
  * @author Vlad Mihalcea
  */
-@SkipForDialect(value = CockroachDialect.class, comment = "See https://hibernate.atlassian.net/browse/HHH-15668")
 public class BatchOptimisticLockingTest extends
 		BaseNonConfigCoreFunctionalTestCase {
 
@@ -101,9 +100,10 @@ public class BatchOptimisticLockingTest extends
 			if ( getDialect() instanceof CockroachDialect ) {
 				// CockroachDB always runs in SERIALIZABLE isolation, and uses SQL state 40001 to indicate
 				// serialization failure.
+				var msg = "org.hibernate.exception.LockAcquisitionException: could not execute batch";
 				assertEquals(
 						"org.hibernate.exception.LockAcquisitionException: could not execute batch",
-						expected.getMessage()
+						expected.getMessage().substring( 0, msg.length() )
 				);
 			}
 			else if ( getDialect() instanceof OracleDialect && getDialect().getVersion().isBefore( 12 ) ) {


### PR DESCRIPTION
This PR fixes the test failure for BatchOptimisticLockingTest.testBatchAndOptimisticLocking.

It also improves the CockroachDB v22.1 configuration which (hopefully) fixes the cascade of build failures we see from build #34 onwards (see e.g. https://ci.hibernate.org/job/hibernate-orm-nightly/job/main/34/)