### PR TITLE
HHH-15890 Fix shouldEmulateFetchClause method for DB2(i)SqlAstTranslator

### DIFF
--- a/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/DB2iLegacySqlAstTranslator.java
+++ b/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/DB2iLegacySqlAstTranslator.java
@@ -34,12 +34,18 @@ public class DB2iLegacySqlAstTranslator<T extends JdbcOperation> extends DB2Lega
 
 	@Override
 	protected boolean shouldEmulateFetchClause(QueryPart queryPart) {
-		// Percent fetches or ties fetches aren't supported in DB2 iSeries
-		// According to LegacyDB2LimitHandler, variable limit also isn't supported before 7.1
-		return getQueryPartForRowNumbering() != queryPart && (
-				useOffsetFetchClause( queryPart ) && !isRowsOnlyFetchClauseType( queryPart )
-						|| version.isBefore(7, 10) && ( queryPart.isRoot() && hasLimit() || !( queryPart.getFetchClauseExpression() instanceof Literal ) )
-		);
+		// Check if current query part is already row numbering to avoid infinite recursion
+		if ( getQueryPartForRowNumbering() == queryPart ) {
+			return false;
+		}
+		// Percent fetches or ties fetches aren't supported in DB2
+		if ( useOffsetFetchClause( queryPart ) && !isRowsOnlyFetchClauseType( queryPart ) ) {
+			return true;
+		}
+		// According to LegacyDB2LimitHandler, variable limit also isn't supported before 7.10
+		return  version.isBefore(7, 10)
+				&& queryPart.getFetchClauseExpression() != null
+				&& !( queryPart.getFetchClauseExpression() instanceof Literal );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/dialect/DB2iSqlAstTranslator.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/DB2iSqlAstTranslator.java
@@ -32,12 +32,18 @@ public class DB2iSqlAstTranslator<T extends JdbcOperation> extends DB2SqlAstTran
 
 	@Override
 	protected boolean shouldEmulateFetchClause(QueryPart queryPart) {
-		// Percent fetches or ties fetches aren't supported in DB2 iSeries
-		// According to LegacyDB2LimitHandler, variable limit also isn't supported before 7.1
-		return getQueryPartForRowNumbering() != queryPart && (
-				useOffsetFetchClause( queryPart ) && !isRowsOnlyFetchClauseType( queryPart )
-						|| version.isBefore(7, 10) && ( queryPart.isRoot() && hasLimit() || !( queryPart.getFetchClauseExpression() instanceof Literal ) )
-		);
+		// Check if current query part is already row numbering to avoid infinite recursion
+		if ( getQueryPartForRowNumbering() == queryPart ) {
+			return false;
+		}
+		// Percent fetches or ties fetches aren't supported in DB2
+		if ( useOffsetFetchClause( queryPart ) && !isRowsOnlyFetchClauseType( queryPart ) ) {
+			return true;
+		}
+		// According to LegacyDB2LimitHandler, variable limit also isn't supported before 7.10
+		return  version.isBefore(7, 10)
+				&& queryPart.getFetchClauseExpression() != null
+				&& !( queryPart.getFetchClauseExpression() instanceof Literal );
 	}
 
 	@Override


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-15890

The issue was already solved for `DB2400Dialect` (deprecated) which uses `DB2SqlAstTranslator` but not for `DB2iDialect` / `DB2iSqlAstTranslator`.