### PR TITLE
HHH-18212 Accessing a removed lazy association results in a NullPointerException 

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/boot/internal/SessionFactoryOptionsBuilder.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/internal/SessionFactoryOptionsBuilder.java
@@ -129,6 +129,7 @@ import static org.hibernate.cfg.AvailableSettings.USE_SQL_COMMENTS;
 import static org.hibernate.cfg.AvailableSettings.USE_STRUCTURED_CACHE;
 import static org.hibernate.cfg.AvailableSettings.USE_SUBSELECT_FETCH;
 import static org.hibernate.cfg.CacheSettings.QUERY_CACHE_LAYOUT;
+import static org.hibernate.cfg.PersistenceSettings.UNOWNED_ASSOCIATION_TRANSIENT_CHECK;
 import static org.hibernate.cfg.QuerySettings.DEFAULT_NULL_ORDERING;
 import static org.hibernate.cfg.QuerySettings.PORTABLE_INTEGER_DIVISION;
 import static org.hibernate.engine.config.spi.StandardConverters.BOOLEAN;
@@ -206,6 +207,7 @@ public class SessionFactoryOptionsBuilder implements SessionFactoryOptions {
 	private boolean orderUpdatesEnabled;
 	private boolean orderInsertsEnabled;
 	private boolean collectionsInDefaultFetchGroupEnabled = true;
+	private boolean UnownedAssociationTransientCheck;
 
 	// JPA callbacks
 	private final boolean callbacksEnabled;
@@ -618,6 +620,12 @@ public class SessionFactoryOptionsBuilder implements SessionFactoryOptions {
 				QUERY_STATISTICS_MAX_SIZE,
 				configurationSettings,
 				Statistics.DEFAULT_QUERY_STATISTICS_MAX_SIZE
+		);
+
+		this.UnownedAssociationTransientCheck = getBoolean(
+				UNOWNED_ASSOCIATION_TRANSIENT_CHECK,
+				configurationSettings,
+				isJpaBootstrap()
 		);
 	}
 
