### PR TITLE
HHH-16964 Disable Log4J2's management beans during integration tests

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,8 +1,10 @@
 # Keep all these properties in sync unless you know what you are doing!
-org.gradle.jvmargs=-Xmx2g -XX:MaxMetaspaceSize=256m -XX:+HeapDumpOnOutOfMemoryError -Duser.language=en -Duser.country=US -Duser.timezone=UTC -Dfile.encoding=UTF-8
-toolchain.compiler.jvmargs=-Xmx2g -XX:MaxMetaspaceSize=256m -XX:+HeapDumpOnOutOfMemoryError -Duser.language=en -Duser.country=US -Duser.timezone=UTC -Dfile.encoding=UTF-8
-toolchain.javadoc.jvmargs=-Xmx2g -XX:MaxMetaspaceSize=256m -XX:+HeapDumpOnOutOfMemoryError -Duser.language=en -Duser.country=US -Duser.timezone=UTC -Dfile.encoding=UTF-8
-toolchain.launcher.jvmargs=-Xmx2g -XX:MaxMetaspaceSize=384m -XX:+HeapDumpOnOutOfMemoryError -Duser.language=en -Duser.country=US -Duser.timezone=UTC -Dfile.encoding=UTF-8
+# We set '-Dlog4j2.disableJmx=true' to prevent classloader leaks triggered by the logger.
+# (Some of these settings need to be repeated in the test.jvmArgs blocks of each module)
+org.gradle.jvmargs=-Dlog4j2.disableJmx -Xmx2g -XX:MaxMetaspaceSize=256m -XX:+HeapDumpOnOutOfMemoryError -Duser.language=en -Duser.country=US -Duser.timezone=UTC -Dfile.encoding=UTF-8
+toolchain.compiler.jvmargs=-Dlog4j2.disableJmx=true -Xmx2g -XX:MaxMetaspaceSize=256m -XX:+HeapDumpOnOutOfMemoryError -Duser.language=en -Duser.country=US -Duser.timezone=UTC -Dfile.encoding=UTF-8
+toolchain.javadoc.jvmargs=-Dlog4j2.disableJmx=true -Xmx2g -XX:MaxMetaspaceSize=256m -XX:+HeapDumpOnOutOfMemoryError -Duser.language=en -Duser.country=US -Duser.timezone=UTC -Dfile.encoding=UTF-8
+toolchain.launcher.jvmargs=-Dlog4j2.disableJmx=true -Xmx2g -XX:MaxMetaspaceSize=384m -XX:+HeapDumpOnOutOfMemoryError -Duser.language=en -Duser.country=US -Duser.timezone=UTC -Dfile.encoding=UTF-8
 
 org.gradle.parallel=true
 

--- a/hibernate-core/hibernate-core.gradle
+++ b/hibernate-core/hibernate-core.gradle
@@ -245,6 +245,9 @@ tasks.withType( Test.class ).each { test ->
     test.jvmArgs( ['--add-opens', 'java.base/java.security=ALL-UNNAMED'] )
     test.jvmArgs( ['--add-opens', 'java.base/java.lang=ALL-UNNAMED'] )
 
+    //Avoid Log4J2 classloader leaks:
+    test.jvmArgs( ['-Dlog4j2.disableJmx=true'] )
+
     test.beforeTest { descriptor ->
         //println "Starting test: " + descriptor
     }


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-16964