### PR TITLE
HHH-17641 Improve error message "Could not identify any active SessionFactory" to also show the SessionFactory name

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/proxy/pojo/bytebuddy/SerializableProxy.java
+++ b/hibernate-core/src/main/java/org/hibernate/proxy/pojo/bytebuddy/SerializableProxy.java
@@ -125,7 +125,7 @@ public final class SerializableProxy extends AbstractSerializableProxy {
 			return sessionFactory;
 		}
 		else {
-			throw new IllegalStateException( "Could not identify any active SessionFactory having UUID " + sessionFactoryUuid );
+			throw new IllegalStateException( "Could not identify any active SessionFactory having SessionFactory name " + sessionFactoryName + " or UUID " + sessionFactoryUuid  );
 		}
 	}
 


### PR DESCRIPTION
<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-17641
<!-- Hibernate GitHub Bot issue links end -->