### PR TITLE
HHH-18056 SQL Server, Sybase, and HANA should allow @Table(options)

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/dialect/HANADialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/HANADialect.java
@@ -52,4 +52,9 @@ public class HANADialect extends AbstractHANADialect {
 	protected DatabaseVersion getMinimumSupportedVersion() {
 		return MINIMUM_VERSION;
 	}
+
+	@Override
+	public boolean supportsTableOptions() {
+		return true;
+	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/dialect/SQLServerDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/SQLServerDialect.java
@@ -1171,4 +1171,9 @@ public class SQLServerDialect extends AbstractTransactSQLDialect {
 		}
 		return "";
 	}
+
+	@Override
+	public boolean supportsTableOptions() {
+		return true;
+	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/dialect/SybaseDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/SybaseDialect.java
@@ -535,4 +535,9 @@ public class SybaseDialect extends AbstractTransactSQLDialect {
 	public boolean supportsFromClauseInUpdate() {
 		return true;
 	}
+
+	@Override
+	public boolean supportsTableOptions() {
+		return true;
+	}
 }


### PR DESCRIPTION
Looks to me like SQL Server, Sybase, and HANA all do support some kind of `create table` options.

But @dreab8, I'm not sure how much value there is to even having `Table.supportsTableOptions()`. Derby was the only database I could find which doesn't allow anything after the closing paren of `create table`. And it's not like these table options are ever portable between databases.

And just silently ignoring what the user specified on certain databases is pretty fragile to begin with anyway.

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-18056
<!-- Hibernate GitHub Bot issue links end -->