### PR TITLE
HHH-16826 - IN-Clause Parameter Padding should grow exponentially for Dialects with InExpressionCountLimit

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/internal/util/MathHelper.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/util/MathHelper.java
@@ -23,4 +23,13 @@ public final class MathHelper {
 	public static int ceilingPowerOfTwo(int value) {
 		return 1 << -Integer.numberOfLeadingZeros(value - 1);
 	}
+
+	/**
+	 * Returns the result of dividing a positive {@code numerator} by a positive {@code denominator} rounded up.
+	 * <p>
+	 * For example dividing 5 by 2 ist 2.5, which (when rounded up) gives a result of 3.
+	 */
+	public static int divideRoundingUp(int numerator, int denominator) {
+		return ( numerator + denominator - 1 ) / denominator;
+	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/sql/ast/spi/AbstractSqlAstTranslator.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/ast/spi/AbstractSqlAstTranslator.java
@@ -6887,8 +6887,10 @@ public abstract class AbstractSqlAstTranslator<T extends JdbcOperation> implemen
 
 		final Iterator<Expression> iterator = listExpressions.iterator();
 		Expression listExpression = null;
-		for ( int i = 0; i < bindValueCountWithPadding; i++ ) {
-			if ( inExprLimit > 0 && i % inExprLimit == 0 && i != 0 ) {
+		int clauseItemNumber = 0;
+		for ( int i = 0; i < bindValueCountWithPadding; i++, clauseItemNumber++ ) {
+			if ( inExprLimit > 0 && inExprLimit == clauseItemNumber ) {
+				clauseItemNumber = 0;
 				appendInClauseSeparator( inListPredicate );
 				separator = NO_SEPARATOR;
 			}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/internal/util/MathHelperTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/internal/util/MathHelperTest.java
@@ -9,17 +9,24 @@ package org.hibernate.orm.test.internal.util;
 import org.hibernate.internal.util.MathHelper;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+
+import java.util.stream.Stream;
 
 
 /**
  * @author Vlad Mihalcea
  */
 public class MathHelperTest {
-	
+
 	@Test
 	public void ceilingPowerOfTwo() {
+		assertThat( MathHelper.ceilingPowerOfTwo( 0 ) ).isEqualTo( 1 );
 		assertThat( MathHelper.ceilingPowerOfTwo( 1 ) ).isEqualTo( 1 );
 		assertThat( MathHelper.ceilingPowerOfTwo( 2 ) ).isEqualTo( 2 );
 		assertThat( MathHelper.ceilingPowerOfTwo( 3 ) ).isEqualTo( 4 );
@@ -39,4 +46,24 @@ public class MathHelperTest {
 		assertThat( MathHelper.ceilingPowerOfTwo( 16 ) ).isEqualTo( 16 );
 	}
 
+	static Stream<Arguments> test_divideRoundingUp() {
+		return Stream.of(
+				arguments( 0, 1, 0 ),
+				arguments( 1, 1, 1 ),
+				arguments( 2, 1, 2 ),
+				arguments( 0, 2, 0 ),
+				arguments( 1, 2, 1 ),
+				arguments( 2, 2, 1 ),
+				arguments( 3, 2, 2 ),
+				arguments( 4, 2, 2 ),
+				arguments( 5, 2, 3 ),
+				arguments( 9, 3, 3 ),
+				arguments( 10, 3, 4 ) );
+	}
+
+	@ParameterizedTest
+	@MethodSource
+	public void test_divideRoundingUp(int numerator, int denominator, int expected) {
+		assertThat( MathHelper.divideRoundingUp( numerator, denominator ) ).isEqualTo( expected );
+	}
 }


### PR DESCRIPTION
See [HHH-16826](https://hibernate.atlassian.net/browse/HHH-16826).

In the first commit I added some parameterized tests to `MaxInExpressionParameterPaddingTest` since they are much less verbose for this kind of test. I also added some of the constellation of the existing tests to the parameterized test data. Now some constellations are tested twice, since I did not dare to remove the existing tests. Some of the existing tests have annotations like `@TestForIssue(jiraKey = "HHH-14109")`. If I were to remove the existing tests in favor of the parameterized tests I wasn't sure what to do with those annotations. Since the annotation is not repeatable I can't add multiple annotations to the parameterized test and I don't know what you use those annotations for.

To avoid the test duplication I removed the duplicated old tests in a second commit and added comments to the parameterized test data to point to the relevant Jira tickets. If this approach is fine I would suggest to squash the two commits into one. If this is not fine I would suggest to drop the second commit.

[HHH-16826]: https://hibernate.atlassian.net/browse/HHH-16826?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