### PR TITLE
HHH-16261 JPA metamodel generator is not considering Java 14's records

### DIFF
--- a/tooling/metamodel-generator/src/main/java/org/hibernate/jpamodelgen/JPAMetaModelEntityProcessor.java
+++ b/tooling/metamodel-generator/src/main/java/org/hibernate/jpamodelgen/JPAMetaModelEntityProcessor.java
@@ -6,7 +6,7 @@
  */
 package org.hibernate.jpamodelgen;
 
-import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
@@ -67,6 +67,7 @@ public class JPAMetaModelEntityProcessor extends AbstractProcessor {
 	public static final String ADD_SUPPRESS_WARNINGS_ANNOTATION = "addSuppressWarningsAnnotation";
 
 	private static final Boolean ALLOW_OTHER_PROCESSORS_TO_CLAIM_ANNOTATIONS = Boolean.FALSE;
+	private static final List<String> HANDLED_ELEMENT_KINDS = Arrays.asList("CLASS", "RECORD");
 
 	private Context context;
 
@@ -221,7 +222,7 @@ public class JPAMetaModelEntityProcessor extends AbstractProcessor {
 	private void handleRootElementAnnotationMirrors(final Element element) {
 		List<? extends AnnotationMirror> annotationMirrors = element.getAnnotationMirrors();
 		for ( AnnotationMirror mirror : annotationMirrors ) {
-			if ( !ElementKind.CLASS.equals( element.getKind() ) ) {
+			if ( !HANDLED_ELEMENT_KINDS.contains( element.getKind().name() ) ) {
 				continue;
 			}
 

--- a/tooling/metamodel-generator/src/main/java/org/hibernate/jpamodelgen/annotation/MetaAttributeGenerationVisitor.java
+++ b/tooling/metamodel-generator/src/main/java/org/hibernate/jpamodelgen/annotation/MetaAttributeGenerationVisitor.java
@@ -6,6 +6,7 @@
  */
 package org.hibernate.jpamodelgen.annotation;
 
+import java.util.Arrays;
 import java.util.List;
 import javax.lang.model.element.AnnotationMirror;
 import javax.lang.model.element.Element;
@@ -288,6 +289,8 @@ public class MetaAttributeGenerationVisitor extends SimpleTypeVisitor6<Annotatio
  */
 class BasicAttributeVisitor extends SimpleTypeVisitor6<Boolean, Element> {
 
+	private static final List<String> HANDLED_ELEMENT_KINDS = Arrays.asList("CLASS", "INTERFACE", "RECORD");
+
 	private final Context context;
 
 	public BasicAttributeVisitor(Context context) {
@@ -313,7 +316,7 @@ class BasicAttributeVisitor extends SimpleTypeVisitor6<Boolean, Element> {
 			return Boolean.TRUE;
 		}
 
-		if ( ElementKind.CLASS.equals( element.getKind() ) || ElementKind.INTERFACE.equals( element.getKind() ) ) {
+		if ( HANDLED_ELEMENT_KINDS.contains( element.getKind().name() ) ) {
 			TypeElement typeElement = ( (TypeElement) element );
 			String typeName = typeElement.getQualifiedName().toString();
 			if ( Constants.BASIC_TYPES.contains( typeName ) ) {


### PR DESCRIPTION
Also:
- keep backward compatibility with compilers, not supporting records