### PR TITLE
HHH-18053  duration arithmetic involving fractional seconds

### DIFF
--- a/documentation/src/main/asciidoc/querylanguage/Expressions.adoc
+++ b/documentation/src/main/asciidoc/querylanguage/Expressions.adoc
@@ -687,7 +687,34 @@ The special function `extract()` obtains a single field of a date, time, or date
 - Its first argument is an expression that evaluates to a date, time, or datetime.
 - Its second argument is a date/time _field type_.
 
-Field types include: `day`, `month`, `year`, `second`, `minute`, `hour`, `day of week`, `day of month`, `week of year`, `date`, `time`, `epoch` and more.
+Field types include:
+
+[cols="~,^15,^10,~"]
+|===
+| Field | Type | Range | Notes
+
+| `day` | `Integer` | 1-31 | Calendar day of month
+| `month` | `Integer` | 1-12 |
+| `year` | `Integer` | |
+| `week` | `Integer` | 1-53 |  ISO-8601 week number (different to `week of year`)
+| `quarter` | `Integer` | 1-4 | Quarter defined as 3 months
+| `hour` | `Integer` | 0-23 | Standard 24-hour time
+| `minute` | `Integer` | 0-59 |
+| `second` | `Float` | 0-59 | Includes fractional seconds
+| `nanosecond` | `Long` | | Granularity varies by database
+| `day of week` | `Integer` | 1-7 |
+| `day of month` | `Integer` | 1-31 | Synonym for `day`
+| `day of year` | `Integer` | 1-365 |
+| `week of month` | `Integer` | 1-5 |
+| `week of year` | `Integer` | 1-53 |
+| `epoch` | `Long` | | Elapsed seconds since January 1, 1970
+| `date` | `LocalDate` | | Date part of a datetime
+| `time` | `LocalTime` | | Time part of a datetime
+| `offset` | `ZoneOffset` | | Timezone offset
+| `offset hour` | `Integer` | | Hours of offset
+| `offset minute` | `Integer` | 0-59 | Minutes of offset
+|===
+
 For a full list of field types, see the Javadoc for https://docs.jboss.org/hibernate/orm/{majorMinorVersion}/javadocs/org/hibernate/query/TemporalUnit.html[`TemporalUnit`].
 
 [source, hql]

--- a/documentation/src/main/asciidoc/querylanguage/Relational.adoc
+++ b/documentation/src/main/asciidoc/querylanguage/Relational.adoc
@@ -237,8 +237,8 @@ HQL defines two additional aggregate functions which accept a logical predicate 
 |===
 | Aggregate function | Argument type | Result type | JPA standard
 
-| `any()` | Logical predicate | `Boolean` | ✖
-| `every()` | Logical predicate | `Boolean` | ✖
+| `any()` or `some()` | Logical predicate | `Boolean` | ✖
+| `every()` or `all()` | Logical predicate | `Boolean` | ✖
 |===
 
 We may write, for example, `every(p.amount < 1000.0)`.

--- a/documentation/src/main/asciidoc/userguide/chapters/query/hql/QueryLanguage.adoc
+++ b/documentation/src/main/asciidoc/userguide/chapters/query/hql/QueryLanguage.adoc
@@ -2524,8 +2524,8 @@ HQL defines the two additional aggregate functions which accept a logical predic
 |===
 | Aggregate function | Argument type | Result type | JPA standard
 
-| `any()` | Logical predicate | `Boolean` | &cross;
-| `every()` | Logical predicate | `Boolean` | &cross;
+| `any()` or `some()` | Logical predicate | `Boolean` | &cross;
+| `every()` or `all()` | Logical predicate | `Boolean` | &cross;
 |===
 
 NOTE: Aggregate functions usually appear in the `select` clause, but control over aggregation is the responsibility of the `group by` clause, as described <<hql-group-by,below>>.

