### PR TITLE
HHH-16791 EntitManager#find with IdClass with OffsetDateTime field returns null when Batch is enabled

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/loader/ast/internal/EntityBatchLoaderArrayParam.java
+++ b/hibernate-core/src/main/java/org/hibernate/loader/ast/internal/EntityBatchLoaderArrayParam.java
@@ -8,12 +8,14 @@ package org.hibernate.loader.ast.internal;
 
 import java.lang.reflect.Array;
 import java.util.Arrays;
+import java.util.List;
 import java.util.Locale;
 
 import org.hibernate.LockOptions;
 import org.hibernate.engine.spi.LoadQueryInfluencers;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
+import org.hibernate.internal.util.collections.CollectionHelper;
 import org.hibernate.loader.ast.spi.SqlArrayMultiKeyLoader;
 import org.hibernate.metamodel.mapping.BasicEntityIdentifierMapping;
 import org.hibernate.metamodel.mapping.EntityIdentifierMapping;
@@ -123,7 +125,7 @@ public class EntityBatchLoaderArrayParam<T>
 	}
 
 	@Override
-	protected void initializeEntities(
+	protected List<Object> initializeEntities(
 			Object[] idsToInitialize,
 			Object id,
 			Object entityInstance,
@@ -135,7 +137,7 @@ public class EntityBatchLoaderArrayParam<T>
 					getLoadable().getEntityName(), id, Arrays.toString(idsToInitialize) );
 		}
 
-		LoaderHelper.loadByArrayParameter(
+		List<Object> entities = LoaderHelper.loadByArrayParameter(
 				idsToInitialize,
 				sqlAst,
 				jdbcSelectOperation,
@@ -155,6 +157,7 @@ public class EntityBatchLoaderArrayParam<T>
 				removeBatchLoadableEntityKey( initializedId, getLoadable(), session );
 			}
 		}
+		return entities;
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/loader/ast/internal/EntityBatchLoaderInPredicate.java
+++ b/hibernate-core/src/main/java/org/hibernate/loader/ast/internal/EntityBatchLoaderInPredicate.java
@@ -122,7 +122,7 @@ public class EntityBatchLoaderInPredicate<T>
 	}
 
 	@Override
-	protected void initializeEntities(
+	protected List<Object> initializeEntities(
 			Object[] idsToInitialize,
 			Object pkValue,
 			Object entityInstance,
@@ -145,7 +145,7 @@ public class EntityBatchLoaderInPredicate<T>
 		final BatchFetchQueue batchFetchQueue = session.getPersistenceContextInternal().getBatchFetchQueue();
 		final List<EntityKey> entityKeys = arrayList( sqlBatchSize );
 
-		chunker.processChunks(
+		List<Object> entities = chunker.processChunks(
 				idsToInitialize,
 				sqlBatchSize,
 				(jdbcParameterBindings, session1) -> {
@@ -178,7 +178,7 @@ public class EntityBatchLoaderInPredicate<T>
 								getLoadable().getEntityName(),
 								pkValue,
 								startIndex,
-								startIndex + ( sqlBatchSize -1)
+								startIndex + ( sqlBatchSize - 1 )
 						);
 					}
 				},
@@ -188,119 +188,8 @@ public class EntityBatchLoaderInPredicate<T>
 				},
 				session
 		);
-
-
-
-//		int numberOfIdsLeft = idsToInitialize.length;
-//		int start = 0;
-//		while ( numberOfIdsLeft > 0 ) {
-//			if ( MULTI_KEY_LOAD_DEBUG_ENABLED ) {
-//				MULTI_KEY_LOAD_LOGGER.debugf( "Processing batch-fetch chunk (`%s#%s`) %s - %s", getLoadable().getEntityName(), pkValue, start, start + ( sqlBatchSize -1) );
-//			}
-//			initializeChunk( idsToInitialize, start, pkValue, entityInstance, lockOptions, readOnly, session );
-//
-//			start += sqlBatchSize;
-//			numberOfIdsLeft -= sqlBatchSize;
-//		}
+		return entities;
 	}
