### PR TITLE
HHH-16069 - Skip CDI for Hibernate extensions by default

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/boot/internal/MetadataBuilderImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/internal/MetadataBuilderImpl.java
@@ -607,6 +607,7 @@ public class MetadataBuilderImpl implements MetadataBuilderImplementor, TypeCont
 
 		private final String schemaCharset;
 		private final boolean xmlMappingEnabled;
+		private final boolean allowExtensionsInCdi;
 
 		public MetadataBuildingOptionsImpl(StandardServiceRegistry serviceRegistry) {
 			this.serviceRegistry = serviceRegistry;
@@ -762,6 +763,12 @@ public class MetadataBuilderImpl implements MetadataBuilderImplementor, TypeCont
 					AvailableSettings.HBM2DDL_CHARSET_NAME,
 					String.class,
 					null
+			);
+
+			allowExtensionsInCdi = configService.getSetting(
+					AvailableSettings.ALLOW_EXTENSIONS_IN_CDI,
+					StandardConverters.BOOLEAN,
+					false
 			);
 		}
 
@@ -949,6 +956,11 @@ public class MetadataBuilderImpl implements MetadataBuilderImplementor, TypeCont
 		@Override
 		public boolean isXmlMappingEnabled() {
 			return xmlMappingEnabled;
+		}
+
+		@Override
+		public boolean disallowExtensionsInCdi() {
+			return allowExtensionsInCdi;
 		}
 
 		/**

--- a/hibernate-core/src/main/java/org/hibernate/boot/model/internal/DelayedParameterizedTypeBean.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/internal/DelayedParameterizedTypeBean.java
@@ -1,0 +1,74 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html.
+ */
+package org.hibernate.boot.model.internal;
+
+import java.util.Properties;
+
+import org.hibernate.boot.BootLogging;
+import org.hibernate.internal.util.collections.CollectionHelper;
+import org.hibernate.resource.beans.spi.ManagedBean;
+import org.hibernate.usertype.ParameterizedType;
+
+/**
+ * ManagedBean implementation for delayed {@link ParameterizedType}
+ * handling (parameter injection) for a UserCollectionType
+ *
+ * @author Steve Ebersole
+ */
+public class DelayedParameterizedTypeBean<T> implements ManagedBean<T> {
+	private final ManagedBean<T> underlyingBean;
+	private final Properties properties;
+
+	private T instance;
+
+	public DelayedParameterizedTypeBean(ManagedBean<T> underlyingBean, Properties properties) {
+		assert ParameterizedType.class.isAssignableFrom( underlyingBean.getBeanClass() );
+		this.underlyingBean = underlyingBean;
+		this.properties = properties;
+	}
+
+	@Override
+	public Class<T> getBeanClass() {
+		return underlyingBean.getBeanClass();
+	}
+
+	@Override
+	public T getBeanInstance() {
+		if ( instance == null ) {
+			instance = underlyingBean.getBeanInstance();
+			( (ParameterizedType) instance ).setParameterValues( properties );
+		}
+		return instance;
+	}
+
+	/**
+	 * Create a bean wrapper which delays parameter injection
+	 * until the bean instance is needed if there are parameters
+	 */
+	public static <T> ManagedBean<T> delayedConfigBean(
+			String role,
+			ManagedBean<T> bean,
+			Properties properties) {
+		if ( CollectionHelper.isNotEmpty( properties ) ) {
+			if ( ParameterizedType.class.isAssignableFrom( bean.getBeanClass() ) ) {
+				return new DelayedParameterizedTypeBean<>( bean, properties );
+			}
+
+			// there were parameters, but the custom-type does not implement the interface
+			// used to inject them - log a "warning"
+			BootLogging.BOOT_LOGGER.debugf(
+					"`@CollectionType` (%s) specified parameters, but the" +
+							" implementation does not implement `%s` which is used to inject them - `%s`",
+					role,
+					ParameterizedType.class.getName(),
+					bean.getBeanClass().getName()
+			);
+		}
+
+		return bean;
+	}
+}

--- a/hibernate-core/src/main/java/org/hibernate/boot/spi/AbstractDelegatingMetadataBuildingOptions.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/spi/AbstractDelegatingMetadataBuildingOptions.java
@@ -7,7 +7,7 @@
 package org.hibernate.boot.spi;
 
 import java.util.List;
