### PR TITLE
HHH-16791 EntitManager#find with IdClass with OffsetDateTime field returns null when Batch is enabled

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/engine/spi/EntityKey.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/spi/EntityKey.java
@@ -57,8 +57,7 @@ public final class EntityKey implements Serializable {
 		int result = 17;
 		final String rootEntityName = persister.getRootEntityName();
 		result = 37 * result + ( rootEntityName != null ? rootEntityName.hashCode() : 0 );
-		result = 37 * result + persister.getIdentifierType().getHashCode( identifier, persister.getFactory() );
-		return result;
+		return  37 * result + persister.getIdentifierMapping().hashCode( identifier, persister.getFactory() );
 	}
 
 	public boolean isBatchLoadable(LoadQueryInfluencers influencers) {
@@ -98,7 +97,7 @@ public final class EntityKey implements Serializable {
 
 	private boolean sameIdentifier(final EntityKey otherKey) {
 		return this.identifier == otherKey.identifier ||
-			persister.getIdentifierType().isEqual( otherKey.identifier, this.identifier, persister.getFactory() );
+			persister.getIdentifierMapping().equals( otherKey.identifier, this.identifier, persister.getFactory() );
 	}
 
 	private boolean samePersistentType(final EntityKey otherKey) {

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/BasicValuedModelPart.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/BasicValuedModelPart.java
@@ -6,7 +6,10 @@
  */
 package org.hibernate.metamodel.mapping;
 
+import org.hibernate.engine.spi.SessionFactoryImplementor;
+import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.sql.results.graph.Fetchable;
+import org.hibernate.type.descriptor.java.JavaType;
 
 /**
  * Describes a ModelPart which is a basic value, either<ul>
@@ -58,5 +61,25 @@ public interface BasicValuedModelPart extends BasicValuedMapping, ValuedModelPar
 	@Override
 	default boolean hasPartitionedSelectionMapping() {
 		return isPartitioned();
+	}
+
+	@Override
+	default int hashCode(Object value, SessionFactoryImplementor sessionFactory) {
+		return ( (JavaType<Object>) getJavaType() ).extractHashCode( value, this, sessionFactory );
+	}
+
+	@Override
+	default boolean equals(Object value1, Object value2, SessionFactoryImplementor sessionFactory) {
+		return ( (JavaType<Object>) getJavaType() ).areEqual( value1, value2, this, sessionFactory );
+	}
+
+	@Override
+	default Object disassemble(Object value, SharedSessionContractImplementor session) {
+		if ( session == null ) {
+			return getJdbcMapping().convertToRelationalValue( value );
+		}
+		return getJdbcMapping().convertToRelationalValue(
+				( (JavaType<Object>) getJavaType() ).getValue( value, this, session.getFactory() )
+		);
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/EmbeddableValuedModelPart.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/EmbeddableValuedModelPart.java
@@ -9,6 +9,7 @@ package org.hibernate.metamodel.mapping;
 import java.util.function.Consumer;
 
 import org.hibernate.cache.MutableCacheKeyBuilder;
+import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.internal.util.IndexedConsumer;
 import org.hibernate.property.access.spi.PropertyAccess;
@@ -185,4 +186,12 @@ public interface EmbeddableValuedModelPart extends ValuedModelPart, Fetchable, F
 			Clause clause,
 			SqmToSqlAstConverter walker,
 			SqlAstCreationState sqlAstCreationState);
+
+	default int hashCode(Object value, SessionFactoryImplementor sessionFactory) {
+		return getEmbeddableTypeDescriptor().hashCode( value, sessionFactory );
+	}
+
+	default boolean equals(Object value1, Object value2, SessionFactoryImplementor sessionFactory) {
+		return getEmbeddableTypeDescriptor().equals( value1, value2, sessionFactory );
+	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/ModelPart.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/ModelPart.java
@@ -9,6 +9,7 @@ package org.hibernate.metamodel.mapping;
 import java.util.Objects;
 import java.util.function.BiConsumer;
 
+import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.metamodel.model.domain.NavigableRole;
 import org.hibernate.query.sqm.sql.internal.DomainResultProducer;
@@ -76,6 +77,14 @@ public interface ModelPart extends MappingModelExpressible {
 	 * {@link #getPartMappingType()}
 	 */
 	JavaType<?> getJavaType();
+
+	default int hashCode(Object value, SessionFactoryImplementor sessionFactory) {
+		return ( (JavaType<Object>) getJavaType() ).extractHashCode( value, null, sessionFactory );
+	}
+
+	default boolean equals(Object value1, Object value2, SessionFactoryImplementor sessionFactory) {
+		return ( (JavaType<Object>) getJavaType() ).areEqual( value1, value2, null, sessionFactory );
+	}
 
 	/**
 	 * Whether this model part describes something that physically

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/AbstractEmbeddableMapping.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/AbstractEmbeddableMapping.java
@@ -20,6 +20,7 @@ import org.hibernate.engine.FetchTiming;
 import org.hibernate.engine.jdbc.env.spi.JdbcEnvironment;
 import org.hibernate.engine.jdbc.spi.JdbcServices;
 import org.hibernate.engine.spi.CascadeStyle;
+import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.internal.util.IndexedConsumer;
 import org.hibernate.internal.util.collections.CollectionHelper;
@@ -622,6 +623,52 @@ public abstract class AbstractEmbeddableMapping implements EmbeddableMappingType
 				final AttributeMapping attributeMapping = attributeMappings.get( i );
 				attributeMapping.addToCacheKey( cacheKey, attributeMapping.getValue( value ), session );
 			}
+		}
+	}
+
+	@Override
+	public int hashCode(Object value, SessionFactoryImplementor sessionFactory) {
+		final int size = attributeMappings.size();
+		int hashCode = 17;
+		if ( value == null ) {
+			for ( int i = 0; i < size; i++ ) {
+				final AttributeMapping attributeMapping = attributeMappings.get( i );
+				hashCode = hashCode * 37 + attributeMapping.hashCode( null, sessionFactory );
+			}
+		}
+		else {
+			final Object[] values = getValues( value );
+			for ( int i = 0; i < size; i++ ) {
+				final AttributeMapping attributeMapping = attributeMappings.get( i );
+				final Object v = values[i];
+				hashCode *= 37;
+				if ( v != null ) {
+					hashCode += attributeMapping.hashCode( v, sessionFactory );
+				}
+			}
+		}
+		return hashCode;
+	}
+
+	@Override
+	public boolean equals(Object value1, Object value2, SessionFactoryImplementor sessionFactory) {
+		if ( value1 == null ) {
+			return value2 == null;
+		}
+		else if ( value2 == null ) {
+			return false;
+		}
+		else {
+			final int size = attributeMappings.size();
+			final Object[] values1 = getValues( value1 );
+			final Object[] values2 = getValues( value2 );
+			for ( int i = 0; i < size; i++ ) {
+				final AttributeMapping attributeMapping = attributeMappings.get( i );
+				if ( !attributeMapping.equals( values1[i], values2[i], sessionFactory ) ) {
+					return false;
+				}
+			}
+			return true;
 		}
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/InverseNonAggregatedIdentifierMapping.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/InverseNonAggregatedIdentifierMapping.java
@@ -12,6 +12,7 @@ import java.util.function.BiConsumer;
 import org.hibernate.cache.MutableCacheKeyBuilder;
 import org.hibernate.engine.spi.EntityKey;
 import org.hibernate.engine.spi.PersistenceContext;
+import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.internal.util.collections.CollectionHelper;
 import org.hibernate.metamodel.mapping.AttributeMapping;
@@ -137,6 +138,16 @@ public class InverseNonAggregatedIdentifierMapping extends EmbeddedAttributeMapp
 	@Override
 	public void addToCacheKey(MutableCacheKeyBuilder cacheKey, Object value, SharedSessionContractImplementor session) {
 		identifierValueMapper.addToCacheKey( cacheKey, value, session );
+	}
+
+	@Override
+	public int hashCode(Object value, SessionFactoryImplementor sessionFactory) {
+		return identifierValueMapper.hashCode( value, sessionFactory );
+	}
+
+	@Override
+	public boolean equals(Object value1, Object value2, SessionFactoryImplementor sessionFactory) {
+		return identifierValueMapper.equals( value1, value2, sessionFactory );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/NonAggregatedIdentifierMappingImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/NonAggregatedIdentifierMappingImpl.java
@@ -13,6 +13,7 @@ import org.hibernate.cache.MutableCacheKeyBuilder;
 import org.hibernate.engine.FetchTiming;
 import org.hibernate.engine.spi.EntityKey;
 import org.hibernate.engine.spi.PersistenceContext;
+import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.internal.util.collections.CollectionHelper;
 import org.hibernate.mapping.Component;
@@ -158,6 +159,16 @@ public class NonAggregatedIdentifierMappingImpl extends AbstractCompositeIdentif
 	@Override
 	public void addToCacheKey(MutableCacheKeyBuilder cacheKey, Object value, SharedSessionContractImplementor session) {
 		identifierValueMapper.addToCacheKey( cacheKey, value, session );
+	}
+
+	@Override
+	public int hashCode(Object value, SessionFactoryImplementor sessionFactory) {
+		return identifierValueMapper.hashCode( value, sessionFactory );
+	}
+
+	@Override
+	public boolean equals(Object value1, Object value2, SessionFactoryImplementor sessionFactory) {
+		return identifierValueMapper.equals( value1, value2, sessionFactory );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/query/derived/AnonymousTupleEmbeddableValuedModelPart.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/derived/AnonymousTupleEmbeddableValuedModelPart.java
@@ -17,6 +17,7 @@ import org.hibernate.Incubating;
 import org.hibernate.cache.MutableCacheKeyBuilder;
 import org.hibernate.engine.FetchStyle;
 import org.hibernate.engine.FetchTiming;
+import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.internal.util.IndexedConsumer;
 import org.hibernate.internal.util.collections.CollectionHelper;
@@ -537,6 +538,51 @@ public class AnonymousTupleEmbeddableValuedModelPart implements EmbeddableValued
 				mapping.addToCacheKey( cacheKey, values[i], session );
 				i++;
 			}
+		}
+	}
+
+	@Override
+	public int hashCode(Object value, SessionFactoryImplementor sessionFactory) {
+		int hashCode = 17;
+		if ( value == null ) {
+			for ( ModelPart mapping : modelParts ) {
+				hashCode = hashCode * 37 + mapping.hashCode( null, sessionFactory );
+			}
+		}
+		else {
+			final Object[] values = getValues( value );
+			int i = 0;
+			for ( ModelPart mapping : modelParts ) {
+				final Object v = values[i];
+				hashCode *= 37;
+				if ( v != null ) {
+					hashCode += mapping.hashCode( v, sessionFactory );
+				}
+				i++;
+			}
+		}
+		return hashCode;
+	}
+
+	@Override
+	public boolean equals(Object value1, Object value2, SessionFactoryImplementor sessionFactory) {
+		if ( value1 == null ) {
+			return value2 == null;
+		}
+		else if ( value2 == null ) {
+			return false;
+		}
+		else {
+			int i = 0;
+			final Object[] values1 = getValues( value1 );
+			final Object[] values2 = getValues( value2 );
+			for ( ModelPart mapping : modelParts ) {
+				if ( !mapping.equals( values1[i], values2[i], sessionFactory ) ) {
+					return false;
+				}
+				i++;
+			}
+			return true;
 		}
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/DateTimeUtils.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/DateTimeUtils.java
@@ -452,14 +452,17 @@ public final class DateTimeUtils {
 	 * than what is supported by a column, which is to round the excess fractions.
 	 */
 	public static <T extends Temporal> T roundToDefaultPrecision(T temporal, Dialect d) {
-		final int defaultTimestampPrecision = d.getDefaultTimestampPrecision();
-		if ( defaultTimestampPrecision >= 9 || !temporal.isSupported( ChronoField.NANO_OF_SECOND ) ) {
+		return roundToPrecision( temporal, d.getDefaultTimestampPrecision() );
+	}
+
+	public static <T extends Temporal> T roundToPrecision(T temporal, int precision) {
+		if ( temporal == null || precision >= 9 || !temporal.isSupported( ChronoField.NANO_OF_SECOND ) ) {
 			return temporal;
 		}
 		//noinspection unchecked
 		return (T) temporal.with(
 				ChronoField.NANO_OF_SECOND,
-				roundToPrecision( temporal.get( ChronoField.NANO_OF_SECOND ), defaultTimestampPrecision )
+				roundToPrecision( temporal.get( ChronoField.NANO_OF_SECOND ), precision )
 		);
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/JavaType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/JavaType.java
@@ -15,10 +15,12 @@ import java.util.Objects;
 import org.hibernate.Incubating;
 import org.hibernate.dialect.Dialect;
 import org.hibernate.engine.jdbc.Size;
+import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.internal.util.CharSequenceHelper;
 import org.hibernate.internal.util.ReflectHelper;
 import org.hibernate.internal.util.compare.ComparableComparator;
+import org.hibernate.metamodel.mapping.SqlTypedMapping;
 import org.hibernate.sql.ast.spi.SqlAppender;
 import org.hibernate.type.descriptor.WrapperOptions;
 import org.hibernate.type.descriptor.converter.spi.BasicValueConverter;
@@ -202,6 +204,10 @@ public interface JavaType<T> extends Serializable {
 		return value.hashCode();
 	}
 
+	default int extractHashCode(T value, SqlTypedMapping mapping, SessionFactoryImplementor sessionFactory) {
+		return extractHashCode( value );
+	}
+
 	/**
 	 * Determine if two instances are equal
 	 *
@@ -212,6 +218,14 @@ public interface JavaType<T> extends Serializable {
 	 */
 	default boolean areEqual(T one, T another) {
 		return Objects.deepEquals( one, another );
+	}
+
+	default boolean areEqual(T one, T another, SqlTypedMapping mapping, SessionFactoryImplementor sessionFactory) {
+		return areEqual( one, another );
+	}
+
+	default T getValue(T value, SqlTypedMapping mapping, SessionFactoryImplementor sessionFactory) {
+		return value;
 	}
 
 	/**

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/OffsetDateTimeJavaType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/OffsetDateTimeJavaType.java
@@ -22,8 +22,11 @@ import java.util.Date;
 import java.util.GregorianCalendar;
 
 import org.hibernate.dialect.Dialect;
+import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.internal.util.CharSequenceHelper;
+import org.hibernate.metamodel.mapping.SqlTypedMapping;
+import org.hibernate.type.descriptor.DateTimeUtils;
 import org.hibernate.type.descriptor.WrapperOptions;
 import org.hibernate.type.descriptor.jdbc.JdbcType;
 import org.hibernate.type.descriptor.jdbc.JdbcTypeIndicators;
@@ -77,6 +80,29 @@ public class OffsetDateTimeJavaType extends AbstractTemporalJavaType<OffsetDateT
 	@SuppressWarnings("unchecked")
 	protected <X> TemporalJavaType<X> forTimestampPrecision(TypeConfiguration typeConfiguration) {
 		return (TemporalJavaType<X>) this;
+	}
+
+	@Override
+	public int extractHashCode(OffsetDateTime value, SqlTypedMapping mapping, SessionFactoryImplementor sessionFactory) {
+		return extractHashCode( getValue( value, mapping, sessionFactory ) );
+	}
+
+	@Override
+	public boolean areEqual(OffsetDateTime one, OffsetDateTime another, SqlTypedMapping mapping, SessionFactoryImplementor sessionFactory) {
+		return areEqual(
+				getValue( one, mapping, sessionFactory ),
+				getValue( another, mapping, sessionFactory )
+		);
+	}
+
+	@Override
+	public OffsetDateTime getValue(OffsetDateTime value, SqlTypedMapping mapping, SessionFactoryImplementor sessionFactory) {
+		return DateTimeUtils.roundToPrecision(
+				value,
+				mapping.getPrecision() != null
+						? mapping.getPrecision()
+						: sessionFactory.getJdbcServices().getDialect().getDefaultTimestampPrecision()
+		);
 	}
 
 	@Override

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/idclass/IdClassWithOffsetDateTimeTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/idclass/IdClassWithOffsetDateTimeTest.java
@@ -1,0 +1,122 @@
+package org.hibernate.orm.test.idclass;
+
+import java.io.Serializable;
+import java.time.OffsetDateTime;
+import java.time.Period;
+import java.time.temporal.ChronoUnit;
+
+import org.hibernate.cfg.AvailableSettings;
+import org.hibernate.dialect.OracleDialect;
+import org.hibernate.dialect.SybaseDialect;
+
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.JiraKey;
+import org.hibernate.testing.orm.junit.ServiceRegistry;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.hibernate.testing.orm.junit.Setting;
+import org.hibernate.testing.orm.junit.SkipForDialect;
+import org.hibernate.testing.orm.junit.SkipForDialectGroup;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.IdClass;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+@DomainModel(
+		annotatedClasses = {
+				IdClassWithOffsetDateTimeTest.MyEntity.class
+		}
+)
+@SessionFactory
+@ServiceRegistry(settings = {
+		@Setting( name = AvailableSettings.DEFAULT_BATCH_FETCH_SIZE, value = "2")
+})
+@JiraKey("HHH-16791")
+@SkipForDialectGroup( {
+		@SkipForDialect( dialectClass = OracleDialect.class, reason = "It does not support column of datatype TIME/TIMESTAMP as primary key"),
+		@SkipForDialect( dialectClass = SybaseDialect.class, reason = "The offset of the OffsetDateTime we persist is different when the same value is retrieved for the db ")
+} )
+public class IdClassWithOffsetDateTimeTest {
+
+	private static final Long ID = 1l;
+	private static final Long ID_2 = 2l;
+	private static final OffsetDateTime BOOK_DATE = OffsetDateTime.now();
+	private static final OffsetDateTime BOOK_DATE_2 = OffsetDateTime.now().plus( Period.ofWeeks( 1 ) );
+
+	@BeforeAll
+	public void setUp(SessionFactoryScope scope) {
+		scope.inTransaction(
+				session -> {
+					MyEntity myEntity = new MyEntity( ID, BOOK_DATE, "one" );
+					MyEntity myEntity2 = new MyEntity( ID_2, BOOK_DATE_2, "two" );
+					session.persist( myEntity );
+					session.persist( myEntity2 );
+				}
+		);
+	}
+
+	@Test
+	public void testFind(SessionFactoryScope scope) {
+		scope.inTransaction(
+				session -> {
+					session.getReference( MyEntity.class, new MyEntityKey( ID_2, BOOK_DATE_2 )  );
+					MyEntity myEntity = session.find( MyEntity.class, new MyEntityKey( ID, BOOK_DATE ) );
+					assertThat( myEntity ).isNotNull();
+				}
+		);
+	}
+
+	@Test
+	public void testFind2(SessionFactoryScope scope) {
+		scope.inTransaction(
+				session -> {
+					MyEntity myEntity = session.find( MyEntity.class, new MyEntityKey( ID, BOOK_DATE ) );
+					assertThat( myEntity ).isNotNull();
+				}
+		);
+	}
+
+	@IdClass(MyEntityKey.class)
+	@Entity(name = "MyEntity")
+	public static class MyEntity {
+
+		@Id
+		private Long id;
+
+		@Id
+		@Column
+		private OffsetDateTime bookDate;
+
+		@Column(name = "DATA_COLUMN")
+		private String data;
+
+		public MyEntity() {
+		}
+
+		public MyEntity(Long id, OffsetDateTime bookDate, String data) {
+			this.id = id;
+			this.bookDate = bookDate;
+			this.data = data;
+		}
+	}
+
+	public static class MyEntityKey implements Serializable {
+
+		private Long id;
+
+		private OffsetDateTime bookDate;
+
+		public MyEntityKey() {
+		}
+
+		public MyEntityKey(Long id, OffsetDateTime bookDate) {
+			this.id = id;
+			this.bookDate = bookDate;
+		}
+	}
+}


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-16791

when we execute session.find( MyEntity.class, new MyEntityKey( ID, BOOK_DATE ) );
with batch we first load all the entities and then we search in the the PC the one corresponding to the EntityKey of the find method in order to return it.
What happens is that the value of the OffsetDateTime (it seems that from Java 13 the precision is nano and not milliseconds) retrieved from the DB is not equal to the one used in the find method so we are not able to locate the EntityKey in the PC (different hashcode) and we return null.