### PR TITLE
HHH-17201 Unexpected value type exception for unordered multi id Load with ordered return disable

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/internal/MultiIdentifierLoadAccessImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/MultiIdentifierLoadAccessImpl.java
@@ -6,6 +6,7 @@
  */
 package org.hibernate.internal;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.function.Supplier;
 
@@ -15,6 +16,7 @@ import org.hibernate.MultiIdentifierLoadAccess;
 import org.hibernate.graph.GraphSemantic;
 import org.hibernate.graph.RootGraph;
 import org.hibernate.graph.spi.RootGraphImplementor;
+import org.hibernate.loader.ast.internal.LoaderHelper;
 import org.hibernate.persister.entity.EntityPersister;
 import org.hibernate.loader.ast.spi.MultiIdLoadOptions;
 
@@ -165,6 +167,13 @@ class MultiIdentifierLoadAccessImpl<T> implements MultiIdentifierLoadAccess<T>, 
 	@Override
 	@SuppressWarnings( "unchecked" )
 	public <K> List<T> multiLoad(List<K> ids) {
-		return perform( () -> (List<T>) entityPersister.multiLoad( ids.toArray( new Object[ 0 ] ), session, this ) );
+		if ( ids.isEmpty() ) {
+			return Collections.emptyList();
+		}
+		return perform( () -> (List<T>) entityPersister.multiLoad(
+				ids.toArray( LoaderHelper.createTypedArray( ids.get( 0 ).getClass(), ids.size() ) ),
+				session,
+				this
+		) );
 	}
 }

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/loading/multiLoad/MultiIdEntityLoadTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/loading/multiLoad/MultiIdEntityLoadTests.java
@@ -12,7 +12,9 @@ import org.hibernate.testing.hamcrest.CollectionMatchers;
 import org.hibernate.testing.orm.domain.StandardDomainModel;
 import org.hibernate.testing.orm.domain.gambit.BasicEntity;
 import org.hibernate.testing.orm.domain.gambit.EntityWithAggregateId;
+import org.hibernate.testing.orm.domain.gambit.SimpleEntity;
 import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.JiraKey;
 import org.hibernate.testing.orm.junit.SessionFactory;
 import org.hibernate.testing.orm.junit.SessionFactoryFunctionalTesting;
 import org.hibernate.testing.orm.junit.SessionFactoryScope;
@@ -40,6 +42,18 @@ public class MultiIdEntityLoadTests {
 				session -> {
 					final List<BasicEntity> results = session.byMultipleIds( BasicEntity.class ).multiLoad( 1, 3 );
 					assertThat( results.size(), is( 2 ) );
+				}
+		);
+	}
+
+	@Test
+	@JiraKey( "HHH-17201" )
+	public void testSimpleEntityUnOrderedMultiLoad(SessionFactoryScope scope) {
+		scope.inTransaction(
+				session -> {
+					List<Integer> idList = List.of( 0, 1 );
+					session.byMultipleIds( SimpleEntity.class )
+							.enableOrderedReturn( false ).multiLoad( idList );
 				}
 		);
 	}


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-17201