-import jakarta.persistence.SharedCacheMode;
+
 import org.hibernate.HibernateException;
 import org.hibernate.TimeZoneStorageStrategy;
 import org.hibernate.boot.model.IdGeneratorStrategyInterpreter;
@@ -20,6 +20,8 @@ import org.hibernate.cfg.MetadataSourceType;
 import org.hibernate.dialect.TimeZoneSupport;
 import org.hibernate.id.factory.IdentifierGeneratorFactory;
 import org.hibernate.type.spi.TypeConfiguration;
+
+import jakarta.persistence.SharedCacheMode;
 
 /**
  * Convenience base class for custom implementors of {@link MetadataBuildingOptions} using delegation.
@@ -169,4 +171,8 @@ public abstract class AbstractDelegatingMetadataBuildingOptions implements Metad
 		return delegate.isXmlMappingEnabled();
 	}
 
+	@Override
+	public boolean disallowExtensionsInCdi() {
+		return delegate.disallowExtensionsInCdi();
+	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/boot/spi/MetadataBuildingOptions.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/spi/MetadataBuildingOptions.java
@@ -8,8 +8,6 @@ package org.hibernate.boot.spi;
 
 import java.util.List;
 
-import jakarta.persistence.SharedCacheMode;
-
 import org.hibernate.TimeZoneStorageStrategy;
 import org.hibernate.boot.model.IdGeneratorStrategyInterpreter;
 import org.hibernate.boot.model.naming.ImplicitNamingStrategy;
@@ -26,6 +24,8 @@ import org.hibernate.id.factory.IdentifierGeneratorFactory;
 import org.hibernate.metamodel.internal.ManagedTypeRepresentationResolverStandard;
 import org.hibernate.metamodel.spi.ManagedTypeRepresentationResolver;
 import org.hibernate.type.spi.TypeConfiguration;
+
+import jakarta.persistence.SharedCacheMode;
 
 /**
  * Describes the options used while building the {@link org.hibernate.boot.Metadata}
@@ -231,4 +231,9 @@ public interface MetadataBuildingOptions {
 	default boolean isXmlMappingEnabled() {
 		return true;
 	}
+
+	/**
+	 * Check to see if extensions can be hosted in CDI
+	 */
+	boolean disallowExtensionsInCdi();
 }

