### PR TITLE
HHH-16819: Corrected typo in JAKARTA_JPA_GROUP_PREFIX

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/boot/beanvalidation/GroupsPerOperation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/beanvalidation/GroupsPerOperation.java
@@ -22,7 +22,7 @@ import jakarta.validation.groups.Default;
  */
 public class GroupsPerOperation {
 	private static final String JPA_GROUP_PREFIX = "javax.persistence.validation.group.";
-	private static final String JAKARTA_JPA_GROUP_PREFIX = "javax.persistence.validation.group.";
+	private static final String JAKARTA_JPA_GROUP_PREFIX = "jakarta.persistence.validation.group.";
 	private static final String HIBERNATE_GROUP_PREFIX = "org.hibernate.validator.group.";
 
 	private static final Class<?>[] DEFAULT_GROUPS = new Class<?>[] { Default.class };


### PR DESCRIPTION
The constant JAKARTA_JPA_GROUP_PREFIX is pointing towards “javax.persistence.validation.group.” which is the old value (and the same value as in JPA_GROUP_PREFIX) when it should be pointing towards “jakarta.persistence.validation.group.” according to the user manual ([Hibernate ORM 6.2.5.Final User Guide 1](https://docs.jboss.org/hibernate/orm/6.2/userguide/html_single/Hibernate_User_Guide.html)).

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-16819
<!-- Hibernate GitHub Bot issue links end -->