### PR TITLE
Fix select without from in old versions of MySQL and MariaDB

### DIFF
--- a/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/MariaDBLegacySqlAstTranslator.java
+++ b/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/MariaDBLegacySqlAstTranslator.java
@@ -222,6 +222,16 @@ public class MariaDBLegacySqlAstTranslator<T extends JdbcOperation> extends Abst
 	}
 
 	@Override
+	protected String getFromDual() {
+		return " from dual";
+	}
+
+	@Override
+	protected String getFromDualForSelectOnly() {
+		return getDialect().getVersion().isBefore( 10, 4 ) ? getFromDual() : "";
+	}
+
+	@Override
 	public MariaDBLegacyDialect getDialect() {
 		return this.dialect;
 	}

--- a/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/MySQLLegacySqlAstTranslator.java
+++ b/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/MySQLLegacySqlAstTranslator.java
@@ -239,6 +239,11 @@ public class MySQLLegacySqlAstTranslator<T extends JdbcOperation> extends Abstra
 	}
 
 	@Override
+	protected String getFromDualForSelectOnly() {
+		return getDialect().getVersion().isBefore( 5, 7 ) ? getFromDual() : "";
+	}
+
+	@Override
 	public MySQLDialect getDialect() {
 		return (MySQLDialect) super.getDialect();
 	}

--- a/hibernate-core/src/main/java/org/hibernate/dialect/MariaDBSqlAstTranslator.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/MariaDBSqlAstTranslator.java
@@ -216,6 +216,16 @@ public class MariaDBSqlAstTranslator<T extends JdbcOperation> extends AbstractSq
 	}
 
 	@Override
+	protected String getFromDual() {
+		return " from dual";
+	}
+
+	@Override
+	protected String getFromDualForSelectOnly() {
+		return getDialect().getVersion().isBefore( 10, 4 ) ? getFromDual() : "";
+	}
+
+	@Override
 	public MariaDBDialect getDialect() {
 		return this.dialect;
 	}

--- a/hibernate-core/src/main/java/org/hibernate/dialect/MySQLSqlAstTranslator.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/MySQLSqlAstTranslator.java
@@ -275,6 +275,11 @@ public class MySQLSqlAstTranslator<T extends JdbcOperation> extends AbstractSqlA
 	}
 
 	@Override
+	protected String getFromDualForSelectOnly() {
+		return getDialect().getVersion().isBefore( 5, 7 ) ? getFromDual() : "";
+	}
+
+	@Override
 	public MySQLDialect getDialect() {
 		return (MySQLDialect) super.getDialect();
 	}


### PR DESCRIPTION
Fix CI errors on [MySQL 5.7](https://ci.hibernate.org/job/hibernate-orm-nightly/job/main/86/testReport/junit/org.hibernate.orm.test.query.hql/FunctionTests/Build___mysql_5_7___Test___testIn_SessionFactoryScope_/) and [MariaDB 10.3](https://ci.hibernate.org/job/hibernate-orm-nightly/job/main/86/testReport/junit/org.hibernate.orm.test.query.hql/FunctionTests/Build___mariadb_10_3___Test___testIn_SessionFactoryScope_/).