### PR TITLE
User guide credits: Move them to a dedicated section and add some missing names

### DIFF
--- a/documentation/src/main/asciidoc/userguide/Credits.adoc
+++ b/documentation/src/main/asciidoc/userguide/Credits.adoc
@@ -8,6 +8,8 @@ The following contributors were involved in this documentation:
 
 * Gail Badner
 * Christian Bauer
+* Christian Beikov
+* Marco Belladelli
 * Emmanuel Bernard
 * Andrea Boriero
 * Chris Cranford
@@ -20,5 +22,9 @@ The following contributors were involved in this documentation:
 * Brett Meyer
 * Vlad Mihalcea
 * Gunnar Morling
+* Yoann Rodière
 * Max Rydahl Andersen
+* Jan Schatteman
+* Fábio Ueno
 * Radim Vansa
+* Nathan Xu

--- a/documentation/src/main/asciidoc/userguide/Credits.adoc
+++ b/documentation/src/main/asciidoc/userguide/Credits.adoc
@@ -1,0 +1,24 @@
+[[credits]]
+== Credits
+
+The full list of contributors to Hibernate ORM can be found in the `copyright.txt` file
+in the Hibernate ORM sources, available in particular in our https://github.com/hibernate/hibernate-orm/[git repository].
+
+The following contributors were involved in this documentation:
+
+* Gail Badner
+* Christian Bauer
+* Emmanuel Bernard
+* Andrea Boriero
+* Chris Cranford
+* Steve Ebersole
+* Hardy Ferentschik
+* Sanne Grinovero
+* Louis Jacomet
+* Gavin King
+* Karel Maesen
+* Brett Meyer
+* Vlad Mihalcea
+* Gunnar Morling
+* Max Rydahl Andersen
+* Radim Vansa

--- a/documentation/src/main/asciidoc/userguide/Hibernate_User_Guide.adoc
+++ b/documentation/src/main/asciidoc/userguide/Hibernate_User_Guide.adoc
@@ -1,5 +1,4 @@
 = Hibernate ORM {fullVersion} User Guide
-Vlad Mihalcea, Steve Ebersole, Andrea Boriero, Gunnar Morling, Gail Badner, Chris Cranford, Emmanuel Bernard, Sanne Grinovero, Brett Meyer, Hardy Ferentschik, Gavin King, Christian Bauer, Max Rydahl Andersen, Karel Maesen, Radim Vansa, Louis Jacomet
 :toc2:
 :toclevels: 3
 :sectanchors:
@@ -43,6 +42,8 @@ include::appendices/Legacy_Bootstrap.adoc[]
 include::appendices/Legacy_DomainModel.adoc[]
 include::appendices/LegacyBasicTypeResolution.adoc[]
 include::appendices/Legacy_Native_Queries.adoc[]
+
+include::Credits.adoc[]
 
 include::ConfigPropertyList.adoc[]
 include::Bibliography.adoc[]


### PR DESCRIPTION
I tried to filter out contributors who only fixed typos, hopefully I didn't forget anyone.