### PR TITLE
HHH-18288 @Index specified by subclass in SINGLE_TABLE inheritance

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/boot/model/internal/EntityBinder.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/internal/EntityBinder.java
@@ -750,8 +750,7 @@ public class EntityBinder {
 		final String table;
 		final String catalog;
 		final UniqueConstraint[] uniqueConstraints;
-		boolean hasTableAnnotation = annotatedClass.isAnnotationPresent( jakarta.persistence.Table.class );
-		if ( hasTableAnnotation ) {
+		if ( annotatedClass.isAnnotationPresent( jakarta.persistence.Table.class ) ) {
 			final jakarta.persistence.Table tableAnnotation = annotatedClass.getAnnotation( jakarta.persistence.Table.class );
 			table = tableAnnotation.name();
 			schema = tableAnnotation.schema();
@@ -771,7 +770,7 @@ public class EntityBinder {
 		}
 		else {
 			// must be a SINGLE_TABLE mapping for a subclass
-			if ( hasTableAnnotation ) {
+			if ( !table.isEmpty() ) {
 				final Table superTable = persistentClass.getRootClass().getTable();
 				if ( !logicalTableName( table, schema, catalog )
 						.equals( superTable.getQualifiedTableName() ) ) {

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/schema/SubclassIndexTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/schema/SubclassIndexTest.java
@@ -1,0 +1,42 @@
+package org.hibernate.orm.test.schema;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.OrderColumn;
+import jakarta.persistence.Table;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.JiraKey;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+@JiraKey("HHH-18288")
+@SessionFactory
+@DomainModel(annotatedClasses = {SubclassIndexTest.Foo.class, SubclassIndexTest.Bar.class})
+public class SubclassIndexTest {
+
+	@Test void test(SessionFactoryScope scope) {
+		scope.getSessionFactory();
+	}
+
+	@Entity
+	@Table(name = "FOO")
+	static class Foo {
+		@Id
+		long id;
+	}
+
+	@Entity
+	@Table(indexes = @Index(name="IDX", columnList = "text"))
+	static class Bar extends Foo {
+		@OneToMany
+		@OrderColumn
+		List<Foo> foo;
+
+		String text;
+	}
+}


### PR DESCRIPTION
I'm definitely not a fan of `@Table` annotations on subclasses in `SINGLE_TABLE` hierarchies. However, unfortunately we've already decided to tolerate it.

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-18288
<!-- Hibernate GitHub Bot issue links end -->