### PR TITLE
Testing the instance of "BindType" but using "Type" afterwards.

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/internal/SqmUtil.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/internal/SqmUtil.java
@@ -361,7 +361,7 @@ public class SqmUtil {
 						jdbcMapping = (JdbcMapping) domainParamBinding.getType();
 					}
 					else if ( domainParamBinding.getBindType() instanceof BasicValuedMapping ) {
-						jdbcMapping = ( (BasicValuedMapping) domainParamBinding.getType() ).getJdbcMapping();
+						jdbcMapping = ( (BasicValuedMapping) domainParamBinding.getBindType() ).getJdbcMapping();
 					}
 					else {
 						jdbcMapping = null;


### PR DESCRIPTION
A "ClassCastException" is thrown in the case of an HQL query with a "ManyToOne" relationship.