### PR TITLE
HHH-16106 Using BatchEntitySelectFetchInitializer causes PostLoad to be called before references are initialized

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/sql/results/jdbc/internal/JdbcValuesSourceProcessingStateStandardImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/jdbc/internal/JdbcValuesSourceProcessingStateStandardImpl.java
@@ -163,13 +163,6 @@ public class JdbcValuesSourceProcessingStateStandardImpl implements JdbcValuesSo
 
 	@Override
 	public void finishUp() {
-		// for arrays, we should end the collection load beforeQuery resolving the entities, since the
-		// actual array instances are not instantiated during loading
-		finishLoadingArrays();
-
-		// now finish loading the entities (2-phase load)
-		performTwoPhaseLoad();
-
 		// now we can finalize loading collections
 		finishLoadingCollections();
 
@@ -205,22 +198,6 @@ public class JdbcValuesSourceProcessingStateStandardImpl implements JdbcValuesSo
 				}
 		);
 		loadingEntityMap = null;
-	}
-
-	private void finishLoadingArrays() {
-		if ( arrayInitializers != null ) {
-			for ( CollectionInitializer collectionInitializer : arrayInitializers ) {
-				collectionInitializer.endLoading( executionContext );
-			}
-		}
-	}
-
-
-	private void performTwoPhaseLoad() {
-		if ( loadingEntityMap == null ) {
-			return;
-		}
-		log.tracev( "Total objects hydrated: {0}", loadingEntityMap.size() );
 	}
 
 	@SuppressWarnings("SimplifiableIfStatement")

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/spi/ListResultsConsumer.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/spi/ListResultsConsumer.java
@@ -201,6 +201,7 @@ public class ListResultsConsumer<R> implements ResultsConsumer<List<R>, R> {
 			}
 
 			try {
+				rowReader.finishUp( jdbcValuesSourceProcessingState );
 				jdbcValuesSourceProcessingState.finishUp();
 			}
 			finally {
@@ -220,7 +221,7 @@ public class ListResultsConsumer<R> implements ResultsConsumer<List<R>, R> {
 		}
 		finally {
 			try {
-				rowReader.finishUp( jdbcValuesSourceProcessingState );
+
 				jdbcValues.finishUp( session );
 				persistenceContext.initializeNonLazyCollections();
 			}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/batch/BatchPostLoadTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/batch/BatchPostLoadTest.java
@@ -1,0 +1,123 @@
+package org.hibernate.orm.test.batch;
+
+import org.hibernate.annotations.BatchSize;
+
+import org.hibernate.testing.TestForIssue;
+import org.hibernate.testing.orm.junit.EntityManagerFactoryScope;
+import org.hibernate.testing.orm.junit.Jpa;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.PostLoad;
+import jakarta.persistence.criteria.CriteriaBuilder;
+import jakarta.persistence.criteria.CriteriaQuery;
+import jakarta.persistence.criteria.Root;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@Jpa(
+		annotatedClasses = {
+				BatchPostLoadTest.MyEntity1.class,
+				BatchPostLoadTest.MyEntity2.class
+		}
+)
+@TestForIssue(jiraKey = "HHH-16106")
+public class BatchPostLoadTest {
+
+	private static final Long MY_ENTITY_1_ID = 1l;
+
+	@BeforeAll
+	public void setUp(EntityManagerFactoryScope scope) {
+		scope.inTransaction(
+				entityManager -> {
+					MyEntity2 entity2 = new MyEntity2( 2l );
+					entityManager.persist( entity2 );
+
+					MyEntity1 entity1 = new MyEntity1( MY_ENTITY_1_ID, entity2 );
+					entityManager.persist( entity1 );
+
+					Long entity1Id = entity1.getId();
+					assertEquals( entity1Id, entity1.getId() );
+				}
+		);
+	}
+
+	@Test
+	public void testIt(EntityManagerFactoryScope scope) {
+		scope.inTransaction(
+				entityManager -> {
+					CriteriaBuilder builder = entityManager.getCriteriaBuilder();
+					CriteriaQuery<MyEntity1> criteria = builder.createQuery( MyEntity1.class );
+					Root<MyEntity1> root = criteria.from( MyEntity1.class );
+					criteria.select( root );
+					MyEntity1 entity1 = entityManager.createQuery( criteria ).getResultList().get( 0 );
+					assertEquals( MY_ENTITY_1_ID, entity1.getId() );
+					assertNotNull( entity1.getRef() );
+				}
+		);
+	}
+
+	@Entity
+	public static class MyEntity1 {
+		@Id
+		private Long id;
+
+		private Long version;
+
+		@ManyToOne
+		@JoinColumn(name = "ref")
+		private MyEntity2 ref;
+
+		public MyEntity1() {
+		}
+
+		public MyEntity1(Long id, MyEntity2 ref) {
+			this.id = id;
+			this.ref = ref;
+		}
+
+		public Long getId() {
+			return id;
+		}
+
+		public Long getVersion() {
+			return version;
+		}
+
+		public MyEntity2 getRef() {
+			return ref;
+		}
+
+		@PostLoad
+		public void test() {
+			assertNotNull( getRef() );
+		}
+	}
+
+	@Entity
+	@BatchSize(size = 100)
+	public static class MyEntity2 {
+		@Id
+		private Long id;
+
+		private String name;
+
+		public MyEntity2() {
+		}
+
+		public MyEntity2(Long id) {
+			this.id = id;
+		}
+
+		public Long getId() {
+			return id;
+		}
+
+	}
+
+}


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-16106