### PR TITLE
HHH-17009 put back AbstractPostInsertGenerator in deprecated mode

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/id/AbstractPostInsertGenerator.java
+++ b/hibernate-core/src/main/java/org/hibernate/id/AbstractPostInsertGenerator.java
@@ -1,0 +1,20 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.id;
+
+/**
+ * Basic implementation of the {@link PostInsertIdentifierGenerator} contract.
+ *
+ * @deprecated Subclasses should now directly inherit {@link PostInsertIdentifierGenerator} and
+ *             {@link BulkInsertionCapableIdentifierGenerator}, or even better, simply implement
+ *             {@link org.hibernate.generator.OnExecutionGenerator} directly.
+ *
+ * @author Gavin King
+ */
+@Deprecated(forRemoval = true, since = "6.2")
+public abstract class AbstractPostInsertGenerator
+		implements PostInsertIdentifierGenerator, BulkInsertionCapableIdentifierGenerator {}

--- a/hibernate-core/src/main/java/org/hibernate/id/IdentifierGeneratorHelper.java
+++ b/hibernate-core/src/main/java/org/hibernate/id/IdentifierGeneratorHelper.java
@@ -45,7 +45,7 @@ public final class IdentifierGeneratorHelper {
 	 *
 	 * @deprecated This is not an elegant way to do anything
 	 */
-	@Deprecated(forRemoval = true)
+	@Deprecated(forRemoval = true, since = "6.2")
 	public static final Serializable SHORT_CIRCUIT_INDICATOR = new Serializable() {
 		@Override
 		public String toString() {
@@ -59,7 +59,7 @@ public final class IdentifierGeneratorHelper {
 	 *
 	 * @deprecated Use a {@link org.hibernate.generator.OnExecutionGenerator}
 	 */
-	@Deprecated(forRemoval = true)
+	@Deprecated(forRemoval = true, since = "6.2")
 	public static final Serializable POST_INSERT_INDICATOR = new Serializable() {
 		@Override
 		public String toString() {


### PR DESCRIPTION
I should not have removed this class, I messed up there.

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-17009
<!-- Hibernate GitHub Bot issue links end -->