### PR TITLE
Fix CockroachDB timestampdiff errors caused by `round()` return type

### DIFF
--- a/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/CockroachLegacyDialect.java
+++ b/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/CockroachLegacyDialect.java
@@ -859,7 +859,7 @@ public class CockroachLegacyDialect extends Dialect {
 					case SECOND:
 					case NANOSECOND:
 					case NATIVE:
-						return "round(extract(epoch from ?3-?2)" + EPOCH.conversionFactor( unit, this ) + ")";
+						return "round(extract(epoch from ?3-?2)" + EPOCH.conversionFactor( unit, this ) + ")::int";
 					default:
 						throw new SemanticException( "unrecognized field: " + unit );
 				}

--- a/hibernate-core/src/main/java/org/hibernate/dialect/CockroachDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/CockroachDialect.java
@@ -861,7 +861,7 @@ public class CockroachDialect extends Dialect {
 				case SECOND:
 				case NANOSECOND:
 				case NATIVE:
-					return "round(extract(epoch from ?3-?2)" + EPOCH.conversionFactor( unit, this ) + ")";
+					return "round(extract(epoch from ?3-?2)" + EPOCH.conversionFactor( unit, this ) + ")::int";
 				default:
 					throw new SemanticException( "Unrecognized field: " + unit );
 			}


### PR DESCRIPTION
Fixes errors in [FunctionTests.testIntervalScaleExpressions](https://ci.hibernate.org/job/hibernate-orm-nightly/job/main/516/testReport/junit/org.hibernate.orm.test.query.hql/FunctionTests/Build___cockroachdb_cockroachdb___Test___testIntervalScaleExpressions_SessionFactoryScope_/) and [StandardFunctionTests.testIntervalScaleExpressions](https://ci.hibernate.org/job/hibernate-orm-nightly/job/main/516/testReport/junit/org.hibernate.orm.test.query.hql/StandardFunctionTests/Build___cockroachdb_cockroachdb___Test___testIntervalScaleExpressions_SessionFactoryScope_/).