### PR TITLE
HHH-9482 - Avoid automatic timing out when requested timeout is 1 second

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/engine/jdbc/internal/JdbcCoordinatorImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/jdbc/internal/JdbcCoordinatorImpl.java
@@ -257,11 +257,11 @@ public class JdbcCoordinatorImpl implements JdbcCoordinator {
 		if ( transactionTimeOutInstant < 0 ) {
 			return -1;
 		}
-		final int secondsRemaining = (int) ((transactionTimeOutInstant - System.currentTimeMillis()) / 1000);
-		if ( secondsRemaining <= 0 ) {
+		final long millisecondsRemaining = transactionTimeOutInstant - System.currentTimeMillis();
+		if ( millisecondsRemaining <= 0L ) {
 			throw new TransactionException( "transaction timeout expired" );
 		}
-		return secondsRemaining;
+		return Math.max( (int) (millisecondsRemaining / 1000), 1 );
 	}
 
 	@Override


### PR DESCRIPTION
<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-9482
<!-- Hibernate GitHub Bot issue links end -->