### PR TITLE
Change `NativeQueryImpl#createCountQueryPlan` scope to protected

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/query/sql/internal/NativeQueryImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sql/internal/NativeQueryImpl.java
@@ -688,7 +688,10 @@ public class NativeQueryImpl<R>
 				.createQueryPlan( queryDefinition, getSessionFactory() );
 	}
 
-	private NativeSelectQueryPlan<Long> createCountQueryPlan() {
+	/*
+	 * Used by Hibernate Reactive
+	 */
+	protected NativeSelectQueryPlan<Long> createCountQueryPlan() {
 		final BasicType<Long> longType = getSessionFactory().getTypeConfiguration().getBasicTypeForJavaType(Long.class);
 		final String sqlString = expandParameterLists();
 		final NativeSelectQueryDefinition<Long> queryDefinition = new NativeSelectQueryDefinition<>() {


### PR DESCRIPTION
Fix https://hibernate.atlassian.net/browse/HHH-18254

So that I can re-use the code when implementing ReactiveSelectQueryPlan#getReactiveResultsCount in Hibernate Reactive

The PR is for 6.5 but it should be applied on all the other branches (I think).
I expect it's possible to cherry pick the same commit, but let me know if I have to send new PRs for each