### PR TITLE
HHH-16827 Avoid useless locks in NaturalId second level cache.

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/engine/internal/NaturalIdResolutionsImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/internal/NaturalIdResolutionsImpl.java
@@ -268,7 +268,7 @@ public class NaturalIdResolutionsImpl implements NaturalIdResolutions, Serializa
 
 		switch ( source ) {
 			case LOAD: {
-				if ( CacheHelper.fromSharedCache( s, cacheKey, cacheAccess ) != null ) {
+				if (cacheAccess.contains(cacheKey)) {
 					// prevent identical re-cachings
 					return;
 				}


### PR DESCRIPTION
When populating second-level-cache by concurrent threads and several threads read the same entities annotated with @NaturalIdCache it comes to a lock-escalation. This scenario is described in [HHH-16726](https://hibernate.atlassian.net/browse/HHH-16726)

One of the reasons for the bad performance, is that when verifying if the shared cache already contains the key for the natural-id resolution, the current code calls if ( CacheHelper.fromSharedCache( s, cacheKey, cacheAccess ) != null ) {

 in order to prevent identical re-cachings (NaturalIdResolutionsImpl.java line 251)
This is suboptimal and an overshoot for multiple reasons:

1.  fromSharedCache call does not only verify if the shared cache contains the cacheKey,
    it also tests if the item is readable by comparing session timestamps.
    If the item is found but considered ‘unreadable', then identical re-caching isn’t prevented.
    Even more bad: the re-caching attempted is done in vain: NaturalId items aren’t versioned so existing entries get never overriden.

```
public boolean isWriteable(long txTimestamp, Object newVersion, Comparator versionComparator) { ...

    return version != null && versionComparator.compare( version, newVersion ) < 0;
```

2. fromSharedCache call does return the found and 'readable' item, but we actually just need the information if the key is cached or not.

3. fromSharedCache call does produce unnecessary read-locks in NaturalId-region and as conseguence of the useless re-caching attempts (point 1) also useless write-locks are done with putFromLoad

All this contributes to a huge amount of useless locks in NaturalId cache when it’s get populated. It can avoided by simply calling cacheAccess.contains(cacheKey).

[HHH-16726]: https://hibernate.atlassian.net/browse/HHH-16726?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