### PR TITLE
HHH-15778 Fetching an Entity with a lazily loaded Embeddable with more fields than the parent results in an ArrayIndexOutOfBoundsException

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/BasicAttributeMapping.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/BasicAttributeMapping.java
@@ -37,6 +37,7 @@ import org.hibernate.sql.results.graph.Fetch;
 import org.hibernate.sql.results.graph.FetchParent;
 import org.hibernate.sql.results.graph.basic.BasicFetch;
 import org.hibernate.sql.results.graph.basic.BasicResult;
+import org.hibernate.sql.results.graph.embeddable.EmbeddableResultGraphNode;
 import org.hibernate.type.descriptor.java.JavaType;
 
 /**
@@ -325,6 +326,7 @@ public class BasicAttributeMapping
 		// returning a domain result assembler that returns LazyPropertyInitializer.UNFETCHED_PROPERTY
 		final EntityMappingType containingEntityMapping = findContainingEntityMapping();
 		if ( fetchTiming == FetchTiming.DELAYED
+				&& !( fetchParent instanceof EmbeddableResultGraphNode )
 				&& containingEntityMapping.getEntityPersister().getPropertyLaziness()[getStateArrayPosition()] ) {
 			valuesArrayPosition = -1;
 		}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/query/sql/EmbeddableLazyFetchTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/query/sql/EmbeddableLazyFetchTest.java
@@ -1,0 +1,108 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.orm.test.query.sql;
+
+import java.util.Collections;
+
+import org.hibernate.graph.spi.RootGraphImplementor;
+
+import org.hibernate.testing.TestForIssue;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import jakarta.persistence.Embeddable;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+@DomainModel(
+		annotatedClasses = EmbeddableLazyFetchTest.Person.class
+)
+@SessionFactory
+@TestForIssue(jiraKey = "HHH-15778")
+public class EmbeddableLazyFetchTest {
+
+	@BeforeEach
+	public void setUp(SessionFactoryScope scope) {
+		scope.inTransaction(
+				session -> {
+					Address address = new Address( "Milan", "Italy", "Italy", "20133" );
+					Person person = new Person( 1, address );
+
+					session.persist( person );
+				}
+		);
+	}
+
+	@AfterEach
+	public void tearDown(SessionFactoryScope scope) {
+		scope.inTransaction(
+				session ->
+						session.createMutationQuery( "delete from Person" ).executeUpdate()
+		);
+	}
+
+	@Test
+	public void testSelect(SessionFactoryScope scope) {
+		scope.inTransaction(
+				session -> {
+					RootGraphImplementor<Person> graph = session.createEntityGraph( Person.class );
+
+					Person person = session.find(
+							Person.class, 1,
+							Collections.singletonMap( "jakarta.persistence.fetchgraph", graph )
+					);
+
+					assertThat( person ).isNotNull();
+					assertThat( person.address.city ).isEqualTo( "Milan" );
+					assertThat( person.address.state ).isEqualTo( "Italy" );
+					assertThat( person.address.country ).isEqualTo( "Italy" );
+					assertThat( person.address.postcode ).isEqualTo( "20133" );
+				}
+		);
+	}
+
+	@Entity(name = "Person")
+	public static class Person {
+		@Id
+		private Integer id;
+
+		private Address address;
+
+		public Person() {
+		}
+
+		public Person(Integer id, Address address) {
+			this.id = id;
+			this.address = address;
+		}
+	}
+
+	@Embeddable
+	public static class Address {
+		private String city;
+		private String state;
+		private String country;
+
+		private String postcode;
+
+		public Address() {
+		}
+
+		public Address(String city, String state, String country, String postcode) {
+			this.city = city;
+			this.state = state;
+			this.country = country;
+			this.postcode = postcode;
+		}
+	}
+}


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-15778

I made an attempt at fixing the bug, but I don't know enough about Hibernate internals to be sure about these changes.