### PR TITLE
ParameterMarkerStrategy markers are 1 based

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/dialect/temptable/StandardTemporaryTableExporter.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/temptable/StandardTemporaryTableExporter.java
@@ -106,7 +106,7 @@ public class StandardTemporaryTableExporter implements TemporaryTableExporter {
 					.getFastSessionServices().parameterMarkerStrategy;
 			return getTruncateTableCommand() + " " + idTable.getQualifiedTableName()
 					+ " where " + idTable.getSessionUidColumn().getColumnName() + " = "
-					+ parameterMarkerStrategy.createMarker( 0, null );
+					+ parameterMarkerStrategy.createMarker( 1, null );
 		}
 		else {
 			return getTruncateTableCommand() + " " + idTable.getQualifiedTableName();


### PR DESCRIPTION
The position argument in `ParameterMarkerStrategy#createMarker` is 1-based, but `StandardTemporaryTableExporter#getSqlTruncateCommand` calls it passing a 0.

Hibernate Reactive is affected by this when running queries on CockroachDB. Hibernate ORM generates queries using `?` as marker and it's not affected by it unless somebody implements the service.

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-17428
<!-- Hibernate GitHub Bot issue links end -->