### PR TITLE
fix previous-page navigation with KeyedResultList

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/internal/AbstractSqmSelectionQuery.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/internal/AbstractSqmSelectionQuery.java
@@ -172,7 +172,7 @@ abstract class AbstractSqmSelectionQuery<R> extends AbstractSelectionQuery<R> {
 						.performList(this);
 
 		return new KeyedResultList<>(
-				collectResults( results, page.getSize() ),
+				collectResults( results, page.getSize(), keyedPage.getKeyInterpretation() ),
 				collectKeys( results, page.getSize() ),
 				keyedPage,
 				nextPage( keyedPage, results ),


### PR DESCRIPTION
It was returning the results in reverse order. This caused a failure in the Data TCK.