### PR TITLE
HHH-18106 - @CheckHQL is reporting error when named query contains valid Java constant

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/JpaMetamodel.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/JpaMetamodel.java
@@ -19,6 +19,7 @@ import org.hibernate.jpa.spi.JpaCompliance;
 import org.hibernate.metamodel.MappingMetamodel;
 import org.hibernate.service.ServiceRegistry;
 import org.hibernate.type.descriptor.java.EnumJavaType;
+import org.hibernate.type.descriptor.java.JavaType;
 import org.hibernate.type.spi.TypeConfiguration;
 
 /**
@@ -93,6 +94,10 @@ public interface JpaMetamodel extends Metamodel {
 	EnumJavaType<?> getEnumType(String prefix);
 
 	<E extends Enum<E>> E enumValue(EnumJavaType<E> enumType, String terminal);
+
+	JavaType<?> getJavaConstantType(String className, String fieldName);
+
+	<T> T getJavaConstant(String className, String fieldName);
 
 	// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 	// Covariant returns

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/internal/MappingMetamodelImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/internal/MappingMetamodelImpl.java
@@ -535,6 +535,16 @@ public class MappingMetamodelImpl extends QueryParameterBindingTypeResolverImpl
 	}
 
 	@Override
+	public JavaType<?> getJavaConstantType(String className, String fieldName) {
+		return jpaMetamodel.getJavaConstantType( className, fieldName );
+	}
+
+	@Override
+	public <T> T getJavaConstant(String className, String fieldName) {
+		return jpaMetamodel.getJavaConstant( className, fieldName );
+	}
+
+	@Override
 	public EnumJavaType<?> getEnumType(String className) {
 		return jpaMetamodel.getEnumType(className);
 	}

--- a/hibernate-core/src/main/java/org/hibernate/query/hql/internal/BasicDotIdentifierConsumer.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/hql/internal/BasicDotIdentifierConsumer.java
@@ -228,16 +228,11 @@ public class BasicDotIdentifierConsumer implements DotIdentifierConsumer {
 						);
 					}
 
-					final Class<?> namedClass =
-							creationContext.getServiceRegistry()
-									.requireService( ClassLoaderService.class )
-									.classForName( prefix );
-					if ( namedClass != null ) {
-						final Field referencedField = namedClass.getDeclaredField( terminal );
-						final JavaType<?> fieldJtd =
-								jpaMetamodel.getTypeConfiguration().getJavaTypeRegistry()
-										.getDescriptor( referencedField.getType() );
-						return new SqmFieldLiteral<>( referencedField, fieldJtd, nodeBuilder);
+					final JavaType<?> fieldJtdTest = jpaMetamodel.getJavaConstantType( prefix, terminal );
+					if ( fieldJtdTest != null ) {
+						final Object constantValue = jpaMetamodel.getJavaConstant( prefix, terminal );
+						return new SqmFieldLiteral( constantValue, fieldJtdTest, terminal, nodeBuilder );
+
 					}
 				}
 				catch (Exception ignore) {

--- a/tooling/metamodel-generator/src/main/java/org/hibernate/processor/validation/MockSessionFactory.java
+++ b/tooling/metamodel-generator/src/main/java/org/hibernate/processor/validation/MockSessionFactory.java
@@ -119,7 +119,6 @@ import org.hibernate.type.spi.TypeConfiguration;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.NoSuchElementException;
 import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
@@ -290,6 +289,8 @@ public abstract class MockSessionFactory
 	abstract boolean isEnum(String className);
 
 	abstract boolean isEnumConstant(String className, String terminal);
+
+	abstract Class<?> javaConstantType(String className, String fieldName);
 
 	abstract boolean isFieldDefined(String qualifiedClassName, String fieldName);
 
@@ -844,6 +845,19 @@ public abstract class MockSessionFactory
 			else {
 				return null;
 			}
+		}
+
+		@Override
+		public JavaType<?> getJavaConstantType(String className, String fieldName) {
+			final Class<?> fieldType = javaConstantType( className, fieldName );
+			return MockSessionFactory.this.getTypeConfiguration()
+					.getJavaTypeRegistry()
+					.getDescriptor( fieldType );
+		}
+
+		@Override
+		public <T> T getJavaConstant(String className, String fieldName) {
+			return null;
 		}
 
 		@Override

--- a/tooling/metamodel-generator/src/test/java/org/hibernate/processor/test/constant/ConstantInNamedQueryTest.java
+++ b/tooling/metamodel-generator/src/test/java/org/hibernate/processor/test/constant/ConstantInNamedQueryTest.java
@@ -1,0 +1,47 @@
+package org.hibernate.processor.test.constant;
+
+import org.hibernate.processor.test.util.CompilationTest;
+import org.hibernate.processor.test.util.TestForIssue;
+import org.hibernate.processor.test.util.TestUtil;
+import org.hibernate.processor.test.util.WithClasses;
+
+import org.junit.Test;
+
+import jakarta.persistence.EntityManager;
+
+import static org.hibernate.processor.test.util.TestUtil.assertMetamodelClassGeneratedFor;
+import static org.hibernate.processor.test.util.TestUtil.assertPresenceOfFieldInMetamodelFor;
+import static org.hibernate.processor.test.util.TestUtil.assertPresenceOfMethodInMetamodelFor;
+
+@TestForIssue(jiraKey = "HHH-18106")
+public class ConstantInNamedQueryTest extends CompilationTest {
+
+	@Test
+	@WithClasses(value = {}, sources = "org.hibernate.processor.test.constant.CookBookWithCheck")
+	public void withCheckHQL() {
+		final String entityClass = "org.hibernate.processor.test.constant.CookBookWithCheck";
+
+		System.out.println( TestUtil.getMetaModelSourceAsString( entityClass ) );
+
+		assertMetamodelClassGeneratedFor( entityClass );
+
+		assertPresenceOfFieldInMetamodelFor( entityClass, "QUERY_FIND_BAD_BOOKS" );
+		assertPresenceOfFieldInMetamodelFor( entityClass, "QUERY_FIND_GOOD_BOOKS" );
+
+		assertPresenceOfMethodInMetamodelFor( entityClass, "findBadBooks", EntityManager.class );
+		assertPresenceOfMethodInMetamodelFor( entityClass, "findGoodBooks", EntityManager.class );
+	}
+
+	@Test
+	@WithClasses(value = CookBookWithoutCheck.class, sources = "org.hibernate.processor.test.constant.NumericBookType")
+	public void withoutCheckHQL() {
+		final String entityClass = "org.hibernate.processor.test.constant.CookBookWithoutCheck";
+
+		System.out.println( TestUtil.getMetaModelSourceAsString( entityClass ) );
+
+		assertMetamodelClassGeneratedFor( entityClass );
+		assertPresenceOfFieldInMetamodelFor( entityClass, "QUERY_FIND_GOOD_BOOKS" );
+
+		assertPresenceOfMethodInMetamodelFor( entityClass, "findGoodBooks", EntityManager.class );
+	}
+}

--- a/tooling/metamodel-generator/src/test/java/org/hibernate/processor/test/constant/CookBookWithoutCheck.java
+++ b/tooling/metamodel-generator/src/test/java/org/hibernate/processor/test/constant/CookBookWithoutCheck.java
@@ -1,0 +1,16 @@
+package org.hibernate.processor.test.constant;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.NamedQuery;
+
+@Entity
+@NamedQuery(name = "#findGoodBooks",
+		query = "from CookBookWithoutCheck where bookType = org.hibernate.processor.test.constant.NumericBookType.GOOD")
+public class CookBookWithoutCheck {
+
+	@Id
+	String isbn;
+	String title;
+	int bookType;
+}

--- a/tooling/metamodel-generator/src/test/java/org/hibernate/processor/test/util/CompilationRunner.java
+++ b/tooling/metamodel-generator/src/test/java/org/hibernate/processor/test/util/CompilationRunner.java
@@ -26,6 +26,7 @@ import org.junit.runners.model.Statement;
 public class CompilationRunner extends BlockJUnit4ClassRunner {
 	private final List<Class<?>> testEntities;
 	private final List<Class<?>> preCompileEntities;
+	private final List<String> sources;
 	private final List<String> mappingFiles;
 	private final Map<String, String> processorOptions;
 	private final String packageName;
@@ -36,6 +37,7 @@ public class CompilationRunner extends BlockJUnit4ClassRunner {
 		super( clazz );
 		this.testEntities = new ArrayList<>();
 		this.preCompileEntities = new ArrayList<>();
+		this.sources = new ArrayList<>();
 		this.mappingFiles = new ArrayList<>();
 		this.processorOptions = new HashMap<>();
 		Package pkg = clazz.getPackage();
@@ -64,6 +66,7 @@ public class CompilationRunner extends BlockJUnit4ClassRunner {
 				getTestClass().getJavaClass(),
 				testEntities,
 				preCompileEntities,
+				sources,
 				mappingFiles,
 				processorOptions,
 				ignoreCompilationErrors
@@ -74,6 +77,7 @@ public class CompilationRunner extends BlockJUnit4ClassRunner {
 		if ( withClasses != null ) {
 			Collections.addAll( testEntities, withClasses.value() );
 			Collections.addAll( preCompileEntities, withClasses.preCompile() );
+			Collections.addAll( sources, withClasses.sources() );
 		}
 	}
 
@@ -116,7 +120,7 @@ public class CompilationRunner extends BlockJUnit4ClassRunner {
 	}
 
 	private boolean annotationProcessorNeedsToRun() {
-		return !testEntities.isEmpty() || !mappingFiles.isEmpty();
+		return !testEntities.isEmpty() || !sources.isEmpty() || !mappingFiles.isEmpty();
 	}
 }
 

--- a/tooling/metamodel-generator/src/test/java/org/hibernate/processor/test/util/TestUtil.java
+++ b/tooling/metamodel-generator/src/test/java/org/hibernate/processor/test/util/TestUtil.java
@@ -79,9 +79,26 @@ public class TestUtil {
 		);
 	}
 
+	public static void assertPresenceOfFieldInMetamodelFor(String className, String fieldName) {
+		assertPresenceOfFieldInMetamodelFor(
+				className,
+				fieldName,
+				"'" + fieldName + "' should appear in metamodel class"
+		);
+	}
+
 	public static void assertPresenceOfMethodInMetamodelFor(Class<?> clazz, String methodName, Class<?>... params) {
 		assertPresenceOfMethodInMetamodelFor(
 				clazz,
+				methodName,
+				"'" + methodName + "' should appear in metamodel class",
+				params
+		);
+	}
+
+	public static void assertPresenceOfMethodInMetamodelFor(String className, String methodName, Class<?>... params) {
+		assertPresenceOfMethodInMetamodelFor(
+				className,
 				methodName,
 				"'" + methodName + "' should appear in metamodel class",
 				params
@@ -92,9 +109,18 @@ public class TestUtil {
 		assertTrue( buildErrorString( errorString, clazz ), hasFieldInMetamodelFor( clazz, fieldName ) );
 	}
 
+	public static void assertPresenceOfFieldInMetamodelFor(String className, String fieldName, String errorString) {
+		assertTrue( buildErrorString( errorString, className ), hasFieldInMetamodelFor( className, fieldName ) );
+	}
+
 	public static void assertPresenceOfMethodInMetamodelFor(Class<?> clazz, String fieldName, String errorString,
 			Class<?>... params) {
 		assertTrue( buildErrorString( errorString, clazz ), hasMethodInMetamodelFor( clazz, fieldName, params ) );
+	}
+
+	public static void assertPresenceOfMethodInMetamodelFor(String className, String fieldName, String errorString,
+			Class<?>... params) {
+		assertTrue( buildErrorString( errorString, className ), hasMethodInMetamodelFor( className, fieldName, params ) );
 	}
 
 	public static void assertPresenceOfNameFieldInMetamodelFor(Class<?> clazz, String fieldName, String errorString) {
@@ -184,6 +210,10 @@ public class TestUtil {
 		assertNotNull( getMetamodelClassFor( clazz ) );
 	}
 
+	public static void assertMetamodelClassGeneratedFor(String className) {
+		assertNotNull( getMetamodelClassFor( className ) );
+	}
+
 	/**
 	 * Asserts that a metamodel class for the specified class got generated.
 	 *
@@ -227,6 +257,14 @@ public class TestUtil {
 	}
 
 	public static File getSourceBaseDir(Class<?> testClass) {
+		return getBaseDir( testClass, "java" );
+	}
+
+	public static File getResourcesBaseDir(Class<?> testClass) {
+		return getBaseDir( testClass, "resources" );
+	}
+
+	private static File getBaseDir(Class<?> testClass, String type) {
 		ClassLoader contextClassLoader = Thread.currentThread().getContextClassLoader();
 		String currentTestClassName = testClass.getName();
 		int hopsToCompileDirectory = currentTestClassName.split( "\\." ).length;
@@ -238,7 +276,7 @@ public class TestUtil {
 		}
 		final String configurationDirectory = targetDir.getName();
 		final File baseDir = targetDir.getParentFile().getParentFile().getParentFile().getParentFile();
-		final File outBaseDir = new File( baseDir, "src/" + configurationDirectory + "/java" );
+		final File outBaseDir = new File( baseDir, "src/" + configurationDirectory + "/" + type );
 		if ( !outBaseDir.exists() ) {
 			if ( !outBaseDir.mkdirs() ) {
 				fail( "Unable to create test output directory " + outBaseDir );
@@ -281,6 +319,23 @@ public class TestUtil {
 		return null;
 	}
 
+	public static Class<?> getMetamodelClassFor(String className) {
+		assertNotNull( "Class parameter cannot be null", className );
+		String metaModelClassName = getMetaModelClassName( className );
+		try {
+			URL outDirUrl = getOutBaseDir( TestUtil.class ).toURI().toURL();
+			URL[] urls = new URL[1];
+			urls[0] = outDirUrl;
+			URLClassLoader classLoader = new URLClassLoader( urls, TestUtil.class.getClassLoader() );
+			return classLoader.loadClass( metaModelClassName );
+		}
+		catch (Exception e) {
+			fail( metaModelClassName + " was not generated." );
+		}
+		// keep the compiler happy
+		return null;
+	}
+
 	public static File getMetaModelSourceFileFor(Class<?> clazz, boolean prefix) {
 		String metaModelClassName = getMetaModelClassName(clazz, prefix);
 		// generate the file name
@@ -289,10 +344,22 @@ public class TestUtil {
 		return new File( getOutBaseDir( clazz ), fileName );
 	}
 
+	public static File getMetaModelSourceFileFor(String className) {
+		String metaModelClassName = getMetaModelClassName(className );
+		// generate the file name
+		String fileName = metaModelClassName.replace( PACKAGE_SEPARATOR, PATH_SEPARATOR );
+		fileName = fileName.concat( ".java" );
+		return new File( getOutBaseDir( TestUtil.class ), fileName );
+	}
+
 	private static String getMetaModelClassName(Class<?> clazz, boolean prefix) {
 		return prefix
 				? clazz.getPackageName() + '.' + META_MODEL_CLASS_POSTFIX + clazz.getSimpleName()
 				: clazz.getName() + META_MODEL_CLASS_POSTFIX;
+	}
+
+	private static String getMetaModelClassName(String className) {
+		return className + META_MODEL_CLASS_POSTFIX;
 	}
 
 	public static String getMetaModelSourceAsString(Class<?> clazz) {
@@ -300,7 +367,14 @@ public class TestUtil {
 	}
 
 	public static String getMetaModelSourceAsString(Class<?> clazz, boolean prefix) {
-		File sourceFile = getMetaModelSourceFileFor( clazz, prefix );
+		return getSourceFileContent( getMetaModelSourceFileFor( clazz, prefix ) );
+	}
+
+	public static String getMetaModelSourceAsString(String className) {
+		return getSourceFileContent( getMetaModelSourceFileFor( className ) );
+	}
+
+	private static String getSourceFileContent(File sourceFile) {
 		StringBuilder contents = new StringBuilder();
 
 		try {
@@ -340,7 +414,11 @@ public class TestUtil {
 	}
 
 	public static Field getFieldFromMetamodelFor(Class<?> entityClass, String fieldName) {
-		Class<?> metaModelClass = getMetamodelClassFor( entityClass );
+		return getFieldFromMetamodelFor(entityClass.getName(), fieldName);
+	}
+
+	public static Field getFieldFromMetamodelFor(String className, String fieldName) {
+		Class<?> metaModelClass = getMetamodelClassFor( className );
 		try {
 			return metaModelClass.getDeclaredField( fieldName );
 		}
@@ -350,7 +428,11 @@ public class TestUtil {
 	}
 
 	public static Method getMethodFromMetamodelFor(Class<?> entityClass, String methodName, Class<?>... params) {
-		Class<?> metaModelClass = getMetamodelClassFor( entityClass );
+		return getMethodFromMetamodelFor(entityClass.getName(), methodName, params);
+	}
+
+	public static Method getMethodFromMetamodelFor(String className, String methodName, Class<?>... params) {
+		Class<?> metaModelClass = getMetamodelClassFor( className );
 		try {
 			return metaModelClass.getDeclaredMethod( methodName, params );
 		}
@@ -372,8 +454,16 @@ public class TestUtil {
 		return getFieldFromMetamodelFor( clazz, fieldName ) != null;
 	}
 
+	private static boolean hasFieldInMetamodelFor(String className, String fieldName) {
+		return getFieldFromMetamodelFor( className, fieldName ) != null;
+	}
+
 	private static boolean hasMethodInMetamodelFor(Class<?> clazz, String fieldName, Class<?>... params) {
 		return getMethodFromMetamodelFor( clazz, fieldName, params ) != null;
+	}
+
+	private static boolean hasMethodInMetamodelFor(String className, String fieldName, Class<?>... params) {
+		return getMethodFromMetamodelFor( className, fieldName, params ) != null;
 	}
 
 	private static String buildErrorString(String baseError, Class<?> clazz) {
@@ -385,6 +475,18 @@ public class TestUtil {
 		builder.append( "_.java:" );
 		builder.append( "\n" );
 		builder.append( getMetaModelSourceAsString( clazz ) );
+		return builder.toString();
+	}
+
+	private static String buildErrorString(String baseError, String className) {
+		StringBuilder builder = new StringBuilder();
+		builder.append( baseError );
+		builder.append( ".\n\n" );
+		builder.append( "Source code for " );
+		builder.append( className );
+		builder.append( "_.java:" );
+		builder.append( "\n" );
+		builder.append( getMetaModelSourceAsString( className ) );
 		return builder.toString();
 	}
 

--- a/tooling/metamodel-generator/src/test/java/org/hibernate/processor/test/util/WithClasses.java
+++ b/tooling/metamodel-generator/src/test/java/org/hibernate/processor/test/util/WithClasses.java
@@ -25,4 +25,6 @@ public @interface WithClasses {
 	 * @return an array of classes which should be complied prior to compiling the actual test classes
 	 */
 	Class<?>[] preCompile() default { };
