### PR TITLE
HHH-18218 Projection without explicitly specifying new DtoClass(...)

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/sql/results/internal/RowTransformerConstructorImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/internal/RowTransformerConstructorImpl.java
@@ -14,6 +14,9 @@ import org.hibernate.sql.results.spi.RowTransformer;
 import java.lang.reflect.Constructor;
 import java.util.List;
 
+import org.hibernate.query.sqm.SqmExpressible;
+import org.hibernate.query.sqm.tree.SqmExpressibleAccessor;
+
 /**
  * {@link RowTransformer} instantiating an arbitrary class
  *
@@ -28,7 +31,7 @@ public class RowTransformerConstructorImpl<T> implements RowTransformer<T> {
 		final List<TupleElement<?>> elements = tupleMetadata.getList();
 		final Class<?>[] sig = new Class[elements.size()];
 		for (int i = 0; i < elements.size(); i++) {
-			sig[i] = elements.get(i).getJavaType();
+			sig[i] = resolveElementJavaType( elements.get( i ) );
 		}
 		try {
 			constructor = type.getDeclaredConstructor( sig );
@@ -38,6 +41,17 @@ public class RowTransformerConstructorImpl<T> implements RowTransformer<T> {
 			//TODO try again with primitive types
 			throw new InstantiationException( "Cannot instantiate query result type ", type, e );
 		}
+	}
+
+	private static Class<?> resolveElementJavaType(TupleElement<?> element) {
+		if ( element instanceof SqmExpressibleAccessor ) {
+			SqmExpressible expressible = ( (SqmExpressibleAccessor) element ).getExpressible();
+			if ( expressible != null ) {
+				return expressible.getExpressibleJavaType().getJavaTypeClass();
+			}
+		}
+
+		return element.getJavaType();
 	}
 
 	@Override

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/query/hql/instantiation/InstantiationWithGenericsTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/query/hql/instantiation/InstantiationWithGenericsTest.java
@@ -46,6 +46,15 @@ public class InstantiationWithGenericsTest {
 	}
 
 	@Test
+	public void testImplicitConstructor(SessionFactoryScope scope) {
+		scope.inTransaction( session -> assertThat( session.createQuery(
+				"select e.id, e.data from ConcreteEntity e",
+				ConstructorDto.class
+		).getSingleResult() ).extracting( ConstructorDto::getId, ConstructorDto::getData )
+				.containsExactly( 1L, "entity_1" ) );
+	}
+
+	@Test
 	public void testInjection(SessionFactoryScope scope) {
 		scope.inTransaction( session -> assertThat( session.createQuery(
 				"select new InjectionDto(e.id as id, e.data as data) from ConcreteEntity e",


### PR DESCRIPTION
Jira issue [HHH-18218](https://hibernate.atlassian.net/browse/HHH-18218)

Problem tackled here is similar to one solved with pull request [#8527](https://github.com/hibernate/hibernate-orm/pull/8527) .

In added test case query

`select new ConstructorDto(e.id, e.data) from ConcreteEntity e`

is changed to

`select e.id, e.data from ConcreteEntity e`

This is causing new test to fail throwing `NoSuchMethodException`. [Actually, both existing test cases are failing unless `Before/AfterAll` is replaced with `Before/AfterEach`]

Suggested solution is similar used in [#8527](https://github.com/hibernate/hibernate-orm/pull/8527) when `TupleElement` is implementing `SqmExpressibleAccessor`. Otherwise, it will fall back to original implementation.



[HHH-18218]: https://hibernate.atlassian.net/browse/HHH-18218?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