### PR TITLE
HHH-16963 Avoid H2's capability to register a JVM shutdown hook

### DIFF
--- a/gradle/databases.gradle
+++ b/gradle/databases.gradle
@@ -18,7 +18,7 @@ ext {
                         'jdbc.driver': 'org.h2.Driver',
                         'jdbc.user'  : 'sa',
                         'jdbc.pass'  : '',
-                        'jdbc.url'   : 'jdbc:h2:mem:db1;DB_CLOSE_DELAY=-1;LOCK_TIMEOUT=10000',
+                        'jdbc.url'   : 'jdbc:h2:mem:db1;DB_CLOSE_DELAY=-1;LOCK_TIMEOUT=10000;DB_CLOSE_ON_EXIT=FALSE',
                         'connection.init_sql' : '',
                         'hibernate.dialect.native_param_markers' : 'true'
                 ],

--- a/hibernate-core/src/test/bundles/templates/cfgxmlpar/org/hibernate/orm/test/jpa/pack/cfgxmlpar/hibernate.cfg.xml
+++ b/hibernate-core/src/test/bundles/templates/cfgxmlpar/org/hibernate/orm/test/jpa/pack/cfgxmlpar/hibernate.cfg.xml
@@ -15,7 +15,7 @@
         <property name="hibernate.connection.username">sa</property>
         <property name="hibernate.connection.password"></property>
         <property name="hibernate.connection.init_sql"></property>
