### PR TITLE
HHH-17212 Avoid jdbc isBeforeFirst() and isAfterLast() in scrollable results calls when possible

### DIFF
--- a/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/lazy/StatelessQueryScrollingTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/lazy/StatelessQueryScrollingTest.java
@@ -73,17 +73,7 @@ public class StatelessQueryScrollingTest extends BaseNonConfigCoreFunctionalTest
 
 		try {
 			final Query query = statelessSession.createQuery( "select p from Producer p join fetch p.products" );
-			if ( getDialect() instanceof DB2Dialect || getDialect() instanceof DerbyDialect ) {
-				/*
-					FetchingScrollableResultsImp#next() in order to check if the ResultSet is empty calls ResultSet#isBeforeFirst()
-					but the support for ResultSet#isBeforeFirst() is optional for ResultSets with a result
-					set type of TYPE_FORWARD_ONLY and db2 does not support it.
-			 	*/
-				scrollableResults = query.scroll( ScrollMode.SCROLL_INSENSITIVE );
-			}
-			else {
-				scrollableResults = query.scroll( ScrollMode.FORWARD_ONLY );
-			}
+			scrollableResults = query.scroll( ScrollMode.FORWARD_ONLY );
 			while ( scrollableResults.next() ) {
 				Producer producer = (Producer) scrollableResults.get();
 				assertTrue( Hibernate.isInitialized( producer ) );

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/lazy/proxy/FetchGraphTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/lazy/proxy/FetchGraphTest.java
@@ -138,7 +138,7 @@ public class FetchGraphTest extends BaseNonConfigCoreFunctionalTestCase {
 					final String qry = "select d from D d";
 
 					final Query query = session.createQuery( qry );
-					try (ScrollableResults scrollableResults = getScrollableResults( query )) {
+					try (ScrollableResults scrollableResults = query.scroll()) {
 						while ( scrollableResults.next() ) {
 							final DEntity dEntity = (DEntity) scrollableResults.get();
 							assertFalse( Hibernate.isPropertyInitialized( dEntity, "blob" ) );
@@ -232,7 +232,7 @@ public class FetchGraphTest extends BaseNonConfigCoreFunctionalTestCase {
 					final String qry = "select e from E e join fetch e.d";
 
 					final Query query = session.createQuery( qry );
-					try (ScrollableResults scrollableResults = getScrollableResults( query )) {
+					try (ScrollableResults scrollableResults = query.scroll()) {
 						while ( scrollableResults.next() ) {
 							final EEntity eEntity = (EEntity) scrollableResults.get();
 							final DEntity dEntity = eEntity.getD();
@@ -253,7 +253,7 @@ public class FetchGraphTest extends BaseNonConfigCoreFunctionalTestCase {
 							"join fetch d.g";
 
 					final Query query = session.createQuery( qry );
-					try (ScrollableResults scrollableResults = getScrollableResults( query )) {
+					try (ScrollableResults scrollableResults = query.scroll()) {
 						int i = 0;
 						while ( scrollableResults.next() ) {
 							i++;
@@ -270,7 +270,7 @@ public class FetchGraphTest extends BaseNonConfigCoreFunctionalTestCase {
 					final String qry = "select g from G g join fetch g.dEntities";
 
 					final Query query = session.createQuery( qry );
-					try (ScrollableResults scrollableResults = getScrollableResults( query )) {
+					try (ScrollableResults scrollableResults = query.scroll()) {
 						while ( scrollableResults.next() ) {
 							final Object o = scrollableResults.get();
 						}
@@ -300,7 +300,7 @@ public class FetchGraphTest extends BaseNonConfigCoreFunctionalTestCase {
 							"join fetch d.g";
 
 					final Query query = session.createQuery( qry );
-					try (ScrollableResults scrollableResults = getScrollableResults( query )) {
+					try (ScrollableResults scrollableResults = query.scroll()) {
 						int i = 0;
 						while ( scrollableResults.next() ) {
 							i++;
@@ -316,20 +316,7 @@ public class FetchGraphTest extends BaseNonConfigCoreFunctionalTestCase {
 	}
 
 	private ScrollableResults getScrollableResults(Query query) {
-		ScrollableResults scrollableResults;
-		final Dialect dialect = sessionFactory().getJdbcServices().getDialect();
-		if ( dialect instanceof DB2Dialect || dialect instanceof DerbyDialect ) {
-					/*
-						FetchingScrollableResultsImp#next() in order to check if the ResultSet is empty calls ResultSet#isBeforeFirst()
-						but the support for ResultSet#isBeforeFirst() is optional for ResultSets with a result
-						set type of TYPE_FORWARD_ONLY and db2 does not support it.
-					*/
-			scrollableResults = query.scroll( ScrollMode.SCROLL_INSENSITIVE );
-		}
-		else {
-			scrollableResults = query.scroll();
-		}
-		return scrollableResults;
+		return query.scroll();
 	}
 
 	@Test

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/lazy/proxy/QueryScrollingWithInheritanceProxyEagerManyToOneTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/lazy/proxy/QueryScrollingWithInheritanceProxyEagerManyToOneTest.java
@@ -17,8 +17,6 @@ import org.hibernate.Session;
 import org.hibernate.StatelessSession;
 import org.hibernate.boot.MetadataSources;
 import org.hibernate.boot.SessionFactoryBuilder;
-import org.hibernate.dialect.DB2Dialect;
-import org.hibernate.dialect.DerbyDialect;
 import org.hibernate.query.Query;
 import org.hibernate.stat.spi.StatisticsImplementor;
 
@@ -77,18 +75,7 @@ public class QueryScrollingWithInheritanceProxyEagerManyToOneTest extends BaseNo
 					"select distinct e from Employee e left join fetch e.otherEntities order by e.dept",
 					Employee.class
 			);
-			if ( getDialect() instanceof DB2Dialect || getDialect() instanceof DerbyDialect ) {
-				/*
-					FetchingScrollableResultsImp#next() in order to check if the ResultSet is empty calls ResultSet#isBeforeFirst()
-					but the support for ResultSet#isBeforeFirst() is optional for ResultSets with a result
-					set type of TYPE_FORWARD_ONLY and db2 does not support it.
-				*/
-				scrollableResults = query.scroll( ScrollMode.SCROLL_INSENSITIVE );
-			}
-			else {
-				scrollableResults = query.scroll( ScrollMode.FORWARD_ONLY );
-			}
-
+			scrollableResults = query.scroll( ScrollMode.FORWARD_ONLY );
 			while ( scrollableResults.next() ) {
 				final Employee employee = (Employee) scrollableResults.get();
 				assertThat( Hibernate.isPropertyInitialized( employee, "otherEntities" ), is( true ) );
@@ -141,18 +128,7 @@ public class QueryScrollingWithInheritanceProxyEagerManyToOneTest extends BaseNo
 					"select distinct e from Employee e left join fetch e.otherEntities order by e.dept",
 					Employee.class
 			);
-			if ( getDialect() instanceof DB2Dialect || getDialect() instanceof DerbyDialect ) {
-				/*
-					FetchingScrollableResultsImp#next() in order to check if the ResultSet is empty calls ResultSet#isBeforeFirst()
-					but the support for ResultSet#isBeforeFirst() is optional for ResultSets with a result
-					set type of TYPE_FORWARD_ONLY and db2 does not support it.
-				*/
-				scrollableResults = query.scroll( ScrollMode.SCROLL_INSENSITIVE );
-			}
-			else {
-				scrollableResults = query.scroll( ScrollMode.FORWARD_ONLY );
-			}
-
+			scrollableResults = query.scroll( ScrollMode.FORWARD_ONLY );
 			while ( scrollableResults.next() ) {
 				final Employee employee = (Employee) scrollableResults.get();
 				assertThat( Hibernate.isPropertyInitialized( employee, "otherEntities" ), is( true ) );

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/lazy/proxy/QueryScrollingWithInheritanceProxyTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/lazy/proxy/QueryScrollingWithInheritanceProxyTest.java
@@ -17,8 +17,6 @@ import org.hibernate.Session;
 import org.hibernate.StatelessSession;
 import org.hibernate.boot.MetadataSources;
 import org.hibernate.boot.SessionFactoryBuilder;
-import org.hibernate.dialect.DB2Dialect;
-import org.hibernate.dialect.DerbyDialect;
 import org.hibernate.query.Query;
 import org.hibernate.stat.spi.StatisticsImplementor;
 
@@ -77,18 +75,7 @@ public class QueryScrollingWithInheritanceProxyTest extends BaseNonConfigCoreFun
 					"select distinct e from Employee e left join fetch e.otherEntities order by e.dept",
 					Employee.class
 			);
-			if ( getDialect() instanceof DB2Dialect || getDialect() instanceof DerbyDialect ) {
-				/*
-					FetchingScrollableResultsImp#next() in order to check if the ResultSet is empty calls ResultSet#isBeforeFirst()
-					but the support for ResultSet#isBeforeFirst() is optional for ResultSets with a result
-					set type of TYPE_FORWARD_ONLY and db2 does not support it.
-			 	*/
-				scrollableResults = query.scroll( ScrollMode.SCROLL_INSENSITIVE );
-			}
-			else {
-				scrollableResults = query.scroll( ScrollMode.FORWARD_ONLY );
-			}
-
+			scrollableResults = query.scroll( ScrollMode.FORWARD_ONLY );
 			while ( scrollableResults.next() ) {
 				final Employee employee = (Employee) scrollableResults.get();
 				assertThat( Hibernate.isPropertyInitialized( employee, "otherEntities" ), is( true ) );
@@ -141,18 +128,7 @@ public class QueryScrollingWithInheritanceProxyTest extends BaseNonConfigCoreFun
 					"select distinct e from Employee e left join fetch e.otherEntities order by e.dept",
 					Employee.class
 			);
-			if ( getDialect() instanceof DB2Dialect || getDialect() instanceof DerbyDialect ) {
-				/*
-					FetchingScrollableResultsImp#next() in order to check if the ResultSet is empty calls ResultSet#isBeforeFirst()
-					but the support for ResultSet#isBeforeFirst() is optional for ResultSets with a result
-					set type of TYPE_FORWARD_ONLY and db2 does not support it.
-			 	*/
-				scrollableResults = query.scroll( ScrollMode.SCROLL_INSENSITIVE );
-			}
-			else {
-				scrollableResults = query.scroll( ScrollMode.FORWARD_ONLY );
-			}
-
+			scrollableResults = query.scroll( ScrollMode.FORWARD_ONLY );
 			while ( scrollableResults.next() ) {
 				final Employee employee = (Employee) scrollableResults.get();
 				assertThat( Hibernate.isPropertyInitialized( employee, "otherEntities" ), is( true ) );

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/hqlfetchscroll/QueryScrollingWithInheritanceTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/hqlfetchscroll/QueryScrollingWithInheritanceTest.java
@@ -13,8 +13,6 @@ import java.util.Set;
 import org.hibernate.Hibernate;
 import org.hibernate.ScrollMode;
 import org.hibernate.ScrollableResults;
-import org.hibernate.dialect.DB2Dialect;
-import org.hibernate.dialect.DerbyDialect;
 import org.hibernate.dialect.Dialect;
 import org.hibernate.query.Query;
 import org.hibernate.stat.spi.StatisticsImplementor;
@@ -64,18 +62,7 @@ public class QueryScrollingWithInheritanceTest {
 								Employee.class
 						);
 						final Dialect dialect = scope.getSessionFactory().getJdbcServices().getDialect();
-						if ( dialect instanceof DB2Dialect ||  dialect instanceof DerbyDialect ) {
-				/*
-					FetchingScrollableResultsImp#next() in order to check if the ResultSet is empty calls ResultSet#isBeforeFirst()
-					but the support for ResultSet#isBeforeFirst() is optional for ResultSets with a result
-					set type of TYPE_FORWARD_ONLY and db2 does not support it.
-			 	*/
-							scrollableResults = query.scroll( ScrollMode.SCROLL_INSENSITIVE );
-						}
-						else {
-							scrollableResults = query.scroll( ScrollMode.FORWARD_ONLY );
-						}
-
+						scrollableResults = query.scroll( ScrollMode.FORWARD_ONLY );
 						while ( scrollableResults.next() ) {
 							final Employee employee = (Employee) scrollableResults.get();
 							assertThat( Hibernate.isPropertyInitialized( employee, "otherEntities" ), is( true ) );
@@ -142,18 +129,7 @@ public class QueryScrollingWithInheritanceTest {
 								Employee.class
 						);
 						final Dialect dialect = scope.getSessionFactory().getJdbcServices().getDialect();
-						if ( dialect instanceof DB2Dialect || dialect instanceof DerbyDialect) {
-				/*
-					FetchingScrollableResultsImp#next() in order to check if the ResultSet is empty calls ResultSet#isBeforeFirst()
-					but the support for ResultSet#isBeforeFirst() is optional for ResultSets with a result
-					set type of TYPE_FORWARD_ONLY and db2 does not support it.
-			 	*/
-							scrollableResults = query.scroll( ScrollMode.SCROLL_INSENSITIVE );
-						}
-						else {
-							scrollableResults = query.scroll( ScrollMode.FORWARD_ONLY );
-						}
-
+						scrollableResults = query.scroll( ScrollMode.FORWARD_ONLY );
 						while ( scrollableResults.next() ) {
 							final Employee employee = (Employee) scrollableResults.get();
 							assertThat( Hibernate.isPropertyInitialized( employee, "otherEntities" ), is( true ) );

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/stream/NestedCollectionFetchStreamTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/stream/NestedCollectionFetchStreamTest.java
@@ -12,14 +12,10 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import org.hibernate.dialect.DB2Dialect;
-import org.hibernate.dialect.DerbyDialect;
-
 import org.hibernate.testing.orm.junit.DomainModel;
 import org.hibernate.testing.orm.junit.Jira;
 import org.hibernate.testing.orm.junit.SessionFactory;
 import org.hibernate.testing.orm.junit.SessionFactoryScope;
-import org.hibernate.testing.orm.junit.SkipForDialect;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -47,8 +43,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 } )
 @SessionFactory
 @Jira( "https://hibernate.atlassian.net/browse/HHH-17131" )
-@SkipForDialect( dialectClass = DB2Dialect.class, reason = "The support for ResultSet#isBeforeFirst() is optional for ResultSets with a result set type of TYPE_FORWARD_ONLY and DB2 does not support it" )
-@SkipForDialect( dialectClass = DerbyDialect.class, reason = "The support for ResultSet#isBeforeFirst() is optional for ResultSets with a result set type of TYPE_FORWARD_ONLY and Derby does not support it" )
 public class NestedCollectionFetchStreamTest {
 	@BeforeAll
 	public void setUp(SessionFactoryScope scope) {


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-17212