### PR TITLE
HHH-13857 Avoid lazy initialization when obtaining persistent class

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/Hibernate.java
+++ b/hibernate-core/src/main/java/org/hibernate/Hibernate.java
@@ -250,8 +250,7 @@ public final class Hibernate {
 		final LazyInitializer lazyInitializer = extractLazyInitializer( proxy );
 		if ( lazyInitializer != null ) {
 			result = lazyInitializer
-					.getImplementation()
-					.getClass();
+					.getPersistentClass();
 		}
 		else {
 			result = proxy.getClass();


### PR DESCRIPTION
Current utility code in Hibernate class forces initialization of the proxies just to obtain the target persistent class that is used, because it uses `getImplementation()` method of LazyInitializer.

There is a method in LazyInitializer that can do the same without initialization (`getPersistentClass()`), so I think it should be used instead.

(this is same as #3230 but for main instead of 5.6)