### PR TITLE
HHH-18035 Change Oracle default timestamp precision to 9

### DIFF
--- a/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/OracleLegacyDialect.java
+++ b/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/OracleLegacyDialect.java
@@ -1210,6 +1210,12 @@ public class OracleLegacyDialect extends Dialect {
 	}
 
 	@Override
+	public int getDefaultTimestampPrecision() {
+		// 9 is supported at least since v10
+		return getVersion().isSameOrAfter( 10 ) ? 9 : 6;
+	}
+
+	@Override
 	public CallableStatementSupport getCallableStatementSupport() {
 		// Oracle supports returning cursors
 		return StandardCallableStatementSupport.REF_CURSOR_INSTANCE;

--- a/hibernate-core/src/main/java/org/hibernate/dialect/OracleDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/OracleDialect.java
@@ -1256,6 +1256,11 @@ public class OracleDialect extends Dialect {
 	}
 
 	@Override
+	public int getDefaultTimestampPrecision() {
+		return 9;
+	}
+
+	@Override
 	public CallableStatementSupport getCallableStatementSupport() {
 		// Oracle supports returning cursors
 		return StandardCallableStatementSupport.REF_CURSOR_INSTANCE;

--- a/migration-guide.adoc
+++ b/migration-guide.adoc
@@ -131,6 +131,11 @@ String isDefault();
 * Removed `hibernate.mapping.precedence` and friends
 
 
+[[ddl-implicit-datatype-timestamp]]
+== Default precision for Oracle timestamp
+
+The default precision for Oracle timestamps was changed to 9 i.e. nanosecond precision.
+
 [[todo]]
 == Todos (dev)
 


### PR DESCRIPTION
<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-18035
<!-- Hibernate GitHub Bot issue links end -->