### PR TITLE
HHH-4301 Allow OnDelete on ElementCollection.

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/boot/model/internal/CollectionBinder.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/internal/CollectionBinder.java
@@ -520,7 +520,8 @@ public abstract class CollectionBinder {
 			final Class<?> targetElement = elementCollectionAnn.targetClass();
 			collectionBinder.setTargetEntity( reflectionManager.toXClass( targetElement ) );
 			//collectionBinder.setCascadeStrategy( getCascadeStrategy( embeddedCollectionAnn.cascade(), hibernateCascade ) );
-			collectionBinder.setOneToMany( true );
+			//While this is a collection-valued property, its mapping significantly differs from those of one-to-many.
+			collectionBinder.setOneToMany( false );
 		}
 		else if ( manyToManyAnn != null ) {
 			mappedBy = nullIfEmpty( manyToManyAnn.mappedBy() );
@@ -1293,7 +1294,8 @@ public abstract class CollectionBinder {
 				&& !property.isAnnotationPresent( JoinColumns.class )) {
 			throw new AnnotationException( "Unidirectional '@OneToMany' association '"
 					+ qualify( propertyHolder.getPath(), propertyName )
-					+ "' is annotated '@OnDelete' and must explicitly specify a '@JoinColumn'" );
+					+ "' is annotated '@OnDelete' and must explicitly specify a '@JoinColumn'"
+					+ " (so that Join Table mechanic is not used)" );
 		}
 	}
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/collectionelement/OnDeleteCascadeToElementCollectionTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/collectionelement/OnDeleteCascadeToElementCollectionTest.java
@@ -1,0 +1,148 @@
+package org.hibernate.orm.test.annotations.collectionelement;
+
+import java.time.LocalDate;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
+import org.hibernate.exception.ConstraintViolationException;
+
+import org.hibernate.testing.orm.junit.DialectFeatureChecks;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.ExpectedException;
+import org.hibernate.testing.orm.junit.ExpectedExceptionExtension;
+import org.hibernate.testing.orm.junit.JiraKey;
+import org.hibernate.testing.orm.junit.RequiresDialectFeature;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import jakarta.persistence.ElementCollection;
+import jakarta.persistence.Embeddable;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DomainModel(
+		annotatedClasses = {
+				OnDeleteCascadeToElementCollectionTest.Cascading.class,
+				OnDeleteCascadeToElementCollectionTest.Ticket.class,
+				OnDeleteCascadeToElementCollectionTest.NonCascading.class
+		}
+)
+@SessionFactory
+@ExtendWith(ExpectedExceptionExtension.class)
+@JiraKey("HHH-4301")
+public class OnDeleteCascadeToElementCollectionTest {
+	@Test
+	@RequiresDialectFeature(feature = DialectFeatureChecks.SupportsCascadeDeleteCheck.class)
+	public void testCascading(SessionFactoryScope scope) {
+		var instance = new Cascading();
+
+		scope.inTransaction(
+				session -> {
+					instance.labels = new HashSet<>( Set.of( "one", "two" ) );
+					instance.tickets = new HashMap<>( Map.of(
+							"t1", new Ticket( "t1-2398", LocalDate.of( 2023, 8, 26 ) ),
+							"t2", new Ticket( "t2-23132", LocalDate.of( 2007, 9, 26 ) )
+					) );
+					session.persist( instance );
+				}
+		);
+
+		scope.inTransaction(
+				session -> {
+					var deleted = session
+							.createNativeQuery(
+									"DELETE FROM Cascading WHERE id = " + instance.id )
+							.executeUpdate();
+					assertThat( deleted ).isEqualTo( 1 );
+				}
+		);
+
+		scope.inTransaction(
+				session -> {
+					var remained = session.createQuery(
+									"select count(id) from Cascading" )
+							.getSingleResult();
+					assertThat( remained ).isEqualTo( 0L );
+				}
+		);
+	}
+
+	@Test
+	@ExpectedException(ConstraintViolationException.class)
+	public void testNonCascading(SessionFactoryScope scope) {
+		var instance = new NonCascading();
+
+		scope.inTransaction(
+				session -> {
+					instance.labels = new HashSet<>( Set.of( "one", "two" ) );
+					instance.tickets = new HashMap<>( Map.of(
+							"t1", new Ticket( "t1-2398", LocalDate.of( 2023, 8, 26 ) ),
+							"t2", new Ticket( "t2-23132", LocalDate.of( 2007, 9, 26 ) )
+					) );
+					session.persist( instance );
+				}
+		);
+
+		scope.inTransaction(
+				session -> {
+					var deleted = session
+							.createNativeQuery(
+									"DELETE FROM NonCascading WHERE id = " + instance.id )
+							.executeUpdate();
+					assertThat( deleted ).isEqualTo( 1 );
+				}
+		);
+	}
+
+	@Entity(name = "Cascading")
+	public static class Cascading {
+		@Id
+		@GeneratedValue
+		public Long id;
+
+		@ElementCollection
+		@OnDelete(action = OnDeleteAction.CASCADE)
+		public Set<String> labels;
+
+		@ElementCollection
+		@OnDelete(action = OnDeleteAction.CASCADE)
+		public Map<String, Ticket> tickets;
+	}
+
+	@Embeddable
+	public static class Ticket {
+		public String serial;
+		public LocalDate issuedOn;
+
+		public Ticket() {
+		}
+
+		public Ticket(String serial, LocalDate issuedOn) {
+			this.serial = serial;
+			this.issuedOn = issuedOn;
+		}
+	}
+
+	@Entity(name = "NonCascading")
+	public static class NonCascading {
+		@Id
+		@GeneratedValue
+		public Long id;
+
+		@ElementCollection
+		public Set<String> labels;
+
+		@ElementCollection
+		public Map<String, Ticket> tickets;
+
+	}
+}


### PR DESCRIPTION
CollectionBinder#oneToMany is only for association, not for element collection:

1. #scheduleSecondPass expects MappedBy, which is only available for associations;
2. #detectMappedByProblem really wants to check association, because only for it JPA requires join table by default;
3. #noAssociationTable cares about association again, because otherwise element won't be a persistent class;
4. #bindManyToManySecondPass:
    1.   #logManyToManySecondPass uses oneToMany only to differentiate between different collection of entities;
    2.   #bindManyToManyInverseForeignKey is run for association only.

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-4301
<!-- Hibernate GitHub Bot issue links end -->