### PR TITLE
HHH-16433 Fix forced follow on locking with order by

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/dialect/OracleSqlAstTranslator.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/OracleSqlAstTranslator.java
@@ -97,7 +97,7 @@ public class OracleSqlAstTranslator<T extends JdbcOperation> extends SqlAstTrans
 			Boolean followOnLocking) {
 		LockStrategy strategy = super.determineLockingStrategy( querySpec, forUpdateClause, followOnLocking );
 		final boolean followOnLockingDisabled = Boolean.FALSE.equals( followOnLocking );
-		if ( strategy != LockStrategy.FOLLOW_ON && querySpec.hasSortSpecifications() ) {
+		if ( strategy != LockStrategy.FOLLOW_ON && querySpec.hasSortSpecifications() && hasLimit() ) {
 			if ( followOnLockingDisabled ) {
 				throw new IllegalQueryOperationException( "Locking with ORDER BY is not supported" );
 			}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/dialect/functional/OracleFollowOnLockingTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/dialect/functional/OracleFollowOnLockingTest.java
@@ -230,6 +230,28 @@ public class OracleFollowOnLockingTest extends
 
 
 	@Test
+	@TestForIssue(jiraKey = "HHH-16433")
+	public void testPessimisticLockWithOrderByThenNoFollowOnLocking() {
+
+		final Session session = openSession();
+		session.beginTransaction();
+
+		sqlStatementInterceptor.getSqlQueries().clear();
+
+		List<Product> products =
+				session.createQuery(
+						"select p from Product p order by p.id", Product.class )
+						.setLockOptions( new LockOptions( LockMode.PESSIMISTIC_WRITE ) )
+						.getResultList();
+
+		assertTrue( products.size() > 1 );
+		assertEquals( 1, sqlStatementInterceptor.getSqlQueries().size() );
+
+		session.getTransaction().commit();
+		session.close();
+	}
+
+	@Test
 	public void testPessimisticLockWithMaxResultsAndOrderByThenFollowOnLocking() {
 
 		final Session session = openSession();


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-16433

Simple "SELECT x ... ORDER BY x.id FOR UPDATE" query does not need follow on locking in Oracle. Avoiding follow-on locking is important for correct semantics if this is used with "skip locked" queue implementation.