### PR TITLE
Reproducer for incorrect function argument domain type

### DIFF
--- a/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/type/dynamicparameterized/DynamicParameterizedTypeTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/type/dynamicparameterized/DynamicParameterizedTypeTest.java
@@ -23,22 +23,49 @@
  */
 package org.hibernate.orm.test.annotations.type.dynamicparameterized;
 
-import java.util.Date;
-
+import jakarta.persistence.metamodel.Attribute;
+import jakarta.persistence.metamodel.EntityType;
+import org.hibernate.boot.model.FunctionContributions;
+import org.hibernate.boot.model.FunctionContributor;
+import org.hibernate.metamodel.mapping.BasicValuedMapping;
+import org.hibernate.metamodel.model.domain.BasicDomainType;
+import org.hibernate.metamodel.model.domain.internal.BasicSqmPathSource;
+import org.hibernate.query.ReturnableType;
+import org.hibernate.query.sqm.function.SqmFunctionRegistry;
+import org.hibernate.query.sqm.produce.function.FunctionReturnTypeResolver;
+import org.hibernate.query.sqm.tree.SqmTypedNode;
+import org.hibernate.sql.ast.tree.SqlAstNode;
+import org.hibernate.testing.orm.junit.BootstrapServiceRegistry;
 import org.hibernate.testing.orm.junit.DomainModel;
 import org.hibernate.testing.orm.junit.SessionFactory;
 import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.hibernate.type.BasicType;
+import org.hibernate.type.CustomType;
+import org.hibernate.type.spi.TypeConfiguration;
+import org.hibernate.usertype.UserType;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import java.util.Date;
+import java.util.List;
+import java.util.function.Supplier;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * @author Daniel Gredler
+ * @author Jan-Willem Gmelig Meyling
+ * @author Sayra Ranjha
  */
 @DomainModel(
 		annotatedClasses = { AbstractEntity.class, Entity1.class, Entity2.class }
 )
 @SessionFactory
+@BootstrapServiceRegistry(
+		javaServices = @BootstrapServiceRegistry.JavaService(
+				role = FunctionContributor.class,
+				impl = DynamicParameterizedTypeTest.FunctionContributorImpl.class
+		)
+)
 public class DynamicParameterizedTypeTest {
 
 	@Test
@@ -74,5 +101,42 @@ public class DynamicParameterizedTypeTest {
 					assertEquals( "ENTITY2.PROP6.YEAH", entity2.entity2_Prop6 );
 				}
 		);
+	}
+
+	@Test
+	public void testMetamodel(SessionFactoryScope scope) {
+		scope.inTransaction(session -> {
+			List resultList = session.createQuery("select boolean_func1(a.entity1_Prop3) from Entity1 a").getResultList();
+			assertNotNull(resultList);
+		});
+	}
+
+
+	public static class FunctionContributorImpl implements FunctionContributor {
+		@Override
+		public void contributeFunctions(FunctionContributions functionContributions) {
+			final BasicType<Boolean> booleanBasicType = functionContributions
+					.getTypeConfiguration()
+					.getBasicTypeForJavaType( Boolean.class );
+
+			final SqmFunctionRegistry functionRegistry = functionContributions.getFunctionRegistry();
+			functionRegistry
+					.patternDescriptorBuilder( "boolean_func1", "(?1=?1)" )
+					.setReturnTypeResolver(new FunctionReturnTypeResolver() {
+						@Override
+						public ReturnableType<?> resolveFunctionReturnType(ReturnableType<?> impliedType, List<? extends SqmTypedNode<?>> arguments, TypeConfiguration typeConfiguration) {
+							SqmTypedNode<?> sqmTypedNode = arguments.get(0);
+							BasicDomainType sqmPathType = ((BasicSqmPathSource) sqmTypedNode.getNodeType()).getSqmPathType();
+							assertInstanceOf(CustomType.class, sqmPathType);
+							return null;
+						}
+
+						@Override
+						public BasicValuedMapping resolveFunctionReturnType(Supplier<BasicValuedMapping> impliedTypeAccess, List<? extends SqlAstNode> arguments) {
+							return null;
+						}
+					})
+					.register();
+		}
 	}
 }


### PR DESCRIPTION
Reproducer that argument type is not properly resolvable from SqmFunction return type resolvers.

Test fails with:

```
Unexpected type ==> expected: <org.hibernate.type.CustomType> but was: <org.hibernate.metamodel.model.domain.internal.BasicTypeImpl>
Expected :org.hibernate.type.CustomType
Actual   :org.hibernate.metamodel.model.domain.internal.BasicTypeImpl
````