### PR TITLE
Update Develocity build scan configuration

### DIFF
--- a/.github/workflows/atlas.yml
+++ b/.github/workflows/atlas.yml
@@ -94,7 +94,7 @@ jobs:
           # WARNING: exposes secrets, so must only be passed to a step that doesn't run unapproved code.
           # WARNING: As this runs on untrusted nodes, we use the same access key as for PRs:
           #          it has limited access, essentially it can only push build scans.
-          GRADLE_ENTERPRISE_ACCESS_KEY: "${{ github.event_name == 'push' && secrets.GRADLE_ENTERPRISE_ACCESS_KEY_PR || '' }}"
+          DEVELOCITY_ACCESS_KEY: "${{ github.event_name == 'push' && secrets.GRADLE_ENTERPRISE_ACCESS_KEY_PR || '' }}"
         run: ./ci/build-github.sh
         shell: bash
       - name: Publish Develocity build scan for previous build
@@ -103,7 +103,7 @@ jobs:
           ./gradlew buildScanPublishPrevious
         env:
           # WARNING: exposes secrets, so must only be passed to a step that doesn't run unapproved code.
-          GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY_PR }}
+          DEVELOCITY_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY_PR }}
       - name: Upload test reports (if Gradle failed)
         uses: actions/upload-artifact@v4
         if: failure()

--- a/.github/workflows/contributor-build.yml
+++ b/.github/workflows/contributor-build.yml
@@ -102,7 +102,7 @@ jobs:
           # Don't populate Develocity cache in pull requests as that's potentially dangerous
           POPULATE_REMOTE_GRADLE_CACHE: "${{ github.event_name == 'push' }}"
           # WARNING: exposes secrets, so must only be passed to a step that doesn't run unapproved code.
-          GRADLE_ENTERPRISE_ACCESS_KEY: "${{ github.event_name == 'push' && secrets.GRADLE_ENTERPRISE_ACCESS_KEY || '' }}"
+          DEVELOCITY_ACCESS_KEY: "${{ github.event_name == 'push' && secrets.GRADLE_ENTERPRISE_ACCESS_KEY || '' }}"
         run: ./ci/build-github.sh
         shell: bash
       - name: Publish Develocity build scan for previous build (pull request)
@@ -111,7 +111,7 @@ jobs:
           ./gradlew buildScanPublishPrevious
         env:
           # WARNING: exposes secrets, so must only be passed to a step that doesn't run unapproved code.
-          GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY_PR }}
+          DEVELOCITY_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY_PR }}
       - name: Upload test reports (if Gradle failed)
         uses: actions/upload-artifact@v4
         if: failure()

--- a/ci/snapshot-publish.Jenkinsfile
+++ b/ci/snapshot-publish.Jenkinsfile
@@ -33,7 +33,7 @@ pipeline {
 				withCredentials([
 					usernamePassword(credentialsId: 'ossrh.sonatype.org', usernameVariable: 'hibernatePublishUsername', passwordVariable: 'hibernatePublishPassword'),
 					usernamePassword(credentialsId: 'plugins.gradle.org', usernameVariable: 'hibernatePluginPortalUsername', passwordVariable: 'hibernatePluginPortalPassword'),
-					string(credentialsId: 'ge.hibernate.org-access-key', variable: 'GRADLE_ENTERPRISE_ACCESS_KEY'),
+					string(credentialsId: 'ge.hibernate.org-access-key', variable: 'DEVELOCITY_ACCESS_KEY'),
 					string(credentialsId: 'release.gpg.passphrase', variable: 'SIGNING_PASS'),
 					file(credentialsId: 'release.gpg.private-key', variable: 'SIGNING_KEYRING')
 				]) {

--- a/gradle/gradle-develocity.gradle
+++ b/gradle/gradle-develocity.gradle
@@ -36,21 +36,28 @@ static java.util.Optional<String> getSetting(String name) {
     return java.util.Optional.ofNullable(sysProp);
 }
 
-gradleEnterprise {
+develocity {
     server = 'https://ge.hibernate.org'
 
     buildScan {
-        captureTaskInputFiles = true
-        publishAlways()
-        publishIfAuthenticated()
+        capture {
+            fileFingerprints = true
+        }
+        publishing.onlyIf { it.authenticated }
+
+        obfuscation {
+            // Don't share ip addresses
+            ipAddresses { addresses -> addresses.collect { address -> "0.0.0.0" } }
+        }
 
         uploadInBackground = !settings.ext.isCiEnvironment
 
-        tag "jdk-${extensions.jdkVersions.test.launcher}"
-        tag extensions.db
-        value 'database', extensions.db
-        if ( extensions.hasProperty( 'ci.node' ) ) {
-            tag extensions.property( 'ci.node' )
+        tag "jdk-${settings.extensions.jdkVersions.test.launcher}"
+        tag settings.extensions.db
+        value 'database', settings.extensions.db
+
+        if ( settings.extensions.findByName( 'ci.node' ) ) {
+            tag settings.extensions.findByName( 'ci.node' )
         }
     }
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -20,7 +20,7 @@ pluginManagement {
 plugins {
     id 'org.hibernate.orm.build.env-settings'
     id 'org.hibernate.orm.build.jdks-settings'
-    id 'com.gradle.enterprise' version '3.17'
+    id 'com.gradle.develocity' version '3.17.1'
     id 'com.gradle.common-custom-user-data-gradle-plugin' version '2.0'
 }
 
@@ -284,7 +284,7 @@ String overrideableVersion(String settingName, String defaultVersion) {
 
 rootProject.name = 'hibernate-orm'
 
-apply from: file( 'gradle/gradle-enterprise.gradle' )
+apply from: file( 'gradle/gradle-develocity.gradle' )
 
 if ( !JavaVersion.current().java11Compatible ) {
     throw new GradleException( "Gradle must be run with Java 11 or later" )
@@ -295,10 +295,10 @@ buildCache {
         // do not use local build cache for CI jobs, period!
         enabled = !settings.ext.isCiEnvironment
     }
-    remote(gradleEnterprise.buildCache) {
+    remote(develocity.buildCache) {
         enabled = true
         // Check access key presence to avoid build cache errors on PR builds when access key is not present
-        def accessKey = System.getenv("GRADLE_ENTERPRISE_ACCESS_KEY")
+        def accessKey = System.getenv("DEVELOCITY_ACCESS_KEY")
         push = settings.ext.populateRemoteBuildCache && accessKey
     }
 }


### PR DESCRIPTION
A followup on https://github.com/hibernate/hibernate-orm/pull/8121 (we've noticed the warnings in Search build and made changes here https://github.com/hibernate/hibernate-search/commit/ff7621bf1952a2f85103a7937a3884a512325b80) and after looking at the ORM build logs -- there's similar warnings there too 🙈 

With 3.17 env variable `GRADLE_ENTERPRISE_ACCESS_KEY` is deprecated and the config changed a bit:
https://docs.gradle.com/enterprise/gradle-plugin/legacy/#develocity_migration

I've also added IP obfuscation. 