### PR TITLE
Fix recommendation in migration guide for duration mapping backwards-compatibility

### DIFF
--- a/migration-guide.adoc
+++ b/migration-guide.adoc
@@ -280,7 +280,7 @@ In either case, schema validation errors could occur as 5.x used the type code `
 Migration to `numeric(21)` should be easy. The migration to `interval second` might require a migration expression like
 `cast(cast(old as numeric(21,9) / 1000000000) as interval second(9))`.
 
-To retain backwards compatibility, configure the setting `hibernate.type.preferred_duration_jdbc_type` to `NUMERIC`.
+To retain backwards compatibility, configure the setting `hibernate.type.preferred_duration_jdbc_type` to `BIGINT`.
 
 === UUID mapping changes
 


### PR DESCRIPTION
Quoting: "5.x used the type code `Types.BIGINT`".

So, in order to retain backwards-compatibility, one needs to set the JDBC type to `BIGINT`, not to `NUMERIC`.

Tested locally on a schema created with 5.x by starting an application using 6.x: with `NUMERIC`, schema validation fails; with `BIGINT` it does not.