### PR TITLE
HHH-15904 Change scope of BasicCollectionPersister#buildRowMutationOperations

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/persister/collection/BasicCollectionPersister.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/collection/BasicCollectionPersister.java
@@ -208,7 +208,7 @@ public class BasicCollectionPersister extends AbstractCollectionPersister {
 	}
 
 
-	private RowMutationOperations buildRowMutationOperations() {
+	protected RowMutationOperations buildRowMutationOperations() {
 		final OperationProducer insertRowOperationProducer;
 		final RowMutationOperations.Values insertRowValues;
 		if ( !isInverse() && isRowInsertEnabled() ) {


### PR DESCRIPTION
A minor change for allowing Hibernate Reactive to reuse the method