### PR TITLE
HHH-15491 - Remove support for database versions that are unsupported by vendors 6.3 edition

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -174,14 +174,6 @@ stage('Build') {
 									sh "./docker_db.sh postgresql"
 									state[buildEnv.tag]['containerName'] = "postgres"
 									break;
-								case "postgresql_10":
-									// use the postgis image to enable the PGSQL GIS (spatial) extension
-									docker.withRegistry('https://index.docker.io/v1/', 'hibernateci.hub.docker.com') {
-										docker.image('postgis/postgis:10-2.5').pull()
-									}
-									sh "./docker_db.sh postgresql_10"
-									state[buildEnv.tag]['containerName'] = "postgres"
-									break;
 								case "edb":
 									docker.image('quay.io/enterprisedb/edb-postgres-advanced:15.2-3.3-postgis').pull()
 									sh "./docker_db.sh edb"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -130,10 +130,6 @@ stage('Build') {
 									state[buildEnv.tag]['additionalOptions'] = state[buildEnv.tag]['additionalOptions'] +
 										" -Pgradle.libs.versions.hsqldb=2.6.1"
 									break;
-								case "derby_10_14":
-									state[buildEnv.tag]['additionalOptions'] = state[buildEnv.tag]['additionalOptions'] +
-										" -Pgradle.libs.versions.derby=10.14.2.0"
-									break;
 								case "mysql":
 									docker.withRegistry('https://index.docker.io/v1/', 'hibernateci.hub.docker.com') {
 										docker.image('mysql:8.0.31').pull()

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -179,11 +179,6 @@ stage('Build') {
 									sh "./docker_db.sh edb"
 									state[buildEnv.tag]['containerName'] = "edb"
 									break;
-								case "edb_10":
-									docker.image('quay.io/enterprisedb/edb-postgres-advanced:10.22').pull()
-									sh "./docker_db.sh edb_10"
-									state[buildEnv.tag]['containerName'] = "edb"
-									break;
 								case "oracle":
 									docker.withRegistry('https://index.docker.io/v1/', 'hibernateci.hub.docker.com') {
 										docker.image('gvenzl/oracle-xe:21.3.0-full').pull()

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -126,10 +126,6 @@ stage('Build') {
 					try {
 						stage('Start database') {
 							switch (buildEnv.dbName) {
-								case "h2_1_4":
-									state[buildEnv.tag]['additionalOptions'] = state[buildEnv.tag]['additionalOptions'] +
-										" -Pgradle.libs.versions.h2=1.4.197 -Pgradle.libs.versions.h2gis=1.5.0"
-									break;
 								case "hsqldb_2_6":
 									state[buildEnv.tag]['additionalOptions'] = state[buildEnv.tag]['additionalOptions'] +
 										" -Pgradle.libs.versions.hsqldb=2.6.1"

--- a/ci/build.sh
+++ b/ci/build.sh
@@ -8,8 +8,6 @@ elif [ "$RDBMS" == "hsqldb" ] || [ "$RDBMS" == "hsqldb_2_6" ]; then
   goal="-Pdb=hsqldb"
 elif [ "$RDBMS" == "derby" ]; then
   goal="-Pdb=derby"
-elif [ "$RDBMS" == "derby_10_14" ]; then
-  goal="-Pdb=derby_old"
 elif [ "$RDBMS" == "mysql" ] || [ "$RDBMS" == "mysql_5_7" ]; then
   goal="-Pdb=mysql_ci"
 elif [ "$RDBMS" == "mariadb" ] || [ "$RDBMS" == "mariadb_10_3" ]; then

--- a/ci/build.sh
+++ b/ci/build.sh
@@ -1,7 +1,7 @@
 #! /bin/bash
 
 goal=
-if [ "$RDBMS" == "h2" ] || [ "$RDBMS" == "h2_1_4" ]; then
+if [ "$RDBMS" == "h2" ]; then
   # This is the default.
   goal=""
 elif [ "$RDBMS" == "hsqldb" ] || [ "$RDBMS" == "hsqldb_2_6" ]; then

--- a/docker_db.sh
+++ b/docker_db.sh
@@ -145,11 +145,11 @@ edb() {
     edb_15
 }
 
-edb_10() {
+edb_11() {
     $CONTAINER_CLI rm -f edb || true
     # We need to build a derived image because the existing image is mainly made for use by a kubernetes operator
-    (cd edb; $CONTAINER_CLI build -t edb-test:10 -f edb10.Dockerfile .)
-    $CONTAINER_CLI run --name edb -e POSTGRES_USER=hibernate_orm_test -e POSTGRES_PASSWORD=hibernate_orm_test -e POSTGRES_DB=hibernate_orm_test -p 5444:5444 -d edb-test:10
+    (cd edb; $CONTAINER_CLI build -t edb-test:11 -f edb11.Dockerfile .)
+    $CONTAINER_CLI run --name edb -e POSTGRES_USER=hibernate_orm_test -e POSTGRES_PASSWORD=hibernate_orm_test -e POSTGRES_DB=hibernate_orm_test -p 5444:5444 -d edb-test:11
 }
 
 edb_14() {

--- a/docker_db.sh
+++ b/docker_db.sh
@@ -121,14 +121,9 @@ postgresql() {
   postgresql_15
 }
 
-postgresql_9_5() {
+postgresql_11() {
     $CONTAINER_CLI rm -f postgres || true
-    $CONTAINER_CLI run --name postgres -e POSTGRES_USER=hibernate_orm_test -e POSTGRES_PASSWORD=hibernate_orm_test -e POSTGRES_DB=hibernate_orm_test -p5432:5432 -d docker.io/postgis/postgis:9.5-2.5
-}
-
-postgresql_10() {
-    $CONTAINER_CLI rm -f postgres || true
-    $CONTAINER_CLI run --name postgres -e POSTGRES_USER=hibernate_orm_test -e POSTGRES_PASSWORD=hibernate_orm_test -e POSTGRES_DB=hibernate_orm_test -p5432:5432 -d docker.io/postgis/postgis:10-2.5
+    $CONTAINER_CLI run --name postgres -e POSTGRES_USER=hibernate_orm_test -e POSTGRES_PASSWORD=hibernate_orm_test -e POSTGRES_DB=hibernate_orm_test -p5432:5432 -d docker.io/postgis/postgis:11-3.3
 }
 
 postgresql_13() {

--- a/edb/edb11.Dockerfile
+++ b/edb/edb11.Dockerfile
@@ -1,16 +1,12 @@
-FROM quay.io/enterprisedb/edb-postgres-advanced:10.22
+FROM quay.io/enterprisedb/edb-postgres-advanced:11.20-3.3-postgis
 USER root
-RUN chown -R postgres:postgres /var/lib/edb && chmod 777 /var/lib/edb && mkdir /docker-entrypoint-initdb.d
-
-#FROM quay.io/enterprisedb/edb-postgres-advanced:11.17-3.2-postgis
-#USER root
 # this 777 will be replaced by 700 at runtime (allows semi-arbitrary "--user" values)
-#RUN chown -R postgres:postgres /var/lib/edb && chmod 777 /var/lib/edb && rm /docker-entrypoint-initdb.d/10_postgis.sh
+RUN chown -R postgres:postgres /var/lib/edb && chmod 777 /var/lib/edb && rm /docker-entrypoint-initdb.d/10_postgis.sh
 
 USER postgres
 ENV LANG en_US.utf8
-ENV PG_MAJOR 10
-ENV PG_VERSION 10
+ENV PG_MAJOR 11
+ENV PG_VERSION 11
 ENV PGPORT 5444
 ENV PGDATA /var/lib/edb/as$PG_MAJOR/data/
 VOLUME /var/lib/edb/as$PG_MAJOR/data/

--- a/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/CommunityDialectSelector.java
+++ b/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/CommunityDialectSelector.java
@@ -84,6 +84,8 @@ public class CommunityDialectSelector implements DialectSelector {
 				return PostgreSQL94Dialect.class;
 			case "PostgreSQL95":
 				return PostgreSQL95Dialect.class;
+			case "PostgreSQL10":
+				return PostgreSQL10Dialect.class;
 			case "RDMSOS2200":
 				return RDMSOS2200Dialect.class;
 			case "SAPDB":

--- a/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/PostgreSQL10Dialect.java
+++ b/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/PostgreSQL10Dialect.java
@@ -4,7 +4,10 @@
  * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
  * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
  */
-package org.hibernate.dialect;
+package org.hibernate.community.dialect;
+
+import org.hibernate.dialect.DatabaseVersion;
+import org.hibernate.dialect.PostgreSQLDialect;
 
 /**
  * An SQL dialect for Postgres 10 and later.

--- a/hibernate-community-dialects/src/test/java/org/hibernate/community/dialect/CommunityDialectSelectorTest.java
+++ b/hibernate-community-dialects/src/test/java/org/hibernate/community/dialect/CommunityDialectSelectorTest.java
@@ -54,6 +54,7 @@ public class CommunityDialectSelectorTest {
 		testDialectNamingResolution( PostgreSQL93Dialect.class );
 		testDialectNamingResolution( PostgreSQL94Dialect.class );
 		testDialectNamingResolution( PostgreSQL95Dialect.class );
+		testDialectNamingResolution( PostgreSQL10Dialect.class );
 
 		testDialectNamingResolution( SAPDBDialect.class );
 

--- a/hibernate-core/src/main/java/org/hibernate/boot/registry/selector/internal/DefaultDialectSelector.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/registry/selector/internal/DefaultDialectSelector.java
@@ -30,7 +30,6 @@ import org.hibernate.dialect.MySQL8Dialect;
 import org.hibernate.dialect.MySQLDialect;
 import org.hibernate.dialect.Oracle12cDialect;
 import org.hibernate.dialect.OracleDialect;
-import org.hibernate.dialect.PostgreSQL10Dialect;
 import org.hibernate.dialect.PostgreSQLDialect;
 import org.hibernate.dialect.PostgresPlusDialect;
 import org.hibernate.dialect.SQLServer2008Dialect;
@@ -120,9 +119,8 @@ public class DefaultDialectSelector implements DialectSelector {
 			case "PostgreSQL93":
 			case "PostgreSQL94":
 			case "PostgreSQL95":
-				return findCommunityDialect( name );
 			case "PostgreSQL10":
-				return PostgreSQL10Dialect.class;
+				return findCommunityDialect( name );
 			case "Spanner":
 				return SpannerDialect.class;
 			case "SQLServer":

--- a/hibernate-core/src/main/java/org/hibernate/dialect/DerbyDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/DerbyDialect.java
@@ -94,7 +94,7 @@ import static org.hibernate.type.SqlTypes.VARBINARY;
 import static org.hibernate.type.SqlTypes.VARCHAR;
 
 /**
- * A {@linkplain Dialect SQL dialect} for Apache Derby 10.14.2 and above.
+ * A {@linkplain Dialect SQL dialect} for Apache Derby 10.15.2 and above.
  *
  * @author Simon Johnston
  * @author Gavin King
@@ -113,7 +113,7 @@ public class DerbyDialect extends Dialect {
 	// * can't select a parameter unless wrapped
 	//   in a cast or function call
 
-	private final static DatabaseVersion MINIMUM_VERSION = DatabaseVersion.make( 10, 14, 2 );
+	private final static DatabaseVersion MINIMUM_VERSION = DatabaseVersion.make( 10, 15, 2 );
 
 	private final LimitHandler limitHandler = new DerbyLimitHandler( true );
 	private final UniqueDelegate uniqueDelegate = new CreateTableUniqueDelegate(this);

--- a/hibernate-core/src/main/java/org/hibernate/dialect/PostgreSQLDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/PostgreSQLDialect.java
@@ -133,12 +133,12 @@ import static org.hibernate.type.descriptor.DateTimeUtils.appendAsTimestampWithM
 import static org.hibernate.type.descriptor.DateTimeUtils.appendAsTimestampWithMillis;
 
 /**
- * A {@linkplain Dialect SQL dialect} for PostgreSQL 10 and above.
+ * A {@linkplain Dialect SQL dialect} for PostgreSQL 11 and above.
  *
  * @author Gavin King
  */
 public class PostgreSQLDialect extends Dialect {
-	protected final static DatabaseVersion MINIMUM_VERSION = DatabaseVersion.make( 10 );
+	protected final static DatabaseVersion MINIMUM_VERSION = DatabaseVersion.make( 11 );
 
 	private final UniqueDelegate uniqueDelegate = new CreateTableUniqueDelegate(this);
 
@@ -1034,9 +1034,7 @@ public class PostgreSQLDialect extends Dialect {
 
 	@Override
 	public CallableStatementSupport getCallableStatementSupport() {
-		return getVersion().isSameOrAfter( 11 )
-				? PostgreSQLCallableStatementSupport.INSTANCE
-				: PostgreSQLCallableStatementSupport.V10_INSTANCE;
+		return PostgreSQLCallableStatementSupport.INSTANCE;
 	}
 
 	@Override

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/loading/multiLoad/MultiLoadSubSelectCollectionDialectWithLimitTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/loading/multiLoad/MultiLoadSubSelectCollectionDialectWithLimitTest.java
@@ -50,7 +50,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 		settingProviders = @SettingProvider( provider = MultiLoadSubSelectCollectionDialectWithLimitTest.TestSettingProvider.class, settingName = AvailableSettings.DIALECT)
 )
 @SessionFactory(generateStatistics = true, useCollectingStatementInspector = true)
-@RequiresDialect( value = H2Dialect.class, majorVersion = 2 )
+@RequiresDialect( value = H2Dialect.class )
 public class MultiLoadSubSelectCollectionDialectWithLimitTest {
 
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/contributed/BasicContributorTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/contributed/BasicContributorTests.java
@@ -171,8 +171,8 @@ public class BasicContributorTests {
 		assertThat(
 				targetDescriptor.getCommands(),
 				CollectionElementMatcher.hasAllOf(
-						CaseInsensitiveStartsWithMatcher.startsWith( "drop table main_table" ),
-						CaseInsensitiveStartsWithMatcher.startsWith( "drop table DynamicEntity" )
+						CaseInsensitiveStartsWithMatcher.startsWith( "drop table if exists main_table" ),
+						CaseInsensitiveStartsWithMatcher.startsWith( "drop table if exists DynamicEntity" )
 				)
 		);
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/fetch/depth/DepthOneBatchTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/fetch/depth/DepthOneBatchTest.java
@@ -52,7 +52,7 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 				@Setting(name = AvailableSettings.FORMAT_SQL, value = "false")
 		}
 )
-@RequiresDialect(value = H2Dialect.class, majorVersion = 2, comment = "H2 didn't support SQL arrays before version 2")
+@RequiresDialect(value = H2Dialect.class)
 @JiraKey("HHH-16469")
 public class DepthOneBatchTest {
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/query/FetchSizeTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/query/FetchSizeTest.java
@@ -49,7 +49,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 		}
 )
 @SessionFactory()
-@RequiresDialect( value = H2Dialect.class, majorVersion = 2 )
+@RequiresDialect( value = H2Dialect.class )
 @JiraKey(value = "HHH-16868")
 public class FetchSizeTest {
 	private PreparedStatementSpyConnectionProvider connectionProvider;

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/query/InExpressionCountLimitExceededTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/query/InExpressionCountLimitExceededTest.java
@@ -39,7 +39,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 		settings = { @Setting(name=AvailableSettings.STATEMENT_BATCH_SIZE, value = "60") }
 )
 @SessionFactory()
-@RequiresDialect( value = H2Dialect.class, majorVersion = 2 )
+@RequiresDialect( value = H2Dialect.class )
 @JiraKey(value = "HHH-16868")
 public class InExpressionCountLimitExceededTest {
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/strategyselectors/DefaultDialectSelectorTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/strategyselectors/DefaultDialectSelectorTest.java
@@ -48,7 +48,6 @@ public class DefaultDialectSelectorTest {
 
 		testDialectNamingResolution( PostgreSQLDialect.class );
 		testDialectNamingResolution( PostgresPlusDialect.class );
-		testDialectNamingResolution( PostgreSQL10Dialect.class );
 
 		testDialectNamingResolution( SQLServerDialect.class );
 		testDialectNamingResolution( SQLServer2008Dialect.class );

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/tool/schema/internal/StandardForeignKeyExporterTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/tool/schema/internal/StandardForeignKeyExporterTest.java
@@ -63,7 +63,7 @@ public class StandardForeignKeyExporterTest {
 					sqlStringGenerationContext
 			);
 			assertEquals( sqlCreateStrings.length, 1 );
-			assertEquals( sqlCreateStrings[0], "alter table PERSON add constraint fk_firstLastName foreign key (pkFirstName, pkLastName) references PERSON" );
+			assertEquals( sqlCreateStrings[0], "alter table if exists PERSON add constraint fk_firstLastName foreign key (pkFirstName, pkLastName) references PERSON" );
 		}
 	}
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/type/H2JsonListTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/type/H2JsonListTest.java
@@ -33,7 +33,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @SessionFactory
 @DomainModel( annotatedClasses = { H2JsonListTest.Path.class, H2JsonListTest.PathClob.class } )
-@RequiresDialect( value = H2Dialect.class, majorVersion = 2 )
+@RequiresDialect( value = H2Dialect.class )
 @Jira( "https://hibernate.atlassian.net/browse/HHH-16320" )
 public class H2JsonListTest {
 	@BeforeAll

--- a/hibernate-testing/src/main/java/org/hibernate/testing/orm/junit/DialectFeatureChecks.java
+++ b/hibernate-testing/src/main/java/org/hibernate/testing/orm/junit/DialectFeatureChecks.java
@@ -420,7 +420,7 @@ abstract public class DialectFeatureChecks {
 	public static class SupportsInverseDistributionFunctions implements DialectFeatureCheck {
 		public boolean apply(Dialect dialect) {
 			dialect = DialectDelegateWrapper.extractRealDialect( dialect );
-			return dialect instanceof H2Dialect && dialect.getVersion().isSameOrAfter( 1, 4, 200 )
+			return dialect instanceof H2Dialect
 					|| dialect instanceof PostgreSQLDialect
 					|| dialect instanceof AbstractHANADialect
 					|| dialect instanceof CockroachDialect
@@ -434,7 +434,7 @@ abstract public class DialectFeatureChecks {
 	public static class SupportsHypotheticalSetFunctions implements DialectFeatureCheck {
 		public boolean apply(Dialect dialect) {
 			dialect = DialectDelegateWrapper.extractRealDialect( dialect );
-			return dialect instanceof H2Dialect && dialect.getVersion().isSameOrAfter( 1, 4, 200 )
+			return dialect instanceof H2Dialect
 					|| dialect instanceof PostgreSQLDialect
 					|| dialect instanceof AbstractHANADialect
 					|| dialect instanceof CockroachDialect

--- a/nightly.Jenkinsfile
+++ b/nightly.Jenkinsfile
@@ -32,7 +32,7 @@ stage('Configure') {
 		new BuildEnvironment( dbName: 'derby_10_14' ),
 		new BuildEnvironment( dbName: 'mysql_5_7' ),
 		new BuildEnvironment( dbName: 'mariadb_10_3' ),
-		new BuildEnvironment( dbName: 'postgresql_10' ),
+		new BuildEnvironment( dbName: 'postgresql_11' ),
 		new BuildEnvironment( dbName: 'edb_10' ),
 		new BuildEnvironment( dbName: 'oracle_11_2' ),
 		new BuildEnvironment( dbName: 'db2_10_5', longRunning: true ),
@@ -158,12 +158,12 @@ stage('Build') {
 									sh "./docker_db.sh postgresql"
 									state[buildEnv.tag]['containerName'] = "postgres"
 									break;
-								case "postgresql_10":
+								case "postgresql_11":
 									// use the postgis image to enable the PGSQL GIS (spatial) extension
 									docker.withRegistry('https://index.docker.io/v1/', 'hibernateci.hub.docker.com') {
-										docker.image('postgis/postgis:10-2.5').pull()
+										docker.image('postgis/postgis:11-3.3').pull()
 									}
-									sh "./docker_db.sh postgresql_10"
+									sh "./docker_db.sh postgresql_11"
 									state[buildEnv.tag]['containerName'] = "postgres"
 									break;
 								case "edb":

--- a/nightly.Jenkinsfile
+++ b/nightly.Jenkinsfile
@@ -27,7 +27,6 @@ helper.runWithNotification {
 stage('Configure') {
 	this.environments = [
 		// Minimum supported versions
-		new BuildEnvironment( dbName: 'h2_1_4' ),
 		new BuildEnvironment( dbName: 'hsqldb_2_6' ),
 		new BuildEnvironment( dbName: 'derby_10_14' ),
 		new BuildEnvironment( dbName: 'mysql_5_7' ),
@@ -110,10 +109,6 @@ stage('Build') {
 					try {
 						stage('Start database') {
 							switch (buildEnv.dbName) {
-								case "h2_1_4":
-									state[buildEnv.tag]['additionalOptions'] = state[buildEnv.tag]['additionalOptions'] +
-										" -Pgradle.libs.versions.h2=1.4.197 -Pgradle.libs.versions.h2gis=1.5.0"
-									break;
 								case "hsqldb_2_6":
 									state[buildEnv.tag]['additionalOptions'] = state[buildEnv.tag]['additionalOptions'] +
 										" -Pgradle.libs.versions.hsqldb=2.6.1"

--- a/nightly.Jenkinsfile
+++ b/nightly.Jenkinsfile
@@ -28,7 +28,6 @@ stage('Configure') {
 	this.environments = [
 		// Minimum supported versions
 		new BuildEnvironment( dbName: 'hsqldb_2_6' ),
-		new BuildEnvironment( dbName: 'derby_10_14' ),
 		new BuildEnvironment( dbName: 'mysql_5_7' ),
 		new BuildEnvironment( dbName: 'mariadb_10_3' ),
 		new BuildEnvironment( dbName: 'postgresql_11' ),
@@ -112,10 +111,6 @@ stage('Build') {
 								case "hsqldb_2_6":
 									state[buildEnv.tag]['additionalOptions'] = state[buildEnv.tag]['additionalOptions'] +
 										" -Pgradle.libs.versions.hsqldb=2.6.1"
-									break;
-								case "derby_10_14":
-									state[buildEnv.tag]['additionalOptions'] = state[buildEnv.tag]['additionalOptions'] +
-										" -Pgradle.libs.versions.derby=10.14.2.0"
 									break;
 								case "mysql":
 									docker.withRegistry('https://index.docker.io/v1/', 'hibernateci.hub.docker.com') {

--- a/nightly.Jenkinsfile
+++ b/nightly.Jenkinsfile
@@ -33,7 +33,7 @@ stage('Configure') {
 		new BuildEnvironment( dbName: 'mysql_5_7' ),
 		new BuildEnvironment( dbName: 'mariadb_10_3' ),
 		new BuildEnvironment( dbName: 'postgresql_11' ),
-		new BuildEnvironment( dbName: 'edb_10' ),
+		new BuildEnvironment( dbName: 'edb_11' ),
 		new BuildEnvironment( dbName: 'oracle_11_2' ),
 		new BuildEnvironment( dbName: 'db2_10_5', longRunning: true ),
 		new BuildEnvironment( dbName: 'mssql_2017' ), // Unfortunately there is no SQL Server 2008 image, so we have to test with 2017
@@ -171,9 +171,9 @@ stage('Build') {
 									sh "./docker_db.sh edb"
 									state[buildEnv.tag]['containerName'] = "edb"
 									break;
-								case "edb_10":
-									docker.image('quay.io/enterprisedb/edb-postgres-advanced:10.22').pull()
-									sh "./docker_db.sh edb_10"
+								case "edb_11":
+									docker.image('quay.io/enterprisedb/edb-postgres-advanced:11.20-3.3-postgis').pull()
+									sh "./docker_db.sh edb_11"
 									state[buildEnv.tag]['containerName'] = "edb"
 									break;
 								case "oracle":

--- a/settings.gradle
+++ b/settings.gradle
@@ -207,7 +207,7 @@ dependencyResolutionManagement {
 
             def db2Version = version "db2", "11.5.8.0"
             // Latest Derby version 10.16.1.1 only supports JDK 17+, but 10.15.2 should be compatible
-            def derbyVersion = version "dervy", overrideableVersion( "gradle.libs.versions.derby", "10.15.2.0" )
+            def derbyVersion = version "derby", overrideableVersion( "gradle.libs.versions.derby", "10.15.2.0" )
             def firebirdVersion = version "firebird", "4.0.8.java11"
             def hanaVersion = version "hana", "2.16.14"
             def h2gisVersion = version "h2gis", overrideableVersion( "gradle.libs.versions.h2gis", "2.2.0" )


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-15177 - Remove support for PostgreSQL versions older than 11
https://hibernate.atlassian.net/browse/HHH-15194 - Remove support for PostgreSQL Advanced Server versions older than 11
https://hibernate.atlassian.net/browse/HHH-15535 - Remove support for H2 versions older than 2.1
https://hibernate.atlassian.net/browse/HHH-15203 - Remove support for Derby versions older than 10.15
