### PR TITLE
Change scope of AbstractEntityInitializer#resolveInstance

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/entity/AbstractEntityInitializer.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/entity/AbstractEntityInitializer.java
@@ -628,7 +628,10 @@ public abstract class AbstractEntityInitializer extends AbstractFetchParentAcces
 
 	}
 
-	private Object resolveInstance(
+	/**
+	 * Used by Hibernate Reactive
+	 */
+	protected Object resolveInstance(
 			Object entityIdentifier,
 			EntityHolder holder,
 			RowProcessingState rowProcessingState) {


### PR DESCRIPTION
For Hibernate Reactive, it extends the class and needs to be able to call the method.

Fix [HHH-17390](https://hibernate.atlassian.net/browse/HHH-17390) 

[HHH-17390]: https://hibernate.atlassian.net/browse/HHH-17390?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