### PR TITLE
HHH-16603, HHH-9763 fix two issues with interpreting @Cache/@Cacheable annotations

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/boot/model/internal/EntityBinder.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/internal/EntityBinder.java
@@ -1524,22 +1524,22 @@ public class EntityBinder {
 	}
 
 	private void bindSubclassCache(SharedCacheMode sharedCacheMode) {
-		final Cache cache = annotatedClass.getAnnotation( Cache.class );
+		if ( annotatedClass.isAnnotationPresent( Cache.class ) ) {
+			final String className = persistentClass.getClassName() == null
+					? annotatedClass.getName()
+					: persistentClass.getClassName();
+			throw new AnnotationException("Entity class '" + className
+					+  "' is annotated '@Cache' but it is a subclass in an entity inheritance hierarchy"
+					+" (only root classes may define second-level caching semantics)");
+		}
+
 		final Cacheable cacheable = annotatedClass.getAnnotation( Cacheable.class );
-		if ( cache != null ) {
-			LOG.cacheOrCacheableAnnotationOnNonRoot(
-					persistentClass.getClassName() == null
-							? annotatedClass.getName()
-							: persistentClass.getClassName()
-			);
-		}
-		else if ( cacheable == null && persistentClass.getSuperclass() != null ) {
-			// we should inherit our super's caching config
-			isCached = persistentClass.getSuperclass().isCached();
-		}
-		else {
-			isCached = isCacheable( sharedCacheMode, cacheable );
-		}
+		isCached = cacheable == null && persistentClass.getSuperclass() != null
+				// we should inherit the root class caching config
+				? persistentClass.getSuperclass().isCached()
+				//TODO: is this even correct?
+				//      Do we even correctly support selectively enabling caching on subclasses like this?
+				: isCacheable( sharedCacheMode, cacheable );
 	}
 
 	private void bindRootClassCache(SharedCacheMode sharedCacheMode, MetadataBuildingContext context) {
@@ -1581,6 +1581,7 @@ public class EntityBinder {
 				// all entities should be cached
 				return true;
 			case ENABLE_SELECTIVE:
+			case UNSPECIFIED: // Hibernate defaults to ENABLE_SELECTIVE, the only sensible setting
 				// only entities with @Cacheable(true) should be cached
 				return explicitCacheableAnn != null && explicitCacheableAnn.value();
 			case DISABLE_SELECTIVE:

--- a/hibernate-core/src/main/java/org/hibernate/cache/internal/QueryResultsCacheImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/cache/internal/QueryResultsCacheImpl.java
@@ -52,7 +52,9 @@ public class QueryResultsCacheImpl implements QueryResultsCache {
 			final List<?> results,
 			final SharedSessionContractImplementor session) throws HibernateException {
 		if ( DEBUG_ENABLED ) {
-			L2CACHE_LOGGER.debugf( "Caching query results in region: %s; timestamp=%s", cacheRegion.getName(), session.getCacheTransactionSynchronization().getCachingTimestamp() );
+			L2CACHE_LOGGER.debugf( "Caching query results in region: %s; timestamp=%s",
+					cacheRegion.getName(),
+					session.getCacheTransactionSynchronization().getCachingTimestamp() );
 		}
 
 		final CacheItem cacheItem = new CacheItem(

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/cache/NonRootEntityWithCacheAnnotationTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/cache/NonRootEntityWithCacheAnnotationTest.java
@@ -9,9 +9,9 @@ package org.hibernate.orm.test.cache;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.hibernate.AnnotationException;
 import org.hibernate.annotations.Cache;
 import org.hibernate.annotations.CacheConcurrencyStrategy;
-import org.hibernate.boot.Metadata;
 import org.hibernate.boot.MetadataSources;
 import org.hibernate.boot.model.internal.EntityBinder;
 import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
@@ -23,7 +23,6 @@ import org.hibernate.service.spi.ServiceRegistryImplementor;
 import org.hibernate.testing.TestForIssue;
 import org.hibernate.testing.cache.CachingRegionFactory;
 import org.hibernate.testing.logger.LoggerInspectionRule;
-import org.hibernate.testing.logger.Triggerable;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -34,8 +33,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.Inheritance;
 import jakarta.persistence.SharedCacheMode;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 /**
  * @author Gail Badner
@@ -57,16 +55,16 @@ public class NonRootEntityWithCacheAnnotationTest {
 		try (ServiceRegistryImplementor serviceRegistry = (ServiceRegistryImplementor) new StandardServiceRegistryBuilder()
 				.applySettings( settings )
 				.build()) {
-
-			Triggerable triggerable = logInspection.watchForLogMessages( "HHH000482" );
-
-			Metadata metadata = new MetadataSources( serviceRegistry )
-					.addAnnotatedClass( ABase.class )
-					.addAnnotatedClass( AEntity.class )
-					.buildMetadata();
-
-			assertTrue( triggerable.wasTriggered() );
-			assertFalse( metadata.getEntityBinding( AEntity.class.getName() ).isCached() );
+			try {
+				new MetadataSources( serviceRegistry )
+						.addAnnotatedClass( ABase.class )
+						.addAnnotatedClass( AEntity.class )
+						.buildMetadata();
+				fail("No error for @Cache on subclass entity");
+			}
+			catch (AnnotationException ae) {
+				//exception required
+			}
 		}
 	}
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/cfg/cache/DefaultCacheConcurrencyPropertyTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/cfg/cache/DefaultCacheConcurrencyPropertyTest.java
@@ -28,7 +28,6 @@ import org.hibernate.testing.junit4.BaseUnitTestCase;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
@@ -39,7 +38,6 @@ public class DefaultCacheConcurrencyPropertyTest extends BaseUnitTestCase {
 
 	@Test
 	@TestForIssue( jiraKey = "HHH-9763" )
-	@FailureExpected( jiraKey = "HHH-9763" )
 	public void testExplicitDefault() {
 
 		final StandardServiceRegistry ssr = new StandardServiceRegistryBuilder()

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/cacheable/annotation/ConfigurationTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/cacheable/annotation/ConfigurationTest.java
@@ -62,7 +62,7 @@ public class ConfigurationTest {
 		MetadataImplementor metadata = buildMetadata( SharedCacheMode.UNSPECIFIED );
 
 		PersistentClass pc = metadata.getEntityBinding( ExplicitlyCacheableEntity.class.getName() );
-		assertFalse( pc.isCached() );
+		assertTrue( pc.isCached() );
 
 		pc = metadata.getEntityBinding( ExplicitlyNonCacheableEntity.class.getName() );
 		assertFalse( pc.isCached() );

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/converted/converter/ExplicitJavaTypeDescriptorTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/converted/converter/ExplicitJavaTypeDescriptorTest.java
@@ -6,6 +6,7 @@
  */
 package org.hibernate.orm.test.mapping.converted.converter;
 
+import java.io.Serializable;
 import java.sql.Types;
 import java.util.Locale;
 import jakarta.persistence.AttributeConverter;
@@ -62,7 +63,7 @@ public class ExplicitJavaTypeDescriptorTest extends BaseNonConfigCoreFunctionalT
 
 		// assertions based on the persist call
 		assertThat( mutableToDomainCallCount, is(1 ) );  			// 1 instead of 0 because of the deep copy call
-		assertThat( mutableToDatabaseCallCount, is(2 ) );  			// 2 instead of 1 because of the deep copy call
+		assertThat( mutableToDatabaseCallCount, is(3 ) );  			// 2 instead of 1 because of the deep copy call
 
 		assertThat( immutableToDomainCallCount, is(0 ) );			// logical
 		assertThat( immutableToDatabaseCallCount, is(1 ) );			// logical
@@ -203,7 +204,7 @@ public class ExplicitJavaTypeDescriptorTest extends BaseNonConfigCoreFunctionalT
 	// Purely immutable state
 
 	@Immutable
-	public static class ImmutableState {
+	public static class ImmutableState implements Serializable {
 		private final String state;
 
 		public ImmutableState(String state) {
@@ -254,7 +255,7 @@ public class ExplicitJavaTypeDescriptorTest extends BaseNonConfigCoreFunctionalT
 	// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 	// Mutable state we treat as immutable
 
-	public static class PseudoMutableState {
+	public static class PseudoMutableState implements Serializable {
 		private String state;
 
 		public PseudoMutableState(String state) {


### PR DESCRIPTION
1. Throw instead of logging a `WARN` if `@Cache` is on a subclass. 
3. Fix interpretation of `SharedCacheMode.UNSPECIFIED` (UPDATE: this was the root cause of https://hibernate.atlassian.net/browse/HHH-9763)

 I just lost 1/2 an hour of my life due to this being a WARN. Logging WARNs is a terrible way to report user error! I've complained about this practice lots of times, and just got bitten by it myself.
