### PR TITLE
HHH-16881 - RevisionListener is not created when Hibernate CDI Extensions are enabled

### DIFF
--- a/hibernate-envers/src/main/java/org/hibernate/envers/internal/revisioninfo/DefaultRevisionInfoGenerator.java
+++ b/hibernate-envers/src/main/java/org/hibernate/envers/internal/revisioninfo/DefaultRevisionInfoGenerator.java
@@ -110,7 +110,7 @@ public class DefaultRevisionInfoGenerator implements RevisionInfoGenerator {
 			Class<? extends RevisionListener> listenerClass,
 			ServiceRegistry serviceRegistry) {
 		if ( !listenerClass.equals( RevisionListener.class ) ) {
-			if ( Helper.allowExtensionsInCdi( serviceRegistry ) ) {
+			if ( !Helper.allowExtensionsInCdi( serviceRegistry ) ) {
 				return new ProvidedInstanceManagedBeanImpl<>(
 						FallbackBeanInstanceProducer.INSTANCE.produceBeanInstance( listenerClass )
 				);


### PR DESCRIPTION
Please refer to the following bug: 
https://hibernate.atlassian.net/jira/software/c/projects/HHH/issues/HHH-16881

I think that this PR should be backported to 6.2 and 6.3 also.

I don't find the test regarding this behavior, so I haven't included new one, but you can test using the demo that I provide in the bug.
