### PR TITLE
HHH-17840 Jackson JsonNode stored as JSON "null" value instead of database NULL

### DIFF
--- a/hibernate-core/hibernate-core.gradle
+++ b/hibernate-core/hibernate-core.gradle
@@ -71,7 +71,7 @@ dependencies {
     testRuntimeOnly testLibs.weld
     testRuntimeOnly testLibs.wildFlyTxnClient
     testRuntimeOnly jakartaLibs.jsonb
-    testRuntimeOnly libs.jackson
+    testImplementation libs.jackson
     testRuntimeOnly libs.jacksonXml
     testRuntimeOnly libs.jacksonJsr310
 


### PR DESCRIPTION
Reproducer for [HHH-17840](https://hibernate.atlassian.net/browse/HHH-17840).

[HHH-17840]: https://hibernate.atlassian.net/browse/HHH-17840?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