### PR TITLE
HHH-16150 Hibernate ORM no longer drops the schema when using the create-drop strategy and a session factory observer throws an exception on startup

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/internal/SessionFactoryImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/SessionFactoryImpl.java
@@ -457,7 +457,6 @@ public class SessionFactoryImpl extends QueryParameterBindingTypeResolverImpl im
 		for ( Integrator integrator : serviceRegistry.getService( IntegratorService.class ).getIntegrators() ) {
 			integrator.disintegrate( this, serviceRegistry );
 			integratorObserver.integrators.remove( integrator );
-			serviceRegistry.close();
 		}
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/internal/SessionFactoryImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/SessionFactoryImpl.java
@@ -371,7 +371,7 @@ public class SessionFactoryImpl extends QueryParameterBindingTypeResolverImpl im
 
 		}
 		catch ( Exception e ) {
-			disintegrate( integratorObserver );
+			disintegrate( e, integratorObserver );
 
 			try {
 				close();
@@ -453,11 +453,16 @@ public class SessionFactoryImpl extends QueryParameterBindingTypeResolverImpl im
 		}
 	}
 
-	private void disintegrate(IntegratorObserver integratorObserver) {
-		for ( Integrator integrator : serviceRegistry.getService( IntegratorService.class ).getIntegrators() ) {
-			integrator.disintegrate( this, serviceRegistry );
-			integratorObserver.integrators.remove( integrator );
+	private void disintegrate(Exception startupException, IntegratorObserver integratorObserver) {
+		for ( Integrator integrator : integratorObserver.integrators ) {
+			try {
+				integrator.disintegrate( this, serviceRegistry );
+			}
+			catch (Throwable ex) {
+				startupException.addSuppressed( ex );
+			}
 		}
+		integratorObserver.integrators.clear();
 	}
 
 


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-16150

cc @beikov , that's the problem I mentioned to you during our last video chat.