### PR TITLE
remove order-by list from the query plan cache key

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/internal/QuerySqmImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/internal/QuerySqmImpl.java
@@ -950,8 +950,12 @@ public class QuerySqmImpl<R>
 	public Query<R> setOrder(List<Order<? super R>> orderList) {
 		if ( sqm instanceof SqmSelectStatement ) {
 			sqm = sqm.copy( SqmCopyContext.noParamCopyContext() );
-			SqmSelectStatement<R> select = (SqmSelectStatement<R>) sqm;
-			select.orderBy( orderList.stream().map( order -> sortSpecification( select, order ) ).collect( toList() ) );
+			final SqmSelectStatement<R> select = (SqmSelectStatement<R>) sqm;
+			select.orderBy( orderList.stream().map( order -> sortSpecification( select, order ) )
+					.collect( toList() ) );
+			// TODO: when the QueryInterpretationCache can handle caching criteria queries,
+			//       simply cache the new SQM as if it were a criteria query, and remove this:
+			getQueryOptions().setQueryPlanCachingEnabled( false );
 			return this;
 		}
 		else {
@@ -965,18 +969,14 @@ public class QuerySqmImpl<R>
 			sqm = sqm.copy( SqmCopyContext.noParamCopyContext() );
 			SqmSelectStatement<R> select = (SqmSelectStatement<R>) sqm;
 			select.orderBy( sortSpecification( select, order ) );
+			// TODO: when the QueryInterpretationCache can handle caching criteria queries,
+			//       simply cache the new SQM as if it were a criteria query, and remove this:
+			getQueryOptions().setQueryPlanCachingEnabled( false );
 			return this;
 		}
 		else {
 			throw new IllegalSelectQueryException( "Not a select query" );
 		}
-	}
-
-	@Override
-	public List<jakarta.persistence.criteria.Order> getOrder() {
-		return sqm instanceof SqmSelectStatement
-				? ((SqmSelectStatement<R>) sqm).getOrderList()
-				: null;
 	}
 
 	// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/internal/SqmInterpretationsKey.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/internal/SqmInterpretationsKey.java
@@ -8,12 +8,10 @@ package org.hibernate.query.sqm.internal;
 
 import java.util.Collection;
 import java.util.Iterator;
-import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 import java.util.function.Supplier;
 
-import jakarta.persistence.criteria.Order;
 import org.hibernate.LockOptions;
 import org.hibernate.engine.spi.LoadQueryInfluencers;
 import org.hibernate.query.ResultListTransformer;
