### PR TITLE
HHH-17735 Community dialects for MySQL 5.7 give invalid SQL syntax for locks since 6.4.4

### DIFF
--- a/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/DB2390Dialect.java
+++ b/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/DB2390Dialect.java
@@ -6,7 +6,6 @@
  */
 package org.hibernate.community.dialect;
 
-import org.hibernate.dialect.DB2zDialect;
 import org.hibernate.dialect.identity.DB2zIdentityColumnSupport;
 import org.hibernate.dialect.identity.IdentityColumnSupport;
 import org.hibernate.dialect.pagination.FetchLimitHandler;
@@ -22,7 +21,7 @@ import org.hibernate.engine.jdbc.dialect.spi.DialectResolutionInfo;
  * DB2 Universal Database for OS/390, also known as DB2/390.
  *
  * @author Kristoffer Dyrkorn
- * @deprecated Use {@link DB2zDialect}
+ * @deprecated Use {@link DB2LegacyDialect}
  */
 @Deprecated
 public class DB2390Dialect extends DB2LegacyDialect {

--- a/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/DB2390V8Dialect.java
+++ b/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/DB2390V8Dialect.java
@@ -12,7 +12,7 @@ package org.hibernate.community.dialect;
  *
  * @author Tobias Sternvik
  *
- * @deprecated use {@code DB2390Dialect(8)}
+ * @deprecated use {@code DB2LegacyDialect(8)}
  */
 @Deprecated
 public class DB2390V8Dialect extends DB2390Dialect {

--- a/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/DB297Dialect.java
+++ b/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/DB297Dialect.java
@@ -12,7 +12,7 @@ import org.hibernate.dialect.DatabaseVersion;
  * An SQL dialect for DB2 9.7.
  *
  * @author Gail Badner
- * @deprecated use {@code DB2Dialect(970)}
+ * @deprecated use {@code DB2LegacyDialect(970)}
  */
 @Deprecated
 public class DB297Dialect extends DB2LegacyDialect {

--- a/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/DerbyTenFiveDialect.java
+++ b/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/DerbyTenFiveDialect.java
@@ -14,7 +14,7 @@ import org.hibernate.dialect.DatabaseVersion;
  * @author Simon Johnston
  * @author Scott Marlow
  *
- * @deprecated use {@code DerbyDialect(1050)}
+ * @deprecated use {@code DerbyLegacyDialect(1050)}
  */
 @Deprecated
 public class DerbyTenFiveDialect extends DerbyLegacyDialect {

--- a/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/DerbyTenSevenDialect.java
+++ b/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/DerbyTenSevenDialect.java
@@ -13,7 +13,7 @@ import org.hibernate.dialect.DatabaseVersion;
  *
  * @author Strong Liu
  *
- * @deprecated use {@code DerbyDialect(1070)}
+ * @deprecated use {@code DerbyLegacyDialect(1070)}
  */
 @Deprecated
 public class DerbyTenSevenDialect extends DerbyLegacyDialect {

--- a/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/DerbyTenSixDialect.java
+++ b/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/DerbyTenSixDialect.java
@@ -14,7 +14,7 @@ import org.hibernate.dialect.DatabaseVersion;
  * @author Simon Johnston
  * @author Scott Marlow
  *
- * @deprecated use {@code DerbyDialect(1060)}
+ * @deprecated use {@code DerbyLegacyDialect(1060)}
  */
 @Deprecated
 public class DerbyTenSixDialect extends DerbyLegacyDialect {

--- a/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/MariaDB102Dialect.java
+++ b/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/MariaDB102Dialect.java
@@ -9,7 +9,7 @@ package org.hibernate.community.dialect;
 import org.hibernate.dialect.DatabaseVersion;
 
 /**
- * @deprecated use {@code MariaDBDialect(1020)}
+ * @deprecated use {@code MariaDBLegacyDialect(1020)}
  */
 @Deprecated
 public class MariaDB102Dialect extends MariaDBLegacyDialect {

--- a/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/MariaDB103Dialect.java
+++ b/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/MariaDB103Dialect.java
@@ -8,17 +8,16 @@ package org.hibernate.community.dialect;
 
 import org.hibernate.LockOptions;
 import org.hibernate.dialect.DatabaseVersion;
-import org.hibernate.dialect.MariaDBDialect;
 
 /**
  * An SQL dialect for MariaDB 10.3 and later, provides sequence support, lock-timeouts, etc.
  *
  * @author Philippe Marschall
  *
- * @deprecated use {@code MariaDBDialect(1030)}
+ * @deprecated use {@code MariaDBLegacyDialect(1030)}
  */
 @Deprecated
-public class MariaDB103Dialect extends MariaDBDialect {
+public class MariaDB103Dialect extends MariaDBLegacyDialect {
 
 	public MariaDB103Dialect() {
 		super( DatabaseVersion.make( 10, 3 ) );

--- a/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/MariaDB10Dialect.java
+++ b/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/MariaDB10Dialect.java
@@ -9,7 +9,7 @@ package org.hibernate.community.dialect;
 import org.hibernate.dialect.DatabaseVersion;
 
 /**
- * @deprecated use {@code MariaDBDialect(1000)}
+ * @deprecated use {@code MariaDBLegacyDialect(1000)}
  */
 @Deprecated
 public class MariaDB10Dialect extends MariaDBLegacyDialect {

--- a/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/MariaDB53Dialect.java
+++ b/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/MariaDB53Dialect.java
@@ -11,7 +11,7 @@ import org.hibernate.dialect.DatabaseVersion;
 /**
  * @author Vlad Mihalcea
  *
- * @deprecated use {@code MariaDBDialect(530)}
+ * @deprecated use {@code MariaDBLegacyDialect(530)}
  */
 @Deprecated
 public class MariaDB53Dialect extends MariaDBLegacyDialect {

--- a/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/MySQL55Dialect.java
+++ b/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/MySQL55Dialect.java
@@ -13,7 +13,7 @@ import org.hibernate.dialect.DatabaseVersion;
  *
  * @author Vlad Mihalcea
  *
- * @deprecated use {@code MySQLDialect(550)}
+ * @deprecated use {@code MySQLLegacyDialect(550)}
  */
 @Deprecated
 public class MySQL55Dialect extends MySQLLegacyDialect {

--- a/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/MySQL57Dialect.java
+++ b/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/MySQL57Dialect.java
@@ -7,15 +7,14 @@
 package org.hibernate.community.dialect;
 
 import org.hibernate.dialect.DatabaseVersion;
-import org.hibernate.dialect.MySQLDialect;
 
 /**
  * @author Gail Badner
  *
- * @deprecated use {@code MySQLDialect(570)}
+ * @deprecated use {@code MySQLLegacyDialect(570)}
  */
 @Deprecated
-public class MySQL57Dialect extends MySQLDialect {
+public class MySQL57Dialect extends MySQLLegacyDialect {
 
 	public MySQL57Dialect() {
 		super( DatabaseVersion.make( 5, 7 ) );

--- a/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/MySQL5Dialect.java
+++ b/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/MySQL5Dialect.java
@@ -13,7 +13,7 @@ import org.hibernate.dialect.DatabaseVersion;
  *
  * @author Steve Ebersole
  *
- * @deprecated use {@code MySQLDialect(500)}
+ * @deprecated use {@code MySQLLegacyDialect(500)}
  */
 @Deprecated
 public class MySQL5Dialect extends MySQLLegacyDialect {

--- a/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/Oracle10gDialect.java
+++ b/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/Oracle10gDialect.java
@@ -17,7 +17,7 @@ import org.hibernate.dialect.DatabaseVersion;
  *
  * @author Steve Ebersole
  *
- * @deprecated use {@code OracleDialect(10)}
+ * @deprecated use {@code OracleLegacyDialect(10)}
  */
 @Deprecated
 public class Oracle10gDialect extends OracleLegacyDialect {

--- a/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/Oracle12cDialect.java
+++ b/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/Oracle12cDialect.java
@@ -14,7 +14,7 @@ import org.hibernate.dialect.OracleDialect;
  *
  * @author zhouyanming (zhouyanming@gmail.com)
  *
- * @deprecated use {@code OracleDialect(12)}
+ * @deprecated use {@code OracleLegacyDialect(12)}
  */
 @Deprecated
 public class Oracle12cDialect extends OracleDialect {

--- a/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/Oracle8iDialect.java
+++ b/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/Oracle8iDialect.java
@@ -11,7 +11,7 @@ import org.hibernate.dialect.DatabaseVersion;
 /**
  * A dialect for Oracle 8i databases.
  *
- * @deprecated use {@code OracleDialect(8)}
+ * @deprecated use {@code OracleLegacyDialect(8)}
  */
 @Deprecated
 public class Oracle8iDialect extends OracleLegacyDialect {

--- a/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/Oracle9iDialect.java
+++ b/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/Oracle9iDialect.java
@@ -16,7 +16,7 @@ import org.hibernate.dialect.DatabaseVersion;
  *
  * @author Steve Ebersole
  *
- * @deprecated use {@code OracleDialect(9)}
+ * @deprecated use {@code OracleLegacyDialect(9)}
  */
 @Deprecated
 public class Oracle9iDialect extends OracleLegacyDialect {

--- a/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/PostgreSQL10Dialect.java
+++ b/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/PostgreSQL10Dialect.java
@@ -12,7 +12,7 @@ import org.hibernate.dialect.PostgreSQLDialect;
 /**
  * An SQL dialect for Postgres 10 and later.
  *
- *  @deprecated use {@code PostgreSQLDialect(1000)}
+ *  @deprecated use {@code PostgreSQLLegacyDialect(1000)}
  */
 @Deprecated
 public class PostgreSQL10Dialect extends PostgreSQLDialect {

--- a/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/PostgreSQL81Dialect.java
+++ b/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/PostgreSQL81Dialect.java
@@ -9,7 +9,7 @@ package org.hibernate.community.dialect;
 import org.hibernate.dialect.DatabaseVersion;
 
 /**
- * @deprecated use {@code PostgreSQLDialect(810)}
+ * @deprecated use {@code PostgreSQLLegacyDialect(810)}
  */
 @Deprecated
 public class PostgreSQL81Dialect extends PostgreSQLLegacyDialect {

--- a/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/PostgreSQL82Dialect.java
+++ b/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/PostgreSQL82Dialect.java
@@ -13,7 +13,7 @@ import org.hibernate.dialect.DatabaseVersion;
  * 
  * @author edalquist
  *
- * @deprecated use {@code PostgreSQLDialect(820)}
+ * @deprecated use {@code PostgreSQLLegacyDialect(820)}
  */
 @Deprecated
 public class PostgreSQL82Dialect extends PostgreSQLLegacyDialect {

--- a/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/PostgreSQL91Dialect.java
+++ b/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/PostgreSQL91Dialect.java
@@ -14,7 +14,7 @@ import org.hibernate.dialect.DatabaseVersion;
  * 
  * @author Mark Robinson
  *
- * @deprecated use {@code PostgreSQLDialect(910)}
+ * @deprecated use {@code PostgreSQLLegacyDialect(910)}
  */
 @Deprecated
 public class PostgreSQL91Dialect extends PostgreSQLLegacyDialect {

--- a/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/PostgreSQL92Dialect.java
+++ b/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/PostgreSQL92Dialect.java
@@ -15,7 +15,7 @@ import org.hibernate.dialect.DatabaseVersion;
  * 
  * @author Mark Robinson
  *
- * @deprecated use {@code PostgreSQLDialect(920)}
+ * @deprecated use {@code PostgreSQLLegacyDialect(920)}
  */
 @Deprecated
 public class PostgreSQL92Dialect extends PostgreSQLLegacyDialect {

--- a/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/PostgreSQL93Dialect.java
+++ b/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/PostgreSQL93Dialect.java
@@ -14,7 +14,7 @@ import org.hibernate.dialect.DatabaseVersion;
  *
  * @author Dionis Argiri
  *
- * @deprecated use {@code PostgreSQLDialect(810)}
+ * @deprecated use {@code PostgreSQLLegacyDialect(810)}
  */
 @Deprecated
 public class PostgreSQL93Dialect extends PostgreSQLLegacyDialect {

--- a/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/PostgreSQL94Dialect.java
+++ b/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/PostgreSQL94Dialect.java
@@ -12,7 +12,7 @@ import org.hibernate.dialect.DatabaseVersion;
  * An SQL dialect for Postgres 9.4 and later.
  * Adds support for various date and time functions
  *
- * @deprecated use {@code PostgreSQLDialect(940)}
+ * @deprecated use {@code PostgreSQLLegacyDialect(940)}
  */
 @Deprecated
 public class PostgreSQL94Dialect extends PostgreSQLLegacyDialect {

--- a/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/PostgreSQL95Dialect.java
+++ b/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/PostgreSQL95Dialect.java
@@ -12,7 +12,7 @@ import org.hibernate.dialect.DatabaseVersion;
  * An SQL dialect for Postgres 9.5 and later.
  * Adds support for SKIP LOCKED.
  *
- * @deprecated use {@code PostgreSQLDialect(950)}
+ * @deprecated use {@code PostgreSQLLegacyDialect(950)}
  */
 @Deprecated
 public class PostgreSQL95Dialect extends PostgreSQLLegacyDialect {

--- a/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/PostgreSQL9Dialect.java
+++ b/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/PostgreSQL9Dialect.java
@@ -14,7 +14,7 @@ import org.hibernate.dialect.DatabaseVersion;
  * 
  * @author edalquist
  *
- * @deprecated use {@code PostgreSQLDialect(900)}
+ * @deprecated use {@code PostgreSQLLegacyDialect(900)}
  */
 @Deprecated
 public class PostgreSQL9Dialect extends PostgreSQLLegacyDialect {

--- a/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/SQLServer2005Dialect.java
+++ b/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/SQLServer2005Dialect.java
@@ -14,7 +14,7 @@ import org.hibernate.dialect.DatabaseVersion;
  * @author Yoryos Valotasios
  * @author Lukasz Antoniak
  *
- * @deprecated use {@code SQLServerDialect(9)}
+ * @deprecated use {@code SQLServerLegacyDialect(9)}
  */
 @Deprecated
 public class SQLServer2005Dialect extends SQLServerLegacyDialect {

--- a/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/SQLServer2008Dialect.java
+++ b/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/SQLServer2008Dialect.java
@@ -14,7 +14,7 @@ import org.hibernate.dialect.SQLServerDialect;
  *
  * @author Gavin King
  *
- * @deprecated use {@code SQLServerDialect(10)}
+ * @deprecated use {@code SQLServerLegacyDialect(10)}
  */
 @Deprecated
 public class SQLServer2008Dialect extends SQLServerDialect {


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-17735