### PR TITLE
HHH-16124 Remove deprecated method CacheTransactionSynchronization#getCurrentTransactionStartTimestamp

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/cache/internal/NoCachingTransactionSynchronizationImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/cache/internal/NoCachingTransactionSynchronizationImpl.java
@@ -19,11 +19,6 @@ public class NoCachingTransactionSynchronizationImpl implements CacheTransaction
 	}
 
 	@Override
-	public long getCurrentTransactionStartTimestamp() {
-		return getCachingTimestamp();
-	}
-
-	@Override
 	public long getCachingTimestamp() {
 		throw new UnsupportedOperationException("Method not supported when 2LC is not enabled");
 	}

--- a/hibernate-core/src/main/java/org/hibernate/cache/spi/AbstractCacheTransactionSynchronization.java
+++ b/hibernate-core/src/main/java/org/hibernate/cache/spi/AbstractCacheTransactionSynchronization.java
@@ -21,12 +21,6 @@ public abstract class AbstractCacheTransactionSynchronization implements CacheTr
 	}
 
 	@Override
-	@Deprecated(forRemoval = true)
-	public long getCurrentTransactionStartTimestamp() {
-		return lastTransactionCompletionTimestamp;
-	}
-
-	@Override
 	public long getCachingTimestamp() {
 		return lastTransactionCompletionTimestamp;
 	}

--- a/hibernate-core/src/main/java/org/hibernate/cache/spi/CacheTransactionSynchronization.java
+++ b/hibernate-core/src/main/java/org/hibernate/cache/spi/CacheTransactionSynchronization.java
@@ -38,24 +38,6 @@ package org.hibernate.cache.spi;
  * @author Radim Vansa
  */
 public interface CacheTransactionSynchronization {
-
-	/**
-	 * What is the start time of this context object?
-	 *
-	 * @apiNote If not currently joined to a transaction, the timestamp from
-	 * the last transaction is safe to use.  If not ever/yet joined to a
-	 * transaction, a timestamp at the time the Session/CacheTransactionSynchronization
-	 * were created should be returned.
-	 *
-	 * @implSpec This "timestamp" need not be related to timestamp in the Java
-	 * Date/millisecond sense.  It just needs to be an incrementing value.
-	 *
-	 * @deprecated Use {@link CacheTransactionSynchronization#getCachingTimestamp()} instead.
-	 * Please do implement also getCachingTimestamp, as its default implementation will be removed.
-	 */
-	@Deprecated(forRemoval = true)
-	long getCurrentTransactionStartTimestamp();
-
 	/**
 	 * What is the start time of this context object?
 	 *
@@ -69,9 +51,7 @@ public interface CacheTransactionSynchronization {
 	 *
 	 * An UnsupportedOperationException is thrown if 2LC has not enabled
 	 */
-	default long getCachingTimestamp() {
-		return getCurrentTransactionStartTimestamp();
-	}
+	long getCachingTimestamp();
 
 	/**
 	 * Callback that owning Session has become joined to a resource transaction.

--- a/hibernate-core/src/main/java/org/hibernate/engine/spi/SessionDelegatorBaseImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/spi/SessionDelegatorBaseImpl.java
@@ -259,12 +259,6 @@ public class SessionDelegatorBaseImpl implements SessionImplementor {
 	}
 
 	@Override
-	@Deprecated(forRemoval = true)
-	public long getTransactionStartTimestamp() {
-		return delegate.getTransactionStartTimestamp();
-	}
-
-	@Override
 	public FlushModeType getFlushMode() {
 		return delegate.getFlushMode();
 	}

--- a/hibernate-core/src/main/java/org/hibernate/engine/spi/SharedSessionContractImplementor.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/spi/SharedSessionContractImplementor.java
@@ -209,18 +209,6 @@ public interface SharedSessionContractImplementor
 	void markForRollbackOnly();
 
 	/**
-	 * A "timestamp" at or before the start of the current transaction.
-	 *
-	 * @apiNote This "timestamp" need not be related to timestamp in the Java Date/millisecond
-	 * sense.  It just needs to be an incrementing value.  See
-	 * {@link CacheTransactionSynchronization#getCurrentTransactionStartTimestamp()}
-	 *
-	 * @deprecated no longer supported, will be removed soon.
-	 */
-	@Deprecated(forRemoval = true)
-	long getTransactionStartTimestamp();
-
-	/**
 	 * The current {@link CacheTransactionSynchronization} associated
 	 * with this session. This may be {@code null} if the session is not
 	 * currently associated with an active transaction.

--- a/hibernate-core/src/main/java/org/hibernate/engine/spi/SharedSessionDelegatorBaseImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/spi/SharedSessionDelegatorBaseImpl.java
@@ -365,11 +365,6 @@ public class SharedSessionDelegatorBaseImpl implements SharedSessionContractImpl
 	}
 
 	@Override
-	public long getTransactionStartTimestamp() {
-		return delegate.getTransactionStartTimestamp();
-	}
-
-	@Override
 	public CacheTransactionSynchronization getCacheTransactionSynchronization() {
 		return delegate.getCacheTransactionSynchronization();
 	}

--- a/hibernate-core/src/main/java/org/hibernate/internal/AbstractSharedSessionContract.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/AbstractSharedSessionContract.java
@@ -513,15 +513,6 @@ public abstract class AbstractSharedSessionContract implements SharedSessionCont
 		return cacheTransactionSync;
 	}
 
-	/**
-	 * @deprecated This will be removed.
-	 */
-	@Override
-	@Deprecated(forRemoval = true)
-	public long getTransactionStartTimestamp() {
-		return getCacheTransactionSynchronization().getCachingTimestamp();
-	}
-
 	@Override
 	public Transaction beginTransaction() {
 		checkOpen();


### PR DESCRIPTION


https://hibernate.atlassian.net/browse/HHH-16124