### PR TITLE
HHH-9110 make it easier to set ResultCheckType from TypeBinder

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/binder/AttributeBinder.java
+++ b/hibernate-core/src/main/java/org/hibernate/binder/AttributeBinder.java
@@ -22,6 +22,7 @@ import java.lang.annotation.Annotation;
  * custom mapping annotation}.
  *
  * @see org.hibernate.annotations.AttributeBinderType
+ * @see TypeBinder
  *
  * @author Gavin King
  */

--- a/hibernate-core/src/main/java/org/hibernate/binder/TypeBinder.java
+++ b/hibernate-core/src/main/java/org/hibernate/binder/TypeBinder.java
@@ -20,8 +20,34 @@ import java.lang.annotation.Annotation;
  * like {@link PersistentClass} and {@link Component} to implement the
  * semantics of some {@linkplain org.hibernate.annotations.TypeBinderType
  * custom mapping annotation}.
+ * <p>
+ * For example, this annotation disables rowcount checking for insert,
+ * update, and delete statements for annotated entities:
+ * <pre>
+ * &#064;TypeBinderType(binder = NoResultCheck.Binder.class)
+ * &#064;Target(TYPE) &#064;Retention(RUNTIME)
+ * public @interface NoResultCheck {
+ *     class Binder implements TypeBinder&lt;NoResultCheck&gt; {
+ *         &#064;Override
+ *         public void bind(NoResultCheck annotation,
+ *                 MetadataBuildingContext buildingContext,
+ *                 PersistentClass persistentClass) {
+ *             persistentClass.setInsertCheckStyle(NONE);
+ *             persistentClass.setUpdateCheckStyle(NONE);
+ *             persistentClass.setDeleteCheckStyle(NONE);
+ *         }
+ *         &#064;Override
+ *         public void bind(NoResultCheck annotation,
+ *                 MetadataBuildingContext buildingContext,
+ *                 Component embeddableClass) {
+ *             throw new AnnotationException("'@NoResultCheck' cannot annotate an '@Embeddable' class");
+ *         }
+ *     }
+ * }
+ * </pre>
  *
  * @see org.hibernate.annotations.TypeBinderType
+ * @see AttributeBinder
  *
  * @author Gavin King
  */

--- a/hibernate-core/src/main/java/org/hibernate/mapping/Join.java
+++ b/hibernate-core/src/main/java/org/hibernate/mapping/Join.java
@@ -143,6 +143,18 @@ public class Join implements AttributeContainer, Serializable {
 		return customInsertCallable;
 	}
 
+	public void setInsertCheckStyle(ExecuteUpdateResultCheckStyle insertCheckStyle) {
+		this.insertCheckStyle = insertCheckStyle;
+	}
+
+	public ExecuteUpdateResultCheckStyle getInsertCheckStyle() {
+		return insertCheckStyle;
+	}
+
+	/**
+	 * @deprecated use {@link #getInsertCheckStyle()}
+	 */
+	@Deprecated(since = "6.5", forRemoval = true)
 	public ExecuteUpdateResultCheckStyle getCustomSQLInsertCheckStyle() {
 		return insertCheckStyle;
 	}
@@ -161,6 +173,18 @@ public class Join implements AttributeContainer, Serializable {
 		return customUpdateCallable;
 	}
 
+	public void setUpdateCheckStyle(ExecuteUpdateResultCheckStyle updateCheckStyle) {
+		this.updateCheckStyle = updateCheckStyle;
+	}
+
+	public ExecuteUpdateResultCheckStyle getUpdateCheckStyle() {
+		return updateCheckStyle;
+	}
+
+	/**
+	 * @deprecated use {@link #getUpdateCheckStyle()}
+	 */
+	@Deprecated(since = "6.5", forRemoval = true)
 	public ExecuteUpdateResultCheckStyle getCustomSQLUpdateCheckStyle() {
 		return updateCheckStyle;
 	}
@@ -179,6 +203,18 @@ public class Join implements AttributeContainer, Serializable {
 		return customDeleteCallable;
 	}
 
