### PR TITLE
HHH-16788 Increase traceability of null whenFragments

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/dialect/DB2SqlAstTranslator.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/DB2SqlAstTranslator.java
@@ -160,8 +160,7 @@ public class DB2SqlAstTranslator<T extends JdbcOperation> extends AbstractSqlAst
 			CaseSearchedExpression caseSearchedExpression,
 			Consumer<Expression> resultRenderer) {
 		if ( getParameterRenderingMode() == SqlAstNodeRenderingMode.DEFAULT && areAllResultsParameters( caseSearchedExpression ) ) {
-			final List<CaseSearchedExpression.WhenFragment> whenFragments = caseSearchedExpression.getWhenFragments();
-			final Expression firstResult = whenFragments.get( 0 ).getResult();
+			final Expression firstResult = caseSearchedExpression.getWhenFragment( 0 ).getResult();
 			super.visitAnsiCaseSearchedExpression(
 					caseSearchedExpression,
 					e -> {

--- a/hibernate-core/src/main/java/org/hibernate/dialect/DerbySqlAstTranslator.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/DerbySqlAstTranslator.java
@@ -70,8 +70,7 @@ public class DerbySqlAstTranslator<T extends JdbcOperation> extends AbstractSqlA
 			CaseSearchedExpression caseSearchedExpression,
 			Consumer<Expression> resultRenderer) {
 		if ( getParameterRenderingMode() == SqlAstNodeRenderingMode.DEFAULT && areAllResultsParameters( caseSearchedExpression ) ) {
-			final List<CaseSearchedExpression.WhenFragment> whenFragments = caseSearchedExpression.getWhenFragments();
-			final Expression firstResult = whenFragments.get( 0 ).getResult();
+			final Expression firstResult = caseSearchedExpression.getWhenFragment( 0 ).getResult();
 			super.visitAnsiCaseSearchedExpression(
 					caseSearchedExpression,
 					e -> {

--- a/hibernate-core/src/main/java/org/hibernate/dialect/HSQLSqlAstTranslator.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/HSQLSqlAstTranslator.java
@@ -110,8 +110,7 @@ public class HSQLSqlAstTranslator<T extends JdbcOperation> extends AbstractSqlAs
 			Consumer<Expression> resultRenderer) {
 		if ( getParameterRenderingMode() == SqlAstNodeRenderingMode.DEFAULT && areAllResultsParameters( expression )
 				|| areAllResultsPlainParametersOrLiterals( expression ) ) {
-			final List<CaseSearchedExpression.WhenFragment> whenFragments = expression.getWhenFragments();
-			final Expression firstResult = whenFragments.get( 0 ).getResult();
+			final Expression firstResult = expression.getWhenFragment( 0 ).getResult();
 			super.visitAnsiCaseSearchedExpression(
 					expression,
 					e -> {

--- a/hibernate-core/src/main/java/org/hibernate/dialect/SybaseASESqlAstTranslator.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/SybaseASESqlAstTranslator.java
@@ -68,8 +68,7 @@ public class SybaseASESqlAstTranslator<T extends JdbcOperation> extends Abstract
 			CaseSearchedExpression caseSearchedExpression,
 			Consumer<Expression> resultRenderer) {
 		if ( getParameterRenderingMode() == SqlAstNodeRenderingMode.DEFAULT && areAllResultsParameters( caseSearchedExpression ) ) {
-			final List<CaseSearchedExpression.WhenFragment> whenFragments = caseSearchedExpression.getWhenFragments();
-			final Expression firstResult = whenFragments.get( 0 ).getResult();
+			final Expression firstResult = caseSearchedExpression.getWhenFragment( 0 ).getResult();
 			super.visitAnsiCaseSearchedExpression(
 					caseSearchedExpression,
 					e -> {

--- a/hibernate-core/src/main/java/org/hibernate/dialect/SybaseSqlAstTranslator.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/SybaseSqlAstTranslator.java
@@ -59,8 +59,7 @@ public class SybaseSqlAstTranslator<T extends JdbcOperation> extends AbstractSql
 			CaseSearchedExpression caseSearchedExpression,
 			Consumer<Expression> resultRenderer) {
 		if ( getParameterRenderingMode() == SqlAstNodeRenderingMode.DEFAULT && areAllResultsParameters( caseSearchedExpression ) ) {
-			final List<CaseSearchedExpression.WhenFragment> whenFragments = caseSearchedExpression.getWhenFragments();
-			final Expression firstResult = whenFragments.get( 0 ).getResult();
+			final Expression firstResult = caseSearchedExpression.getWhenFragment( 0 ).getResult();
 			super.visitAnsiCaseSearchedExpression(
 					caseSearchedExpression,
 					e -> {

--- a/hibernate-core/src/main/java/org/hibernate/dialect/function/FormatFunction.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/function/FormatFunction.java
@@ -503,7 +503,7 @@ public class FormatFunction extends AbstractSqmFunctionDescriptor implements Fun
 			else {
 				// ZoneOffset as seconds
 				final CaseSearchedExpression caseSearchedExpression = new CaseSearchedExpression( stringType );
-				caseSearchedExpression.getWhenFragments().add(
+				caseSearchedExpression.when(
 						new CaseSearchedExpression.WhenFragment(
 								new ComparisonPredicate(
 										offsetExpression,
@@ -516,7 +516,7 @@ public class FormatFunction extends AbstractSqmFunctionDescriptor implements Fun
 								new QueryLiteral<>( "-", stringType )
 						)
 				);
-				caseSearchedExpression.getWhenFragments().add(
+				caseSearchedExpression.when(
 						new CaseSearchedExpression.WhenFragment(
 								new ComparisonPredicate(
 										offsetExpression,
@@ -529,7 +529,7 @@ public class FormatFunction extends AbstractSqmFunctionDescriptor implements Fun
 								new QueryLiteral<>( "-0", stringType )
 						)
 				);
-				caseSearchedExpression.getWhenFragments().add(
+				caseSearchedExpression.when(
 						new CaseSearchedExpression.WhenFragment(
 								new ComparisonPredicate(
 										offsetExpression,
@@ -547,7 +547,7 @@ public class FormatFunction extends AbstractSqmFunctionDescriptor implements Fun
 				final Expression minutes = getMinutes( floorFunction, castFunction, integerType, offsetExpression );
 
 				final CaseSearchedExpression minuteStart = new CaseSearchedExpression( stringType );
-				minuteStart.getWhenFragments().add(
+				minuteStart.when(
 						new CaseSearchedExpression.WhenFragment(
 								new BetweenPredicate(
 										minutes,
@@ -617,7 +617,7 @@ public class FormatFunction extends AbstractSqmFunctionDescriptor implements Fun
 			else {
 				// ZoneOffset as seconds
 				final CaseSearchedExpression caseSearchedExpression = new CaseSearchedExpression( stringType );
-				caseSearchedExpression.getWhenFragments().add(
+				caseSearchedExpression.when(
 						new CaseSearchedExpression.WhenFragment(
 								new ComparisonPredicate(
 										offsetExpression,
@@ -630,7 +630,7 @@ public class FormatFunction extends AbstractSqmFunctionDescriptor implements Fun
 								new QueryLiteral<>( "-", stringType )
 						)
 				);
-				caseSearchedExpression.getWhenFragments().add(
+				caseSearchedExpression.when(
 						new CaseSearchedExpression.WhenFragment(
 								new ComparisonPredicate(
 										offsetExpression,
@@ -643,7 +643,7 @@ public class FormatFunction extends AbstractSqmFunctionDescriptor implements Fun
 								new QueryLiteral<>( "-0", stringType )
 						)
 				);
-				caseSearchedExpression.getWhenFragments().add(
+				caseSearchedExpression.when(
 						new CaseSearchedExpression.WhenFragment(
 								new ComparisonPredicate(
 										offsetExpression,
@@ -662,7 +662,7 @@ public class FormatFunction extends AbstractSqmFunctionDescriptor implements Fun
 				final Expression minutes = getMinutes( floorFunction, castFunction, integerType, offsetExpression );
 
 				final CaseSearchedExpression minuteStart = new CaseSearchedExpression( stringType );
-				minuteStart.getWhenFragments().add(
+				minuteStart.when(
 						new CaseSearchedExpression.WhenFragment(
 								new BetweenPredicate(
 										minutes,
@@ -719,7 +719,7 @@ public class FormatFunction extends AbstractSqmFunctionDescriptor implements Fun
 			else {
 				// ZoneOffset as seconds
 				final CaseSearchedExpression caseSearchedExpression = new CaseSearchedExpression( stringType );
-				caseSearchedExpression.getWhenFragments().add(
+				caseSearchedExpression.when(
 						new CaseSearchedExpression.WhenFragment(
 								new ComparisonPredicate(
 										offsetExpression,
@@ -732,7 +732,7 @@ public class FormatFunction extends AbstractSqmFunctionDescriptor implements Fun
 								new QueryLiteral<>( "-", stringType )
 						)
 				);
-				caseSearchedExpression.getWhenFragments().add(
+				caseSearchedExpression.when(
 						new CaseSearchedExpression.WhenFragment(
 								new ComparisonPredicate(
 										offsetExpression,
@@ -745,7 +745,7 @@ public class FormatFunction extends AbstractSqmFunctionDescriptor implements Fun
 								new QueryLiteral<>( "-0", stringType )
 						)
 				);
-				caseSearchedExpression.getWhenFragments().add(
+				caseSearchedExpression.when(
 						new CaseSearchedExpression.WhenFragment(
 								new ComparisonPredicate(
 										offsetExpression,


### PR DESCRIPTION
I've started seeing spikes of exceptions like this that persist until server restart
```
Java.lang.NullPointerException: Cannot invoke "org.hibernate.sql.ast.tree.expression.CaseSearchedExpression$WhenFragment.getPredicate()" because "whenFragment" is null
at org.hibernate.sql.ast.spi.AbstractSqlAstTranslator.visitAnsiCaseSearchedExpression(AbstractSqlAstTranslator.java:6431)
```
Code being referenced:
```java
for ( CaseSearchedExpression.WhenFragment whenFragment : caseSearchedExpression.getWhenFragments() ) {
    ...
    whenFragment.getPredicate().accept( this ); // <-- NPE, whenFragment is null somehow
    ...
}
```

But looking through the code, I couldn't see how whenFragment could possibly become null, and have been unable to reproduce the issue on anything except an actual production server. So I've not added any tests.

Hopefully, the changes in this pull request will raise an exception sooner and we'll be able to actually see where it's going wrong.

To this end, I have made the `CaseSearchedExpression::getWhenFragments` method return an immutable view and instead added a method in CaseSearchedExpression to modify the list only after a null check. I've also added a null check in the constructor.

https://hibernate.atlassian.net/browse/HHH-16788