### PR TITLE
HHH-16633, HHH-16940 validate the return type of @HQL query methods

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/InstantiationException.java
+++ b/hibernate-core/src/main/java/org/hibernate/InstantiationException.java
@@ -27,7 +27,7 @@ public class InstantiationException extends HibernateException {
 	}
 
 	/**
-	 * Constructs a InstantiationException.
+	 * Constructs an {@code InstantiationException}.
 	 *
 	 * @param message A message explaining the exception condition
 	 * @param clazz The Class we are attempting to instantiate
@@ -37,7 +37,7 @@ public class InstantiationException extends HibernateException {
 	}
 
 	/**
-	 * Constructs a InstantiationException.
+	 * Constructs an {@code InstantiationException}.
 	 *
 	 * @param message A message explaining the exception condition
 	 * @param clazz The Class we are attempting to instantiate
@@ -49,7 +49,7 @@ public class InstantiationException extends HibernateException {
 	}
 
 	/**
-	 * Returns the Class we were attempting to instantiate.
+	 * Returns the {@link Class} we were attempting to instantiate.
 	 *
 	 * @return The class we are unable to instantiate
 	 */
@@ -59,7 +59,9 @@ public class InstantiationException extends HibernateException {
 
 	@Override
 	public String getMessage() {
-		return super.getMessage() + " '" + clazz.getName() + "'";
+		final String message = super.getMessage() + " '" + clazz.getName() + "'";
+		final Throwable cause = getCause();
+		return cause != null ? message + " due to: " + cause.getMessage() : message;
 	}
 
 }

--- a/hibernate-core/src/main/java/org/hibernate/PropertyAccessException.java
+++ b/hibernate-core/src/main/java/org/hibernate/PropertyAccessException.java
@@ -6,7 +6,7 @@
  */
 package org.hibernate;
 
