### PR TITLE
HHH-17619/HHH-17620 Stateless session multi tenancy + filters

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/Session.java
+++ b/hibernate-core/src/main/java/org/hibernate/Session.java
@@ -1260,37 +1260,13 @@ public interface Session extends SharedSessionContract, EntityManager {
 	 */
 	<T> NaturalIdMultiLoadAccess<T> byMultipleNaturalId(String entityName);
 
-	/**
-	 * Enable the named {@linkplain Filter filter} for this current session.
-	 * <p>
-	 * The returned {@link Filter} object must be used to bind arguments
-	 * to parameters of the filter, and every parameter must be set before
-	 * any other operation of this session is called.
-	 *
-	 * @param filterName the name of the filter to be enabled.
-	 *
-	 * @return the {@link Filter} instance representing the enabled filter.
-	 *
-	 * @throws UnknownFilterException if there is no such filter
-	 *
-	 * @see org.hibernate.annotations.FilterDef
-	 */
+	@Override
 	Filter enableFilter(String filterName);
 
-	/**
-	 * Retrieve a currently enabled {@linkplain Filter filter} by name.
-	 *
-	 * @param filterName the name of the filter to be retrieved.
-	 *
-	 * @return the {@link Filter} instance representing the enabled filter.
-	 */
+	@Override
 	Filter getEnabledFilter(String filterName);
 
-	/**
-	 * Disable the named {@linkplain Filter filter} for the current session.
-	 *
-	 * @param filterName the name of the filter to be disabled.
-	 */
+	@Override
 	void disableFilter(String filterName);
 	
 	/**

--- a/hibernate-core/src/main/java/org/hibernate/SharedSessionContract.java
+++ b/hibernate-core/src/main/java/org/hibernate/SharedSessionContract.java
@@ -313,6 +313,39 @@ public interface SharedSessionContract extends QueryProducer, Closeable, Seriali
 	<T> List<EntityGraph<? super T>> getEntityGraphs(Class<T> entityClass);
 
 	/**
+	 * Enable the named {@linkplain Filter filter} for this current session.
+	 * <p>
+	 * The returned {@link Filter} object must be used to bind arguments
+	 * to parameters of the filter, and every parameter must be set before
+	 * any other operation of this session is called.
+	 *
+	 * @param filterName the name of the filter to be enabled.
+	 *
+	 * @return the {@link Filter} instance representing the enabled filter.
+	 *
+	 * @throws UnknownFilterException if there is no such filter
+	 *
+	 * @see org.hibernate.annotations.FilterDef
+	 */
+	Filter enableFilter(String filterName);
+
+	/**
+	 * Retrieve a currently enabled {@linkplain Filter filter} by name.
+	 *
+	 * @param filterName the name of the filter to be retrieved.
+	 *
+	 * @return the {@link Filter} instance representing the enabled filter.
+	 */
+	Filter getEnabledFilter(String filterName);
+
+	/**
+	 * Disable the named {@linkplain Filter filter} for the current session.
+	 *
+	 * @param filterName the name of the filter to be disabled.
+	 */
+	void disableFilter(String filterName);
+
+	/**
 	 * The factory which created this session.
 	 */
 	SessionFactory getFactory();

--- a/hibernate-core/src/main/java/org/hibernate/engine/spi/SharedSessionDelegatorBaseImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/spi/SharedSessionDelegatorBaseImpl.java
@@ -14,6 +14,7 @@ import jakarta.persistence.criteria.CriteriaUpdate;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 import org.hibernate.CacheMode;
+import org.hibernate.Filter;
 import org.hibernate.FlushMode;
 import org.hibernate.HibernateException;
 import org.hibernate.Interceptor;
@@ -650,5 +651,20 @@ public class SharedSessionDelegatorBaseImpl implements SharedSessionContractImpl
 	@Override
 	public <T> List<EntityGraph<? super T>> getEntityGraphs(Class<T> entityClass) {
 		return delegate.getEntityGraphs( entityClass );
+	}
+
+	@Override
+	public Filter enableFilter(String filterName) {
+		return delegate.enableFilter( filterName );
+	}
+
+	@Override
+	public Filter getEnabledFilter(String filterName) {
+		return delegate.getEnabledFilter( filterName );
+	}
+
+	@Override
+	public void disableFilter(String filterName) {
+		delegate.disableFilter( filterName );
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/internal/AbstractSharedSessionContract.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/AbstractSharedSessionContract.java
@@ -21,6 +21,7 @@ import java.util.function.Function;
 import jakarta.persistence.EntityGraph;
 import org.hibernate.CacheMode;
 import org.hibernate.EntityNameResolver;
+import org.hibernate.Filter;
 import org.hibernate.FlushMode;
 import org.hibernate.HibernateException;
 import org.hibernate.Interceptor;
@@ -1489,6 +1490,28 @@ public abstract class AbstractSharedSessionContract implements SharedSessionCont
 	public <T> List<EntityGraph<? super T>> getEntityGraphs(Class<T> entityClass) {
 		checkOpen();
 		return getFactory().findEntityGraphsByType( entityClass );
+	}
+
+	// filter support ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+	@Override
+	public Filter getEnabledFilter(String filterName) {
+		pulseTransactionCoordinator();
+		return getLoadQueryInfluencers().getEnabledFilter( filterName );
+	}
+
+	@Override
+	public Filter enableFilter(String filterName) {
+		checkOpen();
+		pulseTransactionCoordinator();
+		return getLoadQueryInfluencers().enableFilter( filterName );
+	}
+
+	@Override
+	public void disableFilter(String filterName) {
+		checkOpen();
+		pulseTransactionCoordinator();
+		getLoadQueryInfluencers().disableFilter( filterName );
 	}
 
 	private void writeObject(ObjectOutputStream oos) throws IOException {

--- a/hibernate-core/src/main/java/org/hibernate/internal/AbstractSharedSessionContract.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/AbstractSharedSessionContract.java
@@ -29,7 +29,9 @@ import org.hibernate.SessionEventListener;
 import org.hibernate.SessionException;
 import org.hibernate.Transaction;
 import org.hibernate.UnknownEntityTypeException;
+import org.hibernate.binder.internal.TenantIdBinder;
 import org.hibernate.cache.spi.CacheTransactionSynchronization;
+import org.hibernate.context.spi.CurrentTenantIdentifierResolver;
 import org.hibernate.engine.internal.SessionEventListenerManagerImpl;
 import org.hibernate.engine.jdbc.LobCreator;
 import org.hibernate.engine.jdbc.connections.spi.JdbcConnectionAccess;
@@ -38,6 +40,7 @@ import org.hibernate.engine.jdbc.spi.JdbcCoordinator;
 import org.hibernate.engine.jdbc.spi.JdbcServices;
 import org.hibernate.engine.spi.EntityKey;
 import org.hibernate.engine.spi.ExceptionConverter;
+import org.hibernate.engine.spi.LoadQueryInfluencers;
 import org.hibernate.engine.spi.SessionEventListenerManager;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
@@ -224,6 +227,24 @@ public abstract class AbstractSharedSessionContract implements SharedSessionCont
 	private static boolean isTransactionCoordinatorShared(SessionCreationOptions options) {
 		return options instanceof SharedSessionCreationOptions
 			&& ( (SharedSessionCreationOptions) options ).isTransactionCoordinatorShared();
+	}
+
+	protected final void setUpMultitenancy(SessionFactoryImplementor factory, LoadQueryInfluencers loadQueryInfluencers) {
+		if ( factory.getDefinedFilterNames().contains( TenantIdBinder.FILTER_NAME ) ) {
+			final Object tenantIdentifier = getTenantIdentifierValue();
+			if ( tenantIdentifier == null ) {
+				throw new HibernateException( "SessionFactory configured for multi-tenancy, but no tenant identifier specified" );
+			}
+			else {
+				final CurrentTenantIdentifierResolver<Object> resolver = factory.getCurrentTenantIdentifierResolver();
+				if ( resolver==null || !resolver.isRoot( tenantIdentifier ) ) {
+					// turn on the filter, unless this is the "root" tenant with access to all partitions
+					loadQueryInfluencers
+							.enableFilter( TenantIdBinder.FILTER_NAME )
+							.setParameter( TenantIdBinder.PARAMETER_NAME, tenantIdentifier );
+				}
+			}
+		}
 	}
 
 	private void logInconsistentOptions(SharedSessionCreationOptions sharedOptions) {

--- a/hibernate-core/src/main/java/org/hibernate/internal/SessionImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/SessionImpl.java
@@ -1893,29 +1893,6 @@ public class SessionImpl
 		return loadQueryInfluencers;
 	}
 
-	// filter support ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-	@Override
-	public Filter getEnabledFilter(String filterName) {
-		pulseTransactionCoordinator();
-		return loadQueryInfluencers.getEnabledFilter( filterName );
-	}
-
-	@Override
-	public Filter enableFilter(String filterName) {
-		checkOpen();
-		pulseTransactionCoordinator();
-		return loadQueryInfluencers.enableFilter( filterName );
-	}
-
-	@Override
-	public void disableFilter(String filterName) {
-		checkOpen();
-		pulseTransactionCoordinator();
-		loadQueryInfluencers.disableFilter( filterName );
-	}
-
-
 	// fetch profile support ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/internal/StatelessSessionImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/StatelessSessionImpl.java
@@ -80,6 +80,7 @@ public class StatelessSessionImpl extends AbstractSharedSessionContract implemen
 		connectionProvided = options.getConnection() != null;
 		temporaryPersistenceContext = new StatefulPersistenceContext( this );
 		influencers = new LoadQueryInfluencers( getFactory() );
+		setUpMultitenancy( factory, influencers );
 	}
 
 	@Override

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/filter/AbstractStatefulStatelessFilterTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/filter/AbstractStatefulStatelessFilterTest.java
@@ -1,0 +1,40 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.orm.test.filter;
+
+import java.util.List;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+
+import org.hibernate.StatelessSession;
+import org.hibernate.engine.spi.SessionImplementor;
+
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.hibernate.testing.orm.junit.SessionFactoryScopeAware;
+import org.junit.jupiter.params.provider.Arguments;
+
+@SessionFactory
+public abstract class AbstractStatefulStatelessFilterTest implements SessionFactoryScopeAware {
+
+	protected SessionFactoryScope scope;
+
+	@Override
+	public void injectSessionFactoryScope(SessionFactoryScope scope) {
+		this.scope = scope;
+	}
+
+	protected List<? extends Arguments> transactionKind() {
+		// We want to test both regular and stateless session:
+		BiConsumer<SessionFactoryScope, Consumer<SessionImplementor>> kind1 = SessionFactoryScope::inTransaction;
+		BiConsumer<SessionFactoryScope, Consumer<StatelessSession>> kind2 = SessionFactoryScope::inStatelessTransaction;
+		return List.of(
+				Arguments.of( kind1 ),
+				Arguments.of( kind2 )
+		);
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/filter/secondarytable/SecondaryTableTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/filter/secondarytable/SecondaryTableTest.java
@@ -7,23 +7,32 @@
 package org.hibernate.orm.test.filter.secondarytable;
 
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+
 import org.hibernate.Session;
+import org.hibernate.SharedSessionContract;
+import org.hibernate.orm.test.filter.AbstractStatefulStatelessFilterTest;
 
-import org.hibernate.testing.junit4.BaseCoreFunctionalTestCase;
-import org.hibernate.testing.transaction.TransactionUtil;
-import org.junit.Assert;
-import org.junit.Test;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
-public class SecondaryTableTest extends BaseCoreFunctionalTestCase {
+@DomainModel(
+		annotatedClasses = {
+				User.class
+		}
+)
+public class SecondaryTableTest extends AbstractStatefulStatelessFilterTest {
 
-	@Override
-	protected Class<?>[] getAnnotatedClasses() {
-		return new Class[] {User.class};
-	}
-
-	@Override
-	protected void prepareTest() throws Exception {
-		TransactionUtil.doInHibernate( this::sessionFactory, s -> {
+	@BeforeEach
+	void prepareTest() {
+		scope.inTransaction( s -> {
 			insertUser( s, "q@s.com", 21, false, "a1", "b" );
 			insertUser( s, "r@s.com", 22, false, "a2", "b" );
 			insertUser( s, "s@s.com", 23, true, "a3", "b" );
@@ -31,19 +40,26 @@ public class SecondaryTableTest extends BaseCoreFunctionalTestCase {
 		} );
 	}
 
-	@Test
-	public void testFilter() {
-		try (Session session = openSession()) {
+	@AfterEach
+	void tearDown() {
+		scope.inTransaction( s -> {
+			s.createQuery( "delete from User" ).executeUpdate();
+		} );
+	}
+
+	@ParameterizedTest
+	@MethodSource("transactionKind")
+	void testFilter(BiConsumer<SessionFactoryScope, Consumer<? extends SharedSessionContract>> inTransaction) {
+		inTransaction.accept( scope, session -> {
 /*			Assert.assertEquals(
 					4L,
 					session.createQuery( "select count(u) from User u" ).uniqueResult()
 			);*/
 			session.enableFilter( "ageFilter" ).setParameter( "age", 24 );
-			Assert.assertEquals(
-					2L,
+			assertThat(
 					session.createQuery( "select count(u) from User u" ).uniqueResult()
-			);
-		}
+			).isEqualTo( 2L );
+		} );
 	}
 
 	private void insertUser(

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/filter/subclass/MappedSuperclass/FilterInheritanceTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/filter/subclass/MappedSuperclass/FilterInheritanceTest.java
@@ -6,34 +6,36 @@
  */
 package org.hibernate.orm.test.filter.subclass.MappedSuperclass;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.util.List;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
 
-import org.hibernate.Transaction;
-
-import org.junit.Test;
+import org.hibernate.SharedSessionContract;
+import org.hibernate.orm.test.filter.AbstractStatefulStatelessFilterTest;
 
 import org.hibernate.testing.TestForIssue;
-import org.hibernate.testing.junit4.BaseCoreFunctionalTestCase;
-
-import static org.hamcrest.core.Is.is;
-import static org.hibernate.testing.transaction.TransactionUtil.doInHibernate;
-import static org.junit.Assert.assertThat;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 /**
  * @author Andrea Boriero
  */
+@DomainModel(
+		annotatedClasses = {
+				Animal.class, Human.class, Mammal.class
+		}
+)
+public class FilterInheritanceTest extends AbstractStatefulStatelessFilterTest {
 
-public class FilterInheritanceTest extends BaseCoreFunctionalTestCase {
-	private Transaction transaction;
-
-	@Override
-	public Class[] getAnnotatedClasses() {
-		return new Class[] {Animal.class, Human.class, Mammal.class};
-	}
-
-	@Override
+	@BeforeEach
 	protected void prepareTest() throws Exception {
-		doInHibernate( this::sessionFactory, session -> {
+		scope.inTransaction( session -> {
 			Mammal mammal = new Mammal();
 			mammal.setName( "unimportant" );
 			session.persist( mammal );
@@ -48,22 +50,28 @@ public class FilterInheritanceTest extends BaseCoreFunctionalTestCase {
 		} );
 	}
 
-	@Override
-	protected boolean isCleanupTestDataRequired() {
-		return true;
-	}
-
-	@Test
-	@TestForIssue(jiraKey = "HHH-8895")
-	public void testSelectFromHuman() throws Exception {
-		doInHibernate( this::sessionFactory, session -> {
-			session.enableFilter( "nameFilter" ).setParameter( "name", "unimportant" );
-
-			List humans = session.createQuery( "SELECT h FROM Human h" ).list();
-
-			assertThat( humans.size(), is( 1 ) );
-			Human human = (Human) humans.get( 0 );
-			assertThat( human.getName(), is( "unimportant" ) );
+	@AfterEach
+	public void tearDown() throws Exception {
+		scope.inTransaction( session -> {
+			session.createQuery( "delete from Mammal" ).executeUpdate();
+			session.createQuery( "delete from Human" ).executeUpdate();
 		} );
 	}
+
+	@ParameterizedTest
+	@MethodSource("transactionKind")
+	@TestForIssue(jiraKey = "HHH-8895")
+	public void testSelectFromHuman(
+			BiConsumer<SessionFactoryScope, Consumer<? extends SharedSessionContract>> inTransaction) {
+		inTransaction.accept( scope, session -> {
+			session.enableFilter( "nameFilter" ).setParameter( "name", "unimportant" );
+
+			List<Human> humans = session.createQuery( "SELECT h FROM Human h", Human.class ).list();
+
+			assertThat( humans ).hasSize( 1 );
+			Human human = humans.get( 0 );
+			assertThat( human.getName() ).isEqualTo( "unimportant" );
+		} );
+	}
+
 }

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/filter/subclass/SubClassTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/filter/subclass/SubClassTest.java
@@ -6,79 +6,67 @@
  */
 package org.hibernate.orm.test.filter.subclass;
 
-import junit.framework.Assert;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import org.hibernate.testing.junit4.BaseCoreFunctionalTestCase;
-import org.junit.Test;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
 
-public abstract class SubClassTest extends BaseCoreFunctionalTestCase{
-	
-	@Override
-	protected void prepareTest() throws Exception {
-		openSession();
-		session.beginTransaction();
-		
-		persistTestData();
-		
-		session.getTransaction().commit();
-		session.close();
+import org.hibernate.SharedSessionContract;
+import org.hibernate.engine.spi.SessionImplementor;
+import org.hibernate.orm.test.filter.AbstractStatefulStatelessFilterTest;
+
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+public abstract class SubClassTest extends AbstractStatefulStatelessFilterTest {
+
+	@BeforeEach
+	void prepareTest() {
+		scope.inTransaction( this::persistTestData );
 	}
-	
-	protected abstract void persistTestData();
-	
-	@Override
+
+	protected abstract void persistTestData(SessionImplementor session);
+
+	@AfterEach
 	protected void cleanupTest() throws Exception {
-		openSession();
-		session.beginTransaction();
-		
-		session.createQuery("delete from Human").executeUpdate();
-		
-		session.getTransaction().commit();
-		session.close();
+		scope.inTransaction( session -> session.createQuery( "delete from Human" ).executeUpdate() );
 	}
 
-	@Test
-	public void testIqFilter(){
-		openSession();
-		session.beginTransaction();
-		
-		assertCount(3);	
-		session.enableFilter("iqRange").setParameter("min", 101).setParameter("max", 140);
-		assertCount(1);	
-		
-		session.getTransaction().commit();
-		session.close();
+	@ParameterizedTest
+	@MethodSource("transactionKind")
+	public void testIqFilter(BiConsumer<SessionFactoryScope, Consumer<? extends SharedSessionContract>> inTransaction) {
+		inTransaction.accept( scope, session -> {
+			assertCount( session, 3 );
+			session.enableFilter( "iqRange" ).setParameter( "min", 101 ).setParameter( "max", 140 );
+			assertCount( session, 1 );
+		} );
 	}
 
-	@Test
-	public void testPregnantFilter(){
-		openSession();
-		session.beginTransaction();
-		
-		assertCount(3);	
-		session.enableFilter("pregnantOnly");
-		assertCount(1);	
-		
-		session.getTransaction().commit();
-		session.close();
-	}
-	@Test
-	public void testNonHumanFilter(){
-		openSession();
-		session.beginTransaction();
-		
-		assertCount(3);	
-		session.enableFilter("ignoreSome").setParameter("name", "Homo Sapiens");
-		assertCount(0);	
-		
-		session.getTransaction().commit();
-		session.close();
-	}
-	
-	
-	private void assertCount(long expected){
-		long count = (Long) session.createQuery("select count(h) from Human h").uniqueResult();	
-		Assert.assertEquals(expected, count);
+	@ParameterizedTest
+	@MethodSource("transactionKind")
+	public void testPregnantFilter(BiConsumer<SessionFactoryScope, Consumer<? extends SharedSessionContract>> inTransaction) {
+		inTransaction.accept( scope, session -> {
+			assertCount( session, 3 );
+			session.enableFilter( "pregnantOnly" );
+			assertCount( session, 1 );
+		} );
 	}
 
+	@ParameterizedTest
+	@MethodSource("transactionKind")
+	public void testNonHumanFilter(BiConsumer<SessionFactoryScope, Consumer<? extends SharedSessionContract>> inTransaction) {
+		inTransaction.accept( scope, session -> {
+			assertCount( session, 3 );
+			session.enableFilter( "ignoreSome" ).setParameter( "name", "Homo Sapiens" );
+			assertCount( session, 0 );
+		} );
+	}
+
+	private void assertCount(SharedSessionContract session, long expected) {
+		long count = (Long) session.createQuery( "select count(h) from Human h" ).uniqueResult();
+		assertEquals( expected, count );
+	}
 }

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/filter/subclass/joined/JoinedSubClassTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/filter/subclass/joined/JoinedSubClassTest.java
@@ -6,74 +6,68 @@
  */
 package org.hibernate.orm.test.filter.subclass.joined;
 
-import junit.framework.Assert;
+import static org.assertj.core.api.Assertions.assertThat;
 
+import org.hibernate.engine.spi.SessionImplementor;
 import org.hibernate.orm.test.filter.subclass.SubClassTest;
-import org.junit.Test;
+
 import org.hibernate.testing.orm.junit.DialectFeatureChecks;
+import org.hibernate.testing.orm.junit.DomainModel;
 import org.hibernate.testing.orm.junit.RequiresDialectFeature;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 
-@RequiresDialectFeature( feature = DialectFeatureChecks.SupportsTemporaryTable.class)
-public class JoinedSubClassTest extends SubClassTest{
+@RequiresDialectFeature(feature = DialectFeatureChecks.SupportsTemporaryTable.class)
+@DomainModel(
+		annotatedClasses = {
+				Animal.class, Mammal.class, Human.class, Club.class
+		}
+)
+public class JoinedSubClassTest extends SubClassTest {
 
-	@Override
-	protected Class[] getAnnotatedClasses() {
-		return new Class[]{Animal.class, Mammal.class, Human.class, Club.class};
-	}
-	
-	@Override
+	@AfterEach
 	protected void cleanupTest() throws Exception {
 		super.cleanupTest();
-		openSession();
-		session.beginTransaction();
-		
-		session.createQuery("delete from Club").executeUpdate();
-		
-		session.getTransaction().commit();
-		session.close();
-	}	
-	
+		scope.inTransaction( session -> {
+			session.createQuery( "delete from Club" ).executeUpdate();
+		} );
+	}
+
 	@Override
-	protected void persistTestData() {
+	protected void persistTestData(SessionImplementor session) {
 		Club club = new Club();
-		club.setName("Mensa applicants");
-		club.getMembers().add(createHuman(club, false, 90));
-		club.getMembers().add(createHuman(club, false, 100));
-		club.getMembers().add(createHuman(club, true, 110));
-		session.persist(club);
+		club.setName( "Mensa applicants" );
+		club.getMembers().add( createHuman( session, club, false, 90 ) );
+		club.getMembers().add( createHuman( session, club, false, 100 ) );
+		club.getMembers().add( createHuman( session, club, true, 110 ) );
+		session.persist( club );
 	}
 
 	@Test
-	public void testClub(){
-		openSession();
-		session.beginTransaction();
+	public void testClub() {
+		scope.inTransaction( session -> {
+			Club club = session.createQuery( "from Club", Club.class ).uniqueResult();
+			assertThat( club.getMembers() ).hasSize( 3 );
+			session.clear();
 
-		Club club =  (Club) session.createQuery("from Club").uniqueResult();
-		Assert.assertEquals(3, club.getMembers().size());
-		session.clear();
-		
-		session.enableFilter("pregnantMembers");
-		club =  (Club) session.createQuery("from Club").uniqueResult();
-		Assert.assertEquals(1, club.getMembers().size());
-		session.clear();
-		
-		session.enableFilter("iqMin").setParameter("min", 148);
-		club =  (Club) session.createQuery("from Club").uniqueResult();
-		Assert.assertEquals(0, club.getMembers().size());
-		
-		session.getTransaction().commit();
-		session.close();
+			session.enableFilter( "pregnantMembers" );
+			club = session.createQuery( "from Club", Club.class ).uniqueResult();
+			assertThat( club.getMembers() ).hasSize( 1 );
+			session.clear();
+
+			session.enableFilter( "iqMin" ).setParameter( "min", 148 );
+			club = session.createQuery( "from Club", Club.class ).uniqueResult();
+			assertThat( club.getMembers() ).isEmpty();
+		} );
 	}
-	
-	private Human createHuman(Club club, boolean pregnant, int iq){
+
+	private Human createHuman(SessionImplementor session, Club club, boolean pregnant, int iq) {
 		Human human = new Human();
-		human.setClub(club);
-		human.setName("Homo Sapiens");
-		human.setPregnant(pregnant);
-		human.setIq(iq);
-		session.persist(human);
+		human.setClub( club );
+		human.setName( "Homo Sapiens" );
+		human.setPregnant( pregnant );
+		human.setIq( iq );
+		session.persist( human );
 		return human;
 	}
-	
-
 }

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/filter/subclass/joined2/JoinedInheritanceFilterTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/filter/subclass/joined2/JoinedInheritanceFilterTest.java
@@ -1,30 +1,67 @@
 package org.hibernate.orm.test.filter.subclass.joined2;
 
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import java.util.List;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+
+import org.hibernate.Session;
+import org.hibernate.SharedSessionContract;
+import org.hibernate.StatelessSession;
 import org.hibernate.annotations.FilterDef;
 import org.hibernate.annotations.ParamDef;
+import org.hibernate.engine.spi.SessionImplementor;
+
 import org.hibernate.testing.TestForIssue;
 import org.hibernate.testing.orm.junit.DomainModel;
 import org.hibernate.testing.orm.junit.SessionFactory;
 import org.hibernate.testing.orm.junit.SessionFactoryScope;
-import org.junit.jupiter.api.Test;
+import org.hibernate.testing.orm.junit.SessionFactoryScopeAware;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
-import static org.junit.jupiter.api.Assertions.assertNull;
+import org.assertj.core.util.TriFunction;
 
 @TestForIssue(jiraKey = "HHH-9646")
 @SessionFactory
-@DomainModel(annotatedClasses = {Animal.class, Dog.class, Owner.class, JoinedInheritanceFilterTest.class})
+@DomainModel(annotatedClasses = { Animal.class, Dog.class, Owner.class, JoinedInheritanceFilterTest.class })
 @FilterDef(name = "companyFilter", parameters = @ParamDef(name = "companyIdParam", type = long.class))
-public class JoinedInheritanceFilterTest {
-	@Test public void test(SessionFactoryScope scope) {
-		scope.inTransaction( s -> {
-			s.createQuery("SELECT o FROM Owner o INNER JOIN FETCH o.dog d WHERE o.id = 1").getResultList();
-			s.enableFilter("companyFilter").setParameter("companyIdParam", 2l).validate();
-			s.createQuery("SELECT o FROM Owner o INNER JOIN FETCH o.dog d WHERE o.id = 1").getResultList();
-			s.createQuery("FROM Animal").getResultList();
-			s.createQuery("FROM Dog").getResultList();
-			assertNull( s.find(Owner.class, 1) );
-			assertNull( s.find(Animal.class, 1) );
-			assertNull( s.find(Dog.class, 1) );
-		});
+public class JoinedInheritanceFilterTest implements SessionFactoryScopeAware {
+
+	private SessionFactoryScope scope;
+
+	@Override
+	public void injectSessionFactoryScope(SessionFactoryScope scope) {
+		this.scope = scope;
+	}
+
+	@ParameterizedTest
+	@MethodSource("transactionKind")
+	void test(BiConsumer<SessionFactoryScope, Consumer<? extends SharedSessionContract>> inTransaction,
+			TriFunction<SharedSessionContract, Class<?>, Object, Object> find) {
+		inTransaction.accept( scope, s -> {
+			s.createQuery( "SELECT o FROM Owner o INNER JOIN FETCH o.dog d WHERE o.id = 1" ).getResultList();
+			s.enableFilter( "companyFilter" ).setParameter( "companyIdParam", 2l ).validate();
+			s.createQuery( "SELECT o FROM Owner o INNER JOIN FETCH o.dog d WHERE o.id = 1" ).getResultList();
+			s.createQuery( "FROM Animal" ).getResultList();
+			s.createQuery( "FROM Dog" ).getResultList();
+			assertNull( find.apply( s, Owner.class, 1 ) );
+			assertNull( find.apply( s, Animal.class, 1 ) );
+			assertNull( find.apply( s, Dog.class, 1 ) );
+		} );
+	}
+
+	List<? extends Arguments> transactionKind() {
+		// We want to test both regular and stateless session:
+		BiConsumer<SessionFactoryScope, Consumer<SessionImplementor>> kind1 = SessionFactoryScope::inTransaction;
+		TriFunction<Session, Class<?>, Object, Object> find1 = Session::get;
+		BiConsumer<SessionFactoryScope, Consumer<StatelessSession>> kind2 = SessionFactoryScope::inStatelessTransaction;
+		TriFunction<StatelessSession, Class<?>, Object, Object> find2 = StatelessSession::get;
+		return List.of(
+				Arguments.of( kind1, find1 ),
+				Arguments.of( kind2, find2 )
+		);
 	}
 }

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/filter/subclass/singletable/SingleTableTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/filter/subclass/singletable/SingleTableTest.java
@@ -6,32 +6,32 @@
  */
 package org.hibernate.orm.test.filter.subclass.singletable;
 
+import org.hibernate.engine.spi.SessionImplementor;
 import org.hibernate.orm.test.filter.subclass.SubClassTest;
 
-public class SingleTableTest extends SubClassTest{
+import org.hibernate.testing.orm.junit.DomainModel;
 
+@DomainModel(
+		annotatedClasses = {
+				Animal.class, Mammal.class, Human.class
+		}
+)
+public class SingleTableTest extends SubClassTest {
 
-	
 	@Override
-	protected Class[] getAnnotatedClasses() {
-		return new Class[]{Animal.class, Mammal.class, Human.class};
-	}
-	
-	@Override
-	protected void persistTestData() {
-		createHuman(false, 90);
-		createHuman(false, 100);
-		createHuman(true, 110);
+	protected void persistTestData(SessionImplementor session) {
+		createHuman( session, false, 90 );
+		createHuman( session, false, 100 );
+		createHuman( session, true, 110 );
 	}
 
 
-	private void createHuman(boolean pregnant, int iq){
+	private void createHuman(SessionImplementor session, boolean pregnant, int iq) {
 		Human human = new Human();
-		human.setName("Homo Sapiens");
-		human.setPregnant(pregnant);
-		human.setIq(iq);
-		session.persist(human);
+		human.setName( "Homo Sapiens" );
+		human.setPregnant( pregnant );
+		human.setIq( iq );
+		session.persist( human );
 	}
-	
 
 }

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/filter/subclass/tableperclass/TablePerClassTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/filter/subclass/tableperclass/TablePerClassTest.java
@@ -6,28 +6,31 @@
  */
 package org.hibernate.orm.test.filter.subclass.tableperclass;
 
+import org.hibernate.engine.spi.SessionImplementor;
 import org.hibernate.orm.test.filter.subclass.SubClassTest;
 
-public class TablePerClassTest extends SubClassTest{
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.SessionFactory;
+
+@DomainModel(
+		annotatedClasses = {
+				Animal.class, Mammal.class, Human.class
+		}
+)
+@SessionFactory
+public class TablePerClassTest extends SubClassTest {
 	@Override
-	protected Class[] getAnnotatedClasses() {
-		return new Class[]{Animal.class, Mammal.class, Human.class};
-	}
-	
-	@Override
-	protected void persistTestData() {
-		createHuman(false, 90);
-		createHuman(false, 100);
-		createHuman(true, 110);
+	protected void persistTestData(SessionImplementor session) {
+		createHuman( session, false, 90 );
+		createHuman( session, false, 100 );
+		createHuman( session, true, 110 );
 	}
 
-	private void createHuman(boolean pregnant, int iq){
+	private void createHuman(SessionImplementor session, boolean pregnant, int iq) {
 		Human human = new Human();
-		human.setName("Homo Sapiens");
-		human.setPregnant(pregnant);
-		human.setIq(iq);
-		session.persist(human);
+		human.setName( "Homo Sapiens" );
+		human.setPregnant( pregnant );
+		human.setIq( iq );
+		session.persist( human );
 	}
-	
-
 }

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/tenantid/TenantIdTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/tenantid/TenantIdTest.java
@@ -8,6 +8,7 @@ package org.hibernate.orm.test.tenantid;
 
 import org.hibernate.HibernateError;
 import org.hibernate.PropertyValueException;
+import org.hibernate.StatelessSession;
 import org.hibernate.boot.SessionFactoryBuilder;
 import org.hibernate.boot.spi.MetadataImplementor;
 import org.hibernate.context.spi.CurrentTenantIdentifierResolver;
@@ -20,6 +21,9 @@ import org.hibernate.testing.orm.junit.SessionFactoryProducer;
 import org.hibernate.testing.orm.junit.SessionFactoryScope;
 import org.hibernate.testing.orm.junit.Setting;
 import org.hibernate.binder.internal.TenantIdBinder;
+import org.hibernate.query.criteria.HibernateCriteriaBuilder;
+import org.hibernate.query.criteria.JpaCriteriaQuery;
+import org.hibernate.query.criteria.JpaRoot;
 
 import org.hibernate.testing.orm.junit.SkipForDialect;
 import org.junit.jupiter.api.AfterEach;
@@ -28,6 +32,7 @@ import org.junit.jupiter.api.Test;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.EntityManagerFactory;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.hibernate.cfg.AvailableSettings.JAKARTA_HBM2DDL_DATABASE_ACTION;
 import static org.hibernate.internal.util.collections.CollectionHelper.toMap;
 import static org.hibernate.jpa.HibernateHints.HINT_TENANT_ID;
@@ -36,6 +41,8 @@ import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
+
+import java.util.List;
 
 @SessionFactory
 @DomainModel(annotatedClasses = { Account.class, Client.class, Record.class })
@@ -53,6 +60,7 @@ public class TenantIdTest implements SessionFactoryProducer {
         scope.inTransaction( session -> {
             session.createQuery("delete from Account").executeUpdate();
             session.createQuery("delete from Client").executeUpdate();
+            session.createQuery("delete from Record").executeUpdate();
         });
     }
 
@@ -215,6 +223,34 @@ public class TenantIdTest implements SessionFactoryProducer {
             // for cleanup
             currentTenant = "mine";
         }
+    }
+
+
+    @Test
+    public void tenantFilterWithStatelessSession(SessionFactoryScope scope) {
+        currentTenant = "mine";
+        Record myRecord1 = new Record();
+        Record myRecord2 = new Record();
+
+        scope.inTransaction( session -> {
+            session.persist(myRecord1);
+            session.persist(myRecord2);
+        } );
+        scope.inStatelessTransaction( session -> {
+            assertThat( listAllRecordsForTenant( session ) ).hasSize( 2 );
+        } );
+
+        currentTenant = "yours";
+        scope.inStatelessTransaction( session -> {
+            assertThat( listAllRecordsForTenant( session ) ).isEmpty();
+        } );
+    }
+
+    private static List<Record> listAllRecordsForTenant(StatelessSession session) {
+        HibernateCriteriaBuilder criteriaBuilder = session.getCriteriaBuilder();
+        JpaCriteriaQuery<Record> criteriaQuery = criteriaBuilder.createQuery( Record.class );
+        JpaRoot<Record> from = criteriaQuery.from( Record.class );
+        return session.createQuery( criteriaQuery ).getResultList();
     }
 
     private static void waitALittle() {


### PR DESCRIPTION
I've moved the multitenancy configuration in the first commit and then noticed that filters are not exposed through `StatelessSession` so I've moved a few filter-related methods to `SharedSessionContract` in the next commit. 

if both changes make sense, I'll create JIRAs for both and update the messages.

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-17620
https://hibernate.atlassian.net/browse/HHH-17619
<!-- Hibernate GitHub Bot issue links end -->