### PR TITLE
Reproducer for HHH-16459 Bytecode-enhanced inline dirty tracking ignores generic associations from mapped superclasses

### DIFF
--- a/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/generics/GenericToManyAssociationTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/generics/GenericToManyAssociationTest.java
@@ -1,0 +1,194 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html
+ */
+package org.hibernate.orm.test.annotations.generics;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import org.hibernate.query.criteria.JpaPath;
+
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.Jira;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.MappedSuperclass;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.criteria.CriteriaBuilder;
+import jakarta.persistence.criteria.CriteriaQuery;
+import jakarta.persistence.criteria.Join;
+import jakarta.persistence.criteria.Path;
+import jakarta.persistence.criteria.Root;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Yoann Rodière
+ * @author Marco Belladelli
+ */
+@SessionFactory
+@DomainModel( annotatedClasses = {
+		GenericToManyAssociationTest.AbstractParent.class,
+		GenericToManyAssociationTest.Parent.class,
+		GenericToManyAssociationTest.AbstractChild.class,
+		GenericToManyAssociationTest.Child.class
+} )
+@Jira( "https://hibernate.atlassian.net/browse/HHH-16378" )
+public class GenericToManyAssociationTest {
+	@BeforeAll
+	public void setUp(SessionFactoryScope scope) {
+		scope.inTransaction( session -> {
+			final Parent parent = new Parent( 1L );
+			final Child child = new Child( 2L );
+			child.setParent( parent );
+			parent.getChildren().add( child );
+			session.persist( parent );
+			session.persist( child );
+		} );
+	}
+
+	@AfterAll
+	public void tearDown(SessionFactoryScope scope) {
+		scope.inTransaction( session -> session.createQuery( "from Parent", Parent.class )
+				.getResultList()
+				.forEach( p -> p.getChildren().clear() ) );
+		scope.inTransaction( session -> {
+			session.createMutationQuery( "delete from Child" ).executeUpdate();
+			session.createMutationQuery( "delete from Parent" ).executeUpdate();
+		} );
+	}
+
+	@Test
+	public void testParentQuery(SessionFactoryScope scope) {
+		scope.inTransaction( session -> assertThat( session.createQuery(
+				"select parent.id from Child",
+				Long.class
+		).getSingleResult() ).isEqualTo( 1L ) );
+	}
+
+	@Test
+	public void testParentCriteriaQuery(SessionFactoryScope scope) {
+		scope.inTransaction( session -> {
+			final CriteriaBuilder cb = session.getCriteriaBuilder();
+			final CriteriaQuery<Long> query = cb.createQuery( Long.class );
+			final Root<Child> root = query.from( Child.class );
+			final Path<Parent> parent = root.get( "parent" );
+			// generic attributes are always reported as Object java type
+			assertThat( parent.getJavaType() ).isEqualTo( Object.class );
+			assertThat( parent.getModel() ).isSameAs( root.getModel().getAttribute( "parent" ) );
+			assertThat( ( (JpaPath<?>) parent ).getResolvedModel().getBindableJavaType() ).isEqualTo( Parent.class );
+			final Long result = session.createQuery( query.select( parent.get( "id" ) ) ).getSingleResult();
+			assertThat( result ).isEqualTo( 1L );
+		} );
+	}
+
+	@Test
+	public void testChildQuery(SessionFactoryScope scope) {
+		scope.inTransaction( session -> assertThat( session.createQuery(
+				"select c.id from Parent p join p.children c",
+				Long.class
+		).getSingleResult() ).isEqualTo( 2L ) );
+	}
+
+	@Test
+	public void testChildCriteriaQuery(SessionFactoryScope scope) {
+		scope.inTransaction( session -> {
+			final CriteriaBuilder cb = session.getCriteriaBuilder();
+			final CriteriaQuery<Long> query = cb.createQuery( Long.class );
+			final Root<Parent> root = query.from( Parent.class );
+			final Join<Parent, Child> join = root.join( "children" );
+			// generic attributes are always reported as Object java type
+			assertThat( join.getJavaType() ).isEqualTo( Object.class );
+			assertThat( join.getModel() ).isSameAs( root.getModel().getAttribute( "children" ) );
+			assertThat( ( (JpaPath<?>) join ).getResolvedModel().getBindableJavaType() ).isEqualTo( Child.class );
+			final Long result = session.createQuery( query.select( join.get( "id" ) ) ).getSingleResult();
+			assertThat( result ).isEqualTo( 2L );
+		} );
+	}
+
+	@Test
+	public void testElementQuery(SessionFactoryScope scope) {
+		scope.inTransaction( session -> assertThat( session.createQuery(
+				"select element(c).id from Parent p join p.children c",
+				Long.class
+		).getSingleResult() ).isEqualTo( 2L ) );
+	}
+
+	@MappedSuperclass
+	public abstract static class AbstractParent<E, T> {
+		@OneToMany
+		private Set<E> children;
+
+		public AbstractParent() {
+			this.children = new HashSet<>();
+		}
+
+		public Set<E> getChildren() {
+			return children;
+		}
+	}
+
+	@Entity( name = "Parent" )
+	public static class Parent extends AbstractParent<Child, String> {
+		@Id
+		private Long id;
+
+		public Parent() {
+		}
+
+		public Parent(Long id) {
+			this.id = id;
+		}
+
+		public Long getId() {
+			return this.id;
+		}
+	}
+
+	@MappedSuperclass
+	public abstract static class AbstractChild<T> {
+		@ManyToOne
+		private T parent;
+
+		public AbstractChild() {
+		}
+
+		public abstract Long getId();
+
+		public T getParent() {
+			return this.parent;
+		}
+
+		public void setParent(T parent) {
+			this.parent = parent;
+		}
+	}
+
+	@Entity( name = "Child" )
+	public static class Child extends AbstractChild<Parent> {
+		@Id
+		protected Long id;
+
+		public Child() {
+		}
+
+		public Child(Long id) {
+			this.id = id;
+		}
+
+		@Override
+		public Long getId() {
+			return this.id;
+		}
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/association/ToOneInheritedAssociationWithGenericsTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/association/ToOneInheritedAssociationWithGenericsTest.java
@@ -1,0 +1,81 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.orm.test.bytecode.enhancement.association;
+
+import org.hibernate.testing.TestForIssue;
+import org.hibernate.testing.bytecode.enhancement.BytecodeEnhancerRunner;
+import org.hibernate.testing.bytecode.enhancement.EnhancementOptions;
+import org.hibernate.testing.bytecode.enhancement.EnhancerTestUtils;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.MappedSuperclass;
+
+@TestForIssue( jiraKey = "HHH-16459" )
+@RunWith( BytecodeEnhancerRunner.class )
+@EnhancementOptions(inlineDirtyChecking = true)
+public class ToOneInheritedAssociationWithGenericsTest {
+
+    @Test
+    public void test() {
+        var entity = new ChildItem();
+        EnhancerTestUtils.checkDirtyTracking( entity );
+
+        entity.setOther( new Other() );
+        EnhancerTestUtils.checkDirtyTracking( entity, "other" );
+    }
+
+    @Entity
+    public static class Other {
+
+        @Id
+        @GeneratedValue
+        private Long id;
+
+        public Long getId() {
+            return id;
+        }
+
+        public void setId(Long id) {
+            this.id = id;
+        }
+    }
+
+    @MappedSuperclass
+    public static abstract class Item<T> {
+        @ManyToOne( fetch = FetchType.LAZY )
+        private T other;
+
+        public T getOther() {
+            return other;
+        }
+
+        public void setOther(T other) {
+            this.other = other;
+        }
+    }
+
+    @Entity
+    public static class ChildItem extends Item<Other> {
+        @Id
+        @GeneratedValue
+        private Long id;
+
+        public Long getId() {
+            return id;
+        }
+
+        public void setId(Long id) {
+            this.id = id;
+        }
+    }
+}

--- a/hibernate-testing/src/main/java/org/hibernate/testing/bytecode/enhancement/EnhancerTestUtils.java
+++ b/hibernate-testing/src/main/java/org/hibernate/testing/bytecode/enhancement/EnhancerTestUtils.java
@@ -18,9 +18,12 @@ import org.hibernate.testing.junit4.BaseUnitTestCase;
 import java.lang.reflect.Field;
 import java.util.Arrays;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+
+import org.assertj.core.api.Assertions;
 
 /**
  * utility class to use in bytecode enhancement tests
@@ -54,10 +57,10 @@ public abstract class EnhancerTestUtils extends BaseUnitTestCase {
 	 */
 	public static void checkDirtyTracking(Object entityInstance, String... dirtyFields) {
 		SelfDirtinessTracker selfDirtinessTracker = (SelfDirtinessTracker) entityInstance;
-		assertEquals( dirtyFields.length > 0, selfDirtinessTracker.$$_hibernate_hasDirtyAttributes() );
-		String[] tracked = selfDirtinessTracker.$$_hibernate_getDirtyAttributes();
-		assertEquals( dirtyFields.length, tracked.length );
-		assertTrue( Arrays.asList( tracked ).containsAll( Arrays.asList( dirtyFields ) ) );
+		assertThat( selfDirtinessTracker.$$_hibernate_getDirtyAttributes() )
+				.containsExactlyInAnyOrder( dirtyFields );
+		assertThat( selfDirtinessTracker.$$_hibernate_hasDirtyAttributes() )
+				.isEqualTo( dirtyFields.length > 0 );
 	}
 
 	public static EntityEntry makeEntityEntry() {


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-16459

@dreab8 do you think you could have a look when you have some time? The reproducer is in `ToOneInheritedAssociationWithGenericsTest`.