### PR TITLE
fix up lots of errors in generic typing related to DomainTypes...

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/boot/query/HbmResultSetMappingDescriptor.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/query/HbmResultSetMappingDescriptor.java
@@ -402,7 +402,7 @@ public class HbmResultSetMappingDescriptor implements NamedResultSetMappingDescr
 				}
 
 				discriminatorMemento = new FetchMementoBasicStandard(
-						entityPath.append( EntityDiscriminatorMapping.ROLE_NAME ),
+						entityPath.append( EntityDiscriminatorMapping.DISCRIMINATOR_ROLE_NAME ),
 						entityDescriptor.getDiscriminatorMapping(),
 						discriminatorColumnAlias
 				);

--- a/hibernate-core/src/main/java/org/hibernate/boot/query/SqlResultSetMappingDescriptor.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/query/SqlResultSetMappingDescriptor.java
@@ -285,7 +285,7 @@ public class SqlResultSetMappingDescriptor implements NamedResultSetMappingDescr
 			}
 
 			return new FetchMementoBasicStandard(
-					entityPath.append( EntityDiscriminatorMapping.ROLE_NAME ),
+					entityPath.append( EntityDiscriminatorMapping.DISCRIMINATOR_ROLE_NAME ),
 					discriminatorMapping,
 					discriminatorColumn
 			);

