### PR TITLE
HHH-16125 POC

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/boot/model/relational/NamedAuxiliaryDatabaseObject.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/relational/NamedAuxiliaryDatabaseObject.java
@@ -28,6 +28,17 @@ public class NamedAuxiliaryDatabaseObject
 		this.name = name;
 	}
 
+	public NamedAuxiliaryDatabaseObject(
+			String name,
+			Namespace namespace,
+			String createString,
+			String dropString,
+			Set<String> dialectScopes,
+			boolean beforeTables) {
+		super( namespace, createString, dropString, dialectScopes, beforeTables );
+		this.name = name;
+	}
+
 	@Override
 	public String getExportIdentifier() {
 		return new QualifiedNameImpl(

--- a/hibernate-core/src/main/java/org/hibernate/boot/model/relational/SimpleAuxiliaryDatabaseObject.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/relational/SimpleAuxiliaryDatabaseObject.java
@@ -30,6 +30,41 @@ public class SimpleAuxiliaryDatabaseObject extends AbstractAuxiliaryDatabaseObje
 	private final String[] createStrings;
 	private final String[] dropStrings;
 
+	private static String extractName(Identifier identifier) {
+		return identifier == null ? null : identifier.getText();
+	}
+
+	public SimpleAuxiliaryDatabaseObject(
+			Namespace namespace,
+			String createString,
+			String dropString,
+			Set<String> dialectScopes,
+			boolean beforeTables) {
+		this(
+				namespace,
+				new String[] { createString },
+				new String[] { dropString },
+				dialectScopes,
+				beforeTables
+		);
+	}
+
+	public SimpleAuxiliaryDatabaseObject(
+			Namespace namespace,
+			String[] createStrings,
+			String[] dropStrings,
+			Set<String> dialectScopes,
+			boolean beforeTables) {
+		this(
+				dialectScopes,
+				extractName( namespace.getPhysicalName().getCatalog() ),
+				extractName( namespace.getPhysicalName().getSchema() ),
+				createStrings,
+				dropStrings,
+				beforeTables
+		);
+	}
+
 	public SimpleAuxiliaryDatabaseObject(
 			Namespace namespace,
 			String createString,
@@ -57,8 +92,19 @@ public class SimpleAuxiliaryDatabaseObject extends AbstractAuxiliaryDatabaseObje
 		);
 	}
 
-	private static String extractName(Identifier identifier) {
-		return identifier == null ? null : identifier.getText();
+
+	public SimpleAuxiliaryDatabaseObject(
+			Set<String> dialectScopes,
+			String catalogName,
+			String schemaName,
+			String[] createStrings,
+			String[] dropStrings,
+			boolean beforeTables) {
+		super( beforeTables, dialectScopes );
+		this.catalogName = catalogName;
+		this.schemaName = schemaName;
+		this.createStrings = createStrings;
+		this.dropStrings = dropStrings;
 	}
 
 	public SimpleAuxiliaryDatabaseObject(

--- a/hibernate-core/src/main/java/org/hibernate/dialect/Dialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/Dialect.java
@@ -742,6 +742,15 @@ public abstract class Dialect implements ConversionContext, TypeContributor, Fun
 	}
 
 	/**
+	 * Does this database support PostgreSQL-style named {@code enum} types,
+	 * that is, does it support the syntax {@code create type ... as enum .... }.
+	 */
+	@Incubating
+	public boolean hasNamedEnumTypes() {
+		return false;
+	}
+
+	/**
 	 * Render a SQL check condition for a column that represents an enumerated value
 	 * by its {@linkplain jakarta.persistence.EnumType#STRING string representation}.
 	 *

--- a/hibernate-core/src/main/java/org/hibernate/dialect/MySQLDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/MySQLDialect.java
@@ -72,7 +72,6 @@ import org.hibernate.type.SqlTypes;
 import org.hibernate.type.StandardBasicTypes;
 import org.hibernate.type.descriptor.java.JavaType;
 import org.hibernate.type.descriptor.jdbc.JdbcType;
-import org.hibernate.type.descriptor.jdbc.JsonJdbcType;
 import org.hibernate.type.descriptor.jdbc.NullJdbcType;
 import org.hibernate.type.descriptor.jdbc.spi.JdbcTypeRegistry;
 import org.hibernate.type.descriptor.sql.internal.CapacityDependentDdlType;
@@ -113,7 +112,6 @@ import static org.hibernate.type.descriptor.DateTimeUtils.appendAsDate;
 import static org.hibernate.type.descriptor.DateTimeUtils.appendAsLocalTime;
 import static org.hibernate.type.descriptor.DateTimeUtils.appendAsTimestampWithMicros;
 import static org.hibernate.type.descriptor.DateTimeUtils.appendAsTimestampWithMillis;
-import static org.hibernate.type.descriptor.DateTimeUtils.appendAsTimestampWithNanos;
 
 /**
  * A {@linkplain Dialect SQL dialect} for MySQL 5.7 and above.

--- a/hibernate-core/src/main/java/org/hibernate/dialect/PostgreSQLDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/PostgreSQLDialect.java
@@ -378,6 +378,29 @@ public class PostgreSQLDialect extends Dialect {
 	}
 
 	@Override
+	public String getEnumTypeDeclaration(String[] values) {
+		StringBuilder type = new StringBuilder();
+		type.append( "enum (" );
+		String separator = "";
+		for ( String value : values ) {
+			type.append( separator ).append('\'').append( value ).append('\'');
+			separator = ",";
+		}
+		return type.append( ')' ).toString();
+	}
+
+	@Override
+	public String getCheckCondition(String columnName, String[] values) {
+		//not needed, because we use an 'enum' type
+		return null;
+	}
+
+	@Override
+	public boolean hasNamedEnumTypes() {
+		return true;
+	}
+
+	@Override
 	public String currentTime() {
 		return "localtime";
 	}

--- a/hibernate-core/src/main/java/org/hibernate/mapping/BasicValue.java
+++ b/hibernate-core/src/main/java/org/hibernate/mapping/BasicValue.java
@@ -26,6 +26,8 @@ import org.hibernate.boot.model.process.internal.NamedBasicTypeResolution;
 import org.hibernate.boot.model.process.internal.NamedConverterResolution;
 import org.hibernate.boot.model.process.internal.UserTypeResolution;
 import org.hibernate.boot.model.process.internal.VersionResolution;
+import org.hibernate.boot.model.relational.AuxiliaryDatabaseObject;
+import org.hibernate.boot.model.relational.Database;
 import org.hibernate.boot.registry.StandardServiceRegistry;
 import org.hibernate.boot.registry.classloading.spi.ClassLoaderService;
 import org.hibernate.boot.registry.classloading.spi.ClassLoadingException;
@@ -314,6 +316,19 @@ public class BasicValue extends SimpleValue implements JdbcTypeIndicators, Resol
 		final Selectable selectable = getColumn();
 		if ( selectable instanceof Column ) {
 			resolveColumn( (Column) selectable, getDialect() );
+		}
+
+		Database database = getBuildingContext().getMetadataCollector().getDatabase();
+		BasicValueConverter<?, ?> valueConverter = resolution.getValueConverter();
+		if ( valueConverter != null ) {
+			AuxiliaryDatabaseObject udt = valueConverter.getAuxiliaryDatabaseObject(
+					resolution.getJdbcType(),
+					database.getDialect(),
+					database.getDefaultNamespace()
+			);
+			if ( udt != null ) {
+				database.addAuxiliaryDatabaseObject( udt );
+			}
 		}
 
 		return resolution;

--- a/hibernate-core/src/main/java/org/hibernate/tool/schema/internal/ColumnDefinitions.java
+++ b/hibernate-core/src/main/java/org/hibernate/tool/schema/internal/ColumnDefinitions.java
@@ -151,10 +151,10 @@ class ColumnDefinitions {
 			Table table,
 			Metadata metadata,
 			Dialect dialect) {
-		final String columnType = column.getSqlType(metadata);
-		if ( isIdentityColumn(column, table, metadata, dialect) ) {
+		if ( isIdentityColumn( column, table, metadata, dialect ) ) {
 			// to support dialects that have their own identity data type
 			if ( dialect.getIdentityColumnSupport().hasDataTypeInIdentityColumn() ) {
+				final String columnType = column.getSqlType( metadata );
 				definition.append( ' ' ).append( columnType );
 			}
 			final String identityColumnString = dialect.getIdentityColumnSupport()
@@ -162,11 +162,16 @@ class ColumnDefinitions {
 			definition.append( ' ' ).append( identityColumnString );
 		}
 		else {
+			final String columnType;
 			if ( column.hasSpecializedTypeDeclaration() ) {
-				definition.append( ' ' ).append( column.getSpecializedTypeDeclaration() );
-			}
-			else if ( column.getGeneratedAs() == null || dialect.hasDataTypeBeforeGeneratedAs() ) {
+				columnType = column.getSpecializedTypeDeclaration();
 				definition.append( ' ' ).append( columnType );
+			}
+			else {
+				columnType = column.getSqlType( metadata );
+				if ( column.getGeneratedAs() == null || dialect.hasDataTypeBeforeGeneratedAs() ) {
+					definition.append( ' ' ).append( columnType );
+				}
 			}
 
 			final String defaultValue = column.getDefaultValue();

--- a/hibernate-core/src/main/java/org/hibernate/type/CustomType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/CustomType.java
@@ -97,8 +97,20 @@ public class CustomType<J>
 			valueExtractor = (ValueExtractor<J>) jdbcType.getExtractor( jdbcJavaType );
 			//noinspection unchecked
 			valueBinder = (ValueBinder<J>) jdbcType.getBinder( jdbcJavaType );
-			//noinspection unchecked
-			jdbcLiteralFormatter = (JdbcLiteralFormatter<J>) jdbcType.getJdbcLiteralFormatter( jdbcJavaType );
+			if ( userType instanceof EnhancedUserType ) {
+				// because of the way QueryLiteral handling is implemented in the
+				// BaseSqmToSqlAstConverter.visitEnumLiteral(), we can't just use
+				// jdbcType.getJdbcLiteralFormatter( mappedJavaType ) here, since
+				// we need to un-convert the value back to the enum type
+				// TODO: sort this out!
+				EnhancedUserType enhancedUserType = (EnhancedUserType) userType;
+				jdbcLiteralFormatter = (appender, value, dialect, wrapperOptions)
+						-> appender.appendSql( enhancedUserType.toSqlLiteral( convertToDomainValue( value ) ) );
+			}
+			else {
+				//noinspection unchecked
+				jdbcLiteralFormatter = (JdbcLiteralFormatter<J>) jdbcType.getJdbcLiteralFormatter( jdbcJavaType );
+			}
 		}
 		else {
 			// create a JdbcType adapter that uses the UserType binder/extract handling

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/converter/internal/NamedEnumValueConverter.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/converter/internal/NamedEnumValueConverter.java
@@ -7,7 +7,6 @@
 package org.hibernate.type.descriptor.converter.internal;
 
 import java.io.Serializable;
-import java.util.Locale;
 
 import org.hibernate.dialect.Dialect;
 import org.hibernate.type.descriptor.converter.spi.EnumValueConverter;
@@ -19,8 +18,9 @@ import static java.util.Arrays.sort;
 import static org.hibernate.type.descriptor.converter.internal.EnumHelper.getEnumeratedValues;
 
 /**
- * BasicValueConverter handling the conversion of an enum based on
- * JPA {@link jakarta.persistence.EnumType#STRING} strategy (storing the name)
+ * {@link org.hibernate.type.descriptor.converter.spi.BasicValueConverter} handling the
+ * conversion of an enum according to the JPA-defined {@link jakarta.persistence.EnumType#STRING}
+ * strategy (storing the name)
  *
  * @author Steve Ebersole
  */
@@ -65,8 +65,7 @@ public class NamedEnumValueConverter<E extends Enum<E>> implements EnumValueConv
 
 	@Override
 	public String toSqlLiteral(Object value) {
-		//noinspection rawtypes
-		return String.format( Locale.ROOT, "'%s'", ( (Enum) value ).name() );
+		return "'" + ( (Enum) value ).name() + "'";
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/converter/internal/ObjectEnumValueConverter.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/converter/internal/ObjectEnumValueConverter.java
@@ -1,0 +1,94 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html
+ */
+package org.hibernate.type.descriptor.converter.internal;
+
+import org.hibernate.boot.model.relational.AuxiliaryDatabaseObject;
+import org.hibernate.boot.model.relational.NamedAuxiliaryDatabaseObject;
+import org.hibernate.boot.model.relational.Namespace;
+import org.hibernate.dialect.Dialect;
+import org.hibernate.type.descriptor.converter.spi.EnumValueConverter;
+import org.hibernate.type.descriptor.java.EnumJavaType;
+import org.hibernate.type.descriptor.java.JavaType;
+import org.hibernate.type.descriptor.jdbc.JdbcType;
+
+import java.io.Serializable;
+
+import static java.util.Arrays.sort;
+import static java.util.Collections.emptySet;
+import static org.hibernate.type.descriptor.converter.internal.EnumHelper.getEnumeratedValues;
+
+/**
+ * {@link org.hibernate.type.descriptor.converter.spi.BasicValueConverter} handling the
+ * conversion of an enum to a PostgreSQL-style named {@code enum} type.
+ *
+ * @see Dialect#hasNamedEnumTypes()
+ *
+ * @author Gavin King
+ */
+public class ObjectEnumValueConverter implements EnumValueConverter, Serializable {
+	private final EnumJavaType domainTypeDescriptor;
+	private final JdbcType jdbcType;
+	private final JavaType relationalTypeDescriptor;
+
+	public ObjectEnumValueConverter(
+			EnumJavaType domainTypeDescriptor,
+			JdbcType jdbcType,
+			JavaType relationalTypeDescriptor) {
+		this.domainTypeDescriptor = domainTypeDescriptor;
+		this.jdbcType = jdbcType;
+		this.relationalTypeDescriptor = relationalTypeDescriptor;
+	}
+
+	@Override
+	public EnumJavaType getDomainJavaType() {
+		return domainTypeDescriptor;
+	}
+
+	@Override
+	public JavaType getRelationalJavaType() {
+		return relationalTypeDescriptor;
+	}
+
+	@Override
+	public Object toDomainValue(Object relationalForm) {
+		return relationalForm instanceof String
+				? domainTypeDescriptor.fromName( (String) relationalForm )
+				: relationalForm;
+	}
+
+	@Override
+	public Object toRelationalValue(Object domainForm) {
+		return domainForm;
+	}
+
+	@Override
+	public int getJdbcTypeCode() {
+		return jdbcType.getDefaultSqlTypeCode();
+	}
+
+	@Override
+	public String toSqlLiteral(Object value) {
+		return "'" + ( (Enum) value ).name() + "'";
+	}
+
+	@Override
+	public String getSpecializedTypeDeclaration(JdbcType jdbcType, Dialect dialect) {
+		return getDomainJavaType().getJavaTypeClass().getSimpleName();
+	}
+
+	@Override
+	public AuxiliaryDatabaseObject getAuxiliaryDatabaseObject(JdbcType jdbcType, Dialect dialect, Namespace defaultNamespace) {
+		Class enumClass = getDomainJavaType().getJavaTypeClass();
+		String[] values = getEnumeratedValues( enumClass );
+		sort( values ); //sort alphabetically, to guarantee alphabetical ordering in queries with 'order by'
+		String name = enumClass.getSimpleName();
+		String create = "create type " + name + " as " + dialect.getEnumTypeDeclaration( values ) +
+				"; create cast (varchar as " + name + ") with inout as implicit;";
+		String drop = "drop type " + name + " cascade";
+		return new NamedAuxiliaryDatabaseObject( name, defaultNamespace, create, drop, emptySet(), true );
+	}
+}

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/converter/internal/OrdinalEnumValueConverter.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/converter/internal/OrdinalEnumValueConverter.java
@@ -15,8 +15,9 @@ import org.hibernate.type.descriptor.java.JavaType;
 import org.hibernate.type.descriptor.jdbc.JdbcType;
 
 /**
- * BasicValueConverter handling the conversion of an enum based on
- * JPA {@link jakarta.persistence.EnumType#ORDINAL} strategy (storing the ordinal)
+ * {@link org.hibernate.type.descriptor.converter.spi.BasicValueConverter} handling the
+ * conversion of an enum according to the JPA-defined {@link jakarta.persistence.EnumType#ORDINAL}
+ * strategy (storing the ordinal)
  *
  * @author Steve Ebersole
  */

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/converter/spi/BasicValueConverter.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/converter/spi/BasicValueConverter.java
@@ -7,6 +7,8 @@
 package org.hibernate.type.descriptor.converter.spi;
 
 import org.hibernate.Incubating;
+import org.hibernate.boot.model.relational.AuxiliaryDatabaseObject;
+import org.hibernate.boot.model.relational.Namespace;
 import org.hibernate.dialect.Dialect;
 import org.hibernate.type.descriptor.java.JavaType;
 import org.hibernate.type.descriptor.jdbc.JdbcType;
@@ -66,4 +68,10 @@ public interface BasicValueConverter<D,R> {
 	default String getSpecializedTypeDeclaration(JdbcType jdbcType, Dialect dialect) {
 		return null;
 	}
+
+	@Incubating
+	default AuxiliaryDatabaseObject getAuxiliaryDatabaseObject(JdbcType jdbcType, Dialect dialect, Namespace defaultNamespace) {
+		return null;
+	}
+
 }


### PR DESCRIPTION
[Failed] proof of concept implementation of PostgreSQL `enum` support for HHH-16125.

The current implementation of enum support in Hibernate is known to be garbage, involving a `UserType` *and* a `BasicValueConverter`, and this makes it close to impossible to implement this functionality.