### PR TITLE
HHH-15971 Fix Oracle CI build for 11g version

### DIFF
--- a/ci/build.sh
+++ b/ci/build.sh
@@ -18,9 +18,12 @@ elif [ "$RDBMS" == "postgresql" ] || [ "$RDBMS" == "postgresql_10" ]; then
   goal="-Pdb=pgsql_ci"
 elif [ "$RDBMS" == "edb" ] || [ "$RDBMS" == "edb_10" ]; then
   goal="-Pdb=edb_ci -DdbHost=localhost:5444"
-elif [ "$RDBMS" == "oracle" ] || [ "$RDBMS" == "oracle_11_2" ]; then
+elif [ "$RDBMS" == "oracle" ]; then
   # I have no idea why, but these tests don't seem to work on CI...
   goal="-Pdb=oracle_ci -PexcludeTests=**.LockTest.testQueryTimeout*"
+elif [ "$RDBMS" == "oracle_11_2" ]; then
+  # I have no idea why, but these tests don't seem to work on CI...
+  goal="-Pdb=oracle_legacy_ci -PexcludeTests=**.LockTest.testQueryTimeout*"
 elif [ "$RDBMS" == "db2" ]; then
   goal="-Pdb=db2_ci"
 elif [ "$RDBMS" == "db2_10_5" ]; then

--- a/gradle/databases.gradle
+++ b/gradle/databases.gradle
@@ -137,6 +137,15 @@ ext {
                         'jdbc.url'   : 'jdbc:oracle:thin:@' + dbHost + ':1521/xepdb1',
                         'connection.init_sql' : ''
                 ],
+                oracle_legacy_ci : [
+                        'db.dialect' : 'org.hibernate.dialect.OracleDialect',
+                        'jdbc.driver': 'oracle.jdbc.OracleDriver',
+                        'jdbc.user'  : 'hibernate_orm_test',
+                        'jdbc.pass'  : 'hibernate_orm_test',
+                        // For 11 version that doesn't have any XEPDB1 database service
+                        'jdbc.url'   : 'jdbc:oracle:thin:@' + dbHost + ':1521:XE',
+                        'connection.init_sql' : ''
+                ],
                 oracle_cloud_autonomous_tls : [
                         'db.dialect' : 'org.hibernate.dialect.OracleDialect',
                         'jdbc.driver': 'oracle.jdbc.OracleDriver',


### PR DESCRIPTION
This PR fixes nightly 11g build:
- by forcing the oracle_legacy_ci profile hence targeting XE database service name (instead of xepdb1 when using oracle_ci profile)
- it also optimizes this build by disabling the recycle bin and increasing the session_cached_cursors parameter (from 50 to 500)