### PR TITLE
HHH-16552 - Add CockroachDB v23.1 to docker startup script

### DIFF
--- a/docker_db.sh
+++ b/docker_db.sh
@@ -652,6 +652,46 @@ cockroachdb() {
   cockroachdb_22_2
 }
 
+cockroachdb_23_1() {
+  $CONTAINER_CLI rm -f cockroach || true
+  LOG_CONFIG="
+sinks:
+  stderr:
+    channels: all
+    filter: ERROR
+    redact: false
+    exit-on-error: true
+"
+  $CONTAINER_CLI run -d --name=cockroach -m 6g -p 26257:26257 -p 8080:8080 cockroachdb/cockroach-unstable:v23.1.0-rc.1 start-single-node \
+    --insecure --store=type=mem,size=0.25 --advertise-addr=localhost --log="$LOG_CONFIG"
+  OUTPUT=
+  while [[ $OUTPUT != *"CockroachDB node starting"* ]]; do
+        echo "Waiting for CockroachDB to start..."
+        sleep 10
+        # Note we need to redirect stderr to stdout to capture the logs
+        OUTPUT=$($CONTAINER_CLI logs cockroach 2>&1)
+  done
+  echo "Enabling experimental box2d operators and some optimized settings for running the tests"
+  #settings documented in https://www.cockroachlabs.com/docs/v22.1/local-testing.html#use-a-local-single-node-cluster-with-in-memory-storage
+  $CONTAINER_CLI exec cockroach bash -c "cat <<EOF | ./cockroach sql --insecure
+SET CLUSTER SETTING sql.spatial.experimental_box2d_comparison_operators.enabled = on;
+SET CLUSTER SETTING kv.raft_log.disable_synchronization_unsafe = true;
+SET CLUSTER SETTING kv.range_merge.queue_interval = '50ms';
+SET CLUSTER SETTING jobs.registry.interval.gc = '30s';
+SET CLUSTER SETTING jobs.registry.interval.cancel = '180s';
+SET CLUSTER SETTING jobs.retention_time = '15s';
+SET CLUSTER SETTING sql.stats.automatic_collection.enabled = false;
+SET CLUSTER SETTING kv.range_split.by_load_merge_delay = '5s';
+ALTER RANGE default CONFIGURE ZONE USING "gc.ttlseconds" = 600;
+ALTER DATABASE system CONFIGURE ZONE USING "gc.ttlseconds" = 600;
+
+quit
+EOF
+"
+  echo "Cockroachdb successfully started"
+
+}
+
 cockroachdb_22_2() {
   $CONTAINER_CLI rm -f cockroach || true
   LOG_CONFIG="
@@ -807,6 +847,7 @@ if [ -z ${1} ]; then
     echo "No db name provided"
     echo "Provide one of:"
     echo -e "\tcockroachdb"
+    echo -e "\tcockroachdb_23_1"
     echo -e "\tcockroachdb_22_2"
     echo -e "\tcockroachdb_22_1"
     echo -e "\tcockroachdb_21_1"

--- a/nightly.Jenkinsfile
+++ b/nightly.Jenkinsfile
@@ -41,6 +41,7 @@ stage('Configure') {
 		// Long running databases
 		new BuildEnvironment( dbName: 'cockroachdb', node: 'cockroachdb', longRunning: true ),
 		new BuildEnvironment( dbName: 'cockroachdb_21_2', node: 'cockroachdb', longRunning: true ),
+		new BuildEnvironment( dbName: 'cockroachdb_23_1', node: 'cockroachdb', longRunning: true ),
 		new BuildEnvironment( dbName: 'hana_cloud', dbLockableResource: 'hana-cloud', dbLockResourceAsHost: true )
 	];
 
@@ -231,6 +232,13 @@ stage('Build') {
 										docker.image('cockroachdb/cockroach:v21.2.16').pull()
 									}
 									sh "./docker_db.sh cockroachdb_21_2"
+									state[buildEnv.tag]['containerName'] = "cockroach"
+									break;
+								case "cockroachdb_23_1":
+									docker.withRegistry('https://index.docker.io/v1/', 'hibernateci.hub.docker.com') {
+										docker.image('cockroachdb/cockroach-unstable:v23.1.0-rc.1').pull()
+									}
+									sh "./docker_db.sh cockroachdb_23_1"
 									state[buildEnv.tag]['containerName'] = "cockroach"
 									break;
 							}

