### PR TITLE
support for stupid Query by Method Name countBy() queries returning int

### DIFF
--- a/tooling/metamodel-generator/src/jakartaData/java/org/hibernate/processor/test/data/basic/BookAuthorRepository.java
+++ b/tooling/metamodel-generator/src/jakartaData/java/org/hibernate/processor/test/data/basic/BookAuthorRepository.java
@@ -192,4 +192,7 @@ public interface BookAuthorRepository {
 
 	@Update
 	Book edit(Book book);
+
+	@Query("select count(this) from Author")
+	int countAuthors();
 }


### PR DESCRIPTION
This is awful, but we can get rid of it as soon as we drop support for Query by Method Name.