### PR TITLE
make HqlInterpretation generic to eliminate warnings / unchecked casts

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/internal/AbstractSharedSessionContract.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/AbstractSharedSessionContract.java
@@ -767,7 +767,7 @@ public abstract class AbstractSharedSessionContract implements SharedSessionCont
 		delayedAfterCompletion();
 
 		try {
-			final HqlInterpretation interpretation = interpretHql( hql, resultType );
+			final HqlInterpretation<R> interpretation = interpretHql( hql, resultType );
 			checkSelectionQuery( hql, interpretation );
 			return createSelectionQuery( hql, resultType, interpretation );
 		}
@@ -777,7 +777,7 @@ public abstract class AbstractSharedSessionContract implements SharedSessionCont
 		}
 	}
 
-	private <R> SelectionQuery<R> createSelectionQuery(String hql, Class<R> resultType, HqlInterpretation interpretation) {
+	private <R> SelectionQuery<R> createSelectionQuery(String hql, Class<R> resultType, HqlInterpretation<R> interpretation) {
 		final SqmSelectionQueryImpl<R> query = new SqmSelectionQueryImpl<>( hql, interpretation, resultType, this );
 		if ( resultType != null ) {
 			checkResultType( resultType, query );
@@ -787,7 +787,7 @@ public abstract class AbstractSharedSessionContract implements SharedSessionCont
 		return query;
 	}
 
-	protected <R> HqlInterpretation interpretHql(String hql, Class<R> resultType) {
+	protected <R> HqlInterpretation<R> interpretHql(String hql, Class<R> resultType) {
 		final QueryEngine queryEngine = getFactory().getQueryEngine();
 		return queryEngine.getInterpretationCache()
 				.resolveHqlInterpretation(
@@ -797,7 +797,7 @@ public abstract class AbstractSharedSessionContract implements SharedSessionCont
 				);
 	}
 
-	protected static void checkSelectionQuery(String hql, HqlInterpretation hqlInterpretation) {
+	protected static void checkSelectionQuery(String hql, HqlInterpretation<?> hqlInterpretation) {
 		if ( !( hqlInterpretation.getSqmStatement() instanceof SqmSelectStatement ) ) {
 			throw new IllegalSelectQueryException( "Expecting a selection query, but found `" + hql + "`", hql);
 		}
@@ -840,7 +840,7 @@ public abstract class AbstractSharedSessionContract implements SharedSessionCont
 		delayedAfterCompletion();
 
 		try {
-			final HqlInterpretation interpretation = interpretHql( queryString, expectedResultType );
+			final HqlInterpretation<T> interpretation = interpretHql( queryString, expectedResultType );
 			final QuerySqmImpl<T> query = new QuerySqmImpl<>( queryString, interpretation, expectedResultType, this );
 			applyQuerySettingsAndHints( query );
 			query.setComment( queryString );

--- a/hibernate-core/src/main/java/org/hibernate/query/internal/NamedObjectRepositoryImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/internal/NamedObjectRepositoryImpl.java
@@ -249,7 +249,7 @@ public class NamedObjectRepositoryImpl implements NamedObjectRepository {
 				interpretationCache.resolveHqlInterpretation(
 						queryString,
 						null,
-						s -> queryEngine.getHqlTranslator().translate( queryString, null )
+						queryEngine.getHqlTranslator()
 				);
 			}
 			catch ( QueryException e ) {

--- a/hibernate-core/src/main/java/org/hibernate/query/internal/QueryInterpretationCacheDisabledImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/internal/QueryInterpretationCacheDisabledImpl.java
@@ -10,6 +10,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
+import org.hibernate.query.hql.HqlTranslator;
 import org.hibernate.query.spi.HqlInterpretation;
 import org.hibernate.query.spi.NonSelectQueryPlan;
 import org.hibernate.query.spi.ParameterMetadataImplementor;
@@ -60,15 +61,16 @@ public class QueryInterpretationCacheDisabledImpl implements QueryInterpretation
 	}
 
 	@Override
-	public HqlInterpretation resolveHqlInterpretation(String queryString, Class<?> expectedResultType, Function<String, SqmStatement<?>> creator) {
+	public <R> HqlInterpretation<R> resolveHqlInterpretation(
+			String queryString, Class<R> expectedResultType, HqlTranslator translator) {
 		final StatisticsImplementor statistics = statisticsSupplier.get();
 		final boolean stats = statistics.isStatisticsEnabled();
 		final long startTime = stats ? System.nanoTime() : 0L;
-		final SqmStatement<?> sqmStatement = creator.apply( queryString );
+
+		final SqmStatement<R> sqmStatement = translator.translate( queryString, expectedResultType );
 
 		final DomainParameterXref domainParameterXref;
 		final ParameterMetadataImplementor parameterMetadata;
-
 		if ( sqmStatement.getSqmParameters().isEmpty() ) {
 			domainParameterXref = DomainParameterXref.empty();
 			parameterMetadata = ParameterMetadataImpl.EMPTY;
@@ -84,9 +86,9 @@ public class QueryInterpretationCacheDisabledImpl implements QueryInterpretation
 			statistics.queryCompiled( queryString, microseconds );
 		}
 
-		return new HqlInterpretation() {
+		return new HqlInterpretation<>() {
 			@Override
-			public SqmStatement<?> getSqmStatement() {
+			public SqmStatement<R> getSqmStatement() {
 				return sqmStatement;
 			}
 

--- a/hibernate-core/src/main/java/org/hibernate/query/spi/HqlInterpretation.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/spi/HqlInterpretation.java
@@ -11,9 +11,11 @@ import org.hibernate.query.sqm.tree.SqmStatement;
 
 /**
  * @author Steve Ebersole
+ *
+ * @param <R> the query result type
  */
-public interface HqlInterpretation {
-	SqmStatement<?> getSqmStatement();
+public interface HqlInterpretation<R> {
+	SqmStatement<R> getSqmStatement();
 
 	ParameterMetadataImplementor getParameterMetadata();
 

--- a/hibernate-core/src/main/java/org/hibernate/query/spi/QueryInterpretationCache.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/spi/QueryInterpretationCache.java
@@ -37,12 +37,7 @@ public interface QueryInterpretationCache {
 	int getNumberOfCachedHqlInterpretations();
 	int getNumberOfCachedQueryPlans();
 
-	@Deprecated(forRemoval = true)
-	HqlInterpretation resolveHqlInterpretation(String queryString, Class<?> expectedResultType, Function<String, SqmStatement<?>> creator);
-
-	default HqlInterpretation resolveHqlInterpretation(String queryString, Class<?> expectedResultType, HqlTranslator translator) {
-		return resolveHqlInterpretation( queryString, expectedResultType, s -> translator.translate( queryString, expectedResultType ) );
-	}
+	<R> HqlInterpretation<R> resolveHqlInterpretation(String queryString, Class<R> expectedResultType, HqlTranslator translator);
 
 	<R> SelectQueryPlan<R> resolveSelectQueryPlan(Key key, Supplier<SelectQueryPlan<R>> creator);
 

--- a/hibernate-core/src/main/java/org/hibernate/query/spi/SimpleHqlInterpretationImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/spi/SimpleHqlInterpretationImpl.java
@@ -12,13 +12,13 @@ import org.hibernate.query.sqm.tree.SqmStatement;
 /**
  * @author Steve Ebersole
  */
-public class SimpleHqlInterpretationImpl implements HqlInterpretation {
-	private final SqmStatement<?> sqmStatement;
+public class SimpleHqlInterpretationImpl<R> implements HqlInterpretation<R> {
+	private final SqmStatement<R> sqmStatement;
 	private final ParameterMetadataImplementor parameterMetadata;
 	private final DomainParameterXref domainParameterXref;
 
 	public SimpleHqlInterpretationImpl(
-			SqmStatement<?> sqmStatement,
+			SqmStatement<R> sqmStatement,
 			ParameterMetadataImplementor parameterMetadata,
 			DomainParameterXref domainParameterXref) {
 		this.sqmStatement = sqmStatement;
@@ -27,7 +27,7 @@ public class SimpleHqlInterpretationImpl implements HqlInterpretation {
 	}
 
 	@Override
-	public SqmStatement<?> getSqmStatement() {
+	public SqmStatement<R> getSqmStatement() {
 		return sqmStatement;
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/internal/QuerySqmImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/internal/QuerySqmImpl.java
@@ -167,13 +167,10 @@ public class QuerySqmImpl<R>
 
 		final QueryEngine queryEngine = session.getFactory().getQueryEngine();
 		final QueryInterpretationCache interpretationCache = queryEngine.getInterpretationCache();
-		final HqlInterpretation hqlInterpretation = interpretationCache.resolveHqlInterpretation(
-				hql,
-				expectedResultType,
-				(s) -> queryEngine.getHqlTranslator().translate( hql, expectedResultType )
-		);
+		final HqlInterpretation<R> hqlInterpretation =
+				interpretationCache.resolveHqlInterpretation( hql, expectedResultType, queryEngine.getHqlTranslator() );
 
-		this.sqm = (SqmStatement<R>) hqlInterpretation.getSqmStatement();
+		this.sqm = hqlInterpretation.getSqmStatement();
 
 		this.parameterMetadata = hqlInterpretation.getParameterMetadata();
 		this.domainParameterXref = hqlInterpretation.getDomainParameterXref();
@@ -200,17 +197,16 @@ public class QuerySqmImpl<R>
 	/**
 	 * Form used for HQL queries
 	 */
-	@SuppressWarnings("unchecked")
 	public QuerySqmImpl(
 			String hql,
-			HqlInterpretation hqlInterpretation,
+			HqlInterpretation<R> hqlInterpretation,
 			Class<R> resultType,
 			SharedSessionContractImplementor session) {
 		super( session );
 		this.hql = hql;
 		this.resultType = resultType;
 
-		this.sqm = (SqmStatement<R>) hqlInterpretation.getSqmStatement();
+		this.sqm = hqlInterpretation.getSqmStatement();
 
 		this.parameterMetadata = hqlInterpretation.getParameterMetadata();
 		this.domainParameterXref = hqlInterpretation.getDomainParameterXref();
@@ -897,7 +893,7 @@ public class QuerySqmImpl<R>
 	}
 
 	@Override
-	public SqmQueryImplementor<R> setResultListTransformer(ResultListTransformer transformer) {
+	public SqmQueryImplementor<R> setResultListTransformer(ResultListTransformer<R> transformer) {
 		applyResultListTransformer( transformer );
 		return this;
 	}
@@ -1248,7 +1244,7 @@ public class QuerySqmImpl<R>
 	}
 
 	@Override
-	public SqmQueryImplementor<R> setProperties(Map bean) {
+	public SqmQueryImplementor<R> setProperties(@SuppressWarnings("rawtypes") Map bean) {
 		super.setProperties( bean );
 		return this;
 	}
@@ -1362,7 +1358,7 @@ public class QuerySqmImpl<R>
 	}
 
 	@Override
-	public SqmQueryImplementor<R> setParameterList(String name, Collection values) {
+	public SqmQueryImplementor<R> setParameterList(String name, @SuppressWarnings("rawtypes") Collection values) {
 		super.setParameterList( name, values );
 		return this;
 	}

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/internal/SqmSelectionQueryImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/internal/SqmSelectionQueryImpl.java
@@ -101,13 +101,12 @@ public class SqmSelectionQueryImpl<R> extends AbstractSelectionQuery<R>
 
 	public SqmSelectionQueryImpl(
 			String hql,
-			HqlInterpretation hqlInterpretation,
+			HqlInterpretation<R> hqlInterpretation,
 			Class<R> expectedResultType,
 			SharedSessionContractImplementor session) {
 		super( session );
 		this.hql = hql;
 
-		//noinspection unchecked
 		this.sqm = (SqmSelectStatement<R>) hqlInterpretation.getSqmStatement();
 
 		this.parameterMetadata = hqlInterpretation.getParameterMetadata();
@@ -166,14 +165,10 @@ public class SqmSelectionQueryImpl<R> extends AbstractSelectionQuery<R>
 
 		final QueryEngine queryEngine = session.getFactory().getQueryEngine();
 		final QueryInterpretationCache interpretationCache = queryEngine.getInterpretationCache();
-		final HqlInterpretation hqlInterpretation = interpretationCache.resolveHqlInterpretation(
-				hql,
-				resultType,
-				(s) -> queryEngine.getHqlTranslator().translate( hql, resultType )
-		);
+		final HqlInterpretation<R> hqlInterpretation =
+				interpretationCache.resolveHqlInterpretation( hql, resultType, queryEngine.getHqlTranslator() );
 
 		SqmUtil.verifyIsSelectStatement( hqlInterpretation.getSqmStatement(), hql );
-		//noinspection unchecked
 		this.sqm = (SqmSelectStatement<R>) hqlInterpretation.getSqmStatement();
 
 		this.parameterMetadata = hqlInterpretation.getParameterMetadata();


### PR DESCRIPTION
and delete a deprecated method of an @Incubating API