### PR TITLE
HHH-17420 JoinColumn throws an `occurs out of order` AnnotationException

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/boot/model/internal/BinderHelper.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/internal/BinderHelper.java
@@ -448,9 +448,16 @@ public class BinderHelper {
 		// which are mapped to that column. (There might be multiple such
 		// properties for each column.)
 		if ( columnOwner instanceof PersistentClass ) {
-			PersistentClass persistentClass = (PersistentClass) columnOwner;
+			final PersistentClass persistentClass = (PersistentClass) columnOwner;
+			// Process ToOne associations after Components, Basic and Id properties
+			final List<Property> toOneProperties = new ArrayList<>();
 			for ( Property property : persistentClass.getReferenceableProperties() ) {
-				matchColumnsByProperty( property, columnsToProperty );
+				if ( property.getValue() instanceof ToOne ) {
+					toOneProperties.add( property );
+				}
+				else {
+					matchColumnsByProperty( property, columnsToProperty );
+				}
 			}
 			if ( persistentClass.hasIdentifierProperty() ) {
 				matchColumnsByProperty( persistentClass.getIdentifierProperty(), columnsToProperty );
@@ -461,6 +468,9 @@ public class BinderHelper {
 				for ( Property p : key.getProperties() ) {
 					matchColumnsByProperty( p, columnsToProperty );
 				}
+			}
+			for ( Property property : toOneProperties ) {
+				matchColumnsByProperty( property, columnsToProperty );
 			}
 		}
 		else {

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/onetoone/JoinColumnTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/onetoone/JoinColumnTest.java
@@ -1,0 +1,99 @@
+package org.hibernate.orm.test.annotations.onetoone;
+
+import java.io.Serializable;
+
+import org.hibernate.testing.junit4.BaseUnitTestCase;
+import org.hibernate.testing.orm.junit.EntityManagerFactoryScope;
+import org.hibernate.testing.orm.junit.JiraKey;
+import org.hibernate.testing.orm.junit.Jpa;
+import org.junit.jupiter.api.Test;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import jakarta.persistence.EmbeddedId;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
+
+@JiraKey("HHH-17420")
+@Jpa(
+		annotatedClasses = {
+				JoinColumnTest.LeftEntity.class,
+				JoinColumnTest.MidEntity.class,
+				JoinColumnTest.RightEntity.class,
+		}
+)
+class JoinColumnTest extends BaseUnitTestCase {
+
+	@Test
+	void testLeftToRight(EntityManagerFactoryScope scope) {
+		scope.inTransaction(
+				entityManager -> {
+				}
+		);
+	}
+
+	@Entity(name = "LeftEntity")
+	static class LeftEntity {
+
+		@Embeddable
+		static class Pk implements Serializable {
+			@Column
+			String id_one_2;
+
+			@Column
+			String id_two_2;
+
+			@Column
+			String id_three_2;
+		}
+
+		@EmbeddedId
+		Pk id;
+
+		@OneToOne(mappedBy = "aLeftEntity")
+		MidEntity midEntity;
+	}
+
+	@Entity(name = "MidEntity")
+	static class MidEntity {
+
+		@Id
+		@Column
+		String id;
+
+		@Column
+		String id_one;
+
+		@Column
+		String id_two;
+
+		@Column
+		String id_three;
+
+		@OneToOne
+		@JoinColumn(name = "id_one", referencedColumnName = "id_one_2", insertable = false, updatable = false)
+		@JoinColumn(name = "id_two", referencedColumnName = "id_two_2", insertable = false, updatable = false)
+		@JoinColumn(name = "id_three", referencedColumnName = "id_three_2", insertable = false, updatable = false)
+		LeftEntity aLeftEntity;
+
+		@OneToOne(mappedBy = "midEntity")
+		RightEntity rightEntity;
+	}
+
+	@Entity(name = "RightEntity")
+	static class RightEntity {
+
+		@Id
+		Long id;
+
+		@Column
+		String id_three;
+
+		@OneToOne
+		@JoinColumn(name = "id_one", referencedColumnName = "id_one", insertable = false, updatable = false)
+		@JoinColumn(name = "id_two", referencedColumnName = "id_two", insertable = false, updatable = false)
+		MidEntity midEntity;
+	}
+}


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-17420

Not sure this is a good solution, but not able to find a better one. The issue occurs when binding [midEntity](https://github.com/hibernate/hibernate-orm/pull/7728/files#diff-1af5497bc6094fadc87d89a1c72517b1fa6960ea472121edfd2ae631bc529d18R97)
 in the `MidEntity` ,the [aLeftEntity](https://github.com/hibernate/hibernate-orm/pull/7728/files#diff-1af5497bc6094fadc87d89a1c72517b1fa6960ea472121edfd2ae631bc529d18R79) property is processed before all the other properties and has 2 `Selectable` matching the Join columns of `midEntity` , this causes `https://github.com/hibernate/hibernate-orm/pull/7728/files#diff-1367dbe77e6fa4e6ae9a25e199b858cea584e7aa3db83d2fd37ab31072a07526L496`.

