### PR TITLE
HHH-17587 Setting to null a property from a @SecondaryTable and @DynamicUpdate deletes the whole entry from database

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/persister/entity/AbstractEntityPersister.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/entity/AbstractEntityPersister.java
@@ -3479,6 +3479,8 @@ public abstract class AbstractEntityPersister
 		private final Expectation deleteExpectation;
 		private final String customDeleteSql;
 		private final boolean deleteCallable;
+		private final boolean dynamicUpdate;
+		private final boolean dynamicInsert;
 
 		private final List<Integer> attributeIndexes = new ArrayList<>();
 
@@ -3498,7 +3500,9 @@ public abstract class AbstractEntityPersister
 				boolean cascadeDeleteEnabled,
 				Expectation deleteExpectation,
 				String customDeleteSql,
-				boolean deleteCallable) {
+				boolean deleteCallable,
+				boolean dynamicUpdate,
+				boolean dynamicInsert) {
 			this.tableName = tableName;
 			this.relativePosition = relativePosition;
 			this.keyMapping = keyMapping;
@@ -3515,6 +3519,8 @@ public abstract class AbstractEntityPersister
 			this.deleteExpectation = deleteExpectation;
 			this.customDeleteSql = customDeleteSql;
 			this.deleteCallable = deleteCallable;
+			this.dynamicUpdate = dynamicUpdate;
+			this.dynamicInsert = dynamicInsert;
 		}
 
 		private EntityTableMapping build() {
@@ -3535,7 +3541,9 @@ public abstract class AbstractEntityPersister
 					cascadeDeleteEnabled,
 					deleteExpectation,
 					customDeleteSql,
-					deleteCallable
+					deleteCallable,
+					dynamicUpdate,
+					dynamicInsert
 			);
 		}
 	}
@@ -3592,7 +3600,9 @@ public abstract class AbstractEntityPersister
 						isTableCascadeDeleteEnabled( relativePosition ),
 						deleteExpectations[ relativePosition ],
 						customDeleteSql,
-						deleteCallable[ relativePosition ]
+						deleteCallable[ relativePosition ],
+						entityMetamodel.isDynamicUpdate(),
+						entityMetamodel.isDynamicInsert()
 				);
 
 				tableBuilderMap.put( tableExpression, tableMappingBuilder );

