### PR TITLE
update maven dependency of hibernate-spatial

### DIFF
--- a/documentation/src/main/asciidoc/userguide/chapters/query/spatial/Spatial.adoc
+++ b/documentation/src/main/asciidoc/userguide/chapters/query/spatial/Spatial.adoc
@@ -54,7 +54,7 @@ For Maven, you need to add the following dependency:
 [source,xml]
 ----
 <dependency>
-    <groupId>org.hibernate</groupId>
+    <groupId>org.hibernate.orm</groupId>
     <artifactId>hibernate-spatial</artifactId>
     <version>${hibernate.version}</version>
 </dependency>


### PR DESCRIPTION
the new Maven group is org.hibernate.orm (and so referenced in Spring Boot 3)