### PR TITLE
HHH-18151 Fix lazy loading with generics and inheritance

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/bytecode/enhance/internal/bytebuddy/BiDirectionalAssociationHandler.java
+++ b/hibernate-core/src/main/java/org/hibernate/bytecode/enhance/internal/bytebuddy/BiDirectionalAssociationHandler.java
@@ -350,7 +350,7 @@ final class BiDirectionalAssociationHandler implements Implementation {
 									Opcodes.INVOKEVIRTUAL,
 									entity.getInternalName(),
 									EnhancerConstants.PERSISTENT_FIELD_READER_PREFIX + field.getName(),
-									Type.getMethodDescriptor( Type.getType( field.getDescriptor() ) ),
+									Type.getMethodDescriptor( Type.getType( field.asDefined().getDescriptor() ) ),
 									false
 							);
 						}

--- a/hibernate-core/src/main/java/org/hibernate/bytecode/enhance/internal/bytebuddy/PersistentAttributeTransformer.java
+++ b/hibernate-core/src/main/java/org/hibernate/bytecode/enhance/internal/bytebuddy/PersistentAttributeTransformer.java
@@ -261,7 +261,7 @@ final class PersistentAttributeTransformer implements AsmVisitorWrapper.ForDecla
 			builder = builder
 					.defineMethod(
 							EnhancerConstants.PERSISTENT_FIELD_READER_PREFIX + enhancedField.getName(),
-							enhancedField.getType().asErasure(),
+							enhancedField.asDefined().getType().asErasure(),
 							Visibility.PUBLIC
 					)
 					.intercept( fieldReader( enhancedField ) );
@@ -373,10 +373,10 @@ final class PersistentAttributeTransformer implements AsmVisitorWrapper.ForDecla
 					Opcodes.INVOKESPECIAL,
 					managedCtClass.getSuperClass().asErasure().getInternalName(),
 					EnhancerConstants.PERSISTENT_FIELD_READER_PREFIX + persistentField.getName(),
-					Type.getMethodDescriptor( Type.getType( persistentField.getType().asErasure().getDescriptor() ) ),
+					Type.getMethodDescriptor( Type.getType( persistentField.asDefined().getType().asErasure().getDescriptor() ) ),
 					false
 			);
-			methodVisitor.visitInsn( Type.getType( persistentField.getType().asErasure().getDescriptor() ).getOpcode( Opcodes.IRETURN ) );
+			methodVisitor.visitInsn( Type.getType( persistentField.asDefined().getType().asErasure().getDescriptor() ).getOpcode( Opcodes.IRETURN ) );
 			return new Size( persistentField.getType().getStackSize().getSize(), instrumentedMethod.getStackSize() );
 		}
 	}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/lazy/LazyLoadingAndParameterizedInheritanceTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/lazy/LazyLoadingAndParameterizedInheritanceTest.java
