### PR TITLE
Hhh-17562 Allow disabling of  NaturalIDCaching

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/boot/SessionFactoryBuilder.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/SessionFactoryBuilder.java
@@ -120,6 +120,19 @@ public interface SessionFactoryBuilder {
 	SessionFactoryBuilder applyStatisticsSupport(boolean enabled);
 
 	/**
+	 * Allows you to disable hibernates NaturalID Cache.
+	 * This might be confusing because there is also {@link org.hibernate.annotations.NaturalIdCache}
+	 * The Annotations only seems to affect the 2 level cache. But Hibernate also has a sort of first level
+	 * cache which caches all natural ids anyway.
+	 * If you are not {@link org.hibernate.NaturalIdLoadAccess} or not do not rely on it to hit caches its better
+	 * to turn this cache off
+	 *
+	 * @param enabled {@code false} no first or second level caching of natural Ids
+	 * @return {@code this}, for method chaining
+	 */
+	SessionFactoryBuilder enableNaturalIdCache(boolean enabled);
+
+	/**
 	 * Specifies an {@link Interceptor} associated with the {@link SessionFactory},
 	 * which will be used by all sessions unless an interceptor is explicitly
 	 * specified using {@link org.hibernate.SessionBuilder#interceptor}.

--- a/hibernate-core/src/main/java/org/hibernate/boot/internal/SessionFactoryBuilderImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/internal/SessionFactoryBuilderImpl.java
@@ -148,6 +148,12 @@ public class SessionFactoryBuilderImpl implements SessionFactoryBuilderImplement
 	}
 
 	@Override
+	public SessionFactoryBuilder enableNaturalIdCache(boolean enable) {
+		this.optionsBuilder.enableNaturalIdCache(enable);
+		return this;
+	}
+
+	@Override
 	public SessionFactoryBuilder applyStatelessInterceptor(Class<? extends Interceptor> statelessInterceptorClass) {
 		this.optionsBuilder.applyStatelessInterceptor( statelessInterceptorClass );
 		return this;

--- a/hibernate-core/src/main/java/org/hibernate/boot/internal/SessionFactoryOptionsBuilder.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/internal/SessionFactoryOptionsBuilder.java
@@ -267,6 +267,7 @@ public class SessionFactoryOptionsBuilder implements SessionFactoryOptions {
 	private final boolean inClauseParameterPaddingEnabled;
 
 	private final int queryStatisticsMaxSize;
+	private boolean enableNaturalIdCache;
 
 
 	public SessionFactoryOptionsBuilder(StandardServiceRegistry serviceRegistry, BootstrapContext context) {
@@ -335,6 +336,7 @@ public class SessionFactoryOptionsBuilder implements SessionFactoryOptions {
 		this.autoCloseSessionEnabled = configurationService.getSetting( AUTO_CLOSE_SESSION, BOOLEAN, false );
 
 		this.statisticsEnabled = configurationService.getSetting( GENERATE_STATISTICS, BOOLEAN, false );
+		this.enableNaturalIdCache = !configurationService.getSetting(AvailableSettings.DISABLE_NATURAL_ID_RESOLUTIONS_CACHE, BOOLEAN,false);
 		this.interceptor = determineInterceptor( configurationSettings, strategySelector );
 		this.statelessInterceptorSupplier = determineStatelessInterceptor( configurationSettings, strategySelector );
 		this.statementInspector = strategySelector.resolveStrategy(
@@ -904,6 +906,11 @@ public class SessionFactoryOptionsBuilder implements SessionFactoryOptions {
 	}
 
 	@Override
+	public boolean isEnableNaturalIdCache() {
+		return enableNaturalIdCache;
+	}
+
+	@Override
 	public Interceptor getInterceptor() {
 		return interceptor == null ? EmptyInterceptor.INSTANCE : interceptor;
 	}
@@ -1263,6 +1270,8 @@ public class SessionFactoryOptionsBuilder implements SessionFactoryOptions {
 		return xmlFormatMapper;
 	}
 
+
+
 	// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 	// In-flight mutation access
 
@@ -1306,6 +1315,10 @@ public class SessionFactoryOptionsBuilder implements SessionFactoryOptions {
 		this.preferUserTransaction = preferUserTransaction;
 	}
 
+	public void enableNaturalIdCache(boolean enabled) {
+		this.enableNaturalIdCache = enabled;
+	}
+	
 	public void enableStatisticsSupport(boolean enabled) {
 		this.statisticsEnabled = enabled;
 	}

--- a/hibernate-core/src/main/java/org/hibernate/boot/spi/AbstractDelegatingSessionFactoryBuilder.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/spi/AbstractDelegatingSessionFactoryBuilder.java
@@ -96,6 +96,12 @@ public abstract class AbstractDelegatingSessionFactoryBuilder<T extends SessionF
 	}
 
 	@Override
+	public SessionFactoryBuilder enableNaturalIdCache(boolean enabled) {
+		delegate.enableNaturalIdCache(enabled);
+		return getThis();
+	}
+
+	@Override
 	public T applyInterceptor(Interceptor interceptor) {
 		delegate.applyInterceptor( interceptor );
 		return getThis();

--- a/hibernate-core/src/main/java/org/hibernate/boot/spi/AbstractDelegatingSessionFactoryOptions.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/spi/AbstractDelegatingSessionFactoryOptions.java
@@ -119,6 +119,11 @@ public class AbstractDelegatingSessionFactoryOptions implements SessionFactoryOp
 	}
 
 	@Override
+	public boolean isEnableNaturalIdCache() {
+		return delegate.isEnableNaturalIdCache();
+	}
+
+	@Override
 	public Interceptor getInterceptor() {
 		return delegate.getInterceptor();
 	}

--- a/hibernate-core/src/main/java/org/hibernate/boot/spi/SessionFactoryOptions.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/spi/SessionFactoryOptions.java
@@ -106,6 +106,8 @@ public interface SessionFactoryOptions extends QueryEngineOptions {
 
 	boolean isStatisticsEnabled();
 
+	boolean isEnableNaturalIdCache();
+
 	/**
 	 * Get the interceptor to use by default for all sessions opened from this factory.
 	 *

--- a/hibernate-core/src/main/java/org/hibernate/cfg/AvailableSettings.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/AvailableSettings.java
@@ -221,4 +221,5 @@ public interface AvailableSettings
 	@Deprecated(since = "6.0")
 	@SuppressWarnings("DeprecatedIsStillUsed")
 	String IDENTIFIER_GENERATOR_STRATEGY_PROVIDER = "hibernate.identifier_generator_strategy_provider";
+	String DISABLE_NATURAL_ID_RESOLUTIONS_CACHE = "hibernate.cache.natural_id_cache";
 }

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/naturalid/ImmutableNaturalKeyLookupTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/naturalid/ImmutableNaturalKeyLookupTest.java
@@ -11,6 +11,7 @@ import jakarta.persistence.criteria.CriteriaBuilder;
 import jakarta.persistence.criteria.CriteriaQuery;
 import jakarta.persistence.criteria.Root;
 
+import org.hibernate.cfg.AvailableSettings;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -355,6 +356,7 @@ public class ImmutableNaturalKeyLookupTest extends BaseCoreFunctionalTestCase {
 	protected void configure(Configuration cfg) {
 		cfg.setProperty( Environment.GENERATE_STATISTICS, "true" );
 		cfg.setProperty( Environment.USE_QUERY_CACHE, "true" );
+		cfg.setProperty(AvailableSettings.DISABLE_NATURAL_ID_RESOLUTIONS_CACHE, "false" );
 	}
 
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/naturalid/NaturalIdTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/naturalid/NaturalIdTest.java
@@ -13,6 +13,7 @@ import jakarta.persistence.criteria.Root;
 import org.hibernate.NaturalIdLoadAccess;
 import org.hibernate.Session;
 import org.hibernate.Transaction;
+import org.hibernate.cfg.AvailableSettings;
 import org.hibernate.cfg.Configuration;
 import org.hibernate.metamodel.mapping.EntityMappingType;
 import org.hibernate.metamodel.mapping.NaturalIdMapping;
@@ -380,5 +381,6 @@ public class NaturalIdTest extends BaseCoreFunctionalTestCase {
 	@Override
 	protected void configure(Configuration cfg) {
 		cfg.setProperty( "hibernate.cache.use_query_cache", "true" );
+		cfg.setProperty(AvailableSettings.DISABLE_NATURAL_ID_RESOLUTIONS_CACHE, "false");
 	}
 }

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/naturalid/ImmutableNaturalIdTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/naturalid/ImmutableNaturalIdTest.java
@@ -164,8 +164,9 @@ public class ImmutableNaturalIdTest extends AbstractJPATest {
 					u = session.byNaturalId( User.class ).using( "userName", "steve" ).load();
 					assertNotNull( u );
 					assertEquals( 1, sessionFactory().getStatistics().getEntityLoadCount() );
+					//apperently these stats are wrong anyway..
 					assertEquals(
-							1,
+							sessionFactory().getSessionFactory().getSessionFactory().getSessionFactoryOptions().isEnableNaturalIdCache()?1:2,
 							sessionFactory().getStatistics().getNaturalIdQueryExecutionCount()
 					);//0: incorrect stats since hbm.xml can't enable NaturalId caching
 					assertEquals( 0, sessionFactory().getStatistics().getNaturalIdCacheHitCount() );

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/naturalid/MutableNaturalIdTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/naturalid/MutableNaturalIdTest.java
@@ -14,10 +14,10 @@ import org.hibernate.testing.TestForIssue;
 import org.hibernate.testing.orm.junit.SkipForDialect;
 import org.hibernate.orm.test.jpa.model.AbstractJPATest;
 
+import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * @author Steve Ebersole
@@ -71,7 +71,13 @@ public class MutableNaturalIdTest extends AbstractJPATest {
 					e.setName( "Dampf" );
 					session.save( e );
 					e.setName( "Klein" );
-					assertNotNull( session.bySimpleNaturalId( ClassWithIdentityColumn.class ).load( "Klein" ) );
+					final var klein = session.bySimpleNaturalId(ClassWithIdentityColumn.class).load("Klein");
+					final var enableNaturalIdCache = sessionFactory().getSessionFactoryOptions().isEnableNaturalIdCache();
+					if (enableNaturalIdCache) {
+						assertNotNull(klein);
+					} else {
+						assertNull(klein);
+					}
 				}
 		);
 	}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/identifier/MutableNaturalIdTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/identifier/MutableNaturalIdTest.java
@@ -11,9 +11,12 @@ import jakarta.persistence.Id;
 
 import org.hibernate.Session;
 import org.hibernate.annotations.NaturalId;
+import org.hibernate.cfg.AvailableSettings;
 import org.hibernate.orm.test.jpa.BaseEntityManagerFunctionalTestCase;
 
 import org.junit.Test;
+
+import java.util.Map;
 
 import static org.hibernate.testing.transaction.TransactionUtil.doInJPA;
 import static org.junit.Assert.assertEquals;
@@ -31,6 +34,11 @@ public class MutableNaturalIdTest extends BaseEntityManagerFunctionalTestCase {
 		return new Class<?>[] {
 			Author.class
 		};
+	}
+
+	@Override
+	protected void addConfigOptions(Map options) {
+		options.put(AvailableSettings.DISABLE_NATURAL_ID_RESOLUTIONS_CACHE, false);
 	}
 
 	@Test
@@ -61,7 +69,6 @@ public class MutableNaturalIdTest extends BaseEntityManagerFunctionalTestCase {
 					.setSynchronizationEnabled(false)
 					.load("john.doe@acme.com")
 			);
-
 			assertSame(author,
 				entityManager
 					.unwrap(Session.class)
@@ -73,6 +80,11 @@ public class MutableNaturalIdTest extends BaseEntityManagerFunctionalTestCase {
 
 			//end::naturalid-mutable-synchronized-example[]
 		});
+	}
+
+	@Override
+	public void buildEntityManagerFactory() {
+		super.buildEntityManagerFactory();
 	}
 
 	//tag::naturalid-mutable-mapping-example[]

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/naturalid/BasicNaturalIdCachingTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/naturalid/BasicNaturalIdCachingTests.java
@@ -33,6 +33,8 @@ import static org.hamcrest.Matchers.notNullValue;
 		settings = {
 				@Setting( name = AvailableSettings.USE_SECOND_LEVEL_CACHE, value = "true" ),
 				@Setting( name = AvailableSettings.GENERATE_STATISTICS, value = "true" ),
+				//inherently tests internal caches
+				@Setting( name = AvailableSettings.DISABLE_NATURAL_ID_RESOLUTIONS_CACHE, value = "false" ),
 		}
 )
 @DomainModel( annotatedClasses = BasicNaturalIdCachingTests.CachedEntity.class )

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/naturalid/compound/CompoundNaturalIdCacheTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/naturalid/compound/CompoundNaturalIdCacheTest.java
@@ -44,6 +44,7 @@ import static org.hibernate.testing.cache.CachingRegionFactory.DEFAULT_ACCESSTYP
 				@Setting(name = DEFAULT_ACCESSTYPE, value = "nonstrict-read-write"),
 				@Setting(name = AvailableSettings.USE_QUERY_CACHE, value = "true"),
 				@Setting(name = AvailableSettings.SHOW_SQL, value = "false"),
+				@Setting(name = AvailableSettings.DISABLE_NATURAL_ID_RESOLUTIONS_CACHE, value = "false"),
 		}
 )
 @SessionFactory(generateStatistics = true)
@@ -65,7 +66,8 @@ public class CompoundNaturalIdCacheTest {
 						EntityWithSimpleNaturalId withSimpleNaturalIdEntity = new EntityWithSimpleNaturalId();
 						withSimpleNaturalIdEntity.setName( str );
 						session.persist( withSimpleNaturalIdEntity );
-						NaturalIdResolutionsImpl naturalIdResolutions = (NaturalIdResolutionsImpl) session.getPersistenceContext()
+						//??
+						session.getPersistenceContext()
 								.getNaturalIdResolutions();
 					}
 				}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/naturalid/immutable/IdentityGeneratorWithNaturalIdCacheTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/naturalid/immutable/IdentityGeneratorWithNaturalIdCacheTest.java
@@ -40,14 +40,15 @@ import static org.hamcrest.MatcherAssert.assertThat;
 @TestForIssue( jiraKey = "HHH-11330" )
 @ServiceRegistry(
 		settings = {
-				@Setting( name = AvailableSettings.GENERATE_STATISTICS, value = "true" ),
-				@Setting( name = AvailableSettings.USE_SECOND_LEVEL_CACHE, value = "true" )
+				@Setting(name = AvailableSettings.GENERATE_STATISTICS, value = "true"),
+				@Setting(name = AvailableSettings.USE_SECOND_LEVEL_CACHE, value = "true")
 		}
 )
 @DomainModel( annotatedClasses = IdentityGeneratorWithNaturalIdCacheTest.Person.class )
 @SessionFactory
 @RequiresDialectFeature(feature = DialectFeatureChecks.SupportsIdentityColumns.class)
 public class IdentityGeneratorWithNaturalIdCacheTest {
+
 	@BeforeEach
 	public void prepareTestData(SessionFactoryScope scope) {
 		scope.inTransaction(
@@ -69,25 +70,24 @@ public class IdentityGeneratorWithNaturalIdCacheTest {
 	@Test
 	@TestForIssue(jiraKey = "HHH-10659")
 	public void testNaturalIdCacheEntry(SessionFactoryScope scope) {
+
 		final StatisticsImplementor statistics = scope.getSessionFactory().getStatistics();
 		statistics.clear();
-
-		assertThat( statistics.getSecondLevelCacheHitCount(), Matchers.is( 0L ) );
-		assertThat( statistics.getNaturalIdCacheHitCount(), Matchers.is( 0L ) );
-
+		final var enableNaturalIdCache = scope.getSessionFactory().getSessionFactoryOptions().isEnableNaturalIdCache();
+		assertThat(statistics.getSecondLevelCacheHitCount(), Matchers.is(0L));
+		assertThat(statistics.getNaturalIdCacheHitCount(), Matchers.is(0L));
 		scope.inTransaction(
 				(session) -> {
-					session.bySimpleNaturalId( Person.class ).load( "John Doe" );
-					assertThat( statistics.getSecondLevelCacheHitCount(), Matchers.is( 0L ) );
-					assertThat( statistics.getNaturalIdCacheHitCount(), Matchers.is( 1L ) );
+					session.bySimpleNaturalId(Person.class).load("John Doe");
+					assertThat(statistics.getSecondLevelCacheHitCount(), Matchers.is(0L));
+					assertThat(statistics.getNaturalIdCacheHitCount(), Matchers.is(enableNaturalIdCache?1L:0L));
 				}
 		);
-
 		scope.inTransaction(
 				(session) -> {
-					session.bySimpleNaturalId( Person.class ).load( "John Doe" );
-					assertThat( statistics.getSecondLevelCacheHitCount(), Matchers.is( 1L ) );
-					assertThat( statistics.getNaturalIdCacheHitCount(), Matchers.is( 2L ) );
+					session.bySimpleNaturalId(Person.class).load("John Doe");
+					assertThat(statistics.getSecondLevelCacheHitCount(), Matchers.is(enableNaturalIdCache?1L:0));
+					assertThat(statistics.getNaturalIdCacheHitCount(), Matchers.is(enableNaturalIdCache?2L:0));
 				}
 		);
 	}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/naturalid/immutableentity/ImmutableEntityNaturalIdTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/naturalid/immutableentity/ImmutableEntityNaturalIdTest.java
@@ -23,7 +23,9 @@ import org.hibernate.testing.orm.junit.ServiceRegistry;
 import org.hibernate.testing.orm.junit.SessionFactory;
 import org.hibernate.testing.orm.junit.SessionFactoryScope;
 import org.hibernate.testing.orm.junit.Setting;
+import org.junit.Assume;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -74,7 +76,9 @@ public class ImmutableEntityNaturalIdTest {
 
 		assertEquals( "Cache hits should be empty", 0, stats.getNaturalIdCacheHitCount() );
 		assertEquals( "Cache misses should be empty", 0, stats.getNaturalIdCacheMissCount() );
-		assertEquals( "Cache put should be one after insert", 1, stats.getNaturalIdCachePutCount() );
+		if (sessionFactory.getSessionFactoryOptions().isEnableNaturalIdCache()) {
+			assertEquals( "Cache put should be one after insert", 1, stats.getNaturalIdCachePutCount() );
+		}
 	}
 
 	@AfterEach
@@ -120,6 +124,7 @@ public class ImmutableEntityNaturalIdTest {
 
 	@Test
 	public void testImmutableNaturalIdLifecycle(SessionFactoryScope scope) {
+		Assumptions.assumeTrue(scope.getSessionFactory().getSessionFactoryOptions().isEnableNaturalIdCache());
 		final SessionFactoryImplementor sessionFactory = scope.getSessionFactory();
 		final StatisticsImplementor stats = sessionFactory.getStatistics();
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/naturalid/mutable/MutableNaturalIdTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/naturalid/mutable/MutableNaturalIdTest.java
@@ -28,11 +28,7 @@ import org.junit.jupiter.api.Test;
 import static org.hibernate.cfg.AvailableSettings.GENERATE_STATISTICS;
 import static org.hibernate.cfg.AvailableSettings.USE_QUERY_CACHE;
 import static org.hibernate.cfg.AvailableSettings.USE_SECOND_LEVEL_CACHE;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNotSame;
-import static org.junit.Assert.assertNull;
+import static org.junit.Assert.*;
 
 /**
  * @author Gavin King
@@ -85,8 +81,14 @@ public class MutableNaturalIdTest {
 							.using( "name", "gavin" )
 							.using( "org", "hb" )
 							.load();
-					assertNull( original );
-					assertNotSame( user, original );
+					//if there is a cache, hibernate gives you changes that havent been flushed to the db,
+					// otherwise it gives you the db state
+					if (scope.getSessionFactory().getSessionFactoryOptions().isEnableNaturalIdCache()) {
+						assertNull( original );
+						assertNotSame( user, original );
+					} else {
+						assertSame( user, original );
+					}
 				}
 		);
 	}
@@ -114,7 +116,13 @@ public class MutableNaturalIdTest {
 								.using( "name", "Gavin" )
 								.using( "org", "hb" )
 								.load();
-						assertNotNull( loaded );
+						//if there is a cache, hibernate gives you changes that havent been flushed to the db,
+						// otherwise it gives you the db state
+						if (scope.getSessionFactory().getSessionFactoryOptions().isEnableNaturalIdCache()) {
+							assertNotNull(loaded);
+						} else {
+							assertNull(loaded);
+						}
 					}
 					catch( HibernateException expected ) {
 						session.getTransaction().markRollbackOnly();
@@ -156,7 +164,20 @@ public class MutableNaturalIdTest {
 								.using( "name", "Gavin" )
 								.using( "org", "hb" )
 								.load();
-						assertNotNull( loaded );
+						//if there is a cache, hibernate gives you changes that havent been flushed to the db,
+						// otherwise it gives you the db state
+						if (scope.getSessionFactory().getSessionFactoryOptions().isEnableNaturalIdCache()) {
+							assertNotNull(loaded);
+						} else {
+							assertNull(loaded);
+							assertNotNull(session
+									.byNaturalId(User.class)
+									.using("name", "gavin")
+									.using("org", "hb")
+									.load());
+
+						}
+
 					}
 					catch (Throwable t) {
 						try {

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/naturalid/mutable/cached/CachedMutableNaturalIdStrictReadWriteTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/naturalid/mutable/cached/CachedMutableNaturalIdStrictReadWriteTest.java
@@ -7,19 +7,15 @@
 package org.hibernate.orm.test.mapping.naturalid.mutable.cached;
 
 import org.hibernate.Transaction;
+import org.hibernate.internal.SessionFactoryImpl;
 import org.hibernate.stat.NaturalIdStatistics;
 import org.hibernate.stat.spi.StatisticsImplementor;
 
 import org.hibernate.testing.TestForIssue;
-import org.hibernate.testing.orm.junit.DomainModel;
-import org.hibernate.testing.orm.junit.ServiceRegistry;
-import org.hibernate.testing.orm.junit.SessionFactory;
-import org.hibernate.testing.orm.junit.SessionFactoryScope;
-import org.hibernate.testing.orm.junit.Setting;
+import org.hibernate.testing.orm.junit.*;
 import org.junit.jupiter.api.Test;
 
-import static org.hibernate.cfg.AvailableSettings.GENERATE_STATISTICS;
-import static org.hibernate.cfg.AvailableSettings.USE_SECOND_LEVEL_CACHE;
+import static org.hibernate.cfg.AvailableSettings.*;
 import static org.hibernate.testing.cache.CachingRegionFactory.DEFAULT_ACCESSTYPE;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -29,27 +25,98 @@ import static org.junit.Assert.assertNull;
 		settings = {
 				@Setting( name = USE_SECOND_LEVEL_CACHE, value = "true" ),
 				@Setting( name = DEFAULT_ACCESSTYPE, value = "nonstrict-read-write" ),
+				@Setting(name = DISABLE_NATURAL_ID_RESOLUTIONS_CACHE, value = "false"),
 				@Setting( name = GENERATE_STATISTICS, value = "true" )
 		}
 )
 @DomainModel( annotatedClasses = {A.class, Another.class, AllCached.class, B.class, SubClass.class} )
 @SessionFactory
-public class CachedMutableNaturalIdStrictReadWriteTest extends CachedMutableNaturalIdTest {
+public class CachedMutableNaturalIdStrictReadWriteTest extends CachedMutableNaturalIdStrictTest {
+	@Test
+	@JiraKey("HHH-16558")
+	public void testCacheVerifyHits(SessionFactoryScope scope) {
+		scope.inTransaction((session) -> {
+			AllCached aAllCached = new AllCached();
+			aAllCached.setName("John Doe");
+			session.persist(aAllCached);
+			SessionFactoryImpl sfi = (SessionFactoryImpl) session.getSessionFactory();
+			sfi.getStatistics().clear();
+		});
+
+		scope.inTransaction((session) -> {
+			System.out.println("Native load by natural-id, generate first hit");
+			SessionFactoryImpl sfi = (SessionFactoryImpl) session.getSessionFactory();
+			AllCached person = session.bySimpleNaturalId(AllCached.class).load("John Doe");
+			assertNotNull(person);
+			System.out.println("NaturalIdCacheHitCount: " + sfi.getStatistics().getNaturalIdCacheHitCount());
+			System.out.println("SecondLevelCacheHitCount: " + sfi.getStatistics().getSecondLevelCacheHitCount());
+			assertEquals(1, sfi.getStatistics().getNaturalIdCacheHitCount());
+			assertEquals(1, sfi.getStatistics().getSecondLevelCacheHitCount());
+		});
+
+		scope.inTransaction((session) -> {
+			System.out.println("Native load by natural-id, generate second hit");
+
+			SessionFactoryImpl sfi = (SessionFactoryImpl) session.getSessionFactory();
+			//tag::caching-entity-natural-id-example[]
+			AllCached person = session.bySimpleNaturalId(AllCached.class).load("John Doe");
+			assertNotNull(person);
+
+			// resolve in persistence context (first level cache)
+			session.bySimpleNaturalId(AllCached.class).load("John Doe");
+			System.out.println("NaturalIdCacheHitCount: " + sfi.getStatistics().getNaturalIdCacheHitCount());
+			System.out.println("SecondLevelCacheHitCount: " + sfi.getStatistics().getSecondLevelCacheHitCount());
+			assertEquals(2, sfi.getStatistics().getNaturalIdCacheHitCount());
+			assertEquals(2, sfi.getStatistics().getSecondLevelCacheHitCount());
+
+			session.clear();
+			//  persistence context (first level cache) empty, should resolve from second level cache
+			System.out.println("Native load by natural-id, generate third hit");
+			person = session.bySimpleNaturalId(AllCached.class).load("John Doe");
+			System.out.println("NaturalIdCacheHitCount: " + sfi.getStatistics().getNaturalIdCacheHitCount());
+			System.out.println("SecondLevelCacheHitCount: " + sfi.getStatistics().getSecondLevelCacheHitCount());
+			assertNotNull(person);
+			assertEquals(3, sfi.getStatistics().getNaturalIdCacheHitCount());
+			assertEquals(3, sfi.getStatistics().getSecondLevelCacheHitCount());
+
+			//Remove the entity from the persistence context
+			Integer id = person.getId();
+
+			session.detach(person); // still it should resolve from second level cache after this
+
+			System.out.println("Native load by natural-id, generate 4. hit");
+			person = session.bySimpleNaturalId(AllCached.class).load("John Doe");
+			System.out.println("NaturalIdCacheHitCount: " + sfi.getStatistics().getNaturalIdCacheHitCount());
+			assertEquals("we expected now 4 hits", 4, sfi.getStatistics().getNaturalIdCacheHitCount());
+			assertNotNull(person);
+			session.remove(person); // evicts natural-id from first & second level cache
+			person = session.bySimpleNaturalId(AllCached.class).load("John Doe");
+			assertEquals(4, sfi.getStatistics().getNaturalIdCacheHitCount()); // thus hits should not increment
+		});
+	}
 
 	@Test
-	@TestForIssue( jiraKey = "HHH-9203" )
-	public void testToMapConversion(SessionFactoryScope scope) {
+	@TestForIssue( jiraKey = "HHH-9200" )
+	public void testNaturalIdCacheStatisticsReset(SessionFactoryScope scope) {
 		final StatisticsImplementor statistics = scope.getSessionFactory().getStatistics();
 		statistics.clear();
 
 		scope.inTransaction(
-				(session) -> session.save( new AllCached( "IT" ) )
+				(session) -> {
+					session.save( new Another( "IT" ) );
+				}
 		);
 
-		final NaturalIdStatistics naturalIdStatistics = statistics.getNaturalIdStatistics( AllCached.class.getName() );
-		assertEquals( 1, naturalIdStatistics.getCachePutCount() );
+		NaturalIdStatistics stats = statistics.getNaturalIdStatistics( Another.class.getName() );
+		assertEquals( 1, stats.getCachePutCount() );
+
+		statistics.clear();
+
+		// Refresh statistics reference.
+		stats = statistics.getNaturalIdStatistics( Another.class.getName() );
+		assertEquals( 0, stats.getCachePutCount() );
 	}
-	
+
 	@Test
 	@TestForIssue( jiraKey = "HHH-7278" )
 	public void testInsertedNaturalIdCachedAfterTransactionSuccess(SessionFactoryScope scope) {
@@ -68,34 +135,21 @@ public class CachedMutableNaturalIdStrictReadWriteTest extends CachedMutableNatu
 		);
 		assertEquals( 1, statistics.getNaturalIdCacheHitCount() );
 	}
-	
+
 	@Test
-	@TestForIssue( jiraKey = "HHH-7278" )
-	public void testInsertedNaturalIdNotCachedAfterTransactionFailure(SessionFactoryScope scope) {
+	@TestForIssue( jiraKey = "HHH-9203" )
+	public void testToMapConversion(SessionFactoryScope scope) {
 		final StatisticsImplementor statistics = scope.getSessionFactory().getStatistics();
 		statistics.clear();
 
-		scope.inSession(
-				(session) -> {
-					final Transaction transaction = session.getTransaction();
-					transaction.begin();
-
-					session.save( new Another( "it" ) );
-					session.flush();
-
-					transaction.rollback();
-				}
-		);
-
 		scope.inTransaction(
-				(session) -> {
-					final Another it = session.bySimpleNaturalId( Another.class ).load( "it" );
-					assertNull( it );
-					assertEquals( 0, statistics.getNaturalIdCacheHitCount() );
-				}
+				(session) -> session.save( new AllCached( "IT" ) )
 		);
+
+		final NaturalIdStatistics naturalIdStatistics = statistics.getNaturalIdStatistics( AllCached.class.getName() );
+		assertEquals( 1, naturalIdStatistics.getCachePutCount() );
 	}
-	
+
 	@Test
 	@TestForIssue( jiraKey = "HHH-7278" )
 	public void testChangedNaturalIdCachedAfterTransactionSuccess(SessionFactoryScope scope) {
@@ -126,90 +180,15 @@ public class CachedMutableNaturalIdStrictReadWriteTest extends CachedMutableNatu
 
 		assertEquals( 1, statistics.getNaturalIdCacheHitCount() );
 	}
-	
-	@Test
-	@TestForIssue( jiraKey = "HHH-7278" )
-	public void testChangedNaturalIdNotCachedAfterTransactionFailure(SessionFactoryScope scope) {
-		final StatisticsImplementor statistics = scope.getSessionFactory().getStatistics();
-		statistics.clear();
 
-		scope.inTransaction(
-				(session) -> session.save( new Another( "it" ) )
-		);
-
-		scope.inTransaction(
-				(session) -> {
-					final Another it = session.bySimpleNaturalId( Another.class ).load( "it" );
-					assertNotNull( it );
-
-					it.setName( "modified" );
-					session.flush();
-					session.getTransaction().markRollbackOnly();
-				}
-		);
-
-		statistics.clear();
-
-		scope.inTransaction(
-				(session) -> {
-					final Another modified = session.bySimpleNaturalId( Another.class ).load( "modified" );
-					assertNull( modified );
-
-					final Another original = session.bySimpleNaturalId( Another.class ).load( "it" );
-					assertNotNull( original );
-				}
-		);
-
-		assertEquals(0, statistics.getNaturalIdCacheHitCount());
-	}
-	
 	@Test
 	@TestForIssue( jiraKey = "HHH-7309" )
+	@Override
 	public void testInsertUpdateEntity_NaturalIdCachedAfterTransactionSuccess(SessionFactoryScope scope) {
-		final StatisticsImplementor statistics = scope.getSessionFactory().getStatistics();
-		statistics.clear();
+	 	super.testInsertUpdateEntity_NaturalIdCachedAfterTransactionSuccess(scope);
+		assertEquals( "In a strict access strategy we would expect a hit here", 1, scope.getSessionFactory().getStatistics().getNaturalIdCacheHitCount() );
 
-		scope.inTransaction(
-				(session) -> {
-					Another it = new Another( "it" );
-					// schedules an InsertAction
-					session.save( it );
-
-					// schedules an UpdateAction
-					// 	- without bug-fix this will re-cache natural-id with identical key and at same time invalidate it
-					it.setSurname( "1234" );
-				}
-		);
-
-		scope.inTransaction(
-				(session) -> {
-					final Another it = session.bySimpleNaturalId( Another.class ).load( "it" );
-					assertNotNull( it );
-				}
-		);
-
-		assertEquals( "In a strict access strategy we would expect a hit here", 1, statistics.getNaturalIdCacheHitCount() );
 	}
 
-	@Test
-	@TestForIssue( jiraKey = "HHH-9200" )
-	public void testNaturalIdCacheStatisticsReset(SessionFactoryScope scope) {
-		final StatisticsImplementor statistics = scope.getSessionFactory().getStatistics();
-		statistics.clear();
 
-		scope.inTransaction(
-				(session) -> {
-					session.save( new Another( "IT" ) );
-				}
-		);
-
-		NaturalIdStatistics stats = statistics.getNaturalIdStatistics( Another.class.getName() );
-		assertEquals( 1, stats.getCachePutCount() );
-
-		statistics.clear();
-
-		// Refresh statistics reference.
-		stats = statistics.getNaturalIdStatistics( Another.class.getName() );
-		assertEquals( 0, stats.getCachePutCount() );
-	}
 }

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/naturalid/mutable/cached/CachedMutableNaturalIdStrictTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/naturalid/mutable/cached/CachedMutableNaturalIdStrictTest.java
@@ -1,0 +1,118 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.orm.test.mapping.naturalid.mutable.cached;
+
+import org.hibernate.Transaction;
+import org.hibernate.stat.NaturalIdStatistics;
+import org.hibernate.stat.spi.StatisticsImplementor;
+import org.hibernate.testing.TestForIssue;
+import org.hibernate.testing.orm.junit.*;
+import org.junit.jupiter.api.Test;
+
+import static org.hibernate.cfg.AvailableSettings.GENERATE_STATISTICS;
+import static org.hibernate.cfg.AvailableSettings.USE_SECOND_LEVEL_CACHE;
+import static org.hibernate.testing.cache.CachingRegionFactory.DEFAULT_ACCESSTYPE;
+import static org.junit.Assert.*;
+
+
+public abstract class CachedMutableNaturalIdStrictTest extends CachedMutableNaturalIdTest {
+
+
+
+	
+	@Test
+	@TestForIssue( jiraKey = "HHH-7278" )
+	public void testInsertedNaturalIdNotCachedAfterTransactionFailure(SessionFactoryScope scope) {
+		final StatisticsImplementor statistics = scope.getSessionFactory().getStatistics();
+		statistics.clear();
+
+		scope.inSession(
+				(session) -> {
+					final Transaction transaction = session.getTransaction();
+					transaction.begin();
+
+					session.save( new Another( "it" ) );
+					session.flush();
+
+					transaction.rollback();
+				}
+		);
+
+		scope.inTransaction(
+				(session) -> {
+					final Another it = session.bySimpleNaturalId( Another.class ).load( "it" );
+					assertNull( it );
+					assertEquals( 0, statistics.getNaturalIdCacheHitCount() );
+				}
+		);
+	}
+	
+
+	@Test
+	@TestForIssue( jiraKey = "HHH-7278" )
+	public void testChangedNaturalIdNotCachedAfterTransactionFailure(SessionFactoryScope scope) {
+		final StatisticsImplementor statistics = scope.getSessionFactory().getStatistics();
+		statistics.clear();
+
+		scope.inTransaction(
+				(session) -> session.save( new Another( "it" ) )
+		);
+
+		scope.inTransaction(
+				(session) -> {
+					final Another it = session.bySimpleNaturalId( Another.class ).load( "it" );
+					assertNotNull( it );
+
+					it.setName( "modified" );
+					session.flush();
+					session.getTransaction().markRollbackOnly();
+				}
+		);
+
+		statistics.clear();
+
+		scope.inTransaction(
+				(session) -> {
+					final Another modified = session.bySimpleNaturalId( Another.class ).load( "modified" );
+					assertNull( modified );
+
+					final Another original = session.bySimpleNaturalId( Another.class ).load( "it" );
+					assertNotNull( original );
+				}
+		);
+
+		assertEquals(0, statistics.getNaturalIdCacheHitCount());
+	}
+	
+	@Test
+	@TestForIssue( jiraKey = "HHH-7309" )
+	public void testInsertUpdateEntity_NaturalIdCachedAfterTransactionSuccess(SessionFactoryScope scope) {
+		final StatisticsImplementor statistics = scope.getSessionFactory().getStatistics();
+		statistics.clear();
+
+		scope.inTransaction(
+				(session) -> {
+					Another it = new Another( "it" );
+					// schedules an InsertAction
+					session.save( it );
+
+					// schedules an UpdateAction
+					// 	- without bug-fix this will re-cache natural-id with identical key and at same time invalidate it
+					it.setSurname( "1234" );
+				}
+		);
+
+		scope.inTransaction(
+				(session) -> {
+					final Another it = session.bySimpleNaturalId( Another.class ).load( "it" );
+					assertNotNull( it );
+				}
+		);
+	}
+
+
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/naturalid/mutable/cached/UnCachedMutableNaturalIdStrictReadWriteTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/naturalid/mutable/cached/UnCachedMutableNaturalIdStrictReadWriteTest.java
@@ -1,0 +1,33 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.orm.test.mapping.naturalid.mutable.cached;
+
+import org.hibernate.Transaction;
+import org.hibernate.stat.NaturalIdStatistics;
+import org.hibernate.stat.spi.StatisticsImplementor;
+import org.hibernate.testing.TestForIssue;
+import org.hibernate.testing.orm.junit.*;
+import org.junit.jupiter.api.Test;
+
+import static org.hibernate.cfg.AvailableSettings.*;
+import static org.hibernate.testing.cache.CachingRegionFactory.DEFAULT_ACCESSTYPE;
+import static org.junit.Assert.*;
+
+@ServiceRegistry(
+		settings = {
+				@Setting( name = USE_SECOND_LEVEL_CACHE, value = "true" ),
+				@Setting( name = DEFAULT_ACCESSTYPE, value = "nonstrict-read-write" ),
+				@Setting(name = DISABLE_NATURAL_ID_RESOLUTIONS_CACHE, value = "true"),
+				@Setting( name = GENERATE_STATISTICS, value = "true" )
+		}
+)
+@DomainModel( annotatedClasses = {A.class, Another.class, AllCached.class, B.class, SubClass.class} )
+@SessionFactory
+public class UnCachedMutableNaturalIdStrictReadWriteTest extends CachedMutableNaturalIdStrictTest {
+
+
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/naturalid/performance/PerformanceTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/naturalid/performance/PerformanceTest.java
@@ -1,0 +1,86 @@
+package org.hibernate.orm.test.mapping.naturalid.performance;
+
+import jakarta.persistence.*;
+import org.hibernate.Session;
+import org.hibernate.annotations.NaturalId;
+import org.hibernate.cache.spi.access.NaturalIdDataAccess;
+import org.hibernate.cfg.AvailableSettings;
+import org.hibernate.engine.spi.SessionImplementor;
+import org.hibernate.query.spi.QueryImplementor;
+import org.hibernate.testing.orm.junit.*;
+import org.hibernate.testing.transaction.TransactionUtil;
+import org.junit.jupiter.api.Test;
+
+import java.util.Objects;
+import java.util.function.Consumer;
+
+import static jakarta.persistence.GenerationType.AUTO;
+
+@ServiceRegistry(settings = {
+        @Setting(name = AvailableSettings.DISABLE_NATURAL_ID_RESOLUTIONS_CACHE, value = "true")
+})
+@SessionFactory
+@DomainModel(annotatedClasses = {PerformanceTest.Node.class})
+public class PerformanceTest {
+    @Test
+    public void testIt(SessionFactoryScope sessionFactory) {
+        sessionFactory.inTransaction(new Consumer<SessionImplementor>() {
+            @Override
+            public void accept(SessionImplementor session) {
+                var node = new Node();
+                for (int i = 0; i < 100_000; i++) {
+                    session.persist(node);
+                    final var newNode = new Node();
+                    newNode.nextNode = node;
+                    node = newNode;
+                }
+            }
+        });
+        sessionFactory.inSession(new Consumer<SessionImplementor>() {
+            @Override
+            public void accept(SessionImplementor sessionImplementor) {
+                final var selectXFromNode = "from Node";
+                final var query = sessionImplementor.createQuery(selectXFromNode);
+                query.getResultList();
+            }
+        });
+    }
+
+
+    @Entity(name = "Node")
+    public static class Node {
+        @Id
+        @GeneratedValue(strategy = AUTO)
+        public int ident;
+        @ManyToOne(fetch = FetchType.LAZY)
+        @NaturalId
+        public Node nextNode;
+        @NaturalId
+        public String otherPart;
+
+
+        public Node getNextNode() {
+            return nextNode;
+        }
+
+        public String getOtherPart() {
+            return otherPart;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (!(o instanceof Node node)) return false;
+            if (getNextNode() != null ? !getNextNode().equals(node.getNextNode()) : node.getNextNode() != null)
+                return false;
+            return getOtherPart() != null ? getOtherPart().equals(node.getOtherPart()) : node.getOtherPart() == null;
+        }
+
+        @Override
+        public int hashCode() {
+            int result = getNextNode() != null ? getNextNode().hashCode() : 0;
+            result = 31 * result + (getOtherPart() != null ? getOtherPart().hashCode() : 0);
+            return result;
+        }
+    }
+}

--- a/hibernate-micrometer/src/test/java/org/hibernate/test/stat/MicrometerCacheStatisticsTest.java
+++ b/hibernate-micrometer/src/test/java/org/hibernate/test/stat/MicrometerCacheStatisticsTest.java
@@ -152,8 +152,8 @@ public class MicrometerCacheStatisticsTest extends BaseNonConfigCoreFunctionalTe
 		Assert.assertEquals( 1, registry.get("hibernate.sessions.closed").functionCounter().count(), 0 );
 		Assert.assertEquals( 1, registry.get("hibernate.entities.inserts").functionCounter().count(), 0 );
 		Assert.assertEquals( 1, registry.get("hibernate.transactions").tags("result", "success").functionCounter().count(), 0 );
-		Assert.assertEquals( 1, registry.get("hibernate.cache.natural.id.puts").functionCounter().count(), 0);
-		Assert.assertEquals(2, registry.get("hibernate.second.level.cache.puts").tags("region", REGION).functionCounter().count(), 0);
+		Assert.assertEquals( cached() ?1:0, registry.get("hibernate.cache.natural.id.puts").functionCounter().count(), 0);
+		Assert.assertEquals(cached()?2:1, registry.get("hibernate.second.level.cache.puts").tags("region", REGION).functionCounter().count(), 0);
 
 		final String queryString = "select p from Person p";
 		inTransaction(
@@ -165,8 +165,8 @@ public class MicrometerCacheStatisticsTest extends BaseNonConfigCoreFunctionalTe
 		Assert.assertEquals( 2, registry.get("hibernate.sessions.closed").functionCounter().count(), 0 );
 		Assert.assertEquals( 0, registry.get("hibernate.entities.deletes").functionCounter().count(), 0 );
 		Assert.assertEquals( 2, registry.get("hibernate.transactions").tags("result", "success").functionCounter().count(), 0 );
-		Assert.assertEquals( 1, registry.get("hibernate.cache.natural.id.puts").functionCounter().count(), 0);
-		Assert.assertEquals(3, registry.get("hibernate.second.level.cache.puts").tags("region", REGION).functionCounter().count(), 0);
+		Assert.assertEquals( cached()?1:0, registry.get("hibernate.cache.natural.id.puts").functionCounter().count(), 0);
+		Assert.assertEquals(cached()?3:2 ,registry.get("hibernate.second.level.cache.puts").tags("region", REGION).functionCounter().count(), 0);
 
 		// clean up
 		session = openSession();
@@ -179,6 +179,10 @@ public class MicrometerCacheStatisticsTest extends BaseNonConfigCoreFunctionalTe
 		Assert.assertEquals( 3, registry.get("hibernate.sessions.closed").functionCounter().count(), 0 );
 		Assert.assertEquals( 1, registry.get("hibernate.entities.deletes").functionCounter().count(), 0 );
 		Assert.assertEquals( 3, registry.get("hibernate.transactions").tags("result", "success").functionCounter().count(), 0 );
+	}
+
+	private boolean cached() {
+		return sessionFactory().getSessionFactoryOptions().isEnableNaturalIdCache();
 	}
 
 	@Entity( name = "Person" )


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-17562
Added a new Option to turn off Hibernates Natural-ID Cache. 
Motivation is that I ran into multiple bugs and performance problems involving that cache. It seems to me the cache is only usefull if someone uses the strange semantics of Session.byNaturalId to find objects from cache-> and for a lot of usecases you dont need to.
Having this Option "breaking" Hibernate functionality is a bit sad, however I would argue there is a huge problem by design if hibernate has to track each object in every usecase because someone might want to use NaturalLoadId in some usecases. 

Setting this Option will alter the behavior of Session.byNaturalID a bit -> Objects will be always looked up from the database, so if you change your natural id and didn't flush your entity to the database, you cant find it anymore.  

This option allows one to workaround HHH-17556-> no more exceptions because of bad caching.
As another argument for this change see included:
org.hibernate.orm.test.mapping.naturalid.performance.PerformanceTest
disabling the natural Id Resolutions Cache allows the test to complete as expected-> having it enabled will most likely (but not guaranteed) throw an StackoverflowError

Best regards

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-17652
<!-- Hibernate GitHub Bot issue links end -->