### PR TITLE
Require approval for Jenkins builds on PRs from external contributors + Safely publish build scans even for pull requests

### DIFF
--- a/.github/workflows/atlas.yml
+++ b/.github/workflows/atlas.yml
@@ -10,7 +10,9 @@ on:
   push:
     branches:
       - 'main'
-  pull_request:
+  # WARNING: Using pull_request_target to access secrets, but we check out the PR head commit.
+  # See checkout action for details.
+  pull_request_target:
     branches:
       - 'main'
 
@@ -23,7 +25,7 @@ concurrency:
   group: "workflow = ${{ github.workflow }}, ref = ${{ github.event.ref }}, pr = ${{ github.event.pull_request.id }}"
   # Cancel previous builds in the same concurrency group even if they are in process
   # for pull requests or pushes to forks (not the upstream repository).
-  cancel-in-progress: ${{ github.event_name == 'pull_request' || github.repository != 'hibernate/hibernate-orm' }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request_target' || github.repository != 'hibernate/hibernate-orm' }}
 
 jobs:
   build:
@@ -41,8 +43,23 @@ jobs:
           - rdbms: oracle_db21c
           - rdbms: oracle_db23c
     steps:
-      - uses: actions/checkout@v4
+      - name: Check out commit already pushed to branch
+        if: "! github.event.pull_request.number"
+        uses: actions/checkout@v4
         with:
+          persist-credentials: false
+      - name: Check out PR head
+        uses: actions/checkout@v4
+        if: github.event.pull_request.number
+        with:
+          # WARNING: This is potentially dangerous since we're checking out unreviewed code,
+          # and since we're using the pull_request_target event we can use secrets.
+          # Thus, we must be extra careful to never expose secrets to steps that execute this code,
+          # and to strictly limit our of secrets to those that only pose minor security threats.
+          # This means in particular we won't expose Develocity credentials to the main gradle executions,
+          # but instead will execute gradle a second time just to push build scans to Develocity;
+          # see below.
+          ref: "refs/pull/${{ github.event.pull_request.number }}/head"
           persist-credentials: false
       - name: Reclaim Disk Space
         run: .github/ci-prerequisites.sh
@@ -74,8 +91,19 @@ jobs:
         env:
           RDBMS: ${{ matrix.rdbms }}
           RUNID: ${{ github.run_number }}
+          # WARNING: exposes secrets, so must only be passed to a step that doesn't run unapproved code.
+          # WARNING: As this runs on untrusted nodes, we use the same access key as for PRs:
+          #          it has limited access, essentially it can only push build scans.
+          GRADLE_ENTERPRISE_ACCESS_KEY: "${{ github.event_name == 'push' && secrets.GRADLE_ENTERPRISE_ACCESS_KEY_PR || '' }}"
         run: ./ci/build-github.sh
         shell: bash
+      - name: Publish Develocity build scan for previous build
+        if: "${{ !cancelled() && github.event_name == 'pull_request_target' && github.repository == 'hibernate/hibernate-orm' }}"
+        run: |
+          ./gradlew buildScanPublishPrevious
+        env:
+          # WARNING: exposes secrets, so must only be passed to a step that doesn't run unapproved code.
+          GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY_PR }}
       - name: Upload test reports (if Gradle failed)
         uses: actions/upload-artifact@v4
         if: failure()

--- a/.github/workflows/contributor-build.yml
+++ b/.github/workflows/contributor-build.yml
@@ -84,7 +84,7 @@ jobs:
           RDBMS: ${{ matrix.rdbms }}
           # Don't populate Develocity cache in pull requests as that's potentially dangerous
           POPULATE_REMOTE_GRADLE_CACHE: "${{ github.event_name == 'push' }}"
-          GRADLE_ENTERPRISE_ACCESS_KEY: "${{ secrets.DEVELOCITY_ACCESS_TOKEN }}"
+          GRADLE_ENTERPRISE_ACCESS_KEY: "${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}"
         run: ./ci/build-github.sh
         shell: bash
       - name: Upload test reports (if Gradle failed)

--- a/.github/workflows/contributor-build.yml
+++ b/.github/workflows/contributor-build.yml
@@ -10,10 +10,12 @@ on:
   push:
     branches:
       - 'main'
-  pull_request:
+  # WARNING: Using pull_request_target to access secrets, but we check out the PR head commit.
+  # See checkout action for details.
+  pull_request_target:
     branches:
       - 'main'
-      
+
 permissions: {} # none
 
 # See https://github.com/hibernate/hibernate-orm/pull/4615 for a description of the behavior we're getting.
