### PR TITLE
HHH-15895 IllegalArgumentException :Cannot create binding for parameter referencen with criteria builder 

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/internal/DomainParameterXref.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/internal/DomainParameterXref.java
@@ -42,38 +42,9 @@ public class DomainParameterXref {
 		// `.. where a.b = :param or a.c = :param`.  Here we have 2 SqmParameter
 		// references (one for each occurrence of `:param`) both of which map to
 		// the same QueryParameter.
-		final Map<SqmParameter,QueryParameterImplementor<?>> xrefMap = new TreeMap<>(
-				(o1, o2) -> {
-					if ( o1 instanceof SqmNamedParameter ) {
-						final SqmNamedParameter<?> one = (SqmNamedParameter<?>) o1;
-						return o2 instanceof SqmNamedParameter<?>
-								? one.getName().compareTo( ((SqmNamedParameter<?>) o2).getName() )
-								: -1;
-					}
-					else if ( o1 instanceof SqmPositionalParameter ) {
-						final SqmPositionalParameter<?> one = (SqmPositionalParameter<?>) o1;
-						return o2 instanceof SqmPositionalParameter<?>
-								? one.getPosition().compareTo( ( (SqmPositionalParameter<?>) o2 ).getPosition() )
-								: 1;
-					}
-					else if ( o1 instanceof SqmJpaCriteriaParameterWrapper
-							&& o2 instanceof SqmJpaCriteriaParameterWrapper ) {
-//						final SqmJpaCriteriaParameterWrapper wrapper1 = (SqmJpaCriteriaParameterWrapper) o1;
-//						final SqmJpaCriteriaParameterWrapper wrapper2 = (SqmJpaCriteriaParameterWrapper) o2;
-//						if ( wrapper1.getJpaCriteriaParameter() == wrapper2.getJpaCriteriaParameter() ) {
-//							return 0;
-//						}
-//
-//						if ( o1.getName() != null ) {
-//							return o1.getName().compareTo( o2.getName() );
-//						}
-//						else {
-							return Integer.compare( o1.hashCode(), o2.hashCode() );
-//						}
-					}
-
-					throw new HibernateException( "Unexpected SqmParameter type for comparison : " + o1 + " & " + o2 );
-				}
+		final Map<SqmParameter, QueryParameterImplementor<?>> xrefMap = new TreeMap<>(
+				(o1, o2) ->
+						o1.compare( o2 )
 		);
 
 		final SqmStatement.ParameterResolutions parameterResolutions = sqmStatement.resolveParameters();

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/expression/JpaCriteriaParameter.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/expression/JpaCriteriaParameter.java
@@ -164,4 +164,11 @@ public class JpaCriteriaParameter<T>
 		}
 		return Objects.hash( name );
 	}
+
+	@Override
+	public int compare(SqmParameter anotherParameter) {
+		return anotherParameter instanceof JpaCriteriaParameter ?
+				Integer.compare( hashCode(), anotherParameter.hashCode() )
+				: 1;
+	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/expression/SqmJpaCriteriaParameterWrapper.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/expression/SqmJpaCriteriaParameterWrapper.java
@@ -123,6 +123,13 @@ public class SqmJpaCriteriaParameterWrapper<T>
 		jpaCriteriaParameter.appendHqlString( sb );
 	}
 
+	@Override
+	public int compare(SqmParameter anotherParameter) {
+		return anotherParameter instanceof SqmJpaCriteriaParameterWrapper ?
+				getJpaCriteriaParameter().compare( ( (SqmJpaCriteriaParameterWrapper<?>) anotherParameter ).getJpaCriteriaParameter() )
+				: 1;
+	}
+
 //	@Override
 //	public Expression toSqlExpression(
 //			Clause clause,

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/expression/SqmNamedParameter.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/expression/SqmNamedParameter.java
@@ -81,4 +81,11 @@ public class SqmNamedParameter<T> extends AbstractSqmParameter<T> {
 		sb.append( ':' );
 		sb.append( getName() );
 	}
