### PR TITLE
Fix RevisionTimestampValueResolver to provide correct precisision for Instants

### DIFF
--- a/hibernate-envers/src/main/java/org/hibernate/envers/internal/revisioninfo/RevisionTimestampValueResolver.java
+++ b/hibernate-envers/src/main/java/org/hibernate/envers/internal/revisioninfo/RevisionTimestampValueResolver.java
@@ -100,7 +100,7 @@ public class RevisionTimestampValueResolver {
 				return instant;
 			}
 			else {
-				return instant.getEpochSecond();
+				return instant.toEpochMilli();
 			}
 		}
 		return null;

--- a/hibernate-envers/src/test/java/org/hibernate/orm/test/envers/integration/revfordate/RevisionForDate.java
+++ b/hibernate-envers/src/test/java/org/hibernate/orm/test/envers/integration/revfordate/RevisionForDate.java
@@ -121,4 +121,20 @@ public class RevisionForDate extends BaseEnversJPAFunctionalTestCase {
 
 		assert vr.getRevisionDate( vr.getRevisionNumberForDate( new Date( timestamp4 ) ) ).getTime() <= timestamp4;
 	}
+
+	@Test
+	@SkipForDialect(value = CockroachDialect.class, comment = "Fails because of int size")
+	public void testRevisionsForInstant() {
+		AuditReader vr = getAuditReader();
+
+		assert vr.getRevisionDate( vr.getRevisionNumberForDate( new Date( timestamp2 ).toInstant() ) ).getTime() <= timestamp2;
+		assert vr.getRevisionDate( vr.getRevisionNumberForDate( new Date( timestamp2 ).toInstant() ).intValue() + 1 )
+				.getTime() > timestamp2;
+
+		assert vr.getRevisionDate( vr.getRevisionNumberForDate( new Date( timestamp3 ).toInstant() ) ).getTime() <= timestamp3;
+		assert vr.getRevisionDate( vr.getRevisionNumberForDate( new Date( timestamp3 ).toInstant() ).intValue() + 1 )
+				.getTime() > timestamp3;
+
+		assert vr.getRevisionDate( vr.getRevisionNumberForDate( new Date( timestamp4 ).toInstant() ) ).getTime() <= timestamp4;
+	}
 }


### PR DESCRIPTION
In case the revision timestamp is persisted as a long (i.e. a unix timestamp with millisecond precision) and the request to resolve a revision is made with an object of type `Instant`, the resulting parameter is returned as a unix timestamp with seconds precision instead of the expected milliseconds. This leads to (usually) not finding any revisions.

This PR fixes this path to work the same as the case in line 85 where the call is made with an object of type `LocalDateTime`.

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-17975
<!-- Hibernate GitHub Bot issue links end -->