### PR TITLE
HHH-16605 Allow integer <=> boolean comparisons

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/IntegerJavaType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/IntegerJavaType.java
@@ -99,6 +99,8 @@ public class IntegerJavaType extends AbstractClassJavaType<Integer>
 			case "java.lang.Byte":
 			case "short":
 			case "java.lang.Short":
+			case "boolean":
+			case "java.lang.Boolean":
 				return true;
 			default:
 				return false;

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/hql/ASTParserLoadingTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/hql/ASTParserLoadingTest.java
@@ -66,6 +66,7 @@ import org.hibernate.testing.RequiresDialectFeature;
 import org.hibernate.testing.SkipForDialect;
 import org.hibernate.testing.TestForIssue;
 import org.hibernate.testing.junit4.BaseCoreFunctionalTestCase;
+import org.hibernate.testing.orm.junit.JiraKey;
 
 import org.hibernate.orm.test.cid.Customer;
 import org.hibernate.orm.test.cid.LineItem;
@@ -308,6 +309,21 @@ public class ASTParserLoadingTest extends BaseCoreFunctionalTestCase {
 							created.getId() + "foo"
 					);
 					assertEquals( expected, result );
+				}
+		);
+	}
+
+        @Test
+	@JiraKey("HHH-16605")
+	public void testBooleanAndIntegerComparision() {
+		inTransaction(
+				(session) -> {
+					final String qry = "select c from Constructor c where 1 = true";
+					QueryImplementor<Constructor> query = session.createQuery(qry, Constructor.class);
+                                        
+					//do not execute the query here because in H2, integer vs boolean comparison is only valid
+					//when MODE=MYSQL or MODE=MARIADB, however it has to be accepted by the HQL parser
+					assertNotNull(query);
 				}
 		);
 	}


### PR DESCRIPTION
Hello,

I'm trying to fix [HHH-16605](https://hibernate.atlassian.net/browse/HHH-16605) because it worked in version 6.1.7. Actually, it will still crash on H2 (but at the JDBC layer) **unless you use MODE=MYSQL** for the JDBC connection.

I'm not quite sure of the fix because it seems that it should be an option in the [H2Dialect](https://github.com/hibernate/hibernate-orm/blob/main/hibernate-core/src/main/java/org/hibernate/dialect/H2Dialect.java) but it seems that there is no check on the dialect in [SqmCriteriaNodeBuilder](https://github.com/hibernate/hibernate-orm/blob/main/hibernate-core/src/main/java/org/hibernate/query/sqm/internal/SqmCriteriaNodeBuilder.java#L242).

It seems that [this PR](https://github.com/hibernate/hibernate-orm/pull/6189) is causing the regression.

Best regards,
Cedric

[HHH-16605]: https://hibernate.atlassian.net/browse/HHH-16605?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