### PR TITLE
HHH-15758 HHH-15755 Add Oracle Autonomous Database awareness to OracleDialect

### DIFF
--- a/gradle/databases.gradle
+++ b/gradle/databases.gradle
@@ -11,6 +11,7 @@ import org.apache.tools.ant.filters.ReplaceTokens
 ext {
         db = project.hasProperty('db') ? project.getProperty('db') : 'h2'
         dbHost = System.getProperty( 'dbHost', 'localhost' )
+        dbService = System.getProperty( 'dbService', '' )
         dbBundle = [
                 h2 : [
                         'db.dialect' : 'org.hibernate.dialect.H2Dialect',
@@ -134,6 +135,18 @@ ext {
                         'jdbc.user'  : 'SYSTEM',
                         'jdbc.pass'  : 'Oracle18',
                         'jdbc.url'   : 'jdbc:oracle:thin:@' + dbHost + ':1521:XE',
+                        'connection.init_sql' : ''
+                ],
+                oracle_cloud_autonomous_tls : [
+                        'db.dialect' : 'org.hibernate.dialect.OracleDialect',
+                        'jdbc.driver': 'oracle.jdbc.OracleDriver',
+                        'jdbc.user'  : 'hibernate_orm_test',
+                        'jdbc.pass'  : 'Oracle_19_Password',
+                        // Requires dbHost (pointing to the right cloud region) AND dbService (unique database name).
+                        //
+                        // To avoid hibernate-spatial tests failure, JVM must be enabled as stated in documentation:
+                        // https://docs.oracle.com/en/cloud/paas/autonomous-database/adbsa/autonomous-oracle-java.html
+                        'jdbc.url'   : 'jdbc:oracle:thin:@(description=(retry_count=20)(retry_delay=3)(address=(protocol=tcps)(port=1521)(host=' + dbHost + '.oraclecloud.com))(connect_data=(service_name=' + dbService + '_low.adb.oraclecloud.com))(security=(ssl_server_dn_match=yes)))',
                         'connection.init_sql' : ''
                 ],
                 mssql : [


### PR DESCRIPTION
This PR allows the `OracleDialect` to know if the targeted database is an Autonomous Database cloud service. As Autonomous Databases come with all features (OSON support _even in 19c_, Autonomous/Automatic features, Exadata features, Core database features...) this can avoid limiting the feature set available for Hibernate.

It also provides new `oracle_cloud_autonomous_tls` database settings to easily connect to an [Autonomous Database using TLS connection](https://docs.oracle.com/en/cloud/paas/autonomous-database/adbsa/support-tls-mtls-authentication.html#GUID-4C2093B7-4DF0-4CF4-BB2D-33E1FC5D5184) (no requirement regarding separate wallet management).

Remark: to make 100% of the hibernate-spatial tests pass, the Autonomous Database being used must have the in-database JVM enabled (see documentation [here](https://docs.oracle.com/en/cloud/paas/autonomous-database/adbsa/autonomous-oracle-java.html) for more details).