### PR TITLE
mark some ancient hacks as deprecated

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/id/ForeignGenerator.java
+++ b/hibernate-core/src/main/java/org/hibernate/id/ForeignGenerator.java
@@ -35,7 +35,7 @@ import static org.hibernate.spi.NavigablePath.IDENTIFIER_MAPPER_PROPERTY;
  *
  * @deprecated This remains around as an implementation detail of {@code hbm.xml} mappings.
  */
-@Deprecated(since = "6")
+@Deprecated(since = "6", forRemoval = true)
 public class ForeignGenerator implements IdentifierGenerator, StandardGenerator {
 	private static final CoreMessageLogger LOG = messageLogger( ForeignGenerator.class );
 

--- a/hibernate-core/src/main/java/org/hibernate/id/IdentifierGeneratorHelper.java
+++ b/hibernate-core/src/main/java/org/hibernate/id/IdentifierGeneratorHelper.java
@@ -7,6 +7,7 @@
 package org.hibernate.id;
 
 import org.hibernate.HibernateException;
+import org.hibernate.Internal;
 import org.hibernate.dialect.Dialect;
 import org.hibernate.internal.CoreLogging;
 import org.hibernate.internal.CoreMessageLogger;
@@ -32,15 +33,19 @@ import java.util.Objects;
  * @author Gavin King
  * @author Steve Ebersole
  */
+@Internal
 public final class IdentifierGeneratorHelper {
 	private static final CoreMessageLogger LOG = CoreLogging.messageLogger( IdentifierGeneratorHelper.class );
 
 	/**
 	 * Marker object returned from {@link IdentifierGenerator#generate} to indicate that we should
-	 * short-circuit any continued generated id checking.  Currently, this is only used in the case of the
+	 * short-circuit any continued generated id checking. Currently, this is only used in the case of the
 	 * {@linkplain ForeignGenerator foreign} generator as a way to signal that we should use the associated
 	 * entity's id value.
+	 *
+	 * @deprecated This is not an elegant way to do anything
 	 */
+	@Deprecated(forRemoval = true)
 	public static final Serializable SHORT_CIRCUIT_INDICATOR = new Serializable() {
 		@Override
 		public String toString() {
@@ -51,7 +56,10 @@ public final class IdentifierGeneratorHelper {
 	/**
 	 * Marker object returned from {@link IdentifierGenerator#generate} to indicate that the entity's
 	 * identifier will be generated as part of the database insertion.
+	 *
+	 * @deprecated Use a {@link org.hibernate.generator.OnExecutionGenerator}
 	 */
+	@Deprecated(forRemoval = true)
 	public static final Serializable POST_INSERT_INDICATOR = new Serializable() {
 		@Override
 		public String toString() {
@@ -176,6 +184,7 @@ public final class IdentifierGeneratorHelper {
 		throw new IdentifierGenerationException( "Unknown IntegralDataTypeHolder impl [" + holder + "]" );
 	}
 
+	@Internal
 	public static class BasicHolder implements IntegralDataTypeHolder {
 		private final Class<?> exactType;
 		private long value = Long.MIN_VALUE;

--- a/hibernate-core/src/main/java/org/hibernate/mapping/Component.java
+++ b/hibernate-core/src/main/java/org/hibernate/mapping/Component.java
@@ -16,7 +16,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 import org.hibernate.Internal;
 import org.hibernate.MappingException;
@@ -32,6 +31,7 @@ import org.hibernate.dialect.Dialect;
 import org.hibernate.engine.spi.Mapping;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.id.CompositeNestedGeneratedValueGenerator;
+import org.hibernate.id.IdentifierGenerationException;
 import org.hibernate.id.IdentifierGenerator;
 import org.hibernate.id.factory.IdentifierGeneratorFactory;
 import org.hibernate.internal.util.ReflectHelper;
@@ -48,7 +48,6 @@ import org.hibernate.type.EmbeddedComponentType;
 
 import static java.util.stream.Collectors.toList;
 import static org.hibernate.generator.EventType.INSERT;
-import static org.hibernate.id.IdentifierGeneratorHelper.POST_INSERT_INDICATOR;
 
 /**
  * A mapping model object that represents an {@linkplain jakarta.persistence.Embeddable embeddable class}.
@@ -659,11 +658,12 @@ public class Component extends SimpleValue implements MetaAttributable, Sortable
 		@Override
 		public void execute(SharedSessionContractImplementor session, Object incomingObject, Object injectionContext) {
 			if ( !subgenerator.generatedOnExecution() ) {
-				Object generatedId = ( (BeforeExecutionGenerator) subgenerator).generate( session, incomingObject, null, INSERT );
+				final Object generatedId = ( (BeforeExecutionGenerator) subgenerator)
+						.generate( session, incomingObject, null, INSERT );
 				injector.set( injectionContext, generatedId );
 			}
 			else {
-				injector.set( injectionContext, POST_INSERT_INDICATOR );
+				throw new IdentifierGenerationException( "Identity generation isn't supported for composite ids" );
 			}
 		}
 

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/RowVersionJavaType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/RowVersionJavaType.java
@@ -24,7 +24,10 @@ import org.hibernate.type.descriptor.WrapperOptions;
  *
  * @author Steve Ebersole
  * @author Gail Badner
+ *
+ * @deprecated No longer used
  */
+@Deprecated(since = "6")
 public class RowVersionJavaType extends AbstractClassJavaType<byte[]>
 		implements VersionJavaType<byte[]> {
 	public static final RowVersionJavaType INSTANCE = new RowVersionJavaType();


### PR DESCRIPTION
because apparently some users depend on them: https://hibernate.atlassian.net/browse/HHH-16692

Also mark `IdentifierGeneratorHelper` as `@Internal`.