### PR TITLE
Jpamodelgen fixes for panache

### DIFF
--- a/tooling/metamodel-generator/hibernate-jpamodelgen.gradle
+++ b/tooling/metamodel-generator/hibernate-jpamodelgen.gradle
@@ -18,26 +18,9 @@ ext {
 	xsdDir = file( "${projectDir}/src/main/xsd" )
 }
 
-sourceSets {
-	quarkusOrmPanache {
-        compileClasspath += sourceSets.main.output
-        compileClasspath += sourceSets.test.output
-        runtimeClasspath += sourceSets.main.output
-        runtimeClasspath += sourceSets.test.output
-	}
-	quarkusHrPanache {
-        compileClasspath += sourceSets.main.output
-        compileClasspath += sourceSets.test.output
-        runtimeClasspath += sourceSets.main.output
-        runtimeClasspath += sourceSets.test.output
-	}
-}
-
 configurations {
-	quarkusOrmPanacheImplementation.extendsFrom testImplementation
-	quarkusOrmPanacheRuntimeOnly.extendsFrom runtimeOnly
-	quarkusHrPanacheImplementation.extendsFrom testImplementation
-	quarkusHrPanacheRuntimeOnly.extendsFrom runtimeOnly
+	quarkusOrmPanache
+	quarkusHrPanache
 }
 
 dependencies {
@@ -53,46 +36,29 @@ dependencies {
     xjc jakartaLibs.xjc
     xjc jakartaLibs.jaxb
     xjc rootProject.fileTree(dir: 'patched-libs/jaxb2-basics', include: '*.jar')
-    
-    quarkusOrmPanacheImplementation "io.quarkus:quarkus-hibernate-orm-panache:3.6.2"
-	quarkusOrmPanacheImplementation project( ":hibernate-testing" )
-    quarkusOrmPanacheImplementation 'org.checkerframework:checker-qual:3.4.0'
-    
-    quarkusHrPanacheImplementation "io.quarkus:quarkus-hibernate-hr-panache:3.6.2"
-	quarkusHrPanacheImplementation project( ":hibernate-testing" )
-    quarkusHrPanacheImplementation 'org.checkerframework:checker-qual:3.4.0'
+
+	quarkusOrmPanache "io.quarkus:quarkus-hibernate-orm-panache:3.6.2"
+	quarkusHrPanache "io.quarkus:quarkus-hibernate-reactive-panache:3.6.2"
 }
 
 def quarkusOrmPanacheTestTask = tasks.register( 'quarkusOrmPanacheTest', Test ) {
 	description = 'Runs the Quarkus ORM Panache tests.'
 	group = 'verification'
 
-	testClassesDirs = sourceSets.quarkusOrmPanache.output.classesDirs
-	classpath = sourceSets.quarkusOrmPanache.runtimeClasspath
+	testClassesDirs = sourceSets.test.output.classesDirs
+	classpath = sourceSets.test.runtimeClasspath + configurations.quarkusOrmPanache
 	shouldRunAfter test
 	dependsOn test
-
-	useJUnitPlatform()
-
-	testLogging {
-		events "passed"
-	}
 }
 
 def quarkusHrPanacheTestTask = tasks.register( 'quarkusHrPanacheTest', Test ) {
 	description = 'Runs the Quarkus HR Panache tests.'
 	group = 'verification'
 
-	testClassesDirs = sourceSets.quarkusHrPanache.output.classesDirs
-	classpath = sourceSets.quarkusHrPanache.runtimeClasspath
+	testClassesDirs = sourceSets.test.output.classesDirs
+	classpath = sourceSets.test.runtimeClasspath + configurations.quarkusHrPanache
 	shouldRunAfter test
 	dependsOn test
-
-	useJUnitPlatform()
-
-	testLogging {
-		events "passed"
-	}
 }
 
 check.dependsOn quarkusHrPanacheTestTask

--- a/tooling/metamodel-generator/hibernate-jpamodelgen.gradle
+++ b/tooling/metamodel-generator/hibernate-jpamodelgen.gradle
@@ -18,6 +18,28 @@ ext {
 	xsdDir = file( "${projectDir}/src/main/xsd" )
 }
 
+sourceSets {
+	quarkusOrmPanache {
+        compileClasspath += sourceSets.main.output
+        compileClasspath += sourceSets.test.output
+        runtimeClasspath += sourceSets.main.output
+        runtimeClasspath += sourceSets.test.output
+	}
+	quarkusHrPanache {
+        compileClasspath += sourceSets.main.output
+        compileClasspath += sourceSets.test.output
+        runtimeClasspath += sourceSets.main.output
+        runtimeClasspath += sourceSets.test.output
+	}
+}
+
+configurations {
+	quarkusOrmPanacheImplementation.extendsFrom testImplementation
+	quarkusOrmPanacheRuntimeOnly.extendsFrom runtimeOnly
+	quarkusHrPanacheImplementation.extendsFrom testImplementation
+	quarkusHrPanacheRuntimeOnly.extendsFrom runtimeOnly
+}
+
 dependencies {
     // api - ewww... but Maven needs them this way
     api project( ':hibernate-core' )
@@ -31,7 +53,50 @@ dependencies {
     xjc jakartaLibs.xjc
     xjc jakartaLibs.jaxb
     xjc rootProject.fileTree(dir: 'patched-libs/jaxb2-basics', include: '*.jar')
+    
+    quarkusOrmPanacheImplementation "io.quarkus:quarkus-hibernate-orm-panache:3.6.2"
+	quarkusOrmPanacheImplementation project( ":hibernate-testing" )
+    quarkusOrmPanacheImplementation 'org.checkerframework:checker-qual:3.4.0'
+    
+    quarkusHrPanacheImplementation "io.quarkus:quarkus-hibernate-hr-panache:3.6.2"
+	quarkusHrPanacheImplementation project( ":hibernate-testing" )
+    quarkusHrPanacheImplementation 'org.checkerframework:checker-qual:3.4.0'
 }
+
+def quarkusOrmPanacheTestTask = tasks.register( 'quarkusOrmPanacheTest', Test ) {
+	description = 'Runs the Quarkus ORM Panache tests.'
+	group = 'verification'
+
+	testClassesDirs = sourceSets.quarkusOrmPanache.output.classesDirs
+	classpath = sourceSets.quarkusOrmPanache.runtimeClasspath
+	shouldRunAfter test
+	dependsOn test
+
+	useJUnitPlatform()
+
+	testLogging {
+		events "passed"
+	}
+}
+
+def quarkusHrPanacheTestTask = tasks.register( 'quarkusHrPanacheTest', Test ) {
+	description = 'Runs the Quarkus HR Panache tests.'
+	group = 'verification'
+
+	testClassesDirs = sourceSets.quarkusHrPanache.output.classesDirs
+	classpath = sourceSets.quarkusHrPanache.runtimeClasspath
+	shouldRunAfter test
+	dependsOn test
+
+	useJUnitPlatform()
+
+	testLogging {
+		events "passed"
+	}
+}
+
+check.dependsOn quarkusHrPanacheTestTask
+check.dependsOn quarkusOrmPanacheTestTask
 
 sourceSets.main {
     java.srcDir xjcTargetDir

--- a/tooling/metamodel-generator/hibernate-jpamodelgen.gradle
+++ b/tooling/metamodel-generator/hibernate-jpamodelgen.gradle
@@ -76,7 +76,6 @@ def quarkusOrmPanacheTestTask = tasks.register( 'quarkusOrmPanacheTest', Test ) 
 	testClassesDirs = sourceSets.quarkusOrmPanache.output.classesDirs
 	classpath = sourceSets.quarkusOrmPanache.runtimeClasspath
 	shouldRunAfter test
-	dependsOn test
 }
 
 def quarkusHrPanacheTestTask = tasks.register( 'quarkusHrPanacheTest', Test ) {
@@ -86,11 +85,12 @@ def quarkusHrPanacheTestTask = tasks.register( 'quarkusHrPanacheTest', Test ) {
 	testClassesDirs = sourceSets.quarkusHrPanache.output.classesDirs
 	classpath = sourceSets.quarkusHrPanache.runtimeClasspath
 	shouldRunAfter test
-	dependsOn test
 }
 
 check.dependsOn quarkusHrPanacheTestTask
 check.dependsOn quarkusOrmPanacheTestTask
+test.dependsOn quarkusHrPanacheTestTask
+test.dependsOn quarkusOrmPanacheTestTask
 
 sourceSets.main {
     java.srcDir xjcTargetDir

--- a/tooling/metamodel-generator/hibernate-jpamodelgen.gradle
+++ b/tooling/metamodel-generator/hibernate-jpamodelgen.gradle
@@ -18,9 +18,27 @@ ext {
 	xsdDir = file( "${projectDir}/src/main/xsd" )
 }
 
-configurations {
-	quarkusOrmPanache
-	quarkusHrPanache
+sourceSets {
+	quarkusOrmPanache {
+		java {
+			srcDirs = ['src/quarkusOrmPanache/java']
+		}
+		resources {
+			srcDirs tasks.processTestResources
+		}
+		compileClasspath += sourceSets.main.output + sourceSets.test.output
+		runtimeClasspath += sourceSets.main.output + sourceSets.test.output
+	}
+	quarkusHrPanache {
+		java {
+			srcDirs = ['src/quarkusHrPanache/java']
+		}
+		resources {
+			srcDirs tasks.processTestResources
+		}
+		compileClasspath += sourceSets.main.output + sourceSets.test.output
+		runtimeClasspath += sourceSets.main.output + sourceSets.test.output
+	}
 }
 
 dependencies {
@@ -37,16 +55,26 @@ dependencies {
     xjc jakartaLibs.jaxb
     xjc rootProject.fileTree(dir: 'patched-libs/jaxb2-basics', include: '*.jar')
 
-	quarkusOrmPanache "io.quarkus:quarkus-hibernate-orm-panache:3.6.2"
-	quarkusHrPanache "io.quarkus:quarkus-hibernate-reactive-panache:3.6.2"
+	quarkusOrmPanacheImplementation "io.quarkus:quarkus-hibernate-orm-panache:3.6.2"
+	quarkusHrPanacheImplementation "io.quarkus:quarkus-hibernate-reactive-panache:3.6.2"
+}
+
+// The source set gets a custom configuration which extends the normal test implementation config
+configurations {
+	quarkusOrmPanacheImplementation.extendsFrom(testImplementation)
+	quarkusOrmPanacheRuntimeOnly.extendsFrom(testRuntimeOnly)
+	quarkusOrmPanacheCompileOnly.extendsFrom(testCompileOnly)
+	quarkusHrPanacheImplementation.extendsFrom(testImplementation)
+	quarkusHrPanacheRuntimeOnly.extendsFrom(testRuntimeOnly)
+	quarkusHrPanacheCompileOnly.extendsFrom(testCompileOnly)
 }
 
 def quarkusOrmPanacheTestTask = tasks.register( 'quarkusOrmPanacheTest', Test ) {
 	description = 'Runs the Quarkus ORM Panache tests.'
 	group = 'verification'
 
-	testClassesDirs = sourceSets.test.output.classesDirs
-	classpath = sourceSets.test.runtimeClasspath + configurations.quarkusOrmPanache
+	testClassesDirs = sourceSets.quarkusOrmPanache.output.classesDirs
+	classpath = sourceSets.quarkusOrmPanache.runtimeClasspath
 	shouldRunAfter test
 	dependsOn test
 }
@@ -55,8 +83,8 @@ def quarkusHrPanacheTestTask = tasks.register( 'quarkusHrPanacheTest', Test ) {
 	description = 'Runs the Quarkus HR Panache tests.'
 	group = 'verification'
 
-	testClassesDirs = sourceSets.test.output.classesDirs
-	classpath = sourceSets.test.runtimeClasspath + configurations.quarkusHrPanache
+	testClassesDirs = sourceSets.quarkusHrPanache.output.classesDirs
+	classpath = sourceSets.quarkusHrPanache.runtimeClasspath
 	shouldRunAfter test
 	dependsOn test
 }

--- a/tooling/metamodel-generator/src/main/java/org/hibernate/jpamodelgen/Context.java
+++ b/tooling/metamodel-generator/src/main/java/org/hibernate/jpamodelgen/Context.java
@@ -95,6 +95,9 @@ public final class Context {
 	// keep track of which named queries have been checked
 	private final Set<String> checkedNamedQueries = new HashSet<>();
 
+	private boolean usesQuarkusOrm = false;
+	private boolean usesQuarkusReactive = false;
+
 	public Context(ProcessingEnvironment processingEnvironment) {
 		this.processingEnvironment = processingEnvironment;
 
@@ -389,5 +392,21 @@ public final class Context {
 
 	public boolean checkNamedQuery(String name) {
 		return checkedNamedQueries.add(name);
+	}
+
+	public void setUsesQuarkusOrm(boolean b) {
+		usesQuarkusOrm = b;
+	}
+	
+	public boolean usesQuarkusOrm() {
+		return usesQuarkusOrm;
+	}
+
+	public void setUsesQuarkusReactive(boolean b) {
+		usesQuarkusReactive = b;
+	}
+	
+	public boolean usesQuarkusReactive() {
+		return usesQuarkusReactive;
 	}
 }

--- a/tooling/metamodel-generator/src/main/java/org/hibernate/jpamodelgen/JPAMetaModelEntityProcessor.java
+++ b/tooling/metamodel-generator/src/main/java/org/hibernate/jpamodelgen/JPAMetaModelEntityProcessor.java
@@ -174,12 +174,29 @@ public class JPAMetaModelEntityProcessor extends AbstractProcessor {
 				context.getProcessingEnvironment().getElementUtils()
 						.getPackageElement( "io.quarkus.hibernate.orm" );
 
+		PackageElement quarkusOrmPanachePackage =
+				context.getProcessingEnvironment().getElementUtils()
+						.getPackageElement( "io.quarkus.hibernate.orm.panache" );
+		PackageElement quarkusReactivePanachePackage =
+				context.getProcessingEnvironment().getElementUtils()
+						.getPackageElement( "io.quarkus.hibernate.reactive.panache" );
+		if ( quarkusReactivePanachePackage != null
+				&& quarkusOrmPanachePackage != null ) {
+			context.logMessage(
+					Diagnostic.Kind.WARNING,
+					"Both Quarkus Hibernate ORM and Hibernate Reactive with Panache detected: this is not supported, so will proceed as if none were there"
+			);
+			quarkusOrmPanachePackage = quarkusReactivePanachePackage = null;
+		}
+		
 		context.setAddInjectAnnotation( jakartaInjectPackage != null );
 		context.setAddNonnullAnnotation( jakartaAnnotationPackage != null );
 		context.setAddGeneratedAnnotation( jakartaAnnotationPackage != null );
 		context.setAddDependentAnnotation( jakartaContextPackage != null );
 		context.setAddTransactionScopedAnnotation( jakartaTransactionsPackage != null );
 		context.setQuarkusInjection( quarkusOrmPackage != null );
+		context.setUsesQuarkusOrm( quarkusOrmPanachePackage != null );
+		context.setUsesQuarkusReactive( quarkusReactivePanachePackage != null );
 
 		final Map<String, String> options = environment.getOptions();
 

--- a/tooling/metamodel-generator/src/main/java/org/hibernate/jpamodelgen/annotation/AbstractQueryMethod.java
+++ b/tooling/metamodel-generator/src/main/java/org/hibernate/jpamodelgen/annotation/AbstractQueryMethod.java
@@ -204,7 +204,15 @@ public abstract class AbstractQueryMethod implements MetaAttribute {
 
 	void chainSessionEnd(boolean isUpdate, StringBuilder declaration) {
 		if ( isReactiveSession() ) {
-			declaration.append("\n\t});");
+			declaration.append("\n\t})");
+			// here we're checking for a boxed void and not Uni<Void> because the returnType has already
+			// been checked, and is ununi-ed
+			if ( isUpdate && returnTypeName != null && returnTypeName.equals(BOXED_VOID) ) {
+				declaration.append(".replaceWithVoid();");
+			}
+			else {
+				declaration.append(";");
+			}
 		}
 	}
 
@@ -445,7 +453,7 @@ public abstract class AbstractQueryMethod implements MetaAttribute {
 					.append(" _results = ");
 		}
 		else {
-			if ( !"void".equals(returnTypeName) ) {
+			if ( !"void".equals(returnTypeName) || isReactiveSession() ) {
 				declaration
 						.append("return ");
 			}

--- a/tooling/metamodel-generator/src/main/java/org/hibernate/jpamodelgen/annotation/AbstractQueryMethod.java
+++ b/tooling/metamodel-generator/src/main/java/org/hibernate/jpamodelgen/annotation/AbstractQueryMethod.java
@@ -183,7 +183,29 @@ public abstract class AbstractQueryMethod implements MetaAttribute {
 	}
 
 	boolean isReactive() {
-		return MUTINY_SESSION.equals(sessionType);
+		return MUTINY_SESSION.equals(sessionType)
+				|| UNI_MUTINY_SESSION.equals(sessionType);
+	}
+
+	boolean isReactiveSession() {
+		return UNI_MUTINY_SESSION.equals(sessionType);
+	}
+
+	String localSessionName() {
+		return isReactiveSession() ? "resolvedSession" : sessionName;
+	}
+	
+	void chainSession(StringBuilder declaration) {
+		// Reactive calls always have a return type
+		if ( isReactiveSession() ) {
+			declaration.append("\treturn ").append(sessionName).append(".chain(").append(localSessionName()).append(" -> {\n\t");
+		}
+	}
+
+	void chainSessionEnd(boolean isUpdate, StringBuilder declaration) {
+		if ( isReactiveSession() ) {
+			declaration.append("\n\t});");
+		}
 	}
 
 	void setPage(StringBuilder declaration, String paramName, String paramType) {

--- a/tooling/metamodel-generator/src/main/java/org/hibernate/jpamodelgen/annotation/AnnotationMetaEntity.java
+++ b/tooling/metamodel-generator/src/main/java/org/hibernate/jpamodelgen/annotation/AnnotationMetaEntity.java
@@ -459,7 +459,7 @@ public class AnnotationMetaEntity extends AnnotationMeta {
 		if ( method.getParameters().isEmpty() ) {
 			final TypeMirror type = method.getReturnType();
 			if ( type.getKind() == TypeKind.DECLARED ) {
-				final DeclaredType declaredType = (DeclaredType) type;
+				final DeclaredType declaredType = ununi( (DeclaredType) type );
 				final Element element = declaredType.asElement();
 				if ( element.getKind() == ElementKind.INTERFACE ) {
 					final Name name = ((TypeElement) element).getQualifiedName();

--- a/tooling/metamodel-generator/src/main/java/org/hibernate/jpamodelgen/annotation/CriteriaFinderMethod.java
+++ b/tooling/metamodel-generator/src/main/java/org/hibernate/jpamodelgen/annotation/CriteriaFinderMethod.java
@@ -59,12 +59,14 @@ public class CriteriaFinderMethod extends AbstractFinderMethod {
 		comment( declaration );
 		modifiers( declaration );
 		preamble( declaration, returnType(), paramTypes );
+		chainSession( declaration );
 		nullChecks( paramTypes, declaration );
 		createCriteriaQuery( declaration );
 		where( declaration, paramTypes );
 //		orderBy( paramTypes, declaration );
 		executeQuery( declaration, paramTypes );
 		convertExceptions( declaration );
+		chainSessionEnd( false, declaration );
 		closingBrace( declaration );
 		return declaration.toString();
 	}
@@ -102,7 +104,7 @@ public class CriteriaFinderMethod extends AbstractFinderMethod {
 	@Override
 	void createQuery(StringBuilder declaration) {
 		declaration
-				.append(sessionName)
+				.append(localSessionName())
 				.append(".createQuery(_query)\n");
 	}
 
@@ -119,7 +121,7 @@ public class CriteriaFinderMethod extends AbstractFinderMethod {
 	private void createCriteriaQuery(StringBuilder declaration) {
 		declaration
 				.append("\tvar _builder = ")
-				.append(sessionName)
+				.append(localSessionName())
 				.append(isUsingEntityManager()
 						? ".getEntityManagerFactory()"
 						: ".getFactory()")

--- a/tooling/metamodel-generator/src/main/java/org/hibernate/jpamodelgen/annotation/QueryMethod.java
+++ b/tooling/metamodel-generator/src/main/java/org/hibernate/jpamodelgen/annotation/QueryMethod.java
@@ -85,6 +85,7 @@ public class QueryMethod extends AbstractQueryMethod {
 		modifiers( paramTypes, declaration );
 		preamble( declaration, returnType, paramTypes );
 		collectOrdering( declaration, paramTypes );
+		chainSession( declaration );
 		tryReturn( declaration, paramTypes, containerType );
 		castResult( declaration, returnType );
 		createQuery( declaration );
@@ -94,6 +95,7 @@ public class QueryMethod extends AbstractQueryMethod {
 		unwrapped = applyOrder( declaration, paramTypes, containerType, unwrapped );
 		execute( declaration, unwrapped );
 		convertExceptions( declaration );
+		chainSessionEnd( isUpdate, declaration );
 		closingBrace( declaration );
 		return declaration.toString();
 	}
@@ -107,7 +109,7 @@ public class QueryMethod extends AbstractQueryMethod {
 	@Override
 	void createQuery(StringBuilder declaration) {
 		declaration
-				.append(sessionName)
+				.append(localSessionName())
 				.append(isNative ? ".createNativeQuery" : ".createQuery")
 				.append("(")
 				.append(getConstantName());

--- a/tooling/metamodel-generator/src/main/java/org/hibernate/jpamodelgen/util/Constants.java
+++ b/tooling/metamodel-generator/src/main/java/org/hibernate/jpamodelgen/util/Constants.java
@@ -115,6 +115,11 @@ public final class Constants {
 	public static final String OPTIONAL = "java.util.Optional";
 	public static final String STREAM = "java.util.stream.Stream";
 
+	public static final String PANACHE_ORM_REPOSITORY_BASE = "io.quarkus.hibernate.orm.panache.PanacheRepositoryBase";
+	public static final String PANACHE_ORM_ENTITY_BASE = "io.quarkus.hibernate.orm.panache.PanacheEntityBase";
+	public static final String PANACHE_REACTIVE_REPOSITORY_BASE = "io.quarkus.hibernate.reactive.panache.PanacheRepositoryBase";
+	public static final String PANACHE_REACTIVE_ENTITY_BASE = "io.quarkus.hibernate.reactive.panache.PanacheEntityBase";
+
 	public static final Map<String, String> COLLECTIONS = Map.of(
 			COLLECTION, Constants.COLLECTION_ATTRIBUTE,
 			SET, Constants.SET_ATTRIBUTE,

--- a/tooling/metamodel-generator/src/main/java/org/hibernate/jpamodelgen/util/Constants.java
+++ b/tooling/metamodel-generator/src/main/java/org/hibernate/jpamodelgen/util/Constants.java
@@ -99,6 +99,10 @@ public final class Constants {
 
 	public static final String UNI = "io.smallrye.mutiny.Uni";
 	public static final String UNI_MUTINY_SESSION = UNI+"<org.hibernate.reactive.mutiny.Mutiny.Session>";
+	public static final String UNI_INTEGER = UNI+"<java.lang.Integer>";
+	public static final String UNI_VOID = UNI+"<java.lang.Void>";
+	public static final String UNI_BOOLEAN = UNI+"<java.lang.Boolean>";
+	public static final String BOXED_VOID = Void.class.getName();
 
 	public static final String SINGULAR_ATTRIBUTE = "jakarta.persistence.metamodel.SingularAttribute";
 	public static final String COLLECTION_ATTRIBUTE = "jakarta.persistence.metamodel.CollectionAttribute";

--- a/tooling/metamodel-generator/src/main/java/org/hibernate/jpamodelgen/util/Constants.java
+++ b/tooling/metamodel-generator/src/main/java/org/hibernate/jpamodelgen/util/Constants.java
@@ -94,6 +94,7 @@ public final class Constants {
 	public static final String HIB_SESSION_FACTORY = "org.hibernate.SessionFactory";
 	public static final String HIB_STATELESS_SESSION = "org.hibernate.StatelessSession";
 	public static final String MUTINY_SESSION = "org.hibernate.reactive.mutiny.Mutiny.Session";
+	public static final String QUARKUS_SESSION_OPERATIONS = "io.quarkus.hibernate.reactive.panache.common.runtime.SessionOperations";
 
 	public static final String TUPLE = "jakarta.persistence.Tuple";
 

--- a/tooling/metamodel-generator/src/main/java/org/hibernate/jpamodelgen/util/Constants.java
+++ b/tooling/metamodel-generator/src/main/java/org/hibernate/jpamodelgen/util/Constants.java
@@ -98,6 +98,7 @@ public final class Constants {
 	public static final String TUPLE = "jakarta.persistence.Tuple";
 
 	public static final String UNI = "io.smallrye.mutiny.Uni";
+	public static final String UNI_MUTINY_SESSION = UNI+"<org.hibernate.reactive.mutiny.Mutiny.Session>";
 
 	public static final String SINGULAR_ATTRIBUTE = "jakarta.persistence.metamodel.SingularAttribute";
 	public static final String COLLECTION_ATTRIBUTE = "jakarta.persistence.metamodel.CollectionAttribute";
@@ -129,7 +130,8 @@ public final class Constants {
 					Constants.ENTITY_MANAGER,
 					Constants.HIB_SESSION,
 					Constants.HIB_STATELESS_SESSION,
-					Constants.MUTINY_SESSION
+					Constants.MUTINY_SESSION,
+					Constants.UNI_MUTINY_SESSION
 			);
 
 	//TODO: this is not even an exhaustive list of built-in basic types

--- a/tooling/metamodel-generator/src/quarkusHrPanache/java/org/hibernate/jpamodelgen/test/hrPanache/BookRepositoryWithSession.java
+++ b/tooling/metamodel-generator/src/quarkusHrPanache/java/org/hibernate/jpamodelgen/test/hrPanache/BookRepositoryWithSession.java
@@ -1,0 +1,19 @@
+package org.hibernate.jpamodelgen.test.hrPanache;
+
+import java.util.List;
+
+import org.hibernate.annotations.processing.Find;
+import org.hibernate.reactive.mutiny.Mutiny;
+
+import io.quarkus.hibernate.reactive.panache.common.runtime.SessionOperations;
+import io.smallrye.mutiny.Uni;
+
+public interface BookRepositoryWithSession {
+	
+	public default Uni<Mutiny.Session> mySession() {
+		return SessionOperations.getSession();
+	}
+	
+    @Find
+    public Uni<List<PanacheBook>> findBook(String isbn);
+}

--- a/tooling/metamodel-generator/src/quarkusHrPanache/java/org/hibernate/jpamodelgen/test/hrPanache/PanacheBook.java
+++ b/tooling/metamodel-generator/src/quarkusHrPanache/java/org/hibernate/jpamodelgen/test/hrPanache/PanacheBook.java
@@ -1,0 +1,28 @@
+package org.hibernate.jpamodelgen.test.hrPanache;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+
+import java.util.List;
+
+import org.hibernate.annotations.NaturalId;
+import org.hibernate.annotations.processing.Find;
+import org.hibernate.annotations.processing.HQL;
+
+import io.quarkus.hibernate.reactive.panache.PanacheEntity;
+import io.smallrye.mutiny.Uni;
+
+@Entity
+public class PanacheBook extends PanacheEntity {
+	public @Id String isbn;
+    public @NaturalId String title;
+    public @NaturalId String author;
+    public String text;
+    public int pages;
+    
+    @Find
+    public static native Uni<List<PanacheBook>> findBook(String isbn);
+
+    @HQL("WHERE isbn = :isbn")
+    public static native Uni<List<PanacheBook>> hqlBook(String isbn);
+}

--- a/tooling/metamodel-generator/src/quarkusHrPanache/java/org/hibernate/jpamodelgen/test/hrPanache/PanacheBookRepository.java
+++ b/tooling/metamodel-generator/src/quarkusHrPanache/java/org/hibernate/jpamodelgen/test/hrPanache/PanacheBookRepository.java
@@ -1,0 +1,19 @@
+package org.hibernate.jpamodelgen.test.hrPanache;
+
+import java.util.List;
+
+import org.hibernate.annotations.processing.Find;
+import org.hibernate.annotations.processing.HQL;
+
+import io.quarkus.hibernate.reactive.panache.PanacheRepository;
+import io.smallrye.mutiny.Uni;
+import jakarta.enterprise.context.ApplicationScoped;
+
+@ApplicationScoped
+public class PanacheBookRepository implements PanacheRepository<PanacheBook> {
+    @Find
+    public native Uni<List<PanacheBook>> findBook(String isbn);
+
+    @HQL("WHERE isbn = :isbn")
+    public native Uni<List<PanacheBook>> hqlBook(String isbn);
+}

--- a/tooling/metamodel-generator/src/quarkusHrPanache/java/org/hibernate/jpamodelgen/test/hrPanache/QuarkusBookRepository.java
+++ b/tooling/metamodel-generator/src/quarkusHrPanache/java/org/hibernate/jpamodelgen/test/hrPanache/QuarkusBookRepository.java
@@ -1,0 +1,22 @@
+package org.hibernate.jpamodelgen.test.hrPanache;
+
+import java.util.List;
+
+import org.hibernate.annotations.processing.Find;
+import org.hibernate.annotations.processing.HQL;
+
+import io.smallrye.mutiny.Uni;
+
+public interface QuarkusBookRepository {
+    @Find
+    public Uni<List<PanacheBook>> findBook(String isbn);
+
+    @HQL("WHERE isbn = :isbn")
+    public Uni<List<PanacheBook>> hqlBook(String isbn);
+
+    @HQL("DELETE FROM PanacheBook")
+    public Uni<Void> deleteAllBooksVoid();
+
+    @HQL("DELETE FROM PanacheBook")
+    public Uni<Integer> deleteAllBooksInt();
+}

--- a/tooling/metamodel-generator/src/quarkusOrmPanache/java/org/hibernate/jpamodelgen/test/ormPanache/PanacheBook.java
+++ b/tooling/metamodel-generator/src/quarkusOrmPanache/java/org/hibernate/jpamodelgen/test/ormPanache/PanacheBook.java
@@ -1,0 +1,27 @@
+package org.hibernate.jpamodelgen.test.ormPanache;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+
+import java.util.List;
+
+import org.hibernate.annotations.NaturalId;
+import org.hibernate.annotations.processing.Find;
+import org.hibernate.annotations.processing.HQL;
+
+import io.quarkus.hibernate.orm.panache.PanacheEntity;
+
+@Entity
+public class PanacheBook extends PanacheEntity {
+	public @Id String isbn;
+    public @NaturalId String title;
+    public @NaturalId String author;
+    public String text;
+    public int pages;
+    
+    @Find
+    public static native List<PanacheBook> findBook(String isbn);
+
+    @HQL("WHERE isbn = :isbn")
+    public static native List<PanacheBook> hqlBook(String isbn);
+}

--- a/tooling/metamodel-generator/src/quarkusOrmPanache/java/org/hibernate/jpamodelgen/test/ormPanache/PanacheBookRepository.java
+++ b/tooling/metamodel-generator/src/quarkusOrmPanache/java/org/hibernate/jpamodelgen/test/ormPanache/PanacheBookRepository.java
@@ -1,0 +1,18 @@
+package org.hibernate.jpamodelgen.test.ormPanache;
+
+import java.util.List;
+
+import org.hibernate.annotations.processing.Find;
+import org.hibernate.annotations.processing.HQL;
+
+import io.quarkus.hibernate.orm.panache.PanacheRepository;
+import jakarta.enterprise.context.ApplicationScoped;
+
+@ApplicationScoped
+public class PanacheBookRepository implements PanacheRepository<PanacheBook> {
+    @Find
+    public native List<PanacheBook> findBook(String isbn);
+
+    @HQL("WHERE isbn = :isbn")
+    public native List<PanacheBook> hqlBook(String isbn);
+}

--- a/tooling/metamodel-generator/src/quarkusOrmPanache/java/org/hibernate/jpamodelgen/test/ormPanache/QuarkusBookRepository.java
+++ b/tooling/metamodel-generator/src/quarkusOrmPanache/java/org/hibernate/jpamodelgen/test/ormPanache/QuarkusBookRepository.java
@@ -1,0 +1,14 @@
+package org.hibernate.jpamodelgen.test.ormPanache;
+
+import java.util.List;
+
+import org.hibernate.annotations.processing.Find;
+import org.hibernate.annotations.processing.HQL;
+
+public interface QuarkusBookRepository {
+    @Find
+    public List<PanacheBook> findBook(String isbn);
+
+    @HQL("WHERE isbn = :isbn")
+    public List<PanacheBook> hqlBook(String isbn);
+}

--- a/tooling/metamodel-generator/src/quarkusOrmPanache/java/org/hibernate/jpamodelgen/test/ormPanache/QuarkusOrmPanacheTest.java
+++ b/tooling/metamodel-generator/src/quarkusOrmPanache/java/org/hibernate/jpamodelgen/test/ormPanache/QuarkusOrmPanacheTest.java
@@ -1,0 +1,75 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.jpamodelgen.test.ormPanache;
+
+import org.hibernate.jpamodelgen.test.util.CompilationTest;
+import org.hibernate.jpamodelgen.test.util.TestUtil;
+import org.hibernate.jpamodelgen.test.util.WithClasses;
+import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+
+import jakarta.persistence.EntityManager;
+
+import static org.hibernate.jpamodelgen.test.util.TestUtil.getMetamodelClassFor;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+
+/**
+ * @author Gavin King
+ */
+public class QuarkusOrmPanacheTest extends CompilationTest {
+	@Test
+	@WithClasses({ PanacheBook.class })
+	public void testPanacheEntityMetamodel() throws Exception {
+		// Panache entity
+		System.out.println( TestUtil.getMetaModelSourceAsString( PanacheBook.class ) );
+		Class<?> entityClass = getMetamodelClassFor( PanacheBook.class );
+		Assertions.assertNotNull(entityClass);
+		
+		// Make sure it has the proper supertype
+		Class<?> superclass = entityClass.getSuperclass();
+		if(superclass != null) {
+			Assertions.assertEquals("io.quarkus.hibernate.orm.panache.PanacheEntity_", superclass.getName());
+		}
+		
+		// Panache static native method generates a static method
+		Method method = entityClass.getDeclaredMethod("hqlBook", EntityManager.class, String.class);
+		Assertions.assertNotNull(method);
+		Assertions.assertTrue(Modifier.isStatic(method.getModifiers()));
+
+		// Panache static native method generates a static method
+		method = entityClass.getDeclaredMethod("findBook", EntityManager.class, String.class);
+		Assertions.assertNotNull(method);
+		Assertions.assertTrue(Modifier.isStatic(method.getModifiers()));
+	}
+
+	@Test
+	@WithClasses({ PanacheBook.class, PanacheBookRepository.class })
+	public void testPanacheRepositoryMetamodel() throws Exception {
+		// Panache repository
+		System.out.println( TestUtil.getMetaModelSourceAsString( PanacheBookRepository.class ) );
+		Class<?> repositoryClass = getMetamodelClassFor( PanacheBookRepository.class );
+		Assertions.assertNotNull(repositoryClass);
+		
+		// Make sure it has the proper supertype
+		Class<?> superclass = repositoryClass.getSuperclass();
+		if(superclass != null) {
+			Assertions.assertEquals("java.lang.Object", superclass.getName());
+		}
+		
+		// Panache native method generates a static method
+		Method method = repositoryClass.getDeclaredMethod("hqlBook", EntityManager.class, String.class);
+		Assertions.assertNotNull(method);
+		Assertions.assertTrue(Modifier.isStatic(method.getModifiers()));
+
+		// Panache native method generates a static method
+		method = repositoryClass.getDeclaredMethod("findBook", EntityManager.class, String.class);
+		Assertions.assertNotNull(method);
+		Assertions.assertTrue(Modifier.isStatic(method.getModifiers()));
+	}
+}

--- a/tooling/metamodel-generator/src/test/java/org/hibernate/jpamodelgen/test/util/CompilationRunner.java
+++ b/tooling/metamodel-generator/src/test/java/org/hibernate/jpamodelgen/test/util/CompilationRunner.java
@@ -61,6 +61,7 @@ public class CompilationRunner extends BlockJUnit4ClassRunner {
 
 		return new CompilationStatement(
 				statement,
+				getTestClass().getJavaClass(),
 				testEntities,
 				preCompileEntities,
 				mappingFiles,

--- a/tooling/metamodel-generator/src/test/java/org/hibernate/jpamodelgen/test/util/CompilationTest.java
+++ b/tooling/metamodel-generator/src/test/java/org/hibernate/jpamodelgen/test/util/CompilationTest.java
@@ -22,7 +22,7 @@ public abstract class CompilationTest {
 
 	@After
 	public void cleanup() throws Exception {
-		TestUtil.deleteProcessorGeneratedFiles();
+		TestUtil.deleteProcessorGeneratedFiles(getClass());
 	}
 }
 

--- a/tooling/metamodel-generator/src/test/java/org/hibernate/jpamodelgen/test/util/TestUtil.java
+++ b/tooling/metamodel-generator/src/test/java/org/hibernate/jpamodelgen/test/util/TestUtil.java
@@ -181,7 +181,7 @@ public class TestUtil {
 	public static void assertNoCompilationError(List<Diagnostic<?>> diagnostics) {
 		for ( Diagnostic<?> diagnostic : diagnostics ) {
 			if ( diagnostic.getKind().equals( Diagnostic.Kind.ERROR ) ) {
-				fail( "There was a compilation error during annotation processing:\n" + diagnostic.getMessage( null ) );
+				fail( "There was a compilation error during annotation processing:\n" + diagnostic );
 			}
 		}
 	}


### PR DESCRIPTION
Please @gavinking can you review this?

- Support ORM/HR+Panache types such as anything that extends `PanacheEntityBase` or `PanacheRepositoryBase` to make sure to use their session getter type, but never generate a DAO because Quarkus will call the generated static methods. Also support annotations on `native` methods.
- Support `Uni<Mutiny.Session>` session types
- Support session getters with a default implementation, in which case never store the session in a field but always call the getter. This is mostly because reactive sessions can't be stored in a CDI context and need to be obtained for each call.
- Fix update/delete method return types that have to return `Uni<Integer|Void>` for HR
- When ORM/HR+Panache is detected, for types that are _not_ Panache entities or repositories, default to the Quarkus way of obtaining a session unless there's a session getter declared. The default way being `@Inject EntityManager` for ORM and `SessionOperations.getSession()` for HR. Note that this doesn't respect non-default PU for ORM, but we can improve later, if we have an entity defined (for Panache, we can override the PU per entity), and meanwhile users can always define a session getter to override. HR/Panache doesn't support non-default PU so this is not an issue.

Also, do you want docs for the changes? Tests?