### PR TITLE
HHH-16876 Supports Oracle 23c FREE Developer Release for CI

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -179,6 +179,10 @@ The following table illustrates a list of commands for various databases that ca
 |`./docker_db.sh oracle`
 |`./gradlew test -Pdb=oracle_ci`
 
+|Oracle FREE (23c+)
+|`./docker_db.sh oracle_free`
+|`./gradlew test -Pdb=oracle_free_ci`
+
 |DB2
 |`./docker_db.sh db2`
 |`./gradlew test -Pdb=db2_ci`

--- a/ci/build.sh
+++ b/ci/build.sh
@@ -21,6 +21,10 @@ elif [ "$RDBMS" == "edb" ] || [ "$RDBMS" == "edb_10" ]; then
 elif [ "$RDBMS" == "oracle" ]; then
   # I have no idea why, but these tests don't seem to work on CI...
   goal="-Pdb=oracle_ci -PexcludeTests=**.LockTest.testQueryTimeout*"
+elif [ "$RDBMS" == "oracle_free" ]; then
+  # Used starting from 23c because of the renaming of the default pluggable database
+  # I have no idea why, but these tests don't seem to work on CI...
+  goal="-Pdb=oracle_free_ci -PexcludeTests=**.LockTest.testQueryTimeout*"
 elif [ "$RDBMS" == "oracle_11_2" ]; then
   # I have no idea why, but these tests don't seem to work on CI...
   goal="-Pdb=oracle_legacy_ci -PexcludeTests=**.LockTest.testQueryTimeout*"

--- a/docker_db.sh
+++ b/docker_db.sh
@@ -514,6 +514,81 @@ grant all privileges to hibernate_orm_test;
 EOF\""
 }
 
