### PR TITLE
Backport HHH-16832 to branch 6.2 - Follow-up: add missing test annotation

### DIFF
--- a/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhance/internal/bytebuddy/DirtyCheckingWithEmbeddableAndNonVisibleGenericMappedSuperclassTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhance/internal/bytebuddy/DirtyCheckingWithEmbeddableAndNonVisibleGenericMappedSuperclassTest.java
@@ -50,6 +50,7 @@ import jakarta.persistence.Id;
 public class DirtyCheckingWithEmbeddableAndNonVisibleGenericMappedSuperclassTest {
 
 	@JiraKey("HHH-16832")
+	@Test
 	public void shouldNotBreakConstructor() {
 		// This is the actual reproducer for HHH-16832,
 		// other method are just to be consistent with tests in the same package.


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-16832
