### PR TITLE
Test against JDK 21 EA, stop testing against JDK 18 

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -44,8 +44,7 @@ stage('Configure') {
 				additionalOptions: '-DdbHost=localhost:4000',
 				notificationRecipients: 'tidb_hibernate@pingcap.com' ),
 		new BuildEnvironment( testJdkVersion: '17' ),
-		new BuildEnvironment( testJdkVersion: '18' ),
-		// We want to enable preview features when testing early-access builds of OpenJDK:
+		// We want to enable preview features when testing newer builds of OpenJDK:
 		// even if we don't use these features, just enabling them can cause side effects
 		// and it's useful to test that.
 		new BuildEnvironment( testJdkVersion: '19', testJdkLauncherArgs: '--enable-preview' ),

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -49,7 +49,8 @@ stage('Configure') {
 		// even if we don't use these features, just enabling them can cause side effects
 		// and it's useful to test that.
 		new BuildEnvironment( testJdkVersion: '19', testJdkLauncherArgs: '--enable-preview' ),
-		new BuildEnvironment( testJdkVersion: '20', testJdkLauncherArgs: '--enable-preview' )
+		new BuildEnvironment( testJdkVersion: '20', testJdkLauncherArgs: '--enable-preview' ),
+		new BuildEnvironment( testJdkVersion: '21', testJdkLauncherArgs: '--enable-preview' )
 	];
 
 	if ( env.CHANGE_ID ) {


### PR DESCRIPTION
JDK 18 EOL'd on 2022-09-20
See https://endoflife.date/java