### PR TITLE
[HHH-17571] Prepare legacy date/time type handlers to convert to/from modern JSR-310 types

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/CalendarDateJavaType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/CalendarDateJavaType.java
@@ -7,14 +7,24 @@
 package org.hibernate.type.descriptor.java;
 
 import java.sql.Types;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.time.temporal.ChronoField;
+import java.time.temporal.Temporal;
+import java.time.temporal.TemporalAccessor;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.GregorianCalendar;
+import java.util.TimeZone;
 
 import jakarta.persistence.TemporalType;
 
 import org.hibernate.dialect.Dialect;
 import org.hibernate.internal.util.compare.CalendarComparator;
+import org.hibernate.type.descriptor.DateTimeUtils;
 import org.hibernate.type.descriptor.WrapperOptions;
 import org.hibernate.type.descriptor.jdbc.JdbcType;
 import org.hibernate.type.descriptor.jdbc.JdbcTypeIndicators;
@@ -98,6 +108,12 @@ public class CalendarDateJavaType extends AbstractTemporalJavaType<Calendar> {
 		if ( Calendar.class.isAssignableFrom( type ) ) {
 			return (X) value;
 		}
+		if ( Temporal.class.isAssignableFrom( type ) ) {
+			Temporal temporal = DateTimeUtils.calendarToTemporal( value, type.asSubclass( Temporal.class ) );
+			if ( temporal != null ) {
+				return (X) temporal;
+			}
+		}
 		if ( java.sql.Date.class.isAssignableFrom( type ) ) {
 			return (X) new java.sql.Date( value.getTimeInMillis() );
 		}
@@ -117,8 +133,15 @@ public class CalendarDateJavaType extends AbstractTemporalJavaType<Calendar> {
 		if ( value == null ) {
 			return null;
 		}
-		if (value instanceof Calendar) {
+		if ( value instanceof Calendar ) {
 			return (Calendar) value;
+		}
+		if ( value instanceof Temporal ) {
+			Temporal temporal = (Temporal) value;
+			Calendar cal = DateTimeUtils.temporalToCalendar(temporal);
+			if ( cal != null ) {
+				return cal;
+			}
 		}
 
 		if ( !(value instanceof Date)) {

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/CalendarJavaType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/CalendarJavaType.java
@@ -8,6 +8,7 @@ package org.hibernate.type.descriptor.java;
 
 import java.sql.Types;
 import java.time.ZonedDateTime;
+import java.time.temporal.Temporal;
 import java.util.Calendar;
 import java.util.GregorianCalendar;
 
@@ -16,6 +17,7 @@ import jakarta.persistence.TemporalType;
 import org.hibernate.dialect.Dialect;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.internal.util.compare.CalendarComparator;
+import org.hibernate.type.descriptor.DateTimeUtils;
 import org.hibernate.type.descriptor.WrapperOptions;
 import org.hibernate.type.descriptor.jdbc.JdbcType;
 import org.hibernate.type.descriptor.jdbc.JdbcTypeIndicators;
@@ -115,6 +117,12 @@ public class CalendarJavaType extends AbstractTemporalJavaType<Calendar> impleme
 		if ( Calendar.class.isAssignableFrom( type ) ) {
 			return (X) value;
 		}
+		if ( Temporal.class.isAssignableFrom( type ) ) {
+			Temporal temporal = DateTimeUtils.calendarToTemporal( value, type.asSubclass( Temporal.class ) );
+			if ( temporal != null ) {
+				return (X) temporal;
+			}
+		}
 		if ( java.sql.Date.class.isAssignableFrom( type ) ) {
 			return (X) new java.sql.Date( value.getTimeInMillis() );
 		}
@@ -136,6 +144,12 @@ public class CalendarJavaType extends AbstractTemporalJavaType<Calendar> impleme
 		}
 		if (value instanceof Calendar) {
 			return (Calendar) value;
+		}
+		if ( value instanceof Temporal ) {
+			Calendar cal = DateTimeUtils.temporalToCalendar((Temporal) value);
+			if ( cal != null ) {
+				return cal;
+			}
 		}
 
 		if ( !(value instanceof java.util.Date)) {


### PR DESCRIPTION
In the future, when JSR-310 types are used by default, entities using legacy date/time fields will fail to map to/from result sets unless their type handlers are specifically adapted to do so.

This PR only touches the handlers for `Calendar`, because those are the ones that broke when I experimented with replacing `java.sql.Date` with `LocalDate`. However, it seems likely that the handlers for `java.sql.Date`, `java.util.Date`, `java.sql.Time`, and `java.sql.Timestamp` may also need similar converters in the future. If so, the converters to/from `Calendar` could serve as a "conversion hub" for these legacy types. I will expand out my testing to these types, but in the meantime I would like to solicit feedback on this general approach.

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-17571
<!-- Hibernate GitHub Bot issue links end -->