### PR TITLE
HHH-15587 replace use of enums for specifying Expectations

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/annotations/ResultCheckStyle.java
+++ b/hibernate-core/src/main/java/org/hibernate/annotations/ResultCheckStyle.java
@@ -6,6 +6,8 @@
  */
 package org.hibernate.annotations;
 
+import org.hibernate.jdbc.Expectation;
+
 /**
  * Enumerates strategies for checking JDBC return codes for custom SQL DML queries.
  * <p>
@@ -19,13 +21,20 @@ package org.hibernate.annotations;
  * @see SQLUpdate#check()
  * @see SQLDelete#check()
  * @see SQLDeleteAll#check()
+ *
+ * @see Expectation
+ *
+ * @deprecated Use an {@link Expectation} class instead.
  */
+@Deprecated(since = "6.5")
 public enum ResultCheckStyle {
 	/**
 	 * No return code checking. Might mean that no checks are required, or that
 	 * failure is indicated by a {@link java.sql.SQLException} being thrown, for
 	 * example, by a {@link java.sql.CallableStatement stored procedure} which
 	 * performs explicit checks.
+	 *
+	 * @see org.hibernate.jdbc.Expectation.None
 	 */
 	NONE,
 	/**
@@ -34,6 +43,8 @@ public enum ResultCheckStyle {
 	 * {@link java.sql.Statement#executeBatch()}. The row count is checked
 	 * against an expected value. For example, the expected row count for
 	 * an {@code INSERT} statement is always 1.
+	 *
+	 * @see org.hibernate.jdbc.Expectation.RowCount
 	 */
 	COUNT,
 	/**
@@ -42,6 +53,8 @@ public enum ResultCheckStyle {
 	 * stored procedure}.
 	 * <p>
 	 * Statement batching is disabled when {@code PARAM} is selected.
+	 *
+	 * @see org.hibernate.jdbc.Expectation.OutParameter
 	 */
 	PARAM
 }

--- a/hibernate-core/src/main/java/org/hibernate/annotations/SQLDelete.java
+++ b/hibernate-core/src/main/java/org/hibernate/annotations/SQLDelete.java
@@ -6,6 +6,8 @@
  */
 package org.hibernate.annotations;
 
+import org.hibernate.jdbc.Expectation;
+
 import java.lang.annotation.Repeatable;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
