### PR TITLE
HHH-15846 Option to add @SuppressFBWarnings annotation on generated code

### DIFF
--- a/hibernate-core/hibernate-core.gradle
+++ b/hibernate-core/hibernate-core.gradle
@@ -62,6 +62,7 @@ dependencies {
     }
     testImplementation "joda-time:joda-time:2.3"
     testImplementation dbLibs.h2
+    testImplementation testLibs.archunitJUnit4
 
     testRuntimeOnly libs.byteBuddy
     testRuntimeOnly testLibs.weld

--- a/hibernate-core/src/main/java/org/hibernate/bytecode/enhance/internal/bytebuddy/ByteBuddyEnhancementContext.java
+++ b/hibernate-core/src/main/java/org/hibernate/bytecode/enhance/internal/bytebuddy/ByteBuddyEnhancementContext.java
@@ -63,6 +63,10 @@ class ByteBuddyEnhancementContext {
 		return enhancementContext.hasLazyLoadableAttributes( new UnloadedTypeDescription( classDescriptor ) );
 	}
 
+	public boolean addSuppressFBWarnings(TypeDescription classDescriptor) {
+		return enhancementContext.addSuppressFBWarnings( new UnloadedTypeDescription( classDescriptor ) );
+	}
+
 	public boolean isPersistentField(AnnotatedFieldDescription field) {
 		return enhancementContext.isPersistentField( field );
 	}

--- a/hibernate-core/src/main/java/org/hibernate/bytecode/enhance/internal/bytebuddy/CodeTemplates.java
+++ b/hibernate-core/src/main/java/org/hibernate/bytecode/enhance/internal/bytebuddy/CodeTemplates.java
@@ -543,6 +543,23 @@ class CodeTemplates {
 
 	}
 
