### PR TITLE
Fix logging in AbstractCollectionInitializer

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/AbstractCollectionInitializer.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/AbstractCollectionInitializer.java
@@ -82,7 +82,7 @@ public abstract class AbstractCollectionInitializer implements CollectionInitial
 			if ( CollectionLoadingLogger.DEBUG_ENABLED ) {
 				CollectionLoadingLogger.COLL_LOAD_LOGGER.debugf(
 						"(%s) Current row collection key : %s",
-						DelayedCollectionInitializer.class.getSimpleName(),
+						this.getClass().getSimpleName(),
 						LoggingHelper.toLoggableString( getNavigablePath(), this.collectionKey.getKey() )
 				);
 			}


### PR DESCRIPTION
The previous version of the code lead to misleading log statements being printed when debug logging
was enabled for 'org.hibernate.orm.results.loading.collection'