### PR TITLE
Backport HHH-16302 to branch 6.2 - Document that TimeZoneStorageType.NORMALIZE normalizes to the JVM timezone, not to `hibernate.jdbc.time_zone`, upon reading values

### DIFF
--- a/documentation/src/main/asciidoc/userguide/appendices/Configurations.adoc
+++ b/documentation/src/main/asciidoc/userguide/appendices/Configurations.adoc
@@ -385,6 +385,8 @@ Enable nationalized character support on all string / clob based attribute ( str
 Should we not use contextual LOB creation (aka based on `java.sql.Connection#createBlob()` et al)? The default value for HANA, H2, and PostgreSQL is `true`.
 
 [[jdbc-time-zone]]`*hibernate.jdbc.time_zone*` (e.g. A `java.util.TimeZone`, a `java.time.ZoneId` or a `String` representation of a `ZoneId`)::
+The timezone to use in the JDBC driver, which is supposed to match the database timezone.
++
 Unless specified, the JDBC Driver uses the default JVM time zone. If a different time zone is configured via this setting, the JDBC https://docs.oracle.com/javase/8/docs/api/java/sql/PreparedStatement.html#setTimestamp-int-java.sql.Timestamp-java.util.Calendar-[PreparedStatement#setTimestamp] is going to use a `Calendar` instance according to the specified time zone.
 
 `*hibernate.dialect.oracle.prefer_long_raw*` (e.g. `true` or `false` (default value))::

--- a/documentation/src/main/asciidoc/userguide/appendices/Configurations.adoc
+++ b/documentation/src/main/asciidoc/userguide/appendices/Configurations.adoc
@@ -270,13 +270,23 @@ Assuming `hibernate.globally_quoted_identifiers` is `true`, this allows the glob
 Specifies whether to automatically quote any names that are deemed keywords.
 
 ==== Time zone storage
-`*hibernate.timezone.default_storage*` (e.g. `COLUMN`, `NATIVE`, `AUTO` or `NORMALIZE` (default value))::
+`*hibernate.timezone.default_storage*` (e.g. `COLUMN`, `NATIVE`, `NORMALIZE`, `NORMALIZE_UTC`, `AUTO` or `DEFAULT` (default value))::
 Global setting for configuring the default storage for the time zone information for time zone based types.
 +
-`NORMALIZE`::: Does not store the time zone information, and instead normalizes timestamps to UTC
-`COLUMN`::: Stores the time zone information in a separate column; works in conjunction with `@TimeZoneColumn`
-`NATIVE`::: Stores the time zone information by using the `with time zone` type. Error if `Dialect#getTimeZoneSupport()` is not `NATIVE`
+`NORMALIZE`:::
+Legacy behavior (Hibernate ORM 5).
++
+Does not store the time zone information, and instead:
++
+* when persisting to the database, normalizes JDBC timestamps to the
+<<jdbc-time-zone,JDBC timezone>> or to the JVM default time zone if not set.
+* when reading back from the database, sets the offset or zone
+of `OffsetDateTime`/`ZonedDateTime` values to the JVM default time zone.
+`NORMALIZE_UTC`::: Does not store the time zone information, and instead normalizes timestamps to UTC.
+`COLUMN`::: Stores the time zone information in a separate column; works in conjunction with `@TimeZoneColumn`.
+`NATIVE`::: Stores the time zone information by using the `with time zone` type. Error if `Dialect#getTimeZoneSupport()` is not `NATIVE`.
 `AUTO`::: Stores the time zone information either with `NATIVE` if `Dialect#getTimeZoneSupport()` is `NATIVE`, otherwise uses the `COLUMN` strategy.
+`DEFAULT`::: Stores the time zone information either with `NATIVE` if `Dialect#getTimeZoneSupport()` is `NATIVE`, otherwise uses the `NORMALIZE_UTC` strategy.
 +
 The default value is given by the {@link org.hibernate.annotations.TimeZoneStorageType#NORMALIZE},
 meaning that time zone information is not stored by default, but timestamps are normalized instead.
@@ -374,7 +384,7 @@ Enable nationalized character support on all string / clob based attribute ( str
 `*hibernate.jdbc.lob.non_contextual_creation*` (e.g. `true` or `false` (default value))::
 Should we not use contextual LOB creation (aka based on `java.sql.Connection#createBlob()` et al)? The default value for HANA, H2, and PostgreSQL is `true`.
 
-`*hibernate.jdbc.time_zone*` (e.g. A `java.util.TimeZone`, a `java.time.ZoneId` or a `String` representation of a `ZoneId`)::
+[[jdbc-time-zone]]`*hibernate.jdbc.time_zone*` (e.g. A `java.util.TimeZone`, a `java.time.ZoneId` or a `String` representation of a `ZoneId`)::
 Unless specified, the JDBC Driver uses the default JVM time zone. If a different time zone is configured via this setting, the JDBC https://docs.oracle.com/javase/8/docs/api/java/sql/PreparedStatement.html#setTimestamp-int-java.sql.Timestamp-java.util.Calendar-[PreparedStatement#setTimestamp] is going to use a `Calendar` instance according to the specified time zone.
 
 `*hibernate.dialect.oracle.prefer_long_raw*` (e.g. `true` or `false` (default value))::

--- a/hibernate-core/src/main/java/org/hibernate/TimeZoneStorageStrategy.java
+++ b/hibernate-core/src/main/java/org/hibernate/TimeZoneStorageStrategy.java
@@ -28,7 +28,18 @@ public enum TimeZoneStorageStrategy {
 	 */
 	COLUMN,
 	/**
-	 * Doesn't store the time zone, but instead normalizes to the JDBC timezone.
+	 * Does not store the time zone, and instead:
+	 * <ul>
+	 * <li>when persisting to the database, normalizes JDBC timestamps to the
+	 * {@linkplain org.hibernate.cfg.AvailableSettings#JDBC_TIME_ZONE}
+	 * or to the JVM default time zone otherwise.
+	 * <li>when reading back from the database, sets the offset or zone
+	 * of {@code OffsetDateTime}/{@code ZonedDateTime} properties
+	 * to the JVM default time zone.
+	 * </ul>
+	 * <p>
+	 * Provided partly for backward compatibility with older
+	 * versions of Hibernate.
 	 */
 	NORMALIZE,
 	/**

--- a/hibernate-core/src/main/java/org/hibernate/annotations/TimeZoneStorageType.java
+++ b/hibernate-core/src/main/java/org/hibernate/annotations/TimeZoneStorageType.java
@@ -78,15 +78,16 @@ public enum TimeZoneStorageType {
 	/**
 	 * Does not store the time zone, and instead:
 	 * <ul>
-	 * <li>normalizes JDBC timestamps to the
-	 *     {@linkplain org.hibernate.cfg.AvailableSettings#JDBC_TIME_ZONE
-	 *     JDBC timezone}, if set, or
-	 * <li>passes them through in the JVM default time zone
-	 *    otherwise.
+	 * <li>when persisting to the database, normalizes JDBC timestamps to the
+	 * {@linkplain org.hibernate.cfg.AvailableSettings#JDBC_TIME_ZONE}
+	 * or to the JVM default time zone if not set.
+	 * <li>when reading back from the database, sets the offset or zone
+	 * of {@code OffsetDateTime}/{@code ZonedDateTime} values
+	 * to the JVM default time zone.
 	 * </ul>
 	 * <p>
 	 * Provided partly for backward compatibility with older
-	 * versions of Hibernate
+	 * versions of Hibernate.
 	 */
 	NORMALIZE,
 	/**

--- a/hibernate-core/src/main/java/org/hibernate/cfg/AvailableSettings.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/AvailableSettings.java
@@ -1080,7 +1080,10 @@ public interface AvailableSettings {
 	String BATCH_VERSIONED_DATA = "hibernate.jdbc.batch_versioned_data";
 
 	/**
-	 * Specifies a {@linkplain java.util.TimeZone time zone} that should be passed to
+	 * Specifies the {@linkplain java.util.TimeZone time zone} to use in the JDBC driver,
+	 * which is supposed to match the database timezone.
+	 * <p>
+	 * This is the timezone what will be passed to
 	 * {@link java.sql.PreparedStatement#setTimestamp(int, java.sql.Timestamp, java.util.Calendar)}
 	 * {@link java.sql.PreparedStatement#setTime(int, java.sql.Time, java.util.Calendar)},
 	 * {@link java.sql.ResultSet#getTimestamp(int, Calendar)}, and


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-16302

Backport of #6244 to branch 6.2.