### PR TITLE
HHH-16553 Test reproducing a stackoverflow when loading chained entities

### DIFF
--- a/hibernate-core/src/test/java/org/hibernate/orm/test/loading/ChainedEntitiesRecursiveLoadTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/loading/ChainedEntitiesRecursiveLoadTest.java
@@ -4,6 +4,11 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
 import jakarta.persistence.ManyToOne;
+
+import org.hibernate.annotations.Fetch;
+import org.hibernate.annotations.FetchMode;
+import org.hibernate.annotations.Proxy;
+
 import org.hibernate.testing.orm.junit.DomainModel;
 import org.hibernate.testing.orm.junit.SessionFactory;
 import org.hibernate.testing.orm.junit.SessionFactoryScope;
@@ -44,10 +49,13 @@ public class ChainedEntitiesRecursiveLoadTest {
 	}
 
 	@Entity
+	@Proxy(lazy = false)
 	public static class Container {
 
 		@Id @GeneratedValue Long id;
 
-		@ManyToOne Container parent;
+		@Fetch(FetchMode.SELECT)
+		@ManyToOne
+		Container parent;
 	}
 }

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/loading/ChainedEntitiesRecursiveLoadTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/loading/ChainedEntitiesRecursiveLoadTest.java
@@ -1,6 +1,7 @@
 package org.hibernate.orm.test.loading;
 
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
 import jakarta.persistence.ManyToOne;
@@ -52,10 +53,31 @@ public class ChainedEntitiesRecursiveLoadTest {
 	@Proxy(lazy = false)
 	public static class Container {
 
-		@Id @GeneratedValue Long id;
+		Long id;
+
+		Container parent;
+
+		public Container() {
+		}
+
+		@Id
+		@GeneratedValue 
+		public Long getId() {
+			return id;
+		}
+
+		public void setId(Long id) {
+			this.id = id;
+		}
 
 		@Fetch(FetchMode.SELECT)
-		@ManyToOne
-		Container parent;
+		@ManyToOne(fetch = FetchType.LAZY)
+		public Container getParent() {
+			return parent;
+		}
+
+		public void setParent(Container parent) {
+			this.parent = parent;
+		}
 	}
 }

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/loading/ChainedEntitiesRecursiveLoadTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/loading/ChainedEntitiesRecursiveLoadTest.java
@@ -1,0 +1,53 @@
+package org.hibernate.orm.test.loading;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.junit.jupiter.api.Test;
+
+/**
+ * @author gtoison
+ *
+ */
+@SessionFactory
+@DomainModel(annotatedClasses = {ChainedEntitiesRecursiveLoadTest.Container.class})
+public class ChainedEntitiesRecursiveLoadTest {
+
+
+	@Test public void test(SessionFactoryScope scope) {
+		// Create a bunch of chained entities parent/child association and get the last child
+		Container container = scope.fromSession(s -> {
+			s.getSession().beginTransaction();
+			
+			Container c = null;
+			// Assuming that each recursive load needs a few method calls 1000 entities should be enough to trigger a stack overflow
+			for (int i=0; i<1000; i++) {
+				Container child = new Container();
+				child.parent = c;
+				
+				c = child;
+				
+				s.persist(c);
+			}
+			
+			s.getSession().getTransaction().commit();
+			
+			return c;
+		});
+		
+		// Attempt to load the last child
+		scope.inSession(s -> s.getReference(Container.class, container.id).toString());
+	}
+
+	@Entity
+	public static class Container {
+
+		@Id @GeneratedValue Long id;
+
+		@ManyToOne Container parent;
+	}
+}


### PR DESCRIPTION
When attempting to load entities chained together I get a stack overflow