### PR TITLE
Develocity reports improvements

### DIFF
--- a/.github/hibernate-github-bot.yml
+++ b/.github/hibernate-github-bot.yml
@@ -40,3 +40,17 @@ jira:
 develocity:
   buildScan:
     addCheck: true
+    tags:
+      - column: "OS"
+        pattern: "Linux"
+      - column: "OS"
+        pattern: "Windows.*"
+        replacement: "Windows"
+      - column: "Java"
+        pattern: "jdk-(.*)"
+        replacement: "$1"
+      - column: "DB"
+        pattern: "(h2|postgres(ql)?|pgsql|mysql|mariadb|mssql|derby|tidb|cockroach(db)?|oracle.*|db2|hsqldb|edb|sybase)(_ci)?"
+        replacement: "$1"
+      - pattern: "main|HEAD|\\d+.\\d+|PR-\\d+"
+        replacement: "" # Just remove these tags

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -244,7 +244,7 @@ void ciBuild(buildEnv, String args) {
 		def develocityCredentialsId = buildEnv.node ? 'ge.hibernate.org-access-key-pr' : 'ge.hibernate.org-access-key'
 
 		withCredentials([string(credentialsId: develocityCredentialsId,
-				variable: 'GRADLE_ENTERPRISE_ACCESS_KEY')]) {
+				variable: 'DEVELOCITY_ACCESS_KEY')]) {
 			withGradle { // withDevelocity, actually: https://plugins.jenkins.io/gradle/#plugin-content-capturing-build-scans-from-jenkins-pipeline
 				sh "./ci/build.sh $args"
 			}
@@ -257,7 +257,7 @@ void ciBuild(buildEnv, String args) {
 			sh "./ci/build.sh $args"
 		}, { // Finally
 			withCredentials([string(credentialsId: 'ge.hibernate.org-access-key-pr',
-					variable: 'GRADLE_ENTERPRISE_ACCESS_KEY')]) {
+					variable: 'DEVELOCITY_ACCESS_KEY')]) {
 				withGradle { // withDevelocity, actually: https://plugins.jenkins.io/gradle/#plugin-content-capturing-build-scans-from-jenkins-pipeline
 					sh './gradlew buildScanPublishPrevious'
 				}


### PR DESCRIPTION
1. Rename some env variables to remove a few warnings
2. Enable build scans in night Jenkins jobs (for some reason there were not enabled there)
3. Improve the format of the report

Regarding the report, here's what it looks like before recent changes to the bot, and before this patch:

![image](https://github.com/hibernate/hibernate-orm/assets/412878/22d2c071-deb0-4e3b-b6e3-6683781a36c9)

And here's what it could looks like after the patch (example with Hibernate Search):

![image](https://github.com/hibernate/hibernate-orm/assets/412878/6b1538e5-120b-4cf5-8bad-5d1951b35c98)
