### PR TITLE
Reproducer for HHH-17683 hibernate-jpamodelgen generates wrong constructor for metamodel of entities whose methods contain a `static EntityManager getEntityManager()`

### DIFF
--- a/tooling/metamodel-generator/src/test/java/org/hibernate/jpamodelgen/test/constructor/EntityExtendingEntityWithInstanceGetEntityManager.java
+++ b/tooling/metamodel-generator/src/test/java/org/hibernate/jpamodelgen/test/constructor/EntityExtendingEntityWithInstanceGetEntityManager.java
@@ -1,0 +1,22 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html
+ */
+package org.hibernate.jpamodelgen.test.constructor;
+
+import jakarta.persistence.Entity;
+
+@Entity
+public class EntityExtendingEntityWithInstanceGetEntityManager extends EntityWithInstanceGetEntityManager {
+	private String otherName;
+
+	public String getOtherName() {
+		return otherName;
+	}
+
+	public void setOtherName(String otherName) {
+		this.otherName = otherName;
+	}
+}

--- a/tooling/metamodel-generator/src/test/java/org/hibernate/jpamodelgen/test/constructor/EntityExtendingEntityWithStaticGetEntityManager.java
+++ b/tooling/metamodel-generator/src/test/java/org/hibernate/jpamodelgen/test/constructor/EntityExtendingEntityWithStaticGetEntityManager.java
@@ -1,0 +1,22 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html
+ */
+package org.hibernate.jpamodelgen.test.constructor;
+
+import jakarta.persistence.Entity;
+
+@Entity
+public class EntityExtendingEntityWithStaticGetEntityManager extends EntityWithStaticGetEntityManager {
+	private String otherName;
+
+	public String getOtherName() {
+		return otherName;
+	}
+
+	public void setOtherName(String otherName) {
+		this.otherName = otherName;
+	}
+}

--- a/tooling/metamodel-generator/src/test/java/org/hibernate/jpamodelgen/test/constructor/EntityExtendingMapperSuperClassExtendingNonEntityWithInstanceGetEntityManager.java
+++ b/tooling/metamodel-generator/src/test/java/org/hibernate/jpamodelgen/test/constructor/EntityExtendingMapperSuperClassExtendingNonEntityWithInstanceGetEntityManager.java
@@ -1,0 +1,34 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html
+ */
+package org.hibernate.jpamodelgen.test.constructor;
+
+import jakarta.persistence.Entity;
+
+@Entity
+public class EntityExtendingMapperSuperClassExtendingNonEntityWithInstanceGetEntityManager
+		extends MapperSuperClassExtendingNonEntityWithInstanceGetEntityManager {
+
+	private String name;
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+
+	private String otherName;
+
+	public String getOtherName() {
+		return otherName;
+	}
+
+	public void setOtherName(String otherName) {
+		this.otherName = otherName;
+	}
+}

--- a/tooling/metamodel-generator/src/test/java/org/hibernate/jpamodelgen/test/constructor/EntityExtendingMapperSuperClassExtendingNonEntityWithStaticGetEntityManager.java
+++ b/tooling/metamodel-generator/src/test/java/org/hibernate/jpamodelgen/test/constructor/EntityExtendingMapperSuperClassExtendingNonEntityWithStaticGetEntityManager.java
@@ -1,0 +1,34 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html
+ */
+package org.hibernate.jpamodelgen.test.constructor;
+
+import jakarta.persistence.Entity;
+
+@Entity
+public class EntityExtendingMapperSuperClassExtendingNonEntityWithStaticGetEntityManager
+		extends MapperSuperClassExtendingNonEntityWithStaticGetEntityManager {
+
+	private String name;
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+
+	private String otherName;
+
+	public String getOtherName() {
+		return otherName;
+	}
+
+	public void setOtherName(String otherName) {
+		this.otherName = otherName;
+	}
+}

