### PR TITLE
HHH-17935 Running query with "root" tenant leads to "HibernateException: Either value and resolver for filter [_tenantId] parameter [tenantId] not set"

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/binder/internal/TenantIdBinder.java
+++ b/hibernate-core/src/main/java/org/hibernate/binder/internal/TenantIdBinder.java
@@ -59,7 +59,7 @@ public class TenantIdBinder implements AttributeBinder<TenantId> {
 							"",
 							singletonMap( PARAMETER_NAME, tenantIdType ),
 							Collections.emptyMap(),
-							true
+							false
 					)
 			);
 		}


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-17935

Before this patch, the test would fail with an exception: `HibernateException: Either value and resolver for filter [_tenantId] parameter [tenantId] not set`