### PR TITLE
HHH-17034 + HHH-17035 + HHH-17041

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/boot/model/internal/ClassPropertyHolder.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/internal/ClassPropertyHolder.java
@@ -363,14 +363,19 @@ public class ClassPropertyHolder extends AbstractPropertyHolder {
 							actualProperty.setValue( context.getMetadataCollector().getGenericComponent( componentClass ) );
 						}
 						else {
-							final Iterator<Property> propertyIterator = component.getPropertyIterator();
-							while ( propertyIterator.hasNext() ) {
-								Property property = propertyIterator.next();
-								try {
-									property.getGetter( componentClass );
-								}
-								catch (PropertyNotFoundException e) {
-									propertyIterator.remove();
+							if ( componentClass == Object.class ) {
+								// Object is not a valid component class, but that is what we get when using a type variable
+								component.getProperties().clear();
+							}
+							else {
+								final Iterator<Property> propertyIterator = component.getPropertyIterator();
+								while ( propertyIterator.hasNext() ) {
+									try {
+										propertyIterator.next().getGetter( componentClass );
+									}
+									catch (PropertyNotFoundException e) {
+										propertyIterator.remove();
+									}
 								}
 							}
 						}

--- a/hibernate-core/src/main/java/org/hibernate/bytecode/enhance/internal/bytebuddy/CodeTemplates.java
+++ b/hibernate-core/src/main/java/org/hibernate/bytecode/enhance/internal/bytebuddy/CodeTemplates.java
@@ -608,20 +608,20 @@ class CodeTemplates {
 	static class GetterMapping implements Advice.OffsetMapping {
 
 		private final TypeDescription.Generic returnType;
-		private final String name;
+		private final FieldDescription persistentField;
 
 		GetterMapping(FieldDescription persistentField) {
 			this( persistentField, persistentField.getType() );
 		}
 
 		GetterMapping(FieldDescription persistentField, TypeDescription.Generic returnType) {
-			this.name = persistentField.getName();
+			this.persistentField = persistentField;
 			this.returnType = returnType;
 		}
 
 		@Override public Target resolve(TypeDescription instrumentedType, MethodDescription instrumentedMethod, Assigner assigner, Advice.ArgumentHandler argumentHandler, Sort sort) {
-			MethodDescription.Token signature = new MethodDescription.Token( EnhancerConstants.PERSISTENT_FIELD_READER_PREFIX + name , Opcodes.ACC_PUBLIC, returnType );
-			MethodDescription method = new MethodDescription.Latent( instrumentedType.getSuperClass().asErasure(), signature );
+			MethodDescription.Token signature = new MethodDescription.Token( EnhancerConstants.PERSISTENT_FIELD_READER_PREFIX + persistentField.getName() , Opcodes.ACC_PUBLIC, returnType );
+			MethodDescription method = new MethodDescription.Latent( persistentField.getDeclaringType().asErasure(), signature );
 
 			return new Target.AbstractReadOnlyAdapter() {
 				@Override

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/internal/EmbeddableRepresentationStrategyPojo.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/internal/EmbeddableRepresentationStrategyPojo.java
@@ -32,7 +32,6 @@ import org.hibernate.property.access.internal.PropertyAccessStrategyIndexBackRef
 import org.hibernate.property.access.spi.BuiltInPropertyAccessStrategies;
 import org.hibernate.property.access.spi.PropertyAccess;
 import org.hibernate.property.access.spi.PropertyAccessStrategy;
-import org.hibernate.service.ServiceRegistry;
 import org.hibernate.type.descriptor.java.JavaType;
 import org.hibernate.type.descriptor.java.spi.JavaTypeRegistry;
 import org.hibernate.type.internal.CompositeUserTypeJavaTypeWrapper;

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhance/internal/bytebuddy/DirtyCheckingWithEmbeddableAndNonVisibleGenericMappedSuperclassWithDifferentGenericParameterNameTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhance/internal/bytebuddy/DirtyCheckingWithEmbeddableAndNonVisibleGenericMappedSuperclassWithDifferentGenericParameterNameTest.java
@@ -1,0 +1,114 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html
+ */
+package org.hibernate.orm.test.bytecode.enhance.internal.bytebuddy;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hibernate.bytecode.enhance.spi.EnhancerConstants.ENTITY_ENTRY_GETTER_NAME;
+import static org.hibernate.bytecode.enhance.spi.EnhancerConstants.ENTITY_INSTANCE_GETTER_NAME;
+import static org.hibernate.bytecode.enhance.spi.EnhancerConstants.NEXT_GETTER_NAME;
+import static org.hibernate.bytecode.enhance.spi.EnhancerConstants.NEXT_SETTER_NAME;
+import static org.hibernate.bytecode.enhance.spi.EnhancerConstants.PERSISTENT_FIELD_READER_PREFIX;
+import static org.hibernate.bytecode.enhance.spi.EnhancerConstants.PERSISTENT_FIELD_WRITER_PREFIX;
+import static org.hibernate.bytecode.enhance.spi.EnhancerConstants.PREVIOUS_GETTER_NAME;
+import static org.hibernate.bytecode.enhance.spi.EnhancerConstants.PREVIOUS_SETTER_NAME;
+import static org.hibernate.bytecode.enhance.spi.EnhancerConstants.TRACKER_CLEAR_NAME;
+import static org.hibernate.bytecode.enhance.spi.EnhancerConstants.TRACKER_GET_NAME;
+import static org.hibernate.bytecode.enhance.spi.EnhancerConstants.TRACKER_HAS_CHANGED_NAME;
+import static org.hibernate.bytecode.enhance.spi.EnhancerConstants.TRACKER_SUSPEND_NAME;
+
+import org.hibernate.testing.bytecode.enhancement.BytecodeEnhancerRunner;
+import org.hibernate.testing.bytecode.enhancement.EnhancementOptions;
+import org.hibernate.testing.orm.junit.JiraKey;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.MappedSuperclass;
+
+@JiraKey("HHH-17035")
+@RunWith(BytecodeEnhancerRunner.class)
+@EnhancementOptions(inlineDirtyChecking = true)
+public class DirtyCheckingWithEmbeddableAndNonVisibleGenericMappedSuperclassWithDifferentGenericParameterNameTest {
+
+	@Test
+	public void shouldDeclareMethodsInEntityClass() {
+		// The test really is just about checking that bytecode enhancement
+		// (which will run when we load the class for the first time)
+		// does not fail with a StackOverflowError.
+		// But it doesn't hurt to perform a few additional checks.
+		assertThat( MyEntity.class )
+				.hasDeclaredMethods( PERSISTENT_FIELD_READER_PREFIX + "id", PERSISTENT_FIELD_WRITER_PREFIX + "id" )
+				.hasDeclaredMethods( PERSISTENT_FIELD_READER_PREFIX + "embedded", PERSISTENT_FIELD_WRITER_PREFIX + "embedded" )
+				.hasDeclaredMethods( ENTITY_INSTANCE_GETTER_NAME, ENTITY_ENTRY_GETTER_NAME )
+				.hasDeclaredMethods( PREVIOUS_GETTER_NAME, PREVIOUS_SETTER_NAME, NEXT_GETTER_NAME, NEXT_SETTER_NAME )
+				.hasDeclaredMethods( TRACKER_HAS_CHANGED_NAME, TRACKER_CLEAR_NAME, TRACKER_SUSPEND_NAME, TRACKER_GET_NAME );
+	}
+
+	@MappedSuperclass
+	public static abstract class MyAbstractEmbeddable {
+	}
+
+	@Embeddable
+	public static class MyEmbeddable extends MyAbstractEmbeddable {
+
+		@Column
+		private String text;
+
+		public MyEmbeddable() {
+		}
+
+		private MyEmbeddable(String text) {
+			this.text = text;
+		}
+
+		public String getText() {
+			return text;
+		}
+
+		public void setText(String text) {
+			this.text = text;
+		}
+	}
+
+
+	@MappedSuperclass
+	// The key to reproducing the problem is to use a different name for the generic parameter
+	// in this class than in the superclass.
+	// Note that, as in other similar tests, the field of the superclass needs
+	// to not be visible from the subclass in other to reproduce the problem.
+	public static abstract class MyLevel2GenericMappedSuperclass<T extends MyAbstractEmbeddable>
+			extends MyNonVisibleGenericMappedSuperclass<T> {
+	}
+
+	@Entity(name = "myentity")
+	public static class MyEntity extends MyLevel2GenericMappedSuperclass<MyEmbeddable> {
+
+		@Id
+		private Integer id;
+
+		public MyEntity() {
+		}
+
+		private MyEntity(Integer id, String text) {
+			this.id = id;
+			setEmbedded( new MyEmbeddable( text ) );
+		}
+
+		public Integer getId() {
+			return id;
+		}
+
+		public void setId(Integer id) {
+			this.id = id;
+		}
+
+	}
+
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhance/internal/bytebuddy/DirtyCheckingWithEmbeddableAndTwiceRemovedNonVisibleGenericMappedSuperclassTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhance/internal/bytebuddy/DirtyCheckingWithEmbeddableAndTwiceRemovedNonVisibleGenericMappedSuperclassTest.java
@@ -1,0 +1,92 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html
+ */
+package org.hibernate.orm.test.bytecode.enhance.internal.bytebuddy;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.hibernate.bytecode.enhance.spi.EnhancerConstants.PERSISTENT_FIELD_READER_PREFIX;
+import static org.hibernate.bytecode.enhance.spi.EnhancerConstants.PERSISTENT_FIELD_WRITER_PREFIX;
+
+import org.hibernate.testing.bytecode.enhancement.BytecodeEnhancerRunner;
+import org.hibernate.testing.bytecode.enhancement.EnhancementOptions;
+import org.hibernate.testing.orm.junit.JiraKey;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.MappedSuperclass;
+
+@RunWith(BytecodeEnhancerRunner.class)
+@EnhancementOptions(inlineDirtyChecking = true)
+public class DirtyCheckingWithEmbeddableAndTwiceRemovedNonVisibleGenericMappedSuperclassTest {
+
+	@JiraKey("HHH-17034")
+	@Test
+	public void shouldNotBreakConstructor() {
+		// Check the class has been enhanced
+		assertThat( MyEntity.class )
+				.hasDeclaredMethods( PERSISTENT_FIELD_READER_PREFIX + "embedded", PERSISTENT_FIELD_WRITER_PREFIX + "embedded" );
+
+		assertThatCode( () -> new MyEntity( 0, "Magic the Gathering" ) )
+				.doesNotThrowAnyException();
+	}
+
+	@Embeddable
+	public static class MyEmbeddable  {
+
+		@Column
+		private String text;
+
+		public MyEmbeddable() {
+		}
+
+		private MyEmbeddable(String text) {
+			this.text = text;
+		}
+
+		public String getText() {
+			return text;
+		}
+
+		public void setText(String text) {
+			this.text = text;
+		}
+	}
+
+	@MappedSuperclass
+	public static abstract class MyMappedSuperclass
+			extends MyNonVisibleGenericMappedSuperclass<MyEmbeddable> {
+	}
+
+	@Entity(name = "myentity")
+	public static class MyEntity extends MyMappedSuperclass {
+
+		@Id
+		private Integer id;
+
+		public MyEntity() {
+		}
+
+		private MyEntity(Integer id, String text) {
+			this.id = id;
+			setEmbedded( new MyEmbeddable( text ) );
+		}
+
+		public Integer getId() {
+			return id;
+		}
+
+		public void setId(Integer id) {
+			this.id = id;
+		}
+
+	}
+
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhance/internal/bytebuddy/DirtyCheckingWithEmbeddableExtedingAnotherEmbeddableAndTwiceRemovedNonVisibleGenericMappedSuperclassTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhance/internal/bytebuddy/DirtyCheckingWithEmbeddableExtedingAnotherEmbeddableAndTwiceRemovedNonVisibleGenericMappedSuperclassTest.java
@@ -1,0 +1,99 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html
+ */
+package org.hibernate.orm.test.bytecode.enhance.internal.bytebuddy;
+
+import org.hibernate.testing.bytecode.enhancement.BytecodeEnhancerRunner;
+import org.hibernate.testing.bytecode.enhancement.EnhancementOptions;
+import org.hibernate.testing.orm.junit.JiraKey;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.MappedSuperclass;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.hibernate.bytecode.enhance.spi.EnhancerConstants.PERSISTENT_FIELD_READER_PREFIX;
+import static org.hibernate.bytecode.enhance.spi.EnhancerConstants.PERSISTENT_FIELD_WRITER_PREFIX;
+
+@RunWith(BytecodeEnhancerRunner.class)
+@EnhancementOptions(inlineDirtyChecking = true)
+public class DirtyCheckingWithEmbeddableExtedingAnotherEmbeddableAndTwiceRemovedNonVisibleGenericMappedSuperclassTest {
+
+	@JiraKey("HHH-17034")
+	@Test
+	public void shouldNotBreakConstructor() {
+		// Check the class has been enhanced
+		assertThat( MyEntity.class )
+				.hasDeclaredMethods(
+						PERSISTENT_FIELD_READER_PREFIX + "embedded",
+						PERSISTENT_FIELD_WRITER_PREFIX + "embedded"
+				);
+
+		assertThatCode( () -> new MyEntity( 0, "Magic the Gathering" ) )
+				.doesNotThrowAnyException();
+	}
+
+	@MappedSuperclass
+	public static abstract class MyAbstractEmbeddable {
+	}
+
+	@Embeddable
+	public static class MyEmbeddable extends MyAbstractEmbeddable {
+
+		@Column
+		private String text;
+
+		public MyEmbeddable() {
+		}
+
+		private MyEmbeddable(String text) {
+			this.text = text;
+		}
+
+		public String getText() {
+			return text;
+		}
+
+		public void setText(String text) {
+			this.text = text;
+		}
+	}
+
+	@MappedSuperclass
+	public static abstract class MyMappedSuperclass<C extends MyAbstractEmbeddable>
+			extends MyNonVisibleGenericMappedSuperclass<C> {
+	}
+
+	@Entity(name = "myentity")
+	public static class MyEntity extends MyMappedSuperclass<MyEmbeddable> {
+
+		@Id
+		private Integer id;
+
+		public MyEntity() {
+		}
+
+		private MyEntity(Integer id, String text) {
+			this.id = id;
+			setEmbedded( new MyEmbeddable( text ) );
+		}
+
+		public Integer getId() {
+			return id;
+		}
+
+		public void setId(Integer id) {
+			this.id = id;
+		}
+
+	}
+
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhance/internal/bytebuddy/DirtyCheckingWithEmbeddableExtendingMappedSuperclassTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhance/internal/bytebuddy/DirtyCheckingWithEmbeddableExtendingMappedSuperclassTest.java
@@ -1,0 +1,130 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html
+ */
+package org.hibernate.orm.test.bytecode.enhance.internal.bytebuddy;
+
+import java.util.List;
+
+import org.hibernate.testing.bytecode.enhancement.BytecodeEnhancerRunner;
+import org.hibernate.testing.bytecode.enhancement.EnhancementOptions;
+import org.hibernate.testing.junit4.BaseCoreFunctionalTestCase;
+import org.hibernate.testing.orm.junit.JiraKey;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import jakarta.persistence.Embeddable;
+import jakarta.persistence.Embedded;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.MappedSuperclass;
+import jakarta.persistence.Tuple;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@RunWith(BytecodeEnhancerRunner.class)
+@EnhancementOptions(inlineDirtyChecking = true)
+public class DirtyCheckingWithEmbeddableExtendingMappedSuperclassTest extends
+		BaseCoreFunctionalTestCase {
+
+	@Override
+	protected Class<?>[] getAnnotatedClasses() {
+		return new Class[]{
+				MyEntity.class
+		};
+	}
+
+	@JiraKey("HHH-17041")
+	@Test
+	public void testQueryEmbeddableFields() {
+		inTransaction(
+				session -> {
+					MyEntity myEntity  = new MyEntity(1, "one");
+					session.persist( myEntity );
+				}
+		);
+		inTransaction(
+				session -> {
+					List<Tuple> result = session.createQuery( "select m.embedded.text, m.embedded.name from MyEntity m", Tuple.class ).list();
+					assertThat( result.size() ).isEqualTo( 1 );
+					Tuple tuple = result.get( 0 );
+					assertThat( tuple.get( 0 ) ).isEqualTo( "one" );
+					assertThat( tuple.get( 1 ) ).isNull();
+
+				}
+		);
+	}
+
+	@MappedSuperclass
+	public static abstract class MyAbstractEmbeddable {
+		private String name;
+
+		public String getName() {
+			return name;
+		}
+
+		public void setName(String name) {
+			this.name = name;
+		}
+	}
+
+	@Embeddable
+	public static class MyEmbeddable extends MyAbstractEmbeddable {
+
+		private String text;
+
+		public MyEmbeddable() {
+		}
+
+		private MyEmbeddable(String text) {
+			this.text = text;
+		}
+
+		public String getText() {
+			return text;
+		}
+
+		public void setText(String text) {
+			this.text = text;
+		}
+	}
+
+
+	@Entity(name = "MyEntity")
+	public static class MyEntity  {
+
+		@Id
+		private Integer id;
+
+		@Embedded
+		private MyEmbeddable embedded;
+
+		public MyEmbeddable getEmbedded() {
+			return embedded;
+		}
+
+		public void setEmbedded(MyEmbeddable embedded) {
+			this.embedded = embedded;
+		}
+
+		public MyEntity() {
+		}
+
+		private MyEntity(Integer id, String text) {
+			this.id = id;
+			setEmbedded( new MyEmbeddable( text ) );
+		}
+
+		public Integer getId() {
+			return id;
+		}
+
+		public void setId(Integer id) {
+			this.id = id;
+		}
+
+	}
+
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhance/internal/bytebuddy/DirtyCheckingWithEmbeddableNonVisibleGenericExtendsSerializableMappedSuperclassTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhance/internal/bytebuddy/DirtyCheckingWithEmbeddableNonVisibleGenericExtendsSerializableMappedSuperclassTest.java
@@ -1,0 +1,126 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html
+ */
+package org.hibernate.orm.test.bytecode.enhance.internal.bytebuddy;
+
+import java.io.Serializable;
+import java.util.List;
+
+import org.hibernate.testing.bytecode.enhancement.BytecodeEnhancerRunner;
+import org.hibernate.testing.bytecode.enhancement.EnhancementOptions;
+import org.hibernate.testing.junit4.BaseCoreFunctionalTestCase;
+import org.hibernate.testing.orm.junit.JiraKey;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import jakarta.persistence.Embeddable;
+import jakarta.persistence.Embedded;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.MappedSuperclass;
+import jakarta.persistence.Tuple;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@RunWith(BytecodeEnhancerRunner.class)
+@EnhancementOptions(inlineDirtyChecking = true)
+public class DirtyCheckingWithEmbeddableNonVisibleGenericExtendsSerializableMappedSuperclassTest extends
+		BaseCoreFunctionalTestCase {
+
+	@Override
+	protected Class<?>[] getAnnotatedClasses() {
+		return new Class[]{
+				MyEntity.class
+		};
+	}
+
+	@JiraKey("HHH-17041")
+	@Test
+	public void testQueryEmbeddableFields() {
+		inTransaction(
+				session -> {
+					MyEntity myEntity  = new MyEntity(1, "one");
+					session.persist( myEntity );
+				}
+		);
+		inTransaction(
+				session -> {
+					List<Tuple> result = session.createQuery( "select m.embedded.text, m.embedded.name from MyEntity m", Tuple.class ).list();
+					assertThat( result.size() ).isEqualTo( 1 );
+					Tuple tuple = result.get( 0 );
+					assertThat( tuple.get( 0 ) ).isEqualTo( "one" );
+					assertThat( tuple.get( 1 ) ).isNull();
+
+				}
+		);
+	}
+
+	@MappedSuperclass
+	public static abstract class MyAbstractEmbeddable implements Serializable {
+		private String name;
+
+		public String getName() {
+			return name;
+		}
+
+		public void setName(String name) {
+			this.name = name;
+		}
+	}
+
+	@Embeddable
+	public static class MyEmbeddable extends MyAbstractEmbeddable {
+
+		private String text;
+
+		public MyEmbeddable() {
+		}
+
+		private MyEmbeddable(String text) {
+			this.text = text;
+		}
+
+		public String getText() {
+			return text;
+		}
+
+		public void setText(String text) {
+			this.text = text;
+		}
+	}
+
+
+	@MappedSuperclass
+	public static abstract class MyMappedSuperclass<C extends MyAbstractEmbeddable>
+			extends MyNonVisibleGenericExtendsSerializableMappedSuperclass<C> {
+	}
+
+	@Entity(name = "MyEntity")
+	public static class MyEntity extends
+			MyMappedSuperclass<MyEmbeddable> {
+
+		@Id
+		private Integer id;
+
+		public MyEntity() {
+		}
+
+		private MyEntity(Integer id, String text) {
+			this.id = id;
+			setEmbedded( new MyEmbeddable( text ) );
+		}
+
+		public Integer getId() {
+			return id;
+		}
+
+		public void setId(Integer id) {
+			this.id = id;
+		}
+
+	}
+
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhance/internal/bytebuddy/MyNonVisibleGenericExtendsSerializableMappedSuperclass.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhance/internal/bytebuddy/MyNonVisibleGenericExtendsSerializableMappedSuperclass.java
@@ -1,0 +1,29 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html
+ */
+package org.hibernate.orm.test.bytecode.enhance.internal.bytebuddy;
+
+import java.io.Serializable;
+
+import jakarta.persistence.Embedded;
+import jakarta.persistence.MappedSuperclass;
+
+// This class must not be nested in the test class, otherwise its private fields will be visible
+// from subclasses and we won't reproduce the bug.
+@MappedSuperclass
+public abstract class MyNonVisibleGenericExtendsSerializableMappedSuperclass<C extends Serializable> {
+
+	@Embedded
+	private C embedded;
+
+	public C getEmbedded() {
+		return embedded;
+	}
+
+	public void setEmbedded(C embedded) {
+		this.embedded = embedded;
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/component/EmbeddableAndGenericExtendingSerializableMappedSuperclassTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/component/EmbeddableAndGenericExtendingSerializableMappedSuperclassTest.java
@@ -1,0 +1,155 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html
+ */
+package org.hibernate.orm.test.component;
+
+import java.io.Serializable;
+
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.JiraKey;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.junit.jupiter.api.Test;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import jakarta.persistence.Embedded;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.MappedSuperclass;
+
+@DomainModel(
+		annotatedClasses = {
+				EmbeddableAndGenericExtendingSerializableMappedSuperclassTest.MyEntity.class,
+				EmbeddableAndGenericExtendingSerializableMappedSuperclassTest.AnotherEntity.class,
+		}
+)
+@SessionFactory
+public class EmbeddableAndGenericExtendingSerializableMappedSuperclassTest {
+
+	@JiraKey("HHH-17041")
+	@Test
+	public void testQueryEmbeddableFields(SessionFactoryScope scope) {
+		scope.inTransaction(
+				session -> {
+					session.createQuery( "select m.embedded.text, m.embedded.name from MyEntity m" ).list();
+				}
+		);
+	}
+
+	@MappedSuperclass
+	public static abstract class MyAbstractEmbeddable implements Serializable {
+		@Column
+		private String name;
+
+		public String getName() {
+			return name;
+		}
+
+		public void setName(String name) {
+			this.name = name;
+		}
+	}
+
+
+	@Embeddable
+	public static class MyEmbeddable extends MyAbstractEmbeddable {
+
+		@Column
+		private String text;
+
+		public MyEmbeddable() {
+		}
+
+		private MyEmbeddable(String text) {
+			this.text = text;
+		}
+
+		public String getText() {
+			return text;
+		}
+
+		public void setText(String text) {
+			this.text = text;
+		}
+	}
+
+	@Embeddable
+	public static class AnotherEmbeddable  {
+
+		@Column
+		private String value;
+
+		public AnotherEmbeddable() {
+		}
+
+		public String getValue() {
+			return value;
+		}
+
+		public void setValue(String value) {
+			this.value = value;
+		}
+	}
+
+	@MappedSuperclass
+	public static abstract class MyMappedSuperclass<C extends Serializable> {
+		@Embedded
+		private C embedded;
+
+		public C getEmbedded() {
+			return embedded;
+		}
+
+		public void setEmbedded(C embedded) {
+			this.embedded = embedded;
+		}
+	}
+
+	@Entity(name = "MyEntity")
+	public static class MyEntity extends MyMappedSuperclass<MyEmbeddable> {
+
+		@Id
+		private Integer id;
+
+		public MyEntity() {
+		}
+
+		private MyEntity(Integer id, String text) {
+			this.id = id;
+			setEmbedded( new MyEmbeddable( text ) );
+		}
+
+		public Integer getId() {
+			return id;
+		}
+
+		public void setId(Integer id) {
+			this.id = id;
+		}
+
+	}
+
+	@Entity(name = "AnotherEntity")
+	public static class AnotherEntity extends MyMappedSuperclass<MyEmbeddable> {
+
+		@Id
+		private Integer id;
+
+		public AnotherEntity() {
+		}
+
+		public Integer getId() {
+			return id;
+		}
+
+		public void setId(Integer id) {
+			this.id = id;
+		}
+
+	}
+
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/component/EmbeddableAndGenericMappedSuperclass2Test.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/component/EmbeddableAndGenericMappedSuperclass2Test.java
@@ -1,0 +1,153 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html
+ */
+package org.hibernate.orm.test.component;
+
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.JiraKey;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.junit.jupiter.api.Test;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import jakarta.persistence.Embedded;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.MappedSuperclass;
+
+@DomainModel(
+		annotatedClasses = {
+				EmbeddableAndGenericMappedSuperclass2Test.MyEntity.class,
+				EmbeddableAndGenericMappedSuperclass2Test.AnotherEntity.class,
+		}
+)
+@SessionFactory
+public class EmbeddableAndGenericMappedSuperclass2Test {
+
+	@JiraKey("HHH-17041")
+	@Test
+	public void testQueryEmbeddableFields(SessionFactoryScope scope) {
+		scope.inTransaction(
+				session -> {
+					session.createQuery( "select m.embedded.text, m.embedded.name from MyEntity m" ).list();
+				}
+		);
+	}
+
+	@MappedSuperclass
+	public static abstract class MyAbstractEmbeddable {
+		@Column
+		private String name;
+
+		public String getName() {
+			return name;
+		}
+
+		public void setName(String name) {
+			this.name = name;
+		}
+	}
+
+
+	@Embeddable
+	public static class MyEmbeddable extends MyAbstractEmbeddable {
+
+		@Column
+		private String text;
+
+		public MyEmbeddable() {
+		}
+
+		private MyEmbeddable(String text) {
+			this.text = text;
+		}
+
+		public String getText() {
+			return text;
+		}
+
+		public void setText(String text) {
+			this.text = text;
+		}
+	}
+
+	@Embeddable
+	public static class AnotherEmbeddable  {
+
+		@Column
+		private String value;
+
+		public AnotherEmbeddable() {
+		}
+
+		public String getValue() {
+			return value;
+		}
+
+		public void setValue(String value) {
+			this.value = value;
+		}
+	}
+
+	@MappedSuperclass
+	public static abstract class MyMappedSuperclass<C> {
+		@Embedded
+		private C embedded;
+
+		public C getEmbedded() {
+			return embedded;
+		}
+
+		public void setEmbedded(C embedded) {
+			this.embedded = embedded;
+		}
+	}
+
+	@Entity(name = "MyEntity")
+	public static class MyEntity extends MyMappedSuperclass<MyEmbeddable> {
+
+		@Id
+		private Integer id;
+
+		public MyEntity() {
+		}
+
+		private MyEntity(Integer id, String text) {
+			this.id = id;
+			setEmbedded( new MyEmbeddable( text ) );
+		}
+
+		public Integer getId() {
+			return id;
+		}
+
+		public void setId(Integer id) {
+			this.id = id;
+		}
+
+	}
+
+	@Entity(name = "AnotherEntity")
+	public static class AnotherEntity extends MyMappedSuperclass<MyEmbeddable> {
+
+		@Id
+		private Integer id;
+
+		public AnotherEntity() {
+		}
+
+		public Integer getId() {
+			return id;
+		}
+
+		public void setId(Integer id) {
+			this.id = id;
+		}
+
+	}
+
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/component/EmbeddableAndGenericMappedSuperclassTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/component/EmbeddableAndGenericMappedSuperclassTest.java
@@ -1,0 +1,113 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html
+ */
+package org.hibernate.orm.test.component;
+
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.JiraKey;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.junit.jupiter.api.Test;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import jakarta.persistence.Embedded;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.MappedSuperclass;
+
+@DomainModel(
+		annotatedClasses = { EmbeddableAndGenericMappedSuperclassTest.MyEntity.class }
+)
+@SessionFactory
+public class EmbeddableAndGenericMappedSuperclassTest {
+
+	@JiraKey("HHH-17041")
+	@Test
+	public void testQueryEmbeddableFields(SessionFactoryScope scope) {
+		scope.inTransaction(
+				session -> {
+						session.createQuery( "select m.embedded.text, m.embedded.name from MyEntity m" ).list();
+				}
+		);
+	}
+
+	@MappedSuperclass
+	public static abstract class MyAbstractEmbeddable {
+		@Column
+		private String name;
+
+		public String getName() {
+			return name;
+		}
+
+		public void setName(String name) {
+			this.name = name;
+		}
+	}
+
+
+	@Embeddable
+	public static class MyEmbeddable extends MyAbstractEmbeddable {
+
+		@Column
+		private String text;
+
+		public MyEmbeddable() {
+		}
+
+		private MyEmbeddable(String text) {
+			this.text = text;
+		}
+
+		public String getText() {
+			return text;
+		}
+
+		public void setText(String text) {
+			this.text = text;
+		}
+	}
+
+	@MappedSuperclass
+	public static abstract class MyMappedSuperclass<C extends MyAbstractEmbeddable> {
+		@Embedded
+		private C embedded;
+
+		public C getEmbedded() {
+			return embedded;
+		}
+
+		public void setEmbedded(C embedded) {
+			this.embedded = embedded;
+		}
+	}
+
+	@Entity(name = "MyEntity")
+	public static class MyEntity extends MyMappedSuperclass<MyEmbeddable> {
+
+		@Id
+		private Integer id;
+
+		public MyEntity() {
+		}
+
+		private MyEntity(Integer id, String text) {
+			this.id = id;
+			setEmbedded( new MyEmbeddable( text ) );
+		}
+
+		public Integer getId() {
+			return id;
+		}
+
+		public void setId(Integer id) {
+			this.id = id;
+		}
+
+	}
+
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/component/EmbeddableExtendsMappedSuperclassTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/component/EmbeddableExtendsMappedSuperclassTest.java
@@ -1,0 +1,106 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html
+ */
+package org.hibernate.orm.test.component;
+
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.JiraKey;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.junit.jupiter.api.Test;
+
+import jakarta.persistence.Embeddable;
+import jakarta.persistence.Embedded;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.MappedSuperclass;
+
+@DomainModel(
+		annotatedClasses = { EmbeddableExtendsMappedSuperclassTest.MyEntity.class }
+)
+@SessionFactory
+public class EmbeddableExtendsMappedSuperclassTest {
+
+	@JiraKey("HHH-17041")
+	@Test
+	public void testQueryEmbeddableFields(SessionFactoryScope scope) {
+		scope.inTransaction(
+				session -> {
+					session.createQuery( "select m.embedded.text, m.embedded.name from MyEntity m" ).list();
+				}
+		);
+	}
+
+	@MappedSuperclass
+	public static abstract class MyAbstractEmbeddable {
+		private String name;
+
+		public String getName() {
+			return name;
+		}
+
+		public void setName(String name) {
+			this.name = name;
+		}
+	}
+
+	@Embeddable
+	public static class MyEmbeddable extends MyAbstractEmbeddable {
+
+		private String text;
+
+		public MyEmbeddable() {
+		}
+
+		private MyEmbeddable(String text) {
+			this.text = text;
+		}
+
+		public String getText() {
+			return text;
+		}
+
+		public void setText(String text) {
+			this.text = text;
+		}
+	}
+
+
+	@Entity(name = "MyEntity")
+	public static class MyEntity  {
+
+		@Id
+		private Integer id;
+
+		@Embedded
+		private MyEmbeddable embedded;
+
+		public MyEmbeddable getEmbedded() {
+			return embedded;
+		}
+
+		public void setEmbedded(MyEmbeddable embedded) {
+			this.embedded = embedded;
+		}
+
+		public MyEntity() {
+		}
+
+		private MyEntity(Integer id, String text) {
+			this.id = id;
+			setEmbedded( new MyEmbeddable( text ) );
+		}
+
+		public Integer getId() {
+			return id;
+		}
+
+		public void setId(Integer id) {
+			this.id = id;
+		}
+
+	}
+}


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-17034 Bytecode enhancement leads to broken constructor for a generic embedded field in a twice removed MappedSuperclass

https://hibernate.atlassian.net/browse/HHH-17035 Bytecode enhancement leads to StackOverflowError with specific setup involving different generic parameter names

https://hibernate.atlassian.net/browse/HHH-17041 Embeddable and Generics throws IllegalArgumentException