### PR TITLE
HHH-18026 Fix id column not found due to some driver doesn't follow JDBC specification

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/generator/values/GeneratedValueBasicResultBuilder.java
+++ b/hibernate-core/src/main/java/org/hibernate/generator/values/GeneratedValueBasicResultBuilder.java
@@ -103,19 +103,12 @@ public class GeneratedValueBasicResultBuilder implements ResultBuilder {
 	}
 
 	private static int columnIndex(JdbcValuesMetadata jdbcResultsMetadata, BasicValuedModelPart modelPart) {
-		try {
-			return jdbcPositionToValuesArrayPosition( jdbcResultsMetadata.resolveColumnPosition(
-					getActualGeneratedModelPart( modelPart ).getSelectionExpression()
-			) );
+		if ( modelPart.isEntityIdentifierMapping() ) {
+			// Default to the first position for entity identifiers
+			return 0;
 		}
-		catch (Exception e) {
-			if ( modelPart.isEntityIdentifierMapping() ) {
-				// Default to the first position for entity identifiers
-				return 0;
-			}
-			else {
-				throw e;
-			}
-		}
+		return jdbcPositionToValuesArrayPosition( jdbcResultsMetadata.resolveColumnPosition(
+				getActualGeneratedModelPart( modelPart ).getSelectionExpression()
+		) );
 	}
 }


### PR DESCRIPTION
For example, MySQL mysql-connector-j driver use static `GENERATED_KEY` and MS SqlServer mssql-jdbc driver use static `GENERATED_KEYS` instead of actual column name. This commit will improve performance a bit also since it eliminate unnecessary column position lookup.

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-18026
<!-- Hibernate GitHub Bot issue links end -->