### PR TITLE
HHH-16233 Fix logs for mutable non-root entity

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/boot/model/internal/EntityBinder.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/internal/EntityBinder.java
@@ -1188,7 +1188,7 @@ public class EntityBinder {
 		if ( persistentClass instanceof RootClass ) {
 			bindRootEntity();
 		}
-		else if ( isMutable() ) {
+		else if ( !isMutable() ) {
 			LOG.immutableAnnotationOnNonRoot( annotatedClass.getName() );
 		}
 


### PR DESCRIPTION
An incorrect error log message is given about @Immutable is declared to non-root entities that are not @Immutable declared.

@Immutable can only be declared on the Root Entity.
That is, it is not wrong to say that a non-root entity is mutable, so should not send the message `@Immutable used on a non root entity` to non-root entity that are not declared with @Immutable.

This should only happen for non-root entities that are immutable.

https://hibernate.atlassian.net/jira/software/c/projects/HHH/issues/HHH-16233