### PR TITLE
don't throw ParsingException (it represents a bug in the parser)

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/query/SyntaxException.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/SyntaxException.java
@@ -21,4 +21,7 @@ public class SyntaxException extends QueryException {
 	public SyntaxException(String message, String queryString) {
 		super( message, queryString );
 	}
+	public SyntaxException(String message) {
+		super( message );
+	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/sql/ast/spi/SqlExpressionResolver.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/ast/spi/SqlExpressionResolver.java
@@ -24,15 +24,15 @@ import static java.util.Locale.ROOT;
 /**
  * Resolution of a SqlSelection reference for a given SqlSelectable.  Some
  * SqlSelectable are required to be qualified (e.g. a Column) - this is indicated
- * by the QualifiableSqlSelectable sub-type.  The NonQualifiableSqlSelectable
- * sub-type indicates a SqlSelectable that does not require qualification (e.g. a
+ * by the QualifiableSqlSelectable subtype.  The NonQualifiableSqlSelectable
+ * subtype indicates a SqlSelectable that does not require qualification (e.g. a
  * literal).
  * <p>
  * The point of this contract is to allow "unique-ing" of SqlSelectable references
  * in a query to a single SqlSelection reference - effectively a caching of
  * SqlSelection instances keyed by the SqlSelectable (+ qualifier when applicable)
  * that it refers to.
- *
+ * <p>
  * Note also that the returns can be a specialized Expression represented by
  * {@link org.hibernate.sql.ast.tree.expression.SqlSelectionExpression}
  *

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/query/hql/WindowFunctionTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/query/hql/WindowFunctionTest.java
@@ -10,7 +10,7 @@ import java.util.Date;
 import java.util.List;
 
 import org.hibernate.internal.util.ExceptionHelper;
-import org.hibernate.query.sqm.ParsingException;
+import org.hibernate.query.SyntaxException;
 
 import org.hibernate.testing.orm.domain.StandardDomainModel;
 import org.hibernate.testing.orm.domain.gambit.EntityOfBasics;
@@ -202,9 +202,9 @@ public class WindowFunctionTest {
 			}
 			catch (Exception e) {
 				final Throwable rootCause = ExceptionHelper.getRootCause( e );
-				assertInstanceOf( ParsingException.class, rootCause );
+				assertInstanceOf( SyntaxException.class, rootCause );
 				assertEquals(
-						"Position based order-by is not allowed in OVER or WITHIN GROUP clauses",
+						"Position based 'order by' is not allowed in 'over' or 'within group' clauses",
 						rootCause.getMessage()
 				);
 			}


### PR DESCRIPTION
- we should throw `SyntaxException` for expected conditions
- also, avoid the use of weirdo non-standard hyphenation in error messages