### PR TITLE
HHH-16099 Introduce three-state handling for dirty levels to avoid excessive warnings

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/persister/entity/mutation/AttributeAnalysis.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/entity/mutation/AttributeAnalysis.java
@@ -37,7 +37,7 @@ public interface AttributeAnalysis {
 	/**
 	 * Whether the attribute is considered dirty
 	 */
-	boolean isDirty();
+	DirtynessStatus getDirtynessStatus();
 
 	/**
 	 * Whether the attribute be skipped completely.
@@ -48,4 +48,30 @@ public interface AttributeAnalysis {
 	default boolean isSkipped() {
 		return !includeInSet() && !includeInLocking();
 	}
+
+	/**
+	 * Dirty-ness status of each attribute:
+	 * it's useful to differentiate when it's definitely dirty,
+	 * when it's definitely not dirty, and when we need to treat
+	 * it like dirty but there is no certainty - for example
+	 * because we didn't actually load the value from the database.
+	 */
+	enum DirtynessStatus {
+		DIRTY,
+		NOT_DIRTY {
+			@Override
+			boolean isDirty() {
+				return false;
+			}
+		},
+		CONSIDER_LIKE_DIRTY;
+
+		/**
+		 * @return both DIRTY and CONSIDER_LIKE_DIRTY states will return {@code true}
+		 */
+		boolean isDirty() {
+			return true;
+		}
+	};
+
 }


### PR DESCRIPTION
Additional logging cleanups related to
 - https://hibernate.atlassian.net/browse/HHH-16099