### PR TITLE
HHH-15754 IF [NOT] EXISTS DDL

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/dialect/OracleDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/OracleDialect.java
@@ -957,6 +957,11 @@ public class OracleDialect extends Dialect {
 	}
 
 	@Override
+	public boolean supportsIfExistsBeforeTypeName() {
+		return getVersion().isSameOrAfter( 23 );
+	}
+
+	@Override
 	public String getCascadeConstraintsString() {
 		return " cascade constraints";
 	}

--- a/hibernate-core/src/main/java/org/hibernate/dialect/OracleDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/OracleDialect.java
@@ -952,6 +952,11 @@ public class OracleDialect extends Dialect {
 	}
 
 	@Override
+	public boolean supportsIfExistsAfterAlterTable() {
+		return getVersion().isSameOrAfter( 23 );
+	}
+
+	@Override
 	public String getCascadeConstraintsString() {
 		return " cascade constraints";
 	}

--- a/hibernate-core/src/main/java/org/hibernate/dialect/OracleDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/OracleDialect.java
@@ -947,6 +947,11 @@ public class OracleDialect extends Dialect {
 	}
 
 	@Override
+	public boolean supportsIfExistsBeforeTableName() {
+		return getVersion().isSameOrAfter( 23 );
+	}
+
+	@Override
 	public String getCascadeConstraintsString() {
 		return " cascade constraints";
 	}


### PR DESCRIPTION
This will make Hibernate support the new Oracle database 23c feature:
- `DROP TABLE IF EXISTS <TABLE_NAME>`  ([documentation](https://docs.oracle.com/en/database/oracle/oracle-database/23/sqlrf/DROP-TABLE.html))
- `DROP VIEW IF EXISTS <VIEW_NAME>` ([documentation](https://docs.oracle.com/en/database/oracle/oracle-database/23/sqlrf/DROP-VIEW.html))
- `DROP TYPE IF EXISTS <TYPE_NAME>` ([documentation](https://docs.oracle.com/en/database/oracle/oracle-database/23/sqlrf/DROP-TYPE.html))
- `ALTER TABLE IF EXISTS <TABLE_NAME>` ([documentation](https://docs.oracle.com/en/database/oracle/oracle-database/23/sqlrf/ALTER-TABLE.html))

It should reduce the amount of logged stacktraces...

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-15754
<!-- Hibernate GitHub Bot issue links end -->