--- a/hibernate-core/src/main/java/org/hibernate/persister/entity/mutation/EntityTableMapping.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/entity/mutation/EntityTableMapping.java
@@ -65,14 +65,33 @@ public class EntityTableMapping implements TableMapping {
 			boolean cascadeDeleteEnabled,
 			Expectation deleteExpectation,
 			String deleteCustomSql,
-			boolean deleteCallable) {
+			boolean deleteCallable,
+			boolean dynamicUpdate,
+			boolean dynamicInsert) {
 		this.tableName = tableName;
 		this.relativePosition = relativePosition;
 		this.keyMapping = keyMapping;
 		this.attributeIndexes = attributeIndexes;
-		this.insertDetails = new MutationDetails( MutationType.INSERT, insertExpectation, insertCustomSql, insertCallable );
-		this.updateDetails = new MutationDetails( MutationType.UPDATE, updateExpectation, updateCustomSql, updateCallable );
-		this.deleteDetails = new MutationDetails( MutationType.DELETE, deleteExpectation, deleteCustomSql, deleteCallable );
+		this.insertDetails = new MutationDetails(
+				MutationType.INSERT,
+				insertExpectation,
+				insertCustomSql,
+				insertCallable,
+				dynamicInsert
+		);
+		this.updateDetails = new MutationDetails(
+				MutationType.UPDATE,
+				updateExpectation,
+				updateCustomSql,
+				updateCallable,
+				dynamicUpdate
+		);
+		this.deleteDetails = new MutationDetails(
+				MutationType.DELETE,
+				deleteExpectation,
+				deleteCustomSql,
+				deleteCallable
+		);
 
 		if ( isOptional ) {
 			flags.set( Flag.OPTIONAL.ordinal() );

--- a/hibernate-core/src/main/java/org/hibernate/persister/entity/mutation/UpdateCoordinatorStandard.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/entity/mutation/UpdateCoordinatorStandard.java
@@ -305,7 +305,7 @@ public class UpdateCoordinatorStandard extends AbstractMutationCoordinator imple
 		);
 
 		//noinspection StatementWithEmptyBody
-		if ( valuesAnalysis.tablesNeedingUpdate.isEmpty() ) {
+		if ( valuesAnalysis.tablesNeedingUpdate.isEmpty() && valuesAnalysis.tablesNeedingDynamicUpdate.isEmpty() ) {
 			// nothing to do
 		}
 		else if ( valuesAnalysis.needsDynamicUpdate() ) {
@@ -969,7 +969,9 @@ public class UpdateCoordinatorStandard extends AbstractMutationCoordinator imple
 						if ( tableMapping.isOptional()
 								&& !valuesAnalysis.tablesWithNonNullValues.contains( tableMapping ) ) {
 							// the table is optional, and we have null values for all of its columns
-							// todo (6.0) : technically we might need to delete row here
+							if ( valuesAnalysis.dirtyAttributeIndexes.length > 0 ) {
+								return true;
+							}
 							return false;
 						}
 						else {

--- a/hibernate-core/src/main/java/org/hibernate/persister/entity/mutation/UpdateValuesAnalysis.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/entity/mutation/UpdateValuesAnalysis.java
@@ -40,6 +40,8 @@ public interface UpdateValuesAnalysis extends ValuesAnalysis {
 	 */
 	TableSet getTablesWithPreviousNonNullValues();
 
+	TableSet getTablesNeedingDynamicUpdate();
+
 	/**
 	 * Descriptors for the analysis of each attribute
 	 */

--- a/hibernate-core/src/main/java/org/hibernate/sql/model/TableMapping.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/model/TableMapping.java
@@ -81,16 +81,33 @@ public interface TableMapping extends TableDetails {
 		private final Expectation expectation;
 		private final String customSql;
 		private final boolean callable;
+		private final boolean dynamicMutation;
 
 		public MutationDetails(
 				MutationType mutationType,
 				Expectation expectation,
 				String customSql,
 				boolean callable) {
+			this(
+					mutationType,
+					expectation,
+					customSql,
+					callable,
+					false
+			);
+		}
+
+		public MutationDetails(
+				MutationType mutationType,
+				Expectation expectation,
+				String customSql,
+				boolean callable,
+				boolean dynamicMutation) {
 			this.mutationType = mutationType;
 			this.expectation = expectation;
 			this.customSql = customSql;
 			this.callable = callable;
+			this.dynamicMutation = dynamicMutation;
 		}
 
 		/**
@@ -122,5 +139,10 @@ public interface TableMapping extends TableDetails {
 		public boolean isCallable() {
 			return callable;
 		}
+
+		public boolean isDynamicMutation() {
+			return dynamicMutation;
+		}
 	}
+
 }

--- a/hibernate-core/src/main/java/org/hibernate/sql/model/internal/OptionalTableUpdate.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/model/internal/OptionalTableUpdate.java
@@ -128,9 +128,15 @@ public class OptionalTableUpdate
 
 	@Override
 	public MutationOperation createMutationOperation(ValuesAnalysis valuesAnalysis, SessionFactoryImplementor factory) {
-		if ( getMutatingTable().getTableMapping().getInsertDetails().getCustomSql() != null
-				|| getMutatingTable().getTableMapping().getDeleteDetails().getCustomSql() != null ) {
+		final TableMapping tableMapping = getMutatingTable().getTableMapping();
+		if ( tableMapping.getInsertDetails().getCustomSql() != null
+				|| tableMapping.getInsertDetails().isDynamicMutation()
+				|| tableMapping.getDeleteDetails().getCustomSql() != null
+				|| tableMapping.getUpdateDetails().getCustomSql() != null
+				|| tableMapping.getUpdateDetails().isDynamicMutation() ) {
 			// Fallback to the optional table mutation operation because we have to execute user specified SQL
+			// and with dynamic update insert we have to avoid using merge for optional table because
+			// it can cause the deletion of the row when an attribute is set to null
 			return new OptionalTableUpdateOperation( getMutationTarget(), this, factory );
 		}
 		return factory.getJdbcServices().getDialect().createOptionalTableUpdateOperation(

--- a/hibernate-core/src/main/java/org/hibernate/sql/model/jdbc/OptionalTableUpdateOperation.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/model/jdbc/OptionalTableUpdateOperation.java
@@ -127,7 +127,8 @@ public class OptionalTableUpdateOperation implements SelfExecutingUpdateOperatio
 			ValuesAnalysis incomingValuesAnalysis,
 			SharedSessionContractImplementor session) {
 		final UpdateValuesAnalysis valuesAnalysis = (UpdateValuesAnalysis) incomingValuesAnalysis;
-		if ( !valuesAnalysis.getTablesNeedingUpdate().contains( tableMapping ) ) {
+		if ( !valuesAnalysis.getTablesNeedingUpdate().contains( tableMapping )
+				&& !valuesAnalysis.getTablesNeedingDynamicUpdate().contains( tableMapping ) ) {
 			return;
 		}
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/secondarytable/SecondaryTableDynamicUpateTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/secondarytable/SecondaryTableDynamicUpateTest.java
@@ -1,0 +1,149 @@
+package org.hibernate.orm.test.annotations.secondarytable;
+
+import org.hibernate.annotations.DynamicUpdate;
+
+import org.hibernate.testing.orm.junit.EntityManagerFactoryScope;
+import org.hibernate.testing.orm.junit.JiraKey;
+import org.hibernate.testing.orm.junit.Jpa;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.PrimaryKeyJoinColumn;
+import jakarta.persistence.SecondaryTable;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+@Jpa(
+		annotatedClasses = {
+				SecondaryTableDynamicUpateTest.TestEntity.class
+		}
+)
+@JiraKey("HHH-17587")
+public class SecondaryTableDynamicUpateTest {
+
+	private static final Long ENTITY_ID = 123l;
+	private static final String COL_VALUE = "col";
+	private static final String COL1_VALUE = "col1";
+	private static final String COL2_VALUE = "col2";
+
+	@BeforeAll
+	public static void setUp(EntityManagerFactoryScope scope) {
+		scope.inTransaction(
+				entityManager -> {
+					TestEntity testEntity = new TestEntity( ENTITY_ID, COL_VALUE, COL1_VALUE, COL2_VALUE );
+					entityManager.persist( testEntity );
+				}
+		);
+	}
+
+	@Test
+	public void testSetSecondaryTableColumnToNull(EntityManagerFactoryScope scope) {
+		scope.inTransaction(
+				entityManager -> {
+					TestEntity testEntity = entityManager.find( TestEntity.class, ENTITY_ID );
+					assertThat( testEntity.getTestCol() ).isEqualTo( COL_VALUE );
+					assertThat( testEntity.getTestCol1() ).isEqualTo( COL1_VALUE );
+					assertThat( testEntity.getTestCol2() ).isEqualTo( COL2_VALUE );
+					testEntity.setTestCol1( null );
+				}
+		);
+
+		scope.inTransaction(
+				entityManager -> {
+					TestEntity testEntity = entityManager.find( TestEntity.class, ENTITY_ID );
+					assertThat( testEntity ).isNotNull();
+					assertThat( testEntity.getTestCol() ).isEqualTo( COL_VALUE );
+					assertThat( testEntity.getTestCol1() ).isNull();
+					assertThat( testEntity.getTestCol2() ).isEqualTo( COL2_VALUE );
+					testEntity.setTestCol2( null );
+				}
+		);
+
+		scope.inTransaction(
+				entityManager -> {
+					TestEntity testEntity = entityManager.find( TestEntity.class, ENTITY_ID );
+					assertThat( testEntity ).isNotNull();
+					assertThat( testEntity.getTestCol() ).isEqualTo( COL_VALUE );
+					assertThat( testEntity.getTestCol1() ).isNull();
+					assertThat( testEntity.getTestCol2() ).isNull();
+					testEntity.setTestCol1( COL1_VALUE );
+					testEntity.setTestCol( null );
+				}
+		);
+
+		scope.inTransaction(
+				entityManager -> {
+					TestEntity testEntity = entityManager.find( TestEntity.class, ENTITY_ID );
+					assertThat( testEntity ).isNotNull();
+					assertThat( testEntity.getTestCol() ).isNull();
+					assertThat( testEntity.getTestCol1() ).isEqualTo( COL1_VALUE );
+					assertThat( testEntity.getTestCol2() ).isNull();
+					testEntity.setTestCol2( null );
+				}
+		);
+	}
+
+	@Entity(name = "TestEntity")
+	@SecondaryTable(name = "SECOND_TABLE_TEST", pkJoinColumns = @PrimaryKeyJoinColumn(name = "ID"))
+	@DynamicUpdate
+	public static class TestEntity {
+
+		@Id
+		private Long id;
+
+		@Column(name = "TEST_COL")
+		private String testCol;
+
+		@Column(name = "TESTCOL1", table = "SECOND_TABLE_TEST")
+		private String testCol1;
+
+		@Column(name = "TESTCOL2", table = "SECOND_TABLE_TEST")
+		private String testCol2;
+
+		public TestEntity() {
+		}
+
+		public TestEntity(Long id, String testCol, String testCol1, String testCol2) {
+			this.id = id;
+			this.testCol = testCol;
+			this.testCol1 = testCol1;
+			this.testCol2 = testCol2;
+		}
+
+		public Long getId() {
+			return id;
+		}
+
+		public void setId(Long id) {
+			this.id = id;
+		}
+
+		public String getTestCol() {
+			return testCol;
+		}
+
+		public void setTestCol(String testCol) {
+			this.testCol = testCol;
+		}
+
+		public String getTestCol1() {
+			return testCol1;
+		}
+
+		public void setTestCol1(String testCol1) {
+			this.testCol1 = testCol1;
+		}
+
+		public String getTestCol2() {
+			return testCol2;
+		}
+
+		public void setTestCol2(String testCol2) {
+			this.testCol2 = testCol2;
+		}
+
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/secondarytables/SecondaryTableDynamicUpateTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/secondarytables/SecondaryTableDynamicUpateTest.java
@@ -1,0 +1,153 @@
+package org.hibernate.orm.test.bytecode.enhancement.secondarytables;
+
+import org.hibernate.annotations.DynamicUpdate;
+
+import org.hibernate.testing.bytecode.enhancement.BytecodeEnhancerRunner;
+import org.hibernate.testing.junit4.BaseCoreFunctionalTestCase;
+import org.hibernate.testing.orm.junit.JiraKey;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.PrimaryKeyJoinColumn;
+import jakarta.persistence.SecondaryTable;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+@JiraKey("HHH-17587")
+@RunWith(BytecodeEnhancerRunner.class)
+public class SecondaryTableDynamicUpateTest extends BaseCoreFunctionalTestCase {
+
+	private static final Long ENTITY_ID = 123l;
+	private static final String COL_VALUE = "col";
+	private static final String COL1_VALUE = "col1";
+	private static final String COL2_VALUE = "col2";
+
+	@Override
+	protected Class<?>[] getAnnotatedClasses() {
+		return new Class[] {
+				TestEntity.class
+		};
+	}
+
+	@Before
+	public void setUp() {
+		inTransaction(
+				entityManager -> {
+					TestEntity testEntity = new TestEntity( ENTITY_ID, COL_VALUE, COL1_VALUE, COL2_VALUE );
+					entityManager.persist( testEntity );
+				}
+		);
+	}
+
+	@Test
+	public void testSetSecondaryTableColumnToNull() {
+		inTransaction(
+				entityManager -> {
+					TestEntity testEntity = entityManager.find( TestEntity.class, ENTITY_ID );
+					assertThat( testEntity.getTestCol() ).isEqualTo( COL_VALUE );
+					assertThat( testEntity.getTestCol1() ).isEqualTo( COL1_VALUE );
+					assertThat( testEntity.getTestCol2() ).isEqualTo( COL2_VALUE );
+					testEntity.setTestCol1( null );
+				}
+		);
+
+		inTransaction(
+				entityManager -> {
+					TestEntity testEntity = entityManager.find( TestEntity.class, ENTITY_ID );
+					assertThat( testEntity ).isNotNull();
+					assertThat( testEntity.getTestCol() ).isEqualTo( COL_VALUE );
+					assertThat( testEntity.getTestCol1() ).isNull();
+					assertThat( testEntity.getTestCol2() ).isEqualTo( COL2_VALUE );
+					testEntity.setTestCol2( null );
+				}
+		);
+
+		inTransaction(
+				entityManager -> {
+					TestEntity testEntity = entityManager.find( TestEntity.class, ENTITY_ID );
+					assertThat( testEntity ).isNotNull();
+					assertThat( testEntity.getTestCol() ).isEqualTo( COL_VALUE );
+					assertThat( testEntity.getTestCol1() ).isNull();
+					assertThat( testEntity.getTestCol2() ).isNull();
+					testEntity.setTestCol1( COL1_VALUE );
+					testEntity.setTestCol( null );
+				}
+		);
+
+		inTransaction(
+				entityManager -> {
+					TestEntity testEntity = entityManager.find( TestEntity.class, ENTITY_ID );
+					assertThat( testEntity ).isNotNull();
+					assertThat( testEntity.getTestCol() ).isNull();
+					assertThat( testEntity.getTestCol1() ).isEqualTo( COL1_VALUE );
+					assertThat( testEntity.getTestCol2() ).isNull();
+					testEntity.setTestCol2( null );
+				}
+		);
+	}
+
+	@Entity(name = "TestEntity")
+	@SecondaryTable(name = "SECOND_TABLE_TEST", pkJoinColumns = @PrimaryKeyJoinColumn(name = "ID"))
+	@DynamicUpdate
+	public static class TestEntity {
+
+		@Id
+		private Long id;
+
+		@Column(name = "TEST_COL")
+		private String testCol;
+
+		@Column(name = "TESTCOL1", table = "SECOND_TABLE_TEST")
+		private String testCol1;
+
+		@Column(name = "TESTCOL2", table = "SECOND_TABLE_TEST")
+		private String testCol2;
+
+		public TestEntity() {
+		}
+
+		public TestEntity(Long id, String testCol, String testCol1, String testCol2) {
+			this.id = id;
+			this.testCol = testCol;
+			this.testCol1 = testCol1;
+			this.testCol2 = testCol2;
+		}
+
+		public Long getId() {
+			return id;
+		}
+
+		public void setId(Long id) {
+			this.id = id;
+		}
+
+		public String getTestCol() {
+			return testCol;
+		}
+
+		public void setTestCol(String testCol) {
+			this.testCol = testCol;
+		}
+
+		public String getTestCol1() {
+			return testCol1;
+		}
+
+		public void setTestCol1(String testCol1) {
+			this.testCol1 = testCol1;
+		}
+
+		public String getTestCol2() {
+			return testCol2;
+		}
+
+		public void setTestCol2(String testCol2) {
+			this.testCol2 = testCol2;
+		}
+
+	}
+}


### PR DESCRIPTION
backport of https://hibernate.atlassian.net/browse/HHH-17587 to 6.4