### PR TITLE
HHH-17395 Refresh with PESSIMISTIC_WRITE ignored for lazy loaded entity HHH-1645 refresh with LockMode on an unitialized proxy does not work

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/event/internal/DefaultRefreshEventListener.java
+++ b/hibernate-core/src/main/java/org/hibernate/event/internal/DefaultRefreshEventListener.java
@@ -33,6 +33,8 @@ import org.hibernate.loader.ast.spi.CascadingFetchProfile;
 import org.hibernate.metamodel.spi.MappingMetamodelImplementor;
 import org.hibernate.persister.collection.CollectionPersister;
 import org.hibernate.persister.entity.EntityPersister;
+import org.hibernate.proxy.HibernateProxy;
+import org.hibernate.proxy.LazyInitializer;
 import org.hibernate.type.CollectionType;
 import org.hibernate.type.CompositeType;
 import org.hibernate.type.Type;
@@ -62,7 +64,22 @@ public class DefaultRefreshEventListener implements RefreshEventListener {
 		final PersistenceContext persistenceContext = source.getPersistenceContextInternal();
 		final Object object = event.getObject();
 		if ( persistenceContext.reassociateIfUninitializedProxy( object ) ) {
-			if ( isTransient( event, source, object ) ) {
+			final boolean isTransient = isTransient( event, source, object );
+
+			final LazyInitializer lazyInitializer = HibernateProxy.extractLazyInitializer( object );
+			final EntityPersister persister = source.getEntityPersister( lazyInitializer.getEntityName(), object );
+			refresh(
+					event,
+					null,
+					source,
+					persister,
+					lazyInitializer,
+					null,
+					persister.getIdentifier( object, event.getSession() ),
+					persistenceContext
+			);
+
+			if ( isTransient  ) {
 				source.setReadOnly( object, source.isDefaultReadOnly() );
 			}
 		}
@@ -144,9 +161,22 @@ public class DefaultRefreshEventListener implements RefreshEventListener {
 		evictEntity( object, persister, id, source );
 		evictCachedCollections( persister, id, source );
 
+		refresh( event, object, source, persister, null, entry, id, persistenceContext );
+	}
+
+	private static void refresh(
+			RefreshEvent event,
+			Object object,
+			EventSource source,
+			EntityPersister persister,
+			LazyInitializer lazyInitializer,
+			EntityEntry entry,
+			Object id,
+			PersistenceContext persistenceContext) {
+
 		final Object result = source.getLoadQueryInfluencers().fromInternalFetchProfile(
 				CascadingFetchProfile.REFRESH,
-				() -> doRefresh( event, source, object, entry, persister, id, persistenceContext )
+				() -> doRefresh( event, source, object, entry, persister, lazyInitializer, id, persistenceContext )
 		);
 		UnresolvableObjectException.throwIfNull( result, id, persister.getEntityName() );
 	}
@@ -179,6 +209,7 @@ public class DefaultRefreshEventListener implements RefreshEventListener {
 			Object object,
 			EntityEntry entry,
 			EntityPersister persister,
+			LazyInitializer lazyInitializer,
 			Object id,
 			PersistenceContext persistenceContext) {
 		// Handle the requested lock-mode (if one) in relation to the entry's (if one) current lock-mode
@@ -228,17 +259,30 @@ public class DefaultRefreshEventListener implements RefreshEventListener {
 				persistenceContext.getEntry( result ).setLockMode( postRefreshLockMode );
 			}
 
-			// Keep the same read-only/modifiable setting for the entity that it had before refreshing;
-			// If it was transient, then set it to the default for the source.
-			if ( !persister.isMutable() ) {
-				// this is probably redundant; it should already be read-only
-				source.setReadOnly( result, true );
-			}
-			else {
-				source.setReadOnly( result, entry == null ? source.isDefaultReadOnly() : entry.isReadOnly() );
-			}
+			source.setReadOnly( result, isReadOnly( entry, persister, lazyInitializer, source ) );
 		}
 		return result;
+	}
+
+	private static boolean isReadOnly(
+			EntityEntry entry,
+			EntityPersister persister,
+			LazyInitializer lazyInitializer,
+			EventSource source) {
+		// Keep the same read-only/modifiable setting for the entity that it had before refreshing;
+		// If it was transient, then set it to the default for the source.
+		if ( !persister.isMutable() ) {
+			return true;
+		}
+		else if ( entry != null ) {
+			return entry.isReadOnly();
+		}
+		else if ( lazyInitializer != null ) {
+			return lazyInitializer.isReadOnly();
+		}
+		else {
+			return source.isDefaultReadOnly();
+		}
 	}
 
 	private static void evictCachedCollections(EntityPersister persister, Object id, EventSource source) {

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/locking/LockRefreshReferencedTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/locking/LockRefreshReferencedTest.java
@@ -1,0 +1,180 @@
+package org.hibernate.orm.test.locking;
+
+import java.util.List;
+
+import org.hibernate.Hibernate;
+
+import org.hibernate.testing.orm.junit.EntityManagerFactoryScope;
+import org.hibernate.testing.orm.junit.JiraKey;
+import org.hibernate.testing.orm.junit.Jpa;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.LockModeType;
+import jakarta.persistence.OneToOne;
+
+import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+@JiraKey("HHH-17395")
+@Jpa(
+		annotatedClasses = {
+				LockRefreshReferencedTest.MainEntity.class,
+				LockRefreshReferencedTest.ReferencedEntity.class
+		}
+)
+public class LockRefreshReferencedTest {
+
+	@BeforeAll
+	public void setUp(EntityManagerFactoryScope scope) {
+		scope.inTransaction(
+				entityManager -> {
+					final ReferencedEntity e1 = new ReferencedEntity( 0L, "lazy" );
+					final ReferencedEntity e2 = new ReferencedEntity( 1L, "eager" );
+					entityManager.persist( e1 );
+					entityManager.persist( e2 );
+					final MainEntity e3 = new MainEntity( 0L, e1, e2 );
+					entityManager.persist( e3 );
+				}
+		);
+	}
+
+	@Test
+	public void testRefreshBeforeRead(EntityManagerFactoryScope scope) {
+		scope.inTransaction(
+				entityManager -> {
+					MainEntity m = entityManager.find( MainEntity.class, 0L );
+					assertNotNull( m );
+					ReferencedEntity lazyReference = m.referencedLazy();
+					ReferencedEntity eagerReference = m.referencedEager();
+					assertNotNull( lazyReference );
+					assertNotNull( eagerReference );
+					assertFalse( Hibernate.isInitialized( lazyReference ) );
+
+					// First refresh, then access
+					entityManager.refresh( eagerReference, LockModeType.PESSIMISTIC_WRITE );
+					assertFalse( Hibernate.isInitialized( lazyReference ) );
+
+					entityManager.refresh( lazyReference, LockModeType.PESSIMISTIC_WRITE );
+
+					assertEquals( "lazy", lazyReference.status() );
+					assertEquals( "eager", eagerReference.status() );
+					assertEquals( LockModeType.PESSIMISTIC_WRITE, entityManager.getLockMode( lazyReference ) );
+					assertEquals( LockModeType.PESSIMISTIC_WRITE, entityManager.getLockMode( eagerReference ) );
+				} );
+	}
+
+	@Test
+	public void testRefresh(EntityManagerFactoryScope scope) {
+		scope.inTransaction(
+				entityManager -> {
+					MainEntity m = entityManager.find( MainEntity.class, 0L );
+					assertNotNull( m );
+					ReferencedEntity lazyReference = m.referencedLazy();
+					ReferencedEntity eagerReference = m.referencedEager();
+					assertNotNull( lazyReference );
+					assertNotNull( eagerReference );
+					assertFalse( Hibernate.isInitialized( lazyReference ) );
+
+					entityManager.refresh( m );
+					assertFalse( Hibernate.isInitialized( lazyReference ) );
+
+				} );
+	}
+
+	@Test
+	public void testRefreshAfterRead(EntityManagerFactoryScope scope) {
+		scope.inTransaction(
+				entityManager -> {
+					MainEntity m = entityManager.find( MainEntity.class, 0L );
+					assertNotNull( m );
+					ReferencedEntity lazyReference = m.referencedLazy();
+					ReferencedEntity eagerReference = m.referencedEager();
+					assertNotNull( lazyReference );
+					assertNotNull( eagerReference );
+					assertFalse( Hibernate.isInitialized( lazyReference ) );
+
+					// First access, the refresh
+					assertEquals( "lazy", lazyReference.status() );
+					assertEquals( "eager", eagerReference.status() );
+
+					entityManager.refresh( lazyReference, LockModeType.PESSIMISTIC_WRITE );
+					entityManager.refresh( eagerReference, LockModeType.PESSIMISTIC_WRITE );
+
+					assertEquals( LockModeType.PESSIMISTIC_WRITE, entityManager.getLockMode( lazyReference ) );
+					assertEquals( LockModeType.PESSIMISTIC_WRITE, entityManager.getLockMode( eagerReference ) );
+				} );
+	}
+
+
+	@Test
+	public void testFindWithLockMode(EntityManagerFactoryScope scope) {
+		scope.inTransaction(
+				session -> {
+					MainEntity mainEntity = session.find( MainEntity.class, 0L, LockModeType.PESSIMISTIC_WRITE );
+					assertThat( session.getLockMode( mainEntity.referencedEager() ) ).isEqualTo( LockModeType.PESSIMISTIC_WRITE );
+				}
+		);
+	}
+
+	@Entity(name = "MainEntity")
+	public static class MainEntity {
+		@Id
+		private Long id;
+
+		private String name;
+
+		@OneToOne(targetEntity = ReferencedEntity.class, fetch = FetchType.LAZY)
+		@JoinColumn(name = "LAZY_COLUMN")
+		private ReferencedEntity referencedLazy;
+
+		@OneToOne(targetEntity = ReferencedEntity.class, fetch = FetchType.EAGER)
+		@JoinColumn(name = "EAGER_COLUMN")
+		private ReferencedEntity referencedEager;
+
+		protected MainEntity() {
+		}
+
+		public MainEntity(Long id, ReferencedEntity lazy, ReferencedEntity eager) {
+			this.id = id;
+			this.referencedLazy = lazy;
+			this.referencedEager = eager;
+		}
+
+		public ReferencedEntity referencedLazy() {
+			return referencedLazy;
+		}
+
+		public ReferencedEntity referencedEager() {
+			return referencedEager;
+		}
+	}
+
+	@Entity(name = "ReferencedEntity")
+	public static class ReferencedEntity {
+
+		@Id
+		private Long id;
+
+		private String status;
+
+		protected ReferencedEntity() {
+		}
+
+		public ReferencedEntity(Long id, String status) {
+			this.id = id;
+			this.status = status;
+		}
+
+		public String status() {
+			return status;
+		}
+	}
+
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/proxy/ProxyTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/proxy/ProxyTest.java
@@ -24,8 +24,8 @@ import org.hibernate.internal.SessionImpl;
 import org.hibernate.internal.util.SerializationHelper;
 import org.hibernate.proxy.HibernateProxy;
 
-import org.hibernate.testing.FailureExpected;
 import org.hibernate.testing.junit4.BaseCoreFunctionalTestCase;
+import org.hibernate.testing.orm.junit.JiraKey;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
@@ -539,7 +539,7 @@ public class ProxyTest extends BaseCoreFunctionalTestCase {
 	}
 
 	@Test
-	@FailureExpected( jiraKey = "HHH-1645", message = "Session.refresh with LockOptions does not work on uninitialized proxies" )
+	@JiraKey( "HHH-1645" )
 	public void testRefreshLockUninitializedProxy() {
 		Session s = openSession();
 		Transaction t = s.beginTransaction();
@@ -568,7 +568,7 @@ public class ProxyTest extends BaseCoreFunctionalTestCase {
 	}
 
 	@Test
-	@FailureExpected( jiraKey = "HHH-1645", message = "Session.refresh with LockOptions does not work on uninitialized proxies" )
+	@JiraKey( "HHH-1645" )
 	public void testRefreshLockUninitializedProxyThenRead() {
 		Session s = openSession();
 		Transaction t = s.beginTransaction();

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/readonly/ReadOnlyProxyTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/readonly/ReadOnlyProxyTest.java
@@ -1102,7 +1102,7 @@ public class ReadOnlyProxyTest extends AbstractReadOnlyTest {
 		s.setReadOnly( dp, true );
 		assertFalse( Hibernate.isInitialized( dp ) );
 		s.refresh( dp );
-		assertFalse( Hibernate.isInitialized( dp ) );
+		assertTrue( Hibernate.isInitialized( dp ) );
 		assertEquals( "original", dp.getDescription() );
 		assertTrue( Hibernate.isInitialized( dp ) );
 		dp.setDescription( "changed" );
@@ -1232,7 +1232,7 @@ public class ReadOnlyProxyTest extends AbstractReadOnlyTest {
 		assertTrue( s.isReadOnly( dp ) );
 		s.evict( dp );
 		s.refresh( dp );
-		assertFalse( Hibernate.isInitialized( dp ) );
+		assertTrue( Hibernate.isInitialized( dp ) );
 		assertFalse( s.isReadOnly( dp ) );
 		dp.setDescription( "changed" );
 		assertEquals( "changed", dp.getDescription() );

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/readonly/ReadOnlySessionTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/readonly/ReadOnlySessionTest.java
@@ -516,11 +516,11 @@ public class ReadOnlySessionTest extends AbstractReadOnlyTest {
 		assertTrue( s.isReadOnly( dp ) );
 		assertFalse( Hibernate.isInitialized( dp ) );
 		s.refresh( dp );
-		assertFalse( Hibernate.isInitialized( dp ) );
+		assertTrue( Hibernate.isInitialized( dp ) );
 		assertTrue( s.isReadOnly( dp ) );
 		s.setDefaultReadOnly( false );
 		s.refresh( dp );
-		assertFalse( Hibernate.isInitialized( dp ) );
+		assertTrue( Hibernate.isInitialized( dp ) );
 		assertTrue( s.isReadOnly( dp ) );
 		assertEquals( "original", dp.getDescription() );
 		assertTrue( Hibernate.isInitialized( dp ) );
@@ -574,12 +574,12 @@ public class ReadOnlySessionTest extends AbstractReadOnlyTest {
 		assertTrue( s.isReadOnly( dp ) );
 		s.evict( dp );
 		s.refresh( dp );
-		assertFalse( Hibernate.isInitialized( dp ) );
+		assertTrue( Hibernate.isInitialized( dp ) );
 		s.setDefaultReadOnly( false );
 		assertTrue( s.isReadOnly( dp ) );
 		s.evict( dp );
 		s.refresh( dp );
-		assertFalse( Hibernate.isInitialized( dp ) );
+		assertTrue( Hibernate.isInitialized( dp ) );
 		assertFalse( s.isReadOnly( dp ) );
 		assertFalse( s.isReadOnly( ( (HibernateProxy) dp ).getHibernateLazyInitializer().getImplementation() ) );
 		dp.setDescription( "changed" );


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-1645
https://hibernate.atlassian.net/browse/HHH-17395