### PR TITLE
HHH-16461 @Version + session.refresh(entity, LockMode.PESSIMISTIC_WRITE) leads to StaleObjectStateException

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/internal/SqmJdbcExecutionContextAdapter.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/internal/SqmJdbcExecutionContextAdapter.java
@@ -70,4 +70,8 @@ public class SqmJdbcExecutionContextAdapter extends BaseExecutionContext {
 		return true;
 	}
 
+	@Override
+	public boolean upgradeLocks() {
+		return true;
+	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/sql/exec/spi/ExecutionContext.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/exec/spi/ExecutionContext.java
@@ -80,4 +80,12 @@ public interface ExecutionContext {
 		return false;
 	}
 
+	/**
+	 * Does this query return objects that might be already cached
+	 * by the session, whose lock mode may need upgrading
+	 */
+	default boolean upgradeLocks(){
+		return false;
+	}
+
 }

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/entity/AbstractEntityInitializer.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/entity/AbstractEntityInitializer.java
@@ -535,7 +535,7 @@ public abstract class AbstractEntityInitializer extends AbstractFetchParentAcces
 	}
 
 	private void upgradeLockMode(RowProcessingState rowProcessingState) {
-		if ( lockMode != LockMode.NONE ) {
+		if ( lockMode != LockMode.NONE && rowProcessingState.upgradeLocks() ) {
 			final EntityEntry entry =
 					rowProcessingState.getSession().getPersistenceContextInternal()
 							.getEntry( entityInstance );

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/internal/RowProcessingStateStandardImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/internal/RowProcessingStateStandardImpl.java
@@ -156,4 +156,9 @@ public class RowProcessingStateStandardImpl extends BaseExecutionContext impleme
 	public boolean hasCollectionInitializers() {
 		return this.initializers.hasCollectionInitializers();
 	}
+
+	@Override
+	public boolean upgradeLocks() {
+		return executionContext.upgradeLocks();
+	}
 }

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/locking/OptimisticAndPessimisticLockTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/locking/OptimisticAndPessimisticLockTest.java
@@ -1,0 +1,96 @@
+package org.hibernate.orm.test.locking;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.stream.Stream;
+
+import org.hibernate.LockMode;
+
+import org.hibernate.testing.TestForIssue;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Version;
+
+@DomainModel(annotatedClasses = {
+		OptimisticAndPessimisticLockTest.EntityA.class
+})
+@SessionFactory
+@TestForIssue(jiraKey = "HHH-16461")
+public class OptimisticAndPessimisticLockTest {
+
+	public Stream<LockMode> pessimisticLockModes() {
+		return Stream.of(LockMode.UPGRADE_NOWAIT, LockMode.PESSIMISTIC_WRITE, LockMode.PESSIMISTIC_READ, LockMode.PESSIMISTIC_FORCE_INCREMENT);
+	}
+
+	@ParameterizedTest
+	@MethodSource(value = "pessimisticLockModes")
+	public void upgradeFromOptimisticToPessimisticLock(LockMode pessimisticLockMode, SessionFactoryScope scope) {
+		Integer id = scope.fromTransaction( session -> {
+			EntityA entityA1 = new EntityA();
+			entityA1.setPropertyA( 1 );
+			session.persist( entityA1 );
+			return entityA1.getId();
+		} );
+		scope.inTransaction( session -> {
+			EntityA entityA1 = session.find( EntityA.class, id );
+
+			// Do a concurrent change that will update the @Version property
+			scope.inTransaction( session2 -> {
+				var concurrentEntityA1 = session2.find( EntityA.class, id );
+				concurrentEntityA1.setPropertyA( concurrentEntityA1.getPropertyA() + 1 );
+			} );
+
+			// Refresh the entity with concurrent changes and upgrade the lock
+			session.refresh( entityA1, pessimisticLockMode );
+
+			entityA1.setPropertyA( entityA1.getPropertyA() * 2 );
+		} );
+		scope.inTransaction( session -> {
+			EntityA entityA1 = session.find( EntityA.class, id );
+			assertThat( entityA1.getPropertyA() ).isEqualTo( ( 1 + 1 ) * 2 );
+		} );
+	}
+
+	@Entity(name = "EntityA")
+	public static class EntityA {
+
+		@Id
+		@GeneratedValue
+		Integer id;
+
+		@Version
+		long version;
+
+		int propertyA;
+
+		public EntityA() {
+		}
+
+		public EntityA(Integer id) {
+			this.id = id;
+		}
+
+		public Integer getId() {
+			return id;
+		}
+
+		public long getVersion() {
+			return version;
+		}
+
+		public int getPropertyA() {
+			return propertyA;
+		}
+
+		public void setPropertyA(int propertyA) {
+			this.propertyA = propertyA;
+		}
+	}
+}


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-16461

I checked and it seems that in 5.6 we execute the version check only for hql queries https://github.com/hibernate/hibernate-orm/blob/5.6/hibernate-core/src/main/java/org/hibernate/loader/Loader.java#L1703