### PR TITLE
HHH-18076 Remove incorrect dialect warning with ORM 6.0+ when deploying while database server is not running

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/engine/jdbc/dialect/internal/DialectFactoryImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/jdbc/dialect/internal/DialectFactoryImpl.java
@@ -149,9 +149,9 @@ public class DialectFactoryImpl implements DialectFactory, ServiceRegistryAwareS
 			if ( dialect == null ) {
 				throw new HibernateException( "Unable to construct requested dialect [" + dialectReference + "]" );
 			}
-			else if ( Dialect.class.getPackage() == dialect.getClass().getPackage() ) {
-				DEPRECATION_LOGGER.automaticDialect( dialect.getClass().getSimpleName() );
-			}
+			// else if ( Dialect.class.getPackage() == dialect.getClass().getPackage() ) {
+			//	DEPRECATION_LOGGER.automaticDialect( dialect.getClass().getSimpleName() );
+			// }
 			return dialect;
 		}
 		catch (StrategySelectionException e) {

--- a/hibernate-core/src/main/java/org/hibernate/internal/log/DeprecationLogger.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/log/DeprecationLogger.java
@@ -221,11 +221,11 @@ public interface DeprecationLogger extends BasicLogger {
 //	)
 //	void deprecatedComponentMapping(String name);
 
-	@LogMessage(level = WARN)
-	@Message(value = "%s does not need to be specified explicitly using 'hibernate.dialect' "
-			+ "(remove the property setting and it will be selected by default)",
-			id = 90000025)
-	void automaticDialect(String dialect);
+//	@LogMessage(level = WARN)
+//	@Message(value = "%s does not need to be specified explicitly using 'hibernate.dialect' "
+//			+ "(remove the property setting and it will be selected by default)",
+//			id = 90000025)
+//	void automaticDialect(String dialect);
 
 	@LogMessage(level = WARN)
 	@Message(value = "%s has been deprecated",


### PR DESCRIPTION
Hibernate ORM 6 applications are generally highly available except when applications do not specify the `hibernate.dialect` and such applications are deployed without the database server running.  

This was recently discussed on https://groups.google.com/d/msgid/wildfly/0970f2f1-ae62-4353-9795-71939d2448cen%40googlegroups.com?utm_medium=email&utm_source=footer as something that happened when a user migrated their application to WildFly 31 and the user read the warning that they should remove the `hibernate.dialect` setting from their application which they did.  They were surprised when they no longer could deploy their application when the database server is not running.

My first reaction is to remove the warning that Hibernate 6+ users see that tells them they do not need to specify the `hibernate.dialect`  due to deployment failures that may happen when users restart their application deployment while the database server is not running.

Other thoughts?

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-18076
<!-- Hibernate GitHub Bot issue links end -->