### PR TITLE
HHH-17653 Error in generating schema when @Generator annotation is applied to a non id embeddable property 

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/boot/model/internal/EmbeddableBinder.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/internal/EmbeddableBinder.java
@@ -388,7 +388,15 @@ public class EmbeddableBinder {
 
 			final XProperty property = propertyAnnotatedElement.getProperty();
 			if ( property.isAnnotationPresent( GeneratedValue.class ) ) {
-				processGeneratedId( context, component, property );
+				if ( isIdClass || subholder.isOrWithinEmbeddedId() ) {
+					processGeneratedId( context, component, property );
+				}
+				else {
+					throw new AnnotationException(
+							"Property '" + property.getName() + "' of '"
+									+ getPath( propertyHolder, inferredData )
+									+ "' is annotated '@GeneratedValue' but is not part of an identifier" );
+				}
 			}
 		}
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/idgen/GeneratorNotAppliedToIdEmbeddableFieldsShouldThrowAnExceptionTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/idgen/GeneratorNotAppliedToIdEmbeddableFieldsShouldThrowAnExceptionTest.java
@@ -1,0 +1,70 @@
+package org.hibernate.orm.test.idgen;
+
+import org.hibernate.AnnotationException;
+import org.hibernate.boot.MetadataSources;
+import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
+import org.hibernate.boot.spi.MetadataImplementor;
+import org.hibernate.service.ServiceRegistry;
+
+import org.hibernate.testing.orm.junit.BaseUnitTest;
+import org.hibernate.testing.orm.junit.DialectFeatureChecks;
+import org.hibernate.testing.orm.junit.Jira;
+import org.hibernate.testing.orm.junit.RequiresDialectFeature;
+import org.hibernate.testing.util.ServiceRegistryUtil;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import jakarta.persistence.Embeddable;
+import jakarta.persistence.Embedded;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@BaseUnitTest
+@RequiresDialectFeature(feature = DialectFeatureChecks.SupportsIdentityColumns.class)
+@Jira("HHH-17653")
+public class GeneratorNotAppliedToIdEmbeddableFieldsShouldThrowAnExceptionTest {
+	protected ServiceRegistry serviceRegistry;
+	protected MetadataImplementor metadata;
+
+	@AfterEach
+	public void tearDown() {
+		StandardServiceRegistryBuilder.destroy( serviceRegistry );
+	}
+
+	@Test
+	public void testThatAnAnnotationExceptionIsThrown() {
+		Exception exception = assertThrows( AnnotationException.class, () -> {
+			serviceRegistry = ServiceRegistryUtil.serviceRegistry();
+			metadata = (MetadataImplementor) new MetadataSources( serviceRegistry )
+					.addAnnotatedClass( TestEntity.class )
+					.buildMetadata();
+		} );
+		assertThat( exception.getMessage() ).contains( "Property 'serialValue'" );
+	}
+
+	@Entity(name = "TestEntity")
+	@Table(name = "TEST_ENITY")
+	public static class TestEntity {
+
+		@Id
+		private String id;
+
+		@Embedded
+		private TestEmbeddable testEmbeddable;
+
+	}
+
+	@Embeddable
+	public static class TestEmbeddable {
+
+		@GeneratedValue(strategy = GenerationType.IDENTITY)
+		private Integer serialValue;
+	}
+
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/idgen/GeneratorNotAppliedToIdFieldsShouldThrowAnExceptionTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/idgen/GeneratorNotAppliedToIdFieldsShouldThrowAnExceptionTest.java
@@ -1,0 +1,60 @@
+package org.hibernate.orm.test.idgen;
+
+import org.hibernate.AnnotationException;
+import org.hibernate.boot.MetadataSources;
+import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
+import org.hibernate.boot.spi.MetadataImplementor;
+import org.hibernate.service.ServiceRegistry;
+
+import org.hibernate.testing.orm.junit.BaseUnitTest;
+import org.hibernate.testing.orm.junit.DialectFeatureChecks;
+import org.hibernate.testing.orm.junit.Jira;
+import org.hibernate.testing.orm.junit.RequiresDialectFeature;
+import org.hibernate.testing.util.ServiceRegistryUtil;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@BaseUnitTest
+@RequiresDialectFeature(feature = DialectFeatureChecks.SupportsIdentityColumns.class)
+@Jira("HHH-17653")
+public class GeneratorNotAppliedToIdFieldsShouldThrowAnExceptionTest {
+	protected ServiceRegistry serviceRegistry;
+	protected MetadataImplementor metadata;
+
+	@AfterEach
+	public void tearDown() {
+		StandardServiceRegistryBuilder.destroy( serviceRegistry );
+	}
+
+	@Test
+	public void testThatAnAnnotationExceptionIsThrown() {
+		Exception exception = assertThrows( AnnotationException.class, () -> {
+			serviceRegistry = ServiceRegistryUtil.serviceRegistry();
+			metadata = (MetadataImplementor) new MetadataSources( serviceRegistry )
+					.addAnnotatedClass( TestEntity.class )
+					.buildMetadata();
+		} );
+		assertThat( exception.getMessage() ).contains( "Property '" + TestEntity.class.getName() + ".name'" );
+	}
+
+	@Entity(name = "TestEntity")
+	@Table(name = "TEST_ENITY")
+	public static class TestEntity {
+
+		@Id
+		private String id;
+
+		@GeneratedValue(strategy = GenerationType.IDENTITY)
+		private String name;
+
+	}
+}


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-17653

before 6.4.0 Hibernate just silently ignored `@GeneratedValue` applied to a fields not belonging to an identifier, but after the changes made for https://hibernate.atlassian.net/browse/HHH-15074 if a field of an embeddable is annotatted with `@GeneratedValue` the strategy is applied to the entity identifier that contains the embeddable.

My change log a warning not only for this use case but every time a non id property is annotated with `@GeneratedValue`.