### PR TITLE
HHH-16608 literal predicates can match against any type

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/internal/SqmCriteriaNodeBuilder.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/internal/SqmCriteriaNodeBuilder.java
@@ -265,7 +265,11 @@ public class SqmCriteriaNodeBuilder implements NodeBuilder, SqmCreationContext, 
 				|| rhsJavaType.isWider( lhsJavaType )
 				// Polymorphic entity comparison
 				|| lhsJavaType.getJavaTypeClass().isAssignableFrom( rhsJavaType.getJavaTypeClass() )
-				|| rhsJavaType.getJavaTypeClass().isAssignableFrom( lhsJavaType.getJavaTypeClass() );
+				|| rhsJavaType.getJavaTypeClass().isAssignableFrom( lhsJavaType.getJavaTypeClass() )
+				// Special cases for strings because for instance in MySQL/MariaDB, any
+				// value (date, boolean, integer) can be enclosed as string
+				|| JavaTypeHelper.isLiteral(lhsJavaType)
+				|| JavaTypeHelper.isLiteral(rhsJavaType);
 	}
 
 	private static boolean isDiscriminatorComparison(SqmExpressible<?> lhsType, SqmExpressible<?> rhsType) {

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/JavaTypeHelper.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/JavaTypeHelper.java
@@ -29,6 +29,10 @@ public class JavaTypeHelper {
 		);
 	}
 
+	public static boolean isLiteral(JavaType<?> javaType) {
+		return javaType.getClass() == StringJavaType.class;
+	}
+
 	public static boolean isTemporal(JavaType<?> javaType) {
 		return javaType != null && javaType.isTemporalType();
 	}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/hql/ASTParserLoadingTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/hql/ASTParserLoadingTest.java
@@ -66,6 +66,7 @@ import org.hibernate.testing.RequiresDialectFeature;
 import org.hibernate.testing.SkipForDialect;
 import org.hibernate.testing.TestForIssue;
 import org.hibernate.testing.junit4.BaseCoreFunctionalTestCase;
+import org.hibernate.testing.orm.junit.JiraKey;
 
 import org.hibernate.orm.test.cid.Customer;
 import org.hibernate.orm.test.cid.LineItem;
@@ -278,6 +279,21 @@ public class ASTParserLoadingTest extends BaseCoreFunctionalTestCase {
 							.setParameterList( 2, citiesArray )
 							.list();
 					assertEquals( 1, result.size() );
+				}
+		);
+	}
+
+        @Test
+	@JiraKey("HHH-16608")
+	public void testStringPredicate() {
+		// In MySQL/MariaDB and H2 with MODE=MYSQL it is possible to have predicates like dates or numbers or event booleans
+		// encapsulated in quotes, so any type should be accepted agains string and let the database handle it
+		inTransaction(
+				(session) -> {
+					assertNotNull(session.createQuery("select c from Constructor c where c.someNumber = '12345'", Constructor.class));
+					assertNotNull(session.createQuery("select c from Constructor c where c.someBoolean = 'true'", Constructor.class));
+					assertNotNull(session.createQuery("select c from Mammal c where c.birthdate = '2023-01-01 00:00:00'", org.hibernate.testing.orm.domain.animal.Mammal.class));
+					assertNotNull(session.createQuery("select c from Mammal c where c.birthdate = '2023-01-01'", org.hibernate.testing.orm.domain.animal.Mammal.class));
 				}
 		);
 	}


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-16608

After #6189 some queries against MariaDB/MySQL (and also on H2 with either mode) are broken because those engines accept predicates against values that are enclosed in literal, such as `SELECT * FROM table t WHERE t.some_date = '2023-01-01'` and hence that type cannot be refused by Hibernate.

Maybe that should be something configurable from the Dialect :thinking: