### PR TITLE
a couple of small optimizations to writing Integrators

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/event/spi/PostActionEventListener.java
+++ b/hibernate-core/src/main/java/org/hibernate/event/spi/PostActionEventListener.java
@@ -20,5 +20,7 @@ interface PostActionEventListener {
 	 *
 	 * @return {@code true} if after transaction callbacks should be added.
 	 */
-	boolean requiresPostCommitHandling(EntityPersister persister);
+	default boolean requiresPostCommitHandling(EntityPersister persister) {
+		return false;
+	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/integrator/spi/Integrator.java
+++ b/hibernate-core/src/main/java/org/hibernate/integrator/spi/Integrator.java
@@ -71,6 +71,8 @@ public interface Integrator {
 	 * @param sessionFactory The session factory being closed.
 	 * @param serviceRegistry That session factory's service registry
 	 */
-	void disintegrate(SessionFactoryImplementor sessionFactory, SessionFactoryServiceRegistry serviceRegistry);
+	default void disintegrate(SessionFactoryImplementor sessionFactory, SessionFactoryServiceRegistry serviceRegistry) {
+		// do nothing by default
+	}
 
 }

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/collection/LoadEntityWithElementCollectionTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/collection/LoadEntityWithElementCollectionTest.java
@@ -53,11 +53,6 @@ public class LoadEntityWithElementCollectionTest {
 			isPostUpdateCalled = true;
 		}
 
-		@Override
-		public boolean requiresPostCommitHandling(EntityPersister persister) {
-			return false;
-		}
-
 		public boolean isPostUpdateCalled() {
 			return isPostUpdateCalled;
 		}


### PR DESCRIPTION
default impls for:

- `Integrator.disintegrate()`
- `PostActionEventListener.requiresPostCommitHandling()`