### PR TITLE
HHH-16560: Support composite EmbeddedId classes.

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/embeddable/AbstractEmbeddableInitializer.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/embeddable/AbstractEmbeddableInitializer.java
@@ -263,8 +263,9 @@ public abstract class AbstractEmbeddableInitializer extends AbstractFetchParentA
 		FetchParentAccess parentAccess = fetchParentAccess;
 
 		while ( parentAccess != null && parentAccess.isEmbeddableInitializer() ) {
-			assert !( parentAccess.getInitializedPart() instanceof CompositeIdentifierMapping )
-					: "isPartOfKey should have been true in this case";
+			if ( parentAccess.getInitializedPart() instanceof CompositeIdentifierMapping ) {
+				return false;
+			}
 			parentAccess = parentAccess.getFetchParentAccess();
 		}
 

--- a/hibernate-core/src/test/java/org/hibernate/sql/results/graph/embeddable/AbstractEmbeddableInitializerTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/sql/results/graph/embeddable/AbstractEmbeddableInitializerTest.java
@@ -1,0 +1,119 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html
+ */
+package org.hibernate.sql.results.graph.embeddable;
+
+import jakarta.persistence.Embeddable;
+import jakarta.persistence.EmbeddedId;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+
+import org.hibernate.testing.TestForIssue;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * @author Steve Storey
+ */
+@DomainModel(annotatedClasses = { AbstractEmbeddableInitializerTest.DomainEntity.class, })
+@SessionFactory
+public class AbstractEmbeddableInitializerTest {
+
+	@Test
+	@TestForIssue(jiraKey = "HHH-16560")
+	public void testCompositeEmbeddedId(SessionFactoryScope scope) {
+		scope.inTransaction(session -> {
+			DomainEntity entity = new DomainEntity( new SimpleEmbeddedId(1L), "key" );
+			session.persist( entity );
+			session.flush();
+			Object loaded = session.createQuery( "select id from DomainEntity" ).getSingleResult();
+			assertEquals(loaded, entity.getId());
+		});
+	}
+
+	@Entity(name = "DomainEntity")
+	@Table(name = "domain_entity")
+	public static class DomainEntity {
+		@EmbeddedId
+		private CompositeEmbeddedId id;
+		private String name;
+
+		private DomainEntity() {
+		}
+
+		public DomainEntity(SimpleEmbeddedId simpleId, String name) {
+			this();
+			this.id = new CompositeEmbeddedId( simpleId );
+			this.name = name;
+		}
+
+		public CompositeEmbeddedId getId() {
+			return id;
+		}
+
+		public String getName() {
+			return name;
+		}
+	}
+
+	@Embeddable
+	public static class CompositeEmbeddedId {
+		private SimpleEmbeddedId simpleId;
+		private String idType;
+
+		private CompositeEmbeddedId() {
+		}
+
+		public CompositeEmbeddedId(SimpleEmbeddedId simpleId) {
+			this();
+			this.simpleId = simpleId;
+			this.idType = simpleId.getClass().getSimpleName();
+		}
+
+		public String getIdType() {
+			return idType;
+		}
+
+		@Override
+		public boolean equals(Object obj) {
+			if ( !( obj instanceof CompositeEmbeddedId ) ) {
+				return false;
+			}
+			CompositeEmbeddedId other = ( CompositeEmbeddedId ) obj;
+			return other.simpleId.equals( simpleId ) && other.idType.equals( idType );
+		}
+	}
+
+	@Embeddable
+	public static class SimpleEmbeddedId {
+		private Long id;
+
+		protected SimpleEmbeddedId() {
+		}
+
+		protected SimpleEmbeddedId(Long id) {
+			this();
+			this.id = id;
+		}
+
+		public Long getId() {
+			return id;
+		}
+
+		@Override
+		public boolean equals(Object obj) {
+			if ( !( obj instanceof SimpleEmbeddedId ) ) {
+				return false;
+			}
+			SimpleEmbeddedId other = ( SimpleEmbeddedId ) obj;
+			return other.id.equals( id );
+		}
+	}
+}


### PR DESCRIPTION
In 6.2.2 (via commit 995aa53fc0bae734324c16bf2d53080aa65bb079), an assertion failure was triggered when an `@Embeddable` ID class also contained another `@Embeddable`. I'm proposing to restore the <=6.2.1 behaviour instead of triggering the assertion failure here.

/cc @beikov as you added the assertion in the first place, and I don't know whether my proposal is in fact sensible or valid, but I'm hoping you can keep my new test to detect regressions ...