### PR TITLE
HHH-17770: Avoid casting long to int

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/engine/jdbc/BlobProxy.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/jdbc/BlobProxy.java
@@ -201,7 +201,7 @@ public final class BlobProxy implements Blob, BlobImplementer {
 
 		@Override
 		public long getLength() {
-			return (int) length;
+			return length;
 		}
 
 		@Override

--- a/hibernate-core/src/test/java/org/hibernate/engine/jdbc/BlobProxyTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/engine/jdbc/BlobProxyTest.java
@@ -1,0 +1,20 @@
+package org.hibernate.engine.jdbc;
+
+import org.hibernate.testing.orm.junit.JiraKey;
+import org.junit.jupiter.api.Test;
+
+import java.sql.Blob;
+import java.sql.SQLException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@JiraKey("HHH-17770")
+class BlobProxyTest {
+
+    @Test
+    void testLengthIsNotTruncated() throws SQLException {
+        long THREE_GB = 3 * 1024 * 1024 * 1024L;
+        Blob blob = BlobProxy.generateProxy(null, THREE_GB);
+        assertEquals(THREE_GB, blob.length());
+    }
+}


### PR DESCRIPTION
This causes NegativeArraySizeException: -1294967296 when Blob contents > 2Gb

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-17770
<!-- Hibernate GitHub Bot issue links end -->