### PR TITLE
HHH-16977: Fixed in NullPointerException in downgradeLocks

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/engine/internal/EntityEntryContext.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/internal/EntityEntryContext.java
@@ -370,7 +370,10 @@ public class EntityEntryContext {
 
 		ManagedEntity node = head;
 		while ( node != null ) {
-			node.$$_hibernate_getEntityEntry().setLockMode( LockMode.NONE );
+			EntityEntry entityEntry = node.$$_hibernate_getEntityEntry();
+			if (entityEntry != null) {
+				entityEntry.setLockMode( LockMode.NONE ); 
+			}
 
 			node = node.$$_hibernate_getNextManagedEntity();
 		}


### PR DESCRIPTION
Avoid NullPointerException in EntityEntryContext.downgradeLocks

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-16977
<!-- Hibernate GitHub Bot issue links end -->