### PR TITLE
fix queries like 'select ... where ...' with no 'from' clause

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/function/SelfRenderingFunctionSqlAstExpression.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/function/SelfRenderingFunctionSqlAstExpression.java
@@ -73,10 +73,9 @@ public class SelfRenderingFunctionSqlAstExpression
 
 	@Override
 	public JdbcMappingContainer getExpressionType() {
-		if ( type instanceof SqlExpressible) {
-			return (JdbcMappingContainer) type;
-		}
-		return expressible;
+		return type instanceof SqlExpressible
+				? (JdbcMappingContainer) type
+				: expressible;
 	}
 
 	protected FunctionRenderingSupport getRenderer() {
@@ -107,8 +106,12 @@ public class SelfRenderingFunctionSqlAstExpression
 			jdbcJavaType = jdbcMapping.getJdbcJavaType();
 			converter = jdbcMapping.getValueConverter();
 		}
-		else {
+		else if ( type != null ) {
 			jdbcJavaType = type.getExpressibleJavaType();
+			converter = null;
+		}
+		else {
+			jdbcJavaType = null;
 			converter = null;
 		}
 		final SqlAstCreationState sqlAstCreationState = creationState.getSqlAstCreationState();
@@ -123,7 +126,7 @@ public class SelfRenderingFunctionSqlAstExpression
 						)
 						.getValuesArrayPosition(),
 				resultVariable,
-				type.getExpressibleJavaType(),
+				type == null ? null : type.getExpressibleJavaType(),
 				converter
 		);
 	}
@@ -178,9 +181,15 @@ public class SelfRenderingFunctionSqlAstExpression
 
 	@Override
 	public JdbcMapping getJdbcMapping() {
-		return type instanceof SqlExpressible
-				? ( (SqlExpressible) type ).getJdbcMapping()
-				: ( (SqlExpressible) expressible ).getJdbcMapping();
+		if ( type instanceof SqlExpressible ) {
+			return ( (SqlExpressible) type ).getJdbcMapping();
+		}
+		else if ( expressible instanceof SqlExpressible ) {
+			return ( (SqlExpressible) expressible ).getJdbcMapping();
+		}
+		else {
+			return null;
+		}
 	}
 
 	@Override

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/query/hql/FunctionTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/query/hql/FunctionTests.java
@@ -1604,4 +1604,36 @@ public class FunctionTests {
 		);
 	}
 
+	@Test
+	public void testIn(SessionFactoryScope scope) {
+		scope.inTransaction(
+				session -> {
+					assertEquals( 1,
+							session.createQuery("select 1 where 1 in (:list)")
+									.setParameterList("list",List.of(1,2))
+									.list().size() );
+					assertEquals( 0,
+							session.createQuery("select 1 where 1 in (:list)")
+									.setParameterList("list",List.of(0,3,2))
+									.list().size() );
+					assertEquals( 0,
+							session.createQuery("select 1 where 1 in (:list)")
+									.setParameterList("list",List.of())
+									.list().size() );
+					assertEquals( 1,
+							session.createQuery("select 1 where 1 in :list")
+									.setParameterList("list",List.of(1,2))
+									.list().size() );
+					assertEquals( 0,
+							session.createQuery("select 1 where 1 in :list")
+									.setParameterList("list",List.of(0,3,2))
+									.list().size() );
+					assertEquals( 0,
+							session.createQuery("select 1 where 1 in :list")
+									.setParameterList("list",List.of())
+									.list().size() );
+				}
+		);
+	}
+
 }


### PR DESCRIPTION
This was another bug that resulted from the unnecessary use of the untypesafe `getChild()` method in `SemanticQueryBuilder`.

 It's really important that we migrate away from that, who knows how many other bugs are lurking?