### PR TITLE
HHH-17245 Better conform to SQLite/Xerial driver limitations.

### DIFF
--- a/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/SQLiteDialect.java
+++ b/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/SQLiteDialect.java
@@ -13,6 +13,7 @@ import java.util.Date;
 import java.util.TimeZone;
 
 import org.hibernate.ScrollMode;
+import org.hibernate.boot.Metadata;
 import org.hibernate.boot.model.FunctionContributions;
 import org.hibernate.boot.model.TypeContributions;
 import org.hibernate.boot.model.relational.SqlStringGenerationContext;
@@ -37,6 +38,7 @@ import org.hibernate.exception.spi.TemplatedViolatedConstraintNameExtractor;
 import org.hibernate.exception.spi.ViolatedConstraintNameExtractor;
 import org.hibernate.internal.util.JdbcExceptionHelper;
 import org.hibernate.mapping.Column;
+import org.hibernate.mapping.UniqueKey;
 import org.hibernate.query.SemanticException;
 import org.hibernate.query.sqm.IntervalType;
 import org.hibernate.dialect.NullOrdering;
@@ -149,6 +151,19 @@ public class SQLiteDialect extends Dialect {
 		public String getColumnDefinitionUniquenessFragment(Column column, SqlStringGenerationContext context) {
 			return " unique";
 		}
+
+		/**
+		 * Alter table support in SQLite is very limited and does
+		 * not include adding a unique constraint (as of 9/2023).
+		 *
+		 * @return always empty String
+		 * @see <a href="https://www.sqlite.org/omitted.html">SQLite SQL omissions</a>
+		 */
+		@Override
+		public String getAlterTableToAddUniqueKeyCommand(UniqueKey uniqueKey, Metadata metadata, SqlStringGenerationContext context) {
+			return "";
+		}
+
 	}
 
 	@Override
@@ -400,6 +415,16 @@ public class SQLiteDialect extends Dialect {
 	@Override
 	public NullOrdering getNullOrdering() {
 		return NullOrdering.SMALLEST;
+	}
+
+	/**
+	 * Generated keys are not supported by the (standard) Xerial driver (9/2022).
+	 *
+	 * @return false
+	 */
+	@Override
+	public boolean getDefaultUseGetGeneratedKeys() {
+		return false;
 	}
 
 	@Override

--- a/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/SQLiteDialect.java
+++ b/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/SQLiteDialect.java
@@ -92,7 +92,6 @@ import static org.hibernate.type.descriptor.DateTimeUtils.appendAsTimestampWithM
  * An SQL dialect for SQLite.
  *
  * @author Christian Beikov
- * @author Vlad Mihalcea
  */
 public class SQLiteDialect extends Dialect {
 


### PR DESCRIPTION
- Added `getAlterTableToAddUniqueKeyCommand()`, which always returns `""`,  because SQLite does not support unique constraints in `ALTER TABLE`  statements (see [here](https://www.sqlite.org/omitted.html)). 
- Added `getDefaultUseGetGeneratedKey()`, which always returns `false`, as the Xerial driver apparently does not support GET_GENERATED_KEYS.

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-17245
<!-- Hibernate GitHub Bot issue links end -->