### PR TITLE
proposal for NativeQuery.setParameterEscapes()

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/engine/query/internal/NativeQueryInterpreterStandardImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/query/internal/NativeQueryInterpreterStandardImpl.java
@@ -24,8 +24,8 @@ public class NativeQueryInterpreterStandardImpl implements NativeQueryInterprete
 	public static final NativeQueryInterpreterStandardImpl NATIVE_QUERY_INTERPRETER = new NativeQueryInterpreterStandardImpl();
 
 	@Override
-	public void recognizeParameters(String nativeQuery, ParameterRecognizer recognizer) {
-		ParameterParser.parse( nativeQuery, recognizer );
+	public void recognizeParameters(String nativeQuery, ParameterRecognizer recognizer, char namedParamPrefix, char ordinalParamPrefix) {
+		ParameterParser.parse( nativeQuery, recognizer, namedParamPrefix, ordinalParamPrefix );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/engine/query/spi/NativeQueryInterpreter.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/query/spi/NativeQueryInterpreter.java
@@ -9,6 +9,7 @@ package org.hibernate.engine.query.spi;
 import org.hibernate.Incubating;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.query.sql.internal.NativeSelectQueryPlanImpl;
+import org.hibernate.query.sql.internal.ParameterParser;
 import org.hibernate.query.sql.spi.NativeSelectQueryDefinition;
 import org.hibernate.query.sql.spi.NativeSelectQueryPlan;
 import org.hibernate.query.sql.spi.ParameterRecognizer;
@@ -30,7 +31,15 @@ public interface NativeQueryInterpreter extends Service {
 	 * @param nativeQuery The query to recognize parameters in
 	 * @param recognizer The recognizer to call
 	 */
-	void recognizeParameters(String nativeQuery, ParameterRecognizer recognizer);
+	void recognizeParameters(String nativeQuery, ParameterRecognizer recognizer, char namedParamPrefix, char ordinalParamPrefix);
+
+	/**
+	 * @deprecated use {@link #recognizeParameters(String, ParameterRecognizer, char, char)}
+	 */
+	@Deprecated
+	default void recognizeParameters(String nativeQuery, ParameterRecognizer recognizer) {
+		recognizeParameters( nativeQuery, recognizer, ParameterParser.NAMED_PARAM_PREFIX, ParameterParser.ORDINAL_PARAM_PREFIX );
+	}
 
 	/**
 	 * Creates a new query plan for the passed native query definition

--- a/hibernate-core/src/main/java/org/hibernate/jpa/HibernateHints.java
+++ b/hibernate-core/src/main/java/org/hibernate/jpa/HibernateHints.java
@@ -156,4 +156,18 @@ public interface HibernateHints {
 	 * to a function rather than a call to a procedure.
 	 */
 	String HINT_CALLABLE_FUNCTION = "org.hibernate.callableFunction";
+
+	/**
+	 * The prefix character used to recognize a named parameter.
+	 *
+	 * @see org.hibernate.query.NativeQuery#setParameterEscapes(char, char)
+	 */
+	String HINT_NAMED_PARAMETER_PREFIX = "org.hibernate.namedParameterPrefix";
+
+	/**
+	 * The prefix character used to recognize an ordinal parameter.
+	 *
+	 * @see org.hibernate.query.NativeQuery#setParameterEscapes(char, char)
+	 */
+	String HINT_ORDINAL_PARAMETER_PREFIX = "org.hibernate.ordinalParameterPrefix";
 }

--- a/hibernate-core/src/main/java/org/hibernate/query/NativeQuery.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/NativeQuery.java
@@ -626,6 +626,18 @@ public interface NativeQuery<T> extends Query<T>, SynchronizeableQuery {
 	@Override
 	NativeQuery<T> setFirstResult(int startPosition);
 
+	/**
+	 * Set the prefix characters used to recognize named and ordinal parameters.
+	 * By default, named parameters are of form {@code :name}, and ordinal
+	 * parameters are of form {@code ?n}.
+	 *
+	 * @param namedParamPrefix the prefix for named parameters
+	 * @param ordinalParamPrefix the prefix for ordinal parameters
+	 *
+	 * @since 6.3
+	 */
+	NativeQuery<T> setParameterEscapes(char namedParamPrefix, char ordinalParamPrefix);
+
 	@Override
 	NativeQuery<T> setHint(String hintName, Object value);
 

--- a/hibernate-core/src/main/java/org/hibernate/query/sql/spi/NativeQueryImplementor.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sql/spi/NativeQueryImplementor.java
@@ -192,6 +192,9 @@ public interface NativeQueryImplementor<R> extends QueryImplementor<R>, NativeQu
 	NativeQueryImplementor<R> setFirstResult(int startPosition);
 
 	@Override
+	NativeQueryImplementor<R> setParameterEscapes(char namedParamPrefix, char ordinalParamPrefix);
+
+	@Override
 	NativeQueryImplementor<R> addQueryHint(String hint);
 
 	@Override

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/query/NativeQueryParameterPrefixJpaTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/query/NativeQueryParameterPrefixJpaTest.java
@@ -1,0 +1,155 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.orm.test.jpa.query;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Query;
+import jakarta.persistence.Table;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import org.hibernate.jpa.HibernateHints;
+import org.hibernate.testing.orm.junit.EntityManagerFactoryScope;
+import org.hibernate.testing.orm.junit.Jpa;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@Jpa(
+		annotatedClasses = {
+				NativeQueryParameterPrefixJpaTest.Game.class,
+				NativeQueryParameterPrefixJpaTest.Node.class
+		}
+)
+public class NativeQueryParameterPrefixJpaTest {
+
+	private static final String[] GAME_TITLES = { "Super Mario Brothers", "Mario Kart", "F-Zero" };
+
+	@BeforeAll
+	public void setUp(EntityManagerFactoryScope scope) {
+		scope.inTransaction(
+				entityManager -> {
+					for ( String title : GAME_TITLES ) {
+						Game game = new Game( title );
+						entityManager.persist( game );
+					}
+				}
+		);
+	}
+
+	@AfterAll
+	public void tearDown(EntityManagerFactoryScope scope) {
+		scope.inTransaction(
+				entityManager -> entityManager.createQuery( "delete from Game" ).executeUpdate()
+		);
+	}
+
+	@Test
+	public void testNativeQueryIndexedOrdinalParameter(EntityManagerFactoryScope scope) {
+		scope.inTransaction(
+				entityManager -> {
+					Query query = entityManager.createNativeQuery( "SELECT * FROM GAME g WHERE title = @1" );
+					query.setHint(HibernateHints.HINT_ORDINAL_PARAMETER_PREFIX, '@')
+							.setParameter( 1, "Super Mario Brothers" );
+					List list = query.getResultList();
+					assertEquals( 1, list.size() );
+				}
+		);
+	}
+
+	@Test
+	public void testNativeQueryNamedParameter(EntityManagerFactoryScope scope) {
+		scope.inTransaction(
+				entityManager -> {
+					Query query = entityManager.createNativeQuery( "SELECT * FROM GAME g WHERE title = #t" );
+					query.setHint(HibernateHints.HINT_NAMED_PARAMETER_PREFIX, '#')
+							.setParameter( "t", "Super Mario Brothers" );
+					List list = query.getResultList();
+					assertEquals( 1, list.size() );
+				}
+		);
+	}
+
+	@Entity(name = "Game")
+	@Table(name = "GAME")
+	public static class Game {
+		private Long id;
+		private String title;
+
+		public Game() {
+		}
+
+		public Game(String title) {
+			this.title = title;
+		}
+
+		@Id
+		@GeneratedValue
+		public Long getId() {
+			return id;
+		}
+
+		public void setId(Long id) {
+			this.id = id;
+		}
+
+		@NotNull
+		@Size(min = 3, max = 50)
+		public String getTitle() {
+			return title;
+		}
+
+		public void setTitle(String title) {
+			this.title = title;
+		}
+	}
+
+	@Entity(name = "Node")
+	@Table(name = "Node")
+	public static class Node {
+
+		@Id
+		@GeneratedValue
+		private Integer id;
+
+		private String code;
+
+		@ManyToOne(fetch = FetchType.LAZY)
+		private Node parent;
+
+		public Integer getId() {
+			return id;
+		}
+
+		public void setId(Integer id) {
+			this.id = id;
+		}
+
+		public String getCode() {
+			return code;
+		}
+
+		public void setCode(String code) {
+			this.code = code;
+		}
+
+		public Node getParent() {
+			return parent;
+		}
+
+		public void setParent(Node parent) {
+			this.parent = parent;
+		}
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/query/NativeQueryParameterPrefixTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/query/NativeQueryParameterPrefixTest.java
@@ -1,0 +1,157 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.orm.test.jpa.query;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import org.hibernate.query.NativeQuery;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@SessionFactory
+@DomainModel(
+		annotatedClasses = {
+				NativeQueryParameterPrefixTest.Game.class,
+				NativeQueryParameterPrefixTest.Node.class
+		}
+)
+public class NativeQueryParameterPrefixTest {
+
+	private static final String[] GAME_TITLES = { "Super Mario Brothers", "Mario Kart", "F-Zero" };
+
+	@BeforeEach
+	public void setUp(SessionFactoryScope scope) {
+		scope.inTransaction(
+				session -> {
+					for ( String title : GAME_TITLES ) {
+						Game game = new Game( title );
+						session.persist( game );
+					}
+				}
+		);
+	}
+
+	@BeforeEach
+	public void tearDown(SessionFactoryScope scope) {
+		scope.inTransaction(
+				session -> {
+					session.createNativeMutationQuery("delete GAME").executeUpdate();
+				}
+		);
+	}
+
+	@Test
+	public void testNativeQueryIndexedOrdinalParameter(SessionFactoryScope scope) {
+		scope.inTransaction(
+				session -> {
+					NativeQuery query = session.createNativeQuery( "SELECT * FROM GAME g WHERE title = @1" );
+					query.setParameterEscapes('#','@')
+							.setParameter( 1, "Super Mario Brothers" );
+					List list = query.getResultList();
+					assertEquals( 1, list.size() );
+				}
+		);
+	}
+
+	@Test
+	public void testNativeQueryNamedParameter(SessionFactoryScope scope) {
+		scope.inTransaction(
+				session -> {
+					NativeQuery query = session.createNativeQuery( "SELECT * FROM GAME g WHERE title = #t" );
+					query.setParameterEscapes('#','@')
+							.setParameter( "t", "Super Mario Brothers" );
+					List list = query.getResultList();
+					assertEquals( 1, list.size() );
+				}
+		);
+	}
+
+	@Entity(name = "Game")
+	@Table(name = "GAME")
+	public static class Game {
+		private Long id;
+		private String title;
+
+		public Game() {
+		}
+
+		public Game(String title) {
+			this.title = title;
+		}
+
+		@Id
+		@GeneratedValue
+		public Long getId() {
+			return id;
+		}
+
+		public void setId(Long id) {
+			this.id = id;
+		}
+
+		@NotNull
+		@Size(min = 3, max = 50)
+		public String getTitle() {
+			return title;
+		}
+
+		public void setTitle(String title) {
+			this.title = title;
+		}
+	}
+
+	@Entity(name = "Node")
+	@Table(name = "Node")
+	public static class Node {
+
+		@Id
+		@GeneratedValue
+		private Integer id;
+
+		private String code;
+
+		@ManyToOne(fetch = FetchType.LAZY)
+		private Node parent;
+
+		public Integer getId() {
+			return id;
+		}
+
+		public void setId(Integer id) {
+			this.id = id;
+		}
+
+		public String getCode() {
+			return code;
+		}
+
+		public void setCode(String code) {
+			this.code = code;
+		}
+
+		public Node getParent() {
+			return parent;
+		}
+
+		public void setParent(Node parent) {
+			this.parent = parent;
+		}
+	}
+}


### PR DESCRIPTION
ability to override the syntax for named/ordinal parameters in native SQL queries