-        <property name="hibernate.connection.url">jdbc:h2:mem:db1;DB_CLOSE_DELAY=-1</property>
+        <property name="hibernate.connection.url">jdbc:h2:mem:db1;DB_CLOSE_DELAY=-1;LOCK_TIMEOUT=10000;DB_CLOSE_ON_EXIT=FALSE</property>
         <property name="hibernate.cache.use_query_cache">true</property>
         <property name="hibernate.cache.region_prefix">hibernate.test</property>
         <property name="hibernate.jdbc.batch_size">0</property>

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/cache/RefreshUpdatedDataTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/cache/RefreshUpdatedDataTest.java
@@ -50,7 +50,7 @@ public class RefreshUpdatedDataTest extends BaseCoreFunctionalTestCase {
 		super.configure( cfg );
 		Properties properties = Environment.getProperties();
 		if ( H2Dialect.class.getName().equals( properties.get( Environment.DIALECT ) ) ) {
-			cfg.setProperty( Environment.URL, "jdbc:h2:mem:db-mvcc" );
+			cfg.setProperty( Environment.URL, "jdbc:h2:mem:db-mvcc;DB_CLOSE_DELAY=-1;LOCK_TIMEOUT=10000;DB_CLOSE_ON_EXIT=FALSE" );
 		}
 		cfg.setProperty( Environment.CACHE_REGION_PREFIX, "" );
 		cfg.setProperty( Environment.GENERATE_STATISTICS, "true" );

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/connection/ConnectionCreatorTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/connection/ConnectionCreatorTest.java
@@ -46,7 +46,7 @@ public class ConnectionCreatorTest extends BaseUnitTestCase {
 						Collections.emptyList(),
 						Collections.emptyMap()
 				),
-				"jdbc:h2:mem:test-bad-urls;nosuchparam=saywhat",
+				"jdbc:h2:mem:test-bad-urls;nosuchparam=saywhat;DB_CLOSE_ON_EXIT=FALSE",
 				new Properties(),
 				false,
 				null,

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/schemagen/JpaSchemaGeneratorTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/schemagen/JpaSchemaGeneratorTest.java
@@ -150,7 +150,7 @@ public class JpaSchemaGeneratorTest extends EntityManagerFactoryBasedFunctionalT
 		// We want a fresh db after emf close
 		// Unfortunately we have to use this dirty hack because the db seems not to be closed otherwise
 		settings.put( "hibernate.connection.url", "jdbc:h2:mem:db-schemagen" + schemagenNumber++
-				+ ";LOCK_TIMEOUT=10000" );
+				+ ";DB_CLOSE_DELAY=-1;LOCK_TIMEOUT=10000;DB_CLOSE_ON_EXIT=FALSE" );
 		EntityManagerFactoryBuilder emfb = Bootstrap.getEntityManagerFactoryBuilder(
 				buildPersistenceUnitDescriptor(),
 				settings

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/resource/common/DatabaseConnectionInfo.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/resource/common/DatabaseConnectionInfo.java
@@ -24,7 +24,7 @@ public class DatabaseConnectionInfo {
 	public static final DatabaseConnectionInfo INSTANCE = new DatabaseConnectionInfo();
 
 	public static final String DRIVER = "org.h2.Driver";
-	public static final String URL = "jdbc:h2:mem:hibernate-core";
+	public static final String URL = "jdbc:h2:mem:hibernate-core;DB_CLOSE_DELAY=-1;LOCK_TIMEOUT=10000;DB_CLOSE_ON_EXIT=FALSE";
 	public static final String USER = "hibernate";
 	public static final String PASS = "hibernate";
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/schemaupdate/ConnectionsReleaseTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/schemaupdate/ConnectionsReleaseTest.java
@@ -45,7 +45,7 @@ public class ConnectionsReleaseTest extends BaseUnitTestCase {
 	public static Properties getConnectionProviderProperties() {
 		Properties props = new Properties();
 		props.put( Environment.DRIVER, "org.h2.Driver" );
-		props.put( Environment.URL, String.format( "jdbc:h2:mem:%s;DB_CLOSE_DELAY=-1", "db1" ) );
+		props.put( Environment.URL, String.format( "jdbc:h2:mem:%s;DB_CLOSE_DELAY=-1;LOCK_TIMEOUT=10000;DB_CLOSE_ON_EXIT=FALSE", "db1" ) );
 		props.put( Environment.USER, "sa" );
 		props.put( Environment.PASS, "" );
 		return props;

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/schemaupdate/H2DialectDataBaseToUpperTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/schemaupdate/H2DialectDataBaseToUpperTest.java
@@ -42,7 +42,7 @@ public class H2DialectDataBaseToUpperTest extends BaseUnitTestCase {
 		ssr = new StandardServiceRegistryBuilder()
 				.applySetting(
 						AvailableSettings.URL,
-						"jdbc:h2:mem:databaseToUpper;DATABASE_TO_UPPER=" + databaseToUpper
+						"jdbc:h2:mem:databaseToUpper;DATABASE_TO_UPPER=" + databaseToUpper + ";DB_CLOSE_DELAY=-1;LOCK_TIMEOUT=10000;DB_CLOSE_ON_EXIT=FALSE"
 				)
 				.build();
 		final MetadataSources metadataSources = new MetadataSources( ssr );

--- a/hibernate-envers/src/demo/resources/META-INF/persistence.xml
+++ b/hibernate-envers/src/demo/resources/META-INF/persistence.xml
@@ -13,7 +13,7 @@
         <exclude-unlisted-classes />
         <properties>
             <property name="hibernate.dialect" value="org.hibernate.dialect.H2Dialect"/>
-            <property name="hibernate.connection.url" value="jdbc:h2:mem:db1;DB_CLOSE_DELAY=-1"/>
+            <property name="hibernate.connection.url" value="jdbc:h2:mem:db1;DB_CLOSE_DELAY=-1;LOCK_TIMEOUT=10000;DB_CLOSE_ON_EXIT=FALSE"/>
             <property name="hibernate.connection.driver_class" value="org.h2.Driver"/>
             <property name="hibernate.connection.username" value="sa"/>
             <property name="hibernate.connection.password" value=""/>

--- a/hibernate-envers/src/test/resources/hibernate.test.session-cfg.xml
+++ b/hibernate-envers/src/test/resources/hibernate.test.session-cfg.xml
@@ -17,7 +17,7 @@
         <property name="format_sql">false</property>
 
         <property name="dialect">org.hibernate.dialect.H2Dialect</property>
-        <property name="connection.url">jdbc:h2:mem:envers</property>
+        <property name="connection.url">jdbc:h2:mem:envers;DB_CLOSE_DELAY=-1;LOCK_TIMEOUT=10000;DB_CLOSE_ON_EXIT=FALSE</property>
         <property name="connection.driver_class">org.h2.Driver</property>
         <property name="connection.username">sa</property>
         <property name="connection.password"></property>

--- a/hibernate-integrationtest-java-modules/src/test/resources/META-INF/persistence.xml
+++ b/hibernate-integrationtest-java-modules/src/test/resources/META-INF/persistence.xml
@@ -14,7 +14,7 @@
         <properties>
             <property name="hibernate.connection.driver_class" value="org.h2.Driver"/>
             <property name="hibernate.dialect" value="org.hibernate.dialect.H2Dialect"/>
-            <property name="hibernate.connection.url" value="jdbc:h2:mem:db1;DB_CLOSE_DELAY=-1"/>
+            <property name="hibernate.connection.url" value="jdbc:h2:mem:db1;DB_CLOSE_DELAY=-1;LOCK_TIMEOUT=10000;DB_CLOSE_ON_EXIT=FALSE"/>
             <property name="hibernate.connection.username" value="sa"/>
             <property name="hibernate.connection.password" value=""/>
             <property name="hibernate.hbm2ddl.auto" value="create-drop"/>

--- a/hibernate-jcache/src/test/java/org/hibernate/orm/test/jcache/RefreshUpdatedDataTest.java
+++ b/hibernate-jcache/src/test/java/org/hibernate/orm/test/jcache/RefreshUpdatedDataTest.java
@@ -58,7 +58,7 @@ public class RefreshUpdatedDataTest {
 				.configure( "hibernate-config/hibernate.cfg.xml" );
 
 		if ( H2Dialect.class.equals( DialectContext.getDialect().getClass() ) ) {
-			ssrb.applySetting( AvailableSettings.URL, "jdbc:h2:mem:db-mvcc" );
+			ssrb.applySetting( AvailableSettings.URL, "jdbc:h2:mem:db-mvcc;DB_CLOSE_DELAY=-1;LOCK_TIMEOUT=10000;DB_CLOSE_ON_EXIT=FALSE" );
 		}
 		ssrb.applySetting( AvailableSettings.GENERATE_STATISTICS, "true" );
 

--- a/hibernate-jcache/src/test/java/org/hibernate/orm/test/jcache/TestHelper.java
+++ b/hibernate-jcache/src/test/java/org/hibernate/orm/test/jcache/TestHelper.java
@@ -123,7 +123,7 @@ public class TestHelper {
 				.applySetting( AvailableSettings.HBM2DDL_AUTO, "create-drop" );
 
 		if ( H2Dialect.class.equals( DialectContext.getDialect().getClass() ) ) {
-			ssrb.applySetting( AvailableSettings.URL, "jdbc:h2:mem:db-mvcc" );
+			ssrb.applySetting( AvailableSettings.URL, "jdbc:h2:mem:db-mvcc;DB_CLOSE_DELAY=-1;LOCK_TIMEOUT=10000;DB_CLOSE_ON_EXIT=FALSE" );
 		}
 		return ssrb;
 	}

--- a/hibernate-proxool/src/test/resources/pool-one.properties
+++ b/hibernate-proxool/src/test/resources/pool-one.properties
@@ -5,7 +5,7 @@
 # See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
 #
 jdbc-0.proxool.alias=pool-one
-jdbc-0.proxool.driver-url=jdbc:h2:mem:db1;DB_CLOSE_DELAY=-1
+jdbc-0.proxool.driver-url=jdbc:h2:mem:db1;DB_CLOSE_DELAY=-1;LOCK_TIMEOUT=10000;DB_CLOSE_ON_EXIT=FALSE
 jdbc-0.proxool.driver-class=org.h2.Driver
 jdbc-0.user=sa
 jdbc-0.password=

--- a/hibernate-proxool/src/test/resources/pool-two.properties
+++ b/hibernate-proxool/src/test/resources/pool-two.properties
@@ -5,7 +5,7 @@
 # See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
 #
 jdbc-0.proxool.alias=pool-two
-jdbc-0.proxool.driver-url=jdbc:h2:mem:db1;DB_CLOSE_DELAY=-1
+jdbc-0.proxool.driver-url=jdbc:h2:mem:db1;DB_CLOSE_DELAY=-1;LOCK_TIMEOUT=10000;DB_CLOSE_ON_EXIT=FALSE
 jdbc-0.proxool.driver-class=org.h2.Driver
 jdbc-0.user=sa
 jdbc-0.password=

--- a/hibernate-testing/src/main/java/org/hibernate/testing/env/ConnectionProviderBuilder.java
+++ b/hibernate-testing/src/main/java/org/hibernate/testing/env/ConnectionProviderBuilder.java
@@ -34,7 +34,7 @@ public class ConnectionProviderBuilder implements DialectCheck {
 	public static final String DRIVER = "org.h2.Driver";
 	public static final String DATA_SOURCE = "org.h2.jdbcx.JdbcDataSource";
 //	public static final String URL = "jdbc:h2:mem:%s;DB_CLOSE_DELAY=-1";
-	public static final String URL_FORMAT = "jdbc:h2:mem:%s;DB_CLOSE_DELAY=-1";
+	public static final String URL_FORMAT = "jdbc:h2:mem:%s;DB_CLOSE_DELAY=-1;LOCK_TIMEOUT=10000;DB_CLOSE_ON_EXIT=FALSE";
 	public static final String URL = URL_FORMAT;
 	public static final String USER = "sa";
 	public static final String PASS = "";

--- a/hibernate-testing/src/main/java/org/hibernate/testing/env/TestingDatabaseInfo.java
+++ b/hibernate-testing/src/main/java/org/hibernate/testing/env/TestingDatabaseInfo.java
@@ -16,7 +16,7 @@ import org.hibernate.dialect.H2Dialect;
  */
 public final class TestingDatabaseInfo {
 	public static volatile String DRIVER = "org.h2.Driver";
-	public static volatile String URL = "jdbc:h2:mem:db1;DB_CLOSE_DELAY=-1";
+	public static volatile String URL = "jdbc:h2:mem:db1;DB_CLOSE_DELAY=-1;LOCK_TIMEOUT=10000;DB_CLOSE_ON_EXIT=FALSE";
 	public static volatile String USER = "sa";
 	public static volatile String PASS = "";
 


### PR DESCRIPTION

This seems to also reduce the time it takes to run integration tests somewhat; I suppose it's beneficial to save some memory, as memory consumption has historically been a sore point in our tests.

 - https://hibernate.atlassian.net/browse/HHH-16963