### PR TITLE
WIP: Convert bytecodeenhanced tests to use JUnit 5 extensions

### DIFF
--- a/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/collectionelement/recreate/BytecodeEnhancementElementCollectionRecreateCollectionsInDefaultGroupTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/collectionelement/recreate/BytecodeEnhancementElementCollectionRecreateCollectionsInDefaultGroupTest.java
@@ -6,82 +6,74 @@
  */
 package org.hibernate.orm.test.annotations.collectionelement.recreate;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hibernate.orm.test.annotations.collectionelement.recreate.BytecodeEnhancementElementCollectionRecreateCollectionsInDefaultGroupTest.MyEntity;
+import static org.junit.Assert.assertTrue;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-import org.hibernate.boot.SessionFactoryBuilder;
-
-import org.hibernate.testing.TestForIssue;
-import org.hibernate.testing.bytecode.enhancement.BytecodeEnhancerRunner;
 import org.hibernate.testing.bytecode.enhancement.EnhancementOptions;
-import org.hibernate.testing.junit4.BaseNonConfigCoreFunctionalTestCase;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.hibernate.testing.bytecode.enhancement.extension.BytecodeEnhanced;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.JiraKey;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import jakarta.persistence.ElementCollection;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jakarta.persistence.OrderColumn;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertTrue;
-
-@RunWith(BytecodeEnhancerRunner.class)
+@DomainModel(
+		annotatedClasses = {
+				MyEntity.class,
+		}
+)
+@SessionFactory
+@BytecodeEnhanced(testEnhancedClasses = MyEntity.class)
 @EnhancementOptions(lazyLoading = true)
-@TestForIssue(jiraKey = "HHH-14387")
-public class BytecodeEnhancementElementCollectionRecreateCollectionsInDefaultGroupTest
-		extends BaseNonConfigCoreFunctionalTestCase {
+@JiraKey("HHH-14387")
+public class BytecodeEnhancementElementCollectionRecreateCollectionsInDefaultGroupTest {
 
-	@Override
-	protected Class[] getAnnotatedClasses() {
-		return new Class[] {
-				MyEntity.class
-		};
-	}
-
-	@Override
-	protected void configureSessionFactoryBuilder(SessionFactoryBuilder sfb) {
-		super.configureSessionFactoryBuilder( sfb );
-		sfb.applyCollectionsInDefaultFetchGroup( true );
-	}
-
-	@Before
-	public void check() {
-		inSession(
+	@BeforeEach
+	public void check(SessionFactoryScope scope) {
+		scope.inSession(
 				session ->
 						assertTrue( session.getSessionFactory().getSessionFactoryOptions()
-											.isCollectionsInDefaultFetchGroupEnabled() )
+								.isCollectionsInDefaultFetchGroupEnabled() )
 		);
 	}
 
 
-	@After
-	public void tearDown() {
-		inTransaction(
+	@AfterEach
+	public void tearDown(SessionFactoryScope scope) {
+		scope.inTransaction(
 				session ->
 						session.createQuery( "delete from myentity" ).executeUpdate()
 		);
 	}
 
 	@Test
-	public void testRecreateCollection() {
-		inTransaction( session -> {
+	public void testRecreateCollection(SessionFactoryScope scope) {
+		scope.inTransaction( session -> {
 			MyEntity entity = new MyEntity();
 			entity.setId( 1 );
 			entity.setElements( Arrays.asList( "one", "two", "four" ) );
 			session.persist( entity );
 		} );
 
-		inTransaction( session -> {
+		scope.inTransaction( session -> {
 			MyEntity entity = session.get( MyEntity.class, 1 );
 			entity.setElements( Arrays.asList( "two", "three" ) );
 			session.persist( entity );
 		} );
 
-		inTransaction( session -> {
+		scope.inTransaction( session -> {
 			MyEntity entity = session.get( MyEntity.class, 1 );
 			assertThat( entity.getElements() )
 					.containsExactlyInAnyOrder( "two", "three" );
@@ -89,21 +81,21 @@ public class BytecodeEnhancementElementCollectionRecreateCollectionsInDefaultGro
 	}
 
 	@Test
-	public void testRecreateCollectionFind() {
-		inTransaction( session -> {
+	public void testRecreateCollectionFind(SessionFactoryScope scope) {
+		scope.inTransaction( session -> {
 			MyEntity entity = new MyEntity();
 			entity.setId( 1 );
 			entity.setElements( Arrays.asList( "one", "two", "four" ) );
 			session.persist( entity );
 		} );
 
-		inTransaction( session -> {
+		scope.inTransaction( session -> {
 			MyEntity entity = session.find( MyEntity.class, 1 );
 			entity.setElements( Arrays.asList( "two", "three" ) );
 			session.persist( entity );
 		} );
 
-		inTransaction( session -> {
+		scope.inTransaction( session -> {
 			MyEntity entity = session.find( MyEntity.class, 1 );
 			assertThat( entity.getElements() )
 					.containsExactlyInAnyOrder( "two", "three" );
@@ -111,20 +103,20 @@ public class BytecodeEnhancementElementCollectionRecreateCollectionsInDefaultGro
 	}
 
 	@Test
-	public void testDeleteCollection() {
-		inTransaction( session -> {
+	public void testDeleteCollection(SessionFactoryScope scope) {
+		scope.inTransaction( session -> {
 			MyEntity entity = new MyEntity();
 			entity.setId( 1 );
 			entity.setElements( Arrays.asList( "one", "two", "four" ) );
 			session.persist( entity );
 		} );
 
-		inTransaction( session -> {
+		scope.inTransaction( session -> {
 			MyEntity entity = session.get( MyEntity.class, 1 );
 			entity.setElements( new ArrayList<>() );
 		} );
 
-		inTransaction( session -> {
+		scope.inTransaction( session -> {
 			MyEntity entity = session.get( MyEntity.class, 1 );
 			assertThat( entity.getElements() )
 					.isEmpty();
@@ -132,20 +124,20 @@ public class BytecodeEnhancementElementCollectionRecreateCollectionsInDefaultGro
 	}
 
 	@Test
-	public void testDeleteCollectionFind() {
-		inTransaction( session -> {
+	public void testDeleteCollectionFind(SessionFactoryScope scope) {
+		scope.inTransaction( session -> {
 			MyEntity entity = new MyEntity();
 			entity.setId( 1 );
 			entity.setElements( Arrays.asList( "one", "two", "four" ) );
 			session.persist( entity );
 		} );
 
-		inTransaction( session -> {
+		scope.inTransaction( session -> {
 			MyEntity entity = session.find( MyEntity.class, 1 );
 			entity.setElements( new ArrayList<>() );
 		} );
 
-		inTransaction( session -> {
+		scope.inTransaction( session -> {
 			MyEntity entity = session.find( MyEntity.class, 1 );
 			assertThat( entity.getElements() )
 					.isEmpty();
@@ -153,19 +145,19 @@ public class BytecodeEnhancementElementCollectionRecreateCollectionsInDefaultGro
 	}
 
 	@Test
-	public void testLoadAndCommitTransactionDoesNotDeleteCollection() {
-		inTransaction( session -> {
+	public void testLoadAndCommitTransactionDoesNotDeleteCollection(SessionFactoryScope scope) {
+		scope.inTransaction( session -> {
 			MyEntity entity = new MyEntity();
 			entity.setId( 1 );
 			entity.setElements( Arrays.asList( "one", "two", "four" ) );
 			session.persist( entity );
 		} );
 
-		inTransaction( session ->
-							   session.get( MyEntity.class, 1 )
+		scope.inTransaction( session ->
+				session.get( MyEntity.class, 1 )
 		);
 
-		inTransaction( session -> {
+		scope.inTransaction( session -> {
 			MyEntity entity = session.get( MyEntity.class, 1 );
 			assertThat( entity.getElements() )
 					.containsExactlyInAnyOrder( "one", "two", "four" );
@@ -174,19 +166,19 @@ public class BytecodeEnhancementElementCollectionRecreateCollectionsInDefaultGro
 	}
 
 	@Test
-	public void testLoadAndCommitTransactionDoesNotDeleteCollectionFind() {
-		inTransaction( session -> {
+	public void testLoadAndCommitTransactionDoesNotDeleteCollectionFind(SessionFactoryScope scope) {
+		scope.inTransaction( session -> {
 			MyEntity entity = new MyEntity();
 			entity.setId( 1 );
 			entity.setElements( Arrays.asList( "one", "two", "four" ) );
 			session.persist( entity );
 		} );
 
-		inTransaction( session ->
-							   session.find( MyEntity.class, 1 )
+		scope.inTransaction( session ->
+				session.find( MyEntity.class, 1 )
 		);
 
-		inTransaction( session -> {
+		scope.inTransaction( session -> {
 			MyEntity entity = session.find( MyEntity.class, 1 );
 			assertThat( entity.getElements() )
 					.containsExactlyInAnyOrder( "one", "two", "four" );

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhance/internal/bytebuddy/DirtyCheckingWithEmbeddableAndMappedSuperclassTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhance/internal/bytebuddy/DirtyCheckingWithEmbeddableAndMappedSuperclassTest.java
@@ -6,23 +6,6 @@
  */
 package org.hibernate.orm.test.bytecode.enhance.internal.bytebuddy;
 
-import java.lang.reflect.Method;
-import jakarta.persistence.Column;
-import jakarta.persistence.Embeddable;
-import jakarta.persistence.Embedded;
-import jakarta.persistence.Entity;
-import jakarta.persistence.Id;
-import jakarta.persistence.MappedSuperclass;
-
-import org.hibernate.bytecode.enhance.internal.tracker.CompositeOwnerTracker;
-import org.hibernate.bytecode.enhance.internal.tracker.SimpleFieldTracker;
-
-import org.hibernate.testing.TestForIssue;
-import org.hibernate.testing.bytecode.enhancement.BytecodeEnhancerRunner;
-import org.hibernate.testing.bytecode.enhancement.EnhancementOptions;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.extractor.Extractors.resultOf;
 import static org.hibernate.bytecode.enhance.spi.EnhancerConstants.ENTITY_ENTRY_FIELD_NAME;
@@ -44,10 +27,29 @@ import static org.hibernate.bytecode.enhance.spi.EnhancerConstants.TRACKER_FIELD
 import static org.hibernate.bytecode.enhance.spi.EnhancerConstants.TRACKER_GET_NAME;
 import static org.hibernate.bytecode.enhance.spi.EnhancerConstants.TRACKER_HAS_CHANGED_NAME;
 import static org.hibernate.bytecode.enhance.spi.EnhancerConstants.TRACKER_SUSPEND_NAME;
+import static org.hibernate.orm.test.bytecode.enhance.internal.bytebuddy.DirtyCheckingWithEmbeddableAndMappedSuperclassTest.CardGame;
 
-@TestForIssue(jiraKey = "HHH-13759")
-@RunWith(BytecodeEnhancerRunner.class)
+import java.lang.reflect.Method;
+
+import org.hibernate.bytecode.enhance.internal.tracker.CompositeOwnerTracker;
+import org.hibernate.bytecode.enhance.internal.tracker.SimpleFieldTracker;
+
+import org.hibernate.testing.bytecode.enhancement.EnhancementOptions;
+import org.hibernate.testing.bytecode.enhancement.extension.BytecodeEnhanced;
+import org.hibernate.testing.orm.junit.JiraKey;
+import org.junit.jupiter.api.Test;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import jakarta.persistence.Embedded;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.MappedSuperclass;
+
+
+@BytecodeEnhanced(testEnhancedClasses = CardGame.class)
 @EnhancementOptions(inlineDirtyChecking = true)
+@JiraKey("HHH-13759")
 public class DirtyCheckingWithEmbeddableAndMappedSuperclassTest {
 
 	@Test

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhance/internal/bytebuddy/DirtyCheckingWithEmbeddableAndNonVisibleGenericMappedSuperclassTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhance/internal/bytebuddy/DirtyCheckingWithEmbeddableAndNonVisibleGenericMappedSuperclassTest.java
@@ -34,18 +34,17 @@ import java.lang.reflect.Method;
 import org.hibernate.bytecode.enhance.internal.tracker.CompositeOwnerTracker;
 import org.hibernate.bytecode.enhance.internal.tracker.SimpleFieldTracker;
 
-import org.hibernate.testing.bytecode.enhancement.BytecodeEnhancerRunner;
 import org.hibernate.testing.bytecode.enhancement.EnhancementOptions;
+import org.hibernate.testing.bytecode.enhancement.extension.BytecodeEnhanced;
 import org.hibernate.testing.orm.junit.JiraKey;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 
-@RunWith(BytecodeEnhancerRunner.class)
+@BytecodeEnhanced
 @EnhancementOptions(inlineDirtyChecking = true)
 public class DirtyCheckingWithEmbeddableAndNonVisibleGenericMappedSuperclassTest {
 
@@ -99,7 +98,7 @@ public class DirtyCheckingWithEmbeddableAndNonVisibleGenericMappedSuperclassTest
 		assertThat( entity )
 				.extracting( TRACKER_FIELD_NAME ).isInstanceOf( SimpleFieldTracker.class );
 		assertThat( entity.getEmbedded() )
-				.extracting( TRACKER_COMPOSITE_FIELD_NAME ).isInstanceOf( CompositeOwnerTracker.class);
+				.extracting( TRACKER_COMPOSITE_FIELD_NAME ).isInstanceOf( CompositeOwnerTracker.class );
 
 		assertThat( entity ).extracting( resultOf( TRACKER_HAS_CHANGED_NAME ) ).isEqualTo( true );
 		assertThat( entity ).extracting( resultOf( TRACKER_GET_NAME ) )

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhance/internal/bytebuddy/DirtyCheckingWithEmbeddableAndNonVisibleGenericMappedSuperclassWithDifferentGenericParameterNameTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhance/internal/bytebuddy/DirtyCheckingWithEmbeddableAndNonVisibleGenericMappedSuperclassWithDifferentGenericParameterNameTest.java
@@ -20,11 +20,10 @@ import static org.hibernate.bytecode.enhance.spi.EnhancerConstants.TRACKER_GET_N
 import static org.hibernate.bytecode.enhance.spi.EnhancerConstants.TRACKER_HAS_CHANGED_NAME;
 import static org.hibernate.bytecode.enhance.spi.EnhancerConstants.TRACKER_SUSPEND_NAME;
 
-import org.hibernate.testing.bytecode.enhancement.BytecodeEnhancerRunner;
 import org.hibernate.testing.bytecode.enhancement.EnhancementOptions;
+import org.hibernate.testing.bytecode.enhancement.extension.BytecodeEnhanced;
 import org.hibernate.testing.orm.junit.JiraKey;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
@@ -33,7 +32,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.MappedSuperclass;
 
 @JiraKey("HHH-17035")
-@RunWith(BytecodeEnhancerRunner.class)
+@BytecodeEnhanced
 @EnhancementOptions(inlineDirtyChecking = true)
 public class DirtyCheckingWithEmbeddableAndNonVisibleGenericMappedSuperclassWithDifferentGenericParameterNameTest {
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhance/internal/bytebuddy/DirtyCheckingWithEmbeddableAndTwiceRemovedNonVisibleGenericMappedSuperclassTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhance/internal/bytebuddy/DirtyCheckingWithEmbeddableAndTwiceRemovedNonVisibleGenericMappedSuperclassTest.java
@@ -11,11 +11,10 @@ import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.hibernate.bytecode.enhance.spi.EnhancerConstants.PERSISTENT_FIELD_READER_PREFIX;
 import static org.hibernate.bytecode.enhance.spi.EnhancerConstants.PERSISTENT_FIELD_WRITER_PREFIX;
 
-import org.hibernate.testing.bytecode.enhancement.BytecodeEnhancerRunner;
 import org.hibernate.testing.bytecode.enhancement.EnhancementOptions;
+import org.hibernate.testing.bytecode.enhancement.extension.BytecodeEnhanced;
 import org.hibernate.testing.orm.junit.JiraKey;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
@@ -23,7 +22,7 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jakarta.persistence.MappedSuperclass;
 
-@RunWith(BytecodeEnhancerRunner.class)
+@BytecodeEnhanced
 @EnhancementOptions(inlineDirtyChecking = true)
 public class DirtyCheckingWithEmbeddableAndTwiceRemovedNonVisibleGenericMappedSuperclassTest {
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhance/internal/bytebuddy/DirtyCheckingWithEmbeddableExtedingAnotherEmbeddableAndTwiceRemovedNonVisibleGenericMappedSuperclassTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhance/internal/bytebuddy/DirtyCheckingWithEmbeddableExtedingAnotherEmbeddableAndTwiceRemovedNonVisibleGenericMappedSuperclassTest.java
@@ -6,11 +6,10 @@
  */
 package org.hibernate.orm.test.bytecode.enhance.internal.bytebuddy;
 
-import org.hibernate.testing.bytecode.enhancement.BytecodeEnhancerRunner;
 import org.hibernate.testing.bytecode.enhancement.EnhancementOptions;
+import org.hibernate.testing.bytecode.enhancement.extension.BytecodeEnhanced;
 import org.hibernate.testing.orm.junit.JiraKey;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
@@ -23,7 +22,7 @@ import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.hibernate.bytecode.enhance.spi.EnhancerConstants.PERSISTENT_FIELD_READER_PREFIX;
 import static org.hibernate.bytecode.enhance.spi.EnhancerConstants.PERSISTENT_FIELD_WRITER_PREFIX;
 
-@RunWith(BytecodeEnhancerRunner.class)
+@BytecodeEnhanced
 @EnhancementOptions(inlineDirtyChecking = true)
 public class DirtyCheckingWithEmbeddableExtedingAnotherEmbeddableAndTwiceRemovedNonVisibleGenericMappedSuperclassTest {
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhance/internal/bytebuddy/DirtyCheckingWithEmbeddableExtendingMappedSuperclassTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhance/internal/bytebuddy/DirtyCheckingWithEmbeddableExtendingMappedSuperclassTest.java
@@ -8,12 +8,13 @@ package org.hibernate.orm.test.bytecode.enhance.internal.bytebuddy;
 
 import java.util.List;
 
-import org.hibernate.testing.bytecode.enhancement.BytecodeEnhancerRunner;
 import org.hibernate.testing.bytecode.enhancement.EnhancementOptions;
-import org.hibernate.testing.junit4.BaseCoreFunctionalTestCase;
+import org.hibernate.testing.bytecode.enhancement.extension.BytecodeEnhanced;
+import org.hibernate.testing.orm.junit.DomainModel;
 import org.hibernate.testing.orm.junit.JiraKey;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.junit.jupiter.api.Test;
 
 import jakarta.persistence.Embeddable;
 import jakarta.persistence.Embedded;
@@ -23,29 +24,25 @@ import jakarta.persistence.MappedSuperclass;
 import jakarta.persistence.Tuple;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.hibernate.orm.test.bytecode.enhance.internal.bytebuddy.DirtyCheckingWithEmbeddableExtendingMappedSuperclassTest.*;
 
-@RunWith(BytecodeEnhancerRunner.class)
+
+@DomainModel(annotatedClasses = { MyEntity.class, })
+@SessionFactory
+@BytecodeEnhanced(testEnhancedClasses = MyEntity.class)
 @EnhancementOptions(inlineDirtyChecking = true)
-public class DirtyCheckingWithEmbeddableExtendingMappedSuperclassTest extends
-		BaseCoreFunctionalTestCase {
-
-	@Override
-	protected Class<?>[] getAnnotatedClasses() {
-		return new Class[]{
-				MyEntity.class
-		};
-	}
+public class DirtyCheckingWithEmbeddableExtendingMappedSuperclassTest {
 
 	@JiraKey("HHH-17041")
 	@Test
-	public void testQueryEmbeddableFields() {
-		inTransaction(
+	public void testQueryEmbeddableFields(SessionFactoryScope scope) {
+		scope.inTransaction(
 				session -> {
 					MyEntity myEntity  = new MyEntity(1, "one");
 					session.persist( myEntity );
 				}
 		);
-		inTransaction(
+		scope.inTransaction(
 				session -> {
 					List<Tuple> result = session.createQuery( "select m.embedded.text, m.embedded.name from MyEntity m", Tuple.class ).list();
 					assertThat( result.size() ).isEqualTo( 1 );

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhance/internal/bytebuddy/DirtyCheckingWithEmbeddableNonVisibleGenericExtendsSerializableMappedSuperclassTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhance/internal/bytebuddy/DirtyCheckingWithEmbeddableNonVisibleGenericExtendsSerializableMappedSuperclassTest.java
@@ -9,44 +9,43 @@ package org.hibernate.orm.test.bytecode.enhance.internal.bytebuddy;
 import java.io.Serializable;
 import java.util.List;
 
-import org.hibernate.testing.bytecode.enhancement.BytecodeEnhancerRunner;
 import org.hibernate.testing.bytecode.enhancement.EnhancementOptions;
-import org.hibernate.testing.junit4.BaseCoreFunctionalTestCase;
+import org.hibernate.testing.bytecode.enhancement.extension.BytecodeEnhanced;
+import org.hibernate.testing.orm.junit.DomainModel;
 import org.hibernate.testing.orm.junit.JiraKey;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.junit.jupiter.api.Test;
 
 import jakarta.persistence.Embeddable;
-import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jakarta.persistence.MappedSuperclass;
 import jakarta.persistence.Tuple;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.hibernate.orm.test.bytecode.enhance.internal.bytebuddy.DirtyCheckingWithEmbeddableNonVisibleGenericExtendsSerializableMappedSuperclassTest.*;
 
-@RunWith(BytecodeEnhancerRunner.class)
+@DomainModel(
+		annotatedClasses = {
+				MyEntity.class,
+		}
+)
+@SessionFactory
+@BytecodeEnhanced
 @EnhancementOptions(inlineDirtyChecking = true)
-public class DirtyCheckingWithEmbeddableNonVisibleGenericExtendsSerializableMappedSuperclassTest extends
-		BaseCoreFunctionalTestCase {
-
-	@Override
-	protected Class<?>[] getAnnotatedClasses() {
-		return new Class[]{
-				MyEntity.class
-		};
-	}
+public class DirtyCheckingWithEmbeddableNonVisibleGenericExtendsSerializableMappedSuperclassTest {
 
 	@JiraKey("HHH-17041")
 	@Test
-	public void testQueryEmbeddableFields() {
-		inTransaction(
+	public void testQueryEmbeddableFields(SessionFactoryScope scope) {
+		scope.inTransaction(
 				session -> {
 					MyEntity myEntity  = new MyEntity(1, "one");
 					session.persist( myEntity );
 				}
 		);
-		inTransaction(
+		scope.inTransaction(
 				session -> {
 					List<Tuple> result = session.createQuery( "select m.embedded.text, m.embedded.name from MyEntity m", Tuple.class ).list();
 					assertThat( result.size() ).isEqualTo( 1 );

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhance/internal/bytebuddy/DirtyCheckingWithEmbeddedOnGetterTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhance/internal/bytebuddy/DirtyCheckingWithEmbeddedOnGetterTest.java
@@ -16,11 +16,10 @@ import jakarta.persistence.Id;
 import org.hibernate.bytecode.enhance.internal.tracker.CompositeOwnerTracker;
 import org.hibernate.bytecode.enhance.internal.tracker.SimpleFieldTracker;
 
-import org.hibernate.testing.TestForIssue;
-import org.hibernate.testing.bytecode.enhancement.BytecodeEnhancerRunner;
 import org.hibernate.testing.bytecode.enhancement.EnhancementOptions;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.hibernate.testing.bytecode.enhancement.extension.BytecodeEnhanced;
+import org.hibernate.testing.orm.junit.JiraKey;
+import org.junit.jupiter.api.Test;
 
 import org.assertj.core.api.Assertions;
 
@@ -46,8 +45,8 @@ import static org.hibernate.bytecode.enhance.spi.EnhancerConstants.TRACKER_GET_N
 import static org.hibernate.bytecode.enhance.spi.EnhancerConstants.TRACKER_HAS_CHANGED_NAME;
 import static org.hibernate.bytecode.enhance.spi.EnhancerConstants.TRACKER_SUSPEND_NAME;
 
-@TestForIssue(jiraKey = "HHH-13764")
-@RunWith(BytecodeEnhancerRunner.class)
+@JiraKey("HHH-13764")
+@BytecodeEnhanced
 @EnhancementOptions(inlineDirtyChecking = true)
 public class DirtyCheckingWithEmbeddedOnGetterTest {
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhance/internal/bytebuddy/DirtyCheckingWithEmbeddedTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhance/internal/bytebuddy/DirtyCheckingWithEmbeddedTest.java
@@ -16,13 +16,12 @@ import jakarta.persistence.Id;
 import org.hibernate.bytecode.enhance.internal.tracker.CompositeOwnerTracker;
 import org.hibernate.bytecode.enhance.internal.tracker.SimpleFieldTracker;
 
-import org.hibernate.testing.TestForIssue;
-import org.hibernate.testing.bytecode.enhancement.BytecodeEnhancerRunner;
 import org.hibernate.testing.bytecode.enhancement.EnhancementOptions;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.hibernate.testing.bytecode.enhancement.extension.BytecodeEnhanced;
+import org.hibernate.testing.orm.junit.JiraKey;
 
 import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.extractor.Extractors.resultOf;
@@ -46,8 +45,8 @@ import static org.hibernate.bytecode.enhance.spi.EnhancerConstants.TRACKER_GET_N
 import static org.hibernate.bytecode.enhance.spi.EnhancerConstants.TRACKER_HAS_CHANGED_NAME;
 import static org.hibernate.bytecode.enhance.spi.EnhancerConstants.TRACKER_SUSPEND_NAME;
 
-@TestForIssue(jiraKey = "HHH-13764")
-@RunWith(BytecodeEnhancerRunner.class)
+@JiraKey("HHH-13764")
+@BytecodeEnhanced
 @EnhancementOptions(inlineDirtyChecking = true)
 public class DirtyCheckingWithEmbeddedTest {
 
@@ -64,7 +63,8 @@ public class DirtyCheckingWithEmbeddedTest {
 				.hasDeclaredMethods( PERSISTENT_FIELD_READER_PREFIX + "name", PERSISTENT_FIELD_WRITER_PREFIX + "name" )
 				.hasDeclaredMethods( ENTITY_INSTANCE_GETTER_NAME, ENTITY_ENTRY_GETTER_NAME )
 				.hasDeclaredMethods( PREVIOUS_GETTER_NAME, PREVIOUS_SETTER_NAME, NEXT_GETTER_NAME, NEXT_SETTER_NAME )
-				.hasDeclaredMethods( TRACKER_HAS_CHANGED_NAME, TRACKER_CLEAR_NAME, TRACKER_SUSPEND_NAME, TRACKER_GET_NAME );
+				.hasDeclaredMethods(
+						TRACKER_HAS_CHANGED_NAME, TRACKER_CLEAR_NAME, TRACKER_SUSPEND_NAME, TRACKER_GET_NAME );
 	}
 
 	@Test
@@ -76,7 +76,8 @@ public class DirtyCheckingWithEmbeddedTest {
 	@Test
 	public void shouldDeclareMethodsInEmbeddedClass() {
 		assertThat( Component.class )
-				.hasDeclaredMethods( PERSISTENT_FIELD_READER_PREFIX + "component", PERSISTENT_FIELD_WRITER_PREFIX + "component" )
+				.hasDeclaredMethods(
+						PERSISTENT_FIELD_READER_PREFIX + "component", PERSISTENT_FIELD_WRITER_PREFIX + "component" )
 				.hasDeclaredMethods( TRACKER_COMPOSITE_SET_OWNER, TRACKER_COMPOSITE_CLEAR_OWNER );
 	}
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhance/internal/bytebuddy/DirtyCheckingWithMappedsuperclassTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhance/internal/bytebuddy/DirtyCheckingWithMappedsuperclassTest.java
@@ -6,20 +6,6 @@
  */
 package org.hibernate.orm.test.bytecode.enhance.internal.bytebuddy;
 
-import java.lang.reflect.Method;
-import jakarta.persistence.Entity;
-import jakarta.persistence.Id;
-import jakarta.persistence.MappedSuperclass;
-import org.assertj.core.extractor.Extractors;
-
-import org.hibernate.bytecode.enhance.internal.tracker.SimpleFieldTracker;
-
-import org.hibernate.testing.TestForIssue;
-import org.hibernate.testing.bytecode.enhancement.BytecodeEnhancerRunner;
-import org.hibernate.testing.bytecode.enhancement.EnhancementOptions;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.extractor.Extractors.resultOf;
 import static org.hibernate.bytecode.enhance.spi.EnhancerConstants.ENTITY_ENTRY_FIELD_NAME;
@@ -39,8 +25,21 @@ import static org.hibernate.bytecode.enhance.spi.EnhancerConstants.TRACKER_GET_N
 import static org.hibernate.bytecode.enhance.spi.EnhancerConstants.TRACKER_HAS_CHANGED_NAME;
 import static org.hibernate.bytecode.enhance.spi.EnhancerConstants.TRACKER_SUSPEND_NAME;
 
-@TestForIssue(jiraKey = "HHH-13759")
-@RunWith(BytecodeEnhancerRunner.class)
+import java.lang.reflect.Method;
+
+import org.hibernate.bytecode.enhance.internal.tracker.SimpleFieldTracker;
+
+import org.hibernate.testing.bytecode.enhancement.EnhancementOptions;
+import org.hibernate.testing.bytecode.enhancement.extension.BytecodeEnhanced;
+import org.hibernate.testing.orm.junit.JiraKey;
+import org.junit.jupiter.api.Test;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.MappedSuperclass;
+
+@JiraKey("HHH-13759")
+@BytecodeEnhanced
 @EnhancementOptions(inlineDirtyChecking = true)
 public class DirtyCheckingWithMappedsuperclassTest {
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/association/BidirectionalOneToOneWithNonAggregateIdTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/association/BidirectionalOneToOneWithNonAggregateIdTest.java
@@ -6,12 +6,13 @@ import org.hibernate.annotations.Fetch;
 import org.hibernate.annotations.LazyGroup;
 import org.hibernate.annotations.LazyToOne;
 
-import org.hibernate.testing.bytecode.enhancement.BytecodeEnhancerRunner;
-import org.hibernate.testing.junit4.BaseCoreFunctionalTestCase;
+import org.hibernate.testing.bytecode.enhancement.extension.BytecodeEnhanced;
+import org.hibernate.testing.orm.junit.DomainModel;
 import org.hibernate.testing.orm.junit.JiraKey;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -25,25 +26,24 @@ import static jakarta.persistence.CascadeType.ALL;
 import static jakarta.persistence.FetchType.LAZY;
 import static org.hibernate.annotations.FetchMode.SELECT;
 import static org.hibernate.annotations.LazyToOneOption.NO_PROXY;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-@RunWith(BytecodeEnhancerRunner.class)
+@DomainModel(
+		annotatedClasses = {
+				BidirectionalOneToOneWithNonAggregateIdTest.Entity1.class,
+				BidirectionalOneToOneWithNonAggregateIdTest.Entity2.class
+		}
+)
+@SessionFactory
+@BytecodeEnhanced
 @JiraKey("HHH-17519")
-public class BidirectionalOneToOneWithNonAggregateIdTest extends BaseCoreFunctionalTestCase {
+public class BidirectionalOneToOneWithNonAggregateIdTest  {
 
 	static final int ENTITY_ID = 1;
 
-	@Override
-	protected Class<?>[] getAnnotatedClasses() {
-		return new Class<?>[] {
-				Entity1.class,
-				Entity2.class
-		};
-	}
-
-	@Before
-	public void setUp() {
-		inTransaction(
+	@BeforeEach
+	public void setUp(SessionFactoryScope scope) {
+		scope.inTransaction(
 				session -> {
 					Entity1 e1 = new Entity1( ENTITY_ID );
 					Entity2 e2 = new Entity2();
@@ -60,8 +60,8 @@ public class BidirectionalOneToOneWithNonAggregateIdTest extends BaseCoreFunctio
 
 
 	@Test
-	public void testRemovingChild() {
-		inTransaction(
+	public void testRemovingChild(SessionFactoryScope scope) {
+		scope.inTransaction(
 				session -> {
 					Entity1 e1 = session.byId( Entity1.class ).load( ENTITY_ID );
 					Entity2 child = e1.getChild();

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/association/InheritedAttributeAssociationTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/association/InheritedAttributeAssociationTest.java
@@ -6,11 +6,12 @@
  */
 package org.hibernate.orm.test.bytecode.enhancement.association;
 
-import org.hibernate.testing.TestForIssue;
-import org.hibernate.testing.bytecode.enhancement.BytecodeEnhancerRunner;
+import java.util.List;
+
 import org.hibernate.testing.bytecode.enhancement.EnhancerTestUtils;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.hibernate.testing.bytecode.enhancement.extension.BytecodeEnhanced;
+import org.hibernate.testing.orm.junit.JiraKey;
+import org.junit.jupiter.api.Test;
 
 import jakarta.persistence.DiscriminatorColumn;
 import jakarta.persistence.DiscriminatorType;
@@ -24,56 +25,55 @@ import jakarta.persistence.InheritanceType;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.MappedSuperclass;
 import jakarta.persistence.OneToMany;
-import java.util.List;
 
 /**
  * @author Luis Barreiro
  */
-@TestForIssue( jiraKey = "HHH-11050" )
-@RunWith( BytecodeEnhancerRunner.class )
+@JiraKey("HHH-11050")
+@BytecodeEnhanced
 public class InheritedAttributeAssociationTest {
 
-    @Test
-    public void test() {
-        // The mapping is wrong but the point is that the enhancement phase does not need to fail. See JIRA for further detail
+	@Test
+	public void test() {
+		// The mapping is wrong but the point is that the enhancement phase does not need to fail. See JIRA for further detail
 
-        // If enhancement of 'items' attribute fails, 'name' won't be enhanced
-        Author author = new Author();
-        author.name = "Bernardo Soares";
-        EnhancerTestUtils.checkDirtyTracking( author, "name" );
-    }
+		// If enhancement of 'items' attribute fails, 'name' won't be enhanced
+		Author author = new Author();
+		author.name = "Bernardo Soares";
+		EnhancerTestUtils.checkDirtyTracking( author, "name" );
+	}
 
-    // --- //
+	// --- //
 
-    @Entity
-    private static class Author {
+	@Entity
+	private static class Author {
 
-        @Id
-        @GeneratedValue
-        Long id;
+		@Id
+		@GeneratedValue
+		Long id;
 
-        @OneToMany( fetch = FetchType.LAZY, mappedBy = "author" )
-        List<ChildItem> items;
+		@OneToMany(fetch = FetchType.LAZY, mappedBy = "author")
+		List<ChildItem> items;
 
-        // keep this field after 'items'
-        String name;
-    }
+		// keep this field after 'items'
+		String name;
+	}
 
-    @MappedSuperclass
-    @Inheritance( strategy = InheritanceType.SINGLE_TABLE )
-    @DiscriminatorColumn( name = "type", discriminatorType = DiscriminatorType.STRING )
-    private static abstract class Item {
+	@MappedSuperclass
+	@Inheritance(strategy = InheritanceType.SINGLE_TABLE)
+	@DiscriminatorColumn(name = "type", discriminatorType = DiscriminatorType.STRING)
+	private static abstract class Item {
 
-        @Id
-        @GeneratedValue
-        Long id;
+		@Id
+		@GeneratedValue
+		Long id;
 
-        @ManyToOne( fetch = FetchType.LAZY )
-        Author author;
-    }
+		@ManyToOne(fetch = FetchType.LAZY)
+		Author author;
+	}
 
-    @Entity
-    @DiscriminatorValue( "child" )
-    private static class ChildItem extends Item {
-    }
+	@Entity
+	@DiscriminatorValue("child")
+	private static class ChildItem extends Item {
+	}
 }

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/association/ManyToManyAssociationListTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/association/ManyToManyAssociationListTest.java
@@ -6,6 +6,8 @@
  */
 package org.hibernate.orm.test.bytecode.enhancement.association;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -15,15 +17,14 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jakarta.persistence.ManyToMany;
 
-import org.hibernate.testing.bytecode.enhancement.BytecodeEnhancerRunner;
-import org.junit.Assert;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.hibernate.testing.bytecode.enhancement.extension.BytecodeEnhanced;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Luis Barreiro
  */
-@RunWith( BytecodeEnhancerRunner.class )
+@BytecodeEnhanced
 public class ManyToManyAssociationListTest {
     @Test
     public void testBidirectionalExisting() {
@@ -36,8 +37,8 @@ public class ManyToManyAssociationListTest {
         user.setGroups( new ArrayList<>( Collections.singleton( group ) ) );
         user.setGroups( new ArrayList<>( Arrays.asList( group, anotherGroup ) ) );
 
-        Assert.assertEquals( 1, group.getUsers().size() );
-        Assert.assertEquals( 1, anotherGroup.getUsers().size() );
+        assertEquals( 1, group.getUsers().size() );
+        assertEquals( 1, anotherGroup.getUsers().size() );
     }
 
     // -- //

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/association/ManyToManyAssociationTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/association/ManyToManyAssociationTest.java
@@ -6,10 +6,11 @@
  */
 package org.hibernate.orm.test.bytecode.enhancement.association;
 
-import org.hibernate.testing.bytecode.enhancement.BytecodeEnhancerRunner;
-import org.junit.Assert;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.hibernate.testing.bytecode.enhancement.extension.BytecodeEnhanced;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -22,7 +23,7 @@ import java.util.Set;
 /**
  * @author Luis Barreiro
  */
-@RunWith( BytecodeEnhancerRunner.class )
+@BytecodeEnhanced
 public class ManyToManyAssociationTest {
 
     @Test
@@ -37,34 +38,34 @@ public class ManyToManyAssociationTest {
         user.addGroup( anotherGroup );
         anotherUser.addGroup( group );
 
-        Assert.assertEquals( 2, group.getUsers().size() );
-        Assert.assertEquals( 1, anotherGroup.getUsers().size() );
+        assertEquals( 2, group.getUsers().size() );
+        assertEquals( 1, anotherGroup.getUsers().size() );
 
         group.resetUsers();
 
-        Assert.assertEquals( 1, user.getGroups().size() );
-        Assert.assertEquals( 0, anotherUser.getGroups().size() );
+        assertEquals( 1, user.getGroups().size() );
+        assertEquals( 0, anotherUser.getGroups().size() );
 
         // Test remove
         user.addGroup( group );
         anotherUser.addGroup( group );
 
-        Assert.assertEquals( 2, group.getUsers().size() );
-        Assert.assertEquals( 1, anotherGroup.getUsers().size() );
+        assertEquals( 2, group.getUsers().size() );
+        assertEquals( 1, anotherGroup.getUsers().size() );
 
         Set<Group> groups = new HashSet<>( user.getGroups() );
         groups.remove( group );
         user.setGroups( groups );
 
-        Assert.assertEquals( 1, group.getUsers().size() );
-        Assert.assertEquals( 1, anotherGroup.getUsers().size() );
+        assertEquals( 1, group.getUsers().size() );
+        assertEquals( 1, anotherGroup.getUsers().size() );
 
         groups.remove( anotherGroup );
         user.setGroups( groups );
 
-        Assert.assertEquals( 1, group.getUsers().size() );
+        assertEquals( 1, group.getUsers().size() );
         // This happens (and is expected) because there was no snapshot taken before remove
-        Assert.assertEquals( 1, anotherGroup.getUsers().size() );
+        assertEquals( 1, anotherGroup.getUsers().size() );
     }
 
     // -- //

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/association/OneToManyAssociationTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/association/OneToManyAssociationTest.java
@@ -6,10 +6,13 @@
  */
 package org.hibernate.orm.test.bytecode.enhancement.association;
 
-import org.hibernate.testing.bytecode.enhancement.BytecodeEnhancerRunner;
-import org.junit.Assert;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.hibernate.testing.bytecode.enhancement.extension.BytecodeEnhanced;
+import org.junit.jupiter.api.Test;
 
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Entity;
@@ -24,43 +27,43 @@ import java.util.List;
 /**
  * @author Luis Barreiro
  */
-@RunWith( BytecodeEnhancerRunner.class )
+@BytecodeEnhanced
 public class OneToManyAssociationTest {
 
     @Test
     public void test() {
         Customer customer = new Customer();
-        Assert.assertTrue( customer.getInventories().isEmpty() );
+        assertTrue( customer.getInventories().isEmpty() );
 
         CustomerInventory customerInventory = new CustomerInventory();
         customerInventory.setCustomer( customer );
 
-        Assert.assertEquals( 1, customer.getInventories().size() );
-        Assert.assertTrue( customer.getInventories().contains( customerInventory ) );
+        assertEquals( 1, customer.getInventories().size() );
+        assertTrue( customer.getInventories().contains( customerInventory ) );
 
         Customer anotherCustomer = new Customer();
-        Assert.assertTrue( anotherCustomer.getInventories().isEmpty() );
+        assertTrue( anotherCustomer.getInventories().isEmpty() );
         customerInventory.setCustomer( anotherCustomer );
 
-        Assert.assertTrue( customer.getInventories().isEmpty() );
-        Assert.assertEquals( 1, anotherCustomer.getInventories().size() );
-        Assert.assertSame( customerInventory, anotherCustomer.getInventories().get( 0 ) );
+        assertTrue( customer.getInventories().isEmpty() );
+        assertEquals( 1, anotherCustomer.getInventories().size() );
+        assertSame( customerInventory, anotherCustomer.getInventories().get( 0 ) );
 
         customer.addInventory( customerInventory );
 
-        Assert.assertSame( customer, customerInventory.getCustomer() );
-        Assert.assertTrue( anotherCustomer.getInventories().isEmpty() );
-        Assert.assertEquals( 1, customer.getInventories().size() );
+        assertSame( customer, customerInventory.getCustomer() );
+        assertTrue( anotherCustomer.getInventories().isEmpty() );
+        assertEquals( 1, customer.getInventories().size() );
 
         customer.addInventory( new CustomerInventory() );
-        Assert.assertEquals( 2, customer.getInventories().size() );
+        assertEquals( 2, customer.getInventories().size() );
 
         // Test remove
         customer.removeInventory( customerInventory );
-        Assert.assertEquals( 1, customer.getInventories().size() );
+        assertEquals( 1, customer.getInventories().size() );
 
         // This happens (and is expected) because there was no snapshot taken before remove
-        Assert.assertNotNull( customerInventory.getCustomer() );
+        assertNotNull( customerInventory.getCustomer() );
     }
 
     // --- //

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/association/OneToOneAssociationTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/association/OneToOneAssociationTest.java
@@ -6,22 +6,23 @@
  */
 package org.hibernate.orm.test.bytecode.enhancement.association;
 
-import org.hibernate.testing.bytecode.enhancement.BytecodeEnhancerRunner;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
 import org.hibernate.testing.bytecode.enhancement.EnhancerTestUtils;
-import org.junit.Assert;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
 
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jakarta.persistence.OneToOne;
 
+import org.hibernate.testing.bytecode.enhancement.extension.BytecodeEnhanced;
 import org.hibernate.testing.util.uuid.SafeRandomUUIDGenerator;
 
 /**
  * @author Luis Barreiro
  */
-@RunWith( BytecodeEnhancerRunner.class )
+@BytecodeEnhanced
 public class OneToOneAssociationTest {
 
     @Test
@@ -32,7 +33,7 @@ public class OneToOneAssociationTest {
         Customer customer = new Customer();
         customer.setUser( user );
 
-        Assert.assertEquals( customer, user.getCustomer() );
+        assertEquals( customer, user.getCustomer() );
 
         // check dirty tracking is set automatically with bi-directional association management
         EnhancerTestUtils.checkDirtyTracking( user, "login", "customer" );
@@ -42,12 +43,12 @@ public class OneToOneAssociationTest {
 
         customer.setUser( anotherUser );
 
-        Assert.assertNull( user.getCustomer() );
-        Assert.assertEquals( customer, anotherUser.getCustomer() );
+        assertNull( user.getCustomer() );
+        assertEquals( customer, anotherUser.getCustomer() );
 
         user.setCustomer( new Customer() );
 
-        Assert.assertEquals( user, user.getCustomer().getUser() );
+        assertEquals( user, user.getCustomer().getUser() );
     }
 
     @Test
@@ -58,15 +59,15 @@ public class OneToOneAssociationTest {
         Customer customer = new Customer();
         customer.setUser( user );
 
-        Assert.assertEquals( customer, user.getCustomer() );
+        assertEquals( customer, user.getCustomer() );
 
         // check dirty tracking is set automatically with bi-directional association management
         EnhancerTestUtils.checkDirtyTracking( user, "login", "customer" );
 
         user.setCustomer( null );
 
-        Assert.assertNull( user.getCustomer() );
-        Assert.assertNull( customer.getUser() );
+        assertNull( user.getCustomer() );
+        assertNull( customer.getUser() );
     }
 
     // --- //

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/bag/BagAndSetFetchTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/bag/BagAndSetFetchTest.java
@@ -1,40 +1,39 @@
 package org.hibernate.orm.test.bytecode.enhancement.bag;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.Set;
 
-import org.hibernate.testing.bytecode.enhancement.BytecodeEnhancerRunner;
-import org.hibernate.testing.junit4.BaseCoreFunctionalTestCase;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.hibernate.testing.bytecode.enhancement.extension.BytecodeEnhanced;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.junit.jupiter.api.Test;
 
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.Id;
 import jakarta.persistence.OneToMany;
 
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
-import static org.junit.Assert.assertTrue;
-
-
-@RunWith(BytecodeEnhancerRunner.class)
-public class BagAndSetFetchTest extends BaseCoreFunctionalTestCase {
-
-	@Override
-	protected Class<?>[] getAnnotatedClasses() {
-		return new Class[] {
-				EntityA.class,
-				EntityB.class,
-				EntityC.class,
-				EntityD.class,
-		};
-	}
+@DomainModel(
+		annotatedClasses = {
+				BagAndSetFetchTest.EntityA.class,
+				BagAndSetFetchTest.EntityB.class,
+				BagAndSetFetchTest.EntityC.class,
+				BagAndSetFetchTest.EntityD.class,
+		}
+)
+@SessionFactory
+@BytecodeEnhanced
+public class BagAndSetFetchTest {
 
 	@Test
-	public void testIt() {
-		inTransaction(
+	public void testIt(SessionFactoryScope scope) {
+		scope.inTransaction(
 				session -> {
 					EntityB b = new EntityB( 1l, "b" );
 
@@ -85,7 +84,7 @@ public class BagAndSetFetchTest extends BaseCoreFunctionalTestCase {
 				}
 		);
 
-		inTransaction(
+		scope.inTransaction(
 				session -> {
 					EntityA entityA = session.find( EntityA.class, 1l );
 					Collection<EntityB> attributes = entityA.attributes;

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/bag/EagerBagsTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/bag/EagerBagsTest.java
@@ -1,38 +1,39 @@
 package org.hibernate.orm.test.bytecode.enhancement.bag;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import java.util.Collection;
 import java.util.LinkedList;
 
-import org.hibernate.testing.bytecode.enhancement.BytecodeEnhancerRunner;
-import org.hibernate.testing.junit4.BaseCoreFunctionalTestCase;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.hibernate.testing.bytecode.enhancement.extension.BytecodeEnhanced;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.junit.jupiter.api.Test;
 
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.Id;
 import jakarta.persistence.OneToMany;
 
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
-import static org.junit.Assert.assertTrue;
 
 
-@RunWith(BytecodeEnhancerRunner.class)
-public class EagerBagsTest extends BaseCoreFunctionalTestCase {
-
-	@Override
-	protected Class<?>[] getAnnotatedClasses() {
-		return new Class[] {
-				EntityA.class,
-				EntityB.class,
-				EntityC.class,
-				EntityD.class,
-		};
-	}
+@DomainModel(
+		annotatedClasses = {
+				EagerBagsTest.EntityA.class,
+				EagerBagsTest.EntityB.class,
+				EagerBagsTest.EntityC.class,
+				EagerBagsTest.EntityD.class,
+		}
+)
+@SessionFactory
+@BytecodeEnhanced
+public class EagerBagsTest {
 
 	@Test
-	public void testIt() {
-		inTransaction(
+	public void testIt(SessionFactoryScope scope) {
+		scope.inTransaction(
 				session -> {
 					EntityB b = new EntityB( 1l, "b" );
 
@@ -70,7 +71,7 @@ public class EagerBagsTest extends BaseCoreFunctionalTestCase {
 				}
 		);
 
-		inTransaction(
+		scope.inTransaction(
 				session -> {
 					EntityA entityA = session.find( EntityA.class, 1l );
 					Collection<EntityB> attributes = entityA.attributes;

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/basic/BasicEnhancementTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/basic/BasicEnhancementTest.java
@@ -10,14 +10,11 @@ import org.hibernate.Version;
 import org.hibernate.bytecode.enhance.spi.EnhancementInfo;
 import org.hibernate.engine.spi.ManagedEntity;
 import org.hibernate.engine.spi.PersistentAttributeInterceptable;
-import org.hibernate.orm.test.legacy.Simple;
 
-import org.hibernate.testing.TestForIssue;
-import org.hibernate.testing.bytecode.enhancement.BytecodeEnhancerRunner;
 import org.hibernate.testing.bytecode.enhancement.EnhancerTestUtils;
-import org.junit.Assert;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.hibernate.testing.bytecode.enhancement.extension.BytecodeEnhanced;
+import org.hibernate.testing.orm.junit.Jira;
+import org.junit.jupiter.api.Test;
 
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
@@ -26,18 +23,18 @@ import java.util.Collections;
 import java.util.List;
 
 import static org.hibernate.testing.junit4.ExtraAssertions.assertTyping;
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNotSame;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * @author Luis Barreiro
  */
-@RunWith( BytecodeEnhancerRunner.class )
+@BytecodeEnhanced
 public class BasicEnhancementTest {
 
     @Test
@@ -62,10 +59,10 @@ public class BasicEnhancementTest {
     }
 
     @Test
-    @TestForIssue(jiraKey = "HHH-13439")
+    @Jira("HHH-13439")
     public void enhancementInfoTest() {
         EnhancementInfo info = SimpleEntity.class.getAnnotation( EnhancementInfo.class );
-        assertNotNull( "EnhancementInfo was not applied", info );
+        assertNotNull( info, "EnhancementInfo was not applied" );
 
         assertEquals( Version.getVersionString(), info.version() );
     }
@@ -114,7 +111,7 @@ public class BasicEnhancementTest {
         ( (PersistentAttributeInterceptable) entity ).$$_hibernate_setInterceptor( null );
 
         entity.id = 1234567890L;
-        Assert.assertEquals( 1234567890L, (long) entity.getId() );
+        assertEquals( 1234567890L, (long) entity.getId() );
 
         entity.name = "Entity Name";
         assertSame( "Entity Name", entity.name );

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/basic/BasicSessionTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/basic/BasicSessionTest.java
@@ -8,42 +8,44 @@ package org.hibernate.orm.test.bytecode.enhancement.basic;
 
 import org.hibernate.engine.spi.EntityEntry;
 import org.hibernate.engine.spi.ManagedEntity;
-import org.hibernate.testing.bytecode.enhancement.BytecodeEnhancerRunner;
-import org.hibernate.testing.junit4.BaseCoreFunctionalTestCase;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+
+import org.hibernate.testing.bytecode.enhancement.extension.BytecodeEnhanced;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.junit.jupiter.api.Test;
 
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import jakarta.persistence.Transient;
 
-import static org.hibernate.testing.transaction.TransactionUtil.doInHibernate;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 /**
  * @author Luis Barreiro
  */
-@RunWith( BytecodeEnhancerRunner.class )
-public class BasicSessionTest extends BaseCoreFunctionalTestCase {
-
-    @Override
-    protected Class<?>[] getAnnotatedClasses() {
-        return new Class[]{ MyEntity.class};
-    }
+@DomainModel(
+        annotatedClasses = {
+                BasicSessionTest.MyEntity.class,
+        }
+)
+@SessionFactory
+@BytecodeEnhanced
+public class BasicSessionTest {
 
     @Test
-    public void test() {
-        doInHibernate( this::sessionFactory, s -> {
+    public void test(SessionFactoryScope scope) {
+        scope.inTransaction( s -> {
             s.save( new MyEntity( 1L ) );
             s.save( new MyEntity( 2L ) );
         } );
 
         MyEntity[] entities = new MyEntity[2];
 
-        doInHibernate( this::sessionFactory, s -> {
+        scope.inTransaction( s -> {
             entities[0] = s.get( MyEntity.class, 1L );
             entities[1] = s.get( MyEntity.class, 2L );
 
@@ -70,7 +72,7 @@ public class BasicSessionTest extends BaseCoreFunctionalTestCase {
 
     @Entity( name = "MyEntity" )
     @Table( name = "MY_ENTITY" )
-    private static class MyEntity implements ManagedEntity {
+    static class MyEntity implements ManagedEntity {
 
         @Id
         Long id;

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/basic/CrossEnhancementTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/basic/CrossEnhancementTest.java
@@ -6,11 +6,12 @@
  */
 package org.hibernate.orm.test.bytecode.enhancement.basic;
 
-import org.hibernate.testing.TestForIssue;
-import org.hibernate.testing.bytecode.enhancement.BytecodeEnhancerRunner;
-import org.hibernate.testing.junit4.BaseCoreFunctionalTestCase;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.hibernate.testing.bytecode.enhancement.extension.BytecodeEnhanced;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.JiraKey;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.junit.jupiter.api.Test;
 
 import jakarta.persistence.Embeddable;
 import jakarta.persistence.EmbeddedId;
@@ -21,44 +22,45 @@ import jakarta.persistence.MapsId;
 import jakarta.persistence.Table;
 import java.io.Serializable;
 
-import org.hibernate.SessionFactory;
-
 /**
  * @author Luis Barreiro
  */
-@TestForIssue( jiraKey = "HHH-9529" )
-@RunWith( BytecodeEnhancerRunner.class )
-public class CrossEnhancementTest extends BaseCoreFunctionalTestCase {
-
-    @Override
-    public Class<?>[] getAnnotatedClasses() {
-        return new Class<?>[]{Parent.class, Child.class, ChildKey.class};
-    }
+@JiraKey( "HHH-9529" )
+@DomainModel(
+        annotatedClasses = {
+              CrossEnhancementTest.Parent.class, CrossEnhancementTest.Child.class, CrossEnhancementTest.ChildKey.class
+        }
+)
+@SessionFactory
+@BytecodeEnhanced
+public class CrossEnhancementTest {
 
     @Test
-    public void test() {
-        sessionFactory().close();
-        buildSessionFactory();
-    }
+    public void test(SessionFactoryScope scope) {
+		//        sessionFactory().close();
+		//        buildSessionFactory();
+		scope.getSessionFactory().close();
+        // TODO: I do not get this test ^ and not sure how to update it ...
+	}
 
     // --- //
 
     @Entity
     @Table( name = "PARENT" )
-    private static class Parent {
+    static class Parent {
         @Id
         String id;
     }
 
     @Embeddable
-    private static class ChildKey implements Serializable {
+    static class ChildKey implements Serializable {
         String parent;
         String type;
     }
 
     @Entity
     @Table( name = "CHILD" )
-    private static class Child {
+    static class Child {
         @EmbeddedId
         ChildKey id;
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/basic/ExtendedAssociationManagementTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/basic/ExtendedAssociationManagementTest.java
@@ -6,26 +6,25 @@
  */
 package org.hibernate.orm.test.bytecode.enhancement.basic;
 
-import org.hibernate.testing.bytecode.enhancement.BytecodeEnhancerRunner;
 import org.hibernate.testing.bytecode.enhancement.EnhancerTestUtils;
-import org.junit.Assert;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
 
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.Id;
 import jakarta.persistence.OneToOne;
 
+import org.hibernate.testing.bytecode.enhancement.extension.BytecodeEnhanced;
 import org.hibernate.testing.util.uuid.SafeRandomUUIDGenerator;
 
 import static org.hibernate.testing.bytecode.enhancement.EnhancerTestUtils.getFieldByReflection;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 /**
  * @author Luis Barreiro
  */
-@RunWith( BytecodeEnhancerRunner.class )
+@BytecodeEnhanced
 public class ExtendedAssociationManagementTest {
 
     @Test
@@ -46,7 +45,7 @@ public class ExtendedAssociationManagementTest {
 
         customer.user = anotherUser;
 
-        Assert.assertNull( user.customer );
+        assertNull( user.customer );
         assertEquals( customer, getFieldByReflection( anotherUser, "customer" ) );
 
         user.customer = new Customer();

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/basic/ExtendedEnhancementNonStandardAccessTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/basic/ExtendedEnhancementNonStandardAccessTest.java
@@ -4,11 +4,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import org.hibernate.Hibernate;
 
-import org.hibernate.testing.bytecode.enhancement.BytecodeEnhancerRunner;
 import org.hibernate.testing.bytecode.enhancement.EnhancementOptions;
-import org.hibernate.testing.junit4.BaseCoreFunctionalTestCase;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.hibernate.testing.bytecode.enhancement.extension.BytecodeEnhanced;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.junit.jupiter.api.Test;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -21,19 +22,18 @@ import jakarta.persistence.Id;
  * static accessors, accessors defined in a subclass,
  * or accessors defined in an inner class.
  */
-@RunWith(BytecodeEnhancerRunner.class)
+@DomainModel(
+		annotatedClasses = {
+			ExtendedEnhancementNonStandardAccessTest.MyAbstractEntity.class, ExtendedEnhancementNonStandardAccessTest.MyAbstractConfusingEntity.class, ExtendedEnhancementNonStandardAccessTest.MyConcreteEntity.class
+		}
+)
+@SessionFactory
+@BytecodeEnhanced
 @EnhancementOptions(lazyLoading = true, extendedEnhancement = true)
-public class ExtendedEnhancementNonStandardAccessTest extends BaseCoreFunctionalTestCase {
-
-	@Override
-	protected Class<?>[] getAnnotatedClasses() {
-		return new Class[] {
-				MyAbstractEntity.class, MyAbstractConfusingEntity.class, MyConcreteEntity.class
-		};
-	}
+public class ExtendedEnhancementNonStandardAccessTest {
 
 	@Test
-	public void nonStandardInstanceGetterSetterPublicField() {
+	public void nonStandardInstanceGetterSetterPublicField(SessionFactoryScope scope) {
 		doTestFieldAccess( new AccessDelegate() {
 			@Override
 			public void setValue(MyConcreteEntity entity, Long value) {
@@ -44,11 +44,11 @@ public class ExtendedEnhancementNonStandardAccessTest extends BaseCoreFunctional
 			public Long getValue(MyConcreteEntity entity) {
 				return entity.nonStandardGetterForPublicField();
 			}
-		} );
+		}, scope );
 	}
 
 	@Test
-	public void nonStandardInstanceGetterSetterProtectedField() {
+	public void nonStandardInstanceGetterSetterProtectedField(SessionFactoryScope scope) {
 		doTestFieldAccess( new AccessDelegate() {
 			@Override
 			public void setValue(MyConcreteEntity entity, Long value) {
@@ -59,11 +59,11 @@ public class ExtendedEnhancementNonStandardAccessTest extends BaseCoreFunctional
 			public Long getValue(MyConcreteEntity entity) {
 				return entity.nonStandardGetterForProtectedField();
 			}
-		} );
+		}, scope );
 	}
 
 	@Test
-	public void nonStandardInstanceGetterSetterPackagePrivateField() {
+	public void nonStandardInstanceGetterSetterPackagePrivateField(SessionFactoryScope scope) {
 		doTestFieldAccess( new AccessDelegate() {
 			@Override
 			public void setValue(MyConcreteEntity entity, Long value) {
@@ -74,11 +74,11 @@ public class ExtendedEnhancementNonStandardAccessTest extends BaseCoreFunctional
 			public Long getValue(MyConcreteEntity entity) {
 				return entity.nonStandardGetterForPackagePrivateField();
 			}
-		} );
+		}, scope );
 	}
 
 	@Test
-	public void nonStandardInstanceGetterSetterPrivateField() {
+	public void nonStandardInstanceGetterSetterPrivateField(SessionFactoryScope scope) {
 		doTestFieldAccess( new AccessDelegate() {
 			@Override
 			public void setValue(MyConcreteEntity entity, Long value) {
@@ -89,11 +89,11 @@ public class ExtendedEnhancementNonStandardAccessTest extends BaseCoreFunctional
 			public Long getValue(MyConcreteEntity entity) {
 				return entity.nonStandardGetterForPrivateField();
 			}
-		} );
+		}, scope );
 	}
 
 	@Test
-	public void staticGetterSetterPublicField() {
+	public void staticGetterSetterPublicField(SessionFactoryScope scope) {
 		doTestFieldAccess( new AccessDelegate() {
 			@Override
 			public void setValue(MyConcreteEntity entity, Long value) {
@@ -104,11 +104,11 @@ public class ExtendedEnhancementNonStandardAccessTest extends BaseCoreFunctional
 			public Long getValue(MyConcreteEntity entity) {
 				return MyConcreteEntity.staticGetPublicField( entity );
 			}
-		} );
+		}, scope );
 	}
 
 	@Test
-	public void staticGetterSetterProtectedField() {
+	public void staticGetterSetterProtectedField(SessionFactoryScope scope) {
 		doTestFieldAccess( new AccessDelegate() {
 			@Override
 			public void setValue(MyConcreteEntity entity, Long value) {
@@ -119,11 +119,11 @@ public class ExtendedEnhancementNonStandardAccessTest extends BaseCoreFunctional
 			public Long getValue(MyConcreteEntity entity) {
 				return MyConcreteEntity.staticGetProtectedField( entity );
 			}
-		} );
+		}, scope );
 	}
 
 	@Test
-	public void staticGetterSetterPackagePrivateField() {
+	public void staticGetterSetterPackagePrivateField(SessionFactoryScope scope) {
 		doTestFieldAccess( new AccessDelegate() {
 			@Override
 			public void setValue(MyConcreteEntity entity, Long value) {
@@ -134,11 +134,11 @@ public class ExtendedEnhancementNonStandardAccessTest extends BaseCoreFunctional
 			public Long getValue(MyConcreteEntity entity) {
 				return MyConcreteEntity.staticGetPackagePrivateField( entity );
 			}
-		} );
+		}, scope );
 	}
 
 	@Test
-	public void staticGetterSetterPrivateField() {
+	public void staticGetterSetterPrivateField(SessionFactoryScope scope) {
 		doTestFieldAccess( new AccessDelegate() {
 			@Override
 			public void setValue(MyConcreteEntity entity, Long value) {
@@ -149,11 +149,11 @@ public class ExtendedEnhancementNonStandardAccessTest extends BaseCoreFunctional
 			public Long getValue(MyConcreteEntity entity) {
 				return MyConcreteEntity.staticGetPrivateField( entity );
 			}
-		} );
+		}, scope );
 	}
 
 	@Test
-	public void innerClassStaticGetterSetterPublicField() {
+	public void innerClassStaticGetterSetterPublicField(SessionFactoryScope scope) {
 		doTestFieldAccess( new AccessDelegate() {
 			@Override
 			public void setValue(MyConcreteEntity entity, Long value) {
@@ -164,11 +164,11 @@ public class ExtendedEnhancementNonStandardAccessTest extends BaseCoreFunctional
 			public Long getValue(MyConcreteEntity entity) {
 				return MyConcreteEntity.InnerClassAccessors.staticGetPublicField( entity );
 			}
-		} );
+		}, scope );
 	}
 
 	@Test
-	public void innerClassStaticGetterSetterProtectedField() {
+	public void innerClassStaticGetterSetterProtectedField(SessionFactoryScope scope) {
 		doTestFieldAccess( new AccessDelegate() {
 			@Override
 			public void setValue(MyConcreteEntity entity, Long value) {
@@ -179,11 +179,11 @@ public class ExtendedEnhancementNonStandardAccessTest extends BaseCoreFunctional
 			public Long getValue(MyConcreteEntity entity) {
 				return MyConcreteEntity.InnerClassAccessors.staticGetProtectedField( entity );
 			}
-		} );
+		}, scope );
 	}
 
 	@Test
-	public void innerClassStaticGetterSetterPackagePrivateField() {
+	public void innerClassStaticGetterSetterPackagePrivateField(SessionFactoryScope scope) {
 		doTestFieldAccess( new AccessDelegate() {
 			@Override
 			public void setValue(MyConcreteEntity entity, Long value) {
@@ -194,11 +194,11 @@ public class ExtendedEnhancementNonStandardAccessTest extends BaseCoreFunctional
 			public Long getValue(MyConcreteEntity entity) {
 				return MyConcreteEntity.InnerClassAccessors.staticGetPackagePrivateField( entity );
 			}
-		} );
+		}, scope );
 	}
 
 	@Test
-	public void innerClassStaticGetterSetterPrivateField() {
+	public void innerClassStaticGetterSetterPrivateField(SessionFactoryScope scope) {
 		doTestFieldAccess( new AccessDelegate() {
 			@Override
 			public void setValue(MyConcreteEntity entity, Long value) {
@@ -209,11 +209,11 @@ public class ExtendedEnhancementNonStandardAccessTest extends BaseCoreFunctional
 			public Long getValue(MyConcreteEntity entity) {
 				return MyConcreteEntity.InnerClassAccessors.staticGetPrivateField( entity );
 			}
-		} );
+		}, scope );
 	}
 
 	@Test
-	public void innerClassInstanceGetterSetterPublicField() {
+	public void innerClassInstanceGetterSetterPublicField(SessionFactoryScope scope) {
 		doTestFieldAccess( new AccessDelegate() {
 			@Override
 			public void setValue(MyConcreteEntity entity, Long value) {
@@ -224,11 +224,11 @@ public class ExtendedEnhancementNonStandardAccessTest extends BaseCoreFunctional
 			public Long getValue(MyConcreteEntity entity) {
 				return new MyConcreteEntity.InnerClassAccessors().instanceGetPublicField( entity );
 			}
-		} );
+		}, scope );
 	}
 
 	@Test
-	public void innerClassInstanceGetterSetterProtectedField() {
+	public void innerClassInstanceGetterSetterProtectedField(SessionFactoryScope scope) {
 		doTestFieldAccess( new AccessDelegate() {
 			@Override
 			public void setValue(MyConcreteEntity entity, Long value) {
@@ -239,11 +239,11 @@ public class ExtendedEnhancementNonStandardAccessTest extends BaseCoreFunctional
 			public Long getValue(MyConcreteEntity entity) {
 				return new MyConcreteEntity.InnerClassAccessors().instanceGetProtectedField( entity );
 			}
-		} );
+		}, scope );
 	}
 
 	@Test
-	public void innerClassInstanceGetterSetterPackagePrivateField() {
+	public void innerClassInstanceGetterSetterPackagePrivateField(SessionFactoryScope scope) {
 		doTestFieldAccess( new AccessDelegate() {
 			@Override
 			public void setValue(MyConcreteEntity entity, Long value) {
@@ -254,11 +254,11 @@ public class ExtendedEnhancementNonStandardAccessTest extends BaseCoreFunctional
 			public Long getValue(MyConcreteEntity entity) {
 				return new MyConcreteEntity.InnerClassAccessors().instanceGetPackagePrivateField( entity );
 			}
-		} );
+		}, scope );
 	}
 
 	@Test
-	public void innerClassInstanceGetterSetterPrivateField() {
+	public void innerClassInstanceGetterSetterPrivateField(SessionFactoryScope scope) {
 		doTestFieldAccess( new AccessDelegate() {
 			@Override
 			public void setValue(MyConcreteEntity entity, Long value) {
@@ -269,11 +269,11 @@ public class ExtendedEnhancementNonStandardAccessTest extends BaseCoreFunctional
 			public Long getValue(MyConcreteEntity entity) {
 				return new MyConcreteEntity.InnerClassAccessors().instanceGetPrivateField( entity );
 			}
-		} );
+		}, scope );
 	}
 
 	@Test
-	public void externalClassStaticGetterSetterPublicField() {
+	public void externalClassStaticGetterSetterPublicField(SessionFactoryScope scope) {
 		doTestFieldAccess( new AccessDelegate() {
 			@Override
 			public void setValue(MyConcreteEntity entity, Long value) {
@@ -284,11 +284,11 @@ public class ExtendedEnhancementNonStandardAccessTest extends BaseCoreFunctional
 			public Long getValue(MyConcreteEntity entity) {
 				return ExternalClassAccessors.staticGetPublicField( entity );
 			}
-		} );
+		}, scope );
 	}
 
 	@Test
-	public void externalClassStaticGetterSetterProtectedField() {
+	public void externalClassStaticGetterSetterProtectedField(SessionFactoryScope scope) {
 		doTestFieldAccess( new AccessDelegate() {
 			@Override
 			public void setValue(MyConcreteEntity entity, Long value) {
@@ -299,11 +299,11 @@ public class ExtendedEnhancementNonStandardAccessTest extends BaseCoreFunctional
 			public Long getValue(MyConcreteEntity entity) {
 				return ExternalClassAccessors.staticGetProtectedField( entity );
 			}
-		} );
+		}, scope );
 	}
 
 	@Test
-	public void externalClassStaticGetterSetterPackagePrivateField() {
+	public void externalClassStaticGetterSetterPackagePrivateField(SessionFactoryScope scope) {
 		doTestFieldAccess( new AccessDelegate() {
 			@Override
 			public void setValue(MyConcreteEntity entity, Long value) {
@@ -314,11 +314,11 @@ public class ExtendedEnhancementNonStandardAccessTest extends BaseCoreFunctional
 			public Long getValue(MyConcreteEntity entity) {
 				return ExternalClassAccessors.staticGetPackagePrivateField( entity );
 			}
-		} );
+		}, scope );
 	}
 
 	@Test
-	public void externalClassInstanceGetterSetterPublicField() {
+	public void externalClassInstanceGetterSetterPublicField(SessionFactoryScope scope) {
 		doTestFieldAccess( new AccessDelegate() {
 			@Override
 			public void setValue(MyConcreteEntity entity, Long value) {
@@ -329,11 +329,11 @@ public class ExtendedEnhancementNonStandardAccessTest extends BaseCoreFunctional
 			public Long getValue(MyConcreteEntity entity) {
 				return new ExternalClassAccessors().instanceGetPublicField( entity );
 			}
-		} );
+		}, scope );
 	}
 
 	@Test
-	public void externalClassInstanceGetterSetterProtectedField() {
+	public void externalClassInstanceGetterSetterProtectedField(SessionFactoryScope scope) {
 		doTestFieldAccess( new AccessDelegate() {
 			@Override
 			public void setValue(MyConcreteEntity entity, Long value) {
@@ -344,11 +344,11 @@ public class ExtendedEnhancementNonStandardAccessTest extends BaseCoreFunctional
 			public Long getValue(MyConcreteEntity entity) {
 				return new ExternalClassAccessors().instanceGetProtectedField( entity );
 			}
-		} );
+		}, scope );
 	}
 
 	@Test
-	public void externalClassInstanceGetterSetterPackagePrivateField() {
+	public void externalClassInstanceGetterSetterPackagePrivateField(SessionFactoryScope scope) {
 		doTestFieldAccess( new AccessDelegate() {
 			@Override
 			public void setValue(MyConcreteEntity entity, Long value) {
@@ -359,11 +359,11 @@ public class ExtendedEnhancementNonStandardAccessTest extends BaseCoreFunctional
 			public Long getValue(MyConcreteEntity entity) {
 				return new ExternalClassAccessors().instanceGetPackagePrivateField( entity );
 			}
-		} );
+		}, scope );
 	}
 
 	@Test
-	public void subClassInstanceGetterSetterPublicField() {
+	public void subClassInstanceGetterSetterPublicField(SessionFactoryScope scope) {
 		doTestFieldAccess( new AccessDelegate() {
 			@Override
 			public void setValue(MyConcreteEntity entity, Long value) {
@@ -374,11 +374,11 @@ public class ExtendedEnhancementNonStandardAccessTest extends BaseCoreFunctional
 			public Long getValue(MyConcreteEntity entity) {
 				return entity.getAbstractEntityPublicField();
 			}
-		} );
+		}, scope );
 	}
 
 	@Test
-	public void subClassInstanceGetterSetterProtectedField() {
+	public void subClassInstanceGetterSetterProtectedField(SessionFactoryScope scope) {
 		doTestFieldAccess( new AccessDelegate() {
 			@Override
 			public void setValue(MyConcreteEntity entity, Long value) {
@@ -389,11 +389,11 @@ public class ExtendedEnhancementNonStandardAccessTest extends BaseCoreFunctional
 			public Long getValue(MyConcreteEntity entity) {
 				return entity.getAbstractEntityProtectedField();
 			}
-		} );
+		}, scope );
 	}
 
 	@Test
-	public void subClassInstanceGetterSetterPackagePrivateField() {
+	public void subClassInstanceGetterSetterPackagePrivateField(SessionFactoryScope scope) {
 		doTestFieldAccess( new AccessDelegate() {
 			@Override
 			public void setValue(MyConcreteEntity entity, Long value) {
@@ -404,11 +404,11 @@ public class ExtendedEnhancementNonStandardAccessTest extends BaseCoreFunctional
 			public Long getValue(MyConcreteEntity entity) {
 				return entity.getAbstractEntityPackagePrivateField();
 			}
-		} );
+		}, scope );
 	}
 
 	@Test
-	public void subClassNonStandardInstanceGetterSetterPublicField() {
+	public void subClassNonStandardInstanceGetterSetterPublicField(SessionFactoryScope scope) {
 		doTestFieldAccess( new AccessDelegate() {
 			@Override
 			public void setValue(MyConcreteEntity entity, Long value) {
@@ -419,11 +419,11 @@ public class ExtendedEnhancementNonStandardAccessTest extends BaseCoreFunctional
 			public Long getValue(MyConcreteEntity entity) {
 				return entity.nonStandardGetterForAbstractEntityPublicField();
 			}
-		} );
+		}, scope );
 	}
 
 	@Test
-	public void subClassNonStandardInstanceGetterSetterProtectedField() {
+	public void subClassNonStandardInstanceGetterSetterProtectedField(SessionFactoryScope scope) {
 		doTestFieldAccess( new AccessDelegate() {
 			@Override
 			public void setValue(MyConcreteEntity entity, Long value) {
@@ -434,11 +434,11 @@ public class ExtendedEnhancementNonStandardAccessTest extends BaseCoreFunctional
 			public Long getValue(MyConcreteEntity entity) {
 				return entity.nonStandardGetterForAbstractEntityProtectedField();
 			}
-		} );
+		}, scope );
 	}
 
 	@Test
-	public void subClassNonStandardInstanceGetterSetterPackagePrivateField() {
+	public void subClassNonStandardInstanceGetterSetterPackagePrivateField(SessionFactoryScope scope) {
 		doTestFieldAccess( new AccessDelegate() {
 			@Override
 			public void setValue(MyConcreteEntity entity, Long value) {
@@ -449,33 +449,33 @@ public class ExtendedEnhancementNonStandardAccessTest extends BaseCoreFunctional
 			public Long getValue(MyConcreteEntity entity) {
 				return entity.nonStandardGetterForAbstractEntityPackagePrivateField();
 			}
-		} );
+		}, scope );
 	}
 
 	// Ideally we'd make this a @ParameterizedTest and pass the access delegate as parameter,
 	// but we cannot do that due to JUnit using a different classloader than the test.
-	private void doTestFieldAccess(AccessDelegate delegate) {
-		Long id = fromTransaction( em -> {
+	private void doTestFieldAccess(AccessDelegate delegate, SessionFactoryScope scope) {
+		Long id = scope.fromTransaction( em -> {
 			var entity = new MyConcreteEntity();
 			em.persist( entity );
 			return entity.id;
 		} );
 
-		inTransaction( em -> {
+		scope.inTransaction( em -> {
 			var entity = em.find( MyConcreteEntity.class, id );
 			assertThat( delegate.getValue( entity ) )
 					.as( "Loaded value before update" )
 					.isNull();
 		} );
 
-		inTransaction( em -> {
+		scope.inTransaction( em -> {
 			var entity = em.getReference( MyConcreteEntity.class, id );
 			// Since field access is replaced with accessor calls,
 			// we expect this change to be detected by dirty tracking and persisted.
 			delegate.setValue( entity, 42L );
 		} );
 
-		inTransaction( em -> {
+		scope.inTransaction( em -> {
 			var entity = em.find( MyConcreteEntity.class, id );
 			// We're working on an initialized entity.
 			assertThat( entity )
@@ -487,7 +487,7 @@ public class ExtendedEnhancementNonStandardAccessTest extends BaseCoreFunctional
 					.isEqualTo( 42L );
 		} );
 
-		inTransaction( em -> {
+		scope.inTransaction( em -> {
 			var entity = em.getReference( MyConcreteEntity.class, id );
 			// We're working on an uninitialized entity.
 			assertThat( entity )

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/basic/GenericReturnValueMappedSuperclassEnhancementTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/basic/GenericReturnValueMappedSuperclassEnhancementTest.java
@@ -6,7 +6,8 @@
  */
 package org.hibernate.orm.test.bytecode.enhancement.basic;
 
-import static org.junit.Assert.assertEquals;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import jakarta.persistence.Access;
 import jakarta.persistence.AccessType;
@@ -17,16 +18,16 @@ import jakarta.persistence.MappedSuperclass;
 
 import org.hibernate.annotations.Cache;
 import org.hibernate.annotations.CacheConcurrencyStrategy;
-import org.hibernate.testing.TestForIssue;
-import org.hibernate.testing.bytecode.enhancement.BytecodeEnhancerRunner;
-import org.junit.Test;
-import org.junit.runner.RunWith;
 
-@RunWith(BytecodeEnhancerRunner.class)
+import org.hibernate.testing.bytecode.enhancement.extension.BytecodeEnhanced;
+import org.hibernate.testing.orm.junit.JiraKey;
+import org.junit.jupiter.api.Test;
+
+@BytecodeEnhanced
 public class GenericReturnValueMappedSuperclassEnhancementTest {
 
 	@Test
-	@TestForIssue(jiraKey = "HHH-12579")
+	@JiraKey("HHH-12579")
 	public void enhanceClassWithGenericReturnValueOnMappedSuperclass() {
 		SimpleEntity implementation = new SimpleEntity();
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/basic/InheritedTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/basic/InheritedTest.java
@@ -4,13 +4,12 @@ import org.hibernate.bytecode.enhance.spi.DefaultEnhancementContext;
 import org.hibernate.bytecode.enhance.spi.UnloadedClass;
 import org.hibernate.engine.spi.PersistentAttributeInterceptable;
 
-import org.hibernate.testing.TestForIssue;
-import org.hibernate.testing.bytecode.enhancement.BytecodeEnhancerRunner;
 import org.hibernate.testing.bytecode.enhancement.CustomEnhancementContext;
 import org.hibernate.testing.bytecode.enhancement.EnhancerTestContext;
 import org.hibernate.testing.bytecode.enhancement.EnhancerTestUtils;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.hibernate.testing.bytecode.enhancement.extension.BytecodeEnhanced;
+import org.hibernate.testing.orm.junit.JiraKey;
+import org.junit.jupiter.api.Test;
 
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
@@ -18,16 +17,16 @@ import jakarta.persistence.Version;
 
 import static org.hibernate.testing.bytecode.enhancement.EnhancerTestUtils.checkDirtyTracking;
 import static org.hibernate.testing.bytecode.enhancement.EnhancerTestUtils.clearDirtyTracking;
-import static org.junit.Assert.assertNotSame;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assume.assumeTrue;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 /**
  * @author Luis Barreiro
  * @author Craig Andrews
  */
-@TestForIssue( jiraKey = "HHH-11284" )
-@RunWith( BytecodeEnhancerRunner.class )
+@JiraKey( "HHH-11284" )
+@BytecodeEnhanced
 @CustomEnhancementContext( {EnhancerTestContext.class, InheritedTest.EagerEnhancementContext.class} )
 public class InheritedTest {
 
@@ -62,7 +61,7 @@ public class InheritedTest {
 
     // Adapted from BasicEnhancementTest#basicExtendedEnhancementTest
     @Test
-    @TestForIssue(jiraKey = "HHH-14006")
+    @JiraKey("HHH-14006")
     public void extendedEnhancementTest() {
         // This test only works if lazy loading bytecode enhancement is enabled,
         // otherwise extended bytecode enhancement does not do anything we can check.

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/basic/MappedSuperclassTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/basic/MappedSuperclassTest.java
@@ -4,13 +4,12 @@ import org.hibernate.bytecode.enhance.spi.DefaultEnhancementContext;
 import org.hibernate.bytecode.enhance.spi.UnloadedClass;
 import org.hibernate.engine.spi.PersistentAttributeInterceptable;
 
-import org.hibernate.testing.TestForIssue;
-import org.hibernate.testing.bytecode.enhancement.BytecodeEnhancerRunner;
 import org.hibernate.testing.bytecode.enhancement.CustomEnhancementContext;
 import org.hibernate.testing.bytecode.enhancement.EnhancerTestContext;
 import org.hibernate.testing.bytecode.enhancement.EnhancerTestUtils;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.hibernate.testing.bytecode.enhancement.extension.BytecodeEnhanced;
+import org.hibernate.testing.orm.junit.JiraKey;
+import org.junit.jupiter.api.Test;
 
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
@@ -19,15 +18,15 @@ import jakarta.persistence.Version;
 
 import static org.hibernate.testing.bytecode.enhancement.EnhancerTestUtils.checkDirtyTracking;
 import static org.hibernate.testing.bytecode.enhancement.EnhancerTestUtils.clearDirtyTracking;
-import static org.junit.Assert.assertNotSame;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assume.assumeTrue;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 /**
  * @author Luis Barreiro
  */
-@TestForIssue( jiraKey = "HHH-10646" )
-@RunWith( BytecodeEnhancerRunner.class )
+@JiraKey( "HHH-10646" )
+@BytecodeEnhanced
 @CustomEnhancementContext( {EnhancerTestContext.class, MappedSuperclassTest.EagerEnhancementContext.class} )
 public class MappedSuperclassTest {
 
@@ -49,7 +48,7 @@ public class MappedSuperclassTest {
 
     // Adapted from BasicEnhancementTest#basicExtendedEnhancementTest
     @Test
-    @TestForIssue(jiraKey = "HHH-14006")
+    @JiraKey("HHH-14006")
     public void extendedEnhancementTest() {
         // This test only works if lazy loading bytecode enhancement is enabled,
         // otherwise extended bytecode enhancement does not do anything we can check.

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/basic/OverriddenFieldTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/basic/OverriddenFieldTest.java
@@ -1,14 +1,13 @@
 package org.hibernate.orm.test.bytecode.enhancement.basic;
 
-import static org.hibernate.testing.transaction.TransactionUtil.doInHibernate;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import org.hibernate.testing.TestForIssue;
-import org.hibernate.testing.bytecode.enhancement.BytecodeEnhancerRunner;
-import org.hibernate.testing.junit4.BaseCoreFunctionalTestCase;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.hibernate.testing.bytecode.enhancement.extension.BytecodeEnhanced;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.JiraKey;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.junit.jupiter.api.Test;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -21,31 +20,28 @@ import jakarta.persistence.Table;
  * when the entity has the same field defined twice: once in a mappedsuperclass (should be ignored)
  * and once in the concrete entity class.
  */
-@TestForIssue(jiraKey = "HHH-15505")
-@RunWith(BytecodeEnhancerRunner.class)
-public class OverriddenFieldTest extends BaseCoreFunctionalTestCase {
-
-	@Override
-	public Class<?>[] getAnnotatedClasses() {
-		return new Class<?>[] { AbstractEntity.class, Fruit.class };
-	}
-
-	@Before
-	public void prepare() {
-	}
+@JiraKey("HHH-15505")
+@DomainModel(
+		annotatedClasses = {
+				OverriddenFieldTest.AbstractEntity.class, OverriddenFieldTest.Fruit.class
+		}
+)
+@SessionFactory
+@BytecodeEnhanced
+public class OverriddenFieldTest {
 
 	@Test
-	public void test() {
-		doInHibernate( this::sessionFactory, s -> {
+	public void test(SessionFactoryScope scope) {
+		scope.inTransaction( s -> {
 			Fruit testEntity = new Fruit();
 			testEntity.setId( 1 );
 			testEntity.setName( "John" );
 			s.persist( testEntity );
 		} );
 
-		doInHibernate( this::sessionFactory, s -> {
+		scope.inTransaction( s -> {
 			Fruit testEntity = s.get( Fruit.class, 1 );
-			Assert.assertEquals( "John", testEntity.getName() );
+			assertEquals( "John", testEntity.getName() );
 		} );
 	}
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/batch/BatchEntityOneToManyWithDisabledProxyTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/batch/BatchEntityOneToManyWithDisabledProxyTest.java
@@ -9,15 +9,17 @@ import org.hibernate.annotations.Fetch;
 import org.hibernate.annotations.FetchMode;
 import org.hibernate.annotations.Proxy;
 import org.hibernate.cfg.AvailableSettings;
-import org.hibernate.cfg.Configuration;
 
-import org.hibernate.testing.bytecode.enhancement.BytecodeEnhancerRunner;
-import org.hibernate.testing.junit4.BaseCoreFunctionalTestCase;
+import org.hibernate.testing.bytecode.enhancement.extension.BytecodeEnhanced;
+import org.hibernate.testing.orm.junit.DomainModel;
 import org.hibernate.testing.orm.junit.JiraKey;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.hibernate.testing.orm.junit.ServiceRegistry;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.hibernate.testing.orm.junit.Setting;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import jakarta.persistence.Cacheable;
 import jakarta.persistence.Entity;
@@ -33,21 +35,22 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @JiraKey("HHH-16890")
-@RunWith(BytecodeEnhancerRunner.class)
-public class BatchEntityOneToManyWithDisabledProxyTest extends BaseCoreFunctionalTestCase {
+@DomainModel(
+		annotatedClasses = {
+				BatchEntityOneToManyWithDisabledProxyTest.Order.class, BatchEntityOneToManyWithDisabledProxyTest.Product.class
+		}
+)
+@ServiceRegistry(
+		settings = {
+				@Setting( name = AvailableSettings.USE_SECOND_LEVEL_CACHE, value = "true" ),
+		}
+)
+@SessionFactory
+@BytecodeEnhanced
+public class BatchEntityOneToManyWithDisabledProxyTest {
 
-	@Override
-	protected Class<?>[] getAnnotatedClasses() {
-		return new Class[] { Order.class, Product.class };
-	}
-
-	@Override
-	protected void configure(Configuration configuration) {
-		configuration.setProperty( AvailableSettings.USE_SECOND_LEVEL_CACHE, true );
-	}
-
-	@Before
-	public void setupData() {
+	@BeforeEach
+	public void setupData(SessionFactoryScope scope) {
 		Product cheese1 = new Product( 1l, "Cheese 1" );
 		Product cheese2 = new Product( 2l, "Cheese 2" );
 		Product cheese3 = new Product( 3l, "Cheese 3" );
@@ -57,7 +60,7 @@ public class BatchEntityOneToManyWithDisabledProxyTest extends BaseCoreFunctiona
 		order.addProduct( cheese1 );
 		order.addProduct( cheese2 );
 
-		inTransaction( s -> {
+		scope.inTransaction( s -> {
 			s.persist( cheese1 );
 			s.persist( cheese2 );
 			s.persist( cheese3 );
@@ -65,9 +68,9 @@ public class BatchEntityOneToManyWithDisabledProxyTest extends BaseCoreFunctiona
 		} );
 	}
 
-	@After
-	public void tearDown() {
-		inTransaction(
+	@AfterEach
+	public void tearDown(SessionFactoryScope scope) {
+		scope.inTransaction(
 				session -> {
 					session.createMutationQuery( "delete from Order" ).executeUpdate();
 					session.createMutationQuery( "delete from Product" ).executeUpdate();
@@ -76,8 +79,8 @@ public class BatchEntityOneToManyWithDisabledProxyTest extends BaseCoreFunctiona
 	}
 
 	@Test
-	public void testGetOrder() {
-		inSession( s -> {
+	public void testGetOrder(SessionFactoryScope scope) {
+		scope.inSession( s -> {
 			s.getSessionFactory().getCache().evictAllRegions();
 
 			Order o = s.get( Order.class, 1 );
@@ -89,8 +92,8 @@ public class BatchEntityOneToManyWithDisabledProxyTest extends BaseCoreFunctiona
 
 
 	@Test
-	public void testGetProduct() {
-		inSession( s -> {
+	public void testGetProduct(SessionFactoryScope scope) {
+		scope.inSession( s -> {
 			s.getSessionFactory().getCache().evictAllRegions();
 			Product product = s.getReference( Product.class, 3l );
 
@@ -102,8 +105,8 @@ public class BatchEntityOneToManyWithDisabledProxyTest extends BaseCoreFunctiona
 	}
 
 	@Test
-	public void testCriteriaQuery() {
-		inSession( s -> {
+	public void testCriteriaQuery(SessionFactoryScope scope) {
+		scope.inSession( s -> {
 			s.getSessionFactory().getCache().evictAllRegions();
 
 			CriteriaBuilder cb = s.getCriteriaBuilder();

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/batch/BatchEntityWithSelectFetchWithDisableProxyTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/batch/BatchEntityWithSelectFetchWithDisableProxyTest.java
@@ -8,15 +8,17 @@ import org.hibernate.annotations.Fetch;
 import org.hibernate.annotations.FetchMode;
 import org.hibernate.annotations.Proxy;
 import org.hibernate.cfg.AvailableSettings;
-import org.hibernate.cfg.Configuration;
 
-import org.hibernate.testing.bytecode.enhancement.BytecodeEnhancerRunner;
-import org.hibernate.testing.junit4.BaseCoreFunctionalTestCase;
+import org.hibernate.testing.bytecode.enhancement.extension.BytecodeEnhanced;
+import org.hibernate.testing.orm.junit.DomainModel;
 import org.hibernate.testing.orm.junit.JiraKey;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.hibernate.testing.orm.junit.ServiceRegistry;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.hibernate.testing.orm.junit.Setting;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import jakarta.persistence.Cacheable;
 import jakarta.persistence.Entity;
@@ -34,24 +36,23 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @JiraKey("HHH-16890")
-@RunWith( BytecodeEnhancerRunner.class )
-public class BatchEntityWithSelectFetchWithDisableProxyTest extends BaseCoreFunctionalTestCase {
+@DomainModel(
+		annotatedClasses = {
+				BatchEntityWithSelectFetchWithDisableProxyTest.Order.class,
+				BatchEntityWithSelectFetchWithDisableProxyTest.Product.class
+		}
+)
+@ServiceRegistry(
+		settings = {
+				@Setting( name = AvailableSettings.USE_SECOND_LEVEL_CACHE, value = "true" ),
+		}
+)
+@SessionFactory
+@BytecodeEnhanced
+public class BatchEntityWithSelectFetchWithDisableProxyTest {
 
-	@Override
-	protected Class<?>[] getAnnotatedClasses() {
-		return new Class[] {
-				Order.class,
-				Product.class
-		};
-	}
-
-	@Override
-	protected void configure(Configuration configuration) {
-		configuration.setProperty( AvailableSettings.USE_SECOND_LEVEL_CACHE, true );
-	}
-
-	@Before
-	public void setupData() {
+	@BeforeEach
+	public void setupData(SessionFactoryScope scope) {
 		Product cheese1 = new Product( 1l, "Cheese 1" );
 		Product cheese2 = new Product( 2l, "Cheese 2" );
 		Product cheese3 = new Product( 3l, "Cheese 3" );
@@ -62,7 +63,7 @@ public class BatchEntityWithSelectFetchWithDisableProxyTest extends BaseCoreFunc
 		order.setProduct( cheese2 );
 		order2.setProduct( cheese1 );
 
-		inTransaction( s -> {
+		scope.inTransaction( s -> {
 			s.persist( cheese1 );
 			s.persist( cheese2 );
 			s.persist( cheese3 );
@@ -71,9 +72,9 @@ public class BatchEntityWithSelectFetchWithDisableProxyTest extends BaseCoreFunc
 		} );
 	}
 
-	@After
-	public void tearDown(){
-		inTransaction(
+	@AfterEach
+	public void tearDown(SessionFactoryScope scope){
+		scope.inTransaction(
 				session -> {
 					session.createMutationQuery( "delete from Order" ).executeUpdate();
 					session.createMutationQuery( "delete from Product" ).executeUpdate();
@@ -82,8 +83,8 @@ public class BatchEntityWithSelectFetchWithDisableProxyTest extends BaseCoreFunc
 	}
 
 	@Test
-	public void testGetOrder() {
-		inSession( s -> {
+	public void testGetOrder(SessionFactoryScope scope) {
+		scope.inSession( s -> {
 			s.getSessionFactory().getCache().evictAllRegions();
 
 			Product product1 = s.getReference( Product.class, 1l );
@@ -97,8 +98,8 @@ public class BatchEntityWithSelectFetchWithDisableProxyTest extends BaseCoreFunc
 	}
 
 	@Test
-	public void testGetOrder2() {
-		inSession( s -> {
+	public void testGetOrder2(SessionFactoryScope scope) {
+		scope.inSession( s -> {
 			s.getSessionFactory().getCache().evictAllRegions();
 
 			Product product = s.getReference( Product.class, 2l );
@@ -111,8 +112,8 @@ public class BatchEntityWithSelectFetchWithDisableProxyTest extends BaseCoreFunc
 	}
 
 	@Test
-	public void testGetProduct() {
-		inSession( s -> {
+	public void testGetProduct(SessionFactoryScope scope) {
+		scope.inSession( s -> {
 			s.getSessionFactory().getCache().evictAllRegions();
 
 			Product product3 = s.getReference( Product.class, 3l );
@@ -126,8 +127,8 @@ public class BatchEntityWithSelectFetchWithDisableProxyTest extends BaseCoreFunc
 	}
 
 	@Test
-	public void testCriteriaQuery() {
-		inSession( s -> {
+	public void testCriteriaQuery(SessionFactoryScope scope) {
+		scope.inSession( s -> {
 			s.getSessionFactory().getCache().evictAllRegions();
 
 			Product product1 = s.getReference( Product.class, 1l );

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/cache/ManyToOneNoProxyTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/cache/ManyToOneNoProxyTest.java
@@ -7,14 +7,16 @@ import org.hibernate.annotations.Fetch;
 import org.hibernate.annotations.FetchMode;
 import org.hibernate.annotations.Proxy;
 import org.hibernate.cfg.AvailableSettings;
-import org.hibernate.cfg.Configuration;
 
-import org.hibernate.testing.bytecode.enhancement.BytecodeEnhancerRunner;
-import org.hibernate.testing.junit4.BaseCoreFunctionalTestCase;
+import org.hibernate.testing.bytecode.enhancement.extension.BytecodeEnhanced;
+import org.hibernate.testing.orm.junit.DomainModel;
 import org.hibernate.testing.orm.junit.JiraKey;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.hibernate.testing.orm.junit.ServiceRegistry;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.hibernate.testing.orm.junit.Setting;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import jakarta.persistence.Cacheable;
 import jakarta.persistence.DiscriminatorColumn;
@@ -33,31 +35,31 @@ import jakarta.persistence.Table;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
 
-@RunWith(BytecodeEnhancerRunner.class)
 @JiraKey("HHH-16473")
-public class ManyToOneNoProxyTest extends BaseCoreFunctionalTestCase {
+@DomainModel(
+		annotatedClasses = {
+			ManyToOneNoProxyTest.Actor.class,
+				ManyToOneNoProxyTest.User.class,
+				ManyToOneNoProxyTest.UserGroup.class,
+				ManyToOneNoProxyTest.ActorGroup.class
+		}
+)
+@ServiceRegistry(
+		settings = {
+				@Setting( name = AvailableSettings.USE_SECOND_LEVEL_CACHE, value = "true" ),
+		}
+)
+@SessionFactory
+@BytecodeEnhanced
+public class ManyToOneNoProxyTest {
 
 	private static final String ENTITY_A_NAME = "Alice";
 	private static final String ENTITY_B_NAME = "Bob";
 
-	@Override
-	protected Class<?>[] getAnnotatedClasses() {
-		return new Class[] {
-				Actor.class,
-				User.class,
-				UserGroup.class,
-				ActorGroup.class
-		};
-	}
 
-	@Override
-	protected void configure(Configuration configuration) {
-		configuration.setProperty( AvailableSettings.USE_SECOND_LEVEL_CACHE, true );
-	}
-
-	@Before
-	public void setUp() {
-		inTransaction(
+	@BeforeEach
+	public void setUp(SessionFactoryScope scope) {
+		scope.inTransaction(
 				session -> {
 
 					User user1 = new User();
@@ -87,7 +89,7 @@ public class ManyToOneNoProxyTest extends BaseCoreFunctionalTestCase {
 				}
 		);
 
-		inTransaction(
+		scope.inTransaction(
 				session -> {
 					session.getSessionFactory().getCache().evictAllRegions();
 				}
@@ -95,8 +97,8 @@ public class ManyToOneNoProxyTest extends BaseCoreFunctionalTestCase {
 	}
 
 	@Test
-	public void testSelect() {
-		inTransaction(
+	public void testSelect(SessionFactoryScope scope) {
+		scope.inTransaction(
 				session -> {
 					User user = session.getReference( User.class, 1 );
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/cache/ManyToOneTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/cache/ManyToOneTest.java
@@ -6,14 +6,16 @@ import org.hibernate.annotations.BatchSize;
 import org.hibernate.annotations.Cache;
 import org.hibernate.annotations.CacheConcurrencyStrategy;
 import org.hibernate.cfg.AvailableSettings;
-import org.hibernate.cfg.Configuration;
 
-import org.hibernate.testing.TestForIssue;
-import org.hibernate.testing.bytecode.enhancement.BytecodeEnhancerRunner;
-import org.hibernate.testing.junit4.BaseCoreFunctionalTestCase;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.hibernate.testing.bytecode.enhancement.extension.BytecodeEnhanced;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.JiraKey;
+import org.hibernate.testing.orm.junit.ServiceRegistry;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.hibernate.testing.orm.junit.Setting;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import jakarta.persistence.Cacheable;
 import jakarta.persistence.Entity;
@@ -26,28 +28,27 @@ import jakarta.persistence.NamedQuery;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
 
-@RunWith(BytecodeEnhancerRunner.class)
-@TestForIssue( jiraKey = "HHH-16193")
-public class ManyToOneTest extends BaseCoreFunctionalTestCase {
+@JiraKey("HHH-16193")
+@DomainModel(
+		annotatedClasses = {
+				ManyToOneTest.EntityA.class,
+				ManyToOneTest.EntityB.class
+		}
+)
+@ServiceRegistry(
+		settings = {
+				@Setting( name = AvailableSettings.USE_SECOND_LEVEL_CACHE, value = "true" ),
+		}
+)
+@SessionFactory
+@BytecodeEnhanced
+public class ManyToOneTest {
 
 	private static final String ENTITY_B_NAME = "B1";
 
-	@Override
-	protected Class<?>[] getAnnotatedClasses() {
-		return new Class[] {
-				EntityA.class,
-				EntityB.class
-		};
-	}
-
-	@Override
-	protected void configure(Configuration configuration) {
-		configuration.setProperty( AvailableSettings.USE_SECOND_LEVEL_CACHE, true );
-	}
-
-	@Before
-	public void setUp() {
-		inTransaction(
+	@BeforeEach
+	public void setUp(SessionFactoryScope scope) {
+		scope.inTransaction(
 				session -> {
 					EntityB b1 = new EntityB( ENTITY_B_NAME );
 					session.persist( b1 );
@@ -58,8 +59,8 @@ public class ManyToOneTest extends BaseCoreFunctionalTestCase {
 	}
 
 	@Test
-	public void testSelect() {
-		List<EntityA> entities = fromTransaction(
+	public void testSelect(SessionFactoryScope scope) {
+		List<EntityA> entities = scope.fromTransaction(
 				session ->
 						session.createNamedQuery( "PersonType.selectAll", EntityA.class )
 								.getResultList()

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/callbacks/PostLoadLazyListenerTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/callbacks/PostLoadLazyListenerTest.java
@@ -9,12 +9,13 @@ package org.hibernate.orm.test.bytecode.enhancement.callbacks;
 import java.util.ArrayList;
 import java.util.Collection;
 
-import org.hibernate.testing.bytecode.enhancement.BytecodeEnhancerRunner;
-import org.hibernate.testing.junit4.BaseCoreFunctionalTestCase;
+import org.hibernate.testing.bytecode.enhancement.extension.BytecodeEnhanced;
+import org.hibernate.testing.orm.junit.DomainModel;
 import org.hibernate.testing.orm.junit.JiraKey;
-import org.junit.After;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 
 import jakarta.persistence.Entity;
 import jakarta.persistence.EntityListeners;
@@ -27,17 +28,18 @@ import jakarta.persistence.PostLoad;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @JiraKey("HHH-17019")
-@RunWith(BytecodeEnhancerRunner.class)
-public class PostLoadLazyListenerTest extends BaseCoreFunctionalTestCase {
+@DomainModel(
+		annotatedClasses = {
+				PostLoadLazyListenerTest.Person.class, PostLoadLazyListenerTest.Tag.class
+		}
+)
+@SessionFactory
+@BytecodeEnhanced
+public class PostLoadLazyListenerTest {
 
-	@Override
-	protected Class<?>[] getAnnotatedClasses() {
-		return new Class[] { Person.class, Tag.class };
-	}
-
-	@After
-	public void tearDown() {
-		inTransaction( session -> {
+	@AfterEach
+	public void tearDown(SessionFactoryScope scope) {
+		scope.inTransaction( session -> {
 						   session.createQuery( "delete from Tag" ).executeUpdate();
 						   session.createQuery( "delete from Person" ).executeUpdate();
 					   }
@@ -45,8 +47,8 @@ public class PostLoadLazyListenerTest extends BaseCoreFunctionalTestCase {
 	}
 
 	@Test
-	public void smoke() {
-		inTransaction(
+	public void smoke(SessionFactoryScope scope) {
+		scope.inTransaction(
 				session -> {
 					Person person = new Person( 1, "name" );
 					Tag tag = new Tag( 100, person );
@@ -57,7 +59,7 @@ public class PostLoadLazyListenerTest extends BaseCoreFunctionalTestCase {
 				}
 		);
 
-		inTransaction(
+		scope.inTransaction(
 				session -> {
 					Tag tag = session.find( Tag.class, 100 );
 					assertThat( tag )

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/cascade/CascadeDetachedTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/cascade/CascadeDetachedTest.java
@@ -6,11 +6,12 @@
  */
 package org.hibernate.orm.test.bytecode.enhancement.cascade;
 
-import org.hibernate.testing.TestForIssue;
-import org.hibernate.testing.bytecode.enhancement.BytecodeEnhancerRunner;
-import org.hibernate.testing.junit4.BaseCoreFunctionalTestCase;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.hibernate.testing.bytecode.enhancement.extension.BytecodeEnhanced;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.JiraKey;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.junit.jupiter.api.Test;
 
 import jakarta.persistence.Basic;
 import jakarta.persistence.CascadeType;
@@ -26,32 +27,31 @@ import jakarta.persistence.Table;
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.hibernate.testing.transaction.TransactionUtil.doInJPA;
-
 /**
  * @author Luis Barreiro
  */
-@TestForIssue( jiraKey = "HHH-10254" )
-@RunWith( BytecodeEnhancerRunner.class )
-public class CascadeDetachedTest extends BaseCoreFunctionalTestCase {
-
-    @Override
-    protected Class<?>[] getAnnotatedClasses() {
-        return new Class[]{Author.class, Book.class};
-    }
+@JiraKey( "HHH-10254" )
+@DomainModel(
+        annotatedClasses = {
+             CascadeDetachedTest.Author.class, CascadeDetachedTest.Book.class
+        }
+)
+@SessionFactory
+@BytecodeEnhanced
+public class CascadeDetachedTest {
 
     @Test
-    public void test() {
+    public void test(SessionFactoryScope scope) {
         Book book = new Book( "978-1118063330", "Operating System Concepts 9th Edition" );
         book.addAuthor( new Author( "Abraham", "Silberschatz", new char[] { 'a', 'b' } ) );
         book.addAuthor( new Author( "Peter", "Galvin", new char[] { 'c', 'd' }  ) );
         book.addAuthor( new Author( "Greg", "Gagne", new char[] { 'e', 'f' }  ) );
 
-        doInJPA( this::sessionFactory, em -> {
+        scope.inTransaction( em -> {
                     em.persist( book );
         } );
 
-        doInJPA( this::sessionFactory, em -> {
+        scope.inTransaction( em -> {
             em.merge( book );
         } );
     }

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/cascade/CascadeOnUninitializedTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/cascade/CascadeOnUninitializedTest.java
@@ -1,7 +1,6 @@
 package org.hibernate.orm.test.bytecode.enhancement.cascade;
 
 import java.util.HashSet;
-import java.util.Map;
 import java.util.Set;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
@@ -20,120 +19,133 @@ import org.hibernate.annotations.LazyToOneOption;
 import org.hibernate.cfg.AvailableSettings;
 import org.hibernate.proxy.HibernateProxy;
 
-import org.hibernate.testing.TestForIssue;
-import org.hibernate.testing.bytecode.enhancement.BytecodeEnhancerRunner;
-import org.hibernate.testing.jdbc.SQLStatementInterceptor;
-import org.hibernate.testing.junit4.BaseNonConfigCoreFunctionalTestCase;
-import org.hibernate.testing.transaction.TransactionUtil;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.hibernate.testing.bytecode.enhancement.extension.BytecodeEnhanced;
+import org.hibernate.testing.jdbc.SQLStatementInspector;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.JiraKey;
+import org.hibernate.testing.orm.junit.ServiceRegistry;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.hibernate.testing.orm.junit.Setting;
+import org.junit.jupiter.api.Test;
 
-import static junit.framework.TestCase.assertEquals;
-import static org.hamcrest.CoreMatchers.instanceOf;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.not;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hibernate.testing.jdbc.SQLStatementInspector.extractFromSession;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * @author Bolek Ziobrowski
  * @author Gail Badner
  */
-@RunWith(BytecodeEnhancerRunner.class)
-@TestForIssue(jiraKey = "HHH-13129")
-public class CascadeOnUninitializedTest extends BaseNonConfigCoreFunctionalTestCase {
-	private SQLStatementInterceptor sqlInterceptor;
-
-	@Override
-	protected Class<?>[] getAnnotatedClasses() {
-		return new Class<?>[] { Person.class, Address.class };
-	}
-
-	@Override
-	protected void addSettings(Map<String,Object> settings) {
-		super.addSettings( settings );
-		settings.put( AvailableSettings.FORMAT_SQL, "true" );
-		sqlInterceptor = new SQLStatementInterceptor( settings );
-	}
+@JiraKey("HHH-13129")
+@DomainModel(
+		annotatedClasses = {
+			CascadeOnUninitializedTest.Person.class, CascadeOnUninitializedTest.Address.class
+		}
+)
+@ServiceRegistry(
+		settings = {
+				@Setting( name = AvailableSettings.FORMAT_SQL, value = "true" ),
+		}
+)
+@SessionFactory
+@BytecodeEnhanced
+public class CascadeOnUninitializedTest {
 
 	@Test
-	public void testMergeDetachedEnhancedEntityWithUninitializedManyToOne() {
-		final Person person = persistPersonWithManyToOne();
-
-		sqlInterceptor.clear();
+	public void testMergeDetachedEnhancedEntityWithUninitializedManyToOne(SessionFactoryScope scope) {
+		final Person person = persistPersonWithManyToOne(scope);
 
 		// get a detached Person
-		final Person detachedPerson = fromTransaction(
-				session -> session.get( Person.class, person.getId() )
+		final Person detachedPerson = scope.fromTransaction(
+				session -> {
+					final SQLStatementInspector statementInspector = extractFromSession( session );
+					statementInspector.clear();
+					Person p = session.get( Person.class, person.getId() );
+					// loading Person should lead to one SQL
+					statementInspector.assertExecutedCount( 1 );
+					return p;
+				}
 		);
-
-		// loading Person should lead to one SQL
-		assertThat( sqlInterceptor.getQueryCount(), is( 1 ) );
 
 		// primaryAddress should be "initialized" as an enhanced-proxy
 		assertTrue( Hibernate.isPropertyInitialized( detachedPerson, "primaryAddress" ) );
-		assertThat( detachedPerson.getPrimaryAddress(), not( instanceOf( HibernateProxy.class ) ) );
+		assertThat( detachedPerson.getPrimaryAddress() ).isNotInstanceOf( HibernateProxy.class );
 		assertFalse( Hibernate.isInitialized( detachedPerson.getPrimaryAddress() ) );
 
 		// alter the detached reference
 		detachedPerson.setName( "newName" );
 
-		final Person mergedPerson = fromTransaction(
-				session -> (Person) session.merge( detachedPerson )
+		final Person mergedPerson = scope.fromTransaction(
+				session -> {
+					final SQLStatementInspector statementInspector = extractFromSession( session );
+					statementInspector.clear();
+					Person merge = session.merge( detachedPerson );
+
+					// 1) select Person#addresses
+					// 2) select Person#primaryAddress
+					// 3) update Person
+					session.flush();
+					statementInspector.assertExecutedCount( 2 );
+					return merge;
+				}
 		);
-
-		// 1) select Person#addresses
-		// 2) select Person#primaryAddress
-		// 3) update Person
-
-		assertThat( sqlInterceptor.getQueryCount(), is( 3 ) );
 
 		// primaryAddress should not be initialized
 		assertTrue( Hibernate.isPropertyInitialized( detachedPerson, "primaryAddress" ) );
-		assertThat( detachedPerson.getPrimaryAddress(), not( instanceOf( HibernateProxy.class ) ) );
+		assertThat( detachedPerson.getPrimaryAddress() ).isNotInstanceOf( HibernateProxy.class );
 		assertFalse( Hibernate.isInitialized( detachedPerson.getPrimaryAddress() ) );
 
 		assertEquals( "newName", mergedPerson.getName() );
 	}
 
 	@Test
-	public void testDeleteEnhancedEntityWithUninitializedManyToOne() {
-		Person person = persistPersonWithManyToOne();
-
-		sqlInterceptor.clear();
+	public void testDeleteEnhancedEntityWithUninitializedManyToOne(SessionFactoryScope scope) {
+		Person person = persistPersonWithManyToOne(scope);
 
 		// get a detached Person
-		Person detachedPerson = fromTransaction(
-				session -> session.get( Person.class, person.getId() )
-		);
+		Person detachedPerson = scope.fromTransaction(
+				session -> {
+					final SQLStatementInspector statementInspector = extractFromSession( session );
+					statementInspector.clear();
 
-		// loading Person should lead to one SQL
-		assertThat( sqlInterceptor.getQueryCount(), is( 1 ) );
+					Person p = session.get( Person.class, person.getId() );
+
+					// loading Person should lead to one SQL
+					statementInspector.assertExecutedCount( 1 );
+
+					return p;
+				}
+		);
 
 		// primaryAddress should be initialized as an enhance-proxy
 		assertTrue( Hibernate.isPropertyInitialized( detachedPerson, "primaryAddress" ) );
-		assertThat( detachedPerson, not( instanceOf( HibernateProxy.class ) ) );
+		assertThat( detachedPerson ).isNotInstanceOf( HibernateProxy.class );
 		assertFalse( Hibernate.isInitialized( detachedPerson.getPrimaryAddress() ) );
-
-		sqlInterceptor.clear();
 
 		// deleting detachedPerson should result in detachedPerson.primaryAddress being initialized,
 		// so that the DELETE operation can be cascaded to it.
-		inTransaction(
-				session -> session.delete( detachedPerson )
+		scope.inTransaction(
+				session -> {
+					final SQLStatementInspector statementInspector = extractFromSession( session );
+					statementInspector.clear();
+
+					session.delete( detachedPerson );
+
+					// 1) select Person#addresses
+					// 2) select Person#primaryAddress
+					// 3) delete Person
+					// 4) select primary Address
+					session.flush();
+					statementInspector.assertExecutedCount( 4 );
+				}
 		);
 
-		// 1) select Person#addresses
-		// 2) select Person#primaryAddress
-		// 3) delete Person
-		// 4) select primary Address
-
-		assertThat( sqlInterceptor.getQueryCount(), is( 4 ) );
-
 		// both the Person and its Address should be deleted
-		inTransaction(
+		scope.inTransaction(
 				session -> {
 					assertNull( session.get( Person.class, person.getId() ) );
 					assertNull( session.get( Person.class, person.getPrimaryAddress().getId() ) );
@@ -142,26 +154,18 @@ public class CascadeOnUninitializedTest extends BaseNonConfigCoreFunctionalTestC
 	}
 
 	@Test
-	public void testMergeDetachedEnhancedEntityWithUninitializedOneToMany() {
+	public void testMergeDetachedEnhancedEntityWithUninitializedOneToMany(SessionFactoryScope scope) {
 
-		Person person = persistPersonWithOneToMany();
+		Person person = persistPersonWithOneToMany( scope );
 
 		// get a detached Person
-		Person detachedPerson = TransactionUtil.doInHibernate(
-				this::sessionFactory, session -> {
-					return session.get( Person.class, person.getId() );
-				}
-		);
+		Person detachedPerson = scope.fromTransaction( session -> session.get( Person.class, person.getId() ) );
 
 		// address should not be initialized in order to reproduce the problem
 		assertFalse( Hibernate.isInitialized( detachedPerson.getAddresses() ) );
 		detachedPerson.setName( "newName" );
 
-		Person mergedPerson = TransactionUtil.doInHibernate(
-				this::sessionFactory, session -> {
-					return (Person) session.merge( detachedPerson );
-				}
-		);
+		Person mergedPerson = scope.fromTransaction( session -> session.merge( detachedPerson ) );
 
 		// address still shouldn't be initialized: there's no reason for it to be initialized by a merge.
 		assertFalse( Hibernate.isInitialized( detachedPerson.getAddresses() ) );
@@ -169,37 +173,28 @@ public class CascadeOnUninitializedTest extends BaseNonConfigCoreFunctionalTestC
 	}
 
 	@Test
-	public void testDeleteEnhancedEntityWithUninitializedOneToMany() {
-		Person person = persistPersonWithOneToMany();
+	public void testDeleteEnhancedEntityWithUninitializedOneToMany(SessionFactoryScope scope) {
+		Person person = persistPersonWithOneToMany( scope );
 
 		// get a detached Person
-		Person detachedPerson = TransactionUtil.doInHibernate(
-				this::sessionFactory, session -> {
-					return session.get( Person.class, person.getId() );
-				}
-		);
+		Person detachedPerson = scope.fromTransaction( session -> session.get( Person.class, person.getId() ) );
 
 		// address should not be initialized in order to reproduce the problem
 		assertFalse( Hibernate.isInitialized( detachedPerson.getAddresses() ) );
 
 		// deleting detachedPerson should result in detachedPerson.address being initialized,
 		// so that the DELETE operation can be cascaded to it.
-		TransactionUtil.doInHibernate(
-				this::sessionFactory, session -> {
-					session.delete( detachedPerson );
-				}
-		);
+		scope.inTransaction( session -> session.delete( detachedPerson ) );
 
 		// both the Person and its Address should be deleted
-		TransactionUtil.doInHibernate(
-				this::sessionFactory, session -> {
+		scope.inTransaction( session -> {
 					assertNull( session.get( Person.class, person.getId() ) );
 					assertNull( session.get( Person.class, person.getAddresses().iterator().next().getId() ) );
 				}
 		);
 	}
 
-	public Person persistPersonWithManyToOne() {
+	public Person persistPersonWithManyToOne(SessionFactoryScope scope) {
 		Address address = new Address();
 		address.setDescription( "ABC" );
 
@@ -207,16 +202,12 @@ public class CascadeOnUninitializedTest extends BaseNonConfigCoreFunctionalTestC
 		person.setName( "John Doe" );
 		person.setPrimaryAddress( address );
 
-		TransactionUtil.doInHibernate(
-				this::sessionFactory, session -> {
-					session.persist( person );
-				}
-		);
+		scope.inTransaction( session -> session.persist( person ) );
 
 		return person;
 	}
 
-	public Person persistPersonWithOneToMany() {
+	public Person persistPersonWithOneToMany(SessionFactoryScope scope) {
 		Address address = new Address();
 		address.setDescription( "ABC" );
 
@@ -224,11 +215,7 @@ public class CascadeOnUninitializedTest extends BaseNonConfigCoreFunctionalTestC
 		person.setName( "John Doe" );
 		person.getAddresses().add( address );
 
-		TransactionUtil.doInHibernate(
-				this::sessionFactory, session -> {
-					session.persist( person );
-				}
-		);
+		scope.inTransaction( session -> session.persist( person ) );
 
 		return person;
 	}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/cascade/CascadeOnUninitializedWithCollectionInDefaultFetchGroupFalseTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/cascade/CascadeOnUninitializedWithCollectionInDefaultFetchGroupFalseTest.java
@@ -1,35 +1,31 @@
 package org.hibernate.orm.test.bytecode.enhancement.cascade;
 
-import static junit.framework.TestCase.assertEquals;
-import static org.hamcrest.CoreMatchers.instanceOf;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.not;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hibernate.testing.jdbc.SQLStatementInspector.extractFromSession;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.HashSet;
-import java.util.Map;
 import java.util.Set;
 
 import org.hibernate.Hibernate;
 import org.hibernate.annotations.LazyToOne;
 import org.hibernate.annotations.LazyToOneOption;
-import org.hibernate.boot.internal.SessionFactoryBuilderImpl;
-import org.hibernate.boot.internal.SessionFactoryOptionsBuilder;
-import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
-import org.hibernate.boot.spi.SessionFactoryBuilderService;
 import org.hibernate.cfg.AvailableSettings;
 import org.hibernate.proxy.HibernateProxy;
 
-import org.hibernate.testing.TestForIssue;
-import org.hibernate.testing.bytecode.enhancement.BytecodeEnhancerRunner;
-import org.hibernate.testing.jdbc.SQLStatementInterceptor;
-import org.hibernate.testing.junit4.BaseNonConfigCoreFunctionalTestCase;
-import org.hibernate.testing.transaction.TransactionUtil;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.hibernate.testing.bytecode.enhancement.extension.BytecodeEnhanced;
+import org.hibernate.testing.jdbc.SQLStatementInspector;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.JiraKey;
+import org.hibernate.testing.orm.junit.ServiceRegistry;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.hibernate.testing.orm.junit.Setting;
+
+import org.junit.jupiter.api.Test;
 
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
@@ -51,116 +47,117 @@ import jakarta.persistence.Table;
  * @author Bolek Ziobrowski
  * @author Gail Badner
  */
-@RunWith(BytecodeEnhancerRunner.class)
-@TestForIssue(jiraKey = "HHH-13129")
-public class CascadeOnUninitializedWithCollectionInDefaultFetchGroupFalseTest extends BaseNonConfigCoreFunctionalTestCase {
-	private SQLStatementInterceptor sqlInterceptor;
-
-	@Override
-	protected Class<?>[] getAnnotatedClasses() {
-		return new Class<?>[] { Person.class, Address.class };
-	}
-
-	@Override
-	protected void addSettings(Map<String,Object> settings) {
-		super.addSettings( settings );
-		settings.put( AvailableSettings.FORMAT_SQL, "true" );
-		sqlInterceptor = new SQLStatementInterceptor( settings );
-	}
-
-	@Override
-	protected void configureStandardServiceRegistryBuilder(StandardServiceRegistryBuilder serviceRegistryBuilder) {
-		serviceRegistryBuilder.addService(
-				SessionFactoryBuilderService.class,
-				(SessionFactoryBuilderService) (metadata, bootstrapContext) -> {
-					SessionFactoryOptionsBuilder optionsBuilder = new SessionFactoryOptionsBuilder(
-							metadata.getMetadataBuildingOptions().getServiceRegistry(),
-							bootstrapContext
-					);
-					// We want to test with this setting set to false explicitly,
-					// because another test already takes care of the default.
-					optionsBuilder.enableCollectionInDefaultFetchGroup( false );
-					return new SessionFactoryBuilderImpl( metadata, optionsBuilder, bootstrapContext );
-				}
-		);
-	}
+@JiraKey("HHH-13129")
+@DomainModel(
+		annotatedClasses = {
+			CascadeOnUninitializedWithCollectionInDefaultFetchGroupFalseTest.Person.class, CascadeOnUninitializedWithCollectionInDefaultFetchGroupFalseTest.Address.class
+		}
+)
+@ServiceRegistry(
+		settings = {
+				@Setting( name = AvailableSettings.FORMAT_SQL, value = "true" ),
+		}
+)
+@SessionFactory(
+		// We want to test with this setting set to false explicitly,
+		// because another test already takes care of the default.
+		applyCollectionsInDefaultFetchGroup = false
+)
+@BytecodeEnhanced
+public class CascadeOnUninitializedWithCollectionInDefaultFetchGroupFalseTest {
 
 	@Test
-	public void testMergeDetachedEnhancedEntityWithUninitializedManyToOne() {
-		final Person person = persistPersonWithManyToOne();
-
-		sqlInterceptor.clear();
+	public void testMergeDetachedEnhancedEntityWithUninitializedManyToOne(SessionFactoryScope scope) {
+		final Person person = persistPersonWithManyToOne(scope);
 
 		// get a detached Person
-		final Person detachedPerson = fromTransaction(
-				session -> session.get( Person.class, person.getId() )
-		);
+		final Person detachedPerson = scope.fromTransaction(
+				session -> {
+					final SQLStatementInspector statementInspector = extractFromSession( session );
+					statementInspector.clear();
 
-		// loading Person should lead to one SQL
-		assertThat( sqlInterceptor.getQueryCount(), is( 1 ) );
+					Person p = session.get( Person.class, person.getId() );
+
+					// loading Person should lead to one SQL
+					statementInspector.assertExecutedCount( 1 );
+					return p;
+				}
+		);
 
 		// primaryAddress should be "initialized" as an enhanced-proxy
 		assertTrue( Hibernate.isPropertyInitialized( detachedPerson, "primaryAddress" ) );
-		assertThat( detachedPerson.getPrimaryAddress(), not( instanceOf( HibernateProxy.class ) ) );
+		assertThat( detachedPerson.getPrimaryAddress() ).isNotInstanceOf( HibernateProxy.class );
 		assertFalse( Hibernate.isInitialized( detachedPerson.getPrimaryAddress() ) );
 
 		// alter the detached reference
 		detachedPerson.setName( "newName" );
 
-		final Person mergedPerson = fromTransaction(
-				session -> (Person) session.merge( detachedPerson )
+		final Person mergedPerson = scope.fromTransaction(
+				session -> {
+					final SQLStatementInspector statementInspector = extractFromSession( session );
+					statementInspector.clear();
+					Person merged = session.merge( detachedPerson );
+
+					// 1) select Person#addresses
+					// 2) select Person#primaryAddress
+					// 3) update Person
+					session.flush();
+					statementInspector.assertExecutedCount( 2 );
+					return merged;
+				}
 		);
-
-		// 1) select Person#addresses
-		// 2) select Person#primaryAddress
-		// 3) update Person
-
-		assertThat( sqlInterceptor.getQueryCount(), is( 3 ) );
 
 		// primaryAddress should not be initialized
 		assertTrue( Hibernate.isPropertyInitialized( detachedPerson, "primaryAddress" ) );
-		assertThat( detachedPerson.getPrimaryAddress(), not( instanceOf( HibernateProxy.class ) ) );
+		assertThat( detachedPerson.getPrimaryAddress() ).isNotInstanceOf( HibernateProxy.class );
 		assertFalse( Hibernate.isInitialized( detachedPerson.getPrimaryAddress() ) );
 
 		assertEquals( "newName", mergedPerson.getName() );
 	}
 
 	@Test
-	public void testDeleteEnhancedEntityWithUninitializedManyToOne() {
-		Person person = persistPersonWithManyToOne();
-
-		sqlInterceptor.clear();
+	public void testDeleteEnhancedEntityWithUninitializedManyToOne(SessionFactoryScope scope) {
+		Person person = persistPersonWithManyToOne(scope);
 
 		// get a detached Person
-		Person detachedPerson = fromTransaction(
-				session -> session.get( Person.class, person.getId() )
-		);
+		Person detachedPerson = scope.fromTransaction(
+				session -> {
+					final SQLStatementInspector statementInspector = extractFromSession( session );
+					statementInspector.clear();
+					Person p = session.get( Person.class, person.getId() );
 
-		// loading Person should lead to one SQL
-		assertThat( sqlInterceptor.getQueryCount(), is( 1 ) );
+					// loading Person should lead to one SQL
+					statementInspector.assertExecutedCount( 1 );
+
+					return p;
+				}
+		);
 
 		// primaryAddress should be initialized as an enhance-proxy
 		assertTrue( Hibernate.isPropertyInitialized( detachedPerson, "primaryAddress" ) );
-		assertThat( detachedPerson, not( instanceOf( HibernateProxy.class ) ) );
+		assertThat( detachedPerson ).isNotInstanceOf( HibernateProxy.class );
 		assertFalse( Hibernate.isInitialized( detachedPerson.getPrimaryAddress() ) );
-
-		sqlInterceptor.clear();
 
 		// deleting detachedPerson should result in detachedPerson.primaryAddress being initialized,
 		// so that the DELETE operation can be cascaded to it.
-		inTransaction(
-				session -> session.delete( detachedPerson )
+		scope.inTransaction(
+				session -> {
+					final SQLStatementInspector statementInspector = extractFromSession( session );
+					statementInspector.clear();
+
+					session.delete( detachedPerson );
+
+					// 1) select Person#addresses
+					// 2) select Person#primaryAddress
+					// 3) delete Person
+					// 4) select primary Address
+					session.flush();
+					statementInspector.assertExecutedCount( 4 );
+				}
 		);
 
-		// 1) select Person#addresses
-		// 2) select Person#primaryAddress
-		// 3) delete Person
-		// 4) select primary Address
-
-		assertThat( sqlInterceptor.getQueryCount(), is( 4 ) );
-
 		// both the Person and its Address should be deleted
-		inTransaction(
+		scope.inTransaction(
 				session -> {
 					assertNull( session.get( Person.class, person.getId() ) );
 					assertNull( session.get( Person.class, person.getPrimaryAddress().getId() ) );
@@ -169,26 +166,18 @@ public class CascadeOnUninitializedWithCollectionInDefaultFetchGroupFalseTest ex
 	}
 
 	@Test
-	public void testMergeDetachedEnhancedEntityWithUninitializedOneToMany() {
+	public void testMergeDetachedEnhancedEntityWithUninitializedOneToMany(SessionFactoryScope scope) {
 
-		Person person = persistPersonWithOneToMany();
+		Person person = persistPersonWithOneToMany(scope);
 
 		// get a detached Person
-		Person detachedPerson = TransactionUtil.doInHibernate(
-				this::sessionFactory, session -> {
-					return session.get( Person.class, person.getId() );
-				}
-		);
+		Person detachedPerson = scope.fromTransaction( session -> session.get( Person.class, person.getId() ) );
 
 		// address should not be initialized
 		assertFalse( Hibernate.isPropertyInitialized( detachedPerson, "addresses" ) );
 		detachedPerson.setName( "newName" );
 
-		Person mergedPerson = TransactionUtil.doInHibernate(
-				this::sessionFactory, session -> {
-					return (Person) session.merge( detachedPerson );
-				}
-		);
+		Person mergedPerson = scope.fromTransaction( session -> session.merge( detachedPerson ) );
 
 		// address should be initialized
 		assertTrue( Hibernate.isPropertyInitialized( mergedPerson, "addresses" ) );
@@ -196,12 +185,11 @@ public class CascadeOnUninitializedWithCollectionInDefaultFetchGroupFalseTest ex
 	}
 
 	@Test
-	public void testDeleteEnhancedEntityWithUninitializedOneToMany() {
-		Person person = persistPersonWithOneToMany();
+	public void testDeleteEnhancedEntityWithUninitializedOneToMany(SessionFactoryScope scope) {
+		Person person = persistPersonWithOneToMany(scope);
 
 		// get a detached Person
-		Person detachedPerson = TransactionUtil.doInHibernate(
-				this::sessionFactory, session -> {
+		Person detachedPerson = scope.fromTransaction( session -> {
 					return session.get( Person.class, person.getId() );
 				}
 		);
@@ -211,22 +199,17 @@ public class CascadeOnUninitializedWithCollectionInDefaultFetchGroupFalseTest ex
 
 		// deleting detachedPerson should result in detachedPerson.address being initialized,
 		// so that the DELETE operation can be cascaded to it.
-		TransactionUtil.doInHibernate(
-				this::sessionFactory, session -> {
-					session.delete( detachedPerson );
-				}
-		);
+		scope.inTransaction( session -> session.delete( detachedPerson ) );
 
 		// both the Person and its Address should be deleted
-		TransactionUtil.doInHibernate(
-				this::sessionFactory, session -> {
+		scope.inTransaction( session -> {
 					assertNull( session.get( Person.class, person.getId() ) );
 					assertNull( session.get( Person.class, person.getAddresses().iterator().next().getId() ) );
 				}
 		);
 	}
 
-	public Person persistPersonWithManyToOne() {
+	public Person persistPersonWithManyToOne(SessionFactoryScope scope) {
 		Address address = new Address();
 		address.setDescription( "ABC" );
 
@@ -234,16 +217,12 @@ public class CascadeOnUninitializedWithCollectionInDefaultFetchGroupFalseTest ex
 		person.setName( "John Doe" );
 		person.setPrimaryAddress( address );
 
-		TransactionUtil.doInHibernate(
-				this::sessionFactory, session -> {
-					session.persist( person );
-				}
-		);
+		scope.inTransaction( session -> session.persist( person ) );
 
 		return person;
 	}
 
-	public Person persistPersonWithOneToMany() {
+	public Person persistPersonWithOneToMany(SessionFactoryScope scope) {
 		Address address = new Address();
 		address.setDescription( "ABC" );
 
@@ -251,11 +230,7 @@ public class CascadeOnUninitializedWithCollectionInDefaultFetchGroupFalseTest ex
 		person.setName( "John Doe" );
 		person.getAddresses().add( address );
 
-		TransactionUtil.doInHibernate(
-				this::sessionFactory, session -> {
-					session.persist( person );
-				}
-		);
+		scope.inTransaction( session -> session.persist( person ) );
 
 		return person;
 	}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/cascade/CascadeWithFkConstraintTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/cascade/CascadeWithFkConstraintTest.java
@@ -6,13 +6,13 @@
  */
 package org.hibernate.orm.test.bytecode.enhancement.cascade;
 
-import org.hibernate.testing.TestForIssue;
-import org.hibernate.testing.bytecode.enhancement.BytecodeEnhancerRunner;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import org.hibernate.testing.bytecode.enhancement.extension.BytecodeEnhanced;
 import org.hibernate.testing.junit4.BaseCoreFunctionalTestCase;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
@@ -22,28 +22,31 @@ import jakarta.persistence.Table;
 import java.util.HashSet;
 import java.util.Set;
 
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.JiraKey;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
 import org.hibernate.testing.util.uuid.SafeRandomUUIDGenerator;
-
-import static org.hibernate.testing.transaction.TransactionUtil.doInJPA;
 
 /**
  * @author Luis Barreiro
  */
-@TestForIssue( jiraKey = "HHH-10252" )
-@RunWith( BytecodeEnhancerRunner.class )
-public class CascadeWithFkConstraintTest extends BaseCoreFunctionalTestCase {
+@JiraKey( "HHH-10252" )
+@DomainModel(
+        annotatedClasses = {
+            CascadeWithFkConstraintTest.Garage.class, CascadeWithFkConstraintTest.Car.class
+        }
+)
+@SessionFactory
+@BytecodeEnhanced
+public class CascadeWithFkConstraintTest  {
 
     private String garageId, car1Id, car2Id;
 
-    @Override
-    public Class<?>[] getAnnotatedClasses() {
-        return new Class<?>[]{Garage.class, Car.class};
-    }
-
-    @Before
-    public void prepare() {
+    @BeforeEach
+    public void prepare(SessionFactoryScope scope) {
         // Create garage, add 2 cars to garage
-        doInJPA( this::sessionFactory, em -> {
+        scope.inTransaction( em -> {
 
             Garage garage = new Garage();
             Car car1 = new Car();
@@ -62,23 +65,23 @@ public class CascadeWithFkConstraintTest extends BaseCoreFunctionalTestCase {
     }
 
     @Test
-    public void test() {
+    public void test(SessionFactoryScope scope) {
         // Remove garage
-        doInJPA( this::sessionFactory, em -> {
+        scope.inTransaction( em -> {
             Garage toRemoveGarage = em.find( Garage.class, garageId );
             em.remove( toRemoveGarage );
         } );
 
         // Check if there is no garage but cars are still present
-        doInJPA( this::sessionFactory, em -> {
+        scope.inTransaction( em -> {
             Garage foundGarage = em.find( Garage.class, garageId );
-            Assert.assertNull( foundGarage );
+            assertNull( foundGarage );
 
             Car foundCar1 = em.find( Car.class, car1Id );
-            Assert.assertEquals( car1Id, foundCar1.id );
+            assertEquals( car1Id, foundCar1.id );
 
             Car foundCar2 = em.find( Car.class, car2Id );
-            Assert.assertEquals( car2Id, foundCar2.id );
+            assertEquals( car2Id, foundCar2.id );
         } );
     }
 
@@ -86,7 +89,7 @@ public class CascadeWithFkConstraintTest extends BaseCoreFunctionalTestCase {
 
     @Entity
     @Table( name = "GARAGE" )
-    private static class Garage {
+    static class Garage {
 
         @Id
         String id;

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/cascade/circle/AbstractMultiPathCircleCascadeTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/cascade/circle/AbstractMultiPathCircleCascadeTest.java
@@ -17,9 +17,10 @@ import org.hibernate.orm.test.cascade.circle.Route;
 import org.hibernate.orm.test.cascade.circle.Tour;
 import org.hibernate.orm.test.cascade.circle.Transport;
 
-import org.hibernate.testing.junit4.BaseCoreFunctionalTestCase;
-import org.junit.After;
-import org.junit.Test;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import jakarta.persistence.PersistenceException;
 
@@ -33,7 +34,7 @@ import static org.junit.Assert.fail;
 /**
  * @author Andrea Boriero
  */
-public abstract class AbstractMultiPathCircleCascadeTest extends BaseCoreFunctionalTestCase {
+public abstract class AbstractMultiPathCircleCascadeTest {
 	private interface EntityOperation {
 		boolean isLegacy();
 
@@ -80,23 +81,23 @@ public abstract class AbstractMultiPathCircleCascadeTest extends BaseCoreFunctio
 			};
 
 	@Test
-	public void testMergeEntityWithNonNullableTransientEntity() {
-		testEntityWithNonNullableTransientEntity( MERGE_OPERATION );
+	public void testMergeEntityWithNonNullableTransientEntity(SessionFactoryScope scope) {
+		testEntityWithNonNullableTransientEntity( scope, MERGE_OPERATION );
 	}
 
 	@Test
-	public void testSaveEntityWithNonNullableTransientEntity() {
-		testEntityWithNonNullableTransientEntity( SAVE_OPERATION );
+	public void testSaveEntityWithNonNullableTransientEntity(SessionFactoryScope scope) {
+		testEntityWithNonNullableTransientEntity( scope, SAVE_OPERATION );
 	}
 
 	@Test
-	public void testSaveUpdateEntityWithNonNullableTransientEntity() {
-		testEntityWithNonNullableTransientEntity( SAVE_UPDATE_OPERATION );
+	public void testSaveUpdateEntityWithNonNullableTransientEntity(SessionFactoryScope scope) {
+		testEntityWithNonNullableTransientEntity( scope, SAVE_UPDATE_OPERATION );
 	}
 
-	private void testEntityWithNonNullableTransientEntity( EntityOperation operation) {
+	private void testEntityWithNonNullableTransientEntity(SessionFactoryScope scope, EntityOperation operation) {
 
-		Route route = getUpdatedDetachedEntity();
+		Route route = getUpdatedDetachedEntity( scope );
 
 		Node node = (Node) route.getNodes().iterator().next();
 		route.getNodes().remove( node );
@@ -106,7 +107,7 @@ public abstract class AbstractMultiPathCircleCascadeTest extends BaseCoreFunctio
 		routeNew.getNodes().add( node );
 		node.setRoute( routeNew );
 
-		inSession(
+		scope.inSession(
 				session -> {
 					session.beginTransaction();
 					try {
@@ -131,28 +132,28 @@ public abstract class AbstractMultiPathCircleCascadeTest extends BaseCoreFunctio
 	}
 
 	@Test
-	public void testMergeEntityWithNonNullableEntityNull() {
-		testEntityWithNonNullableEntityNull( MERGE_OPERATION );
+	public void testMergeEntityWithNonNullableEntityNull(SessionFactoryScope scope) {
+		testEntityWithNonNullableEntityNull( scope, MERGE_OPERATION );
 	}
 
 	@Test
-	public void testSaveEntityWithNonNullableEntityNull() {
-		testEntityWithNonNullableEntityNull( SAVE_OPERATION );
+	public void testSaveEntityWithNonNullableEntityNull(SessionFactoryScope scope) {
+		testEntityWithNonNullableEntityNull( scope, SAVE_OPERATION );
 	}
 
 	@Test
-	public void testSaveUpdateEntityWithNonNullableEntityNull() {
-		testEntityWithNonNullableEntityNull( SAVE_UPDATE_OPERATION );
+	public void testSaveUpdateEntityWithNonNullableEntityNull(SessionFactoryScope scope) {
+		testEntityWithNonNullableEntityNull( scope, SAVE_UPDATE_OPERATION );
 	}
 
-	private void testEntityWithNonNullableEntityNull( EntityOperation operation) {
-		Route route = getUpdatedDetachedEntity();
+	private void testEntityWithNonNullableEntityNull(SessionFactoryScope scope, EntityOperation operation) {
+		Route route = getUpdatedDetachedEntity( scope );
 
 		Node node = (Node) route.getNodes().iterator().next();
 		route.getNodes().remove( node );
 		node.setRoute( null );
 
-		inSession(
+		scope.inSession(
 				session -> {
 					session.beginTransaction();
 					try {
@@ -176,26 +177,26 @@ public abstract class AbstractMultiPathCircleCascadeTest extends BaseCoreFunctio
 	}
 
 	@Test
-	public void testMergeEntityWithNonNullablePropSetToNull() {
-		testEntityWithNonNullablePropSetToNull( MERGE_OPERATION );
+	public void testMergeEntityWithNonNullablePropSetToNull(SessionFactoryScope scope) {
+		testEntityWithNonNullablePropSetToNull( scope, MERGE_OPERATION );
 	}
 
 	@Test
-	public void testSaveEntityWithNonNullablePropSetToNull() {
-		testEntityWithNonNullablePropSetToNull( SAVE_OPERATION );
+	public void testSaveEntityWithNonNullablePropSetToNull(SessionFactoryScope scope) {
+		testEntityWithNonNullablePropSetToNull( scope, SAVE_OPERATION );
 	}
 
 	@Test
-	public void testSaveUpdateEntityWithNonNullablePropSetToNull() {
-		testEntityWithNonNullablePropSetToNull( SAVE_UPDATE_OPERATION );
+	public void testSaveUpdateEntityWithNonNullablePropSetToNull(SessionFactoryScope scope) {
+		testEntityWithNonNullablePropSetToNull( scope, SAVE_UPDATE_OPERATION );
 	}
 
-	private void testEntityWithNonNullablePropSetToNull( EntityOperation operation) {
-		Route route = getUpdatedDetachedEntity();
+	private void testEntityWithNonNullablePropSetToNull(SessionFactoryScope scope, EntityOperation operation) {
+		Route route = getUpdatedDetachedEntity( scope );
 		Node node = (Node) route.getNodes().iterator().next();
 		node.setName( null );
 
-		inSession(
+		scope.inSession(
 				session -> {
 					session.beginTransaction();
 
@@ -221,31 +222,31 @@ public abstract class AbstractMultiPathCircleCascadeTest extends BaseCoreFunctio
 	}
 
 	@Test
-	public void testMergeRoute() {
-		testRoute( MERGE_OPERATION );
+	public void testMergeRoute(SessionFactoryScope scope) {
+		testRoute( MERGE_OPERATION, scope );
 	}
 
 	// skip SAVE_OPERATION since Route is not transient
 	@Test
-	public void testSaveUpdateRoute() {
-		testRoute( SAVE_UPDATE_OPERATION );
+	public void testSaveUpdateRoute(SessionFactoryScope scope) {
+		testRoute( SAVE_UPDATE_OPERATION, scope );
 	}
 
-	private void testRoute( EntityOperation operation) {
+	private void testRoute( EntityOperation operation, SessionFactoryScope scope) {
 
-		Route r = getUpdatedDetachedEntity();
+		Route r = getUpdatedDetachedEntity( scope );
 
-		clearCounts();
+		clearCounts( scope );
 
-		inTransaction(
+		scope.inTransaction(
 				session ->
 						operation.doEntityOperation( r, session )
 		);
 
-		assertInsertCount( 4 );
-		assertUpdateCount( 1 );
+		assertInsertCount( scope, 4 );
+		assertUpdateCount( scope, 1 );
 
-		inTransaction(
+		scope.inTransaction(
 				session -> {
 					Route route = session.get( Route.class, r.getRouteID() );
 					checkResults( route, true );
@@ -254,27 +255,27 @@ public abstract class AbstractMultiPathCircleCascadeTest extends BaseCoreFunctio
 	}
 
 	@Test
-	public void testMergePickupNode() {
-		testPickupNode( MERGE_OPERATION );
+	public void testMergePickupNode(SessionFactoryScope scope) {
+		testPickupNode( scope, MERGE_OPERATION );
 	}
 
 	@Test
-	public void testSavePickupNode() {
-		testPickupNode( SAVE_OPERATION );
+	public void testSavePickupNode(SessionFactoryScope scope) {
+		testPickupNode( scope, SAVE_OPERATION );
 	}
 
 	@Test
-	public void testSaveUpdatePickupNode() {
-		testPickupNode( SAVE_UPDATE_OPERATION );
+	public void testSaveUpdatePickupNode(SessionFactoryScope scope) {
+		testPickupNode( scope, SAVE_UPDATE_OPERATION );
 	}
 
-	private void testPickupNode( EntityOperation operation) {
+	private void testPickupNode(SessionFactoryScope scope, EntityOperation operation) {
 
-		Route r = getUpdatedDetachedEntity();
+		Route r = getUpdatedDetachedEntity( scope );
 
-		clearCounts();
+		clearCounts( scope );
 
-		inTransaction(
+		scope.inTransaction(
 				session -> {
 					Iterator it = r.getNodes().iterator();
 					Node node = (Node) it.next();
@@ -292,10 +293,10 @@ public abstract class AbstractMultiPathCircleCascadeTest extends BaseCoreFunctio
 				}
 		);
 
-		assertInsertCount( 4 );
-		assertUpdateCount( 0 );
+		assertInsertCount( scope, 4 );
+		assertUpdateCount( scope, 0 );
 
-		inTransaction(
+		scope.inTransaction(
 				session -> {
 					Route route = session.get( Route.class, r.getRouteID() );
 					checkResults( route, false );
@@ -304,27 +305,27 @@ public abstract class AbstractMultiPathCircleCascadeTest extends BaseCoreFunctio
 	}
 
 	@Test
-	public void testMergeDeliveryNode() {
-		testDeliveryNode( MERGE_OPERATION );
+	public void testMergeDeliveryNode(SessionFactoryScope scope) {
+		testDeliveryNode( scope, MERGE_OPERATION );
 	}
 
 	@Test
-	public void testSaveDeliveryNode() {
-		testDeliveryNode( SAVE_OPERATION );
+	public void testSaveDeliveryNode(SessionFactoryScope scope) {
+		testDeliveryNode( scope, SAVE_OPERATION );
 	}
 
 	@Test
-	public void testSaveUpdateDeliveryNode() {
-		testDeliveryNode( SAVE_UPDATE_OPERATION );
+	public void testSaveUpdateDeliveryNode(SessionFactoryScope scope) {
+		testDeliveryNode( scope, SAVE_UPDATE_OPERATION );
 	}
 
-	private void testDeliveryNode( EntityOperation operation) {
+	private void testDeliveryNode(SessionFactoryScope scope, EntityOperation operation) {
 
-		Route r = getUpdatedDetachedEntity();
+		Route r = getUpdatedDetachedEntity( scope );
 
-		clearCounts();
+		clearCounts( scope );
 
-		inTransaction(
+		scope.inTransaction(
 				session -> {
 					Iterator it = r.getNodes().iterator();
 					Node node = (Node) it.next();
@@ -343,10 +344,10 @@ public abstract class AbstractMultiPathCircleCascadeTest extends BaseCoreFunctio
 		);
 
 
-		assertInsertCount( 4 );
-		assertUpdateCount( 0 );
+		assertInsertCount( scope, 4 );
+		assertUpdateCount( scope, 0 );
 
-		inTransaction(
+		scope.inTransaction(
 				session -> {
 					Route route = session.get( Route.class, r.getRouteID() );
 					checkResults( route, false );
@@ -355,35 +356,35 @@ public abstract class AbstractMultiPathCircleCascadeTest extends BaseCoreFunctio
 	}
 
 	@Test
-	public void testMergeTour() {
-		testTour( MERGE_OPERATION );
+	public void testMergeTour(SessionFactoryScope scope) {
+		testTour( scope, MERGE_OPERATION );
 	}
 
 	@Test
-	public void testSaveTour() {
-		testTour( SAVE_OPERATION );
+	public void testSaveTour(SessionFactoryScope scope) {
+		testTour( scope, SAVE_OPERATION );
 	}
 
 	@Test
-	public void testSaveUpdateTour() {
-		testTour( SAVE_UPDATE_OPERATION );
+	public void testSaveUpdateTour(SessionFactoryScope scope) {
+		testTour( scope, SAVE_UPDATE_OPERATION );
 	}
 
-	private void testTour( EntityOperation operation) {
+	private void testTour(SessionFactoryScope scope, EntityOperation operation) {
 
-		Route r = getUpdatedDetachedEntity();
+		Route r = getUpdatedDetachedEntity( scope );
 
-		clearCounts();
+		clearCounts( scope );
 
-		inTransaction(
+		scope.inTransaction(
 				session ->
 						operation.doEntityOperation( ( (Node) r.getNodes().toArray()[0] ).getTour(), session )
 		);
 
-		assertInsertCount( 4 );
-		assertUpdateCount( 0 );
+		assertInsertCount( scope, 4 );
+		assertUpdateCount( scope, 0 );
 
-		inTransaction(
+		scope.inTransaction(
 				session -> {
 					Route route = session.get( Route.class, r.getRouteID() );
 					checkResults( route, false );
@@ -392,27 +393,27 @@ public abstract class AbstractMultiPathCircleCascadeTest extends BaseCoreFunctio
 	}
 
 	@Test
-	public void testMergeTransport() {
-		testTransport( MERGE_OPERATION );
+	public void testMergeTransport(SessionFactoryScope scope) {
+		testTransport( scope, MERGE_OPERATION );
 	}
 
 	@Test
-	public void testSaveTransport() {
-		testTransport( SAVE_OPERATION );
+	public void testSaveTransport(SessionFactoryScope scope) {
+		testTransport( scope, SAVE_OPERATION );
 	}
 
 	@Test
-	public void testSaveUpdateTransport() {
-		testTransport( SAVE_UPDATE_OPERATION );
+	public void testSaveUpdateTransport(SessionFactoryScope scope) {
+		testTransport( scope, SAVE_UPDATE_OPERATION );
 	}
 
-	private void testTransport( EntityOperation operation) {
+	private void testTransport(SessionFactoryScope scope, EntityOperation operation) {
 
-		Route r = getUpdatedDetachedEntity();
+		Route r = getUpdatedDetachedEntity( scope );
 
-		clearCounts();
+		clearCounts( scope );
 
-		inTransaction(
+		scope.inTransaction(
 				session -> {
 					Transport transport;
 					Node node = ( (Node) r.getNodes().toArray()[0] );
@@ -427,10 +428,10 @@ public abstract class AbstractMultiPathCircleCascadeTest extends BaseCoreFunctio
 				}
 		);
 
-		assertInsertCount( 4 );
-		assertUpdateCount( 0 );
+		assertInsertCount( scope, 4 );
+		assertUpdateCount( scope, 0 );
 
-		inTransaction(
+		scope.inTransaction(
 				session -> {
 					Route route = session.get( Route.class, r.getRouteID() );
 					checkResults( route, false );
@@ -445,10 +446,10 @@ public abstract class AbstractMultiPathCircleCascadeTest extends BaseCoreFunctio
 		return deliveryNode;
 	}
 
-	private Route getUpdatedDetachedEntity() {
+	private Route getUpdatedDetachedEntity(SessionFactoryScope scope) {
 
 		Route route = new Route();
-		inTransaction(
+		scope.inTransaction(
 				session -> {
 					route.setName( "routeA" );
 
@@ -494,9 +495,9 @@ public abstract class AbstractMultiPathCircleCascadeTest extends BaseCoreFunctio
 		return route;
 	}
 
-	@After
-	public void cleanup() {
-		inTransaction(
+	@AfterEach
+	public void cleanup(SessionFactoryScope scope) {
+		scope.inTransaction(
 				session -> {
 					session.createQuery( "delete from Transport" );
 					session.createQuery( "delete from Tour" );
@@ -563,24 +564,24 @@ public abstract class AbstractMultiPathCircleCascadeTest extends BaseCoreFunctio
 	}
 
 	@Test
-	public void testMergeData3Nodes() {
-		testData3Nodes( MERGE_OPERATION );
+	public void testMergeData3Nodes(SessionFactoryScope scope) {
+		testData3Nodes( scope, MERGE_OPERATION );
 	}
 
 	@Test
-	public void testSaveData3Nodes() {
-		testData3Nodes( SAVE_OPERATION );
+	public void testSaveData3Nodes(SessionFactoryScope scope) {
+		testData3Nodes( scope, SAVE_OPERATION );
 	}
 
 	@Test
-	public void testSaveUpdateData3Nodes() {
-		testData3Nodes( SAVE_UPDATE_OPERATION );
+	public void testSaveUpdateData3Nodes(SessionFactoryScope scope) {
+		testData3Nodes( scope, SAVE_UPDATE_OPERATION );
 	}
 
-	private void testData3Nodes( EntityOperation operation) {
+	private void testData3Nodes(SessionFactoryScope scope, EntityOperation operation) {
 
 		Route r = new Route();
-		inTransaction(
+		scope.inTransaction(
 				session -> {
 					r.setName( "routeA" );
 
@@ -588,9 +589,9 @@ public abstract class AbstractMultiPathCircleCascadeTest extends BaseCoreFunctio
 				}
 		);
 
-		clearCounts();
+		clearCounts( scope );
 
-		inTransaction(
+		scope.inTransaction(
 				session -> {
 					Route route = session.get( Route.class, r.getRouteID() );
 					route.setName( "new routA" );
@@ -651,8 +652,8 @@ public abstract class AbstractMultiPathCircleCascadeTest extends BaseCoreFunctio
 				}
 		);
 
-		assertInsertCount( 6 );
-		assertUpdateCount( 1 );
+		assertInsertCount( scope, 6 );
+		assertUpdateCount( scope, 1 );
 	}
 
 	protected void checkExceptionFromNullValueForNonNullable(
@@ -668,7 +669,7 @@ public abstract class AbstractMultiPathCircleCascadeTest extends BaseCoreFunctio
 				}
 			}
 			else {
-				assertTrue( ( ex instanceof JDBCException ) || ( ex.getCause() instanceof JDBCException ) );
+				Assertions.assertTrue( ( ex instanceof JDBCException ) || ( ex.getCause() instanceof JDBCException ) );
 			}
 		}
 		else {
@@ -681,22 +682,22 @@ public abstract class AbstractMultiPathCircleCascadeTest extends BaseCoreFunctio
 		}
 	}
 
-	protected void clearCounts() {
-		sessionFactory().getStatistics().clear();
+	protected void clearCounts(SessionFactoryScope scope) {
+		scope.getSessionFactory().getStatistics().clear();
 	}
 
-	protected void assertInsertCount(int expected) {
-		int inserts = (int) sessionFactory().getStatistics().getEntityInsertCount();
-		assertEquals( "unexpected insert count", expected, inserts );
+	protected void assertInsertCount(SessionFactoryScope scope, int expected) {
+		int inserts = (int) scope.getSessionFactory().getStatistics().getEntityInsertCount();
+		Assertions.assertEquals( expected, inserts, "unexpected insert count" );
 	}
 
-	protected void assertUpdateCount(int expected) {
-		int updates = (int) sessionFactory().getStatistics().getEntityUpdateCount();
-		assertEquals( "unexpected update counts", expected, updates );
+	protected void assertUpdateCount(SessionFactoryScope scope, int expected) {
+		int updates = (int) scope.getSessionFactory().getStatistics().getEntityUpdateCount();
+		Assertions.assertEquals( expected, updates, "unexpected update counts" );
 	}
 
-	protected void assertDeleteCount(int expected) {
-		int deletes = (int) sessionFactory().getStatistics().getEntityDeleteCount();
-		assertEquals( "unexpected delete counts", expected, deletes );
+	protected void assertDeleteCount(SessionFactoryScope scope, int expected) {
+		int deletes = (int) scope.getSessionFactory().getStatistics().getEntityDeleteCount();
+		Assertions.assertEquals( expected, deletes, "unexpected delete counts" );
 	}
 }

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/cascade/circle/MultiPathCircleCascadeCheckNullFalseDelayedInsertTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/cascade/circle/MultiPathCircleCascadeCheckNullFalseDelayedInsertTest.java
@@ -6,32 +6,34 @@
  */
 package org.hibernate.orm.test.bytecode.enhancement.cascade.circle;
 
-import org.hibernate.cfg.Configuration;
-import org.hibernate.cfg.Environment;
+import org.hibernate.cfg.AvailableSettings;
 import org.hibernate.orm.test.bytecode.enhancement.lazy.NoDirtyCheckingContext;
 import org.hibernate.orm.test.bytecode.enhancement.lazy.proxy.inlinedirtychecking.DirtyCheckEnhancementContext;
 
-import org.hibernate.testing.bytecode.enhancement.BytecodeEnhancerRunner;
 import org.hibernate.testing.bytecode.enhancement.CustomEnhancementContext;
-import org.junit.runner.RunWith;
+import org.hibernate.testing.bytecode.enhancement.extension.BytecodeEnhanced;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.ServiceRegistry;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.Setting;
 
 /**
  * @author Gail Badner
  */
-@RunWith(BytecodeEnhancerRunner.class)
+@DomainModel(
+		xmlMappings = {
+				"org/hibernate/orm/test/cascade/circle/MultiPathCircleCascadeDelayedInsert.hbm.xml"
+		}
+)
+@ServiceRegistry(
+		settings = {
+				@Setting( name = AvailableSettings.GENERATE_STATISTICS, value = "true" ),
+				@Setting( name = AvailableSettings.STATEMENT_BATCH_SIZE, value = "0" ),
+				@Setting( name = AvailableSettings.CHECK_NULLABILITY, value = "false" ),
+		}
+)
+@SessionFactory
+@BytecodeEnhanced
 @CustomEnhancementContext({ NoDirtyCheckingContext.class, DirtyCheckEnhancementContext.class })
 public class MultiPathCircleCascadeCheckNullFalseDelayedInsertTest extends AbstractMultiPathCircleCascadeTest {
-	@Override
-	protected String[] getOrmXmlFiles() {
-		return new String[] {
-				"org/hibernate/orm/test/cascade/circle/MultiPathCircleCascadeDelayedInsert.hbm.xml"
-		};
-	}
-
-	@Override
-	protected void configure(Configuration configuration) {
-		configuration.setProperty( Environment.GENERATE_STATISTICS, true );
-		configuration.setProperty( Environment.STATEMENT_BATCH_SIZE, 0 );
-		configuration.setProperty( Environment.CHECK_NULLABILITY, false );
-	}
 }

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/cascade/circle/MultiPathCircleCascadeCheckNullTrueDelayedInsertTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/cascade/circle/MultiPathCircleCascadeCheckNullTrueDelayedInsertTest.java
@@ -6,32 +6,35 @@
  */
 package org.hibernate.orm.test.bytecode.enhancement.cascade.circle;
 
-import org.hibernate.cfg.Configuration;
-import org.hibernate.cfg.Environment;
+import org.hibernate.cfg.AvailableSettings;
 import org.hibernate.orm.test.bytecode.enhancement.lazy.NoDirtyCheckingContext;
 import org.hibernate.orm.test.bytecode.enhancement.lazy.proxy.inlinedirtychecking.DirtyCheckEnhancementContext;
 
-import org.hibernate.testing.bytecode.enhancement.BytecodeEnhancerRunner;
 import org.hibernate.testing.bytecode.enhancement.CustomEnhancementContext;
-import org.junit.runner.RunWith;
+import org.hibernate.testing.bytecode.enhancement.extension.BytecodeEnhanced;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.ServiceRegistry;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.Setting;
 
 /**
  * @author Gail Badner
  */
-@RunWith(BytecodeEnhancerRunner.class)
+@DomainModel(
+		xmlMappings = {
+				"org/hibernate/orm/test/cascade/circle/MultiPathCircleCascadeDelayedInsert.hbm.xml"
+		}
+)
+@ServiceRegistry(
+		settings = {
+				@Setting( name = AvailableSettings.GENERATE_STATISTICS, value = "true" ),
+				@Setting( name = AvailableSettings.STATEMENT_BATCH_SIZE, value = "0" ),
+				@Setting( name = AvailableSettings.CHECK_NULLABILITY, value = "false" ),
+		}
+)
+@SessionFactory
+@BytecodeEnhanced
 @CustomEnhancementContext({ NoDirtyCheckingContext.class, DirtyCheckEnhancementContext.class })
 public class MultiPathCircleCascadeCheckNullTrueDelayedInsertTest extends AbstractMultiPathCircleCascadeTest {
-	@Override
-	protected String[] getOrmXmlFiles() {
-		return new String[] {
-				"org/hibernate/orm/test/cascade/circle/MultiPathCircleCascadeDelayedInsert.hbm.xml"
-		};
-	}
 
-	@Override
-	protected void configure(Configuration configuration) {
-		configuration.setProperty( Environment.GENERATE_STATISTICS, true );
-		configuration.setProperty( Environment.STATEMENT_BATCH_SIZE, 0 );
-		configuration.setProperty( Environment.CHECK_NULLABILITY, true );
-	}
 }

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/cascade/circle/MultiPathCircleCascadeCheckNullibilityFalseTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/cascade/circle/MultiPathCircleCascadeCheckNullibilityFalseTest.java
@@ -6,33 +6,35 @@
  */
 package org.hibernate.orm.test.bytecode.enhancement.cascade.circle;
 
-import org.hibernate.cfg.Configuration;
-import org.hibernate.cfg.Environment;
+import org.hibernate.cfg.AvailableSettings;
 import org.hibernate.orm.test.bytecode.enhancement.lazy.NoDirtyCheckingContext;
 import org.hibernate.orm.test.bytecode.enhancement.lazy.proxy.inlinedirtychecking.DirtyCheckEnhancementContext;
 
-import org.hibernate.testing.bytecode.enhancement.BytecodeEnhancerRunner;
 import org.hibernate.testing.bytecode.enhancement.CustomEnhancementContext;
-import org.junit.runner.RunWith;
+import org.hibernate.testing.bytecode.enhancement.extension.BytecodeEnhanced;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.ServiceRegistry;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.Setting;
 
 /**
  * @author Gail Badner
  */
-@RunWith(BytecodeEnhancerRunner.class)
+@DomainModel(
+		xmlMappings = {
+				"org/hibernate/orm/test/cascade/circle/MultiPathCircleCascade.hbm.xml"
+		}
+)
+@ServiceRegistry(
+		settings = {
+				@Setting( name = AvailableSettings.GENERATE_STATISTICS, value = "true" ),
+				@Setting( name = AvailableSettings.STATEMENT_BATCH_SIZE, value = "0" ),
+				@Setting( name = AvailableSettings.CHECK_NULLABILITY, value = "false" ),
+		}
+)
+@SessionFactory
+@BytecodeEnhanced
 @CustomEnhancementContext({ NoDirtyCheckingContext.class, DirtyCheckEnhancementContext.class })
 public class MultiPathCircleCascadeCheckNullibilityFalseTest extends AbstractMultiPathCircleCascadeTest {
 
-	@Override
-	protected String[] getOrmXmlFiles() {
-		return new String[] {
-				"org/hibernate/orm/test/cascade/circle/MultiPathCircleCascade.hbm.xml"
-		};
-	}
-
-	@Override
-	protected void configure(Configuration configuration) {
-		configuration.setProperty( Environment.GENERATE_STATISTICS, true );
-		configuration.setProperty( Environment.STATEMENT_BATCH_SIZE, 0 );
-		configuration.setProperty( Environment.CHECK_NULLABILITY, false );
-	}
 }

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/cascade/circle/MultiPathCircleCascadeCheckNullibilityTrueTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/cascade/circle/MultiPathCircleCascadeCheckNullibilityTrueTest.java
@@ -6,32 +6,35 @@
  */
 package org.hibernate.orm.test.bytecode.enhancement.cascade.circle;
 
-import org.hibernate.cfg.Configuration;
-import org.hibernate.cfg.Environment;
+import org.hibernate.cfg.AvailableSettings;
 import org.hibernate.orm.test.bytecode.enhancement.lazy.NoDirtyCheckingContext;
 import org.hibernate.orm.test.bytecode.enhancement.lazy.proxy.inlinedirtychecking.DirtyCheckEnhancementContext;
 
-import org.hibernate.testing.bytecode.enhancement.BytecodeEnhancerRunner;
 import org.hibernate.testing.bytecode.enhancement.CustomEnhancementContext;
-import org.junit.runner.RunWith;
+import org.hibernate.testing.bytecode.enhancement.extension.BytecodeEnhanced;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.ServiceRegistry;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.Setting;
 
 /**
  * @author Gail Badner
  */
-@RunWith(BytecodeEnhancerRunner.class)
+@DomainModel(
+		xmlMappings = {
+				"org/hibernate/orm/test/cascade/circle/MultiPathCircleCascade.hbm.xml"
+		}
+)
+@ServiceRegistry(
+		settings = {
+				@Setting( name = AvailableSettings.GENERATE_STATISTICS, value = "true" ),
+				@Setting( name = AvailableSettings.STATEMENT_BATCH_SIZE, value = "0" ),
+				@Setting( name = AvailableSettings.CHECK_NULLABILITY, value = "false" ),
+		}
+)
+@SessionFactory
+@BytecodeEnhanced
 @CustomEnhancementContext({ NoDirtyCheckingContext.class, DirtyCheckEnhancementContext.class })
 public class MultiPathCircleCascadeCheckNullibilityTrueTest extends AbstractMultiPathCircleCascadeTest {
-	@Override
-	protected String[] getOrmXmlFiles() {
-		return new String[] {
-				"org/hibernate/orm/test/cascade/circle/MultiPathCircleCascade.hbm.xml"
-		};
-	}
 
-	@Override
-	protected void configure(Configuration configuration) {
-		configuration.setProperty( Environment.GENERATE_STATISTICS, true );
-		configuration.setProperty( Environment.STATEMENT_BATCH_SIZE, 0 );
-		configuration.setProperty( Environment.CHECK_NULLABILITY, true );
-	}
 }

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/cascade/circle/MultiPathCircleCascadeDelayedInsertTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/cascade/circle/MultiPathCircleCascadeDelayedInsertTest.java
@@ -6,31 +6,34 @@
  */
 package org.hibernate.orm.test.bytecode.enhancement.cascade.circle;
 
-import org.hibernate.cfg.Configuration;
-import org.hibernate.cfg.Environment;
+import org.hibernate.cfg.AvailableSettings;
 import org.hibernate.orm.test.bytecode.enhancement.lazy.NoDirtyCheckingContext;
 import org.hibernate.orm.test.bytecode.enhancement.lazy.proxy.inlinedirtychecking.DirtyCheckEnhancementContext;
 
-import org.hibernate.testing.bytecode.enhancement.BytecodeEnhancerRunner;
 import org.hibernate.testing.bytecode.enhancement.CustomEnhancementContext;
-import org.junit.runner.RunWith;
+import org.hibernate.testing.bytecode.enhancement.extension.BytecodeEnhanced;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.ServiceRegistry;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.Setting;
 
 /**
  * @author Gail Badner
  */
-@RunWith(BytecodeEnhancerRunner.class)
+@DomainModel(
+		xmlMappings = {
+				"org/hibernate/orm/test/cascade/circle/MultiPathCircleCascadeDelayedInsert.hbm.xml"
+		}
+)
+@ServiceRegistry(
+		settings = {
+				@Setting( name = AvailableSettings.GENERATE_STATISTICS, value = "true" ),
+				@Setting( name = AvailableSettings.STATEMENT_BATCH_SIZE, value = "0" ),
+		}
+)
+@SessionFactory
+@BytecodeEnhanced
 @CustomEnhancementContext({ NoDirtyCheckingContext.class, DirtyCheckEnhancementContext.class })
 public class MultiPathCircleCascadeDelayedInsertTest extends AbstractMultiPathCircleCascadeTest {
-	@Override
-	protected String[] getOrmXmlFiles() {
-		return new String[] {
-				"org/hibernate/orm/test/cascade/circle/MultiPathCircleCascadeDelayedInsert.hbm.xml"
-		};
-	}
 
-	@Override
-	protected void configure(Configuration configuration) {
-		configuration.setProperty( Environment.GENERATE_STATISTICS, true );
-		configuration.setProperty( Environment.STATEMENT_BATCH_SIZE, 0 );
-	}
 }

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/cascade/circle/MultiPathCircleCascadeTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/cascade/circle/MultiPathCircleCascadeTest.java
@@ -6,14 +6,16 @@
  */
 package org.hibernate.orm.test.bytecode.enhancement.cascade.circle;
 
-import org.hibernate.cfg.Configuration;
-import org.hibernate.cfg.Environment;
+import org.hibernate.cfg.AvailableSettings;
 import org.hibernate.orm.test.bytecode.enhancement.lazy.NoDirtyCheckingContext;
 import org.hibernate.orm.test.bytecode.enhancement.lazy.proxy.inlinedirtychecking.DirtyCheckEnhancementContext;
 
-import org.hibernate.testing.bytecode.enhancement.BytecodeEnhancerRunner;
 import org.hibernate.testing.bytecode.enhancement.CustomEnhancementContext;
-import org.junit.runner.RunWith;
+import org.hibernate.testing.bytecode.enhancement.extension.BytecodeEnhanced;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.ServiceRegistry;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.Setting;
 
 /**
  * The test case uses the following model:
@@ -37,19 +39,20 @@ import org.junit.runner.RunWith;
  *
  * @author Pavol Zibrita, Gail Badner
  */
-@RunWith(BytecodeEnhancerRunner.class)
+@DomainModel(
+		xmlMappings = {
+				"org/hibernate/orm/test/cascade/circle/MultiPathCircleCascade.hbm.xml"
+		}
+)
+@ServiceRegistry(
+		settings = {
+				@Setting( name = AvailableSettings.GENERATE_STATISTICS, value = "true" ),
+				@Setting( name = AvailableSettings.STATEMENT_BATCH_SIZE, value = "0" ),
+		}
+)
+@SessionFactory
+@BytecodeEnhanced
 @CustomEnhancementContext({ NoDirtyCheckingContext.class, DirtyCheckEnhancementContext.class })
 public class MultiPathCircleCascadeTest extends AbstractMultiPathCircleCascadeTest {
-	@Override
-	protected String[] getOrmXmlFiles() {
-		return new String[] {
-				"org/hibernate/orm/test/cascade/circle/MultiPathCircleCascade.hbm.xml"
-		};
-	}
 
-	@Override
-	protected void configure(Configuration configuration) {
-		configuration.setProperty( Environment.GENERATE_STATISTICS, true );
-		configuration.setProperty( Environment.STATEMENT_BATCH_SIZE, 0 );
-	}
 }

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/collectionelement/flush/ElementCollectionFlushAfterQueryTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/collectionelement/flush/ElementCollectionFlushAfterQueryTest.java
@@ -3,11 +3,11 @@ package org.hibernate.orm.test.bytecode.enhancement.collectionelement.flush;
 import java.util.HashSet;
 import java.util.Set;
 
-import org.hibernate.testing.TestForIssue;
-import org.hibernate.testing.bytecode.enhancement.BytecodeEnhancerRunner;
-import org.hibernate.testing.junit4.BaseCoreFunctionalTestCase;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.hibernate.testing.bytecode.enhancement.extension.BytecodeEnhanced;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.JiraKey;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
 
 import jakarta.persistence.CollectionTable;
 import jakarta.persistence.Column;
@@ -16,24 +16,26 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
-@RunWith(BytecodeEnhancerRunner.class)
-@TestForIssue(jiraKey = "HHH-16337")
-public class ElementCollectionFlushAfterQueryTest extends BaseCoreFunctionalTestCase {
+import org.junit.jupiter.api.Test;
+
+
+@DomainModel(
+		annotatedClasses = {
+				ElementCollectionFlushAfterQueryTest.MyEntity.class,
+				ElementCollectionFlushAfterQueryTest.MyOtherEntity.class
+		}
+)
+@SessionFactory
+@BytecodeEnhanced
+@JiraKey("HHH-16337")
+public class ElementCollectionFlushAfterQueryTest {
 	private static final Long MY_ENTITY_ID = 1l;
 
-	@Override
-	protected Class[] getAnnotatedClasses() {
-		return new Class[] {
-				MyEntity.class,
-				MyOtherEntity.class
-		};
-	}
-
 	@Test
-	public void testAutoFlush() {
-		inTransaction(
+	public void testAutoFlush(SessionFactoryScope scope) {
+		scope.inTransaction(
 				session -> {
 					MyEntity myEntity = new MyEntity( MY_ENTITY_ID, "my entity" );
 					myEntity.addRedirectUris( "1" );
@@ -41,7 +43,7 @@ public class ElementCollectionFlushAfterQueryTest extends BaseCoreFunctionalTest
 				}
 		);
 
-		inTransaction(
+		scope.inTransaction(
 				session -> {
 					MyEntity myEntity = session.find( MyEntity.class, MY_ENTITY_ID );
 
@@ -53,7 +55,7 @@ public class ElementCollectionFlushAfterQueryTest extends BaseCoreFunctionalTest
 				}
 		);
 
-		inTransaction(
+		scope.inTransaction(
 				session -> {
 					MyEntity myEntity = session.find( MyEntity.class, MY_ENTITY_ID );
 					Set<String> redirectUris = myEntity.getRedirectUris();

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/collectionelement/recreate/BytecodeEnhancementElementCollectionRecreateCollectionsInDefaultGroupTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/collectionelement/recreate/BytecodeEnhancementElementCollectionRecreateCollectionsInDefaultGroupTest.java
@@ -6,82 +6,74 @@
  */
 package org.hibernate.orm.test.bytecode.enhancement.collectionelement.recreate;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hibernate.orm.test.bytecode.enhancement.collectionelement.recreate.BytecodeEnhancementElementCollectionRecreateCollectionsInDefaultGroupTest.MyEntity;
+import static org.junit.Assert.assertTrue;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-import org.hibernate.boot.SessionFactoryBuilder;
-
-import org.hibernate.testing.TestForIssue;
-import org.hibernate.testing.bytecode.enhancement.BytecodeEnhancerRunner;
 import org.hibernate.testing.bytecode.enhancement.EnhancementOptions;
-import org.hibernate.testing.junit4.BaseNonConfigCoreFunctionalTestCase;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.hibernate.testing.bytecode.enhancement.extension.BytecodeEnhanced;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.JiraKey;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import jakarta.persistence.ElementCollection;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jakarta.persistence.OrderColumn;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertTrue;
-
-@RunWith(BytecodeEnhancerRunner.class)
+@DomainModel(
+		annotatedClasses = {
+				MyEntity.class,
+		}
+)
+@SessionFactory
+@BytecodeEnhanced(testEnhancedClasses = MyEntity.class)
 @EnhancementOptions(lazyLoading = true)
-@TestForIssue(jiraKey = "HHH-14387")
-public class BytecodeEnhancementElementCollectionRecreateCollectionsInDefaultGroupTest
-		extends BaseNonConfigCoreFunctionalTestCase {
+@JiraKey("HHH-14387")
+public class BytecodeEnhancementElementCollectionRecreateCollectionsInDefaultGroupTest {
 
-	@Override
-	protected Class[] getAnnotatedClasses() {
-		return new Class[] {
-				MyEntity.class
-		};
-	}
-
-	@Override
-	protected void configureSessionFactoryBuilder(SessionFactoryBuilder sfb) {
-		super.configureSessionFactoryBuilder( sfb );
-		sfb.applyCollectionsInDefaultFetchGroup( true );
-	}
-
-	@Before
-	public void check() {
-		inSession(
+	@BeforeEach
+	public void check(SessionFactoryScope scope) {
+		scope.inSession(
 				session ->
 						assertTrue( session.getSessionFactory().getSessionFactoryOptions()
-											.isCollectionsInDefaultFetchGroupEnabled() )
+								.isCollectionsInDefaultFetchGroupEnabled() )
 		);
 	}
 
 
-	@After
-	public void tearDown() {
-		inTransaction(
+	@AfterEach
+	public void tearDown(SessionFactoryScope scope) {
+		scope.inTransaction(
 				session ->
 						session.createQuery( "delete from myentity" ).executeUpdate()
 		);
 	}
 
 	@Test
-	public void testRecreateCollection() {
-		inTransaction( session -> {
+	public void testRecreateCollection(SessionFactoryScope scope) {
+		scope.inTransaction( session -> {
 			MyEntity entity = new MyEntity();
 			entity.setId( 1 );
 			entity.setElements( Arrays.asList( "one", "two", "four" ) );
 			session.persist( entity );
 		} );
 
-		inTransaction( session -> {
+		scope.inTransaction( session -> {
 			MyEntity entity = session.get( MyEntity.class, 1 );
 			entity.setElements( Arrays.asList( "two", "three" ) );
 			session.persist( entity );
 		} );
 
-		inTransaction( session -> {
+		scope.inTransaction( session -> {
 			MyEntity entity = session.get( MyEntity.class, 1 );
 			assertThat( entity.getElements() )
 					.containsExactlyInAnyOrder( "two", "three" );
@@ -89,21 +81,21 @@ public class BytecodeEnhancementElementCollectionRecreateCollectionsInDefaultGro
 	}
 
 	@Test
-	public void testRecreateCollectionFind() {
-		inTransaction( session -> {
+	public void testRecreateCollectionFind(SessionFactoryScope scope) {
+		scope.inTransaction( session -> {
 			MyEntity entity = new MyEntity();
 			entity.setId( 1 );
 			entity.setElements( Arrays.asList( "one", "two", "four" ) );
 			session.persist( entity );
 		} );
 
-		inTransaction( session -> {
+		scope.inTransaction( session -> {
 			MyEntity entity = session.find( MyEntity.class, 1 );
 			entity.setElements( Arrays.asList( "two", "three" ) );
 			session.persist( entity );
 		} );
 
-		inTransaction( session -> {
+		scope.inTransaction( session -> {
 			MyEntity entity = session.find( MyEntity.class, 1 );
 			assertThat( entity.getElements() )
 					.containsExactlyInAnyOrder( "two", "three" );
@@ -111,20 +103,20 @@ public class BytecodeEnhancementElementCollectionRecreateCollectionsInDefaultGro
 	}
 
 	@Test
-	public void testDeleteCollection() {
-		inTransaction( session -> {
+	public void testDeleteCollection(SessionFactoryScope scope) {
+		scope.inTransaction( session -> {
 			MyEntity entity = new MyEntity();
 			entity.setId( 1 );
 			entity.setElements( Arrays.asList( "one", "two", "four" ) );
 			session.persist( entity );
 		} );
 
-		inTransaction( session -> {
+		scope.inTransaction( session -> {
 			MyEntity entity = session.get( MyEntity.class, 1 );
 			entity.setElements( new ArrayList<>() );
 		} );
 
-		inTransaction( session -> {
+		scope.inTransaction( session -> {
 			MyEntity entity = session.get( MyEntity.class, 1 );
 			assertThat( entity.getElements() )
 					.isEmpty();
@@ -132,20 +124,20 @@ public class BytecodeEnhancementElementCollectionRecreateCollectionsInDefaultGro
 	}
 
 	@Test
-	public void testDeleteCollectionFind() {
-		inTransaction( session -> {
+	public void testDeleteCollectionFind(SessionFactoryScope scope) {
+		scope.inTransaction( session -> {
 			MyEntity entity = new MyEntity();
 			entity.setId( 1 );
 			entity.setElements( Arrays.asList( "one", "two", "four" ) );
 			session.persist( entity );
 		} );
 
-		inTransaction( session -> {
+		scope.inTransaction( session -> {
 			MyEntity entity = session.find( MyEntity.class, 1 );
 			entity.setElements( new ArrayList<>() );
 		} );
 
-		inTransaction( session -> {
+		scope.inTransaction( session -> {
 			MyEntity entity = session.find( MyEntity.class, 1 );
 			assertThat( entity.getElements() )
 					.isEmpty();
@@ -153,19 +145,19 @@ public class BytecodeEnhancementElementCollectionRecreateCollectionsInDefaultGro
 	}
 
 	@Test
-	public void testLoadAndCommitTransactionDoesNotDeleteCollection() {
-		inTransaction( session -> {
+	public void testLoadAndCommitTransactionDoesNotDeleteCollection(SessionFactoryScope scope) {
+		scope.inTransaction( session -> {
 			MyEntity entity = new MyEntity();
 			entity.setId( 1 );
 			entity.setElements( Arrays.asList( "one", "two", "four" ) );
 			session.persist( entity );
 		} );
 
-		inTransaction( session ->
-							   session.get( MyEntity.class, 1 )
+		scope.inTransaction( session ->
+				session.get( MyEntity.class, 1 )
 		);
 
-		inTransaction( session -> {
+		scope.inTransaction( session -> {
 			MyEntity entity = session.get( MyEntity.class, 1 );
 			assertThat( entity.getElements() )
 					.containsExactlyInAnyOrder( "one", "two", "four" );
@@ -174,19 +166,19 @@ public class BytecodeEnhancementElementCollectionRecreateCollectionsInDefaultGro
 	}
 
 	@Test
-	public void testLoadAndCommitTransactionDoesNotDeleteCollectionFind() {
-		inTransaction( session -> {
+	public void testLoadAndCommitTransactionDoesNotDeleteCollectionFind(SessionFactoryScope scope) {
+		scope.inTransaction( session -> {
 			MyEntity entity = new MyEntity();
 			entity.setId( 1 );
 			entity.setElements( Arrays.asList( "one", "two", "four" ) );
 			session.persist( entity );
 		} );
 
-		inTransaction( session ->
-							   session.find( MyEntity.class, 1 )
+		scope.inTransaction( session ->
+				session.find( MyEntity.class, 1 )
 		);
 
-		inTransaction( session -> {
+		scope.inTransaction( session -> {
 			MyEntity entity = session.find( MyEntity.class, 1 );
 			assertThat( entity.getElements() )
 					.containsExactlyInAnyOrder( "one", "two", "four" );

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/collectionelement/recreate/BytecodeEnhancementElementCollectionRecreateTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/collectionelement/recreate/BytecodeEnhancementElementCollectionRecreateTest.java
@@ -6,80 +6,74 @@
  */
 package org.hibernate.orm.test.bytecode.enhancement.collectionelement.recreate;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hibernate.orm.test.bytecode.enhancement.collectionelement.recreate.BytecodeEnhancementElementCollectionRecreateTest.MyEntity;
+import static org.junit.Assert.assertFalse;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-import org.hibernate.boot.SessionFactoryBuilder;
-
-import org.hibernate.testing.TestForIssue;
-import org.hibernate.testing.bytecode.enhancement.BytecodeEnhancerRunner;
 import org.hibernate.testing.bytecode.enhancement.EnhancementOptions;
-import org.hibernate.testing.junit4.BaseNonConfigCoreFunctionalTestCase;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.hibernate.testing.bytecode.enhancement.extension.BytecodeEnhanced;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.JiraKey;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import jakarta.persistence.ElementCollection;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jakarta.persistence.OrderColumn;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertFalse;
-
-@RunWith(BytecodeEnhancerRunner.class)
+@DomainModel(
+		annotatedClasses = {
+				MyEntity.class,
+		}
+)
+@SessionFactory(applyCollectionsInDefaultFetchGroup = false)
+@BytecodeEnhanced
 @EnhancementOptions(lazyLoading = true)
-@TestForIssue(jiraKey = "HHH-14387")
-public class BytecodeEnhancementElementCollectionRecreateTest extends BaseNonConfigCoreFunctionalTestCase {
+@JiraKey("HHH-14387")
+public class BytecodeEnhancementElementCollectionRecreateTest {
 
-	@Override
-	protected Class[] getAnnotatedClasses() {
-		return new Class[] {
-				MyEntity.class
-		};
-	}
-
-	@Override
-	protected void configureSessionFactoryBuilder(SessionFactoryBuilder sfb) {
-		super.configureSessionFactoryBuilder( sfb );
-		sfb.applyCollectionsInDefaultFetchGroup( false );
-	}
-
-	@Before
-	public void check() {
-		inSession(
+	@BeforeEach
+	public void check(SessionFactoryScope scope) {
+		scope.inSession(
 				session ->
 						assertFalse( session.getSessionFactory().getSessionFactoryOptions()
-											 .isCollectionsInDefaultFetchGroupEnabled() )
+								.isCollectionsInDefaultFetchGroupEnabled() )
 		);
 	}
 
-	@After
-	public void tearDown() {
-		inTransaction(
+	@AfterEach
+	public void tearDown(SessionFactoryScope scope) {
+		scope.inTransaction(
 				session ->
 						session.createQuery( "delete from myentity" ).executeUpdate()
 		);
 	}
 
 	@Test
-	public void testRecreateCollection() {
-		inTransaction( session -> {
+	public void testRecreateCollection(SessionFactoryScope scope) {
+		scope.inTransaction( session -> {
 			MyEntity entity = new MyEntity();
 			entity.setId( 1 );
 			entity.setElements( Arrays.asList( "one", "two", "four" ) );
 			session.persist( entity );
 		} );
 
-		inTransaction( session -> {
+		scope.inTransaction( session -> {
 			MyEntity entity = session.get( MyEntity.class, 1 );
 			entity.setElements( Arrays.asList( "two", "three" ) );
 			session.persist( entity );
 		} );
 
-		inTransaction( session -> {
+		scope.inTransaction( session -> {
 			MyEntity entity = session.get( MyEntity.class, 1 );
 			assertThat( entity.getElements() )
 					.containsExactlyInAnyOrder( "two", "three" );
@@ -87,21 +81,21 @@ public class BytecodeEnhancementElementCollectionRecreateTest extends BaseNonCon
 	}
 
 	@Test
-	public void testRecreateCollectionFind() {
-		inTransaction( session -> {
+	public void testRecreateCollectionFind(SessionFactoryScope scope) {
+		scope.inTransaction( session -> {
 			MyEntity entity = new MyEntity();
 			entity.setId( 1 );
 			entity.setElements( Arrays.asList( "one", "two", "four" ) );
 			session.persist( entity );
 		} );
 
-		inTransaction( session -> {
+		scope.inTransaction( session -> {
 			MyEntity entity = session.find( MyEntity.class, 1 );
 			entity.setElements( Arrays.asList( "two", "three" ) );
 			session.persist( entity );
 		} );
 
-		inTransaction( session -> {
+		scope.inTransaction( session -> {
 			MyEntity entity = session.find( MyEntity.class, 1 );
 			assertThat( entity.getElements() )
 					.containsExactlyInAnyOrder( "two", "three" );
@@ -109,20 +103,20 @@ public class BytecodeEnhancementElementCollectionRecreateTest extends BaseNonCon
 	}
 
 	@Test
-	public void testDeleteCollection() {
-		inTransaction( session -> {
+	public void testDeleteCollection(SessionFactoryScope scope) {
+		scope.inTransaction( session -> {
 			MyEntity entity = new MyEntity();
 			entity.setId( 1 );
 			entity.setElements( Arrays.asList( "one", "two", "four" ) );
 			session.persist( entity );
 		} );
 
-		inTransaction( session -> {
+		scope.inTransaction( session -> {
 			MyEntity entity = session.get( MyEntity.class, 1 );
 			entity.setElements( new ArrayList<>() );
 		} );
 
-		inTransaction( session -> {
+		scope.inTransaction( session -> {
 			MyEntity entity = session.get( MyEntity.class, 1 );
 			assertThat( entity.getElements() )
 					.isEmpty();
@@ -130,20 +124,20 @@ public class BytecodeEnhancementElementCollectionRecreateTest extends BaseNonCon
 	}
 
 	@Test
-	public void testDeleteCollectionFind() {
-		inTransaction( session -> {
+	public void testDeleteCollectionFind(SessionFactoryScope scope) {
+		scope.inTransaction( session -> {
 			MyEntity entity = new MyEntity();
 			entity.setId( 1 );
 			entity.setElements( Arrays.asList( "one", "two", "four" ) );
 			session.persist( entity );
 		} );
 
-		inTransaction( session -> {
+		scope.inTransaction( session -> {
 			MyEntity entity = session.find( MyEntity.class, 1 );
 			entity.setElements( new ArrayList<>() );
 		} );
 
-		inTransaction( session -> {
+		scope.inTransaction( session -> {
 			MyEntity entity = session.find( MyEntity.class, 1 );
 			assertThat( entity.getElements() )
 					.isEmpty();
@@ -151,19 +145,19 @@ public class BytecodeEnhancementElementCollectionRecreateTest extends BaseNonCon
 	}
 
 	@Test
-	public void testLoadAndCommitTransactionDoesNotDeleteCollection() {
-		inTransaction( session -> {
+	public void testLoadAndCommitTransactionDoesNotDeleteCollection(SessionFactoryScope scope) {
+		scope.inTransaction( session -> {
 			MyEntity entity = new MyEntity();
 			entity.setId( 1 );
 			entity.setElements( Arrays.asList( "one", "two", "four" ) );
 			session.persist( entity );
 		} );
 
-		inTransaction( session ->
-							   session.get( MyEntity.class, 1 )
+		scope.inTransaction( session ->
+				session.get( MyEntity.class, 1 )
 		);
 
-		inTransaction( session -> {
+		scope.inTransaction( session -> {
 			MyEntity entity = session.get( MyEntity.class, 1 );
 			assertThat( entity.getElements() )
 					.containsExactlyInAnyOrder( "one", "two", "four" );
@@ -172,19 +166,19 @@ public class BytecodeEnhancementElementCollectionRecreateTest extends BaseNonCon
 	}
 
 	@Test
-	public void testLoadAndCommitTransactionDoesNotDeleteCollectionFind() {
-		inTransaction( session -> {
+	public void testLoadAndCommitTransactionDoesNotDeleteCollectionFind(SessionFactoryScope scope) {
+		scope.inTransaction( session -> {
 			MyEntity entity = new MyEntity();
 			entity.setId( 1 );
 			entity.setElements( Arrays.asList( "one", "two", "four" ) );
 			session.persist( entity );
 		} );
 
-		inTransaction( session ->
-							   session.find( MyEntity.class, 1 )
+		scope.inTransaction( session ->
+				session.find( MyEntity.class, 1 )
 		);
 
-		inTransaction( session -> {
+		scope.inTransaction( session -> {
 			MyEntity entity = session.find( MyEntity.class, 1 );
 			assertThat( entity.getElements() )
 					.containsExactlyInAnyOrder( "one", "two", "four" );

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/detached/RemoveUninitializedLazyCollectionTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/detached/RemoveUninitializedLazyCollectionTest.java
@@ -12,14 +12,14 @@ import java.util.List;
 import org.hibernate.Hibernate;
 
 import org.hibernate.testing.TestForIssue;
-import org.hibernate.testing.bytecode.enhancement.BytecodeEnhancerRunner;
 import org.hibernate.testing.bytecode.enhancement.EnhancementOptions;
-import org.hibernate.testing.junit4.BaseCoreFunctionalTestCase;
-import org.hibernate.testing.transaction.TransactionUtil;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.hibernate.testing.bytecode.enhancement.extension.BytecodeEnhanced;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Entity;
@@ -34,27 +34,25 @@ import jakarta.persistence.OneToMany;
  * @author Christian Beikov
  */
 @TestForIssue(jiraKey = "HHH-14387")
-@RunWith( BytecodeEnhancerRunner.class )
+@DomainModel(
+		annotatedClasses = {
+				RemoveUninitializedLazyCollectionTest.Parent.class,
+				RemoveUninitializedLazyCollectionTest.Child1.class,
+				RemoveUninitializedLazyCollectionTest.Child2.class
+		}
+)
+@SessionFactory
+@BytecodeEnhanced
 @EnhancementOptions(
 		lazyLoading = true,
 		inlineDirtyChecking = true,
 		biDirectionalAssociationManagement = true
 )
-public class RemoveUninitializedLazyCollectionTest extends BaseCoreFunctionalTestCase {
+public class RemoveUninitializedLazyCollectionTest {
 
-	@Override
-	public Class<?>[] getAnnotatedClasses() {
-		return new Class<?>[]{
-				Parent.class,
-				Child1.class,
-				Child2.class
-		};
-	}
-
-	@After
-	public void tearDown() {
-		TransactionUtil.doInJPA(
-				this::sessionFactory,
+	@AfterEach
+	public void tearDown(SessionFactoryScope scope) {
+		scope.inTransaction(
 				session -> {
 					session.createQuery( "delete from Child1" ).executeUpdate();
 					session.createQuery( "delete from Child2" ).executeUpdate();
@@ -63,11 +61,10 @@ public class RemoveUninitializedLazyCollectionTest extends BaseCoreFunctionalTes
 		);
 	}
 
-	@Before
-	public void setup() {
+	@BeforeEach
+	public void setup(SessionFactoryScope scope) {
 		Parent parent = new Parent( 1L, "test" );
-		TransactionUtil.doInJPA(
-				this::sessionFactory,
+		scope.inTransaction(
 				entityManager -> {
 					entityManager.persist( parent );
 					entityManager.persist( new Child2( 1L, "child2", parent ) );
@@ -76,8 +73,8 @@ public class RemoveUninitializedLazyCollectionTest extends BaseCoreFunctionalTes
 	}
 
 	@Test
-	public void testDeleteParentWithBidirOrphanDeleteCollectionBasedOnPropertyRef() {
-		EntityManager em = sessionFactory().createEntityManager();
+	public void testDeleteParentWithBidirOrphanDeleteCollectionBasedOnPropertyRef(SessionFactoryScope scope) {
+		EntityManager em = scope.getSessionFactory().createEntityManager();
 		try {
 			// Lazily initialize the child1 collection
 			List<Child1> child1 = em.find( Parent.class, 1L ).getChild1();

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/dirty/DirtyTrackingCollectionInDefaultFetchGroupFalseTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/dirty/DirtyTrackingCollectionInDefaultFetchGroupFalseTest.java
@@ -6,34 +6,32 @@
  */
 package org.hibernate.orm.test.bytecode.enhancement.dirty;
 
-import static org.hibernate.testing.transaction.TransactionUtil.doInJPA;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
 
-import org.hibernate.boot.internal.SessionFactoryBuilderImpl;
-import org.hibernate.boot.internal.SessionFactoryOptionsBuilder;
-import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
-import org.hibernate.boot.spi.SessionFactoryBuilderService;
 import org.hibernate.bytecode.enhance.spi.interceptor.BytecodeLazyAttributeInterceptor;
 import org.hibernate.engine.spi.PersistentAttributeInterceptable;
 
-import org.hibernate.testing.TestForIssue;
-import org.hibernate.testing.bytecode.enhancement.BytecodeEnhancerRunner;
-import org.hibernate.testing.junit4.BaseCoreFunctionalTestCase;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.hibernate.testing.bytecode.enhancement.extension.BytecodeEnhanced;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.JiraKey;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import jakarta.persistence.CascadeType;
+import jakarta.persistence.CollectionTable;
 import jakarta.persistence.ElementCollection;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
@@ -46,35 +44,23 @@ import jakarta.persistence.Table;
  *
  * @author Christian Beikov
  */
-@TestForIssue( jiraKey = "HHH-14348" )
-@RunWith( BytecodeEnhancerRunner.class )
-public class DirtyTrackingCollectionInDefaultFetchGroupFalseTest extends BaseCoreFunctionalTestCase {
+@JiraKey( "HHH-14348" )
+@DomainModel(
+        annotatedClasses = {
+                DirtyTrackingCollectionInDefaultFetchGroupFalseTest.StringsEntity.class
+        }
+)
+@SessionFactory(
+        // We want to test with this setting set to false explicitly,
+        // because another test already takes care of the default.
+        applyCollectionsInDefaultFetchGroup = false
+)
+@BytecodeEnhanced
+public class DirtyTrackingCollectionInDefaultFetchGroupFalseTest {
 
-    @Override
-    public Class<?>[] getAnnotatedClasses() {
-        return new Class<?>[]{StringsEntity.class};
-    }
-
-    @Override
-    protected void prepareBasicRegistryBuilder(StandardServiceRegistryBuilder serviceRegistryBuilder) {
-        serviceRegistryBuilder.addService(
-                SessionFactoryBuilderService.class,
-                (SessionFactoryBuilderService) (metadata, bootstrapContext) -> {
-                    SessionFactoryOptionsBuilder optionsBuilder = new SessionFactoryOptionsBuilder(
-                            metadata.getMetadataBuildingOptions().getServiceRegistry(),
-                            bootstrapContext
-                    );
-                    // We want to test with this setting set to false explicitly,
-                    // because another test already takes care of the default.
-                    optionsBuilder.enableCollectionInDefaultFetchGroup( false );
-                    return new SessionFactoryBuilderImpl( metadata, optionsBuilder, bootstrapContext );
-                }
-        );
-    }
-
-    @Before
-    public void prepare() {
-        doInJPA( this::sessionFactory, em -> {
+    @BeforeEach
+    public void prepare(SessionFactoryScope scope) {
+        scope.inTransaction( em -> {
             StringsEntity entity = new StringsEntity();
             entity.id = 1L;
             entity.someStrings = new ArrayList<>( Arrays.asList( "a", "b", "c" ) );
@@ -83,8 +69,8 @@ public class DirtyTrackingCollectionInDefaultFetchGroupFalseTest extends BaseCor
     }
 
     @Test
-    public void test() {
-        doInJPA( this::sessionFactory, entityManager -> {
+    public void test(SessionFactoryScope scope) {
+        scope.inTransaction( entityManager -> {
             StringsEntity entity = entityManager.find( StringsEntity.class, 1L );
             entityManager.flush();
             BytecodeLazyAttributeInterceptor interceptor = (BytecodeLazyAttributeInterceptor) ( (PersistentAttributeInterceptable) entity )
@@ -98,13 +84,14 @@ public class DirtyTrackingCollectionInDefaultFetchGroupFalseTest extends BaseCor
     // --- //
 
     @Entity
-    @Table( name = "STRINGS_ENTITY" )
-    private static class StringsEntity {
+    @Table(name = "STRINGS_ENTITY")
+    static class StringsEntity {
 
         @Id
         Long id;
 
         @ElementCollection
+        @CollectionTable(name = "STRINGS_ENTITY_SOME", joinColumns = @JoinColumn(name = "SOME_ID"))
         List<String> someStrings;
 
         @ManyToOne(fetch = FetchType.LAZY)

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/dirty/DirtyTrackingCollectionNotInDefaultFetchGroupTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/dirty/DirtyTrackingCollectionNotInDefaultFetchGroupTest.java
@@ -11,53 +11,50 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
 
-import org.hibernate.boot.SessionFactoryBuilder;
 import org.hibernate.bytecode.enhance.spi.interceptor.BytecodeLazyAttributeInterceptor;
 import org.hibernate.engine.spi.PersistentAttributeInterceptable;
 
-import org.hibernate.testing.TestForIssue;
-import org.hibernate.testing.bytecode.enhancement.BytecodeEnhancerRunner;
-import org.hibernate.testing.junit4.BaseNonConfigCoreFunctionalTestCase;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.jupiter.api.Assertions;
-import org.junit.runner.RunWith;
+import org.hibernate.testing.bytecode.enhancement.extension.BytecodeEnhanced;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.JiraKey;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import jakarta.persistence.CascadeType;
+import jakarta.persistence.CollectionTable;
 import jakarta.persistence.ElementCollection;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 
-import static org.hibernate.testing.transaction.TransactionUtil.doInJPA;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * @author Christian Beikov
  */
-@TestForIssue( jiraKey = "HHH-14348" )
-@RunWith( BytecodeEnhancerRunner.class )
-public class DirtyTrackingCollectionNotInDefaultFetchGroupTest extends BaseNonConfigCoreFunctionalTestCase {
+@JiraKey( "HHH-14348" )
+@DomainModel(
+        annotatedClasses = {
+               DirtyTrackingCollectionNotInDefaultFetchGroupTest.StringsEntity.class
+        }
+)
+@SessionFactory(
+        applyCollectionsInDefaultFetchGroup = false
+)
+@BytecodeEnhanced
+public class DirtyTrackingCollectionNotInDefaultFetchGroupTest {
 
-    @Override
-    public Class<?>[] getAnnotatedClasses() {
-        return new Class<?>[]{StringsEntity.class};
-    }
-
-    @Override
-    protected void configureSessionFactoryBuilder(SessionFactoryBuilder sfb) {
-        super.configureSessionFactoryBuilder( sfb );
-        sfb.applyCollectionsInDefaultFetchGroup( false );
-    }
-
-    @Before
-    public void prepare() {
-        assertFalse( sessionFactory().getSessionFactoryOptions().isCollectionsInDefaultFetchGroupEnabled() );
-        doInJPA( this::sessionFactory, em -> {
+    @BeforeEach
+    public void prepare(SessionFactoryScope scope) {
+        assertFalse( scope.getSessionFactory().getSessionFactoryOptions().isCollectionsInDefaultFetchGroupEnabled() );
+        scope.inTransaction( em -> {
             StringsEntity entity = new StringsEntity();
             entity.id = 1L;
             entity.someStrings = new ArrayList<>( Arrays.asList( "a", "b", "c" ) );
@@ -66,8 +63,8 @@ public class DirtyTrackingCollectionNotInDefaultFetchGroupTest extends BaseNonCo
     }
 
     @Test
-    public void test() {
-        doInJPA( this::sessionFactory, entityManager -> {
+    public void test(SessionFactoryScope scope) {
+        scope.inTransaction( entityManager -> {
             StringsEntity entity = entityManager.find( StringsEntity.class, 1L );
             entityManager.flush();
             BytecodeLazyAttributeInterceptor interceptor = (BytecodeLazyAttributeInterceptor) ( (PersistentAttributeInterceptable) entity )
@@ -82,12 +79,13 @@ public class DirtyTrackingCollectionNotInDefaultFetchGroupTest extends BaseNonCo
 
     @Entity
     @Table( name = "STRINGS_ENTITY" )
-    private static class StringsEntity {
+    static class StringsEntity {
 
         @Id
         Long id;
 
         @ElementCollection
+        @CollectionTable(name = "STRINGS_ENTITY_SOME", joinColumns = @JoinColumn(name = "SOME_ID"))
         List<String> someStrings;
 
         @ManyToOne(fetch = FetchType.LAZY)

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/dirty/DirtyTrackingEmbeddableTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/dirty/DirtyTrackingEmbeddableTest.java
@@ -6,11 +6,10 @@
  */
 package org.hibernate.orm.test.bytecode.enhancement.dirty;
 
-import org.hibernate.testing.bytecode.enhancement.BytecodeEnhancerRunner;
 import org.hibernate.testing.bytecode.enhancement.EnhancerTestUtils;
+import org.hibernate.testing.bytecode.enhancement.extension.BytecodeEnhanced;
 import org.hibernate.testing.orm.junit.JiraKey;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
 
 import jakarta.persistence.Embeddable;
 import jakarta.persistence.Embedded;
@@ -19,7 +18,7 @@ import jakarta.persistence.Id;
 
 @JiraKey( "HHH-16774" )
 @JiraKey( "HHH-16952" )
-@RunWith( BytecodeEnhancerRunner.class )
+@BytecodeEnhanced
 public class DirtyTrackingEmbeddableTest {
 
     @Test

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/dirty/DirtyTrackingInheritanceTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/dirty/DirtyTrackingInheritanceTest.java
@@ -6,13 +6,11 @@
  */
 package org.hibernate.orm.test.bytecode.enhancement.dirty;
 
-import org.hibernate.testing.TestForIssue;
-import org.hibernate.testing.bytecode.enhancement.BytecodeEnhancerRunner;
 import org.hibernate.testing.bytecode.enhancement.EnhancementOptions;
 import org.hibernate.testing.bytecode.enhancement.EnhancerTestUtils;
+import org.hibernate.testing.bytecode.enhancement.extension.BytecodeEnhanced;
 import org.hibernate.testing.orm.junit.Jira;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
 
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -24,7 +22,7 @@ import jakarta.persistence.MappedSuperclass;
  * @author Yoann Rodière
  * @author Marco Belladelli
  */
-@RunWith( BytecodeEnhancerRunner.class )
+@BytecodeEnhanced
 @EnhancementOptions( inlineDirtyChecking = true )
 @Jira( "https://hibernate.atlassian.net/browse/HHH-16459" )
 public class DirtyTrackingInheritanceTest {

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/dirty/DirtyTrackingInheritanceWithGenericsTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/dirty/DirtyTrackingInheritanceWithGenericsTest.java
@@ -6,12 +6,11 @@
  */
 package org.hibernate.orm.test.bytecode.enhancement.dirty;
 
-import org.hibernate.testing.bytecode.enhancement.BytecodeEnhancerRunner;
 import org.hibernate.testing.bytecode.enhancement.EnhancementOptions;
 import org.hibernate.testing.bytecode.enhancement.EnhancerTestUtils;
+import org.hibernate.testing.bytecode.enhancement.extension.BytecodeEnhanced;
 import org.hibernate.testing.orm.junit.Jira;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
 
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -23,7 +22,7 @@ import jakarta.persistence.MappedSuperclass;
  * @author Yoann Rodière
  * @author Marco Belladelli
  */
-@RunWith( BytecodeEnhancerRunner.class )
+@BytecodeEnhanced
 @EnhancementOptions( inlineDirtyChecking = true )
 @Jira( "https://hibernate.atlassian.net/browse/HHH-16459" )
 public class DirtyTrackingInheritanceWithGenericsTest {

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/dirty/DirtyTrackingNonUpdateableTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/dirty/DirtyTrackingNonUpdateableTest.java
@@ -6,11 +6,12 @@
  */
 package org.hibernate.orm.test.bytecode.enhancement.dirty;
 
-import org.hibernate.testing.TestForIssue;
-import org.hibernate.testing.bytecode.enhancement.BytecodeEnhancerRunner;
-import org.hibernate.testing.junit4.BaseCoreFunctionalTestCase;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.hibernate.testing.bytecode.enhancement.extension.BytecodeEnhanced;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.JiraKey;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.junit.jupiter.api.Test;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -20,23 +21,22 @@ import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import jakarta.persistence.Version;
 
-import static org.hibernate.testing.transaction.TransactionUtil.doInJPA;
-
 /**
  * @author Luis Barreiro
  */
-@TestForIssue( jiraKey = "HHH-12051" )
-@RunWith( BytecodeEnhancerRunner.class )
-public class DirtyTrackingNonUpdateableTest extends BaseCoreFunctionalTestCase {
-
-    @Override
-    public Class<?>[] getAnnotatedClasses() {
-        return new Class<?>[]{Thing.class};
-    }
+@JiraKey( "HHH-12051" )
+@DomainModel(
+        annotatedClasses = {
+               DirtyTrackingNonUpdateableTest.Thing.class
+        }
+)
+@SessionFactory
+@BytecodeEnhanced
+public class DirtyTrackingNonUpdateableTest {
 
     @Test
-    public void test() {
-        doInJPA( this::sessionFactory, entityManager -> {
+    public void test(SessionFactoryScope scope) {
+        scope.inTransaction( entityManager -> {
             Thing thing = new Thing();
             entityManager.persist( thing );
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/dirty/DirtyTrackingNotInDefaultFetchGroupPersistTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/dirty/DirtyTrackingNotInDefaultFetchGroupPersistTest.java
@@ -11,15 +11,13 @@ import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 
-import org.hibernate.boot.SessionFactoryBuilder;
-
 import org.hibernate.testing.DialectChecks;
 import org.hibernate.testing.RequiresDialectFeature;
-import org.hibernate.testing.TestForIssue;
-import org.hibernate.testing.bytecode.enhancement.BytecodeEnhancerRunner;
-import org.hibernate.testing.junit4.BaseNonConfigCoreFunctionalTestCase;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.hibernate.testing.bytecode.enhancement.extension.BytecodeEnhanced;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.JiraKey;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
 
 import jakarta.persistence.Basic;
 import jakarta.persistence.CascadeType;
@@ -36,40 +34,37 @@ import jakarta.persistence.OrderColumn;
 import jakarta.persistence.Temporal;
 import jakarta.persistence.TemporalType;
 
-import static org.hibernate.testing.transaction.TransactionUtil.doInHibernate;
-import static org.junit.Assert.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Christian Beikov
  */
-@TestForIssue(jiraKey = "HHH-14360")
-@RunWith(BytecodeEnhancerRunner.class)
+@JiraKey("HHH-14360")
+@DomainModel(
+		annotatedClasses = {
+				DirtyTrackingNotInDefaultFetchGroupPersistTest.HotherEntity.class,
+				DirtyTrackingNotInDefaultFetchGroupPersistTest.Hentity.class
+		}
+)
+@SessionFactory(applyCollectionsInDefaultFetchGroup = false)
+@BytecodeEnhanced
 @RequiresDialectFeature(DialectChecks.SupportsIdentityColumns.class)
-public class DirtyTrackingNotInDefaultFetchGroupPersistTest extends BaseNonConfigCoreFunctionalTestCase {
-
-	@Override
-	public Class<?>[] getAnnotatedClasses() {
-		return new Class<?>[] { HotherEntity.class, Hentity.class };
-	}
-
-	@Override
-	protected void configureSessionFactoryBuilder(SessionFactoryBuilder sfb) {
-		super.configureSessionFactoryBuilder( sfb );
-		sfb.applyCollectionsInDefaultFetchGroup( false );
-	}
+public class DirtyTrackingNotInDefaultFetchGroupPersistTest {
 
 	@Test
-	public void test() {
-		assertFalse( sessionFactory().getSessionFactoryOptions().isCollectionsInDefaultFetchGroupEnabled() );
+	public void test(SessionFactoryScope scope) {
+		assertFalse( scope.getSessionFactory().getSessionFactoryOptions().isCollectionsInDefaultFetchGroupEnabled() );
 
 		Hentity hentity = new Hentity();
 		HotherEntity hotherEntity = new HotherEntity();
 		hentity.setLineItems( new ArrayList<>( Collections.singletonList( hotherEntity ) ) );
 		hentity.setNextRevUNs( new ArrayList<>( Collections.singletonList( "something" ) ) );
-		doInHibernate( this::sessionFactory, session -> {
+		scope.inTransaction( session -> {
 			session.persist( hentity );
 		} );
-		doInHibernate( this::sessionFactory, session -> {
+		scope.inTransaction( session -> {
 			hentity.bumpNumber();
 			session.saveOrUpdate( hentity );
 		} );

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/dirty/DirtyTrackingPersistTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/dirty/DirtyTrackingPersistTest.java
@@ -25,50 +25,46 @@ import jakarta.persistence.OrderColumn;
 import jakarta.persistence.Temporal;
 import jakarta.persistence.TemporalType;
 
-import org.hibernate.boot.SessionFactoryBuilder;
-
 import org.hibernate.testing.DialectChecks;
 import org.hibernate.testing.RequiresDialectFeature;
 import org.hibernate.testing.TestForIssue;
-import org.hibernate.testing.bytecode.enhancement.BytecodeEnhancerRunner;
-import org.hibernate.testing.junit4.BaseNonConfigCoreFunctionalTestCase;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.hibernate.testing.bytecode.enhancement.extension.BytecodeEnhanced;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.JiraKey;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
 
 import static org.hibernate.testing.transaction.TransactionUtil.doInHibernate;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Christian Beikov
  */
-@TestForIssue(jiraKey = "HHH-14360")
-@RunWith(BytecodeEnhancerRunner.class)
+@JiraKey("HHH-14360")
+@DomainModel(
+		annotatedClasses = {
+				DirtyTrackingPersistTest.HotherEntity.class, DirtyTrackingPersistTest.Hentity.class
+		}
+)
+@SessionFactory
+@BytecodeEnhanced
 @RequiresDialectFeature(DialectChecks.SupportsIdentityColumns.class)
-public class DirtyTrackingPersistTest extends BaseNonConfigCoreFunctionalTestCase {
-
-	@Override
-	public Class<?>[] getAnnotatedClasses() {
-		return new Class<?>[] { HotherEntity.class, Hentity.class };
-	}
-
-	@Override
-	protected void configureSessionFactoryBuilder(SessionFactoryBuilder sfb) {
-		super.configureSessionFactoryBuilder( sfb );
-		sfb.applyCollectionsInDefaultFetchGroup( true );
-	}
+public class DirtyTrackingPersistTest {
 
 	@Test
-	public void test() {
-		assertTrue( sessionFactory().getSessionFactoryOptions().isCollectionsInDefaultFetchGroupEnabled() );
+	public void test(SessionFactoryScope scope) {
+		assertTrue( scope.getSessionFactory().getSessionFactoryOptions().isCollectionsInDefaultFetchGroupEnabled() );
 
 		Hentity hentity = new Hentity();
 		HotherEntity hotherEntity = new HotherEntity();
 		hentity.setLineItems( new ArrayList<>( Collections.singletonList( hotherEntity ) ) );
 		hentity.setNextRevUNs( new ArrayList<>( Collections.singletonList( "something" ) ) );
-		doInHibernate( this::sessionFactory, session -> {
+		scope.inTransaction( session -> {
 			session.persist( hentity );
 		} );
-		doInHibernate( this::sessionFactory, session -> {
+		scope.inTransaction( session -> {
 			hentity.bumpNumber();
 			session.saveOrUpdate( hentity );
 		} );

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/dirty/DirtyTrackingTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/dirty/DirtyTrackingTest.java
@@ -6,10 +6,9 @@
  */
 package org.hibernate.orm.test.bytecode.enhancement.dirty;
 
-import org.hibernate.testing.bytecode.enhancement.BytecodeEnhancerRunner;
 import org.hibernate.testing.bytecode.enhancement.EnhancerTestUtils;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.hibernate.testing.bytecode.enhancement.extension.BytecodeEnhanced;
+import org.junit.jupiter.api.Test;
 
 import jakarta.persistence.Embeddable;
 import jakarta.persistence.Embedded;
@@ -24,7 +23,7 @@ import java.util.Set;
 /**
  * @author Luis Barreiro
  */
-@RunWith( BytecodeEnhancerRunner.class )
+@BytecodeEnhanced
 public class DirtyTrackingTest {
 
     @Test

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/eviction/EvictionTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/eviction/EvictionTest.java
@@ -7,11 +7,13 @@
 package org.hibernate.orm.test.bytecode.enhancement.eviction;
 
 import org.hibernate.engine.spi.ManagedEntity;
-import org.hibernate.testing.bytecode.enhancement.BytecodeEnhancerRunner;
-import org.hibernate.testing.junit4.BaseCoreFunctionalTestCase;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+
+import org.hibernate.testing.bytecode.enhancement.extension.BytecodeEnhanced;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -20,27 +22,27 @@ import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 
 import static org.hibernate.testing.junit4.ExtraAssertions.assertTyping;
-import static org.hibernate.testing.transaction.TransactionUtil.doInHibernate;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * @author Gail Badner
  */
-@RunWith( BytecodeEnhancerRunner.class )
-public class EvictionTest extends BaseCoreFunctionalTestCase {
+@DomainModel(
+        annotatedClasses = {
+               EvictionTest.Parent.class
+        }
+)
+@SessionFactory
+@BytecodeEnhanced
+public class EvictionTest {
 
-    @Override
-    public Class<?>[] getAnnotatedClasses() {
-        return new Class<?>[]{Parent.class};
-    }
-
-    @Before
-    public void prepare() {
+    @BeforeEach
+    public void prepare(SessionFactoryScope scope) {
         // Create a Parent
-        doInHibernate( this::sessionFactory, s -> {
+        scope.inTransaction( s -> {
             Parent p = new Parent();
             p.name = "PARENT";
             s.persist( p );
@@ -48,8 +50,8 @@ public class EvictionTest extends BaseCoreFunctionalTestCase {
     }
 
     @Test
-    public void test() {
-        doInHibernate( this::sessionFactory, s -> {
+    public void test(SessionFactoryScope scope) {
+        scope.inTransaction( s -> {
 
             // Delete the Parent
             Parent loadedParent = (Parent) s.createQuery( "SELECT p FROM Parent p WHERE name=:name" )
@@ -91,7 +93,7 @@ public class EvictionTest extends BaseCoreFunctionalTestCase {
 
     @Entity( name = "Parent" )
     @Table( name = "PARENT" )
-    private static class Parent {
+    static class Parent {
 
         @Id
         @GeneratedValue( strategy = GenerationType.AUTO )

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/flush/CollectionFlushAfterQueryTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/flush/CollectionFlushAfterQueryTest.java
@@ -4,37 +4,37 @@ import java.util.HashSet;
 import java.util.Optional;
 import java.util.Set;
 
-import org.hibernate.testing.TestForIssue;
-import org.hibernate.testing.bytecode.enhancement.BytecodeEnhancerRunner;
-import org.hibernate.testing.junit4.BaseCoreFunctionalTestCase;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.hibernate.testing.bytecode.enhancement.extension.BytecodeEnhanced;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.JiraKey;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.junit.jupiter.api.Test;
 
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jakarta.persistence.OneToMany;
 
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
-@RunWith(BytecodeEnhancerRunner.class)
-@TestForIssue(jiraKey = "HHH-16337")
-public class CollectionFlushAfterQueryTest extends BaseCoreFunctionalTestCase {
-
-	private static final Long MY_ENTITY_ID = 1l;
-
-	@Override
-	protected Class[] getAnnotatedClasses() {
-		return new Class[] {
+@DomainModel(
+		annotatedClasses = {
 				CollectionFlushAfterQueryTest.MyEntity.class,
 				CollectionFlushAfterQueryTest.MyOtherEntity.class,
 				CollectionFlushAfterQueryTest.MyAnotherEntity.class
-		};
-	}
+		}
+)
+@SessionFactory
+@BytecodeEnhanced
+@JiraKey("HHH-16337")
+public class CollectionFlushAfterQueryTest {
+
+	private static final Long MY_ENTITY_ID = 1l;
 
 	@Test
-	public void testAutoFlush() {
-		inTransaction(
+	public void testAutoFlush(SessionFactoryScope scope) {
+		scope.inTransaction(
 				session -> {
 					MyEntity myEntity = new MyEntity( MY_ENTITY_ID, "my entity" );
 					MyOtherEntity otherEntity = new MyOtherEntity( 2l, "my other entity" );
@@ -44,7 +44,7 @@ public class CollectionFlushAfterQueryTest extends BaseCoreFunctionalTestCase {
 				}
 		);
 
-		inTransaction(
+		scope.inTransaction(
 				session -> {
 					MyEntity myEntity = session.find( MyEntity.class, MY_ENTITY_ID );
 
@@ -57,7 +57,7 @@ public class CollectionFlushAfterQueryTest extends BaseCoreFunctionalTestCase {
 				}
 		);
 
-		inTransaction(
+		scope.inTransaction(
 				session -> {
 					MyEntity myEntity = session.find( MyEntity.class, MY_ENTITY_ID );
 					Set<MyOtherEntity> redirectUris = myEntity.getOtherEntities();

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/lazy/ConstructorInitializationAndDynamicUpdateTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/lazy/ConstructorInitializationAndDynamicUpdateTest.java
@@ -5,14 +5,15 @@ import java.util.List;
 import org.hibernate.annotations.DynamicUpdate;
 import org.hibernate.orm.test.bytecode.enhancement.lazy.proxy.inlinedirtychecking.DirtyCheckEnhancementContext;
 
-import org.hibernate.testing.bytecode.enhancement.BytecodeEnhancerRunner;
 import org.hibernate.testing.bytecode.enhancement.CustomEnhancementContext;
-import org.hibernate.testing.junit4.BaseCoreFunctionalTestCase;
+import org.hibernate.testing.bytecode.enhancement.extension.BytecodeEnhanced;
+import org.hibernate.testing.orm.junit.DomainModel;
 import org.hibernate.testing.orm.junit.JiraKey;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
@@ -22,25 +23,24 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
 import jakarta.persistence.OneToOne;
 
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 @JiraKey("HHH-17049")
-@RunWith(BytecodeEnhancerRunner.class)
+@DomainModel(
+		annotatedClasses = {
+				ConstructorInitializationAndDynamicUpdateTest.Person.class,
+				ConstructorInitializationAndDynamicUpdateTest.LoginAccount.class,
+				ConstructorInitializationAndDynamicUpdateTest.AccountPreferences.class
+		}
+)
+@SessionFactory
+@BytecodeEnhanced
 @CustomEnhancementContext({ NoDirtyCheckingContext.class, DirtyCheckEnhancementContext.class })
-public class ConstructorInitializationAndDynamicUpdateTest extends BaseCoreFunctionalTestCase {
+public class ConstructorInitializationAndDynamicUpdateTest {
 
-	@Override
-	protected Class<?>[] getAnnotatedClasses() {
-		return new Class[] {
-				Person.class,
-				LoginAccount.class,
-				AccountPreferences.class
-		};
-	}
-
-	@Before
-	public void setUp() {
-		inTransaction(
+	@BeforeEach
+	public void setUp(SessionFactoryScope scope) {
+		scope.inTransaction(
 				session -> {
 					Person person = new Person( 1l, "Henry" );
 					LoginAccount loginAccount = new LoginAccount();
@@ -50,7 +50,7 @@ public class ConstructorInitializationAndDynamicUpdateTest extends BaseCoreFunct
 				}
 		);
 
-		inTransaction(
+		scope.inTransaction(
 				session -> {
 					List<LoginAccount> accounts = session.createQuery(
 							"select la from LoginAccount la",
@@ -67,9 +67,9 @@ public class ConstructorInitializationAndDynamicUpdateTest extends BaseCoreFunct
 		);
 	}
 
-	@After
-	public void tearDown() {
-		inTransaction(
+	@AfterEach
+	public void tearDown(SessionFactoryScope scope) {
+		scope.inTransaction(
 				session -> {
 					session.createMutationQuery( "delete from Person" ).executeUpdate();
 					session.createMutationQuery( "delete from LoginAccount" ).executeUpdate();
@@ -79,15 +79,15 @@ public class ConstructorInitializationAndDynamicUpdateTest extends BaseCoreFunct
 	}
 
 	@Test
-	public void findTest() {
-		inTransaction(
+	public void findTest(SessionFactoryScope scope) {
+		scope.inTransaction(
 				session -> {
 					Person person = session.find( Person.class, 1L );
 					person.setFirstName( "Liza" );
 				}
 		);
 
-		inTransaction(
+		scope.inTransaction(
 				session -> {
 					List<LoginAccount> accounts = session.createQuery(
 							"select la from LoginAccount la",
@@ -105,15 +105,15 @@ public class ConstructorInitializationAndDynamicUpdateTest extends BaseCoreFunct
 	}
 
 	@Test
-	public void getReferenceTest() {
-		inTransaction(
+	public void getReferenceTest(SessionFactoryScope scope) {
+		scope.inTransaction(
 				session -> {
 					Person person = session.getReference( Person.class, 1L );
 					person.setFirstName( "Liza" );
 				}
 		);
 
-		inTransaction(
+		scope.inTransaction(
 				session -> {
 					List<LoginAccount> accounts = session.createQuery(
 							"select la from LoginAccount la",
@@ -131,8 +131,8 @@ public class ConstructorInitializationAndDynamicUpdateTest extends BaseCoreFunct
 	}
 
 	@Test
-	public void findTest2() {
-		inTransaction(
+	public void findTest2(SessionFactoryScope scope) {
+		scope.inTransaction(
 				session -> {
 					Person person = session.find( Person.class, 1L );
 					person.setFirstName( "Liza" );
@@ -142,7 +142,7 @@ public class ConstructorInitializationAndDynamicUpdateTest extends BaseCoreFunct
 				}
 		);
 
-		inTransaction(
+		scope.inTransaction(
 				session -> {
 					Person person = session.find( Person.class, 1L );
 					assertThat( person.getFirstName() ).isEqualTo( "Liza" );
@@ -167,8 +167,8 @@ public class ConstructorInitializationAndDynamicUpdateTest extends BaseCoreFunct
 	}
 
 	@Test
-	public void getReferenceTest2() {
-		inTransaction(
+	public void getReferenceTest2(SessionFactoryScope scope) {
+		scope.inTransaction(
 				session -> {
 					Person person = session.getReference( Person.class, 1L );
 					person.setFirstName( "Liza" );
@@ -178,7 +178,7 @@ public class ConstructorInitializationAndDynamicUpdateTest extends BaseCoreFunct
 				}
 		);
 
-		inTransaction(
+		scope.inTransaction(
 				session -> {
 					Person person = session.find( Person.class, 1L );
 					assertThat( person.getFirstName() ).isEqualTo( "Liza" );

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/lazy/IdInUninitializedProxyTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/lazy/IdInUninitializedProxyTest.java
@@ -11,34 +11,34 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 
 import org.hibernate.Hibernate;
-import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
-import org.hibernate.cfg.AvailableSettings;
 
-import org.hibernate.testing.TestForIssue;
-import org.hibernate.testing.bytecode.enhancement.BytecodeEnhancerRunner;
 import org.hibernate.testing.bytecode.enhancement.EnhancementOptions;
-import org.hibernate.testing.junit4.BaseNonConfigCoreFunctionalTestCase;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.hibernate.testing.bytecode.enhancement.extension.BytecodeEnhanced;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.JiraKey;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@TestForIssue(jiraKey = "HHH-14571")
-@RunWith(BytecodeEnhancerRunner.class)
+@JiraKey("HHH-14571")
+@DomainModel(
+		annotatedClasses = {
+				IdInUninitializedProxyTest.AnEntity.class
+		}
+)
+@SessionFactory
+@BytecodeEnhanced
 @EnhancementOptions(lazyLoading = true, extendedEnhancement = true)
-public class IdInUninitializedProxyTest extends BaseNonConfigCoreFunctionalTestCase {
-
-	@Override
-	protected Class[] getAnnotatedClasses() {
-		return new Class[] { AnEntity.class };
-	}
+public class IdInUninitializedProxyTest {
 
 	@Test
-	public void testIdIsAlwaysConsideredInitialized() {
-		inTransaction( session -> {
+	public void testIdIsAlwaysConsideredInitialized(SessionFactoryScope scope) {
+		scope.inTransaction( session -> {
 			final AnEntity e = session.byId( AnEntity.class ).getReference( 1 );
 			assertFalse( Hibernate.isInitialized( e ) );
 			// This is the gist of the problem
@@ -52,9 +52,9 @@ public class IdInUninitializedProxyTest extends BaseNonConfigCoreFunctionalTestC
 		} );
 	}
 
-	@Before
-	public void prepareTestData() {
-		inTransaction( session -> {
+	@BeforeEach
+	public void prepareTestData(SessionFactoryScope scope) {
+		scope.inTransaction( session -> {
 			AnEntity anEntity = new AnEntity();
 			anEntity.id = 1;
 			anEntity.name = "George";

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/lazy/LazyBasicFieldMergeTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/lazy/LazyBasicFieldMergeTest.java
@@ -17,43 +17,34 @@ import jakarta.persistence.Lob;
 import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
 
-import org.hibernate.Hibernate;
-import org.hibernate.cfg.AvailableSettings;
-import org.hibernate.cfg.Configuration;
-import org.hibernate.persister.entity.EntityPersister;
-import org.hibernate.tuple.NonIdentifierAttribute;
+import org.hibernate.testing.bytecode.enhancement.extension.BytecodeEnhanced;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.JiraKey;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
 
-import org.hibernate.testing.TestForIssue;
-import org.hibernate.testing.bytecode.enhancement.BytecodeEnhancerRunner;
-import org.hibernate.testing.junit4.BaseCoreFunctionalTestCase;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import static org.hibernate.testing.transaction.TransactionUtil.doInHibernate;
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Vlad Mihalcea
  */
-@TestForIssue( jiraKey = "HHH-11117")
-@RunWith( BytecodeEnhancerRunner.class )
-public class LazyBasicFieldMergeTest extends BaseCoreFunctionalTestCase {
-
-    @Override
-    protected Class<?>[] getAnnotatedClasses() {
-        return new Class<?>[] {
-                Company.class,
-                Manager.class,
-        };
-    }
+@JiraKey("HHH-11117")
+@DomainModel(
+        annotatedClasses = {
+                LazyBasicFieldMergeTest.Company.class,
+                LazyBasicFieldMergeTest.Manager.class,
+        }
+)
+@SessionFactory
+@BytecodeEnhanced
+public class LazyBasicFieldMergeTest {
 
     @Test
-    public void test() {
-        doInHibernate( this::sessionFactory, session -> {
+    public void test(SessionFactoryScope scope) {
+        scope.inTransaction( session -> {
             Manager manager = new Manager();
             manager.setName("John Doe");
             manager.setResume(new byte[] {1, 2, 3});

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/lazy/LazyCollectionHandlingTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/lazy/LazyCollectionHandlingTest.java
@@ -6,8 +6,6 @@
  */
 package org.hibernate.orm.test.bytecode.enhancement.lazy;
 
-import static org.hibernate.testing.transaction.TransactionUtil.doInHibernate;
-
 import java.util.LinkedHashSet;
 import java.util.Set;
 
@@ -18,28 +16,26 @@ import jakarta.persistence.Id;
 import jakarta.persistence.ManyToMany;
 import jakarta.persistence.MappedSuperclass;
 
-import org.hibernate.testing.TestForIssue;
-import org.hibernate.testing.bytecode.enhancement.BytecodeEnhancerRunner;
-import org.hibernate.testing.junit4.BaseCoreFunctionalTestCase;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.hibernate.testing.bytecode.enhancement.extension.BytecodeEnhanced;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.junit.jupiter.api.Test;
 
-@TestForIssue(jiraKey = "")
-@RunWith(BytecodeEnhancerRunner.class)
-public class LazyCollectionHandlingTest extends BaseCoreFunctionalTestCase {
+@DomainModel(
+		annotatedClasses = {
+				LazyCollectionHandlingTest.JafSid.class, LazyCollectionHandlingTest.UserGroup.class
+		}
+)
+@SessionFactory
+@BytecodeEnhanced
+public class LazyCollectionHandlingTest {
 
 	private Integer id;
 
-	@Override
-	protected Class<?>[] getAnnotatedClasses() {
-		return new Class[]{
-				JafSid.class, UserGroup.class
-		};
-	}
-
 	@Test
-	public void test() {
-		doInHibernate( this::sessionFactory, s -> {
+	public void test(SessionFactoryScope scope) {
+		scope.inTransaction( s -> {
 			JafSid sid = new JafSid();
 			s.save( sid );
 
@@ -49,7 +45,7 @@ public class LazyCollectionHandlingTest extends BaseCoreFunctionalTestCase {
 			this.id = sid.getId();
 		});
 
-		doInHibernate( this::sessionFactory, s -> {
+		scope.inTransaction( s -> {
 			s.get( JafSid.class, this.id );
 		} );
 	}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/lazy/LazyInitializationWithoutInlineDirtyTrackingTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/lazy/LazyInitializationWithoutInlineDirtyTrackingTest.java
@@ -6,8 +6,6 @@
  */
 package org.hibernate.orm.test.bytecode.enhancement.lazy;
 
-import static org.hibernate.testing.transaction.TransactionUtil.doInHibernate;
-
 import jakarta.persistence.Basic;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -17,30 +15,33 @@ import jakarta.persistence.Lob;
 import jakarta.persistence.Table;
 
 import org.hibernate.bytecode.enhance.spi.UnloadedClass;
-import org.hibernate.testing.TestForIssue;
-import org.hibernate.testing.bytecode.enhancement.BytecodeEnhancerRunner;
+
 import org.hibernate.testing.bytecode.enhancement.CustomEnhancementContext;
 import org.hibernate.testing.bytecode.enhancement.EnhancerTestContext;
-import org.hibernate.testing.junit4.BaseCoreFunctionalTestCase;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.hibernate.testing.bytecode.enhancement.extension.BytecodeEnhanced;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.JiraKey;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Guillaume Smet
  */
-@TestForIssue(jiraKey = "HHH-12633")
-@RunWith(BytecodeEnhancerRunner.class)
+@JiraKey("HHH-12633")
+@DomainModel(
+		annotatedClasses = {
+				LazyInitializationWithoutInlineDirtyTrackingTest.File.class
+		}
+)
+@SessionFactory
+@BytecodeEnhanced
 @CustomEnhancementContext( {EnhancerTestContext.class, LazyInitializationWithoutInlineDirtyTrackingTest.NoInlineDirtyTrackingContext.class} )
-public class LazyInitializationWithoutInlineDirtyTrackingTest extends BaseCoreFunctionalTestCase {
-
-	@Override
-	public Class<?>[] getAnnotatedClasses() {
-		return new Class<?>[]{ File.class };
-	}
+public class LazyInitializationWithoutInlineDirtyTrackingTest {
 
 	@Test
-	public void test() {
-		doInHibernate( this::sessionFactory, s -> {
+	public void test(SessionFactoryScope scope) {
+		scope.inTransaction( s -> {
 			File file = new File();
 			file.setId( 1L );
 			file.setName( "file" );
@@ -49,7 +50,7 @@ public class LazyInitializationWithoutInlineDirtyTrackingTest extends BaseCoreFu
 			s.persist( file );
 		} );
 
-		doInHibernate( this::sessionFactory, s -> {
+		scope.inTransaction( s -> {
 			File file = s.find( File.class, 1L );
 			file.setBytes( new byte[]{ 1 } );
 			s.persist( file );

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/lazy/LazyLoadingIntegrationTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/lazy/LazyLoadingIntegrationTest.java
@@ -9,15 +9,15 @@ package org.hibernate.orm.test.bytecode.enhancement.lazy;
 import org.hibernate.annotations.LazyToOne;
 import org.hibernate.annotations.LazyToOneOption;
 import org.hibernate.cfg.AvailableSettings;
-import org.hibernate.cfg.Configuration;
-import org.hibernate.metamodel.CollectionClassification;
 
-import org.hibernate.testing.bytecode.enhancement.BytecodeEnhancerRunner;
-import org.hibernate.testing.junit4.BaseCoreFunctionalTestCase;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.hibernate.testing.bytecode.enhancement.extension.BytecodeEnhanced;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.ServiceRegistry;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.hibernate.testing.orm.junit.Setting;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Entity;
@@ -31,34 +31,34 @@ import jakarta.persistence.Table;
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.hibernate.cfg.AvailableSettings.DEFAULT_LIST_SEMANTICS;
 import static org.hibernate.testing.bytecode.enhancement.EnhancerTestUtils.checkDirtyTracking;
-import static org.hibernate.testing.transaction.TransactionUtil.doInHibernate;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 /**
  * @author Luis Barreiro
  */
-@RunWith( BytecodeEnhancerRunner.class )
-public class LazyLoadingIntegrationTest extends BaseCoreFunctionalTestCase {
+@DomainModel(
+        annotatedClasses = {
+                LazyLoadingIntegrationTest.Parent.class, LazyLoadingIntegrationTest.Child.class
+        }
+)
+@ServiceRegistry(
+        settings = {
+                @Setting( name = AvailableSettings.USE_SECOND_LEVEL_CACHE, value = "false" ),
+                @Setting( name = AvailableSettings.ENABLE_LAZY_LOAD_NO_TRANS, value = "true" ),
+                @Setting( name = AvailableSettings.DEFAULT_LIST_SEMANTICS, value = "BAG" ),
+        }
+)
+@SessionFactory
+@BytecodeEnhanced
+public class LazyLoadingIntegrationTest {
 
     private static final int CHILDREN_SIZE = 10;
     private Long lastChildID;
 
-    @Override
-    public Class<?>[] getAnnotatedClasses() {
-        return new Class<?>[]{Parent.class, Child.class};
-    }
-
-    @Override
-    protected void configure(Configuration configuration) {
-        configuration.setProperty( AvailableSettings.USE_SECOND_LEVEL_CACHE, false );
-        configuration.setProperty( AvailableSettings.ENABLE_LAZY_LOAD_NO_TRANS, true );
-        configuration.setProperty( DEFAULT_LIST_SEMANTICS, CollectionClassification.BAG );
-    }
-
-    @Before
-    public void prepare() {
-        doInHibernate( this::sessionFactory, s -> {
+    @BeforeEach
+    public void prepare(SessionFactoryScope scope) {
+        scope.inTransaction( s -> {
             Parent parent = new Parent();
             for ( int i = 0; i < CHILDREN_SIZE; i++ ) {
                 Child child = new Child();
@@ -72,8 +72,8 @@ public class LazyLoadingIntegrationTest extends BaseCoreFunctionalTestCase {
     }
 
     @Test
-    public void test() {
-        doInHibernate( this::sessionFactory, s -> {
+    public void test(SessionFactoryScope scope) {
+        scope.inTransaction( s -> {
             Child loadedChild = s.load( Child.class, lastChildID );
             checkDirtyTracking( loadedChild );
 
@@ -89,7 +89,7 @@ public class LazyLoadingIntegrationTest extends BaseCoreFunctionalTestCase {
             loadedChildren.remove( loadedChild );
             loadedParent.setChildren( loadedChildren );
 
-            Assert.assertNull( loadedChild.parent );
+            assertNull( loadedChild.parent );
         } );
     }
 
@@ -97,7 +97,7 @@ public class LazyLoadingIntegrationTest extends BaseCoreFunctionalTestCase {
 
     @Entity
     @Table( name = "PARENT" )
-    private static class Parent {
+    static class Parent {
 
         @Id
         @GeneratedValue( strategy = GenerationType.AUTO )
@@ -113,7 +113,7 @@ public class LazyLoadingIntegrationTest extends BaseCoreFunctionalTestCase {
 
     @Entity
     @Table( name = "CHILD" )
-    private static class Child {
+    static class Child {
 
         @Id
         @GeneratedValue( strategy = GenerationType.AUTO )

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/lazy/LazyManyToOneNoProxyTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/lazy/LazyManyToOneNoProxyTest.java
@@ -1,15 +1,15 @@
 package org.hibernate.orm.test.bytecode.enhancement.lazy;
 
 import org.hibernate.annotations.Proxy;
-import org.hibernate.cfg.Configuration;
 
-import org.hibernate.testing.bytecode.enhancement.BytecodeEnhancerRunner;
+import org.hibernate.testing.bytecode.enhancement.extension.BytecodeEnhanced;
 import org.hibernate.testing.jdbc.SQLStatementInspector;
-import org.hibernate.testing.junit4.BaseCoreFunctionalTestCase;
+import org.hibernate.testing.orm.junit.DomainModel;
 import org.hibernate.testing.orm.junit.JiraKey;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -18,38 +18,32 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
-@RunWith(BytecodeEnhancerRunner.class)
+@DomainModel(
+		annotatedClasses = {
+				LazyManyToOneNoProxyTest.User.class,
+				LazyManyToOneNoProxyTest.UserGroup.class,
+		}
+)
+@SessionFactory
+@BytecodeEnhanced
 @JiraKey("HHH-16794")
-public class LazyManyToOneNoProxyTest extends BaseCoreFunctionalTestCase {
+public class LazyManyToOneNoProxyTest {
 
 	private static final String USER_1_NAME = "Andrea";
 	private static final String USER_2_NAME = "Fab";
 	private static final String USER_GROUP_1_NAME = "group1";
 	private static final String USER_GROUP_2_NAME = "group2";
 
-	@Override
-	protected Class<?>[] getAnnotatedClasses() {
-		return new Class[] {
-				User.class,
-				UserGroup.class,
-		};
+
+	SQLStatementInspector statementInspector(SessionFactoryScope scope) {
+		return (SQLStatementInspector) scope.getSessionFactory().getSessionFactoryOptions().getStatementInspector();
 	}
 
-	@Override
-	protected void afterConfigurationBuilt(Configuration configuration) {
-		super.afterConfigurationBuilt( configuration );
-		configuration.setStatementInspector( new SQLStatementInspector() );
-	}
-
-	SQLStatementInspector statementInspector() {
-		return (SQLStatementInspector) sessionFactory().getSessionFactoryOptions().getStatementInspector();
-	}
-
-	@Before
-	public void setUp() {
-		inTransaction(
+	@BeforeEach
+	public void setUp(SessionFactoryScope scope) {
+		scope.inTransaction(
 				session -> {
 					UserGroup group1 = new UserGroup( 1l, USER_GROUP_1_NAME );
 					UserGroup group2 = new UserGroup( 2l, USER_GROUP_2_NAME );
@@ -66,10 +60,10 @@ public class LazyManyToOneNoProxyTest extends BaseCoreFunctionalTestCase {
 	}
 
 	@Test
-	public void testSelect() {
-		inTransaction(
+	public void testSelect(SessionFactoryScope scope) {
+		scope.inTransaction(
 				session -> {
-					SQLStatementInspector statementInspector = statementInspector();
+					SQLStatementInspector statementInspector = statementInspector( scope );
 					statementInspector.clear();
 
 					User user = session.getReference( User.class, 1 );

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/lazy/LazyOneToManyWithEqualsImplementationTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/lazy/LazyOneToManyWithEqualsImplementationTest.java
@@ -8,13 +8,15 @@ package org.hibernate.orm.test.bytecode.enhancement.lazy;
 
 import org.hibernate.annotations.LazyToOne;
 import org.hibernate.annotations.LazyToOneOption;
-import org.hibernate.orm.test.jpa.BaseEntityManagerFunctionalTestCase;
-import org.hibernate.testing.TestForIssue;
-import org.hibernate.testing.bytecode.enhancement.BytecodeEnhancerRunner;
+import org.hibernate.testing.bytecode.enhancement.extension.BytecodeEnhanced;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.JiraKey;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import jakarta.persistence.Basic;
 import jakarta.persistence.Entity;
@@ -28,24 +30,22 @@ import java.util.HashSet;
 import java.util.Objects;
 import java.util.Set;
 
-import static org.hibernate.testing.transaction.TransactionUtil.doInJPA;
-import static org.junit.Assert.assertEquals;
 
-@TestForIssue(jiraKey = "HHH-13380")
-@RunWith( BytecodeEnhancerRunner.class )
-public class LazyOneToManyWithEqualsImplementationTest
-        extends BaseEntityManagerFunctionalTestCase {
+@JiraKey("HHH-13380")
+@DomainModel(
+        annotatedClasses = {
+                LazyOneToManyWithEqualsImplementationTest.Person.class, LazyOneToManyWithEqualsImplementationTest.Course.class
+        }
+)
+@SessionFactory
+@BytecodeEnhanced
+public class LazyOneToManyWithEqualsImplementationTest {
 
     private Long personId;
 
-    @Override
-    protected Class<?>[] getAnnotatedClasses() {
-        return new Class<?>[] { Person.class, Course.class };
-    }
-
-    @Before
-    public void setUp() {
-        doInJPA( this::entityManagerFactory, entityManager -> {
+    @BeforeEach
+    public void setUp(SessionFactoryScope scope) {
+        scope.inTransaction( entityManager -> {
             Person p = new Person();
             entityManager.persist(p);
             personId = p.getId();
@@ -62,12 +62,12 @@ public class LazyOneToManyWithEqualsImplementationTest
 
 
     @Test
-    public void testRetrievalOfOneToMany() {
-        doInJPA(this::entityManagerFactory, entityManager -> {
+    public void testRetrievalOfOneToMany(SessionFactoryScope scope) {
+        scope.inTransaction( entityManager -> {
             Person p = entityManager.find( Person.class, personId );
 
             Set<Course> courses = p.getCourses();
-            assertEquals( courses.size(), 2 );
+            Assertions.assertEquals( courses.size(), 2 );
         });
     }
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/lazy/ReferenceLoadedEnhancedEntityTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/lazy/ReferenceLoadedEnhancedEntityTest.java
@@ -8,23 +8,25 @@ package org.hibernate.orm.test.bytecode.enhancement.lazy;
 
 import org.hibernate.ObjectNotFoundException;
 import org.hibernate.cfg.AvailableSettings;
-import org.hibernate.cfg.Configuration;
 
-import org.hibernate.testing.bytecode.enhancement.BytecodeEnhancerRunner;
-import org.hibernate.testing.junit4.BaseCoreFunctionalTestCase;
+import org.hibernate.testing.bytecode.enhancement.extension.BytecodeEnhanced;
+import org.hibernate.testing.orm.junit.DomainModel;
 import org.hibernate.testing.orm.junit.JiraKey;
-import org.junit.Assert;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.hibernate.testing.orm.junit.ServiceRegistry;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.hibernate.testing.orm.junit.Setting;
 
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 
-import static org.hibernate.testing.transaction.TransactionUtil.doInHibernate;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import org.junit.jupiter.api.Test;
 
 /**
  * Verifies that an object loaded via getReference and with
@@ -34,23 +36,24 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
  * doesn't exist in the database and a property is being read
  * forcing initialization.
  */
-@RunWith(BytecodeEnhancerRunner.class)
+@DomainModel(
+		annotatedClasses = {
+				ReferenceLoadedEnhancedEntityTest.Country.class
+		}
+)
+@ServiceRegistry(
+		settings = {
+				@Setting( name = AvailableSettings.DEFAULT_BATCH_FETCH_SIZE, value = "10" ),
+		}
+)
+@SessionFactory
+@BytecodeEnhanced
 @JiraKey("HHH-16669")
-public class ReferenceLoadedEnhancedEntityTest extends BaseCoreFunctionalTestCase {
-
-	@Override
-	public Class<?>[] getAnnotatedClasses() {
-		return new Class<?>[] { Country.class };
-	}
-
-	@Override
-	protected void configure(Configuration configuration) {
-		configuration.setProperty( AvailableSettings.DEFAULT_BATCH_FETCH_SIZE, 10 );
-	}
+public class ReferenceLoadedEnhancedEntityTest {
 
 	@Test
-	public void referenceLoadAlwaysWorks() {
-		doInHibernate( this::sessionFactory, s -> {
+	public void referenceLoadAlwaysWorks(SessionFactoryScope scope) {
+		scope.inTransaction( s -> {
 			//Materialize a reference to an object which doesn't exist
 			final Country entity = s.getReference( Country.class, 1L );
 			//should be fine..
@@ -58,59 +61,59 @@ public class ReferenceLoadedEnhancedEntityTest extends BaseCoreFunctionalTestCas
 	}
 
 	@Test
-	public void referenceNotExisting() {
+	public void referenceNotExisting(SessionFactoryScope scope) {
 		Exception exception = assertThrows( ObjectNotFoundException.class,
-				() -> doInHibernate( this::sessionFactory, s -> {
+				() -> scope.inTransaction( s -> {
 			//Materialize a reference to an object which doesn't exist
 			final Country entity = s.getReference( Country.class, 1L );
 			//This should fail:
 			final String name = entity.getName();
 			//Ensure we failed at the previous line:
-			Assert.fail( "Should have thrown an ObjectNotFoundException exception before reaching this point" );
+			fail( "Should have thrown an ObjectNotFoundException exception before reaching this point" );
 		} ) );
 		assertNotNull( exception );
 	}
 
 	@Test
-	public void referenceNotExisting2() {
+	public void referenceNotExisting2(SessionFactoryScope scope) {
 		Exception exception = assertThrows( ObjectNotFoundException.class,
-				() -> doInHibernate( this::sessionFactory, s -> {
+				() -> scope.inTransaction( s -> {
 			//Materialize a reference to an object which doesn't exist
 			final Country entity = s.getReference( Country.class, 1L );
 			final Country entity2 = s.getReference( Country.class, 2L );
 			//This should fail:
 			final String name = entity.getName();
 			//Ensure we failed at the previous line:
-			Assert.fail( "Should have thrown an ObjectNotFoundException exception before reaching this point" );
+			fail( "Should have thrown an ObjectNotFoundException exception before reaching this point" );
 		} ) );
 		assertNotNull( exception );
 	}
 
 	@Test
-	public void referenceNotExistingFieldAccess() {
+	public void referenceNotExistingFieldAccess(SessionFactoryScope scope) {
 		Exception exception = assertThrows( ObjectNotFoundException.class,
-				() -> doInHibernate( this::sessionFactory, s -> {
+				() -> scope.inTransaction( s -> {
 			//Materialize a reference to an object which doesn't exist
 			final Country entity = s.getReference( Country.class, 1L );
 			//This should fail:
 			final String name = entity.name;
 			//Ensure we failed at the previous line:
-			Assert.fail( "Should have thrown an ObjectNotFoundException exception before reaching this point" );
+			fail( "Should have thrown an ObjectNotFoundException exception before reaching this point" );
 		} ) );
 		assertNotNull( exception );
 	}
 
 	@Test
-	public void referenceNotExistingFieldAccess2() {
+	public void referenceNotExistingFieldAccess2(SessionFactoryScope scope) {
 		Exception exception = assertThrows( ObjectNotFoundException.class,
-				() -> doInHibernate( this::sessionFactory, s -> {
+				() -> scope.inTransaction( s -> {
 			//Materialize a reference to an object which doesn't exist
 			final Country entity = s.getReference( Country.class, 1L );
 			final Country entity2 = s.getReference( Country.class, 2L );
 			//This should fail:
 			final String name = entity.name;
 			//Ensure we failed at the previous line:
-			Assert.fail( "Should have thrown an ObjectNotFoundException exception before reaching this point" );
+			fail( "Should have thrown an ObjectNotFoundException exception before reaching this point" );
 		} ) );
 		assertNotNull( exception );
 	}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/lazy/backref/BackrefCompositeMapKeyTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/lazy/backref/BackrefCompositeMapKeyTest.java
@@ -16,15 +16,16 @@ import org.hibernate.orm.test.collection.backref.map.compkey.MapKey;
 import org.hibernate.orm.test.collection.backref.map.compkey.Part;
 import org.hibernate.orm.test.collection.backref.map.compkey.Product;
 
-import org.hibernate.testing.bytecode.enhancement.BytecodeEnhancerRunner;
 import org.hibernate.testing.bytecode.enhancement.CustomEnhancementContext;
-import org.hibernate.testing.junit4.BaseCoreFunctionalTestCase;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.hibernate.testing.bytecode.enhancement.extension.BytecodeEnhanced;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 
 /**
@@ -33,20 +34,19 @@ import static org.junit.Assert.assertTrue;
  *
  * @author Steve Ebersole
  */
-@RunWith( BytecodeEnhancerRunner.class )
-@CustomEnhancementContext({ NoDirtyCheckingContext.class, DirtyCheckEnhancementContext.class })
-public class BackrefCompositeMapKeyTest extends BaseCoreFunctionalTestCase {
-
-	@Override
-	protected String[] getOrmXmlFiles() {
-		return new String[] {
+@DomainModel(
+		xmlMappings = {
 				"org/hibernate/orm/test/collection/backref/map/compkey/Mappings.hbm.xml"
-		};
-	}
+		}
+)
+@SessionFactory
+@BytecodeEnhanced
+@CustomEnhancementContext({ NoDirtyCheckingContext.class, DirtyCheckEnhancementContext.class })
+public class BackrefCompositeMapKeyTest {
 
 	@Test
-	public void testOrphanDeleteOnDelete() {
-		inTransaction(
+	public void testOrphanDeleteOnDelete(SessionFactoryScope scope) {
+		scope.inTransaction(
 				session -> {
 					Product prod = new Product( "Widget" );
 					Part part = new Part( "Widge", "part if a Widget" );
@@ -63,18 +63,18 @@ public class BackrefCompositeMapKeyTest extends BaseCoreFunctionalTestCase {
 				}
 		);
 
-		inTransaction(
+		scope.inTransaction(
 				session -> {
-					assertNull( "Orphan 'Widge' was not deleted", session.get( Part.class, "Widge" ) );
-					assertNull( "Orphan 'Get' was not deleted", session.get( Part.class, "Get" ) );
-					assertNull( "Orphan 'Widget' was not deleted", session.get( Product.class, "Widget" ) );
+					assertNull( session.get( Part.class, "Widge" ), "Orphan 'Widge' was not deleted" );
+					assertNull( session.get( Part.class, "Get" ), "Orphan 'Get' was not deleted" );
+					assertNull( session.get( Product.class, "Widget" ), "Orphan 'Widget' was not deleted" );
 				}
 		);
 	}
 
 	@Test
-	public void testOrphanDeleteAfterPersist() {
-		inTransaction(
+	public void testOrphanDeleteAfterPersist(SessionFactoryScope scope) {
+		scope.inTransaction(
 				session -> {
 					Product prod = new Product( "Widget" );
 					Part part = new Part( "Widge", "part if a Widget" );
@@ -88,15 +88,15 @@ public class BackrefCompositeMapKeyTest extends BaseCoreFunctionalTestCase {
 				}
 		);
 
-		inTransaction(
+		scope.inTransaction(
 				session ->
 						session.delete( session.get( Product.class, "Widget" ) )
 		);
 	}
 
 	@Test
-	public void testOrphanDeleteAfterPersistAndFlush() {
-		inTransaction(
+	public void testOrphanDeleteAfterPersistAndFlush(SessionFactoryScope scope) {
+		scope.inTransaction(
 				session -> {
 					Product prod = new Product( "Widget" );
 					Part part = new Part( "Widge", "part if a Widget" );
@@ -111,7 +111,7 @@ public class BackrefCompositeMapKeyTest extends BaseCoreFunctionalTestCase {
 				}
 		);
 
-		inTransaction(
+		scope.inTransaction(
 				session -> {
 					assertNull( session.get( Part.class, "Widge" ) );
 					assertNotNull( session.get( Part.class, "Get" ) );
@@ -122,10 +122,10 @@ public class BackrefCompositeMapKeyTest extends BaseCoreFunctionalTestCase {
 	}
 
 	@Test
-	public void testOrphanDeleteAfterLock() {
+	public void testOrphanDeleteAfterLock(SessionFactoryScope scope) {
 		Product prod = new Product( "Widget" );
 		MapKey mapKey = new MapKey( "Top" );
-		inTransaction(
+		scope.inTransaction(
 				session -> {
 					Part part = new Part( "Widge", "part if a Widget" );
 					prod.getParts().put( mapKey, part );
@@ -136,14 +136,14 @@ public class BackrefCompositeMapKeyTest extends BaseCoreFunctionalTestCase {
 		);
 
 
-		inTransaction(
+		scope.inTransaction(
 				session -> {
 					session.lock( prod, LockMode.READ );
 					prod.getParts().remove( mapKey );
 				}
 		);
 
-		inTransaction(
+		scope.inTransaction(
 				session -> {
 					assertNull( session.get( Part.class, "Widge" ) );
 					assertNotNull( session.get( Part.class, "Get" ) );
@@ -153,10 +153,10 @@ public class BackrefCompositeMapKeyTest extends BaseCoreFunctionalTestCase {
 	}
 
 	@Test
-	public void testOrphanDeleteOnSaveOrUpdate() {
+	public void testOrphanDeleteOnSaveOrUpdate(SessionFactoryScope scope) {
 		Product prod = new Product( "Widget" );
 		MapKey mapKey = new MapKey( "Top" );
-		inTransaction(
+		scope.inTransaction(
 				session -> {
 					Part part = new Part( "Widge", "part if a Widget" );
 					prod.getParts().put( mapKey, part );
@@ -168,12 +168,12 @@ public class BackrefCompositeMapKeyTest extends BaseCoreFunctionalTestCase {
 
 		prod.getParts().remove( mapKey );
 
-		inTransaction(
+		scope.inTransaction(
 				session ->
 						session.saveOrUpdate( prod )
 		);
 
-		inTransaction(
+		scope.inTransaction(
 				session -> {
 					assertNull( session.get( Part.class, "Widge" ) );
 					assertNotNull( session.get( Part.class, "Get" ) );
@@ -183,10 +183,10 @@ public class BackrefCompositeMapKeyTest extends BaseCoreFunctionalTestCase {
 	}
 
 	@Test
-	public void testOrphanDeleteOnSaveOrUpdateAfterSerialization() {
+	public void testOrphanDeleteOnSaveOrUpdateAfterSerialization(SessionFactoryScope scope) {
 		Product prod = new Product( "Widget" );
 		MapKey mapKey = new MapKey( "Top" );
-		inTransaction(
+		scope.inTransaction(
 				session -> {
 					Part part = new Part( "Widge", "part if a Widget" );
 					prod.getParts().put( mapKey, part );
@@ -200,12 +200,12 @@ public class BackrefCompositeMapKeyTest extends BaseCoreFunctionalTestCase {
 
 		Product cloned = (Product) SerializationHelper.clone( prod );
 
-		inTransaction(
+		scope.inTransaction(
 				session ->
 						session.saveOrUpdate( cloned )
 		);
 
-		inTransaction(
+		scope.inTransaction(
 				session -> {
 					assertNull( session.get( Part.class, "Widge" ) );
 					assertNotNull( session.get( Part.class, "Get" ) );
@@ -215,9 +215,9 @@ public class BackrefCompositeMapKeyTest extends BaseCoreFunctionalTestCase {
 	}
 
 	@Test
-	public void testOrphanDelete() {
+	public void testOrphanDelete(SessionFactoryScope scope) {
 		MapKey mapKey = new MapKey( "Top" );
-		inTransaction(
+		scope.inTransaction(
 				session -> {
 					Product prod = new Product( "Widget" );
 					Part part = new Part( "Widge", "part if a Widget" );
@@ -229,11 +229,11 @@ public class BackrefCompositeMapKeyTest extends BaseCoreFunctionalTestCase {
 		);
 
 
-		SessionFactoryImplementor sessionFactory = sessionFactory();
+		SessionFactoryImplementor sessionFactory = scope.getSessionFactory();
 		sessionFactory.getCache().evictEntityData( Product.class );
 		sessionFactory.getCache().evictEntityData( Part.class );
 
-		inTransaction(
+		scope.inTransaction(
 				session -> {
 					Product prod = session.get( Product.class, "Widget" );
 					assertTrue( Hibernate.isInitialized( prod.getParts() ) );
@@ -246,7 +246,7 @@ public class BackrefCompositeMapKeyTest extends BaseCoreFunctionalTestCase {
 		sessionFactory.getCache().evictEntityData( Product.class );
 		sessionFactory.getCache().evictEntityData( Part.class );
 
-		inTransaction(
+		scope.inTransaction(
 				session -> {
 					Product prod = session.get( Product.class, "Widget" );
 					assertTrue( Hibernate.isInitialized( prod.getParts() ) );
@@ -258,10 +258,10 @@ public class BackrefCompositeMapKeyTest extends BaseCoreFunctionalTestCase {
 	}
 
 	@Test
-	public void testOrphanDeleteOnMerge() {
+	public void testOrphanDeleteOnMerge(SessionFactoryScope scope) {
 		Product prod = new Product( "Widget" );
 		MapKey mapKey = new MapKey( "Top" );
-		inTransaction(
+		scope.inTransaction(
 				session -> {
 					Part part = new Part( "Widge", "part if a Widget" );
 					prod.getParts().put( mapKey, part );
@@ -274,12 +274,12 @@ public class BackrefCompositeMapKeyTest extends BaseCoreFunctionalTestCase {
 
 		prod.getParts().remove( mapKey );
 
-		inTransaction(
+		scope.inTransaction(
 				session ->
 						session.merge( prod )
 		);
 
-		inTransaction(
+		scope.inTransaction(
 				session -> {
 					assertNull( session.get( Part.class, "Widge" ) );
 					assertNotNull( session.get( Part.class, "Get" ) );

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/lazy/basic/LazyBasicFieldAccessTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/lazy/basic/LazyBasicFieldAccessTest.java
@@ -7,15 +7,16 @@
 package org.hibernate.orm.test.bytecode.enhancement.lazy.basic;
 
 import org.hibernate.cfg.AvailableSettings;
-import org.hibernate.cfg.Configuration;
 
-import org.hibernate.testing.TestForIssue;
-import org.hibernate.testing.bytecode.enhancement.BytecodeEnhancerRunner;
-import org.hibernate.testing.junit4.BaseCoreFunctionalTestCase;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.hibernate.testing.bytecode.enhancement.extension.BytecodeEnhanced;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.JiraKey;
+import org.hibernate.testing.orm.junit.ServiceRegistry;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.hibernate.testing.orm.junit.Setting;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import jakarta.persistence.Access;
 import jakarta.persistence.AccessType;
@@ -28,34 +29,35 @@ import jakarta.persistence.Table;
 
 import static org.hibernate.Hibernate.isPropertyInitialized;
 import static org.hibernate.testing.bytecode.enhancement.EnhancerTestUtils.checkDirtyTracking;
-import static org.hibernate.testing.transaction.TransactionUtil.doInHibernate;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * @author Gail Badner
  */
-@RunWith( BytecodeEnhancerRunner.class )
-public class LazyBasicFieldAccessTest extends BaseCoreFunctionalTestCase {
+@DomainModel(
+        annotatedClasses = {
+                LazyBasicFieldAccessTest.LazyEntity.class
+        }
+)
+@ServiceRegistry(
+        settings = {
+                @Setting( name = AvailableSettings.USE_SECOND_LEVEL_CACHE, value = "false" ),
+                @Setting( name = AvailableSettings.ENABLE_LAZY_LOAD_NO_TRANS, value = "true" ),
+        }
+)
+@SessionFactory
+@BytecodeEnhanced
+public class LazyBasicFieldAccessTest {
 
     private LazyEntity entity;
 
     private Long entityId;
 
-    @Override
-    public Class<?>[] getAnnotatedClasses() {
-        return new Class<?>[]{LazyEntity.class};
-    }
-
-    @Override
-    protected void configure(Configuration configuration) {
-        configuration.setProperty( AvailableSettings.USE_SECOND_LEVEL_CACHE, false );
-        configuration.setProperty( AvailableSettings.ENABLE_LAZY_LOAD_NO_TRANS, true );
-    }
-
-    @Before
-    public void prepare() {
-        doInHibernate( this::sessionFactory, s -> {
+    @BeforeEach
+    public void prepare(SessionFactoryScope scope) {
+        scope.inTransaction( s -> {
             LazyEntity entity = new LazyEntity();
             entity.description = "desc";
             s.persist( entity );
@@ -64,20 +66,20 @@ public class LazyBasicFieldAccessTest extends BaseCoreFunctionalTestCase {
     }
 
     @Test
-    public void testAttachedUpdate() {
-        doInHibernate( this::sessionFactory, s -> {
+    public void testAttachedUpdate(SessionFactoryScope scope) {
+        scope.inTransaction( s -> {
             entity = s.get( LazyEntity.class, entityId );
 
-            Assert.assertFalse( isPropertyInitialized( entity, "description" ) );
+            assertFalse( isPropertyInitialized( entity, "description" ) );
             checkDirtyTracking( entity );
 
             assertEquals( "desc", entity.description );
             assertTrue( isPropertyInitialized( entity, "description" ) );
         } );
 
-        doInHibernate( this::sessionFactory, s -> {
+        scope.inTransaction( s -> {
             entity = s.get( LazyEntity.class, entityId );
-            Assert.assertFalse( isPropertyInitialized( entity, "description" ) );
+            assertFalse( isPropertyInitialized( entity, "description" ) );
             entity.description = "desc1";
 
             checkDirtyTracking( entity, "description" );
@@ -86,26 +88,26 @@ public class LazyBasicFieldAccessTest extends BaseCoreFunctionalTestCase {
             assertTrue( isPropertyInitialized( entity, "description" ) );
         } );
 
-        doInHibernate( this::sessionFactory, s -> {
+        scope.inTransaction( s -> {
             entity = s.get( LazyEntity.class, entityId );
             assertEquals( "desc1", entity.description );
         } );
     }
 
     @Test
-    @TestForIssue(jiraKey = "HHH-11882")
-    public void testDetachedUpdate() {
-        doInHibernate( this::sessionFactory, s -> {
+    @JiraKey("HHH-11882")
+    public void testDetachedUpdate(SessionFactoryScope scope) {
+        scope.inTransaction( s -> {
             entity = s.get( LazyEntity.class, entityId );
 
-            Assert.assertFalse( isPropertyInitialized( entity, "description" ) );
+            assertFalse( isPropertyInitialized( entity, "description" ) );
             checkDirtyTracking( entity );
 
             assertEquals( "desc", entity.description );
             assertTrue( isPropertyInitialized( entity, "description" ) );
         } );
 
-        doInHibernate( this::sessionFactory, s -> {
+        scope.inTransaction( s -> {
             entity.description = "desc1";
             s.update( entity );
 
@@ -115,12 +117,12 @@ public class LazyBasicFieldAccessTest extends BaseCoreFunctionalTestCase {
             assertTrue( isPropertyInitialized( entity, "description" ) );
         } );
 
-        doInHibernate( this::sessionFactory, s -> {
+        scope.inTransaction( s -> {
             entity = s.get( LazyEntity.class, entityId );
             assertEquals( "desc1", entity.description );
         } );
 
-        doInHibernate( this::sessionFactory, s -> {
+        scope.inTransaction( s -> {
             entity.description = "desc2";
             LazyEntity mergedEntity = (LazyEntity) s.merge( entity );
 
@@ -131,7 +133,7 @@ public class LazyBasicFieldAccessTest extends BaseCoreFunctionalTestCase {
             assertTrue( isPropertyInitialized( mergedEntity, "description" ) );
         } );
 
-        doInHibernate( this::sessionFactory, s -> {
+        scope.inTransaction( s -> {
             entity = s.get( LazyEntity.class, entityId );
             assertEquals( "desc2", entity.description );
         } );
@@ -142,7 +144,7 @@ public class LazyBasicFieldAccessTest extends BaseCoreFunctionalTestCase {
     @Entity
     @Access( AccessType.FIELD )
     @Table( name = "LAZY_PROPERTY_ENTITY" )
-    private static class LazyEntity {
+    static class LazyEntity {
 
         @Id
         @GeneratedValue

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/lazy/basic/OnlyEagerBasicUpdateTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/lazy/basic/OnlyEagerBasicUpdateTest.java
@@ -6,22 +6,21 @@
  */
 package org.hibernate.orm.test.bytecode.enhancement.lazy.basic;
 
-import static org.hibernate.testing.transaction.TransactionUtil.doInHibernate;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
-import org.hibernate.cfg.Configuration;
 import org.hibernate.orm.test.bytecode.enhancement.lazy.NoDirtyCheckingContext;
 
-import org.hibernate.testing.TestForIssue;
-import org.hibernate.testing.bytecode.enhancement.BytecodeEnhancerRunner;
 import org.hibernate.testing.bytecode.enhancement.CustomEnhancementContext;
 import org.hibernate.testing.bytecode.enhancement.EnhancerTestContext;
+import org.hibernate.testing.bytecode.enhancement.extension.BytecodeEnhanced;
 import org.hibernate.testing.jdbc.SQLStatementInspector;
-import org.hibernate.testing.junit4.BaseCoreFunctionalTestCase;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.JiraKey;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import jakarta.persistence.Basic;
 import jakarta.persistence.Entity;
@@ -35,38 +34,33 @@ import jakarta.persistence.Table;
  * This is mostly for comparison with {@link EagerAndLazyBasicUpdateTest}/{@link OnlyLazyBasicUpdateTest},
  * because the mere presence of lazy properties in one entity may affect the behavior of eager properties, too.
  */
-@RunWith(BytecodeEnhancerRunner.class)
+@DomainModel(
+		annotatedClasses = {
+				OnlyEagerBasicUpdateTest.EagerEntity.class
+		}
+)
+@SessionFactory
+@BytecodeEnhanced
 @CustomEnhancementContext({ EnhancerTestContext.class, NoDirtyCheckingContext.class })
-@TestForIssue(jiraKey = "HHH-16049")
-public class OnlyEagerBasicUpdateTest extends BaseCoreFunctionalTestCase {
+@JiraKey("HHH-16049")
+public class OnlyEagerBasicUpdateTest {
 
 	private Long entityId;
 
-	@Override
-	public Class<?>[] getAnnotatedClasses() {
-		return new Class<?>[] { EagerEntity.class };
+	SQLStatementInspector statementInspector(SessionFactoryScope scope) {
+		return (SQLStatementInspector) scope.getSessionFactory().getSessionFactoryOptions().getStatementInspector();
 	}
 
-	@Override
-	protected void afterConfigurationBuilt(Configuration configuration) {
-		super.afterConfigurationBuilt( configuration );
-		configuration.setStatementInspector( new SQLStatementInspector() );
-	}
-
-	SQLStatementInspector statementInspector() {
-		return (SQLStatementInspector) sessionFactory().getSessionFactoryOptions().getStatementInspector();
-	}
-
-	private void initNull() {
-		doInHibernate( this::sessionFactory, s -> {
+	private void initNull(SessionFactoryScope scope) {
+		scope.inTransaction( s -> {
 			EagerEntity entity = new EagerEntity();
 			s.persist( entity );
 			entityId = entity.getId();
 		} );
 	}
 
-	private void initNonNull() {
-		doInHibernate( this::sessionFactory, s -> {
+	private void initNonNull(SessionFactoryScope scope) {
+		scope.inTransaction( s -> {
 			EagerEntity entity = new EagerEntity();
 			entity.setEagerProperty1( "eager1_initial" );
 			entity.setEagerProperty2( "eager2_initial" );
@@ -75,31 +69,31 @@ public class OnlyEagerBasicUpdateTest extends BaseCoreFunctionalTestCase {
 		} );
 	}
 
-	@Before
-	public void clearStatementInspector() {
-		statementInspector().clear();
+	@BeforeEach
+	public void clearStatementInspector(SessionFactoryScope scope) {
+		statementInspector( scope ).clear();
 	}
 
 	@Test
-	public void updateSomeEagerProperty_nullToNull() {
-		initNull();
-		doInHibernate( this::sessionFactory, s -> {
+	public void updateSomeEagerProperty_nullToNull(SessionFactoryScope scope) {
+		initNull( scope );
+		scope.inTransaction( s -> {
 			EagerEntity entity = s.get( EagerEntity.class, entityId );
 			entity.setEagerProperty1( null );
 		} );
 
 		// We should not update entities when property values did not change
-		statementInspector().assertNoUpdate();
+		statementInspector( scope ).assertNoUpdate();
 	}
 
 	@Test
-	public void updateSomeEagerProperty_nullToNonNull() {
-		initNull();
-		doInHibernate( this::sessionFactory, s -> {
+	public void updateSomeEagerProperty_nullToNonNull(SessionFactoryScope scope) {
+		initNull( scope );
+		scope.inTransaction( s -> {
 			EagerEntity entity = s.get( EagerEntity.class, entityId );
 			entity.setEagerProperty1( "eager1_update" );
 		} );
-		doInHibernate( this::sessionFactory, s -> {
+		scope.inTransaction( s -> {
 			EagerEntity entity = s.get( EagerEntity.class, entityId );
 			assertEquals( "eager1_update", entity.getEagerProperty1() );
 
@@ -108,13 +102,13 @@ public class OnlyEagerBasicUpdateTest extends BaseCoreFunctionalTestCase {
 	}
 
 	@Test
-	public void updateSomeEagerProperty_nonNullToNonNull_differentValues() {
-		initNonNull();
-		doInHibernate( this::sessionFactory, s -> {
+	public void updateSomeEagerProperty_nonNullToNonNull_differentValues(SessionFactoryScope scope) {
+		initNonNull( scope );
+		scope.inTransaction( s -> {
 			EagerEntity entity = s.get( EagerEntity.class, entityId );
 			entity.setEagerProperty1( "eager1_update" );
 		} );
-		doInHibernate( this::sessionFactory, s -> {
+		scope.inTransaction( s -> {
 			EagerEntity entity = s.get( EagerEntity.class, entityId );
 			assertEquals( "eager1_update", entity.getEagerProperty1() );
 
@@ -123,25 +117,25 @@ public class OnlyEagerBasicUpdateTest extends BaseCoreFunctionalTestCase {
 	}
 
 	@Test
-	public void updateSomeEagerProperty_nonNullToNonNull_sameValues() {
-		initNonNull();
-		doInHibernate( this::sessionFactory, s -> {
+	public void updateSomeEagerProperty_nonNullToNonNull_sameValues(SessionFactoryScope scope) {
+		initNonNull( scope );
+		scope.inTransaction( s -> {
 			EagerEntity entity = s.get( EagerEntity.class, entityId );
 			entity.setEagerProperty1( entity.getEagerProperty1() );
 		} );
 
 		// We should not update entities when property values did not change
-		statementInspector().assertNoUpdate();
+		statementInspector( scope ).assertNoUpdate();
 	}
 
 	@Test
-	public void updateSomeEagerProperty_nonNullToNull() {
-		initNonNull();
-		doInHibernate( this::sessionFactory, s -> {
+	public void updateSomeEagerProperty_nonNullToNull(SessionFactoryScope scope) {
+		initNonNull( scope );
+		scope.inTransaction( s -> {
 			EagerEntity entity = s.get( EagerEntity.class, entityId );
 			entity.setEagerProperty1( null );
 		} );
-		doInHibernate( this::sessionFactory, s -> {
+		scope.inTransaction( s -> {
 			EagerEntity entity = s.get( EagerEntity.class, entityId );
 			assertNull( entity.getEagerProperty1() );
 
@@ -150,27 +144,27 @@ public class OnlyEagerBasicUpdateTest extends BaseCoreFunctionalTestCase {
 	}
 
 	@Test
-	public void updateAllEagerProperties_nullToNull() {
-		initNull();
-		doInHibernate( this::sessionFactory, s -> {
+	public void updateAllEagerProperties_nullToNull(SessionFactoryScope scope) {
+		initNull( scope );
+		scope.inTransaction( s -> {
 			EagerEntity entity = s.get( EagerEntity.class, entityId );
 			entity.setEagerProperty1( null );
 			entity.setEagerProperty2( null );
 		} );
 
 		// We should not update entities when property values did not change
-		statementInspector().assertNoUpdate();
+		statementInspector( scope ).assertNoUpdate();
 	}
 
 	@Test
-	public void updateAllEagerProperties_nullToNonNull() {
-		initNull();
-		doInHibernate( this::sessionFactory, s -> {
+	public void updateAllEagerProperties_nullToNonNull(SessionFactoryScope scope) {
+		initNull( scope );
+		scope.inTransaction( s -> {
 			EagerEntity entity = s.get( EagerEntity.class, entityId );
 			entity.setEagerProperty1( "eager1_update" );
 			entity.setEagerProperty2( "eager2_update" );
 		} );
-		doInHibernate( this::sessionFactory, s -> {
+		scope.inTransaction( s -> {
 			EagerEntity entity = s.get( EagerEntity.class, entityId );
 			assertEquals( "eager1_update", entity.getEagerProperty1() );
 			assertEquals( "eager2_update", entity.getEagerProperty2() );
@@ -178,14 +172,14 @@ public class OnlyEagerBasicUpdateTest extends BaseCoreFunctionalTestCase {
 	}
 
 	@Test
-	public void updateAllEagerProperties_nonNullToNonNull_differentValues() {
-		initNonNull();
-		doInHibernate( this::sessionFactory, s -> {
+	public void updateAllEagerProperties_nonNullToNonNull_differentValues(SessionFactoryScope scope) {
+		initNonNull( scope );
+		scope.inTransaction( s -> {
 			EagerEntity entity = s.get( EagerEntity.class, entityId );
 			entity.setEagerProperty1( "eager1_update" );
 			entity.setEagerProperty2( "eager2_update" );
 		} );
-		doInHibernate( this::sessionFactory, s -> {
+		scope.inTransaction( s -> {
 			EagerEntity entity = s.get( EagerEntity.class, entityId );
 			assertEquals( "eager1_update", entity.getEagerProperty1() );
 			assertEquals( "eager2_update", entity.getEagerProperty2() );
@@ -193,27 +187,27 @@ public class OnlyEagerBasicUpdateTest extends BaseCoreFunctionalTestCase {
 	}
 
 	@Test
-	public void updateAllEagerProperties_nonNullToNonNull_sameValues() {
-		initNonNull();
-		doInHibernate( this::sessionFactory, s -> {
+	public void updateAllEagerProperties_nonNullToNonNull_sameValues(SessionFactoryScope scope) {
+		initNonNull( scope );
+		scope.inTransaction( s -> {
 			EagerEntity entity = s.get( EagerEntity.class, entityId );
 			entity.setEagerProperty1( entity.getEagerProperty1() );
 			entity.setEagerProperty2( entity.getEagerProperty2() );
 		} );
 
 		// We should not update entities when property values did not change
-		statementInspector().assertNoUpdate();
+		statementInspector( scope ).assertNoUpdate();
 	}
 
 	@Test
-	public void updateAllEagerProperties_nonNullToNull() {
-		initNonNull();
-		doInHibernate( this::sessionFactory, s -> {
+	public void updateAllEagerProperties_nonNullToNull(SessionFactoryScope scope) {
+		initNonNull( scope );
+		scope.inTransaction( s -> {
 			EagerEntity entity = s.get( EagerEntity.class, entityId );
 			entity.setEagerProperty1( null );
 			entity.setEagerProperty2( null );
 		} );
-		doInHibernate( this::sessionFactory, s -> {
+		scope.inTransaction( s -> {
 			EagerEntity entity = s.get( EagerEntity.class, entityId );
 			assertNull( entity.getEagerProperty1() );
 			assertNull( entity.getEagerProperty2() );
@@ -222,7 +216,7 @@ public class OnlyEagerBasicUpdateTest extends BaseCoreFunctionalTestCase {
 
 	@Entity
 	@Table(name = "LAZY_ENTITY")
-	private static class EagerEntity {
+	static class EagerEntity {
 		@Id
 		@GeneratedValue
 		Long id;

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/lazy/group/LazyGroupMappedByTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/lazy/group/LazyGroupMappedByTest.java
@@ -1,42 +1,42 @@
 package org.hibernate.orm.test.bytecode.enhancement.lazy.group;
 
-import static org.hibernate.testing.transaction.TransactionUtil.doInHibernate;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.hibernate.stat.SessionStatistics;
 import org.hibernate.stat.Statistics;
 
-import org.hibernate.testing.TestForIssue;
-import org.hibernate.testing.bytecode.enhancement.BytecodeEnhancerRunner;
-import org.hibernate.testing.junit4.BaseCoreFunctionalTestCase;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.hibernate.testing.bytecode.enhancement.extension.BytecodeEnhanced;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.JiraKey;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.junit.jupiter.api.Test;
 
 /**
  * Testing OneToOne LazyToOne association
  *
  * @author Jan-Oliver Lustig, Sebastian Viefhaus
  */
-@TestForIssue(jiraKey = "HHH-11986")
-@RunWith(BytecodeEnhancerRunner.class)
-public class LazyGroupMappedByTest extends BaseCoreFunctionalTestCase {
-
-	public Class<?>[] getAnnotatedClasses() {
-		return new Class[] { LGMB_From.class, LGMB_To.class };
-	}
+@JiraKey("HHH-11986")
+@DomainModel(
+		annotatedClasses = {
+				LGMB_From.class, LGMB_To.class
+		}
+)
+@SessionFactory
+@BytecodeEnhanced
+public class LazyGroupMappedByTest {
 
 	@Test
-	@TestForIssue(jiraKey = "HHH-11986")
-	public void test() {
-		Long fromId = createEntities();
+	@JiraKey("HHH-11986")
+	public void test(SessionFactoryScope scope) {
+		Long fromId = createEntities( scope );
 
-		Statistics stats = sessionFactory().getStatistics();
+		Statistics stats = scope.getSessionFactory().getStatistics();
 		stats.setStatisticsEnabled( true );
 		stats.clear();
 
-		doInHibernate(
-				this::sessionFactory, session -> {
-
+		scope.inTransaction( session -> {
 					SessionStatistics sessionStats = session.getStatistics();
 
 					// Should be loaded lazy.
@@ -65,9 +65,8 @@ public class LazyGroupMappedByTest extends BaseCoreFunctionalTestCase {
 	 *
 	 * @return ID der Quell-Entität
 	 */
-	public Long createEntities() {
-		return doInHibernate(
-				this::sessionFactory, session -> {
+	public Long createEntities(SessionFactoryScope scope) {
+		return scope.fromTransaction( session -> {
 					session.createQuery( "delete from LGMB_To" ).executeUpdate();
 					session.createQuery( "delete from LGMB_From" ).executeUpdate();
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/lazy/group/MultiLazyBasicInLazyGroupUpdateTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/lazy/group/MultiLazyBasicInLazyGroupUpdateTest.java
@@ -6,20 +6,20 @@
  */
 package org.hibernate.orm.test.bytecode.enhancement.lazy.group;
 
-import static org.hibernate.testing.transaction.TransactionUtil.doInHibernate;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
 import org.hibernate.annotations.LazyGroup;
 import org.hibernate.orm.test.bytecode.enhancement.lazy.NoDirtyCheckingContext;
 
-import org.hibernate.testing.bytecode.enhancement.BytecodeEnhancerRunner;
 import org.hibernate.testing.bytecode.enhancement.CustomEnhancementContext;
 import org.hibernate.testing.bytecode.enhancement.EnhancerTestContext;
-import org.hibernate.testing.junit4.BaseCoreFunctionalTestCase;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.hibernate.testing.bytecode.enhancement.extension.BytecodeEnhanced;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import jakarta.persistence.Basic;
 import jakarta.persistence.Entity;
@@ -28,20 +28,21 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 
-@RunWith(BytecodeEnhancerRunner.class)
+@DomainModel(
+		annotatedClasses = {
+				MultiLazyBasicInLazyGroupUpdateTest.LazyEntity.class
+		}
+)
+@SessionFactory
+@BytecodeEnhanced
 @CustomEnhancementContext( { EnhancerTestContext.class, NoDirtyCheckingContext.class} )
-public class MultiLazyBasicInLazyGroupUpdateTest extends BaseCoreFunctionalTestCase {
+public class MultiLazyBasicInLazyGroupUpdateTest {
 
 	private Long entityId;
 
-	@Override
-	public Class<?>[] getAnnotatedClasses() {
-		return new Class<?>[] { LazyEntity.class };
-	}
-
-	@Before
-	public void prepare() {
-		doInHibernate( this::sessionFactory, s -> {
+	@BeforeEach
+	public void prepare(SessionFactoryScope scope) {
+		scope.inTransaction( s -> {
 			LazyEntity entity = new LazyEntity();
 			s.persist( entity );
 			entityId = entity.getId();
@@ -49,13 +50,13 @@ public class MultiLazyBasicInLazyGroupUpdateTest extends BaseCoreFunctionalTestC
 	}
 
 	@Test
-	public void updateOneLazyProperty() {
+	public void updateOneLazyProperty(SessionFactoryScope scope) {
 		// null -> non-null
-		doInHibernate( this::sessionFactory, s -> {
+		scope.inTransaction( s -> {
 			LazyEntity entity = s.get( LazyEntity.class, entityId );
 			entity.setLazyProperty1( "update1" );
 		} );
-		doInHibernate( this::sessionFactory, s -> {
+		scope.inTransaction( s -> {
 			LazyEntity entity = s.get( LazyEntity.class, entityId );
 			assertEquals( "update1", entity.getLazyProperty1() );
 			assertNull(entity.getLazyProperty2());
@@ -63,11 +64,11 @@ public class MultiLazyBasicInLazyGroupUpdateTest extends BaseCoreFunctionalTestC
 		} );
 
 		// non-null -> non-null
-		doInHibernate( this::sessionFactory, s -> {
+		scope.inTransaction( s -> {
 			LazyEntity entity = s.get( LazyEntity.class, entityId );
 			entity.setLazyProperty1( "update2" );
 		} );
-		doInHibernate( this::sessionFactory, s -> {
+		scope.inTransaction( s -> {
 			LazyEntity entity = s.get( LazyEntity.class, entityId );
 			assertEquals( "update2", entity.getLazyProperty1() );
 			assertNull(entity.getLazyProperty2());
@@ -76,14 +77,14 @@ public class MultiLazyBasicInLazyGroupUpdateTest extends BaseCoreFunctionalTestC
 	}
 
 	@Test
-	public void updateOneEagerPropertyAndOneLazyProperty() {
+	public void updateOneEagerPropertyAndOneLazyProperty(SessionFactoryScope scope) {
 		// null -> non-null
-		doInHibernate( this::sessionFactory, s -> {
+		scope.inTransaction( s -> {
 			LazyEntity entity = s.get( LazyEntity.class, entityId );
 			entity.setEagerProperty( "eager_update1" );
 			entity.setLazyProperty1( "update1" );
 		} );
-		doInHibernate( this::sessionFactory, s -> {
+		scope.inTransaction( s -> {
 			LazyEntity entity = s.get( LazyEntity.class, entityId );
 			assertEquals( "eager_update1", entity.getEagerProperty() );
 			assertEquals( "update1", entity.getLazyProperty1() );
@@ -91,12 +92,12 @@ public class MultiLazyBasicInLazyGroupUpdateTest extends BaseCoreFunctionalTestC
 		} );
 
 		// non-null -> non-null
-		doInHibernate( this::sessionFactory, s -> {
+		scope.inTransaction( s -> {
 			LazyEntity entity = s.get( LazyEntity.class, entityId );
 			entity.setEagerProperty( "eager_update2" );
 			entity.setLazyProperty1( "update2" );
 		} );
-		doInHibernate( this::sessionFactory, s -> {
+		scope.inTransaction( s -> {
 			LazyEntity entity = s.get( LazyEntity.class, entityId );
 			assertEquals( "eager_update2", entity.getEagerProperty() );
 			assertEquals( "update2", entity.getLazyProperty1() );
@@ -105,14 +106,14 @@ public class MultiLazyBasicInLazyGroupUpdateTest extends BaseCoreFunctionalTestC
 	}
 
 	@Test
-	public void updateAllLazyProperties() {
+	public void updateAllLazyProperties(SessionFactoryScope scope) {
 		// null -> non-null
-		doInHibernate( this::sessionFactory, s -> {
+		scope.inTransaction( s -> {
 			LazyEntity entity = s.get( LazyEntity.class, entityId );
 			entity.setLazyProperty1( "update1" );
 			entity.setLazyProperty2( "update2_1" );
 		} );
-		doInHibernate( this::sessionFactory, s -> {
+		scope.inTransaction( s -> {
 			LazyEntity entity = s.get( LazyEntity.class, entityId );
 			assertEquals( "update1", entity.getLazyProperty1() );
 			assertEquals( "update2_1", entity.getLazyProperty2() );
@@ -120,12 +121,12 @@ public class MultiLazyBasicInLazyGroupUpdateTest extends BaseCoreFunctionalTestC
 		} );
 
 		// non-null -> non-null
-		doInHibernate( this::sessionFactory, s -> {
+		scope.inTransaction( s -> {
 			LazyEntity entity = s.get( LazyEntity.class, entityId );
 			entity.setLazyProperty1( "update2" );
 			entity.setLazyProperty2( "update2_2" );
 		} );
-		doInHibernate( this::sessionFactory, s -> {
+		scope.inTransaction( s -> {
 			LazyEntity entity = s.get( LazyEntity.class, entityId );
 			assertEquals( "update2", entity.getLazyProperty1() );
 			assertEquals( "update2_2", entity.getLazyProperty2() );
@@ -135,7 +136,7 @@ public class MultiLazyBasicInLazyGroupUpdateTest extends BaseCoreFunctionalTestC
 
 	@Entity
 	@Table(name = "LAZY_ENTITY")
-	private static class LazyEntity {
+	static class LazyEntity {
 		@Id
 		@GeneratedValue
 		Long id;

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/lazy/group/MultiLazyBasicInLazyGroupUpdateToNullTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/lazy/group/MultiLazyBasicInLazyGroupUpdateToNullTest.java
@@ -9,13 +9,14 @@ package org.hibernate.orm.test.bytecode.enhancement.lazy.group;
 import org.hibernate.annotations.LazyGroup;
 import org.hibernate.orm.test.bytecode.enhancement.lazy.NoDirtyCheckingContext;
 
-import org.hibernate.testing.bytecode.enhancement.BytecodeEnhancerRunner;
 import org.hibernate.testing.bytecode.enhancement.CustomEnhancementContext;
 import org.hibernate.testing.bytecode.enhancement.EnhancerTestContext;
-import org.hibernate.testing.junit4.BaseCoreFunctionalTestCase;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.hibernate.testing.bytecode.enhancement.extension.BytecodeEnhanced;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import jakarta.persistence.Basic;
 import jakarta.persistence.Entity;
@@ -24,24 +25,24 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 
-import static org.hibernate.testing.transaction.TransactionUtil.doInHibernate;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
-@RunWith(BytecodeEnhancerRunner.class)
+@DomainModel(
+		annotatedClasses = {
+				MultiLazyBasicInLazyGroupUpdateToNullTest.LazyEntity.class
+		}
+)
+@SessionFactory
+@BytecodeEnhanced
 @CustomEnhancementContext( { EnhancerTestContext.class, NoDirtyCheckingContext.class} )
-public class MultiLazyBasicInLazyGroupUpdateToNullTest extends BaseCoreFunctionalTestCase {
+public class MultiLazyBasicInLazyGroupUpdateToNullTest {
 
 	private Long entityId;
 
-	@Override
-	public Class<?>[] getAnnotatedClasses() {
-		return new Class<?>[] { LazyEntity.class };
-	}
-
-	@Before
-	public void prepare() {
-		doInHibernate( this::sessionFactory, s -> {
+	@BeforeEach
+	public void prepare(SessionFactoryScope scope) {
+		scope.inTransaction( s -> {
 			LazyEntity entity = new LazyEntity();
 			entity.setEagerProperty( "eager" );
 			entity.setLazyProperty1( "update1" );
@@ -52,13 +53,13 @@ public class MultiLazyBasicInLazyGroupUpdateToNullTest extends BaseCoreFunctiona
 	}
 
 	@Test
-	public void updateOneLazyProperty() {
+	public void updateOneLazyProperty(SessionFactoryScope scope) {
 		// non-null -> null
-		doInHibernate( this::sessionFactory, s -> {
+		scope.inTransaction( s -> {
 			LazyEntity entity = s.get( LazyEntity.class, entityId );
 			entity.setLazyProperty1( null );
 		} );
-		doInHibernate( this::sessionFactory, s -> {
+		scope.inTransaction( s -> {
 			LazyEntity entity = s.get( LazyEntity.class, entityId );
 			assertNull( entity.getLazyProperty1() );
 			assertNotNull( entity.getLazyProperty2() );
@@ -67,14 +68,14 @@ public class MultiLazyBasicInLazyGroupUpdateToNullTest extends BaseCoreFunctiona
 	}
 
 	@Test
-	public void updateOneEagerPropertyAndOneLazyProperty() {
+	public void updateOneEagerPropertyAndOneLazyProperty(SessionFactoryScope scope) {
 		// non-null -> null
-		doInHibernate( this::sessionFactory, s -> {
+		scope.inTransaction( s -> {
 			LazyEntity entity = s.get( LazyEntity.class, entityId );
 			entity.setEagerProperty( null );
 			entity.setLazyProperty1( null );
 		} );
-		doInHibernate( this::sessionFactory, s -> {
+		scope.inTransaction( s -> {
 			LazyEntity entity = s.get( LazyEntity.class, entityId );
 			assertNull( entity.getEagerProperty() );
 			assertNull( entity.getLazyProperty1() );
@@ -83,14 +84,14 @@ public class MultiLazyBasicInLazyGroupUpdateToNullTest extends BaseCoreFunctiona
 	}
 
 	@Test
-	public void updateAllLazyProperties() {
+	public void updateAllLazyProperties(SessionFactoryScope scope) {
 		// non-null -> null
-		doInHibernate( this::sessionFactory, s -> {
+		scope.inTransaction( s -> {
 			LazyEntity entity = s.get( LazyEntity.class, entityId );
 			entity.setLazyProperty1( null );
 			entity.setLazyProperty2( null );
 		} );
-		doInHibernate( this::sessionFactory, s -> {
+		scope.inTransaction( s -> {
 			LazyEntity entity = s.get( LazyEntity.class, entityId );
 			assertNull( entity.getLazyProperty1() );
 			assertNull( entity.getLazyProperty2() );
@@ -100,7 +101,7 @@ public class MultiLazyBasicInLazyGroupUpdateToNullTest extends BaseCoreFunctiona
 
 	@Entity
 	@Table(name = "LAZY_ENTITY")
-	private static class LazyEntity {
+	static class LazyEntity {
 		@Id
 		@GeneratedValue
 		Long id;

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/lazy/group/OnlyLazyBasicInLazyGroupBasicUpdateTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/lazy/group/OnlyLazyBasicInLazyGroupBasicUpdateTest.java
@@ -9,13 +9,14 @@ package org.hibernate.orm.test.bytecode.enhancement.lazy.group;
 import org.hibernate.annotations.LazyGroup;
 import org.hibernate.orm.test.bytecode.enhancement.lazy.NoDirtyCheckingContext;
 
-import org.hibernate.testing.bytecode.enhancement.BytecodeEnhancerRunner;
 import org.hibernate.testing.bytecode.enhancement.CustomEnhancementContext;
 import org.hibernate.testing.bytecode.enhancement.EnhancerTestContext;
-import org.hibernate.testing.junit4.BaseCoreFunctionalTestCase;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.hibernate.testing.bytecode.enhancement.extension.BytecodeEnhanced;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import jakarta.persistence.Basic;
 import jakarta.persistence.Entity;
@@ -24,24 +25,24 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 
-import static org.hibernate.testing.transaction.TransactionUtil.doInHibernate;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 
-@RunWith(BytecodeEnhancerRunner.class)
+@DomainModel(
+		annotatedClasses = {
+				OnlyLazyBasicInLazyGroupBasicUpdateTest.LazyEntity.class
+		}
+)
+@SessionFactory
+@BytecodeEnhanced
 @CustomEnhancementContext({ EnhancerTestContext.class, NoDirtyCheckingContext.class })
-public class OnlyLazyBasicInLazyGroupBasicUpdateTest extends BaseCoreFunctionalTestCase {
+public class OnlyLazyBasicInLazyGroupBasicUpdateTest {
 
 	private Long entityId;
 
-	@Override
-	public Class<?>[] getAnnotatedClasses() {
-		return new Class<?>[] { LazyEntity.class };
-	}
-
-	@Before
-	public void prepare() {
-		doInHibernate( this::sessionFactory, s -> {
+	@BeforeEach
+	public void prepare(SessionFactoryScope scope) {
+		scope.inTransaction( s -> {
 			LazyEntity entity = new LazyEntity();
 			s.persist( entity );
 			entityId = entity.getId();
@@ -49,24 +50,24 @@ public class OnlyLazyBasicInLazyGroupBasicUpdateTest extends BaseCoreFunctionalT
 	}
 
 	@Test
-	public void updateOneLazyProperty() {
+	public void updateOneLazyProperty(SessionFactoryScope scope) {
 		// null -> non-null
-		doInHibernate( this::sessionFactory, s -> {
+		scope.inTransaction( s -> {
 			LazyEntity entity = s.get( LazyEntity.class, entityId );
 			entity.setLazyProperty1( "update1" );
 		} );
-		doInHibernate( this::sessionFactory, s -> {
+		scope.inTransaction( s -> {
 			LazyEntity entity = s.get( LazyEntity.class, entityId );
 			assertEquals( "update1", entity.getLazyProperty1() );
 			assertNull( entity.getLazyProperty2() );
 		} );
 
 		// non-null -> non-null
-		doInHibernate( this::sessionFactory, s -> {
+		scope.inTransaction( s -> {
 			LazyEntity entity = s.get( LazyEntity.class, entityId );
 			entity.setLazyProperty1( "update2" );
 		} );
-		doInHibernate( this::sessionFactory, s -> {
+		scope.inTransaction( s -> {
 			LazyEntity entity = s.get( LazyEntity.class, entityId );
 			assertEquals( "update2", entity.getLazyProperty1() );
 			assertNull( entity.getLazyProperty2() );
@@ -74,26 +75,26 @@ public class OnlyLazyBasicInLazyGroupBasicUpdateTest extends BaseCoreFunctionalT
 	}
 
 	@Test
-	public void updateAllLazyProperties() {
+	public void updateAllLazyProperties(SessionFactoryScope scope) {
 		// null -> non-null
-		doInHibernate( this::sessionFactory, s -> {
+		scope.inTransaction( s -> {
 			LazyEntity entity = s.get( LazyEntity.class, entityId );
 			entity.setLazyProperty1( "update1" );
 			entity.setLazyProperty2( "update2_1" );
 		} );
-		doInHibernate( this::sessionFactory, s -> {
+		scope.inTransaction( s -> {
 			LazyEntity entity = s.get( LazyEntity.class, entityId );
 			assertEquals( "update1", entity.getLazyProperty1() );
 			assertEquals( "update2_1", entity.getLazyProperty2() );
 		} );
 
 		// non-null -> non-null
-		doInHibernate( this::sessionFactory, s -> {
+		scope.inTransaction( s -> {
 			LazyEntity entity = s.get( LazyEntity.class, entityId );
 			entity.setLazyProperty1( "update2" );
 			entity.setLazyProperty2( "update2_2" );
 		} );
-		doInHibernate( this::sessionFactory, s -> {
+		scope.inTransaction( s -> {
 			LazyEntity entity = s.get( LazyEntity.class, entityId );
 			assertEquals( "update2", entity.getLazyProperty1() );
 			assertEquals( "update2_2", entity.getLazyProperty2() );
@@ -102,7 +103,7 @@ public class OnlyLazyBasicInLazyGroupBasicUpdateTest extends BaseCoreFunctionalT
 
 	@Entity
 	@Table(name = "LAZY_ENTITY")
-	private static class LazyEntity {
+	static class LazyEntity {
 		@Id
 		@GeneratedValue
 		Long id;

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/lazy/notfound/LazyNotFoundManyToOneNonUpdatableNonInsertableTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/lazy/notfound/LazyNotFoundManyToOneNonUpdatableNonInsertableTest.java
@@ -22,37 +22,35 @@ import org.hibernate.annotations.LazyToOneOption;
 import org.hibernate.annotations.NotFound;
 import org.hibernate.annotations.NotFoundAction;
 
-import org.hibernate.testing.TestForIssue;
-import org.hibernate.testing.bytecode.enhancement.BytecodeEnhancerRunner;
-import org.hibernate.testing.junit4.BaseCoreFunctionalTestCase;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.hibernate.testing.bytecode.enhancement.extension.BytecodeEnhanced;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.JiraKey;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.hibernate.testing.transaction.TransactionUtil.doInHibernate;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Gail Badner
  */
-@TestForIssue( jiraKey = "HHH-12226")
-@RunWith( BytecodeEnhancerRunner.class )
-public class LazyNotFoundManyToOneNonUpdatableNonInsertableTest extends BaseCoreFunctionalTestCase {
+@JiraKey("HHH-12226")
+@DomainModel(
+		annotatedClasses = {
+				LazyNotFoundManyToOneNonUpdatableNonInsertableTest.User.class,
+				LazyNotFoundManyToOneNonUpdatableNonInsertableTest.Lazy.class
+		}
+)
+@SessionFactory
+@BytecodeEnhanced
+public class LazyNotFoundManyToOneNonUpdatableNonInsertableTest {
 	private static int ID = 1;
 
-	@Override
-	protected Class<?>[] getAnnotatedClasses() {
-		return new Class[] {
-				User.class,
-				Lazy.class
-		};
-	}
-
 	@Test
-	public void test() {
-		doInHibernate(
-				this::sessionFactory, session -> {
+	public void test(SessionFactoryScope scope) {
+		scope.inTransaction( session -> {
 					Lazy p = new Lazy();
 					p.id = ID;
 					User u = new User();
@@ -62,14 +60,9 @@ public class LazyNotFoundManyToOneNonUpdatableNonInsertableTest extends BaseCore
 				}
 		);
 
-		doInHibernate(
-				this::sessionFactory, session -> {
-					session.delete( session.get( Lazy.class, ID ) );
-				}
-		);
+		scope.inTransaction( session -> session.delete( session.get( Lazy.class, ID ) ) );
 
-		doInHibernate(
-				this::sessionFactory, session -> {
+		scope.inTransaction( session -> {
 					User user = session.find( User.class, ID );
 					// per UserGuide (and simply correct behavior), `@NotFound` forces EAGER fetching
 					assertThat( Hibernate.isPropertyInitialized( user, "lazy" ) )

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/lazy/proxy/DeepInheritanceProxyTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/lazy/proxy/DeepInheritanceProxyTest.java
@@ -14,39 +14,56 @@ import jakarta.persistence.InheritanceType;
 import jakarta.persistence.MappedSuperclass;
 
 import org.hibernate.Hibernate;
-import org.hibernate.boot.MetadataSources;
-import org.hibernate.boot.SessionFactoryBuilder;
-import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
 import org.hibernate.cfg.AvailableSettings;
 import org.hibernate.stat.Statistics;
 
-import org.hibernate.testing.TestForIssue;
-import org.hibernate.testing.bytecode.enhancement.BytecodeEnhancerRunner;
 import org.hibernate.testing.bytecode.enhancement.EnhancementOptions;
-import org.hibernate.testing.junit4.BaseNonConfigCoreFunctionalTestCase;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.hibernate.testing.bytecode.enhancement.extension.BytecodeEnhanced;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.JiraKey;
+import org.hibernate.testing.orm.junit.ServiceRegistry;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.hibernate.testing.orm.junit.Setting;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * @author Gail Badner
  */
 
-@TestForIssue( jiraKey = "HHH-11147" )
-@RunWith( BytecodeEnhancerRunner.class )
+@JiraKey( "HHH-11147" )
+@DomainModel(
+		annotatedClasses = {
+				DeepInheritanceProxyTest.AMappedSuperclass.class,
+				DeepInheritanceProxyTest.AEntity.class,
+				DeepInheritanceProxyTest.AAEntity.class,
+				DeepInheritanceProxyTest.AAAEntity.class
+		}
+)
+@ServiceRegistry(
+		settings = {
+				@Setting( name = AvailableSettings.FORMAT_SQL, value = "false" ),
+				@Setting( name = AvailableSettings.GENERATE_STATISTICS, value = "true" ),
+				@Setting( name = AvailableSettings.USE_SECOND_LEVEL_CACHE, value = "false" ),
+				@Setting( name = AvailableSettings.USE_QUERY_CACHE, value = "false" ),
+		}
+)
+@SessionFactory
+@BytecodeEnhanced
 @EnhancementOptions( lazyLoading = true )
-public class DeepInheritanceProxyTest extends BaseNonConfigCoreFunctionalTestCase {
+public class DeepInheritanceProxyTest {
 
 	@Test
-	public void testRootGetValueToInitialize() {
-		inTransaction(
+	public void testRootGetValueToInitialize(SessionFactoryScope scope) {
+		scope.inTransaction(
 				session -> {
-					final Statistics stats = sessionFactory().getStatistics();
+					final Statistics stats = scope.getSessionFactory().getStatistics();
 					stats.clear();
 
 					AEntity aEntity = session.getReference( AEntity.class, "AEntity" );
@@ -63,9 +80,9 @@ public class DeepInheritanceProxyTest extends BaseNonConfigCoreFunctionalTestCas
 				}
 		);
 
-		inTransaction(
+		scope.inTransaction(
 				session -> {
-					final Statistics stats = sessionFactory().getStatistics();
+					final Statistics stats = scope.getSessionFactory().getStatistics();
 					stats.clear();
 
 					AEntity aEntity = session.getReference( AEntity.class, "AEntity" );
@@ -84,10 +101,10 @@ public class DeepInheritanceProxyTest extends BaseNonConfigCoreFunctionalTestCas
 	}
 
 	@Test
-	public void testRootSetValueToInitialize() {
-		inTransaction(
+	public void testRootSetValueToInitialize(SessionFactoryScope scope) {
+		scope.inTransaction(
 				session -> {
-					final Statistics stats = sessionFactory().getStatistics();
+					final Statistics stats = scope.getSessionFactory().getStatistics();
 					stats.clear();
 
 					AEntity aEntity = session.getReference( AEntity.class, "AEntity" );
@@ -104,9 +121,9 @@ public class DeepInheritanceProxyTest extends BaseNonConfigCoreFunctionalTestCas
 				}
 		);
 
-		inTransaction(
+		scope.inTransaction(
 				session -> {
-					final Statistics stats = sessionFactory().getStatistics();
+					final Statistics stats = scope.getSessionFactory().getStatistics();
 					stats.clear();
 
 					AEntity aEntity = session.getReference( AEntity.class, "AEntity" );
@@ -123,9 +140,9 @@ public class DeepInheritanceProxyTest extends BaseNonConfigCoreFunctionalTestCas
 				}
 		);
 
-		inTransaction(
+		scope.inTransaction(
 				session -> {
-					final Statistics stats = sessionFactory().getStatistics();
+					final Statistics stats = scope.getSessionFactory().getStatistics();
 					stats.clear();
 
 					AEntity aEntity = session.get( AEntity.class, "AEntity" );
@@ -142,10 +159,10 @@ public class DeepInheritanceProxyTest extends BaseNonConfigCoreFunctionalTestCas
 	}
 
 	@Test
-	public void testMiddleGetValueToInitialize() {
-		inTransaction(
+	public void testMiddleGetValueToInitialize(SessionFactoryScope scope) {
+		scope.inTransaction(
 				session -> {
-					final Statistics stats = sessionFactory().getStatistics();
+					final Statistics stats = scope.getSessionFactory().getStatistics();
 					stats.clear();
 
 					AAEntity aaEntity = session.getReference( AAEntity.class, "AAEntity" );
@@ -164,9 +181,9 @@ public class DeepInheritanceProxyTest extends BaseNonConfigCoreFunctionalTestCas
 				}
 		);
 
-		inTransaction(
+		scope.inTransaction(
 				session -> {
-					final Statistics stats = sessionFactory().getStatistics();
+					final Statistics stats = scope.getSessionFactory().getStatistics();
 					stats.clear();
 
 					AAEntity aaEntity = session.getReference( AAEntity.class, "AAEntity" );
@@ -185,9 +202,9 @@ public class DeepInheritanceProxyTest extends BaseNonConfigCoreFunctionalTestCas
 				}
 		);
 
-		inTransaction(
+		scope.inTransaction(
 				session -> {
-					final Statistics stats = sessionFactory().getStatistics();
+					final Statistics stats = scope.getSessionFactory().getStatistics();
 					stats.clear();
 
 					AAEntity aaEntity = session.getReference( AAEntity.class, "AAEntity" );
@@ -208,10 +225,10 @@ public class DeepInheritanceProxyTest extends BaseNonConfigCoreFunctionalTestCas
 	}
 
 	@Test
-	public void testMiddleSetValueToInitialize() {
-		inTransaction(
+	public void testMiddleSetValueToInitialize(SessionFactoryScope scope) {
+		scope.inTransaction(
 				session -> {
-					final Statistics stats = sessionFactory().getStatistics();
+					final Statistics stats = scope.getSessionFactory().getStatistics();
 					stats.clear();
 
 					AAEntity aaEntity = session.getReference( AAEntity.class, "AAEntity" );
@@ -230,9 +247,9 @@ public class DeepInheritanceProxyTest extends BaseNonConfigCoreFunctionalTestCas
 				}
 		);
 
-		inTransaction(
+		scope.inTransaction(
 				session -> {
-					final Statistics stats = sessionFactory().getStatistics();
+					final Statistics stats = scope.getSessionFactory().getStatistics();
 					stats.clear();
 
 					AAEntity aaEntity = session.getReference( AAEntity.class, "AAEntity" );
@@ -251,9 +268,9 @@ public class DeepInheritanceProxyTest extends BaseNonConfigCoreFunctionalTestCas
 				}
 		);
 
-		inTransaction(
+		scope.inTransaction(
 				session -> {
-					final Statistics stats = sessionFactory().getStatistics();
+					final Statistics stats = scope.getSessionFactory().getStatistics();
 					stats.clear();
 
 					AAEntity aaEntity = session.getReference( AAEntity.class, "AAEntity" );
@@ -272,9 +289,9 @@ public class DeepInheritanceProxyTest extends BaseNonConfigCoreFunctionalTestCas
 				}
 		);
 
-		inTransaction(
+		scope.inTransaction(
 				session -> {
-					final Statistics stats = sessionFactory().getStatistics();
+					final Statistics stats = scope.getSessionFactory().getStatistics();
 					stats.clear();
 
 					AAEntity aaEntity = session.get( AAEntity.class, "AAEntity" );
@@ -293,10 +310,10 @@ public class DeepInheritanceProxyTest extends BaseNonConfigCoreFunctionalTestCas
 	}
 
 	@Test
-	public void testLeafGetValueToInitialize() {
-		inTransaction(
+	public void testLeafGetValueToInitialize(SessionFactoryScope scope) {
+		scope.inTransaction(
 				session -> {
-					final Statistics stats = sessionFactory().getStatistics();
+					final Statistics stats = scope.getSessionFactory().getStatistics();
 					stats.clear();
 
 					AAAEntity aaaEntity = session.getReference( AAAEntity.class, "AAAEntity" );
@@ -317,9 +334,9 @@ public class DeepInheritanceProxyTest extends BaseNonConfigCoreFunctionalTestCas
 				}
 		);
 
-		inTransaction(
+		scope.inTransaction(
 				session -> {
-					final Statistics stats = sessionFactory().getStatistics();
+					final Statistics stats = scope.getSessionFactory().getStatistics();
 					stats.clear();
 
 					AAAEntity aaaEntity = session.getReference( AAAEntity.class, "AAAEntity" );
@@ -340,9 +357,9 @@ public class DeepInheritanceProxyTest extends BaseNonConfigCoreFunctionalTestCas
 				}
 		);
 
-		inTransaction(
+		scope.inTransaction(
 				session -> {
-					final Statistics stats = sessionFactory().getStatistics();
+					final Statistics stats = scope.getSessionFactory().getStatistics();
 					stats.clear();
 
 					AAAEntity aaaEntity = session.getReference( AAAEntity.class, "AAAEntity" );
@@ -365,10 +382,10 @@ public class DeepInheritanceProxyTest extends BaseNonConfigCoreFunctionalTestCas
 	}
 
 	@Test
-	public void testLeafSetValueToInitialize() {
-		inTransaction(
+	public void testLeafSetValueToInitialize(SessionFactoryScope scope) {
+		scope.inTransaction(
 				session -> {
-					final Statistics stats = sessionFactory().getStatistics();
+					final Statistics stats = scope.getSessionFactory().getStatistics();
 					stats.clear();
 
 					AAAEntity aaaEntity = session.getReference( AAAEntity.class, "AAAEntity" );
@@ -389,9 +406,9 @@ public class DeepInheritanceProxyTest extends BaseNonConfigCoreFunctionalTestCas
 				}
 		);
 
-		inTransaction(
+		scope.inTransaction(
 				session -> {
-					final Statistics stats = sessionFactory().getStatistics();
+					final Statistics stats = scope.getSessionFactory().getStatistics();
 					stats.clear();
 
 					AAAEntity aaaEntity = session.getReference( AAAEntity.class, "AAAEntity" );
@@ -413,9 +430,9 @@ public class DeepInheritanceProxyTest extends BaseNonConfigCoreFunctionalTestCas
 				}
 		);
 
-		inTransaction(
+		scope.inTransaction(
 				session -> {
-					final Statistics stats = sessionFactory().getStatistics();
+					final Statistics stats = scope.getSessionFactory().getStatistics();
 					stats.clear();
 
 					AAAEntity aaaEntity = session.getReference( AAAEntity.class, "AAAEntity" );
@@ -436,9 +453,9 @@ public class DeepInheritanceProxyTest extends BaseNonConfigCoreFunctionalTestCas
 				}
 		);
 
-		inTransaction(
+		scope.inTransaction(
 				session -> {
-					final Statistics stats = sessionFactory().getStatistics();
+					final Statistics stats = scope.getSessionFactory().getStatistics();
 					stats.clear();
 
 					AAAEntity aaaEntity = session.getReference( AAAEntity.class, "AAAEntity" );
@@ -459,9 +476,9 @@ public class DeepInheritanceProxyTest extends BaseNonConfigCoreFunctionalTestCas
 				}
 		);
 
-		inTransaction(
+		scope.inTransaction(
 				session -> {
-					final Statistics stats = sessionFactory().getStatistics();
+					final Statistics stats = scope.getSessionFactory().getStatistics();
 					stats.clear();
 
 					AAAEntity aaaEntity = session.get( AAAEntity.class, "AAAEntity" );
@@ -481,33 +498,9 @@ public class DeepInheritanceProxyTest extends BaseNonConfigCoreFunctionalTestCas
 		);
 	}
 
-	@Override
-	protected void configureStandardServiceRegistryBuilder(StandardServiceRegistryBuilder ssrb) {
-		super.configureStandardServiceRegistryBuilder( ssrb );
-		ssrb.applySetting( AvailableSettings.FORMAT_SQL, "false" );
-		ssrb.applySetting( AvailableSettings.GENERATE_STATISTICS, "true" );
-	}
-
-	@Override
-	protected void configureSessionFactoryBuilder(SessionFactoryBuilder sfb) {
-		super.configureSessionFactoryBuilder( sfb );
-		sfb.applyStatisticsSupport( true );
-		sfb.applySecondLevelCacheSupport( false );
-		sfb.applyQueryCacheSupport( false );
-	}
-
-	@Override
-	protected void applyMetadataSources(MetadataSources sources) {
-		super.applyMetadataSources( sources );
-		sources.addAnnotatedClass( AMappedSuperclass.class );
-		sources.addAnnotatedClass( AEntity.class );
-		sources.addAnnotatedClass( AAEntity.class );
-		sources.addAnnotatedClass( AAAEntity.class );
-	}
-
-	@Before
-	public void prepareTestData() {
-		inTransaction(
+	@BeforeEach
+	public void prepareTestData(SessionFactoryScope scope) {
+		scope.inTransaction(
 				session -> {
 					AEntity aEntity = new AEntity( "AEntity" );
 					aEntity.setFieldInAMappedSuperclass( (short) 2 );
@@ -530,9 +523,9 @@ public class DeepInheritanceProxyTest extends BaseNonConfigCoreFunctionalTestCas
 		);
 	}
 
-	@After
-	public void clearTestData(){
-		inTransaction(
+	@AfterEach
+	public void clearTestData(SessionFactoryScope scope){
+		scope.inTransaction(
 				session -> {
 					session.createQuery( "delete from AEntity" ).executeUpdate();
 				}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/lazy/proxy/DeepInheritanceWithNonEntitiesProxyTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/lazy/proxy/DeepInheritanceWithNonEntitiesProxyTest.java
@@ -14,40 +14,57 @@ import jakarta.persistence.InheritanceType;
 import jakarta.persistence.MappedSuperclass;
 
 import org.hibernate.Hibernate;
-import org.hibernate.boot.MetadataSources;
-import org.hibernate.boot.SessionFactoryBuilder;
-import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
 import org.hibernate.cfg.AvailableSettings;
 import org.hibernate.proxy.HibernateProxy;
 import org.hibernate.stat.Statistics;
 
-import org.hibernate.testing.TestForIssue;
-import org.hibernate.testing.bytecode.enhancement.BytecodeEnhancerRunner;
 import org.hibernate.testing.bytecode.enhancement.EnhancementOptions;
-import org.hibernate.testing.junit4.BaseNonConfigCoreFunctionalTestCase;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.hibernate.testing.bytecode.enhancement.extension.BytecodeEnhanced;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.JiraKey;
+import org.hibernate.testing.orm.junit.ServiceRegistry;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.hibernate.testing.orm.junit.Setting;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * @author Gail Badner
  */
 
-@TestForIssue( jiraKey = "HHH-11147" )
-@RunWith( BytecodeEnhancerRunner.class )
+@JiraKey( "HHH-11147" )
+@DomainModel(
+		annotatedClasses = {
+				DeepInheritanceWithNonEntitiesProxyTest.AMappedSuperclass.class,
+				DeepInheritanceWithNonEntitiesProxyTest.AEntity.class,
+				DeepInheritanceWithNonEntitiesProxyTest.AAEntity.class,
+				DeepInheritanceWithNonEntitiesProxyTest.AAAEntity.class
+		}
+)
+@ServiceRegistry(
+		settings = {
+				@Setting( name = AvailableSettings.FORMAT_SQL, value = "false" ),
+				@Setting( name = AvailableSettings.USE_SECOND_LEVEL_CACHE, value = "false" ),
+				@Setting( name = AvailableSettings.USE_QUERY_CACHE, value = "false" ),
+				@Setting( name = AvailableSettings.GENERATE_STATISTICS, value = "true" ),
+		}
+)
+@SessionFactory
+@BytecodeEnhanced
 @EnhancementOptions( lazyLoading = true )
-public class DeepInheritanceWithNonEntitiesProxyTest extends BaseNonConfigCoreFunctionalTestCase {
+public class DeepInheritanceWithNonEntitiesProxyTest {
 
 	@Test
-	public void testRootGetValueToInitialize() {
-		inTransaction(
+	public void testRootGetValueToInitialize(SessionFactoryScope scope) {
+		scope.inTransaction(
 				session -> {
-					final Statistics stats = sessionFactory().getStatistics();
+					final Statistics stats = scope.getSessionFactory().getStatistics();
 					stats.clear();
 
 					AEntity aEntity = session.getReference( AEntity.class, "AEntity" );
@@ -68,9 +85,9 @@ public class DeepInheritanceWithNonEntitiesProxyTest extends BaseNonConfigCoreFu
 				}
 		);
 
-		inTransaction(
+		scope.inTransaction(
 				session -> {
-					final Statistics stats = sessionFactory().getStatistics();
+					final Statistics stats = scope.getSessionFactory().getStatistics();
 					stats.clear();
 
 					AEntity aEntity = session.getReference( AEntity.class, "AEntity" );
@@ -93,10 +110,10 @@ public class DeepInheritanceWithNonEntitiesProxyTest extends BaseNonConfigCoreFu
 	}
 
 	@Test
-	public void testRootGetValueInNonEntity() {
-		inTransaction(
+	public void testRootGetValueInNonEntity(SessionFactoryScope scope) {
+		scope.inTransaction(
 				session -> {
-					final Statistics stats = sessionFactory().getStatistics();
+					final Statistics stats = scope.getSessionFactory().getStatistics();
 					stats.clear();
 
 					AEntity aEntity = session.getReference( AEntity.class, "AEntity" );
@@ -118,9 +135,9 @@ public class DeepInheritanceWithNonEntitiesProxyTest extends BaseNonConfigCoreFu
 				}
 		);
 
-		inTransaction(
+		scope.inTransaction(
 				session -> {
-					final Statistics stats = sessionFactory().getStatistics();
+					final Statistics stats = scope.getSessionFactory().getStatistics();
 					stats.clear();
 
 					AEntity aEntity = session.getReference( AEntity.class, "AEntity" );
@@ -144,10 +161,10 @@ public class DeepInheritanceWithNonEntitiesProxyTest extends BaseNonConfigCoreFu
 	}
 
 	@Test
-	public void testRootSetValueToInitialize() {
-		inTransaction(
+	public void testRootSetValueToInitialize(SessionFactoryScope scope) {
+		scope.inTransaction(
 				session -> {
-					final Statistics stats = sessionFactory().getStatistics();
+					final Statistics stats = scope.getSessionFactory().getStatistics();
 					stats.clear();
 
 					AEntity aEntity = session.getReference( AEntity.class, "AEntity" );
@@ -168,9 +185,9 @@ public class DeepInheritanceWithNonEntitiesProxyTest extends BaseNonConfigCoreFu
 				}
 		);
 
-		inTransaction(
+		scope.inTransaction(
 				session -> {
-					final Statistics stats = sessionFactory().getStatistics();
+					final Statistics stats = scope.getSessionFactory().getStatistics();
 					stats.clear();
 
 					AEntity aEntity = session.getReference( AEntity.class, "AEntity" );
@@ -191,9 +208,9 @@ public class DeepInheritanceWithNonEntitiesProxyTest extends BaseNonConfigCoreFu
 				}
 		);
 
-		inTransaction(
+		scope.inTransaction(
 				session -> {
-					final Statistics stats = sessionFactory().getStatistics();
+					final Statistics stats = scope.getSessionFactory().getStatistics();
 					stats.clear();
 
 					AEntity aEntity = session.get( AEntity.class, "AEntity" );
@@ -212,10 +229,10 @@ public class DeepInheritanceWithNonEntitiesProxyTest extends BaseNonConfigCoreFu
 	}
 
 	@Test
-	public void testRootSetValueInNonEntity() {
-		inTransaction(
+	public void testRootSetValueInNonEntity(SessionFactoryScope scope) {
+		scope.inTransaction(
 				session -> {
-					final Statistics stats = sessionFactory().getStatistics();
+					final Statistics stats = scope.getSessionFactory().getStatistics();
 					stats.clear();
 
 					AEntity aEntity = session.getReference( AEntity.class, "AEntity" );
@@ -243,9 +260,9 @@ public class DeepInheritanceWithNonEntitiesProxyTest extends BaseNonConfigCoreFu
 				}
 		);
 
-		inTransaction(
+		scope.inTransaction(
 				session -> {
-					final Statistics stats = sessionFactory().getStatistics();
+					final Statistics stats = scope.getSessionFactory().getStatistics();
 					stats.clear();
 
 					AEntity aEntity = session.getReference( AEntity.class, "AEntity" );
@@ -273,9 +290,9 @@ public class DeepInheritanceWithNonEntitiesProxyTest extends BaseNonConfigCoreFu
 				}
 		);
 
-		inTransaction(
+		scope.inTransaction(
 				session -> {
-					final Statistics stats = sessionFactory().getStatistics();
+					final Statistics stats = scope.getSessionFactory().getStatistics();
 					stats.clear();
 
 					AEntity aEntity = session.get( AEntity.class, "AEntity" );
@@ -295,10 +312,10 @@ public class DeepInheritanceWithNonEntitiesProxyTest extends BaseNonConfigCoreFu
 	}
 
 	@Test
-	public void testMiddleGetValueToInitialize() {
-		inTransaction(
+	public void testMiddleGetValueToInitialize(SessionFactoryScope scope) {
+		scope.inTransaction(
 				session -> {
-					final Statistics stats = sessionFactory().getStatistics();
+					final Statistics stats = scope.getSessionFactory().getStatistics();
 					stats.clear();
 
 					AAEntity aaEntity = session.getReference( AAEntity.class, "AAEntity" );
@@ -322,9 +339,9 @@ public class DeepInheritanceWithNonEntitiesProxyTest extends BaseNonConfigCoreFu
 				}
 		);
 
-		inTransaction(
+		scope.inTransaction(
 				session -> {
-					final Statistics stats = sessionFactory().getStatistics();
+					final Statistics stats = scope.getSessionFactory().getStatistics();
 					stats.clear();
 
 					AAEntity aaEntity = session.getReference( AAEntity.class, "AAEntity" );
@@ -348,9 +365,9 @@ public class DeepInheritanceWithNonEntitiesProxyTest extends BaseNonConfigCoreFu
 				}
 		);
 
-		inTransaction(
+		scope.inTransaction(
 				session -> {
-					final Statistics stats = sessionFactory().getStatistics();
+					final Statistics stats = scope.getSessionFactory().getStatistics();
 					stats.clear();
 
 					AAEntity aaEntity = session.getReference( AAEntity.class, "AAEntity" );
@@ -376,10 +393,10 @@ public class DeepInheritanceWithNonEntitiesProxyTest extends BaseNonConfigCoreFu
 	}
 
 	@Test
-	public void testMiddleGetValueInNonEntity() {
-		inTransaction(
+	public void testMiddleGetValueInNonEntity(SessionFactoryScope scope) {
+		scope.inTransaction(
 				session -> {
-					final Statistics stats = sessionFactory().getStatistics();
+					final Statistics stats = scope.getSessionFactory().getStatistics();
 					stats.clear();
 
 					AAEntity aaEntity = session.getReference( AAEntity.class, "AAEntity" );
@@ -404,9 +421,9 @@ public class DeepInheritanceWithNonEntitiesProxyTest extends BaseNonConfigCoreFu
 				}
 		);
 
-		inTransaction(
+		scope.inTransaction(
 				session -> {
-					final Statistics stats = sessionFactory().getStatistics();
+					final Statistics stats = scope.getSessionFactory().getStatistics();
 					stats.clear();
 
 					AAEntity aaEntity = session.getReference( AAEntity.class, "AAEntity" );
@@ -431,9 +448,9 @@ public class DeepInheritanceWithNonEntitiesProxyTest extends BaseNonConfigCoreFu
 				}
 		);
 
-		inTransaction(
+		scope.inTransaction(
 				session -> {
-					final Statistics stats = sessionFactory().getStatistics();
+					final Statistics stats = scope.getSessionFactory().getStatistics();
 					stats.clear();
 
 					AAEntity aaEntity = session.getReference( AAEntity.class, "AAEntity" );
@@ -460,10 +477,10 @@ public class DeepInheritanceWithNonEntitiesProxyTest extends BaseNonConfigCoreFu
 	}
 
 	@Test
-	public void testMiddleSetValueToInitialize() {
-		inTransaction(
+	public void testMiddleSetValueToInitialize(SessionFactoryScope scope) {
+		scope.inTransaction(
 				session -> {
-					final Statistics stats = sessionFactory().getStatistics();
+					final Statistics stats = scope.getSessionFactory().getStatistics();
 					stats.clear();
 
 					AAEntity aaEntity = session.getReference( AAEntity.class, "AAEntity" );
@@ -487,9 +504,9 @@ public class DeepInheritanceWithNonEntitiesProxyTest extends BaseNonConfigCoreFu
 				}
 		);
 
-		inTransaction(
+		scope.inTransaction(
 				session -> {
-					final Statistics stats = sessionFactory().getStatistics();
+					final Statistics stats = scope.getSessionFactory().getStatistics();
 					stats.clear();
 
 					AAEntity aaEntity = session.getReference( AAEntity.class, "AAEntity" );
@@ -513,9 +530,9 @@ public class DeepInheritanceWithNonEntitiesProxyTest extends BaseNonConfigCoreFu
 				}
 		);
 
-		inTransaction(
+		scope.inTransaction(
 				session -> {
-					final Statistics stats = sessionFactory().getStatistics();
+					final Statistics stats = scope.getSessionFactory().getStatistics();
 					stats.clear();
 
 					AAEntity aaEntity = session.getReference( AAEntity.class, "AAEntity" );
@@ -539,9 +556,9 @@ public class DeepInheritanceWithNonEntitiesProxyTest extends BaseNonConfigCoreFu
 				}
 		);
 
-		inTransaction(
+		scope.inTransaction(
 				session -> {
-					final Statistics stats = sessionFactory().getStatistics();
+					final Statistics stats = scope.getSessionFactory().getStatistics();
 					stats.clear();
 
 					AAEntity aaEntity = session.get( AAEntity.class, "AAEntity" );
@@ -563,10 +580,10 @@ public class DeepInheritanceWithNonEntitiesProxyTest extends BaseNonConfigCoreFu
 	}
 
 	@Test
-	public void testMiddleSetValueInNonEntity() {
-		inTransaction(
+	public void testMiddleSetValueInNonEntity(SessionFactoryScope scope) {
+		scope.inTransaction(
 				session -> {
-					final Statistics stats = sessionFactory().getStatistics();
+					final Statistics stats = scope.getSessionFactory().getStatistics();
 					stats.clear();
 
 					AAEntity aaEntity = session.getReference( AAEntity.class, "AAEntity" );
@@ -599,9 +616,9 @@ public class DeepInheritanceWithNonEntitiesProxyTest extends BaseNonConfigCoreFu
 				}
 		);
 
-		inTransaction(
+		scope.inTransaction(
 				session -> {
-					final Statistics stats = sessionFactory().getStatistics();
+					final Statistics stats = scope.getSessionFactory().getStatistics();
 					stats.clear();
 
 					AAEntity aaEntity = session.getReference( AAEntity.class, "AAEntity" );
@@ -634,9 +651,9 @@ public class DeepInheritanceWithNonEntitiesProxyTest extends BaseNonConfigCoreFu
 				}
 		);
 
-		inTransaction(
+		scope.inTransaction(
 				session -> {
-					final Statistics stats = sessionFactory().getStatistics();
+					final Statistics stats = scope.getSessionFactory().getStatistics();
 					stats.clear();
 
 					AAEntity aaEntity = session.getReference( AAEntity.class, "AAEntity" );
@@ -669,9 +686,9 @@ public class DeepInheritanceWithNonEntitiesProxyTest extends BaseNonConfigCoreFu
 				}
 		);
 
-		inTransaction(
+		scope.inTransaction(
 				session -> {
-					final Statistics stats = sessionFactory().getStatistics();
+					final Statistics stats = scope.getSessionFactory().getStatistics();
 					stats.clear();
 
 					AAEntity aaEntity = session.get( AAEntity.class, "AAEntity" );
@@ -694,10 +711,10 @@ public class DeepInheritanceWithNonEntitiesProxyTest extends BaseNonConfigCoreFu
 	}
 
 	@Test
-	public void testLeafGetValueToInitialize() {
-		inTransaction(
+	public void testLeafGetValueToInitialize(SessionFactoryScope scope) {
+		scope.inTransaction(
 				session -> {
-					final Statistics stats = sessionFactory().getStatistics();
+					final Statistics stats = scope.getSessionFactory().getStatistics();
 					stats.clear();
 
 					AAAEntity aaaEntity = session.getReference( AAAEntity.class, "AAAEntity" );
@@ -725,9 +742,9 @@ public class DeepInheritanceWithNonEntitiesProxyTest extends BaseNonConfigCoreFu
 				}
 		);
 
-		inTransaction(
+		scope.inTransaction(
 				session -> {
-					final Statistics stats = sessionFactory().getStatistics();
+					final Statistics stats = scope.getSessionFactory().getStatistics();
 					stats.clear();
 
 					AAAEntity aaaEntity = session.getReference( AAAEntity.class, "AAAEntity" );
@@ -755,9 +772,9 @@ public class DeepInheritanceWithNonEntitiesProxyTest extends BaseNonConfigCoreFu
 				}
 		);
 
-		inTransaction(
+		scope.inTransaction(
 				session -> {
-					final Statistics stats = sessionFactory().getStatistics();
+					final Statistics stats = scope.getSessionFactory().getStatistics();
 					stats.clear();
 
 					AAAEntity aaaEntity = session.getReference( AAAEntity.class, "AAAEntity" );
@@ -787,10 +804,10 @@ public class DeepInheritanceWithNonEntitiesProxyTest extends BaseNonConfigCoreFu
 	}
 
 	@Test
-	public void testLeafGetValueInNonEntity() {
-		inTransaction(
+	public void testLeafGetValueInNonEntity(SessionFactoryScope scope) {
+		scope.inTransaction(
 				session -> {
-					final Statistics stats = sessionFactory().getStatistics();
+					final Statistics stats = scope.getSessionFactory().getStatistics();
 					stats.clear();
 
 					AAAEntity aaaEntity = session.getReference( AAAEntity.class, "AAAEntity" );
@@ -824,9 +841,9 @@ public class DeepInheritanceWithNonEntitiesProxyTest extends BaseNonConfigCoreFu
 				}
 		);
 
-		inTransaction(
+		scope.inTransaction(
 				session -> {
-					final Statistics stats = sessionFactory().getStatistics();
+					final Statistics stats = scope.getSessionFactory().getStatistics();
 					stats.clear();
 
 					AAAEntity aaaEntity = session.getReference( AAAEntity.class, "AAAEntity" );
@@ -859,9 +876,9 @@ public class DeepInheritanceWithNonEntitiesProxyTest extends BaseNonConfigCoreFu
 				}
 		);
 
-		inTransaction(
+		scope.inTransaction(
 				session -> {
-					final Statistics stats = sessionFactory().getStatistics();
+					final Statistics stats = scope.getSessionFactory().getStatistics();
 					stats.clear();
 
 					AAAEntity aaaEntity = session.getReference( AAAEntity.class, "AAAEntity" );
@@ -894,9 +911,9 @@ public class DeepInheritanceWithNonEntitiesProxyTest extends BaseNonConfigCoreFu
 				}
 		);
 
-		inTransaction(
+		scope.inTransaction(
 				session -> {
-					final Statistics stats = sessionFactory().getStatistics();
+					final Statistics stats = scope.getSessionFactory().getStatistics();
 					stats.clear();
 
 					AAAEntity aaaEntity = session.getReference( AAAEntity.class, "AAAEntity" );
@@ -931,10 +948,10 @@ public class DeepInheritanceWithNonEntitiesProxyTest extends BaseNonConfigCoreFu
 	}
 
 	@Test
-	public void testLeafSetValueToInitialize() {
-		inTransaction(
+	public void testLeafSetValueToInitialize(SessionFactoryScope scope) {
+		scope.inTransaction(
 				session -> {
-					final Statistics stats = sessionFactory().getStatistics();
+					final Statistics stats = scope.getSessionFactory().getStatistics();
 					stats.clear();
 
 					AAAEntity aaaEntity = session.getReference( AAAEntity.class, "AAAEntity" );
@@ -962,9 +979,9 @@ public class DeepInheritanceWithNonEntitiesProxyTest extends BaseNonConfigCoreFu
 				}
 		);
 
-		inTransaction(
+		scope.inTransaction(
 				session -> {
-					final Statistics stats = sessionFactory().getStatistics();
+					final Statistics stats = scope.getSessionFactory().getStatistics();
 					stats.clear();
 
 					AAAEntity aaaEntity = session.getReference( AAAEntity.class, "AAAEntity" );
@@ -993,9 +1010,9 @@ public class DeepInheritanceWithNonEntitiesProxyTest extends BaseNonConfigCoreFu
 				}
 		);
 
-		inTransaction(
+		scope.inTransaction(
 				session -> {
-					final Statistics stats = sessionFactory().getStatistics();
+					final Statistics stats = scope.getSessionFactory().getStatistics();
 					stats.clear();
 
 					AAAEntity aaaEntity = session.getReference( AAAEntity.class, "AAAEntity" );
@@ -1023,9 +1040,9 @@ public class DeepInheritanceWithNonEntitiesProxyTest extends BaseNonConfigCoreFu
 				}
 		);
 
-		inTransaction(
+		scope.inTransaction(
 				session -> {
-					final Statistics stats = sessionFactory().getStatistics();
+					final Statistics stats = scope.getSessionFactory().getStatistics();
 					stats.clear();
 
 					AAAEntity aaaEntity = session.getReference( AAAEntity.class, "AAAEntity" );
@@ -1053,9 +1070,9 @@ public class DeepInheritanceWithNonEntitiesProxyTest extends BaseNonConfigCoreFu
 				}
 		);
 
-		inTransaction(
+		scope.inTransaction(
 				session -> {
-					final Statistics stats = sessionFactory().getStatistics();
+					final Statistics stats = scope.getSessionFactory().getStatistics();
 					stats.clear();
 
 					AAAEntity aaaEntity = session.get( AAAEntity.class, "AAAEntity" );
@@ -1080,10 +1097,10 @@ public class DeepInheritanceWithNonEntitiesProxyTest extends BaseNonConfigCoreFu
 	}
 
 	@Test
-	public void testLeafSetValueInNonEntity() {
-		inTransaction(
+	public void testLeafSetValueInNonEntity(SessionFactoryScope scope) {
+		scope.inTransaction(
 				session -> {
-					final Statistics stats = sessionFactory().getStatistics();
+					final Statistics stats = scope.getSessionFactory().getStatistics();
 					stats.clear();
 
 					AAAEntity aaaEntity = session.getReference( AAAEntity.class, "AAAEntity" );
@@ -1124,9 +1141,9 @@ public class DeepInheritanceWithNonEntitiesProxyTest extends BaseNonConfigCoreFu
 				}
 		);
 
-		inTransaction(
+		scope.inTransaction(
 				session -> {
-					final Statistics stats = sessionFactory().getStatistics();
+					final Statistics stats = scope.getSessionFactory().getStatistics();
 					stats.clear();
 
 					AAAEntity aaaEntity = session.getReference( AAAEntity.class, "AAAEntity" );
@@ -1168,9 +1185,9 @@ public class DeepInheritanceWithNonEntitiesProxyTest extends BaseNonConfigCoreFu
 				}
 		);
 
-		inTransaction(
+		scope.inTransaction(
 				session -> {
-					final Statistics stats = sessionFactory().getStatistics();
+					final Statistics stats = scope.getSessionFactory().getStatistics();
 					stats.clear();
 
 					AAAEntity aaaEntity = session.getReference( AAAEntity.class, "AAAEntity" );
@@ -1213,9 +1230,9 @@ public class DeepInheritanceWithNonEntitiesProxyTest extends BaseNonConfigCoreFu
 				}
 		);
 
-		inTransaction(
+		scope.inTransaction(
 				session -> {
-					final Statistics stats = sessionFactory().getStatistics();
+					final Statistics stats = scope.getSessionFactory().getStatistics();
 					stats.clear();
 
 					AAAEntity aaaEntity = session.getReference( AAAEntity.class, "AAAEntity" );
@@ -1258,9 +1275,9 @@ public class DeepInheritanceWithNonEntitiesProxyTest extends BaseNonConfigCoreFu
 				}
 		);
 
-		inTransaction(
+		scope.inTransaction(
 				session -> {
-					final Statistics stats = sessionFactory().getStatistics();
+					final Statistics stats = scope.getSessionFactory().getStatistics();
 					stats.clear();
 
 					AAAEntity aaaEntity = session.get( AAAEntity.class, "AAAEntity" );
@@ -1285,33 +1302,9 @@ public class DeepInheritanceWithNonEntitiesProxyTest extends BaseNonConfigCoreFu
 		);
 	}
 
-	@Override
-	protected void configureStandardServiceRegistryBuilder(StandardServiceRegistryBuilder ssrb) {
-		super.configureStandardServiceRegistryBuilder( ssrb );
-		ssrb.applySetting( AvailableSettings.FORMAT_SQL, "false" );
-		ssrb.applySetting( AvailableSettings.GENERATE_STATISTICS, "true" );
-	}
-
-	@Override
-	protected void configureSessionFactoryBuilder(SessionFactoryBuilder sfb) {
-		super.configureSessionFactoryBuilder( sfb );
-		sfb.applyStatisticsSupport( true );
-		sfb.applySecondLevelCacheSupport( false );
-		sfb.applyQueryCacheSupport( false );
-	}
-
-	@Override
-	protected void applyMetadataSources(MetadataSources sources) {
-		super.applyMetadataSources( sources );
-		sources.addAnnotatedClass( AMappedSuperclass.class );
-		sources.addAnnotatedClass( AEntity.class );
-		sources.addAnnotatedClass( AAEntity.class );
-		sources.addAnnotatedClass( AAAEntity.class );
-	}
-
-	@Before
-	public void prepareTestData() {
-		inTransaction(
+	@BeforeEach
+	public void prepareTestData(SessionFactoryScope scope) {
+		scope.inTransaction(
 				session -> {
 					AEntity aEntity = new AEntity( "AEntity" );
 					aEntity.setFieldInAMappedSuperclass( (short) 2 );
@@ -1343,9 +1336,9 @@ public class DeepInheritanceWithNonEntitiesProxyTest extends BaseNonConfigCoreFu
 		);
 	}
 
-	@After
-	public void clearTestData(){
-		inTransaction(
+	@AfterEach
+	public void clearTestData(SessionFactoryScope scope){
+		scope.inTransaction(
 				session -> {
 					session.createQuery( "delete from AEntity" ).executeUpdate();
 				}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/lazy/proxy/EagerOneToOneMappedByInDoubleEmbeddedTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/lazy/proxy/EagerOneToOneMappedByInDoubleEmbeddedTest.java
@@ -2,37 +2,38 @@ package org.hibernate.orm.test.bytecode.enhancement.lazy.proxy;
 
 import java.io.Serializable;
 
-import org.hibernate.testing.TestForIssue;
-import org.hibernate.testing.bytecode.enhancement.BytecodeEnhancerRunner;
 import org.hibernate.testing.bytecode.enhancement.EnhancementOptions;
-import org.hibernate.testing.junit4.BaseNonConfigCoreFunctionalTestCase;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.hibernate.testing.bytecode.enhancement.extension.BytecodeEnhanced;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.JiraKey;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import jakarta.persistence.Embeddable;
 import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
 import jakarta.persistence.Id;
 import jakarta.persistence.OneToOne;
 
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
-@RunWith(BytecodeEnhancerRunner.class)
+@DomainModel(
+		annotatedClasses = {
+				EagerOneToOneMappedByInDoubleEmbeddedTest.EntityA.class, EagerOneToOneMappedByInDoubleEmbeddedTest.EntityB.class
+		}
+)
+@SessionFactory
+@BytecodeEnhanced
 @EnhancementOptions(lazyLoading = true)
-@TestForIssue(jiraKey = "HHH-15967")
-public class EagerOneToOneMappedByInDoubleEmbeddedTest extends BaseNonConfigCoreFunctionalTestCase {
+@JiraKey("HHH-15967")
+public class EagerOneToOneMappedByInDoubleEmbeddedTest {
 
-	@Override
-	public Class<?>[] getAnnotatedClasses() {
-		return new Class<?>[] { EntityA.class, EntityB.class };
-	}
-
-	@Before
-	public void prepare() {
-		inTransaction( s -> {
+	@BeforeEach
+	public void prepare(SessionFactoryScope scope) {
+		scope.inTransaction( s -> {
 			EntityA entityA = new EntityA( 1 );
 			EntityB entityB = new EntityB( 2 );
 
@@ -49,9 +50,9 @@ public class EagerOneToOneMappedByInDoubleEmbeddedTest extends BaseNonConfigCore
 		} );
 	}
 
-	@After
-	public void tearDown() {
-		inTransaction(
+	@AfterEach
+	public void tearDown(SessionFactoryScope scope) {
+		scope.inTransaction(
 				session -> {
 					session.createQuery( "delete from EntityB" ).executeUpdate();
 					session.createQuery( "delete from EntityA" ).executeUpdate();
@@ -60,8 +61,8 @@ public class EagerOneToOneMappedByInDoubleEmbeddedTest extends BaseNonConfigCore
 	}
 
 	@Test
-	public void testGetEntityA() {
-		inTransaction(
+	public void testGetEntityA(SessionFactoryScope scope) {
+		scope.inTransaction(
 				session -> {
 					EntityA entityA = session.get( EntityA.class, 1 );
 					assertThat( entityA ).isNotNull();
@@ -74,8 +75,8 @@ public class EagerOneToOneMappedByInDoubleEmbeddedTest extends BaseNonConfigCore
 	}
 
 	@Test
-	public void testGetReferenceEntityA() {
-		inTransaction(
+	public void testGetReferenceEntityA(SessionFactoryScope scope) {
+		scope.inTransaction(
 				session -> {
 					EntityA entityA = session.getReference( EntityA.class, 1 );
 					assertThat( entityA ).isNotNull();

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/lazy/proxy/IdClassEntityGraphTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/lazy/proxy/IdClassEntityGraphTest.java
@@ -14,17 +14,17 @@ import java.util.List;
 import java.util.Objects;
 
 import org.hibernate.Hibernate;
-import org.hibernate.boot.MetadataSources;
 import org.hibernate.jpa.SpecHints;
 
-import org.hibernate.testing.TestForIssue;
-import org.hibernate.testing.bytecode.enhancement.BytecodeEnhancerRunner;
 import org.hibernate.testing.bytecode.enhancement.EnhancementOptions;
-import org.hibernate.testing.junit4.BaseNonConfigCoreFunctionalTestCase;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.hibernate.testing.bytecode.enhancement.extension.BytecodeEnhanced;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.JiraKey;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import jakarta.persistence.Basic;
 import jakarta.persistence.Column;
@@ -43,21 +43,21 @@ import jakarta.persistence.Table;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@TestForIssue(jiraKey = "HHH-15607")
-@RunWith(BytecodeEnhancerRunner.class)
+@JiraKey("HHH-15607")
+@DomainModel(
+		annotatedClasses = {
+				IdClassEntityGraphTest.Parent.class,
+				IdClassEntityGraphTest.Child.class
+		}
+)
+@SessionFactory
+@BytecodeEnhanced
 @EnhancementOptions(lazyLoading = true)
-public class IdClassEntityGraphTest extends BaseNonConfigCoreFunctionalTestCase {
+public class IdClassEntityGraphTest {
 
-	@Override
-	protected void applyMetadataSources(MetadataSources sources) {
-		super.applyMetadataSources( sources );
-		sources.addAnnotatedClass( Parent.class );
-		sources.addAnnotatedClass( Child.class );
-	}
-
-	@Before
-	public void setUp() {
-		inTransaction(
+	@BeforeEach
+	public void setUp(SessionFactoryScope scope) {
+		scope.inTransaction(
 				session -> {
 					Parent parent = new Parent( 1l, "abc" );
 					Child child1 = new Child( parent, LocalDateTime.of( 2002, Month.APRIL, 12, 12, 12 ) );
@@ -69,9 +69,9 @@ public class IdClassEntityGraphTest extends BaseNonConfigCoreFunctionalTestCase 
 		);
 	}
 
-	@After
-	public void tearDown() {
-		inTransaction(
+	@AfterEach
+	public void tearDown(SessionFactoryScope scope) {
+		scope.inTransaction(
 				session -> {
 					session.createQuery( "delete from Child" ).executeUpdate();
 					session.createQuery( "delete from Parent" ).executeUpdate();
@@ -80,8 +80,8 @@ public class IdClassEntityGraphTest extends BaseNonConfigCoreFunctionalTestCase 
 	}
 
 	@Test
-	public void testFetchBasicAttributeAndOneToMany() {
-		inTransaction(
+	public void testFetchBasicAttributeAndOneToMany(SessionFactoryScope scope) {
+		scope.inTransaction(
 				session -> {
 					Parent parent = session.createQuery( "SELECT p FROM Parent p WHERE p.id = :id", Parent.class )
 							.setParameter( "id", 1L )
@@ -98,8 +98,8 @@ public class IdClassEntityGraphTest extends BaseNonConfigCoreFunctionalTestCase 
 	}
 
 	@Test
-	public void testFetchBasicAttributeOnly() {
-		inTransaction(
+	public void testFetchBasicAttributeOnly(SessionFactoryScope scope) {
+		scope.inTransaction(
 				session -> {
 					Parent parent = session.createQuery( "SELECT p FROM Parent p WHERE p.id = :id", Parent.class )
 							.setParameter( "id", 1L )
@@ -116,8 +116,8 @@ public class IdClassEntityGraphTest extends BaseNonConfigCoreFunctionalTestCase 
 	}
 
 	@Test
-	public void testFetchOneToMany() {
-		inTransaction(
+	public void testFetchOneToMany(SessionFactoryScope scope) {
+		scope.inTransaction(
 				session -> {
 					Parent parent = session.createQuery( "SELECT p FROM Parent p WHERE p.id = :id", Parent.class )
 							.setParameter( "id", 1L )

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/lazy/proxy/LazyGroupWithInheritanceAllowProxyTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/lazy/proxy/LazyGroupWithInheritanceAllowProxyTest.java
@@ -10,39 +10,63 @@ import java.util.List;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import org.hibernate.boot.MetadataSources;
-import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
 import org.hibernate.bytecode.enhance.spi.interceptor.EnhancementAsProxyLazinessInterceptor;
 import org.hibernate.cfg.AvailableSettings;
 import org.hibernate.engine.spi.PersistentAttributeInterceptable;
 import org.hibernate.engine.spi.PersistentAttributeInterceptor;
 import org.hibernate.stat.Statistics;
 
-import org.hibernate.testing.TestForIssue;
-import org.hibernate.testing.bytecode.enhancement.BytecodeEnhancerRunner;
 import org.hibernate.testing.bytecode.enhancement.EnhancementOptions;
-import org.hibernate.testing.junit4.BaseNonConfigCoreFunctionalTestCase;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.hibernate.testing.bytecode.enhancement.extension.BytecodeEnhanced;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.JiraKey;
+import org.hibernate.testing.orm.junit.ServiceRegistry;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.hibernate.testing.orm.junit.Setting;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * @author Steve Ebersole
  */
 
-@TestForIssue(jiraKey = "HHH-11147")
-@RunWith(BytecodeEnhancerRunner.class)
+@JiraKey("HHH-11147")
+@DomainModel(
+		annotatedClasses = {
+				Customer.class,
+				ForeignCustomer.class,
+				DomesticCustomer.class,
+				Payment.class,
+				CreditCardPayment.class,
+				DebitCardPayment.class,
+				Address.class,
+				Order.class,
+				OrderSupplemental.class,
+				OrderSupplemental2.class
+		}
+)
+@ServiceRegistry(
+		settings = {
+				@Setting( name = AvailableSettings.GENERATE_STATISTICS, value = "true" ),
+				@Setting( name = AvailableSettings.USE_SECOND_LEVEL_CACHE, value = "false" ),
+				@Setting( name = AvailableSettings.USE_QUERY_CACHE, value = "false" ),
+		}
+)
+@SessionFactory
+@BytecodeEnhanced
 @EnhancementOptions( lazyLoading = true )
-public class LazyGroupWithInheritanceAllowProxyTest extends BaseNonConfigCoreFunctionalTestCase {
+public class LazyGroupWithInheritanceAllowProxyTest {
+
 	@Test
-	public void baseline() {
-		inTransaction(
+	public void baseline(SessionFactoryScope scope) {
+		scope.inTransaction(
 				session -> {
 					final List<Order> orders = session.createQuery( "select o from Order o", Order.class ).list();
 					for ( Order order : orders ) {
@@ -57,8 +81,8 @@ public class LazyGroupWithInheritanceAllowProxyTest extends BaseNonConfigCoreFun
 	}
 
 	@Test
-	public void testMergingUninitializedProxy() {
-		inTransaction(
+	public void testMergingUninitializedProxy(SessionFactoryScope scope) {
+		scope.inTransaction(
 				session -> {
 					final List<Order> orders = session.createQuery( "select o from Order o", Order.class ).list();
 					for ( Order order : orders ) {
@@ -74,13 +98,13 @@ public class LazyGroupWithInheritanceAllowProxyTest extends BaseNonConfigCoreFun
 
 
 	@Test
-	public void queryEntityWithAssociationToAbstract() {
-		final Statistics stats = sessionFactory().getStatistics();
+	public void queryEntityWithAssociationToAbstract(SessionFactoryScope scope) {
+		final Statistics stats = scope.getSessionFactory().getStatistics();
 		stats.clear();
 
 		final AtomicInteger expectedQueryCount = new AtomicInteger( 0 );
 
-		inTransaction(
+		scope.inTransaction(
 				session -> {
 					final List<Order> orders = session.createQuery( "select o from Order o", Order.class ).list();
 
@@ -126,17 +150,17 @@ public class LazyGroupWithInheritanceAllowProxyTest extends BaseNonConfigCoreFun
 	}
 
 	/**
-	 * Same test as {@link #queryEntityWithAssociationToAbstract()}, but using runtime
+	 * Same test as {@link #queryEntityWithAssociationToAbstract(SessionFactoryScope)}, but using runtime
 	 * fetching to issues just a single select
 	 */
 	@Test
-	public void queryEntityWithAssociationToAbstractRuntimeFetch() {
-		final Statistics stats = sessionFactory().getStatistics();
+	public void queryEntityWithAssociationToAbstractRuntimeFetch(SessionFactoryScope scope) {
+		final Statistics stats = scope.getSessionFactory().getStatistics();
 		stats.clear();
 
 		final AtomicInteger expectedQueryCount = new AtomicInteger( 0 );
 
-		inTransaction(
+		scope.inTransaction(
 				session -> {
 					final String qry = "select o from Order o join fetch o.customer c join fetch o.payments join fetch o.supplemental join fetch o.supplemental2";
 
@@ -187,19 +211,9 @@ public class LazyGroupWithInheritanceAllowProxyTest extends BaseNonConfigCoreFun
 		);
 	}
 
-	@Override
-	protected void configureStandardServiceRegistryBuilder(StandardServiceRegistryBuilder ssrb) {
-		super.configureStandardServiceRegistryBuilder( ssrb );
-
-		ssrb.applySetting( AvailableSettings.GENERATE_STATISTICS, "true" );
-		ssrb.applySetting( AvailableSettings.USE_SECOND_LEVEL_CACHE, "false" );
-		ssrb.applySetting( AvailableSettings.USE_QUERY_CACHE, "false" );
-	}
-
-
-	@Before
-	public void prepareTestData() {
-		inTransaction(
+	@BeforeEach
+	public void prepareTestData(SessionFactoryScope scope) {
+		scope.inTransaction(
 				session -> {
 					final Address austin = new Address( 1, "Austin" );
 					final Address london = new Address( 2, "London" );
@@ -251,9 +265,9 @@ public class LazyGroupWithInheritanceAllowProxyTest extends BaseNonConfigCoreFun
 		);
 	}
 
-	@After
-	public void cleanUpTestData() {
-		inTransaction(
+	@AfterEach
+	public void cleanUpTestData(SessionFactoryScope scope) {
+		scope.inTransaction(
 				session -> {
 					session.createQuery( "delete from CreditCardPayment" ).executeUpdate();
 					session.createQuery( "delete from DebitCardPayment" ).executeUpdate();
@@ -271,24 +285,4 @@ public class LazyGroupWithInheritanceAllowProxyTest extends BaseNonConfigCoreFun
 				}
 		);
 	}
-
-	@Override
-	protected void applyMetadataSources(MetadataSources sources) {
-		super.applyMetadataSources( sources );
-
-		sources.addAnnotatedClass( Customer.class );
-		sources.addAnnotatedClass( ForeignCustomer.class );
-		sources.addAnnotatedClass( DomesticCustomer.class );
-
-		sources.addAnnotatedClass( Payment.class );
-		sources.addAnnotatedClass( CreditCardPayment.class );
-		sources.addAnnotatedClass( DebitCardPayment.class );
-
-		sources.addAnnotatedClass( Address.class );
-
-		sources.addAnnotatedClass( Order.class );
-		sources.addAnnotatedClass( OrderSupplemental.class );
-		sources.addAnnotatedClass( OrderSupplemental2.class );
-	}
-
 }

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/lazy/proxy/LazyGroupWithInheritanceTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/lazy/proxy/LazyGroupWithInheritanceTest.java
@@ -11,42 +11,66 @@ import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.hibernate.Hibernate;
-import org.hibernate.boot.MetadataSources;
-import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
 import org.hibernate.bytecode.enhance.spi.interceptor.BytecodeLazyAttributeInterceptor;
 import org.hibernate.cfg.AvailableSettings;
 import org.hibernate.engine.spi.PersistentAttributeInterceptable;
 import org.hibernate.engine.spi.PersistentAttributeInterceptor;
 import org.hibernate.stat.Statistics;
 
-import org.hibernate.testing.TestForIssue;
-import org.hibernate.testing.bytecode.enhancement.BytecodeEnhancerRunner;
 import org.hibernate.testing.bytecode.enhancement.EnhancementOptions;
-import org.hibernate.testing.junit4.BaseNonConfigCoreFunctionalTestCase;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.hibernate.testing.bytecode.enhancement.extension.BytecodeEnhanced;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.JiraKey;
+import org.hibernate.testing.orm.junit.ServiceRegistry;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.hibernate.testing.orm.junit.Setting;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * @author Steve Ebersole
  */
 
-@TestForIssue(jiraKey = "HHH-11147")
-@RunWith(BytecodeEnhancerRunner.class)
+@JiraKey("HHH-11147")
+@DomainModel(
+		annotatedClasses = {
+				Customer.class,
+				ForeignCustomer.class,
+				DomesticCustomer.class,
+				Payment.class,
+				CreditCardPayment.class,
+				DebitCardPayment.class,
+				Address.class,
+				Order.class,
+				OrderSupplemental.class,
+				OrderSupplemental2.class
+		}
+)
+@ServiceRegistry(
+		settings = {
+				@Setting( name = AvailableSettings.GENERATE_STATISTICS, value = "true" ),
+				@Setting( name = AvailableSettings.USE_SECOND_LEVEL_CACHE, value = "false" ),
+				@Setting( name = AvailableSettings.USE_QUERY_CACHE, value = "false" ),
+		}
+)
+@SessionFactory
+@BytecodeEnhanced
 @EnhancementOptions( lazyLoading = true )
-public class LazyGroupWithInheritanceTest extends BaseNonConfigCoreFunctionalTestCase {
+public class LazyGroupWithInheritanceTest {
+
 	@Test
-	public void loadEntityWithAssociationToAbstract() {
-		final Statistics stats = sessionFactory().getStatistics();
+	public void loadEntityWithAssociationToAbstract(SessionFactoryScope scope) {
+		final Statistics stats = scope.getSessionFactory().getStatistics();
 		stats.clear();
 
-		inTransaction(
+		scope.inTransaction(
 				(session) -> {
 					final Order loaded = session.byId( Order.class ).load( 1 );
 					assert Hibernate.isPropertyInitialized( loaded, "customer" );
@@ -61,13 +85,13 @@ public class LazyGroupWithInheritanceTest extends BaseNonConfigCoreFunctionalTes
 	}
 
 	@Test
-	public void queryEntityWithAssociationToAbstract() {
-		final Statistics stats = sessionFactory().getStatistics();
+	public void queryEntityWithAssociationToAbstract(SessionFactoryScope scope) {
+		final Statistics stats = scope.getSessionFactory().getStatistics();
 		stats.clear();
 
 		final AtomicInteger expectedQueryCount = new AtomicInteger( 0 );
 
-		inTransaction(
+		scope.inTransaction(
 				session -> {
 					final List<Order> orders = session.createQuery( "select o from Order o", Order.class ).list();
 
@@ -121,17 +145,17 @@ public class LazyGroupWithInheritanceTest extends BaseNonConfigCoreFunctionalTes
 	}
 
 	/**
-	 * Same test as {@link #queryEntityWithAssociationToAbstract()}, but using runtime
+	 * Same test as {@link #queryEntityWithAssociationToAbstract(SessionFactoryScope)}, but using runtime
 	 * fetching to issues just a single select
 	 */
 	@Test
-	public void queryEntityWithAssociationToAbstractRuntimeFetch() {
-		final Statistics stats = sessionFactory().getStatistics();
+	public void queryEntityWithAssociationToAbstractRuntimeFetch(SessionFactoryScope scope) {
+		final Statistics stats = scope.getSessionFactory().getStatistics();
 		stats.clear();
 
 		final AtomicInteger expectedQueryCount = new AtomicInteger( 0 );
 
-		inTransaction(
+		scope.inTransaction(
 				session -> {
 					final String qry = "select o from Order o join fetch o.customer c join fetch o.payments join fetch o.supplemental join fetch o.supplemental2";
 
@@ -182,19 +206,9 @@ public class LazyGroupWithInheritanceTest extends BaseNonConfigCoreFunctionalTes
 		);
 	}
 
-	@Override
-	protected void configureStandardServiceRegistryBuilder(StandardServiceRegistryBuilder ssrb) {
-		super.configureStandardServiceRegistryBuilder( ssrb );
-
-		ssrb.applySetting( AvailableSettings.GENERATE_STATISTICS, "true" );
-		ssrb.applySetting( AvailableSettings.USE_SECOND_LEVEL_CACHE, "false" );
-		ssrb.applySetting( AvailableSettings.USE_QUERY_CACHE, "false" );
-	}
-
-
-	@Before
-	public void prepareTestData() {
-		inTransaction(
+	@BeforeEach
+	public void prepareTestData(SessionFactoryScope scope) {
+		scope.inTransaction(
 				session -> {
 					final Address austin = new Address( 1, "Austin" );
 					final Address london = new Address( 2, "London" );
@@ -246,9 +260,9 @@ public class LazyGroupWithInheritanceTest extends BaseNonConfigCoreFunctionalTes
 		);
 	}
 
-	@After
-	public void cleanUpTestData() {
-		inTransaction(
+	@AfterEach
+	public void cleanUpTestData(SessionFactoryScope scope) {
+		scope.inTransaction(
 				session -> {
 					session.createQuery( "delete from CreditCardPayment" ).executeUpdate();
 					session.createQuery( "delete from DebitCardPayment" ).executeUpdate();
@@ -266,25 +280,4 @@ public class LazyGroupWithInheritanceTest extends BaseNonConfigCoreFunctionalTes
 				}
 		);
 	}
-
-	@Override
-	protected void applyMetadataSources(MetadataSources sources) {
-		super.applyMetadataSources( sources );
-
-		sources.addAnnotatedClass( Customer.class );
-		sources.addAnnotatedClass( ForeignCustomer.class );
-		sources.addAnnotatedClass( DomesticCustomer.class );
-
-		sources.addAnnotatedClass( Payment.class );
-		sources.addAnnotatedClass( CreditCardPayment.class );
-		sources.addAnnotatedClass( DebitCardPayment.class );
-
-		sources.addAnnotatedClass( Address.class );
-
-		sources.addAnnotatedClass( Order.class );
-		sources.addAnnotatedClass( OrderSupplemental.class );
-		sources.addAnnotatedClass( OrderSupplemental2.class );
-	}
-
-
 }

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/lazy/proxy/LazyOneToOneMappedByInDoubleEmbeddedTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/lazy/proxy/LazyOneToOneMappedByInDoubleEmbeddedTest.java
@@ -2,14 +2,15 @@ package org.hibernate.orm.test.bytecode.enhancement.lazy.proxy;
 
 import java.io.Serializable;
 
-import org.hibernate.testing.TestForIssue;
-import org.hibernate.testing.bytecode.enhancement.BytecodeEnhancerRunner;
 import org.hibernate.testing.bytecode.enhancement.EnhancementOptions;
-import org.hibernate.testing.junit4.BaseNonConfigCoreFunctionalTestCase;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.hibernate.testing.bytecode.enhancement.extension.BytecodeEnhanced;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.JiraKey;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import jakarta.persistence.Embeddable;
 import jakarta.persistence.Embedded;
@@ -18,21 +19,22 @@ import jakarta.persistence.FetchType;
 import jakarta.persistence.Id;
 import jakarta.persistence.OneToOne;
 
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
-@RunWith(BytecodeEnhancerRunner.class)
+@DomainModel(
+		annotatedClasses = {
+				LazyOneToOneMappedByInDoubleEmbeddedTest.EntityA.class, LazyOneToOneMappedByInDoubleEmbeddedTest.EntityB.class
+		}
+)
+@SessionFactory
+@BytecodeEnhanced
 @EnhancementOptions(lazyLoading = true)
-@TestForIssue(jiraKey = "HHH-15967")
-public class LazyOneToOneMappedByInDoubleEmbeddedTest extends BaseNonConfigCoreFunctionalTestCase {
+@JiraKey("HHH-15967")
+public class LazyOneToOneMappedByInDoubleEmbeddedTest {
 
-	@Override
-	public Class<?>[] getAnnotatedClasses() {
-		return new Class<?>[] { EntityA.class, EntityB.class };
-	}
-
-	@Before
-	public void prepare() {
-		inTransaction( s -> {
+	@BeforeEach
+	public void prepare(SessionFactoryScope scope) {
+		scope.inTransaction( s -> {
 			EntityA entityA = new EntityA( 1 );
 			EntityB entityB = new EntityB( 2 );
 
@@ -49,9 +51,9 @@ public class LazyOneToOneMappedByInDoubleEmbeddedTest extends BaseNonConfigCoreF
 		} );
 	}
 
-	@After
-	public void tearDown() {
-		inTransaction(
+	@AfterEach
+	public void tearDown(SessionFactoryScope scope) {
+		scope.inTransaction(
 				session -> {
 					session.createQuery( "delete from EntityB" ).executeUpdate();
 					session.createQuery( "delete from EntityA" ).executeUpdate();
@@ -60,8 +62,8 @@ public class LazyOneToOneMappedByInDoubleEmbeddedTest extends BaseNonConfigCoreF
 	}
 
 	@Test
-	public void testGetEntityA() {
-		inTransaction(
+	public void testGetEntityA(SessionFactoryScope scope) {
+		scope.inTransaction(
 				session -> {
 					EntityA entityA = session.get( EntityA.class, 1 );
 					assertThat( entityA ).isNotNull();
@@ -74,8 +76,8 @@ public class LazyOneToOneMappedByInDoubleEmbeddedTest extends BaseNonConfigCoreF
 	}
 
 	@Test
-	public void testGetReferenceEntityA() {
-		inTransaction(
+	public void testGetReferenceEntityA(SessionFactoryScope scope) {
+		scope.inTransaction(
 				session -> {
 					EntityA entityA = session.getReference( EntityA.class, 1 );
 					assertThat( entityA ).isNotNull();

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/lazy/proxy/LazyOneToOneMappedByTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/lazy/proxy/LazyOneToOneMappedByTest.java
@@ -6,20 +6,21 @@
  */
 package org.hibernate.orm.test.bytecode.enhancement.lazy.proxy;
 
-import java.util.Map;
-
 import org.hibernate.Hibernate;
 import org.hibernate.cfg.AvailableSettings;
 import org.hibernate.stat.Statistics;
 
-import org.hibernate.testing.TestForIssue;
-import org.hibernate.testing.bytecode.enhancement.BytecodeEnhancerRunner;
 import org.hibernate.testing.bytecode.enhancement.EnhancementOptions;
-import org.hibernate.testing.junit4.BaseNonConfigCoreFunctionalTestCase;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.hibernate.testing.bytecode.enhancement.extension.BytecodeEnhanced;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.JiraKey;
+import org.hibernate.testing.orm.junit.ServiceRegistry;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.hibernate.testing.orm.junit.Setting;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -29,24 +30,25 @@ import jakarta.persistence.OneToOne;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 
-@RunWith(BytecodeEnhancerRunner.class)
+@DomainModel(
+		annotatedClasses = {
+				LazyOneToOneMappedByTest.EntityA.class, LazyOneToOneMappedByTest.EntityB.class
+		}
+)
+@ServiceRegistry(
+		settings = {
+				@Setting( name = AvailableSettings.GENERATE_STATISTICS, value = "true" ),
+		}
+)
+@SessionFactory
+@BytecodeEnhanced
 @EnhancementOptions(lazyLoading = true)
-@TestForIssue(jiraKey = "HHH-15606")
-public class LazyOneToOneMappedByTest extends BaseNonConfigCoreFunctionalTestCase {
+@JiraKey("HHH-15606")
+public class LazyOneToOneMappedByTest {
 
-	@Override
-	public Class<?>[] getAnnotatedClasses() {
-		return new Class<?>[] { EntityA.class, EntityB.class };
-	}
-
-	@Override
-	protected void addSettings(Map<String, Object> settings) {
-		settings.put( AvailableSettings.GENERATE_STATISTICS, "true" );
-	}
-
-	@Before
-	public void prepare() {
-		inTransaction( s -> {
+	@BeforeEach
+	public void prepare(SessionFactoryScope scope) {
+		scope.inTransaction( s -> {
 			EntityA entityA = new EntityA( 1, "A" );
 			EntityB entityB = new EntityB( 2 );
 			entityA.setEntityB( entityB );
@@ -56,19 +58,19 @@ public class LazyOneToOneMappedByTest extends BaseNonConfigCoreFunctionalTestCas
 		} );
 	}
 
-	@After
-	public void tearDown() {
-		inTransaction( s -> {
+	@AfterEach
+	public void tearDown(SessionFactoryScope scope) {
+		scope.inTransaction( s -> {
 			s.createMutationQuery( "delete entityb" ).executeUpdate();
 			s.createMutationQuery( "delete entitya" ).executeUpdate();
 		} );
 	}
 
 	@Test
-	public void testGet() {
-		final Statistics stats = sessionFactory().getStatistics();
+	public void testGet(SessionFactoryScope scope) {
+		final Statistics stats = scope.getSessionFactory().getStatistics();
 		stats.clear();
-		inTransaction( s -> {
+		scope.inTransaction( s -> {
 			EntityA entityA = s.get( EntityA.class, "1" );
 			assertThat( stats.getPrepareStatementCount() ).isEqualTo( 1 );
 			assertThat( entityA ).isNotNull();
@@ -86,10 +88,10 @@ public class LazyOneToOneMappedByTest extends BaseNonConfigCoreFunctionalTestCas
 	}
 
 	@Test
-	public void testGetReference() {
-		final Statistics stats = sessionFactory().getStatistics();
+	public void testGetReference(SessionFactoryScope scope) {
+		final Statistics stats = scope.getSessionFactory().getStatistics();
 		stats.clear();
-		inTransaction( s -> {
+		scope.inTransaction( s -> {
 			EntityA entityA = s.getReference( EntityA.class, "1" );
 			assertThat( stats.getPrepareStatementCount() ).isEqualTo( 0 );
 			assertThat( entityA ).isNotNull();

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/lazy/proxy/LazyOneToOneMultiAssociationTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/lazy/proxy/LazyOneToOneMultiAssociationTest.java
@@ -11,49 +11,51 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 
 import org.hibernate.Hibernate;
 
-import org.hibernate.testing.TestForIssue;
-import org.hibernate.testing.bytecode.enhancement.BytecodeEnhancerRunner;
 import org.hibernate.testing.bytecode.enhancement.EnhancementOptions;
-import org.hibernate.testing.junit4.BaseNonConfigCoreFunctionalTestCase;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.hibernate.testing.bytecode.enhancement.extension.BytecodeEnhanced;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.JiraKey;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.Id;
 import jakarta.persistence.OneToOne;
 
-@RunWith(BytecodeEnhancerRunner.class)
+@DomainModel(
+		annotatedClasses = {
+				LazyOneToOneMultiAssociationTest.EntityA.class, LazyOneToOneMultiAssociationTest.EntityB.class
+		}
+)
+@SessionFactory
+@BytecodeEnhanced
 @EnhancementOptions(lazyLoading = true)
-@TestForIssue(jiraKey = "HHH-16108")
-public class LazyOneToOneMultiAssociationTest extends BaseNonConfigCoreFunctionalTestCase {
+@JiraKey("HHH-16108")
+public class LazyOneToOneMultiAssociationTest {
 
-	@Override
-	public Class<?>[] getAnnotatedClasses() {
-		return new Class<?>[] { EntityA.class, EntityB.class };
-	}
-
-	@Before
-	public void prepare() {
-		inTransaction( s -> {
+	@BeforeEach
+	public void prepare(SessionFactoryScope scope) {
+		scope.inTransaction( s -> {
 			EntityA entityA = new EntityA( 1 );
 			s.persist( entityA );
 		} );
 	}
 
-	@After
-	public void tearDown() {
-		inTransaction( s -> {
+	@AfterEach
+	public void tearDown(SessionFactoryScope scope) {
+		scope.inTransaction( s -> {
 			s.createMutationQuery( "delete entityb" ).executeUpdate();
 			s.createMutationQuery( "delete entitya" ).executeUpdate();
 		} );
 	}
 
 	@Test
-	public void testPersist() {
-		inTransaction( s -> {
+	public void testPersist(SessionFactoryScope scope) {
+		scope.inTransaction( s -> {
 			EntityA entityA = s.get( EntityA.class, 1 );
 			EntityB entityB = new EntityB( 2 );
 			entityA.setMappedAssociation1( entityB );
@@ -64,7 +66,7 @@ public class LazyOneToOneMultiAssociationTest extends BaseNonConfigCoreFunctiona
 			//	at org.hibernate.persister.entity.mutation.UpdateCoordinatorStandard.processSet(UpdateCoordinatorStandard.java:665)
 		} );
 
-		inTransaction( s -> {
+		scope.inTransaction( s -> {
 			EntityA entityA = s.get( EntityA.class, 1 );
 			assertThat( entityA ).isNotNull();
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/lazy/proxy/LazyToOnesNoProxyFactoryWithSubclassesStatelessTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/lazy/proxy/LazyToOnesNoProxyFactoryWithSubclassesStatelessTest.java
@@ -7,17 +7,19 @@
 package org.hibernate.orm.test.bytecode.enhancement.lazy.proxy;
 
 import org.hibernate.Hibernate;
-import org.hibernate.boot.MetadataSources;
-import org.hibernate.boot.SessionFactoryBuilder;
+import org.hibernate.cfg.AvailableSettings;
 import org.hibernate.proxy.HibernateProxy;
 import org.hibernate.stat.Statistics;
 
-import org.hibernate.testing.TestForIssue;
-import org.hibernate.testing.bytecode.enhancement.BytecodeEnhancerRunner;
-import org.hibernate.testing.junit4.BaseNonConfigCoreFunctionalTestCase;
-import org.junit.After;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.hibernate.testing.bytecode.enhancement.extension.BytecodeEnhanced;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.JiraKey;
+import org.hibernate.testing.orm.junit.ServiceRegistry;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.hibernate.testing.orm.junit.Setting;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -27,39 +29,38 @@ import jakarta.persistence.InheritanceType;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * @author Gail Badner
  */
-@TestForIssue( jiraKey = "HHH-13640" )
-@RunWith(BytecodeEnhancerRunner.class)
-public class LazyToOnesNoProxyFactoryWithSubclassesStatelessTest extends BaseNonConfigCoreFunctionalTestCase {
-
-	@Override
-	protected void configureSessionFactoryBuilder(SessionFactoryBuilder sfb) {
-		super.configureSessionFactoryBuilder( sfb );
-		sfb.applyStatisticsSupport( true );
-		sfb.applySecondLevelCacheSupport( false );
-		sfb.applyQueryCacheSupport( false );
-	}
-
-	@Override
-	protected void applyMetadataSources(MetadataSources sources) {
-		super.applyMetadataSources( sources );
-		sources.addAnnotatedClass( Animal.class );
-		sources.addAnnotatedClass( Primate.class );
-		sources.addAnnotatedClass( Human.class );
-		sources.addAnnotatedClass( OtherEntity.class );
-	}
+@JiraKey( "HHH-13640" )
+@DomainModel(
+		annotatedClasses = {
+				LazyToOnesNoProxyFactoryWithSubclassesStatelessTest.Animal.class,
+				LazyToOnesNoProxyFactoryWithSubclassesStatelessTest.Primate.class,
+				LazyToOnesNoProxyFactoryWithSubclassesStatelessTest.Human.class,
+				LazyToOnesNoProxyFactoryWithSubclassesStatelessTest.OtherEntity.class
+		}
+)
+@ServiceRegistry(
+		settings = {
+				@Setting( name = AvailableSettings.GENERATE_STATISTICS, value = "true" ),
+				@Setting( name = AvailableSettings.USE_SECOND_LEVEL_CACHE, value = "false" ),
+				@Setting( name = AvailableSettings.USE_QUERY_CACHE, value = "false" ),
+		}
+)
+@SessionFactory
+@BytecodeEnhanced
+public class LazyToOnesNoProxyFactoryWithSubclassesStatelessTest {
 
 	@Test
-	public void testNewEnhancedProxyAssociation() {
-		inStatelessTransaction(
+	public void testNewEnhancedProxyAssociation(SessionFactoryScope scope) {
+		scope.inStatelessTransaction(
 				session -> {
 					Human human = new Human( "A Human" );
 					OtherEntity otherEntity = new OtherEntity( "test1" );
@@ -70,9 +71,9 @@ public class LazyToOnesNoProxyFactoryWithSubclassesStatelessTest extends BaseNon
 				}
 		);
 
-		inStatelessSession(
+		scope.inStatelessSession(
 				session -> {
-					final Statistics stats = sessionFactory().getStatistics();
+					final Statistics stats = scope.getSessionFactory().getStatistics();
 					stats.clear();
 					final OtherEntity otherEntity = (OtherEntity) session.get( OtherEntity.class, "test1" );
 					assertTrue( Hibernate.isPropertyInitialized( otherEntity, "human" ) );
@@ -84,8 +85,8 @@ public class LazyToOnesNoProxyFactoryWithSubclassesStatelessTest extends BaseNon
 	}
 
 	@Test
-	public void testExistingInitializedAssociationLeafSubclass() {
-		inStatelessSession(
+	public void testExistingInitializedAssociationLeafSubclass(SessionFactoryScope scope) {
+		scope.inStatelessSession(
 				session -> {
 					Human human = new Human( "A Human" );
 					OtherEntity otherEntity = new OtherEntity( "test1" );
@@ -97,10 +98,10 @@ public class LazyToOnesNoProxyFactoryWithSubclassesStatelessTest extends BaseNon
 				}
 		);
 
-		final Statistics stats = sessionFactory().getStatistics();
+		final Statistics stats = scope.getSessionFactory().getStatistics();
 		stats.clear();
 
-		inStatelessSession(
+		scope.inStatelessSession(
 				session -> {
 
 					final OtherEntity otherEntity = (OtherEntity) session.get( OtherEntity.class, "test1" );
@@ -145,8 +146,8 @@ public class LazyToOnesNoProxyFactoryWithSubclassesStatelessTest extends BaseNon
 	}
 
 	@Test
-	public void testExistingEnhancedProxyAssociationLeafSubclassOnly() {
-		inStatelessSession(
+	public void testExistingEnhancedProxyAssociationLeafSubclassOnly(SessionFactoryScope scope) {
+		scope.inStatelessSession(
 				session -> {
 					Human human = new Human( "A Human" );
 					OtherEntity otherEntity = new OtherEntity( "test1" );
@@ -157,9 +158,9 @@ public class LazyToOnesNoProxyFactoryWithSubclassesStatelessTest extends BaseNon
 				}
 		);
 
-		inStatelessSession(
+		scope.inStatelessSession(
 				session -> {
-					final Statistics stats = sessionFactory().getStatistics();
+					final Statistics stats = scope.getSessionFactory().getStatistics();
 					stats.clear();
 
 					final OtherEntity otherEntity = (OtherEntity) session.get( OtherEntity.class, "test1" );
@@ -177,9 +178,9 @@ public class LazyToOnesNoProxyFactoryWithSubclassesStatelessTest extends BaseNon
 		);
 	}
 
-	@After
-	public void cleanUpTestData() {
-		inTransaction(
+	@AfterEach
+	public void cleanUpTestData(SessionFactoryScope scope) {
+		scope.inTransaction(
 				session -> {
 					session.createQuery( "delete from OtherEntity" ).executeUpdate();
 					session.createQuery( "delete from Human" ).executeUpdate();

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/lazy/proxy/LazyToOnesProxyWithSubclassesTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/lazy/proxy/LazyToOnesProxyWithSubclassesTest.java
@@ -15,55 +15,51 @@ import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 
 import org.hibernate.Hibernate;
-import org.hibernate.annotations.LazyToOne;
-import org.hibernate.annotations.LazyToOneOption;
-import org.hibernate.boot.MetadataSources;
-import org.hibernate.boot.SessionFactoryBuilder;
-import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
 import org.hibernate.cfg.AvailableSettings;
 import org.hibernate.proxy.HibernateProxy;
 import org.hibernate.stat.Statistics;
 
-import org.hibernate.testing.TestForIssue;
-import org.hibernate.testing.bytecode.enhancement.BytecodeEnhancerRunner;
-import org.hibernate.testing.junit4.BaseNonConfigCoreFunctionalTestCase;
-import org.junit.After;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.hibernate.testing.bytecode.enhancement.extension.BytecodeEnhanced;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.JiraKey;
+import org.hibernate.testing.orm.junit.ServiceRegistry;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.hibernate.testing.orm.junit.Setting;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 
-import static org.hibernate.testing.transaction.TransactionUtil.doInHibernate;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * @author Gail Badner
  */
-@TestForIssue( jiraKey = "HHH-13640" )
-@RunWith(BytecodeEnhancerRunner.class)
-public class LazyToOnesProxyWithSubclassesTest extends BaseNonConfigCoreFunctionalTestCase {
-
-	@Override
-	protected void configureSessionFactoryBuilder(SessionFactoryBuilder sfb) {
-		super.configureSessionFactoryBuilder( sfb );
-		sfb.applyStatisticsSupport( true );
-		sfb.applySecondLevelCacheSupport( false );
-		sfb.applyQueryCacheSupport( false );
-	}
-
-	@Override
-	protected void applyMetadataSources(MetadataSources sources) {
-		super.applyMetadataSources( sources );
-		sources.addAnnotatedClass( Animal.class );
-		sources.addAnnotatedClass( Primate.class );
-		sources.addAnnotatedClass( Human.class );
-		sources.addAnnotatedClass( OtherEntity.class );
-	}
+@JiraKey( "HHH-13640" )
+@DomainModel(
+		annotatedClasses = {
+				LazyToOnesProxyWithSubclassesTest.Animal.class,
+				LazyToOnesProxyWithSubclassesTest.Primate.class,
+				LazyToOnesProxyWithSubclassesTest.Human.class,
+				LazyToOnesProxyWithSubclassesTest.OtherEntity.class
+		}
+)
+@ServiceRegistry(
+		settings = {
+				@Setting( name = AvailableSettings.GENERATE_STATISTICS, value = "true" ),
+				@Setting( name = AvailableSettings.USE_SECOND_LEVEL_CACHE, value = "false" ),
+				@Setting( name = AvailableSettings.USE_QUERY_CACHE, value = "false" ),
+		}
+)
+@SessionFactory
+@BytecodeEnhanced
+public class LazyToOnesProxyWithSubclassesTest {
 
 	@Test
-	public void testNewProxyAssociation() {
-		inTransaction(
+	public void testNewProxyAssociation(SessionFactoryScope scope) {
+		scope.inTransaction(
 				session -> {
 					Human human = new Human( "A Human" );
 					OtherEntity otherEntity = new OtherEntity( "test1" );
@@ -73,9 +69,9 @@ public class LazyToOnesProxyWithSubclassesTest extends BaseNonConfigCoreFunction
 				}
 		);
 
-		inSession(
+		scope.inSession(
 				session -> {
-					final Statistics stats = sessionFactory().getStatistics();
+					final Statistics stats = scope.getSessionFactory().getStatistics();
 					stats.clear();
 					final OtherEntity otherEntity = session.get( OtherEntity.class, "test1" );
 					assertTrue( Hibernate.isPropertyInitialized( otherEntity, "animal" ) );
@@ -92,8 +88,8 @@ public class LazyToOnesProxyWithSubclassesTest extends BaseNonConfigCoreFunction
 	}
 
 	@Test
-	public void testGetInitializeAssociations() {
-		inTransaction(
+	public void testGetInitializeAssociations(SessionFactoryScope scope) {
+		scope.inTransaction(
 				session -> {
 					Human human = new Human( "A Human" );
 					OtherEntity otherEntity = new OtherEntity( "test1" );
@@ -104,9 +100,9 @@ public class LazyToOnesProxyWithSubclassesTest extends BaseNonConfigCoreFunction
 				}
 		);
 
-		inSession(
+		scope.inSession(
 				session -> {
-					final Statistics stats = sessionFactory().getStatistics();
+					final Statistics stats = scope.getSessionFactory().getStatistics();
 					stats.clear();
 					final OtherEntity otherEntity = session.get( OtherEntity.class, "test1" );
 					assertTrue( Hibernate.isPropertyInitialized( otherEntity, "animal" ) );
@@ -122,8 +118,8 @@ public class LazyToOnesProxyWithSubclassesTest extends BaseNonConfigCoreFunction
 	}
 
 	@Test
-	public void testExistingProxyAssociation() {
-		inTransaction(
+	public void testExistingProxyAssociation(SessionFactoryScope scope) {
+		scope.inTransaction(
 				session -> {
 					Human human = new Human( "A Human" );
 					OtherEntity otherEntity = new OtherEntity( "test1" );
@@ -134,9 +130,9 @@ public class LazyToOnesProxyWithSubclassesTest extends BaseNonConfigCoreFunction
 				}
 		);
 
-		inSession(
+		scope.inSession(
 				session -> {
-					final Statistics stats = sessionFactory().getStatistics();
+					final Statistics stats = scope.getSessionFactory().getStatistics();
 					stats.clear();
 					final OtherEntity otherEntity = session.get( OtherEntity.class, "test1" );
 					assertTrue( Hibernate.isPropertyInitialized( otherEntity, "animal" ) );
@@ -151,8 +147,8 @@ public class LazyToOnesProxyWithSubclassesTest extends BaseNonConfigCoreFunction
 	}
 
 	@Test
-	public void testExistingHibernateProxyAssociationLeafSubclass() {
-		inTransaction(
+	public void testExistingHibernateProxyAssociationLeafSubclass(SessionFactoryScope scope) {
+		scope.inTransaction(
 				session -> {
 					Human human = new Human( "A Human" );
 					OtherEntity otherEntity = new OtherEntity( "test1" );
@@ -164,10 +160,10 @@ public class LazyToOnesProxyWithSubclassesTest extends BaseNonConfigCoreFunction
 				}
 		);
 
-		final Statistics stats = sessionFactory().getStatistics();
+		final Statistics stats = scope.getSessionFactory().getStatistics();
 		stats.clear();
 
-		inSession(
+		scope.inSession(
 				session -> {
 
 					final OtherEntity otherEntity = session.get( OtherEntity.class, "test1" );
@@ -203,7 +199,7 @@ public class LazyToOnesProxyWithSubclassesTest extends BaseNonConfigCoreFunction
 		assertEquals( 2, stats.getPrepareStatementCount() );
 		stats.clear();
 
-		inSession(
+		scope.inSession(
 				session -> {
 
 					final OtherEntity otherEntity = session.get( OtherEntity.class, "test1" );
@@ -233,8 +229,8 @@ public class LazyToOnesProxyWithSubclassesTest extends BaseNonConfigCoreFunction
 	}
 
 	@Test
-	public void testExistingEnhancedProxyAssociationLeafSubclassOnly() {
-		inTransaction(
+	public void testExistingEnhancedProxyAssociationLeafSubclassOnly(SessionFactoryScope scope) {
+		scope.inTransaction(
 				session -> {
 					Human human = new Human( "A Human" );
 					OtherEntity otherEntity = new OtherEntity( "test1" );
@@ -244,9 +240,8 @@ public class LazyToOnesProxyWithSubclassesTest extends BaseNonConfigCoreFunction
 				}
 		);
 
-		doInHibernate(
-				this::sessionFactory, session -> {
-					final Statistics stats = sessionFactory().getStatistics();
+		scope.fromTransaction( session -> {
+					final Statistics stats = scope.getSessionFactory().getStatistics();
 					stats.clear();
 
 					final OtherEntity otherEntity = session.get( OtherEntity.class, "test1" );
@@ -276,9 +271,9 @@ public class LazyToOnesProxyWithSubclassesTest extends BaseNonConfigCoreFunction
 		);
 	}
 
-	@After
-	public void cleanUpTestData() {
-		inTransaction(
+	@AfterEach
+	public void cleanUpTestData(SessionFactoryScope scope) {
+		scope.inTransaction(
 				session -> {
 					session.createQuery( "delete from OtherEntity" ).executeUpdate();
 					session.createQuery( "delete from Human" ).executeUpdate();

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/lazy/proxy/LoadANonExistingEntityTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/lazy/proxy/LoadANonExistingEntityTest.java
@@ -21,46 +21,57 @@ import jakarta.persistence.ManyToOne;
 
 import org.hibernate.Hibernate;
 import org.hibernate.ObjectNotFoundException;
-import org.hibernate.annotations.LazyToOne;
-import org.hibernate.annotations.LazyToOneOption;
-import org.hibernate.boot.SessionFactoryBuilder;
-import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
 import org.hibernate.cfg.AvailableSettings;
 import org.hibernate.stat.spi.StatisticsImplementor;
 
-import org.hibernate.testing.TestForIssue;
-import org.hibernate.testing.bytecode.enhancement.BytecodeEnhancerRunner;
 import org.hibernate.testing.bytecode.enhancement.EnhancementOptions;
-import org.hibernate.testing.junit4.BaseNonConfigCoreFunctionalTestCase;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.hibernate.testing.bytecode.enhancement.extension.BytecodeEnhanced;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.JiraKey;
+import org.hibernate.testing.orm.junit.ServiceRegistry;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.hibernate.testing.orm.junit.Setting;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-import static org.hibernate.testing.transaction.TransactionUtil.doInHibernate;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * @author Andrea Boriero
  */
-@TestForIssue(jiraKey = "HHH-11147")
-@RunWith(BytecodeEnhancerRunner.class)
+@JiraKey("HHH-11147")
+@DomainModel(
+		annotatedClasses = {
+				LoadANonExistingEntityTest.Employee.class,
+				LoadANonExistingEntityTest.Employer.class
+		}
+)
+@ServiceRegistry(
+		settings = {
+				@Setting( name = AvailableSettings.FORMAT_SQL, value = "false" ),
+				@Setting( name = AvailableSettings.GENERATE_STATISTICS, value = "true" ),
+				@Setting( name = AvailableSettings.USE_SECOND_LEVEL_CACHE, value = "false" ),
+				@Setting( name = AvailableSettings.USE_QUERY_CACHE, value = "false" ),
+		}
+)
+@SessionFactory
+@BytecodeEnhanced
 @EnhancementOptions(lazyLoading = true)
-public class LoadANonExistingEntityTest extends BaseNonConfigCoreFunctionalTestCase {
+public class LoadANonExistingEntityTest {
 
 	private static int NUMBER_OF_ENTITIES = 20;
 
 	@Test
-	@TestForIssue(jiraKey = "HHH-11147")
-	public void testInitilaizeNonExistingEntity() {
-		final StatisticsImplementor statistics = sessionFactory().getStatistics();
+	@JiraKey("HHH-11147")
+	public void testInitilaizeNonExistingEntity(SessionFactoryScope scope) {
+		final StatisticsImplementor statistics = scope.getSessionFactory().getStatistics();
 		statistics.clear();
 
-		doInHibernate(
-				this::sessionFactory, session -> {
+		scope.inTransaction( session -> {
 					Employer nonExisting = session.load( Employer.class, -1 );
 					assertEquals( 0, statistics.getPrepareStatementCount() );
 					assertFalse( Hibernate.isInitialized( nonExisting ) );
@@ -77,12 +88,11 @@ public class LoadANonExistingEntityTest extends BaseNonConfigCoreFunctionalTestC
 	}
 
 	@Test
-	@TestForIssue(jiraKey = "HHH-11147")
-	public void testSetFieldNonExistingEntity() {
-		final StatisticsImplementor statistics = sessionFactory().getStatistics();
+	@JiraKey("HHH-11147")
+	public void testSetFieldNonExistingEntity(SessionFactoryScope scope) {
+		final StatisticsImplementor statistics = scope.getSessionFactory().getStatistics();
 		statistics.clear();
-		doInHibernate(
-				this::sessionFactory, session -> {
+		scope.inTransaction( session -> {
 					Employer nonExisting = session.load( Employer.class, -1 );
 					assertEquals( 0, statistics.getPrepareStatementCount() );
 					assertFalse( Hibernate.isInitialized( nonExisting ) );
@@ -99,12 +109,11 @@ public class LoadANonExistingEntityTest extends BaseNonConfigCoreFunctionalTestC
 	}
 
 	@Test
-	@TestForIssue(jiraKey = "HHH-11147")
-	public void testGetFieldNonExistingEntity() {
-		final StatisticsImplementor statistics = sessionFactory().getStatistics();
+	@JiraKey("HHH-11147")
+	public void testGetFieldNonExistingEntity(SessionFactoryScope scope) {
+		final StatisticsImplementor statistics = scope.getSessionFactory().getStatistics();
 		statistics.clear();
-		doInHibernate(
-				this::sessionFactory, session -> {
+		scope.inTransaction( session -> {
 					Employer nonExisting = session.load( Employer.class, -1 );
 					assertEquals( 0, statistics.getPrepareStatementCount() );
 					assertFalse( Hibernate.isInitialized( nonExisting ) );
@@ -120,18 +129,9 @@ public class LoadANonExistingEntityTest extends BaseNonConfigCoreFunctionalTestC
 		);
 	}
 
-	@Override
-	protected Class[] getAnnotatedClasses() {
-		return new Class[] {
-				Employee.class,
-				Employer.class
-		};
-	}
-
-	@Before
-	public void setUpData() {
-		doInHibernate(
-				this::sessionFactory, session -> {
+	@BeforeEach
+	public void setUpData(SessionFactoryScope scope) {
+		scope.inTransaction( session -> {
 					for ( int i = 0; i < NUMBER_OF_ENTITIES; i++ ) {
 						final Employee employee = new Employee();
 						employee.id = i + 1;
@@ -146,29 +146,13 @@ public class LoadANonExistingEntityTest extends BaseNonConfigCoreFunctionalTestC
 		);
 	}
 
-	@After
-	public void cleanupDate() {
-		doInHibernate(
-				this::sessionFactory, session -> {
+	@AfterEach
+	public void cleanupDate(SessionFactoryScope scope) {
+		scope.inTransaction( session -> {
 					session.createQuery( "delete from Employee" ).executeUpdate();
 					session.createQuery( "delete from Employer" ).executeUpdate();
 				}
 		);
-	}
-
-	@Override
-	protected void configureStandardServiceRegistryBuilder(StandardServiceRegistryBuilder ssrb) {
-		super.configureStandardServiceRegistryBuilder( ssrb );
-		ssrb.applySetting( AvailableSettings.FORMAT_SQL, "false" );
-		ssrb.applySetting( AvailableSettings.GENERATE_STATISTICS, "true" );
-	}
-
-	@Override
-	protected void configureSessionFactoryBuilder(SessionFactoryBuilder sfb) {
-		super.configureSessionFactoryBuilder( sfb );
-		sfb.applyStatisticsSupport( true );
-		sfb.applySecondLevelCacheSupport( false );
-		sfb.applyQueryCacheSupport( false );
 	}
 
 	@Entity(name = "Employee")

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/lazy/proxy/LoadANonExistingNotFoundBatchEntityTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/lazy/proxy/LoadANonExistingNotFoundBatchEntityTest.java
@@ -28,44 +28,58 @@ import org.hibernate.Hibernate;
 import org.hibernate.annotations.BatchSize;
 import org.hibernate.annotations.NotFound;
 import org.hibernate.annotations.NotFoundAction;
-import org.hibernate.boot.SessionFactoryBuilder;
-import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
 import org.hibernate.cfg.AvailableSettings;
 import org.hibernate.stat.spi.StatisticsImplementor;
 
-import org.hibernate.testing.TestForIssue;
-import org.hibernate.testing.bytecode.enhancement.BytecodeEnhancerRunner;
 import org.hibernate.testing.bytecode.enhancement.EnhancementOptions;
-import org.hibernate.testing.junit4.BaseNonConfigCoreFunctionalTestCase;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.hibernate.testing.bytecode.enhancement.extension.BytecodeEnhanced;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.JiraKey;
+import org.hibernate.testing.orm.junit.ServiceRegistry;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.hibernate.testing.orm.junit.Setting;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.hibernate.testing.transaction.TransactionUtil.doInHibernate;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * @author Andrea Boriero
  * @author Gail Badner
  */
-@TestForIssue(jiraKey = "HHH-11147")
-@RunWith(BytecodeEnhancerRunner.class)
+@JiraKey("HHH-11147")
+@DomainModel(
+		annotatedClasses = {
+				LoadANonExistingNotFoundBatchEntityTest.Employee.class,
+				LoadANonExistingNotFoundBatchEntityTest.Employer.class
+		}
+)
+@ServiceRegistry(
+		settings = {
+				@Setting( name = AvailableSettings.FORMAT_SQL, value = "false" ),
+				@Setting( name = AvailableSettings.GENERATE_STATISTICS, value = "true" ),
+				@Setting( name = AvailableSettings.USE_SECOND_LEVEL_CACHE, value = "false" ),
+				@Setting( name = AvailableSettings.USE_QUERY_CACHE, value = "false" ),
+		}
+)
+@SessionFactory
+@BytecodeEnhanced
 @EnhancementOptions(lazyLoading = true)
-public class LoadANonExistingNotFoundBatchEntityTest extends BaseNonConfigCoreFunctionalTestCase {
+public class LoadANonExistingNotFoundBatchEntityTest {
 
 	private static final int NUMBER_OF_ENTITIES = 20;
 
 	@Test
-	@TestForIssue(jiraKey = "HHH-11147")
-	public void loadEntityWithNotFoundAssociation() {
-		final StatisticsImplementor statistics = sessionFactory().getStatistics();
+	@JiraKey("HHH-11147")
+	public void loadEntityWithNotFoundAssociation(SessionFactoryScope scope) {
+		final StatisticsImplementor statistics = scope.getSessionFactory().getStatistics();
 		statistics.clear();
 
-		inTransaction( (session) -> {
+		scope.inTransaction( (session) -> {
 			List<Employee> employees = new ArrayList<>( NUMBER_OF_ENTITIES );
 			for ( int i = 0 ; i < NUMBER_OF_ENTITIES ; i++ ) {
 				employees.add( session.load( Employee.class, i + 1 ) );
@@ -81,12 +95,12 @@ public class LoadANonExistingNotFoundBatchEntityTest extends BaseNonConfigCoreFu
 	}
 
 	@Test
-	@TestForIssue(jiraKey = "HHH-11147")
-	public void getEntityWithNotFoundAssociation() {
-		final StatisticsImplementor statistics = sessionFactory().getStatistics();
+	@JiraKey("HHH-11147")
+	public void getEntityWithNotFoundAssociation(SessionFactoryScope scope) {
+		final StatisticsImplementor statistics = scope.getSessionFactory().getStatistics();
 		statistics.clear();
 
-		inTransaction( (session) -> {
+		scope.inTransaction( (session) -> {
 			for ( int i = 0 ; i < NUMBER_OF_ENTITIES ; i++ ) {
 				Employee employee = session.get( Employee.class, i + 1 );
 				assertNull( employee.employer );
@@ -98,12 +112,12 @@ public class LoadANonExistingNotFoundBatchEntityTest extends BaseNonConfigCoreFu
 	}
 
 	@Test
-	@TestForIssue(jiraKey = "HHH-11147")
-	public void updateNotFoundAssociationWithNew() {
-		final StatisticsImplementor statistics = sessionFactory().getStatistics();
+	@JiraKey("HHH-11147")
+	public void updateNotFoundAssociationWithNew(SessionFactoryScope scope) {
+		final StatisticsImplementor statistics = scope.getSessionFactory().getStatistics();
 		statistics.clear();
 
-		inTransaction( (session) -> {
+		scope.inTransaction( (session) -> {
 			for ( int i = 0; i < NUMBER_OF_ENTITIES; i++ ) {
 				Employee employee = session.get( Employee.class, i + 1 );
 				Employer employer = new Employer();
@@ -113,7 +127,7 @@ public class LoadANonExistingNotFoundBatchEntityTest extends BaseNonConfigCoreFu
 			}
 		} );
 
-		inTransaction( (session) -> {
+		scope.inTransaction( (session) -> {
 			for ( int i = 0; i < NUMBER_OF_ENTITIES; i++ ) {
 				Employee employee = session.get( Employee.class, i + 1 );
 				assertTrue( Hibernate.isInitialized( employee.employer ) );
@@ -123,18 +137,9 @@ public class LoadANonExistingNotFoundBatchEntityTest extends BaseNonConfigCoreFu
 		} );
 	}
 
-	@Override
-	protected Class[] getAnnotatedClasses() {
-		return new Class[] {
-				Employee.class,
-				Employer.class
-		};
-	}
-
-	@Before
-	public void setUpData() {
-		doInHibernate(
-				this::sessionFactory, session -> {
+	@BeforeEach
+	public void setUpData(SessionFactoryScope scope) {
+		scope.inTransaction( session -> {
 					for ( int i = 0; i < NUMBER_OF_ENTITIES; i++ ) {
 						final Employee employee = new Employee();
 						employee.id = i + 1;
@@ -144,38 +149,20 @@ public class LoadANonExistingNotFoundBatchEntityTest extends BaseNonConfigCoreFu
 				}
 		);
 
-
-		doInHibernate(
-				this::sessionFactory, session -> {
+		scope.inTransaction( session -> {
 					// Add "not found" associations
 					session.createNativeQuery( "update Employee set employer_id = id" ).executeUpdate();
 				}
 		);
 	}
 
-	@After
-	public void cleanupDate() {
-		doInHibernate(
-				this::sessionFactory, session -> {
+	@AfterEach
+	public void cleanupDate(SessionFactoryScope scope) {
+		scope.inTransaction( session -> {
 					session.createQuery( "delete from Employee" ).executeUpdate();
 					session.createQuery( "delete from Employer" ).executeUpdate();
 				}
 		);
-	}
-
-	@Override
-	protected void configureStandardServiceRegistryBuilder(StandardServiceRegistryBuilder ssrb) {
-		super.configureStandardServiceRegistryBuilder( ssrb );
-		ssrb.applySetting( AvailableSettings.FORMAT_SQL, "false" );
-		ssrb.applySetting( AvailableSettings.GENERATE_STATISTICS, "true" );
-	}
-
-	@Override
-	protected void configureSessionFactoryBuilder(SessionFactoryBuilder sfb) {
-		super.configureSessionFactoryBuilder( sfb );
-		sfb.applyStatisticsSupport( true );
-		sfb.applySecondLevelCacheSupport( false );
-		sfb.applyQueryCacheSupport( false );
 	}
 
 	@Entity(name = "Employee")

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/lazy/proxy/LoadANonExistingNotFoundEntityTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/lazy/proxy/LoadANonExistingNotFoundEntityTest.java
@@ -25,42 +25,56 @@ import jakarta.persistence.ManyToOne;
 import org.hibernate.Hibernate;
 import org.hibernate.annotations.NotFound;
 import org.hibernate.annotations.NotFoundAction;
-import org.hibernate.boot.SessionFactoryBuilder;
-import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
 import org.hibernate.cfg.AvailableSettings;
 import org.hibernate.stat.spi.StatisticsImplementor;
 
-import org.hibernate.testing.TestForIssue;
-import org.hibernate.testing.bytecode.enhancement.BytecodeEnhancerRunner;
 import org.hibernate.testing.bytecode.enhancement.EnhancementOptions;
-import org.hibernate.testing.junit4.BaseNonConfigCoreFunctionalTestCase;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.hibernate.testing.bytecode.enhancement.extension.BytecodeEnhanced;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.JiraKey;
+import org.hibernate.testing.orm.junit.ServiceRegistry;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.hibernate.testing.orm.junit.Setting;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-import static org.hibernate.testing.transaction.TransactionUtil.doInHibernate;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * @author Andrea Boriero
  * @author Gail Badner
  */
-@TestForIssue(jiraKey = "HHH-11147")
-@RunWith(BytecodeEnhancerRunner.class)
+@JiraKey("HHH-11147")
+@DomainModel(
+		annotatedClasses = {
+				LoadANonExistingNotFoundEntityTest.Employee.class,
+				LoadANonExistingNotFoundEntityTest.Employer.class
+		}
+)
+@ServiceRegistry(
+		settings = {
+				@Setting( name = AvailableSettings.FORMAT_SQL, value = "false" ),
+				@Setting( name = AvailableSettings.GENERATE_STATISTICS, value = "true" ),
+				@Setting( name = AvailableSettings.USE_SECOND_LEVEL_CACHE, value = "false" ),
+				@Setting( name = AvailableSettings.USE_QUERY_CACHE, value = "false" ),
+		}
+)
+@SessionFactory
+@BytecodeEnhanced
 @EnhancementOptions(lazyLoading = true)
-public class LoadANonExistingNotFoundEntityTest extends BaseNonConfigCoreFunctionalTestCase {
+public class LoadANonExistingNotFoundEntityTest {
 
 	@Test
-	@TestForIssue(jiraKey = "HHH-11147")
-	public void loadEntityWithNotFoundAssociation() {
-		final StatisticsImplementor statistics = sessionFactory().getStatistics();
+	@JiraKey("HHH-11147")
+	public void loadEntityWithNotFoundAssociation(SessionFactoryScope scope) {
+		final StatisticsImplementor statistics = scope.getSessionFactory().getStatistics();
 		statistics.clear();
 
-		doInHibernate(
-				this::sessionFactory, session -> {
+		scope.inTransaction( session -> {
 					Employee employee = session.load( Employee.class, 1 );
 					Hibernate.initialize( employee );
 					assertNull( employee.employer );
@@ -72,13 +86,12 @@ public class LoadANonExistingNotFoundEntityTest extends BaseNonConfigCoreFunctio
 	}
 
 	@Test
-	@TestForIssue(jiraKey = "HHH-11147")
-	public void getEntityWithNotFoundAssociation() {
-		final StatisticsImplementor statistics = sessionFactory().getStatistics();
+	@JiraKey("HHH-11147")
+	public void getEntityWithNotFoundAssociation(SessionFactoryScope scope) {
+		final StatisticsImplementor statistics = scope.getSessionFactory().getStatistics();
 		statistics.clear();
 
-		doInHibernate(
-				this::sessionFactory, session -> {
+		scope.inTransaction( session -> {
 					Employee employee = session.get( Employee.class, 1 );
 					assertNull( employee.employer );
 				}
@@ -89,13 +102,12 @@ public class LoadANonExistingNotFoundEntityTest extends BaseNonConfigCoreFunctio
 	}
 
 	@Test
-	@TestForIssue(jiraKey = "HHH-11147")
-	public void updateNotFoundAssociationWithNew() {
-		final StatisticsImplementor statistics = sessionFactory().getStatistics();
+	@JiraKey("HHH-11147")
+	public void updateNotFoundAssociationWithNew(SessionFactoryScope scope) {
+		final StatisticsImplementor statistics = scope.getSessionFactory().getStatistics();
 		statistics.clear();
 
-		doInHibernate(
-				this::sessionFactory, session -> {
+		scope.inTransaction( session -> {
 					Employee employee = session.get( Employee.class, 1 );
 					Employer employer = new Employer();
 					employer.id = 2 * employee.id;
@@ -104,8 +116,7 @@ public class LoadANonExistingNotFoundEntityTest extends BaseNonConfigCoreFunctio
 				}
 		);
 
-		doInHibernate(
-				this::sessionFactory, session -> {
+		scope.inTransaction( session -> {
 					Employee employee = session.get( Employee.class, 1 );
 					assertTrue( Hibernate.isInitialized( employee.employer ) );
 					assertEquals( employee.id * 2, employee.employer.id );
@@ -114,18 +125,9 @@ public class LoadANonExistingNotFoundEntityTest extends BaseNonConfigCoreFunctio
 		);
 	}
 
-	@Override
-	protected Class[] getAnnotatedClasses() {
-		return new Class[] {
-				Employee.class,
-				Employer.class
-		};
-	}
-
-	@Before
-	public void setUpData() {
-		doInHibernate(
-				this::sessionFactory, session -> {
+	@BeforeEach
+	public void setUpData(SessionFactoryScope scope) {
+		scope.inTransaction( session -> {
 					final Employee employee = new Employee();
 					employee.id = 1;
 					employee.name = "Employee #" + employee.id;
@@ -134,37 +136,20 @@ public class LoadANonExistingNotFoundEntityTest extends BaseNonConfigCoreFunctio
 		);
 
 
-		doInHibernate(
-				this::sessionFactory, session -> {
+		scope.inTransaction( session -> {
 					// Add "not found" associations
 					session.createNativeQuery( "update Employee set employer_id = 0 ").executeUpdate();
 				}
 		);
 	}
 
-	@After
-	public void cleanupDate() {
-		doInHibernate(
-				this::sessionFactory, session -> {
+	@AfterEach
+	public void cleanupDate(SessionFactoryScope scope) {
+		scope.inTransaction( session -> {
 					session.createQuery( "delete from Employee" ).executeUpdate();
 					session.createQuery( "delete from Employer" ).executeUpdate();
 				}
 		);
-	}
-
-	@Override
-	protected void configureStandardServiceRegistryBuilder(StandardServiceRegistryBuilder ssrb) {
-		super.configureStandardServiceRegistryBuilder( ssrb );
-		ssrb.applySetting( AvailableSettings.FORMAT_SQL, "false" );
-		ssrb.applySetting( AvailableSettings.GENERATE_STATISTICS, "true" );
-	}
-
-	@Override
-	protected void configureSessionFactoryBuilder(SessionFactoryBuilder sfb) {
-		super.configureSessionFactoryBuilder( sfb );
-		sfb.applyStatisticsSupport( true );
-		sfb.applySecondLevelCacheSupport( false );
-		sfb.applyQueryCacheSupport( false );
 	}
 
 	@Entity(name = "Employee")

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/lazy/proxy/MapsIdProxyBidirectionalTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/lazy/proxy/MapsIdProxyBidirectionalTest.java
@@ -14,41 +14,56 @@ import jakarta.persistence.MapsId;
 import jakarta.persistence.OneToOne;
 
 import org.hibernate.Hibernate;
-import org.hibernate.boot.SessionFactoryBuilder;
-import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
 import org.hibernate.cfg.AvailableSettings;
 import org.hibernate.stat.Statistics;
 
-import org.hibernate.testing.bytecode.enhancement.BytecodeEnhancerRunner;
 import org.hibernate.testing.bytecode.enhancement.EnhancementOptions;
-import org.hibernate.testing.junit4.BaseNonConfigCoreFunctionalTestCase;
+import org.hibernate.testing.bytecode.enhancement.extension.BytecodeEnhanced;
+import org.hibernate.testing.orm.junit.DomainModel;
 import org.hibernate.testing.orm.junit.JiraKey;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.hibernate.testing.orm.junit.ServiceRegistry;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.hibernate.testing.orm.junit.Setting;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * @author Gail Badner
  */
 
 @JiraKey("HHH-13814")
-@RunWith( BytecodeEnhancerRunner.class )
+@DomainModel(
+		annotatedClasses = {
+				MapsIdProxyBidirectionalTest.EmployerInfo.class,
+				MapsIdProxyBidirectionalTest.Employer.class
+		}
+)
+@ServiceRegistry(
+		settings = {
+				@Setting( name = AvailableSettings.FORMAT_SQL, value = "false" ),
+				@Setting( name = AvailableSettings.GENERATE_STATISTICS, value = "true" ),
+				@Setting( name = AvailableSettings.USE_SECOND_LEVEL_CACHE, value = "false" ),
+				@Setting( name = AvailableSettings.USE_QUERY_CACHE, value = "false" ),
+		}
+)
+@SessionFactory
+@BytecodeEnhanced
 @EnhancementOptions( lazyLoading = true )
-public class MapsIdProxyBidirectionalTest extends BaseNonConfigCoreFunctionalTestCase {
+public class MapsIdProxyBidirectionalTest {
 
 	@Test
-	public void testAssociation() {
-		inTransaction(
+	public void testAssociation(SessionFactoryScope scope) {
+		scope.inTransaction(
 				session -> {
-					final Statistics statistics = sessionFactory().getStatistics();
+					final Statistics statistics = scope.getSessionFactory().getStatistics();
 					statistics.clear();
 					EmployerInfo employerInfo = session.get( EmployerInfo.class, 1 );
 
@@ -60,17 +75,17 @@ public class MapsIdProxyBidirectionalTest extends BaseNonConfigCoreFunctionalTes
 					Hibernate.initialize( employer );
 					assertEquals( "Employer #" + employer.id, employer.name );
 
-					assertThat( statistics.getEntityLoadCount(), is( 2L ) );
-					assertThat( statistics.getPrepareStatementCount(), is( 2L ) );
+					assertThat( statistics.getEntityLoadCount() ).isEqualTo( 2L );
+					assertThat( statistics.getPrepareStatementCount() ).isEqualTo( 2L );
 				}
 		);
 	}
 
 	@Test
-	public void testMappedByAssociation() {
-		inTransaction(
+	public void testMappedByAssociation(SessionFactoryScope scope) {
+		scope.inTransaction(
 				session -> {
-					final Statistics statistics = sessionFactory().getStatistics();
+					final Statistics statistics = scope.getSessionFactory().getStatistics();
 					statistics.clear();
 					Employer employer = session.get( Employer.class, 1 );
 
@@ -83,24 +98,16 @@ public class MapsIdProxyBidirectionalTest extends BaseNonConfigCoreFunctionalTes
 					assertTrue( Hibernate.isPropertyInitialized( employerInfo, "employer" ) );
 					assertSame( employer, employerInfo.employer );
 
-					assertThat( statistics.getEntityLoadCount(), is( 2L ) );
-					assertThat( statistics.getPrepareStatementCount(), is( 2L ) );
+					assertThat( statistics.getEntityLoadCount() ).isEqualTo( 2L );
+					assertThat( statistics.getPrepareStatementCount() ).isEqualTo( 2L );
 				}
 		);
 	}
 
 
-	@Override
-	protected Class[] getAnnotatedClasses() {
-		return new Class[] {
-				EmployerInfo.class,
-				Employer.class
-		};
-	}
-
-	@Before
-	public void setUpData() {
-		inTransaction(
+	@BeforeEach
+	public void setUpData(SessionFactoryScope scope) {
+		scope.inTransaction(
 				session -> {
 					final Employer employer = new Employer();
 					employer.id = 1;
@@ -113,30 +120,14 @@ public class MapsIdProxyBidirectionalTest extends BaseNonConfigCoreFunctionalTes
 		);
 	}
 
-	@After
-	public void cleanupDate() {
-		inTransaction(
+	@AfterEach
+	public void cleanupDate(SessionFactoryScope scope) {
+		scope.inTransaction(
 				session -> {
 					session.createQuery( "delete from EmployerInfo" ).executeUpdate();
 					session.createQuery( "delete from Employer" ).executeUpdate();
 				}
 		);
-	}
-
-	@Override
-	protected void configureStandardServiceRegistryBuilder(StandardServiceRegistryBuilder ssrb) {
-		super.configureStandardServiceRegistryBuilder( ssrb );
-		ssrb.applySetting( AvailableSettings.FORMAT_SQL, "false" );
-		ssrb.applySetting( AvailableSettings.GENERATE_STATISTICS, "true" );
-		ssrb.applySetting( AvailableSettings.SHOW_SQL, true );
-	}
-
-	@Override
-	protected void configureSessionFactoryBuilder(SessionFactoryBuilder sfb) {
-		super.configureSessionFactoryBuilder( sfb );
-		sfb.applyStatisticsSupport( true );
-		sfb.applySecondLevelCacheSupport( false );
-		sfb.applyQueryCacheSupport( false );
 	}
 
 	@Entity(name = "EmployerInfo")

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/lazy/proxy/ProxyInitializeAndUpdateTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/lazy/proxy/ProxyInitializeAndUpdateTest.java
@@ -11,48 +11,49 @@ import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 
 import org.hibernate.Hibernate;
-import org.hibernate.boot.MetadataSources;
-import org.hibernate.boot.SessionFactoryBuilder;
+import org.hibernate.cfg.AvailableSettings;
 
-import org.hibernate.testing.TestForIssue;
-import org.hibernate.testing.bytecode.enhancement.BytecodeEnhancerRunner;
 import org.hibernate.testing.bytecode.enhancement.EnhancementOptions;
-import org.hibernate.testing.junit4.BaseNonConfigCoreFunctionalTestCase;
-import org.junit.After;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.hibernate.testing.bytecode.enhancement.extension.BytecodeEnhanced;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.JiraKey;
+import org.hibernate.testing.orm.junit.ServiceRegistry;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.hibernate.testing.orm.junit.Setting;
 
-import static org.hibernate.testing.transaction.TransactionUtil.doInHibernate;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Gail Badner
  */
-@TestForIssue( jiraKey = "HHH-13640" )
-@RunWith(BytecodeEnhancerRunner.class)
+@JiraKey( "HHH-13640" )
+@DomainModel(
+		annotatedClasses = {
+				ProxyInitializeAndUpdateTest.Animal.class
+		}
+)
+@ServiceRegistry(
+		settings = {
+				@Setting( name = AvailableSettings.GENERATE_STATISTICS, value = "true" ),
+				@Setting( name = AvailableSettings.USE_SECOND_LEVEL_CACHE, value = "false" ),
+				@Setting( name = AvailableSettings.USE_QUERY_CACHE, value = "false" ),
+		}
+)
+@SessionFactory
+@BytecodeEnhanced
 @EnhancementOptions(lazyLoading = true)
-public class ProxyInitializeAndUpdateTest extends BaseNonConfigCoreFunctionalTestCase {
-
-	@Override
-	protected void configureSessionFactoryBuilder(SessionFactoryBuilder sfb) {
-		super.configureSessionFactoryBuilder( sfb );
-		sfb.applyStatisticsSupport( true );
-		sfb.applySecondLevelCacheSupport( false );
-		sfb.applyQueryCacheSupport( false );
-	}
-
-	@Override
-	protected void applyMetadataSources(MetadataSources sources) {
-		super.applyMetadataSources( sources );
-		sources.addAnnotatedClass( Animal.class );
-	}
+public class ProxyInitializeAndUpdateTest {
 
 	@Test
-	public void testInitializeWithGetter() {
-		inTransaction(
+	public void testInitializeWithGetter(SessionFactoryScope scope) {
+		scope.inTransaction(
 				session -> {
 					Animal animal = new Animal();
 					animal.name = "animal";
@@ -63,7 +64,7 @@ public class ProxyInitializeAndUpdateTest extends BaseNonConfigCoreFunctionalTes
 				}
 		);
 
-		inTransaction(
+		scope.inTransaction(
 				session -> {
 					Animal animal = session.load( Animal.class, "animal" );
 					assertFalse( Hibernate.isInitialized( animal ) );
@@ -74,7 +75,7 @@ public class ProxyInitializeAndUpdateTest extends BaseNonConfigCoreFunctionalTes
 				}
 		);
 
-		inSession(
+		scope.inSession(
 				session -> {
 					Animal animal = session.get( Animal.class, "animal" );
 					assertTrue( Hibernate.isInitialized( animal ) );
@@ -86,8 +87,8 @@ public class ProxyInitializeAndUpdateTest extends BaseNonConfigCoreFunctionalTes
 	}
 
 	@Test
-	public void testInitializeWithSetter() {
-		inTransaction(
+	public void testInitializeWithSetter(SessionFactoryScope scope) {
+		scope.inTransaction(
 				session -> {
 					Animal animal = new Animal();
 					animal.name = "animal";
@@ -98,7 +99,7 @@ public class ProxyInitializeAndUpdateTest extends BaseNonConfigCoreFunctionalTes
 				}
 		);
 
-		inTransaction(
+		scope.inTransaction(
 				session -> {
 					Animal animal = session.load( Animal.class, "animal" );
 					assertFalse( Hibernate.isInitialized( animal ) );
@@ -108,7 +109,7 @@ public class ProxyInitializeAndUpdateTest extends BaseNonConfigCoreFunctionalTes
 				}
 		);
 
-		inSession(
+		scope.inSession(
 				session -> {
 					Animal animal = session.get( Animal.class, "animal" );
 					assertTrue( Hibernate.isInitialized( animal ) );
@@ -120,8 +121,8 @@ public class ProxyInitializeAndUpdateTest extends BaseNonConfigCoreFunctionalTes
 	}
 
 	@Test
-	public void testMergeUpdatedOntoUninitialized() {
-		inTransaction(
+	public void testMergeUpdatedOntoUninitialized(SessionFactoryScope scope) {
+		scope.inTransaction(
 				session -> {
 					Animal animal = new Animal();
 					animal.name = "animal";
@@ -131,9 +132,7 @@ public class ProxyInitializeAndUpdateTest extends BaseNonConfigCoreFunctionalTes
 				}
 		);
 
-		final Animal animalInitialized = doInHibernate(
-				this::sessionFactory,
-				session -> {
+		final Animal animalInitialized = scope.fromTransaction( session -> {
 					final Animal animal = session.get( Animal.class, "animal" );
 					assertTrue( Hibernate.isInitialized( animal ) );
 					assertEquals( "female", animal.getSex() );
@@ -145,7 +144,7 @@ public class ProxyInitializeAndUpdateTest extends BaseNonConfigCoreFunctionalTes
 		animalInitialized.setAge( 4 );
 		animalInitialized.setSex( "other" );
 
-		inTransaction(
+		scope.inTransaction(
 				session -> {
 					final Animal animal = session.load( Animal.class, "animal" );
 					assertFalse( Hibernate.isInitialized( animal ) );
@@ -157,7 +156,7 @@ public class ProxyInitializeAndUpdateTest extends BaseNonConfigCoreFunctionalTes
 				}
 		);
 
-		inTransaction(
+		scope.inTransaction(
 				session -> {
 					final Animal animal = session.get( Animal.class, "animal" );
 					assertTrue( Hibernate.isInitialized( animal ) );
@@ -168,8 +167,8 @@ public class ProxyInitializeAndUpdateTest extends BaseNonConfigCoreFunctionalTes
 	}
 
 	@Test
-	public void testMergeUpdatedOntoUpdated() {
-		inTransaction(
+	public void testMergeUpdatedOntoUpdated(SessionFactoryScope scope) {
+		scope.inTransaction(
 				session -> {
 					Animal animal = new Animal();
 					animal.name = "animal";
@@ -179,9 +178,7 @@ public class ProxyInitializeAndUpdateTest extends BaseNonConfigCoreFunctionalTes
 				}
 		);
 
-		final Animal animalInitialized = doInHibernate(
-				this::sessionFactory,
-				session -> {
+		final Animal animalInitialized = scope.fromTransaction( session -> {
 					final Animal animal = session.get( Animal.class, "animal" );
 					assertTrue( Hibernate.isInitialized( animal ) );
 					assertEquals( "female", animal.getSex() );
@@ -193,7 +190,7 @@ public class ProxyInitializeAndUpdateTest extends BaseNonConfigCoreFunctionalTes
 		animalInitialized.setAge( 4 );
 		animalInitialized.setSex( "other" );
 
-		inTransaction(
+		scope.inTransaction(
 				session -> {
 					final Animal animal = session.get( Animal.class, "animal" );
 					assertTrue( Hibernate.isInitialized( animal ) );
@@ -206,7 +203,7 @@ public class ProxyInitializeAndUpdateTest extends BaseNonConfigCoreFunctionalTes
 				}
 		);
 
-		inTransaction(
+		scope.inTransaction(
 				session -> {
 					final Animal animal = session.get( Animal.class, "animal" );
 					assertTrue( Hibernate.isInitialized( animal ) );
@@ -217,8 +214,8 @@ public class ProxyInitializeAndUpdateTest extends BaseNonConfigCoreFunctionalTes
 	}
 
 	@Test
-	public void testMergeUninitializedOntoUninitialized() {
-		inTransaction(
+	public void testMergeUninitializedOntoUninitialized(SessionFactoryScope scope) {
+		scope.inTransaction(
 				session -> {
 					Animal animal = new Animal();
 					animal.name = "animal";
@@ -228,16 +225,14 @@ public class ProxyInitializeAndUpdateTest extends BaseNonConfigCoreFunctionalTes
 				}
 		);
 
-		final Animal animalUninitialized = doInHibernate(
-				this::sessionFactory,
-				session -> {
+		final Animal animalUninitialized = scope.fromTransaction( session -> {
 					final Animal animal = session.load( Animal.class, "animal" );
 					assertFalse( Hibernate.isInitialized( animal ) );
 					return animal;
 				}
 		);
 
-		inTransaction(
+		scope.inTransaction(
 				session -> {
 					final Animal animal = session.load( Animal.class, "animal" );
 					assertFalse( Hibernate.isInitialized( animal ) );
@@ -247,7 +242,7 @@ public class ProxyInitializeAndUpdateTest extends BaseNonConfigCoreFunctionalTes
 				}
 		);
 
-		inTransaction(
+		scope.inTransaction(
 				session -> {
 					final Animal animal = session.get( Animal.class, "animal" );
 					assertTrue( Hibernate.isInitialized( animal ) );
@@ -258,8 +253,8 @@ public class ProxyInitializeAndUpdateTest extends BaseNonConfigCoreFunctionalTes
 	}
 
 	@Test
-	public void testMergeUninitializedOntoUpdated() {
-		inTransaction(
+	public void testMergeUninitializedOntoUpdated(SessionFactoryScope scope) {
+		scope.inTransaction(
 				session -> {
 					Animal animal = new Animal();
 					animal.name = "animal";
@@ -269,16 +264,14 @@ public class ProxyInitializeAndUpdateTest extends BaseNonConfigCoreFunctionalTes
 				}
 		);
 
-		final Animal animalUninitialized = doInHibernate(
-				this::sessionFactory,
-				session -> {
+		final Animal animalUninitialized = scope.fromTransaction( session -> {
 					final Animal animal = session.load( Animal.class, "animal" );
 					assertFalse( Hibernate.isInitialized( animal ) );
 					return animal;
 				}
 		);
 
-		inTransaction(
+		scope.inTransaction(
 				session -> {
 					final Animal animal = session.load( Animal.class, "animal" );
 					assertFalse( Hibernate.isInitialized( animal ) );
@@ -293,7 +286,7 @@ public class ProxyInitializeAndUpdateTest extends BaseNonConfigCoreFunctionalTes
 				}
 		);
 
-		inTransaction(
+		scope.inTransaction(
 				session -> {
 					final Animal animal = session.get( Animal.class, "animal" );
 					assertTrue( Hibernate.isInitialized( animal ) );
@@ -303,9 +296,9 @@ public class ProxyInitializeAndUpdateTest extends BaseNonConfigCoreFunctionalTes
 		);
 	}
 
-	@After
-	public void cleanUpTestData() {
-		inTransaction(
+	@AfterEach
+	public void cleanUpTestData(SessionFactoryScope scope) {
+		scope.inTransaction(
 				session -> {
 					session.createQuery( "delete from Animal" ).executeUpdate();
 				}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/lazy/proxy/QueryScrollingWithInheritanceProxyEagerManyToOneTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/lazy/proxy/QueryScrollingWithInheritanceProxyEagerManyToOneTest.java
@@ -15,17 +15,16 @@ import org.hibernate.ScrollMode;
 import org.hibernate.ScrollableResults;
 import org.hibernate.Session;
 import org.hibernate.StatelessSession;
-import org.hibernate.boot.MetadataSources;
-import org.hibernate.boot.SessionFactoryBuilder;
+import org.hibernate.cfg.AvailableSettings;
 import org.hibernate.query.Query;
 import org.hibernate.stat.spi.StatisticsImplementor;
 
-import org.hibernate.testing.bytecode.enhancement.BytecodeEnhancerRunner;
-import org.hibernate.testing.junit4.BaseNonConfigCoreFunctionalTestCase;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.hibernate.testing.bytecode.enhancement.extension.BytecodeEnhanced;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.ServiceRegistry;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.hibernate.testing.orm.junit.Setting;
 
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -40,34 +39,37 @@ import jakarta.persistence.Table;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
 /**
  * @author Andrea Boriero
  */
-@RunWith(BytecodeEnhancerRunner.class)
-public class QueryScrollingWithInheritanceProxyEagerManyToOneTest extends BaseNonConfigCoreFunctionalTestCase {
-
-	@Override
-	protected void configureSessionFactoryBuilder(SessionFactoryBuilder sfb) {
-		super.configureSessionFactoryBuilder( sfb );
-		sfb.applyStatisticsSupport( true );
-		sfb.applySecondLevelCacheSupport( false );
-		sfb.applyQueryCacheSupport( false );
-	}
-
-	@Override
-	protected void applyMetadataSources(MetadataSources sources) {
-		super.applyMetadataSources( sources );
-		sources.addAnnotatedClass( EmployeeParent.class );
-		sources.addAnnotatedClass( Employee.class );
-		sources.addAnnotatedClass( OtherEntity.class );
-	}
+@DomainModel(
+		annotatedClasses = {
+				QueryScrollingWithInheritanceProxyEagerManyToOneTest.EmployeeParent.class,
+				QueryScrollingWithInheritanceProxyEagerManyToOneTest.Employee.class,
+				QueryScrollingWithInheritanceProxyEagerManyToOneTest.OtherEntity.class
+		}
+)
+@ServiceRegistry(
+		settings = {
+				@Setting( name = AvailableSettings.GENERATE_STATISTICS, value = "true" ),
+				@Setting( name = AvailableSettings.USE_SECOND_LEVEL_CACHE, value = "false" ),
+				@Setting( name = AvailableSettings.USE_QUERY_CACHE, value = "false" ),
+		}
+)
+@SessionFactory
+@BytecodeEnhanced
+public class QueryScrollingWithInheritanceProxyEagerManyToOneTest {
 
 	@Test
-	public void testScrollableWithStatelessSession() {
-		final StatisticsImplementor stats = sessionFactory().getStatistics();
+	public void testScrollableWithStatelessSession(SessionFactoryScope scope) {
+		final StatisticsImplementor stats = scope.getSessionFactory().getStatistics();
 		stats.clear();
 		ScrollableResults scrollableResults = null;
-		final StatelessSession statelessSession = sessionFactory().openStatelessSession();
+		final StatelessSession statelessSession = scope.getSessionFactory().openStatelessSession();
 
 		try {
 			statelessSession.beginTransaction();
@@ -116,11 +118,11 @@ public class QueryScrollingWithInheritanceProxyEagerManyToOneTest extends BaseNo
 	}
 
 	@Test
-	public void testScrollableWithSession() {
-		final StatisticsImplementor stats = sessionFactory().getStatistics();
+	public void testScrollableWithSession(SessionFactoryScope scope) {
+		final StatisticsImplementor stats = scope.getSessionFactory().getStatistics();
 		stats.clear();
 		ScrollableResults scrollableResults = null;
-		final Session session = sessionFactory().openSession();
+		final Session session = scope.getSessionFactory().openSession();
 
 		try {
 			session.beginTransaction();
@@ -168,9 +170,9 @@ public class QueryScrollingWithInheritanceProxyEagerManyToOneTest extends BaseNo
 		}
 	}
 
-	@Before
-	public void prepareTestData() {
-		inTransaction(
+	@BeforeEach
+	public void prepareTestData(SessionFactoryScope scope) {
+		scope.inTransaction(
 				session -> {
 					Employee e1 = new Employee( "ENG1" );
 					Employee e2 = new Employee( "ENG2" );
@@ -192,9 +194,9 @@ public class QueryScrollingWithInheritanceProxyEagerManyToOneTest extends BaseNo
 		);
 	}
 
-	@After
-	public void cleanUpTestData() {
-		inTransaction(
+	@AfterEach
+	public void cleanUpTestData(SessionFactoryScope scope) {
+		scope.inTransaction(
 				session -> {
 					session.createQuery( "delete from OtherEntity" ).executeUpdate();
 					session.createQuery( "delete from Employee" ).executeUpdate();

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/lazy/proxy/SharingReferenceTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/lazy/proxy/SharingReferenceTest.java
@@ -17,19 +17,20 @@ import jakarta.persistence.Id;
 import jakarta.persistence.ManyToMany;
 import jakarta.persistence.ManyToOne;
 
-import org.hibernate.boot.MetadataSources;
-import org.hibernate.boot.SessionFactoryBuilder;
-import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
 import org.hibernate.cfg.AvailableSettings;
 
-import org.hibernate.testing.bytecode.enhancement.BytecodeEnhancerRunner;
 import org.hibernate.testing.bytecode.enhancement.CustomEnhancementContext;
-import org.hibernate.testing.junit4.BaseNonConfigCoreFunctionalTestCase;
+import org.hibernate.testing.bytecode.enhancement.extension.BytecodeEnhanced;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.ServiceRegistry;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.hibernate.testing.orm.junit.Setting;
+
 import org.hibernate.orm.test.bytecode.enhancement.lazy.proxy.inlinedirtychecking.DirtyCheckEnhancementContext;
 import org.hibernate.orm.test.bytecode.enhancement.lazy.proxy.inlinedirtychecking.NoDirtyCheckEnhancementContext;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertSame;
@@ -37,36 +38,30 @@ import static org.junit.Assert.assertSame;
 /**
  * @author Andrea Boriero
  */
-@RunWith(BytecodeEnhancerRunner.class)
+@DomainModel(
+		annotatedClasses = {
+				SharingReferenceTest.Ceo.class,
+				SharingReferenceTest.Manager.class,
+				SharingReferenceTest.Supervisor.class,
+				SharingReferenceTest.Worker.class
+		}
+)
+@ServiceRegistry(
+		settings = {
+				@Setting(name = AvailableSettings.FORMAT_SQL, value = "false"),
+				@Setting(name = AvailableSettings.USE_SECOND_LEVEL_CACHE, value = "false"),
+				@Setting(name = AvailableSettings.USE_QUERY_CACHE, value = "false"),
+				@Setting(name = AvailableSettings.GENERATE_STATISTICS, value = "true"),
+		}
+)
+@SessionFactory
+@BytecodeEnhanced
 @CustomEnhancementContext({ DirtyCheckEnhancementContext.class, NoDirtyCheckEnhancementContext.class })
-public class SharingReferenceTest extends BaseNonConfigCoreFunctionalTestCase {
-	@Override
-	protected void configureStandardServiceRegistryBuilder(StandardServiceRegistryBuilder ssrb) {
-		super.configureStandardServiceRegistryBuilder( ssrb );
-		ssrb.applySetting( AvailableSettings.FORMAT_SQL, "false" );
-		ssrb.applySetting( AvailableSettings.GENERATE_STATISTICS, "true" );
-	}
+public class SharingReferenceTest {
 
-	@Override
-	protected void configureSessionFactoryBuilder(SessionFactoryBuilder sfb) {
-		super.configureSessionFactoryBuilder( sfb );
-		sfb.applyStatisticsSupport( true );
-		sfb.applySecondLevelCacheSupport( false );
-		sfb.applyQueryCacheSupport( false );
-	}
-
-	@Override
-	protected void applyMetadataSources(MetadataSources sources) {
-		super.applyMetadataSources( sources );
-		sources.addAnnotatedClass( Ceo.class );
-		sources.addAnnotatedClass( Manager.class );
-		sources.addAnnotatedClass( Supervisor.class );
-		sources.addAnnotatedClass( Worker.class );
-	}
-
-	@Before
-	public void setUp() {
-		inTransaction(
+	@BeforeEach
+	public void setUp(SessionFactoryScope scope) {
+		scope.inTransaction(
 				session -> {
 					Ceo ceo = new Ceo();
 					ceo.setName( "Jill" );
@@ -98,8 +93,8 @@ public class SharingReferenceTest extends BaseNonConfigCoreFunctionalTestCase {
 	}
 
 	@Test
-	public void testFind() {
-		inTransaction(
+	public void testFind(SessionFactoryScope scope) {
+		scope.inTransaction(
 				session -> {
 					Ceo ceo = session.find( Ceo.class, 1L );
 					assertEquals( "Jill", ceo.getName() );

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/lazy/proxy/SimpleUpdateWithLazyLoadingWithCollectionInDefaultFetchGroupFalseTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/lazy/proxy/SimpleUpdateWithLazyLoadingWithCollectionInDefaultFetchGroupFalseTest.java
@@ -9,7 +9,9 @@ package org.hibernate.orm.test.bytecode.enhancement.lazy.proxy;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.sameInstance;
 import static org.hamcrest.core.Is.is;
-import static org.hibernate.testing.transaction.TransactionUtil.doInHibernate;
+import static org.hibernate.orm.test.bytecode.enhancement.lazy.proxy.SimpleUpdateWithLazyLoadingWithCollectionInDefaultFetchGroupFalseTest.Child;
+import static org.hibernate.orm.test.bytecode.enhancement.lazy.proxy.SimpleUpdateWithLazyLoadingWithCollectionInDefaultFetchGroupFalseTest.Parent;
+import static org.hibernate.orm.test.bytecode.enhancement.lazy.proxy.SimpleUpdateWithLazyLoadingWithCollectionInDefaultFetchGroupFalseTest.Person;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 
@@ -17,10 +19,6 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.hibernate.Hibernate;
-import org.hibernate.boot.internal.SessionFactoryBuilderImpl;
-import org.hibernate.boot.internal.SessionFactoryOptionsBuilder;
-import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
-import org.hibernate.boot.spi.SessionFactoryBuilderService;
 import org.hibernate.bytecode.enhance.spi.LazyPropertyInitializer;
 import org.hibernate.bytecode.enhance.spi.interceptor.EnhancementAsProxyLazinessInterceptor;
 import org.hibernate.cfg.AvailableSettings;
@@ -30,14 +28,17 @@ import org.hibernate.engine.spi.PersistentAttributeInterceptor;
 import org.hibernate.persister.entity.EntityPersister;
 import org.hibernate.stat.Statistics;
 
-import org.hibernate.testing.TestForIssue;
-import org.hibernate.testing.bytecode.enhancement.BytecodeEnhancerRunner;
 import org.hibernate.testing.bytecode.enhancement.EnhancementOptions;
-import org.hibernate.testing.junit4.BaseNonConfigCoreFunctionalTestCase;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.hibernate.testing.bytecode.enhancement.extension.BytecodeEnhanced;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.JiraKey;
+import org.hibernate.testing.orm.junit.ServiceRegistry;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.hibernate.testing.orm.junit.Setting;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Entity;
@@ -58,44 +59,31 @@ import org.hamcrest.MatcherAssert;
  *
  * @author Andrea Boriero
  */
-@TestForIssue(jiraKey = "HHH-11147")
-@RunWith(BytecodeEnhancerRunner.class)
+@JiraKey("HHH-11147")
+@DomainModel(
+		annotatedClasses = {
+				Parent.class, Child.class, Person.class
+		}
+)
+@ServiceRegistry(
+		settings = {
+				@Setting( name = AvailableSettings.FORMAT_SQL, value = "false" ),
+				@Setting( name = AvailableSettings.USE_SECOND_LEVEL_CACHE, value = "false" ),
+				@Setting( name = AvailableSettings.ENABLE_LAZY_LOAD_NO_TRANS, value = "true" ),
+				@Setting( name = AvailableSettings.GENERATE_STATISTICS, value = "true" ),
+		}
+)
+@SessionFactory(applyCollectionsInDefaultFetchGroup = false)
+@BytecodeEnhanced
 @EnhancementOptions(lazyLoading = true)
-public class SimpleUpdateWithLazyLoadingWithCollectionInDefaultFetchGroupFalseTest extends BaseNonConfigCoreFunctionalTestCase {
-
-	@Override
-	protected void configureStandardServiceRegistryBuilder(StandardServiceRegistryBuilder ssrb) {
-		super.configureStandardServiceRegistryBuilder( ssrb );
-		ssrb.applySetting( AvailableSettings.FORMAT_SQL, "false" );
-		ssrb.applySetting( AvailableSettings.USE_SECOND_LEVEL_CACHE, "false" );
-		ssrb.applySetting( AvailableSettings.ENABLE_LAZY_LOAD_NO_TRANS, "true" );
-		ssrb.applySetting( AvailableSettings.GENERATE_STATISTICS, "true" );
-		ssrb.addService(
-				SessionFactoryBuilderService.class,
-				(SessionFactoryBuilderService) (metadata, bootstrapContext) -> {
-					SessionFactoryOptionsBuilder optionsBuilder = new SessionFactoryOptionsBuilder(
-							metadata.getMetadataBuildingOptions().getServiceRegistry(),
-							bootstrapContext
-					);
-					// We want to test with this setting set to false explicitly,
-					// because another test already takes care of the default.
-					optionsBuilder.enableCollectionInDefaultFetchGroup( false );
-					return new SessionFactoryBuilderImpl( metadata, optionsBuilder, bootstrapContext );
-				}
-		);
-	}
+public class SimpleUpdateWithLazyLoadingWithCollectionInDefaultFetchGroupFalseTest {
 
 	private static final int CHILDREN_SIZE = 10;
 	private Long lastChildID;
 
-	@Override
-	public Class<?>[] getAnnotatedClasses() {
-		return new Class<?>[] { Parent.class, Child.class, Person.class };
-	}
-
-	@Before
-	public void prepare() {
-		doInHibernate( this::sessionFactory, s -> {
+	@BeforeEach
+	public void prepare(SessionFactoryScope scope) {
+		scope.inTransaction( s -> {
 			Parent parent = new Parent();
 			for ( int i = 0; i < CHILDREN_SIZE; i++ ) {
 				Child child = new Child();
@@ -116,28 +104,28 @@ public class SimpleUpdateWithLazyLoadingWithCollectionInDefaultFetchGroupFalseTe
 	}
 
 
-	@After
-	public void tearDown() {
-		doInHibernate( this::sessionFactory, s -> {
+	@AfterEach
+	public void tearDown(SessionFactoryScope scope) {
+		scope.inTransaction( s -> {
 			s.createQuery( "delete from Child" ).executeUpdate();
 			s.createQuery( "delete from Parent" ).executeUpdate();
 		} );
 	}
 
 	@Test
-	public void updateSimpleField() {
-		final Statistics stats = sessionFactory().getStatistics();
+	public void updateSimpleField(SessionFactoryScope scope) {
+		final Statistics stats = scope.getSessionFactory().getStatistics();
 		stats.clear();
 
 		final String updatedName = "Barrabas_";
 
-		final EntityPersister childPersister = sessionFactory().getRuntimeMetamodels()
+		final EntityPersister childPersister = scope.getSessionFactory().getRuntimeMetamodels()
 				.getMappingMetamodel()
 				.getEntityDescriptor( Child.class.getName() );
 
 		final int relativesAttributeIndex = childPersister.getEntityMetamodel().getPropertyIndex( "relatives" );
 
-		inTransaction(
+		scope.inTransaction(
 				session -> {
 					stats.clear();
 					Child loadedChild = session.load( Child.class, lastChildID );
@@ -177,7 +165,7 @@ public class SimpleUpdateWithLazyLoadingWithCollectionInDefaultFetchGroupFalseTe
 				}
 		);
 
-		inTransaction(
+		scope.inTransaction(
 				session -> {
 					Child loadedChild = session.load( Child.class, lastChildID );
 					assertThat( loadedChild.getName(), is( updatedName ) );
@@ -193,11 +181,11 @@ public class SimpleUpdateWithLazyLoadingWithCollectionInDefaultFetchGroupFalseTe
 	}
 
 	@Test
-	public void testUpdateAssociation() {
+	public void testUpdateAssociation(SessionFactoryScope scope) {
 		String updatedName = "Barrabas_";
 		String parentName = "Yodit";
-		doInHibernate( this::sessionFactory, s -> {
-			final Statistics stats = sessionFactory().getStatistics();
+		scope.inTransaction( s -> {
+			final Statistics stats = scope.getSessionFactory().getStatistics();
 			stats.clear();
 			Child loadedChild = s.load( Child.class, lastChildID );
 
@@ -214,7 +202,7 @@ public class SimpleUpdateWithLazyLoadingWithCollectionInDefaultFetchGroupFalseTe
 			s.save( parent );
 		} );
 
-		doInHibernate( this::sessionFactory, s -> {
+		scope.inTransaction( s -> {
 			Child loadedChild = s.load( Child.class, lastChildID );
 			assertThat( Hibernate.isInitialized( loadedChild ), is( false ) );
 			assertThat( loadedChild.getName(), is( updatedName ) );
@@ -226,9 +214,9 @@ public class SimpleUpdateWithLazyLoadingWithCollectionInDefaultFetchGroupFalseTe
 	}
 
 	@Test
-	public void testUpdateCollection() {
-		doInHibernate( this::sessionFactory, s -> {
-			final Statistics stats = sessionFactory().getStatistics();
+	public void testUpdateCollection(SessionFactoryScope scope) {
+		scope.inTransaction( s -> {
+			final Statistics stats = scope.getSessionFactory().getStatistics();
 			stats.clear();
 			Child loadedChild = s.load( Child.class, lastChildID );
 
@@ -243,7 +231,7 @@ public class SimpleUpdateWithLazyLoadingWithCollectionInDefaultFetchGroupFalseTe
 			s.persist( relative );
 		} );
 
-		doInHibernate( this::sessionFactory, s -> {
+		scope.inTransaction( s -> {
 			Child loadedChild = s.load( Child.class, lastChildID );
 			assertThat( loadedChild.getRelatives().size(), is( 2 ) );
 		} );
@@ -251,7 +239,7 @@ public class SimpleUpdateWithLazyLoadingWithCollectionInDefaultFetchGroupFalseTe
 
 	@Entity(name = "Parent")
 	@Table(name = "PARENT")
-	private static class Parent {
+	static class Parent {
 
 		String name;
 
@@ -277,7 +265,7 @@ public class SimpleUpdateWithLazyLoadingWithCollectionInDefaultFetchGroupFalseTe
 
 	@Entity(name = "Person")
 	@Table(name = "Person")
-	private static class Person {
+	static class Person {
 		@Id
 		@GeneratedValue(strategy = GenerationType.AUTO)
 		Long id;
@@ -295,7 +283,7 @@ public class SimpleUpdateWithLazyLoadingWithCollectionInDefaultFetchGroupFalseTe
 
 	@Entity(name = "Child")
 	@Table(name = "CHILD")
-	private static class Child {
+	static class Child {
 
 		@Id
 		@GeneratedValue(strategy = GenerationType.AUTO)

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/lazy/proxy/batch/AbstractBatchingTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/lazy/proxy/batch/AbstractBatchingTest.java
@@ -15,71 +15,67 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.OneToOne;
 
 import org.hibernate.Hibernate;
-import org.hibernate.boot.MetadataSources;
-import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
 import org.hibernate.cfg.AvailableSettings;
+
+import org.hibernate.testing.bytecode.enhancement.extension.BytecodeEnhanced;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.ServiceRegistry;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.hibernate.testing.orm.junit.Setting;
 import org.hibernate.testing.util.uuid.SafeRandomUUIDGenerator;
+
 import org.hibernate.stat.spi.StatisticsImplementor;
 
-import org.hibernate.testing.bytecode.enhancement.BytecodeEnhancerRunner;
 import org.hibernate.testing.bytecode.enhancement.CustomEnhancementContext;
-import org.hibernate.testing.junit4.BaseNonConfigCoreFunctionalTestCase;
 import org.hibernate.orm.test.bytecode.enhancement.lazy.proxy.inlinedirtychecking.NoDirtyCheckEnhancementContext;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThat;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 /**
  * @author Andrea Boriero
  */
-@RunWith(BytecodeEnhancerRunner.class)
+@DomainModel(
+		annotatedClasses = {
+				AbstractBatchingTest.ParentEntity.class, AbstractBatchingTest.ChildEntity.class
+		}
+)
+@SessionFactory
+@BytecodeEnhanced
 @CustomEnhancementContext({ NoDirtyCheckEnhancementContext.class })
-public abstract class AbstractBatchingTest extends BaseNonConfigCoreFunctionalTestCase {
+public abstract class AbstractBatchingTest {
 	protected String childName = SafeRandomUUIDGenerator.safeRandomUUIDAsString();
 	protected Long parentId;
 
-	@Override
-	protected void configureStandardServiceRegistryBuilder(StandardServiceRegistryBuilder ssrb) {
-		super.configureStandardServiceRegistryBuilder( ssrb );
-		ssrb.applySetting( AvailableSettings.DEFAULT_BATCH_FETCH_SIZE, "100" );
-		ssrb.applySetting( AvailableSettings.GENERATE_STATISTICS, "true" );
-	}
-
-	@Override
-	protected void applyMetadataSources(MetadataSources sources) {
-		sources.addAnnotatedClass( ParentEntity.class );
-		sources.addAnnotatedClass( ChildEntity.class );
-	}
-
 	@Test
-	public void testLoadParent() {
-		StatisticsImplementor statistics = sessionFactory().getStatistics();
+	public void testLoadParent(SessionFactoryScope scope) {
+		StatisticsImplementor statistics = scope.getSessionFactory().getStatistics();
 		statistics.clear();
-		inTransaction(
+		scope.inTransaction(
 				session -> {
 					ParentEntity parentEntity = session.find( ParentEntity.class, parentId );
 
-					assertThat( statistics.getPrepareStatementCount(), is( 1L ) );
+					assertThat( statistics.getPrepareStatementCount() ).isEqualTo( 1L );
 
 					ChildEntity childEntity = parentEntity.getChildEntity();
 
 					assertFalse( Hibernate.isPropertyInitialized( childEntity, "name" ) );
 					assertEquals( childName, childEntity.getName() );
 
-					assertThat( statistics.getPrepareStatementCount(), is( 2L ) );
+					assertThat( statistics.getPrepareStatementCount() ).isEqualTo( 2L );
 				}
 		);
 	}
 
-	@Before
-	public void setUp() {
+	@BeforeEach
+	public void setUp(SessionFactoryScope scope) {
 		ParentEntity parent = new ParentEntity();
-		inTransaction(
+		scope.inTransaction(
 				session -> {
 					ChildEntity childEntity = new ChildEntity();
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/lazy/proxy/batch/DynamicBatchingTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/lazy/proxy/batch/DynamicBatchingTest.java
@@ -6,22 +6,23 @@
  */
 package org.hibernate.orm.test.bytecode.enhancement.lazy.proxy.batch;
 
-import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
 import org.hibernate.cfg.AvailableSettings;
-import org.hibernate.loader.BatchFetchStyle;
 
-import org.hibernate.testing.TestForIssue;
+import org.hibernate.testing.orm.junit.JiraKey;
+import org.hibernate.testing.orm.junit.ServiceRegistry;
+import org.hibernate.testing.orm.junit.Setting;
 
 /**
  * @author Andrea Boriero
  */
-@TestForIssue(jiraKey = "HHH-14108")
+@JiraKey("HHH-14108")
+@ServiceRegistry(
+		settings = {
+				@Setting(name = AvailableSettings.BATCH_FETCH_STYLE, value = "DYNAMIC"),
+				@Setting( name = AvailableSettings.DEFAULT_BATCH_FETCH_SIZE, value = "100" ),
+				@Setting( name = AvailableSettings.GENERATE_STATISTICS, value = "true" ),
+		}
+)
 public class DynamicBatchingTest extends AbstractBatchingTest {
-
-	@Override
-	protected void configureStandardServiceRegistryBuilder(StandardServiceRegistryBuilder ssrb) {
-		super.configureStandardServiceRegistryBuilder( ssrb );
-		ssrb.applySetting( AvailableSettings.BATCH_FETCH_STYLE, BatchFetchStyle.DYNAMIC.toString() );
-	}
 
 }

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/lazy/proxy/batch/PaddedBatchingTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/lazy/proxy/batch/PaddedBatchingTest.java
@@ -6,21 +6,22 @@
  */
 package org.hibernate.orm.test.bytecode.enhancement.lazy.proxy.batch;
 
-import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
 import org.hibernate.cfg.AvailableSettings;
-import org.hibernate.loader.BatchFetchStyle;
 
-import org.hibernate.testing.TestForIssue;
+import org.hibernate.testing.orm.junit.JiraKey;
+import org.hibernate.testing.orm.junit.ServiceRegistry;
+import org.hibernate.testing.orm.junit.Setting;
 
 /**
  * @author Andrea Boriero
  */
-@TestForIssue(jiraKey = "HHH-14108")
+@JiraKey("HHH-14108")
+@ServiceRegistry(
+		settings = {
+				@Setting(name = AvailableSettings.BATCH_FETCH_STYLE, value = "PADDED"),
+				@Setting( name = AvailableSettings.DEFAULT_BATCH_FETCH_SIZE, value = "100" ),
+				@Setting( name = AvailableSettings.GENERATE_STATISTICS, value = "true" ),
+		}
+)
 public class PaddedBatchingTest extends AbstractBatchingTest {
-
-	@Override
-	protected void configureStandardServiceRegistryBuilder(StandardServiceRegistryBuilder ssrb) {
-		super.configureStandardServiceRegistryBuilder( ssrb );
-		ssrb.applySetting( AvailableSettings.BATCH_FETCH_STYLE, BatchFetchStyle.PADDED.toString() );
-	}
 }

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/lazy/proxy/inlinedirtychecking/LoadAndUpdateEntitiesWithCollectionsTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/lazy/proxy/inlinedirtychecking/LoadAndUpdateEntitiesWithCollectionsTest.java
@@ -13,8 +13,6 @@ import jakarta.persistence.criteria.CriteriaBuilder;
 import jakarta.persistence.criteria.CriteriaQuery;
 import jakarta.persistence.criteria.Root;
 
-import org.hibernate.boot.MetadataSources;
-import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
 import org.hibernate.bytecode.internal.BytecodeProviderInitiator;
 import org.hibernate.cfg.AvailableSettings;
 import org.hibernate.cfg.Environment;
@@ -22,54 +20,54 @@ import org.hibernate.engine.spi.SessionImplementor;
 
 import org.hibernate.testing.DialectChecks;
 import org.hibernate.testing.RequiresDialectFeature;
-import org.hibernate.testing.TestForIssue;
-import org.hibernate.testing.bytecode.enhancement.BytecodeEnhancerRunner;
 import org.hibernate.testing.bytecode.enhancement.CustomEnhancementContext;
-import org.hibernate.testing.junit4.BaseNonConfigCoreFunctionalTestCase;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.hibernate.testing.bytecode.enhancement.extension.BytecodeEnhanced;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.JiraKey;
+import org.hibernate.testing.orm.junit.ServiceRegistry;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.hibernate.testing.orm.junit.Setting;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
 
-@TestForIssue(jiraKey = "HHH14424")
-@RunWith(BytecodeEnhancerRunner.class)
+@JiraKey("HHH14424")
+@DomainModel(
+		annotatedClasses = {
+				SamplingOrder.class,
+				Customer.class,
+				User.class,
+				Role.class
+		}
+)
+@ServiceRegistry(
+		settings = {
+				@Setting( name = AvailableSettings.DEFAULT_BATCH_FETCH_SIZE, value = "100" ),
+				@Setting( name = AvailableSettings.GENERATE_STATISTICS, value = "true" ),
+		}
+)
+@SessionFactory
+@BytecodeEnhanced
 @CustomEnhancementContext({ DirtyCheckEnhancementContext.class, NoDirtyCheckEnhancementContext.class })
 @RequiresDialectFeature(DialectChecks.SupportsIdentityColumns.class)
-public class LoadAndUpdateEntitiesWithCollectionsTest extends BaseNonConfigCoreFunctionalTestCase {
+public class LoadAndUpdateEntitiesWithCollectionsTest {
 
-	boolean skipTest;
-
-	@Override
-	protected void configureStandardServiceRegistryBuilder(StandardServiceRegistryBuilder ssrb) {
-		super.configureStandardServiceRegistryBuilder( ssrb );
-		ssrb.applySetting( AvailableSettings.DEFAULT_BATCH_FETCH_SIZE, "100" );
-		ssrb.applySetting( AvailableSettings.GENERATE_STATISTICS, "true" );
-	}
-
-	@Override
-	protected void applyMetadataSources(MetadataSources sources) {
+	@BeforeAll
+	static void beforeAll() {
 		String byteCodeProvider = Environment.getProperties().getProperty( AvailableSettings.BYTECODE_PROVIDER );
-		if ( byteCodeProvider != null && !BytecodeProviderInitiator.BYTECODE_PROVIDER_NAME_BYTEBUDDY.equals( byteCodeProvider ) ) {
-			// skip the test if the bytecode provider is Javassist
-			skipTest = true;
-		}
-		else {
-			sources.addAnnotatedClass( SamplingOrder.class );
-			sources.addAnnotatedClass( Customer.class );
-			sources.addAnnotatedClass( User.class );
-			sources.addAnnotatedClass( Role.class );
-		}
+		assumeFalse( byteCodeProvider != null && !BytecodeProviderInitiator.BYTECODE_PROVIDER_NAME_BYTEBUDDY.equals(
+				byteCodeProvider ) );
 	}
 
-	@Before
-	public void setUp() {
-		if ( skipTest ) {
-			return;
-		}
-		inTransaction(
+	@BeforeEach
+	public void setUp(SessionFactoryScope scope) {
+		scope.inTransaction(
 				session -> {
 					User user = new User();
 					user.setEmail( "foo@bar.com" );
@@ -95,12 +93,9 @@ public class LoadAndUpdateEntitiesWithCollectionsTest extends BaseNonConfigCoreF
 		);
 	}
 
-	@After
-	public void tearDown() {
-		if ( skipTest ) {
-			return;
-		}
-		inTransaction(
+	@AfterEach
+	public void tearDown(SessionFactoryScope scope) {
+		scope.inTransaction(
 				session -> {
 					session.createQuery( "delete from SamplingOrder" ).executeUpdate();
 					session.createQuery( "delete from Customer" ).executeUpdate();
@@ -111,11 +106,8 @@ public class LoadAndUpdateEntitiesWithCollectionsTest extends BaseNonConfigCoreF
 	}
 
 	@Test
-	public void testLoad() {
-		if ( skipTest ) {
-			return;
-		}
-		inTransaction(
+	public void testLoad(SessionFactoryScope scope) {
+		scope.inTransaction(
 				session -> {
 					CriteriaBuilder cb = session.getCriteriaBuilder();
 					CriteriaQuery<SamplingOrder> cq = cb.createQuery( SamplingOrder.class );
@@ -127,7 +119,7 @@ public class LoadAndUpdateEntitiesWithCollectionsTest extends BaseNonConfigCoreF
 				}
 		);
 
-		inTransaction(
+		scope.inTransaction(
 				session -> {
 					List<User> users = session.createQuery( "from User u", User.class ).list();
 					User user = users.get( 0 );
@@ -137,11 +129,8 @@ public class LoadAndUpdateEntitiesWithCollectionsTest extends BaseNonConfigCoreF
 	}
 
 	@Test
-	public void testAddUserRoles() {
-		if ( skipTest ) {
-			return;
-		}
-		inTransaction(
+	public void testAddUserRoles(SessionFactoryScope scope) {
+		scope.inTransaction(
 				session -> {
 					SamplingOrder samplingOrder = getSamplingOrder( session );
 					User user = samplingOrder.getCustomer().getUser();
@@ -152,7 +141,7 @@ public class LoadAndUpdateEntitiesWithCollectionsTest extends BaseNonConfigCoreF
 				}
 		);
 
-		inTransaction(
+		scope.inTransaction(
 				session -> {
 					List<User> users = session.createQuery( "from User u", User.class ).list();
 					User user = users.get( 0 );
@@ -161,7 +150,7 @@ public class LoadAndUpdateEntitiesWithCollectionsTest extends BaseNonConfigCoreF
 				}
 		);
 
-		inTransaction(
+		scope.inTransaction(
 				session -> {
 					SamplingOrder samplingOrder = getSamplingOrder( session );
 					User user = samplingOrder.getCustomer().getUser();
@@ -172,7 +161,7 @@ public class LoadAndUpdateEntitiesWithCollectionsTest extends BaseNonConfigCoreF
 				}
 		);
 
-		inTransaction(
+		scope.inTransaction(
 				session -> {
 					List<User> users = session.createQuery( "from User u", User.class ).list();
 					User user = users.get( 0 );
@@ -181,7 +170,7 @@ public class LoadAndUpdateEntitiesWithCollectionsTest extends BaseNonConfigCoreF
 				}
 		);
 
-		inTransaction(
+		scope.inTransaction(
 				session -> {
 					User user = session
 							.createQuery(
@@ -196,7 +185,7 @@ public class LoadAndUpdateEntitiesWithCollectionsTest extends BaseNonConfigCoreF
 				}
 		);
 
-		inTransaction(
+		scope.inTransaction(
 				session -> {
 					List<User> users = session
 							.createQuery(
@@ -214,11 +203,8 @@ public class LoadAndUpdateEntitiesWithCollectionsTest extends BaseNonConfigCoreF
 	}
 
 	@Test
-	public void testDeleteUserRoles() {
-		if ( skipTest ) {
-			return;
-		}
-		inTransaction(
+	public void testDeleteUserRoles(SessionFactoryScope scope) {
+		scope.inTransaction(
 				session -> {
 					SamplingOrder samplingOrder = getSamplingOrder( session );
 					User user = samplingOrder.getCustomer().getUser();
@@ -226,7 +212,7 @@ public class LoadAndUpdateEntitiesWithCollectionsTest extends BaseNonConfigCoreF
 				}
 		);
 
-		inTransaction(
+		scope.inTransaction(
 				session -> {
 					List<User> users = session.createQuery( "from User u", User.class ).list();
 					User user = users.get( 0 );
@@ -237,11 +223,8 @@ public class LoadAndUpdateEntitiesWithCollectionsTest extends BaseNonConfigCoreF
 	}
 
 	@Test
-	public void testModifyUserMail() {
-		if ( skipTest ) {
-			return;
-		}
-		inTransaction(
+	public void testModifyUserMail(SessionFactoryScope scope) {
+		scope.inTransaction(
 				session -> {
 					SamplingOrder samplingOrder = getSamplingOrder( session );
 					User user = samplingOrder.getCustomer().getUser();
@@ -249,7 +232,7 @@ public class LoadAndUpdateEntitiesWithCollectionsTest extends BaseNonConfigCoreF
 				}
 		);
 
-		inTransaction(
+		scope.inTransaction(
 				session -> {
 					List<User> users = session.createQuery( "from User u", User.class ).list();
 					User user = users.get( 0 );

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/lazy/proxy/inlinedirtychecking/ManyToOnePropertyAccessByFieldTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/lazy/proxy/inlinedirtychecking/ManyToOnePropertyAccessByFieldTest.java
@@ -34,20 +34,20 @@ import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 
 import org.hibernate.annotations.NaturalId;
-import org.hibernate.boot.MetadataSources;
-import org.hibernate.boot.SessionFactoryBuilder;
-import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
 import org.hibernate.cfg.AvailableSettings;
 import org.hibernate.stat.Statistics;
 
-import org.hibernate.testing.TestForIssue;
-import org.hibernate.testing.bytecode.enhancement.BytecodeEnhancerRunner;
 import org.hibernate.testing.bytecode.enhancement.CustomEnhancementContext;
-import org.hibernate.testing.junit4.BaseNonConfigCoreFunctionalTestCase;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.hibernate.testing.bytecode.enhancement.extension.BytecodeEnhanced;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.JiraKey;
+import org.hibernate.testing.orm.junit.ServiceRegistry;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.hibernate.testing.orm.junit.Setting;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
@@ -56,43 +56,37 @@ import static org.hamcrest.MatcherAssert.assertThat;
 /**
  * @author Andrea Boriero
  */
-@RunWith(BytecodeEnhancerRunner.class)
+@DomainModel(
+		annotatedClasses = {
+				ManyToOnePropertyAccessByFieldTest.User.class,
+				ManyToOnePropertyAccessByFieldTest.Office.class,
+				ManyToOnePropertyAccessByFieldTest.Client.class,
+				ManyToOnePropertyAccessByFieldTest.Request.class,
+				ManyToOnePropertyAccessByFieldTest.InternalRequest.class,
+				ManyToOnePropertyAccessByFieldTest.Phone.class
+		}
+)
+@ServiceRegistry(
+		settings = {
+				@Setting( name = AvailableSettings.FORMAT_SQL, value = "false" ),
+				@Setting( name = AvailableSettings.GENERATE_STATISTICS, value = "true" ),
+				@Setting( name = AvailableSettings.USE_SECOND_LEVEL_CACHE, value = "false" ),
+				@Setting( name = AvailableSettings.USE_QUERY_CACHE, value = "false" ),
+		}
+)
+@SessionFactory
+@BytecodeEnhanced
 @CustomEnhancementContext({ DirtyCheckEnhancementContext.class, NoDirtyCheckEnhancementContext.class })
-@TestForIssue(jiraKey = "HHH-13705")
-public class ManyToOnePropertyAccessByFieldTest extends BaseNonConfigCoreFunctionalTestCase {
-	@Override
-	protected void configureStandardServiceRegistryBuilder(StandardServiceRegistryBuilder ssrb) {
-		super.configureStandardServiceRegistryBuilder( ssrb );
-		ssrb.applySetting( AvailableSettings.FORMAT_SQL, "false" );
-		ssrb.applySetting( AvailableSettings.GENERATE_STATISTICS, "true" );
-	}
-
-	@Override
-	protected void configureSessionFactoryBuilder(SessionFactoryBuilder sfb) {
-		super.configureSessionFactoryBuilder( sfb );
-		sfb.applyStatisticsSupport( true );
-		sfb.applySecondLevelCacheSupport( false );
-		sfb.applyQueryCacheSupport( false );
-	}
-
-	@Override
-	protected void applyMetadataSources(MetadataSources sources) {
-		super.applyMetadataSources( sources );
-		sources.addAnnotatedClass( User.class );
-		sources.addAnnotatedClass( Office.class );
-		sources.addAnnotatedClass( Client.class );
-		sources.addAnnotatedClass( Request.class );
-		sources.addAnnotatedClass( InternalRequest.class );
-		sources.addAnnotatedClass( Phone.class );
-	}
+@JiraKey("HHH-13705")
+public class ManyToOnePropertyAccessByFieldTest {
 
 	private Long userId;
 	private Long targetUserId;
 	private Long officeId;
 
-	@Before
-	public void setUp() {
-		inTransaction(
+	@BeforeEach
+	public void setUp(SessionFactoryScope scope) {
+		scope.inTransaction(
 				session -> {
 					Log log = new Log();
 					log.setCreationDate( OffsetDateTime.now() );
@@ -127,9 +121,9 @@ public class ManyToOnePropertyAccessByFieldTest extends BaseNonConfigCoreFunctio
 		);
 	}
 
-	@After
-	public void tearDown() {
-		inTransaction(
+	@AfterEach
+	public void tearDown(SessionFactoryScope scope) {
+		scope.inTransaction(
 				session -> {
 					session.createQuery( "delete from Request" ).executeUpdate();
 					session.createQuery( "delete from User" ).executeUpdate();
@@ -141,12 +135,12 @@ public class ManyToOnePropertyAccessByFieldTest extends BaseNonConfigCoreFunctio
 	}
 
 	@Test
-	public void testPersist() {
-		final Statistics stats = sessionFactory().getStatistics();
+	public void testPersist(SessionFactoryScope scope) {
+		final Statistics stats = scope.getSessionFactory().getStatistics();
 		stats.clear();
 
 		InternalRequest internalRequest = new InternalRequest( 1L );
-		inTransaction(
+		scope.inTransaction(
 				session -> {
 					User user = session.find( User.class, userId );
 					internalRequest.setUser( user );
@@ -165,18 +159,18 @@ public class ManyToOnePropertyAccessByFieldTest extends BaseNonConfigCoreFunctio
 	}
 
 	@Test
-	public void testDelete() {
+	public void testDelete(SessionFactoryScope scope) {
 		Set<Phone> officePhones = new HashSet<>();
 		officePhones.add( new Phone( 1L, "landline", "028-234-9876" ) );
 		officePhones.add( new Phone( 2L, "mobile", "072-122-9876" ) );
 		Office office = buildOffice( "second office", "Fab", officePhones );
-		inTransaction(
+		scope.inTransaction(
 				session -> {
 					session.save( office );
 				}
 		);
 
-		inTransaction(
+		scope.inTransaction(
 				session -> {
 					Office result = session.find( Office.class, office.id );
 					session.delete( result );
@@ -184,7 +178,7 @@ public class ManyToOnePropertyAccessByFieldTest extends BaseNonConfigCoreFunctio
 		);
 
 
-		inTransaction(
+		scope.inTransaction(
 				session -> {
 					List<Office> offices = session.createQuery( "from Office" ).list();
 					assertThat( offices.size(), is( 1 ) );
@@ -197,9 +191,9 @@ public class ManyToOnePropertyAccessByFieldTest extends BaseNonConfigCoreFunctio
 	}
 
 	@Test
-	public void testUpdate() {
+	public void testUpdate(SessionFactoryScope scope) {
 		InternalRequest internalRequest = new InternalRequest( 1L );
-		inTransaction(
+		scope.inTransaction(
 				session -> {
 					User user = session.find( User.class, userId );
 					internalRequest.setUser( user );
@@ -212,7 +206,7 @@ public class ManyToOnePropertyAccessByFieldTest extends BaseNonConfigCoreFunctio
 				}
 		);
 
-		inTransaction(
+		scope.inTransaction(
 				session -> {
 					InternalRequest result = session.find( InternalRequest.class, internalRequest.getId() );
 					assertThat( result.getTargetUser().getId(), is( targetUserId ) );
@@ -221,7 +215,7 @@ public class ManyToOnePropertyAccessByFieldTest extends BaseNonConfigCoreFunctio
 				}
 		);
 
-		inTransaction(
+		scope.inTransaction(
 				session -> {
 					InternalRequest result = session.find( InternalRequest.class, internalRequest.getId() );
 					assertThat( result.getTargetUser().getId(), is( targetUserId ) );
@@ -233,7 +227,7 @@ public class ManyToOnePropertyAccessByFieldTest extends BaseNonConfigCoreFunctio
 				}
 		);
 
-		inTransaction(
+		scope.inTransaction(
 				session -> {
 					InternalRequest result = session.find( InternalRequest.class, internalRequest.getId() );
 					assertThat( result.getTargetUser().getId(), is( userId ) );
@@ -257,7 +251,7 @@ public class ManyToOnePropertyAccessByFieldTest extends BaseNonConfigCoreFunctio
 				}
 		);
 
-		inTransaction(
+		scope.inTransaction(
 				session -> {
 					InternalRequest result = session.find( InternalRequest.class, internalRequest.getId() );
 					assertThat( result.getTargetUser().getId(), is( userId ) );

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/merge/MergeDetachedCascadedCollectionInEmbeddableTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/merge/MergeDetachedCascadedCollectionInEmbeddableTest.java
@@ -17,29 +17,36 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.OneToMany;
 
-import org.hibernate.testing.TestForIssue;
-import org.hibernate.testing.bytecode.enhancement.BytecodeEnhancerRunner;
-import org.hibernate.testing.junit4.BaseCoreFunctionalTestCase;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.hibernate.testing.bytecode.enhancement.extension.BytecodeEnhanced;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.JiraKey;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
 
-import static org.hibernate.testing.transaction.TransactionUtil.doInHibernate;
+import static org.hibernate.orm.test.bytecode.enhancement.merge.MergeDetachedCascadedCollectionInEmbeddableTest.Grouping;
+import static org.hibernate.orm.test.bytecode.enhancement.merge.MergeDetachedCascadedCollectionInEmbeddableTest.Heading;
+import static org.hibernate.orm.test.bytecode.enhancement.merge.MergeDetachedCascadedCollectionInEmbeddableTest.Thing;
 import static org.junit.Assert.assertNotSame;
+
+import org.junit.jupiter.api.Test;
+
 
 /**
  * @author Gail Badner
  */
-@TestForIssue(jiraKey = "HHH-12592")
-@RunWith(BytecodeEnhancerRunner.class)
-public class MergeDetachedCascadedCollectionInEmbeddableTest extends BaseCoreFunctionalTestCase {
-	@Override
-	protected Class<?>[] getAnnotatedClasses() {
-		return new Class<?>[] { Heading.class, Grouping.class, Thing.class };
-	}
+@JiraKey("HHH-12592")
+@DomainModel(
+		annotatedClasses = {
+			Heading.class, Grouping.class, Thing.class
+		}
+)
+@SessionFactory
+@BytecodeEnhanced
+public class MergeDetachedCascadedCollectionInEmbeddableTest {
 
 	@Test
-	public void testMergeDetached() {
-		final Heading heading = doInHibernate( this::sessionFactory, session -> {
+	public void testMergeDetached(SessionFactoryScope scope) {
+		final Heading heading = scope.fromSession( session -> {
 			Heading entity = new Heading();
 			entity.name = "new";
 			entity.setGrouping( new Grouping() );
@@ -48,7 +55,7 @@ public class MergeDetachedCascadedCollectionInEmbeddableTest extends BaseCoreFun
 			return entity;
 		} );
 
-		doInHibernate( this::sessionFactory, session -> {
+		scope.inTransaction( session -> {
 			heading.name = "updated";
 			Heading headingMerged = (Heading) session.merge( heading );
 			assertNotSame( heading, headingMerged );

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/merge/MergeDetachedNonCascadedCollectionInEmbeddableTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/merge/MergeDetachedNonCascadedCollectionInEmbeddableTest.java
@@ -16,29 +16,33 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.OneToMany;
 
-import org.hibernate.testing.TestForIssue;
-import org.hibernate.testing.bytecode.enhancement.BytecodeEnhancerRunner;
-import org.hibernate.testing.junit4.BaseCoreFunctionalTestCase;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.hibernate.testing.bytecode.enhancement.extension.BytecodeEnhanced;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.JiraKey;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
 
-import static org.hibernate.testing.transaction.TransactionUtil.doInHibernate;
+import static org.hibernate.orm.test.bytecode.enhancement.merge.MergeDetachedNonCascadedCollectionInEmbeddableTest.*;
 import static org.junit.Assert.assertNotSame;
+
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Gail Badner
  */
-@TestForIssue(jiraKey = "HHH-12637")
-@RunWith(BytecodeEnhancerRunner.class)
-public class MergeDetachedNonCascadedCollectionInEmbeddableTest extends BaseCoreFunctionalTestCase {
-	@Override
-	protected Class<?>[] getAnnotatedClasses() {
-		return new Class<?>[] { Heading.class, Grouping.class, Thing.class };
-	}
+@JiraKey("HHH-12637")
+@DomainModel(
+		annotatedClasses = {
+				Heading.class, Grouping.class, Thing.class
+		}
+)
+@SessionFactory
+@BytecodeEnhanced
+public class MergeDetachedNonCascadedCollectionInEmbeddableTest {
 
 	@Test
-	public void testMergeDetached() {
-		final Heading heading = doInHibernate( this::sessionFactory, session -> {
+	public void testMergeDetached(SessionFactoryScope scope) {
+		final Heading heading = scope.fromTransaction( session -> {
 			Heading entity = new Heading();
 			entity.name = "new";
 			entity.setGrouping( new Grouping() );
@@ -49,7 +53,7 @@ public class MergeDetachedNonCascadedCollectionInEmbeddableTest extends BaseCore
 			return entity;
 		} );
 
-		doInHibernate( this::sessionFactory, session -> {
+		scope.inTransaction( session -> {
 			heading.name = "updated";
 			Heading headingMerged = (Heading) session.merge( heading );
 			assertNotSame( heading, headingMerged );

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/merge/MergeEnhancedDetachedOrphanRemovalTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/merge/MergeEnhancedDetachedOrphanRemovalTest.java
@@ -6,47 +6,51 @@
  */
 package org.hibernate.orm.test.bytecode.enhancement.merge;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
 
-import org.hibernate.testing.TestForIssue;
-import org.hibernate.testing.bytecode.enhancement.BytecodeEnhancerRunner;
-import org.hibernate.testing.junit4.BaseCoreFunctionalTestCase;
+import org.hibernate.testing.bytecode.enhancement.extension.BytecodeEnhanced;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.JiraKey;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
 
-import static org.hibernate.testing.transaction.TransactionUtil.doInHibernate;
-import static org.junit.Assert.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+
+import org.junit.jupiter.api.Test;
+
 
 /**
  * @author Chris Cranford
  */
-@TestForIssue(jiraKey = "HHH-12592")
-@RunWith(BytecodeEnhancerRunner.class)
-public class MergeEnhancedDetachedOrphanRemovalTest extends BaseCoreFunctionalTestCase {
-	@Override
-	protected Class<?>[] getAnnotatedClasses() {
-		return new Class<?>[] { Leaf.class, Root.class };
-	}
+@JiraKey("HHH-12592")
+@DomainModel(
+		annotatedClasses = {
+				Leaf.class, Root.class
+		}
+)
+@SessionFactory
+@BytecodeEnhanced
+public class MergeEnhancedDetachedOrphanRemovalTest {
 
 	@Test
-	public void testMergeDetachedOrphanRemoval() {
-		final Root entity = doInHibernate( this::sessionFactory, session -> {
+	public void testMergeDetachedOrphanRemoval(SessionFactoryScope scope) {
+		final Root entity = scope.fromTransaction( session -> {
 			Root root = new Root();
 			root.setName( "new" );
 			session.save( root );
 			return root;
 		} );
 
-		doInHibernate( this::sessionFactory, session -> {
+		scope.inTransaction( session -> {
 			entity.setName( "updated" );
-			Root entityMerged = (Root) session.merge( entity );
+			Root entityMerged = session.merge( entity );
 			assertNotSame( entity, entityMerged );
 			assertNotSame( entity.getLeaves(), entityMerged.getLeaves() );
 		} );
 	}
 
 	@Test
-	public void testMergeDetachedNonEmptyCollection() {
-		final Root entity = doInHibernate( this::sessionFactory, session -> {
+	public void testMergeDetachedNonEmptyCollection(SessionFactoryScope scope) {
+		final Root entity = scope.fromTransaction( session -> {
 			Root root = new Root();
 			root.setName( "new" );
 			Leaf leaf = new Leaf();
@@ -56,9 +60,9 @@ public class MergeEnhancedDetachedOrphanRemovalTest extends BaseCoreFunctionalTe
 			return root;
 		} );
 
-		doInHibernate( this::sessionFactory, session -> {
+		scope.inTransaction( session -> {
 			entity.setName( "updated" );
-			Root entityMerged = (Root) session.merge( entity );
+			Root entityMerged = session.merge( entity );
 			assertNotSame( entity, entityMerged );
 			assertNotSame( entity.getLeaves(), entityMerged.getLeaves() );
 		} );

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/merge/MergeUnsavedEntitiesTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/merge/MergeUnsavedEntitiesTest.java
@@ -3,12 +3,11 @@ package org.hibernate.orm.test.bytecode.enhancement.merge;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.hibernate.testing.TestForIssue;
-import org.hibernate.testing.bytecode.enhancement.BytecodeEnhancerRunner;
-import org.hibernate.testing.junit4.BaseCoreFunctionalTestCase;
-import org.junit.After;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.hibernate.testing.bytecode.enhancement.extension.BytecodeEnhanced;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.JiraKey;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
 
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -18,25 +17,27 @@ import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 
 import static jakarta.persistence.CascadeType.MERGE;
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
-@RunWith(BytecodeEnhancerRunner.class)
-@TestForIssue(jiraKey = "HHH-16322")
-public class MergeUnsavedEntitiesTest extends BaseCoreFunctionalTestCase {
+import org.junit.jupiter.api.Test;
+
+
+@DomainModel(
+		annotatedClasses = {
+				MergeUnsavedEntitiesTest.Parent.class,
+				MergeUnsavedEntitiesTest.Child.class
+		}
+)
+@SessionFactory
+@BytecodeEnhanced
+@JiraKey("HHH-16322")
+public class MergeUnsavedEntitiesTest {
 
 	public static final String CHILD_NAME = "first child";
 
-	@Override
-	protected Class<?>[] getAnnotatedClasses() {
-		return new Class[] {
-				Parent.class,
-				Child.class
-		};
-	}
-
 	@Test
-	public void testMerge() {
-		inTransaction(
+	public void testMerge(SessionFactoryScope scope) {
+		scope.inTransaction(
 				session -> {
 					Parent parent = new Parent( 1l, 2l );
 					parent = session.merge( parent );
@@ -47,7 +48,7 @@ public class MergeUnsavedEntitiesTest extends BaseCoreFunctionalTestCase {
 				}
 		);
 
-		inTransaction(
+		scope.inTransaction(
 				session -> {
 					Parent parent = session.find( Parent.class, 1l );
 					assertThat( parent.getChildren().size() ).isEqualTo( 1 );
@@ -56,14 +57,14 @@ public class MergeUnsavedEntitiesTest extends BaseCoreFunctionalTestCase {
 				}
 		);
 
-		inTransaction(
+		scope.inTransaction(
 				session -> {
 					Parent parent = session.find( Parent.class, 1l );
 					session.merge( parent );
 				}
 		);
 
-		inTransaction(
+		scope.inTransaction(
 				session -> {
 					Parent parent = session.find( Parent.class, 1l );
 					assertThat( parent.getChildren().size() ).isEqualTo( 1 );

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/mutable/MutableTypeEnhancementTestCase.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/mutable/MutableTypeEnhancementTestCase.java
@@ -7,27 +7,30 @@
 
 package org.hibernate.orm.test.bytecode.enhancement.mutable;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import java.util.Date;
 
-import org.hibernate.testing.TestForIssue;
-import org.hibernate.testing.bytecode.enhancement.BytecodeEnhancerRunner;
-import org.hibernate.testing.junit4.BaseCoreFunctionalTestCase;
-import org.junit.Assert;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.hibernate.testing.bytecode.enhancement.extension.BytecodeEnhanced;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.JiraKey;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.junit.jupiter.api.Test;
 
-@RunWith(BytecodeEnhancerRunner.class)
-public class MutableTypeEnhancementTestCase extends BaseCoreFunctionalTestCase {
-
-	@Override
-	protected Class<?>[] getAnnotatedClasses() {
-		return new Class[] { TestEntity.class };
-	}
+@DomainModel(
+		annotatedClasses = {
+				TestEntity.class
+		}
+)
+@SessionFactory
+@BytecodeEnhanced
+public class MutableTypeEnhancementTestCase {
 
 	@Test
-	@TestForIssue(jiraKey = "HHH-14329")
-	public void testMutateMutableTypeObject() throws Exception {
-		inTransaction( entityManager -> {
+	@JiraKey("HHH-14329")
+	public void testMutateMutableTypeObject(SessionFactoryScope scope) throws Exception {
+		scope.inTransaction( entityManager -> {
 			TestEntity e = new TestEntity();
 			e.setId( 1L );
 			e.setDate( new Date() );
@@ -35,16 +38,16 @@ public class MutableTypeEnhancementTestCase extends BaseCoreFunctionalTestCase {
 			entityManager.persist( e );
 		} );
 
-		inTransaction( entityManager -> {
+		scope.inTransaction( entityManager -> {
 			TestEntity e = entityManager.find( TestEntity.class, 1L );
 			e.getDate().setTime( 0 );
 			e.getTexts().put( "a", "def" );
 		} );
 
-		inTransaction( entityManager -> {
+		scope.inTransaction( entityManager -> {
 			TestEntity e = entityManager.find( TestEntity.class, 1L );
-			Assert.assertEquals( 0L, e.getDate().getTime() );
-			Assert.assertEquals( "def", e.getTexts().get( "a" ) );
+			assertEquals( 0L, e.getDate().getTime() );
+			assertEquals( "def", e.getTexts().get( "a" ) );
 		} );
 	}
 }

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/naturalid/QueryWithProxyAsParametersTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/naturalid/QueryWithProxyAsParametersTest.java
@@ -1,14 +1,14 @@
 package org.hibernate.orm.test.bytecode.enhancement.naturalid;
 
-import org.hibernate.Hibernate;
 import org.hibernate.annotations.NaturalId;
 
-import org.hibernate.testing.bytecode.enhancement.BytecodeEnhancerRunner;
-import org.hibernate.testing.junit4.BaseCoreFunctionalTestCase;
+import org.hibernate.testing.bytecode.enhancement.extension.BytecodeEnhanced;
+import org.hibernate.testing.orm.junit.DomainModel;
 import org.hibernate.testing.orm.junit.JiraKey;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -16,23 +16,22 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.OneToOne;
 
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
-@RunWith(BytecodeEnhancerRunner.class)
+@DomainModel(
+		annotatedClasses = {
+				QueryWithProxyAsParametersTest.Parent.class,
+				QueryWithProxyAsParametersTest.Child.class
+		}
+)
+@SessionFactory
+@BytecodeEnhanced
 @JiraKey( "HHH-17881" )
-public class QueryWithProxyAsParametersTest extends BaseCoreFunctionalTestCase {
+public class QueryWithProxyAsParametersTest {
 
-	@Override
-	protected Class<?>[] getAnnotatedClasses() {
-		return new Class[]{
-				Parent.class,
-				Child.class
-		};
-	}
-
-	@Before
-	public void setUp(){
-		inTransaction(
+	@BeforeEach
+	public void setUp(SessionFactoryScope scope){
+		scope.inTransaction(
 				session -> {
 					Child child = new Child(1l, "abc", "Andrea");
 					Parent parent = new Parent(2l, "Lionello", child);
@@ -43,8 +42,8 @@ public class QueryWithProxyAsParametersTest extends BaseCoreFunctionalTestCase {
 	}
 
 	@Test
-	public void testQuery(){
-		inTransaction(
+	public void testQuery(SessionFactoryScope scope){
+		scope.inTransaction(
 				session -> {
 					Child child = session.getReference( Child.class, 1l );
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/ondemandload/OnDemandLoadWithCollectionInDefaultFetchGroupFalseTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/ondemandload/OnDemandLoadWithCollectionInDefaultFetchGroupFalseTest.java
@@ -8,11 +8,11 @@
 package org.hibernate.orm.test.bytecode.enhancement.ondemandload;
 
 import static org.hibernate.Hibernate.isPropertyInitialized;
-import static org.hibernate.testing.transaction.TransactionUtil.doInHibernate;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.hibernate.orm.test.bytecode.enhancement.ondemandload.OnDemandLoadWithCollectionInDefaultFetchGroupFalseTest.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.math.BigDecimal;
 import java.util.ArrayList;
@@ -20,20 +20,18 @@ import java.util.Collections;
 import java.util.List;
 
 import org.hibernate.annotations.GenericGenerator;
-import org.hibernate.boot.internal.SessionFactoryBuilderImpl;
-import org.hibernate.boot.internal.SessionFactoryOptionsBuilder;
-import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
-import org.hibernate.boot.spi.SessionFactoryBuilderService;
 import org.hibernate.cfg.AvailableSettings;
-import org.hibernate.cfg.Configuration;
 
-import org.hibernate.testing.TestForIssue;
-import org.hibernate.testing.bytecode.enhancement.BytecodeEnhancerRunner;
-import org.hibernate.testing.junit4.BaseCoreFunctionalTestCase;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.hibernate.testing.bytecode.enhancement.extension.BytecodeEnhanced;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.JiraKey;
+import org.hibernate.testing.orm.junit.ServiceRegistry;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.hibernate.testing.orm.junit.Setting;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Entity;
@@ -54,42 +52,30 @@ import jakarta.persistence.Version;
  *
  * @author Luis Barreiro
  */
-@TestForIssue( jiraKey = "HHH-10055" )
-@RunWith( BytecodeEnhancerRunner.class )
-public class OnDemandLoadWithCollectionInDefaultFetchGroupFalseTest extends BaseCoreFunctionalTestCase {
+@JiraKey( "HHH-10055" )
+@DomainModel(
+        annotatedClasses = {
+               Store.class, Inventory.class, Product.class
+        }
+)
+@ServiceRegistry(
+        settings = {
+                @Setting( name = AvailableSettings.USE_SECOND_LEVEL_CACHE, value = "false" ),
+                @Setting( name = AvailableSettings.ENABLE_LAZY_LOAD_NO_TRANS, value = "true" ),
+                @Setting( name = AvailableSettings.GENERATE_STATISTICS, value = "true" ),
+        }
+)
+@SessionFactory(
+        // We want to test with this setting set to false explicitly,
+        // because another test already takes care of the default.
+        applyCollectionsInDefaultFetchGroup = false
+)
+@BytecodeEnhanced
+public class OnDemandLoadWithCollectionInDefaultFetchGroupFalseTest {
 
-    @Override
-    public Class[] getAnnotatedClasses() {
-        return new Class[]{Store.class, Inventory.class, Product.class};
-    }
-
-    @Override
-    protected void configure(Configuration configuration) {
-        configuration.setProperty( AvailableSettings.USE_SECOND_LEVEL_CACHE, false );
-        configuration.setProperty( AvailableSettings.ENABLE_LAZY_LOAD_NO_TRANS, true );
-        configuration.setProperty( AvailableSettings.GENERATE_STATISTICS, true );
-    }
-
-    @Override
-    protected void prepareBasicRegistryBuilder(StandardServiceRegistryBuilder serviceRegistryBuilder) {
-        serviceRegistryBuilder.addService(
-                SessionFactoryBuilderService.class,
-                (SessionFactoryBuilderService) (metadata, bootstrapContext) -> {
-                    SessionFactoryOptionsBuilder optionsBuilder = new SessionFactoryOptionsBuilder(
-                            metadata.getMetadataBuildingOptions().getServiceRegistry(),
-                            bootstrapContext
-                    );
-                    // We want to test with this setting set to false explicitly,
-                    // because another test already takes care of the default.
-                    optionsBuilder.enableCollectionInDefaultFetchGroup( false );
-                    return new SessionFactoryBuilderImpl( metadata, optionsBuilder, bootstrapContext );
-                }
-        );
-    }
-
-    @Before
-    public void prepare() {
-        doInHibernate( this::sessionFactory, s -> {
+    @BeforeEach
+    public void prepare(SessionFactoryScope scope) {
+        scope.inTransaction( s -> {
             Store store = new Store( 1L ).setName( "Acme Super Outlet" );
             s.persist( store );
 
@@ -101,41 +87,41 @@ public class OnDemandLoadWithCollectionInDefaultFetchGroupFalseTest extends Base
     }
 
     @Test
-    public void testClosedSession() {
-        sessionFactory().getStatistics().clear();
+    public void testClosedSession(SessionFactoryScope scope) {
+        scope.getSessionFactory().getStatistics().clear();
         Store[] store = new Store[1];
 
-        doInHibernate( this::sessionFactory, s -> {
+        scope.inTransaction( s -> {
             // first load the store, making sure it is not initialized
             store[0] = s.load( Store.class, 1L );
             assertNotNull( store[0] );
             assertFalse( isPropertyInitialized( store[0], "inventories" ) );
 
-            assertEquals( 1, sessionFactory().getStatistics().getSessionOpenCount() );
-            assertEquals( 0, sessionFactory().getStatistics().getSessionCloseCount() );
+            assertEquals( 1, scope.getSessionFactory().getStatistics().getSessionOpenCount() );
+            assertEquals( 0, scope.getSessionFactory().getStatistics().getSessionCloseCount() );
         } );
 
-        assertEquals( 1, sessionFactory().getStatistics().getSessionOpenCount() );
-        assertEquals( 1, sessionFactory().getStatistics().getSessionCloseCount() );
+        assertEquals( 1, scope.getSessionFactory().getStatistics().getSessionOpenCount() );
+        assertEquals( 1, scope.getSessionFactory().getStatistics().getSessionCloseCount() );
 
         store[0].getInventories();
         assertTrue( isPropertyInitialized( store[0], "inventories" ) );
 
-        assertEquals( 2, sessionFactory().getStatistics().getSessionOpenCount() );
-        assertEquals( 2, sessionFactory().getStatistics().getSessionCloseCount() );
+        assertEquals( 2, scope.getSessionFactory().getStatistics().getSessionOpenCount() );
+        assertEquals( 2, scope.getSessionFactory().getStatistics().getSessionCloseCount() );
     }
 
     @Test
-    public void testClearedSession() {
-        sessionFactory().getStatistics().clear();
+    public void testClearedSession(SessionFactoryScope scope) {
+        scope.getSessionFactory().getStatistics().clear();
 
-        doInHibernate( this::sessionFactory, s -> {
+        scope.inTransaction( s -> {
             // first load the store, making sure collection is not initialized
             Store store = s.get( Store.class, 1L );
             assertNotNull( store );
             assertFalse( isPropertyInitialized( store, "inventories" ) );
-            assertEquals( 1, sessionFactory().getStatistics().getSessionOpenCount() );
-            assertEquals( 0, sessionFactory().getStatistics().getSessionCloseCount() );
+            assertEquals( 1, scope.getSessionFactory().getStatistics().getSessionOpenCount() );
+            assertEquals( 0, scope.getSessionFactory().getStatistics().getSessionCloseCount() );
 
             // then clear session and try to initialize collection
             s.clear();
@@ -146,15 +132,15 @@ public class OnDemandLoadWithCollectionInDefaultFetchGroupFalseTest extends Base
 
             // the extra Sessions are the temp Sessions needed to perform the init:
             // first the entity, then the collection (since it's lazy)
-            assertEquals( 3, sessionFactory().getStatistics().getSessionOpenCount() );
-            assertEquals( 2, sessionFactory().getStatistics().getSessionCloseCount() );
+            assertEquals( 3, scope.getSessionFactory().getStatistics().getSessionOpenCount() );
+            assertEquals( 2, scope.getSessionFactory().getStatistics().getSessionCloseCount() );
 
             // clear Session again.  The collection should still be recognized as initialized from above
             s.clear();
             assertNotNull( store );
             assertTrue( isPropertyInitialized( store, "inventories" ) );
-            assertEquals( 3, sessionFactory().getStatistics().getSessionOpenCount() );
-            assertEquals( 2, sessionFactory().getStatistics().getSessionCloseCount() );
+            assertEquals( 3, scope.getSessionFactory().getStatistics().getSessionOpenCount() );
+            assertEquals( 2, scope.getSessionFactory().getStatistics().getSessionCloseCount() );
 
             // lets clear the Session again and this time reload the Store
             s.clear();
@@ -164,28 +150,28 @@ public class OnDemandLoadWithCollectionInDefaultFetchGroupFalseTest extends Base
 
             // collection should be back to uninitialized since we have a new entity instance
             assertFalse( isPropertyInitialized( store, "inventories" ) );
-            assertEquals( 3, sessionFactory().getStatistics().getSessionOpenCount() );
-            assertEquals( 2, sessionFactory().getStatistics().getSessionCloseCount() );
+            assertEquals( 3, scope.getSessionFactory().getStatistics().getSessionOpenCount() );
+            assertEquals( 2, scope.getSessionFactory().getStatistics().getSessionCloseCount() );
             store.getInventories().size();
             assertTrue( isPropertyInitialized( store, "inventories" ) );
 
             // the extra Sessions are the temp Sessions needed to perform the init:
             // first the entity, then the collection (since it's lazy)
-            assertEquals( 5, sessionFactory().getStatistics().getSessionOpenCount() );
-            assertEquals( 4, sessionFactory().getStatistics().getSessionCloseCount() );
+            assertEquals( 5, scope.getSessionFactory().getStatistics().getSessionOpenCount() );
+            assertEquals( 4, scope.getSessionFactory().getStatistics().getSessionCloseCount() );
 
             // clear Session again.  The collection should still be recognized as initialized from above
             s.clear();
             assertNotNull( store );
             assertTrue( isPropertyInitialized( store, "inventories" ) );
-            assertEquals( 5, sessionFactory().getStatistics().getSessionOpenCount() );
-            assertEquals( 4, sessionFactory().getStatistics().getSessionCloseCount() );
+            assertEquals( 5, scope.getSessionFactory().getStatistics().getSessionOpenCount() );
+            assertEquals( 4, scope.getSessionFactory().getStatistics().getSessionCloseCount() );
         } );
     }
 
-    @After
-    public void cleanup() throws Exception {
-        doInHibernate( this::sessionFactory, s -> {
+    @AfterEach
+    public void cleanup(SessionFactoryScope scope) throws Exception {
+        scope.inTransaction( s -> {
             Store store = s.find( Store.class, 1L );
             s.delete( store );
 
@@ -198,7 +184,7 @@ public class OnDemandLoadWithCollectionInDefaultFetchGroupFalseTest extends Base
 
     @Entity
     @Table( name = "STORE" )
-    private static class Store {
+    static class Store {
         @Id
         Long id;
 
@@ -235,7 +221,7 @@ public class OnDemandLoadWithCollectionInDefaultFetchGroupFalseTest extends Base
 
     @Entity
     @Table( name = "INVENTORY" )
-    private static class Inventory {
+    static class Inventory {
 
         @Id
         @GeneratedValue
@@ -285,7 +271,7 @@ public class OnDemandLoadWithCollectionInDefaultFetchGroupFalseTest extends Base
 
     @Entity
     @Table( name = "PRODUCT" )
-    private static class Product {
+    static class Product {
         @Id
         String id;
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/orphan/EagerOneToManyPersistAndLoad2Test.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/orphan/EagerOneToManyPersistAndLoad2Test.java
@@ -6,14 +6,15 @@ import java.util.List;
 import org.hibernate.Hibernate;
 import org.hibernate.bytecode.enhance.spi.DefaultEnhancementContext;
 
-import org.hibernate.testing.TestForIssue;
-import org.hibernate.testing.bytecode.enhancement.BytecodeEnhancerRunner;
 import org.hibernate.testing.bytecode.enhancement.CustomEnhancementContext;
 import org.hibernate.testing.bytecode.enhancement.EnhancerTestContext;
-import org.hibernate.testing.junit4.BaseCoreFunctionalTestCase;
-import org.junit.After;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.hibernate.testing.bytecode.enhancement.extension.BytecodeEnhanced;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.JiraKey;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Entity;
@@ -23,31 +24,30 @@ import jakarta.persistence.Id;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@TestForIssue(jiraKey = "HHH-16334")
-@RunWith(BytecodeEnhancerRunner.class)
+@JiraKey("HHH-16334")
+@DomainModel(
+		annotatedClasses = {
+				EagerOneToManyPersistAndLoad2Test.Parent.class,
+				EagerOneToManyPersistAndLoad2Test.Child.class
+		}
+)
+@SessionFactory
+@BytecodeEnhanced
 @CustomEnhancementContext({
 		EnhancerTestContext.class, // supports laziness and dirty-checking
 		NoDirtyCheckEnhancementContext.class, // supports laziness; does not support dirty-checking,
 		DefaultEnhancementContext.class
 })
-public class EagerOneToManyPersistAndLoad2Test extends BaseCoreFunctionalTestCase {
+public class EagerOneToManyPersistAndLoad2Test {
 
 	public static final String CHILD_NAME = "Luigi";
 
-	@Override
-	protected Class<?>[] getAnnotatedClasses() {
-		return new Class[]{
-				Parent.class,
-				Child.class
-		};
-	}
-
-	@After
-	public void tearDown() {
-		inTransaction(
+	@AfterEach
+	public void tearDown(SessionFactoryScope scope) {
+		scope.inTransaction(
 				session -> {
 					session.createMutationQuery( "delete from Child" ).executeUpdate();
 					session.createMutationQuery( "delete from Parent" ).executeUpdate();
@@ -56,15 +56,15 @@ public class EagerOneToManyPersistAndLoad2Test extends BaseCoreFunctionalTestCas
 	}
 
 	@Test
-	public void testEmptyCollectionPersistQueryJoinFetch() {
-		inTransaction(
+	public void testEmptyCollectionPersistQueryJoinFetch(SessionFactoryScope scope) {
+		scope.inTransaction(
 				session -> {
 					Parent p = new Parent( 1l );
 					session.persist( p );
 				}
 		);
 
-		inTransaction(
+		scope.inTransaction(
 				session -> {
 					Parent p = session.getReference( Parent.class, 1l );
 
@@ -87,15 +87,15 @@ public class EagerOneToManyPersistAndLoad2Test extends BaseCoreFunctionalTestCas
 	}
 
 	@Test
-	public void testEmptyCollectionPersistQuery() {
-		inTransaction(
+	public void testEmptyCollectionPersistQuery(SessionFactoryScope scope) {
+		scope.inTransaction(
 				session -> {
 					Parent p = new Parent( 1l );
 					session.persist( p );
 				}
 		);
 
-		inTransaction(
+		scope.inTransaction(
 				session -> {
 					Parent p = session.getReference( Parent.class, 1l );
 
@@ -117,8 +117,8 @@ public class EagerOneToManyPersistAndLoad2Test extends BaseCoreFunctionalTestCas
 	}
 
 	@Test
-	public void testCollectionPersistQueryJoinFetch() {
-		inTransaction(
+	public void testCollectionPersistQueryJoinFetch(SessionFactoryScope scope) {
+		scope.inTransaction(
 				session -> {
 					Parent p = new Parent( 1l );
 					Child c = new Child( CHILD_NAME );
@@ -128,7 +128,7 @@ public class EagerOneToManyPersistAndLoad2Test extends BaseCoreFunctionalTestCas
 				}
 		);
 
-		inTransaction(
+		scope.inTransaction(
 				session -> {
 					Parent p = session.getReference( Parent.class, 1l );
 
@@ -150,8 +150,8 @@ public class EagerOneToManyPersistAndLoad2Test extends BaseCoreFunctionalTestCas
 	}
 
 	@Test
-	public void testCollectionPersistQuery() {
-		inTransaction(
+	public void testCollectionPersistQuery(SessionFactoryScope scope) {
+		scope.inTransaction(
 				session -> {
 					Parent p = new Parent( 1l );
 					Child c = new Child( CHILD_NAME );
@@ -161,7 +161,7 @@ public class EagerOneToManyPersistAndLoad2Test extends BaseCoreFunctionalTestCas
 				}
 		);
 
-		inTransaction(
+		scope.inTransaction(
 				session -> {
 					Parent p = session.getReference( Parent.class, 1l );
 					List<Parent> parents = session.createQuery(

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/orphan/EagerSubSelectOneToManyPersistAndLoad2Test.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/orphan/EagerSubSelectOneToManyPersistAndLoad2Test.java
@@ -8,14 +8,15 @@ import org.hibernate.annotations.Fetch;
 import org.hibernate.annotations.FetchMode;
 import org.hibernate.bytecode.enhance.spi.DefaultEnhancementContext;
 
-import org.hibernate.testing.TestForIssue;
-import org.hibernate.testing.bytecode.enhancement.BytecodeEnhancerRunner;
 import org.hibernate.testing.bytecode.enhancement.CustomEnhancementContext;
 import org.hibernate.testing.bytecode.enhancement.EnhancerTestContext;
-import org.hibernate.testing.junit4.BaseCoreFunctionalTestCase;
-import org.junit.After;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.hibernate.testing.bytecode.enhancement.extension.BytecodeEnhanced;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.JiraKey;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Entity;
@@ -25,31 +26,30 @@ import jakarta.persistence.Id;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@TestForIssue(jiraKey = "HHH-16334")
-@RunWith(BytecodeEnhancerRunner.class)
+@JiraKey("HHH-16334")
+@DomainModel(
+		annotatedClasses = {
+				EagerSubSelectOneToManyPersistAndLoad2Test.Parent.class,
+				EagerSubSelectOneToManyPersistAndLoad2Test.Child.class
+		}
+)
+@SessionFactory
+@BytecodeEnhanced
 @CustomEnhancementContext({
 		EnhancerTestContext.class, // supports laziness and dirty-checking
 		NoDirtyCheckEnhancementContext.class, // supports laziness; does not support dirty-checking,
 		DefaultEnhancementContext.class
 })
-public class EagerSubSelectOneToManyPersistAndLoad2Test extends BaseCoreFunctionalTestCase {
+public class EagerSubSelectOneToManyPersistAndLoad2Test {
 
 	public static final String CHILD_NAME = "Luigi";
 
-	@Override
-	protected Class<?>[] getAnnotatedClasses() {
-		return new Class[]{
-				Parent.class,
-				Child.class
-		};
-	}
-
-	@After
-	public void tearDown() {
-		inTransaction(
+	@AfterEach
+	public void tearDown(SessionFactoryScope scope) {
+		scope.inTransaction(
 				session -> {
 					session.createMutationQuery( "delete from Child" ).executeUpdate();
 					session.createMutationQuery( "delete from Parent" ).executeUpdate();
@@ -58,15 +58,15 @@ public class EagerSubSelectOneToManyPersistAndLoad2Test extends BaseCoreFunction
 	}
 
 	@Test
-	public void testEmptyCollectionPersistQueryJoinFetch() {
-		inTransaction(
+	public void testEmptyCollectionPersistQueryJoinFetch(SessionFactoryScope scope) {
+		scope.inTransaction(
 				session -> {
 					Parent p = new Parent( 1l );
 					session.persist( p );
 				}
 		);
 
-		inTransaction(
+		scope.inTransaction(
 				session -> {
 					Parent p = session.getReference( Parent.class, 1l );
 
@@ -89,15 +89,15 @@ public class EagerSubSelectOneToManyPersistAndLoad2Test extends BaseCoreFunction
 	}
 
 	@Test
-	public void testEmptyCollectionPersistQuery() {
-		inTransaction(
+	public void testEmptyCollectionPersistQuery(SessionFactoryScope scope) {
+		scope.inTransaction(
 				session -> {
 					Parent p = new Parent( 1l );
 					session.persist( p );
 				}
 		);
 
-		inTransaction(
+		scope.inTransaction(
 				session -> {
 					Parent p = session.getReference( Parent.class, 1l );
 
@@ -119,8 +119,8 @@ public class EagerSubSelectOneToManyPersistAndLoad2Test extends BaseCoreFunction
 	}
 
 	@Test
-	public void testCollectionPersistQueryJoinFetch() {
-		inTransaction(
+	public void testCollectionPersistQueryJoinFetch(SessionFactoryScope scope) {
+		scope.inTransaction(
 				session -> {
 					Parent p = new Parent( 1l );
 					Child c = new Child( CHILD_NAME );
@@ -130,7 +130,7 @@ public class EagerSubSelectOneToManyPersistAndLoad2Test extends BaseCoreFunction
 				}
 		);
 
-		inTransaction(
+		scope.inTransaction(
 				session -> {
 					Parent p = session.getReference( Parent.class, 1l );
 
@@ -152,8 +152,8 @@ public class EagerSubSelectOneToManyPersistAndLoad2Test extends BaseCoreFunction
 	}
 
 	@Test
-	public void testCollectionPersistQuery() {
-		inTransaction(
+	public void testCollectionPersistQuery(SessionFactoryScope scope) {
+		scope.inTransaction(
 				session -> {
 					Parent p = new Parent( 1l );
 					Child c = new Child( CHILD_NAME );
@@ -163,7 +163,7 @@ public class EagerSubSelectOneToManyPersistAndLoad2Test extends BaseCoreFunction
 				}
 		);
 
-		inTransaction(
+		scope.inTransaction(
 				session -> {
 					Parent p = session.getReference( Parent.class, 1l );
 					List<Parent> parents = session.createQuery(

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/orphan/EagerSubSelectOneToManyPersistAndLoadTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/orphan/EagerSubSelectOneToManyPersistAndLoadTest.java
@@ -8,14 +8,15 @@ import org.hibernate.annotations.Fetch;
 import org.hibernate.annotations.FetchMode;
 import org.hibernate.bytecode.enhance.spi.DefaultEnhancementContext;
 
-import org.hibernate.testing.TestForIssue;
-import org.hibernate.testing.bytecode.enhancement.BytecodeEnhancerRunner;
 import org.hibernate.testing.bytecode.enhancement.CustomEnhancementContext;
 import org.hibernate.testing.bytecode.enhancement.EnhancerTestContext;
-import org.hibernate.testing.junit4.BaseCoreFunctionalTestCase;
-import org.junit.After;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.hibernate.testing.bytecode.enhancement.extension.BytecodeEnhanced;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.JiraKey;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Entity;
@@ -25,31 +26,30 @@ import jakarta.persistence.Id;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@TestForIssue(jiraKey = "HHH-16334")
-@RunWith(BytecodeEnhancerRunner.class)
+@JiraKey("HHH-16334")
+@DomainModel(
+		annotatedClasses = {
+			EagerSubSelectOneToManyPersistAndLoadTest.Parent.class,
+				EagerSubSelectOneToManyPersistAndLoadTest.Child.class
+		}
+)
+@SessionFactory
+@BytecodeEnhanced
 @CustomEnhancementContext({
 		EnhancerTestContext.class, // supports laziness and dirty-checking
 		NoDirtyCheckEnhancementContext.class, // supports laziness; does not support dirty-checking,
 		DefaultEnhancementContext.class
 })
-public class EagerSubSelectOneToManyPersistAndLoadTest extends BaseCoreFunctionalTestCase {
+public class EagerSubSelectOneToManyPersistAndLoadTest {
 
 	public static final String CHILD_NAME = "Luigi";
 
-	@Override
-	protected Class<?>[] getAnnotatedClasses() {
-		return new Class[] {
-				Parent.class,
-				Child.class
-		};
-	}
-
-	@After
-	public void tearDown() {
-		inTransaction(
+	@AfterEach
+	public void tearDown(SessionFactoryScope scope) {
+		scope.inTransaction(
 				session -> {
 					session.createMutationQuery( "delete from Child" ).executeUpdate();
 					session.createMutationQuery( "delete from Parent" ).executeUpdate();
@@ -58,8 +58,8 @@ public class EagerSubSelectOneToManyPersistAndLoadTest extends BaseCoreFunctiona
 	}
 
 	@Test
-	public void testEmptyCollectionPersistLoad() {
-		inTransaction(
+	public void testEmptyCollectionPersistLoad(SessionFactoryScope scope) {
+		scope.inTransaction(
 				session -> {
 					Parent p = new Parent( 1l );
 					session.persist( p );
@@ -78,15 +78,15 @@ public class EagerSubSelectOneToManyPersistAndLoadTest extends BaseCoreFunctiona
 	}
 
 	@Test
-	public void testEmptyCollectionPersistQueryJoinFetch() {
-		inTransaction(
+	public void testEmptyCollectionPersistQueryJoinFetch(SessionFactoryScope scope) {
+		scope.inTransaction(
 				session -> {
 					Parent p = new Parent( 1l );
 					session.persist( p );
 				}
 		);
 
-		inTransaction(
+		scope.inTransaction(
 				session -> {
 					Parent p = session.get( Parent.class, 1l );
 					List<Child> children = p.getChildren();
@@ -110,15 +110,15 @@ public class EagerSubSelectOneToManyPersistAndLoadTest extends BaseCoreFunctiona
 	}
 
 	@Test
-	public void testEmptyCollectionPersistQuery() {
-		inTransaction(
+	public void testEmptyCollectionPersistQuery(SessionFactoryScope scope) {
+		scope.inTransaction(
 				session -> {
 					Parent p = new Parent( 1l );
 					session.persist( p );
 				}
 		);
 
-		inTransaction(
+		scope.inTransaction(
 				session -> {
 					Parent p = session.get( Parent.class, 1l );
 					List<Child> children = p.getChildren();
@@ -142,8 +142,8 @@ public class EagerSubSelectOneToManyPersistAndLoadTest extends BaseCoreFunctiona
 	}
 
 	@Test
-	public void testCollectionPersistLoad() {
-		inTransaction(
+	public void testCollectionPersistLoad(SessionFactoryScope scope) {
+		scope.inTransaction(
 				session -> {
 					Parent p = new Parent( 1l );
 					Child c = new Child( CHILD_NAME );
@@ -163,8 +163,8 @@ public class EagerSubSelectOneToManyPersistAndLoadTest extends BaseCoreFunctiona
 	}
 
 	@Test
-	public void testCollectionPersistQueryJoinFetch() {
-		inTransaction(
+	public void testCollectionPersistQueryJoinFetch(SessionFactoryScope scope) {
+		scope.inTransaction(
 				session -> {
 					Parent p = new Parent( 1l );
 					Child c = new Child( CHILD_NAME );
@@ -174,7 +174,7 @@ public class EagerSubSelectOneToManyPersistAndLoadTest extends BaseCoreFunctiona
 				}
 		);
 
-		inTransaction(
+		scope.inTransaction(
 				session -> {
 					Parent p = session.get( Parent.class, 1l );
 					List<Child> children = p.getChildren();
@@ -197,8 +197,8 @@ public class EagerSubSelectOneToManyPersistAndLoadTest extends BaseCoreFunctiona
 	}
 
 	@Test
-	public void testCollectionPersistQuery() {
-		inTransaction(
+	public void testCollectionPersistQuery(SessionFactoryScope scope) {
+		scope.inTransaction(
 				session -> {
 					Parent p = new Parent( 1l );
 					Child c = new Child( CHILD_NAME );
@@ -208,7 +208,7 @@ public class EagerSubSelectOneToManyPersistAndLoadTest extends BaseCoreFunctiona
 				}
 		);
 
-		inTransaction(
+		scope.inTransaction(
 				session -> {
 					Parent p = session.get( Parent.class, 1l );
 					List<Child> children = p.getChildren();

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/orphan/LazyOneToManyPersistAndLoad2Test.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/orphan/LazyOneToManyPersistAndLoad2Test.java
@@ -6,14 +6,15 @@ import java.util.List;
 import org.hibernate.Hibernate;
 import org.hibernate.bytecode.enhance.spi.DefaultEnhancementContext;
 
-import org.hibernate.testing.TestForIssue;
-import org.hibernate.testing.bytecode.enhancement.BytecodeEnhancerRunner;
 import org.hibernate.testing.bytecode.enhancement.CustomEnhancementContext;
 import org.hibernate.testing.bytecode.enhancement.EnhancerTestContext;
-import org.hibernate.testing.junit4.BaseCoreFunctionalTestCase;
-import org.junit.After;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.hibernate.testing.bytecode.enhancement.extension.BytecodeEnhanced;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.JiraKey;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Entity;
@@ -22,32 +23,31 @@ import jakarta.persistence.Id;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@TestForIssue(jiraKey = "HHH-16334")
-@RunWith(BytecodeEnhancerRunner.class)
+@JiraKey("HHH-16334")
+@DomainModel(
+		annotatedClasses = {
+				LazyOneToManyPersistAndLoad2Test.Parent.class,
+				LazyOneToManyPersistAndLoad2Test.Child.class
+		}
+)
+@SessionFactory
+@BytecodeEnhanced
 @CustomEnhancementContext({
 		EnhancerTestContext.class, // supports laziness and dirty-checking
 		NoDirtyCheckEnhancementContext.class, // supports laziness; does not support dirty-checking,
 		DefaultEnhancementContext.class
 })
-public class LazyOneToManyPersistAndLoad2Test extends BaseCoreFunctionalTestCase {
+public class LazyOneToManyPersistAndLoad2Test {
 
 	public static final String CHILD_NAME = "Luigi";
 
-	@Override
-	protected Class<?>[] getAnnotatedClasses() {
-		return new Class[] {
-				Parent.class,
-				Child.class
-		};
-	}
-
-	@After
-	public void tearDown() {
-		inTransaction(
+	@AfterEach
+	public void tearDown(SessionFactoryScope scope) {
+		scope.inTransaction(
 				session -> {
 					session.createMutationQuery( "delete from Child" ).executeUpdate();
 					session.createMutationQuery( "delete from Parent" ).executeUpdate();
@@ -56,15 +56,15 @@ public class LazyOneToManyPersistAndLoad2Test extends BaseCoreFunctionalTestCase
 	}
 
 	@Test
-	public void testEmptyCollectionPersistQueryJoinFetch() {
-		inTransaction(
+	public void testEmptyCollectionPersistQueryJoinFetch(SessionFactoryScope scope) {
+		scope.inTransaction(
 				session -> {
 					Parent p = new Parent( 1l );
 					session.persist( p );
 				}
 		);
 
-		inTransaction(
+		scope.inTransaction(
 				session -> {
 					Parent p = session.getReference( Parent.class, 1l );
 
@@ -86,15 +86,15 @@ public class LazyOneToManyPersistAndLoad2Test extends BaseCoreFunctionalTestCase
 	}
 
 	@Test
-	public void testEmptyCollectionPersistQuery() {
-		inTransaction(
+	public void testEmptyCollectionPersistQuery(SessionFactoryScope scope) {
+		scope.inTransaction(
 				session -> {
 					Parent p = new Parent( 1l );
 					session.persist( p );
 				}
 		);
 
-		inTransaction(
+		scope.inTransaction(
 				session -> {
 					Parent p = session.getReference( Parent.class, 1l );
 
@@ -116,8 +116,8 @@ public class LazyOneToManyPersistAndLoad2Test extends BaseCoreFunctionalTestCase
 	}
 
 	@Test
-	public void testCollectionPersistQueryJoinFetch() {
-		inTransaction(
+	public void testCollectionPersistQueryJoinFetch(SessionFactoryScope scope) {
+		scope.inTransaction(
 				session -> {
 					Parent p = new Parent( 1l );
 					Child c = new Child( CHILD_NAME );
@@ -127,7 +127,7 @@ public class LazyOneToManyPersistAndLoad2Test extends BaseCoreFunctionalTestCase
 				}
 		);
 
-		inTransaction(
+		scope.inTransaction(
 				session -> {
 					Parent p = session.getReference( Parent.class, 1l );
 
@@ -149,8 +149,8 @@ public class LazyOneToManyPersistAndLoad2Test extends BaseCoreFunctionalTestCase
 	}
 
 	@Test
-	public void testCollectionPersistQuery() {
-		inTransaction(
+	public void testCollectionPersistQuery(SessionFactoryScope scope) {
+		scope.inTransaction(
 				session -> {
 					Parent p = new Parent( 1l );
 					Child c = new Child( CHILD_NAME );
@@ -160,7 +160,7 @@ public class LazyOneToManyPersistAndLoad2Test extends BaseCoreFunctionalTestCase
 				}
 		);
 
-		inTransaction(
+		scope.inTransaction(
 				session -> {
 					Parent p = session.getReference( Parent.class, 1l );
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/orphan/LazyOneToManyPersistAndLoadTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/orphan/LazyOneToManyPersistAndLoadTest.java
@@ -6,14 +6,15 @@ import java.util.List;
 import org.hibernate.Hibernate;
 import org.hibernate.bytecode.enhance.spi.DefaultEnhancementContext;
 
-import org.hibernate.testing.TestForIssue;
-import org.hibernate.testing.bytecode.enhancement.BytecodeEnhancerRunner;
 import org.hibernate.testing.bytecode.enhancement.CustomEnhancementContext;
 import org.hibernate.testing.bytecode.enhancement.EnhancerTestContext;
-import org.hibernate.testing.junit4.BaseCoreFunctionalTestCase;
-import org.junit.After;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.hibernate.testing.bytecode.enhancement.extension.BytecodeEnhanced;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.JiraKey;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Entity;
@@ -22,32 +23,31 @@ import jakarta.persistence.Id;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@TestForIssue(jiraKey = "HHH-16334")
-@RunWith(BytecodeEnhancerRunner.class)
+@JiraKey("HHH-16334")
+@DomainModel(
+		annotatedClasses = {
+				LazyOneToManyPersistAndLoadTest.Parent.class,
+				LazyOneToManyPersistAndLoadTest.Child.class
+		}
+)
+@SessionFactory
+@BytecodeEnhanced
 @CustomEnhancementContext({
 		EnhancerTestContext.class, // supports laziness and dirty-checking
 		NoDirtyCheckEnhancementContext.class, // supports laziness; does not support dirty-checking,
 		DefaultEnhancementContext.class
 })
-public class LazyOneToManyPersistAndLoadTest extends BaseCoreFunctionalTestCase {
+public class LazyOneToManyPersistAndLoadTest {
 
 	public static final String CHILD_NAME = "Luigi";
 
-	@Override
-	protected Class<?>[] getAnnotatedClasses() {
-		return new Class[] {
-				Parent.class,
-				Child.class
-		};
-	}
-
-	@After
-	public void tearDown() {
-		inTransaction(
+	@AfterEach
+	public void tearDown(SessionFactoryScope scope) {
+		scope.inTransaction(
 				session -> {
 					session.createMutationQuery( "delete from Child" ).executeUpdate();
 					session.createMutationQuery( "delete from Parent" ).executeUpdate();
@@ -56,8 +56,8 @@ public class LazyOneToManyPersistAndLoadTest extends BaseCoreFunctionalTestCase 
 	}
 
 	@Test
-	public void testEmptyCollectionPersistLoad() {
-		inTransaction(
+	public void testEmptyCollectionPersistLoad(SessionFactoryScope scope) {
+		scope.inTransaction(
 				session -> {
 					Parent p = new Parent( 1l );
 					session.persist( p );
@@ -76,15 +76,15 @@ public class LazyOneToManyPersistAndLoadTest extends BaseCoreFunctionalTestCase 
 	}
 
 	@Test
-	public void testEmptyCollectionPersistQueryJoinFetch() {
-		inTransaction(
+	public void testEmptyCollectionPersistQueryJoinFetch(SessionFactoryScope scope) {
+		scope.inTransaction(
 				session -> {
 					Parent p = new Parent( 1l );
 					session.persist( p );
 				}
 		);
 
-		inTransaction(
+		scope.inTransaction(
 				session -> {
 					Parent p = session.get( Parent.class, 1l );
 
@@ -108,15 +108,15 @@ public class LazyOneToManyPersistAndLoadTest extends BaseCoreFunctionalTestCase 
 	}
 
 	@Test
-	public void testEmptyCollectionPersistQuery() {
-		inTransaction(
+	public void testEmptyCollectionPersistQuery(SessionFactoryScope scope) {
+		scope.inTransaction(
 				session -> {
 					Parent p = new Parent( 1l );
 					session.persist( p );
 				}
 		);
 
-		inTransaction(
+		scope.inTransaction(
 				session -> {
 					Parent p = session.get( Parent.class, 1l );
 					List<Child> children = p.getChildren();
@@ -138,8 +138,8 @@ public class LazyOneToManyPersistAndLoadTest extends BaseCoreFunctionalTestCase 
 	}
 
 	@Test
-	public void testCollectionPersistLoad() {
-		inTransaction(
+	public void testCollectionPersistLoad(SessionFactoryScope scope) {
+		scope.inTransaction(
 				session -> {
 					Parent p = new Parent( 1l );
 					Child c = new Child( CHILD_NAME );
@@ -158,8 +158,8 @@ public class LazyOneToManyPersistAndLoadTest extends BaseCoreFunctionalTestCase 
 	}
 
 	@Test
-	public void testCollectionPersistQueryJoinFetch() {
-		inTransaction(
+	public void testCollectionPersistQueryJoinFetch(SessionFactoryScope scope) {
+		scope.inTransaction(
 				session -> {
 					Parent p = new Parent( 1l );
 					Child c = new Child( CHILD_NAME );
@@ -169,7 +169,7 @@ public class LazyOneToManyPersistAndLoadTest extends BaseCoreFunctionalTestCase 
 				}
 		);
 
-		inTransaction(
+		scope.inTransaction(
 				session -> {
 					Parent p = session.get( Parent.class, 1l );
 					assertFalse( Hibernate.isInitialized( p.getChildren() ) );
@@ -192,8 +192,8 @@ public class LazyOneToManyPersistAndLoadTest extends BaseCoreFunctionalTestCase 
 	}
 
 	@Test
-	public void testCollectionPersistQuery() {
-		inTransaction(
+	public void testCollectionPersistQuery(SessionFactoryScope scope) {
+		scope.inTransaction(
 				session -> {
 					Parent p = new Parent( 1l );
 					Child c = new Child( CHILD_NAME );
@@ -203,7 +203,7 @@ public class LazyOneToManyPersistAndLoadTest extends BaseCoreFunctionalTestCase 
 				}
 		);
 
-		inTransaction(
+		scope.inTransaction(
 				session -> {
 					Parent p = session.get( Parent.class, 1l );
 					List<Child> children = p.getChildren();

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/orphan/OneToManyPersistAndLoad2Test.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/orphan/OneToManyPersistAndLoad2Test.java
@@ -8,14 +8,15 @@ import org.hibernate.Hibernate;
 import org.hibernate.bytecode.enhance.spi.DefaultEnhancementContext;
 import org.hibernate.engine.spi.SessionImplementor;
 
-import org.hibernate.testing.TestForIssue;
-import org.hibernate.testing.bytecode.enhancement.BytecodeEnhancerRunner;
 import org.hibernate.testing.bytecode.enhancement.CustomEnhancementContext;
 import org.hibernate.testing.bytecode.enhancement.EnhancerTestContext;
-import org.hibernate.testing.junit4.BaseCoreFunctionalTestCase;
-import org.junit.After;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.hibernate.testing.bytecode.enhancement.extension.BytecodeEnhanced;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.JiraKey;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Entity;
@@ -25,16 +26,23 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinTable;
 import jakarta.persistence.OneToMany;
 
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@TestForIssue(jiraKey = "HHH-16334")
-@RunWith(BytecodeEnhancerRunner.class)
+@JiraKey("HHH-16334")
+@DomainModel(
+		annotatedClasses = {
+				OneToManyPersistAndLoad2Test.Parent.class,
+				OneToManyPersistAndLoad2Test.Child.class
+		}
+)
+@SessionFactory
+@BytecodeEnhanced
 @CustomEnhancementContext({
 		EnhancerTestContext.class, // supports laziness and dirty-checking
 		DefaultEnhancementContext.class
 })
-public class OneToManyPersistAndLoad2Test extends BaseCoreFunctionalTestCase {
+public class OneToManyPersistAndLoad2Test {
 
 	public static final String CHILD_NAME = "Luigi";
 	public static final String CHILD_NAME_2 = "Fab1";
@@ -48,17 +56,9 @@ public class OneToManyPersistAndLoad2Test extends BaseCoreFunctionalTestCase {
 	public static final String CHILD_NAME_8 = "Fab7";
 	public static final String CHILD_NAME_9 = "Fab8";
 
-	@Override
-	protected Class<?>[] getAnnotatedClasses() {
-		return new Class[] {
-				Parent.class,
-				Child.class
-		};
-	}
-
-	@After
-	public void tearDown() {
-		inTransaction(
+	@AfterEach
+	public void tearDown(SessionFactoryScope scope) {
+		scope.inTransaction(
 				session -> {
 					Parent parent = session.get( Parent.class, 1l );
 					session.delete( parent );
@@ -67,15 +67,15 @@ public class OneToManyPersistAndLoad2Test extends BaseCoreFunctionalTestCase {
 	}
 
 	@Test
-	public void testEmptyCollectionPersistQueryJoinFetch() {
-		inTransaction(
+	public void testEmptyCollectionPersistQueryJoinFetch(SessionFactoryScope scope) {
+		scope.inTransaction(
 				session -> {
 					Parent p = new Parent( 1l );
 					session.persist( p );
 				}
 		);
 
-		inTransaction(
+		scope.inTransaction(
 				session -> {
 					Parent p = session.getReference( Parent.class, 1l );
 
@@ -104,15 +104,15 @@ public class OneToManyPersistAndLoad2Test extends BaseCoreFunctionalTestCase {
 	}
 
 	@Test
-	public void testEmptyCollectionPersistQuery() {
-		inTransaction(
+	public void testEmptyCollectionPersistQuery(SessionFactoryScope scope) {
+		scope.inTransaction(
 				session -> {
 					Parent p = new Parent( 1l );
 					session.persist( p );
 				}
 		);
 
-		inTransaction(
+		scope.inTransaction(
 				session -> {
 					Parent p = session.getReference( Parent.class, 1l );
 
@@ -141,14 +141,14 @@ public class OneToManyPersistAndLoad2Test extends BaseCoreFunctionalTestCase {
 	}
 
 	@Test
-	public void testCollectionPersistQueryJoinFetch() {
-		inTransaction(
+	public void testCollectionPersistQueryJoinFetch(SessionFactoryScope scope) {
+		scope.inTransaction(
 				session -> {
 					populateParentWithChildren( session );
 				}
 		);
 
-		inTransaction(
+		scope.inTransaction(
 				session -> {
 					Parent p = session.getReference( Parent.class, 1l );
 
@@ -177,14 +177,14 @@ public class OneToManyPersistAndLoad2Test extends BaseCoreFunctionalTestCase {
 	}
 
 	@Test
-	public void testCollectionPersistQuery() {
-		inTransaction(
+	public void testCollectionPersistQuery(SessionFactoryScope scope) {
+		scope.inTransaction(
 				session -> {
 					populateParentWithChildren( session );
 				}
 		);
 
-		inTransaction(
+		scope.inTransaction(
 				session -> {
 					Parent p = session.getReference( Parent.class, 1l );
 					List<Parent> parents = session.createQuery(

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/orphan/OneToManyPersistAndLoadTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/orphan/OneToManyPersistAndLoadTest.java
@@ -8,14 +8,15 @@ import org.hibernate.Hibernate;
 import org.hibernate.bytecode.enhance.spi.DefaultEnhancementContext;
 import org.hibernate.engine.spi.SessionImplementor;
 
-import org.hibernate.testing.TestForIssue;
-import org.hibernate.testing.bytecode.enhancement.BytecodeEnhancerRunner;
 import org.hibernate.testing.bytecode.enhancement.CustomEnhancementContext;
 import org.hibernate.testing.bytecode.enhancement.EnhancerTestContext;
-import org.hibernate.testing.junit4.BaseCoreFunctionalTestCase;
-import org.junit.After;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.hibernate.testing.bytecode.enhancement.extension.BytecodeEnhanced;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.JiraKey;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Entity;
@@ -25,16 +26,23 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinTable;
 import jakarta.persistence.OneToMany;
 
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@TestForIssue(jiraKey = "HHH-16334")
-@RunWith(BytecodeEnhancerRunner.class)
+@JiraKey("HHH-16334")
+@DomainModel(
+		annotatedClasses = {
+				OneToManyPersistAndLoadTest.Parent.class,
+				OneToManyPersistAndLoadTest.Child.class
+		}
+)
+@SessionFactory
+@BytecodeEnhanced
 @CustomEnhancementContext({
 		EnhancerTestContext.class, // supports laziness and dirty-checking
 		DefaultEnhancementContext.class
 })
-public class OneToManyPersistAndLoadTest extends BaseCoreFunctionalTestCase {
+public class OneToManyPersistAndLoadTest {
 
 	public static final String CHILD_NAME = "Luigi";
 	public static final String CHILD_NAME_2 = "Fab1";
@@ -48,17 +56,9 @@ public class OneToManyPersistAndLoadTest extends BaseCoreFunctionalTestCase {
 	public static final String CHILD_NAME_8 = "Fab7";
 	public static final String CHILD_NAME_9 = "Fab8";
 
-	@Override
-	protected Class<?>[] getAnnotatedClasses() {
-		return new Class[] {
-				Parent.class,
-				Child.class
-		};
-	}
-
-	@After
-	public void tearDown() {
-		inTransaction(
+	@AfterEach
+	public void tearDown(SessionFactoryScope scope) {
+		scope.inTransaction(
 				session -> {
 					Parent parent = session.get( Parent.class, 1l );
 					session.delete( parent );
@@ -67,15 +67,15 @@ public class OneToManyPersistAndLoadTest extends BaseCoreFunctionalTestCase {
 	}
 
 	@Test
-	public void testEmptyCollectionPersistQueryJoinFetch() {
-		inTransaction(
+	public void testEmptyCollectionPersistQueryJoinFetch(SessionFactoryScope scope) {
+		scope.inTransaction(
 				session -> {
 					Parent p = new Parent( 1l );
 					session.persist( p );
 				}
 		);
 
-		inTransaction(
+		scope.inTransaction(
 				session -> {
 					Parent p = session.get( Parent.class, 1l );
 
@@ -104,15 +104,15 @@ public class OneToManyPersistAndLoadTest extends BaseCoreFunctionalTestCase {
 	}
 
 	@Test
-	public void testEmptyCollectionPersistQuery() {
-		inTransaction(
+	public void testEmptyCollectionPersistQuery(SessionFactoryScope scope) {
+		scope.inTransaction(
 				session -> {
 					Parent p = new Parent( 1l );
 					session.persist( p );
 				}
 		);
 
-		inTransaction(
+		scope.inTransaction(
 				session -> {
 					Parent p = session.get( Parent.class, 1l );
 
@@ -141,14 +141,14 @@ public class OneToManyPersistAndLoadTest extends BaseCoreFunctionalTestCase {
 	}
 
 	@Test
-	public void testCollectionPersistQueryJoinFetch() {
-		inTransaction(
+	public void testCollectionPersistQueryJoinFetch(SessionFactoryScope scope) {
+		scope.inTransaction(
 				session -> {
 					populateParentWithChildren( session );
 				}
 		);
 
-		inTransaction(
+		scope.inTransaction(
 				session -> {
 					Parent p = session.get( Parent.class, 1l );
 
@@ -177,14 +177,14 @@ public class OneToManyPersistAndLoadTest extends BaseCoreFunctionalTestCase {
 	}
 
 	@Test
-	public void testCollectionPersistQuery() {
-		inTransaction(
+	public void testCollectionPersistQuery(SessionFactoryScope scope) {
+		scope.inTransaction(
 				session -> {
 					populateParentWithChildren( session );
 				}
 		);
 
-		inTransaction(
+		scope.inTransaction(
 				session -> {
 					Parent p = session.get( Parent.class, 1l );
 					List<Parent> parents = session.createQuery(

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/orphan/OrphanRemovalTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/orphan/OrphanRemovalTest.java
@@ -6,12 +6,13 @@ import org.hibernate.annotations.Fetch;
 import org.hibernate.annotations.LazyGroup;
 import org.hibernate.annotations.LazyToOne;
 
-import org.hibernate.testing.bytecode.enhancement.BytecodeEnhancerRunner;
-import org.hibernate.testing.junit4.BaseCoreFunctionalTestCase;
+import org.hibernate.testing.bytecode.enhancement.extension.BytecodeEnhanced;
+import org.hibernate.testing.orm.junit.DomainModel;
 import org.hibernate.testing.orm.junit.JiraKey;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -25,26 +26,24 @@ import static jakarta.persistence.CascadeType.ALL;
 import static jakarta.persistence.FetchType.LAZY;
 import static org.hibernate.annotations.FetchMode.SELECT;
 import static org.hibernate.annotations.LazyToOneOption.NO_PROXY;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
-@RunWith(BytecodeEnhancerRunner.class)
+@DomainModel(
+		annotatedClasses = {
+				OrphanRemovalTest.Entity1.class,
+				OrphanRemovalTest.Entity2.class
+		}
+)
+@SessionFactory
+@BytecodeEnhanced
 @JiraKey("HHH-16756")
-public class OrphanRemovalTest extends BaseCoreFunctionalTestCase {
+public class OrphanRemovalTest {
 
 	static final int ENTITY_ID = 1;
 
-	@Override
-	protected Class<?>[] getAnnotatedClasses() {
-		return new Class<?>[] {
-				Entity1.class,
-				Entity2.class
-		};
-	}
-
-	@Before
-	public void setUp() {
-		inTransaction(
+	@BeforeEach
+	public void setUp(SessionFactoryScope scope) {
+		scope.inTransaction(
 				session -> {
 					Entity1 e1 = new Entity1( ENTITY_ID );
 					Entity2 e2 = new Entity2();
@@ -61,8 +60,8 @@ public class OrphanRemovalTest extends BaseCoreFunctionalTestCase {
 
 
 	@Test
-	public void testRemovingChild() {
-		inTransaction(
+	public void testRemovingChild(SessionFactoryScope scope) {
+		scope.inTransaction(
 				session -> {
 					Entity1 e1 = session.byId( Entity1.class ).load( ENTITY_ID );
 					e1.setChild( null );

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/pk/EmbeddedPKTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/pk/EmbeddedPKTest.java
@@ -6,12 +6,11 @@
  */
 package org.hibernate.orm.test.bytecode.enhancement.pk;
 
-import org.hibernate.testing.bytecode.enhancement.BytecodeEnhancerRunner;
-import org.hibernate.testing.junit4.BaseCoreFunctionalTestCase;
-import org.hibernate.testing.transaction.TransactionUtil;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.hibernate.testing.bytecode.enhancement.extension.BytecodeEnhanced;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.junit.jupiter.api.Test;
 
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
@@ -26,17 +25,18 @@ import java.util.Calendar;
 /**
  * @author Gail Badner
  */
-@RunWith( BytecodeEnhancerRunner.class )
-public class EmbeddedPKTest extends BaseCoreFunctionalTestCase {
-
-    @Override
-    public Class<?>[] getAnnotatedClasses() {
-        return new Class<?>[]{WorkOrder.class, WorkOrderPK.class};
-    }
+@DomainModel(
+        annotatedClasses = {
+              EmbeddedPKTest.WorkOrder.class, EmbeddedPKTest.WorkOrderPK.class
+        }
+)
+@SessionFactory
+@BytecodeEnhanced
+public class EmbeddedPKTest {
 
     @Test
-    public void test() {
-        TransactionUtil.doInHibernate( this::sessionFactory, s -> {
+    public void test(SessionFactoryScope scope) {
+        scope.inTransaction( s -> {
             s.persist( new WorkOrder() );
         } );
     }
@@ -46,7 +46,7 @@ public class EmbeddedPKTest extends BaseCoreFunctionalTestCase {
     @Entity
     @IdClass( WorkOrderPK.class )
     @Table( name = "WORK_ORDER" )
-    private static class WorkOrder {
+    static class WorkOrder {
 
         @Id
         long id;
@@ -184,7 +184,7 @@ public class EmbeddedPKTest extends BaseCoreFunctionalTestCase {
         }
     }
 
-    private static class WorkOrderPK implements Serializable {
+    static class WorkOrderPK implements Serializable {
         long id;
         long location;
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/refresh/RefreshTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/refresh/RefreshTest.java
@@ -6,13 +6,13 @@ import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.Set;
 
-import org.hibernate.testing.TestForIssue;
-import org.hibernate.testing.bytecode.enhancement.BytecodeEnhancerRunner;
-import org.hibernate.testing.junit4.BaseCoreFunctionalTestCase;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.hibernate.testing.bytecode.enhancement.extension.BytecodeEnhanced;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.JiraKey;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
@@ -27,24 +27,23 @@ import jakarta.persistence.Table;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@RunWith(BytecodeEnhancerRunner.class)
-@TestForIssue(jiraKey = "HHH-16423")
-public class RefreshTest extends BaseCoreFunctionalTestCase {
+@DomainModel(
+		annotatedClasses = {
+			RefreshTest.RealmEntity.class,
+				RefreshTest.RealmAttributeEntity.class,
+				RefreshTest.ComponentEntity.class,
+		}
+)
+@SessionFactory
+@BytecodeEnhanced
+@JiraKey("HHH-16423")
+public class RefreshTest {
 
 	private static final String REALM_ID = "id";
 
-	@Override
-	protected Class[] getAnnotatedClasses() {
-		return new Class[] {
-				RealmEntity.class,
-				RealmAttributeEntity.class,
-				ComponentEntity.class,
-		};
-	}
-
-	@After
-	public void trearDown() {
-		inTransaction(
+	@AfterEach
+	public void trearDown(SessionFactoryScope scope) {
+		scope.inTransaction(
 				session -> {
 					RealmEntity find = session.find( RealmEntity.class, "id" );
 					if(find != null) {
@@ -55,8 +54,8 @@ public class RefreshTest extends BaseCoreFunctionalTestCase {
 	}
 
 	@Test
-	public void testRefresh() {
-		inTransaction(
+	public void testRefresh(SessionFactoryScope scope) {
+		scope.inTransaction(
 				session -> {
 					RealmEntity realm = new RealmEntity();
 					realm.setId( REALM_ID );
@@ -65,7 +64,7 @@ public class RefreshTest extends BaseCoreFunctionalTestCase {
 				}
 		);
 
-		inTransaction(
+		scope.inTransaction(
 				session -> {
 					RealmEntity realm = session.find( RealmEntity.class, REALM_ID );
 
@@ -79,8 +78,8 @@ public class RefreshTest extends BaseCoreFunctionalTestCase {
 	}
 
 	@Test
-	public void testRefresh2() {
-		inTransaction(
+	public void testRefresh2(SessionFactoryScope scope) {
+		scope.inTransaction(
 				session -> {
 					RealmEntity realm = new RealmEntity();
 					realm.setId( "id" );
@@ -100,7 +99,7 @@ public class RefreshTest extends BaseCoreFunctionalTestCase {
 				}
 		);
 
-		inTransaction(
+		scope.inTransaction(
 				session -> {
 					RealmEntity realm = session.find( RealmEntity.class, REALM_ID );
 
@@ -115,8 +114,8 @@ public class RefreshTest extends BaseCoreFunctionalTestCase {
 	}
 
 	@Test
-	public void testRefresh3() {
-		inTransaction(
+	public void testRefresh3(SessionFactoryScope scope) {
+		scope.inTransaction(
 				session -> {
 					RealmEntity realm = new RealmEntity();
 					realm.setId( "id" );
@@ -134,7 +133,7 @@ public class RefreshTest extends BaseCoreFunctionalTestCase {
 				}
 		);
 
-		inTransaction(
+		scope.inTransaction(
 				session -> {
 					RealmEntity realm = session.find( RealmEntity.class, REALM_ID );
 
@@ -149,8 +148,8 @@ public class RefreshTest extends BaseCoreFunctionalTestCase {
 	}
 
 	@Test
-	public void testRefresh4() {
-		inTransaction(
+	public void testRefresh4(SessionFactoryScope scope) {
+		scope.inTransaction(
 				session -> {
 					RealmEntity realm = new RealmEntity();
 					realm.setId( "id" );
@@ -178,7 +177,7 @@ public class RefreshTest extends BaseCoreFunctionalTestCase {
 				}
 		);
 
-		inTransaction(
+		scope.inTransaction(
 				session -> {
 					RealmEntity realm = session.find( RealmEntity.class, REALM_ID );
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/secondarytables/SecondaryTableDynamicUpateTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/secondarytables/SecondaryTableDynamicUpateTest.java
@@ -2,12 +2,13 @@ package org.hibernate.orm.test.bytecode.enhancement.secondarytables;
 
 import org.hibernate.annotations.DynamicUpdate;
 
-import org.hibernate.testing.bytecode.enhancement.BytecodeEnhancerRunner;
-import org.hibernate.testing.junit4.BaseCoreFunctionalTestCase;
+import org.hibernate.testing.bytecode.enhancement.extension.BytecodeEnhanced;
+import org.hibernate.testing.orm.junit.DomainModel;
 import org.hibernate.testing.orm.junit.JiraKey;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -18,24 +19,23 @@ import jakarta.persistence.SecondaryTable;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
 @JiraKey("HHH-17587")
-@RunWith(BytecodeEnhancerRunner.class)
-public class SecondaryTableDynamicUpateTest extends BaseCoreFunctionalTestCase {
+@DomainModel(
+		annotatedClasses = {
+				SecondaryTableDynamicUpateTest.TestEntity.class
+		}
+)
+@SessionFactory
+@BytecodeEnhanced
+public class SecondaryTableDynamicUpateTest {
 
 	private static final Long ENTITY_ID = 123l;
 	private static final String COL_VALUE = "col";
 	private static final String COL1_VALUE = "col1";
 	private static final String COL2_VALUE = "col2";
 
-	@Override
-	protected Class<?>[] getAnnotatedClasses() {
-		return new Class[] {
-				TestEntity.class
-		};
-	}
-
-	@Before
-	public void setUp() {
-		inTransaction(
+	@BeforeEach
+	public void setUp(SessionFactoryScope scope) {
+		scope.inTransaction(
 				entityManager -> {
 					TestEntity testEntity = new TestEntity( ENTITY_ID, COL_VALUE, COL1_VALUE, COL2_VALUE );
 					entityManager.persist( testEntity );
@@ -44,8 +44,8 @@ public class SecondaryTableDynamicUpateTest extends BaseCoreFunctionalTestCase {
 	}
 
 	@Test
-	public void testSetSecondaryTableColumnToNull() {
-		inTransaction(
+	public void testSetSecondaryTableColumnToNull(SessionFactoryScope scope) {
+		scope.inTransaction(
 				entityManager -> {
 					TestEntity testEntity = entityManager.find( TestEntity.class, ENTITY_ID );
 					assertThat( testEntity.getTestCol() ).isEqualTo( COL_VALUE );
@@ -55,7 +55,7 @@ public class SecondaryTableDynamicUpateTest extends BaseCoreFunctionalTestCase {
 				}
 		);
 
-		inTransaction(
+		scope.inTransaction(
 				entityManager -> {
 					TestEntity testEntity = entityManager.find( TestEntity.class, ENTITY_ID );
 					assertThat( testEntity ).isNotNull();
@@ -66,7 +66,7 @@ public class SecondaryTableDynamicUpateTest extends BaseCoreFunctionalTestCase {
 				}
 		);
 
-		inTransaction(
+		scope.inTransaction(
 				entityManager -> {
 					TestEntity testEntity = entityManager.find( TestEntity.class, ENTITY_ID );
 					assertThat( testEntity ).isNotNull();
@@ -78,7 +78,7 @@ public class SecondaryTableDynamicUpateTest extends BaseCoreFunctionalTestCase {
 				}
 		);
 
-		inTransaction(
+		scope.inTransaction(
 				entityManager -> {
 					TestEntity testEntity = entityManager.find( TestEntity.class, ENTITY_ID );
 					assertThat( testEntity ).isNotNull();

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/update/JoinedInheritanceTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/update/JoinedInheritanceTest.java
@@ -2,15 +2,14 @@ package org.hibernate.orm.test.bytecode.enhancement.update;
 
 import java.util.List;
 
-import org.hibernate.annotations.Formula;
-
-import org.hibernate.testing.bytecode.enhancement.BytecodeEnhancerRunner;
-import org.hibernate.testing.junit4.BaseNonConfigCoreFunctionalTestCase;
+import org.hibernate.testing.bytecode.enhancement.extension.BytecodeEnhanced;
+import org.hibernate.testing.orm.junit.DomainModel;
 import org.hibernate.testing.orm.junit.JiraKey;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import jakarta.persistence.Basic;
 import jakarta.persistence.Column;
@@ -27,20 +26,19 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 
-@RunWith(BytecodeEnhancerRunner.class)
+@DomainModel(
+		annotatedClasses = {
+				JoinedInheritanceTest.Plane.class, JoinedInheritanceTest.A320.class
+		}
+)
+@SessionFactory
+@BytecodeEnhanced
 @JiraKey("HHH-17632")
-public class JoinedInheritanceTest extends BaseNonConfigCoreFunctionalTestCase {
+public class JoinedInheritanceTest {
 
-	@Override
-	protected Class[] getAnnotatedClasses() {
-		return new Class[] {
-				Plane.class, A320.class
-		};
-	}
-
-	@Before
-	public void setUp() {
-		inTransaction(
+	@BeforeEach
+	public void setUp(SessionFactoryScope scope) {
+		scope.inTransaction(
 				session -> {
 					A320 a320 = new A320( 1l, "Airbus A320", 101, true, "1.0" );
 					session.persist( a320 );
@@ -48,9 +46,9 @@ public class JoinedInheritanceTest extends BaseNonConfigCoreFunctionalTestCase {
 		);
 	}
 
-	@After
-	public void tearDown() {
-		inTransaction(
+	@AfterEach
+	public void tearDown(SessionFactoryScope scope) {
+		scope.inTransaction(
 				session -> {
 					session.createMutationQuery( "delete from A320" ).executeUpdate();
 				}
@@ -58,8 +56,8 @@ public class JoinedInheritanceTest extends BaseNonConfigCoreFunctionalTestCase {
 	}
 
 	@Test
-	public void testUpdateField() {
-		inTransaction(
+	public void testUpdateField(SessionFactoryScope scope) {
+		scope.inTransaction(
 				session -> {
 					A320 referenceById = session.getReference( A320.class, 1L );
 
@@ -80,8 +78,8 @@ public class JoinedInheritanceTest extends BaseNonConfigCoreFunctionalTestCase {
 	}
 
 	@Test
-	public void testUpdateTwoFields() {
-		inTransaction(
+	public void testUpdateTwoFields(SessionFactoryScope scope) {
+		scope.inTransaction(
 				session -> {
 					A320 referenceById = session.getReference( A320.class, 1L );
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/version/VersionedEntityTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/version/VersionedEntityTest.java
@@ -1,12 +1,14 @@
 package org.hibernate.orm.test.bytecode.enhancement.version;
 
 import org.hibernate.Hibernate;
-import org.hibernate.testing.TestForIssue;
-import org.hibernate.testing.bytecode.enhancement.BytecodeEnhancerRunner;
-import org.hibernate.testing.junit4.BaseCoreFunctionalTestCase;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+
+import org.hibernate.testing.bytecode.enhancement.extension.BytecodeEnhanced;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.JiraKey;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.Serializable;
 import java.util.HashSet;
@@ -25,31 +27,31 @@ import jakarta.persistence.OneToMany;
 import jakarta.persistence.Version;
 
 import static org.hibernate.Hibernate.isInitialized;
-import static org.hibernate.testing.transaction.TransactionUtil.doInJPA;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@TestForIssue(jiraKey = "HHH-15134")
-@RunWith(BytecodeEnhancerRunner.class)
-public class VersionedEntityTest extends BaseCoreFunctionalTestCase {
+@JiraKey("HHH-15134")
+@DomainModel(
+        annotatedClasses = {
+              VersionedEntityTest.FooEntity.class, VersionedEntityTest.BarEntity.class, VersionedEntityTest.BazEntity.class
+        }
+)
+@SessionFactory
+@BytecodeEnhanced
+public class VersionedEntityTest {
     private final Long parentID = 1L;
 
-    @Override
-    public Class<?>[] getAnnotatedClasses() {
-        return new Class<?>[]{ FooEntity.class, BarEntity.class, BazEntity.class };
-    }
-
-    @Before
-    public void prepare() {
-        doInJPA(this::sessionFactory, em -> {
+    @BeforeEach
+    public void prepare(SessionFactoryScope scope) {
+        scope.inTransaction( em -> {
             final FooEntity entity = FooEntity.of( parentID, "foo" );
             em.persist( entity );
-        });
+        } );
     }
 
     @Test
-    public void testUpdateVersionedEntity() {
-        doInJPA(this::sessionFactory, em -> {
+    public void testUpdateVersionedEntity(SessionFactoryScope scope) {
+        scope.inTransaction( em -> {
             final FooEntity entity = em.getReference( FooEntity.class, parentID );
 
             assertFalse( isInitialized( entity ) );

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/hbm/query/HbmNamedQueryConfigurationTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/hbm/query/HbmNamedQueryConfigurationTest.java
@@ -8,40 +8,44 @@ package org.hibernate.orm.test.hbm.query;
 
 import java.util.Map;
 
-import org.hibernate.orm.test.jpa.BaseEntityManagerFunctionalTestCase;
 import org.hibernate.query.named.NamedObjectRepository;
 import org.hibernate.query.sqm.spi.NamedSqmQueryMemento;
 
-import org.hibernate.testing.TestForIssue;
-import org.hibernate.testing.bytecode.enhancement.BytecodeEnhancerRunner;
 import org.hibernate.testing.bytecode.enhancement.EnhancementOptions;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.hibernate.testing.bytecode.enhancement.extension.BytecodeEnhanced;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.JiraKey;
+import org.hibernate.testing.orm.junit.ServiceRegistry;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.hibernate.testing.orm.junit.Setting;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@RunWith(BytecodeEnhancerRunner.class)
-@EnhancementOptions(inlineDirtyChecking = true, lazyLoading = true, extendedEnhancement = true)
-public class HbmNamedQueryConfigurationTest extends BaseEntityManagerFunctionalTestCase {
-	@Override
-	protected String[] getMappings() {
-		return new String[]{
+import org.junit.jupiter.api.Test;
+
+@DomainModel(
+		xmlMappings = {
 				"org/hibernate/orm/test/hbm/query/HbmOverridesAnnotation.orm.xml",
 				"org/hibernate/orm/test/hbm/query/HbmOverridesAnnotation.hbm.xml"
-		};
-	}
-
-	@SuppressWarnings({ "unchecked", "rawtypes" })
-	@Override
-	protected void addConfigOptions(Map options) {
-		options.put( "hibernate.enable_specj_proprietary_syntax", "true" );
-		options.put( "hibernate.transform_hbm_xml.enabled", "true" );
-	}
+		}
+)
+@ServiceRegistry(
+		settings = {
+				@Setting( name ="hibernate.enable_specj_proprietary_syntax", value = "true"),
+				@Setting( name ="hibernate.transform_hbm_xml.enabled", value = "true"),
+		}
+)
+@SessionFactory
+@BytecodeEnhanced
+@EnhancementOptions(inlineDirtyChecking = true, lazyLoading = true, extendedEnhancement = true)
+public class HbmNamedQueryConfigurationTest {
 
 	@Test
-	@TestForIssue( jiraKey = { "HHH-15619", "HHH-15620"} )
-	public void testHbmOverride() {
-		NamedObjectRepository namedObjectRepository = entityManagerFactory()
+	@JiraKey("HHH-15619")
+	@JiraKey("HHH-15620")
+	public void testHbmOverride(SessionFactoryScope scope) {
+		NamedObjectRepository namedObjectRepository = scope.getSessionFactory()
 				.getQueryEngine()
 				.getNamedObjectRepository();
 		NamedSqmQueryMemento sqmQueryMemento = namedObjectRepository.getSqmQueryMemento( Bar.FIND_ALL );

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/lazytoone/InstrumentedProxyLazyToOneTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/lazytoone/InstrumentedProxyLazyToOneTest.java
@@ -7,16 +7,20 @@
 package org.hibernate.orm.test.mapping.lazytoone;
 
 import org.hibernate.Hibernate;
-import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
 import org.hibernate.bytecode.enhance.spi.interceptor.EnhancementAsProxyLazinessInterceptor;
 import org.hibernate.cfg.AvailableSettings;
 import org.hibernate.engine.spi.PersistentAttributeInterceptable;
 import org.hibernate.stat.spi.StatisticsImplementor;
 
-import org.hibernate.testing.bytecode.enhancement.BytecodeEnhancerRunner;
-import org.hibernate.testing.junit4.BaseNonConfigCoreFunctionalTestCase;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.hibernate.testing.bytecode.enhancement.extension.BytecodeEnhanced;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.ServiceRegistry;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.hibernate.testing.orm.junit.Setting;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
@@ -26,22 +30,23 @@ import static org.hamcrest.MatcherAssert.assertThat;
 /**
  * Same as {@link InstrumentedLazyToOneTest} except here we enable bytecode-enhanced proxies
  */
-@RunWith( BytecodeEnhancerRunner.class )
-public class InstrumentedProxyLazyToOneTest extends BaseNonConfigCoreFunctionalTestCase {
+@DomainModel(
+		annotatedClasses = {
+				Airport.class, Flight.class
+		}
+)
+@ServiceRegistry(
+		settings = {
+				@Setting( name = AvailableSettings.GENERATE_STATISTICS, value = "true" ),
+		}
+)
+@SessionFactory
+@BytecodeEnhanced
+public class InstrumentedProxyLazyToOneTest {
 
-	@Override
-	protected Class<?>[] getAnnotatedClasses() {
-		return new Class[] { Airport.class, Flight.class };
-	}
-
-	@Override
-	protected void configureStandardServiceRegistryBuilder(StandardServiceRegistryBuilder ssrb) {
-		ssrb.applySetting( AvailableSettings.GENERATE_STATISTICS, "true" );
-	}
-
-	@Override
-	protected void prepareTest() throws Exception {
-		inTransaction(
+	@BeforeEach
+	protected void prepareTest(SessionFactoryScope scope) throws Exception {
+		scope.inTransaction(
 				(session) -> {
 					final Airport austin = new Airport( 1, "AUS" );
 					final Airport baltimore = new Airport( 2, "BWI" );
@@ -58,22 +63,22 @@ public class InstrumentedProxyLazyToOneTest extends BaseNonConfigCoreFunctionalT
 		);
 	}
 
-	@Override
-	protected void cleanupTestData() throws Exception {
-		inTransaction(
+	@AfterEach
+	protected void cleanupTestData(SessionFactoryScope scope) throws Exception {
+		scope.inTransaction(
 				(session) -> {
-					session.createQuery( "delete Flight" ).executeUpdate();
-					session.createQuery( "delete Airport" ).executeUpdate();
+					session.createMutationQuery( "delete Flight" ).executeUpdate();
+					session.createMutationQuery( "delete Airport" ).executeUpdate();
 				}
 		);
 	}
 
 	@Test
-	public void testEnhancedWithProxy() {
-		final StatisticsImplementor statistics = sessionFactory().getStatistics();
+	public void testEnhancedWithProxy(SessionFactoryScope scope) {
+		final StatisticsImplementor statistics = scope.getSessionFactory().getStatistics();
 		statistics.clear();
 
-		inTransaction(
+		scope.inTransaction(
 				(session) -> {
 					final Flight flight1 = session.byId( Flight.class ).load( 1 );
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/lazytoone/LanyProxylessManyToOneTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/lazytoone/LanyProxylessManyToOneTests.java
@@ -11,22 +11,18 @@ import jakarta.persistence.Id;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import org.hibernate.Hibernate;
-import org.hibernate.boot.MetadataSources;
-import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
 import org.hibernate.bytecode.enhance.spi.interceptor.BytecodeLazyAttributeInterceptor;
 import org.hibernate.bytecode.enhance.spi.interceptor.EnhancementAsProxyLazinessInterceptor;
 import org.hibernate.bytecode.enhance.spi.interceptor.LazyAttributeLoadingInterceptor;
 import org.hibernate.bytecode.spi.BytecodeEnhancementMetadata;
 import org.hibernate.persister.entity.EntityPersister;
-import org.hibernate.testing.TestForIssue;
-import org.hibernate.testing.bytecode.enhancement.BytecodeEnhancerRunner;
 import org.hibernate.testing.bytecode.enhancement.EnhancementOptions;
-import org.hibernate.testing.jdbc.SQLStatementInterceptor;
-import org.hibernate.testing.junit4.BaseNonConfigCoreFunctionalTestCase;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.hibernate.testing.bytecode.enhancement.extension.BytecodeEnhanced;
+import org.hibernate.testing.jdbc.SQLStatementInspector;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.JiraKey;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
 
 import java.math.BigDecimal;
 
@@ -40,31 +36,28 @@ import static org.hamcrest.CoreMatchers.sameInstance;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertTrue;
 
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
 /**
  * Baseline test for uni-directional to-one, using an explicit @LazyToOne(NO_PROXY)
  *
  * @author Steve Ebersole
  */
-@RunWith( BytecodeEnhancerRunner.class)
+@DomainModel(
+		annotatedClasses = {
+				LanyProxylessManyToOneTests.Customer.class, LanyProxylessManyToOneTests.Order.class
+		}
+)
+@SessionFactory
+@BytecodeEnhanced
 @EnhancementOptions( lazyLoading = true )
-public class LanyProxylessManyToOneTests extends BaseNonConfigCoreFunctionalTestCase {
-	private SQLStatementInterceptor sqlStatementInterceptor;
+public class LanyProxylessManyToOneTests {
 
-	@Override
-	protected void applyMetadataSources(MetadataSources sources) {
-		super.applyMetadataSources( sources );
-		sources.addAnnotatedClass( Customer.class );
-		sources.addAnnotatedClass( Order.class );
-	}
-
-	@Override
-	protected void configureStandardServiceRegistryBuilder(StandardServiceRegistryBuilder ssrb) {
-		super.configureStandardServiceRegistryBuilder( ssrb );
-		sqlStatementInterceptor = new SQLStatementInterceptor( ssrb );
-	}
-
-	@Test public void testLazyManyToOne() {
-		inTransaction(
+	@Test
+	public void testLazyManyToOne(SessionFactoryScope scope) {
+		scope.inTransaction(
 				(session) -> {
 					final Order order = session.byId(Order.class).getReference(1);
 					assertThat( Hibernate.isPropertyInitialized( order, "customer"), is(false) );
@@ -80,7 +73,7 @@ public class LanyProxylessManyToOneTests extends BaseNonConfigCoreFunctionalTest
 					assertThat( Hibernate.isInitialized(customer), is(true) );
 				}
 		);
-		inTransaction(
+		scope.inTransaction(
 				(session) -> {
 					final Order order = session.byId(Order.class).getReference(1);
 					assertThat( Hibernate.isPropertyInitialized( order, "customer"), is(false) );
@@ -99,34 +92,37 @@ public class LanyProxylessManyToOneTests extends BaseNonConfigCoreFunctionalTest
 	}
 
 	@Test
-	public void testOwnerIsProxy() {
-		final EntityPersister orderDescriptor = sessionFactory().getMappingMetamodel().getEntityDescriptor( Order.class );
+	public void testOwnerIsProxy(SessionFactoryScope scope) {
+		SQLStatementInspector statementInspector = (SQLStatementInspector) scope.getSessionFactory()
+				.getSessionFactoryOptions()
+				.getStatementInspector();
+		final EntityPersister orderDescriptor = scope.getSessionFactory().getMappingMetamodel().getEntityDescriptor( Order.class );
 		final BytecodeEnhancementMetadata orderEnhancementMetadata = orderDescriptor.getBytecodeEnhancementMetadata();
 		assertThat( orderEnhancementMetadata.isEnhancedForLazyLoading(), is( true ) );
 
-		final EntityPersister customerDescriptor = sessionFactory().getMappingMetamodel().getEntityDescriptor( Customer.class );
+		final EntityPersister customerDescriptor = scope.getSessionFactory().getMappingMetamodel().getEntityDescriptor( Customer.class );
 		final BytecodeEnhancementMetadata customerEnhancementMetadata = customerDescriptor.getBytecodeEnhancementMetadata();
 		assertThat( customerEnhancementMetadata.isEnhancedForLazyLoading(), is( true ) );
 
-		inTransaction(
+		scope.inTransaction(
 				(session) -> {
 					final Order order = session.byId( Order.class ).getReference( 1 );
 
 					// we should have just the uninitialized proxy of the owner - and
 					// therefore no SQL statements should have been executed
-					assertThat( sqlStatementInterceptor.getSqlQueries().size(), is( 0 ) );
+					assertThat( statementInspector.getSqlQueries().size(), is( 0 ) );
 
 					final BytecodeLazyAttributeInterceptor initialInterceptor = orderEnhancementMetadata.extractLazyInterceptor( order );
 					assertThat( initialInterceptor, instanceOf( EnhancementAsProxyLazinessInterceptor.class ) );
 
 					// access the id - should do nothing with db
 					order.getId();
-					assertThat( sqlStatementInterceptor.getSqlQueries().size(), is( 0 ) );
+					assertThat( statementInspector.getSqlQueries().size(), is( 0 ) );
 					assertThat( initialInterceptor, sameInstance( orderEnhancementMetadata.extractLazyInterceptor( order ) ) );
 
 					// this should trigger loading the entity's base state
 					order.getAmount();
-					assertThat( sqlStatementInterceptor.getSqlQueries().size(), is( 1 ) );
+					assertThat( statementInspector.getSqlQueries().size(), is( 1 ) );
 					final BytecodeLazyAttributeInterceptor interceptor = orderEnhancementMetadata.extractLazyInterceptor( order );
 					assertThat( initialInterceptor, not( sameInstance( interceptor ) ) );
 					assertThat( interceptor, instanceOf( LazyAttributeLoadingInterceptor.class ) );
@@ -135,32 +131,36 @@ public class LanyProxylessManyToOneTests extends BaseNonConfigCoreFunctionalTest
 
 					// should not trigger a load and the `customer` reference should be an uninitialized enhanced proxy
 					final Customer customer = order.getCustomer();
-					assertThat( sqlStatementInterceptor.getSqlQueries().size(), is( 1 ) );
+					assertThat( statementInspector.getSqlQueries().size(), is( 1 ) );
 
 					final BytecodeLazyAttributeInterceptor initialCustomerInterceptor = customerEnhancementMetadata.extractLazyInterceptor( customer );
 					assertThat( initialCustomerInterceptor, instanceOf( EnhancementAsProxyLazinessInterceptor.class ) );
 
 					// just as above, accessing id should trigger no loads
 					customer.getId();
-					assertThat( sqlStatementInterceptor.getSqlQueries().size(), is( 1 ) );
+					assertThat( statementInspector.getSqlQueries().size(), is( 1 ) );
 					assertThat( initialCustomerInterceptor, sameInstance( customerEnhancementMetadata.extractLazyInterceptor( customer ) ) );
 
 					customer.getName();
-					assertThat( sqlStatementInterceptor.getSqlQueries().size(), is( 2 ) );
+					assertThat( statementInspector.getSqlQueries().size(), is( 2 ) );
 					assertThat( customerEnhancementMetadata.extractLazyInterceptor( customer ), instanceOf( LazyAttributeLoadingInterceptor.class ) );
 				}
 		);
 	}
 
 	@Test
-	@TestForIssue(jiraKey = "HHH-14659")
-	public void testQueryJoinFetch() {
-		Order order = fromTransaction( (session) -> {
+	@JiraKey("HHH-14659")
+	public void testQueryJoinFetch(SessionFactoryScope scope) {
+		SQLStatementInspector statementInspector = (SQLStatementInspector) scope.getSessionFactory()
+				.getSessionFactoryOptions()
+				.getStatementInspector();
+
+		Order order = scope.fromTransaction( (session) -> {
 			final Order result = session.createQuery(
 							"select o from Order o join fetch o.customer",
 							Order.class )
 					.uniqueResult();
-			assertThat( sqlStatementInterceptor.getSqlQueries().size(), is( 1 ) );
+			assertThat( statementInspector.getSqlQueries().size(), is( 1 ) );
 			return result;
 		} );
 
@@ -170,12 +170,12 @@ public class LanyProxylessManyToOneTests extends BaseNonConfigCoreFunctionalTest
 		// The "join fetch" should have already initialized the associated entity.
 		Customer customer = order.getCustomer();
 		assertTrue( Hibernate.isInitialized( customer ) );
-		assertThat( sqlStatementInterceptor.getSqlQueries().size(), is( 1 ) );
+		assertThat( statementInspector.getSqlQueries().size(), is( 1 ) );
 	}
 
-	@Before
-	public void createTestData() {
-		inTransaction(
+	@BeforeEach
+	public void createTestData(SessionFactoryScope scope) {
+		scope.inTransaction(
 				(session) -> {
 					final Customer customer = new Customer( 1, "Acme Brick" );
 					session.persist( customer );
@@ -183,12 +183,13 @@ public class LanyProxylessManyToOneTests extends BaseNonConfigCoreFunctionalTest
 					session.persist( order );
 				}
 		);
-		sqlStatementInterceptor.clear();
+		( (SQLStatementInspector) scope.getSessionFactory().getSessionFactoryOptions()
+				.getStatementInspector() ).clear();
 	}
 
-	@After
-	public void dropTestData() {
-		inTransaction(
+	@AfterEach
+	public void dropTestData(SessionFactoryScope scope) {
+		scope.inTransaction(
 				(session) -> {
 					session.createQuery( "delete Order" ).executeUpdate();
 					session.createQuery( "delete Customer" ).executeUpdate();

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/lazytoone/ManyToOneExplicitOptionTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/lazytoone/ManyToOneExplicitOptionTests.java
@@ -14,23 +14,19 @@ import jakarta.persistence.Table;
 
 import org.hibernate.Hibernate;
 import org.hibernate.annotations.LazyToOne;
-import org.hibernate.boot.MetadataSources;
-import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
 import org.hibernate.bytecode.enhance.spi.interceptor.BytecodeLazyAttributeInterceptor;
 import org.hibernate.bytecode.enhance.spi.interceptor.EnhancementAsProxyLazinessInterceptor;
 import org.hibernate.bytecode.enhance.spi.interceptor.LazyAttributeLoadingInterceptor;
 import org.hibernate.bytecode.spi.BytecodeEnhancementMetadata;
 import org.hibernate.persister.entity.EntityPersister;
 
-import org.hibernate.testing.TestForIssue;
-import org.hibernate.testing.bytecode.enhancement.BytecodeEnhancerRunner;
 import org.hibernate.testing.bytecode.enhancement.EnhancementOptions;
-import org.hibernate.testing.jdbc.SQLStatementInterceptor;
-import org.hibernate.testing.junit4.BaseNonConfigCoreFunctionalTestCase;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.hibernate.testing.bytecode.enhancement.extension.BytecodeEnhanced;
+import org.hibernate.testing.jdbc.SQLStatementInspector;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.JiraKey;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
 
 import static jakarta.persistence.FetchType.LAZY;
 import static org.hamcrest.CoreMatchers.instanceOf;
@@ -43,31 +39,28 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hibernate.annotations.LazyToOneOption.NO_PROXY;
 import static org.junit.Assert.assertTrue;
 
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
 /**
  * Baseline test for uni-directional to-one, using an explicit @LazyToOne(NO_PROXY)
  *
  * @author Steve Ebersole
  */
-@RunWith( BytecodeEnhancerRunner.class)
+@DomainModel(
+		annotatedClasses = {
+				ManyToOneExplicitOptionTests.Customer.class, ManyToOneExplicitOptionTests.Order.class
+		}
+)
+@SessionFactory
+@BytecodeEnhanced
 @EnhancementOptions( lazyLoading = true )
-public class ManyToOneExplicitOptionTests extends BaseNonConfigCoreFunctionalTestCase {
-	private SQLStatementInterceptor sqlStatementInterceptor;
+public class ManyToOneExplicitOptionTests {
 
-	@Override
-	protected void applyMetadataSources(MetadataSources sources) {
-		super.applyMetadataSources( sources );
-		sources.addAnnotatedClass( Customer.class );
-		sources.addAnnotatedClass( Order.class );
-	}
-
-	@Override
-	protected void configureStandardServiceRegistryBuilder(StandardServiceRegistryBuilder ssrb) {
-		super.configureStandardServiceRegistryBuilder( ssrb );
-		sqlStatementInterceptor = new SQLStatementInterceptor( ssrb );
-	}
-
-	@Test public void testLazyManyToOne() {
-		inTransaction(
+	@Test
+	public void testLazyManyToOne(SessionFactoryScope scope) {
+		scope.inTransaction(
 				(session) -> {
 					final Order order = session.byId(Order.class).getReference(1);
 					assertThat( Hibernate.isPropertyInitialized( order, "customer"), is(false) );
@@ -83,7 +76,7 @@ public class ManyToOneExplicitOptionTests extends BaseNonConfigCoreFunctionalTes
 					assertThat( Hibernate.isInitialized(customer), is(true) );
 				}
 		);
-		inTransaction(
+		scope.inTransaction(
 				(session) -> {
 					final Order order = session.byId(Order.class).getReference(1);
 					assertThat( Hibernate.isPropertyInitialized( order, "customer"), is(false) );
@@ -102,34 +95,36 @@ public class ManyToOneExplicitOptionTests extends BaseNonConfigCoreFunctionalTes
 	}
 
 	@Test
-	public void testOwnerIsProxy() {
-		final EntityPersister orderDescriptor = sessionFactory().getMappingMetamodel().getEntityDescriptor( Order.class );
+	public void testOwnerIsProxy(SessionFactoryScope scope) {
+		final EntityPersister orderDescriptor = scope.getSessionFactory().getMappingMetamodel().getEntityDescriptor( Order.class );
 		final BytecodeEnhancementMetadata orderEnhancementMetadata = orderDescriptor.getBytecodeEnhancementMetadata();
 		assertThat( orderEnhancementMetadata.isEnhancedForLazyLoading(), is( true ) );
 
-		final EntityPersister customerDescriptor = sessionFactory().getMappingMetamodel().getEntityDescriptor( Customer.class );
+		final EntityPersister customerDescriptor = scope.getSessionFactory().getMappingMetamodel().getEntityDescriptor( Customer.class );
 		final BytecodeEnhancementMetadata customerEnhancementMetadata = customerDescriptor.getBytecodeEnhancementMetadata();
 		assertThat( customerEnhancementMetadata.isEnhancedForLazyLoading(), is( true ) );
 
-		inTransaction(
+		SQLStatementInspector statementInspector = scope.getCollectingStatementInspector();
+
+		scope.inTransaction(
 				(session) -> {
 					final Order order = session.byId( Order.class ).getReference( 1 );
 
 					// we should have just the uninitialized proxy of the owner - and
 					// therefore no SQL statements should have been executed
-					assertThat( sqlStatementInterceptor.getSqlQueries().size(), is( 0 ) );
+					assertThat( statementInspector.getSqlQueries().size(), is( 0 ) );
 
 					final BytecodeLazyAttributeInterceptor initialInterceptor = orderEnhancementMetadata.extractLazyInterceptor( order );
 					assertThat( initialInterceptor, instanceOf( EnhancementAsProxyLazinessInterceptor.class ) );
 
 					// access the id - should do nothing with db
 					order.getId();
-					assertThat( sqlStatementInterceptor.getSqlQueries().size(), is( 0 ) );
+					assertThat( statementInspector.getSqlQueries().size(), is( 0 ) );
 					assertThat( initialInterceptor, sameInstance( orderEnhancementMetadata.extractLazyInterceptor( order ) ) );
 
 					// this should trigger loading the entity's base state
 					order.getAmount();
-					assertThat( sqlStatementInterceptor.getSqlQueries().size(), is( 1 ) );
+					assertThat( statementInspector.getSqlQueries().size(), is( 1 ) );
 					final BytecodeLazyAttributeInterceptor interceptor = orderEnhancementMetadata.extractLazyInterceptor( order );
 					assertThat( initialInterceptor, not( sameInstance( interceptor ) ) );
 					assertThat( interceptor, instanceOf( LazyAttributeLoadingInterceptor.class ) );
@@ -138,32 +133,32 @@ public class ManyToOneExplicitOptionTests extends BaseNonConfigCoreFunctionalTes
 
 					// should not trigger a load and the `customer` reference should be an uninitialized enhanced proxy
 					final Customer customer = order.getCustomer();
-					assertThat( sqlStatementInterceptor.getSqlQueries().size(), is( 1 ) );
+					assertThat( statementInspector.getSqlQueries().size(), is( 1 ) );
 
 					final BytecodeLazyAttributeInterceptor initialCustomerInterceptor = customerEnhancementMetadata.extractLazyInterceptor( customer );
 					assertThat( initialCustomerInterceptor, instanceOf( EnhancementAsProxyLazinessInterceptor.class ) );
 
 					// just as above, accessing id should trigger no loads
 					customer.getId();
-					assertThat( sqlStatementInterceptor.getSqlQueries().size(), is( 1 ) );
+					assertThat( statementInspector.getSqlQueries().size(), is( 1 ) );
 					assertThat( initialCustomerInterceptor, sameInstance( customerEnhancementMetadata.extractLazyInterceptor( customer ) ) );
 
 					customer.getName();
-					assertThat( sqlStatementInterceptor.getSqlQueries().size(), is( 2 ) );
+					assertThat( statementInspector.getSqlQueries().size(), is( 2 ) );
 					assertThat( customerEnhancementMetadata.extractLazyInterceptor( customer ), instanceOf( LazyAttributeLoadingInterceptor.class ) );
 				}
 		);
 	}
 
 	@Test
-	@TestForIssue(jiraKey = "HHH-14659")
-	public void testQueryJoinFetch() {
-		Order order = fromTransaction( (session) -> {
+	@JiraKey("HHH-14659")
+	public void testQueryJoinFetch(SessionFactoryScope scope) {
+		Order order = scope.fromTransaction( (session) -> {
 			final Order result = session.createQuery(
 							"select o from Order o join fetch o.customer",
 							Order.class )
 					.uniqueResult();
-			assertThat( sqlStatementInterceptor.getSqlQueries().size(), is( 1 ) );
+			assertThat( scope.getCollectingStatementInspector().getSqlQueries().size(), is( 1 ) );
 			return result;
 		} );
 
@@ -173,12 +168,12 @@ public class ManyToOneExplicitOptionTests extends BaseNonConfigCoreFunctionalTes
 		// The "join fetch" should have already initialized the associated entity.
 		Customer customer = order.getCustomer();
 		assertTrue( Hibernate.isInitialized( customer ) );
-		assertThat( sqlStatementInterceptor.getSqlQueries().size(), is( 1 ) );
+		assertThat( scope.getCollectingStatementInspector().getSqlQueries().size(), is( 1 ) );
 	}
 
-	@Before
-	public void createTestData() {
-		inTransaction(
+	@BeforeEach
+	public void createTestData(SessionFactoryScope scope) {
+		scope.inTransaction(
 				(session) -> {
 					final Customer customer = new Customer( 1, "Acme Brick" );
 					session.persist( customer );
@@ -186,12 +181,12 @@ public class ManyToOneExplicitOptionTests extends BaseNonConfigCoreFunctionalTes
 					session.persist( order );
 				}
 		);
-		sqlStatementInterceptor.clear();
+		scope.getCollectingStatementInspector().clear();
 	}
 
-	@After
-	public void dropTestData() {
-		inTransaction(
+	@AfterEach
+	public void dropTestData(SessionFactoryScope scope) {
+		scope.inTransaction(
 				(session) -> {
 					session.createQuery( "delete Order" ).executeUpdate();
 					session.createQuery( "delete Customer" ).executeUpdate();

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/lazytoone/collectioninitializer/InitLazyToOneWithinPaddedCollectionInitializationAllowProxyTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/lazytoone/collectioninitializer/InitLazyToOneWithinPaddedCollectionInitializationAllowProxyTest.java
@@ -7,19 +7,20 @@
 package org.hibernate.orm.test.mapping.lazytoone.collectioninitializer;
 
 import org.hibernate.Hibernate;
-import org.hibernate.boot.MetadataSources;
-import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
 import org.hibernate.cfg.AvailableSettings;
-import org.hibernate.engine.spi.SessionFactoryImplementor;
 
-import org.hibernate.testing.TestForIssue;
-import org.hibernate.testing.bytecode.enhancement.BytecodeEnhancerRunner;
-import org.hibernate.testing.junit4.BaseNonConfigCoreFunctionalTestCase;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.hibernate.testing.bytecode.enhancement.extension.BytecodeEnhanced;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.JiraKey;
+import org.hibernate.testing.orm.junit.ServiceRegistry;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.hibernate.testing.orm.junit.Setting;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.hibernate.loader.BatchFetchStyle.PADDED;
 
 /**
  * Test lazy-to-one initialization within a collection initialization,
@@ -38,31 +39,29 @@ import static org.hibernate.loader.BatchFetchStyle.PADDED;
  *     (once for UserAuthorization1, and once for UserAuthorization2)</li>
  * </ul>
  */
-@RunWith(BytecodeEnhancerRunner.class)
-@TestForIssue(jiraKey = "HHH-14730")
-public class InitLazyToOneWithinPaddedCollectionInitializationAllowProxyTest
-		extends BaseNonConfigCoreFunctionalTestCase {
+@JiraKey("HHH-14730")
+@DomainModel(
+		annotatedClasses = {
+				User.class,
+				UserAuthorization.class,
+				Company.class,
+				CostCenter.class,
+				Offer.class
+		}
+)
+@ServiceRegistry(
+		settings = {
+				@Setting( name = AvailableSettings.BATCH_FETCH_STYLE, value = "PADDED" ),
+				@Setting( name = AvailableSettings.DEFAULT_BATCH_FETCH_SIZE, value = "10" ),
+		}
+)
+@SessionFactory
+@BytecodeEnhanced
+public class InitLazyToOneWithinPaddedCollectionInitializationAllowProxyTest {
 
-	@Override
-	protected void applyMetadataSources(MetadataSources sources) {
-		super.applyMetadataSources( sources );
-		sources.addAnnotatedClass( User.class );
-		sources.addAnnotatedClass( UserAuthorization.class );
-		sources.addAnnotatedClass( Company.class );
-		sources.addAnnotatedClass( CostCenter.class );
-		sources.addAnnotatedClass( Offer.class );
-	}
-
-	@Override
-	protected void configureStandardServiceRegistryBuilder(StandardServiceRegistryBuilder ssrb) {
-		super.configureStandardServiceRegistryBuilder( ssrb );
-		ssrb.applySetting( AvailableSettings.BATCH_FETCH_STYLE, PADDED );
-		ssrb.applySetting( AvailableSettings.DEFAULT_BATCH_FETCH_SIZE, 10 );
-	}
-
-	@Override
-	protected void afterSessionFactoryBuilt(SessionFactoryImplementor sessionFactory) {
-		inTransaction( session -> {
+	@BeforeEach
+	void afterSessionFactoryBuilt(SessionFactoryScope scope) {
+		scope.inTransaction( session -> {
 			User user0 = new User();
 			user0.setId( 0L );
 			session.persist( user0 );
@@ -127,9 +126,20 @@ public class InitLazyToOneWithinPaddedCollectionInitializationAllowProxyTest
 		} );
 	}
 
+	@AfterEach
+	void tearDown(SessionFactoryScope scope) {
+		scope.inTransaction( (session) -> {
+			session.createMutationQuery( "delete from UserAuthorization" ).executeUpdate();
+			session.createMutationQuery( "delete from Offer" ).executeUpdate();
+			session.createMutationQuery( "delete from CostCenter" ).executeUpdate();
+			session.createMutationQuery( "delete from User" ).executeUpdate();
+			session.createMutationQuery( "delete from Company" ).executeUpdate();
+		} );
+	}
+
 	@Test
-	public void testOneReference() {
-		inTransaction( (session) -> {
+	public void testOneReference(SessionFactoryScope scope) {
+		scope.inTransaction( (session) -> {
 			// Add a lazy proxy of the cost center to the persistence context
 			// through the lazy to-one association from the offer.
 			Offer offer = session.find( Offer.class, 6L );
@@ -148,8 +158,8 @@ public class InitLazyToOneWithinPaddedCollectionInitializationAllowProxyTest
 	}
 
 	@Test
-	public void testTwoReferences() {
-		inTransaction( (session) -> {
+	public void testTwoReferences(SessionFactoryScope scope) {
+		scope.inTransaction( (session) -> {
 			// Add a lazy proxy of the cost center to the persistence context
 			// through the lazy to-one association from the offer.
 			Offer offer = session.find( Offer.class, 6L );
@@ -168,8 +178,8 @@ public class InitLazyToOneWithinPaddedCollectionInitializationAllowProxyTest
 	}
 
 	@Test
-	public void testThreeReferences() {
-		inTransaction( (session) -> {
+	public void testThreeReferences(SessionFactoryScope scope) {
+		scope.inTransaction( (session) -> {
 			// Add a lazy proxy of the cost center to the persistence context
 			// through the lazy to-one association from the offer.
 			Offer offer = session.find( Offer.class, 6L );

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/lazytoone/mappedby/InverseToOneAllowProxyTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/lazytoone/mappedby/InverseToOneAllowProxyTests.java
@@ -12,24 +12,22 @@ import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
 
 import org.hibernate.Hibernate;
-import org.hibernate.boot.MetadataSources;
-import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
 import org.hibernate.bytecode.enhance.spi.interceptor.BytecodeLazyAttributeInterceptor;
 import org.hibernate.bytecode.enhance.spi.interceptor.EnhancementAsProxyLazinessInterceptor;
 import org.hibernate.bytecode.enhance.spi.interceptor.LazyAttributeLoadingInterceptor;
 import org.hibernate.bytecode.spi.BytecodeEnhancementMetadata;
-import org.hibernate.cfg.AvailableSettings;
 import org.hibernate.persister.entity.EntityPersister;
 
-import org.hibernate.testing.TestForIssue;
-import org.hibernate.testing.bytecode.enhancement.BytecodeEnhancerRunner;
 import org.hibernate.testing.bytecode.enhancement.EnhancementOptions;
-import org.hibernate.testing.jdbc.SQLStatementInterceptor;
-import org.hibernate.testing.junit4.BaseNonConfigCoreFunctionalTestCase;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.hibernate.testing.bytecode.enhancement.extension.BytecodeEnhanced;
+import org.hibernate.testing.jdbc.SQLStatementInspector;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.JiraKey;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import static jakarta.persistence.FetchType.LAZY;
 import static org.hamcrest.CoreMatchers.instanceOf;
@@ -37,40 +35,34 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.CoreMatchers.sameInstance;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * @author Steve Ebersole
  */
-@RunWith( BytecodeEnhancerRunner.class)
+@DomainModel(
+		annotatedClasses = {
+				InverseToOneAllowProxyTests.Customer.class, InverseToOneAllowProxyTests.SupplementalInfo.class
+		}
+)
+@SessionFactory
+@BytecodeEnhanced
 @EnhancementOptions( lazyLoading = true )
-public class InverseToOneAllowProxyTests extends BaseNonConfigCoreFunctionalTestCase {
-	private SQLStatementInterceptor sqlStatementInterceptor;
-
-	@Override
-	protected void applyMetadataSources(MetadataSources sources) {
-		super.applyMetadataSources( sources );
-		sources.addAnnotatedClass( Customer.class );
-		sources.addAnnotatedClass( SupplementalInfo.class );
-	}
-
-	@Override
-	protected void configureStandardServiceRegistryBuilder(StandardServiceRegistryBuilder ssrb) {
-		super.configureStandardServiceRegistryBuilder( ssrb );
-		sqlStatementInterceptor = new SQLStatementInterceptor( ssrb );
-	}
+public class InverseToOneAllowProxyTests {
 
 	@Test
-	public void testOwnerIsProxy() {
-		final EntityPersister supplementalInfoDescriptor = sessionFactory().getMappingMetamodel().getEntityDescriptor( SupplementalInfo.class );
+	public void testOwnerIsProxy(SessionFactoryScope scope) {
+		final EntityPersister supplementalInfoDescriptor = scope.getSessionFactory().getMappingMetamodel().getEntityDescriptor( SupplementalInfo.class );
 		final BytecodeEnhancementMetadata supplementalInfoEnhancementMetadata = supplementalInfoDescriptor.getBytecodeEnhancementMetadata();
 		assertThat( supplementalInfoEnhancementMetadata.isEnhancedForLazyLoading(), is( true ) );
 
-		final EntityPersister customerDescriptor = sessionFactory().getMappingMetamodel().getEntityDescriptor( Customer.class );
+		final EntityPersister customerDescriptor = scope.getSessionFactory().getMappingMetamodel().getEntityDescriptor( Customer.class );
 		final BytecodeEnhancementMetadata customerEnhancementMetadata = customerDescriptor.getBytecodeEnhancementMetadata();
 		assertThat( customerEnhancementMetadata.isEnhancedForLazyLoading(), is( true ) );
 
-		inTransaction(
+		SQLStatementInspector statementInspector = scope.getCollectingStatementInspector();
+
+		scope.inTransaction(
 				(session) -> {
 
 					// Get a reference to the SupplementalInfo we created
@@ -78,14 +70,14 @@ public class InverseToOneAllowProxyTests extends BaseNonConfigCoreFunctionalTest
 					final SupplementalInfo supplementalInfo = session.byId( SupplementalInfo.class ).getReference( 1 );
 
 					// 1) we should have just the uninitialized SupplementalInfo enhanced proxy
-					assertThat( sqlStatementInterceptor.getSqlQueries().size(), is( 0 ) );
+					assertThat( statementInspector.getSqlQueries().size(), is( 0 ) );
 					final BytecodeLazyAttributeInterceptor initialInterceptor = supplementalInfoEnhancementMetadata.extractLazyInterceptor( supplementalInfo );
 					assertThat( initialInterceptor, instanceOf( EnhancementAsProxyLazinessInterceptor.class ) );
 
 					// (2) Access the SupplementalInfo's id value - should trigger no SQL
 
 					supplementalInfo.getId();
-					assertThat( sqlStatementInterceptor.getSqlQueries().size(), is( 0 ) );
+					assertThat( statementInspector.getSqlQueries().size(), is( 0 ) );
 					assertThat( initialInterceptor, sameInstance( supplementalInfoEnhancementMetadata.extractLazyInterceptor( supplementalInfo ) ) );
 
 					// 3) Access SupplementalInfo's `something` state
@@ -93,7 +85,7 @@ public class InverseToOneAllowProxyTests extends BaseNonConfigCoreFunctionalTest
 					//			NOTE: `customer` is not part of this lazy group because we do not know the
 					//			Customer PK from this side
 					supplementalInfo.getSomething();
-					assertThat( sqlStatementInterceptor.getSqlQueries().size(), is( 1 ) );
+					assertThat( statementInspector.getSqlQueries().size(), is( 1 ) );
 					final BytecodeLazyAttributeInterceptor interceptor = supplementalInfoEnhancementMetadata.extractLazyInterceptor( supplementalInfo );
 					assertThat( initialInterceptor, not( sameInstance( interceptor ) ) );
 					assertThat( interceptor, instanceOf( LazyAttributeLoadingInterceptor.class ) );
@@ -101,27 +93,27 @@ public class InverseToOneAllowProxyTests extends BaseNonConfigCoreFunctionalTest
 					// 4) Access SupplementalInfo's `customer` state
 					//		- should trigger load from Customer table, by FK
 					final Customer customer = supplementalInfo.getCustomer();
-					assertThat( sqlStatementInterceptor.getSqlQueries().size(), is( 2 ) );
+					assertThat( statementInspector.getSqlQueries().size(), is( 2 ) );
 
 					// just as above, accessing id should trigger no loads
 					customer.getId();
-					assertThat( sqlStatementInterceptor.getSqlQueries().size(), is( 2 ) );
+					assertThat( statementInspector.getSqlQueries().size(), is( 2 ) );
 
 					customer.getName();
-					assertThat( sqlStatementInterceptor.getSqlQueries().size(), is( 2 ) );
+					assertThat( statementInspector.getSqlQueries().size(), is( 2 ) );
 				}
 		);
 	}
 
 	@Test
-	@TestForIssue(jiraKey = "HHH-14659")
-	public void testQueryJoinFetch() {
-		SupplementalInfo info = fromTransaction( (session) -> {
+	@JiraKey("HHH-14659")
+	public void testQueryJoinFetch(SessionFactoryScope scope) {
+		SupplementalInfo info = scope.fromTransaction( (session) -> {
 			final SupplementalInfo result = session.createQuery(
 							"select s from SupplementalInfo s join fetch s.customer",
 							SupplementalInfo.class )
 					.uniqueResult();
-			assertThat( sqlStatementInterceptor.getSqlQueries().size(), is( 1 ) );
+			assertThat( scope.getCollectingStatementInspector().getSqlQueries().size(), is( 1 ) );
 			return result;
 		} );
 
@@ -131,12 +123,12 @@ public class InverseToOneAllowProxyTests extends BaseNonConfigCoreFunctionalTest
 		// The "join fetch" should have already initialized the associated entity.
 		Customer customer = info.getCustomer();
 		assertTrue( Hibernate.isInitialized( customer ) );
-		assertThat( sqlStatementInterceptor.getSqlQueries().size(), is( 1 ) );
+		assertThat( scope.getCollectingStatementInspector().getSqlQueries().size(), is( 1 ) );
 	}
 
-	@Before
-	public void createTestData() {
-		inTransaction(
+	@BeforeEach
+	public void createTestData(SessionFactoryScope scope) {
+		scope.inTransaction(
 				(session) -> {
 					final Customer customer = new Customer( 1, "Acme Brick" );
 					session.persist( customer );
@@ -144,12 +136,12 @@ public class InverseToOneAllowProxyTests extends BaseNonConfigCoreFunctionalTest
 					session.persist( supplementalInfo );
 				}
 		);
-		sqlStatementInterceptor.clear();
+		scope.getCollectingStatementInspector().clear();
 	}
 
-	@After
-	public void dropTestData() {
-		inTransaction(
+	@AfterEach
+	public void dropTestData(SessionFactoryScope scope) {
+		scope.inTransaction(
 				(session) -> {
 					session.createQuery( "delete Customer" ).executeUpdate();
 					session.createQuery( "delete SupplementalInfo" ).executeUpdate();

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/lazytoone/mappedby/InverseToOneExplicitOptionTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/lazytoone/mappedby/InverseToOneExplicitOptionTests.java
@@ -13,23 +13,21 @@ import jakarta.persistence.Table;
 
 import org.hibernate.Hibernate;
 import org.hibernate.annotations.LazyToOne;
-import org.hibernate.boot.MetadataSources;
-import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
 import org.hibernate.bytecode.enhance.spi.interceptor.EnhancementAsProxyLazinessInterceptor;
 import org.hibernate.bytecode.enhance.spi.interceptor.LazyAttributeLoadingInterceptor;
 import org.hibernate.bytecode.spi.BytecodeEnhancementMetadata;
-import org.hibernate.cfg.AvailableSettings;
 import org.hibernate.persister.entity.EntityPersister;
 
-import org.hibernate.testing.TestForIssue;
-import org.hibernate.testing.bytecode.enhancement.BytecodeEnhancerRunner;
 import org.hibernate.testing.bytecode.enhancement.EnhancementOptions;
-import org.hibernate.testing.jdbc.SQLStatementInterceptor;
-import org.hibernate.testing.junit4.BaseNonConfigCoreFunctionalTestCase;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.hibernate.testing.bytecode.enhancement.extension.BytecodeEnhanced;
+import org.hibernate.testing.jdbc.SQLStatementInspector;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.JiraKey;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import static jakarta.persistence.FetchType.LAZY;
 import static org.hamcrest.CoreMatchers.instanceOf;
@@ -41,35 +39,29 @@ import static org.junit.Assert.assertTrue;
 /**
  * Baseline test for inverse (mappedBy) to-one, using an explicit @LazyToOne(NO_PROXY)
  */
-@RunWith( BytecodeEnhancerRunner.class)
+@DomainModel(
+		annotatedClasses = {
+				InverseToOneExplicitOptionTests.Customer.class, InverseToOneExplicitOptionTests.SupplementalInfo.class
+		}
+)
+@SessionFactory
+@BytecodeEnhanced
 @EnhancementOptions( lazyLoading = true )
-public class InverseToOneExplicitOptionTests extends BaseNonConfigCoreFunctionalTestCase {
-	private SQLStatementInterceptor sqlStatementInterceptor;
-
-	@Override
-	protected void applyMetadataSources(MetadataSources sources) {
-		super.applyMetadataSources( sources );
-		sources.addAnnotatedClass( Customer.class );
-		sources.addAnnotatedClass( SupplementalInfo.class );
-	}
-
-	@Override
-	protected void configureStandardServiceRegistryBuilder(StandardServiceRegistryBuilder ssrb) {
-		super.configureStandardServiceRegistryBuilder( ssrb );
-		sqlStatementInterceptor = new SQLStatementInterceptor( ssrb );
-	}
+public class InverseToOneExplicitOptionTests {
 
 	@Test
-	public void testOwnerIsProxy() {
-		final EntityPersister supplementalInfoDescriptor = sessionFactory().getMappingMetamodel().getEntityDescriptor( SupplementalInfo.class );
+	public void testOwnerIsProxy(SessionFactoryScope scope) {
+		final EntityPersister supplementalInfoDescriptor = scope.getSessionFactory().getMappingMetamodel().getEntityDescriptor( SupplementalInfo.class );
 		final BytecodeEnhancementMetadata supplementalInfoEnhancementMetadata = supplementalInfoDescriptor.getBytecodeEnhancementMetadata();
 		assertThat( supplementalInfoEnhancementMetadata.isEnhancedForLazyLoading(), is( true ) );
 
-		final EntityPersister customerDescriptor = sessionFactory().getMappingMetamodel().getEntityDescriptor( Customer.class );
+		final EntityPersister customerDescriptor = scope.getSessionFactory().getMappingMetamodel().getEntityDescriptor( Customer.class );
 		final BytecodeEnhancementMetadata customerEnhancementMetadata = customerDescriptor.getBytecodeEnhancementMetadata();
 		assertThat( customerEnhancementMetadata.isEnhancedForLazyLoading(), is( true ) );
 
-		inTransaction(
+		SQLStatementInspector statementInspector = scope.getCollectingStatementInspector();
+
+		scope.inTransaction(
 				(session) -> {
 
 					// 1) Get a reference to the SupplementalInfo we created
@@ -87,7 +79,7 @@ public class InverseToOneExplicitOptionTests extends BaseNonConfigCoreFunctional
 
 					// we should have just the uninitialized SupplementalInfo proxy
 					//		- therefore no SQL statements should have been executed
-					assertThat( sqlStatementInterceptor.getSqlQueries().size(), is( 0 ) );
+					assertThat( statementInspector.getSqlQueries().size(), is( 0 ) );
 
 					assertThat(
 							supplementalInfoEnhancementMetadata.extractLazyInterceptor( supplementalInfo ),
@@ -96,7 +88,7 @@ public class InverseToOneExplicitOptionTests extends BaseNonConfigCoreFunctional
 
 					// access the id - should do nothing with db
 					supplementalInfo.getId();
-					assertThat( sqlStatementInterceptor.getSqlQueries().size(), is( 0 ) );
+					assertThat( statementInspector.getSqlQueries().size(), is( 0 ) );
 					assertThat(
 							supplementalInfoEnhancementMetadata.extractLazyInterceptor( supplementalInfo ),
 							instanceOf( EnhancementAsProxyLazinessInterceptor.class )
@@ -104,7 +96,7 @@ public class InverseToOneExplicitOptionTests extends BaseNonConfigCoreFunctional
 
 					// this should trigger loading the entity's base state
 					supplementalInfo.getSomething();
-					assertThat( sqlStatementInterceptor.getSqlQueries().size(), is( 1 ) );
+					assertThat( statementInspector.getSqlQueries().size(), is( 1 ) );
 					assertThat(
 							supplementalInfoEnhancementMetadata.extractLazyInterceptor( supplementalInfo ),
 							instanceOf( LazyAttributeLoadingInterceptor.class )
@@ -115,7 +107,7 @@ public class InverseToOneExplicitOptionTests extends BaseNonConfigCoreFunctional
 					//
 					// here we access customer which triggers a load from customer table
 					final Customer customer = supplementalInfo.getCustomer();
-					assertThat( sqlStatementInterceptor.getSqlQueries().size(), is( 2 ) );
+					assertThat( statementInspector.getSqlQueries().size(), is( 2 ) );
 
 					assertThat(
 							customerEnhancementMetadata.extractLazyInterceptor( customer ),
@@ -124,23 +116,23 @@ public class InverseToOneExplicitOptionTests extends BaseNonConfigCoreFunctional
 
 					// just as above, accessing id should trigger no loads
 					customer.getId();
-					assertThat( sqlStatementInterceptor.getSqlQueries().size(), is( 2 ) );
+					assertThat( statementInspector.getSqlQueries().size(), is( 2 ) );
 
 					customer.getName();
-					assertThat( sqlStatementInterceptor.getSqlQueries().size(), is( 2 ) );
+					assertThat( statementInspector.getSqlQueries().size(), is( 2 ) );
 				}
 		);
 	}
 
 	@Test
-	@TestForIssue(jiraKey = "HHH-14659")
-	public void testQueryJoinFetch() {
-		SupplementalInfo info = fromTransaction( (session) -> {
+	@JiraKey("HHH-14659")
+	public void testQueryJoinFetch(SessionFactoryScope scope) {
+		SupplementalInfo info = scope.fromTransaction( (session) -> {
 			final SupplementalInfo result = session.createQuery(
 							"select s from SupplementalInfo s join fetch s.customer",
 							SupplementalInfo.class )
 					.uniqueResult();
-			assertThat( sqlStatementInterceptor.getSqlQueries().size(), is( 1 ) );
+			assertThat( scope.getCollectingStatementInspector().getSqlQueries().size(), is( 1 ) );
 			return result;
 		} );
 
@@ -150,12 +142,12 @@ public class InverseToOneExplicitOptionTests extends BaseNonConfigCoreFunctional
 		// The "join fetch" should have already initialized the associated entity.
 		Customer customer = info.getCustomer();
 		assertTrue( Hibernate.isInitialized( customer ) );
-		assertThat( sqlStatementInterceptor.getSqlQueries().size(), is( 1 ) );
+		assertThat( scope.getCollectingStatementInspector().getSqlQueries().size(), is( 1 ) );
 	}
 
-	@Before
-	public void createTestData() {
-		inTransaction(
+	@BeforeEach
+	public void createTestData(SessionFactoryScope scope) {
+		scope.inTransaction(
 				(session) -> {
 					final Customer customer = new Customer( 1, "Acme Brick" );
 					session.persist( customer );
@@ -163,12 +155,12 @@ public class InverseToOneExplicitOptionTests extends BaseNonConfigCoreFunctional
 					session.persist( supplementalInfo );
 				}
 		);
-		sqlStatementInterceptor.clear();
+		scope.getCollectingStatementInspector().clear();
 	}
 
-	@After
-	public void dropTestData() {
-		inTransaction(
+	@AfterEach
+	public void dropTestData(SessionFactoryScope scope) {
+		scope.inTransaction(
 				(session) -> {
 					session.createQuery( "delete Customer" ).executeUpdate();
 					session.createQuery( "delete SupplementalInfo" ).executeUpdate();

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/lazytoone/onetoone/JoinFetchedOneToOneAllowProxyTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/lazytoone/onetoone/JoinFetchedOneToOneAllowProxyTests.java
@@ -13,96 +13,88 @@ import jakarta.persistence.Table;
 
 import org.hibernate.Hibernate;
 import org.hibernate.annotations.Fetch;
-import org.hibernate.boot.MetadataSources;
-import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
 import org.hibernate.bytecode.spi.BytecodeEnhancementMetadata;
-import org.hibernate.cfg.AvailableSettings;
 import org.hibernate.persister.entity.EntityPersister;
 
-import org.hibernate.testing.TestForIssue;
-import org.hibernate.testing.bytecode.enhancement.BytecodeEnhancerRunner;
 import org.hibernate.testing.bytecode.enhancement.EnhancementOptions;
-import org.hibernate.testing.jdbc.SQLStatementInterceptor;
-import org.hibernate.testing.junit4.BaseNonConfigCoreFunctionalTestCase;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.hibernate.testing.bytecode.enhancement.extension.BytecodeEnhanced;
+import org.hibernate.testing.jdbc.SQLStatementInspector;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.JiraKey;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import static jakarta.persistence.FetchType.LAZY;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hibernate.annotations.FetchMode.JOIN;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * @author Steve Ebersole
  */
-@RunWith( BytecodeEnhancerRunner.class)
+@DomainModel(
+		annotatedClasses = {
+				JoinFetchedOneToOneAllowProxyTests.Customer.class, JoinFetchedOneToOneAllowProxyTests.SupplementalInfo.class
+		}
+)
+@SessionFactory
+@BytecodeEnhanced
 @EnhancementOptions( lazyLoading = true )
-public class JoinFetchedOneToOneAllowProxyTests extends BaseNonConfigCoreFunctionalTestCase {
-	private SQLStatementInterceptor sqlStatementInterceptor;
-
-	@Override
-	protected void applyMetadataSources(MetadataSources sources) {
-		super.applyMetadataSources( sources );
-		sources.addAnnotatedClass( Customer.class );
-		sources.addAnnotatedClass( SupplementalInfo.class );
-	}
-
-	@Override
-	protected void configureStandardServiceRegistryBuilder(StandardServiceRegistryBuilder ssrb) {
-		super.configureStandardServiceRegistryBuilder( ssrb );
-		sqlStatementInterceptor = new SQLStatementInterceptor( ssrb );
-	}
+public class JoinFetchedOneToOneAllowProxyTests {
 
 	@Test
-	public void testOwnerIsProxy() {
-		final EntityPersister supplementalInfoDescriptor = sessionFactory().getMappingMetamodel().getEntityDescriptor( SupplementalInfo.class );
+	public void testOwnerIsProxy(SessionFactoryScope scope) {
+		final EntityPersister supplementalInfoDescriptor = scope.getSessionFactory().getMappingMetamodel().getEntityDescriptor( SupplementalInfo.class );
 		final BytecodeEnhancementMetadata supplementalInfoEnhancementMetadata = supplementalInfoDescriptor.getBytecodeEnhancementMetadata();
 		assertThat( supplementalInfoEnhancementMetadata.isEnhancedForLazyLoading(), is( true ) );
 
-		final EntityPersister customerDescriptor = sessionFactory().getMappingMetamodel().getEntityDescriptor( Customer.class );
+		final EntityPersister customerDescriptor = scope.getSessionFactory().getMappingMetamodel().getEntityDescriptor( Customer.class );
 		final BytecodeEnhancementMetadata customerEnhancementMetadata = customerDescriptor.getBytecodeEnhancementMetadata();
 		assertThat( customerEnhancementMetadata.isEnhancedForLazyLoading(), is( true ) );
 
-		inTransaction(
+		SQLStatementInspector sqlStatementInspector = scope.getCollectingStatementInspector();
+
+		scope.inTransaction(
 				(session) -> {
 					final SupplementalInfo supplementalInfo = session.byId( SupplementalInfo.class ).getReference( 1 );
 
 					// we should have just the uninitialized SupplementalInfo proxy
 					//		- therefore no SQL statements should have been executed
-					assertThat( sqlStatementInterceptor.getSqlQueries().size(), is( 0 ) );
+					assertThat( sqlStatementInspector.getSqlQueries().size(), is( 0 ) );
 
 					// access the id - should do nothing with db
 					supplementalInfo.getId();
-					assertThat( sqlStatementInterceptor.getSqlQueries().size(), is( 0 ) );
+					assertThat( sqlStatementInspector.getSqlQueries().size(), is( 0 ) );
 
 					// this should trigger loading the entity's base state which should include join fetching Customer
 					supplementalInfo.getSomething();
-					assertThat( sqlStatementInterceptor.getSqlQueries().size(), is( 1 ) );
+					assertThat( sqlStatementInspector.getSqlQueries().size(), is( 1 ) );
 
 					// should not trigger a load and the `customer` reference should be an uninitialized enhanced proxy
 					final Customer customer = supplementalInfo.getCustomer();
-					assertThat( sqlStatementInterceptor.getSqlQueries().size(), is( 1 ) );
+					assertThat( sqlStatementInspector.getSqlQueries().size(), is( 1 ) );
 
 					// just as above, accessing id should trigger no loads
 					customer.getId();
 					customer.getName();
-					assertThat( sqlStatementInterceptor.getSqlQueries().size(), is( 1 ) );
+					assertThat( sqlStatementInspector.getSqlQueries().size(), is( 1 ) );
 				}
 		);
 	}
 
 	@Test
-	@TestForIssue(jiraKey = "HHH-14659")
-	public void testQueryJoinFetch() {
-		SupplementalInfo info = fromTransaction( (session) -> {
+	@JiraKey("HHH-14659")
+	public void testQueryJoinFetch(SessionFactoryScope scope) {
+		SupplementalInfo info = scope.fromTransaction( (session) -> {
 			final SupplementalInfo result = session.createQuery(
 							"select s from SupplementalInfo s join fetch s.customer",
 							SupplementalInfo.class )
 					.uniqueResult();
-			assertThat( sqlStatementInterceptor.getSqlQueries().size(), is( 1 ) );
+			assertThat( scope.getCollectingStatementInspector().getSqlQueries().size(), is( 1 ) );
 			return result;
 		} );
 
@@ -112,12 +104,12 @@ public class JoinFetchedOneToOneAllowProxyTests extends BaseNonConfigCoreFunctio
 		// The "join fetch" should have already initialized the associated entity.
 		Customer customer = info.getCustomer();
 		assertTrue( Hibernate.isInitialized( customer ) );
-		assertThat( sqlStatementInterceptor.getSqlQueries().size(), is( 1 ) );
+		assertThat( scope.getCollectingStatementInspector().getSqlQueries().size(), is( 1 ) );
 	}
 
-	@Before
-	public void createTestData() {
-		inTransaction(
+	@BeforeEach
+	public void createTestData(SessionFactoryScope scope) {
+		scope.inTransaction(
 				(session) -> {
 					final Customer customer = new Customer( 1, "Acme Brick" );
 					session.persist( customer );
@@ -125,12 +117,12 @@ public class JoinFetchedOneToOneAllowProxyTests extends BaseNonConfigCoreFunctio
 					session.persist( supplementalInfo );
 				}
 		);
-		sqlStatementInterceptor.clear();
+		scope.getCollectingStatementInspector().clear();
 	}
 
-	@After
-	public void dropTestData() {
-		inTransaction(
+	@AfterEach
+	public void dropTestData(SessionFactoryScope scope) {
+		scope.inTransaction(
 				(session) -> {
 					session.createQuery( "delete SupplementalInfo" ).executeUpdate();
 					session.createQuery( "delete Customer" ).executeUpdate();

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/lazytoone/onetoone/LazyProxylessOneToOneTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/lazytoone/onetoone/LazyProxylessOneToOneTests.java
@@ -11,22 +11,21 @@ import jakarta.persistence.Id;
 import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
 import org.hibernate.Hibernate;
-import org.hibernate.boot.MetadataSources;
-import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
 import org.hibernate.bytecode.enhance.spi.interceptor.BytecodeLazyAttributeInterceptor;
 import org.hibernate.bytecode.enhance.spi.interceptor.EnhancementAsProxyLazinessInterceptor;
 import org.hibernate.bytecode.enhance.spi.interceptor.LazyAttributeLoadingInterceptor;
 import org.hibernate.bytecode.spi.BytecodeEnhancementMetadata;
 import org.hibernate.persister.entity.EntityPersister;
-import org.hibernate.testing.TestForIssue;
-import org.hibernate.testing.bytecode.enhancement.BytecodeEnhancerRunner;
 import org.hibernate.testing.bytecode.enhancement.EnhancementOptions;
-import org.hibernate.testing.jdbc.SQLStatementInterceptor;
-import org.hibernate.testing.junit4.BaseNonConfigCoreFunctionalTestCase;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.hibernate.testing.bytecode.enhancement.extension.BytecodeEnhanced;
+import org.hibernate.testing.jdbc.SQLStatementInspector;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.JiraKey;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import static jakarta.persistence.FetchType.LAZY;
 import static org.hamcrest.CoreMatchers.instanceOf;
@@ -36,31 +35,24 @@ import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.CoreMatchers.sameInstance;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Same as OneToOneExplicitOptionTests but using @Proxyless
  */
-@RunWith( BytecodeEnhancerRunner.class)
+@DomainModel(
+		annotatedClasses = {
+				LazyProxylessOneToOneTests.Customer.class, LazyProxylessOneToOneTests.SupplementalInfo.class
+		}
+)
+@SessionFactory
+@BytecodeEnhanced
 @EnhancementOptions( lazyLoading = true )
-public class LazyProxylessOneToOneTests extends BaseNonConfigCoreFunctionalTestCase {
-	private SQLStatementInterceptor sqlStatementInterceptor;
+public class LazyProxylessOneToOneTests {
 
-	@Override
-	protected void applyMetadataSources(MetadataSources sources) {
-		super.applyMetadataSources( sources );
-		sources.addAnnotatedClass( Customer.class );
-		sources.addAnnotatedClass( SupplementalInfo.class );
-	}
-
-	@Override
-	protected void configureStandardServiceRegistryBuilder(StandardServiceRegistryBuilder ssrb) {
-		super.configureStandardServiceRegistryBuilder( ssrb );
-		sqlStatementInterceptor = new SQLStatementInterceptor( ssrb );
-	}
-
-	@Test public void testLazyOneToOne() {
-		inTransaction(
+	@Test
+	public void testLazyOneToOne(SessionFactoryScope scope) {
+		scope.inTransaction(
 				(session) -> {
 					final SupplementalInfo supplementalInfo = session.byId(SupplementalInfo.class).getReference(1);
 					assertThat( Hibernate.isPropertyInitialized( supplementalInfo, "customer"), is(false) );
@@ -76,7 +68,7 @@ public class LazyProxylessOneToOneTests extends BaseNonConfigCoreFunctionalTestC
 					assertThat( Hibernate.isInitialized(customer), is(true) );
 				}
 		);
-		inTransaction(
+		scope.inTransaction(
 				(session) -> {
 					final SupplementalInfo supplementalInfo = session.byId(SupplementalInfo.class).getReference(1);
 					assertThat( Hibernate.isPropertyInitialized( supplementalInfo, "customer"), is(false) );
@@ -95,34 +87,36 @@ public class LazyProxylessOneToOneTests extends BaseNonConfigCoreFunctionalTestC
 	}
 
 	@Test
-	public void testOwnerIsProxy() {
-		final EntityPersister supplementalInfoDescriptor = sessionFactory().getMappingMetamodel().getEntityDescriptor( SupplementalInfo.class );
+	public void testOwnerIsProxy(SessionFactoryScope scope) {
+		final EntityPersister supplementalInfoDescriptor = scope.getSessionFactory().getMappingMetamodel().getEntityDescriptor( SupplementalInfo.class );
 		final BytecodeEnhancementMetadata supplementalInfoEnhancementMetadata = supplementalInfoDescriptor.getBytecodeEnhancementMetadata();
 		assertThat( supplementalInfoEnhancementMetadata.isEnhancedForLazyLoading(), is( true ) );
 
-		final EntityPersister customerDescriptor = sessionFactory().getMappingMetamodel().getEntityDescriptor( Customer.class );
+		final EntityPersister customerDescriptor = scope.getSessionFactory().getMappingMetamodel().getEntityDescriptor( Customer.class );
 		final BytecodeEnhancementMetadata customerEnhancementMetadata = customerDescriptor.getBytecodeEnhancementMetadata();
 		assertThat( customerEnhancementMetadata.isEnhancedForLazyLoading(), is( true ) );
 
-		inTransaction(
+		SQLStatementInspector sqlStatementInspector = scope.getCollectingStatementInspector();
+
+		scope.inTransaction(
 				(session) -> {
 					final SupplementalInfo supplementalInfo = session.byId( SupplementalInfo.class ).getReference( 1 );
 
 					// we should have just the uninitialized SupplementalInfo proxy
 					//		- therefore no SQL statements should have been executed
-					assertThat( sqlStatementInterceptor.getSqlQueries().size(), is( 0 ) );
+					assertThat( sqlStatementInspector.getSqlQueries().size(), is( 0 ) );
 
 					final BytecodeLazyAttributeInterceptor initialInterceptor = supplementalInfoEnhancementMetadata.extractLazyInterceptor( supplementalInfo );
 					assertThat( initialInterceptor, instanceOf( EnhancementAsProxyLazinessInterceptor.class ) );
 
 					// access the id - should do nothing with db
 					supplementalInfo.getId();
-					assertThat( sqlStatementInterceptor.getSqlQueries().size(), is( 0 ) );
+					assertThat( sqlStatementInspector.getSqlQueries().size(), is( 0 ) );
 					assertThat( supplementalInfoEnhancementMetadata.extractLazyInterceptor( supplementalInfo ), sameInstance( initialInterceptor ) );
 
 					// this should trigger loading the entity's base state
 					supplementalInfo.getSomething();
-					assertThat( sqlStatementInterceptor.getSqlQueries().size(), is( 1 ) );
+					assertThat( sqlStatementInspector.getSqlQueries().size(), is( 1 ) );
 					final BytecodeLazyAttributeInterceptor interceptor = supplementalInfoEnhancementMetadata.extractLazyInterceptor( supplementalInfo );
 					assertThat( initialInterceptor, not( sameInstance( interceptor ) ) );
 					assertThat( interceptor, instanceOf( LazyAttributeLoadingInterceptor.class ) );
@@ -131,32 +125,32 @@ public class LazyProxylessOneToOneTests extends BaseNonConfigCoreFunctionalTestC
 
 					// should not trigger a load and the `customer` reference should be an uninitialized enhanced proxy
 					final Customer customer = supplementalInfo.getCustomer();
-					assertThat( sqlStatementInterceptor.getSqlQueries().size(), is( 1 ) );
+					assertThat( sqlStatementInspector.getSqlQueries().size(), is( 1 ) );
 
 					final BytecodeLazyAttributeInterceptor initialCustomerInterceptor = customerEnhancementMetadata.extractLazyInterceptor( customer );
 					assertThat( initialCustomerInterceptor, instanceOf( EnhancementAsProxyLazinessInterceptor.class ) );
 
 					// just as above, accessing id should trigger no loads
 					customer.getId();
-					assertThat( sqlStatementInterceptor.getSqlQueries().size(), is( 1 ) );
+					assertThat( sqlStatementInspector.getSqlQueries().size(), is( 1 ) );
 					assertThat( initialCustomerInterceptor, sameInstance( customerEnhancementMetadata.extractLazyInterceptor( customer ) ) );
 
 					customer.getName();
-					assertThat( sqlStatementInterceptor.getSqlQueries().size(), is( 2 ) );
+					assertThat( sqlStatementInspector.getSqlQueries().size(), is( 2 ) );
 					assertThat( customerEnhancementMetadata.extractLazyInterceptor( customer ), instanceOf( LazyAttributeLoadingInterceptor.class ) );
 				}
 		);
 	}
 
 	@Test
-	@TestForIssue(jiraKey = "HHH-14659")
-	public void testQueryJoinFetch() {
-		SupplementalInfo info = fromTransaction( (session) -> {
+	@JiraKey("HHH-14659")
+	public void testQueryJoinFetch(SessionFactoryScope scope) {
+		SupplementalInfo info = scope.fromTransaction( (session) -> {
 			final SupplementalInfo result = session.createQuery(
 							"select s from SupplementalInfo s join fetch s.customer",
 							SupplementalInfo.class )
 					.uniqueResult();
-			assertThat( sqlStatementInterceptor.getSqlQueries().size(), is( 1 ) );
+			assertThat( scope.getCollectingStatementInspector().getSqlQueries().size(), is( 1 ) );
 			return result;
 		} );
 
@@ -166,12 +160,12 @@ public class LazyProxylessOneToOneTests extends BaseNonConfigCoreFunctionalTestC
 		// The "join fetch" should have already initialized the associated entity.
 		Customer customer = info.getCustomer();
 		assertTrue( Hibernate.isInitialized( customer ) );
-		assertThat( sqlStatementInterceptor.getSqlQueries().size(), is( 1 ) );
+		assertThat( scope.getCollectingStatementInspector().getSqlQueries().size(), is( 1 ) );
 	}
 
-	@Before
-	public void createTestData() {
-		inTransaction(
+	@BeforeEach
+	public void createTestData(SessionFactoryScope scope) {
+		scope.inTransaction(
 				(session) -> {
 					final Customer customer = new Customer( 1, "Acme Brick" );
 					session.persist( customer );
@@ -179,12 +173,12 @@ public class LazyProxylessOneToOneTests extends BaseNonConfigCoreFunctionalTestC
 					session.persist( supplementalInfo );
 				}
 		);
-		sqlStatementInterceptor.clear();
+		scope.getCollectingStatementInspector().clear();
 	}
 
-	@After
-	public void dropTestData() {
-		inTransaction(
+	@AfterEach
+	public void dropTestData(SessionFactoryScope scope) {
+		scope.inTransaction(
 				(session) -> {
 					session.createQuery( "delete SupplementalInfo" ).executeUpdate();
 					session.createQuery( "delete Customer" ).executeUpdate();

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/lazytoone/onetoone/OneToOneAllowProxyTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/lazytoone/onetoone/OneToOneAllowProxyTests.java
@@ -12,24 +12,22 @@ import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
 
 import org.hibernate.Hibernate;
-import org.hibernate.boot.MetadataSources;
-import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
 import org.hibernate.bytecode.enhance.spi.interceptor.BytecodeLazyAttributeInterceptor;
 import org.hibernate.bytecode.enhance.spi.interceptor.EnhancementAsProxyLazinessInterceptor;
 import org.hibernate.bytecode.enhance.spi.interceptor.LazyAttributeLoadingInterceptor;
 import org.hibernate.bytecode.spi.BytecodeEnhancementMetadata;
-import org.hibernate.cfg.AvailableSettings;
 import org.hibernate.persister.entity.EntityPersister;
 
-import org.hibernate.testing.TestForIssue;
-import org.hibernate.testing.bytecode.enhancement.BytecodeEnhancerRunner;
 import org.hibernate.testing.bytecode.enhancement.EnhancementOptions;
-import org.hibernate.testing.jdbc.SQLStatementInterceptor;
-import org.hibernate.testing.junit4.BaseNonConfigCoreFunctionalTestCase;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.hibernate.testing.bytecode.enhancement.extension.BytecodeEnhanced;
+import org.hibernate.testing.jdbc.SQLStatementInspector;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.JiraKey;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import static jakarta.persistence.FetchType.LAZY;
 import static org.hamcrest.CoreMatchers.instanceOf;
@@ -37,58 +35,52 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.CoreMatchers.sameInstance;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * @author Steve Ebersole
  */
-@RunWith( BytecodeEnhancerRunner.class)
+@DomainModel(
+		annotatedClasses = {
+				OneToOneAllowProxyTests.Customer.class, OneToOneAllowProxyTests.SupplementalInfo.class
+		}
+)
+@SessionFactory
+@BytecodeEnhanced
 @EnhancementOptions( lazyLoading = true )
-public class OneToOneAllowProxyTests extends BaseNonConfigCoreFunctionalTestCase {
-	private SQLStatementInterceptor sqlStatementInterceptor;
-
-	@Override
-	protected void applyMetadataSources(MetadataSources sources) {
-		super.applyMetadataSources( sources );
-		sources.addAnnotatedClass( Customer.class );
-		sources.addAnnotatedClass( SupplementalInfo.class );
-	}
-
-	@Override
-	protected void configureStandardServiceRegistryBuilder(StandardServiceRegistryBuilder ssrb) {
-		super.configureStandardServiceRegistryBuilder( ssrb );
-		sqlStatementInterceptor = new SQLStatementInterceptor( ssrb );
-	}
+public class OneToOneAllowProxyTests {
 
 	@Test
-	public void testOwnerIsProxy() {
-		final EntityPersister supplementalInfoDescriptor = sessionFactory().getMappingMetamodel().getEntityDescriptor( SupplementalInfo.class );
+	public void testOwnerIsProxy(SessionFactoryScope scope) {
+		final EntityPersister supplementalInfoDescriptor = scope.getSessionFactory().getMappingMetamodel().getEntityDescriptor( SupplementalInfo.class );
 		final BytecodeEnhancementMetadata supplementalInfoEnhancementMetadata = supplementalInfoDescriptor.getBytecodeEnhancementMetadata();
 		assertThat( supplementalInfoEnhancementMetadata.isEnhancedForLazyLoading(), is( true ) );
 
-		final EntityPersister customerDescriptor = sessionFactory().getMappingMetamodel().getEntityDescriptor( Customer.class );
+		final EntityPersister customerDescriptor = scope.getSessionFactory().getMappingMetamodel().getEntityDescriptor( Customer.class );
 		final BytecodeEnhancementMetadata customerEnhancementMetadata = customerDescriptor.getBytecodeEnhancementMetadata();
 		assertThat( customerEnhancementMetadata.isEnhancedForLazyLoading(), is( true ) );
 
-		inTransaction(
+		SQLStatementInspector sqlStatementInspector = scope.getCollectingStatementInspector();
+
+		scope.inTransaction(
 				(session) -> {
 					final SupplementalInfo supplementalInfo = session.byId( SupplementalInfo.class ).getReference( 1 );
 
 					// we should have just the uninitialized SupplementalInfo proxy
 					//		- therefore no SQL statements should have been executed
-					assertThat( sqlStatementInterceptor.getSqlQueries().size(), is( 0 ) );
+					assertThat( sqlStatementInspector.getSqlQueries().size(), is( 0 ) );
 
 					final BytecodeLazyAttributeInterceptor initialInterceptor = supplementalInfoEnhancementMetadata.extractLazyInterceptor( supplementalInfo );
 					assertThat( initialInterceptor, instanceOf( EnhancementAsProxyLazinessInterceptor.class ) );
 
 					// access the id - should do nothing with db
 					supplementalInfo.getId();
-					assertThat( sqlStatementInterceptor.getSqlQueries().size(), is( 0 ) );
+					assertThat( sqlStatementInspector.getSqlQueries().size(), is( 0 ) );
 					assertThat( supplementalInfoEnhancementMetadata.extractLazyInterceptor( supplementalInfo ), sameInstance( initialInterceptor ) );
 
 					// this should trigger loading the entity's base state
 					supplementalInfo.getSomething();
-					assertThat( sqlStatementInterceptor.getSqlQueries().size(), is( 1 ) );
+					assertThat( sqlStatementInspector.getSqlQueries().size(), is( 1 ) );
 					final BytecodeLazyAttributeInterceptor interceptor = supplementalInfoEnhancementMetadata.extractLazyInterceptor( supplementalInfo );
 					assertThat( initialInterceptor, not( sameInstance( interceptor ) ) );
 					assertThat( interceptor, instanceOf( LazyAttributeLoadingInterceptor.class ) );
@@ -97,32 +89,32 @@ public class OneToOneAllowProxyTests extends BaseNonConfigCoreFunctionalTestCase
 
 					// should not trigger a load and the `customer` reference should be an uninitialized enhanced proxy
 					final Customer customer = supplementalInfo.getCustomer();
-					assertThat( sqlStatementInterceptor.getSqlQueries().size(), is( 1 ) );
+					assertThat( sqlStatementInspector.getSqlQueries().size(), is( 1 ) );
 
 					final BytecodeLazyAttributeInterceptor initialCustomerInterceptor = customerEnhancementMetadata.extractLazyInterceptor( customer );
 					assertThat( initialCustomerInterceptor, instanceOf( EnhancementAsProxyLazinessInterceptor.class ) );
 
 					// just as above, accessing id should trigger no loads
 					customer.getId();
-					assertThat( sqlStatementInterceptor.getSqlQueries().size(), is( 1 ) );
+					assertThat( sqlStatementInspector.getSqlQueries().size(), is( 1 ) );
 					assertThat( initialCustomerInterceptor, sameInstance( customerEnhancementMetadata.extractLazyInterceptor( customer ) ) );
 
 					customer.getName();
-					assertThat( sqlStatementInterceptor.getSqlQueries().size(), is( 2 ) );
+					assertThat( sqlStatementInspector.getSqlQueries().size(), is( 2 ) );
 					assertThat( customerEnhancementMetadata.extractLazyInterceptor( customer ), instanceOf( LazyAttributeLoadingInterceptor.class ) );
 				}
 		);
 	}
 
 	@Test
-	@TestForIssue(jiraKey = "HHH-14659")
-	public void testQueryJoinFetch() {
-		SupplementalInfo info = fromTransaction( (session) -> {
+	@JiraKey("HHH-14659")
+	public void testQueryJoinFetch(SessionFactoryScope scope) {
+		SupplementalInfo info = scope.fromTransaction( (session) -> {
 			final SupplementalInfo result = session.createQuery(
 							"select s from SupplementalInfo s join fetch s.customer",
 							SupplementalInfo.class )
 					.uniqueResult();
-			assertThat( sqlStatementInterceptor.getSqlQueries().size(), is( 1 ) );
+			assertThat( scope.getCollectingStatementInspector().getSqlQueries().size(), is( 1 ) );
 			return result;
 		} );
 
@@ -132,12 +124,12 @@ public class OneToOneAllowProxyTests extends BaseNonConfigCoreFunctionalTestCase
 		// The "join fetch" should have already initialized the associated entity.
 		Customer customer = info.getCustomer();
 		assertTrue( Hibernate.isInitialized( customer ) );
-		assertThat( sqlStatementInterceptor.getSqlQueries().size(), is( 1 ) );
+		assertThat( scope.getCollectingStatementInspector().getSqlQueries().size(), is( 1 ) );
 	}
 
-	@Before
-	public void createTestData() {
-		inTransaction(
+	@BeforeEach
+	public void createTestData(SessionFactoryScope scope) {
+		scope.inTransaction(
 				(session) -> {
 					final Customer customer = new Customer( 1, "Acme Brick" );
 					session.persist( customer );
@@ -145,12 +137,12 @@ public class OneToOneAllowProxyTests extends BaseNonConfigCoreFunctionalTestCase
 					session.persist( supplementalInfo );
 				}
 		);
-		sqlStatementInterceptor.clear();
+		scope.getCollectingStatementInspector().clear();
 	}
 
-	@After
-	public void dropTestData() {
-		inTransaction(
+	@AfterEach
+	public void dropTestData(SessionFactoryScope scope) {
+		scope.inTransaction(
 				(session) -> {
 					session.createQuery( "delete SupplementalInfo" ).executeUpdate();
 					session.createQuery( "delete Customer" ).executeUpdate();

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/lazytoone/onetoone/OneToOneExplicitOptionTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/lazytoone/onetoone/OneToOneExplicitOptionTests.java
@@ -13,23 +13,22 @@ import jakarta.persistence.Table;
 
 import org.hibernate.Hibernate;
 import org.hibernate.annotations.LazyToOne;
-import org.hibernate.boot.MetadataSources;
-import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
 import org.hibernate.bytecode.enhance.spi.interceptor.BytecodeLazyAttributeInterceptor;
 import org.hibernate.bytecode.enhance.spi.interceptor.EnhancementAsProxyLazinessInterceptor;
 import org.hibernate.bytecode.enhance.spi.interceptor.LazyAttributeLoadingInterceptor;
 import org.hibernate.bytecode.spi.BytecodeEnhancementMetadata;
 import org.hibernate.persister.entity.EntityPersister;
 
-import org.hibernate.testing.TestForIssue;
-import org.hibernate.testing.bytecode.enhancement.BytecodeEnhancerRunner;
 import org.hibernate.testing.bytecode.enhancement.EnhancementOptions;
-import org.hibernate.testing.jdbc.SQLStatementInterceptor;
-import org.hibernate.testing.junit4.BaseNonConfigCoreFunctionalTestCase;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.hibernate.testing.bytecode.enhancement.extension.BytecodeEnhanced;
+import org.hibernate.testing.jdbc.SQLStatementInspector;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.JiraKey;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import static jakarta.persistence.FetchType.LAZY;
 import static org.hamcrest.CoreMatchers.instanceOf;
@@ -40,31 +39,24 @@ import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.CoreMatchers.sameInstance;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hibernate.annotations.LazyToOneOption.NO_PROXY;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Baseline test for uni-directional one-to-one, using an explicit @LazyToOne(NO_PROXY) and allowing enhanced proxies
  */
-@RunWith( BytecodeEnhancerRunner.class)
+@DomainModel(
+		annotatedClasses = {
+				OneToOneExplicitOptionTests.Customer.class, OneToOneExplicitOptionTests.SupplementalInfo.class
+		}
+)
+@SessionFactory
+@BytecodeEnhanced
 @EnhancementOptions( lazyLoading = true )
-public class OneToOneExplicitOptionTests extends BaseNonConfigCoreFunctionalTestCase {
-	private SQLStatementInterceptor sqlStatementInterceptor;
+public class OneToOneExplicitOptionTests {
 
-	@Override
-	protected void applyMetadataSources(MetadataSources sources) {
-		super.applyMetadataSources( sources );
-		sources.addAnnotatedClass( Customer.class );
-		sources.addAnnotatedClass( SupplementalInfo.class );
-	}
-
-	@Override
-	protected void configureStandardServiceRegistryBuilder(StandardServiceRegistryBuilder ssrb) {
-		super.configureStandardServiceRegistryBuilder( ssrb );
-		sqlStatementInterceptor = new SQLStatementInterceptor( ssrb );
-	}
-
-	@Test public void testLazyOneToOne() {
-		inTransaction(
+	@Test
+	public void testLazyOneToOne(SessionFactoryScope scope) {
+		scope.inTransaction(
 				(session) -> {
 					final SupplementalInfo supplementalInfo = session.byId(SupplementalInfo.class).getReference(1);
 					assertThat( Hibernate.isPropertyInitialized( supplementalInfo, "customer"), is(false) );
@@ -80,7 +72,7 @@ public class OneToOneExplicitOptionTests extends BaseNonConfigCoreFunctionalTest
 					assertThat( Hibernate.isInitialized(customer), is(true) );
 				}
 		);
-		inTransaction(
+		scope.inTransaction(
 				(session) -> {
 					final SupplementalInfo supplementalInfo = session.byId(SupplementalInfo.class).getReference(1);
 					assertThat( Hibernate.isPropertyInitialized( supplementalInfo, "customer"), is(false) );
@@ -99,34 +91,36 @@ public class OneToOneExplicitOptionTests extends BaseNonConfigCoreFunctionalTest
 	}
 
 	@Test
-	public void testOwnerIsProxy() {
-		final EntityPersister supplementalInfoDescriptor = sessionFactory().getMappingMetamodel().getEntityDescriptor( SupplementalInfo.class );
+	public void testOwnerIsProxy(SessionFactoryScope scope) {
+		final EntityPersister supplementalInfoDescriptor = scope.getSessionFactory().getMappingMetamodel().getEntityDescriptor( SupplementalInfo.class );
 		final BytecodeEnhancementMetadata supplementalInfoEnhancementMetadata = supplementalInfoDescriptor.getBytecodeEnhancementMetadata();
 		assertThat( supplementalInfoEnhancementMetadata.isEnhancedForLazyLoading(), is( true ) );
 
-		final EntityPersister customerDescriptor = sessionFactory().getMappingMetamodel().getEntityDescriptor( Customer.class );
+		final EntityPersister customerDescriptor = scope.getSessionFactory().getMappingMetamodel().getEntityDescriptor( Customer.class );
 		final BytecodeEnhancementMetadata customerEnhancementMetadata = customerDescriptor.getBytecodeEnhancementMetadata();
 		assertThat( customerEnhancementMetadata.isEnhancedForLazyLoading(), is( true ) );
 
-		inTransaction(
+		SQLStatementInspector sqlStatementInspector = scope.getCollectingStatementInspector();
+
+		scope.inTransaction(
 				(session) -> {
 					final SupplementalInfo supplementalInfo = session.byId( SupplementalInfo.class ).getReference( 1 );
 
 					// we should have just the uninitialized SupplementalInfo proxy
 					//		- therefore no SQL statements should have been executed
-					assertThat( sqlStatementInterceptor.getSqlQueries().size(), is( 0 ) );
+					assertThat( sqlStatementInspector.getSqlQueries().size(), is( 0 ) );
 
 					final BytecodeLazyAttributeInterceptor initialInterceptor = supplementalInfoEnhancementMetadata.extractLazyInterceptor( supplementalInfo );
 					assertThat( initialInterceptor, instanceOf( EnhancementAsProxyLazinessInterceptor.class ) );
 
 					// access the id - should do nothing with db
 					supplementalInfo.getId();
-					assertThat( sqlStatementInterceptor.getSqlQueries().size(), is( 0 ) );
+					assertThat( sqlStatementInspector.getSqlQueries().size(), is( 0 ) );
 					assertThat( supplementalInfoEnhancementMetadata.extractLazyInterceptor( supplementalInfo ), sameInstance( initialInterceptor ) );
 
 					// this should trigger loading the entity's base state
 					supplementalInfo.getSomething();
-					assertThat( sqlStatementInterceptor.getSqlQueries().size(), is( 1 ) );
+					assertThat( sqlStatementInspector.getSqlQueries().size(), is( 1 ) );
 					final BytecodeLazyAttributeInterceptor interceptor = supplementalInfoEnhancementMetadata.extractLazyInterceptor( supplementalInfo );
 					assertThat( initialInterceptor, not( sameInstance( interceptor ) ) );
 					assertThat( interceptor, instanceOf( LazyAttributeLoadingInterceptor.class ) );
@@ -135,32 +129,32 @@ public class OneToOneExplicitOptionTests extends BaseNonConfigCoreFunctionalTest
 
 					// should not trigger a load and the `customer` reference should be an uninitialized enhanced proxy
 					final Customer customer = supplementalInfo.getCustomer();
-					assertThat( sqlStatementInterceptor.getSqlQueries().size(), is( 1 ) );
+					assertThat( sqlStatementInspector.getSqlQueries().size(), is( 1 ) );
 
 					final BytecodeLazyAttributeInterceptor initialCustomerInterceptor = customerEnhancementMetadata.extractLazyInterceptor( customer );
 					assertThat( initialCustomerInterceptor, instanceOf( EnhancementAsProxyLazinessInterceptor.class ) );
 
 					// just as above, accessing id should trigger no loads
 					customer.getId();
-					assertThat( sqlStatementInterceptor.getSqlQueries().size(), is( 1 ) );
+					assertThat( sqlStatementInspector.getSqlQueries().size(), is( 1 ) );
 					assertThat( initialCustomerInterceptor, sameInstance( customerEnhancementMetadata.extractLazyInterceptor( customer ) ) );
 
 					customer.getName();
-					assertThat( sqlStatementInterceptor.getSqlQueries().size(), is( 2 ) );
+					assertThat( sqlStatementInspector.getSqlQueries().size(), is( 2 ) );
 					assertThat( customerEnhancementMetadata.extractLazyInterceptor( customer ), instanceOf( LazyAttributeLoadingInterceptor.class ) );
 				}
 		);
 	}
 
 	@Test
-	@TestForIssue(jiraKey = "HHH-14659")
-	public void testQueryJoinFetch() {
-		SupplementalInfo info = fromTransaction( (session) -> {
+	@JiraKey("HHH-14659")
+	public void testQueryJoinFetch(SessionFactoryScope scope) {
+		SupplementalInfo info = scope.fromTransaction( (session) -> {
 			final SupplementalInfo result = session.createQuery(
 							"select s from SupplementalInfo s join fetch s.customer",
 							SupplementalInfo.class )
 					.uniqueResult();
-			assertThat( sqlStatementInterceptor.getSqlQueries().size(), is( 1 ) );
+			assertThat( scope.getCollectingStatementInspector().getSqlQueries().size(), is( 1 ) );
 			return result;
 		} );
 
@@ -170,12 +164,12 @@ public class OneToOneExplicitOptionTests extends BaseNonConfigCoreFunctionalTest
 		// The "join fetch" should have already initialized the associated entity.
 		Customer customer = info.getCustomer();
 		assertTrue( Hibernate.isInitialized( customer ) );
-		assertThat( sqlStatementInterceptor.getSqlQueries().size(), is( 1 ) );
+		assertThat( scope.getCollectingStatementInspector().getSqlQueries().size(), is( 1 ) );
 	}
 
-	@Before
-	public void createTestData() {
-		inTransaction(
+	@BeforeEach
+	public void createTestData(SessionFactoryScope scope) {
+		scope.inTransaction(
 				(session) -> {
 					final Customer customer = new Customer( 1, "Acme Brick" );
 					session.persist( customer );
@@ -183,12 +177,12 @@ public class OneToOneExplicitOptionTests extends BaseNonConfigCoreFunctionalTest
 					session.persist( supplementalInfo );
 				}
 		);
-		sqlStatementInterceptor.clear();
+		scope.getCollectingStatementInspector().clear();
 	}
 
-	@After
-	public void dropTestData() {
-		inTransaction(
+	@AfterEach
+	public void dropTestData(SessionFactoryScope scope) {
+		scope.inTransaction(
 				(session) -> {
 					session.createQuery( "delete SupplementalInfo" ).executeUpdate();
 					session.createQuery( "delete Customer" ).executeUpdate();

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/property/FieldMappingWithGetterAndIsTest2.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/property/FieldMappingWithGetterAndIsTest2.java
@@ -6,13 +6,12 @@
  */
 package org.hibernate.orm.test.property;
 
-import org.hibernate.boot.MetadataSources;
-
-import org.hibernate.testing.bytecode.enhancement.BytecodeEnhancerRunner;
 import org.hibernate.testing.bytecode.enhancement.EnhancementOptions;
-import org.hibernate.testing.junit4.BaseNonConfigCoreFunctionalTestCase;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.hibernate.testing.bytecode.enhancement.extension.BytecodeEnhanced;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.junit.jupiter.api.Test;
 
 import jakarta.persistence.Basic;
 import jakarta.persistence.Entity;
@@ -22,18 +21,19 @@ import jakarta.persistence.Table;
 /**
  * @author Steve Ebersole
  */
-@RunWith(BytecodeEnhancerRunner.class)
+@DomainModel(
+		annotatedClasses = {
+			FieldMappingWithGetterAndIsTest2.Tester.class
+		}
+)
+@SessionFactory
+@BytecodeEnhanced(testEnhancedClasses = FieldMappingWithGetterAndIsTest2.Tester.class)
 @EnhancementOptions( inlineDirtyChecking = true, lazyLoading = true )
-public class FieldMappingWithGetterAndIsTest2 extends BaseNonConfigCoreFunctionalTestCase {
-	@Override
-	protected void applyMetadataSources(MetadataSources sources) {
-		super.applyMetadataSources( sources );
-		sources.addAnnotatedClass( Tester.class );
-	}
+public class FieldMappingWithGetterAndIsTest2 {
 
 	@Test
-	public void testResolution() {
-		sessionFactory();
+	public void testResolution(SessionFactoryScope scope) {
+		scope.getSessionFactory();
 	}
 
 	@Entity(name="Tester")

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/proxy/MissingSetterWithEnhancementTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/proxy/MissingSetterWithEnhancementTest.java
@@ -18,27 +18,26 @@ import org.hibernate.cfg.Environment;
 import org.hibernate.service.ServiceRegistry;
 
 import org.hibernate.testing.ServiceRegistryBuilder;
-import org.hibernate.testing.TestForIssue;
-import org.hibernate.testing.bytecode.enhancement.BytecodeEnhancerRunner;
+import org.hibernate.testing.bytecode.enhancement.extension.BytecodeEnhanced;
+import org.hibernate.testing.orm.junit.JiraKey;
 import org.hibernate.testing.util.ServiceRegistryUtil;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  *
  * @author Christian Beikov
  */
-@TestForIssue(jiraKey = "HHH-14460")
-@RunWith( BytecodeEnhancerRunner.class )
+@JiraKey("HHH-14460")
+@BytecodeEnhanced
 public class MissingSetterWithEnhancementTest {
     private ServiceRegistry serviceRegistry;
 
-    @Before
+    @BeforeEach
     public void setUp() {
 		final BootstrapServiceRegistryBuilder builder = new BootstrapServiceRegistryBuilder();
 		builder.applyClassLoader( getClass().getClassLoader() );
@@ -47,7 +46,7 @@ public class MissingSetterWithEnhancementTest {
 				.build();
     }
 
-    @After
+    @AfterEach
     public void tearDown() {
         if ( serviceRegistry != null ) {
             ServiceRegistryBuilder.destroy( serviceRegistry );

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/serialization/CacheKeyEmbeddedIdEnanchedTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/serialization/CacheKeyEmbeddedIdEnanchedTest.java
@@ -5,64 +5,68 @@ import java.io.ByteArrayOutputStream;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.io.Serializable;
-import java.util.Map;
 
 import org.hibernate.Session;
 import org.hibernate.cache.internal.DefaultCacheKeysFactory;
 import org.hibernate.cache.internal.SimpleCacheKeysFactory;
 import org.hibernate.cache.spi.CacheKeysFactory;
 import org.hibernate.cfg.Environment;
+import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.orm.test.serialization.entity.BuildRecord;
 import org.hibernate.orm.test.serialization.entity.BuildRecordId;
 import org.hibernate.persister.entity.EntityPersister;
 
-import org.hibernate.testing.TestForIssue;
-import org.hibernate.testing.bytecode.enhancement.BytecodeEnhancerRunner;
 import org.hibernate.testing.bytecode.enhancement.EnhancementOptions;
-import org.hibernate.testing.cache.CachingRegionFactory;
-import org.hibernate.testing.junit4.BaseNonConfigCoreFunctionalTestCase;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.hibernate.testing.bytecode.enhancement.extension.BytecodeEnhanced;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.JiraKey;
+import org.hibernate.testing.orm.junit.ServiceRegistry;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.hibernate.testing.orm.junit.Setting;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@RunWith(BytecodeEnhancerRunner.class)
+@DomainModel(
+		annotatedClasses = {
+				BuildRecord.class
+		}
+)
+@ServiceRegistry(
+		settings = {
+				@Setting( name = Environment.USE_SECOND_LEVEL_CACHE, value = "true"),
+				@Setting( name = Environment.CACHE_REGION_FACTORY, value = "org.hibernate.testing.cache.CachingRegionFactory" ),
+				@Setting( name = Environment.DEFAULT_CACHE_CONCURRENCY_STRATEGY, value = "transactional"),
+				@Setting( name = "javax.persistence.sharedCache.mode", value = "ALL"),
+				@Setting( name = Environment.CACHE_KEYS_FACTORY, value = "org.hibernate.cache.internal.DefaultCacheKeysFactory" ),
+		}
+)
+@SessionFactory
+@BytecodeEnhanced
 @EnhancementOptions(lazyLoading = true, inlineDirtyChecking = true)
-@TestForIssue( jiraKey = "HHH-14843")
-public class CacheKeyEmbeddedIdEnanchedTest extends BaseNonConfigCoreFunctionalTestCase {
+@JiraKey("HHH-14843")
+public class CacheKeyEmbeddedIdEnanchedTest  {
 
-	@Override
-	protected void addSettings(Map settings) {
-		settings.put( Environment.USE_SECOND_LEVEL_CACHE, "true" );
-		settings.put( Environment.CACHE_REGION_FACTORY, CachingRegionFactory.class.getName() );
-		settings.put( Environment.DEFAULT_CACHE_CONCURRENCY_STRATEGY, "transactional" );
-		settings.put( "javax.persistence.sharedCache.mode", "ALL" );
-		settings.put( Environment.CACHE_KEYS_FACTORY, DefaultCacheKeysFactory.INSTANCE.getClass().getName() );
-	}
-
-	@Override
-	public Class<?>[] getAnnotatedClasses() {
-		return new Class<?>[] { BuildRecord.class };
+	@Test
+	public void testDefaultCacheKeysFactorySerialization(SessionFactoryScope scope) throws Exception {
+		testId( scope, DefaultCacheKeysFactory.INSTANCE, BuildRecord.class.getName(), new BuildRecordId( 2l ) );
 	}
 
 	@Test
-	public void testDefaultCacheKeysFactorySerialization() throws Exception {
-		testId( DefaultCacheKeysFactory.INSTANCE, BuildRecord.class.getName(), new BuildRecordId( 2l ) );
+	public void testSimpleCacheKeysFactorySerialization(SessionFactoryScope scope) throws Exception {
+		testId( scope, SimpleCacheKeysFactory.INSTANCE, BuildRecord.class.getName(), new BuildRecordId( 2l ) );
 	}
 
-	@Test
-	public void testSimpleCacheKeysFactorySerialization() throws Exception {
-		testId( SimpleCacheKeysFactory.INSTANCE, BuildRecord.class.getName(), new BuildRecordId( 2l ) );
-	}
-
-	private void testId(CacheKeysFactory cacheKeysFactory, String entityName, Object id) throws Exception {
-		final EntityPersister persister = sessionFactory().getMetamodel().entityPersister( entityName );
+	private void testId(SessionFactoryScope scope, CacheKeysFactory cacheKeysFactory, String entityName, Object id) throws Exception {
+		SessionFactoryImplementor sessionFactory = scope.getSessionFactory();
+		final EntityPersister persister = sessionFactory.getMetamodel().entityPersister( entityName );
 		final Object key = cacheKeysFactory.createEntityKey(
 				id,
 				persister,
-				sessionFactory(),
+				sessionFactory,
 				null
 		);
 
@@ -84,7 +88,7 @@ public class CacheKeyEmbeddedIdEnanchedTest extends BaseNonConfigCoreFunctionalT
 		}
 		else {
 			// DefaultCacheKeysFactory#getEntityId will return a disassembled version
-			try (Session session = sessionFactory().openSession()) {
+			try (Session session = sessionFactory.openSession()) {
 				idClone = persister.getIdentifierType().assemble(
 						(Serializable) cacheKeysFactory.getEntityId( keyClone ),
 						(SharedSessionContractImplementor) session,
@@ -96,7 +100,7 @@ public class CacheKeyEmbeddedIdEnanchedTest extends BaseNonConfigCoreFunctionalT
 		assertEquals( id.hashCode(), idClone.hashCode() );
 		assertEquals( id, idClone );
 		assertEquals( idClone, id );
-		assertTrue( persister.getIdentifierType().isEqual( id, idClone, sessionFactory() ) );
-		assertTrue( persister.getIdentifierType().isEqual( idClone, id, sessionFactory() ) );
+		assertTrue( persister.getIdentifierType().isEqual( id, idClone, sessionFactory ) );
+		assertTrue( persister.getIdentifierType().isEqual( idClone, id, sessionFactory ) );
 	}
 }

--- a/hibernate-core/src/test/java17/org/hibernate/orm/test/records/RecordAsEmbeddableEnhancementTest.java
+++ b/hibernate-core/src/test/java17/org/hibernate/orm/test/records/RecordAsEmbeddableEnhancementTest.java
@@ -10,12 +10,10 @@ package org.hibernate.orm.test.records;
 import org.hibernate.engine.spi.ManagedComposite;
 import org.hibernate.engine.spi.ManagedEntity;
 
-import org.hibernate.testing.bytecode.enhancement.BytecodeEnhancerRunner;
 import org.hibernate.testing.bytecode.enhancement.EnhancementOptions;
-import org.hibernate.testing.junit4.BaseCoreFunctionalTestCase;
 import org.hibernate.testing.orm.junit.JiraKey;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.junit.jupiter.api.Test;
 
 import jakarta.persistence.Embeddable;
 import jakarta.persistence.Embedded;
@@ -29,30 +27,29 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 @JiraKey( "HHH-15072" )
-@RunWith( BytecodeEnhancerRunner.class )
+@DomainModel(
+		annotatedClasses = {
+				RecordAsEmbeddableEnhancementTest.MyEntity.class
+		}
+)
+@SessionFactory
+@BytecodeEnhanced
 @EnhancementOptions(lazyLoading = true, extendedEnhancement = true, inlineDirtyChecking = true)
-public class RecordAsEmbeddableEnhancementTest extends BaseCoreFunctionalTestCase {
-
-	@Override
-	public Class<?>[] getAnnotatedClasses() {
-		return new Class<?>[] { MyEntity.class };
-	}
+public class RecordAsEmbeddableEnhancementTest {
 
 	@Test
-	public void test() {
+	public void test(SessionFactoryScope scope) {
 		// Ensure entity is enhanced, but not the record class
 		assertTrue( ManagedEntity.class.isAssignableFrom( MyEntity.class ) );
 		assertFalse( ManagedComposite.class.isAssignableFrom( MyRecord.class ) );
 
-		doInHibernate(
-				this::sessionFactory,
+		scope.inTransaction(
 				session -> {
 					session.persist( new MyEntity( 1L, new MyRecord( "test", "abc" ) ) );
 				}
 		);
 
-		doInHibernate(
-				this::sessionFactory,
+		scope.inTransaction(
 				session -> {
 					MyEntity myEntity = session.get( MyEntity.class, 1L );
 					assertNotNull( myEntity );

--- a/hibernate-testing/hibernate-testing.gradle
+++ b/hibernate-testing/hibernate-testing.gradle
@@ -43,6 +43,8 @@ dependencies {
     implementation libs.hcann
     implementation libs.jandex
     implementation testLibs.wildFlyTxnClient
+    implementation testLibs.junit5Engine
+    implementation testLibs.junit5Launcher
 
     annotationProcessor project( ':hibernate-jpamodelgen' )
 }

--- a/hibernate-testing/src/main/java/org/hibernate/testing/bytecode/enhancement/extension/BytecodeEnhanced.java
+++ b/hibernate-testing/src/main/java/org/hibernate/testing/bytecode/enhancement/extension/BytecodeEnhanced.java
@@ -1,0 +1,29 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html
+ */
+package org.hibernate.testing.bytecode.enhancement.extension;
+
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@Inherited
+@Retention(RetentionPolicy.RUNTIME)
+@ExtendWith(BytecodeEnhancementExtension.class)
+public @interface BytecodeEnhanced {
+	/**
+	 * If set to true, the test will be executed with and without bytecode enhancement within the same execution.
+	 */
+	boolean runNotEnhancedAsWell() default false;
+
+	/**
+	 * Entity classes will be checked whether they were enhanced or not depending on the context the test is executed in.
+	 * Enhancement check simply verifies that the class has any methods starting with {@code $$_hibernate_}
+	 */
+	Class<?>[] testEnhancedClasses() default {};
+}

--- a/hibernate-testing/src/main/java/org/hibernate/testing/bytecode/enhancement/extension/BytecodeEnhancementExtension.java
+++ b/hibernate-testing/src/main/java/org/hibernate/testing/bytecode/enhancement/extension/BytecodeEnhancementExtension.java
@@ -1,0 +1,31 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html
+ */
+package org.hibernate.testing.bytecode.enhancement.extension;
+
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.TestInstanceFactoryContext;
+import org.junit.jupiter.api.extension.TestInstancePreConstructCallback;
+import org.junit.jupiter.api.extension.TestInstancePreDestroyCallback;
+
+public class BytecodeEnhancementExtension implements TestInstancePreConstructCallback, TestInstancePreDestroyCallback {
+
+	private ClassLoader originalClassLoader;
+
+	@Override
+	public void preConstructTestInstance(TestInstanceFactoryContext testInstanceFactoryContext,
+			ExtensionContext extensionContext) {
+		originalClassLoader = Thread.currentThread().getContextClassLoader();
+		Thread.currentThread().setContextClassLoader( testInstanceFactoryContext.getTestClass().getClassLoader() );
+	}
+
+	@Override
+	public void preDestroyTestInstance(ExtensionContext extensionContext) {
+		Thread.currentThread().setContextClassLoader( originalClassLoader );
+	}
+
+
+}

--- a/hibernate-testing/src/main/java/org/hibernate/testing/bytecode/enhancement/extension/BytecodeEnhancementPostDiscoveryFilter.java
+++ b/hibernate-testing/src/main/java/org/hibernate/testing/bytecode/enhancement/extension/BytecodeEnhancementPostDiscoveryFilter.java
@@ -1,0 +1,43 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html
+ */
+package org.hibernate.testing.bytecode.enhancement.extension;
+
+
+import static org.junit.platform.commons.util.AnnotationUtils.isAnnotated;
+
+import org.hibernate.testing.bytecode.enhancement.extension.engine.BytecodeEnhancedEngineDescriptor;
+import org.junit.jupiter.engine.descriptor.ClassBasedTestDescriptor;
+import org.junit.platform.engine.FilterResult;
+import org.junit.platform.engine.TestDescriptor;
+
+public class BytecodeEnhancementPostDiscoveryFilter implements org.junit.platform.launcher.PostDiscoveryFilter {
+	@Override
+	public FilterResult apply(TestDescriptor testDescriptor) {
+		if ( testDescriptor instanceof ClassBasedTestDescriptor ) {
+			ClassBasedTestDescriptor descriptor = (ClassBasedTestDescriptor) testDescriptor;
+
+			TestDescriptor root = testDescriptor;
+			while ( !root.isRoot() ) {
+				root = root.getParent().get();
+			}
+
+			boolean isEnhanced = isAnnotated( descriptor.getTestClass(), BytecodeEnhanced.class );
+			if ( root instanceof BytecodeEnhancedEngineDescriptor ) {
+				if ( !isEnhanced ) {
+					return FilterResult.excluded( "Not bytecode enhanced." );
+				}
+			}
+			else {
+				if ( isEnhanced ) {
+					testDescriptor.removeFromHierarchy();
+					return FilterResult.excluded( "Not bytecode enhanced." );
+				}
+			}
+		}
+		return FilterResult.included( "Ok." );
+	}
+}

--- a/hibernate-testing/src/main/java/org/hibernate/testing/bytecode/enhancement/extension/engine/BytecodeEnhancedClassUtils.java
+++ b/hibernate-testing/src/main/java/org/hibernate/testing/bytecode/enhancement/extension/engine/BytecodeEnhancedClassUtils.java
@@ -1,0 +1,243 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html
+ */
+package org.hibernate.testing.bytecode.enhancement.extension.engine;
+
+import static org.hibernate.bytecode.internal.BytecodeProviderInitiator.buildDefaultBytecodeProvider;
+
+import java.io.BufferedInputStream;
+import java.io.File;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Consumer;
+
+import org.hibernate.bytecode.enhance.spi.EnhancementContext;
+import org.hibernate.bytecode.enhance.spi.Enhancer;
+import org.hibernate.bytecode.enhance.spi.UnloadedClass;
+import org.hibernate.bytecode.enhance.spi.UnloadedField;
+
+import org.hibernate.testing.bytecode.enhancement.ClassEnhancementSelector;
+import org.hibernate.testing.bytecode.enhancement.ClassEnhancementSelectors;
+import org.hibernate.testing.bytecode.enhancement.ClassSelector;
+import org.hibernate.testing.bytecode.enhancement.CustomEnhancementContext;
+import org.hibernate.testing.bytecode.enhancement.EnhancementOptions;
+import org.hibernate.testing.bytecode.enhancement.EnhancementSelector;
+import org.hibernate.testing.bytecode.enhancement.EnhancerTestContext;
+import org.hibernate.testing.bytecode.enhancement.ImplEnhancementSelector;
+import org.hibernate.testing.bytecode.enhancement.ImplEnhancementSelectors;
+import org.hibernate.testing.bytecode.enhancement.PackageEnhancementSelector;
+import org.hibernate.testing.bytecode.enhancement.PackageEnhancementSelectors;
+import org.hibernate.testing.bytecode.enhancement.PackageSelector;
+
+final class BytecodeEnhancedClassUtils {
+	private BytecodeEnhancedClassUtils() {
+	}
+
+	static Map<Object, Class<?>> enhanceTestClass(Class<?> klass) throws ClassNotFoundException {
+		String packageName = klass.getPackage().getName();
+		Map<Object, Class<?>> classes = new LinkedHashMap<>();
+
+		try {
+			if ( klass.isAnnotationPresent( EnhancementOptions.class )
+					|| klass.isAnnotationPresent( ClassEnhancementSelector.class )
+					|| klass.isAnnotationPresent( ClassEnhancementSelectors.class )
+					|| klass.isAnnotationPresent( PackageEnhancementSelector.class )
+					|| klass.isAnnotationPresent( PackageEnhancementSelectors.class )
+					|| klass.isAnnotationPresent( ImplEnhancementSelector.class )
+					|| klass.isAnnotationPresent( ImplEnhancementSelectors.class ) ) {
+				classes.put( "-", buildEnhancerClassLoader( klass ).loadClass( klass.getName() ) );
+			}
+			else if ( klass.isAnnotationPresent( CustomEnhancementContext.class ) ) {
+				for ( Class<? extends EnhancementContext> contextClass : klass.getAnnotation( CustomEnhancementContext.class )
+						.value() ) {
+					EnhancementContext enhancementContextInstance = contextClass.getConstructor().newInstance();
+					classes.put( contextClass.getSimpleName(),
+							getEnhancerClassLoader( enhancementContextInstance, packageName ).loadClass( klass.getName() ) );
+				}
+			}
+			else {
+				classes.put( "-", getEnhancerClassLoader( new EnhancerTestContext(), packageName ).loadClass( klass.getName() ) );
+			}
+		}
+		catch (IllegalAccessException | InstantiationException | NoSuchMethodException | InvocationTargetException e) {
+			// This is unlikely, but if happens throw runtime exception to fail the test
+			throw new RuntimeException( e );
+		}
+		return classes;
+	}
+
+	// --- //
+
+
+	private static ClassLoader buildEnhancerClassLoader(Class<?> klass) {
+		final EnhancementOptions options = klass.getAnnotation( EnhancementOptions.class );
+		final EnhancementContext enhancerContext;
+		if ( options == null ) {
+			enhancerContext = new EnhancerTestContext();
+		}
+		else {
+			enhancerContext = new EnhancerTestContext() {
+				@Override
+				public boolean doBiDirectionalAssociationManagement(UnloadedField field) {
+					return options.biDirectionalAssociationManagement() && super.doBiDirectionalAssociationManagement( field );
+				}
+
+				@Override
+				public boolean doDirtyCheckingInline(UnloadedClass classDescriptor) {
+					return options.inlineDirtyChecking() && super.doDirtyCheckingInline( classDescriptor );
+				}
+
+				@Override
+				public boolean doExtendedEnhancement(UnloadedClass classDescriptor) {
+					return options.extendedEnhancement() && super.doExtendedEnhancement( classDescriptor );
+				}
+
+				@Override
+				public boolean hasLazyLoadableAttributes(UnloadedClass classDescriptor) {
+					return options.lazyLoading() && super.hasLazyLoadableAttributes( classDescriptor );
+				}
+
+				@Override
+				public boolean isLazyLoadable(UnloadedField field) {
+					return options.lazyLoading() && super.isLazyLoadable( field );
+				}
+			};
+		}
+
+		final List<EnhancementSelector> selectors = new ArrayList<>();
+		selectors.add( new PackageSelector( klass.getPackage().getName() ) );
+		applySelectors(
+				klass,
+				ClassEnhancementSelector.class,
+				ClassEnhancementSelectors.class,
+				selectorAnnotation -> selectors.add( new ClassSelector( selectorAnnotation.value().getName() ) )
+		);
+		applySelectors(
+				klass,
+				PackageEnhancementSelector.class,
+				PackageEnhancementSelectors.class,
+				selectorAnnotation -> selectors.add( new PackageSelector( selectorAnnotation.value() ) )
+		);
+		applySelectors(
+				klass,
+				ImplEnhancementSelector.class,
+				ImplEnhancementSelectors.class,
+				selectorAnnotation -> {
+					try {
+						selectors.add( selectorAnnotation.impl().getDeclaredConstructor().newInstance() );
+					}
+					catch (RuntimeException re) {
+						throw re;
+					}
+					catch (Exception e) {
+						throw new RuntimeException( e );
+					}
+				}
+		);
+
+		return buildEnhancerClassLoader( enhancerContext, selectors );
+	}
+
+	private static <A extends Annotation> void applySelectors(
+			Class<?> klass,
+			Class<A> selectorAnnotationType,
+			Class<? extends Annotation> selectorsAnnotationType,
+			Consumer<A> action) {
+		final A selectorAnnotation = klass.getAnnotation( selectorAnnotationType );
+		final Annotation selectorsAnnotation = klass.getAnnotation( selectorsAnnotationType );
+
+		if ( selectorAnnotation != null ) {
+			action.accept( selectorAnnotation );
+		}
+		else if ( selectorsAnnotation != null ) {
+			try {
+				final Method valuesMethod = selectorsAnnotationType.getDeclaredMethods()[0];
+				@SuppressWarnings("unchecked")
+				final A[] selectorAnnotations = (A[]) valuesMethod.invoke( selectorsAnnotation );
+				for ( A groupedSelectorAnnotation : selectorAnnotations ) {
+					action.accept( groupedSelectorAnnotation );
+				}
+
+			}
+			catch (Exception e) {
+				throw new RuntimeException( e );
+			}
+		}
+	}
+
+	private static ClassLoader buildEnhancerClassLoader(
+			EnhancementContext enhancerContext,
+			List<EnhancementSelector> selectors) {
+		return new EnhancingClassLoader(
+				buildDefaultBytecodeProvider().getEnhancer( enhancerContext ),
+				selectors
+		);
+	}
+
+	private static class EnhancingClassLoader extends ClassLoader {
+		private final Enhancer enhancer;
+		private final List<EnhancementSelector> selectors;
+
+		public EnhancingClassLoader(Enhancer enhancer, List<EnhancementSelector> selectors) {
+			this.enhancer = enhancer;
+			this.selectors = selectors;
+		}
+
+		@Override
+		public Class<?> loadClass(String name) throws ClassNotFoundException {
+			for ( EnhancementSelector selector : selectors ) {
+				if ( selector.select( name ) ) {
+					final Class<?> c = findLoadedClass( name );
+					if ( c != null ) {
+						return c;
+					}
+
+					try ( InputStream is = getResourceAsStream( name.replace( '.', '/' ) + ".class" ) ) {
+						if ( is == null ) {
+							throw new ClassNotFoundException( name + " not found" );
+						}
+
+						byte[] original = new byte[is.available()];
+						try ( BufferedInputStream bis = new BufferedInputStream( is ) ) {
+							bis.read( original );
+						}
+
+						byte[] enhanced = enhancer.enhance( name, original );
+						if ( enhanced == null ) {
+							return defineClass( name, original, 0, original.length );
+						}
+						Path f = Files.createTempDirectory( "" ).getParent()
+								.resolve( name.replace( ".", File.separator ) + ".class" );
+						Files.createDirectories( f.getParent() );
+						try ( OutputStream out = Files.newOutputStream( f ) ) {
+							out.write( enhanced );
+						}
+						return defineClass( name, enhanced, 0, enhanced.length );
+					}
+					catch (Exception t) {
+						throw new ClassNotFoundException( name + " not found", t );
+					}
+				}
+			}
+
+			return getParent().loadClass( name );
+		}
+	}
+
+	private static ClassLoader getEnhancerClassLoader(EnhancementContext context, String packageName) {
+		return buildEnhancerClassLoader( context, Collections.singletonList( new PackageSelector( packageName ) ) );
+	}
+}

--- a/hibernate-testing/src/main/java/org/hibernate/testing/bytecode/enhancement/extension/engine/BytecodeEnhancedEngineDescriptor.java
+++ b/hibernate-testing/src/main/java/org/hibernate/testing/bytecode/enhancement/extension/engine/BytecodeEnhancedEngineDescriptor.java
@@ -1,0 +1,17 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html
+ */
+package org.hibernate.testing.bytecode.enhancement.extension.engine;
+
+import org.junit.jupiter.engine.config.JupiterConfiguration;
+import org.junit.jupiter.engine.descriptor.JupiterEngineDescriptor;
+import org.junit.platform.engine.UniqueId;
+
+public class BytecodeEnhancedEngineDescriptor extends JupiterEngineDescriptor {
+	public BytecodeEnhancedEngineDescriptor(UniqueId uniqueId, JupiterConfiguration configuration) {
+		super( uniqueId, configuration );
+	}
+}

--- a/hibernate-testing/src/main/java/org/hibernate/testing/bytecode/enhancement/extension/engine/BytecodeEnhancedTestEngine.java
+++ b/hibernate-testing/src/main/java/org/hibernate/testing/bytecode/enhancement/extension/engine/BytecodeEnhancedTestEngine.java
@@ -1,0 +1,437 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html
+ */
+package org.hibernate.testing.bytecode.enhancement.extension.engine;
+
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hibernate.testing.bytecode.enhancement.extension.engine.BytecodeEnhancedClassUtils.enhanceTestClass;
+import static org.junit.platform.commons.util.AnnotationUtils.findAnnotation;
+
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import java.util.function.Supplier;
+
+import org.hibernate.testing.bytecode.enhancement.extension.BytecodeEnhanced;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.ClassOrderer;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.extension.ExecutionCondition;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.io.CleanupMode;
+import org.junit.jupiter.api.io.TempDirFactory;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.junit.jupiter.engine.config.CachingJupiterConfiguration;
+import org.junit.jupiter.engine.config.DefaultJupiterConfiguration;
+import org.junit.jupiter.engine.config.JupiterConfiguration;
+import org.junit.jupiter.engine.descriptor.ClassBasedTestDescriptor;
+import org.junit.jupiter.engine.descriptor.ClassTestDescriptor;
+import org.junit.jupiter.engine.descriptor.JupiterEngineDescriptor;
+import org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor;
+import org.junit.jupiter.engine.descriptor.TestTemplateTestDescriptor;
+import org.junit.jupiter.engine.discovery.DiscoverySelectorResolver;
+import org.junit.jupiter.engine.execution.JupiterEngineExecutionContext;
+import org.junit.platform.engine.EngineDiscoveryRequest;
+import org.junit.platform.engine.ExecutionRequest;
+import org.junit.platform.engine.TestDescriptor;
+import org.junit.platform.engine.UniqueId;
+import org.junit.platform.engine.support.hierarchical.EngineExecutionContext;
+import org.junit.platform.engine.support.hierarchical.HierarchicalTestEngine;
+import org.junit.platform.engine.support.hierarchical.ThrowableCollector;
+
+public class BytecodeEnhancedTestEngine extends HierarchicalTestEngine<JupiterEngineExecutionContext> {
+
+	@Override
+	public String getId() {
+		return "bytecode-enhanced-engine";
+	}
+
+	@Override
+	public TestDescriptor discover(EngineDiscoveryRequest discoveryRequest, UniqueId uniqueId) {
+		JupiterConfiguration configuration = new CachingJupiterConfiguration(
+				new DefaultJupiterConfiguration( discoveryRequest.getConfigurationParameters() ) );
+		JupiterEngineDescriptor engineDescriptor = new BytecodeEnhancedEngineDescriptor( uniqueId, configuration );
+		new DiscoverySelectorResolver().resolveSelectors( discoveryRequest, engineDescriptor );
+
+		for ( TestDescriptor testDescriptor : new HashSet<>( engineDescriptor.getChildren() ) ) {
+			if ( testDescriptor instanceof ClassBasedTestDescriptor ) {
+				try {
+					ClassBasedTestDescriptor descriptor = (ClassBasedTestDescriptor) testDescriptor;
+					// if the test class is annotated with @BytecodeEnhanced
+					// we replace the descriptor with the new one that will point to an enhanced test class,
+					// this also means that we need to add all the child descriptors back as well...
+					// Then on the extension side we set the classloader that contains the enhanced test class
+					// and set it back to the original once the test class is destroyed.
+					Optional<BytecodeEnhanced> bytecodeEnhanced = findAnnotation(
+							descriptor.getTestClass(), BytecodeEnhanced.class );
+					if ( bytecodeEnhanced.isPresent() ) {
+						TestDescriptor parent = descriptor.getParent().orElseThrow( IllegalStateException::new );
+						Class<?> klass = descriptor.getTestClass();
+
+						JupiterConfiguration jc = ( (JupiterEngineDescriptor) parent ).getConfiguration();
+
+						String[] testEnhancedClasses = Arrays.stream( bytecodeEnhanced.get().testEnhancedClasses() )
+								.map( Class::getName ).toArray( String[]::new );
+
+						// NOTE: get children before potentially removing from hierarchy, since after that there will be none.
+						Set<? extends TestDescriptor> children = new HashSet<>( descriptor.getChildren() );
+						if ( !bytecodeEnhanced.get().runNotEnhancedAsWell() ) {
+							descriptor.removeFromHierarchy();
+						}
+
+						Map<Object, Class<?>> classes = enhanceTestClass( klass );
+						if ( classes.size() == 1 ) {
+							replaceWithEnhanced( classes.values().iterator().next(), descriptor, jc, children, parent, testEnhancedClasses );
+						}
+						else {
+							for ( Map.Entry<Object, Class<?>> entry : classes.entrySet() ) {
+								replaceWithEnhanced(
+										entry.getValue(), descriptor, jc, children, parent, testEnhancedClasses, entry.getKey() );
+							}
+						}
+
+						addEnhancementCheck( false, testEnhancedClasses, descriptor, jc );
+					}
+					else {
+						testDescriptor.removeFromHierarchy();
+					}
+				}
+				catch (ClassNotFoundException | NoSuchMethodException e) {
+					throw new RuntimeException( e );
+				}
+			}
+		}
+
+		return engineDescriptor;
+	}
+
+	private void addEnhancementCheck(boolean enhance, String[] testEnhancedClasses,
+			ClassBasedTestDescriptor descriptor, JupiterConfiguration jc) {
+		if ( testEnhancedClasses.length > 0 ) {
+			descriptor.addChild( new EnhancementWorkedCheckMethodTestDescriptor(
+					UniqueId.forEngine( getId() )
+							.append(
+									ClassTestDescriptor.SEGMENT_TYPE,
+									descriptor.getTestClass().getName()
+							),
+					descriptor.getTestClass(),
+					jc,
+					enhance,
+					testEnhancedClasses
+			) );
+		}
+	}
+
+	private void replaceWithEnhanced(Class<?> enhanced, ClassBasedTestDescriptor descriptor, JupiterConfiguration jc,
+			Set<? extends TestDescriptor> children, TestDescriptor parent, String[] testEnhancedClasses)
+			throws NoSuchMethodException {
+		replaceWithEnhanced( enhanced, descriptor, jc, children, parent, testEnhancedClasses, null );
+	}
+
+	private void replaceWithEnhanced(Class<?> enhanced, ClassBasedTestDescriptor descriptor, JupiterConfiguration jc,
+			Set<? extends TestDescriptor> children, TestDescriptor parent, String[] testEnhancedClasses,
+			Object enhancementContextId)
+			throws NoSuchMethodException {
+		DelegatingJupiterConfiguration configuration = new DelegatingJupiterConfiguration( jc, enhancementContextId );
+
+		ClassTestDescriptor updated = new ClassTestDescriptor(
+				convertUniqueId( descriptor.getUniqueId(), enhancementContextId ),
+				enhanced,
+				configuration
+		);
+
+		for ( TestDescriptor child : children ) {
+			// this needs more cases for parameterized tests, test templates and so on ...
+			// for now it'll only work with simple @Test tests
+			if ( child instanceof TestMethodTestDescriptor ) {
+				Method testMethod = ( (TestMethodTestDescriptor) child ).getTestMethod();
+				updated.addChild(
+						new TestMethodTestDescriptor(
+								convertUniqueId( child.getUniqueId(), enhancementContextId ),
+								updated.getTestClass(),
+								findMethodReplacement( updated, testMethod ),
+								configuration
+						)
+				);
+
+			}
+			if ( child instanceof TestTemplateTestDescriptor ) {
+				Method testMethod = ( (TestTemplateTestDescriptor) child ).getTestMethod();
+				updated.addChild( new TestTemplateTestDescriptor(
+						convertUniqueId( child.getUniqueId(), enhancementContextId ),
+						updated.getTestClass(),
+						findMethodReplacement( updated, testMethod ),
+						configuration
+				) );
+			}
+		}
+		addEnhancementCheck( true, testEnhancedClasses, updated, configuration );
+		parent.addChild( updated );
+	}
+
+	private UniqueId convertUniqueId(UniqueId id, Object enhancementContextId) {
+		UniqueId uniqueId = UniqueId.forEngine( getId() )
+				.append( "Enhanced", enhancementContextId == null ? "true" : Objects.toString( enhancementContextId ) );
+
+		List<UniqueId.Segment> segments = id.getSegments();
+		for ( int i = 1; i < segments.size(); i++ ) {
+			UniqueId.Segment segment = segments.get( i );
+			uniqueId = uniqueId.append( segment );
+		}
+		return uniqueId;
+	}
+
+	private Method findMethodReplacement(ClassTestDescriptor updated, Method testMethod) throws NoSuchMethodException {
+		String name = testMethod.getDeclaringClass().getName();
+
+		Class<?> testClass = updated.getTestClass();
+		while ( !testClass.getName().equals( name ) ) {
+			testClass = testClass.getSuperclass();
+			if ( Object.class.equals( testClass ) ) {
+				throw new IllegalStateException( "Wasn't able to find a test method " + testMethod );
+			}
+		}
+		return testClass.getDeclaredMethod(
+				testMethod.getName(),
+				testMethod.getParameterTypes()
+		);
+	}
+
+	@Override
+	protected JupiterEngineExecutionContext createExecutionContext(ExecutionRequest request) {
+		return new JupiterEngineExecutionContext(
+				request.getEngineExecutionListener(),
+				this.getJupiterConfiguration( request )
+		);
+	}
+
+	private JupiterConfiguration getJupiterConfiguration(ExecutionRequest request) {
+		JupiterEngineDescriptor engineDescriptor = (JupiterEngineDescriptor) request.getRootTestDescriptor();
+		return engineDescriptor.getConfiguration();
+	}
+
+	public Optional<String> getGroupId() {
+		return Optional.of( "org.junit.jupiter" );
+	}
+
+	public Optional<String> getArtifactId() {
+		return Optional.of( "junit-jupiter-engine" );
+	}
+
+	public static class Context implements EngineExecutionContext {
+		private final ExecutionRequest request;
+
+		public Context(ExecutionRequest request) {
+			this.request = request;
+		}
+	}
+
+	private static class DelegatingJupiterConfiguration implements JupiterConfiguration {
+		private final JupiterConfiguration configuration;
+		private final DelegatingDisplayNameGenerator displayNameGenerator;
+
+		private DelegatingJupiterConfiguration(JupiterConfiguration configuration, Object id) {
+			this.configuration = configuration;
+			displayNameGenerator = new DelegatingDisplayNameGenerator(
+					configuration.getDefaultDisplayNameGenerator(),
+					id
+			);
+		}
+
+		@Override
+		public Optional<String> getRawConfigurationParameter(String s) {
+			return configuration.getRawConfigurationParameter( s );
+		}
+
+		@Override
+		public <T> Optional<T> getRawConfigurationParameter(String s, Function<String, T> function) {
+			return configuration.getRawConfigurationParameter( s, function );
+		}
+
+		@Override
+		public boolean isParallelExecutionEnabled() {
+			return configuration.isParallelExecutionEnabled();
+		}
+
+		@Override
+		public boolean isExtensionAutoDetectionEnabled() {
+			return configuration.isExtensionAutoDetectionEnabled();
+		}
+
+		@Override
+		public ExecutionMode getDefaultExecutionMode() {
+			return configuration.getDefaultExecutionMode();
+		}
+
+		@Override
+		public ExecutionMode getDefaultClassesExecutionMode() {
+			return configuration.getDefaultClassesExecutionMode();
+		}
+
+		@Override
+		public TestInstance.Lifecycle getDefaultTestInstanceLifecycle() {
+			return configuration.getDefaultTestInstanceLifecycle();
+		}
+
+		@Override
+		public Predicate<ExecutionCondition> getExecutionConditionFilter() {
+			return configuration.getExecutionConditionFilter();
+		}
+
+		@Override
+		public DisplayNameGenerator getDefaultDisplayNameGenerator() {
+			return displayNameGenerator;
+		}
+
+		@Override
+		public Optional<MethodOrderer> getDefaultTestMethodOrderer() {
+			return configuration.getDefaultTestMethodOrderer();
+		}
+
+		@Override
+		public Optional<ClassOrderer> getDefaultTestClassOrderer() {
+			return configuration.getDefaultTestClassOrderer();
+		}
+
+		@Override
+		public CleanupMode getDefaultTempDirCleanupMode() {
+			return configuration.getDefaultTempDirCleanupMode();
+		}
+
+		@Override
+		public Supplier<TempDirFactory> getDefaultTempDirFactorySupplier() {
+			return configuration.getDefaultTempDirFactorySupplier();
+		}
+	}
+
+	private static class DelegatingDisplayNameGenerator implements DisplayNameGenerator {
+
+		private final DisplayNameGenerator delegate;
+		private final Object id;
+
+		private DelegatingDisplayNameGenerator(DisplayNameGenerator delegate, Object id) {
+			this.delegate = delegate;
+			this.id = id;
+		}
+
+		@Override
+		public String generateDisplayNameForClass(Class<?> aClass) {
+			return prefix() + delegate.generateDisplayNameForClass( aClass );
+		}
+
+		private String prefix() {
+			return "Enhanced" + ( id == null ? "" : "[" + id + "]" ) + ":";
+		}
+
+		@Override
+		public String generateDisplayNameForNestedClass(Class<?> aClass) {
+			return prefix() + delegate.generateDisplayNameForNestedClass( aClass );
+		}
+
+		@Override
+		public String generateDisplayNameForMethod(Class<?> aClass, Method method) {
+			return prefix() + delegate.generateDisplayNameForMethod( aClass, method );
+		}
+	}
+
+	private static class EnhancementWorkedCheckMethodTestDescriptor extends TestMethodTestDescriptor {
+
+		private final boolean enhanced;
+		private final String[] classes;
+
+		public EnhancementWorkedCheckMethodTestDescriptor(UniqueId uniqueId, Class<?> testClass,
+				JupiterConfiguration configuration,
+				boolean enhanced, String[] classes) {
+			super(
+					prepareId( uniqueId, testMethod( enhanced ) ),
+					testClass, testMethod( enhanced ),
+					configuration
+			);
+			this.enhanced = enhanced;
+			this.classes = classes;
+		}
+
+		private static Method testMethod(boolean enhanced) {
+			return enhanced ? METHOD_ENHANCED : METHOD_NOT_ENHANCED;
+		}
+
+		@Override
+		public JupiterEngineExecutionContext execute(JupiterEngineExecutionContext context,
+				DynamicTestExecutor dynamicTestExecutor) {
+			ExtensionContext extensionContext = context.getExtensionContext();
+			ThrowableCollector throwableCollector = context.getThrowableCollector();
+
+			throwableCollector.execute( () -> {
+				Object instance = extensionContext.getRequiredTestInstance();
+				for ( String className : classes ) {
+					assertEnhancementWorked( className, enhanced, instance );
+				}
+			} );
+
+			return context;
+		}
+
+		private static final Method METHOD_ENHANCED;
+		private static final Method METHOD_NOT_ENHANCED;
+
+		static {
+			try {
+				METHOD_ENHANCED = EnhancementWorkedCheckMethodTestDescriptor.class.getDeclaredMethod(
+						"assertEntityClassesWereEnhanced" );
+				METHOD_NOT_ENHANCED = EnhancementWorkedCheckMethodTestDescriptor.class.getDeclaredMethod(
+						"assertEntityClassesWereNotEnhanced" );
+			}
+			catch (NoSuchMethodException e) {
+				throw new RuntimeException( e );
+			}
+		}
+
+		private static void assertEntityClassesWereEnhanced() {
+			// just for JUint to display the name
+		}
+
+		private static void assertEntityClassesWereNotEnhanced() {
+			// just for JUint to display the name
+		}
+
+		private static void assertEnhancementWorked(String className, boolean enhanced, Object testClassInstance) {
+			try {
+				Class<?> loaded = testClassInstance.getClass().getClassLoader().loadClass( className );
+				if ( enhanced ) {
+					assertThat( loaded.getDeclaredMethods() )
+							.extracting( Method::getName )
+							.anyMatch( name -> name.startsWith( "$$_hibernate_" ) );
+				}
+				else {
+					assertThat( loaded.getDeclaredMethods() )
+							.extracting( Method::getName )
+							.noneMatch( name -> name.startsWith( "$$_hibernate_" ) );
+				}
+			}
+
+			catch (ClassNotFoundException e) {
+				Assertions.fail( e.getMessage() );
+			}
+		}
+
+		private static UniqueId prepareId(UniqueId uniqueId, Method method) {
+			return uniqueId.append(
+					TestMethodTestDescriptor.SEGMENT_TYPE,
+					method.getName()
+			);
+		}
+	}
+}

--- a/hibernate-testing/src/main/java/org/hibernate/testing/orm/junit/DialectFeatureChecks.java
+++ b/hibernate-testing/src/main/java/org/hibernate/testing/orm/junit/DialectFeatureChecks.java
@@ -691,4 +691,11 @@ abstract public class DialectFeatureChecks {
 			return dialect.supportsCaseInsensitiveLike();
 		}
 	}
+
+	public static class SupportsNClob implements DialectFeatureCheck {
+		@Override
+		public boolean apply(Dialect dialect) {
+			return dialect.getNationalizationSupport() == NationalizationSupport.EXPLICIT;
+		}
+	}
 }

--- a/hibernate-testing/src/main/java/org/hibernate/testing/orm/junit/ServiceRegistryExtension.java
+++ b/hibernate-testing/src/main/java/org/hibernate/testing/orm/junit/ServiceRegistryExtension.java
@@ -334,6 +334,7 @@ public class ServiceRegistryExtension
 
 		private StandardServiceRegistry createRegistry() {
 			BootstrapServiceRegistryBuilder bsrb = new BootstrapServiceRegistryBuilder().enableAutoClose();
+			bsrb.applyClassLoader( Thread.currentThread().getContextClassLoader() );
 			ssrProducer.prepareBootstrapRegistryBuilder(bsrb);
 
 			final org.hibernate.boot.registry.BootstrapServiceRegistry bsr = bsrProducer.produceServiceRegistry( bsrb );

--- a/hibernate-testing/src/main/java/org/hibernate/testing/orm/junit/SessionFactory.java
+++ b/hibernate-testing/src/main/java/org/hibernate/testing/orm/junit/SessionFactory.java
@@ -56,4 +56,6 @@ public @interface SessionFactory {
 	 * @see SQLStatementInspector
 	 */
 	boolean useCollectingStatementInspector() default false;
+
+	boolean applyCollectionsInDefaultFetchGroup() default true;
 }

--- a/hibernate-testing/src/main/java/org/hibernate/testing/orm/junit/SessionFactoryExtension.java
+++ b/hibernate-testing/src/main/java/org/hibernate/testing/orm/junit/SessionFactoryExtension.java
@@ -147,6 +147,7 @@ public class SessionFactoryExtension
 						else if ( ! explicitInspectorClass.equals( StatementInspector.class ) ) {
 							sessionFactoryBuilder.applyStatementInspector( explicitInspectorClass.getConstructor().newInstance() );
 						}
+						sessionFactoryBuilder.applyCollectionsInDefaultFetchGroup( sessionFactoryConfig.applyCollectionsInDefaultFetchGroup() );
 
 						final SessionFactoryImplementor sessionFactory = (SessionFactoryImplementor) sessionFactoryBuilder.build();
 

--- a/hibernate-testing/src/main/resources/META-INF/services/org.junit.platform.engine.TestEngine
+++ b/hibernate-testing/src/main/resources/META-INF/services/org.junit.platform.engine.TestEngine
@@ -1,0 +1,1 @@
+org.hibernate.testing.bytecode.enhancement.extension.engine.BytecodeEnhancedTestEngine

--- a/hibernate-testing/src/main/resources/META-INF/services/org.junit.platform.launcher.PostDiscoveryFilter
+++ b/hibernate-testing/src/main/resources/META-INF/services/org.junit.platform.launcher.PostDiscoveryFilter
@@ -1,0 +1,1 @@
+org.hibernate.testing.bytecode.enhancement.extension.BytecodeEnhancementPostDiscoveryFilter

--- a/settings.gradle
+++ b/settings.gradle
@@ -171,6 +171,7 @@ dependencyResolutionManagement {
         testLibs {
             def junit5Version = version "junit5", "5.9.2"
             def junit4Version = version "junit4", "4.13.2"
+            def junit5LauncherVersion = version "junit5Launcher", "1.10.2"
 
             def assertjVersion = version "assertj", "3.22.0"
             def bytemanVersion = version "byteman", "4.0.20"
@@ -191,6 +192,7 @@ dependencyResolutionManagement {
             library( "junit5Engine", "org.junit.jupiter", "junit-jupiter-engine" ).versionRef( junit5Version )
             library( "junit5Params", "org.junit.jupiter", "junit-jupiter-params" ).versionRef( junit5Version )
             library( "junit4Engine", "org.junit.vintage", "junit-vintage-engine" ).versionRef( junit5Version )
+            library( "junit5Launcher", "org.junit.platform", "junit-platform-launcher" ).versionRef( junit5LauncherVersion )
             library( "junit4", "junit", "junit" ).versionRef( junit4Version )
 
             library( "assertjCore", "org.assertj", "assertj-core" ).versionRef( assertjVersion )


### PR DESCRIPTION
Hey,

As per title 😃. This new "extension" allows to use bytecode enhancement with JUnit 5. There's an additional flag on that annotation `@BytecodeEnhanced(runNotEnhancedAsWell = true)` that allows to run such test both with enhancement and without in the same run:
![image](https://github.com/hibernate/hibernate-orm/assets/4004823/317a8a98-c799-48e6-811d-823636a04e4f)

I'm thinking that this way, we could put it on more classes than what we have now to cover more scenarios, adding bytecode enhancement to the mix. 