### PR TITLE
 HHH-16125 introduce JdbcTypeConstructor instead of using JdbcTypes as their own factories

### DIFF
--- a/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/CockroachLegacyDialect.java
+++ b/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/CockroachLegacyDialect.java
@@ -72,8 +72,8 @@ import org.hibernate.sql.ast.tree.Statement;
 import org.hibernate.sql.exec.spi.JdbcOperation;
 import org.hibernate.tool.schema.extract.spi.ColumnTypeInformation;
 import org.hibernate.type.JavaObjectType;
-import org.hibernate.type.descriptor.jdbc.ArrayJdbcType;
 import org.hibernate.type.descriptor.jdbc.JdbcType;
+import org.hibernate.type.descriptor.jdbc.JdbcTypeConstructor;
 import org.hibernate.type.descriptor.jdbc.ObjectNullAsBinaryTypeJdbcType;
 import org.hibernate.type.descriptor.jdbc.UUIDJdbcType;
 import org.hibernate.type.descriptor.jdbc.VarbinaryJdbcType;
@@ -285,13 +285,13 @@ public class CockroachLegacyDialect extends Dialect {
 				}
 				break;
 			case ARRAY:
-				final JdbcType jdbcType = jdbcTypeRegistry.getDescriptor( jdbcTypeCode );
+				final JdbcTypeConstructor jdbcTypeConstructor = jdbcTypeRegistry.getConstructor( jdbcTypeCode );
 				// PostgreSQL names array types by prepending an underscore to the base name
