### PR TITLE
Add more type name alias mappings

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/tool/schema/internal/ColumnDefinitions.java
+++ b/hibernate-core/src/main/java/org/hibernate/tool/schema/internal/ColumnDefinitions.java
@@ -248,12 +248,18 @@ class ColumnDefinitions {
 		else {
 			final String lowerCaseTypName = typeName.toLowerCase(Locale.ROOT);
 			switch (lowerCaseTypName) {
+				case "int":
+					return "integer";
 				case "character":
 					return "char";
 				case "character varying":
 					return "varchar";
 				case "binary varying":
 					return "varbinary";
+				case "character large object":
+					return "clob";
+				case "binary large object":
+					return "blob";
 				case "interval second":
 					return "interval";
 				default:


### PR DESCRIPTION
1. MySQL returns `int` even `integer` is specified
2. H2 returns `character large object` and `binary large object` even `clob` and `blob` is specified