### PR TITLE
trim array holding batch of ids before passing to JDBC

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/engine/spi/BatchFetchQueue.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/spi/BatchFetchQueue.java
@@ -368,14 +368,15 @@ public class BatchFetchQueue {
 			return;
 		}
 
-		int i = 1;
-		int end = -1;
-		boolean checkForEnd = false;
-
-		final LinkedHashMap<CollectionEntry, PersistentCollection<?>> map = batchLoadableCollections.get( pluralAttributeMapping.getNavigableRole().getFullPath() );
+		final LinkedHashMap<CollectionEntry, PersistentCollection<?>> map =
+				batchLoadableCollections.get( pluralAttributeMapping.getNavigableRole().getFullPath() );
 		if ( map == null ) {
 			return;
 		}
+
+		int i = 1;
+		int end = -1;
+		boolean checkForEnd = false;
 
 		for ( Entry<CollectionEntry, PersistentCollection<?>> me : map.entrySet() ) {
 			final CollectionEntry ce = me.getKey();


### PR DESCRIPTION
Before this, the array length was the batch size, and was padded with nulls, which isn't great if you have a large batch size, I suppose.

cc @sebersole WDYT, Steve?