### PR TITLE
HHH-18221 Fix for Incomplete list of existing foreign keys

### DIFF
--- a/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/InformixDialect.java
+++ b/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/InformixDialect.java
@@ -574,6 +574,26 @@ public class InformixDialect extends Dialect {
 	}
 
 	@Override
+	public String[] getCreateSchemaCommand(String schemaName) {
+		return new String[] { "create schema authorization " + schemaName };
+	}
+
+	@Override
+	public String[] getDropSchemaCommand(String schemaName) {
+		return new String[] { "" };
+	}
+
+	@Override
+	public boolean useCrossReferenceForeignKeys(){
+		return true;
+	}
+
+	@Override
+	public String getCrossReferenceParentTableFilter(){
+		return "%";
+	}
+
+	@Override
 	public UniqueDelegate getUniqueDelegate() {
 		return uniqueDelegate;
 	}

--- a/hibernate-core/src/main/java/org/hibernate/dialect/Dialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/Dialect.java
@@ -2613,6 +2613,23 @@ public abstract class Dialect implements ConversionContext, TypeContributor, Fun
 	}
 
 	/**
+	 * Does the dialect also need cross-references to get a complete
+	 * list of foreign keys?
+	 */
+	public boolean useCrossReferenceForeignKeys(){
+		return false;
+	}
+
+	/**
+	 * Some dialects require a not null primaryTable filter.
+	 * Sometimes a wildcard entry is sufficient for the like condition.
+	 * @return
+	 */
+	public String getCrossReferenceParentTableFilter(){
+		return null;
+	}
+
+	/**
 	 * The syntax used to add a primary key constraint to a table.
 	 *
 	 * @param constraintName The name of the PK constraint.

--- a/hibernate-core/src/main/java/org/hibernate/tool/schema/extract/internal/InformationExtractorJdbcDatabaseMetaDataImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/tool/schema/extract/internal/InformationExtractorJdbcDatabaseMetaDataImpl.java
@@ -134,6 +134,26 @@ public class InformationExtractorJdbcDatabaseMetaDataImpl extends AbstractInform
 		}
 	}
 
+	@Override
+	protected <T> T processCrossReferenceResultSet(
+			String parentCatalog,
+			String parentSchema,
+			String parentTable,
+			String foreignCatalog,
+			String foreignSchema,
+			String foreignTable,
+			ExtractionContext.ResultSetProcessor<T> processor) throws SQLException {
+		try (ResultSet resultSet = getExtractionContext().getJdbcDatabaseMetaData().getCrossReference(
+				parentCatalog,
+				parentSchema,
+				parentTable,
+				foreignCatalog,
+				foreignSchema,
+				foreignTable) ) {
+			return processor.process( resultSet );
+		}
+	}
+
 	protected void addColumns(TableInformation tableInformation) {
 		final Dialect dialect = getExtractionContext().getJdbcEnvironment().getDialect();
 


### PR DESCRIPTION
... DatabaseMetaData.crossReferences(...) not used

Most dialects retrieve all foreign keys when calling getImportedKeys(), hence the useCrossReferenceForeignKeys() method returns false in the Dialect. The ParentTable parameter of the getCrossReference() method must be non-null for Informix, resulting in the getCrossReferenceParentTableFilter() method returning a wildcard expression for the like condition (Select statement identified during debugging in the Informix driver). Upon verification, many dialects also accept a null value, in which case this condition is ignored.

There is no explicit command in Informix equivalent to "drop schema schema_name". After deleting objects, it is not necessary to explicitly drop the schema.

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-18221
<!-- Hibernate GitHub Bot issue links end -->