### PR TITLE
HHH-16649 - This commit effectively reverts d8bf6499 (HHH-15910)

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/Hibernate.java
+++ b/hibernate-core/src/main/java/org/hibernate/Hibernate.java
@@ -234,57 +234,6 @@ public final class Hibernate {
 	}
 
 	/**
-	 * Remove the value associated with the given key by the given persistent
-	 * map, without fetching the state of the map from the database.
-	 *
-	 * @param map a persistent map associated with an open session
-	 * @param key a key belonging to the map
-	 * @return the previous value associated by the map with the given key, or null if there was no value associated
-	 * with the given key
-	 *
-	 * @since 6.2.0
-	 */
-	public static <K, V> V remove(Map<? super K, V> map, K key) {
-		return ( map instanceof PersistentMap )
-				? ( (PersistentMap<K, V>) map ).queuedRemove( key )
-				: map.remove( key );
-	}
-
-	/**
-	 * Remove the specified element of the given persistent set,
-	 * without fetching the state of the set from the database.
-	 *
-	 * @param set a persistent set associated with an open session
-	 * @param element an element belonging to the set
-	 * @return true if this set contained the specified element
-	 *
-	 * @since 6.2.0
-	 */
-	public static <T> boolean remove(Set<T> set, T element) {
-		return ( set instanceof PersistentSet )
-				? ( (PersistentSet<T>) set ).queuedRemove( element )
-				: set.remove( element );
-	}
-
-	/**
-	 * Remove the specified element of the given persistent list,
-	 * without fetching the state of the list from the database.
-	 *
-	 * @param list a persistent list associated with an open session
-	 * @param element an element belonging to the list
-	 * @return true if this list contained the specified element
-	 *
-	 * @since 6.2.0
-	 */
-	public static <T> boolean remove(List<T> list, T element) {
-		return ( list instanceof PersistentList )
-				? ( (PersistentList<T>) list ).queuedRemove( element )
-				: ( list instanceof PersistentBag )
-					? ( (PersistentBag<T>) list ).queuedRemove( element )
-					: list.remove( element );
-	}
-
-	/**
 	 * Get the true, underlying class of a proxied entity. This operation will
 	 * initialize a proxy by side effect.
 	 *

--- a/hibernate-core/src/main/java/org/hibernate/annotations/LazyCollection.java
+++ b/hibernate-core/src/main/java/org/hibernate/annotations/LazyCollection.java
@@ -31,9 +31,8 @@ import java.util.Map;
  *     instead of {@code LazyCollection(FALSE)}.
  * <li>Use static methods of {@link org.hibernate.Hibernate},
  *     for example {@link org.hibernate.Hibernate#size(Collection)},
- *     {@link org.hibernate.Hibernate#contains(Collection, Object)},
- *     {@link org.hibernate.Hibernate#get(Map, Object)}, or
- *     {@link org.hibernate.Hibernate#remove(Map, Object)} instead
+ *     {@link org.hibernate.Hibernate#contains(Collection, Object)}, or
+ *     {@link org.hibernate.Hibernate#get(Map, Object)} instead
  *     of {@code LazyCollection(EXTRA)}.
  * </ul>
  */

