### PR TITLE
Migrating `Serializable[] getPropertySpaces()` to `String[] getPropertySpaces()`

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/action/internal/BulkOperationCleanupAction.java
+++ b/hibernate-core/src/main/java/org/hibernate/action/internal/BulkOperationCleanupAction.java
@@ -46,7 +46,7 @@ import org.hibernate.sql.ast.tree.insert.InsertSelectStatement;
  */
 public class BulkOperationCleanupAction implements Executable, Serializable {
 
-	private final Serializable[] affectedTableSpaces;
+	private final String[] affectedTableSpaces;
 
 	private final Set<EntityCleanup> entityCleanups = new HashSet<>();
 	private final Set<CollectionCleanup> collectionCleanups = new HashSet<>();
@@ -211,7 +211,7 @@ public class BulkOperationCleanupAction implements Executable, Serializable {
 	}
 
 	@Override
-	public Serializable[] getPropertySpaces() {
+	public String[] getPropertySpaces() {
 		return affectedTableSpaces;
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/action/internal/CollectionAction.java
+++ b/hibernate-core/src/main/java/org/hibernate/action/internal/CollectionAction.java
@@ -6,8 +6,6 @@
  */
 package org.hibernate.action.internal;
 
-import java.io.Serializable;
-
 import org.hibernate.action.spi.AfterTransactionCompletionProcess;
 import org.hibernate.action.spi.BeforeTransactionCompletionProcess;
 import org.hibernate.cache.CacheException;
@@ -101,7 +99,7 @@ public abstract class CollectionAction implements ComparableExecutable {
 	}
 
 	@Override
-	public Serializable[] getPropertySpaces() {
+	public String[] getPropertySpaces() {
 		return persister.getCollectionSpaces();
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/action/internal/EntityAction.java
+++ b/hibernate-core/src/main/java/org/hibernate/action/internal/EntityAction.java
@@ -6,8 +6,6 @@
  */
 package org.hibernate.action.internal;
 
-import java.io.Serializable;
-
 import org.hibernate.AssertionFailure;
 import org.hibernate.action.spi.AfterTransactionCompletionProcess;
 import org.hibernate.action.spi.BeforeTransactionCompletionProcess;
@@ -136,7 +134,7 @@ public abstract class EntityAction
 	}
 
 	@Override
-	public final Serializable[] getPropertySpaces() {
+	public final String[] getPropertySpaces() {
 		return persister.getPropertySpaces();
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/action/spi/Executable.java
+++ b/hibernate-core/src/main/java/org/hibernate/action/spi/Executable.java
@@ -6,8 +6,6 @@
  */
 package org.hibernate.action.spi;
 
-import java.io.Serializable;
-
 import org.hibernate.HibernateException;
 import org.hibernate.event.spi.EventSource;
 
@@ -27,7 +25,7 @@ public interface Executable {
 	 *
 	 * @return The spaces affected by this action.
 	 */
-	Serializable[] getPropertySpaces();
+	String[] getPropertySpaces();
 
 	/**
 	 * Called before executing any actions.  Gives actions a chance to perform any preparation.

--- a/hibernate-core/src/main/java/org/hibernate/engine/spi/ActionQueue.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/spi/ActionQueue.java
@@ -423,7 +423,7 @@ public class ActionQueue {
 			beforeTransactionProcesses.register( executable.getBeforeTransactionCompletionProcess() );
 		}
 		if ( session.getFactory().getSessionFactoryOptions().isQueryCacheEnabled() ) {
-			invalidateSpaces( (String[]) executable.getPropertySpaces() );
+			invalidateSpaces( executable.getPropertySpaces() );
 		}
 		if ( executable.getAfterTransactionCompletionProcess() != null ) {
 			if ( afterTransactionProcesses == null ) {

--- a/hibernate-core/src/main/java/org/hibernate/persister/collection/CollectionPersister.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/collection/CollectionPersister.java
@@ -6,7 +6,6 @@
  */
 package org.hibernate.persister.collection;
 
-import java.io.Serializable;
 import java.util.Comparator;
 import java.util.Map;
 import java.util.Set;
@@ -255,7 +254,7 @@ public interface CollectionPersister extends Restrictable {
 	/**
 	 * Get the "space" that holds the persistent state
 	 */
-	Serializable[] getCollectionSpaces();
+	String[] getCollectionSpaces();
 
 	/**
 	 * Get the user-visible metadata for the collection (optional operation)

--- a/hibernate-core/src/main/java/org/hibernate/persister/entity/EntityPersister.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/entity/EntityPersister.java
@@ -210,7 +210,7 @@ public interface EntityPersister extends EntityMappingType, RootTableGroupProduc
 	 *
 	 * @return The property spaces.
 	 */
-	Serializable[] getPropertySpaces();
+	String[] getPropertySpaces();
 
 	/**
 	 * Returns an array of objects that identify spaces in which properties of

--- a/hibernate-core/src/main/java/org/hibernate/persister/entity/JoinedSubclassEntityPersister.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/entity/JoinedSubclassEntityPersister.java
@@ -6,7 +6,6 @@
  */
 package org.hibernate.persister.entity;
 
-import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -873,7 +872,7 @@ public class JoinedSubclassEntityPersister extends AbstractEntityPersister {
 	}
 
 	@Override
-	public Serializable[] getPropertySpaces() {
+	public String[] getPropertySpaces() {
 		return spaces; // don't need subclass tables, because they can't appear in conditions
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/persister/entity/SingleTableEntityPersister.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/entity/SingleTableEntityPersister.java
@@ -6,7 +6,6 @@
  */
 package org.hibernate.persister.entity;
 
-import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -502,7 +501,7 @@ public class SingleTableEntityPersister extends AbstractEntityPersister {
 	}
 
 	@Override
-	public Serializable[] getPropertySpaces() {
+	public String[] getPropertySpaces() {
 		return spaces;
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/persister/entity/UnionSubclassEntityPersister.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/entity/UnionSubclassEntityPersister.java
@@ -341,7 +341,7 @@ public class UnionSubclassEntityPersister extends AbstractEntityPersister {
 	}
 
 	@Override
-	public Serializable[] getPropertySpaces() {
+	public String[] getPropertySpaces() {
 		return spaces;
 	}
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/cfg/persister/GoofyPersisterClassProvider.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/cfg/persister/GoofyPersisterClassProvider.java
@@ -250,8 +250,8 @@ public class GoofyPersisterClassProvider implements PersisterClassResolver {
 		}
 
 		@Override
-		public Serializable[] getPropertySpaces() {
-			return new Serializable[0];
+		public String[] getPropertySpaces() {
+			return new String[0];
 		}
 
 		@Override
@@ -924,8 +924,8 @@ public class GoofyPersisterClassProvider implements PersisterClassResolver {
 			return false;  //To change body of implemented methods use File | Settings | File Templates.
 		}
 
-		public Serializable[] getCollectionSpaces() {
-			return new Serializable[0];  //To change body of implemented methods use File | Settings | File Templates.
+		public String[] getCollectionSpaces() {
+			return new String[0];  //To change body of implemented methods use File | Settings | File Templates.
 		}
 
 		public CollectionMetadata getCollectionMetadata() {

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/engine/action/NonSortedExecutableListTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/engine/action/NonSortedExecutableListTest.java
@@ -40,7 +40,7 @@ public class NonSortedExecutableListTest {
 	private static class AnExecutable implements ComparableExecutable {
 
 		private final int n;
-		private final Serializable[] spaces;
+		private final String[] spaces;
 
 		private transient boolean afterDeserializeCalled;
 
@@ -75,7 +75,7 @@ public class NonSortedExecutableListTest {
 		}
 
 		@Override
-		public Serializable[] getPropertySpaces() {
+		public String[] getPropertySpaces() {
 			return spaces;
 		}
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/engine/action/SortedExecutableListTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/engine/action/SortedExecutableListTest.java
@@ -39,7 +39,7 @@ public class SortedExecutableListTest {
 	private static class AnExecutable implements ComparableExecutable {
 
 		private final int n;
-		private Serializable[] spaces;
+		private String[] spaces;
 		private transient boolean afterDeserializeCalled;
 
 		public AnExecutable(int n, String... spaces) {
@@ -73,7 +73,7 @@ public class SortedExecutableListTest {
 		}
 
 		@Override
-		public Serializable[] getPropertySpaces() {
+		public String[] getPropertySpaces() {
 			return spaces;
 		}
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/ejb3configuration/PersisterClassProviderTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/ejb3configuration/PersisterClassProviderTest.java
@@ -277,8 +277,8 @@ public class PersisterClassProviderTest {
 		}
 
 		@Override
-		public Serializable[] getPropertySpaces() {
-			return new Serializable[0];
+		public String[] getPropertySpaces() {
+			return new String[0];
 		}
 
 		@Override

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/legacy/CustomPersister.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/legacy/CustomPersister.java
@@ -594,7 +594,7 @@ public class CustomPersister implements EntityPersister {
 		return "CUSTOMS";
 	}
 
-	public Serializable[] getPropertySpaces() {
+	public String[] getPropertySpaces() {
 		return new String[] { "CUSTOMS" };
 	}
 

--- a/tooling/metamodel-generator/src/main/java/org/hibernate/jpamodelgen/validation/MockCollectionPersister.java
+++ b/tooling/metamodel-generator/src/main/java/org/hibernate/jpamodelgen/validation/MockCollectionPersister.java
@@ -16,8 +16,6 @@ import org.hibernate.type.ListType;
 import org.hibernate.type.MapType;
 import org.hibernate.type.Type;
 
-import java.io.Serializable;
-
 import static org.hibernate.internal.util.StringHelper.root;
 import static org.hibernate.jpamodelgen.validation.MockSessionFactory.typeConfiguration;
 
@@ -146,8 +144,8 @@ public abstract class MockCollectionPersister implements QueryableCollection {
 	}
 
 	@Override
-	public Serializable[] getCollectionSpaces() {
-		return new Serializable[] {role};
+	public String[] getCollectionSpaces() {
+		return new String[] {role};
 	}
 
 	@Override

--- a/tooling/metamodel-generator/src/main/java/org/hibernate/jpamodelgen/validation/MockEntityPersister.java
+++ b/tooling/metamodel-generator/src/main/java/org/hibernate/jpamodelgen/validation/MockEntityPersister.java
@@ -173,8 +173,8 @@ public abstract class MockEntityPersister implements EntityPersister, Queryable,
 	}
 
 	@Override
-	public Serializable[] getPropertySpaces() {
-		return new Serializable[] {entityName};
+	public String[] getPropertySpaces() {
+		return new String[] {entityName};
 	}
 
 	@Override


### PR DESCRIPTION
Migrating `Serializable[] getPropertySpaces()` to `String[] getPropertySpaces()` : we seem to require these to be String[] and need to occasionally do some casting; might as well make it explicit?

Please let me know if this is considered an SPI breaking change, I could do it with a deprecation cycle and choosing a new methodname... I hope that's unnecessary in this case.