### PR TITLE
Add "Git commit id" to build scans generated on Jenkins

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -130,7 +130,10 @@ stage('Build') {
 					}
 					state[buildEnv.tag]['containerName'] = null;
 					stage('Checkout') {
-						checkout scm
+						// https://stackoverflow.com/a/45845221
+						def scmVars = checkout(scm)
+						state[buildEnv.tag]['additionalOptions'] = state[buildEnv.tag]['additionalOptions'] +
+								" -Pci.git.commit=${scmVars.GIT_COMMIT}"
 					}
 					try {
 						stage('Start database') {

--- a/gradle/gradle-enterprise.gradle
+++ b/gradle/gradle-enterprise.gradle
@@ -53,5 +53,9 @@ gradleEnterprise {
         if ( rootProject.hasProperty( 'ci.node' ) ) {
             tag rootProject.property('ci.node')
         }
+        if ( rootProject.hasProperty( 'ci.git.commit' ) ) {
+            // Workaroud use on Jenkins for this custom value not being added automatically by Gradle
+            value 'Git commit id', rootProject.property('ci.git.commit')
+        }
     }
 }


### PR DESCRIPTION
Apparently that's not being done automatically for Gradle, and we need this info in order to have the Hibernate GitHub Bot list all build scans.

Not sure this will work, as I need to run it on CI. Let's see how this plays out and merge if the Devlocity build scans listed on this PR include the Jenkins ones.