### PR TITLE
HHH-15752 Add Boolean support to oracle dialect

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/dialect/BooleanDecoder.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/BooleanDecoder.java
@@ -66,6 +66,8 @@ public final class BooleanDecoder {
 				return "decode(?1,1,'Y',0,'N',null)";
 			case TF_BOOLEAN:
 				return "decode(?1,'T','Y','F','N',null)";
+			case BOOLEAN:
+				return "decode(?1,true,'Y',false,'N',null)";
 			case INTEGER:
 			case LONG:
 				return "decode(abs(sign(?1)),1,'Y',0,'N',null)";
@@ -81,6 +83,8 @@ public final class BooleanDecoder {
 				return "decode(?1,1,'T',0,'F',null)";
 			case YN_BOOLEAN:
 				return "decode(?1,'Y','T','N','F',null)";
+			case BOOLEAN:
+				return "decode(?1,true,'T',false,'F',null)";
 			case INTEGER:
 			case LONG:
 				return "decode(abs(sign(?1)),1,'T',0,'F',null)";

--- a/hibernate-core/src/main/java/org/hibernate/dialect/OracleDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/OracleDialect.java
@@ -248,7 +248,7 @@ public class OracleDialect extends Dialect {
 
 	@Override
 	public int getPreferredSqlTypeCodeForBoolean() {
-		return Types.BIT;
+		return getVersion().isSameOrAfter( 23 ) ? super.getPreferredSqlTypeCodeForBoolean() : Types.BIT;
 	}
 
 	@Override
@@ -408,7 +408,6 @@ public class OracleDialect extends Dialect {
 	}
 
 	/**
-	 * Oracle doesn't have any sort of {@link Types#BOOLEAN}
 	 * type or {@link Types#TIME} type, and its default behavior
 	 * for casting dates and timestamps to and from strings is just awful.
 	 */
@@ -436,6 +435,11 @@ public class OracleDialect extends Dialect {
 				}
 				break;
 			case BOOLEAN:
+				result = BooleanDecoder.toBoolean(from);
+				if ( result != null ) {
+					return result;
+				}
+				break;
 			case TF_BOOLEAN:
 				result = BooleanDecoder.toTrueFalseBoolean( from );
 				if ( result != null ) {
@@ -444,6 +448,7 @@ public class OracleDialect extends Dialect {
 				break;
 			case STRING:
 				switch ( from ) {
+					case BOOLEAN:
 					case INTEGER_BOOLEAN:
 					case TF_BOOLEAN:
 					case YN_BOOLEAN:
@@ -683,9 +688,12 @@ public class OracleDialect extends Dialect {
 	protected String columnType(int sqlTypeCode) {
 		switch ( sqlTypeCode ) {
 			case BOOLEAN:
-				// still, after all these years...
-				return "number(1,0)";
-
+				if ( getVersion().isSameOrAfter( DatabaseVersion.make(23) ) ) {
+						return super.columnType( sqlTypeCode );
+				}
+				else {
+						return "number(1,0)";
+				}
 			case TINYINT:
 				return "number(3,0)";
 			case SMALLINT:
@@ -871,8 +879,10 @@ public class OracleDialect extends Dialect {
 	@Override
 	public void contributeTypes(TypeContributions typeContributions, ServiceRegistry serviceRegistry) {
 		super.contributeTypes( typeContributions, serviceRegistry );
-
-		typeContributions.contributeJdbcType( OracleBooleanJdbcType.INSTANCE );
+		if ( getVersion().isSame( 21 ) || getVersion().isBefore( 21 )) {
+			// starting 23c we support Boolean type natively
+			typeContributions.contributeJdbcType(OracleBooleanJdbcType.INSTANCE);
+		}
 		typeContributions.contributeJdbcType( OracleXmlJdbcType.INSTANCE );
 		if ( OracleJdbcHelper.isUsable( serviceRegistry ) ) {
 			typeContributions.contributeJdbcType( OracleJdbcHelper.getStructJdbcType( serviceRegistry ) );


### PR DESCRIPTION
Hi,

This pull request is about adding Boolean support to Oracle dialect. 
Starting to version 23 the new BOOLEAN type will be used for Boolean entity fields.

Local tests have been run successfully. 