+	public void setDeleteCheckStyle(ExecuteUpdateResultCheckStyle deleteCheckStyle) {
+		this.deleteCheckStyle = deleteCheckStyle;
+	}
+
+	public ExecuteUpdateResultCheckStyle getDeleteCheckStyle() {
+		return deleteCheckStyle;
+	}
+
+	/**
+	 * @deprecated use {@link #getDeleteCheckStyle()}
+	 */
+	@Deprecated(since = "6.5", forRemoval = true)
 	public ExecuteUpdateResultCheckStyle getCustomSQLDeleteCheckStyle() {
 		return deleteCheckStyle;
 	}

--- a/hibernate-core/src/main/java/org/hibernate/mapping/PersistentClass.java
+++ b/hibernate-core/src/main/java/org/hibernate/mapping/PersistentClass.java
@@ -232,7 +232,7 @@ public abstract class PersistentClass implements IdentifiableTypeClass, Attribut
 	}
 
 	public boolean hasSubclasses() {
-		return subclasses.size() > 0;
+		return !subclasses.isEmpty();
 	}
 
 	public int getSubclassSpan() {
@@ -817,6 +817,18 @@ public abstract class PersistentClass implements IdentifiableTypeClass, Attribut
 		return customInsertCallable;
 	}
 
+	public void setInsertCheckStyle(ExecuteUpdateResultCheckStyle insertCheckStyle) {
+		this.insertCheckStyle = insertCheckStyle;
+	}
+
+	public ExecuteUpdateResultCheckStyle getInsertCheckStyle() {
+		return insertCheckStyle;
+	}
+
+	/**
+	 * @deprecated use {@link #getInsertCheckStyle()}
+	 */
+	@Deprecated(since = "6.5", forRemoval = true)
 	public ExecuteUpdateResultCheckStyle getCustomSQLInsertCheckStyle() {
 		return insertCheckStyle;
 	}
@@ -845,6 +857,18 @@ public abstract class PersistentClass implements IdentifiableTypeClass, Attribut
 		return customUpdateCallable;
 	}
 
+	public void setUpdateCheckStyle(ExecuteUpdateResultCheckStyle updateCheckStyle) {
+		this.updateCheckStyle = updateCheckStyle;
+	}
+
+	public ExecuteUpdateResultCheckStyle getUpdateCheckStyle() {
+		return updateCheckStyle;
+	}
+
+	/**
+	 * @deprecated use {@link #getUpdateCheckStyle()}
+	 */
+	@Deprecated(since = "6.5", forRemoval = true)
 	public ExecuteUpdateResultCheckStyle getCustomSQLUpdateCheckStyle() {
 		return updateCheckStyle;
 	}
@@ -873,6 +897,18 @@ public abstract class PersistentClass implements IdentifiableTypeClass, Attribut
 		return customDeleteCallable;
 	}
 
+	public void setDeleteCheckStyle(ExecuteUpdateResultCheckStyle deleteCheckStyle) {
+		this.deleteCheckStyle = deleteCheckStyle;
+	}
+
+	public ExecuteUpdateResultCheckStyle getDeleteCheckStyle() {
+		return deleteCheckStyle;
+	}
+
+	/**
+	 * @deprecated use {@link #getDeleteCheckStyle()}
+	 */
+	@Deprecated(since = "6.5", forRemoval = true)
 	public ExecuteUpdateResultCheckStyle getCustomSQLDeleteCheckStyle() {
 		return deleteCheckStyle;
 	}

