### PR TITLE
HHH-15982 Refactor tests to use StatementInspector and correct bidirectionalAttributeName handling

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/ToOneAttributeMapping.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/ToOneAttributeMapping.java
@@ -147,6 +147,10 @@ public class ToOneAttributeMapping
 	private final Set<String> targetKeyPropertyNames;
 
 	private final Cardinality cardinality;
+	/*
+	 Capture the other side's name of a possibly bidirectional association to allow resolving circular fetches.
+	 It may be null if the referenced property is a non-entity.
+	 */
 	private final String bidirectionalAttributeName;
 	private final TableGroupProducer declaringTableGroupProducer;
 
@@ -222,10 +226,10 @@ public class ToOneAttributeMapping
 			else {
 				cardinality = Cardinality.MANY_TO_ONE;
 			}
+			final PersistentClass entityBinding = manyToOne.getMetadata()
+					.getEntityBinding( manyToOne.getReferencedEntityName() );
 			if ( referencedPropertyName == null ) {
 				String bidirectionalAttributeName = null;
-				final PersistentClass entityBinding = manyToOne.getMetadata()
-						.getEntityBinding( manyToOne.getReferencedEntityName() );
 				if ( cardinality == Cardinality.LOGICAL_ONE_TO_ONE ) {
 					// Handle join table cases
 					for ( Join join : entityBinding.getJoinClosure() ) {
@@ -271,7 +275,11 @@ public class ToOneAttributeMapping
 				this.bidirectionalAttributeName = bidirectionalAttributeName;
 			}
 			else {
-				this.bidirectionalAttributeName = referencedPropertyName;
+				// Only set the bidirectional attribute name if the referenced property can actually be circular i.e. an entity type
+				final Property property = entityBinding.getProperty( referencedPropertyName );
+				this.bidirectionalAttributeName = property != null && property.getValue() instanceof EntityType
+						? referencedPropertyName
+						: null;
 			}
 			if ( bootValue.isNullable() ) {
 				isKeyTableNullable = true;
@@ -991,8 +999,7 @@ public class ToOneAttributeMapping
 			}
 			return false;
 		}
-		return parentNavigablePath.getLocalName().equals( bidirectionalAttributeName ) ||
-				parentNavigablePath.getLocalName().equals( identifyingColumnsTableExpression );
+		return parentNavigablePath.getLocalName().equals( bidirectionalAttributeName );
 	}
 
 	public String getBidirectionalAttributeName(){

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/converted/converter/onetoone/BidirectionalOneToOneWithConverterEagerTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/converted/converter/onetoone/BidirectionalOneToOneWithConverterEagerTest.java
@@ -142,7 +142,7 @@ public class BidirectionalOneToOneWithConverterEagerTest {
 	}
 
 	@Entity(name = "FooEntity")
-	@Table(name = "foo")
+	@Table(name = "foo_table")
 	public static class FooEntity {
 		@Id
 		@GeneratedValue
@@ -192,7 +192,7 @@ public class BidirectionalOneToOneWithConverterEagerTest {
 	}
 
 	@Entity(name = "BarEntity")
-	@Table(name = "bar")
+	@Table(name = "bar_table")
 	public static class BarEntity {
 		@Id
 		@GeneratedValue

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/converted/converter/onetoone/BidirectionalOneToOneWithConverterEagerTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/converted/converter/onetoone/BidirectionalOneToOneWithConverterEagerTest.java
@@ -8,10 +8,8 @@ package org.hibernate.orm.test.mapping.converted.converter.onetoone;
 
 import java.io.Serializable;
 import java.util.UUID;
-import java.util.concurrent.atomic.AtomicInteger;
 
-import org.hibernate.engine.internal.StatisticalLoggingSessionEventListener;
-
+import org.hibernate.testing.jdbc.SQLStatementInspector;
 import org.hibernate.testing.orm.junit.DomainModel;
 import org.hibernate.testing.orm.junit.JiraKey;
 import org.hibernate.testing.orm.junit.SessionFactory;
@@ -36,7 +34,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 /**
  * @author Marco Belladelli
  */
-@SessionFactory
+@SessionFactory(useCollectingStatementInspector = true)
 @DomainModel(annotatedClasses = {
 		BidirectionalOneToOneWithConverterEagerTest.FooEntity.class,
 		BidirectionalOneToOneWithConverterEagerTest.BarEntity.class,
@@ -72,24 +70,18 @@ public class BidirectionalOneToOneWithConverterEagerTest {
 
 	@Test
 	public void testBidirectionalFetch(SessionFactoryScope scope) {
+		final SQLStatementInspector statementInspector = scope.getCollectingStatementInspector();
+		statementInspector.clear();
 		scope.inTransaction( session -> {
 			FooEntity foo = session.find( FooEntity.class, 1L );
-
-			final AtomicInteger queryExecutionCount = new AtomicInteger();
-			session.getEventListenerManager().addListener( new StatisticalLoggingSessionEventListener() {
-				@Override
-				public void jdbcExecuteStatementStart() {
-					super.jdbcExecuteStatementStart();
-					queryExecutionCount.getAndIncrement();
-				}
-			} );
+			statementInspector.assertExecutedCount( 1 );
 
 			BarEntity bar = foo.getBar();
-			assertEquals( 0, queryExecutionCount.get() );
+			statementInspector.assertExecutedCount( 1 );
 			assertEquals( 0.5, bar.getaDouble() );
 
 			FooEntity associatedFoo = bar.getFoo();
-			assertEquals( 0, queryExecutionCount.get() );
+			statementInspector.assertExecutedCount( 1 );
 			assertEquals( "foo_name", associatedFoo.getName() );
 			assertEquals( foo, associatedFoo );
 
@@ -99,24 +91,18 @@ public class BidirectionalOneToOneWithConverterEagerTest {
 
 	@Test
 	public void testBidirectionalFetchInverse(SessionFactoryScope scope) {
+		final SQLStatementInspector statementInspector = scope.getCollectingStatementInspector();
+		statementInspector.clear();
 		scope.inTransaction( session -> {
 			BarEntity bar = session.find( BarEntity.class, 1L );
-
-			final AtomicInteger queryExecutionCount = new AtomicInteger();
-			session.getEventListenerManager().addListener( new StatisticalLoggingSessionEventListener() {
-				@Override
-				public void jdbcExecuteStatementStart() {
-					super.jdbcExecuteStatementStart();
-					queryExecutionCount.getAndIncrement();
-				}
-			} );
+			statementInspector.assertExecutedCount( 1 );
 
 			FooEntity foo = bar.getFoo();
-			assertEquals( 0, queryExecutionCount.get() );
+			statementInspector.assertExecutedCount( 1 );
 			assertEquals( "foo_name", foo.getName() );
 
 			BarEntity associatedBar = foo.getBar();
-			assertEquals( 0, queryExecutionCount.get() );
+			statementInspector.assertExecutedCount( 1 );
 			assertEquals( 0.5, associatedBar.getaDouble() );
 			assertEquals( bar, associatedBar );
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/converted/converter/onetoone/BidirectionalOneToOneWithConverterLazyTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/converted/converter/onetoone/BidirectionalOneToOneWithConverterLazyTest.java
@@ -140,7 +140,7 @@ public class BidirectionalOneToOneWithConverterLazyTest {
 	}
 
 	@Entity(name = "FooEntity")
-	@Table(name = "foo")
+	@Table(name = "foo_table")
 	public static class FooEntity {
 		@Id
 		@GeneratedValue
@@ -190,7 +190,7 @@ public class BidirectionalOneToOneWithConverterLazyTest {
 	}
 
 	@Entity(name = "BarEntity")
-	@Table(name = "bar")
+	@Table(name = "bar_table")
 	public static class BarEntity {
 		@Id
 		@GeneratedValue

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/onetoone/bidirectional/BidirectionalOneToOneEagerFKTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/onetoone/bidirectional/BidirectionalOneToOneEagerFKTest.java
@@ -104,7 +104,7 @@ public class BidirectionalOneToOneEagerFKTest {
 	}
 
 	@Entity(name = "FooEntity")
-	@Table(name = "foo")
+	@Table(name = "foo_table")
 	public static class FooEntity {
 		@Id
 		@GeneratedValue
@@ -153,7 +153,7 @@ public class BidirectionalOneToOneEagerFKTest {
 	}
 
 	@Entity(name = "BarEntity")
-	@Table(name = "bar")
+	@Table(name = "bar_table")
 	public static class BarEntity {
 		@Id
 		@GeneratedValue

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/onetoone/bidirectional/BidirectionalOneToOneLazyFKTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/onetoone/bidirectional/BidirectionalOneToOneLazyFKTest.java
@@ -102,7 +102,7 @@ public class BidirectionalOneToOneLazyFKTest {
 	}
 
 	@Entity(name = "FooEntity")
-	@Table(name = "foo")
+	@Table(name = "foo_table")
 	public static class FooEntity {
 		@Id
 		@GeneratedValue
@@ -151,7 +151,7 @@ public class BidirectionalOneToOneLazyFKTest {
 	}
 
 	@Entity(name = "BarEntity")
-	@Table(name = "bar")
+	@Table(name = "bar_table")
 	public static class BarEntity {
 		@Id
 		@GeneratedValue


### PR DESCRIPTION
Refactor tests as suggested by https://github.com/hibernate/hibernate-orm/pull/5921#discussion_r1064505664.

Also, only set `bidirectionalAttributeName` when needed and rollback the check for bidirectional associations that was wrongly using the table expression.