### PR TITLE
Add a dialect for YugabyteDB

### DIFF
--- a/ci/build.sh
+++ b/ci/build.sh
@@ -67,6 +67,8 @@ elif [ "$RDBMS" == "hana_cloud" ]; then
   goal="-Pdb=hana_cloud"
 elif [ "$RDBMS" == "cockroachdb" ]; then
   goal="-Pdb=cockroachdb"
+elif [ "$RDBMS" == "yugabytedb" ]; then
+  goal="-Pdb=yugabytedb"
 fi
 
 # Only run checkstyle in the H2 build,

--- a/ci/database-start.sh
+++ b/ci/database-start.sh
@@ -30,4 +30,6 @@ elif [ "$RDBMS" == 'cockroachdb' ]; then
   bash $DIR/../docker_db.sh cockroachdb
 elif [ "$RDBMS" == 'hana' ]; then
   bash $DIR/../docker_db.sh hana
+elif [ "$RDBMS" == 'yugabytedb' ]; then
+  bash $DIR/../docker_db.sh yugabytedb
 fi

--- a/docker_db.sh
+++ b/docker_db.sh
@@ -871,6 +871,24 @@ tidb_5_1() {
     fi
 }
 
+yugabytedb() {
+  $CONTAINER_CLI rm -f yugabyte || true
+  $CONTAINER_CLI run -d --name=yugabyte -p7000:7000 -p9000:9000 -p5433:5433 -p9042:9042 \
+    docker.io/yugabytedb/yugabyte:2.19.2.0-b121 bin/yugabyted start --daemon=false
+  # --advertise_address=127.0.0.1
+
+  OUTPUT=
+  while [[ $OUTPUT != *"Cluster started in an insecure mode"* ]]; do
+        echo "Waiting for YugabyteDB to start..."
+        # TOCO Should check for "YugabyteDB Started" instead?
+        sleep 5
+        # Note we need to redirect stderr to stdout to capture the logs
+        OUTPUT=$($CONTAINER_CLI logs yugabyte 2>&1)
+  done
+  echo "YugabyteDB successfully started"
+
+}
+
 if [ -z ${1} ]; then
     echo "No db name provided"
     echo "Provide one of:"
@@ -907,6 +925,7 @@ if [ -z ${1} ]; then
     echo -e "\tsybase"
     echo -e "\ttidb"
     echo -e "\ttidb_5_1"
+    echo -e "\tyugabytedb"
 else
     ${1}
 fi

--- a/gradle/databases.gradle
+++ b/gradle/databases.gradle
@@ -292,6 +292,16 @@ ext {
                         'jdbc.url'   : 'jdbc:firebirdsql://' + dbHost +'/hibernate_orm_test?charSet=utf-8;TRANSACTION_READ_COMMITTED=read_committed,rec_version,wait,lock_timeout=5',
                         'connection.init_sql' : ''
                 ],
+                yugabytedb : [
+                        'db.dialect' : 'org.hibernate.community.dialect.YugabyteDBDialect',
+                        // 'jdbc.driver': 'org.postgresql.Driver',
+                        'jdbc.driver': 'com.yugabyte.Driver',
+                        'jdbc.user'  : 'yugabyte',
+                        'jdbc.pass'  : 'yugabyte',
+                        // 'jdbc.url'   : 'jdbc:postgresql://' + dbHost + ':5433/hibernate_orm_test',
+                        'jdbc.url'   : 'jdbc:yugabytedb://' + dbHost + '/hibernate_orm_test',
+                        'connection.init_sql' : ''
+                ],
         ]
 }
 

