### PR TITLE
HHH-18079 Default to minimum supported DB version when using hibernate.boot.allow_jdbc_metadata_access=false with jakarta.persistence.database-product-name

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/engine/jdbc/env/internal/JdbcEnvironmentInitiator.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/jdbc/env/internal/JdbcEnvironmentInitiator.java
@@ -128,12 +128,7 @@ public class JdbcEnvironmentInitiator implements StandardServiceInitiator<JdbcEn
 					explicitDatabaseMinorVersion,
 					explicitDatabaseVersion);
 		}
-		else if ( explicitDialectConfiguration(
-				configurationValues,
-				explicitDatabaseName,
-				explicitDatabaseMajorVersion,
-				explicitDatabaseMinorVersion,
-				explicitDatabaseVersion) ) {
+		else if ( explicitDialectConfiguration( explicitDatabaseName, configurationValues ) ) {
 			return getJdbcEnvironmentWithExplicitConfiguration(
 					configurationValues,
 					registry,
@@ -394,14 +389,9 @@ public class JdbcEnvironmentInitiator implements StandardServiceInitiator<JdbcEn
 		}
 	}
 
-	private static boolean explicitDialectConfiguration(
-			Map<String, Object> configurationValues,
-			String explicitDatabaseName,
-			Integer explicitDatabaseMajorVersion,
-			Integer explicitDatabaseMinorVersion,
-			String explicitDatabaseVersion) {
-		return ( isNotEmpty(explicitDatabaseVersion) || explicitDatabaseMajorVersion != null || explicitDatabaseMinorVersion != null )
-			&& ( isNotEmpty(explicitDatabaseName) || isNotNullAndNotEmpty( configurationValues.get(DIALECT) ) );
+	private static boolean explicitDialectConfiguration(String explicitDatabaseName,
+			Map<String, Object> configurationValues) {
+		return isNotEmpty( explicitDatabaseName ) || isNotNullAndNotEmpty( configurationValues.get( DIALECT ) );
 	}
 
 	private static boolean isNotNullAndNotEmpty(Object o) {
@@ -502,7 +492,7 @@ public class JdbcEnvironmentInitiator implements StandardServiceInitiator<JdbcEn
 				String databaseName,
 				String databaseVersion,
 				int databaseMajorVersion,
-				int databaseMinorVersion, 
+				int databaseMinorVersion,
 				int databaseMicroVersion,
 				String driverName,
 				int driverMajorVersion,


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-18079

A backport to 6.5 or a 6.6.0.Final release before mid-may would be nice, as it would allow merging https://github.com/quarkusio/quarkus/pull/40474  in Quarkus and fixing a pesky warning: https://github.com/quarkusio/quarkus/issues/37575

EDIT: And I really mean "nice", not "absolutely necessary". Worst case we can live without it one more month.