### PR TITLE
HHH-18112 Some dialects use the wrong default version

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/dialect/H2Dialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/H2Dialect.java
@@ -148,7 +148,11 @@ public class H2Dialect extends Dialect {
 	}
 
 	private static DatabaseVersion parseVersion(DialectResolutionInfo info) {
-		return DatabaseVersion.make( info.getMajor(), info.getMinor(), parseBuildId( info ) );
+		DatabaseVersion version = info.makeCopyOrDefault( MINIMUM_VERSION );
+		if ( info.getDatabaseVersion() != null ) {
+			version = DatabaseVersion.make( version.getMajor(), version.getMinor(), parseBuildId( info ) );
+		}
+		return version;
 	}
 
 	private static int parseBuildId(DialectResolutionInfo info) {

--- a/hibernate-core/src/main/java/org/hibernate/dialect/HANADialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/HANADialect.java
@@ -24,7 +24,7 @@ import org.hibernate.engine.jdbc.dialect.spi.DialectResolutionInfo;
 @SuppressWarnings("removal")
 public class HANADialect extends AbstractHANADialect {
 
-	private static final DatabaseVersion MINIMUM_VERSION = DatabaseVersion.make( 1, 0, 120 );
+	static final DatabaseVersion MINIMUM_VERSION = DatabaseVersion.make( 1, 0, 120 );
 
 	public HANADialect(DialectResolutionInfo info) {
 		this( HANAServerConfiguration.fromDialectResolutionInfo( info ), true );

--- a/hibernate-core/src/main/java/org/hibernate/dialect/HANAServerConfiguration.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/HANAServerConfiguration.java
@@ -83,6 +83,9 @@ public class HANAServerConfiguration {
 		int majorVersion = 1;
 		int minorVersion = 0;
 		int patchLevel = 0;
+		if ( versionString == null ) {
+			return HANADialect.MINIMUM_VERSION;
+		}
 		final String[] components = versionString.split( "\\." );
 		if ( components.length >= 3 ) {
 			try {

--- a/hibernate-core/src/main/java/org/hibernate/dialect/MariaDBDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/MariaDBDialect.java
@@ -62,7 +62,7 @@ public class MariaDBDialect extends MySQLDialect {
 	}
 
 	public MariaDBDialect(DialectResolutionInfo info) {
-		super( createVersion( info ), MySQLServerConfiguration.fromDialectResolutionInfo( info ) );
+		super( createVersion( info, MINIMUM_VERSION ), MySQLServerConfiguration.fromDialectResolutionInfo( info ) );
 		registerKeywords( info );
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/dialect/MySQLDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/MySQLDialect.java
@@ -188,7 +188,12 @@ public class MySQLDialect extends Dialect {
 		registerKeywords( info );
 	}
 
+	@Deprecated
 	protected static DatabaseVersion createVersion(DialectResolutionInfo info) {
+		return createVersion( info, MINIMUM_VERSION );
+	}
+
+	protected static DatabaseVersion createVersion(DialectResolutionInfo info, DatabaseVersion defaultVersion) {
 		final String versionString = info.getDatabaseVersion();
 		if ( versionString != null ) {
 			final String[] components = versionString.split( "\\." );
@@ -204,7 +209,7 @@ public class MySQLDialect extends Dialect {
 				}
 			}
 		}
-		return info.makeCopyOrDefault( MINIMUM_VERSION );
+		return info.makeCopyOrDefault( defaultVersion );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/dialect/PostgreSQLDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/PostgreSQLDialect.java
@@ -152,7 +152,7 @@ public class PostgreSQLDialect extends Dialect {
 	}
 
 	public PostgreSQLDialect(DialectResolutionInfo info) {
-		this( info, PostgreSQLDriverKind.determineKind( info ) );
+		this( info.makeCopyOrDefault( MINIMUM_VERSION ), PostgreSQLDriverKind.determineKind( info ) );
 		registerKeywords( info );
 	}
 


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-18112

We were testing Oracle only, hence the undetected failures.

I kept this test as a unit test, but I wonder if it shouldn't rather be an integration test TBH. That would require some changes to `database.gradle`, e.g. to add the product name, so that we can (somehow) retrieve it from the test. Probably better do that as a separate improvement, on `main` only, and when we're not being rushed.

Backport to branch 6.5: #8381