### PR TITLE
HHH-17951 Deprecate unused Size.LobMultiplier

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/engine/jdbc/Size.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/jdbc/Size.java
@@ -20,6 +20,8 @@ import java.io.Serializable;
  * @author Steve Ebersole
  */
 public class Size implements Serializable {
+
+	@Deprecated( forRemoval = true )
 	public enum LobMultiplier {
 		NONE( 1 ),
 		K( NONE.factor * 1024 ),
@@ -60,7 +62,9 @@ public class Size implements Serializable {
 	 * @param scale numeric scale
 	 * @param length type length
 	 * @param lobMultiplier LOB length multiplier
+	 * @deprecated in favor of {@link Size#Size(Integer, Integer, Long)}
 	 */
+	@Deprecated( forRemoval = true )
 	public Size(Integer precision, Integer scale, Long length, LobMultiplier lobMultiplier) {
 		this.precision = precision;
 		this.scale = scale;
@@ -68,11 +72,19 @@ public class Size implements Serializable {
 		this.lobMultiplier = lobMultiplier;
 	}
 
+	/**
+	 * @deprecated in favor of {@link Size#Size(Integer, Integer, Long)}
+	 */
+	@Deprecated( forRemoval = true )
 	public Size(Integer precision, Integer scale, Integer length, LobMultiplier lobMultiplier) {
 		this.precision = precision;
 		this.scale = scale;
 		this.length = length == null ?  null : length.longValue();
 		this.lobMultiplier = lobMultiplier;
+	}
+
+	public Size(Integer precision, Integer scale, Long length) {
+		this( precision, scale, length, Size.LobMultiplier.NONE );
 	}
 
 	public static Size nil() {
@@ -111,6 +123,7 @@ public class Size implements Serializable {
 		return arrayLength;
 	}
 
+	@Deprecated( forRemoval = true )
 	public LobMultiplier getLobMultiplier() {
 		return lobMultiplier;
 	}
@@ -141,6 +154,7 @@ public class Size implements Serializable {
 		return this;
 	}
 
+	@Deprecated( forRemoval = true )
 	public Size setLobMultiplier(LobMultiplier lobMultiplier) {
 		this.lobMultiplier = lobMultiplier;
 		return this;

--- a/hibernate-core/src/main/java/org/hibernate/type/AbstractType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/AbstractType.java
@@ -26,7 +26,7 @@ public abstract class AbstractType implements Type {
 	protected static final Size LEGACY_DICTATED_SIZE = new Size();
 
 	@Deprecated(forRemoval = true)
-	protected static final Size LEGACY_DEFAULT_SIZE = new Size( 19, 2, 255L, Size.LobMultiplier.NONE ); // to match legacy behavior
+	protected static final Size LEGACY_DEFAULT_SIZE = new Size( 19, 2, 255L ); // to match legacy behavior
 
 	@Override
 	public boolean isAssociationType() {


### PR DESCRIPTION
IMO It doesn't make much sense, `n*1024*1024` is more simple and intuitional.

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-17951
<!-- Hibernate GitHub Bot issue links end -->