### PR TITLE
fix generate error sql when have @DiscriminatorValue("not null") and …

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/persister/entity/AbstractEntityPersister.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/entity/AbstractEntityPersister.java
@@ -3214,8 +3214,14 @@ public abstract class AbstractEntityPersister
 				// Return an empty Junction
 				return junction;
 			}
+			
+			if ( hasNotNull ) {
+				junction.add( new NegatedPredicate( new NullnessPredicate( sqlExpression ) ) );			
+			}
+			if ( hasNull ) {
+				junction.add( new NullnessPredicate( sqlExpression ) );				
+			}
 
-			junction.add( new NullnessPredicate( sqlExpression ) );
 			junction.add( predicate );
 			return junction;
 		}


### PR DESCRIPTION
…entity is superclass of other entity

fix bug of when @DiscriminatorValue("not null") entity is superclass of other entity. Query sql generate error I have create a reprduce java project: 
https://github.com/lrobot/hibernate-bug-discriminatorvalue

the public class TypeHaveProduct  entity is marked with: @DiscriminatorValue("not null"), and  also have subclass Pen & Book

my test for @DiscriminatorValue generate bad query sql: it should be "where  thp1_0."product_type" is not null"
```
Hibernate: 
    select
        thp1_0."product_id",
        thp1_0."product_type",
        thp1_0."name",
        thp1_0."author",
        thp1_0."color" 
    from
        "products" thp1_0 
    where
        thp1_0."product_type" is null 
        or thp1_0."product_type" in ('1', '2')
```