### PR TITLE
HHH-17570 Fix wrong name when checking Oracle autonomous JSON database

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/dialect/OracleServerConfiguration.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/OracleServerConfiguration.java
@@ -81,12 +81,12 @@ public class OracleServerConfiguration {
 	}
 
 	private static boolean isAutonomous(String cloudServiceParam) {
-		return cloudServiceParam != null && List.of( "OLTP", "DWCS", "JSON" ).contains( cloudServiceParam );
+		return cloudServiceParam != null && List.of( "OLTP", "DWCS", "JDCS" ).contains( cloudServiceParam );
 	}
 
 	private static boolean isAutonomous(DatabaseMetaData databaseMetaData) {
 		try (final Statement statement = databaseMetaData.getConnection().createStatement()) {
-			return statement.executeQuery( "select 1 from dual where sys_context('USERENV','CLOUD_SERVICE') in ('OLTP','DWCS','JSON')" ).next();
+			return statement.executeQuery( "select 1 from dual where sys_context('USERENV','CLOUD_SERVICE') in ('OLTP','DWCS','JDCS')" ).next();
 		}
 		catch (SQLException ex) {
 			// Ignore


### PR DESCRIPTION
According to https://docs.oracle.com/en/database/oracle/oracle-database/23/sqlrf/SYS_CONTEXT.html#GUID-B9934A5D-D97B-4E51-B01B-80C76A5BD086

>> Returns DWCS on autonomous database management systems (ADW), OLTP on autonomous transaction processing systems (ATP), and JDCS on autonomous JSON database systems.

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-17570
<!-- Hibernate GitHub Bot issue links end -->