### PR TITLE
HHH-16695, HHH-166914 add enableFetchProfile() to Query and XxxxLoadAccess

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/IdentifierLoadAccess.java
+++ b/hibernate-core/src/main/java/org/hibernate/IdentifierLoadAccess.java
@@ -104,6 +104,10 @@ public interface IdentifierLoadAccess<T> {
 	 */
 	IdentifierLoadAccess<T> with(RootGraph<T> graph, GraphSemantic semantic);
 
+	IdentifierLoadAccess<T> enableFetchProfile(String profileName);
+
+	IdentifierLoadAccess<T> disableFetchProfile(String profileName);
+
 	/**
 	 * Return the persistent instance with the given identifier, assuming
 	 * that the instance exists. This method might return a proxied instance

--- a/hibernate-core/src/main/java/org/hibernate/IdentifierLoadAccess.java
+++ b/hibernate-core/src/main/java/org/hibernate/IdentifierLoadAccess.java
@@ -104,8 +104,28 @@ public interface IdentifierLoadAccess<T> {
 	 */
 	IdentifierLoadAccess<T> with(RootGraph<T> graph, GraphSemantic semantic);
 
+	/**
+	 * Customize the associations fetched by specifying a
+	 * {@linkplain org.hibernate.annotations.FetchProfile fetch profile}
+	 * that should be enabled during this operation.
+	 * <p>
+	 * This allows the {@linkplain Session#isFetchProfileEnabled(String)
+	 * session-level fetch profiles} to be temporarily overridden.
+	 *
+	 * @since 6.3
+	 */
 	IdentifierLoadAccess<T> enableFetchProfile(String profileName);
 
+	/**
+	 * Customize the associations fetched by specifying a
+	 * {@linkplain org.hibernate.annotations.FetchProfile fetch profile}
+	 * that should be disabled during this operation.
+	 * <p>
+	 * This allows the {@linkplain Session#isFetchProfileEnabled(String)
+	 * session-level fetch profiles} to be temporarily overridden.
+	 *
+	 * @since 6.3
+	 */
 	IdentifierLoadAccess<T> disableFetchProfile(String profileName);
 
 	/**

--- a/hibernate-core/src/main/java/org/hibernate/NaturalIdLoadAccess.java
+++ b/hibernate-core/src/main/java/org/hibernate/NaturalIdLoadAccess.java
@@ -44,6 +44,10 @@ public interface NaturalIdLoadAccess<T> {
 	 */
 	NaturalIdLoadAccess<T> with(LockOptions lockOptions);
 
+	NaturalIdLoadAccess<T> enableFetchProfile(String profileName);
+
+	NaturalIdLoadAccess<T> disableFetchProfile(String profileName);
+
 	/**
 	 * Add a {@link org.hibernate.annotations.NaturalId @NaturalId}
 	 * attribute value in a typesafe way.

--- a/hibernate-core/src/main/java/org/hibernate/NaturalIdLoadAccess.java
+++ b/hibernate-core/src/main/java/org/hibernate/NaturalIdLoadAccess.java
@@ -7,6 +7,8 @@
 package org.hibernate;
 
 import jakarta.persistence.metamodel.SingularAttribute;
+import org.hibernate.graph.GraphSemantic;
+import org.hibernate.graph.RootGraph;
 
 import java.util.Map;
 import java.util.Optional;
@@ -43,6 +45,31 @@ public interface NaturalIdLoadAccess<T> {
 	 * @return {@code this}, for method chaining
 	 */
 	NaturalIdLoadAccess<T> with(LockOptions lockOptions);
+
+	/**
+	 * Override the associations fetched by default by specifying
+	 * the complete list of associations to be fetched as an
+	 * {@linkplain jakarta.persistence.EntityGraph entity graph}.
+	 */
+	default NaturalIdLoadAccess<T> withFetchGraph(RootGraph<T> graph) {
+		return with( graph, GraphSemantic.FETCH );
+	}
+
+	/**
+	 * Augment the associations fetched by default by specifying a
+	 * list of additional associations to be fetched as an
+	 * {@linkplain jakarta.persistence.EntityGraph entity graph}.
+	 */
+	default NaturalIdLoadAccess<T> withLoadGraph(RootGraph<T> graph) {
+		return with( graph, GraphSemantic.LOAD );
+	}
+
+	/**
+	 * Customize the associations fetched by specifying an
+	 * {@linkplain jakarta.persistence.EntityGraph entity graph},
+	 * and how it should be {@linkplain GraphSemantic interpreted}.
+	 */
+	NaturalIdLoadAccess<T> with(RootGraph<T> graph, GraphSemantic semantic);
 
 	/**
 	 * Customize the associations fetched by specifying a

--- a/hibernate-core/src/main/java/org/hibernate/NaturalIdLoadAccess.java
+++ b/hibernate-core/src/main/java/org/hibernate/NaturalIdLoadAccess.java
@@ -110,7 +110,7 @@ public interface NaturalIdLoadAccess<T> {
 	 * Determines if cached natural id cross-references are synchronized
 	 * before query execution with unflushed modifications made in memory
 	 * to {@linkplain org.hibernate.annotations.NaturalId#mutable mutable}
-	 * natural ids .
+	 * natural ids.
 	 * <p>
 	 * By default, every cached cross-reference is updated to reflect any
 	 * modification made in memory.

--- a/hibernate-core/src/main/java/org/hibernate/NaturalIdLoadAccess.java
+++ b/hibernate-core/src/main/java/org/hibernate/NaturalIdLoadAccess.java
@@ -44,8 +44,28 @@ public interface NaturalIdLoadAccess<T> {
 	 */
 	NaturalIdLoadAccess<T> with(LockOptions lockOptions);
 
+	/**
+	 * Customize the associations fetched by specifying a
+	 * {@linkplain org.hibernate.annotations.FetchProfile fetch profile}
+	 * that should be enabled during this operation.
+	 * <p>
+	 * This allows the {@linkplain Session#isFetchProfileEnabled(String)
+	 * session-level fetch profiles} to be temporarily overridden.
+	 *
+	 * @since 6.3
+	 */
 	NaturalIdLoadAccess<T> enableFetchProfile(String profileName);
 
+	/**
+	 * Customize the associations fetched by specifying a
+	 * {@linkplain org.hibernate.annotations.FetchProfile fetch profile}
+	 * that should be disabled during this operation.
+	 * <p>
+	 * This allows the {@linkplain Session#isFetchProfileEnabled(String)
+	 * session-level fetch profiles} to be temporarily overridden.
+	 *
+	 * @since 6.3
+	 */
 	NaturalIdLoadAccess<T> disableFetchProfile(String profileName);
 
 	/**

--- a/hibernate-core/src/main/java/org/hibernate/SimpleNaturalIdLoadAccess.java
+++ b/hibernate-core/src/main/java/org/hibernate/SimpleNaturalIdLoadAccess.java
@@ -6,6 +6,9 @@
  */
 package org.hibernate;
 
+import org.hibernate.graph.GraphSemantic;
+import org.hibernate.graph.RootGraph;
+
 import java.util.Optional;
 
 /**
@@ -36,6 +39,31 @@ public interface SimpleNaturalIdLoadAccess<T> {
 	 * @return {@code this}, for method chaining
 	 */
 	SimpleNaturalIdLoadAccess<T> with(LockOptions lockOptions);
+
+	/**
+	 * Override the associations fetched by default by specifying
+	 * the complete list of associations to be fetched as an
+	 * {@linkplain jakarta.persistence.EntityGraph entity graph}.
+	 */
+	default SimpleNaturalIdLoadAccess<T> withFetchGraph(RootGraph<T> graph) {
+		return with( graph, GraphSemantic.FETCH );
+	}
+
+	/**
+	 * Augment the associations fetched by default by specifying a
+	 * list of additional associations to be fetched as an
+	 * {@linkplain jakarta.persistence.EntityGraph entity graph}.
+	 */
+	default SimpleNaturalIdLoadAccess<T> withLoadGraph(RootGraph<T> graph) {
+		return with( graph, GraphSemantic.LOAD );
+	}
+
+	/**
+	 * Customize the associations fetched by specifying an
+	 * {@linkplain jakarta.persistence.EntityGraph entity graph},
+	 * and how it should be {@linkplain GraphSemantic interpreted}.
+	 */
+	SimpleNaturalIdLoadAccess<T> with(RootGraph<T> graph, GraphSemantic semantic);
 
 	/**
 	 * Customize the associations fetched by specifying a

--- a/hibernate-core/src/main/java/org/hibernate/SimpleNaturalIdLoadAccess.java
+++ b/hibernate-core/src/main/java/org/hibernate/SimpleNaturalIdLoadAccess.java
@@ -37,6 +37,10 @@ public interface SimpleNaturalIdLoadAccess<T> {
 	 */
 	SimpleNaturalIdLoadAccess<T> with(LockOptions lockOptions);
 
+	SimpleNaturalIdLoadAccess<T> enableFetchProfile(String profileName);
+
+	SimpleNaturalIdLoadAccess<T> disableFetchProfile(String profileName);
+
 	/**
 	 * For entities with mutable natural ids, should Hibernate perform
 	 * "synchronization" prior to performing lookups? The default is

--- a/hibernate-core/src/main/java/org/hibernate/SimpleNaturalIdLoadAccess.java
+++ b/hibernate-core/src/main/java/org/hibernate/SimpleNaturalIdLoadAccess.java
@@ -37,8 +37,28 @@ public interface SimpleNaturalIdLoadAccess<T> {
 	 */
 	SimpleNaturalIdLoadAccess<T> with(LockOptions lockOptions);
 
+	/**
+	 * Customize the associations fetched by specifying a
+	 * {@linkplain org.hibernate.annotations.FetchProfile fetch profile}
+	 * that should be enabled during this operation.
+	 * <p>
+	 * This allows the {@linkplain Session#isFetchProfileEnabled(String)
+	 * session-level fetch profiles} to be temporarily overridden.
+	 *
+	 * @since 6.3
+	 */
 	SimpleNaturalIdLoadAccess<T> enableFetchProfile(String profileName);
 
+	/**
+	 * Customize the associations fetched by specifying a
+	 * {@linkplain org.hibernate.annotations.FetchProfile fetch profile}
+	 * that should be disabled during this operation.
+	 * <p>
+	 * This allows the {@linkplain Session#isFetchProfileEnabled(String)
+	 * session-level fetch profiles} to be temporarily overridden.
+	 *
+	 * @since 6.3
+	 */
 	SimpleNaturalIdLoadAccess<T> disableFetchProfile(String profileName);
 
 	/**

--- a/hibernate-core/src/main/java/org/hibernate/annotations/processing/CheckHQL.java
+++ b/hibernate-core/src/main/java/org/hibernate/annotations/processing/CheckHQL.java
@@ -57,7 +57,24 @@ import static java.lang.annotation.RetentionPolicy.CLASS;
  * @see jakarta.persistence.EntityManager#createQuery(String,Class)
  * @see org.hibernate.Session#createSelectionQuery(String,Class)
  *
+ * @implNote The static HQL type checker is not aware of metadata defined
+ *           purely in XML, nor of JPA converters, and therefore sometimes
+ *           reports false positives. That is, it rejects queries at compile
+ *           time that would be accepted at runtime.
+ *           <p>
+ *           Therefore, by default, HQL specified in {@code NamedQuery}
+ *           annotations is always validated for both syntax and semantics,
+ *           but only illegal syntax is reported with severity
+ *           {@link javax.tools.Diagnostic.Kind#ERROR}. Problems with the
+ *           semantics of HQL named queries (typing problem) are reported to
+ *           the Java compiler by the Metamodel Generator with severity
+ *           {@link javax.tools.Diagnostic.Kind#WARNING}.
+ *           <p>
+ *           So, actually, the effect of {@code CheckHQL} is only to change
+ *           the severity of reported problem.
+ *
  * @author Gavin King
+ * @since 6.3
  */
 @Target({PACKAGE, TYPE})
 @Retention(CLASS)

--- a/hibernate-core/src/main/java/org/hibernate/annotations/processing/Find.java
+++ b/hibernate-core/src/main/java/org/hibernate/annotations/processing/Find.java
@@ -61,4 +61,6 @@ import static java.lang.annotation.RetentionPolicy.CLASS;
 @Target(METHOD)
 @Retention(CLASS)
 @Incubating
-public @interface Find {}
+public @interface Find {
+	String[] enabledFetchProfiles() default {};
+}

--- a/hibernate-core/src/main/java/org/hibernate/annotations/processing/Find.java
+++ b/hibernate-core/src/main/java/org/hibernate/annotations/processing/Find.java
@@ -16,10 +16,20 @@ import static java.lang.annotation.RetentionPolicy.CLASS;
 
 /**
  * Identifies a method of an abstract class or interface as defining
- * the signature of a finder method, and being generated automatically
- * by the Hibernate Metamodel Generator.
+ * the signature of a <em>finder method</em>, with an implementation
+ * generated automatically by the Hibernate Metamodel Generator.
  * <p>
- * For example:
+ * For example, suppose the entity {@code Book} is defined as follows:
+ * <pre>
+ * &#64;Entity
+ * class Book {
+ *     &#64;Id String isbn;
+ *     String title;
+ *     ...
+ * }
+ * </pre>
+ * <p>
+ * Then we might define:
  * <pre>
  * &#064;Find
  * Book getBookForIsbn(String isbn);
@@ -27,6 +37,55 @@ import static java.lang.annotation.RetentionPolicy.CLASS;
  * &#064;Find
  * List&lt;Book&gt; getBooksWithTitle(String title);
  * </pre>
+ * <p>
+ * Notice that:
+ * <ul>
+ * <li>the types and names of the method parameters exactly match the
+ *     types and names of the corresponding fields of the entity.
+ * <li>there's no special naming convention for the {@code @Find}
+ *     methods&mdash;they may be named arbitrarily, and their names
+ *     encode no semantics.
+ * </ul>
+ * <p>
+ * The Metamodel Generator automatically creates an "implementation"
+ * of every finder method in the static metamodel class {@code Books_}.
+ * The generated method may be called according to the following
+ * protocol:
+ * <pre>
+ * Book book = Books_.findBookByIsbn(session, isbn);
+ * List&lt;Book&gt; books = Books_.getBooksWithTitle(session, String title);
+ * </pre>
+ * <p>
+ * Notice the extra parameter of type {@code EntityManager} at the
+ * start of the parameter list.
+ * <p>
+ * Alternatively, the type to which the annotated method belongs may
+ * also declare an abstract method with no parameters which returns
+ * one of the types {@link jakarta.persistence.EntityManager},
+ * {@link org.hibernate.StatelessSession},
+ * or {@link org.hibernate.Session}, for example:
+ * <pre>
+ * EntityManager entityManager();
+ * </pre>
+ * In this case:
+ * <ul>
+ * <li>the generated method is no longer {@code static},
+ * <li>the generated method will use this method to obtain the
+ *     session object, instead of having a parameter of type
+ *     {@code EntityManager}, and
+ * <li>the generated static metamodel class will actually implement
+ *     the type which declares the method annotated {@code @SQL}.
+ * </ul>
+ * <p>
+ * Thus, the generated method may be called according to the following
+ * protocol:
+ * <pre>
+ * Books books = new Books_(session);
+ * Book book = books.getBookForIsbn(isbn);
+ * List&lt;Book&gt; books = books.getBooksWithTitle(String title);
+ * </pre>
+ * <p>
+ * This is reminiscent of traditional DAO-style repositories.
  * <p>
  * The return type of an annotated method must be an entity type {@code E},
  * or one of the following types:
@@ -47,13 +106,16 @@ import static java.lang.annotation.RetentionPolicy.CLASS;
  *     {@link jakarta.persistence.EntityManager#find(Class, Object)}
  *     to retrieve the entity.
  * <li>If the parameters match exactly with the {@code @NaturalId}
- *     fieldd of the entity, the finder method uses
+ *     field of the entity, the finder method uses
  *     {@link org.hibernate.Session#byNaturalId(Class)} to retrieve the
  *     entity.
  * <li>Otherwise, the finder method builds and executes a
  *     {@linkplain jakarta.persistence.criteria.CriteriaBuilder criteria
  *     query}.
  * </ul>
+ *
+ * @see HQL
+ * @see SQL
  *
  * @author Gavin King
  * @since 6.3

--- a/hibernate-core/src/main/java/org/hibernate/annotations/processing/HQL.java
+++ b/hibernate-core/src/main/java/org/hibernate/annotations/processing/HQL.java
@@ -17,8 +17,8 @@ import static java.lang.annotation.RetentionPolicy.CLASS;
 /**
  * Identifies a method of an abstract class or interface as defining
  * the signature of a method which is used to execute the given
- * {@linkplain #value HQL query}, and is generated automatically by
- * the Hibernate Metamodel Generator.
+ * {@linkplain #value HQL query}, with an implementation generated
+ * automatically by the Hibernate Metamodel Generator.
  * <p>
  * For example:
  * <pre>
@@ -36,10 +36,43 @@ import static java.lang.annotation.RetentionPolicy.CLASS;
  * <p>
  * The Metamodel Generator automatically creates an "implementation"
  * of these methods in the static metamodel class {@code Books_}.
+ * The generated methods may be called according to the following
+ * protocol:
  * <pre>
  * Book book = Books_.findBookByIsbn(session, isbn);
  * List&lt;Book&gt; books = Books_.findBooksByTitleWithPagination(session, pattern, 10, 0);
  * </pre>
+ * <p>
+ * Notice the extra parameter of type {@code EntityManager} at the
+ * start of the parameter list.
+ * <p>
+ * Alternatively, the type to which the annotated method belongs may
+ * also declare an abstract method with no parameters which returns
+ * one of the types {@link jakarta.persistence.EntityManager},
+ * {@link org.hibernate.StatelessSession},
+ * or {@link org.hibernate.Session}, for example:
+ * <pre>
+ * EntityManager entityManager();
+ * </pre>
+ * In this case:
+ * <ul>
+ * <li>the generated method is no longer {@code static},
+ * <li>the generated method will use this method to obtain the
+ *     session object, instead of having a parameter of type
+ *     {@code EntityManager}, and
+ * <li>the generated static metamodel class will actually implement
+ *     the type which declares the method annotated {@code @SQL}.
+ * </ul>
+ * <p>
+ * Thus, the generated methods may be called according to the following
+ * protocol:
+ * <pre>
+ * Books books = new Books_(session);
+ * Book book = books.findBookByIsbn(isbn);
+ * List&lt;Book&gt; books = books.findBooksByTitleWithPagination(pattern, 10, 0);
+ * </pre>
+ * <p>
+ * This is reminiscent of traditional DAO-style repositories.
  * <p>
  * The return type of an annotated method must be:
  * <ul>
@@ -72,6 +105,9 @@ import static java.lang.annotation.RetentionPolicy.CLASS;
  * Queries specified using this annotation are always validated by
  * the Metamodel Generator, and so it isn't necessary to specify the
  * {@link CheckHQL} annotation.
+ *
+ * @see SQL
+ * @see Find
  *
  * @author Gavin King
  * @since 6.3

--- a/hibernate-core/src/main/java/org/hibernate/annotations/processing/SQL.java
+++ b/hibernate-core/src/main/java/org/hibernate/annotations/processing/SQL.java
@@ -17,8 +17,8 @@ import static java.lang.annotation.RetentionPolicy.CLASS;
 /**
  * Identifies a method of an abstract class or interface as defining
  * the signature of a method which is used to execute the given
- * {@linkplain #value SQL query}, and is generated automatically by
- * the Hibernate Metamodel Generator.
+ * {@linkplain #value SQL query}, with an implementation generated
+ * automatically by the Hibernate Metamodel Generator.
  * <p>
  * For example:
  * <pre>
@@ -36,10 +36,43 @@ import static java.lang.annotation.RetentionPolicy.CLASS;
  * <p>
  * The Metamodel Generator automatically creates an "implementation"
  * of these methods in the static metamodel class {@code Books_}.
+ * The generated methods may be called according to the following
+ * protocol:
  * <pre>
  * Book book = Books_.findBookByIsbn(session, isbn);
  * List&lt;Book&gt; books = Books_.findBooksByTitleWithPagination(session, pattern, 10, 0);
  * </pre>
+ * <p>
+ * Notice the extra parameter of type {@code EntityManager} at the
+ * start of the parameter list.
+ * <p>
+ * Alternatively, the type to which the annotated method belongs may
+ * also declare an abstract method with no parameters which returns
+ * one of the types {@link jakarta.persistence.EntityManager},
+ * {@link org.hibernate.StatelessSession},
+ * or {@link org.hibernate.Session}, for example:
+ * <pre>
+ * EntityManager entityManager();
+ * </pre>
+ * In this case:
+ * <ul>
+ * <li>the generated method is no longer {@code static},
+ * <li>the generated method will use this method to obtain the
+ *     session object, instead of having a parameter of type
+ *     {@code EntityManager}, and
+ * <li>the generated static metamodel class will actually implement
+ *     the type which declares the method annotated {@code @SQL}.
+ * </ul>
+ * <p>
+ * Thus, the generated methods may be called according to the following
+ * protocol:
+ * <pre>
+ * Books books = new Books_(session);
+ * Book book = books.findBookByIsbn(isbn);
+ * List&lt;Book&gt; books = books.findBooksByTitleWithPagination(pattern, 10, 0);
+ * </pre>
+ * <p>
+ * This is reminiscent of traditional DAO-style repositories.
  * <p>
  * The return type of an annotated method must be:
  * <ul>
@@ -58,6 +91,9 @@ import static java.lang.annotation.RetentionPolicy.CLASS;
  * <li>a named query parameter of form {@code :name} is matched to
  *     the method parameter {@code name}.
  * </ul>
+ *
+ * @see HQL
+ * @see Find
  *
  * @author Gavin King
  * @since 6.3

--- a/hibernate-core/src/main/java/org/hibernate/engine/jdbc/mutation/internal/MutationQueryOptions.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/jdbc/mutation/internal/MutationQueryOptions.java
@@ -8,6 +8,7 @@ package org.hibernate.engine.jdbc.mutation.internal;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 
 import org.hibernate.FlushMode;
 import org.hibernate.LockOptions;
@@ -98,6 +99,16 @@ public class MutationQueryOptions implements QueryOptions {
 
 	@Override
 	public Integer getFetchSize() {
+		return null;
+	}
+
+	@Override
+	public Set<String> getEnabledFetchProfiles() {
+		return null;
+	}
+
+	@Override
+	public Set<String> getDisabledFetchProfiles() {
 		return null;
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/engine/spi/LoadQueryInfluencers.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/spi/LoadQueryInfluencers.java
@@ -264,10 +264,13 @@ public class LoadQueryInfluencers implements Serializable {
 	public HashSet<String> adjustFetchProfiles(Set<String> disabledFetchProfiles, Set<String> enabledFetchProfiles) {
 		final HashSet<String> oldFetchProfiles =
 				hasEnabledFetchProfiles() ? new HashSet<>( enabledFetchProfileNames ) : null;
-		if ( disabledFetchProfiles != null ) {
+		if ( disabledFetchProfiles != null && enabledFetchProfileNames != null ) {
 			enabledFetchProfileNames.removeAll( disabledFetchProfiles );
 		}
 		if ( enabledFetchProfiles != null ) {
+			if ( enabledFetchProfileNames == null ) {
+				enabledFetchProfileNames = new HashSet<>();
+			}
 			enabledFetchProfileNames.addAll( enabledFetchProfiles );
 		}
 		return oldFetchProfiles;

--- a/hibernate-core/src/main/java/org/hibernate/engine/spi/LoadQueryInfluencers.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/spi/LoadQueryInfluencers.java
@@ -261,6 +261,19 @@ public class LoadQueryInfluencers implements Serializable {
 	}
 
 	@Internal
+	public HashSet<String> adjustFetchProfiles(Set<String> disabledFetchProfiles, Set<String> enabledFetchProfiles) {
+		final HashSet<String> oldFetchProfiles =
+				hasEnabledFetchProfiles() ? new HashSet<>( enabledFetchProfileNames ) : null;
+		if ( disabledFetchProfiles != null ) {
+			enabledFetchProfileNames.removeAll( disabledFetchProfiles );
+		}
+		if ( enabledFetchProfiles != null ) {
+			enabledFetchProfileNames.addAll( enabledFetchProfiles );
+		}
+		return oldFetchProfiles;
+	}
+
+	@Internal
 	public void setEnabledFetchProfileNames(HashSet<String> enabledFetchProfileNames) {
 		this.enabledFetchProfileNames = enabledFetchProfileNames;
 	}

--- a/hibernate-core/src/main/java/org/hibernate/engine/spi/LoadQueryInfluencers.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/spi/LoadQueryInfluencers.java
@@ -19,6 +19,8 @@ import org.hibernate.Internal;
 import org.hibernate.UnknownProfileException;
 import org.hibernate.engine.profile.Fetch;
 import org.hibernate.engine.profile.FetchProfile;
+import org.hibernate.graph.GraphSemantic;
+import org.hibernate.graph.spi.RootGraphImplementor;
 import org.hibernate.internal.FilterImpl;
 import org.hibernate.internal.SessionCreationOptions;
 import org.hibernate.loader.ast.spi.CascadingFetchProfile;
@@ -81,6 +83,17 @@ public class LoadQueryInfluencers implements Serializable {
 		this.sessionFactory = sessionFactory;
 		batchSize = options.getDefaultBatchFetchSize();
 		subselectFetchEnabled = options.isSubselectFetchEnabled();
+	}
+
+	public EffectiveEntityGraph applyEntityGraph(RootGraphImplementor<?> rootGraph, GraphSemantic graphSemantic) {
+		final EffectiveEntityGraph effectiveEntityGraph = getEffectiveEntityGraph();
+		if ( graphSemantic != null ) {
+			if ( rootGraph == null ) {
+				throw new IllegalArgumentException( "Graph semantic specified, but no RootGraph was supplied" );
+			}
+			effectiveEntityGraph.applyGraph( rootGraph, graphSemantic );
+		}
+		return effectiveEntityGraph;
 	}
 
 	public SessionFactoryImplementor getSessionFactory() {

--- a/hibernate-core/src/main/java/org/hibernate/engine/spi/LoadQueryInfluencers.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/spi/LoadQueryInfluencers.java
@@ -11,11 +11,11 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Set;
 import java.util.function.Supplier;
 
 import org.hibernate.Filter;
+import org.hibernate.Internal;
 import org.hibernate.UnknownProfileException;
 import org.hibernate.engine.profile.Fetch;
 import org.hibernate.engine.profile.FetchProfile;
@@ -230,7 +230,7 @@ public class LoadQueryInfluencers implements Serializable {
 	}
 
 	public Set<String> getEnabledFetchProfileNames() {
-		return Objects.requireNonNullElse( enabledFetchProfileNames, emptySet() );
+		return enabledFetchProfileNames == null ? emptySet() : enabledFetchProfileNames;
 	}
 
 	private void checkFetchProfileName(String name) {
@@ -258,6 +258,11 @@ public class LoadQueryInfluencers implements Serializable {
 		if ( enabledFetchProfileNames != null ) {
 			enabledFetchProfileNames.remove( name );
 		}
+	}
+
+	@Internal
+	public void setEnabledFetchProfileNames(HashSet<String> enabledFetchProfileNames) {
+		this.enabledFetchProfileNames = enabledFetchProfileNames;
 	}
 
 	public EffectiveEntityGraph getEffectiveEntityGraph() {

--- a/hibernate-core/src/main/java/org/hibernate/internal/util/collections/ArrayHelper.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/util/collections/ArrayHelper.java
@@ -13,7 +13,6 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
-import java.util.Locale;
 import java.util.SortedSet;
 import java.util.TreeSet;
 import java.util.function.Consumer;

--- a/hibernate-core/src/main/java/org/hibernate/loader/ast/internal/LoaderSelectBuilder.java
+++ b/hibernate-core/src/main/java/org/hibernate/loader/ast/internal/LoaderSelectBuilder.java
@@ -282,6 +282,36 @@ public class LoaderSelectBuilder {
 		return process.generateSelect();
 	}
 
+	// TODO: this method is probably unnecessary if we make
+	// determineWhetherToForceIdSelection() a bit smarter
+	static SelectStatement createSelect(
+			Loadable loadable,
+			List<ModelPart> partsToSelect,
+			boolean forceIdentifierSelection,
+			List<ModelPart> restrictedParts,
+			DomainResult<?> cachedDomainResult,
+			int numberOfKeysToLoad,
+			LoadQueryInfluencers loadQueryInfluencers,
+			LockOptions lockOptions,
+			Consumer<JdbcParameter> jdbcParameterConsumer,
+			SessionFactoryImplementor sessionFactory) {
+		final LoaderSelectBuilder process = new LoaderSelectBuilder(
+				sessionFactory,
+				loadable,
+				partsToSelect,
+				restrictedParts,
+				cachedDomainResult,
+				numberOfKeysToLoad,
+				loadQueryInfluencers,
+				lockOptions,
+				determineGraphTraversalState( loadQueryInfluencers, sessionFactory ),
+				forceIdentifierSelection,
+				jdbcParameterConsumer
+		);
+
+		return process.generateSelect();
+	}
+
 	/**
 	 * Create an SQL AST select-statement used for subselect-based CollectionLoader
 	 *

--- a/hibernate-core/src/main/java/org/hibernate/loader/ast/internal/LoaderSqlAstCreationState.java
+++ b/hibernate-core/src/main/java/org/hibernate/loader/ast/internal/LoaderSqlAstCreationState.java
@@ -63,7 +63,7 @@ public class LoaderSqlAstCreationState
 
 	private boolean resolvingCircularFetch;
 	private ForeignKeyDescriptor.Nature currentlyResolvingForeignKeySide;
-	private Set<AssociationKey> visitedAssociationKeys = new HashSet<>();
+	private final Set<AssociationKey> visitedAssociationKeys = new HashSet<>();
 
 	public LoaderSqlAstCreationState(
 			QueryPart queryPart,
@@ -243,12 +243,12 @@ public class LoaderSqlAstCreationState
 	}
 
 	@Override
-	public TupleTransformer getTupleTransformer() {
+	public TupleTransformer<?> getTupleTransformer() {
 		return null;
 	}
 
 	@Override
-	public ResultListTransformer getResultListTransformer() {
+	public ResultListTransformer<?> getResultListTransformer() {
 		return null;
 	}
 
@@ -299,6 +299,16 @@ public class LoaderSqlAstCreationState
 
 	@Override
 	public Limit getLimit() {
+		return null;
+	}
+
+	@Override
+	public Set<String> getEnabledFetchProfiles() {
+		return null;
+	}
+
+	@Override
+	public Set<String> getDisabledFetchProfiles() {
 		return null;
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/loader/ast/internal/MultiIdEntityLoaderArrayParam.java
+++ b/hibernate-core/src/main/java/org/hibernate/loader/ast/internal/MultiIdEntityLoaderArrayParam.java
@@ -8,7 +8,6 @@ package org.hibernate.loader.ast.internal;
 
 import java.lang.reflect.Array;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 
 import org.hibernate.LockMode;

--- a/hibernate-core/src/main/java/org/hibernate/loader/ast/internal/SingleIdEntityLoaderStandardImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/loader/ast/internal/SingleIdEntityLoaderStandardImpl.java
@@ -37,13 +37,13 @@ public class SingleIdEntityLoaderStandardImpl<T> extends SingleIdEntityLoaderSup
 		// see org.hibernate.persister.entity.AbstractEntityPersister#createLoaders
 		// we should preload a few - maybe LockMode.NONE and LockMode.READ
 		final LockOptions lockOptions = LockOptions.NONE;
-		final LoadQueryInfluencers queryInfluencers = new LoadQueryInfluencers( sessionFactory );
+		final LoadQueryInfluencers influencers = new LoadQueryInfluencers( sessionFactory );
 		final SingleIdLoadPlan<T> plan = createLoadPlan(
 				lockOptions,
-				queryInfluencers,
+				influencers,
 				sessionFactory
 		);
-		if ( isLoadPlanReusable( lockOptions, queryInfluencers ) ) {
+		if ( isLoadPlanReusable( lockOptions, influencers ) ) {
 			selectByLockMode.put( lockOptions.getLockMode(), plan );
 		}
 	}
@@ -125,7 +125,7 @@ public class SingleIdEntityLoaderStandardImpl<T> extends SingleIdEntityLoaderSup
 			}
 		}
 		else {
-			return createLoadPlan(lockOptions, loadQueryInfluencers, sessionFactory);
+			return createLoadPlan( lockOptions, loadQueryInfluencers, sessionFactory );
 		}
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/loader/ast/internal/SingleIdLoadPlan.java
+++ b/hibernate-core/src/main/java/org/hibernate/loader/ast/internal/SingleIdLoadPlan.java
@@ -20,7 +20,6 @@ import org.hibernate.query.internal.SimpleQueryOptions;
 import org.hibernate.query.spi.QueryOptions;
 import org.hibernate.query.spi.QueryOptionsAdapter;
 import org.hibernate.sql.ast.SqlAstTranslatorFactory;
-import org.hibernate.sql.ast.tree.expression.JdbcParameter;
 import org.hibernate.sql.ast.tree.select.SelectStatement;
 import org.hibernate.sql.exec.internal.BaseExecutionContext;
 import org.hibernate.sql.exec.internal.CallbackImpl;
@@ -34,14 +33,14 @@ import org.hibernate.sql.results.spi.ListResultsConsumer;
 import org.hibernate.sql.results.spi.RowTransformer;
 
 /**
- * todo (6.0) : this can generically define a load-by-uk as well.  only the SQL AST and `restrictivePart` vary and they are passed as ctor args
- *
  * Describes a plan for loading an entity by identifier.
  *
  * @implNote Made up of (1) a SQL AST for the SQL SELECT and (2) the `ModelPart` used as the restriction
  *
  * @author Steve Ebersole
  */
+// todo (6.0) : this can generically define a load-by-uk as well.
+// only the SQL AST and `restrictivePart` vary and they are passed as constructor args
 public class SingleIdLoadPlan<T> implements SingleEntityLoadPlan {
 	private final EntityMappingType entityMappingType;
 	private final ModelPart restrictivePart;

--- a/hibernate-core/src/main/java/org/hibernate/loader/ast/internal/SingleUniqueKeyEntityLoaderStandard.java
+++ b/hibernate-core/src/main/java/org/hibernate/loader/ast/internal/SingleUniqueKeyEntityLoaderStandard.java
@@ -6,7 +6,6 @@
  */
 package org.hibernate.loader.ast.internal;
 
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
@@ -24,7 +23,6 @@ import org.hibernate.metamodel.mapping.SingularAttributeMapping;
 import org.hibernate.metamodel.mapping.internal.ToOneAttributeMapping;
 import org.hibernate.query.spi.QueryOptions;
 import org.hibernate.sql.ast.SqlAstTranslatorFactory;
-import org.hibernate.sql.ast.tree.expression.JdbcParameter;
 import org.hibernate.sql.ast.tree.select.SelectStatement;
 import org.hibernate.sql.exec.internal.BaseExecutionContext;
 import org.hibernate.sql.exec.internal.CallbackImpl;

--- a/hibernate-core/src/main/java/org/hibernate/loader/internal/BaseNaturalIdLoadAccessImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/loader/internal/BaseNaturalIdLoadAccessImpl.java
@@ -8,7 +8,6 @@ package org.hibernate.loader.internal;
 
 import java.util.Collection;
 import java.util.HashSet;
-import java.util.Map;
 import java.util.Set;
 
 import org.hibernate.HibernateException;
@@ -98,18 +97,18 @@ public abstract class BaseNaturalIdLoadAccessImpl<T> implements NaturalIdLoadOpt
 	protected void synchronizationEnabled(boolean synchronizationEnabled) {
 		this.synchronizationEnabled = synchronizationEnabled;
 	}
-
-	protected final Object resolveNaturalId(Map<String, Object> naturalIdParameters) {
-		performAnyNeededCrossReferenceSynchronizations();
-
-		final Object resolvedId = entityPersister()
-				.getNaturalIdLoader()
-				.resolveNaturalIdToId( naturalIdParameters, context.getSession() );
-
-		return resolvedId == INVALID_NATURAL_ID_REFERENCE
-				? null
-				: resolvedId;
-	}
+//
+//	protected final Object resolveNaturalId(Map<String, Object> naturalIdParameters) {
+//		performAnyNeededCrossReferenceSynchronizations();
+//
+//		final Object resolvedId = entityPersister()
+//				.getNaturalIdLoader()
+//				.resolveNaturalIdToId( naturalIdParameters, context.getSession() );
+//
+//		return resolvedId == INVALID_NATURAL_ID_REFERENCE
+//				? null
+//				: resolvedId;
+//	}
 
 	protected void performAnyNeededCrossReferenceSynchronizations() {
 		if ( !synchronizationEnabled ) {

--- a/hibernate-core/src/main/java/org/hibernate/loader/internal/BaseNaturalIdLoadAccessImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/loader/internal/BaseNaturalIdLoadAccessImpl.java
@@ -14,6 +14,7 @@ import java.util.Set;
 import org.hibernate.HibernateException;
 import org.hibernate.IdentifierLoadAccess;
 import org.hibernate.LockOptions;
+import org.hibernate.UnknownProfileException;
 import org.hibernate.engine.spi.EntityEntry;
 import org.hibernate.engine.spi.EntityKey;
 import org.hibernate.engine.spi.LoadQueryInfluencers;
@@ -61,6 +62,9 @@ public abstract class BaseNaturalIdLoadAccessImpl<T> implements NaturalIdLoadOpt
 	}
 
 	public Object enableFetchProfile(String profileName) {
+		if ( !context.getSession().getFactory().containsFetchProfileDefinition( profileName ) ) {
+			throw new UnknownProfileException( profileName );
+		}
 		if ( enabledFetchProfiles == null ) {
 			enabledFetchProfiles = new HashSet<>();
 		}

--- a/hibernate-core/src/main/java/org/hibernate/loader/internal/IdentifierLoadAccessImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/loader/internal/IdentifierLoadAccessImpl.java
@@ -6,7 +6,9 @@
  */
 package org.hibernate.loader.internal;
 
+import java.util.HashSet;
 import java.util.Optional;
+import java.util.Set;
 import java.util.function.Supplier;
 
 import org.hibernate.CacheMode;
@@ -17,6 +19,7 @@ import org.hibernate.bytecode.enhance.spi.interceptor.BytecodeLazyAttributeInter
 import org.hibernate.bytecode.enhance.spi.interceptor.EnhancementAsProxyLazinessInterceptor;
 import org.hibernate.bytecode.spi.BytecodeEnhancementMetadata;
 import org.hibernate.engine.spi.EffectiveEntityGraph;
+import org.hibernate.engine.spi.LoadQueryInfluencers;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.engine.spi.SessionImplementor;
 import org.hibernate.event.spi.EventSource;
@@ -46,6 +49,8 @@ public class IdentifierLoadAccessImpl<T> implements IdentifierLoadAccess<T>, Jav
 	private Boolean readOnly;
 	private RootGraphImplementor<T> rootGraph;
 	private GraphSemantic graphSemantic;
+	private Set<String> enabledFetchProfiles;
+	private Set<String> disabledFetchProfiles;
 
 	public IdentifierLoadAccessImpl(LoadAccessContext context, EntityPersister entityPersister) {
 		this.context = context;
@@ -97,6 +102,9 @@ public class IdentifierLoadAccessImpl<T> implements IdentifierLoadAccess<T>, Jav
 		}
 
 		try {
+			final LoadQueryInfluencers influencers = session.getLoadQueryInfluencers();
+			final HashSet<String> fetchProfiles =
+					influencers.adjustFetchProfiles( disabledFetchProfiles, enabledFetchProfiles );
 			final EffectiveEntityGraph effectiveEntityGraph =
 					session.getLoadQueryInfluencers().getEffectiveEntityGraph();
 			if ( graphSemantic != null ) {
@@ -113,6 +121,7 @@ public class IdentifierLoadAccessImpl<T> implements IdentifierLoadAccess<T>, Jav
 				if ( graphSemantic != null ) {
 					effectiveEntityGraph.clear();
 				}
+				influencers.setEnabledFetchProfileNames( fetchProfiles );
 			}
 		}
 		finally {
@@ -173,7 +182,7 @@ public class IdentifierLoadAccessImpl<T> implements IdentifierLoadAccess<T>, Jav
 			String entityName,
 			Boolean readOnly) {
 		if ( lockOptions != null ) {
-			final LoadEvent event = new LoadEvent(id, entityName, lockOptions, eventSource, readOnly);
+			final LoadEvent event = new LoadEvent( id, entityName, lockOptions, eventSource, readOnly );
 			context.fireLoad( event, LoadEventListener.LOAD );
 			return event.getResult();
 		}
@@ -266,5 +275,29 @@ public class IdentifierLoadAccessImpl<T> implements IdentifierLoadAccess<T>, Jav
 	@Override
 	public TypeConfiguration getTypeConfiguration() {
 		return context.getSession().getSessionFactory().getTypeConfiguration();
+	}
+
+	@Override
+	public IdentifierLoadAccess<T> enableFetchProfile(String profileName) {
+		if ( enabledFetchProfiles == null ) {
+			enabledFetchProfiles = new HashSet<>();
+		}
+		enabledFetchProfiles.add( profileName );
+		if ( disabledFetchProfiles != null ) {
+			disabledFetchProfiles.remove( profileName );
+		}
+		return this;
+	}
+
+	@Override
+	public IdentifierLoadAccess<T> disableFetchProfile(String profileName) {
+		if ( disabledFetchProfiles == null ) {
+			disabledFetchProfiles = new HashSet<>();
+		}
+		disabledFetchProfiles.add( profileName );
+		if ( enabledFetchProfiles != null ) {
+			enabledFetchProfiles.remove( profileName );
+		}
+		return this;
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/loader/internal/IdentifierLoadAccessImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/loader/internal/IdentifierLoadAccessImpl.java
@@ -15,6 +15,7 @@ import org.hibernate.CacheMode;
 import org.hibernate.IdentifierLoadAccess;
 import org.hibernate.LockOptions;
 import org.hibernate.ObjectNotFoundException;
+import org.hibernate.UnknownProfileException;
 import org.hibernate.bytecode.enhance.spi.interceptor.BytecodeLazyAttributeInterceptor;
 import org.hibernate.bytecode.enhance.spi.interceptor.EnhancementAsProxyLazinessInterceptor;
 import org.hibernate.bytecode.spi.BytecodeEnhancementMetadata;
@@ -279,6 +280,9 @@ public class IdentifierLoadAccessImpl<T> implements IdentifierLoadAccess<T>, Jav
 
 	@Override
 	public IdentifierLoadAccess<T> enableFetchProfile(String profileName) {
+		if ( !context.getSession().getFactory().containsFetchProfileDefinition( profileName ) ) {
+			throw new UnknownProfileException( profileName );
+		}
 		if ( enabledFetchProfiles == null ) {
 			enabledFetchProfiles = new HashSet<>();
 		}

--- a/hibernate-core/src/main/java/org/hibernate/loader/internal/IdentifierLoadAccessImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/loader/internal/IdentifierLoadAccessImpl.java
@@ -107,21 +107,12 @@ public class IdentifierLoadAccessImpl<T> implements IdentifierLoadAccess<T>, Jav
 			final HashSet<String> fetchProfiles =
 					influencers.adjustFetchProfiles( disabledFetchProfiles, enabledFetchProfiles );
 			final EffectiveEntityGraph effectiveEntityGraph =
-					session.getLoadQueryInfluencers().getEffectiveEntityGraph();
-			if ( graphSemantic != null ) {
-				if ( rootGraph == null ) {
-					throw new IllegalArgumentException( "Graph semantic specified, but no RootGraph was supplied" );
-				}
-				effectiveEntityGraph.applyGraph( rootGraph, graphSemantic );
-			}
-
+					session.getLoadQueryInfluencers().applyEntityGraph( rootGraph, graphSemantic);
 			try {
 				return executor.get();
 			}
 			finally {
-				if ( graphSemantic != null ) {
-					effectiveEntityGraph.clear();
-				}
+				effectiveEntityGraph.clear();
 				influencers.setEnabledFetchProfileNames( fetchProfiles );
 			}
 		}

--- a/hibernate-core/src/main/java/org/hibernate/loader/internal/NaturalIdLoadAccessImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/loader/internal/NaturalIdLoadAccessImpl.java
@@ -75,4 +75,16 @@ public class NaturalIdLoadAccessImpl<T> extends BaseNaturalIdLoadAccessImpl<T> i
 	public Optional<T> loadOptional() {
 		return Optional.ofNullable( load() );
 	}
+
+	@Override
+	public NaturalIdLoadAccess<T> enableFetchProfile(String profileName) {
+		super.enableFetchProfile( profileName );
+		return this;
+	}
+
+	@Override
+	public NaturalIdLoadAccess<T> disableFetchProfile(String profileName) {
+		super.enableFetchProfile( profileName );
+		return this;
+	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/loader/internal/NaturalIdLoadAccessImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/loader/internal/NaturalIdLoadAccessImpl.java
@@ -13,6 +13,8 @@ import java.util.Optional;
 import jakarta.persistence.metamodel.SingularAttribute;
 import org.hibernate.LockOptions;
 import org.hibernate.NaturalIdLoadAccess;
+import org.hibernate.graph.GraphSemantic;
+import org.hibernate.graph.RootGraph;
 import org.hibernate.internal.util.collections.CollectionHelper;
 import org.hibernate.metamodel.mapping.EntityMappingType;
 
@@ -74,6 +76,12 @@ public class NaturalIdLoadAccessImpl<T> extends BaseNaturalIdLoadAccessImpl<T> i
 	@Override
 	public Optional<T> loadOptional() {
 		return Optional.ofNullable( load() );
+	}
+
+	@Override
+	public NaturalIdLoadAccess<T> with(RootGraph<T> graph, GraphSemantic semantic) {
+		super.with( graph, semantic );
+		return this;
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/loader/internal/SimpleNaturalIdLoadAccessImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/loader/internal/SimpleNaturalIdLoadAccessImpl.java
@@ -108,4 +108,17 @@ public class SimpleNaturalIdLoadAccessImpl<T>
 	public Optional<T> loadOptional(Object naturalIdValue) {
 		return Optional.ofNullable( load( naturalIdValue ) );
 	}
+
+
+	@Override
+	public SimpleNaturalIdLoadAccess<T> enableFetchProfile(String profileName) {
+		super.enableFetchProfile( profileName );
+		return this;
+	}
+
+	@Override
+	public SimpleNaturalIdLoadAccess<T> disableFetchProfile(String profileName) {
+		super.enableFetchProfile( profileName );
+		return this;
+	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/loader/internal/SimpleNaturalIdLoadAccessImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/loader/internal/SimpleNaturalIdLoadAccessImpl.java
@@ -14,6 +14,8 @@ import java.util.Optional;
 import org.hibernate.HibernateException;
 import org.hibernate.LockOptions;
 import org.hibernate.SimpleNaturalIdLoadAccess;
+import org.hibernate.graph.GraphSemantic;
+import org.hibernate.graph.RootGraph;
 import org.hibernate.loader.LoaderLogging;
 import org.hibernate.metamodel.mapping.EntityMappingType;
 import org.hibernate.metamodel.mapping.internal.SimpleNaturalIdMapping;
@@ -109,6 +111,16 @@ public class SimpleNaturalIdLoadAccessImpl<T>
 		return Optional.ofNullable( load( naturalIdValue ) );
 	}
 
+	@Override
+	public SimpleNaturalIdLoadAccess<T> with(RootGraph<T> graph, GraphSemantic semantic) {
+		super.with( graph, semantic );
+		return this;
+	}
+
+	@Override
+	public SimpleNaturalIdLoadAccess<T> withLoadGraph(RootGraph<T> graph) {
+		return SimpleNaturalIdLoadAccess.super.withLoadGraph(graph);
+	}
 
 	@Override
 	public SimpleNaturalIdLoadAccess<T> enableFetchProfile(String profileName) {

--- a/hibernate-core/src/main/java/org/hibernate/query/Query.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/Query.java
@@ -15,6 +15,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Stream;
 
+import jakarta.persistence.EntityGraph;
 import org.hibernate.CacheMode;
 import org.hibernate.FlushMode;
 import org.hibernate.Incubating;
@@ -904,6 +905,15 @@ public interface Query<R> extends SelectionQuery<R>, MutationQuery, TypedQuery<R
 
 	@Override
 	Query<R> setHint(String hintName, Object value);
+
+	@Override
+	Query<R> setEntityGraph(EntityGraph<R> graph, GraphSemantic semantic);
+
+	@Override
+	Query<R> enableFetchProfile(String profileName);
+
+	@Override
+	Query<R> disableFetchProfile(String profileName);
 
 	@Override
 	Query<R> setFlushMode(FlushModeType flushMode);

--- a/hibernate-core/src/main/java/org/hibernate/query/SelectionQuery.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/SelectionQuery.java
@@ -29,6 +29,7 @@ import org.hibernate.ScrollMode;
 import org.hibernate.ScrollableResults;
 import org.hibernate.Session;
 import org.hibernate.SessionFactory;
+import org.hibernate.UnknownProfileException;
 import org.hibernate.dialect.Dialect;
 
 import jakarta.persistence.FlushModeType;
@@ -213,6 +214,37 @@ public interface SelectionQuery<R> extends CommonQueryContract {
 	 * @since 6.3
 	 */
 	SelectionQuery<R> setEntityGraph(EntityGraph<R> graph, GraphSemantic semantic);
+
+	/**
+	 * Enable the {@link org.hibernate.annotations.FetchProfile fetch profile}
+	 * for this query. If the requested fetch profile is already enabled,
+	 * the call has no effect.
+	 * <p>
+	 * This is an alternative way to specify the associations which
+	 * should be fetched as part of the initial query.
+	 *
+	 * @param profileName the name of the fetch profile to be enabled
+	 *
+	 * @throws UnknownProfileException Indicates that the given name does not
+	 *                                 match any known fetch profile names
+	 *
+	 * @see org.hibernate.annotations.FetchProfile
+	 */
+	SelectionQuery<R> enableFetchProfile(String profileName);
+
+	/**
+	 * Disable the {@link org.hibernate.annotations.FetchProfile fetch profile}
+	 * with the given name in this session. If the requested fetch profile
+	 * is not currently enabled, the call has no effect.
+	 *
+	 * @param profileName the name of the fetch profile to be disabled
+	 *
+	 * @throws UnknownProfileException Indicates that the given name does not
+	 *                                 match any known fetch profile names
+	 *
+	 * @see org.hibernate.annotations.FetchProfile
+	 */
+	SelectionQuery<R> disableFetchProfile(String profileName);
 
 	@Override
 	SelectionQuery<R> setFlushMode(FlushModeType flushMode);

--- a/hibernate-core/src/main/java/org/hibernate/query/hql/spi/SqmQueryImplementor.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/hql/spi/SqmQueryImplementor.java
@@ -66,16 +66,16 @@ public interface SqmQueryImplementor<R> extends QueryImplementor<R>, SqmQuery, N
 	SqmQueryImplementor<R> setReadOnly(boolean readOnly);
 
 	@Override
-	SqmQueryImplementor<R> applyGraph(RootGraph graph, GraphSemantic semantic);
+	SqmQueryImplementor<R> applyGraph(@SuppressWarnings("rawtypes") RootGraph graph, GraphSemantic semantic);
 
 	@Override
-	default SqmQueryImplementor<R> applyFetchGraph(RootGraph graph) {
+	default SqmQueryImplementor<R> applyFetchGraph(@SuppressWarnings("rawtypes") RootGraph graph) {
 		QueryImplementor.super.applyFetchGraph( graph );
 		return this;
 	}
 
 	@Override
-	default SqmQueryImplementor<R> applyLoadGraph(RootGraph graph) {
+	default SqmQueryImplementor<R> applyLoadGraph(@SuppressWarnings("rawtypes") RootGraph graph) {
 		QueryImplementor.super.applyLoadGraph( graph );
 		return this;
 	}
@@ -96,7 +96,7 @@ public interface SqmQueryImplementor<R> extends QueryImplementor<R>, SqmQuery, N
 	<T> SqmQueryImplementor<T> setTupleTransformer(TupleTransformer<T> transformer);
 
 	@Override
-	SqmQueryImplementor<R> setResultListTransformer(ResultListTransformer transformer);
+	SqmQueryImplementor<R> setResultListTransformer(ResultListTransformer<R> transformer);
 
 	@Override
 	@Deprecated(since = "5.2")
@@ -177,7 +177,7 @@ public interface SqmQueryImplementor<R> extends QueryImplementor<R>, SqmQuery, N
 	SqmQueryImplementor<R> setParameter(Parameter<Date> param, Date value, TemporalType temporalType);
 
 	@Override
-	SqmQueryImplementor<R> setParameterList(String name, Collection values);
+	SqmQueryImplementor<R> setParameterList(String name, @SuppressWarnings("rawtypes") Collection values);
 
 	@Override
 	<P> SqmQueryImplementor<R> setParameterList(String name, Collection<? extends P> values, Class<P> javaType);
@@ -234,5 +234,5 @@ public interface SqmQueryImplementor<R> extends QueryImplementor<R>, SqmQuery, N
 	SqmQueryImplementor<R> setProperties(Object bean);
 
 	@Override
-	SqmQueryImplementor<R> setProperties(Map bean);
+	SqmQueryImplementor<R> setProperties(@SuppressWarnings("rawtypes") Map bean);
 }

--- a/hibernate-core/src/main/java/org/hibernate/query/internal/QueryOptionsImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/internal/QueryOptionsImpl.java
@@ -8,7 +8,10 @@ package org.hibernate.query.internal;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
+
 import jakarta.persistence.CacheRetrieveMode;
 import jakarta.persistence.CacheStoreMode;
 
@@ -42,11 +45,13 @@ public class QueryOptionsImpl implements MutableQueryOptions, AppliedGraph {
 	private Boolean readOnlyEnabled;
 	private Boolean queryPlanCachingEnabled;
 
-	private TupleTransformer tupleTransformer;
-	private ResultListTransformer resultListTransformer;
+	private TupleTransformer<?> tupleTransformer;
+	private ResultListTransformer<?> resultListTransformer;
 
 	private RootGraphImplementor<?> rootGraph;
 	private GraphSemantic graphSemantic;
+	private Set<String> enabledFetchProfiles;
+	private Set<String> disabledFetchProfiles;
 
 	@Override
 	public Integer getTimeout() {
@@ -91,12 +96,12 @@ public class QueryOptionsImpl implements MutableQueryOptions, AppliedGraph {
 	}
 
 	@Override
-	public void setTupleTransformer(TupleTransformer transformer) {
+	public void setTupleTransformer(TupleTransformer<?> transformer) {
 		this.tupleTransformer = transformer;
 	}
 
 	@Override
-	public void setResultListTransformer(ResultListTransformer transformer) {
+	public void setResultListTransformer(ResultListTransformer<?> transformer) {
 		this.resultListTransformer = transformer;
 	}
 
@@ -165,12 +170,12 @@ public class QueryOptionsImpl implements MutableQueryOptions, AppliedGraph {
 	}
 
 	@Override
-	public TupleTransformer getTupleTransformer() {
+	public TupleTransformer<?> getTupleTransformer() {
 		return tupleTransformer;
 	}
 
 	@Override
-	public ResultListTransformer getResultListTransformer() {
+	public ResultListTransformer<?> getResultListTransformer() {
 		return resultListTransformer;
 	}
 
@@ -203,6 +208,38 @@ public class QueryOptionsImpl implements MutableQueryOptions, AppliedGraph {
 	public void applyGraph(RootGraphImplementor<?> rootGraph, GraphSemantic graphSemantic) {
 		this.rootGraph = rootGraph;
 		this.graphSemantic = graphSemantic;
+	}
+
+	@Override
+	public void enableFetchProfile(String profileName) {
+		if ( enabledFetchProfiles == null ) {
+			enabledFetchProfiles = new HashSet<>();
+		}
+		enabledFetchProfiles.add( profileName );
+		if ( disabledFetchProfiles != null ) {
+			disabledFetchProfiles.remove( profileName );
+		}
+	}
+
+	@Override
+	public void disableFetchProfile(String profileName) {
+		if ( disabledFetchProfiles == null ) {
+			disabledFetchProfiles = new HashSet<>();
+		}
+		disabledFetchProfiles.add( profileName );
+		if ( enabledFetchProfiles != null ) {
+			enabledFetchProfiles.remove( profileName );
+		}
+	}
+
+	@Override
+	public Set<String> getEnabledFetchProfiles() {
+		return enabledFetchProfiles;
+	}
+
+	@Override
+	public Set<String> getDisabledFetchProfiles() {
+		return disabledFetchProfiles;
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/query/spi/AbstractQuery.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/spi/AbstractQuery.java
@@ -11,6 +11,7 @@ import java.time.Instant;
 import java.util.Calendar;
 import java.util.Collection;
 import java.util.Date;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
@@ -631,7 +632,7 @@ public abstract class AbstractQuery<R>
 	@Override
 	public int executeUpdate() throws HibernateException {
 		getSession().checkTransactionNeededForUpdateOperation( "Executing an update/delete query" );
-		beforeQuery();
+		final HashSet<String> fetchProfiles = beforeQuery();
 		boolean success = false;
 		try {
 			final int result = doExecuteUpdate();
@@ -648,7 +649,7 @@ public abstract class AbstractQuery<R>
 			throw getSession().getExceptionConverter().convert( e );
 		}
 		finally {
-			afterQuery( success );
+			afterQuery( success, fetchProfiles );
 		}
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/query/spi/AbstractQuery.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/spi/AbstractQuery.java
@@ -16,6 +16,7 @@ import java.util.Set;
 
 import jakarta.persistence.CacheRetrieveMode;
 import jakarta.persistence.CacheStoreMode;
+import jakarta.persistence.EntityGraph;
 import jakarta.persistence.FlushModeType;
 import jakarta.persistence.LockModeType;
 import jakarta.persistence.Parameter;
@@ -28,6 +29,7 @@ import org.hibernate.LockMode;
 import org.hibernate.LockOptions;
 import org.hibernate.TypeMismatchException;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
+import org.hibernate.graph.GraphSemantic;
 import org.hibernate.internal.EntityManagerMessageLogger;
 import org.hibernate.internal.HEMLogging;
 import org.hibernate.jpa.AvailableHints;
@@ -37,6 +39,7 @@ import org.hibernate.query.BindableType;
 import org.hibernate.query.IllegalQueryOperationException;
 import org.hibernate.query.QueryParameter;
 import org.hibernate.query.ResultListTransformer;
+import org.hibernate.query.SelectionQuery;
 import org.hibernate.query.TupleTransformer;
 import org.hibernate.query.named.NamedQueryMemento;
 
@@ -118,6 +121,24 @@ public abstract class AbstractQuery<R>
 	@Override
 	public QueryImplementor<R> setHint(String hintName, Object value) {
 		super.setHint( hintName, value );
+		return this;
+	}
+
+	@Override
+	public QueryImplementor<R> setEntityGraph(EntityGraph<R> graph, GraphSemantic semantic) {
+		super.setEntityGraph( graph, semantic );
+		return this;
+	}
+
+	@Override
+	public QueryImplementor<R> enableFetchProfile(String profileName) {
+		super.enableFetchProfile( profileName );
+		return this;
+	}
+
+	@Override
+	public QueryImplementor<R> disableFetchProfile(String profileName) {
+		super.disableFetchProfile( profileName );
 		return this;
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/query/spi/AbstractSelectionQuery.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/spi/AbstractSelectionQuery.java
@@ -40,6 +40,7 @@ import org.hibernate.LockOptions;
 import org.hibernate.NonUniqueResultException;
 import org.hibernate.ScrollMode;
 import org.hibernate.TypeMismatchException;
+import org.hibernate.UnknownProfileException;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.graph.GraphSemantic;
@@ -649,6 +650,9 @@ public abstract class AbstractSelectionQuery<R>
 
 	@Override
 	public SelectionQuery<R> enableFetchProfile(String profileName) {
+		if ( !getSession().getFactory().containsFetchProfileDefinition( profileName ) ) {
+			throw new UnknownProfileException( profileName );
+		}
 		getQueryOptions().enableFetchProfile( profileName );
 		return this;
 	}

--- a/hibernate-core/src/main/java/org/hibernate/query/spi/DelegatingQueryOptions.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/spi/DelegatingQueryOptions.java
@@ -7,6 +7,8 @@
 package org.hibernate.query.spi;
 
 import java.util.List;
+import java.util.Set;
+
 import jakarta.persistence.CacheRetrieveMode;
 import jakarta.persistence.CacheStoreMode;
 
@@ -107,6 +109,16 @@ public class DelegatingQueryOptions implements QueryOptions {
 	@Override
 	public Integer getFetchSize() {
 		return queryOptions.getFetchSize();
+	}
+
+	@Override
+	public Set<String> getEnabledFetchProfiles() {
+		return queryOptions.getEnabledFetchProfiles();
+	}
+
+	@Override
+	public Set<String> getDisabledFetchProfiles() {
+		return queryOptions.getDisabledFetchProfiles();
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/query/spi/MutableQueryOptions.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/spi/MutableQueryOptions.java
@@ -89,9 +89,13 @@ public interface MutableQueryOptions extends QueryOptions {
 	 */
 	void addDatabaseHint(String hint);
 
-	void setTupleTransformer(TupleTransformer transformer);
+	void setTupleTransformer(TupleTransformer<?> transformer);
 
-	void setResultListTransformer(ResultListTransformer transformer);
+	void setResultListTransformer(ResultListTransformer<?> transformer);
 
 	void applyGraph(RootGraphImplementor<?> rootGraph, GraphSemantic graphSemantic);
+
+	void enableFetchProfile(String profileName);
+
+	void disableFetchProfile(String profileName);
 }

--- a/hibernate-core/src/main/java/org/hibernate/query/spi/QueryOptions.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/spi/QueryOptions.java
@@ -8,6 +8,8 @@ package org.hibernate.query.spi;
 
 import java.sql.Statement;
 import java.util.List;
+import java.util.Set;
+
 import jakarta.persistence.CacheRetrieveMode;
 import jakarta.persistence.CacheStoreMode;
 
@@ -104,6 +106,16 @@ public interface QueryOptions {
 	 */
 	Boolean getQueryPlanCachingEnabled();
 
+	/**
+	 * The explicitly enabled profiles for this query
+	 */
+	Set<String> getEnabledFetchProfiles();
+
+	/**
+	 * The explicitly disabled profiles for this query
+	 */
+	Set<String> getDisabledFetchProfiles();
+
 
 	// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 	// JDBC / SQL options
@@ -130,6 +142,7 @@ public interface QueryOptions {
 	 * @see Statement#getFetchSize
 	 */
 	Integer getFetchSize();
+
 	/**
 	 * The limit to the query results.  May also be accessed via
 	 * {@link #getFirstRow} and {@link #getMaxRows}

--- a/hibernate-core/src/main/java/org/hibernate/query/spi/QueryOptionsAdapter.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/spi/QueryOptionsAdapter.java
@@ -8,6 +8,8 @@ package org.hibernate.query.spi;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Set;
+
 import jakarta.persistence.CacheRetrieveMode;
 import jakarta.persistence.CacheStoreMode;
 
@@ -96,12 +98,22 @@ public abstract class QueryOptionsAdapter implements QueryOptions {
 	}
 
 	@Override
-	public TupleTransformer getTupleTransformer() {
+	public TupleTransformer<?> getTupleTransformer() {
 		return null;
 	}
 
 	@Override
-	public ResultListTransformer getResultListTransformer() {
+	public ResultListTransformer<?> getResultListTransformer() {
+		return null;
+	}
+
+	@Override
+	public Set<String> getEnabledFetchProfiles() {
+		return null;
+	}
+
+	@Override
+	public Set<String> getDisabledFetchProfiles() {
 		return null;
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/query/spi/SqlOmittingQueryOptions.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/spi/SqlOmittingQueryOptions.java
@@ -111,7 +111,7 @@ public class SqlOmittingQueryOptions extends DelegatingQueryOptions {
 
 	@Override
 	public boolean hasLimit() {
-		return omitLimit ? false : super.hasLimit();
+		return !omitLimit && super.hasLimit();
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/SqmExpressible.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/SqmExpressible.java
@@ -50,7 +50,7 @@ public interface SqmExpressible<J> extends BindableType<J> {
 	default String getTypeName() {
 		// default impl to handle the general case returning the Java type name
 		JavaType<J> expressibleJavaType = getExpressibleJavaType();
-		return expressibleJavaType == null ? "unknown" : expressibleJavaType.getJavaType().getTypeName();
+		return expressibleJavaType == null ? "unknown" : expressibleJavaType.getTypeName();
 	}
 
 	DomainType<J> getSqmType();

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/internal/QuerySqmImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/internal/QuerySqmImpl.java
@@ -14,6 +14,7 @@ import java.util.Calendar;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Supplier;
@@ -668,7 +669,7 @@ public class QuerySqmImpl<R>
 	public int executeUpdate() {
 		verifyUpdate();
 		getSession().checkTransactionNeededForUpdateOperation( "Executing an update/delete query" );
-		beforeQuery();
+		final HashSet<String> fetchProfiles = beforeQuery();
 		boolean success = false;
 		try {
 			final int result = doExecuteUpdate();
@@ -685,7 +686,7 @@ public class QuerySqmImpl<R>
 			throw getSession().getExceptionConverter().convert( e );
 		}
 		finally {
-			afterQuery( success );
+			afterQuery( success, fetchProfiles );
 		}
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/internal/QuerySqmImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/internal/QuerySqmImpl.java
@@ -18,6 +18,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.Supplier;
 
+import jakarta.persistence.EntityGraph;
 import org.hibernate.CacheMode;
 import org.hibernate.FlushMode;
 import org.hibernate.HibernateException;
@@ -871,11 +872,6 @@ public class QuerySqmImpl<R>
 	}
 
 	@Override
-	public LockOptions getLockOptions() {
-		return getQueryOptions().getLockOptions();
-	}
-
-	@Override
 	public SqmQueryImplementor<R> setLockOptions(LockOptions lockOptions) {
 		// No verifySelect call, because in Hibernate we support locking in subqueries
 		getQueryOptions().getLockOptions().overlay( lockOptions );
@@ -1017,6 +1013,24 @@ public class QuerySqmImpl<R>
 	@Override
 	public SqmQueryImplementor<R> setHint(String hintName, Object value) {
 		applyHint( hintName, value );
+		return this;
+	}
+
+	@Override
+	public Query<R> setEntityGraph(EntityGraph<R> graph, GraphSemantic semantic) {
+		super.setEntityGraph( graph, semantic );
+		return this;
+	}
+
+	@Override
+	public Query<R> enableFetchProfile(String profileName) {
+		super.enableFetchProfile( profileName );
+		return this;
+	}
+
+	@Override
+	public Query<R> disableFetchProfile(String profileName) {
+		super.disableFetchProfile( profileName );
 		return this;
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/sql/BaseSqmToSqlAstConverter.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/sql/BaseSqmToSqlAstConverter.java
@@ -7884,8 +7884,8 @@ public abstract class BaseSqmToSqlAstConverter<T extends Statement> extends Base
 //					if ( fetchTiming != FetchTiming.IMMEDIATE || fetchable.incrementFetchDepth() ) {
 						final String fetchableRole = fetchable.getNavigableRole().getFullPath();
 
-						for ( String enabledFetchProfileName : getLoadQueryInfluencers()
-								.getEnabledFetchProfileNames() ) {
+						for ( String enabledFetchProfileName :
+								getLoadQueryInfluencers().getEnabledFetchProfileNames() ) {
 							final FetchProfile enabledFetchProfile = getCreationContext()
 									.getSessionFactory()
 									.getFetchProfile( enabledFetchProfileName );

--- a/hibernate-core/src/main/java/org/hibernate/sql/exec/internal/JdbcSelectExecutorStandardImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/exec/internal/JdbcSelectExecutorStandardImpl.java
@@ -798,5 +798,14 @@ public class JdbcSelectExecutorStandardImpl implements JdbcSelectExecutor {
 			return context.getCallback();
 		}
 
+		@Override
+		public Set<String> getEnabledFetchProfiles() {
+			return null;
+		}
+
+		@Override
+		public Set<String> getDisabledFetchProfiles() {
+			return null;
+		}
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/sql/exec/spi/ExecutionContext.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/exec/spi/ExecutionContext.java
@@ -61,10 +61,6 @@ public interface ExecutionContext {
 	}
 
 	/**
-	 *
-	 * @param entityKey
-	 * @param entry
-	 *
 	 * @deprecated use {@link #registerSubselect(EntityKey, LoadingEntityEntry)} instead.
 	 */
 	@Deprecated
@@ -80,10 +76,10 @@ public interface ExecutionContext {
 	 * Hook to allow delaying calls to {@link LogicalConnectionImplementor#afterStatement()}.
 	 * Mainly used in the case of batching and multi-table mutations
 	 *
-	 * todo (6.0) : come back and make sure we are calling this at appropriate times.  despite the name, it should be
-	 * 		called after a logical group of statements - e.g., after all of the delete statements against all of the
-	 * 		tables for a particular entity
 	 */
+	// todo (6.0) : come back and make sure we are calling this at appropriate times.
+	// Despite the name, it should be called after a logical group of statements - e.g.,
+	// after all of the delete statements against all of the tables for a particular entity
 	default void afterStatement(LogicalConnectionImplementor logicalConnection) {
 		logicalConnection.afterStatement();
 	}

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/jdbc/internal/DeferredResultSetAccess.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/jdbc/internal/DeferredResultSetAccess.java
@@ -232,7 +232,7 @@ public class DeferredResultSetAccess extends AbstractResultSetAccess {
 					.getEventListenerManager();
 
 			long executeStartNanos = 0;
-			if ( this.sqlStatementLogger.getLogSlowQuery() > 0 ) {
+			if ( sqlStatementLogger.getLogSlowQuery() > 0 ) {
 				executeStartNanos = System.nanoTime();
 			}
 			try {

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/JavaType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/JavaType.java
@@ -87,6 +87,13 @@ public interface JavaType<T> extends Serializable {
 	}
 
 	/**
+	 * Get the name of the Java type.
+	 */
+	default String getTypeName() {
+		return getJavaType().getTypeName();
+	}
+
+	/**
 	 * Is the given value an instance of the described type?
 	 * <p>
 	 * Usually just {@link #getJavaTypeClass() getJavaTypeClass().}{@link Class#isInstance isInstance(value)},

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/fetchprofile/NewFetchTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/fetchprofile/NewFetchTest.java
@@ -79,6 +79,40 @@ public class NewFetchTest {
 		assertTrue( isInitialized( ee.f ) );
 	}
 
+	@Test void testQuery(SessionFactoryScope scope) {
+		scope.inTransaction( s-> {
+			G g = new G();
+			F f = new F();
+			E e = new E();
+			f.g = g;
+			e.f = f;
+			s.persist(g);
+			s.persist(f);
+			s.persist(e);
+		});
+
+		F f = scope.fromSession( s ->
+				s.createSelectionQuery("from F where id = 1", F.class)
+						.getSingleResult());
+		assertFalse( isInitialized( f.g ) );
+		assertFalse( isInitialized( f.es ) );
+		F ff = scope.fromSession( s ->
+				s.createSelectionQuery("from F where id = 1", F.class)
+						.enableFetchProfile(NEW_PROFILE).getSingleResult());
+		assertTrue( isInitialized( ff.g ) );
+		assertTrue( isInitialized( ff.es ) );
+
+		E e = scope.fromSession( s ->
+				s.createSelectionQuery("from E where id = 1", E.class)
+						.getSingleResult());
+		assertFalse( isInitialized( e.f ) );
+		E ee = scope.fromSession( s ->
+				s.createSelectionQuery("from E where id = 1", E.class)
+						.enableFetchProfile(OLD_PROFILE)
+						.getSingleResult());
+		assertTrue( isInitialized( ee.f ) );
+	}
+
 	@Test void testStyles(SessionFactoryScope scope) {
 		long id = scope.fromTransaction( s-> {
 			G g = new G();

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/fetchprofile/NewFetchTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/fetchprofile/NewFetchTest.java
@@ -7,6 +7,7 @@ import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import org.hibernate.annotations.FetchProfile;
 import org.hibernate.annotations.FetchProfileOverride;
+import org.hibernate.annotations.NaturalId;
 import org.hibernate.testing.orm.junit.DomainModel;
 import org.hibernate.testing.orm.junit.SessionFactory;
 import org.hibernate.testing.orm.junit.SessionFactoryScope;
@@ -60,7 +61,7 @@ public class NewFetchTest {
 			s.persist(e);
 		});
 
-		F f = scope.fromSession( s -> s.find(F.class, 1));
+		F f = scope.fromSession( s -> s.find(F.class, 1) );
 		assertFalse( isInitialized( f.g ) );
 		assertFalse( isInitialized( f.es ) );
 		F ff = scope.fromSession( s -> {
@@ -70,12 +71,91 @@ public class NewFetchTest {
 		assertTrue( isInitialized( ff.g ) );
 		assertTrue( isInitialized( ff.es ) );
 
-		E e = scope.fromSession( s -> s.find(E.class, 1));
+		E e = scope.fromSession( s -> s.find(E.class, 1) );
 		assertFalse( isInitialized( e.f ) );
 		E ee = scope.fromSession( s -> {
 			s.enableFetchProfile(OLD_PROFILE);
 			return s.find(E.class, 1);
 		} );
+		assertTrue( isInitialized( ee.f ) );
+	}
+
+	@Test void testById(SessionFactoryScope scope) {
+		scope.inTransaction( s-> {
+			G g = new G();
+			F f = new F();
+			E e = new E();
+			f.g = g;
+			e.f = f;
+			s.persist(g);
+			s.persist(f);
+			s.persist(e);
+		});
+
+		F f = scope.fromSession( s -> s.byId(F.class).load(1) );
+		assertFalse( isInitialized( f.g ) );
+		assertFalse( isInitialized( f.es ) );
+		F ff = scope.fromSession( s -> s.byId(F.class).enableFetchProfile(NEW_PROFILE).load(1) );
+		assertTrue( isInitialized( ff.g ) );
+		assertTrue( isInitialized( ff.es ) );
+
+		E e = scope.fromSession( s -> s.byId(E.class).load(1) );
+		assertFalse( isInitialized( e.f ) );
+		E ee = scope.fromSession( s -> s.byId(E.class).enableFetchProfile(OLD_PROFILE).load(1) );
+		assertTrue( isInitialized( ee.f ) );
+	}
+
+	@Test void testBySimpleNaturalId(SessionFactoryScope scope) {
+		scope.inTransaction( s-> {
+			G g = new G();
+			F f = new F();
+			E e = new E();
+			f.g = g;
+			e.f = f;
+			e.s = "1";
+			f.s = "1";
+			s.persist(g);
+			s.persist(f);
+			s.persist(e);
+		});
+
+		F f = scope.fromSession( s -> s.bySimpleNaturalId(F.class).load("1") );
+		assertFalse( isInitialized( f.g ) );
+		assertFalse( isInitialized( f.es ) );
+		F ff = scope.fromSession( s -> s.bySimpleNaturalId(F.class).enableFetchProfile(NEW_PROFILE).load("1") );
+		assertTrue( isInitialized( ff.g ) );
+		assertTrue( isInitialized( ff.es ) );
+
+		E e = scope.fromSession( s -> s.bySimpleNaturalId(E.class).load("1") );
+		assertFalse( isInitialized( e.f ) );
+		E ee = scope.fromSession( s -> s.bySimpleNaturalId(E.class).enableFetchProfile(OLD_PROFILE).load("1") );
+		assertTrue( isInitialized( ee.f ) );
+	}
+
+	@Test void testByNaturalId(SessionFactoryScope scope) {
+		scope.inTransaction( s-> {
+			G g = new G();
+			F f = new F();
+			E e = new E();
+			f.g = g;
+			e.f = f;
+			e.s = "2";
+			f.s = "2";
+			s.persist(g);
+			s.persist(f);
+			s.persist(e);
+		});
+
+		F f = scope.fromSession( s -> s.byNaturalId(F.class).using("s", "2").load() );
+		assertFalse( isInitialized( f.g ) );
+		assertFalse( isInitialized( f.es ) );
+		F ff = scope.fromSession( s -> s.byNaturalId(F.class).using("s", "2").enableFetchProfile(NEW_PROFILE).load() );
+		assertTrue( isInitialized( ff.g ) );
+		assertTrue( isInitialized( ff.es ) );
+
+		E e = scope.fromSession( s -> s.byNaturalId(E.class).using("s", "2").load() );
+		assertFalse( isInitialized( e.f ) );
+		E ee = scope.fromSession( s -> s.byNaturalId(E.class).using("s", "2").enableFetchProfile(OLD_PROFILE).load() );
 		assertTrue( isInitialized( ee.f ) );
 	}
 
@@ -268,6 +348,7 @@ public class NewFetchTest {
 		Long id;
 		@ManyToOne(fetch = LAZY)
 		F f;
+		@NaturalId String s;
 	}
 	@Entity(name = "F")
 	static class F {
@@ -284,6 +365,7 @@ public class NewFetchTest {
 		@FetchProfileOverride(mode = SELECT, fetch = EAGER, profile = EAGER_SELECT_PROFILE)
 		@FetchProfileOverride(mode = JOIN, profile = JOIN_PROFILE)
 		Set<E> es;
+		@NaturalId String s;
 	}
 	@Entity(name = "G")
 	static class G {

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/fetchprofile/NewGraphTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/fetchprofile/NewGraphTest.java
@@ -1,0 +1,198 @@
+package org.hibernate.orm.test.annotations.fetchprofile;
+
+import jakarta.persistence.*;
+import org.hibernate.annotations.NaturalId;
+import org.hibernate.graph.GraphSemantic;
+import org.hibernate.graph.RootGraph;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.junit.jupiter.api.Test;
+
+import java.util.Set;
+
+import static jakarta.persistence.FetchType.LAZY;
+import static org.hibernate.Hibernate.isInitialized;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@SessionFactory
+@DomainModel(annotatedClasses = {NewGraphTest.class, NewGraphTest.E.class, NewGraphTest.F.class, NewGraphTest.G.class, NewGraphTest.H.class})
+public class NewGraphTest {
+
+	@Test void testByIdEntityGraph(SessionFactoryScope scope) {
+		scope.inTransaction( s-> {
+			G g = new G();
+			F f = new F();
+			E e = new E();
+			f.g = g;
+			e.f = f;
+			s.persist(g);
+			s.persist(f);
+			s.persist(e);
+		});
+
+		F f = scope.fromSession( s -> s.byId(F.class).load(1) );
+		assertFalse( isInitialized( f.g ) );
+		assertFalse( isInitialized( f.es ) );
+		F ff = scope.fromSession( s -> {
+			RootGraph<F> graph = s.createEntityGraph(F.class);
+			graph.addAttributeNodes("g", "es");
+			return s.byId(F.class).withFetchGraph(graph).load(1);
+		});
+		assertTrue( isInitialized( ff.g ) );
+		assertTrue( isInitialized( ff.es ) );
+
+		E e = scope.fromSession( s -> s.byId(E.class).load(1) );
+		assertFalse( isInitialized( e.f ) );
+		E ee = scope.fromSession( s -> {
+			RootGraph<E> graph = s.createEntityGraph(E.class);
+			graph.addAttributeNodes("f");
+			return s.byId(E.class).withFetchGraph(graph).load(1);
+		});
+		assertTrue( isInitialized( ee.f ) );
+	}
+
+	@Test void testBySimpleNaturalIdEntityGraph(SessionFactoryScope scope) {
+		scope.inTransaction( s-> {
+			G g = new G();
+			F f = new F();
+			E e = new E();
+			f.g = g;
+			e.f = f;
+			e.s = "3";
+			f.s = "3";
+			s.persist(g);
+			s.persist(f);
+			s.persist(e);
+		});
+
+		F f = scope.fromSession( s -> s.bySimpleNaturalId(F.class).load("3") );
+		assertFalse( isInitialized( f.g ) );
+		assertFalse( isInitialized( f.es ) );
+		F ff = scope.fromSession( s -> {
+			RootGraph<F> graph = s.createEntityGraph(F.class);
+			graph.addAttributeNodes("g", "es");
+			return s.bySimpleNaturalId(F.class).withFetchGraph(graph).load("3");
+		});
+		assertTrue( isInitialized( ff.g ) );
+		assertTrue( isInitialized( ff.es ) );
+
+		E e = scope.fromSession( s -> s.bySimpleNaturalId(E.class).load("3") );
+		assertFalse( isInitialized( e.f ) );
+		E ee = scope.fromSession( s -> {
+			RootGraph<E> graph = s.createEntityGraph(E.class);
+			graph.addAttributeNodes("f");
+			return s.bySimpleNaturalId(E.class).withFetchGraph(graph).load("3");
+		});
+		assertTrue( isInitialized( ee.f ) );
+	}
+
+	@Test void testNaturalIdEntityGraph(SessionFactoryScope scope) {
+		scope.inTransaction( s-> {
+			G g = new G();
+			F f = new F();
+			E e = new E();
+			f.g = g;
+			e.f = f;
+			e.s = "4";
+			f.s = "4";
+			s.persist(g);
+			s.persist(f);
+			s.persist(e);
+		});
+
+		F f = scope.fromSession( s -> s.byNaturalId(F.class).using("s", "4").load() );
+		assertFalse( isInitialized( f.g ) );
+		assertFalse( isInitialized( f.es ) );
+		F ff = scope.fromSession( s -> {
+			RootGraph<F> graph = s.createEntityGraph(F.class);
+			graph.addAttributeNodes("g", "es");
+			return s.byNaturalId(F.class).withFetchGraph(graph).using("s", "4").load();
+		});
+		assertTrue( isInitialized( ff.g ) );
+		assertTrue( isInitialized( ff.es ) );
+
+		E e = scope.fromSession( s -> s.byNaturalId(E.class).using("s", "4").load() );
+		assertFalse( isInitialized( e.f ) );
+		E ee = scope.fromSession( s -> {
+			RootGraph<E> graph = s.createEntityGraph(E.class);
+			graph.addAttributeNodes("f");
+			return s.byNaturalId(E.class).withFetchGraph(graph).using("s", "4").load();
+		});
+		assertTrue( isInitialized( ee.f ) );
+	}
+
+	@Test void testQuery(SessionFactoryScope scope) {
+		scope.inTransaction( s-> {
+			G g = new G();
+			F f = new F();
+			E e = new E();
+			f.g = g;
+			e.f = f;
+			s.persist(g);
+			s.persist(f);
+			s.persist(e);
+		});
+
+		F f = scope.fromSession(s ->
+				s.createSelectionQuery("from F where id = 1", F.class)
+						.getSingleResult());
+		assertFalse( isInitialized( f.g ) );
+		assertFalse( isInitialized( f.es ) );
+		F ff = scope.fromSession(s -> {
+			RootGraph<F> graph = s.createEntityGraph(F.class);
+			graph.addAttributeNodes("g", "es");
+			return s.createSelectionQuery("from F where id = 1", F.class)
+					.setEntityGraph(graph, GraphSemantic.FETCH)
+					.getSingleResult();
+		});
+		assertTrue( isInitialized( ff.g ) );
+		assertTrue( isInitialized( ff.es ) );
+
+		E e = scope.fromSession(s ->
+				s.createSelectionQuery("from E where id = 1", E.class)
+						.getSingleResult());
+		assertFalse( isInitialized( e.f ) );
+		E ee = scope.fromSession(s -> {
+			RootGraph<E> graph = s.createEntityGraph(E.class);
+			graph.addAttributeNodes("f");
+			return s.createSelectionQuery("from E where id = 1", E.class)
+					.setEntityGraph(graph, GraphSemantic.LOAD)
+					.getSingleResult();
+		});
+		assertTrue( isInitialized( ee.f ) );
+	}
+
+	@Entity(name = "E")
+	static class E {
+		@Id @GeneratedValue
+		Long id;
+		@ManyToOne(fetch = LAZY)
+		F f;
+		@NaturalId String s;
+	}
+
+	@Entity(name = "F")
+	static class F {
+		@Id @GeneratedValue
+		Long id;
+		@ManyToOne(fetch = LAZY)
+		G g;
+		@OneToMany(mappedBy = "f")
+		Set<E> es;
+		@NaturalId String s;
+	}
+	@Entity(name = "G")
+	static class G {
+		@Id @GeneratedValue
+		Long id;
+	}
+
+	@Entity(name = "H")
+	static class H {
+		@Id @GeneratedValue
+		Long id;
+		@ManyToOne G g;
+	}
+}

--- a/tooling/metamodel-generator/src/main/java/org/hibernate/jpamodelgen/ClassWriter.java
+++ b/tooling/metamodel-generator/src/main/java/org/hibernate/jpamodelgen/ClassWriter.java
@@ -100,10 +100,12 @@ public final class ClassWriter {
 		final StringWriter sw = new StringWriter();
 		try ( PrintWriter pw = new PrintWriter(sw) ) {
 
+			if ( context.addDependentAnnotation() && entity.isInjectable() ) {
+				pw.println( writeDependentAnnotation( entity ) );
+			}
 			if ( entity.getElement() instanceof TypeElement ) {
 				pw.println( writeStaticMetaModelAnnotation( entity ) );
 			}
-
 			if ( context.addGeneratedAnnotation() ) {
 				pw.println( writeGeneratedAnnotation( entity, context ) );
 			}
@@ -239,7 +241,12 @@ public final class ClassWriter {
 		return "@SuppressWarnings({ \"deprecation\", \"rawtypes\" })";
 	}
 
+	private static String writeDependentAnnotation(Metamodel entity) {
+		return "@" + entity.importType( "jakarta.enterprise.context.Dependent" );
+	}
+
 	private static String writeStaticMetaModelAnnotation(Metamodel entity) {
-		return "@" + entity.importType( "jakarta.persistence.metamodel.StaticMetamodel" ) + "(" + entity.getSimpleName() + ".class)";
+		return "@" + entity.importType( "jakarta.persistence.metamodel.StaticMetamodel" )
+				+ "(" + entity.getSimpleName() + ".class)";
 	}
 }

--- a/tooling/metamodel-generator/src/main/java/org/hibernate/jpamodelgen/Context.java
+++ b/tooling/metamodel-generator/src/main/java/org/hibernate/jpamodelgen/Context.java
@@ -16,6 +16,7 @@ import java.util.Map;
 import java.util.Set;
 import javax.annotation.processing.ProcessingEnvironment;
 import javax.lang.model.element.AnnotationMirror;
+import javax.lang.model.element.AnnotationValue;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.TypeElement;
 import javax.lang.model.util.Elements;
@@ -72,6 +73,9 @@ public final class Context {
 
 	// keep track of all classes for which model have been generated
 	private final Collection<String> generatedModelClasses = new HashSet<>();
+
+	// keep track of which named queries have been checked
+	private Set<String> checkedNamedQueries = new HashSet<>();
 
 	public Context(ProcessingEnvironment processingEnvironment) {
 		this.processingEnvironment = processingEnvironment;
@@ -266,13 +270,15 @@ public final class Context {
 		getProcessingEnvironment().getMessager()
 				.printMessage( severity, message, method );
 	}
+
+	public void message(Element method, AnnotationMirror mirror, AnnotationValue value, String message, Diagnostic.Kind severity) {
+		getProcessingEnvironment().getMessager()
+				.printMessage( severity, message, method, mirror, value );
+	}
+
 	public void message(Element method, AnnotationMirror mirror, String message, Diagnostic.Kind severity) {
 		getProcessingEnvironment().getMessager()
-				.printMessage( severity, message, method, mirror,
-						mirror.getElementValues().entrySet().stream()
-								.filter( entry -> entry.getKey().getSimpleName().contentEquals("query")
-										|| entry.getKey().getSimpleName().contentEquals("value") )
-								.map(Map.Entry::getValue).findAny().orElseThrow() );
+				.printMessage( severity, message, method, mirror );
 	}
 
 	@Override
@@ -287,5 +293,9 @@ public final class Context {
 		sb.append( ", persistenceXmlLocation='" ).append( persistenceXmlLocation ).append( '\'' );
 		sb.append( '}' );
 		return sb.toString();
+	}
+
+	public boolean checkNamedQuery(String name) {
+		return checkedNamedQueries.add(name);
 	}
 }

--- a/tooling/metamodel-generator/src/main/java/org/hibernate/jpamodelgen/Context.java
+++ b/tooling/metamodel-generator/src/main/java/org/hibernate/jpamodelgen/Context.java
@@ -66,6 +66,7 @@ public final class Context {
 	 */
 	private Boolean fullyXmlConfigured;
 	private boolean addInjectAnnotation = false;
+	private boolean addDependentAnnotation = false;
 	private boolean addNonnullAnnotation = false;
 	private boolean addGeneratedAnnotation = true;
 	private boolean addGenerationDate;
@@ -120,6 +121,14 @@ public final class Context {
 
 	public void setAddInjectAnnotation(boolean addInjectAnnotation) {
 		this.addInjectAnnotation = addInjectAnnotation;
+	}
+
+	public boolean addDependentAnnotation() {
+		return addDependentAnnotation;
+	}
+
+	public void setAddDependentAnnotation(boolean addDependentAnnotation) {
+		this.addDependentAnnotation = addDependentAnnotation;
 	}
 
 	public boolean addNonnullAnnotation() {

--- a/tooling/metamodel-generator/src/main/java/org/hibernate/jpamodelgen/Context.java
+++ b/tooling/metamodel-generator/src/main/java/org/hibernate/jpamodelgen/Context.java
@@ -66,6 +66,7 @@ public final class Context {
 	 */
 	private Boolean fullyXmlConfigured;
 	private boolean addInjectAnnotation = false;
+	private boolean addNonnullAnnotation = false;
 	private boolean addGeneratedAnnotation = true;
 	private boolean addGenerationDate;
 	private boolean addSuppressWarningsAnnotation;
@@ -119,6 +120,14 @@ public final class Context {
 
 	public void setAddInjectAnnotation(boolean addInjectAnnotation) {
 		this.addInjectAnnotation = addInjectAnnotation;
+	}
+
+	public boolean addNonnullAnnotation() {
+		return addNonnullAnnotation;
+	}
+
+	public void setAddNonnullAnnotation(boolean addNonnullAnnotation) {
+		this.addNonnullAnnotation = addNonnullAnnotation;
 	}
 
 	public boolean addGeneratedAnnotation() {

--- a/tooling/metamodel-generator/src/main/java/org/hibernate/jpamodelgen/JPAMetaModelEntityProcessor.java
+++ b/tooling/metamodel-generator/src/main/java/org/hibernate/jpamodelgen/JPAMetaModelEntityProcessor.java
@@ -164,12 +164,13 @@ public class JPAMetaModelEntityProcessor extends AbstractProcessor {
 			);
 		}
 		else {
+			context.logMessage( Diagnostic.Kind.OTHER, "Starting new round" );
 			try {
 				processClasses( roundEnvironment );
 				createMetaModelClasses();
 			}
 			catch (Exception e) {
-				context.logMessage( Diagnostic.Kind.ERROR, "Error generating JPA metamodel:" + e.getMessage() );
+				context.logMessage( Diagnostic.Kind.ERROR, "Error generating JPA metamodel: " + e.getMessage() );
 			}
 		}
 		return ALLOW_OTHER_PROCESSORS_TO_CLAIM_ANNOTATIONS;

--- a/tooling/metamodel-generator/src/main/java/org/hibernate/jpamodelgen/JPAMetaModelEntityProcessor.java
+++ b/tooling/metamodel-generator/src/main/java/org/hibernate/jpamodelgen/JPAMetaModelEntityProcessor.java
@@ -117,10 +117,14 @@ public class JPAMetaModelEntityProcessor extends AbstractProcessor {
 		final PackageElement jakartaAnnotationPackage =
 				context.getProcessingEnvironment().getElementUtils()
 						.getPackageElement( "jakarta.annotation" );
+		final PackageElement jakartaContextPackage =
+				context.getProcessingEnvironment().getElementUtils()
+						.getPackageElement( "jakarta.enterprise.context" );
 
 		context.setAddInjectAnnotation( jakartaInjectPackage != null );
 		context.setAddNonnullAnnotation( jakartaAnnotationPackage != null );
 		context.setAddGeneratedAnnotation( jakartaAnnotationPackage != null );
+		context.setAddDependentAnnotation( jakartaContextPackage != null );
 
 		final Map<String, String> options = environment.getOptions();
 

--- a/tooling/metamodel-generator/src/main/java/org/hibernate/jpamodelgen/JPAMetaModelEntityProcessor.java
+++ b/tooling/metamodel-generator/src/main/java/org/hibernate/jpamodelgen/JPAMetaModelEntityProcessor.java
@@ -114,19 +114,19 @@ public class JPAMetaModelEntityProcessor extends AbstractProcessor {
 		final PackageElement jakartaInjectPackage =
 				context.getProcessingEnvironment().getElementUtils()
 						.getPackageElement( "jakarta.inject" );
+		final PackageElement jakartaAnnotationPackage =
+				context.getProcessingEnvironment().getElementUtils()
+						.getPackageElement( "jakarta.annotation" );
+
 		context.setAddInjectAnnotation( jakartaInjectPackage != null );
+		context.setAddNonnullAnnotation( jakartaAnnotationPackage != null );
+		context.setAddGeneratedAnnotation( jakartaAnnotationPackage != null );
 
 		final Map<String, String> options = environment.getOptions();
 
 		String setting = options.get( ADD_GENERATED_ANNOTATION );
 		if ( setting != null ) {
 			context.setAddGeneratedAnnotation( parseBoolean( setting ) );
-		}
-		else {
-			PackageElement jakartaAnnotationPackage =
-					context.getProcessingEnvironment().getElementUtils()
-							.getPackageElement( "jakarta.annotation" );
-			context.setAddGeneratedAnnotation( jakartaAnnotationPackage != null );
 		}
 
 		context.setAddGenerationDate( parseBoolean( options.get( ADD_GENERATION_DATE ) ) );

--- a/tooling/metamodel-generator/src/main/java/org/hibernate/jpamodelgen/ProcessLaterException.java
+++ b/tooling/metamodel-generator/src/main/java/org/hibernate/jpamodelgen/ProcessLaterException.java
@@ -4,7 +4,7 @@
  * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
  * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
  */
-package org.hibernate.jpamodelgen.annotation;
+package org.hibernate.jpamodelgen;
 
 public class ProcessLaterException extends RuntimeException {
 }

--- a/tooling/metamodel-generator/src/main/java/org/hibernate/jpamodelgen/annotation/AbstractFinderMethod.java
+++ b/tooling/metamodel-generator/src/main/java/org/hibernate/jpamodelgen/annotation/AbstractFinderMethod.java
@@ -20,179 +20,179 @@ import static org.hibernate.jpamodelgen.util.StringUtil.getUpperUnderscoreCaseFr
  * @author Gavin King
  */
 public abstract class AbstractFinderMethod implements MetaAttribute {
-    final Metamodel annotationMetaEntity;
-    final String methodName;
-    final String entity;
-    final boolean belongsToDao;
-    final String sessionType;
-    final boolean usingEntityManager;
-    final List<String> fetchProfiles;
+	final Metamodel annotationMetaEntity;
+	final String methodName;
+	final String entity;
+	final boolean belongsToDao;
+	final String sessionType;
+	final boolean usingEntityManager;
+	final List<String> fetchProfiles;
 
-    final List<String> paramNames;
-    final List<String> paramTypes;
+	final List<String> paramNames;
+	final List<String> paramTypes;
 
-    public AbstractFinderMethod(
-            Metamodel annotationMetaEntity,
-            String methodName,
-            String entity,
-            boolean belongsToDao,
-            String sessionType,
-            List<String> fetchProfiles, List<String> paramNames, List<String> paramTypes) {
-        this.annotationMetaEntity = annotationMetaEntity;
-        this.methodName = methodName;
-        this.entity = entity;
-        this.belongsToDao = belongsToDao;
-        this.sessionType = sessionType;
-        this.fetchProfiles = fetchProfiles;
-        this.paramNames = paramNames;
-        this.paramTypes = paramTypes;
-        usingEntityManager = Constants.ENTITY_MANAGER.equals(sessionType);
-    }
+	public AbstractFinderMethod(
+			Metamodel annotationMetaEntity,
+			String methodName,
+			String entity,
+			boolean belongsToDao,
+			String sessionType,
+			List<String> fetchProfiles, List<String> paramNames, List<String> paramTypes) {
+		this.annotationMetaEntity = annotationMetaEntity;
+		this.methodName = methodName;
+		this.entity = entity;
+		this.belongsToDao = belongsToDao;
+		this.sessionType = sessionType;
+		this.fetchProfiles = fetchProfiles;
+		this.paramNames = paramNames;
+		this.paramTypes = paramTypes;
+		usingEntityManager = Constants.ENTITY_MANAGER.equals(sessionType);
+	}
 
-    @Override
-    public boolean hasTypedAttribute() {
-        return true;
-    }
+	@Override
+	public boolean hasTypedAttribute() {
+		return true;
+	}
 
-    @Override
-    public boolean hasStringAttribute() {
-        return false;
-    }
+	@Override
+	public boolean hasStringAttribute() {
+		return false;
+	}
 
-    @Override
-    public String getMetaType() {
-        throw new UnsupportedOperationException();
-    }
+	@Override
+	public String getMetaType() {
+		throw new UnsupportedOperationException();
+	}
 
-    @Override
-    public String getPropertyName() {
-        return methodName;
-    }
+	@Override
+	public String getPropertyName() {
+		return methodName;
+	}
 
-    @Override
-    public String getTypeDeclaration() {
-        return entity;
-    }
+	@Override
+	public String getTypeDeclaration() {
+		return entity;
+	}
 
-    @Override
-    public Metamodel getHostingEntity() {
-        return annotationMetaEntity;
-    }
+	@Override
+	public Metamodel getHostingEntity() {
+		return annotationMetaEntity;
+	}
 
 
-    @Override
-    public String getAttributeNameDeclarationString() {
-        return new StringBuilder()
-                .append("public static final String ")
-                .append(constantName())
-                .append(" = \"!")
-                .append(annotationMetaEntity.getQualifiedName())
-                .append('.')
-                .append(methodName)
-                .append("(")
-                .append(parameterList())
-                .append(")")
-                .append("\";")
-                .toString();
-    }
+	@Override
+	public String getAttributeNameDeclarationString() {
+		return new StringBuilder()
+				.append("public static final String ")
+				.append(constantName())
+				.append(" = \"!")
+				.append(annotationMetaEntity.getQualifiedName())
+				.append('.')
+				.append(methodName)
+				.append("(")
+				.append(parameterList())
+				.append(")")
+				.append("\";")
+				.toString();
+	}
 
-    private String parameterList() {
-        return paramTypes.stream()
-                .map(this::strip)
-                .map(annotationMetaEntity::importType)
-                .reduce((x, y) -> x + ',' + y)
-                .orElse("");
-    }
+	private String parameterList() {
+		return paramTypes.stream()
+				.map(this::strip)
+				.map(annotationMetaEntity::importType)
+				.reduce((x, y) -> x + ',' + y)
+				.orElse("");
+	}
 
-    private String strip(String type) {
-        int index = type.indexOf("<");
-        String stripped = index > 0 ? type.substring(0, index) : type;
-        return type.endsWith("...") ? stripped + "..." : stripped;
-    }
+	private String strip(String type) {
+		int index = type.indexOf("<");
+		String stripped = index > 0 ? type.substring(0, index) : type;
+		return type.endsWith("...") ? stripped + "..." : stripped;
+	}
 
-    String constantName() {
-        return getUpperUnderscoreCaseFromLowerCamelCase(methodName) + "_BY_"
-                + paramNames.stream()
-                .map(StringHelper::unqualify)
-                .map(name -> name.toUpperCase(Locale.ROOT))
-                .reduce((x,y) -> x + "_AND_" + y)
-                .orElse("");
-    }
+	String constantName() {
+		return getUpperUnderscoreCaseFromLowerCamelCase(methodName) + "_BY_"
+				+ paramNames.stream()
+				.map(StringHelper::unqualify)
+				.map(name -> name.toUpperCase(Locale.ROOT))
+				.reduce((x,y) -> x + "_AND_" + y)
+				.orElse("");
+	}
 
-    void comment(StringBuilder declaration) {
-        declaration
-                .append("\n/**\n * @see ")
-                .append(annotationMetaEntity.getQualifiedName())
-                .append("#")
-                .append(methodName)
-                .append("(")
-                .append(parameterList())
-                .append(")")
-                .append("\n **/\n");
-    }
+	void comment(StringBuilder declaration) {
+		declaration
+				.append("\n/**\n * @see ")
+				.append(annotationMetaEntity.getQualifiedName())
+				.append("#")
+				.append(methodName)
+				.append("(")
+				.append(parameterList())
+				.append(")")
+				.append("\n **/\n");
+	}
 
-    void unwrapSession(StringBuilder declaration) {
-        if ( usingEntityManager ) {
-            declaration
-                    .append(".unwrap(")
-                    .append(annotationMetaEntity.importType(Constants.HIB_SESSION))
-                    .append(".class)\n\t\t\t");
-        }
-    }
+	void unwrapSession(StringBuilder declaration) {
+		if ( usingEntityManager ) {
+			declaration
+					.append(".unwrap(")
+					.append(annotationMetaEntity.importType(Constants.HIB_SESSION))
+					.append(".class)\n\t\t\t");
+		}
+	}
 
-    void enableFetchProfile(StringBuilder declaration) {
-//        if ( !usingEntityManager ) {
-//            declaration
-//                    .append("\n\t\t\t.enableFetchProfile(")
-//                    .append(constantName())
-//                    .append(")");
-//        }
-        // currently unused: no way to specify explicit fetch profiles
-        for ( String profile : fetchProfiles ) {
-            declaration
-                    .append("\n\t\t\t.enableFetchProfile(")
-                    .append(profile)
-                    .append(")");
-        }
-    }
+	void enableFetchProfile(StringBuilder declaration) {
+//		if ( !usingEntityManager ) {
+//			declaration
+//					.append("\n\t\t\t.enableFetchProfile(")
+//					.append(constantName())
+//					.append(")");
+//		}
+		// currently unused: no way to specify explicit fetch profiles
+		for ( String profile : fetchProfiles ) {
+			declaration
+					.append("\n\t\t\t.enableFetchProfile(")
+					.append(profile)
+					.append(")");
+		}
+	}
 
-    void preamble(StringBuilder declaration) {
-        modifiers( declaration );
-        declaration
-                .append(annotationMetaEntity.importType(entity));
-        declaration
-                .append(" ")
-                .append(methodName);
-        parameters( declaration) ;
-        declaration
-                .append(" {")
-                .append("\n\treturn entityManager");
-    }
+	void preamble(StringBuilder declaration) {
+		modifiers( declaration );
+		declaration
+				.append(annotationMetaEntity.importType(entity));
+		declaration
+				.append(" ")
+				.append(methodName);
+		parameters( declaration) ;
+		declaration
+				.append(" {")
+				.append("\n\treturn entityManager");
+	}
 
-    void modifiers(StringBuilder declaration) {
-        declaration
-                .append(belongsToDao ? "@Override\npublic " : "public static ");
-    }
+	void modifiers(StringBuilder declaration) {
+		declaration
+				.append(belongsToDao ? "@Override\npublic " : "public static ");
+	}
 
-    void parameters(StringBuilder declaration) {
-        declaration
-                .append("(");
-        if ( !belongsToDao ) {
-            declaration
-                    .append(annotationMetaEntity.importType(Constants.ENTITY_MANAGER))
-                    .append(" entityManager");
-        }
-        for ( int i = 0; i < paramNames.size(); i ++ ) {
-            if ( !belongsToDao || i > 0 ) {
-                declaration
-                        .append(", ");
-            }
-            declaration
-                    .append(annotationMetaEntity.importType(paramTypes.get(i)))
-                    .append(" ")
-                    .append(paramNames.get(i));
-        }
-        declaration
-                .append(')');
-    }
+	void parameters(StringBuilder declaration) {
+		declaration
+				.append("(");
+		if ( !belongsToDao ) {
+			declaration
+					.append(annotationMetaEntity.importType(Constants.ENTITY_MANAGER))
+					.append(" entityManager");
+		}
+		for ( int i = 0; i < paramNames.size(); i ++ ) {
+			if ( !belongsToDao || i > 0 ) {
+				declaration
+						.append(", ");
+			}
+			declaration
+					.append(annotationMetaEntity.importType(paramTypes.get(i)))
+					.append(" ")
+					.append(paramNames.get(i));
+		}
+		declaration
+				.append(')');
+	}
 }

--- a/tooling/metamodel-generator/src/main/java/org/hibernate/jpamodelgen/annotation/AbstractFinderMethod.java
+++ b/tooling/metamodel-generator/src/main/java/org/hibernate/jpamodelgen/annotation/AbstractFinderMethod.java
@@ -37,7 +37,9 @@ public abstract class AbstractFinderMethod implements MetaAttribute {
 			String entity,
 			boolean belongsToDao,
 			String sessionType,
-			List<String> fetchProfiles, List<String> paramNames, List<String> paramTypes) {
+			List<String> fetchProfiles,
+			List<String> paramNames,
+			List<String> paramTypes) {
 		this.annotationMetaEntity = annotationMetaEntity;
 		this.methodName = methodName;
 		this.entity = entity;

--- a/tooling/metamodel-generator/src/main/java/org/hibernate/jpamodelgen/annotation/AbstractFinderMethod.java
+++ b/tooling/metamodel-generator/src/main/java/org/hibernate/jpamodelgen/annotation/AbstractFinderMethod.java
@@ -1,0 +1,198 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.jpamodelgen.annotation;
+
+import org.hibernate.internal.util.StringHelper;
+import org.hibernate.jpamodelgen.model.MetaAttribute;
+import org.hibernate.jpamodelgen.model.Metamodel;
+import org.hibernate.jpamodelgen.util.Constants;
+
+import java.util.List;
+import java.util.Locale;
+
+import static org.hibernate.jpamodelgen.util.StringUtil.getUpperUnderscoreCaseFromLowerCamelCase;
+
+/**
+ * @author Gavin King
+ */
+public abstract class AbstractFinderMethod implements MetaAttribute {
+    final Metamodel annotationMetaEntity;
+    final String methodName;
+    final String entity;
+    final boolean belongsToDao;
+    final String sessionType;
+    final boolean usingEntityManager;
+    final List<String> fetchProfiles;
+
+    final List<String> paramNames;
+    final List<String> paramTypes;
+
+    public AbstractFinderMethod(
+            Metamodel annotationMetaEntity,
+            String methodName,
+            String entity,
+            boolean belongsToDao,
+            String sessionType,
+            List<String> fetchProfiles, List<String> paramNames, List<String> paramTypes) {
+        this.annotationMetaEntity = annotationMetaEntity;
+        this.methodName = methodName;
+        this.entity = entity;
+        this.belongsToDao = belongsToDao;
+        this.sessionType = sessionType;
+        this.fetchProfiles = fetchProfiles;
+        this.paramNames = paramNames;
+        this.paramTypes = paramTypes;
+        usingEntityManager = Constants.ENTITY_MANAGER.equals(sessionType);
+    }
+
+    @Override
+    public boolean hasTypedAttribute() {
+        return true;
+    }
+
+    @Override
+    public boolean hasStringAttribute() {
+        return false;
+    }
+
+    @Override
+    public String getMetaType() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getPropertyName() {
+        return methodName;
+    }
+
+    @Override
+    public String getTypeDeclaration() {
+        return entity;
+    }
+
+    @Override
+    public Metamodel getHostingEntity() {
+        return annotationMetaEntity;
+    }
+
+
+    @Override
+    public String getAttributeNameDeclarationString() {
+        return new StringBuilder()
+                .append("public static final String ")
+                .append(constantName())
+                .append(" = \"!")
+                .append(annotationMetaEntity.getQualifiedName())
+                .append('.')
+                .append(methodName)
+                .append("(")
+                .append(parameterList())
+                .append(")")
+                .append("\";")
+                .toString();
+    }
+
+    private String parameterList() {
+        return paramTypes.stream()
+                .map(this::strip)
+                .map(annotationMetaEntity::importType)
+                .reduce((x, y) -> x + ',' + y)
+                .orElse("");
+    }
+
+    private String strip(String type) {
+        int index = type.indexOf("<");
+        String stripped = index > 0 ? type.substring(0, index) : type;
+        return type.endsWith("...") ? stripped + "..." : stripped;
+    }
+
+    String constantName() {
+        return getUpperUnderscoreCaseFromLowerCamelCase(methodName) + "_BY_"
+                + paramNames.stream()
+                .map(StringHelper::unqualify)
+                .map(name -> name.toUpperCase(Locale.ROOT))
+                .reduce((x,y) -> x + "_AND_" + y)
+                .orElse("");
+    }
+
+    void comment(StringBuilder declaration) {
+        declaration
+                .append("\n/**\n * @see ")
+                .append(annotationMetaEntity.getQualifiedName())
+                .append("#")
+                .append(methodName)
+                .append("(")
+                .append(parameterList())
+                .append(")")
+                .append("\n **/\n");
+    }
+
+    void unwrapSession(StringBuilder declaration) {
+        if ( usingEntityManager ) {
+            declaration
+                    .append(".unwrap(")
+                    .append(annotationMetaEntity.importType(Constants.HIB_SESSION))
+                    .append(".class)\n\t\t\t");
+        }
+    }
+
+    void enableFetchProfile(StringBuilder declaration) {
+//        if ( !usingEntityManager ) {
+//            declaration
+//                    .append("\n\t\t\t.enableFetchProfile(")
+//                    .append(constantName())
+//                    .append(")");
+//        }
+        // currently unused: no way to specify explicit fetch profiles
+        for ( String profile : fetchProfiles ) {
+            declaration
+                    .append("\n\t\t\t.enableFetchProfile(")
+                    .append(profile)
+                    .append(")");
+        }
+    }
+
+    void preamble(StringBuilder declaration) {
+        modifiers( declaration );
+        declaration
+                .append(annotationMetaEntity.importType(entity));
+        declaration
+                .append(" ")
+                .append(methodName);
+        parameters( declaration) ;
+        declaration
+                .append(" {")
+                .append("\n\treturn entityManager");
+    }
+
+    void modifiers(StringBuilder declaration) {
+        declaration
+                .append(belongsToDao ? "@Override\npublic " : "public static ");
+    }
+
+    void parameters(StringBuilder declaration) {
+        declaration
+                .append("(");
+        if ( !belongsToDao ) {
+            declaration
+                    .append(annotationMetaEntity.importType(Constants.ENTITY_MANAGER))
+                    .append(" entityManager");
+        }
+        for ( int i = 0; i < paramNames.size(); i ++ ) {
+            if ( !belongsToDao || i > 0 ) {
+                declaration
+                        .append(", ");
+            }
+            declaration
+                    .append(annotationMetaEntity.importType(paramTypes.get(i)))
+                    .append(" ")
+                    .append(paramNames.get(i));
+        }
+        declaration
+                .append(')');
+    }
+}

--- a/tooling/metamodel-generator/src/main/java/org/hibernate/jpamodelgen/annotation/AnnotationMetaAttribute.java
+++ b/tooling/metamodel-generator/src/main/java/org/hibernate/jpamodelgen/annotation/AnnotationMetaAttribute.java
@@ -13,7 +13,8 @@ import javax.lang.model.util.Elements;
 
 import org.hibernate.jpamodelgen.model.MetaAttribute;
 import org.hibernate.jpamodelgen.model.Metamodel;
-import org.hibernate.jpamodelgen.util.StringUtil;
+
+import static org.hibernate.jpamodelgen.util.StringUtil.getUpperUnderscoreCaseFromLowerCamelCase;
 
 /**
  * Captures all information about an annotated persistent attribute.
@@ -70,7 +71,7 @@ public abstract class AnnotationMetaAttribute implements MetaAttribute {
 				.append("public static final ")
 				.append(parent.importType(String.class.getName()))
 				.append(" ")
-				.append(StringUtil.getUpperUnderscoreCaseFromLowerCamelCase(getPropertyName()))
+				.append(getUpperUnderscoreCaseFromLowerCamelCase(getPropertyName()))
 				.append(" = ")
 				.append("\"")
 				.append(getPropertyName())

--- a/tooling/metamodel-generator/src/main/java/org/hibernate/jpamodelgen/annotation/AnnotationMetaEntity.java
+++ b/tooling/metamodel-generator/src/main/java/org/hibernate/jpamodelgen/annotation/AnnotationMetaEntity.java
@@ -11,15 +11,7 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import javax.lang.model.element.AnnotationMirror;
-import javax.lang.model.element.AnnotationValue;
-import javax.lang.model.element.Element;
-import javax.lang.model.element.ElementKind;
-import javax.lang.model.element.ExecutableElement;
-import javax.lang.model.element.Modifier;
-import javax.lang.model.element.Name;
-import javax.lang.model.element.TypeElement;
-import javax.lang.model.element.VariableElement;
+import javax.lang.model.element.*;
 import javax.lang.model.type.DeclaredType;
 import javax.lang.model.type.ExecutableType;
 import javax.lang.model.type.TypeKind;
@@ -32,6 +24,7 @@ import org.hibernate.Session;
 import org.hibernate.StatelessSession;
 import org.hibernate.jpamodelgen.Context;
 import org.hibernate.jpamodelgen.ImportContextImpl;
+import org.hibernate.jpamodelgen.ProcessLaterException;
 import org.hibernate.jpamodelgen.model.ImportContext;
 import org.hibernate.jpamodelgen.model.MetaAttribute;
 import org.hibernate.jpamodelgen.model.Metamodel;
@@ -712,32 +705,4 @@ public class AnnotationMetaEntity extends AnnotationMeta {
 			&& !isPageParam(type)
 			&& !isOrderParam(type);
 	}
-
-//	private void checkHqlSyntax(ExecutableElement method, AnnotationMirror mirror, String queryString) {
-//		final ANTLRErrorListener errorListener = new ErrorHandler( method, mirror, queryString );
-//		final HqlLexer hqlLexer = HqlParseTreeBuilder.INSTANCE.buildHqlLexer( queryString );
-//		final HqlParser hqlParser = HqlParseTreeBuilder.INSTANCE.buildHqlParser( queryString, hqlLexer );
-//		hqlLexer.addErrorListener( errorListener );
-//		hqlParser.getInterpreter().setPredictionMode( PredictionMode.SLL );
-//		hqlParser.removeErrorListeners();
-//		hqlParser.addErrorListener( errorListener );
-//		hqlParser.setErrorHandler( new BailErrorStrategy() );
-//
-//		try {
-//			hqlParser.statement();
-//		}
-//		catch ( ParseCancellationException e) {
-//			// reset the input token stream and parser state
-//			hqlLexer.reset();
-//			hqlParser.reset();
-//
-//			// fall back to LL(k)-based parsing
-//			hqlParser.getInterpreter().setPredictionMode( PredictionMode.LL );
-//			hqlParser.setErrorHandler( new DefaultErrorStrategy() );
-//
-//			hqlParser.statement();
-//		}
-//	}
-
-
 }

--- a/tooling/metamodel-generator/src/main/java/org/hibernate/jpamodelgen/annotation/AnnotationMetaEntity.java
+++ b/tooling/metamodel-generator/src/main/java/org/hibernate/jpamodelgen/annotation/AnnotationMetaEntity.java
@@ -18,7 +18,6 @@ import javax.lang.model.element.ElementKind;
 import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.element.Modifier;
 import javax.lang.model.element.Name;
-import javax.lang.model.element.PackageElement;
 import javax.lang.model.element.TypeElement;
 import javax.lang.model.element.VariableElement;
 import javax.lang.model.type.DeclaredType;
@@ -144,8 +143,7 @@ public class AnnotationMetaEntity extends AnnotationMeta {
 	}
 
 	private static String getPackageName(Context context, TypeElement element) {
-		PackageElement packageOf = context.getElementUtils().getPackageOf( element );
-		return context.getElementUtils().getName( packageOf.getQualifiedName() ).toString();
+		return context.getElementUtils().getPackageOf( element ).getQualifiedName().toString();
 	}
 
 	@Override
@@ -485,7 +483,11 @@ public class AnnotationMetaEntity extends AnnotationMeta {
 		else {
 			@SuppressWarnings("unchecked")
 			final List<AnnotationValue> annotationValues = (List<AnnotationValue>) enabledFetchProfiles;
-			return annotationValues.stream().map(AnnotationValue::toString).collect(toList());
+			List<String> result = annotationValues.stream().map(AnnotationValue::toString).collect(toList());
+			if ( result.stream().anyMatch("<error>"::equals) ) {
+				throw new ProcessLaterException();
+			}
+			return result;
 		}
 	}
 

--- a/tooling/metamodel-generator/src/main/java/org/hibernate/jpamodelgen/annotation/AnnotationMetaEntity.java
+++ b/tooling/metamodel-generator/src/main/java/org/hibernate/jpamodelgen/annotation/AnnotationMetaEntity.java
@@ -287,7 +287,15 @@ public class AnnotationMetaEntity extends AnnotationMeta {
 		String typeName = element.getSimpleName().toString() + '_';
 		String sessionType = getterOrSetter.getReturnType().toString();
 		putMember( name,
-				new DaoConstructor(this, typeName, name, sessionType, context.addInjectAnnotation() ) );
+				new DaoConstructor(
+						this,
+						typeName,
+						name,
+						sessionType,
+						context.addInjectAnnotation(),
+						context.addNonnullAnnotation()
+				)
+		);
 		return sessionType;
 	}
 
@@ -502,7 +510,8 @@ public class AnnotationMetaEntity extends AnnotationMeta {
 						false,
 						dao,
 						sessionType,
-						enabledFetchProfiles( method )
+						enabledFetchProfiles( method ),
+						context.addNonnullAnnotation()
 				)
 		);
 	}
@@ -541,7 +550,8 @@ public class AnnotationMetaEntity extends AnnotationMeta {
 							paramTypes,
 							dao,
 							sessionType,
-							enabledFetchProfiles( method )
+							enabledFetchProfiles( method ),
+							context.addNonnullAnnotation()
 					)
 			);
 		}
@@ -557,7 +567,8 @@ public class AnnotationMetaEntity extends AnnotationMeta {
 							false,
 							dao,
 							sessionType,
-							enabledFetchProfiles( method )
+							enabledFetchProfiles( method ),
+							context.addNonnullAnnotation()
 					)
 			);
 		}
@@ -582,7 +593,8 @@ public class AnnotationMetaEntity extends AnnotationMeta {
 										parameter.asType().toString(),
 										dao,
 										sessionType,
-										enabledFetchProfiles( method )
+										enabledFetchProfiles( method ),
+										context.addNonnullAnnotation()
 								)
 						);
 						break;
@@ -598,7 +610,8 @@ public class AnnotationMetaEntity extends AnnotationMeta {
 										List.of( parameter.asType().toString() ),
 										dao,
 										sessionType,
-										enabledFetchProfiles( method )
+										enabledFetchProfiles( method ),
+										context.addNonnullAnnotation()
 								)
 						);
 						break;
@@ -615,7 +628,8 @@ public class AnnotationMetaEntity extends AnnotationMeta {
 									fieldType == FieldType.ID,
 									dao,
 									sessionType,
-									enabledFetchProfiles( method )
+									enabledFetchProfiles( method ),
+									context.addNonnullAnnotation()
 							)
 					);
 					break;
@@ -703,7 +717,8 @@ public class AnnotationMetaEntity extends AnnotationMeta {
 								paramTypes,
 								isNative,
 								dao,
-								sessionType
+								sessionType,
+								context.addNonnullAnnotation()
 						);
 				putMember( attribute.getPropertyName() + paramTypes, attribute );
 

--- a/tooling/metamodel-generator/src/main/java/org/hibernate/jpamodelgen/annotation/AnnotationMetaEntity.java
+++ b/tooling/metamodel-generator/src/main/java/org/hibernate/jpamodelgen/annotation/AnnotationMetaEntity.java
@@ -12,6 +12,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import javax.lang.model.element.AnnotationMirror;
+import javax.lang.model.element.AnnotationValue;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.ElementKind;
 import javax.lang.model.element.ExecutableElement;
@@ -41,6 +42,7 @@ import org.hibernate.jpamodelgen.util.Constants;
 import org.hibernate.jpamodelgen.validation.ProcessorSessionFactory;
 import org.hibernate.jpamodelgen.validation.Validation;
 
+import static java.util.Collections.emptyList;
 import static java.util.Collections.emptySet;
 import static java.util.stream.Collectors.toList;
 import static javax.lang.model.util.ElementFilter.fieldsIn;
@@ -468,9 +470,24 @@ public class AnnotationMetaEntity extends AnnotationMeta {
 						paramNames,
 						paramTypes,
 						dao,
-						sessionType
+						sessionType,
+						enabledFetchProfiles( method )
 				)
 		);
+	}
+
+	private static List<String> enabledFetchProfiles(ExecutableElement method) {
+		final Object enabledFetchProfiles =
+				getAnnotationValue( castNonNull( getAnnotationMirror( method, Constants.FIND ) ),
+						"enabledFetchProfiles" );
+		if ( enabledFetchProfiles == null ) {
+			return emptyList();
+		}
+		else {
+			@SuppressWarnings("unchecked")
+			final List<AnnotationValue> annotationValues = (List<AnnotationValue>) enabledFetchProfiles;
+			return annotationValues.stream().map(AnnotationValue::toString).collect(toList());
+		}
 	}
 
 	private void createMultipleParameterFinder(ExecutableElement method, TypeMirror returnType, TypeElement entity) {
@@ -487,7 +504,8 @@ public class AnnotationMetaEntity extends AnnotationMeta {
 							paramNames,
 							paramTypes,
 							dao,
-							sessionType
+							sessionType,
+							enabledFetchProfiles( method )
 					)
 			);
 		}
@@ -501,7 +519,8 @@ public class AnnotationMetaEntity extends AnnotationMeta {
 							paramNames,
 							paramTypes,
 							dao,
-							sessionType
+							sessionType,
+							enabledFetchProfiles( method )
 					)
 			);
 		}
@@ -523,7 +542,8 @@ public class AnnotationMetaEntity extends AnnotationMeta {
 									List.of( parameter.getSimpleName().toString() ),
 									List.of( parameter.asType().toString() ),
 									dao,
-									sessionType
+									sessionType,
+									enabledFetchProfiles( method )
 							)
 					);
 					break;
@@ -536,7 +556,8 @@ public class AnnotationMetaEntity extends AnnotationMeta {
 									parameter.getSimpleName().toString(),
 									parameter.asType().toString(),
 									dao,
-									sessionType
+									sessionType,
+									enabledFetchProfiles( method )
 							)
 					);
 					break;
@@ -550,7 +571,8 @@ public class AnnotationMetaEntity extends AnnotationMeta {
 									List.of( parameter.getSimpleName().toString() ),
 									List.of( parameter.asType().toString() ),
 									dao,
-									sessionType
+									sessionType,
+									enabledFetchProfiles( method )
 							)
 					);
 					break;

--- a/tooling/metamodel-generator/src/main/java/org/hibernate/jpamodelgen/annotation/AnnotationMetaEntity.java
+++ b/tooling/metamodel-generator/src/main/java/org/hibernate/jpamodelgen/annotation/AnnotationMetaEntity.java
@@ -222,6 +222,11 @@ public class AnnotationMetaEntity extends AnnotationMeta {
 	}
 
 	@Override
+	public boolean isInjectable() {
+		return dao;
+	}
+
+	@Override
 	public String toString() {
 		return new StringBuilder()
 				.append( "AnnotationMetaEntity" )

--- a/tooling/metamodel-generator/src/main/java/org/hibernate/jpamodelgen/annotation/AnnotationMetaEntity.java
+++ b/tooling/metamodel-generator/src/main/java/org/hibernate/jpamodelgen/annotation/AnnotationMetaEntity.java
@@ -479,6 +479,9 @@ public class AnnotationMetaEntity extends AnnotationMeta {
 		}
 	}
 
+	/**
+	 * Create a finder method which returns multiple results.
+	 */
 	private void createCriteriaFinder(
 			ExecutableElement method, TypeMirror returnType, @Nullable TypeElement containerType, TypeElement entity) {
 		final String methodName = method.getSimpleName().toString();
@@ -496,6 +499,7 @@ public class AnnotationMetaEntity extends AnnotationMeta {
 						containerType == null ? null : containerType.toString(),
 						paramNames,
 						paramTypes,
+						false,
 						dao,
 						sessionType,
 						enabledFetchProfiles( method )
@@ -550,6 +554,7 @@ public class AnnotationMetaEntity extends AnnotationMeta {
 							null,
 							paramNames,
 							paramTypes,
+							false,
 							dao,
 							sessionType,
 							enabledFetchProfiles( method )
@@ -607,6 +612,7 @@ public class AnnotationMetaEntity extends AnnotationMeta {
 									null,
 									List.of( parameter.getSimpleName().toString() ),
 									List.of( parameter.asType().toString() ),
+									fieldType == FieldType.ID,
 									dao,
 									sessionType,
 									enabledFetchProfiles( method )

--- a/tooling/metamodel-generator/src/main/java/org/hibernate/jpamodelgen/annotation/AnnotationMetaPackage.java
+++ b/tooling/metamodel-generator/src/main/java/org/hibernate/jpamodelgen/annotation/AnnotationMetaPackage.java
@@ -138,4 +138,9 @@ public class AnnotationMetaPackage extends AnnotationMeta {
 	boolean belongsToDao() {
 		return false;
 	}
+
+	@Override
+	public boolean isInjectable() {
+		return false;
+	}
 }

--- a/tooling/metamodel-generator/src/main/java/org/hibernate/jpamodelgen/annotation/AnnotationMetaPackage.java
+++ b/tooling/metamodel-generator/src/main/java/org/hibernate/jpamodelgen/annotation/AnnotationMetaPackage.java
@@ -133,4 +133,9 @@ public class AnnotationMetaPackage extends AnnotationMeta {
 	void putMember(String name, MetaAttribute nameMetaAttribute) {
 		members.put( name, nameMetaAttribute );
 	}
+
+	@Override
+	boolean belongsToDao() {
+		return false;
+	}
 }

--- a/tooling/metamodel-generator/src/main/java/org/hibernate/jpamodelgen/annotation/CriteriaFinderMethod.java
+++ b/tooling/metamodel-generator/src/main/java/org/hibernate/jpamodelgen/annotation/CriteriaFinderMethod.java
@@ -27,6 +27,7 @@ public class CriteriaFinderMethod implements MetaAttribute {
 	private final List<String> paramTypes;
 	private final boolean belongsToDao;
 	private final String sessionType;
+	private final List<String> fetchProfiles;
 
 	public CriteriaFinderMethod(
 			Metamodel annotationMetaEntity,
@@ -34,7 +35,8 @@ public class CriteriaFinderMethod implements MetaAttribute {
 			@Nullable String containerType,
 			List<String> paramNames, List<String> paramTypes,
 			boolean belongsToDao,
-			String sessionType) {
+			String sessionType,
+			List<String> fetchProfiles) {
 		this.annotationMetaEntity = annotationMetaEntity;
 		this.methodName = methodName;
 		this.entity = entity;
@@ -43,6 +45,7 @@ public class CriteriaFinderMethod implements MetaAttribute {
 		this.paramTypes = paramTypes;
 		this.belongsToDao = belongsToDao;
 		this.sessionType = sessionType;
+		this.fetchProfiles = fetchProfiles;
 	}
 
 	@Override
@@ -146,6 +149,23 @@ public class CriteriaFinderMethod implements MetaAttribute {
 		}
 		declaration
 				.append("entityManager.createQuery(query)");
+		if ( !fetchProfiles.isEmpty() ) {
+			if ( Constants.ENTITY_MANAGER.equals(sessionType) ) {
+				declaration
+						.append("\n\t\t\t.unwrap(")
+						.append(annotationMetaEntity.importType(Constants.HIB_SELECTION_QUERY))
+						.append(".class)");
+			}
+		}
+		for ( String profile : fetchProfiles ) {
+			declaration
+					.append("\n\t\t\t.enableFetchProfile(")
+					.append(profile)
+					.append(")");
+		}
+		if ( !fetchProfiles.isEmpty() ) {
+			declaration.append("\n\t\t\t");
+		}
 		if ( containerType == null) {
 			declaration
 					.append(".getSingleResult()");

--- a/tooling/metamodel-generator/src/main/java/org/hibernate/jpamodelgen/annotation/CriteriaFinderMethod.java
+++ b/tooling/metamodel-generator/src/main/java/org/hibernate/jpamodelgen/annotation/CriteriaFinderMethod.java
@@ -29,11 +29,17 @@ public class CriteriaFinderMethod extends AbstractFinderMethod {
 			boolean isId,
 			boolean belongsToDao,
 			String sessionType,
-			List<String> fetchProfiles) {
+			List<String> fetchProfiles,
+			boolean addNonnullAnnotation) {
 		super( annotationMetaEntity, methodName, entity, belongsToDao, sessionType, fetchProfiles,
-				paramNames, paramTypes );
+				paramNames, paramTypes, addNonnullAnnotation );
 		this.containerType = containerType;
 		this.isId = isId;
+	}
+
+	@Override
+	public boolean isId() {
+		return isId;
 	}
 
 	@Override

--- a/tooling/metamodel-generator/src/main/java/org/hibernate/jpamodelgen/annotation/DaoConstructor.java
+++ b/tooling/metamodel-generator/src/main/java/org/hibernate/jpamodelgen/annotation/DaoConstructor.java
@@ -20,7 +20,12 @@ public class DaoConstructor implements MetaAttribute {
 	private final String returnTypeName;
 	private final boolean inject;
 
-	public DaoConstructor(Metamodel annotationMetaEntity, String constructorName, String methodName, String returnTypeName, boolean inject) {
+	public DaoConstructor(
+			Metamodel annotationMetaEntity,
+			String constructorName,
+			String methodName,
+			String returnTypeName,
+			boolean inject) {
 		this.annotationMetaEntity = annotationMetaEntity;
 		this.constructorName = constructorName;
 		this.methodName = methodName;

--- a/tooling/metamodel-generator/src/main/java/org/hibernate/jpamodelgen/annotation/DaoConstructor.java
+++ b/tooling/metamodel-generator/src/main/java/org/hibernate/jpamodelgen/annotation/DaoConstructor.java
@@ -18,7 +18,7 @@ public class DaoConstructor implements MetaAttribute {
 	private final String constructorName;
 	private final String methodName;
 	private final String returnTypeName;
-	private final boolean inject;
+	private final boolean addInjectAnnotation;
 	private final boolean addNonnullAnnotation;
 
 	public DaoConstructor(
@@ -26,13 +26,13 @@ public class DaoConstructor implements MetaAttribute {
 			String constructorName,
 			String methodName,
 			String returnTypeName,
-			boolean inject,
+			boolean addInjectAnnotation,
 			boolean addNonnullAnnotation) {
 		this.annotationMetaEntity = annotationMetaEntity;
 		this.constructorName = constructorName;
 		this.methodName = methodName;
 		this.returnTypeName = returnTypeName;
-		this.inject = inject;
+		this.addInjectAnnotation = addInjectAnnotation;
 		this.addNonnullAnnotation = addNonnullAnnotation;
 	}
 
@@ -55,8 +55,9 @@ public class DaoConstructor implements MetaAttribute {
 		declaration
 				.append(annotationMetaEntity.importType(returnTypeName))
 				.append(" entityManager;")
-				.append("\n")
-				.append(inject ? "\n@" + annotationMetaEntity.importType("jakarta.inject.Inject") : "")
+				.append("\n");
+		inject( declaration );
+		declaration
 				.append("\npublic ")
 				.append(constructorName)
 				.append("(");
@@ -77,6 +78,14 @@ public class DaoConstructor implements MetaAttribute {
 				.append("\n\treturn entityManager;")
 				.append("\n}");
 		return declaration.toString();
+	}
+
+	private void inject(StringBuilder declaration) {
+		if ( addInjectAnnotation ) {
+			declaration
+					.append("\n@")
+					.append(annotationMetaEntity.importType("jakarta.inject.Inject"));
+		}
 	}
 
 	private void notNull(StringBuilder declaration) {

--- a/tooling/metamodel-generator/src/main/java/org/hibernate/jpamodelgen/annotation/DaoConstructor.java
+++ b/tooling/metamodel-generator/src/main/java/org/hibernate/jpamodelgen/annotation/DaoConstructor.java
@@ -19,18 +19,21 @@ public class DaoConstructor implements MetaAttribute {
 	private final String methodName;
 	private final String returnTypeName;
 	private final boolean inject;
+	private final boolean addNonnullAnnotation;
 
 	public DaoConstructor(
 			Metamodel annotationMetaEntity,
 			String constructorName,
 			String methodName,
 			String returnTypeName,
-			boolean inject) {
+			boolean inject,
+			boolean addNonnullAnnotation) {
 		this.annotationMetaEntity = annotationMetaEntity;
 		this.constructorName = constructorName;
 		this.methodName = methodName;
 		this.returnTypeName = returnTypeName;
 		this.inject = inject;
+		this.addNonnullAnnotation = addNonnullAnnotation;
 	}
 
 	@Override
@@ -45,28 +48,44 @@ public class DaoConstructor implements MetaAttribute {
 
 	@Override
 	public String getAttributeDeclarationString() {
-		return new StringBuilder()
-				.append("\nprivate final ")
+		StringBuilder declaration = new StringBuilder();
+		declaration
+				.append("\nprivate final ");
+		notNull( declaration );
+		declaration
 				.append(annotationMetaEntity.importType(returnTypeName))
 				.append(" entityManager;")
 				.append("\n")
 				.append(inject ? "\n@" + annotationMetaEntity.importType("jakarta.inject.Inject") : "")
 				.append("\npublic ")
 				.append(constructorName)
-				.append("(")
+				.append("(");
+		notNull( declaration );
+		declaration
 				.append(annotationMetaEntity.importType(returnTypeName))
 				.append(" entityManager) {")
 				.append("\n\tthis.entityManager = entityManager;")
 				.append("\n}")
 				.append("\n\n")
-				.append("public ")
+				.append("public ");
+		notNull( declaration );
+		declaration
 				.append(annotationMetaEntity.importType(returnTypeName))
 				.append(" ")
 				.append(methodName)
 				.append("() {")
 				.append("\n\treturn entityManager;")
-				.append("\n}")
-				.toString();
+				.append("\n}");
+		return declaration.toString();
+	}
+
+	private void notNull(StringBuilder declaration) {
+		if ( addNonnullAnnotation ) {
+			declaration
+					.append('@')
+					.append(annotationMetaEntity.importType("jakarta.annotation.Nonnull"))
+					.append(' ');
+		}
 	}
 
 	@Override

--- a/tooling/metamodel-generator/src/main/java/org/hibernate/jpamodelgen/annotation/ErrorHandler.java
+++ b/tooling/metamodel-generator/src/main/java/org/hibernate/jpamodelgen/annotation/ErrorHandler.java
@@ -15,6 +15,7 @@ import org.hibernate.jpamodelgen.Context;
 import org.hibernate.jpamodelgen.validation.Validation;
 
 import javax.lang.model.element.AnnotationMirror;
+import javax.lang.model.element.AnnotationValue;
 import javax.lang.model.element.Element;
 import javax.tools.Diagnostic;
 import java.util.BitSet;
@@ -27,13 +28,15 @@ import static org.hibernate.query.hql.internal.StandardHqlTranslator.prettifyAnt
 class ErrorHandler implements Validation.Handler {
 	private final Element element;
 	private final AnnotationMirror mirror;
+	private final AnnotationValue value;
 	private final String queryString;
 	private final Context context;
 	private int errorCount;
 
-	public ErrorHandler(Element element, AnnotationMirror mirror, String queryString, Context context) {
+	public ErrorHandler(Element element, AnnotationMirror mirror, AnnotationValue value, String queryString, Context context) {
 		this.element = element;
 		this.mirror = mirror;
+		this.value = value;
 		this.queryString = queryString;
 		this.context = context;
 	}
@@ -46,11 +49,12 @@ class ErrorHandler implements Validation.Handler {
 	@Override
 	public void error(int start, int end, String message) {
 		errorCount++;
-		context.message( element, mirror, message, Diagnostic.Kind.ERROR );
+		context.message( element, mirror, value, message, Diagnostic.Kind.ERROR );
 	}
 
 	@Override
 	public void warn(int start, int end, String message) {
+		context.message( element, mirror, value, message, Diagnostic.Kind.WARNING );
 	}
 
 	@Override
@@ -58,7 +62,7 @@ class ErrorHandler implements Validation.Handler {
 		errorCount++;
 		String prettyMessage = "illegal HQL syntax - "
 				+ prettifyAntlrError( offendingSymbol, line, charPositionInLine, message, e, queryString, false );
-		context.message( element, mirror, prettyMessage, Diagnostic.Kind.ERROR );
+		context.message( element, mirror, value, prettyMessage, Diagnostic.Kind.ERROR );
 	}
 
 	@Override

--- a/tooling/metamodel-generator/src/main/java/org/hibernate/jpamodelgen/annotation/ErrorHandler.java
+++ b/tooling/metamodel-generator/src/main/java/org/hibernate/jpamodelgen/annotation/ErrorHandler.java
@@ -23,6 +23,9 @@ import java.util.BitSet;
 import static org.hibernate.query.hql.internal.StandardHqlTranslator.prettifyAntlrError;
 
 /**
+ * Responsible for forwarding errors from the HQL typechecker to the Java compiler,
+ * via {@link Context#message}.
+ *
  * @author Gavin King
  */
 class ErrorHandler implements Validation.Handler {
@@ -33,11 +36,11 @@ class ErrorHandler implements Validation.Handler {
 	private final Context context;
 	private int errorCount;
 
-	public ErrorHandler(Element element, AnnotationMirror mirror, AnnotationValue value, String queryString, Context context) {
+	public ErrorHandler(Context context, Element element, AnnotationMirror mirror, AnnotationValue value, String hql) {
 		this.element = element;
 		this.mirror = mirror;
 		this.value = value;
-		this.queryString = queryString;
+		this.queryString = hql;
 		this.context = context;
 	}
 

--- a/tooling/metamodel-generator/src/main/java/org/hibernate/jpamodelgen/annotation/IdFinderMethod.java
+++ b/tooling/metamodel-generator/src/main/java/org/hibernate/jpamodelgen/annotation/IdFinderMethod.java
@@ -17,6 +17,7 @@ import java.util.List;
 public class IdFinderMethod extends AbstractFinderMethod {
 
 	private final String paramName;
+	private final boolean usingStatelessSession;
 
 	public IdFinderMethod(
 			Metamodel annotationMetaEntity,
@@ -28,6 +29,7 @@ public class IdFinderMethod extends AbstractFinderMethod {
 		super( annotationMetaEntity, methodName, entity, belongsToDao, sessionType, fetchProfiles,
 				List.of(paramName), List.of(paramType) );
 		this.paramName = paramName;
+		usingStatelessSession = Constants.HIB_STATELESS_SESSION.equals(sessionType);
 	}
 
 	@Override
@@ -35,7 +37,6 @@ public class IdFinderMethod extends AbstractFinderMethod {
 		final StringBuilder declaration = new StringBuilder();
 		comment( declaration );
 		preamble( declaration );
-		final boolean usingStatelessSession = Constants.HIB_STATELESS_SESSION.equals(sessionType);
 		if ( usingStatelessSession || usingEntityManager && fetchProfiles.isEmpty() ) {
 			declaration
 					.append(usingStatelessSession ? ".get(" : ".find(")

--- a/tooling/metamodel-generator/src/main/java/org/hibernate/jpamodelgen/annotation/IdFinderMethod.java
+++ b/tooling/metamodel-generator/src/main/java/org/hibernate/jpamodelgen/annotation/IdFinderMethod.java
@@ -6,7 +6,6 @@
  */
 package org.hibernate.jpamodelgen.annotation;
 
-import org.hibernate.jpamodelgen.model.MetaAttribute;
 import org.hibernate.jpamodelgen.model.Metamodel;
 import org.hibernate.jpamodelgen.util.Constants;
 
@@ -15,15 +14,9 @@ import java.util.List;
 /**
  * @author Gavin King
  */
-public class IdFinderMethod implements MetaAttribute {
-	private final Metamodel annotationMetaEntity;
-	private final String methodName;
-	private final String entity;
+public class IdFinderMethod extends AbstractFinderMethod {
+
 	private final String paramName;
-	private final String paramType;
-	private final boolean belongsToDao;
-	private final String sessionType;
-	private final List<String> fetchProfiles;
 
 	public IdFinderMethod(
 			Metamodel annotationMetaEntity,
@@ -32,68 +25,20 @@ public class IdFinderMethod implements MetaAttribute {
 			boolean belongsToDao,
 			String sessionType,
 			List<String> fetchProfiles) {
-		this.annotationMetaEntity = annotationMetaEntity;
-		this.methodName = methodName;
-		this.entity = entity;
+		super( annotationMetaEntity, methodName, entity, belongsToDao, sessionType, fetchProfiles,
+				List.of(paramName), List.of(paramType) );
 		this.paramName = paramName;
-		this.paramType = paramType;
-		this.belongsToDao = belongsToDao;
-		this.sessionType = sessionType;
-		this.fetchProfiles = fetchProfiles;
-	}
-
-	@Override
-	public boolean hasTypedAttribute() {
-		return true;
-	}
-
-	@Override
-	public boolean hasStringAttribute() {
-		return false;
 	}
 
 	@Override
 	public String getAttributeDeclarationString() {
-		final boolean usingEntityManager = Constants.ENTITY_MANAGER.equals(sessionType);
-
-		StringBuilder declaration = new StringBuilder();
-		declaration
-				.append("\n/**\n * @see ")
-				.append(annotationMetaEntity.getQualifiedName())
-				.append("#")
-				.append(methodName)
-				.append("(")
-				.append(annotationMetaEntity.importType(paramType))
-				.append(")")
-				.append("\n **/\n");
-		if ( belongsToDao ) {
+		final StringBuilder declaration = new StringBuilder();
+		comment( declaration );
+		preamble( declaration );
+		final boolean usingStatelessSession = Constants.HIB_STATELESS_SESSION.equals(sessionType);
+		if ( usingStatelessSession || usingEntityManager && fetchProfiles.isEmpty() ) {
 			declaration
-					.append("@Override\npublic ");
-		}
-		else {
-			declaration
-					.append("public static ");
-		}
-		declaration
-				.append(annotationMetaEntity.importType(entity));
-		declaration
-				.append(" ")
-				.append(methodName)
-				.append("(");
-		if ( !belongsToDao ) {
-			declaration
-					.append(annotationMetaEntity.importType(Constants.ENTITY_MANAGER))
-					.append(" entityManager, ");
-		}
-		declaration
-				.append(annotationMetaEntity.importType(paramType))
-				.append(" ")
-				.append(paramName)
-				.append(") {")
-				.append("\n\treturn entityManager");
-		if ( fetchProfiles.isEmpty() ) {
-			declaration
-					.append(Constants.HIB_STATELESS_SESSION.equals(sessionType) ? ".get(" : ".find(")
+					.append(usingStatelessSession ? ".get(" : ".find(")
 					.append(annotationMetaEntity.importType(entity))
 					.append(".class, ")
 					.append(paramName)
@@ -101,22 +46,12 @@ public class IdFinderMethod implements MetaAttribute {
 					.append("\n}");
 		}
 		else {
-			if ( usingEntityManager ) {
-				declaration
-						.append(".unwrap(")
-						.append(annotationMetaEntity.importType(Constants.HIB_SESSION))
-						.append(".class)\n\t\t\t");
-			}
+			unwrapSession( declaration );
 			declaration
 					.append(".byId(")
 					.append(annotationMetaEntity.importType(entity))
 					.append(".class)");
-			for ( String profile : fetchProfiles ) {
-				declaration
-						.append("\n\t\t\t.enableFetchProfile(")
-						.append(profile)
-						.append(")");
-			}
+			enableFetchProfile( declaration );
 			declaration
 					.append("\n\t\t\t.load(")
 					.append(paramName)
@@ -124,30 +59,5 @@ public class IdFinderMethod implements MetaAttribute {
 
 		}
 		return declaration.toString();
-	}
-
-	@Override
-	public String getAttributeNameDeclarationString() {
-		throw new UnsupportedOperationException();
-	}
-
-	@Override
-	public String getMetaType() {
-		throw new UnsupportedOperationException();
-	}
-
-	@Override
-	public String getPropertyName() {
-		return methodName;
-	}
-
-	@Override
-	public String getTypeDeclaration() {
-		return entity;
-	}
-
-	@Override
-	public Metamodel getHostingEntity() {
-		return annotationMetaEntity;
 	}
 }

--- a/tooling/metamodel-generator/src/main/java/org/hibernate/jpamodelgen/annotation/IdFinderMethod.java
+++ b/tooling/metamodel-generator/src/main/java/org/hibernate/jpamodelgen/annotation/IdFinderMethod.java
@@ -54,6 +54,8 @@ public class IdFinderMethod implements MetaAttribute {
 
 	@Override
 	public String getAttributeDeclarationString() {
+		final boolean usingEntityManager = Constants.ENTITY_MANAGER.equals(sessionType);
+
 		StringBuilder declaration = new StringBuilder();
 		declaration
 				.append("\n/**\n * @see ")
@@ -99,7 +101,7 @@ public class IdFinderMethod implements MetaAttribute {
 					.append("\n}");
 		}
 		else {
-			if ( Constants.ENTITY_MANAGER.equals(sessionType) ) {
+			if ( usingEntityManager ) {
 				declaration
 						.append(".unwrap(")
 						.append(annotationMetaEntity.importType(Constants.HIB_SESSION))

--- a/tooling/metamodel-generator/src/main/java/org/hibernate/jpamodelgen/annotation/IdFinderMethod.java
+++ b/tooling/metamodel-generator/src/main/java/org/hibernate/jpamodelgen/annotation/IdFinderMethod.java
@@ -25,11 +25,17 @@ public class IdFinderMethod extends AbstractFinderMethod {
 			String paramName, String paramType,
 			boolean belongsToDao,
 			String sessionType,
-			List<String> fetchProfiles) {
+			List<String> fetchProfiles,
+			boolean addNonnullAnnotation) {
 		super( annotationMetaEntity, methodName, entity, belongsToDao, sessionType, fetchProfiles,
-				List.of(paramName), List.of(paramType) );
+				List.of(paramName), List.of(paramType), addNonnullAnnotation );
 		this.paramName = paramName;
 		usingStatelessSession = Constants.HIB_STATELESS_SESSION.equals(sessionType);
+	}
+
+	@Override
+	boolean isId() {
+		return true;
 	}
 
 	@Override

--- a/tooling/metamodel-generator/src/main/java/org/hibernate/jpamodelgen/annotation/NameMetaAttribute.java
+++ b/tooling/metamodel-generator/src/main/java/org/hibernate/jpamodelgen/annotation/NameMetaAttribute.java
@@ -8,7 +8,8 @@ package org.hibernate.jpamodelgen.annotation;
 
 import org.hibernate.jpamodelgen.model.MetaAttribute;
 import org.hibernate.jpamodelgen.model.Metamodel;
-import org.hibernate.jpamodelgen.util.StringUtil;
+
+import static org.hibernate.jpamodelgen.util.StringUtil.nameToFieldName;
 
 /**
  * @author Gavin King
@@ -46,13 +47,17 @@ class NameMetaAttribute implements MetaAttribute {
 				.append(annotationMetaEntity.importType(String.class.getName()))
 				.append(" ")
 				.append(prefix)
-				.append(StringUtil.nameToFieldName(name))
+				.append(fieldName())
 				.append(" = ")
 				.append("\"")
 				.append(name)
 				.append("\"")
 				.append(";")
 				.toString();
+	}
+
+	private String fieldName() {
+		return nameToFieldName(name.charAt(0) == '#' ? name.substring(1) : name);
 	}
 
 	@Override

--- a/tooling/metamodel-generator/src/main/java/org/hibernate/jpamodelgen/annotation/NamedQueryMethod.java
+++ b/tooling/metamodel-generator/src/main/java/org/hibernate/jpamodelgen/annotation/NamedQueryMethod.java
@@ -1,0 +1,201 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.jpamodelgen.annotation;
+
+import org.checkerframework.checker.nullness.qual.Nullable;
+import org.hibernate.jpamodelgen.model.MetaAttribute;
+import org.hibernate.jpamodelgen.model.Metamodel;
+import org.hibernate.jpamodelgen.util.Constants;
+import org.hibernate.query.sqm.SqmExpressible;
+import org.hibernate.query.sqm.tree.expression.SqmParameter;
+import org.hibernate.query.sqm.tree.select.SqmSelectStatement;
+import org.hibernate.query.sqm.tree.select.SqmSelectableNode;
+import org.hibernate.type.descriptor.java.JavaType;
+
+import javax.lang.model.element.ModuleElement;
+import javax.lang.model.element.TypeElement;
+import java.util.List;
+import java.util.TreeSet;
+
+import static org.hibernate.jpamodelgen.util.StringUtil.nameToFieldName;
+import static org.hibernate.jpamodelgen.validation.ProcessorSessionFactory.findEntityByUnqualifiedName;
+
+/**
+ * @author Gavin King
+ */
+class NamedQueryMethod implements MetaAttribute {
+	private final AnnotationMeta annotationMeta;
+	private final SqmSelectStatement<?> select;
+	private final String name;
+	private final boolean belongsToDao;
+
+	public NamedQueryMethod(AnnotationMeta annotationMeta, SqmSelectStatement<?> select, String name, boolean belongsToDao) {
+		this.annotationMeta = annotationMeta;
+		this.select = select;
+		this.name = name;
+		this.belongsToDao = belongsToDao;
+	}
+
+	@Override
+	public boolean hasTypedAttribute() {
+		return true;
+	}
+
+	@Override
+	public boolean hasStringAttribute() {
+		return false;
+	}
+
+	@Override
+	public String getAttributeDeclarationString() {
+		final TreeSet<SqmParameter<?>> sortedParameters =
+				new TreeSet<>( select.getSqmParameters() );
+		final String returnType = returnType();
+		StringBuilder declaration = new StringBuilder();
+		comment( declaration );
+		modifiers( declaration );
+		returnType( returnType, declaration );
+		parameters( sortedParameters, declaration );
+		declaration
+				.append(" {")
+				.append("\n\treturn entityManager.createNamedQuery(")
+				.append(fieldName())
+				.append(")");
+		for ( SqmParameter<?> param : sortedParameters ) {
+			declaration
+					.append("\n\t\t\t.setParameter(")
+					.append(param.getName() == null ? param.getPosition() : '"' + param.getName() + '"')
+					.append(", ")
+					.append(param.getName() == null ? "parameter" + param.getPosition() : param.getName())
+					.append(')');
+		}
+		declaration
+				.append("\n\t\t\t.getResultList();\n}");
+		return declaration.toString();
+	}
+
+	private String fieldName() {
+		return "QUERY_" + nameToFieldName(name);
+	}
+
+	private String returnType() {
+		final JavaType<?> javaType = select.getSelection().getJavaTypeDescriptor();
+		if ( javaType != null ) {
+			return javaType.getTypeName();
+		}
+		else {
+			final List<SqmSelectableNode<?>> items =
+					select.getQuerySpec().getSelectClause().getSelectionItems();
+			if ( items.size() == 1 ) {
+				final String typeName = items.get(0).getExpressible().getTypeName();
+				final TypeElement entityType = entityType( typeName );
+				return entityType == null ? typeName : entityType.getQualifiedName().toString();
+
+			}
+			else {
+				return "Object[]";
+			}
+		}
+	}
+
+	private void comment(StringBuilder declaration) {
+		declaration
+				.append("\n/**\n * Executes named query {@value #")
+				.append(fieldName())
+				.append("} defined by annotation of {@link ")
+				.append(annotationMeta.getSimpleName())
+				.append("}.\n **/\n");
+	}
+
+	private void modifiers(StringBuilder declaration) {
+		declaration
+				.append(belongsToDao ? "public " : "public static ");
+	}
+
+	private void returnType(String returnType, StringBuilder declaration) {
+		declaration
+				.append(annotationMeta.importType(Constants.LIST))
+				.append('<')
+				.append(annotationMeta.importType(returnType))
+				.append("> ")
+				.append(name);
+	}
+
+	private void parameters(TreeSet<SqmParameter<?>> sortedParameters, StringBuilder declaration) {
+		declaration
+				.append('(');
+		if ( !belongsToDao ) {
+			declaration
+					.append(annotationMeta.importType(Constants.ENTITY_MANAGER))
+					.append(" entityManager");
+		}
+		int i = 0;
+		for ( SqmParameter<?> param : sortedParameters) {
+			if ( 0 < i++ || !belongsToDao ) {
+				declaration
+						.append(", ");
+			}
+			declaration
+					.append(parameterType(param))
+					.append(" ")
+					.append(parameterName(param));
+		}
+		declaration
+				.append(')');
+	}
+
+	private static String parameterName(SqmParameter<?> param) {
+		return param.getName() == null ? "parameter" + param.getPosition() : param.getName();
+	}
+
+	private String parameterType(SqmParameter<?> param) {
+		final SqmExpressible<?> expressible = param.getExpressible();
+		final String paramType = expressible == null ? "unknown" : expressible.getTypeName(); //getTypeName() can return "unknown"
+		return "unknown".equals(paramType) ? "Object" : annotationMeta.importType(paramType);
+	}
+
+	private @Nullable TypeElement entityType(String entityName) {
+		TypeElement symbol =
+				findEntityByUnqualifiedName( entityName,
+						annotationMeta.getContext().getElementUtils().getModuleElement("") );
+		if ( symbol != null ) {
+			return symbol;
+		}
+		for ( ModuleElement module : annotationMeta.getContext().getElementUtils().getAllModuleElements() ) {
+			symbol = findEntityByUnqualifiedName( entityName, module );
+			if ( symbol != null ) {
+				return symbol;
+			}
+		}
+		return null;
+	}
+
+	@Override
+	public String getAttributeNameDeclarationString() {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public String getMetaType() {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public String getPropertyName() {
+		return name;
+	}
+
+	@Override
+	public String getTypeDeclaration() {
+		return Constants.LIST;
+	}
+
+	@Override
+	public Metamodel getHostingEntity() {
+		return annotationMeta;
+	}
+}

--- a/tooling/metamodel-generator/src/main/java/org/hibernate/jpamodelgen/annotation/NaturalIdFinderMethod.java
+++ b/tooling/metamodel-generator/src/main/java/org/hibernate/jpamodelgen/annotation/NaturalIdFinderMethod.java
@@ -23,13 +23,15 @@ public class NaturalIdFinderMethod implements MetaAttribute {
 	private final List<String> paramTypes;
 	private final boolean belongsToDao;
 	private final String sessionType;
+	private final List<String> fetchProfiles;
 
 	public NaturalIdFinderMethod(
 			Metamodel annotationMetaEntity,
 			String methodName, String entity,
 			List<String> paramNames, List<String> paramTypes,
 			boolean belongsToDao,
-			String sessionType) {
+			String sessionType,
+			List<String> fetchProfiles) {
 		this.annotationMetaEntity = annotationMetaEntity;
 		this.methodName = methodName;
 		this.entity = entity;
@@ -37,6 +39,7 @@ public class NaturalIdFinderMethod implements MetaAttribute {
 		this.paramTypes = paramTypes;
 		this.belongsToDao = belongsToDao;
 		this.sessionType = sessionType;
+		this.fetchProfiles = fetchProfiles;
 	}
 
 	@Override
@@ -111,6 +114,12 @@ public class NaturalIdFinderMethod implements MetaAttribute {
 					.append(paramNames.get(i))
 					.append(", ")
 					.append(paramNames.get(i))
+					.append(")");
+		}
+		for ( String profile : fetchProfiles ) {
+			declaration
+					.append("\n\t\t\t.enableFetchProfile(")
+					.append(profile)
 					.append(")");
 		}
 		declaration

--- a/tooling/metamodel-generator/src/main/java/org/hibernate/jpamodelgen/annotation/NaturalIdFinderMethod.java
+++ b/tooling/metamodel-generator/src/main/java/org/hibernate/jpamodelgen/annotation/NaturalIdFinderMethod.java
@@ -6,24 +6,14 @@
  */
 package org.hibernate.jpamodelgen.annotation;
 
-import org.hibernate.jpamodelgen.model.MetaAttribute;
 import org.hibernate.jpamodelgen.model.Metamodel;
-import org.hibernate.jpamodelgen.util.Constants;
 
 import java.util.List;
 
 /**
  * @author Gavin King
  */
-public class NaturalIdFinderMethod implements MetaAttribute {
-	private final Metamodel annotationMetaEntity;
-	private final String methodName;
-	private final String entity;
-	private final List<String> paramNames;
-	private final List<String> paramTypes;
-	private final boolean belongsToDao;
-	private final String sessionType;
-	private final List<String> fetchProfiles;
+public class NaturalIdFinderMethod extends AbstractFinderMethod {
 
 	public NaturalIdFinderMethod(
 			Metamodel annotationMetaEntity,
@@ -32,94 +22,30 @@ public class NaturalIdFinderMethod implements MetaAttribute {
 			boolean belongsToDao,
 			String sessionType,
 			List<String> fetchProfiles) {
-		this.annotationMetaEntity = annotationMetaEntity;
-		this.methodName = methodName;
-		this.entity = entity;
-		this.paramNames = paramNames;
-		this.paramTypes = paramTypes;
-		this.belongsToDao = belongsToDao;
-		this.sessionType = sessionType;
-		this.fetchProfiles = fetchProfiles;
-	}
-
-	@Override
-	public boolean hasTypedAttribute() {
-		return true;
-	}
-
-	@Override
-	public boolean hasStringAttribute() {
-		return false;
+		super( annotationMetaEntity, methodName, entity, belongsToDao, sessionType, fetchProfiles,
+				paramNames, paramTypes );
 	}
 
 	@Override
 	public String getAttributeDeclarationString() {
-		StringBuilder declaration = new StringBuilder();
-		declaration
-				.append("\n/**\n * @see ")
-				.append(annotationMetaEntity.getQualifiedName())
-				.append("#")
-				.append(methodName)
-				.append("(")
-				.append(parameterList())
-				.append(")")
-				.append("\n **/\n");
-		if ( belongsToDao ) {
-			declaration
-					.append("@Override\npublic ");
-		}
-		else {
-			declaration
-					.append("public static ");
-		}
-		declaration
-				.append(annotationMetaEntity.importType(entity));
-		declaration
-				.append(" ")
-				.append(methodName)
-				.append("(");
-		if ( !belongsToDao ) {
-			declaration
-					.append(annotationMetaEntity.importType(Constants.ENTITY_MANAGER))
-					.append(" entityManager");
-		}
-		for ( int i = 0; i < paramNames.size(); i ++ ) {
-			if ( !belongsToDao || i > 0 ) {
-				declaration
-						.append(", ");
-			}
-			declaration
-					.append(annotationMetaEntity.importType(paramTypes.get(i)))
-					.append(" ")
-					.append(paramNames.get(i));
-		}
-		declaration
-				.append(") {")
-				.append("\n\treturn entityManager");
-		if ( Constants.ENTITY_MANAGER.equals(sessionType) ) {
-			declaration
-					.append(".unwrap(")
-					.append(annotationMetaEntity.importType(Constants.HIB_SESSION))
-					.append(".class)\n\t\t\t");
-		}
+		final StringBuilder declaration = new StringBuilder();
+		comment( declaration );
+		preamble( declaration );
+		unwrapSession( declaration );
 		declaration
 				.append(".byNaturalId(")
 				.append(annotationMetaEntity.importType(entity))
 				.append(".class)");
+		enableFetchProfile( declaration );
 		for ( int i = 0; i < paramNames.size(); i ++ ) {
+			final String paramName = paramNames.get(i);
 			declaration
 					.append("\n\t\t\t.using(")
-					.append(annotationMetaEntity.importType(entity+'_'))
+					.append(annotationMetaEntity.importType(entity + '_'))
 					.append('.')
-					.append(paramNames.get(i))
+					.append(paramName)
 					.append(", ")
-					.append(paramNames.get(i))
-					.append(")");
-		}
-		for ( String profile : fetchProfiles ) {
-			declaration
-					.append("\n\t\t\t.enableFetchProfile(")
-					.append(profile)
+					.append(paramName)
 					.append(")");
 		}
 		declaration
@@ -127,42 +53,4 @@ public class NaturalIdFinderMethod implements MetaAttribute {
 		return declaration.toString();
 	}
 
-	private String parameterList() {
-		return paramTypes.stream()
-				.map(this::strip)
-				.map(annotationMetaEntity::importType)
-				.reduce((x, y) -> x + y)
-				.orElse("");
-	}
-
-	private String strip(String type) {
-		int index = type.indexOf("<");
-		String stripped = index > 0 ? type.substring(0, index) : type;
-		return type.endsWith("...") ? stripped + "..." : stripped;
-	}
-
-	@Override
-	public String getAttributeNameDeclarationString() {
-		throw new UnsupportedOperationException();
-	}
-
-	@Override
-	public String getMetaType() {
-		throw new UnsupportedOperationException();
-	}
-
-	@Override
-	public String getPropertyName() {
-		return methodName;
-	}
-
-	@Override
-	public String getTypeDeclaration() {
-		return entity;
-	}
-
-	@Override
-	public Metamodel getHostingEntity() {
-		return annotationMetaEntity;
-	}
 }

--- a/tooling/metamodel-generator/src/main/java/org/hibernate/jpamodelgen/annotation/NaturalIdFinderMethod.java
+++ b/tooling/metamodel-generator/src/main/java/org/hibernate/jpamodelgen/annotation/NaturalIdFinderMethod.java
@@ -21,9 +21,16 @@ public class NaturalIdFinderMethod extends AbstractFinderMethod {
 			List<String> paramNames, List<String> paramTypes,
 			boolean belongsToDao,
 			String sessionType,
-			List<String> fetchProfiles) {
+			List<String> fetchProfiles,
+			boolean addNonnullAnnotation) {
 		super( annotationMetaEntity, methodName, entity, belongsToDao, sessionType, fetchProfiles,
-				paramNames, paramTypes );
+				paramNames, paramTypes, addNonnullAnnotation );
+	}
+
+	@Override
+	boolean isId() {
+		// natural ids can be null
+		return false;
 	}
 
 	@Override

--- a/tooling/metamodel-generator/src/main/java/org/hibernate/jpamodelgen/annotation/ProcessLaterException.java
+++ b/tooling/metamodel-generator/src/main/java/org/hibernate/jpamodelgen/annotation/ProcessLaterException.java
@@ -1,0 +1,10 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.jpamodelgen.annotation;
+
+public class ProcessLaterException extends RuntimeException {
+}

--- a/tooling/metamodel-generator/src/main/java/org/hibernate/jpamodelgen/annotation/QueryMethod.java
+++ b/tooling/metamodel-generator/src/main/java/org/hibernate/jpamodelgen/annotation/QueryMethod.java
@@ -33,6 +33,7 @@ public class QueryMethod implements MetaAttribute {
 	private final boolean isNative;
 	private final boolean belongsToDao;
 	final boolean usingEntityManager;
+	private final boolean addNonnullAnnotation;
 
 	public QueryMethod(
 			Metamodel annotationMetaEntity,
@@ -46,7 +47,8 @@ public class QueryMethod implements MetaAttribute {
 			List<String> paramTypes,
 			boolean isNative,
 			boolean belongsToDao,
-			String sessionType) {
+			String sessionType,
+			boolean addNonnullAnnotation) {
 		this.annotationMetaEntity = annotationMetaEntity;
 		this.methodName = methodName;
 		this.queryString = queryString;
@@ -56,7 +58,8 @@ public class QueryMethod implements MetaAttribute {
 		this.paramTypes = paramTypes;
 		this.isNative = isNative;
 		this.belongsToDao = belongsToDao;
-		usingEntityManager = Constants.ENTITY_MANAGER.equals(sessionType);
+		this.usingEntityManager = Constants.ENTITY_MANAGER.equals(sessionType);
+		this.addNonnullAnnotation = addNonnullAnnotation;
 	}
 
 	@Override
@@ -177,6 +180,7 @@ public class QueryMethod implements MetaAttribute {
 	private void parameters(List<String> paramTypes, StringBuilder declaration) {
 		declaration.append("(");
 		if ( !belongsToDao ) {
+			notNull( declaration );
 			declaration
 					.append(annotationMetaEntity.importType(Constants.ENTITY_MANAGER))
 					.append(" entityManager");
@@ -313,6 +317,15 @@ public class QueryMethod implements MetaAttribute {
 							.map(StringHelper::unqualify)
 							.reduce((x,y) -> x + '_' + y)
 							.orElse("");
+		}
+	}
+
+	private void notNull(StringBuilder declaration) {
+		if ( addNonnullAnnotation ) {
+			declaration
+					.append('@')
+					.append(annotationMetaEntity.importType("jakarta.annotation.Nonnull"))
+					.append(' ');
 		}
 	}
 

--- a/tooling/metamodel-generator/src/main/java/org/hibernate/jpamodelgen/annotation/QueryMethod.java
+++ b/tooling/metamodel-generator/src/main/java/org/hibernate/jpamodelgen/annotation/QueryMethod.java
@@ -138,7 +138,7 @@ public class QueryMethod implements MetaAttribute {
 				if ( paramType.endsWith("...") ) {
 					declaration
 							.append("\n\t\t\t.setOrder(")
-							.append(annotationMetaEntity.importType(List.class.getName()))
+							.append(annotationMetaEntity.importType(Constants.LIST))
 							.append(".of(")
 							.append(paramName)
 							.append("))");

--- a/tooling/metamodel-generator/src/main/java/org/hibernate/jpamodelgen/model/Metamodel.java
+++ b/tooling/metamodel-generator/src/main/java/org/hibernate/jpamodelgen/model/Metamodel.java
@@ -36,4 +36,6 @@ public interface Metamodel extends ImportContext {
 	Context getContext();
 
 	boolean isImplementation();
+
+	boolean isInjectable();
 }

--- a/tooling/metamodel-generator/src/main/java/org/hibernate/jpamodelgen/util/TypeUtils.java
+++ b/tooling/metamodel-generator/src/main/java/org/hibernate/jpamodelgen/util/TypeUtils.java
@@ -214,7 +214,7 @@ public final class TypeUtils {
 		assert parameterValue != null;
 		for ( Map.Entry<? extends ExecutableElement, ? extends AnnotationValue> entry
 				: annotationMirror.getElementValues().entrySet() ) {
-			if ( parameterValue.equals( entry.getKey().getSimpleName().toString() ) ) {
+			if ( entry.getKey().getSimpleName().contentEquals( parameterValue ) ) {
 				return entry.getValue().getValue();
 			}
 		}

--- a/tooling/metamodel-generator/src/main/java/org/hibernate/jpamodelgen/util/TypeUtils.java
+++ b/tooling/metamodel-generator/src/main/java/org/hibernate/jpamodelgen/util/TypeUtils.java
@@ -221,6 +221,18 @@ public final class TypeUtils {
 		return null;
 	}
 
+	public static @Nullable AnnotationValue getAnnotationValueRef(AnnotationMirror annotationMirror, String parameterValue) {
+		assert annotationMirror != null;
+		assert parameterValue != null;
+		for ( Map.Entry<? extends ExecutableElement, ? extends AnnotationValue> entry
+				: annotationMirror.getElementValues().entrySet() ) {
+			if ( entry.getKey().getSimpleName().contentEquals( parameterValue ) ) {
+				return entry.getValue();
+			}
+		}
+		return null;
+	}
+
 	public static void determineAccessTypeForHierarchy(TypeElement searchedElement, Context context) {
 		final String fqcn = searchedElement.getQualifiedName().toString();
 		context.logMessage( Diagnostic.Kind.OTHER, "Determining access type for " + fqcn );

--- a/tooling/metamodel-generator/src/main/java/org/hibernate/jpamodelgen/xml/JpaDescriptorParser.java
+++ b/tooling/metamodel-generator/src/main/java/org/hibernate/jpamodelgen/xml/JpaDescriptorParser.java
@@ -58,7 +58,7 @@ public class JpaDescriptorParser {
 
 	public JpaDescriptorParser(Context context) {
 		this.context = context;
-		this.entityMappings = new ArrayList<EntityMappings>();
+		this.entityMappings = new ArrayList<>();
 		this.xmlParserHelper = new XmlParserHelper( context );
 	}
 
@@ -87,7 +87,7 @@ public class JpaDescriptorParser {
 	}
 
 	private Collection<String> determineMappingFileNames() {
-		Collection<String> mappingFileNames = new ArrayList<String>();
+		Collection<String> mappingFileNames = new ArrayList<>();
 
 		Persistence persistence = getPersistence();
 		if ( persistence != null ) {
@@ -227,10 +227,7 @@ public class JpaDescriptorParser {
 					}
 				}
 			}
-			catch (IOException e) {
-				//handled in the outer scope
-			}
-			catch (ClassNotFoundException e) {
+			catch (IOException|ClassNotFoundException e) {
 				//handled in the outer scope
 			}
 		}
@@ -436,12 +433,7 @@ public class JpaDescriptorParser {
 		for ( EntityMappings mappings : entityMappings ) {
 			PersistenceUnitMetadata meta = mappings.getPersistenceUnitMetadata();
 			if ( meta != null ) {
-				if ( meta.getXmlMappingMetadataComplete() != null ) {
-					context.mappingDocumentFullyXmlConfigured( true );
-				}
-				else {
-					context.mappingDocumentFullyXmlConfigured( false );
-				}
+				context.mappingDocumentFullyXmlConfigured( meta.getXmlMappingMetadataComplete() != null );
 
 				PersistenceUnitDefaults persistenceUnitDefaults = meta.getPersistenceUnitDefaults();
 				if ( persistenceUnitDefaults != null ) {

--- a/tooling/metamodel-generator/src/main/java/org/hibernate/jpamodelgen/xml/XmlMetaEntity.java
+++ b/tooling/metamodel-generator/src/main/java/org/hibernate/jpamodelgen/xml/XmlMetaEntity.java
@@ -622,4 +622,9 @@ public class XmlMetaEntity implements Metamodel {
 	public boolean isImplementation() {
 		return false;
 	}
+
+	@Override
+	public boolean isInjectable() {
+		return false;
+	}
 }

--- a/tooling/metamodel-generator/src/test/java/org/hibernate/jpamodelgen/test/dao/Dao.java
+++ b/tooling/metamodel-generator/src/test/java/org/hibernate/jpamodelgen/test/dao/Dao.java
@@ -16,6 +16,9 @@ public interface Dao {
     @Find
     Book getBook(String isbn);
 
+    @Find(enabledFetchProfiles="Goodbye")
+    Book getBookFetching(String isbn);
+
     @Find
     Book getBook(String title, String author);
 

--- a/tooling/metamodel-generator/src/test/java/org/hibernate/jpamodelgen/test/dao/Dao.java
+++ b/tooling/metamodel-generator/src/test/java/org/hibernate/jpamodelgen/test/dao/Dao.java
@@ -19,11 +19,17 @@ public interface Dao {
     @Find
     Book getBook(String title, String author);
 
+    @Find(enabledFetchProfiles="Hello")
+    Book getBookFetching(String title, String author);
+
     @Find
     Book getBook(String title, String isbn, String author);
 
     @Find
     List<Book> getBooks(String title);
+
+    @Find(enabledFetchProfiles="Hello")
+    List<Book> getBooksFetching(String title);
 
     @Find
     SelectionQuery<Book> createBooksSelectionQuery(String title);

--- a/tooling/metamodel-generator/src/test/java/org/hibernate/jpamodelgen/test/dao/StatefulDao.java
+++ b/tooling/metamodel-generator/src/test/java/org/hibernate/jpamodelgen/test/dao/StatefulDao.java
@@ -16,14 +16,23 @@ public interface StatefulDao {
     @Find
     Book getBook(String isbn);
 
+    @Find(enabledFetchProfiles="Goodbye")
+    Book getBookFetching(String isbn);
+
     @Find
     Book getBook(String title, String author);
+
+    @Find(enabledFetchProfiles="Hello")
+    Book getBookFetching(String title, String author);
 
     @Find
     Book getBook(String title, String isbn, String author);
 
     @Find
     List<Book> getBooks(String title);
+
+    @Find(enabledFetchProfiles="Hello")
+    List<Book> getBooksFetching(String title);
 
     @Find
     SelectionQuery<Book> createBooksSelectionQuery(String title);

--- a/tooling/metamodel-generator/src/test/java/org/hibernate/jpamodelgen/test/dao/StatelessDao.java
+++ b/tooling/metamodel-generator/src/test/java/org/hibernate/jpamodelgen/test/dao/StatelessDao.java
@@ -16,14 +16,23 @@ public interface StatelessDao {
     @Find
     Book getBook(String isbn);
 
+    @Find(enabledFetchProfiles="Goodbye")
+    Book getBookFetching(String isbn);
+
     @Find
     Book getBook(String title, String author);
+
+    @Find(enabledFetchProfiles="Hello")
+    Book getBookFetching(String title, String author);
 
     @Find
     Book getBook(String title, String isbn, String author);
 
     @Find
     List<Book> getBooks(String title);
+
+    @Find(enabledFetchProfiles="Hello")
+    List<Book> getBooksFetching(String title);
 
     @Find
     SelectionQuery<Book> createBooksSelectionQuery(String title);

--- a/tooling/metamodel-generator/src/test/java/org/hibernate/jpamodelgen/test/hqlsql/QueryMethodTest.java
+++ b/tooling/metamodel-generator/src/test/java/org/hibernate/jpamodelgen/test/hqlsql/QueryMethodTest.java
@@ -19,7 +19,7 @@ import static org.hibernate.jpamodelgen.test.util.TestUtil.assertMetamodelClassG
 public class QueryMethodTest extends CompilationTest {
 	@Test
 	@WithClasses({ Book.class, Dao.class })
-	public void testGeneratedAnnotationNotGenerated() {
+	public void testQueryMethod() {
 		System.out.println( TestUtil.getMetaModelSourceAsString( Dao.class ) );
 		assertMetamodelClassGeneratedFor( Book.class );
 		assertMetamodelClassGeneratedFor( Dao.class );

--- a/tooling/metamodel-generator/src/test/java/org/hibernate/jpamodelgen/test/namedquery/AuxiliaryTest.java
+++ b/tooling/metamodel-generator/src/test/java/org/hibernate/jpamodelgen/test/namedquery/AuxiliaryTest.java
@@ -6,12 +6,14 @@
  */
 package org.hibernate.jpamodelgen.test.namedquery;
 
+import jakarta.persistence.EntityManager;
 import org.hibernate.jpamodelgen.test.util.CompilationTest;
 import org.hibernate.jpamodelgen.test.util.TestUtil;
 import org.hibernate.jpamodelgen.test.util.WithClasses;
 import org.junit.Test;
 
 import static org.hibernate.jpamodelgen.test.util.TestUtil.assertMetamodelClassGeneratedFor;
+import static org.hibernate.jpamodelgen.test.util.TestUtil.assertPresenceOfMethodInMetamodelFor;
 import static org.hibernate.jpamodelgen.test.util.TestUtil.assertPresenceOfNameFieldInMetamodelFor;
 
 /**
@@ -20,8 +22,9 @@ import static org.hibernate.jpamodelgen.test.util.TestUtil.assertPresenceOfNameF
 public class AuxiliaryTest extends CompilationTest {
 	@Test
 	@WithClasses({ Book.class, Main.class })
-	public void testGeneratedAnnotationNotGenerated() {
+	public void test() {
 		System.out.println( TestUtil.getMetaModelSourceAsString( Main.class ) );
+		System.out.println( TestUtil.getMetaModelSourceAsString( Book.class ) );
 		assertMetamodelClassGeneratedFor( Book.class );
 		assertMetamodelClassGeneratedFor( Main.class );
 		assertPresenceOfNameFieldInMetamodelFor(
@@ -74,10 +77,59 @@ public class AuxiliaryTest extends CompilationTest {
 				"QUERY__SYSDATE_",
 				"Missing fetch profile attribute."
 		);
+		assertPresenceOfMethodInMetamodelFor(
+				Main.class,
+				"bookByIsbn",
+				EntityManager.class,
+				String.class
+		);
+		assertPresenceOfMethodInMetamodelFor(
+				Main.class,
+				"bookByTitle",
+				EntityManager.class,
+				String.class
+		);
+
 		assertPresenceOfNameFieldInMetamodelFor(
 				Book.class,
 				"GRAPH_ENTITY_GRAPH",
 				"Missing fetch profile attribute."
+		);
+		assertPresenceOfMethodInMetamodelFor(
+				Book.class,
+				"findByTitle",
+				EntityManager.class,
+				String.class
+		);
+		assertPresenceOfMethodInMetamodelFor(
+				Book.class,
+				"findByTitleAndType",
+				EntityManager.class,
+				String.class,
+				Type.class
+		);
+		assertPresenceOfMethodInMetamodelFor(
+				Book.class,
+				"getTitles",
+				EntityManager.class
+		);
+		assertPresenceOfMethodInMetamodelFor(
+				Book.class,
+				"getUpperLowerTitles",
+				EntityManager.class
+		);
+		assertPresenceOfMethodInMetamodelFor(
+				Book.class,
+				"typeOfBook",
+				EntityManager.class,
+				String.class
+		);
+		assertPresenceOfMethodInMetamodelFor(
+				Book.class,
+				"crazy",
+				EntityManager.class,
+				Object.class,
+				Object.class
 		);
 	}
 }

--- a/tooling/metamodel-generator/src/test/java/org/hibernate/jpamodelgen/test/namedquery/Book.java
+++ b/tooling/metamodel-generator/src/test/java/org/hibernate/jpamodelgen/test/namedquery/Book.java
@@ -3,11 +3,25 @@ package org.hibernate.jpamodelgen.test.namedquery;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jakarta.persistence.NamedEntityGraph;
+import jakarta.persistence.NamedQuery;
 
 @Entity
 @NamedEntityGraph(name = "entityGraph")
+@NamedQuery(name = "#findByTitle",
+        query = "from Book where title like :titlePattern")
+@NamedQuery(name = "#findByTitleAndType",
+        query = "select book from Book book where book.title like :titlePattern and book.type = :type")
+@NamedQuery(name = "#getTitles",
+        query = "select title from Book")
+@NamedQuery(name = "#getUpperLowerTitles",
+        query = "select upper(title), lower(title), length(title) from Book")
+@NamedQuery(name = "#typeOfBook",
+        query = "select type from Book where isbn = :isbn")
+@NamedQuery(name = "#crazy",
+        query = "select 1 where :x = :y")
 public class Book {
     @Id String isbn;
     String title;
     String text;
+    Type type = Type.Book;
 }

--- a/tooling/metamodel-generator/src/test/java/org/hibernate/jpamodelgen/test/namedquery/Main.java
+++ b/tooling/metamodel-generator/src/test/java/org/hibernate/jpamodelgen/test/namedquery/Main.java
@@ -9,8 +9,8 @@ import jakarta.persistence.SqlResultSetMappings;
 import org.hibernate.annotations.FetchProfile;
 import org.hibernate.annotations.FetchProfiles;
 
-@NamedQueries(@NamedQuery(name = "bookByIsbn", query = "from Book where isbn = :isbn"))
-@NamedQuery(name = "bookByTitle", query = "from Book where title = :title")
+@NamedQueries(@NamedQuery(name = "#bookByIsbn", query = "from Book where isbn = :isbn"))
+@NamedQuery(name = "#bookByTitle", query = "from Book where title = :title")
 @FetchProfile(name = "dummy-fetch")
 @FetchProfiles({@FetchProfile(name = "fetch.one"), @FetchProfile(name = "fetch#two")})
 @NamedNativeQuery(name = "bookNativeQuery", query = "select * from Book")

--- a/tooling/metamodel-generator/src/test/java/org/hibernate/jpamodelgen/test/namedquery/Type.java
+++ b/tooling/metamodel-generator/src/test/java/org/hibernate/jpamodelgen/test/namedquery/Type.java
@@ -1,0 +1,3 @@
+package org.hibernate.jpamodelgen.test.namedquery;
+
+enum Type {Book, Magazine, Journal}

--- a/tooling/metamodel-generator/src/test/java/org/hibernate/jpamodelgen/test/util/TestUtil.java
+++ b/tooling/metamodel-generator/src/test/java/org/hibernate/jpamodelgen/test/util/TestUtil.java
@@ -13,6 +13,7 @@ import java.io.FileReader;
 import java.io.IOException;
 import java.lang.reflect.Field;
 import java.lang.reflect.GenericArrayType;
+import java.lang.reflect.Method;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.net.URL;
@@ -78,8 +79,21 @@ public class TestUtil {
 		);
 	}
 
+	public static void assertPresenceOfMethodInMetamodelFor(Class<?> clazz, String methodName, Class<?>... params) {
+		assertPresenceOfMethodInMetamodelFor(
+				clazz,
+				methodName,
+				"'" + methodName + "' should appear in metamodel class",
+				params
+		);
+	}
+
 	public static void assertPresenceOfFieldInMetamodelFor(Class<?> clazz, String fieldName, String errorString) {
 		assertTrue( buildErrorString( errorString, clazz ), hasFieldInMetamodelFor( clazz, fieldName ) );
+	}
+
+	public static void assertPresenceOfMethodInMetamodelFor(Class<?> clazz, String fieldName, String errorString, Class<?>... params) {
+		assertTrue( buildErrorString( errorString, clazz ), hasMethodInMetamodelFor( clazz, fieldName, params ) );
 	}
 
 	public static void assertPresenceOfNameFieldInMetamodelFor(Class<?> clazz, String fieldName, String errorString) {
@@ -254,14 +268,22 @@ public class TestUtil {
 
 	public static Field getFieldFromMetamodelFor(Class<?> entityClass, String fieldName) {
 		Class<?> metaModelClass = getMetamodelClassFor( entityClass );
-		Field field;
 		try {
-			field = metaModelClass.getDeclaredField( fieldName );
+			return metaModelClass.getDeclaredField( fieldName );
 		}
 		catch ( NoSuchFieldException e ) {
-			field = null;
+			return null;
 		}
-		return field;
+	}
+
+	public static Method getMethodFromMetamodelFor(Class<?> entityClass, String methodName, Class<?>... params) {
+		Class<?> metaModelClass = getMetamodelClassFor( entityClass );
+		try {
+			return metaModelClass.getDeclaredMethod( methodName, params );
+		}
+		catch ( NoSuchMethodException e ) {
+			return null;
+		}
 	}
 
 	public static String fcnToPath(String fcn) {
@@ -270,6 +292,10 @@ public class TestUtil {
 
 	private static boolean hasFieldInMetamodelFor(Class<?> clazz, String fieldName) {
 		return getFieldFromMetamodelFor( clazz, fieldName ) != null;
+	}
+
+	private static boolean hasMethodInMetamodelFor(Class<?> clazz, String fieldName, Class<?>... params) {
+		return getMethodFromMetamodelFor( clazz, fieldName, params ) != null;
 	}
 
 	private static String buildErrorString(String baseError, Class<?> clazz) {


### PR DESCRIPTION
This set of changes adds:

1. `enableFetchProfile()` you `SelectionQuery` and `XxxxLoadAccess`.
2. Support for setting `EntityGraph`s on `(Simple)NaturalIdLoadAccess`.
3. `enabledFetchProfiles` to the `@Find` annotation.
4. Generation of query methods directing from `@NamedQuery` annotations without the need for a `@HQL` annotation.
5. Some polish to generated code for DAO-style query methods.