### PR TITLE
Fix HHH-17862: TemporaryTable identity column sqlTypeName error

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/dialect/temptable/TemporaryTable.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/temptable/TemporaryTable.java
@@ -319,15 +319,17 @@ public class TemporaryTable implements Exportable, Contributable {
 						int idIdx = 0;
 						for ( Column column : entityBinding.getKey().getColumns() ) {
 							final JdbcMapping jdbcMapping = identifierMapping.getJdbcMapping( idIdx++ );
+							String sqlTypeName = "";
+							if ( dialect.getIdentityColumnSupport().hasDataTypeInIdentityColumn() ) {
+								sqlTypeName = column.getSqlType( runtimeModelCreationContext.getMetadata() ) + " ";
+							}
+							sqlTypeName = sqlTypeName + dialect.getIdentityColumnSupport().getIdentityColumnString( column.getSqlTypeCode( runtimeModelCreationContext.getMetadata() ) );
 							columns.add(
 									new TemporaryTableColumn(
 											temporaryTable,
 											ENTITY_TABLE_IDENTITY_COLUMN,
 											jdbcMapping,
-											column.getSqlType(
-													runtimeModelCreationContext.getMetadata()
-											) + " " +
-											dialect.getIdentityColumnSupport().getIdentityColumnString( column.getSqlTypeCode( runtimeModelCreationContext.getMetadata() ) ),
+											sqlTypeName,
 											column.getColumnSize(
 													dialect,
 													runtimeModelCreationContext.getMetadata()


### PR DESCRIPTION
Generated SQL in org.hibernate.orm.test.hql.BulkManipulationTest#testInsertAcrossMappedJoin test
```
create temp table HTE_Joiner(
HTE_IDENTITY int8 serial8 not null,
 id int8,
 joinedName varchar(255),
 name varchar(255),
 primary key (HTE_IDENTITY))
 with no log
```
fixed to 

```
create temp table HTE_Joiner(
HTE_IDENTITY serial8 not null,
 id int8,
 joinedName varchar(255),
 name varchar(255),
 primary key (HTE_IDENTITY))
 with no log
```