### PR TITLE
Provide a way to override global env properties in a test ConnectionProviderBuilder

### DIFF
--- a/hibernate-testing/src/main/java/org/hibernate/testing/env/ConnectionProviderBuilder.java
+++ b/hibernate-testing/src/main/java/org/hibernate/testing/env/ConnectionProviderBuilder.java
@@ -12,6 +12,7 @@ import java.lang.reflect.Proxy;
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.util.Collections;
+import java.util.Map;
 import java.util.Properties;
 import javax.sql.DataSource;
 
@@ -26,7 +27,6 @@ import org.hibernate.internal.util.ReflectHelper;
 
 import org.hibernate.testing.DialectCheck;
 import org.hibernate.testing.jdbc.ConnectionProviderDelegate;
-import org.hibernate.testing.jdbc.SharedDriverManagerConnectionProviderImpl;
 import org.hibernate.testing.util.ServiceRegistryUtil;
 
 /**
@@ -46,7 +46,14 @@ public class ConnectionProviderBuilder implements DialectCheck {
 	public static final String PASS = "";
 
 	public static Properties getConnectionProviderProperties(String dbName) {
+		return getConnectionProviderProperties( dbName, Collections.emptyMap() );
+	}
+
+	public static Properties getConnectionProviderProperties(String dbName, Map<String, String> environmentOverrides) {
 		final Properties globalProperties = Environment.getProperties();
+		// since returned global properties are a copy, we just add our overrides to them:
+		globalProperties.putAll( environmentOverrides );
+
 		assert globalProperties.getProperty( Environment.URL ).startsWith( "jdbc:h2:" )
 				: "Connection provider properties are only usable when running against H2";
 		final Properties props = new Properties( null );
@@ -93,6 +100,10 @@ public class ConnectionProviderBuilder implements DialectCheck {
 
 	public static ConnectionProvider buildConnectionProvider(String dbName) {
 		return buildConnectionProvider( getConnectionProviderProperties( dbName ), false );
+	}
+
+	public static ConnectionProvider buildConnectionProvider(String dbName, Map<String, String> environmentOverrides) {
+		return buildConnectionProvider( getConnectionProviderProperties( dbName, environmentOverrides ), false );
 	}
 
 	public static ConnectionProvider buildDataSourceConnectionProvider(String dbName) {


### PR DESCRIPTION
Hey 😃 

We are using this `ConnectionProviderBuilder` in Search tests and in those cases, we usually have database settings coming from a Junit extension, which may be too late as `Environment.getProperties()` are already initialized. These changes would allow us to pass the settings from an extension into this builder. 

Let me know if it makes sense to apply this, or if maybe you have other suggestions on how we can address the problem at hand 😃.