### PR TITLE
HHH-16819: Changed JAKARTA_JPA_GROUP_PREFIX to correct value

### DIFF
--- a/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/CockroachLegacyDialect.java
+++ b/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/CockroachLegacyDialect.java
@@ -1038,7 +1038,7 @@ public class CockroachLegacyDialect extends Dialect {
 
 	@Override
 	public FunctionalDependencyAnalysisSupport getFunctionalDependencyAnalysisSupport() {
-		return FunctionalDependencyAnalysisSupportImpl.TABLE_GROUP_AND_CONSTANTS;
+		return FunctionalDependencyAnalysisSupportImpl.TABLE_REFERENCE;
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/beanvalidation/GroupsPerOperation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/beanvalidation/GroupsPerOperation.java
@@ -22,7 +22,7 @@ import jakarta.validation.groups.Default;
  */
 public class GroupsPerOperation {
 	private static final String JPA_GROUP_PREFIX = "javax.persistence.validation.group.";
-	private static final String JAKARTA_JPA_GROUP_PREFIX = "javax.persistence.validation.group.";
+	private static final String JAKARTA_JPA_GROUP_PREFIX = "jakarta.persistence.validation.group.";
 	private static final String HIBERNATE_GROUP_PREFIX = "org.hibernate.validator.group.";
 
 	private static final Class<?>[] DEFAULT_GROUPS = new Class<?>[] { Default.class };

--- a/hibernate-core/src/main/java/org/hibernate/boot/model/TypeDefinition.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/TypeDefinition.java
@@ -227,8 +227,7 @@ public class TypeDefinition implements Serializable {
 			return createBasicTypeResolution( legacyType, typeImplementorClass, indicators, typeConfiguration );
 		}
 
-		if ( indicators.getEnumeratedType() != null ) {
-			assert typeImplementorClass.isInterface();
+		if ( typeImplementorClass.isInterface() ) {
 			return createBasicTypeResolution( new JavaObjectType(), typeImplementorClass, indicators, typeConfiguration );
 		}
 

--- a/hibernate-core/src/main/java/org/hibernate/dialect/CockroachDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/CockroachDialect.java
@@ -990,7 +990,7 @@ public class CockroachDialect extends Dialect {
 
 	@Override
 	public FunctionalDependencyAnalysisSupport getFunctionalDependencyAnalysisSupport() {
-		return FunctionalDependencyAnalysisSupportImpl.TABLE_GROUP_AND_CONSTANTS;
+		return FunctionalDependencyAnalysisSupportImpl.TABLE_REFERENCE;
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/dialect/TiDBDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/TiDBDialect.java
@@ -157,4 +157,9 @@ public class TiDBDialect extends MySQLDialect {
 		Duration duration = Duration.ofMillis( timeoutInMilliseconds );
 		return duration.getSeconds();
 	}
+
+	@Override
+	public FunctionalDependencyAnalysisSupport getFunctionalDependencyAnalysisSupport() {
+		return FunctionalDependencyAnalysisSupportImpl.TABLE_REFERENCE;
+	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/internal/SqmJdbcExecutionContextAdapter.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/internal/SqmJdbcExecutionContextAdapter.java
@@ -70,4 +70,8 @@ public class SqmJdbcExecutionContextAdapter extends BaseExecutionContext {
 		return true;
 	}
 
+	@Override
+	public boolean upgradeLocks() {
+		return true;
+	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/sql/exec/spi/ExecutionContext.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/exec/spi/ExecutionContext.java
@@ -97,4 +97,12 @@ public interface ExecutionContext {
 		return false;
 	}
 
+	/**
+	 * Does this query return objects that might be already cached
+	 * by the session, whose lock mode may need upgrading
+	 */
+	default boolean upgradeLocks(){
+		return false;
+	}
+
 }

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/entity/AbstractEntityInitializer.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/entity/AbstractEntityInitializer.java
@@ -557,7 +557,7 @@ public abstract class AbstractEntityInitializer extends AbstractFetchParentAcces
 	}
 
 	private void upgradeLockMode(RowProcessingState rowProcessingState) {
-		if ( lockMode != LockMode.NONE ) {
+		if ( lockMode != LockMode.NONE && rowProcessingState.upgradeLocks() ) {
 			final EntityEntry entry =
 					rowProcessingState.getSession().getPersistenceContextInternal()
 							.getEntry( entityInstance );

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/internal/RowProcessingStateStandardImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/internal/RowProcessingStateStandardImpl.java
@@ -196,4 +196,9 @@ public class RowProcessingStateStandardImpl extends BaseExecutionContext impleme
 	public boolean hasCollectionInitializers() {
 		return this.initializers.hasCollectionInitializers();
 	}
+
+	@Override
+	public boolean upgradeLocks() {
+		return executionContext.upgradeLocks();
+	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/tuple/entity/EntityMetamodel.java
+++ b/hibernate-core/src/main/java/org/hibernate/tuple/entity/EntityMetamodel.java
@@ -401,9 +401,9 @@ public class EntityMetamodel implements Serializable {
 
 		lazy = persistentClass.isLazy() && (
 				// TODO: this disables laziness even in non-pojo entity modes:
-				!persistentClass.hasPojoRepresentation() ||
-				!isFinalClass( persistentClass.getProxyInterface() )
-		);
+				!persistentClass.hasPojoRepresentation() || !isFinalClass( persistentClass.getProxyInterface() ) )
+				|| bytecodeEnhancementMetadata.isEnhancedForLazyLoading();
+
 		mutable = persistentClass.isMutable();
 		if ( persistentClass.isAbstract() == null ) {
 			// legacy behavior (with no abstract attribute specified)

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/generics/MappedSuperclassTemporalAccessorTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/generics/MappedSuperclassTemporalAccessorTest.java
@@ -1,0 +1,128 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html
+ */
+package org.hibernate.orm.test.annotations.generics;
+
+import java.io.Serializable;
+import java.time.LocalDateTime;
+import java.time.temporal.TemporalAccessor;
+
+import org.hibernate.query.criteria.JpaPath;
+
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.Jira;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.MappedSuperclass;
+import jakarta.persistence.criteria.CriteriaBuilder;
+import jakarta.persistence.criteria.CriteriaQuery;
+import jakarta.persistence.criteria.Path;
+import jakarta.persistence.criteria.Root;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Marco Belladelli
+ */
+@SessionFactory
+@DomainModel( annotatedClasses = {
+		MappedSuperclassTemporalAccessorTest.AbstractSuperclass.class,
+		MappedSuperclassTemporalAccessorTest.TestEntity.class,
+} )
+@Jira( "https://hibernate.atlassian.net/browse/HHH-16784" )
+public class MappedSuperclassTemporalAccessorTest {
+	@BeforeAll
+	public void setUp(SessionFactoryScope scope) {
+		scope.inTransaction( session -> session.persist( new TestEntity(
+				1L,
+				"Marco",
+				LocalDateTime.of( 2023, 6, 16, 11, 41 )
+		) ) );
+	}
+
+	@AfterAll
+	public void tearDown(SessionFactoryScope scope) {
+		scope.inTransaction( session -> session.createMutationQuery( "delete from TestEntity" ).executeUpdate() );
+	}
+
+	@Test
+	public void testGenericTemporalAccessorPath(SessionFactoryScope scope) {
+		scope.inTransaction( session -> {
+			final CriteriaBuilder cb = session.getCriteriaBuilder();
+			final CriteriaQuery<Object> cq = cb.createQuery( Object.class );
+			final Root<TestEntity> root = cq.from( TestEntity.class );
+			final Path<Object> createTime = root.get( "createTime" );
+			assertThat( createTime.getModel() ).isSameAs( root.getModel().getAttribute( "createTime" ) );
+			assertThat( ( (JpaPath<?>) createTime ).getResolvedModel()
+								.getBindableJavaType() ).isEqualTo( LocalDateTime.class );
+			final Object result = session.createQuery( cq.select( createTime ) ).getSingleResult();
+			assertThat( result ).isEqualTo( LocalDateTime.of( 2023, 6, 16, 11, 41 ) );
+		} );
+	}
+
+	@Test
+	public void testGenericSerializablePath(SessionFactoryScope scope) {
+		scope.inTransaction( session -> {
+			final CriteriaBuilder cb = session.getCriteriaBuilder();
+			final CriteriaQuery<Object> cq = cb.createQuery( Object.class );
+			final Root<TestEntity> root = cq.from( TestEntity.class );
+			final Path<Object> id = root.get( "id" );
+			assertThat( id.getModel() ).isSameAs( root.getModel().getAttribute( "id" ) );
+			assertThat( ( (JpaPath<?>) id ).getResolvedModel()
+								.getBindableJavaType() ).isEqualTo( Long.class );
+			final Object result = session.createQuery( cq.select( id ) ).getSingleResult();
+			assertThat( result ).isEqualTo( 1L );
+		} );
+	}
+
+	@Test
+	public void testGenericObjectPath(SessionFactoryScope scope) {
+		scope.inTransaction( session -> {
+			final CriteriaBuilder cb = session.getCriteriaBuilder();
+			final CriteriaQuery<Object> cq = cb.createQuery( Object.class );
+			final Root<TestEntity> root = cq.from( TestEntity.class );
+			final Path<Object> createUser = root.get( "createUser" );
+			assertThat( createUser.getModel() ).isSameAs( root.getModel().getAttribute( "createUser" ) );
+			assertThat( ( (JpaPath<?>) createUser ).getResolvedModel()
+								.getBindableJavaType() ).isEqualTo( String.class );
+			final Object result = session.createQuery( cq.select( createUser ) ).getSingleResult();
+			assertThat( result ).isEqualTo( "Marco" );
+		} );
+	}
+
+	@MappedSuperclass
+	public static abstract class AbstractSuperclass<I extends Serializable, U, T extends TemporalAccessor> {
+		@Id
+		private I id;
+		private U createUser;
+		private T createTime;
+
+		public AbstractSuperclass() {
+		}
+
+		public AbstractSuperclass(I id, U createUser, T createTime) {
+			this.id = id;
+			this.createUser = createUser;
+			this.createTime = createTime;
+		}
+	}
+
+	@Entity( name = "TestEntity" )
+	public static class TestEntity extends AbstractSuperclass<Long, String, LocalDateTime> {
+		public TestEntity() {
+		}
+
+		public TestEntity(Long id, String createUser, LocalDateTime createTime) {
+			super( id, createUser, createTime );
+		}
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/cache/AbstractManyToOneNoProxyTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/cache/AbstractManyToOneNoProxyTest.java
@@ -1,0 +1,215 @@
+package org.hibernate.orm.test.bytecode.enhancement.cache;
+
+import org.hibernate.annotations.BatchSize;
+import org.hibernate.annotations.Cache;
+import org.hibernate.annotations.CacheConcurrencyStrategy;
+import org.hibernate.annotations.Fetch;
+import org.hibernate.annotations.FetchMode;
+import org.hibernate.annotations.Proxy;
+import org.hibernate.cfg.AvailableSettings;
+import org.hibernate.cfg.Configuration;
+
+import org.hibernate.testing.bytecode.enhancement.BytecodeEnhancerRunner;
+import org.hibernate.testing.junit4.BaseCoreFunctionalTestCase;
+import org.hibernate.testing.orm.junit.JiraKey;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import jakarta.persistence.Cacheable;
+import jakarta.persistence.DiscriminatorColumn;
+import jakarta.persistence.DiscriminatorType;
+import jakarta.persistence.DiscriminatorValue;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Inheritance;
+import jakarta.persistence.InheritanceType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+
+@RunWith(BytecodeEnhancerRunner.class)
+@JiraKey("HHH-16473")
+public class AbstractManyToOneNoProxyTest extends BaseCoreFunctionalTestCase {
+
+	private static final String ENTITY_A_NAME = "Alice";
+	private static final String ENTITY_B_NAME = "Bob";
+
+	@Override
+	protected Class<?>[] getAnnotatedClasses() {
+		return new Class[] {
+				Actor.class,
+				User.class,
+				UserGroup.class,
+				ActorGroup.class
+		};
+	}
+
+	@Override
+	protected void configure(Configuration configuration) {
+		configuration.setProperty( AvailableSettings.USE_SECOND_LEVEL_CACHE, "true" );
+	}
+
+	@Before
+	public void setUp() {
+		inTransaction(
+				session -> {
+
+					User user1 = new User();
+					User user2 = new User();
+
+					UserGroup group1 = new UserGroup();
+					UserGroup group2 = new UserGroup();
+					UserGroup group3 = new UserGroup();
+					UserGroup group4 = new UserGroup();
+
+					group1.parent = group2;
+					group2.parent = group3;
+					group3.parent = group4;
+
+					user1.team = group1;
+					user2.team = group1;
+
+					user1.name = ENTITY_A_NAME;
+					user2.name = ENTITY_B_NAME;
+
+					session.persist( user1 );
+					session.persist( user2 );
+					session.persist( group1 );
+					session.persist( group2 );
+					session.persist( group3 );
+					session.persist( group4 );
+				}
+		);
+
+		inTransaction(
+				session -> {
+					session.getSessionFactory().getCache().evictAllRegions();
+				}
+		);
+	}
+
+	@Test
+	public void testSelect() {
+		inTransaction(
+				session -> {
+					User user = session.getReference( User.class, 1 );
+
+					assertThat( user ).isNotNull();
+					assertThat( user.getName() ).isEqualTo( ENTITY_A_NAME );
+				}
+		);
+	}
+
+	@Entity
+	@Table(name = "users")
+	@Proxy(lazy = false)
+	@BatchSize(size = 512)
+	@Inheritance(strategy = InheritanceType.SINGLE_TABLE)
+	@Cacheable
+	@Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
+	@DiscriminatorColumn(discriminatorType = DiscriminatorType.STRING, name = "type")
+	@DiscriminatorValue(value = "ACTOR")
+	public static class Actor {
+		Long id;
+
+		String name;
+
+		public Actor() {
+		}
+
+		@Id
+		@GeneratedValue
+		public Long getId() {
+			return id;
+		}
+
+		public void setId(Long id) {
+			this.id = id;
+		}
+
+		public String getName() {
+			return name;
+		}
+
+		public void setName(String name) {
+			this.name = name;
+		}
+	}
+
+	@Entity
+	@Proxy(lazy = false)
+	@BatchSize(size = 512)
+	@DiscriminatorValue(value = "USER")
+	public static class User extends Actor {
+		ActorGroup team;
+
+		public User() {
+			super();
+		}
+
+		@ManyToOne(fetch = FetchType.LAZY)
+		@JoinColumn(name = "team_id")
+		public ActorGroup getTeam() {
+			return team;
+		}
+
+		public void setTeam(ActorGroup team) {
+			this.team = team;
+		}
+	}
+
+	@Entity
+	@Proxy(lazy = false)
+	@DiscriminatorValue("USERS")
+	@BatchSize(size = 256)
+	public static class UserGroup extends ActorGroup<User> {
+
+		public UserGroup() {
+		}
+	}
+
+	@Entity
+	@Proxy(lazy = false)
+	@Table(name = "actor_group")
+	@Inheritance(strategy = InheritanceType.SINGLE_TABLE)
+	@DiscriminatorColumn(name = "TYPE")
+	@Cacheable
+	@Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
+	@BatchSize(size = 256)
+	public abstract static class ActorGroup<T extends Actor> {
+		Long id;
+
+		ActorGroup<T> parent;
+
+		public ActorGroup() {
+		}
+
+		@Id
+		@GeneratedValue
+		public Long getId() {
+			return id;
+		}
+
+		public void setId(Long id) {
+			this.id = id;
+		}
+
+		@ManyToOne(fetch = FetchType.LAZY, targetEntity = ActorGroup.class)
+		@Fetch(FetchMode.SELECT)
+		@JoinColumn(name = "parent_id")
+		public ActorGroup<T> getParent() {
+			return parent;
+		}
+
+		public void setParent(ActorGroup<T> parent) {
+			this.parent = parent;
+		}
+
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/cache/ManyToOneNoProxyTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/cache/ManyToOneNoProxyTest.java
@@ -1,0 +1,215 @@
+package org.hibernate.orm.test.bytecode.enhancement.cache;
+
+import org.hibernate.annotations.BatchSize;
+import org.hibernate.annotations.Cache;
+import org.hibernate.annotations.CacheConcurrencyStrategy;
+import org.hibernate.annotations.Fetch;
+import org.hibernate.annotations.FetchMode;
+import org.hibernate.annotations.Proxy;
+import org.hibernate.cfg.AvailableSettings;
+import org.hibernate.cfg.Configuration;
+
+import org.hibernate.testing.bytecode.enhancement.BytecodeEnhancerRunner;
+import org.hibernate.testing.junit4.BaseCoreFunctionalTestCase;
+import org.hibernate.testing.orm.junit.JiraKey;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import jakarta.persistence.Cacheable;
+import jakarta.persistence.DiscriminatorColumn;
+import jakarta.persistence.DiscriminatorType;
+import jakarta.persistence.DiscriminatorValue;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Inheritance;
+import jakarta.persistence.InheritanceType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+
+@RunWith(BytecodeEnhancerRunner.class)
+@JiraKey("HHH-16473")
+public class ManyToOneNoProxyTest extends BaseCoreFunctionalTestCase {
+
+	private static final String ENTITY_A_NAME = "Alice";
+	private static final String ENTITY_B_NAME = "Bob";
+
+	@Override
+	protected Class<?>[] getAnnotatedClasses() {
+		return new Class[] {
+				Actor.class,
+				User.class,
+				UserGroup.class,
+				ActorGroup.class
+		};
+	}
+
+	@Override
+	protected void configure(Configuration configuration) {
+		configuration.setProperty( AvailableSettings.USE_SECOND_LEVEL_CACHE, "true" );
+	}
+
+	@Before
+	public void setUp() {
+		inTransaction(
+				session -> {
+
+					User user1 = new User();
+					User user2 = new User();
+
+					UserGroup group1 = new UserGroup();
+					UserGroup group2 = new UserGroup();
+					UserGroup group3 = new UserGroup();
+					UserGroup group4 = new UserGroup();
+
+					group1.parent = group2;
+					group2.parent = group3;
+					group3.parent = group4;
+
+					user1.team = group1;
+					user2.team = group1;
+
+					user1.name = ENTITY_A_NAME;
+					user2.name = ENTITY_B_NAME;
+
+					session.persist( user1 );
+					session.persist( user2 );
+					session.persist( group1 );
+					session.persist( group2 );
+					session.persist( group3 );
+					session.persist( group4 );
+				}
+		);
+
+		inTransaction(
+				session -> {
+					session.getSessionFactory().getCache().evictAllRegions();
+				}
+		);
+	}
+
+	@Test
+	public void testSelect() {
+		inTransaction(
+				session -> {
+					User user = session.getReference( User.class, 1 );
+
+					assertThat( user ).isNotNull();
+					assertThat( user.getName() ).isEqualTo( ENTITY_A_NAME );
+				}
+		);
+	}
+
+	@Entity
+	@Table(name = "users")
+	@Proxy(lazy = false)
+	@BatchSize(size = 512)
+	@Inheritance(strategy = InheritanceType.SINGLE_TABLE)
+	@Cacheable
+	@Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
+	@DiscriminatorColumn(discriminatorType = DiscriminatorType.STRING, name = "type")
+	@DiscriminatorValue(value = "ACTOR")
+	public static class Actor {
+		Long id;
+
+		String name;
+
+		public Actor() {
+		}
+
+		@Id
+		@GeneratedValue
+		public Long getId() {
+			return id;
+		}
+
+		public void setId(Long id) {
+			this.id = id;
+		}
+
+		public String getName() {
+			return name;
+		}
+
+		public void setName(String name) {
+			this.name = name;
+		}
+	}
+
+	@Entity
+	@Proxy(lazy = false)
+	@BatchSize(size = 512)
+	@DiscriminatorValue(value = "USER")
+	public static class User extends Actor {
+		UserGroup team;
+
+		public User() {
+			super();
+		}
+
+		@ManyToOne(fetch = FetchType.LAZY)
+		@JoinColumn(name = "team_id")
+		public UserGroup getTeam() {
+			return team;
+		}
+
+		public void setTeam(UserGroup team) {
+			this.team = team;
+		}
+	}
+
+	@Entity
+	@Proxy(lazy = false)
+	@DiscriminatorValue("USERS")
+	@BatchSize(size = 256)
+	public static class UserGroup extends ActorGroup<User> {
+
+		public UserGroup() {
+		}
+	}
+
+	@Entity
+	@Proxy(lazy = false)
+	@Table(name = "actor_group")
+	@Inheritance(strategy = InheritanceType.SINGLE_TABLE)
+	@DiscriminatorColumn(name = "TYPE")
+	@Cacheable
+	@Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
+	@BatchSize(size = 256)
+	public abstract static class ActorGroup<T extends Actor> {
+		Long id;
+
+		ActorGroup<T> parent;
+
+		public ActorGroup() {
+		}
+
+		@Id
+		@GeneratedValue
+		public Long getId() {
+			return id;
+		}
+
+		public void setId(Long id) {
+			this.id = id;
+		}
+
+		@ManyToOne(fetch = FetchType.LAZY, targetEntity = ActorGroup.class)
+		@Fetch(FetchMode.SELECT)
+		@JoinColumn(name = "parent_id")
+		public ActorGroup<T> getParent() {
+			return parent;
+		}
+
+		public void setParent(ActorGroup<T> parent) {
+			this.parent = parent;
+		}
+
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/lazy/LazyAbstractManyToOneNoProxyTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/lazy/LazyAbstractManyToOneNoProxyTest.java
@@ -1,0 +1,172 @@
+package org.hibernate.orm.test.bytecode.enhancement.lazy;
+
+import org.hibernate.annotations.Proxy;
+import org.hibernate.cfg.Configuration;
+
+import org.hibernate.testing.bytecode.enhancement.BytecodeEnhancerRunner;
+import org.hibernate.testing.jdbc.SQLStatementInspector;
+import org.hibernate.testing.junit4.BaseCoreFunctionalTestCase;
+import org.hibernate.testing.orm.junit.JiraKey;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import jakarta.persistence.DiscriminatorColumn;
+import jakarta.persistence.DiscriminatorValue;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Inheritance;
+import jakarta.persistence.InheritanceType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+@RunWith(BytecodeEnhancerRunner.class)
+@JiraKey("HHH-16794")
+public class LazyAbstractManyToOneNoProxyTest extends BaseCoreFunctionalTestCase {
+
+	private static final String USER_1_NAME = "Andrea";
+	private static final String USER_2_NAME = "Fab";
+	private static final String USER_GROUP_1_NAME = "group1";
+	private static final String USER_GROUP_2_NAME = "group2";
+
+	@Override
+	protected Class<?>[] getAnnotatedClasses() {
+		return new Class[] {
+				User.class,
+				UserGroup.class,
+		};
+	}
+
+	@Override
+	protected void afterConfigurationBuilt(Configuration configuration) {
+		super.afterConfigurationBuilt( configuration );
+		configuration.setStatementInspector( new SQLStatementInspector() );
+	}
+
+	SQLStatementInspector statementInspector() {
+		return (SQLStatementInspector) sessionFactory().getSessionFactoryOptions().getStatementInspector();
+	}
+
+	@Before
+	public void setUp() {
+		inTransaction(
+				session -> {
+					UserGroup group1 = new UserGroup( 1l, USER_GROUP_1_NAME );
+					UserGroup group2 = new UserGroup( 2l, USER_GROUP_2_NAME );
+
+					User user1 = new User( 1l, USER_1_NAME, group1 );
+					User user2 = new User( 2l, USER_2_NAME, group2 );
+
+					session.persist( user1 );
+					session.persist( user2 );
+					session.persist( group1 );
+					session.persist( group2 );
+				}
+		);
+	}
+
+	@Test
+	public void testSelect() {
+		inTransaction(
+				session -> {
+					SQLStatementInspector statementInspector = statementInspector();
+					statementInspector.clear();
+
+					User user = session.getReference( User.class, 1 );
+
+					assertThat( user ).isNotNull();
+					assertThat( user.getName() ).isEqualTo( USER_1_NAME );
+
+					// The User#team type has subclasses so even if it is lazy we need to initialize it because we do not know
+					// the real type and Proxy creation is disabled
+					assertThat( statementInspector.getSqlQueries().size() ).isEqualTo( 2 );
+
+					statementInspector.clear();
+
+					ActorGroup team = user.getTeam();
+					assertThat( team ).isInstanceOf( UserGroup.class );
+					UserGroup userGroup = (UserGroup) team;
+					assertThat( userGroup.getName() ).isEqualTo( USER_GROUP_1_NAME );
+					assertThat( statementInspector.getSqlQueries().size() ).isEqualTo( 0 );
+				}
+		);
+	}
+
+	@Entity
+	@Proxy(lazy = false)
+	public static class User {
+		@Id
+		Long id;
+
+		String name;
+
+		@ManyToOne(fetch = FetchType.LAZY)
+		@JoinColumn(name = "team_id")
+		ActorGroup team;
+
+		public User() {
+		}
+
+		public User(Long id, String name, UserGroup team) {
+			this.id = id;
+			this.name = name;
+			this.team = team;
+		}
+
+		public Long getId() {
+			return id;
+		}
+
+		public String getName() {
+			return name;
+		}
+
+		public ActorGroup getTeam() {
+			return team;
+		}
+	}
+
+	@Entity
+	@Inheritance(strategy = InheritanceType.SINGLE_TABLE)
+	@DiscriminatorColumn(name = "TYPE")
+	@Proxy(lazy = false)
+	public abstract static class ActorGroup {
+		@Id
+		Long id;
+
+		public ActorGroup() {
+		}
+
+		public ActorGroup(Long id) {
+			this.id = id;
+		}
+	}
+
+	@Entity
+	@Proxy(lazy = false)
+	@DiscriminatorValue("USERS")
+	public static class UserGroup extends ActorGroup {
+
+		String name;
+
+		public UserGroup() {
+		}
+
+		public UserGroup(Long id, String name) {
+			super( id );
+			this.name = name;
+		}
+
+		public Long getId() {
+			return id;
+		}
+
+		public String getName() {
+			return name;
+		}
+	}
+
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/lazy/LazyManyToOneNoProxyTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/lazy/LazyManyToOneNoProxyTest.java
@@ -1,0 +1,150 @@
+package org.hibernate.orm.test.bytecode.enhancement.lazy;
+
+import org.hibernate.annotations.Proxy;
+import org.hibernate.cfg.Configuration;
+
+import org.hibernate.testing.bytecode.enhancement.BytecodeEnhancerRunner;
+import org.hibernate.testing.jdbc.SQLStatementInspector;
+import org.hibernate.testing.junit4.BaseCoreFunctionalTestCase;
+import org.hibernate.testing.orm.junit.JiraKey;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+@RunWith(BytecodeEnhancerRunner.class)
+@JiraKey("HHH-16794")
+public class LazyManyToOneNoProxyTest extends BaseCoreFunctionalTestCase {
+
+	private static final String USER_1_NAME = "Andrea";
+	private static final String USER_2_NAME = "Fab";
+	private static final String USER_GROUP_1_NAME = "group1";
+	private static final String USER_GROUP_2_NAME = "group2";
+
+	@Override
+	protected Class<?>[] getAnnotatedClasses() {
+		return new Class[] {
+				User.class,
+				UserGroup.class,
+		};
+	}
+
+	@Override
+	protected void afterConfigurationBuilt(Configuration configuration) {
+		super.afterConfigurationBuilt( configuration );
+		configuration.setStatementInspector( new SQLStatementInspector() );
+	}
+
+	SQLStatementInspector statementInspector() {
+		return (SQLStatementInspector) sessionFactory().getSessionFactoryOptions().getStatementInspector();
+	}
+
+	@Before
+	public void setUp() {
+		inTransaction(
+				session -> {
+					UserGroup group1 = new UserGroup( 1l, USER_GROUP_1_NAME );
+					UserGroup group2 = new UserGroup( 2l, USER_GROUP_2_NAME );
+
+					User user1 = new User( 1l, USER_1_NAME, group1 );
+					User user2 = new User( 2l, USER_2_NAME, group2 );
+
+					session.persist( user1 );
+					session.persist( user2 );
+					session.persist( group1 );
+					session.persist( group2 );
+				}
+		);
+	}
+
+	@Test
+	public void testSelect() {
+		inTransaction(
+				session -> {
+					SQLStatementInspector statementInspector = statementInspector();
+					statementInspector.clear();
+
+					User user = session.getReference( User.class, 1 );
+
+					assertThat( user ).isNotNull();
+					assertThat( user.getName() ).isEqualTo( USER_1_NAME );
+
+					// User#team is lazy, so it should not be initialized
+					assertThat( statementInspector.getSqlQueries().size() ).isEqualTo( 1 );
+
+					statementInspector.clear();
+
+					UserGroup team = user.getTeam();
+					assertThat( team.getName() ).isEqualTo( USER_GROUP_1_NAME );
+					assertThat( statementInspector.getSqlQueries().size() ).isEqualTo( 1 );
+				}
+		);
+	}
+
+	@Entity
+	@Proxy(lazy = false)
+	public static class User {
+		@Id
+		Long id;
+
+		String name;
+
+		@ManyToOne(fetch = FetchType.LAZY)
+		@JoinColumn(name = "team_id")
+		UserGroup team;
+
+		public User() {
+		}
+
+		public User(Long id, String name, UserGroup team) {
+			this.id = id;
+			this.name = name;
+			this.team = team;
+		}
+
+		public Long getId() {
+			return id;
+		}
+
+		public String getName() {
+			return name;
+		}
+
+		public UserGroup getTeam() {
+			return team;
+		}
+	}
+
+	@Entity
+	@Proxy(lazy = false)
+	public static class UserGroup {
+		@Id
+		Long id;
+
+		String name;
+
+		public UserGroup() {
+		}
+
+		public UserGroup(Long id, String name) {
+			this.id = id;
+			this.name = name;
+		}
+
+		public Long getId() {
+			return id;
+		}
+
+		public String getName() {
+			return name;
+		}
+	}
+
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/locking/OptimisticAndPessimisticLockTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/locking/OptimisticAndPessimisticLockTest.java
@@ -1,0 +1,96 @@
+package org.hibernate.orm.test.locking;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.stream.Stream;
+
+import org.hibernate.LockMode;
+
+import org.hibernate.testing.TestForIssue;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Version;
+
+@DomainModel(annotatedClasses = {
+		OptimisticAndPessimisticLockTest.EntityA.class
+})
+@SessionFactory
+@TestForIssue(jiraKey = "HHH-16461")
+public class OptimisticAndPessimisticLockTest {
+
+	public Stream<LockMode> pessimisticLockModes() {
+		return Stream.of(LockMode.UPGRADE_NOWAIT, LockMode.PESSIMISTIC_WRITE, LockMode.PESSIMISTIC_READ, LockMode.PESSIMISTIC_FORCE_INCREMENT);
+	}
+
+	@ParameterizedTest
+	@MethodSource(value = "pessimisticLockModes")
+	public void upgradeFromOptimisticToPessimisticLock(LockMode pessimisticLockMode, SessionFactoryScope scope) {
+		Integer id = scope.fromTransaction( session -> {
+			EntityA entityA1 = new EntityA();
+			entityA1.setPropertyA( 1 );
+			session.persist( entityA1 );
+			return entityA1.getId();
+		} );
+		scope.inTransaction( session -> {
+			EntityA entityA1 = session.find( EntityA.class, id );
+
+			// Do a concurrent change that will update the @Version property
+			scope.inTransaction( session2 -> {
+				var concurrentEntityA1 = session2.find( EntityA.class, id );
+				concurrentEntityA1.setPropertyA( concurrentEntityA1.getPropertyA() + 1 );
+			} );
+
+			// Refresh the entity with concurrent changes and upgrade the lock
+			session.refresh( entityA1, pessimisticLockMode );
+
+			entityA1.setPropertyA( entityA1.getPropertyA() * 2 );
+		} );
+		scope.inTransaction( session -> {
+			EntityA entityA1 = session.find( EntityA.class, id );
+			assertThat( entityA1.getPropertyA() ).isEqualTo( ( 1 + 1 ) * 2 );
+		} );
+	}
+
+	@Entity(name = "EntityA")
+	public static class EntityA {
+
+		@Id
+		@GeneratedValue
+		Integer id;
+
+		@Version
+		long version;
+
+		int propertyA;
+
+		public EntityA() {
+		}
+
+		public EntityA(Integer id) {
+			this.id = id;
+		}
+
+		public Integer getId() {
+			return id;
+		}
+
+		public long getVersion() {
+			return version;
+		}
+
+		public int getPropertyA() {
+			return propertyA;
+		}
+
+		public void setPropertyA(int propertyA) {
+			this.propertyA = propertyA;
+		}
+	}
+}


### PR DESCRIPTION
The constant JAKARTA_JPA_GROUP_PREFIX is pointing towards “javax.persistence.validation.group.” which is the old value (and the same value as in JPA_GROUP_PREFIX) when it should be pointing towards “jakarta.persistence.validation.group.” according to the user manual ([Hibernate ORM 6.2.5.Final User Guide 1](https://docs.jboss.org/hibernate/orm/6.2/userguide/html_single/Hibernate_User_Guide.html)).