### PR TITLE
HHH-16279 Hibernate ORM with hibernate.hbm2ddl.import_files_sql_extractor = multi-line fails to process import.sql containing 

### DIFF
--- a/hibernate-core/src/main/antlr/org/hibernate/grammars/importsql/SqlScriptParser.g4
+++ b/hibernate-core/src/main/antlr/org/hibernate/grammars/importsql/SqlScriptParser.g4
@@ -15,7 +15,7 @@ package org.hibernate.grammars.importsql;
 }
 
 script
-	: (NEWLINE | SPACE | TAB)* ( commandBlock (NEWLINE | SPACE | TAB)* )+ EOF
+	: (NEWLINE | SPACE | TAB)* ( commandBlock (NEWLINE | SPACE | TAB)* )* EOF
 	;
 
 commandBlock

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/tool/schema/scripts/MultiLineImportExtractorTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/tool/schema/scripts/MultiLineImportExtractorTest.java
@@ -14,6 +14,7 @@ import java.util.List;
 
 import org.hibernate.tool.schema.internal.script.MultiLineSqlScriptExtractor;
 
+import org.hibernate.testing.TestForIssue;
 import org.hibernate.testing.orm.junit.DialectContext;
 import org.junit.Test;
 
@@ -29,6 +30,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
  */
 public class MultiLineImportExtractorTest {
 	public static final String IMPORT_FILE = "org/hibernate/orm/test/tool/schema/scripts/multi-line-statements2.sql";
+	public static final String IMPORT_FILE_COMMENTS_ONLY = "org/hibernate/orm/test/tool/schema/scripts/comments-only.sql";
 
 	private final MultiLineSqlScriptExtractor extractor = new MultiLineSqlScriptExtractor();
 
@@ -36,9 +38,9 @@ public class MultiLineImportExtractorTest {
 	public void testExtraction() throws IOException {
 		final ClassLoader classLoader = ClassLoader.getSystemClassLoader();
 
-		try (final InputStream stream = classLoader.getResourceAsStream( IMPORT_FILE )) {
+		try ( final InputStream stream = classLoader.getResourceAsStream( IMPORT_FILE ) ) {
 			assertThat( stream, notNullValue() );
-			try (final InputStreamReader reader = new InputStreamReader( stream )) {
+			try ( final InputStreamReader reader = new InputStreamReader( stream ) ) {
 				final List<String> commands = extractor.extractCommands( reader, DialectContext.getDialect() );
 				assertThat( commands, notNullValue() );
 				assertThat( commands.size(), is( 6 ) );
@@ -55,7 +57,10 @@ public class MultiLineImportExtractorTest {
 				assertThat( commands.get( 4 ), startsWith( "INSERT INTO test_data VALUES (3" ) );
 				assertThat( commands.get( 4 ), not( containsString( "third record" ) ) );
 
-				assertThat( commands.get( 5 ).replace( "\t", "" ), is( "INSERT INTO test_data VALUES (     4       , NULL     )" ) );
+				assertThat(
+						commands.get( 5 ).replace( "\t", "" ),
+						is( "INSERT INTO test_data VALUES (     4       , NULL     )" )
+				);
 			}
 		}
 	}
@@ -66,5 +71,20 @@ public class MultiLineImportExtractorTest {
 		final List<String> commands = extractor.extractCommands( reader, DialectContext.getDialect() );
 		assertThat( commands, notNullValue() );
 		assertThat( commands.size(), is( 0 ) );
+	}
+
+	@Test
+	@TestForIssue(jiraKey = "HHH-16279")
+	public void testExtractionFromCommentsOnlyScript() throws IOException {
+		final ClassLoader classLoader = ClassLoader.getSystemClassLoader();
+
+		try ( final InputStream stream = classLoader.getResourceAsStream( IMPORT_FILE_COMMENTS_ONLY ) ) {
+			assertThat( stream, notNullValue() );
+			try ( final InputStreamReader reader = new InputStreamReader( stream ) ) {
+				final List<String> commands = extractor.extractCommands( reader, DialectContext.getDialect() );
+				assertThat( commands, notNullValue() );
+				assertThat( commands.size(), is( 0 ) );
+			}
+		}
 	}
 }

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/tool/schema/scripts/SingleLineImportExtractorTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/tool/schema/scripts/SingleLineImportExtractorTest.java
@@ -1,0 +1,53 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.orm.test.tool.schema.scripts;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.StringReader;
+import java.util.List;
+
+import org.hibernate.tool.schema.internal.script.SingleLineSqlScriptExtractor;
+
+import org.hibernate.testing.TestForIssue;
+import org.hibernate.testing.orm.junit.DialectContext;
+import org.junit.Test;
+
+public class SingleLineImportExtractorTest {
+	public static final String IMPORT_FILE_COMMENTS_ONLY = "org/hibernate/orm/test/tool/schema/scripts/comments-only.sql";
+
+	private final SingleLineSqlScriptExtractor extractor = new SingleLineSqlScriptExtractor();
+
+	@Test
+	public void testExtractionFromEmptyScript() {
+		StringReader reader = new StringReader( "" );
+		final List<String> commands = extractor.extractCommands( reader, DialectContext.getDialect() );
+		assertThat( commands, notNullValue() );
+		assertThat( commands.size(), is( 0 ) );
+	}
+
+	@Test
+	@TestForIssue(jiraKey = "HHH-16279")
+	// Note this worked from the start as HHH-16279 only affects the multi-line extractor
+	public void testExtractionFromCommentsOnlyScript() throws IOException {
+		final ClassLoader classLoader = ClassLoader.getSystemClassLoader();
+
+		try ( final InputStream stream = classLoader.getResourceAsStream( IMPORT_FILE_COMMENTS_ONLY ) ) {
+			assertThat( stream, notNullValue() );
+			try ( final InputStreamReader reader = new InputStreamReader( stream ) ) {
+				final List<String> commands = extractor.extractCommands( reader, DialectContext.getDialect() );
+				assertThat( commands, notNullValue() );
+				assertThat( commands.size(), is( 0 ) );
+			}
+		}
+	}
+}

--- a/hibernate-core/src/test/resources/org/hibernate/orm/test/tool/schema/scripts/comments-only.sql
+++ b/hibernate-core/src/test/resources/org/hibernate/orm/test/tool/schema/scripts/comments-only.sql
@@ -1,0 +1,5 @@
+-- This file allow to write SQL commands that will be emitted in test and dev.
+-- The commands are commented as their support depends of the database
+-- insert into myentity (id, field) values(nextval('hibernate_sequence'), 'field-1');
+-- insert into myentity (id, field) values(nextval('hibernate_sequence'), 'field-2');
+-- insert into myentity (id, field) values(nextval('hibernate_sequence'), 'field-3');


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-16279

The patch seems to make sense, though I wouldn't be able to tell you why the parser was fine with an empty file before... There's probably some early check that's not part of the grammar.