### PR TITLE
HHH-16009 jakarta @OrderBy annotation generates a non-transformed column name in the SQL query for a composite key's field

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/mapping/Component.java
+++ b/hibernate-core/src/main/java/org/hibernate/mapping/Component.java
@@ -43,6 +43,7 @@ import org.hibernate.property.access.spi.Setter;
 import org.hibernate.generator.Generator;
 import org.hibernate.generator.BeforeExecutionGenerator;
 import org.hibernate.type.ComponentType;
+import org.hibernate.type.CompositeType;
 import org.hibernate.type.EmbeddedComponentType;
 import org.hibernate.type.Type;
 
@@ -77,7 +78,7 @@ public class Component extends SimpleValue implements MetaAttributable, Sortable
 	private String[] instantiatorPropertyNames;
 
 	// cache the status of the type
-	private volatile Type type;
+	private volatile CompositeType type;
 
 	private AggregateColumn aggregateColumn;
 	private AggregateColumn parentAggregateColumn;
@@ -370,12 +371,12 @@ public class Component extends SimpleValue implements MetaAttributable, Sortable
 	}
 
 	@Override
-	public Type getType() throws MappingException {
+	public CompositeType getType() throws MappingException {
 		// Resolve the type of the value once and for all as this operation generates a proxy class
 		// for each invocation.
 		// Unfortunately, there's no better way of doing that as none of the classes are immutable and
 		// we can't know for sure the current state of the property or the value.
-		Type localType = type;
+		CompositeType localType = type;
 
 		if ( localType == null ) {
 			synchronized ( this ) {

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/AbstractEmbeddableMapping.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/AbstractEmbeddableMapping.java
@@ -7,6 +7,7 @@
 package org.hibernate.metamodel.mapping.internal;
 
 import java.io.Serializable;
+import java.util.List;
 import java.util.Locale;
 import java.util.function.Consumer;
 
@@ -18,6 +19,9 @@ import org.hibernate.engine.FetchTiming;
 import org.hibernate.engine.jdbc.env.spi.JdbcEnvironment;
 import org.hibernate.engine.jdbc.spi.JdbcServices;
 import org.hibernate.engine.spi.CascadeStyle;
+import org.hibernate.engine.spi.SharedSessionContractImplementor;
+import org.hibernate.internal.util.IndexedConsumer;
+import org.hibernate.internal.util.collections.CollectionHelper;
 import org.hibernate.mapping.Any;
 import org.hibernate.mapping.BasicValue;
 import org.hibernate.mapping.Column;
@@ -29,20 +33,27 @@ import org.hibernate.metamodel.UnsupportedMappingException;
 import org.hibernate.metamodel.mapping.AttributeMapping;
 import org.hibernate.metamodel.mapping.EmbeddableMappingType;
 import org.hibernate.metamodel.mapping.EmbeddableValuedModelPart;
+import org.hibernate.metamodel.mapping.EntityMappingType;
 import org.hibernate.metamodel.mapping.ForeignKeyDescriptor;
+import org.hibernate.metamodel.mapping.JdbcMapping;
 import org.hibernate.metamodel.mapping.ManagedMappingType;
+import org.hibernate.metamodel.mapping.ModelPart;
+import org.hibernate.metamodel.mapping.PluralAttributeMapping;
+import org.hibernate.metamodel.mapping.SelectableConsumer;
 import org.hibernate.metamodel.mapping.SelectableMapping;
 import org.hibernate.metamodel.mapping.SelectableMappings;
 import org.hibernate.metamodel.mapping.SelectablePath;
 import org.hibernate.metamodel.model.domain.NavigableRole;
 import org.hibernate.metamodel.spi.EmbeddableRepresentationStrategy;
 import org.hibernate.metamodel.spi.RuntimeModelCreationContext;
+import org.hibernate.persister.entity.AttributeMappingsList;
 import org.hibernate.persister.entity.EntityPersister;
 import org.hibernate.persister.internal.MutableAttributeMappingList;
 import org.hibernate.property.access.internal.PropertyAccessStrategyBackRefImpl;
 import org.hibernate.property.access.spi.Getter;
 import org.hibernate.property.access.spi.PropertyAccess;
 import org.hibernate.sql.ast.tree.from.TableGroupProducer;
+import org.hibernate.sql.results.graph.Fetchable;
 import org.hibernate.type.AnyType;
 import org.hibernate.type.BasicType;
 import org.hibernate.type.CollectionType;
@@ -58,12 +69,11 @@ import org.hibernate.type.spi.TypeConfiguration;
  * Base support for EmbeddableMappingType implementations
  */
 public abstract class AbstractEmbeddableMapping implements EmbeddableMappingType {
+	final protected MutableAttributeMappingList attributeMappings;
+	protected SelectableMappings selectableMappings;
 
-	public AbstractEmbeddableMapping(MappingModelCreationProcess creationProcess) {
-		this( creationProcess.getCreationContext() );
-	}
-
-	public AbstractEmbeddableMapping(RuntimeModelCreationContext creationContext) {
+	public AbstractEmbeddableMapping(MutableAttributeMappingList attributeMappings) {
+		this.attributeMappings = attributeMappings;
 	}
 
 	@Override
@@ -126,7 +136,7 @@ public abstract class AbstractEmbeddableMapping implements EmbeddableMappingType
 		void check(String name, Type type) throws IllegalAttributeType;
 	}
 
-	protected static boolean inverseInitializeCallback(
+	protected boolean inverseInitializeCallback(
 			TableGroupProducer declaringTableGroupProducer,
 			SelectableMappings selectableMappings,
 			EmbeddableMappingType inverseMappingType,
@@ -209,7 +219,7 @@ public abstract class AbstractEmbeddableMapping implements EmbeddableMappingType
 		return true;
 	}
 
-	protected static boolean finishInitialization(
+	protected boolean finishInitialization(
 			NavigableRole navigableRole,
 			Component bootDescriptor,
 			CompositeType compositeType,
@@ -439,6 +449,214 @@ public abstract class AbstractEmbeddableMapping implements EmbeddableMappingType
 		}
 
 		completionCallback.success();
+		return true;
+	}
+
+	@Override
+	public int getNumberOfFetchables() {
+		return getAttributeMappings().size();
+	}
+
+	@Override
+	public Fetchable getFetchable(int position) {
+		return getAttributeMappings().get( position );
+	}
+
+	@Override
+	public void visitFetchables(Consumer<? super Fetchable> consumer, EntityMappingType treatTargetType) {
+		forEachAttributeMapping( consumer );
+	}
+
+	@Override
+	public void visitFetchables(IndexedConsumer<? super Fetchable> indexedConsumer, EntityMappingType treatTargetType) {
+		this.getAttributeMappings().indexedForEach( indexedConsumer );
+	}
+
+	@Override
+	public int getNumberOfAttributeMappings() {
+		return getAttributeMappings().size();
+	}
+
+	@Override
+	public AttributeMapping getAttributeMapping(int position) {
+		return getAttributeMappings().get( position );
+	}
+
+	@Override
+	public AttributeMapping findAttributeMapping(String name) {
+		final AttributeMappingsList attributes = getAttributeMappings();
+		for ( int i = 0; i < attributes.size(); i++ ) {
+			final AttributeMapping attr = attributes.get( i );
+			if ( name.equals( attr.getAttributeName() ) ) {
+				return attr;
+			}
+		}
+		return null;
+	}
+
+	@Override
+	public AttributeMappingsList getAttributeMappings() {
+		return attributeMappings;
+	}
+
+	private void checkIsReady() {
+		if ( selectableMappings == null ) {
+			// This is expected to happen when processing a
+			// PostInitCallbackEntry because the callbacks
+			// are not ordered. The exception is caught in
+			// MappingModelCreationProcess.executePostInitCallbacks()
+			// and the callback is re-queued.
+			throw new IllegalStateException( "Not yet ready" );
+		}
+	}
+
+	@Override
+	public SelectableMapping getSelectable(int columnIndex) {
+		return getSelectableMappings().getSelectable( columnIndex );
+	}
+
+	@Override
+	public int forEachSelectable(SelectableConsumer consumer) {
+		return getSelectableMappings().forEachSelectable( 0, consumer );
+	}
+
+	@Override
+	public int forEachSelectable(int offset, SelectableConsumer consumer) {
+		return getSelectableMappings().forEachSelectable( offset, consumer );
+	}
+
+	@Override
+	public int getJdbcTypeCount() {
+		return getSelectableMappings().getJdbcTypeCount();
+	}
+
+	@Override
+	public int forEachJdbcType(int offset, IndexedConsumer<JdbcMapping> action) {
+		return getSelectableMappings().forEachSelectable(
+				offset,
+				(index, selectable) -> action.accept( index, selectable.getJdbcMapping() )
+		);
+	}
+
+	@Override
+	public List<JdbcMapping> getJdbcMappings() {
+		return getSelectableMappings().getJdbcMappings();
+	}
+
+	@Override
+	public JdbcMapping getJdbcMapping(int index) {
+		return getSelectable( index ).getJdbcMapping();
+	}
+
+	@Override
+	public void forEachAttributeMapping(final IndexedConsumer<? super AttributeMapping> consumer) {
+		getAttributeMappings().indexedForEach( consumer );
+	}
+
+	@Override
+	public void forEachAttributeMapping(final Consumer<? super AttributeMapping> action) {
+		getAttributeMappings().forEach( action );
+	}
+
+	@Override
+	public ModelPart findSubPart(String name, EntityMappingType treatTargetType) {
+		return findAttributeMapping( name );
+	}
+
+	@Override
+	public void forEachSubPart(IndexedConsumer<ModelPart> consumer, EntityMappingType treatTarget) {
+		final AttributeMappingsList attributes = getAttributeMappings();
+		for ( int i = 0; i < attributes.size(); i++ ) {
+			consumer.accept( i, attributes.get(i) );
+		}
+	}
+
+	@Override
+	public void visitSubParts(Consumer<ModelPart> consumer, EntityMappingType treatTargetType) {
+		forEachAttributeMapping( consumer );
+	}
+
+	@Override
+	public Object disassemble(Object value, SharedSessionContractImplementor session) {
+		final MutableAttributeMappingList attributes = attributeMappings;
+		final int size = attributes.size();
+		final Object[] result = new Object[ size ];
+		for ( int i = 0; i < size; i++ ) {
+			final AttributeMapping attributeMapping = attributes.get( i );
+			final Object o = attributeMapping.getValue( value );
+			result[i] = attributeMapping.disassemble( o, session );
+		}
+
+		return result;
+	}
+
+	@Override
+	public <X, Y> int forEachDisassembledJdbcValue(
+			Object value,
+			int offset,
+			X x,
+			Y y,
+			JdbcValuesBiConsumer<X, Y> valuesConsumer,
+			SharedSessionContractImplementor session) {
+		final Object[] values = (Object[]) value;
+		int span = 0;
+		for ( int i = 0; i < attributeMappings.size(); i++ ) {
+			final AttributeMapping mapping = attributeMappings.get( i );
+			span += mapping.forEachDisassembledJdbcValue( values[i], span + offset, x, y, valuesConsumer, session );
+		}
+		return span;
+	}
+
+	@Override
+	public <X, Y> int forEachJdbcValue(
+			Object value,
+			int offset,
+			X x,
+			Y y,
+			JdbcValuesBiConsumer<X, Y> valuesConsumer,
+			SharedSessionContractImplementor session) {
+		int span = 0;
+
+		for ( int i = 0; i < attributeMappings.size(); i++ ) {
+			final AttributeMapping attributeMapping = attributeMappings.get( i );
+			if ( attributeMapping instanceof PluralAttributeMapping ) {
+				continue;
+			}
+			final Object o = attributeMapping.getPropertyAccess().getGetter().get( value );
+			span += attributeMapping.forEachJdbcValue( o, span + offset, x, y, valuesConsumer, session );
+		}
+		return span;
+	}
+
+	protected void addAttribute(AttributeMapping attributeMapping) {
+		// check if we've already seen this attribute...
+		for ( int i = 0; i < attributeMappings.size(); i++ ) {
+			final AttributeMapping previous = attributeMappings.get( i );
+			if ( attributeMapping.getAttributeName().equals( previous.getAttributeName() ) ) {
+				attributeMappings.setAttributeMapping( i, attributeMapping );
+				return;
+			}
+		}
+
+		attributeMappings.add( attributeMapping );
+	}
+
+	protected SelectableMappings getSelectableMappings() {
+		checkIsReady();
+		return selectableMappings;
+	}
+
+	protected boolean initColumnMappings() {
+		final int propertySpan = attributeMappings.size();
+		final List<SelectableMapping> selectableMappings = CollectionHelper.arrayList( propertySpan );
+
+		attributeMappings.indexedForEach(
+				(index, attributeMapping) -> attributeMapping.forEachSelectable(
+						(columnIndex, selection) -> selectableMappings.add( selection )
+				)
+		);
+
+		this.selectableMappings = new SelectableMappingsImpl( selectableMappings.toArray( new SelectableMapping[0] ) );
 
 		return true;
 	}

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/AbstractEmbeddableMapping.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/AbstractEmbeddableMapping.java
@@ -496,6 +496,7 @@ public abstract class AbstractEmbeddableMapping implements EmbeddableMappingType
 
 	@Override
 	public AttributeMappingsList getAttributeMappings() {
+		checkIsReady();
 		return attributeMappings;
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/EmbeddableMappingTypeImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/EmbeddableMappingTypeImpl.java
@@ -7,9 +7,7 @@
 package org.hibernate.metamodel.mapping.internal;
 
 import java.io.Serializable;
-import java.util.List;
 import java.util.Locale;
-import java.util.function.Consumer;
 import java.util.function.Function;
 
 import org.hibernate.MappingException;
@@ -23,7 +21,6 @@ import org.hibernate.engine.jdbc.env.spi.JdbcEnvironment;
 import org.hibernate.engine.jdbc.spi.JdbcServices;
 import org.hibernate.engine.spi.CascadeStyle;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
-import org.hibernate.internal.util.IndexedConsumer;
 import org.hibernate.internal.util.config.ConfigurationHelper;
 import org.hibernate.mapping.AggregateColumn;
 import org.hibernate.mapping.Any;
@@ -39,7 +36,6 @@ import org.hibernate.metamodel.mapping.EmbeddableMappingType;
 import org.hibernate.metamodel.mapping.EmbeddableValuedModelPart;
 import org.hibernate.metamodel.mapping.EntityMappingType;
 import org.hibernate.metamodel.mapping.JdbcMapping;
-import org.hibernate.metamodel.mapping.ModelPart;
 import org.hibernate.metamodel.mapping.PluralAttributeMapping;
 import org.hibernate.metamodel.mapping.SelectableConsumer;
 import org.hibernate.metamodel.mapping.SelectableMapping;
@@ -48,7 +44,6 @@ import org.hibernate.metamodel.mapping.SelectablePath;
 import org.hibernate.metamodel.model.domain.NavigableRole;
 import org.hibernate.metamodel.spi.EmbeddableRepresentationStrategy;
 import org.hibernate.metamodel.spi.RuntimeModelCreationContext;
-import org.hibernate.persister.entity.AttributeMappingsList;
 import org.hibernate.persister.entity.EntityPersister;
 import org.hibernate.persister.internal.MutableAttributeMappingList;
 import org.hibernate.property.access.spi.PropertyAccess;
@@ -57,7 +52,6 @@ import org.hibernate.sql.ast.tree.from.TableGroup;
 import org.hibernate.sql.ast.tree.from.TableGroupProducer;
 import org.hibernate.sql.results.graph.DomainResult;
 import org.hibernate.sql.results.graph.DomainResultCreationState;
-import org.hibernate.sql.results.graph.Fetchable;
 import org.hibernate.sql.results.graph.embeddable.internal.EmbeddableResultImpl;
 import org.hibernate.type.AnyType;
 import org.hibernate.type.BasicType;
@@ -149,9 +143,6 @@ public class EmbeddableMappingTypeImpl extends AbstractEmbeddableMapping impleme
 	private final JavaType<?> embeddableJtd;
 	private final EmbeddableRepresentationStrategy representationStrategy;
 
-	private final MutableAttributeMappingList attributeMappings = new MutableAttributeMappingList( 5 );
-	private SelectableMappings selectableMappings;
-
 	private final EmbeddableValuedModelPart valueMapping;
 
 	private final boolean createEmptyCompositesEnabled;
@@ -165,7 +156,7 @@ public class EmbeddableMappingTypeImpl extends AbstractEmbeddableMapping impleme
 			Property componentProperty,
 			Function<EmbeddableMappingType, EmbeddableValuedModelPart> embeddedPartBuilder,
 			RuntimeModelCreationContext creationContext) {
-		super( creationContext );
+		super( new MutableAttributeMappingList( 5 ) );
 		this.representationStrategy = creationContext
 				.getBootstrapContext()
 				.getRepresentationStrategySelector()
@@ -258,7 +249,7 @@ public class EmbeddableMappingTypeImpl extends AbstractEmbeddableMapping impleme
 			SelectableMappings selectableMappings,
 			EmbeddableMappingType inverseMappingType,
 			MappingModelCreationProcess creationProcess) {
-		super( creationProcess );
+		super( new MutableAttributeMappingList( 5 ) );
 
 		this.embeddableJtd = inverseMappingType.getJavaType();
 		this.representationStrategy = inverseMappingType.getRepresentationStrategy();
@@ -277,7 +268,7 @@ public class EmbeddableMappingTypeImpl extends AbstractEmbeddableMapping impleme
 						inverseMappingType,
 						creationProcess,
 						valueMapping.getDeclaringType(),
-						this.attributeMappings
+						attributeMappings
 				)
 		);
 	}
@@ -344,7 +335,7 @@ public class EmbeddableMappingTypeImpl extends AbstractEmbeddableMapping impleme
 		int columnPosition = 0;
 
 		// Reset the attribute mappings that were added in previous attempts
-		this.attributeMappings.clear();
+		attributeMappings.clear();
 
 		for ( Property bootPropertyDescriptor : bootDescriptor.getProperties() ) {
 			final AttributeMapping attributeMapping;
@@ -591,23 +582,7 @@ public class EmbeddableMappingTypeImpl extends AbstractEmbeddableMapping impleme
 		}
 	}
 
-	private boolean initColumnMappings() {
-		this.selectableMappings = SelectableMappingsImpl.from( this );
-		return true;
-	}
 
-	private void addAttribute(AttributeMapping attributeMapping) {
-		// check if we've already seen this attribute...
-		for ( int i = 0; i < attributeMappings.size(); i++ ) {
-			final AttributeMapping previous = attributeMappings.get( i );
-			if ( attributeMapping.getAttributeName().equals( previous.getAttributeName() ) ) {
-				attributeMappings.setAttributeMapping( i, attributeMapping );
-				return;
-			}
-		}
-
-		attributeMappings.add( attributeMapping );
-	}
 
 	public EmbeddableValuedModelPart getEmbeddedValueMapping() {
 		return valueMapping;
@@ -643,54 +618,6 @@ public class EmbeddableMappingTypeImpl extends AbstractEmbeddableMapping impleme
 				valueMapping,
 				resultVariable,
 				creationState
-		);
-	}
-
-	@Override
-	public int getNumberOfFetchables() {
-		return attributeMappings.size();
-	}
-
-	@Override
-	public Fetchable getFetchable(int position) {
-		return attributeMappings.get( position );
-	}
-
-	@Override
-	public void visitFetchables(Consumer<? super Fetchable> consumer, EntityMappingType treatTargetType) {
-		forEachAttributeMapping( consumer );
-	}
-
-	@Override
-	public void visitFetchables(IndexedConsumer<? super Fetchable> indexedConsumer, EntityMappingType treatTargetType) {
-		this.attributeMappings.indexedForEach( indexedConsumer );
-	}
-
-	@Override
-	public SelectableMapping getSelectable(int columnIndex) {
-		return getSelectableMappings().getSelectable( columnIndex );
-	}
-
-	@Override
-	public int getJdbcTypeCount() {
-		return getSelectableMappings().getJdbcTypeCount();
-	}
-
-	@Override
-	public List<JdbcMapping> getJdbcMappings() {
-		return getSelectableMappings().getJdbcMappings();
-	}
-
-	@Override
-	public JdbcMapping getJdbcMapping(int index) {
-		return getSelectable( index ).getJdbcMapping();
-	}
-
-	@Override
-	public int forEachJdbcType(int offset, IndexedConsumer<JdbcMapping> action) {
-		return getSelectableMappings().forEachSelectable(
-				offset,
-				(index, selectable) -> action.accept( index, selectable.getJdbcMapping() )
 		);
 	}
 
@@ -778,66 +705,6 @@ public class EmbeddableMappingTypeImpl extends AbstractEmbeddableMapping impleme
 	}
 
 	@Override
-	public Object disassemble(Object value, SharedSessionContractImplementor session) {
-		final Object[] result = new Object[ getNumberOfAttributeMappings() ];
-		for ( int i = 0; i < result.length; i++ ) {
-			final AttributeMapping attributeMapping = getAttributeMapping( i );
-			Object o = attributeMapping.getPropertyAccess().getGetter().get( value );
-			result[i] = attributeMapping.disassemble( o, session );
-		}
-
-		return result;
-	}
-
-	@Override
-	public <X, Y> int forEachJdbcValue(
-			Object value,
-			int offset,
-			X x,
-			Y y,
-			JdbcValuesBiConsumer<X, Y> consumer,
-			SharedSessionContractImplementor session) {
-		int span = 0;
-
-		for ( int i = 0; i < attributeMappings.size(); i++ ) {
-			final AttributeMapping attributeMapping = attributeMappings.get( i );
-			if ( attributeMapping instanceof PluralAttributeMapping ) {
-				continue;
-			}
-			final Object o = attributeMapping.getPropertyAccess().getGetter().get( value );
-			span += attributeMapping.forEachJdbcValue( o, span + offset, x, y, consumer, session );
-		}
-		return span;
-	}
-
-	@Override
-	public <X, Y> int forEachDisassembledJdbcValue(
-			Object value,
-			int offset,
-			X x,
-			Y y,
-			JdbcValuesBiConsumer<X, Y> valuesConsumer,
-			SharedSessionContractImplementor session) {
-		final Object[] values = (Object[]) value;
-		int span = 0;
-		for ( int i = 0; i < attributeMappings.size(); i++ ) {
-			final AttributeMapping mapping = attributeMappings.get( i );
-			span += mapping.forEachDisassembledJdbcValue( values[i], span + offset, x, y, valuesConsumer, session );
-		}
-		return span;
-	}
-
-	@Override
-	public int forEachSelectable(SelectableConsumer consumer) {
-		return getSelectableMappings().forEachSelectable( 0, consumer );
-	}
-
-	@Override
-	public int forEachSelectable(int offset, SelectableConsumer consumer) {
-		return getSelectableMappings().forEachSelectable( offset, consumer );
-	}
-
-	@Override
 	public void forEachInsertable(int offset, SelectableConsumer consumer) {
 		if ( shouldMutateAggregateMapping() ) {
 			if ( aggregateMapping.isInsertable() ) {
@@ -873,75 +740,11 @@ public class EmbeddableMappingTypeImpl extends AbstractEmbeddableMapping impleme
 		}
 	}
 
-	private SelectableMappings getSelectableMappings() {
-		if (selectableMappings == null) {
-			// This is expected to happen when processing a
-			// PostInitCallbackEntry because the callbacks
-			// are not ordered. The exception is caught in
-			// MappingModelCreationProcess.executePostInitCallbacks()
-			// and the callback is re-queued.
-			throw new IllegalStateException("Not yet ready");
-		}
-		return selectableMappings;
-	}
-
 	@Override
 	public EntityMappingType findContainingEntityMapping() {
 		return valueMapping.findContainingEntityMapping();
 	}
 
-	@Override
-	public int getNumberOfAttributeMappings() {
-		return attributeMappings.size();
-	}
-
-	@Override
-	public AttributeMapping getAttributeMapping(int position) {
-		return attributeMappings.get( position );
-	}
-
-	@Override
-	public AttributeMapping findAttributeMapping(String name) {
-		for ( int i = 0; i < attributeMappings.size(); i++ ) {
-			final AttributeMapping attr = attributeMappings.get( i );
-			if ( name.equals( attr.getAttributeName() ) ) {
-				return attr;
-			}
-		}
-		return null;
-	}
-
-	@Override
-	public AttributeMappingsList getAttributeMappings() {
-		return attributeMappings;
-	}
-
-	@Override
-	public void forEachAttributeMapping(final IndexedConsumer<? super AttributeMapping> consumer) {
-		attributeMappings.indexedForEach( consumer );
-	}
-
-	@Override
-	public void forEachAttributeMapping(final Consumer<? super AttributeMapping> action) {
-		attributeMappings.forEach( action );
-	}
-
-	@Override
-	public ModelPart findSubPart(String name, EntityMappingType treatTargetType) {
-		return findAttributeMapping( name );
-	}
-
-	@Override
-	public void forEachSubPart(IndexedConsumer<ModelPart> consumer, EntityMappingType treatTarget) {
-		for ( int i = 0; i < attributeMappings.size(); i++ ) {
-			consumer.accept( i, attributeMappings.get(i) );
-		}
-	}
-
-	@Override
-	public void visitSubParts(Consumer<ModelPart> consumer, EntityMappingType treatTargetType) {
-		forEachAttributeMapping( consumer );
-	}
 
 	@Override
 	public boolean isCreateEmptyCompositesEnabled() {

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/VirtualIdEmbeddable.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/VirtualIdEmbeddable.java
@@ -6,26 +6,15 @@
  */
 package org.hibernate.metamodel.mapping.internal;
 
-import java.util.List;
-import java.util.function.Consumer;
-
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
-import org.hibernate.internal.util.IndexedConsumer;
 import org.hibernate.mapping.Component;
 import org.hibernate.metamodel.mapping.AttributeMapping;
 import org.hibernate.metamodel.mapping.EmbeddableMappingType;
 import org.hibernate.metamodel.mapping.EmbeddableValuedModelPart;
 import org.hibernate.metamodel.mapping.EntityMappingType;
-import org.hibernate.metamodel.mapping.JdbcMapping;
-import org.hibernate.metamodel.mapping.ModelPart;
 import org.hibernate.metamodel.mapping.NonAggregatedIdentifierMapping;
-import org.hibernate.metamodel.mapping.PluralAttributeMapping;
-import org.hibernate.metamodel.mapping.SelectableConsumer;
-import org.hibernate.metamodel.mapping.SelectableMapping;
 import org.hibernate.metamodel.mapping.SelectableMappings;
-import org.hibernate.metamodel.mapping.SingularAttributeMapping;
 import org.hibernate.metamodel.model.domain.NavigableRole;
-import org.hibernate.persister.entity.AttributeMappingsList;
 import org.hibernate.persister.entity.EntityPersister;
 import org.hibernate.persister.internal.MutableAttributeMappingList;
 import org.hibernate.spi.NavigablePath;
@@ -33,7 +22,6 @@ import org.hibernate.sql.ast.tree.from.TableGroup;
 import org.hibernate.sql.ast.tree.from.TableGroupProducer;
 import org.hibernate.sql.results.graph.DomainResult;
 import org.hibernate.sql.results.graph.DomainResultCreationState;
-import org.hibernate.sql.results.graph.Fetchable;
 import org.hibernate.type.AnyType;
 import org.hibernate.type.CollectionType;
 import org.hibernate.type.CompositeType;
@@ -49,9 +37,6 @@ public class VirtualIdEmbeddable extends AbstractEmbeddableMapping implements Id
 	private final NonAggregatedIdentifierMapping idMapping;
 	private final VirtualIdRepresentationStrategy representationStrategy;
 
-	private final MutableAttributeMappingList attributeMappings;
-	private SelectableMappings selectableMappings;
-
 	public VirtualIdEmbeddable(
 			Component virtualIdSource,
 			NonAggregatedIdentifierMapping idMapping,
@@ -59,7 +44,7 @@ public class VirtualIdEmbeddable extends AbstractEmbeddableMapping implements Id
 			String rootTableExpression,
 			String[] rootTableKeyColumnNames,
 			MappingModelCreationProcess creationProcess) {
-		super( creationProcess );
+		super( new MutableAttributeMappingList( virtualIdSource.getType().getPropertyNames().length ) );
 
 		this.navigableRole = idMapping.getNavigableRole();
 		this.idMapping = idMapping;
@@ -70,9 +55,7 @@ public class VirtualIdEmbeddable extends AbstractEmbeddableMapping implements Id
 				creationProcess.getCreationContext()
 		);
 
-		final CompositeType compositeType = (CompositeType) virtualIdSource.getType();
-		this.attributeMappings = new MutableAttributeMappingList( (compositeType).getPropertyNames().length );
-
+		final CompositeType compositeType = virtualIdSource.getType();
 		( (CompositeTypeImplementor) compositeType ).injectMappingModelPart( idMapping, creationProcess );
 
 		creationProcess.registerInitializationCallback(
@@ -94,12 +77,11 @@ public class VirtualIdEmbeddable extends AbstractEmbeddableMapping implements Id
 			SelectableMappings selectableMappings,
 			VirtualIdEmbeddable inverseMappingType,
 			MappingModelCreationProcess creationProcess) {
-		super( creationProcess );
+		super( new MutableAttributeMappingList( inverseMappingType.attributeMappings.size() ) );
 
 		this.navigableRole = inverseMappingType.getNavigableRole();
 		this.idMapping = (NonAggregatedIdentifierMapping) valueMapping;
 		this.representationStrategy = inverseMappingType.representationStrategy;
-		this.attributeMappings = new MutableAttributeMappingList( inverseMappingType.attributeMappings.size() );
 		this.selectableMappings = selectableMappings;
 		creationProcess.registerInitializationCallback(
 				"VirtualIdEmbeddable(" + inverseMappingType.getNavigableRole().getFullPath() + ".{inverse})#finishInitialization",
@@ -162,106 +144,9 @@ public class VirtualIdEmbeddable extends AbstractEmbeddableMapping implements Id
 	}
 
 	@Override
-	public AttributeMapping findAttributeMapping(String name) {
-		for ( int i = 0; i < attributeMappings.size(); i++ ) {
-			final AttributeMapping attr = attributeMappings.get( i );
-			if ( name.equals( attr.getAttributeName() ) ) {
-				return attr;
-			}
-		}
-		return null;
-	}
-
-	@Override
-	public SelectableMapping getSelectable(int columnIndex) {
-		return getSelectableMappings().getSelectable( columnIndex );
-	}
-
-	@Override
-	public int forEachSelectable(SelectableConsumer consumer) {
-		return getSelectableMappings().forEachSelectable( 0, consumer );
-	}
-
-	@Override
-	public int forEachSelectable(int offset, SelectableConsumer consumer) {
-		return getSelectableMappings().forEachSelectable( offset, consumer );
-	}
-
-	@Override
-	public int getJdbcTypeCount() {
-		return getSelectableMappings().getJdbcTypeCount();
-	}
-
-	@Override
-	public List<JdbcMapping> getJdbcMappings() {
-		return getSelectableMappings().getJdbcMappings();
-	}
-
-	@Override
-	public JdbcMapping getJdbcMapping(int index) {
-		return getSelectableMappings().getSelectable( index ).getJdbcMapping();
-	}
-
-	private SelectableMappings getSelectableMappings() {
-		if (selectableMappings == null) {
-			// This is expected to happen when processing a
-			// PostInitCallbackEntry because the callbacks
-			// are not ordered. The exception is caught in
-			// MappingModelCreationProcess.executePostInitCallbacks()
-			// and the callback is re-queued.
-			throw new IllegalStateException("Not yet ready");
-		}
-		return selectableMappings;
-	}
-
-	@Override
-	public int forEachJdbcType(int offset, IndexedConsumer<JdbcMapping> action) {
-		return getSelectableMappings().forEachSelectable(
-				offset,
-				(index, selectable) -> action.accept( index, selectable.getJdbcMapping() )
-		);
-	}
-
-	@Override
 	public boolean isCreateEmptyCompositesEnabled() {
 		// generally we do not want empty composites for identifiers
 		return false;
-	}
-
-	@Override
-	public int getNumberOfAttributeMappings() {
-		return attributeMappings.size();
-	}
-
-	@Override
-	public AttributeMapping getAttributeMapping(int position) {
-		return attributeMappings.get( position );
-	}
-
-	@SuppressWarnings({ "unchecked", "rawtypes" })
-	@Override
-	public AttributeMappingsList getAttributeMappings() {
-		return attributeMappings;
-	}
-
-	@Override
-	public void forEachAttributeMapping(Consumer<? super AttributeMapping> action) {
-		forEachAttribute( (index, attribute) -> action.accept( attribute ) );
-	}
-
-	@Override
-	public void forEachAttributeMapping(final IndexedConsumer<? super AttributeMapping> consumer) {
-		this.attributeMappings.indexedForEach( consumer );
-	}
-
-	@Override
-	public int getNumberOfFetchables() {
-		return getNumberOfAttributeMappings();
-	}
-
-	@Override
-	public Fetchable getFetchable(int position) {
-		return attributeMappings.get( position );
 	}
 
 	@Override
@@ -270,52 +155,8 @@ public class VirtualIdEmbeddable extends AbstractEmbeddableMapping implements Id
 	}
 
 	@Override
-	public void visitSubParts(Consumer<ModelPart> consumer, EntityMappingType treatTargetType) {
-		attributeMappings.forEach( consumer );
-	}
-
-	@Override
-	public ModelPart findSubPart(String name, EntityMappingType treatTargetType) {
-		for ( int i = 0; i < attributeMappings.size(); i++ ) {
-			final SingularAttributeMapping attribute = attributeMappings.getSingularAttributeMapping( i );
-			if ( attribute.getAttributeName().equals( name ) ) {
-				return attribute;
-			}
-		}
-		return null;
-	}
-
-	@Override
-	public void forEachSubPart(IndexedConsumer<ModelPart> consumer, EntityMappingType treatTarget) {
-		for ( int i = 0; i < attributeMappings.size(); i++ ) {
-			consumer.accept( i, attributeMappings.get( i ) );
-		}
-	}
-
-	@Override
 	public <T> DomainResult<T> createDomainResult(NavigablePath navigablePath, TableGroup tableGroup, String resultVariable, DomainResultCreationState creationState) {
 		throw new UnsupportedOperationException();
-	}
-
-	@Override
-	public <X, Y> int forEachJdbcValue(
-			Object value,
-			int offset,
-			X x,
-			Y y,
-			JdbcValuesBiConsumer<X, Y> valuesConsumer,
-			SharedSessionContractImplementor session) {
-		int span = 0;
-
-		for ( int i = 0; i < attributeMappings.size(); i++ ) {
-			final AttributeMapping attributeMapping = attributeMappings.get( i );
-			if ( attributeMapping instanceof PluralAttributeMapping ) {
-				continue;
-			}
-			final Object o = attributeMapping.getPropertyAccess().getGetter().get( value );
-			span += attributeMapping.forEachJdbcValue( o, span + offset, x, y, valuesConsumer, session );
-		}
-		return span;
 	}
 
 	@Override
@@ -361,35 +202,6 @@ public class VirtualIdEmbeddable extends AbstractEmbeddableMapping implements Id
 			}
 			return span;
 		}
-	}
-
-	@Override
-	public Object disassemble(Object value, SharedSessionContractImplementor session) {
-		final Object[] result = new Object[ attributeMappings.size() ];
-		for ( int i = 0; i < attributeMappings.size(); i++ ) {
-			final AttributeMapping attributeMapping = attributeMappings.get( i );
-			final Object o = attributeMapping.getValue( value );
-			result[i] = attributeMapping.disassemble( o, session );
-		}
-
-		return result;
-	}
-
-	@Override
-	public <X, Y> int forEachDisassembledJdbcValue(
-			Object value,
-			int offset,
-			X x,
-			Y y,
-			JdbcValuesBiConsumer<X, Y> valuesConsumer,
-			SharedSessionContractImplementor session) {
-		final Object[] values = (Object[]) value;
-		int span = 0;
-		for ( int i = 0; i < attributeMappings.size(); i++ ) {
-			final AttributeMapping mapping = attributeMappings.get( i );
-			span += mapping.forEachDisassembledJdbcValue( values[i], span + offset, x, y, valuesConsumer, session );
-		}
-		return span;
 	}
 
 	@Override
