### PR TITLE
HHH-17745 @HQL methods accepting embeddables

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/binder/internal/TenantIdBinder.java
+++ b/hibernate-core/src/main/java/org/hibernate/binder/internal/TenantIdBinder.java
@@ -66,9 +66,9 @@ public class TenantIdBinder implements AttributeBinder<TenantId> {
 			if ( !parameterJtd.getJavaTypeClass().equals( tenantIdTypeJtd.getJavaTypeClass() ) ) {
 				throw new MappingException(
 						"all @TenantId fields must have the same type: "
-								+ parameterJtd.getJavaType().getTypeName()
+								+ parameterJtd.getTypeName()
 								+ " differs from "
-								+ tenantIdTypeJtd.getJavaType().getTypeName()
+								+ tenantIdTypeJtd.getTypeName()
 				);
 			}
 		}

--- a/hibernate-core/src/main/java/org/hibernate/boot/model/TypeDefinitionRegistryStandardImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/TypeDefinitionRegistryStandardImpl.java
@@ -57,7 +57,7 @@ public class TypeDefinitionRegistryStandardImpl implements TypeDefinitionRegistr
 			return null;
 		}
 
-		return typeDefinitionMap.get( jtd.getJavaType().getTypeName() );
+		return typeDefinitionMap.get( jtd.getTypeName() );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/model/internal/AnnotationBinder.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/internal/AnnotationBinder.java
@@ -782,11 +782,11 @@ public final class AnnotationBinder {
 				new JpaAttributeConverterImpl( bean, converterJtd, domainJtd, relationalJtd );
 		return new ConvertedBasicTypeImpl<>(
 				ConverterDescriptor.TYPE_NAME_PREFIX
-						+ valueConverter.getConverterJavaType().getJavaType().getTypeName(),
+						+ valueConverter.getConverterJavaType().getTypeName(),
 				String.format(
 						"BasicType adapter for AttributeConverter<%s,%s>",
-						domainJtd.getJavaType().getTypeName(),
-						relationalJtd.getJavaType().getTypeName()
+						domainJtd.getTypeName(),
+						relationalJtd.getTypeName()
 				),
 				relationalJtd.getRecommendedJdbcType( typeConfiguration.getCurrentBaseSqlTypeIndicators() ),
 				valueConverter

--- a/hibernate-core/src/main/java/org/hibernate/boot/model/process/internal/NamedConverterResolution.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/process/internal/NamedConverterResolution.java
@@ -200,11 +200,11 @@ public class NamedConverterResolution<J> implements BasicValue.Resolution<J> {
 
 		this.legacyResolvedType = new CustomMutabilityConvertedBasicTypeImpl<>(
 				ConverterDescriptor.TYPE_NAME_PREFIX
-						+ valueConverter.getConverterJavaType().getJavaType().getTypeName(),
+						+ valueConverter.getConverterJavaType().getTypeName(),
 				String.format(
 						"BasicType adapter for AttributeConverter<%s,%s>",
-						domainJtd.getJavaType().getTypeName(),
-						relationalJtd.getJavaType().getTypeName()
+						domainJtd.getTypeName(),
+						relationalJtd.getTypeName()
 				),
 				jdbcType,
 				valueConverter,

--- a/hibernate-core/src/main/java/org/hibernate/id/UUIDGenerator.java
+++ b/hibernate-core/src/main/java/org/hibernate/id/UUIDGenerator.java
@@ -91,7 +91,7 @@ public class UUIDGenerator implements IdentifierGenerator, StandardGenerator {
 			valueTransformer = UUIDJavaType.ToBytesTransformer.INSTANCE;
 		}
 		else {
-			throw new HibernateException( "Unanticipated return type [" + type.getReturnedClass().getName() + "] for UUID conversion" );
+			throw new HibernateException( "Unanticipated return type [" + type.getReturnedClassName() + "] for UUID conversion" );
 		}
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/mapping/SimpleValue.java
+++ b/hibernate-core/src/main/java/org/hibernate/mapping/SimpleValue.java
@@ -772,11 +772,11 @@ public abstract class SimpleValue implements KeyValue {
 		// todo : cache the AttributeConverterTypeAdapter in case that AttributeConverter is applied multiple times.
 		return new ConvertedBasicTypeImpl<>(
 				TYPE_NAME_PREFIX
-						+ jpaAttributeConverter.getConverterJavaType().getJavaType().getTypeName(),
+						+ jpaAttributeConverter.getConverterJavaType().getTypeName(),
 				String.format(
 						"BasicType adapter for AttributeConverter<%s,%s>",
-						domainJavaType.getJavaType().getTypeName(),
-						relationalJavaType.getJavaType().getTypeName()
+						domainJavaType.getTypeName(),
+						relationalJavaType.getTypeName()
 				),
 				metadata.getTypeConfiguration().getJdbcTypeRegistry().getDescriptor( jdbcTypeCode ),
 				jpaAttributeConverter

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/internal/EmbeddableRepresentationStrategyPojo.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/internal/EmbeddableRepresentationStrategyPojo.java
@@ -153,7 +153,7 @@ public class EmbeddableRepresentationStrategyPojo extends AbstractEmbeddableRepr
 					String.format(
 							Locale.ROOT,
 							"Could not resolve PropertyAccess for attribute `%s#%s`",
-							getEmbeddableJavaType().getJavaType().getTypeName(),
+							getEmbeddableJavaType().getTypeName(),
 							bootAttributeDescriptor.getName()
 					)
 			);

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/internal/EntityRepresentationStrategyPojoStandard.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/internal/EntityRepresentationStrategyPojoStandard.java
@@ -330,7 +330,7 @@ public class EntityRepresentationStrategyPojoStandard implements EntityRepresent
 					String.format(
 							Locale.ROOT,
 							"Could not resolve PropertyAccess for attribute `%s#%s`",
-							mappedJtd.getJavaType().getTypeName(),
+							mappedJtd.getTypeName(),
 							bootAttributeDescriptor.getName()
 					)
 			);

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/SimpleNaturalIdMapping.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/SimpleNaturalIdMapping.java
@@ -141,7 +141,7 @@ public class SimpleNaturalIdMapping extends AbstractNaturalIdMapping implements 
 							"Incoming natural-id value [%s (`%s`)] is not of expected type [`%s`] and could not be coerced",
 							naturalIdValue,
 							naturalIdValueClass.getName(),
-							getJavaType().getJavaType().getTypeName()
+							getJavaType().getTypeName()
 					)
 			);
 		}

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/ToOneAttributeMapping.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/ToOneAttributeMapping.java
@@ -592,7 +592,7 @@ public class ToOneAttributeMapping
 				final Collection collection = (Collection) value;
 				if ( propertyPath.equals( collection.getMappedByProperty() )
 						&& collection.getElement().getType().getName()
-						.equals( declaringType.getJavaType().getJavaType().getTypeName() ) ) {
+						.equals( declaringType.getJavaType().getTypeName() ) ) {
 					return parentSelectablePath == null
 							? SelectablePath.parse( property.getName() )
 							: parentSelectablePath.append( property.getName() );
@@ -627,7 +627,7 @@ public class ToOneAttributeMapping
 				if (declaringTableGroupProducer.getNavigableRole().getLocalName().equals( oneToOne.getReferencedEntityName() )
 				&& propertyPath.equals( oneToOne.getMappedByProperty() )
 						&& oneToOne.getReferencedEntityName()
-						.equals( declaringType.getJavaType().getJavaType().getTypeName() ) ) {
+						.equals( declaringType.getJavaType().getTypeName() ) ) {
 					return parentSelectablePath == null
 									? SelectablePath.parse( property.getName() )
 									: parentSelectablePath.append( property.getName() );
@@ -1466,13 +1466,13 @@ public class ToOneAttributeMapping
 
 				where leve2Child is of type DerivedLevel2 while level2Parent of type Level2
 
-				for this reason we need the check entityMappingType.isSubclassEntityName( partMappingType.getMappedJavaType().getJavaType().getTypeName() )
+				for this reason we need the check entityMappingType.isSubclassEntityName( partMappingType.getMappedJavaType().getTypeName() )
 				to be sure that the referencedNavigablePath corresponds to leve2Child
 
 		 */
 		while ( !( partMappingType instanceof EntityMappingType )
 				|| ( partMappingType != entityMappingType
-				&& !entityMappingType.getEntityPersister().isSubclassEntityName( partMappingType.getMappedJavaType().getJavaType().getTypeName() )
+				&& !entityMappingType.getEntityPersister().isSubclassEntityName( partMappingType.getMappedJavaType().getTypeName() )
 				&& !( (EntityMappingType) partMappingType ).getEntityPersister().isSubclassEntityName( entityMappingType.getEntityName() ) ) ) {
 			referencedNavigablePath = referencedNavigablePath.getParent();
 			if ( referencedNavigablePath == null ) {

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/internal/EmbeddableTypeImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/internal/EmbeddableTypeImpl.java
@@ -15,7 +15,6 @@ import org.hibernate.metamodel.model.domain.spi.JpaMetamodelImplementor;
 import org.hibernate.type.descriptor.java.JavaType;
 
 import jakarta.persistence.metamodel.SingularAttribute;
-import jakarta.persistence.metamodel.Type;
 
 /**
  * Implementation of {@link jakarta.persistence.metamodel.EmbeddableType}.
@@ -33,7 +32,7 @@ public class EmbeddableTypeImpl<J>
 			JavaType<J> javaType,
 			boolean isDynamic,
 			JpaMetamodelImplementor domainMetamodel) {
-		super( javaType.getJavaType().getTypeName(), javaType, null, domainMetamodel );
+		super( javaType.getTypeName(), javaType, null, domainMetamodel );
 		this.isDynamic = isDynamic;
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/internal/MappedSuperclassTypeImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/internal/MappedSuperclassTypeImpl.java
@@ -51,7 +51,7 @@ public class MappedSuperclassTypeImpl<J> extends AbstractIdentifiableType<J> imp
 			IdentifiableDomainType<? super J> superType,
 			JpaMetamodelImplementor jpaMetamodel) {
 		this(
-				javaType.getJavaType().getTypeName(),
+				javaType.getTypeName(),
 				mappedSuperclass.getDeclaredIdentifierMapper() != null
 						|| superType != null && superType.hasIdClass(),
 				mappedSuperclass.hasIdentifierProperty(),

--- a/hibernate-core/src/main/java/org/hibernate/persister/entity/AbstractEntityPersister.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/entity/AbstractEntityPersister.java
@@ -6087,15 +6087,11 @@ public abstract class AbstractEntityPersister
 											Locale.ROOT,
 											"Could not resolve attribute '%s' of '%s' due to the attribute being declared in multiple subtypes '%s' and '%s'",
 											name,
-											getJavaType().getJavaType().getTypeName(),
+											getJavaType().getTypeName(),
 											attribute.asAttributeMapping().getDeclaringType()
-													.getJavaType()
-													.getJavaType()
-													.getTypeName(),
+													.getJavaType().getTypeName(),
 											subDefinedAttribute.asAttributeMapping().getDeclaringType()
-													.getJavaType()
-													.getJavaType()
-													.getTypeName()
+													.getJavaType().getTypeName()
 									)
 							);
 						}

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/internal/QuerySqmImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/internal/QuerySqmImpl.java
@@ -405,8 +405,8 @@ public class QuerySqmImpl<R>
 //				throw new SemanticException(
 //						String.format(
 //								"Expected insert attribute type [%s] did not match Query selection type [%s] at selection index [%d]",
-//								insertionTargetPaths.get( i ).getJavaTypeDescriptor().getJavaType().getTypeName(),
-//								expression.getNodeJavaType().getJavaType().getTypeName(),
+//								insertionTargetPaths.get( i ).getJavaTypeDescriptor().getTypeName(),
+//								expression.getNodeJavaType().getTypeName(),
 //								i
 //						),
 //						hqlString,

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/domain/SqmPolymorphicRootDescriptor.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/domain/SqmPolymorphicRootDescriptor.java
@@ -117,7 +117,7 @@ public class SqmPolymorphicRootDescriptor<T> implements EntityDomainType<T> {
 
 	@Override
 	public String getName() {
-		return polymorphicJavaType.getJavaType().getTypeName();
+		return polymorphicJavaType.getTypeName();
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/expression/SqmEnumLiteral.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/expression/SqmEnumLiteral.java
@@ -100,7 +100,7 @@ public class SqmEnumLiteral<E extends Enum<E>> extends SqmLiteral<E> implements 
 				String.format(
 						Locale.ROOT,
 						"Static enum reference [%s#%s] cannot be de-referenced",
-						referencedEnumTypeDescriptor.getJavaType().getTypeName(),
+						referencedEnumTypeDescriptor.getTypeName(),
 						enumValueName
 				)
 		);
@@ -115,7 +115,7 @@ public class SqmEnumLiteral<E extends Enum<E>> extends SqmLiteral<E> implements 
 				String.format(
 						Locale.ROOT,
 						"Static enum reference [%s#%s] cannot be de-referenced",
-						referencedEnumTypeDescriptor.getJavaType().getTypeName(),
+						referencedEnumTypeDescriptor.getTypeName(),
 						enumValueName
 				)
 		);

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/expression/SqmFieldLiteral.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/expression/SqmFieldLiteral.java
@@ -243,7 +243,7 @@ public class SqmFieldLiteral<T> implements SqmExpression<T>, SqmExpressible<T>, 
 				String.format(
 						Locale.ROOT,
 						"Static field reference [%s#%s] cannot be de-referenced",
-						fieldJavaType.getJavaType().getTypeName(),
+						fieldJavaType.getTypeName(),
 						fieldName
 				)
 		);
@@ -258,7 +258,7 @@ public class SqmFieldLiteral<T> implements SqmExpression<T>, SqmExpressible<T>, 
 				String.format(
 						Locale.ROOT,
 						"Static field reference [%s#%s] cannot be de-referenced",
-						fieldJavaType.getJavaType().getTypeName(),
+						fieldJavaType.getTypeName(),
 						fieldName
 				)
 		);

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/basic/BasicResultAssembler.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/basic/BasicResultAssembler.java
@@ -68,7 +68,7 @@ public class BasicResultAssembler<J> implements DomainResultAssembler<J> {
 							String.format(
 									Locale.ROOT,
 									"Expecting raw JDBC value of type `%s`, but found `%s` : [%s]",
-									valueConverter.getRelationalJavaType().getJavaType().getTypeName(),
+									valueConverter.getRelationalJavaType().getTypeName(),
 									jdbcValue.getClass().getName(),
 									jdbcValue
 							)

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/instantiation/internal/DynamicInstantiation.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/instantiation/internal/DynamicInstantiation.java
@@ -90,7 +90,7 @@ public class DynamicInstantiation<T> implements DomainResultProducer {
 
 	@Override
 	public String toString() {
-		return "DynamicInstantiation(" + getTargetJavaType().getJavaType().getTypeName() + ")";
+		return "DynamicInstantiation(" + getTargetJavaType().getTypeName() + ")";
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/instantiation/internal/DynamicInstantiationAssemblerInjectionImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/instantiation/internal/DynamicInstantiationAssemblerInjectionImpl.java
@@ -94,7 +94,7 @@ public class DynamicInstantiationAssemblerInjectionImpl<T> implements DomainResu
 		catch ( NoSuchMethodException | IllegalAccessException | InvocationTargetException | InstantiationException
 				| java.lang.InstantiationException e ) {
 			throw new InstantiationException( "Error instantiating class '"
-					+ target.getJavaType().getTypeName() + "' using default constructor: " + e.getMessage(), e );
+					+ target.getTypeName() + "' using default constructor: " + e.getMessage(), e );
 		}
 		for ( BeanInjection beanInjection : beanInjections ) {
 			final Object assembled = beanInjection.getValueAssembler().assemble( rowProcessingState, options );

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/instantiation/internal/DynamicInstantiationResultImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/instantiation/internal/DynamicInstantiationResultImpl.java
@@ -180,20 +180,20 @@ public class DynamicInstantiationResultImpl<R> implements DynamicInstantiationRe
 		if ( log.isDebugEnabled() ) {
 			log.debugf(
 					"Could not locate appropriate constructor for dynamic instantiation of [%s]; attempting bean-injection instantiation",
-					javaType.getJavaType().getTypeName()
+					javaType.getTypeName()
 			);
 		}
 
 		if ( !areAllArgumentsAliased) {
 			throw new IllegalStateException(
-					"Cannot instantiate class '" + javaType.getJavaType().getTypeName() + "'"
+					"Cannot instantiate class '" + javaType.getTypeName() + "'"
 							+ " (it has no constructor with signature " + signature()
 							+ ", and not every argument has an alias)"
 			);
 		}
 		if ( !duplicatedAliases.isEmpty() ) {
 			throw new IllegalStateException(
-					"Cannot instantiate class '" + javaType.getJavaType().getTypeName() + "'"
+					"Cannot instantiate class '" + javaType.getTypeName() + "'"
 							+ " (it has no constructor with signature " + signature()
 							+ ", and has arguments with duplicate aliases ["
 							+ StringHelper.join( ",", duplicatedAliases) + "])"
@@ -205,7 +205,7 @@ public class DynamicInstantiationResultImpl<R> implements DynamicInstantiationRe
 
 	private List<String> signature() {
 		return argumentResults.stream()
-				.map( adt -> adt.getResultJavaType().getJavaType().getTypeName() )
+				.map( adt -> adt.getResultJavaType().getTypeName() )
 				.collect( toList() );
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/type/AbstractStandardBasicType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/AbstractStandardBasicType.java
@@ -119,7 +119,7 @@ public abstract class AbstractStandardBasicType<T>
 	@Override
 	public String[] getRegistrationKeys() {
 		return registerUnderJavaType()
-				? new String[] { getName(), javaType.getJavaType().getTypeName() }
+				? new String[] { getName(), javaType.getTypeName() }
 				: new String[] { getName() };
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/type/CollectionType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/CollectionType.java
@@ -217,7 +217,7 @@ public abstract class CollectionType extends AbstractType implements Association
 
 	@Override
 	public String getName() {
-		return getReturnedClass().getName() + '(' + getRole() + ')';
+		return getReturnedClassName() + '(' + getRole() + ')';
 	}
 
 	/**

--- a/hibernate-core/src/main/java/org/hibernate/type/ComponentType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/ComponentType.java
@@ -663,7 +663,7 @@ public class ComponentType extends AbstractType implements CompositeTypeImplemen
 			}
 		}
 		throw new PropertyNotFoundException(
-				"Could not resolve attribute '" + name + "' of '" + getReturnedClass().getName() + "'"
+				"Could not resolve attribute '" + name + "' of '" + getReturnedClassName() + "'"
 					+ " (must be one of '" + StringHelper.join("', '", names) + "')"
 		);
 	}

--- a/hibernate-core/src/main/java/org/hibernate/type/SerializableToBlobType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/SerializableToBlobType.java
@@ -133,7 +133,7 @@ public class SerializableToBlobType<T extends Serializable> implements BasicType
 	@Override
 	public String[] getRegistrationKeys() {
 		return registerUnderJavaType()
-				? new String[] { getName(), javaType.getJavaType().getTypeName() }
+				? new String[] { getName(), javaType.getTypeName() }
 				: new String[] { getName() };
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/type/StandardBasicTypeTemplate.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/StandardBasicTypeTemplate.java
@@ -28,7 +28,7 @@ public class StandardBasicTypeTemplate<J> extends AbstractSingleColumnStandardBa
 		super( jdbcType, javaType );
 		this.registrationKeys = registrationKeys;
 
-		this.name = javaType.getJavaType() == null ? "(map-mode)" : javaType.getJavaType().getTypeName()
+		this.name = javaType.getJavaType() == null ? "(map-mode)" : javaType.getTypeName()
 				+ " -> " + jdbcType.getDefaultSqlTypeCode();
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/type/Type.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/Type.java
@@ -123,9 +123,20 @@ public interface Type extends Serializable {
 	/**
 	 * The class handled by this type.
 	 *
-	 * @return The java type class handled by this type.
+	 * @return The Java class handled by this type.
 	 */
 	Class<?> getReturnedClass();
+
+	/**
+	 * The qualified name of the class handled by this type.
+	 *
+	 * @return The qualified Java class name.
+	 *
+	 * @since 6.5
+	 */
+	default String getReturnedClassName() {
+		return getReturnedClass().getName();
+	}
 
 	/**
 	 * Compare two instances of the class mapped by this type for persistence "equality",

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/AbstractTemporalJavaType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/AbstractTemporalJavaType.java
@@ -82,6 +82,6 @@ public abstract class AbstractTemporalJavaType<T>
 
 	@Override
 	public String toString() {
-		return "TemporalJavaType(javaType=" + getJavaType().getTypeName() + ")";
+		return "TemporalJavaType(javaType=" + getTypeName() + ")";
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/BigDecimalJavaType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/BigDecimalJavaType.java
@@ -101,7 +101,7 @@ public class BigDecimalJavaType extends AbstractClassJavaType<BigDecimal> {
 
 	@Override
 	public boolean isWider(JavaType<?> javaType) {
-		switch ( javaType.getJavaType().getTypeName() ) {
+		switch ( javaType.getTypeName() ) {
 			case "byte":
 			case "java.lang.Byte":
 			case "short":

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/BigIntegerJavaType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/BigIntegerJavaType.java
@@ -99,7 +99,7 @@ public class BigIntegerJavaType extends AbstractClassJavaType<BigInteger> {
 
 	@Override
 	public boolean isWider(JavaType<?> javaType) {
-		switch ( javaType.getJavaType().getTypeName() ) {
+		switch ( javaType.getTypeName() ) {
 			case "byte":
 			case "java.lang.Byte":
 			case "short":

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/CalendarDateJavaType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/CalendarDateJavaType.java
@@ -132,7 +132,7 @@ public class CalendarDateJavaType extends AbstractTemporalJavaType<Calendar> {
 
 	@Override
 	public boolean isWider(JavaType<?> javaType) {
-		switch ( javaType.getJavaType().getTypeName() ) {
+		switch ( javaType.getTypeName() ) {
 			case "java.sql.Date":
 				return true;
 			default:

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/CalendarJavaType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/CalendarJavaType.java
@@ -149,7 +149,7 @@ public class CalendarJavaType extends AbstractTemporalJavaType<Calendar> impleme
 
 	@Override
 	public boolean isWider(JavaType<?> javaType) {
-		switch ( javaType.getJavaType().getTypeName() ) {
+		switch ( javaType.getTypeName() ) {
 			case "java.util.Date":
 			case "java.sql.Date":
 			case "java.sql.Timestamp":

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/CalendarTimeJavaType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/CalendarTimeJavaType.java
@@ -134,7 +134,7 @@ public class CalendarTimeJavaType extends AbstractTemporalJavaType<Calendar> {
 
 	@Override
 	public boolean isWider(JavaType<?> javaType) {
-		switch ( javaType.getJavaType().getTypeName() ) {
+		switch ( javaType.getTypeName() ) {
 			case "java.sql.Time":
 				return true;
 			default:

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/DateJavaType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/DateJavaType.java
@@ -169,7 +169,7 @@ public class DateJavaType extends AbstractTemporalJavaType<Date> implements Vers
 
 	@Override
 	public boolean isWider(JavaType<?> javaType) {
-		switch ( javaType.getJavaType().getTypeName() ) {
+		switch ( javaType.getTypeName() ) {
 			case "java.sql.Date":
 			case "java.sql.Timestamp":
 			case "java.util.Calendar":

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/DoubleJavaType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/DoubleJavaType.java
@@ -100,7 +100,7 @@ public class DoubleJavaType extends AbstractClassJavaType<Double> implements
 
 	@Override
 	public boolean isWider(JavaType<?> javaType) {
-		switch ( javaType.getJavaType().getTypeName() ) {
+		switch ( javaType.getTypeName() ) {
 			case "byte":
 			case "java.lang.Byte":
 			case "short":

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/FloatJavaType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/FloatJavaType.java
@@ -99,7 +99,7 @@ public class FloatJavaType extends AbstractClassJavaType<Float> implements Primi
 
 	@Override
 	public boolean isWider(JavaType<?> javaType) {
-		switch ( javaType.getJavaType().getTypeName() ) {
+		switch ( javaType.getTypeName() ) {
 			case "byte":
 			case "java.lang.Byte":
 			case "short":

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/IntegerJavaType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/IntegerJavaType.java
@@ -96,7 +96,7 @@ public class IntegerJavaType extends AbstractClassJavaType<Integer>
 
 	@Override
 	public boolean isWider(JavaType<?> javaType) {
-		switch ( javaType.getJavaType().getTypeName() ) {
+		switch ( javaType.getTypeName() ) {
 			case "byte":
 			case "java.lang.Byte":
 			case "short":

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/JdbcTimestampJavaType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/JdbcTimestampJavaType.java
@@ -194,7 +194,7 @@ public class JdbcTimestampJavaType extends AbstractTemporalJavaType<Date> implem
 
 	@Override
 	public boolean isWider(JavaType<?> javaType) {
-		switch ( javaType.getJavaType().getTypeName() ) {
+		switch ( javaType.getTypeName() ) {
 			case "java.sql.Date":
 			case "java.sql.Timestamp":
 			case "java.util.Date":

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/LocalDateJavaType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/LocalDateJavaType.java
@@ -163,7 +163,7 @@ public class LocalDateJavaType extends AbstractTemporalJavaType<LocalDate> {
 
 	@Override
 	public boolean isWider(JavaType<?> javaType) {
-		switch ( javaType.getJavaType().getTypeName() ) {
+		switch ( javaType.getTypeName() ) {
 			case "java.sql.Date":
 				return true;
 			default:

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/LocalDateTimeJavaType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/LocalDateTimeJavaType.java
@@ -162,7 +162,7 @@ public class LocalDateTimeJavaType extends AbstractTemporalJavaType<LocalDateTim
 
 	@Override
 	public boolean isWider(JavaType<?> javaType) {
-		switch ( javaType.getJavaType().getTypeName() ) {
+		switch ( javaType.getTypeName() ) {
 			case "java.sql.Date":
 			case "java.sql.Timestamp":
 			case "java.util.Date":

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/LocalTimeJavaType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/LocalTimeJavaType.java
@@ -169,7 +169,7 @@ public class LocalTimeJavaType extends AbstractTemporalJavaType<LocalTime> {
 
 	@Override
 	public boolean isWider(JavaType<?> javaType) {
-		switch ( javaType.getJavaType().getTypeName() ) {
+		switch ( javaType.getTypeName() ) {
 			case "java.sql.Time":
 				return true;
 			default:

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/LongJavaType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/LongJavaType.java
@@ -96,7 +96,7 @@ public class LongJavaType extends AbstractClassJavaType<Long>
 
 	@Override
 	public boolean isWider(JavaType<?> javaType) {
-		switch ( javaType.getJavaType().getTypeName() ) {
+		switch ( javaType.getTypeName() ) {
 			case "byte":
 			case "java.lang.Byte":
 			case "short":

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/ShortJavaType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/ShortJavaType.java
@@ -42,7 +42,7 @@ public class ShortJavaType extends AbstractClassJavaType<Short>
 
 	@Override
 	public boolean isWider(JavaType<?> javaType) {
-		switch ( javaType.getJavaType().getTypeName() ) {
+		switch ( javaType.getTypeName() ) {
 			case "byte":
 			case "java.lang.Byte":
 				return true;

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/StringJavaType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/StringJavaType.java
@@ -119,7 +119,7 @@ public class StringJavaType extends AbstractClassJavaType<String> {
 
 	@Override
 	public boolean isWider(JavaType<?> javaType) {
-		switch ( javaType.getJavaType().getTypeName() ) {
+		switch ( javaType.getTypeName() ) {
 			case "char":
 			case "char[]":
 			case "java.lang.Character":

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/spi/EmbeddableAggregateJavaType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/spi/EmbeddableAggregateJavaType.java
@@ -42,7 +42,7 @@ public class EmbeddableAggregateJavaType<T> extends AbstractClassJavaType<T> {
 			return descriptor;
 		}
 		throw new JdbcTypeRecommendationException(
-				"Could not determine recommended JdbcType for `" + getJavaType().getTypeName() + "`"
+				"Could not determine recommended JdbcType for `" + getTypeName() + "`"
 		);
 	}
 
@@ -54,7 +54,7 @@ public class EmbeddableAggregateJavaType<T> extends AbstractClassJavaType<T> {
 	@Override
 	public T fromString(CharSequence string) {
 		throw new UnsupportedOperationException(
-				"Conversion from String strategy not known for this Java type : " + getJavaType().getTypeName()
+				"Conversion from String strategy not known for this Java type: " + getTypeName()
 		);
 	}
 
@@ -65,7 +65,7 @@ public class EmbeddableAggregateJavaType<T> extends AbstractClassJavaType<T> {
 			return (X) value;
 		}
 		throw new UnsupportedOperationException(
-				"Unwrap strategy not known for this Java type : " + getJavaType().getTypeName()
+				"Unwrap strategy not known for this Java type: " + getTypeName()
 		);
 	}
 
@@ -76,12 +76,12 @@ public class EmbeddableAggregateJavaType<T> extends AbstractClassJavaType<T> {
 			return (T) value;
 		}
 		throw new UnsupportedOperationException(
-				"Wrap strategy not known for this Java type : " + getJavaType().getTypeName()
+				"Wrap strategy not known for this Java type: " + getTypeName()
 		);
 	}
 
 	@Override
 	public String toString() {
-		return "BasicJavaType(" + getJavaType().getTypeName() + ")";
+		return "BasicJavaType(" + getTypeName() + ")";
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/spi/EntityJavaType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/spi/EntityJavaType.java
@@ -30,7 +30,7 @@ public class EntityJavaType<T> extends AbstractClassJavaType<T> {
 	@Override
 	public JdbcType getRecommendedJdbcType(JdbcTypeIndicators context) {
 		throw new JdbcTypeRecommendationException(
-				"Could not determine recommended JdbcType for `" + getJavaType().getTypeName() + "`"
+				"Could not determine recommended JdbcType for '" + getTypeName() + "'"
 		);
 	}
 
@@ -65,26 +65,26 @@ public class EntityJavaType<T> extends AbstractClassJavaType<T> {
 	@Override
 	public T fromString(CharSequence string) {
 		throw new UnsupportedOperationException(
-				"Conversion from String strategy not known for this Java type : " + getJavaType().getTypeName()
+				"Conversion from String strategy not known for this Java type: " + getTypeName()
 		);
 	}
 
 	@Override
 	public <X> X unwrap(T value, Class<X> type, WrapperOptions options) {
 		throw new UnsupportedOperationException(
-				"Unwrap strategy not known for this Java type : " + getJavaType().getTypeName()
+				"Unwrap strategy not known for this Java type: " + getTypeName()
 		);
 	}
 
 	@Override
 	public <X> T wrap(X value, WrapperOptions options) {
 		throw new UnsupportedOperationException(
-				"Wrap strategy not known for this Java type : " + getJavaType().getTypeName()
+				"Wrap strategy not known for this Java type: " + getTypeName()
 		);
 	}
 
 	@Override
 	public String toString() {
-		return "EntityJavaType(" + getJavaType().getTypeName() + ")";
+		return "EntityJavaType(" + getTypeName() + ")";
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/spi/FormatMapperBasedJavaType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/spi/FormatMapperBasedJavaType.java
@@ -43,7 +43,7 @@ public abstract class FormatMapperBasedJavaType<T> extends AbstractJavaType<T> i
 	@Override
 	public JdbcType getRecommendedJdbcType(JdbcTypeIndicators context) {
 		throw new JdbcTypeRecommendationException(
-				"Could not determine recommended JdbcType for Java type '" + getJavaType().getTypeName() + "'"
+				"Could not determine recommended JdbcType for Java type '" + getTypeName() + "'"
 		);
 	}
 
@@ -76,7 +76,7 @@ public abstract class FormatMapperBasedJavaType<T> extends AbstractJavaType<T> i
 			return (X) getFormatMapper( typeConfiguration ).toString( value, this, options );
 		}
 		throw new UnsupportedOperationException(
-				"Unwrap strategy not known for this Java type : " + getJavaType().getTypeName()
+				"Unwrap strategy not known for this Java type: " + getTypeName()
 		);
 	}
 
@@ -90,7 +90,7 @@ public abstract class FormatMapperBasedJavaType<T> extends AbstractJavaType<T> i
 			return getFormatMapper( typeConfiguration ).fromString( (String) value, this, options );
 		}
 		throw new UnsupportedOperationException(
-				"Wrap strategy not known for this Java type : " + getJavaType().getTypeName()
+				"Wrap strategy not known for this Java type: " + getTypeName()
 		);
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/spi/JavaTypeBasicAdaptor.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/spi/JavaTypeBasicAdaptor.java
@@ -30,7 +30,7 @@ public class JavaTypeBasicAdaptor<T> extends AbstractClassJavaType<T> {
 	@Override
 	public JdbcType getRecommendedJdbcType(JdbcTypeIndicators context) {
 		throw new JdbcTypeRecommendationException(
-				"Could not determine recommended JdbcType for `" + getJavaType().getTypeName() + "`"
+				"Could not determine recommended JdbcType for '" + getTypeName() + "'"
 		);
 	}
 
@@ -42,26 +42,26 @@ public class JavaTypeBasicAdaptor<T> extends AbstractClassJavaType<T> {
 	@Override
 	public T fromString(CharSequence string) {
 		throw new UnsupportedOperationException(
-				"Conversion from String strategy not known for this Java type : " + getJavaType().getTypeName()
+				"Conversion from String strategy not known for this Java type: " + getTypeName()
 		);
 	}
 
 	@Override
 	public <X> X unwrap(T value, Class<X> type, WrapperOptions options) {
 		throw new UnsupportedOperationException(
-				"Unwrap strategy not known for this Java type : " + getJavaType().getTypeName()
+				"Unwrap strategy not known for this Java type: " + getTypeName()
 		);
 	}
 
 	@Override
 	public <X> T wrap(X value, WrapperOptions options) {
 		throw new UnsupportedOperationException(
-				"Wrap strategy not known for this Java type : " + getJavaType().getTypeName()
+				"Wrap strategy not known for this Java type: " + getTypeName()
 		);
 	}
 
 	@Override
 	public String toString() {
-		return "JavaTypeBasicAdaptor(" + getJavaType().getTypeName() + ")";
+		return "JavaTypeBasicAdaptor(" + getTypeName() + ")";
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/spi/JsonJavaType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/spi/JsonJavaType.java
@@ -38,6 +38,6 @@ public class JsonJavaType<T> extends FormatMapperBasedJavaType<T> {
 
 	@Override
 	public String toString() {
-		return "JsonJavaType(" + getJavaType().getTypeName() + ")";
+		return "JsonJavaType(" + getTypeName() + ")";
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/spi/UnknownBasicJavaType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/spi/UnknownBasicJavaType.java
@@ -19,22 +19,35 @@ import org.hibernate.type.descriptor.jdbc.JdbcTypeIndicators;
  * {@link org.hibernate.type.descriptor.java.JavaType} for a given Java type.
  */
 public final class UnknownBasicJavaType<T> extends AbstractJavaType<T> {
+	private final String typeName;
+
 	public UnknownBasicJavaType(Class<T> type) {
+		this( type, type.getTypeName() );
+	}
+	public UnknownBasicJavaType(Class<T> type, String typeName) {
 		super( type );
+		this.typeName = typeName;
 	}
 
 	public UnknownBasicJavaType(Class<T> type, MutabilityPlan<T> mutabilityPlan) {
 		super( type, mutabilityPlan );
+		this.typeName = type.getTypeName();
 	}
 
 	public UnknownBasicJavaType(Type type, MutabilityPlan<T> mutabilityPlan) {
 		super( type, mutabilityPlan );
+		this.typeName = type.getTypeName();
+	}
+
+	@Override
+	public String getTypeName() {
+		return typeName;
 	}
 
 	@Override
 	public JdbcType getRecommendedJdbcType(JdbcTypeIndicators context) {
 		throw new JdbcTypeRecommendationException(
-				"Could not determine recommended JdbcType for Java type '" + getJavaType().getTypeName() + "'"
+				"Could not determine recommended JdbcType for Java type '" + getTypeName() + "'"
 		);
 	}
 
@@ -46,7 +59,7 @@ public final class UnknownBasicJavaType<T> extends AbstractJavaType<T> {
 	@Override
 	public T fromString(CharSequence string) {
 		throw new UnsupportedOperationException(
-				"Conversion from String strategy not known for this Java type : " + getJavaType().getTypeName()
+				"Conversion from String strategy not known for this Java type: " + getTypeName()
 		);
 	}
 
@@ -57,7 +70,7 @@ public final class UnknownBasicJavaType<T> extends AbstractJavaType<T> {
 			return (X) value;
 		}
 		throw new UnsupportedOperationException(
-				"Unwrap strategy not known for this Java type : " + getJavaType().getTypeName()
+				"Unwrap strategy not known for this Java type: " + getTypeName()
 		);
 	}
 
@@ -68,12 +81,12 @@ public final class UnknownBasicJavaType<T> extends AbstractJavaType<T> {
 			return (T) value;
 		}
 		throw new UnsupportedOperationException(
-				"Wrap strategy not known for this Java type : " + getJavaType().getTypeName()
+				"Wrap strategy not known for this Java type: " + getTypeName()
 		);
 	}
 
 	@Override
 	public String toString() {
-		return "BasicJavaType(" + getJavaType().getTypeName() + ")";
+		return "BasicJavaType(" + getTypeName() + ")";
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/spi/XmlJavaType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/spi/XmlJavaType.java
@@ -38,6 +38,6 @@ public class XmlJavaType<T> extends FormatMapperBasedJavaType<T> {
 
 	@Override
 	public String toString() {
-		return "XmlJavaType(" + getJavaType().getTypeName() + ")";
+		return "XmlJavaType(" + getTypeName() + ")";
 	}
 }

--- a/tooling/metamodel-generator/src/main/java/org/hibernate/jpamodelgen/validation/MockSessionFactory.java
+++ b/tooling/metamodel-generator/src/main/java/org/hibernate/jpamodelgen/validation/MockSessionFactory.java
@@ -1061,16 +1061,15 @@ public abstract class MockSessionFactory
 		}
 	}
 
-	private EmbeddableTypeImpl<Object> createEmbeddableDomainType(String entityName, CompositeType compositeType, ManagedDomainType<?> owner) {
-		return new EmbeddableTypeImpl<Object>(new UnknownBasicJavaType<>(Object.class), true, metamodel.getJpaMetamodel()) {
+	private EmbeddableTypeImpl<?> createEmbeddableDomainType(String entityName, CompositeType compositeType, ManagedDomainType<?> owner) {
+		final JavaType<Object> javaType = new UnknownBasicJavaType<>(Object.class, compositeType.getReturnedClassName());
+		return new EmbeddableTypeImpl<>(javaType, true, metamodel.getJpaMetamodel()) {
 			@Override
 			public PersistentAttribute<Object, Object> findAttribute(String name) {
-				int i = compositeType.getPropertyIndex(name);
-				Type subtype = compositeType.getSubtypes()[i];
 				return createAttribute(
 						name,
-						entityName, //TOOD: WRONG!!!
-						subtype,
+						entityName,
+						compositeType.getSubtypes()[compositeType.getPropertyIndex(name)],
 						owner
 				);
 			}

--- a/tooling/metamodel-generator/src/main/java/org/hibernate/jpamodelgen/validation/ProcessorSessionFactory.java
+++ b/tooling/metamodel-generator/src/main/java/org/hibernate/jpamodelgen/validation/ProcessorSessionFactory.java
@@ -265,6 +265,11 @@ public abstract class ProcessorSessionFactory extends MockSessionFactory {
 		}
 
 		@Override
+		public String getReturnedClassName() {
+			return type.getQualifiedName().toString();
+		}
+
+		@Override
 		public boolean isComponentType() {
 			return true;
 		}
@@ -803,11 +808,10 @@ public abstract class ProcessorSessionFactory extends MockSessionFactory {
 	//						}
 							else if (type instanceof BasicType) {
 								String className;
-								//sadly there is no way to get the classname
-								//from a Hibernate Type without trying to load
-								//the class!
+								//TODO: custom impl of getReturnedClassName()
+								//      for many more Hibernate types!
 								try {
-									className = type.getReturnedClass().getName();
+									className = type.getReturnedClassName();
 								}
 								catch (Exception e) {
 									continue;

--- a/tooling/metamodel-generator/src/test/java/org/hibernate/jpamodelgen/test/hqlsql/Address.java
+++ b/tooling/metamodel-generator/src/test/java/org/hibernate/jpamodelgen/test/hqlsql/Address.java
@@ -1,0 +1,55 @@
+package org.hibernate.jpamodelgen.test.hqlsql;
+
+import jakarta.persistence.Embeddable;
+
+import java.util.Objects;
+
+@Embeddable
+public final class Address {
+    private String street;
+    private String city;
+    private String zip;
+
+    public Address(String street, String city, String zip) {
+        this.street = street;
+        this.city = city;
+        this.zip = zip;
+    }
+
+    Address() {}
+
+    public String street() {
+        return street;
+    }
+
+    public String city() {
+        return city;
+    }
+
+    public String zip() {
+        return zip;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == this) return true;
+        if (obj == null || obj.getClass() != this.getClass()) return false;
+        var that = (Address) obj;
+        return Objects.equals(this.street, that.street) &&
+                Objects.equals(this.city, that.city) &&
+                Objects.equals(this.zip, that.zip);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(street, city, zip);
+    }
+
+    @Override
+    public String toString() {
+        return "Address[" +
+                "street=" + street + ", " +
+                "city=" + city + ", " +
+                "zip=" + zip + ']';
+    }
+}

--- a/tooling/metamodel-generator/src/test/java/org/hibernate/jpamodelgen/test/hqlsql/Book.java
+++ b/tooling/metamodel-generator/src/test/java/org/hibernate/jpamodelgen/test/hqlsql/Book.java
@@ -6,6 +6,7 @@ import jakarta.persistence.ManyToOne;
 import org.hibernate.annotations.NaturalId;
 
 import java.math.BigDecimal;
+import java.time.LocalDate;
 
 @Entity
 public class Book {
@@ -16,4 +17,5 @@ public class Book {
     @ManyToOne Publisher publisher;
     BigDecimal price;
     int pages;
+    LocalDate publicationDate;
 }

--- a/tooling/metamodel-generator/src/test/java/org/hibernate/jpamodelgen/test/hqlsql/Dao.java
+++ b/tooling/metamodel-generator/src/test/java/org/hibernate/jpamodelgen/test/hqlsql/Dao.java
@@ -40,6 +40,9 @@ public interface Dao {
     @HQL("from Book where isbn = :isbn")
     Book findByIsbn(String isbn);
 
+    @HQL("order by isbn asc, publicationDate desc")
+    List<Book> allBooks();
+
     @SQL("select * from Book where isbn = :isbn")
     Book findByIsbnNative(String isbn);
 
@@ -64,4 +67,6 @@ public interface Dao {
     @HQL("select new list(title, pages) from Book")
     List<List> dtoQuery4();
 
+    @HQL("from Publisher where address = :address")
+    List<Publisher> publisherAt(Address address);
 }

--- a/tooling/metamodel-generator/src/test/java/org/hibernate/jpamodelgen/test/hqlsql/Publisher.java
+++ b/tooling/metamodel-generator/src/test/java/org/hibernate/jpamodelgen/test/hqlsql/Publisher.java
@@ -7,4 +7,5 @@ import jakarta.persistence.Id;
 public class Publisher {
     @Id Long id;
     String name;
+    Address address;
 }


### PR DESCRIPTION
and replace usages of getJavaType().getTypeName(), since using `getTypeName()` directly is much more freindly to the annotation processor (as well as less verbose)

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-17745
<!-- Hibernate GitHub Bot issue links end -->