### PR TITLE
HHH-18000 : Remove XmlProcessingHelper methods for creating AnnotationUsage instances

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/boot/model/internal/BinderHelper.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/internal/BinderHelper.java
@@ -999,7 +999,7 @@ public class BinderHelper {
 		}
 
 		// no override was found.  return the base annotation (if one)
-		return element.getAnnotationUsage( annotationType );
+		return element.getSingleAnnotationUsage( annotationType );
 	}
 
 	public static boolean overrideMatchesDialect(AnnotationUsage<? extends Annotation> override, Dialect dialect) {

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/HibernateAnnotations.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/HibernateAnnotations.java
@@ -155,6 +155,8 @@ public interface HibernateAnnotations {
 	AnnotationDescriptor<SqlFragmentAlias> SQL_FRAGMENT_ALIAS = createOrmDescriptor( SqlFragmentAlias.class );
 	AnnotationDescriptor<SQLInserts> SQL_INSERTS = createOrmDescriptor( SQLInserts.class );
 	AnnotationDescriptor<SQLInsert> SQL_INSERT = createOrmDescriptor( SQLInsert.class, SQL_INSERTS );
+	AnnotationDescriptor<SQLRestriction> SQL_RESTRICTION = createOrmDescriptor( SQLRestriction.class, SQL_INSERTS );
+	AnnotationDescriptor<SQLJoinTableRestriction> SQL_RESTRICTION_JOIN_TABLE = createOrmDescriptor( SQLJoinTableRestriction.class, SQL_INSERTS );
 	AnnotationDescriptor<SQLUpdates> SQL_UPDATES = createOrmDescriptor( SQLUpdates.class );
 	AnnotationDescriptor<SQLUpdate> SQL_UPDATE = createOrmDescriptor( SQLUpdate.class, SQL_UPDATES );
 	AnnotationDescriptor<Struct> STRUCT = createOrmDescriptor( Struct.class );
@@ -162,6 +164,7 @@ public interface HibernateAnnotations {
 	AnnotationDescriptor<Synchronize> SYNCHRONIZE = createOrmDescriptor( Synchronize.class );
 	AnnotationDescriptor<Tables> TABLES = createOrmDescriptor( Tables.class );
 	AnnotationDescriptor<Table> TABLE = createOrmDescriptor( Table.class, TABLES );
+	AnnotationDescriptor<TenantId> TENANT_ID = createOrmDescriptor( TenantId.class );
 	AnnotationDescriptor<TimeZoneColumn> TZ_COLUMN = createOrmDescriptor( TimeZoneColumn.class );
 	AnnotationDescriptor<TimeZoneStorage> TZ_STORAGE = createOrmDescriptor( TimeZoneStorage.class );
 	AnnotationDescriptor<Type> TYPE = createOrmDescriptor( Type.class );

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/JpaAnnotations.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/JpaAnnotations.java
@@ -19,6 +19,7 @@ import jakarta.persistence.AttributeOverride;
 import jakarta.persistence.AttributeOverrides;
 import jakarta.persistence.Basic;
 import jakarta.persistence.Cacheable;
+import jakarta.persistence.CheckConstraint;
 import jakarta.persistence.CollectionTable;
 import jakarta.persistence.Column;
 import jakarta.persistence.ColumnResult;
@@ -114,6 +115,7 @@ public interface JpaAnnotations {
 	AnnotationDescriptor<AttributeOverride> ATTRIBUTE_OVERRIDE = createOrmDescriptor( AttributeOverride.class, ATTRIBUTE_OVERRIDES );
 	AnnotationDescriptor<Basic> BASIC = createOrmDescriptor( Basic.class );
 	AnnotationDescriptor<Cacheable> CACHEABLE = createOrmDescriptor( Cacheable.class );
+	AnnotationDescriptor<CheckConstraint> CHECK_CONSTRAINT = createOrmDescriptor(CheckConstraint.class );
 	AnnotationDescriptor<CollectionTable> COLLECTION_TABLE = createOrmDescriptor( CollectionTable.class );
 	AnnotationDescriptor<Column> COLUMN = createOrmDescriptor( Column.class );
 	AnnotationDescriptor<ColumnResult> COLUMN_RESULT = createOrmDescriptor( ColumnResult.class );

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/xml/internal/AttributeProcessor.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/xml/internal/AttributeProcessor.java
@@ -6,7 +6,6 @@
  */
 package org.hibernate.boot.models.xml.internal;
 
-import java.util.ArrayList;
 import java.util.List;
 
 import org.hibernate.boot.jaxb.mapping.spi.JaxbAnyMappingImpl;
@@ -17,8 +16,6 @@ import org.hibernate.boot.jaxb.mapping.spi.JaxbBaseAttributesContainer;
 import org.hibernate.boot.jaxb.mapping.spi.JaxbBasicImpl;
 import org.hibernate.boot.jaxb.mapping.spi.JaxbElementCollectionImpl;
 import org.hibernate.boot.jaxb.mapping.spi.JaxbEmbeddedImpl;
-import org.hibernate.boot.jaxb.mapping.spi.JaxbForeignKeyImpl;
-import org.hibernate.boot.jaxb.mapping.spi.JaxbJoinTableImpl;
 import org.hibernate.boot.jaxb.mapping.spi.JaxbManyToManyImpl;
 import org.hibernate.boot.jaxb.mapping.spi.JaxbManyToOneImpl;
 import org.hibernate.boot.jaxb.mapping.spi.JaxbNaturalId;
@@ -37,21 +34,11 @@ import org.hibernate.boot.models.xml.internal.attr.ManyToOneAttributeProcessing;
 import org.hibernate.boot.models.xml.internal.attr.OneToManyAttributeProcessing;
 import org.hibernate.boot.models.xml.internal.attr.OneToOneAttributeProcessing;
 import org.hibernate.boot.models.xml.internal.attr.PluralAnyMappingAttributeProcessing;
-import org.hibernate.boot.models.xml.internal.db.ColumnProcessing;
-import org.hibernate.boot.models.xml.internal.db.ForeignKeyProcessing;
-import org.hibernate.boot.models.xml.internal.db.JoinColumnProcessing;
-import org.hibernate.boot.models.xml.internal.db.TableProcessing;
 import org.hibernate.boot.models.xml.spi.XmlDocumentContext;
-import org.hibernate.models.spi.MutableAnnotationUsage;
 import org.hibernate.models.spi.MutableClassDetails;
 import org.hibernate.models.spi.MutableMemberDetails;
 
 import jakarta.persistence.AccessType;
-import jakarta.persistence.AssociationOverride;
-import jakarta.persistence.AssociationOverrides;
-import jakarta.persistence.AttributeOverride;
-import jakarta.persistence.AttributeOverrides;
-import jakarta.persistence.Column;
 
 /**
  * Helper for handling persistent attributes defined in mapping XML in metadata-complete mode
@@ -243,84 +230,22 @@ public class AttributeProcessor {
 			List<JaxbAttributeOverrideImpl> attributeOverrides,
 			MutableClassDetails mutableClassDetails,
 			XmlDocumentContext xmlDocumentContext) {
-		final List<MutableAnnotationUsage<AttributeOverride>> attributeOverrideList = new ArrayList<>( attributeOverrides.size() );
-		for ( JaxbAttributeOverrideImpl attributeOverride : attributeOverrides ) {
-			final MutableAnnotationUsage<AttributeOverride> attributeOverrideAnn = XmlProcessingHelper.makeNestedAnnotation(
-					AttributeOverride.class,
-					mutableClassDetails,
-					xmlDocumentContext
-			);
-			attributeOverrideList.add( attributeOverrideAnn );
-
-			final MutableAnnotationUsage<Column> attributeOverrideColumnAnn = XmlProcessingHelper.makeNestedAnnotation(
-					Column.class,
-					mutableClassDetails,
-					xmlDocumentContext
-			);
-			ColumnProcessing.applyColumnDetails( attributeOverride.getColumn(), attributeOverrideColumnAnn, xmlDocumentContext );
-			attributeOverrideAnn.setAttributeValue( "name", attributeOverride.getName() );
-			attributeOverrideAnn.setAttributeValue( "column", attributeOverrideColumnAnn );
-		}
-
-		final MutableAnnotationUsage<AttributeOverrides> attributeOverridesAnn = XmlProcessingHelper.getOrMakeAnnotation(
-				AttributeOverrides.class,
+		XmlAnnotationHelper.applyAttributeOverrides(
+				attributeOverrides,
 				mutableClassDetails,
+				null,
 				xmlDocumentContext
 		);
-		attributeOverridesAnn.setAttributeValue( "value", attributeOverrideList );
 	}
 
 	public static void processAssociationOverrides(
 			List<JaxbAssociationOverrideImpl> associationOverrides,
 			MutableClassDetails mutableClassDetails,
 			XmlDocumentContext xmlDocumentContext) {
-		final List<MutableAnnotationUsage<AssociationOverride>> associationOverrideList = new ArrayList<>( associationOverrides.size() );
-		for ( JaxbAssociationOverrideImpl associationOverride : associationOverrides ) {
-			final MutableAnnotationUsage<AssociationOverride> attributeOverrideAnn = XmlProcessingHelper.makeNestedAnnotation(
-					AssociationOverride.class,
-					mutableClassDetails,
-					xmlDocumentContext
-			);
-			associationOverrideList.add( attributeOverrideAnn );
-
-			attributeOverrideAnn.setAttributeValue( "name", associationOverride.getName() );
-			attributeOverrideAnn.setAttributeValue(
-					"joinColumns",
-					JoinColumnProcessing.createJoinColumns(
-							associationOverride.getJoinColumns(),
-							mutableClassDetails,
-							xmlDocumentContext
-					)
-			);
-			final JaxbForeignKeyImpl foreignKeys = associationOverride.getForeignKeys();
-			if ( foreignKeys != null ) {
-				attributeOverrideAnn.setAttributeValue(
-						"foreignKey",
-						ForeignKeyProcessing.createNestedForeignKeyAnnotation(
-								foreignKeys,
-								mutableClassDetails,
-								xmlDocumentContext
-						)
-				);
-			}
-			final JaxbJoinTableImpl joinTable = associationOverride.getJoinTable();
-			if ( joinTable != null ) {
-				attributeOverrideAnn.setAttributeValue(
-						"joinTable",
-						TableProcessing.createNestedJoinTable(
-								joinTable,
-								mutableClassDetails,
-								xmlDocumentContext
-						)
-				);
-			}
-		}
-
-		final MutableAnnotationUsage<AssociationOverrides> associationOverridesAnn = XmlProcessingHelper.getOrMakeAnnotation(
-				AssociationOverrides.class,
+		XmlAnnotationHelper.applyAssociationOverrides(
+				associationOverrides,
 				mutableClassDetails,
 				xmlDocumentContext
 		);
-		associationOverridesAnn.setAttributeValue( "value", associationOverrideList );
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/xml/internal/XmlAnnotationHelper.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/xml/internal/XmlAnnotationHelper.java
@@ -117,7 +117,6 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.IdClass;
 import jakarta.persistence.Index;
 import jakarta.persistence.Inheritance;
-import jakarta.persistence.JoinColumn;
 import jakarta.persistence.SequenceGenerator;
 import jakarta.persistence.Table;
 import jakarta.persistence.TableGenerator;
@@ -147,40 +146,6 @@ public class XmlAnnotationHelper {
 		if ( StringHelper.isNotEmpty( value ) ) {
 			annotationUsage.setAttributeValue( attributeName, value );
 		}
-	}
-
-	public static <S> void applyOptionalAttribute(
-			MutableAnnotationUsage<? extends Annotation> annotationUsage,
-			String attributeName,
-			S valueSource,
-			Function<S,Object> valueExtractor) {
-		if ( valueSource == null ) {
-			return;
-		}
-
-		final Object value = valueExtractor.apply( valueSource );
-		if ( value == null ) {
-			return;
-		}
-
-		annotationUsage.setAttributeValue( attributeName, value );
-	}
-
-	public static <S> void applyOptionalStringAttribute(
-			MutableAnnotationUsage<? extends Annotation> annotationUsage,
-			String attributeName,
-			S valueSource,
-			Function<S,String> valueExtractor) {
-		if ( valueSource == null ) {
-			return;
-		}
-
-		final String value = valueExtractor.apply( valueSource );
-		if ( StringHelper.isEmpty( value ) ) {
-			return;
-		}
-
-		annotationUsage.setAttributeValue( attributeName, value );
 	}
 
 	/**
@@ -223,16 +188,6 @@ public class XmlAnnotationHelper {
 		return columnAnnotationUsage;
 	}
 
-	public static MutableAnnotationUsage<JoinColumn> applyJoinColumn(
-			JaxbJoinColumnImpl jaxbJoinColumn,
-			MutableMemberDetails memberDetails,
-			XmlDocumentContext xmlDocumentContext) {
-		if ( jaxbJoinColumn == null ) {
-			return null;
-		}
-
-		return JoinColumnProcessing.createJoinColumnAnnotation( jaxbJoinColumn, memberDetails, JoinColumn.class, xmlDocumentContext );
-	}
 
 	public static <T,N> void applyOr(
 			N jaxbNode,
@@ -266,6 +221,12 @@ public class XmlAnnotationHelper {
 				() -> (T) annotationDescriptor.getAttribute( name ).getAttributeMethod().getDefaultValue()
 		);
 	}
+
+
+
+
+
+
 
 	public static void applyUserType(
 			JaxbUserTypeImpl jaxbType,

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/xml/internal/XmlAnnotationHelper.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/xml/internal/XmlAnnotationHelper.java
@@ -1202,14 +1202,9 @@ public class XmlAnnotationHelper {
 			JaxbEntityListenerImpl jaxbEntityListener,
 			MutableClassDetails classDetails,
 			XmlDocumentContext xmlDocumentContext) {
-		final MutableAnnotationUsage<EntityListeners> applied = classDetails.applyAnnotationUsage(
+		final MutableAnnotationUsage<EntityListeners> listenersUsage = classDetails.applyAnnotationUsage(
 				JpaAnnotations.ENTITY_LISTENERS,
 				xmlDocumentContext.getModelBuildingContext()
-		);
-		final MutableAnnotationUsage<EntityListeners> listenersUsage = XmlProcessingHelper.getOrMakeAnnotation(
-				EntityListeners.class,
-				classDetails,
-				xmlDocumentContext
 		);
 
 		final MutableClassDetails entityListenerClass = xmlDocumentContext.resolveJavaType( jaxbEntityListener.getClazz() );

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/xml/internal/XmlProcessingHelper.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/xml/internal/XmlProcessingHelper.java
@@ -15,6 +15,7 @@ import org.hibernate.boot.models.MemberResolutionException;
 import org.hibernate.boot.models.internal.AnnotationUsageHelper;
 import org.hibernate.boot.models.xml.spi.XmlDocumentContext;
 import org.hibernate.internal.util.StringHelper;
+import org.hibernate.models.spi.AnnotationDescriptor;
 import org.hibernate.models.spi.AnnotationUsage;
 import org.hibernate.models.spi.FieldDetails;
 import org.hibernate.models.spi.MethodDetails;
@@ -115,11 +116,11 @@ public class XmlProcessingHelper {
 	 * Used when applying XML in override mode.
 	 */
 	public static <A extends Annotation> MutableAnnotationUsage<A> getOrMakeNamedAnnotation(
-			Class<A> annotationType,
+			AnnotationDescriptor<A> annotationDescriptor,
 			String name,
 			MutableAnnotationTarget target,
 			XmlDocumentContext xmlDocumentContext) {
-		return getOrMakeNamedAnnotation( annotationType, name, "name", target, xmlDocumentContext );
+		return getOrMakeNamedAnnotation( annotationDescriptor, name, "name", target, xmlDocumentContext );
 	}
 
 	/**
@@ -127,43 +128,30 @@ public class XmlProcessingHelper {
 	 * Used when applying XML in override mode.
 	 */
 	public static <A extends Annotation> MutableAnnotationUsage<A> getOrMakeNamedAnnotation(
-			Class<A> annotationType,
+			AnnotationDescriptor<A> annotationDescriptor,
 			String name,
 			String attributeToMatch,
 			MutableAnnotationTarget target,
 			XmlDocumentContext xmlDocumentContext) {
 		if ( name == null ) {
-			return xmlDocumentContext
-					.getModelBuildingContext()
-					.getAnnotationDescriptorRegistry()
-					.getDescriptor( annotationType )
-					.createUsage( null, xmlDocumentContext.getModelBuildingContext() );
+			return annotationDescriptor.createUsage( null, xmlDocumentContext.getModelBuildingContext() );
 		}
 
-		final AnnotationUsage<A> existing = target.getNamedAnnotationUsage( annotationType, name, attributeToMatch );
+		final AnnotationUsage<A> existing = target.getNamedAnnotationUsage( annotationDescriptor, name, attributeToMatch );
 		if ( existing != null ) {
 			return (MutableAnnotationUsage<A>) existing;
 		}
 
-		return makeNamedAnnotation( annotationType, name, attributeToMatch, target, xmlDocumentContext );
+		return makeNamedAnnotation( annotationDescriptor, name, attributeToMatch, target, xmlDocumentContext );
 	}
 
-	/**
-	 * Make a named AnnotationUsage.
-	 * Used when applying XML in complete mode or when {@linkplain #getOrMakeNamedAnnotation}
-	 * needs to make.
-	 */
-	public static <A extends Annotation> MutableAnnotationUsage<A> makeNamedAnnotation(
-			Class<A> annotationType,
+	private static <A extends Annotation> MutableAnnotationUsage<A> makeNamedAnnotation(
+			AnnotationDescriptor<A> annotationDescriptor,
 			String name,
 			String nameAttributeName,
 			MutableAnnotationTarget target,
 			XmlDocumentContext xmlDocumentContext) {
-		final MutableAnnotationUsage<A> created = xmlDocumentContext
-				.getModelBuildingContext()
-				.getAnnotationDescriptorRegistry()
-				.getDescriptor( annotationType )
-				.createUsage( null, xmlDocumentContext.getModelBuildingContext() );
+		final MutableAnnotationUsage<A> created = annotationDescriptor.createUsage( null, xmlDocumentContext.getModelBuildingContext() );
 		target.addAnnotationUsage( created );
 		created.setAttributeValue( nameAttributeName, name );
 		return created;

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/xml/internal/attr/BasicAttributeProcessing.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/xml/internal/attr/BasicAttributeProcessing.java
@@ -8,6 +8,8 @@ package org.hibernate.boot.models.xml.internal.attr;
 
 import org.hibernate.annotations.Formula;
 import org.hibernate.boot.jaxb.mapping.spi.JaxbBasicImpl;
+import org.hibernate.boot.models.HibernateAnnotations;
+import org.hibernate.boot.models.JpaAnnotations;
 import org.hibernate.boot.models.xml.internal.XmlAnnotationHelper;
 import org.hibernate.boot.models.xml.internal.XmlProcessingHelper;
 import org.hibernate.boot.models.xml.internal.db.ColumnProcessing;
@@ -40,16 +42,25 @@ public class BasicAttributeProcessing {
 				declarer
 		);
 
-		final MutableAnnotationUsage<Basic> basicAnn = XmlProcessingHelper.getOrMakeAnnotation( Basic.class, memberDetails, xmlDocumentContext );
+		final MutableAnnotationUsage<Basic> basicAnn = memberDetails.applyAnnotationUsage(
+				JpaAnnotations.BASIC,
+				xmlDocumentContext.getModelBuildingContext()
+		);
 		CommonAttributeProcessing.applyAttributeBasics( jaxbBasic, memberDetails, basicAnn, accessType, xmlDocumentContext );
 
 		if ( StringHelper.isNotEmpty( jaxbBasic.getFormula() ) ) {
 			assert jaxbBasic.getColumn() == null;
-			final MutableAnnotationUsage<Formula> formulaAnn = XmlProcessingHelper.getOrMakeAnnotation( Formula.class, memberDetails, xmlDocumentContext );
+			final MutableAnnotationUsage<Formula> formulaAnn = memberDetails.applyAnnotationUsage(
+					HibernateAnnotations.FORMULA,
+					xmlDocumentContext.getModelBuildingContext()
+			);
 			formulaAnn.setAttributeValue( "value", jaxbBasic.getFormula() );
 		}
 		else if ( jaxbBasic.getColumn() != null ) {
-			final MutableAnnotationUsage<Column> columnAnn = XmlProcessingHelper.getOrMakeAnnotation( Column.class, memberDetails, xmlDocumentContext );
+			final MutableAnnotationUsage<Column> columnAnn = memberDetails.applyAnnotationUsage(
+					JpaAnnotations.COLUMN,
+					xmlDocumentContext.getModelBuildingContext()
+			);
 			ColumnProcessing.applyColumnDetails( jaxbBasic.getColumn(), memberDetails, columnAnn, xmlDocumentContext );
 		}
 

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/xml/internal/attr/BasicIdAttributeProcessing.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/xml/internal/attr/BasicIdAttributeProcessing.java
@@ -7,16 +7,16 @@
 package org.hibernate.boot.models.xml.internal.attr;
 
 import org.hibernate.boot.jaxb.mapping.spi.JaxbIdImpl;
+import org.hibernate.boot.models.JpaAnnotations;
 import org.hibernate.boot.models.xml.internal.XmlAnnotationHelper;
 import org.hibernate.boot.models.xml.internal.XmlProcessingHelper;
 import org.hibernate.boot.models.xml.spi.XmlDocumentContext;
+import org.hibernate.models.spi.MutableAnnotationUsage;
 import org.hibernate.models.spi.MutableClassDetails;
 import org.hibernate.models.spi.MutableMemberDetails;
-import org.hibernate.models.spi.MutableAnnotationUsage;
 
 import jakarta.persistence.AccessType;
 import jakarta.persistence.Basic;
-import jakarta.persistence.Id;
 
 import static org.hibernate.internal.util.NullnessHelper.coalesce;
 
@@ -37,8 +37,8 @@ public class BasicIdAttributeProcessing {
 				declarer
 		);
 
-		final MutableAnnotationUsage<Id> idAnn = XmlProcessingHelper.makeAnnotation( Id.class, memberDetails, xmlDocumentContext );
-		final MutableAnnotationUsage<Basic> basicAnn = XmlProcessingHelper.makeAnnotation( Basic.class, memberDetails, xmlDocumentContext );
+		memberDetails.applyAnnotationUsage( JpaAnnotations.ID, xmlDocumentContext.getModelBuildingContext() );
+		final MutableAnnotationUsage<Basic> basicAnn = memberDetails.applyAnnotationUsage( JpaAnnotations.BASIC, xmlDocumentContext.getModelBuildingContext() );
 
 		CommonAttributeProcessing.applyAttributeBasics( jaxbId, memberDetails, basicAnn, accessType, xmlDocumentContext );
 

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/xml/internal/attr/CommonPluralAttributeProcessing.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/xml/internal/attr/CommonPluralAttributeProcessing.java
@@ -8,10 +8,6 @@ package org.hibernate.boot.models.xml.internal.attr;
 
 import org.hibernate.annotations.Bag;
 import org.hibernate.annotations.Fetch;
-import org.hibernate.annotations.SQLDelete;
-import org.hibernate.annotations.SQLDeleteAll;
-import org.hibernate.annotations.SQLInsert;
-import org.hibernate.annotations.SQLUpdate;
 import org.hibernate.annotations.SortComparator;
 import org.hibernate.annotations.SortNatural;
 import org.hibernate.boot.internal.CollectionClassification;
@@ -19,6 +15,7 @@ import org.hibernate.boot.internal.LimitedCollectionClassification;
 import org.hibernate.boot.jaxb.mapping.spi.JaxbMapKeyImpl;
 import org.hibernate.boot.jaxb.mapping.spi.JaxbOrderColumnImpl;
 import org.hibernate.boot.jaxb.mapping.spi.JaxbPluralAttribute;
+import org.hibernate.boot.models.HibernateAnnotations;
 import org.hibernate.boot.models.xml.internal.XmlAnnotationHelper;
 import org.hibernate.boot.models.xml.internal.XmlProcessingHelper;
 import org.hibernate.boot.models.xml.internal.db.ColumnProcessing;
@@ -153,16 +150,12 @@ public class CommonPluralAttributeProcessing {
 		// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 		// filters and custom sql
 
-		jaxbPluralAttribute.getFilters().forEach( (jaxbFilter) -> {
-			XmlAnnotationHelper.applyFilter( jaxbFilter, memberDetails, xmlDocumentContext );
-		} );
-
+		XmlAnnotationHelper.applyFilters( jaxbPluralAttribute.getFilters(), memberDetails, xmlDocumentContext );
 		XmlAnnotationHelper.applySqlRestriction( jaxbPluralAttribute.getSqlRestriction(), memberDetails, xmlDocumentContext );
-
-		XmlAnnotationHelper.applyCustomSql( jaxbPluralAttribute.getSqlInsert(), memberDetails, SQLInsert.class, xmlDocumentContext );
-		XmlAnnotationHelper.applyCustomSql( jaxbPluralAttribute.getSqlUpdate(), memberDetails, SQLUpdate.class, xmlDocumentContext );
-		XmlAnnotationHelper.applyCustomSql( jaxbPluralAttribute.getSqlDelete(), memberDetails, SQLDelete.class, xmlDocumentContext );
-		XmlAnnotationHelper.applyCustomSql( jaxbPluralAttribute.getSqlDeleteAll(), memberDetails, SQLDeleteAll.class, xmlDocumentContext );
+		XmlAnnotationHelper.applyCustomSql( jaxbPluralAttribute.getSqlInsert(), memberDetails, HibernateAnnotations.SQL_INSERT, xmlDocumentContext );
+		XmlAnnotationHelper.applyCustomSql( jaxbPluralAttribute.getSqlUpdate(), memberDetails, HibernateAnnotations.SQL_UPDATE, xmlDocumentContext );
+		XmlAnnotationHelper.applyCustomSql( jaxbPluralAttribute.getSqlDelete(), memberDetails, HibernateAnnotations.SQL_DELETE, xmlDocumentContext );
+		XmlAnnotationHelper.applyCustomSql( jaxbPluralAttribute.getSqlDeleteAll(), memberDetails, HibernateAnnotations.SQL_DELETE_ALL, xmlDocumentContext );
 	}
 
 	private static void applyOrderColumn(

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/xml/internal/attr/ElementCollectionAttributeProcessing.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/xml/internal/attr/ElementCollectionAttributeProcessing.java
@@ -101,10 +101,9 @@ public class ElementCollectionAttributeProcessing {
 			return;
 		}
 
-		final MutableAnnotationUsage<CollectionTable> collectionTableAnn = XmlProcessingHelper.getOrMakeAnnotation(
-				CollectionTable.class,
-				memberDetails,
-				xmlDocumentContext
+		final MutableAnnotationUsage<CollectionTable> collectionTableAnn = memberDetails.applyAnnotationUsage(
+				JpaAnnotations.COLLECTION_TABLE,
+				xmlDocumentContext.getModelBuildingContext()
 		);
 		final AnnotationDescriptor<CollectionTable> collectionTableDescriptor = xmlDocumentContext.getModelBuildingContext()
 				.getAnnotationDescriptorRegistry()

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/xml/internal/attr/EmbeddedAttributeProcessing.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/xml/internal/attr/EmbeddedAttributeProcessing.java
@@ -8,6 +8,8 @@ package org.hibernate.boot.models.xml.internal.attr;
 
 import org.hibernate.boot.internal.Target;
 import org.hibernate.boot.jaxb.mapping.spi.JaxbEmbeddedImpl;
+import org.hibernate.boot.models.HibernateAnnotations;
+import org.hibernate.boot.models.JpaAnnotations;
 import org.hibernate.boot.models.xml.internal.XmlAnnotationHelper;
 import org.hibernate.boot.models.xml.internal.XmlProcessingHelper;
 import org.hibernate.boot.models.xml.spi.XmlDocumentContext;
@@ -39,10 +41,16 @@ public class EmbeddedAttributeProcessing {
 				declarer
 		);
 
-		final MutableAnnotationUsage<Embedded> embeddedAnn = XmlProcessingHelper.getOrMakeAnnotation( Embedded.class, memberDetails, xmlDocumentContext );
+		final MutableAnnotationUsage<Embedded> embeddedAnn = memberDetails.applyAnnotationUsage(
+				JpaAnnotations.EMBEDDED,
+				xmlDocumentContext.getModelBuildingContext()
+		);
 
 		if ( StringHelper.isNotEmpty( jaxbEmbedded.getTarget() ) ) {
-			final MutableAnnotationUsage<Target> targetAnn = XmlProcessingHelper.getOrMakeAnnotation( Target.class, memberDetails, xmlDocumentContext );
+			final MutableAnnotationUsage<Target> targetAnn = memberDetails.applyAnnotationUsage(
+					HibernateAnnotations.TARGET,
+					xmlDocumentContext.getModelBuildingContext()
+			);
 			targetAnn.setAttributeValue( "value", determineTargetName( jaxbEmbedded.getTarget(), xmlDocumentContext ) );
 		}
 

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/xml/internal/attr/EmbeddedIdAttributeProcessing.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/xml/internal/attr/EmbeddedIdAttributeProcessing.java
@@ -8,13 +8,15 @@ package org.hibernate.boot.models.xml.internal.attr;
 
 import org.hibernate.boot.internal.Target;
 import org.hibernate.boot.jaxb.mapping.spi.JaxbEmbeddedIdImpl;
+import org.hibernate.boot.models.HibernateAnnotations;
+import org.hibernate.boot.models.JpaAnnotations;
 import org.hibernate.boot.models.xml.internal.XmlAnnotationHelper;
 import org.hibernate.boot.models.xml.internal.XmlProcessingHelper;
 import org.hibernate.boot.models.xml.spi.XmlDocumentContext;
 import org.hibernate.internal.util.StringHelper;
+import org.hibernate.models.spi.MutableAnnotationUsage;
 import org.hibernate.models.spi.MutableClassDetails;
 import org.hibernate.models.spi.MutableMemberDetails;
-import org.hibernate.models.spi.MutableAnnotationUsage;
 
 import jakarta.persistence.AccessType;
 import jakarta.persistence.EmbeddedId;
@@ -39,11 +41,17 @@ public class EmbeddedIdAttributeProcessing {
 				classDetails
 		);
 
-		final MutableAnnotationUsage<EmbeddedId> idAnn = XmlProcessingHelper.makeAnnotation( EmbeddedId.class, memberDetails, xmlDocumentContext );
+		final MutableAnnotationUsage<EmbeddedId> idAnn = memberDetails.applyAnnotationUsage(
+				JpaAnnotations.EMBEDDED_ID,
+				xmlDocumentContext.getModelBuildingContext()
+		);
 		CommonAttributeProcessing.applyAttributeBasics( jaxbEmbeddedId, memberDetails, idAnn, accessType, xmlDocumentContext );
 
 		if ( StringHelper.isNotEmpty( jaxbEmbeddedId.getTarget() ) ) {
-			final MutableAnnotationUsage<Target> targetAnn = XmlProcessingHelper.getOrMakeAnnotation( Target.class, memberDetails, xmlDocumentContext );
+			final MutableAnnotationUsage<Target> targetAnn = memberDetails.applyAnnotationUsage(
+					HibernateAnnotations.TARGET,
+					xmlDocumentContext.getModelBuildingContext()
+			);
 			targetAnn.setAttributeValue( "value", determineTargetName( jaxbEmbeddedId.getTarget(), xmlDocumentContext ) );
 		}
 

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/xml/internal/attr/ManyToManyAttributeProcessing.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/xml/internal/attr/ManyToManyAttributeProcessing.java
@@ -65,9 +65,7 @@ public class ManyToManyAttributeProcessing {
 
 		XmlAnnotationHelper.applySqlJoinTableRestriction( jaxbManyToMany.getSqlJoinTableRestriction(), memberDetails, xmlDocumentContext );
 
-		jaxbManyToMany.getJoinTableFilters().forEach( (jaxbFilter) -> {
-			XmlAnnotationHelper.applyJoinTableFilter( jaxbFilter, memberDetails, xmlDocumentContext );
-		} );
+		XmlAnnotationHelper.applyJoinTableFilters( jaxbManyToMany.getJoinTableFilters(), memberDetails, xmlDocumentContext );
 
 		return memberDetails;
 	}

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/xml/internal/attr/ManyToManyAttributeProcessing.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/xml/internal/attr/ManyToManyAttributeProcessing.java
@@ -7,20 +7,19 @@
 package org.hibernate.boot.models.xml.internal.attr;
 
 import org.hibernate.boot.jaxb.mapping.spi.JaxbManyToManyImpl;
+import org.hibernate.boot.models.JpaAnnotations;
 import org.hibernate.boot.models.xml.internal.XmlAnnotationHelper;
 import org.hibernate.boot.models.xml.internal.XmlProcessingHelper;
 import org.hibernate.boot.models.xml.internal.db.TableProcessing;
 import org.hibernate.boot.models.xml.spi.XmlDocumentContext;
 import org.hibernate.internal.util.StringHelper;
+import org.hibernate.models.spi.MutableAnnotationUsage;
 import org.hibernate.models.spi.MutableClassDetails;
 import org.hibernate.models.spi.MutableMemberDetails;
-import org.hibernate.models.spi.AnnotationDescriptor;
-import org.hibernate.models.spi.MutableAnnotationUsage;
 
 import jakarta.persistence.AccessType;
 import jakarta.persistence.ManyToMany;
 
-import static org.hibernate.boot.models.xml.internal.XmlProcessingHelper.getOrMakeAnnotation;
 import static org.hibernate.internal.util.NullnessHelper.coalesce;
 
 /**
@@ -74,18 +73,15 @@ public class ManyToManyAttributeProcessing {
 			JaxbManyToManyImpl jaxbManyToMany,
 			MutableMemberDetails memberDetails,
 			XmlDocumentContext xmlDocumentContext) {
-		final MutableAnnotationUsage<ManyToMany> manyToManyAnn = getOrMakeAnnotation(
-				ManyToMany.class,
-				memberDetails,
-				xmlDocumentContext
+		final MutableAnnotationUsage<ManyToMany> manyToManyAnn = memberDetails.applyAnnotationUsage(
+				JpaAnnotations.MANY_TO_MANY,
+				xmlDocumentContext.getModelBuildingContext()
 		);
-		final AnnotationDescriptor<ManyToMany> manyToManyDescriptor = xmlDocumentContext
-				.getModelBuildingContext()
-				.getAnnotationDescriptorRegistry()
-				.getDescriptor( ManyToMany.class );
 
-		XmlAnnotationHelper.applyOr( jaxbManyToMany, JaxbManyToManyImpl::getFetch, "fetch", manyToManyAnn, manyToManyDescriptor );
-		XmlAnnotationHelper.applyOr( jaxbManyToMany, JaxbManyToManyImpl::getMappedBy, "mappedBy", manyToManyAnn, manyToManyDescriptor );
+		if ( jaxbManyToMany != null ) {
+			XmlAnnotationHelper.applyOptionalAttribute( manyToManyAnn, "fetch", jaxbManyToMany.getFetch() );
+			XmlAnnotationHelper.applyOptionalAttribute( manyToManyAnn, "mappedBy", jaxbManyToMany.getMappedBy() );
+		}
 
 		return manyToManyAnn;
 	}

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/xml/internal/attr/ManyToOneAttributeProcessing.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/xml/internal/attr/ManyToOneAttributeProcessing.java
@@ -6,15 +6,13 @@
  */
 package org.hibernate.boot.models.xml.internal.attr;
 
-import java.util.EnumSet;
-import java.util.List;
-
 import org.hibernate.annotations.NotFound;
 import org.hibernate.annotations.NotFoundAction;
 import org.hibernate.annotations.OnDelete;
 import org.hibernate.annotations.OnDeleteAction;
 import org.hibernate.boot.internal.Target;
 import org.hibernate.boot.jaxb.mapping.spi.JaxbManyToOneImpl;
+import org.hibernate.boot.models.HibernateAnnotations;
 import org.hibernate.boot.models.JpaAnnotations;
 import org.hibernate.boot.models.xml.internal.XmlAnnotationHelper;
 import org.hibernate.boot.models.xml.internal.XmlProcessingHelper;
@@ -22,7 +20,6 @@ import org.hibernate.boot.models.xml.internal.db.JoinColumnProcessing;
 import org.hibernate.boot.models.xml.internal.db.TableProcessing;
 import org.hibernate.boot.models.xml.spi.XmlDocumentContext;
 import org.hibernate.internal.util.StringHelper;
-import org.hibernate.internal.util.collections.CollectionHelper;
 import org.hibernate.models.spi.MutableAnnotationUsage;
 import org.hibernate.models.spi.MutableClassDetails;
 import org.hibernate.models.spi.MutableMemberDetails;
@@ -74,12 +71,12 @@ public class ManyToOneAttributeProcessing {
 			MutableMemberDetails memberDetails,
 			JaxbManyToOneImpl jaxbManyToOne,
 			XmlDocumentContext xmlDocumentContext) {
-		final MutableAnnotationUsage<ManyToOne> manyToOneUsage = XmlProcessingHelper.getOrMakeAnnotation( ManyToOne.class, memberDetails, xmlDocumentContext );
-		XmlAnnotationHelper.applyOptionalAttribute(
-				manyToOneUsage,
-				"fetch",
-				jaxbManyToOne.getFetch()
+		final MutableAnnotationUsage<ManyToOne> manyToOneUsage = memberDetails.applyAnnotationUsage(
+				JpaAnnotations.MANY_TO_ONE,
+				xmlDocumentContext.getModelBuildingContext()
 		);
+
+		XmlAnnotationHelper.applyOptionalAttribute( manyToOneUsage, "fetch", jaxbManyToOne.getFetch() );
 
 		if ( jaxbManyToOne.isId() == Boolean.TRUE ) {
 			memberDetails.applyAnnotationUsage( JpaAnnotations.ID, xmlDocumentContext.getModelBuildingContext() );
@@ -106,7 +103,10 @@ public class ManyToOneAttributeProcessing {
 			return;
 		}
 
-		final MutableAnnotationUsage<NotFound> notFoundAnn = XmlProcessingHelper.makeAnnotation( NotFound.class, memberDetails, xmlDocumentContext );
+		final MutableAnnotationUsage<NotFound> notFoundAnn = memberDetails.applyAnnotationUsage(
+				HibernateAnnotations.NOT_FOUND,
+				xmlDocumentContext.getModelBuildingContext()
+		);
 		notFoundAnn.setAttributeValue( "action", notFoundAction );
 	}
 
@@ -121,7 +121,10 @@ public class ManyToOneAttributeProcessing {
 			return;
 		}
 
-		final MutableAnnotationUsage<OnDelete> notFoundAnn = XmlProcessingHelper.makeAnnotation( OnDelete.class, memberDetails, xmlDocumentContext );
+		final MutableAnnotationUsage<OnDelete> notFoundAnn = memberDetails.applyAnnotationUsage(
+				HibernateAnnotations.ON_DELETE,
+				xmlDocumentContext.getModelBuildingContext()
+		);
 		notFoundAnn.setAttributeValue( "action", action );
 	}
 
@@ -136,13 +139,10 @@ public class ManyToOneAttributeProcessing {
 			return;
 		}
 
-		final MutableAnnotationUsage<Target> targetAnn = XmlProcessingHelper.makeAnnotation( Target.class, memberDetails, xmlDocumentContext );
+		final MutableAnnotationUsage<Target> targetAnn = memberDetails.applyAnnotationUsage(
+				HibernateAnnotations.TARGET,
+				xmlDocumentContext.getModelBuildingContext()
+		);
 		targetAnn.setAttributeValue( "value", determineTargetName( targetEntityName, xmlDocumentContext ) );
-	}
-
-	private static <E extends Enum<E>> List<E> asList(EnumSet<E> enums) {
-		final List<E> list = CollectionHelper.arrayList( enums.size() );
-		list.addAll( enums );
-		return list;
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/xml/internal/attr/OneToManyAttributeProcessing.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/xml/internal/attr/OneToManyAttributeProcessing.java
@@ -66,10 +66,8 @@ public class OneToManyAttributeProcessing {
 		TableProcessing.transformJoinTable( jaxbOneToMany.getJoinTable(), memberDetails, xmlDocumentContext );
 
 		XmlAnnotationHelper.applySqlJoinTableRestriction( jaxbOneToMany.getSqlJoinTableRestriction(), memberDetails, xmlDocumentContext );
+		XmlAnnotationHelper.applyJoinTableFilters( jaxbOneToMany.getJoinTableFilters(), memberDetails, xmlDocumentContext );
 
-		jaxbOneToMany.getJoinTableFilters().forEach( (jaxbFilter) -> {
-			XmlAnnotationHelper.applyJoinTableFilter( jaxbFilter, memberDetails, xmlDocumentContext );
-		} );
 
 		// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 		// other properties

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/xml/internal/attr/OneToManyAttributeProcessing.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/xml/internal/attr/OneToManyAttributeProcessing.java
@@ -14,6 +14,7 @@ import org.hibernate.boot.models.HibernateAnnotations;
 import org.hibernate.boot.models.JpaAnnotations;
 import org.hibernate.boot.models.xml.internal.XmlAnnotationHelper;
 import org.hibernate.boot.models.xml.internal.XmlProcessingHelper;
+import org.hibernate.boot.models.xml.internal.db.JoinColumnProcessing;
 import org.hibernate.boot.models.xml.internal.db.TableProcessing;
 import org.hibernate.boot.models.xml.spi.XmlDocumentContext;
 import org.hibernate.internal.util.StringHelper;
@@ -73,9 +74,7 @@ public class OneToManyAttributeProcessing {
 		// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 		// other properties
 
-		jaxbOneToMany.getJoinColumn().forEach( jaxbJoinColumn -> {
-			XmlAnnotationHelper.applyJoinColumn( jaxbJoinColumn, memberDetails, xmlDocumentContext );
-		} );
+		JoinColumnProcessing.applyJoinColumns( jaxbOneToMany.getJoinColumn(), memberDetails, xmlDocumentContext );
 
 		if ( jaxbOneToMany.getOnDelete() != null ) {
 			final MutableAnnotationUsage<OnDelete> onDeleteAnn = memberDetails.applyAnnotationUsage(

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/xml/internal/attr/OneToOneAttributeProcessing.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/xml/internal/attr/OneToOneAttributeProcessing.java
@@ -20,6 +20,7 @@ import org.hibernate.models.spi.MutableClassDetails;
 import org.hibernate.models.spi.MutableMemberDetails;
 
 import jakarta.persistence.AccessType;
+import jakarta.persistence.MapsId;
 import jakarta.persistence.OneToOne;
 
 import static org.hibernate.boot.models.xml.internal.XmlAnnotationHelper.applyCascading;
@@ -67,11 +68,11 @@ public class OneToOneAttributeProcessing {
 		}
 
 		if ( StringHelper.isNotEmpty( jaxbOneToOne.getMapsId() ) ) {
-			memberDetails.applyAnnotationUsage(
+			final MutableAnnotationUsage<MapsId> mapsIdAnn = memberDetails.applyAnnotationUsage(
 					JpaAnnotations.MAPS_ID,
-					(usage) -> usage.setAttributeValue( "value", jaxbOneToOne.getMapsId() ),
 					xmlDocumentContext.getModelBuildingContext()
 			);
+			mapsIdAnn.setAttributeValue( "value", jaxbOneToOne.getMapsId() );
 		}
 
 		return memberDetails;
@@ -81,24 +82,20 @@ public class OneToOneAttributeProcessing {
 			MutableMemberDetails memberDetails,
 			JaxbOneToOneImpl jaxbOneToOne,
 			XmlDocumentContext xmlDocumentContext) {
-		return memberDetails.applyAnnotationUsage(
-				JpaAnnotations.ONE_TO_ONE,
-				(usage) -> {
-					if ( jaxbOneToOne.getFetch() != null ) {
-						usage.setAttributeValue( "fetch", jaxbOneToOne.getFetch() );
-					}
-					if ( jaxbOneToOne.isOptional() != null ) {
-						usage.setAttributeValue( "optional", jaxbOneToOne.isOptional() );
-					}
-					if ( StringHelper.isNotEmpty( jaxbOneToOne.getMappedBy() ) ) {
-						usage.setAttributeValue( "mappedBy", jaxbOneToOne.getMappedBy() );
-					}
-					if ( jaxbOneToOne.isOrphanRemoval() != null ) {
-						usage.setAttributeValue( "orphanRemoval", jaxbOneToOne.isOrphanRemoval() );
-					}
-				},
-				xmlDocumentContext.getModelBuildingContext()
-		);
+		final MutableAnnotationUsage<OneToOne> usage = memberDetails.applyAnnotationUsage( JpaAnnotations.ONE_TO_ONE, xmlDocumentContext.getModelBuildingContext() );
+		if ( jaxbOneToOne.getFetch() != null ) {
+			usage.setAttributeValue( "fetch", jaxbOneToOne.getFetch() );
+		}
+		if ( jaxbOneToOne.isOptional() != null ) {
+			usage.setAttributeValue( "optional", jaxbOneToOne.isOptional() );
+		}
+		if ( StringHelper.isNotEmpty( jaxbOneToOne.getMappedBy() ) ) {
+			usage.setAttributeValue( "mappedBy", jaxbOneToOne.getMappedBy() );
+		}
+		if ( jaxbOneToOne.isOrphanRemoval() != null ) {
+			usage.setAttributeValue( "orphanRemoval", jaxbOneToOne.isOrphanRemoval() );
+		}
+		return usage;
 	}
 
 	@SuppressWarnings("unused")

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/xml/internal/db/ColumnProcessing.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/xml/internal/db/ColumnProcessing.java
@@ -19,12 +19,12 @@ import org.hibernate.boot.jaxb.mapping.spi.db.JaxbColumnSizable;
 import org.hibernate.boot.jaxb.mapping.spi.db.JaxbColumnStandard;
 import org.hibernate.boot.jaxb.mapping.spi.db.JaxbColumnUniqueable;
 import org.hibernate.boot.jaxb.mapping.spi.db.JaxbCommentable;
+import org.hibernate.boot.models.JpaAnnotations;
 import org.hibernate.boot.models.internal.AnnotationUsageHelper;
 import org.hibernate.boot.models.xml.internal.XmlAnnotationHelper;
 import org.hibernate.boot.models.xml.internal.XmlProcessingHelper;
 import org.hibernate.boot.models.xml.spi.XmlDocumentContext;
 import org.hibernate.models.spi.AnnotationTarget;
-import org.hibernate.models.spi.MutableAnnotationTarget;
 import org.hibernate.models.spi.MutableAnnotationUsage;
 import org.hibernate.models.spi.MutableMemberDetails;
 
@@ -210,8 +210,10 @@ public class ColumnProcessing {
 			return;
 		}
 
-		final MutableAnnotationUsage<MapKeyColumn> columnAnn = XmlProcessingHelper.getOrMakeAnnotation( MapKeyColumn.class, memberDetails, xmlDocumentContext );
-
+		final MutableAnnotationUsage<MapKeyColumn> columnAnn = memberDetails.applyAnnotationUsage(
+				JpaAnnotations.MAP_KEY_COLUMN,
+				xmlDocumentContext.getModelBuildingContext()
+		);
 		applyColumnDetails( jaxbMapKeyColumn, memberDetails, columnAnn, xmlDocumentContext );
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/xml/internal/db/ColumnProcessing.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/xml/internal/db/ColumnProcessing.java
@@ -72,7 +72,7 @@ public class ColumnProcessing {
 		applyColumnDefinition( jaxbColumn, columnAnn, xmlDocumentContext );
 		applyColumnUniqueness( jaxbColumn, columnAnn, xmlDocumentContext );
 		applyColumnComment( jaxbColumn, columnAnn, xmlDocumentContext );
-		XmlAnnotationHelper.applyCheckConstraints( jaxbColumn, columnAnn, xmlDocumentContext );
+		XmlAnnotationHelper.applyCheckConstraints( jaxbColumn, null, columnAnn, xmlDocumentContext );
 
 		if ( jaxbColumn instanceof JaxbColumnSizable sizable ) {
 			applyColumnSizing( sizable, columnAnn, xmlDocumentContext );
@@ -94,7 +94,7 @@ public class ColumnProcessing {
 		applyColumnSizing( jaxbColumn, columnAnn, xmlDocumentContext );
 		applyColumnUniqueness( jaxbColumn, columnAnn, xmlDocumentContext );
 		applyColumnComment( jaxbColumn, columnAnn, xmlDocumentContext );
-		XmlAnnotationHelper.applyCheckConstraints( jaxbColumn, columnAnn, xmlDocumentContext );
+		XmlAnnotationHelper.applyCheckConstraints( jaxbColumn, null, columnAnn, xmlDocumentContext );
 	}
 
 	public static <A extends Annotation> void applyColumnDetails(

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/xml/internal/db/ForeignKeyProcessing.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/xml/internal/db/ForeignKeyProcessing.java
@@ -11,7 +11,6 @@ import org.hibernate.boot.models.JpaAnnotations;
 import org.hibernate.boot.models.xml.internal.XmlAnnotationHelper;
 import org.hibernate.boot.models.xml.spi.XmlDocumentContext;
 import org.hibernate.models.spi.AnnotationTarget;
-import org.hibernate.models.spi.MemberDetails;
 import org.hibernate.models.spi.MutableAnnotationUsage;
 import org.hibernate.models.spi.MutableMemberDetails;
 
@@ -40,16 +39,29 @@ public class ForeignKeyProcessing {
 		if ( jaxbForeignKey == null ) {
 			return null;
 		}
-		return memberDetails.applyAnnotationUsage(
+		final MutableAnnotationUsage<ForeignKey> foreignKeyUsage = memberDetails.applyAnnotationUsage(
 				JpaAnnotations.FOREIGN_KEY,
-				(foreignKeyUsage) -> {
-					XmlAnnotationHelper.applyOptionalAttribute( foreignKeyUsage, "name", jaxbForeignKey.getName() );
-					XmlAnnotationHelper.applyOptionalAttribute( foreignKeyUsage, "value", jaxbForeignKey.getConstraintMode() );
-					XmlAnnotationHelper.applyOptionalAttribute( foreignKeyUsage, "foreignKeyDefinition", jaxbForeignKey.getForeignKeyDefinition() );
-					XmlAnnotationHelper.applyOptionalAttribute( foreignKeyUsage, "options", jaxbForeignKey.getOptions() );
-				},
 				xmlDocumentContext.getModelBuildingContext()
 		);
+
+		XmlAnnotationHelper.applyOptionalAttribute( foreignKeyUsage, "name", jaxbForeignKey.getName() );
+		XmlAnnotationHelper.applyOptionalAttribute(
+				foreignKeyUsage,
+				"value",
+				jaxbForeignKey.getConstraintMode()
+		);
+		XmlAnnotationHelper.applyOptionalAttribute(
+				foreignKeyUsage,
+				"foreignKeyDefinition",
+				jaxbForeignKey.getForeignKeyDefinition()
+		);
+		XmlAnnotationHelper.applyOptionalAttribute(
+				foreignKeyUsage,
+				"options",
+				jaxbForeignKey.getOptions()
+		);
+
+		return foreignKeyUsage;
 	}
 
 	public static MutableAnnotationUsage<ForeignKey> createNestedForeignKeyAnnotation(
@@ -59,7 +71,7 @@ public class ForeignKeyProcessing {
 		assert jaxbForeignKey != null;
 
 		final MutableAnnotationUsage<ForeignKey> foreignKeyUsage = JpaAnnotations.FOREIGN_KEY.createUsage(
-				annotationTarget,
+				null,
 				xmlDocumentContext.getModelBuildingContext()
 		);
 

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/xml/internal/db/JoinColumnProcessing.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/xml/internal/db/JoinColumnProcessing.java
@@ -23,7 +23,6 @@ import org.hibernate.boot.models.xml.spi.XmlDocumentContext;
 import org.hibernate.internal.util.collections.CollectionHelper;
 import org.hibernate.models.spi.AnnotationTarget;
 import org.hibernate.models.spi.AnnotationUsage;
-import org.hibernate.models.spi.MutableAnnotationTarget;
 import org.hibernate.models.spi.MutableAnnotationUsage;
 import org.hibernate.models.spi.MutableMemberDetails;
 
@@ -213,10 +212,9 @@ public class JoinColumnProcessing {
 			XmlAnnotationHelper.applyJoinColumn( jaxbJoinColumns.get( 0 ), memberDetails, xmlDocumentContext );
 		}
 		else {
-			final MutableAnnotationUsage<JoinColumns> columnsAnn = XmlProcessingHelper.makeAnnotation(
-					JoinColumns.class,
-					memberDetails,
-					xmlDocumentContext
+			final MutableAnnotationUsage<JoinColumns> columnsAnn = memberDetails.applyAnnotationUsage(
+					JpaAnnotations.JOIN_COLUMNS,
+					xmlDocumentContext.getModelBuildingContext()
 			);
 			columnsAnn.setAttributeValue( "value", createJoinColumns( jaxbJoinColumns, memberDetails, xmlDocumentContext ) );
 		}

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/xml/internal/db/JoinColumnProcessing.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/xml/internal/db/JoinColumnProcessing.java
@@ -21,6 +21,7 @@ import org.hibernate.boot.models.xml.internal.XmlAnnotationHelper;
 import org.hibernate.boot.models.xml.internal.XmlProcessingHelper;
 import org.hibernate.boot.models.xml.spi.XmlDocumentContext;
 import org.hibernate.internal.util.collections.CollectionHelper;
+import org.hibernate.models.spi.AnnotationDescriptor;
 import org.hibernate.models.spi.AnnotationTarget;
 import org.hibernate.models.spi.AnnotationUsage;
 import org.hibernate.models.spi.MutableAnnotationUsage;
@@ -164,10 +165,10 @@ public class JoinColumnProcessing {
 	public static <A extends Annotation> MutableAnnotationUsage<A> createJoinColumnAnnotation(
 			JaxbColumnJoined jaxbJoinColumn,
 			MutableMemberDetails memberDetails,
-			Class<A> annotationType,
+			AnnotationDescriptor<A> annotationDescriptor,
 			XmlDocumentContext xmlDocumentContext) {
 		final MutableAnnotationUsage<A> joinColumnAnn = XmlProcessingHelper.getOrMakeNamedAnnotation(
-				annotationType,
+				annotationDescriptor,
 				jaxbJoinColumn.getName(),
 				memberDetails,
 				xmlDocumentContext
@@ -208,15 +209,10 @@ public class JoinColumnProcessing {
 			return;
 		}
 
-		if ( jaxbJoinColumns.size() == 1 ) {
-			XmlAnnotationHelper.applyJoinColumn( jaxbJoinColumns.get( 0 ), memberDetails, xmlDocumentContext );
-		}
-		else {
-			final MutableAnnotationUsage<JoinColumns> columnsAnn = memberDetails.applyAnnotationUsage(
-					JpaAnnotations.JOIN_COLUMNS,
-					xmlDocumentContext.getModelBuildingContext()
-			);
-			columnsAnn.setAttributeValue( "value", createJoinColumns( jaxbJoinColumns, memberDetails, xmlDocumentContext ) );
-		}
+		final MutableAnnotationUsage<JoinColumns> columnsAnn = memberDetails.applyAnnotationUsage(
+				JpaAnnotations.JOIN_COLUMNS,
+				xmlDocumentContext.getModelBuildingContext()
+		);
+		columnsAnn.setAttributeValue( "value", createJoinColumns( jaxbJoinColumns, memberDetails, xmlDocumentContext ) );
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/xml/internal/db/JoinColumnProcessing.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/xml/internal/db/JoinColumnProcessing.java
@@ -153,7 +153,7 @@ public class JoinColumnProcessing {
 		final List<AnnotationUsage<JoinColumn>> joinColumns = new ArrayList<>( jaxbJoinColumns.size() );
 		jaxbJoinColumns.forEach( jaxbJoinColumn -> {
 			final MutableAnnotationUsage<JoinColumn> joinColumnAnn = JpaAnnotations.JOIN_COLUMN.createUsage(
-					annotationTarget,
+					null,
 					xmlDocumentContext.getModelBuildingContext()
 			);
 			transferJoinColumn( jaxbJoinColumn, joinColumnAnn, null, xmlDocumentContext );

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/xml/internal/db/TableProcessing.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/xml/internal/db/TableProcessing.java
@@ -12,7 +12,6 @@ import org.hibernate.boot.jaxb.mapping.spi.JaxbJoinColumnImpl;
 import org.hibernate.boot.jaxb.mapping.spi.JaxbJoinTableImpl;
 import org.hibernate.boot.models.JpaAnnotations;
 import org.hibernate.boot.models.xml.internal.XmlAnnotationHelper;
-import org.hibernate.boot.models.xml.internal.XmlProcessingHelper;
 import org.hibernate.boot.models.xml.spi.XmlDocumentContext;
 import org.hibernate.internal.util.collections.CollectionHelper;
 import org.hibernate.models.spi.AnnotationTarget;
@@ -39,23 +38,6 @@ public class TableProcessing {
 		);
 		applyJoinTable( jaxbJoinTable, joinTableUsage, target, xmlDocumentContext );
 		return joinTableUsage;
-	}
-
-	public static MutableAnnotationUsage<JoinTable> createNestedJoinTable(
-			JaxbJoinTableImpl jaxbJoinTable,
-			AnnotationTarget annotationTarget,
-			XmlDocumentContext xmlDocumentContext) {
-		if ( jaxbJoinTable == null ) {
-			return null;
-		}
-
-		final MutableAnnotationUsage<JoinTable> joinTableAnn = XmlProcessingHelper.makeNestedAnnotation(
-				JoinTable.class,
-				annotationTarget,
-				xmlDocumentContext
-		);
-		applyJoinTable( jaxbJoinTable, joinTableAnn, annotationTarget, xmlDocumentContext );
-		return joinTableAnn;
 	}
 
 	private static void applyJoinTable(

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/xml/internal/db/TableProcessing.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/xml/internal/db/TableProcessing.java
@@ -16,10 +16,9 @@ import org.hibernate.boot.models.xml.internal.XmlProcessingHelper;
 import org.hibernate.boot.models.xml.spi.XmlDocumentContext;
 import org.hibernate.internal.util.collections.CollectionHelper;
 import org.hibernate.models.spi.AnnotationTarget;
+import org.hibernate.models.spi.MutableAnnotationTarget;
 import org.hibernate.models.spi.MutableAnnotationUsage;
-import org.hibernate.models.spi.MutableMemberDetails;
 
-import jakarta.persistence.AssociationOverride;
 import jakarta.persistence.JoinTable;
 
 /**
@@ -28,17 +27,17 @@ import jakarta.persistence.JoinTable;
 public class TableProcessing {
 	public static MutableAnnotationUsage<JoinTable> transformJoinTable(
 			JaxbJoinTableImpl jaxbJoinTable,
-			MutableMemberDetails memberDetails,
+			MutableAnnotationTarget target,
 			XmlDocumentContext xmlDocumentContext) {
 		if ( jaxbJoinTable == null ) {
 			return null;
 		}
 
-		final MutableAnnotationUsage<JoinTable> joinTableUsage = memberDetails.applyAnnotationUsage(
+		final MutableAnnotationUsage<JoinTable> joinTableUsage = target.applyAnnotationUsage(
 				JpaAnnotations.JOIN_TABLE,
 				xmlDocumentContext.getModelBuildingContext()
 		);
-		applyJoinTable( jaxbJoinTable, joinTableUsage, memberDetails, xmlDocumentContext );
+		applyJoinTable( jaxbJoinTable, joinTableUsage, target, xmlDocumentContext );
 		return joinTableUsage;
 	}
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/derivedidentities/e1/b/specjmapid/lazy/CompositeKeyDeleteTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/derivedidentities/e1/b/specjmapid/lazy/CompositeKeyDeleteTest.java
@@ -22,12 +22,12 @@ public class CompositeKeyDeleteTest extends BaseCoreFunctionalTestCase {
 
    @Override
    protected String getBaseForMappings() {
-      return "org/hibernate/orm/test/";
+      return "";
    }
 
    @Override
    public String[] getMappings() {
-      return new String[] { "annotations/derivedidentities/e1/b/specjmapid/lazy/order_orm.xml" };
+      return new String[] { "org/hibernate/orm/test/annotations/derivedidentities/e1/b/specjmapid/lazy/order_orm.xml" };
    }
 
    public CompositeKeyDeleteTest() {

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/xml/ejb3/Ejb3XmlElementCollectionTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/xml/ejb3/Ejb3XmlElementCollectionTest.java
@@ -214,8 +214,8 @@ public class Ejb3XmlElementCollectionTest extends Ejb3XmlTestCase {
 	public void testSingleMapKeyAttributeOverride() {
 		final MemberDetails memberDetails = getAttributeMember( Entity3.class, "field1", "element-collection.orm10.xml" );
 		assertThat( memberDetails.hasAnnotationUsage( ElementCollection.class ) ).isTrue();
-		assertThat( memberDetails.hasAnnotationUsage( AttributeOverride.class ) ).isTrue();
-		assertThat( memberDetails.hasAnnotationUsage( AttributeOverrides.class ) ).isFalse();
+		assertThat( memberDetails.hasAnnotationUsage( AttributeOverride.class ) ).isFalse();
+		assertThat( memberDetails.hasAnnotationUsage( AttributeOverrides.class ) ).isTrue();
 
 		final AnnotationUsage<AttributeOverride> attributeOverrideUsage = memberDetails.getAnnotationUsage( AttributeOverride.class );
 		assertThat( attributeOverrideUsage.getString( "name" ) ).isEqualTo( "key.field1" );
@@ -440,8 +440,8 @@ public class Ejb3XmlElementCollectionTest extends Ejb3XmlTestCase {
 		final MemberDetails memberDetails = getAttributeMember( Entity3.class, "field1", "element-collection.orm21.xml" );
 		assertThat( memberDetails.hasAnnotationUsage( ElementCollection.class ) ).isTrue();
 
-		assertThat( memberDetails.hasAnnotationUsage( AttributeOverride.class ) ).isTrue();
-		assertThat( memberDetails.hasAnnotationUsage( AttributeOverrides.class ) ).isFalse();
+		assertThat( memberDetails.hasAnnotationUsage( AttributeOverride.class ) ).isFalse();
+		assertThat( memberDetails.hasAnnotationUsage( AttributeOverrides.class ) ).isTrue();
 
 		final AnnotationUsage<AttributeOverride> overrideUsage = memberDetails.getAnnotationUsage( AttributeOverride.class );
 		assertThat( overrideUsage.getString( "name" ) ).isEqualTo( "value.field1" );
@@ -527,8 +527,8 @@ public class Ejb3XmlElementCollectionTest extends Ejb3XmlTestCase {
 		final MemberDetails memberDetails = getAttributeMember( Entity3.class, "field1", "element-collection.orm24.xml" );
 		assertThat( memberDetails.hasAnnotationUsage( ElementCollection.class ) ).isTrue();
 
-		assertThat( memberDetails.hasAnnotationUsage( AssociationOverride.class ) ).isTrue();
-		assertThat( memberDetails.hasAnnotationUsage( AssociationOverrides.class ) ).isFalse();
+		assertThat( memberDetails.hasAnnotationUsage( AssociationOverride.class ) ).isFalse();
+		assertThat( memberDetails.hasAnnotationUsage( AssociationOverrides.class ) ).isTrue();
 
 		final AnnotationUsage<AssociationOverride> overrideUsage = memberDetails.getAnnotationUsage( AssociationOverride.class );
 		assertThat( overrideUsage.getString( "name" ) ).isEqualTo( "association1" );

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/xml/ejb3/Ejb3XmlManyToOneTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/xml/ejb3/Ejb3XmlManyToOneTest.java
@@ -60,8 +60,8 @@ public class Ejb3XmlManyToOneTest extends Ejb3XmlTestCase {
 		final MemberDetails memberDetails = getAttributeMember( Entity1.class, "field1", "many-to-one.orm2.xml" );
 		assertThat( memberDetails.hasAnnotationUsage( ManyToOne.class ) ).isTrue();
 
-		assertThat( memberDetails.hasAnnotationUsage( JoinColumn.class ) ).isTrue();
-		assertThat( memberDetails.hasAnnotationUsage( JoinColumns.class ) ).isFalse();
+		assertThat( memberDetails.hasAnnotationUsage( JoinColumn.class ) ).isFalse();
+		assertThat( memberDetails.hasAnnotationUsage( JoinColumns.class ) ).isTrue();
 
 		assertThat( memberDetails.hasAnnotationUsage( JoinTable.class ) ).isFalse();
 		assertThat( memberDetails.hasAnnotationUsage( Id.class ) ).isFalse();

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/xml/ejb3/Ejb3XmlOneToOneTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/xml/ejb3/Ejb3XmlOneToOneTest.java
@@ -119,8 +119,8 @@ public class Ejb3XmlOneToOneTest extends Ejb3XmlTestCase {
 	public void testSingleJoinColumn() {
 		final MemberDetails memberDetails = getAttributeMember( Entity1.class, "field1", "one-to-one.orm4.xml" );
 		assertThat( memberDetails.hasAnnotationUsage( OneToOne.class ) ).isTrue();
-		assertThat( memberDetails.hasAnnotationUsage( JoinColumn.class ) ).isTrue();
-		assertThat( memberDetails.hasAnnotationUsage( JoinColumns.class ) ).isFalse();
+		assertThat( memberDetails.hasAnnotationUsage( JoinColumn.class ) ).isFalse();
+		assertThat( memberDetails.hasAnnotationUsage( JoinColumns.class ) ).isTrue();
 
 		assertThat( memberDetails.hasAnnotationUsage( MapsId.class ) ).isFalse();
 		assertThat( memberDetails.hasAnnotationUsage( Id.class ) ).isFalse();

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/intg/AdditionalMappingContributorTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/intg/AdditionalMappingContributorTests.java
@@ -22,6 +22,7 @@ import org.hibernate.models.internal.dynamic.DynamicClassDetails;
 import org.hibernate.models.internal.jdk.JdkClassDetails;
 import org.hibernate.models.spi.ClassDetails;
 import org.hibernate.models.spi.ClassDetailsRegistry;
+import org.hibernate.models.spi.MutableAnnotationUsage;
 import org.hibernate.models.spi.MutableMemberDetails;
 
 import org.hibernate.testing.orm.junit.BootstrapServiceRegistry;
@@ -328,11 +329,11 @@ public class AdditionalMappingContributorTests {
 								modelBuildingContext
 						);
 
-						jdkClassDetails.applyAnnotationUsage(
+						final MutableAnnotationUsage<Entity> entityUsage = jdkClassDetails.applyAnnotationUsage(
 								JpaAnnotations.ENTITY,
-								(entityUsage) -> entityUsage.setAttributeValue( "name", "___Entity5___" ),
 								modelBuildingContext
 						);
+						entityUsage.setAttributeValue( "name", "___Entity5___" );
 
 						final MutableMemberDetails idField = (MutableMemberDetails) jdkClassDetails.findFieldByName( "id" );
 						idField.applyAnnotationUsage( JpaAnnotations.ID, modelBuildingContext );
@@ -368,11 +369,11 @@ public class AdditionalMappingContributorTests {
 						assertThat( modelBuildingContext ).isSameAs( buildingContext.getMetadataCollector().getSourceModelBuildingContext() );
 
 						final DynamicClassDetails classDetails = new DynamicClassDetails( "Entity6", modelBuildingContext );
-						classDetails.applyAnnotationUsage(
+						final MutableAnnotationUsage<Entity> entityUsage = classDetails.applyAnnotationUsage(
 								JpaAnnotations.ENTITY,
-								(config) -> config.setAttributeValue( "name", "Entity6" ),
 								modelBuildingContext
 						);
+						entityUsage.setAttributeValue( "name", "Entity6" );
 						classDetails.applyAttribute(
 								"id",
 								classDetailsRegistry.resolveClassDetails( Integer.class.getName() ),


### PR DESCRIPTION
Prefer using creation methods from `AnnotationDescriptor` and `MutableAnnotationTarget`

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-18000
<!-- Hibernate GitHub Bot issue links end -->