--- a/tooling/metamodel-generator/src/test/java/org/hibernate/jpamodelgen/test/constructor/EntityExtendingMapperSuperClassWithInstanceGetEntityManager.java
+++ b/tooling/metamodel-generator/src/test/java/org/hibernate/jpamodelgen/test/constructor/EntityExtendingMapperSuperClassWithInstanceGetEntityManager.java
@@ -1,0 +1,34 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html
+ */
+package org.hibernate.jpamodelgen.test.constructor;
+
+import jakarta.persistence.Entity;
+
+@Entity
+public class EntityExtendingMapperSuperClassWithInstanceGetEntityManager
+		extends MapperSuperClassWithInstanceGetEntityManager {
+
+	private String name;
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+
+	private String otherName;
+
+	public String getOtherName() {
+		return otherName;
+	}
+
+	public void setOtherName(String otherName) {
+		this.otherName = otherName;
+	}
+}

--- a/tooling/metamodel-generator/src/test/java/org/hibernate/jpamodelgen/test/constructor/EntityExtendingMapperSuperClassWithStaticGetEntityManager.java
+++ b/tooling/metamodel-generator/src/test/java/org/hibernate/jpamodelgen/test/constructor/EntityExtendingMapperSuperClassWithStaticGetEntityManager.java
@@ -1,0 +1,34 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html
+ */
+package org.hibernate.jpamodelgen.test.constructor;
+
+import jakarta.persistence.Entity;
+
+@Entity
+public class EntityExtendingMapperSuperClassWithStaticGetEntityManager
+		extends MapperSuperClassWithStaticGetEntityManager {
+
+	private String name;
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+
+	private String otherName;
+
+	public String getOtherName() {
+		return otherName;
+	}
+
+	public void setOtherName(String otherName) {
+		this.otherName = otherName;
+	}
+}