-
-//	private void initializeChunk(
-//			Object[] idsToInitialize,
-//			int start,
-//			Object pkValue,
-//			Object entityInstance,
-//			LockOptions lockOptions,
-//			Boolean readOnly,
-//			SharedSessionContractImplementor session) {
-//		initializeChunk(
-//				idsToInitialize,
-//				getLoadable(),
-//				start,
-//				sqlBatchSize,
-//				jdbcParameters,
-//				sqlAst,
-//				jdbcSelectOperation,
-//				pkValue,
-//				entityInstance,
-//				lockOptions,
-//				readOnly,
-//				session
-//		);
-//	}
-
-//	private static void initializeChunk(
-//			Object[] idsToInitialize,
-//			EntityMappingType entityMapping,
-//			int startIndex,
-//			int numberOfKeys,
-//			List<JdbcParameter> jdbcParameters,
-//			SelectStatement sqlAst,
-//			JdbcOperationQuerySelect jdbcSelectOperation,
-//			Object pkValue,
-//			Object entityInstance,
-//			LockOptions lockOptions,
-//			Boolean readOnly,
-//			SharedSessionContractImplementor session) {
-//		final BatchFetchQueue batchFetchQueue = session.getPersistenceContext().getBatchFetchQueue();
-//
-//		final int numberOfJdbcParameters = entityMapping.getIdentifierMapping().getJdbcTypeCount() * numberOfKeys;
-//		final JdbcParameterBindings jdbcParameterBindings = new JdbcParameterBindingsImpl( numberOfJdbcParameters );
-//
-//		final List<EntityKey> entityKeys = arrayList( numberOfKeys );
-//		int bindCount = 0;
-//		for ( int i = 0; i < numberOfKeys; i++ ) {
-//			final int idPosition = i + startIndex;
-//			final Object value;
-//			if ( idPosition >= idsToInitialize.length ) {
-//				value = null;
-//			}
-//			else {
-//				value = idsToInitialize[idPosition];
-//			}
-//			if ( value != null ) {
-//				entityKeys.add( session.generateEntityKey( value, entityMapping.getEntityPersister() ) );
-//			}
-//			bindCount += jdbcParameterBindings.registerParametersForEachJdbcValue(
-//					value,
-//					bindCount,
-//					entityMapping.getIdentifierMapping(),
-//					jdbcParameters,
-//					session
-//			);
-//		}
-//		assert bindCount == jdbcParameters.size();
-//
-//		if ( entityKeys.isEmpty() ) {
-//			// there are no non-null keys in the chunk
-//			return;
-//		}
-//
-//		// Create a SubselectFetch.RegistrationHandler for handling any subselect fetches we encounter here
-//		final SubselectFetch.RegistrationHandler subSelectFetchableKeysHandler = SubselectFetch.createRegistrationHandler(
-//				batchFetchQueue,
-//				sqlAst,
-//				jdbcParameters,
-//				jdbcParameterBindings
-//		);
-//
-//		session.getJdbcServices().getJdbcSelectExecutor().list(
-//				jdbcSelectOperation,
-//				jdbcParameterBindings,
-//				new SingleIdExecutionContext(
-//						pkValue,
-//						entityInstance,
-//						entityMapping.getRootEntityDescriptor(),
-//						readOnly,
-//						lockOptions,
-//						subSelectFetchableKeysHandler,
-//						session
-//				),
-//				RowTransformerStandardImpl.instance(),
-//				ListResultsConsumer.UniqueSemantic.FILTER
-//		);
-//
-//		entityKeys.forEach( batchFetchQueue::removeBatchLoadableEntityKey );
-//	}
 
 	@Override
 	public String toString() {

--- a/hibernate-core/src/main/java/org/hibernate/type/AbstractStandardBasicType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/AbstractStandardBasicType.java
@@ -183,28 +183,39 @@ public abstract class AbstractStandardBasicType<T>
 
 	@Override
 	public final boolean isEqual(Object x, Object y, SessionFactoryImplementor factory) {
-		return isEqual( x, y );
-	}
-
-	@Override
-	@SuppressWarnings("unchecked")
-	public boolean isEqual(Object one, Object another) {
-		if ( one == another ) {
+		if ( x == y ) {
 			return true;
 		}
-		else if ( one == null || another == null ) {
+		else if ( x == null || y == null ) {
 			return false;
 		}
 		else {
 			final AbstractClassJavaType<T> type = this.javaTypeAsAbstractClassJavaType;
 			if ( type != null ) {
 				//Optimize for the most common case: avoid the megamorphic call
-				return type.areEqual( (T) one, (T) another );
+				if ( factory == null ) {
+					return type.areEqual( (T) x, (T) y );
+				}
+				else {
+					return type.areEqual( (T) x, (T) y, factory.getJdbcServices().getDialect() );
+				}
 			}
 			else {
-				return javaType.areEqual( (T) one, (T) another );
+				if ( factory == null ) {
+					return javaType.areEqual( (T) x, (T) y );
+				}
+				else {
+					return javaType.areEqual( (T) x, (T) y, factory.getJdbcServices().getDialect() );
+				}
 			}
 		}
+
+	}
+
+	@Override
+	@SuppressWarnings("unchecked")
+	public boolean isEqual(Object one, Object another) {
+		return isEqual( one, another , null);
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/JavaType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/JavaType.java
@@ -214,6 +214,10 @@ public interface JavaType<T> extends Serializable {
 		return Objects.deepEquals( one, another );
 	}
 
+	default boolean areEqual(T one, T another, Dialect dialect){
+		return Objects.deepEquals( one, another );
+	}
+
 	/**
 	 * Extract a loggable representation of the given value.
 	 *

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/OffsetDateTimeJavaType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/OffsetDateTimeJavaType.java
@@ -24,6 +24,7 @@ import java.util.GregorianCalendar;
 import org.hibernate.dialect.Dialect;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.internal.util.CharSequenceHelper;
+import org.hibernate.type.descriptor.DateTimeUtils;
 import org.hibernate.type.descriptor.WrapperOptions;
 import org.hibernate.type.descriptor.jdbc.JdbcType;
 import org.hibernate.type.descriptor.jdbc.JdbcTypeIndicators;
@@ -71,6 +72,12 @@ public class OffsetDateTimeJavaType extends AbstractTemporalJavaType<OffsetDateT
 	public JdbcType getRecommendedJdbcType(JdbcTypeIndicators stdIndicators) {
 		return stdIndicators.getTypeConfiguration().getJdbcTypeRegistry()
 				.getDescriptor( stdIndicators.getDefaultZonedTimestampSqlType() );
+	}
+
+	@Override
+	public boolean areEqual(OffsetDateTime one, OffsetDateTime another, Dialect dialect) {
+		return DateTimeUtils.roundToDefaultPrecision( one, dialect )
+				.isEqual( DateTimeUtils.roundToDefaultPrecision( another, dialect ) );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/OffsetTimeJavaType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/OffsetTimeJavaType.java
@@ -8,7 +8,6 @@ package org.hibernate.type.descriptor.java;
 
 import java.sql.Time;
 import java.sql.Timestamp;
-import java.sql.Types;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalTime;
@@ -54,6 +53,12 @@ public class OffsetTimeJavaType extends AbstractTemporalJavaType<OffsetTime> {
 	public JdbcType getRecommendedJdbcType(JdbcTypeIndicators stdIndicators) {
 		return stdIndicators.getTypeConfiguration().getJdbcTypeRegistry()
 				.getDescriptor( stdIndicators.getDefaultZonedTimeSqlType() );
+	}
+
+	@Override
+	public boolean areEqual(OffsetTime one, OffsetTime another, Dialect dialect) {
+		return DateTimeUtils.roundToDefaultPrecision( one, dialect )
+				.isEqual( DateTimeUtils.roundToDefaultPrecision( another, dialect ) );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/jdbc/TimestampWithTimeZoneJdbcType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/jdbc/TimestampWithTimeZoneJdbcType.java
@@ -6,6 +6,7 @@
  */
 package org.hibernate.type.descriptor.jdbc;
 
+import org.hibernate.type.descriptor.DateTimeUtils;
 import org.hibernate.type.descriptor.ValueBinder;
 import org.hibernate.type.descriptor.ValueExtractor;
 import org.hibernate.type.descriptor.WrapperOptions;
@@ -78,7 +79,10 @@ public class TimestampWithTimeZoneJdbcType implements JdbcType {
 					int index,
 					WrapperOptions options) throws SQLException {
 				try {
-					final OffsetDateTime dateTime = javaType.unwrap( value, OffsetDateTime.class, options );
+					final OffsetDateTime dateTime = DateTimeUtils.roundToDefaultPrecision(
+							javaType.unwrap( value, OffsetDateTime.class, options ),
+							options.getSession().getJdbcServices().getDialect()
+					);
 					// supposed to be supported in JDBC 4.2
 					st.setObject( index, dateTime, Types.TIMESTAMP_WITH_TIMEZONE );
 				}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/idclass/IdClassWithOffsetDateTimeTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/idclass/IdClassWithOffsetDateTimeTest.java
@@ -1,0 +1,113 @@
+package org.hibernate.orm.test.idclass;
+
+import java.io.Serializable;
+import java.time.OffsetDateTime;
+import java.time.Period;
+import java.time.temporal.ChronoUnit;
+
+import org.hibernate.cfg.AvailableSettings;
+
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.JiraKey;
+import org.hibernate.testing.orm.junit.ServiceRegistry;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.hibernate.testing.orm.junit.Setting;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.IdClass;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+@DomainModel(
+		annotatedClasses = {
+				IdClassWithOffsetDateTimeTest.MyEntity.class
+		}
+)
+@SessionFactory
+@ServiceRegistry(settings = {
+		@Setting( name = AvailableSettings.DEFAULT_BATCH_FETCH_SIZE, value = "2")
+})
+@JiraKey("HHH-16791")
+public class IdClassWithOffsetDateTimeTest {
+
+	private static final Long ID = 1l;
+	private static final Long ID_2 = 2l;
+	private static final OffsetDateTime BOOK_DATE = OffsetDateTime.now();
+	private static final OffsetDateTime BOOK_DATE_2 = OffsetDateTime.now().plus( Period.ofWeeks( 1 ) );
+
+	@BeforeAll
+	public void setUp(SessionFactoryScope scope) {
+		scope.inTransaction(
+				session -> {
+					MyEntity myEntity = new MyEntity( ID, BOOK_DATE, "one" );
+					MyEntity myEntity2 = new MyEntity( ID_2, BOOK_DATE_2, "two" );
+					session.persist( myEntity );
+					session.persist( myEntity2 );
+				}
+		);
+	}
+
+	@Test
+	public void testFind(SessionFactoryScope scope) {
+		scope.inTransaction(
+				session -> {
+					session.getReference( MyEntity.class, new MyEntityKey( ID_2, BOOK_DATE_2 )  );
+					MyEntity myEntity = session.find( MyEntity.class, new MyEntityKey( ID, BOOK_DATE ) );
+					assertThat( myEntity ).isNotNull();
+				}
+		);
+	}
+
+	@Test
+	public void testFind2(SessionFactoryScope scope) {
+		scope.inTransaction(
+				session -> {
+					MyEntity myEntity = session.find( MyEntity.class, new MyEntityKey( ID, BOOK_DATE ) );
+					assertThat( myEntity ).isNotNull();
+				}
+		);
+	}
+
+	@IdClass(MyEntityKey.class)
+	@Entity(name = "MyEntity")
+	public static class MyEntity {
+
+		@Id
+		private Long id;
+
+		@Id
+		@Column
+		private OffsetDateTime bookDate;
+
+		private String data;
+
+		public MyEntity() {
+		}
+
+		public MyEntity(Long id, OffsetDateTime bookDate, String data) {
+			this.id = id;
+			this.bookDate = bookDate;
+			this.data = data;
+		}
+	}
+
+	public static class MyEntityKey implements Serializable {
+
+		private Long id;
+
+		private OffsetDateTime bookDate;
+
+		public MyEntityKey() {
+		}
+
+		public MyEntityKey(Long id, OffsetDateTime bookDate) {
+			this.id = id;
+			this.bookDate = bookDate;
+		}
+	}
+}


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-16791

when we execute session.find( MyEntity.class, new MyEntityKey( ID, BOOK_DATE ) );
with batch we first load all the entities and then we search in the the PC the one corresponding to the EntityKey of the find method in order to return it.
What happens is that the value of the OffsetDateTime (it seems that from Java 13  the precision is nano and not milliseconds) retrieved from the DB is not equal to the one used in the find method so we are not able to locate the EntityKey in the PC (different hashcode) and we return null.