### PR TITLE
HHH-16606 - Class cast exception when retrieving only single property of array type using criteria query

### DIFF
--- a/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/criteria/SelectOnlyArrayPropertyTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/criteria/SelectOnlyArrayPropertyTest.java
@@ -1,0 +1,115 @@
+package org.hibernate.orm.test.jpa.criteria;
+
+import org.hibernate.orm.test.jpa.BaseEntityManagerFunctionalTestCase;
+
+import org.hibernate.testing.orm.junit.JiraKey;
+import org.junit.Test;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.TypedQuery;
+import jakarta.persistence.criteria.CriteriaBuilder;
+import jakarta.persistence.criteria.CriteriaQuery;
+import jakarta.persistence.criteria.Root;
+
+import static org.hibernate.testing.transaction.TransactionUtil.doInJPA;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@JiraKey("HHH-16606")
+public class SelectOnlyArrayPropertyTest extends BaseEntityManagerFunctionalTestCase {
+
+
+	@Override
+	protected Class[] getAnnotatedClasses() {
+		return new Class[] {
+				EntityWithIdAndIntegerArray.class
+		};
+	}
+
+	@Test
+	@JiraKey("HHH-16606")
+	public void criteriaSelectOnlyIntArray() {
+		doInJPA( this::entityManagerFactory, entityManager -> {
+			int[] result = new int[4];
+
+			EntityWithIdAndIntegerArray myEntity = new EntityWithIdAndIntegerArray( 1, result );
+			entityManager.persist( myEntity );
+
+			CriteriaBuilder cb = entityManager.getCriteriaBuilder();
+			CriteriaQuery<int[]> cq = cb.createQuery( int[].class );
+
+			Root<EntityWithIdAndIntegerArray> root = cq.from( EntityWithIdAndIntegerArray.class );
+
+			cq.select( root.get( "ints" ) )
+					.where( cb.equal( root.get( "id" ), 1 ) );
+
+			TypedQuery<int[]> q = entityManager.createQuery( cq );
+
+			int[] bytes = q.getSingleResult();
+
+			assertArrayEquals( result, bytes );
+		} );
+	}
+
+	@Test
+	public void criteriaSelectWrappedIntArray() {
+		doInJPA( this::entityManagerFactory, entityManager -> {
+			int[] result = new int[4];
+			result[0] = 1;
+
+			EntityWithIdAndIntegerArray myEntity = new EntityWithIdAndIntegerArray( 2, result );
+			entityManager.persist( myEntity );
+
+			CriteriaBuilder cb = entityManager.getCriteriaBuilder();
+			CriteriaQuery<Object[]> cq = cb.createQuery( Object[].class );
+
+			Root<EntityWithIdAndIntegerArray> root = cq.from( EntityWithIdAndIntegerArray.class );
+
+			cq.select( root.get( "ints" ) )
+					.where( cb.equal( root.get( "id" ), 2 ) );
+
+			TypedQuery<Object[]> q = entityManager.createQuery( cq );
+
+			final Object[] objects = q.getSingleResult();
+			assertEquals( 1, objects.length );
+			int[] bytes = (int[]) objects[0];
+
+			assertArrayEquals( result, bytes );
+		} );
+	}
+
+	@Entity
+	public static class EntityWithIdAndIntegerArray {
+
+		@Id
+		private Integer id;
+
+		private int[] ints;
+
+		public EntityWithIdAndIntegerArray(Integer id, int[] ints) {
+			this.id = id;
+			this.ints = ints;
+		}
+
+		public EntityWithIdAndIntegerArray() {
+
+		}
+
+		public Integer getId() {
+			return id;
+		}
+
+		public void setId(Integer id) {
+			this.id = id;
+		}
+
+		public int[] getInts() {
+			return ints;
+		}
+
+		public void setInts(int[] ints) {
+			this.ints = ints;
+		}
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/criteria/SelectOnlyArrayPropertyTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/criteria/SelectOnlyArrayPropertyTest.java
@@ -31,22 +31,22 @@ public class SelectOnlyArrayPropertyTest extends BaseEntityManagerFunctionalTest
 	@JiraKey("HHH-16606")
 	public void criteriaSelectOnlyIntArray() {
 		doInJPA( this::entityManagerFactory, entityManager -> {
-			int[] result = new int[4];
+			final byte[] result = "Hello, World!".getBytes();
 
 			EntityWithIdAndIntegerArray myEntity = new EntityWithIdAndIntegerArray( 1, result );
 			entityManager.persist( myEntity );
 
 			CriteriaBuilder cb = entityManager.getCriteriaBuilder();
-			CriteriaQuery<int[]> cq = cb.createQuery( int[].class );
+			CriteriaQuery<byte[]> cq = cb.createQuery( byte[].class );
 
 			Root<EntityWithIdAndIntegerArray> root = cq.from( EntityWithIdAndIntegerArray.class );
 
-			cq.select( root.get( "ints" ) )
+			cq.select( root.get( "bytes" ) )
 					.where( cb.equal( root.get( "id" ), 1 ) );
 
-			TypedQuery<int[]> q = entityManager.createQuery( cq );
+			TypedQuery<byte[]> q = entityManager.createQuery( cq );
 
-			int[] bytes = q.getSingleResult();
+			byte[] bytes = q.getSingleResult();
 
 			assertArrayEquals( result, bytes );
 		} );
@@ -55,8 +55,7 @@ public class SelectOnlyArrayPropertyTest extends BaseEntityManagerFunctionalTest
 	@Test
 	public void criteriaSelectWrappedIntArray() {
 		doInJPA( this::entityManagerFactory, entityManager -> {
-			int[] result = new int[4];
-			result[0] = 1;
+			final byte[] result = "Hi there!".getBytes();
 
 			EntityWithIdAndIntegerArray myEntity = new EntityWithIdAndIntegerArray( 2, result );
 			entityManager.persist( myEntity );
@@ -66,14 +65,14 @@ public class SelectOnlyArrayPropertyTest extends BaseEntityManagerFunctionalTest
 
 			Root<EntityWithIdAndIntegerArray> root = cq.from( EntityWithIdAndIntegerArray.class );
 
-			cq.select( root.get( "ints" ) )
+			cq.select( root.get( "bytes" ) )
 					.where( cb.equal( root.get( "id" ), 2 ) );
 
 			TypedQuery<Object[]> q = entityManager.createQuery( cq );
 
 			final Object[] objects = q.getSingleResult();
 			assertEquals( 1, objects.length );
-			int[] bytes = (int[]) objects[0];
+			byte[] bytes = (byte[]) objects[0];
 
 			assertArrayEquals( result, bytes );
 		} );
@@ -85,11 +84,11 @@ public class SelectOnlyArrayPropertyTest extends BaseEntityManagerFunctionalTest
 		@Id
 		private Integer id;
 
-		private int[] ints;
+		private byte[] bytes;
 
-		public EntityWithIdAndIntegerArray(Integer id, int[] ints) {
+		public EntityWithIdAndIntegerArray(Integer id, byte[] bytes) {
 			this.id = id;
-			this.ints = ints;
+			this.bytes = bytes;
 		}
 
 		public EntityWithIdAndIntegerArray() {
@@ -104,12 +103,12 @@ public class SelectOnlyArrayPropertyTest extends BaseEntityManagerFunctionalTest
 			this.id = id;
 		}
 
-		public int[] getInts() {
-			return ints;
+		public byte[] getBytes() {
+			return bytes;
 		}
 
-		public void setInts(int[] ints) {
-			this.ints = ints;
+		public void setBytes(byte[] bytes) {
+			this.bytes = bytes;
 		}
 	}
 }


### PR DESCRIPTION
Jira issue [HHH-16606](https://hibernate.atlassian.net/browse/HHH-16606)

When only single property of array type is selected using criteria query with explictely specified (array) result type, returned result is wrapped into object array. Thi is caused by wrongly determined result transformer as RowTransformerArrayImpl instead of RowTransformerSingularReturnImpl.

[HHH-16606]: https://hibernate.atlassian.net/browse/HHH-16606?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