### PR TITLE
make Dialect implement TypeContributor and FunctionContributor

### DIFF
--- a/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/CUBRIDDialect.java
+++ b/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/CUBRIDDialect.java
@@ -8,6 +8,7 @@ package org.hibernate.community.dialect;
 
 import java.sql.Types;
 
+import org.hibernate.boot.model.FunctionContributions;
 import org.hibernate.boot.model.TypeContributions;
 import org.hibernate.community.dialect.identity.CUBRIDIdentityColumnSupport;
 import org.hibernate.community.dialect.sequence.CUBRIDSequenceSupport;
@@ -24,7 +25,6 @@ import org.hibernate.dialect.sequence.SequenceSupport;
 import org.hibernate.engine.jdbc.dialect.spi.DialectResolutionInfo;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.query.SemanticException;
-import org.hibernate.query.spi.QueryEngine;
 import org.hibernate.query.sqm.IntervalType;
 import org.hibernate.query.sqm.TemporalUnit;
 import org.hibernate.service.ServiceRegistry;
@@ -203,10 +203,10 @@ public class CUBRIDDialect extends Dialect {
 	}
 
 	@Override
-	public void initializeFunctionRegistry(QueryEngine queryEngine) {
-		super.initializeFunctionRegistry( queryEngine );
+	public void initializeFunctionRegistry(FunctionContributions functionContributions) {
+		super.initializeFunctionRegistry(functionContributions);
 
-		CommonFunctionFactory functionFactory = new CommonFunctionFactory(queryEngine);
+		CommonFunctionFactory functionFactory = new CommonFunctionFactory(functionContributions);
 		functionFactory.trim2();
 		functionFactory.space();
 		functionFactory.reverse();

--- a/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/CacheDialect.java
+++ b/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/CacheDialect.java
@@ -12,6 +12,7 @@ import java.sql.SQLException;
 import java.sql.Types;
 
 import org.hibernate.LockMode;
+import org.hibernate.boot.model.FunctionContributions;
 import org.hibernate.cfg.Environment;
 import org.hibernate.community.dialect.identity.CacheIdentityColumnSupport;
 import org.hibernate.community.dialect.sequence.CacheSequenceSupport;
@@ -40,7 +41,6 @@ import org.hibernate.exception.spi.TemplatedViolatedConstraintNameExtractor;
 import org.hibernate.exception.spi.ViolatedConstraintNameExtractor;
 import org.hibernate.internal.util.JdbcExceptionHelper;
 import org.hibernate.persister.entity.Lockable;
-import org.hibernate.query.spi.QueryEngine;
 import org.hibernate.query.sqm.IntervalType;
 import org.hibernate.query.sqm.TemporalUnit;
 import org.hibernate.sql.ast.SqlAstTranslator;
@@ -110,11 +110,11 @@ public class CacheDialect extends Dialect {
 		return 15;
 	}
 
-	private static void useJdbcEscape(QueryEngine queryEngine, String name) {
+	private static void useJdbcEscape(FunctionContributions queryEngine, String name) {
 		//Yep, this seems to be truly necessary for certain functions
-		queryEngine.getSqmFunctionRegistry().wrapInJdbcEscape(
+		queryEngine.getFunctionRegistry().wrapInJdbcEscape(
 				name,
-				queryEngine.getSqmFunctionRegistry().findFunctionDescriptor(name)
+				queryEngine.getFunctionRegistry().findFunctionDescriptor(name)
 		);
 	}
 
@@ -149,10 +149,10 @@ public class CacheDialect extends Dialect {
 	}
 
 	@Override
-	public void initializeFunctionRegistry(QueryEngine queryEngine) {
-		super.initializeFunctionRegistry( queryEngine );
+	public void initializeFunctionRegistry(FunctionContributions functionContributions) {
+		super.initializeFunctionRegistry(functionContributions);
 
-		CommonFunctionFactory functionFactory = new CommonFunctionFactory(queryEngine);
+		CommonFunctionFactory functionFactory = new CommonFunctionFactory(functionContributions);
 		functionFactory.repeat();
 		functionFactory.trim2();
 		functionFactory.substr();
@@ -182,42 +182,42 @@ public class CacheDialect extends Dialect {
 		functionFactory.varPopSamp();
 		functionFactory.lastDay();
 
-		queryEngine.getSqmFunctionRegistry().registerBinaryTernaryPattern(
+		functionContributions.getFunctionRegistry().registerBinaryTernaryPattern(
 				"locate",
-				queryEngine.getTypeConfiguration().getBasicTypeRegistry().resolve( StandardBasicTypes.INTEGER ),
+				functionContributions.getTypeConfiguration().getBasicTypeRegistry().resolve( StandardBasicTypes.INTEGER ),
 				"$find(?2,?1)",
 				"$find(?2,?1,?3)",
 				STRING, STRING, INTEGER,
-				queryEngine.getTypeConfiguration()
+				functionContributions.getTypeConfiguration()
 		).setArgumentListSignature("(pattern, string[, start])");
 		functionFactory.bitLength_pattern( "($length(?1)*8)" );
 
-		useJdbcEscape(queryEngine, "sin");
-		useJdbcEscape(queryEngine, "cos");
-		useJdbcEscape(queryEngine, "tan");
-		useJdbcEscape(queryEngine, "asin");
-		useJdbcEscape(queryEngine, "acos");
-		useJdbcEscape(queryEngine, "atan");
-		useJdbcEscape(queryEngine, "atan2");
-		useJdbcEscape(queryEngine, "exp");
-		useJdbcEscape(queryEngine, "log");
-		useJdbcEscape(queryEngine, "log10");
-		useJdbcEscape(queryEngine, "pi");
-		useJdbcEscape(queryEngine, "truncate");
+		useJdbcEscape(functionContributions, "sin");
+		useJdbcEscape(functionContributions, "cos");
+		useJdbcEscape(functionContributions, "tan");
+		useJdbcEscape(functionContributions, "asin");
+		useJdbcEscape(functionContributions, "acos");
+		useJdbcEscape(functionContributions, "atan");
+		useJdbcEscape(functionContributions, "atan2");
+		useJdbcEscape(functionContributions, "exp");
+		useJdbcEscape(functionContributions, "log");
+		useJdbcEscape(functionContributions, "log10");
+		useJdbcEscape(functionContributions, "pi");
+		useJdbcEscape(functionContributions, "truncate");
 
-		useJdbcEscape(queryEngine, "left");
-		useJdbcEscape(queryEngine, "right");
+		useJdbcEscape(functionContributions, "left");
+		useJdbcEscape(functionContributions, "right");
 
-		useJdbcEscape(queryEngine, "hour");
-		useJdbcEscape(queryEngine, "minute");
-		useJdbcEscape(queryEngine, "second");
-		useJdbcEscape(queryEngine, "week");
-		useJdbcEscape(queryEngine, "quarter");
-		useJdbcEscape(queryEngine, "dayname");
-		useJdbcEscape(queryEngine, "monthname");
-		useJdbcEscape(queryEngine, "dayofweek");
-		useJdbcEscape(queryEngine, "dayofmonth");
-		useJdbcEscape(queryEngine, "dayofyear");
+		useJdbcEscape(functionContributions, "hour");
+		useJdbcEscape(functionContributions, "minute");
+		useJdbcEscape(functionContributions, "second");
+		useJdbcEscape(functionContributions, "week");
+		useJdbcEscape(functionContributions, "quarter");
+		useJdbcEscape(functionContributions, "dayname");
+		useJdbcEscape(functionContributions, "monthname");
+		useJdbcEscape(functionContributions, "dayofweek");
+		useJdbcEscape(functionContributions, "dayofmonth");
+		useJdbcEscape(functionContributions, "dayofyear");
 
 	}
 

--- a/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/CockroachLegacyDialect.java
+++ b/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/CockroachLegacyDialect.java
@@ -25,6 +25,7 @@ import org.hibernate.LockMode;
 import org.hibernate.LockOptions;
 import org.hibernate.PessimisticLockException;
 import org.hibernate.QueryTimeoutException;
+import org.hibernate.boot.model.FunctionContributions;
 import org.hibernate.boot.model.TypeContributions;
 import org.hibernate.dialect.DatabaseVersion;
 import org.hibernate.dialect.Dialect;
@@ -59,7 +60,6 @@ import org.hibernate.exception.spi.TemplatedViolatedConstraintNameExtractor;
 import org.hibernate.exception.spi.ViolatedConstraintNameExtractor;
 import org.hibernate.internal.CoreMessageLogger;
 import org.hibernate.internal.util.JdbcExceptionHelper;
-import org.hibernate.query.spi.QueryEngine;
 import org.hibernate.query.sqm.IntervalType;
 import org.hibernate.query.sqm.NullOrdering;
 import org.hibernate.query.sqm.TemporalUnit;
@@ -359,10 +359,10 @@ public class CockroachLegacyDialect extends Dialect {
 	}
 
 	@Override
-	public void initializeFunctionRegistry(QueryEngine queryEngine) {
-		super.initializeFunctionRegistry(queryEngine);
+	public void initializeFunctionRegistry(FunctionContributions functionContributions) {
+		super.initializeFunctionRegistry(functionContributions);
 
-		final CommonFunctionFactory functionFactory = new CommonFunctionFactory( queryEngine );
+		final CommonFunctionFactory functionFactory = new CommonFunctionFactory(functionContributions);
 		functionFactory.ascii();
 		functionFactory.char_chr();
 		functionFactory.overlay();
@@ -399,9 +399,9 @@ public class CockroachLegacyDialect extends Dialect {
 		functionFactory.corr();
 		functionFactory.regrLinearRegressionAggregates();
 
-		queryEngine.getSqmFunctionRegistry().register(
+		functionContributions.getFunctionRegistry().register(
 				"format",
-				new FormatFunction( "experimental_strftime", queryEngine.getTypeConfiguration() )
+				new FormatFunction( "experimental_strftime", functionContributions.getTypeConfiguration() )
 		);
 		functionFactory.windowFunctions();
 		functionFactory.listagg_stringAgg( "string" );

--- a/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/DB2LegacyDialect.java
+++ b/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/DB2LegacyDialect.java
@@ -14,6 +14,7 @@ import java.sql.Types;
 import java.util.List;
 
 import org.hibernate.LockOptions;
+import org.hibernate.boot.model.FunctionContributions;
 import org.hibernate.boot.model.TypeContributions;
 import org.hibernate.dialect.DB2Dialect;
 import org.hibernate.dialect.DB2StructJdbcType;
@@ -36,7 +37,6 @@ import org.hibernate.dialect.pagination.LimitHandler;
 import org.hibernate.dialect.sequence.DB2SequenceSupport;
 import org.hibernate.dialect.sequence.LegacyDB2SequenceSupport;
 import org.hibernate.dialect.sequence.SequenceSupport;
-import org.hibernate.dialect.unique.AlterTableUniqueDelegate;
 import org.hibernate.dialect.unique.AlterTableUniqueIndexDelegate;
 import org.hibernate.dialect.unique.SkipNullableUniqueDelegate;
 import org.hibernate.dialect.unique.UniqueDelegate;
@@ -52,7 +52,6 @@ import org.hibernate.metamodel.mapping.EntityMappingType;
 import org.hibernate.metamodel.spi.RuntimeModelCreationContext;
 import org.hibernate.procedure.internal.DB2CallableStatementSupport;
 import org.hibernate.procedure.spi.CallableStatementSupport;
-import org.hibernate.query.spi.QueryEngine;
 import org.hibernate.query.sqm.IntervalType;
 import org.hibernate.query.sqm.TemporalUnit;
 import org.hibernate.query.sqm.mutation.internal.cte.CteInsertStrategy;
@@ -248,10 +247,10 @@ public class DB2LegacyDialect extends Dialect {
 	}
 
 	@Override
-	public void initializeFunctionRegistry(QueryEngine queryEngine) {
-		super.initializeFunctionRegistry( queryEngine );
+	public void initializeFunctionRegistry(FunctionContributions functionContributions) {
+		super.initializeFunctionRegistry(functionContributions);
 
-		CommonFunctionFactory functionFactory = new CommonFunctionFactory(queryEngine);
+		CommonFunctionFactory functionFactory = new CommonFunctionFactory(functionContributions);
 		// AVG by default uses the input type, so we possibly need to cast the argument type, hence a special function
 		functionFactory.avg_castingNonDoubleArguments( this, SqlAstNodeRenderingMode.DEFAULT );
 
@@ -267,17 +266,17 @@ public class DB2LegacyDialect extends Dialect {
 		functionFactory.trim2();
 		functionFactory.space();
 		functionFactory.repeat();
-		queryEngine.getSqmFunctionRegistry().namedDescriptorBuilder( "substr" )
+		functionContributions.getFunctionRegistry().namedDescriptorBuilder( "substr" )
 				.setInvariantType(
-						queryEngine.getTypeConfiguration().getBasicTypeRegistry().resolve( StandardBasicTypes.STRING )
+						functionContributions.getTypeConfiguration().getBasicTypeRegistry().resolve( StandardBasicTypes.STRING )
 				)
 				.setArgumentCountBetween( 2, 3 )
 				.setParameterTypes(FunctionParameterType.STRING, FunctionParameterType.INTEGER, FunctionParameterType.INTEGER)
 				.setArgumentListSignature( "(STRING string, INTEGER start[, INTEGER length])" )
 				.register();
-		queryEngine.getSqmFunctionRegistry().register(
+		functionContributions.getFunctionRegistry().register(
 				"substring",
-				new DB2SubstringFunction( queryEngine.getTypeConfiguration() )
+				new DB2SubstringFunction( functionContributions.getTypeConfiguration() )
 		);
 		functionFactory.translate();
 		functionFactory.bitand();
@@ -315,17 +314,17 @@ public class DB2LegacyDialect extends Dialect {
 		}
 		else {
 			// Before version 11, the position function required the use of the code units
-			queryEngine.getSqmFunctionRegistry().register(
+			functionContributions.getFunctionRegistry().register(
 					"position",
-					new DB2PositionFunction( queryEngine.getTypeConfiguration() )
+					new DB2PositionFunction( functionContributions.getTypeConfiguration() )
 			);
 			// Before version 11, the overlay function required the use of the code units
 			functionFactory.overlayLength_overlay( true );
 			// ordered set aggregate functions are only available as of version 11, and we can't reasonably emulate them
 			// so no percent_rank, cume_dist, median, mode, percentile_cont or percentile_disc
-			queryEngine.getSqmFunctionRegistry().registerAlternateKey( "stddev_pop", "stddev" );
+			functionContributions.getFunctionRegistry().registerAlternateKey( "stddev_pop", "stddev" );
 			functionFactory.stddevSamp_sumCount();
-			queryEngine.getSqmFunctionRegistry().registerAlternateKey( "var_pop", "variance" );
+			functionContributions.getFunctionRegistry().registerAlternateKey( "var_pop", "variance" );
 			functionFactory.varSamp_sumCount();
 		}
 
@@ -335,27 +334,27 @@ public class DB2LegacyDialect extends Dialect {
 		functionFactory.bitLength_pattern( "length(?1)*8" );
 
 		// DB2 wants parameter operands to be casted to allow lengths bigger than 255
-		queryEngine.getSqmFunctionRegistry().register(
+		functionContributions.getFunctionRegistry().register(
 				"concat",
 				new CastingConcatFunction(
 						this,
 						"||",
 						true,
 						SqlAstNodeRenderingMode.NO_PLAIN_PARAMETER,
-						queryEngine.getTypeConfiguration()
+						functionContributions.getTypeConfiguration()
 				)
 		);
 		// For the count distinct emulation distinct
-		queryEngine.getSqmFunctionRegistry().register(
+		functionContributions.getFunctionRegistry().register(
 				"count",
 				new CountFunction(
 						this,
-						queryEngine.getTypeConfiguration(),
+						functionContributions.getTypeConfiguration(),
 						SqlAstNodeRenderingMode.DEFAULT,
 						"||",
-						queryEngine.getTypeConfiguration().getDdlTypeRegistry().getDescriptor( VARCHAR )
+						functionContributions.getTypeConfiguration().getDdlTypeRegistry().getDescriptor( VARCHAR )
 								.getCastTypeName(
-										queryEngine.getTypeConfiguration()
+										functionContributions.getTypeConfiguration()
 												.getBasicTypeRegistry()
 												.resolve( StandardBasicTypes.STRING ),
 										null,
@@ -366,22 +365,22 @@ public class DB2LegacyDialect extends Dialect {
 				)
 		);
 
-		queryEngine.getSqmFunctionRegistry().register(
+		functionContributions.getFunctionRegistry().register(
 				"format",
-				new DB2FormatEmulation( queryEngine.getTypeConfiguration() )
+				new DB2FormatEmulation( functionContributions.getTypeConfiguration() )
 		);
 
-		queryEngine.getSqmFunctionRegistry().patternDescriptorBuilder( "atan2", "atan2(?2,?1)" )
+		functionContributions.getFunctionRegistry().patternDescriptorBuilder( "atan2", "atan2(?2,?1)" )
 				.setInvariantType(
-						queryEngine.getTypeConfiguration().getBasicTypeRegistry().resolve( StandardBasicTypes.DOUBLE )
+						functionContributions.getTypeConfiguration().getBasicTypeRegistry().resolve( StandardBasicTypes.DOUBLE )
 				)
 				.setExactArgumentCount( 2 )
 				.setParameterTypes( FunctionParameterType.NUMERIC, FunctionParameterType.NUMERIC )
 				.register();
 
-		queryEngine.getSqmFunctionRegistry().namedDescriptorBuilder( "posstr" )
+		functionContributions.getFunctionRegistry().namedDescriptorBuilder( "posstr" )
 				.setInvariantType(
-						queryEngine.getTypeConfiguration().getBasicTypeRegistry().resolve( StandardBasicTypes.INTEGER )
+						functionContributions.getTypeConfiguration().getBasicTypeRegistry().resolve( StandardBasicTypes.INTEGER )
 				)
 				.setExactArgumentCount( 2 )
 				.setParameterTypes(FunctionParameterType.STRING, FunctionParameterType.STRING)

--- a/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/DB2iLegacyDialect.java
+++ b/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/DB2iLegacyDialect.java
@@ -6,6 +6,7 @@
  */
 package org.hibernate.community.dialect;
 
+import org.hibernate.boot.model.FunctionContributions;
 import org.hibernate.dialect.DatabaseVersion;
 import org.hibernate.dialect.function.CommonFunctionFactory;
 import org.hibernate.dialect.identity.DB2390IdentityColumnSupport;
@@ -23,7 +24,6 @@ import org.hibernate.dialect.unique.UniqueDelegate;
 import org.hibernate.engine.jdbc.dialect.spi.DialectResolutionInfo;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.mapping.Column;
-import org.hibernate.query.spi.QueryEngine;
 import org.hibernate.sql.ast.SqlAstTranslator;
 import org.hibernate.sql.ast.SqlAstTranslatorFactory;
 import org.hibernate.sql.ast.spi.StandardSqlAstTranslatorFactory;
@@ -56,10 +56,10 @@ public class DB2iLegacyDialect extends DB2LegacyDialect {
 	}
 
 	@Override
-	public void initializeFunctionRegistry(QueryEngine queryEngine) {
-		super.initializeFunctionRegistry( queryEngine );
+	public void initializeFunctionRegistry(FunctionContributions functionContributions) {
+		super.initializeFunctionRegistry(functionContributions);
 		if ( getVersion().isSameOrAfter( 7, 2 ) ) {
-			CommonFunctionFactory functionFactory = new CommonFunctionFactory(queryEngine);
+			CommonFunctionFactory functionFactory = new CommonFunctionFactory(functionContributions);
 			functionFactory.listagg( null );
 			functionFactory.inverseDistributionOrderedSetAggregates();
 			functionFactory.hypotheticalOrderedSetAggregates_windowEmulation();

--- a/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/DB2zLegacyDialect.java
+++ b/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/DB2zLegacyDialect.java
@@ -7,6 +7,7 @@
 package org.hibernate.community.dialect;
 
 
+import org.hibernate.boot.model.FunctionContributions;
 import org.hibernate.dialect.DatabaseVersion;
 import org.hibernate.dialect.TimeZoneSupport;
 import org.hibernate.dialect.function.CommonFunctionFactory;
@@ -24,7 +25,6 @@ import org.hibernate.dialect.unique.UniqueDelegate;
 import org.hibernate.engine.jdbc.dialect.spi.DialectResolutionInfo;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.mapping.Column;
-import org.hibernate.query.spi.QueryEngine;
 import org.hibernate.query.sqm.IntervalType;
 import org.hibernate.query.sqm.TemporalUnit;
 import org.hibernate.sql.ast.SqlAstTranslator;
@@ -62,10 +62,10 @@ public class DB2zLegacyDialect extends DB2LegacyDialect {
 	}
 
 	@Override
-	public void initializeFunctionRegistry(QueryEngine queryEngine) {
-		super.initializeFunctionRegistry( queryEngine );
+	public void initializeFunctionRegistry(FunctionContributions functionContributions) {
+		super.initializeFunctionRegistry(functionContributions);
 		if ( getVersion().isSameOrAfter( 12 ) ) {
-			CommonFunctionFactory functionFactory = new CommonFunctionFactory(queryEngine);
+			CommonFunctionFactory functionFactory = new CommonFunctionFactory(functionContributions);
 			functionFactory.listagg( null );
 			functionFactory.inverseDistributionOrderedSetAggregates();
 			functionFactory.hypotheticalOrderedSetAggregates_windowEmulation();

--- a/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/DerbyLegacyDialect.java
+++ b/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/DerbyLegacyDialect.java
@@ -10,6 +10,7 @@ import java.sql.DatabaseMetaData;
 import java.sql.SQLException;
 import java.sql.Types;
 
+import org.hibernate.boot.model.FunctionContributions;
 import org.hibernate.boot.model.TypeContributions;
 import org.hibernate.dialect.DB2Dialect;
 import org.hibernate.dialect.DatabaseVersion;
@@ -42,7 +43,6 @@ import org.hibernate.exception.spi.SQLExceptionConversionDelegate;
 import org.hibernate.internal.util.JdbcExceptionHelper;
 import org.hibernate.metamodel.mapping.EntityMappingType;
 import org.hibernate.metamodel.spi.RuntimeModelCreationContext;
-import org.hibernate.query.spi.QueryEngine;
 import org.hibernate.query.sqm.CastType;
 import org.hibernate.query.sqm.IntervalType;
 import org.hibernate.query.sqm.TemporalUnit;
@@ -260,24 +260,24 @@ public class DerbyLegacyDialect extends Dialect {
 	}
 
 	@Override
-	public void initializeFunctionRegistry(QueryEngine queryEngine) {
-		super.initializeFunctionRegistry( queryEngine );
+	public void initializeFunctionRegistry(FunctionContributions functionContributions) {
+		super.initializeFunctionRegistry(functionContributions);
 
-		final BasicTypeRegistry basicTypeRegistry = queryEngine.getTypeConfiguration().getBasicTypeRegistry();
+		final BasicTypeRegistry basicTypeRegistry = functionContributions.getTypeConfiguration().getBasicTypeRegistry();
 		final BasicType<String> stringType = basicTypeRegistry.resolve( StandardBasicTypes.STRING );
 
-		CommonFunctionFactory functionFactory = new CommonFunctionFactory(queryEngine);
+		CommonFunctionFactory functionFactory = new CommonFunctionFactory(functionContributions);
 
 		// Derby needs an actual argument type for aggregates like SUM, AVG, MIN, MAX to determine the result type
 		functionFactory.aggregates( this, SqlAstNodeRenderingMode.NO_PLAIN_PARAMETER );
-		queryEngine.getSqmFunctionRegistry().register(
+		functionContributions.getFunctionRegistry().register(
 				"count",
 				new CountFunction(
 						this,
-						queryEngine.getTypeConfiguration(),
+						functionContributions.getTypeConfiguration(),
 						SqlAstNodeRenderingMode.NO_PLAIN_PARAMETER,
 						"||",
-						queryEngine.getTypeConfiguration().getDdlTypeRegistry().getDescriptor( VARCHAR )
+						functionContributions.getTypeConfiguration().getDdlTypeRegistry().getDescriptor( VARCHAR )
 								.getCastTypeName( stringType, null, null, null ),
 						true
 				)
@@ -290,9 +290,9 @@ public class DerbyLegacyDialect extends Dialect {
 		// sort of to_char() function.
 
 		// We register an emulation instead, that can at least translate integer literals
-		queryEngine.getSqmFunctionRegistry().register(
+		functionContributions.getFunctionRegistry().register(
 				"chr",
-				new ChrLiteralEmulation( queryEngine.getTypeConfiguration() )
+				new ChrLiteralEmulation( functionContributions.getTypeConfiguration() )
 		);
 
 		functionFactory.concat_pipeOperator();
@@ -319,23 +319,23 @@ public class DerbyLegacyDialect extends Dialect {
 		functionFactory.octetLength_pattern( "length(?1)" );
 		functionFactory.bitLength_pattern( "length(?1)*8" );
 
-		queryEngine.getSqmFunctionRegistry().register(
+		functionContributions.getFunctionRegistry().register(
 				"concat",
 				new CastingConcatFunction(
 						this,
 						"||",
 						true,
 						SqlAstNodeRenderingMode.NO_PLAIN_PARAMETER,
-						queryEngine.getTypeConfiguration()
+						functionContributions.getTypeConfiguration()
 				)
 		);
 
 		//no way I can see to pad with anything other than spaces
-		queryEngine.getSqmFunctionRegistry().register( "lpad", new DerbyLpadEmulation( queryEngine.getTypeConfiguration() ) );
-		queryEngine.getSqmFunctionRegistry().register( "rpad", new DerbyRpadEmulation( queryEngine.getTypeConfiguration() ) );
-		queryEngine.getSqmFunctionRegistry().register( "least", new CaseLeastGreatestEmulation( true ) );
-		queryEngine.getSqmFunctionRegistry().register( "greatest", new CaseLeastGreatestEmulation( false ) );
-		queryEngine.getSqmFunctionRegistry().register( "overlay", new InsertSubstringOverlayEmulation( queryEngine.getTypeConfiguration(), true ) );
+		functionContributions.getFunctionRegistry().register( "lpad", new DerbyLpadEmulation( functionContributions.getTypeConfiguration() ) );
+		functionContributions.getFunctionRegistry().register( "rpad", new DerbyRpadEmulation( functionContributions.getTypeConfiguration() ) );
+		functionContributions.getFunctionRegistry().register( "least", new CaseLeastGreatestEmulation( true ) );
+		functionContributions.getFunctionRegistry().register( "greatest", new CaseLeastGreatestEmulation( false ) );
+		functionContributions.getFunctionRegistry().register( "overlay", new InsertSubstringOverlayEmulation( functionContributions.getTypeConfiguration(), true ) );
 	}
 
 	@Override

--- a/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/FirebirdDialect.java
+++ b/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/FirebirdDialect.java
@@ -24,6 +24,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import org.hibernate.boot.Metadata;
+import org.hibernate.boot.model.FunctionContributions;
 import org.hibernate.boot.model.TypeContributions;
 import org.hibernate.boot.model.relational.SqlStringGenerationContext;
 import org.hibernate.community.dialect.identity.FirebirdIdentityColumnSupport;
@@ -57,7 +58,6 @@ import org.hibernate.mapping.Column;
 import org.hibernate.mapping.Index;
 import org.hibernate.metamodel.mapping.EntityMappingType;
 import org.hibernate.metamodel.spi.RuntimeModelCreationContext;
-import org.hibernate.query.spi.QueryEngine;
 import org.hibernate.query.sqm.CastType;
 import org.hibernate.query.sqm.FetchClauseType;
 import org.hibernate.query.sqm.IntervalType;
@@ -250,17 +250,17 @@ public class FirebirdDialect extends Dialect {
 	}
 
 	@Override
-	public void initializeFunctionRegistry(QueryEngine queryEngine) {
-		super.initializeFunctionRegistry( queryEngine );
+	public void initializeFunctionRegistry(FunctionContributions functionContributions) {
+		super.initializeFunctionRegistry(functionContributions);
 
-		final BasicTypeRegistry basicTypeRegistry = queryEngine.getTypeConfiguration().getBasicTypeRegistry();
+		final BasicTypeRegistry basicTypeRegistry = functionContributions.getTypeConfiguration().getBasicTypeRegistry();
 		final BasicType<byte[]> byteArrayType = basicTypeRegistry.resolve( StandardBasicTypes.BINARY );
 		final BasicType<Integer> integerType = basicTypeRegistry.resolve( StandardBasicTypes.INTEGER );
 		final BasicType<Short> shortType = basicTypeRegistry.resolve( StandardBasicTypes.SHORT );
 		final BasicType<Double> doubleType = basicTypeRegistry.resolve( StandardBasicTypes.DOUBLE );
 		final BasicType<Character> characterType = basicTypeRegistry.resolve( StandardBasicTypes.CHARACTER );
 
-		CommonFunctionFactory functionFactory = new CommonFunctionFactory(queryEngine);
+		CommonFunctionFactory functionFactory = new CommonFunctionFactory(functionContributions);
 
 		// Firebird needs an actual argument type for aggregates like SUM, AVG, MIN, MAX to determine the result type
 		functionFactory.aggregates( this, SqlAstNodeRenderingMode.NO_PLAIN_PARAMETER );
@@ -297,14 +297,14 @@ public class FirebirdDialect extends Dialect {
 		functionFactory.bitandorxornot_binAndOrXorNot();
 		functionFactory.leastGreatest_minMaxValue();
 
-		SqmFunctionRegistry functionRegistry = queryEngine.getSqmFunctionRegistry();
+		SqmFunctionRegistry functionRegistry = functionContributions.getFunctionRegistry();
 		functionRegistry.registerBinaryTernaryPattern(
 				"locate",
 				integerType,
 				"position(?1 in ?2)",
 				"position(?1,?2,?3)",
 				STRING, STRING, INTEGER,
-				queryEngine.getTypeConfiguration()
+				functionContributions.getTypeConfiguration()
 		).setArgumentListSignature( "(pattern, string[, start])" );
 		functionRegistry.namedDescriptorBuilder( "ascii_val" )
 				.setExactArgumentCount( 1 )

--- a/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/H2LegacyDialect.java
+++ b/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/H2LegacyDialect.java
@@ -17,6 +17,7 @@ import java.util.List;
 import java.util.TimeZone;
 
 import org.hibernate.PessimisticLockException;
+import org.hibernate.boot.model.FunctionContributions;
 import org.hibernate.boot.model.TypeContributions;
 import org.hibernate.dialect.DatabaseVersion;
 import org.hibernate.dialect.Dialect;
@@ -53,7 +54,6 @@ import org.hibernate.internal.CoreMessageLogger;
 import org.hibernate.internal.util.JdbcExceptionHelper;
 import org.hibernate.metamodel.mapping.EntityMappingType;
 import org.hibernate.metamodel.spi.RuntimeModelCreationContext;
-import org.hibernate.query.spi.QueryEngine;
 import org.hibernate.query.sqm.FetchClauseType;
 import org.hibernate.query.sqm.IntervalType;
 import org.hibernate.query.sqm.NullOrdering;
@@ -75,7 +75,6 @@ import org.hibernate.tool.schema.extract.internal.SequenceInformationExtractorH2
 import org.hibernate.tool.schema.extract.internal.SequenceInformationExtractorLegacyImpl;
 import org.hibernate.tool.schema.extract.internal.SequenceInformationExtractorNoOpImpl;
 import org.hibernate.tool.schema.extract.spi.SequenceInformationExtractor;
-import org.hibernate.type.descriptor.DateTimeUtils;
 import org.hibernate.type.descriptor.jdbc.InstantJdbcType;
 import org.hibernate.type.descriptor.jdbc.JdbcType;
 import org.hibernate.type.descriptor.jdbc.UUIDJdbcType;
@@ -279,10 +278,10 @@ public class H2LegacyDialect extends Dialect {
 	}
 
 	@Override
-	public void initializeFunctionRegistry(QueryEngine queryEngine) {
-		super.initializeFunctionRegistry( queryEngine );
+	public void initializeFunctionRegistry(FunctionContributions functionContributions) {
+		super.initializeFunctionRegistry(functionContributions);
 
-		CommonFunctionFactory functionFactory = new CommonFunctionFactory(queryEngine);
+		CommonFunctionFactory functionFactory = new CommonFunctionFactory(functionContributions);
 
 		// H2 needs an actual argument type for aggregates like SUM, AVG, MIN, MAX to determine the result type
 		functionFactory.aggregates( this, SqlAstNodeRenderingMode.NO_PLAIN_PARAMETER );

--- a/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/HSQLLegacyDialect.java
+++ b/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/HSQLLegacyDialect.java
@@ -13,6 +13,7 @@ import java.sql.Types;
 import org.hibernate.JDBCException;
 import org.hibernate.LockMode;
 import org.hibernate.StaleObjectStateException;
+import org.hibernate.boot.model.FunctionContributions;
 import org.hibernate.dialect.BooleanDecoder;
 import org.hibernate.dialect.DatabaseVersion;
 import org.hibernate.dialect.Dialect;
@@ -43,7 +44,6 @@ import org.hibernate.engine.jdbc.env.spi.IdentifierHelper;
 import org.hibernate.engine.jdbc.env.spi.IdentifierHelperBuilder;
 import org.hibernate.engine.jdbc.env.spi.NameQualifierSupport;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
-import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.event.spi.EventSource;
 import org.hibernate.exception.spi.TemplatedViolatedConstraintNameExtractor;
 import org.hibernate.exception.spi.ViolatedConstraintNameExtractor;
@@ -53,7 +53,6 @@ import org.hibernate.internal.util.ReflectHelper;
 import org.hibernate.metamodel.mapping.EntityMappingType;
 import org.hibernate.metamodel.spi.RuntimeModelCreationContext;
 import org.hibernate.persister.entity.Lockable;
-import org.hibernate.query.spi.QueryEngine;
 import org.hibernate.query.sqm.CastType;
 import org.hibernate.query.sqm.IntervalType;
 import org.hibernate.query.sqm.NullOrdering;
@@ -187,10 +186,10 @@ public class HSQLLegacyDialect extends Dialect {
 	}
 
 	@Override
-	public void initializeFunctionRegistry(QueryEngine queryEngine) {
-		super.initializeFunctionRegistry( queryEngine );
+	public void initializeFunctionRegistry(FunctionContributions functionContributions) {
+		super.initializeFunctionRegistry(functionContributions);
 
-		CommonFunctionFactory functionFactory = new CommonFunctionFactory( queryEngine);
+		CommonFunctionFactory functionFactory = new CommonFunctionFactory(functionContributions);
 
 		// AVG by default uses the input type, so we possibly need to cast the argument type, hence a special function
 		functionFactory.avg_castingNonDoubleArguments( this, SqlAstNodeRenderingMode.DEFAULT );

--- a/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/InformixDialect.java
+++ b/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/InformixDialect.java
@@ -6,6 +6,7 @@
  */
 package org.hibernate.community.dialect;
 
+import org.hibernate.boot.model.FunctionContributions;
 import org.hibernate.boot.model.TypeContributions;
 import org.hibernate.community.dialect.identity.InformixIdentityColumnSupport;
 import org.hibernate.community.dialect.pagination.FirstLimitHandler;
@@ -32,7 +33,6 @@ import org.hibernate.exception.spi.ViolatedConstraintNameExtractor;
 import org.hibernate.internal.util.JdbcExceptionHelper;
 import org.hibernate.metamodel.mapping.EntityMappingType;
 import org.hibernate.metamodel.spi.RuntimeModelCreationContext;
-import org.hibernate.query.spi.QueryEngine;
 import org.hibernate.query.spi.QueryOptions;
 import org.hibernate.query.spi.QueryParameterBindings;
 import org.hibernate.query.sqm.TemporalUnit;
@@ -198,10 +198,10 @@ public class InformixDialect extends Dialect {
 	}
 
 	@Override
-	public void initializeFunctionRegistry(QueryEngine queryEngine) {
-		super.initializeFunctionRegistry( queryEngine );
+	public void initializeFunctionRegistry(FunctionContributions functionContributions) {
+		super.initializeFunctionRegistry(functionContributions);
 
-		CommonFunctionFactory functionFactory = new CommonFunctionFactory(queryEngine);
+		CommonFunctionFactory functionFactory = new CommonFunctionFactory(functionContributions);
 		functionFactory.instr();
 		functionFactory.substr();
 		functionFactory.substring_substr();
@@ -232,8 +232,8 @@ public class InformixDialect extends Dialect {
 
 		//coalesce() and nullif() both supported since Informix 12
 
-		queryEngine.getSqmFunctionRegistry().register( "least", new CaseLeastGreatestEmulation( true ) );
-		queryEngine.getSqmFunctionRegistry().register( "greatest", new CaseLeastGreatestEmulation( false ) );
+		functionContributions.getFunctionRegistry().register( "least", new CaseLeastGreatestEmulation( true ) );
+		functionContributions.getFunctionRegistry().register( "greatest", new CaseLeastGreatestEmulation( false ) );
 		if ( supportsWindowFunctions() ) {
 			functionFactory.windowFunctions();
 		}

--- a/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/IngresDialect.java
+++ b/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/IngresDialect.java
@@ -8,6 +8,7 @@ package org.hibernate.community.dialect;
 
 import java.sql.Types;
 
+import org.hibernate.boot.model.FunctionContributions;
 import org.hibernate.community.dialect.identity.Ingres10IdentityColumnSupport;
 import org.hibernate.community.dialect.identity.Ingres9IdentityColumnSupport;
 import org.hibernate.community.dialect.pagination.FirstLimitHandler;
@@ -29,7 +30,6 @@ import org.hibernate.engine.spi.LoadQueryInfluencers;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.metamodel.mapping.EntityMappingType;
 import org.hibernate.metamodel.spi.RuntimeModelCreationContext;
-import org.hibernate.query.spi.QueryEngine;
 import org.hibernate.query.spi.QueryOptions;
 import org.hibernate.query.spi.QueryParameterBindings;
 import org.hibernate.query.sqm.FetchClauseType;
@@ -235,16 +235,16 @@ public class IngresDialect extends Dialect {
 	}
 
 	@Override
-	public void initializeFunctionRegistry(QueryEngine queryEngine) {
-		super.initializeFunctionRegistry( queryEngine );
+	public void initializeFunctionRegistry(FunctionContributions functionContributions) {
+		super.initializeFunctionRegistry(functionContributions);
 
-		final BasicTypeRegistry basicTypeRegistry = queryEngine.getTypeConfiguration().getBasicTypeRegistry();
+		final BasicTypeRegistry basicTypeRegistry = functionContributions.getTypeConfiguration().getBasicTypeRegistry();
 		final BasicType<String> stringType = basicTypeRegistry.resolve( StandardBasicTypes.STRING );
 
 		// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 		// Common functions
 
-		CommonFunctionFactory functionFactory = new CommonFunctionFactory(queryEngine);
+		CommonFunctionFactory functionFactory = new CommonFunctionFactory(functionContributions);
 		functionFactory.log();
 		functionFactory.rand();
 		functionFactory.soundex();
@@ -272,22 +272,22 @@ public class IngresDialect extends Dialect {
 		functionFactory.dateTrunc();
 		functionFactory.bitLength_pattern( "octet_length(hex(?1))*4" );
 
-		final BasicType<Integer> integerType = queryEngine.getTypeConfiguration().getBasicTypeRegistry()
+		final BasicType<Integer> integerType = functionContributions.getTypeConfiguration().getBasicTypeRegistry()
 				.resolve( StandardBasicTypes.INTEGER );
-		queryEngine.getSqmFunctionRegistry().registerBinaryTernaryPattern(
+		functionContributions.getFunctionRegistry().registerBinaryTernaryPattern(
 				"locate",
 				integerType,
 				"position(?1 in ?2)",
 				"(position(?1 in substring(?2 from ?3))+(?3)-1)",
 				STRING, STRING, INTEGER,
-				queryEngine.getTypeConfiguration()
+				functionContributions.getTypeConfiguration()
 		).setArgumentListSignature("(pattern, string[, start])");
 
-		queryEngine.getSqmFunctionRegistry().registerPattern( "extract", "date_part('?1',?2)", integerType );
+		functionContributions.getFunctionRegistry().registerPattern( "extract", "date_part('?1',?2)", integerType );
 
 		functionFactory.bitandorxornot_bitAndOrXorNot();
 
-		queryEngine.getSqmFunctionRegistry().namedDescriptorBuilder( "squeeze" )
+		functionContributions.getFunctionRegistry().namedDescriptorBuilder( "squeeze" )
 				.setExactArgumentCount( 1 )
 				.setInvariantType( stringType )
 				.register();

--- a/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/MariaDBLegacyDialect.java
+++ b/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/MariaDBLegacyDialect.java
@@ -9,6 +9,7 @@ package org.hibernate.community.dialect;
 import java.sql.DatabaseMetaData;
 import java.sql.SQLException;
 
+import org.hibernate.boot.model.FunctionContributions;
 import org.hibernate.boot.model.TypeContributions;
 import org.hibernate.dialect.DatabaseVersion;
 import org.hibernate.dialect.Dialect;
@@ -25,11 +26,9 @@ import org.hibernate.engine.jdbc.env.spi.IdentifierCaseStrategy;
 import org.hibernate.engine.jdbc.env.spi.IdentifierHelper;
 import org.hibernate.engine.jdbc.env.spi.IdentifierHelperBuilder;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
-import org.hibernate.query.spi.QueryEngine;
 import org.hibernate.service.ServiceRegistry;
 import org.hibernate.sql.ast.SqlAstTranslator;
 import org.hibernate.sql.ast.SqlAstTranslatorFactory;
-import org.hibernate.sql.ast.spi.SqlAppender;
 import org.hibernate.sql.ast.spi.StandardSqlAstTranslatorFactory;
 import org.hibernate.sql.ast.tree.Statement;
 import org.hibernate.sql.exec.spi.JdbcOperation;
@@ -83,23 +82,23 @@ public class MariaDBLegacyDialect extends MySQLLegacyDialect {
 	}
 
 	@Override
-	public void initializeFunctionRegistry(QueryEngine queryEngine) {
-		super.initializeFunctionRegistry(queryEngine);
+	public void initializeFunctionRegistry(FunctionContributions functionContributions) {
+		super.initializeFunctionRegistry(functionContributions);
 
 		if ( getVersion().isSameOrAfter( 10, 2 ) ) {
-			CommonFunctionFactory commonFunctionFactory = new CommonFunctionFactory( queryEngine );
+			CommonFunctionFactory commonFunctionFactory = new CommonFunctionFactory(functionContributions);
 			commonFunctionFactory.windowFunctions();
 			commonFunctionFactory.hypotheticalOrderedSetAggregates_windowEmulation();
-			queryEngine.getSqmFunctionRegistry().registerNamed(
+			functionContributions.getFunctionRegistry().registerNamed(
 					"json_valid",
-					queryEngine.getTypeConfiguration()
+					functionContributions.getTypeConfiguration()
 							.getBasicTypeRegistry()
 							.resolve( StandardBasicTypes.BOOLEAN )
 			);
 			if ( getVersion().isSameOrAfter( 10, 3, 3 ) ) {
 				commonFunctionFactory.inverseDistributionOrderedSetAggregates_windowEmulation();
-				queryEngine.getSqmFunctionRegistry().patternDescriptorBuilder( "median", "median(?1) over ()" )
-						.setInvariantType( queryEngine.getTypeConfiguration().getBasicTypeRegistry().resolve( StandardBasicTypes.DOUBLE ) )
+				functionContributions.getFunctionRegistry().patternDescriptorBuilder( "median", "median(?1) over ()" )
+						.setInvariantType( functionContributions.getTypeConfiguration().getBasicTypeRegistry().resolve( StandardBasicTypes.DOUBLE ) )
 						.setExactArgumentCount( 1 )
 						.setParameterTypes(NUMERIC)
 						.register();

--- a/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/MaxDBDialect.java
+++ b/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/MaxDBDialect.java
@@ -9,6 +9,7 @@ package org.hibernate.community.dialect;
 import java.sql.DatabaseMetaData;
 import java.sql.Types;
 
+import org.hibernate.boot.model.FunctionContributions;
 import org.hibernate.community.dialect.sequence.MaxDBSequenceSupport;
 import org.hibernate.community.dialect.sequence.SequenceInformationExtractorSAPDBDatabaseImpl;
 import org.hibernate.dialect.AbstractTransactSQLDialect;
@@ -23,7 +24,6 @@ import org.hibernate.engine.jdbc.dialect.spi.DialectResolutionInfo;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.metamodel.mapping.EntityMappingType;
 import org.hibernate.metamodel.spi.RuntimeModelCreationContext;
-import org.hibernate.query.spi.QueryEngine;
 import org.hibernate.query.sqm.TrimSpec;
 import org.hibernate.query.sqm.mutation.internal.temptable.AfterUseAction;
 import org.hibernate.query.sqm.mutation.internal.temptable.BeforeUseAction;
@@ -134,10 +134,10 @@ public class MaxDBDialect extends Dialect {
 	}
 
 	@Override
-	public void initializeFunctionRegistry(QueryEngine queryEngine) {
-		super.initializeFunctionRegistry( queryEngine );
+	public void initializeFunctionRegistry(FunctionContributions functionContributions) {
+		super.initializeFunctionRegistry(functionContributions);
 
-		CommonFunctionFactory functionFactory = new CommonFunctionFactory(queryEngine);
+		CommonFunctionFactory functionFactory = new CommonFunctionFactory(functionContributions);
 		functionFactory.log();
 		functionFactory.pi();
 		functionFactory.cot();
@@ -169,24 +169,24 @@ public class MaxDBDialect extends Dialect {
 		functionFactory.adddateSubdateAddtimeSubtime();
 		functionFactory.addMonths();
 
-		final BasicType<Integer> integerType = queryEngine.getTypeConfiguration().getBasicTypeRegistry()
+		final BasicType<Integer> integerType = functionContributions.getTypeConfiguration().getBasicTypeRegistry()
 				.resolve( StandardBasicTypes.INTEGER );
-		queryEngine.getSqmFunctionRegistry().registerPattern( "extract", "?1(?2)", integerType );
+		functionContributions.getFunctionRegistry().registerPattern( "extract", "?1(?2)", integerType );
 
-		queryEngine.getSqmFunctionRegistry().patternDescriptorBuilder( "nullif", "case ?1 when ?2 then null else ?1 end" )
+		functionContributions.getFunctionRegistry().patternDescriptorBuilder( "nullif", "case ?1 when ?2 then null else ?1 end" )
 				.setExactArgumentCount(2)
 				.register();
 
-		queryEngine.getSqmFunctionRegistry().namedDescriptorBuilder( "index" )
+		functionContributions.getFunctionRegistry().namedDescriptorBuilder( "index" )
 				.setInvariantType( integerType )
 				.setArgumentCountBetween( 2, 4 )
 				.register();
 
-		queryEngine.getSqmFunctionRegistry().registerBinaryTernaryPattern(
+		functionContributions.getFunctionRegistry().registerBinaryTernaryPattern(
 				"locate",
 				integerType, "index(?2,?1)", "index(?2,?1,?3)",
 				STRING, STRING, INTEGER,
-				queryEngine.getTypeConfiguration()
+				functionContributions.getTypeConfiguration()
 		).setArgumentListSignature("(pattern, string[, start])");
 	}
 

--- a/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/MimerSQLDialect.java
+++ b/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/MimerSQLDialect.java
@@ -6,6 +6,7 @@
  */
 package org.hibernate.community.dialect;
 
+import org.hibernate.boot.model.FunctionContributions;
 import org.hibernate.boot.model.TypeContributions;
 import org.hibernate.community.dialect.identity.MimerSQLIdentityColumnSupport;
 import org.hibernate.community.dialect.sequence.MimerSequenceSupport;
@@ -20,7 +21,6 @@ import org.hibernate.dialect.sequence.SequenceSupport;
 import org.hibernate.engine.jdbc.dialect.spi.DialectResolutionInfo;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.query.SemanticException;
-import org.hibernate.query.spi.QueryEngine;
 import org.hibernate.query.sqm.IntervalType;
 import org.hibernate.query.sqm.TemporalUnit;
 import org.hibernate.service.ServiceRegistry;
@@ -151,10 +151,10 @@ public class MimerSQLDialect extends Dialect {
 	}
 
 	@Override
-	public void initializeFunctionRegistry(QueryEngine queryEngine) {
-		super.initializeFunctionRegistry( queryEngine );
+	public void initializeFunctionRegistry(FunctionContributions functionContributions) {
+		super.initializeFunctionRegistry(functionContributions);
 
-		CommonFunctionFactory functionFactory = new CommonFunctionFactory(queryEngine);
+		CommonFunctionFactory functionFactory = new CommonFunctionFactory(functionContributions);
 		functionFactory.soundex();
 		functionFactory.octetLength();
 		functionFactory.bitLength();

--- a/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/MySQLLegacyDialect.java
+++ b/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/MySQLLegacyDialect.java
@@ -14,6 +14,7 @@ import java.sql.Types;
 
 import org.hibernate.LockOptions;
 import org.hibernate.PessimisticLockException;
+import org.hibernate.boot.model.FunctionContributions;
 import org.hibernate.boot.model.TypeContributions;
 import org.hibernate.cfg.Environment;
 import org.hibernate.dialect.DatabaseVersion;
@@ -50,7 +51,6 @@ import org.hibernate.exception.spi.ViolatedConstraintNameExtractor;
 import org.hibernate.internal.util.JdbcExceptionHelper;
 import org.hibernate.metamodel.mapping.EntityMappingType;
 import org.hibernate.metamodel.spi.RuntimeModelCreationContext;
-import org.hibernate.query.spi.QueryEngine;
 import org.hibernate.query.sqm.CastType;
 import org.hibernate.query.sqm.IntervalType;
 import org.hibernate.query.sqm.NullOrdering;
@@ -517,10 +517,10 @@ public class MySQLLegacyDialect extends Dialect {
 //	}
 
 	@Override
-	public void initializeFunctionRegistry(QueryEngine queryEngine) {
-		super.initializeFunctionRegistry( queryEngine );
+	public void initializeFunctionRegistry(FunctionContributions functionContributions) {
+		super.initializeFunctionRegistry(functionContributions);
 
-		CommonFunctionFactory functionFactory = new CommonFunctionFactory(queryEngine);
+		CommonFunctionFactory functionFactory = new CommonFunctionFactory(functionContributions);
 
 		functionFactory.soundex();
 		functionFactory.radians();
@@ -544,7 +544,7 @@ public class MySQLLegacyDialect extends Dialect {
 		functionFactory.lastDay();
 		functionFactory.date();
 		functionFactory.timestamp();
-		time( queryEngine );
+		time(functionContributions);
 
 		functionFactory.utcDateTimeTimestamp();
 		functionFactory.rand();
@@ -574,9 +574,9 @@ public class MySQLLegacyDialect extends Dialect {
 		functionFactory.makedateMaketime();
 		functionFactory.localtimeLocaltimestamp();
 
-		BasicTypeRegistry basicTypeRegistry = queryEngine.getTypeConfiguration().getBasicTypeRegistry();
+		BasicTypeRegistry basicTypeRegistry = functionContributions.getTypeConfiguration().getBasicTypeRegistry();
 
-		SqmFunctionRegistry functionRegistry = queryEngine.getSqmFunctionRegistry();
+		SqmFunctionRegistry functionRegistry = functionContributions.getFunctionRegistry();
 		functionRegistry.noArgsBuilder( "localtime" )
 				.setInvariantType(basicTypeRegistry.resolve( StandardBasicTypes.TIMESTAMP ))
 				.setUseParenthesesWhenNoArgs( false )
@@ -681,8 +681,8 @@ public class MySQLLegacyDialect extends Dialect {
 		return super.castPattern( from, to );
 	}
 
-	private void time(QueryEngine queryEngine) {
-		queryEngine.getSqmFunctionRegistry().namedDescriptorBuilder( "time" )
+	private void time(FunctionContributions queryEngine) {
+		queryEngine.getFunctionRegistry().namedDescriptorBuilder( "time" )
 				.setExactArgumentCount( 1 )
 				.setInvariantType(
 						queryEngine.getTypeConfiguration().getBasicTypeRegistry().resolve( StandardBasicTypes.STRING )

--- a/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/OracleLegacyDialect.java
+++ b/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/OracleLegacyDialect.java
@@ -17,6 +17,7 @@ import java.util.regex.Pattern;
 
 import org.hibernate.LockOptions;
 import org.hibernate.QueryTimeoutException;
+import org.hibernate.boot.model.FunctionContributions;
 import org.hibernate.boot.model.TypeContributions;
 import org.hibernate.cfg.Environment;
 import org.hibernate.dialect.BooleanDecoder;
@@ -67,7 +68,6 @@ import org.hibernate.metamodel.spi.RuntimeModelCreationContext;
 import org.hibernate.procedure.internal.StandardCallableStatementSupport;
 import org.hibernate.procedure.spi.CallableStatementSupport;
 import org.hibernate.query.SemanticException;
-import org.hibernate.query.spi.QueryEngine;
 import org.hibernate.query.spi.QueryOptions;
 import org.hibernate.query.sqm.CastType;
 import org.hibernate.query.sqm.FetchClauseType;
@@ -175,11 +175,11 @@ public class OracleLegacyDialect extends Dialect {
 	}
 
 	@Override
-	public void initializeFunctionRegistry(QueryEngine queryEngine) {
-		super.initializeFunctionRegistry( queryEngine );
-		final TypeConfiguration typeConfiguration = queryEngine.getTypeConfiguration();
+	public void initializeFunctionRegistry(FunctionContributions functionContributions) {
+		super.initializeFunctionRegistry(functionContributions);
+		final TypeConfiguration typeConfiguration = functionContributions.getTypeConfiguration();
 
-		CommonFunctionFactory functionFactory = new CommonFunctionFactory(queryEngine);
+		CommonFunctionFactory functionFactory = new CommonFunctionFactory(functionContributions);
 		functionFactory.ascii();
 		functionFactory.char_chr();
 		functionFactory.cosh();
@@ -225,14 +225,14 @@ public class OracleLegacyDialect extends Dialect {
 		functionFactory.bitLength_pattern( "lengthb(?1)*8", "dbms_lob.getlength(?1)*16" );
 
 		if ( getVersion().isBefore( 9 ) ) {
-			queryEngine.getSqmFunctionRegistry().register( "coalesce", new NvlCoalesceEmulation() );
+			functionContributions.getFunctionRegistry().register( "coalesce", new NvlCoalesceEmulation() );
 		}
 		else {
 			//Oracle has had coalesce() since 9.0.1
 			functionFactory.coalesce();
 		}
 
-		queryEngine.getSqmFunctionRegistry().registerBinaryTernaryPattern(
+		functionContributions.getFunctionRegistry().registerBinaryTernaryPattern(
 				"locate",
 				typeConfiguration.getBasicTypeRegistry().resolve( StandardBasicTypes.INTEGER ),
 				"instr(?2,?1)",
@@ -251,7 +251,7 @@ public class OracleLegacyDialect extends Dialect {
 		functionFactory.hypotheticalOrderedSetAggregates();
 		functionFactory.inverseDistributionOrderedSetAggregates();
 		// Oracle has a regular aggregate function named stats_mode
-		queryEngine.getSqmFunctionRegistry().register(
+		functionContributions.getFunctionRegistry().register(
 				"mode",
 				new ModeStatsModeEmulation( typeConfiguration )
 		);

--- a/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/PostgreSQLLegacyDialect.java
+++ b/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/PostgreSQLLegacyDialect.java
@@ -23,6 +23,7 @@ import org.hibernate.LockMode;
 import org.hibernate.LockOptions;
 import org.hibernate.PessimisticLockException;
 import org.hibernate.QueryTimeoutException;
+import org.hibernate.boot.model.FunctionContributions;
 import org.hibernate.boot.model.TypeContributions;
 import org.hibernate.community.dialect.sequence.PostgreSQLLegacySequenceSupport;
 import org.hibernate.dialect.DatabaseVersion;
@@ -68,7 +69,6 @@ import org.hibernate.metamodel.spi.RuntimeModelCreationContext;
 import org.hibernate.procedure.internal.PostgreSQLCallableStatementSupport;
 import org.hibernate.procedure.spi.CallableStatementSupport;
 import org.hibernate.query.SemanticException;
-import org.hibernate.query.spi.QueryEngine;
 import org.hibernate.query.sqm.FetchClauseType;
 import org.hibernate.query.sqm.IntervalType;
 import org.hibernate.query.sqm.TemporalUnit;
@@ -533,10 +533,10 @@ public class PostgreSQLLegacyDialect extends Dialect {
 	}
 
 	@Override
-	public void initializeFunctionRegistry(QueryEngine queryEngine) {
-		super.initializeFunctionRegistry( queryEngine );
+	public void initializeFunctionRegistry(FunctionContributions functionContributions) {
+		super.initializeFunctionRegistry(functionContributions);
 
-		CommonFunctionFactory functionFactory = new CommonFunctionFactory(queryEngine);
+		CommonFunctionFactory functionFactory = new CommonFunctionFactory(functionContributions);
 
 		functionFactory.round_roundFloor(); //Postgres round(x,n) does not accept double
 		functionFactory.trunc_truncFloor();
@@ -553,7 +553,7 @@ public class PostgreSQLLegacyDialect extends Dialect {
 			functionFactory.moreHyperbolic();
 		}
 		else {
-			queryEngine.getSqmFunctionRegistry().registerAlternateKey( "log10", "log" );
+			functionContributions.getFunctionRegistry().registerAlternateKey( "log10", "log" );
 		}
 		functionFactory.cbrt();
 		functionFactory.pi();
@@ -602,8 +602,8 @@ public class PostgreSQLLegacyDialect extends Dialect {
 		}
 
 		if ( !supportsMinMaxOnUuid() ) {
-			queryEngine.getSqmFunctionRegistry().register( "min", new PostgreSQLMinMaxFunction( "min" ) );
-			queryEngine.getSqmFunctionRegistry().register( "max", new PostgreSQLMinMaxFunction( "max" ) );
+			functionContributions.getFunctionRegistry().register( "min", new PostgreSQLMinMaxFunction( "min" ) );
+			functionContributions.getFunctionRegistry().register( "max", new PostgreSQLMinMaxFunction( "max" ) );
 		}
 	}
 

--- a/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/PostgresPlusLegacyDialect.java
+++ b/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/PostgresPlusLegacyDialect.java
@@ -11,10 +11,10 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Types;
 
+import org.hibernate.boot.model.FunctionContributions;
 import org.hibernate.dialect.DatabaseVersion;
 import org.hibernate.dialect.function.CommonFunctionFactory;
 import org.hibernate.engine.jdbc.dialect.spi.DialectResolutionInfo;
-import org.hibernate.query.spi.QueryEngine;
 import org.hibernate.query.sqm.CastType;
 import org.hibernate.query.sqm.TemporalUnit;
 
@@ -45,10 +45,10 @@ public class PostgresPlusLegacyDialect extends PostgreSQLLegacyDialect {
 	}
 
 	@Override
-	public void initializeFunctionRegistry(QueryEngine queryEngine) {
-		super.initializeFunctionRegistry( queryEngine );
+	public void initializeFunctionRegistry(FunctionContributions functionContributions) {
+		super.initializeFunctionRegistry(functionContributions);
 
-		CommonFunctionFactory functionFactory = new CommonFunctionFactory(queryEngine);
+		CommonFunctionFactory functionFactory = new CommonFunctionFactory(functionContributions);
 		functionFactory.soundex();
 		functionFactory.rownumRowid();
 		functionFactory.sysdate();

--- a/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/RDMSOS2200Dialect.java
+++ b/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/RDMSOS2200Dialect.java
@@ -9,6 +9,7 @@ package org.hibernate.community.dialect;
 import java.sql.Types;
 
 import org.hibernate.LockMode;
+import org.hibernate.boot.model.FunctionContributions;
 import org.hibernate.community.dialect.sequence.RDMSSequenceSupport;
 import org.hibernate.dialect.AbstractTransactSQLDialect;
 import org.hibernate.dialect.DatabaseVersion;
@@ -31,7 +32,6 @@ import org.hibernate.engine.jdbc.dialect.spi.DialectResolutionInfo;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.internal.CoreMessageLogger;
 import org.hibernate.persister.entity.Lockable;
-import org.hibernate.query.spi.QueryEngine;
 import org.hibernate.query.sqm.IntervalType;
 import org.hibernate.query.sqm.TemporalUnit;
 import org.hibernate.query.sqm.TrimSpec;
@@ -205,10 +205,10 @@ public class RDMSOS2200Dialect extends Dialect {
 	}
 
 	@Override
-	public void initializeFunctionRegistry(QueryEngine queryEngine) {
-		super.initializeFunctionRegistry( queryEngine );
+	public void initializeFunctionRegistry(FunctionContributions functionContributions) {
+		super.initializeFunctionRegistry(functionContributions);
 
-		CommonFunctionFactory functionFactory = new CommonFunctionFactory(queryEngine);
+		CommonFunctionFactory functionFactory = new CommonFunctionFactory(functionContributions);
 		functionFactory.cosh();
 		functionFactory.sinh();
 		functionFactory.tanh();

--- a/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/SQLServerLegacyDialect.java
+++ b/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/SQLServerLegacyDialect.java
@@ -8,6 +8,7 @@ package org.hibernate.community.dialect;
 
 import org.hibernate.*;
 import org.hibernate.boot.Metadata;
+import org.hibernate.boot.model.FunctionContributions;
 import org.hibernate.boot.model.TypeContributions;
 import org.hibernate.boot.model.relational.QualifiedSequenceName;
 import org.hibernate.boot.model.relational.Sequence;
@@ -47,7 +48,6 @@ import org.hibernate.query.sqm.CastType;
 import org.hibernate.query.sqm.FetchClauseType;
 import org.hibernate.query.sqm.IntervalType;
 import org.hibernate.query.sqm.TemporalUnit;
-import org.hibernate.query.spi.QueryEngine;
 import org.hibernate.query.sqm.TrimSpec;
 import org.hibernate.service.ServiceRegistry;
 import org.hibernate.sql.ast.SqlAstNodeRenderingMode;
@@ -274,22 +274,22 @@ public class SQLServerLegacyDialect extends AbstractTransactSQLDialect {
 	}
 
 	@Override
-	public void initializeFunctionRegistry(QueryEngine queryEngine) {
-		super.initializeFunctionRegistry(queryEngine);
+	public void initializeFunctionRegistry(FunctionContributions functionContributions) {
+		super.initializeFunctionRegistry(functionContributions);
 
-		final BasicTypeRegistry basicTypeRegistry = queryEngine.getTypeConfiguration().getBasicTypeRegistry();
+		final BasicTypeRegistry basicTypeRegistry = functionContributions.getTypeConfiguration().getBasicTypeRegistry();
 		BasicType<Date> dateType = basicTypeRegistry.resolve( StandardBasicTypes.DATE );
 		BasicType<Date> timeType = basicTypeRegistry.resolve( StandardBasicTypes.TIME );
 		BasicType<Date> timestampType = basicTypeRegistry.resolve( StandardBasicTypes.TIMESTAMP );
 
-		CommonFunctionFactory functionFactory = new CommonFunctionFactory(queryEngine);
+		CommonFunctionFactory functionFactory = new CommonFunctionFactory(functionContributions);
 
 		// For SQL-Server we need to cast certain arguments to varchar(max) to be able to concat them
-		queryEngine.getSqmFunctionRegistry().register(
+		functionContributions.getFunctionRegistry().register(
 				"count",
 				new CountFunction(
 						this,
-						queryEngine.getTypeConfiguration(),
+						functionContributions.getTypeConfiguration(),
 						SqlAstNodeRenderingMode.DEFAULT,
 						"count_big",
 						"+",
@@ -316,9 +316,9 @@ public class SQLServerLegacyDialect extends AbstractTransactSQLDialect {
 		}
 
 		if ( getVersion().isSameOrAfter( 11 ) ) {
-			queryEngine.getSqmFunctionRegistry().register(
+			functionContributions.getFunctionRegistry().register(
 					"format",
-					new SQLServerFormatEmulation( queryEngine.getTypeConfiguration() )
+					new SQLServerFormatEmulation( functionContributions.getTypeConfiguration() )
 			);
 
 			//actually translate() was added in 2017 but
@@ -327,32 +327,32 @@ public class SQLServerLegacyDialect extends AbstractTransactSQLDialect {
 
 			functionFactory.median_percentileCont( true );
 
-			queryEngine.getSqmFunctionRegistry().namedDescriptorBuilder( "datefromparts" )
+			functionContributions.getFunctionRegistry().namedDescriptorBuilder( "datefromparts" )
 					.setInvariantType( dateType )
 					.setExactArgumentCount( 3 )
 					.setParameterTypes(INTEGER)
 					.register();
-			queryEngine.getSqmFunctionRegistry().namedDescriptorBuilder( "timefromparts" )
+			functionContributions.getFunctionRegistry().namedDescriptorBuilder( "timefromparts" )
 					.setInvariantType( timeType )
 					.setExactArgumentCount( 5 )
 					.setParameterTypes(INTEGER)
 					.register();
-			queryEngine.getSqmFunctionRegistry().namedDescriptorBuilder( "smalldatetimefromparts" )
+			functionContributions.getFunctionRegistry().namedDescriptorBuilder( "smalldatetimefromparts" )
 					.setInvariantType( timestampType )
 					.setExactArgumentCount( 5 )
 					.setParameterTypes(INTEGER)
 					.register();
-			queryEngine.getSqmFunctionRegistry().namedDescriptorBuilder( "datetimefromparts" )
+			functionContributions.getFunctionRegistry().namedDescriptorBuilder( "datetimefromparts" )
 					.setInvariantType( timestampType )
 					.setExactArgumentCount( 7 )
 					.setParameterTypes(INTEGER)
 					.register();
-			queryEngine.getSqmFunctionRegistry().namedDescriptorBuilder( "datetime2fromparts" )
+			functionContributions.getFunctionRegistry().namedDescriptorBuilder( "datetime2fromparts" )
 					.setInvariantType( timestampType )
 					.setExactArgumentCount( 8 )
 					.setParameterTypes(INTEGER)
 					.register();
-			queryEngine.getSqmFunctionRegistry().namedDescriptorBuilder( "datetimeoffsetfromparts" )
+			functionContributions.getFunctionRegistry().namedDescriptorBuilder( "datetimeoffsetfromparts" )
 					.setInvariantType( timestampType )
 					.setExactArgumentCount( 10 )
 					.setParameterTypes(INTEGER)

--- a/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/SybaseAnywhereDialect.java
+++ b/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/SybaseAnywhereDialect.java
@@ -10,6 +10,7 @@ package org.hibernate.community.dialect;
 import java.util.Map;
 
 import org.hibernate.LockOptions;
+import org.hibernate.boot.model.FunctionContributions;
 import org.hibernate.community.dialect.identity.SybaseAnywhereIdentityColumnSupport;
 import org.hibernate.dialect.DatabaseVersion;
 import org.hibernate.dialect.RowLockStrategy;
@@ -21,7 +22,6 @@ import org.hibernate.dialect.pagination.LimitHandler;
 import org.hibernate.dialect.pagination.TopLimitHandler;
 import org.hibernate.engine.jdbc.dialect.spi.DialectResolutionInfo;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
-import org.hibernate.query.spi.QueryEngine;
 import org.hibernate.sql.ForUpdateFragment;
 import org.hibernate.sql.ast.SqlAstTranslator;
 import org.hibernate.sql.ast.SqlAstTranslatorFactory;
@@ -90,9 +90,9 @@ public class SybaseAnywhereDialect extends SybaseDialect {
 	}
 
 	@Override
-	public void initializeFunctionRegistry(QueryEngine queryEngine) {
-		super.initializeFunctionRegistry( queryEngine );
-		final CommonFunctionFactory functionFactory = new CommonFunctionFactory( queryEngine );
+	public void initializeFunctionRegistry(FunctionContributions functionContributions) {
+		super.initializeFunctionRegistry(functionContributions);
+		final CommonFunctionFactory functionFactory = new CommonFunctionFactory(functionContributions);
 		functionFactory.listagg_list( "varchar" );
 		if ( getVersion().isSameOrAfter( 12 ) ) {
 			functionFactory.windowFunctions();

--- a/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/SybaseLegacyDialect.java
+++ b/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/SybaseLegacyDialect.java
@@ -10,6 +10,7 @@ import java.sql.DatabaseMetaData;
 import java.sql.SQLException;
 import java.sql.Types;
 
+import org.hibernate.boot.model.FunctionContributions;
 import org.hibernate.boot.model.TypeContributions;
 import org.hibernate.dialect.AbstractTransactSQLDialect;
 import org.hibernate.dialect.DatabaseVersion;
@@ -28,7 +29,6 @@ import org.hibernate.engine.spi.LoadQueryInfluencers;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.procedure.internal.JTDSCallableStatementSupport;
 import org.hibernate.procedure.spi.CallableStatementSupport;
-import org.hibernate.query.spi.QueryEngine;
 import org.hibernate.query.spi.QueryOptions;
 import org.hibernate.query.spi.QueryParameterBindings;
 import org.hibernate.query.sqm.CastType;
@@ -205,10 +205,10 @@ public class SybaseLegacyDialect extends AbstractTransactSQLDialect {
 	}
 
 	@Override
-	public void initializeFunctionRegistry(QueryEngine queryEngine) {
-		super.initializeFunctionRegistry(queryEngine);
+	public void initializeFunctionRegistry(FunctionContributions functionContributions) {
+		super.initializeFunctionRegistry(functionContributions);
 
-		CommonFunctionFactory functionFactory = new CommonFunctionFactory(queryEngine);
+		CommonFunctionFactory functionFactory = new CommonFunctionFactory(functionContributions);
 
 		functionFactory.stddev();
 		functionFactory.variance();
@@ -220,11 +220,11 @@ public class SybaseLegacyDialect extends AbstractTransactSQLDialect {
 		functionFactory.round_round();
 
 		// For SQL-Server we need to cast certain arguments to varchar(16384) to be able to concat them
-		queryEngine.getSqmFunctionRegistry().register(
+		functionContributions.getFunctionRegistry().register(
 				"count",
 				new CountFunction(
 						this,
-						queryEngine.getTypeConfiguration(),
+						functionContributions.getTypeConfiguration(),
 						SqlAstNodeRenderingMode.DEFAULT,
 						"count_big",
 						"+",
@@ -246,8 +246,8 @@ public class SybaseLegacyDialect extends AbstractTransactSQLDialect {
 		functionFactory.octetLength_pattern( "datalength(?1)" );
 		functionFactory.bitLength_pattern( "datalength(?1)*8" );
 
-		queryEngine.getSqmFunctionRegistry().register( "timestampadd",
-				new IntegralTimestampaddFunction( this, queryEngine.getTypeConfiguration() ) );
+		functionContributions.getFunctionRegistry().register( "timestampadd",
+				new IntegralTimestampaddFunction( this, functionContributions.getTypeConfiguration() ) );
 	}
 
 	@Override

--- a/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/TeradataDialect.java
+++ b/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/TeradataDialect.java
@@ -14,6 +14,7 @@ import java.util.Map;
 
 import org.hibernate.LockOptions;
 import org.hibernate.boot.Metadata;
+import org.hibernate.boot.model.FunctionContributions;
 import org.hibernate.boot.model.naming.Identifier;
 import org.hibernate.boot.model.relational.QualifiedNameImpl;
 import org.hibernate.boot.model.relational.QualifiedTableName;
@@ -35,7 +36,6 @@ import org.hibernate.mapping.Column;
 import org.hibernate.mapping.Index;
 import org.hibernate.metamodel.mapping.EntityMappingType;
 import org.hibernate.metamodel.spi.RuntimeModelCreationContext;
-import org.hibernate.query.spi.QueryEngine;
 import org.hibernate.query.spi.QueryOptions;
 import org.hibernate.query.sqm.IntervalType;
 import org.hibernate.query.sqm.TemporalUnit;
@@ -251,12 +251,12 @@ public class TeradataDialect extends Dialect {
 	}
 
 	@Override
-	public void initializeFunctionRegistry(QueryEngine queryEngine) {
-		super.initializeFunctionRegistry( queryEngine );
-		final BasicTypeRegistry basicTypeRegistry = queryEngine.getTypeConfiguration().getBasicTypeRegistry();
+	public void initializeFunctionRegistry(FunctionContributions functionContributions) {
+		super.initializeFunctionRegistry(functionContributions);
+		final BasicTypeRegistry basicTypeRegistry = functionContributions.getTypeConfiguration().getBasicTypeRegistry();
 		final BasicType<String> stringType = basicTypeRegistry.resolve( StandardBasicTypes.STRING );
 
-		CommonFunctionFactory functionFactory = new CommonFunctionFactory(queryEngine);
+		CommonFunctionFactory functionFactory = new CommonFunctionFactory(functionContributions);
 		functionFactory.concat_pipeOperator();
 		functionFactory.octetLength();
 		functionFactory.moreHyperbolic();
@@ -267,7 +267,7 @@ public class TeradataDialect extends Dialect {
 		functionFactory.position();
 		functionFactory.bitLength_pattern( "octet_length(cast(?1 as char))*4" );
 
-		queryEngine.getSqmFunctionRegistry().patternDescriptorBuilder( "mod", "(?1 mod ?2)" )
+		functionContributions.getFunctionRegistry().patternDescriptorBuilder( "mod", "(?1 mod ?2)" )
 				.setInvariantType( stringType )
 				.setExactArgumentCount( 2 )
 				.register();

--- a/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/TimesTenDialect.java
+++ b/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/TimesTenDialect.java
@@ -10,6 +10,7 @@ import java.sql.Types;
 
 import org.hibernate.LockMode;
 import org.hibernate.LockOptions;
+import org.hibernate.boot.model.FunctionContributions;
 import org.hibernate.community.dialect.pagination.TimesTenLimitHandler;
 import org.hibernate.community.dialect.sequence.SequenceInformationExtractorTimesTenDatabaseImpl;
 import org.hibernate.community.dialect.sequence.TimesTenSequenceSupport;
@@ -33,7 +34,6 @@ import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.metamodel.mapping.EntityMappingType;
 import org.hibernate.metamodel.spi.RuntimeModelCreationContext;
 import org.hibernate.persister.entity.Lockable;
-import org.hibernate.query.spi.QueryEngine;
 import org.hibernate.query.sqm.IntervalType;
 import org.hibernate.query.sqm.TemporalUnit;
 import org.hibernate.query.sqm.mutation.internal.temptable.GlobalTemporaryTableInsertStrategy;
@@ -154,10 +154,10 @@ public class TimesTenDialect extends Dialect {
 	}
 
 	@Override
-	public void initializeFunctionRegistry(QueryEngine queryEngine) {
-		super.initializeFunctionRegistry( queryEngine );
+	public void initializeFunctionRegistry(FunctionContributions functionContributions) {
+		super.initializeFunctionRegistry(functionContributions);
 
-		CommonFunctionFactory functionFactory = new CommonFunctionFactory(queryEngine);
+		CommonFunctionFactory functionFactory = new CommonFunctionFactory(functionContributions);
 		functionFactory.trim2();
 		functionFactory.soundex();
 		functionFactory.trunc();
@@ -173,13 +173,13 @@ public class TimesTenDialect extends Dialect {
 		functionFactory.addMonths();
 		functionFactory.monthsBetween();
 
-		queryEngine.getSqmFunctionRegistry().registerBinaryTernaryPattern(
+		functionContributions.getFunctionRegistry().registerBinaryTernaryPattern(
 				"locate",
-				queryEngine.getTypeConfiguration().getBasicTypeRegistry().resolve( StandardBasicTypes.INTEGER ),
+				functionContributions.getTypeConfiguration().getBasicTypeRegistry().resolve( StandardBasicTypes.INTEGER ),
 				"instr(?2,?1)",
 				"instr(?2,?1,?3)",
 				STRING, STRING, INTEGER,
-				queryEngine.getTypeConfiguration()
+				functionContributions.getTypeConfiguration()
 		).setArgumentListSignature("(pattern, string[, start])");
 	}
 

--- a/hibernate-community-dialects/src/test/java/org/hibernate/community/dialect/InformixDialectTestCase.java
+++ b/hibernate-community-dialects/src/test/java/org/hibernate/community/dialect/InformixDialectTestCase.java
@@ -1,0 +1,125 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.community.dialect;
+
+import java.util.Collections;
+
+import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
+import org.hibernate.engine.query.internal.NativeQueryInterpreterStandardImpl;
+import org.hibernate.metamodel.model.domain.internal.JpaMetamodelImpl;
+import org.hibernate.metamodel.model.domain.internal.MappingMetamodelImpl;
+import org.hibernate.query.criteria.ValueHandlingMode;
+import org.hibernate.query.internal.NamedObjectRepositoryImpl;
+import org.hibernate.query.spi.QueryEngine;
+import org.hibernate.query.sqm.function.SelfRenderingSqmFunction;
+import org.hibernate.query.sqm.function.SqmFunctionDescriptor;
+import org.hibernate.service.ServiceRegistry;
+import org.hibernate.sql.ast.spi.SqlAppender;
+import org.hibernate.sql.ast.spi.StringBuilderSqlAppender;
+import org.hibernate.type.BasicType;
+import org.hibernate.type.descriptor.java.JdbcDateJavaType;
+import org.hibernate.type.descriptor.java.JdbcTimestampJavaType;
+import org.hibernate.type.descriptor.jdbc.DateJdbcType;
+import org.hibernate.type.descriptor.jdbc.TimestampJdbcType;
+import org.hibernate.type.spi.TypeConfiguration;
+
+import org.hibernate.testing.TestForIssue;
+import org.hibernate.testing.junit4.BaseUnitTestCase;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Testing of patched support for Informix boolean type; see HHH-9894, HHH-10800
+ *
+ * @author Greg Jones
+ */
+public class InformixDialectTestCase extends BaseUnitTestCase {
+
+	private static final InformixDialect dialect = new InformixDialect();
+	private static ServiceRegistry ssr;
+	private static QueryEngine queryEngine;
+
+	@BeforeClass
+	public static void init() {
+		TypeConfiguration typeConfiguration = new TypeConfiguration();
+		final JpaMetamodelImpl jpaMetamodel = new JpaMetamodelImpl( typeConfiguration, new MappingMetamodelImpl( typeConfiguration, ssr ), ssr );
+
+		ssr = new StandardServiceRegistryBuilder().build();
+		queryEngine = new QueryEngine(
+				null,
+				null,
+				jpaMetamodel,
+				ValueHandlingMode.BIND,
+				dialect.getPreferredSqlTypeCodeForBoolean(),
+				false,
+				new NamedObjectRepositoryImpl( Collections.emptyMap(), Collections.emptyMap(), Collections.emptyMap(), Collections.emptyMap() ),
+				NativeQueryInterpreterStandardImpl.NATIVE_QUERY_INTERPRETER,
+				dialect,
+				ssr
+		);
+	}
+
+	@AfterClass
+	public static void tearDown() {
+		queryEngine.close();
+		ssr.close();
+	}
+
+	@Test
+	@TestForIssue(jiraKey = "HHH-9894")
+	public void testToBooleanValueStringTrue() {
+		assertEquals( "'t'", dialect.toBooleanValueString( true ) );
+	}
+
+	@Test
+	@TestForIssue(jiraKey = "HHH-9894")
+	public void testToBooleanValueStringFalse() {
+		assertEquals( "'f'", dialect.toBooleanValueString( false ) );
+	}
+
+	@Test
+	@TestForIssue(jiraKey = "HHH-10800")
+	public void testCurrentTimestampFunction() {
+		SqmFunctionDescriptor functionDescriptor = queryEngine.getSqmFunctionRegistry()
+				.findFunctionDescriptor( "current_timestamp" );
+		SelfRenderingSqmFunction<Object> sqmExpression = functionDescriptor.generateSqmExpression(
+				null,
+				queryEngine,
+				new TypeConfiguration()
+		);
+		BasicType<?> basicType = (BasicType<?>) sqmExpression.getNodeType();
+		assertEquals( JdbcTimestampJavaType.INSTANCE, basicType.getJavaTypeDescriptor() );
+		assertEquals( TimestampJdbcType.INSTANCE, basicType.getJdbcType() );
+
+		SqlAppender appender = new StringBuilderSqlAppender();
+		sqmExpression.getRenderingSupport().render( appender, Collections.emptyList(), null );
+		assertEquals( "current", appender.toString() );
+	}
+
+	@Test
+	@TestForIssue(jiraKey = "HHH-10800")
+	public void testCurrentDateFunction() {
+		SqmFunctionDescriptor functionDescriptor = queryEngine.getSqmFunctionRegistry()
+				.findFunctionDescriptor( "current_date" );
+		SelfRenderingSqmFunction<Object> sqmExpression = functionDescriptor.generateSqmExpression(
+				null,
+				queryEngine,
+				new TypeConfiguration()
+		);
+		BasicType<?> basicType = (BasicType<?>) sqmExpression.getNodeType();
+		assertEquals( JdbcDateJavaType.INSTANCE, basicType.getJavaTypeDescriptor() );
+		assertEquals( DateJdbcType.INSTANCE, basicType.getJdbcType() );
+
+		SqlAppender appender = new StringBuilderSqlAppender();
+		sqmExpression.getRenderingSupport().render( appender, Collections.emptyList(), null );
+		assertEquals( "today", appender.toString() );
+	}
+
+}

--- a/hibernate-core/src/main/java/org/hibernate/boot/model/FunctionContributor.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/FunctionContributor.java
@@ -35,17 +35,18 @@ package org.hibernate.boot.model;
 public interface FunctionContributor {
 
 	/**
-	 *  Contribute functions
+	 * Contribute functions
 	 *
 	 * @param functionContributions The target for the contributions
 	 */
 	void contributeFunctions(FunctionContributions functionContributions);
 
 	/**
-	 * Determines order in which the contributions will be applied (lowest ordinal first).
-	 *
-	 * The range 0-500 is reserved for Hibernate, range 500-1000 for libraries and 1000-Integer.MAX_VALUE for
-	 * user-defined FunctionContributors.
+	 * Determines order in which the contributions will be applied
+	 * (lowest ordinal first).
+	 * <p>
+	 * The range 0-500 is reserved for Hibernate, range 500-1000 for libraries and
+	 * 1000-Integer.MAX_VALUE for user-defined FunctionContributors.
 	 *
 	 * @return the ordinal for this FunctionContributor
 	 */

--- a/hibernate-core/src/main/java/org/hibernate/boot/model/process/spi/MetadataBuildingProcess.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/process/spi/MetadataBuildingProcess.java
@@ -390,7 +390,7 @@ public class MetadataBuildingProcess {
 
 		// add Dialect contributed types
 		final Dialect dialect = options.getServiceRegistry().getService( JdbcServices.class ).getDialect();
-		dialect.contributeTypes( typeContributions, options.getServiceRegistry() );
+		dialect.contribute( typeContributions, options.getServiceRegistry() );
 		// Capture the dialect configured JdbcTypes so that we can detect if a TypeContributor overwrote them,
 		// which has precedence over the fallback and preferred type registrations
 		final JdbcType dialectUuidDescriptor = jdbcTypeRegistry.findDescriptor( SqlTypes.UUID );

--- a/hibernate-core/src/main/java/org/hibernate/dialect/AbstractHANADialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/AbstractHANADialect.java
@@ -43,6 +43,7 @@ import org.hibernate.LockMode;
 import org.hibernate.LockOptions;
 import org.hibernate.ScrollMode;
 import org.hibernate.boot.Metadata;
+import org.hibernate.boot.model.FunctionContributions;
 import org.hibernate.boot.model.TypeContributions;
 import org.hibernate.boot.model.naming.Identifier;
 import org.hibernate.boot.model.relational.SqlStringGenerationContext;
@@ -79,7 +80,6 @@ import org.hibernate.internal.util.JdbcExceptionHelper;
 import org.hibernate.mapping.Table;
 import org.hibernate.procedure.internal.StandardCallableStatementSupport;
 import org.hibernate.procedure.spi.CallableStatementSupport;
-import org.hibernate.query.spi.QueryEngine;
 import org.hibernate.query.sqm.CastType;
 import org.hibernate.query.sqm.IntervalType;
 import org.hibernate.query.sqm.NullOrdering;
@@ -375,11 +375,11 @@ public abstract class AbstractHANADialect extends Dialect {
 	}
 
 	@Override
-	public void initializeFunctionRegistry(QueryEngine queryEngine) {
-		super.initializeFunctionRegistry( queryEngine );
-		final TypeConfiguration typeConfiguration = queryEngine.getTypeConfiguration();
+	public void initializeFunctionRegistry(FunctionContributions functionContributions) {
+		super.initializeFunctionRegistry(functionContributions);
+		final TypeConfiguration typeConfiguration = functionContributions.getTypeConfiguration();
 
-		queryEngine.getSqmFunctionRegistry().registerBinaryTernaryPattern(
+		functionContributions.getFunctionRegistry().registerBinaryTernaryPattern(
 				"locate",
 				typeConfiguration.getBasicTypeRegistry().resolve( StandardBasicTypes.INTEGER ),
 				"locate(?2,?1)",
@@ -388,7 +388,7 @@ public abstract class AbstractHANADialect extends Dialect {
 				typeConfiguration
 		).setArgumentListSignature("(pattern, string[, start])");
 
-		CommonFunctionFactory functionFactory = new CommonFunctionFactory(queryEngine);
+		CommonFunctionFactory functionFactory = new CommonFunctionFactory(functionContributions);
 
 		functionFactory.ceiling_ceil();
 		functionFactory.concat_pipeOperator();
@@ -427,7 +427,7 @@ public abstract class AbstractHANADialect extends Dialect {
 		functionFactory.radians_acos();
 		functionFactory.degrees_acos();
 
-		queryEngine.getSqmFunctionRegistry().register( "timestampadd",
+		functionContributions.getFunctionRegistry().register( "timestampadd",
 				new IntegralTimestampaddFunction( this, typeConfiguration ) );
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/dialect/AbstractTransactSQLDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/AbstractTransactSQLDialect.java
@@ -8,6 +8,7 @@ package org.hibernate.dialect;
 
 import org.hibernate.LockMode;
 import org.hibernate.LockOptions;
+import org.hibernate.boot.model.FunctionContributions;
 import org.hibernate.dialect.function.CastingConcatFunction;
 import org.hibernate.dialect.function.TransactSQLStrFunction;
 import org.hibernate.engine.jdbc.dialect.spi.DialectResolutionInfo;
@@ -19,7 +20,6 @@ import org.hibernate.dialect.identity.IdentityColumnSupport;
 import org.hibernate.metamodel.mapping.EntityMappingType;
 import org.hibernate.metamodel.spi.RuntimeModelCreationContext;
 import org.hibernate.query.sqm.TrimSpec;
-import org.hibernate.query.spi.QueryEngine;
 import org.hibernate.query.sqm.mutation.internal.temptable.AfterUseAction;
 import org.hibernate.dialect.temptable.TemporaryTable;
 import org.hibernate.query.sqm.mutation.internal.temptable.BeforeUseAction;
@@ -123,10 +123,10 @@ public abstract class AbstractTransactSQLDialect extends Dialect {
 	}
 
 	@Override
-	public void initializeFunctionRegistry(QueryEngine queryEngine) {
-		super.initializeFunctionRegistry( queryEngine );
+	public void initializeFunctionRegistry(FunctionContributions functionContributions) {
+		super.initializeFunctionRegistry(functionContributions);
 
-		CommonFunctionFactory functionFactory = new CommonFunctionFactory(queryEngine);
+		CommonFunctionFactory functionFactory = new CommonFunctionFactory(functionContributions);
 		functionFactory.cot();
 		functionFactory.ln_log();
 		functionFactory.log_loglog();
@@ -151,17 +151,17 @@ public abstract class AbstractTransactSQLDialect extends Dialect {
 		functionFactory.datepartDatename();
 		functionFactory.lastDay_eomonth();
 
-		queryEngine.getSqmFunctionRegistry().register( "least", new CaseLeastGreatestEmulation( true ) );
-		queryEngine.getSqmFunctionRegistry().register( "greatest", new CaseLeastGreatestEmulation( false ) );
-		queryEngine.getSqmFunctionRegistry().register( "str", new TransactSQLStrFunction( queryEngine.getTypeConfiguration() ) );
-		queryEngine.getSqmFunctionRegistry().register(
+		functionContributions.getFunctionRegistry().register( "least", new CaseLeastGreatestEmulation( true ) );
+		functionContributions.getFunctionRegistry().register( "greatest", new CaseLeastGreatestEmulation( false ) );
+		functionContributions.getFunctionRegistry().register( "str", new TransactSQLStrFunction( functionContributions.getTypeConfiguration() ) );
+		functionContributions.getFunctionRegistry().register(
 				"concat",
 				new CastingConcatFunction(
 						this,
 						"+",
 						false,
 						SqlAstNodeRenderingMode.DEFAULT,
-						queryEngine.getTypeConfiguration()
+						functionContributions.getTypeConfiguration()
 				)
 		);
 	}

--- a/hibernate-core/src/main/java/org/hibernate/dialect/CockroachDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/CockroachDialect.java
@@ -23,6 +23,7 @@ import org.hibernate.LockMode;
 import org.hibernate.LockOptions;
 import org.hibernate.PessimisticLockException;
 import org.hibernate.QueryTimeoutException;
+import org.hibernate.boot.model.FunctionContributions;
 import org.hibernate.boot.model.TypeContributions;
 import org.hibernate.dialect.function.CommonFunctionFactory;
 import org.hibernate.dialect.function.FormatFunction;
@@ -44,7 +45,6 @@ import org.hibernate.exception.spi.TemplatedViolatedConstraintNameExtractor;
 import org.hibernate.exception.spi.ViolatedConstraintNameExtractor;
 import org.hibernate.internal.CoreMessageLogger;
 import org.hibernate.internal.util.JdbcExceptionHelper;
-import org.hibernate.query.spi.QueryEngine;
 import org.hibernate.query.sqm.IntervalType;
 import org.hibernate.query.sqm.NullOrdering;
 import org.hibernate.query.sqm.TemporalUnit;
@@ -365,10 +365,10 @@ public class CockroachDialect extends Dialect {
 	}
 
 	@Override
-	public void initializeFunctionRegistry(QueryEngine queryEngine) {
-		super.initializeFunctionRegistry(queryEngine);
+	public void initializeFunctionRegistry(FunctionContributions functionContributions) {
+		super.initializeFunctionRegistry(functionContributions);
 
-		final CommonFunctionFactory functionFactory = new CommonFunctionFactory( queryEngine );
+		final CommonFunctionFactory functionFactory = new CommonFunctionFactory(functionContributions);
 		functionFactory.ascii();
 		functionFactory.char_chr();
 		functionFactory.overlay();
@@ -405,9 +405,9 @@ public class CockroachDialect extends Dialect {
 		functionFactory.corr();
 		functionFactory.regrLinearRegressionAggregates();
 
-		queryEngine.getSqmFunctionRegistry().register(
+		functionContributions.getFunctionRegistry().register(
 				"format",
-				new FormatFunction( "experimental_strftime", queryEngine.getTypeConfiguration() )
+				new FormatFunction( "experimental_strftime", functionContributions.getTypeConfiguration() )
 		);
 		functionFactory.windowFunctions();
 		functionFactory.listagg_stringAgg( "string" );

--- a/hibernate-core/src/main/java/org/hibernate/dialect/DB2iDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/DB2iDialect.java
@@ -6,6 +6,7 @@
  */
 package org.hibernate.dialect;
 
+import org.hibernate.boot.model.FunctionContributions;
 import org.hibernate.dialect.function.CommonFunctionFactory;
 import org.hibernate.dialect.identity.DB2IdentityColumnSupport;
 import org.hibernate.dialect.identity.DB2zIdentityColumnSupport;
@@ -19,7 +20,6 @@ import org.hibernate.dialect.sequence.SequenceSupport;
 import org.hibernate.engine.jdbc.dialect.spi.DialectResolutionInfo;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.mapping.Column;
-import org.hibernate.query.spi.QueryEngine;
 import org.hibernate.sql.ast.SqlAstTranslator;
 import org.hibernate.sql.ast.SqlAstTranslatorFactory;
 import org.hibernate.sql.ast.spi.StandardSqlAstTranslatorFactory;
@@ -60,10 +60,10 @@ public class DB2iDialect extends DB2Dialect {
 	}
 
 	@Override
-	public void initializeFunctionRegistry(QueryEngine queryEngine) {
-		super.initializeFunctionRegistry( queryEngine );
+	public void initializeFunctionRegistry(FunctionContributions functionContributions) {
+		super.initializeFunctionRegistry(functionContributions);
 		if ( getVersion().isSameOrAfter( 7, 2 ) ) {
-			CommonFunctionFactory functionFactory = new CommonFunctionFactory(queryEngine);
+			CommonFunctionFactory functionFactory = new CommonFunctionFactory(functionContributions);
 			functionFactory.listagg( null );
 			functionFactory.inverseDistributionOrderedSetAggregates();
 			functionFactory.hypotheticalOrderedSetAggregates_windowEmulation();

--- a/hibernate-core/src/main/java/org/hibernate/dialect/DB2zDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/DB2zDialect.java
@@ -7,6 +7,7 @@
 package org.hibernate.dialect;
 
 
+import org.hibernate.boot.model.FunctionContributions;
 import org.hibernate.dialect.function.CommonFunctionFactory;
 import org.hibernate.dialect.identity.DB2zIdentityColumnSupport;
 import org.hibernate.dialect.identity.IdentityColumnSupport;
@@ -17,7 +18,6 @@ import org.hibernate.dialect.sequence.SequenceSupport;
 import org.hibernate.engine.jdbc.dialect.spi.DialectResolutionInfo;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.mapping.Column;
-import org.hibernate.query.spi.QueryEngine;
 import org.hibernate.query.sqm.IntervalType;
 import org.hibernate.query.sqm.TemporalUnit;
 import org.hibernate.sql.ast.SqlAstTranslator;
@@ -66,10 +66,10 @@ public class DB2zDialect extends DB2Dialect {
 	}
 
 	@Override
-	public void initializeFunctionRegistry(QueryEngine queryEngine) {
-		super.initializeFunctionRegistry( queryEngine );
+	public void initializeFunctionRegistry(FunctionContributions functionContributions) {
+		super.initializeFunctionRegistry(functionContributions);
 		if ( getVersion().isSameOrAfter( 12 ) ) {
-			CommonFunctionFactory functionFactory = new CommonFunctionFactory(queryEngine);
+			CommonFunctionFactory functionFactory = new CommonFunctionFactory(functionContributions);
 			functionFactory.listagg( null );
 			functionFactory.inverseDistributionOrderedSetAggregates();
 			functionFactory.hypotheticalOrderedSetAggregates_windowEmulation();

--- a/hibernate-core/src/main/java/org/hibernate/dialect/DerbyDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/DerbyDialect.java
@@ -10,6 +10,7 @@ import java.sql.DatabaseMetaData;
 import java.sql.SQLException;
 import java.sql.Types;
 
+import org.hibernate.boot.model.FunctionContributions;
 import org.hibernate.boot.model.TypeContributions;
 import org.hibernate.dialect.function.CaseLeastGreatestEmulation;
 import org.hibernate.dialect.function.CastingConcatFunction;
@@ -38,7 +39,6 @@ import org.hibernate.exception.spi.SQLExceptionConversionDelegate;
 import org.hibernate.internal.util.JdbcExceptionHelper;
 import org.hibernate.metamodel.mapping.EntityMappingType;
 import org.hibernate.metamodel.spi.RuntimeModelCreationContext;
-import org.hibernate.query.spi.QueryEngine;
 import org.hibernate.query.sqm.CastType;
 import org.hibernate.query.sqm.IntervalType;
 import org.hibernate.query.sqm.TemporalUnit;
@@ -245,24 +245,24 @@ public class DerbyDialect extends Dialect {
 	}
 
 	@Override
-	public void initializeFunctionRegistry(QueryEngine queryEngine) {
-		super.initializeFunctionRegistry( queryEngine );
+	public void initializeFunctionRegistry(FunctionContributions functionContributions) {
+		super.initializeFunctionRegistry(functionContributions);
 
-		final BasicTypeRegistry basicTypeRegistry = queryEngine.getTypeConfiguration().getBasicTypeRegistry();
+		final BasicTypeRegistry basicTypeRegistry = functionContributions.getTypeConfiguration().getBasicTypeRegistry();
 		final BasicType<String> stringType = basicTypeRegistry.resolve( StandardBasicTypes.STRING );
 
-		CommonFunctionFactory functionFactory = new CommonFunctionFactory(queryEngine);
+		CommonFunctionFactory functionFactory = new CommonFunctionFactory(functionContributions);
 
 		// Derby needs an actual argument type for aggregates like SUM, AVG, MIN, MAX to determine the result type
 		functionFactory.aggregates( this, SqlAstNodeRenderingMode.NO_PLAIN_PARAMETER );
-		queryEngine.getSqmFunctionRegistry().register(
+		functionContributions.getFunctionRegistry().register(
 				"count",
 				new CountFunction(
 						this,
-						queryEngine.getTypeConfiguration(),
+						functionContributions.getTypeConfiguration(),
 						SqlAstNodeRenderingMode.NO_PLAIN_PARAMETER,
 						"||",
-						queryEngine.getTypeConfiguration().getDdlTypeRegistry().getDescriptor( VARCHAR )
+						functionContributions.getTypeConfiguration().getDdlTypeRegistry().getDescriptor( VARCHAR )
 								.getCastTypeName( stringType, null, null, null ),
 						true
 				)
@@ -275,9 +275,9 @@ public class DerbyDialect extends Dialect {
 		// sort of to_char() function.
 
 		// We register an emulation instead, that can at least translate integer literals
-		queryEngine.getSqmFunctionRegistry().register(
+		functionContributions.getFunctionRegistry().register(
 				"chr",
-				new ChrLiteralEmulation( queryEngine.getTypeConfiguration() )
+				new ChrLiteralEmulation( functionContributions.getTypeConfiguration() )
 		);
 
 		functionFactory.concat_pipeOperator();
@@ -304,23 +304,23 @@ public class DerbyDialect extends Dialect {
 		functionFactory.octetLength_pattern( "length(?1)" );
 		functionFactory.bitLength_pattern( "length(?1)*8" );
 
-		queryEngine.getSqmFunctionRegistry().register(
+		functionContributions.getFunctionRegistry().register(
 				"concat",
 				new CastingConcatFunction(
 						this,
 						"||",
 						true,
 						SqlAstNodeRenderingMode.NO_PLAIN_PARAMETER,
-						queryEngine.getTypeConfiguration()
+						functionContributions.getTypeConfiguration()
 				)
 		);
 
 		//no way I can see to pad with anything other than spaces
-		queryEngine.getSqmFunctionRegistry().register( "lpad", new DerbyLpadEmulation( queryEngine.getTypeConfiguration() ) );
-		queryEngine.getSqmFunctionRegistry().register( "rpad", new DerbyRpadEmulation( queryEngine.getTypeConfiguration() ) );
-		queryEngine.getSqmFunctionRegistry().register( "least", new CaseLeastGreatestEmulation( true ) );
-		queryEngine.getSqmFunctionRegistry().register( "greatest", new CaseLeastGreatestEmulation( false ) );
-		queryEngine.getSqmFunctionRegistry().register( "overlay", new InsertSubstringOverlayEmulation( queryEngine.getTypeConfiguration(), true ) );
+		functionContributions.getFunctionRegistry().register( "lpad", new DerbyLpadEmulation( functionContributions.getTypeConfiguration() ) );
+		functionContributions.getFunctionRegistry().register( "rpad", new DerbyRpadEmulation( functionContributions.getTypeConfiguration() ) );
+		functionContributions.getFunctionRegistry().register( "least", new CaseLeastGreatestEmulation( true ) );
+		functionContributions.getFunctionRegistry().register( "greatest", new CaseLeastGreatestEmulation( false ) );
+		functionContributions.getFunctionRegistry().register( "overlay", new InsertSubstringOverlayEmulation( functionContributions.getTypeConfiguration(), true ) );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/dialect/DerbySqlAstTranslator.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/DerbySqlAstTranslator.java
@@ -16,8 +16,6 @@ import org.hibernate.sql.ast.SqlAstNodeRenderingMode;
 import org.hibernate.sql.ast.spi.AbstractSqlAstTranslator;
 import org.hibernate.sql.ast.spi.SqlSelection;
 import org.hibernate.sql.ast.tree.Statement;
-import org.hibernate.sql.ast.tree.cte.CteContainer;
-import org.hibernate.sql.ast.tree.cte.CteStatement;
 import org.hibernate.sql.ast.tree.expression.BinaryArithmeticExpression;
 import org.hibernate.sql.ast.tree.expression.CaseSearchedExpression;
 import org.hibernate.sql.ast.tree.expression.CaseSimpleExpression;

--- a/hibernate-core/src/main/java/org/hibernate/dialect/Dialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/Dialect.java
@@ -46,7 +46,10 @@ import org.hibernate.LockMode;
 import org.hibernate.LockOptions;
 import org.hibernate.ScrollMode;
 import org.hibernate.boot.TempTableDdlTransactionHandling;
+import org.hibernate.boot.model.FunctionContributions;
+import org.hibernate.boot.model.FunctionContributor;
 import org.hibernate.boot.model.TypeContributions;
+import org.hibernate.boot.model.TypeContributor;
 import org.hibernate.boot.model.relational.AuxiliaryDatabaseObject;
 import org.hibernate.boot.model.relational.Sequence;
 import org.hibernate.boot.spi.SessionFactoryOptions;
@@ -120,7 +123,6 @@ import org.hibernate.procedure.internal.StandardCallableStatementSupport;
 import org.hibernate.procedure.spi.CallableStatementSupport;
 import org.hibernate.query.Query;
 import org.hibernate.query.hql.HqlTranslator;
-import org.hibernate.query.spi.QueryEngine;
 import org.hibernate.query.spi.QueryOptions;
 import org.hibernate.query.sqm.CastType;
 import org.hibernate.query.sqm.FetchClauseType;
@@ -255,7 +257,7 @@ import static org.hibernate.type.descriptor.DateTimeUtils.appendAsTimestampWithN
  * <ul>
  *     <li>{@link #columnType(int)} to define a mapping from SQL
  *     {@linkplain SqlTypes type codes} to database column types, and
- *     <li>{@link #initializeFunctionRegistry(QueryEngine)} to register
+ *     <li>{@link #initializeFunctionRegistry(FunctionContributions)} to register
  *     mappings for standard HQL functions with the
  *     {@link org.hibernate.query.sqm.function.SqmFunctionRegistry}.
  * </ul>
@@ -282,7 +284,7 @@ import static org.hibernate.type.descriptor.DateTimeUtils.appendAsTimestampWithN
  *
  * @author Gavin King, David Channon
  */
-public abstract class Dialect implements ConversionContext {
+public abstract class Dialect implements ConversionContext, TypeContributor, FunctionContributor {
 
 	/**
 	 * Characters used as opening for quoting SQL identifiers
@@ -761,6 +763,17 @@ public abstract class Dialect implements ConversionContext {
 		return columnName + " between " + min + " and " + max;
 	}
 
+	@Override
+	public final void contributeFunctions(FunctionContributions functionContributions) {
+		initializeFunctionRegistry( functionContributions );
+	}
+
+	@Override
+	public int ordinal() {
+		// dialect-contributed functions come first
+		return 0;
+	}
+
 	/**
 	 * Initialize the given registry with any dialect-specific functions.
 	 * <p>
@@ -906,8 +919,8 @@ public abstract class Dialect implements ConversionContext {
 	 * Thus, we don't just naively map these HQL functions to the native SQL
 	 * functions with the same names.
 	 */
-	public void initializeFunctionRegistry(QueryEngine queryEngine) {
-		final TypeConfiguration typeConfiguration = queryEngine.getTypeConfiguration();
+	public void initializeFunctionRegistry(FunctionContributions functionContributions) {
+		final TypeConfiguration typeConfiguration = functionContributions.getTypeConfiguration();
 		final BasicTypeRegistry basicTypeRegistry = typeConfiguration.getBasicTypeRegistry();
 		final BasicType<Date> timestampType = basicTypeRegistry.resolve( StandardBasicTypes.TIMESTAMP );
 		final BasicType<Date> dateType = basicTypeRegistry.resolve( StandardBasicTypes.DATE );
@@ -918,7 +931,7 @@ public abstract class Dialect implements ConversionContext {
 		final BasicType<LocalTime> localTimeType = basicTypeRegistry.resolve( StandardBasicTypes.LOCAL_TIME );
 		final BasicType<LocalDate> localDateType = basicTypeRegistry.resolve( StandardBasicTypes.LOCAL_DATE );
 
-		CommonFunctionFactory functionFactory = new CommonFunctionFactory(queryEngine);
+		CommonFunctionFactory functionFactory = new CommonFunctionFactory(functionContributions);
 
 		//standard aggregate functions count(), sum(), max(), min(), avg(),
 		//supported on every database
@@ -1001,20 +1014,20 @@ public abstract class Dialect implements ConversionContext {
 		//only some databases support the ANSI SQL-style position() function, so
 		//define it here as an alias for locate()
 
-		queryEngine.getSqmFunctionRegistry().register( "position",
+		functionContributions.getFunctionRegistry().register( "position",
 				new LocatePositionEmulation( typeConfiguration ) );
 
 		//very few databases support ANSI-style overlay() function, so emulate
 		//it here in terms of either insert() or concat()/substring()
 
-		queryEngine.getSqmFunctionRegistry().register( "overlay",
+		functionContributions.getFunctionRegistry().register( "overlay",
 				new InsertSubstringOverlayEmulation( typeConfiguration, false ) );
 
 		//ANSI SQL trim() function is supported on almost all of the databases
 		//we care about, but on some it must be emulated using ltrim(), rtrim(),
 		//and replace()
 
-		queryEngine.getSqmFunctionRegistry().register( "trim",
+		functionContributions.getFunctionRegistry().register( "trim",
 				new TrimFunction( this, typeConfiguration ) );
 
 		//ANSI SQL cast() function is supported on the databases we care most
@@ -1025,11 +1038,13 @@ public abstract class Dialect implements ConversionContext {
 		// - casts to and from Boolean, and
 		// - casting Double or Float to String.
 
-		queryEngine.getSqmFunctionRegistry().register(
+		functionContributions.getFunctionRegistry().register(
 				"cast",
 				new CastFunction(
 						this,
-						queryEngine.getPreferredSqlTypeCodeForBoolean()
+						functionContributions.getTypeConfiguration()
+								.getCurrentBaseSqlTypeIndicators()
+								.getPreferredSqlTypeCodeForBoolean()
 				)
 		);
 
@@ -1042,7 +1057,7 @@ public abstract class Dialect implements ConversionContext {
 		//additional non-standard temporal field types, which must be emulated in
 		//a very dialect-specific way
 
-		queryEngine.getSqmFunctionRegistry().register( "extract",
+		functionContributions.getFunctionRegistry().register( "extract",
 				new ExtractFunction( this, typeConfiguration ) );
 
 		//comparison functions supported on most databases, emulated on others
@@ -1053,7 +1068,7 @@ public abstract class Dialect implements ConversionContext {
 		//two-argument synonym for coalesce() supported on most but not every
 		//database, so define it here as an alias for coalesce(arg1,arg2)
 
-		queryEngine.getSqmFunctionRegistry().register( "ifnull",
+		functionContributions.getFunctionRegistry().register( "ifnull",
 				new CoalesceIfnullEmulation() );
 
 		//rpad() and pad() are supported on almost every database, and emulated
@@ -1064,13 +1079,13 @@ public abstract class Dialect implements ConversionContext {
 
 		//pad() is a function we've designed to look like ANSI trim()
 
-		queryEngine.getSqmFunctionRegistry().register( "pad",
+		functionContributions.getFunctionRegistry().register( "pad",
 				new LpadRpadPadEmulation( typeConfiguration ) );
 
 		//legacy Hibernate convenience function for casting to string, defined
 		//here as an alias for cast(arg as String)
 
-		queryEngine.getSqmFunctionRegistry().register( "str",
+		functionContributions.getFunctionRegistry().register( "str",
 				new CastStrEmulation( typeConfiguration ) );
 
 		//format() function for datetimes, emulated on many databases using the
@@ -1082,17 +1097,17 @@ public abstract class Dialect implements ConversionContext {
 		//timestampadd()/timestampdiff() delegated back to the Dialect itself
 		//since there is a great variety of different ways to emulate them
 
-		queryEngine.getSqmFunctionRegistry().register( "timestampadd",
+		functionContributions.getFunctionRegistry().register( "timestampadd",
 				new TimestampaddFunction( this, typeConfiguration ) );
-		queryEngine.getSqmFunctionRegistry().register( "timestampdiff",
+		functionContributions.getFunctionRegistry().register( "timestampdiff",
 				new TimestampdiffFunction( this, typeConfiguration ) );
-		queryEngine.getSqmFunctionRegistry().registerAlternateKey( "dateadd", "timestampadd" );
-		queryEngine.getSqmFunctionRegistry().registerAlternateKey( "datediff", "timestampdiff" );
+		functionContributions.getFunctionRegistry().registerAlternateKey( "dateadd", "timestampadd" );
+		functionContributions.getFunctionRegistry().registerAlternateKey( "datediff", "timestampdiff" );
 
 		//ANSI SQL (and JPA) current date/time/timestamp functions, supported
 		//natively on almost every database, delegated back to the Dialect
 
-		queryEngine.getSqmFunctionRegistry().register(
+		functionContributions.getFunctionRegistry().register(
 				"current_date",
 				new CurrentFunction(
 						"current_date",
@@ -1100,7 +1115,7 @@ public abstract class Dialect implements ConversionContext {
 						dateType
 				)
 		);
-		queryEngine.getSqmFunctionRegistry().register(
+		functionContributions.getFunctionRegistry().register(
 				"current_time",
 				new CurrentFunction(
 						"current_time",
@@ -1108,7 +1123,7 @@ public abstract class Dialect implements ConversionContext {
 						timeType
 				)
 		);
-		queryEngine.getSqmFunctionRegistry().register(
+		functionContributions.getFunctionRegistry().register(
 				"current_timestamp",
 				new CurrentFunction(
 						"current_timestamp",
@@ -1116,12 +1131,12 @@ public abstract class Dialect implements ConversionContext {
 						timestampType
 				)
 		);
-		queryEngine.getSqmFunctionRegistry().registerAlternateKey( "current date", "current_date" );
-		queryEngine.getSqmFunctionRegistry().registerAlternateKey( "current time", "current_time" );
-		queryEngine.getSqmFunctionRegistry().registerAlternateKey( "current timestamp", "current_timestamp" );
+		functionContributions.getFunctionRegistry().registerAlternateKey( "current date", "current_date" );
+		functionContributions.getFunctionRegistry().registerAlternateKey( "current time", "current_time" );
+		functionContributions.getFunctionRegistry().registerAlternateKey( "current timestamp", "current_timestamp" );
 		//HQL current instant/date/time/datetime functions, delegated back to the Dialect
 
-		queryEngine.getSqmFunctionRegistry().register(
+		functionContributions.getFunctionRegistry().register(
 				"local_date",
 				new CurrentFunction(
 						"local_date",
@@ -1129,7 +1144,7 @@ public abstract class Dialect implements ConversionContext {
 						localDateType
 				)
 		);
-		queryEngine.getSqmFunctionRegistry().register(
+		functionContributions.getFunctionRegistry().register(
 				"local_time",
 				new CurrentFunction(
 						"local_time",
@@ -1137,7 +1152,7 @@ public abstract class Dialect implements ConversionContext {
 						localTimeType
 				)
 		);
-		queryEngine.getSqmFunctionRegistry().register(
+		functionContributions.getFunctionRegistry().register(
 				"local_datetime",
 				new CurrentFunction(
 						"local_datetime",
@@ -1145,7 +1160,7 @@ public abstract class Dialect implements ConversionContext {
 						localDateTimeType
 				)
 		);
-		queryEngine.getSqmFunctionRegistry().register(
+		functionContributions.getFunctionRegistry().register(
 				"offset_datetime",
 				new CurrentFunction(
 						"offset_datetime",
@@ -1153,12 +1168,12 @@ public abstract class Dialect implements ConversionContext {
 						offsetDateTimeType
 				)
 		);
-		queryEngine.getSqmFunctionRegistry().registerAlternateKey( "local date", "local_date" );
-		queryEngine.getSqmFunctionRegistry().registerAlternateKey( "local time", "local_time" );
-		queryEngine.getSqmFunctionRegistry().registerAlternateKey( "local datetime", "local_datetime" );
-		queryEngine.getSqmFunctionRegistry().registerAlternateKey( "offset datetime", "offset_datetime" );
+		functionContributions.getFunctionRegistry().registerAlternateKey( "local date", "local_date" );
+		functionContributions.getFunctionRegistry().registerAlternateKey( "local time", "local_time" );
+		functionContributions.getFunctionRegistry().registerAlternateKey( "local datetime", "local_datetime" );
+		functionContributions.getFunctionRegistry().registerAlternateKey( "offset datetime", "offset_datetime" );
 
-		queryEngine.getSqmFunctionRegistry().register(
+		functionContributions.getFunctionRegistry().register(
 				"instant",
 				new CurrentFunction(
 						"instant",
@@ -1166,9 +1181,9 @@ public abstract class Dialect implements ConversionContext {
 						instantType
 				)
 		);
-		queryEngine.getSqmFunctionRegistry().registerAlternateKey( "current_instant", "instant" ); //deprecated legacy!
+		functionContributions.getFunctionRegistry().registerAlternateKey( "current_instant", "instant" ); //deprecated legacy!
 
-		queryEngine.getSqmFunctionRegistry().register( "sql", new SqlFunction() );
+		functionContributions.getFunctionRegistry().register( "sql", new SqlFunction() );
 	}
 
 	/**
@@ -1503,6 +1518,11 @@ public abstract class Dialect implements ConversionContext {
 
 
 	// database type mapping support ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+	@Override
+	public final void contribute(TypeContributions typeContributions, ServiceRegistry serviceRegistry) {
+		contributeTypes( typeContributions, serviceRegistry );
+	}
 
 	/**
 	 * A callback which allows the {@code Dialect} to contribute types.
@@ -4147,7 +4167,7 @@ public abstract class Dialect implements ConversionContext {
 	 * has higher precedence since it comes directly from the user config
 	 *
 	 * @see org.hibernate.query.hql.internal.StandardHqlTranslator
-	 * @see QueryEngine#getHqlTranslator()
+	 * @see org.hibernate.query.spi.QueryEngine#getHqlTranslator()
 	 */
 	public HqlTranslator getHqlTranslator() {
 		return null;
@@ -4161,7 +4181,7 @@ public abstract class Dialect implements ConversionContext {
 	 * has higher precedence since it comes directly from the user config
 	 *
 	 * @see org.hibernate.query.sqm.sql.internal.StandardSqmTranslator
-	 * @see QueryEngine#getSqmTranslatorFactory()
+	 * @see org.hibernate.query.spi.QueryEngine#getSqmTranslatorFactory()
 	 */
 	public SqmTranslatorFactory getSqmTranslatorFactory() {
 		return null;

--- a/hibernate-core/src/main/java/org/hibernate/dialect/H2Dialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/H2Dialect.java
@@ -17,6 +17,7 @@ import java.util.List;
 import java.util.TimeZone;
 
 import org.hibernate.PessimisticLockException;
+import org.hibernate.boot.model.FunctionContributions;
 import org.hibernate.boot.model.TypeContributions;
 import org.hibernate.dialect.function.CommonFunctionFactory;
 import org.hibernate.dialect.hint.IndexQueryHintHandler;
@@ -42,7 +43,6 @@ import org.hibernate.exception.spi.ViolatedConstraintNameExtractor;
 import org.hibernate.internal.util.JdbcExceptionHelper;
 import org.hibernate.metamodel.mapping.EntityMappingType;
 import org.hibernate.metamodel.spi.RuntimeModelCreationContext;
-import org.hibernate.query.spi.QueryEngine;
 import org.hibernate.query.sqm.FetchClauseType;
 import org.hibernate.query.sqm.IntervalType;
 import org.hibernate.query.sqm.NullOrdering;
@@ -245,10 +245,10 @@ public class H2Dialect extends Dialect {
 	}
 
 	@Override
-	public void initializeFunctionRegistry(QueryEngine queryEngine) {
-		super.initializeFunctionRegistry( queryEngine );
+	public void initializeFunctionRegistry(FunctionContributions functionContributions) {
+		super.initializeFunctionRegistry(functionContributions);
 
-		CommonFunctionFactory functionFactory = new CommonFunctionFactory(queryEngine);
+		CommonFunctionFactory functionFactory = new CommonFunctionFactory(functionContributions);
 
 		// H2 needs an actual argument type for aggregates like SUM, AVG, MIN, MAX to determine the result type
 		functionFactory.aggregates( this, SqlAstNodeRenderingMode.NO_PLAIN_PARAMETER );

--- a/hibernate-core/src/main/java/org/hibernate/dialect/HANAColumnStoreDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/HANAColumnStoreDialect.java
@@ -6,10 +6,10 @@
  */
 package org.hibernate.dialect;
 
+import org.hibernate.boot.model.FunctionContributions;
 import org.hibernate.engine.jdbc.dialect.spi.DialectResolutionInfo;
 import org.hibernate.metamodel.mapping.EntityMappingType;
 import org.hibernate.metamodel.spi.RuntimeModelCreationContext;
-import org.hibernate.query.spi.QueryEngine;
 import org.hibernate.query.sqm.mutation.internal.temptable.GlobalTemporaryTableInsertStrategy;
 import org.hibernate.query.sqm.mutation.internal.temptable.GlobalTemporaryTableMutationStrategy;
 import org.hibernate.dialect.temptable.TemporaryTable;
@@ -87,18 +87,18 @@ public class HANAColumnStoreDialect extends AbstractHANADialect {
 
 
 	@Override
-	public void initializeFunctionRegistry(QueryEngine queryEngine) {
-		super.initializeFunctionRegistry( queryEngine );
-		final TypeConfiguration typeConfiguration = queryEngine.getTypeConfiguration();
+	public void initializeFunctionRegistry(FunctionContributions functionContributions) {
+		super.initializeFunctionRegistry(functionContributions);
+		final TypeConfiguration typeConfiguration = functionContributions.getTypeConfiguration();
 
 		// full-text search functions
-		queryEngine.getSqmFunctionRegistry().registerNamed(
+		functionContributions.getFunctionRegistry().registerNamed(
 				"score",
 				typeConfiguration.getBasicTypeRegistry().resolve( StandardBasicTypes.DOUBLE )
 		);
-		queryEngine.getSqmFunctionRegistry().registerNamed( "snippets" );
-		queryEngine.getSqmFunctionRegistry().registerNamed( "highlighted" );
-		queryEngine.getSqmFunctionRegistry().registerBinaryTernaryPattern(
+		functionContributions.getFunctionRegistry().registerNamed( "snippets" );
+		functionContributions.getFunctionRegistry().registerNamed( "highlighted" );
+		functionContributions.getFunctionRegistry().registerBinaryTernaryPattern(
 				"contains",
 				typeConfiguration.getBasicTypeRegistry().resolve( StandardBasicTypes.BOOLEAN ),
 				"contains(?1,?2)",

--- a/hibernate-core/src/main/java/org/hibernate/dialect/HSQLDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/HSQLDialect.java
@@ -10,6 +10,7 @@ import java.sql.DatabaseMetaData;
 import java.sql.SQLException;
 import java.sql.Types;
 
+import org.hibernate.boot.model.FunctionContributions;
 import org.hibernate.dialect.function.CommonFunctionFactory;
 import org.hibernate.dialect.identity.HSQLIdentityColumnSupport;
 import org.hibernate.dialect.identity.IdentityColumnSupport;
@@ -31,7 +32,6 @@ import org.hibernate.exception.spi.ViolatedConstraintNameExtractor;
 import org.hibernate.internal.util.JdbcExceptionHelper;
 import org.hibernate.metamodel.mapping.EntityMappingType;
 import org.hibernate.metamodel.spi.RuntimeModelCreationContext;
-import org.hibernate.query.spi.QueryEngine;
 import org.hibernate.query.sqm.CastType;
 import org.hibernate.query.sqm.IntervalType;
 import org.hibernate.query.sqm.NullOrdering;
@@ -127,10 +127,10 @@ public class HSQLDialect extends Dialect {
 	}
 
 	@Override
-	public void initializeFunctionRegistry(QueryEngine queryEngine) {
-		super.initializeFunctionRegistry( queryEngine );
+	public void initializeFunctionRegistry(FunctionContributions functionContributions) {
+		super.initializeFunctionRegistry(functionContributions);
 
-		CommonFunctionFactory functionFactory = new CommonFunctionFactory( queryEngine );
+		CommonFunctionFactory functionFactory = new CommonFunctionFactory(functionContributions);
 
 		// AVG by default uses the input type, so we possibly need to cast the argument type, hence a special function
 		functionFactory.avg_castingNonDoubleArguments( this, SqlAstNodeRenderingMode.DEFAULT );

--- a/hibernate-core/src/main/java/org/hibernate/dialect/MariaDBDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/MariaDBDialect.java
@@ -9,6 +9,7 @@ package org.hibernate.dialect;
 import java.sql.DatabaseMetaData;
 import java.sql.SQLException;
 
+import org.hibernate.boot.model.FunctionContributions;
 import org.hibernate.boot.model.TypeContributions;
 import org.hibernate.dialect.function.CommonFunctionFactory;
 import org.hibernate.dialect.sequence.MariaDBSequenceSupport;
@@ -18,7 +19,6 @@ import org.hibernate.engine.jdbc.env.spi.IdentifierCaseStrategy;
 import org.hibernate.engine.jdbc.env.spi.IdentifierHelper;
 import org.hibernate.engine.jdbc.env.spi.IdentifierHelperBuilder;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
-import org.hibernate.query.spi.QueryEngine;
 import org.hibernate.service.ServiceRegistry;
 import org.hibernate.sql.ast.SqlAstTranslator;
 import org.hibernate.sql.ast.SqlAstTranslatorFactory;
@@ -78,21 +78,21 @@ public class MariaDBDialect extends MySQLDialect {
 	}
 
 	@Override
-	public void initializeFunctionRegistry(QueryEngine queryEngine) {
-		super.initializeFunctionRegistry(queryEngine);
+	public void initializeFunctionRegistry(FunctionContributions functionContributions) {
+		super.initializeFunctionRegistry(functionContributions);
 
-		CommonFunctionFactory commonFunctionFactory = new CommonFunctionFactory( queryEngine );
+		CommonFunctionFactory commonFunctionFactory = new CommonFunctionFactory(functionContributions);
 		commonFunctionFactory.windowFunctions();
 		commonFunctionFactory.hypotheticalOrderedSetAggregates_windowEmulation();
-		queryEngine.getSqmFunctionRegistry().registerNamed(
+		functionContributions.getFunctionRegistry().registerNamed(
 				"json_valid",
-				queryEngine.getTypeConfiguration()
+				functionContributions.getTypeConfiguration()
 						.getBasicTypeRegistry()
 						.resolve( StandardBasicTypes.BOOLEAN )
 		);
 		commonFunctionFactory.inverseDistributionOrderedSetAggregates_windowEmulation();
-		queryEngine.getSqmFunctionRegistry().patternDescriptorBuilder( "median", "median(?1) over ()" )
-				.setInvariantType( queryEngine.getTypeConfiguration().getBasicTypeRegistry().resolve( StandardBasicTypes.DOUBLE ) )
+		functionContributions.getFunctionRegistry().patternDescriptorBuilder( "median", "median(?1) over ()" )
+				.setInvariantType( functionContributions.getTypeConfiguration().getBasicTypeRegistry().resolve( StandardBasicTypes.DOUBLE ) )
 				.setExactArgumentCount( 1 )
 				.setParameterTypes(NUMERIC)
 				.register();

--- a/hibernate-core/src/main/java/org/hibernate/dialect/MySQLDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/MySQLDialect.java
@@ -14,6 +14,7 @@ import java.sql.Types;
 
 import org.hibernate.LockOptions;
 import org.hibernate.PessimisticLockException;
+import org.hibernate.boot.model.FunctionContributions;
 import org.hibernate.boot.model.TypeContributions;
 import org.hibernate.cfg.Environment;
 import org.hibernate.dialect.function.CommonFunctionFactory;
@@ -41,7 +42,6 @@ import org.hibernate.exception.spi.ViolatedConstraintNameExtractor;
 import org.hibernate.internal.util.JdbcExceptionHelper;
 import org.hibernate.metamodel.mapping.EntityMappingType;
 import org.hibernate.metamodel.spi.RuntimeModelCreationContext;
-import org.hibernate.query.spi.QueryEngine;
 import org.hibernate.query.sqm.CastType;
 import org.hibernate.query.sqm.IntervalType;
 import org.hibernate.query.sqm.NullOrdering;
@@ -507,10 +507,10 @@ public class MySQLDialect extends Dialect {
 //	}
 
 	@Override
-	public void initializeFunctionRegistry(QueryEngine queryEngine) {
-		super.initializeFunctionRegistry( queryEngine );
+	public void initializeFunctionRegistry(FunctionContributions functionContributions) {
+		super.initializeFunctionRegistry(functionContributions);
 
-		CommonFunctionFactory functionFactory = new CommonFunctionFactory(queryEngine);
+		CommonFunctionFactory functionFactory = new CommonFunctionFactory(functionContributions);
 
 		functionFactory.soundex();
 		functionFactory.radians();
@@ -534,7 +534,7 @@ public class MySQLDialect extends Dialect {
 		functionFactory.lastDay();
 		functionFactory.date();
 		functionFactory.timestamp();
-		time( queryEngine );
+		time(functionContributions);
 
 		functionFactory.utcDateTimeTimestamp();
 		functionFactory.rand();
@@ -564,9 +564,9 @@ public class MySQLDialect extends Dialect {
 		functionFactory.makedateMaketime();
 		functionFactory.localtimeLocaltimestamp();
 
-		BasicTypeRegistry basicTypeRegistry = queryEngine.getTypeConfiguration().getBasicTypeRegistry();
+		BasicTypeRegistry basicTypeRegistry = functionContributions.getTypeConfiguration().getBasicTypeRegistry();
 
-		SqmFunctionRegistry functionRegistry = queryEngine.getSqmFunctionRegistry();
+		SqmFunctionRegistry functionRegistry = functionContributions.getFunctionRegistry();
 
 		functionRegistry.noArgsBuilder( "localtime" )
 				.setInvariantType(basicTypeRegistry.resolve( StandardBasicTypes.TIMESTAMP ))
@@ -666,8 +666,8 @@ public class MySQLDialect extends Dialect {
 		return super.castPattern( from, to );
 	}
 
-	private void time(QueryEngine queryEngine) {
-		queryEngine.getSqmFunctionRegistry().namedDescriptorBuilder( "time" )
+	private void time(FunctionContributions queryEngine) {
+		queryEngine.getFunctionRegistry().namedDescriptorBuilder( "time" )
 				.setExactArgumentCount( 1 )
 				.setInvariantType(
 					queryEngine.getTypeConfiguration().getBasicTypeRegistry().resolve( StandardBasicTypes.STRING )

--- a/hibernate-core/src/main/java/org/hibernate/dialect/OracleDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/OracleDialect.java
@@ -16,6 +16,7 @@ import java.util.regex.Pattern;
 
 import org.hibernate.LockOptions;
 import org.hibernate.QueryTimeoutException;
+import org.hibernate.boot.model.FunctionContributions;
 import org.hibernate.boot.model.TypeContributions;
 import org.hibernate.dialect.aggregate.AggregateSupport;
 import org.hibernate.dialect.aggregate.OracleAggregateSupport;
@@ -50,7 +51,6 @@ import org.hibernate.metamodel.spi.RuntimeModelCreationContext;
 import org.hibernate.procedure.internal.StandardCallableStatementSupport;
 import org.hibernate.procedure.spi.CallableStatementSupport;
 import org.hibernate.query.SemanticException;
-import org.hibernate.query.spi.QueryEngine;
 import org.hibernate.query.spi.QueryOptions;
 import org.hibernate.query.sqm.CastType;
 import org.hibernate.query.sqm.FetchClauseType;
@@ -195,11 +195,11 @@ public class OracleDialect extends Dialect {
 	}
 
 	@Override
-	public void initializeFunctionRegistry(QueryEngine queryEngine) {
-		super.initializeFunctionRegistry( queryEngine );
-		final TypeConfiguration typeConfiguration = queryEngine.getTypeConfiguration();
+	public void initializeFunctionRegistry(FunctionContributions functionContributions) {
+		super.initializeFunctionRegistry(functionContributions);
+		final TypeConfiguration typeConfiguration = functionContributions.getTypeConfiguration();
 
-		CommonFunctionFactory functionFactory = new CommonFunctionFactory(queryEngine);
+		CommonFunctionFactory functionFactory = new CommonFunctionFactory(functionContributions);
 		functionFactory.ascii();
 		functionFactory.char_chr();
 		functionFactory.cosh();
@@ -248,7 +248,7 @@ public class OracleDialect extends Dialect {
 		//Oracle has had coalesce() since 9.0.1
 		functionFactory.coalesce();
 
-		queryEngine.getSqmFunctionRegistry().registerBinaryTernaryPattern(
+		functionContributions.getFunctionRegistry().registerBinaryTernaryPattern(
 				"locate",
 				typeConfiguration.getBasicTypeRegistry().resolve( StandardBasicTypes.INTEGER ),
 				"instr(?2,?1)",
@@ -267,7 +267,7 @@ public class OracleDialect extends Dialect {
 		functionFactory.hypotheticalOrderedSetAggregates();
 		functionFactory.inverseDistributionOrderedSetAggregates();
 		// Oracle has a regular aggregate function named stats_mode
-		queryEngine.getSqmFunctionRegistry().register(
+		functionContributions.getFunctionRegistry().register(
 				"mode",
 				new ModeStatsModeEmulation( typeConfiguration )
 		);

--- a/hibernate-core/src/main/java/org/hibernate/dialect/PostgreSQLDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/PostgreSQLDialect.java
@@ -23,6 +23,7 @@ import org.hibernate.LockMode;
 import org.hibernate.LockOptions;
 import org.hibernate.PessimisticLockException;
 import org.hibernate.QueryTimeoutException;
+import org.hibernate.boot.model.FunctionContributions;
 import org.hibernate.boot.model.TypeContributions;
 import org.hibernate.dialect.aggregate.AggregateSupport;
 import org.hibernate.dialect.aggregate.PostgreSQLAggregateSupport;
@@ -52,7 +53,6 @@ import org.hibernate.metamodel.spi.RuntimeModelCreationContext;
 import org.hibernate.procedure.internal.PostgreSQLCallableStatementSupport;
 import org.hibernate.procedure.spi.CallableStatementSupport;
 import org.hibernate.query.SemanticException;
-import org.hibernate.query.spi.QueryEngine;
 import org.hibernate.query.sqm.FetchClauseType;
 import org.hibernate.query.sqm.IntervalType;
 import org.hibernate.query.sqm.TemporalUnit;
@@ -518,10 +518,10 @@ public class PostgreSQLDialect extends Dialect {
 	}
 
 	@Override
-	public void initializeFunctionRegistry(QueryEngine queryEngine) {
-		super.initializeFunctionRegistry( queryEngine );
+	public void initializeFunctionRegistry(FunctionContributions functionContributions) {
+		super.initializeFunctionRegistry(functionContributions);
 
-		CommonFunctionFactory functionFactory = new CommonFunctionFactory(queryEngine);
+		CommonFunctionFactory functionFactory = new CommonFunctionFactory(functionContributions);
 
 		functionFactory.round_roundFloor(); //Postgres round(x,n) does not accept double
 		functionFactory.trunc_truncFloor();
@@ -538,7 +538,7 @@ public class PostgreSQLDialect extends Dialect {
 			functionFactory.moreHyperbolic();
 		}
 		else {
-			queryEngine.getSqmFunctionRegistry().registerAlternateKey( "log10", "log" );
+			functionContributions.getFunctionRegistry().registerAlternateKey( "log10", "log" );
 		}
 		functionFactory.cbrt();
 		functionFactory.pi();
@@ -585,8 +585,8 @@ public class PostgreSQLDialect extends Dialect {
 		functionFactory.hypotheticalOrderedSetAggregates();
 
 		if ( !supportsMinMaxOnUuid() ) {
-			queryEngine.getSqmFunctionRegistry().register( "min", new PostgreSQLMinMaxFunction( "min" ) );
-			queryEngine.getSqmFunctionRegistry().register( "max", new PostgreSQLMinMaxFunction( "max" ) );
+			functionContributions.getFunctionRegistry().register( "min", new PostgreSQLMinMaxFunction( "min" ) );
+			functionContributions.getFunctionRegistry().register( "max", new PostgreSQLMinMaxFunction( "max" ) );
 		}
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/dialect/PostgresPlusDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/PostgresPlusDialect.java
@@ -13,11 +13,11 @@ import java.sql.Types;
 
 import jakarta.persistence.TemporalType;
 
+import org.hibernate.boot.model.FunctionContributions;
 import org.hibernate.dialect.function.CommonFunctionFactory;
 import org.hibernate.engine.jdbc.dialect.spi.DialectResolutionInfo;
 import org.hibernate.query.sqm.CastType;
 import org.hibernate.query.sqm.TemporalUnit;
-import org.hibernate.query.spi.QueryEngine;
 
 
 import static org.hibernate.query.sqm.TemporalUnit.DAY;
@@ -45,10 +45,10 @@ public class PostgresPlusDialect extends PostgreSQLDialect {
 	}
 
 	@Override
-	public void initializeFunctionRegistry(QueryEngine queryEngine) {
-		super.initializeFunctionRegistry( queryEngine );
+	public void initializeFunctionRegistry(FunctionContributions functionContributions) {
+		super.initializeFunctionRegistry(functionContributions);
 
-		CommonFunctionFactory functionFactory = new CommonFunctionFactory(queryEngine);
+		CommonFunctionFactory functionFactory = new CommonFunctionFactory(functionContributions);
 		functionFactory.soundex();
 		functionFactory.rownumRowid();
 		functionFactory.sysdate();

--- a/hibernate-core/src/main/java/org/hibernate/dialect/SQLServerDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/SQLServerDialect.java
@@ -19,6 +19,7 @@ import org.hibernate.LockMode;
 import org.hibernate.LockOptions;
 import org.hibernate.QueryTimeoutException;
 import org.hibernate.boot.Metadata;
+import org.hibernate.boot.model.FunctionContributions;
 import org.hibernate.boot.model.TypeContributions;
 import org.hibernate.boot.model.relational.QualifiedSequenceName;
 import org.hibernate.boot.model.relational.Sequence;
@@ -46,7 +47,6 @@ import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.exception.LockTimeoutException;
 import org.hibernate.exception.spi.SQLExceptionConversionDelegate;
 import org.hibernate.internal.util.JdbcExceptionHelper;
-import org.hibernate.query.spi.QueryEngine;
 import org.hibernate.mapping.Column;
 import org.hibernate.query.sqm.CastType;
 import org.hibernate.query.sqm.FetchClauseType;
@@ -278,22 +278,22 @@ public class SQLServerDialect extends AbstractTransactSQLDialect {
 	}
 
 	@Override
-	public void initializeFunctionRegistry(QueryEngine queryEngine) {
-		super.initializeFunctionRegistry(queryEngine);
+	public void initializeFunctionRegistry(FunctionContributions functionContributions) {
+		super.initializeFunctionRegistry(functionContributions);
 
-		final BasicTypeRegistry basicTypeRegistry = queryEngine.getTypeConfiguration().getBasicTypeRegistry();
+		final BasicTypeRegistry basicTypeRegistry = functionContributions.getTypeConfiguration().getBasicTypeRegistry();
 		BasicType<Date> dateType = basicTypeRegistry.resolve( StandardBasicTypes.DATE );
 		BasicType<Date> timeType = basicTypeRegistry.resolve( StandardBasicTypes.TIME );
 		BasicType<Date> timestampType = basicTypeRegistry.resolve( StandardBasicTypes.TIMESTAMP );
 
-		CommonFunctionFactory functionFactory = new CommonFunctionFactory(queryEngine);
+		CommonFunctionFactory functionFactory = new CommonFunctionFactory(functionContributions);
 
 		// For SQL-Server we need to cast certain arguments to varchar(max) to be able to concat them
-		queryEngine.getSqmFunctionRegistry().register(
+		functionContributions.getFunctionRegistry().register(
 				"count",
 				new CountFunction(
 						this,
-						queryEngine.getTypeConfiguration(),
+						functionContributions.getTypeConfiguration(),
 						SqlAstNodeRenderingMode.DEFAULT,
 						"count_big",
 						"+",
@@ -318,9 +318,9 @@ public class SQLServerDialect extends AbstractTransactSQLDialect {
 		functionFactory.varPopSamp_varp();
 
 		if ( getVersion().isSameOrAfter( 11 ) ) {
-			queryEngine.getSqmFunctionRegistry().register(
+			functionContributions.getFunctionRegistry().register(
 					"format",
-					new SQLServerFormatEmulation( queryEngine.getTypeConfiguration() )
+					new SQLServerFormatEmulation( functionContributions.getTypeConfiguration() )
 			);
 
 			//actually translate() was added in 2017 but
@@ -329,32 +329,32 @@ public class SQLServerDialect extends AbstractTransactSQLDialect {
 
 			functionFactory.median_percentileCont( true );
 
-			queryEngine.getSqmFunctionRegistry().namedDescriptorBuilder( "datefromparts" )
+			functionContributions.getFunctionRegistry().namedDescriptorBuilder( "datefromparts" )
 					.setInvariantType( dateType )
 					.setExactArgumentCount( 3 )
 					.setParameterTypes(INTEGER)
 					.register();
-			queryEngine.getSqmFunctionRegistry().namedDescriptorBuilder( "timefromparts" )
+			functionContributions.getFunctionRegistry().namedDescriptorBuilder( "timefromparts" )
 					.setInvariantType( timeType )
 					.setExactArgumentCount( 5 )
 					.setParameterTypes(INTEGER)
 					.register();
-			queryEngine.getSqmFunctionRegistry().namedDescriptorBuilder( "smalldatetimefromparts" )
+			functionContributions.getFunctionRegistry().namedDescriptorBuilder( "smalldatetimefromparts" )
 					.setInvariantType( timestampType )
 					.setExactArgumentCount( 5 )
 					.setParameterTypes(INTEGER)
 					.register();
-			queryEngine.getSqmFunctionRegistry().namedDescriptorBuilder( "datetimefromparts" )
+			functionContributions.getFunctionRegistry().namedDescriptorBuilder( "datetimefromparts" )
 					.setInvariantType( timestampType )
 					.setExactArgumentCount( 7 )
 					.setParameterTypes(INTEGER)
 					.register();
-			queryEngine.getSqmFunctionRegistry().namedDescriptorBuilder( "datetime2fromparts" )
+			functionContributions.getFunctionRegistry().namedDescriptorBuilder( "datetime2fromparts" )
 					.setInvariantType( timestampType )
 					.setExactArgumentCount( 8 )
 					.setParameterTypes(INTEGER)
 					.register();
-			queryEngine.getSqmFunctionRegistry().namedDescriptorBuilder( "datetimeoffsetfromparts" )
+			functionContributions.getFunctionRegistry().namedDescriptorBuilder( "datetimeoffsetfromparts" )
 					.setInvariantType( timestampType )
 					.setExactArgumentCount( 10 )
 					.setParameterTypes(INTEGER)

--- a/hibernate-core/src/main/java/org/hibernate/dialect/SpannerDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/SpannerDialect.java
@@ -13,6 +13,7 @@ import org.hibernate.LockMode;
 import org.hibernate.LockOptions;
 import org.hibernate.StaleObjectStateException;
 import org.hibernate.boot.Metadata;
+import org.hibernate.boot.model.FunctionContributions;
 import org.hibernate.boot.model.relational.Exportable;
 import org.hibernate.boot.model.relational.Sequence;
 import org.hibernate.boot.model.relational.SqlStringGenerationContext;
@@ -35,7 +36,6 @@ import org.hibernate.mapping.Table;
 import org.hibernate.mapping.UniqueKey;
 import org.hibernate.persister.entity.Lockable;
 import org.hibernate.query.SemanticException;
-import org.hibernate.query.spi.QueryEngine;
 import org.hibernate.query.sqm.IntervalType;
 import org.hibernate.query.sqm.TemporalUnit;
 import org.hibernate.sql.ast.SqlAstTranslator;
@@ -192,9 +192,9 @@ public class SpannerDialect extends Dialect {
 	}
 
 	@Override
-	public void initializeFunctionRegistry(QueryEngine queryEngine) {
-		super.initializeFunctionRegistry( queryEngine );
-		final BasicTypeRegistry basicTypeRegistry = queryEngine.getTypeConfiguration().getBasicTypeRegistry();
+	public void initializeFunctionRegistry(FunctionContributions functionContributions) {
+		super.initializeFunctionRegistry(functionContributions);
+		final BasicTypeRegistry basicTypeRegistry = functionContributions.getTypeConfiguration().getBasicTypeRegistry();
 		final BasicType<byte[]> byteArrayType = basicTypeRegistry.resolve( StandardBasicTypes.BINARY );
 		final BasicType<Long> longType = basicTypeRegistry.resolve( StandardBasicTypes.LONG );
 		final BasicType<Boolean> booleanType = basicTypeRegistry.resolve( StandardBasicTypes.BOOLEAN );
@@ -203,30 +203,30 @@ public class SpannerDialect extends Dialect {
 		final BasicType<Date> timestampType = basicTypeRegistry.resolve( StandardBasicTypes.TIMESTAMP );
 
 		// Aggregate Functions
-		queryEngine.getSqmFunctionRegistry().namedAggregateDescriptorBuilder( "any_value" )
+		functionContributions.getFunctionRegistry().namedAggregateDescriptorBuilder( "any_value" )
 				.setExactArgumentCount( 1 )
 				.register();
-		queryEngine.getSqmFunctionRegistry().namedAggregateDescriptorBuilder( "array_agg" )
+		functionContributions.getFunctionRegistry().namedAggregateDescriptorBuilder( "array_agg" )
 				.setExactArgumentCount( 1 )
 				.register();
-		queryEngine.getSqmFunctionRegistry().namedAggregateDescriptorBuilder( "countif" )
+		functionContributions.getFunctionRegistry().namedAggregateDescriptorBuilder( "countif" )
 				.setInvariantType( longType )
 				.setExactArgumentCount( 1 )
 				.register();
-		queryEngine.getSqmFunctionRegistry().namedAggregateDescriptorBuilder( "logical_and" )
+		functionContributions.getFunctionRegistry().namedAggregateDescriptorBuilder( "logical_and" )
 				.setInvariantType( booleanType )
 				.setExactArgumentCount( 1 )
 				.register();
-		queryEngine.getSqmFunctionRegistry().namedAggregateDescriptorBuilder( "logical_or" )
+		functionContributions.getFunctionRegistry().namedAggregateDescriptorBuilder( "logical_or" )
 				.setInvariantType( booleanType )
 				.setExactArgumentCount( 1 )
 				.register();
-		queryEngine.getSqmFunctionRegistry().namedAggregateDescriptorBuilder( "string_agg" )
+		functionContributions.getFunctionRegistry().namedAggregateDescriptorBuilder( "string_agg" )
 				.setInvariantType( stringType )
 				.setArgumentCountBetween( 1, 2 )
 				.register();
 
-		CommonFunctionFactory functionFactory = new CommonFunctionFactory(queryEngine);
+		CommonFunctionFactory functionFactory = new CommonFunctionFactory(functionContributions);
 
 		// Mathematical Functions
 		functionFactory.log();
@@ -240,19 +240,19 @@ public class SpannerDialect extends Dialect {
 
 		functionFactory.bitandorxornot_bitAndOrXorNot();
 
-		queryEngine.getSqmFunctionRegistry().namedDescriptorBuilder( "is_inf" )
+		functionContributions.getFunctionRegistry().namedDescriptorBuilder( "is_inf" )
 				.setInvariantType( booleanType )
 				.setExactArgumentCount( 1 )
 				.register();
-		queryEngine.getSqmFunctionRegistry().namedDescriptorBuilder( "is_nan" )
+		functionContributions.getFunctionRegistry().namedDescriptorBuilder( "is_nan" )
 				.setInvariantType( booleanType )
 				.setExactArgumentCount( 1 )
 				.register();
-		queryEngine.getSqmFunctionRegistry().namedDescriptorBuilder( "ieee_divide" )
+		functionContributions.getFunctionRegistry().namedDescriptorBuilder( "ieee_divide" )
 				.setInvariantType( booleanType )
 				.setExactArgumentCount( 2 )
 				.register();
-		queryEngine.getSqmFunctionRegistry().namedDescriptorBuilder( "div" )
+		functionContributions.getFunctionRegistry().namedDescriptorBuilder( "div" )
 				.setInvariantType( longType )
 				.setExactArgumentCount( 2 )
 				.register();
@@ -260,15 +260,15 @@ public class SpannerDialect extends Dialect {
 		functionFactory.sha1();
 
 		// Hash Functions
-		queryEngine.getSqmFunctionRegistry().namedDescriptorBuilder( "farm_fingerprint" )
+		functionContributions.getFunctionRegistry().namedDescriptorBuilder( "farm_fingerprint" )
 				.setInvariantType( longType )
 				.setExactArgumentCount( 1 )
 				.register();
-		queryEngine.getSqmFunctionRegistry().namedDescriptorBuilder( "sha256" )
+		functionContributions.getFunctionRegistry().namedDescriptorBuilder( "sha256" )
 				.setInvariantType( byteArrayType )
 				.setExactArgumentCount( 1 )
 				.register();
-		queryEngine.getSqmFunctionRegistry().namedDescriptorBuilder( "sha512" )
+		functionContributions.getFunctionRegistry().namedDescriptorBuilder( "sha512" )
 				.setInvariantType( byteArrayType )
 				.setExactArgumentCount( 1 )
 				.register();
@@ -280,200 +280,200 @@ public class SpannerDialect extends Dialect {
 		functionFactory.repeat();
 		functionFactory.substr();
 		functionFactory.substring_substr();
-		queryEngine.getSqmFunctionRegistry().namedDescriptorBuilder( "byte_length" )
+		functionContributions.getFunctionRegistry().namedDescriptorBuilder( "byte_length" )
 				.setInvariantType( longType )
 				.setExactArgumentCount( 1 )
 				.register();
-		queryEngine.getSqmFunctionRegistry().namedDescriptorBuilder( "code_points_to_bytes" )
+		functionContributions.getFunctionRegistry().namedDescriptorBuilder( "code_points_to_bytes" )
 				.setInvariantType( byteArrayType )
 				.setExactArgumentCount( 1 )
 				.register();
-		queryEngine.getSqmFunctionRegistry().namedDescriptorBuilder( "code_points_to_string" )
+		functionContributions.getFunctionRegistry().namedDescriptorBuilder( "code_points_to_string" )
 				.setInvariantType( stringType )
 				.setExactArgumentCount( 1 )
 				.register();
-		queryEngine.getSqmFunctionRegistry().namedDescriptorBuilder( "ends_with" )
+		functionContributions.getFunctionRegistry().namedDescriptorBuilder( "ends_with" )
 				.setInvariantType( booleanType )
 				.setExactArgumentCount( 2 )
 				.register();
 //		queryEngine.getSqmFunctionRegistry().namedTemplateBuilder( "format" )
 //				.setInvariantType( StandardBasicTypes.STRING )
 //				.register();
-		queryEngine.getSqmFunctionRegistry().namedDescriptorBuilder( "from_base64" )
+		functionContributions.getFunctionRegistry().namedDescriptorBuilder( "from_base64" )
 				.setInvariantType( byteArrayType )
 				.setExactArgumentCount( 1 )
 				.register();
-		queryEngine.getSqmFunctionRegistry().namedDescriptorBuilder( "from_hex" )
+		functionContributions.getFunctionRegistry().namedDescriptorBuilder( "from_hex" )
 				.setInvariantType( byteArrayType )
 				.setExactArgumentCount( 1 )
 				.register();
-		queryEngine.getSqmFunctionRegistry().namedDescriptorBuilder( "regexp_contains" )
+		functionContributions.getFunctionRegistry().namedDescriptorBuilder( "regexp_contains" )
 				.setInvariantType( booleanType )
 				.setExactArgumentCount( 2 )
 				.register();
-		queryEngine.getSqmFunctionRegistry().namedDescriptorBuilder( "regexp_extract" )
+		functionContributions.getFunctionRegistry().namedDescriptorBuilder( "regexp_extract" )
 				.setExactArgumentCount( 2 )
 				.register();
-		queryEngine.getSqmFunctionRegistry().namedDescriptorBuilder( "regexp_extract_all" )
+		functionContributions.getFunctionRegistry().namedDescriptorBuilder( "regexp_extract_all" )
 				.setExactArgumentCount( 2 )
 				.register();
-		queryEngine.getSqmFunctionRegistry().namedDescriptorBuilder( "regexp_replace" )
+		functionContributions.getFunctionRegistry().namedDescriptorBuilder( "regexp_replace" )
 				.setExactArgumentCount( 3 )
 				.register();
-		queryEngine.getSqmFunctionRegistry().namedDescriptorBuilder( "safe_convert_bytes_to_string" )
+		functionContributions.getFunctionRegistry().namedDescriptorBuilder( "safe_convert_bytes_to_string" )
 				.setInvariantType( stringType )
 				.setExactArgumentCount( 1 )
 				.register();
-		queryEngine.getSqmFunctionRegistry().namedDescriptorBuilder( "split" )
+		functionContributions.getFunctionRegistry().namedDescriptorBuilder( "split" )
 				.setArgumentCountBetween( 1, 2 )
 				.register();
-		queryEngine.getSqmFunctionRegistry().namedDescriptorBuilder( "starts_with" )
+		functionContributions.getFunctionRegistry().namedDescriptorBuilder( "starts_with" )
 				.setInvariantType( booleanType )
 				.setExactArgumentCount( 2 )
 				.register();
-		queryEngine.getSqmFunctionRegistry().namedDescriptorBuilder( "strpos" )
+		functionContributions.getFunctionRegistry().namedDescriptorBuilder( "strpos" )
 				.setInvariantType( longType )
 				.setExactArgumentCount( 2 )
 				.register();
-		queryEngine.getSqmFunctionRegistry().namedDescriptorBuilder( "to_base64" )
+		functionContributions.getFunctionRegistry().namedDescriptorBuilder( "to_base64" )
 				.setInvariantType( stringType )
 				.setExactArgumentCount( 1 )
 				.register();
-		queryEngine.getSqmFunctionRegistry().namedDescriptorBuilder( "to_code_points" )
+		functionContributions.getFunctionRegistry().namedDescriptorBuilder( "to_code_points" )
 				.setExactArgumentCount( 1 )
 				.register();
-		queryEngine.getSqmFunctionRegistry().namedDescriptorBuilder( "to_hex" )
+		functionContributions.getFunctionRegistry().namedDescriptorBuilder( "to_hex" )
 				.setInvariantType( stringType )
 				.setExactArgumentCount( 1 )
 				.register();
 
 		// JSON Functions
-		queryEngine.getSqmFunctionRegistry().namedDescriptorBuilder( "json_query" )
+		functionContributions.getFunctionRegistry().namedDescriptorBuilder( "json_query" )
 				.setInvariantType( stringType )
 				.setExactArgumentCount( 2 )
 				.register();
-		queryEngine.getSqmFunctionRegistry().namedDescriptorBuilder( "json_value" )
+		functionContributions.getFunctionRegistry().namedDescriptorBuilder( "json_value" )
 				.setInvariantType( stringType )
 				.setExactArgumentCount( 2 )
 				.register();
 
 		// Array Functions
-		queryEngine.getSqmFunctionRegistry().namedDescriptorBuilder( "array" )
+		functionContributions.getFunctionRegistry().namedDescriptorBuilder( "array" )
 				.setExactArgumentCount( 1 )
 				.register();
-		queryEngine.getSqmFunctionRegistry().namedDescriptorBuilder( "array_concat" )
+		functionContributions.getFunctionRegistry().namedDescriptorBuilder( "array_concat" )
 				.register();
-		queryEngine.getSqmFunctionRegistry().namedDescriptorBuilder( "array_length" )
+		functionContributions.getFunctionRegistry().namedDescriptorBuilder( "array_length" )
 				.setInvariantType( longType )
 				.setExactArgumentCount( 1 )
 				.register();
-		queryEngine.getSqmFunctionRegistry().namedDescriptorBuilder( "array_to_string" )
+		functionContributions.getFunctionRegistry().namedDescriptorBuilder( "array_to_string" )
 				.setInvariantType( stringType )
 				.setArgumentCountBetween( 2, 3 )
 				.register();
-		queryEngine.getSqmFunctionRegistry().namedDescriptorBuilder( "array_reverse" )
+		functionContributions.getFunctionRegistry().namedDescriptorBuilder( "array_reverse" )
 				.setExactArgumentCount( 1 )
 				.register();
 
 		// Date functions
-		queryEngine.getSqmFunctionRegistry().namedDescriptorBuilder( "date" )
+		functionContributions.getFunctionRegistry().namedDescriptorBuilder( "date" )
 				.setInvariantType( dateType )
 				.setArgumentCountBetween( 1, 3 )
 				.register();
-		queryEngine.getSqmFunctionRegistry().namedDescriptorBuilder( "date_add" )
+		functionContributions.getFunctionRegistry().namedDescriptorBuilder( "date_add" )
 				.setInvariantType( dateType )
 				.setExactArgumentCount( 2 )
 				.register();
-		queryEngine.getSqmFunctionRegistry().namedDescriptorBuilder( "date_sub" )
+		functionContributions.getFunctionRegistry().namedDescriptorBuilder( "date_sub" )
 				.setInvariantType( dateType )
 				.setExactArgumentCount( 2 )
 				.register();
-		queryEngine.getSqmFunctionRegistry().namedDescriptorBuilder( "date_diff" )
+		functionContributions.getFunctionRegistry().namedDescriptorBuilder( "date_diff" )
 				.setInvariantType( longType )
 				.setExactArgumentCount( 3 )
 				.register();
-		queryEngine.getSqmFunctionRegistry().namedDescriptorBuilder( "date_trunc" )
+		functionContributions.getFunctionRegistry().namedDescriptorBuilder( "date_trunc" )
 				.setInvariantType( dateType )
 				.setExactArgumentCount( 2 )
 				.register();
-		queryEngine.getSqmFunctionRegistry().namedDescriptorBuilder( "date_from_unix_date" )
+		functionContributions.getFunctionRegistry().namedDescriptorBuilder( "date_from_unix_date" )
 				.setInvariantType( dateType )
 				.setExactArgumentCount( 1 )
 				.register();
-		queryEngine.getSqmFunctionRegistry().namedDescriptorBuilder( "format_date" )
+		functionContributions.getFunctionRegistry().namedDescriptorBuilder( "format_date" )
 				.setInvariantType( stringType )
 				.setExactArgumentCount( 2 )
 				.register();
-		queryEngine.getSqmFunctionRegistry().namedDescriptorBuilder( "parse_date" )
+		functionContributions.getFunctionRegistry().namedDescriptorBuilder( "parse_date" )
 				.setInvariantType( dateType )
 				.setExactArgumentCount( 2 )
 				.register();
-		queryEngine.getSqmFunctionRegistry().namedDescriptorBuilder( "unix_date" )
+		functionContributions.getFunctionRegistry().namedDescriptorBuilder( "unix_date" )
 				.setInvariantType( longType )
 				.setExactArgumentCount( 1 )
 				.register();
 
 		// Timestamp functions
-		queryEngine.getSqmFunctionRegistry().namedDescriptorBuilder( "string" )
+		functionContributions.getFunctionRegistry().namedDescriptorBuilder( "string" )
 				.setInvariantType( stringType )
 				.setArgumentCountBetween( 1, 2 )
 				.register();
-		queryEngine.getSqmFunctionRegistry().namedDescriptorBuilder( "timestamp" )
+		functionContributions.getFunctionRegistry().namedDescriptorBuilder( "timestamp" )
 				.setInvariantType( timestampType )
 				.setArgumentCountBetween( 1, 2 )
 				.register();
-		queryEngine.getSqmFunctionRegistry().namedDescriptorBuilder( "timestamp_add" )
+		functionContributions.getFunctionRegistry().namedDescriptorBuilder( "timestamp_add" )
 				.setInvariantType( timestampType )
 				.setExactArgumentCount( 2 )
 				.register();
-		queryEngine.getSqmFunctionRegistry().namedDescriptorBuilder( "timestamp_sub" )
+		functionContributions.getFunctionRegistry().namedDescriptorBuilder( "timestamp_sub" )
 				.setInvariantType( timestampType )
 				.setExactArgumentCount( 2 )
 				.register();
-		queryEngine.getSqmFunctionRegistry().namedDescriptorBuilder( "timestamp_diff" )
+		functionContributions.getFunctionRegistry().namedDescriptorBuilder( "timestamp_diff" )
 				.setInvariantType( longType )
 				.setExactArgumentCount( 3 )
 				.register();
-		queryEngine.getSqmFunctionRegistry().namedDescriptorBuilder( "timestamp_trunc" )
+		functionContributions.getFunctionRegistry().namedDescriptorBuilder( "timestamp_trunc" )
 				.setInvariantType( timestampType )
 				.setArgumentCountBetween( 2, 3 )
 				.register();
-		queryEngine.getSqmFunctionRegistry().namedDescriptorBuilder( "format_timestamp" )
+		functionContributions.getFunctionRegistry().namedDescriptorBuilder( "format_timestamp" )
 				.setInvariantType( stringType )
 				.setArgumentCountBetween( 2, 3 )
 				.register();
-		queryEngine.getSqmFunctionRegistry().namedDescriptorBuilder( "parse_timestamp" )
+		functionContributions.getFunctionRegistry().namedDescriptorBuilder( "parse_timestamp" )
 				.setInvariantType( timestampType )
 				.setArgumentCountBetween( 2, 3 )
 				.register();
-		queryEngine.getSqmFunctionRegistry().namedDescriptorBuilder( "timestamp_seconds" )
+		functionContributions.getFunctionRegistry().namedDescriptorBuilder( "timestamp_seconds" )
 				.setInvariantType( timestampType )
 				.setExactArgumentCount( 1 )
 				.register();
-		queryEngine.getSqmFunctionRegistry().namedDescriptorBuilder( "timestamp_millis" )
+		functionContributions.getFunctionRegistry().namedDescriptorBuilder( "timestamp_millis" )
 				.setInvariantType( timestampType )
 				.setExactArgumentCount( 1 )
 				.register();
-		queryEngine.getSqmFunctionRegistry().namedDescriptorBuilder( "timestamp_micros" )
+		functionContributions.getFunctionRegistry().namedDescriptorBuilder( "timestamp_micros" )
 				.setInvariantType( timestampType )
 				.setExactArgumentCount( 1 )
 				.register();
-		queryEngine.getSqmFunctionRegistry().namedDescriptorBuilder( "unix_seconds" )
+		functionContributions.getFunctionRegistry().namedDescriptorBuilder( "unix_seconds" )
 				.setInvariantType( longType )
 				.setExactArgumentCount( 1 )
 				.register();
-		queryEngine.getSqmFunctionRegistry().namedDescriptorBuilder( "unix_millis" )
+		functionContributions.getFunctionRegistry().namedDescriptorBuilder( "unix_millis" )
 				.setInvariantType( longType )
 				.setExactArgumentCount( 1 )
 				.register();
-		queryEngine.getSqmFunctionRegistry().namedDescriptorBuilder( "unix_micros" )
+		functionContributions.getFunctionRegistry().namedDescriptorBuilder( "unix_micros" )
 				.setInvariantType( longType )
 				.setExactArgumentCount( 1 )
 				.register();
 
-		queryEngine.getSqmFunctionRegistry().register(
+		functionContributions.getFunctionRegistry().register(
 				"format",
-				new FormatFunction( "format_timestamp", true, true, queryEngine.getTypeConfiguration() )
+				new FormatFunction( "format_timestamp", true, true, functionContributions.getTypeConfiguration() )
 		);
 		functionFactory.listagg_stringAgg( "string" );
 		functionFactory.inverseDistributionOrderedSetAggregates();

--- a/hibernate-core/src/main/java/org/hibernate/dialect/SybaseDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/SybaseDialect.java
@@ -10,6 +10,7 @@ import java.sql.DatabaseMetaData;
 import java.sql.SQLException;
 import java.sql.Types;
 
+import org.hibernate.boot.model.FunctionContributions;
 import org.hibernate.boot.model.TypeContributions;
 import org.hibernate.dialect.function.CommonFunctionFactory;
 import org.hibernate.dialect.function.CountFunction;
@@ -25,7 +26,6 @@ import org.hibernate.engine.spi.LoadQueryInfluencers;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.procedure.internal.JTDSCallableStatementSupport;
 import org.hibernate.procedure.spi.CallableStatementSupport;
-import org.hibernate.query.spi.QueryEngine;
 import org.hibernate.query.spi.QueryOptions;
 import org.hibernate.query.spi.QueryParameterBindings;
 import org.hibernate.query.sqm.CastType;
@@ -209,10 +209,10 @@ public class SybaseDialect extends AbstractTransactSQLDialect {
 	}
 
 	@Override
-	public void initializeFunctionRegistry(QueryEngine queryEngine) {
-		super.initializeFunctionRegistry(queryEngine);
+	public void initializeFunctionRegistry(FunctionContributions functionContributions) {
+		super.initializeFunctionRegistry(functionContributions);
 
-		CommonFunctionFactory functionFactory = new CommonFunctionFactory(queryEngine);
+		CommonFunctionFactory functionFactory = new CommonFunctionFactory(functionContributions);
 
 		functionFactory.stddev();
 		functionFactory.variance();
@@ -224,11 +224,11 @@ public class SybaseDialect extends AbstractTransactSQLDialect {
 		functionFactory.round_round();
 
 		// For SQL-Server we need to cast certain arguments to varchar(16384) to be able to concat them
-		queryEngine.getSqmFunctionRegistry().register(
+		functionContributions.getFunctionRegistry().register(
 				"count",
 				new CountFunction(
 						this,
-						queryEngine.getTypeConfiguration(),
+						functionContributions.getTypeConfiguration(),
 						SqlAstNodeRenderingMode.DEFAULT,
 						"count_big",
 						"+",
@@ -250,8 +250,8 @@ public class SybaseDialect extends AbstractTransactSQLDialect {
 		functionFactory.octetLength_pattern( "datalength(?1)" );
 		functionFactory.bitLength_pattern( "datalength(?1)*8" );
 
-		queryEngine.getSqmFunctionRegistry().register( "timestampadd",
-				new IntegralTimestampaddFunction( this, queryEngine.getTypeConfiguration() ) );
+		functionContributions.getFunctionRegistry().register( "timestampadd",
+				new IntegralTimestampaddFunction( this, functionContributions.getTypeConfiguration() ) );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/dialect/function/ChrLiteralEmulation.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/function/ChrLiteralEmulation.java
@@ -10,7 +10,6 @@ import java.util.List;
 import java.util.Locale;
 
 import org.hibernate.QueryException;
-import org.hibernate.metamodel.MappingMetamodel;
 import org.hibernate.query.sqm.function.AbstractSqmSelfRenderingFunctionDescriptor;
 import org.hibernate.query.sqm.produce.function.ArgumentTypesValidator;
 import org.hibernate.query.sqm.produce.function.ArgumentsValidator;
@@ -43,7 +42,7 @@ public class ChrLiteralEmulation extends AbstractSqmSelfRenderingFunctionDescrip
 								StandardArgumentsValidators.exactly(1),
 								new ArgumentsValidator() {
 									@Override
-									public void validate(List<? extends SqmTypedNode<?>> arguments, String functionName, MappingMetamodel metamodel) {
+									public void validate(List<? extends SqmTypedNode<?>> arguments, String functionName, TypeConfiguration typeConfiguration) {
 										if ( !( arguments.get( 0 ) instanceof SqmLiteral<?> ) ) {
 											throw new QueryException(
 													String.format(

--- a/hibernate-core/src/main/java/org/hibernate/dialect/function/CommonFunctionFactory.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/function/CommonFunctionFactory.java
@@ -9,9 +9,9 @@ package org.hibernate.dialect.function;
 import java.util.Date;
 import java.util.Arrays;
 
+import org.hibernate.boot.model.FunctionContributions;
 import org.hibernate.dialect.Dialect;
 
-import org.hibernate.query.spi.QueryEngine;
 import org.hibernate.query.sqm.function.SqmFunctionRegistry;
 import org.hibernate.query.sqm.produce.function.StandardFunctionArgumentTypeResolvers;
 import org.hibernate.sql.ast.SqlAstNodeRenderingMode;
@@ -45,9 +45,9 @@ public class CommonFunctionFactory {
 	private final SqmFunctionRegistry functionRegistry;
 	private final TypeConfiguration typeConfiguration;
 
-	public CommonFunctionFactory(QueryEngine queryEngine) {
-		functionRegistry = queryEngine.getSqmFunctionRegistry();
-		typeConfiguration = queryEngine.getTypeConfiguration();
+	public CommonFunctionFactory(FunctionContributions functionContributions) {
+		functionRegistry = functionContributions.getFunctionRegistry();
+		typeConfiguration = functionContributions.getTypeConfiguration();
 
 		BasicTypeRegistry basicTypeRegistry = typeConfiguration.getBasicTypeRegistry();
 		dateType = basicTypeRegistry.resolve(StandardBasicTypes.DATE);

--- a/hibernate-core/src/main/java/org/hibernate/engine/spi/SessionFactoryDelegatingImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/spi/SessionFactoryDelegatingImpl.java
@@ -349,12 +349,12 @@ public class SessionFactoryDelegatingImpl implements SessionFactoryImplementor, 
 		return delegate.isOpen();
 	}
 
-	@Override
+	@Override @Deprecated
 	public <T> BindableType<? extends T> resolveParameterBindType(T bindValue) {
 		return delegate.resolveParameterBindType( bindValue );
 	}
 
-	@Override
+	@Override @Deprecated
 	public <T> BindableType<T> resolveParameterBindType(Class<T> clazz) {
 		return delegate.resolveParameterBindType( clazz );
 	}

--- a/hibernate-core/src/main/java/org/hibernate/engine/spi/SessionFactoryImplementor.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/spi/SessionFactoryImplementor.java
@@ -25,6 +25,7 @@ import org.hibernate.metamodel.spi.MappingMetamodelImplementor;
 import org.hibernate.metamodel.spi.MetamodelImplementor;
 import org.hibernate.metamodel.spi.RuntimeMetamodelsImplementor;
 import org.hibernate.proxy.EntityNotFoundDelegate;
+import org.hibernate.query.BindableType;
 import org.hibernate.query.criteria.HibernateCriteriaBuilder;
 import org.hibernate.query.spi.QueryEngine;
 import org.hibernate.query.spi.QueryParameterBindingTypeResolver;
@@ -47,7 +48,8 @@ import org.hibernate.type.spi.TypeConfiguration;
  * @author Steve Ebersole
  */
 public interface SessionFactoryImplementor
-		extends Mapping, SessionFactory, SqmCreationContext, SqlAstCreationContext, QueryParameterBindingTypeResolver {
+		extends Mapping, SessionFactory, SqmCreationContext, SqlAstCreationContext,
+				QueryParameterBindingTypeResolver { //deprecated extension, use MappingMetamodel
 	/**
 	 * Get the UUID for this SessionFactory.
 	 * <p>
@@ -204,5 +206,17 @@ public interface SessionFactoryImplementor
 	 * The best guess entity name for an entity not in an association
 	 */
 	String bestGuessEntityName(Object object);
+
+	/**
+	 * @deprecated Use {@link #getMappingMetamodel()}.{@link MappingMetamodelImplementor#resolveParameterBindType(Object)}
+	 */
+	@Deprecated(since = "6.2", forRemoval = true)
+	<T> BindableType<? extends T> resolveParameterBindType(T bindValue);
+
+	/**
+	 * @deprecated Use {@link #getMappingMetamodel()}.{@link MappingMetamodelImplementor#resolveParameterBindType(Class)}
+	 */
+	@Deprecated(since = "6.2", forRemoval = true)
+	<T> BindableType<T> resolveParameterBindType(Class<T> clazz);
 
 }

--- a/hibernate-core/src/main/java/org/hibernate/internal/QueryParameterBindingTypeResolverImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/QueryParameterBindingTypeResolverImpl.java
@@ -1,0 +1,63 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.internal;
+
+import org.hibernate.proxy.LazyInitializer;
+import org.hibernate.query.BindableType;
+import org.hibernate.query.spi.QueryParameterBindingTypeResolver;
+
+import java.io.Serializable;
+
+import static org.hibernate.proxy.HibernateProxy.extractLazyInitializer;
+
+/**
+ * @implNote This code was originally in {@link SessionFactoryImpl}, but has been factored out so that it
+ *           can be shared by {@link org.hibernate.metamodel.model.domain.internal.MappingMetamodelImpl},
+ *           which is where it really belongs, IMO. Eventually, we can kill off the subtyping relationship
+ *           between {@link SessionFactoryImpl} and {@link QueryParameterBindingTypeResolver}, and then
+ *           get rid of this class.
+ *
+ * @author Gavin King
+ *
+ * @since 6.2
+ */
+public abstract class QueryParameterBindingTypeResolverImpl implements QueryParameterBindingTypeResolver {
+
+	@Override
+	public <T> BindableType<T> resolveParameterBindType(Class<T> javaType) {
+		return getMappingMetamodel().resolveQueryParameterType( javaType );
+	}
+
+	@Override
+	public <T> BindableType<? extends T> resolveParameterBindType(T bindValue) {
+		if ( bindValue == null ) {
+			// we can't guess
+			return null;
+		}
+
+		final LazyInitializer lazyInitializer = extractLazyInitializer( bindValue );
+		final Class<?> clazz = lazyInitializer != null ? lazyInitializer.getPersistentClass() : bindValue.getClass();
+
+		// Resolve superclass bindable type if necessary, as we don't register types for e.g. Inet4Address
+		Class<?> c = clazz;
+		do {
+			final BindableType<?> type = resolveParameterBindType( c );
+			if ( type != null ) {
+				//noinspection unchecked
+				return (BindableType<? extends T>) type;
+			}
+			c = c.getSuperclass();
+		}
+		while ( c != Object.class );
+		if ( !clazz.isEnum() && Serializable.class.isAssignableFrom( clazz ) ) {
+			//noinspection unchecked
+			return (BindableType<? extends T>) resolveParameterBindType( Serializable.class );
+		}
+		return null;
+	}
+
+}

--- a/hibernate-core/src/main/java/org/hibernate/internal/SessionFactoryImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/SessionFactoryImpl.java
@@ -77,7 +77,6 @@ import org.hibernate.mapping.Collection;
 import org.hibernate.mapping.PersistentClass;
 import org.hibernate.mapping.RootClass;
 import org.hibernate.metadata.CollectionMetadata;
-import org.hibernate.metamodel.MappingMetamodel;
 import org.hibernate.metamodel.internal.RuntimeMetamodelsImpl;
 import org.hibernate.metamodel.model.domain.internal.MappingMetamodelImpl;
 import org.hibernate.metamodel.model.domain.spi.JpaMetamodelImplementor;
@@ -1148,7 +1147,7 @@ public class SessionFactoryImpl implements SessionFactoryImplementor {
 
 	@Override
 	public <T> BindableType<T> resolveParameterBindType(Class<T> javaType) {
-		return getRuntimeMetamodels().getMappingMetamodel().resolveQueryParameterType( javaType );
+		return getMappingMetamodel().resolveQueryParameterType( javaType );
 	}
 
 	/**

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/MappingMetamodel.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/MappingMetamodel.java
@@ -47,10 +47,6 @@ public interface MappingMetamodel {
 			Function<NavigablePath,
 			TableGroup> tableGroupLocator);
 
-	MappingModelExpressible<?> lenientlyResolveMappingExpressible(
-			SqmExpressible<?> sqmExpressible,
-			Function<NavigablePath, TableGroup> tableGroupLocator);
-
 	/**
 	 * Given a Java type, determine the corresponding BindableType to
 	 * use implicitly
@@ -66,11 +62,6 @@ public interface MappingMetamodel {
 	 */
 	void forEachEntityDescriptor(Consumer<EntityPersister> action);
 	Stream<EntityPersister> streamEntityDescriptors();
-
-	/**
-	 * Given a JPA entity domain type, get the associated Hibernate entity descriptor
-	 */
-	EntityPersister resolveEntityDescriptor(EntityDomainType<?> entityDomainType);
 
 	/**
 	 * Get an entity mapping descriptor based on its Hibernate entity-name

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/internal/MappingMetamodelImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/internal/MappingMetamodelImpl.java
@@ -34,6 +34,7 @@ import org.hibernate.graph.RootGraph;
 import org.hibernate.graph.spi.RootGraphImplementor;
 import org.hibernate.internal.EntityManagerMessageLogger;
 import org.hibernate.internal.HEMLogging;
+import org.hibernate.internal.QueryParameterBindingTypeResolverImpl;
 import org.hibernate.internal.util.collections.ArrayHelper;
 import org.hibernate.jpa.spi.JpaCompliance;
 import org.hibernate.mapping.Collection;
@@ -93,7 +94,8 @@ import static org.hibernate.metamodel.internal.JpaStaticMetaModelPopulationSetti
  * @author Emmanuel Bernard
  * @author Andrea Boriero
  */
-public class MappingMetamodelImpl implements MappingMetamodelImplementor, MetamodelImplementor, Serializable {
+public class MappingMetamodelImpl extends QueryParameterBindingTypeResolverImpl
+		implements MappingMetamodelImplementor, MetamodelImplementor, Serializable {
 	// todo : Integrate EntityManagerLogger into CoreMessageLogger
 	private static final EntityManagerMessageLogger log = HEMLogging.messageLogger( MappingMetamodelImpl.class );
 
@@ -359,6 +361,11 @@ public class MappingMetamodelImpl implements MappingMetamodelImplementor, Metamo
 	@Override
 	public TypeConfiguration getTypeConfiguration() {
 		return typeConfiguration;
+	}
+
+	@Override
+	public MappingMetamodel getMappingMetamodel() {
+		return this;
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/internal/MappingMetamodelImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/internal/MappingMetamodelImpl.java
@@ -384,11 +384,6 @@ public class MappingMetamodelImpl extends QueryParameterBindingTypeResolverImpl
 	}
 
 	@Override
-	public EntityPersister resolveEntityDescriptor(EntityDomainType<?> entityDomainType) {
-		throw new UnsupportedOperationException();
-	}
-
-	@Override
 	public EntityPersister getEntityDescriptor(String entityName) {
 		final EntityPersister entityPersister = entityPersisterMap.get( entityName );
 		if ( entityPersister == null ) {
@@ -757,14 +752,10 @@ public class MappingMetamodelImpl extends QueryParameterBindingTypeResolverImpl
 	}
 
 	@Override
-	public MappingModelExpressible<?> lenientlyResolveMappingExpressible(
+	public MappingModelExpressible<?> resolveMappingExpressible(
 			SqmExpressible<?> sqmExpressible,
-			Function<NavigablePath, TableGroup> tableGroupLocator) {
-		return resolveMappingExpressible(sqmExpressible, tableGroupLocator );
-	}
-
-	@Override
-	public MappingModelExpressible<?> resolveMappingExpressible(SqmExpressible<?> sqmExpressible, Function<NavigablePath, TableGroup> tableGroupLocator) {
+			Function<NavigablePath,
+					TableGroup> tableGroupLocator) {
 		if ( sqmExpressible instanceof SqmPath ) {
 			final SqmPath<?> sqmPath = (SqmPath<?>) sqmExpressible;
 			final NavigablePath navigablePath = sqmPath.getNavigablePath();

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/spi/MappingMetamodelImplementor.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/spi/MappingMetamodelImplementor.java
@@ -11,11 +11,12 @@ import java.util.Set;
 
 import org.hibernate.EntityNameResolver;
 import org.hibernate.metamodel.MappingMetamodel;
+import org.hibernate.query.spi.QueryParameterBindingTypeResolver;
 
 /**
  * @author Steve Ebersole
  */
-public interface MappingMetamodelImplementor extends MappingMetamodel {
+public interface MappingMetamodelImplementor extends MappingMetamodel, QueryParameterBindingTypeResolver {
 
 	/**
 	 * Retrieves a set of all the collection roles in which the given entity is a participant, as either an
@@ -32,7 +33,5 @@ public interface MappingMetamodelImplementor extends MappingMetamodel {
 	 * use for determining the entity descriptor from an instance of an entity
 	 */
 	Collection<EntityNameResolver> getEntityNameResolvers();
-
-
 
 }

--- a/hibernate-core/src/main/java/org/hibernate/procedure/internal/ProcedureCallImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/procedure/internal/ProcedureCallImpl.java
@@ -488,7 +488,7 @@ public class ProcedureCallImpl<R>
 
 	@Override
 	public <T> ProcedureParameter<T> registerParameter(int position, Class<T> javaType, ParameterMode mode) {
-		final BindableType<T> parameterType = getSessionFactory().resolveParameterBindType( javaType );
+		final BindableType<T> parameterType = getSessionFactory().getMappingMetamodel().resolveParameterBindType( javaType );
 
 		final ProcedureParameterImpl<T> procedureParameter = new ProcedureParameterImpl<>(
 				position,
@@ -531,7 +531,7 @@ public class ProcedureCallImpl<R>
 
 	@Override
 	public <T> ProcedureParameterImplementor<T> registerParameter(String name, Class<T> javaType, ParameterMode mode) {
-		final BindableType<T> parameterType = getSessionFactory().resolveParameterBindType( javaType );
+		final BindableType<T> parameterType = getSessionFactory().getMappingMetamodel().resolveParameterBindType( javaType );
 
 		final ProcedureParameterImpl<T> parameter = new ProcedureParameterImpl<>(
 				name,

--- a/hibernate-core/src/main/java/org/hibernate/query/internal/QueryParameterBindingImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/internal/QueryParameterBindingImpl.java
@@ -174,7 +174,7 @@ public class QueryParameterBindingImpl<T> implements QueryParameterBinding<T>, J
 
 		if ( bindType == null ) {
 			if ( value != null ) {
-				this.bindType = sessionFactory.resolveParameterBindType( value );
+				this.bindType = sessionFactory.getMappingMetamodel().resolveParameterBindType( value );
 			}
 		}
 	}
@@ -267,7 +267,7 @@ public class QueryParameterBindingImpl<T> implements QueryParameterBinding<T>, J
 		}
 
 		if ( bindType == null && value != null ) {
-			this.bindType = sessionFactory.resolveParameterBindType( value );
+			this.bindType = sessionFactory.getMappingMetamodel().resolveParameterBindType( value );
 		}
 
 	}

--- a/hibernate-core/src/main/java/org/hibernate/query/spi/AbstractCommonQueryContract.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/spi/AbstractCommonQueryContract.java
@@ -1429,7 +1429,7 @@ public abstract class AbstractCommonQueryContract implements CommonQueryContract
 			type = getParameterMetadata().getQueryParameter( namedParam ).getHibernateType();
 		}
 		if ( type == null && retType != null ) {
-			type = getSession().getFactory().resolveParameterBindType( retType );
+			type = getSession().getFactory().getMappingMetamodel().resolveParameterBindType( retType );
 		}
 		//noinspection unchecked
 		return (BindableType<Object>) type;

--- a/hibernate-core/src/main/java/org/hibernate/query/spi/QueryEngine.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/spi/QueryEngine.java
@@ -178,27 +178,14 @@ public class QueryEngine implements QueryParameterBindingTypeResolver {
 		this.sqmFunctionRegistry = new SqmFunctionRegistry();
 		this.typeConfiguration = typeConfiguration;
 		this.preferredSqlTypeCodeForBoolean = preferredSqlTypeCodeForBoolean;
-		dialect.initializeFunctionRegistry( this );
+
+		final FunctionContributions functionContributions = new FunctionContributionsImpl( serviceRegistry );
+
+		dialect.initializeFunctionRegistry( functionContributions );
 		if ( userDefinedRegistry != null ) {
 			userDefinedRegistry.overlay( sqmFunctionRegistry );
 		}
 
-		final FunctionContributions functionContributions = new FunctionContributions() {
-			@Override
-			public TypeConfiguration getTypeConfiguration() {
-				return typeConfiguration;
-			}
-
-			@Override
-			public SqmFunctionRegistry getFunctionRegistry() {
-				return sqmFunctionRegistry;
-			}
-
-			@Override
-			public ServiceRegistry getServiceRegistry() {
-				return serviceRegistry;
-			}
-		};
 		for ( FunctionContributor contributor : sortedFunctionContributors( serviceRegistry ) ) {
 			contributor.contributeFunctions( functionContributions );
 		}
@@ -231,7 +218,8 @@ public class QueryEngine implements QueryParameterBindingTypeResolver {
 		this.sqmFunctionRegistry = new SqmFunctionRegistry();
 		this.typeConfiguration = jpaMetamodel.getTypeConfiguration();
 		this.preferredSqlTypeCodeForBoolean = preferredSqlTypeCodeForBoolean;
-		dialect.initializeFunctionRegistry( this );
+
+		dialect.contributeFunctions( new FunctionContributionsImpl( serviceRegistry ) );
 
 		SessionFactoryImplementor sessionFactory = jpaMetamodel.getTypeConfiguration().getSessionFactory();
 		this.queryParameterBindingTypeResolver = sessionFactory;
@@ -417,6 +405,7 @@ public class QueryEngine implements QueryParameterBindingTypeResolver {
 		return preferredSqlTypeCodeForBoolean;
 	}
 
+
 	@Override
 	public <T> BindableType<? extends T> resolveParameterBindType(T bindValue) {
 		return queryParameterBindingTypeResolver.resolveParameterBindType( bindValue );
@@ -425,5 +414,28 @@ public class QueryEngine implements QueryParameterBindingTypeResolver {
 	@Override
 	public <T> BindableType<T> resolveParameterBindType(Class<T> clazz) {
 		return queryParameterBindingTypeResolver.resolveParameterBindType( clazz );
+	}
+
+	private class FunctionContributionsImpl implements FunctionContributions {
+		private final ServiceRegistry serviceRegistry;
+
+		public FunctionContributionsImpl(ServiceRegistry serviceRegistry) {
+			this.serviceRegistry = serviceRegistry;
+		}
+
+		@Override
+		public TypeConfiguration getTypeConfiguration() {
+			return typeConfiguration;
+		}
+
+		@Override
+		public SqmFunctionRegistry getFunctionRegistry() {
+			return sqmFunctionRegistry;
+		}
+
+		@Override
+		public ServiceRegistry getServiceRegistry() {
+			return serviceRegistry;
+		}
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/query/spi/QueryEngine.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/spi/QueryEngine.java
@@ -18,6 +18,7 @@ import org.hibernate.boot.model.FunctionContributions;
 import org.hibernate.boot.model.FunctionContributor;
 import org.hibernate.boot.registry.classloading.spi.ClassLoaderService;
 import org.hibernate.boot.spi.MetadataImplementor;
+import org.hibernate.boot.spi.SessionFactoryOptions;
 import org.hibernate.cfg.AvailableSettings;
 import org.hibernate.dialect.Dialect;
 import org.hibernate.engine.config.spi.ConfigurationService;
@@ -25,9 +26,7 @@ import org.hibernate.engine.query.spi.NativeQueryInterpreter;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.internal.CoreLogging;
 import org.hibernate.internal.util.config.ConfigurationHelper;
-import org.hibernate.jpa.spi.JpaCompliance;
 import org.hibernate.metamodel.model.domain.spi.JpaMetamodelImplementor;
-import org.hibernate.query.BindableType;
 import org.hibernate.query.criteria.ValueHandlingMode;
 import org.hibernate.query.hql.HqlTranslator;
 import org.hibernate.query.hql.internal.StandardHqlTranslator;
@@ -36,7 +35,6 @@ import org.hibernate.query.internal.QueryInterpretationCacheDisabledImpl;
 import org.hibernate.query.internal.QueryInterpretationCacheStandardImpl;
 import org.hibernate.query.named.NamedObjectRepository;
 import org.hibernate.query.sqm.NodeBuilder;
-import org.hibernate.query.sqm.function.SqmFunctionDescriptor;
 import org.hibernate.query.sqm.function.SqmFunctionRegistry;
 import org.hibernate.query.sqm.internal.SqmCreationOptionsStandard;
 import org.hibernate.query.sqm.internal.SqmCriteriaNodeBuilder;
@@ -58,7 +56,7 @@ import static java.util.Comparator.comparingInt;
  * @author Steve Ebersole
  */
 @Incubating
-public class QueryEngine implements QueryParameterBindingTypeResolver {
+public class QueryEngine {
 
 	/**
 	 * The default soft reference count.
@@ -68,133 +66,86 @@ public class QueryEngine implements QueryParameterBindingTypeResolver {
 	private static final Logger LOG_HQL_FUNCTIONS = CoreLogging.logger( "org.hibernate.HQL_FUNCTIONS" );
 
 	public static QueryEngine from(SessionFactoryImplementor sessionFactory, MetadataImplementor metadata) {
-		final QueryEngineOptions queryEngineOptions = sessionFactory.getSessionFactoryOptions();
+		final QueryEngineOptions options = sessionFactory.getSessionFactoryOptions();
 		final Dialect dialect = sessionFactory.getJdbcServices().getDialect();
 		return new QueryEngine(
 				sessionFactory,
-				resolveHqlTranslator(
-						queryEngineOptions,
-						dialect,
-						sessionFactory,
-						new SqmCreationOptionsStandard( queryEngineOptions )
-				),
-				resolveSqmTranslatorFactory( queryEngineOptions, dialect ),
-				metadata,
-				dialect,
-				buildCustomFunctionRegistry( queryEngineOptions )
-		);
-	}
-
-	private static SqmFunctionRegistry buildCustomFunctionRegistry(QueryEngineOptions queryEngineOptions) {
-		if ( queryEngineOptions.getCustomSqmFunctionRegistry() == null ) {
-			final Map<String, SqmFunctionDescriptor> customSqlFunctionMap = queryEngineOptions.getCustomSqlFunctionMap();
-			if ( customSqlFunctionMap == null || customSqlFunctionMap.isEmpty() ) {
-				return null;
-			}
-			else {
-				SqmFunctionRegistry customSqmFunctionRegistry = new SqmFunctionRegistry();
-				customSqlFunctionMap.forEach( customSqmFunctionRegistry::register );
-				return customSqmFunctionRegistry;
-			}
-		}
-		else {
-			return queryEngineOptions.getCustomSqmFunctionRegistry();
-		}
-	}
-
-	private final NamedObjectRepository namedObjectRepository;
-	private final SqmCriteriaNodeBuilder criteriaBuilder;
-	private final HqlTranslator hqlTranslator;
-	private final SqmTranslatorFactory sqmTranslatorFactory;
-	private final NativeQueryInterpreter nativeQueryInterpreter;
-	private final QueryInterpretationCache interpretationCache;
-	private final SqmFunctionRegistry sqmFunctionRegistry;
-	private final TypeConfiguration typeConfiguration;
-	private final int preferredSqlTypeCodeForBoolean;
-	private final QueryParameterBindingTypeResolver queryParameterBindingTypeResolver;
-
-	private QueryEngine(
-			SessionFactoryImplementor sessionFactory,
-			HqlTranslator hqlTranslator,
-			SqmTranslatorFactory sqmTranslatorFactory,
-			MetadataImplementor metadata,
-			Dialect dialect,
-			SqmFunctionRegistry customFunctionRegistry) {
-		this(
-				sessionFactory.getUuid(),
-				sessionFactory.getName(),
-				sessionFactory.getSessionFactoryOptions().getJpaCompliance(),
-				() -> sessionFactory.getRuntimeMetamodels().getJpaMetamodel(),
-				sessionFactory.getSessionFactoryOptions().getCriteriaValueHandlingMode(),
-				sessionFactory.getSessionFactoryOptions().getPreferredSqlTypeCodeForBoolean(),
-				metadata.buildNamedQueryRepository( sessionFactory ),
-				hqlTranslator,
-				sqmTranslatorFactory,
-				sessionFactory.getServiceRegistry().getService( NativeQueryInterpreter.class ),
-				buildInterpretationCache( sessionFactory::getStatistics, sessionFactory.getProperties() ),
 				metadata.getTypeConfiguration(),
-				dialect,
-				customFunctionRegistry,
-				sessionFactory.getServiceRegistry(),
-				sessionFactory
+				resolveHqlTranslator( options, dialect, sessionFactory, new SqmCreationOptionsStandard( options ) ),
+				resolveSqmTranslatorFactory( options, dialect ),
+				createFunctionRegistry( sessionFactory, metadata, options, dialect ),
+				metadata.buildNamedQueryRepository( sessionFactory ),
+				buildInterpretationCache( sessionFactory::getStatistics, sessionFactory.getProperties() )
 		);
 	}
 
-	private QueryEngine(
-			String uuid,
-			String name,
-			JpaCompliance jpaCompliance,
-			Supplier<JpaMetamodelImplementor> jpaMetamodelAccess,
-			ValueHandlingMode criteriaValueHandlingMode,
-			int preferredSqlTypeCodeForBoolean,
-			NamedObjectRepository namedObjectRepository,
-			HqlTranslator hqlTranslator,
-			SqmTranslatorFactory sqmTranslatorFactory,
-			NativeQueryInterpreter nativeQueryInterpreter,
-			QueryInterpretationCache interpretationCache,
-			TypeConfiguration typeConfiguration,
-			Dialect dialect,
-			SqmFunctionRegistry userDefinedRegistry,
-			ServiceRegistry serviceRegistry,
-			SessionFactoryImplementor sessionFactory) {
-		this.queryParameterBindingTypeResolver = sessionFactory;
-		this.namedObjectRepository = Objects.requireNonNull( namedObjectRepository );
-		this.sqmTranslatorFactory = sqmTranslatorFactory;
-		this.nativeQueryInterpreter = Objects.requireNonNull( nativeQueryInterpreter );
-		this.interpretationCache = interpretationCache;
-		this.hqlTranslator = hqlTranslator;
+	private static SqmFunctionRegistry createFunctionRegistry(
+			SessionFactoryImplementor sessionFactory,
+			MetadataImplementor metadata,
+			QueryEngineOptions queryEngineOptions,
+			Dialect dialect) {
+		final SqmFunctionRegistry sqmFunctionRegistry = new SqmFunctionRegistry();
 
-		this.criteriaBuilder = new SqmCriteriaNodeBuilder(
-				uuid,
-				name,
-				jpaCompliance.isJpaQueryComplianceEnabled(),
-				this,
-				jpaMetamodelAccess,
-				serviceRegistry,
-				criteriaValueHandlingMode,
-				sessionFactory
-		);
+		queryEngineOptions.getCustomSqlFunctionMap().forEach( sqmFunctionRegistry::register );
 
-		this.sqmFunctionRegistry = new SqmFunctionRegistry();
-		this.typeConfiguration = typeConfiguration;
-		this.preferredSqlTypeCodeForBoolean = preferredSqlTypeCodeForBoolean;
-
-		final FunctionContributions functionContributions = new FunctionContributionsImpl( serviceRegistry );
-
-		dialect.initializeFunctionRegistry( functionContributions );
-		if ( userDefinedRegistry != null ) {
-			userDefinedRegistry.overlay( sqmFunctionRegistry );
+		final SqmFunctionRegistry customSqmFunctionRegistry = queryEngineOptions.getCustomSqmFunctionRegistry();
+		if ( customSqmFunctionRegistry != null ) {
+			customSqmFunctionRegistry.overlay( sqmFunctionRegistry );
 		}
 
-		for ( FunctionContributor contributor : sortedFunctionContributors( serviceRegistry ) ) {
+		final FunctionContributions functionContributions = new FunctionContributionsImpl(
+				sessionFactory.getServiceRegistry(),
+				metadata.getTypeConfiguration(),
+				sqmFunctionRegistry
+		);
+		for ( FunctionContributor contributor : sortedFunctionContributors( sessionFactory.getServiceRegistry() ) ) {
 			contributor.contributeFunctions( functionContributions );
 		}
+		dialect.initializeFunctionRegistry( functionContributions );
 
 		if ( LOG_HQL_FUNCTIONS.isDebugEnabled() ) {
 			sqmFunctionRegistry.getFunctionsByName().forEach(
 					entry -> LOG_HQL_FUNCTIONS.debug( entry.getValue().getSignature( entry.getKey() ) )
 			);
 		}
+
+		return sqmFunctionRegistry;
+	}
+
+	private final NamedObjectRepository namedObjectRepository;
+	private final NativeQueryInterpreter nativeQueryInterpreter;
+	private final QueryInterpretationCache interpretationCache;
+	private final SqmCriteriaNodeBuilder criteriaBuilder;
+	private final HqlTranslator hqlTranslator;
+	private final SqmTranslatorFactory sqmTranslatorFactory;
+	private final SqmFunctionRegistry sqmFunctionRegistry;
+	private final TypeConfiguration typeConfiguration;
+
+	private QueryEngine(
+			SessionFactoryImplementor sessionFactory,
+			TypeConfiguration typeConfiguration,
+			HqlTranslator hqlTranslator,
+			SqmTranslatorFactory sqmTranslatorFactory,
+			SqmFunctionRegistry functionRegistry,
+			NamedObjectRepository namedObjectRepository,
+			QueryInterpretationCache interpretationCache) {
+		this.typeConfiguration = typeConfiguration;
+		this.sqmFunctionRegistry = functionRegistry;
+		this.sqmTranslatorFactory = sqmTranslatorFactory;
+		this.hqlTranslator = hqlTranslator;
+		this.namedObjectRepository = namedObjectRepository;
+		this.interpretationCache = interpretationCache;
+		this.nativeQueryInterpreter = sessionFactory.getServiceRegistry().getService( NativeQueryInterpreter.class );
+		final SessionFactoryOptions sessionFactoryOptions = sessionFactory.getSessionFactoryOptions();
+		this.criteriaBuilder = new SqmCriteriaNodeBuilder(
+				sessionFactory.getUuid(),
+				sessionFactory.getName(),
+				this,
+				sessionFactoryOptions.getJpaCompliance().isJpaQueryComplianceEnabled(),
+				sessionFactoryOptions.getCriteriaValueHandlingMode(),
+				sessionFactory.getServiceRegistry(),
+				() -> sessionFactory
+		);
 	}
 
 	/**
@@ -214,62 +165,49 @@ public class QueryEngine implements QueryParameterBindingTypeResolver {
 		this.namedObjectRepository = Objects.requireNonNull( namedObjectRepository );
 		this.sqmTranslatorFactory = null;
 		this.nativeQueryInterpreter = Objects.requireNonNull( nativeQueryInterpreter );
-
 		this.sqmFunctionRegistry = new SqmFunctionRegistry();
 		this.typeConfiguration = jpaMetamodel.getTypeConfiguration();
-		this.preferredSqlTypeCodeForBoolean = preferredSqlTypeCodeForBoolean;
 
-		dialect.contributeFunctions( new FunctionContributionsImpl( serviceRegistry ) );
-
-		SessionFactoryImplementor sessionFactory = jpaMetamodel.getTypeConfiguration().getSessionFactory();
-		this.queryParameterBindingTypeResolver = sessionFactory;
-		this.criteriaBuilder = new SqmCriteriaNodeBuilder(
-				uuid,
-				name,
-				false,
-				this,
-				() -> jpaMetamodel,
-				serviceRegistry,
-				criteriaValueHandlingMode,
-				sessionFactory
-		);
-
-		final SqmCreationContext sqmCreationContext = new SqmCreationContext() {
-			@Override
-			public JpaMetamodelImplementor getJpaMetamodel() {
-				return jpaMetamodel;
-			}
-
-			@Override
-			public ServiceRegistry getServiceRegistry() {
-				return serviceRegistry;
-			}
-
-			@Override
-			public QueryEngine getQueryEngine() {
-				return QueryEngine.this;
-			}
-
-			@Override
-			public NodeBuilder getNodeBuilder() {
-				return criteriaBuilder;
-			}
-		};
-
-		//noinspection Convert2Lambda
-		this.hqlTranslator = new StandardHqlTranslator(
-				sqmCreationContext,
-				new SqmCreationOptions() {
-					@Override
-					public boolean useStrictJpaCompliance() {
-						return useStrictJpaCompliance;
-					}
-				}
-		);
+		dialect.contributeFunctions( new FunctionContributionsImpl( serviceRegistry, typeConfiguration, sqmFunctionRegistry ) );
 
 		this.interpretationCache = buildInterpretationCache(
 				() -> serviceRegistry.getService( StatisticsImplementor.class ),
 				serviceRegistry.getService( ConfigurationService.class ).getSettings()
+		);
+
+		this.criteriaBuilder = new SqmCriteriaNodeBuilder(
+				uuid,
+				name,
+				this,
+				useStrictJpaCompliance,
+				criteriaValueHandlingMode,
+				serviceRegistry,
+				typeConfiguration::getSessionFactory
+		);
+
+		this.hqlTranslator = new StandardHqlTranslator(
+				new SqmCreationContext() {
+					@Override
+					public JpaMetamodelImplementor getJpaMetamodel() {
+						return jpaMetamodel;
+					}
+
+					@Override
+					public ServiceRegistry getServiceRegistry() {
+						return serviceRegistry;
+					}
+
+					@Override
+					public QueryEngine getQueryEngine() {
+						return QueryEngine.this;
+					}
+
+					@Override
+					public NodeBuilder getNodeBuilder() {
+						return criteriaBuilder;
+					}
+				},
+				() -> useStrictJpaCompliance
 		);
 	}
 
@@ -401,26 +339,19 @@ public class QueryEngine implements QueryParameterBindingTypeResolver {
 		}
 	}
 
-	public int getPreferredSqlTypeCodeForBoolean() {
-		return preferredSqlTypeCodeForBoolean;
-	}
 
-
-	@Override
-	public <T> BindableType<? extends T> resolveParameterBindType(T bindValue) {
-		return queryParameterBindingTypeResolver.resolveParameterBindType( bindValue );
-	}
-
-	@Override
-	public <T> BindableType<T> resolveParameterBindType(Class<T> clazz) {
-		return queryParameterBindingTypeResolver.resolveParameterBindType( clazz );
-	}
-
-	private class FunctionContributionsImpl implements FunctionContributions {
+	private static class FunctionContributionsImpl implements FunctionContributions {
 		private final ServiceRegistry serviceRegistry;
+		private final TypeConfiguration typeConfiguration;
+		private final SqmFunctionRegistry functionRegistry;
 
-		public FunctionContributionsImpl(ServiceRegistry serviceRegistry) {
+		public FunctionContributionsImpl(
+				ServiceRegistry serviceRegistry,
+				TypeConfiguration typeConfiguration,
+				SqmFunctionRegistry functionRegistry) {
 			this.serviceRegistry = serviceRegistry;
+			this.typeConfiguration = typeConfiguration;
+			this.functionRegistry = functionRegistry;
 		}
 
 		@Override
@@ -430,7 +361,7 @@ public class QueryEngine implements QueryParameterBindingTypeResolver {
 
 		@Override
 		public SqmFunctionRegistry getFunctionRegistry() {
-			return sqmFunctionRegistry;
+			return functionRegistry;
 		}
 
 		@Override

--- a/hibernate-core/src/main/java/org/hibernate/query/spi/QueryEngineOptions.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/spi/QueryEngineOptions.java
@@ -9,6 +9,7 @@ package org.hibernate.query.spi;
 import java.util.Map;
 
 import org.hibernate.jpa.spi.JpaCompliance;
+import org.hibernate.query.criteria.ValueHandlingMode;
 import org.hibernate.query.hql.HqlTranslator;
 import org.hibernate.query.sqm.function.SqmFunctionDescriptor;
 import org.hibernate.query.sqm.function.SqmFunctionRegistry;
@@ -69,4 +70,6 @@ public interface QueryEngineOptions {
 	SqmMultiTableInsertStrategy getCustomSqmMultiTableInsertStrategy();
 
 	JpaCompliance getJpaCompliance();
+
+	ValueHandlingMode getCriteriaValueHandlingMode();
 }

--- a/hibernate-core/src/main/java/org/hibernate/query/spi/QueryParameterBindingTypeResolver.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/spi/QueryParameterBindingTypeResolver.java
@@ -6,12 +6,17 @@
  */
 package org.hibernate.query.spi;
 
+import org.hibernate.metamodel.MappingMetamodel;
 import org.hibernate.query.BindableType;
 import org.hibernate.type.spi.TypeConfiguration;
 
 /**
- * A resolver for Type based on a parameter value being bound, when no
- * explicit type information is supplied.
+ * A resolver for {@link BindableType} based on a parameter value being bound, when no explicit type information is
+ * supplied.
+ *
+ * @apiNote This interface was originally a supertype of {@link org.hibernate.engine.spi.SessionFactoryImplementor},
+ *          but this is now a deprecated relationship. Its functionality should now be accessed via its new subtype
+ *          {@link org.hibernate.metamodel.spi.MappingMetamodelImplementor}.
  *
  * @author Steve Ebersole
  */
@@ -19,4 +24,5 @@ public interface QueryParameterBindingTypeResolver {
 	<T> BindableType<? extends T> resolveParameterBindType(T bindValue);
 	<T> BindableType<T> resolveParameterBindType(Class<T> clazz);
 	TypeConfiguration getTypeConfiguration();
+	MappingMetamodel getMappingMetamodel();
 }

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/NodeBuilder.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/NodeBuilder.java
@@ -74,9 +74,7 @@ import jakarta.persistence.criteria.Subquery;
 public interface NodeBuilder extends HibernateCriteriaBuilder {
 	JpaMetamodel getDomainModel();
 
-	default TypeConfiguration getTypeConfiguration() {
-		return getDomainModel().getTypeConfiguration();
-	}
+	TypeConfiguration getTypeConfiguration();
 
 	boolean isJpaQueryComplianceEnabled();
 

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/function/AbstractSqmFunctionDescriptor.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/function/AbstractSqmFunctionDescriptor.java
@@ -101,7 +101,7 @@ public abstract class AbstractSqmFunctionDescriptor implements SqmFunctionDescri
 			ReturnableType<T> impliedResultType,
 			QueryEngine queryEngine,
 			TypeConfiguration typeConfiguration) {
-		argumentsValidator.validate( arguments, getName(), queryEngine);
+		argumentsValidator.validate( arguments, getName(), typeConfiguration );
 
 		return generateSqmFunctionExpression(
 				arguments,
@@ -118,7 +118,7 @@ public abstract class AbstractSqmFunctionDescriptor implements SqmFunctionDescri
 			ReturnableType<T> impliedResultType,
 			QueryEngine queryEngine,
 			TypeConfiguration typeConfiguration) {
-		argumentsValidator.validate( arguments, getName(), queryEngine );
+		argumentsValidator.validate( arguments, getName(), typeConfiguration );
 
 		return generateSqmAggregateFunctionExpression(
 				arguments,
@@ -137,7 +137,7 @@ public abstract class AbstractSqmFunctionDescriptor implements SqmFunctionDescri
 			ReturnableType<T> impliedResultType,
 			QueryEngine queryEngine,
 			TypeConfiguration typeConfiguration) {
-		argumentsValidator.validate( arguments, getName(), queryEngine );
+		argumentsValidator.validate( arguments, getName(), typeConfiguration );
 
 		return generateSqmOrderedSetAggregateFunctionExpression(
 				arguments,
@@ -158,7 +158,7 @@ public abstract class AbstractSqmFunctionDescriptor implements SqmFunctionDescri
 			ReturnableType<T> impliedResultType,
 			QueryEngine queryEngine,
 			TypeConfiguration typeConfiguration) {
-		argumentsValidator.validate( arguments, getName(), queryEngine );
+		argumentsValidator.validate( arguments, getName(), typeConfiguration );
 
 		return generateSqmWindowFunctionExpression(
 				arguments,
@@ -233,7 +233,8 @@ public abstract class AbstractSqmFunctionDescriptor implements SqmFunctionDescri
 	 * Return an SQM node or subtree representing an invocation of this window function
 	 * with the given arguments. This method may be overridden in the case of
 	 * function descriptors that wish to customize creation of the node.
-	 *  @param arguments the arguments of the function invocation
+	 *
+	 * @param arguments the arguments of the function invocation
 	 * @param respectNulls
 	 * @param fromFirst
 	 * @param impliedResultType the function return type as inferred from its usage

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/internal/SqmCriteriaNodeBuilder.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/internal/SqmCriteriaNodeBuilder.java
@@ -43,6 +43,7 @@ import org.hibernate.metamodel.model.domain.BasicDomainType;
 import org.hibernate.metamodel.model.domain.DomainType;
 import org.hibernate.metamodel.model.domain.JpaMetamodel;
 import org.hibernate.metamodel.model.domain.spi.JpaMetamodelImplementor;
+import org.hibernate.metamodel.spi.MappingMetamodelImplementor;
 import org.hibernate.query.BindableType;
 import org.hibernate.query.ReturnableType;
 import org.hibernate.query.SemanticException;
@@ -180,35 +181,31 @@ public class SqmCriteriaNodeBuilder implements NodeBuilder, SqmCreationContext, 
 	private final String name;
 	private final transient boolean jpaComplianceEnabled;
 	private final transient QueryEngine queryEngine;
-	private final transient Supplier<JpaMetamodelImplementor> domainModelAccess;
 	private final transient ServiceRegistry serviceRegistry;
+	private final transient Supplier<SessionFactoryImplementor> sessionFactory;
 	private final transient ValueHandlingMode criteriaValueHandlingMode;
-	private final transient SessionFactoryImplementor sessionFactory;
 	private transient BasicType<Boolean> booleanType;
 	private transient BasicType<Integer> integerType;
 	private transient BasicType<Character> characterType;
 	private final transient Map<Class<? extends HibernateCriteriaBuilder>, HibernateCriteriaBuilder> extensions;
 
 	public SqmCriteriaNodeBuilder(
-			String uuid,
-			String name,
-			boolean jpaComplianceEnabled,
+			String uuid, String name,
 			QueryEngine queryEngine,
-			Supplier<JpaMetamodelImplementor> domainModelAccess,
-			ServiceRegistry serviceRegistry,
+			boolean jpaComplianceEnabled,
 			ValueHandlingMode criteriaValueHandlingMode,
-			SessionFactoryImplementor sessionFactory) {
+			ServiceRegistry serviceRegistry,
+			Supplier<SessionFactoryImplementor> sessionFactory) {
+		this.serviceRegistry = serviceRegistry;
 		this.sessionFactory = sessionFactory;
+		this.queryEngine = queryEngine;
 		this.uuid = uuid;
 		this.name = name;
 		this.jpaComplianceEnabled = jpaComplianceEnabled;
-		this.queryEngine = queryEngine;
-		this.domainModelAccess = domainModelAccess;
-		this.serviceRegistry = serviceRegistry;
 		this.criteriaValueHandlingMode = criteriaValueHandlingMode;
 		// load registered criteria builder extensions
 		this.extensions = new HashMap<>();
-		for (CriteriaBuilderExtension extension : ServiceLoader.load( CriteriaBuilderExtension.class ) ) {
+		for ( CriteriaBuilderExtension extension : ServiceLoader.load( CriteriaBuilderExtension.class ) ) {
 			HibernateCriteriaBuilder builder = extension.extend( this );
 			extensions.put( extension.getRegistrationKey(), builder );
 		}
@@ -216,7 +213,7 @@ public class SqmCriteriaNodeBuilder implements NodeBuilder, SqmCreationContext, 
 
 	@Override
 	public JpaMetamodel getDomainModel() {
-		return domainModelAccess.get();
+		return getSessionFactory().getJpaMetamodel();
 	}
 
 	@Override
@@ -226,7 +223,7 @@ public class SqmCriteriaNodeBuilder implements NodeBuilder, SqmCreationContext, 
 
 	@Override
 	public SessionFactoryImplementor getSessionFactory() {
-		return sessionFactory;
+		return sessionFactory.get();
 	}
 
 	@Override
@@ -269,7 +266,7 @@ public class SqmCriteriaNodeBuilder implements NodeBuilder, SqmCreationContext, 
 
 	@Override
 	public JpaMetamodelImplementor getJpaMetamodel() {
-		return domainModelAccess.get();
+		return getSessionFactory().getJpaMetamodel();
 	}
 
 	public void close() {
@@ -616,7 +613,7 @@ public class SqmCriteriaNodeBuilder implements NodeBuilder, SqmCreationContext, 
 			expressibleType = (DomainType<R>) typeConfiguration.resolveTupleType( sqmExpressions );
 		}
 		else {
-			expressibleType = domainModelAccess.get().embeddable( tupleType );
+			expressibleType = getDomainModel().embeddable( tupleType );
 		}
 		return tuple( expressibleType, sqmExpressions );
 	}
@@ -1187,12 +1184,16 @@ public class SqmCriteriaNodeBuilder implements NodeBuilder, SqmCreationContext, 
 			return new SqmLiteralNull<>( this );
 		}
 
-		final BindableType<? extends T> valueParamType = queryEngine.resolveParameterBindType( value );
+		final BindableType<? extends T> valueParamType = getMappingMetamodel().resolveParameterBindType( value );
 		final SqmExpressible<? extends T> sqmExpressible = valueParamType == null
 				? null
-				: valueParamType.resolveExpressible( sessionFactory );
+				: valueParamType.resolveExpressible( getSessionFactory() );
 
 		return new SqmLiteral<>( value, sqmExpressible, this );
+	}
+
+	private MappingMetamodelImplementor getMappingMetamodel() {
+		return getSessionFactory().getMappingMetamodel();
 	}
 
 	@Override
@@ -1226,7 +1227,7 @@ public class SqmCriteriaNodeBuilder implements NodeBuilder, SqmCreationContext, 
 		final TypeConfiguration typeConfiguration = getTypeConfiguration();
 		final BasicType<T> basicTypeForJavaType = typeConfiguration.getBasicTypeForJavaType( resultClass );
 		final SqmExpressible<T> sqmExpressible = basicTypeForJavaType == null
-				? domainModelAccess.get().managedType( resultClass )
+				? getDomainModel().managedType( resultClass )
 				: basicTypeForJavaType;
 		return new SqmLiteralNull<>(sqmExpressible, this );
 	}
@@ -1235,10 +1236,7 @@ public class SqmCriteriaNodeBuilder implements NodeBuilder, SqmCreationContext, 
 		private final JavaType<T> javaType;
 
 		public MultiValueParameterType(Class<T> type) {
-			this.javaType = domainModelAccess.get()
-					.getTypeConfiguration()
-					.getJavaTypeRegistry()
-					.getDescriptor( type );
+			this.javaType = getTypeConfiguration().getJavaTypeRegistry().getDescriptor( type );
 		}
 
 		@Override
@@ -1718,7 +1716,7 @@ public class SqmCriteriaNodeBuilder implements NodeBuilder, SqmCreationContext, 
 					this
 			);
 		}
-		final SqmExpressible<T> expressible = bindableType.resolveExpressible( sessionFactory );
+		final SqmExpressible<T> expressible = bindableType.resolveExpressible( getSessionFactory() );
 		T coercedValue = expressible.getExpressibleJavaType().coerce( value, this::getTypeConfiguration );
 		if ( isInstance( bindableType, coercedValue ) ) {
 			return new ValueBindJpaCriteriaParameter<>(
@@ -1730,7 +1728,7 @@ public class SqmCriteriaNodeBuilder implements NodeBuilder, SqmCreationContext, 
 		else {
 			// ignore typeInferenceSource and fallback the value type
 			return new ValueBindJpaCriteriaParameter<>(
-					queryEngine.resolveParameterBindType( value ),
+					getMappingMetamodel().resolveParameterBindType( value ),
 					value,
 					this
 			);
@@ -1744,7 +1742,7 @@ public class SqmCriteriaNodeBuilder implements NodeBuilder, SqmCreationContext, 
 		if ( bindableType.getBindableJavaType().isInstance( value ) ) {
 			return true;
 		}
-		return bindableType.resolveExpressible( sessionFactory )
+		return bindableType.resolveExpressible( getSessionFactory() )
 				.getExpressibleJavaType()
 				.isInstance( value );
 	}
@@ -1783,7 +1781,7 @@ public class SqmCriteriaNodeBuilder implements NodeBuilder, SqmCreationContext, 
 		}
 		else {
 			return new ValueBindJpaCriteriaParameter<>(
-					queryEngine.resolveParameterBindType( value ),
+					getMappingMetamodel().resolveParameterBindType( value ),
 					value,
 					this
 			);

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/internal/SqmCriteriaNodeBuilder.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/internal/SqmCriteriaNodeBuilder.java
@@ -217,6 +217,11 @@ public class SqmCriteriaNodeBuilder implements NodeBuilder, SqmCreationContext, 
 	}
 
 	@Override
+	public TypeConfiguration getTypeConfiguration() {
+		return queryEngine.getTypeConfiguration();
+	}
+
+	@Override
 	public boolean isJpaQueryComplianceEnabled() {
 		return jpaComplianceEnabled;
 	}

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/produce/function/ArgumentsValidator.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/produce/function/ArgumentsValidator.java
@@ -6,10 +6,10 @@
  */
 package org.hibernate.query.sqm.produce.function;
 
-import org.hibernate.metamodel.MappingMetamodel;
 import org.hibernate.query.spi.QueryEngine;
 import org.hibernate.query.sqm.tree.SqmTypedNode;
 import org.hibernate.sql.ast.tree.SqlAstNode;
+import org.hibernate.type.spi.TypeConfiguration;
 
 import java.util.List;
 
@@ -25,17 +25,17 @@ public interface ArgumentsValidator {
 	/**
 	 * Perform validation that may be done using the {@link SqmTypedNode} tree and assigned Java types.
 	 *
-	 * @deprecated Use {@link #validate(List, String, MappingMetamodel)}
+	 * @deprecated Use {@link #validate(List, String, TypeConfiguration)}
 	 */
 	@Deprecated(since = "6.2")
 	default void validate(List<? extends SqmTypedNode<?>> arguments, String functionName, QueryEngine queryEngine) {
-		validate( arguments, functionName, queryEngine.getTypeConfiguration().getSessionFactory().getMappingMetamodel() );
+		validate( arguments, functionName, queryEngine.getTypeConfiguration() );
 	}
 
 	/**
 	 * Perform validation that may be done using the {@link SqmTypedNode} tree and assigned Java types.
 	 */
-	default void validate(List<? extends SqmTypedNode<?>> arguments, String functionName, MappingMetamodel metamodel) {}
+	default void validate(List<? extends SqmTypedNode<?>> arguments, String functionName, TypeConfiguration typeConfiguration) {}
 
 	/**
 	 * Pretty-print the signature of the argument list.

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/produce/function/StandardArgumentsValidators.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/produce/function/StandardArgumentsValidators.java
@@ -7,8 +7,8 @@
 package org.hibernate.query.sqm.produce.function;
 
 import org.hibernate.QueryException;
-import org.hibernate.metamodel.MappingMetamodel;
 import org.hibernate.query.sqm.tree.SqmTypedNode;
+import org.hibernate.type.spi.TypeConfiguration;
 
 import java.util.List;
 import java.util.Locale;
@@ -43,7 +43,7 @@ public final class StandardArgumentsValidators {
 		public void validate(
 				List<? extends SqmTypedNode<?>> arguments,
 				String functionName,
-				MappingMetamodel metamodel) {
+				TypeConfiguration typeConfiguration) {
 			if ( !arguments.isEmpty() ) {
 				throw new QueryException(
 						String.format(
@@ -71,7 +71,7 @@ public final class StandardArgumentsValidators {
 			public void validate(
 					List<? extends SqmTypedNode<?>> arguments,
 					String functionName,
-					MappingMetamodel metamodel) {
+					TypeConfiguration typeConfiguration) {
 				if ( arguments.size() < minNumOfArgs ) {
 					throw new QueryException(
 							String.format(
@@ -108,7 +108,7 @@ public final class StandardArgumentsValidators {
 			public void validate(
 					List<? extends SqmTypedNode<?>> arguments,
 					String functionName,
-					MappingMetamodel metamodel) {
+					TypeConfiguration typeConfiguration) {
 				if ( arguments.size() != number ) {
 					throw new QueryException(
 							String.format(
@@ -147,7 +147,7 @@ public final class StandardArgumentsValidators {
 			public void validate(
 					List<? extends SqmTypedNode<?>> arguments,
 					String functionName,
-					MappingMetamodel metamodel) {
+					TypeConfiguration typeConfiguration) {
 				if ( arguments.size() > maxNumOfArgs ) {
 					throw new QueryException(
 							String.format(
@@ -182,7 +182,7 @@ public final class StandardArgumentsValidators {
 			public void validate(
 					List<? extends SqmTypedNode<?>> arguments,
 					String functionName,
-					MappingMetamodel metamodel) {
+					TypeConfiguration typeConfiguration) {
 				if (arguments.size() < minNumOfArgs || arguments.size() > maxNumOfArgs) {
 					throw new QueryException(
 							String.format(
@@ -221,7 +221,7 @@ public final class StandardArgumentsValidators {
 			public void validate(
 					List<? extends SqmTypedNode<?>> arguments,
 					String functionName,
-					MappingMetamodel metamodel) {
+					TypeConfiguration typeConfiguration) {
 				for ( SqmTypedNode<?> argument : arguments ) {
 					Class<?> argType = argument.getNodeJavaType().getJavaTypeClass();
 					if ( !javaType.isAssignableFrom( argType ) ) {
@@ -250,11 +250,11 @@ public final class StandardArgumentsValidators {
 			public void validate(
 					List<? extends SqmTypedNode<?>> arguments,
 					String functionName,
-					MappingMetamodel metamodel) {
+					TypeConfiguration typeConfiguration) {
 				validators.forEach( individualValidator -> individualValidator.validate(
 						arguments,
 						functionName,
-						metamodel
+						typeConfiguration
 				) );
 			}
 		};

--- a/hibernate-core/src/main/java/org/hibernate/sql/exec/internal/AbstractJdbcParameter.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/exec/internal/AbstractJdbcParameter.java
@@ -118,9 +118,9 @@ public abstract class AbstractJdbcParameter
 			return jdbcMapping;
 		}
 
-		final BindableType<?> parameterType = executionContext.getSession()
-				.getFactory()
-				.resolveParameterBindType( bindValue );
+		final BindableType<?> parameterType =
+				executionContext.getSession().getFactory().getMappingMetamodel()
+						.resolveParameterBindType( bindValue );
 		if ( parameterType instanceof JdbcMapping ) {
 			return (JdbcMapping) parameterType;
 		}


### PR DESCRIPTION
There is little *concrete* benefit to this change, and it's slightly break-y but:

- it removes a dependence on the `@Incubating` type `QueryEngine` from `Dialect`
- we eat our own dogfood, that is, use our own abstractions
- it appears that this was how it was *originally* intended to be

... and, I guess I just *like* it.