### PR TITLE
Fix test that caused sporadic CI failures and shorten entity names for ORA11

### DIFF
--- a/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/naturalid/compound/CompoundNaturalIdTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/naturalid/compound/CompoundNaturalIdTest.java
@@ -75,7 +75,7 @@ public class CompoundNaturalIdTest {
 		long loadDurationForSimpleNaturalId = loadEntities( EntityWithSimpleNaturalId.class, MAX_RESULTS, scope );
 
 		assertTrue(
-				loadDurationForCompoundNaturalId <= 5 * loadDurationForSimpleNaturalId,
+				loadDurationForCompoundNaturalId <= 10 * loadDurationForSimpleNaturalId,
 				"it should not be soo long to load entities with compound naturalId"
 		);
 	}
@@ -94,7 +94,7 @@ public class CompoundNaturalIdTest {
 		return duration;
 	}
 
-	@Entity(name = "EntityWithSimpleNaturalId")
+	@Entity(name = "SimpleNaturalId")
 	public static class EntityWithSimpleNaturalId {
 
 		@Id
@@ -121,7 +121,7 @@ public class CompoundNaturalIdTest {
 		}
 	}
 
-	@Entity(name = "EntityWithCompoundNaturalId")
+	@Entity(name = "CompoundNaturalId")
 	public static class EntityWithCompoundNaturalId {
 
 		@Id

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/ops/HANANoColumnInsertTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/ops/HANANoColumnInsertTest.java
@@ -15,15 +15,14 @@ import org.hibernate.testing.orm.junit.BaseSessionFactoryFunctionalTest;
 import org.hibernate.testing.orm.junit.RequiresDialect;
 import org.junit.jupiter.api.Test;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.core.Is.is;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.fail;
 
 
 /**
  * @author Vlad Mihalcea
  */
-@RequiresDialect(value = AbstractHANADialect.class)
+@RequiresDialect( value = AbstractHANADialect.class )
 public class HANANoColumnInsertTest extends BaseSessionFactoryFunctionalTest {
 
 	@Override
@@ -43,13 +42,9 @@ public class HANANoColumnInsertTest extends BaseSessionFactoryFunctionalTest {
 			return sessionFactoryImplementor;
 		}
 		catch (MappingException e) {
-			assertThat(
-
-					e.getMessage(),
-					is( "The INSERT statement for table [Competition] contains no column, and this is not supported by [" + getDialect()
-							.getClass()
-							.getName() + "]" )
-			);
+			assertThat( e.getMessage() ).startsWith(
+					"The INSERT statement for table [Competition] contains no column, and this is not supported by [" + getDialect().getClass()
+							.getName() );
 		}
 		return sessionFactoryImplementor;
 	}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/timezones/UTCNormalizedInstantTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/timezones/UTCNormalizedInstantTest.java
@@ -1,92 +1,88 @@
 package org.hibernate.orm.test.timezones;
 
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.Id;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.TimeZone;
+
 import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.dialect.Dialect;
 import org.hibernate.dialect.SybaseDialect;
+import org.hibernate.type.descriptor.DateTimeUtils;
+
 import org.hibernate.testing.orm.junit.DomainModel;
 import org.hibernate.testing.orm.junit.SessionFactory;
 import org.hibernate.testing.orm.junit.SessionFactoryScope;
-import org.hibernate.testing.orm.junit.SkipForDialect;
 import org.junit.jupiter.api.Test;
 
-import java.time.Instant;
-import java.util.TimeZone;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
 
 import static java.sql.Types.TIMESTAMP;
-import static java.time.temporal.ChronoUnit.SECONDS;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @DomainModel(annotatedClasses = UTCNormalizedInstantTest.Zoned.class)
 @SessionFactory
 public class UTCNormalizedInstantTest {
 
-	@SkipForDialect(dialectClass = SybaseDialect.class, matchSubTypes = true)
 	@Test void test(SessionFactoryScope scope) {
-		Instant instant = Instant.now();
+		final Instant instant = Instant.now();
 		long id = scope.fromTransaction( s-> {
-			Zoned z = new Zoned();
+			final Zoned z = new Zoned();
 			z.utcInstant = instant;
 			z.localInstant = instant;
 			s.persist(z);
 			return z.id;
 		});
 		scope.inSession( s-> {
-			Zoned z = s.find(Zoned.class, id);
-			assertEquals( instant, z.utcInstant );
-			assertEquals( instant, z.localInstant );
+			final Zoned z = s.find(Zoned.class, id);
+			final Dialect dialect = scope.getSessionFactory().getJdbcServices().getDialect();
+			if ( dialect instanceof SybaseDialect) {
+				// Sybase with jTDS driver has 1/300th sec precision
+				assertEquals( z.utcInstant.truncatedTo(ChronoUnit.SECONDS), instant.truncatedTo(ChronoUnit.SECONDS) );
+				assertEquals( z.localInstant.truncatedTo(ChronoUnit.SECONDS), instant.truncatedTo(ChronoUnit.SECONDS) );
+			}
+			else {
+				assertEquals(
+						DateTimeUtils.roundToDefaultPrecision( z.utcInstant, dialect ),
+						DateTimeUtils.roundToDefaultPrecision( instant, dialect )
+				);
+				assertEquals(
+						DateTimeUtils.roundToDefaultPrecision( z.localInstant, dialect ),
+						DateTimeUtils.roundToDefaultPrecision( instant, dialect )
+				);
+			}
 		});
 	}
 
-	@SkipForDialect(dialectClass = SybaseDialect.class, matchSubTypes = true)
 	@Test void testWithSystemTimeZone(SessionFactoryScope scope) {
 		TimeZone.setDefault( TimeZone.getTimeZone("CET") );
-		Instant instant = Instant.now();
+		final Instant instant = Instant.now();
 		long id = scope.fromTransaction( s-> {
-			Zoned z = new Zoned();
+			final Zoned z = new Zoned();
 			z.utcInstant = instant;
 			z.localInstant = instant;
 			s.persist(z);
 			return z.id;
 		});
 		scope.inSession( s-> {
-			Zoned z = s.find(Zoned.class, id);
-			assertEquals( instant, z.utcInstant );
-			assertEquals( instant, z.localInstant );
-		});
-	}
-
-	@Test void testSybase(SessionFactoryScope scope) {
-		Instant instant = Instant.now().truncatedTo(SECONDS);
-		long id = scope.fromTransaction( s-> {
-			Zoned z = new Zoned();
-			z.utcInstant = instant;
-			z.localInstant = instant;
-			s.persist(z);
-			return z.id;
-		});
-		scope.inSession( s-> {
-			Zoned z = s.find(Zoned.class, id);
-			assertEquals( instant, z.utcInstant );
-			assertEquals( instant, z.localInstant );
-		});
-	}
-
-	@Test void testWithSystemTimeZoneSybase(SessionFactoryScope scope) {
-		TimeZone.setDefault( TimeZone.getTimeZone("CET") );
-		Instant instant = Instant.now().truncatedTo(SECONDS);
-		long id = scope.fromTransaction( s-> {
-			Zoned z = new Zoned();
-			z.utcInstant = instant;
-			z.localInstant = instant;
-			s.persist(z);
-			return z.id;
-		});
-		scope.inSession( s-> {
-			Zoned z = s.find(Zoned.class, id);
-			assertEquals( instant, z.utcInstant );
-			assertEquals( instant, z.localInstant );
+			final Zoned z = s.find(Zoned.class, id);
+			final Dialect dialect = scope.getSessionFactory().getJdbcServices().getDialect();
+			if ( dialect instanceof SybaseDialect) {
+				// Sybase with jTDS driver has 1/300th sec precision
+				assertEquals( z.utcInstant.truncatedTo(ChronoUnit.SECONDS), instant.truncatedTo(ChronoUnit.SECONDS) );
+				assertEquals( z.localInstant.truncatedTo(ChronoUnit.SECONDS), instant.truncatedTo(ChronoUnit.SECONDS) );
+			}
+			else {
+				assertEquals(
+						DateTimeUtils.roundToDefaultPrecision( z.utcInstant, dialect ),
+						DateTimeUtils.roundToDefaultPrecision( instant, dialect )
+				);
+				assertEquals(
+						DateTimeUtils.roundToDefaultPrecision( z.localInstant, dialect ),
+						DateTimeUtils.roundToDefaultPrecision( instant, dialect )
+				);
+			}
 		});
 	}
 


### PR DESCRIPTION
Should also fix some [timestamp failures on s390x](https://ci.hibernate.org/job/hibernate-orm-pipeline/job/main/1721/testReport/junit/org.hibernate.orm.test.timezones/UTCNormalizedInstantTest/Build___s390x_h2___Test___test_SessionFactoryScope_/).