### PR TITLE
HHH-16197 Circular references of the same entity result in different Java objects when caching is enabled and using a query

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/engine/spi/SharedSessionContractImplementor.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/spi/SharedSessionContractImplementor.java
@@ -330,6 +330,16 @@ public interface SharedSessionContractImplementor
 	String bestGuessEntityName(Object object);
 
 	/**
+	 * Obtain the best estimate of the entity name of the given entity
+	 * instance, which is not involved in an association, by also
+	 * considering information held in the proxy, and whether the object
+	 * is already associated with this session.
+	 */
+	default String bestGuessEntityName(Object object, EntityEntry entry) {
+		return bestGuessEntityName( object );
+	}
+
+	/**
 	 * Obtain an estimate of the entity name of the given entity instance,
 	 * which is not involved in an association, using only the
 	 * {@link org.hibernate.EntityNameResolver}.

--- a/hibernate-core/src/main/java/org/hibernate/event/internal/DefaultPersistEventListener.java
+++ b/hibernate-core/src/main/java/org/hibernate/event/internal/DefaultPersistEventListener.java
@@ -81,7 +81,7 @@ public class DefaultPersistEventListener
 	private void persist(PersistEvent event, PersistContext createCache, Object entity) {
 		final EventSource source = event.getSession();
 		final EntityEntry entityEntry = source.getPersistenceContextInternal().getEntry( entity );
-		final String entityName = entityName( event, entity );
+		final String entityName = entityName( event, entity, entityEntry );
 		switch ( entityState( event, entity, entityName, entityEntry ) ) {
 			case DETACHED:
 				throw new PersistentObjectException( "detached entity passed to persist: "
@@ -133,13 +133,13 @@ public class DefaultPersistEventListener
 		return entityState;
 	}
 
-	private static String entityName(PersistEvent event, Object entity) {
+	private static String entityName(PersistEvent event, Object entity, EntityEntry entityEntry) {
 		if ( event.getEntityName() != null ) {
 			return event.getEntityName();
 		}
 		else {
 			// changes event.entityName by side effect!
-			final String entityName = event.getSession().bestGuessEntityName( entity );
+			final String entityName = event.getSession().bestGuessEntityName( entity, entityEntry );
 			event.setEntityName( entityName );
 			return entityName;
 		}

--- a/hibernate-core/src/main/java/org/hibernate/internal/SessionImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/SessionImpl.java
@@ -1719,6 +1719,25 @@ public class SessionImpl
 	}
 
 	@Override
+	public String bestGuessEntityName(Object object, EntityEntry entry) {
+		final LazyInitializer lazyInitializer = extractLazyInitializer( object );
+		if ( lazyInitializer != null ) {
+			// it is possible for this method to be called during flush processing,
+			// so make certain that we do not accidentally initialize an uninitialized proxy
+			if ( lazyInitializer.isUninitialized() ) {
+				return lazyInitializer.getEntityName();
+			}
+			object = lazyInitializer.getImplementation();
+		}
+		if ( entry == null ) {
+			return guessEntityName( object );
+		}
+		else {
+			return entry.getPersister().getEntityName();
+		}
+	}
+
+	@Override
 	public String getEntityName(Object object) {
 		checkOpen();
 //		checkTransactionSynchStatus();

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/cache/CircularityTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/cache/CircularityTest.java
@@ -1,0 +1,167 @@
+package org.hibernate.orm.test.cache;
+
+import org.hibernate.annotations.Cache;
+import org.hibernate.annotations.CacheConcurrencyStrategy;
+import org.hibernate.cfg.AvailableSettings;
+
+import org.hibernate.testing.TestForIssue;
+import org.hibernate.testing.orm.junit.EntityManagerFactoryScope;
+import org.hibernate.testing.orm.junit.Jpa;
+import org.hibernate.testing.orm.junit.Setting;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToOne;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+@Jpa(
+		annotatedClasses = {
+				CircularityTest.GrandParent.class,
+				CircularityTest.Parent.class,
+				CircularityTest.Child.class
+		},
+		integrationSettings = @Setting(name = AvailableSettings.USE_SECOND_LEVEL_CACHE, value = "true")
+)
+@TestForIssue(jiraKey = "HHH-16197")
+public class CircularityTest {
+
+	private static final String CHILD_ID = "c1";
+
+	@BeforeAll
+	public void setUp(EntityManagerFactoryScope scope) {
+		scope.inTransaction(
+				entityManager -> {
+					Child c1 = new Child( CHILD_ID );
+					Parent p1 = new Parent( "p1", c1 );
+					GrandParent gp1 = new GrandParent("gp1", p1);
+
+					entityManager.persist( c1 );
+					entityManager.persist( p1 );
+					entityManager.persist( gp1 );
+				}
+		);
+	}
+
+	@Test
+	public void testSelection(EntityManagerFactoryScope scope) {
+		scope.inTransaction(
+				entityManager -> {
+					Child child = entityManager.createQuery(
+							"SELECT child from Child child WHERE child.id = :id",
+							Child.class
+					).setParameter( "id", CHILD_ID ).getSingleResult();
+					assertThat( child ).isNotNull();
+					assertThat( child ).isEqualTo( child.getParent().getChild() );
+					assertThat( child.getParent().getGrandParent().getChild() ).isEqualTo( child.getParent() );
+				}
+		);
+	}
+
+	@Entity(name = "Child")
+	@Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "hibernate.test")
+	public static class Child {
+
+		@Id
+		private String id;
+
+		private String name;
+
+		@ManyToOne
+		private Parent parent;
+
+		public Child() {
+		}
+
+		public Child(String id) {
+			this.id = id;
+		}
+
+		public String getId() {
+			return id;
+		}
+
+		public Parent getParent() {
+			return parent;
+		}
+
+	}
+
+	@Entity(name = "Parent")
+	@Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "hibernate.test")
+	public static class Parent {
+
+		@Id
+		private String id;
+
+		private String name;
+
+		@OneToOne
+		private Child child;
+
+		@OneToOne
+		private GrandParent grandParent;
+
+		public Parent(String id, Child child) {
+			this.id = id;
+			this.child = child;
+			this.child.parent = this;
+		}
+
+		public Parent() {
+		}
+
+		public String getId() {
+			return id;
+		}
+
+		public void setId(String id) {
+			this.id = id;
+		}
+
+		public Child getChild() {
+			return child;
+		}
+
+		public void setChild(Child child) {
+			this.child = child;
+		}
+
+		public GrandParent getGrandParent() {
+			return grandParent;
+		}
+	}
+
+	@Entity(name = "GrandParent")
+	@Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "hibernate.test")
+	public static class GrandParent {
+
+		@Id
+		private String id;
+
+		private String name;
+
+		@OneToOne
+		private Parent child;
+
+		public GrandParent(String id, Parent child) {
+			this.id = id;
+			this.child = child;
+			this.child.grandParent = this;
+		}
+
+		public GrandParent() {
+		}
+
+		public String getId() {
+			return id;
+		}
+
+		public Parent getChild() {
+			return child;
+		}
+	}
+}


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-16197