### PR TITLE
deprecate config property org.hibernate.flushMode on AvailableSettings

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/cfg/AvailableSettings.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/AvailableSettings.java
@@ -3068,8 +3068,13 @@ public interface AvailableSettings {
 	/**
 	 * Used to determine flush mode.
 	 *
+	 * @deprecated There are much better ways to control the flush mode of a session,
+	 *             for example, {@link org.hibernate.SessionBuilder#flushMode} or
+	 *             {@link org.hibernate.Session#setHibernateFlushMode}.
+	 *
 	 * @see org.hibernate.jpa.HibernateHints#HINT_FLUSH_MODE
 	 */
+	@Deprecated(since = "6.2", forRemoval = true)
 	String FLUSH_MODE = "org.hibernate.flushMode";
 
 	String CFG_XML_FILE = "hibernate.cfg_xml_file";

--- a/hibernate-core/src/main/java/org/hibernate/internal/FastSessionServices.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/FastSessionServices.java
@@ -17,7 +17,6 @@ import org.hibernate.LockOptions;
 import org.hibernate.TimeZoneStorageStrategy;
 import org.hibernate.boot.registry.classloading.spi.ClassLoaderService;
 import org.hibernate.boot.spi.SessionFactoryOptions;
-import org.hibernate.cfg.AvailableSettings;
 import org.hibernate.dialect.Dialect;
 import org.hibernate.engine.jdbc.batch.spi.BatchBuilder;
 import org.hibernate.engine.jdbc.connections.spi.ConnectionProvider;
@@ -59,6 +58,7 @@ import org.hibernate.event.spi.RefreshEventListener;
 import org.hibernate.event.spi.ReplicateEventListener;
 import org.hibernate.event.spi.ResolveNaturalIdEventListener;
 import org.hibernate.event.spi.SaveOrUpdateEventListener;
+import org.hibernate.jpa.HibernateHints;
 import org.hibernate.jpa.LegacySpecHints;
 import org.hibernate.jpa.SpecHints;
 import org.hibernate.jpa.internal.util.CacheModeHelper;
@@ -262,7 +262,7 @@ public final class FastSessionServices {
 	}
 
 	private static FlushMode initializeDefaultFlushMode(Map<String, Object> defaultSessionProperties) {
-		Object setMode = defaultSessionProperties.get( AvailableSettings.FLUSH_MODE );
+		Object setMode = defaultSessionProperties.get( HibernateHints.HINT_FLUSH_MODE );
 		return ConfigurationHelper.getFlushMode( setMode, FlushMode.AUTO );
 	}
 
@@ -290,7 +290,7 @@ public final class FastSessionServices {
 		final HashMap<String,Object> settings = new HashMap<>();
 
 		//Static defaults:
-		settings.putIfAbsent( AvailableSettings.FLUSH_MODE, FlushMode.AUTO.name() );
+		settings.putIfAbsent( HibernateHints.HINT_FLUSH_MODE, FlushMode.AUTO.name() );
 		settings.putIfAbsent( JPA_LOCK_SCOPE, PessimisticLockScope.EXTENDED.name() );
 		settings.putIfAbsent( JAKARTA_LOCK_SCOPE, PessimisticLockScope.EXTENDED.name() );
 		settings.putIfAbsent( JPA_LOCK_TIMEOUT, LockOptions.WAIT_FOREVER );
@@ -308,7 +308,7 @@ public final class FastSessionServices {
 				SpecHints.HINT_SPEC_CACHE_RETRIEVE_MODE,
 				SpecHints.HINT_SPEC_CACHE_STORE_MODE,
 
-				AvailableSettings.FLUSH_MODE,
+				HibernateHints.HINT_FLUSH_MODE,
 
 				LegacySpecHints.HINT_JAVAEE_LOCK_SCOPE,
 				LegacySpecHints.HINT_JAVAEE_LOCK_TIMEOUT,

--- a/hibernate-core/src/main/java/org/hibernate/internal/SessionImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/SessionImpl.java
@@ -151,8 +151,17 @@ import static java.lang.Boolean.parseBoolean;
 import static java.lang.System.currentTimeMillis;
 import static java.util.Collections.unmodifiableMap;
 import static org.hibernate.CacheMode.fromJpaModes;
-import static org.hibernate.cfg.AvailableSettings.*;
+import static org.hibernate.cfg.AvailableSettings.CRITERIA_COPY_TREE;
+import static org.hibernate.cfg.AvailableSettings.JAKARTA_LOCK_SCOPE;
+import static org.hibernate.cfg.AvailableSettings.JAKARTA_LOCK_TIMEOUT;
+import static org.hibernate.cfg.AvailableSettings.JAKARTA_SHARED_CACHE_RETRIEVE_MODE;
+import static org.hibernate.cfg.AvailableSettings.JAKARTA_SHARED_CACHE_STORE_MODE;
+import static org.hibernate.cfg.AvailableSettings.JPA_LOCK_SCOPE;
+import static org.hibernate.cfg.AvailableSettings.JPA_LOCK_TIMEOUT;
+import static org.hibernate.cfg.AvailableSettings.JPA_SHARED_CACHE_RETRIEVE_MODE;
+import static org.hibernate.cfg.AvailableSettings.JPA_SHARED_CACHE_STORE_MODE;
 import static org.hibernate.jpa.HibernateHints.HINT_READ_ONLY;
+import static org.hibernate.jpa.HibernateHints.HINT_FLUSH_MODE;
 import static org.hibernate.jpa.LegacySpecHints.HINT_JAVAEE_LOCK_TIMEOUT;
 import static org.hibernate.jpa.LegacySpecHints.HINT_JAVAEE_QUERY_TIMEOUT;
 import static org.hibernate.jpa.SpecHints.HINT_SPEC_LOCK_TIMEOUT;
@@ -257,7 +266,7 @@ public class SessionImpl
 	private FlushMode getInitialFlushMode() {
 		return properties == null
 				? fastSessionServices.initialSessionFlushMode
-				: ConfigurationHelper.getFlushMode( getSessionProperty( FLUSH_MODE ), FlushMode.AUTO );
+				: ConfigurationHelper.getFlushMode( getSessionProperty( HINT_FLUSH_MODE ), FlushMode.AUTO );
 	}
 
 	private void setUpMultitenancy(SessionFactoryImplementor factory) {
@@ -1607,7 +1616,7 @@ public class SessionImpl
 
 		try {
 			final LazyInitializer li = extractLazyInitializer( object );
-			if ( ! ( li != null ) && persistenceContext.getEntry( object ) == null ) {
+			if ( li == null && persistenceContext.getEntry( object ) == null ) {
 				// check if it is an entity -> if not throw an exception (per JPA)
 				try {
 					getFactory().getRuntimeMetamodels()
@@ -2057,7 +2066,6 @@ public class SessionImpl
 		}
 
 		@Override
-		@SuppressWarnings("unchecked")
 		public SharedSessionBuilderImpl connection() {
 			this.shareTransactionContext = true;
 			return this;
@@ -2635,7 +2643,7 @@ public class SessionImpl
 
 	private void interpretProperty(String propertyName, Object value) {
 		switch ( propertyName ) {
-			case FLUSH_MODE:
+			case HINT_FLUSH_MODE:
 				setHibernateFlushMode( ConfigurationHelper.getFlushMode(value, FlushMode.AUTO) );
 				break;
 			case JPA_LOCK_SCOPE:
@@ -2682,7 +2690,7 @@ public class SessionImpl
 		final Map<String, Object> map = new HashMap<>( fastSessionServices.defaultSessionProperties );
 		//The FLUSH_MODE is always set at Session creation time,
 		//so it needs special treatment to not eagerly initialize this Map:
-		map.put( FLUSH_MODE, getHibernateFlushMode().name() );
+		map.put( HINT_FLUSH_MODE, getHibernateFlushMode().name() );
 		return map;
 	}
 


### PR DESCRIPTION
It's actually a JPA hint, and rightfully belongs on `HibernateHints`.

cc @Sanne 