--- a/hibernate-core/src/main/java/org/hibernate/cfg/AvailableSettings.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/AvailableSettings.java
@@ -1308,6 +1308,16 @@ public interface AvailableSettings {
 	 */
 	String DELAY_CDI_ACCESS = "hibernate.delay_cdi_access";
 
+	/**
+	 * Controls whether Hibernate can try to create beans other than converters
+	 * and listeners using CDI.  Only meaningful when a CDI {@link #BEAN_CONTAINER container}
+	 * is used.
+	 *
+	 * By default, Hibernate will only attempt to create converter and listener beans using CDI.
+	 *
+	 * @since 6.2
+	 */
+	String ALLOW_EXTENSIONS_IN_CDI = "hibernate.cdi.extensions";
 
 
 	// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/hibernate-core/src/main/java/org/hibernate/id/factory/internal/StandardIdentifierGeneratorFactory.java
+++ b/hibernate-core/src/main/java/org/hibernate/id/factory/internal/StandardIdentifierGeneratorFactory.java
@@ -74,7 +74,7 @@ public class StandardIdentifierGeneratorFactory
 	 * Constructs a new factory
 	 */
 	public StandardIdentifierGeneratorFactory(ServiceRegistry serviceRegistry) {
-		this( serviceRegistry, Helper.shouldIgnoreBeanContainer( serviceRegistry ) );
+		this( serviceRegistry, !Helper.allowExtensionsInCdi( serviceRegistry ) );
 	}
 
 	/**

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/internal/ManagedTypeRepresentationResolverStandard.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/internal/ManagedTypeRepresentationResolverStandard.java
@@ -20,6 +20,7 @@ import org.hibernate.metamodel.spi.EntityRepresentationStrategy;
 import org.hibernate.metamodel.spi.ManagedTypeRepresentationResolver;
 import org.hibernate.metamodel.spi.RuntimeModelCreationContext;
 import org.hibernate.persister.entity.EntityPersister;
+import org.hibernate.resource.beans.internal.FallbackBeanInstanceProducer;
 import org.hibernate.resource.beans.spi.ManagedBeanRegistry;
 import org.hibernate.usertype.CompositeUserType;
 
@@ -78,32 +79,42 @@ public class ManagedTypeRepresentationResolverStandard implements ManagedTypeRep
 			}
 		}
 
-		final CompositeUserType<Object> compositeUserType;
+		final CompositeUserType<?> compositeUserType;
 		if ( bootDescriptor.getTypeName() != null ) {
-			compositeUserType = (CompositeUserType<Object>) creationContext.getBootstrapContext()
-					.getServiceRegistry()
-					.getService( ManagedBeanRegistry.class )
-					.getBean(
-							creationContext.getBootstrapContext()
-									.getClassLoaderAccess()
-									.classForName( bootDescriptor.getTypeName() )
-					)
-					.getBeanInstance();
+			final Class<CompositeUserType<?>> userTypeClass = creationContext.getBootstrapContext()
+					.getClassLoaderAccess()
+					.classForName( bootDescriptor.getTypeName() );
+			if ( creationContext.getBootModel().getMetadataBuildingOptions().disallowExtensionsInCdi() ) {
+				compositeUserType = FallbackBeanInstanceProducer.INSTANCE.produceBeanInstance( userTypeClass );
+			}
+			else {
+				compositeUserType = creationContext.getBootstrapContext()
+						.getServiceRegistry()
+						.getService( ManagedBeanRegistry.class )
+						.getBean( userTypeClass )
+						.getBeanInstance();
+			}
 		}
 		else {
 			compositeUserType = null;
 		}
 		final EmbeddableInstantiator customInstantiator;
 		if ( bootDescriptor.getCustomInstantiator() != null ) {
-			final Class<? extends EmbeddableInstantiator> customInstantiatorImpl = bootDescriptor.getCustomInstantiator();
-			customInstantiator = creationContext.getBootstrapContext()
-					.getServiceRegistry()
-					.getService( ManagedBeanRegistry.class )
-					.getBean( customInstantiatorImpl )
-					.getBeanInstance();
+			final Class<? extends EmbeddableInstantiator> instantiatorClass = bootDescriptor.getCustomInstantiator();
+			if ( creationContext.getBootModel().getMetadataBuildingOptions().disallowExtensionsInCdi() ) {
+				customInstantiator = FallbackBeanInstanceProducer.INSTANCE.produceBeanInstance( instantiatorClass );
+			}
+			else {
+				customInstantiator = creationContext.getBootstrapContext()
+						.getServiceRegistry()
+						.getService( ManagedBeanRegistry.class )
+						.getBean( instantiatorClass )
+						.getBeanInstance();
+			}
 		}
 		else if ( compositeUserType != null ) {
-			customInstantiator = new EmbeddableCompositeUserTypeInstantiator( compositeUserType );
+			//noinspection unchecked,rawtypes
+			customInstantiator = new EmbeddableCompositeUserTypeInstantiator( (CompositeUserType) compositeUserType );
 		}
 		else if ( bootDescriptor.getComponentClassName() != null && ReflectHelper.isRecord( bootDescriptor.getComponentClass() ) ) {
 			if ( bootDescriptor.sortProperties() == null ) {
@@ -143,11 +154,12 @@ public class ManagedTypeRepresentationResolverStandard implements ManagedTypeRep
 			//
 			//		instead, resolve ReflectionOptimizer once - here - and pass along to
 			//		StandardPojoRepresentationStrategy
+			//noinspection unchecked
 			return new EmbeddableRepresentationStrategyPojo(
 					bootDescriptor,
 					runtimeDescriptorAccess,
 					customInstantiator,
-					compositeUserType,
+					(CompositeUserType<Object>) compositeUserType,
 					creationContext
 			);
 		}

--- a/hibernate-core/src/main/java/org/hibernate/resource/beans/internal/Helper.java
+++ b/hibernate-core/src/main/java/org/hibernate/resource/beans/internal/Helper.java
@@ -9,10 +9,9 @@ package org.hibernate.resource.beans.internal;
 import org.hibernate.cfg.AvailableSettings;
 import org.hibernate.engine.config.spi.ConfigurationService;
 import org.hibernate.engine.config.spi.StandardConverters;
-import org.hibernate.resource.beans.container.spi.BeanLifecycleStrategy;
 import org.hibernate.resource.beans.container.internal.ContainerManagedLifecycleStrategy;
 import org.hibernate.resource.beans.container.internal.JpaCompliantLifecycleStrategy;
-import org.hibernate.resource.beans.container.spi.ExtendedBeanManager;
+import org.hibernate.resource.beans.container.spi.BeanLifecycleStrategy;
 import org.hibernate.service.ServiceRegistry;
 
 /**
@@ -31,19 +30,13 @@ public final class Helper {
 		return beanType.getName() + ':' + name;
 	}
 
-	public static boolean shouldIgnoreBeanContainer(ServiceRegistry serviceRegistry) {
+	public static boolean allowExtensionsInCdi(ServiceRegistry serviceRegistry) {
 		final ConfigurationService configService = serviceRegistry.getService( ConfigurationService.class );
-		final Object beanManagerRef = configService.getSettings().get( AvailableSettings.JAKARTA_CDI_BEAN_MANAGER );
-
-		if ( beanManagerRef instanceof ExtendedBeanManager ) {
-			return true;
-		}
-
-		if ( configService.getSetting( AvailableSettings.DELAY_CDI_ACCESS, StandardConverters.BOOLEAN, false ) ) {
-			return true;
-		}
-
-		return false;
+		return configService.getSetting(
+				AvailableSettings.ALLOW_EXTENSIONS_IN_CDI,
+				StandardConverters.BOOLEAN,
+				false
+		);
 	}
 
 	@SuppressWarnings("unused")

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/cdi/type/CdiSmokeTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/cdi/type/CdiSmokeTests.java
@@ -1,0 +1,56 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html.
+ */
+package org.hibernate.orm.test.cdi.type;
+
+import org.hibernate.resource.beans.container.internal.NotYetReadyException;
+
+import org.junit.jupiter.api.Test;
+
+import jakarta.enterprise.context.spi.CreationalContext;
+import jakarta.enterprise.inject.se.SeContainer;
+import jakarta.enterprise.inject.se.SeContainerInitializer;
+import jakarta.enterprise.inject.spi.AnnotatedType;
+import jakarta.enterprise.inject.spi.BeanManager;
+import jakarta.enterprise.inject.spi.InjectionTarget;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Steve Ebersole
+ */
+public class CdiSmokeTests {
+	@Test
+	void testCdiOperations() {
+		final SeContainerInitializer cdiInitializer = SeContainerInitializer.newInstance()
+				.disableDiscovery()
+				.addBeanClasses( UrlType.class, OtherBean.class );
+		try ( final SeContainer cdiContainer = cdiInitializer.initialize() ) {
+			final BeanManager beanManager = cdiContainer.getBeanManager();
+
+			final AnnotatedType<UrlType> annotatedType;
+			try {
+				annotatedType = beanManager.createAnnotatedType( UrlType.class );
+			}
+			catch (Exception e) {
+				throw new IllegalStateException( new NotYetReadyException( e ) );
+			}
+
+			final InjectionTarget<UrlType> injectionTarget = beanManager
+					.getInjectionTargetFactory( annotatedType )
+					.createInjectionTarget( null );
+			final CreationalContext<UrlType> creationalContext = beanManager.createCreationalContext( null );
+
+			final UrlType beanInstance = injectionTarget.produce( creationalContext );
+			injectionTarget.inject( beanInstance, creationalContext );
+
+			injectionTarget.postConstruct( beanInstance );
+
+			assertThat( beanInstance ).isNotNull();
+//			assertThat( beanInstance.getOtherBean() ).isNotNull();
+		}
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/cdi/type/ExtendedBeanManagerImpl.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/cdi/type/ExtendedBeanManagerImpl.java
@@ -1,0 +1,27 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html.
+ */
+package org.hibernate.orm.test.cdi.type;
+
+import org.hibernate.resource.beans.container.spi.ExtendedBeanManager;
+
+import jakarta.enterprise.inject.spi.BeanManager;
+
+/**
+ * @author Steve Ebersole
+ */
+public class ExtendedBeanManagerImpl implements ExtendedBeanManager {
+	private LifecycleListener lifecycleListener;
+
+	@Override
+	public void registerLifecycleListener(LifecycleListener lifecycleListener) {
+		this.lifecycleListener = lifecycleListener;
+	}
+
+	public void injectBeanManager(BeanManager beanManager) {
+		lifecycleListener.beanManagerInitialized( beanManager );
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/cdi/type/OtherBean.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/cdi/type/OtherBean.java
@@ -1,0 +1,13 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html.
+ */
+package org.hibernate.orm.test.cdi.type;
+
+/**
+ * @author Steve Ebersole
+ */
+public class OtherBean {
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/cdi/type/SimpleTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/cdi/type/SimpleTests.java
@@ -1,0 +1,120 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html.
+ */
+package org.hibernate.orm.test.cdi.type;
+
+import java.net.URL;
+
+import org.hibernate.SessionFactory;
+import org.hibernate.annotations.Type;
+import org.hibernate.boot.Metadata;
+import org.hibernate.boot.MetadataSources;
+import org.hibernate.boot.model.process.internal.UserTypeResolution;
+import org.hibernate.boot.registry.StandardServiceRegistry;
+import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
+import org.hibernate.cfg.AvailableSettings;
+import org.hibernate.mapping.BasicValue;
+import org.hibernate.mapping.PersistentClass;
+import org.hibernate.mapping.Property;
+import org.hibernate.tool.schema.Action;
+
+import org.junit.jupiter.api.Test;
+
+import jakarta.enterprise.inject.se.SeContainer;
+import jakarta.enterprise.inject.se.SeContainerInitializer;
+import jakarta.enterprise.inject.spi.BeanManager;
+import jakarta.persistence.Basic;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Steve Ebersole
+ */
+public class SimpleTests {
+	@Test
+	void testProperUsage() {
+		final ExtendedBeanManagerImpl extendedBeanManager = new ExtendedBeanManagerImpl();
+
+		final StandardServiceRegistryBuilder ssrbBuilder = new StandardServiceRegistryBuilder()
+				.applySetting( AvailableSettings.HBM2DDL_AUTO, Action.CREATE_DROP )
+				.applySetting( AvailableSettings.JAKARTA_CDI_BEAN_MANAGER, extendedBeanManager );
+
+		try ( final StandardServiceRegistry ssr = ssrbBuilder.build() ) {
+			final Metadata metadata = new MetadataSources( ssr )
+					.addAnnotatedClass( MappedEntity.class )
+					.buildMetadata();
+
+			final PersistentClass entityBinding = metadata.getEntityBinding( MappedEntity.class.getName() );
+			final Property property = entityBinding.getProperty( "url" );
+			assertThat( property ).isNotNull();
+			assertThat( property.getValue() ).isInstanceOf( BasicValue.class );
+			final BasicValue.Resolution<?> resolution = ( (BasicValue) property.getValue() ).getResolution();
+			assertThat( resolution ).isNotNull();
+			assertThat( resolution ).isInstanceOf( UserTypeResolution.class );
+//			assertThat( ( (UserTypeResolution) resolution ).isResolved() ).isFalse();
+
+			final SeContainerInitializer cdiInitializer = SeContainerInitializer.newInstance()
+					.disableDiscovery()
+					.addBeanClasses( UrlType.class, OtherBean.class );
+			try ( final SeContainer cdiContainer = cdiInitializer.initialize() ) {
+				final BeanManager beanManager = cdiContainer.getBeanManager();
+				extendedBeanManager.injectBeanManager( beanManager );
+			}
+
+			try ( final SessionFactory sf = metadata.buildSessionFactory() ) {
+				sf.inSession( (session) -> {
+					session.createSelectionQuery( "from MappedEntity" ).list();
+				} );
+			}
+		}
+
+	}
+
+	@Entity( name = "MappedEntity" )
+	@Table( name = "mapped_entity" )
+	public static class MappedEntity {
+		@Id
+		private Integer id;
+		@Basic
+		private String name;
+		@Basic
+		@Type( UrlType.class )
+		private URL url;
+
+		protected MappedEntity() {
+			// for use by Hibernate
+		}
+
+		public MappedEntity(Integer id, String name, URL url) {
+			this.id = id;
+			this.name = name;
+			this.url = url;
+		}
+
+		public Integer getId() {
+			return id;
+		}
+
+		public String getName() {
+			return name;
+		}
+
+		public void setName(String name) {
+			this.name = name;
+		}
+
+		public URL getUrl() {
+			return url;
+		}
+
+		public void setUrl(URL url) {
+			this.url = url;
+		}
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/cdi/type/UrlType.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/cdi/type/UrlType.java
@@ -1,0 +1,91 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html.
+ */
+package org.hibernate.orm.test.cdi.type;
+
+import java.io.Serializable;
+import java.net.URL;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+import org.hibernate.engine.spi.SharedSessionContractImplementor;
+import org.hibernate.type.SqlTypes;
+import org.hibernate.usertype.UserType;
+
+import jakarta.inject.Singleton;
+import org.assertj.core.util.Objects;
+
+/**
+ * @author Steve Ebersole
+ */
+@Singleton
+public class UrlType implements UserType<URL> {
+// because we cannot use CDI, injection is not available
+//	private final OtherBean otherBean;
+//
+//	@Inject
+//	public UrlType(OtherBean otherBean) {
+//		if ( otherBean == null ) {
+//			throw new UnsupportedOperationException( "OtherBean cannot be null" );
+//		}
+//		this.otherBean = otherBean;
+//	}
+//
+//	public OtherBean getOtherBean() {
+//		return otherBean;
+//	}
+
+	@Override
+	public int getSqlType() {
+		return SqlTypes.VARCHAR;
+	}
+
+	@Override
+	public Class<URL> returnedClass() {
+		return URL.class;
+	}
+
+	@Override
+	public boolean equals(URL x, URL y) {
+		return Objects.areEqual( x, y );
+	}
+
+	@Override
+	public int hashCode(URL x) {
+		return Objects.hashCodeFor( x );
+	}
+
+	@Override
+	public URL nullSafeGet(ResultSet rs, int position, SharedSessionContractImplementor session, Object owner) throws SQLException {
+		throw new UnsupportedOperationException( "Not used" );
+	}
+
+	@Override
+	public void nullSafeSet(PreparedStatement st, URL value, int index, SharedSessionContractImplementor session) throws SQLException {
+		throw new UnsupportedOperationException( "Not used" );
+	}
+
+	@Override
+	public URL deepCopy(URL value) {
+		throw new UnsupportedOperationException( "Not used" );
+	}
+
+	@Override
+	public boolean isMutable() {
+		return false;
+	}
+
+	@Override
+	public Serializable disassemble(URL value) {
+		throw new UnsupportedOperationException( "Not used" );
+	}
+
+	@Override
+	public URL assemble(Serializable cached, Object owner) {
+		throw new UnsupportedOperationException( "Not used" );
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/idgen/userdefined/UserDefinedGeneratorsTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/idgen/userdefined/UserDefinedGeneratorsTests.java
@@ -6,22 +6,8 @@
  */
 package org.hibernate.orm.test.idgen.userdefined;
 
-import static org.hamcrest.CoreMatchers.instanceOf;
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.same;
-import static org.mockito.BDDMockito.given;
-import static org.mockito.BDDMockito.then;
-import static org.mockito.Mockito.times;
-
 import java.io.Serializable;
 import java.util.concurrent.atomic.AtomicInteger;
-
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.Id;
-import jakarta.persistence.Table;
 
 import org.hibernate.annotations.GenericGenerator;
 import org.hibernate.boot.Metadata;
@@ -39,12 +25,25 @@ import org.hibernate.resource.beans.container.spi.BeanContainer;
 import org.hibernate.resource.beans.container.spi.BeanContainer.LifecycleOptions;
 import org.hibernate.resource.beans.container.spi.ContainedBean;
 import org.hibernate.resource.beans.internal.FallbackBeanInstanceProducer;
+
 import org.hibernate.testing.TestForIssue;
 import org.hibernate.testing.orm.junit.BaseUnitTest;
-
 import org.junit.jupiter.api.Test;
 
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
 import org.mockito.Mockito;
+
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.same;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.times;
 
 /**
  * @author Yanming Zhou
@@ -65,7 +64,8 @@ public class UserDefinedGeneratorsTests {
 		} );
 		
 		final StandardServiceRegistryBuilder ssrb = new StandardServiceRegistryBuilder();
-		ssrb.applySetting( AvailableSettings.BEAN_CONTAINER, beanContainer );
+		ssrb.applySetting( AvailableSettings.BEAN_CONTAINER, beanContainer )
+				.applySetting( AvailableSettings.ALLOW_EXTENSIONS_IN_CDI, "true" );
 
 		try (final StandardServiceRegistry ssr = ssrb.build()) {
 			final Metadata metadata = new MetadataSources( ssr )

--- a/hibernate-envers/src/main/java/org/hibernate/envers/configuration/internal/metadata/ComponentMetadataGenerator.java
+++ b/hibernate-envers/src/main/java/org/hibernate/envers/configuration/internal/metadata/ComponentMetadataGenerator.java
@@ -56,12 +56,13 @@ public final class ComponentMetadataGenerator extends AbstractMetadataGenerator 
 			if ( getMetadataBuildingContext().getBuildingOptions().disallowExtensionsInCdi() ) {
 				instantiator = FallbackBeanInstanceProducer.INSTANCE.produceBeanInstance( propComponent.getCustomInstantiator() );
 			}
-			else
+			else {
 				instantiator = getMetadataBuildingContext().getBootstrapContext()
-					.getServiceRegistry()
-					.getService( ManagedBeanRegistry.class )
-					.getBean( propComponent.getCustomInstantiator() )
-					.getBeanInstance();
+						.getServiceRegistry()
+						.getService( ManagedBeanRegistry.class )
+						.getBean( propComponent.getCustomInstantiator() )
+						.getBeanInstance();
+			}
 		}
 		else if ( propComponent.getTypeName() != null ) {
 			final Class<CompositeUserType<?>> userTypeClass = getMetadataBuildingContext().getBootstrapContext()

--- a/hibernate-envers/src/main/java/org/hibernate/envers/internal/revisioninfo/DefaultRevisionInfoGenerator.java
+++ b/hibernate-envers/src/main/java/org/hibernate/envers/internal/revisioninfo/DefaultRevisionInfoGenerator.java
@@ -15,8 +15,11 @@ import org.hibernate.envers.RevisionType;
 import org.hibernate.envers.exception.AuditException;
 import org.hibernate.envers.internal.synchronization.SessionCacheCleaner;
 import org.hibernate.internal.util.ReflectHelper;
+import org.hibernate.resource.beans.internal.FallbackBeanInstanceProducer;
+import org.hibernate.resource.beans.internal.Helper;
 import org.hibernate.resource.beans.spi.ManagedBean;
 import org.hibernate.resource.beans.spi.ManagedBeanRegistry;
+import org.hibernate.resource.beans.spi.ProvidedInstanceManagedBeanImpl;
 import org.hibernate.service.ServiceRegistry;
 
 /**
@@ -107,6 +110,11 @@ public class DefaultRevisionInfoGenerator implements RevisionInfoGenerator {
 			Class<? extends RevisionListener> listenerClass,
 			ServiceRegistry serviceRegistry) {
 		if ( !listenerClass.equals( RevisionListener.class ) ) {
+			if ( Helper.allowExtensionsInCdi( serviceRegistry ) ) {
+				return new ProvidedInstanceManagedBeanImpl<>(
+						FallbackBeanInstanceProducer.INSTANCE.produceBeanInstance( listenerClass )
+				);
+			}
 			return serviceRegistry.getService( ManagedBeanRegistry.class ).getBean( listenerClass );
 		}
 		return null;

--- a/migration-guide.adoc
+++ b/migration-guide.adoc
@@ -144,6 +144,26 @@ The minimum supported dialect versions are as follows:
 |2.6.1
 |===
 
+
+[[cdi]]
+== Changes to CDI handling
+
+When CDI is available and configured, Hibernate can use the CDI `BeanManager` to resolve various
+bean references.  JPA explicitly defines support for this for both attribute-converters and
+entity-listeners.
+
+Hibernate also has the ability to resolve some of its extension points using the CDI `BeanManager`.
+Version 6.2 adds a new boolean `hibernate.cdi.extensions` setting to control this:
+
+true:: indicates to use the CDI `BeanManager` to resolve these extensions
+false:: (the default) indicates to not use the CDI `BeanManager` to resolve these extensions
+
+The previous behavior was to always load the extensions from CDI if it was available.  However,
+this can sometimes lead to timing issues with the `BeanManager` not being ready for use when we need
+those extension beans.  Starting with 6.2, these extensions will only be resolved from the CDI
+`BeanManager` is `hibernate.cdi.extensions` is set to true.
+
+
 [[enhancement]]
 == Change enhancement defaults and deprecation
 


### PR DESCRIPTION
This is a fourth option for dealing with "deferred" CDI access.

In this one we only look for converters and listeners in CDI by default.  To enable resolving Hibernate extensions in CDI, a setting (`hibernate.cdi.extensions`, false by default) has been introduced