### PR TITLE
[6.2] HHH-16172 BasicCacheKeyImplementation must be public to support externalization.

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/cache/internal/BasicCacheKeyImplementation.java
+++ b/hibernate-core/src/main/java/org/hibernate/cache/internal/BasicCacheKeyImplementation.java
@@ -25,7 +25,7 @@ import org.hibernate.type.Type;
  * @since 6.2
  */
 @Internal
-final class BasicCacheKeyImplementation implements Serializable {
+public final class BasicCacheKeyImplementation implements Serializable {
 
 	final Serializable id;
 	private final String entityOrRoleName;


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-16172

Original HHH-16172 fix neglected to make this class public so that it can be instantiated outside the org.hibernate.cache.internal package.