### PR TITLE
HHH-17204 visibility changes for Reactive upsert() support

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/persister/entity/AbstractEntityPersister.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/entity/AbstractEntityPersister.java
@@ -1051,6 +1051,11 @@ public abstract class AbstractEntityPersister
 		return deleteCoordinator;
 	}
 
+	@Internal
+	public UpdateCoordinator getMergeCoordinator() {
+		return mergeCoordinator;
+	}
+
 	public String getVersionSelectString() {
 		return sqlVersionSelectString;
 	}

--- a/hibernate-core/src/main/java/org/hibernate/persister/entity/mutation/MergeCoordinator.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/entity/mutation/MergeCoordinator.java
@@ -24,7 +24,7 @@ public class MergeCoordinator extends UpdateCoordinatorStandard {
 	}
 
 	@Override
-	<O extends MutationOperation> AbstractTableUpdateBuilder<O> newTableUpdateBuilder(EntityTableMapping tableMapping) {
+	protected <O extends MutationOperation> AbstractTableUpdateBuilder<O> newTableUpdateBuilder(EntityTableMapping tableMapping) {
 		return new TableMergeBuilder<>( entityPersister(), tableMapping, factory() );
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/persister/entity/mutation/UpdateCoordinatorStandard.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/entity/mutation/UpdateCoordinatorStandard.java
@@ -1088,7 +1088,7 @@ public class UpdateCoordinatorStandard extends AbstractMutationCoordinator imple
 		return createOperationGroup( valuesAnalysis, updateGroupBuilder.buildMutationGroup() );
 	}
 
-	<O extends MutationOperation> AbstractTableUpdateBuilder<O> newTableUpdateBuilder(EntityTableMapping tableMapping) {
+	protected <O extends MutationOperation> AbstractTableUpdateBuilder<O> newTableUpdateBuilder(EntityTableMapping tableMapping) {
 		return new TableUpdateBuilderStandard<>( entityPersister(), tableMapping, factory() );
 	}
 


### PR DESCRIPTION
Reactive support for `upsert()` feature in ORM requires relaxed visibility changes to a few methods

see:  https://github.com/hibernate/hibernate-reactive/issues/1702 for details and this [PR](https://github.com/hibernate/hibernate-reactive/pull/1757)

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-17204
<!-- Hibernate GitHub Bot issue links end -->