### PR TITLE
HHH-16897 Delete query for entity using table-per-class inheritance may result in NullPointerException

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/mutation/internal/MultiTableSqmMutationConverter.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/mutation/internal/MultiTableSqmMutationConverter.java
@@ -27,6 +27,7 @@ import org.hibernate.query.sqm.tree.from.SqmRoot;
 import org.hibernate.query.sqm.tree.insert.SqmInsertStatement;
 import org.hibernate.query.sqm.tree.predicate.SqmWhereClause;
 import org.hibernate.query.sqm.tree.update.SqmSetClause;
+import org.hibernate.sql.ast.Clause;
 import org.hibernate.sql.ast.spi.SqlAstCreationContext;
 import org.hibernate.sql.ast.spi.SqlAstHelper;
 import org.hibernate.sql.ast.spi.SqlAstProcessingState;
@@ -214,12 +215,14 @@ public class MultiTableSqmMutationConverter extends BaseSqmToSqlAstConverter<Sta
 
 		pushProcessingState( restrictionProcessingState, getFromClauseIndex() );
 		try {
+			getCurrentClauseStack().push( Clause.WHERE );
 			return SqlAstHelper.combinePredicates(
 					(Predicate) sqmWhereClause.getPredicate().accept( this ),
 					discriminatorPredicate
 			);
 		}
 		finally {
+			getCurrentClauseStack().pop();
 			popProcessingStateStack();
 			this.parameterResolutionConsumer = null;
 		}


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-16897

Found this while was trying to clean up the workarounds for https://hibernate.atlassian.net/browse/HHH-14814 in Search.

Opening as a draft since its more of a reproducer (I'm not sure that the suggested fix is ok 😃)