@@ -40,7 +38,6 @@ public final class SqmInterpretationsKey implements QueryInterpretationCache.Key
 
 	public interface InterpretationsKeySource extends CacheabilityInfluencers {
 		Class<?> getResultType();
-		List<Order> getOrder();
 	}
 
 	public static SqmInterpretationsKey createInterpretationsKey(InterpretationsKeySource keySource) {
@@ -52,7 +49,6 @@ public final class SqmInterpretationsKey implements QueryInterpretationCache.Key
 					query,
 					query.hashCode(),
 					keySource.getResultType(),
-					keySource.getOrder(),
 					keySource.getQueryOptions().getLockOptions(),
 					keySource.getQueryOptions().getTupleTransformer(),
 					keySource.getQueryOptions().getResultListTransformer(),
@@ -113,7 +109,6 @@ public final class SqmInterpretationsKey implements QueryInterpretationCache.Key
 
 	private final Object query;
 	private final Class<?> resultType;
-	private final List<Order> order;
 	private final LockOptions lockOptions;
 	private final TupleTransformer<?> tupleTransformer;
 	private final ResultListTransformer<?> resultListTransformer;
@@ -124,7 +119,6 @@ public final class SqmInterpretationsKey implements QueryInterpretationCache.Key
 			Object query,
 			int hash,
 			Class<?> resultType,
-			List<Order> order,
 			LockOptions lockOptions,
 			TupleTransformer<?> tupleTransformer,
 			ResultListTransformer<?> resultListTransformer,
@@ -132,7 +126,6 @@ public final class SqmInterpretationsKey implements QueryInterpretationCache.Key
 		this.query = query;
 		this.hashcode = hash;
 		this.resultType = resultType;
-		this.order = order;
 		this.lockOptions = lockOptions;
 		this.tupleTransformer = tupleTransformer;
 		this.resultListTransformer = resultListTransformer;
@@ -145,7 +138,6 @@ public final class SqmInterpretationsKey implements QueryInterpretationCache.Key
 				query,
 				hashcode,
 				resultType,
-				order,
 				// Since lock options might be mutable, we need a copy for the cache key
 				lockOptions.makeDefensiveCopy(),
 				tupleTransformer,
@@ -172,7 +164,6 @@ public final class SqmInterpretationsKey implements QueryInterpretationCache.Key
 		return this.hashcode == o.hashCode() //check this first as some other checks are expensive
 			&& query.equals( that.query )
 			&& Objects.equals( resultType, that.resultType )
-			&& Objects.equals( order, that.order )
 			&& Objects.equals( lockOptions, that.lockOptions )
 			&& Objects.equals( tupleTransformer, that.tupleTransformer )
 			&& Objects.equals( resultListTransformer, that.resultListTransformer )

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/internal/SqmSelectionQueryImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/internal/SqmSelectionQueryImpl.java
@@ -293,7 +293,11 @@ public class SqmSelectionQueryImpl<R> extends AbstractSelectionQuery<R>
 	@Override
 	public final SelectionQuery<R> setOrder(List<Order<? super R>> orderList) {
 		sqm = sqm.copy( SqmCopyContext.noParamCopyContext() );
-		sqm.orderBy( orderList.stream().map( order -> sortSpecification( sqm, order ) ).collect( toList() ) );
+		sqm.orderBy( orderList.stream().map( order -> sortSpecification( sqm, order ) )
+				.collect( toList() ) );
+		// TODO: when the QueryInterpretationCache can handle caching criteria queries,
+		//       simply cache the new SQM as if it were a criteria query, and remove this:
+		getQueryOptions().setQueryPlanCachingEnabled( false );
 		return this;
 	}
 
@@ -301,6 +305,9 @@ public class SqmSelectionQueryImpl<R> extends AbstractSelectionQuery<R>
 	public final SelectionQuery<R> setOrder(Order<? super R> order) {
 		sqm = sqm.copy( SqmCopyContext.noParamCopyContext() );
 		sqm.orderBy( sortSpecification( sqm, order ) );
+		// TODO: when the QueryInterpretationCache can handle caching criteria queries,
+		//       simply cache the new SQM as if it were a criteria query, and remove this:
+		getQueryOptions().setQueryPlanCachingEnabled( false );
 		return this;
 	}
 
@@ -582,11 +589,6 @@ public class SqmSelectionQueryImpl<R> extends AbstractSelectionQuery<R>
 				// For criteria queries, query plan caching requires an explicit opt-in
 				? getQueryOptions().getQueryPlanCachingEnabled() == Boolean.TRUE
 				: super.isQueryPlanCacheable();
-	}
-
-	@Override
-	public List<jakarta.persistence.criteria.Order> getOrder() {
-		return sqm.getOrderList();
 	}
 
 	// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/query/order/OrderTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/query/order/OrderTest.java
@@ -12,7 +12,6 @@ import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
-import static java.util.Collections.emptyList;
 import static java.util.stream.Collectors.toList;
 import static org.hibernate.query.Order.asc;
 import static org.hibernate.query.Order.desc;


### PR DESCRIPTION
Roll back my always-intended-to-be-temporary bandaid to allow caching of the query plan after calls to `setOrder()`. Instead, just disable caching of the query plan. When the query plan cache can handle caching of criteria queries, change to use that strategy instead.