### PR TITLE
HHH-17662 - Only generate a new array type if it is a new element type

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/jdbc/ArrayJdbcType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/jdbc/ArrayJdbcType.java
@@ -203,4 +203,22 @@ public class ArrayJdbcType implements JdbcType {
 	public String toString() {
 		return "ArrayTypeDescriptor";
 	}
+
+	/**
+	 * Check equality. Needed so that ArrayJdbcType in collections correctly match each other.
+	 *
+	 * @param o other object
+	 * @return true if the two array types share the same element type
+	 */
+	@Override
+	public boolean equals(Object o) {
+		return o != null &&
+				getClass() == o.getClass() &&
+				getElementJdbcType().equals( ((ArrayJdbcType) o).getElementJdbcType() );
+	}
+
+	@Override
+	public int hashCode() {
+		return getJdbcTypeCode() + getElementJdbcType().hashCode();
+	}
 }

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/type/descriptor/jdbc/ArrayJdbcTypeTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/type/descriptor/jdbc/ArrayJdbcTypeTest.java
@@ -1,0 +1,27 @@
+package org.hibernate.orm.test.type.descriptor.jdbc;
+
+import org.hibernate.testing.TestForIssue;
+import org.hibernate.type.descriptor.jdbc.ArrayJdbcType;
+import org.hibernate.type.descriptor.jdbc.BigIntJdbcType;
+import org.hibernate.type.descriptor.jdbc.IntegerJdbcType;
+import org.hibernate.type.descriptor.jdbc.JdbcType;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class ArrayJdbcTypeTest {
+    @Test
+    @TestForIssue(jiraKey = "HHH-17662")
+    public void testEquality() {
+        Map<JdbcType, String> typeMap = new HashMap<>();
+        JdbcType bigInt = new BigIntJdbcType();
+        typeMap.put(new ArrayJdbcType(bigInt), "bees");
+        typeMap.put(new ArrayJdbcType(bigInt), "bees");
+        typeMap.put(new ArrayJdbcType(bigInt), "bees");
+        typeMap.put(new ArrayJdbcType(new IntegerJdbcType()), "waffles");
+        assertThat("A map of arrays only contains non duplicate entries", typeMap.size() == 2);
+    }
+}


### PR DESCRIPTION
Later on types are compared with .equals and none of the jdbc types implement it so constructed types are always registered as new unique types each time they are used.  Make array function as a singleton like other basic types.

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-17662
<!-- Hibernate GitHub Bot issue links end -->