### PR TITLE
HHH-18250 Informix multi insert not supported

### DIFF
--- a/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/InformixDialect.java
+++ b/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/InformixDialect.java
@@ -480,6 +480,11 @@ public class InformixDialect extends Dialect {
 	}
 
 	@Override
+	public boolean supportsValuesListForInsert() {
+		return false;
+	}
+
+	@Override
 	public ViolatedConstraintNameExtractor getViolatedConstraintNameExtractor() {
 		return EXTRACTOR;
 	}

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/internal/QuerySqmImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/internal/QuerySqmImpl.java
@@ -788,7 +788,7 @@ public class QuerySqmImpl<R>
 			final NonSelectQueryPlan[] planParts = new NonSelectQueryPlan[valuesList.size()];
 			for ( int i = 0; i < valuesList.size(); i++ ) {
 				final SqmInsertValuesStatement<?> subInsert = insertValues.copyWithoutValues( SqmCopyContext.simpleContext() );
-				subInsert.values( valuesList );
+				subInsert.values( valuesList.get( i ) );
 				planParts[i] = new SimpleInsertQueryPlan( subInsert, domainParameterXref );
 			}
 


### PR DESCRIPTION
After the change in InformixDialect, where the `supportsValuesListForInsert()` method returns `false`, another error occurred:

```
org.hibernate.query.IllegalQueryOperationException: Dialect does not support values lists for insert statements
	at app//org.hibernate.sql.ast.spi.AbstractSqlAstTranslator.visitValuesListStandard(AbstractSqlAstTranslator.java:1671)
	at app//org.hibernate.sql.ast.spi.AbstractSqlAstTranslator.visitValuesList(AbstractSqlAstTranslator.java:1666)
	at app//org.hibernate.sql.ast.spi.AbstractSqlAstTranslator.visitInsertSource(AbstractSqlAstTranslator.java:1333)
	at app//org.hibernate.sql.ast.spi.AbstractSqlAstTranslator.visitInsertStatementOnly(AbstractSqlAstTranslator.java:1313)
	at app//org.hibernate.sql.ast.spi.AbstractSqlAstTranslator.visitInsertStatement(AbstractSqlAstTranslator.java:1056)
	at app//org.hibernate.sql.ast.spi.AbstractSqlAstTranslator.translateInsert(AbstractSqlAstTranslator.java:846)
	at app//org.hibernate.sql.ast.spi.AbstractSqlAstTranslator.translate(AbstractSqlAstTranslator.java:806)
	at app//org.hibernate.query.sqm.internal.SimpleInsertQueryPlan.executeUpdate(SimpleInsertQueryPlan.java:116)
	at app//org.hibernate.query.sqm.internal.AggregatedNonSelectQueryPlanImpl.executeUpdate(AggregatedNonSelectQueryPlanImpl.java:26)
	at app//org.hibernate.query.sqm.internal.QuerySqmImpl.doExecuteUpdate(QuerySqmImpl.java:667)
	at app//org.hibernate.query.sqm.internal.QuerySqmImpl.executeUpdate(QuerySqmImpl.java:639)
	at app//org.hibernate.orm.test.hql.HQLTest.lambda$hql_multi_insert_example$13(HQLTest.java:262)
```

I believe there is a regression in commit https://github.com/hibernate/hibernate-orm/commit/bb4ed4b000081705aac8edfb68cb50ba79cf55dd 
in the class `hibernate-core/src/main/java/org/hibernate/query/sqm/internal/QuerySqmImpl.java`
`subInsert.getValuesList().add( valuesList.get( i ) );` -> `subInsert.values( valuesList );`
, which was not detected because `supportsValuesListForInsert()` returned `false` so far only in `org.hibernate.community.dialect.FirebirdDialect`, which is not tested during build.

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-18250
<!-- Hibernate GitHub Bot issue links end -->