### PR TITLE
Fix typo in documentation `13.1.2. Caching configuration properties`

### DIFF
--- a/documentation/src/main/asciidoc/userguide/chapters/caching/Caching.adoc
+++ b/documentation/src/main/asciidoc/userguide/chapters/caching/Caching.adoc
@@ -76,7 +76,7 @@ Besides provider specific configuration, there are a number of configurations op
     (incl. its configuration) guarantees that different entity types are stored separately and multi-tenancy is not
     used, you can omit this wrapping to achieve better performance. Currently, this property is only supported when
     Infinispan is configured as the second-level cache implementation. Valid values are:
-* `default` (wraps identitifers in the tuple)
+* `default` (wraps identifiers in the tuple)
 * `simple` (uses identifiers as keys without any wrapping)
 * fully qualified class name that implements `org.hibernate.cache.spi.CacheKeysFactory`
 


### PR DESCRIPTION
### Motivation
---
I found a typo while reading docs.
I'm reading it useful. Thank you.

To fIx typo in documentation [13.1.2. Caching configuration properties](https://docs.jboss.org/hibernate/orm/current/userguide/html_single/Hibernate_User_Guide.html#caching-config-properties)

### Details (Actual typo)
---
<img width="1023" alt="스크린샷 2023-08-13 오후 8 26 12" src="https://github.com/hibernate/hibernate-orm/assets/58777597/52804e45-aba2-4905-994f-e200d52ed9f8">
