### PR TITLE
HHH-15790 Type Pollution Mitigation on generic BiConsumer

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/engine/internal/ManagedTypeHelper.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/internal/ManagedTypeHelper.java
@@ -168,6 +168,17 @@ public final class ManagedTypeHelper {
 	}
 
 	/**
+	 * This interface has been introduced to mitigate <a href="https://bugs.openjdk.org/browse/JDK-8180450">JDK-8180450</a>.<br>
+	 * Sadly, using  {@code BiConsumer} cause a type pollution issue, because
+	 * of generics type-erasure: {@code BiConsumer}'s actual parameters types on the lambda implemention's
+	 * {@link BiConsumer#accept} are stealthy enforced via {@code checkcast}, messing up with type check cached data.
+	 */
+	@FunctionalInterface
+	public interface PersistentAttributeInterceptableAction<T> {
+		public void accept(PersistentAttributeInterceptable interceptable, T optionalParam);
+	}
+
+	/**
 	 * Helper to execute an action on an entity, but exclusively if it's implementing the {@see PersistentAttributeInterceptable}
 	 * interface. Otherwise no action is performed.
 	 *
@@ -178,7 +189,7 @@ public final class ManagedTypeHelper {
 	 */
 	public static <T> void processIfPersistentAttributeInterceptable(
 			final Object entity,
-			final BiConsumer<PersistentAttributeInterceptable, T> action,
+			final PersistentAttributeInterceptableAction<T> action,
 			final T optionalParam) {
 		if ( entity instanceof PrimeAmongSecondarySupertypes ) {
 			final PrimeAmongSecondarySupertypes t = (PrimeAmongSecondarySupertypes) entity;


### PR DESCRIPTION
As explained in the code itself, this is going to cover a very stealth case of type pollution due to how type erasure works in Java.

Sadly, despite https://github.com/RedHatPerf/type-pollution-agent has introduced support for lambda redefinition, given that the underlying ByteBuddy feature is "experimental" (see https://github.com/raphw/byte-buddy/issues/558#issuecomment-440443548 for more info ) isn't always possible to verify it in the usual pollution reports.

Luckly the flamegraphs are good enough to spot it
![image](https://user-images.githubusercontent.com/13125299/205320996-738f71ae-87bf-43df-bb1d-e0230c58d5ce.png)
