### PR TITLE
HHH-16858 improve typechecking for comparisons/assignments

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/query/OutputableType.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/OutputableType.java
@@ -14,8 +14,8 @@ import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.type.descriptor.jdbc.JdbcType;
 
 /**
- * Specialization of DomainType for types that can be used as a
- * parameter output for a {@link org.hibernate.procedure.ProcedureCall}
+ * Specialization of {@link org.hibernate.metamodel.model.domain.DomainType} for types that
+ * can be used as a parameter output for a {@link org.hibernate.procedure.ProcedureCall}.
  *
  * @apiNote We assume a type that maps to exactly one SQL value, hence {@link #getJdbcType()}
  *

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/internal/QuerySqmImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/internal/QuerySqmImpl.java
@@ -382,7 +382,7 @@ public class QuerySqmImpl<R>
 			JdbcType lhsJdbcType = ((JdbcMapping) lhsDomainType).getJdbcType();
 			JdbcType rhsJdbcType = ((JdbcMapping) rhsDomainType).getJdbcType();
 			if ( lhsJdbcType.getJdbcTypeCode() == rhsJdbcType.getJdbcTypeCode()
-					|| lhsJdbcType.isString() && rhsJdbcType.isString()
+					|| lhsJdbcType.isStringLike() && rhsJdbcType.isStringLike()
 					|| lhsJdbcType.isInteger() && rhsJdbcType.isInteger() ) {
 				return true;
 			}

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/internal/QuerySqmImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/internal/QuerySqmImpl.java
@@ -43,7 +43,9 @@ import org.hibernate.id.enhanced.Optimizer;
 import org.hibernate.internal.CoreLogging;
 import org.hibernate.internal.CoreMessageLogger;
 import org.hibernate.metamodel.mapping.EntityIdentifierMapping;
+import org.hibernate.metamodel.mapping.JdbcMapping;
 import org.hibernate.metamodel.mapping.internal.SingleAttributeIdentifierMapping;
+import org.hibernate.metamodel.model.domain.DomainType;
 import org.hibernate.metamodel.model.domain.EntityDomainType;
 import org.hibernate.persister.entity.AbstractEntityPersister;
 import org.hibernate.persister.entity.EntityPersister;
@@ -79,6 +81,7 @@ import org.hibernate.query.spi.ScrollableResultsImplementor;
 import org.hibernate.query.spi.SelectQueryPlan;
 import org.hibernate.query.sqm.NodeBuilder;
 import org.hibernate.query.sqm.SortOrder;
+import org.hibernate.query.sqm.SqmExpressible;
 import org.hibernate.query.sqm.SqmPathSource;
 import org.hibernate.query.sqm.internal.SqmInterpretationsKey.InterpretationsKeySource;
 import org.hibernate.query.sqm.mutation.spi.SqmMultiTableMutationStrategy;
@@ -113,6 +116,8 @@ import jakarta.persistence.LockModeType;
 import jakarta.persistence.Parameter;
 import jakarta.persistence.PersistenceException;
 import jakarta.persistence.TemporalType;
+import org.hibernate.type.descriptor.java.JavaType;
+import org.hibernate.type.descriptor.jdbc.JdbcType;
 
 import static org.hibernate.jpa.HibernateHints.HINT_CACHEABLE;
 import static org.hibernate.jpa.HibernateHints.HINT_CACHE_MODE;
@@ -130,6 +135,7 @@ import static org.hibernate.query.sqm.internal.SqmInterpretationsKey.createInter
 import static org.hibernate.query.sqm.internal.SqmInterpretationsKey.generateNonSelectKey;
 import static org.hibernate.query.sqm.internal.SqmUtil.isSelect;
 import static org.hibernate.query.sqm.internal.SqmUtil.verifyIsNonSelectStatement;
+import static org.hibernate.type.descriptor.java.JavaTypeHelper.isUnknown;
 
 /**
  * {@link Query} implementation based on an SQM
@@ -351,23 +357,47 @@ public class QuerySqmImpl<R>
 			final SqmAssignment<?> assignment = assignments.get( i );
 			final SqmPath<?> targetPath = assignment.getTargetPath();
 			final SqmExpression<?> expression = assignment.getValue();
-			if ( targetPath.getNodeJavaType() == null || expression.getNodeJavaType() == null ) {
-				continue;
-			}
-			if ( targetPath.getNodeJavaType() != expression.getNodeJavaType()
-					&& !targetPath.getNodeJavaType().isWider( expression.getNodeJavaType() ) ) {
+			if ( !isAssignable( targetPath, expression ) ) {
 				throw new SemanticException(
 						String.format(
-								"The assignment expression type [%s] did not match the assignment path type [%s] for the path [%s]",
+								"Cannot assign expression of type '%s' to target path '%s' of type '%s'",
 								expression.getNodeJavaType().getJavaType().getTypeName(),
-								targetPath.getNodeJavaType().getJavaType().getTypeName(),
-								targetPath.toHqlString()
+								targetPath.toHqlString(),
+								targetPath.getNodeJavaType().getJavaType().getTypeName()
 						),
 						hqlString,
 						null
 				);
 			}
 		}
+	}
+
+	/**
+	 * @see SqmCriteriaNodeBuilder#areTypesComparable(SqmExpressible, SqmExpressible)
+	 */
+	public static boolean isAssignable(SqmPath<?> targetPath, SqmExpression<?> expression) {
+		DomainType<?> lhsDomainType = targetPath.getExpressible().getSqmType();
+		DomainType<?> rhsDomainType = expression.getExpressible().getSqmType();
+		if ( lhsDomainType instanceof JdbcMapping && rhsDomainType instanceof JdbcMapping ) {
+			JdbcType lhsJdbcType = ((JdbcMapping) lhsDomainType).getJdbcType();
+			JdbcType rhsJdbcType = ((JdbcMapping) rhsDomainType).getJdbcType();
+			if ( lhsJdbcType.getJdbcTypeCode() == rhsJdbcType.getJdbcTypeCode()
+					|| lhsJdbcType.isString() && rhsJdbcType.isString()
+					|| lhsJdbcType.isInteger() && rhsJdbcType.isInteger() ) {
+				return true;
+			}
+		}
+
+		JavaType<?> targetType = targetPath.getNodeJavaType();
+		JavaType<?> assignedType = expression.getNodeJavaType();
+		return targetType == assignedType
+			// If we don't know the java types, let's just be lenient
+			|| isUnknown( targetType)
+			|| isUnknown( assignedType )
+			// Assume we can coerce one to another
+			|| targetType.isWider( assignedType )
+			// Enum assignment, other strange user type mappings
+			|| targetType.getJavaTypeClass().isAssignableFrom( assignedType.getJavaTypeClass() );
 	}
 
 	private void verifyInsertTypesMatch(String hqlString, SqmInsertStatement<R> sqmStatement) {

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/internal/SqmCriteriaNodeBuilder.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/internal/SqmCriteriaNodeBuilder.java
@@ -264,7 +264,7 @@ public class SqmCriteriaNodeBuilder implements NodeBuilder, SqmCreationContext, 
 			JdbcType lhsJdbcType = ((JdbcMapping) lhsDomainType).getJdbcType();
 			JdbcType rhsJdbcType = ((JdbcMapping) rhsDomainType).getJdbcType();
 			if ( lhsJdbcType.getJdbcTypeCode() == rhsJdbcType.getJdbcTypeCode()
-					|| lhsJdbcType.isString() && rhsJdbcType.isString()
+					|| lhsJdbcType.isStringLike() && rhsJdbcType.isStringLike()
 					|| lhsJdbcType.isTemporal() && rhsJdbcType.isTemporal()
 					|| lhsJdbcType.isNumber() && rhsJdbcType.isNumber() ) {
 				return true;

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/produce/function/ArgumentTypesValidator.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/produce/function/ArgumentTypesValidator.java
@@ -10,10 +10,10 @@ import java.lang.reflect.Type;
 import java.sql.Types;
 import java.util.List;
 
-import org.hibernate.QueryException;
 import org.hibernate.metamodel.MappingMetamodel;
 import org.hibernate.metamodel.mapping.JdbcMapping;
 import org.hibernate.metamodel.mapping.JdbcMappingContainer;
+import org.hibernate.metamodel.model.domain.DomainType;
 import org.hibernate.query.sqm.SqmExpressible;
 import org.hibernate.query.sqm.tree.SqmTypedNode;
 import org.hibernate.query.sqm.tree.expression.SqmCollation;
@@ -95,16 +95,7 @@ public class ArgumentTypesValidator implements ArgumentsValidator {
 			if ( nodeType != null ) {
 				JavaType<?> javaType = nodeType.getRelationalJavaType();
 				if (javaType != null) {
-					try {
-						checkType(
-								count, functionName, type,
-								getJdbcType( indicators, javaType ),
-								javaType.getJavaTypeClass()
-						);
-					}
-					catch (JdbcTypeRecommendationException e) {
-						// it's a converter or something like that, and we will check it later
-					}
+					checkArgumentType( functionName, count, argument, indicators, type, javaType );
 				}
 				switch (type) {
 					case TEMPORAL_UNIT:
@@ -134,9 +125,39 @@ public class ArgumentTypesValidator implements ArgumentsValidator {
 		}
 	}
 
+	private void checkArgumentType(
+			String functionName,
+			int count,
+			SqmTypedNode<?> argument,
+			JdbcTypeIndicators indicators,
+			FunctionParameterType type,
+			JavaType<?> javaType) {
+		DomainType<?> domainType = argument.getExpressible().getSqmType();
+		if ( domainType instanceof JdbcMapping ) {
+			checkArgumentType(
+					count, functionName, type,
+					((JdbcMapping) domainType).getJdbcType().getDefaultSqlTypeCode(),
+					javaType.getJavaTypeClass()
+			);
+		}
+		else {
+			//TODO: this branch is now probably obsolete and can be deleted!
+			try {
+				checkArgumentType(
+						count, functionName, type,
+						getJdbcType( indicators, javaType ),
+						javaType.getJavaTypeClass()
+				);
+			}
+			catch (JdbcTypeRecommendationException e) {
+				// it's a converter or something like that, and we will check it later
+			}
+		}
+	}
+
 	private int getJdbcType(JdbcTypeIndicators indicators, JavaType<?> javaType) {
 		if ( javaType.getJavaTypeClass().isEnum() ) {
-			// magic value indicates it can be coerced STRING or ORDINAL
+			// we can't tell if the enum is mapped STRING or ORDINAL
 			return ENUM_UNKNOWN_JDBC_TYPE;
 		}
 		else {
@@ -177,7 +198,7 @@ public class ArgumentTypesValidator implements ArgumentsValidator {
 			final JdbcMapping mapping = expressionType.getJdbcMapping( i );
 			FunctionParameterType type = count < types.length ? types[count++] : types[types.length - 1];
 			if (type != null) {
-				checkType(
+				checkArgumentType(
 						count,
 						functionName,
 						type,
@@ -189,19 +210,21 @@ public class ArgumentTypesValidator implements ArgumentsValidator {
 		return count;
 	}
 
-	private void checkType(int count, String functionName, FunctionParameterType type, int code, Type javaType) {
+	private void checkArgumentType(int count, String functionName, FunctionParameterType type, int code, Type javaType) {
 		switch (type) {
 			case COMPARABLE:
-				if ( !isCharacterType(code) && !isTemporalType(code) && !isNumericType(code) && code != UUID ) {
-					if ( javaType == java.util.UUID.class && ( code == Types.BINARY || isCharacterType( code ) ) ) {
-						// We also consider UUID to be comparable when it's a character or binary type
-						return;
-					}
+				if ( !isCharacterType(code) && !isTemporalType(code) && !isNumericType(code)
+						// both Java and the database consider UUIDs
+						// comparable, so go ahead and accept them
+						&& code != UUID
+						// as a special case, we consider a binary column
+						// comparable when it is mapped by a Java UUID
+						&& !( javaType == java.util.UUID.class && code == Types.BINARY ) ) {
 					throwError(type, javaType, functionName, count);
 				}
 				break;
 			case STRING:
-				if ( !isCharacterType(code) && !isEnumType(code) && code != ENUM_UNKNOWN_JDBC_TYPE) {
+				if ( !isCharacterType(code) && !isEnumType(code) ) {
 					throwError(type, javaType, functionName, count);
 				}
 				break;
@@ -216,7 +239,7 @@ public class ArgumentTypesValidator implements ArgumentsValidator {
 				}
 				break;
 			case INTEGER:
-				if ( !isIntegral(code) && code != ENUM_UNKNOWN_JDBC_TYPE ) {
+				if ( !isIntegral(code) ) {
 					throwError(type, javaType, functionName, count);
 				}
 				break;

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/produce/function/ArgumentTypesValidator.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/produce/function/ArgumentTypesValidator.java
@@ -213,7 +213,7 @@ public class ArgumentTypesValidator implements ArgumentsValidator {
 	private void checkArgumentType(int count, String functionName, FunctionParameterType type, int code, Type javaType) {
 		switch (type) {
 			case COMPARABLE:
-				if ( !isCharacterType(code) && !isTemporalType(code) && !isNumericType(code)
+				if ( !isCharacterType(code) && !isTemporalType(code) && !isNumericType(code) && !isEnumType( code )
 						// both Java and the database consider UUIDs
 						// comparable, so go ahead and accept them
 						&& code != UUID

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/CurrencyJavaType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/CurrencyJavaType.java
@@ -60,15 +60,4 @@ public class CurrencyJavaType extends AbstractClassJavaType<Currency> {
 	public long getDefaultSqlLength(Dialect dialect, JdbcType jdbcType) {
 		return 3;
 	}
-
-	@Override
-	public boolean isWider(JavaType<?> javaType) {
-		// This is necessary to allow comparing/assigning a currency attribute against a literal of the JdbcType
-		switch ( javaType.getJavaType().getTypeName() ) {
-			case "java.lang.String":
-				return true;
-			default:
-				return false;
-		}
-	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/EnumJavaType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/EnumJavaType.java
@@ -230,33 +230,13 @@ public class EnumJavaType<T extends Enum<T>> extends AbstractClassJavaType<T> {
 	}
 
 	/**
-	 * Interpret a String value as the named value of the enum type
+	 * Interpret a string value as the named value of the enum type
 	 */
 	public T fromName(String relationalForm) {
 		if ( relationalForm == null ) {
 			return null;
 		}
 		return Enum.valueOf( getJavaTypeClass(), relationalForm.trim() );
-	}
-
-	@Override
-	public boolean isWider(JavaType<?> javaType) {
-		// This is necessary to allow comparing/assigning an enum attribute against a literal of the JdbcType
-		switch ( javaType.getJavaType().getTypeName() ) {
-			case "byte":
-			case "java.lang.Byte":
-			case "short":
-			case "java.lang.Short":
-			case "int":
-			case "java.lang.Integer":
-			case "long":
-			case "java.lang.Long":
-			case "java.lang.String":
-			case "java.lang.Character":
-				return true;
-			default:
-				return false;
-		}
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/JdbcTimestampJavaType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/JdbcTimestampJavaType.java
@@ -10,7 +10,6 @@ import java.sql.Timestamp;
 import java.sql.Types;
 import java.time.Instant;
 import java.time.LocalDateTime;
-import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/jdbc/JdbcType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/jdbc/JdbcType.java
@@ -223,6 +223,12 @@ public interface JdbcType extends Serializable {
 		return isCharacterOrClobType( getDdlTypeCode() );
 	}
 
+	default boolean isStringLike() {
+		int ddlTypeCode = getDdlTypeCode();
+		return isCharacterOrClobType( ddlTypeCode )
+			|| isEnumType( ddlTypeCode );
+	}
+
 	default boolean isTemporal() {
 		return isTemporalType( getDdlTypeCode() );
 	}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/CompositeIdFkUpdateTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/CompositeIdFkUpdateTest.java
@@ -41,7 +41,7 @@ public class CompositeIdFkUpdateTest {
                     }
                     catch (IllegalArgumentException ex) {
                         assertThat( ex.getCause() ).isInstanceOf( SemanticException.class );
-                        assertThat( ex.getCause() ).hasMessageContaining( "did not match" );
+                        assertThat( ex.getCause() ).hasMessageContaining( "Cannot assign expression of type" );
                     }
                 }
         );

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/query/hql/EnumComparisonTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/query/hql/EnumComparisonTest.java
@@ -1,0 +1,61 @@
+package org.hibernate.orm.test.query.hql;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import org.hibernate.query.SemanticException;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
+
+@SessionFactory
+@DomainModel(annotatedClasses = EnumComparisonTest.WithEnum.class)
+public class EnumComparisonTest {
+    @Test
+    void test(SessionFactoryScope scope) {
+        scope.inTransaction(session -> {
+            session.persist(new WithEnum());
+            assertEquals(1,
+                    session.createSelectionQuery("from WithEnum where stringEnum > X").getResultList().size());
+            assertEquals(1,
+                    session.createSelectionQuery("from WithEnum where ordinalEnum > X").getResultList().size());
+            assertEquals(1,
+                    session.createSelectionQuery("from WithEnum where stringEnum > 'X'").getResultList().size());
+            assertEquals(1,
+                    session.createSelectionQuery("from WithEnum where ordinalEnum > 1").getResultList().size());
+            try {
+                session.createSelectionQuery("from WithEnum where ordinalEnum > 'X'").getResultList();
+                fail();
+            }
+            catch (SemanticException se) {
+            }
+            try {
+                session.createSelectionQuery("from WithEnum where stringEnum > 1").getResultList();
+                fail();
+            }
+            catch (SemanticException se) {
+            }
+        });
+    }
+
+    enum Enum { X, Y, Z }
+
+    @Entity(name = "WithEnum")
+    static class WithEnum {
+        @Id
+        @GeneratedValue
+        long id;
+
+        @Enumerated(EnumType.STRING)
+        Enum stringEnum = Enum.Y;
+
+        @Enumerated(EnumType.ORDINAL)
+        Enum ordinalEnum = Enum.Z;
+    }
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/query/hql/EnumComparisonTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/query/hql/EnumComparisonTest.java
@@ -41,6 +41,8 @@ public class EnumComparisonTest {
             }
             catch (SemanticException se) {
             }
+            session.createSelectionQuery("select max(ordinalEnum) from WithEnum").getSingleResult();
+            session.createSelectionQuery("select max(stringEnum) from WithEnum").getSingleResult();
         });
     }
 


### PR DESCRIPTION
In particular, correctly type check comparisons between enums and other enums, literal integers, and literal strings. 

Actually I'm not a great fan of comparing enums with int/string literals but since we used to support it in 5, and kinda mostly support it in earlier releases of 6, on balance we might as well continue to allow it. It's not like it's wrong wrong, just something that's probably bad most of the time.

Indeed, this patch goes so far as to allow this sort of comparison _in general_ when JDBC types match in a "reasonable" way. Where "reasonable" involves some handwavey heuristics. Not perfect but I guess this probably a case where worse is better.

UPDATE: I was also obligated to "fix" the non-bug HHH-16859 by side-effect of cleaning up another issue with type-checking of enum function args. Once again, I'm really not sold that `max(enum)` is a great thing to write, but given that we used to allow it, it's pretty hard for me to justify inserting new code to specifically _disallow_ it.