### PR TITLE
Upgrade to hibernate-jenkins-pipeline-helpers 1.11

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -13,7 +13,7 @@ import org.jenkinsci.plugins.workflow.support.steps.build.RunWrapper
 /*
  * See https://github.com/hibernate/hibernate-jenkins-pipeline-helpers
  */
-@Library('hibernate-jenkins-pipeline-helpers@1.9') _
+@Library('hibernate-jenkins-pipeline-helpers@1.11') _
 import org.hibernate.jenkins.pipeline.helpers.job.JobHelper
 
 @Field final String DEFAULT_JDK_VERSION = '11'

--- a/ci/jpa-3.1-tck.Jenkinsfile
+++ b/ci/jpa-3.1-tck.Jenkinsfile
@@ -1,4 +1,4 @@
-@Library('hibernate-jenkins-pipeline-helpers@1.5') _
+@Library('hibernate-jenkins-pipeline-helpers@1.11') _
 
 // Avoid running the pipeline on branch indexing
 if (currentBuild.getBuildCauses().toString().contains('BranchIndexingCause')) {

--- a/ci/release/Jenkinsfile
+++ b/ci/release/Jenkinsfile
@@ -9,7 +9,7 @@
 /*
  * See https://github.com/hibernate/hibernate-jenkins-pipeline-helpers
  */
-@Library('hibernate-jenkins-pipeline-helpers@1.5') _
+@Library('hibernate-jenkins-pipeline-helpers@1.11') _
 
 // Avoid running the pipeline on branch indexing
 if (currentBuild.getBuildCauses().toString().contains('BranchIndexingCause')) {

--- a/ci/snapshot-publish.Jenkinsfile
+++ b/ci/snapshot-publish.Jenkinsfile
@@ -1,7 +1,7 @@
 /*
  * See https://github.com/hibernate/hibernate-jenkins-pipeline-helpers
  */
-@Library('hibernate-jenkins-pipeline-helpers@1.5') _
+@Library('hibernate-jenkins-pipeline-helpers@1.11') _
 
 // Avoid running the pipeline on branch indexing
 if (currentBuild.getBuildCauses().toString().contains('BranchIndexingCause')) {

--- a/nightly.Jenkinsfile
+++ b/nightly.Jenkinsfile
@@ -13,7 +13,7 @@ import org.jenkinsci.plugins.workflow.support.steps.build.RunWrapper
 /*
  * See https://github.com/hibernate/hibernate-jenkins-pipeline-helpers
  */
-@Library('hibernate-jenkins-pipeline-helpers@1.5') _
+@Library('hibernate-jenkins-pipeline-helpers@1.11') _
 import org.hibernate.jenkins.pipeline.helpers.job.JobHelper
 
 @Field final String DEFAULT_JDK_VERSION = '11'


### PR DESCRIPTION
Mainly to improve tracing in case `requireApprovalForPullRequest` doesn't work properly, but also simply to keep things up to date.

https://github.com/hibernate/hibernate-jenkins-pipeline-helpers/compare/1.9...1.11 https://github.com/hibernate/hibernate-jenkins-pipeline-helpers/compare/1.5...1.11