### PR TITLE
HHH-16556 Correct MS SQL 2016 deprecation version

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/dialect/SQLServer2016Dialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/SQLServer2016Dialect.java
@@ -8,7 +8,7 @@ package org.hibernate.dialect;
 
 /**
  * Microsoft SQL Server 2016 Dialect
- * @deprecated use {@code SQLServerDialect(11)}
+ * @deprecated use {@code SQLServerDialect(13)}
  */
 @Deprecated
 public class SQLServer2016Dialect extends SQLServerDialect {


### PR DESCRIPTION
Use version 13 as suggestion in the deprecation warning instead of 11 which is version MS SQL 2012