@@ -450,25 +262,4 @@ public class VirtualIdEmbeddable extends AbstractEmbeddableMapping implements Id
 		);
 	}
 
-	private boolean initColumnMappings() {
-		this.selectableMappings = SelectableMappingsImpl.from( this );
-		return true;
-	}
-
-	private void addAttribute(AttributeMapping attributeMapping) {
-		addAttribute( (SingularAttributeMapping) attributeMapping );
-	}
-
-	private void addAttribute(SingularAttributeMapping attributeMapping) {
-		// check if we've already seen this attribute...
-		for ( int i = 0; i < attributeMappings.size(); i++ ) {
-			final AttributeMapping previous = attributeMappings.get( i );
-			if ( attributeMapping.getAttributeName().equals( previous.getAttributeName() ) ) {
-				attributeMappings.setAttributeMapping( i, attributeMapping );
-				return;
-			}
-		}
-
-		attributeMappings.add( attributeMapping );
-	}
 }

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/onetomany/orderby/Department.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/onetomany/orderby/Department.java
@@ -1,0 +1,37 @@
+package org.hibernate.orm.test.annotations.onetomany.orderby;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.IdClass;
+import jakarta.persistence.ManyToOne;
+
+@Entity(name = "Department")
+@IdClass(DepartmentId.class)
+public class Department {
+
+	@Id
+	@ManyToOne
+	private ECompany company;
+
+
+	@Id
+	private String departmentCode;
+
+	private String name;
+
+	public String getName() {
+		return name;
+	}
+
+	public void setCompany(ECompany company) {
+		this.company = company;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+
+	public void setDepartmentCode(String departmentId) {
+		this.departmentCode = departmentId;
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/onetomany/orderby/DepartmentId.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/onetomany/orderby/DepartmentId.java
@@ -1,0 +1,10 @@
+package org.hibernate.orm.test.annotations.onetomany.orderby;
+
+import java.io.Serializable;
+
+public class DepartmentId implements Serializable {
+
+	private ECompany company;
+	private String departmentCode;
+
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/onetomany/orderby/ECompany.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/onetomany/orderby/ECompany.java
@@ -1,0 +1,36 @@
+package org.hibernate.orm.test.annotations.onetomany.orderby;
+
+import java.util.Set;
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.OrderBy;
+
+@Entity(name = "Company")
+public class ECompany {
+
+	@Id
+	@GeneratedValue
+	private Long id;
+
+	private String name;
+
+	@OneToMany(mappedBy = "company", cascade = CascadeType.ALL)
+	@OrderBy("departmentCode DESC")
+	private Set<Department> departments;
+
+	public Set<Department> getDepartments() {
+		return departments;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+
+	public void setDepartments(Set<Department> departments) {
+		this.departments = departments;
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/onetomany/orderby/IdClassAndOrderByTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/onetomany/orderby/IdClassAndOrderByTest.java
@@ -1,0 +1,93 @@
+package org.hibernate.orm.test.annotations.onetomany.orderby;
+
+import org.hibernate.boot.model.naming.CamelCaseToUnderscoresNamingStrategy;
+import org.hibernate.boot.model.naming.Identifier;
+import org.hibernate.boot.model.naming.ImplicitJoinTableNameSource;
+import org.hibernate.boot.model.naming.ImplicitNamingStrategyJpaCompliantImpl;
+import org.hibernate.cfg.AvailableSettings;
+
+import org.hibernate.testing.TestForIssue;
+import org.hibernate.testing.orm.junit.EntityManagerFactoryScope;
+import org.hibernate.testing.orm.junit.Jpa;
+import org.hibernate.testing.orm.junit.SettingProvider;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+@Jpa(
+		annotatedClasses = {
+				ECompany.class,
+				Department.class
+		},
+		settingProviders = {
+				@SettingProvider(
+						settingName = AvailableSettings.PHYSICAL_NAMING_STRATEGY,
+						provider = IdClassAndOrderByTest.PhysicalNamingStrategyProvider.class
+				),
+				@SettingProvider(
+						settingName = AvailableSettings.IMPLICIT_NAMING_STRATEGY,
+						provider = IdClassAndOrderByTest.ImplicitNamingStrategyProvider.class
+				),
+
+		}
+)
+@TestForIssue(jiraKey = "HHH-16009")
+public class IdClassAndOrderByTest {
+
+	public static final String COMPANY_NAME = "Foo Company";
+
+	public static class PhysicalNamingStrategyProvider implements SettingProvider.Provider<String> {
+		@Override
+		public String getSetting() {
+			return CamelCaseToUnderscoresNamingStrategy.class.getName();
+		}
+	}
+
+	public static class ImplicitNamingStrategyProvider implements SettingProvider.Provider<String> {
+		@Override
+		public String getSetting() {
+			return CustomImplicitNamingStrategy.class.getName();
+		}
+	}
+
+	@BeforeAll
+	public void setUp(EntityManagerFactoryScope scope) {
+		scope.inTransaction(
+				entityManager -> {
+					ECompany company = new ECompany();
+					company.setName( COMPANY_NAME );
+					entityManager.persist( company );
+
+					Department department = new Department();
+					department.setCompany( company );
+					department.setDepartmentCode( "1234567" );
+					department.setName( "Foo Department" );
+					entityManager.persist( department );
+				}
+		);
+
+	}
+
+	@Test
+	public void testSelect(EntityManagerFactoryScope scope) {
+		scope.inTransaction(
+				entityManager -> {
+					entityManager.createQuery(
+									"SELECT c FROM Company c LEFT JOIN FETCH c.departments WHERE c.name = :name" )
+							.setParameter( "name", COMPANY_NAME ).getResultList();
+				}
+		);
+	}
+
+
+	public static class CustomImplicitNamingStrategy extends ImplicitNamingStrategyJpaCompliantImpl {
+		public CustomImplicitNamingStrategy() {
+		}
+
+		@Override
+		public Identifier determineJoinTableName(ImplicitJoinTableNameSource source) {
+			String var10000 = source.getOwningPhysicalTableName();
+			String name = var10000 + "_" + source.getAssociationOwningAttributePath().getProperty();
+			return this.toIdentifier( name, source.getBuildingContext() );
+		}
+	}
+}


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-16009

the fix is https://github.com/hibernate/hibernate-orm/commit/da4d87ab7236c09e646fbc4f2bfe3003d97d4da5

when the order by refers to a property of an `IdClass` and the `finishInitialization` method of the `PluralAttribute` is executed before the one of the `EmbeddableMappingType` then when hibernate tries to resolve the path of the order by the `EmbeddableMappingType #findAttributeMapping(String name)` returns null (its attributes have not yet been initialized) and a `ColumnReference` is created assuming that the name of the column is equal to the name of the property, but this does not work when a physical naming strategy is provided. 

