### PR TITLE
HHH-17551 Gradle enterprise update 

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -5,7 +5,7 @@ Hibernate implements JPA, the standard API for object/relational persistence in 
 See https://hibernate.org/orm/[Hibernate.org] for more information.
 
 image:https://ci.hibernate.org/job/hibernate-orm-pipeline/job/main/badge/icon[Build Status,link=https://ci.hibernate.org/job/hibernate-orm-pipeline/job/main/]
-image:https://img.shields.io/badge/Revved%20up%20by-Gradle%20Enterprise-06A0CE?logo=Gradle&labelColor=02303A[link=https://ge.hibernate.org/scans]
+image:https://img.shields.io/badge/Revved%20up%20by-Develocity-06A0CE?logo=Gradle&labelColor=02303A[link=https://ge.hibernate.org/scans]
 
 == Continuous Integration
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -19,8 +19,8 @@ pluginManagement {
 
 plugins {
     id 'org.hibernate.orm.build.env-settings'
-    id 'com.gradle.enterprise' version '3.13.4'
-    id 'com.gradle.common-custom-user-data-gradle-plugin' version '1.11'
+    id 'com.gradle.enterprise' version '3.16'
+    id 'com.gradle.common-custom-user-data-gradle-plugin' version '1.12.1'
 }
 
 // version catalog support

--- a/settings.gradle
+++ b/settings.gradle
@@ -235,7 +235,9 @@ buildCache {
     }
     remote(HttpBuildCache) {
         enabled = true
-        push = settings.ext.populateRemoteBuildCache
+        // Check access key presence to avoid build cache errors on PR builds when access key is not present
+        def accessKey = System.getenv("GRADLE_ENTERPRISE_ACCESS_KEY")
+        push = settings.ext.populateRemoteBuildCache && accessKey
         url = 'https://ge.hibernate.org/cache/'
     }
 }


### PR DESCRIPTION
- Updated Revved up by Gradle Enterprise badge to say Revved up by Develocity (after GE -> Develocity rename)
- Bumped Gradle Enterprise and Common Custom User Data plugins to latest versions
- Updated build cache config to only push when authenticated

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-17551
<!-- Hibernate GitHub Bot issue links end -->