### PR TITLE
HHH-18102 - @CheckHQL is not reporting error when non-existing enum constant is referenced in named HQL query

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/query/hql/internal/BasicDotIdentifierConsumer.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/hql/internal/BasicDotIdentifierConsumer.java
@@ -205,11 +205,10 @@ public class BasicDotIdentifierConsumer implements DotIdentifierConsumer {
 				final String prefix = path.substring( 0, splitPosition );
 				final String terminal = path.substring( splitPosition + 1 );
 
-				//TODO: try interpreting paths of form foo.bar.Foo.Bar as foo.bar.Foo$Bar
-				final EnumJavaType<?> enumType = jpaMetamodel.getEnumType(prefix);
+				final EnumJavaType<?> enumType = jpaMetamodel.getEnumType( prefix );
 				if ( enumType != null ) {
 					return new SqmEnumLiteral(
-							jpaMetamodel.enumValue(enumType, terminal),
+							jpaMetamodel.enumValue( enumType, terminal ),
 							enumType,
 							terminal,
 							nodeBuilder

--- a/hibernate-core/src/main/java/org/hibernate/query/hql/internal/BasicDotIdentifierConsumer.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/hql/internal/BasicDotIdentifierConsumer.java
@@ -205,17 +205,17 @@ public class BasicDotIdentifierConsumer implements DotIdentifierConsumer {
 				final String prefix = path.substring( 0, splitPosition );
 				final String terminal = path.substring( splitPosition + 1 );
 
-				final EnumJavaType<?> enumType = jpaMetamodel.getEnumType( prefix );
-				if ( enumType != null ) {
-					return new SqmEnumLiteral(
-							jpaMetamodel.enumValue( enumType, terminal ),
-							enumType,
-							terminal,
-							nodeBuilder
-					);
-				}
-
 				try {
+					final EnumJavaType<?> enumType = jpaMetamodel.getEnumType( prefix );
+					if ( enumType != null ) {
+						return new SqmEnumLiteral(
+								jpaMetamodel.enumValue( enumType, terminal ),
+								enumType,
+								terminal,
+								nodeBuilder
+						);
+					}
+
 					final Class<?> namedClass =
 							creationContext.getServiceRegistry()
 									.requireService( ClassLoaderService.class )

--- a/tooling/metamodel-generator/src/main/java/org/hibernate/processor/validation/MockSessionFactory.java
+++ b/tooling/metamodel-generator/src/main/java/org/hibernate/processor/validation/MockSessionFactory.java
@@ -842,7 +842,7 @@ public abstract class MockSessionFactory
 		}
 
 		@Override
-		public <E extends Enum<E>> E enumValue(EnumJavaType<E> enumType, String terminal) {
+		public <E extends Enum<E>> E enumValue(EnumJavaType<E> enumType, String enumValueName) {
 			return null;
 		}
 

--- a/tooling/metamodel-generator/src/main/java/org/hibernate/processor/validation/MockSessionFactory.java
+++ b/tooling/metamodel-generator/src/main/java/org/hibernate/processor/validation/MockSessionFactory.java
@@ -118,6 +118,7 @@ import org.hibernate.type.spi.TypeConfiguration;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.NoSuchElementException;
 import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
@@ -285,6 +286,8 @@ public abstract class MockSessionFactory
 	abstract boolean isClassDefined(String qualifiedName);
 
 	abstract boolean isEnum(String className);
+
+	abstract boolean isEnumConstant(String className, String terminal);
 
 	abstract boolean isFieldDefined(String qualifiedClassName, String fieldName);
 
@@ -843,6 +846,9 @@ public abstract class MockSessionFactory
 
 		@Override
 		public <E extends Enum<E>> E enumValue(EnumJavaType<E> enumType, String enumValueName) {
+			if ( !isEnumConstant( enumType.getTypeName(), enumValueName ) ) {
+				throw new IllegalArgumentException( "No enum constant " + enumType.getTypeName() + "." + enumValueName );
+			}
 			return null;
 		}
 

--- a/tooling/metamodel-generator/src/main/java/org/hibernate/processor/validation/ProcessorSessionFactory.java
+++ b/tooling/metamodel-generator/src/main/java/org/hibernate/processor/validation/ProcessorSessionFactory.java
@@ -595,6 +595,18 @@ public abstract class ProcessorSessionFactory extends MockSessionFactory {
 		return typeElement != null && typeElement.getKind() == ElementKind.ENUM;
 	}
 
+	@Override
+	boolean isEnumConstant(String className, String terminal) {
+		final TypeElement typeElement = elementUtil.getTypeElement(className);
+		if (typeElement == null || typeElement.getKind() != ElementKind.ENUM) {
+			return false;
+		}
+		return typeElement.getEnclosedElements()
+				.stream()
+				.filter(e -> terminal.equals(e.getSimpleName().toString()))
+				.anyMatch(e -> e.getKind() == ElementKind.ENUM_CONSTANT);
+	}
+
 	private static boolean isEmbeddableType(TypeElement type) {
 		return hasAnnotation(type, "Embeddable");
 	}

--- a/tooling/metamodel-generator/src/test/java/org/hibernate/processor/test/constant/BadEnumConstantInNamedQueryTest.java
+++ b/tooling/metamodel-generator/src/test/java/org/hibernate/processor/test/constant/BadEnumConstantInNamedQueryTest.java
@@ -1,0 +1,31 @@
+package org.hibernate.processor.test.constant;
+
+import org.hibernate.processor.test.util.CompilationTest;
+import org.hibernate.processor.test.util.TestForIssue;
+import org.hibernate.processor.test.util.WithClasses;
+
+import org.junit.Test;
+
+import jakarta.persistence.EntityManager;
+
+import static org.hibernate.processor.test.util.TestUtil.assertMetamodelClassGeneratedFor;
+import static org.hibernate.processor.test.util.TestUtil.assertPresenceOfFieldInMetamodelFor;
+import static org.hibernate.processor.test.util.TestUtil.assertPresenceOfMethodInMetamodelFor;
+import static org.hibernate.processor.test.util.TestUtil.getMetaModelSourceAsString;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@TestForIssue(jiraKey = "HHH-No-Such-Key")
+public class BadEnumConstantInNamedQueryTest extends CompilationTest {
+
+	@Test
+	@WithClasses({ CookBook.class })
+	public void testFourthWithoutCheckHQL() {
+		System.out.println( getMetaModelSourceAsString( CookBook.class ) );
+		assertMetamodelClassGeneratedFor( CookBook.class );
+		assertPresenceOfFieldInMetamodelFor( CookBook.class, "QUERY_FIND_GOOD_BOOKS" );
+		assertThrows(
+				AssertionError.class,
+				() -> assertPresenceOfMethodInMetamodelFor( CookBook.class, "findGoodBooks", EntityManager.class )
+		);
+	}
+}

--- a/tooling/metamodel-generator/src/test/java/org/hibernate/processor/test/constant/BookType.java
+++ b/tooling/metamodel-generator/src/test/java/org/hibernate/processor/test/constant/BookType.java
@@ -1,0 +1,5 @@
+package org.hibernate.processor.test.constant;
+
+public enum BookType {
+	GOOD, BAD, UGLY;
+}

--- a/tooling/metamodel-generator/src/test/java/org/hibernate/processor/test/constant/CookBook.java
+++ b/tooling/metamodel-generator/src/test/java/org/hibernate/processor/test/constant/CookBook.java
@@ -1,0 +1,16 @@
+package org.hibernate.processor.test.constant;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.NamedQuery;
+
+@Entity
+@NamedQuery(name = "#findGoodBooks",
+		query = "from CookBook where bookType = org.hibernate.processor.test.constant.BookType.GOOD_BOOK")
+public class CookBook {
+
+	@Id
+	String isbn;
+	String title;
+	BookType bookType;
+}


### PR DESCRIPTION
See Jira issue [HHH-18102](https://hibernate.atlassian.net/browse/HHH-18102)

Method `org.hibernate.processor.validation.MockSessionFactory.MockJpaMetamodelImpl#enumValue` is not checking for enum value existence

[HHH-18102]: https://hibernate.atlassian.net/browse/HHH-18102?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