### PR TITLE
HHH-15736 Make sure dialects have default like-predicate escape char configured

### DIFF
--- a/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/CockroachLegacySqlAstTranslator.java
+++ b/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/CockroachLegacySqlAstTranslator.java
@@ -15,6 +15,7 @@ import org.hibernate.sql.ast.tree.expression.Expression;
 import org.hibernate.sql.ast.tree.expression.Literal;
 import org.hibernate.sql.ast.tree.expression.Summarization;
 import org.hibernate.sql.ast.tree.predicate.BooleanExpressionPredicate;
+import org.hibernate.sql.ast.tree.predicate.LikePredicate;
 import org.hibernate.sql.ast.tree.select.QueryGroup;
 import org.hibernate.sql.ast.tree.select.QueryPart;
 import org.hibernate.sql.ast.tree.select.QuerySpec;
@@ -150,6 +151,31 @@ public class CockroachLegacySqlAstTranslator<T extends JdbcOperation> extends Ab
 		}
 		else {
 			expression.accept( this );
+		}
+	}
+
+	@Override
+	public void visitLikePredicate(LikePredicate likePredicate) {
+		// Custom implementation because CockroachDB uses backslash as default escape character
+		likePredicate.getMatchExpression().accept( this );
+		if ( likePredicate.isNegated() ) {
+			appendSql( " not" );
+		}
+		if ( likePredicate.isCaseSensitive() ) {
+			appendSql( " like " );
+		}
+		else {
+			appendSql( WHITESPACE );
+			appendSql( getDialect().getCaseInsensitiveLike() );
+			appendSql( WHITESPACE );
+		}
+		likePredicate.getPattern().accept( this );
+		if ( likePredicate.getEscapeCharacter() != null ) {
+			appendSql( " escape " );
+			likePredicate.getEscapeCharacter().accept( this );
+		}
+		else {
+			appendSql( " escape ''" );
 		}
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/dialect/CockroachSqlAstTranslator.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/CockroachSqlAstTranslator.java
@@ -15,6 +15,7 @@ import org.hibernate.sql.ast.tree.expression.Expression;
 import org.hibernate.sql.ast.tree.expression.Literal;
 import org.hibernate.sql.ast.tree.expression.Summarization;
 import org.hibernate.sql.ast.tree.predicate.BooleanExpressionPredicate;
+import org.hibernate.sql.ast.tree.predicate.LikePredicate;
 import org.hibernate.sql.ast.tree.select.QueryGroup;
 import org.hibernate.sql.ast.tree.select.QueryPart;
 import org.hibernate.sql.ast.tree.select.QuerySpec;
@@ -122,6 +123,31 @@ public class CockroachSqlAstTranslator<T extends JdbcOperation> extends Abstract
 		}
 		else {
 			expression.accept( this );
+		}
+	}
+
+	@Override
+	public void visitLikePredicate(LikePredicate likePredicate) {
+		// Custom implementation because CockroachDB uses backslash as default escape character
+		likePredicate.getMatchExpression().accept( this );
+		if ( likePredicate.isNegated() ) {
+			appendSql( " not" );
+		}
+		if ( likePredicate.isCaseSensitive() ) {
+			appendSql( " like " );
+		}
+		else {
+			appendSql( WHITESPACE );
+			appendSql( getDialect().getCaseInsensitiveLike() );
+			appendSql( WHITESPACE );
+		}
+		likePredicate.getPattern().accept( this );
+		if ( likePredicate.getEscapeCharacter() != null ) {
+			appendSql( " escape " );
+			likePredicate.getEscapeCharacter().accept( this );
+		}
+		else {
+			appendSql( " escape ''" );
 		}
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/dialect/MySQLSqlAstTranslator.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/MySQLSqlAstTranslator.java
@@ -142,12 +142,50 @@ public class MySQLSqlAstTranslator<T extends JdbcOperation> extends AbstractSqlA
 
 	@Override
 	public void visitLikePredicate(LikePredicate likePredicate) {
-		super.visitLikePredicate( likePredicate );
 		// Custom implementation because MySQL uses backslash as the default escape character
-		// We can override this by specifying an empty escape character
-		// See https://dev.mysql.com/doc/refman/8.0/en/string-comparison-functions.html#operator_like
-		if ( !( (MySQLDialect) getDialect() ).isNoBackslashEscapesEnabled() && likePredicate.getEscapeCharacter() == null ) {
-			appendSql( " escape ''" );
+		if ( getDialect().getVersion().isSameOrAfter( 8 ) ) {
+			// From version 8 we can override this by specifying an empty escape character
+			// See https://dev.mysql.com/doc/refman/8.0/en/string-comparison-functions.html#operator_like
+			super.visitLikePredicate( likePredicate );
+			if ( !getDialect().isNoBackslashEscapesEnabled() && likePredicate.getEscapeCharacter() == null ) {
+				appendSql( " escape ''" );
+			}
+		}
+		else {
+			if ( likePredicate.isCaseSensitive() ) {
+				likePredicate.getMatchExpression().accept( this );
+				if ( likePredicate.isNegated() ) {
+					appendSql( " not" );
+				}
+				appendSql( " like " );
+				renderBackslashEscapedLikePattern(
+						likePredicate.getPattern(),
+						likePredicate.getEscapeCharacter(),
+						getDialect().isNoBackslashEscapesEnabled()
+				);
+			}
+			else {
+				appendSql( getDialect().getLowercaseFunction() );
+				appendSql( OPEN_PARENTHESIS );
+				likePredicate.getMatchExpression().accept( this );
+				appendSql( CLOSE_PARENTHESIS );
+				if ( likePredicate.isNegated() ) {
+					appendSql( " not" );
+				}
+				appendSql( " like " );
+				appendSql( getDialect().getLowercaseFunction() );
+				appendSql( OPEN_PARENTHESIS );
+				renderBackslashEscapedLikePattern(
+						likePredicate.getPattern(),
+						likePredicate.getEscapeCharacter(),
+						getDialect().isNoBackslashEscapesEnabled()
+				);
+				appendSql( CLOSE_PARENTHESIS );
+			}
+			if ( likePredicate.getEscapeCharacter() != null ) {
+				appendSql( " escape " );
+				likePredicate.getEscapeCharacter().accept( this );
+			}
 		}
 	}
 
@@ -195,5 +233,10 @@ public class MySQLSqlAstTranslator<T extends JdbcOperation> extends AbstractSqlA
 	@Override
 	protected String getFromDual() {
 		return " from dual";
+	}
+
+	@Override
+	public MySQLDialect getDialect() {
+		return (MySQLDialect) super.getDialect();
 	}
 }


### PR DESCRIPTION
[HHH-15736](https://hibernate.atlassian.net/browse/HHH-15736) - Solve errors in CockroachDB and MySQL 5.7 highlighted by new tests introduced in the previous PR https://github.com/hibernate/hibernate-orm/pull/5746.