### PR TITLE
HHH-16997 Fix treated path `getResolvedModel()` logic

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/internal/AbstractPluralAttribute.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/internal/AbstractPluralAttribute.java
@@ -170,9 +170,9 @@ public abstract class AbstractPluralAttribute<D, C, E>
 					"`lhs` cannot be null for a sub-navigable reference - " + getName()
 			);
 		}
-		final SqmPathSource<?> parentPathSource = parent.getResolvedModel();
+		final SqmPathSource<?> parentPathSource = parent.getReferencedPathSource();
 		NavigablePath navigablePath = parent.getNavigablePath();
-		if ( parentPathSource instanceof PluralPersistentAttribute<?, ?, ?> ) {
+		if ( parent.getResolvedModel() instanceof PluralPersistentAttribute<?, ?, ?> ) {
 			navigablePath = navigablePath.append( CollectionPart.Nature.ELEMENT.getName() );
 		}
 		final DomainType<?> parentType = parentPathSource.getSqmPathType();

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/internal/SingularAttributeImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/internal/SingularAttributeImpl.java
@@ -173,9 +173,9 @@ public class SingularAttributeImpl<D,J>
 					"LHS cannot be null for a sub-navigable reference - " + getName()
 			);
 		}
-		final SqmPathSource<?> parentPathSource = parent.getResolvedModel();
+		final SqmPathSource<?> parentPathSource = parent.getReferencedPathSource();
 		NavigablePath navigablePath = parent.getNavigablePath();
-		if ( parentPathSource instanceof PluralPersistentAttribute<?, ?, ?> ) {
+		if ( parent.getResolvedModel() instanceof PluralPersistentAttribute<?, ?, ?> ) {
 			navigablePath = navigablePath.append( CollectionPart.Nature.ELEMENT.getName() );
 		}
 		final DomainType<?> parentType = parentPathSource.getSqmPathType();
@@ -224,7 +224,7 @@ public class SingularAttributeImpl<D,J>
 				);
 			}
 			NavigablePath navigablePath = parent.getNavigablePath();
-			if ( parent.getResolvedModel() instanceof PluralPersistentAttribute<?, ?, ?> ) {
+			if ( parent.getReferencedPathSource() instanceof PluralPersistentAttribute<?, ?, ?> ) {
 				navigablePath = navigablePath.append( CollectionPart.Nature.ELEMENT.getName() );
 			}
 			if ( getDeclaringType() instanceof IdentifiableDomainType<?> ) {

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/domain/SqmTreatedBagJoin.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/domain/SqmTreatedBagJoin.java
@@ -104,11 +104,6 @@ public class SqmTreatedBagJoin<O,T, S extends T> extends SqmBagJoin<O,S> impleme
 	}
 
 	@Override
-	public SqmPathSource<?> getResolvedModel() {
-		return treatTarget;
-	}
-
-	@Override
 	public SqmAttributeJoin<O, S> makeCopy(SqmCreationProcessingState creationProcessingState) {
 		return new SqmTreatedBagJoin<>( wrappedPath, treatTarget, getAlias() );
 	}

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/domain/SqmTreatedCrossJoin.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/domain/SqmTreatedCrossJoin.java
@@ -95,11 +95,6 @@ public class SqmTreatedCrossJoin<T, S extends T> extends SqmCrossJoin<S> impleme
 	}
 
 	@Override
-	public SqmPathSource<?> getResolvedModel() {
-		return treatTarget;
-	}
-
-	@Override
 	public void appendHqlString(StringBuilder sb) {
 		sb.append( "treat(" );
 		wrappedPath.appendHqlString( sb );

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/domain/SqmTreatedEntityJoin.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/domain/SqmTreatedEntityJoin.java
@@ -78,11 +78,6 @@ public class SqmTreatedEntityJoin<T, S extends T> extends SqmEntityJoin<S> imple
 	}
 
 	@Override
