### PR TITLE
Release Jenkinsfile: enable manual releases

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,0 +1,146 @@
+Guide for maintainers of Hibernate ORM
+====
+
+This guide is intended for maintainers of Hibernate ORM,
+i.e. anybody with direct push access to the git repository.
+
+## Contributing
+
+See [CONTRIBUTING.md](CONTRIBUTING.md).
+
+## Continuous integration
+
+Continuous integration is split across two platforms:
+
+* GitHub Actions at https://github.com/hibernate/hibernate-orm/actions
+* a self-hosted Jenkins instance at https://ci.hibernate.org.
+
+### GitHub Actions workflows
+
+TODO: describe the workflows available.
+
+### Jenkins main pipeline
+
+https://ci.hibernate.org/job/hibernate-orm-pipeline/
+
+This job takes care of testing additional DBs for:
+
+* Primary branch builds
+* Pull request builds
+
+It is generally triggered on push,
+but can also be triggered manually,
+which is particularly useful to test more environments on a pull request.
+
+See [Jenkinsfile](Jenkinsfile) for the job definition.
+
+### Release pipeline
+
+https://ci.hibernate.org/job/hibernate-orm-release/
+
+This job takes care of releases. It is triggered manually.
+
+See [ci/release/Jenkinsfile](ci/release/Jenkinsfile) for the job definition.
+
+See [Releasing](#releasing) for more information.
+
+## <a id="releasing"></a> Releasing
+
+### Automated releases
+
+On select maintenance branches (`6.2`, `6.4`, ...),
+micro releases (`x.y.1`, `x.y.2`, ...) are performed as soon as you push to that branch.
+
+Make sure to assign fix versions properly before merging pull requests.
+
+No announcements are expected for such releases:
+neither through X, blog posts, or email.
+
+### Manual releases
+
+On `main` and some maintenance branches (`6.5`, ...),
+automated releases are disabled.
+
+You must perform releases by manually triggering a CI job.
+
+#### Preparing the release
+
+In any case, before the release:
+
+* Check that everything has been pushed to the upstream repository.
+* Check that the [CI jobs](#continuous-integration) for the branch you want to release are green.
+* Check Jira [Releases](https://hibernate.atlassian.net/projects/HHH?selectedItem=com.atlassian.jira.jira-projects-plugin%3Arelease-page):
+  * Check that the release you are about to publish exists in Jira.
+  * Check there are no outstanding issues assigned to that release.
+  * Check there are no resolved/closed issues in the corresponding "work-in-progress version"
+    (e.g. `6.6`, `6.6-next`, ... naming convention may vary);
+    if there are, you might want to assign them to your release.
+
+**If it is a new major or minor release**, before the release:
+
+* Reset the migration guide to include only information relevant to the new major or minor.
+
+**If it's a `.CR` or `.Final` release**, before the release:
+
+* Check that the [migration guide](documentation/src/main/asciidoc/migration/index.adoc) is up to date.
+  In particular, check the git history for API/SPI changes
+  and document them in the migration guide.
+
+#### Performing the release
+
+Once you trigger the CI job, it automatically pushes artifacts to the
+[OSSRH repository manager](https://oss.sonatype.org/#stagingRepositories),
+the distribution to [SourceForge](https://sourceforge.net/projects/hibernate/files/hibernate-search/)
+and the documentation to [docs.jboss.org](https://docs.jboss.org/hibernate/search/).
+
+* Do *not* mark the Jira Release as "released" or close issues,
+  the release job does it for you.
+* Do *not* update the repository (in particular changelog.txt and README.md), 
+  the release job does it for you.
+* Trigger the release on CI:
+  * Go to CI, to [the "hibernate-orm-release" CI job](https://ci.hibernate.org/job/hibernate-orm-release/).
+  * Click the "run" button (the green triangle on top of a clock, to the right) next to the branch you want to release.
+  * **Be careful** when filling the form with the build parameters.
+    Note only `RELEASE_VERSION` is absolutely necessary.
+  * Note that for new branches where the job has never run, the first run may not ask for parameters and thus may fail:
+    that's expected, just run it again.
+* After the job succeeds, check the artifacts are available on Maven Central:
+  https://repo1.maven.org/maven2/org/hibernate/hibernate-core/.
+  They should appear after a few minutes, sometimes a few hours.
+
+#### Announcing the release
+
+* Blog about release on [in.relation.to](https://github.com/hibernate/in.relation.to).
+  Make sure to use the tags "Hibernate ORM" and "Releases" for the blog entry.
+  Use [release-announcement.adoc](release-announcement.adoc) as a starting point.
+* Update [hibernate.org](https://github.com/hibernate/hibernate.org) if necessary:
+  * If it is a new major or minor release, add a `_data/projects/orm/releases/series.yml` file
+    and a `orm/releases/<version>/index.adoc` file.
+  * Adjust the release file in `_data/projects/orm/releases`: use a meaningful summary and set `announcement_url` to the blog post, if any.
+  * Depending on which series you want to have displayed,
+    make sure to adjust the `status`/`displayed` attributes of the `series.yml` file of the old series.
+  * Push to the production branch.
+* Send an email to `hibernate-announce@lists.jboss.org` and CC `hibernate-dev@lists.jboss.org`.
+* Tweet about the release via the `@Hibernate` account.
+
+#### Updating depending projects
+
+If you just released the latest stable, you will need to update other projects:
+
+* Approve and merge automatic updates that dependabot will send (it might take ~24h):
+  * In the [test case templates](https://github.com/hibernate/hibernate-test-case-templates/tree/master/search).
+  * In the [demos](https://github.com/hibernate/hibernate-demos/tree/master/hibernate-search).
+* **If it's a `.Final` release**, upgrade the Hibernate ORM dependency manually:
+  * In the [Quarkus BOM](https://github.com/quarkusio/quarkus/blob/main/bom/application/pom.xml).
+  * In any other relevant project.
+
+#### Updating Hibernate ORM
+
+In any case:
+
+* Reset [release-announcement.adoc](release-announcement.adoc).
+
+**If it is a new major or minor release**:
+
+* Reset the migration guide on the `main` branch if you forgot about it when preparing the release.
+* Create a maintenance branch for the previous series, if necessary; see [branching](branching.adoc).

--- a/branching.adoc
+++ b/branching.adoc
@@ -11,7 +11,7 @@ Describes the paradigm used for branching within the ORM project
 * PR branches for performance improvements, security fixes and bugfixes target the affected minor branches (which could be main for a short period of time)
 
 [[process]]
-== THe Process
+== The Process
 
 Process (using 6.3 -> 6.4 as an example):
 

--- a/ci/release/Jenkinsfile
+++ b/ci/release/Jenkinsfile
@@ -9,7 +9,9 @@
 /*
  * See https://github.com/hibernate/hibernate-jenkins-pipeline-helpers
  */
-@Library('hibernate-jenkins-pipeline-helpers@1.13') _
+@Library('hibernate-jenkins-pipeline-helpers@1.14') _
+
+import org.hibernate.jenkins.pipeline.helpers.version.Version
 
 // Avoid running the pipeline on branch indexing
 if (currentBuild.getBuildCauses().toString().contains('BranchIndexingCause')) {
@@ -70,38 +72,39 @@ pipeline {
 						checkout scmGit(branches: [[name: '*/main']], extensions: [], userRemoteConfigs: [[credentialsId: 'ed25519.Hibernate-CI.github.com', url: 'https://github.com/hibernate/hibernate-release-scripts.git']])
 					}
 					// Determine version information for release process
-					def currentVersion = sh(
+					def currentVersion = Version.parseDevelopmentVersion( sh(
 							script: ".release/scripts/determine-current-version.sh ${env.PROJECT}",
 							returnStdout: true
-					).trim()
+					).trim() )
 					echo "Workspace version: ${currentVersion}"
+					def releaseVersion
+					def developmentVersion
 
 					if ( params.RELEASE_VERSION == null || params.RELEASE_VERSION.isEmpty() ) {
-						env.RELEASE_VERSION = sh(
+						releaseVersion = Version.parseReleaseVersion( sh(
 								script: ".release/scripts/determine-release-version.sh ${currentVersion}",
 								returnStdout: true
-						).trim()
+						).trim() )
 					}
 					else {
-						env.RELEASE_VERSION = params.RELEASE_VERSION
+						releaseVersion = Version.parseReleaseVersion( params.RELEASE_VERSION )
 					}
-					echo "Release version: ${env.RELEASE_VERSION}"
+					echo "Release version: ${releaseVersion}"
 
 					if ( params.DEVELOPMENT_VERSION == null || params.DEVELOPMENT_VERSION.isEmpty() ) {
-						env.DEVELOPMENT_VERSION = sh(
-								script: ".release/scripts/determine-development-version.sh ${env.RELEASE_VERSION}",
+						developmentVersion = Version.parseDevelopmentVersion( sh(
+								script: ".release/scripts/determine-development-version.sh ${releaseVersion}",
 								returnStdout: true
-						).trim()
+						).trim() )
 					}
 					else {
-						env.DEVELOPMENT_VERSION = params.DEVELOPMENT_VERSION
+						developmentVersion = Version.parseDevelopmentVersion( params.DEVELOPMENT_VERSION )
 					}
-					echo "Development version: ${env.DEVELOPMENT_VERSION}"
+					echo "Development version: ${developmentVersion}"
 
-					def versionBasis = sh(
-							script: ".release/scripts/determine-version-basis.sh ${env.RELEASE_VERSION}",
-							returnStdout: true
-					).trim()
+					env.RELEASE_VERSION = releaseVersion.toString()
+					env.DEVELOPMENT_VERSION = developmentVersion.toString()
+					def versionBasis = releaseVersion.unqualified
 
 					env.SCRIPT_OPTIONS = params.RELEASE_DRY_RUN ? "-d" : ""
 

--- a/ci/release/Jenkinsfile
+++ b/ci/release/Jenkinsfile
@@ -70,20 +70,23 @@ pipeline {
 						checkout scmGit(branches: [[name: '*/main']], extensions: [], userRemoteConfigs: [[credentialsId: 'ed25519.Hibernate-CI.github.com', url: 'https://github.com/hibernate/hibernate-release-scripts.git']])
 					}
 					// Determine version information for release process
-					env.CURRENT_VERSION = sh(
+					def currentVersion = sh(
 							script: ".release/scripts/determine-current-version.sh ${env.PROJECT}",
 							returnStdout: true
 					).trim()
+					echo "Workspace version: ${currentVersion}"
 
 					if ( params.RELEASE_VERSION == null || params.RELEASE_VERSION.isEmpty() ) {
 						env.RELEASE_VERSION = sh(
-								script: ".release/scripts/determine-release-version.sh ${env.CURRENT_VERSION}",
+								script: ".release/scripts/determine-release-version.sh ${currentVersion}",
 								returnStdout: true
 						).trim()
 					}
 					else {
 						env.RELEASE_VERSION = params.RELEASE_VERSION
 					}
+					echo "Release version: ${env.RELEASE_VERSION}"
+
 					if ( params.DEVELOPMENT_VERSION == null || params.DEVELOPMENT_VERSION.isEmpty() ) {
 						env.DEVELOPMENT_VERSION = sh(
 								script: ".release/scripts/determine-development-version.sh ${env.RELEASE_VERSION}",
@@ -93,26 +96,17 @@ pipeline {
 					else {
 						env.DEVELOPMENT_VERSION = params.DEVELOPMENT_VERSION
 					}
-					env.VERSION_BASIS = sh(
+					echo "Development version: ${env.DEVELOPMENT_VERSION}"
+
+					def versionBasis = sh(
 							script: ".release/scripts/determine-version-basis.sh ${env.RELEASE_VERSION}",
 							returnStdout: true
 					).trim()
-					env.VERSION_FAMILY = sh(
-							script: ".release/scripts/determine-version-family.sh ${env.RELEASE_VERSION}",
-							returnStdout: true
-					).trim()
-					env.NEXT_VERSION_BASIS = sh(
-							script: ".release/scripts/determine-version-basis.sh ${env.DEVELOPMENT_VERSION}",
-							returnStdout: true
-					).trim()
+
 					env.SCRIPT_OPTIONS = params.RELEASE_DRY_RUN ? "-d" : ""
-					echo "Workspace version: ${env.CURRENT_VERSION}"
-					echo "Release version: ${env.RELEASE_VERSION}"
-					echo "Development version: ${env.DEVELOPMENT_VERSION}"
-					echo "Version family: ${env.VERSION_FAMILY}"
 
 					// Determine version id to check if Jira version exists
-					sh(script: ".release/scripts/determine-jira-version-id.sh ${env.JIRA_KEY} ${env.VERSION_BASIS}", returnStdout: true)
+					sh(script: ".release/scripts/determine-jira-version-id.sh ${env.JIRA_KEY} ${versionBasis}", returnStdout: true)
 				}
 			}
 		}

--- a/ci/release/Jenkinsfile
+++ b/ci/release/Jenkinsfile
@@ -13,6 +13,14 @@
 
 import org.hibernate.jenkins.pipeline.helpers.version.Version
 
+def checkoutReleaseScripts() {
+	dir('.release/scripts') {
+		checkout scmGit(branches: [[name: '*/main']], extensions: [],
+				userRemoteConfigs: [[credentialsId: 'ed25519.Hibernate-CI.github.com',
+									 url: 'https://github.com/hibernate/hibernate-release-scripts.git']])
+	}
+}
+
 // Avoid running the pipeline on branch indexing
 if (currentBuild.getBuildCauses().toString().contains('BranchIndexingCause')) {
 	print "INFO: Build skipped due to trigger being Branch Indexing"
@@ -59,9 +67,7 @@ pipeline {
 		stage('Release check') {
 			steps {
 				script {
-					dir('.release/scripts') {
-						checkout scmGit(branches: [[name: '*/main']], extensions: [], userRemoteConfigs: [[credentialsId: 'ed25519.Hibernate-CI.github.com', url: 'https://github.com/hibernate/hibernate-release-scripts.git']])
-					}
+					checkoutReleaseScripts()
 
 					def manualRelease = currentBuild.getBuildCauses().toString().contains( 'UserIdCause' )
 
@@ -130,10 +136,12 @@ pipeline {
 		stage('Release prepare') {
 			steps {
 				script {
-					dir('.release/scripts') {
-						checkout scmGit(branches: [[name: '*/main']], extensions: [], userRemoteConfigs: [[credentialsId: 'ed25519.Hibernate-CI.github.com', url: 'https://github.com/hibernate/hibernate-release-scripts.git']])
-					}
-					configFileProvider([configFile(fileId: 'release.config.ssh', targetLocation: "${env.HOME}/.ssh/config"), configFile(fileId: 'release.config.ssh.knownhosts', targetLocation: "${env.HOME}/.ssh/known_hosts")]) {
+					checkoutReleaseScripts()
+
+					configFileProvider([
+							configFile(fileId: 'release.config.ssh', targetLocation: "${env.HOME}/.ssh/config"),
+							configFile(fileId: 'release.config.ssh.knownhosts', targetLocation: "${env.HOME}/.ssh/known_hosts")
+					]) {
 						withCredentials([
 							usernamePassword(credentialsId: 'ossrh.sonatype.org', passwordVariable: 'OSSRH_PASSWORD', usernameVariable: 'OSSRH_USER'),
 							usernamePassword(credentialsId: 'gradle-plugin-portal-api-key', passwordVariable: 'PLUGIN_PORTAL_PASSWORD', usernameVariable: 'PLUGIN_PORTAL_USERNAME'),
@@ -155,10 +163,12 @@ pipeline {
 		stage('Publish release') {
 			steps {
 				script {
-					dir('.release/scripts') {
-						checkout scmGit(branches: [[name: '*/main']], extensions: [], userRemoteConfigs: [[credentialsId: 'ed25519.Hibernate-CI.github.com', url: 'https://github.com/hibernate/hibernate-release-scripts.git']])
-					}
-					configFileProvider([configFile(fileId: 'release.config.ssh', targetLocation: "${env.HOME}/.ssh/config"), configFile(fileId: 'release.config.ssh.knownhosts', targetLocation: "${env.HOME}/.ssh/known_hosts")]) {
+					checkoutReleaseScripts()
+
+					configFileProvider([
+							configFile(fileId: 'release.config.ssh', targetLocation: "${env.HOME}/.ssh/config"),
+							configFile(fileId: 'release.config.ssh.knownhosts', targetLocation: "${env.HOME}/.ssh/known_hosts")
+					]) {
 						withCredentials([
 							usernamePassword(credentialsId: 'ossrh.sonatype.org', passwordVariable: 'OSSRH_PASSWORD', usernameVariable: 'OSSRH_USER'),
 							usernamePassword(credentialsId: 'gradle-plugin-portal-api-key', passwordVariable: 'PLUGIN_PORTAL_PASSWORD', usernameVariable: 'PLUGIN_PORTAL_USERNAME'),
@@ -179,10 +189,12 @@ pipeline {
 		stage('Website release') {
 			steps {
 				script {
-					dir('.release/scripts') {
-						checkout scmGit(branches: [[name: '*/main']], extensions: [], userRemoteConfigs: [[credentialsId: 'ed25519.Hibernate-CI.github.com', url: 'https://github.com/hibernate/hibernate-release-scripts.git']])
-					}
-					configFileProvider([configFile(fileId: 'release.config.ssh', targetLocation: "${env.HOME}/.ssh/config"), configFile(fileId: 'release.config.ssh.knownhosts', targetLocation: "${env.HOME}/.ssh/known_hosts")]) {
+					checkoutReleaseScripts()
+
+					configFileProvider([
+							configFile(fileId: 'release.config.ssh', targetLocation: "${env.HOME}/.ssh/config"),
+							configFile(fileId: 'release.config.ssh.knownhosts', targetLocation: "${env.HOME}/.ssh/known_hosts")
+					]) {
 						withCredentials([
 								gitUsernamePassword(credentialsId: 'username-and-token.Hibernate-CI.github.com', gitToolName: 'Default')
 						]) {
@@ -204,9 +216,7 @@ pipeline {
 		stage('GitHub release') {
 			steps {
 				script {
-					dir('.release/scripts') {
-						checkout scmGit(branches: [[name: '*/main']], extensions: [], userRemoteConfigs: [[credentialsId: 'ed25519.Hibernate-CI.github.com', url: 'https://github.com/hibernate/hibernate-release-scripts.git']])
-					}
+					checkoutReleaseScripts()
 					withCredentials([string(credentialsId: 'Hibernate-CI.github.com', variable: 'GITHUB_API_TOKEN')]) {
 						sh ".release/scripts/github-release.sh ${env.SCRIPT_OPTIONS} ${env.PROJECT} ${env.RELEASE_VERSION}"
 					}

--- a/ci/release/Jenkinsfile
+++ b/ci/release/Jenkinsfile
@@ -123,7 +123,7 @@ pipeline {
 					env.SCRIPT_OPTIONS = params.RELEASE_DRY_RUN ? "-d" : ""
 
 					// Determine version id to check if Jira version exists
-					sh(script: ".release/scripts/determine-jira-version-id.sh ${env.JIRA_KEY} ${versionBasis}", returnStdout: true)
+					sh ".release/scripts/determine-jira-version-id.sh ${env.JIRA_KEY} ${versionBasis}"
 				}
 			}
 		}

--- a/ci/release/Jenkinsfile
+++ b/ci/release/Jenkinsfile
@@ -95,11 +95,18 @@ pipeline {
 					else {
 						echo "Release was triggered automatically"
 
-						// Avoid doing a release for commits from a release
+						// Avoid doing an automatic release on a non-maintenance branch
+						if ( ! ( env.BRANCH_NAME ==~ /^\d+\.\d+$/ ) ) {
+							print "INFO: Automatic release skipped because the branch name doesn't follow pattern /^\\d+\\.\\d+\$/"
+							currentBuild.result = 'ABORTED'
+							return
+						}
+
+						// Avoid doing an automatic release for commits from a release
 						def lastCommitter = sh(script: 'git show -s --format=\'%an\'', returnStdout: true)
 						def secondLastCommitter = sh(script: 'git show -s --format=\'%an\' HEAD~1', returnStdout: true)
 						if (lastCommitter == 'Hibernate-CI' && secondLastCommitter == 'Hibernate-CI') {
-							print "INFO: Build skipped because last commits were for the previous release"
+							print "INFO: Automatic release skipped because last commits were for the previous release"
 							currentBuild.result = 'ABORTED'
 							return
 						}

--- a/ci/release/Jenkinsfile
+++ b/ci/release/Jenkinsfile
@@ -40,13 +40,13 @@ pipeline {
 		string(
 				name: 'RELEASE_VERSION',
 				defaultValue: '',
-				description: 'The version to be released, e.g. 6.2.1.Final.',
+				description: 'The version to be released, e.g. 6.2.1.Final. Mandatory for manual releases, to prevent mistakes.',
 				trim: true
 		)
 		string(
 				name: 'DEVELOPMENT_VERSION',
 				defaultValue: '',
-				description: 'The next version to be used after the release, e.g. 6.2.2-SNAPSHOT.',
+				description: 'The next version to be used after the release, e.g. 6.2.2-SNAPSHOT. If not set, determined automatically from the release version.',
 				trim: true
 		)
 		booleanParam(
@@ -59,39 +59,53 @@ pipeline {
 		stage('Release check') {
 			steps {
 				script {
-					// Avoid doing a release for commits from a release
-					def lastCommitter = sh(script: 'git show -s --format=\'%an\'', returnStdout: true)
-					def secondLastCommitter = sh(script: 'git show -s --format=\'%an\' HEAD~1', returnStdout: true)
-					if (lastCommitter == 'Hibernate-CI' && secondLastCommitter == 'Hibernate-CI') {
-						print "INFO: Build skipped because last commits were for the previous release"
-						currentBuild.result = 'ABORTED'
-						return
-					}
-
 					dir('.release/scripts') {
 						checkout scmGit(branches: [[name: '*/main']], extensions: [], userRemoteConfigs: [[credentialsId: 'ed25519.Hibernate-CI.github.com', url: 'https://github.com/hibernate/hibernate-release-scripts.git']])
 					}
-					// Determine version information for release process
+
+					def manualRelease = currentBuild.getBuildCauses().toString().contains( 'UserIdCause' )
+
 					def currentVersion = Version.parseDevelopmentVersion( sh(
 							script: ".release/scripts/determine-current-version.sh ${env.PROJECT}",
 							returnStdout: true
 					).trim() )
 					echo "Workspace version: ${currentVersion}"
+
 					def releaseVersion
 					def developmentVersion
 
-					if ( params.RELEASE_VERSION == null || params.RELEASE_VERSION.isEmpty() ) {
+					if ( manualRelease ) {
+						echo "Release was requested manually"
+
+						if ( !params.RELEASE_VERSION ) {
+						        throw new IllegalArgumentException( 'Missing value for parameter RELEASE_VERSION. This parameter must be set explicitly to prevent mistakes.' )
+						}
+						releaseVersion = Version.parseReleaseVersion( params.RELEASE_VERSION )
+
+						if ( releaseVersion.toString().startsWith( currentVersion.family + '.' ) ) {
+							throw new IllegalArgumentException( "RELEASE_VERSION = $releaseVersion, which is different from the family of CURRENT_VERSION = $currentVersion. Did you make a mistake?" )
+						}
+					}
+					else {
+						echo "Release was triggered automatically"
+
+						// Avoid doing a release for commits from a release
+						def lastCommitter = sh(script: 'git show -s --format=\'%an\'', returnStdout: true)
+						def secondLastCommitter = sh(script: 'git show -s --format=\'%an\' HEAD~1', returnStdout: true)
+						if (lastCommitter == 'Hibernate-CI' && secondLastCommitter == 'Hibernate-CI') {
+							print "INFO: Build skipped because last commits were for the previous release"
+							currentBuild.result = 'ABORTED'
+							return
+						}
+
 						releaseVersion = Version.parseReleaseVersion( sh(
 								script: ".release/scripts/determine-release-version.sh ${currentVersion}",
 								returnStdout: true
 						).trim() )
 					}
-					else {
-						releaseVersion = Version.parseReleaseVersion( params.RELEASE_VERSION )
-					}
 					echo "Release version: ${releaseVersion}"
 
-					if ( params.DEVELOPMENT_VERSION == null || params.DEVELOPMENT_VERSION.isEmpty() ) {
+					if ( !params.DEVELOPMENT_VERSION ) {
 						developmentVersion = Version.parseDevelopmentVersion( sh(
 								script: ".release/scripts/determine-development-version.sh ${releaseVersion}",
 								returnStdout: true


### PR DESCRIPTION
I think the file was mostly ready, I just:

* added some safety: parsing of version strings to check they are correct, mandatory release version for manual releases
* prevented automatic releases on the main branch (so we can enable the Jenkins job on the main branch)
* removed some duplication (release script checkout) and improved formatting a little bit (long lines)

Next tasks:

1. Enable the Jenkins job on the main branch.
2. Check that all these credentials really are necessary... it seems weird that we need an SSH agent to prepare a release, for example.