### PR TITLE
HHH-18056 Support for JPA 32 table options

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/dialect/CockroachDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/CockroachDialect.java
@@ -1179,9 +1179,4 @@ public class CockroachDialect extends Dialect {
 	public boolean supportsFromClauseInUpdate() {
 		return true;
 	}
-
-	@Override
-	public boolean supportsTableOptions() {
-		return true;
-	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/dialect/DB2Dialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/DB2Dialect.java
@@ -1293,9 +1293,4 @@ public class DB2Dialect extends Dialect {
 	public boolean supportsFromClauseInUpdate() {
 		return getDB2Version().isSameOrAfter( 11 );
 	}
-
-	@Override
-	public boolean supportsTableOptions() {
-		return true;
-	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/dialect/H2Dialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/H2Dialect.java
@@ -1000,8 +1000,4 @@ public class H2Dialect extends Dialect {
 		return true;
 	}
 
-	@Override
-	public boolean supportsTableOptions() {
-		return true;
-	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/dialect/HSQLDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/HSQLDialect.java
@@ -727,9 +727,4 @@ public class HSQLDialect extends Dialect {
 	public DmlTargetColumnQualifierSupport getDmlTargetColumnQualifierSupport() {
 		return DmlTargetColumnQualifierSupport.TABLE_ALIAS;
 	}
-
-	@Override
-	public boolean supportsTableOptions() {
-		return true;
-	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/dialect/MySQLDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/MySQLDialect.java
@@ -1561,9 +1561,4 @@ public class MySQLDialect extends Dialect {
 		}
 		return sqlCheckConstraint;
 	}
-
-	@Override
-	public boolean supportsTableOptions() {
-		return true;
-	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/dialect/OracleDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/OracleDialect.java
@@ -1612,9 +1612,4 @@ public class OracleDialect extends Dialect {
 		}
 		return sqlCheckConstraint;
 	}
-
-	@Override
-	public boolean supportsTableOptions() {
-		return true;
-	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/dialect/PostgreSQLDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/PostgreSQLDialect.java
@@ -1565,9 +1565,4 @@ public class PostgreSQLDialect extends Dialect {
 	public boolean supportsFromClauseInUpdate() {
 		return true;
 	}
-
-	@Override
-	public boolean supportsTableOptions() {
-		return true;
-	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/tool/schema/internal/StandardTableExporter.java
+++ b/hibernate-core/src/main/java/org/hibernate/tool/schema/internal/StandardTableExporter.java
@@ -111,13 +111,12 @@ public class StandardTableExporter implements Exporter<Table> {
 				applyTableTypeString( createTable );
 			}
 
-			final List<String> sqlStrings = new ArrayList<>();
 			if ( StringHelper.isNotEmpty( table.getOptions() ) ) {
-				if ( dialect.supportsTableOptions() ) {
-					createTable.append( " " );
-					createTable.append( table.getOptions() );
-				}
+				createTable.append( " " );
+				createTable.append( table.getOptions() );
 			}
+
+			final List<String> sqlStrings = new ArrayList<>();
 			sqlStrings.add( createTable.toString() );
 			applyComments( table, formattedTableName, sqlStrings );
 			applyInitCommands( table, sqlStrings, context );

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/schemaupdate/tableoptions/TableOptionsTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/schemaupdate/tableoptions/TableOptionsTest.java
@@ -14,8 +14,6 @@ import org.hibernate.tool.hbm2ddl.SchemaExport;
 import org.hibernate.tool.schema.TargetType;
 
 import org.hibernate.testing.orm.junit.BaseUnitTest;
-import org.hibernate.testing.orm.junit.DialectFeatureChecks;
-import org.hibernate.testing.orm.junit.RequiresDialectFeature;
 import org.hibernate.testing.util.ServiceRegistryUtil;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -24,7 +22,6 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @BaseUnitTest
-@RequiresDialectFeature( feature = DialectFeatureChecks.SupportsTableOptions.class)
 public class TableOptionsTest {
 	static final String TABLE_NAME = "PRIMARY_TABLE";
 	static final String TABLE_OPTIONS = "option_1";

--- a/hibernate-testing/src/main/java/org/hibernate/testing/orm/junit/DialectFeatureChecks.java
+++ b/hibernate-testing/src/main/java/org/hibernate/testing/orm/junit/DialectFeatureChecks.java
@@ -698,11 +698,4 @@ abstract public class DialectFeatureChecks {
 			return dialect.getNationalizationSupport() == NationalizationSupport.EXPLICIT;
 		}
 	}
-
-	public static class SupportsTableOptions implements DialectFeatureCheck{
-		@Override
-		public boolean apply(Dialect dialect) {
-			return dialect.supportsTableOptions();
-		}
-	}
 }


### PR DESCRIPTION
removed `Dialect#supportsTableOptions`

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-18056
<!-- Hibernate GitHub Bot issue links end -->