### PR TITLE
HHH-16645 two API improvements to EntityGraphs

### DIFF
--- a/documentation/src/main/asciidoc/introduction/Interacting.adoc
+++ b/documentation/src/main/asciidoc/introduction/Interacting.adoc
@@ -416,7 +416,7 @@ Hibernate has a better way:
 ----
 var graph = session.createEntityGraph(Book.class);
 graph.addSubgraph(Book_.publisher);
-session.byId(Book.class).fetching(graph).load(bookId);
+session.byId(Book.class).withFetchGraph(graph).load(bookId);
 ----
 
 This code adds a `left outer join` to our SQL query, fetching the associated `Publisher` along with the `Book`.
@@ -428,7 +428,7 @@ We may even attach additional nodes to our `EntityGraph`:
 var graph = session.createEntityGraph(Book.class);
 graph.addSubgraph(Book_.publisher);
 graph.addPluralSubgraph(Book_.authors).addSubgraph(Author_.person);
-session.byId(Book.class).fetching(graph).load(bookId);
+session.byId(Book.class).withFetchGraph(graph).load(bookId);
 
 ----
 

--- a/hibernate-core/src/main/java/org/hibernate/IdentifierLoadAccess.java
+++ b/hibernate-core/src/main/java/org/hibernate/IdentifierLoadAccess.java
@@ -43,19 +43,20 @@ public interface IdentifierLoadAccess<T> {
 	 */
 	IdentifierLoadAccess<T> withReadOnly(boolean readOnly);
 
-	default IdentifierLoadAccess<T> fetching(RootGraph<T> graph) {
+	default IdentifierLoadAccess<T> withFetchGraph(RootGraph<T> graph) {
 		return with( graph, GraphSemantic.FETCH );
 	}
-	default IdentifierLoadAccess<T> loading(RootGraph<T> graph) {
+
+	default IdentifierLoadAccess<T> withLoadGraph(RootGraph<T> graph) {
 		return with( graph, GraphSemantic.LOAD );
 	}
 
 	/**
-	 * @deprecated use {@link #loading}
+	 * @deprecated use {@link #withLoadGraph}
 	 */
 	@Deprecated(since = "6.3")
 	default IdentifierLoadAccess<T> with(RootGraph<T> graph) {
-		return loading( graph );
+		return withLoadGraph( graph );
 	}
 
 	IdentifierLoadAccess<T> with(RootGraph<T> graph, GraphSemantic semantic);

--- a/hibernate-core/src/main/java/org/hibernate/IdentifierLoadAccess.java
+++ b/hibernate-core/src/main/java/org/hibernate/IdentifierLoadAccess.java
@@ -43,8 +43,19 @@ public interface IdentifierLoadAccess<T> {
 	 */
 	IdentifierLoadAccess<T> withReadOnly(boolean readOnly);
 
-	default IdentifierLoadAccess<T> with(RootGraph<T> graph) {
+	default IdentifierLoadAccess<T> fetching(RootGraph<T> graph) {
+		return with( graph, GraphSemantic.FETCH );
+	}
+	default IdentifierLoadAccess<T> loading(RootGraph<T> graph) {
 		return with( graph, GraphSemantic.LOAD );
+	}
+
+	/**
+	 * @deprecated use {@link #loading}
+	 */
+	@Deprecated(since = "6.3")
+	default IdentifierLoadAccess<T> with(RootGraph<T> graph) {
+		return loading( graph );
 	}
 
 	IdentifierLoadAccess<T> with(RootGraph<T> graph, GraphSemantic semantic);

--- a/hibernate-core/src/main/java/org/hibernate/MultiIdentifierLoadAccess.java
+++ b/hibernate-core/src/main/java/org/hibernate/MultiIdentifierLoadAccess.java
@@ -36,6 +36,17 @@ public interface MultiIdentifierLoadAccess<T> {
 	 */
 	MultiIdentifierLoadAccess<T> with(CacheMode cacheMode);
 
+	default MultiIdentifierLoadAccess<T> fetching(RootGraph<T> graph) {
+		return with( graph, GraphSemantic.FETCH );
+	}
+	default MultiIdentifierLoadAccess<T> loading(RootGraph<T> graph) {
+		return with( graph, GraphSemantic.LOAD );
+	}
+
+	/**
+	 * @deprecated use {@link #loading}
+	 */
+	@Deprecated(since = "6.3")
 	default MultiIdentifierLoadAccess<T> with(RootGraph<T> graph) {
 		return with( graph, GraphSemantic.LOAD );
 	}
@@ -46,7 +57,7 @@ public interface MultiIdentifierLoadAccess<T> {
 	 * Specify a batch size for loading the entities (how many at a time).  The default is
 	 * to use a batch sizing strategy defined by the Dialect in use.  Any greater-than-one
 	 * value here will override that default behavior.  If giving an explicit value here,
-	 * care should be taken to not exceed the capabilities of of the underlying database.
+	 * care should be taken to not exceed the capabilities of the underlying database.
 	 * <p>
 	 * Note that overall a batch-size is considered a hint.  How the underlying loading
 	 * mechanism interprets that is completely up to that underlying loading mechanism.

--- a/hibernate-core/src/main/java/org/hibernate/MultiIdentifierLoadAccess.java
+++ b/hibernate-core/src/main/java/org/hibernate/MultiIdentifierLoadAccess.java
@@ -36,15 +36,16 @@ public interface MultiIdentifierLoadAccess<T> {
 	 */
 	MultiIdentifierLoadAccess<T> with(CacheMode cacheMode);
 
-	default MultiIdentifierLoadAccess<T> fetching(RootGraph<T> graph) {
+	default MultiIdentifierLoadAccess<T> withFetchGraph(RootGraph<T> graph) {
 		return with( graph, GraphSemantic.FETCH );
 	}
-	default MultiIdentifierLoadAccess<T> loading(RootGraph<T> graph) {
+
+	default MultiIdentifierLoadAccess<T> withLoadGraph(RootGraph<T> graph) {
 		return with( graph, GraphSemantic.LOAD );
 	}
 
 	/**
-	 * @deprecated use {@link #loading}
+	 * @deprecated use {@link #withLoadGraph}
 	 */
 	@Deprecated(since = "6.3")
 	default MultiIdentifierLoadAccess<T> with(RootGraph<T> graph) {

--- a/hibernate-core/src/main/java/org/hibernate/NaturalIdMultiLoadAccess.java
+++ b/hibernate-core/src/main/java/org/hibernate/NaturalIdMultiLoadAccess.java
@@ -35,15 +35,16 @@ public interface NaturalIdMultiLoadAccess<T> {
 	 */
 	NaturalIdMultiLoadAccess<T> with(CacheMode cacheMode);
 
-	default NaturalIdMultiLoadAccess<T> fetching(RootGraph<T> graph) {
+	default NaturalIdMultiLoadAccess<T> withFetchGraph(RootGraph<T> graph) {
 		return with( graph, GraphSemantic.FETCH );
 	}
-	default NaturalIdMultiLoadAccess<T> loading(RootGraph<T> graph) {
+
+	default NaturalIdMultiLoadAccess<T> withLoadGraph(RootGraph<T> graph) {
 		return with( graph, GraphSemantic.LOAD );
 	}
 
 	/**
-	 * @deprecated use {@link #loading}
+	 * @deprecated use {@link #withLoadGraph}
 	 */
 	@Deprecated(since = "6.3")
 	default NaturalIdMultiLoadAccess<T> with(RootGraph<T> graph) {

--- a/hibernate-core/src/main/java/org/hibernate/NaturalIdMultiLoadAccess.java
+++ b/hibernate-core/src/main/java/org/hibernate/NaturalIdMultiLoadAccess.java
@@ -35,9 +35,17 @@ public interface NaturalIdMultiLoadAccess<T> {
 	 */
 	NaturalIdMultiLoadAccess<T> with(CacheMode cacheMode);
 
+	default NaturalIdMultiLoadAccess<T> fetching(RootGraph<T> graph) {
+		return with( graph, GraphSemantic.FETCH );
+	}
+	default NaturalIdMultiLoadAccess<T> loading(RootGraph<T> graph) {
+		return with( graph, GraphSemantic.LOAD );
+	}
+
 	/**
-	 * Define a load graph to be used when retrieving the entity
+	 * @deprecated use {@link #loading}
 	 */
+	@Deprecated(since = "6.3")
 	default NaturalIdMultiLoadAccess<T> with(RootGraph<T> graph) {
 		return with( graph, GraphSemantic.LOAD );
 	}

--- a/hibernate-core/src/main/java/org/hibernate/graph/Graph.java
+++ b/hibernate-core/src/main/java/org/hibernate/graph/Graph.java
@@ -22,7 +22,6 @@ import org.hibernate.metamodel.model.domain.PersistentAttribute;
  * @author Steve Ebersole
  * @author Andrea Boriero
  */
-@SuppressWarnings({"unused", "UnusedReturnValue"})
 public interface Graph<J> extends GraphNode<J> {
 
 	/**

--- a/hibernate-core/src/main/java/org/hibernate/graph/Graph.java
+++ b/hibernate-core/src/main/java/org/hibernate/graph/Graph.java
@@ -8,6 +8,7 @@ package org.hibernate.graph;
 
 import java.util.List;
 
+import jakarta.persistence.metamodel.PluralAttribute;
 import org.hibernate.metamodel.model.domain.ManagedDomainType;
 import org.hibernate.metamodel.model.domain.PersistentAttribute;
 
@@ -23,6 +24,21 @@ import org.hibernate.metamodel.model.domain.PersistentAttribute;
  */
 @SuppressWarnings({"unused", "UnusedReturnValue"})
 public interface Graph<J> extends GraphNode<J> {
+
+	/**
+	 * Add a subgraph rooted at a plural attribute, allowing
+	 * further nodes to be added to the subgraph.
+	 *
+	 * @apiNote This method is missing in JPA, and nodes cannot be
+	 *          added in a typesafe way to subgraphs representing
+	 *          fetched collections
+	 *
+	 * @since 6.3
+	 */
+	default <AJ> SubGraph<AJ> addPluralSubgraph(PluralAttribute<? extends J, ?, AJ> attribute) {
+		return addSubGraph( attribute.getName() );
+	}
+
 	/**
 	 * Graphs apply only to {@link jakarta.persistence.metamodel.ManagedType}s.
 	 *
@@ -110,7 +126,6 @@ public interface Graph<J> extends GraphNode<J> {
 	<AJ> SubGraph<AJ> addSubGraph(PersistentAttribute<? extends J, AJ> attribute) throws CannotContainSubGraphException;
 
 	<AJ> SubGraph<? extends AJ> addSubGraph(PersistentAttribute<? extends J, AJ> attribute, Class<? extends AJ> type) throws CannotContainSubGraphException;
-
 
 	// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 	// key sub graph nodes

--- a/hibernate-core/src/main/java/org/hibernate/loader/internal/SimpleNaturalIdLoadAccessImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/loader/internal/SimpleNaturalIdLoadAccessImpl.java
@@ -14,7 +14,6 @@ import java.util.Optional;
 import org.hibernate.HibernateException;
 import org.hibernate.LockOptions;
 import org.hibernate.SimpleNaturalIdLoadAccess;
-import org.hibernate.engine.spi.SessionImplementor;
 import org.hibernate.loader.LoaderLogging;
 import org.hibernate.metamodel.mapping.EntityMappingType;
 import org.hibernate.metamodel.mapping.internal.SimpleNaturalIdMapping;


### PR DESCRIPTION
1. make fetch/load graph distinction clearer in the `XxxxLoadAccess` APIs
2. `addPluralSubgraph()`, which is missing in JPA