### PR TITLE
Improve testJoinedInheritanceNativeQuery to operate on an entity with actual inheritance

### DIFF
--- a/hibernate-core/src/test/java/org/hibernate/orm/test/hql/joinedSubclass/JoinedSubclassNativeQueryTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/hql/joinedSubclass/JoinedSubclassNativeQueryTest.java
@@ -27,7 +27,8 @@ import jakarta.persistence.InheritanceType;
  */
 @DomainModel(
 		annotatedClasses = {
-				JoinedSubclassNativeQueryTest.Person.class
+				JoinedSubclassNativeQueryTest.Person.class,
+				JoinedSubclassNativeQueryTest.Employee.class
 		}
 )
 @SessionFactory
@@ -56,7 +57,7 @@ public class JoinedSubclassNativeQueryTest {
 	public void testJoinedInheritanceNativeQuery(SessionFactoryScope scope) {
 		scope.inTransaction(
 				session -> {
-					Person p = session.createNativeQuery( "select p.*, 0 as clazz_ from Person p", Person.class ).getSingleResult();
+					Person p = session.createNativeQuery( "select p.*, null as companyName, 0 as clazz_  from Person p", Person.class ).getSingleResult();
 					Assertions.assertNotNull( p );
 					Assertions.assertEquals( p.getFirstName(), "Jan" );
 				}
@@ -81,4 +82,19 @@ public class JoinedSubclassNativeQueryTest {
 			this.firstName = firstName;
 		}
 	}
+
+	@Entity(name = "Employee")
+	public static class Employee extends Person {
+		@Basic(optional = false)
+		private String companyName;
+
+		public String getCompanyName() {
+			return companyName;
+		}
+
+		public void setCompanyName(String companyName) {
+			this.companyName = companyName;
+		}
+	}
+
 }


### PR DESCRIPTION
Hi,
not sure how to do PRs against this repository, but at least here's the code, feel free to use it any way you like

Note: I tested with ./gradlew hibernate-core:test --tests 'JoinedSubclassNativeQueryTest'
without the "null as companyName", I get the org.hibernate.exception.SQLGrammarException: Unable to find column position by name: companyName [Column "companyName" not found [42122-220]] [n/a]
with it the test passes

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-17303
<!-- Hibernate GitHub Bot issue links end -->