### PR TITLE
HHH-17257 ElementCollection is missing elements after update if embeddable type has primitive columns marked as nullable

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/EmbeddableMappingTypeImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/EmbeddableMappingTypeImpl.java
@@ -385,7 +385,7 @@ public class EmbeddableMappingTypeImpl extends AbstractEmbeddableMapping impleme
 					length = column.getLength();
 					precision = column.getPrecision();
 					scale = column.getScale();
-					nullable = column.isNullable();
+					nullable = bootPropertyDescriptor.isOptional() && column.isNullable() ;
 					selectablePath = basicValue.createSelectablePath( column.getQuotedName( dialect ) );
 				}
 				else {
@@ -393,7 +393,7 @@ public class EmbeddableMappingTypeImpl extends AbstractEmbeddableMapping impleme
 					length = null;
 					precision = null;
 					scale = null;
-					nullable = true;
+					nullable = bootPropertyDescriptor.isOptional();
 					selectablePath = basicValue.createSelectablePath( bootPropertyDescriptor.getName() );
 				}
 				attributeMapping = MappingModelCreationHelper.buildBasicAttributeMapping(

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/embeddable/ElementCollectionAllNonOptionalPropertyUpdateTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/embeddable/ElementCollectionAllNonOptionalPropertyUpdateTest.java
@@ -74,6 +74,8 @@ public class ElementCollectionAllNonOptionalPropertyUpdateTest {
 		@Id
 		private Long id;
 
+		private String name;
+
 		@ElementCollection(fetch = FetchType.EAGER)
 		private Set<MyEmbeddable> elementCollection;
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/embeddable/ElementCollectionAllPrimitivePropertyUpdateTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/embeddable/ElementCollectionAllPrimitivePropertyUpdateTest.java
@@ -21,12 +21,12 @@ import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 
 @DomainModel(
 		annotatedClasses = {
-				ElementCollectionOptionalPropertyUpdateTest.MyEntity.class
+				ElementCollectionAllPrimitivePropertyUpdateTest.MyEntity.class
 		}
 )
 @SessionFactory
 @JiraKey( "HHH-17257" )
-public class ElementCollectionOptionalPropertyUpdateTest {
+public class ElementCollectionAllPrimitivePropertyUpdateTest {
 
 	private static final Long ENTITY_ID = 1l;
 
@@ -35,8 +35,8 @@ public class ElementCollectionOptionalPropertyUpdateTest {
 		scope.inTransaction(
 				session -> {
 					MyEntity myEntity = new MyEntity( ENTITY_ID, Set.of(
-							new MyEmbeddable( "1", false ),
-							new MyEmbeddable( "2", false )
+							new MyEmbeddable( 1, false ),
+							new MyEmbeddable( 2, false )
 					) );
 					session.persist( myEntity );
 
@@ -53,7 +53,7 @@ public class ElementCollectionOptionalPropertyUpdateTest {
 					Set<MyEmbeddable> elementCollection = myEntity.getElementCollection();
 					assertThat( elementCollection ).hasSize( 2 );
 
-					elementCollection.stream().filter( it -> it.getStringField().equals( "1" ) ).forEach(
+					elementCollection.stream().filter( it -> it.getIntField() == 1 ).forEach(
 							it -> it.setBooleanField( true ) );
 				}
 		);
@@ -103,32 +103,34 @@ public class ElementCollectionOptionalPropertyUpdateTest {
 	@Embeddable
 	public static class MyEmbeddable {
 		@Column
-		private String stringField;
+		// the field is considered non-optional because of its primitive type
+		private int intField;
 
 		@Column
-		private Boolean booleanField;
+		// the field is considered non-optional because of its primitive type
+		private boolean booleanField;
 
 		public MyEmbeddable() {
 		}
 
-		public MyEmbeddable(String stringField, boolean booleanField) {
-			this.stringField = stringField;
+		public MyEmbeddable(int intField, boolean booleanField) {
+			this.intField = intField;
 			this.booleanField = booleanField;
 		}
 
-		public String getStringField() {
-			return stringField;
+		public int getIntField() {
+			return intField;
 		}
 
-		public void setStringField(String stringField) {
-			this.stringField = stringField;
+		public void setIntField(int intField) {
+			this.intField = intField;
 		}
 
-		public Boolean isBooleanField() {
+		public boolean isBooleanField() {
 			return booleanField;
 		}
 
-		public void setBooleanField(Boolean booleanField) {
+		public void setBooleanField(boolean booleanField) {
 			this.booleanField = booleanField;
 		}
 
@@ -141,12 +143,12 @@ public class ElementCollectionOptionalPropertyUpdateTest {
 				return false;
 			}
 			MyEmbeddable that = (MyEmbeddable) o;
-			return booleanField == that.booleanField && Objects.equals( stringField, that.stringField );
+			return booleanField == that.booleanField && Objects.equals( intField, that.intField );
 		}
 
 		@Override
 		public int hashCode() {
-			return Objects.hash( stringField, booleanField );
+			return Objects.hash( intField, booleanField );
 		}
 	}
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/embeddable/ElementCollectionNonOptionalPropertyUpdateTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/embeddable/ElementCollectionNonOptionalPropertyUpdateTest.java
@@ -74,6 +74,8 @@ public class ElementCollectionNonOptionalPropertyUpdateTest {
 		@Id
 		private Long id;
 
+		private String name;
+
 		@ElementCollection(fetch = FetchType.EAGER)
 		private Set<MyEmbeddable> elementCollection;
 


### PR DESCRIPTION
 https://hibernate.atlassian.net/browse/HHH-17257 

this should resolve a case the user reported that  https://github.com/hibernate/hibernate-orm/pull/7372 haven't fixed