### PR TITLE
HHH-16497 Deprecate JUnit 4 testing annotations

### DIFF
--- a/hibernate-testing/src/main/java/org/hibernate/testing/AfterClassOnce.java
+++ b/hibernate-testing/src/main/java/org/hibernate/testing/AfterClassOnce.java
@@ -17,8 +17,18 @@ import java.lang.annotation.Target;
  * except this annotation need not be attached to a static method
  *
  * @author Steve Ebersole
+ * @deprecated Use JUnit 5 along with one of the Hibernate ORM's class-level test annotations
+ * ({@link org.hibernate.testing.orm.junit.BaseUnitTest},
+ * {@link org.hibernate.testing.orm.junit.SessionFactory},
+ * {@link org.hibernate.testing.orm.junit.Jpa},
+ * {@link org.hibernate.testing.orm.junit.SessionFactoryFunctionalTesting},
+ * {@link org.hibernate.testing.orm.junit.ServiceRegistryFunctionalTesting}, ...)
+ * and {@link org.junit.jupiter.api.AfterAll}.
+ * Alternatively to the Hibernate ORM test annotations,
+ * you can use {@code @TestInstance(TestInstance.Lifecycle.PER_CLASS)} directly on your test.
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ ElementType.METHOD, ElementType.TYPE })
+@Deprecated(forRemoval = true)
 public @interface AfterClassOnce {
 }

--- a/hibernate-testing/src/main/java/org/hibernate/testing/BeforeClassOnce.java
+++ b/hibernate-testing/src/main/java/org/hibernate/testing/BeforeClassOnce.java
@@ -17,8 +17,18 @@ import java.lang.annotation.Target;
  * except this annotation need not be attached to a static method
  *
  * @author Steve Ebersole
+ * @deprecated Use JUnit 5 along with one of the Hibernate ORM's class-level test annotations
+ * ({@link org.hibernate.testing.orm.junit.BaseUnitTest},
+ * {@link org.hibernate.testing.orm.junit.SessionFactory},
+ * {@link org.hibernate.testing.orm.junit.Jpa},
+ * {@link org.hibernate.testing.orm.junit.SessionFactoryFunctionalTesting},
+ * {@link org.hibernate.testing.orm.junit.ServiceRegistryFunctionalTesting}, ...)
+ * and {@link org.junit.jupiter.api.BeforeAll}.
+ * Alternatively to the Hibernate ORM test annotations,
+ * you can use {@code @TestInstance(TestInstance.Lifecycle.PER_CLASS)} directly on your test.
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ ElementType.METHOD, ElementType.TYPE })
+@Deprecated(forRemoval = true)
 public @interface BeforeClassOnce {
 }

--- a/hibernate-testing/src/main/java/org/hibernate/testing/FailureExpected.java
+++ b/hibernate-testing/src/main/java/org/hibernate/testing/FailureExpected.java
@@ -16,9 +16,11 @@ import java.lang.annotation.Target;
  *
  * @author Hardy Ferentschik
  * @author Steve Ebersole
