### PR TITLE
Fix failing tests on CockroachDB and Oracle 11

### DIFF
--- a/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/generics/GenericMapAssociationTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/generics/GenericMapAssociationTest.java
@@ -21,6 +21,8 @@ import org.junit.jupiter.api.Test;
 
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.JoinTable;
 import jakarta.persistence.MappedSuperclass;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
@@ -110,6 +112,7 @@ public class GenericMapAssociationTest {
 	@MappedSuperclass
 	public static abstract class AbstractParent<K, E> {
 		@OneToMany
+		@JoinTable( name = "map_join_table", joinColumns = @JoinColumn( name = "container_id" ) )
 		private Map<K, E> map;
 
 		public AbstractParent() {

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/naturalid/compound/CompoundNaturalIdCacheTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/naturalid/compound/CompoundNaturalIdCacheTest.java
@@ -100,7 +100,7 @@ public class CompoundNaturalIdCacheTest {
 		);
 	}
 
-	@Entity(name = "EntityWithSimpleNaturalId")
+	@Entity(name = "SimpleNaturalId")
 	@NaturalIdCache
 	public static class EntityWithSimpleNaturalId {
 
@@ -128,7 +128,7 @@ public class CompoundNaturalIdCacheTest {
 		}
 	}
 
-	@Entity(name = "EntityWithCompoundNaturalId")
+	@Entity(name = "CompoundNaturalId")
 	@NaturalIdCache
 	public static class EntityWithCompoundNaturalId {
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/onetomany/RefreshWithPropertyAccessAndCollectionMapManipulationInSetterMethodTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/onetomany/RefreshWithPropertyAccessAndCollectionMapManipulationInSetterMethodTest.java
@@ -17,7 +17,6 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.MapKeyColumn;
@@ -54,7 +53,7 @@ public class RefreshWithPropertyAccessAndCollectionMapManipulationInSetterMethod
 	public static class Car {
 
 		@Id
-		@GeneratedValue(strategy = GenerationType.IDENTITY)
+		@GeneratedValue
 		@Access(AccessType.PROPERTY)
 		private Long id;
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/onetomany/RefreshWithPropertyAccessAndListManipulationInSetterMethodTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/onetomany/RefreshWithPropertyAccessAndListManipulationInSetterMethodTest.java
@@ -16,7 +16,6 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
@@ -50,7 +49,7 @@ public class RefreshWithPropertyAccessAndListManipulationInSetterMethodTest {
 	public static class Car {
 
 		@Id
-		@GeneratedValue(strategy = GenerationType.IDENTITY)
+		@GeneratedValue
 		@Access(AccessType.PROPERTY)
 		private Long id;
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/query/NamedParameterInSelectAndWhereTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/query/NamedParameterInSelectAndWhereTest.java
@@ -8,6 +8,7 @@ package org.hibernate.orm.test.query;
 
 import java.time.LocalDate;
 
+import org.hibernate.dialect.CockroachDialect;
 import org.hibernate.dialect.PostgreSQLDialect;
 
 import org.hibernate.testing.orm.domain.gambit.EntityOfBasics;
@@ -69,6 +70,7 @@ public class NamedParameterInSelectAndWhereTest {
 	@Test
 	@Jira( "https://hibernate.atlassian.net/browse/HHH-16305" )
 	@SkipForDialect( dialectClass = PostgreSQLDialect.class, reason = "PostgreSQL doesn't support parameters as arguments for timestampdiff" )
+	@SkipForDialect( dialectClass = CockroachDialect.class, reason = "CockroachDB doesn't support parameters as arguments for timestampdiff" )
 	public void testSelectFunctionAndWhere(SessionFactoryScope scope) {
 		scope.inTransaction( session -> assertEquals( 0, session.createQuery(
 						"select timestampdiff(year, e.theLocalDate, :date) from EntityOfBasics e where e.theLocalDate <= :date",


### PR DESCRIPTION
Fix a couple failing tests due to unsupported features and Oracle 11 table name length restriction:
https://ci.hibernate.org/job/hibernate-orm-nightly/job/main/155/