### PR TITLE
HHH-15942 introduce ForcedFlushMode 

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/ForcedFlushMode.java
+++ b/hibernate-core/src/main/java/org/hibernate/ForcedFlushMode.java
@@ -1,0 +1,33 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate;
+
+/**
+ * Enumerates the possible flush modes for execution of a
+ * {@link org.hibernate.query.Query}. A "forced" flush mode
+ * overrides the {@linkplain Session#getHibernateFlushMode()
+ * flush mode of the session}.
+ *
+ * @author Gavin King
+ *
+ * @since 6.2
+ */
+public enum ForcedFlushMode {
+	/**
+	 * Flush before executing the query.
+	 */
+	FORCE_FLUSH,
+	/**
+	 * Do not flush before executing the query.
+	 */
+	FORCE_NO_FLUSH,
+	/**
+	 * Let the owning {@link Session session} decide whether
+	 * to flush, depending on its {@link FlushMode}.
+	 */
+	NO_FORCING
+}

--- a/hibernate-core/src/main/java/org/hibernate/Session.java
+++ b/hibernate-core/src/main/java/org/hibernate/Session.java
@@ -148,7 +148,7 @@ public interface Session extends SharedSessionContract, EntityManager {
 	void flush();
 
 	/**
-	 * Set the current {@link FlushModeType JPA flush mode} for this session.
+	 * Set the current {@linkplain FlushModeType JPA flush mode} for this session.
 	 * <p>
 	 * <em>Flushing</em> is the process of synchronizing the underlying persistent
 	 * store with persistable state held in memory. The current flush mode determines
@@ -162,7 +162,7 @@ public interface Session extends SharedSessionContract, EntityManager {
 	void setFlushMode(FlushModeType flushMode);
 
 	/**
-	 * Set the current {@link FlushMode flush mode} for this session.
+	 * Set the current {@linkplain FlushMode flush mode} for this session.
 	 * <p>
 	 * <em>Flushing</em> is the process of synchronizing the underlying persistent
 	 * store with persistable state held in memory. The current flush mode determines
@@ -180,7 +180,7 @@ public interface Session extends SharedSessionContract, EntityManager {
 	void setHibernateFlushMode(FlushMode flushMode);
 
 	/**
-	 * Get the current {@link FlushModeType JPA flush mode} for this session.
+	 * Get the current {@linkplain FlushModeType JPA flush mode} for this session.
 	 *
 	 * @return the {@link FlushModeType} currently in effect
 	 */
@@ -188,14 +188,14 @@ public interface Session extends SharedSessionContract, EntityManager {
 	FlushModeType getFlushMode();
 
 	/**
-	 * Get the current {@link FlushMode flush mode} for this session.
+	 * Get the current {@linkplain FlushMode flush mode} for this session.
 	 *
 	 * @return the {@link FlushMode} currently in effect
 	 */
 	FlushMode getHibernateFlushMode();
 
 	/**
-	 * Set the current {@link CacheMode cache mode} for this session.
+	 * Set the current {@linkplain CacheMode cache mode} for this session.
 	 * <p>
 	 * The cache mode determines the manner in which this session can interact with
 	 * the second level cache.
@@ -205,7 +205,7 @@ public interface Session extends SharedSessionContract, EntityManager {
 	void setCacheMode(CacheMode cacheMode);
 
 	/**
-	 * Get the current {@link CacheMode cache mode} for this session.
+	 * Get the current {@linkplain CacheMode cache mode} for this session.
 	 *
 	 * @return the current cache mode
 	 */

--- a/hibernate-core/src/main/java/org/hibernate/annotations/FlushModeType.java
+++ b/hibernate-core/src/main/java/org/hibernate/annotations/FlushModeType.java
@@ -16,7 +16,10 @@ package org.hibernate.annotations;
  *
  * @see NamedQuery
  * @see NamedNativeQuery
+ *
+ * @deprecated use {@link org.hibernate.ForcedFlushMode}
  */
+@Deprecated(since="6")
 public enum FlushModeType {
 	/**
 	 * Corresponds to {@link org.hibernate.FlushMode#ALWAYS}.

--- a/hibernate-core/src/main/java/org/hibernate/annotations/NamedNativeQuery.java
+++ b/hibernate-core/src/main/java/org/hibernate/annotations/NamedNativeQuery.java
@@ -13,6 +13,7 @@ import java.lang.annotation.Target;
 import jakarta.persistence.CacheRetrieveMode;
 import jakarta.persistence.CacheStoreMode;
 import org.hibernate.CacheMode;
+import org.hibernate.ForcedFlushMode;
 import org.hibernate.Remove;
 
 import static java.lang.annotation.ElementType.PACKAGE;
@@ -65,11 +66,22 @@ public @interface NamedNativeQuery {
 	String resultSetMapping() default "";
 
 	/**
+	 * Determines whether the session should be flushed before
+	 * executing the query.
+	 *
+	 * @see org.hibernate.query.CommonQueryContract#setForcedFlushMode(ForcedFlushMode)
+	 */
+	ForcedFlushMode flush() default ForcedFlushMode.NO_FORCING;
+
+	/**
 	 * The flush mode for the query.
 	 *
 	 * @see org.hibernate.query.CommonQueryContract#setFlushMode(jakarta.persistence.FlushModeType)
 	 * @see org.hibernate.jpa.HibernateHints#HINT_FLUSH_MODE
+	 *
+	 * @deprecated use {@link #flush()}
 	 */
+	@Deprecated(since = "6")
 	FlushModeType flushMode() default FlushModeType.PERSISTENCE_CONTEXT;
 
 	/**

--- a/hibernate-core/src/main/java/org/hibernate/annotations/NamedQuery.java
+++ b/hibernate-core/src/main/java/org/hibernate/annotations/NamedQuery.java
@@ -12,6 +12,7 @@ import java.lang.annotation.Target;
 
 import jakarta.persistence.CacheRetrieveMode;
 import jakarta.persistence.CacheStoreMode;
+import org.hibernate.ForcedFlushMode;
 import org.hibernate.Remove;
 
 import static java.lang.annotation.ElementType.PACKAGE;
@@ -48,11 +49,22 @@ public @interface NamedQuery {
 	String query();
 
 	/**
+	 * Determines whether the session should be flushed before
+	 * executing the query.
+	 *
+	 * @see org.hibernate.query.CommonQueryContract#setForcedFlushMode(ForcedFlushMode)
+	 */
+	ForcedFlushMode flush() default ForcedFlushMode.NO_FORCING;
+
+	/**
 	 * The flush mode for this query.
 	 *
 	 * @see org.hibernate.query.CommonQueryContract#setFlushMode(jakarta.persistence.FlushModeType)
 	 * @see org.hibernate.jpa.HibernateHints#HINT_FLUSH_MODE
+	 *
+	 * @deprecated use {@link #flush()}
 	 */
+	@Deprecated(since = "6")
 	FlushModeType flushMode() default FlushModeType.PERSISTENCE_CONTEXT;
 
 	/**

--- a/hibernate-core/src/main/java/org/hibernate/graph/internal/parse/GraphParser.java
+++ b/hibernate-core/src/main/java/org/hibernate/graph/internal/parse/GraphParser.java
@@ -18,8 +18,6 @@ import org.hibernate.internal.util.StringHelper;
 import org.hibernate.internal.util.collections.Stack;
 import org.hibernate.internal.util.collections.StandardStack;
 
-import org.jboss.logging.Logger;
-
 import org.antlr.v4.runtime.CharStreams;
 import org.antlr.v4.runtime.CommonTokenStream;
 

--- a/hibernate-core/src/main/java/org/hibernate/jpa/internal/util/FlushModeTypeHelper.java
+++ b/hibernate-core/src/main/java/org/hibernate/jpa/internal/util/FlushModeTypeHelper.java
@@ -12,6 +12,7 @@ import jakarta.persistence.FlushModeType;
 
 import org.hibernate.AssertionFailure;
 import org.hibernate.FlushMode;
+import org.hibernate.ForcedFlushMode;
 import org.hibernate.MappingException;
 
 import org.jboss.logging.Logger;
@@ -28,33 +29,69 @@ public class FlushModeTypeHelper {
 	}
 
 	public static FlushModeType getFlushModeType(FlushMode flushMode) {
-		if ( flushMode == FlushMode.ALWAYS ) {
-			log.debug( "Interpreting Hibernate FlushMode#ALWAYS to JPA FlushModeType#AUTO; may cause problems if relying on FlushMode#ALWAYS-specific behavior" );
-			return FlushModeType.AUTO;
+		if ( flushMode == null ) {
+			return null;
 		}
-		else if ( flushMode == FlushMode.MANUAL ) {
-			log.debug( "Interpreting Hibernate FlushMode#MANUAL to JPA FlushModeType#COMMIT; may cause problems if relying on FlushMode#MANUAL-specific behavior" );
-			return FlushModeType.COMMIT;
+		switch ( flushMode ) {
+			case ALWAYS:
+				log.debug( "Interpreting Hibernate FlushMode#ALWAYS to JPA FlushModeType#AUTO; may cause problems if relying on FlushMode#ALWAYS-specific behavior" );
+				return FlushModeType.AUTO;
+			case MANUAL:
+				log.debug( "Interpreting Hibernate FlushMode#MANUAL to JPA FlushModeType#COMMIT; may cause problems if relying on FlushMode#MANUAL-specific behavior" );
+				return FlushModeType.COMMIT;
+			case COMMIT:
+				return FlushModeType.COMMIT;
+			case AUTO:
+				return FlushModeType.AUTO;
+			default:
+				throw new AssertionFailure( "unhandled FlushMode " + flushMode );
 		}
-		else if ( flushMode == FlushMode.COMMIT ) {
-			return FlushModeType.COMMIT;
-		}
-		else if ( flushMode == FlushMode.AUTO ) {
-			return FlushModeType.AUTO;
-		}
+	}
 
-		throw new AssertionFailure( "unhandled FlushMode " + flushMode );
+	public static ForcedFlushMode getForcedFlushMode(FlushMode flushMode) {
+		if ( flushMode == null ) {
+			return ForcedFlushMode.NO_FORCING;
+		}
+		switch ( flushMode ) {
+			case ALWAYS:
+				return ForcedFlushMode.FORCE_FLUSH;
+			case COMMIT:
+			case MANUAL:
+				return ForcedFlushMode.FORCE_NO_FLUSH;
+			case AUTO:
+				// this is not precisely correctly correct, but good enough
+				return ForcedFlushMode.NO_FORCING;
+			default:
+				throw new AssertionFailure( "unhandled FlushMode " + flushMode );
+		}
 	}
 
 	public static FlushMode getFlushMode(FlushModeType flushModeType) {
-		if ( flushModeType == FlushModeType.AUTO ) {
-			return FlushMode.AUTO;
+		if ( flushModeType == null ) {
+			return null;
 		}
-		else if ( flushModeType == FlushModeType.COMMIT ) {
-			return FlushMode.COMMIT;
+		switch ( flushModeType ) {
+			case AUTO:
+				return FlushMode.AUTO;
+			case COMMIT:
+				return FlushMode.COMMIT;
+			default:
+				throw new AssertionFailure( "unhandled FlushModeType " + flushModeType );
 		}
+	}
 
-		throw new AssertionFailure( "unhandled FlushModeType " + flushModeType );
+	public static FlushMode getFlushMode(ForcedFlushMode forcedFlushMode) {
+		if ( forcedFlushMode == null ) {
+			return null;
+		}
+		switch ( forcedFlushMode ) {
+			case FORCE_FLUSH:
+				return FlushMode.ALWAYS;
+			case FORCE_NO_FLUSH:
+				return FlushMode.MANUAL;
+			default:
+				return null;
+		}
 	}
 
 	public static FlushMode interpretFlushMode(Object value) {

--- a/hibernate-core/src/main/java/org/hibernate/procedure/internal/ProcedureCallImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/procedure/internal/ProcedureCallImpl.java
@@ -784,7 +784,7 @@ public class ProcedureCallImpl<R>
 				isCacheable(),
 				getCacheRegion(),
 				getCacheMode(),
-				getHibernateFlushMode(),
+				getQueryOptions().getFlushMode(),
 				isReadOnly(),
 				getTimeout(),
 				getFetchSize(),

--- a/hibernate-core/src/main/java/org/hibernate/query/CommonQueryContract.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/CommonQueryContract.java
@@ -13,6 +13,7 @@ import java.util.Date;
 import java.util.Map;
 
 import org.hibernate.FlushMode;
+import org.hibernate.ForcedFlushMode;
 import org.hibernate.Session;
 
 import jakarta.persistence.FlushModeType;
@@ -31,35 +32,65 @@ import jakarta.persistence.TemporalType;
 public interface CommonQueryContract {
 
 	/**
+	 * The {@link ForcedFlushMode} in effect for this query.
+	 * <p>
+	 * By default, this is {@link ForcedFlushMode#NO_FORCING}, and the
+	 * {@link FlushMode} of the owning {@link Session} determines whether
+	 * it is flushed.
+	 *
+	 * @see Session#getHibernateFlushMode()
+	 */
+	ForcedFlushMode getForcedFlushMode();
+
+	/**
+	 * Set the {@link ForcedFlushMode} in to use for this query.
+	 *
+	 * @see Session#getHibernateFlushMode()
+	 */
+	CommonQueryContract setForcedFlushMode(ForcedFlushMode forcedFlushMode);
+
+	/**
 	 * The JPA {@link FlushModeType} in effect for this query.  By default, the
 	 * query inherits the {@link FlushMode} of the {@link Session} from which
 	 * it originates.
 	 *
-	 * @see #getHibernateFlushMode
-	 * @see Session#getHibernateFlushMode
+	 * @see #getForcedFlushMode()
+	 * @see #getHibernateFlushMode()
+	 * @see Session#getHibernateFlushMode()
+	 *
+	 * @deprecated use {@link #getForcedFlushMode()}
 	 */
+	@Deprecated(since = "6")
 	FlushModeType getFlushMode();
 
 	/**
 	 * Set the {@link FlushMode} in to use for this query.
+	 * <p>
+	 * Setting this to {@code null} ultimately indicates to use the
+	 * {@link FlushMode} of the Session. Use {@link #setHibernateFlushMode}
+	 * passing {@link FlushMode#MANUAL} instead to indicate that no automatic
+	 * flushing should occur.
 	 *
-	 * @implNote Setting to {@code null} ultimately indicates to use the
-	 * FlushMode of the Session.  Use {@link #setHibernateFlushMode} passing
-	 * {@link FlushMode#MANUAL} instead to indicate that no automatic flushing
-	 * should occur
-	 *
+	 * @see #getForcedFlushMode()
 	 * @see #getHibernateFlushMode()
 	 * @see Session#getHibernateFlushMode()
+	 *
+	 * @deprecated use {@link #setForcedFlushMode(ForcedFlushMode)}
 	 */
+	@Deprecated(since = "6")
 	CommonQueryContract setFlushMode(FlushModeType flushMode);
 
 	/**
-	 * The {@link FlushMode} in effect for this query.  By default, the query
+	 * The {@link FlushMode} in effect for this query. By default, the query
 	 * inherits the {@code FlushMode} of the {@link Session} from which it
 	 * originates.
 	 *
-	 * @see Session#getHibernateFlushMode
+	 * @see #getForcedFlushMode()
+	 * @see Session#getHibernateFlushMode()
+	 *
+	 * @deprecated use {@link #getForcedFlushMode()}
 	 */
+	@Deprecated(since = "6")
 	FlushMode getHibernateFlushMode();
 
 	/**
@@ -69,9 +100,13 @@ public interface CommonQueryContract {
 	 * {@link FlushMode} of the Session.  Use {@link FlushMode#MANUAL}
 	 * instead to indicate that no automatic flushing should occur.
 	 *
+	 * @see #getForcedFlushMode()
 	 * @see #getHibernateFlushMode()
 	 * @see Session#getHibernateFlushMode()
+	 *
+	 * @deprecated use {@link #setForcedFlushMode(ForcedFlushMode)}
 	 */
+	@Deprecated(since = "6")
 	CommonQueryContract setHibernateFlushMode(FlushMode flushMode);
 
 	/**

--- a/hibernate-core/src/main/java/org/hibernate/query/MutationQuery.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/MutationQuery.java
@@ -13,6 +13,7 @@ import java.util.Date;
 import java.util.Map;
 
 import org.hibernate.FlushMode;
+import org.hibernate.ForcedFlushMode;
 import org.hibernate.Incubating;
 
 import jakarta.persistence.Parameter;
@@ -195,4 +196,7 @@ public interface MutationQuery extends CommonQueryContract {
 
 	@Override
 	MutationQuery setHibernateFlushMode(FlushMode flushMode);
+
+	@Override
+	MutationQuery setForcedFlushMode(ForcedFlushMode forcedFlushMode);
 }

--- a/hibernate-core/src/main/java/org/hibernate/query/NativeQuery.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/NativeQuery.java
@@ -23,6 +23,7 @@ import jakarta.persistence.metamodel.SingularAttribute;
 
 import org.hibernate.CacheMode;
 import org.hibernate.FlushMode;
+import org.hibernate.ForcedFlushMode;
 import org.hibernate.LockMode;
 import org.hibernate.LockOptions;
 import org.hibernate.MappingException;
@@ -556,6 +557,9 @@ public interface NativeQuery<T> extends Query<T>, SynchronizeableQuery {
 
 	@Override
 	NativeQuery<T> setHibernateFlushMode(FlushMode flushMode);
+
+	@Override
+	NativeQuery<T> setForcedFlushMode(ForcedFlushMode forcedFlushMode);
 
 	@Override
 	NativeQuery<T> setFlushMode(FlushModeType flushMode);

--- a/hibernate-core/src/main/java/org/hibernate/query/Query.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/Query.java
@@ -17,6 +17,7 @@ import java.util.stream.Stream;
 
 import org.hibernate.CacheMode;
 import org.hibernate.FlushMode;
+import org.hibernate.ForcedFlushMode;
 import org.hibernate.Incubating;
 import org.hibernate.LockMode;
 import org.hibernate.LockOptions;
@@ -854,6 +855,9 @@ public interface Query<R> extends SelectionQuery<R>, MutationQuery, TypedQuery<R
 
 	@Override
 	Query<R> setHibernateFlushMode(FlushMode flushMode);
+
+	@Override
+	Query<R> setForcedFlushMode(ForcedFlushMode forcedFlushMode);
 
 	@Override
 	Query<R> setCacheable(boolean cacheable);

--- a/hibernate-core/src/main/java/org/hibernate/query/SelectionQuery.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/SelectionQuery.java
@@ -19,6 +19,7 @@ import jakarta.persistence.CacheRetrieveMode;
 import jakarta.persistence.CacheStoreMode;
 import org.hibernate.CacheMode;
 import org.hibernate.FlushMode;
+import org.hibernate.ForcedFlushMode;
 import org.hibernate.Incubating;
 import org.hibernate.LockMode;
 import org.hibernate.LockOptions;
@@ -193,6 +194,9 @@ public interface SelectionQuery<R> extends CommonQueryContract {
 	SelectionQuery<R> setHibernateFlushMode(FlushMode flushMode);
 
 	@Override
+	SelectionQuery<R> setForcedFlushMode(ForcedFlushMode forcedFlushMode);
+
+	@Override
 	SelectionQuery<R> setTimeout(int timeout);
 
 	/**
@@ -299,14 +303,13 @@ public interface SelectionQuery<R> extends CommonQueryContract {
 	 * the query inherits the {@link CacheMode} of the session from which
 	 * it originates.
 	 * <p>
-	 * The {@link CacheMode} here describes reading-from/writing-to the
-	 * entity/collection caches as we process query results. For caching
-	 * of the actual query results, see {@link #isCacheable()} and
-	 * {@link #getCacheRegion()}
+	 * The {@link CacheMode} here affects the use of entity and collection
+	 * caches as the query result set is processed. For caching of the actual
+	 * query results, use {@link #isCacheable()} and {@link #getCacheRegion()}.
 	 * <p>
 	 * In order for this setting to have any affect, second-level caching
-	 * would have to be enabled and the entities/collections in question
-	 * configured for caching.
+	 * must be enabled and the entities and collections must be eligible
+	 * for storage in the second-level cache.
 	 *
 	 * @see Session#getCacheMode()
 	 */
@@ -328,9 +331,9 @@ public interface SelectionQuery<R> extends CommonQueryContract {
 
 	/**
 	 * Set the current {@link CacheMode} in effect for this query.
-	 *
-	 * @implNote Setting it to {@code null} ultimately indicates to use the
-	 *           {@code CacheMode} of the session.
+	 * <p>
+	 * Set it to {@code null} to indicate that the {@code CacheMode}
+	 * of the {@link Session#getCacheMode() session} should be used.
 	 *
 	 * @see #getCacheMode()
 	 * @see Session#setCacheMode(CacheMode)

--- a/hibernate-core/src/main/java/org/hibernate/query/hql/spi/SqmQueryImplementor.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/hql/spi/SqmQueryImplementor.java
@@ -14,11 +14,13 @@ import java.util.Map;
 
 import org.hibernate.CacheMode;
 import org.hibernate.FlushMode;
+import org.hibernate.ForcedFlushMode;
 import org.hibernate.LockMode;
 import org.hibernate.LockOptions;
 import org.hibernate.graph.GraphSemantic;
 import org.hibernate.graph.RootGraph;
 import org.hibernate.query.BindableType;
+import org.hibernate.query.Query;
 import org.hibernate.query.QueryParameter;
 import org.hibernate.query.ResultListTransformer;
 import org.hibernate.query.TupleTransformer;
@@ -106,6 +108,9 @@ public interface SqmQueryImplementor<R> extends QueryImplementor<R>, SqmQuery, N
 
 	@Override
 	SqmQueryImplementor<R> setHibernateFlushMode(FlushMode flushMode);
+
+	@Override
+	SqmQueryImplementor<R> setForcedFlushMode(ForcedFlushMode forcedFlushMode);
 
 	@Override
 	SqmQueryImplementor<R> setMaxResults(int maxResult);

--- a/hibernate-core/src/main/java/org/hibernate/query/spi/AbstractCommonQueryContract.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/spi/AbstractCommonQueryContract.java
@@ -17,6 +17,7 @@ import java.util.Set;
 
 import org.hibernate.CacheMode;
 import org.hibernate.FlushMode;
+import org.hibernate.ForcedFlushMode;
 import org.hibernate.HibernateException;
 import org.hibernate.LockMode;
 import org.hibernate.LockOptions;
@@ -172,7 +173,7 @@ public abstract class AbstractCommonQueryContract implements CommonQueryContract
 		}
 
 		putIfNotNull( hints, HINT_COMMENT, getComment() );
-		putIfNotNull( hints, HINT_FLUSH_MODE, getHibernateFlushMode() );
+		putIfNotNull( hints, HINT_FLUSH_MODE,  getQueryOptions().getFlushMode() );
 
 		putIfNotNull( hints, HINT_READONLY, getQueryOptions().isReadOnly() );
 		putIfNotNull( hints, HINT_FETCH_SIZE, getQueryOptions().getFetchSize() );
@@ -541,12 +542,24 @@ public abstract class AbstractCommonQueryContract implements CommonQueryContract
 
 	@Override
 	public FlushMode getHibernateFlushMode() {
-		return getQueryOptions().getFlushMode();
+		FlushMode flushMode = getQueryOptions().getFlushMode();
+		return flushMode == null ? getSession().getHibernateFlushMode() : flushMode;
 	}
 
 	@Override
 	public CommonQueryContract setHibernateFlushMode(FlushMode flushMode) {
 		getQueryOptions().setFlushMode( flushMode );
+		return this;
+	}
+
+	@Override
+	public ForcedFlushMode getForcedFlushMode() {
+		return FlushModeTypeHelper.getForcedFlushMode( getQueryOptions().getFlushMode() );
+	}
+
+	@Override
+	public CommonQueryContract setForcedFlushMode(ForcedFlushMode forcedFlushMode) {
+		getQueryOptions().setFlushMode( FlushModeTypeHelper.getFlushMode( forcedFlushMode ) );
 		return this;
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/query/spi/SqmQuery.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/spi/SqmQuery.java
@@ -13,6 +13,7 @@ import java.util.Date;
 import java.util.Map;
 
 import org.hibernate.FlushMode;
+import org.hibernate.ForcedFlushMode;
 import org.hibernate.query.BindableType;
 import org.hibernate.query.CommonQueryContract;
 import org.hibernate.query.ParameterMetadata;
@@ -151,8 +152,11 @@ public interface SqmQuery extends CommonQueryContract {
 	SqmQuery setProperties(Object bean);
 
 	@Override
-	SqmQuery setProperties(Map bean);
+	SqmQuery setProperties(@SuppressWarnings("rawtypes") Map bean);
 
 	@Override
 	SqmQuery setHibernateFlushMode(FlushMode flushMode);
+
+	@Override
+	SqmQuery setForcedFlushMode(ForcedFlushMode forcedFlushMode);
 }

--- a/hibernate-core/src/main/java/org/hibernate/query/sql/internal/NativeQueryImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sql/internal/NativeQueryImpl.java
@@ -22,6 +22,7 @@ import java.util.function.Supplier;
 
 import org.hibernate.CacheMode;
 import org.hibernate.FlushMode;
+import org.hibernate.ForcedFlushMode;
 import org.hibernate.HibernateException;
 import org.hibernate.LockMode;
 import org.hibernate.LockOptions;
@@ -67,6 +68,7 @@ import org.hibernate.query.spi.MutableQueryOptions;
 import org.hibernate.query.spi.NonSelectQueryPlan;
 import org.hibernate.query.spi.ParameterMetadataImplementor;
 import org.hibernate.query.spi.QueryEngine;
+import org.hibernate.query.spi.QueryImplementor;
 import org.hibernate.query.spi.QueryInterpretationCache;
 import org.hibernate.query.spi.QueryParameterBinding;
 import org.hibernate.query.spi.QueryParameterBindings;
@@ -454,7 +456,7 @@ public class NativeQueryImpl<R>
 				isCacheable(),
 				getCacheRegion(),
 				getCacheMode(),
-				getHibernateFlushMode(),
+				getQueryOptions().getFlushMode(),
 				isReadOnly(),
 				getTimeout(),
 				getFetchSize(),
@@ -579,7 +581,7 @@ public class NativeQueryImpl<R>
 
 	private boolean shouldFlush() {
 		if ( getSession().isTransactionInProgress() ) {
-			FlushMode effectiveFlushMode = getHibernateFlushMode();
+			FlushMode effectiveFlushMode = getQueryOptions().getFlushMode();
 			if ( effectiveFlushMode == null ) {
 				effectiveFlushMode = getSession().getHibernateFlushMode();
 			}
@@ -1084,6 +1086,12 @@ public class NativeQueryImpl<R>
 	@Override
 	public NativeQueryImplementor<R> setHibernateFlushMode(FlushMode flushMode) {
 		super.setHibernateFlushMode( flushMode );
+		return this;
+	}
+
+	@Override
+	public NativeQueryImplementor<R> setForcedFlushMode(ForcedFlushMode forcedFlushMode) {
+		super.setForcedFlushMode(forcedFlushMode);
 		return this;
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/query/sql/spi/NativeQueryImplementor.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sql/spi/NativeQueryImplementor.java
@@ -14,6 +14,7 @@ import java.util.Map;
 
 import org.hibernate.CacheMode;
 import org.hibernate.FlushMode;
+import org.hibernate.ForcedFlushMode;
 import org.hibernate.Incubating;
 import org.hibernate.LockMode;
 import org.hibernate.LockOptions;
@@ -148,6 +149,9 @@ public interface NativeQueryImplementor<R> extends QueryImplementor<R>, NativeQu
 
 	@Override
 	NativeQueryImplementor<R> setHibernateFlushMode(FlushMode flushMode);
+
+	@Override
+	NativeQueryImplementor<R> setForcedFlushMode(ForcedFlushMode forcedFlushMode);
 
 	@Override
 	NativeQueryImplementor<R> setFlushMode(FlushModeType flushMode);

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/SqmSelectionQuery.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/SqmSelectionQuery.java
@@ -14,6 +14,7 @@ import java.util.Map;
 
 import org.hibernate.CacheMode;
 import org.hibernate.FlushMode;
+import org.hibernate.ForcedFlushMode;
 import org.hibernate.query.BindableType;
 import org.hibernate.query.QueryParameter;
 import org.hibernate.query.SelectionQuery;
@@ -82,7 +83,7 @@ public interface SqmSelectionQuery<R> extends SqmQuery, SelectionQuery<R> {
 	SqmSelectionQuery<R> setParameter(Parameter<Date> param, Date value, TemporalType temporalType);
 
 	@Override
-	SqmSelectionQuery<R> setParameterList(String name, Collection values);
+	SqmSelectionQuery<R> setParameterList(String name, @SuppressWarnings("rawtypes") Collection values);
 
 	@Override
 	<P> SqmSelectionQuery<R> setParameterList(String name, Collection<? extends P> values, Class<P> javaType);
@@ -100,7 +101,7 @@ public interface SqmSelectionQuery<R> extends SqmQuery, SelectionQuery<R> {
 	<P> SqmSelectionQuery<R> setParameterList(String name, P[] values, BindableType<P> type);
 
 	@Override
-	SqmSelectionQuery<R> setParameterList(int position, Collection values);
+	SqmSelectionQuery<R> setParameterList(int position, @SuppressWarnings("rawtypes") Collection values);
 
 	@Override
 	<P> SqmSelectionQuery<R> setParameterList(int position, Collection<? extends P> values, Class<P> javaType);
@@ -139,10 +140,13 @@ public interface SqmSelectionQuery<R> extends SqmQuery, SelectionQuery<R> {
 	SqmSelectionQuery<R> setProperties(Object bean);
 
 	@Override
-	SqmSelectionQuery<R> setProperties(Map bean);
+	SqmSelectionQuery<R> setProperties(@SuppressWarnings("rawtypes") Map bean);
 
 	@Override
 	SqmSelectionQuery<R> setHibernateFlushMode(FlushMode flushMode);
+
+	@Override
+	SqmSelectionQuery<R> setForcedFlushMode(ForcedFlushMode forcedFlushMode);
 
 	@Override
 	SqmSelectionQuery<R> setCacheMode(CacheMode cacheMode);

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/internal/QuerySqmImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/internal/QuerySqmImpl.java
@@ -21,6 +21,7 @@ import java.util.stream.Stream;
 
 import org.hibernate.CacheMode;
 import org.hibernate.FlushMode;
+import org.hibernate.ForcedFlushMode;
 import org.hibernate.HibernateException;
 import org.hibernate.LockMode;
 import org.hibernate.LockOptions;
@@ -955,6 +956,12 @@ public class QuerySqmImpl<R>
 	}
 
 	@Override
+	public SqmQueryImplementor<R> setForcedFlushMode(ForcedFlushMode forcedFlushMode) {
+		super.setForcedFlushMode( forcedFlushMode );
+		return this;
+	}
+
+	@Override
 	public SqmQueryImplementor<R> setFlushMode(FlushModeType flushMode) {
 		applyJpaFlushMode( flushMode );
 		return this;
@@ -1133,7 +1140,7 @@ public class QuerySqmImpl<R>
 					isCacheable(),
 					getCacheRegion(),
 					getCacheMode(),
-					getHibernateFlushMode(),
+					getQueryOptions().getFlushMode(),
 					isReadOnly(),
 					getLockOptions(),
 					getTimeout(),
@@ -1152,7 +1159,7 @@ public class QuerySqmImpl<R>
 				isCacheable(),
 				getCacheRegion(),
 				getCacheMode(),
-				getHibernateFlushMode(),
+				getQueryOptions().getFlushMode(),
 				isReadOnly(),
 				getLockOptions(),
 				getTimeout(),

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/internal/SqmSelectionQueryImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/internal/SqmSelectionQueryImpl.java
@@ -25,6 +25,7 @@ import jakarta.persistence.Tuple;
 
 import org.hibernate.CacheMode;
 import org.hibernate.FlushMode;
+import org.hibernate.ForcedFlushMode;
 import org.hibernate.HibernateException;
 import org.hibernate.LockMode;
 import org.hibernate.ScrollMode;
@@ -569,6 +570,12 @@ public class SqmSelectionQueryImpl<R> extends AbstractSelectionQuery<R> implemen
 	@Override
 	public SqmSelectionQuery<R> setHibernateFlushMode(FlushMode flushMode) {
 		super.setHibernateFlushMode( flushMode );
+		return this;
+	}
+
+	@Override
+	public SqmSelectionQuery<R> setForcedFlushMode(ForcedFlushMode forcedFlushMode) {
+		super.setForcedFlushMode( forcedFlushMode );
 		return this;
 	}
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/query/NamedQueryForcedFlushModeTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/query/NamedQueryForcedFlushModeTest.java
@@ -9,19 +9,16 @@ package org.hibernate.orm.test.jpa.query;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
-
 import org.hibernate.FlushMode;
+import org.hibernate.ForcedFlushMode;
 import org.hibernate.Session;
-import org.hibernate.annotations.FlushModeType;
 import org.hibernate.annotations.NamedNativeQuery;
 import org.hibernate.annotations.NamedQuery;
 import org.hibernate.query.NativeQuery;
 import org.hibernate.query.Query;
-
 import org.hibernate.testing.TestForIssue;
 import org.hibernate.testing.orm.junit.EntityManagerFactoryScope;
 import org.hibernate.testing.orm.junit.Jpa;
-
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -31,9 +28,9 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  */
 @TestForIssue(jiraKey = "HHH-12795")
 @Jpa(annotatedClasses = {
-		NamedQueryFlushModeTest.TestEntity.class
+		NamedQueryForcedFlushModeTest.TestEntity.class
 })
-public class NamedQueryFlushModeTest {
+public class NamedQueryForcedFlushModeTest {
 
 	@Test
 	public void testNamedQueryWithFlushModeManual(EntityManagerFactoryScope scope) {
@@ -56,7 +53,7 @@ public class NamedQueryFlushModeTest {
 				entityManager -> {
 					Session s = entityManager.unwrap( Session.class );
 					Query<?> query = s.getNamedQuery( queryName );
-					assertEquals( FlushMode.COMMIT, query.getHibernateFlushMode() );
+					assertEquals( FlushMode.MANUAL, query.getHibernateFlushMode() );
 					assertEquals( jakarta.persistence.FlushModeType.COMMIT, query.getFlushMode() );
 				}
 		);
@@ -104,21 +101,25 @@ public class NamedQueryFlushModeTest {
 					query = s.getNamedQuery( queryName );
 					assertEquals( FlushMode.MANUAL, query.getHibernateFlushMode() );
 					assertEquals( jakarta.persistence.FlushModeType.COMMIT, query.getFlushMode() );
+					assertEquals( ForcedFlushMode.NO_FORCING, query.getForcedFlushMode() );
 
 					s.setHibernateFlushMode( FlushMode.COMMIT );
 					query = s.getNamedQuery( queryName );
 					assertEquals( FlushMode.COMMIT, query.getHibernateFlushMode() );
 					assertEquals( jakarta.persistence.FlushModeType.COMMIT, query.getFlushMode() );
+					assertEquals( ForcedFlushMode.NO_FORCING, query.getForcedFlushMode() );
 
 					s.setHibernateFlushMode( FlushMode.AUTO );
 					query = s.getNamedQuery( queryName );
 					assertEquals( FlushMode.AUTO, query.getHibernateFlushMode() );
 					assertEquals( jakarta.persistence.FlushModeType.AUTO, query.getFlushMode() );
+					assertEquals( ForcedFlushMode.NO_FORCING, query.getForcedFlushMode() );
 
 					s.setHibernateFlushMode( FlushMode.ALWAYS );
 					query = s.getNamedQuery( queryName );
 					assertEquals( FlushMode.ALWAYS, query.getHibernateFlushMode() );
 					assertEquals( jakarta.persistence.FlushModeType.AUTO, query.getFlushMode() );
+					assertEquals( ForcedFlushMode.NO_FORCING, query.getForcedFlushMode() );
 				}
 		);
 	}
@@ -131,6 +132,7 @@ public class NamedQueryFlushModeTest {
 					Session s = entityManager.unwrap( Session.class );
 					NativeQuery<?> query = s.getNamedNativeQuery( queryName );
 					assertEquals( FlushMode.MANUAL, query.getHibernateFlushMode() );
+					assertEquals( ForcedFlushMode.FORCE_NO_FLUSH, query.getForcedFlushMode() );
 				}
 		);
 	}
@@ -142,7 +144,8 @@ public class NamedQueryFlushModeTest {
 				entityManager -> {
 					Session s = entityManager.unwrap( Session.class );
 					NativeQuery<?> query = s.getNamedNativeQuery( queryName );
-					assertEquals( FlushMode.COMMIT, query.getHibernateFlushMode() );
+					assertEquals( FlushMode.MANUAL, query.getHibernateFlushMode() );
+					assertEquals( ForcedFlushMode.FORCE_NO_FLUSH, query.getForcedFlushMode() );
 				}
 		);
 	}
@@ -155,6 +158,7 @@ public class NamedQueryFlushModeTest {
 					Session s = entityManager.unwrap( Session.class );
 					NativeQuery<?> query = s.getNamedNativeQuery( queryName );
 					assertEquals( FlushMode.AUTO, query.getHibernateFlushMode() );
+					assertEquals( ForcedFlushMode.NO_FORCING, query.getForcedFlushMode() );
 				}
 		);
 	}
