### PR TITLE
[Question] Update collection of embeddables bug

### DIFF
--- a/hibernate-core/src/test/java/org/hibernate/orm/test/embeddable/ElementCollectionUpdateTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/embeddable/ElementCollectionUpdateTest.java
@@ -1,0 +1,126 @@
+package org.hibernate.orm.test.embeddable;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Objects;
+import java.util.Set;
+
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import jakarta.persistence.ElementCollection;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import org.assertj.core.api.Assertions;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+@DomainModel(annotatedClasses = ElementCollectionUpdateTest.Person.class)
+@SessionFactory
+public class ElementCollectionUpdateTest {
+
+	private Person thePerson;
+
+	@BeforeAll
+	public void prepare(SessionFactoryScope scope) {
+		scope.inTransaction( session -> {
+			Set<String> phones = new HashSet<>( Arrays.asList( "999-999-9999", "111-111-1111", "123-456-7890" ) );
+			thePerson = new Person( 7242000, "Claude", phones );
+			session.persist( thePerson );
+		} );
+	}
+
+	@Test
+	public void removeElementAndAddNewOne(SessionFactoryScope scope) {
+		scope.inTransaction( session -> {
+			Person foundPerson = session.find( Person.class, thePerson.getId() );
+			Assertions.assertThat( foundPerson ).isNotNull();
+			foundPerson.getPhones().remove( "111-111-1111" );
+			foundPerson.getPhones().add( "000" );
+			assertThat( foundPerson.getPhones() )
+					.containsExactlyInAnyOrder( "999-999-9999", "123-456-7890", "000" );
+		} );
+		scope.inTransaction( session -> {
+			Person person = session.find( Person.class, thePerson.getId() );
+			assertThat( person.getPhones() )
+					.containsExactlyInAnyOrder( "999-999-9999", "123-456-7890", "000" );
+		} );
+	}
+
+	@Entity(name = "Person")
+	@Table(name = "Person")
+	static class Person {
+		@Id
+		private Integer id;
+		private String name;
+
+		@ElementCollection(fetch = FetchType.EAGER)
+		private Set<String> phones;
+
+		public Person() {
+		}
+
+		public Person(Integer id, String name, Collection<String> phones) {
+			this.id = id;
+			this.name = name;
+			this.phones = new HashSet<>( phones );
+		}
+
+		public Integer getId() {
+			return id;
+		}
+
+		public void setId(Integer id) {
+			this.id = id;
+		}
+
+		public String getName() {
+			return name;
+		}
+
+		public void setName(String name) {
+			this.name = name;
+		}
+
+		public void setPhones(Set<String> phones) {
+			this.phones = phones;
+		}
+
+		public Set<String> getPhones() {
+			return phones;
+		}
+
+		@Override
+		public boolean equals(Object o) {
+			if ( this == o ) {
+				return true;
+			}
+			if ( o == null || getClass() != o.getClass() ) {
+				return false;
+			}
+			Person person = (Person) o;
+			return Objects.equals( name, person.name );
+		}
+
+		@Override
+		public int hashCode() {
+			return Objects.hash( name );
+		}
+
+		@Override
+		public String toString() {
+			final StringBuilder sb = new StringBuilder();
+			sb.append( id );
+			sb.append( ", " ).append( name );
+			sb.append( ", " ).append( phones );
+			return sb.toString();
+		}
+	}
+}


### PR DESCRIPTION
It seem that updating an element in a collection of elements will delete the whole collection and only keep the new value.

Am I doing something wrong or is this a bug in ORM 6.2?