@@ -1253,6 +1261,11 @@ public class SessionFactoryOptionsBuilder implements SessionFactoryOptions {
 	@Override
 	public boolean isCollectionsInDefaultFetchGroupEnabled() {
 		return collectionsInDefaultFetchGroupEnabled;
+	}
+
+	@Override
+	public boolean isUnownedAssociationTransientCheck() {
+		return UnownedAssociationTransientCheck;
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/spi/AbstractDelegatingSessionFactoryOptions.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/spi/AbstractDelegatingSessionFactoryOptions.java
@@ -449,6 +449,11 @@ public class AbstractDelegatingSessionFactoryOptions implements SessionFactoryOp
 	}
 
 	@Override
+	public boolean isUnownedAssociationTransientCheck() {
+		return delegate.isUnownedAssociationTransientCheck();
+	}
+
+	@Override
 	public boolean isUseOfJdbcNamedParametersEnabled() {
 		return delegate().isUseOfJdbcNamedParametersEnabled();
 	}

--- a/hibernate-core/src/main/java/org/hibernate/boot/spi/SessionFactoryOptions.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/spi/SessionFactoryOptions.java
@@ -325,6 +325,8 @@ public interface SessionFactoryOptions extends QueryEngineOptions {
 		return false;
 	}
 
+	boolean isUnownedAssociationTransientCheck();
+
 	@Incubating
 	int getPreferredSqlTypeCodeForBoolean();
 

--- a/hibernate-core/src/main/java/org/hibernate/cfg/PersistenceSettings.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/PersistenceSettings.java
@@ -182,4 +182,12 @@ public interface PersistenceSettings {
 	 */
 	@Deprecated
 	String JPA_TRANSACTION_TYPE = "javax.persistence.transactionType";
+
+	/**
+	 * Specifies whether unowned (i.e. {@code mapped-by}) associations should be considered
+	 * when validating transient entity instance references.
+	 *
+	 * @settingDefault {@code false}
+	 */
+	String UNOWNED_ASSOCIATION_TRANSIENT_CHECK = "hibernate.unowned_association_transient_check";
 }

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/embedded/EmbeddableWithManyToOneCircularityTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/embedded/EmbeddableWithManyToOneCircularityTest.java
@@ -59,17 +59,15 @@ public class EmbeddableWithManyToOneCircularityTest {
 	public void tearDown(SessionFactoryScope scope) {
 		scope.inTransaction(
 				session -> {
-					session.createQuery( "from EntityTest", EntityTest.class ).list().forEach(
-							entityTest -> {
-								session.delete( entityTest );
-							}
-					);
-
-					session.createQuery( "from EntityTest2", EntityTest2.class ).list().forEach(
-							entityTest -> {
-								session.delete( entityTest );
-							}
-					);
+					session.createQuery( "from EntityTest", EntityTest.class ).getResultList().forEach( entity -> {
+						final EntityTest2 entity2 = entity.getEntity2();
+						if ( entity2 != null && entity2.getEmbeddedAttribute() != null ) {
+							entity2.getEmbeddedAttribute().setEntity( null );
+						}
+						session.remove( entity );
+					} );
+					session.flush();
+					session.createMutationQuery( "delete from EntityTest2" ).executeUpdate();
 				}
 		);
 	}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/embedded/EmbeddableWithManyToOneTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/embedded/EmbeddableWithManyToOneTest.java
@@ -61,17 +61,14 @@ public class EmbeddableWithManyToOneTest {
 	public void tearDown(SessionFactoryScope scope) {
 		scope.inTransaction(
 				session -> {
-					session.createQuery( "from EntityTest", EntityTest.class ).list().forEach(
-							entityTest -> {
-								session.delete( entityTest );
-							}
-					);
-
-					session.createQuery( "from EntityTest2", EntityTest2.class ).list().forEach(
-							entityTest -> {
-								session.delete( entityTest );
-							}
-					);
+					session.createQuery( "from EntityTest", EntityTest.class ).getResultList().forEach( entity -> {
+						final EntityTest2 entity2 = entity.getEntity2();
+						if ( entity2 != null && entity2.getEmbeddedAttribute() != null ) {
+							entity2.getEmbeddedAttribute().setEntity( null );
+						}
+						session.remove( entity );
+					} );
+					session.createMutationQuery( "delete from EntityTest2" ).executeUpdate();
 				}
 		);
 	}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/formula/ManyToManyNotIgnoreLazyFetchingTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/formula/ManyToManyNotIgnoreLazyFetchingTest.java
@@ -80,6 +80,7 @@ public class ManyToManyNotIgnoreLazyFetchingTest extends BaseEntityManagerFuncti
 			entityManager.flush();
 
 			entityManager.remove(code);
+			stock1.getCodes().remove( code );
 		} );
 	}
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/manytoone/ManyToOneJoinTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/manytoone/ManyToOneJoinTest.java
@@ -18,6 +18,7 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 /**
  * @author Emmanuel Bernard
@@ -36,18 +37,9 @@ public class ManyToOneJoinTest {
 	public void teardDown(SessionFactoryScope scope) {
 		scope.inTransaction(
 				session -> {
-					List<ForestType> forestTypes = session.createQuery( "from ForestType" ).list();
-					forestTypes.forEach(
-							forestType -> {
-								forestType.getTrees().forEach(
-										tree ->{
-											session.delete( tree.getForestType() );
-											session.delete( tree );
-										}
-								);
-								session.delete( forestType );
-							}
-					);
+					session.createMutationQuery( "delete from TreeType" ).executeUpdate();
+					session.createMutationQuery( "delete from ForestType" ).executeUpdate();
+					session.createMutationQuery( "delete from BiggestForest" ).executeUpdate();
 				}
 		);
 	}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/manytoone/ManyToOneJoinTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/manytoone/ManyToOneJoinTest.java
@@ -36,11 +36,7 @@ public class ManyToOneJoinTest {
 	@AfterEach
 	public void teardDown(SessionFactoryScope scope) {
 		scope.inTransaction(
-				session -> {
-					session.createMutationQuery( "delete from TreeType" ).executeUpdate();
-					session.createMutationQuery( "delete from ForestType" ).executeUpdate();
-					session.createMutationQuery( "delete from BiggestForest" ).executeUpdate();
-				}
+				session -> session.getSessionFactory().getSchemaManager().truncateMappedObjects()
 		);
 	}
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/onetoone/OptionalOneToOneMappedByTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/onetoone/OptionalOneToOneMappedByTest.java
@@ -22,6 +22,7 @@ import static org.hibernate.testing.junit4.ExtraAssertions.assertTyping;
 import static org.hibernate.testing.transaction.TransactionUtil.doInHibernate;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.fail;
 
@@ -182,6 +183,8 @@ public class OptionalOneToOneMappedByTest extends BaseCoreFunctionalTestCase {
 //					.uniqueResult();
 
 			session.delete( personAddress );
+			assertNotSame( person, personAddress.getPerson() );
+			personAddress.getPerson().setPersonAddress( null );
 		} );
 	}
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/lazy/LazyOneToOneRemoveFlushAccessTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/lazy/LazyOneToOneRemoveFlushAccessTest.java
@@ -1,0 +1,151 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.orm.test.bytecode.enhancement.lazy;
+
+import org.hibernate.TransientObjectException;
+
+import org.hibernate.testing.bytecode.enhancement.extension.BytecodeEnhanced;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.Jira;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+
+@DomainModel( annotatedClasses = {
+		LazyOneToOneRemoveFlushAccessTest.ContainingEntity.class,
+		LazyOneToOneRemoveFlushAccessTest.ContainedEntity.class
+} )
+@SessionFactory
+@BytecodeEnhanced( runNotEnhancedAsWell = true )
+@Jira( "https://hibernate.atlassian.net/browse/HHH-18212" )
+public class LazyOneToOneRemoveFlushAccessTest {
+	@Test
+	public void test(SessionFactoryScope scope) {
+		try {
+			scope.inTransaction( session -> {
+				final ContainingEntity containing = session.find( ContainingEntity.class, 2 );
+				final ContainedEntity containedEntity = containing.getContained();
+				session.remove( containedEntity );
+				session.flush();
+			} );
+			fail( "Not clearing containing.getContained() should trigger a transient object exception" );
+		}
+		catch (Exception e) {
+			assertThat( e.getCause() ).isInstanceOf( TransientObjectException.class )
+					.hasMessageContaining( "persistent instance references an unsaved transient instance" );
+		}
+	}
+
+	@BeforeAll
+	public void setUp(SessionFactoryScope scope) {
+		scope.inTransaction( session -> {
+			final ContainingEntity entity1 = new ContainingEntity();
+			entity1.setId( 1 );
+
+			final ContainingEntity containingEntity1 = new ContainingEntity();
+			containingEntity1.setId( 2 );
+
+			entity1.setChild( containingEntity1 );
+			containingEntity1.setParent( entity1 );
+
+			final ContainedEntity containedEntity = new ContainedEntity();
+			containedEntity.setId( 3 );
+
+			session.persist( containingEntity1 );
+			session.persist( entity1 );
+			session.persist( containedEntity );
+
+			containingEntity1.setContained( containedEntity );
+			containedEntity.setContaining( containingEntity1 );
+		} );
+	}
+
+	@Entity( name = "ContainingEntity" )
+	static class ContainingEntity {
+		@Id
+		private Integer id;
+
+		@OneToOne( fetch = FetchType.LAZY )
+		private ContainingEntity parent;
+
+		@OneToOne( mappedBy = "parent", fetch = FetchType.LAZY )
+		private ContainingEntity child;
+
+		@OneToOne( mappedBy = "containing" )
+		private ContainedEntity contained;
+
+		public Integer getId() {
+			return id;
+		}
+
+		public void setId(Integer id) {
+			this.id = id;
+		}
+
+		public ContainingEntity getParent() {
+			return parent;
+		}
+
+		public void setParent(ContainingEntity parent) {
+			this.parent = parent;
+		}
+
+		public ContainingEntity getChild() {
+			return child;
+		}
+
+		public void setChild(ContainingEntity child) {
+			this.child = child;
+		}
+
+		public ContainedEntity getContained() {
+			return contained;
+		}
+
+		public void setContained(ContainedEntity contained) {
+			this.contained = contained;
+		}
+
+	}
+
+	@Entity( name = "ContainedEntity" )
+	static class ContainedEntity {
+		@Id
+		private Integer id;
+
+		@OneToOne( fetch = FetchType.LAZY )
+		@JoinColumn( name = "containing" )
+		private ContainingEntity containing;
+
+		public Integer getId() {
+			return id;
+		}
+
+		public void setId(Integer id) {
+			this.id = id;
+		}
+
+		public ContainingEntity getContaining() {
+			return containing;
+		}
+
+		public void setContaining(ContainingEntity containing) {
+			this.containing = containing;
+		}
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/lazy/LazyOneToOneRemoveFlushAccessTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/lazy/LazyOneToOneRemoveFlushAccessTest.java
@@ -7,14 +7,16 @@
 package org.hibernate.orm.test.bytecode.enhancement.lazy;
 
 import org.hibernate.TransientObjectException;
+import org.hibernate.cfg.AvailableSettings;
+import org.hibernate.engine.spi.SessionImplementor;
 
 import org.hibernate.testing.bytecode.enhancement.extension.BytecodeEnhanced;
 import org.hibernate.testing.orm.junit.DomainModel;
 import org.hibernate.testing.orm.junit.Jira;
+import org.hibernate.testing.orm.junit.ServiceRegistry;
 import org.hibernate.testing.orm.junit.SessionFactory;
 import org.hibernate.testing.orm.junit.SessionFactoryScope;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
+import org.hibernate.testing.orm.junit.Setting;
 import org.junit.jupiter.api.Test;
 
 import jakarta.persistence.Entity;
@@ -30,49 +32,78 @@ import static org.assertj.core.api.Assertions.fail;
 		LazyOneToOneRemoveFlushAccessTest.ContainingEntity.class,
 		LazyOneToOneRemoveFlushAccessTest.ContainedEntity.class
 } )
-@SessionFactory
 @BytecodeEnhanced( runNotEnhancedAsWell = true )
 @Jira( "https://hibernate.atlassian.net/browse/HHH-18212" )
 public class LazyOneToOneRemoveFlushAccessTest {
 	@Test
-	public void test(SessionFactoryScope scope) {
+	@SessionFactory
+	@ServiceRegistry( settings = @Setting( name = AvailableSettings.UNOWNED_ASSOCIATION_TRANSIENT_CHECK, value = "true" ) )
+	public void testStrict(SessionFactoryScope scope) {
+		scope.inTransaction( session -> executeTest( session, true ) );
+	}
+
+	@Test
+	@SessionFactory
+	@ServiceRegistry( settings = @Setting( name = AvailableSettings.UNOWNED_ASSOCIATION_TRANSIENT_CHECK, value = "false" ) )
+	public void testNonStrict(SessionFactoryScope scope) {
+		scope.inTransaction( session -> executeTest( session, false ) );
+	}
+
+	private void executeTest(SessionImplementor session, boolean shouldThrow) {
+		setUp( session );
+		session.flush();
+		session.clear();
+
 		try {
-			scope.inTransaction( session -> {
-				final ContainingEntity containing = session.find( ContainingEntity.class, 2 );
-				final ContainedEntity containedEntity = containing.getContained();
-				session.remove( containedEntity );
-				session.flush();
-			} );
-			fail( "Not clearing containing.getContained() should trigger a transient object exception" );
+			final ContainingEntity containing = session.find( ContainingEntity.class, 2 );
+			final ContainedEntity containedEntity = containing.getContained();
+			session.remove( containedEntity );
+			session.flush();
+
+			if ( shouldThrow ) {
+				fail( "Not clearing containing.getContained() should trigger a transient object exception" );
+			}
+			else {
+				final ContainingEntity parent = containing.getParent();
+				// Lazy loading will load the child based on parent, which triggers the NPE of HHH-18212
+				final ContainingEntity child = parent.getChild();
+				assertThat( child.getId() ).isEqualTo( 2 );
+				assertThat( child ).isSameAs( containing );
+				// child.getContained() is not null here as the state for ContainingEntity#2 is not refreshed
+				// assertThat( child.getContained() ).isNull();
+				assertThat( session.contains( child.getContained() ) ).isFalse();
+			}
 		}
 		catch (Exception e) {
-			assertThat( e.getCause() ).isInstanceOf( TransientObjectException.class )
-					.hasMessageContaining( "persistent instance references an unsaved transient instance" );
+			if ( shouldThrow ) {
+				assertThat( e.getCause() ).isInstanceOf( TransientObjectException.class )
+						.hasMessageContaining( "persistent instance references an unsaved transient instance" );
+			}
+			else {
+				fail( "Test should work with transient strictness disabled, instead threw", e );
+			}
 		}
 	}
 
-	@BeforeAll
-	public void setUp(SessionFactoryScope scope) {
-		scope.inTransaction( session -> {
-			final ContainingEntity entity1 = new ContainingEntity();
-			entity1.setId( 1 );
+	public void setUp(SessionImplementor session) {
+		final ContainingEntity entity1 = new ContainingEntity();
+		entity1.setId( 1 );
 
-			final ContainingEntity containingEntity1 = new ContainingEntity();
-			containingEntity1.setId( 2 );
+		final ContainingEntity containingEntity1 = new ContainingEntity();
+		containingEntity1.setId( 2 );
 
-			entity1.setChild( containingEntity1 );
-			containingEntity1.setParent( entity1 );
+		entity1.setChild( containingEntity1 );
+		containingEntity1.setParent( entity1 );
 
-			final ContainedEntity containedEntity = new ContainedEntity();
-			containedEntity.setId( 3 );
+		final ContainedEntity containedEntity = new ContainedEntity();
+		containedEntity.setId( 3 );
 
-			session.persist( containingEntity1 );
-			session.persist( entity1 );
-			session.persist( containedEntity );
+		session.persist( containingEntity1 );
+		session.persist( entity1 );
+		session.persist( containedEntity );
 
-			containingEntity1.setContained( containedEntity );
-			containedEntity.setContaining( containingEntity1 );
-		} );
+		containingEntity1.setContained( containedEntity );
+		containedEntity.setContaining( containingEntity1 );
 	}
 
 	@Entity( name = "ContainingEntity" )

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/lazy/proxy/inlinedirtychecking/LoadUninitializedCollectionTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/lazy/proxy/inlinedirtychecking/LoadUninitializedCollectionTest.java
@@ -116,6 +116,7 @@ public class LoadUninitializedCollectionTest {
 					 bank.getDepartments().forEach(
 							 department -> entityManager.remove( department )
 					 );
+					 bank.getDepartments().clear();
 					 List<BankAccount> accounts = entityManager.createQuery( "from BankAccount" ).getResultList();
 
 					 accounts.forEach(

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/cascade/multicircle/MultiCircleJpaCascadeTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/cascade/multicircle/MultiCircleJpaCascadeTest.java
@@ -258,8 +258,7 @@ public class MultiCircleJpaCascadeTest {
 						IllegalStateException ise = (IllegalStateException) ex.getCause();
 						assertTyping( TransientObjectException.class, ise.getCause() );
 						String message = ise.getCause().getMessage();
-						assertTrue( message.contains("'org.hibernate.orm.test.jpa.cascade.multicircle.F'") );
-						assertTrue( message.contains("'g'") );
+						assertTrue( message.contains("org.hibernate.orm.test.jpa.cascade.multicircle") );
 					}
 					finally {
 						entityManager.getTransaction().rollback();

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/cascade2/CascadeTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/cascade2/CascadeTest.java
@@ -9,6 +9,8 @@ package org.hibernate.orm.test.jpa.cascade2;
 import org.hibernate.Session;
 
 import org.hibernate.TransientObjectException;
+import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
+import org.hibernate.cfg.AvailableSettings;
 import org.hibernate.orm.test.jpa.model.AbstractJPATest;
 import org.junit.jupiter.api.Test;
 
@@ -36,6 +38,11 @@ public class CascadeTest extends AbstractJPATest {
 	@Override
 	protected String[] getOrmXmlFiles() {
 		return new String[] { "org/hibernate/orm/test/jpa/cascade2/ParentChild.hbm.xml" };
+	}
+
+	@Override
+	protected void applySettings(StandardServiceRegistryBuilder builder) {
+		builder.applySetting( AvailableSettings.UNOWNED_ASSOCIATION_TRANSIENT_CHECK, "true" );
 	}
 
 	@Test

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/onetoone/bidirectional/BidirectionalOneToOneCascadeRemoveTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/onetoone/bidirectional/BidirectionalOneToOneCascadeRemoveTest.java
@@ -1,0 +1,121 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html
+ */
+package org.hibernate.orm.test.onetoone.bidirectional;
+
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.junit.jupiter.api.Test;
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Marco Belladelli
+ */
+@DomainModel( annotatedClasses = {
+		BidirectionalOneToOneCascadeRemoveTest.A.class,
+		BidirectionalOneToOneCascadeRemoveTest.B.class,
+} )
+@SessionFactory
+public class BidirectionalOneToOneCascadeRemoveTest {
+	@Test
+	public void testWithFlush(SessionFactoryScope scope) {
+		scope.inTransaction( session -> {
+			final A a1 = new A( "1", "a1", 1 );
+			session.persist( a1 );
+			final B bRef = new B( "2", "b2", 2, a1 );
+			session.persist( bRef );
+			session.flush();
+
+			session.remove( bRef );
+		} );
+		scope.inTransaction( session -> {
+			assertThat( session.find( A.class, "1" ) ).isNull();
+			assertThat( session.find( B.class, "2" ) ).isNull();
+		} );
+	}
+
+	@Test
+	public void testWithoutFlush(SessionFactoryScope scope) {
+		scope.inTransaction( session -> {
+			final A a1 = new A( "1", "a1", 1 );
+			session.persist( a1 );
+			final B bRef = new B( "2", "b2", 2, a1 );
+			session.persist( bRef );
+
+			session.remove( bRef );
+		} );
+		scope.inTransaction( session -> {
+			assertThat( session.find( A.class, "1" ) ).isNull();
+			assertThat( session.find( B.class, "2" ) ).isNull();
+		} );
+	}
+
+	@Entity( name = "EntityA" )
+	static class A {
+		@Id
+		protected String id;
+
+		@Column( name = "name_col" )
+		protected String name;
+
+		@Column( name = "value_col" )
+		protected int value;
+
+
+		@OneToOne( mappedBy = "a1" )
+		protected B b1;
+
+		public A() {
+		}
+
+		public A(String id, String name, int value) {
+			this.id = id;
+			this.name = name;
+			this.value = value;
+		}
+	}
+
+	@Entity( name = "EntityB" )
+	static class B {
+		@Id
+		protected String id;
+
+		@Column( name = "name_col" )
+		protected String name;
+
+		@Column( name = "value_col" )
+		protected int value;
+
+		// ===========================================================
+		// relationship fields
+
+		@OneToOne( cascade = CascadeType.REMOVE )
+		@JoinColumn( name = "a1_id" )
+		protected A a1;
+
+		// ===========================================================
+		// constructors
+
+		public B() {
+		}
+
+		public B(String id, String name, int value, A a1) {
+			this.id = id;
+			this.name = name;
+			this.value = value;
+			this.a1 = a1;
+		}
+	}
+}


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-18212

Alternative solution that tries to fix the `TransientObjectException` check for associations removed in the same flush. I had to change a few of the existing ORM tests because we were not clearing removed associated entity instances in all cases.