### PR TITLE
HHH-17514 Reproducer for metamodel generation failure on Map<String, Map<String, Object>> field

### DIFF
--- a/tooling/metamodel-generator/src/test/java/org/hibernate/jpamodelgen/test/map/MapOfMapEntity.java
+++ b/tooling/metamodel-generator/src/test/java/org/hibernate/jpamodelgen/test/map/MapOfMapEntity.java
@@ -1,0 +1,30 @@
+package org.hibernate.jpamodelgen.test.map;
+
+import java.util.Map;
+
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+@Entity
+@Table( name = "MAP_OF_MAP_ENTITY" )
+public class MapOfMapEntity {
+	@Id
+	@Column(name="key_")
+	private String key;
+
+	@JdbcTypeCode(SqlTypes.JSON)
+	private Map<String, Map<String, Object>> mapOfMap;
+
+	public String getKey() {
+		return key;
+	}
+
+	public void setKey(String key) {
+		this.key = key;
+	}
+}

--- a/tooling/metamodel-generator/src/test/java/org/hibernate/jpamodelgen/test/map/MetamodelGeneratedTest.java
+++ b/tooling/metamodel-generator/src/test/java/org/hibernate/jpamodelgen/test/map/MetamodelGeneratedTest.java
@@ -1,0 +1,22 @@
+package org.hibernate.jpamodelgen.test.map;
+
+import org.hibernate.jpamodelgen.test.util
+		.CompilationTest;
+import org.hibernate.jpamodelgen.test.util.TestForIssue;
+import org.hibernate.jpamodelgen.test.util.WithClasses;
+
+import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+
+import static org.hibernate.jpamodelgen.test.util.TestUtil.getMetamodelClassFor;
+
+public class MetamodelGeneratedTest extends CompilationTest {
+
+	@Test
+	@WithClasses({ MapOfMapEntity.class })
+	@TestForIssue(jiraKey = " HHH-17514")
+	public void test() {
+		Class<?> repositoryClass = getMetamodelClassFor( MapOfMapEntity.class );
+		Assertions.assertNotNull( repositoryClass );
+	}
+}


### PR DESCRIPTION
Just to show that if you add the test on top of 6.4.0, it fails.

See #8403

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-17514
<!-- Hibernate GitHub Bot issue links end -->