### PR TITLE
HHH-17286 Upgrade integration tests to use Oracle JDBC driver version 23.3.0.23.09

### DIFF
--- a/databases/oracle/matrix.gradle
+++ b/databases/oracle/matrix.gradle
@@ -4,4 +4,5 @@
  * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
  * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
  */
+// Do not forget to update settings.gradle as well
 jdbcDependency 'com.oracle.database.jdbc:ojdbc11:23.3.0.23.09'

--- a/databases/oracle/matrix.gradle
+++ b/databases/oracle/matrix.gradle
@@ -4,4 +4,4 @@
  * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
  * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
  */
-jdbcDependency 'com.oracle.database.jdbc:ojdbc11:23.2.0.0'
+jdbcDependency 'com.oracle.database.jdbc:ojdbc11:23.3.0.23.09'

--- a/settings.gradle
+++ b/settings.gradle
@@ -218,7 +218,7 @@ dependencyResolutionManagement {
             def mariadbVersion = version "mariadb", "2.7.9"
             def mssqlVersion = version "mssql", "12.2.0.jre11"
             def mysqlVersion = version "mysql", "8.0.33"
-            def oracleVersion = version "oracle", "23.2.0.0"
+            def oracleVersion = version "oracle", "23.3.0.23.09"
             def oracleLegacyVersion = version "oracleLegacy", "11.2.0.4"
             def pgsqlVersion = version "pgsql", "42.6.0"
             def sybaseVersion = version "sybase", "1.3.1"


### PR DESCRIPTION
This PR updates the Oracle JDBC driver to the latest version to date (released on the 2nd of October 2023 on Maven Central).

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-17286
<!-- Hibernate GitHub Bot issue links end -->