--- a/nightly.Jenkinsfile
+++ b/nightly.Jenkinsfile
@@ -40,7 +40,7 @@ stage('Configure') {
 // 		new BuildEnvironment( dbName: 'sybase_16' ), // There only is a Sybase ASE 16 image, so no pint in testing that nightly
 		// Long running databases
 		new BuildEnvironment( dbName: 'cockroachdb', node: 'cockroachdb', longRunning: true ),
-		new BuildEnvironment( dbName: 'cockroachdb_21_2', node: 'cockroachdb', longRunning: true ),
+		new BuildEnvironment( dbName: 'cockroachdb_23_1', node: 'cockroachdb', longRunning: true ),
 		new BuildEnvironment( dbName: 'hana_cloud', dbLockableResource: 'hana-cloud', dbLockResourceAsHost: true )
 	];
 
@@ -226,11 +226,11 @@ stage('Build') {
 									sh "./docker_db.sh cockroachdb"
 									state[buildEnv.tag]['containerName'] = "cockroach"
 									break;
-								case "cockroachdb_21_2":
+								case "cockroachdb_23_1":
 									docker.withRegistry('https://index.docker.io/v1/', 'hibernateci.hub.docker.com') {
-										docker.image('cockroachdb/cockroach:v21.2.16').pull()
+										docker.image('cockroachdb/cockroach-unstable:v23.1.0-rc.1').pull()
 									}
-									sh "./docker_db.sh cockroachdb_21_2"
+									sh "./docker_db.sh cockroachdb_23_1"
 									state[buildEnv.tag]['containerName'] = "cockroach"
 									break;
 							}

--- a/nightly.Jenkinsfile
+++ b/nightly.Jenkinsfile
@@ -40,7 +40,7 @@ stage('Configure') {
 // 		new BuildEnvironment( dbName: 'sybase_16' ), // There only is a Sybase ASE 16 image, so no pint in testing that nightly
 		// Long running databases
 		new BuildEnvironment( dbName: 'cockroachdb', node: 'cockroachdb', longRunning: true ),
-		new BuildEnvironment( dbName: 'cockroachdb_23_1', node: 'cockroachdb', longRunning: true ),
+		new BuildEnvironment( dbName: 'cockroachdb_21_2', node: 'cockroachdb', longRunning: true ),
 		new BuildEnvironment( dbName: 'hana_cloud', dbLockableResource: 'hana-cloud', dbLockResourceAsHost: true )
 	];
 
@@ -226,11 +226,11 @@ stage('Build') {
 									sh "./docker_db.sh cockroachdb"
 									state[buildEnv.tag]['containerName'] = "cockroach"
 									break;
-								case "cockroachdb_23_1":
+								case "cockroachdb_21_2":
 									docker.withRegistry('https://index.docker.io/v1/', 'hibernateci.hub.docker.com') {
-										docker.image('cockroachdb/cockroach-unstable:v23.1.0-rc.1').pull()
+										docker.image('cockroachdb/cockroach:v21.2.16').pull()
 									}
-									sh "./docker_db.sh cockroachdb_23_1"
+									sh "./docker_db.sh cockroachdb_21_2"
 									state[buildEnv.tag]['containerName'] = "cockroach"
 									break;
 							}


### PR DESCRIPTION
The guys at Cockroach Labs asked to test also against the 23.1 version. 

I've added the configuration to the docker startup script. Could you add a job for the new version to Jenkins? Maybe replace the 20.1 job with this one?