### PR TITLE
override supportsRowValueConstructorSyntaxInInList

### DIFF
--- a/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/SQLiteSqlAstTranslator.java
+++ b/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/SQLiteSqlAstTranslator.java
@@ -58,6 +58,11 @@ public class SQLiteSqlAstTranslator<T extends JdbcOperation> extends AbstractSql
 	}
 
 	@Override
+	protected boolean supportsRowValueConstructorSyntaxInInList() {
+		return false;
+	}
+
+	@Override
 	public boolean supportsFilterClause() {
 		return getDialect().getVersion().isSameOrAfter( 3, 3 );
 	}


### PR DESCRIPTION
override supportsRowValueConstructorSyntaxInInList because a Query like

`select * from table where (field1, field2) in (('a', 'b'), ('c','d'))`

is not supported in SQLite