### PR TITLE
HHH-17707 Improve ColumnReference.toString() to remove repeated qualifier

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/sql/ast/tree/expression/ColumnReference.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/ast/tree/expression/ColumnReference.java
@@ -30,6 +30,7 @@ import static org.hibernate.sql.Template.TEMPLATE;
  *
  * @author Steve Ebersole
  * @author Nathan Xu
+ * @author Yanming Zhou
  */
 public class ColumnReference implements Expression, Assignable {
 	private final String qualifier;
@@ -224,15 +225,6 @@ public class ColumnReference implements Expression, Assignable {
 
 	@Override
 	public String toString() {
-		if ( StringHelper.isNotEmpty( qualifier ) ) {
-			return String.format(
-					Locale.ROOT,
-					"%s(%s.%s)",
-					getClass().getSimpleName(),
-					qualifier,
-					getExpressionText()
-			);
-		}
 		return String.format(
 				Locale.ROOT,
 				"%s(%s)",


### PR DESCRIPTION
`getExpressionText()` already contains `qualifier`

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-17707
<!-- Hibernate GitHub Bot issue links end -->