### PR TITLE
HHH-16973 optional 'from' clause

### DIFF
--- a/hibernate-core/src/main/antlr/org/hibernate/grammars/hql/HqlParser.g4
+++ b/hibernate-core/src/main/antlr/org/hibernate/grammars/hql/HqlParser.g4
@@ -152,6 +152,7 @@ queryExpression
 orderedQuery
 	: query queryOrder?										# QuerySpecExpression
 	| LEFT_PAREN queryExpression RIGHT_PAREN queryOrder?	# NestedQueryExpression
+	| queryOrder											# QueryOrderExpression
 	;
 
 /**
@@ -180,6 +181,7 @@ query
 // TODO: add with clause
 	: selectClause fromClause? whereClause? (groupByClause havingClause?)?
 	| fromClause whereClause? (groupByClause havingClause?)? selectClause?
+	| whereClause
 	;
 
 

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/StrictJpaComplianceViolation.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/StrictJpaComplianceViolation.java
@@ -16,6 +16,7 @@ import org.hibernate.query.SemanticException;
 public class StrictJpaComplianceViolation extends SemanticException {
 	public enum Type {
 		IMPLICIT_SELECT( "implicit select clause" ),
+		IMPLICIT_FROM( "implicit from clause" ),
 		ALIASED_FETCH_JOIN( "aliased fetch join" ),
 		UNMAPPED_POLYMORPHISM( "unmapped polymorphic reference" ),
 		FUNCTION_CALL( "improper non-standard function call" ),

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/hql/nofrom/NoFromTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/hql/nofrom/NoFromTest.java
@@ -1,0 +1,66 @@
+package org.hibernate.orm.test.hql.nofrom;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import org.hibernate.query.SemanticException;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.fail;
+
+@SessionFactory
+@DomainModel(annotatedClasses = NoFromTest.Thing.class)
+public class NoFromTest {
+
+	@Test
+	public void test(SessionFactoryScope scope) {
+		scope.inTransaction( s -> {
+			s.persist(new Thing());
+			s.persist(new Thing());
+		});
+		scope.inSession( s -> {
+			List<Thing> things = s.createSelectionQuery("where id = 1", Thing.class).getResultList();
+			assertEquals(1, things.size());
+			assertEquals(1, things.get(0).id);
+			Thing thing = s.createSelectionQuery("where id = 1", Thing.class).getSingleResultOrNull();
+			assertNotNull(thing);
+			assertEquals(1, thing.id);
+		});
+		scope.inSession( s -> {
+			List<Thing> things = s.createSelectionQuery("order by id desc", Thing.class).getResultList();
+			assertEquals(2, things.size());
+			assertEquals(2, things.get(0).id);
+			assertEquals(1, things.get(1).id);
+		});
+	}
+
+	@Test
+	public void testError(SessionFactoryScope scope) {
+		scope.inSession( s -> {
+			try {
+				s.createSelectionQuery("where id = 1").getResultList();
+				fail();
+			}
+			catch (SemanticException se) {}
+		});
+		scope.inSession( s -> {
+			try {
+				s.createSelectionQuery("order by id desc").getResultList();
+				fail();
+			}
+			catch (SemanticException se) {}
+		});
+	}
+
+	@Entity(name = "Thing")
+	static class Thing {
+		@Id @GeneratedValue Long id;
+	}
+}


### PR DESCRIPTION

<https://hibernate.atlassian.net/browse/HHH-16973>

- Makes the `from` clause optional when the result class is an entity type.
- Misc code and typing cleanups to SQB.