@@ -42,8 +44,20 @@ public @interface SQLDelete {
 	boolean callable() default false;
 
 	/**
-	 * For persistence operation what style of determining results (success/failure) is to be used.
+	 * An {@link Expectation} class used to verify that the operation was successful.
+	 *
+	 * @see Expectation.None
+	 * @see Expectation.RowCount
+	 * @see Expectation.OutParameter
 	 */
+	Class<? extends Expectation> verify() default Expectation.class;
+
+	/**
+	 * A {@link ResultCheckStyle} used to verify that the operation was successful.
+	 *
+	 * @deprecated use {@link #verify()} with an {@link Expectation} class
+	 */
+	@Deprecated(since = "6.5")
 	ResultCheckStyle check() default ResultCheckStyle.NONE;
 
 	/**

--- a/hibernate-core/src/main/java/org/hibernate/annotations/SQLDeleteAll.java
+++ b/hibernate-core/src/main/java/org/hibernate/annotations/SQLDeleteAll.java
@@ -6,6 +6,8 @@
  */
 package org.hibernate.annotations;
 
+import org.hibernate.jdbc.Expectation;
+
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
@@ -34,8 +36,20 @@ public @interface SQLDeleteAll {
 	boolean callable() default false;
 
 	/**
-	 * For persistence operation what style of determining results (success/failure) is to be used.
+	 * An {@link Expectation} class used to verify that the operation was successful.
+	 *
+	 * @see Expectation.None
+	 * @see Expectation.RowCount
+	 * @see Expectation.OutParameter
 	 */
+	Class<? extends Expectation> verify() default Expectation.class;
+
+	/**
+	 * A {@link ResultCheckStyle} used to verify that the operation was successful.
+	 *
+	 * @deprecated use {@link #verify()} with an {@link Expectation} class
+	 */
+	@Deprecated(since = "6.5")
 	ResultCheckStyle check() default ResultCheckStyle.NONE;
 
 	/**

--- a/hibernate-core/src/main/java/org/hibernate/annotations/SQLInsert.java
+++ b/hibernate-core/src/main/java/org/hibernate/annotations/SQLInsert.java
@@ -6,6 +6,8 @@
  */
 package org.hibernate.annotations;
 
+import org.hibernate.jdbc.Expectation;
+
 import java.lang.annotation.Repeatable;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
@@ -58,8 +60,20 @@ public @interface SQLInsert {
 	boolean callable() default false;
 
 	/**
-	 * For persistence operation what style of determining results (success/failure) is to be used.
+	 * An {@link Expectation} class used to verify that the operation was successful.
+	 *
+	 * @see Expectation.None
+	 * @see Expectation.RowCount
+	 * @see Expectation.OutParameter
 	 */
+	Class<? extends Expectation> verify() default Expectation.class;
+
+	/**
+	 * A {@link ResultCheckStyle} used to verify that the operation was successful.
+	 *
+	 * @deprecated use {@link #verify()} with an {@link Expectation} class
+	 */
+	@Deprecated(since = "6.5")
 	ResultCheckStyle check() default ResultCheckStyle.NONE;
 
 	/**

--- a/hibernate-core/src/main/java/org/hibernate/annotations/SQLUpdate.java
+++ b/hibernate-core/src/main/java/org/hibernate/annotations/SQLUpdate.java
@@ -6,6 +6,8 @@
  */
 package org.hibernate.annotations;
 
+import org.hibernate.jdbc.Expectation;
+
 import java.lang.annotation.Repeatable;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
@@ -61,8 +63,20 @@ public @interface SQLUpdate {
 	boolean callable() default false;
 
 	/**
-	 * For persistence operation what style of determining results (success/failure) is to be used.
+	 * An {@link Expectation} class used to verify that the operation was successful.
+	 *
+	 * @see Expectation.None
+	 * @see Expectation.RowCount
+	 * @see Expectation.OutParameter
 	 */
+	Class<? extends Expectation> verify() default Expectation.class;
+
+	/**
+	 * A {@link ResultCheckStyle} used to verify that the operation was successful.
+	 *
+	 * @deprecated use {@link #verify()} with an {@link Expectation} class
+	 */
+	@Deprecated(since = "6.5")
 	ResultCheckStyle check() default ResultCheckStyle.NONE;
 
 	/**

--- a/hibernate-core/src/main/java/org/hibernate/boot/model/internal/CollectionBinder.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/internal/CollectionBinder.java
@@ -65,6 +65,7 @@ import org.hibernate.annotations.OptimisticLock;
 import org.hibernate.annotations.Parameter;
 import org.hibernate.annotations.Persister;
 import org.hibernate.annotations.QueryCacheLayout;
+import org.hibernate.annotations.ResultCheckStyle;
 import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.SQLDeleteAll;
 import org.hibernate.annotations.SQLInsert;
@@ -95,6 +96,8 @@ import org.hibernate.engine.jdbc.env.spi.JdbcEnvironment;
 import org.hibernate.engine.spi.FilterDefinition;
 import org.hibernate.internal.CoreMessageLogger;
 import org.hibernate.internal.util.collections.CollectionHelper;
+import org.hibernate.jdbc.Expectation;
+import org.hibernate.jdbc.Expectations;
 import org.hibernate.mapping.Any;
 import org.hibernate.mapping.Backref;
 import org.hibernate.mapping.CheckConstraint;
@@ -1321,6 +1324,7 @@ public abstract class CollectionBinder {
 		propertyHolder.addProperty( prop, declaringClass );
 	}
 
+	@SuppressWarnings("deprecation")
 	private void bindLoader() {
 		//SQL overriding
 
@@ -1331,7 +1335,9 @@ public abstract class CollectionBinder {
 					sqlInsert.callable(),
 					fromResultCheckStyle( sqlInsert.check() )
 			);
-
+			if ( sqlInsert.verify() != Expectation.class ) {
+				collection.setInsertExpectation( sqlInsert.verify() );
+			}
 		}
 
 		final SQLUpdate sqlUpdate = property.getAnnotation( SQLUpdate.class );
@@ -1341,6 +1347,9 @@ public abstract class CollectionBinder {
 					sqlUpdate.callable(),
 					fromResultCheckStyle( sqlUpdate.check() )
 			);
+			if ( sqlUpdate.verify() != Expectation.class ) {
+				collection.setUpdateExpectation( sqlUpdate.verify() );
+			}
 		}
 
 		final SQLDelete sqlDelete = property.getAnnotation( SQLDelete.class );
@@ -1350,6 +1359,9 @@ public abstract class CollectionBinder {
 					sqlDelete.callable(),
 					fromResultCheckStyle( sqlDelete.check() )
 			);
+			if ( sqlDelete.verify() != Expectation.class ) {
+				collection.setDeleteExpectation( sqlDelete.verify() );
+			}
 		}
 
 		final SQLDeleteAll sqlDeleteAll = property.getAnnotation( SQLDeleteAll.class );
@@ -1359,6 +1371,9 @@ public abstract class CollectionBinder {
 					sqlDeleteAll.callable(),
 					fromResultCheckStyle( sqlDeleteAll.check() )
 			);
+			if ( sqlDeleteAll.verify() != Expectation.class ) {
+				collection.setDeleteAllExpectation( sqlDeleteAll.verify() );
+			}
 		}
 
 		final SQLSelect sqlSelect = property.getAnnotation( SQLSelect.class );

--- a/hibernate-core/src/main/java/org/hibernate/boot/model/internal/EntityBinder.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/internal/EntityBinder.java
@@ -90,6 +90,7 @@ import org.hibernate.engine.jdbc.env.spi.JdbcEnvironment;
 import org.hibernate.engine.spi.FilterDefinition;
 import org.hibernate.internal.CoreMessageLogger;
 import org.hibernate.internal.util.StringHelper;
+import org.hibernate.jdbc.Expectation;
 import org.hibernate.jpa.event.spi.CallbackType;
 import org.hibernate.mapping.BasicValue;
 import org.hibernate.mapping.CheckConstraint;
@@ -1387,7 +1388,9 @@ public class EntityBinder {
 					sqlInsert.callable(),
 					fromResultCheckStyle( sqlInsert.check() )
 			);
-
+			if ( sqlInsert.verify() != Expectation.class ) {
+				persistentClass.setInsertExpectation( sqlInsert.verify() );
+			}
 		}
 
 		final SQLUpdate sqlUpdate = findMatchingSqlAnnotation( "", SQLUpdate.class, SQLUpdates.class );
@@ -1397,6 +1400,9 @@ public class EntityBinder {
 					sqlUpdate.callable(),
 					fromResultCheckStyle( sqlUpdate.check() )
 			);
+			if ( sqlUpdate.verify() != Expectation.class ) {
+				persistentClass.setUpdateExpectation( sqlUpdate.verify() );
+			}
 		}
 
 		final SQLDelete sqlDelete = findMatchingSqlAnnotation( "", SQLDelete.class, SQLDeletes.class );
@@ -1406,6 +1412,9 @@ public class EntityBinder {
 					sqlDelete.callable(),
 					fromResultCheckStyle( sqlDelete.check() )
 			);
+			if ( sqlDelete.verify() != Expectation.class ) {
+				persistentClass.setDeleteExpectation( sqlDelete.verify() );
+			}
 		}
 
 		final SQLDeleteAll sqlDeleteAll = annotatedClass.getAnnotation( SQLDeleteAll.class );
@@ -2265,6 +2274,9 @@ public class EntityBinder {
 					sqlInsert.callable(),
 					fromResultCheckStyle( sqlInsert.check() )
 			);
+			if ( sqlInsert.verify() != Expectation.class ) {
+				join.setInsertExpectation( sqlInsert.verify() );
+			}
 		}
 		else if ( matchingTable != null ) {
 			final String insertSql = matchingTable.sqlInsert().sql();
@@ -2284,6 +2296,9 @@ public class EntityBinder {
 					sqlUpdate.callable(),
 					fromResultCheckStyle( sqlUpdate.check() )
 			);
+			if ( sqlUpdate.verify() != Expectation.class ) {
+				join.setUpdateExpectation( sqlUpdate.verify() );
+			}
 		}
 		else if ( matchingTable != null ) {
 			final String updateSql = matchingTable.sqlUpdate().sql();
@@ -2303,6 +2318,9 @@ public class EntityBinder {
 					sqlDelete.callable(),
 					fromResultCheckStyle( sqlDelete.check() )
 			);
+			if ( sqlDelete.verify() != Expectation.class ) {
+				join.setDeleteExpectation( sqlDelete.verify() );
+			}
 		}
 		else if ( matchingTable != null ) {
 			final String deleteSql = matchingTable.sqlDelete().sql();

--- a/hibernate-core/src/main/java/org/hibernate/engine/spi/ExecuteUpdateResultCheckStyle.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/spi/ExecuteUpdateResultCheckStyle.java
@@ -10,6 +10,7 @@ import org.hibernate.AssertionFailure;
 import org.hibernate.annotations.ResultCheckStyle;
 
 import org.checkerframework.checker.nullness.qual.Nullable;
+import org.hibernate.jdbc.Expectation;
 
 /**
  * For persistence operations (INSERT, UPDATE, DELETE) what style of
@@ -21,7 +22,10 @@ import org.checkerframework.checker.nullness.qual.Nullable;
  *           new {@code org.hibernate.ResultCheck} enum.
  *
  * @author Steve Ebersole
+ *
+ * @deprecated Use an {@link org.hibernate.jdbc.Expectation} class
  */
+@Deprecated(since = "6.5", forRemoval = true)
 public enum ExecuteUpdateResultCheckStyle {
 	/**
 	 * Do not perform checking.  Either user simply does not want checking, or is
@@ -84,5 +88,27 @@ public enum ExecuteUpdateResultCheckStyle {
 
 	public static ExecuteUpdateResultCheckStyle determineDefault(@Nullable String customSql, boolean callable) {
 		return customSql != null && callable ? PARAM : COUNT;
+	}
+
+	public static @Nullable Class<? extends Expectation> expectationClass(@Nullable ExecuteUpdateResultCheckStyle style) {
+		if ( style == null ) {
+			return null;
+		}
+		else {
+			return style.expectationClass();
+		}
+	}
+
+	public Class<? extends Expectation> expectationClass() {
+		switch (this) {
+			case NONE:
+				return Expectation.None.class;
+			case COUNT:
+				return Expectation.RowCount.class;
+			case PARAM:
+				return Expectation.OutParameter.class;
+			default:
+				throw new AssertionFailure( "Unrecognized ExecuteUpdateResultCheckStyle");
+		}
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/jdbc/Expectation.java
+++ b/hibernate-core/src/main/java/org/hibernate/jdbc/Expectation.java
@@ -5,13 +5,43 @@
  * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
  */
 package org.hibernate.jdbc;
+
+import java.sql.CallableStatement;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
+import java.sql.Types;
 
 import org.hibernate.HibernateException;
+import org.hibernate.exception.GenericJDBCException;
+
+import static org.hibernate.jdbc.Expectations.checkBatched;
+import static org.hibernate.jdbc.Expectations.checkNonBatched;
+import static org.hibernate.jdbc.Expectations.sqlExceptionHelper;
+import static org.hibernate.jdbc.Expectations.toCallableStatement;
 
 /**
  * Defines an expected DML operation outcome.
+ * Used to verify that a JDBC operation completed successfully.
+ * <p>
+ * The two standard implementations are {@link RowCount} for
+ * row count checking, and {@link OutParameter} for checking
+ * the return code assigned to an output parameter of a
+ * {@link CallableStatement}. Custom implementations are
+ * permitted.
+ * <p>
+ * An {@code Expectation} is usually selected via an annotation,
+ * for example:
+ * <pre>
+ * &#064;Entity
+ * &#064;SQLUpdate(sql = "update Record set uid = gen_random_uuid(), whatever = ? where id = ?",
+ *            verify = Expectation.RowCount.class)
+ * class Record { ... }
+ * </pre>
+ *
+ * @see org.hibernate.annotations.SQLInsert#verify
+ * @see org.hibernate.annotations.SQLUpdate#verify
+ * @see org.hibernate.annotations.SQLDelete#verify
+ * @see org.hibernate.annotations.SQLDeleteAll#verify
  *
  * @author Steve Ebersole
  */
@@ -22,12 +52,14 @@ public interface Expectation {
 	 *
 	 * @return True if batching can be combined with this expectation; false otherwise.
 	 */
-	boolean canBeBatched();
+	default boolean canBeBatched() {
+		return true;
+	}
 
 	/**
 	 * The number of parameters this expectation implies.  E.g.,
-	 * {@link Expectations.BasicParamExpectation} requires a single
-	 * OUT parameter for reading back the number of affected rows.
+	 * {@link OutParameter} requires a single OUT parameter for
+	 * reading back the number of affected rows.
 	 */
 	default int getNumberOfParametersUsed() {
 		return 0;
@@ -40,11 +72,12 @@ public interface Expectation {
 	 * @param rowCount The RDBMS reported "number of rows affected".
 	 * @param statement The statement representing the operation
 	 * @param batchPosition The position in the batch (if batching)
-	 * @param statementSQL The SQL backing the prepared statement, for logging purposes
+	 * @param sql The SQL backing the prepared statement, for logging purposes
 	 * @throws SQLException Exception from the JDBC driver
 	 * @throws HibernateException Problem processing the outcome.
 	 */
-	void verifyOutcome(int rowCount, PreparedStatement statement, int batchPosition, String statementSQL) throws SQLException, HibernateException;
+	void verifyOutcome(int rowCount, PreparedStatement statement, int batchPosition, String sql)
+			throws SQLException, HibernateException;
 
 	/**
 	 * Perform any special statement preparation.
@@ -54,5 +87,101 @@ public interface Expectation {
 	 * @throws SQLException Exception from the JDBC driver
 	 * @throws HibernateException Problem performing preparation.
 	 */
-	int prepare(PreparedStatement statement) throws SQLException, HibernateException;
+	default int prepare(PreparedStatement statement) throws SQLException, HibernateException {
+		return 0;
+	}
+
+	/**
+	 * No return code checking. Might mean that no checks are required, or that
+	 * failure is indicated by a {@link java.sql.SQLException} being thrown, for
+	 * example, by a {@link java.sql.CallableStatement stored procedure} which
+	 * performs explicit checks.
+	 *
+	 * @since 6.5
+	 */
+	class None implements Expectation {
+		@Override
+		public void verifyOutcome(int rowCount, PreparedStatement statement, int batchPosition, String sql) {
+			// nothing to do
+		}
+	}
+
+	/**
+	 * Row count checking. A row count is an integer value returned by
+	 * {@link java.sql.PreparedStatement#executeUpdate()} or
+	 * {@link java.sql.Statement#executeBatch()}. The row count is checked
+	 * against an expected value. For example, the expected row count for
+	 * an {@code INSERT} statement is always 1.
+	 *
+	 * @since 6.5
+	 */
+	class RowCount implements Expectation {
+		@Override
+		public final void verifyOutcome(int rowCount, PreparedStatement statement, int batchPosition, String sql) {
+			if ( batchPosition < 0 ) {
+				checkNonBatched( expectedRowCount(), rowCount, sql );
+			}
+			else {
+				checkBatched( expectedRowCount(), rowCount, batchPosition, sql );
+			}
+		}
+
+		protected int expectedRowCount() {
+			return 1;
+		}
+	}
+
+	/**
+	 * Essentially identical to {@link RowCount} except that the row count
+	 * is obtained via an output parameter of a {@link CallableStatement
+	 * stored procedure}.
+	 * <p>
+	 * Statement batching is disabled when {@code OutParameter} is used.
+	 *
+	 * @since 6.5
+	 */
+	class OutParameter implements Expectation {
+		@Override
+		public final void verifyOutcome(int rowCount, PreparedStatement statement, int batchPosition, String sql) {
+			final int result;
+			try {
+				result = toCallableStatement( statement ).getInt( parameterIndex() );
+			}
+			catch ( SQLException sqle ) {
+				sqlExceptionHelper.logExceptions( sqle, "Could not extract row count from CallableStatement" );
+				throw new GenericJDBCException( "Could not extract row count from CallableStatement", sqle );
+			}
+			if ( batchPosition < 0 ) {
+				checkNonBatched( expectedRowCount(), result, sql );
+			}
+			else {
+				checkBatched( expectedRowCount(), result, batchPosition, sql );
+			}
+		}
+
+		@Override
+		public int getNumberOfParametersUsed() {
+			return 1;
+		}
+
+		@Override
+		public int prepare(PreparedStatement statement) throws SQLException, HibernateException {
+			toCallableStatement( statement ).registerOutParameter( parameterIndex(), Types.NUMERIC );
+			return 1;
+		}
+
+		@Override
+		public boolean canBeBatched() {
+			return false;
+		}
+
+		protected int parameterIndex() {
+			return 1;
+		}
+
+		protected int expectedRowCount() {
+			return 1;
+		}
+	}
+
 }

--- a/hibernate-core/src/main/java/org/hibernate/mapping/Join.java
+++ b/hibernate-core/src/main/java/org/hibernate/mapping/Join.java
@@ -12,7 +12,10 @@ import java.util.Iterator;
 import java.util.List;
 
 import org.hibernate.engine.spi.ExecuteUpdateResultCheckStyle;
+import org.hibernate.jdbc.Expectation;
 import org.hibernate.sql.Alias;
+
+import static org.hibernate.engine.spi.ExecuteUpdateResultCheckStyle.expectationClass;
 
 /**
  * A mapping model object representing some sort of auxiliary table, for
@@ -46,6 +49,10 @@ public class Join implements AttributeContainer, Serializable {
 	private String customSQLDelete;
 	private boolean customDeleteCallable;
 	private ExecuteUpdateResultCheckStyle deleteCheckStyle;
+
+	private Class<? extends Expectation> insertExpectation;
+	private Class<? extends Expectation> updateExpectation;
+	private Class<? extends Expectation> deleteExpectation;
 
 	@Override
 	public void addProperty(Property property) {
@@ -133,6 +140,7 @@ public class Join implements AttributeContainer, Serializable {
 		this.customSQLInsert = customSQLInsert;
 		this.customInsertCallable = callable;
 		this.insertCheckStyle = checkStyle;
+		this.insertExpectation = expectationClass( checkStyle );
 	}
 
 	public String getCustomSQLInsert() {
@@ -143,16 +151,8 @@ public class Join implements AttributeContainer, Serializable {
 		return customInsertCallable;
 	}
 
-	public void setInsertCheckStyle(ExecuteUpdateResultCheckStyle insertCheckStyle) {
-		this.insertCheckStyle = insertCheckStyle;
-	}
-
-	public ExecuteUpdateResultCheckStyle getInsertCheckStyle() {
-		return insertCheckStyle;
-	}
-
 	/**
-	 * @deprecated use {@link #getInsertCheckStyle()}
+	 * @deprecated use {@link #getInsertExpectation()}
 	 */
 	@Deprecated(since = "6.5", forRemoval = true)
 	public ExecuteUpdateResultCheckStyle getCustomSQLInsertCheckStyle() {
@@ -163,6 +163,7 @@ public class Join implements AttributeContainer, Serializable {
 		this.customSQLUpdate = customSQLUpdate;
 		this.customUpdateCallable = callable;
 		this.updateCheckStyle = checkStyle;
+		this.updateExpectation = expectationClass( checkStyle );
 	}
 
 	public String getCustomSQLUpdate() {
@@ -173,16 +174,8 @@ public class Join implements AttributeContainer, Serializable {
 		return customUpdateCallable;
 	}
 
-	public void setUpdateCheckStyle(ExecuteUpdateResultCheckStyle updateCheckStyle) {
-		this.updateCheckStyle = updateCheckStyle;
-	}
-
-	public ExecuteUpdateResultCheckStyle getUpdateCheckStyle() {
-		return updateCheckStyle;
-	}
-
 	/**
-	 * @deprecated use {@link #getUpdateCheckStyle()}
+	 * @deprecated use {@link #getUpdateExpectation()}
 	 */
 	@Deprecated(since = "6.5", forRemoval = true)
 	public ExecuteUpdateResultCheckStyle getCustomSQLUpdateCheckStyle() {
@@ -193,6 +186,7 @@ public class Join implements AttributeContainer, Serializable {
 		this.customSQLDelete = customSQLDelete;
 		this.customDeleteCallable = callable;
 		this.deleteCheckStyle = checkStyle;
+		this.deleteExpectation = expectationClass( checkStyle );
 	}
 
 	public String getCustomSQLDelete() {
@@ -203,16 +197,8 @@ public class Join implements AttributeContainer, Serializable {
 		return customDeleteCallable;
 	}
 
-	public void setDeleteCheckStyle(ExecuteUpdateResultCheckStyle deleteCheckStyle) {
-		this.deleteCheckStyle = deleteCheckStyle;
-	}
-
-	public ExecuteUpdateResultCheckStyle getDeleteCheckStyle() {
-		return deleteCheckStyle;
-	}
-
 	/**
-	 * @deprecated use {@link #getDeleteCheckStyle()}
+	 * @deprecated use {@link #getDeleteExpectation()}
 	 */
 	@Deprecated(since = "6.5", forRemoval = true)
 	public ExecuteUpdateResultCheckStyle getCustomSQLDeleteCheckStyle() {
@@ -243,7 +229,32 @@ public class Join implements AttributeContainer, Serializable {
 	public boolean isOptional() {
 		return optional;
 	}
+
 	public void setOptional(boolean nullable) {
 		this.optional = nullable;
+	}
+
+	public Class<? extends Expectation> getInsertExpectation() {
+		return insertExpectation;
+	}
+
+	public void setInsertExpectation(Class<? extends Expectation> insertExpectation) {
+		this.insertExpectation = insertExpectation;
+	}
+
+	public Class<? extends Expectation> getUpdateExpectation() {
+		return updateExpectation;
+	}
+
+	public void setUpdateExpectation(Class<? extends Expectation> updateExpectation) {
+		this.updateExpectation = updateExpectation;
+	}
+
+	public Class<? extends Expectation> getDeleteExpectation() {
+		return deleteExpectation;
+	}
+
+	public void setDeleteExpectation(Class<? extends Expectation> deleteExpectation) {
+		this.deleteExpectation = deleteExpectation;
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/persister/entity/SingleTableEntityPersister.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/entity/SingleTableEntityPersister.java
@@ -18,7 +18,6 @@ import org.hibernate.Remove;
 import org.hibernate.cache.spi.access.EntityDataAccess;
 import org.hibernate.cache.spi.access.NaturalIdDataAccess;
 import org.hibernate.dialect.Dialect;
-import org.hibernate.engine.spi.ExecuteUpdateResultCheckStyle;
 import org.hibernate.internal.DynamicFilterAliasGenerator;
 import org.hibernate.internal.FilterAliasGenerator;
 import org.hibernate.internal.util.collections.ArrayHelper;
@@ -49,7 +48,7 @@ import static org.hibernate.internal.util.collections.ArrayHelper.toBooleanArray
 import static org.hibernate.internal.util.collections.ArrayHelper.toIntArray;
 import static org.hibernate.internal.util.collections.ArrayHelper.toStringArray;
 import static org.hibernate.internal.util.collections.CollectionHelper.toSmallMap;
-import static org.hibernate.jdbc.Expectations.appropriateExpectation;
+import static org.hibernate.jdbc.Expectations.createExpectation;
 import static org.hibernate.persister.entity.DiscriminatorHelper.NOT_NULL_DISCRIMINATOR;
 import static org.hibernate.persister.entity.DiscriminatorHelper.NULL_DISCRIMINATOR;
 import static org.hibernate.sql.model.ast.builder.TableMutationBuilder.NULL;
@@ -170,28 +169,16 @@ public class SingleTableEntityPersister extends AbstractEntityPersister {
 		deleteExpectations = new Expectation[joinSpan];
 
 		customSQLInsert[0] = persistentClass.getCustomSQLInsert();
-		insertCallable[0] = customSQLInsert[0] != null && persistentClass.isCustomInsertCallable();
-		insertExpectations[0] = appropriateExpectation(
-				persistentClass.getInsertCheckStyle() == null
-						? ExecuteUpdateResultCheckStyle.determineDefault( customSQLInsert[0], insertCallable[0] )
-						: persistentClass.getInsertCheckStyle()
-		);
+		insertCallable[0] = persistentClass.isCustomInsertCallable();
+		insertExpectations[0] = createExpectation( persistentClass.getInsertExpectation(), insertCallable[0] );
 
 		customSQLUpdate[0] = persistentClass.getCustomSQLUpdate();
-		updateCallable[0] = customSQLUpdate[0] != null && persistentClass.isCustomUpdateCallable();
-		updateExpectations[0] = appropriateExpectation(
-				persistentClass.getUpdateCheckStyle() == null
-						? ExecuteUpdateResultCheckStyle.determineDefault( customSQLUpdate[0], updateCallable[0] )
-						: persistentClass.getUpdateCheckStyle()
-		);
+		updateCallable[0] = persistentClass.isCustomUpdateCallable();
+		updateExpectations[0] = createExpectation( persistentClass.getUpdateExpectation(), updateCallable[0] );
 
 		customSQLDelete[0] = persistentClass.getCustomSQLDelete();
-		deleteCallable[0] = customSQLDelete[0] != null && persistentClass.isCustomDeleteCallable();
-		deleteExpectations[0] = appropriateExpectation(
-				persistentClass.getDeleteCheckStyle() == null
-						? ExecuteUpdateResultCheckStyle.determineDefault( customSQLDelete[0], deleteCallable[0] )
-						: persistentClass.getDeleteCheckStyle()
-		);
+		deleteCallable[0] = persistentClass.isCustomDeleteCallable();
+		deleteExpectations[0] = createExpectation( persistentClass.getDeleteExpectation(), deleteCallable[0] );
 
 		// JOINS
 
@@ -207,28 +194,16 @@ public class SingleTableEntityPersister extends AbstractEntityPersister {
 			cascadeDeleteEnabled[j] = join.getKey().isCascadeDeleteEnabled() && dialect.supportsCascadeDelete();
 
 			customSQLInsert[j] = join.getCustomSQLInsert();
-			insertCallable[j] = customSQLInsert[j] != null && join.isCustomInsertCallable();
-			insertExpectations[j] = appropriateExpectation(
-					join.getInsertCheckStyle() == null
-							? ExecuteUpdateResultCheckStyle.determineDefault( customSQLInsert[j], insertCallable[j] )
-							: join.getInsertCheckStyle()
-			);
+			insertCallable[j] = join.isCustomInsertCallable();
+			insertExpectations[j] = createExpectation( join.getInsertExpectation(), insertCallable[j] );
 
 			customSQLUpdate[j] = join.getCustomSQLUpdate();
-			updateCallable[j] = customSQLUpdate[j] != null && join.isCustomUpdateCallable();
-			updateExpectations[j] = appropriateExpectation(
-					join.getUpdateCheckStyle() == null
-							? ExecuteUpdateResultCheckStyle.determineDefault( customSQLUpdate[j], updateCallable[j] )
-							: join.getUpdateCheckStyle()
-			);
+			updateCallable[j] = join.isCustomUpdateCallable();
+			updateExpectations[j] = createExpectation( join.getUpdateExpectation(), updateCallable[j] );
 
 			customSQLDelete[j] = join.getCustomSQLDelete();
-			deleteCallable[j] = customSQLDelete[j] != null && join.isCustomDeleteCallable();
-			deleteExpectations[j] = appropriateExpectation(
-					join.getDeleteCheckStyle() == null
-							? ExecuteUpdateResultCheckStyle.determineDefault( customSQLDelete[j], deleteCallable[j] )
-							: join.getDeleteCheckStyle()
-			);
+			deleteCallable[j] = join.isCustomDeleteCallable();
+			deleteExpectations[j] = createExpectation( join.getDeleteExpectation(), deleteCallable[j] );
 
 			keyColumnNames[j] = new String[join.getKey().getColumnSpan()];
 

--- a/hibernate-core/src/main/java/org/hibernate/persister/entity/UnionSubclassEntityPersister.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/entity/UnionSubclassEntityPersister.java
@@ -30,7 +30,6 @@ import org.hibernate.boot.Metadata;
 import org.hibernate.cache.spi.access.EntityDataAccess;
 import org.hibernate.cache.spi.access.NaturalIdDataAccess;
 import org.hibernate.dialect.Dialect;
-import org.hibernate.engine.spi.ExecuteUpdateResultCheckStyle;
 import org.hibernate.id.IdentityGenerator;
 import org.hibernate.internal.FilterAliasGenerator;
 import org.hibernate.internal.StaticFilterAliasGenerator;
@@ -65,7 +64,7 @@ import org.hibernate.type.StandardBasicTypes;
 
 import static org.hibernate.internal.util.collections.ArrayHelper.to2DStringArray;
 import static org.hibernate.internal.util.collections.ArrayHelper.toStringArray;
-import static org.hibernate.jdbc.Expectations.appropriateExpectation;
+import static org.hibernate.jdbc.Expectations.createExpectation;
 
 /**
  * An {@link EntityPersister} implementing the
@@ -125,41 +124,20 @@ public class UnionSubclassEntityPersister extends AbstractEntityPersister {
 		subclassTableNames = new String[]{tableName};
 		//Custom SQL
 
-		String sql;
-		boolean callable;
-		ExecuteUpdateResultCheckStyle checkStyle;
-		sql = persistentClass.getCustomSQLInsert();
-		callable = sql != null && persistentClass.isCustomInsertCallable();
-		checkStyle = sql == null
-				? ExecuteUpdateResultCheckStyle.COUNT
-				: persistentClass.getInsertCheckStyle() == null
-				? ExecuteUpdateResultCheckStyle.determineDefault( sql, callable )
-				: persistentClass.getInsertCheckStyle();
-		customSQLInsert = new String[] {sql};
-		insertCallable = new boolean[] {callable};
-		insertExpectations = new Expectation[] { appropriateExpectation( checkStyle ) };
+		customSQLInsert = new String[] { persistentClass.getCustomSQLInsert() };
+		insertCallable = new boolean[] { persistentClass.isCustomInsertCallable() };
+		insertExpectations = new Expectation[] { createExpectation( persistentClass.getInsertExpectation(),
+				persistentClass.isCustomInsertCallable() ) };
 
-		sql = persistentClass.getCustomSQLUpdate();
-		callable = sql != null && persistentClass.isCustomUpdateCallable();
-		checkStyle = sql == null
-				? ExecuteUpdateResultCheckStyle.COUNT
-				: persistentClass.getUpdateCheckStyle() == null
-				? ExecuteUpdateResultCheckStyle.determineDefault( sql, callable )
-				: persistentClass.getUpdateCheckStyle();
-		customSQLUpdate = new String[] {sql};
-		updateCallable = new boolean[] {callable};
-		updateExpectations = new Expectation[] { appropriateExpectation( checkStyle ) };
+		customSQLUpdate = new String[] { persistentClass.getCustomSQLUpdate() };
+		updateCallable = new boolean[] { persistentClass.isCustomUpdateCallable() };
+		updateExpectations = new Expectation[] { createExpectation( persistentClass.getUpdateExpectation(),
+				persistentClass.isCustomUpdateCallable() ) };
 
-		sql = persistentClass.getCustomSQLDelete();
-		callable = sql != null && persistentClass.isCustomDeleteCallable();
-		checkStyle = sql == null
-				? ExecuteUpdateResultCheckStyle.COUNT
-				: persistentClass.getDeleteCheckStyle() == null
-				? ExecuteUpdateResultCheckStyle.determineDefault( sql, callable )
-				: persistentClass.getDeleteCheckStyle();
-		customSQLDelete = new String[] {sql};
-		deleteCallable = new boolean[] {callable};
-		deleteExpectations = new Expectation[] { appropriateExpectation( checkStyle ) };
+		customSQLDelete = new String[] { persistentClass.getCustomSQLDelete() };
+		deleteCallable = new boolean[] { persistentClass.isCustomDeleteCallable() };
+		deleteExpectations = new Expectation[] { createExpectation( persistentClass.getDeleteExpectation(),
+				persistentClass.isCustomDeleteCallable() ) };
 
 		discriminatorValue = persistentClass.getSubclassId();
 		discriminatorSQLValue = String.valueOf( persistentClass.getSubclassId() );

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/hql/size/WhereClauseOrderBySizeTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/hql/size/WhereClauseOrderBySizeTest.java
@@ -28,6 +28,7 @@ import org.hibernate.annotations.SQLRestriction;
 import org.hibernate.annotations.Where;
 import org.hibernate.dialect.H2Dialect;
 import org.hibernate.dialect.PostgreSQLDialect;
+import org.hibernate.jdbc.Expectation;
 import org.hibernate.orm.test.jpa.BaseEntityManagerFunctionalTestCase;
 
 import org.hibernate.testing.RequiresDialect;
@@ -141,7 +142,8 @@ public class WhereClauseOrderBySizeTest extends BaseEntityManagerFunctionalTestC
 	}
 
 	@Entity(name = "Book")
-	@SQLDelete(sql = "UPDATE Book SET deleted = true WHERE id = ?", check = ResultCheckStyle.COUNT)
+	@SQLDelete(sql = "UPDATE Book SET deleted = true WHERE id = ?",
+			verify = Expectation.RowCount.class)
 	@SQLRestriction("deleted = false")
 	public static class Book {
 		@Id

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/attributebinder/typebinder/NoResultCheck.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/attributebinder/typebinder/NoResultCheck.java
@@ -3,6 +3,7 @@ package org.hibernate.orm.test.mapping.attributebinder.typebinder;
 import org.hibernate.annotations.TypeBinderType;
 import org.hibernate.binder.TypeBinder;
 import org.hibernate.boot.spi.MetadataBuildingContext;
+import org.hibernate.jdbc.Expectation;
 import org.hibernate.mapping.Component;
 import org.hibernate.mapping.PersistentClass;
 
@@ -11,7 +12,6 @@ import java.lang.annotation.Target;
 
 import static java.lang.annotation.ElementType.TYPE;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
-import static org.hibernate.engine.spi.ExecuteUpdateResultCheckStyle.NONE;
 
 @TypeBinderType(binder = NoResultCheck.Binder.class)
 @Retention(RUNTIME)
@@ -20,9 +20,9 @@ public @interface NoResultCheck {
 	class Binder implements TypeBinder<NoResultCheck> {
 		@Override
 		public void bind(NoResultCheck annotation, MetadataBuildingContext buildingContext, PersistentClass persistentClass) {
-			persistentClass.setInsertCheckStyle(NONE);
-			persistentClass.setUpdateCheckStyle(NONE);
-			persistentClass.setDeleteCheckStyle(NONE);
+			persistentClass.setInsertExpectation(Expectation.None.class);
+			persistentClass.setUpdateExpectation(Expectation.None.class);
+			persistentClass.setDeleteExpectation(Expectation.None.class);
 		}
 
 		@Override

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/sql/CustomSQLTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/sql/CustomSQLTest.java
@@ -26,6 +26,7 @@ import org.hibernate.annotations.SQLSelect;
 import org.hibernate.annotations.SQLUpdate;
 import org.hibernate.dialect.H2Dialect;
 import org.hibernate.dialect.PostgreSQLDialect;
+import org.hibernate.jdbc.Expectation;
 import org.hibernate.metamodel.CollectionClassification;
 import org.hibernate.orm.test.jpa.BaseEntityManagerFunctionalTestCase;
 
@@ -109,7 +110,7 @@ public class CustomSQLTest extends BaseEntityManagerFunctionalTestCase {
 	@Entity(name = "Person")
 	@SQLInsert(
 		sql = "INSERT INTO person (name, id, valid) VALUES (?, ?, true) ",
-		check = ResultCheckStyle.COUNT
+		verify = Expectation.RowCount.class
 	)
 	@SQLUpdate(
 		sql = "UPDATE person SET name = ? where id = ? "

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/write/CustomSqlWithExpectationTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/write/CustomSqlWithExpectationTests.java
@@ -1,0 +1,107 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html.
+ */
+package org.hibernate.orm.test.write;
+
+import jakarta.persistence.Basic;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import org.hibernate.HibernateException;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.SQLInsert;
+import org.hibernate.annotations.SQLUpdate;
+import org.hibernate.jdbc.Expectation;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.junit.jupiter.api.Test;
+
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * @author Steve Ebersole
+ */
+@DomainModel( annotatedClasses = CustomSqlWithExpectationTests.CustomEntity.class )
+@SessionFactory
+public class CustomSqlWithExpectationTests {
+	@Test
+	public void testBasicOperations(SessionFactoryScope scope) {
+
+		assertEquals(0,count);
+
+		// insert
+		scope.inTransaction( (session) -> {
+			session.persist( new CustomEntity( 1, "csutmo" ) );
+		} );
+
+		assertEquals(1,count);
+
+		// update
+		scope.inTransaction( (session) -> {
+			final CustomEntity customEntity = session.get( CustomEntity.class, 1 );
+			customEntity.setName( "custom" );
+		} );
+
+		assertEquals(2,count);
+
+		// delete
+		scope.inTransaction( (session) -> {
+			final CustomEntity customEntity = session.get( CustomEntity.class, 1 );
+			assertThat( customEntity.getName() ).isEqualTo( "custom" );
+			session.remove( customEntity );
+		} );
+
+		assertEquals(3,count);
+	}
+
+	static int count = 0;
+
+	public static class Custom extends Expectation.RowCount {
+		@Override
+		public int prepare(PreparedStatement statement) throws SQLException, HibernateException {
+			count ++;
+			return super.prepare(statement);
+		}
+	}
+
+	@Entity( name = "CustomEntity" )
+	@Table( name = "custom_entity" )
+	@SQLInsert( sql = "insert into custom_entity (name, id) values (?, ?)", verify = Custom.class )
+	@SQLDelete( sql = "delete from custom_entity where id = ?", verify = Custom.class )
+	@SQLUpdate( sql = "update custom_entity set name = ? where id = ? ", verify = Custom.class )
+	public static class CustomEntity {
+	    @Id
+	    private Integer id;
+	    @Basic
+		private String name;
+
+		CustomEntity() {
+			// for use by Hibernate
+		}
+
+		public CustomEntity(Integer id, String name) {
+			this.id = id;
+			this.name = name;
+		}
+
+		public Integer getId() {
+			return id;
+		}
+
+		public String getName() {
+			return name;
+		}
+
+		public void setName(String name) {
+			this.name = name;
+		}
+	}
+}


### PR DESCRIPTION
Use of class objects is simpler, more elegant, and more flexible.

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-15587
<!-- Hibernate GitHub Bot issue links end -->