--- a/hibernate-core/src/main/java/org/hibernate/persister/entity/JoinedSubclassEntityPersister.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/entity/JoinedSubclassEntityPersister.java
@@ -411,25 +411,25 @@ public class JoinedSubclassEntityPersister extends AbstractEntityPersister {
 			customSQLInsert[jk] = currentClass.getCustomSQLInsert();
 			insertCallable[jk] = customSQLInsert[jk] != null && currentClass.isCustomInsertCallable();
 			insertExpectations[jk] = appropriateExpectation(
-					currentClass.getCustomSQLInsertCheckStyle() == null
+					currentClass.getInsertCheckStyle() == null
 							? ExecuteUpdateResultCheckStyle.determineDefault( customSQLInsert[jk], insertCallable[jk] )
-							: currentClass.getCustomSQLInsertCheckStyle()
+							: currentClass.getInsertCheckStyle()
 			);
 
 			customSQLUpdate[jk] = currentClass.getCustomSQLUpdate();
 			updateCallable[jk] = customSQLUpdate[jk] != null && currentClass.isCustomUpdateCallable();
 			updateExpectations[jk] = appropriateExpectation(
-					currentClass.getCustomSQLUpdateCheckStyle() == null
+					currentClass.getUpdateCheckStyle() == null
 							? ExecuteUpdateResultCheckStyle.determineDefault( customSQLUpdate[jk], updateCallable[jk] )
-							: currentClass.getCustomSQLUpdateCheckStyle()
+							: currentClass.getUpdateCheckStyle()
 			);
 
 			customSQLDelete[jk] = currentClass.getCustomSQLDelete();
 			deleteCallable[jk] = customSQLDelete[jk] != null && currentClass.isCustomDeleteCallable();
 			deleteExpectations[jk] = appropriateExpectation(
-					currentClass.getCustomSQLDeleteCheckStyle() == null
+					currentClass.getDeleteCheckStyle() == null
 					? ExecuteUpdateResultCheckStyle.determineDefault( customSQLDelete[jk], deleteCallable[jk] )
-					: currentClass.getCustomSQLDeleteCheckStyle()
+					: currentClass.getDeleteCheckStyle()
 			);
 
 			jk--;
@@ -448,25 +448,25 @@ public class JoinedSubclassEntityPersister extends AbstractEntityPersister {
 			customSQLInsert[j] = join.getCustomSQLInsert();
 			insertCallable[j] = customSQLInsert[j] != null && join.isCustomInsertCallable();
 			insertExpectations[j] = appropriateExpectation(
-					join.getCustomSQLInsertCheckStyle() == null
+					join.getInsertCheckStyle() == null
 							? ExecuteUpdateResultCheckStyle.determineDefault( customSQLInsert[j], insertCallable[j] )
-							: join.getCustomSQLInsertCheckStyle()
+							: join.getInsertCheckStyle()
 			);
 
 			customSQLUpdate[j] = join.getCustomSQLUpdate();
 			updateCallable[j] = customSQLUpdate[j] != null && join.isCustomUpdateCallable();
 			updateExpectations[j] = appropriateExpectation(
-					join.getCustomSQLUpdateCheckStyle() == null
+					join.getUpdateCheckStyle() == null
 							? ExecuteUpdateResultCheckStyle.determineDefault( customSQLUpdate[j], updateCallable[j] )
-							: join.getCustomSQLUpdateCheckStyle()
+							: join.getUpdateCheckStyle()
 			);
 
 			customSQLDelete[j] = join.getCustomSQLDelete();
 			deleteCallable[j] = customSQLDelete[j] != null && join.isCustomDeleteCallable();
 			deleteExpectations[j] = appropriateExpectation(
-					join.getCustomSQLDeleteCheckStyle() == null
+					join.getDeleteCheckStyle() == null
 							? ExecuteUpdateResultCheckStyle.determineDefault( customSQLDelete[j], deleteCallable[j] )
-							: join.getCustomSQLDeleteCheckStyle()
+							: join.getDeleteCheckStyle()
 			);
 
 			j++;

--- a/hibernate-core/src/main/java/org/hibernate/persister/entity/SingleTableEntityPersister.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/entity/SingleTableEntityPersister.java
@@ -172,25 +172,25 @@ public class SingleTableEntityPersister extends AbstractEntityPersister {
 		customSQLInsert[0] = persistentClass.getCustomSQLInsert();
 		insertCallable[0] = customSQLInsert[0] != null && persistentClass.isCustomInsertCallable();
 		insertExpectations[0] = appropriateExpectation(
-				persistentClass.getCustomSQLInsertCheckStyle() == null
+				persistentClass.getInsertCheckStyle() == null
 						? ExecuteUpdateResultCheckStyle.determineDefault( customSQLInsert[0], insertCallable[0] )
-						: persistentClass.getCustomSQLInsertCheckStyle()
+						: persistentClass.getInsertCheckStyle()
 		);
 
 		customSQLUpdate[0] = persistentClass.getCustomSQLUpdate();
 		updateCallable[0] = customSQLUpdate[0] != null && persistentClass.isCustomUpdateCallable();
 		updateExpectations[0] = appropriateExpectation(
-				persistentClass.getCustomSQLUpdateCheckStyle() == null
+				persistentClass.getUpdateCheckStyle() == null
 						? ExecuteUpdateResultCheckStyle.determineDefault( customSQLUpdate[0], updateCallable[0] )
-						: persistentClass.getCustomSQLUpdateCheckStyle()
+						: persistentClass.getUpdateCheckStyle()
 		);
 
 		customSQLDelete[0] = persistentClass.getCustomSQLDelete();
 		deleteCallable[0] = customSQLDelete[0] != null && persistentClass.isCustomDeleteCallable();
 		deleteExpectations[0] = appropriateExpectation(
-				persistentClass.getCustomSQLDeleteCheckStyle() == null
+				persistentClass.getDeleteCheckStyle() == null
 						? ExecuteUpdateResultCheckStyle.determineDefault( customSQLDelete[0], deleteCallable[0] )
-						: persistentClass.getCustomSQLDeleteCheckStyle()
+						: persistentClass.getDeleteCheckStyle()
 		);
 
 		// JOINS
@@ -209,25 +209,25 @@ public class SingleTableEntityPersister extends AbstractEntityPersister {
 			customSQLInsert[j] = join.getCustomSQLInsert();
 			insertCallable[j] = customSQLInsert[j] != null && join.isCustomInsertCallable();
 			insertExpectations[j] = appropriateExpectation(
-					join.getCustomSQLInsertCheckStyle() == null
+					join.getInsertCheckStyle() == null
 							? ExecuteUpdateResultCheckStyle.determineDefault( customSQLInsert[j], insertCallable[j] )
-							: join.getCustomSQLInsertCheckStyle()
+							: join.getInsertCheckStyle()
 			);
 
 			customSQLUpdate[j] = join.getCustomSQLUpdate();
 			updateCallable[j] = customSQLUpdate[j] != null && join.isCustomUpdateCallable();
 			updateExpectations[j] = appropriateExpectation(
-					join.getCustomSQLUpdateCheckStyle() == null
+					join.getUpdateCheckStyle() == null
 							? ExecuteUpdateResultCheckStyle.determineDefault( customSQLUpdate[j], updateCallable[j] )
-							: join.getCustomSQLUpdateCheckStyle()
+							: join.getUpdateCheckStyle()
 			);
 
 			customSQLDelete[j] = join.getCustomSQLDelete();
 			deleteCallable[j] = customSQLDelete[j] != null && join.isCustomDeleteCallable();
 			deleteExpectations[j] = appropriateExpectation(
-					join.getCustomSQLDeleteCheckStyle() == null
+					join.getDeleteCheckStyle() == null
 							? ExecuteUpdateResultCheckStyle.determineDefault( customSQLDelete[j], deleteCallable[j] )
-							: join.getCustomSQLDeleteCheckStyle()
+							: join.getDeleteCheckStyle()
 			);
 
 			keyColumnNames[j] = new String[join.getKey().getColumnSpan()];

--- a/hibernate-core/src/main/java/org/hibernate/persister/entity/UnionSubclassEntityPersister.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/entity/UnionSubclassEntityPersister.java
@@ -132,9 +132,9 @@ public class UnionSubclassEntityPersister extends AbstractEntityPersister {
 		callable = sql != null && persistentClass.isCustomInsertCallable();
 		checkStyle = sql == null
 				? ExecuteUpdateResultCheckStyle.COUNT
-				: persistentClass.getCustomSQLInsertCheckStyle() == null
+				: persistentClass.getInsertCheckStyle() == null
 				? ExecuteUpdateResultCheckStyle.determineDefault( sql, callable )
-				: persistentClass.getCustomSQLInsertCheckStyle();
+				: persistentClass.getInsertCheckStyle();
 		customSQLInsert = new String[] {sql};
 		insertCallable = new boolean[] {callable};
 		insertExpectations = new Expectation[] { appropriateExpectation( checkStyle ) };
@@ -143,9 +143,9 @@ public class UnionSubclassEntityPersister extends AbstractEntityPersister {
 		callable = sql != null && persistentClass.isCustomUpdateCallable();
 		checkStyle = sql == null
 				? ExecuteUpdateResultCheckStyle.COUNT
-				: persistentClass.getCustomSQLUpdateCheckStyle() == null
+				: persistentClass.getUpdateCheckStyle() == null
 				? ExecuteUpdateResultCheckStyle.determineDefault( sql, callable )
-				: persistentClass.getCustomSQLUpdateCheckStyle();
+				: persistentClass.getUpdateCheckStyle();
 		customSQLUpdate = new String[] {sql};
 		updateCallable = new boolean[] {callable};
 		updateExpectations = new Expectation[] { appropriateExpectation( checkStyle ) };
@@ -154,9 +154,9 @@ public class UnionSubclassEntityPersister extends AbstractEntityPersister {
 		callable = sql != null && persistentClass.isCustomDeleteCallable();
 		checkStyle = sql == null
 				? ExecuteUpdateResultCheckStyle.COUNT
-				: persistentClass.getCustomSQLDeleteCheckStyle() == null
+				: persistentClass.getDeleteCheckStyle() == null
 				? ExecuteUpdateResultCheckStyle.determineDefault( sql, callable )
-				: persistentClass.getCustomSQLDeleteCheckStyle();
+				: persistentClass.getDeleteCheckStyle();
 		customSQLDelete = new String[] {sql};
 		deleteCallable = new boolean[] {callable};
 		deleteExpectations = new Expectation[] { appropriateExpectation( checkStyle ) };

--- a/hibernate-core/src/main/java/org/hibernate/query/package-info.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/package-info.java
@@ -17,7 +17,7 @@
  * <p>
  * The classes {@link org.hibernate.query.Order}, {@link org.hibernate.query.Page},
  * {@link org.hibernate.query.KeyedPage}, and {@link org.hibernate.query.KeyedResultList}
- * define an API for dynamic ordering and key-based pagination. These are
+ * define an API for dynamic ordering and key-based pagination. These
  * classes are especially useful as parameters of generated
  * {@link org.hibernate.annotations.processing.Find @Find} and
  * {@link org.hibernate.annotations.processing.HQL @HQL} methods.

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/attributebinder/typebinder/NoResultCheck.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/attributebinder/typebinder/NoResultCheck.java
@@ -1,0 +1,33 @@
+package org.hibernate.orm.test.mapping.attributebinder.typebinder;
+
+import org.hibernate.annotations.TypeBinderType;
+import org.hibernate.binder.TypeBinder;
+import org.hibernate.boot.spi.MetadataBuildingContext;
+import org.hibernate.mapping.Component;
+import org.hibernate.mapping.PersistentClass;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+import static org.hibernate.engine.spi.ExecuteUpdateResultCheckStyle.NONE;
+
+@TypeBinderType(binder = NoResultCheck.Binder.class)
+@Retention(RUNTIME)
+@Target(TYPE)
+public @interface NoResultCheck {
+	class Binder implements TypeBinder<NoResultCheck> {
+		@Override
+		public void bind(NoResultCheck annotation, MetadataBuildingContext buildingContext, PersistentClass persistentClass) {
+			persistentClass.setInsertCheckStyle(NONE);
+			persistentClass.setUpdateCheckStyle(NONE);
+			persistentClass.setDeleteCheckStyle(NONE);
+		}
+
+		@Override
+		public void bind(NoResultCheck annotation, MetadataBuildingContext buildingContext, Component embeddableClass) {
+
+		}
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/attributebinder/typebinder/ResultCheckBinderTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/attributebinder/typebinder/ResultCheckBinderTest.java
@@ -1,0 +1,24 @@
+package org.hibernate.orm.test.mapping.attributebinder.typebinder;
+
+import jakarta.persistence.Id;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.junit.jupiter.api.Test;
+
+@SessionFactory
+@DomainModel(annotatedClasses = ResultCheckBinderTest.Entity.class)
+public class ResultCheckBinderTest {
+	@Test void test(SessionFactoryScope scope) {
+		Entity entity = new Entity();
+		scope.inStatelessTransaction(s -> s.insert(entity) );
+		scope.inStatelessTransaction(s -> s.delete(entity) );
+		scope.inStatelessTransaction( s -> s.update(entity) );
+		scope.inStatelessTransaction(s -> s.delete(entity) );
+	}
+	@NoResultCheck
+	@jakarta.persistence.Entity
+	static class Entity {
+		@Id long id;
+	}
+}


### PR DESCRIPTION
This was already possible, but not very comfortable when not also setting custom SQL.

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-9110
<!-- Hibernate GitHub Bot issue links end -->