### PR TITLE
HHH-18150 Fix for Informix float and double precision in decimal digits

### DIFF
--- a/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/InformixDialect.java
+++ b/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/InformixDialect.java
@@ -7,6 +7,8 @@
 package org.hibernate.community.dialect;
 
 import org.hibernate.boot.Metadata;
+import java.sql.Types;
+
 import org.hibernate.boot.model.FunctionContributions;
 import org.hibernate.boot.model.TypeContributions;
 import org.hibernate.boot.model.relational.SqlStringGenerationContext;
@@ -27,6 +29,7 @@ import org.hibernate.dialect.sequence.SequenceSupport;
 import org.hibernate.dialect.temptable.TemporaryTable;
 import org.hibernate.dialect.temptable.TemporaryTableKind;
 import org.hibernate.dialect.unique.UniqueDelegate;
+import org.hibernate.engine.jdbc.Size;
 import org.hibernate.engine.jdbc.dialect.spi.DialectResolutionInfo;
 import org.hibernate.engine.spi.LoadQueryInfluencers;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
@@ -62,6 +65,8 @@ import org.hibernate.sql.exec.spi.JdbcOperation;
 import org.hibernate.tool.schema.extract.spi.SequenceInformationExtractor;
 import org.hibernate.tool.schema.internal.StandardForeignKeyExporter;
 import org.hibernate.tool.schema.spi.Exporter;
+import org.hibernate.type.descriptor.java.JavaType;
+import org.hibernate.type.descriptor.jdbc.JdbcType;
 import org.hibernate.type.descriptor.sql.internal.CapacityDependentDdlType;
 import org.hibernate.type.descriptor.sql.spi.DdlTypeRegistry;
 import org.hibernate.type.spi.TypeConfiguration;
@@ -113,6 +118,24 @@ public class InformixDialect extends Dialect {
 		}
 	};
 
+	private final SizeStrategy sizeStrategy = new SizeStrategyImpl() {
+		@Override
+		public Size resolveSize(
+				JdbcType jdbcType,
+				JavaType<?> javaType,
+				Integer precision,
+				Integer scale,
+				Long length) {
+			switch ( jdbcType.getDdlTypeCode() ) {
+				case Types.FLOAT:
+					// Informix allows FLOAT with a precision up to 16
+					if ( precision != null ) {
+						return Size.precision( Math.min( Math.max( precision, 1 ), 16 ) );
+					}
+			}
+			return super.resolveSize( jdbcType, javaType, precision, scale, length );
+		}
+	};
 	public InformixDialect(DialectResolutionInfo info) {
 		this( info.makeCopyOrDefault( DEFAULT_VERSION ) );
 		registerKeywords( info );
@@ -177,7 +200,7 @@ public class InformixDialect extends Dialect {
 		//double precision.
 		ddlTypeRegistry.addDescriptor(
 				CapacityDependentDdlType.builder( FLOAT, "float($p)", this )
-						.withTypeCapacity( 24, "smallfloat" )
+						.withTypeCapacity( 8, "smallfloat" )
 						.build()
 		);
 
@@ -222,6 +245,21 @@ public class InformixDialect extends Dialect {
 	public int getDefaultTimestampPrecision() {
 		//the maximum
 		return 5;
+	}
+
+	@Override
+	public int getFloatPrecision() {
+		return 8;
+	}
+
+	@Override
+	public int getDoublePrecision() {
+		return 16;
+	}
+
+	@Override
+	public SizeStrategy getSizeStrategy() {
+		return sizeStrategy;
 	}
 
 	@Override

--- a/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/InformixDialect.java
+++ b/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/InformixDialect.java
@@ -7,7 +7,6 @@
 package org.hibernate.community.dialect;
 
 import org.hibernate.boot.Metadata;
-import java.sql.Types;
 
 import org.hibernate.boot.model.FunctionContributions;
 import org.hibernate.boot.model.TypeContributions;
@@ -29,7 +28,6 @@ import org.hibernate.dialect.sequence.SequenceSupport;
 import org.hibernate.dialect.temptable.TemporaryTable;
 import org.hibernate.dialect.temptable.TemporaryTableKind;
 import org.hibernate.dialect.unique.UniqueDelegate;
-import org.hibernate.engine.jdbc.Size;
 import org.hibernate.engine.jdbc.dialect.spi.DialectResolutionInfo;
 import org.hibernate.engine.spi.LoadQueryInfluencers;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
@@ -65,8 +63,6 @@ import org.hibernate.sql.exec.spi.JdbcOperation;
 import org.hibernate.tool.schema.extract.spi.SequenceInformationExtractor;
 import org.hibernate.tool.schema.internal.StandardForeignKeyExporter;
 import org.hibernate.tool.schema.spi.Exporter;
-import org.hibernate.type.descriptor.java.JavaType;
-import org.hibernate.type.descriptor.jdbc.JdbcType;
 import org.hibernate.type.descriptor.sql.internal.CapacityDependentDdlType;
 import org.hibernate.type.descriptor.sql.spi.DdlTypeRegistry;
 import org.hibernate.type.spi.TypeConfiguration;
@@ -118,24 +114,6 @@ public class InformixDialect extends Dialect {
 		}
 	};
 
-	private final SizeStrategy sizeStrategy = new SizeStrategyImpl() {
-		@Override
-		public Size resolveSize(
-				JdbcType jdbcType,
-				JavaType<?> javaType,
-				Integer precision,
-				Integer scale,
-				Long length) {
-			switch ( jdbcType.getDdlTypeCode() ) {
-				case Types.FLOAT:
-					// Informix allows FLOAT with a precision up to 16
-					if ( precision != null ) {
-						return Size.precision( Math.min( Math.max( precision, 1 ), 16 ) );
-					}
-			}
-			return super.resolveSize( jdbcType, javaType, precision, scale, length );
-		}
-	};
 	public InformixDialect(DialectResolutionInfo info) {
 		this( info.makeCopyOrDefault( DEFAULT_VERSION ) );
 		registerKeywords( info );
@@ -199,7 +177,7 @@ public class InformixDialect extends Dialect {
 		//float(n) and just always defaults to
 		//double precision.
 		ddlTypeRegistry.addDescriptor(
-				CapacityDependentDdlType.builder( FLOAT, "float($p)", this )
+				CapacityDependentDdlType.builder( FLOAT, "float", this )
 						.withTypeCapacity( 8, "smallfloat" )
 						.build()
 		);
@@ -255,11 +233,6 @@ public class InformixDialect extends Dialect {
 	@Override
 	public int getDoublePrecision() {
 		return 16;
-	}
-
-	@Override
-	public SizeStrategy getSizeStrategy() {
-		return sizeStrategy;
 	}
 
 	@Override


### PR DESCRIPTION
I propose using float precision 8 since the documentation [smallfoat documentation](https://www.ibm.com/docs/en/informix-servers/14.10?topic=types-smallfloat) states that the SMALLFLOAT data type stores single-precision floating-point numbers with approximately nine significant digits.

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-18150
<!-- Hibernate GitHub Bot issue links end -->