### PR TITLE
Recognize ConstraintViolationException from error code in Sql Server

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/dialect/SQLServerDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/SQLServerDialect.java
@@ -46,6 +46,7 @@ import org.hibernate.engine.jdbc.env.spi.IdentifierHelper;
 import org.hibernate.engine.jdbc.env.spi.IdentifierHelperBuilder;
 import org.hibernate.engine.jdbc.env.spi.NameQualifierSupport;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
+import org.hibernate.exception.ConstraintViolationException;
 import org.hibernate.exception.LockTimeoutException;
 import org.hibernate.exception.spi.SQLExceptionConversionDelegate;
 import org.hibernate.internal.util.JdbcExceptionHelper;
@@ -719,6 +720,9 @@ public class SQLServerDialect extends AbstractTransactSQLDialect {
 			}
 			if ( 1222 == errorCode ) {
 				throw new LockTimeoutException( message, sqlException, sql );
+			}
+			if ( 2627 == errorCode || 2601 == errorCode ) {
+				throw new ConstraintViolationException( message, sqlException, sql );
 			}
 			return null;
 		};


### PR DESCRIPTION
Fix [HHH-16399](https://hibernate.atlassian.net/browse/HHH-16399)

    This is for Hibernate Reactive.

    Hibernate ORM recognizes the error because, when it comes from the JDBC driver,
     it's an instance of `java.sql.SQLIntegrityConstraintViolationException`.


[HHH-16399]: https://hibernate.atlassian.net/browse/HHH-16399?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