### PR TITLE
Backport HHH-18241 to branch 6.5 - roll back change to semantics of 'null in ()'

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/persister/entity/AbstractEntityPersister.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/entity/AbstractEntityPersister.java
@@ -3199,7 +3199,7 @@ public abstract class AbstractEntityPersister
 			Map<String, EntityNameUse> entityNameUses,
 			MappingMetamodelImplementor mappingMetamodel,
 			String alias) {
-		final InFragment frag = new InFragment( false );
+		final InFragment frag = new InFragment();
 		if ( isDiscriminatorFormula() ) {
 			frag.setFormula( alias, getDiscriminatorFormulaTemplate() );
 		}

--- a/hibernate-core/src/main/java/org/hibernate/sql/InFragment.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/InFragment.java
@@ -21,15 +21,10 @@ import org.hibernate.internal.util.StringHelper;
 @Internal
 public class InFragment {
 
-	public InFragment(boolean columnCanBeNull) {
-		this.columnCanBeNull = columnCanBeNull;
-	}
-
 	public static final String NULL = "null";
 	public static final String NOT_NULL = "not null";
 
 	protected String columnName;
-	protected boolean columnCanBeNull;
 	protected List<Object> values = new ArrayList<>();
 
 	/**
@@ -71,15 +66,7 @@ public class InFragment {
 
 		switch ( values.size() ) {
 			case 0: {
-				if ( columnCanBeNull ) {
-					return buf.append( "(1 = case when " )
-							.append( columnName )
-							.append(" is not null then 0 end)")
-							.toString();
-				}
-				else {
-					return "0=1";
-				}
+				return "0=1";
 			}
 			case 1: {
 				Object value = values.get( 0 );

--- a/hibernate-core/src/main/java/org/hibernate/sql/ast/spi/AbstractSqlAstTranslator.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/ast/spi/AbstractSqlAstTranslator.java
@@ -7606,7 +7606,7 @@ public abstract class AbstractSqlAstTranslator<T extends JdbcOperation> implemen
 	public void visitInListPredicate(InListPredicate inListPredicate) {
 		final List<Expression> listExpressions = inListPredicate.getListExpressions();
 		if ( listExpressions.isEmpty() ) {
-			emptyInList( inListPredicate );
+			appendSql( "1=" + ( inListPredicate.isNegated() ? "1" : "0" ) );
 			return;
 		}
 		Function<Expression, Expression> itemAccessor = Function.identity();
@@ -7711,16 +7711,6 @@ public abstract class AbstractSqlAstTranslator<T extends JdbcOperation> implemen
 		if ( parenthesis ) {
 			appendSql( CLOSE_PARENTHESIS );
 		}
-	}
-
-	protected void emptyInList(InListPredicate inListPredicate) {
-		appendSql("(");
-		appendSql( inListPredicate.isNegated() ? "0" : "1" );
-		appendSql(" = case when ");
-		inListPredicate.getTestExpression().accept( this );
-		appendSql( " is not null then 0");
-//		dialect.appendBooleanValueString( this, inListPredicate.isNegated() );
-		appendSql(" end)");
 	}
 
 	private void appendInClauseSeparator(InListPredicate inListPredicate) {

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/criteria/basic/PredicateTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/criteria/basic/PredicateTest.java
@@ -31,6 +31,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -334,7 +335,7 @@ public class PredicateTest extends AbstractMetamodelSpecificTest {
 		CriteriaQuery<Order> orderCriteria = builder.createQuery( Order.class );
 		Root<Order> orderRoot = orderCriteria.from( Order.class );
 		orderCriteria.select( orderRoot );
-		orderCriteria.where( builder.in( orderRoot.get("creditCard") ) );
+		orderCriteria.where( builder.in( orderRoot.get("id") ) );
 
 		List<Order> orders = em.createQuery( orderCriteria ).getResultList();
 		assertTrue( orders.isEmpty() );
@@ -350,10 +351,10 @@ public class PredicateTest extends AbstractMetamodelSpecificTest {
 		CriteriaQuery<Order> orderCriteria = builder.createQuery( Order.class );
 		Root<Order> orderRoot = orderCriteria.from( Order.class );
 		orderCriteria.select( orderRoot );
-		orderCriteria.where( builder.in( orderRoot.get("creditCard") ).not() );
+		orderCriteria.where( builder.in( orderRoot.get("id") ).not() );
 
 		List<Order> orders = em.createQuery( orderCriteria ).getResultList();
-		assertTrue( orders.isEmpty() );
+		assertFalse( orders.isEmpty() );
 		em.getTransaction().commit();
 		em.close();
 	}


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-18241

Backport of #8528 to branch 6.5.

Backporting is necessary due to huge performance degradation apparently caused by the changes we’re reverting: https://hibernate.atlassian.net/browse/HHH-18235

Was https://hibernate.atlassian.net/browse/HHH-17804