### PR TITLE
Move setting of net.bytebuddy.experimental to the Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -49,7 +49,11 @@ stage('Configure') {
 		new BuildEnvironment( testJdkVersion: '20', testJdkLauncherArgs: '--enable-preview' ),
 		new BuildEnvironment( testJdkVersion: '21', testJdkLauncherArgs: '--enable-preview' ),
 		new BuildEnvironment( testJdkVersion: '22', testJdkLauncherArgs: '--enable-preview' ),
-		new BuildEnvironment( testJdkVersion: '23', testJdkLauncherArgs: '--enable-preview' )
+		// The following JDKs aren't supported by Hibernate ORM out-of-the box yet:
+		// they require the use of -Dnet.bytebuddy.experimental=true.
+		// Make sure to remove that argument as soon as possible
+		// -- generally that requires upgrading bytebuddy after the JDK goes GA.
+		new BuildEnvironment( testJdkVersion: '23', testJdkLauncherArgs: '--enable-preview -Dnet.bytebuddy.experimental=true' )
 	];
 
 	if ( env.CHANGE_ID ) {

--- a/gradle/java-module.gradle
+++ b/gradle/java-module.gradle
@@ -295,21 +295,6 @@ test {
 	jvmArgs '-XX:+StartAttachListener'
 }
 
-// Enable the experimental features of ByteBuddy with JDK 22+
-test {
-	// We need to test the *launcher* version,
-	// because some tests will use Mockito (and thus Bytebuddy) to mock/spy
-	// classes that are part of the JDK,
-	// and those classes always have bytecode matching the version of the launcher.
-	// So for example, when using a JDK22 launcher and compiling tests with --release 21,
-	// Bytebuddy will still encounter classes with Java 22 bytecode.
-	if ( jdkVersions.test.launcher.asInt() >= 22 ) {
-		logger.warn( "The version of Java bytecode that will be tested is not supported by Bytebuddy by default. " +
-				 " Setting 'net.bytebuddy.experimental=true'." )
-		systemProperty 'net.bytebuddy.experimental', true
-	}
-}
-
 test {
 	if ( project.findProperty( 'log-test-progress' )?.toString()?.toBoolean() ) {
 		// Log a statement for each test.

--- a/hibernate-core/hibernate-core.gradle
+++ b/hibernate-core/hibernate-core.gradle
@@ -299,12 +299,6 @@ if ( jdkVersions.test.release.asInt() >= 17 && jdkVersions.explicit ) {
         useJUnitPlatform()
         testClassesDirs = sourceSets.testJava17.output.classesDirs
         classpath = sourceSets.testJava17.runtimeClasspath
-
-        if ( jdkVersions.test.launcher.asInt() >= 19 ) {
-            logger.warn( "The version of Java bytecode that will be tested is not supported by Byte Buddy by default. " +
-                                 " Setting 'net.bytebuddy.experimental=true'." )
-            systemProperty 'net.bytebuddy.experimental', true
-        }
     }
 
     testClasses.dependsOn compileTestJava17Java

--- a/tooling/metamodel-generator/hibernate-jpamodelgen.gradle
+++ b/tooling/metamodel-generator/hibernate-jpamodelgen.gradle
@@ -61,12 +61,6 @@ if ( jdkVersions.test.release.asInt() >= 17 && jdkVersions.explicit ) {
         javaLauncher = javaToolchains.launcherFor {
             languageVersion = jdkVersions.test.launcher
         }
-
-        if ( jdkVersions.test.launcher.asInt() >= 19 ) {
-            logger.warn( "The version of Java bytecode that will be tested is not supported by Bytebuddy by default. " +
-                                 " Setting 'net.bytebuddy.experimental=true'." )
-            systemProperty 'net.bytebuddy.experimental', true
-        }
     }
 } else {
     sourceSets {


### PR DESCRIPTION
The hope is that whenever we add a new JDK version to test, we'll notice this setting, will try to remove it and upgrade bytebuddy if necessary. This would avoid mess-ups like the one that caused https://github.com/hibernate/hibernate-orm/pull/7790