+
+	String[] sources() default {};
 }

--- a/tooling/metamodel-generator/src/test/resources/org/hibernate/processor/test/constant/CookBookWithCheck.java
+++ b/tooling/metamodel-generator/src/test/resources/org/hibernate/processor/test/constant/CookBookWithCheck.java
@@ -1,0 +1,25 @@
+package org.hibernate.processor.test.constant;
+
+import org.hibernate.annotations.processing.CheckHQL;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.NamedQuery;
+
+@Entity
+@CheckHQL
+@NamedQuery(name = "#findGoodBooks",
+		query = "from CookBookWithCheck where bookType = org.hibernate.processor.test.constant.CookBookWithCheck.GOOD")
+@NamedQuery(name = "#findBadBooks",
+		query = "from CookBookWithCheck where bookType = 0")
+public class CookBookWithCheck {
+
+	public static final int GOOD = 1;
+	public static final int BAD = 0;
+	public static final int UGLY = -1;
+
+	@Id
+	String isbn;
+	String title;
+	int bookType;
+}

--- a/tooling/metamodel-generator/src/test/resources/org/hibernate/processor/test/constant/NumericBookType.java
+++ b/tooling/metamodel-generator/src/test/resources/org/hibernate/processor/test/constant/NumericBookType.java
@@ -1,0 +1,7 @@
+package org.hibernate.processor.test.constant;
+
+public class NumericBookType {
+	public static final Integer GOOD = 1;
+	public static final Integer BAD = 0;
+	public static final Integer UGLY = -1;
+}


### PR DESCRIPTION
See Jira issue [HHH-18106](https://hibernate.atlassian.net/browse/HHH-18106)

When named query in entity method annotated with @CheckHQL contains valid Java constant, processor should not report error

[HHH-18106]: https://hibernate.atlassian.net/browse/HHH-18106?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