### PR TITLE
HHH-16144 AbstractManagedType should look up declared concrete generic attributes before super attributes

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/AbstractManagedType.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/AbstractManagedType.java
@@ -39,6 +39,7 @@ import static org.hibernate.internal.util.collections.CollectionHelper.isEmpty;
  * Functionality common to all implementations of {@link ManagedType}.
  *
  * @author Steve Ebersole
+ * @author Yanming Zhou
  */
 public abstract class AbstractManagedType<J>
 		extends AbstractDomainType<J>
@@ -152,7 +153,13 @@ public abstract class AbstractManagedType<J>
 	@Override
 	public PersistentAttribute<? super J,?> findAttribute(String name) {
 		// first look at declared attributes
-		final PersistentAttribute<J,?> attribute = findDeclaredAttribute( name );
+		PersistentAttribute<J,?> attribute = findDeclaredAttribute( name );
+		if ( attribute != null ) {
+			return attribute;
+		}
+
+		// second look at declared concrete generic attributes
+		attribute = findDeclaredConcreteGenericAttribute( name );
 		if ( attribute != null ) {
 			return attribute;
 		}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/generics/EmbeddedIdGenericsSuperclassTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/generics/EmbeddedIdGenericsSuperclassTest.java
@@ -31,6 +31,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author Marco Belladelli
+ * @author Yanming Zhou
  */
 @DomainModel(annotatedClasses = {
 		EmbeddedIdGenericsSuperclassTest.Customer.class,
@@ -81,7 +82,7 @@ public class EmbeddedIdGenericsSuperclassTest {
 			final CriteriaQuery<Customer> query = cb.createQuery( Customer.class );
 			final Root<Customer> root = query.from( Customer.class );
 			final Path<DomainEntityId> id = root.get( "id" );
-			assertThat( id.getJavaType() ).isEqualTo( DomainEntityId.class );
+			assertThat( id.getJavaType() ).isEqualTo( CustomerId.class );
 			assertThat( id.getModel() ).isSameAs( root.getModel().getAttribute( "id" ) );
 			assertThat( ( (SqmPath<?>) id ).getResolvedModel().getBindableJavaType() ).isEqualTo( CustomerId.class );
 			query.select( root ).where( cb.equal( id.get( "someDomainField" ), 1 ) );
@@ -111,7 +112,7 @@ public class EmbeddedIdGenericsSuperclassTest {
 			final CriteriaQuery<Invoice> query = cb.createQuery( Invoice.class );
 			final Root<Invoice> root = query.from( Invoice.class );
 			final Path<DomainEntityId> id = root.get( "id" );
-			assertThat( id.getJavaType() ).isEqualTo( DomainEntityId.class );
+			assertThat( id.getJavaType() ).isEqualTo( InvoiceId.class );
 			assertThat( id.getModel() ).isSameAs( root.getModel().getAttribute( "id" ) );
 			assertThat( ( (SqmPath<?>) id ).getResolvedModel().getBindableJavaType() ).isEqualTo( InvoiceId.class );
 			query.select( root ).where( cb.equal( id.get( "someOtherDomainField" ), 1 ) );

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/generics/GenericBasicValuedPathTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/generics/GenericBasicValuedPathTest.java
@@ -28,6 +28,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author Marco Belladelli
+ * @author Yanming Zhou
  */
 @SessionFactory
 @DomainModel( annotatedClasses = {
@@ -53,8 +54,7 @@ public class GenericBasicValuedPathTest {
 			final CriteriaQuery<Object> query = cb.createQuery();
 			final Root<MyEntity> root = query.from( MyEntity.class );
 			final Path<String> idPath = root.get( "id" );
-			// generic attributes are always reported as Object java type
-			assertThat( idPath.getJavaType() ).isEqualTo( Object.class );
+			assertThat( idPath.getJavaType() ).isEqualTo( Integer.class );
 			assertThat( idPath.getModel() ).isSameAs( root.getModel().getAttribute( "id" ) );
 			assertThat( ( (SqmPath<?>) idPath ).getResolvedModel().getBindableJavaType() ).isEqualTo( Integer.class );
 			final Object result = session.createQuery( query.select( idPath ) ).getSingleResult();
@@ -69,8 +69,7 @@ public class GenericBasicValuedPathTest {
 			final CriteriaQuery<Object> query = cb.createQuery();
 			final Root<MyEntity> root = query.from( MyEntity.class );
 			final Path<String> dataPath = root.get( "data" );
-			// generic attributes are always reported as Object java type
-			assertThat( dataPath.getJavaType() ).isEqualTo( Object.class );
+			assertThat( dataPath.getJavaType() ).isEqualTo( String.class );
 			assertThat( dataPath.getModel() ).isSameAs( root.getModel().getAttribute( "data" ) );
 			assertThat( ( (SqmPath<?>) dataPath ).getResolvedModel().getBindableJavaType() ).isEqualTo( String.class );
 			final Object result = session.createQuery( query.select( dataPath ) ).getSingleResult();

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/generics/GenericMapAssociationTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/generics/GenericMapAssociationTest.java
@@ -34,6 +34,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author Marco Belladelli
+ * @author Yanming Zhou
  */
 @SessionFactory
 @DomainModel( annotatedClasses = {
@@ -81,8 +82,7 @@ public class GenericMapAssociationTest {
 			final CriteriaQuery<Long> query = cb.createQuery( Long.class );
 			final Root<MapContainerEntity> root = query.from( MapContainerEntity.class );
 			final Join<MapContainerEntity, MapValueEntity> join = root.join( "map" );
-			// generic attributes are always reported as Object java type
-			assertThat( join.getJavaType() ).isEqualTo( Object.class );
+			assertThat( join.getJavaType() ).isEqualTo( MapValueEntity.class );
 			assertThat( join.getModel() ).isSameAs( root.getModel().getAttribute( "map" ) );
 			assertThat( ( (SqmPath<?>) join ).getResolvedModel()
 								.getBindableJavaType() ).isEqualTo( MapValueEntity.class );

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/generics/GenericMappedSuperclassAssociationTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/generics/GenericMappedSuperclassAssociationTest.java
@@ -34,6 +34,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author Marco Belladelli
+ * @author Yanming Zhou
  */
 @DomainModel( annotatedClasses = {
 		GenericMappedSuperclassAssociationTest.Parent.class,
@@ -86,7 +87,7 @@ public class GenericMappedSuperclassAssociationTest {
 			final CriteriaQuery<ChildB> cq = cb.createQuery( ChildB.class );
 			final Root<ChildB> from = cq.from( ChildB.class );
 			final Path<Object> parent = from.get( "parent" );
-			assertThat( parent.getModel().getBindableJavaType() ).isEqualTo( Parent.class );
+			assertThat( parent.getModel().getBindableJavaType() ).isEqualTo( ParentB.class );
 			assertThat( ( (SqmPath<?>) parent ).getResolvedModel().getBindableJavaType() ).isEqualTo( ParentB.class );
 			cq.select( from ).where( cb.equal( from.get( "parent" ).get( "id" ), 2L ) );
 			final ChildB result = session.createQuery( cq ).getSingleResult();

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/generics/GenericToManyAssociationTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/generics/GenericToManyAssociationTest.java
@@ -34,6 +34,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 /**
  * @author Yoann Rodière
  * @author Marco Belladelli
+ * @author Yanming Zhou
  */
 @SessionFactory
 @DomainModel( annotatedClasses = {
@@ -82,8 +83,7 @@ public class GenericToManyAssociationTest {
 			final CriteriaQuery<Long> query = cb.createQuery( Long.class );
 			final Root<Child> root = query.from( Child.class );
 			final Path<Parent> parent = root.get( "parent" );
-			// generic attributes are always reported as Object java type
-			assertThat( parent.getJavaType() ).isEqualTo( Object.class );
+			assertThat( parent.getJavaType() ).isEqualTo( Parent.class );
 			assertThat( parent.getModel() ).isSameAs( root.getModel().getAttribute( "parent" ) );
 			assertThat( ( (SqmPath<?>) parent ).getResolvedModel().getBindableJavaType() ).isEqualTo( Parent.class );
 			final Long result = session.createQuery( query.select( parent.get( "id" ) ) ).getSingleResult();
@@ -106,8 +106,7 @@ public class GenericToManyAssociationTest {
 			final CriteriaQuery<Long> query = cb.createQuery( Long.class );
 			final Root<Parent> root = query.from( Parent.class );
 			final Join<Parent, Child> join = root.join( "children" );
-			// generic attributes are always reported as Object java type
-			assertThat( join.getJavaType() ).isEqualTo( Object.class );
+			assertThat( join.getJavaType() ).isEqualTo( Child.class );
 			assertThat( join.getModel() ).isSameAs( root.getModel().getAttribute( "children" ) );
 			assertThat( ( (SqmPath<?>) join ).getResolvedModel().getBindableJavaType() ).isEqualTo( Child.class );
 			final Long result = session.createQuery( query.select( join.get( "id" ) ) ).getSingleResult();

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/generics/GenericToOneAssociationTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/generics/GenericToOneAssociationTest.java
@@ -30,6 +30,7 @@ import jakarta.persistence.criteria.Root;
 /**
  * @author Yoann Rodière
  * @author Marco Belladelli
+ * @author Yanming Zhou
  */
 @SessionFactory
 @DomainModel( annotatedClasses = {
@@ -78,8 +79,7 @@ public class GenericToOneAssociationTest {
 			final CriteriaQuery<Long> query = cb.createQuery( Long.class );
 			final Root<Child> root = query.from( Child.class );
 			final Path<Parent> parent = root.get( "parent" );
-			// generic attributes are always reported as Object java type
-			assertThat( parent.getJavaType() ).isEqualTo( Object.class );
+			assertThat( parent.getJavaType() ).isEqualTo( Parent.class );
 			assertThat( parent.getModel() ).isSameAs( root.getModel().getAttribute( "parent" ) );
 			assertThat( ( (SqmPath<?>) parent ).getResolvedModel().getBindableJavaType() ).isEqualTo( Parent.class );
 			final Long result = session.createQuery( query.select( parent.get( "id" ) ) ).getSingleResult();
@@ -102,8 +102,7 @@ public class GenericToOneAssociationTest {
 			final CriteriaQuery<Long> query = cb.createQuery( Long.class );
 			final Root<Parent> root = query.from( Parent.class );
 			final Join<Parent, Child> join = root.join( "child" );
-			// generic attributes are always reported as Object java type
-			assertThat( join.getJavaType() ).isEqualTo( Object.class );
+			assertThat( join.getJavaType() ).isEqualTo( Child.class );
 			assertThat( join.getModel() ).isSameAs( root.getModel().getAttribute( "child" ) );
 			assertThat( ( (SqmPath<?>) join ).getResolvedModel().getBindableJavaType() ).isEqualTo( Child.class );
 			final Long result = session.createQuery( query.select( join.get( "id" ) ) ).getSingleResult();

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/generics/MultipleEmbeddedGenericsTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/generics/MultipleEmbeddedGenericsTest.java
@@ -30,6 +30,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author Marco Belladelli
+ * @author Yanming Zhou
  */
 @DomainModel(annotatedClasses = {
 		MultipleEmbeddedGenericsTest.Customer.class,
@@ -74,12 +75,12 @@ public class MultipleEmbeddedGenericsTest {
 			final CriteriaQuery<Customer> query = cb.createQuery( Customer.class );
 			final Root<Customer> root = query.from( Customer.class );
 			final Path<CustomerEmbeddableOne> firstEmbedded = root.get( "firstEmbedded" );
-			assertThat( firstEmbedded.getJavaType() ).isEqualTo( GenericEmbeddableOne.class );
+			assertThat( firstEmbedded.getJavaType() ).isEqualTo( CustomerEmbeddableOne.class );
 			assertThat( firstEmbedded.getModel() ).isSameAs( root.getModel().getAttribute( "firstEmbedded" ) );
 			assertThat( ( (SqmPath<?>) firstEmbedded ).getResolvedModel().getBindableJavaType() )
 					.isEqualTo( CustomerEmbeddableOne.class );
 			final Path<CustomerEmbeddableTwo> secondEmbedded = root.get( "secondEmbedded" );
-			assertThat( secondEmbedded.getJavaType() ).isEqualTo( GenericEmbeddableTwo.class );
+			assertThat( secondEmbedded.getJavaType() ).isEqualTo( CustomerEmbeddableTwo.class );
 			assertThat( secondEmbedded.getModel() ).isSameAs( root.getModel().getAttribute( "secondEmbedded" ) );
 			assertThat( ( (SqmPath<?>) secondEmbedded ).getResolvedModel().getBindableJavaType() )
 					.isEqualTo( CustomerEmbeddableTwo.class );
@@ -110,12 +111,12 @@ public class MultipleEmbeddedGenericsTest {
 			final CriteriaQuery<Invoice> query = cb.createQuery( Invoice.class );
 			final Root<Invoice> root = query.from( Invoice.class );
 			final Path<InvoiceEmbeddableOne> firstEmbedded = root.get( "firstEmbedded" );
-			assertThat( firstEmbedded.getJavaType() ).isEqualTo( GenericEmbeddableOne.class );
+			assertThat( firstEmbedded.getJavaType() ).isEqualTo( InvoiceEmbeddableOne.class );
 			assertThat( firstEmbedded.getModel() ).isSameAs( root.getModel().getAttribute( "firstEmbedded" ) );
 			assertThat( ( (SqmPath<?>) firstEmbedded ).getResolvedModel().getBindableJavaType() )
 					.isEqualTo( InvoiceEmbeddableOne.class );
 			final Path<InvoiceEmbeddableTwo> secondEmbedded = root.get( "secondEmbedded" );
-			assertThat( secondEmbedded.getJavaType() ).isEqualTo( GenericEmbeddableTwo.class );
+			assertThat( secondEmbedded.getJavaType() ).isEqualTo( InvoiceEmbeddableTwo.class );
 			assertThat( secondEmbedded.getModel() ).isSameAs( root.getModel().getAttribute( "secondEmbedded" ) );
 			assertThat( ( (SqmPath<?>) secondEmbedded ).getResolvedModel().getBindableJavaType() )
 					.isEqualTo( InvoiceEmbeddableTwo.class );

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/metamodel/genericmodel/GenericMappedSuperclassMetamodelTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/metamodel/genericmodel/GenericMappedSuperclassMetamodelTest.java
@@ -1,0 +1,59 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.orm.test.metamodel.genericmodel;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.MappedSuperclass;
+import jakarta.persistence.metamodel.EntityType;
+import org.hibernate.testing.orm.junit.EntityManagerFactoryScope;
+import org.hibernate.testing.orm.junit.Jpa;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * @author Yanming Zhou
+ */
+@Jpa(
+		annotatedClasses = {
+				GenericMappedSuperclassMetamodelTest.Book.class,
+				GenericMappedSuperclassMetamodelTest.Owner.class,
+				GenericMappedSuperclassMetamodelTest.OwnerContainer.class
+		}
+)
+public class GenericMappedSuperclassMetamodelTest {
+
+	@Test
+	public void testGenericAttributeFromMappedSuperclassIsNotTypeErased(EntityManagerFactoryScope scope) {
+		scope.inTransaction( entityManager -> {
+			EntityType<Book> bookType = entityManager.getMetamodel().entity( Book.class );
+			assertEquals( Owner.class, bookType.getAttribute("owner").getJavaType() );
+		});
+	}
+
+	@Entity
+	public static class Book extends OwnerContainer<Owner> {
+
+		@Id
+		private Long id;
+	}
+
+	@Entity
+	public static class Owner {
+		@Id
+		private Long id;
+	}
+
+	@MappedSuperclass
+	public static class OwnerContainer<T> {
+
+		@ManyToOne
+		T owner;
+	}
+}


### PR DESCRIPTION
Fix 
```
java.lang.IllegalArgumentException: Unable to locate Attribute with the given name [xxx] on this ManagedType [java.lang.Object]
	at org.hibernate.metamodel.model.domain.AbstractManagedType.checkNotNull(AbstractManagedType.java:225) ~[hibernate-core-6.3.1.Final.jar:6.3.1.Final]
	at org.hibernate.metamodel.model.domain.AbstractManagedType.getAttribute(AbstractManagedType.java:148) ~[hibernate-core-6.3.1.Final.jar:6.3.1.Final]
	at org.hibernate.metamodel.model.domain.AbstractManagedType.getAttribute(AbstractManagedType.java:43) ~[hibernate-core-6.3.1.Final.jar:6.3.1.Final]
	at org.springframework.data.jpa.repository.query.QueryUtils.requiresOuterJoin(QueryUtils.java:836) ~[spring-data-jpa-3.2.0.jar:3.2.0]
```

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-16144
<!-- Hibernate GitHub Bot issue links end -->