### PR TITLE
SQLServer2016Dialect correct deprection

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/dialect/SQLServer2016Dialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/SQLServer2016Dialect.java
@@ -8,7 +8,7 @@ package org.hibernate.dialect;
 
 /**
  * Microsoft SQL Server 2016 Dialect
- * @deprecated use {@code SQLServerDialect(11)}
+ * @deprecated use {@code SQLServerDialect(13)}
  */
 @Deprecated
 public class SQLServer2016Dialect extends SQLServerDialect {


### PR DESCRIPTION
In the deprecation of the SQLServer2016Dialect set the correct version for the constructor of SQLServer2016Dialect