### PR TITLE
HHH-17130 remove restrictive instanceof EntityResultInitializer check

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/engine/spi/SubselectFetch.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/spi/SubselectFetch.java
@@ -150,11 +150,7 @@ public class SubselectFetch {
 		}
 
 		public void addKey(EntityKey key, LoadingEntityEntry entry) {
-			if ( !entry.getDescriptor().hasSubselectLoadableCollections() ) {
-				return;
-			}
-
-			if ( shouldAddSubselectFetch( entry ) ) {
+			if ( entry.getDescriptor().hasSubselectLoadableCollections() ) {
 				final SubselectFetch subselectFetch = subselectFetches.computeIfAbsent(
 						entry.getEntityInitializer().getNavigablePath(),
 						navigablePath -> new SubselectFetch(
@@ -170,23 +166,6 @@ public class SubselectFetch {
 				subselectFetch.resultingEntityKeys.add( key );
 				batchFetchQueue.addSubselect( key, subselectFetch );
 			}
-		}
-
-		private boolean shouldAddSubselectFetch(LoadingEntityEntry entry) {
-			if ( entry.getEntityInitializer() instanceof EntityResultInitializer ) {
-				return true;
-			}
-
-			final NavigablePath entityInitializerParent = entry.getEntityInitializer().getNavigablePath().getParent();
-
-			// We want to add only the collections of the loading entities
-			for ( DomainResult<?> domainResult : loadingSqlAst.getDomainResultDescriptors() ) {
-				if ( domainResult.getNavigablePath().equals( entityInitializerParent ) ) {
-					return true;
-				}
-			}
-
-			return false;
 		}
 	}
 }


### PR DESCRIPTION
Back-ported some of the changes to SubselectFetch in 6.3 that refactored/removed the restrictive check on the
class EntityResultInitializer

This change will fix Hibernate Reactive tests
* [#1502 - SubSelectTest fails](https://github.com/hibernate/hibernate-reactive/issues/1502)
* [#1501 - BatchFetchTest.testQuery() fails](https://github.com/hibernate/hibernate-reactive/issues/1501)

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-17130
<!-- Hibernate GitHub Bot issue links end -->