### PR TITLE
HHH-15792: Explicitly add JavaDoc to make @deprecated hint for createSQLQuery visible in Eclipse

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/Session.java
+++ b/hibernate-core/src/main/java/org/hibernate/Session.java
@@ -1171,6 +1171,16 @@ public interface Session extends SharedSessionContract, EntityManager, Hibernate
 
 	<T> org.hibernate.query.Query<T> createNamedQuery(String name, Class<T> resultType);
 
+	/**
+	 * Create a {@link NativeQuery} instance for the given SQL query string.
+	 *
+	 * @param queryString The SQL query
+	 *
+	 * @return The query instance for manipulation and execution
+	 *
+	 * @deprecated (since 5.2) use {@link #createNativeQuery(String)} instead
+	 */
+	@Deprecated
 	@Override
 	NativeQuery createSQLQuery(String queryString);
 }


### PR DESCRIPTION
Explicitly add the JavaDoc to Session.java to provide users the @deprecated JavaDoc hint on how to resolve the deprecation warnings.

Without this patch, e.g., in Eclipse, there are no warning generated when the method createSQLQuery is used which makes upgrading to 6.x harder (cf. #5032).