### PR TITLE
HHH-18278 Metamodel generator is ignoring JPA/Hibernate annotations in package-info

### DIFF
--- a/tooling/metamodel-generator/src/main/java/org/hibernate/processor/HibernateProcessor.java
+++ b/tooling/metamodel-generator/src/main/java/org/hibernate/processor/HibernateProcessor.java
@@ -25,6 +25,7 @@ import javax.lang.model.element.Element;
 import javax.lang.model.element.ElementKind;
 import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.element.PackageElement;
+import javax.lang.model.element.QualifiedNameable;
 import javax.lang.model.element.TypeElement;
 import javax.lang.model.type.DeclaredType;
 import javax.lang.model.type.TypeKind;
@@ -338,9 +339,9 @@ public class HibernateProcessor extends AbstractProcessor {
 	}
 
 	private boolean included(Element element) {
-		if ( element instanceof TypeElement) {
-			final TypeElement typeElement = (TypeElement) element;
-			return context.isIncluded( typeElement.getQualifiedName().toString() );
+		if ( element instanceof TypeElement || element instanceof PackageElement ) {
+			final QualifiedNameable nameable = (QualifiedNameable) element;
+			return context.isIncluded( nameable.getQualifiedName().toString() );
 		}
 		else {
 			return false;

--- a/tooling/metamodel-generator/src/test/java/org/hibernate/processor/test/packageinfo/PackageInfoMetamodelTest.java
+++ b/tooling/metamodel-generator/src/test/java/org/hibernate/processor/test/packageinfo/PackageInfoMetamodelTest.java
@@ -1,0 +1,43 @@
+package org.hibernate.processor.test.packageinfo;
+
+import org.hibernate.processor.test.util.CompilationTest;
+import org.hibernate.processor.test.util.WithClasses;
+
+import org.junit.Test;
+
+import jakarta.persistence.EntityManager;
+
+import static org.hibernate.processor.test.util.TestUtil.assertMetamodelClassGeneratedFor;
+import static org.hibernate.processor.test.util.TestUtil.assertPresenceOfFieldInMetamodelFor;
+import static org.hibernate.processor.test.util.TestUtil.assertPresenceOfMethodInMetamodelFor;
+import static org.hibernate.processor.test.util.TestUtil.getMetaModelSourceAsString;
+
+public class PackageInfoMetamodelTest extends CompilationTest {
+
+	@Test
+	@WithClasses(value = {}, sources = {
+			"org.hibernate.processor.test.packageinfo.Message",
+			"org.hibernate.processor.test.packageinfo.package-info"
+	})
+	public void test() {
+		assertMetamodelClassGeneratedFor( "org.hibernate.processor.test.packageinfo.Message" );
+
+		System.out.println( getMetaModelSourceAsString( "org.hibernate.processor.test.packageinfo.packageinfo" ) );
+
+		assertPresenceOfFieldInMetamodelFor(
+				"org.hibernate.processor.test.packageinfo.packageinfo",
+				"QUERY_FIND_BY_KEY"
+		);
+		assertPresenceOfFieldInMetamodelFor(
+				"org.hibernate.processor.test.packageinfo.packageinfo",
+				"QUERY_FIND_BY_ID_AND_KEY"
+		);
+
+		assertPresenceOfMethodInMetamodelFor(
+				"org.hibernate.processor.test.packageinfo.packageinfo",
+				"findByKey",
+				EntityManager.class,
+				String.class
+		);
+	}
+}

--- a/tooling/metamodel-generator/src/test/resources/org/hibernate/processor/test/packageinfo/Message.java
+++ b/tooling/metamodel-generator/src/test/resources/org/hibernate/processor/test/packageinfo/Message.java
@@ -1,0 +1,13 @@
+package org.hibernate.processor.test.packageinfo;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+
+@Entity
+public class Message {
+
+	@Id
+	Integer id;
+
+	String key;
+}

--- a/tooling/metamodel-generator/src/test/resources/org/hibernate/processor/test/packageinfo/package-info.java
+++ b/tooling/metamodel-generator/src/test/resources/org/hibernate/processor/test/packageinfo/package-info.java
@@ -1,0 +1,10 @@
+@NamedQuery(
+        name = "#findByKey",
+        query = "from Message where key=:key")
+@NamedQuery(
+		name = "findByIdAndKey",
+		query = "from Message where id=:id and key=:key")
+
+package org.hibernate.processor.test.packageinfo;
+
+import org.hibernate.annotations.NamedQuery;


### PR DESCRIPTION
Jira issue [https://hibernate.atlassian.net/browse/HHH-18278](HHH-18278)

Since version 6.6 meta model generator is ignoring package.info.java

In previous versions (last checked version 6.5.2) meta model generator was creating from

`a.b.c.package-info`

class

`a.b.c.c_`


Problem is in method `org.hibernate.processor.HibernateProcessor.included(Element)` which is accepting only `TypeElement`'s and ignoring `PackageElement`'s