### PR TITLE
Add more Jakarta libs to the platform

### DIFF
--- a/hibernate-platform/hibernate-platform.gradle
+++ b/hibernate-platform/hibernate-platform.gradle
@@ -50,6 +50,12 @@ dependencies {
         runtime jakartaLibs.jaxbApi
         runtime jakartaLibs.inject
 
+        runtime jakartaLibs.cdi
+        runtime jakartaLibs.validation
+        runtime jakartaLibs.jacc
+        runtime jakartaLibs.annotation
+        runtime jakartaLibs.jsonbApi
+        // jakartaLibs.interceptors -- for tests only
 
         // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         // todo : imo these are questionable


### PR DESCRIPTION
Hey hey 😃 ,

I am opening this as a draft to discuss the changes. We have used the `hibernate-platform` in Search to align some dependency versions (https://github.com/hibernate/hibernate-search/pull/3585).  We have CDI dependency that we are also aligning with ORM, but CDI is missing from the BOM. 

So the question is ... is it OK to add more of the Jakarta libs to the platform?

I have also looked at the suggestion @yrodiere had on that linked PR on using the Jakarta BOM, and there is one under:
```
<groupId>jakarta.platform</groupId>
<artifactId>jakarta.jakartaee-bom</artifactId>
```
but with my Gradle knowledge, I couldn't make it work together with the `versionCatalogs` where all the libs are defined 😞🤷🏻‍♂️ 

and pinging @sebersole since you are the author of this module 🙈😃 