### PR TITLE
HHH-18282 fix generate error sql in case of @DiscriminatorValue("not null")

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/persister/entity/AbstractEntityPersister.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/entity/AbstractEntityPersister.java
@@ -3215,7 +3215,13 @@ public abstract class AbstractEntityPersister
 				return junction;
 			}
 
-			junction.add( new NullnessPredicate( sqlExpression ) );
+			if ( hasNonNull ) {
+				junction.add( new NegatedPredicate( new NullnessPredicate( sqlExpression ) ) );			
+			}
+			if ( hasNull ) {
+				junction.add( new NullnessPredicate( sqlExpression ) );				
+			}
+			
 			junction.add( predicate );
 			return junction;
 		}


### PR DESCRIPTION
fix generate error sql in case of @DiscriminatorValue("not null")  and the entity is superclass of other entity

I have create a reprduce java project: 
https://github.com/lrobot/hibernate-bug-discriminatorvalue

the entity TypeHaveProduct is marked with: @DiscriminatorValue("not null"), and  also have subclass Pen & Book

my test for @DiscriminatorValue generate bad query sql: it should be "where not( thp1_0."product_type" is null)"
```
Hibernate: 
    select
        thp1_0."product_id",
        thp1_0."product_type",
        thp1_0."name",
        thp1_0."author",
        thp1_0."color" 
    from
        "products" thp1_0 
    where
        thp1_0."product_type" is null 
        or thp1_0."product_type" in ('1', '2')
```

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-18282
<!-- Hibernate GitHub Bot issue links end -->