### PR TITLE
HHH-16538 Keep using `javax.validation.ConstraintViolation` as fallback

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/boot/beanvalidation/BeanValidationIntegrator.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/beanvalidation/BeanValidationIntegrator.java
@@ -36,7 +36,7 @@ public class BeanValidationIntegrator implements Integrator {
 
 	public static final String APPLY_CONSTRAINTS = "hibernate.validator.apply_to_ddl";
 
-	public static final String BV_CHECK_CLASS = "jakarta.validation.ConstraintViolation";
+	public static final String BV_CHECK_CLASS = "javax.validation.ConstraintViolation";
 	public static final String JAKARTA_BV_CHECK_CLASS = "jakarta.validation.ConstraintViolation";
 
 	public static final String MODE_PROPERTY = "javax.persistence.validation.mode";


### PR DESCRIPTION
Fixes https://hibernate.atlassian.net/browse/HHH-16538

Should also be ported to the `main` branch (and maybe to 6.1 and/or 6.0 if they are still maintained?)