### PR TITLE
HHH-17576 inappropriate use of getDefaultTimestampPrecision() as default precision

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/CalendarDateJavaType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/CalendarDateJavaType.java
@@ -142,6 +142,6 @@ public class CalendarDateJavaType extends AbstractTemporalJavaType<Calendar> {
 
 	@Override
 	public int getDefaultSqlPrecision(Dialect dialect, JdbcType jdbcType) {
-		return dialect.getDefaultTimestampPrecision();
+		return 0;
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/CalendarTimeJavaType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/CalendarTimeJavaType.java
@@ -144,6 +144,9 @@ public class CalendarTimeJavaType extends AbstractTemporalJavaType<Calendar> {
 
 	@Override
 	public int getDefaultSqlPrecision(Dialect dialect, JdbcType jdbcType) {
-		return dialect.getDefaultTimestampPrecision();
+		// times represent repeating events - they
+		// almost never come equipped with seconds,
+		// let alone fractional seconds!
+		return 0;
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/DateJavaType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/DateJavaType.java
@@ -52,6 +52,7 @@ public class DateJavaType extends AbstractTemporalJavaType<Date> implements Vers
 
 	@Override
 	public int getDefaultSqlPrecision(Dialect dialect, JdbcType jdbcType) {
+		// this "Date" is really a timestamp
 		return dialect.getDefaultTimestampPrecision();
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/JdbcTimeJavaType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/JdbcTimeJavaType.java
@@ -273,7 +273,10 @@ public class JdbcTimeJavaType extends AbstractTemporalJavaType<Date> {
 
 	@Override
 	public int getDefaultSqlPrecision(Dialect dialect, JdbcType jdbcType) {
-		return dialect.getDefaultTimestampPrecision();
+		// times represent repeating events - they
+		// almost never come equipped with seconds,
+		// let alone fractional seconds!
+		return 0;
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/LocalTimeJavaType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/LocalTimeJavaType.java
@@ -189,7 +189,10 @@ public class LocalTimeJavaType extends AbstractTemporalJavaType<LocalTime> {
 
 	@Override
 	public int getDefaultSqlPrecision(Dialect dialect, JdbcType jdbcType) {
-		return dialect.getDefaultTimestampPrecision();
+		// times represent repeating events - they
+		// almost never come equipped with seconds,
+		// let alone fractional seconds!
+		return 0;
 	}
 
 }

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/OffsetTimeJavaType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/OffsetTimeJavaType.java
@@ -251,7 +251,10 @@ public class OffsetTimeJavaType extends AbstractTemporalJavaType<OffsetTime> {
 
 	@Override
 	public int getDefaultSqlPrecision(Dialect dialect, JdbcType jdbcType) {
-		return dialect.getDefaultTimestampPrecision();
+		// times represent repeating events - they
+		// almost never come equipped with seconds,
+		// let alone fractional seconds!
+		return 0;
 	}
 
 }

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/sql/spi/DdlTypeRegistry.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/sql/spi/DdlTypeRegistry.java
@@ -162,9 +162,6 @@ public class DdlTypeRegistry implements Serializable {
 				return getTypeName( typeCode, Size.precision( dialect.getFloatPrecision() ) );
 			case SqlTypes.DOUBLE:
 				return getTypeName( typeCode, Size.precision( dialect.getDoublePrecision() ) );
-			case SqlTypes.TIME:
-			case SqlTypes.TIME_WITH_TIMEZONE:
-			case SqlTypes.TIME_UTC:
 			case SqlTypes.TIMESTAMP:
 			case SqlTypes.TIMESTAMP_WITH_TIMEZONE:
 			case SqlTypes.TIMESTAMP_UTC:

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/compliance/LocalTimeTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/compliance/LocalTimeTest.java
@@ -35,8 +35,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 )
 public class LocalTimeTest {
 
-	private static final LocalTime LOCAL_TIME = DateTimeUtils.adjustToDefaultPrecision(
-			LocalTime.now(),
+	private static final LocalTime LOCAL_TIME = DateTimeUtils.adjustToPrecision(
+			LocalTime.now(), 0,
 			DialectContext.getDialect()
 	);
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/javatime/GlobalJavaTimeJdbcTypeTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/javatime/GlobalJavaTimeJdbcTypeTests.java
@@ -45,6 +45,7 @@ import jakarta.persistence.Table;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hibernate.type.descriptor.DateTimeUtils.adjustToDefaultPrecision;
+import static org.hibernate.type.descriptor.DateTimeUtils.adjustToPrecision;
 
 /**
  * Tests for "direct" JDBC handling of {@linkplain java.time Java Time} types.
@@ -177,7 +178,7 @@ public class GlobalJavaTimeJdbcTypeTests {
 	@SkipForDialect(dialectClass = AltibaseDialect.class, reason = "Altibase drivers truncate fractional seconds from the LocalTime")
 	void testLocalTime(SessionFactoryScope scope) {
 		final Dialect dialect = scope.getSessionFactory().getJdbcServices().getDialect();
-		final LocalTime startTime = adjustToDefaultPrecision( LocalTime.now(), dialect );
+		final LocalTime startTime = adjustToPrecision( LocalTime.now(), 0, dialect );
 
 		scope.inTransaction( (session) -> {
 			final EntityWithJavaTimeValues entity = new EntityWithJavaTimeValues();

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/javatime/JavaTimeJdbcTypeTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/javatime/JavaTimeJdbcTypeTests.java
@@ -46,6 +46,7 @@ import jakarta.persistence.Table;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hibernate.type.descriptor.DateTimeUtils.adjustToDefaultPrecision;
+import static org.hibernate.type.descriptor.DateTimeUtils.adjustToPrecision;
 
 /**
  * Tests for "direct" JDBC handling of {@linkplain java.time Java Time} types.
@@ -178,7 +179,7 @@ public class JavaTimeJdbcTypeTests {
 	@SkipForDialect(dialectClass = AltibaseDialect.class, reason = "Altibase drivers truncate fractional seconds from the LocalTime")
 	void testLocalTime(SessionFactoryScope scope) {
 		final Dialect dialect = scope.getSessionFactory().getJdbcServices().getDialect();
-		final LocalTime startTime = adjustToDefaultPrecision( LocalTime.now(), dialect );
+		final LocalTime startTime = adjustToPrecision( LocalTime.now(), 0, dialect );
 
 		scope.inTransaction( (session) -> {
 			final EntityWithJavaTimeValues entity = new EntityWithJavaTimeValues();

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/temporal/FractionalSecondsTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/temporal/FractionalSecondsTests.java
@@ -63,9 +63,9 @@ public class FractionalSecondsTests {
 		final PersistentClass entityBinding = scope.getEntityBinding( TestEntity.class );
 		checkPrecision( "theInstant", defaultPrecision, entityBinding, domainModel );
 		checkPrecision( "theLocalDateTime", defaultPrecision, entityBinding, domainModel );
-		checkPrecision( "theLocalTime", defaultPrecision, entityBinding, domainModel );
+		checkPrecision( "theLocalTime", 0, entityBinding, domainModel );
 		checkPrecision( "theOffsetDateTime", defaultPrecision, entityBinding, domainModel );
-		checkPrecision( "theOffsetTime", defaultPrecision, entityBinding, domainModel );
+		checkPrecision( "theOffsetTime", 0, entityBinding, domainModel );
 		checkPrecision( "theZonedDateTime", defaultPrecision, entityBinding, domainModel );
 
 		final PersistentClass entityBinding0 = scope.getEntityBinding( TestEntity0.class );

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/temporal/JavaTimeFractionalSecondsTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/temporal/JavaTimeFractionalSecondsTests.java
@@ -65,9 +65,9 @@ public class JavaTimeFractionalSecondsTests {
 		final PersistentClass entityBinding = scope.getEntityBinding( TestEntity.class );
 		checkPrecision( "theInstant", defaultPrecision, entityBinding, domainModel );
 		checkPrecision( "theLocalDateTime", defaultPrecision, entityBinding, domainModel );
-		checkPrecision( "theLocalTime", defaultPrecision, entityBinding, domainModel );
+		checkPrecision( "theLocalTime", 0, entityBinding, domainModel );
 		checkPrecision( "theOffsetDateTime", defaultPrecision, entityBinding, domainModel );
-		checkPrecision( "theOffsetTime", defaultPrecision, entityBinding, domainModel );
+		checkPrecision( "theOffsetTime", 0, entityBinding, domainModel );
 		checkPrecision( "theZonedDateTime", defaultPrecision, entityBinding, domainModel );
 
 		final PersistentClass entityBinding0 = scope.getEntityBinding( TestEntity0.class );


### PR DESCRIPTION
The default precision returned by `getDefaultTimestampPrecision()` is only appropriate for timestamps (hence the name) and should not be used for dates or plain times.

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-17576
<!-- Hibernate GitHub Bot issue links end -->