### PR TITLE
HHH-16843 fix interpretation of 'value = null' in HQL

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/JavaTypeHelper.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/JavaTypeHelper.java
@@ -34,6 +34,7 @@ public class JavaTypeHelper {
 	}
 
 	public static boolean isUnknown(JavaType<?> javaType) {
-		return javaType.getClass() == UnknownBasicJavaType.class;
+		return javaType == null
+			|| javaType.getClass() == UnknownBasicJavaType.class;
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/type/format/jaxb/JaxbXmlFormatMapper.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/format/jaxb/JaxbXmlFormatMapper.java
@@ -24,7 +24,6 @@ import org.hibernate.internal.util.ReflectHelper;
 import org.hibernate.internal.util.collections.CollectionHelper;
 import org.hibernate.sql.ast.spi.StringBuilderSqlAppender;
 import org.hibernate.type.descriptor.java.JavaTypeHelper;
-import org.hibernate.type.descriptor.java.spi.UnknownBasicJavaType;
 import org.hibernate.type.format.FormatMapper;
 import org.hibernate.type.descriptor.WrapperOptions;
 import org.hibernate.type.descriptor.java.BasicPluralJavaType;

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/hql/BulkManipulationTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/hql/BulkManipulationTest.java
@@ -1158,7 +1158,7 @@ public class BulkManipulationTest extends BaseCoreFunctionalTestCase {
 		int count = s.createQuery( "update Mammal set bodyWeight = null" ).executeUpdate();
 		assertEquals( "Incorrect deletion count on joined subclass", 2, count );
 
-		count = s.createQuery( "delete Animal where bodyWeight = null" ).executeUpdate();
+		count = s.createQuery( "delete Animal where bodyWeight is null" ).executeUpdate();
 		assertEquals( "Incorrect deletion count on joined subclass", 2, count );
 
 		t.commit();

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/pagination/DistinctSelectTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/pagination/DistinctSelectTest.java
@@ -47,13 +47,13 @@ public class DistinctSelectTest extends BaseCoreFunctionalTestCase {
 		Transaction t = s.beginTransaction();
 
 		for (int i = 0; i < 5; i++) {
-			Tag tag = new Tag("Tag: " + UUID.randomUUID().toString());
+			Tag tag = new Tag("Tag: " + UUID.randomUUID());
 			tags.add(tag);
 			s.save(tag);
 		}
 
 		for (int i = 0; i < NUM_OF_USERS; i++) {
-			Entry e = new Entry("Entry: " + UUID.randomUUID().toString());
+			Entry e = new Entry("Entry: " + UUID.randomUUID());
 			e.getTags().addAll(tags);
 			s.save(e);
 		}
@@ -68,7 +68,7 @@ public class DistinctSelectTest extends BaseCoreFunctionalTestCase {
 
 		Session s = openSession();
 
-		List<Entry> entries = s.createQuery("select distinct e from Entry e join e.tags t where t.surrogate != null order by e.name").setFirstResult(10).setMaxResults(5).list();
+		List<Entry> entries = s.createQuery("select distinct e from Entry e join e.tags t where t.surrogate is not null order by e.name").setFirstResult(10).setMaxResults(5).list();
 
 		// System.out.println(entries);
 		Entry firstEntry = entries.remove(0);


### PR DESCRIPTION
the previous implementation was not compliant with the JPA spec and defied logic