+ * @deprecated Use JUnit 5 and {@link org.hibernate.testing.orm.junit.FailureExpected} instead.
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ ElementType.METHOD, ElementType.TYPE })
+@Deprecated(forRemoval = true)
 public @interface FailureExpected {
 	String VALIDATE_FAILURE_EXPECTED = "hibernate.test.validatefailureexpected";
 

--- a/hibernate-testing/src/main/java/org/hibernate/testing/OnExpectedFailure.java
+++ b/hibernate-testing/src/main/java/org/hibernate/testing/OnExpectedFailure.java
@@ -15,8 +15,10 @@ import java.lang.annotation.Target;
  * Annotation used to identify a method as a callback to be executed whenever a {@link FailureExpected} is handled.
  *
  * @author Steve Ebersole
+ * @deprecated No replacement with JUnit 5 at the moment.
  */
 @Retention( RetentionPolicy.RUNTIME )
 @Target( ElementType.METHOD )
+@Deprecated(forRemoval = true)
 public @interface OnExpectedFailure {
 }

--- a/hibernate-testing/src/main/java/org/hibernate/testing/OnFailure.java
+++ b/hibernate-testing/src/main/java/org/hibernate/testing/OnFailure.java
@@ -15,8 +15,10 @@ import java.lang.annotation.Target;
  * Annotation used to identify a method as a callback to be executed on test failures.
  *
  * @author Steve Ebersole
+ * @deprecated No replacement with JUnit 5 at the moment.
  */
 @Retention( RetentionPolicy.RUNTIME )
 @Target( ElementType.METHOD )
+@Deprecated(forRemoval = true)
 public @interface OnFailure {
 }

--- a/hibernate-testing/src/main/java/org/hibernate/testing/RequiresDialect.java
+++ b/hibernate-testing/src/main/java/org/hibernate/testing/RequiresDialect.java
@@ -21,10 +21,12 @@ import org.hibernate.dialect.Dialect;
  * @see RequiresDialects
  *
  * @author Hardy Ferentschik
+ * @deprecated Use JUnit 5 and {@link org.hibernate.testing.orm.junit.RequiresDialect} instead.
  */
 @Target({ ElementType.METHOD, ElementType.TYPE })
 @Retention(RetentionPolicy.RUNTIME)
 @Repeatable(RequiresDialects.class)
+@Deprecated(forRemoval = true)
 public @interface RequiresDialect {
 	/**
 	 * The dialects against which to run the test

--- a/hibernate-testing/src/main/java/org/hibernate/testing/RequiresDialectFeature.java
+++ b/hibernate-testing/src/main/java/org/hibernate/testing/RequiresDialectFeature.java
@@ -16,9 +16,11 @@ import java.lang.annotation.Target;
  * specified feature.
  *
  * @author Hardy Ferentschik
+ * @deprecated Use JUnit 5 and {@link org.hibernate.testing.orm.junit.RequiresDialectFeature} instead.
  */
 @Target({ ElementType.METHOD, ElementType.TYPE })
 @Retention(RetentionPolicy.RUNTIME)
+@Deprecated(forRemoval = true)
 public @interface RequiresDialectFeature {
 	/**
 	 * @return Class which checks the necessary dialect feature

--- a/hibernate-testing/src/main/java/org/hibernate/testing/RequiresDialects.java
+++ b/hibernate-testing/src/main/java/org/hibernate/testing/RequiresDialects.java
@@ -16,9 +16,11 @@ import java.lang.annotation.Target;
  * Useful when test needs to be run against more than one dialect because of a different reason.
  *
  * @author Lukasz Antoniak
+ * @deprecated Use JUnit 5 and {@link org.hibernate.testing.orm.junit.RequiresDialects} instead.
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ ElementType.METHOD, ElementType.TYPE })
+@Deprecated(forRemoval = true)
 public @interface RequiresDialects {
 	RequiresDialect[] value();
 }

--- a/hibernate-testing/src/main/java/org/hibernate/testing/Skip.java
+++ b/hibernate-testing/src/main/java/org/hibernate/testing/Skip.java
@@ -15,9 +15,12 @@ import java.lang.annotation.Target;
  * An annotation, used in combination with {@link Matcher}, to determine when/if tests should be skipped.
  *
  * @author Steve Ebersole
+ * @deprecated Use JUnit 5 and {@link org.junit.jupiter.api.condition.DisabledOnOs}
+ * or {@link org.junit.jupiter.api.condition.DisabledIf}.
  */
 @Retention( RetentionPolicy.RUNTIME )
 @Target({ ElementType.METHOD, ElementType.TYPE })
+@Deprecated(forRemoval = true)
 public @interface Skip {
 	/**
 	 * The condition which causes a skip

--- a/hibernate-testing/src/main/java/org/hibernate/testing/SkipForDialect.java
+++ b/hibernate-testing/src/main/java/org/hibernate/testing/SkipForDialect.java
@@ -22,10 +22,12 @@ import org.hibernate.dialect.Dialect;
  *
  * @author Hardy Ferentschik
  * @author Steve Ebersole
+ * @deprecated Use JUnit 5 and {@link org.hibernate.testing.orm.junit.SkipForDialect} instead.
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ ElementType.METHOD, ElementType.TYPE })
 @Repeatable(SkipForDialects.class)
+@Deprecated(forRemoval = true)
 public @interface SkipForDialect {
 	/**
 	 * The dialects against which to skip the test

--- a/hibernate-testing/src/main/java/org/hibernate/testing/SkipForDialects.java
+++ b/hibernate-testing/src/main/java/org/hibernate/testing/SkipForDialects.java
@@ -16,9 +16,11 @@ import java.lang.annotation.Target;
  * Useful when more than one dialect needs to be skipped because of a different reason.
  *
  * @author Lukasz Antoniak
+ * @deprecated Use JUnit 5 and {@link org.hibernate.testing.orm.junit.SkipForDialectGroup} instead.
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ ElementType.METHOD, ElementType.TYPE })
+@Deprecated(forRemoval = true)
 public @interface SkipForDialects {
 	SkipForDialect[] value();
 }

--- a/hibernate-testing/src/main/java/org/hibernate/testing/TestForIssue.java
+++ b/hibernate-testing/src/main/java/org/hibernate/testing/TestForIssue.java
@@ -15,9 +15,11 @@ import java.lang.annotation.Target;
  * A documentation annotation for notating what JIRA issue is being tested.
  *
  * @author Steve Ebersole
+ * @deprecated Use {@link org.hibernate.testing.orm.junit.JiraKey} instead.
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ ElementType.METHOD, ElementType.TYPE })
+@Deprecated(forRemoval = true)
 public @interface TestForIssue {
 	/**
 	 * The key of a JIRA issue tested.


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-16497

Technically we could keep `TestForIssue` undeprecated since it "works" on JUnit 5 as well, but I suppose `org.hibernate.testing.orm.junit.JiraKey` was introduced for a reason, so we may as well avoid duplicating the feature.

Personally I wouldn't backport to 6.2, but YMMV.