### PR TITLE
HHH-9110 Allow @SQLInsert with no sql field set

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/annotations/SQLInsert.java
+++ b/hibernate-core/src/main/java/org/hibernate/annotations/SQLInsert.java
@@ -50,7 +50,7 @@ public @interface SQLInsert {
 	/**
 	 * Procedure name or SQL {@code INSERT} statement.
 	 */
-	String sql();
+	String sql() default "";
 
 	/**
 	 * Is the statement callable (aka a {@link java.sql.CallableStatement})?

--- a/hibernate-core/src/main/java/org/hibernate/boot/model/internal/CollectionBinder.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/internal/CollectionBinder.java
@@ -1334,7 +1334,7 @@ public abstract class CollectionBinder {
 		final SQLInsert sqlInsert = property.getAnnotation( SQLInsert.class );
 		if ( sqlInsert != null ) {
 			collection.setCustomSQLInsert(
-					sqlInsert.sql().trim(),
+					sqlInsert.sql().trim().isEmpty() ? null : sqlInsert.sql().trim(),
 					sqlInsert.callable(),
 					fromResultCheckStyle( sqlInsert.check() )
 			);

--- a/hibernate-core/src/main/java/org/hibernate/boot/model/internal/EntityBinder.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/internal/EntityBinder.java
@@ -1349,7 +1349,7 @@ public class EntityBinder {
 		final SQLInsert sqlInsert = findMatchingSqlAnnotation( "", SQLInsert.class, SQLInserts.class );
 		if ( sqlInsert != null ) {
 			persistentClass.setCustomSQLInsert(
-					sqlInsert.sql().trim(),
+					sqlInsert.sql().trim().isEmpty() ? null : sqlInsert.sql().trim(),
 					sqlInsert.callable(),
 					fromResultCheckStyle( sqlInsert.check() )
 			);
@@ -2232,7 +2232,7 @@ public class EntityBinder {
 		final SQLInsert sqlInsert = findMatchingSqlAnnotation( tableName, SQLInsert.class, SQLInserts.class );
 		if ( sqlInsert != null ) {
 			join.setCustomSQLInsert(
-					sqlInsert.sql().trim(),
+					sqlInsert.sql().trim().isEmpty() ? null : sqlInsert.sql().trim(),
 					sqlInsert.callable(),
 					fromResultCheckStyle( sqlInsert.check() )
 			);


### PR DESCRIPTION
Hello, I open this PR for starting a discussion on fixing [HHH-9110](https://hibernate.atlassian.net/browse/HHH-9110) (and incidentally [HHH-17353](https://hibernate.atlassian.net/browse/HHH-17353)).

Historically, Postgresql had an issue on some way of doing partitionning where the result of an insert would be 0 instead of 1.
As @SQLInsert does not allow to specify only the ResultCheckStyle value, the sql had to be provided, even when it's not the user intention ([HHH-9110](https://hibernate.atlassian.net/browse/HHH-9110)).
Before Hibernate 6, a workaround was to add @DynamicInsert with an empty string sql for @SQLInsert as it generated the sql correctly ([HHH-17353](https://hibernate.atlassian.net/browse/HHH-17353)).

This PR show the quickest way to resolve the issue, but the following others solutions could be chosen :
* Expand the current solution to @SQLUpdate, @SQLDelete and @SQLDeleteAll to be coherent
* Add specific annotations for ResultCheckStyle value for insert, update, delete and deleteAll 
* Add specific annotations for Expectation value for insert, update, delete and deleteAll, (losely following [HHH-15587](https://hibernate.atlassian.net/browse/HHH-15587))

[HHH-9110]: https://hibernate.atlassian.net/browse/HHH-9110?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[HHH-17353]: https://hibernate.atlassian.net/browse/HHH-17353?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[HHH-9110]: https://hibernate.atlassian.net/browse/HHH-9110?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[HHH-17353]: https://hibernate.atlassian.net/browse/HHH-17353?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[HHH-15587]: https://hibernate.atlassian.net/browse/HHH-15587?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