### PR TITLE
HHH-16356 Add option to allow nullable components in composite IDs for Hibernate

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/cfg/AvailableSettings.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/AvailableSettings.java
@@ -192,8 +192,8 @@ public interface AvailableSettings {
 
 	/**
 	 * Used to pass along any discovered {@link jakarta.validation.ValidatorFactory}.
-	 * 
-	 * @see org.hibernate.boot.SessionFactoryBuilder#applyValidatorFactory(Object) 
+	 *
+	 * @see org.hibernate.boot.SessionFactoryBuilder#applyValidatorFactory(Object)
 	 */
 	String JAKARTA_VALIDATION_FACTORY = "jakarta.persistence.validation.factory";
 
@@ -264,8 +264,8 @@ public interface AvailableSettings {
 	 * This setting is used to configure access to the {@code BeanManager},
 	 * either directly, or via
 	 * {@link org.hibernate.resource.beans.container.spi.ExtendedBeanManager}.
-	 * 
-	 * @see org.hibernate.boot.SessionFactoryBuilder#applyBeanManager(Object) 
+	 *
+	 * @see org.hibernate.boot.SessionFactoryBuilder#applyBeanManager(Object)
 	 */
 	String JAKARTA_CDI_BEAN_MANAGER = "jakarta.persistence.bean.manager";
 
@@ -970,7 +970,7 @@ public interface AvailableSettings {
 	 *
 	 * @see #SESSION_FACTORY_NAME_IS_JNDI
 	 * @see org.hibernate.internal.SessionFactoryRegistry
-	 * @see org.hibernate.boot.SessionFactoryBuilder#applyName(String) 
+	 * @see org.hibernate.boot.SessionFactoryBuilder#applyName(String)
 	 */
 	String SESSION_FACTORY_NAME = "hibernate.session_factory_name";
 
@@ -985,7 +985,7 @@ public interface AvailableSettings {
 	 * not want JNDI to be used.
 	 *
 	 * @see #SESSION_FACTORY_NAME
-	 * @see org.hibernate.boot.SessionFactoryBuilder#applyNameAsJndiName(boolean) 
+	 * @see org.hibernate.boot.SessionFactoryBuilder#applyNameAsJndiName(boolean)
 	 */
 	String SESSION_FACTORY_NAME_IS_JNDI = "hibernate.session_factory_name_is_jndi";
 
@@ -1106,16 +1106,16 @@ public interface AvailableSettings {
 	/**
 	 * When enabled, specifies that the {@link org.hibernate.Session} should be
 	 * closed automatically at the end of each transaction.
-	 * 
-	 * @see org.hibernate.boot.SessionFactoryBuilder#applyAutoClosing(boolean) 
+	 *
+	 * @see org.hibernate.boot.SessionFactoryBuilder#applyAutoClosing(boolean)
 	 */
 	String AUTO_CLOSE_SESSION = "hibernate.transaction.auto_close_session";
 
 	/**
 	 * When enabled, specifies that automatic flushing should occur during the JTA
 	 * {@link jakarta.transaction.Synchronization#beforeCompletion()} callback.
-	 * 
-	 * @see org.hibernate.boot.SessionFactoryBuilder#applyAutoFlushing(boolean) 
+	 *
+	 * @see org.hibernate.boot.SessionFactoryBuilder#applyAutoFlushing(boolean)
 	 */
 	String FLUSH_BEFORE_COMPLETION = "hibernate.transaction.flush_before_completion";
 
@@ -2080,8 +2080,8 @@ public interface AvailableSettings {
 	 * applied; the same instance will be passed to each {@code Session}. If there
 	 * should be a separate instance of {@code Interceptor} for each {@code Session},
 	 * use {@link #SESSION_SCOPED_INTERCEPTOR} instead.
-	 * 
-	 * @see org.hibernate.boot.SessionFactoryBuilder#applyInterceptor(Interceptor) 
+	 *
+	 * @see org.hibernate.boot.SessionFactoryBuilder#applyInterceptor(Interceptor)
 	 *
 	 * @since 5.0
 	 */
@@ -2105,7 +2105,7 @@ public interface AvailableSettings {
 	 *
 	 * @see org.hibernate.boot.SessionFactoryBuilder#applyStatelessInterceptor(Class)
 	 * @see org.hibernate.boot.SessionFactoryBuilder#applyStatelessInterceptor(Supplier)
-	 * 
+	 *
 	 * @since 5.2
 	 */
 	String SESSION_SCOPED_INTERCEPTOR = "hibernate.session_factory.session_scoped_interceptor";
@@ -2226,8 +2226,8 @@ public interface AvailableSettings {
 	/**
 	 * When enabled, specifies that {@linkplain org.hibernate.stat.Statistics statistics}
 	 * should be collected.
-	 * 
-	 * @see org.hibernate.boot.SessionFactoryBuilder#applyStatisticsSupport(boolean) 
+	 *
+	 * @see org.hibernate.boot.SessionFactoryBuilder#applyStatisticsSupport(boolean)
 	 */
 	String GENERATE_STATISTICS = "hibernate.generate_statistics";
 
@@ -3212,4 +3212,15 @@ public interface AvailableSettings {
 	 * and the database will drop the temporary tables automatically.
 	 */
 	String BULK_ID_STRATEGY_LOCAL_TEMPORARY_DROP_TABLES = LocalTemporaryTableStrategy.DROP_ID_TABLES;
+
+	/**
+	 * Specifies whether nullable components are allowed in composite IDs when using Hibernate.
+	 * <p>
+	 * When this property is set to {@code false} (the default value), Hibernate requires that all components of a
+	 * composite ID have non-null values.
+	 * <p>
+	 * When this property is set to {@code true}, Hibernate allows nullable components in composite IDs.
+	 */
+	String ID_NULLABLE = "hibernate.id.nullable";
+
 }

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/embeddables/EmbeddableIdNullableTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/embeddables/EmbeddableIdNullableTest.java
@@ -4,8 +4,6 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jakarta.persistence.Query;
 import org.hibernate.cfg.AvailableSettings;
-import org.hibernate.dialect.H2Dialect;
-import org.hibernate.testing.RequiresDialect;
 import org.hibernate.testing.TestForIssue;
 import org.hibernate.testing.orm.junit.DomainModel;
 import org.hibernate.testing.orm.junit.ServiceRegistry;
@@ -27,7 +25,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 @SessionFactory
 @TestForIssue(jiraKey = "HHH-16356")
 @ServiceRegistry(settings = @Setting( name = AvailableSettings.ID_NULLABLE, value = "true"))
-@RequiresDialect(H2Dialect.class)
 public class EmbeddableIdNullableTest {
 
     @Test
@@ -35,7 +32,7 @@ public class EmbeddableIdNullableTest {
         scope.inTransaction(
                 session -> {
                     // Select the entity from the database using a null id component
-                    Query query = session.createNativeQuery("SELECT 123L AS id, NULL AS name", Product.class);
+                    Query query = session.createNativeQuery("SELECT 123 AS id, NULL AS name", Product.class);
                     List<Product> results = query.getResultList();
 
                     assertThat( results.size() ).isEqualTo(1);

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/embeddables/EmbeddableIdNullableTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/embeddables/EmbeddableIdNullableTest.java
@@ -4,6 +4,8 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jakarta.persistence.Query;
 import org.hibernate.cfg.AvailableSettings;
+import org.hibernate.dialect.H2Dialect;
+import org.hibernate.testing.RequiresDialect;
 import org.hibernate.testing.TestForIssue;
 import org.hibernate.testing.orm.junit.DomainModel;
 import org.hibernate.testing.orm.junit.ServiceRegistry;
@@ -25,6 +27,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 @SessionFactory
 @TestForIssue(jiraKey = "HHH-16356")
 @ServiceRegistry(settings = @Setting( name = AvailableSettings.ID_NULLABLE, value = "true"))
+@RequiresDialect(H2Dialect.class)
 public class EmbeddableIdNullableTest {
 
     @Test

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/embeddables/EmbeddableIdNullableTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/embeddables/EmbeddableIdNullableTest.java
@@ -1,0 +1,70 @@
+package org.hibernate.orm.test.annotations.embeddables;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Query;
+import org.hibernate.cfg.AvailableSettings;
+import org.hibernate.testing.TestForIssue;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.ServiceRegistry;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.hibernate.testing.orm.junit.Setting;
+import org.junit.jupiter.api.Test;
+
+import java.io.Serializable;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DomainModel(
+        annotatedClasses = {
+                EmbeddableIdNullableTest.Product.class
+        }
+)
+@SessionFactory
+@TestForIssue(jiraKey = "HHH-16356")
+@ServiceRegistry(settings = @Setting( name = AvailableSettings.ID_NULLABLE, value = "true"))
+public class EmbeddableIdNullableTest {
+
+    @Test
+    public void testSelectWithNullableIdComponent(SessionFactoryScope scope) {
+        scope.inTransaction(
+                session -> {
+                    // Select the entity from the database using a null id component
+                    Query query = session.createNativeQuery("SELECT 123L AS id, NULL AS name", Product.class);
+                    List<Product> results = query.getResultList();
+
+                    assertThat( results.size() ).isEqualTo(1);
+                    assertThat( results.get(0).getId() ).isEqualTo(123L);
+                    assertThat( results.get(0).getName() ).isNull();
+                }
+        );
+    }
+
+    @Entity(name = "Product")
+    public static class Product implements Serializable {
+        @Id
+        private Long id;
+
+        @Id
+        private String name;
+
+        public Long getId() {
+            return id;
+        }
+
+        public void setId(Long id) {
+            this.id = id;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+    }
+
+}


### PR DESCRIPTION
This commit adds a new property to Hibernate, "hibernate.id.nullable", that specifies whether nullable components are allowed in composite IDs. By default, this property is set to false, which means that all components of a composite ID must have non-null values. However, when set to true, Hibernate now allows nullable components in composite IDs.