### PR TITLE
HHH-16799 Backport 6.2: Don't fall back to field access type too early

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/property/access/internal/PropertyAccessEnhancedImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/property/access/internal/PropertyAccessEnhancedImpl.java
@@ -15,7 +15,6 @@ import org.hibernate.property.access.spi.PropertyAccess;
 import org.hibernate.property.access.spi.PropertyAccessBuildingException;
 import org.hibernate.property.access.spi.PropertyAccessStrategy;
 import org.hibernate.property.access.spi.Setter;
-import org.hibernate.property.access.spi.SetterMethodImpl;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
@@ -86,10 +85,7 @@ public class PropertyAccessEnhancedImpl implements PropertyAccess {
 			// this should indicate FIELD access
 			return getterAccessType;
 		}
-
-		// prefer using the field for getting if we can
-		final Field field = AccessStrategyHelper.fieldOrNull( containerJavaType, propertyName );
-		return field != null ? AccessType.FIELD : AccessType.PROPERTY;
+		return AccessStrategyHelper.getAccessType( containerJavaType, propertyName );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/property/access/internal/PropertyAccessStrategyEnhancedImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/property/access/internal/PropertyAccessStrategyEnhancedImpl.java
@@ -6,7 +6,6 @@
  */
 package org.hibernate.property.access.internal;
 
-import org.hibernate.property.access.spi.BuiltInPropertyAccessStrategies;
 import org.hibernate.property.access.spi.PropertyAccess;
 import org.hibernate.property.access.spi.PropertyAccessStrategy;
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/access/PropertyAccessTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/access/PropertyAccessTest.java
@@ -1,0 +1,85 @@
+package org.hibernate.orm.test.bytecode.enhancement.access;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hibernate.testing.transaction.TransactionUtil.doInHibernate;
+
+import org.hibernate.testing.bytecode.enhancement.BytecodeEnhancerRunner;
+import org.hibernate.testing.junit4.BaseCoreFunctionalTestCase;
+import org.hibernate.testing.orm.junit.JiraKey;
+import org.junit.After;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import jakarta.persistence.Access;
+import jakarta.persistence.AccessType;
+import jakarta.persistence.Basic;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+@JiraKey("HHH-16799")
+@RunWith(BytecodeEnhancerRunner.class)
+public class PropertyAccessTest extends BaseCoreFunctionalTestCase {
+
+	@Override
+	public Class<?>[] getAnnotatedClasses() {
+		return new Class<?>[] { SomeEntity.class };
+	}
+
+	@Test
+	public void test() {
+		doInHibernate( this::sessionFactory, session -> {
+			session.persist( new SomeEntity( 1L, "field", "property" ) );
+		} );
+
+		doInHibernate( this::sessionFactory, session -> {
+			SomeEntity entity = session.get( SomeEntity.class, 1L );
+			assertThat( entity.property ).isEqualTo( "from getter: property" );
+
+			entity.setProperty( "updated" );
+		} );
+
+		doInHibernate( this::sessionFactory, session -> {
+			SomeEntity entity = session.get( SomeEntity.class, 1L );
+			assertThat( entity.property ).isEqualTo( "from getter: updated" );
+		} );
+	}
+
+	@After
+	public void cleanup() {
+		doInHibernate( this::sessionFactory, session -> {
+			session.remove( session.get( SomeEntity.class, 1L ) );
+		} );
+	}
+
+	@Entity
+	@Table(name = "SOME_ENTITY")
+	private static class SomeEntity {
+		@Id
+		Long id;
+
+		@Basic
+		String field;
+
+		String property;
+
+		public SomeEntity() {
+		}
+
+		public SomeEntity(Long id, String field, String property) {
+			this.id = id;
+			this.field = field;
+			this.property = property;
+		}
+
+		@Basic
+		@Access(AccessType.PROPERTY)
+		public String getProperty() {
+			return "from getter: " + property;
+		}
+
+		public void setProperty(String property) {
+			this.property = property;
+		}
+	}
+}


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-16799

While the test case itself may look a bit silly, it was as close as I got to get to the same state as in the original issue caused by using Kotlin in Quarkus 🙈 (https://github.com/quarkusio/quarkus/issues/33740)

If the fix isn't ok -- let me know 😄 