### PR TITLE
HHH-16542 - Correct typo in javadoc

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/internal/util/ReflectHelper.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/util/ReflectHelper.java
@@ -513,7 +513,7 @@ public final class ReflectHelper {
 	}
 
 	/**
-	 * Find the method that can be used as the setter for this property.
+	 * Find the method that can be used as the getter for this property.
 	 *
 	 * @param containerClass The Class which contains the property
 	 * @param propertyName The name of the property


### PR DESCRIPTION
This PR fixes typo in the javadoc of `getGetterOrNull`.