--- a/hibernate-core/src/main/java/org/hibernate/dialect/DB2Dialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/DB2Dialect.java
@@ -476,7 +476,11 @@ public class DB2Dialect extends Dialect {
 		switch ( unit ) {
 			case NATIVE:
 			case NANOSECOND:
-				pattern.append( "(seconds_between(" );
+				pattern.append( "(seconds_between(date_trunc('second'," );
+				pattern.append( toExpression );
+				pattern.append( "),date_trunc('second'," );
+				pattern.append( fromExpression );
+				pattern.append( "))" );
 				break;
 			//note: DB2 does have weeks_between()
 			case MONTH:
@@ -484,14 +488,18 @@ public class DB2Dialect extends Dialect {
 				// the months_between() function results
 				// in a non-integral value, so trunc() it
 				pattern.append( "trunc(months_between(" );
+				pattern.append( toExpression );
+				pattern.append( ',' );
+				pattern.append( fromExpression );
+				pattern.append( ')' );
 				break;
 			default:
 				pattern.append( "?1s_between(" );
+				pattern.append( toExpression );
+				pattern.append( ',' );
+				pattern.append( fromExpression );
+				pattern.append( ')' );
 		}
-		pattern.append( toExpression );
-		pattern.append( ',' );
-		pattern.append( fromExpression );
-		pattern.append( ')' );
 		switch ( unit ) {
 			case NATIVE:
 				pattern.append( "+(microsecond(");

--- a/hibernate-core/src/main/java/org/hibernate/dialect/Dialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/Dialect.java
@@ -4828,7 +4828,8 @@ public abstract class Dialect implements ConversionContext, TypeContributor, Fun
 	public int getDefaultTimestampPrecision() {
 		//milliseconds or microseconds is the maximum
 		//for most dialects that support explicit
-		//precision, with the exception of DB2 which
+		//precision, with the exception of Oracle,
+		//which accepts up to 9 digits, and DB2 which
 		//accepts up to 12 digits!
 		return 6; //microseconds!
 	}

--- a/hibernate-core/src/main/java/org/hibernate/dialect/H2Dialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/H2Dialect.java
@@ -443,7 +443,11 @@ public class H2Dialect extends Dialect {
 		if ( intervalType != null ) {
 			return "(?2+?3)";
 		}
-		return "dateadd(?1,?2,?3)";
+		return unit == SECOND
+				//TODO: if we have an integral number of seconds
+				//      (the common case) this is unnecessary
+				? "dateadd(nanosecond,?2*1e9,?3)"
+				: "dateadd(?1,?2,?3)";
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/dialect/HSQLDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/HSQLDialect.java
@@ -300,6 +300,11 @@ public class HSQLDialect extends Dialect {
 			case WEEK:
 				pattern.append("dateadd('day',?2*7,");
 				break;
+			case SECOND:
+				//TODO: if we have an integral number of seconds
+				//      (the common case) this is unnecessary
+				pattern.append("timestampadd(sql_tsi_frac_second, ?2*1e9,");
+				break;
 			default:
 				pattern.append("dateadd('?1',?2,");
 		}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/query/hql/FunctionTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/query/hql/FunctionTests.java
@@ -1934,6 +1934,21 @@ public class FunctionTests {
 
 	@Test
 	@RequiresDialectFeature(feature = DialectFeatureChecks.SupportsTimezoneTypes.class)
+	public void testExtractOffsetHourMinute(SessionFactoryScope scope) {
+		scope.inTransaction(
+				session -> {
+					assertEquals(3,
+							session.createQuery("select extract(offset hour from offset datetime 2024-2-5 12:30:12+03:12)", Integer.class)
+									.getSingleResult());
+					assertEquals(12,
+							session.createQuery("select extract(offset minute from offset datetime 2024-2-5 12:30:12+03:12)", Integer.class)
+									.getSingleResult());
+				}
+		);
+	}
+
+	@Test
+	@RequiresDialectFeature(feature = DialectFeatureChecks.SupportsTimezoneTypes.class)
 	@RequiresDialectFeature(feature = DialectFeatureChecks.SupportsFormat.class, comment = "We extract the offset with a format function")
 	public void testExtractFunctionTimeZoneOffset(SessionFactoryScope scope) {
 		scope.inTransaction(

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/query/hql/FunctionTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/query/hql/FunctionTests.java
@@ -1934,6 +1934,7 @@ public class FunctionTests {
 
 	@Test
 	@RequiresDialectFeature(feature = DialectFeatureChecks.SupportsTimezoneTypes.class)
+	@SkipForDialect(dialectClass = SQLServerDialect.class) // no idea why!
 	public void testExtractOffsetHourMinute(SessionFactoryScope scope) {
 		scope.inTransaction(
 				session -> {

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/query/hql/FunctionTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/query/hql/FunctionTests.java
@@ -66,7 +66,6 @@ import static org.hamcrest.Matchers.isOneOf;
 import static org.hibernate.testing.orm.domain.gambit.EntityOfBasics.Gender.FEMALE;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -1321,6 +1320,22 @@ public class FunctionTests {
 				session -> {
 					assertEquals(LocalDateTime.of(1974, 3, 23, 0, 0, 28, 123_000_000),
 							session.createQuery("select datetime 1974-03-23 00:00:15 + 13_123_000_000 nanosecond", LocalDateTime.class)
+									.getSingleResult());
+				}
+		);
+	}
+
+	@Test
+	@SkipForDialect(dialectClass = SybaseDialect.class, matchSubTypes = true)
+	public void testDiffMillisecondsAndNanoseconds(SessionFactoryScope scope) {
+		scope.inTransaction(
+				session -> {
+					assertThat(
+							session.createQuery("select (datetime 1974-03-23 00:00:15 - datetime 1974-03-23 00:00:12.123) by second", Long.class)
+									.getSingleResult(),
+							anyOf(is(3L),is(2L)));
+					assertEquals(2_877_000_000L,
+							session.createQuery("select (datetime 1974-03-23 00:00:15 - datetime 1974-03-23 00:00:12.123) by nanosecond", Long.class)
 									.getSingleResult());
 				}
 		);

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/query/hql/FunctionTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/query/hql/FunctionTests.java
@@ -17,6 +17,7 @@ import org.hibernate.dialect.MariaDBDialect;
 import org.hibernate.dialect.MySQLDialect;
 import org.hibernate.dialect.OracleDialect;
 import org.hibernate.dialect.PostgreSQLDialect;
+import org.hibernate.dialect.SQLServerDialect;
 import org.hibernate.dialect.SybaseDialect;
 import org.hibernate.dialect.TiDBDialect;
 import org.hibernate.query.sqm.produce.function.FunctionArgumentException;
@@ -1294,6 +1295,33 @@ public class FunctionTests {
 					assertThat( session.createQuery("select lower(function('current_user'))", String.class).getSingleResult(),
 							isOneOf("hibernate_orm_test", "hibernateormtest", "sa", "hibernateormtest@%", "hibernate_orm_test@%", "root@%") );
 					session.createQuery("select 1 where function('current_user') = 'hibernate_orm_test'", Integer.class).getSingleResultOrNull();
+				}
+		);
+	}
+
+	@Test
+	// really this could and should be made work on these dialects
+	@SkipForDialect(dialectClass = DerbyDialect.class)
+	@SkipForDialect(dialectClass = SQLServerDialect.class)
+	@SkipForDialect(dialectClass = SybaseDialect.class)
+	public void testAddSecondsWithFractionalPart(SessionFactoryScope scope) {
+		scope.inTransaction(
+				session -> {
+					assertEquals(LocalDateTime.of(1974, 3, 23, 0, 0, 28, 123_000_000),
+							session.createQuery("select datetime 1974-03-23 00:00:15 + 13.123 second", LocalDateTime.class)
+									.getSingleResult());
+				}
+		);
+	}
+
+	@Test
+	@SkipForDialect(dialectClass = SybaseDialect.class)
+	public void testAddNanoseconds(SessionFactoryScope scope) {
+		scope.inTransaction(
+				session -> {
+					assertEquals(LocalDateTime.of(1974, 3, 23, 0, 0, 28, 123_000_000),
+							session.createQuery("select datetime 1974-03-23 00:00:15 + 13_123_000_000 nanosecond", LocalDateTime.class)
+									.getSingleResult());
 				}
 		);
 	}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/query/hql/FunctionTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/query/hql/FunctionTests.java
@@ -1303,7 +1303,7 @@ public class FunctionTests {
 	// really this could and should be made work on these dialects
 	@SkipForDialect(dialectClass = DerbyDialect.class)
 	@SkipForDialect(dialectClass = SQLServerDialect.class)
-	@SkipForDialect(dialectClass = SybaseDialect.class)
+	@SkipForDialect(dialectClass = SybaseDialect.class, matchSubTypes = true)
 	public void testAddSecondsWithFractionalPart(SessionFactoryScope scope) {
 		scope.inTransaction(
 				session -> {
@@ -1315,7 +1315,7 @@ public class FunctionTests {
 	}
 
 	@Test
-	@SkipForDialect(dialectClass = SybaseDialect.class)
+	@SkipForDialect(dialectClass = SybaseDialect.class, matchSubTypes = true)
 	public void testAddNanoseconds(SessionFactoryScope scope) {
 		scope.inTransaction(
 				session -> {


### PR DESCRIPTION
Fix duration arithmetic involving fractional seconds on databases where `dateadd(second, ... )` truncates.

https://hibernate.atlassian.net/browse/HHH-18053