### PR TITLE
[HHH-13965] AssertionError exception is thrown by SqlFunctionMetadataBuilderContributorIllegalClassArgumentTest when executing on Eclipse OpenJ9 VM AdoptOpenJDK (v. 11.0.6)

### DIFF
--- a/hibernate-core/src/test/java/org/hibernate/boot/spi/metadatabuildercontributor/SqlFunctionMetadataBuilderContributorIllegalClassArgumentTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/boot/spi/metadatabuildercontributor/SqlFunctionMetadataBuilderContributorIllegalClassArgumentTest.java
@@ -37,7 +37,7 @@ public class SqlFunctionMetadataBuilderContributorIllegalClassArgumentTest
 		catch (ClassCastException e) {
 			final String javaVendor = System.getProperty("java.vendor");
 
-			if (javaVendor != null && javaVendor.startsWith("IBM")) {
+			if (javaVendor != null && (javaVendor.startsWith("IBM") || javaVendor.startsWith("AdoptOpenJDK") || javaVendor.startsWith("Eclipse OpenJ9"))) {
 				assertTrue( e.getMessage().contains( "incompatible with" ) );
 			} else {
 				assertTrue( e.getMessage().contains( "cannot be cast to" ) );


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-13965
https://issues.redhat.com/browse/JBEAP-19317
