### PR TITLE
HHH-16911 Ensure the PhantomReference doesn't get collected before having had a change to trigger

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,10 +1,10 @@
 # Keep all these properties in sync unless you know what you are doing!
 # We set '-Dlog4j2.disableJmx=true' to prevent classloader leaks triggered by the logger.
 # (Some of these settings need to be repeated in the test.jvmArgs blocks of each module)
-org.gradle.jvmargs=-Dlog4j2.disableJmx -Xmx2g -XX:MaxMetaspaceSize=256m -XX:+HeapDumpOnOutOfMemoryError -Duser.language=en -Duser.country=US -Duser.timezone=UTC -Dfile.encoding=UTF-8
-toolchain.compiler.jvmargs=-Dlog4j2.disableJmx=true -Xmx2g -XX:MaxMetaspaceSize=256m -XX:+HeapDumpOnOutOfMemoryError -Duser.language=en -Duser.country=US -Duser.timezone=UTC -Dfile.encoding=UTF-8
-toolchain.javadoc.jvmargs=-Dlog4j2.disableJmx=true -Xmx2g -XX:MaxMetaspaceSize=256m -XX:+HeapDumpOnOutOfMemoryError -Duser.language=en -Duser.country=US -Duser.timezone=UTC -Dfile.encoding=UTF-8
-toolchain.launcher.jvmargs=-Dlog4j2.disableJmx=true -Xmx2g -XX:MaxMetaspaceSize=384m -XX:+HeapDumpOnOutOfMemoryError -Duser.language=en -Duser.country=US -Duser.timezone=UTC -Dfile.encoding=UTF-8
+org.gradle.jvmargs=-Dlog4j2.disableJmx -Xmx3g -XX:MaxMetaspaceSize=256m -XX:+HeapDumpOnOutOfMemoryError -Duser.language=en -Duser.country=US -Duser.timezone=UTC -Dfile.encoding=UTF-8
+toolchain.compiler.jvmargs=-Dlog4j2.disableJmx=true -Xmx3g -XX:MaxMetaspaceSize=256m -XX:+HeapDumpOnOutOfMemoryError -Duser.language=en -Duser.country=US -Duser.timezone=UTC -Dfile.encoding=UTF-8
+toolchain.javadoc.jvmargs=-Dlog4j2.disableJmx=true -Xmx3g -XX:MaxMetaspaceSize=256m -XX:+HeapDumpOnOutOfMemoryError -Duser.language=en -Duser.country=US -Duser.timezone=UTC -Dfile.encoding=UTF-8
+toolchain.launcher.jvmargs=-Dlog4j2.disableJmx=true -Xmx3g -XX:MaxMetaspaceSize=384m -XX:+HeapDumpOnOutOfMemoryError -Duser.language=en -Duser.country=US -Duser.timezone=UTC -Dfile.encoding=UTF-8
 
 org.gradle.parallel=true
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/bootstrap/registry/classloading/PhantomReferenceLeakDetector.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/bootstrap/registry/classloading/PhantomReferenceLeakDetector.java
@@ -21,7 +21,7 @@ import org.junit.Assert;
  *
  * @author Sanne Grinovero (C) 2023 Red Hat Inc.
  */
-public class PhantomReferenceLeakDetector {
+public final class PhantomReferenceLeakDetector {
 
 	/**
 	 * A single second should be more than enough; this might need
@@ -34,6 +34,7 @@ public class PhantomReferenceLeakDetector {
 	 */
 	private static final int MAX_TOTAL_WAIT_SECONDS = 180;
 	private static final int GC_ATTEMPTS = MAX_TOTAL_WAIT_SECONDS * 5;
+	private static PhantomReference hold;
 
 	/**
 	 * Asserts that a certain operation won't be leaking
@@ -77,11 +78,35 @@ public class PhantomReferenceLeakDetector {
 		T criticalReference = action.get();
 		final ReferenceQueue<T> referenceQueue = new ReferenceQueue<>();
 		final PhantomReference<T> reference = new PhantomReference<>( criticalReference, referenceQueue );
+		holdOnTo( reference );
 		//Ignore IDE's suggestion to remove the following line: we really need it!
 		// (it could be inlined above, but I prefer this style so that it serves as an example for
 		// future maintenance of how this works)
 		criticalReference = null;
-		return verifyCollection( referenceQueue, gcAttempts, totalWaitSeconds );
+		try {
+			return verifyCollection( referenceQueue, gcAttempts, totalWaitSeconds );
+		}
+		finally {
+			clearHeldReferences();
+		}
+	}
+
+	private static synchronized void clearHeldReferences() {
+		PhantomReferenceLeakDetector.hold = null;
+	}
+
+	/**
+	 * Ensure we keep a reference to the PhantomReference until we're done
+	 * with the test, otherwise it might get collected before having had
+	 * a change to trigger; this seems to behave differently on different
+	 * JVMs but is most likely just a timing issue.
+	 * @param reference
+	 */
+	private static synchronized void holdOnTo(PhantomReference reference) {
+		if ( PhantomReferenceLeakDetector.hold != null ) {
+			throw new IllegalStateException( "Detected recursive use of PhantomReferenceLeakDetector, which is not supported, or possibly a leaked previous run" );
+		}
+		PhantomReferenceLeakDetector.hold = reference;
 	}
 
 	private static <T> boolean verifyCollection(final ReferenceQueue<T> referenceQueue, final int gcAttempts, final int totalWaitSeconds) {


### PR DESCRIPTION
Follow up to [HHH-16911](https://hibernate.atlassian.net/browse/HHH-16911) , possibly fixing the issues on x390

Many thanks to Andrew Haley for suggesting it.

[HHH-16911]: https://hibernate.atlassian.net/browse/HHH-16911?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