### PR TITLE
HHH-16194 Failure to automatically integrate with Bean Validation is excessively noisy

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/boot/beanvalidation/TypeSafeActivator.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/beanvalidation/TypeSafeActivator.java
@@ -483,11 +483,6 @@ class TypeSafeActivator {
 			return Validation.buildDefaultValidatorFactory();
 		}
 		catch ( Exception e ) {
-			LOG.infof(
-					e,
-					"Error calling `%s`",
-					"jakarta.validation.Validation#buildDefaultValidatorFactory"
-			);
 			throw new IntegrationException( "Unable to build the default ValidatorFactory", e );
 		}
 	}


### PR DESCRIPTION
Failure to automatically integrate with Bean Validation is excessively noisy
https://hibernate.atlassian.net/browse/HHH-16194