### PR TITLE
HHH-17072 Process tenant-id from XML mapping

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/boot/model/internal/JPAXMLOverriddenAnnotationReader.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/internal/JPAXMLOverriddenAnnotationReader.java
@@ -32,6 +32,7 @@ import org.hibernate.annotations.JdbcTypeCode;
 import org.hibernate.annotations.ManyToAny;
 import org.hibernate.annotations.Parameter;
 import org.hibernate.annotations.Subselect;
+import org.hibernate.annotations.TenantId;
 import org.hibernate.annotations.Type;
 import org.hibernate.annotations.UuidGenerator;
 import org.hibernate.annotations.common.annotationfactory.AnnotationDescriptor;
@@ -98,6 +99,7 @@ import org.hibernate.boot.jaxb.mapping.JaxbStoredProcedureParameter;
 import org.hibernate.boot.jaxb.mapping.JaxbSynchronizedTable;
 import org.hibernate.boot.jaxb.mapping.JaxbTable;
 import org.hibernate.boot.jaxb.mapping.JaxbTableGenerator;
+import org.hibernate.boot.jaxb.mapping.JaxbTenantId;
 import org.hibernate.boot.jaxb.mapping.JaxbUniqueConstraint;
 import org.hibernate.boot.jaxb.mapping.JaxbUuidGenerator;
 import org.hibernate.boot.jaxb.mapping.JaxbVersion;
@@ -1604,6 +1606,7 @@ public class JPAXMLOverriddenAnnotationReader implements AnnotationReader {
 			annotationList.add( AnnotationFactory.create( basic ) );
 			getType( annotationList, element.getType() );
 			getJdbcTypeCode( annotationList, element.getJdbcTypeCode() );
+			getTenantId( annotationList, element );
 		}
 		if ( elementsForProperty.isEmpty() && defaults.canUseJavaAnnotations() ) {
 			//no annotation presence constraint, basic is the default
@@ -1627,6 +1630,13 @@ public class JPAXMLOverriddenAnnotationReader implements AnnotationReader {
 			addIfNotNull( annotationList, annotation );
 			annotation = getPhysicalAnnotation( AssociationOverrides.class );
 			addIfNotNull( annotationList, annotation );
+		}
+	}
+
+	private void getTenantId(List<Annotation> annotationList, JaxbBasic element) {
+		if ( element instanceof JaxbTenantId ) {
+			AnnotationDescriptor ad = new AnnotationDescriptor( TenantId.class );
+			annotationList.add( AnnotationFactory.create( ad ) );
 		}
 	}
 
