### PR TITLE
HHH 17613 - Generated metamodel contains invalid import when using generics

### DIFF
--- a/tooling/metamodel-generator/src/main/java/org/hibernate/jpamodelgen/ImportContextImpl.java
+++ b/tooling/metamodel-generator/src/main/java/org/hibernate/jpamodelgen/ImportContextImpl.java
@@ -167,6 +167,7 @@ public class ImportContextImpl implements ImportContext {
 		for ( String next : imports ) {
 			// don't add automatically "imported" stuff
 			if ( !isAutoImported( next ) ) {
+				next = next.replaceAll( ">+$", "" );
 				if ( staticImports.contains( next ) ) {
 					builder.append( "import static " ).append( next ).append( ";" ).append( System.lineSeparator() );
 				}

--- a/tooling/metamodel-generator/src/test/java/org/hibernate/jpamodelgen/test/hhh17613/ChildB.java
+++ b/tooling/metamodel-generator/src/test/java/org/hibernate/jpamodelgen/test/hhh17613/ChildB.java
@@ -1,0 +1,7 @@
+package org.hibernate.jpamodelgen.test.hhh17613;
+
+import jakarta.persistence.MappedSuperclass;
+
+@MappedSuperclass
+public abstract class ChildB<A> extends Parent {
+}

--- a/tooling/metamodel-generator/src/test/java/org/hibernate/jpamodelgen/test/hhh17613/HHH17613Test.java
+++ b/tooling/metamodel-generator/src/test/java/org/hibernate/jpamodelgen/test/hhh17613/HHH17613Test.java
@@ -1,0 +1,22 @@
+package org.hibernate.jpamodelgen.test.hhh17613;
+
+import org.hibernate.jpamodelgen.test.hhh17613.a.ChildA;
+import org.hibernate.jpamodelgen.test.util.CompilationTest;
+import org.hibernate.jpamodelgen.test.util.TestForIssue;
+import org.hibernate.jpamodelgen.test.util.TestUtil;
+import org.hibernate.jpamodelgen.test.util.WithClasses;
+
+import org.junit.Test;
+
+@TestForIssue(jiraKey = " HHH-17613")
+public class HHH17613Test extends CompilationTest {
+
+	@Test
+	@WithClasses({ ChildA.class, ChildB.class, Parent.class })
+	@TestForIssue(jiraKey = " HHH-17613")
+	public void test() {
+		System.out.println( TestUtil.getMetaModelSourceAsString( ChildA.class ) );
+		System.out.println( TestUtil.getMetaModelSourceAsString( ChildB.class ) );
+		System.out.println( TestUtil.getMetaModelSourceAsString( Parent.class ) );
+	}
+}

--- a/tooling/metamodel-generator/src/test/java/org/hibernate/jpamodelgen/test/hhh17613/Parent.java
+++ b/tooling/metamodel-generator/src/test/java/org/hibernate/jpamodelgen/test/hhh17613/Parent.java
@@ -1,0 +1,11 @@
+package org.hibernate.jpamodelgen.test.hhh17613;
+
+import jakarta.persistence.Id;
+import jakarta.persistence.MappedSuperclass;
+
+@MappedSuperclass
+public abstract class Parent {
+
+	@Id
+	private Long id;
+}

--- a/tooling/metamodel-generator/src/test/java/org/hibernate/jpamodelgen/test/hhh17613/a/ChildA.java
+++ b/tooling/metamodel-generator/src/test/java/org/hibernate/jpamodelgen/test/hhh17613/a/ChildA.java
@@ -1,0 +1,18 @@
+package org.hibernate.jpamodelgen.test.hhh17613.a;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import org.hibernate.jpamodelgen.test.hhh17613.ChildB;
+import org.hibernate.jpamodelgen.test.hhh17613.Parent;
+
+import jakarta.persistence.MappedSuperclass;
+import jakarta.persistence.OneToMany;
+
+@MappedSuperclass
+public abstract class ChildA<A extends Parent, B extends ChildB<A>> extends Parent {
+
+	@OneToMany
+	private Set<B> bs = new HashSet<>();
+
+}


### PR DESCRIPTION
See Jira issue [HHH-17613](https://hibernate.atlassian.net/browse/HHH-17613)

When creating import statuement trailing >('s) should be removed. 

This soultion will hold until somebody finds another case when it will fail ... like most of the moetamodel generator code :-(

[HHH-17613]: https://hibernate.atlassian.net/browse/HHH-17613?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