### PR TITLE
remove type parameter from StatelessSessionBuilder + deprecate an operation of SessionFactory

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/SessionBuilder.java
+++ b/hibernate-core/src/main/java/org/hibernate/SessionBuilder.java
@@ -93,7 +93,6 @@ public interface SessionBuilder {
 	 *
 	 * @return {@code this}, for method chaining
 	 */
-	@SuppressWarnings("UnusedReturnValue")
 	SessionBuilder autoClear(boolean autoClear);
 
 	/**
@@ -130,7 +129,7 @@ public interface SessionBuilder {
 	 * Remove all listeners intended for the built session currently held here,
 	 * including any auto-apply ones; in other words, start with a clean slate.
 	 *
-	 * {@code this}, for method chaining
+	 * @return {@code this}, for method chaining
 	 */
 	SessionBuilder clearEventListeners();
 

--- a/hibernate-core/src/main/java/org/hibernate/SessionFactory.java
+++ b/hibernate-core/src/main/java/org/hibernate/SessionFactory.java
@@ -118,13 +118,6 @@ import jakarta.persistence.EntityManagerFactory;
  */
 public interface SessionFactory extends EntityManagerFactory, Referenceable, Serializable, java.io.Closeable {
 	/**
-	 * Get the special options used to build the factory.
-	 *
-	 * @return The special options used to build the factory.
-	 */
-	SessionFactoryOptions getSessionFactoryOptions();
-
-	/**
 	 * Obtain a {@linkplain SessionBuilder session builder} for creating
 	 * new {@link Session}s with certain customized options.
 	 *
@@ -410,4 +403,15 @@ public interface SessionFactory extends EntityManagerFactory, Referenceable, Ser
 		return getDefinedFilterNames().contains( name );
 	}
 
+	/**
+	 * Get the {@linkplain SessionFactoryOptions options} used to build this factory.
+	 *
+	 * @return The special options used to build the factory.
+	 *
+	 * @deprecated There is no plan to remove this operation, but its use should be
+	 *             avoided since {@link SessionFactoryOptions} is an SPI type, and so
+	 *             this operation is a layer-breaker.
+	 */
+	@Deprecated(since = "6.2")
+	SessionFactoryOptions getSessionFactoryOptions();
 }

--- a/hibernate-core/src/main/java/org/hibernate/StatelessSessionBuilder.java
+++ b/hibernate-core/src/main/java/org/hibernate/StatelessSessionBuilder.java
@@ -8,14 +8,12 @@ package org.hibernate;
 
 import java.sql.Connection;
 
-import org.hibernate.query.Query;
-
 /**
- * Represents a consolidation of all stateless session creation options into a builder style delegate.
+ * Allows creation of a new {@link StatelessSession} with specific options.
  *
  * @author Steve Ebersole
  */
-public interface StatelessSessionBuilder<T extends StatelessSessionBuilder> {
+public interface StatelessSessionBuilder {
 	/**
 	 * Opens a session with the specified options.
 	 *
@@ -30,7 +28,7 @@ public interface StatelessSessionBuilder<T extends StatelessSessionBuilder> {
 	 *
 	 * @return {@code this}, for method chaining
 	 */
-	T connection(Connection connection);
+	StatelessSessionBuilder connection(Connection connection);
 
 	/**
 	 * Define the tenant identifier to be associated with the opened session.
@@ -39,5 +37,5 @@ public interface StatelessSessionBuilder<T extends StatelessSessionBuilder> {
 	 *
 	 * @return {@code this}, for method chaining
 	 */
-	T tenantIdentifier(String tenantIdentifier);
+	StatelessSessionBuilder tenantIdentifier(String tenantIdentifier);
 }

--- a/hibernate-core/src/main/java/org/hibernate/internal/SessionFactoryImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/SessionFactoryImpl.java
@@ -187,7 +187,7 @@ public class SessionFactoryImpl extends QueryParameterBindingTypeResolverImpl im
 	private final transient WrapperOptions wrapperOptions;
 	private final transient SessionBuilderImpl defaultSessionOpenOptions;
 	private final transient SessionBuilderImpl temporarySessionOpenOptions;
-	private final transient StatelessSessionBuilder<?> defaultStatelessOptions;
+	private final transient StatelessSessionBuilder defaultStatelessOptions;
 	private final transient EntityNameResolver entityNameResolver;
 
 	private final transient SchemaManager schemaManager;


### PR DESCRIPTION
- the TP of `StatelessSessionBuilder` was missed when `SessionBuilder` was done
- `SessionFactory.getOptions()` is a layer-breaker, returning an SPI interface