### PR TITLE
Test: having map key as an object and map annotated with a `@MapKeyClass` fails to boot

### DIFF
--- a/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/MapKeyTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/MapKeyTest.java
@@ -71,7 +71,12 @@ public class MapKeyTest {
 					Map<Date, Person> lastNames = new HashMap<>();
 					lastNames.put( date1, person1 );
 					lastNames.put( date2, person2 );
+
 					school2.setStudentsByDate( lastNames );
+					Map<Object, Person> lastNames2 = new HashMap<>();
+					lastNames2.put( date1, person1 );
+					lastNames2.put( date2, person2 );
+					school2.setStudentsByObjectThatIsDate( lastNames2 );
 
 					entityManager.persist( school1 );
 					entityManager.persist( school2 );
@@ -95,6 +100,15 @@ public class MapKeyTest {
 					Collection<Person> people = studentsByDate.values();
 					assertEquals( expectedPeople.size(), people.size() );
 					assertTrue( expectedPeople.containsAll( people ) );
+
+					Map<Object, Person> studentsByObjectThatIsDate = school.getStudentsByObjectThatIsDate();
+					Set<Object> dates2 = studentsByObjectThatIsDate.keySet();
+					assertEquals( expectedDates.size(), dates2.size() );
+					assertTrue( expectedDates.containsAll( dates2 ) );
+
+					Collection<Person> people2 = studentsByObjectThatIsDate.values();
+					assertEquals( expectedPeople.size(), people2.size() );
+					assertTrue( expectedPeople.containsAll( people2 ) );
 				}
 		);
 	}
@@ -165,6 +179,12 @@ public class MapKeyTest {
 		@MapKeyTemporal(TemporalType.DATE)
 		private Map<Date, Person> studentsByDate;
 
+		@OneToMany(mappedBy = "school")
+		@MapKeyClass(Date.class)
+		@MapKeyColumn(name = "THE_DATE")
+		@MapKeyTemporal(TemporalType.DATE)
+		private Map<Object, Person> studentsByObjectThatIsDate;
+
 		@Temporal( TemporalType.DATE )
 		private Date aDate;
 
@@ -192,6 +212,14 @@ public class MapKeyTest {
 			this.studentsByDate = studentsByDate;
 		}
 
+		public Map<Object, Person> getStudentsByObjectThatIsDate() {
+			return studentsByObjectThatIsDate;
+		}
+
+		public void setStudentsByObjectThatIsDate(
+				Map<Object, Person> studentsByObjectThatIsDate) {
+			this.studentsByObjectThatIsDate = studentsByObjectThatIsDate;
+		}
 	}
 
 }


### PR DESCRIPTION
Having some map with an object key and `@MapKeyClass`, e.g.:
```java
@OneToMany(mappedBy = "school")
@MapKeyClass(Date.class)
@MapKeyColumn(name = "THE_DATE")
@MapKeyTemporal(TemporalType.DATE)
private Map<Object, Person> studentsByObjectThatIsDate;
```
Leads to an error:

```java
org.hibernate.AnnotationException: Property 'org.hibernate.orm.test.jpa.MapKeyTest$School.studentsByObjectThatIsDate' has an unbound type and no explicit target entity (resolve this generics usage issue or set an explicit target attribute with '@OneToMany(target=)' or use an explicit '@Type')
	at org.hibernate.boot.model.internal.PropertyContainer.verifyAndInitializePersistentAttributes(PropertyContainer.java:324)
	at org.hibernate.boot.model.internal.PropertyContainer.resolveAttributeMembers(PropertyContainer.java:134)
	at org.hibernate.boot.model.internal.PropertyContainer.<init>(PropertyContainer.java:95)
	at org.hibernate.boot.model.internal.InheritanceState.getElementsToProcess(InheritanceState.java:225)
	at org.hibernate.boot.model.internal.InheritanceState.postProcess(InheritanceState.java:164)
	at org.hibernate.boot.model.internal.EntityBinder.handleIdentifier(EntityBinder.java:406)
	at org.hibernate.boot.model.internal.EntityBinder.bindEntityClass(EntityBinder.java:248)
	at org.hibernate.boot.model.internal.AnnotationBinder.bindClass(AnnotationBinder.java:255)
	at org.hibernate.boot.model.source.internal.annotations.AnnotationMetadataSourceProcessorImpl.processEntityHierarchies(AnnotationMetadataSourceProcessorImpl.java:209)
	at org.hibernate.boot.model.process.spi.MetadataBuildingProcess$1.processEntityHierarchies(MetadataBuildingProcess.java:334)
	at org.hibernate.boot.model.process.spi.MetadataBuildingProcess.coordinateProcessors(MetadataBuildingProcess.java:377)
	at org.hibernate.boot.model.process.spi.MetadataBuildingProcess.complete(MetadataBuildingProcess.java:227)
	at org.hibernate.jpa.boot.internal.EntityManagerFactoryBuilderImpl.metadata(EntityManagerFactoryBuilderImpl.java:1431)
	at org.hibernate.jpa.boot.internal.EntityManagerFactoryBuilderImpl.build(EntityManagerFactoryBuilderImpl.java:1502)
	at org.hibernate.testing.orm.junit.EntityManagerFactoryExtension$EntityManagerFactoryScopeImpl.createEntityManagerFactory(EntityManagerFactoryExtension.java:328)
	at org.hibernate.testing.orm.junit.AbstractEntityManagerFactoryScope.getEntityManagerFactory(AbstractEntityManagerFactoryScope.java:38)
	at org.hibernate.testing.orm.junit.AbstractEntityManagerFactoryScope.inTransaction(AbstractEntityManagerFactoryScope.java:124)
	at org.hibernate.orm.test.jpa.MapKeyTest.testMapKeyTemporal(MapKeyTest.java:69)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:568)
```

Noticed this while testing Search against 7.0. This kind of mapping worked in the previous versions. Is this a new rule, or should ORM try to figure out the type since there's a `@MapKeyClass` annotation?