--- a/tooling/metamodel-generator/src/test/java/org/hibernate/jpamodelgen/test/constructor/EntityExtendingNonEntityWithInstanceGetEntityManager.java
+++ b/tooling/metamodel-generator/src/test/java/org/hibernate/jpamodelgen/test/constructor/EntityExtendingNonEntityWithInstanceGetEntityManager.java
@@ -1,0 +1,43 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html
+ */
+package org.hibernate.jpamodelgen.test.constructor;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+
+@Entity
+public class EntityExtendingNonEntityWithInstanceGetEntityManager extends NonEntityWithInstanceGetEntityManager {
+	@Id
+	private Long id;
+	private String name;
+
+	public Long getId() {
+		return id;
+	}
+
+	public void setId(Long id) {
+		this.id = id;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+
+	private String otherName;
+
+	public String getOtherName() {
+		return otherName;
+	}
+
+	public void setOtherName(String otherName) {
+		this.otherName = otherName;
+	}
+}

--- a/tooling/metamodel-generator/src/test/java/org/hibernate/jpamodelgen/test/constructor/EntityExtendingNonEntityWithStaticGetEntityManager.java
+++ b/tooling/metamodel-generator/src/test/java/org/hibernate/jpamodelgen/test/constructor/EntityExtendingNonEntityWithStaticGetEntityManager.java
@@ -1,0 +1,43 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html
+ */
+package org.hibernate.jpamodelgen.test.constructor;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+
+@Entity
+public class EntityExtendingNonEntityWithStaticGetEntityManager extends NonEntityWithStaticGetEntityManager {
+	@Id
+	private Long id;
+	private String name;
+
+	public Long getId() {
+		return id;
+	}
+
+	public void setId(Long id) {
+		this.id = id;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+
+	private String otherName;
+
+	public String getOtherName() {
+		return otherName;
+	}
+
+	public void setOtherName(String otherName) {
+		this.otherName = otherName;
+	}
+}

--- a/tooling/metamodel-generator/src/test/java/org/hibernate/jpamodelgen/test/constructor/EntityWithInstanceGetEntityManager.java
+++ b/tooling/metamodel-generator/src/test/java/org/hibernate/jpamodelgen/test/constructor/EntityWithInstanceGetEntityManager.java
@@ -1,0 +1,44 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html
+ */
+package org.hibernate.jpamodelgen.test.constructor;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.Id;
+import jakarta.persistence.Transient;
+
+@Entity
+public class EntityWithInstanceGetEntityManager {
+
+	@Transient
+	public EntityManager getEntityManager() {
+		// In a real-world scenario, this would contain some framework-specific code
+		throw new IllegalStateException( "This method shouldn't be called in tests" );
+	}
+
+	@Id
+	private Long id;
+	private String name;
+	private String entityManager;
+
+	public Long getId() {
+		return id;
+	}
+
+	public void setId(Long id) {
+		this.id = id;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+
+}

--- a/tooling/metamodel-generator/src/test/java/org/hibernate/jpamodelgen/test/constructor/EntityWithStaticGetEntityManager.java
+++ b/tooling/metamodel-generator/src/test/java/org/hibernate/jpamodelgen/test/constructor/EntityWithStaticGetEntityManager.java
@@ -1,0 +1,41 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html
+ */
+package org.hibernate.jpamodelgen.test.constructor;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.Id;
+
+@Entity
+public class EntityWithStaticGetEntityManager {
+
+	public static EntityManager getEntityManager() {
+		// In a real-world scenario, this would contain some framework-specific code
+		throw new IllegalStateException( "This method shouldn't be called in tests" );
+	}
+
+	@Id
+	private Long id;
+	private String name;
+
+	public Long getId() {
+		return id;
+	}
+
+	public void setId(Long id) {
+		this.id = id;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+
+}

--- a/tooling/metamodel-generator/src/test/java/org/hibernate/jpamodelgen/test/constructor/MapperSuperClassExtendingNonEntityWithInstanceGetEntityManager.java
+++ b/tooling/metamodel-generator/src/test/java/org/hibernate/jpamodelgen/test/constructor/MapperSuperClassExtendingNonEntityWithInstanceGetEntityManager.java
@@ -1,0 +1,27 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html
+ */
+package org.hibernate.jpamodelgen.test.constructor;
+
+import jakarta.persistence.Id;
+import jakarta.persistence.MappedSuperclass;
+
+@MappedSuperclass
+public abstract class MapperSuperClassExtendingNonEntityWithInstanceGetEntityManager
+		extends NonEntityWithInstanceGetEntityManager {
+
+	@Id
+	private Long id;
+
+	public Long getId() {
+		return id;
+	}
+
+	public void setId(Long id) {
+		this.id = id;
+	}
+
+}

--- a/tooling/metamodel-generator/src/test/java/org/hibernate/jpamodelgen/test/constructor/MapperSuperClassExtendingNonEntityWithStaticGetEntityManager.java
+++ b/tooling/metamodel-generator/src/test/java/org/hibernate/jpamodelgen/test/constructor/MapperSuperClassExtendingNonEntityWithStaticGetEntityManager.java
@@ -1,0 +1,27 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html
+ */
+package org.hibernate.jpamodelgen.test.constructor;
+
+import jakarta.persistence.Id;
+import jakarta.persistence.MappedSuperclass;
+
+@MappedSuperclass
+public abstract class MapperSuperClassExtendingNonEntityWithStaticGetEntityManager
+		extends NonEntityWithStaticGetEntityManager {
+
+	@Id
+	private Long id;
+
+	public Long getId() {
+		return id;
+	}
+
+	public void setId(Long id) {
+		this.id = id;
+	}
+
+}

--- a/tooling/metamodel-generator/src/test/java/org/hibernate/jpamodelgen/test/constructor/MapperSuperClassWithInstanceGetEntityManager.java
+++ b/tooling/metamodel-generator/src/test/java/org/hibernate/jpamodelgen/test/constructor/MapperSuperClassWithInstanceGetEntityManager.java
@@ -1,0 +1,33 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html
+ */
+package org.hibernate.jpamodelgen.test.constructor;
+
+import jakarta.persistence.Id;
+import jakarta.persistence.MappedSuperclass;
+import jakarta.persistence.Transient;
+
+@MappedSuperclass
+public abstract class MapperSuperClassWithInstanceGetEntityManager {
+
+	@Id
+	private Long id;
+
+	public Long getId() {
+		return id;
+	}
+
+	public void setId(Long id) {
+		this.id = id;
+	}
+
+	@Transient
+	public String getEntityManager() {
+		// In a real-world scenario, this would contain some framework-specific code
+		throw new IllegalStateException( "This method shouldn't be called in tests" );
+	}
+
+}

--- a/tooling/metamodel-generator/src/test/java/org/hibernate/jpamodelgen/test/constructor/MapperSuperClassWithStaticGetEntityManager.java
+++ b/tooling/metamodel-generator/src/test/java/org/hibernate/jpamodelgen/test/constructor/MapperSuperClassWithStaticGetEntityManager.java
@@ -1,0 +1,32 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html
+ */
+package org.hibernate.jpamodelgen.test.constructor;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.Id;
+import jakarta.persistence.MappedSuperclass;
+
+@MappedSuperclass
+public abstract class MapperSuperClassWithStaticGetEntityManager {
+
+	public static EntityManager getEntityManager() {
+		// In a real-world scenario, this would contain some framework-specific code
+		throw new IllegalStateException( "This method shouldn't be called in tests" );
+	}
+
+	@Id
+	private Long id;
+
+	public Long getId() {
+		return id;
+	}
+
+	public void setId(Long id) {
+		this.id = id;
+	}
+
+}

--- a/tooling/metamodel-generator/src/test/java/org/hibernate/jpamodelgen/test/constructor/NonEntityWithInstanceGetEntityManager.java
+++ b/tooling/metamodel-generator/src/test/java/org/hibernate/jpamodelgen/test/constructor/NonEntityWithInstanceGetEntityManager.java
@@ -1,0 +1,19 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html
+ */
+package org.hibernate.jpamodelgen.test.constructor;
+
+import jakarta.persistence.Transient;
+
+public abstract class NonEntityWithInstanceGetEntityManager {
+
+	@Transient
+	public String getEntityManager() {
+		// In a real-world scenario, this would contain some framework-specific code
+		throw new IllegalStateException( "This method shouldn't be called in tests" );
+	}
+
+}

--- a/tooling/metamodel-generator/src/test/java/org/hibernate/jpamodelgen/test/constructor/NonEntityWithStaticGetEntityManager.java
+++ b/tooling/metamodel-generator/src/test/java/org/hibernate/jpamodelgen/test/constructor/NonEntityWithStaticGetEntityManager.java
@@ -1,0 +1,18 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html
+ */
+package org.hibernate.jpamodelgen.test.constructor;
+
+import jakarta.persistence.EntityManager;
+
+public abstract class NonEntityWithStaticGetEntityManager {
+
+	public static EntityManager getEntityManager() {
+		// In a real-world scenario, this would contain some framework-specific code
+		throw new IllegalStateException( "This method shouldn't be called in tests" );
+	}
+
+}

--- a/tooling/metamodel-generator/src/test/java/org/hibernate/jpamodelgen/test/constructor/SuperClassWithGetEntityManagerTest.java
+++ b/tooling/metamodel-generator/src/test/java/org/hibernate/jpamodelgen/test/constructor/SuperClassWithGetEntityManagerTest.java
@@ -1,0 +1,125 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html
+ */
+package org.hibernate.jpamodelgen.test.constructor;
+
+import static org.hibernate.jpamodelgen.test.util.TestUtil.assertAbsenceOfNonDefaultConstructorInMetamodelFor;
+import static org.hibernate.jpamodelgen.test.util.TestUtil.assertMetamodelClassGeneratedFor;
+
+import org.hibernate.jpamodelgen.test.util.CompilationTest;
+import org.hibernate.jpamodelgen.test.util.TestForIssue;
+import org.hibernate.jpamodelgen.test.util.TestUtil;
+import org.hibernate.jpamodelgen.test.util.WithClasses;
+
+import org.junit.Test;
+
+/**
+ * Test various scenarios where a superclass of an entity has a {@code getEntityManager()} method.
+ * <p>
+ * The superclass may be itself an entity, or a mapped superclass, or not mapped at all.
+ * <p>
+ * The method may be static or not.
+ */
+@TestForIssue(jiraKey = "HHH-17683")
+public class SuperClassWithGetEntityManagerTest extends CompilationTest {
+	@Test
+	@WithClasses({ EntityWithInstanceGetEntityManager.class, EntityExtendingEntityWithInstanceGetEntityManager.class })
+	public void entityWithInstanceGetEntityManager() {
+		doTest( EntityWithInstanceGetEntityManager.class, EntityExtendingEntityWithInstanceGetEntityManager.class );
+	}
+
+	@Test
+	@WithClasses({ EntityWithStaticGetEntityManager.class, EntityExtendingEntityWithStaticGetEntityManager.class })
+	public void entityWithStaticGetEntityManager() {
+		doTest( EntityWithStaticGetEntityManager.class, EntityExtendingEntityWithStaticGetEntityManager.class );
+	}
+
+	@Test
+	@WithClasses({
+			NonEntityWithInstanceGetEntityManager.class, EntityExtendingNonEntityWithInstanceGetEntityManager.class
+	})
+	public void nonEntityWithInstanceGetEntityManager() {
+		doTest(
+				NonEntityWithInstanceGetEntityManager.class,
+				EntityExtendingNonEntityWithInstanceGetEntityManager.class
+		);
+	}
+
+	@Test
+	@WithClasses({
+			NonEntityWithStaticGetEntityManager.class,
+			EntityExtendingNonEntityWithStaticGetEntityManager.class
+	})
+	public void nonEntityWithStaticGetEntityManager() {
+		doTest(
+				NonEntityWithStaticGetEntityManager.class,
+				EntityExtendingNonEntityWithStaticGetEntityManager.class
+		);
+	}
+
+	@Test
+	@WithClasses({
+			MapperSuperClassWithInstanceGetEntityManager.class,
+			EntityExtendingMapperSuperClassWithInstanceGetEntityManager.class
+	})
+	public void mappedSuperClassWithInstanceGetEntityManager() {
+		doTest(
+				MapperSuperClassWithInstanceGetEntityManager.class,
+				EntityExtendingMapperSuperClassWithInstanceGetEntityManager.class
+		);
+	}
+
+	@Test
+	@WithClasses({
+			MapperSuperClassWithStaticGetEntityManager.class,
+			EntityExtendingMapperSuperClassWithStaticGetEntityManager.class
+	})
+	public void mappedSuperClassWithStaticGetEntityManager() {
+		doTest(
+				MapperSuperClassWithStaticGetEntityManager.class,
+				EntityExtendingMapperSuperClassWithStaticGetEntityManager.class
+		);
+	}
+
+	@Test
+	@WithClasses({
+			NonEntityWithInstanceGetEntityManager.class,
+			MapperSuperClassExtendingNonEntityWithInstanceGetEntityManager.class,
+			EntityExtendingMapperSuperClassExtendingNonEntityWithInstanceGetEntityManager.class
+	})
+	public void mappedSuperClassExtendingNonEntityWithInstanceGetEntityManager() {
+		doTest(
+				MapperSuperClassExtendingNonEntityWithInstanceGetEntityManager.class,
+				EntityExtendingMapperSuperClassExtendingNonEntityWithInstanceGetEntityManager.class
+		);
+	}
+
+	// NOTE: only this test matches the Panache use case exactly.
+	// see https://github.com/quarkusio/quarkus/issues/38378#issuecomment-1911702314
+	@Test
+	@WithClasses({
+			NonEntityWithStaticGetEntityManager.class,
+			MapperSuperClassExtendingNonEntityWithStaticGetEntityManager.class,
+			EntityExtendingMapperSuperClassExtendingNonEntityWithStaticGetEntityManager.class
+	})
+	public void mappedSuperClassExtendingNonEntityWithStaticGetEntityManager() {
+		doTest(
+				MapperSuperClassExtendingNonEntityWithStaticGetEntityManager.class,
+				EntityExtendingMapperSuperClassExtendingNonEntityWithStaticGetEntityManager.class
+		);
+	}
+
+	private void doTest(Class<?> superclass, Class<?> entitySubclass) {
+		System.out.println( TestUtil.getMetaModelSourceAsString( superclass ) );
+		System.out.println( TestUtil.getMetaModelSourceAsString( entitySubclass ) );
+		assertMetamodelClassGeneratedFor( entitySubclass );
+		assertAbsenceOfNonDefaultConstructorInMetamodelFor(
+				entitySubclass,
+				"The generated metamodel shouldn't include a non-default constructor. In particular, it shouldn't be injected with an entity manager."
+		);
+	}
+}
+


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-17683

~~Creating as draft: this is a reproducer, not a fix.~~ => The fix was merged as part of #7755 
