### PR TITLE
HHH-16579 - Add constructor for CockroachDialect that parses the version without querying the db

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/dialect/CockroachDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/CockroachDialect.java
@@ -147,6 +147,13 @@ public class CockroachDialect extends Dialect {
 		this.driverKind = driverKind;
 	}
 
+	/**
+	 * For Hibernate Reactive
+	 */
+	public CockroachDialect(String version, PostgreSQLDriverKind driverKind) {
+		this( parseVersion( version ), driverKind );
+	}
+
 	protected static DatabaseVersion fetchDataBaseVersion( DialectResolutionInfo info ) {
 		String versionString = null;
 		if ( info.getDatabaseMetadata() != null ) {

--- a/hibernate-core/src/main/java/org/hibernate/dialect/CockroachDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/CockroachDialect.java
@@ -147,13 +147,6 @@ public class CockroachDialect extends Dialect {
 		this.driverKind = driverKind;
 	}
 
-	/**
-	 * For Hibernate Reactive
-	 */
-	public CockroachDialect(String version, PostgreSQLDriverKind driverKind) {
-		this( parseVersion( version ), driverKind );
-	}
-
 	protected static DatabaseVersion fetchDataBaseVersion( DialectResolutionInfo info ) {
 		String versionString = null;
 		if ( info.getDatabaseMetadata() != null ) {
@@ -170,7 +163,7 @@ public class CockroachDialect extends Dialect {
 		return parseVersion( versionString );
 	}
 
-	protected static DatabaseVersion parseVersion(String versionString ) {
+	public static DatabaseVersion parseVersion(String versionString ) {
 		DatabaseVersion databaseVersion = null;
 		// What the DB select returns is similar to "CockroachDB CCL v21.2.10 (x86_64-unknown-linux-gnu, built 2022/05/02 17:38:58, go1.16.6)"
 		Matcher m = CRDB_VERSION_PATTERN.matcher( versionString == null ? "" : versionString );


### PR DESCRIPTION
Fix [HHH-16579](https://hibernate.atlassian.net/browse/HHH-16579)

[HHH-16579]: https://hibernate.atlassian.net/browse/HHH-16579?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