### PR TITLE
HHH-18043 Change SQL Server default timestamp precision to 7

### DIFF
--- a/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/SQLServerLegacyDialect.java
+++ b/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/SQLServerLegacyDialect.java
@@ -806,18 +806,9 @@ public class SQLServerLegacyDialect extends AbstractTransactSQLDialect {
 		};
 	}
 
-	/**
-	 * SQL server supports up to 7 decimal digits of
-	 * fractional second precision in a datetime2,
-	 * but since its duration arithmetic functions
-	 * try to fit durations into an int,
-	 * which is impossible with such high precision,
-	 * so default to generating {@code datetime2(3)}
-	 * columns.
-	 */
 	@Override
 	public int getDefaultTimestampPrecision() {
-		return 6; //microseconds!
+		return 7;
 	}
 
 	/**

--- a/hibernate-core/src/main/java/org/hibernate/dialect/SQLServerDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/SQLServerDialect.java
@@ -774,18 +774,9 @@ public class SQLServerDialect extends AbstractTransactSQLDialect {
 		};
 	}
 
-	/**
-	 * SQL server supports up to 7 decimal digits of
-	 * fractional second precision in a datetime2,
-	 * but since its duration arithmetic functions
-	 * try to fit durations into an int,
-	 * which is impossible with such high precision,
-	 * so default to generating {@code datetime2(3)}
-	 * columns.
-	 */
 	@Override
 	public int getDefaultTimestampPrecision() {
-		return 6; //microseconds!
+		return 7;
 	}
 
 	/**

--- a/migration-guide.adoc
+++ b/migration-guide.adoc
@@ -132,9 +132,10 @@ String isDefault();
 
 
 [[ddl-implicit-datatype-timestamp]]
-== Default precision for Oracle timestamp
+== Default precision for timestamp on some databases
 
 The default precision for Oracle timestamps was changed to 9 i.e. nanosecond precision.
+The default precision for SQL Server timestamps was changed to 7 i.e. 100 nanosecond precision.
 
 [[todo]]
 == Todos (dev)


### PR DESCRIPTION
<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-18043
<!-- Hibernate GitHub Bot issue links end -->