### PR TITLE
HHH-17372 - Avoid endless recursion

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/query/Query.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/Query.java
@@ -184,7 +184,7 @@ public interface Query<R> extends SelectionQuery<R>, MutationQuery, TypedQuery<R
 	 */
 	@Override
 	default Stream<R> stream() {
-		return getResultStream();
+		return list().stream();
 	}
 
 	/**

--- a/hibernate-core/src/main/java/org/hibernate/query/SelectionQuery.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/SelectionQuery.java
@@ -140,6 +140,10 @@ public interface SelectionQuery<R> extends CommonQueryContract {
 	 * stream so that resources are freed as soon as possible.
 	 *
 	 * @return The results as a {@link Stream}
+	 *
+	 * @implNote: The default implementation simply returns
+	 * <code>{@link #list()}.stream()</code>. Concrete implementations
+	 * may provide more efficient implementations.
 	 */
 	default Stream<R> getResultStream() {
 		return stream();
@@ -159,7 +163,7 @@ public interface SelectionQuery<R> extends CommonQueryContract {
 	 * @since 5.2
 	 */
 	default Stream<R> stream() {
-		return getResultStream();
+		return list().stream();
 	}
 
 	/**


### PR DESCRIPTION
in default methods in Selectionquery referring to each other.

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-17372
<!-- Hibernate GitHub Bot issue links end -->