### PR TITLE
Testing database configuration for MySQL has mismatched credentials

### DIFF
--- a/gradle/databases.gradle
+++ b/gradle/databases.gradle
@@ -84,8 +84,8 @@ ext {
                 mysql : [
                         'db.dialect' : 'org.hibernate.dialect.MySQLDialect',
                         'jdbc.driver': 'com.mysql.cj.jdbc.Driver',
-                        'jdbc.user'  : 'hibernateormtest',
-                        'jdbc.pass'  : 'hibernateormtest',
+                        'jdbc.user'  : 'hibernate_orm_test',
+                        'jdbc.pass'  : 'hibernate_orm_test',
                         'jdbc.url'   : 'jdbc:mysql://' + dbHost + '/hibernate_orm_test',
                         'connection.init_sql' : ''
                 ],


### PR DESCRIPTION
This is a bit odd - not sure why nobody noticed, perhaps you all have your custom scripts? I hope this won't be too inconvenient to fix.

Essentially the configuration expected by the integration tests e.g. 

```
./gradlew :hibernate-core:test -Pdb=mysql
```

Doesn't match the credentials of MySQL when started via

```
./docker_db.sh mysql
```

Wondering if I'm missing something but according to README this should work?