### PR TITLE
Remove inefficient method to avoid misuse: getJdbcMappings()

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/dialect/temptable/TemporaryTable.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/temptable/TemporaryTable.java
@@ -33,6 +33,7 @@ import org.hibernate.mapping.Property;
 import org.hibernate.mapping.Selectable;
 import org.hibernate.mapping.SimpleValue;
 import org.hibernate.metamodel.mapping.EntityDiscriminatorMapping;
+import org.hibernate.metamodel.mapping.EntityIdentifierMapping;
 import org.hibernate.metamodel.mapping.EntityMappingType;
 import org.hibernate.metamodel.mapping.ForeignKeyDescriptor;
 import org.hibernate.metamodel.mapping.JdbcMapping;
@@ -180,11 +181,10 @@ public class TemporaryTable implements Exportable, Contributable {
 					final PersistentClass entityBinding = runtimeModelCreationContext.getBootModel()
 							.getEntityBinding( entityDescriptor.getEntityName() );
 
-					final Iterator<JdbcMapping> jdbcMappings = entityDescriptor.getIdentifierMapping()
-							.getJdbcMappings()
-							.iterator();
+					final EntityIdentifierMapping identifierMapping = entityDescriptor.getIdentifierMapping();
+					int idIdx = 0;
 					for ( Column column : entityBinding.getKey().getColumns() ) {
-						final JdbcMapping jdbcMapping = jdbcMappings.next();
+						final JdbcMapping jdbcMapping = identifierMapping.getJdbcMapping( idIdx++ );
 						columns.add(
 								new TemporaryTableColumn(
 										temporaryTable,
@@ -315,11 +315,10 @@ public class TemporaryTable implements Exportable, Contributable {
 					final boolean hasOptimizer;
 					if ( identityColumn ) {
 						hasOptimizer = false;
-						final Iterator<JdbcMapping> jdbcMappings = entityDescriptor.getIdentifierMapping()
-								.getJdbcMappings()
-								.iterator();
+						final EntityIdentifierMapping identifierMapping = entityDescriptor.getIdentifierMapping();
+						int idIdx = 0;
 						for ( Column column : entityBinding.getKey().getColumns() ) {
-							final JdbcMapping jdbcMapping = jdbcMappings.next();
+							final JdbcMapping jdbcMapping = identifierMapping.getJdbcMapping( idIdx++ );
 							columns.add(
 									new TemporaryTableColumn(
 											temporaryTable,
@@ -349,11 +348,10 @@ public class TemporaryTable implements Exportable, Contributable {
 							hasOptimizer = false;
 						}
 					}
-					final Iterator<JdbcMapping> jdbcMappings = entityDescriptor.getIdentifierMapping()
-							.getJdbcMappings()
-							.iterator();
+					final EntityIdentifierMapping identifierMapping = entityDescriptor.getIdentifierMapping();
+					int idIdx = 0;
 					for ( Column column : entityBinding.getKey().getColumns() ) {
-						final JdbcMapping jdbcMapping = jdbcMappings.next();
+						final JdbcMapping jdbcMapping = identifierMapping.getJdbcMapping( idIdx++ );
 						columns.add(
 								new TemporaryTableColumn(
 										temporaryTable,

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/BasicValuedMapping.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/BasicValuedMapping.java
@@ -6,14 +6,8 @@
  */
 package org.hibernate.metamodel.mapping;
 
-import java.io.Serializable;
-import java.util.Collections;
-import java.util.List;
-
 import org.hibernate.cache.MutableCacheKeyBuilder;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
-import org.hibernate.type.descriptor.converter.spi.BasicValueConverter;
-import org.hibernate.type.descriptor.java.JavaType;
 
 import static org.hibernate.engine.internal.CacheHelper.addBasicValueToCacheKey;
 
@@ -27,14 +21,10 @@ import static org.hibernate.engine.internal.CacheHelper.addBasicValueToCacheKey;
  * @author Steve Ebersole
  */
 public interface BasicValuedMapping extends ValueMapping, SqlExpressible {
+
 	@Override
 	default int getJdbcTypeCount() {
 		return 1;
-	}
-
-	@Override
-	default List<JdbcMapping> getJdbcMappings() {
-		return Collections.singletonList( getJdbcMapping() );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/BasicValuedModelPart.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/BasicValuedModelPart.java
@@ -31,11 +31,6 @@ public interface BasicValuedModelPart extends BasicValuedMapping, ValuedModelPar
 	}
 
 	@Override
-	default List<JdbcMapping> getJdbcMappings() {
-		return BasicValuedMapping.super.getJdbcMappings();
-	}
-
-	@Override
 	default JdbcMapping getJdbcMapping(int index) {
 		return BasicValuedMapping.super.getJdbcMapping( index );
 	}

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/Bindable.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/Bindable.java
@@ -32,16 +32,6 @@ public interface Bindable extends JdbcMappingContainer {
 	}
 
 	/**
-	 * The list of JDBC mappings
-	 */
-	@Override
-	default List<JdbcMapping> getJdbcMappings() {
-		final List<JdbcMapping> results = new ArrayList<>();
-		forEachJdbcType( (index, jdbcMapping) -> results.add( jdbcMapping ) );
-		return results;
-	}
-
-	/**
 	 * Visit each of JdbcMapping
 	 *
 	 * @apiNote Same as {@link #forEachJdbcType(int, IndexedConsumer)} starting from `0`

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/EmbeddableMappingType.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/EmbeddableMappingType.java
@@ -218,9 +218,6 @@ public interface EmbeddableMappingType extends ManagedMappingType, SelectableMap
 	int getJdbcTypeCount();
 
 	@Override
-	List<JdbcMapping> getJdbcMappings();
-
-	@Override
 	int forEachJdbcType(int offset, IndexedConsumer<JdbcMapping> action);
 
 	// Make this abstract again to ensure subclasses implement this method

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/EmbeddableValuedModelPart.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/EmbeddableValuedModelPart.java
@@ -64,11 +64,6 @@ public interface EmbeddableValuedModelPart extends ValuedModelPart, Fetchable, F
 	}
 
 	@Override
-	default List<JdbcMapping> getJdbcMappings() {
-		return getEmbeddableTypeDescriptor().getJdbcMappings();
-	}
-
-	@Override
 	default JdbcMapping getJdbcMapping(int index) {
 		return getEmbeddableTypeDescriptor().getJdbcMapping( index );
 	}

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/JdbcMapping.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/JdbcMapping.java
@@ -6,9 +6,6 @@
  */
 package org.hibernate.metamodel.mapping;
 
-import java.util.Collections;
-import java.util.List;
-
 import org.hibernate.Incubating;
 import org.hibernate.internal.util.IndexedConsumer;
 import org.hibernate.type.descriptor.converter.spi.BasicValueConverter;
@@ -129,11 +126,6 @@ public interface JdbcMapping extends MappingType, JdbcMappingContainer {
 	@Override
 	default int getJdbcTypeCount() {
 		return 1;
-	}
-
-	@Override
-	default List<JdbcMapping> getJdbcMappings() {
-		return Collections.singletonList( this );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/JdbcMappingContainer.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/JdbcMappingContainer.java
@@ -6,9 +6,6 @@
  */
 package org.hibernate.metamodel.mapping;
 
-import java.util.ArrayList;
-import java.util.List;
-
 import org.hibernate.internal.util.IndexedConsumer;
 
 /**
@@ -19,26 +16,15 @@ public interface JdbcMappingContainer {
 	 * The number of JDBC mappings
 	 */
 	default int getJdbcTypeCount() {
-		return forEachJdbcType( (index, jdbcMapping) -> {} );
+		return forEachJdbcType( (index, jdbcMapping) -> {
+		} );
 	}
 
-	/**
-	 * The list of JDBC mappings
-	 */
-	default List<JdbcMapping> getJdbcMappings() {
-		final List<JdbcMapping> results = new ArrayList<>();
-		forEachJdbcType( (index, jdbcMapping) -> results.add( jdbcMapping ) );
-		return results;
-	}
-
-	default JdbcMapping getJdbcMapping(int index) {
-		return getJdbcMappings().get( index );
-	}
+	JdbcMapping getJdbcMapping(int index);
 
 	default JdbcMapping getSingleJdbcMapping() {
-		final List<JdbcMapping> jdbcMappings = getJdbcMappings();
-		assert jdbcMappings.size() == 1;
-		return jdbcMappings.get( 0 );
+		assert getJdbcTypeCount() == 1;
+		return getJdbcMapping( 0 );
 	}
 
 	/**

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/SelectableMappings.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/SelectableMappings.java
@@ -45,14 +45,4 @@ public interface SelectableMappings {
 		return forEachSelectable( 0, consumer );
 	}
 
-	/**
-	 * Obtain the JdbcMappings for the underlying selectable mappings
-	 *
-	 * @see SelectableMapping#getJdbcMapping()
-	 */
-	default List<JdbcMapping> getJdbcMappings() {
-		final List<JdbcMapping> results = new ArrayList<>();
-		forEachSelectable( (index, selection) -> results.add( selection.getJdbcMapping() ) );
-		return results;
-	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/SqlExpressible.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/SqlExpressible.java
@@ -18,4 +18,11 @@ public interface SqlExpressible extends JdbcMappingContainer {
 	 * would be of basic type.
 	 */
 	JdbcMapping getJdbcMapping();
+
+	@Override
+	default JdbcMapping getJdbcMapping(int index) {
+		assert index == 0;
+		return getJdbcMapping();
+	}
+
 }

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/ValuedModelPart.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/ValuedModelPart.java
@@ -28,16 +28,6 @@ public interface ValuedModelPart extends ModelPart, ValueMapping, SelectableMapp
 	}
 
 	@Override
-	default List<JdbcMapping> getJdbcMappings() {
-		return ModelPart.super.getJdbcMappings();
-	}
-
-	@Override
-	default JdbcMapping getJdbcMapping(int index) {
-		return ModelPart.super.getJdbcMapping( index );
-	}
-
-	@Override
 	default JdbcMapping getSingleJdbcMapping() {
 		return ModelPart.super.getSingleJdbcMapping();
 	}

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/AbstractEmbeddableMapping.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/AbstractEmbeddableMapping.java
@@ -537,11 +537,6 @@ public abstract class AbstractEmbeddableMapping implements EmbeddableMappingType
 	}
 
 	@Override
-	public List<JdbcMapping> getJdbcMappings() {
-		return getSelectableMappings().getJdbcMappings();
-	}
-
-	@Override
 	public JdbcMapping getJdbcMapping(int index) {
 		return getSelectable( index ).getJdbcMapping();
 	}

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/AnyKeyPart.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/AnyKeyPart.java
@@ -6,8 +6,6 @@
  */
 package org.hibernate.metamodel.mapping.internal;
 
-import java.util.Collections;
-import java.util.List;
 import java.util.function.BiConsumer;
 
 import org.hibernate.engine.FetchStyle;
@@ -286,11 +284,6 @@ public class AnyKeyPart implements BasicValuedModelPart, FetchOptions {
 			SharedSessionContractImplementor session) {
 		valuesConsumer.consume( offset, x, y, value, jdbcMapping );
 		return getJdbcTypeCount();
-	}
-
-	@Override
-	public List<JdbcMapping> getJdbcMappings() {
-		return Collections.singletonList( jdbcMapping );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/BasicValuedCollectionPart.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/BasicValuedCollectionPart.java
@@ -282,11 +282,6 @@ public class BasicValuedCollectionPart
 	}
 
 	@Override
-	public List<JdbcMapping> getJdbcMappings() {
-		return Collections.singletonList( getJdbcMapping() );
-	}
-
-	@Override
 	public JdbcMapping getJdbcMapping(int index) {
 		if ( index != 0 ) {
 			throw new IndexOutOfBoundsException( index );

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/CompoundNaturalIdMapping.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/CompoundNaturalIdMapping.java
@@ -377,11 +377,6 @@ public class CompoundNaturalIdMapping extends AbstractNaturalIdMapping implement
 	}
 
 	@Override
-	public List<JdbcMapping> getJdbcMappings() {
-		return jdbcMappings;
-	}
-
-	@Override
 	public JdbcMapping getJdbcMapping(int index) {
 		return jdbcMappings.get( index );
 	}

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/DiscriminatedAssociationAttributeMapping.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/DiscriminatedAssociationAttributeMapping.java
@@ -210,6 +210,16 @@ public class DiscriminatedAssociationAttributeMapping
 	}
 
 	@Override
+	public JdbcMapping getJdbcMapping(final int index) {
+		switch (index) {
+			case 0 : return discriminatorMapping.getDiscriminatorPart().getJdbcMapping();
+			case 1 : return discriminatorMapping.getKeyPart().getJdbcMapping();
+			default:
+				throw new IndexOutOfBoundsException( index );
+		}
+	}
+
+	@Override
 	public SelectableMapping getSelectable(int columnIndex) {
 		if ( columnIndex == 0 ) {
 			return getDiscriminatorPart();

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/DiscriminatedCollectionPart.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/DiscriminatedCollectionPart.java
@@ -262,6 +262,17 @@ public class DiscriminatedCollectionPart implements DiscriminatedAssociationMode
 	}
 
 	@Override
+	public JdbcMapping getJdbcMapping(final int index) {
+		final int base = getDiscriminatorPart().getJdbcTypeCount();
+		if ( index >= base ) {
+			return getKeyPart().getJdbcMapping( index - base );
+		}
+		else {
+			return getDiscriminatorPart().getJdbcMapping( index );
+		}
+	}
+
+	@Override
 	public SelectableMapping getSelectable(int columnIndex) {
 		return getDiscriminatorPart().getSelectable( columnIndex );
 	}

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/EmbeddedForeignKeyDescriptor.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/EmbeddedForeignKeyDescriptor.java
@@ -636,6 +636,11 @@ public class EmbeddedForeignKeyDescriptor implements ForeignKeyDescriptor {
 	}
 
 	@Override
+	public JdbcMapping getJdbcMapping(final int index) {
+		return targetSide.getModelPart().getJdbcMapping( index );
+	}
+
+	@Override
 	public int forEachJdbcType(int offset, IndexedConsumer<JdbcMapping> action) {
 		return targetSide.getModelPart().forEachJdbcType( offset, action );
 	}

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/EntityRowIdMappingImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/EntityRowIdMappingImpl.java
@@ -114,10 +114,17 @@ public class EntityRowIdMappingImpl implements EntityRowIdMapping {
 	}
 
 	@Override
-	public JdbcMapping getSingleJdbcMapping() {
+	public JdbcMapping getJdbcMapping(int index) {
+		if ( index != 0 ) {
+			throw new IndexOutOfBoundsException( index );
+		}
 		return getJdbcMapping();
 	}
 
+	@Override
+	public JdbcMapping getSingleJdbcMapping() {
+		return getJdbcMapping();
+	}
 
 	@Override
 	public Object disassemble(Object value, SharedSessionContractImplementor session) {

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/ManyToManyCollectionPart.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/ManyToManyCollectionPart.java
@@ -30,6 +30,7 @@ import org.hibernate.metamodel.mapping.EntityAssociationMapping;
 import org.hibernate.metamodel.mapping.EntityIdentifierMapping;
 import org.hibernate.metamodel.mapping.EntityMappingType;
 import org.hibernate.metamodel.mapping.ForeignKeyDescriptor;
+import org.hibernate.metamodel.mapping.JdbcMapping;
 import org.hibernate.metamodel.mapping.ManagedMappingType;
 import org.hibernate.metamodel.mapping.ModelPart;
 import org.hibernate.metamodel.mapping.ModelPartContainer;
@@ -728,5 +729,10 @@ public class ManyToManyCollectionPart extends AbstractEntityCollectionPart imple
 				entityType.isReferenceToPrimaryKey(),
 				fkValue.isConstrained()
 		);
+	}
+
+	@Override
+	public JdbcMapping getJdbcMapping(final int index) {
+		return getEntityMappingType().getJdbcMapping( index );
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/OneToManyCollectionPart.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/OneToManyCollectionPart.java
@@ -16,6 +16,7 @@ import org.hibernate.metamodel.mapping.AssociationKey;
 import org.hibernate.metamodel.mapping.AttributeMapping;
 import org.hibernate.metamodel.mapping.EntityMappingType;
 import org.hibernate.metamodel.mapping.ForeignKeyDescriptor;
+import org.hibernate.metamodel.mapping.JdbcMapping;
 import org.hibernate.metamodel.mapping.PluralAttributeMapping;
 import org.hibernate.metamodel.mapping.SelectableConsumer;
 import org.hibernate.metamodel.mapping.SelectableMapping;
@@ -248,4 +249,10 @@ public class OneToManyCollectionPart extends AbstractEntityCollectionPart implem
 		fetchAssociationKey = foreignKey.getAssociationKey();
 		return true;
 	}
+
+	@Override
+	public JdbcMapping getJdbcMapping(final int index) {
+		return getEntityMappingType().getJdbcMapping( index );
+	}
+
 }

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/PluralAttributeMappingImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/PluralAttributeMappingImpl.java
@@ -999,6 +999,11 @@ public class PluralAttributeMappingImpl
 	}
 
 	@Override
+	public JdbcMapping getJdbcMapping(int index) {
+		throw new IndexOutOfBoundsException( index );
+	}
+
+	@Override
 	public SelectableMapping getSelectable(int columnIndex) {
 		return null;
 	}

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/SimpleForeignKeyDescriptor.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/SimpleForeignKeyDescriptor.java
@@ -563,12 +563,6 @@ public class SimpleForeignKeyDescriptor implements ForeignKeyDescriptor, BasicVa
 	}
 
 	@Override
-	public List<JdbcMapping> getJdbcMappings() {
-		return Collections.singletonList( targetSide.getModelPart().getJdbcMapping() );
-	}
-
-
-	@Override
 	public JdbcMapping getJdbcMapping(int index) {
 		if ( index != 0 ) {
 			throw new IndexOutOfBoundsException( index );

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/SimpleNaturalIdMapping.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/SimpleNaturalIdMapping.java
@@ -225,11 +225,6 @@ public class SimpleNaturalIdMapping extends AbstractNaturalIdMapping implements 
 	}
 
 	@Override
-	public List<JdbcMapping> getJdbcMappings() {
-		return attribute.getJdbcMappings();
-	}
-
-	@Override
 	public JdbcMapping getJdbcMapping(int index) {
 		return attribute.getJdbcMapping( index );
 	}

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/ToOneAttributeMapping.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/ToOneAttributeMapping.java
@@ -2333,6 +2333,11 @@ public class ToOneAttributeMapping
 	}
 
 	@Override
+	public JdbcMapping getJdbcMapping(final int index) {
+		return foreignKeyDescriptor.getJdbcMapping( index );
+	}
+
+	@Override
 	public SelectableMapping getSelectable(int columnIndex) {
 		if ( sideNature == ForeignKeyDescriptor.Nature.KEY ) {
 			return foreignKeyDescriptor.getSelectable( columnIndex );

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/internal/ArrayTupleType.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/internal/ArrayTupleType.java
@@ -111,6 +111,11 @@ public class ArrayTupleType implements TupleType<Object[]>,
 	}
 
 	@Override
+	public JdbcMapping getJdbcMapping(int index) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
 	public int forEachJdbcType(int offset, IndexedConsumer<JdbcMapping> action) {
 		throw new UnsupportedOperationException();
 	}

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/internal/TupleMappingModelExpressible.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/internal/TupleMappingModelExpressible.java
@@ -6,6 +6,8 @@
  */
 package org.hibernate.metamodel.model.domain.internal;
 
+import java.util.ArrayList;
+
 import org.hibernate.cache.MutableCacheKeyBuilder;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.internal.util.IndexedConsumer;
@@ -18,9 +20,18 @@ import org.hibernate.metamodel.mapping.MappingModelExpressible;
 public class TupleMappingModelExpressible implements MappingModelExpressible {
 
 	private final MappingModelExpressible<Object>[] components;
+	private final JdbcMapping[] mappings;
 
 	public TupleMappingModelExpressible(MappingModelExpressible<?>[] components) {
 		this.components = (MappingModelExpressible<Object>[]) components;
+		final ArrayList<JdbcMapping> results = new ArrayList<>();
+		forEachJdbcType( 0, (index, jdbcMapping) -> results.add( jdbcMapping ) );
+		this.mappings = results.toArray( new JdbcMapping[0] );
+	}
+
+	@Override
+	public JdbcMapping getJdbcMapping(final int index) {
+		return mappings[ index ];
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/persister/entity/AbstractEntityPersister.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/entity/AbstractEntityPersister.java
@@ -2062,6 +2062,11 @@ public abstract class AbstractEntityPersister
 		}
 	}
 
+	@Override
+	public JdbcMapping getJdbcMapping(int index) {
+		return getIdentifierMapping().getJdbcMapping( index );
+	}
+
 	protected LockingStrategy generateLocker(LockMode lockMode) {
 		return factory.getJdbcServices().getDialect().getLockingStrategy( this, lockMode );
 	}

--- a/hibernate-core/src/main/java/org/hibernate/persister/entity/JoinedSubclassEntityPersister.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/entity/JoinedSubclassEntityPersister.java
@@ -44,6 +44,7 @@ import org.hibernate.metamodel.mapping.EntityDiscriminatorMapping;
 import org.hibernate.metamodel.mapping.EntityIdentifierMapping;
 import org.hibernate.metamodel.mapping.EntityMappingType;
 import org.hibernate.metamodel.mapping.EntityVersionMapping;
+import org.hibernate.metamodel.mapping.JdbcMapping;
 import org.hibernate.metamodel.mapping.TableDetails;
 import org.hibernate.metamodel.mapping.internal.BasicEntityIdentifierMappingImpl;
 import org.hibernate.metamodel.mapping.internal.CaseStatementDiscriminatorMappingImpl;

--- a/hibernate-core/src/main/java/org/hibernate/query/derived/AnonymousTupleEmbeddableValuedModelPart.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/derived/AnonymousTupleEmbeddableValuedModelPart.java
@@ -288,13 +288,6 @@ public class AnonymousTupleEmbeddableValuedModelPart implements EmbeddableValued
 	}
 
 	@Override
-	public List<JdbcMapping> getJdbcMappings() {
-		final List<JdbcMapping> results = new ArrayList<>();
-		forEachSelectable( (index, selection) -> results.add( selection.getJdbcMapping() ) );
-		return results;
-	}
-
-	@Override
 	public int forEachSelectable(SelectableConsumer consumer) {
 		return forEachSelectable( 0, consumer );
 	}

--- a/hibernate-core/src/main/java/org/hibernate/query/derived/AnonymousTupleEntityValuedModelPart.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/derived/AnonymousTupleEntityValuedModelPart.java
@@ -215,13 +215,6 @@ public class AnonymousTupleEntityValuedModelPart
 	}
 
 	@Override
-	public List<JdbcMapping> getJdbcMappings() {
-		final List<JdbcMapping> results = new ArrayList<>();
-		forEachSelectable( (index, selection) -> results.add( selection.getJdbcMapping() ) );
-		return results;
-	}
-
-	@Override
 	public JdbcMapping getJdbcMapping(int index) {
 		return identifierMapping.getJdbcMapping( index );
 	}

--- a/hibernate-core/src/main/java/org/hibernate/query/derived/AnonymousTupleTableGroupProducer.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/derived/AnonymousTupleTableGroupProducer.java
@@ -367,6 +367,11 @@ public class AnonymousTupleTableGroupProducer implements TableGroupProducer, Map
 	}
 
 	@Override
+	public JdbcMapping getJdbcMapping(int index) {
+		throw new UnsupportedOperationException( "Not yet implemented" );
+	}
+
+	@Override
 	public int forEachJdbcType(int offset, IndexedConsumer<JdbcMapping> action) {
 		throw new UnsupportedOperationException( "Not yet implemented" );
 	}

--- a/hibernate-core/src/main/java/org/hibernate/sql/ast/spi/AbstractSqlAstTranslator.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/ast/spi/AbstractSqlAstTranslator.java
@@ -6236,7 +6236,7 @@ public abstract class AbstractSqlAstTranslator<T extends JdbcOperation> implemen
 	}
 
 	protected final void renderParameterAsParameter(JdbcParameter jdbcParameter) {
-		final JdbcType jdbcType = jdbcParameter.getExpressionType().getJdbcMappings().get( 0 ).getJdbcType();
+		final JdbcType jdbcType = jdbcParameter.getExpressionType().getJdbcMapping( 0 ).getJdbcType();
 		assert jdbcType != null;
 		renderParameterAsParameter( parameterBinders.size() + 1, jdbcParameter );
 	}
@@ -6247,7 +6247,7 @@ public abstract class AbstractSqlAstTranslator<T extends JdbcOperation> implemen
 	 * @param position
 	 */
 	protected void renderParameterAsParameter(int position, JdbcParameter jdbcParameter) {
-		final JdbcType jdbcType = jdbcParameter.getExpressionType().getJdbcMappings().get( 0 ).getJdbcType();
+		final JdbcType jdbcType = jdbcParameter.getExpressionType().getJdbcMapping( 0 ).getJdbcType();
 		assert jdbcType != null;
 		final String parameterMarker = parameterMarkerStrategy.createMarker( position, jdbcType );
 		jdbcType.appendWriteExpression( parameterMarker, this, dialect );

--- a/hibernate-core/src/main/java/org/hibernate/sql/ast/tree/expression/EntityTypeLiteral.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/ast/tree/expression/EntityTypeLiteral.java
@@ -56,11 +56,6 @@ public class EntityTypeLiteral
 	}
 
 	@Override
-	public List<JdbcMapping> getJdbcMappings() {
-		return discriminatorType.getJdbcMappings();
-	}
-
-	@Override
 	public JdbcMapping getJdbcMapping(int index) {
 		return discriminatorType.getJdbcMapping( index );
 	}

--- a/hibernate-core/src/main/java/org/hibernate/sql/ast/tree/expression/Expression.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/ast/tree/expression/Expression.java
@@ -55,7 +55,7 @@ public interface Expression extends SqlAstNode, SqlSelectionProducer {
 			expression = this;
 		}
 		else {
-			expression = expressionType.getJdbcMappings().get( 0 ).getJdbcType().wrapTopLevelSelectionExpression( this );
+			expression = expressionType.getJdbcMapping( 0 ).getJdbcType().wrapTopLevelSelectionExpression( this );
 		}
 		return expression == this
 			? createSqlSelection( jdbcPosition, valuesArrayPosition, javaType, typeConfiguration )

--- a/hibernate-core/src/main/java/org/hibernate/sql/ast/tree/expression/JdbcLiteral.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/ast/tree/expression/JdbcLiteral.java
@@ -9,8 +9,6 @@ package org.hibernate.sql.ast.tree.expression;
 import java.io.Serializable;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
-import java.util.Collections;
-import java.util.List;
 
 import org.hibernate.cache.MutableCacheKeyBuilder;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
@@ -90,11 +88,6 @@ public class JdbcLiteral<T> implements Literal, MappingModelExpressible<T>, Doma
 	@Override
 	public int getJdbcTypeCount() {
 		return 1;
-	}
-
-	@Override
-	public List<JdbcMapping> getJdbcMappings() {
-		return Collections.singletonList( jdbcMapping );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/sql/exec/internal/JdbcParameterImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/exec/internal/JdbcParameterImpl.java
@@ -7,7 +7,6 @@
 package org.hibernate.sql.exec.internal;
 
 import org.hibernate.metamodel.mapping.JdbcMapping;
-import org.hibernate.sql.ast.SqlAstWalker;
 
 /**
  * @author Steve Ebersole
@@ -17,4 +16,5 @@ public class JdbcParameterImpl extends AbstractJdbcParameter {
 	public JdbcParameterImpl(JdbcMapping jdbcMapping) {
 		super( jdbcMapping );
 	}
+
 }

--- a/hibernate-core/src/main/java/org/hibernate/type/BasicType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/BasicType.java
@@ -6,9 +6,6 @@
  */
 package org.hibernate.type;
 
-import java.util.Collections;
-import java.util.List;
-
 import org.hibernate.Incubating;
 import org.hibernate.dialect.Dialect;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
@@ -17,10 +14,10 @@ import org.hibernate.internal.util.IndexedConsumer;
 import org.hibernate.metamodel.mapping.BasicValuedMapping;
 import org.hibernate.metamodel.mapping.JdbcMapping;
 import org.hibernate.metamodel.mapping.MappingType;
-import org.hibernate.type.descriptor.converter.spi.BasicValueConverter;
 import org.hibernate.metamodel.model.domain.BasicDomainType;
 import org.hibernate.type.descriptor.ValueBinder;
 import org.hibernate.type.descriptor.ValueExtractor;
+import org.hibernate.type.descriptor.converter.spi.BasicValueConverter;
 import org.hibernate.type.descriptor.java.JavaType;
 import org.hibernate.type.descriptor.jdbc.JdbcLiteralFormatter;
 
@@ -66,11 +63,6 @@ public interface BasicType<T> extends Type, BasicDomainType<T>, MappingType, Bas
 	@Override
 	default int getJdbcTypeCount() {
 		return 1;
-	}
-
-	@Override
-	default List<JdbcMapping> getJdbcMappings() {
-		return Collections.singletonList( this );
 	}
 
 	@Override

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/cfg/persister/GoofyPersisterClassProvider.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/cfg/persister/GoofyPersisterClassProvider.java
@@ -182,6 +182,11 @@ public class GoofyPersisterClassProvider implements PersisterClassResolver {
 		}
 
 		@Override
+		public JdbcMapping getJdbcMapping(int index) {
+			throw new IndexOutOfBoundsException( index );
+		}
+
+		@Override
 		public int forEachJdbcType(
 				int offset, IndexedConsumer<JdbcMapping> action) {
 			return 0;

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/id/uuid/sqlrep/sqlbinary/UUIDBinaryTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/id/uuid/sqlrep/sqlbinary/UUIDBinaryTest.java
@@ -7,7 +7,6 @@
 package org.hibernate.orm.test.id.uuid.sqlrep.sqlbinary;
 
 import java.sql.Types;
-import java.util.List;
 import java.util.UUID;
 
 import org.hibernate.annotations.JdbcTypeCode;
@@ -30,7 +29,6 @@ import jakarta.persistence.ManyToOne;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.hasSize;
 
 /**
  * @author Steve Ebersole
@@ -54,9 +52,7 @@ public class UUIDBinaryTest {
 	public void testUsage(SessionFactoryScope scope) {
 		final MappingMetamodel domainModel = scope.getSessionFactory().getRuntimeMetamodels().getMappingMetamodel();
 		final EntityPersister entityDescriptor = domainModel.findEntityDescriptor( Node.class );
-		final List<JdbcMapping> identifierJdbcMappings = entityDescriptor.getIdentifierMapping().getJdbcMappings();
-		assertThat( identifierJdbcMappings, hasSize( 1 ) );
-		final JdbcMapping jdbcMapping = identifierJdbcMappings.get( 0 );
+		final JdbcMapping jdbcMapping = entityDescriptor.getIdentifierMapping().getSingleJdbcMapping();
 		assertThat( jdbcMapping.getJdbcType().isBinary(), is( true ) );
 
 		final UUIDPair uuidPair = scope.fromTransaction( session -> {

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/id/uuid/sqlrep/sqlchar/UuidAsCharAnnotationTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/id/uuid/sqlrep/sqlchar/UuidAsCharAnnotationTest.java
@@ -7,7 +7,6 @@
 package org.hibernate.orm.test.id.uuid.sqlrep.sqlchar;
 
 import java.sql.Types;
-import java.util.List;
 import java.util.UUID;
 
 import org.hibernate.annotations.JdbcTypeCode;
@@ -30,7 +29,6 @@ import jakarta.persistence.ManyToOne;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.hasSize;
 
 /**
  * @author Steve Ebersole
@@ -54,9 +52,7 @@ public class UuidAsCharAnnotationTest {
 	public void testUsage(SessionFactoryScope scope) {
 		final MappingMetamodel domainModel = scope.getSessionFactory().getRuntimeMetamodels().getMappingMetamodel();
 		final EntityPersister entityDescriptor = domainModel.findEntityDescriptor( Node.class );
-		final List<JdbcMapping> identifierJdbcMappings = entityDescriptor.getIdentifierMapping().getJdbcMappings();
-		assertThat( identifierJdbcMappings, hasSize( 1 ) );
-		final JdbcMapping jdbcMapping = identifierJdbcMappings.get( 0 );
+		final JdbcMapping jdbcMapping = entityDescriptor.getIdentifierMapping().getSingleJdbcMapping();
 		assertThat( jdbcMapping.getJdbcType().isString(), is( true ) );
 
 		final UUIDPair uuidPair = scope.fromTransaction( session -> {

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/id/uuid/sqlrep/sqlchar/UuidAsCharSettingTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/id/uuid/sqlrep/sqlchar/UuidAsCharSettingTest.java
@@ -7,12 +7,7 @@
 package org.hibernate.orm.test.id.uuid.sqlrep.sqlchar;
 
 import java.sql.Types;
-import java.util.List;
 import java.util.UUID;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.Id;
-import jakarta.persistence.ManyToOne;
 
 import org.hibernate.cfg.AvailableSettings;
 import org.hibernate.mapping.Property;
@@ -30,10 +25,14 @@ import org.hibernate.testing.orm.junit.SessionFactoryScope;
 import org.hibernate.testing.orm.junit.Setting;
 import org.junit.jupiter.api.Test;
 
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
+
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.hasSize;
 
 /**
  * @author Steve Ebersole
@@ -69,9 +68,7 @@ public class UuidAsCharSettingTest {
 	public void testUsage(SessionFactoryScope scope) {
 		final MappingMetamodel domainModel = scope.getSessionFactory().getRuntimeMetamodels().getMappingMetamodel();
 		final EntityPersister entityDescriptor = domainModel.findEntityDescriptor( Node.class );
-		final List<JdbcMapping> identifierJdbcMappings = entityDescriptor.getIdentifierMapping().getJdbcMappings();
-		assertThat( identifierJdbcMappings, hasSize( 1 ) );
-		final JdbcMapping jdbcMapping = identifierJdbcMappings.get( 0 );
+		final JdbcMapping jdbcMapping = entityDescriptor.getIdentifierMapping().getSingleJdbcMapping();
 		assertThat( jdbcMapping.getJdbcType().isString(), is( true ) );
 
 		final UUIDPair uuidPair = scope.fromTransaction( session -> {

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/ejb3configuration/PersisterClassProviderTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/ejb3configuration/PersisterClassProviderTest.java
@@ -209,6 +209,11 @@ public class PersisterClassProviderTest {
 		}
 
 		@Override
+		public JdbcMapping getJdbcMapping(int index) {
+			throw new IndexOutOfBoundsException( index );
+		}
+
+		@Override
 		public int forEachJdbcType(
 				int offset, IndexedConsumer<JdbcMapping> action) {
 			return 0;

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/legacy/CustomPersister.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/legacy/CustomPersister.java
@@ -170,6 +170,11 @@ public class CustomPersister implements EntityPersister {
 	}
 
 	@Override
+	public JdbcMapping getJdbcMapping(int index) {
+		throw new IndexOutOfBoundsException( index );
+	}
+
+	@Override
 	public int forEachJdbcType(
 			int offset, IndexedConsumer<JdbcMapping> action) {
 		return 0;


### PR DESCRIPTION

The method `getJdbcMappings()` returns a `List<JdbcMapping>` , which in turn implies mutability; for this reason several implementations create a defensive copy (althought this is inconsistently applied).

It's also clear there are multiple alternative methods to enumerate the JdbcMapping(s), making this a little redundant; and the strongest reason for me to remove this method is the fact that in several cases the implementation was provided by a super default method which would often result in very inefficient allocations.

By removing this method it turns out I could somewhat trivially re-route all needs to more efficient accessors, so I think I'm on the right path to make this a bit more robust and efficient.