### PR TITLE
HHH-16059 Add getters and relax scopes

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/mutation/internal/cte/CteInsertStrategy.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/mutation/internal/cte/CteInsertStrategy.java
@@ -154,4 +154,16 @@ public class CteInsertStrategy implements SqmMultiTableInsertStrategy {
 			DomainQueryExecutionContext context) {
 		return new CteInsertHandler( entityCteTable, sqmInsertStatement, domainParameterXref, sessionFactory ).execute( context );
 	}
+
+	protected EntityPersister getRootDescriptor() {
+		return rootDescriptor;
+	}
+
+	protected SessionFactoryImplementor getSessionFactory() {
+		return sessionFactory;
+	}
+
+	protected CteTable getEntityCteTable() {
+		return entityCteTable;
+	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/mutation/internal/cte/CteMutationStrategy.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/mutation/internal/cte/CteMutationStrategy.java
@@ -106,7 +106,7 @@ public class CteMutationStrategy implements SqmMultiTableMutationStrategy {
 		return new CteUpdateHandler( idCteTable, sqmUpdate, domainParameterXref, this, sessionFactory ).execute( context );
 	}
 
-	private void checkMatch(SqmDeleteOrUpdateStatement<?> sqmStatement) {
+	protected void checkMatch(SqmDeleteOrUpdateStatement<?> sqmStatement) {
 		final String targetEntityName = sqmStatement.getTarget().getEntityName();
 		final EntityPersister targetEntityDescriptor = sessionFactory.getRuntimeMetamodels()
 				.getMappingMetamodel()
@@ -123,5 +123,17 @@ public class CteMutationStrategy implements SqmMultiTableMutationStrategy {
 			);
 		}
 
+	}
+
+	protected EntityPersister getRootDescriptor() {
+		return rootDescriptor;
+	}
+
+	protected SessionFactoryImplementor getSessionFactory() {
+		return sessionFactory;
+	}
+
+	protected CteTable getIdCteTable() {
+		return idCteTable;
 	}
 }


### PR DESCRIPTION
So that Hibernate Reactive can avoid copy and paste when extending CteInsertStrategy and CteMutationStrategy

Fix https://hibernate.atlassian.net/browse/HHH-16059