### PR TITLE
HHH-16443 Convert SqlStatementLogger into a Service

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/engine/jdbc/internal/JdbcServicesImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/jdbc/internal/JdbcServicesImpl.java
@@ -45,12 +45,7 @@ public class JdbcServicesImpl implements JdbcServices, ServiceRegistryAwareServi
 		this.jdbcEnvironment = serviceRegistry.getService( JdbcEnvironment.class );
 		assert jdbcEnvironment != null : "JdbcEnvironment was not found";
 
-		final boolean showSQL = ConfigurationHelper.getBoolean( Environment.SHOW_SQL, configValues, false );
-		final boolean formatSQL = ConfigurationHelper.getBoolean( Environment.FORMAT_SQL, configValues, false );
-		final boolean highlightSQL = ConfigurationHelper.getBoolean( Environment.HIGHLIGHT_SQL, configValues, false );
-		final long logSlowQuery = ConfigurationHelper.getLong( Environment.LOG_SLOW_QUERY, configValues, 0 );
-
-		this.sqlStatementLogger = new SqlStatementLogger( showSQL, formatSQL, highlightSQL, logSlowQuery );
+		this.sqlStatementLogger = serviceRegistry.getService( SqlStatementLogger.class );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/engine/jdbc/internal/SqlStatementLoggerInitiator.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/jdbc/internal/SqlStatementLoggerInitiator.java
@@ -1,0 +1,41 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.engine.jdbc.internal;
+
+import java.util.Map;
+
+import org.hibernate.boot.registry.StandardServiceInitiator;
+import org.hibernate.cfg.Environment;
+import org.hibernate.engine.jdbc.spi.SqlStatementLogger;
+import org.hibernate.internal.util.config.ConfigurationHelper;
+import org.hibernate.service.spi.ServiceRegistryImplementor;
+
+/**
+ * The {@link SqlStatementLogger} is accessible via {@link org.hibernate.engine.jdbc.spi.JdbcServices},
+ * but during service initialization, it might be needed before the {@code JdbcServices} service is initialized.
+ *
+ * For Hibernate Reactive
+ */
+public class SqlStatementLoggerInitiator implements StandardServiceInitiator<SqlStatementLogger> {
+
+	public static final SqlStatementLoggerInitiator INSTANCE = new SqlStatementLoggerInitiator();
+
+	@Override
+	public SqlStatementLogger initiateService(Map<String, Object> configValues, ServiceRegistryImplementor registry) {
+		final boolean showSQL = ConfigurationHelper.getBoolean( Environment.SHOW_SQL, configValues, false );
+		final boolean formatSQL = ConfigurationHelper.getBoolean( Environment.FORMAT_SQL, configValues, false );
+		final boolean highlightSQL = ConfigurationHelper.getBoolean( Environment.HIGHLIGHT_SQL, configValues, false );
+		final long logSlowQuery = ConfigurationHelper.getLong( Environment.LOG_SLOW_QUERY, configValues, 0 );
+
+		return new SqlStatementLogger( showSQL, formatSQL, highlightSQL, logSlowQuery );
+	}
+
+	@Override
+	public Class<SqlStatementLogger> getServiceInitiated() {
+		return SqlStatementLogger.class;
+	}
+}

--- a/hibernate-core/src/main/java/org/hibernate/engine/jdbc/spi/SqlStatementLogger.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/jdbc/spi/SqlStatementLogger.java
@@ -10,6 +10,8 @@ import org.hibernate.engine.jdbc.internal.FormatStyle;
 import org.hibernate.engine.jdbc.internal.Formatter;
 import org.hibernate.internal.CoreLogging;
 import org.hibernate.internal.build.AllowSysOut;
+import org.hibernate.service.Service;
+
 import org.jboss.logging.Logger;
 
 import java.sql.Statement;
@@ -21,7 +23,7 @@ import java.util.function.Supplier;
  *
  * @author Steve Ebersole
  */
-public class SqlStatementLogger {
+public class SqlStatementLogger implements Service {
 	private static final Logger LOG = CoreLogging.logger( "org.hibernate.SQL" );
 	private static final Logger LOG_SLOW = CoreLogging.logger( "org.hibernate.SQL_SLOW" );
 

--- a/hibernate-core/src/main/java/org/hibernate/service/StandardServiceInitiators.java
+++ b/hibernate-core/src/main/java/org/hibernate/service/StandardServiceInitiators.java
@@ -25,6 +25,7 @@ import org.hibernate.engine.jdbc.dialect.internal.DialectFactoryInitiator;
 import org.hibernate.engine.jdbc.dialect.internal.DialectResolverInitiator;
 import org.hibernate.engine.jdbc.env.internal.JdbcEnvironmentInitiator;
 import org.hibernate.engine.jdbc.internal.JdbcServicesInitiator;
+import org.hibernate.engine.jdbc.internal.SqlStatementLoggerInitiator;
 import org.hibernate.engine.jdbc.mutation.internal.MutationExecutorServiceInitiator;
 import org.hibernate.engine.jndi.internal.JndiServiceInitiator;
 import org.hibernate.engine.transaction.jta.platform.internal.JtaPlatformInitiator;
@@ -118,6 +119,9 @@ public final class StandardServiceInitiators {
 
 		// BatchBuilder
 		serviceInitiators.add( BatchBuilderInitiator.INSTANCE );
+
+		// SqlStatementLoggerInitiator
+		serviceInitiators.add( SqlStatementLoggerInitiator.INSTANCE );
 
 		// JdbcServices
 		serviceInitiators.add( JdbcServicesInitiator.INSTANCE );


### PR DESCRIPTION
This way is possible to get the logger without having to initialize the JdbcServices service.

Something that I need for Hibernate Reactive.


Before I clean up the changes, is this acceptable?