### PR TITLE
HHH-16589 In clause padding can no longer cause in clauses to exceed Dialect.getInExpressionCountLimit

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/internal/util/MathHelper.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/util/MathHelper.java
@@ -21,6 +21,10 @@ public final class MathHelper {
 	 * @return smallest power of two number
 	 */
 	public static int ceilingPowerOfTwo(int value) {
-		return 1 << -Integer.numberOfLeadingZeros(value - 1);
+		int result = 1 << -Integer.numberOfLeadingZeros(value - 1);
+		if ( result < value ) { // Overflow
+			return Integer.MAX_VALUE;
+		}
+		return result;
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/internal/util/MathHelper.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/util/MathHelper.java
@@ -8,6 +8,7 @@ package org.hibernate.internal.util;
 
 /**
  * @author Vlad Mihalcea
+ * @author Adrodoc
  */
 public final class MathHelper {
 
@@ -26,5 +27,16 @@ public final class MathHelper {
 			return Integer.MAX_VALUE;
 		}
 		return result;
+	}
+
+	/**
+	 * Returns the result of dividing a positive {@code numerator} by a positive {@code denominator} rounded up. For
+	 * example dividing 5 by 2 would give a result of 3.
+	 */
+	public static int divideRoundingUp(int numerator, int denominator) {
+		if ( numerator == 0 ) {
+			return 0;
+		}
+		return ( ( numerator - 1 ) / denominator ) + 1;
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/sql/ast/spi/AbstractSqlAstTranslator.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/ast/spi/AbstractSqlAstTranslator.java
@@ -6832,15 +6832,8 @@ public abstract class AbstractSqlAstTranslator<T extends JdbcOperation> implemen
 			}
 		}
 
-		inListPredicate.getTestExpression().accept( this );
-		if ( inListPredicate.isNegated() ) {
-			appendSql( " not" );
-		}
-		appendSql( " in (" );
-		String separator = NO_SEPARATOR;
-
 		int bindValueCount = listExpressions.size();
-		int bindValueMaxCount = bindValueCount;
+		int bindValueCountWithPadding = bindValueCount;
 
 		int inExprLimit = dialect.getInExpressionCountLimit();
 
@@ -6849,68 +6842,72 @@ public abstract class AbstractSqlAstTranslator<T extends JdbcOperation> implemen
 				&& bindValueCount > 2;
 
 		if ( inClauseParameterPaddingEnabled ) {
-			bindValueMaxCount = calculateLastInClauseSize( bindValueCount, inExprLimit );
+			bindValueCountWithPadding = addPadding( bindValueCount, inExprLimit );
 		}
+		final boolean splitInClause = inExprLimit > 0 && bindValueCountWithPadding > inExprLimit;
+
+		if ( splitInClause ) {
+			appendSql( OPEN_PARENTHESIS );
+		}
+
+		inListPredicate.getTestExpression().accept( this );
+		if ( inListPredicate.isNegated() ) {
+			appendSql( " not" );
+		}
+		appendSql( " in (" );
+		String separator = NO_SEPARATOR;
 
 		final Iterator<Expression> iterator = listExpressions.iterator();
-		int itemNumber = 0;
-		while ( iterator.hasNext() && ( inExprLimit == 0 || itemNumber < inExprLimit ) ) {
-			final Expression listExpression = itemAccessor.apply( iterator.next() );
+		Expression expression = null;
+		for ( int i = 0; i < bindValueCountWithPadding; i++ ) {
+			if ( inExprLimit > 0 && i % inExprLimit == 0 && i != 0 ) {
+				appendInClauseSeperator( inListPredicate );
+				separator = NO_SEPARATOR;
+			}
+
+			if ( iterator.hasNext() ) { // If the iterator is exhausted, reuse the last expression for padding.
+				expression = itemAccessor.apply( iterator.next() );
+			}
 			appendSql( separator );
-			listExpression.accept( this );
+			expression.accept( this );
 			separator = COMMA_SEPARATOR;
-			itemNumber++;
+
 			// If we encounter an expression that is not a parameter or literal, we reset the inExprLimit and bindValueMaxCount
 			// and just render through the in list expressions as they are without padding/splitting
-			if ( !( listExpression instanceof JdbcParameter || listExpression instanceof SqmParameterInterpretation || listExpression instanceof Literal ) ) {
+			if ( !( expression instanceof JdbcParameter || expression instanceof SqmParameterInterpretation || expression instanceof Literal ) ) {
 				inExprLimit = 0;
-				bindValueMaxCount = bindValueCount;
-			}
-		}
-
-		if ( itemNumber != inExprLimit && bindValueCount == bindValueMaxCount ) {
-			appendSql( CLOSE_PARENTHESIS );
-			return;
-		}
-
-		if ( inExprLimit > 0 && bindValueCount > inExprLimit ) {
-			do {
-				append( ") or " );
-				inListPredicate.getTestExpression().accept( this );
-				if ( inListPredicate.isNegated() ) {
-					appendSql( " not" );
-				}
-				appendSql( " in (" );
-				separator = NO_SEPARATOR;
-				itemNumber = 0;
-				while ( iterator.hasNext() && itemNumber < inExprLimit ) {
-					final Expression listExpression = iterator.next();
-					appendSql( separator );
-					itemAccessor.apply( listExpression ).accept( this );
-					separator = COMMA_SEPARATOR;
-					itemNumber++;
-				}
-			} while ( iterator.hasNext() );
-		}
-
-		if ( inClauseParameterPaddingEnabled ) {
-			final Expression lastExpression = itemAccessor.apply( listExpressions.get( listExpressions.size() - 1 ) );
-			for ( ; itemNumber < bindValueMaxCount; itemNumber++ ) {
-				appendSql( separator );
-				lastExpression.accept( this );
-				separator = COMMA_SEPARATOR;
+				bindValueCountWithPadding = bindValueCount;
 			}
 		}
 		appendSql( CLOSE_PARENTHESIS );
+
+		if ( splitInClause ) {
+			appendSql( CLOSE_PARENTHESIS );
+		}
 	}
 
-	private int calculateLastInClauseSize(int bindValueCount, int inExprLimit) {
+	private void appendInClauseSeperator(InListPredicate inListPredicate) {
+		appendSql( CLOSE_PARENTHESIS );
+		appendSql( inListPredicate.isNegated() ? " and " : " or " );
+		inListPredicate.getTestExpression().accept( this );
+		if ( inListPredicate.isNegated() ) {
+			appendSql( " not" );
+		}
+		appendSql( " in (" );
+	}
+
+	private static int addPadding(int bindValueCount, int inExprLimit) {
 		if ( inExprLimit <= 0 ) {
 			return MathHelper.ceilingPowerOfTwo( bindValueCount );
 		}
+
 		int lastInClauseSize = bindValueCount % inExprLimit;
-		int lastInClauseSizeWithPadding = lastInClauseSize == 0 ? 0 : MathHelper.ceilingPowerOfTwo( lastInClauseSize );
-		return Math.min( inExprLimit, lastInClauseSizeWithPadding );
+		if ( lastInClauseSize == 0 ) {
+			return bindValueCount;
+		}
+		int lastInClauseSizeWithPadding = Math.min( inExprLimit, MathHelper.ceilingPowerOfTwo( lastInClauseSize ) );
+		int padding = lastInClauseSizeWithPadding - lastInClauseSize;
+		return bindValueCount + padding;
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/sql/ast/spi/AbstractSqlAstTranslator.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/ast/spi/AbstractSqlAstTranslator.java
@@ -6849,29 +6849,7 @@ public abstract class AbstractSqlAstTranslator<T extends JdbcOperation> implemen
 				&& bindValueCount > 2;
 
 		if ( inClauseParameterPaddingEnabled ) {
-			// bindValueCount: 1005
-			// bindValuePaddingCount: 1024
-			int bindValuePaddingCount = MathHelper.ceilingPowerOfTwo( bindValueCount );
-
-			// inExprLimit: 1000
-			if ( inExprLimit > 0 ) {
-				if ( bindValuePaddingCount > inExprLimit ) {
-					// bindValueCount % inExprLimit: 5
-					// bindValuePaddingCount: 8
-					if ( bindValueCount < inExprLimit ) {
-						bindValueMaxCount = inExprLimit;
-					}
-					else {
-						bindValueMaxCount = MathHelper.ceilingPowerOfTwo( bindValueCount % inExprLimit );
-					}
-				}
-				else if ( bindValueCount < bindValuePaddingCount ) {
-					bindValueMaxCount = bindValuePaddingCount;
-				}
-			}
-			else if ( bindValueCount < bindValuePaddingCount ) {
-				bindValueMaxCount = bindValuePaddingCount;
-			}
+			bindValueMaxCount = calculateLastInClauseSize( bindValueCount, inExprLimit );
 		}
 
 		final Iterator<Expression> iterator = listExpressions.iterator();
@@ -6924,6 +6902,15 @@ public abstract class AbstractSqlAstTranslator<T extends JdbcOperation> implemen
 			}
 		}
 		appendSql( CLOSE_PARENTHESIS );
+	}
+
+	private int calculateLastInClauseSize(int bindValueCount, int inExprLimit) {
+		if ( inExprLimit <= 0 ) {
+			return MathHelper.ceilingPowerOfTwo( bindValueCount );
+		}
+		int lastInClauseSize = bindValueCount % inExprLimit;
+		int lastInClauseSizeWithPadding = lastInClauseSize == 0 ? 0 : MathHelper.ceilingPowerOfTwo( lastInClauseSize );
+		return Math.min( inExprLimit, lastInClauseSizeWithPadding );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/sql/ast/spi/AbstractSqlAstTranslator.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/ast/spi/AbstractSqlAstTranslator.java
@@ -220,6 +220,7 @@ import static org.hibernate.sql.results.graph.DomainResultGraphPrinter.logDomain
 
 /**
  * @author Steve Ebersole
+ * @author Adrodoc
  */
 public abstract class AbstractSqlAstTranslator<T extends JdbcOperation> implements SqlAstTranslator<T>, SqlAppender {
 
@@ -6897,17 +6898,14 @@ public abstract class AbstractSqlAstTranslator<T extends JdbcOperation> implemen
 	}
 
 	private static int addPadding(int bindValueCount, int inExprLimit) {
-		if ( inExprLimit <= 0 ) {
-			return MathHelper.ceilingPowerOfTwo( bindValueCount );
+		int ceilingPowerOfTwo = MathHelper.ceilingPowerOfTwo( bindValueCount );
+		if ( inExprLimit <= 0 || ceilingPowerOfTwo <= inExprLimit ) {
+			return ceilingPowerOfTwo;
 		}
 
-		int lastInClauseSize = bindValueCount % inExprLimit;
-		if ( lastInClauseSize == 0 ) {
-			return bindValueCount;
-		}
-		int lastInClauseSizeWithPadding = Math.min( inExprLimit, MathHelper.ceilingPowerOfTwo( lastInClauseSize ) );
-		int padding = lastInClauseSizeWithPadding - lastInClauseSize;
-		return bindValueCount + padding;
+		int numberOfInClauses = MathHelper.divideRoundingUp( bindValueCount, inExprLimit );
+		int numberOfInClausesWithPadding = MathHelper.ceilingPowerOfTwo( numberOfInClauses );
+		return numberOfInClausesWithPadding * inExprLimit;
 	}
 
 	@Override

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/internal/util/MathHelperTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/internal/util/MathHelperTest.java
@@ -43,4 +43,20 @@ public class MathHelperTest {
 		assertThat( MathHelper.ceilingPowerOfTwo( Integer.MAX_VALUE ) ).isEqualTo( Integer.MAX_VALUE );
 	}
 
+	@Test
+	public void divideRoundingUp() {
+		assertThat( MathHelper.divideRoundingUp( 0, 1 ) ).isEqualTo( 0 );
+		assertThat( MathHelper.divideRoundingUp( 1, 1 ) ).isEqualTo( 1 );
+		assertThat( MathHelper.divideRoundingUp( 2, 1 ) ).isEqualTo( 2 );
+		assertThat( MathHelper.divideRoundingUp( 0, 2 ) ).isEqualTo( 0 );
+		assertThat( MathHelper.divideRoundingUp( 1, 2 ) ).isEqualTo( 1 );
+		assertThat( MathHelper.divideRoundingUp( 2, 2 ) ).isEqualTo( 1 );
+		assertThat( MathHelper.divideRoundingUp( 3, 2 ) ).isEqualTo( 2 );
+		assertThat( MathHelper.divideRoundingUp( 4, 2 ) ).isEqualTo( 2 );
+		assertThat( MathHelper.divideRoundingUp( 5, 2 ) ).isEqualTo( 3 );
+		assertThat( MathHelper.divideRoundingUp( 9, 3 ) ).isEqualTo( 3 );
+		assertThat( MathHelper.divideRoundingUp( 10, 3 ) ).isEqualTo( 4 );
+		assertThat( MathHelper.divideRoundingUp( Integer.MAX_VALUE, 2 ) ).isEqualTo( 1_073_741_824 );
+	}
+
 }

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/internal/util/MathHelperTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/internal/util/MathHelperTest.java
@@ -20,6 +20,7 @@ public class MathHelperTest {
 
 	@Test
 	public void ceilingPowerOfTwo() {
+		assertThat( MathHelper.ceilingPowerOfTwo( 0 ) ).isEqualTo( 1 );
 		assertThat( MathHelper.ceilingPowerOfTwo( 1 ) ).isEqualTo( 1 );
 		assertThat( MathHelper.ceilingPowerOfTwo( 2 ) ).isEqualTo( 2 );
 		assertThat( MathHelper.ceilingPowerOfTwo( 3 ) ).isEqualTo( 4 );

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/internal/util/MathHelperTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/internal/util/MathHelperTest.java
@@ -17,7 +17,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Vlad Mihalcea
  */
 public class MathHelperTest {
-	
+
 	@Test
 	public void ceilingPowerOfTwo() {
 		assertThat( MathHelper.ceilingPowerOfTwo( 1 ) ).isEqualTo( 1 );
@@ -37,6 +37,9 @@ public class MathHelperTest {
 		assertThat( MathHelper.ceilingPowerOfTwo( 14 ) ).isEqualTo( 16 );
 		assertThat( MathHelper.ceilingPowerOfTwo( 15 ) ).isEqualTo( 16 );
 		assertThat( MathHelper.ceilingPowerOfTwo( 16 ) ).isEqualTo( 16 );
+
+		assertThat( MathHelper.ceilingPowerOfTwo( Integer.MAX_VALUE - 1 ) ).isEqualTo( Integer.MAX_VALUE );
+		assertThat( MathHelper.ceilingPowerOfTwo( Integer.MAX_VALUE ) ).isEqualTo( Integer.MAX_VALUE );
 	}
 
 }

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/query/MaxInExpressionParameterPaddingTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/query/MaxInExpressionParameterPaddingTest.java
@@ -134,12 +134,36 @@ public class MaxInExpressionParameterPaddingTest {
 		);
 
 		StringBuilder expectedInClause = new StringBuilder();
-		expectedInClause.append( "in (?" );
+		expectedInClause.append( "(p1_0.id in (?" );
 		for ( int i = 1; i < MAX_COUNT; i++ ) {
 			expectedInClause.append( ",?" );
 		}
 		expectedInClause.append( ")" );
-		expectedInClause.append( " or p1_0.id in (?)" );
+		expectedInClause.append( " or p1_0.id in (?))" );
+
+		assertTrue( statementInspector.getSqlQueries().get( 0 ).endsWith( expectedInClause.toString() ) );
+	}
+
+	@Test
+	public void testInClauseParameterSplittingAfterLimitNotIn(EntityManagerFactoryScope scope) {
+		final SQLStatementInspector statementInspector = scope.getCollectingStatementInspector();
+		statementInspector.clear();
+
+		scope.inTransaction(
+				entityManager -> entityManager.createQuery(
+						"select p from Person p where p.id not in :ids" )
+						.setParameter( "ids", IntStream.range( 0, 16 )
+								.boxed()
+								.collect( Collectors.toList() ) )
+						.getResultList() );
+
+		StringBuilder expectedInClause = new StringBuilder();
+		expectedInClause.append( "(p1_0.id not in (?" );
+		for ( int i = 1; i < MAX_COUNT; i++ ) {
+			expectedInClause.append( ",?" );
+		}
+		expectedInClause.append( ")" );
+		expectedInClause.append( " and p1_0.id not in (?))" );
 
 		assertTrue( statementInspector.getSqlQueries().get( 0 ).endsWith( expectedInClause.toString() ) );
 	}
@@ -160,12 +184,12 @@ public class MaxInExpressionParameterPaddingTest {
 		);
 
 		StringBuilder expectedInClause = new StringBuilder();
-		expectedInClause.append( "in (?" );
+		expectedInClause.append( "(p1_0.id in (?" );
 		for ( int i = 1; i < MAX_COUNT; i++ ) {
 			expectedInClause.append( ",?" );
 		}
 		expectedInClause.append( ")" );
-		expectedInClause.append( " or p1_0.id in (?,?,?,?)" );
+		expectedInClause.append( " or p1_0.id in (?,?,?,?))" );
 
 		assertTrue( statementInspector.getSqlQueries().get( 0 ).endsWith( expectedInClause.toString() ) );
 	}
@@ -186,7 +210,7 @@ public class MaxInExpressionParameterPaddingTest {
 		);
 
 		StringBuilder expectedInClause = new StringBuilder();
-		expectedInClause.append( "in (?" );
+		expectedInClause.append( "(p1_0.id in (?" );
 		for ( int i = 1; i < MAX_COUNT; i++ ) {
 			expectedInClause.append( ",?" );
 		}
@@ -196,7 +220,7 @@ public class MaxInExpressionParameterPaddingTest {
 			expectedInClause.append( ",?" );
 		}
 		expectedInClause.append( ")" );
-		expectedInClause.append( " or p1_0.id in (?,?,?,?)" );
+		expectedInClause.append( " or p1_0.id in (?,?,?,?))" );
 
 
 		assertTrue( statementInspector.getSqlQueries().get( 0 ).endsWith( expectedInClause.toString() ) );
@@ -219,7 +243,7 @@ public class MaxInExpressionParameterPaddingTest {
 		);
 
 		StringBuilder expectedInClause = new StringBuilder();
-		expectedInClause.append( "in (?" );
+		expectedInClause.append( "(p1_0.id in (?" );
 		for ( int i = 1; i < MAX_COUNT; i++ ) {
 			expectedInClause.append( ",?" );
 		}
@@ -233,7 +257,7 @@ public class MaxInExpressionParameterPaddingTest {
 		for ( int i = 1; i < MAX_COUNT; i++ ) {
 			expectedInClause.append( ",?" );
 		}
-		expectedInClause.append( ")" );
+		expectedInClause.append( "))" );
 
 
 		assertTrue( statementInspector.getSqlQueries().get( 0 ).endsWith( expectedInClause.toString() ) );


### PR DESCRIPTION
See [HHH-16589](https://hibernate.atlassian.net/browse/HHH-16589).

This PR fixes several bugs mentioned in the JIRA issue:
1. In clauses can no longer exceed `Dialect.getInExpressionCountLimit`.
2. When a large in clause is split into several in clauses they are now surrounded by parenthesis.
3. When splitting negated in clauses (`not in`) they are now joined with an `and` instead of an `or`.

Additionally this PR changes the algorithm to select the number of bind variables used when padding in clauses that need to be split due to `Dialect.getInExpressionCountLimit`. Previously the algorithm would fill as many in clauses as possible and then pad the last in clause to a power of two. This differs widely from the power of two rule used when not splitting in clauses and results in poor statement cache utilization for large in-clauses. While the number of required statements grew logarithmic without splitting, it grew linearly with splitting.

The new algorithm pads to a power of two when below `Dialect.getInExpressionCountLimit` and then uses a power of two multiplied by `Dialect.getInExpressionCountLimit` to continue the exponential growth of bind variables when above the limit. This way there are as few splits as possible, while still only requiring a logarithmic amount of statements.

[HHH-16589]: https://hibernate.atlassian.net/browse/HHH-16589?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