### PR TITLE
HHH-17220 Avoid runtime lookups of JdbcService from TableGenerator and TableStructure

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/id/enhanced/TableGenerator.java
+++ b/hibernate-core/src/main/java/org/hibernate/id/enhanced/TableGenerator.java
@@ -32,7 +32,6 @@ import org.hibernate.engine.config.spi.StandardConverters;
 import org.hibernate.engine.jdbc.Size;
 import org.hibernate.engine.jdbc.env.spi.JdbcEnvironment;
 import org.hibernate.engine.jdbc.internal.FormatStyle;
-import org.hibernate.engine.jdbc.spi.JdbcServices;
 import org.hibernate.engine.jdbc.spi.SqlStatementLogger;
 import org.hibernate.engine.spi.SessionEventListenerManager;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
@@ -555,8 +554,8 @@ public class TableGenerator implements PersistentIdentifierGenerator {
 
 	@Override
 	public Object generate(final SharedSessionContractImplementor session, final Object obj) {
-		final SqlStatementLogger statementLogger = session.getFactory().getServiceRegistry()
-				.getService( JdbcServices.class )
+		final SqlStatementLogger statementLogger = session.
+				getFactory().getJdbcServices()
 				.getSqlStatementLogger();
 		final SessionEventListenerManager statsCollector = session.getEventListenerManager();
 

--- a/hibernate-core/src/main/java/org/hibernate/id/enhanced/TableStructure.java
+++ b/hibernate-core/src/main/java/org/hibernate/id/enhanced/TableStructure.java
@@ -120,8 +120,7 @@ public class TableStructure implements DatabaseStructure {
 
 	@Override
 	public AccessCallback buildCallback(final SharedSessionContractImplementor session) {
-		final SqlStatementLogger statementLogger = session.getFactory().getServiceRegistry()
-				.getService( JdbcServices.class )
+		final SqlStatementLogger statementLogger = session.getFactory().getJdbcServices()
 				.getSqlStatementLogger();
 		if ( selectQuery == null || updateQuery == null ) {
 			throw new AssertionFailure( "SequenceStyleGenerator's TableStructure was not properly initialized" );

--- a/hibernate-core/src/main/java/org/hibernate/persister/entity/AbstractEntityPersister.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/entity/AbstractEntityPersister.java
@@ -850,7 +850,7 @@ public abstract class AbstractEntityPersister
 
 	private MultiIdEntityLoader<Object> buildMultiIdLoader(PersistentClass persistentClass) {
 		if ( persistentClass.getIdentifier() instanceof BasicValue
-				&& MultiKeyLoadHelper.supportsSqlArrayType( factory.getServiceRegistry().getService( JdbcServices.class ).getDialect() ) ) {
+				&& MultiKeyLoadHelper.supportsSqlArrayType( factory.getFastSessionServices().dialect ) ) {
 			return new MultiIdEntityLoaderArrayParam<>( this, factory );
 		}
 		return new MultiIdEntityLoaderStandard<>( this, persistentClass, factory );


### PR DESCRIPTION
backported version, targeting 6.2.10

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-17220
<!-- Hibernate GitHub Bot issue links end -->