### PR TITLE
HHH-15653 Named Native Query cannot be registered/used with named parameters

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/boot/internal/NamedNativeQueryDefinitionImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/internal/NamedNativeQueryDefinitionImpl.java
@@ -89,6 +89,7 @@ public class NamedNativeQueryDefinitionImpl extends AbstractNamedQueryDefinition
 		return new NamedNativeQueryMementoImpl(
 				getRegistrationName(),
 				sqlString,
+				sqlString,
 				resultSetMappingName,
 				isNotEmpty( resultSetMappingClassName )
 						? factory.getServiceRegistry().getService( ClassLoaderService.class )

--- a/hibernate-core/src/main/java/org/hibernate/query/sql/internal/NamedNativeQueryMementoImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sql/internal/NamedNativeQueryMementoImpl.java
@@ -25,6 +25,7 @@ import org.hibernate.query.sql.spi.NativeQueryImplementor;
  */
 public class NamedNativeQueryMementoImpl extends AbstractNamedQueryMemento implements NamedNativeQueryMemento {
 	private final String sqlString;
+	private final String originalSqlString;
 
 	private final String resultSetMappingName;
 	private final Class<?> resultSetMappingClass;
@@ -38,6 +39,7 @@ public class NamedNativeQueryMementoImpl extends AbstractNamedQueryMemento imple
 	public NamedNativeQueryMementoImpl(
 			String name,
 			String sqlString,
+			String originalSqlString,
 			String resultSetMappingName,
 			Class<?> resultSetMappingClass,
 			Set<String> querySpaces,
@@ -65,6 +67,7 @@ public class NamedNativeQueryMementoImpl extends AbstractNamedQueryMemento imple
 				hints
 		);
 		this.sqlString = sqlString;
+		this.originalSqlString = originalSqlString;
 		this.resultSetMappingName = resultSetMappingName == null || resultSetMappingName.isEmpty()
 				? null
 				: resultSetMappingName;
@@ -92,6 +95,11 @@ public class NamedNativeQueryMementoImpl extends AbstractNamedQueryMemento imple
 	}
 
 	@Override
+	public String getOriginalSqlString() {
+		return originalSqlString;
+	}
+
+	@Override
 	public String getResultMappingName() {
 		return resultSetMappingName;
 	}
@@ -116,6 +124,7 @@ public class NamedNativeQueryMementoImpl extends AbstractNamedQueryMemento imple
 		return new NamedNativeQueryMementoImpl(
 				name,
 				sqlString,
+				originalSqlString,
 				resultSetMappingName,
 				resultSetMappingClass,
 				querySpaces,

--- a/hibernate-core/src/main/java/org/hibernate/query/sql/internal/NativeQueryImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sql/internal/NativeQueryImpl.java
@@ -111,7 +111,7 @@ public class NativeQueryImpl<R>
 		extends AbstractQuery<R>
 		implements NativeQueryImplementor<R>, DomainQueryExecutionContext, ResultSetMappingResolutionContext {
 	private final String sqlString;
-
+	private final String originalSqlString;
 	private final ParameterMetadataImplementor parameterMetadata;
 	private final List<ParameterOccurrence> parameterOccurrences;
 	private final QueryParameterBindings parameterBindings;
@@ -186,8 +186,12 @@ public class NativeQueryImpl<R>
 			SharedSessionContractImplementor session) {
 		super( session );
 
-		final String mementoSqlString = memento.getSqlString();
-		final ParameterInterpretation parameterInterpretation = resolveParameterInterpretation( mementoSqlString, session );
+		this.originalSqlString = memento.getOriginalSqlString();
+
+		final ParameterInterpretation parameterInterpretation = resolveParameterInterpretation(
+				originalSqlString,
+				session
+		);
 
 		this.sqlString = parameterInterpretation.getAdjustedSqlString();
 		this.parameterMetadata = parameterInterpretation.toParameterMetadata( session );
@@ -322,6 +326,7 @@ public class NativeQueryImpl<R>
 
 		final ParameterInterpretation parameterInterpretation = resolveParameterInterpretation( sqlString, session );
 
+		this.originalSqlString = sqlString;
 		this.sqlString = parameterInterpretation.getAdjustedSqlString();
 		this.parameterMetadata = parameterInterpretation.toParameterMetadata( session );
 		this.parameterOccurrences = parameterInterpretation.getOrderedParameterOccurrences();
@@ -383,7 +388,7 @@ public class NativeQueryImpl<R>
 		this.querySpaces = new HashSet<>();
 
 		final ParameterInterpretation parameterInterpretation = resolveParameterInterpretation( sqlString, session );
-
+		this.originalSqlString = sqlString;
 		this.sqlString = parameterInterpretation.getAdjustedSqlString();
 		this.parameterMetadata = parameterInterpretation.toParameterMetadata( session );
 		this.parameterOccurrences = parameterInterpretation.getOrderedParameterOccurrences();
@@ -455,6 +460,7 @@ public class NativeQueryImpl<R>
 		return new NamedNativeQueryMementoImpl(
 				name,
 				sqlString,
+				originalSqlString,
 				resultSetMapping.getMappingIdentifier(),
 				null,
 				querySpaces,

--- a/hibernate-core/src/main/java/org/hibernate/query/sql/spi/NamedNativeQueryMemento.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sql/spi/NamedNativeQueryMemento.java
@@ -29,6 +29,10 @@ public interface NamedNativeQueryMemento extends NamedQueryMemento {
 	 */
 	String getSqlString();
 
+	default String getOriginalSqlString(){
+		return getSqlString();
+	}
+
 	/**
 	 * The affected query spaces.
 	 */
@@ -131,6 +135,7 @@ public interface NamedNativeQueryMemento extends NamedQueryMemento {
 		public NamedNativeQueryMemento build(SessionFactoryImplementor sessionFactory) {
 			return new NamedNativeQueryMementoImpl(
 					name,
+					queryString,
 					queryString,
 					resultSetMappingName,
 					sessionFactory.getServiceRegistry()

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/query/RegisterNamedQueryWithParameterTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/query/RegisterNamedQueryWithParameterTest.java
@@ -1,0 +1,74 @@
+package org.hibernate.orm.test.jpa.query;
+
+import java.util.List;
+
+import org.hibernate.testing.TestForIssue;
+import org.hibernate.testing.orm.junit.EntityManagerFactoryScope;
+import org.hibernate.testing.orm.junit.Jpa;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.NamedNativeQuery;
+import jakarta.persistence.Query;
+import jakarta.persistence.Table;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+@Jpa(
+		annotatedClasses = RegisterNamedQueryWithParameterTest.TestEntity.class
+)
+@TestForIssue(jiraKey = "HHH-15653")
+public class RegisterNamedQueryWithParameterTest {
+
+	private static final String QUERY_NAME = "ENTITY_BY_NAME";
+	private static final String QUERY = "select t.id from TEST_ENTITY t where t.anInteger = :value";
+
+	@BeforeAll
+	public void setUp(EntityManagerFactoryScope scope) {
+		scope.inTransaction(
+				entityManager -> {
+					Query query = entityManager.createNativeQuery( QUERY );
+					scope.getEntityManagerFactory().addNamedQuery( "ENTITY_BY_NAME", query );
+
+					TestEntity entity = new TestEntity( 1l, "And", 1 );
+					TestEntity entity2 = new TestEntity( 2l, "Fab", 2 );
+					entityManager.persist( entity );
+					entityManager.persist( entity2 );
+				}
+		);
+	}
+
+	@Test
+	public void testExecuteNativQuery(EntityManagerFactoryScope scope) {
+		scope.inTransaction(
+				entityManager -> {
+					Query query = entityManager.createNamedQuery( QUERY_NAME );
+					query.setParameter( "value", 1 );
+					List results = query.getResultList();
+					assertThat( results.size() ).isEqualTo( 1 );
+				}
+		);
+	}
+
+	@Entity(name = "TestEntity")
+	@Table(name = "TEST_ENTITY")
+	public static class TestEntity {
+		@Id
+		Long id;
+
+		String name;
+
+		Integer anInteger;
+
+		public TestEntity() {
+		}
+
+		public TestEntity(Long id, String name, Integer anInteger) {
+			this.id = id;
+			this.name = name;
+			this.anInteger = anInteger;
+		}
+	}
+}


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-15653

The issue is that the sql string of the memento used by `addNamedQuery` has been adjusted, so instead of the named parameter it contains the `?` , this causes the creation of a ordinal instead of using the registered name parameter.