### PR TITLE
Hhh 16759 merge fails when entity has an embedded java record transient

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/type/TypeHelper.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/TypeHelper.java
@@ -191,7 +191,10 @@ public class TypeHelper {
 			}
 			else {
 				final Type type = types[i];
-				if ( type.isComponentType() ) {
+				if ( type.isComponentType() && !type.isMutable() ) {
+					copied[i] = target[i];
+				}
+				else if ( type.isComponentType() ) {
 					final CompositeType compositeType = (CompositeType) type;
 					// need to extract the component values and check for subtype replacements...
 					final Object[] objects =

--- a/hibernate-core/src/test/java17/org/hibernate/orm/test/records/MergeRecordPropertyTestCase.java
+++ b/hibernate-core/src/test/java17/org/hibernate/orm/test/records/MergeRecordPropertyTestCase.java
@@ -21,7 +21,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 public class MergeRecordPropertyTestCase {
 
 	@Test
-	public void merge(SessionFactoryScope scope) {
+	public void mergeDetached(SessionFactoryScope scope) {
 		scope.inTransaction(
 				session -> session.persist( new MyEntity( 1L, new MyRecord( "test", "abc" ) ) )
 		);
@@ -33,6 +33,39 @@ public class MergeRecordPropertyTestCase {
 					final MyEntity entity = session.find( MyEntity.class, 1L );
 					assertEquals( "test", entity.record.name );
 					assertEquals( "d", entity.record.description );
+				}
+		);
+	}
+
+	@Test
+	public void mergeTransient(SessionFactoryScope scope) {
+		scope.inTransaction(
+				session -> session.merge( new MyEntity( 2L, new MyRecord( "test", "xyz" ) ) )
+		);
+		scope.inSession(
+				session -> {
+					final MyEntity entity = session.find( MyEntity.class, 2L );
+					assertEquals( "test", entity.record.name );
+					assertEquals( "xyz", entity.record.description );
+				}
+		);
+	}
+
+	@Test
+	public void mergePersistent(SessionFactoryScope scope) {
+		scope.inTransaction(
+				session -> {
+					final MyEntity entity = new MyEntity( 3L, new MyRecord( "test", "efg" ) );
+					session.persist( entity );
+					entity.setRecord( new MyRecord( "test", "h" ) );
+					session.merge( entity );
+				}
+		);
+		scope.inSession(
+				session -> {
+					final MyEntity entity = session.find( MyEntity.class, 3L );
+					assertEquals( "test", entity.record.name );
+					assertEquals( "h", entity.record.description );
 				}
 		);
 	}


### PR DESCRIPTION
[HHH-16759](https://hibernate.atlassian.net/browse/HHH-16759) When ComponentType is immutable, use target value instead of setting property values

This PR is replacing dead [PR 6820](https://github.com/hibernate/hibernate-orm/pull/6820)

[HHH-16759]: https://hibernate.atlassian.net/browse/HHH-16759?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