### PR TITLE
Update AbstractHANADialect.java

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/dialect/AbstractHANADialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/AbstractHANADialect.java
@@ -913,7 +913,7 @@ public abstract class AbstractHANADialect extends Dialect {
 
 	@Override
 	public String getColumnComment(String comment) {
-		return "comment '" + comment + "'";
+		return " comment '" + comment + "'";
 	}
 
 	@Override


### PR DESCRIPTION
getColumnComment must have a space as first character. Otherwise the column definition is wrong. Without space, we get something like "a_column varchar(30) not nullcomment" instead of "a_column varchar(30) not null comment". And hence, each create table statement fails when using comments.