### PR TITLE
HHH-16971 Upgrade ByteBuddy to 1.14.5

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -53,7 +53,7 @@ dependencyResolutionManagement {
     versionCatalogs {
         libs {
             def antlrVersion = "4.10.1"
-            def byteBuddyVersion = "1.12.23"
+            def byteBuddyVersion = "1.14.5"
             def classmateVersion = "1.5.1"
             def geolatteVersion = "1.8.2"
             def hcannVersion = "6.0.6.Final"


### PR DESCRIPTION
Just checking if the Hibernate ORM main branch testsuite passes with ByteBuddy 1.14.5 which is the most recent BB release and includes the latest ASM release that has a constant defined for Java SE 21.

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-16971
<!-- Hibernate GitHub Bot issue links end -->