### PR TITLE
HHH-18018 Use NO_PLAIN_PARAMETER for Derby functions that use the length function

### DIFF
--- a/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/DerbyLegacyDialect.java
+++ b/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/DerbyLegacyDialect.java
@@ -380,8 +380,8 @@ public class DerbyLegacyDialect extends Dialect {
 		functionFactory.power_expLn();
 		functionFactory.round_floor();
 		functionFactory.trunc_floor();
-		functionFactory.octetLength_pattern( "length(?1)" );
-		functionFactory.bitLength_pattern( "length(?1)*8" );
+		functionFactory.octetLength_pattern( "length(?1)", SqlAstNodeRenderingMode.NO_PLAIN_PARAMETER );
+		functionFactory.bitLength_pattern( "length(?1)*8", SqlAstNodeRenderingMode.NO_PLAIN_PARAMETER );
 
 		functionContributions.getFunctionRegistry().register(
 				"concat",

--- a/hibernate-core/src/main/java/org/hibernate/dialect/DerbyDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/DerbyDialect.java
@@ -77,6 +77,8 @@ import org.hibernate.type.spi.TypeConfiguration;
 
 import jakarta.persistence.TemporalType;
 
+import static org.hibernate.query.sqm.produce.function.FunctionParameterType.INTEGER;
+import static org.hibernate.query.sqm.produce.function.FunctionParameterType.STRING;
 import static org.hibernate.type.SqlTypes.BINARY;
 import static org.hibernate.type.SqlTypes.BLOB;
 import static org.hibernate.type.SqlTypes.CHAR;
@@ -369,8 +371,8 @@ public class DerbyDialect extends Dialect {
 		functionFactory.power_expLn();
 		functionFactory.round_floor();
 		functionFactory.trunc_floor();
-		functionFactory.octetLength_pattern( "length(?1)" );
-		functionFactory.bitLength_pattern( "length(?1)*8" );
+		functionFactory.octetLength_pattern( "length(?1)", SqlAstNodeRenderingMode.NO_PLAIN_PARAMETER );
+		functionFactory.bitLength_pattern( "length(?1)*8", SqlAstNodeRenderingMode.NO_PLAIN_PARAMETER );
 
 		functionContributions.getFunctionRegistry().register(
 				"concat",

--- a/hibernate-core/src/main/java/org/hibernate/dialect/function/CommonFunctionFactory.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/function/CommonFunctionFactory.java
@@ -814,6 +814,11 @@ public class CommonFunctionFactory {
 				.register();
 	}
 
+	/**
+	 * Emulate left via substr and right via substr and length.
+	 * This function is for Apache Derby and uses {@link SqlAstNodeRenderingMode#NO_PLAIN_PARAMETER}
+	 * for the right function emulation, because length in Apache Derby can't handle plain parameters.
+	 */
 	public void leftRight_substrLength() {
 		functionRegistry.patternDescriptorBuilder( "left", "substr(?1,1,?2)" )
 				.setInvariantType(stringType)
@@ -826,6 +831,7 @@ public class CommonFunctionFactory {
 				.setExactArgumentCount( 2 )
 				.setParameterTypes(STRING, INTEGER)
 				.setArgumentListSignature( "(STRING string, INTEGER length)" )
+				.setArgumentRenderingMode( SqlAstNodeRenderingMode.NO_PLAIN_PARAMETER )
 				.register();
 	}
 
@@ -1638,10 +1644,15 @@ public class CommonFunctionFactory {
 	}
 
 	public void octetLength_pattern(String pattern) {
+		octetLength_pattern( pattern, SqlAstNodeRenderingMode.DEFAULT );
+	}
+
+	public void octetLength_pattern(String pattern, SqlAstNodeRenderingMode renderingMode) {
 		functionRegistry.patternDescriptorBuilder( "octet_length", pattern )
 				.setInvariantType(integerType)
 				.setExactArgumentCount( 1 )
 				.setParameterTypes(STRING_OR_CLOB)
+				.setArgumentRenderingMode( renderingMode )
 				.register();
 	}
 
@@ -1661,10 +1672,15 @@ public class CommonFunctionFactory {
 	}
 
 	public void bitLength_pattern(String pattern) {
+		bitLength_pattern( pattern, SqlAstNodeRenderingMode.DEFAULT );
+	}
+
+	public void bitLength_pattern(String pattern, SqlAstNodeRenderingMode renderingMode) {
 		functionRegistry.patternDescriptorBuilder( "bit_length", pattern )
 				.setInvariantType(integerType)
 				.setExactArgumentCount( 1 )
 				.setParameterTypes(STRING_OR_CLOB)
+				.setArgumentRenderingMode( renderingMode )
 				.register();
 	}
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/query/hql/FunctionTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/query/hql/FunctionTests.java
@@ -691,6 +691,8 @@ public class FunctionTests {
 							.list();
 					assertThat( session.createQuery("select left('hello world', 5)", String.class).getSingleResult(), is("hello") );
 					assertThat( session.createQuery("select right('hello world', 5)", String.class).getSingleResult(), is("world") );
+
+					assertThat( session.createQuery("select right(:data, 5)", String.class).setParameter( "data", "hello world" ).getSingleResult(), is("world") );
 				}
 		);
 	}


### PR DESCRIPTION
<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-18018
<!-- Hibernate GitHub Bot issue links end -->