### PR TITLE
Declare constructor of `OracleServerConfiguration` as private

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/dialect/OracleServerConfiguration.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/OracleServerConfiguration.java
@@ -35,7 +35,7 @@ public class OracleServerConfiguration {
 		return extended;
 	}
 
-	public OracleServerConfiguration(boolean autonomous, boolean extended) {
+	private OracleServerConfiguration(boolean autonomous, boolean extended) {
 		this.autonomous = autonomous;
 		this.extended = extended;
 	}


### PR DESCRIPTION
There is a factory method `fromDialectResolutionInfo(DialectResolutionInfo info)`,  `autonomous` and `extended` should only inferred from `DialectResolutionInfo`.