### PR TITLE
HHH-16912 return null from deprecated method instead of producing a CCE

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/mapping/KeyValue.java
+++ b/hibernate-core/src/main/java/org/hibernate/mapping/KeyValue.java
@@ -36,6 +36,9 @@ public interface KeyValue extends Value {
 
 	/**
 	 * @deprecated Use {@link #createGenerator(IdentifierGeneratorFactory, Dialect, RootClass)} instead.
+	 *
+	 * @return {@code null} if the {@code Generator} returned by {@link #createGenerator} is not an instance
+	 *         of {@link IdentifierGenerator}.
 	 */
 	@Deprecated(since="6.2")
 	default IdentifierGenerator createIdentifierGenerator(
@@ -44,18 +47,23 @@ public interface KeyValue extends Value {
 			String defaultCatalog,
 			String defaultSchema,
 			RootClass rootClass) {
-		return (IdentifierGenerator) createGenerator( identifierGeneratorFactory, dialect, rootClass );
+		final Generator generator = createGenerator( identifierGeneratorFactory, dialect, rootClass );
+		return generator instanceof IdentifierGenerator ? (IdentifierGenerator) generator : null;
 	}
 
 	/**
 	 * @deprecated Use {@link #createGenerator(IdentifierGeneratorFactory, Dialect, RootClass)} instead.
+	 *
+	 * @return {@code null} if the {@code Generator} returned by {@link #createGenerator} is not an instance
+	 *         of {@link IdentifierGenerator}.
 	 */
 	@Deprecated(since="6.2")
 	default IdentifierGenerator createIdentifierGenerator(
 			IdentifierGeneratorFactory identifierGeneratorFactory,
 			Dialect dialect,
 			RootClass rootClass) {
-		return (IdentifierGenerator) createGenerator( identifierGeneratorFactory, dialect, rootClass );
+		final Generator generator = createGenerator( identifierGeneratorFactory, dialect, rootClass );
+		return generator instanceof IdentifierGenerator ? (IdentifierGenerator) generator : null;
 	}
 
 	/**


### PR DESCRIPTION
This is a band-aid over an error occurring in Liquibase. But it seems to me that Liquibase itself should be updated to use the new APIs.

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-16912
<!-- Hibernate GitHub Bot issue links end -->