--- a/hibernate-core/src/main/java/org/hibernate/annotations/LazyCollectionOption.java
+++ b/hibernate-core/src/main/java/org/hibernate/annotations/LazyCollectionOption.java
@@ -25,9 +25,8 @@ import java.util.Map;
  *     instead of {@code LazyCollection(FALSE)}.
  * <li>Use static methods of {@link org.hibernate.Hibernate},
  *     for example {@link org.hibernate.Hibernate#size(Collection)},
- *     {@link org.hibernate.Hibernate#contains(Collection, Object)},
- *     {@link org.hibernate.Hibernate#get(Map, Object)}, or
- *     {@link org.hibernate.Hibernate#remove(Map, Object)} instead
+ *     {@link org.hibernate.Hibernate#contains(Collection, Object)}, or
+ *     {@link org.hibernate.Hibernate#get(Map, Object)} instead
  *     of {@code LazyCollection(EXTRA)}.
  * </ul>
  */

--- a/hibernate-core/src/main/java/org/hibernate/collection/spi/AbstractPersistentCollection.java
+++ b/hibernate-core/src/main/java/org/hibernate/collection/spi/AbstractPersistentCollection.java
@@ -620,7 +620,7 @@ public abstract class AbstractPersistentCollection<E> implements Serializable, P
 		);
 	}
 
-	void throwLazyInitializationExceptionIfNotConnected() {
+	private void throwLazyInitializationExceptionIfNotConnected() {
 		if ( !isConnectedToSession() ) {
 			throwLazyInitializationException( "no session or session was closed" );
 		}
@@ -629,7 +629,7 @@ public abstract class AbstractPersistentCollection<E> implements Serializable, P
 		}
 	}
 
-	void throwLazyInitializationException(String message) {
+	private void throwLazyInitializationException(String message) {
 		throw new LazyInitializationException(
 				"failed to lazily initialize a collection" +
 						(role == null ? "" : " of role: " + role) +

--- a/hibernate-core/src/main/java/org/hibernate/collection/spi/PersistentBag.java
+++ b/hibernate-core/src/main/java/org/hibernate/collection/spi/PersistentBag.java
@@ -409,27 +409,6 @@ public class PersistentBag<E> extends AbstractPersistentCollection<E> implements
 		}
 	}
 
-	@Internal
-	public boolean queuedRemove(Object element) {
-		final CollectionEntry entry = getSession().getPersistenceContextInternal().getCollectionEntry( PersistentBag.this );
-		if ( entry == null ) {
-			throwLazyInitializationExceptionIfNotConnected();
-			throwLazyInitializationException("collection not associated with session");
-		}
-		else {
-			final CollectionPersister persister = entry.getLoadedPersister();
-			if ( hasQueuedOperations() ) {
-				getSession().flush();
-			}
-			if ( persister.elementExists( entry.getLoadedKey(), element, getSession() ) ) {
-				elementRemoved = true;
-				queueOperation( new PersistentBag.SimpleRemove( (E) element ) );
-				return true;
-			}
-		}
-		return false;
-	}
-
 	@Override
 	public boolean containsAll(Collection<?> c) {
 		read();

--- a/hibernate-core/src/main/java/org/hibernate/collection/spi/PersistentList.java
+++ b/hibernate-core/src/main/java/org/hibernate/collection/spi/PersistentList.java
@@ -221,27 +221,6 @@ public class PersistentList<E> extends AbstractPersistentCollection<E> implement
 		}
 	}
 
-	@Internal
-	public boolean queuedRemove(Object element) {
-		final CollectionEntry entry = getSession().getPersistenceContextInternal().getCollectionEntry( PersistentList.this );
-		if ( entry == null ) {
-			throwLazyInitializationExceptionIfNotConnected();
-			throwLazyInitializationException("collection not associated with session");
-		}
-		else {
-			final CollectionPersister persister = entry.getLoadedPersister();
-			if ( hasQueuedOperations() ) {
-				getSession().flush();
-			}
-			if ( persister.elementExists( entry.getLoadedKey(), element, getSession() ) ) {
-				elementRemoved = true;
-				queueOperation( new PersistentList.SimpleRemove( (E) element ) );
-				return true;
-			}
-		}
-		return false;
-	}
-
 	@Override
 	public boolean containsAll(Collection<?> coll) {
 		read();

--- a/hibernate-core/src/main/java/org/hibernate/collection/spi/PersistentMap.java
+++ b/hibernate-core/src/main/java/org/hibernate/collection/spi/PersistentMap.java
@@ -197,28 +197,6 @@ public class PersistentMap<K,E> extends AbstractPersistentCollection<E> implemen
 		return map.remove( key );
 	}
 
-	@Internal
-	public E queuedRemove(Object key) {
-		final CollectionEntry entry = getSession().getPersistenceContextInternal().getCollectionEntry( PersistentMap.this );
-		if ( entry == null ) {
-			throwLazyInitializationExceptionIfNotConnected();
-			throwLazyInitializationException("collection not associated with session");
-		}
-		else {
-			final CollectionPersister persister = entry.getLoadedPersister();
-			if ( hasQueuedOperations() ) {
-				getSession().flush();
-			}
-			Object element = persister.getElementByIndex( entry.getLoadedKey(), key, getSession(), getOwner() );
-			if ( element != null ) {
-				elementRemoved = true;
-				queueOperation( new Remove( (K) key, (E) element ) );
-				return (E) element;
-			}
-		}
-		return null;
-	}
-
 	@Override
 	public void putAll(Map<? extends K,? extends E> puts) {
 		if ( puts.size() > 0 ) {

--- a/hibernate-core/src/main/java/org/hibernate/collection/spi/PersistentSet.java
+++ b/hibernate-core/src/main/java/org/hibernate/collection/spi/PersistentSet.java
@@ -228,27 +228,6 @@ public class PersistentSet<E> extends AbstractPersistentCollection<E> implements
 		}
 	}
 
-	@Internal
-	public boolean queuedRemove(Object element) {
-		final CollectionEntry entry = getSession().getPersistenceContextInternal().getCollectionEntry( PersistentSet.this );
-		if ( entry == null ) {
-			throwLazyInitializationExceptionIfNotConnected();
-			throwLazyInitializationException("collection not associated with session");
-		}
-		else {
-			final CollectionPersister persister = entry.getLoadedPersister();
-			if ( hasQueuedOperations() ) {
-				getSession().flush();
-			}
-			if ( persister.elementExists( entry.getLoadedKey(), element, getSession() ) ) {
-				elementRemoved = true;
-				queueOperation( new SimpleRemove( (E) element ) );
-				return true;
-			}
-		}
-		return false;
-	}
-
 	@Override
 	public boolean containsAll(Collection<?> coll) {
 		read();

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/collection/basic/CollectionSizeTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/collection/basic/CollectionSizeTest.java
@@ -12,9 +12,7 @@ import org.hibernate.testing.orm.junit.SessionFactory;
 import org.hibernate.testing.orm.junit.SessionFactoryScope;
 import org.junit.jupiter.api.Test;
 
-import java.util.ArrayList;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -37,16 +35,12 @@ public class CollectionSizeTest {
 		emailAddresses.add( new EmailAddress( "test1@test.com" ) );
 		emailAddresses.add( new EmailAddress( "test2@test.com" ) );
 		emailAddresses.add( new EmailAddress( "test3@test.com" ) );
-		List<EmailAddress> emailAddresses3 = new ArrayList<>();
-		emailAddresses3.add( new EmailAddress( "test4@test.com" ) );
-		emailAddresses3.add( new EmailAddress( "test5@test.com" ) );
 		User user = new User();
 		user.setName( "john" );
 		Contact contact = new Contact();
 		contact.setName( "John Doe" );
 		contact.setEmailAddresses( emailAddresses );
 		emailAddresses.forEach( address -> contact.getContactsByEmail().put(address, contact) );
-		contact.setEmailAddresses3( emailAddresses3 );
 
 		scope.inTransaction(
 				session -> {
@@ -70,20 +64,6 @@ public class CollectionSizeTest {
 					assertEquals( cont, Hibernate.get(contactsByEmail, new EmailAddress( "test1@test.com" ) ) );
 					assertNull( Hibernate.get(contactsByEmail, new EmailAddress( "test9@test.com" ) ) );
 					assertFalse( Hibernate.isInitialized(contactsByEmail) );
-
-					Hibernate.remove( contactsByEmail, new EmailAddress( "test1@test.com" ) );
-					assertFalse( Hibernate.isInitialized(contactsByEmail) );
-					assertEquals( cont, Hibernate.get(contactsByEmail, new EmailAddress( "test1@test.com" ) ) );
-					assertEquals( Hibernate.size( contactsByEmail.entrySet() ), 3 );
-
-					Hibernate.remove( addresses, new EmailAddress( "test1@test.com" ) );
-					assertFalse( Hibernate.isInitialized(addresses) );
-					assertEquals( Hibernate.size( addresses ), 3 );
-
-					List<EmailAddress> addresses3 = cont.getEmailAddresses3();
-					Hibernate.remove( addresses3, new EmailAddress( "test4@test.com" ) );
-					assertFalse( Hibernate.isInitialized( addresses3 ) );
-					assertEquals( Hibernate.size(addresses3), 2 );
 				}
 		);
 	}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/collection/basic/Contact.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/collection/basic/Contact.java
@@ -7,10 +7,8 @@
 package org.hibernate.orm.test.collection.basic;
 
 import java.io.Serializable;
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import jakarta.persistence.Basic;
@@ -33,8 +31,6 @@ public class Contact implements Serializable {
     private String name;
     private Set<EmailAddress> emailAddresses = new HashSet<>();
     private Set<EmailAddress> emailAddresses2 = new HashSet<>();
-
-    private List<EmailAddress> emailAddresses3 = new ArrayList<>();
     private Map<EmailAddress,Contact> contactsByEmail = new HashMap<>();
 
     @Id
@@ -54,16 +50,6 @@ public class Contact implements Serializable {
 
     public void setName(String name) {
         this.name = name;
-    }
-
-    @ElementCollection
-    @CollectionTable(name = "user_email_addresses3", joinColumns = @JoinColumn(name = "user_id", referencedColumnName = "id"))
-    public List<EmailAddress> getEmailAddresses3() {
-        return emailAddresses3;
-    }
-
-    public void setEmailAddresses3(List<EmailAddress> emailAddresses3) {
-        this.emailAddresses3 = emailAddresses3;
     }
 
     @ElementCollection


### PR DESCRIPTION
In which static remove methods were added to the Hibernate class

The reason for this is that the methods in fact don't work, since the machinery behind them just isn't there, nor has it even been.
The CollectionSizeTest that was modified to test these new methods was incomplete and hid this fact.