### PR TITLE
Backport HHH-15967 to branch 6.1 - @OneToOne(mappedBy = ..., fetch = LAZY) in embedded referencing an association within another embedded 

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/entity/internal/EntityDelayedFetchInitializer.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/entity/internal/EntityDelayedFetchInitializer.java
@@ -120,7 +120,7 @@ public class EntityDelayedFetchInitializer extends AbstractFetchParentAccess imp
 				}
 				else {
 					if ( selectByUniqueKey ) {
-						final String uniqueKeyPropertyName = referencedModelPart.getBidirectionalAttributeName();
+						final String uniqueKeyPropertyName = referencedModelPart.getReferencedPropertyName();
 						final Type uniqueKeyPropertyType = ( referencedModelPart.getReferencedPropertyName() == null ) ?
 								concreteDescriptor.getIdentifierType() :
 								session.getFactory()

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/lazy/proxy/LazyOneToOneMappedByInDoubleEmbeddedTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/lazy/proxy/LazyOneToOneMappedByInDoubleEmbeddedTest.java
@@ -1,0 +1,181 @@
+package org.hibernate.orm.test.bytecode.enhancement.lazy.proxy;
+
+import java.io.Serializable;
+
+import org.hibernate.testing.TestForIssue;
+import org.hibernate.testing.bytecode.enhancement.BytecodeEnhancerRunner;
+import org.hibernate.testing.bytecode.enhancement.EnhancementOptions;
+import org.hibernate.testing.junit4.BaseNonConfigCoreFunctionalTestCase;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import jakarta.persistence.Embeddable;
+import jakarta.persistence.Embedded;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToOne;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+@RunWith(BytecodeEnhancerRunner.class)
+@EnhancementOptions(lazyLoading = true)
+@TestForIssue(jiraKey = "HHH-15967")
+public class LazyOneToOneMappedByInDoubleEmbeddedTest extends BaseNonConfigCoreFunctionalTestCase {
+
+	@Override
+	public Class<?>[] getAnnotatedClasses() {
+		return new Class<?>[] { EntityA.class, EntityB.class };
+	}
+
+	@Before
+	public void prepare() {
+		inTransaction( s -> {
+			EntityA entityA = new EntityA( 1 );
+			EntityB entityB = new EntityB( 2 );
+
+			EmbeddedValueInA embeddedValueInA = new EmbeddedValueInA();
+			EmbeddedValueInB embeddedValueInB = new EmbeddedValueInB();
+			embeddedValueInA.setEntityB( entityB );
+			embeddedValueInB.setEntityA( entityA );
+
+			entityB.setEmbedded( embeddedValueInB );
+			entityA.setEmbedded( embeddedValueInA );
+
+			s.persist( entityA );
+			s.persist( entityB );
+		} );
+	}
+
+	@After
+	public void tearDown() {
+		inTransaction(
+				session -> {
+					session.createQuery( "delete from EntityB" ).executeUpdate();
+					session.createQuery( "delete from EntityA" ).executeUpdate();
+				}
+		);
+	}
+
+	@Test
+	public void testGetEntityA() {
+		inTransaction(
+				session -> {
+					EntityA entityA = session.get( EntityA.class, 1 );
+					assertThat( entityA ).isNotNull();
+					EntityB entityB = entityA.getEmbedded().getEntityB();
+					assertThat( entityB ).isNotNull();
+					assertThat( entityB.getEmbedded().getEntityA() ).isNotNull();
+					assertThat( entityB.getEmbedded().getEntityA() ).isEqualTo( entityA );
+				}
+		);
+	}
+
+	@Test
+	public void testGetReferenceEntityA() {
+		inTransaction(
+				session -> {
+					EntityA entityA = session.getReference( EntityA.class, 1 );
+					assertThat( entityA ).isNotNull();
+					EntityB entityB = entityA.getEmbedded().getEntityB();
+					assertThat( entityB ).isNotNull();
+					assertThat( entityB.getEmbedded().getEntityA() ).isNotNull();
+					assertThat( entityB.getEmbedded().getEntityA() ).isEqualTo( entityA );
+				}
+		);
+	}
+
+	@Entity(name = "EntityA")
+	public static class EntityA {
+		@Id
+		private Integer id;
+
+		@Embedded
+		private EmbeddedValueInA embedded = new EmbeddedValueInA();
+
+		public EntityA() {
+		}
+
+		private EntityA(Integer id) {
+			this.id = id;
+		}
+
+		public Integer getId() {
+			return id;
+		}
+
+		public EmbeddedValueInA getEmbedded() {
+			return embedded;
+		}
+
+		public void setEmbedded(EmbeddedValueInA embedded) {
+			this.embedded = embedded;
+		}
+	}
+
+	@Embeddable
+	public static class EmbeddedValueInA implements Serializable {
+		@OneToOne(mappedBy = "embedded.entityA", fetch = FetchType.LAZY)
+		private EntityB entityB;
+
+		public EmbeddedValueInA() {
+		}
+
+		public EntityB getEntityB() {
+			return entityB;
+		}
+
+		public void setEntityB(
+				EntityB entityB) {
+			this.entityB = entityB;
+		}
+	}
+
+	@Entity(name = "EntityB")
+	public static class EntityB {
+		@Id
+		private Integer id;
+
+		@Embedded
+		private EmbeddedValueInB embedded = new EmbeddedValueInB();
+
+		public EntityB() {
+		}
+
+		private EntityB(Integer id) {
+			this.id = id;
+		}
+
+		public Integer getId() {
+			return id;
+		}
+
+		public EmbeddedValueInB getEmbedded() {
+			return embedded;
+		}
+
+		public void setEmbedded(EmbeddedValueInB embedded) {
+			this.embedded = embedded;
+		}
+	}
+
+	@Embeddable
+	public static class EmbeddedValueInB implements Serializable {
+		@OneToOne
+		private EntityA entityA;
+
+		public EmbeddedValueInB() {
+		}
+
+		public EntityA getEntityA() {
+			return entityA;
+		}
+
+		public void setEntityA(
+				EntityA entityA) {
+			this.entityA = entityA;
+		}
+	}
+}


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-15967

Needed for ease of testing in Hibernate Search in particular, but I'm sure this will help people using ORM 6.1 too.

[HHH-15967]: https://hibernate.atlassian.net/browse/HHH-15967?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