@@ -167,6 +171,7 @@ public class NamedQueryFlushModeTest {
 					Session s = entityManager.unwrap( Session.class );
 					NativeQuery<?> query = s.getNamedNativeQuery( queryName );
 					assertEquals( FlushMode.ALWAYS, query.getHibernateFlushMode() );
+					assertEquals( ForcedFlushMode.FORCE_FLUSH, query.getForcedFlushMode() );
 				}
 		);
 	}
@@ -209,57 +214,57 @@ public class NamedQueryFlushModeTest {
 	@NamedQuery(
 			name = "NamedQueryFlushModeManual",
 			query = "select e from TestEntity e where e.text = :text",
-			flushMode = FlushModeType.MANUAL
+			flush = ForcedFlushMode.FORCE_NO_FLUSH
 	)
 	@NamedQuery(
 			name = "NamedQueryFlushModeCommit",
 			query = "select e from TestEntity e where e.text = :text",
-			flushMode = FlushModeType.COMMIT
+			flush = ForcedFlushMode.FORCE_NO_FLUSH
 	)
 	@NamedQuery(
 			name = "NamedQueryFlushModeAuto",
 			query = "select e from TestEntity e where e.text = :text",
-			flushMode = FlushModeType.AUTO
+			flush = ForcedFlushMode.NO_FORCING
 	)
 	@NamedQuery(
 			name = "NamedQueryFlushModeAlways",
 			query = "select e from TestEntity e where e.text = :text",
-			flushMode = FlushModeType.ALWAYS
+			flush = ForcedFlushMode.FORCE_FLUSH
 	)
 	@NamedQuery(
 			name = "NamedQueryFlushModePersistenceContext",
 			query = "select e from TestEntity e where e.text = :text",
-			flushMode = FlushModeType.PERSISTENCE_CONTEXT
+			flush = ForcedFlushMode.NO_FORCING
 	)
 	@NamedNativeQuery(
 			name = "NamedNativeQueryFlushModeManual",
 			query = "select * from TestEntity e where e.text = :text",
 			resultClass = TestEntity.class,
-			flushMode = FlushModeType.MANUAL
+			flush = ForcedFlushMode.FORCE_NO_FLUSH
 	)
 	@NamedNativeQuery(
 			name = "NamedNativeQueryFlushModeCommit",
 			query = "select * from TestEntity e where e.text = :text",
 			resultClass = TestEntity.class,
-			flushMode = FlushModeType.COMMIT
+			flush = ForcedFlushMode.FORCE_NO_FLUSH
 	)
 	@NamedNativeQuery(
 			name = "NamedNativeQueryFlushModeAuto",
 			query = "select * from TestEntity e where e.text = :text",
 			resultClass = TestEntity.class,
-			flushMode = FlushModeType.AUTO
+			flush = ForcedFlushMode.NO_FORCING
 	)
 	@NamedNativeQuery(
 			name = "NamedNativeQueryFlushModeAlways",
 			query = "select * from TestEntity e where e.text = :text",
 			resultClass = TestEntity.class,
-			flushMode = FlushModeType.ALWAYS
+			flush = ForcedFlushMode.FORCE_FLUSH
 	)
 	@NamedNativeQuery(
 			name = "NamedNativeQueryFlushModePersistenceContext",
 			query = "select * from TestEntity e where e.text = :text",
 			resultClass = TestEntity.class,
-			flushMode = FlushModeType.PERSISTENCE_CONTEXT
+			flush = ForcedFlushMode.NO_FORCING
 	)
 
 	public static class TestEntity {


### PR DESCRIPTION
for specifying whether a query flushes or not:

- replaces `FlushModeType` in the annotation package
- much less confusing when applied to a `Query`
  * what do `MANUAL` and `COMMIT` mean for a `Query`?
  * how is `AUTO` useful for a` Query`?

- also make `Query.getHibernateFlushMode()` obey its documented semantics by returning the session flush mode instead of null when unset