### PR TITLE
Returning false in case the proxy is null for isInitialised()

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/Hibernate.java
+++ b/hibernate-core/src/main/java/org/hibernate/Hibernate.java
@@ -153,6 +153,9 @@ public final class Hibernate {
 	 * @return true if the argument is already initialized, or is not a proxy or collection
 	 */
 	public static boolean isInitialized(Object proxy) {
+		if ( proxy == null ) {
+			return false;
+		}
 		final LazyInitializer lazyInitializer = extractLazyInitializer( proxy );
 		if ( lazyInitializer != null ) {
 			return !lazyInitializer.isUninitialized();


### PR DESCRIPTION
The method isInitialised() should return false if the argument, proxy, is null.