### PR TITLE
HHH-16650 fix for native queries with "unknown" numeric types on Oracle

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/dialect/OracleDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/OracleDialect.java
@@ -647,6 +647,10 @@ public class OracleDialect extends Dialect {
 			case REAL:
 				// Oracle's 'real' type is actually double precision
 				return "float(24)";
+			case DOUBLE:
+				// Oracle's 'double precision' means float(126), and
+				// we never need 126 bits (38 decimal digits)
+				return "float(53)";
 
 			case NUMERIC:
 			case DECIMAL:
@@ -745,12 +749,20 @@ public class OracleDialect extends Dialect {
 				}
 				break;
 			case NUMERIC:
-				if ( scale == -127 ) {
-					// For some reason, the Oracle JDBC driver reports FLOAT
-					// as NUMERIC with scale -127
-					return precision <= getFloatPrecision()
-							? jdbcTypeRegistry.getDescriptor( FLOAT )
-							: jdbcTypeRegistry.getDescriptor( DOUBLE );
+				if ( precision > 8 // precision of 0 means something funny
+						// For some reason, the Oracle JDBC driver reports
+						// FLOAT or DOUBLE as NUMERIC with scale -127
+						// (but note that expressions with unknown type
+						//  also get reported this way, so take care)
+						&& scale == -127 ) {
+					if ( precision <= 24 ) {
+						// Can be represented as a Java float
+						return jdbcTypeRegistry.getDescriptor( FLOAT );
+					}
+					else if ( precision <= 53 ) {
+						// Can be represented as a Java double
+						return jdbcTypeRegistry.getDescriptor( DOUBLE );
+					}
 				}
 				//intentional fall-through:
 			case DECIMAL:

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/query/OracleNumericTypesTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/query/OracleNumericTypesTest.java
@@ -1,0 +1,29 @@
+package org.hibernate.orm.test.query;
+
+import org.hibernate.dialect.OracleDialect;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.JiraKey;
+import org.hibernate.testing.orm.junit.RequiresDialect;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+
+@SessionFactory
+@DomainModel
+@RequiresDialect(OracleDialect.class)
+@JiraKey("HHH-16650")
+public class OracleNumericTypesTest {
+	@Test void test(SessionFactoryScope scope) {
+		String sql = "SELECT 012345678901234567890123456789, cast(1234567890123.456 as number(30,5)), cast(1234567890123.456 as double precision), cast(1234567890123.456 as float(32)), cast(1234567890123.456 as float(24)) from dual";
+		Object[] values = scope.fromSession( s -> s.createNativeQuery(sql, Object[].class).getSingleResult());
+		assertInstanceOf(BigDecimal.class, values[0]);
+		assertInstanceOf(BigDecimal.class, values[1]);
+		assertInstanceOf(BigDecimal.class, values[2]);
+		assertInstanceOf(Double.class, values[3]);
+		assertInstanceOf(Float.class, values[4]);
+	}
+}


### PR DESCRIPTION
Oracle reports `FLOAT`/`DOUBLE PRECISION` as `NUMBER`, which is wrong. The workaround was to look at the scale, which it reports as -127 for `FLOAT`. But certain other expression also get scale -127, and this could cause truncation of least-significant digits in conversion of a huge `NUMBER` to `Double`.