### PR TITLE
HHH-15961 Speed-up Oracle CI build

### DIFF
--- a/databases/oracle/matrix.gradle
+++ b/databases/oracle/matrix.gradle
@@ -4,4 +4,4 @@
  * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
  * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
  */
-jdbcDependency 'com.oracle.database.jdbc:ojdbc8:21.1.0.0'
+jdbcDependency 'com.oracle.database.jdbc:ojdbc8:21.8.0.0'

--- a/docker_db.sh
+++ b/docker_db.sh
@@ -450,24 +450,57 @@ oracle_setup() {
     echo "Oracle successfully started"
     # We increase file sizes to avoid online resizes as that requires lots of CPU which is restricted in XE
     $CONTAINER_CLI exec oracle bash -c "source /home/oracle/.bashrc; bash -c \"
-cat <<EOF | \$ORACLE_HOME/bin/sqlplus sys/Oracle18@localhost/XE as sysdba
-alter database tempfile '\$ORACLE_BASE/oradata/XE/temp01.dbf' resize 400M;
-alter database datafile '\$ORACLE_BASE/oradata/XE/system01.dbf' resize 1000M;
-alter database datafile '\$ORACLE_BASE/oradata/XE/sysaux01.dbf' resize 600M;
-alter database datafile '\$ORACLE_BASE/oradata/XE/undotbs01.dbf' resize 300M;
+cat <<EOF | \$ORACLE_HOME/bin/sqlplus / as sysdba
+-- Increasing redo logs
 alter database add logfile group 4 '\$ORACLE_BASE/oradata/XE/redo04.log' size 500M reuse;
 alter database add logfile group 5 '\$ORACLE_BASE/oradata/XE/redo05.log' size 500M reuse;
 alter database add logfile group 6 '\$ORACLE_BASE/oradata/XE/redo06.log' size 500M reuse;
-
 alter system switch logfile;
 alter system switch logfile;
 alter system switch logfile;
 alter system checkpoint;
-
 alter database drop logfile group 1;
 alter database drop logfile group 2;
 alter database drop logfile group 3;
+!rm \$ORACLE_BASE/oradata/XE/redo01.log
+!rm \$ORACLE_BASE/oradata/XE/redo02.log
+!rm \$ORACLE_BASE/oradata/XE/redo03.log
+
+-- Increasing SYSAUX data file
+alter database datafile '\$ORACLE_BASE/oradata/XE/sysaux01.dbf' resize 600M;
+
+-- Modifying database init parameters
 alter system set open_cursors=1000 sid='*' scope=both;
+alter system set session_cached_cursors=500 sid='*' scope=spfile;
+alter system set db_securefile=ALWAYS sid='*' scope=spfile;
+alter system set dispatchers='(PROTOCOL=TCP)(SERVICE=XEXDB)(DISPATCHERS=0)' sid='*' scope=spfile;
+alter system set recyclebin=OFF sid='*' SCOPE=SPFILE;
+
+-- Comment the 2 next lines to be able to use Diagnostics Pack features
+alter system set sga_target=0m sid='*' scope=both;
+alter system set statistics_level=BASIC sid='*' scope=spfile;
+
+-- Restart the database
+SHUTDOWN IMMEDIATE;
+STARTUP MOUNT;
+ALTER DATABASE OPEN;
+
+-- Switch to the XEPDB1 pluggable database
+alter session set container=xepdb1;
+
+-- Modify XEPDB1 datafiles and tablespaces
+alter database datafile '\$ORACLE_BASE/oradata/XE/XEPDB1/system01.dbf' resize 320M;
+alter database datafile '\$ORACLE_BASE/oradata/XE/XEPDB1/sysaux01.dbf' resize 360M;
+alter database datafile '\$ORACLE_BASE/oradata/XE/XEPDB1/undotbs01.dbf' resize 400M;
+alter database datafile '\$ORACLE_BASE/oradata/XE/XEPDB1/undotbs01.dbf' autoextend on next 16M;
+alter database tempfile '\$ORACLE_BASE/oradata/XE/XEPDB1/temp01.dbf' resize 400M;
+alter database tempfile '\$ORACLE_BASE/oradata/XE/XEPDB1/temp01.dbf' autoextend on next 16M;
+alter database datafile '\$ORACLE_BASE/oradata/XE/XEPDB1/users01.dbf' resize 100M;
+alter database datafile '\$ORACLE_BASE/oradata/XE/XEPDB1/users01.dbf' autoextend on next 16M;
+alter tablespace USERS nologging;
+alter tablespace SYSTEM nologging;
+alter tablespace SYSAUX nologging;
+
 create user hibernate_orm_test identified by hibernate_orm_test quota unlimited on users;
 grant all privileges to hibernate_orm_test;
 EOF\""

--- a/documentation/src/test/java/org/hibernate/userguide/events/InterceptorTest.java
+++ b/documentation/src/test/java/org/hibernate/userguide/events/InterceptorTest.java
@@ -18,7 +18,9 @@ import org.hibernate.Session;
 import org.hibernate.SessionFactory;
 import org.hibernate.boot.MetadataSources;
 import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
+import org.hibernate.cfg.AvailableSettings;
 import org.hibernate.orm.test.jpa.BaseEntityManagerFunctionalTestCase;
+import org.hibernate.testing.jdbc.SharedDriverManagerConnectionProviderImpl;
 import org.hibernate.type.Type;
 
 import org.junit.Before;
@@ -77,7 +79,9 @@ public class InterceptorTest extends BaseEntityManagerFunctionalTestCase {
 
 		Serializable customerId = 1L;
 		//tag::events-interceptors-session-factory-scope-example[]
-		SessionFactory sessionFactory = new MetadataSources(new StandardServiceRegistryBuilder().build())
+		SessionFactory sessionFactory = new MetadataSources(new StandardServiceRegistryBuilder()
+				.applySetting(AvailableSettings.CONNECTION_PROVIDER, SharedDriverManagerConnectionProviderImpl.getInstance())
+				.build())
 			.addAnnotatedClass(Customer.class)
 			.getMetadataBuilder()
 			.build()

--- a/gradle/databases.gradle
+++ b/gradle/databases.gradle
@@ -126,7 +126,7 @@ ext {
                         'jdbc.driver': 'oracle.jdbc.OracleDriver',
                         'jdbc.user'  : 'hibernate_orm_test',
                         'jdbc.pass'  : 'hibernate_orm_test',
-                        'jdbc.url'   : 'jdbc:oracle:thin:@' + dbHost + ':1521/xe',
+                        'jdbc.url'   : 'jdbc:oracle:thin:@' + dbHost + ':1521/xepdb1',
                         'connection.init_sql' : ''
                 ],
                 oracle_ci : [
@@ -134,7 +134,7 @@ ext {
                         'jdbc.driver': 'oracle.jdbc.OracleDriver',
                         'jdbc.user'  : 'hibernate_orm_test',
                         'jdbc.pass'  : 'hibernate_orm_test',
-                        'jdbc.url'   : 'jdbc:oracle:thin:@' + dbHost + ':1521:XE',
+                        'jdbc.url'   : 'jdbc:oracle:thin:@' + dbHost + ':1521/xepdb1',
                         'connection.init_sql' : ''
                 ],
                 oracle_cloud_autonomous_tls : [

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/type/AbstractJavaTimeTypeTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/type/AbstractJavaTimeTypeTest.java
@@ -27,6 +27,7 @@ import org.hibernate.cfg.AvailableSettings;
 import org.hibernate.cfg.Configuration;
 import org.hibernate.dialect.Dialect;
 import org.hibernate.dialect.H2Dialect;
+import org.hibernate.dialect.HSQLDialect;
 import org.hibernate.service.ServiceRegistry;
 
 import org.hibernate.testing.TestForIssue;
@@ -197,7 +198,9 @@ public abstract class AbstractJavaTimeTypeTest<T, E> extends BaseCoreFunctionalT
 		TimeZone timeZoneBefore = TimeZone.getDefault();
 		TimeZone.setDefault( toTimeZone( env.defaultJvmTimeZone ) );
 		// Clear the connection pool to avoid issues with drivers that initialize the session TZ to the system TZ
-		SharedDriverManagerConnectionProviderImpl.getInstance().reset();
+		if( determineDialect() instanceof H2Dialect || determineDialect() instanceof HSQLDialect) {
+			SharedDriverManagerConnectionProviderImpl.getInstance().reset();
+		}
 		/*
 		 * Run the code in a new thread, because some libraries (looking at you, h2 JDBC driver)
 		 * cache data dependent on the default timezone in thread local variables,
@@ -227,7 +230,9 @@ public abstract class AbstractJavaTimeTypeTest<T, E> extends BaseCoreFunctionalT
 		finally {
 			TimeZone.setDefault( timeZoneBefore );
 			// Clear the connection pool to avoid issues with drivers that initialize the session TZ to the system TZ
-			SharedDriverManagerConnectionProviderImpl.getInstance().reset();
+			if( determineDialect() instanceof H2Dialect || determineDialect() instanceof HSQLDialect) {
+				SharedDriverManagerConnectionProviderImpl.getInstance().reset();
+			}
 		}
 	}
 

--- a/hibernate-hikaricp/src/test/resources/hibernate.properties
+++ b/hibernate-hikaricp/src/test/resources/hibernate.properties
@@ -17,3 +17,6 @@ hibernate.connection.provider_class HikariCPConnectionProvider
 hibernate.hikari.poolName testPool
 # Purposefully low and simplisitic.
 hibernate.hikari.maximumPoolSize 2
+# Reduce default timeout from 30 seconds down to 5 seconds to speed-up
+# HikariCPConnectionProviderTest#testHikariCPConnectionProvider
+hibernate.hikari.connectionTimeout 5000

--- a/hibernate-testing/src/main/java/org/hibernate/testing/jdbc/SharedDriverManagerConnectionProviderImpl.java
+++ b/hibernate-testing/src/main/java/org/hibernate/testing/jdbc/SharedDriverManagerConnectionProviderImpl.java
@@ -21,6 +21,7 @@ import org.hibernate.internal.util.config.ConfigurationHelper;
  * A special connection provider that is shared across test runs for better performance.
  *
  * @author Christian Beikov
+ * @author Loïc Lefèvre
  */
 public class SharedDriverManagerConnectionProviderImpl extends DriverManagerConnectionProviderImpl {
 
@@ -88,7 +89,7 @@ public class SharedDriverManagerConnectionProviderImpl extends DriverManagerConn
 
 		public Config(Map<String,Object> configurationValues) {
 			this.autoCommit = ConfigurationHelper.getBoolean( AvailableSettings.AUTOCOMMIT, configurationValues, false );
-			this.minSize = ConfigurationHelper.getInt( MIN_SIZE, configurationValues, 2 );
+			this.minSize = ConfigurationHelper.getInt( MIN_SIZE, configurationValues, 0 );
 			this.maxSize = ConfigurationHelper.getInt( AvailableSettings.POOL_SIZE, configurationValues, 20 );
 			this.initialSize = ConfigurationHelper.getInt( INITIAL_SIZE, configurationValues, minSize );
 			this.driverClassName = (String) configurationValues.get( AvailableSettings.DRIVER );

--- a/settings.gradle
+++ b/settings.gradle
@@ -183,7 +183,7 @@ dependencyResolutionManagement {
             version( "derby", derbyVersion )
             version( "pgsql", "42.5.0" )
             version( "mysql", "8.0.27" )
-            version( "oracle", "21.3.0.0" )
+            version( "oracle", "21.8.0.0" )
 
             alias( "h2" ).to( "com.h2database", "h2" ).versionRef( "h2" )
             alias( "h2gis" ).to( "org.orbisgis", "h2gis" ).versionRef( "h2gis" )


### PR DESCRIPTION
This PR brings some optimizations to reduce CI build duration when targeting Oracle database:
- Docker XE image setup: datafiles and tablespaces configuration, initialization parameters
- Update of the Oracle JDBC driver (21.8 instead of 21.3)
- Better management of JDBC connection pool in `SharedDriverManagerConnectionProviderImpl` (minimum size and removing `reset()` invocations in `AbstractJavaTimeTypeTest`)
- HikariCP timeout configuration
