### PR TITLE
Backport HHH-16892 to branch 6.2 - LocalXmlResourceResolver does not resolve dtd URLs that use https scheme

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/boot/jaxb/internal/stax/LocalXmlResourceResolver.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/jaxb/internal/stax/LocalXmlResourceResolver.java
@@ -203,14 +203,14 @@ public class LocalXmlResourceResolver implements javax.xml.stream.XMLResolver {
 		public boolean matches(String publicId, String systemId) {
 			if ( publicId != null ) {
 				if ( publicId.startsWith( httpBase )
-						|| publicId.matches( httpsBase ) ) {
+						|| publicId.startsWith( httpsBase ) ) {
 					return true;
 				}
 			}
 
 			if ( systemId != null ) {
 				if ( systemId.startsWith( httpBase )
-						|| systemId.matches( httpsBase ) ) {
+						|| systemId.startsWith( httpsBase ) ) {
 					return true;
 				}
 			}

--- a/hibernate-core/src/test/java/org/hibernate/boot/jaxb/internal/stax/LocalXmlResourceResolverTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/boot/jaxb/internal/stax/LocalXmlResourceResolverTest.java
@@ -77,7 +77,10 @@ public class LocalXmlResourceResolverTest {
 			"https://hibernate.org/dtd/hibernate-configuration,org/hibernate/hibernate-configuration-3.0.dtd",
 
 			"http://hibernate.sourceforge.net/hibernate-configuration,org/hibernate/hibernate-configuration-3.0.dtd",
-			"https://hibernate.sourceforge.net/hibernate-configuration,org/hibernate/hibernate-configuration-3.0.dtd"
+			"https://hibernate.sourceforge.net/hibernate-configuration,org/hibernate/hibernate-configuration-3.0.dtd",
+
+			"http://hibernate.org/dtd/hibernate-mapping-3.0.dtd,org/hibernate/hibernate-mapping-3.0.dtd",
+			"https://hibernate.org/dtd/hibernate-mapping-3.0.dtd,org/hibernate/hibernate-mapping-3.0.dtd"
 	})
 	void resolve_dtd_localResource(String id, String expectedLocalResource) throws XMLStreamException {
 		// publicId


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-16892

Backport of #6939 to branch 6.2