### PR TITLE
Remove final from SqmSelectionQueryImpl#setOrder

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/internal/SqmSelectionQueryImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/internal/SqmSelectionQueryImpl.java
@@ -291,7 +291,7 @@ public class SqmSelectionQueryImpl<R> extends AbstractSelectionQuery<R>
 	}
 
 	@Override
-	public final SelectionQuery<R> setOrder(List<Order<? super R>> orderList) {
+	public SelectionQuery<R> setOrder(List<Order<? super R>> orderList) {
 		sqm = sqm.copy( SqmCopyContext.noParamCopyContext() );
 		sqm.orderBy( orderList.stream().map( order -> sortSpecification( sqm, order ) )
 				.collect( toList() ) );
@@ -302,7 +302,7 @@ public class SqmSelectionQueryImpl<R> extends AbstractSelectionQuery<R>
 	}
 
 	@Override
-	public final SelectionQuery<R> setOrder(Order<? super R> order) {
+	public SelectionQuery<R> setOrder(Order<? super R> order) {
 		sqm = sqm.copy( SqmCopyContext.noParamCopyContext() );
 		sqm.orderBy( sortSpecification( sqm, order ) );
 		// TODO: when the QueryInterpretationCache can handle caching criteria queries,


### PR DESCRIPTION
Hibernate Reactive needs to override these methods to implement `setOrder`

Fix https://hibernate.atlassian.net/browse/HHH-17150