### PR TITLE
HHH-18139 throw an exception when assigned id is null in StatelessSession.insert()

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/internal/StatelessSessionImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/StatelessSessionImpl.java
@@ -54,6 +54,7 @@ import org.hibernate.generator.Generator;
 import org.hibernate.generator.values.GeneratedValues;
 import org.hibernate.graph.GraphSemantic;
 import org.hibernate.graph.spi.RootGraphImplementor;
+import org.hibernate.id.IdentifierGenerationException;
 import org.hibernate.loader.ast.spi.CascadingFetchProfile;
 import org.hibernate.metamodel.mapping.PluralAttributeMapping;
 import org.hibernate.persister.collection.CollectionPersister;
@@ -137,6 +138,10 @@ public class StatelessSessionImpl extends AbstractSharedSessionContract implemen
 			}
 			else {
 				id = persister.getIdentifier( entity, this );
+				if ( id == null ) {
+					throw new IdentifierGenerationException( "Identifier of entity '" + persister.getEntityName()
+							+ "' must be manually assigned before calling 'insert()'" );
+				}
 			}
 			if ( firePreInsert(entity, id, state, persister) ) {
 				return id;


### PR DESCRIPTION
<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-18139
<!-- Hibernate GitHub Bot issue links end -->