### PR TITLE
HHH-16602, HHH-16701 ActionQueue changes for collection removals of orphaned entities

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/action/internal/CollectionRemoveAction.java
+++ b/hibernate-core/src/main/java/org/hibernate/action/internal/CollectionRemoveAction.java
@@ -21,7 +21,7 @@ import org.hibernate.stat.spi.StatisticsImplementor;
 /**
  * The action for removing a collection
  */
-public final class CollectionRemoveAction extends CollectionAction {
+public class CollectionRemoveAction extends CollectionAction {
 
 	private final Object affectedOwner;
 	private final boolean emptySnapshot;

--- a/hibernate-core/src/main/java/org/hibernate/action/internal/OrphanCollectionRemoveAction.java
+++ b/hibernate-core/src/main/java/org/hibernate/action/internal/OrphanCollectionRemoveAction.java
@@ -1,0 +1,26 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html
+ */
+package org.hibernate.action.internal;
+
+import org.hibernate.collection.spi.PersistentCollection;
+import org.hibernate.event.spi.EventSource;
+import org.hibernate.persister.collection.CollectionPersister;
+
+/**
+ * @author Marco Belladelli
+ */
+public class OrphanCollectionRemoveAction extends CollectionRemoveAction {
+
+	public OrphanCollectionRemoveAction(
+			PersistentCollection<?> collection,
+			CollectionPersister persister,
+			Object id,
+			boolean emptySnapshot,
+			EventSource session) {
+		super( collection, persister, id, emptySnapshot, session );
+	}
+}

--- a/hibernate-core/src/main/java/org/hibernate/action/internal/OrphanRemovalAction.java
+++ b/hibernate-core/src/main/java/org/hibernate/action/internal/OrphanRemovalAction.java
@@ -6,8 +6,15 @@
  */
 package org.hibernate.action.internal;
 
+import org.hibernate.collection.spi.PersistentCollection;
+import org.hibernate.engine.spi.CollectionEntry;
+import org.hibernate.engine.spi.CollectionKey;
 import org.hibernate.event.spi.EventSource;
+import org.hibernate.persister.collection.CollectionPersister;
 import org.hibernate.persister.entity.EntityPersister;
+import org.hibernate.type.CollectionType;
+import org.hibernate.type.CompositeType;
+import org.hibernate.type.Type;
 
 public final class OrphanRemovalAction extends EntityDeleteAction {
 
@@ -15,5 +22,49 @@ public final class OrphanRemovalAction extends EntityDeleteAction {
 			Object id, Object[] state, Object version, Object instance,
 			EntityPersister persister, boolean isCascadeDeleteEnabled, EventSource session) {
 		super( id, state, version, instance, persister, isCascadeDeleteEnabled, session );
+		markOwnedCollectionsForEarlyRemoval( instance, persister, session );
+	}
+
+	private void markOwnedCollectionsForEarlyRemoval(Object owner, EntityPersister persister, EventSource session) {
+		if ( persister.hasOwnedCollections() ) {
+			for ( Type type : persister.getPropertyTypes() ) {
+				deleteOwnedCollections( type, owner, session );
+			}
+		}
+	}
+
+	private static void deleteOwnedCollections(Type type, Object owner, EventSource session) {
+		if ( type.isCollectionType() ) {
+			final CollectionType collectionType = (CollectionType) type;
+			final String role = collectionType.getRole();
+			final CollectionPersister collectionPersister = session.getFactory()
+					.getMappingMetamodel()
+					.getCollectionDescriptor( role );
+			if ( !collectionPersister.isInverse() ) {
+				final CollectionKey collectionKey = new CollectionKey(
+						collectionPersister,
+						collectionType.getKeyOfOwner( owner, session )
+				);
+				final PersistentCollection<?> coll = session.getPersistenceContext().getCollection( collectionKey );
+				final CollectionEntry ce = session.getPersistenceContextInternal().getCollectionEntry( coll );
+				session.getInterceptor().onCollectionRemove( coll, ce.getLoadedKey() );
+				session.getActionQueue().addAction(
+						new OrphanCollectionRemoveAction(
+								coll,
+								ce.getLoadedPersister(),
+								ce.getLoadedKey(),
+								ce.isSnapshotEmpty( coll ),
+								session
+						)
+				);
+				ce.setIgnore( true );
+			}
+		}
+		else if ( type.isComponentType() ) {
+			final Type[] subtypes = ( (CompositeType) type ).getSubtypes();
+			for ( Type subtype : subtypes ) {
+				deleteOwnedCollections( subtype, owner, session );
+			}
+		}
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/engine/spi/CollectionEntry.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/spi/CollectionEntry.java
@@ -337,6 +337,10 @@ public final class CollectionEntry implements Serializable {
 		return ignore;
 	}
 
+	public void setIgnore(boolean ignore) {
+		this.ignore = ignore;
+	}
+
 	public CollectionPersister getCurrentPersister() {
 		return currentPersister;
 	}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/beanvalidation/LazyCollectionValidationTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/beanvalidation/LazyCollectionValidationTest.java
@@ -1,0 +1,226 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.orm.test.annotations.beanvalidation;
+
+import java.util.EnumSet;
+import java.util.Set;
+
+import org.hibernate.testing.orm.junit.EntityManagerFactoryScope;
+import org.hibernate.testing.orm.junit.JiraKey;
+import org.hibernate.testing.orm.junit.Jpa;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Test;
+
+import jakarta.persistence.ElementCollection;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+import jakarta.persistence.ValidationMode;
+import jakarta.validation.constraints.NotEmpty;
+
+/**
+ * @author Jan Schatteman
+ */
+@Jpa( annotatedClasses = {
+		LazyCollectionValidationTest.UserWithEnumRoles.class,
+		LazyCollectionValidationTest.UserWithStringRoles.class,
+		LazyCollectionValidationTest.StringUserRole.class,
+		LazyCollectionValidationTest.EnumUserRole.class
+}, validationMode = ValidationMode.AUTO )
+@JiraKey( value = "HHH-16701" )
+public class LazyCollectionValidationTest {
+	@AfterAll
+	public void cleanup(EntityManagerFactoryScope scope) {
+		scope.inTransaction( entityManager -> {
+			entityManager.createQuery( "delete from enumuser" ).executeUpdate();
+			entityManager.createQuery( "delete from stringuser" ).executeUpdate();
+			entityManager.createQuery( "delete from stringuserrole" ).executeUpdate();
+		} );
+	}
+
+	@Test
+	public void testWithEnumCollection(EntityManagerFactoryScope scope) {
+		scope.inTransaction( entityManager -> {
+			UserWithEnumRoles a = new UserWithEnumRoles();
+			a.setUserRoles( EnumSet.of( EnumUserRole.USER ) );
+			entityManager.persist( a );
+			UserWithEnumRoles user = new UserWithEnumRoles();
+			user.setUserRoles( EnumSet.of( EnumUserRole.USER ) );
+			user.setCreatedBy( a );
+			entityManager.persist( user );
+		} );
+		scope.inTransaction( entityManager -> {
+			for ( UserWithEnumRoles user : entityManager.createQuery(
+					"Select u from enumuser u",
+					UserWithEnumRoles.class
+			).getResultList() ) {
+				entityManager.remove( user );
+			}
+		} );
+	}
+
+	@Test
+	public void testWithNormalCollection(EntityManagerFactoryScope scope) {
+		final Set<StringUserRole> bosses = scope.fromTransaction( entityManager -> {
+			StringUserRole role1 = new StringUserRole( 1, "Boss" );
+			StringUserRole role2 = new StringUserRole( 2, "SuperBoss" );
+			entityManager.persist( role1 );
+			entityManager.persist( role2 );
+			return Set.of( role1, role2 );
+		} );
+		final Set<StringUserRole> dorks = scope.fromTransaction( entityManager -> {
+			StringUserRole role1 = new StringUserRole( 3, "Dork" );
+			StringUserRole role2 = new StringUserRole( 4, "SuperDork" );
+			entityManager.persist( role1 );
+			entityManager.persist( role2 );
+			return Set.of( role1, role2 );
+		} );
+		scope.inTransaction( entityManager -> {
+			UserWithStringRoles a = new UserWithStringRoles();
+			a.setUserRoles( bosses );
+			entityManager.persist( a );
+
+			UserWithStringRoles userWithEnumRoles = new UserWithStringRoles();
+			userWithEnumRoles.setUserRoles( dorks );
+			userWithEnumRoles.setCreatedBy( a );
+			entityManager.persist( userWithEnumRoles );
+		} );
+		scope.inTransaction( entityManager -> {
+			for ( UserWithStringRoles userWithStringRoles : entityManager.createQuery(
+					"Select u from stringuser u",
+					UserWithStringRoles.class
+			).getResultList() ) {
+				entityManager.remove( userWithStringRoles );
+			}
+		} );
+	}
+
+	@Entity( name = "enumuser" )
+	@Table( name = "enum_user" )
+	public static class UserWithEnumRoles {
+		@Id
+		@GeneratedValue( strategy = GenerationType.AUTO )
+		private long id;
+
+		@ManyToOne( fetch = FetchType.LAZY )
+		private UserWithEnumRoles createdBy;
+
+		@Enumerated( EnumType.STRING )
+		@ElementCollection( fetch = FetchType.LAZY )
+		@NotEmpty
+		private Set<EnumUserRole> userRoles;
+
+		public UserWithEnumRoles() {
+		}
+
+		public long getId() {
+			return id;
+		}
+
+		public void setId(long id) {
+			this.id = id;
+		}
+
+		public UserWithEnumRoles getCreatedBy() {
+			return createdBy;
+		}
+
+		public void setCreatedBy(UserWithEnumRoles createdBy) {
+			this.createdBy = createdBy;
+		}
+
+		public Set<EnumUserRole> getUserRoles() {
+			return userRoles;
+		}
+
+		public void setUserRoles(Set<EnumUserRole> userRoles) {
+			this.userRoles = userRoles;
+		}
+	}
+
+	@Entity( name = "stringuser" )
+	@Table( name = "string_user" )
+	public static class UserWithStringRoles {
+		private long id;
+
+		private UserWithStringRoles createdBy;
+
+		private Set<StringUserRole> userRoles;
+
+		@Id
+		@GeneratedValue( strategy = GenerationType.AUTO )
+		public long getId() {
+			return id;
+		}
+
+		public void setId(long id) {
+			this.id = id;
+		}
+
+		@ManyToOne( fetch = FetchType.LAZY )
+		public UserWithStringRoles getCreatedBy() {
+			return createdBy;
+		}
+
+		public void setCreatedBy(UserWithStringRoles createdBy) {
+			this.createdBy = createdBy;
+		}
+
+		@OneToMany( fetch = FetchType.LAZY )
+		@NotEmpty
+		public Set<StringUserRole> getUserRoles() {
+			return userRoles;
+		}
+
+		public void setUserRoles(Set<StringUserRole> userRoles) {
+			this.userRoles = userRoles;
+		}
+	}
+
+	public enum EnumUserRole {
+		USER, ADMIN, OPERATOR
+	}
+
+	@Entity( name = "stringuserrole" )
+	@Table( name = "string_user_role" )
+	public static class StringUserRole {
+		@Id
+		private long id;
+		private String role;
+
+		public StringUserRole() {
+		}
+
+		public StringUserRole(long id, String role) {
+			this.id = id;
+			this.role = role;
+		}
+
+		public long getId() {
+			return id;
+		}
+
+		public void setId(long id) {
+			this.id = id;
+		}
+
+		public String getRole() {
+			return role;
+		}
+
+		public void setRole(String role) {
+			this.role = role;
+		}
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/flush/LazyCollectionInitalizationPreUpdateTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/flush/LazyCollectionInitalizationPreUpdateTest.java
@@ -1,0 +1,136 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html
+ */
+package org.hibernate.orm.test.flush;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import org.hibernate.Hibernate;
+import org.hibernate.event.spi.EventType;
+import org.hibernate.event.spi.PreUpdateEvent;
+import org.hibernate.event.spi.PreUpdateEventListener;
+
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.Jira;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Marco Belladelli
+ */
+@SessionFactory
+@DomainModel( annotatedClasses = {
+		LazyCollectionInitalizationPreUpdateTest.TreeNode.class,
+		LazyCollectionInitalizationPreUpdateTest.ReferencedEntity.class,
+} )
+@Jira( "https://hibernate.atlassian.net/browse/HHH-16602" )
+public class LazyCollectionInitalizationPreUpdateTest {
+	@BeforeAll
+	public void setUp(SessionFactoryScope scope) {
+		scope.inTransaction( session -> {
+			final TreeNode first = new TreeNode( 1L, null );
+			session.persist( first );
+			final TreeNode second = new TreeNode( 2L, first );
+			final ReferencedEntity referenced = new ReferencedEntity( "referenced" );
+			session.persist( referenced );
+			second.getSomeSet().add( referenced );
+			session.persist( second );
+		} );
+	}
+
+	@AfterAll
+	public void tearDown(SessionFactoryScope scope) {
+		scope.inTransaction( session -> session.createMutationQuery( "delete from ReferencedEntity" ).executeUpdate() );
+	}
+
+	@Test
+	public void test(SessionFactoryScope scope) {
+		scope.getSessionFactory().getEventEngine().getListenerRegistry().appendListeners(
+				EventType.PRE_UPDATE,
+				Listener.class
+		);
+		scope.inTransaction( session -> {
+			final TreeNode first = session.byId( TreeNode.class ).load( 1L );
+			final TreeNode second = session.byId( TreeNode.class ).load( 2L );
+			session.remove( first );
+			session.remove( second );
+		} );
+	}
+
+	@Entity( name = "TreeNode" )
+	public static class TreeNode {
+		@Id
+		private Long id;
+
+		@ManyToOne
+		@JoinColumn( name = "parent_id" )
+		private TreeNode parent;
+
+		@OneToMany
+		private Set<ReferencedEntity> someSet = new HashSet<>();
+
+		public TreeNode() {
+		}
+
+		public TreeNode(Long id, TreeNode parent) {
+			this.id = id;
+			this.parent = parent;
+		}
+
+		public Set<ReferencedEntity> getSomeSet() {
+			return someSet;
+		}
+	}
+
+	@Entity( name = "ReferencedEntity" )
+	public static class ReferencedEntity {
+		@Id
+		@GeneratedValue
+		private Long id;
+
+		private String name;
+
+		public ReferencedEntity() {
+		}
+
+		public ReferencedEntity(String name) {
+			this.name = name;
+		}
+
+		public String getName() {
+			return name;
+		}
+	}
+
+	public static class Listener implements PreUpdateEventListener {
+		@Override
+		public boolean onPreUpdate(PreUpdateEvent event) {
+			final Object entity = event.getEntity();
+			if ( entity instanceof TreeNode ) {
+				final TreeNode treeNode = (TreeNode) entity;
+				assertThat( Hibernate.isInitialized( treeNode.getSomeSet() ) ).isFalse();
+				treeNode.getSomeSet().forEach( entry -> {
+					assertThat( entry.getName() ).isEqualTo( "referenced" );
+				} );
+				assertThat( Hibernate.isInitialized( treeNode.getSomeSet() ) ).isTrue();
+			}
+			return false;
+		}
+	}
+}


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-16602
https://hibernate.atlassian.net/browse/HHH-16701

Alternative solution to https://github.com/hibernate/hibernate-orm/pull/6848, creating the orphan collection remove early instead of checking each time we add an action.