### PR TITLE
Upgrade docker mssql image to 2022-CU12-ubuntu-22.04

### DIFF
--- a/docker_db.sh
+++ b/docker_db.sh
@@ -381,8 +381,8 @@ mssql_2017() {
 
 mssql_2022() {
     $CONTAINER_CLI rm -f mssql || true
-    #This sha256 matches a specific tag of mcr.microsoft.com/mssql/server:2022-latest :
-    $CONTAINER_CLI run --name mssql -d -p 1433:1433 -e "SA_PASSWORD=Hibernate_orm_test" -e ACCEPT_EULA=Y mcr.microsoft.com/mssql/server@sha256:5439be9edc3b514cf647bcd3651779fa13f487735a985f40cbdcfecc60fea273
+    #This sha256 matches a specific tag of 2022-CU12-ubuntu-22.04 (https://mcr.microsoft.com/en-us/product/mssql/server/tags):
+    $CONTAINER_CLI run --name mssql -d -p 1433:1433 -e "SA_PASSWORD=Hibernate_orm_test" -e ACCEPT_EULA=Y mcr.microsoft.com/mssql/server@sha256:b94071acd4612bfe60a73e265097c2b6388d14d9d493db8f37cf4479a4337480
     sleep 5
     n=0
     until [ "$n" -ge 5 ]


### PR DESCRIPTION
6.4 backport of https://github.com/hibernate/hibernate-orm/pull/8099