+oracle_free_setup() {
+    HEALTHSTATUS=
+    until [ "$HEALTHSTATUS" == "healthy" ];
+    do
+        echo "Waiting for Oracle to start..."
+        sleep 5;
+        # On WSL, health-checks intervals don't work for Podman, so run them manually
+        if command -v podman > /dev/null; then
+          $CONTAINER_CLI healthcheck run oracle > /dev/null
+        fi
+        HEALTHSTATUS="`$CONTAINER_CLI inspect -f $HEALTCHECK_PATH oracle`"
+        HEALTHSTATUS=${HEALTHSTATUS##+( )} #Remove longest matching series of spaces from the front
+        HEALTHSTATUS=${HEALTHSTATUS%%+( )} #Remove longest matching series of spaces from the back
+    done
+    sleep 2;
+    echo "Oracle successfully started"
+    # We increase file sizes to avoid online resizes as that requires lots of CPU which is restricted in XE
+    $CONTAINER_CLI exec oracle bash -c "source /home/oracle/.bashrc; bash -c \"
+cat <<EOF | \$ORACLE_HOME/bin/sqlplus / as sysdba
+set timing on
+-- Increasing redo logs
+alter database add logfile group 4 '\$ORACLE_BASE/oradata/FREE/redo04.log' size 500M reuse;
+alter database add logfile group 5 '\$ORACLE_BASE/oradata/FREE/redo05.log' size 500M reuse;
+alter database add logfile group 6 '\$ORACLE_BASE/oradata/FREE/redo06.log' size 500M reuse;
+alter system switch logfile;
+alter system switch logfile;
+alter system switch logfile;
+alter system checkpoint;
+alter database drop logfile group 1;
+alter database drop logfile group 2;
+alter database drop logfile group 3;
+!rm \$ORACLE_BASE/oradata/FREE/redo01.log
+!rm \$ORACLE_BASE/oradata/FREE/redo02.log
+!rm \$ORACLE_BASE/oradata/FREE/redo03.log
+
+-- Increasing SYSAUX data file
+alter database datafile '\$ORACLE_BASE/oradata/FREE/sysaux01.dbf' resize 600M;
+
+-- Modifying database init parameters
+alter system set open_cursors=1000 sid='*' scope=both;
+alter system set session_cached_cursors=500 sid='*' scope=spfile;
+alter system set db_securefile=ALWAYS sid='*' scope=spfile;
+alter system set dispatchers='(PROTOCOL=TCP)(SERVICE=FREEXDB)(DISPATCHERS=0)' sid='*' scope=spfile;
+alter system set recyclebin=OFF sid='*' SCOPE=SPFILE;
+
+-- Comment the 2 next lines to be able to use Diagnostics Pack features
+alter system set sga_target=0m sid='*' scope=both;
+-- alter system set statistics_level=BASIC sid='*' scope=spfile;
+
+-- Restart the database
+SHUTDOWN IMMEDIATE;
+STARTUP MOUNT;
+ALTER DATABASE OPEN;
+
+-- Switch to the FREEPDB1 pluggable database
+alter session set container=freepdb1;
+
+-- Modify FREEPDB1 datafiles and tablespaces
+alter database datafile '\$ORACLE_BASE/oradata/FREE/FREEPDB1/system01.dbf' resize 320M;
+alter database datafile '\$ORACLE_BASE/oradata/FREE/FREEPDB1/sysaux01.dbf' resize 360M;
+alter database datafile '\$ORACLE_BASE/oradata/FREE/FREEPDB1/undotbs01.dbf' resize 400M;
+alter database datafile '\$ORACLE_BASE/oradata/FREE/FREEPDB1/undotbs01.dbf' autoextend on next 16M;
+alter database tempfile '\$ORACLE_BASE/oradata/FREE/FREEPDB1/temp01.dbf' resize 400M;
+alter database tempfile '\$ORACLE_BASE/oradata/FREE/FREEPDB1/temp01.dbf' autoextend on next 16M;
+alter database datafile '\$ORACLE_BASE/oradata/FREE/FREEPDB1/users01.dbf' resize 100M;
+alter database datafile '\$ORACLE_BASE/oradata/FREE/FREEPDB1/users01.dbf' autoextend on next 16M;
+alter tablespace USERS nologging;
+alter tablespace SYSTEM nologging;
+alter tablespace SYSAUX nologging;
+
+create user hibernate_orm_test identified by hibernate_orm_test quota unlimited on users;
+grant all privileges to hibernate_orm_test;
+EOF\""
+}
+
 oracle_setup_old() {
     HEALTHSTATUS=
     until [ "$HEALTHSTATUS" == "healthy" ];
@@ -620,6 +695,23 @@ oracle_21() {
        --health-retries 10 \
        docker.io/gvenzl/oracle-xe:21.3.0-full
     oracle_setup
+}
+
+oracle_free() {
+  oracle_23
+}
+
+oracle_23() {
+    $CONTAINER_CLI rm -f oracle || true
+    # We need to use the defaults
+    # SYSTEM/Oracle18
+    $CONTAINER_CLI run --name oracle -d -p 1521:1521 -e ORACLE_PASSWORD=Oracle18 \
+       --health-cmd healthcheck.sh \
+       --health-interval 5s \
+       --health-timeout 5s \
+       --health-retries 10 \
+       docker.io/gvenzl/oracle-free:23-full
+    oracle_free_setup
 }
 
 hana() {
@@ -869,6 +961,7 @@ if [ -z ${1} ]; then
     echo -e "\tmysql_8_0"
     echo -e "\tmysql_5_7"
     echo -e "\toracle"
+    echo -e "\toracle_23"
     echo -e "\toracle_21"
     echo -e "\toracle_18"
     echo -e "\toracle_11"

--- a/docker_db.sh
+++ b/docker_db.sh
@@ -518,7 +518,7 @@ oracle_free_setup() {
     HEALTHSTATUS=
     until [ "$HEALTHSTATUS" == "healthy" ];
     do
-        echo "Waiting for Oracle to start..."
+        echo "Waiting for Oracle Free to start..."
         sleep 5;
         # On WSL, health-checks intervals don't work for Podman, so run them manually
         if command -v podman > /dev/null; then

--- a/gradle/databases.gradle
+++ b/gradle/databases.gradle
@@ -147,6 +147,14 @@ ext {
                         'jdbc.url'   : 'jdbc:oracle:thin:@' + dbHost + ':1521/xepdb1',
                         'connection.init_sql' : ''
                 ],
+                oracle_free_ci : [
+                        'db.dialect' : 'org.hibernate.dialect.OracleDialect',
+                        'jdbc.driver': 'oracle.jdbc.OracleDriver',
+                        'jdbc.user'  : 'hibernate_orm_test',
+                        'jdbc.pass'  : 'hibernate_orm_test',
+                        'jdbc.url'   : 'jdbc:oracle:thin:@' + dbHost + ':1521/freepdb1',
+                        'connection.init_sql' : ''
+                ],
                 oracle_legacy_ci : [
                         'db.dialect' : 'org.hibernate.dialect.OracleDialect',
                         'jdbc.driver': 'oracle.jdbc.OracleDriver',

--- a/hibernate-spatial/hibernate-spatial.gradle
+++ b/hibernate-spatial/hibernate-spatial.gradle
@@ -50,6 +50,7 @@ tasks.test {
 			   'mysql_ci',
 			   'oracle',
 			   'oracle_ci',
+			   'oracle_free_ci',
 			   'mssql',
 			   'mssql_ci'
 	].contains( project.db )


### PR DESCRIPTION
This PR brings the support of the 23c FREE Developer Release docker image from Gerald Venzl for Hibernate.
It adds 2 entries into `docker_db.sh`:
- oracle_23
- oracle_free (which is an alias)

It adds a CI pipeline called `oracle_free_ci` that aims at producing the correct JDBC connection string to the *freepdb1* pluggable database (since it was renamed from xepdb1).

HTH