### PR TITLE
HHH-16108 NullPointerException when flushing a (simple) entity update for models with bytecode enhancement and multiple one-to-one associations (some lazy)

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/persister/entity/mutation/UpdateCoordinatorStandard.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/entity/mutation/UpdateCoordinatorStandard.java
@@ -662,7 +662,7 @@ public class UpdateCoordinatorStandard extends AbstractMutationCoordinator imple
 	}
 
 	private void processSet(UpdateValuesAnalysisImpl analysis, SelectableMapping selectable) {
-		if ( !selectable.isFormula() && selectable.isUpdateable() ) {
+		if ( selectable != null && !selectable.isFormula() && selectable.isUpdateable() ) {
 			final EntityTableMapping tableMapping = entityPersister().getPhysicalTableMappingForMutation( selectable );
 			analysis.registerColumnSet( tableMapping, selectable.getSelectionExpression(), selectable.getWriteExpression() );
 		}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/lazy/proxy/LazyOneToOneMultiAssociationTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/lazy/proxy/LazyOneToOneMultiAssociationTest.java
@@ -1,0 +1,189 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html
+ */
+package org.hibernate.orm.test.bytecode.enhancement.lazy.proxy;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import org.hibernate.Hibernate;
+
+import org.hibernate.testing.TestForIssue;
+import org.hibernate.testing.bytecode.enhancement.BytecodeEnhancerRunner;
+import org.hibernate.testing.bytecode.enhancement.EnhancementOptions;
+import org.hibernate.testing.junit4.BaseNonConfigCoreFunctionalTestCase;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToOne;
+
+@RunWith(BytecodeEnhancerRunner.class)
+@EnhancementOptions(lazyLoading = true)
+@TestForIssue(jiraKey = "HHH-16108")
+public class LazyOneToOneMultiAssociationTest extends BaseNonConfigCoreFunctionalTestCase {
+
+	@Override
+	public Class<?>[] getAnnotatedClasses() {
+		return new Class<?>[] { EntityA.class, EntityB.class };
+	}
+
+	@Before
+	public void prepare() {
+		inTransaction( s -> {
+			EntityA entityA = new EntityA( 1 );
+			s.persist( entityA );
+		} );
+	}
+
+	@After
+	public void tearDown() {
+		inTransaction( s -> {
+			s.createMutationQuery( "delete entityb" ).executeUpdate();
+			s.createMutationQuery( "delete entitya" ).executeUpdate();
+		} );
+	}
+
+	@Test
+	public void testPersist() {
+		inTransaction( s -> {
+			EntityA entityA = s.get( EntityA.class, 1 );
+			EntityB entityB = new EntityB( 2 );
+			entityA.setMappedAssociation1( entityB );
+			entityB.setAssociation1( entityA );
+			s.persist( entityB );
+			// Without a fix, this ends up failing during the flush:
+			// java.lang.NullPointerException: Cannot invoke "org.hibernate.metamodel.mapping.SelectableMapping.isFormula()" because "selectable" is null
+			//	at org.hibernate.persister.entity.mutation.UpdateCoordinatorStandard.processSet(UpdateCoordinatorStandard.java:665)
+		} );
+
+		inTransaction( s -> {
+			EntityA entityA = s.get( EntityA.class, 1 );
+			assertThat( entityA ).isNotNull();
+
+			assertFalse( Hibernate.isPropertyInitialized( entityA, "mappedAssociation1" ) );
+			EntityB entityB = entityA.getMappedAssociation1();
+
+			assertThat( entityB ).isNotNull();
+			assertThat( entityB.getAssociation1() ).isEqualTo( entityA );
+		} );
+	}
+
+	@Entity(name = "entitya")
+	public static class EntityA {
+
+		@Id
+		private Integer id;
+
+		@OneToOne
+		private EntityA selfAssociation;
+
+		@OneToOne(mappedBy = "selfAssociation")
+		private EntityA mappedSelfAssociation;
+
+		@OneToOne(mappedBy = "association1", fetch = FetchType.LAZY)
+		private EntityB mappedAssociation1;
+
+		@OneToOne(mappedBy = "association2", fetch = FetchType.LAZY)
+		private EntityB mappedAssociation2;
+
+		protected EntityA() {
+		}
+
+		public EntityA(Integer id) {
+			this.id = id;
+		}
+
+		public Integer getId() {
+			return id;
+		}
+
+		public void setId(Integer id) {
+			this.id = id;
+		}
+
+		public EntityA getSelfAssociation() {
+			return selfAssociation;
+		}
+
+		public void setSelfAssociation(EntityA selfAssociation) {
+			this.selfAssociation = selfAssociation;
+		}
+
+		public EntityA getMappedSelfAssociation() {
+			return mappedSelfAssociation;
+		}
+
+		public void setMappedSelfAssociation(EntityA mappedSelfAssociation) {
+			this.mappedSelfAssociation = mappedSelfAssociation;
+		}
+
+		public EntityB getMappedAssociation1() {
+			return mappedAssociation1;
+		}
+
+		public void setMappedAssociation1(EntityB mappedAssociation1) {
+			this.mappedAssociation1 = mappedAssociation1;
+		}
+
+		public EntityB getMappedAssociation2() {
+			return mappedAssociation2;
+		}
+
+		public void setMappedAssociation2(EntityB mappedAssociation2) {
+			this.mappedAssociation2 = mappedAssociation2;
+		}
+
+	}
+
+	@Entity(name = "entityb")
+	public static class EntityB {
+		@Id
+		private Integer id;
+
+		@OneToOne
+		private EntityA association1;
+
+		@OneToOne
+		private EntityA association2;
+
+		protected EntityB() {
+		}
+
+		public EntityB(Integer id) {
+			this.id = id;
+		}
+
+		public Integer getId() {
+			return id;
+		}
+
+		public void setId(Integer id) {
+			this.id = id;
+		}
+
+		public EntityA getAssociation1() {
+			return association1;
+		}
+
+		public void setAssociation1(EntityA association1) {
+			this.association1 = association1;
+		}
+
+		public EntityA getAssociation2() {
+			return association2;
+		}
+
+		public void setAssociation2(EntityA association2) {
+			this.association2 = association2;
+		}
+
+	}
+}


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-16108