### PR TITLE
promote joinTransaction() and isJoinedToTransaction() to SharedSessionContract

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/SharedSessionContract.java
+++ b/hibernate-core/src/main/java/org/hibernate/SharedSessionContract.java
@@ -64,8 +64,29 @@ public interface SharedSessionContract extends QueryProducer, Closeable, Seriali
 	 * Get the {@link Transaction} instance associated with this session.
 	 *
 	 * @return a Transaction instance
+	 *
+	 * @see jakarta.persistence.EntityManager#getTransaction()
 	 */
 	Transaction getTransaction();
+
+	/**
+	 * Join the currently-active JTA transaction.
+	 *
+	 * @see jakarta.persistence.EntityManager#joinTransaction()
+	 *
+	 * @since 6.2
+	 */
+	void joinTransaction();
+
+	/**
+	 * Check if the session is joined to the current transaction.
+	 *
+	 * @see #joinTransaction()
+	 * @see jakarta.persistence.EntityManager#isJoinedToTransaction()
+	 *
+	 * @since 6.2
+	 */
+	boolean isJoinedToTransaction();
 
 	/**
 	 * Obtain a {@link ProcedureCall} based on a named template

--- a/hibernate-core/src/main/java/org/hibernate/engine/spi/SharedSessionDelegatorBaseImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/spi/SharedSessionDelegatorBaseImpl.java
@@ -285,6 +285,16 @@ public class SharedSessionDelegatorBaseImpl implements SharedSessionContractImpl
 	}
 
 	@Override
+	public void joinTransaction() {
+		delegate.joinTransaction();
+	}
+
+	@Override
+	public boolean isJoinedToTransaction() {
+		return delegate.isJoinedToTransaction();
+	}
+
+	@Override
 	public HibernateCriteriaBuilder getCriteriaBuilder() {
 		return delegate.getCriteriaBuilder();
 	}

--- a/hibernate-core/src/main/java/org/hibernate/internal/SessionImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/SessionImpl.java
@@ -127,7 +127,6 @@ import org.hibernate.query.SelectionQuery;
 import org.hibernate.query.UnknownSqlResultSetMappingException;
 import org.hibernate.resource.jdbc.spi.JdbcSessionOwner;
 import org.hibernate.resource.jdbc.spi.PhysicalConnectionHandlingMode;
-import org.hibernate.resource.transaction.TransactionRequiredForJoinException;
 import org.hibernate.resource.transaction.backend.jta.internal.JtaTransactionCoordinatorImpl;
 import org.hibernate.resource.transaction.spi.TransactionCoordinator;
 import org.hibernate.resource.transaction.spi.TransactionCoordinatorBuilder;
@@ -2746,31 +2745,6 @@ public class SessionImpl
 		catch ( RuntimeException e ) {
 			throw getExceptionConverter().convert( e );
 		}
-	}
-
-	@Override
-	public void joinTransaction() {
-		checkOpen();
-		if ( !getTransactionCoordinator().getTransactionCoordinatorBuilder().isJta() ) {
-			log.callingJoinTransactionOnNonJtaEntityManager();
-			return;
-		}
-
-		try {
-			getTransactionCoordinator().explicitJoin();
-		}
-		catch ( TransactionRequiredForJoinException e ) {
-			throw new TransactionRequiredException( e.getMessage() );
-		}
-		catch ( HibernateException he ) {
-			throw getExceptionConverter().convert( he );
-		}
-	}
-
-	@Override
-	public boolean isJoinedToTransaction() {
-		checkOpen();
-		return getTransactionCoordinator().isJoined();
 	}
 
 	@Override


### PR DESCRIPTION
This makes these operations available on `StatelessSession` instead of just on `Session`.

See https://twitter.com/omidboot/status/1612019552904253441

@sebersole what do you think of this proposal?