### PR TITLE
HHH-16516 Do not toLowerCase quoted identifiers

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/boot/model/naming/CamelCaseToUnderscoresNamingStrategy.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/naming/CamelCaseToUnderscoresNamingStrategy.java
@@ -68,7 +68,7 @@ public class CamelCaseToUnderscoresNamingStrategy implements PhysicalNamingStrat
 	 * @return an identifier instance
 	 */
 	protected Identifier getIdentifier(String name, final boolean quoted, final JdbcEnvironment jdbcEnvironment) {
-		if ( isCaseInsensitive( jdbcEnvironment ) ) {
+		if ( !quoted && isCaseInsensitive( jdbcEnvironment ) ) {
 			name = name.toLowerCase( Locale.ROOT );
 		}
 		return new Identifier( name, quoted );


### PR DESCRIPTION
`CamelCaseToUnderscoresNamingStrategy` converts all identifiers to lowercase, but quoted identifiers are generally case-sensitive and should not be converted.

This simple patch prevents calling toLowerCase on quoted Identifiers.