### PR TITLE
HHH-16444 When logging the selected dialect, log the db version too

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/dialect/Dialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/Dialect.java
@@ -1526,7 +1526,7 @@ public abstract class Dialect implements ConversionContext, TypeContributor, Fun
 
 	@Override
 	public String toString() {
-		return getClass().getName();
+		return getClass().getName() + ", version: " + getVersion();
 	}
 
 

--- a/hibernate-core/src/main/java/org/hibernate/dialect/SimpleDatabaseVersion.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/SimpleDatabaseVersion.java
@@ -84,4 +84,21 @@ public class SimpleDatabaseVersion implements DatabaseVersion {
 	public int getMicro() {
 		return micro;
 	}
+
+	@Override
+	public String toString() {
+		StringBuilder version = new StringBuilder();
+		if ( major != NO_VERSION ) {
+			version.append( major );
+		}
+		if ( minor != NO_VERSION ) {
+			version.append( "." );
+			version.append( minor );
+			if ( micro > 0 ) {
+				version.append( "." );
+				version.append( micro );
+			}
+		}
+		return version.toString();
+	}
 }


### PR DESCRIPTION
Fix for https://hibernate.atlassian.net/browse/HHH-16444

This is what the log will look like:
```
INFO SQL dialect [vert.x-worker-thread-0] HHH000400: Using dialect: org.hibernate.dialect.MariaDBDialect, version: 10.11
```