### PR TITLE
HHH-18291 Boolean expression type not resolved properly for subquery

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/query/hql/internal/SemanticQueryBuilder.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/hql/internal/SemanticQueryBuilder.java
@@ -264,6 +264,7 @@ import static org.hibernate.query.sqm.TemporalUnit.TIMEZONE_HOUR;
 import static org.hibernate.query.sqm.TemporalUnit.TIMEZONE_MINUTE;
 import static org.hibernate.query.sqm.TemporalUnit.WEEK_OF_MONTH;
 import static org.hibernate.query.sqm.TemporalUnit.WEEK_OF_YEAR;
+import static org.hibernate.query.sqm.internal.SqmUtil.resolveExpressibleJavaTypeClass;
 import static org.hibernate.type.descriptor.DateTimeUtils.DATE_TIME;
 import static org.hibernate.type.spi.TypeConfiguration.isJdbcTemporalType;
 
@@ -2918,8 +2919,11 @@ public class SemanticQueryBuilder<R> extends HqlParserBaseVisitor<Object> implem
 	@Override
 	public SqmPredicate visitBooleanExpressionPredicate(HqlParser.BooleanExpressionPredicateContext ctx) {
 		final SqmExpression<?> expression = (SqmExpression<?>) ctx.expression().accept( this );
-		if ( expression.getJavaType() != Boolean.class ) {
-			throw new SemanticException( "Non-boolean expression used in predicate context: " + ctx.getText(), query );
+		if ( resolveExpressibleJavaTypeClass( expression ) != Boolean.class ) {
+			throw new SemanticException(
+					"Non-boolean expression used in predicate context: " + ctx.getText(),
+					query
+			);
 		}
 		@SuppressWarnings("unchecked")
 		final SqmExpression<Boolean> booleanExpression = (SqmExpression<Boolean>) expression;

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/internal/SqmUtil.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/internal/SqmUtil.java
@@ -15,6 +15,7 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.StringTokenizer;
 import java.util.function.Function;
@@ -43,6 +44,7 @@ import org.hibernate.query.spi.QueryParameterBinding;
 import org.hibernate.query.spi.QueryParameterBindings;
 import org.hibernate.query.spi.QueryParameterImplementor;
 import org.hibernate.query.sqm.NodeBuilder;
+import org.hibernate.query.sqm.SqmExpressible;
 import org.hibernate.query.sqm.SqmPathSource;
 import org.hibernate.query.sqm.SqmQuerySource;
 import org.hibernate.query.sqm.spi.JdbcParameterBySqmParameterAccess;
@@ -740,6 +742,13 @@ public class SqmUtil {
 
 	public static boolean isHqlTuple(SqmSelection<?> selection) {
 		return selection != null && selection.getSelectableNode() instanceof SqmTuple;
+	}
+
+	public static Class<?> resolveExpressibleJavaTypeClass(final SqmExpression<?> expression) {
+		final SqmExpressible<?> expressible = expression.getExpressible();
+		return expressible == null || expressible.getExpressibleJavaType() == null
+				? null
+				: expressible.getExpressibleJavaType().getJavaTypeClass();
 	}
 
 	private static class CriteriaParameterCollector {

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/query/hhh18291/BooleanSubqueryTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/query/hhh18291/BooleanSubqueryTest.java
@@ -1,0 +1,44 @@
+package org.hibernate.orm.test.query.hhh18291;
+
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.JiraKey;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import jakarta.persistence.TypedQuery;
+
+@DomainModel(
+		annotatedClasses = {
+				InvoiceBE.class,
+				PaidInvoiceBE.class
+		}
+)
+@SessionFactory
+public class BooleanSubqueryTest {
+
+	@Test
+	@JiraKey("HHH-18292")
+	public void hhh18291Test(SessionFactoryScope scope) throws Exception {
+		final var paidInvoiceBE = scope.fromTransaction( entityManager -> {
+			final var invoice = new InvoiceBE().setId( 1L ).setRemoved( false );
+			entityManager.persist( invoice );
+			final var paidInvoice = new PaidInvoiceBE().setId( 1 ).setInvoice( invoice );
+			entityManager.persist( paidInvoice );
+			return paidInvoice;
+		} );
+		scope.inTransaction( entityManager -> {
+			TypedQuery<Boolean> query = entityManager.createQuery(
+					"SELECT i.removed = false " +
+					"AND (SELECT count(*) = 0 " +
+					"FROM PaidInvoiceBE pi " +
+					"WHERE pi.invoice.id = i.id) " +
+					"FROM InvoiceBE i " +
+					"WHERE i.id = :invoiceId", Boolean.class );
+			query.setParameter( "invoiceId", 1L );
+			Boolean result = query.getSingleResult();
+			Assertions.assertFalse( result );
+		} );
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/query/hhh18291/InvoiceBE.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/query/hhh18291/InvoiceBE.java
@@ -1,0 +1,28 @@
+package org.hibernate.orm.test.query.hhh18291;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+@Entity
+@Table(name = "invoice")
+public class InvoiceBE {
+
+  @Id
+//  @GeneratedValue
+  private long id;
+
+  @Column(name = "removed", nullable = false)
+  private boolean removed;
+
+  public InvoiceBE setId(long id) {
+    this.id = id;
+    return this;
+  }
+
+  public InvoiceBE setRemoved(boolean removed) {
+    this.removed = removed;
+    return this;
+  }
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/query/hhh18291/PaidInvoiceBE.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/query/hhh18291/PaidInvoiceBE.java
@@ -1,0 +1,30 @@
+package org.hibernate.orm.test.query.hhh18291;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+
+@Entity
+@Table(
+    name = "paid_invoice")
+public class PaidInvoiceBE {
+
+  @Id
+//  @GeneratedValue
+  private long id;
+
+  @ManyToOne(optional = false, fetch = FetchType.LAZY)
+  private InvoiceBE invoice;
+
+  public PaidInvoiceBE setId(long id) {
+    this.id = id;
+    return this;
+  }
+
+  public PaidInvoiceBE setInvoice(InvoiceBE invoice) {
+    this.invoice = invoice;
+    return this;
+  }
+}


### PR DESCRIPTION
Jira issue [HHH-18292](https://hibernate.atlassian.net/browse/HHH-18292)

When boolean expression is subquery, type can not be resolved directly as Java type; expressible Java type should be used instead.

[HHH-18292]: https://hibernate.atlassian.net/browse/HHH-18292?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-18291
<!-- Hibernate GitHub Bot issue links end -->