### PR TITLE
HHH-17030 Followup: move schema check from the engine into a listener

### DIFF
--- a/hibernate-agroal/src/test/resources/META-INF/services/org.junit.platform.launcher.LauncherSessionListener
+++ b/hibernate-agroal/src/test/resources/META-INF/services/org.junit.platform.launcher.LauncherSessionListener
@@ -1,0 +1,1 @@
+org.hibernate.testing.schema.CheckClearSchemaListener

--- a/hibernate-c3p0/src/test/resources/META-INF/services/org.junit.platform.launcher.LauncherSessionListener
+++ b/hibernate-c3p0/src/test/resources/META-INF/services/org.junit.platform.launcher.LauncherSessionListener
@@ -1,0 +1,1 @@
+org.hibernate.testing.schema.CheckClearSchemaListener

--- a/hibernate-community-dialects/src/test/resources/META-INF/services/org.junit.platform.launcher.LauncherSessionListener
+++ b/hibernate-community-dialects/src/test/resources/META-INF/services/org.junit.platform.launcher.LauncherSessionListener
@@ -1,0 +1,1 @@
+org.hibernate.testing.schema.CheckClearSchemaListener

--- a/hibernate-core/src/test/resources/META-INF/services/org.junit.platform.launcher.LauncherSessionListener
+++ b/hibernate-core/src/test/resources/META-INF/services/org.junit.platform.launcher.LauncherSessionListener
@@ -1,0 +1,1 @@
+org.hibernate.testing.schema.CheckClearSchemaListener

