### PR TITLE
HHH-16069 - Defer handling of custom types until after deployment time

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/resource/beans/container/internal/JpaCompliantLifecycleStrategy.java
+++ b/hibernate-core/src/main/java/org/hibernate/resource/beans/container/internal/JpaCompliantLifecycleStrategy.java
@@ -7,11 +7,6 @@
 package org.hibernate.resource.beans.container.internal;
 
 import java.util.Set;
-import jakarta.enterprise.context.spi.CreationalContext;
-import jakarta.enterprise.inject.spi.AnnotatedType;
-import jakarta.enterprise.inject.spi.Bean;
-import jakarta.enterprise.inject.spi.BeanManager;
-import jakarta.enterprise.inject.spi.InjectionTarget;
 
 import org.hibernate.resource.beans.container.spi.BeanContainer;
 import org.hibernate.resource.beans.container.spi.BeanLifecycleStrategy;
@@ -19,6 +14,12 @@ import org.hibernate.resource.beans.container.spi.ContainedBeanImplementor;
 import org.hibernate.resource.beans.spi.BeanInstanceProducer;
 
 import org.jboss.logging.Logger;
+
+import jakarta.enterprise.context.spi.CreationalContext;
+import jakarta.enterprise.inject.spi.AnnotatedType;
+import jakarta.enterprise.inject.spi.Bean;
+import jakarta.enterprise.inject.spi.BeanManager;
+import jakarta.enterprise.inject.spi.InjectionTarget;
 
 /**
  * A {@link BeanLifecycleStrategy} to use when JPA compliance is required
@@ -128,7 +129,7 @@ public class JpaCompliantLifecycleStrategy implements BeanLifecycleStrategy {
 			}
 
 			try {
-				this.injectionTarget = beanManager.getInjectionTargetFactory( annotatedType ).createInjectionTarget( (Bean) null );
+				this.injectionTarget = beanManager.getInjectionTargetFactory( annotatedType ).createInjectionTarget( null );
 				this.creationalContext = beanManager.createCreationalContext( null );
 
 				this.beanInstance = this.injectionTarget.produce( creationalContext );
@@ -223,6 +224,11 @@ public class JpaCompliantLifecycleStrategy implements BeanLifecycleStrategy {
 				return;
 			}
 
+			if ( beanManager == null ) {
+				// CDI is not ready yet, use the fallback producer
+				this.beanInstance = fallbackProducer.produceBeanInstance( beanName, beanType );
+				return;
+			}
 
 			try {
 				this.creationalContext = beanManager.createCreationalContext( null );

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/cdi/type/CdiSmokeTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/cdi/type/CdiSmokeTests.java
@@ -1,0 +1,56 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html.
+ */
+package org.hibernate.orm.test.cdi.type;
+
+import org.hibernate.resource.beans.container.internal.NotYetReadyException;
+
+import org.junit.jupiter.api.Test;
+
+import jakarta.enterprise.context.spi.CreationalContext;
+import jakarta.enterprise.inject.se.SeContainer;
+import jakarta.enterprise.inject.se.SeContainerInitializer;
+import jakarta.enterprise.inject.spi.AnnotatedType;
+import jakarta.enterprise.inject.spi.BeanManager;
+import jakarta.enterprise.inject.spi.InjectionTarget;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Steve Ebersole
+ */
+public class CdiSmokeTests {
+	@Test
+	void testCdiOperations() {
+		final SeContainerInitializer cdiInitializer = SeContainerInitializer.newInstance()
+				.disableDiscovery()
+				.addBeanClasses( UrlType.class, OtherBean.class );
+		try ( final SeContainer cdiContainer = cdiInitializer.initialize() ) {
+			final BeanManager beanManager = cdiContainer.getBeanManager();
+
+			final AnnotatedType<UrlType> annotatedType;
+			try {
+				annotatedType = beanManager.createAnnotatedType( UrlType.class );
+			}
+			catch (Exception e) {
+				throw new IllegalStateException( new NotYetReadyException( e ) );
+			}
+
+			final InjectionTarget<UrlType> injectionTarget = beanManager
+					.getInjectionTargetFactory( annotatedType )
+					.createInjectionTarget( null );
+			final CreationalContext<UrlType> creationalContext = beanManager.createCreationalContext( null );
+
+			final UrlType beanInstance = injectionTarget.produce( creationalContext );
+			injectionTarget.inject( beanInstance, creationalContext );
+
+			injectionTarget.postConstruct( beanInstance );
+
+			assertThat( beanInstance ).isNotNull();
+//			assertThat( beanInstance.getOtherBean() ).isNotNull();
+		}
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/cdi/type/ExtendedBeanManagerImpl.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/cdi/type/ExtendedBeanManagerImpl.java
@@ -1,0 +1,27 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html.
+ */
+package org.hibernate.orm.test.cdi.type;
+
+import org.hibernate.resource.beans.container.spi.ExtendedBeanManager;
+
+import jakarta.enterprise.inject.spi.BeanManager;
+
+/**
+ * @author Steve Ebersole
+ */
+public class ExtendedBeanManagerImpl implements ExtendedBeanManager {
+	private LifecycleListener lifecycleListener;
+
+	@Override
+	public void registerLifecycleListener(LifecycleListener lifecycleListener) {
+		this.lifecycleListener = lifecycleListener;
+	}
+
+	public void injectBeanManager(BeanManager beanManager) {
+		lifecycleListener.beanManagerInitialized( beanManager );
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/cdi/type/OtherBean.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/cdi/type/OtherBean.java
@@ -1,0 +1,17 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html.
+ */
+package org.hibernate.orm.test.cdi.type;
+
+import jakarta.inject.Singleton;
+
+/**
+ * @author Steve Ebersole
+ */
+@Singleton
+public class OtherBean {
+
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/cdi/type/SimpleTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/cdi/type/SimpleTests.java
@@ -1,0 +1,120 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html.
+ */
+package org.hibernate.orm.test.cdi.type;
+
+import java.net.URL;
+
+import org.hibernate.SessionFactory;
+import org.hibernate.annotations.Type;
+import org.hibernate.boot.Metadata;
+import org.hibernate.boot.MetadataSources;
+import org.hibernate.boot.model.process.internal.UserTypeResolution;
+import org.hibernate.boot.registry.StandardServiceRegistry;
+import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
+import org.hibernate.cfg.AvailableSettings;
+import org.hibernate.mapping.BasicValue;
+import org.hibernate.mapping.PersistentClass;
+import org.hibernate.mapping.Property;
+import org.hibernate.tool.schema.Action;
+
+import org.junit.jupiter.api.Test;
+
+import jakarta.enterprise.inject.se.SeContainer;
+import jakarta.enterprise.inject.se.SeContainerInitializer;
+import jakarta.enterprise.inject.spi.BeanManager;
+import jakarta.persistence.Basic;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Steve Ebersole
+ */
+public class SimpleTests {
+	@Test
+	void testProperUsage() {
+		final ExtendedBeanManagerImpl extendedBeanManager = new ExtendedBeanManagerImpl();
+
+		final StandardServiceRegistryBuilder ssrbBuilder = new StandardServiceRegistryBuilder()
+				.applySetting( AvailableSettings.HBM2DDL_AUTO, Action.CREATE_DROP )
+				.applySetting( AvailableSettings.JAKARTA_CDI_BEAN_MANAGER, extendedBeanManager );
+
+		try ( final StandardServiceRegistry ssr = ssrbBuilder.build() ) {
+			final Metadata metadata = new MetadataSources( ssr )
+					.addAnnotatedClass( MappedEntity.class )
+					.buildMetadata();
+
+			final PersistentClass entityBinding = metadata.getEntityBinding( MappedEntity.class.getName() );
+			final Property property = entityBinding.getProperty( "url" );
+			assertThat( property ).isNotNull();
+			assertThat( property.getValue() ).isInstanceOf( BasicValue.class );
+			final BasicValue.Resolution<?> resolution = ( (BasicValue) property.getValue() ).getResolution();
+			assertThat( resolution ).isNotNull();
+			assertThat( resolution ).isInstanceOf( UserTypeResolution.class );
+			assertThat( ( (UserTypeResolution) resolution ).isResolved() ).isFalse();
+
+			final SeContainerInitializer cdiInitializer = SeContainerInitializer.newInstance()
+					.disableDiscovery()
+					.addBeanClasses( UrlType.class, OtherBean.class );
+			try ( final SeContainer cdiContainer = cdiInitializer.initialize() ) {
+				final BeanManager beanManager = cdiContainer.getBeanManager();
+				extendedBeanManager.injectBeanManager( beanManager );
+			}
+
+			try ( final SessionFactory sf = metadata.buildSessionFactory() ) {
+				sf.inSession( (session) -> {
+					session.createSelectionQuery( "from MappedEntity" ).list();
+				} );
+			}
+		}
+
+	}
+
+	@Entity( name = "MappedEntity" )
+	@Table( name = "mapped_entity" )
+	public static class MappedEntity {
+	    @Id
+	    private Integer id;
+	    @Basic
+		private String name;
+		@Basic
+		@Type( UrlType.class )
+		private URL url;
+
+		protected MappedEntity() {
+			// for use by Hibernate
+		}
+
+		public MappedEntity(Integer id, String name, URL url) {
+			this.id = id;
+			this.name = name;
+			this.url = url;
+		}
+
+		public Integer getId() {
+			return id;
+		}
+
+		public String getName() {
+			return name;
+		}
+
+		public void setName(String name) {
+			this.name = name;
+		}
+
+		public URL getUrl() {
+			return url;
+		}
+
+		public void setUrl(URL url) {
+			this.url = url;
+		}
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/cdi/type/UrlType.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/cdi/type/UrlType.java
@@ -1,0 +1,90 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html.
+ */
+package org.hibernate.orm.test.cdi.type;
+
+import java.io.Serializable;
+import java.net.URL;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+import org.hibernate.engine.spi.SharedSessionContractImplementor;
+import org.hibernate.type.SqlTypes;
+import org.hibernate.usertype.UserType;
+
+import jakarta.inject.Singleton;
+import org.assertj.core.util.Objects;
+
+/**
+ * @author Steve Ebersole
+ */
+@Singleton
+public class UrlType implements UserType<URL> {
+//	private final OtherBean otherBean;
+//
+//	@Inject
+//	public UrlType(OtherBean otherBean) {
+//		if ( otherBean == null ) {
+//			throw new UnsupportedOperationException( "OtherBean cannot be null" );
+//		}
+//		this.otherBean = otherBean;
+//	}
+//
+//	public OtherBean getOtherBean() {
+//		return otherBean;
+//	}
+
+	@Override
+	public int getSqlType() {
+		return SqlTypes.VARCHAR;
+	}
+
+	@Override
+	public Class<URL> returnedClass() {
+		return URL.class;
+	}
+
+	@Override
+	public boolean equals(URL x, URL y) {
+		return Objects.areEqual( x, y );
+	}
+
+	@Override
+	public int hashCode(URL x) {
+		return Objects.hashCodeFor( x );
+	}
+
+	@Override
+	public URL nullSafeGet(ResultSet rs, int position, SharedSessionContractImplementor session, Object owner) throws SQLException {
+		throw new UnsupportedOperationException( "Not used" );
+	}
+
+	@Override
+	public void nullSafeSet(PreparedStatement st, URL value, int index, SharedSessionContractImplementor session) throws SQLException {
+		throw new UnsupportedOperationException( "Not used" );
+	}
+
+	@Override
+	public URL deepCopy(URL value) {
+		throw new UnsupportedOperationException( "Not used" );
+	}
+
+	@Override
+	public boolean isMutable() {
+		return false;
+	}
+
+	@Override
+	public Serializable disassemble(URL value) {
+		throw new UnsupportedOperationException( "Not used" );
+	}
+
+	@Override
+	public URL assemble(Serializable cached, Object owner) {
+		throw new UnsupportedOperationException( "Not used" );
+	}
+}


### PR DESCRIPTION
This form simply falls back to non-CDI creation if the BeanManager is not yet ready to use.

Not sure how kosher this is as it happens inconsistently such that some UserType implementations get resolved via CDI and others not.  The inconsistency concerns me.

Going to create an alternative that simply never uses CDI for UserType when using the extended or delayed strategies