@@ -23,7 +25,7 @@ concurrency:
   group: "workflow = ${{ github.workflow }}, ref = ${{ github.event.ref }}, pr = ${{ github.event.pull_request.id }}"
   # Cancel previous builds in the same concurrency group even if they are in process
   # for pull requests or pushes to forks (not the upstream repository).
-  cancel-in-progress: ${{ github.event_name == 'pull_request' || github.repository != 'hibernate/hibernate-orm' }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request_target' || github.repository != 'hibernate/hibernate-orm' }}
 
 jobs:
   build:
@@ -51,8 +53,23 @@ jobs:
 # Running with HANA requires at least 8GB memory just for the database, which we don't have on GH Actions runners
 #          - rdbms: hana
     steps:
-      - uses: actions/checkout@v4
+      - name: Check out commit already pushed to branch
+        if: "! github.event.pull_request.number"
+        uses: actions/checkout@v4
         with:
+          persist-credentials: false
+      - name: Check out PR head
+        uses: actions/checkout@v4
+        if: github.event.pull_request.number
+        with:
+          # WARNING: This is potentially dangerous since we're checking out unreviewed code,
+          # and since we're using the pull_request_target event we can use secrets.
+          # Thus, we must be extra careful to never expose secrets to steps that execute this code,
+          # and to strictly limit our of secrets to those that only pose minor security threats.
+          # This means in particular we won't expose Develocity credentials to the main gradle executions,
+          # but instead will execute gradle a second time just to push build scans to Develocity;
+          # see below.
+          ref: "refs/pull/${{ github.event.pull_request.number }}/head"
           persist-credentials: false
       - name: Reclaim Disk Space
         run: .github/ci-prerequisites.sh
@@ -84,9 +101,17 @@ jobs:
           RDBMS: ${{ matrix.rdbms }}
           # Don't populate Develocity cache in pull requests as that's potentially dangerous
           POPULATE_REMOTE_GRADLE_CACHE: "${{ github.event_name == 'push' }}"
-          GRADLE_ENTERPRISE_ACCESS_KEY: "${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}"
+          # WARNING: exposes secrets, so must only be passed to a step that doesn't run unapproved code.
+          GRADLE_ENTERPRISE_ACCESS_KEY: "${{ github.event_name == 'push' && secrets.GRADLE_ENTERPRISE_ACCESS_KEY || '' }}"
         run: ./ci/build-github.sh
         shell: bash
+      - name: Publish Develocity build scan for previous build (pull request)
+        if: "${{ !cancelled() && github.event_name == 'pull_request_target' && github.repository == 'hibernate/hibernate-orm' }}"
+        run: |
+          ./gradlew buildScanPublishPrevious
+        env:
+          # WARNING: exposes secrets, so must only be passed to a step that doesn't run unapproved code.
+          GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY_PR }}
       - name: Upload test reports (if Gradle failed)
         uses: actions/upload-artifact@v4
         if: failure()

--- a/.github/workflows/contributor-build.yml
+++ b/.github/workflows/contributor-build.yml
@@ -82,7 +82,8 @@ jobs:
       - name: Run build script
         env:
           RDBMS: ${{ matrix.rdbms }}
-          POPULATE_REMOTE_GRADLE_CACHE: true
+          # Don't populate Develocity cache in pull requests as that's potentially dangerous
+          POPULATE_REMOTE_GRADLE_CACHE: "${{ github.event_name == 'push' }}"
           GRADLE_ENTERPRISE_ACCESS_KEY: "${{ secrets.DEVELOCITY_ACCESS_TOKEN }}"
         run: ./ci/build-github.sh
         shell: bash

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -13,7 +13,7 @@ import org.jenkinsci.plugins.workflow.support.steps.build.RunWrapper
 /*
  * See https://github.com/hibernate/hibernate-jenkins-pipeline-helpers
  */
-@Library('hibernate-jenkins-pipeline-helpers@1.5') _
+@Library('hibernate-jenkins-pipeline-helpers@1.9') _
 import org.hibernate.jenkins.pipeline.helpers.job.JobHelper
 
 @Field final String DEFAULT_JDK_VERSION = '11'
@@ -25,6 +25,8 @@ this.helper = new JobHelper(this)
 
 helper.runWithNotification {
 stage('Configure') {
+	requireApprovalForPullRequest 'hibernate'
+
 	this.environments = [
 //		new BuildEnvironment( dbName: 'h2' ),
 //		new BuildEnvironment( dbName: 'hsqldb' ),

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -250,7 +250,7 @@ void ciBuild(buildEnv, String args) {
 			}
 		}
 	}
-	else {
+	else if ( buildEnv.node && buildEnv.node != 's390x' ) { // We couldn't get the code below to work on s390x for some reason.
 		// Pull request: we can't pass credentials to the build, since we'd be exposing secrets to e.g. tests.
 		// We do the build first, then publish the build scan separately.
 		tryFinally({
@@ -263,6 +263,10 @@ void ciBuild(buildEnv, String args) {
 				}
 			}
 		})
+	}
+	else {
+		// Don't do build scans
+		sh "./ci/build.sh $args"
 	}
 }
 

