### PR TITLE
HHH-16726 adjust readability condition for strict read-write cache items according isolation level

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/cache/spi/support/AbstractReadWriteAccess.java
+++ b/hibernate-core/src/main/java/org/hibernate/cache/spi/support/AbstractReadWriteAccess.java
@@ -300,7 +300,7 @@ public abstract class AbstractReadWriteAccess extends AbstractCachedDomainDataAc
 				);
 			}
 
-			return txTimestamp > timestamp;
+			return txTimestamp >= timestamp;
 		}
 
 		@Override

--- a/hibernate-core/src/main/java/org/hibernate/engine/jdbc/env/internal/JdbcEnvironmentImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/jdbc/env/internal/JdbcEnvironmentImpl.java
@@ -6,6 +6,7 @@
  */
 package org.hibernate.engine.jdbc.env.internal;
 
+import java.sql.Connection;
 import java.sql.DatabaseMetaData;
 import java.sql.SQLException;
 
@@ -60,6 +61,8 @@ public class JdbcEnvironmentImpl implements JdbcEnvironment {
 	private final LobCreatorBuilderImpl lobCreatorBuilder;
 
 	private final NameQualifierSupport nameQualifierSupport;
+
+	private int transactionIsolation = Connection.TRANSACTION_SERIALIZABLE;
 
 	/**
 	 * Constructor form used when the JDBC {@link DatabaseMetaData} is not available.
@@ -207,6 +210,8 @@ public class JdbcEnvironmentImpl implements JdbcEnvironment {
 		);
 
 		this.lobCreatorBuilder = LobCreatorBuilderImpl.makeLobCreatorBuilder();
+
+		this.transactionIsolation = databaseMetaData.getConnection().getTransactionIsolation();
 	}
 
 	private NameQualifierSupport determineNameQualifierSupport(DatabaseMetaData databaseMetaData) throws SQLException {
@@ -308,6 +313,8 @@ public class JdbcEnvironmentImpl implements JdbcEnvironment {
 				cfgService.getSettings(),
 				databaseMetaData.getConnection()
 		);
+
+		this.transactionIsolation = databaseMetaData.getConnection().getTransactionIsolation();
 	}
 
 	public static final String SCHEMA_NAME_RESOLVER = "hibernate.schema_name_resolver";
@@ -396,6 +403,11 @@ public class JdbcEnvironmentImpl implements JdbcEnvironment {
 	@Override
 	public LobCreatorBuilder getLobCreatorBuilder() {
 		return lobCreatorBuilder;
+	}
+
+	@Override
+	public int getTransactionIsolation() {
+		return transactionIsolation;
 	}
 
 }

--- a/hibernate-core/src/main/java/org/hibernate/engine/jdbc/env/spi/JdbcEnvironment.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/jdbc/env/spi/JdbcEnvironment.java
@@ -92,4 +92,13 @@ public interface JdbcEnvironment extends Service {
 	 * @return The LobCreator builder.
 	 */
 	LobCreatorBuilder getLobCreatorBuilder();
+
+	/**
+	 * Retrieve the transaction isolation level ANSI/ISO standard SQL 92
+	 *
+	 * @return the transaction isolation level
+	 */
+	int getTransactionIsolation();
+
+
 }


### PR DESCRIPTION
1.  items are always readable from 2ndLevelCache if we accept phantom reads
2.  items are readable when cached timestamp is equal to current session timestamp (trust items which were cached by ourself)