### PR TITLE
HHH-17395 Refresh with PESSIMISTIC_WRITE ignored for lazy loaded entity HHH-1645 refresh with LockMode on an unitialized proxy does not work

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/internal/SessionImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/SessionImpl.java
@@ -565,7 +565,7 @@ public class SessionImpl
 		if ( lazyInitializer != null ) {
 			object = lazyInitializer.getImplementation( this );
 			if ( object == null ) {
-				return LockMode.NONE;
+				return lazyInitializer.getLockMode();
 			}
 		}
 

--- a/hibernate-core/src/main/java/org/hibernate/proxy/LazyInitializer.java
+++ b/hibernate-core/src/main/java/org/hibernate/proxy/LazyInitializer.java
@@ -7,6 +7,7 @@
 package org.hibernate.proxy;
 
 import org.hibernate.HibernateException;
+import org.hibernate.LockMode;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
 
 /**
@@ -159,6 +160,22 @@ public interface LazyInitializer {
 	 * @see org.hibernate.Session#setReadOnly(Object entityOrProxy, boolean readOnly)
 	 */
 	void setReadOnly(boolean readOnly);
+
+	/**
+	 * The LockMode the proxy target has to be set after the proxy has been initialized
+	 *
+	 * @param lockMode the lock mode
+	 */
+	default void setLockMode(LockMode lockMode){
+	}
+
+	/**
+	 * Return the LockMode the proxy target has to be set when the proxy is initialized
+	 *
+	 */
+	default LockMode getLockMode(){
+		return LockMode.NONE;
+	}
 
 	/**
 	 * Get the session to which this proxy is associated, or null if it is not attached.

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/locking/LockRefreshReferencedTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/locking/LockRefreshReferencedTest.java
@@ -1,0 +1,142 @@
+package org.hibernate.orm.test.locking;
+
+import org.hibernate.testing.orm.junit.EntityManagerFactoryScope;
+import org.hibernate.testing.orm.junit.JiraKey;
+import org.hibernate.testing.orm.junit.Jpa;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.LockModeType;
+import jakarta.persistence.OneToOne;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+@JiraKey("HHH-17395")
+@Jpa(
+		annotatedClasses = {
+				LockRefreshReferencedTest.MainEntity.class,
+				LockRefreshReferencedTest.ReferencedEntity.class
+		}
+)
+public class LockRefreshReferencedTest {
+
+	@BeforeAll
+	public void setUp(EntityManagerFactoryScope scope) {
+		scope.inTransaction(
+				entityManager -> {
+					final ReferencedEntity e1 = new ReferencedEntity( 0, "lazy" );
+					final ReferencedEntity e2 = new ReferencedEntity( 1, "eager" );
+					entityManager.persist( e1 );
+					entityManager.persist( e2 );
+					final MainEntity e3 = new MainEntity( 0, e1, e2 );
+					entityManager.persist( e3 );
+				}
+		);
+	}
+
+	@Test
+	public void testRefreshBeforeRead(EntityManagerFactoryScope scope) {
+		scope.inTransaction(
+				entityManager -> {
+					MainEntity m = entityManager.find( MainEntity.class, 0 );
+					assertNotNull( m );
+					ReferencedEntity lazyReference = m.referencedLazy();
+					ReferencedEntity eagerReference = m.referencedEager();
+					assertNotNull( lazyReference );
+					assertNotNull( eagerReference );
+
+					// First refresh, then access
+					entityManager.refresh( eagerReference, LockModeType.PESSIMISTIC_WRITE );
+					entityManager.refresh( lazyReference, LockModeType.PESSIMISTIC_WRITE );
+
+					assertEquals( "lazy", lazyReference.status() );
+					assertEquals( "eager", eagerReference.status() );
+					assertEquals( LockModeType.PESSIMISTIC_WRITE, entityManager.getLockMode( lazyReference ) );
+					assertEquals( LockModeType.PESSIMISTIC_WRITE, entityManager.getLockMode( eagerReference ) );
+				} );
+	}
+
+	@Test
+	public void testRefreshAfterRead(EntityManagerFactoryScope scope) {
+		scope.inTransaction(
+				entityManager -> {
+					MainEntity m = entityManager.find( MainEntity.class, 0 );
+					assertNotNull( m );
+					ReferencedEntity lazyReference = m.referencedLazy();
+					ReferencedEntity eagerReference = m.referencedEager();
+					assertNotNull( lazyReference );
+					assertNotNull( eagerReference );
+
+					// First access, the refresh
+					assertEquals( "lazy", lazyReference.status() );
+					assertEquals( "eager", eagerReference.status() );
+
+					entityManager.refresh( lazyReference, LockModeType.PESSIMISTIC_WRITE );
+					entityManager.refresh( eagerReference, LockModeType.PESSIMISTIC_WRITE );
+
+					assertEquals( LockModeType.PESSIMISTIC_WRITE, entityManager.getLockMode( lazyReference ) );
+					assertEquals( LockModeType.PESSIMISTIC_WRITE, entityManager.getLockMode( eagerReference ) );
+				} );
+	}
+
+
+	@Entity
+	public static class MainEntity {
+		@Id
+		private long id;
+
+		private String name;
+
+		@OneToOne(targetEntity = ReferencedEntity.class, fetch = FetchType.LAZY)
+		@JoinColumn(name = "LAZY_COLUMN")
+		private ReferencedEntity referencedLazy;
+
+		@OneToOne(targetEntity = ReferencedEntity.class, fetch = FetchType.EAGER)
+		@JoinColumn(name = "EAGER_COLUMN")
+		private ReferencedEntity referencedEager;
+
+		protected MainEntity() {
+		}
+
+		public MainEntity(long id, ReferencedEntity lazy, ReferencedEntity eager) {
+			this.id = id;
+			this.referencedLazy = lazy;
+			this.referencedEager = eager;
+		}
+
+		public ReferencedEntity referencedLazy() {
+			return referencedLazy;
+		}
+
+		public ReferencedEntity referencedEager() {
+			return referencedEager;
+		}
+	}
+
+	@Entity
+	public static class ReferencedEntity {
+
+		@Id
+		private long id;
+
+		private String status;
+
+		protected ReferencedEntity() {
+		}
+
+		public ReferencedEntity(long id, String status) {
+			this.id = id;
+			this.status = status;
+		}
+
+		public String status() {
+			return status;
+		}
+	}
+
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/proxy/ProxyTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/proxy/ProxyTest.java
@@ -24,8 +24,8 @@ import org.hibernate.internal.SessionImpl;
 import org.hibernate.internal.util.SerializationHelper;
 import org.hibernate.proxy.HibernateProxy;
 
-import org.hibernate.testing.FailureExpected;
 import org.hibernate.testing.junit4.BaseCoreFunctionalTestCase;
+import org.hibernate.testing.orm.junit.JiraKey;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
@@ -539,7 +539,7 @@ public class ProxyTest extends BaseCoreFunctionalTestCase {
 	}
 
 	@Test
-	@FailureExpected( jiraKey = "HHH-1645", message = "Session.refresh with LockOptions does not work on uninitialized proxies" )
+	@JiraKey( "HHH-1645" )
 	public void testRefreshLockUninitializedProxy() {
 		Session s = openSession();
 		Transaction t = s.beginTransaction();
@@ -568,7 +568,7 @@ public class ProxyTest extends BaseCoreFunctionalTestCase {
 	}
 
 	@Test
-	@FailureExpected( jiraKey = "HHH-1645", message = "Session.refresh with LockOptions does not work on uninitialized proxies" )
+	@JiraKey( "HHH-1645" )
 	public void testRefreshLockUninitializedProxyThenRead() {
 		Session s = openSession();
 		Transaction t = s.beginTransaction();


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-1645
https://hibernate.atlassian.net/browse/HHH-17395