### PR TITLE
HHH-15973 hibernate-envers tests must rely on SharedDriverManagerConnectionProviderImpl

### DIFF
--- a/hibernate-envers/src/test/java/org/hibernate/orm/test/envers/AbstractOneSessionTest.java
+++ b/hibernate-envers/src/test/java/org/hibernate/orm/test/envers/AbstractOneSessionTest.java
@@ -13,16 +13,18 @@ import java.net.URL;
 import org.hibernate.MappingException;
 import org.hibernate.Session;
 import org.hibernate.SessionFactory;
+import org.hibernate.cfg.AvailableSettings;
 import org.hibernate.cfg.Configuration;
+import org.hibernate.cfg.Environment;
 import org.hibernate.envers.AuditReader;
 import org.hibernate.envers.AuditReaderFactory;
 import org.hibernate.envers.configuration.EnversSettings;
-import org.hibernate.internal.util.PropertiesHelper;
 import org.hibernate.service.ServiceRegistry;
 
 import org.hibernate.testing.AfterClassOnce;
 import org.hibernate.testing.BeforeClassOnce;
 import org.hibernate.testing.ServiceRegistryBuilder;
+import org.hibernate.testing.jdbc.SharedDriverManagerConnectionProviderImpl;
 import org.junit.Before;
 
 /**
@@ -56,6 +58,13 @@ public abstract class AbstractOneSessionTest extends AbstractEnversTest {
 		addProperties( config );
 
 		this.initMappings();
+
+		if ( !Environment.getProperties().containsKey( Environment.CONNECTION_PROVIDER ) ) {
+			config.getProperties().put(
+					AvailableSettings.CONNECTION_PROVIDER,
+					SharedDriverManagerConnectionProviderImpl.getInstance()
+			);
+		}
 
 		serviceRegistry = ServiceRegistryBuilder.buildServiceRegistry( config.getProperties() );
 		sessionFactory = config.buildSessionFactory( serviceRegistry );

--- a/hibernate-envers/src/test/java/org/hibernate/orm/test/envers/entities/converter/BasicModelingTest.java
+++ b/hibernate-envers/src/test/java/org/hibernate/orm/test/envers/entities/converter/BasicModelingTest.java
@@ -16,6 +16,7 @@ import org.hibernate.orm.test.envers.AbstractEnversTest;
 import org.hibernate.mapping.PersistentClass;
 
 import org.hibernate.testing.TestForIssue;
+import org.hibernate.testing.jdbc.SharedDriverManagerConnectionProviderImpl;
 import org.junit.Test;
 
 import static org.junit.Assert.assertNotNull;
@@ -29,6 +30,7 @@ public class BasicModelingTest extends AbstractEnversTest {
 	public void testMetamodelBuilding() {
 		StandardServiceRegistry ssr = new StandardServiceRegistryBuilder()
 				.applySetting( AvailableSettings.HBM2DDL_AUTO, "create-drop" )
+				.applySetting( AvailableSettings.CONNECTION_PROVIDER, SharedDriverManagerConnectionProviderImpl.getInstance() )
 				.build();
 		try {
 			Metadata metadata = new MetadataSources( ssr )

--- a/hibernate-envers/src/test/java/org/hibernate/orm/test/envers/integration/strategy/AuditStraegySelectorTest.java
+++ b/hibernate-envers/src/test/java/org/hibernate/orm/test/envers/integration/strategy/AuditStraegySelectorTest.java
@@ -13,6 +13,8 @@ import java.util.Map;
 
 import org.hibernate.boot.MetadataSources;
 import org.hibernate.boot.spi.MetadataImplementor;
+import org.hibernate.cfg.AvailableSettings;
+import org.hibernate.cfg.Environment;
 import org.hibernate.envers.boot.internal.EnversService;
 import org.hibernate.envers.configuration.Configuration;
 import org.hibernate.envers.configuration.EnversSettings;
@@ -20,6 +22,7 @@ import org.hibernate.envers.strategy.AuditStrategy;
 import org.hibernate.envers.strategy.DefaultAuditStrategy;
 import org.hibernate.envers.strategy.ValidityAuditStrategy;
 import org.hibernate.service.ServiceRegistry;
+import org.hibernate.testing.jdbc.SharedDriverManagerConnectionProviderImpl;
 import org.junit.Test;
 
 import org.hibernate.testing.ServiceRegistryBuilder;
@@ -72,6 +75,8 @@ public class AuditStraegySelectorTest {
 		if ( propertyValue != null ) {
 			properties.put( EnversSettings.AUDIT_STRATEGY, propertyValue );
 		}
+
+		properties.put(AvailableSettings.CONNECTION_PROVIDER, SharedDriverManagerConnectionProviderImpl.getInstance() );
 
 		final ServiceRegistry sr = ServiceRegistryBuilder.buildServiceRegistry( properties );
 		try {

--- a/hibernate-envers/src/test/java/org/hibernate/orm/test/envers/integrator/BasicIntegratorTest.java
+++ b/hibernate-envers/src/test/java/org/hibernate/orm/test/envers/integrator/BasicIntegratorTest.java
@@ -9,9 +9,12 @@ package org.hibernate.orm.test.envers.integrator;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 
+import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
+import org.hibernate.cfg.AvailableSettings;
 import org.hibernate.cfg.Configuration;
 
 import org.hibernate.testing.TestForIssue;
+import org.hibernate.testing.jdbc.SharedDriverManagerConnectionProviderImpl;
 import org.junit.Test;
 
 /**
@@ -25,8 +28,12 @@ public class BasicIntegratorTest {
 	@Test
 	@TestForIssue( jiraKey = "HHH-9675" )
 	public void testNoAudited() {
-		new Configuration().buildSessionFactory().close();
-		new Configuration().addAnnotatedClass( SimpleNonAuditedEntity.class ).buildSessionFactory().close();
+		new Configuration().buildSessionFactory(new StandardServiceRegistryBuilder()
+				.applySetting(AvailableSettings.CONNECTION_PROVIDER, SharedDriverManagerConnectionProviderImpl.getInstance())
+				.build()).close();
+		new Configuration().addAnnotatedClass( SimpleNonAuditedEntity.class ).buildSessionFactory(new StandardServiceRegistryBuilder()
+				.applySetting(AvailableSettings.CONNECTION_PROVIDER, SharedDriverManagerConnectionProviderImpl.getInstance())
+				.build()).close();
 	}
 
 	@Entity

--- a/hibernate-envers/src/test/java/org/hibernate/orm/test/envers/various/ExportIdentifierTest.java
+++ b/hibernate-envers/src/test/java/org/hibernate/orm/test/envers/various/ExportIdentifierTest.java
@@ -18,11 +18,13 @@ import org.hibernate.boot.model.relational.QualifiedNameImpl;
 import org.hibernate.boot.registry.StandardServiceRegistry;
 import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
 import org.hibernate.boot.spi.MetadataBuildingOptions;
+import org.hibernate.cfg.AvailableSettings;
 import org.hibernate.engine.jdbc.env.spi.JdbcEnvironment;
 import org.hibernate.id.enhanced.SequenceStructure;
 import org.hibernate.testing.DialectChecks;
 import org.hibernate.testing.RequiresDialectFeature;
 import org.hibernate.testing.TestForIssue;
+import org.hibernate.testing.jdbc.SharedDriverManagerConnectionProviderImpl;
 import org.hibernate.testing.junit4.BaseUnitTestCase;
 import org.junit.Test;
 
@@ -34,7 +36,9 @@ public class ExportIdentifierTest extends BaseUnitTestCase {
 	@Test
 	@TestForIssue( jiraKey = "HHH-12935" )
 	public void testUniqueExportableIdentifier() {
-		final StandardServiceRegistry ssr = new StandardServiceRegistryBuilder().build();
+		final StandardServiceRegistry ssr = new StandardServiceRegistryBuilder()
+				.applySetting(AvailableSettings.CONNECTION_PROVIDER, SharedDriverManagerConnectionProviderImpl.getInstance())
+				.build();
 		final MetadataBuilderImpl.MetadataBuildingOptionsImpl options = new MetadataBuilderImpl.MetadataBuildingOptionsImpl( ssr );
 		options.setBootstrapContext( new BootstrapContextImpl( ssr, options ) );
 		final Database database = new Database( options );


### PR DESCRIPTION
This PR fixes some hibernate-envers tests so that they rely on `SharedDriverManagerConnectionProviderImpl` instead of the default `DriverManagerConnectionProviderImpl` Connection Provider.

Tests modified:
- BasicModelingTest
- ReadEntityWhitEntityNameTest
- ReadEntityWithAuditedCollectionTest
- ReadEntityAssociatedAuditedTest
- ReadEntityAssociatedNotAuditedTest
- ReadEntityWithAuditedManyToManyTest
- ReadEntityWithAuditedCollectionTest
- SingleDomainObjectToMultipleTablesTest
- HasChangedAuditedManyToManyTest
- AuditStraegySelectorTest
- ExportIdentifierTest
- BasicIntegratorTest
