### PR TITLE
HHH-16589 Backport for 6.2: In clause padding can no longer cause in clauses to exceed Dialect.getInExpressionCountLimit

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/internal/util/MathHelper.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/util/MathHelper.java
@@ -21,6 +21,10 @@ public final class MathHelper {
 	 * @return smallest power of two number
 	 */
 	public static int ceilingPowerOfTwo(int value) {
-		return 1 << -Integer.numberOfLeadingZeros(value - 1);
+		int result = 1 << -Integer.numberOfLeadingZeros(value - 1);
+		if ( result < value ) { // Overflow
+			return Integer.MAX_VALUE;
+		}
+		return result;
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/internal/util/MathHelper.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/util/MathHelper.java
@@ -8,6 +8,7 @@ package org.hibernate.internal.util;
 
 /**
  * @author Vlad Mihalcea
+ * @author Adrodoc
  */
 public final class MathHelper {
 
@@ -26,5 +27,16 @@ public final class MathHelper {
 			return Integer.MAX_VALUE;
 		}
 		return result;
+	}
+
+	/**
+	 * Returns the result of dividing a positive {@code numerator} by a positive {@code denominator} rounded up. For
+	 * example dividing 5 by 2 would give a result of 3.
+	 */
+	public static int divideRoundingUp(int numerator, int denominator) {
+		if ( numerator == 0 ) {
+			return 0;
+		}
+		return ( ( numerator - 1 ) / denominator ) + 1;
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/sql/ast/spi/AbstractSqlAstTranslator.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/ast/spi/AbstractSqlAstTranslator.java
@@ -216,6 +216,7 @@ import static org.hibernate.sql.results.graph.DomainResultGraphPrinter.logDomain
 
 /**
  * @author Steve Ebersole
+ * @author Adrodoc
  */
 public abstract class AbstractSqlAstTranslator<T extends JdbcOperation> implements SqlAstTranslator<T>, SqlAppender {
 
@@ -6885,17 +6886,14 @@ public abstract class AbstractSqlAstTranslator<T extends JdbcOperation> implemen
 	}
 
 	private static int addPadding(int bindValueCount, int inExprLimit) {
-		if ( inExprLimit <= 0 ) {
-			return MathHelper.ceilingPowerOfTwo( bindValueCount );
+		int ceilingPowerOfTwo = MathHelper.ceilingPowerOfTwo( bindValueCount );
+		if ( inExprLimit <= 0 || ceilingPowerOfTwo <= inExprLimit ) {
+			return ceilingPowerOfTwo;
 		}
 
-		int lastInClauseSize = bindValueCount % inExprLimit;
-		if ( lastInClauseSize == 0 ) {
-			return bindValueCount;
-		}
-		int lastInClauseSizeWithPadding = Math.min( inExprLimit, MathHelper.ceilingPowerOfTwo( lastInClauseSize ) );
-		int padding = lastInClauseSizeWithPadding - lastInClauseSize;
-		return bindValueCount + padding;
+		int numberOfInClauses = MathHelper.divideRoundingUp( bindValueCount, inExprLimit );
+		int numberOfInClausesWithPadding = MathHelper.ceilingPowerOfTwo( numberOfInClauses );
+		return numberOfInClausesWithPadding * inExprLimit;
 	}
 
 	@Override

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/internal/util/MathHelperTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/internal/util/MathHelperTest.java
@@ -43,4 +43,20 @@ public class MathHelperTest {
 		assertThat( MathHelper.ceilingPowerOfTwo( Integer.MAX_VALUE ) ).isEqualTo( Integer.MAX_VALUE );
 	}
 
+	@Test
+	public void divideRoundingUp() {
+		assertThat( MathHelper.divideRoundingUp( 0, 1 ) ).isEqualTo( 0 );
+		assertThat( MathHelper.divideRoundingUp( 1, 1 ) ).isEqualTo( 1 );
+		assertThat( MathHelper.divideRoundingUp( 2, 1 ) ).isEqualTo( 2 );
+		assertThat( MathHelper.divideRoundingUp( 0, 2 ) ).isEqualTo( 0 );
+		assertThat( MathHelper.divideRoundingUp( 1, 2 ) ).isEqualTo( 1 );
+		assertThat( MathHelper.divideRoundingUp( 2, 2 ) ).isEqualTo( 1 );
+		assertThat( MathHelper.divideRoundingUp( 3, 2 ) ).isEqualTo( 2 );
+		assertThat( MathHelper.divideRoundingUp( 4, 2 ) ).isEqualTo( 2 );
+		assertThat( MathHelper.divideRoundingUp( 5, 2 ) ).isEqualTo( 3 );
+		assertThat( MathHelper.divideRoundingUp( 9, 3 ) ).isEqualTo( 3 );
+		assertThat( MathHelper.divideRoundingUp( 10, 3 ) ).isEqualTo( 4 );
+		assertThat( MathHelper.divideRoundingUp( Integer.MAX_VALUE, 2 ) ).isEqualTo( 1_073_741_824 );
+	}
+
 }

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/internal/util/MathHelperTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/internal/util/MathHelperTest.java
@@ -20,6 +20,7 @@ public class MathHelperTest {
 
 	@Test
 	public void ceilingPowerOfTwo() {
+		assertThat( MathHelper.ceilingPowerOfTwo( 0 ) ).isEqualTo( 1 );
 		assertThat( MathHelper.ceilingPowerOfTwo( 1 ) ).isEqualTo( 1 );
 		assertThat( MathHelper.ceilingPowerOfTwo( 2 ) ).isEqualTo( 2 );
 		assertThat( MathHelper.ceilingPowerOfTwo( 3 ) ).isEqualTo( 4 );

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/internal/util/MathHelperTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/internal/util/MathHelperTest.java
@@ -17,7 +17,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Vlad Mihalcea
  */
 public class MathHelperTest {
-	
+
 	@Test
 	public void ceilingPowerOfTwo() {
 		assertThat( MathHelper.ceilingPowerOfTwo( 1 ) ).isEqualTo( 1 );
@@ -37,6 +37,9 @@ public class MathHelperTest {
 		assertThat( MathHelper.ceilingPowerOfTwo( 14 ) ).isEqualTo( 16 );
 		assertThat( MathHelper.ceilingPowerOfTwo( 15 ) ).isEqualTo( 16 );
 		assertThat( MathHelper.ceilingPowerOfTwo( 16 ) ).isEqualTo( 16 );
+
+		assertThat( MathHelper.ceilingPowerOfTwo( Integer.MAX_VALUE - 1 ) ).isEqualTo( Integer.MAX_VALUE );
+		assertThat( MathHelper.ceilingPowerOfTwo( Integer.MAX_VALUE ) ).isEqualTo( Integer.MAX_VALUE );
 	}
 
 }

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/query/MaxInExpressionParameterPaddingTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/query/MaxInExpressionParameterPaddingTest.java
@@ -134,12 +134,36 @@ public class MaxInExpressionParameterPaddingTest {
 		);
 
 		StringBuilder expectedInClause = new StringBuilder();
-		expectedInClause.append( "in (?" );
+		expectedInClause.append( "(p1_0.id in (?" );
 		for ( int i = 1; i < MAX_COUNT; i++ ) {
 			expectedInClause.append( ",?" );
 		}
 		expectedInClause.append( ")" );
-		expectedInClause.append( " or p1_0.id in (?)" );
+		expectedInClause.append( " or p1_0.id in (?))" );
+
+		assertTrue( statementInspector.getSqlQueries().get( 0 ).endsWith( expectedInClause.toString() ) );
+	}
+
+	@Test
+	public void testInClauseParameterSplittingAfterLimitNotIn(EntityManagerFactoryScope scope) {
+		final SQLStatementInspector statementInspector = scope.getCollectingStatementInspector();
+		statementInspector.clear();
+
+		scope.inTransaction(
+				entityManager -> entityManager.createQuery(
+						"select p from Person p where p.id not in :ids" )
+						.setParameter( "ids", IntStream.range( 0, 16 )
+								.boxed()
+								.collect( Collectors.toList() ) )
+						.getResultList() );
+
+		StringBuilder expectedInClause = new StringBuilder();
+		expectedInClause.append( "(p1_0.id not in (?" );
+		for ( int i = 1; i < MAX_COUNT; i++ ) {
+			expectedInClause.append( ",?" );
+		}
+		expectedInClause.append( ")" );
+		expectedInClause.append( " and p1_0.id not in (?))" );
 
 		assertTrue( statementInspector.getSqlQueries().get( 0 ).endsWith( expectedInClause.toString() ) );
 	}
@@ -160,12 +184,12 @@ public class MaxInExpressionParameterPaddingTest {
 		);
 
 		StringBuilder expectedInClause = new StringBuilder();
-		expectedInClause.append( "in (?" );
+		expectedInClause.append( "(p1_0.id in (?" );
 		for ( int i = 1; i < MAX_COUNT; i++ ) {
 			expectedInClause.append( ",?" );
 		}
 		expectedInClause.append( ")" );
-		expectedInClause.append( " or p1_0.id in (?,?,?,?)" );
+		expectedInClause.append( " or p1_0.id in (?,?,?,?))" );
 
 		assertTrue( statementInspector.getSqlQueries().get( 0 ).endsWith( expectedInClause.toString() ) );
 	}
@@ -186,7 +210,7 @@ public class MaxInExpressionParameterPaddingTest {
 		);
 
 		StringBuilder expectedInClause = new StringBuilder();
-		expectedInClause.append( "in (?" );
+		expectedInClause.append( "(p1_0.id in (?" );
 		for ( int i = 1; i < MAX_COUNT; i++ ) {
 			expectedInClause.append( ",?" );
 		}
@@ -196,7 +220,7 @@ public class MaxInExpressionParameterPaddingTest {
 			expectedInClause.append( ",?" );
 		}
 		expectedInClause.append( ")" );
-		expectedInClause.append( " or p1_0.id in (?,?,?,?)" );
+		expectedInClause.append( " or p1_0.id in (?,?,?,?))" );
 
 
 		assertTrue( statementInspector.getSqlQueries().get( 0 ).endsWith( expectedInClause.toString() ) );
@@ -219,7 +243,7 @@ public class MaxInExpressionParameterPaddingTest {
 		);
 
 		StringBuilder expectedInClause = new StringBuilder();
-		expectedInClause.append( "in (?" );
+		expectedInClause.append( "(p1_0.id in (?" );
 		for ( int i = 1; i < MAX_COUNT; i++ ) {
 			expectedInClause.append( ",?" );
 		}
@@ -233,7 +257,7 @@ public class MaxInExpressionParameterPaddingTest {
 		for ( int i = 1; i < MAX_COUNT; i++ ) {
 			expectedInClause.append( ",?" );
 		}
-		expectedInClause.append( ")" );
+		expectedInClause.append( "))" );
 
 
 		assertTrue( statementInspector.getSqlQueries().get( 0 ).endsWith( expectedInClause.toString() ) );


### PR DESCRIPTION
Backport of #6555 for Hibernate 6.2.

The commits of the two PR are exactly the same.