### PR TITLE
Fix build cache misses on JavaCompile tasks when project is relocated

### DIFF
--- a/gradle/java-module.gradle
+++ b/gradle/java-module.gradle
@@ -518,14 +518,33 @@ task nonFatalCheckstyle(type:Checkstyle) {
 	configFile = rootProject.file( 'shared/config/checkstyle/checkstyle-non-fatal.xml' )
 }
 
+class CompilerStubsArgumentProvider implements CommandLineArgumentProvider {
+
+    @InputDirectory
+    @PathSensitive(PathSensitivity.NONE)
+    File stubsDir
+
+    @Override
+    Iterable<String> asArguments() {
+        { return ["-Astubs=${stubsDir}"]}
+    }
+}
+
+tasks.withType(JavaCompile).configureEach { task ->
+    // stubs argument needs to be passed as an absolute path, JavaCompile uses the Worker API which changes the current
+    // working directory and prevents from using a relative path to locate a project file.
+    // Using a CommandLineArgumentProvider allows build cache hits when the build cache is relocated.
+    task.options.compilerArgumentProviders.add(new CompilerStubsArgumentProvider(stubsDir: new File(project.rootDir, "checkerstubs")))
+}
+
 checkerFramework {
 	checkers = [
 			'org.checkerframework.checker.nullness.NullnessChecker'
 	]
 	extraJavacArgs = [
-	        '-AsuppressWarnings=initialization',
-			"-Astubs=${project.rootDir}/checkerstubs",
-			'-AonlyDefs=^org\\.hibernate\\.(jpamodelgen|spi|pretty|stat|engine\\.(profile|transaction)|(action|context|bytecode)\\.spi)\\.'
+            '-AsuppressWarnings=initialization',
+            // stubs is passed directly through options.compilerArgumentProviders
+            '-AonlyDefs=^org\\.hibernate\\.(jpamodelgen|spi|pretty|stat|engine\\.(profile|transaction)|(action|context|bytecode)\\.spi)\\.'
 	]
 }
 


### PR DESCRIPTION
### Issue
See JIRA [HHH-16896](https://hibernate.atlassian.net/browse/HHH-16896)

The `JavaCompile` tasks [reference](https://github.com/hibernate/hibernate-orm/blob/39bc616cd97a505f0a8816a3422e09a009eac576/gradle/java-module.gradle#L527) the `stubs` argument (through the [check-framework-gradle-plugin](https://github.com/kelloggm/checkerframework-gradle-plugin)) plugin which is defined as an absolute path to the `checkerstubs` folder.
When the project folder is different (CI vs local build for instance), this absolute path is different which changes the build cache key of the task and prevents from getting a build cache hit.

See related issue https://github.com/kelloggm/checkerframework-gradle-plugin/issues/252

Experimenting locally, the impact is 5mn28s of CPU time (starting with an empty cache):
![Screenshot 2023-07-04 at 5 40 51 PM](https://github.com/hibernate/hibernate-orm/assets/10243934/cb9a0114-0ff8-48e9-90a3-045e47e1ced5)

### Fix
The stubs argument can't be passed as a relative path because the `JavaCompile` task is leveraging the [Worker API](https://docs.gradle.org/current/userguide/worker_api.html) which changes the current working directory.
The fix is to use a [CommandLineArgumentProvider](https://docs.gradle.org/current/javadoc/org/gradle/process/CommandLineArgumentProvider.html) which configures [PathSensitivity](https://docs.gradle.org/current/javadoc/org/gradle/api/tasks/PathSensitivity.html) not to be dependent on the path to the `checkerstubs` folder.


[HHH-16896]: https://hibernate.atlassian.net/browse/HHH-16896?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