### PR TITLE
HHH-16971 upgrade ByteBuddy to 1.12.23

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -60,7 +60,7 @@ dependencyResolutionManagement {
             version( "antlr", "4.10.1" )
             version( "hcann", "6.0.6.Final" )
             version( "geolatte", "1.8.2" )
-            version( "byteBuddy", "1.12.18" )
+            version( "byteBuddy", "1.12.23" )
             version( "agroal", "2.0" )
             version( "c3po", "0.9.5.5" )
             version( "hikaricp", "3.2.0" )


### PR DESCRIPTION
back-port of https://hibernate.atlassian.net/browse/HHH-16971