### PR TITLE
HHH-15707 - Fix Gradle plugin with Kotlin 1.7.0 or higher

### DIFF
--- a/tooling/hibernate-gradle-plugin/src/main/java/org/hibernate/orm/tooling/gradle/HibernateOrmPlugin.java
+++ b/tooling/hibernate-gradle-plugin/src/main/java/org/hibernate/orm/tooling/gradle/HibernateOrmPlugin.java
@@ -6,6 +6,7 @@
  */
 package org.hibernate.orm.tooling.gradle;
 
+import java.lang.reflect.Method;
 import java.util.Set;
 
 import org.gradle.api.Action;
@@ -69,21 +70,26 @@ public class HibernateOrmPlugin implements Plugin<Project> {
 
 			for ( String language : languages ) {
 				final String languageCompileTaskName = sourceSet.getCompileTaskName( language );
-				final AbstractCompile languageCompileTask = (AbstractCompile) project.getTasks().findByName( languageCompileTaskName );
+				final Task languageCompileTask = project.getTasks().findByName( languageCompileTaskName );
 				if ( languageCompileTask == null ) {
 					continue;
 				}
 
 				//noinspection Convert2Lambda
-				languageCompileTask.doLast( new Action<>() {
+				languageCompileTask.doLast(new Action<>() {
 					@Override
 					public void execute(Task t) {
-						final DirectoryProperty classesDirectory = languageCompileTask.getDestinationDirectory();
-						final ClassLoader classLoader = Helper.toClassLoader( sourceSet, project );
-
-						EnhancementHelper.enhance( classesDirectory, classLoader, ormDsl, project );
+						try {
+							final Method getDestinationDirectory = languageCompileTask.getClass().getMethod("getDestinationDirectory");
+							final DirectoryProperty classesDirectory = (DirectoryProperty) getDestinationDirectory.invoke(languageCompileTask);
+							final ClassLoader classLoader = Helper.toClassLoader(sourceSet, project);
+							EnhancementHelper.enhance(classesDirectory, classLoader, ormDsl, project);
+						}
+						catch (Exception e) {
+							throw new RuntimeException(e);
+						}
 					}
-				} );
+				});
 			}
 		} );
 	}


### PR DESCRIPTION
Since Kotlin version 1.7.0 the KotlinCompile task no longer extends Gradle's AbstractCompile.

This commit updates Hibernate Gradle enhancement plugin to not cast to AbstractCompile and instead use reflection to invoke the "getDestinationDirectory" method.

It also updates the Kotlin version on used to test the Gradle enhancement (but remains backwards compatible with previous Kotlin versions).