### PR TITLE
HHH-16260 - JdbcParameterRenderer not called with dynamic filters

### DIFF
--- a/hibernate-agroal/src/test/resources/hibernate.properties
+++ b/hibernate-agroal/src/test/resources/hibernate.properties
@@ -11,6 +11,9 @@ hibernate.connection.username @jdbc.user@
 hibernate.connection.password @jdbc.pass@
 hibernate.connection.init_sql @connection.init_sql@
 
+# some Agroal tests fail with native markers.  not sure why yet
+hibernate.dialect.native_param_markers=false
+
 hibernate.jdbc.batch_size 10
 hibernate.connection.provider_class AgroalConnectionProvider
 

--- a/hibernate-agroal/src/test/resources/hibernate.properties
+++ b/hibernate-agroal/src/test/resources/hibernate.properties
@@ -11,9 +11,6 @@ hibernate.connection.username @jdbc.user@
 hibernate.connection.password @jdbc.pass@
 hibernate.connection.init_sql @connection.init_sql@
 
-# some Agroal tests fail with native markers.  not sure why yet
-hibernate.dialect.native_param_markers=false
-
 hibernate.jdbc.batch_size 10
 hibernate.connection.provider_class AgroalConnectionProvider
 

--- a/hibernate-core/src/main/java/org/hibernate/cfg/AvailableSettings.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/AvailableSettings.java
@@ -2788,6 +2788,21 @@ public interface AvailableSettings {
 	 */
 	String TIMEZONE_DEFAULT_STORAGE = "hibernate.timezone.default_storage";
 
+	/**
+	 * Specifies whether to use JDBC parameter markers (`?`) or dialect native markers.
+	 *
+	 * @implNote By default ({@code true}), dialect native markers are used, if any; disable
+	 * ({@code false}) to use the standard JDBC parameter markers (`?`) instead
+	 *
+	 * @see org.hibernate.sql.ast.spi.JdbcParameterRenderer
+	 * @see org.hibernate.dialect.Dialect#getNativeParameterRenderer()
+	 *
+	 * @since 6.2
+	 */
+	@Incubating
+	String DIALECT_NATIVE_PARAM_MARKERS = "hibernate.dialect.native_param_markers";
+
+
 	// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 	// Java (javax) Persistence defined settings
 	// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/hibernate-core/src/main/java/org/hibernate/cfg/AvailableSettings.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/AvailableSettings.java
@@ -2789,7 +2789,7 @@ public interface AvailableSettings {
 	String TIMEZONE_DEFAULT_STORAGE = "hibernate.timezone.default_storage";
 
 	/**
-	 * Specifies whether to use JDBC parameter markers (`?`) or dialect native markers.
+	 * Controls whether to use JDBC parameter markers (`?`) or dialect native markers.
 	 *
 	 * @implNote By default ({@code true}), dialect native markers are used, if any; disable
 	 * ({@code false}) to use the standard JDBC parameter markers (`?`) instead

--- a/hibernate-core/src/main/java/org/hibernate/dialect/Dialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/Dialect.java
@@ -117,7 +117,6 @@ import org.hibernate.mapping.Index;
 import org.hibernate.mapping.Table;
 import org.hibernate.mapping.UserDefinedType;
 import org.hibernate.metamodel.mapping.EntityMappingType;
-import org.hibernate.metamodel.mapping.internal.MappingModelCreationProcess;
 import org.hibernate.metamodel.spi.RuntimeModelCreationContext;
 import org.hibernate.persister.entity.Lockable;
 import org.hibernate.persister.entity.mutation.EntityMutationTarget;

--- a/hibernate-core/src/main/java/org/hibernate/dialect/Dialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/Dialect.java
@@ -145,6 +145,8 @@ import org.hibernate.service.spi.ServiceRegistryImplementor;
 import org.hibernate.sql.ForUpdateFragment;
 import org.hibernate.sql.ast.SqlAstNodeRenderingMode;
 import org.hibernate.sql.ast.SqlAstTranslatorFactory;
+import org.hibernate.sql.ast.internal.JdbcParameterRendererStandard;
+import org.hibernate.sql.ast.spi.JdbcParameterRenderer;
 import org.hibernate.sql.ast.spi.SqlAppender;
 import org.hibernate.sql.ast.spi.StringBuilderSqlAppender;
 import org.hibernate.sql.model.MutationOperation;
@@ -4811,6 +4813,13 @@ public abstract class Dialect implements ConversionContext, TypeContributor, Fun
 	 */
 	public String getTruncateTableStatement(String tableName) {
 		return "truncate table " + tableName;
+	}
+
+	/**
+	 * Support for native parameter rendering
+	 */
+	public JdbcParameterRenderer getNativeParameterRenderer() {
+		return JdbcParameterRendererStandard.INSTANCE;
 	}
 
 	/**

--- a/hibernate-core/src/main/java/org/hibernate/dialect/H2Dialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/H2Dialect.java
@@ -911,11 +911,18 @@ public class H2Dialect extends Dialect {
 
 	@Override
 	public JdbcParameterRenderer getNativeParameterRenderer() {
-		return H2Dialect::renderNatively;
+		return OrdinalParameterRenderer.INSTANCE;
 	}
 
-	private static void renderNatively(int position, JdbcType jdbcType, SqlAppender appender, Dialect dialect) {
-		appender.append( "?" );
-		appender.appendSql( position );
+	public static class OrdinalParameterRenderer implements JdbcParameterRenderer {
+		/**
+		 * Singleton access
+		 */
+		public static final OrdinalParameterRenderer INSTANCE = new OrdinalParameterRenderer();
+
+		@Override
+		public String renderJdbcParameter(int position, JdbcType jdbcType) {
+			return "?" + position;
+		}
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/dialect/H2Dialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/H2Dialect.java
@@ -57,6 +57,7 @@ import org.hibernate.service.ServiceRegistry;
 import org.hibernate.sql.ast.SqlAstNodeRenderingMode;
 import org.hibernate.sql.ast.SqlAstTranslator;
 import org.hibernate.sql.ast.SqlAstTranslatorFactory;
+import org.hibernate.sql.ast.spi.JdbcParameterRenderer;
 import org.hibernate.sql.ast.spi.SqlAppender;
 import org.hibernate.sql.ast.spi.StandardSqlAstTranslatorFactory;
 import org.hibernate.sql.ast.tree.Statement;
@@ -906,5 +907,15 @@ public class H2Dialect extends Dialect {
 			OptionalTableUpdate optionalTableUpdate,
 			SessionFactoryImplementor factory) {
 		return new OptionalTableUpdateOperation( mutationTarget, optionalTableUpdate, factory );
+	}
+
+	@Override
+	public JdbcParameterRenderer getNativeParameterRenderer() {
+		return H2Dialect::renderNatively;
+	}
+
+	private static void renderNatively(int position, JdbcType jdbcType, SqlAppender appender, Dialect dialect) {
+		appender.append( "?" );
+		appender.appendSql( position );
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/dialect/PostgreSQLDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/PostgreSQLDialect.java
@@ -66,6 +66,7 @@ import org.hibernate.query.sqm.mutation.spi.SqmMultiTableMutationStrategy;
 import org.hibernate.service.ServiceRegistry;
 import org.hibernate.sql.ast.SqlAstTranslator;
 import org.hibernate.sql.ast.SqlAstTranslatorFactory;
+import org.hibernate.sql.ast.spi.JdbcParameterRenderer;
 import org.hibernate.sql.ast.spi.SqlAppender;
 import org.hibernate.sql.ast.spi.StandardSqlAstTranslatorFactory;
 import org.hibernate.sql.ast.tree.Statement;
@@ -1428,5 +1429,15 @@ public class PostgreSQLDialect extends Dialect {
 			OptionalTableUpdate optionalTableUpdate,
 			SessionFactoryImplementor factory) {
 		return new OptionalTableUpdateOperation( mutationTarget, optionalTableUpdate, factory );
+	}
+
+	@Override
+	public JdbcParameterRenderer getNativeParameterRenderer() {
+		return PostgreSQLDialect::renderNatively;
+	}
+
+	private static void renderNatively(int position, JdbcType jdbcType, SqlAppender appender, Dialect dialect) {
+		appender.append( "$" );
+		appender.appendSql( position );
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/dialect/PostgreSQLDriverKind.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/PostgreSQLDriverKind.java
@@ -14,6 +14,7 @@ import org.hibernate.engine.jdbc.dialect.spi.DialectResolutionInfo;
  */
 public enum PostgreSQLDriverKind {
 	PG_JDBC,
+	VERT_X,
 	OTHER;
 
 	public static PostgreSQLDriverKind determineKind(DialectResolutionInfo dialectResolutionInfo) {

--- a/hibernate-core/src/main/java/org/hibernate/dialect/lock/PessimisticReadSelectLockingStrategy.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/lock/PessimisticReadSelectLockingStrategy.java
@@ -104,13 +104,13 @@ public class PessimisticReadSelectLockingStrategy extends AbstractSelectLockingS
 		final SessionFactoryImplementor factory = getLockable().getFactory();
 		final LockOptions lockOptions = new LockOptions( getLockMode() );
 		lockOptions.setTimeOut( lockTimeout );
-		final SimpleSelect select = new SimpleSelect( factory.getJdbcServices().getDialect() )
+		final SimpleSelect select = new SimpleSelect( factory )
 				.setLockOptions( lockOptions )
 				.setTableName( getLockable().getRootTableName() )
 				.addColumn( getLockable().getRootTableIdentifierColumnNames()[0] )
-				.addCondition( getLockable().getRootTableIdentifierColumnNames(), "=?" );
+				.addRestriction( getLockable().getRootTableIdentifierColumnNames() );
 		if ( getLockable().isVersioned() ) {
-			select.addCondition( getLockable().getVersionColumnName(), "=?" );
+			select.addRestriction( getLockable().getVersionColumnName() );
 		}
 		if ( factory.getSessionFactoryOptions().isCommentsEnabled() ) {
 			select.setComment( getLockMode() + " lock " + getLockable().getEntityName() );

--- a/hibernate-core/src/main/java/org/hibernate/dialect/lock/PessimisticReadUpdateLockingStrategy.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/lock/PessimisticReadUpdateLockingStrategy.java
@@ -122,11 +122,11 @@ public class PessimisticReadUpdateLockingStrategy implements LockingStrategy {
 
 	protected String generateLockString() {
 		final SessionFactoryImplementor factory = lockable.getFactory();
-		final Update update = new Update( factory.getJdbcServices().getDialect() );
+		final Update update = new Update( factory );
 		update.setTableName( lockable.getRootTableName() );
-		update.addPrimaryKeyColumns( lockable.getRootTableIdentifierColumnNames() );
-		update.setVersionColumnName( lockable.getVersionColumnName() );
-		update.addColumn( lockable.getVersionColumnName() );
+		update.addAssignment( lockable.getVersionColumnName() );
+		update.addRestriction( lockable.getRootTableIdentifierColumnNames() );
+		update.addRestriction( lockable.getVersionColumnName() );
 		if ( factory.getSessionFactoryOptions().isCommentsEnabled() ) {
 			update.setComment( lockMode + " lock " + lockable.getEntityName() );
 		}

--- a/hibernate-core/src/main/java/org/hibernate/dialect/lock/PessimisticWriteSelectLockingStrategy.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/lock/PessimisticWriteSelectLockingStrategy.java
@@ -107,13 +107,13 @@ public class PessimisticWriteSelectLockingStrategy extends AbstractSelectLocking
 		final SessionFactoryImplementor factory = getLockable().getFactory();
 		final LockOptions lockOptions = new LockOptions( getLockMode() );
 		lockOptions.setTimeOut( lockTimeout );
-		final SimpleSelect select = new SimpleSelect( factory.getJdbcServices().getDialect() )
+		final SimpleSelect select = new SimpleSelect( factory )
 				.setLockOptions( lockOptions )
 				.setTableName( getLockable().getRootTableName() )
 				.addColumn( getLockable().getRootTableIdentifierColumnNames()[0] )
-				.addCondition( getLockable().getRootTableIdentifierColumnNames(), "=?" );
+				.addRestriction( getLockable().getRootTableIdentifierColumnNames() );
 		if ( getLockable().isVersioned() ) {
-			select.addCondition( getLockable().getVersionColumnName(), "=?" );
+			select.addRestriction( getLockable().getVersionColumnName() );
 		}
 		if ( factory.getSessionFactoryOptions().isCommentsEnabled() ) {
 			select.setComment( getLockMode() + " lock " + getLockable().getEntityName() );

--- a/hibernate-core/src/main/java/org/hibernate/dialect/lock/PessimisticWriteUpdateLockingStrategy.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/lock/PessimisticWriteUpdateLockingStrategy.java
@@ -120,11 +120,11 @@ public class PessimisticWriteUpdateLockingStrategy implements LockingStrategy {
 
 	protected String generateLockString() {
 		final SessionFactoryImplementor factory = lockable.getFactory();
-		final Update update = new Update( factory.getJdbcServices().getDialect() );
+		final Update update = new Update( factory );
 		update.setTableName( lockable.getRootTableName() );
-		update.addPrimaryKeyColumns( lockable.getRootTableIdentifierColumnNames() );
-		update.setVersionColumnName( lockable.getVersionColumnName() );
-		update.addColumn( lockable.getVersionColumnName() );
+		update.addAssignment( lockable.getVersionColumnName() );
+		update.addRestriction( lockable.getRootTableIdentifierColumnNames() );
+		update.addRestriction( lockable.getVersionColumnName() );
 		if ( factory.getSessionFactoryOptions().isCommentsEnabled() ) {
 			update.setComment( lockMode + " lock " + lockable.getEntityName() );
 		}

--- a/hibernate-core/src/main/java/org/hibernate/dialect/lock/SelectLockingStrategy.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/lock/SelectLockingStrategy.java
@@ -102,13 +102,13 @@ public class SelectLockingStrategy extends AbstractSelectLockingStrategy {
 		final SessionFactoryImplementor factory = getLockable().getFactory();
 		final LockOptions lockOptions = new LockOptions( getLockMode() );
 		lockOptions.setTimeOut( timeout );
-		final SimpleSelect select = new SimpleSelect( factory.getJdbcServices().getDialect() )
+		final SimpleSelect select = new SimpleSelect( factory )
 				.setLockOptions( lockOptions )
 				.setTableName( getLockable().getRootTableName() )
 				.addColumn( getLockable().getRootTableIdentifierColumnNames()[0] )
-				.addCondition( getLockable().getRootTableIdentifierColumnNames(), "=?" );
+				.addRestriction( getLockable().getRootTableIdentifierColumnNames() );
 		if ( getLockable().isVersioned() ) {
-			select.addCondition( getLockable().getVersionColumnName(), "=?" );
+			select.addRestriction( getLockable().getVersionColumnName() );
 		}
 		if ( factory.getSessionFactoryOptions().isCommentsEnabled() ) {
 			select.setComment( getLockMode() + " lock " + getLockable().getEntityName() );

--- a/hibernate-core/src/main/java/org/hibernate/dialect/lock/UpdateLockingStrategy.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/lock/UpdateLockingStrategy.java
@@ -123,11 +123,11 @@ public class UpdateLockingStrategy implements LockingStrategy {
 
 	protected String generateLockString() {
 		final SessionFactoryImplementor factory = lockable.getFactory();
-		final Update update = new Update( factory.getJdbcServices().getDialect() );
+		final Update update = new Update( factory );
 		update.setTableName( lockable.getRootTableName() );
-		update.addPrimaryKeyColumns( lockable.getRootTableIdentifierColumnNames() );
-		update.setVersionColumnName( lockable.getVersionColumnName() );
-		update.addColumn( lockable.getVersionColumnName() );
+		update.addAssignment( lockable.getVersionColumnName() );
+		update.addRestriction( lockable.getRootTableIdentifierColumnNames() );
+		update.addRestriction( lockable.getVersionColumnName() );
 		if ( factory.getSessionFactoryOptions().isCommentsEnabled() ) {
 			update.setComment( lockMode + " lock " + lockable.getEntityName() );
 		}

--- a/hibernate-core/src/main/java/org/hibernate/id/insert/BasicSelectingDelegate.java
+++ b/hibernate-core/src/main/java/org/hibernate/id/insert/BasicSelectingDelegate.java
@@ -33,7 +33,7 @@ public class BasicSelectingDelegate extends AbstractSelectingDelegate {
 
 	@Override @Deprecated
 	public IdentifierGeneratingInsert prepareIdentifierGeneratingInsert(SqlStringGenerationContext context) {
-		IdentifierGeneratingInsert insert = new IdentifierGeneratingInsert( dialect );
+		IdentifierGeneratingInsert insert = new IdentifierGeneratingInsert( persister.getFactory() );
 		insert.addGeneratedColumns( persister.getRootTableKeyColumnNames(), (OnExecutionGenerator) persister.getGenerator() );
 		return insert;
 	}

--- a/hibernate-core/src/main/java/org/hibernate/id/insert/GetGeneratedKeysDelegate.java
+++ b/hibernate-core/src/main/java/org/hibernate/id/insert/GetGeneratedKeysDelegate.java
@@ -51,7 +51,7 @@ public class GetGeneratedKeysDelegate extends AbstractReturningDelegate {
 
 	@Override @Deprecated
 	public IdentifierGeneratingInsert prepareIdentifierGeneratingInsert(SqlStringGenerationContext context) {
-		IdentifierGeneratingInsert insert = new IdentifierGeneratingInsert( dialect );
+		IdentifierGeneratingInsert insert = new IdentifierGeneratingInsert( persister.getFactory() );
 		insert.addGeneratedColumns( persister.getRootTableKeyColumnNames(), (OnExecutionGenerator) persister.getGenerator() );
 		return insert;
 	}

--- a/hibernate-core/src/main/java/org/hibernate/id/insert/IdentifierGeneratingInsert.java
+++ b/hibernate-core/src/main/java/org/hibernate/id/insert/IdentifierGeneratingInsert.java
@@ -6,6 +6,7 @@
  */
 package org.hibernate.id.insert;
 import org.hibernate.dialect.Dialect;
+import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.sql.Insert;
 
 /**
@@ -16,7 +17,7 @@ import org.hibernate.sql.Insert;
  * @author Steve Ebersole
  */
 public class IdentifierGeneratingInsert extends Insert {
-	public IdentifierGeneratingInsert(Dialect dialect) {
-		super( dialect );
+	public IdentifierGeneratingInsert(SessionFactoryImplementor sessionFactory) {
+		super( sessionFactory );
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/id/insert/InsertReturningDelegate.java
+++ b/hibernate-core/src/main/java/org/hibernate/id/insert/InsertReturningDelegate.java
@@ -45,7 +45,7 @@ public class InsertReturningDelegate extends AbstractReturningDelegate {
 
 	@Override @Deprecated
 	public IdentifierGeneratingInsert prepareIdentifierGeneratingInsert(SqlStringGenerationContext context) {
-		InsertSelectIdentityInsert insert = new InsertSelectIdentityInsert( dialect );
+		InsertSelectIdentityInsert insert = new InsertSelectIdentityInsert( persister.getFactory() );
 		insert.addGeneratedColumns( persister.getRootTableKeyColumnNames(), (OnExecutionGenerator) persister.getGenerator() );
 		return insert;
 	}

--- a/hibernate-core/src/main/java/org/hibernate/id/insert/InsertSelectIdentityInsert.java
+++ b/hibernate-core/src/main/java/org/hibernate/id/insert/InsertSelectIdentityInsert.java
@@ -7,6 +7,7 @@
 package org.hibernate.id.insert;
 import org.hibernate.MappingException;
 import org.hibernate.dialect.Dialect;
+import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.sql.Insert;
 import org.hibernate.generator.OnExecutionGenerator;
 
@@ -19,6 +20,10 @@ import org.hibernate.generator.OnExecutionGenerator;
  */
 public class InsertSelectIdentityInsert extends IdentifierGeneratingInsert {
 	protected String identityColumnName;
+
+	public InsertSelectIdentityInsert(SessionFactoryImplementor sessionFactory) {
+		super( sessionFactory );
+	}
 
 	public Insert addIdentityColumn(String columnName) {
 		identityColumnName = columnName;
@@ -34,10 +39,6 @@ public class InsertSelectIdentityInsert extends IdentifierGeneratingInsert {
 		}
 		identityColumnName = columnNames[0];
 		return super.addGeneratedColumns( columnNames, generator );
-	}
-
-	public InsertSelectIdentityInsert(Dialect dialect) {
-		super( dialect );
 	}
 
 	public String toStatementString() {

--- a/hibernate-core/src/main/java/org/hibernate/id/insert/UniqueKeySelectingDelegate.java
+++ b/hibernate-core/src/main/java/org/hibernate/id/insert/UniqueKeySelectingDelegate.java
@@ -54,7 +54,7 @@ public class UniqueKeySelectingDelegate extends AbstractSelectingDelegate {
 
 	@Override @Deprecated
 	public IdentifierGeneratingInsert prepareIdentifierGeneratingInsert(SqlStringGenerationContext context) {
-		return new IdentifierGeneratingInsert( dialect );
+		return new IdentifierGeneratingInsert( persister.getFactory() );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/internal/FilterJdbcParameter.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/FilterJdbcParameter.java
@@ -6,65 +6,52 @@
  */
 package org.hibernate.internal;
 
-import java.util.Objects;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
 
 import org.hibernate.metamodel.mapping.JdbcMapping;
+import org.hibernate.metamodel.mapping.JdbcMappingContainer;
+import org.hibernate.sql.ast.SqlAstWalker;
 import org.hibernate.sql.ast.tree.expression.JdbcParameter;
-import org.hibernate.sql.exec.internal.JdbcParameterBindingImpl;
-import org.hibernate.sql.exec.internal.JdbcParameterImpl;
+import org.hibernate.sql.exec.spi.ExecutionContext;
 import org.hibernate.sql.exec.spi.JdbcParameterBinder;
-import org.hibernate.sql.exec.spi.JdbcParameterBinding;
-import org.hibernate.type.descriptor.java.JavaType;
+import org.hibernate.sql.exec.spi.JdbcParameterBindings;
 
 /**
  * @author Nathan Xu
  */
-public class FilterJdbcParameter {
-	private final JdbcParameter parameter;
+public class FilterJdbcParameter implements JdbcParameter, JdbcParameterBinder {
 	private final JdbcMapping jdbcMapping;
 	private final Object jdbcParameterValue;
 
 	public FilterJdbcParameter(JdbcMapping jdbcMapping, Object jdbcParameterValue) {
-		this.parameter = new JdbcParameterImpl( jdbcMapping );
 		this.jdbcMapping = jdbcMapping;
 		this.jdbcParameterValue = jdbcParameterValue;
 	}
 
-	public JdbcParameter getParameter() {
-		return parameter;
-	}
-
-	public JdbcParameterBinder getBinder() {
-		return parameter.getParameterBinder();
-	}
-
-	public JdbcParameterBinding getBinding() {
-		return new JdbcParameterBindingImpl( jdbcMapping, jdbcMapping.convertToRelationalValue( jdbcParameterValue ) );
+	@Override
+	public JdbcParameterBinder getParameterBinder() {
+		return this;
 	}
 
 	@Override
-	public boolean equals(Object o) {
-		if ( this == o ) {
-			return true;
-		}
-		if ( o == null || getClass() != o.getClass() ) {
-			return false;
-		}
-		FilterJdbcParameter that = (FilterJdbcParameter) o;
-		return Objects.equals( parameter, that.parameter ) &&
-				Objects.equals( jdbcMapping, that.jdbcMapping ) &&
-				( (JavaType<Object>) jdbcMapping.getMappedJavaType() ).areEqual(
-						jdbcParameterValue,
-						that.jdbcParameterValue
-				);
-	}
-
-	@Override
-	public int hashCode() {
-		return Objects.hash(
-				parameter,
-				jdbcMapping,
-				( (JavaType<Object>) jdbcMapping.getMappedJavaType() ).extractHashCode( jdbcParameterValue )
+	public void bindParameterValue(PreparedStatement statement, int startPosition, JdbcParameterBindings jdbcParameterBindings, ExecutionContext executionContext) throws SQLException {
+		jdbcMapping.getJdbcValueBinder().bind(
+				statement,
+				jdbcMapping.convertToRelationalValue( jdbcParameterValue ),
+				startPosition,
+				executionContext.getSession()
 		);
+
+	}
+
+	@Override
+	public JdbcMappingContainer getExpressionType() {
+		return jdbcMapping;
+	}
+
+	@Override
+	public void accept(SqlAstWalker sqlTreeWalker) {
+		throw new IllegalStateException(  );
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/internal/util/collections/CollectionHelper.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/util/collections/CollectionHelper.java
@@ -489,6 +489,14 @@ public final class CollectionHelper {
 		return values == null ? 0 : values.size();
 	}
 
+	public static int size(Collection<?> values) {
+		return values == null ? 0 : values.size();
+	}
+
+	public static int size(Map<?,?> values) {
+		return values == null ? 0 : values.size();
+	}
+
 	public static <X> Set<X> toSet(X... values) {
 		final HashSet<X> result = new HashSet<>();
 		if ( isNotEmpty( values ) ) {

--- a/hibernate-core/src/main/java/org/hibernate/loader/ast/internal/CollectionLoaderBatchKey.java
+++ b/hibernate-core/src/main/java/org/hibernate/loader/ast/internal/CollectionLoaderBatchKey.java
@@ -172,7 +172,6 @@ public class CollectionLoaderBatchKey implements CollectionLoader {
 					.translate( null, QueryOptions.NONE );
 
 			final JdbcParameterBindings jdbcParameterBindings = new JdbcParameterBindingsImpl( keyJdbcCount * smallBatchLength );
-			jdbcSelect.bindFilterJdbcParameters( jdbcParameterBindings );
 
 			int offset = 0;
 

--- a/hibernate-core/src/main/java/org/hibernate/loader/ast/internal/SingleIdLoadPlan.java
+++ b/hibernate-core/src/main/java/org/hibernate/loader/ast/internal/SingleIdLoadPlan.java
@@ -126,7 +126,6 @@ public class SingleIdLoadPlan<T> implements SingleEntityLoadPlan {
 		assert jdbcParameters.size() % jdbcTypeCount == 0;
 
 		final JdbcParameterBindings jdbcParameterBindings = new JdbcParameterBindingsImpl( jdbcTypeCount );
-		jdbcSelect.bindFilterJdbcParameters( jdbcParameterBindings );
 
 		int offset = 0;
 		while ( offset < jdbcParameters.size() ) {

--- a/hibernate-core/src/main/java/org/hibernate/persister/collection/AbstractCollectionPersister.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/collection/AbstractCollectionPersister.java
@@ -128,7 +128,6 @@ import org.hibernate.sql.model.jdbc.JdbcMutationOperation;
 import org.hibernate.sql.results.graph.DomainResult;
 import org.hibernate.sql.results.graph.internal.ImmutableFetchList;
 import org.hibernate.sql.results.internal.SqlSelectionImpl;
-import org.hibernate.type.AssociationType;
 import org.hibernate.type.CollectionType;
 import org.hibernate.type.CompositeType;
 import org.hibernate.type.EntityType;
@@ -1023,7 +1022,7 @@ public abstract class AbstractCollectionPersister
 				"count(" + getElementColumnNames()[0] + ")"; // sets, maps, bags
 		return new SimpleSelect( getFactory() )
 				.setTableName( getTableName() )
-				.addCondition( getKeyColumnNames(), "=?" )
+				.addRestriction( getKeyColumnNames() )
 				.addWhereToken( sqlWhereString )
 				.addColumn( selectValue )
 				.toStatementString();
@@ -1035,9 +1034,9 @@ public abstract class AbstractCollectionPersister
 		}
 		return new SimpleSelect( getFactory() )
 				.setTableName( getTableName() )
-				.addCondition( getKeyColumnNames(), "=?" )
-				.addCondition( getIndexColumnNames(), "=?" )
-				.addCondition( indexFormulas, "=?" )
+				.addRestriction( getKeyColumnNames() )
+				.addRestriction( getIndexColumnNames() )
+				.addRestriction( indexFormulas )
 				.addWhereToken( sqlWhereString )
 				.addColumn( "1" )
 				.toStatementString();
@@ -1047,9 +1046,9 @@ public abstract class AbstractCollectionPersister
 	protected String generateDetectRowByElementString() {
 		return new SimpleSelect( getFactory() )
 				.setTableName( getTableName() )
-				.addCondition( getKeyColumnNames(), "=?" )
-				.addCondition( getElementColumnNames(), "=?" )
-				.addCondition( elementFormulas, "=?" )
+				.addRestriction( getKeyColumnNames() )
+				.addRestriction( getElementColumnNames() )
+				.addRestriction( elementFormulas )
 				.addWhereToken( sqlWhereString )
 				.addColumn( "1" )
 				.toStatementString();

--- a/hibernate-core/src/main/java/org/hibernate/persister/collection/AbstractCollectionPersister.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/collection/AbstractCollectionPersister.java
@@ -1021,7 +1021,7 @@ public abstract class AbstractCollectionPersister
 		String selectValue = isIntegerIndexed ?
 				"max(" + getIndexColumnNames()[0] + ") + 1" : // lists, arrays
 				"count(" + getElementColumnNames()[0] + ")"; // sets, maps, bags
-		return new SimpleSelect( dialect )
+		return new SimpleSelect( getFactory() )
 				.setTableName( getTableName() )
 				.addCondition( getKeyColumnNames(), "=?" )
 				.addWhereToken( sqlWhereString )
@@ -1033,7 +1033,7 @@ public abstract class AbstractCollectionPersister
 		if ( !hasIndex() ) {
 			return null;
 		}
-		return new SimpleSelect( dialect )
+		return new SimpleSelect( getFactory() )
 				.setTableName( getTableName() )
 				.addCondition( getKeyColumnNames(), "=?" )
 				.addCondition( getIndexColumnNames(), "=?" )
@@ -1045,7 +1045,7 @@ public abstract class AbstractCollectionPersister
 
 
 	protected String generateDetectRowByElementString() {
-		return new SimpleSelect( dialect )
+		return new SimpleSelect( getFactory() )
 				.setTableName( getTableName() )
 				.addCondition( getKeyColumnNames(), "=?" )
 				.addCondition( getElementColumnNames(), "=?" )

--- a/hibernate-core/src/main/java/org/hibernate/persister/entity/AbstractEntityPersister.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/entity/AbstractEntityPersister.java
@@ -1910,8 +1910,7 @@ public abstract class AbstractEntityPersister
 	 * Generate the SQL that selects the version number by id
 	 */
 	public String generateSelectVersionString() {
-		final SimpleSelect select = new SimpleSelect( getFactory().getJdbcServices().getDialect() )
-				.setTableName( getVersionedTableName() );
+		final SimpleSelect select = new SimpleSelect( getFactory() ).setTableName( getVersionedTableName() );
 		if ( isVersioned() ) {
 			select.addColumn( getVersionColumnName(), VERSION_COLUMN_ALIAS );
 		}
@@ -1921,7 +1920,7 @@ public abstract class AbstractEntityPersister
 		if ( getFactory().getSessionFactoryOptions().isCommentsEnabled() ) {
 			select.setComment( "get version " + getEntityName() );
 		}
-		return select.addCondition( rootTableKeyColumnNames, "=?" ).toStatementString();
+		return select.addRestriction( rootTableKeyColumnNames ).toStatementString();
 	}
 
 	private GeneratedValuesProcessor createGeneratedValuesProcessor(EventType timing) {
@@ -2741,12 +2740,11 @@ public abstract class AbstractEntityPersister
 
 	@Override
 	public String getSelectByUniqueKeyString(String[] propertyNames) {
-		final SimpleSelect select =
-				new SimpleSelect( getFactory().getJdbcServices().getDialect() )
-						.setTableName( getTableName(0) )
-						.addColumns( getKeyColumns(0) );
+		final SimpleSelect select = new SimpleSelect( getFactory() )
+				.setTableName( getTableName(0) )
+				.addColumns( getKeyColumns(0) );
 		for ( int i = 0; i < propertyNames.length; i++ ) {
-			select.addCondition( getPropertyColumnNames( propertyNames[i] ), "= ?" );
+			select.addRestriction( getPropertyColumnNames( propertyNames[i] ) );
 		}
 		return select.toStatementString();
 	}
@@ -6039,9 +6037,9 @@ public abstract class AbstractEntityPersister
 	@Deprecated(forRemoval = true)
 	@Remove
 	public String generateDeleteString(int j) {
-		final Delete delete = new Delete()
+		final Delete delete = new Delete( getFactory() )
 				.setTableName( getTableName( j ) )
-				.addPrimaryKeyColumns( getKeyColumns( j ) );
+				.addColumnRestriction( getKeyColumns( j ) );
 		if ( j == 0 ) {
 			delete.setVersionColumnName( getVersionColumnName() );
 		}
@@ -6137,9 +6135,9 @@ public abstract class AbstractEntityPersister
 		int span = getTableSpan();
 		String[] deleteStrings = new String[span];
 		for ( int j = span - 1; j >= 0; j-- ) {
-			final Delete delete = new Delete()
+			final Delete delete = new Delete( getFactory() )
 					.setTableName( getTableName( j ) )
-					.addPrimaryKeyColumns( getKeyColumns( j ) );
+					.addColumnRestriction( getKeyColumns( j ) );
 			if ( getFactory().getSessionFactoryOptions().isCommentsEnabled() ) {
 				delete.setComment( "delete " + getEntityName() + " [" + j + "]" );
 			}
@@ -6154,10 +6152,10 @@ public abstract class AbstractEntityPersister
 					boolean[] propertyNullness = types[i].toColumnNullness( loadedState[i], getFactory() );
 					for ( int k = 0; k < propertyNullness.length; k++ ) {
 						if ( propertyNullness[k] ) {
-							delete.addWhereFragment( propertyColumnNames[k] + " = ?" );
+							delete.addColumnRestriction( propertyColumnNames[k] );
 						}
 						else {
-							delete.addWhereFragment( propertyColumnNames[k] + " is null" );
+							delete.addColumnNullnessRestriction( propertyColumnNames[k] );
 						}
 					}
 				}

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/internal/ConcreteSqmSelectQueryPlan.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/internal/ConcreteSqmSelectQueryPlan.java
@@ -304,7 +304,7 @@ public class ConcreteSqmSelectQueryPlan<R> implements SelectQueryPlan<R> {
 
 	private JdbcParameterBindings createJdbcParameterBindings(CacheableSqmInterpretation sqmInterpretation, DomainQueryExecutionContext executionContext) {
 		final SharedSessionContractImplementor session = executionContext.getSession();
-		final JdbcParameterBindings jdbcParameterBindings = SqmUtil.createJdbcParameterBindings(
+		return SqmUtil.createJdbcParameterBindings(
 				executionContext.getQueryParameterBindings(),
 				domainParameterXref,
 				sqmInterpretation.getJdbcParamsXref(),
@@ -319,8 +319,6 @@ public class ConcreteSqmSelectQueryPlan<R> implements SelectQueryPlan<R> {
 				},
 				session
 		);
-		sqmInterpretation.getJdbcSelect().bindFilterJdbcParameters( jdbcParameterBindings );
-		return jdbcParameterBindings;
 	}
 
 	private static CacheableSqmInterpretation buildCacheableSqmInterpretation(

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/internal/SimpleDeleteQueryPlan.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/internal/SimpleDeleteQueryPlan.java
@@ -123,9 +123,6 @@ public class SimpleDeleteQueryPlan implements NonSelectQueryPlan {
 		if ( deleteTranslator != null ) {
 			jdbcDelete = deleteTranslator.translate( jdbcParameterBindings, executionContext.getQueryOptions() );
 		}
-		else {
-			jdbcDelete.bindFilterJdbcParameters( jdbcParameterBindings );
-		}
 
 		final boolean missingRestriction = sqmDelete.getWhereClause() == null
 				|| sqmDelete.getWhereClause().getPredicate() == null;

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/internal/SimpleInsertQueryPlan.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/internal/SimpleInsertQueryPlan.java
@@ -117,9 +117,6 @@ public class SimpleInsertQueryPlan implements NonSelectQueryPlan {
 		if ( insertTranslator != null ) {
 			jdbcInsert = insertTranslator.translate( jdbcParameterBindings, executionContext.getQueryOptions() );
 		}
-		else {
-			jdbcInsert.bindFilterJdbcParameters( jdbcParameterBindings );
-		}
 
 		return jdbcServices.getJdbcMutationExecutor().execute(
 				jdbcInsert,

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/internal/SimpleUpdateQueryPlan.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/internal/SimpleUpdateQueryPlan.java
@@ -86,9 +86,6 @@ public class SimpleUpdateQueryPlan implements NonSelectQueryPlan {
 		if ( updateTranslator != null ) {
 			jdbcUpdate = updateTranslator.translate( jdbcParameterBindings, executionContext.getQueryOptions() );
 		}
-		else {
-			jdbcUpdate.bindFilterJdbcParameters( jdbcParameterBindings );
-		}
 
 		return jdbcServices.getJdbcMutationExecutor().execute(
 				jdbcUpdate,

--- a/hibernate-core/src/main/java/org/hibernate/sql/ComparisonRestriction.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/ComparisonRestriction.java
@@ -1,0 +1,48 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html.
+ */
+package org.hibernate.sql;
+
+import org.hibernate.Internal;
+
+/**
+ * A binary-comparison restriction
+ *
+ * @author Steve Ebersole
+ */
+@Internal
+public class ComparisonRestriction implements Restriction {
+	private final String lhs;
+	private final String operator;
+	private final String rhs;
+
+	public ComparisonRestriction(String lhs) {
+		this( lhs, "?" );
+	}
+
+	public ComparisonRestriction(String lhs, String rhs) {
+		this( lhs, "=", rhs );
+	}
+
+	public ComparisonRestriction(String lhs, String operator, String rhs) {
+		this.lhs = lhs;
+		this.operator = operator;
+		this.rhs = rhs;
+	}
+
+	@Override
+	public void render(StringBuilder sqlBuffer, RestrictionRenderingContext context) {
+		sqlBuffer.append( lhs );
+		sqlBuffer.append( operator );
+
+		if ( "?".equals( rhs ) ) {
+			sqlBuffer.append( context.makeParameterMarker() );
+		}
+		else {
+			sqlBuffer.append( rhs );
+		}
+	}
+}

--- a/hibernate-core/src/main/java/org/hibernate/sql/CompleteRestriction.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/CompleteRestriction.java
@@ -1,0 +1,28 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html.
+ */
+package org.hibernate.sql;
+
+import org.hibernate.Internal;
+
+/**
+ * For a complete predicate.  E.g. {@link org.hibernate.annotations.Where}
+ *
+ * @author Steve Ebersole
+ */
+@Internal
+public class CompleteRestriction implements Restriction {
+	private final String predicate;
+
+	public CompleteRestriction(String predicate) {
+		this.predicate = predicate;
+	}
+
+	@Override
+	public void render(StringBuilder sqlBuffer, RestrictionRenderingContext context) {
+		sqlBuffer.append( predicate );
+	}
+}

--- a/hibernate-core/src/main/java/org/hibernate/sql/NullnessRestriction.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/NullnessRestriction.java
@@ -1,0 +1,40 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html.
+ */
+package org.hibernate.sql;
+
+import org.hibernate.Internal;
+
+/**
+ * Nullness restriction - is [not] null
+ *
+ * @author Steve Ebersole
+ */
+@Internal
+public class NullnessRestriction implements Restriction {
+	private final String columnName;
+	private final boolean negated;
+
+	public NullnessRestriction(String columnName) {
+		this( columnName, false );
+	}
+
+	public NullnessRestriction(String columnName, boolean negated) {
+		this.columnName = columnName;
+		this.negated = negated;
+	}
+
+	@Override
+	public void render(StringBuilder sqlBuffer, RestrictionRenderingContext context) {
+		sqlBuffer.append( columnName );
+		if ( negated ) {
+			sqlBuffer.append( " is not null" );
+		}
+		else {
+			sqlBuffer.append( " is null" );
+		}
+	}
+}

--- a/hibernate-core/src/main/java/org/hibernate/sql/Restriction.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/Restriction.java
@@ -1,0 +1,22 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html.
+ */
+package org.hibernate.sql;
+
+import org.hibernate.Internal;
+
+/**
+ * A restriction (predicate) to be applied to a query
+ *
+ * @author Steve Ebersole
+ */
+@Internal
+public interface Restriction {
+	/**
+	 * Render the restriction into the SQL buffer
+	 */
+	void render(StringBuilder sqlBuffer, RestrictionRenderingContext context);
+}

--- a/hibernate-core/src/main/java/org/hibernate/sql/RestrictionRenderingContext.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/RestrictionRenderingContext.java
@@ -1,0 +1,17 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html.
+ */
+package org.hibernate.sql;
+
+import org.hibernate.Internal;
+
+/**
+ * @author Steve Ebersole
+ */
+@Internal
+public interface RestrictionRenderingContext {
+	String makeParameterMarker();
+}

--- a/hibernate-core/src/main/java/org/hibernate/sql/SimpleSelect.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/SimpleSelect.java
@@ -9,7 +9,6 @@ package org.hibernate.sql;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -27,47 +26,44 @@ import org.hibernate.sql.ast.spi.JdbcParameterRenderer;
  * @author Gavin King
  */
 @Internal
-public class SimpleSelect {
+public class SimpleSelect implements RestrictionRenderingContext {
 	protected String tableName;
 	protected String orderBy;
 	protected String comment;
 
 	protected List<String> columns = new ArrayList<>();
 	protected Map<String, String> aliases = new HashMap<>();
-	protected List<String> whereTokens = new ArrayList<>();
+	protected List<Restriction> restrictions = new ArrayList<>();
 
 	protected LockOptions lockOptions = new LockOptions( LockMode.READ );
 
 	private final SessionFactoryImplementor factory;
 	private final Dialect dialect;
-	private JdbcParameterRenderer _jdbcParameterRenderer;
+	private final JdbcParameterRenderer jdbcParameterRenderer;
+	private int parameterCount;
 
 	public SimpleSelect(SessionFactoryImplementor factory) {
 		this.factory = factory;
 		this.dialect = factory.getJdbcServices().getDialect();
+		this.jdbcParameterRenderer = factory.getServiceRegistry().getService( JdbcParameterRenderer.class );
 	}
 
-	//private static final Alias DEFAULT_ALIAS = new Alias(10, null);
+	@Override
+	public String makeParameterMarker() {
+		return jdbcParameterRenderer.renderJdbcParameter( ++parameterCount, null );
+	}
 
-
-	public SimpleSelect addColumns(String[] columnNames, String[] columnAliases) {
-		for ( int i = 0; i < columnNames.length; i++ ) {
-			if ( columnNames[i] != null ) {
-				addColumn( columnNames[i], columnAliases[i] );
-			}
-		}
+	/**
+	 * Sets the name of the table we are selecting from
+	 */
+	public SimpleSelect setTableName(String tableName) {
+		this.tableName = tableName;
 		return this;
 	}
 
-	public SimpleSelect addColumns(String[] columns, String[] aliases, boolean[] ignore) {
-		for ( int i = 0; i < ignore.length; i++ ) {
-			if ( !ignore[i] && columns[i] != null ) {
-				addColumn( columns[i], aliases[i] );
-			}
-		}
-		return this;
-	}
-
+	/**
+	 * Adds selections
+	 */
 	public SimpleSelect addColumns(String[] columnNames) {
 		for ( String columnName : columnNames ) {
 			if ( columnName != null ) {
@@ -77,20 +73,66 @@ public class SimpleSelect {
 		return this;
 	}
 
+	/**
+	 * Adds a selection
+	 */
 	public SimpleSelect addColumn(String columnName) {
 		columns.add( columnName );
-		//aliases.put( columnName, DEFAULT_ALIAS.toAliasString(columnName) );
 		return this;
 	}
 
+	/**
+	 * Adds a selection, with an alias
+	 */
 	public SimpleSelect addColumn(String columnName, String alias) {
 		columns.add( columnName );
 		aliases.put( columnName, alias );
 		return this;
 	}
 
-	public SimpleSelect setTableName(String tableName) {
-		this.tableName = tableName;
+	/**
+	 * Appends a complete {@linkplain org.hibernate.annotations.Where where} condition.
+	 * The {@code condition} is added as-is.
+	 */
+	public SimpleSelect addWhereToken(String condition) {
+		if ( condition != null ) {
+			restrictions.add( new CompleteRestriction( condition ) );
+		}
+		return this;
+	}
+
+	/**
+	 * Appends a restriction comparing the {@code columnName} for equality with a parameter
+	 *
+	 * @see #addRestriction(String, String, String)
+	 */
+	public SimpleSelect addRestriction(String columnName) {
+		restrictions.add( new ComparisonRestriction( columnName ) );
+		return this;
+	}
+
+	/**
+	 * Appends a restriction based on the comparison between {@code lhs} and {@code rhs}.
+	 * <p/>
+	 * The {@code rhs} is checked for parameter marker and processed via {@link JdbcParameterRenderer}
+	 * if needed.
+	 */
+	public SimpleSelect addRestriction(String lhs, String op, String rhs) {
+		restrictions.add( new ComparisonRestriction( lhs, op, rhs ) );
+		return this;
+	}
+
+	/**
+	 * Appends a restriction comparing each name in {@code columnNames} for equality with a parameter
+	 *
+	 * @see #addRestriction(String)
+	 */
+	public SimpleSelect addRestriction(String... columnNames) {
+		for ( int i = 0; i < columnNames.length; i++ ) {
+			if ( columnNames[i] != null ) {
+				addRestriction( columnNames[i] );
+			}
+		}
 		return this;
 	}
 
@@ -104,114 +146,6 @@ public class SimpleSelect {
 		return this;
 	}
 
-	/**
-	 * Appends a complete {@linkplain org.hibernate.annotations.Where where} fragment.  The {@code token} is added as-is
-	 */
-	public SimpleSelect addWhereToken(String token) {
-		if (token != null ) {
-			and();
-			whereTokens.add( token );
-		}
-		return this;
-	}
-
-	private void and() {
-		if ( !whereTokens.isEmpty() ) {
-			whereTokens.add( "and" );
-		}
-	}
-
-	private JdbcParameterRenderer jdbcParameterRenderer() {
-		if ( _jdbcParameterRenderer == null ) {
-			_jdbcParameterRenderer = factory.getServiceRegistry().getService( JdbcParameterRenderer.class );
-		}
-		return _jdbcParameterRenderer;
-	}
-
-	public SimpleSelect addCondition(String lhs, String op, String rhs) {
-		and();
-		whereTokens.add( lhs + ' ' + op + ' ' + rhs );
-		return this;
-	}
-
-	public SimpleSelect addCondition(String lhs, String condition) {
-		and();
-		whereTokens.add( lhs + ' ' + condition );
-		return this;
-	}
-
-	public SimpleSelect addCondition(String[] lhs, String condition) {
-		for ( String lh : lhs ) {
-			if ( lh != null ) {
-				addCondition( lh, condition );
-			}
-		}
-		return this;
-	}
-
-	public String toStatementString() {
-		StringBuilder buf = new StringBuilder(
-				columns.size() * 10 +
-						tableName.length() +
-						whereTokens.size() * 10 +
-						10
-		);
-
-		if ( comment != null ) {
-			buf.append( "/* " ).append( Dialect.escapeComment( comment ) ).append( " */ " );
-		}
-
-		buf.append( "select " );
-		Set<String> uniqueColumns = new HashSet<>();
-		Iterator<String> iter = columns.iterator();
-		boolean appendComma = false;
-		while ( iter.hasNext() ) {
-			String col = iter.next();
-			String alias = aliases.get( col );
-			if ( uniqueColumns.add( alias == null ? col : alias ) ) {
-				if ( appendComma ) {
-					buf.append( ", " );
-				}
-				buf.append( col );
-				if ( alias != null && !alias.equals( col ) ) {
-					buf.append( " as " )
-							.append( alias );
-				}
-				appendComma = true;
-			}
-		}
-
-		buf.append( " from " )
-				.append( dialect.appendLockHint( lockOptions, tableName ) );
-
-		if ( whereTokens.size() > 0 ) {
-			buf.append( " where " )
-					.append( toWhereClause() );
-		}
-
-		if ( orderBy != null ) {
-			buf.append( orderBy );
-		}
-
-		if ( lockOptions != null ) {
-			buf = new StringBuilder( dialect.applyLocksToSql( buf.toString(), lockOptions, null ) );
-		}
-
-		return dialect.transformSelectString( buf.toString() );
-	}
-
-	public String toWhereClause() {
-		StringBuilder buf = new StringBuilder( whereTokens.size() * 5 );
-		Iterator<String> iter = whereTokens.iterator();
-		while ( iter.hasNext() ) {
-			buf.append( iter.next() );
-			if ( iter.hasNext() ) {
-				buf.append( ' ' );
-			}
-		}
-		return buf.toString();
-	}
-
 	public SimpleSelect setOrderBy(String orderBy) {
 		this.orderBy = orderBy;
 		return this;
@@ -220,6 +154,82 @@ public class SimpleSelect {
 	public SimpleSelect setComment(String comment) {
 		this.comment = comment;
 		return this;
+	}
+
+	public String toStatementString() {
+		final StringBuilder buf = new StringBuilder(
+				columns.size() * 10 +
+						tableName.length() +
+						restrictions.size() * 10 +
+						10
+		);
+
+		applyComment( buf );
+		applySelectClause( buf );
+		applyFromClause( buf );
+		applyWhereClause( buf );
+		applyOrderBy( buf );
+
+		final String selectString = (lockOptions != null)
+				? dialect.applyLocksToSql( buf.toString(), lockOptions, null )
+				: buf.toString();
+
+		return dialect.transformSelectString( selectString );
+	}
+
+	private void applyComment(StringBuilder buf) {
+		if ( comment != null ) {
+			buf.append( "/* " ).append( Dialect.escapeComment( comment ) ).append( " */ " );
+		}
+	}
+
+	private void applySelectClause(StringBuilder buf) {
+		buf.append( "select " );
+
+		boolean appendComma = false;
+		final Set<String> uniqueColumns = new HashSet<>();
+		for ( int i = 0; i < columns.size(); i++ ) {
+			final String col = columns.get( i );
+			final String alias = aliases.get( col );
+
+			if ( uniqueColumns.add( alias == null ? col : alias ) ) {
+				if ( appendComma ) {
+					buf.append( ", " );
+				}
+				buf.append( col );
+				if ( alias != null && !alias.equals( col ) ) {
+					buf.append( " as " ).append( alias );
+				}
+				appendComma = true;
+			}
+		}
+	}
+
+	private void applyFromClause(StringBuilder buf) {
+		buf.append( " from " ).append( dialect.appendLockHint( lockOptions, tableName ) );
+	}
+
+	private void applyWhereClause(StringBuilder buf) {
+		if ( restrictions.isEmpty() ) {
+			return;
+		}
+
+		buf.append( " where " );
+
+		for ( int i = 0; i < restrictions.size(); i++ ) {
+			if ( i > 0 ) {
+				buf.append( " and " );
+			}
+
+			final Restriction restriction = restrictions.get( i );
+			restriction.render( buf, this );
+		}
+	}
+
+	private void applyOrderBy(StringBuilder buf) {
+		if ( orderBy != null ) {
+			buf.append( ' ' ).append( orderBy );
+		}
 	}
 
 }

--- a/hibernate-core/src/main/java/org/hibernate/sql/Update.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/Update.java
@@ -5,14 +5,16 @@
  * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
  */
 package org.hibernate.sql;
-import java.util.HashMap;
+import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 
 import org.hibernate.Internal;
 import org.hibernate.dialect.Dialect;
-import org.hibernate.metamodel.mapping.ModelPart;
+import org.hibernate.engine.spi.SessionFactoryImplementor;
+import org.hibernate.sql.ast.spi.JdbcParameterRenderer;
 
 /**
  * A SQL {@code UPDATE} statement.
@@ -20,37 +22,27 @@ import org.hibernate.metamodel.mapping.ModelPart;
  * @author Gavin King
  */
 @Internal
-public class Update {
-
+public class Update implements RestrictionRenderingContext {
 	protected String tableName;
-	protected String versionColumnName;
-	protected String where;
-	protected String assignments;
 	protected String comment;
+	protected Map<String,String> assignments = new LinkedHashMap<>();
+	protected List<Restriction> restrictions = new ArrayList<>();
 
-	protected Map<String,String> primaryKeyColumns = new LinkedHashMap<>();
-	protected Map<String,String> columns = new LinkedHashMap<>();
-	protected Map<String,String> lobColumns;
-	protected Map<String,String> whereColumns = new LinkedHashMap<>();
-	
-	private Dialect dialect;
-	
-	public Update(Dialect dialect) {
-		this.dialect = dialect;
+	private final JdbcParameterRenderer jdbcParameterRenderer;
+	private final boolean standardParamRendering;
+	private int parameterCount;
+
+	public Update(SessionFactoryImplementor factory) {
+		this( factory.getServiceRegistry().getService( JdbcParameterRenderer.class ) );
+	}
+
+	public Update(JdbcParameterRenderer jdbcParameterRenderer) {
+		this.jdbcParameterRenderer = jdbcParameterRenderer;
+		this.standardParamRendering = JdbcParameterRenderer.isStandardRenderer( jdbcParameterRenderer );
 	}
 
 	public String getTableName() {
 		return tableName;
-	}
-
-	public Update appendAssignmentFragment(String fragment) {
-		if ( assignments == null ) {
-			assignments = fragment;
-		}
-		else {
-			assignments += ", " + fragment;
-		}
-		return this;
 	}
 
 	public Update setTableName(String tableName) {
@@ -58,185 +50,114 @@ public class Update {
 		return this;
 	}
 
-	public Update setPrimaryKeyColumnNames(String[] columnNames) {
-		this.primaryKeyColumns.clear();
-		addPrimaryKeyColumns(columnNames);
-		return this;
-	}	
-	
-	public Update addPrimaryKeyColumns(String[] columnNames) {
-		for ( String columnName : columnNames ) {
-			addPrimaryKeyColumn( columnName, "?" );
-		}
-		return this;
-	}
-
-	public Update addPrimaryKeyColumns(ModelPart keyPart) {
-		keyPart.forEachSelectable( (selectionIndex, selectableMapping) -> {
-			addPrimaryKeyColumn( selectableMapping.getSelectionExpression(), "?" );
-		} );
-		return this;
-	}
-	
-	public Update addPrimaryKeyColumns(String[] columnNames, boolean[] includeColumns, String[] valueExpressions) {
-		for ( int i=0; i<columnNames.length; i++ ) {
-			if( includeColumns[i] ) {
-				addPrimaryKeyColumn( columnNames[i], valueExpressions[i] );
-			}
-		}
-		return this;
-	}
-	
-	public Update addPrimaryKeyColumns(String[] columnNames, String[] valueExpressions) {
-		for ( int i=0; i<columnNames.length; i++ ) {
-			addPrimaryKeyColumn( columnNames[i], valueExpressions[i] );
-		}
-		return this;
-	}	
-
-	public Update addPrimaryKeyColumn(String columnName, String valueExpression) {
-		this.primaryKeyColumns.put(columnName, valueExpression);
-		return this;
-	}
-	
-	public Update setVersionColumnName(String versionColumnName) {
-		this.versionColumnName = versionColumnName;
-		return this;
-	}
-
-
 	public Update setComment(String comment) {
 		this.comment = comment;
 		return this;
 	}
-	
-	public Update addColumns(String[] columnNames) {
+
+	public Update addAssignments(String... columnNames) {
 		for ( String columnName : columnNames ) {
-			addColumn( columnName );
+			addAssignment( columnName );
 		}
 		return this;
 	}
 
-	public Update addColumns(String[] columnNames, boolean[] updateable, String[] valueExpressions) {
-		for ( int i=0; i<columnNames.length; i++ ) {
-			if ( updateable[i] ) {
-				addColumn( columnNames[i], valueExpressions[i] );
+	public Update addAssignment(String columnName) {
+		return addAssignment( columnName, "?" );
+	}
+
+	public Update addAssignment(String columnName, String valueExpression) {
+		assignments.put( columnName, valueExpression );
+		return this;
+	}
+
+	public Update addRestriction(String column) {
+		restrictions.add( new ComparisonRestriction( column ) );
+		return this;
+	}
+
+	public Update addRestriction(String... columns) {
+		for ( int i = 0; i < columns.length; i++ ) {
+			final String columnName = columns[ i ];
+			if ( columnName != null ) {
+				addRestriction( columnName );
 			}
 		}
 		return this;
 	}
 
-	public Update addColumns(String[] columnNames, String valueExpression) {
-		for ( String columnName : columnNames ) {
-			addColumn( columnName, valueExpression );
-		}
+	public Update addRestriction(String column, String value) {
+		restrictions.add( new ComparisonRestriction( column, value ) );
 		return this;
 	}
 
-	public Update addColumn(String columnName) {
-		return addColumn(columnName, "?");
-	}
-
-	public Update addColumn(String columnName, String valueExpression) {
-		columns.put(columnName, valueExpression);
+	public Update addRestriction(String column, String op, String value) {
+		restrictions.add( new ComparisonRestriction( column, op, value ) );
 		return this;
 	}
 
-	public void addLobColumn(String columnName, String valueExpression) {
-		assert dialect.forceLobAsLastValue();
-		if ( lobColumns == null ) {
-			lobColumns = new HashMap<>();
-		}
-		lobColumns.put( columnName, valueExpression );
+	private String normalizeExpressionFragment(String rhs) {
+		return rhs.equals( "?" ) && !standardParamRendering
+				? jdbcParameterRenderer.renderJdbcParameter( ++parameterCount, null )
+				: rhs;
 	}
 
-	public Update addWhereColumns(String[] columnNames) {
-		for ( String columnName : columnNames ) {
-			addWhereColumn( columnName );
-		}
-		return this;
-	}
-
-	public Update addWhereColumns(String[] columnNames, String valueExpression) {
-		for ( String columnName : columnNames ) {
-			addWhereColumn( columnName, valueExpression );
-		}
-		return this;
-	}
-
-	public Update addWhereColumn(String columnName) {
-		return addWhereColumn(columnName, "=?");
-	}
-
-	public Update addWhereColumn(String columnName, String valueExpression) {
-		whereColumns.put(columnName, valueExpression);
-		return this;
-	}
-
-	public Update setWhere(String where) {
-		this.where=where;
+	public Update addNullnessRestriction(String column) {
+		restrictions.add( new NullnessRestriction( column ) );
 		return this;
 	}
 
 	public String toStatementString() {
-		StringBuilder buf = new StringBuilder( (columns.size() * 15) + tableName.length() + 10 );
-		if ( comment!=null ) {
-			buf.append( "/* " ).append( Dialect.escapeComment( comment ) ).append( " */ " );
-		}
-		buf.append( "update " ).append( tableName ).append( " set " );
-		boolean assignmentsAppended = false;
-		Iterator<Map.Entry<String,String>> iter = columns.entrySet().iterator();
-		while ( iter.hasNext() ) {
-			Map.Entry<String,String> e = iter.next();
-			buf.append( e.getKey() ).append( '=' ).append( e.getValue() );
-			if ( iter.hasNext() ) {
-				buf.append( ", " );
-			}
-			assignmentsAppended = true;
-		}
-		if ( assignments != null ) {
-			if ( assignmentsAppended ) {
-				buf.append( ", " );
-			}
-			buf.append( assignments );
-		}
+		final StringBuilder buf = new StringBuilder( ( assignments.size() * 15) + tableName.length() + 10 );
 
-		boolean conditionsAppended = false;
-		if ( !primaryKeyColumns.isEmpty() || where != null || !whereColumns.isEmpty() || versionColumnName != null ) {
-			buf.append( " where " );
-		}
-		iter = primaryKeyColumns.entrySet().iterator();
-		while ( iter.hasNext() ) {
-			Map.Entry<String,String> e = iter.next();
-			buf.append( e.getKey() ).append( '=' ).append( e.getValue() );
-			if ( iter.hasNext() ) {
-				buf.append( " and " );
-			}
-			conditionsAppended = true;
-		}
-		if ( where != null ) {
-			if ( conditionsAppended ) {
-				buf.append( " and " );
-			}
-			buf.append( where );
-			conditionsAppended = true;
-		}
-		iter = whereColumns.entrySet().iterator();
-		while ( iter.hasNext() ) {
-			final Map.Entry<String,String> e = iter.next();
-			if ( conditionsAppended ) {
-				buf.append( " and " );
-			}
-			buf.append( e.getKey() ).append( e.getValue() );
-			conditionsAppended = true;
-		}
-		if ( versionColumnName != null ) {
-			if ( conditionsAppended ) {
-				buf.append( " and " );
-			}
-			buf.append( versionColumnName ).append( "=?" );
-		}
+		applyComment( buf );
+		buf.append( "update " ).append( tableName );
+		applyAssignments( buf );
+		applyRestrictions( buf );
 
 		return buf.toString();
+	}
+
+	private void applyComment(StringBuilder buf) {
+		if ( comment != null ) {
+			buf.append( "/* " ).append( Dialect.escapeComment( comment ) ).append( " */ " );
+		}
+	}
+
+	private void applyAssignments(StringBuilder buf) {
+		buf.append( " set " );
+
+		final Iterator<Map.Entry<String,String>> entries = assignments.entrySet().iterator();
+		while ( entries.hasNext() ) {
+			final Map.Entry<String,String> entry = entries.next();
+			buf.append( entry.getKey() )
+					.append( '=' )
+					.append( normalizeExpressionFragment( entry.getValue() ) );
+			if ( entries.hasNext() ) {
+				buf.append( ", " );
+			}
+		}
+	}
+
+	private void applyRestrictions(StringBuilder buf) {
+		if ( restrictions.isEmpty() ) {
+			return;
+		}
+
+		buf.append( " where " );
+
+		for ( int i = 0; i < restrictions.size(); i++ ) {
+			if ( i > 0 ) {
+				buf.append( " and " );
+			}
+
+			final Restriction restriction = restrictions.get( i );
+			restriction.render( buf, this );
+		}
+	}
+
+	@Override
+	public String makeParameterMarker() {
+		return jdbcParameterRenderer.renderJdbcParameter( ++parameterCount, null );
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/sql/ast/internal/JdbcParameterRendererInitiator.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/ast/internal/JdbcParameterRendererInitiator.java
@@ -9,6 +9,10 @@ package org.hibernate.sql.ast.internal;
 import java.util.Map;
 
 import org.hibernate.boot.registry.StandardServiceInitiator;
+import org.hibernate.cfg.AvailableSettings;
+import org.hibernate.dialect.Dialect;
+import org.hibernate.engine.jdbc.spi.JdbcServices;
+import org.hibernate.internal.util.config.ConfigurationHelper;
 import org.hibernate.service.spi.ServiceRegistryImplementor;
 import org.hibernate.sql.ast.spi.JdbcParameterRenderer;
 
@@ -23,6 +27,17 @@ public class JdbcParameterRendererInitiator implements StandardServiceInitiator<
 
 	@Override
 	public JdbcParameterRenderer initiateService(Map<String, Object> configurationValues, ServiceRegistryImplementor registry) {
+		final boolean useNativeMarkers = ConfigurationHelper.getBoolean(
+				AvailableSettings.DIALECT_NATIVE_PARAM_MARKERS,
+				configurationValues,
+				true
+		);
+
+		if ( useNativeMarkers ) {
+			final Dialect dialect = registry.getService( JdbcServices.class ).getDialect();
+			return dialect.getNativeParameterRenderer();
+		}
+
 		return JdbcParameterRendererStandard.INSTANCE;
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/sql/ast/internal/JdbcParameterRendererStandard.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/ast/internal/JdbcParameterRendererStandard.java
@@ -6,9 +6,7 @@
  */
 package org.hibernate.sql.ast.internal;
 
-import org.hibernate.dialect.Dialect;
 import org.hibernate.sql.ast.spi.JdbcParameterRenderer;
-import org.hibernate.sql.ast.spi.SqlAppender;
 import org.hibernate.type.descriptor.jdbc.JdbcType;
 
 /**
@@ -21,7 +19,7 @@ public class JdbcParameterRendererStandard implements JdbcParameterRenderer {
 	public static final JdbcParameterRendererStandard INSTANCE = new JdbcParameterRendererStandard();
 
 	@Override
-	public void renderJdbcParameter(int position, JdbcType jdbcType, SqlAppender appender, Dialect dialect) {
-		jdbcType.appendWriteExpression( "?", appender, dialect );
+	public String renderJdbcParameter(int position, JdbcType jdbcType) {
+		return "?";
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/sql/ast/spi/AbstractSqlAstTranslator.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/ast/spi/AbstractSqlAstTranslator.java
@@ -6187,8 +6187,12 @@ public abstract class AbstractSqlAstTranslator<T extends JdbcOperation> implemen
 	}
 
 	protected void renderParameterAsParameter(JdbcParameter jdbcParameter) {
+		renderParameterAsParameter( jdbcParameter, parameterBinders.size() + 1 );
+	}
+
+	protected void renderParameterAsParameter(JdbcParameter jdbcParameter, int position) {
 		jdbcParameterRenderer.renderJdbcParameter(
-				parameterBinders.size() + 1,
+				position,
 				jdbcParameter.getExpressionType().getJdbcMappings().get( 0 ).getJdbcType(),
 				this,
 				getDialect()

--- a/hibernate-core/src/main/java/org/hibernate/sql/ast/spi/AbstractSqlAstTranslator.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/ast/spi/AbstractSqlAstTranslator.java
@@ -203,6 +203,7 @@ import org.hibernate.type.StandardBasicTypes;
 import org.hibernate.type.descriptor.WrapperOptions;
 import org.hibernate.type.descriptor.java.JavaType;
 import org.hibernate.type.descriptor.jdbc.JdbcLiteralFormatter;
+import org.hibernate.type.descriptor.jdbc.JdbcType;
 import org.hibernate.type.descriptor.sql.DdlType;
 import org.hibernate.type.descriptor.sql.spi.DdlTypeRegistry;
 
@@ -6191,12 +6192,10 @@ public abstract class AbstractSqlAstTranslator<T extends JdbcOperation> implemen
 	}
 
 	protected void renderParameterAsParameter(JdbcParameter jdbcParameter, int position) {
-		jdbcParameterRenderer.renderJdbcParameter(
-				position,
-				jdbcParameter.getExpressionType().getJdbcMappings().get( 0 ).getJdbcType(),
-				this,
-				getDialect()
-		);
+		final JdbcType jdbcType = jdbcParameter.getExpressionType().getJdbcMappings().get( 0 ).getJdbcType();
+		assert jdbcType != null;
+		final String parameterMarker = jdbcParameterRenderer.renderJdbcParameter( position, jdbcType );
+		jdbcType.appendWriteExpression( parameterMarker, this, dialect );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/sql/ast/spi/JdbcParameterRenderer.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/ast/spi/JdbcParameterRenderer.java
@@ -8,6 +8,7 @@ package org.hibernate.sql.ast.spi;
 
 import org.hibernate.dialect.Dialect;
 import org.hibernate.service.Service;
+import org.hibernate.sql.ast.internal.JdbcParameterRendererStandard;
 import org.hibernate.type.descriptor.jdbc.JdbcType;
 
 /**
@@ -26,4 +27,8 @@ public interface JdbcParameterRenderer extends Service {
 	 * @param dialect The Dialect in use within the SessionFactory
 	 */
 	void renderJdbcParameter(int position, JdbcType jdbcType, SqlAppender appender, Dialect dialect);
+
+	static boolean isStandardRenderer(JdbcParameterRenderer check) {
+		return check == null || JdbcParameterRendererStandard.class.equals( check.getClass() );
+	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/sql/ast/spi/JdbcParameterRenderer.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/ast/spi/JdbcParameterRenderer.java
@@ -6,14 +6,21 @@
  */
 package org.hibernate.sql.ast.spi;
 
-import org.hibernate.dialect.Dialect;
 import org.hibernate.service.Service;
 import org.hibernate.sql.ast.internal.JdbcParameterRendererStandard;
 import org.hibernate.type.descriptor.jdbc.JdbcType;
 
 /**
- * Extension point, intended for use from Hibernate Reactive, to render JDBC
- * parameter placeholders into the SQL query string being generated.
+ * Extension point for rendering parameter markers.
+ * <p/>
+ * Generally Hibernate will use the JDBC standard marker - {@code ?}.  Many
+ * databases support alternative marker syntax, often numbered.
+ * <p/>
+ * Originally developed as an extension point for use from Hibernate Reactive
+ * to handle the fact that some Vert.X drivers (ok, their PGSQL driver) only
+ * support native parameter marker syntax instead of the JDBC standard
+ *
+ * @see org.hibernate.cfg.AvailableSettings#DIALECT_NATIVE_PARAM_MARKERS
  *
  * @author Steve Ebersole
  */
@@ -22,11 +29,9 @@ public interface JdbcParameterRenderer extends Service {
 	 * Render the parameter for the given position
 	 *
 	 * @param position The 1-based position of the parameter.
-	 * @param jdbcType The type of the parameter
-	 * @param appender The appender where the parameter should be rendered
-	 * @param dialect The Dialect in use within the SessionFactory
+	 * @param jdbcType The type of the parameter, if known
 	 */
-	void renderJdbcParameter(int position, JdbcType jdbcType, SqlAppender appender, Dialect dialect);
+	String renderJdbcParameter(int position, JdbcType jdbcType);
 
 	static boolean isStandardRenderer(JdbcParameterRenderer check) {
 		return check == null || JdbcParameterRendererStandard.class.equals( check.getClass() );

--- a/hibernate-core/src/main/java/org/hibernate/sql/ast/spi/SqlAppender.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/ast/spi/SqlAppender.java
@@ -11,6 +11,7 @@ package org.hibernate.sql.ast.spi;
  *
  * @author Steve Ebersole
  */
+@FunctionalInterface
 public interface SqlAppender extends Appendable {
 	String NO_SEPARATOR = "";
 	String COMA_SEPARATOR = ",";

--- a/hibernate-core/src/main/java/org/hibernate/sql/exec/internal/AbstractJdbcOperationQueryInsert.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/exec/internal/AbstractJdbcOperationQueryInsert.java
@@ -24,6 +24,6 @@ public class AbstractJdbcOperationQueryInsert extends AbstractJdbcOperationQuery
 			String sql,
 			List<JdbcParameterBinder> parameterBinders,
 			Set<String> affectedTableNames) {
-		super( sql, parameterBinders, affectedTableNames, Collections.emptySet() );
+		super( sql, parameterBinders, affectedTableNames );
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/sql/exec/internal/JdbcCallImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/exec/internal/JdbcCallImpl.java
@@ -113,11 +113,6 @@ public class JdbcCallImpl implements JdbcOperationQueryCall {
 	}
 
 	@Override
-	public Set<FilterJdbcParameter> getFilterJdbcParameters() {
-		return Collections.emptySet();
-	}
-
-	@Override
 	public boolean dependsOnParameterBindings() {
 		return false;
 	}

--- a/hibernate-core/src/main/java/org/hibernate/sql/exec/spi/AbstractJdbcOperationQuery.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/exec/spi/AbstractJdbcOperationQuery.java
@@ -24,9 +24,12 @@ public class AbstractJdbcOperationQuery implements JdbcOperationQuery {
 	protected final String sql;
 	protected final List<JdbcParameterBinder> parameterBinders;
 	protected final Set<String> affectedTableNames;
-	protected final Set<FilterJdbcParameter> filterJdbcParameters;
 	protected final Map<JdbcParameter, JdbcParameterBinding> appliedParameters;
 
+	/**
+	 * @deprecated {@code filterJdbcParameters} is no longer used
+	 */
+	@Deprecated
 	public AbstractJdbcOperationQuery(
 			String sql,
 			List<JdbcParameterBinder> parameterBinders,
@@ -35,22 +38,43 @@ public class AbstractJdbcOperationQuery implements JdbcOperationQuery {
 		this(
 				sql,
 				parameterBinders,
-				affectedTableNames,
-				filterJdbcParameters,
-				Collections.emptyMap()
+				affectedTableNames
 		);
 	}
 
 	public AbstractJdbcOperationQuery(
 			String sql,
 			List<JdbcParameterBinder> parameterBinders,
+			Set<String> affectedTableNames) {
+		this(
+				sql,
+				parameterBinders,
+				affectedTableNames,
+				Collections.emptyMap()
+		);
+	}
+
+	/**
+	 * @deprecated {@code filterJdbcParameters} is no longer used
+	 */
+	@Deprecated
+	public AbstractJdbcOperationQuery(
+			String sql,
+			List<JdbcParameterBinder> parameterBinders,
 			Set<String> affectedTableNames,
 			Set<FilterJdbcParameter> filterJdbcParameters,
+			Map<JdbcParameter, JdbcParameterBinding> appliedParameters) {
+		this( sql, parameterBinders, affectedTableNames, appliedParameters );
+	}
+
+	public AbstractJdbcOperationQuery(
+			String sql,
+			List<JdbcParameterBinder> parameterBinders,
+			Set<String> affectedTableNames,
 			Map<JdbcParameter, JdbcParameterBinding> appliedParameters) {
 		this.sql = sql;
 		this.parameterBinders = parameterBinders;
 		this.affectedTableNames = affectedTableNames;
-		this.filterJdbcParameters = filterJdbcParameters;
 		this.appliedParameters = appliedParameters;
 	}
 
@@ -67,11 +91,6 @@ public class AbstractJdbcOperationQuery implements JdbcOperationQuery {
 	@Override
 	public Set<String> getAffectedTableNames() {
 		return affectedTableNames;
-	}
-
-	@Override
-	public Set<FilterJdbcParameter> getFilterJdbcParameters() {
-		return filterJdbcParameters;
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/sql/exec/spi/JdbcOperationQuery.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/exec/spi/JdbcOperationQuery.java
@@ -6,10 +6,10 @@
  */
 package org.hibernate.sql.exec.spi;
 
+import java.util.Collections;
 import java.util.Set;
 
 import org.hibernate.internal.FilterJdbcParameter;
-import org.hibernate.internal.util.collections.CollectionHelper;
 import org.hibernate.query.spi.QueryOptions;
 
 /**
@@ -28,8 +28,13 @@ public interface JdbcOperationQuery extends JdbcOperation {
 	 * Any parameters to apply for filters
 	 *
 	 * @see org.hibernate.annotations.Filter
+	 *
+	 * @deprecated No longer used.
 	 */
-	Set<FilterJdbcParameter> getFilterJdbcParameters();
+	@Deprecated(since = "6.2")
+	default Set<FilterJdbcParameter> getFilterJdbcParameters() {
+		return Collections.emptySet();
+	}
 
 	/**
 	 * Signals that the SQL depends on the parameter bindings e.g. due to the need for inlining
@@ -38,12 +43,4 @@ public interface JdbcOperationQuery extends JdbcOperation {
 	boolean dependsOnParameterBindings();
 
 	boolean isCompatibleWith(JdbcParameterBindings jdbcParameterBindings, QueryOptions queryOptions);
-
-	default void bindFilterJdbcParameters(JdbcParameterBindings jdbcParameterBindings) {
-		if ( CollectionHelper.isNotEmpty( getFilterJdbcParameters() ) ) {
-			for ( FilterJdbcParameter filterJdbcParameter : getFilterJdbcParameters() ) {
-				jdbcParameterBindings.addBinding( filterJdbcParameter.getParameter(), filterJdbcParameter.getBinding() );
-			}
-		}
-	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/sql/exec/spi/JdbcOperationQueryDelete.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/exec/spi/JdbcOperationQueryDelete.java
@@ -18,12 +18,24 @@ import org.hibernate.sql.ast.tree.expression.JdbcParameter;
  */
 public class JdbcOperationQueryDelete extends AbstractJdbcOperationQuery implements JdbcOperationQueryMutation {
 
+	/**
+	 * @deprecated {@code filterJdbcParameters} is no longer used
+	 */
+	@Deprecated
 	public JdbcOperationQueryDelete(
 			String sql,
 			List<JdbcParameterBinder> parameterBinders,
 			Set<String> affectedTableNames,
 			Set<FilterJdbcParameter> filterJdbcParameters,
 			Map<JdbcParameter, JdbcParameterBinding> appliedParameters) {
-		super( sql, parameterBinders, affectedTableNames, filterJdbcParameters, appliedParameters );
+		this( sql, parameterBinders, affectedTableNames, appliedParameters );
+	}
+
+	public JdbcOperationQueryDelete(
+			String sql,
+			List<JdbcParameterBinder> parameterBinders,
+			Set<String> affectedTableNames,
+			Map<JdbcParameter, JdbcParameterBinding> appliedParameters) {
+		super( sql, parameterBinders, affectedTableNames, appliedParameters );
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/sql/exec/spi/JdbcOperationQueryMutationNative.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/exec/spi/JdbcOperationQueryMutationNative.java
@@ -6,11 +6,9 @@
  */
 package org.hibernate.sql.exec.spi;
 
-import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 
-import org.hibernate.internal.FilterJdbcParameter;
 import org.hibernate.query.spi.QueryOptions;
 
 /**
@@ -45,11 +43,6 @@ public class JdbcOperationQueryMutationNative implements JdbcOperationQueryMutat
 	@Override
 	public Set<String> getAffectedTableNames() {
 		return affectedTableNames;
-	}
-
-	@Override
-	public Set<FilterJdbcParameter> getFilterJdbcParameters() {
-		return Collections.EMPTY_SET;
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/sql/exec/spi/JdbcOperationQuerySelect.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/exec/spi/JdbcOperationQuerySelect.java
@@ -30,6 +30,10 @@ public class JdbcOperationQuerySelect extends AbstractJdbcOperationQuery {
 	private final JdbcParameter limitParameter;
 	private final JdbcLockStrategy jdbcLockStrategy;
 
+	/**
+	 * @deprecated {@code filterJdbcParameters} is no longer used
+	 */
+	@Deprecated
 	public JdbcOperationQuerySelect(
 			String sql,
 			List<JdbcParameterBinder> parameterBinders,
@@ -40,8 +44,21 @@ public class JdbcOperationQuerySelect extends AbstractJdbcOperationQuery {
 				sql,
 				parameterBinders,
 				jdbcValuesMappingProducer,
+				affectedTableNames
+		);
+	}
+
+	public JdbcOperationQuerySelect(
+			String sql,
+			List<JdbcParameterBinder> parameterBinders,
+			JdbcValuesMappingProducer jdbcValuesMappingProducer,
+			Set<String> affectedTableNames) {
+		this(
+				sql,
+				parameterBinders,
+				jdbcValuesMappingProducer,
 				affectedTableNames,
-				filterJdbcParameters,
+				null,
 				0,
 				Integer.MAX_VALUE,
 				Collections.emptyMap(),
@@ -51,6 +68,10 @@ public class JdbcOperationQuerySelect extends AbstractJdbcOperationQuery {
 		);
 	}
 
+	/**
+	 * @deprecated {@code filterJdbcParameters} is no longer used
+	 */
+	@Deprecated
 	public JdbcOperationQuerySelect(
 			String sql,
 			List<JdbcParameterBinder> parameterBinders,
@@ -63,7 +84,32 @@ public class JdbcOperationQuerySelect extends AbstractJdbcOperationQuery {
 			JdbcLockStrategy jdbcLockStrategy,
 			JdbcParameter offsetParameter,
 			JdbcParameter limitParameter) {
-		super( sql, parameterBinders, affectedTableNames, filterJdbcParameters, appliedParameters );
+		this(
+				sql,
+				parameterBinders,
+				jdbcValuesMappingProducer,
+				affectedTableNames,
+				rowsToSkip,
+				maxRows,
+				appliedParameters,
+				jdbcLockStrategy,
+				offsetParameter,
+				limitParameter
+		);
+	}
+
+	public JdbcOperationQuerySelect(
+			String sql,
+			List<JdbcParameterBinder> parameterBinders,
+			JdbcValuesMappingProducer jdbcValuesMappingProducer,
+			Set<String> affectedTableNames,
+			int rowsToSkip,
+			int maxRows,
+			Map<JdbcParameter, JdbcParameterBinding> appliedParameters,
+			JdbcLockStrategy jdbcLockStrategy,
+			JdbcParameter offsetParameter,
+			JdbcParameter limitParameter) {
+		super( sql, parameterBinders, affectedTableNames, appliedParameters );
 		this.jdbcValuesMappingProducer = jdbcValuesMappingProducer;
 		this.rowsToSkip = rowsToSkip;
 		this.maxRows = maxRows;

--- a/hibernate-core/src/main/java/org/hibernate/sql/exec/spi/JdbcOperationQueryUpdate.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/exec/spi/JdbcOperationQueryUpdate.java
@@ -19,13 +19,24 @@ import org.hibernate.sql.ast.tree.expression.JdbcParameter;
 public class JdbcOperationQueryUpdate
 		extends AbstractJdbcOperationQuery
 		implements JdbcOperationQueryMutation {
-
+	/**
+	 * @deprecated {@code filterJdbcParameters} is no longer used
+	 */
+	@Deprecated
 	public JdbcOperationQueryUpdate(
 			String sql,
 			List<JdbcParameterBinder> parameterBinders,
 			Set<String> affectedTableNames,
 			Set<FilterJdbcParameter> filterJdbcParameters,
 			Map<JdbcParameter, JdbcParameterBinding> appliedParameters) {
-		super( sql, parameterBinders, affectedTableNames, filterJdbcParameters, appliedParameters );
+		this( sql, parameterBinders, affectedTableNames, appliedParameters );
+	}
+
+	public JdbcOperationQueryUpdate(
+			String sql,
+			List<JdbcParameterBinder> parameterBinders,
+			Set<String> affectedTableNames,
+			Map<JdbcParameter, JdbcParameterBinding> appliedParameters) {
+		super( sql, parameterBinders, affectedTableNames, appliedParameters );
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/sql/model/ast/ColumnValueBindingList.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/model/ast/ColumnValueBindingList.java
@@ -10,13 +10,10 @@ import java.util.ArrayList;
 
 import org.hibernate.Internal;
 import org.hibernate.engine.jdbc.mutation.ParameterUsage;
-import org.hibernate.metamodel.mapping.EmbeddableMappingType;
 import org.hibernate.metamodel.mapping.JdbcMapping;
 import org.hibernate.metamodel.mapping.ModelPart;
 import org.hibernate.metamodel.mapping.SelectableMapping;
-import org.hibernate.sql.ast.tree.expression.ColumnReference;
-import org.hibernate.type.descriptor.jdbc.AggregateJdbcType;
-import org.hibernate.type.descriptor.jdbc.JdbcType;
+import org.hibernate.sql.model.ast.builder.ColumnValueBindingBuilder;
 
 @Internal
 public class ColumnValueBindingList extends ArrayList<ColumnValueBinding> implements ModelPart.JdbcValueConsumer {
@@ -53,16 +50,6 @@ public class ColumnValueBindingList extends ArrayList<ColumnValueBinding> implem
 		add( createValueBinding( column.getSelectionExpression(), null, column.getJdbcMapping() ) );
 	}
 
-	public void addRestriction(SelectableMapping column) {
-		add(
-				createValueBinding(
-						column.getSelectionExpression(),
-						column.getWriteExpression(),
-						column.getJdbcMapping()
-				)
-		);
-	}
-
 	public void addRestriction(String columnName, String columnWriteFragment, JdbcMapping jdbcMapping) {
 		add( createValueBinding( columnName, columnWriteFragment, jdbcMapping ) );
 	}
@@ -71,41 +58,14 @@ public class ColumnValueBindingList extends ArrayList<ColumnValueBinding> implem
 			String columnName,
 			String customWriteExpression,
 			JdbcMapping jdbcMapping) {
-		final ColumnReference columnReference = new ColumnReference( mutatingTable, columnName, jdbcMapping );
-		final ColumnWriteFragment columnWriteFragment;
-		if ( customWriteExpression == null ) {
-			columnWriteFragment = null;
-		}
-		else if ( customWriteExpression.contains( "?" ) ) {
-			final JdbcType jdbcType = jdbcMapping.getJdbcType();
-			final EmbeddableMappingType aggregateMappingType = jdbcType instanceof AggregateJdbcType
-					? ( (AggregateJdbcType) jdbcType ).getEmbeddableMappingType()
-					: null;
-			if ( aggregateMappingType != null && !aggregateMappingType.shouldBindAggregateMapping() ) {
-				final ColumnValueParameterList parameters = new ColumnValueParameterList(
-						mutatingTable,
-						parameterUsage,
-						aggregateMappingType.getJdbcTypeCount()
-				);
-				aggregateMappingType.forEachSelectable( parameters );
-				this.parameters.addAll( parameters );
-
-				columnWriteFragment = new ColumnWriteFragment(
-						customWriteExpression,
-						parameters,
-						jdbcMapping
-				);
-			}
-			else {
-				final ColumnValueParameter parameter = new ColumnValueParameter( columnReference, parameterUsage );
-				parameters.add( parameter );
-				columnWriteFragment = new ColumnWriteFragment( customWriteExpression, parameter, jdbcMapping );
-			}
-		}
-		else {
-			columnWriteFragment = new ColumnWriteFragment( customWriteExpression, jdbcMapping );
-		}
-		return new ColumnValueBinding( columnReference, columnWriteFragment ) ;
+		return ColumnValueBindingBuilder.createValueBinding(
+				columnName,
+				customWriteExpression,
+				jdbcMapping,
+				mutatingTable,
+				parameterUsage,
+				parameters::apply
+		);
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/sql/model/ast/ColumnValueParameterList.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/model/ast/ColumnValueParameterList.java
@@ -44,4 +44,13 @@ public class ColumnValueParameterList extends ArrayList<ColumnValueParameter> im
 				)
 		);
 	}
+
+	public void apply(Object parameterRef) {
+		if ( parameterRef instanceof ColumnValueParameterList ) {
+			addAll( (ColumnValueParameterList) parameterRef );
+		}
+		else {
+			add( (ColumnValueParameter) parameterRef );
+		}
+	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/sql/model/ast/ColumnWriteFragment.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/model/ast/ColumnWriteFragment.java
@@ -17,7 +17,11 @@ import org.hibernate.sql.ast.SqlAstWalker;
 import org.hibernate.sql.ast.tree.expression.Expression;
 
 /**
- * Models a column's "write fragment" within the SQL AST
+ * Models a column's value expression within the SQL AST. Used to model:<ul>
+ *     <li>a column's new value in a SET clause</li>
+ *     <li>a column's new value in a SET clause</li>
+ *     <li>a column's old value in a restriction (optimistic locking)</li>
+ * </ul>
  *
  * @see ColumnTransformer#write()
  *

--- a/hibernate-core/src/main/java/org/hibernate/sql/model/ast/builder/ColumnValueBindingBuilder.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/model/ast/builder/ColumnValueBindingBuilder.java
@@ -1,0 +1,129 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html.
+ */
+package org.hibernate.sql.model.ast.builder;
+
+import java.util.function.Consumer;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.hibernate.engine.jdbc.mutation.ParameterUsage;
+import org.hibernate.metamodel.mapping.EmbeddableMappingType;
+import org.hibernate.metamodel.mapping.JdbcMapping;
+import org.hibernate.sql.ast.tree.expression.ColumnReference;
+import org.hibernate.sql.model.ast.ColumnValueBinding;
+import org.hibernate.sql.model.ast.ColumnValueParameter;
+import org.hibernate.sql.model.ast.ColumnValueParameterList;
+import org.hibernate.sql.model.ast.ColumnWriteFragment;
+import org.hibernate.sql.model.ast.MutatingTableReference;
+import org.hibernate.type.descriptor.jdbc.AggregateJdbcType;
+import org.hibernate.type.descriptor.jdbc.JdbcType;
+
+/**
+ * Builder for {@link ColumnValueBinding} instances
+ *
+ * @author Steve Ebersole
+ */
+public class ColumnValueBindingBuilder {
+
+	/**
+	 * rexgex used to split the write-expressions into chunks of (1) quoted strings and (2) everything else.
+	 */
+	private static final String SPLIT_REGEX = "[^\\s\"']+|\"([^\"]*)\"|'([^']*)'";
+	private static final Pattern SPLIT_PATTERN = Pattern.compile( SPLIT_REGEX );
+
+
+	public static ColumnValueBinding createValueBinding(
+			String columnName,
+			String writeExpression,
+			JdbcMapping jdbcMapping,
+			MutatingTableReference mutatingTableReference,
+			ParameterUsage parameterUsage,
+			Consumer<Object> parameterConsumer) {
+		final ColumnReference columnReference = new ColumnReference( mutatingTableReference, columnName, jdbcMapping );
+		final ColumnWriteFragment columnWriteFragment = buildWriteFragment(
+				writeExpression,
+				jdbcMapping,
+				mutatingTableReference,
+				columnReference,
+				parameterUsage,
+				parameterConsumer
+		);
+		return new ColumnValueBinding( columnReference, columnWriteFragment ) ;
+	}
+
+	public static ColumnWriteFragment buildWriteFragment(
+			String writeExpression,
+			JdbcMapping jdbcMapping,
+			MutatingTableReference mutatingTableReference,
+			ColumnReference columnReference,
+			ParameterUsage parameterUsage,
+			Consumer<Object> parameterConsumer) {
+		if ( writeExpression == null ) {
+			return null;
+		}
+
+		if ( writeExpression.equals( "?" )
+				|| ( writeExpression.contains( "?" ) && !writeExpression.contains( "'" ) ) ) {
+			return buildParameterizedWriteFragment( writeExpression, jdbcMapping, mutatingTableReference, columnReference, parameterUsage, parameterConsumer );
+		}
+
+		if ( !writeExpression.contains( "?" ) ) {
+			return new ColumnWriteFragment( writeExpression, jdbcMapping );
+		}
+
+		if ( containsParameter( writeExpression ) ) {
+			return buildParameterizedWriteFragment( writeExpression, jdbcMapping, mutatingTableReference, columnReference, parameterUsage, parameterConsumer );
+		}
+
+		return new ColumnWriteFragment( writeExpression, jdbcMapping );
+	}
+
+	private static ColumnWriteFragment buildParameterizedWriteFragment(
+			String writeExpression,
+			JdbcMapping jdbcMapping,
+			MutatingTableReference mutatingTableReference,
+			ColumnReference columnReference,
+			ParameterUsage parameterUsage,
+			Consumer<Object> parameterConsumer) {
+		final JdbcType jdbcType = jdbcMapping.getJdbcType();
+		final EmbeddableMappingType aggregateMappingType = jdbcType instanceof AggregateJdbcType
+				? ( (AggregateJdbcType) jdbcType ).getEmbeddableMappingType()
+				: null;
+		if ( aggregateMappingType != null && !aggregateMappingType.shouldBindAggregateMapping() ) {
+			final ColumnValueParameterList parameters = new ColumnValueParameterList(
+					mutatingTableReference,
+					parameterUsage,
+					aggregateMappingType.getJdbcTypeCount()
+			);
+			aggregateMappingType.forEachSelectable( parameters );
+			parameterConsumer.accept( parameters );
+
+			return new ColumnWriteFragment( writeExpression, parameters, jdbcMapping );
+		}
+		else {
+			final ColumnValueParameter parameter = new ColumnValueParameter( columnReference, parameterUsage );
+			parameterConsumer.accept( parameter );
+			return new ColumnWriteFragment( writeExpression, parameter, jdbcMapping );
+		}
+	}
+
+	private static boolean containsParameter(String writeExpression) {
+		final Matcher matcher = SPLIT_PATTERN.matcher( writeExpression );
+		while ( matcher.find() ) {
+			final String group = matcher.group();
+			if ( group.startsWith( "'" ) && group.endsWith( "'" ) ) {
+				continue;
+			}
+
+			if ( group.contains( "?" ) ) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/onetomany/OrderByTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/onetomany/OrderByTest.java
@@ -297,7 +297,7 @@ public class OrderByTest extends BaseCoreFunctionalTestCase {
 		
 		try {
 			final QueryableCollection queryableCollection = (QueryableCollection) transactionsPersister;
-			SimpleSelect select = new SimpleSelect( sessionFactory().getJdbcServices().getDialect() )
+			SimpleSelect select = new SimpleSelect( sessionFactory() )
 					.setTableName( queryableCollection.getTableName() )
 					.addColumn( "code" )
 					.addColumn( "transactions_index" );

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/batch/BatchAndClassIdAndLazyCollectionTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/batch/BatchAndClassIdAndLazyCollectionTest.java
@@ -8,12 +8,15 @@ import java.util.Set;
 
 import org.hibernate.Hibernate;
 import org.hibernate.annotations.BatchSize;
+import org.hibernate.cfg.AvailableSettings;
 
 import org.hibernate.testing.TestForIssue;
 import org.hibernate.testing.jdbc.SQLStatementInspector;
 import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.ServiceRegistry;
 import org.hibernate.testing.orm.junit.SessionFactory;
 import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.hibernate.testing.orm.junit.Setting;
 
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -32,6 +35,11 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
+@ServiceRegistry(
+		settings = {
+				@Setting( name = AvailableSettings.DIALECT_NATIVE_PARAM_MARKERS, value = "false" )
+		}
+)
 @DomainModel(
 		annotatedClasses = {
 				BatchAndClassIdAndLazyCollectionTest.Child.class,

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/batch/BatchAndClassIdTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/batch/BatchAndClassIdTest.java
@@ -8,12 +8,15 @@ import java.util.Set;
 
 import org.hibernate.Hibernate;
 import org.hibernate.annotations.BatchSize;
+import org.hibernate.cfg.AvailableSettings;
 
 import org.hibernate.testing.TestForIssue;
 import org.hibernate.testing.jdbc.SQLStatementInspector;
 import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.ServiceRegistry;
 import org.hibernate.testing.orm.junit.SessionFactory;
 import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.hibernate.testing.orm.junit.Setting;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
@@ -31,6 +34,11 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
+@ServiceRegistry(
+		settings = {
+				@Setting( name = AvailableSettings.DIALECT_NATIVE_PARAM_MARKERS, value = "false" )
+		}
+)
 @DomainModel(
 		annotatedClasses = {
 				BatchAndClassIdTest.Child.class,

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/batch/BatchAndEmbeddedIdId2Test.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/batch/BatchAndEmbeddedIdId2Test.java
@@ -8,12 +8,15 @@ import java.util.Set;
 
 import org.hibernate.Hibernate;
 import org.hibernate.annotations.BatchSize;
+import org.hibernate.cfg.AvailableSettings;
 
 import org.hibernate.testing.TestForIssue;
 import org.hibernate.testing.jdbc.SQLStatementInspector;
 import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.ServiceRegistry;
 import org.hibernate.testing.orm.junit.SessionFactory;
 import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.hibernate.testing.orm.junit.Setting;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
@@ -32,6 +35,11 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
+@ServiceRegistry(
+		settings = {
+				@Setting( name = AvailableSettings.DIALECT_NATIVE_PARAM_MARKERS, value = "false" )
+		}
+)
 @DomainModel(
 		annotatedClasses = {
 				BatchAndEmbeddedIdId2Test.Child.class,

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/batch/BatchAndEmbeddedIdIdAndLazyCollectionTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/batch/BatchAndEmbeddedIdIdAndLazyCollectionTest.java
@@ -9,12 +9,15 @@ import java.util.Set;
 import org.hibernate.DuplicateMappingException;
 import org.hibernate.Hibernate;
 import org.hibernate.annotations.BatchSize;
+import org.hibernate.cfg.AvailableSettings;
 
 import org.hibernate.testing.TestForIssue;
 import org.hibernate.testing.jdbc.SQLStatementInspector;
 import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.ServiceRegistry;
 import org.hibernate.testing.orm.junit.SessionFactory;
 import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.hibernate.testing.orm.junit.Setting;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
@@ -34,6 +37,11 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
+@ServiceRegistry(
+		settings = {
+				@Setting( name = AvailableSettings.DIALECT_NATIVE_PARAM_MARKERS, value = "false" )
+		}
+)
 @DomainModel(
 		annotatedClasses = {
 				BatchAndEmbeddedIdIdAndLazyCollectionTest.Child.class,

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/batch/BatchAndEmbeddedIdIdTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/batch/BatchAndEmbeddedIdIdTest.java
@@ -8,12 +8,15 @@ import java.util.Set;
 
 import org.hibernate.Hibernate;
 import org.hibernate.annotations.BatchSize;
+import org.hibernate.cfg.AvailableSettings;
 
 import org.hibernate.testing.TestForIssue;
 import org.hibernate.testing.jdbc.SQLStatementInspector;
 import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.ServiceRegistry;
 import org.hibernate.testing.orm.junit.SessionFactory;
 import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.hibernate.testing.orm.junit.Setting;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
@@ -32,6 +35,11 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
+@ServiceRegistry(
+		settings = {
+				@Setting( name = AvailableSettings.DIALECT_NATIVE_PARAM_MARKERS, value = "false" )
+		}
+)
 @DomainModel(
 		annotatedClasses = {
 				BatchAndEmbeddedIdIdTest.Child.class,

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/batch/BatchOptimisticLockingTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/batch/BatchOptimisticLockingTest.java
@@ -48,6 +48,7 @@ public class BatchOptimisticLockingTest extends
 	@Override
 	protected void addSettings(Map<String,Object> settings) {
 		settings.put( AvailableSettings.STATEMENT_BATCH_SIZE, String.valueOf( 2 ) );
+		settings.put( AvailableSettings.DIALECT_NATIVE_PARAM_MARKERS, Boolean.FALSE );
 	}
 
 	@Test

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/collection/list/PersistentListTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/collection/list/PersistentListTest.java
@@ -72,11 +72,11 @@ public class PersistentListTest {
 					session2.doWork(
 							connection -> {
 								final QueryableCollection queryableCollection = (QueryableCollection) collectionPersister;
-								SimpleSelect select = new SimpleSelect( sessionFactory.getJdbcServices().getDialect() )
+								SimpleSelect select = new SimpleSelect( sessionFactory )
 										.setTableName( queryableCollection.getTableName() )
 										.addColumn( "NAME" )
 										.addColumn( "LIST_INDEX" )
-										.addCondition( "NAME", "<>", "?" );
+										.addRestriction( "NAME", "<>", "?" );
 								PreparedStatement preparedStatement = ( (SessionImplementor) session2 ).getJdbcCoordinator()
 										.getStatementPreparer()
 										.prepareStatement( select.toStatementString() );
@@ -133,7 +133,7 @@ public class PersistentListTest {
 					session2.doWork(
 							connection -> {
 								final QueryableCollection queryableCollection = (QueryableCollection) collectionPersister;
-								SimpleSelect select = new SimpleSelect( sessionFactory.getJdbcServices().getDialect() )
+								SimpleSelect select = new SimpleSelect( sessionFactory )
 										.setTableName( queryableCollection.getTableName() )
 										.addColumn( "order_id" )
 										.addColumn( "INDX" )

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/insertordering/BaseInsertOrderingTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/insertordering/BaseInsertOrderingTest.java
@@ -48,6 +48,7 @@ abstract class BaseInsertOrderingTest extends BaseSessionFactoryFunctionalTest {
 				.get( AvailableSettings.CONNECTION_PROVIDER );
 		this.connectionProvider.setConnectionProvider( connectionProvider );
 		builer.applySetting( AvailableSettings.CONNECTION_PROVIDER, this.connectionProvider );
+		builer.applySetting( AvailableSettings.DIALECT_NATIVE_PARAM_MARKERS, false );
 		builer.applySetting( AvailableSettings.DEFAULT_LIST_SEMANTICS, CollectionClassification.BAG );
 	}
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/jdbc/internal/SessionJdbcBatchTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/jdbc/internal/SessionJdbcBatchTest.java
@@ -38,6 +38,7 @@ public class SessionJdbcBatchTest
 	@Override
 	protected void addSettings(Map<String,Object> settings) {
 		settings.put( AvailableSettings.STATEMENT_BATCH_SIZE, 2 );
+		settings.put( AvailableSettings.DIALECT_NATIVE_PARAM_MARKERS, Boolean.FALSE );
 		connectionProvider.setConnectionProvider( (ConnectionProvider) settings.get( AvailableSettings.CONNECTION_PROVIDER ) );
 		settings.put(
 				AvailableSettings.CONNECTION_PROVIDER,

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/criteria/literal/AbstractCriteriaLiteralHandlingModeTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/criteria/literal/AbstractCriteriaLiteralHandlingModeTest.java
@@ -14,6 +14,7 @@ import jakarta.persistence.Tuple;
 import jakarta.persistence.criteria.CriteriaQuery;
 import jakarta.persistence.criteria.Root;
 
+import org.hibernate.cfg.AvailableSettings;
 import org.hibernate.orm.test.jpa.BaseEntityManagerFunctionalTestCase;
 import org.hibernate.query.sqm.CastType;
 import org.hibernate.query.criteria.HibernateCriteriaBuilder;
@@ -40,6 +41,7 @@ public abstract class AbstractCriteriaLiteralHandlingModeTest extends BaseEntity
 	@Override
 	protected void addConfigOptions(Map options) {
 		sqlStatementInterceptor = new SQLStatementInterceptor( options );
+		options.put( AvailableSettings.DIALECT_NATIVE_PARAM_MARKERS, Boolean.FALSE );
 	}
 
 	@Override

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/criteria/nulliteral/CriteriaLiteralsTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/criteria/nulliteral/CriteriaLiteralsTest.java
@@ -23,6 +23,7 @@ import jakarta.persistence.criteria.CriteriaQuery;
 import jakarta.persistence.criteria.ListJoin;
 import jakarta.persistence.criteria.Root;
 
+import org.hibernate.cfg.AvailableSettings;
 import org.hibernate.dialect.H2Dialect;
 import org.hibernate.exception.SQLGrammarException;
 import org.hibernate.orm.test.jpa.BaseEntityManagerFunctionalTestCase;
@@ -32,6 +33,7 @@ import org.hibernate.testing.jdbc.SQLStatementInterceptor;
 import org.junit.Before;
 import org.junit.Test;
 
+import static java.lang.Boolean.FALSE;
 import static org.hibernate.testing.transaction.TransactionUtil.doInJPA;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -49,6 +51,7 @@ public class CriteriaLiteralsTest extends BaseEntityManagerFunctionalTestCase {
 	@Override
 	protected void addConfigOptions(Map options) {
 		sqlStatementInterceptor = new SQLStatementInterceptor( options );
+		options.put( AvailableSettings.DIALECT_NATIVE_PARAM_MARKERS, FALSE );
 	}
 
 	@Override

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/query/NamedQueryCommentTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/query/NamedQueryCommentTest.java
@@ -41,7 +41,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 @Jpa(
 		annotatedClasses = { NamedQueryCommentTest.Game.class },
 		integrationSettings = {
-				@Setting( name = AvailableSettings.USE_SQL_COMMENTS, value = "true" )
+				@Setting( name = AvailableSettings.USE_SQL_COMMENTS, value = "true" ),
+				@Setting( name = AvailableSettings.DIALECT_NATIVE_PARAM_MARKERS, value = "false" )
 		},
 		useCollectingStatementInspector = true
 )

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/query/InClauseParameterPaddingCriteriaTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/query/InClauseParameterPaddingCriteriaTest.java
@@ -39,6 +39,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 		integrationSettings = {
 				@Setting(name = AvailableSettings.USE_SQL_COMMENTS, value = "true"),
 				@Setting(name = AvailableSettings.IN_CLAUSE_PARAMETER_PADDING, value = "true"),
+				@Setting(name = AvailableSettings.DIALECT_NATIVE_PARAM_MARKERS, value = "false"),
 		},
 		useCollectingStatementInspector = true
 )

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/query/InClauseParameterPaddingTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/query/InClauseParameterPaddingTest.java
@@ -32,7 +32,8 @@ import static org.junit.Assert.assertTrue;
 		annotatedClasses = { InClauseParameterPaddingTest.Person.class },
 		integrationSettings = {
 				@Setting(name = AvailableSettings.USE_SQL_COMMENTS, value = "true"),
-				@Setting(name = AvailableSettings.IN_CLAUSE_PARAMETER_PADDING, value = "true")
+				@Setting(name = AvailableSettings.IN_CLAUSE_PARAMETER_PADDING, value = "true"),
+				@Setting(name = AvailableSettings.DIALECT_NATIVE_PARAM_MARKERS, value = "false")
 		},
 		useCollectingStatementInspector = true
 )

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/query/MaxInExpressionParameterPaddingTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/query/MaxInExpressionParameterPaddingTest.java
@@ -37,6 +37,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 		integrationSettings = {
 				@Setting(name = AvailableSettings.USE_SQL_COMMENTS, value = "true"),
 				@Setting(name = AvailableSettings.IN_CLAUSE_PARAMETER_PADDING, value = "true"),
+				@Setting(name = AvailableSettings.DIALECT_NATIVE_PARAM_MARKERS, value = "false"),
 		},
 		settingProviders ={
 				@SettingProvider(

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/sql/ast/JdbcParameterRendererTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/sql/ast/JdbcParameterRendererTests.java
@@ -6,6 +6,9 @@
  */
 package org.hibernate.orm.test.sql.ast;
 
+import org.hibernate.annotations.Filter;
+import org.hibernate.annotations.FilterDef;
+import org.hibernate.annotations.ParamDef;
 import org.hibernate.dialect.Dialect;
 import org.hibernate.dialect.H2Dialect;
 import org.hibernate.sql.ast.spi.JdbcParameterRenderer;
@@ -21,6 +24,12 @@ import org.hibernate.testing.orm.junit.SessionFactory;
 import org.hibernate.testing.orm.junit.SessionFactoryScope;
 import org.junit.jupiter.api.Test;
 
+import jakarta.persistence.Basic;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
@@ -33,7 +42,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 		role = JdbcParameterRenderer.class,
 		impl = JdbcParameterRendererTests.JdbcParameterRendererImpl.class
 ) )
-@DomainModel( annotatedClasses = EntityOfBasics.class )
+@DomainModel( annotatedClasses = { EntityOfBasics.class, JdbcParameterRendererTests.EntityWithFilters.class } )
 @SessionFactory( useCollectingStatementInspector = true )
 @RequiresDialect( H2Dialect.class )
 public class JdbcParameterRendererTests {
@@ -52,11 +61,71 @@ public class JdbcParameterRendererTests {
 		final String sql = statementInspector.getSqlQueries().get( 0 );
 		assertThat( sql ).contains( "?1" );
 	}
+	@Test
+	public void testFilters(SessionFactoryScope scope) {
+		final SQLStatementInspector statementInspector = scope.getCollectingStatementInspector();
+		statementInspector.clear();
+
+		scope.inTransaction( (session) -> {
+			session.enableFilter( "region" ).setParameter( "region", "NA" );
+			session.createSelectionQuery( "from EntityWithFilters", EntityWithFilters.class ).list();
+			assertThat( statementInspector.getSqlQueries() ).hasSize( 1 );
+			final String sql = statementInspector.getSqlQueries().get( 0 );
+			assertThat( sql ).contains( "?1" );
+		} );
+	}
 
 	public static class JdbcParameterRendererImpl implements JdbcParameterRenderer {
 		@Override
 		public void renderJdbcParameter(int position, JdbcType jdbcType, SqlAppender appender, Dialect dialect) {
 			jdbcType.appendWriteExpression( "?" + position, appender, dialect );
+		}
+	}
+
+	@Entity( name = "EntityWithFilters" )
+	@Table( name = "filtered_entity" )
+	@FilterDef(
+			name = "region",
+			defaultCondition = "region = :region",
+			parameters = @ParamDef(name = "region", type = String.class)
+	)
+	@Filter( name = "region" )
+	public static class EntityWithFilters {
+	    @Id
+	    private Integer id;
+	    @Basic
+		private String name;
+		@Basic
+		private String region;
+
+		protected EntityWithFilters() {
+			// for use by Hibernate
+		}
+
+		public EntityWithFilters(Integer id, String name, String region) {
+			this.id = id;
+			this.name = name;
+			this.region = region;
+		}
+
+		public Integer getId() {
+			return id;
+		}
+
+		public String getName() {
+			return name;
+		}
+
+		public void setName(String name) {
+			this.name = name;
+		}
+
+		public String getRegion() {
+			return region;
+		}
+
+		public void setRegion(String region) {
+			this.region = region;
 		}
 	}
 }

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/sql/ast/JdbcParameterRendererTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/sql/ast/JdbcParameterRendererTests.java
@@ -109,8 +109,8 @@ public class JdbcParameterRendererTests {
 
 	public static class JdbcParameterRendererImpl implements JdbcParameterRenderer {
 		@Override
-		public void renderJdbcParameter(int position, JdbcType jdbcType, SqlAppender appender, Dialect dialect) {
-			jdbcType.appendWriteExpression( "?" + position, appender, dialect );
+		public String renderJdbcParameter(int position, JdbcType jdbcType) {
+			return "?" + position;
 		}
 	}
 

--- a/hibernate-spatial/src/test/resources/hibernate.properties
+++ b/hibernate-spatial/src/test/resources/hibernate.properties
@@ -17,6 +17,10 @@ hibernate.connection.pool_size 5
 hibernate.show_sql false
 hibernate.format_sql true
 
+# the tests use a lot of regex pattern matching for test assertions
+# and the different parameter markers cause problems with that
+hibernate.dialect.native_param_markers=false
+
 hibernate.max_fetch_depth 5
 
 hibernate.cache.region_prefix hibernate.test


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-16260

Includes general improvements to filter handing.  Drops the need for separate "filter parameter" tracking.

Part of that change was to push a not strictly "clean" representation into the SQL AST.  Mainly it delays processing parameters until we are in the `SqlAstTranslator` so it can apply the renderer.  Its also what facilitates the improved parameter handling.