+
+	@Override
+	public int compare(SqmParameter anotherParameter) {
+		return anotherParameter instanceof SqmNamedParameter<?>
+				? getName().compareTo( ( (SqmNamedParameter<?>) anotherParameter ).getName() )
+				: -1;
+	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/expression/SqmParameter.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/expression/SqmParameter.java
@@ -6,6 +6,7 @@
  */
 package org.hibernate.query.sqm.tree.expression;
 
+import org.hibernate.HibernateException;
 import org.hibernate.query.BindableType;
 import org.hibernate.query.criteria.JpaParameterExpression;
 import org.hibernate.query.sqm.SqmExpressible;
@@ -74,4 +75,24 @@ public interface SqmParameter<T> extends SqmExpression<T>, JpaParameterExpressio
 
 	@Override
 	SqmParameter<T> copy(SqmCopyContext context);
+
+	default int compare(SqmParameter anotherParameter) {
+		if ( this instanceof SqmNamedParameter ) {
+			final SqmNamedParameter<?> one = (SqmNamedParameter<?>) this;
+			return anotherParameter instanceof SqmNamedParameter<?>
+					? one.getName().compareTo( ( (SqmNamedParameter<?>) anotherParameter ).getName() )
+					: -1;
+		}
+		else if ( this instanceof SqmPositionalParameter ) {
+			final SqmPositionalParameter<?> one = (SqmPositionalParameter<?>) this;
+			return anotherParameter instanceof SqmPositionalParameter<?>
+					? one.getPosition().compareTo( ( (SqmPositionalParameter<?>) anotherParameter ).getPosition() )
+					: 1;
+		}
+		else if ( anotherParameter instanceof SqmJpaCriteriaParameterWrapper
+				&& anotherParameter instanceof SqmJpaCriteriaParameterWrapper ) {
+			return Integer.compare( this.hashCode(), anotherParameter.hashCode() );
+		}
+		throw new HibernateException( "Unexpected SqmParameter type for comparison : " + this + " & " + anotherParameter );
+	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/expression/SqmPositionalParameter.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/expression/SqmPositionalParameter.java
@@ -85,4 +85,10 @@ public class SqmPositionalParameter<T> extends AbstractSqmParameter<T> {
 		sb.append( getPosition() );
 	}
 
+	@Override
+	public int compare(SqmParameter anotherParameter) {
+		return anotherParameter instanceof SqmPositionalParameter<?>
+				? getPosition().compareTo( ( (SqmPositionalParameter<?>) anotherParameter ).getPosition() )
+				: 1;
+	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/expression/ValueBindJpaCriteriaParameter.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/expression/ValueBindJpaCriteriaParameter.java
@@ -6,6 +6,8 @@
  */
 package org.hibernate.query.sqm.tree.expression;
 
+import java.util.Objects;
+
 import org.hibernate.query.BindableType;
 import org.hibernate.query.sqm.NodeBuilder;
 import org.hibernate.query.sqm.tree.SqmCopyContext;
@@ -61,5 +63,13 @@ public class ValueBindJpaCriteriaParameter<T> extends JpaCriteriaParameter<T>{
 	@Override
 	public int hashCode() {
 		return System.identityHashCode( this );
+	}
+
+	@Override
+	public int compare(SqmParameter anotherParameter) {
+		if ( this == anotherParameter ) {
+			return 0;
+		}
+		return 1;
 	}
 }

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/criteria/InPredicateTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/criteria/InPredicateTest.java
@@ -1,0 +1,98 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html
+ */
+package org.hibernate.orm.test.jpa.criteria;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.hibernate.dialect.Dialect;
+import org.hibernate.dialect.H2Dialect;
+import org.hibernate.dialect.HSQLDialect;
+import org.hibernate.dialect.MariaDBDialect;
+import org.hibernate.dialect.MySQLDialect;
+
+import org.hibernate.testing.TestForIssue;
+import org.hibernate.testing.orm.junit.EntityManagerFactoryScope;
+import org.hibernate.testing.orm.junit.Jpa;
+import org.junit.jupiter.api.Test;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.persistence.criteria.CriteriaBuilder;
+import jakarta.persistence.criteria.CriteriaQuery;
+import jakarta.persistence.criteria.Root;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+@Jpa(annotatedClasses = {
+		InPredicateTest.Event.class
+})
+@TestForIssue(jiraKey = "HHH-15895")
+public class InPredicateTest {
+
+	@Test
+	public void testInPredicate(EntityManagerFactoryScope scope) {
+		scope.inTransaction(
+				entityManager -> {
+					CriteriaBuilder cb = entityManager.getCriteriaBuilder();
+					CriteriaQuery<Event> cr = cb.createQuery( Event.class );
+					Root<Event> root = cr.from( Event.class );
+					List<String> names = getNames( scope );
+					cr.select( root ).where( root.get( "name" ).in( names ) );
+
+					List<Event> results = entityManager.createQuery( cr ).getResultList();
+					assertNotNull( results );
+				}
+		);
+	}
+
+	private List<String> getNames(EntityManagerFactoryScope scope) {
+		int maxNames;
+		Dialect dialect = scope.getDialect();
+		if ( dialect instanceof H2Dialect
+				|| dialect instanceof MariaDBDialect
+				|| dialect instanceof HSQLDialect
+				|| dialect instanceof MySQLDialect ) {
+			maxNames = 100000;
+		}
+		else {
+			// the other dialects does not support 100000 parameters
+			maxNames = 65500;
+		}
+
+		List<String> names = new ArrayList<>( maxNames );
+		for ( int i = 0; i < maxNames; i++ ) {
+			names.add( "abc" + i );
+		}
+		return names;
+	}
+
+	@Entity(name = "Event")
+	@Table(name = "EVENT_TABLE")
+	public static class Event {
+
+		@Id
+		@GeneratedValue
+		private Long id;
+
+		private String name;
+
+		public Event() {
+		}
+
+		public Long getId() {
+			return id;
+		}
+
+		public String getName() {
+			return name;
+		}
+
+	}
+}

--- a/hibernate-testing/src/main/java/org/hibernate/testing/orm/junit/EntityManagerFactoryScope.java
+++ b/hibernate-testing/src/main/java/org/hibernate/testing/orm/junit/EntityManagerFactoryScope.java
@@ -11,6 +11,8 @@ import java.util.function.Function;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.EntityManagerFactory;
 
+import org.hibernate.dialect.Dialect;
+import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.resource.jdbc.spi.StatementInspector;
 
 import org.hibernate.testing.jdbc.SQLStatementInspector;
@@ -34,5 +36,8 @@ public interface EntityManagerFactoryScope {
 	<T> T fromTransaction(Function<EntityManager, T> action);
 	<T> T fromTransaction(EntityManager entityManager, Function<EntityManager, T> action);
 
+	default Dialect getDialect() {
+		return ((SessionFactoryImplementor) getEntityManagerFactory()).getJdbcServices().getDialect();
+	}
 
 }


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-15895

different instances of `SqmParameter` instances can have the same hashcode value, so when the number of `SqmJpaCriteriaParameterWrapper` is huge the probability of considering 2 instances equals is high if  
`return Integer.compare( o1.hashCode(), o2.hashCode() );` is used to compare them.