### PR TITLE
HHH-17705 Load default bytecode provider using the correct ClassLoader

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/bytecode/internal/BytecodeProviderInitiator.java
+++ b/hibernate-core/src/main/java/org/hibernate/bytecode/internal/BytecodeProviderInitiator.java
@@ -61,7 +61,11 @@ public final class BytecodeProviderInitiator implements StandardServiceInitiator
 
 	@Internal
 	public static BytecodeProvider buildDefaultBytecodeProvider() {
-		return getBytecodeProvider( ServiceLoader.load( BytecodeProvider.class ) );
+		// Use BytecodeProvider's ClassLoader to ensure we can find the service
+		return getBytecodeProvider( ServiceLoader.load(
+				BytecodeProvider.class,
+				BytecodeProvider.class.getClassLoader()
+		) );
 	}
 
 	@Internal


### PR DESCRIPTION
(cherry picked from commit 4226cf2c02e869a0d9f92d7a066e33241a10564f)

Issue: https://hibernate.atlassian.net/browse/HHH-17705

JBEAP issue: https://issues.redhat.com/browse/JBEAP-26819

This backports the fix to 6.2 branch for EAP 8.

Upstream PR: https://github.com/hibernate/hibernate-orm/pull/7785 

FYI @beikov 