-	public EntityDomainType<S> getModel() {
-		return getTreatTarget();
-	}
-
-	@Override
 	public SqmPath<T> getWrappedPath() {
 		return wrappedPath;
 	}

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/domain/SqmTreatedListJoin.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/domain/SqmTreatedListJoin.java
@@ -103,11 +103,6 @@ public class SqmTreatedListJoin<O,T, S extends T> extends SqmListJoin<O,S> imple
 	}
 
 	@Override
-	public SqmPathSource<?> getResolvedModel() {
-		return treatTarget;
-	}
-
-	@Override
 	public SqmPath<?> resolveIndexedAccess(
 			SqmExpression<?> selector,
 			boolean isTerminal,

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/domain/SqmTreatedMapJoin.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/domain/SqmTreatedMapJoin.java
@@ -99,11 +99,6 @@ public class SqmTreatedMapJoin<O, K, V, S extends V> extends SqmMapJoin<O, K, S>
 	}
 
 	@Override
-	public SqmPathSource<?> getResolvedModel() {
-		return treatTarget;
-	}
-
-	@Override
 	public SqmMapJoin<O, K, S> makeCopy(SqmCreationProcessingState creationProcessingState) {
 		return new SqmTreatedMapJoin<>(
 				wrappedPath,

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/domain/SqmTreatedPluralPartJoin.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/domain/SqmTreatedPluralPartJoin.java
@@ -97,11 +97,6 @@ public class SqmTreatedPluralPartJoin<O,T, S extends T> extends SqmPluralPartJoi
 	}
 
 	@Override
-	public SqmPathSource<?> getResolvedModel() {
-		return treatTarget;
-	}
-
-	@Override
 	public void appendHqlString(StringBuilder sb) {
 		sb.append( "treat(" );
 		wrappedPath.appendHqlString( sb );

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/domain/SqmTreatedSetJoin.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/domain/SqmTreatedSetJoin.java
@@ -101,11 +101,6 @@ public class SqmTreatedSetJoin<O,T, S extends T> extends SqmSetJoin<O,S> impleme
 	}
 
 	@Override
-	public SqmPathSource<?> getResolvedModel() {
-		return treatTarget;
-	}
-
-	@Override
 	public SqmAttributeJoin<O, S> makeCopy(SqmCreationProcessingState creationProcessingState) {
 		return new SqmTreatedSetJoin<>( wrappedPath, treatTarget, getAlias() );
 	}

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/domain/SqmTreatedSimplePath.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/domain/SqmTreatedSimplePath.java
@@ -115,11 +115,6 @@ public class SqmTreatedSimplePath<T, S extends T>
 	}
 
 	@Override
-	public SqmPathSource<?> getResolvedModel() {
-		return treatTarget;
-	}
-
-	@Override
 	public <S1 extends S> SqmTreatedSimplePath<S,S1> treatAs(Class<S1> treatJavaType) throws PathException {
 		return super.treatAs( treatJavaType );
 	}

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/domain/SqmTreatedSingularJoin.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/domain/SqmTreatedSingularJoin.java
@@ -101,11 +101,6 @@ public class SqmTreatedSingularJoin<O,T, S extends T> extends SqmSingularJoin<O,
 	}
 
 	@Override
-	public SqmPathSource<?> getResolvedModel() {
-		return treatTarget;
-	}
-
-	@Override
 	public SqmAttributeJoin<O, S> makeCopy(SqmCreationProcessingState creationProcessingState) {
 		return new SqmTreatedSingularJoin<>( wrappedPath, treatTarget, getAlias() );
 	}


### PR DESCRIPTION
While working on #7373 I noticed the navigable paths for basic valued simple paths that are children of treated joins were missing the `CollectionPart` name. This PR partially reverts the changes in #7110, removing the `getResolvedModel()` overrides for treated join paths, and fixes a couple of checks with the correct logic.

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-16997
<!-- Hibernate GitHub Bot issue links end -->