--- a/gradle/java-module.gradle
+++ b/gradle/java-module.gradle
@@ -103,6 +103,7 @@ dependencies {
 	testRuntimeOnly dbLibs.informix
 	testRuntimeOnly dbLibs.cockroachdb
 	testRuntimeOnly dbLibs.sybase
+	testRuntimeOnly dbLibs.yugabytedb
 	testRuntimeOnly rootProject.fileTree(dir: 'drivers', include: '*.jar')
 
 	// Since both the DB2 driver and HANA have a package "net.jpountz" we have to add dependencies conditionally

--- a/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/YugabyteDBDialect.java
+++ b/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/YugabyteDBDialect.java
@@ -1,0 +1,112 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.community.dialect;
+
+import org.hibernate.boot.model.TypeContributions;
+import org.hibernate.boot.registry.classloading.spi.ClassLoaderService;
+import org.hibernate.boot.registry.classloading.spi.ClassLoadingException;
+import org.hibernate.dialect.*;
+import org.hibernate.engine.jdbc.dialect.spi.DialectResolutionInfo;
+import org.hibernate.service.ServiceRegistry;
+import org.hibernate.type.JavaObjectType;
+import org.hibernate.type.descriptor.jdbc.*;
+import org.hibernate.type.descriptor.jdbc.spi.JdbcTypeRegistry;
+
+import java.sql.Types;
+
+public class YugabyteDBDialect extends PostgreSQLDialect {
+
+	protected final static DatabaseVersion MINIMUM_YUGABYTEDB_VERSION = DatabaseVersion.make( 2, 18 );
+
+	public YugabyteDBDialect() {
+		super(DatabaseVersion.make(2, 18));
+	}
+
+	public YugabyteDBDialect(DialectResolutionInfo info) {
+		this( info, PostgreSQLDriverKind.determineKind( info ) );
+	}
+
+	public YugabyteDBDialect(DatabaseVersion version, PostgreSQLDriverKind driverKind) {
+		super( version, driverKind );
+	}
+
+	@Override
+	protected DatabaseVersion getMinimumSupportedVersion() {
+		return MINIMUM_YUGABYTEDB_VERSION;
+	}
+
+	protected void contributePostgreSQLTypes(TypeContributions typeContributions, ServiceRegistry serviceRegistry) {
+		final JdbcTypeRegistry jdbcTypeRegistry = typeContributions.getTypeConfiguration()
+				.getJdbcTypeRegistry();
+		// For discussion of BLOB support in Postgres, as of 8.4, have a peek at
+		// <a href="http://jdbc.postgresql.org/documentation/84/binary-data.html">http://jdbc.postgresql.org/documentation/84/binary-data.html</a>.
+		// For the effects in regards to Hibernate see <a href="http://in.relation.to/15492.lace">http://in.relation.to/15492.lace</a>
+
+		// Force BLOB binding.  Otherwise, byte[] fields annotated
+		// with @Lob will attempt to use
+		// BlobTypeDescriptor.PRIMITIVE_ARRAY_BINDING.  Since the
+		// dialect uses oid for Blobs, byte arrays cannot be used.
+		jdbcTypeRegistry.addDescriptor( Types.BLOB, BlobJdbcType.BLOB_BINDING );
+		jdbcTypeRegistry.addDescriptor( Types.CLOB, ClobJdbcType.CLOB_BINDING );
+		// Don't use this type due to https://github.com/pgjdbc/pgjdbc/issues/2862
+		//jdbcTypeRegistry.addDescriptor( TimestampUtcAsOffsetDateTimeJdbcType.INSTANCE );
+		jdbcTypeRegistry.addDescriptor( XmlJdbcType.INSTANCE );
+
+		if ( driverKind == PostgreSQLDriverKind.PG_JDBC ) {
+			// HHH-9562
+			jdbcTypeRegistry.addDescriptorIfAbsent( UUIDJdbcType.INSTANCE );
+			if ( isUsable( serviceRegistry ) ) {
+				jdbcTypeRegistry.addDescriptorIfAbsent( PgJdbcHelper.getInetJdbcType( serviceRegistry ) );
+				jdbcTypeRegistry.addDescriptorIfAbsent( PgJdbcHelper.getIntervalJdbcType( serviceRegistry ) );
+				jdbcTypeRegistry.addDescriptorIfAbsent( PgJdbcHelper.getStructJdbcType( serviceRegistry ) );
+				jdbcTypeRegistry.addDescriptorIfAbsent( PgJdbcHelper.getJsonbJdbcType( serviceRegistry ) );
+			}
+			else {
+				jdbcTypeRegistry.addDescriptorIfAbsent( PostgreSQLCastingInetJdbcType.INSTANCE );
+				jdbcTypeRegistry.addDescriptorIfAbsent( PostgreSQLCastingIntervalSecondJdbcType.INSTANCE );
+				jdbcTypeRegistry.addDescriptorIfAbsent( PostgreSQLStructCastingJdbcType.INSTANCE );
+				jdbcTypeRegistry.addDescriptorIfAbsent( PostgreSQLCastingJsonJdbcType.JSONB_INSTANCE );
+			}
+		}
+		else {
+			jdbcTypeRegistry.addDescriptorIfAbsent( UUIDJdbcType.INSTANCE );
+			jdbcTypeRegistry.addDescriptorIfAbsent( PostgreSQLCastingInetJdbcType.INSTANCE );
+			jdbcTypeRegistry.addDescriptorIfAbsent( PostgreSQLCastingIntervalSecondJdbcType.INSTANCE );
+			jdbcTypeRegistry.addDescriptorIfAbsent( PostgreSQLStructCastingJdbcType.INSTANCE );
+			jdbcTypeRegistry.addDescriptorIfAbsent( PostgreSQLCastingJsonJdbcType.JSONB_INSTANCE );
+		}
+
+		// PostgreSQL requires a custom binder for binding untyped nulls as VARBINARY
+		typeContributions.contributeJdbcType( ObjectNullAsBinaryTypeJdbcType.INSTANCE );
+
+		// Until we remove StandardBasicTypes, we have to keep this
+		typeContributions.contributeType(
+				new JavaObjectType(
+						ObjectNullAsBinaryTypeJdbcType.INSTANCE,
+						typeContributions.getTypeConfiguration()
+								.getJavaTypeRegistry()
+								.getDescriptor( Object.class )
+				)
+		);
+	}
+
+	@Override
+	public String getQueryHintString(String sql, String hints) {
+		return "/*+ " + hints + " */" + sql;
+	}
+
+	public static boolean isUsable(ServiceRegistry serviceRegistry) {
+		final ClassLoaderService classLoaderService = serviceRegistry.getService( ClassLoaderService.class );
+		try {
+			classLoaderService.classForName( "com.yugabyte.util.PGobject" );
+			return true;
+		}
+		catch (ClassLoadingException ex) {
+			return false;
+		}
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/queryhint/YugabyteDBQueryHintTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/queryhint/YugabyteDBQueryHintTest.java
@@ -1,0 +1,103 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.orm.test.queryhint;
+
+import java.util.List;
+
+import org.hibernate.cfg.AvailableSettings;
+import org.hibernate.community.dialect.YugabyteDBDialect;
+import org.hibernate.query.Query;
+
+import org.hibernate.testing.jdbc.SQLStatementInspector;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.RequiresDialect;
+import org.hibernate.testing.orm.junit.ServiceRegistry;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.hibernate.testing.orm.junit.Setting;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * @author Amogh Shetkar
+ */
+@RequiresDialect(value = YugabyteDBDialect.class)
+@DomainModel(
+        annotatedClasses = { YugabyteDBQueryHintTest.Employee.class, YugabyteDBQueryHintTest.Department.class }
+)
+@SessionFactory(useCollectingStatementInspector = true)
+@ServiceRegistry(
+        settings = @Setting(name = AvailableSettings.USE_SQL_COMMENTS, value = "true")
+)
+public class YugabyteDBQueryHintTest {
+
+    @BeforeAll
+    protected void setUp(SessionFactoryScope scope) {
+        Department department = new Department();
+        department.name = "Sales";
+        Employee employee1 = new Employee();
+        employee1.department = department;
+        Employee employee2 = new Employee();
+        employee2.department = department;
+
+        scope.inTransaction( s -> {
+            s.persist( department );
+            s.persist( employee1 );
+            s.persist( employee2 );
+        } );
+    }
+
+    @Test
+    public void testQueryHint(SessionFactoryScope scope) {
+        final SQLStatementInspector statementInspector = scope.getCollectingStatementInspector();
+        statementInspector.clear();
+
+        // test Query with a simple hint
+        String hint = "someHint";
+        scope.inTransaction( s -> {
+            Query query = s.createQuery( "FROM Employee e WHERE e.department.name = :departmentName" )
+                    .addQueryHint( hint )
+                    .setParameter( "departmentName", "Sales" );
+            List results = query.list();
+
+            assertEquals( 2, results.size() );
+        } );
+
+        statementInspector.assertExecutedCount( 1 );
+        assertTrue( statementInspector.getSqlQueries().get( 0 ).contains( "/*+ " + hint + " */select" ) );
+        statementInspector.clear();
+    }
+
+
+    @Entity(name = "Employee")
+    public static class Employee {
+        @Id
+        @GeneratedValue
+        public long id;
+
+        @ManyToOne(fetch = FetchType.LAZY)
+        public Department department;
+    }
+
+    @Entity(name = "Department")
+    public static class Department {
+        @Id
+        @GeneratedValue
+        public long id;
+
+        public String name;
+    }
+}

--- a/hibernate-testing/src/main/java/org/hibernate/testing/orm/junit/DialectContext.java
+++ b/hibernate-testing/src/main/java/org/hibernate/testing/orm/junit/DialectContext.java
@@ -78,7 +78,7 @@ public final class DialectContext {
 					+ jdbcUrl + "' [" + sqle.getMessage() + "]", sqle );
 		}
 		catch (Exception e) {
-			throw new HibernateException( "Could not instantiate given dialect class: " + dialectName, e );
+			throw new HibernateException( "Could not instantiate given dialect class: " + dialectName + ", " + jdbcUrl + ", " + driver, e );
 		}
 	}
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -230,6 +230,7 @@ dependencyResolutionManagement {
             def pgsqlVersion = version "pgsql", "42.6.0"
             def sybaseVersion = version "sybase", "1.3.1"
             def tidbVersion = version "tidb", mysqlVersion
+            def yugabytedbVersion = version "yugabytedb", "42.3.5-yb-3"
 
             library( "h2", "com.h2database", "h2" ).versionRef( h2Version )
             library( "h2gis", "org.orbisgis", "h2gis" ).versionRef( h2gisVersion )
@@ -249,6 +250,8 @@ dependencyResolutionManagement {
             library( "sybase", "net.sourceforge.jtds", "jtds" ).versionRef( sybaseVersion )
             library( "informix", "com.ibm.informix", "jdbc" ).versionRef( informixVersion )
             library( "firebird", "org.firebirdsql.jdbc", "jaybird" ).versionRef( firebirdVersion )
+            // library( "yugabytedb", "org.postgresql", "postgresql" ).versionRef( yugabytedbVersion )
+            library( "yugabytedb", "com.yugabyte", "jdbc-yugabytedb" ).versionRef( yugabytedbVersion )
         }
         mavenLibs {
             def mavenCoreVersion = version "mavenCore", "3.8.1"


### PR DESCRIPTION
[YugabyteDB](https://www.yugabyte.com/) is a cloud-native database, compatible with Postgresql. We want to add a dialect for YugabyteDB for a better integration with Hibernate for the community.

Please let me know if I need to file a ticket for this first.

This is a draft PR since I would like an early feedback on the changes itself and also because I am facing issues running some tests appropriately which I need help with:
1. Every time I run `./gradlew test -Pdb=yugabytedb`, I see tests running from different modules. Does this need to be configured specifically for a dialect?
2. When I run individual tests from `hibernate-core`, all of them - except one or two - run fine. But with above command there are quite a few failures, suggesting the tests may be running in parallel. Is it really the case? If yes, how do I change this?
3. A newly added test class `YugabyteDBQueryHintTest` (still needs changes) shows up as ignored even when run individually. How do I avoid getting it ignored?

Thanks in advance!