### PR TITLE
HHH-16943 Column ordering leads to wrong column order in unique constraints  + HHH-16953 Hibernate doesn't observe column order on multicolumn indexes 

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/boot/internal/MetadataImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/internal/MetadataImpl.java
@@ -417,18 +417,6 @@ public class MetadataImpl implements MetadataImplementor, Serializable {
 							primaryKey.reorderColumns( primaryKeyColumns );
 						}
 					}
-					for ( UniqueKey uniqueKey : table.getUniqueKeys().values() ) {
-						if ( uniqueKey.getColumns().size() > 1 ) {
-							final List<Column> uniqueKeyColumns = columnOrderingStrategy.orderConstraintColumns(
-									uniqueKey,
-									this
-							);
-							if ( uniqueKeyColumns != null ) {
-								uniqueKey.getColumns().clear();
-								uniqueKey.getColumns().addAll( uniqueKeyColumns );
-							}
-						}
-					}
 					for ( ForeignKey foreignKey : table.getForeignKeys().values() ) {
 						final List<Column> columns = foreignKey.getColumns();
 						if ( columns.size() > 1 ) {

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/schemaupdate/index/IndexesOrderTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/schemaupdate/index/IndexesOrderTest.java
@@ -1,0 +1,98 @@
+package org.hibernate.orm.test.schemaupdate.index;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.util.EnumSet;
+
+import org.hibernate.boot.MetadataSources;
+import org.hibernate.boot.registry.StandardServiceRegistry;
+import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
+import org.hibernate.boot.spi.MetadataImplementor;
+import org.hibernate.cfg.Environment;
+import org.hibernate.dialect.H2Dialect;
+import org.hibernate.tool.hbm2ddl.SchemaExport;
+import org.hibernate.tool.schema.TargetType;
+
+import org.hibernate.testing.orm.junit.JiraKey;
+import org.hibernate.testing.orm.junit.RequiresDialect;
+import org.junit.jupiter.api.Test;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+
+@RequiresDialect(H2Dialect.class)
+public class IndexesOrderTest {
+
+	@Test
+	@JiraKey("HHH-16953")
+	// see https://jakarta.ee/specifications/persistence/3.1/jakarta-persistence-spec-3.1.html#a14862
+	public void testCreatedIndexColumnsOrderedAsSpecified() throws Exception {
+		StandardServiceRegistry ssr = new StandardServiceRegistryBuilder()
+				.applySetting( Environment.HBM2DDL_AUTO, "none" )
+				.build();
+		try {
+			File output = File.createTempFile( "update_script", ".sql" );
+			output.deleteOnExit();
+
+			final MetadataImplementor metadata = (MetadataImplementor) new MetadataSources( ssr )
+					.addAnnotatedClass( EntityA.class )
+					.addAnnotatedClass( EntityB.class )
+					.buildMetadata();
+			metadata.orderColumns( true );
+			metadata.validate();
+
+			new SchemaExport()
+					.setOutputFile( output.getAbsolutePath() )
+					.setDelimiter( ";" )
+					.setFormat( false )
+					.create( EnumSet.of( TargetType.SCRIPT ), metadata );
+
+			String fileContent = new String( Files.readAllBytes( output.toPath() ) ).toLowerCase()
+					.replace( System.lineSeparator(), "" );
+			assertThat( fileContent ).contains( "constraint entity_a_index unique (entityb_id, name, is_active)" );
+		}
+		finally {
+			StandardServiceRegistryBuilder.destroy( ssr );
+		}
+	}
+
+	@Entity(name = "EntityA")
+	@Table(
+			name = "ENTITY_A",
+			indexes = { @Index(name = "entity_a_index", columnList = "entityb_id,name,is_active", unique = true) }
+	)
+	public static class EntityA {
+
+		@Id
+		private Long id;
+
+
+		@Column(name = "name")
+		private String name;
+
+		@Column(name = "is_active")
+		private Boolean isActive;
+
+		@ManyToOne
+		@JoinColumn(name = "entityb_id")
+		private EntityB entityB;
+	}
+
+	@Entity(name = "EntityB")
+	@Table(name = "ENTITY_B")
+	public static class EntityB {
+
+		@Id
+		private Long id;
+
+		private String name;
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/schemaupdate/uniqueconstraint/UniqueConstraintColumnOrderTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/schemaupdate/uniqueconstraint/UniqueConstraintColumnOrderTest.java
@@ -14,6 +14,7 @@ import java.util.Map;
 
 import org.hibernate.boot.Metadata;
 import org.hibernate.cfg.AvailableSettings;
+import org.hibernate.dialect.H2Dialect;
 import org.hibernate.jpa.boot.spi.Bootstrap;
 import org.hibernate.jpa.boot.spi.EntityManagerFactoryBuilder;
 import org.hibernate.jpa.boot.spi.PersistenceUnitDescriptor;
@@ -22,6 +23,7 @@ import org.hibernate.tool.schema.TargetType;
 
 import org.hibernate.testing.orm.jpa.PersistenceUnitDescriptorAdapter;
 import org.hibernate.testing.orm.junit.JiraKey;
+import org.hibernate.testing.orm.junit.RequiresDialect;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -34,9 +36,11 @@ import jakarta.persistence.UniqueConstraint;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @JiraKey("HHH-16943")
+@RequiresDialect( H2Dialect.class )
 class UniqueConstraintColumnOrderTest {
 
 	@Test
+	// see https://jakarta.ee/specifications/persistence/3.1/jakarta-persistence-spec-3.1.html#uniqueconstraint
 	public void testUniqueConstraintColumnOrder(@TempDir Path tempDir) throws Exception {
 		PersistenceUnitDescriptor puDescriptor = new PersistenceUnitDescriptorAdapter() {
 			@Override

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/schemaupdate/uniqueconstraint/UniqueConstraintColumnOrderTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/schemaupdate/uniqueconstraint/UniqueConstraintColumnOrderTest.java
@@ -1,0 +1,79 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.orm.test.schemaupdate.uniqueconstraint;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Map;
+
+import org.hibernate.boot.Metadata;
+import org.hibernate.cfg.AvailableSettings;
+import org.hibernate.jpa.boot.spi.Bootstrap;
+import org.hibernate.jpa.boot.spi.EntityManagerFactoryBuilder;
+import org.hibernate.jpa.boot.spi.PersistenceUnitDescriptor;
+import org.hibernate.tool.hbm2ddl.SchemaExport;
+import org.hibernate.tool.schema.TargetType;
+
+import org.hibernate.testing.orm.jpa.PersistenceUnitDescriptorAdapter;
+import org.hibernate.testing.orm.junit.JiraKey;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityManagerFactory;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@JiraKey("HHH-16943")
+class UniqueConstraintColumnOrderTest {
+
+	@Test
+	public void testUniqueConstraintColumnOrder(@TempDir Path tempDir) throws Exception {
+		PersistenceUnitDescriptor puDescriptor = new PersistenceUnitDescriptorAdapter() {
+			@Override
+			public List<String> getManagedClassNames() {
+				return List.of( TestEntity.class.getName() );
+			}
+		};
+
+		Map<Object, Object> settings = Map.of( AvailableSettings.HBM2DDL_AUTO, "create" );
+		EntityManagerFactoryBuilder emfBuilder = Bootstrap.getEntityManagerFactoryBuilder( puDescriptor, settings );
+
+		Path ddlScript = tempDir.resolve( "ddl.sql" );
+
+		try (EntityManagerFactory entityManagerFactory = emfBuilder.build()) {
+			// we do not need the entityManagerFactory, but we need to build it in order to demonstrate the issue (HHH-16943)
+
+			Metadata metadata = emfBuilder.metadata();
+
+			new SchemaExport()
+					.setHaltOnError( true )
+					.setOutputFile( ddlScript.toString() )
+					.setFormat( true )
+					.create( EnumSet.of( TargetType.SCRIPT ), metadata );
+		}
+
+		String ddl = Files.readString( ddlScript );
+		assertThat( ddl ).contains( "constraint uk_b_a unique (b, a)" );
+	}
+
+	@Entity
+	@Table(uniqueConstraints = @UniqueConstraint(name = "uk_b_a", columnNames = { "b", "a" }))
+	static class TestEntity {
+
+		@Id
+		private Long id;
+		private String a;
+		private String b;
+
+	}
+}


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-16943 
https://hibernate.atlassian.net/browse/HHH-16953 

see https://jakarta.ee/specifications/persistence/3.1/jakarta-persistence-spec-3.1.html#a14862
and https://jakarta.ee/specifications/persistence/3.1/jakarta-persistence-spec-3.1.html#uniqueconstraint