@@ -1737,6 +1747,7 @@ public class JPAXMLOverriddenAnnotationReader implements AnnotationReader {
 		if ( entityListener != null ) {
 			elementsForProperty.collectLifecycleCallbacksIfMatching( entityListener );
 		}
+		elementsForProperty.collectTenantIdIfMatching( managedType );
 	}
 
 	private void getId(List<Annotation> annotationList, XMLContext.Default defaults) {

--- a/hibernate-core/src/main/java/org/hibernate/boot/model/internal/PropertyMappingElementCollector.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/internal/PropertyMappingElementCollector.java
@@ -17,6 +17,7 @@ import org.hibernate.boot.jaxb.mapping.JaxbBasic;
 import org.hibernate.boot.jaxb.mapping.JaxbElementCollection;
 import org.hibernate.boot.jaxb.mapping.JaxbEmbedded;
 import org.hibernate.boot.jaxb.mapping.JaxbEmbeddedId;
+import org.hibernate.boot.jaxb.mapping.JaxbEntity;
 import org.hibernate.boot.jaxb.mapping.JaxbId;
 import org.hibernate.boot.jaxb.mapping.JaxbManyToMany;
 import org.hibernate.boot.jaxb.mapping.JaxbManyToOne;
@@ -29,10 +30,12 @@ import org.hibernate.boot.jaxb.mapping.JaxbPostUpdate;
 import org.hibernate.boot.jaxb.mapping.JaxbPrePersist;
 import org.hibernate.boot.jaxb.mapping.JaxbPreRemove;
 import org.hibernate.boot.jaxb.mapping.JaxbPreUpdate;
+import org.hibernate.boot.jaxb.mapping.JaxbTenantId;
 import org.hibernate.boot.jaxb.mapping.JaxbTransient;
 import org.hibernate.boot.jaxb.mapping.JaxbVersion;
 import org.hibernate.boot.jaxb.mapping.LifecycleCallback;
 import org.hibernate.boot.jaxb.mapping.LifecycleCallbackContainer;
+import org.hibernate.boot.jaxb.mapping.ManagedType;
 import org.hibernate.boot.jaxb.mapping.PersistentAttribute;
 
 
@@ -119,6 +122,13 @@ public final class PropertyMappingElementCollector {
 		preUpdate = collectIfMatching( preUpdate, container.getPreUpdate(), LIFECYCLE_CALLBACK_NAME );
 		postUpdate = collectIfMatching( postUpdate, container.getPostUpdate(), LIFECYCLE_CALLBACK_NAME );
 		postLoad = collectIfMatching( postLoad, container.getPostLoad(), LIFECYCLE_CALLBACK_NAME );
+	}
+
+	public void collectTenantIdIfMatching(ManagedType managedType) {
+		if ( managedType instanceof JaxbEntity ) {
+			JaxbTenantId tenantId = ( (JaxbEntity) managedType ).getTenantId();
+			basic = collectIfMatching( basic, tenantId, PERSISTENT_ATTRIBUTE_NAME );
+		}
 	}
 
 	private <T> List<T> collectIfMatching(List<T> collected, List<T> candidates,

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/HibernateOrmSpecificAttributesMappingTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/boot/jaxb/mapping/HibernateOrmSpecificAttributesMappingTest.java
@@ -13,10 +13,16 @@ import java.util.Set;
 import java.util.UUID;
 
 import org.hibernate.boot.model.process.internal.UserTypeResolution;
+import org.hibernate.boot.model.relational.Database;
 import org.hibernate.generator.Generator;
+import org.hibernate.generator.GeneratorCreationContext;
+import org.hibernate.generator.internal.TenantIdGeneration;
 import org.hibernate.id.uuid.UuidGenerator;
 import org.hibernate.mapping.BasicValue;
+import org.hibernate.mapping.GeneratorCreator;
+import org.hibernate.mapping.PersistentClass;
 import org.hibernate.mapping.Property;
+import org.hibernate.service.ServiceRegistry;
 import org.hibernate.type.SqlTypes;
 import org.hibernate.usertype.UserTypeSupport;
 
@@ -44,6 +50,17 @@ public class HibernateOrmSpecificAttributesMappingTest {
 					.isInstanceOf( BasicValue.class );
 			assertThat( ( (BasicValue) tags.getValue() ).getResolution() )
 					.isInstanceOf( UserTypeResolution.class );
+		} );
+
+		scope.withHierarchy( HibernateOrmSpecificAttributesMappingTest.MyEntityWithTenantId.class, (entityDescriptor) -> {
+			Property tenantId = entityDescriptor.getProperty( "tenantId" );
+			GeneratorCreator valueGeneratorCreator = tenantId.getValueGeneratorCreator();
+			assertThat( valueGeneratorCreator ).isNotNull();
+			Generator generator = valueGeneratorCreator.createGenerator( new CustomTenantGeneratorContext( tenantId ) );
+
+			assertThat( generator )
+					.isInstanceOf( TenantIdGeneration.class );
+
 		} );
 	}
 
@@ -79,9 +96,69 @@ public class HibernateOrmSpecificAttributesMappingTest {
 		}
 	}
 
+	public static class MyEntityWithTenantId {
+		private Long id;
+
+		private String tenantId;
+
+		public Long getId() {
+			return id;
+		}
+
+		public void setId(Long id) {
+			this.id = id;
+		}
+
+		public String getTenantId() {
+			return tenantId;
+		}
+
+		public void setTenantId(String tenantId) {
+			this.tenantId = tenantId;
+		}
+	}
+
 	public static class DelimitedStringsJavaType extends UserTypeSupport<Set> {
 		public DelimitedStringsJavaType() {
 			super( Set.class, Types.VARCHAR );
+		}
+	}
+
+	private static class CustomTenantGeneratorContext implements GeneratorCreationContext {
+		private final Property tenantId;
+
+		public CustomTenantGeneratorContext(Property tenantId) {
+			this.tenantId = tenantId;
+		}
+
+		@Override
+		public Database getDatabase() {
+			return null;
+		}
+
+		@Override
+		public ServiceRegistry getServiceRegistry() {
+			return null;
+		}
+
+		@Override
+		public String getDefaultCatalog() {
+			return null;
+		}
+
+		@Override
+		public String getDefaultSchema() {
+			return null;
+		}
+
+		@Override
+		public PersistentClass getPersistentClass() {
+			return tenantId.getPersistentClass();
+		}
+
+		@Override
+		public Property getProperty() {
+			return tenantId;
 		}
 	}
 }

--- a/hibernate-core/src/test/resources/xml/jaxb/mapping/partial/hibernate-orm-specific-attributes.xml
+++ b/hibernate-core/src/test/resources/xml/jaxb/mapping/partial/hibernate-orm-specific-attributes.xml
@@ -19,4 +19,10 @@
             </basic>
         </attributes>
     </entity>
+    <entity class="HibernateOrmSpecificAttributesMappingTest$MyEntityWithTenantId">
+        <tenant-id name="tenantId"/>
+        <attributes>
+            <id name="id"/>
+        </attributes>
+    </entity>
 </entity-mappings>


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-17072

This one is for Search integration. It seems that the tenant id element was present but then ignored when converting to annotation proxies (https://github.com/hibernate/hibernate-orm/blob/4666d774e42266da90d6fc132193454020b37019/hibernate-core/src/main/resources/org/hibernate/xsd/mapping/mapping-3.1.0.xsd#L472C16-L472C17)