### PR TITLE
Fix for HHh-17172 to retrieve matching session factory either by uuid *or name* during serialization/deserialization

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/internal/MultiIdentifierLoadAccessImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/MultiIdentifierLoadAccessImpl.java
@@ -6,6 +6,7 @@
  */
 package org.hibernate.internal;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.function.Supplier;
 
@@ -15,6 +16,7 @@ import org.hibernate.MultiIdentifierLoadAccess;
 import org.hibernate.graph.GraphSemantic;
 import org.hibernate.graph.RootGraph;
 import org.hibernate.graph.spi.RootGraphImplementor;
+import org.hibernate.loader.ast.internal.LoaderHelper;
 import org.hibernate.persister.entity.EntityPersister;
 import org.hibernate.loader.ast.spi.MultiIdLoadOptions;
 
@@ -165,6 +167,13 @@ class MultiIdentifierLoadAccessImpl<T> implements MultiIdentifierLoadAccess<T>, 
 	@Override
 	@SuppressWarnings( "unchecked" )
 	public <K> List<T> multiLoad(List<K> ids) {
-		return perform( () -> (List<T>) entityPersister.multiLoad( ids.toArray( new Object[ 0 ] ), session, this ) );
+		if ( ids.isEmpty() ) {
+			return Collections.emptyList();
+		}
+		return perform( () -> (List<T>) entityPersister.multiLoad(
+				ids.toArray( LoaderHelper.createTypedArray( ids.get( 0 ).getClass(), ids.size() ) ),
+				session,
+				this
+		) );
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/proxy/AbstractLazyInitializer.java
+++ b/hibernate-core/src/main/java/org/hibernate/proxy/AbstractLazyInitializer.java
@@ -41,6 +41,7 @@ public abstract class AbstractLazyInitializer implements LazyInitializer {
 	private Boolean readOnlyBeforeAttachedToSession;
 
 	private String sessionFactoryUuid;
+	private String sessionFactoryName;
 	private boolean allowLoadOutsideTransaction;
 
 	/**
@@ -277,6 +278,9 @@ public abstract class AbstractLazyInitializer implements LazyInitializer {
 				// such configuration, so to know if such operation isn't allowed or configured otherwise.
 				sessionFactoryUuid = session.getFactory().getUuid();
 			}
+			if ( sessionFactoryName == null ) {
+				sessionFactoryName = session.getFactory().getName();
+			}
 		}
 	}
 
@@ -442,6 +446,18 @@ public abstract class AbstractLazyInitializer implements LazyInitializer {
 	}
 
 	/**
+	 * Get the session factory name.
+	 *
+	 * This method should only be called during serialization,
+	 * and only makes sense after a call to {@link #prepareForPossibleLoadingOutsideTransaction()}.
+	 *
+	 * @return the session factory UUID.
+	 */
+	protected String getSessionFactoryName() {
+		return sessionFactoryName;
+	}
+
+	/**
 	 * Restore settings that are not passed to the constructor,
 	 * but are still preserved during serialization.
 	 *
@@ -458,7 +474,7 @@ public abstract class AbstractLazyInitializer implements LazyInitializer {
 	 */
 	/* package-private */
 	final void afterDeserialization(Boolean readOnlyBeforeAttachedToSession,
-			String sessionFactoryUuid, boolean allowLoadOutsideTransaction) {
+			String sessionFactoryUuid, String sessionFactoryName, boolean allowLoadOutsideTransaction) {
 		if ( isReadOnlySettingAvailable() ) {
 			throw new IllegalStateException(
 					"Cannot call afterDeserialization when isReadOnlySettingAvailable == true [" + entityName + "#" + id + "]"
@@ -467,6 +483,7 @@ public abstract class AbstractLazyInitializer implements LazyInitializer {
 		this.readOnlyBeforeAttachedToSession = readOnlyBeforeAttachedToSession;
 
 		this.sessionFactoryUuid = sessionFactoryUuid;
+		this.sessionFactoryName = sessionFactoryName;
 		this.allowLoadOutsideTransaction = allowLoadOutsideTransaction;
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/proxy/AbstractSerializableProxy.java
+++ b/hibernate-core/src/main/java/org/hibernate/proxy/AbstractSerializableProxy.java
@@ -18,6 +18,7 @@ public abstract class AbstractSerializableProxy implements Serializable {
 	private final Object id;
 	private final Boolean readOnly;
 	protected final String sessionFactoryUuid;
+	protected final String sessionFactoryName;
 	private final boolean allowLoadOutsideTransaction;
 
 	protected AbstractSerializableProxy(
@@ -25,11 +26,13 @@ public abstract class AbstractSerializableProxy implements Serializable {
 			Object id,
 			Boolean readOnly,
 			String sessionFactoryUuid,
+			String sessionFactoryName,
 			boolean allowLoadOutsideTransaction) {
 		this.entityName = entityName;
 		this.id = id;
 		this.readOnly = readOnly;
 		this.sessionFactoryUuid = sessionFactoryUuid;
+		this.sessionFactoryName = sessionFactoryName;
 		this.allowLoadOutsideTransaction = allowLoadOutsideTransaction;
 	}
 
@@ -50,6 +53,6 @@ public abstract class AbstractSerializableProxy implements Serializable {
 	 * @param li the {@link AbstractLazyInitializer} to initialize.
 	 */
 	protected void afterDeserialization(AbstractLazyInitializer li) {
-		li.afterDeserialization( readOnly, sessionFactoryUuid, allowLoadOutsideTransaction );
+		li.afterDeserialization( readOnly, sessionFactoryUuid, sessionFactoryName, allowLoadOutsideTransaction );
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/proxy/map/MapLazyInitializer.java
+++ b/hibernate-core/src/main/java/org/hibernate/proxy/map/MapLazyInitializer.java
@@ -53,4 +53,9 @@ public class MapLazyInitializer extends AbstractLazyInitializer implements Seria
 	protected String getSessionFactoryUuid() {
 		return super.getSessionFactoryUuid();
 	}
+
+	@Override
+	protected String getSessionFactoryName() {
+		return super.getSessionFactoryName();
+	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/proxy/map/MapProxy.java
+++ b/hibernate-core/src/main/java/org/hibernate/proxy/map/MapProxy.java
@@ -120,6 +120,7 @@ public class MapProxy implements HibernateProxy, Map, Serializable {
 				li.getInternalIdentifier(),
 				( li.isReadOnlySettingAvailable() ? Boolean.valueOf( li.isReadOnly() ) : li.isReadOnlyBeforeAttachedToSession() ),
 				li.getSessionFactoryUuid(),
+				li.getSessionFactoryName(),
 				li.isAllowLoadOutsideTransaction()
 		);
 	}

--- a/hibernate-core/src/main/java/org/hibernate/proxy/map/SerializableMapProxy.java
+++ b/hibernate-core/src/main/java/org/hibernate/proxy/map/SerializableMapProxy.java
@@ -15,8 +15,9 @@ public final class SerializableMapProxy extends AbstractSerializableProxy {
 			Object id,
 			Boolean readOnly,
 			String sessionFactoryUuid,
+			String sessionFactoryName,
 			boolean allowLoadOutsideTransaction) {
-		super( entityName, id, readOnly, sessionFactoryUuid, allowLoadOutsideTransaction );
+		super( entityName, id, readOnly, sessionFactoryUuid, sessionFactoryName, allowLoadOutsideTransaction );
 	}
 
 	private Object readResolve() {

--- a/hibernate-core/src/main/java/org/hibernate/proxy/pojo/bytebuddy/ByteBuddyInterceptor.java
+++ b/hibernate-core/src/main/java/org/hibernate/proxy/pojo/bytebuddy/ByteBuddyInterceptor.java
@@ -87,6 +87,7 @@ public class ByteBuddyInterceptor extends BasicLazyInitializer implements ProxyC
 				getInternalIdentifier(),
 				( isReadOnlySettingAvailable() ? Boolean.valueOf( isReadOnly() ) : isReadOnlyBeforeAttachedToSession() ),
 				getSessionFactoryUuid(),
+				getSessionFactoryName(),
 				isAllowLoadOutsideTransaction(),
 				getIdentifierMethod,
 				setIdentifierMethod,

--- a/hibernate-core/src/main/java/org/hibernate/proxy/pojo/bytebuddy/SerializableProxy.java
+++ b/hibernate-core/src/main/java/org/hibernate/proxy/pojo/bytebuddy/SerializableProxy.java
@@ -37,11 +37,12 @@ public final class SerializableProxy extends AbstractSerializableProxy {
 			Object id,
 			Boolean readOnly,
 			String sessionFactoryUuid,
+			String sessionFactoryName,
 			boolean allowLoadOutsideTransaction,
 			Method getIdentifierMethod,
 			Method setIdentifierMethod,
 			CompositeType componentIdType) {
-		super( entityName, id, readOnly, sessionFactoryUuid, allowLoadOutsideTransaction );
+		super( entityName, id, readOnly, sessionFactoryUuid, sessionFactoryName, allowLoadOutsideTransaction );
 		this.persistentClass = persistentClass;
 		this.interfaces = interfaces;
 		if ( getIdentifierMethod != null ) {
@@ -110,16 +111,16 @@ public final class SerializableProxy extends AbstractSerializableProxy {
 	}
 
 	private Object readResolve() {
-		final SessionFactoryImplementor sessionFactory = retrieveMatchingSessionFactory( this.sessionFactoryUuid );
+		final SessionFactoryImplementor sessionFactory = retrieveMatchingSessionFactory( this.sessionFactoryUuid, this.sessionFactoryName );
 		BytecodeProviderImpl byteBuddyBytecodeProvider = retrieveByteBuddyBytecodeProvider( sessionFactory );
 		HibernateProxy proxy = byteBuddyBytecodeProvider.getByteBuddyProxyHelper().deserializeProxy( this );
 		afterDeserialization( (ByteBuddyInterceptor) proxy.getHibernateLazyInitializer() );
 		return proxy;
 	}
 
-	private static SessionFactoryImplementor retrieveMatchingSessionFactory(final String sessionFactoryUuid) {
+	private static SessionFactoryImplementor retrieveMatchingSessionFactory(final String sessionFactoryUuid, final String sessionFactoryName) {
 		Objects.requireNonNull( sessionFactoryUuid );
-		final SessionFactoryImplementor sessionFactory = SessionFactoryRegistry.INSTANCE.getSessionFactory( sessionFactoryUuid );
+		final SessionFactoryImplementor sessionFactory = SessionFactoryRegistry.INSTANCE.findSessionFactory( sessionFactoryUuid, sessionFactoryName );
 		if ( sessionFactory != null ) {
 			return sessionFactory;
 		}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/proxy/MultipleSessionFactoriesProxyTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/proxy/MultipleSessionFactoriesProxyTest.java
@@ -1,0 +1,91 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.orm.test.proxy;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.math.BigDecimal;
+import org.hibernate.Hibernate;
+import org.hibernate.Session;
+import org.hibernate.Transaction;
+import org.hibernate.cfg.Configuration;
+import org.hibernate.cfg.Environment;
+import org.hibernate.internal.util.SerializationHelper;
+import org.hibernate.testing.TestForIssue;
+import org.hibernate.testing.junit4.BaseCoreFunctionalTestCase;
+import org.junit.Test;
+
+/**
+ * @author Gavin King
+ */
+public class MultipleSessionFactoriesProxyTest extends BaseCoreFunctionalTestCase {
+
+	@Override
+	public String[] getMappings() {
+		return new String[] { "proxy/DataPoint.hbm.xml" };
+	}
+
+	@Override
+	protected String getBaseForMappings() {
+		return "org/hibernate/orm/test/";
+	}
+
+	@Override
+	public void configure(Configuration cfg) {
+		super.configure( cfg );
+		cfg.setProperty( Environment.STATEMENT_BATCH_SIZE, "0" ); // problem on HSQLDB (go figure)
+		cfg.setProperty( Environment.SESSION_FACTORY_NAME, "sf-name" ); // explicitly define the session factory name
+		cfg.setProperty( Environment.SESSION_FACTORY_NAME_IS_JNDI, "false" ); // do not bind it to jndi
+	}
+
+	@Test @TestForIssue(jiraKey="HHH-17172")
+	public void testProxySerializationWithMultipleSessionFactories() {
+		Session s = openSession();
+		Transaction t = s.beginTransaction();
+		Container container = new Container( "container" );
+		container.setOwner( new Owner( "owner" ) );
+		container.setInfo( new Info( "blah blah blah" ) );
+		container.getDataPoints().add( new DataPoint( new BigDecimal( 1 ), new BigDecimal( 1 ), "first data point" ) );
+		container.getDataPoints().add( new DataPoint( new BigDecimal( 2 ), new BigDecimal( 2 ), "second data point" ) );
+		s.persist(container);
+		s.flush();
+		s.clear();
+
+		container = s.load( Container.class, container.getId());
+		assertFalse( Hibernate.isInitialized(container) );
+		container.getId();
+		assertFalse( Hibernate.isInitialized(container) );
+		container.getName();
+		assertTrue( Hibernate.isInitialized(container) );
+
+		t.commit();
+		s.close();
+
+		// Serialize the container.
+		byte[] bytes = SerializationHelper.serialize(container);
+
+		// Now deserialize, which works at this stage, because the session factory UUID in the
+		// serialized object is the same as the current session factory.
+		SerializationHelper.deserialize(bytes);
+
+		// Now rebuild the session factory (it will get a new unique UUID).
+		// As configured for this test an explicit session factory name is used ("sf-name"),
+		// so we would expect the deserialization to work after rebuilding the session factory.
+		// Rebuilding the session factory simulates multiple JVM instances with different session
+		// factories (different UUID's, but same name!) trying to deserialize objects from a
+		// centralized cache (e.g. Hazelcast).
+		rebuildSessionFactory();
+
+		// But this fails with:
+		// java.lang.IllegalStateException: Could not identify any active SessionFactory having UUID 6a97f04e-1aeb-4790-9de6-19ee1e069bab
+		// As it cannot retrieve a matching session factory by the UUID.
+		// However, it should internally use the session factory name and not the UUID.
+		SerializationHelper.deserialize(bytes);
+
+	}
+}


### PR DESCRIPTION
<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-17172
<!-- Hibernate GitHub Bot issue links end -->