--- a/hibernate-core/src/main/java/org/hibernate/graph/RootGraph.java
+++ b/hibernate-core/src/main/java/org/hibernate/graph/RootGraph.java
@@ -24,10 +24,6 @@ import org.hibernate.metamodel.model.domain.PersistentAttribute;
  */
 public interface RootGraph<J> extends Graph<J>, EntityGraph<J> {
 
-//	boolean appliesTo(String entityName);
-//
-//	boolean appliesTo(Class<?> entityType);
-
 	@Override
 	RootGraph<J> makeRootGraph(String name, boolean mutable);
 

--- a/hibernate-core/src/main/java/org/hibernate/graph/internal/RootGraphImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/graph/internal/RootGraphImpl.java
@@ -7,22 +7,18 @@
 package org.hibernate.graph.internal;
 
 import org.hibernate.graph.SubGraph;
+import org.hibernate.graph.spi.GraphHelper;
 import org.hibernate.graph.spi.GraphImplementor;
 import org.hibernate.graph.spi.RootGraphImplementor;
 import org.hibernate.graph.spi.SubGraphImplementor;
 import org.hibernate.metamodel.model.domain.EntityDomainType;
-import org.hibernate.metamodel.model.domain.IdentifiableDomainType;
-import org.hibernate.metamodel.model.domain.JpaMetamodel;
-import org.hibernate.metamodel.model.domain.ManagedDomainType;
-
-import jakarta.persistence.EntityGraph;
 
 /**
- * The Hibernate implementation of the JPA EntityGraph contract.
+ * Implementation of the JPA-defined {@link jakarta.persistence.EntityGraph} interface.
  *
  * @author Steve Ebersole
  */
-public class RootGraphImpl<J> extends AbstractGraph<J> implements EntityGraph<J>, RootGraphImplementor<J> {
+public class RootGraphImpl<J> extends AbstractGraph<J> implements RootGraphImplementor<J> {
 
 	private final String name;
 
@@ -66,30 +62,7 @@ public class RootGraphImpl<J> extends AbstractGraph<J> implements EntityGraph<J>
 	}
 
 	@Override
-	public boolean appliesTo(EntityDomainType<?> entityType, JpaMetamodel metamodel) {
-		final ManagedDomainType<J> managedTypeDescriptor = getGraphedType();
-		if ( managedTypeDescriptor.equals( entityType ) ) {
-			return true;
-		}
-
-		IdentifiableDomainType<?> superType = entityType.getSupertype();
-		while ( superType != null ) {
-			if ( managedTypeDescriptor.equals( superType ) ) {
-				return true;
-			}
-			superType = superType.getSupertype();
-		}
-
-		return false;
-	}
-
-	@Override
-	public boolean appliesTo(String entityName, JpaMetamodel metamodel) {
-		return appliesTo( metamodel.entity( entityName ), metamodel );
-	}
-
-	@Override
-	public boolean appliesTo(Class<?> type, JpaMetamodel metamodel) {
-		return appliesTo( metamodel.entity( type ), metamodel );
+	public boolean appliesTo(EntityDomainType<?> entityType) {
+		return GraphHelper.appliesTo( this, entityType );
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/graph/internal/SubGraphImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/graph/internal/SubGraphImpl.java
@@ -7,10 +7,11 @@
 package org.hibernate.graph.internal;
 
 import org.hibernate.graph.spi.SubGraphImplementor;
-import org.hibernate.metamodel.model.domain.JpaMetamodel;
 import org.hibernate.metamodel.model.domain.ManagedDomainType;
 
 /**
+ * Implementation of the JPA-defined {@link jakarta.persistence.Subgraph} interface.
+ *
  * @author Steve Ebersole
  */
 public class SubGraphImpl<J> extends AbstractGraph<J> implements SubGraphImplementor<J> {
@@ -38,25 +39,4 @@ public class SubGraphImpl<J> extends AbstractGraph<J> implements SubGraphImpleme
 		return super.addKeySubGraph( attributeName );
 	}
 
-	@Override
-	public boolean appliesTo(ManagedDomainType<?> managedType, JpaMetamodel metamodel) {
-		if ( getGraphedType().equals( managedType ) ) {
-			return true;
-		}
-
-		ManagedDomainType<?> superType = managedType.getSuperType();
-		while ( superType != null ) {
-			if ( superType.equals( managedType ) ) {
-				return true;
-			}
-			superType = superType.getSuperType();
-		}
-
-		return false;
-	}
-
-	@Override
-	public boolean appliesTo(Class<?> javaType, JpaMetamodel metamodel) {
-		return appliesTo( metamodel.managedType( javaType ), metamodel );
-	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/graph/internal/parse/PathQualifierType.java
+++ b/hibernate-core/src/main/java/org/hibernate/graph/internal/parse/PathQualifierType.java
@@ -8,8 +8,10 @@ package org.hibernate.graph.internal.parse;
 
 import org.hibernate.graph.CannotContainSubGraphException;
 import org.hibernate.metamodel.model.domain.DomainType;
-import org.hibernate.metamodel.model.domain.SimpleDomainType;
 import org.hibernate.metamodel.model.domain.ManagedDomainType;
+import org.hibernate.metamodel.model.domain.spi.JpaMetamodelImplementor;
+
+import static org.hibernate.metamodel.model.domain.internal.DomainModelHelper.resolveSubType;
 
 /**
  * @author Steve Ebersole
@@ -21,7 +23,8 @@ public enum PathQualifierType {
 					attributeNode.makeKeySubGraph(
 							resolveSubTypeManagedType(
 									attributeNode.getAttributeDescriptor().getKeyGraphType(),
-									subTypeName
+									subTypeName,
+									sessionFactory.getJpaMetamodel()
 							)
 					)
 	),
@@ -30,14 +33,16 @@ public enum PathQualifierType {
 					attributeNode.makeSubGraph(
 							resolveSubTypeManagedType(
 									attributeNode.getAttributeDescriptor().getValueGraphType(),
-									subTypeName
+									subTypeName,
+									sessionFactory.getJpaMetamodel()
 							)
 					)
 	);
 
 	private static ManagedDomainType resolveSubTypeManagedType(
 			DomainType<?> graphType,
-			String subTypeName) {
+			String subTypeName,
+			JpaMetamodelImplementor metamodel) {
 		if ( !( graphType instanceof ManagedDomainType ) ) {
 			throw new CannotContainSubGraphException( "The given type [" + graphType + "] is not a ManagedType" );
 		}
@@ -45,7 +50,7 @@ public enum PathQualifierType {
 		ManagedDomainType managedType = (ManagedDomainType) graphType;
 
 		if ( subTypeName != null ) {
-			managedType = managedType.findSubType( subTypeName );
+			managedType = resolveSubType( managedType, subTypeName, metamodel );
 		}
 		return managedType;
 	}

--- a/hibernate-core/src/main/java/org/hibernate/graph/spi/AttributeNodeImplementor.java
+++ b/hibernate-core/src/main/java/org/hibernate/graph/spi/AttributeNodeImplementor.java
@@ -33,13 +33,13 @@ public interface AttributeNodeImplementor<J> extends AttributeNode<J>, GraphNode
 	}
 
 	@Override
-	@SuppressWarnings("unchecked")
+	@SuppressWarnings({"unchecked", "rawtypes"})
 	default Map<Class<? extends J>, SubGraph<? extends J>> getSubGraphs() {
 		return (Map) getSubGraphMap();
 	}
 
 	@Override
-	@SuppressWarnings("unchecked")
+	@SuppressWarnings({"unchecked", "rawtypes"})
 	default Map<Class<? extends J>, SubGraph<? extends J>> getKeySubGraphs() {
 		return (Map) getKeySubGraphMap();
 	}
@@ -51,7 +51,7 @@ public interface AttributeNodeImplementor<J> extends AttributeNode<J>, GraphNode
 	}
 
 	@Override
-	@SuppressWarnings("unchecked")
+	@SuppressWarnings({"unchecked", "rawtypes"})
 	default Map<Class, Subgraph> getKeySubgraphs() {
 		return (Map) getKeySubGraphMap();
 	}

--- a/hibernate-core/src/main/java/org/hibernate/graph/spi/GraphHelper.java
+++ b/hibernate-core/src/main/java/org/hibernate/graph/spi/GraphHelper.java
@@ -6,11 +6,8 @@
  */
 package org.hibernate.graph.spi;
 
-import org.hibernate.metamodel.model.domain.IdentifiableDomainType;
-import org.hibernate.metamodel.model.domain.SimpleDomainType;
-import org.hibernate.metamodel.model.domain.MapPersistentAttribute;
-import org.hibernate.metamodel.model.domain.PluralPersistentAttribute;
-import org.hibernate.metamodel.model.domain.SingularPersistentAttribute;
+import org.hibernate.graph.Graph;
+import org.hibernate.metamodel.model.domain.ManagedDomainType;
 
 /**
  * Helper containing utilities useful for graph handling
@@ -18,41 +15,17 @@ import org.hibernate.metamodel.model.domain.SingularPersistentAttribute;
  * @author Steve Ebersole
  */
 public class GraphHelper {
-	@SuppressWarnings("unchecked")
-	public static <J> SimpleDomainType<J> resolveKeyTypeDescriptor(SingularPersistentAttribute attribute) {
-		// only valid for entity-valued attributes where the entity has a
-		// composite id
-		final SimpleDomainType attributeType = attribute.getType();
-		if ( attributeType instanceof IdentifiableDomainType ) {
-			return ( (IdentifiableDomainType) attributeType ).getIdType();
-		}
 
-		return null;
+	public static boolean appliesTo(Graph<?> graph, ManagedDomainType<?> managedType) {
+		final ManagedDomainType<?> graphedType = graph.getGraphedType();
+		ManagedDomainType<?> superType = managedType;
+		while ( superType != null ) {
+			if ( graphedType.equals( superType ) ) {
+				return true;
+			}
+			superType = superType.getSuperType();
+		}
+		return false;
 	}
 
-	@SuppressWarnings({"unchecked", "ConstantConditions"})
-	public static <J> SimpleDomainType<J> resolveKeyTypeDescriptor(PluralPersistentAttribute attribute) {
-		if ( attribute instanceof SingularPersistentAttribute ) {
-			// only valid for entity-valued attributes where the entity has a
-			// composite id
-			final SimpleDomainType attributeType = ( (SingularPersistentAttribute) attribute ).getType();
-			if ( attributeType instanceof IdentifiableDomainType ) {
-				return ( (IdentifiableDomainType) attributeType ).getIdType();
-			}
-
-			return null;
-		}
-		else if ( attribute instanceof PluralPersistentAttribute ) {
-			if ( attribute instanceof MapPersistentAttribute ) {
-				return ( (MapPersistentAttribute) attribute ).getKeyType();
-			}
-
-			return null;
-		}
-
-		throw new IllegalArgumentException(
-				"Unexpected Attribute Class [" + attribute.getClass().getName()
-						+ "] - expecting SingularAttributeImplementor or PluralAttributeImplementor"
-		);
-	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/graph/spi/GraphImplementor.java
+++ b/hibernate-core/src/main/java/org/hibernate/graph/spi/GraphImplementor.java
@@ -13,8 +13,6 @@ import org.hibernate.graph.AttributeNode;
 import org.hibernate.graph.CannotBecomeEntityGraphException;
 import org.hibernate.graph.CannotContainSubGraphException;
 import org.hibernate.graph.Graph;
-import org.hibernate.metamodel.model.domain.JpaMetamodel;
-import org.hibernate.metamodel.model.domain.ManagedDomainType;
 import org.hibernate.metamodel.model.domain.PersistentAttribute;
 
 /**
@@ -26,15 +24,11 @@ import org.hibernate.metamodel.model.domain.PersistentAttribute;
  */
 public interface GraphImplementor<J> extends Graph<J>, GraphNodeImplementor<J> {
 
-	boolean appliesTo(ManagedDomainType<?> managedType, JpaMetamodel metamodel);
-
-	boolean appliesTo(Class<?> javaType, JpaMetamodel metamodel);
-
 	void merge(GraphImplementor<? extends J> other);
 
 
 	// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-	// Co-variant returns
+	// Covariant returns
 
 	@Override
 	RootGraphImplementor<J> makeRootGraph(String name, boolean mutable)

--- a/hibernate-core/src/main/java/org/hibernate/graph/spi/RootGraphImplementor.java
+++ b/hibernate-core/src/main/java/org/hibernate/graph/spi/RootGraphImplementor.java
@@ -8,25 +8,17 @@ package org.hibernate.graph.spi;
 
 import org.hibernate.graph.RootGraph;
 import org.hibernate.metamodel.model.domain.EntityDomainType;
-import org.hibernate.metamodel.model.domain.JpaMetamodel;
-import org.hibernate.metamodel.model.domain.ManagedDomainType;
 
 /**
- * Integration version of the {@link RootGraph} contract
+ * Integration version of the {@link RootGraph} contract.
  *
  * @author Steve Ebersole
+ *
+ * @see SubGraphImplementor
  */
 public interface RootGraphImplementor<J> extends RootGraph<J>, GraphImplementor<J> {
 
-	boolean appliesTo(String entityName, JpaMetamodel metamodel);
-
-	boolean appliesTo(EntityDomainType<?> entityType, JpaMetamodel metamodel);
-
-	@Override
-	default boolean appliesTo(ManagedDomainType<?> managedType, JpaMetamodel metamodel) {
-		assert managedType instanceof EntityDomainType;
-		return appliesTo( (EntityDomainType<?>) managedType, metamodel );
-	}
+	boolean appliesTo(EntityDomainType<?> entityType);
 
 	@Override
 	RootGraphImplementor<J> makeRootGraph(String name, boolean mutable);

--- a/hibernate-core/src/main/java/org/hibernate/graph/spi/SubGraphImplementor.java
+++ b/hibernate-core/src/main/java/org/hibernate/graph/spi/SubGraphImplementor.java
@@ -12,11 +12,14 @@ import org.hibernate.graph.SubGraph;
 import org.hibernate.metamodel.model.domain.PersistentAttribute;
 
 /**
- * Integration version of the {@link SubGraph} contract
+ * Integration version of the {@link SubGraph} contract.
  *
  * @author Steve Ebersole
+ *
+ * @see RootGraphImplementor
  */
 public interface SubGraphImplementor<J> extends SubGraph<J>, GraphImplementor<J> {
+
 	@Override
 	SubGraphImplementor<J> makeCopy(boolean mutable);
 

--- a/hibernate-core/src/main/java/org/hibernate/internal/SessionImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/SessionImpl.java
@@ -1064,7 +1064,8 @@ public class SessionImpl
 		final GraphSemantic semantic = effectiveEntityGraph.getSemantic();
 		final RootGraphImplementor<?> graph = effectiveEntityGraph.getGraph();
 		boolean clearedEffectiveGraph;
-		if ( semantic == null || graph.appliesTo( entityName, getFactory().getJpaMetamodel() ) ) {
+		if ( semantic == null
+				|| graph.appliesTo( getFactory().getJpaMetamodel().entity( entityName ) ) ) {
 			clearedEffectiveGraph = false;
 		}
 		else {

--- a/hibernate-core/src/main/java/org/hibernate/loader/ast/internal/AbstractNaturalIdLoader.java
+++ b/hibernate-core/src/main/java/org/hibernate/loader/ast/internal/AbstractNaturalIdLoader.java
@@ -6,7 +6,6 @@
  */
 package org.hibernate.loader.ast.internal;
 
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
@@ -267,7 +266,7 @@ public abstract class AbstractNaturalIdLoader<T> implements NaturalIdLoader<T> {
 				naturalIdMapping().normalizeInput( naturalIdValue ),
 				NaturalIdLoadOptions.NONE,
 				(tableGroup, creationState) -> entityDescriptor.getIdentifierMapping().createDomainResult(
-						tableGroup.getNavigablePath().append( EntityIdentifierMapping.ROLE_LOCAL_NAME ),
+						tableGroup.getNavigablePath().append( EntityIdentifierMapping.ID_ROLE_NAME ),
 						tableGroup,
 						null,
 						creationState

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/internal/AbstractCompositeIdentifierMapping.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/internal/AbstractCompositeIdentifierMapping.java
@@ -47,7 +47,6 @@ import org.hibernate.sql.results.graph.FetchParent;
 import org.hibernate.sql.results.graph.embeddable.EmbeddableValuedFetchable;
 import org.hibernate.sql.results.graph.embeddable.internal.EmbeddableFetchImpl;
 import org.hibernate.sql.results.graph.embeddable.internal.EmbeddableResultImpl;
-import org.hibernate.type.descriptor.java.JavaType;
 
 /**
  * Base implementation for composite identifier mappings
@@ -67,7 +66,7 @@ public abstract class AbstractCompositeIdentifierMapping
 			EntityMappingType entityMapping,
 			String tableExpression,
 			MappingModelCreationProcess creationProcess) {
-		this.navigableRole = entityMapping.getNavigableRole().appendContainer( EntityIdentifierMapping.ROLE_LOCAL_NAME );
+		this.navigableRole = entityMapping.getNavigableRole().appendContainer( EntityIdentifierMapping.ID_ROLE_NAME );
 		this.entityMapping = entityMapping;
 		this.tableExpression = tableExpression;
 		this.sessionFactory = creationProcess.getCreationContext().getSessionFactory();

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/internal/PluralAttributeMetadataImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/internal/PluralAttributeMetadataImpl.java
@@ -30,8 +30,8 @@ class PluralAttributeMetadataImpl<X, Y, E>
 	private final CollectionClassification collectionClassification;
 	private final AttributeClassification elementClassification;
 	private final AttributeClassification listIndexOrMapKeyClassification;
-	private final Class elementJavaType;
-	private final Class keyJavaType;
+	private final Class<?> elementJavaType;
+	private final Class<?> keyJavaType;
 	private final ValueContext elementValueContext;
 	private final ValueContext keyValueContext;
 
@@ -86,7 +86,7 @@ class PluralAttributeMetadataImpl<X, Y, E>
 				return ( (Collection) getPropertyMapping().getValue() ).getElement();
 			}
 
-			public Class getJpaBindableType() {
+			public Class<?> getJpaBindableType() {
 				return elementJavaType;
 			}
 
@@ -104,7 +104,7 @@ class PluralAttributeMetadataImpl<X, Y, E>
 				}
 			}
 
-			public AttributeMetadata getAttributeMetadata() {
+			public AttributeMetadata<X,Y> getAttributeMetadata() {
 				return PluralAttributeMetadataImpl.this;
 			}
 		};
@@ -116,7 +116,7 @@ class PluralAttributeMetadataImpl<X, Y, E>
 					return ( (Map) getPropertyMapping().getValue() ).getIndex();
 				}
 
-				public Class getJpaBindableType() {
+				public Class<?> getJpaBindableType() {
 					return keyJavaType;
 				}
 
@@ -134,7 +134,7 @@ class PluralAttributeMetadataImpl<X, Y, E>
 					}
 				}
 
-				public AttributeMetadata getAttributeMetadata() {
+				public AttributeMetadata<X,Y> getAttributeMetadata() {
 					return PluralAttributeMetadataImpl.this;
 				}
 			};
@@ -146,10 +146,10 @@ class PluralAttributeMetadataImpl<X, Y, E>
 
 	private Class<?> getClassFromGenericArgument(java.lang.reflect.Type type) {
 		if ( type instanceof Class ) {
-			return (Class) type;
+			return (Class<?>) type;
 		}
 		else if ( type instanceof TypeVariable ) {
-			final java.lang.reflect.Type upperBound = ( (TypeVariable) type ).getBounds()[0];
+			final java.lang.reflect.Type upperBound = ( (TypeVariable<?>) type ).getBounds()[0];
 			return getClassFromGenericArgument( upperBound );
 		}
 		else if ( type instanceof ParameterizedType ) {
@@ -168,7 +168,7 @@ class PluralAttributeMetadataImpl<X, Y, E>
 		}
 	}
 
-	public static CollectionClassification determineCollectionType(Class javaType, Property property) {
+	public static CollectionClassification determineCollectionType(Class<?> javaType, Property property) {
 		final Collection collection = (Collection) property.getValue();
 
 		if ( java.util.List.class.isAssignableFrom( javaType ) ) {

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/internal/PluralAttributeMetadataImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/internal/PluralAttributeMetadataImpl.java
@@ -53,11 +53,11 @@ class PluralAttributeMetadataImpl<X, Y, E>
 			case MAP:
 			case SORTED_MAP:
 			case ORDERED_MAP: {
-				this.keyJavaType = signatureType != null
+				keyJavaType = signatureType != null
 						? getClassFromGenericArgument( signatureType.getActualTypeArguments()[0] )
 						: Object.class;
 
-				this.elementJavaType = signatureType != null
+				elementJavaType = signatureType != null
 						? getClassFromGenericArgument( signatureType.getActualTypeArguments()[1] )
 						: Object.class;
 
@@ -65,75 +65,63 @@ class PluralAttributeMetadataImpl<X, Y, E>
 			}
 			case ARRAY:
 			case LIST: {
-				this.keyJavaType = Integer.class;
+				keyJavaType = Integer.class;
 
-				this.elementJavaType = signatureType != null
+				elementJavaType = signatureType != null
 						? getClassFromGenericArgument( signatureType.getActualTypeArguments()[0] )
 						: Object.class;
 
 				break;
 			}
 			default: {
-				this.elementJavaType = signatureType != null
+				elementJavaType = signatureType != null
 						? getClassFromGenericArgument( signatureType.getActualTypeArguments()[0] )
 						: Object.class;
-				this.keyJavaType = null;
+				keyJavaType = null;
 			}
 		}
 
-		this.elementValueContext = new ValueContext() {
+		elementValueContext = new ValueContext() {
+			@Override
 			public Value getHibernateValue() {
 				return ( (Collection) getPropertyMapping().getValue() ).getElement();
 			}
 
+			@Override
 			public Class<?> getJpaBindableType() {
 				return elementJavaType;
 			}
 
+			@Override
 			public ValueClassification getValueClassification() {
-				switch ( PluralAttributeMetadataImpl.this.elementClassification ) {
-					case EMBEDDED: {
-						return ValueClassification.EMBEDDABLE;
-					}
-					case BASIC: {
-						return ValueClassification.BASIC;
-					}
-					default: {
-						return ValueClassification.ENTITY;
-					}
-				}
+				return toValueClassification(PluralAttributeMetadataImpl.this.elementClassification);
 			}
 
+			@Override
 			public AttributeMetadata<X,Y> getAttributeMetadata() {
 				return PluralAttributeMetadataImpl.this;
 			}
 		};
 
 		// interpret the key, if one
-		if ( this.listIndexOrMapKeyClassification != null ) {
-			this.keyValueContext = new ValueContext() {
+		if ( listIndexOrMapKeyClassification != null ) {
+			keyValueContext = new ValueContext() {
+				@Override
 				public Value getHibernateValue() {
 					return ( (Map) getPropertyMapping().getValue() ).getIndex();
 				}
 
+				@Override
 				public Class<?> getJpaBindableType() {
 					return keyJavaType;
 				}
 
+				@Override
 				public ValueClassification getValueClassification() {
-					switch ( PluralAttributeMetadataImpl.this.listIndexOrMapKeyClassification ) {
-						case EMBEDDED: {
-							return ValueClassification.EMBEDDABLE;
-						}
-						case BASIC: {
-							return ValueClassification.BASIC;
-						}
-						default: {
-							return ValueClassification.ENTITY;
-						}
-					}
+					return toValueClassification(PluralAttributeMetadataImpl.this.listIndexOrMapKeyClassification);
 				}
 
+				@Override
 				public AttributeMetadata<X,Y> getAttributeMetadata() {
 					return PluralAttributeMetadataImpl.this;
 				}
@@ -141,6 +129,17 @@ class PluralAttributeMetadataImpl<X, Y, E>
 		}
 		else {
 			keyValueContext = null;
+		}
+	}
+
+	private static ValueClassification toValueClassification(AttributeClassification classification) {
+		switch ( classification ) {
+			case EMBEDDED:
+				return ValueClassification.EMBEDDABLE;
+			case BASIC:
+				return ValueClassification.BASIC;
+			default:
+				return ValueClassification.ENTITY;
 		}
 	}
 
@@ -211,6 +210,7 @@ class PluralAttributeMetadataImpl<X, Y, E>
 		}
 	}
 
+	@Override
 	public ValueContext getElementValueContext() {
 		return elementValueContext;
 	}
@@ -220,6 +220,7 @@ class PluralAttributeMetadataImpl<X, Y, E>
 		return collectionClassification;
 	}
 
+	@Override
 	public ValueContext getMapKeyValueContext() {
 		return keyValueContext;
 	}

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/internal/SingularAttributeMetadataImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/internal/SingularAttributeMetadataImpl.java
@@ -29,14 +29,17 @@ public class SingularAttributeMetadataImpl<X, Y> extends BaseAttributeMetadata<X
 			MetadataContext metadataContext) {
 		super( propertyMapping, ownerType, member, attributeClassification, metadataContext );
 		valueContext = new ValueContext() {
+			@Override
 			public Value getHibernateValue() {
 				return getPropertyMapping().getValue();
 			}
 
+			@Override
 			public Class<Y> getJpaBindableType() {
 				return getAttributeMetadata().getJavaType();
 			}
 
+			@Override
 			public ValueClassification getValueClassification() {
 				switch ( attributeClassification ) {
 					case EMBEDDED: {
@@ -51,12 +54,14 @@ public class SingularAttributeMetadataImpl<X, Y> extends BaseAttributeMetadata<X
 				}
 			}
 
+			@Override
 			public AttributeMetadata<X,Y> getAttributeMetadata() {
 				return SingularAttributeMetadataImpl.this;
 			}
 		};
 	}
 
+	@Override
 	public ValueContext getValueContext() {
 		return valueContext;
 	}

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/internal/SingularAttributeMetadataImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/internal/SingularAttributeMetadataImpl.java
@@ -33,7 +33,7 @@ public class SingularAttributeMetadataImpl<X, Y> extends BaseAttributeMetadata<X
 				return getPropertyMapping().getValue();
 			}
 
-			public Class getJpaBindableType() {
+			public Class<Y> getJpaBindableType() {
 				return getAttributeMetadata().getJavaType();
 			}
 
@@ -51,7 +51,7 @@ public class SingularAttributeMetadataImpl<X, Y> extends BaseAttributeMetadata<X
 				}
 			}
 
-			public AttributeMetadata getAttributeMetadata() {
+			public AttributeMetadata<X,Y> getAttributeMetadata() {
 				return SingularAttributeMetadataImpl.this;
 			}
 		};

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/internal/ValueContext.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/internal/ValueContext.java
@@ -17,7 +17,7 @@ public interface ValueContext {
 
 	Value getHibernateValue();
 
-	Class getJpaBindableType();
+	Class<?> getJpaBindableType();
 
-	AttributeMetadata getAttributeMetadata();
+	AttributeMetadata<?,?> getAttributeMetadata();
 }

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/EntityDiscriminatorMapping.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/EntityDiscriminatorMapping.java
@@ -29,16 +29,18 @@ import org.hibernate.sql.results.graph.basic.BasicFetch;
  * @author Steve Ebersole
  */
 public interface EntityDiscriminatorMapping extends DiscriminatorMapping, FetchOptions {
-	String ROLE_NAME = "{discriminator}";
-	String LEGACY_HQL_ROLE_NAME = "class";
+
+	String DISCRIMINATOR_ROLE_NAME = "{discriminator}";
+	String LEGACY_DISCRIMINATOR_NAME = "class";
 
 	static boolean matchesRoleName(String name) {
-		return ROLE_NAME.equals( name ) || LEGACY_HQL_ROLE_NAME.equals( name );
+		return DISCRIMINATOR_ROLE_NAME.equals( name )
+			|| LEGACY_DISCRIMINATOR_NAME.equalsIgnoreCase( name );
 	}
 
 	@Override
 	default String getPartName() {
-		return ROLE_NAME;
+		return DISCRIMINATOR_ROLE_NAME;
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/EntityIdentifierMapping.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/EntityIdentifierMapping.java
@@ -25,11 +25,17 @@ import jakarta.persistence.IdClass;
  */
 public interface EntityIdentifierMapping extends ValuedModelPart {
 
-	String ROLE_LOCAL_NAME = "{id}";
+	String ID_ROLE_NAME = "{id}";
+	String LEGACY_ID_NAME = "id";
+
+	static boolean matchesRoleName(String name) {
+		return LEGACY_ID_NAME.equalsIgnoreCase( name )
+			|| ID_ROLE_NAME.equals( name );
+	}
 
 	@Override
 	default String getPartName() {
-		return ROLE_LOCAL_NAME;
+		return ID_ROLE_NAME;
 	}
 
 	/**

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/MappingModelHelper.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/MappingModelHelper.java
@@ -6,18 +6,7 @@
  */
 package org.hibernate.metamodel.mapping;
 
-import java.util.ArrayList;
-import java.util.List;
-
-import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.persister.entity.UnionSubclassEntityPersister;
-import org.hibernate.sql.ast.spi.SqlExpressionResolver;
-import org.hibernate.sql.ast.tree.expression.ColumnReference;
-import org.hibernate.sql.ast.tree.expression.Expression;
-import org.hibernate.sql.ast.tree.expression.SqlTuple;
-import org.hibernate.sql.ast.tree.from.TableGroup;
-
-import static org.hibernate.sql.ast.spi.SqlExpressionResolver.createColumnReferenceKey;
 
 /**
  * @author Steve Ebersole
@@ -27,80 +16,79 @@ public class MappingModelHelper {
 	private MappingModelHelper() {
 		// disallow direct instantiation
 	}
-
-	public static Expression buildColumnReferenceExpression(
-			ModelPart modelPart,
-			SqlExpressionResolver sqlExpressionResolver,
-			SessionFactoryImplementor sessionFactory) {
-		return buildColumnReferenceExpression( null, modelPart, sqlExpressionResolver, sessionFactory );
-	}
-
-	public static Expression buildColumnReferenceExpression(
-			TableGroup tableGroup,
-			ModelPart modelPart,
-			SqlExpressionResolver sqlExpressionResolver,
-			SessionFactoryImplementor sessionFactory) {
-		final int jdbcTypeCount = modelPart.getJdbcTypeCount();
-
-		if ( modelPart instanceof EmbeddableValuedModelPart ) {
-			final List<ColumnReference> columnReferences = new ArrayList<>( jdbcTypeCount );
-			modelPart.forEachSelectable(
-					(columnIndex, selection) -> {
-						final ColumnReference colRef;
-						final String qualifier;
-						if ( tableGroup == null ) {
-							qualifier = selection.getContainingTableExpression();
-						}
-						else {
-							qualifier = tableGroup.resolveTableReference( selection.getContainingTableExpression() ).getIdentificationVariable();
-						}
-						if ( sqlExpressionResolver == null ) {
-							colRef = new ColumnReference(
-									qualifier,
-									selection
-							);
-						}
-						else {
-							colRef = (ColumnReference) sqlExpressionResolver.resolveSqlExpression(
-									createColumnReferenceKey( qualifier, selection ),
-									sqlAstProcessingState -> new ColumnReference(
-											qualifier,
-											selection
-									)
-							);
-						}
-						columnReferences.add( colRef );
-					}
-			);
-			return new SqlTuple( columnReferences, modelPart );
-		}
-		else {
-			assert modelPart instanceof BasicValuedModelPart;
-			final BasicValuedModelPart basicPart = (BasicValuedModelPart) modelPart;
-			final String qualifier;
-			if ( tableGroup == null ) {
-				qualifier = basicPart.getContainingTableExpression();
-			}
-			else {
-				qualifier = tableGroup.resolveTableReference( basicPart.getContainingTableExpression() ).getIdentificationVariable();
-			}
-			if ( sqlExpressionResolver == null ) {
-				return new ColumnReference(
-						qualifier,
-						basicPart
-				);
-			}
-			else {
-				return sqlExpressionResolver.resolveSqlExpression(
-						createColumnReferenceKey( qualifier, basicPart ),
-						sqlAstProcessingState -> new ColumnReference(
-								qualifier,
-								basicPart
-						)
-				);
-			}
-		}
-	}
+//
+//	public static Expression buildColumnReferenceExpression(
+//			ModelPart modelPart,
+//			SqlExpressionResolver sqlExpressionResolver) {
+//		return buildColumnReferenceExpression( null, modelPart, sqlExpressionResolver );
+//	}
+//
+//	public static Expression buildColumnReferenceExpression(
+//			TableGroup tableGroup,
+//			ModelPart modelPart,
+//			SqlExpressionResolver sqlExpressionResolver) {
+//		final int jdbcTypeCount = modelPart.getJdbcTypeCount();
+//
+//		if ( modelPart instanceof EmbeddableValuedModelPart ) {
+//			final List<ColumnReference> columnReferences = new ArrayList<>( jdbcTypeCount );
+//			modelPart.forEachSelectable(
+//					(columnIndex, selection) -> {
+//						final ColumnReference colRef;
+//						final String qualifier;
+//						if ( tableGroup == null ) {
+//							qualifier = selection.getContainingTableExpression();
+//						}
+//						else {
+//							qualifier = tableGroup.resolveTableReference( selection.getContainingTableExpression() ).getIdentificationVariable();
+//						}
+//						if ( sqlExpressionResolver == null ) {
+//							colRef = new ColumnReference(
+//									qualifier,
+//									selection
+//							);
+//						}
+//						else {
+//							colRef = (ColumnReference) sqlExpressionResolver.resolveSqlExpression(
+//									createColumnReferenceKey( qualifier, selection ),
+//									sqlAstProcessingState -> new ColumnReference(
+//											qualifier,
+//											selection
+//									)
+//							);
+//						}
+//						columnReferences.add( colRef );
+//					}
+//			);
+//			return new SqlTuple( columnReferences, modelPart );
+//		}
+//		else {
+//			assert modelPart instanceof BasicValuedModelPart;
+//			final BasicValuedModelPart basicPart = (BasicValuedModelPart) modelPart;
+//			final String qualifier;
+//			if ( tableGroup == null ) {
+//				qualifier = basicPart.getContainingTableExpression();
+//			}
+//			else {
+//				qualifier = tableGroup.resolveTableReference( basicPart.getContainingTableExpression() ).getIdentificationVariable();
+//			}
+//			if ( sqlExpressionResolver == null ) {
+//				return new ColumnReference(
+//						qualifier,
+//						basicPart
+//				);
+//			}
+//			else {
+//				return sqlExpressionResolver.resolveSqlExpression(
+//						createColumnReferenceKey( qualifier, basicPart ),
+//						sqlAstProcessingState -> new ColumnReference(
+//								qualifier,
+//								basicPart
+//						)
+//				);
+//			}
+//		}
+//	}
+//
 	public static boolean isCompatibleModelPart(ModelPart attribute1, ModelPart attribute2) {
 		if ( attribute1 == attribute2 ) {
 			return true;

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/AbstractDiscriminatorMapping.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/AbstractDiscriminatorMapping.java
@@ -53,7 +53,7 @@ public abstract class AbstractDiscriminatorMapping implements EntityDiscriminato
 		this.underlyingJdbcMapping = underlyingJdbcMapping;
 		this.entityDescriptor = entityDescriptor;
 
-		this.role = entityDescriptor.getNavigableRole().append( EntityDiscriminatorMapping.ROLE_NAME );
+		this.role = entityDescriptor.getNavigableRole().append( EntityDiscriminatorMapping.DISCRIMINATOR_ROLE_NAME );
 
 		this.discriminatorType = discriminatorType;
 	}

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/AbstractEntityCollectionPart.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/AbstractEntityCollectionPart.java
@@ -23,7 +23,6 @@ import org.hibernate.mapping.Value;
 import org.hibernate.metamodel.mapping.AssociationKey;
 import org.hibernate.metamodel.mapping.EntityIdentifierMapping;
 import org.hibernate.metamodel.mapping.EntityMappingType;
-import org.hibernate.metamodel.mapping.ForeignKeyDescriptor;
 import org.hibernate.metamodel.mapping.PluralAttributeMapping;
 import org.hibernate.metamodel.model.domain.NavigableRole;
 import org.hibernate.persister.collection.CollectionPersister;
@@ -33,7 +32,6 @@ import org.hibernate.sql.ast.spi.FromClauseAccess;
 import org.hibernate.sql.ast.spi.SqlAliasBase;
 import org.hibernate.sql.ast.spi.SqlAstCreationContext;
 import org.hibernate.sql.ast.spi.SqlAstCreationState;
-import org.hibernate.sql.ast.spi.SqlExpressionResolver;
 import org.hibernate.sql.ast.tree.from.PluralTableGroup;
 import org.hibernate.sql.ast.tree.from.StandardTableGroup;
 import org.hibernate.sql.ast.tree.from.TableGroup;
@@ -376,7 +374,7 @@ public abstract class AbstractEntityCollectionPart implements EntityCollectionPa
 
 		if ( referencedPropertyName == null ) {
 			final Set<String> targetKeyPropertyNames = new HashSet<>( 2 );
-			targetKeyPropertyNames.add( EntityIdentifierMapping.ROLE_LOCAL_NAME );
+			targetKeyPropertyNames.add( EntityIdentifierMapping.ID_ROLE_NAME );
 			final Type propertyType;
 			if ( entityBinding.getIdentifierMapper() == null ) {
 				propertyType = entityBinding.getIdentifier().getType();
@@ -396,7 +394,7 @@ public abstract class AbstractEntityCollectionPart implements EntityCollectionPa
 					);
 					ToOneAttributeMapping.addPrefixedPropertyNames(
 							targetKeyPropertyNames,
-							EntityIdentifierMapping.ROLE_LOCAL_NAME,
+							EntityIdentifierMapping.ID_ROLE_NAME,
 							propertyType,
 							creationProcess.getCreationContext().getSessionFactory()
 					);
@@ -451,7 +449,7 @@ public abstract class AbstractEntityCollectionPart implements EntityCollectionPa
 				);
 				ToOneAttributeMapping.addPrefixedPropertyNames(
 						targetKeyPropertyNames,
-						EntityIdentifierMapping.ROLE_LOCAL_NAME,
+						EntityIdentifierMapping.ID_ROLE_NAME,
 						propertyType,
 						creationProcess.getCreationContext().getSessionFactory()
 				);
@@ -459,7 +457,7 @@ public abstract class AbstractEntityCollectionPart implements EntityCollectionPa
 			}
 			else {
 				final Set<String> targetKeyPropertyNames = new HashSet<>( 2 );
-				targetKeyPropertyNames.add( EntityIdentifierMapping.ROLE_LOCAL_NAME );
+				targetKeyPropertyNames.add( EntityIdentifierMapping.ID_ROLE_NAME );
 				targetKeyPropertyNames.add( referencedPropertyName );
 				final String mapsIdAttributeName;
 				if ( ( mapsIdAttributeName = ToOneAttributeMapping.findMapsIdPropertyName( elementTypeDescriptor, referencedPropertyName ) ) != null ) {

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/AnyDiscriminatorPart.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/AnyDiscriminatorPart.java
@@ -42,7 +42,6 @@ import org.hibernate.sql.results.graph.FetchOptions;
 import org.hibernate.sql.results.graph.FetchParent;
 import org.hibernate.sql.results.graph.basic.BasicFetch;
 import org.hibernate.type.BasicType;
-import org.hibernate.type.descriptor.converter.spi.BasicValueConverter;
 import org.hibernate.type.descriptor.java.ClassJavaType;
 import org.hibernate.type.descriptor.java.JavaType;
 
@@ -52,7 +51,7 @@ import org.hibernate.type.descriptor.java.JavaType;
  * @author Steve Ebersole
  */
 public class AnyDiscriminatorPart implements DiscriminatorMapping, FetchOptions {
-	public static final String ROLE_NAME = EntityDiscriminatorMapping.ROLE_NAME;
+	public static final String ROLE_NAME = EntityDiscriminatorMapping.DISCRIMINATOR_ROLE_NAME;
 
 	private final NavigableRole navigableRole;
 	private final DiscriminatedAssociationModelPart declaringType;

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/BasicEntityIdentifierMappingImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/BasicEntityIdentifierMappingImpl.java
@@ -113,7 +113,7 @@ public class BasicEntityIdentifierMappingImpl implements BasicEntityIdentifierMa
 		propertyAccess = entityPersister.getRepresentationStrategy()
 				.resolvePropertyAccess( bootEntityDescriptor.getIdentifierProperty() );
 
-		idRole = entityPersister.getNavigableRole().append( EntityIdentifierMapping.ROLE_LOCAL_NAME );
+		idRole = entityPersister.getNavigableRole().append( EntityIdentifierMapping.ID_ROLE_NAME );
 		sessionFactory = creationProcess.getCreationContext().getSessionFactory();
 
 		unsavedStrategy = UnsavedValueFactory.getUnsavedIdentifierValue(

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/CaseStatementDiscriminatorMappingImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/CaseStatementDiscriminatorMappingImpl.java
@@ -188,7 +188,7 @@ public class CaseStatementDiscriminatorMappingImpl extends AbstractDiscriminator
 	public String getSelectionExpression() {
 		// this *should* only be used to create the sql-expression key, so just
 		// using the ROLE_NAME should be fine
-		return ROLE_NAME;
+		return DISCRIMINATOR_ROLE_NAME;
 	}
 
 

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/IdClassEmbeddable.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/IdClassEmbeddable.java
@@ -77,7 +77,7 @@ public class IdClassEmbeddable extends AbstractEmbeddableMapping implements Iden
 
 		final PropertyAccess propertyAccess = PropertyAccessStrategyMapImpl.INSTANCE.buildPropertyAccess(
 				null,
-				EntityIdentifierMapping.ROLE_LOCAL_NAME,
+				EntityIdentifierMapping.ID_ROLE_NAME,
 				true );
 		final AttributeMetadata attributeMetadata = MappingModelCreationHelper.getAttributeMetadata(
 				propertyAccess
@@ -86,7 +86,7 @@ public class IdClassEmbeddable extends AbstractEmbeddableMapping implements Iden
 		embedded = new EmbeddedAttributeMapping(
 				NavigablePath.IDENTIFIER_MAPPER_PROPERTY,
 				identifiedEntityMapping.getNavigableRole()
-						.append( EntityIdentifierMapping.ROLE_LOCAL_NAME )
+						.append( EntityIdentifierMapping.ID_ROLE_NAME )
 						.append( NavigablePath.IDENTIFIER_MAPPER_PROPERTY ),
 				-1,
 				-1,

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/InverseNonAggregatedIdentifierMapping.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/InverseNonAggregatedIdentifierMapping.java
@@ -304,7 +304,7 @@ public class InverseNonAggregatedIdentifierMapping extends EmbeddedAttributeMapp
 
 	@Override
 	public String getFetchableName() {
-		return EntityIdentifierMapping.ROLE_LOCAL_NAME;
+		return EntityIdentifierMapping.ID_ROLE_NAME;
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/NonAggregatedIdentifierMappingImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/NonAggregatedIdentifierMappingImpl.java
@@ -379,7 +379,7 @@ public class NonAggregatedIdentifierMappingImpl extends AbstractCompositeIdentif
 
 	@Override
 	public String getFetchableName() {
-		return EntityIdentifierMapping.ROLE_LOCAL_NAME;
+		return EntityIdentifierMapping.ID_ROLE_NAME;
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/SingleAttributeIdentifierMapping.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/SingleAttributeIdentifierMapping.java
@@ -30,7 +30,7 @@ public interface SingleAttributeIdentifierMapping extends EntityIdentifierMappin
 
 	@Override
 	default String getPartName() {
-		return ROLE_LOCAL_NAME;
+		return ID_ROLE_NAME;
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/ToOneAttributeMapping.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/ToOneAttributeMapping.java
@@ -390,7 +390,7 @@ public class ToOneAttributeMapping
 
 		if ( referencedPropertyName == null ) {
 			final Set<String> targetKeyPropertyNames = new HashSet<>( 2 );
-			targetKeyPropertyNames.add( EntityIdentifierMapping.ROLE_LOCAL_NAME );
+			targetKeyPropertyNames.add( EntityIdentifierMapping.ID_ROLE_NAME );
 			final PersistentClass entityBinding = bootValue.getBuildingContext().getMetadataCollector()
 					.getEntityBinding( entityMappingType.getEntityName() );
 			final Type propertyType;
@@ -413,13 +413,13 @@ public class ToOneAttributeMapping
 					);
 					addPrefixedPropertyNames(
 							targetKeyPropertyNames,
-							EntityIdentifierMapping.ROLE_LOCAL_NAME,
+							EntityIdentifierMapping.ID_ROLE_NAME,
 							propertyType,
 							declaringEntityPersister.getFactory()
 					);
 				}
 				else {
-					this.targetKeyPropertyName = EntityIdentifierMapping.ROLE_LOCAL_NAME;
+					this.targetKeyPropertyName = EntityIdentifierMapping.ID_ROLE_NAME;
 					addPrefixedPropertyPaths(
 							targetKeyPropertyNames,
 							null,
@@ -467,7 +467,7 @@ public class ToOneAttributeMapping
 				);
 				addPrefixedPropertyNames(
 						targetKeyPropertyNames,
-						EntityIdentifierMapping.ROLE_LOCAL_NAME,
+						EntityIdentifierMapping.ID_ROLE_NAME,
 						propertyType,
 						declaringEntityPersister.getFactory()
 				);
@@ -685,7 +685,7 @@ public class ToOneAttributeMapping
 		);
 		addPrefixedPropertyNames(
 				targetKeyPropertyNames,
-				EntityIdentifierMapping.ROLE_LOCAL_NAME,
+				EntityIdentifierMapping.ID_ROLE_NAME,
 				type,
 				factory
 		);
@@ -732,17 +732,17 @@ public class ToOneAttributeMapping
 			final String newFkPrefix;
 			if ( prefix == null ) {
 				newPrefix = propertyName;
-				newPkPrefix = propertyName + "." + EntityIdentifierMapping.ROLE_LOCAL_NAME;
+				newPkPrefix = propertyName + "." + EntityIdentifierMapping.ID_ROLE_NAME;
 				newFkPrefix = ForeignKeyDescriptor.PART_NAME;
 			}
 			else if ( propertyName == null ) {
 				newPrefix = prefix;
-				newPkPrefix = prefix + "." + EntityIdentifierMapping.ROLE_LOCAL_NAME;
+				newPkPrefix = prefix + "." + EntityIdentifierMapping.ID_ROLE_NAME;
 				newFkPrefix = prefix + "." + ForeignKeyDescriptor.PART_NAME;
 			}
 			else {
 				newPrefix = prefix + "." + propertyName;
-				newPkPrefix = prefix + "." + EntityIdentifierMapping.ROLE_LOCAL_NAME;
+				newPkPrefix = prefix + "." + EntityIdentifierMapping.ID_ROLE_NAME;
 				newFkPrefix = prefix + "." + ForeignKeyDescriptor.PART_NAME;
 			}
 			addPrefixedPropertyNames( targetKeyPropertyNames, newPrefix, identifierOrUniqueKeyType, factory );
@@ -752,11 +752,11 @@ public class ToOneAttributeMapping
 				final String newEmbeddedPkPrefix;
 				final String newEmbeddedFkPrefix;
 				if ( prefix == null ) {
-					newEmbeddedPkPrefix = EntityIdentifierMapping.ROLE_LOCAL_NAME;
+					newEmbeddedPkPrefix = EntityIdentifierMapping.ID_ROLE_NAME;
 					newEmbeddedFkPrefix = ForeignKeyDescriptor.PART_NAME;
 				}
 				else {
-					newEmbeddedPkPrefix = prefix + "." + EntityIdentifierMapping.ROLE_LOCAL_NAME;
+					newEmbeddedPkPrefix = prefix + "." + EntityIdentifierMapping.ID_ROLE_NAME;
 					newEmbeddedFkPrefix = prefix + "." + ForeignKeyDescriptor.PART_NAME;
 				}
 				addPrefixedPropertyNames( targetKeyPropertyNames, newEmbeddedPkPrefix, identifierOrUniqueKeyType, factory );
@@ -876,7 +876,7 @@ public class ToOneAttributeMapping
 				fkPart = foreignKeyDescriptor.getTargetPart();
 			}
 			if ( fkPart instanceof EmbeddableValuedModelPart && fkPart instanceof VirtualModelPart
-					&& !EntityIdentifierMapping.ROLE_LOCAL_NAME.equals( name )
+					&& !EntityIdentifierMapping.ID_ROLE_NAME.equals( name )
 					&& !ForeignKeyDescriptor.PART_NAME.equals( name )
 					&& !ForeignKeyDescriptor.TARGET_PART_NAME.equals( name )
 					&& !fkPart.getPartName().equals( name ) ) {
@@ -1138,7 +1138,7 @@ public class ToOneAttributeMapping
 		NavigablePath navigablePath = parentNavigablePath.trimSuffix( bidirectionalAttributePath );
 		if ( navigablePath != null ) {
 			final String localName = navigablePath.getLocalName();
-			if ( localName.equals( EntityIdentifierMapping.ROLE_LOCAL_NAME )
+			if ( localName.equals( EntityIdentifierMapping.ID_ROLE_NAME )
 					|| localName.equals( ForeignKeyDescriptor.PART_NAME )
 					|| localName.equals( ForeignKeyDescriptor.TARGET_PART_NAME ) ) {
 				navigablePath = navigablePath.getParent();
@@ -1759,7 +1759,7 @@ public class ToOneAttributeMapping
 		if ( referencedPropertyName == null ) {
 			//noinspection unchecked
 			return new EntityDelayedResultImpl(
-					navigablePath.append( EntityIdentifierMapping.ROLE_LOCAL_NAME ),
+					navigablePath.append( EntityIdentifierMapping.ID_ROLE_NAME ),
 					this,
 					tableGroupToUse,
 					creationState

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/AbstractDomainType.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/AbstractDomainType.java
@@ -6,23 +6,16 @@
  */
 package org.hibernate.metamodel.model.domain;
 
-import org.hibernate.metamodel.model.domain.spi.JpaMetamodelImplementor;
 import org.hibernate.type.descriptor.java.JavaType;
 
 /**
  * @author Steve Ebersole
  */
 public abstract class AbstractDomainType<J> implements SimpleDomainType<J> {
-	private final JpaMetamodelImplementor domainMetamodel;
 	private final JavaType<J> javaType;
 
-	public AbstractDomainType(JavaType<J> javaType, JpaMetamodelImplementor domainMetamodel) {
+	public AbstractDomainType(JavaType<J> javaType) {
 		this.javaType = javaType;
-		this.domainMetamodel = domainMetamodel;
-	}
-
-	protected JpaMetamodelImplementor jpaMetamodel() {
-		return domainMetamodel;
 	}
 
 	@Override
@@ -32,7 +25,7 @@ public abstract class AbstractDomainType<J> implements SimpleDomainType<J> {
 
 	@Override
 	public Class<J> getJavaType() {
-		return this.getExpressibleJavaType().getJavaTypeClass();
+		return getExpressibleJavaType().getJavaTypeClass();
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/AnyMappingDomainType.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/AnyMappingDomainType.java
@@ -15,6 +15,6 @@ package org.hibernate.metamodel.model.domain;
  * @author Steve Ebersole
  */
 public interface AnyMappingDomainType<J> extends SimpleDomainType<J> {
-	SimpleDomainType getDiscriminatorType();
-	SimpleDomainType getKeyType();
+	SimpleDomainType<?> getDiscriminatorType();
+	SimpleDomainType<?> getKeyType();
 }

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/EntityDomainType.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/EntityDomainType.java
@@ -13,7 +13,7 @@ import jakarta.persistence.metamodel.EntityType;
 import org.hibernate.query.sqm.SqmPathSource;
 
 /**
- * Extension to the JPA {@link EntityType} contract
+ * Extension to the JPA {@link EntityType} contract.
  *
  * @author Steve Ebersole
  */

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/IdentifiableDomainType.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/IdentifiableDomainType.java
@@ -45,7 +45,7 @@ public interface IdentifiableDomainType<J> extends ManagedDomainType<J>, Identif
 
 	boolean hasIdClass();
 
-	SingularPersistentAttribute<J,?> findIdAttribute();
+	SingularPersistentAttribute<? super J,?> findIdAttribute();
 
 	void visitIdClassAttributes(Consumer<SingularPersistentAttribute<? super J,?>> action);
 

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/IdentifiableDomainType.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/IdentifiableDomainType.java
@@ -15,7 +15,7 @@ import jakarta.persistence.metamodel.SingularAttribute;
 import org.hibernate.query.sqm.SqmPathSource;
 
 /**
- * Extension to the JPA {@link IdentifiableType} contract
+ * Extension to the JPA {@link IdentifiableType} contract.
  *
  * @author Steve Ebersole
  */

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/ManagedDomainType.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/ManagedDomainType.java
@@ -9,14 +9,13 @@ package org.hibernate.metamodel.model.domain;
 import java.util.Collection;
 import java.util.function.Consumer;
 
-import org.hibernate.graph.spi.SubGraphImplementor;
 import org.hibernate.metamodel.RepresentationMode;
 import org.hibernate.query.sqm.SqmExpressible;
 
 import jakarta.persistence.metamodel.ManagedType;
 
 /**
- * Hibernate extension to the JPA {@link ManagedType} contract
+ * Extensions to the JPA-defined {@link ManagedType} contract.
  *
  * @author Steve Ebersole
  */
@@ -24,9 +23,9 @@ public interface ManagedDomainType<J> extends SqmExpressible<J>, DomainType<J>, 
 	/**
 	 * Get the type name.
 	 *
-	 * Generally speaking, this returns the name of the Java class.  However, for
-	 * dynamic models ({@link RepresentationMode#MAP}), this returns the symbolic name
-	 * since the Java type is {@link java.util.Map}
+	 * @apiNote This usually returns the name of the Java class. However, for
+	 *          {@linkplain RepresentationMode#MAP dynamic models}, this returns
+	 *          the symbolic name since the Java type is {@link java.util.Map}.
 	 *
 	 * @return The type name.
 	 *
@@ -37,16 +36,18 @@ public interface ManagedDomainType<J> extends SqmExpressible<J>, DomainType<J>, 
 	RepresentationMode getRepresentationMode();
 
 	/**
-	 * This type's super type descriptor.  Note : we define this on the managed
-	 * type descriptor in anticipation of supporting embeddable inheritance
+	 * The descriptor of the supertype of this type.
+	 *
+	 * @apiNote we define this here in anticipation of eventually supporting
+	 *          embeddable inheritance
 	 */
 	ManagedDomainType<? super J> getSuperType();
 
 	Collection<? extends ManagedDomainType<? extends J>> getSubTypes();
 
-	void addSubType(ManagedDomainType subType);
+	void addSubType(ManagedDomainType<? extends J> subType);
 
-	void visitAttributes(Consumer<? super PersistentAttribute<J, ?>> action);
+	void visitAttributes(Consumer<? super PersistentAttribute<? super J, ?>> action);
 	void visitDeclaredAttributes(Consumer<? super PersistentAttribute<J, ?>> action);
 
 	@Override
@@ -57,7 +58,7 @@ public interface ManagedDomainType<J> extends SqmExpressible<J>, DomainType<J>, 
 
 	PersistentAttribute<? super J,?> findAttribute(String name);
 
-	PersistentAttribute<? super J, ?> findSubTypesAttribute(String name);
+	PersistentAttribute<?, ?> findSubTypesAttribute(String name);
 	PersistentAttribute<? super J, ?> findAttributeInSuperTypes(String name);
 
 	SingularPersistentAttribute<? super J,?> findSingularAttribute(String name);
@@ -65,13 +66,7 @@ public interface ManagedDomainType<J> extends SqmExpressible<J>, DomainType<J>, 
 	PersistentAttribute<? super J, ?> findConcreteGenericAttribute(String name);
 
 	PersistentAttribute<J,?> findDeclaredAttribute(String name);
-	SingularPersistentAttribute<? super J, ?> findDeclaredSingularAttribute(String name);
-	PluralPersistentAttribute<? super J, ?, ?> findDeclaredPluralAttribute(String name);
-	PersistentAttribute<? super J, ?> findDeclaredConcreteGenericAttribute(String name);
-
-	SubGraphImplementor<J> makeSubGraph();
-	<S extends J> SubGraphImplementor<S> makeSubGraph(Class<S> subClassType);
-
-	<S extends J> ManagedDomainType<S> findSubType(String subTypeName);
-	<S extends J> ManagedDomainType<S> findSubType(Class<S> subType);
+	SingularPersistentAttribute<J, ?> findDeclaredSingularAttribute(String name);
+	PluralPersistentAttribute<J, ?, ?> findDeclaredPluralAttribute(String name);
+	PersistentAttribute<J, ?> findDeclaredConcreteGenericAttribute(String name);
 }

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/PluralPersistentAttribute.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/PluralPersistentAttribute.java
@@ -14,10 +14,7 @@ import org.hibernate.query.sqm.SqmJoinable;
 import org.hibernate.query.sqm.SqmPathSource;
 
 /**
- * Hibernate extension to the JPA {@link PluralAttribute} descriptor
- *
- * todo (6.0) : Create an form of plural attribute (and singular) in the API package (org.hibernate.metamodel.model.domain)
- * 		and have this extend it
+ * Extension of the JPA-defined {@link PluralAttribute} interface.
  *
  * @author Steve Ebersole
  */

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/SingularPersistentAttribute.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/SingularPersistentAttribute.java
@@ -12,12 +12,12 @@ import org.hibernate.query.sqm.SqmJoinable;
 import org.hibernate.query.sqm.SqmPathSource;
 
 /**
- * Hibernate extension to the JPA {@link SingularAttribute} descriptor
+ * Extension of the JPA-defined {@link SingularAttribute} interface.
  *
  * @author Steve Ebersole
  */
 public interface SingularPersistentAttribute<D,J>
-		extends SingularAttribute<D,J>, PersistentAttribute<D,J>, SqmPathSource<J>, SqmJoinable {
+		extends SingularAttribute<D,J>, PersistentAttribute<D,J>, SqmPathSource<J>, SqmJoinable<D,J> {
 	@Override
 	SimpleDomainType<J> getType();
 

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/internal/AbstractPluralAttribute.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/internal/AbstractPluralAttribute.java
@@ -16,6 +16,7 @@ import org.hibernate.metamodel.model.domain.DomainType;
 import org.hibernate.metamodel.model.domain.EntityDomainType;
 import org.hibernate.metamodel.model.domain.PluralPersistentAttribute;
 import org.hibernate.metamodel.model.domain.SimpleDomainType;
+import org.hibernate.metamodel.model.domain.spi.JpaMetamodelImplementor;
 import org.hibernate.spi.NavigablePath;
 import org.hibernate.query.sqm.SqmPathSource;
 import org.hibernate.query.sqm.internal.SqmMappingModelHelper;
@@ -84,6 +85,14 @@ public abstract class AbstractPluralAttribute<D, C, E>
 			return elementPathSource;
 		}
 		return elementPathSource.findSubPathSource( name );
+	}
+
+	@Override
+	public SqmPathSource<?> findSubPathSource(String name, JpaMetamodelImplementor metamodel) {
+		if ( CollectionPart.Nature.ELEMENT.getName().equals( name ) ) {
+			return elementPathSource;
+		}
+		return elementPathSource.findSubPathSource( name, metamodel );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/internal/AbstractPluralAttribute.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/internal/AbstractPluralAttribute.java
@@ -24,6 +24,7 @@ import org.hibernate.query.sqm.tree.domain.SqmPath;
 import org.hibernate.query.sqm.tree.domain.SqmPluralValuedSimplePath;
 import org.hibernate.type.descriptor.java.JavaType;
 
+import static jakarta.persistence.metamodel.Bindable.BindableType.PLURAL_ATTRIBUTE;
 import static org.hibernate.query.sqm.spi.SqmCreationHelper.buildSubNavigablePath;
 
 /**
@@ -59,7 +60,7 @@ public abstract class AbstractPluralAttribute<D, C, E>
 		this.elementPathSource = SqmMappingModelHelper.resolveSqmPathSource(
 				CollectionPart.Nature.ELEMENT.getName(),
 				builder.getValueType(),
-				BindableType.PLURAL_ATTRIBUTE,
+				PLURAL_ATTRIBUTE,
 				builder.isGeneric()
 		);
 	}
@@ -134,7 +135,7 @@ public abstract class AbstractPluralAttribute<D, C, E>
 	@Override
 	public boolean isAssociation() {
 		return getPersistentAttributeType() == PersistentAttributeType.ONE_TO_MANY
-				|| getPersistentAttributeType() == PersistentAttributeType.MANY_TO_MANY;
+			|| getPersistentAttributeType() == PersistentAttributeType.MANY_TO_MANY;
 	}
 
 	@Override
@@ -144,7 +145,7 @@ public abstract class AbstractPluralAttribute<D, C, E>
 
 	@Override
 	public BindableType getBindableType() {
-		return BindableType.PLURAL_ATTRIBUTE;
+		return PLURAL_ATTRIBUTE;
 	}
 
 	@Override
@@ -154,15 +155,8 @@ public abstract class AbstractPluralAttribute<D, C, E>
 
 	@Override
 	public SqmPath<E> createSqmPath(SqmPath<?> lhs, SqmPathSource<?> intermediatePathSource) {
-		final NavigablePath navigablePath;
-		if ( intermediatePathSource == null ) {
-			navigablePath = lhs.getNavigablePath().append( getPathName() );
-		}
-		else {
-			navigablePath = lhs.getNavigablePath().append( intermediatePathSource.getPathName() ).append( getPathName() );
-		}
 		return new SqmPluralValuedSimplePath<>(
-				navigablePath,
+				PathHelper.append( lhs, this, intermediatePathSource ),
 				this,
 				lhs,
 				lhs.nodeBuilder()

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/internal/AbstractSqmPathSource.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/internal/AbstractSqmPathSource.java
@@ -41,7 +41,7 @@ public abstract class AbstractSqmPathSource<J> implements SqmPathSource<J> {
 	}
 
 	@Override
-	public DomainType<?> getSqmPathType() {
+	public DomainType<J> getSqmPathType() {
 		return domainType;
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/internal/AnyDiscriminatorSqmPathSource.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/internal/AnyDiscriminatorSqmPathSource.java
@@ -16,7 +16,7 @@ import org.hibernate.type.BasicType;
 import org.hibernate.type.descriptor.java.JavaType;
 
 /**
- * SqmPathSource implementation for {@link org.hibernate.annotations.AnyDiscriminator}
+ * {@link SqmPathSource} implementation for {@link org.hibernate.annotations.AnyDiscriminator}
  *
  */
 public class AnyDiscriminatorSqmPathSource<D> extends AbstractSqmPathSource<D>
@@ -39,7 +39,7 @@ public class AnyDiscriminatorSqmPathSource<D> extends AbstractSqmPathSource<D>
 		else {
 			navigablePath = lhs.getNavigablePath().append( intermediatePathSource.getPathName() );
 		}
-		return new AnyDiscriminatorSqmPath( navigablePath, pathModel, lhs, lhs.nodeBuilder() );
+		return new AnyDiscriminatorSqmPath<>( navigablePath, pathModel, lhs, lhs.nodeBuilder() );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/internal/AnyMappingDomainTypeImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/internal/AnyMappingDomainTypeImpl.java
@@ -26,16 +26,16 @@ import java.util.List;
 /**
  * @author Steve Ebersole
  */
-public class AnyMappingDomainTypeImpl implements AnyMappingDomainType<Class> {
+public class AnyMappingDomainTypeImpl<T> implements AnyMappingDomainType<T> {
 	private final AnyType anyType;
-	private final JavaType<Class> baseJtd;
-	private final BasicType<Class> anyDiscriminatorType;
+	private final JavaType<T> baseJtd;
+	private final BasicType<Class<?>> anyDiscriminatorType;
 
 	@SuppressWarnings({ "unchecked", "rawtypes" })
 	public AnyMappingDomainTypeImpl(
 			Any bootAnyMapping,
 			AnyType anyType,
-			JavaType<Class> baseJtd,
+			JavaType<T> baseJtd,
 			MappingMetamodelImplementor mappingMetamodel) {
 		this.anyType = anyType;
 		this.baseJtd = baseJtd;
@@ -90,23 +90,22 @@ public class AnyMappingDomainTypeImpl implements AnyMappingDomainType<Class> {
 	}
 
 	@Override
-	@SuppressWarnings("unchecked")
-	public Class<Class> getJavaType() {
-		return (Class<Class>) anyType.getReturnedClass();
+	public Class<T> getJavaType() {
+		return baseJtd.getJavaTypeClass();
 	}
 
 	@Override
-	public JavaType<Class> getExpressibleJavaType() {
+	public JavaType<T> getExpressibleJavaType() {
 		return baseJtd;
 	}
 
 	@Override
-	public BasicType<Class> getDiscriminatorType() {
+	public BasicType<Class<?>> getDiscriminatorType() {
 		return anyDiscriminatorType;
 	}
 
 	@Override
-	public SimpleDomainType getKeyType() {
+	public SimpleDomainType<?> getKeyType() {
 		return (BasicType<?>) anyType.getIdentifierType();
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/internal/AnyMappingSqmPathSource.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/internal/AnyMappingSqmPathSource.java
@@ -11,7 +11,6 @@ import org.hibernate.metamodel.mapping.internal.AnyDiscriminatorPart;
 import org.hibernate.metamodel.mapping.internal.AnyKeyPart;
 import org.hibernate.metamodel.model.domain.AnyMappingDomainType;
 import org.hibernate.metamodel.model.domain.BasicDomainType;
-import org.hibernate.spi.NavigablePath;
 import org.hibernate.query.sqm.SqmPathSource;
 import org.hibernate.query.sqm.tree.domain.SqmAnyValuedSimplePath;
 import org.hibernate.query.sqm.tree.domain.SqmPath;
@@ -23,7 +22,7 @@ import static jakarta.persistence.metamodel.Bindable.BindableType.SINGULAR_ATTRI
  */
 public class AnyMappingSqmPathSource<J> extends AbstractSqmPathSource<J> {
 	private final SqmPathSource<?> keyPathSource;
-	private final AnyDiscriminatorSqmPathSource discriminatorPathSource;
+	private final AnyDiscriminatorSqmPathSource<?> discriminatorPathSource;
 
 	public AnyMappingSqmPathSource(
 			String localPathName,
@@ -47,7 +46,7 @@ public class AnyMappingSqmPathSource<J> extends AbstractSqmPathSource<J> {
 		);
 	}
 
-	@Override @SuppressWarnings("unchecked")
+	@Override
 	public AnyMappingDomainType<J> getSqmPathType() {
 		return (AnyMappingDomainType<J>) super.getSqmPathType();
 	}
@@ -68,13 +67,11 @@ public class AnyMappingSqmPathSource<J> extends AbstractSqmPathSource<J> {
 
 	@Override
 	public SqmPath<J> createSqmPath(SqmPath<?> lhs, SqmPathSource<?> intermediatePathSource) {
-		final NavigablePath navigablePath;
-		if ( intermediatePathSource == null ) {
-			navigablePath = lhs.getNavigablePath().append( getPathName() );
-		}
-		else {
-			navigablePath = lhs.getNavigablePath().append( intermediatePathSource.getPathName() ).append( getPathName() );
-		}
-		return new SqmAnyValuedSimplePath<>( navigablePath, pathModel, lhs, lhs.nodeBuilder() );
+		return new SqmAnyValuedSimplePath<>(
+				PathHelper.append( lhs, this, intermediatePathSource ),
+				pathModel,
+				lhs,
+				lhs.nodeBuilder()
+		);
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/internal/BagAttributeImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/internal/BagAttributeImpl.java
@@ -33,14 +33,13 @@ public class BagAttributeImpl<X, E>
 	}
 
 	@Override
-	public SqmAttributeJoin createSqmJoin(
-			SqmFrom lhs,
+	public SqmAttributeJoin<X,E> createSqmJoin(
+			SqmFrom<?,X> lhs,
 			SqmJoinType joinType,
 			String alias,
 			boolean fetched,
 			SqmCreationState creationState) {
-		//noinspection unchecked
-		return new SqmBagJoin(
+		return new SqmBagJoin<>(
 				lhs,
 				this,
 				alias,

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/internal/BasicSqmPathSource.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/internal/BasicSqmPathSource.java
@@ -13,7 +13,6 @@ import org.hibernate.query.sqm.TerminalPathException;
 import org.hibernate.query.sqm.SqmPathSource;
 import org.hibernate.query.sqm.tree.domain.SqmBasicValuedSimplePath;
 import org.hibernate.query.sqm.tree.domain.SqmPath;
-import org.hibernate.spi.NavigablePath;
 import org.hibernate.type.descriptor.java.JavaType;
 
 /**
@@ -39,7 +38,6 @@ public class BasicSqmPathSource<J>
 
 	@Override
 	public BasicDomainType<J> getSqmPathType() {
-		//noinspection unchecked
 		return (BasicDomainType<J>) super.getSqmPathType();
 	}
 
@@ -57,15 +55,8 @@ public class BasicSqmPathSource<J>
 
 	@Override
 	public SqmPath<J> createSqmPath(SqmPath<?> lhs, SqmPathSource<?> intermediatePathSource) {
-		final NavigablePath navigablePath;
-		if ( intermediatePathSource == null ) {
-			navigablePath = lhs.getNavigablePath().append( getPathName() );
-		}
-		else {
-			navigablePath = lhs.getNavigablePath().append( intermediatePathSource.getPathName() ).append( getPathName() );
-		}
 		return new SqmBasicValuedSimplePath<>(
-				navigablePath,
+				PathHelper.append( lhs, this, intermediatePathSource ),
 				pathModel,
 				lhs,
 				lhs.nodeBuilder()

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/internal/DiscriminatorSqmPathSource.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/internal/DiscriminatorSqmPathSource.java
@@ -6,14 +6,15 @@
  */
 package org.hibernate.metamodel.model.domain.internal;
 
-import org.hibernate.metamodel.mapping.EntityDiscriminatorMapping;
 import org.hibernate.metamodel.mapping.EntityMappingType;
 import org.hibernate.metamodel.model.domain.DomainType;
 import org.hibernate.metamodel.model.domain.EntityDomainType;
 import org.hibernate.query.ReturnableType;
-import org.hibernate.spi.NavigablePath;
 import org.hibernate.query.sqm.SqmPathSource;
 import org.hibernate.query.sqm.tree.domain.SqmPath;
+
+import static jakarta.persistence.metamodel.Bindable.BindableType.SINGULAR_ATTRIBUTE;
+import static org.hibernate.metamodel.mapping.EntityDiscriminatorMapping.DISCRIMINATOR_ROLE_NAME;
 
 /**
  * SqmPathSource implementation for entity discriminator
@@ -29,7 +30,7 @@ public class DiscriminatorSqmPathSource<D> extends AbstractSqmPathSource<D>
 			DomainType<D> discriminatorValueType,
 			EntityDomainType<?> entityDomainType,
 			EntityMappingType entityMapping) {
-		super( EntityDiscriminatorMapping.DISCRIMINATOR_ROLE_NAME, null, discriminatorValueType, BindableType.SINGULAR_ATTRIBUTE );
+		super( DISCRIMINATOR_ROLE_NAME, null, discriminatorValueType, SINGULAR_ATTRIBUTE );
 		this.entityDomainType = entityDomainType;
 		this.entityMapping = entityMapping;
 	}
@@ -44,14 +45,14 @@ public class DiscriminatorSqmPathSource<D> extends AbstractSqmPathSource<D>
 
 	@Override
 	public SqmPath<D> createSqmPath(SqmPath<?> lhs, SqmPathSource<?> intermediatePathSource) {
-		final NavigablePath navigablePath;
-		if ( intermediatePathSource == null ) {
-			navigablePath = lhs.getNavigablePath().append( getPathName() );
-		}
-		else {
-			navigablePath = lhs.getNavigablePath().append( intermediatePathSource.getPathName() ).append( getPathName() );
-		}
-		return new EntityDiscriminatorSqmPath( navigablePath, pathModel, lhs, entityDomainType, entityMapping, lhs.nodeBuilder() );
+		return new EntityDiscriminatorSqmPath<>(
+				PathHelper.append( lhs, this, intermediatePathSource ),
+				pathModel,
+				lhs,
+				entityDomainType,
+				entityMapping,
+				lhs.nodeBuilder()
+		);
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/internal/DiscriminatorSqmPathSource.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/internal/DiscriminatorSqmPathSource.java
@@ -29,7 +29,7 @@ public class DiscriminatorSqmPathSource<D> extends AbstractSqmPathSource<D>
 			DomainType<D> discriminatorValueType,
 			EntityDomainType<?> entityDomainType,
 			EntityMappingType entityMapping) {
-		super( EntityDiscriminatorMapping.ROLE_NAME, null, discriminatorValueType, BindableType.SINGULAR_ATTRIBUTE );
+		super( EntityDiscriminatorMapping.DISCRIMINATOR_ROLE_NAME, null, discriminatorValueType, BindableType.SINGULAR_ATTRIBUTE );
 		this.entityDomainType = entityDomainType;
 		this.entityMapping = entityMapping;
 	}

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/internal/DomainModelHelper.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/internal/DomainModelHelper.java
@@ -7,9 +7,16 @@
 package org.hibernate.metamodel.model.domain.internal;
 
 import org.hibernate.boot.registry.classloading.spi.ClassLoaderService;
+import org.hibernate.graph.internal.SubGraphImpl;
+import org.hibernate.graph.spi.SubGraphImplementor;
+import org.hibernate.metamodel.MappingMetamodel;
+import org.hibernate.metamodel.mapping.EntityMappingType;
+import org.hibernate.metamodel.mapping.MappingModelHelper;
 import org.hibernate.metamodel.model.domain.EmbeddableDomainType;
 import org.hibernate.metamodel.model.domain.JpaMetamodel;
 import org.hibernate.metamodel.model.domain.ManagedDomainType;
+import org.hibernate.metamodel.model.domain.PersistentAttribute;
+import org.hibernate.metamodel.model.domain.spi.JpaMetamodelImplementor;
 
 /**
  * Helper containing utilities useful for domain model handling
@@ -24,11 +31,11 @@ public class DomainModelHelper {
 			String subTypeName,
 			JpaMetamodel jpaMetamodel) {
 		if ( baseType instanceof EmbeddableDomainType<?> ) {
-			// todo : at least validate the string is a valid sub-type of the embeddable class?
-			return (ManagedDomainType) baseType;
+			// todo : at least validate the string is a valid subtype of the embeddable class?
+			return (ManagedDomainType<S>) baseType;
 		}
 
-		// first, try to find it by name directly..
+		// first, try to find it by name directly
 		ManagedDomainType<S> subManagedType = jpaMetamodel.resolveHqlEntityReference( subTypeName );
 		if ( subManagedType != null ) {
 			return subManagedType;
@@ -36,24 +43,74 @@ public class DomainModelHelper {
 
 		// it could still be a mapped-superclass
 		try {
-			final Class javaType = jpaMetamodel.getServiceRegistry()
+			final Class<?> javaType = jpaMetamodel.getServiceRegistry()
 					.getService( ClassLoaderService.class )
 					.classForName( subTypeName );
-			return jpaMetamodel.managedType( javaType );
+			return (ManagedDomainType<S>) jpaMetamodel.managedType( javaType );
 		}
 		catch (Exception ignore) {
 		}
 
-		throw new IllegalArgumentException( "Unknown sub-type name (" + baseType.getTypeName() + ") : " + subTypeName );
+		throw new IllegalArgumentException( "Unknown subtype name (" + baseType.getTypeName() + ") : " + subTypeName );
 	}
 
-	public static <S> ManagedDomainType<S> resolveSubType(
-			ManagedDomainType<? super S> baseType,
-			Class<S> subTypeClass,
-			JpaMetamodel jpaMetamodel) {
-		// todo : validate the hierarchy-ness...
-		return jpaMetamodel.managedType( subTypeClass );
+	static boolean isCompatible(
+			PersistentAttribute<?, ?> attribute1,
+			PersistentAttribute<?, ?> attribute2,
+			JpaMetamodelImplementor jpaMetamodel) {
+		if ( attribute1 == attribute2 ) {
+			return true;
+		}
+		final MappingMetamodel mappingMetamodel = jpaMetamodel.getMappingMetamodel();
+		final EntityMappingType entity1 = mappingMetamodel.getEntityDescriptor(
+				attribute1.getDeclaringType().getTypeName()
+		);
+		final EntityMappingType entity2 = mappingMetamodel.getEntityDescriptor(
+				attribute2.getDeclaringType().getTypeName()
+		);
+
+		return entity1 != null && entity2 != null && MappingModelHelper.isCompatibleModelPart(
+				entity1.findSubPart( attribute1.getName() ),
+				entity2.findSubPart( attribute2.getName() )
+		);
 	}
 
+	public static <J, S> ManagedDomainType<S> findSubType(ManagedDomainType<J> type, Class<S> subtype) {
+		if ( type.getBindableJavaType() == subtype ) {
+			@SuppressWarnings("unchecked")
+			final ManagedDomainType<S> result = (ManagedDomainType<S>) type;
+			return result;
+		}
+		for ( ManagedDomainType<? extends J> candidate : type.getSubTypes() ) {
+			if ( candidate.getBindableJavaType() == subtype ) {
+				@SuppressWarnings("unchecked")
+				final ManagedDomainType<S> result = (ManagedDomainType<S>) candidate;
+				return result;
+			}
+		}
+		for ( ManagedDomainType<? extends J> candidate : type.getSubTypes() ) {
+			final ManagedDomainType<S> candidateSubtype = findSubType( candidate, subtype );
+			if ( candidateSubtype != null) {
+				return candidateSubtype;
+			}
+		}
+		throw new IllegalArgumentException( "The class '" + subtype.getName()
+				+ "' is not a mapped subtype of '" + type.getTypeName() + "'" );
+//		return metamodel.managedType( subtype );
+	}
 
+	public static <J, S> SubGraphImplementor<S> makeSubGraph(ManagedDomainType<J> type, Class<S> subtype) {
+		if ( type.getBindableJavaType().isAssignableFrom( subtype ) ) {
+			return new SubGraphImpl( type, true );
+		}
+		else {
+			throw new IllegalArgumentException(
+					String.format(
+							"Type '%s' cannot be treated as subtype '%s'",
+							type.getTypeName(),
+							subtype.getName()
+					)
+			);
+		}
+	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/internal/EmbeddableTypeImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/internal/EmbeddableTypeImpl.java
@@ -16,11 +16,10 @@ import org.hibernate.metamodel.model.domain.spi.JpaMetamodelImplementor;
 import org.hibernate.type.descriptor.java.JavaType;
 
 /**
- * Standard Hibernate implementation of JPA's {@link jakarta.persistence.metamodel.EmbeddableType}
- * contract
+ * Implementation of {@link jakarta.persistence.metamodel.EmbeddableType}.
  *
  * @author Emmanuel Bernard
- * @author Steve Ebersole`
+ * @author Steve Ebersole
  */
 public class EmbeddableTypeImpl<J>
 		extends AbstractManagedType<J>
@@ -39,11 +38,5 @@ public class EmbeddableTypeImpl<J>
 	@Override
 	public PersistenceType getPersistenceType() {
 		return PersistenceType.EMBEDDABLE;
-	}
-
-	@Override
-	@SuppressWarnings("unchecked")
-	public <S extends J> SubGraphImplementor<S> makeSubGraph(Class<S> subType) {
-		return new SubGraphImpl( this, true );
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/internal/EmbeddedSqmPathSource.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/internal/EmbeddedSqmPathSource.java
@@ -10,7 +10,6 @@ import org.hibernate.metamodel.model.domain.EmbeddableDomainType;
 import org.hibernate.query.sqm.SqmPathSource;
 import org.hibernate.query.sqm.tree.domain.SqmEmbeddedValuedSimplePath;
 import org.hibernate.query.sqm.tree.domain.SqmPath;
-import org.hibernate.spi.NavigablePath;
 
 /**
  * @author Steve Ebersole
@@ -32,7 +31,6 @@ public class EmbeddedSqmPathSource<J>
 
 	@Override
 	public EmbeddableDomainType<J> getSqmPathType() {
-		//noinspection unchecked
 		return (EmbeddableDomainType<J>) super.getSqmPathType();
 	}
 
@@ -48,15 +46,8 @@ public class EmbeddedSqmPathSource<J>
 
 	@Override
 	public SqmPath<J> createSqmPath(SqmPath<?> lhs, SqmPathSource<?> intermediatePathSource) {
-		final NavigablePath navigablePath;
-		if ( intermediatePathSource == null ) {
-			navigablePath = lhs.getNavigablePath().append( getPathName() );
-		}
-		else {
-			navigablePath = lhs.getNavigablePath().append( intermediatePathSource.getPathName() ).append( getPathName() );
-		}
 		return new SqmEmbeddedValuedSimplePath<>(
-				navigablePath,
+				PathHelper.append( lhs, this, intermediatePathSource ),
 				pathModel,
 				lhs,
 				lhs.nodeBuilder()

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/internal/EntityDiscriminatorSqmPath.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/internal/EntityDiscriminatorSqmPath.java
@@ -7,6 +7,7 @@
 package org.hibernate.metamodel.model.domain.internal;
 
 import org.hibernate.metamodel.mapping.EntityMappingType;
+import org.hibernate.metamodel.model.domain.DiscriminatorSqmPath;
 import org.hibernate.metamodel.model.domain.EntityDomainType;
 import org.hibernate.query.sqm.NodeBuilder;
 import org.hibernate.query.sqm.SemanticQueryWalker;
@@ -18,12 +19,12 @@ import org.hibernate.query.sqm.tree.expression.SqmLiteralEntityType;
 import org.hibernate.spi.NavigablePath;
 
 /**
- * SqmPath specialization for an entity discriminator
+ * {@link SqmPath} specialization for an entity discriminator
  *
  * @author Steve Ebersole
  */
 @SuppressWarnings({ "rawtypes", "unchecked" })
-public class EntityDiscriminatorSqmPath extends AbstractSqmPath implements org.hibernate.metamodel.model.domain.DiscriminatorSqmPath {
+public class EntityDiscriminatorSqmPath<T> extends AbstractSqmPath<T> implements DiscriminatorSqmPath<T> {
 	private final EntityDomainType entityDomainType;
 	private final EntityMappingType entityDescriptor;
 

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/internal/EntitySqmPathSource.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/internal/EntitySqmPathSource.java
@@ -8,7 +8,6 @@ package org.hibernate.metamodel.model.domain.internal;
 
 import org.hibernate.metamodel.model.domain.EntityDomainType;
 import org.hibernate.metamodel.model.domain.spi.JpaMetamodelImplementor;
-import org.hibernate.spi.NavigablePath;
 import org.hibernate.query.hql.spi.SqmCreationState;
 import org.hibernate.query.sqm.SqmJoinable;
 import org.hibernate.query.sqm.SqmPathSource;
@@ -36,7 +35,6 @@ public class EntitySqmPathSource<J> extends AbstractSqmPathSource<J> implements 
 
 	@Override
 	public EntityDomainType<J> getSqmPathType() {
-		//noinspection unchecked
 		return (EntityDomainType<J>) super.getSqmPathType();
 	}
 
@@ -57,15 +55,8 @@ public class EntitySqmPathSource<J> extends AbstractSqmPathSource<J> implements 
 
 	@Override
 	public SqmPath<J> createSqmPath(SqmPath<?> lhs, SqmPathSource<?> intermediatePathSource) {
-		final NavigablePath navigablePath;
-		if ( intermediatePathSource == null ) {
-			navigablePath = lhs.getNavigablePath().append( getPathName() );
-		}
-		else {
-			navigablePath = lhs.getNavigablePath().append( intermediatePathSource.getPathName() ).append( getPathName() );
-		}
 		return new SqmEntityValuedSimplePath<>(
-				navigablePath,
+				PathHelper.append( lhs, this, intermediatePathSource ),
 				pathModel,
 				lhs,
 				lhs.nodeBuilder()

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/internal/EntitySqmPathSource.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/internal/EntitySqmPathSource.java
@@ -7,6 +7,7 @@
 package org.hibernate.metamodel.model.domain.internal;
 
 import org.hibernate.metamodel.model.domain.EntityDomainType;
+import org.hibernate.metamodel.model.domain.spi.JpaMetamodelImplementor;
 import org.hibernate.spi.NavigablePath;
 import org.hibernate.query.hql.spi.SqmCreationState;
 import org.hibernate.query.sqm.SqmJoinable;
@@ -41,8 +42,12 @@ public class EntitySqmPathSource<J> extends AbstractSqmPathSource<J> implements 
 
 	@Override
 	public SqmPathSource<?> findSubPathSource(String name) {
-		final EntityDomainType<J> sqmPathType = getSqmPathType();
-		return sqmPathType.findSubPathSource( name );
+		return getSqmPathType().findSubPathSource( name );
+	}
+
+	@Override
+	public SqmPathSource<?> findSubPathSource(String name, JpaMetamodelImplementor metamodel) {
+		return getSqmPathType().findSubPathSource( name, metamodel );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/internal/EntityTypeImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/internal/EntityTypeImpl.java
@@ -9,11 +9,10 @@ package org.hibernate.metamodel.model.domain.internal;
 import java.io.ObjectStreamException;
 import java.io.Serializable;
 import java.util.Collection;
+import java.util.Locale;
 
 import jakarta.persistence.metamodel.EntityType;
 
-import org.hibernate.graph.internal.SubGraphImpl;
-import org.hibernate.graph.spi.SubGraphImplementor;
 import org.hibernate.mapping.PersistentClass;
 import org.hibernate.metamodel.UnsupportedMappingException;
 import org.hibernate.metamodel.mapping.EntityDiscriminatorMapping;
@@ -23,18 +22,21 @@ import org.hibernate.metamodel.model.domain.DomainType;
 import org.hibernate.metamodel.model.domain.EntityDomainType;
 import org.hibernate.metamodel.model.domain.IdentifiableDomainType;
 import org.hibernate.metamodel.model.domain.JpaMetamodel;
+import org.hibernate.metamodel.model.domain.ManagedDomainType;
 import org.hibernate.metamodel.model.domain.PersistentAttribute;
-import org.hibernate.metamodel.model.domain.SingularPersistentAttribute;
 import org.hibernate.metamodel.model.domain.spi.JpaMetamodelImplementor;
 import org.hibernate.persister.entity.DiscriminatorMetadata;
 import org.hibernate.persister.entity.Queryable;
+import org.hibernate.query.PathException;
 import org.hibernate.query.sqm.SqmPathSource;
 import org.hibernate.query.sqm.tree.domain.SqmPath;
 import org.hibernate.type.StandardBasicTypes;
 import org.hibernate.type.descriptor.java.JavaType;
 
+import static org.hibernate.metamodel.model.domain.internal.DomainModelHelper.isCompatible;
+
 /**
- * Defines the Hibernate implementation of the JPA {@link EntityType} contract.
+ * Implementation of {@link EntityType}.
  *
  * @author Steve Ebersole
  * @author Emmanuel Bernard
@@ -42,7 +44,9 @@ import org.hibernate.type.descriptor.java.JavaType;
 public class EntityTypeImpl<J>
 		extends AbstractIdentifiableType<J>
 		implements EntityDomainType<J>, Serializable {
+
 	private final String jpaEntityName;
+	private final JpaMetamodelImplementor metamodel;
 	private final SqmPathSource<?> discriminatorPathSource;
 
 	public EntityTypeImpl(
@@ -53,7 +57,7 @@ public class EntityTypeImpl<J>
 			boolean hasVersion,
 			JavaType<J> javaType,
 			IdentifiableDomainType<? super J> superType,
-			JpaMetamodelImplementor jpaMetamodel) {
+			JpaMetamodelImplementor metamodel) {
 		super(
 				entityName,
 				javaType,
@@ -61,13 +65,14 @@ public class EntityTypeImpl<J>
 				hasIdClass,
 				hasIdProperty,
 				hasVersion,
-				jpaMetamodel
+				metamodel
 		);
 
 		this.jpaEntityName = jpaEntityName;
+		this.metamodel = metamodel;
 
 		final Queryable entityDescriptor = (Queryable)
-				jpaMetamodel.getMappingMetamodel()
+				metamodel.getMappingMetamodel()
 						.getEntityDescriptor( getHibernateEntityName() );
 		final DiscriminatorMetadata discriminatorMetadata = entityDescriptor.getTypeDiscriminatorMetadata();
 		final DomainType discriminatorType;
@@ -75,7 +80,7 @@ public class EntityTypeImpl<J>
 			discriminatorType = (DomainType) discriminatorMetadata.getResolutionType();
 		}
 		else {
-			discriminatorType = jpaMetamodel.getTypeConfiguration()
+			discriminatorType = metamodel.getTypeConfiguration()
 					.getBasicTypeRegistry()
 					.resolve( StandardBasicTypes.STRING );
 		}
@@ -91,7 +96,7 @@ public class EntityTypeImpl<J>
 			JavaType<J> javaType,
 			IdentifiableDomainType<? super J> superType,
 			PersistentClass persistentClass,
-			JpaMetamodelImplementor jpaMetamodel) {
+			JpaMetamodelImplementor metamodel) {
 		this(
 				persistentClass.getEntityName(),
 				persistentClass.getJpaEntityName(),
@@ -101,11 +106,11 @@ public class EntityTypeImpl<J>
 				persistentClass.isVersioned(),
 				javaType,
 				superType,
-				jpaMetamodel
+				metamodel
 		);
 	}
 
-	public EntityTypeImpl(JavaType<J> javaTypeDescriptor, JpaMetamodelImplementor jpaMetamodel) {
+	public EntityTypeImpl(JavaType<J> javaTypeDescriptor, JpaMetamodelImplementor metamodel) {
 		super(
 				javaTypeDescriptor.getJavaTypeClass().getName(),
 				javaTypeDescriptor,
@@ -113,10 +118,11 @@ public class EntityTypeImpl<J>
 				false,
 				false,
 				false,
-				jpaMetamodel
+				metamodel
 		);
 
 		this.jpaEntityName = javaTypeDescriptor.getJavaTypeClass().getName();
+		this.metamodel = metamodel;
 		this.discriminatorPathSource = null;
 	}
 
@@ -142,12 +148,12 @@ public class EntityTypeImpl<J>
 
 	@Override
 	public SqmPathSource<?> findSubPathSource(String name) {
-		final PersistentAttribute<?,?> attribute = findAttribute( name );
+		final PersistentAttribute<? super J,?> attribute = findAttribute( name );
 		if ( attribute != null ) {
 			return (SqmPathSource<?>) attribute;
 		}
 
-		if ( "id".equalsIgnoreCase( name ) ) {
+		if ( EntityIdentifierMapping.matchesRoleName( name ) ) {
 			if ( hasIdClass() ) {
 				return getIdentifierDescriptor();
 			}
@@ -161,18 +167,60 @@ public class EntityTypeImpl<J>
 	}
 
 	@Override
+	public SqmPathSource<?> findSubPathSource(String name, JpaMetamodelImplementor metamodel) {
+		final PersistentAttribute<? super J,?> attribute = super.findAttribute( name );
+		if ( attribute != null ) {
+			return (SqmPathSource<?>) attribute;
+		}
+
+		PersistentAttribute<?, ?> subtypeAttribute = findSubtypeAttribute( name, metamodel );
+		if ( subtypeAttribute != null ) {
+			return (SqmPathSource<?>) subtypeAttribute;
+		}
+
+		if ( EntityIdentifierMapping.matchesRoleName( name ) ) {
+			return hasIdClass() ? getIdentifierDescriptor() : findIdAttribute();
+		}
+
+		if ( EntityDiscriminatorMapping.matchesRoleName( name ) ) {
+			return discriminatorPathSource;
+		}
+
+		return null;
+	}
+
+	private PersistentAttribute<?, ?> findSubtypeAttribute(String name, JpaMetamodelImplementor metamodel) {
+		PersistentAttribute<?,?> subtypeAttribute = null;
+		for ( ManagedDomainType<?> subtype : getSubTypes() ) {
+			final PersistentAttribute<?,?> candidate = subtype.findSubTypesAttribute( name );
+			if ( candidate != null ) {
+				if ( subtypeAttribute != null && !isCompatible( subtypeAttribute, candidate, metamodel ) ) {
+					throw new PathException(
+							String.format(
+									Locale.ROOT,
+									"Could not resolve attribute '%s' of '%s' due to the attribute being declared in multiple subtypes '%s' and '%s'",
+									name,
+									getTypeName(),
+									subtypeAttribute.getDeclaringType().getTypeName(),
+									candidate.getDeclaringType().getTypeName()
+							)
+					);
+				}
+				subtypeAttribute = candidate;
+			}
+		}
+		return subtypeAttribute;
+	}
+
+	@Override
 	public PersistentAttribute<? super J, ?> findAttribute(String name) {
 		final PersistentAttribute<? super J, ?> attribute = super.findAttribute( name );
 		if ( attribute != null ) {
 			return attribute;
 		}
 
-		if ( "id".equalsIgnoreCase( name ) || EntityIdentifierMapping.ROLE_LOCAL_NAME.equals( name ) ) {
-			final SingularPersistentAttribute<J, ?> idAttribute = findIdAttribute();
-			//noinspection RedundantIfStatement
-			if ( idAttribute != null ) {
-				return idAttribute;
-			}
+		if ( EntityIdentifierMapping.matchesRoleName( name ) ) {
+			return findIdAttribute();
 		}
 
 		return null;
@@ -200,27 +248,6 @@ public class EntityTypeImpl<J>
 	}
 
 	@Override
-	@SuppressWarnings("unchecked")
-	public <S extends J> SubGraphImplementor<S> makeSubGraph(Class<S> subType) {
-		if ( ! getBindableJavaType().isAssignableFrom( subType ) ) {
-			throw new IllegalArgumentException(
-					String.format(
-							"Entity type [%s] cannot be treated as requested sub-type [%s]",
-							getName(),
-							subType.getName()
-					)
-			);
-		}
-
-		return new SubGraphImpl( this, true );
-	}
-
-	@Override
-	public SubGraphImplementor<J> makeSubGraph() {
-		return makeSubGraph( getBindableJavaType() );
-	}
-
-	@Override
 	public String toString() {
 		return getName();
 	}
@@ -236,7 +263,7 @@ public class EntityTypeImpl<J>
 	// Serialization
 
 	protected Object writeReplace() throws ObjectStreamException {
-		return new SerialForm( jpaMetamodel(), getHibernateEntityName() );
+		return new SerialForm( metamodel, getHibernateEntityName() );
 	}
 
 	private static class SerialForm implements Serializable {

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/internal/JpaMetamodelImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/internal/JpaMetamodelImpl.java
@@ -265,24 +265,19 @@ public class JpaMetamodelImpl implements JpaMetamodelImplementor, Serializable {
 	public <T> List<RootGraphImplementor<? super T>> findEntityGraphsByJavaType(Class<T> entityClass) {
 		final EntityDomainType<T> entityType = entity( entityClass );
 		if ( entityType == null ) {
-			throw new IllegalArgumentException( "Given class is not an entity : " + entityClass.getName() );
+			throw new IllegalArgumentException( "Given class is not an entity: " + entityClass.getName() );
 		}
-
-		final List<RootGraphImplementor<? super T>> results = new ArrayList<>();
-
-		for ( EntityGraph<?> entityGraph : entityGraphMap.values() ) {
-			if ( !( entityGraph instanceof RootGraphImplementor ) ) {
-				continue;
+		else {
+			final List<RootGraphImplementor<? super T>> results = new ArrayList<>();
+			for ( RootGraphImplementor<?> entityGraph : entityGraphMap.values() ) {
+				if ( entityGraph.appliesTo( entityType ) ) {
+					@SuppressWarnings("unchecked")
+					final RootGraphImplementor<? super T> result = (RootGraphImplementor<? super T>) entityGraph;
+					results.add( result );
+				}
 			}
-
-			//noinspection unchecked
-			final RootGraphImplementor<T> egi = (RootGraphImplementor<T>) entityGraph;
-			if ( egi.appliesTo( entityType, this ) ) {
-				results.add( egi );
-			}
+			return results;
 		}
-
-		return results;
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/internal/JpaMetamodelImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/internal/JpaMetamodelImpl.java
@@ -447,7 +447,7 @@ public class JpaMetamodelImpl implements JpaMetamodelImplementor, Serializable {
 			}
 
 			// create a set of descriptors that should be used to build the polymorphic EntityDomainType
-			final Set<EntityDomainType<?>> matchingDescriptors = new HashSet<>();
+			final Set<EntityDomainType<? extends T>> matchingDescriptors = new HashSet<>();
 			for ( EntityDomainType<?> entityDomainType : jpaEntityTypeMap.values() ) {
 				// see if we should add `entityDomainType` as one of the matching-descriptors.
 				if ( javaType.isAssignableFrom( entityDomainType.getJavaType() ) ) {
@@ -477,7 +477,7 @@ public class JpaMetamodelImpl implements JpaMetamodelImplementor, Serializable {
 					}
 
 					// aside from these special cases, add it
-					matchingDescriptors.add( entityDomainType );
+					matchingDescriptors.add( (EntityDomainType<? extends T>) entityDomainType );
 				}
 			}
 

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/internal/ListAttributeImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/internal/ListAttributeImpl.java
@@ -79,18 +79,17 @@ public class ListAttributeImpl<X, E> extends AbstractPluralAttribute<X, List<E>,
 	public SqmPathSource<?> getIntermediatePathSource(SqmPathSource<?> pathSource) {
 		final String pathName = pathSource.getPathName();
 		return pathName.equals( getElementPathSource().getPathName() )
-				|| pathName.equals( indexPathSource.getPathName() ) ? null : getElementPathSource();
+			|| pathName.equals( indexPathSource.getPathName() ) ? null : getElementPathSource();
 	}
 
 	@Override
-	public SqmAttributeJoin createSqmJoin(
-			SqmFrom lhs,
+	public SqmAttributeJoin<X,E> createSqmJoin(
+			SqmFrom<?,X> lhs,
 			SqmJoinType joinType,
 			String alias,
 			boolean fetched,
 			SqmCreationState creationState) {
-		//noinspection unchecked
-		return new SqmListJoin(
+		return new SqmListJoin<>(
 				lhs,
 				this,
 				alias,

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/internal/ListAttributeImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/internal/ListAttributeImpl.java
@@ -11,6 +11,7 @@ import java.util.List;
 import org.hibernate.metamodel.internal.MetadataContext;
 import org.hibernate.metamodel.mapping.CollectionPart;
 import org.hibernate.metamodel.model.domain.ListPersistentAttribute;
+import org.hibernate.metamodel.model.domain.spi.JpaMetamodelImplementor;
 import org.hibernate.query.sqm.SqmPathSource;
 import org.hibernate.query.hql.spi.SqmCreationState;
 import org.hibernate.query.sqm.internal.SqmMappingModelHelper;
@@ -58,6 +59,20 @@ public class ListAttributeImpl<X, E> extends AbstractPluralAttribute<X, List<E>,
 			}
 		}
 		return getElementPathSource().findSubPathSource( name );
+	}
+
+	@Override
+	public SqmPathSource<?> findSubPathSource(String name, JpaMetamodelImplementor metamodel) {
+		final CollectionPart.Nature nature = CollectionPart.Nature.fromNameExact( name );
+		if ( nature != null ) {
+			switch ( nature ) {
+				case INDEX:
+					return indexPathSource;
+				case ELEMENT:
+					return getElementPathSource();
+			}
+		}
+		return getElementPathSource().findSubPathSource( name, metamodel );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/internal/MapAttributeImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/internal/MapAttributeImpl.java
@@ -103,9 +103,9 @@ public class MapAttributeImpl<X, K, V> extends AbstractPluralAttribute<X, Map<K,
 	}
 
 	@Override
-	public SqmAttributeJoin createSqmJoin(
-			SqmFrom lhs, SqmJoinType joinType, String alias, boolean fetched, SqmCreationState creationState) {
-		return new SqmMapJoin(
+	public SqmAttributeJoin<X,V> createSqmJoin(
+			SqmFrom<?,X> lhs, SqmJoinType joinType, String alias, boolean fetched, SqmCreationState creationState) {
+		return new SqmMapJoin<>(
 				lhs,
 				this,
 				alias,

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/internal/MapAttributeImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/internal/MapAttributeImpl.java
@@ -12,6 +12,7 @@ import org.hibernate.metamodel.internal.MetadataContext;
 import org.hibernate.metamodel.mapping.CollectionPart;
 import org.hibernate.metamodel.model.domain.MapPersistentAttribute;
 import org.hibernate.metamodel.model.domain.SimpleDomainType;
+import org.hibernate.metamodel.model.domain.spi.JpaMetamodelImplementor;
 import org.hibernate.query.sqm.SqmPathSource;
 import org.hibernate.query.hql.spi.SqmCreationState;
 import org.hibernate.query.sqm.internal.SqmMappingModelHelper;
@@ -68,6 +69,20 @@ public class MapAttributeImpl<X, K, V> extends AbstractPluralAttribute<X, Map<K,
 			}
 		}
 		return getElementPathSource().findSubPathSource( name );
+	}
+
+	@Override
+	public SqmPathSource<?> findSubPathSource(String name, JpaMetamodelImplementor metamodel) {
+		final CollectionPart.Nature nature = CollectionPart.Nature.fromNameExact( name );
+		if ( nature != null ) {
+			switch ( nature ) {
+				case INDEX:
+					return keyPathSource;
+				case ELEMENT:
+					return getElementPathSource();
+			}
+		}
+		return getElementPathSource().findSubPathSource( name, metamodel );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/internal/MappedSuperclassSqmPathSource.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/internal/MappedSuperclassSqmPathSource.java
@@ -8,7 +8,6 @@ package org.hibernate.metamodel.model.domain.internal;
 
 import org.hibernate.metamodel.model.domain.MappedSuperclassDomainType;
 import org.hibernate.query.hql.spi.SqmCreationState;
-import org.hibernate.spi.NavigablePath;
 import org.hibernate.query.sqm.SqmJoinable;
 import org.hibernate.query.sqm.SqmPathSource;
 import org.hibernate.query.sqm.tree.SqmJoinType;
@@ -31,8 +30,7 @@ public class MappedSuperclassSqmPathSource<J> extends AbstractSqmPathSource<J> i
 
 	@Override
 	public MappedSuperclassDomainType<J> getSqmPathType() {
-		//noinspection unchecked
-		return ( MappedSuperclassDomainType<J> ) super.getSqmPathType();
+		return (MappedSuperclassDomainType<J>) super.getSqmPathType();
 	}
 
 	@Override
@@ -43,15 +41,8 @@ public class MappedSuperclassSqmPathSource<J> extends AbstractSqmPathSource<J> i
 
 	@Override
 	public SqmPath<J> createSqmPath(SqmPath<?> lhs, SqmPathSource<?> intermediatePathSource) {
-		final NavigablePath navigablePath;
-		if ( intermediatePathSource == null ) {
-			navigablePath = lhs.getNavigablePath().append( getPathName() );
-		}
-		else {
-			navigablePath = lhs.getNavigablePath().append( intermediatePathSource.getPathName() ).append( getPathName() );
-		}
 		return new SqmEntityValuedSimplePath<>(
-				navigablePath,
+				PathHelper.append( lhs, this, intermediatePathSource ),
 				pathModel,
 				lhs,
 				lhs.nodeBuilder()

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/internal/MappedSuperclassTypeImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/internal/MappedSuperclassTypeImpl.java
@@ -6,8 +6,6 @@
  */
 package org.hibernate.metamodel.model.domain.internal;
 
-import org.hibernate.graph.internal.SubGraphImpl;
-import org.hibernate.graph.spi.SubGraphImplementor;
 import org.hibernate.mapping.MappedSuperclass;
 import org.hibernate.metamodel.UnsupportedMappingException;
 import org.hibernate.metamodel.mapping.EntityIdentifierMapping;
@@ -15,13 +13,14 @@ import org.hibernate.metamodel.model.domain.AbstractIdentifiableType;
 import org.hibernate.metamodel.model.domain.IdentifiableDomainType;
 import org.hibernate.metamodel.model.domain.MappedSuperclassDomainType;
 import org.hibernate.metamodel.model.domain.PersistentAttribute;
-import org.hibernate.metamodel.model.domain.SingularPersistentAttribute;
 import org.hibernate.metamodel.model.domain.spi.JpaMetamodelImplementor;
 import org.hibernate.query.sqm.SqmPathSource;
 import org.hibernate.query.sqm.tree.domain.SqmPath;
 import org.hibernate.type.descriptor.java.JavaType;
 
 /**
+ * Implementation of {@link jakarta.persistence.metamodel.MappedSuperclassType}.
+ *
  * @author Emmanuel Bernard
  * @author Steve Ebersole
  */
@@ -96,12 +95,8 @@ public class MappedSuperclassTypeImpl<J> extends AbstractIdentifiableType<J> imp
 			return attribute;
 		}
 
-		if ( "id".equalsIgnoreCase( name ) || EntityIdentifierMapping.ROLE_LOCAL_NAME.equals( name ) ) {
-			final SingularPersistentAttribute<J, ?> idAttribute = findIdAttribute();
-			//noinspection RedundantIfStatement
-			if ( idAttribute != null ) {
-				return idAttribute;
-			}
+		if ( EntityIdentifierMapping.matchesRoleName( name ) ) {
+			return findIdAttribute();
 		}
 
 		return null;
@@ -115,27 +110,6 @@ public class MappedSuperclassTypeImpl<J> extends AbstractIdentifiableType<J> imp
 	@Override
 	public PersistenceType getPersistenceType() {
 		return PersistenceType.MAPPED_SUPERCLASS;
-	}
-
-	@Override
-	@SuppressWarnings("unchecked")
-	public <S extends J> SubGraphImplementor<S> makeSubGraph(Class<S> subType) {
-		if ( ! getBindableJavaType().isAssignableFrom( subType ) ) {
-			throw new IllegalArgumentException(
-					String.format(
-							"MappedSuperclass type [%s] cannot be treated as requested sub-type [%s]",
-							getTypeName(),
-							subType.getName()
-					)
-			);
-		}
-
-		return new SubGraphImpl( this, true );
-	}
-
-	@Override
-	public SubGraphImplementor<J> makeSubGraph() {
-		return makeSubGraph( getBindableJavaType() );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/internal/NonAggregatedCompositeSqmPathSource.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/internal/NonAggregatedCompositeSqmPathSource.java
@@ -7,7 +7,6 @@
 package org.hibernate.metamodel.model.domain.internal;
 
 import org.hibernate.metamodel.model.domain.ManagedDomainType;
-import org.hibernate.spi.NavigablePath;
 import org.hibernate.query.sqm.SqmPathSource;
 import org.hibernate.query.sqm.tree.domain.NonAggregatedCompositeSimplePath;
 import org.hibernate.query.sqm.tree.domain.SqmPath;
@@ -27,8 +26,8 @@ public class NonAggregatedCompositeSqmPathSource<J> extends AbstractSqmPathSourc
 	}
 
 	@Override
-	public ManagedDomainType<?> getSqmPathType() {
-		return (ManagedDomainType<?>) super.getSqmPathType();
+	public ManagedDomainType<J> getSqmPathType() {
+		return (ManagedDomainType<J>) super.getSqmPathType();
 	}
 
 	@Override
@@ -38,15 +37,8 @@ public class NonAggregatedCompositeSqmPathSource<J> extends AbstractSqmPathSourc
 
 	@Override
 	public SqmPath<J> createSqmPath(SqmPath<?> lhs, SqmPathSource<?> intermediatePathSource) {
-		final NavigablePath navigablePath;
-		if ( intermediatePathSource == null ) {
-			navigablePath = lhs.getNavigablePath().append( getPathName() );
-		}
-		else {
-			navigablePath = lhs.getNavigablePath().append( intermediatePathSource.getPathName() ).append( getPathName() );
-		}
 		return new NonAggregatedCompositeSimplePath<>(
-				navigablePath,
+				PathHelper.append( lhs, this, intermediatePathSource ),
 				pathModel,
 				lhs,
 				lhs.nodeBuilder()

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/internal/PathHelper.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/internal/PathHelper.java
@@ -1,0 +1,19 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html
+ */
+package org.hibernate.metamodel.model.domain.internal;
+
+import org.hibernate.query.sqm.SqmPathSource;
+import org.hibernate.query.sqm.tree.domain.SqmPath;
+import org.hibernate.spi.NavigablePath;
+
+public class PathHelper {
+	public static NavigablePath append(SqmPath<?> lhs, SqmPathSource<?> rhs, SqmPathSource<?> intermediatePathSource) {
+		return intermediatePathSource == null
+				? lhs.getNavigablePath().append( rhs.getPathName() )
+				: lhs.getNavigablePath().append( intermediatePathSource.getPathName() ).append( rhs.getPathName() );
+	}
+}

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/internal/PluralAttributeBuilder.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/internal/PluralAttributeBuilder.java
@@ -32,7 +32,7 @@ import static org.hibernate.metamodel.internal.AttributeFactory.determineSimpleT
  */
 public class PluralAttributeBuilder<D, C, E, K> {
 	private final JavaType<C> collectionJtd;
-	private boolean isGeneric;
+	private final boolean isGeneric;
 
 	private final AttributeClassification attributeClassification;
 	private final CollectionClassification collectionClassification;

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/internal/SetAttributeImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/internal/SetAttributeImpl.java
@@ -31,9 +31,9 @@ public class SetAttributeImpl<X, E> extends AbstractPluralAttribute<X, Set<E>, E
 	}
 
 	@Override
-	public SqmAttributeJoin createSqmJoin(
-			SqmFrom lhs, SqmJoinType joinType, String alias, boolean fetched, SqmCreationState creationState) {
-		return new SqmSetJoin(
+	public SqmAttributeJoin<X, E> createSqmJoin(
+			SqmFrom<?,X> lhs, SqmJoinType joinType, String alias, boolean fetched, SqmCreationState creationState) {
+		return new SqmSetJoin<>(
 				lhs,
 				this,
 				alias,

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/internal/SingularAttributeImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/internal/SingularAttributeImpl.java
@@ -22,6 +22,7 @@ import org.hibernate.metamodel.model.domain.ManagedDomainType;
 import org.hibernate.metamodel.model.domain.PluralPersistentAttribute;
 import org.hibernate.metamodel.model.domain.SimpleDomainType;
 import org.hibernate.metamodel.model.domain.SingularPersistentAttribute;
+import org.hibernate.metamodel.model.domain.spi.JpaMetamodelImplementor;
 import org.hibernate.query.SemanticException;
 import org.hibernate.query.sqm.SqmPathSource;
 import org.hibernate.query.hql.spi.SqmCreationState;
@@ -128,6 +129,11 @@ public class SingularAttributeImpl<D,J>
 	@Override
 	public SqmPathSource<?> findSubPathSource(String name) {
 		return sqmPathSource.findSubPathSource( name );
+	}
+
+	@Override
+	public SqmPathSource<?> findSubPathSource(String name, JpaMetamodelImplementor metamodel) {
+		return sqmPathSource.findSubPathSource( name, metamodel );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/package-info.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/package-info.java
@@ -16,4 +16,7 @@
  *
  * @see jakarta.persistence.metamodel
  */
+@Incubating
 package org.hibernate.metamodel.model.domain;
+
+import org.hibernate.Incubating;

--- a/hibernate-core/src/main/java/org/hibernate/persister/entity/AbstractEntityPersister.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/entity/AbstractEntityPersister.java
@@ -2276,7 +2276,7 @@ public abstract class AbstractEntityPersister
 
 		//noinspection rawtypes
 		final DiscriminatorConverter converter = MappedDiscriminatorConverter.fromValueMappings(
-				getNavigableRole().append( EntityDiscriminatorMapping.ROLE_NAME ),
+				getNavigableRole().append( EntityDiscriminatorMapping.DISCRIMINATOR_ROLE_NAME ),
 				domainJavaType,
 				underlingJdbcMapping,
 				getSubclassByDiscriminatorValue(),
@@ -4900,7 +4900,7 @@ public abstract class AbstractEntityPersister
 		}
 
 		identifierMapping = creationProcess.processSubPart(
-				EntityIdentifierMapping.ROLE_LOCAL_NAME,
+				EntityIdentifierMapping.ID_ROLE_NAME,
 				(role, process) -> generateIdentifierMapping( templateInstanceCreator, bootEntityDescriptor, process )
 		);
 
@@ -5811,7 +5811,7 @@ public abstract class AbstractEntityPersister
 	}
 
 	private boolean isIdentifierReference(String name) {
-		return EntityIdentifierMapping.ROLE_LOCAL_NAME.equals( name )
+		return EntityIdentifierMapping.ID_ROLE_NAME.equals( name )
 			|| hasIdentifierProperty() && getIdentifierPropertyName().equals( name )
 			|| !entityMetamodel.hasNonIdentifierPropertyNamedId() && "id".equals( name );
 	}

--- a/hibernate-core/src/main/java/org/hibernate/persister/entity/AbstractEntityPersister.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/entity/AbstractEntityPersister.java
@@ -3617,7 +3617,8 @@ public abstract class AbstractEntityPersister
 	@Override
 	public boolean isAffectedByEntityGraph(LoadQueryInfluencers loadQueryInfluencers) {
 		final RootGraphImplementor<?> graph = loadQueryInfluencers.getEffectiveEntityGraph().getGraph();
-		return graph != null && graph.appliesTo( getEntityName(), getFactory().getJpaMetamodel() );
+		return graph != null
+			&& graph.appliesTo( getFactory().getJpaMetamodel().entity( getEntityName() ) );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/procedure/internal/EntityDomainResultBuilder.java
+++ b/hibernate-core/src/main/java/org/hibernate/procedure/internal/EntityDomainResultBuilder.java
@@ -73,7 +73,7 @@ public class EntityDomainResultBuilder implements ResultBuilder {
 					}
 					return discriminatorFetchBuilder.buildFetch(
 							entityResult,
-							navigablePath.append( EntityDiscriminatorMapping.ROLE_NAME ),
+							navigablePath.append( EntityDiscriminatorMapping.DISCRIMINATOR_ROLE_NAME ),
 							jdbcResultsMetadata,
 							legacyFetchResolver,
 							domainResultCreationState

--- a/hibernate-core/src/main/java/org/hibernate/query/criteria/JpaOrder.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/criteria/JpaOrder.java
@@ -29,7 +29,7 @@ public interface JpaOrder extends Order, JpaCriteriaNode {
 
 
 	// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-	// Co-variants
+	// Covariant returns
 
 	@Override
 	JpaOrder reverse();

--- a/hibernate-core/src/main/java/org/hibernate/query/derived/AnonymousTupleEntityValuedModelPart.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/derived/AnonymousTupleEntityValuedModelPart.java
@@ -100,7 +100,7 @@ public class AnonymousTupleEntityValuedModelPart
 		final EntityPersister persister = ((EntityMappingType) delegate.getPartMappingType())
 				.getEntityPersister();
 		final Set<String> targetKeyPropertyNames = new HashSet<>();
-		targetKeyPropertyNames.add( EntityIdentifierMapping.ROLE_LOCAL_NAME );
+		targetKeyPropertyNames.add( EntityIdentifierMapping.ID_ROLE_NAME );
 		ToOneAttributeMapping.addPrefixedPropertyNames(
 				targetKeyPropertyNames,
 				persister.getIdentifierPropertyName(),

--- a/hibernate-core/src/main/java/org/hibernate/query/derived/AnonymousTupleSimpleSqmPathSource.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/derived/AnonymousTupleSimpleSqmPathSource.java
@@ -8,10 +8,10 @@ package org.hibernate.query.derived;
 
 import org.hibernate.Incubating;
 import org.hibernate.metamodel.model.domain.DomainType;
+import org.hibernate.metamodel.model.domain.internal.PathHelper;
 import org.hibernate.query.sqm.SqmPathSource;
 import org.hibernate.query.sqm.tree.domain.SqmBasicValuedSimplePath;
 import org.hibernate.query.sqm.tree.domain.SqmPath;
-import org.hibernate.spi.NavigablePath;
 import org.hibernate.type.descriptor.java.JavaType;
 
 /**
@@ -43,7 +43,7 @@ public class AnonymousTupleSimpleSqmPathSource<J> implements SqmPathSource<J> {
 	}
 
 	@Override
-	public DomainType<?> getSqmPathType() {
+	public DomainType<J> getSqmPathType() {
 		return domainType;
 	}
 
@@ -64,15 +64,8 @@ public class AnonymousTupleSimpleSqmPathSource<J> implements SqmPathSource<J> {
 
 	@Override
 	public SqmPath<J> createSqmPath(SqmPath<?> lhs, SqmPathSource<?> intermediatePathSource) {
-		final NavigablePath navigablePath;
-		if ( intermediatePathSource == null ) {
-			navigablePath = lhs.getNavigablePath().append( getPathName() );
-		}
-		else {
-			navigablePath = lhs.getNavigablePath().append( intermediatePathSource.getPathName() ).append( getPathName() );
-		}
 		return new SqmBasicValuedSimplePath<>(
-				navigablePath,
+				PathHelper.append( lhs, this, intermediatePathSource ),
 				this,
 				lhs,
 				lhs.nodeBuilder()

--- a/hibernate-core/src/main/java/org/hibernate/query/derived/AnonymousTupleSqmAssociationPathSource.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/derived/AnonymousTupleSqmAssociationPathSource.java
@@ -40,8 +40,8 @@ public class AnonymousTupleSqmAssociationPathSource<O, J> extends AnonymousTuple
 	}
 
 	@Override
-	public SqmJoin createSqmJoin(
-			SqmFrom lhs,
+	public SqmJoin<O, J> createSqmJoin(
+			SqmFrom<?, O> lhs,
 			SqmJoinType joinType,
 			String alias,
 			boolean fetched,

--- a/hibernate-core/src/main/java/org/hibernate/query/derived/AnonymousTupleSqmPathSource.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/derived/AnonymousTupleSqmPathSource.java
@@ -11,17 +11,12 @@ import org.hibernate.metamodel.model.domain.BasicDomainType;
 import org.hibernate.metamodel.model.domain.DomainType;
 import org.hibernate.metamodel.model.domain.EmbeddableDomainType;
 import org.hibernate.metamodel.model.domain.EntityDomainType;
-import org.hibernate.metamodel.model.domain.PersistentAttribute;
-import org.hibernate.metamodel.model.domain.internal.BasicSqmPathSource;
-import org.hibernate.metamodel.model.domain.internal.EmbeddedSqmPathSource;
-import org.hibernate.metamodel.model.domain.internal.EntitySqmPathSource;
+import org.hibernate.metamodel.model.domain.internal.PathHelper;
 import org.hibernate.query.sqm.SqmPathSource;
 import org.hibernate.query.sqm.tree.domain.SqmBasicValuedSimplePath;
 import org.hibernate.query.sqm.tree.domain.SqmEmbeddedValuedSimplePath;
 import org.hibernate.query.sqm.tree.domain.SqmEntityValuedSimplePath;
 import org.hibernate.query.sqm.tree.domain.SqmPath;
-import org.hibernate.spi.NavigablePath;
-import org.hibernate.type.BasicType;
 import org.hibernate.type.descriptor.java.JavaType;
 
 /**
@@ -51,8 +46,7 @@ public class AnonymousTupleSqmPathSource<J> implements SqmPathSource<J> {
 
 	@Override
 	public DomainType<J> getSqmPathType() {
-		//noinspection unchecked
-		return (DomainType<J>) path.getNodeType().getSqmPathType();
+		return path.getNodeType().getSqmPathType();
 	}
 
 	@Override
@@ -72,17 +66,10 @@ public class AnonymousTupleSqmPathSource<J> implements SqmPathSource<J> {
 
 	@Override
 	public SqmPath<J> createSqmPath(SqmPath<?> lhs, SqmPathSource<?> intermediatePathSource) {
-		final NavigablePath navigablePath;
-		if ( intermediatePathSource == null ) {
-			navigablePath = lhs.getNavigablePath().append( getPathName() );
-		}
-		else {
-			navigablePath = lhs.getNavigablePath().append( intermediatePathSource.getPathName() ).append( getPathName() );
-		}
 		final DomainType<?> domainType = path.getNodeType().getSqmPathType();
 		if ( domainType instanceof BasicDomainType<?> ) {
 			return new SqmBasicValuedSimplePath<>(
-					navigablePath,
+					PathHelper.append( lhs, this, intermediatePathSource ),
 					this,
 					lhs,
 					lhs.nodeBuilder()
@@ -90,7 +77,7 @@ public class AnonymousTupleSqmPathSource<J> implements SqmPathSource<J> {
 		}
 		else if ( domainType instanceof EmbeddableDomainType<?> ) {
 			return new SqmEmbeddedValuedSimplePath<>(
-					navigablePath,
+					PathHelper.append( lhs, this, intermediatePathSource ),
 					this,
 					lhs,
 					lhs.nodeBuilder()
@@ -98,7 +85,7 @@ public class AnonymousTupleSqmPathSource<J> implements SqmPathSource<J> {
 		}
 		else if ( domainType instanceof EntityDomainType<?> ) {
 			return new SqmEntityValuedSimplePath<>(
-					navigablePath,
+					PathHelper.append( lhs, this, intermediatePathSource ),
 					this,
 					lhs,
 					lhs.nodeBuilder()

--- a/hibernate-core/src/main/java/org/hibernate/query/derived/AnonymousTupleType.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/derived/AnonymousTupleType.java
@@ -236,7 +236,7 @@ public class AnonymousTupleType<T> implements TupleType<T>, DomainType<T>, Retur
 	}
 
 	@Override
-	public DomainType<?> getSqmPathType() {
+	public DomainType<T> getSqmPathType() {
 		return this;
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/query/derived/AnonymousTupleType.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/derived/AnonymousTupleType.java
@@ -117,13 +117,7 @@ public class AnonymousTupleType<T> implements TupleType<T>, DomainType<T>, Retur
 		if ( domainType instanceof EntityDomainType<?> ) {
 			final EntityDomainType<?> entityDomainType = (EntityDomainType<?>) domainType;
 			final SingularPersistentAttribute<?, ?> idAttribute = entityDomainType.findIdAttribute();
-			final String idPath;
-			if ( idAttribute == null ) {
-				idPath = componentName;
-			}
-			else {
-				idPath = componentName + "_" + idAttribute.getName();
-			}
+			final String idPath = idAttribute == null ? componentName : componentName + "_" + idAttribute.getName();
 			addColumnNames( columnNames, entityDomainType.getIdentifierDescriptor().getSqmPathType(), idPath );
 		}
 		else if ( domainType instanceof ManagedDomainType<?> ) {

--- a/hibernate-core/src/main/java/org/hibernate/query/hql/internal/SqmPathRegistryImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/hql/internal/SqmPathRegistryImpl.java
@@ -14,6 +14,7 @@ import java.util.Map;
 import java.util.function.Function;
 
 import org.hibernate.jpa.spi.JpaCompliance;
+import org.hibernate.metamodel.model.domain.spi.JpaMetamodelImplementor;
 import org.hibernate.query.hql.HqlLogging;
 import org.hibernate.query.hql.spi.SqmCreationProcessingState;
 import org.hibernate.query.hql.spi.SqmPathRegistry;
@@ -247,7 +248,11 @@ public class SqmPathRegistryImpl implements SqmPathRegistry {
 	}
 
 	private boolean definesAttribute(SqmPathSource<?> containerType, String name) {
-		return containerType.findSubPathSource( name ) != null;
+		return containerType.findSubPathSource( name, getJpaMetamodel() ) != null;
+	}
+
+	private JpaMetamodelImplementor getJpaMetamodel() {
+		return associatedProcessingState.getCreationState().getCreationContext().getJpaMetamodel();
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/query/results/ResultsHelper.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/results/ResultsHelper.java
@@ -7,7 +7,6 @@
 package org.hibernate.query.results;
 
 import org.hibernate.metamodel.mapping.EntityIdentifierMapping;
-import org.hibernate.metamodel.mapping.JdbcMapping;
 import org.hibernate.metamodel.mapping.ModelPart;
 import org.hibernate.metamodel.mapping.SelectableMapping;
 import org.hibernate.metamodel.mapping.internal.SingleAttributeIdentifierMapping;
@@ -74,11 +73,11 @@ public class ResultsHelper {
 	public static boolean isIdentifier(EntityIdentifierMapping identifierDescriptor, String... names) {
 		final String identifierAttributeName = identifierDescriptor instanceof SingleAttributeIdentifierMapping
 				? ( (SingleAttributeIdentifierMapping) identifierDescriptor ).getAttributeName()
-				: EntityIdentifierMapping.ROLE_LOCAL_NAME;
+				: EntityIdentifierMapping.ID_ROLE_NAME;
 
 		for ( int i = 0; i < names.length; i++ ) {
 			final String name = names[ i ];
-			if ( EntityIdentifierMapping.ROLE_LOCAL_NAME.equals( name ) ) {
+			if ( EntityIdentifierMapping.ID_ROLE_NAME.equals( name ) ) {
 				return true;
 			}
 

--- a/hibernate-core/src/main/java/org/hibernate/query/results/complete/CompleteResultBuilderEntityJpa.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/results/complete/CompleteResultBuilderEntityJpa.java
@@ -122,7 +122,7 @@ public class CompleteResultBuilderEntityJpa implements CompleteResultBuilderEnti
 
 						return discriminatorFetchBuilder.buildFetch(
 								entityResult,
-								navigablePath.append( EntityDiscriminatorMapping.ROLE_NAME ),
+								navigablePath.append( EntityDiscriminatorMapping.DISCRIMINATOR_ROLE_NAME ),
 								jdbcResultsMetadata,
 								legacyFetchResolver,
 								domainResultCreationState

--- a/hibernate-core/src/main/java/org/hibernate/query/results/complete/CompleteResultBuilderEntityStandard.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/results/complete/CompleteResultBuilderEntityStandard.java
@@ -156,7 +156,7 @@ public class CompleteResultBuilderEntityStandard implements CompleteResultBuilde
 
 						return discriminatorFetchBuilder.buildFetch(
 								entityResult,
-								navigablePath.append( EntityDiscriminatorMapping.ROLE_NAME ),
+								navigablePath.append( EntityDiscriminatorMapping.DISCRIMINATOR_ROLE_NAME ),
 								jdbcResultsMetadata,
 								legacyFetchResolver,
 								domainResultCreationState

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/SqmPathSource.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/SqmPathSource.java
@@ -28,16 +28,18 @@ import org.hibernate.query.sqm.tree.domain.SqmPath;
  */
 public interface SqmPathSource<J> extends SqmExpressible<J>, Bindable<J>, SqmExpressibleAccessor<J> {
 	/**
-	 * The name of this thing.  Mainly used in logging and when creating a
-	 * {@link NavigablePath}
+	 * The name of this thing.
+	 *
+	 * @apiNote Mainly used in logging and when creating a {@link NavigablePath}.
 	 */
 	String getPathName();
 
 	/**
-	 * The type of SqmPaths this source creates.  Corollary to JPA's
-	 * {@link Bindable#getBindableJavaType()}
+	 * The type of {@linkplain SqmPath path} this source creates.
+	 *
+	 * @apiNote Analogous to {@link Bindable#getBindableJavaType()}.
 	 */
-	DomainType<?> getSqmPathType();
+	DomainType<J> getSqmPathType();
 
 	/**
 	 * Find a {@link SqmPathSource} by name relative to this source.

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/internal/QuerySqmImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/internal/QuerySqmImpl.java
@@ -838,7 +838,7 @@ public class QuerySqmImpl<R>
 		final EntityIdentifierMapping identifierMapping = entityDescriptor.getIdentifierMapping();
 		final String partName = identifierMapping instanceof SingleAttributeIdentifierMapping
 				? identifierMapping.getAttributeName()
-				: EntityIdentifierMapping.ROLE_LOCAL_NAME;
+				: EntityIdentifierMapping.ID_ROLE_NAME;
 		for ( SqmPath<?> insertionTargetPath : sqmInsert.getInsertionTargetPaths() ) {
 			final SqmPath<?> lhs = insertionTargetPath.getLhs();
 			if ( !( lhs instanceof SqmRoot<?> ) ) {

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/sql/BaseSqmToSqlAstConverter.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/sql/BaseSqmToSqlAstConverter.java
@@ -5079,7 +5079,7 @@ public abstract class BaseSqmToSqlAstConverter<T extends Statement> extends Base
 			}
 
 			final DiscriminatorPathInterpretation<?> typeExpression = new DiscriminatorPathInterpretation<>(
-					tableGroup.getNavigablePath().append( EntityDiscriminatorMapping.ROLE_NAME ),
+					tableGroup.getNavigablePath().append( EntityDiscriminatorMapping.DISCRIMINATOR_ROLE_NAME ),
 					entityMapping,
 					tableGroup,
 					this

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/domain/AbstractSqmFrom.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/domain/AbstractSqmFrom.java
@@ -406,7 +406,8 @@ public abstract class AbstractSqmFrom<O,T> extends AbstractSqmPath<T> implements
 	@Override
 	@SuppressWarnings("unchecked")
 	public <X, Y> SqmAttributeJoin<X, Y> join(String attributeName, JoinType jt) {
-		final SqmPathSource<?> subPathSource = getReferencedPathSource().getSubPathSource( attributeName );
+		final SqmPathSource<?> subPathSource =
+				getReferencedPathSource().getSubPathSource( attributeName, nodeBuilder().getJpaMetamodel() );
 		return (SqmAttributeJoin<X, Y>) buildJoin( subPathSource, SqmJoinType.from( jt ), false );
 	}
 
@@ -418,7 +419,8 @@ public abstract class AbstractSqmFrom<O,T> extends AbstractSqmPath<T> implements
 	@Override
 	@SuppressWarnings("unchecked")
 	public <X, Y> SqmBagJoin<X, Y> joinCollection(String attributeName, JoinType jt) {
-		final SqmPathSource<?> joinedPathSource = getReferencedPathSource().getSubPathSource( attributeName );
+		final SqmPathSource<?> joinedPathSource =
+				getReferencedPathSource().getSubPathSource( attributeName, nodeBuilder().getJpaMetamodel() );
 
 		if ( joinedPathSource instanceof BagPersistentAttribute ) {
 			final SqmBagJoin<T, Y> join = buildBagJoin(
@@ -449,7 +451,8 @@ public abstract class AbstractSqmFrom<O,T> extends AbstractSqmPath<T> implements
 	@Override
 	@SuppressWarnings("unchecked")
 	public <X, Y> SqmSetJoin<X, Y> joinSet(String attributeName, JoinType jt) {
-		final SqmPathSource<?> joinedPathSource = getReferencedPathSource().getSubPathSource( attributeName );
+		final SqmPathSource<?> joinedPathSource =
+				getReferencedPathSource().getSubPathSource( attributeName, nodeBuilder().getJpaMetamodel() );
 
 		if ( joinedPathSource instanceof SetPersistentAttribute ) {
 			final SqmSetJoin<T, Y> join = buildSetJoin(
@@ -480,7 +483,8 @@ public abstract class AbstractSqmFrom<O,T> extends AbstractSqmPath<T> implements
 	@Override
 	@SuppressWarnings("unchecked")
 	public <X, Y> SqmListJoin<X, Y> joinList(String attributeName, JoinType jt) {
-		final SqmPathSource<?> joinedPathSource = getReferencedPathSource().getSubPathSource( attributeName );
+		final SqmPathSource<?> joinedPathSource =
+				getReferencedPathSource().getSubPathSource( attributeName, nodeBuilder().getJpaMetamodel() );
 
 		if ( joinedPathSource instanceof ListPersistentAttribute ) {
 			final SqmListJoin<T, Y> join = buildListJoin(
@@ -511,7 +515,8 @@ public abstract class AbstractSqmFrom<O,T> extends AbstractSqmPath<T> implements
 	@Override
 	@SuppressWarnings("unchecked")
 	public <X, K, V> SqmMapJoin<X, K, V> joinMap(String attributeName, JoinType jt) {
-		final SqmPathSource<?> joinedPathSource = getReferencedPathSource().getSubPathSource( attributeName );
+		final SqmPathSource<?> joinedPathSource =
+				getReferencedPathSource().getSubPathSource( attributeName, nodeBuilder().getJpaMetamodel() );
 
 		if ( joinedPathSource instanceof MapPersistentAttribute<?, ?, ?> ) {
 			final SqmMapJoin<T, K, V> join = buildMapJoin(

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/domain/AbstractSqmPath.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/domain/AbstractSqmPath.java
@@ -168,23 +168,24 @@ public abstract class AbstractSqmPath<T> extends AbstractSqmExpression<T> implem
 	@SuppressWarnings("unchecked")
 	public SqmExpression<Class<? extends T>> type() {
 		final SqmPathSource<T> referencedPathSource = getReferencedPathSource();
-		final SqmPathSource<?> subPathSource = referencedPathSource.findSubPathSource( EntityDiscriminatorMapping.ROLE_NAME );
+		final SqmPathSource<?> subPathSource = referencedPathSource.findSubPathSource( EntityDiscriminatorMapping.DISCRIMINATOR_ROLE_NAME );
 
 		if ( subPathSource == null ) {
 			return new SqmLiteral<>(
 					referencedPathSource.getBindableJavaType(),
-					(SqmExpressible<? extends Class<? extends T>>) (SqmExpressible<?>) nodeBuilder().getTypeConfiguration()
-							.getBasicTypeForJavaType( Class.class ),
+					(SqmExpressible<? extends Class<? extends T>>) (SqmExpressible<?>)
+							nodeBuilder().getTypeConfiguration().getBasicTypeForJavaType( Class.class ),
 					nodeBuilder()
 			);
 		}
-		return (SqmExpression<Class<? extends T>>) resolvePath( EntityDiscriminatorMapping.ROLE_NAME, subPathSource );
+		return (SqmExpression<Class<? extends T>>) resolvePath( EntityDiscriminatorMapping.DISCRIMINATOR_ROLE_NAME, subPathSource );
 	}
 
 	@Override
 	@SuppressWarnings("unchecked")
 	public SqmPath<?> get(String attributeName) {
-		final SqmPathSource<?> subNavigable = getResolvedModel().getSubPathSource( attributeName );
+		final SqmPathSource<?> subNavigable =
+				getResolvedModel().getSubPathSource( attributeName, nodeBuilder().getSessionFactory().getJpaMetamodel() );
 		return resolvePath( attributeName, subNavigable );
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/domain/SqmPolymorphicRootDescriptor.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/domain/SqmPolymorphicRootDescriptor.java
@@ -15,7 +15,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Consumer;
-import java.util.stream.Collectors;
+
 import jakarta.persistence.metamodel.Attribute;
 import jakarta.persistence.metamodel.CollectionAttribute;
 import jakarta.persistence.metamodel.ListAttribute;
@@ -24,7 +24,6 @@ import jakarta.persistence.metamodel.PluralAttribute;
 import jakarta.persistence.metamodel.SetAttribute;
 import jakarta.persistence.metamodel.SingularAttribute;
 
-import org.hibernate.graph.spi.SubGraphImplementor;
 import org.hibernate.metamodel.RepresentationMode;
 import org.hibernate.metamodel.model.domain.DomainType;
 import org.hibernate.metamodel.model.domain.EntityDomainType;
@@ -37,56 +36,67 @@ import org.hibernate.metamodel.model.domain.SingularPersistentAttribute;
 import org.hibernate.query.sqm.SqmPathSource;
 import org.hibernate.type.descriptor.java.JavaType;
 
+import static java.util.Collections.unmodifiableMap;
+
 /**
- * Acts as the EntityValuedNavigable for a "polymorphic query" grouping
+ * Acts as the {@link EntityDomainType} for a "polymorphic query" grouping.
  *
  * @author Steve Ebersole
  */
 public class SqmPolymorphicRootDescriptor<T> implements EntityDomainType<T> {
-	private final Set<EntityDomainType<?>> implementors;
-	private final Map<String, PersistentAttribute> commonAttributes;
+	private final Set<EntityDomainType<? extends T>> implementors;
+	private final Map<String, PersistentAttribute<? super T,?>> commonAttributes;
 
 	private final JavaType<T> polymorphicJavaType;
 
 	public SqmPolymorphicRootDescriptor(
 			JavaType<T> polymorphicJavaType,
-			Set<EntityDomainType<?>> implementors) {
+			Set<EntityDomainType<? extends T>> implementors) {
 		this.polymorphicJavaType = polymorphicJavaType;
-
 		this.implementors = implementors;
+		this.commonAttributes = unmodifiableMap( inferCommonAttributes( implementors ) );
+	}
 
-		final Map<String, PersistentAttribute> workMap = new HashMap<>();
-
-		final ArrayList<EntityDomainType<?>> implementorsList = new ArrayList<>( implementors );
-
+	/**
+	 * The attributes of a "polymorphic" root are the attributes which are
+	 * common to all subtypes of the root type.
+	 */
+	private Map<String, PersistentAttribute<? super T, ?>> inferCommonAttributes(Set<EntityDomainType<? extends T>> implementors) {
+		final Map<String, PersistentAttribute<? super T,?>> workMap = new HashMap<>();
+		final ArrayList<EntityDomainType<?>> implementorsList = new ArrayList<>(implementors);
 		final EntityDomainType<?> firstImplementor = implementorsList.get( 0 );
-
 		if ( implementorsList.size() == 1 ) {
 			firstImplementor.visitAttributes(
-					attribute -> {
-						workMap.put( attribute.getName(), attribute );
-					}
+					attribute -> workMap.put( attribute.getName(), promote( attribute ) )
 			);
 		}
 		else {
-			// basically we want to "expose" only the attributes that all the implementors expose...
-			// 		- visit all of the attributes defined on the first implementor and check it against
-			// 		all of the others
+			// we want to "expose" only the attributes that all the implementors expose
+			// visit every attribute declared on the first implementor and check that it
+			// is also declared by every other implementor
 			final List<EntityDomainType<?>> subList = implementorsList.subList( 1, implementors.size() - 1 );
 			firstImplementor.visitAttributes(
 					attribute -> {
 						if ( isACommonAttribute( subList, attribute ) ) {
-							// if isACommonAttribute - they all had it.  so put it in the workMap
-							//
-							// todo (6.0) : Atm We use the attribute from the first implementor directly for each implementor
-							//		need to handle this in QuerySplitter somehow
-
-							workMap.put( attribute.getName(), attribute );
+							// they all had it, so put it in the workMap
+							// todo (6.0) : ATM we use the attribute from the first implementor directly for
+							//              each implementor - need to handle this in QuerySplitter somehow
+							workMap.put( attribute.getName(), promote( attribute ) );
 						}
 					}
 			);
 		}
-		this.commonAttributes = Collections.unmodifiableMap( workMap );
+		return workMap;
+	}
+
+	/**
+	 * Here we pretend that an attribute belonging to all known subtypes
+	 * is an attribute of this type. The unchecked and unsound-looking
+	 * type cast is actually perfectly correct.
+	 */
+	@SuppressWarnings("unchecked")
+	private PersistentAttribute<? super T, ?> promote(PersistentAttribute<?, ?> attribute) {
+		return (PersistentAttribute<? super T, ?>) attribute;
 	}
 
 	private static boolean isACommonAttribute(List<EntityDomainType<?>> subList, PersistentAttribute<?, ?> attribute) {
@@ -159,12 +169,12 @@ public class SqmPolymorphicRootDescriptor<T> implements EntityDomainType<T> {
 	// Attribute handling
 
 	@Override
-	@SuppressWarnings("unchecked")
-	public PersistentAttribute findAttribute(String name) {
+	public PersistentAttribute<? super T, ?> findAttribute(String name) {
 		return commonAttributes.get( name );
 	}
 
-	public PersistentAttribute findSubTypesAttribute(String name) {
+	@Override
+	public PersistentAttribute<?, ?> findSubTypesAttribute(String name) {
 		return commonAttributes.get( name );
 	}
 
@@ -175,8 +185,8 @@ public class SqmPolymorphicRootDescriptor<T> implements EntityDomainType<T> {
 	}
 
 	@Override
-	public void visitAttributes(Consumer<? super PersistentAttribute<T, ?>> action) {
-		commonAttributes.values().forEach( (Consumer) action );
+	public void visitAttributes(Consumer<? super PersistentAttribute<? super T, ?>> action) {
+		commonAttributes.values().forEach( action );
 	}
 
 	@Override
@@ -200,13 +210,11 @@ public class SqmPolymorphicRootDescriptor<T> implements EntityDomainType<T> {
 
 	@Override
 	public SingularPersistentAttribute<? super T, ?> findSingularAttribute(String name) {
-		//noinspection unchecked
 		return (SingularPersistentAttribute<? super T, ?>) findAttribute( name );
 	}
 
 	@Override
 	public PluralPersistentAttribute<? super T, ?, ?> findPluralAttribute(String name) {
-		//noinspection unchecked
 		return (PluralPersistentAttribute<? super T, ?, ?>) findAttribute( name );
 	}
 
@@ -221,24 +229,23 @@ public class SqmPolymorphicRootDescriptor<T> implements EntityDomainType<T> {
 	}
 
 	@Override
-	public SingularPersistentAttribute<? super T, ?> findDeclaredSingularAttribute(String name) {
+	public SingularPersistentAttribute<T, ?> findDeclaredSingularAttribute(String name) {
 		return null;
 	}
 
 	@Override
-	public PluralPersistentAttribute<? super T, ?, ?> findDeclaredPluralAttribute(String name) {
+	public PluralPersistentAttribute<T, ?, ?> findDeclaredPluralAttribute(String name) {
 		return null;
 	}
 
 	@Override
-	public PersistentAttribute<? super T, ?> findDeclaredConcreteGenericAttribute(String name) {
+	public PersistentAttribute<T, ?> findDeclaredConcreteGenericAttribute(String name) {
 		return null;
 	}
 
 	@Override
 	public Set<Attribute<? super T, ?>> getAttributes() {
-		//noinspection unchecked
-		return (Set<Attribute<? super T, ?>>) commonAttributes;
+		return new HashSet<>( commonAttributes.values() );
 	}
 
 	@Override
@@ -260,10 +267,13 @@ public class SqmPolymorphicRootDescriptor<T> implements EntityDomainType<T> {
 
 	@Override
 	public Set<SingularAttribute<? super T, ?>> getSingularAttributes() {
-		//noinspection unchecked
-		return (Set) commonAttributes.values().stream()
-				.filter( attribute -> attribute instanceof SingularAttribute )
-				.collect( Collectors.toSet() );
+		final Set<SingularAttribute<? super T, ?>> singularAttributes = new HashSet<>();
+		for ( PersistentAttribute<? super T, ?> attribute : commonAttributes.values() ) {
+			if ( attribute instanceof SingularAttribute ) {
+				singularAttributes.add( (SingularPersistentAttribute<? super T, ?>) attribute );
+			}
+		}
+		return singularAttributes;
 	}
 
 	@Override
@@ -317,10 +327,13 @@ public class SqmPolymorphicRootDescriptor<T> implements EntityDomainType<T> {
 
 	@Override
 	public Set<PluralAttribute<? super T, ?, ?>> getPluralAttributes() {
-		//noinspection unchecked
-		return (Set) commonAttributes.values().stream()
-				.filter( attribute -> attribute instanceof PluralAttribute )
-				.collect( Collectors.toSet() );
+		final Set<PluralAttribute<? super T, ?, ?>> pluralAttributes = new HashSet<>();
+		for ( PersistentAttribute<? super T, ?> attribute : commonAttributes.values() ) {
+			if ( attribute instanceof PluralAttribute ) {
+				pluralAttributes.add( (PluralPersistentAttribute<? super T, ?, ?>) attribute );
+			}
+		}
+		return pluralAttributes;
 	}
 
 	@Override
@@ -330,8 +343,7 @@ public class SqmPolymorphicRootDescriptor<T> implements EntityDomainType<T> {
 
 	@Override
 	public SingularAttribute<? super T, ?> getSingularAttribute(String name) {
-		//noinspection unchecked
-		return (SingularAttribute<? super T, ?>) getAttribute( name );
+		return (SingularPersistentAttribute<? super T, ?>) getAttribute( name );
 	}
 
 	@Override
@@ -403,28 +415,6 @@ public class SqmPolymorphicRootDescriptor<T> implements EntityDomainType<T> {
 	}
 
 	@Override
-	public SubGraphImplementor<T> makeSubGraph() {
-		throw new UnsupportedOperationException(  );
-	}
-
-	@Override
-	public <S extends T> SubGraphImplementor<S> makeSubGraph(Class<S> subType) {
-		throw new UnsupportedOperationException(  );
-	}
-
-	@Override
-	public <S extends T> ManagedDomainType<S> findSubType(String subTypeName) {
-		// technically we could support this
-		throw new UnsupportedOperationException(  );
-	}
-
-	@Override
-	public <S extends T> ManagedDomainType<S> findSubType(Class<S> type) {
-		// technically we could support this
-		throw new UnsupportedOperationException(  );
-	}
-
-	@Override
 	public SqmPathSource<?> getIdentifierDescriptor() {
 		return null;
 	}
@@ -470,7 +460,7 @@ public class SqmPolymorphicRootDescriptor<T> implements EntityDomainType<T> {
 	}
 
 	@Override
-	public SingularPersistentAttribute<T, ?> findIdAttribute() {
+	public SingularPersistentAttribute<? super T, ?> findIdAttribute() {
 		throw new UnsupportedOperationException(  );
 	}
 
@@ -509,7 +499,7 @@ public class SqmPolymorphicRootDescriptor<T> implements EntityDomainType<T> {
 	}
 
 	@Override
-	public void addSubType(ManagedDomainType subType) {
+	public void addSubType(ManagedDomainType<? extends T> subType) {
 		throw new UnsupportedOperationException(  );
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/domain/SqmPolymorphicRootDescriptor.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/domain/SqmPolymorphicRootDescriptor.java
@@ -136,7 +136,7 @@ public class SqmPolymorphicRootDescriptor<T> implements EntityDomainType<T> {
 	}
 
 	@Override
-	public DomainType<?> getSqmPathType() {
+	public DomainType<T> getSqmPathType() {
 		return this;
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/spi/EntityIdentifierNavigablePath.java
+++ b/hibernate-core/src/main/java/org/hibernate/spi/EntityIdentifierNavigablePath.java
@@ -20,12 +20,12 @@ public class EntityIdentifierNavigablePath extends NavigablePath {
 	private final String identifierAttributeName;
 
 	public EntityIdentifierNavigablePath(NavigablePath parent, String identifierAttributeName) {
-		super( parent, EntityIdentifierMapping.ROLE_LOCAL_NAME );
+		super( parent, EntityIdentifierMapping.ID_ROLE_NAME );
 		this.identifierAttributeName = identifierAttributeName;
 	}
 
 	public EntityIdentifierNavigablePath(NavigablePath parent, String alias, String identifierAttributeName) {
-		super( parent, EntityIdentifierMapping.ROLE_LOCAL_NAME, alias );
+		super( parent, EntityIdentifierMapping.ID_ROLE_NAME, alias );
 		this.identifierAttributeName = identifierAttributeName;
 	}
 
@@ -35,7 +35,7 @@ public class EntityIdentifierNavigablePath extends NavigablePath {
 
 	@Override
 	public String getLocalName() {
-		return EntityIdentifierMapping.ROLE_LOCAL_NAME;
+		return EntityIdentifierMapping.ID_ROLE_NAME;
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/spi/NavigablePath.java
+++ b/hibernate-core/src/main/java/org/hibernate/spi/NavigablePath.java
@@ -160,7 +160,7 @@ public class NavigablePath implements DotIdentifierSequence, Serializable {
 
 	protected boolean localNamesMatch(EntityIdentifierNavigablePath other) {
 		return Objects.equals( getLocalName(), other.getLocalName() )
-				|| Objects.equals( getLocalName(), other.getIdentifierAttributeName() );
+			|| Objects.equals( getLocalName(), other.getIdentifierAttributeName() );
 	}
 
 	public NavigablePath append(String property) {

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/DomainResultCreationState.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/DomainResultCreationState.java
@@ -6,17 +6,12 @@
  */
 package org.hibernate.sql.results.graph;
 
-import java.util.List;
-
 import org.hibernate.Incubating;
 import org.hibernate.engine.FetchTiming;
 import org.hibernate.metamodel.mapping.AssociationKey;
-import org.hibernate.metamodel.mapping.EmbeddableValuedModelPart;
-import org.hibernate.metamodel.mapping.EntityAssociationMapping;
 import org.hibernate.metamodel.mapping.EntityDiscriminatorMapping;
 import org.hibernate.metamodel.mapping.EntityIdentifierMapping;
 import org.hibernate.metamodel.mapping.EntityMappingType;
-import org.hibernate.metamodel.mapping.EntityValuedModelPart;
 import org.hibernate.metamodel.mapping.ForeignKeyDescriptor;
 import org.hibernate.metamodel.mapping.ModelPart;
 import org.hibernate.spi.EntityIdentifierNavigablePath;
@@ -110,7 +105,7 @@ public interface DomainResultCreationState {
 		if ( discriminatorMapping != null && entityDescriptor.hasSubclasses() ) {
 			return discriminatorMapping.generateFetch(
 					fetchParent,
-					fetchParent.getNavigablePath().append( EntityDiscriminatorMapping.ROLE_NAME ),
+					fetchParent.getNavigablePath().append( EntityDiscriminatorMapping.DISCRIMINATOR_ROLE_NAME ),
 					FetchTiming.IMMEDIATE,
 					true,
 					null,

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/embeddable/AbstractEmbeddableInitializer.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/embeddable/AbstractEmbeddableInitializer.java
@@ -91,7 +91,7 @@ public abstract class AbstractEmbeddableInitializer extends AbstractFetchParentA
 	private static boolean isPartOfKey(NavigableRole navigableRole) {
 		final NavigableRole parent = navigableRole.getParent();
 		return parent != null
-				&& ( parent.getLocalName().equals( EntityIdentifierMapping.ROLE_LOCAL_NAME ) || isPartOfKey( parent ) );
+				&& ( parent.getLocalName().equals( EntityIdentifierMapping.ID_ROLE_NAME ) || isPartOfKey( parent ) );
 	}
 
 	protected DomainResultAssembler<?>[] createAssemblers(

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/entity/EntityResultGraphNode.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/entity/EntityResultGraphNode.java
@@ -6,6 +6,7 @@
  */
 package org.hibernate.sql.results.graph.entity;
 
+import org.hibernate.graph.spi.GraphHelper;
 import org.hibernate.graph.spi.GraphImplementor;
 import org.hibernate.metamodel.mapping.EntityMappingType;
 import org.hibernate.metamodel.model.domain.JpaMetamodel;
@@ -43,9 +44,7 @@ public interface EntityResultGraphNode extends DomainResultGraphNode, FetchParen
 
 	@Override
 	default boolean appliesTo(GraphImplementor<?> graphImplementor, JpaMetamodel metamodel) {
-		return graphImplementor.appliesTo(
-				getEntityValuedModelPart().getEntityMappingType().getJavaType().getJavaTypeClass(),
-				metamodel
-		);
+		final String entityName = getEntityValuedModelPart().getEntityMappingType().getEntityName();
+		return GraphHelper.appliesTo( graphImplementor, metamodel.entity( entityName ) );
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/entity/internal/EntityDelayedResultImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/entity/internal/EntityDelayedResultImpl.java
@@ -8,7 +8,6 @@ package org.hibernate.sql.results.graph.entity.internal;
 
 import org.hibernate.metamodel.mapping.EntityAssociationMapping;
 import org.hibernate.metamodel.mapping.EntityIdentifierMapping;
-import org.hibernate.metamodel.mapping.ForeignKeyDescriptor;
 import org.hibernate.metamodel.mapping.internal.ToOneAttributeMapping;
 import org.hibernate.spi.NavigablePath;
 import org.hibernate.sql.ast.tree.from.TableGroup;
@@ -39,7 +38,7 @@ public class EntityDelayedResultImpl implements DomainResult {
 		this.navigablePath = navigablePath;
 		this.entityValuedModelPart = entityValuedModelPart;
 		this.identifierResult = entityValuedModelPart.getForeignKeyDescriptor().createKeyDomainResult(
-				navigablePath.append( EntityIdentifierMapping.ROLE_LOCAL_NAME ),
+				navigablePath.append( EntityIdentifierMapping.ID_ROLE_NAME ),
 				targetTableGroup,
 				entityValuedModelPart.getSideNature(),
 				null,

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/bootstrap/binding/hbm/simple/dynamic/SimpleDynamicHbmTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/bootstrap/binding/hbm/simple/dynamic/SimpleDynamicHbmTests.java
@@ -47,7 +47,7 @@ public class SimpleDynamicHbmTests {
 			assertThat( identifierMapping, instanceOf( BasicEntityIdentifierMapping.class ) );
 			final BasicEntityIdentifierMapping bid = (BasicEntityIdentifierMapping) identifierMapping;
 			assertThat( bid.getFetchableName(), is( "id" ) );
-			assertThat( bid.getPartName(), is( EntityIdentifierMapping.ROLE_LOCAL_NAME ) );
+			assertThat( bid.getPartName(), is( EntityIdentifierMapping.ID_ROLE_NAME ) );
 
 			assertThat( entityDescriptor.getNumberOfAttributeMappings(), is( 1 ) );
 			assertThat( entityDescriptor.getNumberOfDeclaredAttributeMappings(), is( 1 ) );

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/bootstrap/binding/hbm/simple/pojo/SimpleHbmTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/bootstrap/binding/hbm/simple/pojo/SimpleHbmTests.java
@@ -42,7 +42,7 @@ public class SimpleHbmTests {
 		assertThat( identifierMapping, instanceOf( BasicEntityIdentifierMapping.class ) );
 		final BasicEntityIdentifierMapping bid = (BasicEntityIdentifierMapping) identifierMapping;
 		assertThat( bid.getFetchableName(), is( "id" ) );
-		assertThat( bid.getPartName(), is( EntityIdentifierMapping.ROLE_LOCAL_NAME ) );
+		assertThat( bid.getPartName(), is( EntityIdentifierMapping.ID_ROLE_NAME ) );
 
 		assertThat( entityDescriptor.getNumberOfAttributeMappings(), is( 1 ) );
 		assertThat( entityDescriptor.getNumberOfDeclaredAttributeMappings(), is( 1 ) );

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/graph/EntityGraphsTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/graph/EntityGraphsTest.java
@@ -12,6 +12,7 @@ import jakarta.persistence.EntityManager;
 import org.hibernate.graph.EntityGraphs;
 import org.hibernate.graph.spi.RootGraphImplementor;
 
+import org.hibernate.metamodel.model.domain.EntityDomainType;
 import org.hibernate.testing.TestForIssue;
 import org.junit.Assert;
 import org.junit.Ignore;
@@ -198,6 +199,7 @@ public class EntityGraphsTest extends AbstractEntityGraphTest {
 	@TestForIssue( jiraKey = "HHH-14264" )
 	public void testRootGraphAppliesToChildEntityClass() {
 		RootGraphImplementor<GraphParsingTestEntity> rootGraphImplementor = parseGraph( GraphParsingTestEntity.class, "name, description" );
-		Assert.assertTrue( rootGraphImplementor.appliesTo( GraphParsingTestSubentity.class, entityManagerFactory().getJpaMetamodel() ) );
+		EntityDomainType<?> entity = entityManagerFactory().getJpaMetamodel().entity( (Class<?>) GraphParsingTestSubentity.class );
+		Assert.assertTrue( rootGraphImplementor.appliesTo( entity ) );
 	}
 }

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/query/hql/AttributePathTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/query/hql/AttributePathTests.java
@@ -111,7 +111,7 @@ public class AttributePathTests extends BaseSqmUnitTest {
 		final EntityDomainType<OddOne> entity = sessionFactory().getRuntimeMetamodels()
 				.getJpaMetamodel()
 				.entity( OddOne.class );
-		final SingularPersistentAttribute<OddOne, ?> idAttribute = entity.findIdAttribute();
+		final SingularPersistentAttribute<? super OddOne, ?> idAttribute = entity.findIdAttribute();
 
 		final SqmSelectStatement<?> sqmSelectStatement = interpretSelect( "select s.id from OddOne s where s.pk = ?1" );
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/spi/path/NavigablePathTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/spi/path/NavigablePathTests.java
@@ -103,12 +103,12 @@ public class NavigablePathTests {
 		final String aliasedRootStr = "org.hibernate.Root(r)";
 
 		final String pkStr = "pk";
-		final String pkFullPathStr = aliasedRootStr + "." + EntityIdentifierMapping.ROLE_LOCAL_NAME;
+		final String pkFullPathStr = aliasedRootStr + "." + EntityIdentifierMapping.ID_ROLE_NAME;
 
 		final NavigablePath root = new NavigablePath( rootStr, "r" );
 
 		final NavigablePath idPath = new EntityIdentifierNavigablePath( root, pkStr );
-		assertThat( idPath.getLocalName() ).isEqualTo( EntityIdentifierMapping.ROLE_LOCAL_NAME );
+		assertThat( idPath.getLocalName() ).isEqualTo( EntityIdentifierMapping.ID_ROLE_NAME );
 		assertThat( idPath.getFullPath() ).isEqualTo( pkFullPathStr );
 	}
 }


### PR DESCRIPTION
...and reduce coupling to JpaMetamodel. This is useful for tools like Query Validator which need to instantiate these metamodel objects in a "mocked" environment. It will also make it possible for the Metamodel Generator to generate static references to these metamodel objects.