### PR TITLE
HHH-17143 - Bad handling of not-found association references in mutation queries

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/ToOneAttributeMapping.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/ToOneAttributeMapping.java
@@ -62,6 +62,7 @@ import org.hibernate.property.access.spi.PropertyAccess;
 import org.hibernate.spi.EntityIdentifierNavigablePath;
 import org.hibernate.spi.NavigablePath;
 import org.hibernate.spi.TreatedNavigablePath;
+import org.hibernate.sql.ast.Clause;
 import org.hibernate.sql.ast.SqlAstJoinType;
 import org.hibernate.sql.ast.spi.FromClauseAccess;
 import org.hibernate.sql.ast.spi.SqlAliasBase;
@@ -1981,6 +1982,19 @@ public class ToOneAttributeMapping
 		);
 
 		return join;
+	}
+
+	@Override
+	public SqlAstJoinType determineSqlJoinType(TableGroup lhs, SqlAstJoinType requestedJoinType, boolean fetched) {
+		if ( requestedJoinType != null ) {
+			return requestedJoinType;
+		}
+
+		if ( fetched ) {
+			return getDefaultSqlAstJoinType( lhs );
+		}
+
+		return SqlAstJoinType.INNER;
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/sql/ast/tree/from/TableGroupJoinProducer.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/ast/tree/from/TableGroupJoinProducer.java
@@ -78,18 +78,14 @@ public interface TableGroupJoinProducer extends TableGroupProducer {
 			SqlAstCreationState creationState);
 
 	default SqlAstJoinType determineSqlJoinType(TableGroup lhs, SqlAstJoinType requestedJoinType, boolean fetched) {
-		final SqlAstJoinType joinType;
-		if ( requestedJoinType == null ) {
-			if ( fetched ) {
-				joinType = getDefaultSqlAstJoinType( lhs );
-			}
-			else {
-				joinType = SqlAstJoinType.INNER;
-			}
+		if ( requestedJoinType != null ) {
+			return requestedJoinType;
 		}
-		else {
-			joinType = requestedJoinType;
+
+		if ( fetched ) {
+			return getDefaultSqlAstJoinType( lhs );
 		}
-		return joinType;
+
+		return SqlAstJoinType.INNER;
 	}
 }

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/associations/NotFoundTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/associations/NotFoundTest.java
@@ -14,6 +14,8 @@ import org.hibernate.annotations.NotFoundAction;
 
 import org.hibernate.testing.jdbc.SQLStatementInspector;
 import org.hibernate.testing.orm.junit.EntityManagerFactoryScope;
+import org.hibernate.testing.orm.junit.FailureExpected;
+import org.hibernate.testing.orm.junit.Jira;
 import org.hibernate.testing.orm.junit.Jpa;
 
 import org.junit.jupiter.api.AfterEach;
@@ -133,6 +135,38 @@ public class NotFoundTest {
 					assertThat( sqlStatementInspector.getSqlQueries().get( 1 ) ).doesNotContain( " join " );
 				}
 		);
+	}
+
+	@Test
+	@Jira( "https://hibernate.atlassian.net/browse/HHH-17143" )
+	@FailureExpected
+	void testHqlDelete(EntityManagerFactoryScope scope) {
+		breakForeignKey( scope );
+		final SQLStatementInspector sqlStatementInspector = scope.getCollectingStatementInspector();
+		sqlStatementInspector.clear();
+
+		scope.inTransaction( (entityManager) -> {
+			entityManager.createQuery( "delete from Person p where p.city is null" ).executeUpdate();
+
+			assertThat( sqlStatementInspector.getSqlQueries() ).hasSize( 1 );
+			assertThat( sqlStatementInspector.getSqlQueries().get( 0 ) ).doesNotContainIgnoringCase( "city_fk is null" );
+		} );
+	}
+
+	@Test
+	@Jira( "https://hibernate.atlassian.net/browse/HHH-17143" )
+	@FailureExpected
+	void testHqlUpdate(EntityManagerFactoryScope scope) {
+		breakForeignKey( scope );
+		final SQLStatementInspector sqlStatementInspector = scope.getCollectingStatementInspector();
+		sqlStatementInspector.clear();
+
+		scope.inTransaction( (entityManager) -> {
+			entityManager.createQuery( "update Person p set p.name = 'abc' where p.city is null" ).executeUpdate();
+
+			assertThat( sqlStatementInspector.getSqlQueries() ).hasSize( 1 );
+			assertThat( sqlStatementInspector.getSqlQueries().get( 0 ) ).doesNotContainIgnoringCase( "city_fk is null" );
+		} );
 	}
 
 	private void breakForeignKey(EntityManagerFactoryScope scope) {

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/associations/NotFoundTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/associations/NotFoundTest.java
@@ -137,38 +137,6 @@ public class NotFoundTest {
 		);
 	}
 
-	@Test
-	@Jira( "https://hibernate.atlassian.net/browse/HHH-17143" )
-	@FailureExpected
-	void testHqlDelete(EntityManagerFactoryScope scope) {
-		breakForeignKey( scope );
-		final SQLStatementInspector sqlStatementInspector = scope.getCollectingStatementInspector();
-		sqlStatementInspector.clear();
-
-		scope.inTransaction( (entityManager) -> {
-			entityManager.createQuery( "delete from Person p where p.city is null" ).executeUpdate();
-
-			assertThat( sqlStatementInspector.getSqlQueries() ).hasSize( 1 );
-			assertThat( sqlStatementInspector.getSqlQueries().get( 0 ) ).doesNotContainIgnoringCase( "city_fk is null" );
-		} );
-	}
-
-	@Test
-	@Jira( "https://hibernate.atlassian.net/browse/HHH-17143" )
-	@FailureExpected
-	void testHqlUpdate(EntityManagerFactoryScope scope) {
-		breakForeignKey( scope );
-		final SQLStatementInspector sqlStatementInspector = scope.getCollectingStatementInspector();
-		sqlStatementInspector.clear();
-
-		scope.inTransaction( (entityManager) -> {
-			entityManager.createQuery( "update Person p set p.name = 'abc' where p.city is null" ).executeUpdate();
-
-			assertThat( sqlStatementInspector.getSqlQueries() ).hasSize( 1 );
-			assertThat( sqlStatementInspector.getSqlQueries().get( 0 ) ).doesNotContainIgnoringCase( "city_fk is null" );
-		} );
-	}
-
 	private void breakForeignKey(EntityManagerFactoryScope scope) {
 		scope.inTransaction(
 				entityManager -> {


### PR DESCRIPTION
HHH-17143 - Bad handling of not-found association references in mutation queries

https://hibernate.atlassian.net/browse/HHH-17143