### PR TITLE
get rid of a stack trace from debug-level log

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/bytecode/internal/bytebuddy/BytecodeProviderImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/bytecode/internal/bytebuddy/BytecodeProviderImpl.java
@@ -168,7 +168,7 @@ public class BytecodeProviderImpl implements BytecodeProvider {
 			findAccessors( clazz, getterNames, setterNames, types, getters, setters );
 		}
 		catch (InvalidPropertyAccessorException ex) {
-			LOG.unableToGenerateReflectionOptimizer( clazz.getName(), ex );
+			LOG.unableToGenerateReflectionOptimizer( clazz.getName(), ex.getMessage() );
 			return null;
 		}
 
@@ -232,7 +232,7 @@ public class BytecodeProviderImpl implements BytecodeProvider {
 			findAccessors( clazz, propertyAccessMap, getters, setters );
 		}
 		catch (InvalidPropertyAccessorException ex) {
-			LOG.unableToGenerateReflectionOptimizer( clazz.getName(), ex );
+			LOG.unableToGenerateReflectionOptimizer( clazz.getName(), ex.getMessage() );
 			return null;
 		}
 

--- a/hibernate-core/src/main/java/org/hibernate/internal/CoreMessageLogger.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/CoreMessageLogger.java
@@ -1843,9 +1843,9 @@ public interface CoreMessageLogger extends BasicLogger {
 	void unableToDetermineCockroachDatabaseVersion(String minimumVersion);
 
 	@LogMessage(level = DEBUG)
-	@Message(value = "Unable to create the ReflectionOptimizer for [%s]",
+	@Message(value = "Unable to create the ReflectionOptimizer for [%s]: %s",
 			id = 513)
-	void unableToGenerateReflectionOptimizer(String className, @Cause Throwable cause);
+	void unableToGenerateReflectionOptimizer(String className, String cause);
 
 	@LogMessage(level = WARN)
 	@Message(value = "PostgreSQL JDBC driver classes are inaccessible and thus, certain DDL types like JSONB, JSON, GEOMETRY can not be used.",


### PR DESCRIPTION
because some amazing geniuses on stackoverflow who know much more than me about Hibernate are obsessing over this DEBUG-level log message