### PR TITLE
HHH-16906 Duplicate column exception in Embeddable class

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/mapping/PersistentClass.java
+++ b/hibernate-core/src/main/java/org/hibernate/mapping/PersistentClass.java
@@ -25,6 +25,7 @@ import org.hibernate.engine.spi.ExecuteUpdateResultCheckStyle;
 import org.hibernate.engine.spi.Mapping;
 import org.hibernate.internal.FilterConfiguration;
 import org.hibernate.internal.util.StringHelper;
+import org.hibernate.internal.util.collections.ArrayHelper;
 import org.hibernate.internal.util.collections.JoinedIterator;
 import org.hibernate.internal.util.collections.JoinedList;
 import org.hibernate.internal.util.collections.SingletonIterator;
@@ -1003,7 +1004,8 @@ public abstract class PersistentClass implements AttributeContainer, Serializabl
 		for ( Selectable columnOrFormula : value.getSelectables() ) {
 			if ( !columnOrFormula.isFormula() ) {
 				Column col = (Column) columnOrFormula;
-				if (col.getValue().getColumnUpdateability()[0] || col.getValue().getColumnInsertability()[0]) {
+				if (!ArrayHelper.isAllFalse(col.getValue().getColumnUpdateability())
+						|| !ArrayHelper.isAllFalse(col.getValue().getColumnInsertability())) {
 					if (!distinctColumns.add(col.getName())) {
 						throw new MappingException(
 								"Column '" + col.getName()

--- a/hibernate-core/src/main/java/org/hibernate/mapping/PersistentClass.java
+++ b/hibernate-core/src/main/java/org/hibernate/mapping/PersistentClass.java
@@ -1003,12 +1003,14 @@ public abstract class PersistentClass implements AttributeContainer, Serializabl
 		for ( Selectable columnOrFormula : value.getSelectables() ) {
 			if ( !columnOrFormula.isFormula() ) {
 				Column col = (Column) columnOrFormula;
-				if ( !distinctColumns.add( col.getName() ) ) {
-					throw new MappingException(
-							"Column '" + col.getName()
-									+ "' is duplicated in mapping for entity '" + getEntityName()
-									+ "' (use '@Column(insertable=false, updatable=false)' when mapping multiple properties to the same column)"
-					);
+				if (col.getValue().getColumnUpdateability()[0] || col.getValue().getColumnInsertability()[0]) {
+					if (!distinctColumns.add(col.getName())) {
+						throw new MappingException(
+								"Column '" + col.getName()
+										+ "' is duplicated in mapping for entity '" + getEntityName()
+										+ "' (use '@Column(insertable=false, updatable=false)' when mapping multiple properties to the same column)"
+						);
+					}
 				}
 			}
 		}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/Participant.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/Participant.java
@@ -1,0 +1,24 @@
+package org.hibernate.orm.test.mapping;
+
+import jakarta.persistence.EmbeddedId;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+
+import java.io.Serializable;
+
+@Entity
+@Table(name = "PARTICIPANT")
+public class Participant implements Serializable {
+    private static final long serialVersionUID = 1L;
+
+    @EmbeddedId
+    private ParticipantId id;
+
+    public ParticipantId getId() {
+        return id;
+    }
+
+    public void setId(ParticipantId id) {
+        this.id = id;
+    }
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/ParticipantId.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/ParticipantId.java
@@ -1,0 +1,30 @@
+package org.hibernate.orm.test.mapping;
+
+import jakarta.persistence.AttributeOverride;
+import jakarta.persistence.AttributeOverrides;
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import jakarta.persistence.Embedded;
+
+import java.io.Serializable;
+
+@Embeddable
+public class ParticipantId implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    @Embedded
+    @AttributeOverrides({
+            @AttributeOverride( name = "registrationIndex", column = @Column(name = "REGISTRATION_INDEX")),
+            @AttributeOverride( name = "registrationDisplay", column = @Column(name = "REGISTRATION_INDEX", insertable=false, updatable=false)),
+    })
+    private ParticipantRegistration registrationNumber;
+
+    public ParticipantRegistration getRegistrationNumber() {
+        return registrationNumber;
+    }
+
+    public void setRegistrationNumber(ParticipantRegistration registrationNumber) {
+        this.registrationNumber = registrationNumber;
+    }
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/ParticipantRegistration.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/ParticipantRegistration.java
@@ -1,0 +1,31 @@
+package org.hibernate.orm.test.mapping;
+
+import jakarta.persistence.Embeddable;
+
+import java.io.Serializable;
+
+@Embeddable
+public class ParticipantRegistration implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private String registrationIndex;
+
+    private String registrationDisplay;
+
+    public String getRegistrationIndex() {
+        return registrationIndex;
+    }
+
+    public void setRegistrationIndex(String registrationIndex) {
+        this.registrationIndex = registrationIndex;
+    }
+
+    public String getRegistrationDisplay() {
+        return registrationDisplay;
+    }
+
+    public void setRegistrationDisplay(String registrationDisplay) {
+        this.registrationDisplay = registrationDisplay;
+    }
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/PersistentClassTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/PersistentClassTest.java
@@ -7,32 +7,39 @@
 package org.hibernate.orm.test.mapping;
 
 import org.hibernate.MappingException;
+import org.hibernate.boot.MetadataSources;
 import org.hibernate.boot.registry.StandardServiceRegistry;
 import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
 import org.hibernate.boot.spi.MetadataBuildingContext;
+import org.hibernate.boot.spi.MetadataImplementor;
 import org.hibernate.mapping.Property;
 import org.hibernate.mapping.RootClass;
-
 import org.hibernate.testing.boot.MetadataBuildingContextTestingImpl;
 import org.hibernate.testing.orm.junit.BaseUnitTest;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.fail;
+
 
 @BaseUnitTest
 public class PersistentClassTest {
 
 	private StandardServiceRegistry serviceRegistry;
 	private MetadataBuildingContext metadataBuildingContext;
+	private MetadataImplementor metadata;
 
 	@BeforeEach
 	public void prepare() {
 		serviceRegistry = new StandardServiceRegistryBuilder().build();
 		metadataBuildingContext = new MetadataBuildingContextTestingImpl( serviceRegistry );
+		metadata = (MetadataImplementor) new MetadataSources( serviceRegistry )
+				.addAnnotatedClass(Participant.class)
+				.getMetadataBuilder().build();
 	}
 
 	@AfterEach
@@ -77,4 +84,10 @@ public class PersistentClassTest {
 		}
 	}
 
+	@Test
+	public void testCheckColumnDuplication() {
+		RootClass pc = (RootClass) metadata.getEntityBinding( Participant.class.getName() );
+
+		assertDoesNotThrow( () -> pc.validate( metadata ) );
+	}
 }


### PR DESCRIPTION
When mapping multiple attributes in an Embeddable class to the same column, the Column insertable and updatable attributes are not considered, and a MappingException is raised stating that “Column X is duplicated in mapping for entity Y (use '@Column(insertable=false, updatable=false)' when mapping multiple properties to the same column)”. 

1. Updated checkColumnDuplication() in PersistentClass so that when checking if a column is mapped by multiple properties, an additional check is carried out to allow column duplication if the insertable and updatable attributes are both set to false.
2. Added test for the PersistentClass method validate() which internally calls checkColumnDuplication().
3. Added test entity class Participant, and two test embeddable classes ParticipantId and ParticipantRegistration to be used by the new test.