+	/**
+	 * Used to suppress <a href="https://spotbugs.readthedocs.io">SpotBugs</a> warnings.
+	 */
+	@Retention(RetentionPolicy.CLASS)
+	@interface SuppressFBWarnings {
+		/**
+		 * @see "https://spotbugs.readthedocs.io/en/latest/bugDescriptions.html"
+		 */
+		String[] value();
+
+		/**
+		 * Reason why the warning is suppressed. Use a SpotBugs issue id where appropriate.
+		 */
+		String justification();
+	}
+
+
 	// mapping to get private field from superclass by calling the enhanced reader, for use when field is not visible
 	static class GetterMapping implements Advice.OffsetMapping {
 

--- a/hibernate-core/src/main/java/org/hibernate/bytecode/enhance/spi/DefaultEnhancementContext.java
+++ b/hibernate-core/src/main/java/org/hibernate/bytecode/enhance/spi/DefaultEnhancementContext.java
@@ -87,6 +87,11 @@ public class DefaultEnhancementContext implements EnhancementContext {
 		return true;
 	}
 
+	@Override
+	public boolean addSuppressFBWarnings(UnloadedClass classDescriptor) {
+		return true;
+	}
+
 	/**
 	 * @return true
 	 */

--- a/hibernate-core/src/main/java/org/hibernate/bytecode/enhance/spi/EnhancementContext.java
+++ b/hibernate-core/src/main/java/org/hibernate/bytecode/enhance/spi/EnhancementContext.java
@@ -101,6 +101,15 @@ public interface EnhancementContext {
 	@Deprecated(forRemoval = true)
 	boolean hasLazyLoadableAttributes(UnloadedClass classDescriptor);
 
+	/**
+	 * Should we add edu.umd.cs.findbugs.annotations.SuppressFBWarnings annotation?
+	 * <a href="https://spotbugs.readthedocs.io">SpotBugs</a>
+	 *
+	 * @param classDescriptor The descriptor of the class to check.
+	 * @return true indicates that we should add the annotation.
+	 */
+	boolean addSuppressFBWarnings(UnloadedClass classDescriptor);
+
 	// todo : may be better to invert these 2 such that the context is asked for an ordered list of persistent fields for an entity/composite
 
 	/**

--- a/hibernate-core/src/main/java/org/hibernate/bytecode/enhance/spi/EnhancementContextWrapper.java
+++ b/hibernate-core/src/main/java/org/hibernate/bytecode/enhance/spi/EnhancementContextWrapper.java
@@ -57,6 +57,11 @@ public class EnhancementContextWrapper implements EnhancementContext {
 	}
 
 	@Override
+	public boolean addSuppressFBWarnings(UnloadedClass classDescriptor) {
+		return wrappedContext.addSuppressFBWarnings( classDescriptor );
+	}
+
+	@Override
 	public boolean isPersistentField(UnloadedField ctField) {
 		return wrappedContext.isPersistentField( ctField );
 	}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhance/internal/bytebuddy/SuppressFBWarningsAnnotationTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhance/internal/bytebuddy/SuppressFBWarningsAnnotationTest.java
@@ -1,0 +1,151 @@
+package org.hibernate.orm.test.bytecode.enhance.internal.bytebuddy;
+
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.fields;
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.methods;
+
+import java.io.File;
+
+import com.tngtech.archunit.core.domain.JavaClasses;
+import com.tngtech.archunit.core.importer.ClassFileImporter;
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import jakarta.persistence.Embedded;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import org.hibernate.testing.TestForIssue;
+import org.hibernate.testing.bytecode.enhancement.BytecodeEnhancerRunner;
+import org.hibernate.testing.bytecode.enhancement.EnhancementOptions;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@TestForIssue(jiraKey = "HHH-15846")
+@RunWith(BytecodeEnhancerRunner.class)
+@EnhancementOptions(inlineDirtyChecking = true, addSuppressFBWarnings = true, biDirectionalAssociationManagement = true, lazyLoading = true, extendedEnhancement = true)
+public class SuppressFBWarningsAnnotationTest {
+
+    @Test
+    public void shouldDeclareAnnotationOnFieldsInEntityClass() {
+        fields()
+            .that()
+            .areDeclaredIn(CardGame.class)
+            .and()
+            .haveNameMatching("\\$\\$_hibernate_.*")
+            .should()
+            .beAnnotatedWith("org.hibernate.bytecode.enhance.internal.bytebuddy.CodeTemplates$SuppressFBWarnings")
+            .check(javaClasses());
+    }
+
+    @Test
+    public void shouldDeclareAnnotationOnMethodsInEntityClass() {
+        methods()
+            .that()
+            .areDeclaredIn(CardGame.class)
+            .and()
+            .haveNameMatching("\\$\\$_hibernate_.*")
+            .should()
+            .beAnnotatedWith("org.hibernate.bytecode.enhance.internal.bytebuddy.CodeTemplates$SuppressFBWarnings")
+            .check(javaClasses());
+    }
+
+    @Test
+    public void shouldDeclareAnnotationOnFieldsInEmbeddedClass() {
+        fields()
+            .that()
+            .areDeclaredIn(Component.class)
+            .and()
+            .haveNameMatching("\\$\\$_hibernate_.*")
+            .should()
+            .beAnnotatedWith("org.hibernate.bytecode.enhance.internal.bytebuddy.CodeTemplates$SuppressFBWarnings")
+            .check(javaClasses());
+    }
+
+    @Test
+    public void shouldDeclareAnnotationOnMethodsInEmbeddedClass() {
+        methods()
+            .that()
+            .areDeclaredIn(Component.class)
+            .and()
+            .haveNameMatching("\\$\\$_hibernate_.*")
+            .should()
+            .beAnnotatedWith("org.hibernate.bytecode.enhance.internal.bytebuddy.CodeTemplates$SuppressFBWarnings")
+            .check(javaClasses());
+    }
+
+    private JavaClasses javaClasses() {
+        String path = System.getProperty("java.io.tmpdir") + File.separator;
+
+        return new ClassFileImporter()
+            .importPath(path + "/org/hibernate/orm/test/bytecode/enhance/internal/bytebuddy");
+    }
+
+    @Embeddable
+    public static class Component {
+        @Column(name = "first_player_token")
+        private String component;
+
+        public Component() {
+        }
+
+        private Component(String component) {
+            this.component = component;
+        }
+
+        public String getComponent() {
+            return component;
+        }
+
+        public void setComponent(String component) {
+            this.component = component;
+        }
+    }
+
+    @Entity(name = "CardGame")
+    public static class CardGame {
+
+        @Id
+        private String id;
+        private String name;
+
+        @Embedded
+        private Component firstPlayerToken;
+
+        public CardGame() {
+        }
+
+        private CardGame(String id, String name) {
+            this.id = id;
+            this.name = name;
+            this.firstPlayerToken = createEmbeddedValue(name);
+        }
+
+        public String getId() {
+            return id;
+        }
+
+        public void setId(String id) {
+            this.id = id;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+            this.firstPlayerToken = createEmbeddedValue(name);
+        }
+
+        public Component getFirstPlayerToken() {
+            return firstPlayerToken;
+        }
+
+        public void setFirstPlayerToken(Component firstPlayerToken) {
+            this.firstPlayerToken = firstPlayerToken;
+        }
+
+        private Component createEmbeddedValue(String name) {
+            return new Component(name + " first player token");
+        }
+    }
+
+}

--- a/hibernate-testing/src/main/java/org/hibernate/testing/bytecode/enhancement/BytecodeEnhancerRunner.java
+++ b/hibernate-testing/src/main/java/org/hibernate/testing/bytecode/enhancement/BytecodeEnhancerRunner.java
@@ -111,6 +111,11 @@ public class BytecodeEnhancerRunner extends Suite {
 				}
 
 				@Override
+				public boolean addSuppressFBWarnings(UnloadedClass classDescriptor) {
+					return options.addSuppressFBWarnings() && super.addSuppressFBWarnings( classDescriptor );
+				}
+
+				@Override
 				public boolean isLazyLoadable(UnloadedField field) {
 					return options.lazyLoading() && super.isLazyLoadable( field );
 				}

--- a/hibernate-testing/src/main/java/org/hibernate/testing/bytecode/enhancement/EnhancementOptions.java
+++ b/hibernate-testing/src/main/java/org/hibernate/testing/bytecode/enhancement/EnhancementOptions.java
@@ -23,4 +23,5 @@ public @interface EnhancementOptions {
 	boolean inlineDirtyChecking() default false;
 	boolean lazyLoading() default false;
 	boolean extendedEnhancement() default false;
+	boolean addSuppressFBWarnings() default false;
 }

--- a/hibernate-testing/src/main/java/org/hibernate/testing/bytecode/enhancement/EnhancerTestContext.java
+++ b/hibernate-testing/src/main/java/org/hibernate/testing/bytecode/enhancement/EnhancerTestContext.java
@@ -38,6 +38,11 @@ public class EnhancerTestContext extends DefaultEnhancementContext {
 	}
 
 	@Override
+	public boolean addSuppressFBWarnings(UnloadedClass classDescriptor) {
+		return true;
+	}
+
+	@Override
 	public boolean isLazyLoadable(UnloadedField field) {
 		return true;
 	}

--- a/settings.gradle
+++ b/settings.gradle
@@ -158,6 +158,9 @@ dependencyResolutionManagement {
             alias( "jbossTxSpi" ).to( "org.jboss", "jboss-transaction-spi-jakarta" ).version( "7.6.1.Final" )
             alias( "wildFlyTxnClient" ).to( "org.wildfly.transaction", "wildfly-transaction-client-jakarta" ).version( "2.0.0.Final" )
             alias( "weld" ).to( "org.jboss.weld.se", "weld-se-shaded" ).version( "4.0.1.SP1" )
+
+            alias( "archunitJUnit4" ).to( "com.tngtech.archunit", "archunit-junit4" ).version( "1.0.1" )
+
         }
         dbLibs {
             String h2Version = settings.ext.find( "gradle.libs.versions.h2" )

--- a/tooling/hibernate-enhance-maven-plugin/src/main/java/org/hibernate/orm/tooling/maven/MavenEnhancePlugin.java
+++ b/tooling/hibernate-enhance-maven-plugin/src/main/java/org/hibernate/orm/tooling/maven/MavenEnhancePlugin.java
@@ -80,6 +80,9 @@ public class MavenEnhancePlugin extends AbstractMojo {
 	@Parameter(property = "enableExtendedEnhancement", defaultValue = "false")
 	private boolean enableExtendedEnhancement;
 
+	@Parameter(property = "addSuppressFBWarnings", defaultValue = "false")
+	private boolean addSuppressFBWarnings;
+
 	private boolean shouldApply() {
 		return enableLazyInitialization || enableDirtyTracking || enableAssociationManagement || enableExtendedEnhancement;
 	}
@@ -130,6 +133,11 @@ public class MavenEnhancePlugin extends AbstractMojo {
 			@Override
 			public boolean hasLazyLoadableAttributes(UnloadedClass classDescriptor) {
 				return enableLazyInitialization;
+			}
+
+			@Override
+			public boolean addSuppressFBWarnings(UnloadedClass classDescriptor) {
+				return addSuppressFBWarnings;
 			}
 
 			@Override

--- a/tooling/hibernate-enhance-maven-plugin/src/main/resources/META-INF/maven/org.hibernate.orm.tooling/hibernate-enhance-maven-plugin/plugin-help.xml
+++ b/tooling/hibernate-enhance-maven-plugin/src/main/resources/META-INF/maven/org.hibernate.orm.tooling/hibernate-enhance-maven-plugin/plugin-help.xml
@@ -80,6 +80,14 @@
           <editable>true</editable>
           <description>Enable enhancement of field access</description>
         </parameter>
+        <parameter>
+          <name>addSuppressFBWarnings</name>
+          <type>java.lang.Boolean</type>
+          <required>false</required>
+          <editable>true</editable>
+          <description>Adds @SuppressFBWarnings annotation to generated nodes which is useful if you want to
+              run FindBugs on your class files.</description>
+        </parameter>
       </parameters>
       <configuration>
         <base>${project.build.outputDirectory}</base>
@@ -89,6 +97,7 @@
         <enableDirtyTracking>false</enableDirtyTracking>
         <enableAssociationManagement>false</enableAssociationManagement>
         <enableExtendedEnhancement>false</enableExtendedEnhancement>
+        <addSuppressFBWarnings>false</addSuppressFBWarnings>
       </configuration>
     </mojo>
   </mojos>

--- a/tooling/hibernate-enhance-maven-plugin/src/main/resources/META-INF/maven/plugin.xml
+++ b/tooling/hibernate-enhance-maven-plugin/src/main/resources/META-INF/maven/plugin.xml
@@ -81,6 +81,14 @@
           <editable>true</editable>
           <description>Enable enhancement of field access</description>
         </parameter>
+        <parameter>
+          <name>addSuppressFBWarnings</name>
+          <type>java.lang.Boolean</type>
+          <required>false</required>
+          <editable>true</editable>
+          <description>Adds @SuppressFBWarnings annotation to generated nodes which is useful if you want to
+            run FindBugs on your class files.</description>
+        </parameter>
       </parameters>
       <configuration>
         <base>${project.build.outputDirectory}</base>
@@ -90,6 +98,7 @@
         <enableDirtyTracking>false</enableDirtyTracking>
         <enableAssociationManagement>false</enableAssociationManagement>
         <enableExtendedEnhancement>false</enableExtendedEnhancement>
+        <addSuppressFBWarnings>false</addSuppressFBWarnings>
       </configuration>
       <requirements>
         <requirement>

--- a/tooling/hibernate-gradle-plugin/README.adoc
+++ b/tooling/hibernate-gradle-plugin/README.adoc
@@ -68,6 +68,7 @@ hibernate {
     dirtyTracking = true
     associationManagement = true
     extendedEnhancement = false
+    addSuppressFBWarnings = false
   }
 }
 ----

--- a/tooling/hibernate-gradle-plugin/src/main/java/org/hibernate/orm/tooling/gradle/enhance/EnhancementHelper.java
+++ b/tooling/hibernate-gradle-plugin/src/main/java/org/hibernate/orm/tooling/gradle/enhance/EnhancementHelper.java
@@ -120,6 +120,11 @@ public class EnhancementHelper {
 			}
 
 			@Override
+			public boolean addSuppressFBWarnings(UnloadedClass classDescriptor) {
+				return enhancementDsl.getAddSuppressFBWarnings().get();
+			}
+
+			@Override
 			public boolean isLazyLoadable(UnloadedField field) {
 				return enhancementDsl.getEnableLazyInitialization().get();
 			}

--- a/tooling/hibernate-gradle-plugin/src/main/java/org/hibernate/orm/tooling/gradle/enhance/EnhancementSpec.java
+++ b/tooling/hibernate-gradle-plugin/src/main/java/org/hibernate/orm/tooling/gradle/enhance/EnhancementSpec.java
@@ -28,7 +28,7 @@ public class EnhancementSpec {
 	private final Property<Boolean> enableDirtyTracking;
 	private final Property<Boolean> enableAssociationManagement;
 	private final Property<Boolean> enableExtendedEnhancement;
-
+	private final Property<Boolean> addSuppressFBWarnings;
 
 	@Inject
 	public EnhancementSpec(HibernateOrmSpec ormDsl, Project project) {
@@ -38,13 +38,15 @@ public class EnhancementSpec {
 		enableDirtyTracking = makeProperty( project ).convention( true );
 		enableAssociationManagement = makeProperty( project );
 		enableExtendedEnhancement = makeProperty( project );
+		addSuppressFBWarnings = makeProperty( project );
 	}
 
 	public boolean hasAnythingToDo() {
 		return enableLazyInitialization.get()
 				|| enableDirtyTracking.get()
 				|| enableAssociationManagement.get()
-				|| enableExtendedEnhancement.get();
+				|| enableExtendedEnhancement.get()
+				|| addSuppressFBWarnings.get();
 	}
 
 	@Deprecated(forRemoval = true)
@@ -115,7 +117,6 @@ public class EnhancementSpec {
 		setEnableAssociationManagement( enable );
 	}
 
-
 	public Property<Boolean> getEnableExtendedEnhancement() {
 		return enableExtendedEnhancement;
 	}
@@ -124,12 +125,24 @@ public class EnhancementSpec {
 		enableExtendedEnhancement.set( enable );
 	}
 
+	public void setAddSuppressFBWarnings(boolean enable) {
+		addSuppressFBWarnings.set( enable );
+	}
+
 	public void enableExtendedEnhancement(boolean enable) {
 		setEnableExtendedEnhancement( enable );
 	}
 
 	public void extendedEnhancement(boolean enable) {
 		setEnableExtendedEnhancement( enable );
+	}
+
+	public void addSuppressFBWarnings(boolean enable) {
+		setAddSuppressFBWarnings( enable );
+	}
+
+	public Property<Boolean> getAddSuppressFBWarnings() {
+		return addSuppressFBWarnings;
 	}
 
 	@SuppressWarnings( "UnstableApiUsage" )


### PR DESCRIPTION
Lombok has an option to add `@SuppressFBWarnings` to generated code via `lombok.extern.findbugs.addSuppressFBWarnings`.

It would be really helpful if the hibernate gradle/maven enhance plugins would provide a similar option.

We're currently struggling with warnings related to hibernate generated code in our entities, in SpotBugs.

```
NP | Non-null field $_hibernate_attributeInterceptor is not initialized by new <entity>
NP | Non-null field $_hibernate_entityEntryHolder is not initialized by new <entity>
NP | Non-null field $_hibernate_nextManagedEntity is not initialized by new <entity>
NP | Non-null field $_hibernate_previousManagedEntity is not initialized by new <entity>
NP | Non-null field $_hibernate_tracker is not initialized by new <entity>
```

Discussion on GitHub
Enhance plugin - Option to add @SuppressFBWarnings annotation · Discussion #5668 · hibernate/hibernate-orm