### PR TITLE
fix exceptions thrown from JD lifecycle method

### DIFF
--- a/tooling/metamodel-generator/src/main/java/org/hibernate/processor/annotation/AbstractQueryMethod.java
+++ b/tooling/metamodel-generator/src/main/java/org/hibernate/processor/annotation/AbstractQueryMethod.java
@@ -279,14 +279,14 @@ public abstract class AbstractQueryMethod extends AbstractAnnotatedMethod {
 						.append(" exception) {\n")
 						.append("\t\tthrow new ")
 						.append(annotationMetaEntity.importType("jakarta.data.exceptions.EmptyResultException"))
-						.append("(exception);\n")
+						.append("(exception.getMessage(), exception);\n")
 						.append("\t}\n")
 						.append("\tcatch (")
 						.append(annotationMetaEntity.importType("jakarta.persistence.NonUniqueResultException"))
 						.append(" exception) {\n")
 						.append("\t\tthrow new ")
 						.append(annotationMetaEntity.importType("jakarta.data.exceptions.NonUniqueResultException"))
-						.append("(exception);\n")
+						.append("(exception.getMessage(), exception);\n")
 						.append("\t}\n");
 			}
 			declaration
@@ -295,7 +295,7 @@ public abstract class AbstractQueryMethod extends AbstractAnnotatedMethod {
 					.append(" exception) {\n")
 					.append("\t\tthrow new ")
 					.append(annotationMetaEntity.importType("jakarta.data.exceptions.DataException"))
-					.append("(exception);\n")
+					.append("(exception.getMessage(), exception);\n")
 					.append("\t}\n");
 		}
 	}

--- a/tooling/metamodel-generator/src/main/java/org/hibernate/processor/annotation/IdFinderMethod.java
+++ b/tooling/metamodel-generator/src/main/java/org/hibernate/processor/annotation/IdFinderMethod.java
@@ -86,7 +86,11 @@ public class IdFinderMethod extends AbstractFinderMethod {
 				declaration
 						.append("\t\tif (_result == null) throw new ")
 						.append(annotationMetaEntity.importType("jakarta.data.exceptions.EmptyResultException"))
-						.append("(new ")
+						.append("(\"No '")
+						.append(annotationMetaEntity.importType(entity))
+						.append("' for given id [\" + ")
+						.append(paramName)
+						.append(" + \"]\",\n\t\t\t\tnew ")
 						.append(annotationMetaEntity.importType("org.hibernate.ObjectNotFoundException"))
 						.append("((Object) ")
 						.append(paramName)

--- a/tooling/metamodel-generator/src/main/java/org/hibernate/processor/annotation/LifecycleMethod.java
+++ b/tooling/metamodel-generator/src/main/java/org/hibernate/processor/annotation/LifecycleMethod.java
@@ -62,12 +62,12 @@ public class LifecycleMethod extends AbstractAnnotatedMethod {
 		declaration.append("\t}\n");
 		if ( operationName.equals("insert") ) {
 			convertException(declaration,
-					"jakarta.persistence.EntityExistsException",
+					"org.hibernate.exception.ConstraintViolationException",
 					"jakarta.data.exceptions.EntityExistsException");
 		}
 		else {
 			convertException(declaration,
-					"jakarta.persistence.OptimisticLockException",
+					"org.hibernate.StaleStateException",
 					"jakarta.data.exceptions.OptimisticLockingFailureException");
 		}
 		convertException(declaration,

--- a/tooling/metamodel-generator/src/main/java/org/hibernate/processor/annotation/LifecycleMethod.java
+++ b/tooling/metamodel-generator/src/main/java/org/hibernate/processor/annotation/LifecycleMethod.java
@@ -192,7 +192,7 @@ public class LifecycleMethod extends AbstractAnnotatedMethod {
 				.append(" exception) {\n")
 				.append("\t\tthrow new ")
 				.append(annotationMetaEntity.importType(convertedException))
-				.append("(exception);\n")
+				.append("(exception.getMessage(), exception);\n")
 				.append("\t}\n");
 	}
 


### PR DESCRIPTION
SS does not do exception translation, so we need to catch native Hibernate exceptions instead.