### PR TITLE
Apply changes needed for support of @ValueGenerationType in Hibernate Reactive

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/GeneratedValuesProcessor.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/GeneratedValuesProcessor.java
@@ -139,4 +139,24 @@ public class GeneratedValuesProcessor {
 			attribute.getAttributeMetadata().getPropertyAccess().getSetter().set( entity, generatedValue );
 		}
 	}
+
+	public SelectStatement getSelectStatement() {
+		return selectStatement;
+	}
+
+	public List<AttributeMapping> getGeneratedValuesToSelect() {
+		return generatedValuesToSelect;
+	}
+
+	public List<JdbcParameter> getJdbcParameters() {
+		return jdbcParameters;
+	}
+
+	public EntityMappingType getEntityDescriptor() {
+		return entityDescriptor;
+	}
+
+	public SessionFactoryImplementor getSessionFactory() {
+		return sessionFactory;
+	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/persister/entity/AbstractEntityPersister.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/entity/AbstractEntityPersister.java
@@ -1000,6 +1000,16 @@ public abstract class AbstractEntityPersister
 		return sqlVersionSelectString;
 	}
 
+	@Internal
+	public GeneratedValuesProcessor getInsertGeneratedValuesProcessor() {
+		return insertGeneratedValuesProcessor;
+	}
+
+	@Internal
+	public GeneratedValuesProcessor getUpdateGeneratedValuesProcessor() {
+		return updateGeneratedValuesProcessor;
+	}
+
 	@Override
 	public boolean hasRowId() {
 		return rowIdName != null;

--- a/hibernate-core/src/main/java/org/hibernate/persister/entity/mutation/UpdateCoordinatorStandard.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/entity/mutation/UpdateCoordinatorStandard.java
@@ -216,7 +216,7 @@ public class UpdateCoordinatorStandard extends AbstractMutationCoordinator imple
 		);
 	}
 
-	private void performUpdate(
+	protected void performUpdate(
 			Object entity,
 			Object id,
 			Object rowId,
@@ -294,7 +294,7 @@ public class UpdateCoordinatorStandard extends AbstractMutationCoordinator imple
 		}
 	}
 
-	private static int[] dirtyAttributeIndexes(int[] incomingDirtyIndexes, int[] preUpdateGeneratedIndexes) {
+	protected static int[] dirtyAttributeIndexes(int[] incomingDirtyIndexes, int[] preUpdateGeneratedIndexes) {
 		if ( preUpdateGeneratedIndexes.length == 0 ) {
 			return incomingDirtyIndexes;
 		}
@@ -356,7 +356,7 @@ public class UpdateCoordinatorStandard extends AbstractMutationCoordinator imple
 		}
 	}
 
-	private boolean handlePotentialImplicitForcedVersionIncrement(
+	protected boolean handlePotentialImplicitForcedVersionIncrement(
 			Object entity,
 			Object id,
 			Object[] values,
@@ -532,7 +532,7 @@ public class UpdateCoordinatorStandard extends AbstractMutationCoordinator imple
 	 * Transform the array of property indexes to an array of booleans for each attribute,
 	 * true when the property is dirty
 	 */
-	private boolean[] getPropertiesToUpdate(final int[] dirtyProperties, final boolean hasDirtyCollection) {
+	protected boolean[] getPropertiesToUpdate(final int[] dirtyProperties, final boolean hasDirtyCollection) {
 		final boolean[] updateability = entityPersister().getPropertyUpdateability();
 		if ( dirtyProperties == null ) {
 			return updateability;


### PR DESCRIPTION
This change would need to be backported to `6.2` in order for us to proceed with the HR [work](https://github.com/hibernate/hibernate-reactive/pull/1462)