### PR TITLE
HHH-17315 Reduce Oracle database user privileges to avoid cross schemas clashes

### DIFF
--- a/docker_db.sh
+++ b/docker_db.sh
@@ -728,7 +728,7 @@ oracle_atps() {
   export SERVICE=$(echo $INFO | jq -r '.database' | jq -r '.service')
   export PASSWORD=$(echo $INFO | jq -r '.database' | jq -r '.password')
 
-  curl -s -X POST "https://${HOST}.oraclecloudapps.com/ords/admin/_/sql" -H 'content-type: application/sql' -H 'accept: application/json' -basic -u admin:${PASSWORD} --data-ascii "create user hibernate_orm_test_$RUNID identified by \"Oracle_19_Password\" DEFAULT TABLESPACE DATA TEMPORARY TABLESPACE TEMP;alter user hibernate_orm_test_$RUNID quota unlimited on data;grant pdb_dba to hibernate_orm_test_$RUNID;BEGIN ords_admin.enable_schema(p_enabled => TRUE, p_schema => 'hibernate_orm_test_$RUNID', p_url_mapping_type => 'BASE_PATH', p_url_mapping_pattern => 'hibernate_orm_test_$RUNID', p_auto_rest_auth => TRUE); END;"
+  curl -s -X POST "https://${HOST}.oraclecloudapps.com/ords/admin/_/sql" -H 'content-type: application/sql' -H 'accept: application/json' -basic -u admin:${PASSWORD} --data-ascii "create user hibernate_orm_test_$RUNID identified by \"Oracle_19_Password\" DEFAULT TABLESPACE DATA TEMPORARY TABLESPACE TEMP;alter user hibernate_orm_test_$RUNID quota unlimited on data;grant CREATE SESSION, RESOURCE, CREATE VIEW, CREATE SYNONYM, CREATE ANY INDEX, EXECUTE ANY TYPE to hibernate_orm_test_$RUNID;"
 }
 
 oracle_db19c() {
@@ -741,7 +741,7 @@ oracle_db19c() {
 /home/opc/sqlcl/bin/sql -s system/$PASSWORD@$HOST:1521/$SERVICE <<EOF
     create user hibernate_orm_test_$RUNID identified by "Oracle_19_Password" DEFAULT TABLESPACE USERS TEMPORARY TABLESPACE TEMP;
     alter user hibernate_orm_test_$RUNID quota unlimited on users;
-    grant all privileges to hibernate_orm_test_$RUNID;
+    grant CREATE SESSION, RESOURCE, CREATE VIEW, CREATE SYNONYM, CREATE ANY INDEX, EXECUTE ANY TYPE to hibernate_orm_test_$RUNID;
 EOF
 
 }
@@ -756,7 +756,7 @@ oracle_db21c() {
 /home/opc/sqlcl/bin/sql -s system/$PASSWORD@$HOST:1521/$SERVICE <<EOF
     create user hibernate_orm_test_$RUNID identified by "Oracle_21_Password" DEFAULT TABLESPACE USERS TEMPORARY TABLESPACE TEMP;
     alter user hibernate_orm_test_$RUNID quota unlimited on users;
-    grant all privileges to hibernate_orm_test_$RUNID;
+    grant CREATE SESSION, RESOURCE, CREATE VIEW, CREATE SYNONYM, CREATE ANY INDEX, EXECUTE ANY TYPE to hibernate_orm_test_$RUNID;
 EOF
 }
 
@@ -770,7 +770,7 @@ oracle_db23c() {
 /home/opc/sqlcl/bin/sql -s system/$PASSWORD@$HOST:1521/$SERVICE <<EOF
     create user hibernate_orm_test_$RUNID identified by "Oracle_23_Password" DEFAULT TABLESPACE USERS TEMPORARY TABLESPACE TEMP;
     alter user hibernate_orm_test_$RUNID quota unlimited on users;
-    grant all privileges to hibernate_orm_test_$RUNID;
+    grant DB_DEVELOPER_ROLE to hibernate_orm_test_$RUNID;
 EOF
 }
 


### PR DESCRIPTION
Today Oracle database users for testing/CI have way too much privileges that may have impacts when querying Database Metadata (i.e. seeing tables that should not be seen).

Current set of privileges are enough:
- RESOURCE role
- CREATE VIEW
- CREATE SESSION
- CREATE SYNONYM
- CREATE ANY INDEX (for XMLType tables)
- EXECUTE ANY TYPE (to avoid a grant just after type creation)

For 23c, DB_DEVELOPER_ROLE would be perfect.

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-17315
<!-- Hibernate GitHub Bot issue links end -->