### PR TITLE
HHH-17716 implement JtaTransactionAdapterTransactionManagerImpl.setTimeOut()

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/resource/transaction/backend/jta/internal/JtaTransactionAdapterTransactionManagerImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/resource/transaction/backend/jta/internal/JtaTransactionAdapterTransactionManagerImpl.java
@@ -106,6 +106,13 @@ public class JtaTransactionAdapterTransactionManagerImpl implements JtaTransacti
 
 	@Override
 	public void setTimeOut(int seconds) {
-
+		if ( seconds > 0 ) {
+			try {
+				transactionManager.setTransactionTimeout( seconds );
+			}
+			catch (SystemException e) {
+				throw new TransactionException( "Unable to apply requested transaction timeout", e );
+			}
+		}
 	}
 }


### PR DESCRIPTION
Why was this empty?

Let's see if this immediately breaks something...

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-17716
<!-- Hibernate GitHub Bot issue links end -->