### PR TITLE
Ignore JIRA checks for commits targeting only build-related files

### DIFF
--- a/.github/hibernate-github-bot.yml
+++ b/.github/hibernate-github-bot.yml
@@ -2,3 +2,38 @@
 jira:
   projectKey: "HHH"
   insertLinksInPullRequests: true
+  ignoreFiles:
+    # Git
+    - ".git*"
+    - ".mailmap"
+    # Gradle
+    - "gradlew*"
+    - "gradle/"
+    - "local-build-plugins/"
+    - "build.gradle"
+    # NOT settings.gradle: contains dependency versions, changing those requires a Jira issue
+    - "utilities.gradle"
+    # CI
+    - ".github/"
+    - ".release/"
+    - "ci/"
+    - "databases/"
+    - "*.sh"
+    - "Jenkinsfile"
+    - "*/Jenkinsfile"
+    - "*.Jenkinsfile"
+    # In-repo documentation
+    - "design/"
+    - "README.adoc"
+    - "MAINTAINERS.md"
+    - "CONTRIBUTING.md"
+    # Misc. build files
+    - "checkerstubs/"
+    - "drivers/"
+    - "edb/"
+    - "etc/"
+    - "javadoc/"
+    - "patched-libs/"
+    - "release/"
+    - "rules/"
+    - "shared/"


### PR DESCRIPTION
See https://github.com/hibernate/hibernate-github-bot/pull/196

This should avoid pesky Jira-related checks on at least some PRs that blatantly don't need these checks.