### PR TITLE
HHH-16209 Identically-named association in entity root and embeddable leads to mixup during association loading

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/ToOneAttributeMapping.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/ToOneAttributeMapping.java
@@ -1065,7 +1065,15 @@ public class ToOneAttributeMapping
 			}
 			return false;
 		}
-		return parentNavigablePath.isSuffix( bidirectionalAttributePath );
+
+		NavigablePath navigablePath = parentNavigablePath.trimSuffix( bidirectionalAttributePath );
+		if ( navigablePath != null ) {
+			if ( navigablePath.getLocalName().equals( EntityIdentifierMapping.ROLE_LOCAL_NAME ) ) {
+				navigablePath = navigablePath.getParent();
+			}
+			return creationState.resolveModelPart( navigablePath ).getPartMappingType() == entityMappingType;
+		}
+		return false;
 	}
 
 	private boolean isParentEmbeddedCollectionPart(DomainResultCreationState creationState, NavigablePath parentNavigablePath) {

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/ToOneAttributeMapping.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/ToOneAttributeMapping.java
@@ -1068,7 +1068,10 @@ public class ToOneAttributeMapping
 
 		NavigablePath navigablePath = parentNavigablePath.trimSuffix( bidirectionalAttributePath );
 		if ( navigablePath != null ) {
-			if ( navigablePath.getLocalName().equals( EntityIdentifierMapping.ROLE_LOCAL_NAME ) ) {
+			final String localName = navigablePath.getLocalName();
+			if ( localName.equals( EntityIdentifierMapping.ROLE_LOCAL_NAME )
+					|| localName.equals( ForeignKeyDescriptor.PART_NAME )
+					|| localName.equals( ForeignKeyDescriptor.TARGET_PART_NAME ) ) {
 				navigablePath = navigablePath.getParent();
 			}
 			return creationState.resolveModelPart( navigablePath ).getPartMappingType() == entityMappingType;

--- a/hibernate-core/src/main/java/org/hibernate/spi/NavigablePath.java
+++ b/hibernate-core/src/main/java/org/hibernate/spi/NavigablePath.java
@@ -206,6 +206,30 @@ public class NavigablePath implements DotIdentifierSequence, Serializable {
 	}
 
 	/**
+	 *
+	 * Removes the suffix part from the NavigablePath,
+	 * when the NavigablePath does not contain the suffix it returns null;
+	 *
+	 * @param suffix the part to remove from the NavigablePath
+	 *
+	 * @return the NavigablePath stripped of the suffix part
+	 * or null if the NavigablePath does not contain the suffix.
+	 *
+	 */
+	public NavigablePath trimSuffix(DotIdentifierSequence suffix) {
+		if ( suffix == null ) {
+			return this;
+		}
+		if ( !getLocalName().equals( suffix.getLocalName() ) ) {
+			return null;
+		}
+		if ( getParent() != null ) {
+			return getParent().trimSuffix( suffix.getParent() );
+		}
+		return null;
+	}
+
+	/**
 	 * Determine whether this path is part of the given path's parent
 	 */
 	public boolean isParentOrEqual(NavigablePath navigablePath) {

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/embeddable/EmbeddableWithIdenticallyNamedAssociationTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/embeddable/EmbeddableWithIdenticallyNamedAssociationTest.java
@@ -1,0 +1,229 @@
+package org.hibernate.orm.test.mapping.embeddable;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.hibernate.testing.TestForIssue;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import jakarta.persistence.Embeddable;
+import jakarta.persistence.Embedded;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
+
+@DomainModel(
+		annotatedClasses = {
+				EmbeddableWithIdenticallyNamedAssociationTest.EntityA.class,
+				EmbeddableWithIdenticallyNamedAssociationTest.EntityB.class,
+				EmbeddableWithIdenticallyNamedAssociationTest.EmbeddableB.class
+		}
+)
+@SessionFactory
+@TestForIssue(jiraKey = "TODO")
+public class EmbeddableWithIdenticallyNamedAssociationTest {
+
+	@BeforeAll
+	public void setUp(SessionFactoryScope scope) {
+		EntityA a1 = new EntityA();
+		a1.setId( 1 );
+		EntityB b1 = new EntityB();
+		b1.setId( 1 );
+		b1.setIdenticallyNamedAssociationFromB( a1 );
+		a1.setIdenticallyNamedAssociationFromA( b1 );
+
+		EntityA a2 = new EntityA();
+		a2.setId( 2 );
+		EntityB b2 = new EntityB();
+		b2.setId( 2 );
+		b2.setIdenticallyNamedAssociationFromB( a2 );
+		a2.setIdenticallyNamedAssociationFromA( b2 );
+
+		EmbeddableB embeddableB = new EmbeddableB();
+		embeddableB.setIdenticallyNamedAssociationFromB( a2 );
+		b1.setEmbeddableB( embeddableB );
+		EmbeddableA embeddableA = new EmbeddableA();
+		embeddableA.setIdenticallyNamedAssociationFromA( b1 );
+		a2.setEmbeddableA( embeddableA );
+
+		scope.inTransaction( session -> {
+			session.persist( a1 );
+			session.persist( a2 );
+			session.persist( b1 );
+			session.persist( b2 );
+
+			assertEntityContent( a1, a2, b1, b2 );
+		} );
+	}
+
+	private void assertEntityContent(EntityA a1, EntityA a2, EntityB b1, EntityB b2) {
+		assertThat( a1 ).isNotNull();
+		assertThat( a2 ).isNotNull();
+		assertThat( b1 ).isNotNull();
+		assertThat( b2 ).isNotNull();
+
+		assertThat( b1.getIdenticallyNamedAssociationFromB() ).isEqualTo( a1 );
+		assertThat( a1.getIdenticallyNamedAssociationFromA() ).isEqualTo( b1 );
+
+		assertThat( b2.getIdenticallyNamedAssociationFromB() ).isEqualTo( a2 );
+		assertThat( a2.getIdenticallyNamedAssociationFromA() ).isEqualTo( b2 );
+
+		assertThat( b1.getEmbeddableB() ).isNotNull();
+		assertThat( b1.getEmbeddableB().getIdenticallyNamedAssociationFromB() ).isEqualTo( a2 );
+		assertThat( a2.getEmbeddableA() ).isNotNull();
+		assertThat( a2.getEmbeddableA().getIdenticallyNamedAssociationFromA() ).isEqualTo( b1 );
+	}
+
+	@Test
+	public void testGetEntities(SessionFactoryScope scope) {
+		scope.inTransaction( session -> {
+			EntityA a1 = session.get( EntityA.class, 1 );
+			EntityA a2 = session.get( EntityA.class, 2 );
+			EntityB b1 = session.get( EntityB.class, 1 );
+			EntityB b2 = session.get( EntityB.class, 2 );
+
+			// Run the *exact* same assertions we ran just after persisting.
+			// Entity content should be identical, but the bug is: it's not.
+			assertEntityContent(a1, a2, b1, b2);
+		} );
+	}
+
+	@Entity(name = "entityA")
+	public static class EntityA {
+		@Id
+		private Integer id;
+
+		@OneToOne(mappedBy = "identicallyNamedAssociationFromB")
+		private EntityB identicallyNamedAssociationFromA;
+
+		@Embedded
+		private EmbeddableA embeddableA;
+
+		@Override
+		public String toString() {
+			return "EntityB{" +
+					"id=" + id +
+					", identicallyNamedAssociationFromA=" + identicallyNamedAssociationFromA.getId() +
+					", embeddableA=" + embeddableA +
+					'}';
+		}
+
+		public Integer getId() {
+			return id;
+		}
+
+		public void setId(Integer id) {
+			this.id = id;
+		}
+
+		public EntityB getIdenticallyNamedAssociationFromA() {
+			return identicallyNamedAssociationFromA;
+		}
+
+		public void setIdenticallyNamedAssociationFromA(EntityB identicallyNamedAssociationFromA) {
+			this.identicallyNamedAssociationFromA = identicallyNamedAssociationFromA;
+		}
+
+		public EmbeddableA getEmbeddableA() {
+			return embeddableA;
+		}
+
+		public void setEmbeddableA(EmbeddableA embeddableA) {
+			this.embeddableA = embeddableA;
+		}
+	}
+
+	@Embeddable
+	public static class EmbeddableA {
+		@OneToOne(mappedBy = "embeddableB.identicallyNamedAssociationFromB")
+		private EntityB identicallyNamedAssociationFromA;
+
+		@Override
+		public String toString() {
+			return "EmbeddableA{" +
+					", identicallyNamedAssociationFromA=" + identicallyNamedAssociationFromA.getId() +
+					'}';
+		}
+
+		public EntityB getIdenticallyNamedAssociationFromA() {
+			return identicallyNamedAssociationFromA;
+		}
+
+		public void setIdenticallyNamedAssociationFromA(EntityB a) {
+			this.identicallyNamedAssociationFromA = a;
+		}
+	}
+
+	@Entity(name = "entityB")
+	public static class EntityB {
+		@Id
+		private Integer id;
+
+		@OneToOne
+		@JoinColumn(name = "entityA_id")
+		private EntityA identicallyNamedAssociationFromB;
+
+		@Embedded
+		private EmbeddableB embeddableB;
+
+		@Override
+		public String toString() {
+			return "EntityB{" +
+					"id=" + id +
+					", identicallyNamedAssociationFromB=" + identicallyNamedAssociationFromB.getId() +
+					", embeddableB=" + embeddableB +
+					'}';
+		}
+
+		public Integer getId() {
+			return id;
+		}
+
+		public void setId(Integer id) {
+			this.id = id;
+		}
+
+		public EntityA getIdenticallyNamedAssociationFromB() {
+			return identicallyNamedAssociationFromB;
+		}
+
+		public void setIdenticallyNamedAssociationFromB(EntityA a) {
+			this.identicallyNamedAssociationFromB = a;
+		}
+
+		public EmbeddableB getEmbeddableB() {
+			return embeddableB;
+		}
+
+		public void setEmbeddableB(EmbeddableB embeddableB) {
+			this.embeddableB = embeddableB;
+		}
+	}
+
+	@Embeddable
+	public static class EmbeddableB {
+		@OneToOne
+		@JoinColumn(name = "emb_entityA_id")
+		private EntityA identicallyNamedAssociationFromB;
+
+		@Override
+		public String toString() {
+			return "EmbeddableB{" +
+					", identicallyNamedAssociationFromB=" + identicallyNamedAssociationFromB.getId() +
+					'}';
+		}
+
+		public EntityA getIdenticallyNamedAssociationFromB() {
+			return identicallyNamedAssociationFromB;
+		}
+
+		public void setIdenticallyNamedAssociationFromB(EntityA a) {
+			this.identicallyNamedAssociationFromB = a;
+		}
+	}
+
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/embeddable/EmbeddableWithIdenticallyNamedAssociationTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/embeddable/EmbeddableWithIdenticallyNamedAssociationTest.java
@@ -24,30 +24,32 @@ import jakarta.persistence.OneToOne;
 		}
 )
 @SessionFactory
-@TestForIssue(jiraKey = "TODO")
+@TestForIssue(jiraKey = "HHH-16209")
 public class EmbeddableWithIdenticallyNamedAssociationTest {
 
 	@BeforeAll
 	public void setUp(SessionFactoryScope scope) {
 		EntityA a1 = new EntityA();
 		a1.setId( 1 );
+
 		EntityB b1 = new EntityB();
 		b1.setId( 1 );
-		b1.setIdenticallyNamedAssociationFromB( a1 );
-		a1.setIdenticallyNamedAssociationFromA( b1 );
+		b1.setEntityA( a1 );
+		a1.setEntityB( b1 );
 
 		EntityA a2 = new EntityA();
 		a2.setId( 2 );
 		EntityB b2 = new EntityB();
 		b2.setId( 2 );
-		b2.setIdenticallyNamedAssociationFromB( a2 );
-		a2.setIdenticallyNamedAssociationFromA( b2 );
+		b2.setEntityA( a2 );
+		a2.setEntityB( b2 );
 
 		EmbeddableB embeddableB = new EmbeddableB();
-		embeddableB.setIdenticallyNamedAssociationFromB( a2 );
+		embeddableB.setEntityA( a2 );
 		b1.setEmbeddableB( embeddableB );
+
 		EmbeddableA embeddableA = new EmbeddableA();
-		embeddableA.setIdenticallyNamedAssociationFromA( b1 );
+		embeddableA.setEntityB( b1 );
 		a2.setEmbeddableA( embeddableA );
 
 		scope.inTransaction( session -> {
@@ -66,16 +68,16 @@ public class EmbeddableWithIdenticallyNamedAssociationTest {
 		assertThat( b1 ).isNotNull();
 		assertThat( b2 ).isNotNull();
 
-		assertThat( b1.getIdenticallyNamedAssociationFromB() ).isEqualTo( a1 );
-		assertThat( a1.getIdenticallyNamedAssociationFromA() ).isEqualTo( b1 );
+		assertThat( b1.getEntityA() ).isEqualTo( a1 );
+		assertThat( a1.getEntityB() ).isEqualTo( b1 );
 
-		assertThat( b2.getIdenticallyNamedAssociationFromB() ).isEqualTo( a2 );
-		assertThat( a2.getIdenticallyNamedAssociationFromA() ).isEqualTo( b2 );
+		assertThat( b2.getEntityA() ).isEqualTo( a2 );
+		assertThat( a2.getEntityB() ).isEqualTo( b2 );
 
 		assertThat( b1.getEmbeddableB() ).isNotNull();
-		assertThat( b1.getEmbeddableB().getIdenticallyNamedAssociationFromB() ).isEqualTo( a2 );
+		assertThat( b1.getEmbeddableB().getEntityA() ).isEqualTo( a2 );
 		assertThat( a2.getEmbeddableA() ).isNotNull();
-		assertThat( a2.getEmbeddableA().getIdenticallyNamedAssociationFromA() ).isEqualTo( b1 );
+		assertThat( a2.getEmbeddableA().getEntityB() ).isEqualTo( b1 );
 	}
 
 	@Test
@@ -97,8 +99,8 @@ public class EmbeddableWithIdenticallyNamedAssociationTest {
 		@Id
 		private Integer id;
 
-		@OneToOne(mappedBy = "identicallyNamedAssociationFromB")
-		private EntityB identicallyNamedAssociationFromA;
+		@OneToOne(mappedBy = "entityA")
+		private EntityB entityB;
 
 		@Embedded
 		private EmbeddableA embeddableA;
@@ -107,7 +109,7 @@ public class EmbeddableWithIdenticallyNamedAssociationTest {
 		public String toString() {
 			return "EntityB{" +
 					"id=" + id +
-					", identicallyNamedAssociationFromA=" + identicallyNamedAssociationFromA.getId() +
+					", entityB =" + entityB.getId() +
 					", embeddableA=" + embeddableA +
 					'}';
 		}
@@ -120,12 +122,12 @@ public class EmbeddableWithIdenticallyNamedAssociationTest {
 			this.id = id;
 		}
 
-		public EntityB getIdenticallyNamedAssociationFromA() {
-			return identicallyNamedAssociationFromA;
+		public EntityB getEntityB() {
+			return entityB;
 		}
 
-		public void setIdenticallyNamedAssociationFromA(EntityB identicallyNamedAssociationFromA) {
-			this.identicallyNamedAssociationFromA = identicallyNamedAssociationFromA;
+		public void setEntityB(EntityB entityB) {
+			this.entityB = entityB;
 		}
 
 		public EmbeddableA getEmbeddableA() {
@@ -139,22 +141,22 @@ public class EmbeddableWithIdenticallyNamedAssociationTest {
 
 	@Embeddable
 	public static class EmbeddableA {
-		@OneToOne(mappedBy = "embeddableB.identicallyNamedAssociationFromB")
-		private EntityB identicallyNamedAssociationFromA;
+		@OneToOne(mappedBy = "embeddableB.entityA")
+		private EntityB entityB;
 
 		@Override
 		public String toString() {
 			return "EmbeddableA{" +
-					", identicallyNamedAssociationFromA=" + identicallyNamedAssociationFromA.getId() +
+					", entityB=" + entityB.getId() +
 					'}';
 		}
 
-		public EntityB getIdenticallyNamedAssociationFromA() {
-			return identicallyNamedAssociationFromA;
+		public EntityB getEntityB() {
+			return entityB;
 		}
 
-		public void setIdenticallyNamedAssociationFromA(EntityB a) {
-			this.identicallyNamedAssociationFromA = a;
+		public void setEntityB(EntityB a) {
+			this.entityB = a;
 		}
 	}
 
@@ -165,7 +167,7 @@ public class EmbeddableWithIdenticallyNamedAssociationTest {
 
 		@OneToOne
 		@JoinColumn(name = "entityA_id")
-		private EntityA identicallyNamedAssociationFromB;
+		private EntityA entityA;
 
 		@Embedded
 		private EmbeddableB embeddableB;
@@ -174,7 +176,7 @@ public class EmbeddableWithIdenticallyNamedAssociationTest {
 		public String toString() {
 			return "EntityB{" +
 					"id=" + id +
-					", identicallyNamedAssociationFromB=" + identicallyNamedAssociationFromB.getId() +
+					", entityA=" + entityA.getId() +
 					", embeddableB=" + embeddableB +
 					'}';
 		}
@@ -187,12 +189,12 @@ public class EmbeddableWithIdenticallyNamedAssociationTest {
 			this.id = id;
 		}
 
-		public EntityA getIdenticallyNamedAssociationFromB() {
-			return identicallyNamedAssociationFromB;
+		public EntityA getEntityA() {
+			return entityA;
 		}
 
-		public void setIdenticallyNamedAssociationFromB(EntityA a) {
-			this.identicallyNamedAssociationFromB = a;
+		public void setEntityA(EntityA a) {
+			this.entityA = a;
 		}
 
 		public EmbeddableB getEmbeddableB() {
@@ -208,21 +210,21 @@ public class EmbeddableWithIdenticallyNamedAssociationTest {
 	public static class EmbeddableB {
 		@OneToOne
 		@JoinColumn(name = "emb_entityA_id")
-		private EntityA identicallyNamedAssociationFromB;
+		private EntityA entityA;
 
 		@Override
 		public String toString() {
 			return "EmbeddableB{" +
-					", identicallyNamedAssociationFromB=" + identicallyNamedAssociationFromB.getId() +
+					", entityA=" + entityA.getId() +
 					'}';
 		}
 
-		public EntityA getIdenticallyNamedAssociationFromB() {
-			return identicallyNamedAssociationFromB;
+		public EntityA getEntityA() {
+			return entityA;
 		}
 
-		public void setIdenticallyNamedAssociationFromB(EntityA a) {
-			this.identicallyNamedAssociationFromB = a;
+		public void setEntityA(EntityA a) {
+			this.entityA = a;
 		}
 	}
 


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-16209