### PR TITLE
HHH-18067 get rid of a typecast to AbstractPersistentCollection

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/engine/internal/StatefulPersistenceContext.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/internal/StatefulPersistenceContext.java
@@ -1107,7 +1107,7 @@ public class StatefulPersistenceContext implements PersistenceContext {
 	public CollectionEntry addInitializedCollection(CollectionPersister persister, PersistentCollection<?> collection, Object id)
 			throws HibernateException {
 		final CollectionEntry ce = new CollectionEntry( collection, persister, id, flushing );
-		ce.postInitialize( collection );
+		ce.postInitialize( collection, session );
 		addCollection( collection, ce, id );
 		return ce;
 	}

--- a/hibernate-core/src/main/java/org/hibernate/loader/ast/internal/CollectionLoaderNamedQuery.java
+++ b/hibernate-core/src/main/java/org/hibernate/loader/ast/internal/CollectionLoaderNamedQuery.java
@@ -53,9 +53,12 @@ public class CollectionLoaderNamedQuery implements CollectionLoader {
 		else {
 			// using annotations we have no way to specify a @CollectionResult
 			final CollectionKey collectionKey = new CollectionKey( persister, key );
-			final PersistentCollection<?> collection = session.getPersistenceContextInternal().getCollection( collectionKey );
+			final PersistentCollection<?> collection =
+					session.getPersistenceContextInternal()
+							.getCollection( collectionKey );
 			for ( Object element : resultList ) {
-				if ( element != null && !persister.getElementType().getReturnedClass().isInstance( element ) ) {
+				if ( element != null
+						&& !persister.getElementType().getReturnedClass().isInstance( element ) ) {
 					throw new QueryTypeMismatchException( "Collection loader for '" + persister.getRole()
 							+ "' returned an instance of '" + element.getClass().getName() + "'" );
 				}
@@ -63,7 +66,9 @@ public class CollectionLoaderNamedQuery implements CollectionLoader {
 			collection.beforeInitialize( persister, resultList.size() );
 			collection.injectLoadedState( getLoadable(), resultList );
 			collection.afterInitialize();
-			session.getPersistenceContextInternal().getCollectionEntry( collection ).postInitialize( collection );
+			session.getPersistenceContextInternal()
+					.getCollectionEntry( collection )
+					.postInitialize( collection, session );
 			return collection;
 		}
 	}

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/internal/ResultsHelper.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/internal/ResultsHelper.java
@@ -184,16 +184,14 @@ public class ResultsHelper {
 			PersistentCollection<?> collectionInstance,
 			Object key,
 			boolean hasNoQueuedAdds) {
+		final SharedSessionContractImplementor session = persistenceContext.getSession();
+
 		CollectionEntry collectionEntry = persistenceContext.getCollectionEntry( collectionInstance );
 		if ( collectionEntry == null ) {
-			collectionEntry = persistenceContext.addInitializedCollection(
-					collectionDescriptor,
-					collectionInstance,
-					key
-			);
+			collectionEntry = persistenceContext.addInitializedCollection( collectionDescriptor, collectionInstance, key );
 		}
 		else {
-			collectionEntry.postInitialize( collectionInstance );
+			collectionEntry.postInitialize( collectionInstance, session );
 		}
 
 		if ( collectionDescriptor.getCollectionType().hasHolder() ) {
@@ -211,7 +209,6 @@ public class ResultsHelper {
 		final BatchFetchQueue batchFetchQueue = persistenceContext.getBatchFetchQueue();
 		batchFetchQueue.removeBatchLoadableCollection( collectionEntry );
 
-		final SharedSessionContractImplementor session = persistenceContext.getSession();
 		// add to cache if:
 		final boolean addToCache =
 				// there were no queued additions


### PR DESCRIPTION
and code cleanups

(Note that this typecast has actually been there since 2012, though it only used to happen when batching was enabled.)

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-18067
<!-- Hibernate GitHub Bot issue links end -->