### PR TITLE
followup: HHH-16815

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/query/spi/AbstractQuery.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/spi/AbstractQuery.java
@@ -20,6 +20,7 @@ import jakarta.persistence.FlushModeType;
 import jakarta.persistence.LockModeType;
 import jakarta.persistence.Parameter;
 import jakarta.persistence.TemporalType;
+import jakarta.persistence.metamodel.SingularAttribute;
 
 import org.hibernate.CacheMode;
 import org.hibernate.FlushMode;
@@ -35,8 +36,10 @@ import org.hibernate.jpa.internal.util.FlushModeTypeHelper;
 import org.hibernate.jpa.internal.util.LockModeTypeHelper;
 import org.hibernate.query.BindableType;
 import org.hibernate.query.IllegalQueryOperationException;
+import org.hibernate.query.Query;
 import org.hibernate.query.QueryParameter;
 import org.hibernate.query.ResultListTransformer;
+import org.hibernate.query.SelectionQuery;
 import org.hibernate.query.TupleTransformer;
 import org.hibernate.query.named.NamedQueryMemento;
 
@@ -273,6 +276,21 @@ public abstract class AbstractQuery<R>
 		getSession().checkOpen();
 		super.setHibernateLockMode( LockModeTypeHelper.getLockMode( lockModeType ) );
 		return this;
+	}
+
+	@Override
+	public Query<R> ascending(SingularAttribute<? super R, ?> attribute) {
+		throw new UnsupportedOperationException( "Should be implemented by " + this.getClass().getName() );
+	}
+
+	@Override
+	public Query<R> descending(SingularAttribute<? super R, ?> attribute) {
+		throw new UnsupportedOperationException( "Should be implemented by " + this.getClass().getName() );
+	}
+
+	@Override
+	public Query<R> unordered() {
+		throw new UnsupportedOperationException( "Should be implemented by " + this.getClass().getName() );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/query/spi/AbstractQuery.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/spi/AbstractQuery.java
@@ -37,10 +37,8 @@ import org.hibernate.query.BindableType;
 import org.hibernate.query.IllegalQueryOperationException;
 import org.hibernate.query.QueryParameter;
 import org.hibernate.query.ResultListTransformer;
-import org.hibernate.query.SelectionQuery;
 import org.hibernate.query.TupleTransformer;
 import org.hibernate.query.named.NamedQueryMemento;
-import org.hibernate.query.sqm.SqmExpressible;
 
 import static org.hibernate.LockOptions.WAIT_FOREVER;
 import static org.hibernate.jpa.HibernateHints.HINT_CACHEABLE;
@@ -75,6 +73,7 @@ public abstract class AbstractQuery<R>
 		super( session );
 	}
 
+	@Override
 	protected void applyOptions(NamedQueryMemento memento) {
 		if ( memento.getHints() != null ) {
 			memento.getHints().forEach( this::setHint );
@@ -303,6 +302,7 @@ public abstract class AbstractQuery<R>
 		return AvailableHints.getDefinedHints();
 	}
 
+	@Override
 	protected void collectHints(Map<String, Object> hints) {
 		if ( getQueryOptions().getTimeout() != null ) {
 			hints.put( HINT_TIMEOUT, getQueryOptions().getTimeout() );
@@ -370,13 +370,6 @@ public abstract class AbstractQuery<R>
 	public QueryImplementor<R> setParameter(String name, Object value) {
 		super.setParameter( name, value );
 		return this;
-	}
-
-	private boolean isInstance(BindableType<?> parameterType, Object value) {
-		final SqmExpressible<?> sqmExpressible = parameterType.resolveExpressible( getSession().getFactory() );
-		assert sqmExpressible != null;
-
-		return sqmExpressible.getExpressibleJavaType().isInstance( value );
 	}
 
 	@Override
@@ -447,26 +440,6 @@ public abstract class AbstractQuery<R>
 		super.setParameter( parameter, value );
 		return this;
 	}
-
-	private <P> void setParameter(Parameter<P> parameter, P value, BindableType<P> type) {
-		if ( parameter instanceof QueryParameter ) {
-			setParameter( (QueryParameter<P>) parameter, value, type );
-		}
-		else if ( value == null ) {
-			locateBinding( parameter ).setBindValue( null, type );
-		}
-		else if ( value instanceof Collection ) {
-			//TODO: this looks wrong to me: how can value be both a P and a (Collection<P>)?
-			locateBinding( parameter ).setBindValues( (Collection<P>) value );
-		}
-		else {
-			locateBinding( parameter ).setBindValue( value, type );
-		}
-	}
-
-
-
-
 
 	// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 	// Parameter list


### PR DESCRIPTION
This is a small follow-up on https://hibernate.atlassian.net/browse/HHH-16815

In Hibernate Search, we are using the `AbstractQuery` SPI. It would be easier for us to support both 6.2 and 6.3 at the same time if `AbstractQuery` (or `AbstractSelectionQuery`) would implement the new sorting methods even if that's just throwing an unsupported exception 

https://ci.hibernate.org/blue/organizations/jenkins/hibernate-search-dependency-update/detail/main/111/pipeline/222/
```
[ERROR] /mnt/jenkins-workdir/workspace/te-search-dependency-update_main/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/search/query/impl/HibernateOrmSearchQueryAdapter.java:[53,13] error: HibernateOrmSearchQueryAdapter is not abstract and does not override abstract method unordered() in Query
[ERROR]   where R is a type-variable:
[ERROR]     R extends Object declared in class HibernateOrmSearchQueryAdapter
```

cc: @yrodiere 