### PR TITLE
HHH-16999 Relax visibility of some methods for hibernate-reactive

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/action/internal/EntityInsertAction.java
+++ b/hibernate-core/src/main/java/org/hibernate/action/internal/EntityInsertAction.java
@@ -138,7 +138,7 @@ public class EntityInsertAction extends AbstractEntityInsertAction {
 		}
 	}
 
-	private void putCacheIfNecessary() {
+	protected void putCacheIfNecessary() {
 		final EntityPersister persister = getPersister();
 		final SharedSessionContractImplementor session = getSession();
 		if ( isCachePutEnabled( persister, session ) ) {

--- a/hibernate-core/src/main/java/org/hibernate/action/internal/EntityUpdateAction.java
+++ b/hibernate-core/src/main/java/org/hibernate/action/internal/EntityUpdateAction.java
@@ -180,7 +180,7 @@ public class EntityUpdateAction extends EntityAction {
 		}
 	}
 
-	private void handleNaturalIdResolutions(EntityPersister persister, SharedSessionContractImplementor session, Object id) {
+	protected void handleNaturalIdResolutions(EntityPersister persister, SharedSessionContractImplementor session, Object id) {
 		if ( naturalIdMapping != null ) {
 			session.getPersistenceContextInternal().getNaturalIdResolutions().manageSharedResolution(
 					id,
@@ -192,7 +192,7 @@ public class EntityUpdateAction extends EntityAction {
 		}
 	}
 
-	private void updateCacheItem(Object previousVersion, Object ck, EntityEntry entry) {
+	protected void updateCacheItem(Object previousVersion, Object ck, EntityEntry entry) {
 		final EntityPersister persister = getPersister();
 		if ( persister.canWriteToCache() ) {
 			final SharedSessionContractImplementor session = getSession();
@@ -279,7 +279,7 @@ public class EntityUpdateAction extends EntityAction {
 		}
 	}
 
-	private Object lockCacheItem(Object previousVersion) {
+	protected Object lockCacheItem(Object previousVersion) {
 		final EntityPersister persister = getPersister();
 		if ( persister.canWriteToCache() ) {
 			final SharedSessionContractImplementor session = getSession();

--- a/hibernate-core/src/main/java/org/hibernate/internal/AbstractSharedSessionContract.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/AbstractSharedSessionContract.java
@@ -735,7 +735,7 @@ public abstract class AbstractSharedSessionContract implements SharedSessionCont
 		return query;
 	}
 
-	private <R> HqlInterpretation interpretHql(String hql, Class<R> resultType) {
+	protected <R> HqlInterpretation interpretHql(String hql, Class<R> resultType) {
 		final QueryEngine queryEngine = getFactory().getQueryEngine();
 		return queryEngine.getInterpretationCache()
 				.resolveHqlInterpretation(
@@ -745,13 +745,13 @@ public abstract class AbstractSharedSessionContract implements SharedSessionCont
 				);
 	}
 
-	private static void checkSelectionQuery(String hql, HqlInterpretation hqlInterpretation) {
+	protected static void checkSelectionQuery(String hql, HqlInterpretation hqlInterpretation) {
 		if ( !( hqlInterpretation.getSqmStatement() instanceof SqmSelectStatement ) ) {
 			throw new IllegalSelectQueryException( "Expecting a selection query, but found `" + hql + "`", hql);
 		}
 	}
 
-	private static <R> void checkResultType(Class<R> expectedResultType, SqmSelectionQueryImpl<?> query) {
+	protected static <R> void checkResultType(Class<R> expectedResultType, SqmSelectionQueryImpl<?> query) {
 		final Class<?> resultType = query.getResultType();
 		if ( !expectedResultType.isAssignableFrom( resultType ) ) {
 			throw new QueryTypeMismatchException(
@@ -836,7 +836,7 @@ public abstract class AbstractSharedSessionContract implements SharedSessionCont
 		}
 	}
 
-	private NamedResultSetMappingMemento getResultSetMappingMemento(String resultSetMappingName) {
+	protected NamedResultSetMappingMemento getResultSetMappingMemento(String resultSetMappingName) {
 		final NamedResultSetMappingMemento resultSetMappingMemento = getFactory().getQueryEngine()
 				.getNamedObjectRepository().getResultSetMappingMemento( resultSetMappingName );
 		if ( resultSetMappingMemento == null ) {
@@ -1088,7 +1088,7 @@ public abstract class AbstractSharedSessionContract implements SharedSessionCont
 		return query;
 	}
 
-	private static void checkMutationQuery(String hqlString, SqmStatement<?> sqmStatement) {
+	protected static void checkMutationQuery(String hqlString, SqmStatement<?> sqmStatement) {
 		if ( !( sqmStatement instanceof SqmDmlStatement ) ) {
 			throw new IllegalMutationQueryException( "Expecting a mutation query, but found `" + hqlString + "`" );
 		}
@@ -1112,7 +1112,7 @@ public abstract class AbstractSharedSessionContract implements SharedSessionCont
 		);
 	}
 
-	private NativeQueryImplementor<?> createNativeQueryImplementor(String queryName, NamedNativeQueryMemento memento) {
+	protected NativeQueryImplementor<?> createNativeQueryImplementor(String queryName, NamedNativeQueryMemento memento) {
 		final NativeQueryImplementor<?> query = memento.toQuery( this );
 		final Boolean isUnequivocallySelect = query.isSelectQuery();
 		if ( isUnequivocallySelect == TRUE ) {
@@ -1128,7 +1128,7 @@ public abstract class AbstractSharedSessionContract implements SharedSessionCont
 		return query;
 	}
 
-	private SqmQueryImplementor<?> createSqmQueryImplementor(String queryName, NamedSqmQueryMemento memento) {
+	protected SqmQueryImplementor<?> createSqmQueryImplementor(String queryName, NamedSqmQueryMemento memento) {
 		final SqmQueryImplementor<?> query = memento.toQuery( this );
 		final SqmStatement<?> sqmStatement = query.getSqmStatement();
 		if ( !( sqmStatement instanceof SqmDmlStatement ) ) {

--- a/hibernate-core/src/main/java/org/hibernate/internal/SessionImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/SessionImpl.java
@@ -1087,7 +1087,7 @@ public class SessionImpl
 		}
 	}
 
-	private static LoadType internalLoadType(boolean eager, boolean nullable) {
+	protected static LoadType internalLoadType(boolean eager, boolean nullable) {
 		if ( nullable ) {
 			return LoadEventListener.INTERNAL_LOAD_NULLABLE;
 		}


### PR DESCRIPTION
Reactive support for ORM currently uses redundant code already in ORM.  Changing the visibility of a handful of methods from `private` to `protected` will simplify HR code and reduce risk of future errors.

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-16999
<!-- Hibernate GitHub Bot issue links end -->