### PR TITLE
Use backward compatible BIGINT instead of INTEGER for NUMBER(10,0) JDBC type

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/dialect/OracleDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/OracleDialect.java
@@ -771,7 +771,14 @@ public class OracleDialect extends Dialect {
 					// Don't infer TINYINT or SMALLINT on Oracle, since the
 					// range of values of a NUMBER(3,0) or NUMBER(5,0) just
 					// doesn't really match naturally.
-					if ( precision <= 10 ) {
+
+					// Backwards compatibility patch:
+					// In Oracle8iDialect (maybe also in previous and
+					// intermediate versions) all DECIMALs used BIGINT JDBC
+					// type descriptor.
+					boolean tryInteger = false;
+
+					if ( tryInteger && precision <= 10 ) {
 						// We map INTEGER to NUMBER(10,0), so we should also
 						// map NUMBER(10,0) back to INTEGER. (In principle,
 						// a NUMBER(10,0) might not fit in a 32-bit integer,


### PR DESCRIPTION
The problem, a breaking change, occurred after changing the SQL dialect.

Previous versions (specifically, OracleDialect8, OracleDialect9 and OracleDialect10) returned BigDecimal for all NUMBER Oracle/SQL types, Oracle12cDialect return Integer for  NUMBER with precision <= 10. This breaks the current logic, because you can't directly cast Integer to BigDecimal.

We think this is a bug, because it's a breaking change, which is not documented.


### Versions:

OLD:
<hibernate.version>6.2.7.Final</hibernate.version>
<property name="hibernate.dialect" value="org.hibernate.dialect.Oracle12cDialect"/>

NEW:
<property name="hibernate.dialect" value="org.hibernate.dialect.Oracle10gDialect"/>
<hibernate.version>5.3.17.Final</hibernate.version>


### Proposed solutions

1. Fix/update the OracleDialect in Hibernate v6.

2. Create a separate, new dialect, e.g. OracleDialectLegacy.