### PR TITLE
HHH-16592 value of @MapsId should be used to infer column mappings for @ManyToOne

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/boot/model/internal/AnnotatedColumn.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/internal/AnnotatedColumn.java
@@ -280,6 +280,7 @@ public class AnnotatedColumn {
 		}
 		else {
 			mappingColumn = new Column();
+			mappingColumn.setExplicit( !isImplicit );
 			redefineColumnName( columnName, propertyName, applyNamingStrategy );
 			mappingColumn.setLength( length );
 			if ( precision != null && precision > 0 ) {  //relevant precision

--- a/hibernate-core/src/main/java/org/hibernate/boot/model/internal/AnnotatedJoinColumn.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/internal/AnnotatedJoinColumn.java
@@ -292,7 +292,7 @@ public class AnnotatedJoinColumn extends AnnotatedColumn {
 			throw new AssertionFailure( "Building implicit column but the column is not implicit" );
 		}
 		for ( Column synthCol: referencedValue.getColumns() ) {
-			this.linkValueUsingDefaultColumnNaming( synthCol, referencedEntity, value );
+			linkValueUsingDefaultColumnNaming( synthCol, referencedEntity, value );
 		}
 		//reset for the future
 		setMappingColumn( null );
@@ -302,9 +302,18 @@ public class AnnotatedJoinColumn extends AnnotatedColumn {
 			Column referencedColumn,
 			PersistentClass referencedEntity,
 			SimpleValue value) {
+		int columnIndex = getParent().getJoinColumns().indexOf(this);
+		linkValueUsingDefaultColumnNaming( columnIndex, referencedColumn, referencedEntity, value );
+	}
+
+	public void linkValueUsingDefaultColumnNaming(
+			int columnIndex,
+			Column referencedColumn,
+			PersistentClass referencedEntity,
+			SimpleValue value) {
 		final String logicalReferencedColumn = getBuildingContext().getMetadataCollector()
 				.getLogicalColumnName( referencedEntity.getTable(), referencedColumn.getQuotedName() );
-		final String columnName = getParent().buildDefaultColumnName( referencedEntity, logicalReferencedColumn );
+		final String columnName = defaultColumnName( columnIndex, referencedEntity, logicalReferencedColumn );
 		//yuk side effect on an implicit column
 		setLogicalColumnName( columnName );
 		setReferencedColumn( logicalReferencedColumn );
@@ -322,6 +331,23 @@ public class AnnotatedJoinColumn extends AnnotatedColumn {
 				false
 		);
 		linkWithValue( value );
+	}
+
+	private String defaultColumnName(int columnIndex, PersistentClass referencedEntity, String logicalReferencedColumn) {
+		final AnnotatedJoinColumns parent = getParent();
+		if ( parent.hasMapsId() ) {
+			// infer the join column of the association
+			// from the name of the mapped primary key
+			// column (this is not required by the JPA
+			// spec) and is arguably backwards, given
+			// the name of the @MapsId annotation, but
+			// it's better than just having two different
+			// column names which disagree
+			return parent.resolveMapsId().getValue().getColumns().get( columnIndex ).getQuotedName();
+		}
+		else {
+			return parent.buildDefaultColumnName( referencedEntity, logicalReferencedColumn );
+		}
 	}
 
 	public void addDefaultJoinColumnName(PersistentClass referencedEntity, String logicalReferencedColumn) {

--- a/hibernate-core/src/main/java/org/hibernate/boot/model/internal/AnnotatedJoinColumn.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/internal/AnnotatedJoinColumn.java
@@ -316,6 +316,7 @@ public class AnnotatedJoinColumn extends AnnotatedColumn {
 		final String columnName = defaultColumnName( columnIndex, referencedEntity, logicalReferencedColumn );
 		//yuk side effect on an implicit column
 		setLogicalColumnName( columnName );
+		setImplicit( true );
 		setReferencedColumn( logicalReferencedColumn );
 		final Column mappingColumn = getMappingColumn();
 		initMappingColumn(
@@ -335,16 +336,23 @@ public class AnnotatedJoinColumn extends AnnotatedColumn {
 
 	private String defaultColumnName(int columnIndex, PersistentClass referencedEntity, String logicalReferencedColumn) {
 		final AnnotatedJoinColumns parent = getParent();
-//		if ( parent.hasMapsId() ) {
-//			// infer the join column of the association
-//			// from the name of the mapped primary key
-//			// column (this is not required by the JPA
-//			// spec) and is arguably backwards, given
-//			// the name of the @MapsId annotation, but
-//			// it's better than just having two different
-//			// column names which disagree
-//			return parent.resolveMapsId().getValue().getColumns().get( columnIndex ).getQuotedName();
-//		}
+		if ( parent.hasMapsId() ) {
+			// infer the join column of the association
+			// from the name of the mapped primary key
+			// column (this is not required by the JPA
+			// spec) and is arguably backwards, given
+			// the name of the @MapsId annotation, but
+			// it's better than just having two different
+			// column names which disagree
+			final Column column = parent.resolveMapsId().getValue().getColumns().get( columnIndex );
+//			return column.getQuotedName();
+			if ( column.isExplicit() ) {
+				throw new AnnotationException( "Association '" + parent.getPropertyName()
+						+ "' in entity '" + parent.getPropertyHolder().getEntityName()
+						+ "' is annotated '@MapsId' but refers to a property '"
+						+ parent.getMapsId() + "' which has an explicit column mapping" );
+			}
+		}
 //		else {
 			return parent.buildDefaultColumnName( referencedEntity, logicalReferencedColumn );
 //		}

--- a/hibernate-core/src/main/java/org/hibernate/boot/model/internal/AnnotatedJoinColumn.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/internal/AnnotatedJoinColumn.java
@@ -335,19 +335,19 @@ public class AnnotatedJoinColumn extends AnnotatedColumn {
 
 	private String defaultColumnName(int columnIndex, PersistentClass referencedEntity, String logicalReferencedColumn) {
 		final AnnotatedJoinColumns parent = getParent();
-		if ( parent.hasMapsId() ) {
-			// infer the join column of the association
-			// from the name of the mapped primary key
-			// column (this is not required by the JPA
-			// spec) and is arguably backwards, given
-			// the name of the @MapsId annotation, but
-			// it's better than just having two different
-			// column names which disagree
-			return parent.resolveMapsId().getValue().getColumns().get( columnIndex ).getQuotedName();
-		}
-		else {
+//		if ( parent.hasMapsId() ) {
+//			// infer the join column of the association
+//			// from the name of the mapped primary key
+//			// column (this is not required by the JPA
+//			// spec) and is arguably backwards, given
+//			// the name of the @MapsId annotation, but
+//			// it's better than just having two different
+//			// column names which disagree
+//			return parent.resolveMapsId().getValue().getColumns().get( columnIndex ).getQuotedName();
+//		}
+//		else {
 			return parent.buildDefaultColumnName( referencedEntity, logicalReferencedColumn );
-		}
+//		}
 	}
 
 	public void addDefaultJoinColumnName(PersistentClass referencedEntity, String logicalReferencedColumn) {

--- a/hibernate-core/src/main/java/org/hibernate/boot/model/internal/ColumnsBuilder.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/internal/ColumnsBuilder.java
@@ -177,7 +177,7 @@ class ColumnsBuilder {
 			);
 		}
 		else {
-			OneToOne oneToOneAnn = property.getAnnotation( OneToOne.class );
+			final OneToOne oneToOneAnn = property.getAnnotation( OneToOne.class );
 			return AnnotatedJoinColumns.buildJoinColumns(
 					null,
 //					comment,

--- a/hibernate-core/src/main/java/org/hibernate/boot/model/internal/TableBinder.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/internal/TableBinder.java
@@ -310,7 +310,7 @@ public class TableBinder {
 
 		final Identifier logicalName;
 		if ( isJPA2ElementCollection ) {
-			logicalName    = buildingContext.getBuildingOptions().getImplicitNamingStrategy().determineCollectionTableName(
+			logicalName = buildingContext.getBuildingOptions().getImplicitNamingStrategy().determineCollectionTableName(
 					new ImplicitCollectionTableNameSource() {
 						private final EntityNaming owningEntityNaming = new EntityNaming() {
 							@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/model/internal/TableBinder.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/internal/TableBinder.java
@@ -751,6 +751,21 @@ public class TableBinder {
 			final AnnotatedJoinColumn firstColumn = joinColumns.getJoinColumns().get(0);
 			firstColumn.linkValueUsingDefaultColumnNaming( i, column, referencedEntity, value );
 			firstColumn.overrideFromReferencedColumnIfNecessary( column );
+			final Column createdColumn = firstColumn.getMappingColumn();
+			if ( createdColumn != null ) {
+				final String logicalColumnName = createdColumn.getQuotedName();
+				if ( logicalColumnName != null && joinColumns.hasMapsId() ) {
+					final Value idValue = joinColumns.resolveMapsId().getValue();
+					final Column idColumn = idValue.getColumns().get(i);
+					// infer the names of the primary key column
+					// from the join column of the association
+					// as (sorta) required by the JPA spec
+					if ( !idColumn.getQuotedName().equals(logicalColumnName) ) {
+						idColumn.setName( logicalColumnName );
+						idValue.getTable().columnRenamed( idColumn);
+					}
+				}
+			}
 		}
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/boot/model/internal/ToOneBinder.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/internal/ToOneBinder.java
@@ -205,11 +205,14 @@ public class ToOneBinder {
 		}
 
 		if ( property.isAnnotationPresent( MapsId.class ) ) {
+			final MapsId mapsId = property.getAnnotation(MapsId.class);
+			final List<AnnotatedJoinColumn> joinColumnList = joinColumns.getJoinColumns();
 			//read only
-			for ( AnnotatedJoinColumn column : joinColumns.getJoinColumns() ) {
+			for ( AnnotatedJoinColumn column : joinColumnList ) {
 				column.setInsertable( false );
 				column.setUpdatable( false );
 			}
+			joinColumns.setMapsId( mapsId.value() );
 		}
 
 		boolean hasSpecjManyToOne = handleSpecjSyntax( joinColumns, inferredData, context, property );

--- a/hibernate-core/src/main/java/org/hibernate/mapping/Column.java
+++ b/hibernate-core/src/main/java/org/hibernate/mapping/Column.java
@@ -57,6 +57,7 @@ public class Column implements Selectable, Serializable, Cloneable, ColumnTypeIn
 	private String sqlTypeName;
 	private Integer sqlTypeCode;
 	private boolean quoted;
+	private boolean explicit;
 	int uniqueInteger;
 	private String comment;
 	private String defaultValue;
@@ -115,6 +116,14 @@ public class Column implements Selectable, Serializable, Cloneable, ColumnTypeIn
 		else {
 			this.name = name;
 		}
+	}
+
+	public boolean isExplicit() {
+		return explicit;
+	}
+
+	public void setExplicit(boolean explicit) {
+		this.explicit = explicit;
 	}
 
 	private static boolean isQuoted(String name) {

--- a/hibernate-core/src/main/java/org/hibernate/mapping/Table.java
+++ b/hibernate-core/src/main/java/org/hibernate/mapping/Table.java
@@ -298,6 +298,17 @@ public class Table implements Serializable, ContributableDatabaseObject {
 		}
 	}
 
+	@Internal
+	public void columnRenamed(Column column) {
+		for ( Map.Entry<String, Column> entry : columns.entrySet() ) {
+			if ( entry.getValue() == column ) {
+				columns.remove( entry.getKey() );
+				columns.put( column.getCanonicalName(), column );
+				break;
+			}
+		}
+	}
+
 	public int getColumnSpan() {
 		return columns.size();
 	}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/mapsid/DefaultedMapsIdTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/mapsid/DefaultedMapsIdTest.java
@@ -13,6 +13,7 @@ import org.hibernate.testing.orm.junit.SessionFactory;
 import org.hibernate.testing.orm.junit.SessionFactoryScope;
 import org.junit.jupiter.api.Test;
 
+
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.List;
@@ -107,7 +108,6 @@ public class DefaultedMapsIdTest {
     @IdClass(ExtensionId.class)
     static class Extension {
         @Id
-//        @Column(name = "EX_LOAN_ID")
         private Long exLoanId;
 
         @Id
@@ -119,7 +119,6 @@ public class DefaultedMapsIdTest {
 
         @ManyToOne
         @MapsId("exLoanId")
-//        @JoinColumn(name = "EX_LOAN_ID")
         private Loan loan;
     }
 }

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/mapsid/DefaultedMapsIdTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/mapsid/DefaultedMapsIdTest.java
@@ -13,7 +13,6 @@ import org.hibernate.testing.orm.junit.SessionFactory;
 import org.hibernate.testing.orm.junit.SessionFactoryScope;
 import org.junit.jupiter.api.Test;
 
-
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.List;
@@ -23,8 +22,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 @SessionFactory
-@DomainModel(annotatedClasses = {MapsIdTest.Loan.class, MapsIdTest.Extension.class})
-public class MapsIdTest {
+@DomainModel(annotatedClasses = {DefaultedMapsIdTest.Loan.class, DefaultedMapsIdTest.Extension.class})
+public class DefaultedMapsIdTest {
 
     @Test void test(SessionFactoryScope scope) {
         ExtensionId eid = scope.fromTransaction( s -> {
@@ -108,7 +107,7 @@ public class MapsIdTest {
     @IdClass(ExtensionId.class)
     static class Extension {
         @Id
-        @Column(name = "EX_LOAN_ID") //TODO: this should really cause an error
+//        @Column(name = "EX_LOAN_ID")
         private Long exLoanId;
 
         @Id

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/mapsid/MapsEmbeddedIdTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/mapsid/MapsEmbeddedIdTest.java
@@ -1,0 +1,130 @@
+package org.hibernate.orm.test.annotations.mapsid;
+
+import jakarta.persistence.AttributeOverride;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import jakarta.persistence.EmbeddedId;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.MapsId;
+import jakarta.persistence.OneToMany;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+@SessionFactory
+@DomainModel(annotatedClasses = {MapsEmbeddedIdTest.Loan.class, MapsEmbeddedIdTest.ExtensionId.class, MapsEmbeddedIdTest.Extension.class})
+public class MapsEmbeddedIdTest {
+
+    @Test void test(SessionFactoryScope scope) {
+        ExtensionId eid = scope.fromTransaction( s -> {
+            Loan loan = new Loan();
+            loan.id = 999L;
+            ExtensionId exid = new ExtensionId(loan.id, 1);
+            Extension extension = new Extension();
+            extension.id = exid;
+            extension.loan = loan;
+            extension.exExtensionDays = 30;
+            loan.extensions.add(extension);
+            exid = new ExtensionId(loan.id, 2);
+            extension = new Extension();
+            extension.id = exid;
+            extension.loan = loan;
+            extension.exExtensionDays = 14;
+            loan.extensions.add(extension);
+            s.persist(loan);
+            return exid;
+        });
+        scope.inSession( s -> {
+            List<Extension> extensions = s.createQuery("from Extension", Extension.class).getResultList();
+            assertEquals(2, extensions.size());
+        } );
+        scope.inSession( s -> {
+            Extension extension = s.find(Extension.class, eid);
+            assertEquals(14, extension.exExtensionDays);
+            assertEquals(2, extension.id.exNo);
+            assertEquals(999L, extension.id.exLoanId);
+            assertNotNull( extension.loan );
+        });
+        scope.inSession( s -> {
+            Loan loan = s.find(Loan.class, eid.exLoanId);
+            Extension extension = loan.extensions.get(0);
+            assertEquals(1, extension.id.exNo);
+            assertEquals(30, extension.exExtensionDays);
+            assertEquals(999L, extension.id.exLoanId);
+            assertEquals(loan, extension.loan);
+        });
+    }
+
+    @Entity(name = "Loan")
+    static class Loan {
+        @Id
+        @Column(name = "LOAN_ID")
+        private Long id;
+
+        private BigDecimal amount = BigDecimal.ZERO;
+
+        @OneToMany(cascade = CascadeType.ALL, mappedBy = "loan")
+        private List<Extension> extensions = new ArrayList<>();
+    }
+
+    @Embeddable
+    public static class ExtensionId {
+
+//        @Column(name="EX_LOAN_ID")
+        private Long exLoanId;
+
+//        @Column(name="EX_NO")
+        private int exNo;
+
+        public ExtensionId(Long exLoanId, int exNo) {
+            this.exLoanId = exLoanId;
+            this.exNo = exNo;
+        }
+
+        public ExtensionId() {
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (!(o instanceof ExtensionId)) return false;
+            ExtensionId that = (ExtensionId) o;
+            return exNo == that.exNo && Objects.equals(exLoanId, that.exLoanId);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(exLoanId, exNo);
+        }
+    }
+
+    @Entity(name = "Extension")
+    static class Extension {
+
+        @EmbeddedId
+        @AttributeOverride(name = "exLoanId", column = @Column(name="EX_LOAN_ID"))
+        @AttributeOverride(name = "exNo", column = @Column(name="EX_NO"))
+        private ExtensionId id;
+
+        @Column(name = "EX_EXTENSION_DAYS")
+        private int exExtensionDays;
+
+        @ManyToOne
+        @MapsId("exLoanId")
+        @JoinColumn(name = "EX_LOAN_ID")
+        private Loan loan;
+    }
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/mapsid/MapsIdTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/mapsid/MapsIdTest.java
@@ -5,7 +5,6 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jakarta.persistence.IdClass;
-import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.MapsId;
 import jakarta.persistence.OneToMany;
@@ -120,8 +119,8 @@ public class MapsIdTest {
         private int exExtensionDays;
 
         @ManyToOne
-        @MapsId
-        @JoinColumn(name = "EX_LOAN_ID")
+        @MapsId("exLoanId")
+//        @JoinColumn(name = "EX_LOAN_ID")
         private Loan loan;
     }
 }

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/mapsid/MapsIdTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/mapsid/MapsIdTest.java
@@ -5,6 +5,7 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jakarta.persistence.IdClass;
+import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.MapsId;
 import jakarta.persistence.OneToMany;
@@ -12,7 +13,6 @@ import org.hibernate.testing.orm.junit.DomainModel;
 import org.hibernate.testing.orm.junit.SessionFactory;
 import org.hibernate.testing.orm.junit.SessionFactoryScope;
 import org.junit.jupiter.api.Test;
-
 
 import java.math.BigDecimal;
 import java.util.ArrayList;
@@ -108,7 +108,6 @@ public class MapsIdTest {
     @IdClass(ExtensionId.class)
     static class Extension {
         @Id
-        @Column(name = "EX_LOAN_ID") //TODO: this should really cause an error
         private Long exLoanId;
 
         @Id
@@ -120,7 +119,7 @@ public class MapsIdTest {
 
         @ManyToOne
         @MapsId("exLoanId")
-//        @JoinColumn(name = "EX_LOAN_ID")
+        @JoinColumn(name = "EX_LOAN_ID")
         private Loan loan;
     }
 }

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/mapsid/MapsIdTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/mapsid/MapsIdTest.java
@@ -1,0 +1,127 @@
+package org.hibernate.orm.test.annotations.mapsid;
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.IdClass;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.MapsId;
+import jakarta.persistence.OneToMany;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.junit.jupiter.api.Test;
+
+
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+@SessionFactory
+@DomainModel(annotatedClasses = {MapsIdTest.Loan.class, MapsIdTest.Extension.class})
+public class MapsIdTest {
+
+    @Test void test(SessionFactoryScope scope) {
+        ExtensionId eid = scope.fromTransaction( s -> {
+            Loan loan = new Loan();
+            loan.id = 999L;
+            Extension extension = new Extension();
+            extension.exLoanId = loan.id;
+            extension.loan = loan;
+            extension.exNo = 1;
+            extension.exExtensionDays = 30;
+            loan.extensions.add(extension);
+            extension = new Extension();
+            extension.exLoanId = loan.id;
+            extension.loan = loan;
+            extension.exNo = 2;
+            extension.exExtensionDays = 14;
+            loan.extensions.add(extension);
+            s.persist(loan);
+            return new ExtensionId(extension.exLoanId, extension.exNo );
+        });
+        scope.inSession( s -> {
+            List<Extension> extensions = s.createQuery("from Extension", Extension.class).getResultList();
+            assertEquals(2, extensions.size());
+        } );
+        scope.inSession( s -> {
+            Extension extension = s.find(Extension.class, eid);
+            assertEquals(14, extension.exExtensionDays);
+            assertEquals(2, extension.exNo);
+            assertEquals(999L, extension.exLoanId);
+            assertNotNull( extension.loan );
+        });
+        scope.inSession( s -> {
+            Loan loan = s.find(Loan.class, eid.exLoanId);
+            Extension extension = loan.extensions.get(0);
+            assertEquals(1, extension.exNo);
+            assertEquals(30, extension.exExtensionDays);
+            assertEquals(999L, extension.exLoanId);
+            assertEquals(loan, extension.loan);
+        });
+    }
+
+    @Entity(name = "Loan")
+    static class Loan {
+        @Id
+        @Column(name = "LOAN_ID")
+        private Long id;
+
+        private BigDecimal amount = BigDecimal.ZERO;
+
+        @OneToMany(cascade = CascadeType.ALL, mappedBy = "loan")
+        private List<Extension> extensions = new ArrayList<>();
+    }
+
+    static class ExtensionId {
+        private Long exLoanId;
+        private int exNo;
+
+        public ExtensionId(Long exLoanId, int exNo) {
+            this.exLoanId = exLoanId;
+            this.exNo = exNo;
+        }
+
+        public ExtensionId() {
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (!(o instanceof ExtensionId)) return false;
+            ExtensionId that = (ExtensionId) o;
+            return exNo == that.exNo && Objects.equals(exLoanId, that.exLoanId);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(exLoanId, exNo);
+        }
+    }
+
+    @Entity(name = "Extension")
+    @IdClass(ExtensionId.class)
+    static class Extension {
+        @Id
+        @Column(name = "EX_LOAN_ID")
+        private Long exLoanId;
+
+        @Id
+        @Column(name = "EX_NO")
+        private int exNo;
+
+        @Column(name = "EX_EXTENSION_DAYS")
+        private int exExtensionDays;
+
+        @ManyToOne
+        @MapsId
+        @JoinColumn(name = "EX_LOAN_ID")
+        private Loan loan;
+    }
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/mapsid/NoIdClassMapsIdTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/mapsid/NoIdClassMapsIdTest.java
@@ -1,10 +1,7 @@
 package org.hibernate.orm.test.annotations.mapsid;
 
-import jakarta.persistence.AttributeOverride;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
-import jakarta.persistence.Embeddable;
-import jakarta.persistence.EmbeddedId;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
@@ -19,33 +16,32 @@ import org.junit.jupiter.api.Test;
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Objects;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 @SessionFactory
-@DomainModel(annotatedClasses = {MapsEmbeddedIdTest.Loan.class, MapsEmbeddedIdTest.ExtensionId.class, MapsEmbeddedIdTest.Extension.class})
-public class MapsEmbeddedIdTest {
+@DomainModel(annotatedClasses = {NoIdClassMapsIdTest.Loan.class, NoIdClassMapsIdTest.Extension.class})
+public class NoIdClassMapsIdTest {
 
     @Test void test(SessionFactoryScope scope) {
-        ExtensionId eid = scope.fromTransaction( s -> {
+        Extension eid = scope.fromTransaction( s -> {
             Loan loan = new Loan();
             loan.id = 999L;
-            ExtensionId exid = new ExtensionId(loan.id, 1);
             Extension extension = new Extension();
-            extension.id = exid;
+            extension.exLoanId = loan.id;
             extension.loan = loan;
+            extension.exNo = 1;
             extension.exExtensionDays = 30;
             loan.extensions.add(extension);
-            exid = new ExtensionId(loan.id, 2);
             extension = new Extension();
-            extension.id = exid;
+            extension.exLoanId = loan.id;
             extension.loan = loan;
+            extension.exNo = 2;
             extension.exExtensionDays = 14;
             loan.extensions.add(extension);
             s.persist(loan);
-            return exid;
+            return extension;
         });
         scope.inSession( s -> {
             List<Extension> extensions = s.createQuery("from Extension", Extension.class).getResultList();
@@ -54,16 +50,16 @@ public class MapsEmbeddedIdTest {
         scope.inSession( s -> {
             Extension extension = s.find(Extension.class, eid);
             assertEquals(14, extension.exExtensionDays);
-            assertEquals(2, extension.id.exNo);
-            assertEquals(999L, extension.id.exLoanId);
+            assertEquals(2, extension.exNo);
+            assertEquals(999L, extension.exLoanId);
             assertNotNull( extension.loan );
         });
         scope.inSession( s -> {
             Loan loan = s.find(Loan.class, eid.exLoanId);
             Extension extension = loan.extensions.get(0);
-            assertEquals(1, extension.id.exNo);
+            assertEquals(1, extension.exNo);
             assertEquals(30, extension.exExtensionDays);
-            assertEquals(999L, extension.id.exLoanId);
+            assertEquals(999L, extension.exLoanId);
             assertEquals(loan, extension.loan);
         });
     }
@@ -80,41 +76,15 @@ public class MapsEmbeddedIdTest {
         private List<Extension> extensions = new ArrayList<>();
     }
 
-    @Embeddable
-    public static class ExtensionId {
-
-        private Long exLoanId;
-
-        @Column(name="EX_NO")
-        private int exNo;
-
-        public ExtensionId(Long exLoanId, int exNo) {
-            this.exLoanId = exLoanId;
-            this.exNo = exNo;
-        }
-
-        public ExtensionId() {
-        }
-
-        @Override
-        public boolean equals(Object o) {
-            if (this == o) return true;
-            if (!(o instanceof ExtensionId)) return false;
-            ExtensionId that = (ExtensionId) o;
-            return exNo == that.exNo && Objects.equals(exLoanId, that.exLoanId);
-        }
-
-        @Override
-        public int hashCode() {
-            return Objects.hash(exLoanId, exNo);
-        }
-    }
 
     @Entity(name = "Extension")
     static class Extension {
+        @Id
+        private Long exLoanId;
 
-        @EmbeddedId
-        private ExtensionId id;
+        @Id
+        @Column(name = "EX_NO")
+        private int exNo;
 
         @Column(name = "EX_EXTENSION_DAYS")
         private int exExtensionDays;

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/mapsid/NoMapsIdTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/mapsid/NoMapsIdTest.java
@@ -1,0 +1,120 @@
+package org.hibernate.orm.test.annotations.mapsid;
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.IdClass;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+@SessionFactory
+@DomainModel(annotatedClasses = {NoMapsIdTest.Loan.class, NoMapsIdTest.Extension.class})
+public class NoMapsIdTest {
+
+    @Test void test(SessionFactoryScope scope) {
+        ExtensionId eid = scope.fromTransaction( s -> {
+            Loan loan = new Loan();
+            loan.id = 999L;
+            Extension extension = new Extension();
+            extension.loan = loan;
+            extension.exNo = 1;
+            extension.exExtensionDays = 30;
+            loan.extensions.add(extension);
+            extension = new Extension();
+            extension.loan = loan;
+            extension.exNo = 2;
+            extension.exExtensionDays = 14;
+            loan.extensions.add(extension);
+            s.persist(loan);
+            return new ExtensionId(extension.loan.id, extension.exNo );
+        });
+        scope.inSession( s -> {
+            List<Extension> extensions = s.createQuery("from Extension", Extension.class).getResultList();
+            assertEquals(2, extensions.size());
+        } );
+        scope.inSession( s -> {
+            Extension extension = s.find(Extension.class, eid);
+            assertEquals(14, extension.exExtensionDays);
+            assertEquals(2, extension.exNo);
+            assertEquals(999L, extension.loan.id);
+            assertNotNull( extension.loan );
+        });
+        scope.inSession( s -> {
+            Loan loan = s.find(Loan.class, eid.loan);
+            Extension extension = loan.extensions.get(0);
+            assertEquals(1, extension.exNo);
+            assertEquals(30, extension.exExtensionDays);
+            assertEquals(999L, extension.loan.id);
+            assertEquals(loan, extension.loan);
+        });
+    }
+
+    @Entity(name = "Loan")
+    static class Loan {
+        @Id
+        @Column(name = "LOAN_ID")
+        private Long id;
+
+        private BigDecimal amount = BigDecimal.ZERO;
+
+        @OneToMany(cascade = CascadeType.ALL, mappedBy = "loan")
+        private List<Extension> extensions = new ArrayList<>();
+    }
+
+    static class ExtensionId {
+        private Long loan;
+        private int exNo;
+
+        public ExtensionId(Long loan, int exNo) {
+            this.loan = loan;
+            this.exNo = exNo;
+        }
+
+        public ExtensionId() {
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (!(o instanceof ExtensionId)) return false;
+            ExtensionId that = (ExtensionId) o;
+            return exNo == that.exNo && Objects.equals(loan, that.loan);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(loan, exNo);
+        }
+    }
+
+    @Entity(name = "Extension")
+    @IdClass(ExtensionId.class)
+    static class Extension {
+
+        @Id
+        @Column(name = "EX_NO")
+        private int exNo;
+
+        @Column(name = "EX_EXTENSION_DAYS")
+        private int exExtensionDays;
+
+        @ManyToOne
+        @Id
+        @JoinColumn(name = "EX_LOAN_ID")
+        private Loan loan;
+    }
+}

--- a/hibernate-envers/src/test/java/org/hibernate/orm/test/envers/integration/ids/embeddedid/CorrectChild.java
+++ b/hibernate-envers/src/test/java/org/hibernate/orm/test/envers/integration/ids/embeddedid/CorrectChild.java
@@ -23,7 +23,7 @@ public class CorrectChild {
 	private CorrectChildId id;
 
 	@ManyToOne
-	@MapsId("parent_id")
+	@MapsId("id")
 	private Parent parent;
 
 	CorrectChild() {


### PR DESCRIPTION
Previously, the `value` member of the `@MapsId` annotation was essentially ignored, at least for `@ManyToOne` mappings. This forced the user to specify duplicate mappings for the columns.

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-16592
<!-- Hibernate GitHub Bot issue links end -->