### PR TITLE
HHH-18036 Truncate time-related milliseconds when creating a java.sql.Date

### DIFF
--- a/hibernate-core/src/test/java/org/hibernate/orm/test/type/descriptor/java/JdbcDateJavaTypeDescriptorTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/type/descriptor/java/JdbcDateJavaTypeDescriptorTest.java
@@ -1,10 +1,13 @@
 package org.hibernate.orm.test.type.descriptor.java;
 
 import java.sql.Date;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
 
 import org.hibernate.type.descriptor.java.JdbcDateJavaType;
 
 import org.hibernate.testing.orm.junit.BaseUnitTest;
+import org.hibernate.testing.orm.junit.JiraKey;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
@@ -32,6 +35,7 @@ public class JdbcDateJavaTypeDescriptorTest {
 	}
 
 	@Test
+	@JiraKey("HHH-18036")
 	public void testWrap() {
 		final JdbcDateJavaType javaType = JdbcDateJavaType.INSTANCE;
 
@@ -42,5 +46,18 @@ public class JdbcDateJavaTypeDescriptorTest {
 		final java.util.Date utilDate = new java.util.Date( 0 );
 		final java.util.Date wrappedUtilDate = javaType.wrap( utilDate, null );
 		assertThat( wrappedUtilDate ).isInstanceOf( java.sql.Date.class );
+
+		final java.util.Date utilDateWithTime = java.util.Date.from( ZonedDateTime.of(
+				2000,
+				1,
+				1,
+				12,
+				0,
+				0,
+				0,
+				ZoneOffset.UTC
+		).toInstant() );
+		final java.util.Date wrappedUtilDateWithTime = javaType.wrap( utilDateWithTime, null );
+		assertThat( wrappedUtilDateWithTime ).isEqualTo( java.sql.Date.valueOf( "2000-01-01" ) );
 	}
 }


### PR DESCRIPTION
<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-18036
<!-- Hibernate GitHub Bot issue links end -->