### PR TITLE
Add @NonNull for the return type of getReferencedProperty

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/mapping/PersistentClass.java
+++ b/hibernate-core/src/main/java/org/hibernate/mapping/PersistentClass.java
@@ -17,6 +17,8 @@ import java.util.Map;
 import java.util.Set;
 import java.util.StringTokenizer;
 
+import org.checkerframework.checker.nullness.qual.NonNull;
+
 import org.hibernate.MappingException;
 import org.hibernate.Remove;
 import org.hibernate.boot.Metadata;
@@ -550,7 +552,7 @@ public abstract class PersistentClass implements IdentifiableTypeClass, Attribut
 	 *
 	 * @throws MappingException If the property could not be found.
 	 */
-	public Property getReferencedProperty(String propertyPath) throws MappingException {
+	public @NonNull Property getReferencedProperty(String propertyPath) throws MappingException {
 		try {
 			return getRecursiveProperty( propertyPath, getReferenceableProperties() );
 		}


### PR DESCRIPTION
This PR adds @NonNull for the return type of `getReferencedProperty` method to signify that the return value of the method is not null.