### PR TITLE
HHH-17980 Excessive contention during getter identification in the ByteBuddy enhancer

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/bytecode/enhance/internal/bytebuddy/ByteBuddyEnhancementContext.java
+++ b/hibernate-core/src/main/java/org/hibernate/bytecode/enhance/internal/bytebuddy/ByteBuddyEnhancementContext.java
@@ -33,6 +33,7 @@ class ByteBuddyEnhancementContext {
 	private final EnhancementContext enhancementContext;
 
 	private final ConcurrentHashMap<TypeDescription, Map<String, MethodDescription>> getterByTypeMap = new ConcurrentHashMap<>();
+	private final ConcurrentHashMap<String, Object> locksMap = new ConcurrentHashMap<>();
 
 	ByteBuddyEnhancementContext(EnhancementContext enhancementContext) {
 		this.enhancementContext = enhancementContext;
@@ -135,15 +136,35 @@ class ByteBuddyEnhancementContext {
 	}
 
 	Optional<MethodDescription> resolveGetter(FieldDescription fieldDescription) {
-		Map<String, MethodDescription> getters = getterByTypeMap
-				.computeIfAbsent( fieldDescription.getDeclaringType().asErasure(), declaringType -> {
-					return MethodGraph.Compiler.DEFAULT.compile( declaringType )
+		//There is a non-straightforward cache here, but we really need this to be able to
+		//efficiently handle enhancement of large models.
+
+		final TypeDescription erasure = fieldDescription.getDeclaringType().asErasure();
+
+		//Always try to get with a simple "get" before doing a "computeIfAbsent" operation,
+		//otherwise large models might exhibit significant contention on the map.
+		Map<String, MethodDescription> getters = getterByTypeMap.get( erasure );
+
+		if ( getters == null ) {
+			//poor man lock striping: as CHM#computeIfAbsent has too coarse lock granularity
+			//and has been shown to trigger significant, unnecessary contention.
+			final String lockKey = erasure.toString();
+			final Object candidateLock = new Object();
+			final Object existingLock = locksMap.putIfAbsent( lockKey, candidateLock );
+			final Object lock = existingLock == null ? candidateLock : existingLock;
+			synchronized ( lock ) {
+				getters = getterByTypeMap.get( erasure );
+				if ( getters == null ) {
+					getters = MethodGraph.Compiler.DEFAULT.compile( erasure )
 							.listNodes()
 							.asMethodList()
 							.filter( IS_GETTER )
 							.stream()
 							.collect( Collectors.toMap( MethodDescription::getActualName, Function.identity() ) );
-				} );
+					getterByTypeMap.put( erasure, getters );
+				}
+			}
+		}
 
 		String capitalizedFieldName = Character.toUpperCase( fieldDescription.getName().charAt( 0 ) )
 				+ fieldDescription.getName().substring( 1 );


### PR DESCRIPTION

This is the first patch on a series, motivated by the analysis of bootstrap times using https://github.com/topicusonderwijs/tribe-krd-quarkus.

https://hibernate.atlassian.net/browse/HHH-17980

This patch in isolation will not dramatically improve things, as contention is currently quite low - however this lock becomes a problem as other bottlenecks are resolved. I'm resolving the other bottlenecks via a combination of patches on the Quarkus side and other improvements coming on the ORM side.

Not all improvements on the ORM side will be suitable for pre-7 versions, still I'd apply this one on 6.5+ as well as the combination of improvements on 6.5 is still meaningful enough to make this lock problematic.