### PR TITLE
HHH-16544 POC support for Oracle nested tables

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/boot/model/internal/BasicValueBinder.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/internal/BasicValueBinder.java
@@ -74,6 +74,7 @@ import org.hibernate.type.descriptor.java.JavaType;
 import org.hibernate.type.descriptor.java.MutabilityPlan;
 import org.hibernate.type.descriptor.jdbc.JdbcType;
 import org.hibernate.type.descriptor.jdbc.JdbcTypeIndicators;
+import org.hibernate.type.descriptor.jdbc.spi.JdbcTypeRegistry;
 import org.hibernate.type.spi.TypeConfiguration;
 import org.hibernate.usertype.DynamicParameterizedType;
 import org.hibernate.usertype.UserType;
@@ -152,6 +153,7 @@ public class BasicValueBinder implements JdbcTypeIndicators {
 	private TemporalType temporalPrecision;
 	private TimeZoneStorageType timeZoneStorageType;
 	private boolean partitionKey;
+	private Integer jdbcTypeCode;
 
 	private Table table;
 	private AnnotatedColumns columns;
@@ -940,7 +942,13 @@ public class BasicValueBinder implements JdbcTypeIndicators {
 			if ( jdbcTypeCodeAnn != null ) {
 				final int jdbcTypeCode = jdbcTypeCodeAnn.value();
 				if ( jdbcTypeCode != Integer.MIN_VALUE ) {
-					return typeConfiguration.getJdbcTypeRegistry().getDescriptor( jdbcTypeCode );
+					final JdbcTypeRegistry jdbcTypeRegistry = typeConfiguration.getJdbcTypeRegistry();
+					if ( jdbcTypeRegistry.getConstructor( jdbcTypeCode ) != null ) {
+						return null;
+					}
+					else {
+						return jdbcTypeRegistry.getDescriptor( jdbcTypeCode );
+					}
 				}
 			}
 
@@ -1052,15 +1060,15 @@ public class BasicValueBinder implements JdbcTypeIndicators {
 	private void normalSupplementalDetails(XProperty attributeXProperty) {
 
 		explicitJavaTypeAccess = typeConfiguration -> {
-			final org.hibernate.annotations.JavaType javaTypeAnn = findAnnotation( attributeXProperty, org.hibernate.annotations.JavaType.class );
-			if ( javaTypeAnn != null ) {
-				final Class<? extends BasicJavaType<?>> javaTypeClass = normalizeJavaType( javaTypeAnn.value() );
+			final org.hibernate.annotations.JavaType javaType =
+					findAnnotation( attributeXProperty, org.hibernate.annotations.JavaType.class );
+			if ( javaType != null ) {
+				final Class<? extends BasicJavaType<?>> javaTypeClass = normalizeJavaType( javaType.value() );
 				if ( javaTypeClass != null ) {
 					if ( buildingContext.getBuildingOptions().disallowExtensionsInCdi() ) {
 						return FallbackBeanInstanceProducer.INSTANCE.produceBeanInstance( javaTypeClass );
 					}
-					final ManagedBean<? extends BasicJavaType<?>> jtdBean = getManagedBeanRegistry().getBean( javaTypeClass );
-					return jtdBean.getBeanInstance();
+					return getManagedBeanRegistry().getBean( javaTypeClass ).getBeanInstance();
 				}
 			}
 
@@ -1072,22 +1080,28 @@ public class BasicValueBinder implements JdbcTypeIndicators {
 			return null;
 		};
 
+		final org.hibernate.annotations.JdbcTypeCode jdbcType =
+				findAnnotation( attributeXProperty, org.hibernate.annotations.JdbcTypeCode.class );
+		if ( jdbcType != null ) {
+			jdbcTypeCode = jdbcType.value();
+		}
+
 		normalJdbcTypeDetails( attributeXProperty);
 		normalMutabilityDetails( attributeXProperty );
 
-		final Enumerated enumeratedAnn = attributeXProperty.getAnnotation( Enumerated.class );
-		if ( enumeratedAnn != null ) {
-			enumType = enumeratedAnn.value();
+		final Enumerated enumerated = attributeXProperty.getAnnotation( Enumerated.class );
+		if ( enumerated != null ) {
+			enumType = enumerated.value();
 		}
 
-		final Temporal temporalAnn = attributeXProperty.getAnnotation( Temporal.class );
-		if ( temporalAnn != null ) {
-			temporalPrecision = temporalAnn.value();
+		final Temporal temporal = attributeXProperty.getAnnotation( Temporal.class );
+		if ( temporal != null ) {
+			temporalPrecision = temporal.value();
 		}
 
-		final TimeZoneStorage timeZoneStorageAnn = attributeXProperty.getAnnotation( TimeZoneStorage.class );
-		if ( timeZoneStorageAnn != null ) {
-			timeZoneStorageType = timeZoneStorageAnn.value();
+		final TimeZoneStorage timeZoneStorage = attributeXProperty.getAnnotation( TimeZoneStorage.class );
+		if ( timeZoneStorage != null ) {
+			timeZoneStorageType = timeZoneStorage.value();
 			final TimeZoneColumn timeZoneColumnAnn = attributeXProperty.getAnnotation( TimeZoneColumn.class );
 			if ( timeZoneColumnAnn != null ) {
 				if ( timeZoneStorageType != TimeZoneStorageType.AUTO && timeZoneStorageType != TimeZoneStorageType.COLUMN ) {
@@ -1221,6 +1235,10 @@ public class BasicValueBinder implements JdbcTypeIndicators {
 
 		if ( temporalPrecision != null ) {
 			basicValue.setTemporalPrecision( temporalPrecision );
+		}
+
+		if ( jdbcTypeCode != null ) {
+			basicValue.setExplicitJdbcTypeCode( jdbcTypeCode );
 		}
 
 		linkWithValue();

--- a/hibernate-core/src/main/java/org/hibernate/boot/model/process/internal/InferredBasicValueResolver.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/process/internal/InferredBasicValueResolver.java
@@ -72,7 +72,7 @@ public class InferredBasicValueResolver {
 
 		final BasicType<T> jdbcMapping;
 
-		if (explicitJavaType != null) {
+		if ( explicitJavaType != null ) {
 			// we have an explicit JavaType
 			if ( isTemporal( explicitJavaType ) ) {
 				return fromTemporal(
@@ -85,26 +85,21 @@ public class InferredBasicValueResolver {
 			}
 			else if ( explicitJdbcType != null ) {
 				// we also have an explicit JdbcType
-				jdbcMapping = typeConfiguration.getBasicTypeRegistry().resolve(
-						explicitJavaType,
-						explicitJdbcType
-				);
+				jdbcMapping = typeConfiguration.getBasicTypeRegistry().resolve( explicitJavaType, explicitJdbcType );
 			}
 			else {
 				// we need to infer the JdbcType and use that to build the value-mapping
 				final JdbcType inferredJdbcType = explicitJavaType.getRecommendedJdbcType( stdIndicators );
-				if ( inferredJdbcType instanceof ObjectJdbcType && ( explicitJavaType instanceof SerializableJavaType
-						|| explicitJavaType.getJavaType() instanceof Serializable ) ) {
+				if ( inferredJdbcType instanceof ObjectJdbcType
+						&& ( explicitJavaType instanceof SerializableJavaType
+							|| explicitJavaType.getJavaType() instanceof Serializable ) ) {
 					// Use the SerializableType if possible since ObjectJdbcType is our fallback
 					jdbcMapping = new SerializableType( explicitJavaType );
 				}
 				else {
 					jdbcMapping = resolveSqlTypeIndicators(
 							stdIndicators,
-							typeConfiguration.getBasicTypeRegistry().resolve(
-									explicitJavaType,
-									inferredJdbcType
-							),
+							typeConfiguration.getBasicTypeRegistry().resolve( explicitJavaType, inferredJdbcType ),
 							explicitJavaType
 					);
 				}
@@ -201,10 +196,7 @@ public class InferredBasicValueResolver {
 					if ( recommendedJdbcType != null ) {
 						jdbcMapping = resolveSqlTypeIndicators(
 								stdIndicators,
-								typeConfiguration.getBasicTypeRegistry().resolve(
-										reflectedJtd,
-										recommendedJdbcType
-								),
+								typeConfiguration.getBasicTypeRegistry().resolve( reflectedJtd, recommendedJdbcType ),
 								reflectedJtd
 						);
 					}
@@ -241,18 +233,11 @@ public class InferredBasicValueResolver {
 					}
 				}
 
-				final JavaType<T> recommendedJtd = explicitJdbcType.getJdbcRecommendedJavaTypeMapping(
-						length,
-						scale,
-						typeConfiguration
-				);
-
+				final JavaType<T> recommendedJtd =
+						explicitJdbcType.getJdbcRecommendedJavaTypeMapping( length, scale, typeConfiguration );
 				jdbcMapping = resolveSqlTypeIndicators(
 						stdIndicators,
-						typeConfiguration.getBasicTypeRegistry().resolve(
-								recommendedJtd,
-								explicitJdbcType
-						),
+						typeConfiguration.getBasicTypeRegistry().resolve( recommendedJtd, explicitJdbcType ),
 						recommendedJtd
 				);
 			}

--- a/hibernate-core/src/main/java/org/hibernate/dialect/OracleDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/OracleDialect.java
@@ -100,6 +100,7 @@ import static org.hibernate.LockOptions.SKIP_LOCKED;
 import static org.hibernate.LockOptions.WAIT_FOREVER;
 import static org.hibernate.cfg.AvailableSettings.BATCH_VERSIONED_DATA;
 import static org.hibernate.dialect.OracleJdbcHelper.getArrayJdbcTypeConstructor;
+import static org.hibernate.dialect.OracleJdbcHelper.getNestedTableJdbcTypeConstructor;
 import static org.hibernate.exception.spi.TemplatedViolatedConstraintNameExtractor.extractUsingTemplate;
 import static org.hibernate.internal.util.StringHelper.isEmpty;
 import static org.hibernate.query.sqm.TemporalUnit.DAY;
@@ -125,6 +126,7 @@ import static org.hibernate.type.SqlTypes.REAL;
 import static org.hibernate.type.SqlTypes.SMALLINT;
 import static org.hibernate.type.SqlTypes.SQLXML;
 import static org.hibernate.type.SqlTypes.STRUCT;
+import static org.hibernate.type.SqlTypes.TABLE;
 import static org.hibernate.type.SqlTypes.TIME;
 import static org.hibernate.type.SqlTypes.TIME_WITH_TIMEZONE;
 import static org.hibernate.type.SqlTypes.TINYINT;
@@ -689,6 +691,7 @@ public class OracleDialect extends Dialect {
 		}
 
 		ddlTypeRegistry.addDescriptor( new ArrayDdlTypeImpl( this ) );
+		ddlTypeRegistry.addDescriptor( TABLE, new ArrayDdlTypeImpl( this ) );
 	}
 
 	@Override
@@ -833,6 +836,7 @@ public class OracleDialect extends Dialect {
 
 		if ( OracleJdbcHelper.isUsable( serviceRegistry ) ) {
 			typeContributions.contributeJdbcTypeConstructor( getArrayJdbcTypeConstructor( serviceRegistry ) );
+			typeContributions.contributeJdbcTypeConstructor( getNestedTableJdbcTypeConstructor( serviceRegistry ) );
 		}
 		else {
 			typeContributions.contributeJdbcType( OracleReflectionStructJdbcType.INSTANCE );

--- a/hibernate-core/src/main/java/org/hibernate/dialect/OracleJdbcHelper.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/OracleJdbcHelper.java
@@ -38,11 +38,15 @@ public class OracleJdbcHelper {
 		return create( serviceRegistry, "org.hibernate.dialect.OracleArrayJdbcTypeConstructor" );
 	}
 
+	public static JdbcTypeConstructor getNestedTableJdbcTypeConstructor(ServiceRegistry serviceRegistry) {
+		return create( serviceRegistry, "org.hibernate.dialect.OracleNestedTableJdbcTypeConstructor" );
+	}
+
 	public static JdbcType getStructJdbcType(ServiceRegistry serviceRegistry) {
 		return create( serviceRegistry, "org.hibernate.dialect.OracleStructJdbcType" );
 	}
 
-	public static <X> X create(ServiceRegistry serviceRegistry, String className) {
+	private static <X> X create(ServiceRegistry serviceRegistry, String className) {
 		final ClassLoaderService classLoaderService = serviceRegistry.getService( ClassLoaderService.class );
 		try {
 			return classLoaderService.<X>classForName( className ).getConstructor().newInstance();

--- a/hibernate-core/src/main/java/org/hibernate/dialect/OracleNestedTableJdbcTypeConstructor.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/OracleNestedTableJdbcTypeConstructor.java
@@ -1,0 +1,50 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.dialect;
+
+import org.hibernate.tool.schema.extract.spi.ColumnTypeInformation;
+import org.hibernate.type.BasicType;
+import org.hibernate.type.SqlTypes;
+import org.hibernate.type.descriptor.jdbc.JdbcType;
+import org.hibernate.type.descriptor.jdbc.JdbcTypeConstructor;
+import org.hibernate.type.spi.TypeConfiguration;
+
+/**
+ * Factory for {@link OracleNestedTableJdbcType}.
+ *
+ * @see OracleJdbcHelper#getArrayJdbcTypeConstructor
+ *
+ * @author Gavin King
+ */
+public class OracleNestedTableJdbcTypeConstructor implements JdbcTypeConstructor {
+	@Override
+	public JdbcType resolveType(
+			TypeConfiguration typeConfiguration,
+			Dialect dialect, BasicType<?> elementType,
+			ColumnTypeInformation columnTypeInformation) {
+		String typeName = columnTypeInformation.getTypeName();
+		if ( typeName == null || typeName.isBlank() ) {
+			typeName = OracleArrayJdbcType.getTypeName( elementType.getJavaTypeDescriptor(), dialect );
+		}
+		return new OracleNestedTableJdbcType( elementType.getJdbcType(), typeName );
+	}
+
+	@Override
+	public JdbcType resolveType(
+			TypeConfiguration typeConfiguration,
+			Dialect dialect,
+			JdbcType elementType,
+			ColumnTypeInformation columnTypeInformation) {
+		// a bit wrong, since columnTypeInformation.getTypeName() is typically null!
+		return new OracleNestedTableJdbcType( elementType, columnTypeInformation.getTypeName() );
+	}
+
+	@Override
+	public int getDefaultSqlTypeCode() {
+		return SqlTypes.TABLE;
+	}
+}

--- a/hibernate-core/src/main/java/org/hibernate/mapping/Column.java
+++ b/hibernate-core/src/main/java/org/hibernate/mapping/Column.java
@@ -287,9 +287,10 @@ public class Column implements Selectable, Serializable, Cloneable, ColumnTypeIn
 				throw new MappingException(
 						String.format(
 								Locale.ROOT,
-								"Unable to determine SQL type name for column '%s' of table '%s'",
+								"Unable to determine SQL type name for column '%s' of table '%s': %s",
 								getName(),
-								getValue().getTable().getName()
+								getValue().getTable().getName(),
+								cause.getMessage()
 						),
 						cause
 				);

--- a/hibernate-core/src/main/java/org/hibernate/type/BasicArrayType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/BasicArrayType.java
@@ -16,21 +16,21 @@ import org.hibernate.type.descriptor.jdbc.JdbcTypeIndicators;
  * @author Jordan Gigov
  * @author Christian Beikov
  */
-public class BasicArrayType<T>
-		extends AbstractSingleColumnStandardBasicType<T[]>
-		implements AdjustableBasicType<T[]>, BasicPluralType<T[], T> {
+public class BasicArrayType<T,E>
+		extends AbstractSingleColumnStandardBasicType<T>
+		implements AdjustableBasicType<T>, BasicPluralType<T, E> {
 
-	private final BasicType<T> baseDescriptor;
+	private final BasicType<E> baseDescriptor;
 	private final String name;
 
-	public BasicArrayType(BasicType<T> baseDescriptor, JdbcType arrayJdbcType, JavaType<T[]> arrayTypeDescriptor) {
+	public BasicArrayType(BasicType<E> baseDescriptor, JdbcType arrayJdbcType, JavaType<T> arrayTypeDescriptor) {
 		super( arrayJdbcType, arrayTypeDescriptor );
 		this.baseDescriptor = baseDescriptor;
 		this.name = baseDescriptor.getName() + "[]";
 	}
 
 	@Override
-	public BasicType<T> getElementType() {
+	public BasicType<E> getElementType() {
 		return baseDescriptor;
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/type/SqlTypes.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/SqlTypes.java
@@ -278,6 +278,13 @@ public class SqlTypes {
 	public final static int ARRAY = Types.ARRAY;
 
 	/**
+	 * A type code representing an Oracle-style nested table.
+	 *
+	 * @see org.hibernate.dialect.OracleNestedTableJdbcType
+	 */
+	public final static int TABLE = 4000;
+
+	/**
 	 * A type code representing the generic SQL type {@code BLOB}.
 	 *
 	 * @see Types#BLOB
@@ -527,6 +534,8 @@ public class SqlTypes {
 	 * {@link org.hibernate.dialect.MySQLDialect MySQL} where {@code ENUM}
 	 * types do not have names.
 	 *
+	 * @see org.hibernate.dialect.MySQLEnumJdbcType
+	 *
 	 * @since 6.3
 	 */
 	public static final int ENUM = 6000;
@@ -535,6 +544,8 @@ public class SqlTypes {
 	 * A type code representing a SQL {@code ENUM} type for databases like
 	 * {@link org.hibernate.dialect.PostgreSQLDialect PostgreSQL} where
 	 * {@code ENUM} types must have names.
+	 *
+	 * @see org.hibernate.dialect.PostgreSQLEnumJdbcType
 	 *
 	 * @since 6.3
 	 */

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/converter/internal/ArrayConverter.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/converter/internal/ArrayConverter.java
@@ -12,72 +12,94 @@ import org.hibernate.type.descriptor.converter.spi.BasicValueConverter;
 import org.hibernate.type.descriptor.java.JavaType;
 
 /**
- * Handles conversion to/from an array of a converted element type.
+ * Given a {@link BasicValueConverter} for array elements, handles conversion
+ * to and from an array of the converted element type.
+ *
+ * @param <E> the unconverted element type
+ * @param <F> the converted element type
+ * @param <T> the unconverted array type
+ * @param <S> the converted array type
  */
-public class ArrayConverter<X, Y> implements BasicValueConverter<X, Y> {
+public class ArrayConverter<T, S, E, F> implements BasicValueConverter<T, S> {
 
-	private final BasicValueConverter<Object, Object> elementConverter;
-	private final JavaType<X> domainJavaType;
-	private final JavaType<Y> relationalJavaType;
+	private final BasicValueConverter<E, F> elementConverter;
+	private final JavaType<T> domainJavaType;
+	private final JavaType<S> relationalJavaType;
 
 	public ArrayConverter(
-			BasicValueConverter<Object, Object> elementConverter,
-			JavaType<X> domainJavaType,
-			JavaType<Y> relationalJavaType) {
+			BasicValueConverter<E, F> elementConverter,
+			JavaType<T> domainJavaType,
+			JavaType<S> relationalJavaType) {
 		this.elementConverter = elementConverter;
 		this.domainJavaType = domainJavaType;
 		this.relationalJavaType = relationalJavaType;
 	}
 
 	@Override
-	public X toDomainValue(Y relationalForm) {
+	public T toDomainValue(S relationalForm) {
 		if ( relationalForm == null ) {
 			return null;
 		}
-		if ( relationalForm.getClass().getComponentType() == elementConverter.getDomainJavaType().getJavaTypeClass() ) {
-			//noinspection unchecked
-			return (X) relationalForm;
+		else {
+			final Class<E> elementClass = elementConverter.getDomainJavaType().getJavaTypeClass();
+			if ( relationalForm.getClass().getComponentType() == elementClass) {
+				//noinspection unchecked
+				return (T) relationalForm;
+			}
+			else {
+				//noinspection unchecked
+				return convertTo( (F[]) relationalForm, elementClass );
+			}
 		}
-		final Object[] relationalArray = (Object[]) relationalForm;
-		final Object[] domainArray = (Object[]) Array.newInstance(
-				elementConverter.getDomainJavaType().getJavaTypeClass(),
-				relationalArray.length
-		);
+	}
+
+	private T convertTo(F[] relationalArray, Class<E> elementClass) {
+		//TODO: the following implementation only handles conversion between non-primitive arrays!
+		//noinspection unchecked
+		final E[] domainArray = (E[]) Array.newInstance( elementClass, relationalArray.length );
 		for ( int i = 0; i < relationalArray.length; i++ ) {
 			domainArray[i] = elementConverter.toDomainValue( relationalArray[i] );
 		}
 		//noinspection unchecked
-		return (X) domainArray;
+		return (T) domainArray;
 	}
 
 	@Override
-	public Y toRelationalValue(X domainForm) {
+	public S toRelationalValue(T domainForm) {
 		if ( domainForm == null ) {
 			return null;
 		}
-		if ( domainForm.getClass().getComponentType() == elementConverter.getRelationalJavaType().getJavaTypeClass() ) {
-			//noinspection unchecked
-			return (Y) domainForm;
+		else {
+			final Class<F> elementClass = elementConverter.getRelationalJavaType().getJavaTypeClass();
+			if ( domainForm.getClass().getComponentType() == elementClass) {
+				//noinspection unchecked
+				return (S) domainForm;
+			}
+			else {
+				//noinspection unchecked
+				return convertFrom((E[]) domainForm, elementClass);
+			}
 		}
-		final Object[] domainArray = (Object[]) domainForm;
-		final Object[] relationalArray = (Object[]) Array.newInstance(
-				elementConverter.getRelationalJavaType().getJavaTypeClass(),
-				domainArray.length
-		);
+	}
+
+	private S convertFrom(E[] domainArray, Class<F> elementClass) {
+		 //TODO: the following implementation only handles conversion between non-primitive arrays!
+		//noinspection unchecked
+		final F[] relationalArray = (F[]) Array.newInstance( elementClass, domainArray.length );
 		for ( int i = 0; i < domainArray.length; i++ ) {
 			relationalArray[i] = elementConverter.toRelationalValue( domainArray[i] );
 		}
 		//noinspection unchecked
-		return (Y) relationalArray;
+		return (S) relationalArray;
 	}
 
 	@Override
-	public JavaType<X> getDomainJavaType() {
+	public JavaType<T> getDomainJavaType() {
 		return domainJavaType;
 	}
 
 	@Override
-	public JavaType<Y> getRelationalJavaType() {
+	public JavaType<S> getRelationalJavaType() {
 		return relationalJavaType;
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/AbstractArrayJavaType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/AbstractArrayJavaType.java
@@ -7,8 +7,6 @@
 package org.hibernate.type.descriptor.java;
 
 import java.lang.reflect.Array;
-import java.sql.Types;
-import java.util.function.Function;
 
 import org.hibernate.dialect.Dialect;
 import org.hibernate.tool.schema.extract.spi.ColumnTypeInformation;
@@ -29,10 +27,6 @@ public abstract class AbstractArrayJavaType<T, E> extends AbstractClassJavaType<
 		implements BasicPluralJavaType<E> {
 
 	private final JavaType<E> componentJavaType;
-
-	public AbstractArrayJavaType(Class<T> clazz, BasicType<E> baseDescriptor, MutabilityPlan<T> mutabilityPlan) {
-		this( clazz, baseDescriptor.getJavaTypeDescriptor(), mutabilityPlan );
-	}
 
 	public AbstractArrayJavaType(Class<T> clazz, JavaType<E> baseDescriptor, MutabilityPlan<T> mutabilityPlan) {
 		super( clazz, mutabilityPlan );
@@ -64,39 +58,76 @@ public abstract class AbstractArrayJavaType<T, E> extends AbstractClassJavaType<
 			ColumnTypeInformation columnTypeInformation,
 			JdbcTypeIndicators stdIndicators) {
 		final Class<?> elementJavaTypeClass = elementType.getJavaTypeDescriptor().getJavaTypeClass();
-		if ( elementType instanceof BasicPluralType<?, ?> || elementJavaTypeClass != null && elementJavaTypeClass.isArray() ) {
+		if ( elementType instanceof BasicPluralType<?, ?>
+				|| elementJavaTypeClass != null && elementJavaTypeClass.isArray() ) {
 			return null;
 		}
 		final BasicValueConverter<E, ?> valueConverter = elementType.getValueConverter();
-		if ( valueConverter == null ) {
-			final Function<JavaType<T>, BasicType<T>> creator = javaType -> {
-				final JdbcType arrayJdbcType =
-						getArrayJdbcType( typeConfiguration, dialect, Types.ARRAY, elementType, columnTypeInformation );
-				//noinspection unchecked,rawtypes
-				return new BasicArrayType( elementType, arrayJdbcType, javaType );
-			};
-			if ( typeConfiguration.getBasicTypeRegistry().getRegisteredType( elementType.getName() ) == elementType ) {
-				return typeConfiguration.standardBasicTypeForJavaType( getJavaType(), creator );
-			}
-			else {
-				return creator.apply( this );
-			}
-		}
-		else {
-			final JavaType<Object> relationalJavaType = typeConfiguration.getJavaTypeRegistry().getDescriptor(
-					Array.newInstance( valueConverter.getRelationalJavaType().getJavaTypeClass(), 0 ).getClass()
-			);
-			//noinspection unchecked,rawtypes
-			return new ConvertedBasicArrayType(
-					elementType,
-					getArrayJdbcType( typeConfiguration, dialect, Types.ARRAY, elementType, columnTypeInformation ),
-					this,
-					new ArrayConverter( valueConverter, this, relationalJavaType )
-			);
-		}
+		return valueConverter == null
+				? createType( typeConfiguration, dialect, this, elementType, columnTypeInformation, stdIndicators )
+				: createTypeUsingConverter( typeConfiguration, dialect, elementType, columnTypeInformation, stdIndicators, valueConverter );
 	}
 
-	private static JdbcType getArrayJdbcType(
+	<F> BasicType<T> createTypeUsingConverter(
+			TypeConfiguration typeConfiguration,
+			Dialect dialect,
+			BasicType<E> elementType,
+			ColumnTypeInformation columnTypeInformation,
+			JdbcTypeIndicators stdIndicators,
+			BasicValueConverter<E, F> valueConverter) {
+		final Class<F> convertedElementClass = valueConverter.getRelationalJavaType().getJavaTypeClass();
+		final Class<?> convertedArrayClass = Array.newInstance( convertedElementClass, 0 ).getClass();
+		final JavaType<?> relationalJavaType = typeConfiguration.getJavaTypeRegistry().getDescriptor( convertedArrayClass );
+		return new ConvertedBasicArrayType<>(
+				elementType,
+				getArrayJdbcType(
+						typeConfiguration,
+						dialect,
+						stdIndicators.getExplicitJdbcTypeCode(),
+						elementType,
+						columnTypeInformation
+				),
+				this,
+				new ArrayConverter<>( valueConverter, this, relationalJavaType )
+		);
+	}
+
+	BasicType<T> createType(
+			TypeConfiguration typeConfiguration,
+			Dialect dialect,
+			AbstractArrayJavaType<T,E> arrayJavaType,
+			BasicType<E> elementType,
+			ColumnTypeInformation columnTypeInformation,
+			JdbcTypeIndicators stdIndicators) {
+		return typeConfiguration.getBasicTypeRegistry().getRegisteredType( elementType.getName() ) == elementType
+				? typeConfiguration.standardBasicTypeForJavaType(
+						arrayJavaType.getJavaType(),
+						javaType -> basicArrayType( typeConfiguration, dialect, elementType, columnTypeInformation, stdIndicators, arrayJavaType )
+				)
+				: basicArrayType( typeConfiguration, dialect, elementType, columnTypeInformation, stdIndicators, arrayJavaType );
+	}
+
+	BasicType<T> basicArrayType(
+			TypeConfiguration typeConfiguration,
+			Dialect dialect,
+			BasicType<E> elementType,
+			ColumnTypeInformation columnTypeInformation,
+			JdbcTypeIndicators stdIndicators,
+			JavaType<T> javaType) {
+		return new BasicArrayType<>(
+				elementType,
+				getArrayJdbcType(
+						typeConfiguration,
+						dialect,
+						stdIndicators.getExplicitJdbcTypeCode(),
+						elementType,
+						columnTypeInformation
+				),
+				javaType
+		);
+	}
+
+	static JdbcType getArrayJdbcType(
 			TypeConfiguration typeConfiguration,
 			Dialect dialect,
 			int preferredSqlTypeCodeForArray,

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/jdbc/ArrayJdbcType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/jdbc/ArrayJdbcType.java
@@ -74,14 +74,17 @@ public class ArrayJdbcType implements JdbcType {
 			//noinspection unchecked
 			elementJavaType = (JavaType<T>) ByteJavaType.INSTANCE;
 		}
-		else {
+		else if (javaTypeDescriptor instanceof BasicPluralJavaType) {
 			//noinspection unchecked
-			elementJavaType = javaTypeDescriptor instanceof BasicPluralJavaType
-					? ( (BasicPluralJavaType<T>) javaTypeDescriptor ).getElementJavaType()
-					: null; //TODO: what should really happen here?
+			elementJavaType = ((BasicPluralJavaType<T>) javaTypeDescriptor).getElementJavaType();
 		}
-		final JdbcLiteralFormatter<T> elementFormatter = elementJdbcType.getJdbcLiteralFormatter( elementJavaType );
-		return new JdbcLiteralFormatterArray<>( javaTypeDescriptor, elementFormatter );
+		else {
+			throw new IllegalArgumentException("not a BasicPluralJavaType");
+		}
+		return new JdbcLiteralFormatterArray<>(
+				javaTypeDescriptor,
+				elementJdbcType.getJdbcLiteralFormatter( elementJavaType )
+		);
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/jdbc/JdbcTypeIndicators.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/jdbc/JdbcTypeIndicators.java
@@ -10,6 +10,7 @@ import jakarta.persistence.EnumType;
 import jakarta.persistence.TemporalType;
 
 import org.hibernate.AssertionFailure;
+import org.hibernate.Incubating;
 import org.hibernate.TimeZoneStorageStrategy;
 import org.hibernate.dialect.Dialect;
 import org.hibernate.type.SqlTypes;
@@ -149,6 +150,17 @@ public interface JdbcTypeIndicators {
 	 */
 	default int getColumnScale() {
 		return NO_COLUMN_SCALE;
+	}
+
+	/**
+	 * Used (for now) only to choose a container {@link JdbcType} for
+	 * SQL arrays.
+	 *
+	 * @since 6.3
+	 */
+	@Incubating
+	default Integer getExplicitJdbcTypeCode() {
+		return getPreferredSqlTypeCodeForArray();
 	}
 
 	/**

--- a/hibernate-core/src/main/java/org/hibernate/type/internal/ConvertedBasicTypeImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/internal/ConvertedBasicTypeImpl.java
@@ -88,6 +88,7 @@ public class ConvertedBasicTypeImpl<J> implements ConvertedBasicType<J>,
 		this.converter = converter;
 		this.jdbcType = jdbcType;
 		this.sqlTypes = new int[] { jdbcType.getDdlTypeCode() };
+		//TODO: these type casts look completely bogus
 		this.jdbcValueBinder = (ValueBinder<J>) jdbcType.getBinder( converter.getRelationalJavaType() );
 		this.jdbcValueExtractor = (ValueExtractor<J>) jdbcType.getExtractor( converter.getRelationalJavaType() );
 		this.jdbcLiteralFormatter = (JdbcLiteralFormatter<J>) jdbcType.getJdbcLiteralFormatter( converter.getRelationalJavaType() );

--- a/hibernate-testing/src/main/java/org/hibernate/testing/orm/junit/SessionFactoryExtension.java
+++ b/hibernate-testing/src/main/java/org/hibernate/testing/orm/junit/SessionFactoryExtension.java
@@ -157,7 +157,7 @@ public class SessionFactoryExtension
 						return sessionFactory;
 					}
 					catch (Exception e) {
-						throw new RuntimeException( "Could not build SessionFactory", e );
+						throw new RuntimeException( "Could not build SessionFactory: " + e.getMessage(), e );
 					}
 				};
 			}


### PR DESCRIPTION
This PR lets you write stuff like:

```java
@Column(length = 25)
@JdbcTypeCode(SqlTypes.TABLE)
String[] strings;
```

To get a nested table instead of a `varray` on Oracle.

This was surprisingly difficult to do, due to how array types are set up and initialized.