### PR TITLE
Enable build scans and build cache in Jenkinsfile and list build scans in a GitHub check

### DIFF
--- a/.github/hibernate-github-bot.yml
+++ b/.github/hibernate-github-bot.yml
@@ -37,3 +37,6 @@ jira:
     - "release/"
     - "rules/"
     - "shared/"
+develocity:
+  buildScan:
+    addCheck: true

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -124,6 +124,10 @@ stage('Build') {
 						state[buildEnv.tag]['additionalOptions'] = state[buildEnv.tag]['additionalOptions'] +
 								" -Ptest.jdk.launcher.args='${buildEnv.testJdkLauncherArgs}'"
 					}
+					if ( buildEnv.node ) {
+						state[buildEnv.tag]['additionalOptions'] = state[buildEnv.tag]['additionalOptions'] +
+								" -Pci.node=${buildEnv.node}"
+					}
 					state[buildEnv.tag]['containerName'] = null;
 					stage('Checkout') {
 						checkout scm

--- a/gradle/gradle-enterprise.gradle
+++ b/gradle/gradle-enterprise.gradle
@@ -50,6 +50,11 @@ gradleEnterprise {
             tag "JOB ${System.getenv('JOB_NAME')}"
         }
         tag "JDK ${JavaVersion.current().toString()}"
-        value 'database', rootProject.hasProperty( 'db' ) ? rootProject.properties.db : 'h2'
+        String db = rootProject.hasProperty( 'db' ) ? rootProject.properties.db : 'h2'
+        tag db
+        value 'database', db
+        if ( rootProject.hasProperty( 'ci.node' ) ) {
+            tag rootProject.property('ci.node')
+        }
     }
 }

--- a/gradle/gradle-enterprise.gradle
+++ b/gradle/gradle-enterprise.gradle
@@ -46,9 +46,6 @@ gradleEnterprise {
 
         uploadInBackground = !settings.ext.isCiEnvironment
 
-        if ( settings.ext.isCiEnvironment ) {
-            tag "JOB ${System.getenv('JOB_NAME')}"
-        }
         tag "JDK ${JavaVersion.current().toString()}"
         String db = rootProject.hasProperty( 'db' ) ? rootProject.properties.db : 'h2'
         tag db


### PR DESCRIPTION
Oddly, it seems the build cache and, more annoyingly, build scans, were not enabled in the Jenkinsfile. So this fixes that. Note that for pull requests, we use a different access key which is not able to push to the build cache -- for security reasons.

Also, this enables a new feature in hibernate-github-bot that basically adds a GitHub check next to the existing ones for GitHub Actions or Jenkins, and inside that check is a list of build scans, along with some context (tags, ...).

Note this works best when build scans are tagged properly, e.g. you add a `postgresql` tag to CI runs against postgresql. So I adjusted GitHub Actions workflows and the Jenkinsfile accordingly.

![image](https://github.com/hibernate/hibernate-github-bot/assets/412878/8102fd5b-8015-4b2e-abd5-ae46907a542b)

![image](https://github.com/hibernate/hibernate-github-bot/assets/412878/670c1523-fb2f-467d-ab82-24ae3439f073)

See https://github.com/hibernate/hibernate-github-bot/pull/227