-import org.hibernate.internal.util.StringHelper;
+import static org.hibernate.internal.util.StringHelper.qualify;
 
 /**
  * A problem occurred accessing a property of an instance of a
@@ -64,7 +64,7 @@ public class PropertyAccessException extends HibernateException {
 	@Override
 	public String getMessage() {
 		return originalMessage()
-				+ " : `" + StringHelper.qualify( persistentClass.getName(), propertyName )
-				+ ( wasSetter ? "` (setter)" : "` (getter)" );
+				+ ": '" + qualify( persistentClass.getName(), propertyName ) + "'"
+				+ ( wasSetter ? " (setter)" : " (getter)" );
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/jpa/spi/NativeQueryConstructorTransformer.java
+++ b/hibernate-core/src/main/java/org/hibernate/jpa/spi/NativeQueryConstructorTransformer.java
@@ -48,7 +48,7 @@ public class NativeQueryConstructorTransformer<T> implements TupleTransformer<T>
 				}
 			}
 			catch (Exception e) {
-				throw new InstantiationException( "Cannot instantiate query result type ", resultClass, e );
+				throw new InstantiationException( "Cannot instantiate query result type", resultClass, e );
 			}
 			if ( constructor == null ) {
 				throw new InstantiationException( "Result class must have a single constructor with exactly "

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/domain/AbstractSqmFrom.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/domain/AbstractSqmFrom.java
@@ -24,7 +24,6 @@ import org.hibernate.metamodel.model.domain.MapPersistentAttribute;
 import org.hibernate.metamodel.model.domain.PluralPersistentAttribute;
 import org.hibernate.metamodel.model.domain.SetPersistentAttribute;
 import org.hibernate.metamodel.model.domain.SingularPersistentAttribute;
-import org.hibernate.query.PathException;
 import org.hibernate.query.criteria.JpaCrossJoin;
 import org.hibernate.query.criteria.JpaCteCriteria;
 import org.hibernate.query.criteria.JpaDerivedJoin;

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/property/access/spi/GetterMethodImplTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/property/access/spi/GetterMethodImplTest.java
@@ -83,14 +83,14 @@ public class GetterMethodImplTest {
 		Getter runtimeException = getter( TargetThrowingExceptions.class, "runtimeException" );
 		assertThatThrownBy( () -> runtimeException.get( target ) )
 				.isInstanceOf( PropertyAccessException.class )
-				.hasMessage( "Exception occurred inside : `" + TargetThrowingExceptions.class.getName() +".runtimeException` (getter)" )
+				.hasMessage( "Exception occurred inside: '" + TargetThrowingExceptions.class.getName() +".runtimeException' (getter)" )
 				.getCause() // Not the root cause, the *direct* cause! We don't want extra wrapping.
 				.isExactlyInstanceOf( RuntimeException.class );
 
 		Getter checkedException = getter( TargetThrowingExceptions.class, "checkedException" );
 		assertThatThrownBy( () -> checkedException.get( target ) )
 				.isInstanceOf( PropertyAccessException.class )
-				.hasMessage( "Exception occurred inside : `" + TargetThrowingExceptions.class.getName() +".checkedException` (getter)" )
+				.hasMessage( "Exception occurred inside: '" + TargetThrowingExceptions.class.getName() +".checkedException' (getter)" )
 				.getCause() // Not the root cause, the *direct* cause! We don't want extra wrapping.
 				.isExactlyInstanceOf( Exception.class );
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/property/access/spi/SetterMethodImplTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/property/access/spi/SetterMethodImplTest.java
@@ -86,14 +86,14 @@ public class SetterMethodImplTest {
 		Setter runtimeException = setter( TargetThrowingExceptions.class, "runtimeException", String.class );
 		assertThatThrownBy( () -> runtimeException.set( target, "foo" ) )
 				.isInstanceOf( PropertyAccessException.class )
-				.hasMessage( "Exception occurred inside : `" + TargetThrowingExceptions.class.getName() +".runtimeException` (setter)" )
+				.hasMessage( "Exception occurred inside: '" + TargetThrowingExceptions.class.getName() +".runtimeException' (setter)" )
 				.getCause() // Not the root cause, the *direct* cause! We don't want extra wrapping.
 				.isExactlyInstanceOf( RuntimeException.class );
 
 		Setter checkedException = setter( TargetThrowingExceptions.class, "checkedException", String.class );
 		assertThatThrownBy( () -> checkedException.set( target, "foo" ) )
 				.isInstanceOf( PropertyAccessException.class )
-				.hasMessage( "Exception occurred inside : `" + TargetThrowingExceptions.class.getName() +".checkedException` (setter)" )
+				.hasMessage( "Exception occurred inside: '" + TargetThrowingExceptions.class.getName() +".checkedException' (setter)" )
 				.getCause() // Not the root cause, the *direct* cause! We don't want extra wrapping.
 				.isExactlyInstanceOf( Exception.class );
 

--- a/tooling/metamodel-generator/src/main/java/org/hibernate/jpamodelgen/JPAMetaModelEntityProcessor.java
+++ b/tooling/metamodel-generator/src/main/java/org/hibernate/jpamodelgen/JPAMetaModelEntityProcessor.java
@@ -187,7 +187,7 @@ public class JPAMetaModelEntityProcessor extends AbstractProcessor {
 			final TypeElement typeElement = context.getElementUtils().getTypeElement( elementName );
 			try {
 				final AnnotationMetaEntity metaEntity =
-						AnnotationMetaEntity.create( typeElement, context, false );
+						AnnotationMetaEntity.create( typeElement, context, false, false );
 				context.addMetaAuxiliary( metaEntity.getQualifiedName(), metaEntity );
 				context.removeElementToRedo( elementName );
 			}
@@ -212,7 +212,7 @@ public class JPAMetaModelEntityProcessor extends AbstractProcessor {
 							if ( containsAnnotation( member, HQL, SQL, FIND ) ) {
 								context.logMessage( Diagnostic.Kind.OTHER, "Processing annotated class '" + element + "'" );
 								final AnnotationMetaEntity metaEntity =
-										AnnotationMetaEntity.create( typeElement, context, false );
+										AnnotationMetaEntity.create( typeElement, context, false, false );
 								context.addMetaAuxiliary( metaEntity.getQualifiedName(), metaEntity );
 								break;
 							}
@@ -357,7 +357,7 @@ public class JPAMetaModelEntityProcessor extends AbstractProcessor {
 							= containsAnnotation( element, Constants.EMBEDDABLE )
 							|| containsAnnotation( element, Constants.MAPPED_SUPERCLASS );
 					final AnnotationMetaEntity metaEntity =
-							AnnotationMetaEntity.create( typeElement, context, requiresLazyMemberInitialization );
+							AnnotationMetaEntity.create( typeElement, context, requiresLazyMemberInitialization, true );
 					if ( alreadyExistingMetaEntity != null ) {
 						metaEntity.mergeInMembers( alreadyExistingMetaEntity );
 					}
@@ -370,7 +370,7 @@ public class JPAMetaModelEntityProcessor extends AbstractProcessor {
 	private void handleRootElementAuxiliaryAnnotationMirrors(final Element element) {
 		if ( element instanceof TypeElement ) {
 			final AnnotationMetaEntity metaEntity =
-					AnnotationMetaEntity.create( (TypeElement) element, context, false );
+					AnnotationMetaEntity.create( (TypeElement) element, context, false, false );
 			context.addMetaAuxiliary( metaEntity.getQualifiedName(), metaEntity );
 		}
 		else if ( element instanceof PackageElement ) {

--- a/tooling/metamodel-generator/src/main/java/org/hibernate/jpamodelgen/annotation/AnnotationMetaEntity.java
+++ b/tooling/metamodel-generator/src/main/java/org/hibernate/jpamodelgen/annotation/AnnotationMetaEntity.java
@@ -85,6 +85,7 @@ public class AnnotationMetaEntity extends AnnotationMeta {
 	private final TypeElement element;
 	private final Map<String, MetaAttribute> members;
 	private final Context context;
+	private final boolean managed;
 
 	private AccessTypeInformation entityAccessTypeInfo;
 
@@ -120,15 +121,16 @@ public class AnnotationMetaEntity extends AnnotationMeta {
 
 	private final Map<String,String> memberTypes = new HashMap<>();
 
-	public AnnotationMetaEntity(TypeElement element, Context context) {
+	public AnnotationMetaEntity(TypeElement element, Context context, boolean managed) {
 		this.element = element;
 		this.context = context;
+		this.managed = managed;
 		this.members = new HashMap<>();
 		this.importContext = new ImportContextImpl( getPackageName( context, element ) );
 	}
 
-	public static AnnotationMetaEntity create(TypeElement element, Context context, boolean lazilyInitialised) {
-		final AnnotationMetaEntity annotationMetaEntity = new AnnotationMetaEntity( element, context );
+	public static AnnotationMetaEntity create(TypeElement element, Context context, boolean lazilyInitialised, boolean managed) {
+		final AnnotationMetaEntity annotationMetaEntity = new AnnotationMetaEntity( element, context, managed );
 		if ( !lazilyInitialised ) {
 			annotationMetaEntity.init();
 		}
@@ -282,6 +284,10 @@ public class AnnotationMetaEntity extends AnnotationMeta {
 		}
 
 		findSessionGetter( methodsOfClass );
+
+		if ( managed ) {
+			putMember( "class", new AnnotationMetaType(this) );
+		}
 
 		addPersistentMembers( fieldsOfClass, AccessType.FIELD );
 		addPersistentMembers( gettersAndSettersOfClass, AccessType.PROPERTY );

--- a/tooling/metamodel-generator/src/main/java/org/hibernate/jpamodelgen/annotation/AnnotationMetaType.java
+++ b/tooling/metamodel-generator/src/main/java/org/hibernate/jpamodelgen/annotation/AnnotationMetaType.java
@@ -1,0 +1,86 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.jpamodelgen.annotation;
+
+import org.hibernate.jpamodelgen.model.MetaAttribute;
+import org.hibernate.jpamodelgen.model.Metamodel;
+import org.hibernate.jpamodelgen.util.Constants;
+import org.hibernate.metamodel.model.domain.ManagedDomainType;
+
+import static org.hibernate.jpamodelgen.util.TypeUtils.hasAnnotation;
+
+/**
+ * @author Gavin King
+ */
+public class AnnotationMetaType implements MetaAttribute {
+
+	private final AnnotationMetaEntity annotationMetaEntity;
+
+	public AnnotationMetaType(AnnotationMetaEntity annotationMetaEntity) {
+		this.annotationMetaEntity = annotationMetaEntity;
+	}
+
+	@Override
+	public boolean hasTypedAttribute() {
+		return true;
+	}
+
+	@Override
+	public boolean hasStringAttribute() {
+		return false;
+	}
+
+	@Override
+	public String getAttributeDeclarationString() {
+		return new StringBuilder()
+				.append("\n/**\n * @see ")
+				.append( annotationMetaEntity.getQualifiedName() )
+				.append( "\n **/\n" )
+				.append("public static volatile ")
+				.append(annotationMetaEntity.importType(getTypeDeclaration()))
+				.append("<")
+				.append(annotationMetaEntity.importType(annotationMetaEntity.getQualifiedName()))
+				.append(">")
+				.append(" class_;").toString();
+	}
+
+	@Override
+	public String getAttributeNameDeclarationString() {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public String getMetaType() {
+		return ManagedDomainType.class.getName();
+	}
+
+	@Override
+	public String getPropertyName() {
+		return "class";
+	}
+
+	@Override
+	public String getTypeDeclaration() {
+		if ( hasAnnotation(annotationMetaEntity.getElement(), Constants.ENTITY) ) {
+			return "jakarta.persistence.metamodel.EntityType";
+		}
+		else if ( hasAnnotation(annotationMetaEntity.getElement(), Constants.EMBEDDABLE) ) {
+			return "jakarta.persistence.metamodel.EmbeddableType";
+		}
+		else if ( hasAnnotation(annotationMetaEntity.getElement(), Constants.MAPPED_SUPERCLASS) ) {
+			return "jakarta.persistence.metamodel.MappedSuperclassType";
+		}
+		else {
+			return "jakarta.persistence.metamodel.ManagedType";
+		}
+	}
+
+	@Override
+	public Metamodel getHostingEntity() {
+		return annotationMetaEntity;
+	}
+}

--- a/tooling/metamodel-generator/src/main/java/org/hibernate/jpamodelgen/util/Constants.java
+++ b/tooling/metamodel-generator/src/main/java/org/hibernate/jpamodelgen/util/Constants.java
@@ -72,6 +72,8 @@ public final class Constants {
 	public static final String HIB_STATELESS_SESSION = "org.hibernate.StatelessSession";
 	public static final String MUTINY_SESSION = "org.hibernate.reactive.mutiny.Mutiny.Session";
 
+	public static final String TUPLE = "jakarta.persistence.Tuple";
+
 	public static final String UNI = "io.smallrye.mutiny.Uni";
 
 	public static final String SINGULAR_ATTRIBUTE = "jakarta.persistence.metamodel.SingularAttribute";

--- a/tooling/metamodel-generator/src/main/java/org/hibernate/jpamodelgen/util/TypeUtils.java
+++ b/tooling/metamodel-generator/src/main/java/org/hibernate/jpamodelgen/util/TypeUtils.java
@@ -211,6 +211,10 @@ public final class TypeUtils {
 		return null;
 	}
 
+	public static boolean hasAnnotation(Element element, String qualifiedName) {
+		return getAnnotationMirror( element, qualifiedName ) != null;
+	}
+
 	public static @Nullable Object getAnnotationValue(AnnotationMirror annotationMirror, String parameterValue) {
 		assert annotationMirror != null;
 		assert parameterValue != null;

--- a/tooling/metamodel-generator/src/test/java/org/hibernate/jpamodelgen/test/hqlsql/Books.java
+++ b/tooling/metamodel-generator/src/test/java/org/hibernate/jpamodelgen/test/hqlsql/Books.java
@@ -6,6 +6,7 @@ import org.hibernate.Session;
 import org.hibernate.StatelessSession;
 import org.hibernate.annotations.processing.Find;
 import org.hibernate.annotations.processing.HQL;
+import org.hibernate.query.Order;
 
 import java.util.List;
 
@@ -28,5 +29,8 @@ public abstract class Books {
     @HQL("from Book where title like ?2 order by title fetch first ?3 rows only")
     abstract List<Book> findFirstNByTitle(Session session, String title, int N);
 
+    static class Summary { Summary(String title, String publisher, String isbn) {} }
 
+    @HQL("select title, publisher.name, isbn from Book")
+    abstract List<Summary> summarize(Session session, Order order);
 }


### PR DESCRIPTION
1. typechecking for the return type of `@HQL` query methods
2. adds generation of `Book_.class_` returning `EntityType<Book>` (with appropriate support for `@Embeddable`s and `@MappedSuperclass`es.