### PR TITLE
Add Hibernate Search Update Dependency job execution to the build

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -151,6 +151,9 @@ stage('Build') {
 			}
 		})
 	}
+	executions.put('Hibernate Search Update Dependency', {
+		build job: '/hibernate-search-dependency-update/6.2', propagate: true, parameters: [string(name: 'UPDATE_JOB', value: 'orm6.2'), string(name: 'ORM_REPOSITORY', value: helper.scmSource.remoteUrl), string(name: 'ORM_PULL_REQUEST_ID', value: helper.scmSource.pullRequest.id)]
+	})
 	parallel(executions)
 }
 


### PR DESCRIPTION
Hey hey @yrodiere @beikov 😃 
To follow up on the conversation from Zulip, this is an attempt to add the Hibernate Search update dependency tests to the Hibernate ORM build. Is this the correct place/way to do that? 😄 (hence, opening as a draft 😉)