--- a/nightly.Jenkinsfile
+++ b/nightly.Jenkinsfile
@@ -103,7 +103,7 @@ stage('Build') {
 					stage('Checkout') {
 						checkout scm
 					}
-					try {
+					tryFinally({
 						stage('Start database') {
 							switch (buildEnv.dbName) {
 								case "hsqldb_2_6":
@@ -175,7 +175,7 @@ stage('Build') {
 						stage('Test') {
 							String cmd = "./ci/build.sh ${buildEnv.additionalOptions ?: ''} ${state[buildEnv.tag]['additionalOptions'] ?: ''}"
 							withEnv(["RDBMS=${buildEnv.dbName}"]) {
-								try {
+								tryFinally({
 									if (buildEnv.dbLockableResource == null) {
 										withCredentials([file(credentialsId: 'sybase-jconnect-driver', variable: 'jconnect_driver')]) {
 											sh 'cp -f $jconnect_driver ./drivers/jconn4.jar'
@@ -194,14 +194,12 @@ stage('Build') {
 											}
 										}
 									}
-								}
-								finally {
+								}, { // Finally
 									junit '**/target/test-results/test/*.xml,**/target/test-results/testKitTest/*.xml'
-								}
+								})
 							}
 						}
-					}
-					finally {
+					}, { // Finally
 						if ( state[buildEnv.tag]['containerName'] != null ) {
 							sh "docker rm -f ${state[buildEnv.tag]['containerName']}"
 						}
@@ -209,7 +207,7 @@ stage('Build') {
 						if ( !env.CHANGE_ID && buildEnv.notificationRecipients != null ) {
 							handleNotifications(currentBuild, buildEnv)
 						}
-					}
+					})
 				}
 			}
 		})
@@ -239,16 +237,13 @@ class BuildEnvironment {
 void runBuildOnNode(String label, Closure body) {
 	node( label ) {
 		pruneDockerContainers()
-        try {
-			body()
-        }
-        finally {
-        	// If this is a PR, we clean the workspace at the end
-        	if ( env.CHANGE_BRANCH != null ) {
-        		cleanWs()
-        	}
-        	pruneDockerContainers()
-        }
+    tryFinally(body, {
+      // If this is a PR, we clean the workspace at the end
+      if ( env.CHANGE_BRANCH != null ) {
+        cleanWs()
+      }
+      pruneDockerContainers()
+    })
 	}
 }
 void pruneDockerContainers() {
@@ -323,4 +318,34 @@ String getParallelResult( RunWrapper build, String parallelBranchName ) {
     	return null;
     }
     return branch.status.result
+}
+
+// try-finally construct that properly suppresses exceptions thrown in the finally block.
+def tryFinally(Closure main, Closure ... finallies) {
+	def mainFailure = null
+	try {
+		main()
+	}
+	catch (Throwable t) {
+		mainFailure = t
+		throw t
+	}
+	finally {
+		finallies.each {it ->
+			try {
+				it()
+			}
+			catch (Throwable t) {
+				if ( mainFailure ) {
+					mainFailure.addSuppressed( t )
+				}
+				else {
+					mainFailure = t
+				}
+			}
+		}
+	}
+	if ( mainFailure ) { // We may reach here if only the "finally" failed
+		throw mainFailure
+	}
 }


### PR DESCRIPTION
This PR:

* Makes sure that the Jenkins pipeline won't execute for PRs of external contributors until it's been approved. No approval is needed for members of the Hibernate organization.
* Makes sure that secrets are exposed only to build steps that really need them, and in particular not to the actual build
* Changes the GitHub actions build to use the `pull_request_target` event instead of `pull_request`, to have access to secrets, while still checkout out the PR head. This is a bit dodgy but safe if we're careful, see comments. More importantly this is strictly equivalent to what we're doing on Jenkins.
* Adds publication of build scans to both the GitHub Actions build and the Jenkins build.

For Jenkins, the approval screen (using BlueOcean) will look like this:

![Screenshot from 2024-03-28 15-39-03](https://github.com/hibernate/hibernate-orm/assets/412878/59df98a5-a27a-4537-824e-677668ce0328)

Note we'll need to merge this PR before we can see the effect of the GitHub Actions changes.