--- a/hibernate-envers/src/test/java/org/hibernate/orm/test/envers/AbstractEnversTest.java
+++ b/hibernate-envers/src/test/java/org/hibernate/orm/test/envers/AbstractEnversTest.java
@@ -26,10 +26,6 @@ import org.jboss.logging.Logger;
 @RunWith(EnversRunner.class)
 public abstract class AbstractEnversTest {
 
-	static {
-		DatabaseCleaner.clearSchemas();
-	}
-
 	protected final Logger log = Logger.getLogger( getClass() );
 
 	private String auditStrategy;

--- a/hibernate-envers/src/test/resources/META-INF/services/org.junit.platform.launcher.LauncherSessionListener
+++ b/hibernate-envers/src/test/resources/META-INF/services/org.junit.platform.launcher.LauncherSessionListener
@@ -1,0 +1,1 @@
+org.hibernate.testing.schema.CheckClearSchemaListener

--- a/hibernate-hikaricp/src/test/resources/META-INF/services/org.junit.platform.launcher.LauncherSessionListener
+++ b/hibernate-hikaricp/src/test/resources/META-INF/services/org.junit.platform.launcher.LauncherSessionListener
@@ -1,0 +1,1 @@
+org.hibernate.testing.schema.CheckClearSchemaListener

--- a/hibernate-jcache/src/test/resources/META-INF/services/org.junit.platform.launcher.LauncherSessionListener
+++ b/hibernate-jcache/src/test/resources/META-INF/services/org.junit.platform.launcher.LauncherSessionListener
@@ -1,0 +1,1 @@
+org.hibernate.testing.schema.CheckClearSchemaListener

--- a/hibernate-jfr/src/test/resources/META-INF/services/org.junit.platform.launcher.LauncherSessionListener
+++ b/hibernate-jfr/src/test/resources/META-INF/services/org.junit.platform.launcher.LauncherSessionListener
@@ -1,0 +1,1 @@
+org.hibernate.testing.schema.CheckClearSchemaListener

--- a/hibernate-micrometer/src/test/resources/META-INF/services/org.junit.platform.launcher.LauncherSessionListener
+++ b/hibernate-micrometer/src/test/resources/META-INF/services/org.junit.platform.launcher.LauncherSessionListener
@@ -1,0 +1,1 @@
+org.hibernate.testing.schema.CheckClearSchemaListener

--- a/hibernate-spatial/src/test/resources/META-INF/services/org.junit.platform.launcher.LauncherSessionListener
+++ b/hibernate-spatial/src/test/resources/META-INF/services/org.junit.platform.launcher.LauncherSessionListener
@@ -1,0 +1,1 @@
+org.hibernate.testing.schema.CheckClearSchemaListener

--- a/hibernate-testing/src/main/java/org/hibernate/testing/bytecode/enhancement/extension/engine/BytecodeEnhancedTestEngine.java
+++ b/hibernate-testing/src/main/java/org/hibernate/testing/bytecode/enhancement/extension/engine/BytecodeEnhancedTestEngine.java
@@ -62,13 +62,6 @@ public class BytecodeEnhancedTestEngine extends HierarchicalTestEngine<JupiterEn
 
 	@Override
 	public TestDescriptor discover(EngineDiscoveryRequest discoveryRequest, UniqueId uniqueId) {
-		// Make sure this runs first
-		try {
-			BaseUnitTestCase.checkClearSchema();
-		}
-		catch (Throwable e) {
-			throw new RuntimeException( e );
-		}
 		JupiterConfiguration configuration = new CachingJupiterConfiguration(
 				new DefaultJupiterConfiguration( discoveryRequest.getConfigurationParameters() ) );
 		JupiterEngineDescriptor engineDescriptor = new BytecodeEnhancedEngineDescriptor( uniqueId, configuration );

--- a/hibernate-testing/src/main/java/org/hibernate/testing/junit4/BaseUnitTestCase.java
+++ b/hibernate-testing/src/main/java/org/hibernate/testing/junit4/BaseUnitTestCase.java
@@ -16,8 +16,6 @@ import jakarta.transaction.SystemException;
 import org.hibernate.engine.transaction.internal.jta.JtaStatusHelper;
 
 import org.hibernate.testing.AfterClassOnce;
-import org.hibernate.testing.BeforeClassOnce;
-import org.hibernate.testing.cleaner.DatabaseCleaner;
 import org.hibernate.testing.jdbc.leak.ConnectionLeakUtil;
 import org.hibernate.testing.jta.TestingJtaPlatformImpl;
 import org.junit.After;
@@ -35,24 +33,6 @@ import org.jboss.logging.Logger;
  */
 @RunWith( CustomRunner.class )
 public abstract class BaseUnitTestCase {
-
-	private static Throwable schemaClearError;
-
-	static {
-		try {
-			DatabaseCleaner.clearSchemas();
-		}
-		catch (Throwable t) {
-			schemaClearError = t;
-		}
-	}
-
-	@BeforeClassOnce
-	public static void checkClearSchema() throws Throwable {
-		if (schemaClearError!=null) {
-			throw schemaClearError;
-		}
-	}
 
 	protected final Logger log = Logger.getLogger( getClass() );
 

--- a/hibernate-testing/src/main/java/org/hibernate/testing/schema/CheckClearSchemaListener.java
+++ b/hibernate-testing/src/main/java/org/hibernate/testing/schema/CheckClearSchemaListener.java
@@ -1,0 +1,27 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.testing.schema;
+
+import org.hibernate.testing.cleaner.DatabaseCleaner;
+import org.junit.platform.launcher.LauncherSession;
+import org.junit.platform.launcher.LauncherSessionListener;
+
+/**
+ * This listener should be called before the discovery request is sent to the test engines.
+ * <p>
+ * Note, it is on purpose not registered as a service within the {@code hibernate-testing} (i.e. in {@code META-INF/services} of this jar).
+ * This is to prevent this listener be invoked by non Hibernate ORM users of the {@code hibernate-testing} lib.
+ * <p>
+ * See also <a href="https://junit.org/junit5/docs/current/user-guide/#launcher-api-launcher-session-listeners-tool-example-usage">...</a>
+ */
+public class CheckClearSchemaListener implements LauncherSessionListener {
+
+	@Override
+	public void launcherSessionOpened(LauncherSession session) {
+		DatabaseCleaner.clearSchemas();
+	}
+}

--- a/hibernate-vector/src/test/resources/META-INF/services/org.junit.platform.launcher.LauncherSessionListener
+++ b/hibernate-vector/src/test/resources/META-INF/services/org.junit.platform.launcher.LauncherSessionListener
@@ -1,0 +1,1 @@
+org.hibernate.testing.schema.CheckClearSchemaListener


### PR DESCRIPTION
This is only related to the JUnit change from the PR related to the JIRA mentioned in the title (https://github.com/hibernate/hibernate-orm/pull/8413)

We'd want to reuse this engine/extension in Hibernate Search, and this check `BaseUnitTestCase.checkClearSchema();` leads to failure there 😔. 

Here, I've added a listener and referenced it in the core module so that it is not automatically picked up by those who just want to use the testing jar.

Alternatively, if you think that the listener isn't a good idea, we could try to use engine config parameters and make this check optional through them ...

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-17030
<!-- Hibernate GitHub Bot issue links end -->