-				if ( jdbcType instanceof ArrayJdbcType && columnTypeName.charAt( 0 ) == '_' ) {
+				if ( jdbcTypeConstructor != null && columnTypeName.charAt( 0 ) == '_' ) {
 					final String componentTypeName = columnTypeName.substring( 1 );
 					final Integer sqlTypeCode = resolveSqlTypeCode( componentTypeName, jdbcTypeRegistry.getTypeConfiguration() );
 					if ( sqlTypeCode != null ) {
-						return ( (ArrayJdbcType) jdbcType ).resolveType(
+						return jdbcTypeConstructor.resolveType(
 								jdbcTypeRegistry.getTypeConfiguration(),
 								this,
 								jdbcTypeRegistry.getDescriptor( sqlTypeCode ),
@@ -299,7 +299,7 @@ public class CockroachLegacyDialect extends Dialect {
 						);
 					}
 				}
-				return jdbcType;
+				break;
 		}
 		return jdbcTypeRegistry.getDescriptor( jdbcTypeCode );
 	}

--- a/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/OracleLegacyDialect.java
+++ b/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/OracleLegacyDialect.java
@@ -793,7 +793,7 @@ public class OracleLegacyDialect extends Dialect {
 		}
 
 		if ( OracleJdbcHelper.isUsable( serviceRegistry ) ) {
-			typeContributions.contributeJdbcType( OracleJdbcHelper.getArrayJdbcType( serviceRegistry ) );
+			typeContributions.contributeJdbcTypeConstructor( OracleJdbcHelper.getArrayJdbcTypeConstructor( serviceRegistry ) );
 		}
 		else {
 			typeContributions.contributeJdbcType( OracleReflectionStructJdbcType.INSTANCE );

--- a/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/PostgreSQLLegacyDialect.java
+++ b/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/PostgreSQLLegacyDialect.java
@@ -89,10 +89,10 @@ import org.hibernate.tool.schema.extract.spi.ColumnTypeInformation;
 import org.hibernate.type.JavaObjectType;
 import org.hibernate.type.descriptor.java.PrimitiveByteArrayJavaType;
 import org.hibernate.type.descriptor.jdbc.AggregateJdbcType;
-import org.hibernate.type.descriptor.jdbc.ArrayJdbcType;
 import org.hibernate.type.descriptor.jdbc.BlobJdbcType;
 import org.hibernate.type.descriptor.jdbc.ClobJdbcType;
 import org.hibernate.type.descriptor.jdbc.JdbcType;
+import org.hibernate.type.descriptor.jdbc.JdbcTypeConstructor;
 import org.hibernate.type.descriptor.jdbc.ObjectNullAsBinaryTypeJdbcType;
 import org.hibernate.type.descriptor.jdbc.UUIDJdbcType;
 import org.hibernate.type.descriptor.jdbc.XmlJdbcType;
@@ -337,13 +337,13 @@ public class PostgreSQLLegacyDialect extends Dialect {
 				}
 				break;
 			case ARRAY:
-				final JdbcType jdbcType = jdbcTypeRegistry.getDescriptor( jdbcTypeCode );
+				final JdbcTypeConstructor jdbcTypeConstructor = jdbcTypeRegistry.getConstructor( jdbcTypeCode );
 				// PostgreSQL names array types by prepending an underscore to the base name
-				if ( jdbcType instanceof ArrayJdbcType && columnTypeName.charAt( 0 ) == '_' ) {
+				if ( jdbcTypeConstructor != null && columnTypeName.charAt( 0 ) == '_' ) {
 					final String componentTypeName = columnTypeName.substring( 1 );
 					final Integer sqlTypeCode = resolveSqlTypeCode( componentTypeName, jdbcTypeRegistry.getTypeConfiguration() );
 					if ( sqlTypeCode != null ) {
-						return ( (ArrayJdbcType) jdbcType ).resolveType(
+						return jdbcTypeConstructor.resolveType(
 								jdbcTypeRegistry.getTypeConfiguration(),
 								this,
 								jdbcTypeRegistry.getDescriptor( sqlTypeCode ),
@@ -351,7 +351,7 @@ public class PostgreSQLLegacyDialect extends Dialect {
 						);
 					}
 				}
-				return jdbcType;
+				break;
 			case STRUCT:
 				final AggregateJdbcType aggregateDescriptor = jdbcTypeRegistry.findAggregateDescriptor( columnTypeName );
 				if ( aggregateDescriptor != null ) {

--- a/hibernate-core/src/main/java/org/hibernate/boot/model/TypeContributions.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/TypeContributions.java
@@ -13,6 +13,7 @@ import org.hibernate.type.CustomType;
 import org.hibernate.type.StandardBasicTypeTemplate;
 import org.hibernate.type.descriptor.java.JavaType;
 import org.hibernate.type.descriptor.java.spi.JavaTypeRegistry;
+import org.hibernate.type.descriptor.jdbc.JdbcTypeConstructor;
 import org.hibernate.type.descriptor.jdbc.spi.JdbcTypeRegistry;
 import org.hibernate.type.descriptor.jdbc.JdbcType;
 import org.hibernate.type.spi.TypeConfiguration;
@@ -46,6 +47,10 @@ public interface TypeContributions {
 	 */
 	default void contributeJdbcType(JdbcType descriptor) {
 		getTypeConfiguration().getJdbcTypeRegistry().addDescriptor( descriptor );
+	}
+
+	default void contributeJdbcTypeConstructor(JdbcTypeConstructor typeConstructor) {
+		getTypeConfiguration().getJdbcTypeRegistry().addTypeConstructor( typeConstructor );
 	}
 
 	/**

--- a/hibernate-core/src/main/java/org/hibernate/dialect/CockroachDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/CockroachDialect.java
@@ -59,8 +59,8 @@ import org.hibernate.sql.ast.tree.Statement;
 import org.hibernate.sql.exec.spi.JdbcOperation;
 import org.hibernate.tool.schema.extract.spi.ColumnTypeInformation;
 import org.hibernate.type.JavaObjectType;
-import org.hibernate.type.descriptor.jdbc.ArrayJdbcType;
 import org.hibernate.type.descriptor.jdbc.JdbcType;
+import org.hibernate.type.descriptor.jdbc.JdbcTypeConstructor;
 import org.hibernate.type.descriptor.jdbc.ObjectNullAsBinaryTypeJdbcType;
 import org.hibernate.type.descriptor.jdbc.UUIDJdbcType;
 import org.hibernate.type.descriptor.jdbc.VarbinaryJdbcType;
@@ -304,13 +304,13 @@ public class CockroachDialect extends Dialect {
 				}
 				break;
 			case ARRAY:
-				final JdbcType jdbcType = jdbcTypeRegistry.getDescriptor( jdbcTypeCode );
+				final JdbcTypeConstructor jdbcTypeConstructor = jdbcTypeRegistry.getConstructor( jdbcTypeCode );
 				// PostgreSQL names array types by prepending an underscore to the base name
-				if ( jdbcType instanceof ArrayJdbcType && columnTypeName.charAt( 0 ) == '_' ) {
+				if ( jdbcTypeConstructor != null && columnTypeName.charAt( 0 ) == '_' ) {
 					final String componentTypeName = columnTypeName.substring( 1 );
 					final Integer sqlTypeCode = resolveSqlTypeCode( componentTypeName, jdbcTypeRegistry.getTypeConfiguration() );
 					if ( sqlTypeCode != null ) {
-						return ( (ArrayJdbcType) jdbcType ).resolveType(
+						return jdbcTypeConstructor.resolveType(
 								jdbcTypeRegistry.getTypeConfiguration(),
 								this,
 								jdbcTypeRegistry.getDescriptor( sqlTypeCode ),
@@ -318,7 +318,7 @@ public class CockroachDialect extends Dialect {
 						);
 					}
 				}
-				return jdbcType;
+				break;
 		}
 		return jdbcTypeRegistry.getDescriptor( jdbcTypeCode );
 	}

--- a/hibernate-core/src/main/java/org/hibernate/dialect/OracleArrayJdbcTypeConstructor.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/OracleArrayJdbcTypeConstructor.java
@@ -1,0 +1,56 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.dialect;
+
+import org.hibernate.tool.schema.extract.spi.ColumnTypeInformation;
+import org.hibernate.type.BasicType;
+import org.hibernate.type.descriptor.jdbc.JdbcType;
+import org.hibernate.type.descriptor.jdbc.JdbcTypeConstructor;
+import org.hibernate.type.spi.TypeConfiguration;
+
+import java.sql.Types;
+
+/**
+ * Factory for {@link OracleArrayJdbcType}.
+ *
+ * @see OracleJdbcHelper#getArrayJdbcTypeConstructor
+ *
+ * @author Gavin King
+ */
+public class OracleArrayJdbcTypeConstructor implements JdbcTypeConstructor {
+	@Override
+	public JdbcType resolveType(
+			TypeConfiguration typeConfiguration,
+			Dialect dialect, BasicType<?> elementType,
+			ColumnTypeInformation columnTypeInformation) {
+		String typeName = columnTypeInformation.getTypeName();
+		if ( typeName == null || typeName.isBlank() ) {
+			typeName = OracleArrayJdbcType.getTypeName( elementType.getJavaTypeDescriptor(), dialect );
+		}
+//		if ( typeName == null ) {
+//			// Fallback to XML type for the representation of arrays as the native JSON type was only introduced in 21
+//			// Also, use the XML type if the Oracle JDBC driver classes are not visible
+//			return typeConfiguration.getJdbcTypeRegistry().getDescriptor( SqlTypes.SQLXML );
+//		}
+		return new OracleArrayJdbcType( elementType.getJdbcType(), typeName );
+	}
+
+	@Override
+	public JdbcType resolveType(
+			TypeConfiguration typeConfiguration,
+			Dialect dialect,
+			JdbcType elementType,
+			ColumnTypeInformation columnTypeInformation) {
+		// a bit wrong, since columnTypeInformation.getTypeName() is typically null!
+		return new OracleArrayJdbcType( elementType, columnTypeInformation.getTypeName() );
+	}
+
+	@Override
+	public int getDefaultSqlTypeCode() {
+		return Types.ARRAY;
+	}
+}

--- a/hibernate-core/src/main/java/org/hibernate/dialect/OracleDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/OracleDialect.java
@@ -99,6 +99,7 @@ import static org.hibernate.LockOptions.NO_WAIT;
 import static org.hibernate.LockOptions.SKIP_LOCKED;
 import static org.hibernate.LockOptions.WAIT_FOREVER;
 import static org.hibernate.cfg.AvailableSettings.BATCH_VERSIONED_DATA;
+import static org.hibernate.dialect.OracleJdbcHelper.getArrayJdbcTypeConstructor;
 import static org.hibernate.exception.spi.TemplatedViolatedConstraintNameExtractor.extractUsingTemplate;
 import static org.hibernate.internal.util.StringHelper.isEmpty;
 import static org.hibernate.query.sqm.TemporalUnit.DAY;
@@ -831,7 +832,7 @@ public class OracleDialect extends Dialect {
 		}
 
 		if ( OracleJdbcHelper.isUsable( serviceRegistry ) ) {
-			typeContributions.contributeJdbcType( OracleJdbcHelper.getArrayJdbcType( serviceRegistry ) );
+			typeContributions.contributeJdbcTypeConstructor( getArrayJdbcTypeConstructor( serviceRegistry ) );
 		}
 		else {
 			typeContributions.contributeJdbcType( OracleReflectionStructJdbcType.INSTANCE );

--- a/hibernate-core/src/main/java/org/hibernate/dialect/OracleJdbcHelper.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/OracleJdbcHelper.java
@@ -6,7 +6,6 @@
  */
 package org.hibernate.dialect;
 
-import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 
 import org.hibernate.HibernateError;
@@ -14,6 +13,7 @@ import org.hibernate.boot.registry.classloading.spi.ClassLoaderService;
 import org.hibernate.boot.registry.classloading.spi.ClassLoadingException;
 import org.hibernate.service.ServiceRegistry;
 import org.hibernate.type.descriptor.jdbc.JdbcType;
+import org.hibernate.type.descriptor.jdbc.JdbcTypeConstructor;
 
 /**
  * The following class provides some convenience methods for accessing JdbcType instance,
@@ -34,20 +34,18 @@ public class OracleJdbcHelper {
 		}
 	}
 
-	public static JdbcType getArrayJdbcType(ServiceRegistry serviceRegistry) {
-		return createJdbcType( serviceRegistry, "org.hibernate.dialect.OracleArrayJdbcType" );
+	public static JdbcTypeConstructor getArrayJdbcTypeConstructor(ServiceRegistry serviceRegistry) {
+		return create( serviceRegistry, "org.hibernate.dialect.OracleArrayJdbcTypeConstructor" );
 	}
 
 	public static JdbcType getStructJdbcType(ServiceRegistry serviceRegistry) {
-		return createJdbcType( serviceRegistry, "org.hibernate.dialect.OracleStructJdbcType" );
+		return create( serviceRegistry, "org.hibernate.dialect.OracleStructJdbcType" );
 	}
 
-	public static JdbcType createJdbcType(ServiceRegistry serviceRegistry, String className) {
+	public static <X> X create(ServiceRegistry serviceRegistry, String className) {
 		final ClassLoaderService classLoaderService = serviceRegistry.getService( ClassLoaderService.class );
 		try {
-			final Class<?> clazz = classLoaderService.classForName( className );
-			final Constructor<?> constructor = clazz.getConstructor();
-			return (JdbcType) constructor.newInstance();
+			return classLoaderService.<X>classForName( className ).getConstructor().newInstance();
 		}
 		catch (NoSuchMethodException e) {
 			throw new HibernateError( "Class does not have an empty constructor", e );

--- a/hibernate-core/src/main/java/org/hibernate/dialect/PostgreSQLDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/PostgreSQLDialect.java
@@ -82,6 +82,7 @@ import org.hibernate.type.descriptor.jdbc.ArrayJdbcType;
 import org.hibernate.type.descriptor.jdbc.BlobJdbcType;
 import org.hibernate.type.descriptor.jdbc.ClobJdbcType;
 import org.hibernate.type.descriptor.jdbc.JdbcType;
+import org.hibernate.type.descriptor.jdbc.JdbcTypeConstructor;
 import org.hibernate.type.descriptor.jdbc.ObjectNullAsBinaryTypeJdbcType;
 import org.hibernate.type.descriptor.jdbc.UUIDJdbcType;
 import org.hibernate.type.descriptor.jdbc.XmlJdbcType;
@@ -316,13 +317,13 @@ public class PostgreSQLDialect extends Dialect {
 				}
 				break;
 			case ARRAY:
-				final JdbcType jdbcType = jdbcTypeRegistry.getDescriptor( jdbcTypeCode );
+				final JdbcTypeConstructor jdbcTypeConstructor = jdbcTypeRegistry.getConstructor( jdbcTypeCode );
 				// PostgreSQL names array types by prepending an underscore to the base name
-				if ( jdbcType instanceof ArrayJdbcType && columnTypeName.charAt( 0 ) == '_' ) {
+				if ( jdbcTypeConstructor != null && columnTypeName.charAt( 0 ) == '_' ) {
 					final String componentTypeName = columnTypeName.substring( 1 );
 					final Integer sqlTypeCode = resolveSqlTypeCode( componentTypeName, jdbcTypeRegistry.getTypeConfiguration() );
 					if ( sqlTypeCode != null ) {
-						return ( (ArrayJdbcType) jdbcType ).resolveType(
+						return jdbcTypeConstructor.resolveType(
 								jdbcTypeRegistry.getTypeConfiguration(),
 								this,
 								jdbcTypeRegistry.getDescriptor( sqlTypeCode ),
@@ -330,7 +331,7 @@ public class PostgreSQLDialect extends Dialect {
 						);
 					}
 				}
-				return jdbcType;
+				break;
 			case STRUCT:
 				final AggregateJdbcType aggregateDescriptor = jdbcTypeRegistry.findAggregateDescriptor( columnTypeName );
 				if ( aggregateDescriptor != null ) {

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/jdbc/ArrayJdbcType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/jdbc/ArrayJdbcType.java
@@ -14,11 +14,8 @@ import java.sql.SQLException;
 import java.sql.Types;
 
 import org.hibernate.HibernateException;
-import org.hibernate.dialect.Dialect;
 import org.hibernate.engine.jdbc.Size;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
-import org.hibernate.tool.schema.extract.spi.ColumnTypeInformation;
-import org.hibernate.type.BasicType;
 import org.hibernate.type.descriptor.ValueBinder;
 import org.hibernate.type.descriptor.ValueExtractor;
 import org.hibernate.type.descriptor.WrapperOptions;
@@ -39,28 +36,10 @@ import org.hibernate.type.spi.TypeConfiguration;
  */
 public class ArrayJdbcType implements JdbcType {
 
-	public static final ArrayJdbcType INSTANCE = new ArrayJdbcType( ObjectJdbcType.INSTANCE );
-
 	private final JdbcType elementJdbcType;
 
 	public ArrayJdbcType(JdbcType elementJdbcType) {
 		this.elementJdbcType = elementJdbcType;
-	}
-
-	public JdbcType resolveType(
-			TypeConfiguration typeConfiguration,
-			Dialect dialect,
-			BasicType<?> elementType,
-			ColumnTypeInformation columnTypeInformation) {
-		return resolveType( typeConfiguration, dialect, elementType.getJdbcType(), columnTypeInformation );
-	}
-
-	public JdbcType resolveType(
-			TypeConfiguration typeConfiguration,
-			Dialect dialect,
-			JdbcType elementType,
-			ColumnTypeInformation columnTypeInformation) {
-		return new ArrayJdbcType( elementType );
 	}
 
 	@Override
@@ -219,6 +198,6 @@ public class ArrayJdbcType implements JdbcType {
 
 	@Override
 	public String toString() {
-		return "ArrayTypeDescriptor(" + getFriendlyName() + ")";
+		return "ArrayTypeDescriptor";
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/jdbc/ArrayJdbcTypeConstructor.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/jdbc/ArrayJdbcTypeConstructor.java
@@ -1,0 +1,44 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.type.descriptor.jdbc;
+
+import org.hibernate.dialect.Dialect;
+import org.hibernate.tool.schema.extract.spi.ColumnTypeInformation;
+import org.hibernate.type.BasicType;
+import org.hibernate.type.spi.TypeConfiguration;
+
+import java.sql.Types;
+
+/**
+ * Factory for {@link ArrayJdbcType}.
+ *
+ * @author Gavin King
+ */
+public class ArrayJdbcTypeConstructor implements JdbcTypeConstructor {
+	public static final ArrayJdbcTypeConstructor INSTANCE = new ArrayJdbcTypeConstructor();
+
+	public JdbcType resolveType(
+			TypeConfiguration typeConfiguration,
+			Dialect dialect,
+			BasicType<?> elementType,
+			ColumnTypeInformation columnTypeInformation) {
+		return resolveType( typeConfiguration, dialect, elementType.getJdbcType(), columnTypeInformation );
+	}
+
+	public JdbcType resolveType(
+			TypeConfiguration typeConfiguration,
+			Dialect dialect,
+			JdbcType elementType,
+			ColumnTypeInformation columnTypeInformation) {
+		return new ArrayJdbcType( elementType );
+	}
+
+	@Override
+	public int getDefaultSqlTypeCode() {
+		return Types.ARRAY;
+	}
+}

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/jdbc/JdbcTypeConstructor.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/jdbc/JdbcTypeConstructor.java
@@ -1,0 +1,50 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.type.descriptor.jdbc;
+
+import org.hibernate.dialect.Dialect;
+import org.hibernate.tool.schema.extract.spi.ColumnTypeInformation;
+import org.hibernate.type.BasicType;
+import org.hibernate.type.spi.TypeConfiguration;
+
+/**
+ * Factory for any {@link JdbcType} which is parameterized by
+ * a second {@code JdbcType}, the "element" type.
+ * <p>
+ * For example, {@link ArrayJdbcType} is parameterized by the
+ * type of its elements.
+ *
+ * @author Gavin King
+ */
+public interface JdbcTypeConstructor {
+	/**
+	 * Called by {@link org.hibernate.type.descriptor.java.ArrayJavaType}
+	 * and friends. Here we already know the type argument, which
+	 * we're given as a {@link BasicType}.
+	 */
+	default JdbcType resolveType(
+			TypeConfiguration typeConfiguration,
+			Dialect dialect,
+			BasicType<?> elementType,
+			ColumnTypeInformation columnTypeInformation) {
+		return resolveType( typeConfiguration, dialect, elementType.getJdbcType(), columnTypeInformation );
+	}
+
+	/**
+	 * Called from {@link Dialect#resolveSqlTypeDescriptor} when
+	 * inferring {@link JdbcType}s from a JDBC {@code ResultSet}
+	 * or when reverse-engineering a schema. Here we do not have
+	 * a known {@link BasicType}.
+	 */
+	JdbcType resolveType(
+			TypeConfiguration typeConfiguration,
+			Dialect dialect,
+			JdbcType elementType,
+			ColumnTypeInformation columnTypeInformation);
+
+	int getDefaultSqlTypeCode();
+}


### PR DESCRIPTION
previously, there was a global instance of `ArrayJdbcType` registered by the `Dialect`s, in an inconsistent state, that acted as a factory for correctly-initialized instances