### PR TITLE
HHH-17370 Unable to create requested service [org.hibernate.engine.jdbc.env.spi.JdbcEnvironment] due to: Cannot invoke org.hibernate.resource.jdbc.spi.JdbcObserver.jdbcConnectionAcquisitionEnd(java.sql.Connection) because this.observer is null

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/engine/jdbc/env/internal/JdbcEnvironmentInitiator.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/jdbc/env/internal/JdbcEnvironmentInitiator.java
@@ -557,6 +557,7 @@ public class JdbcEnvironmentInitiator implements StandardServiceInitiator<JdbcEn
 		private final boolean connectionProviderDisablesAutoCommit;
 		private final PhysicalConnectionHandlingMode connectionHandlingMode;
 		private final JpaCompliance jpaCompliance;
+		private static final EmptyJdbcObserver EMPTY_JDBC_OBSERVER = EmptyJdbcObserver.INSTANCE;
 		TransactionCoordinator transactionCoordinator;
 
 		public TemporaryJdbcSessionOwner(
@@ -691,7 +692,7 @@ public class JdbcEnvironmentInitiator implements StandardServiceInitiator<JdbcEn
 
 		@Override
 		public JdbcObserver getObserver() {
-			return null;
+			return EMPTY_JDBC_OBSERVER;
 		}
 
 		@Override
@@ -717,6 +718,61 @@ public class JdbcEnvironmentInitiator implements StandardServiceInitiator<JdbcEn
 		@Override
 		public boolean isActive() {
 			return true;
+		}
+
+		private static class EmptyJdbcObserver implements JdbcObserver{
+
+			public static final EmptyJdbcObserver INSTANCE = new EmptyJdbcObserver();
+
+			@Override
+			public void jdbcConnectionAcquisitionStart() {
+
+			}
+
+			@Override
+			public void jdbcConnectionAcquisitionEnd(Connection connection) {
+
+			}
+
+			@Override
+			public void jdbcConnectionReleaseStart() {
+
+			}
+
+			@Override
+			public void jdbcConnectionReleaseEnd() {
+
+			}
+
+			@Override
+			public void jdbcPrepareStatementStart() {
+
+			}
+
+			@Override
+			public void jdbcPrepareStatementEnd() {
+
+			}
+
+			@Override
+			public void jdbcExecuteStatementStart() {
+
+			}
+
+			@Override
+			public void jdbcExecuteStatementEnd() {
+
+			}
+
+			@Override
+			public void jdbcExecuteBatchStart() {
+
+			}
+
+			@Override
+			public void jdbcExecuteBatchEnd() {
+
+			}
 		}
 	}
 }

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/connections/ImmediatAcqusitionAndHoldConnectionHandlingModeTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/connections/ImmediatAcqusitionAndHoldConnectionHandlingModeTest.java
@@ -1,0 +1,25 @@
+package org.hibernate.orm.test.connections;
+
+import org.hibernate.cfg.AvailableSettings;
+
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.Jira;
+import org.hibernate.testing.orm.junit.ServiceRegistry;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.hibernate.testing.orm.junit.Setting;
+import org.junit.jupiter.api.Test;
+
+@DomainModel
+@SessionFactory
+@ServiceRegistry(
+		settings = @Setting( name = AvailableSettings.CONNECTION_HANDLING, value = "IMMEDIATE_ACQUISITION_AND_HOLD")
+)
+@Jira( "HHH-17370" )
+public class ImmediatAcqusitionAndHoldConnectionHandlingModeTest {
+
+	@Test
+	public void testIt(SessionFactoryScope scope){
+		// this is enough to reproduce the issue
+	}
+}


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-17370

backport of https://github.com/hibernate/hibernate-orm/pull/7505 to 6.3