### PR TITLE
HHH-16380 Avoid map-based mapping metamodel access when instantiating entity instances

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/entity/AbstractEntityInitializer.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/entity/AbstractEntityInitializer.java
@@ -659,7 +659,7 @@ public abstract class AbstractEntityInitializer extends AbstractFetchParentAcces
 	}
 
 	protected Object instantiateEntity(Object entityIdentifier, SharedSessionContractImplementor session) {
-		final Object instance = session.instantiate( concreteDescriptor.getEntityName(), entityKey.getIdentifier() );
+		final Object instance = session.instantiate( concreteDescriptor, entityKey.getIdentifier() );
 		if ( EntityLoadingLogging.DEBUG_ENABLED ) {
 			EntityLoadingLogging.ENTITY_LOADING_LOGGER.debugf(
 					"(%s) Created new entity instance [%s] : %s",


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-16380