@@ -1,0 +1,204 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.orm.test.bytecode.enhancement.lazy;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.MappedSuperclass;
+import jakarta.persistence.OneToMany;
+
+import org.hibernate.cfg.AvailableSettings;
+
+import org.hibernate.testing.bytecode.enhancement.extension.BytecodeEnhanced;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.JiraKey;
+import org.hibernate.testing.orm.junit.ServiceRegistry;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.hibernate.testing.orm.junit.Setting;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DomainModel(
+		annotatedClasses = {
+				LazyLoadingAndParameterizedInheritanceTest.One.class,
+				LazyLoadingAndParameterizedInheritanceTest.AbsOne.class,
+				LazyLoadingAndParameterizedInheritanceTest.AbsTwo.class,
+				LazyLoadingAndParameterizedInheritanceTest.Three.class,
+				LazyLoadingAndParameterizedInheritanceTest.Two.class,
+		}
+)
+@ServiceRegistry(
+		settings = {
+				@Setting(name = AvailableSettings.USE_SECOND_LEVEL_CACHE, value = "false"),
+				@Setting(name = AvailableSettings.ENABLE_LAZY_LOAD_NO_TRANS, value = "true"),
+		}
+)
+@SessionFactory
+@BytecodeEnhanced
+@JiraKey("HHH-18151")
+public class LazyLoadingAndParameterizedInheritanceTest {
+
+	private Long oneId;
+	private Long threeId;
+
+	@BeforeAll
+	public void before(SessionFactoryScope scope) {
+		scope.inTransaction( s -> {
+			final var one = new One();
+			final var two = new Two();
+			final var three = new Three();
+			one.setTwo( two );
+			two.getOnes().add( one );
+			two.setThree( three );
+			three.getTwos().add( two );
+
+			s.persist( one );
+			s.persist( two );
+			s.persist( three );
+			oneId = one.getId();
+			threeId = three.getId();
+		} );
+	}
+
+	@AfterAll
+	void after(SessionFactoryScope scope) {
+		scope.inTransaction( session -> {
+			session.createMutationQuery( session.getCriteriaBuilder().createCriteriaDelete( One.class ) )
+					.executeUpdate();
+			session.createMutationQuery( session.getCriteriaBuilder().createCriteriaDelete( Two.class ) )
+					.executeUpdate();
+			session.createMutationQuery( session.getCriteriaBuilder().createCriteriaDelete( Three.class ) )
+					.executeUpdate();
+		} );
+	}
+
+	@Test
+	public void test(SessionFactoryScope scope) {
+		scope.inTransaction( s -> {
+			One one = s.find( One.class, oneId );
+			Two two = one.getTwo();
+			final var three = two.getThree();
+
+			final var actualThree = s.find( Three.class, threeId );
+			assertThat( actualThree ).isNotNull();
+			assertThat( actualThree.getTwos().iterator().next().getId() ).isEqualTo( two.getId() );
+
+			//That is the actual test. If three == null ==> lazy load was not performed.
+			assertThat( three ).isNotNull();
+		} );
+	}
+
+	@Entity(name = "One")
+	public static class One extends AbsOne<Two> {
+	}
+
+	@MappedSuperclass
+	public static abstract class AbsOne<TWO extends AbsTwo<?, ?>> {
+		@Id
+		@GeneratedValue
+		private Long id;
+
+		@ManyToOne(fetch = FetchType.LAZY)
+		@JoinColumn(name = "two_id")
+		private TWO two;
+
+		public Long getId() {
+			return id;
+		}
+
+		public void setId(Long id) {
+			this.id = id;
+		}
+
+		public TWO getTwo() {
+			return two;
+		}
+
+		public void setTwo(TWO two) {
+			this.two = two;
+		}
+	}
+
+	@Entity(name = "Two")
+	public static class Two extends AbsTwo<One, Three> {
+	}
+
+	@MappedSuperclass
+	public static abstract class AbsTwo<ONE extends AbsOne<?>, THREE> {
+		@Id
+		@GeneratedValue
+		private Long id;
+
+		@ManyToOne(fetch = FetchType.LAZY)
+		@JoinColumn(name = "three_id")
+		private THREE three;
+
+		@OneToMany(mappedBy = "two")
+		private Set<ONE> ones = new HashSet<>();
+
+		public Long getId() {
+			return id;
+		}
+
+		public void setId(Long id) {
+			this.id = id;
+		}
+
+		public THREE getThree() {
+			return three;
+		}
+
+		public void setThree(THREE three) {
+			this.three = three;
+		}
+
+		public Set<ONE> getOnes() {
+			return ones;
+		}
+
+		public void setOnes(Set<ONE> ones) {
+			this.ones = ones;
+		}
+	}
+
+	@Entity(name = "Three")
+	public static class Three {
+		@Id
+		@GeneratedValue
+		private Long id;
+
+		@OneToMany(mappedBy = "three")
+		private Set<Two> twos = new HashSet<>();
+
+		public Long getId() {
+			return id;
+		}
+
+		public void setId(Long id) {
+			this.id = id;
+		}
+
+		public Set<Two> getTwos() {
+			return twos;
+		}
+
+		public void setTwos(Set<Two> twos) {
+			this.twos = twos;
+		}
+	}
+}


### PR DESCRIPTION
https://hibernate.atlassian.net/jira/software/c/projects/HHH/issues/HHH-18151

**My first PR. :)**

The issue turned to be quite similar to 
https://hibernate.atlassian.net/jira/software/c/projects/HHH/issues/HHH-16459
with fix https://github.com/hibernate/hibernate-orm/pull/6404

The problem was that the method `$$_$$_hibernate_read_GENERIC_ATTRIBUTE` that was defined in concrete class did not override the same method in its MappedSuperclass. 
Because method signature (return type) was different.