### PR TITLE
Fixed Informix physical naming strategy compatibility

### DIFF
--- a/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/query/AllTables.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/query/AllTables.java
@@ -26,10 +26,11 @@ import org.hibernate.annotations.Formula;
  public class AllTables {
 
 	@Id
-	@Column(name = "TABLE_NAME", nullable = false)
+	@Column(name = "table_name", nullable = false)
 	private String tableName;
 
 	@Formula(value = "(SYSDATE())")
+	@Column(name = "days_old")
 	private String daysOld;
 
 	public String getTableName() {

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/query/QueryAndSQLTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/query/QueryAndSQLTest.java
@@ -98,11 +98,11 @@ public class QueryAndSQLTest {
 				.currentDate();
 
 		String sql = String.format(
-				"select t.TABLE_NAME as {t.tableName}, %s as {t.daysOld} from ALL_TABLES t where t.TABLE_NAME = 'AUDIT_ACTIONS' ",
+				"select t.table_name as {t.tableName}, %s as {t.daysOld} from ALL_TABLES t where t.table_name = 'AUDIT_ACTIONS' ",
 				dateFunctionRendered
 		);
 		String sql2 = String.format(
-				"select TABLE_NAME as t_name, %s as t_time from ALL_TABLES where TABLE_NAME = 'AUDIT_ACTIONS' ",
+				"select table_name as t_name, %s as t_time from ALL_TABLES where table_name = 'AUDIT_ACTIONS' ",
 				dateFunctionRendered
 		);
 
@@ -128,8 +128,8 @@ public class QueryAndSQLTest {
 	public void testNativeQueryWithFormulaAttributeWithoutAlias(SessionFactoryScope scope) {
 		scope.inTransaction(
 				session -> {
-                    String sql = "select TABLE_NAME , " + scope.getSessionFactory().getJdbcServices().getDialect()
-							.currentDate() + " as daysOld from ALL_TABLES  where TABLE_NAME = 'AUDIT_ACTIONS' ";
+                    String sql = "select table_name , " + scope.getSessionFactory().getJdbcServices().getDialect()
+							.currentDate() + " as days_old from ALL_TABLES  where table_name = 'AUDIT_ACTIONS' ";
 					session.createNativeQuery( sql ).addEntity( "t", AllTables.class ).list();
 				}
 		);

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/hql/joinedSubclass/JoinedSubclassNativeQueryTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/hql/joinedSubclass/JoinedSubclassNativeQueryTest.java
@@ -20,6 +20,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import jakarta.persistence.Basic;
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
@@ -69,7 +70,7 @@ public class JoinedSubclassNativeQueryTest {
 					// PostgreSQLDialect#getSelectClauseNullString produces e.g. `null::text` which we interpret as parameter,
 					// so workaround this problem by configuring to ignore JDBC parameters
 					session.setProperty( AvailableSettings.NATIVE_IGNORE_JDBC_PARAMETERS, true );
-					Person p = session.createNativeQuery( "select p.*, " + nullColumnString + " as companyName, 0 as clazz_  from Person p", Person.class ).getSingleResult();
+					Person p = session.createNativeQuery( "select p.*, " + nullColumnString + " as company_name, 0 as clazz_  from Person p", Person.class ).getSingleResult();
 					Assertions.assertNotNull( p );
 					Assertions.assertEquals( p.getFirstName(), "Jan" );
 				}
@@ -84,6 +85,7 @@ public class JoinedSubclassNativeQueryTest {
 		private Long id;
 
 		@Basic(optional = false)
+		@Column(name = "first_name")
 		private String firstName;
 
 		public String getFirstName() {
@@ -98,6 +100,7 @@ public class JoinedSubclassNativeQueryTest {
 	@Entity(name = "Employee")
 	public static class Employee extends Person {
 		@Basic(optional = false)
+		@Column(name = "company_name")
 		private String companyName;
 
 		public String getCompanyName() {

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/Item.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/Item.java
@@ -107,6 +107,7 @@ public class Item implements Serializable {
 		this.name = name;
 	}
 
+	@Column(name = "int_val")
 	public Integer getIntVal() {
 		return intVal;
 	}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/Wallet.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/Wallet.java
@@ -9,6 +9,8 @@
 package org.hibernate.orm.test.jpa;
 import java.io.Serializable;
 import java.util.Date;
+
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 
@@ -47,6 +49,7 @@ public class Wallet implements Serializable {
 		this.brand = brand;
 	}
 
+	@Column(name = "market_entrance")
 	public Date getMarketEntrance() {
 		return marketEntrance;
 	}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/query/QueryTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/query/QueryTest.java
@@ -387,16 +387,16 @@ public class QueryTest extends BaseEntityManagerFunctionalTestCase {
 			em.persist( item );
 			// native queries don't seem to flush by default ?!?
 			em.flush();
-			Query q = em.createNativeQuery( "select * from Item i where i.intVal=?" );
+			Query q = em.createNativeQuery( "select * from Item i where i.int_val=?" );
 			q.setParameter( 1, null );
 			List results = q.getResultList();
 			// null != null
 			assertEquals( 0, results.size() );
-			q = em.createNativeQuery( "select * from Item i where i.intVal is null and ? is null" );
+			q = em.createNativeQuery( "select * from Item i where i.int_val is null and ? is null" );
 			q.setParameter( 1, null );
 			results = q.getResultList();
 			assertEquals( 1, results.size() );
-			q = em.createNativeQuery( "select * from Item i where i.intVal is null or i.intVal = ?" );
+			q = em.createNativeQuery( "select * from Item i where i.int_val is null or i.int_val = ?" );
 			q.setParameter(1, null );
 			results = q.getResultList();
 			assertEquals( 1, results.size() );
@@ -422,7 +422,7 @@ public class QueryTest extends BaseEntityManagerFunctionalTestCase {
 			em.persist( item );
 			// native queries don't seem to flush by default ?!?
 			em.flush();
-			Query q = em.createNativeQuery( "select * from Item i where i.intVal=?" );
+			Query q = em.createNativeQuery( "select * from Item i where i.int_val=?" );
 			Parameter p = new Parameter() {
 				@Override
 				public String getName() {
@@ -444,11 +444,11 @@ public class QueryTest extends BaseEntityManagerFunctionalTestCase {
 			List results = q.getResultList();
 			// null != null
 			assertEquals( 0, results.size() );
-			q = em.createNativeQuery( "select * from Item i where i.intVal is null and ? is null" );
+			q = em.createNativeQuery( "select * from Item i where i.int_val is null and ? is null" );
 			q.setParameter( p, null );
 			results = q.getResultList();
 			assertEquals( 1, results.size() );
-			q = em.createNativeQuery( "select * from Item i where i.intVal is null or i.intVal = ?" );
+			q = em.createNativeQuery( "select * from Item i where i.int_val is null or i.int_val = ?" );
 			q.setParameter( p, null );
 			results = q.getResultList();
 			assertEquals( 1, results.size() );
@@ -473,16 +473,16 @@ public class QueryTest extends BaseEntityManagerFunctionalTestCase {
 			em.persist( item );
 			// native queries don't seem to flush by default ?!?
 			em.flush();
-			Query q = em.createNativeQuery( "select * from Item i where i.intVal=:iVal" );
+			Query q = em.createNativeQuery( "select * from Item i where i.int_val=:iVal" );
 			q.setParameter( "iVal", null );
 			List results = q.getResultList();
 			// null != null
 			assertEquals( 0, results.size() );
-			q = em.createNativeQuery( "select * from Item i where (i.intVal is null) and (:iVal is null)" );
+			q = em.createNativeQuery( "select * from Item i where (i.int_val is null) and (:iVal is null)" );
 			q.setParameter( "iVal", null );
 			results = q.getResultList();
 			assertEquals( 1, results.size() );
-			q = em.createNativeQuery( "select * from Item i where i.intVal is null or i.intVal = :iVal" );
+			q = em.createNativeQuery( "select * from Item i where i.int_val is null or i.int_val = :iVal" );
 			q.setParameter( "iVal", null );
 			results = q.getResultList();
 			assertEquals( 1, results.size() );
@@ -508,7 +508,7 @@ public class QueryTest extends BaseEntityManagerFunctionalTestCase {
 			em.persist( item );
 			// native queries don't seem to flush by default ?!?
 			em.flush();
-			Query q = em.createNativeQuery( "select * from Item i where i.intVal=:iVal" );
+			Query q = em.createNativeQuery( "select * from Item i where i.int_val=:iVal" );
 			Parameter p = new Parameter() {
 				@Override
 				public String getName() {
@@ -529,11 +529,11 @@ public class QueryTest extends BaseEntityManagerFunctionalTestCase {
 			Parameter pGotten = q.getParameter( p.getName() );
 			List results = q.getResultList();
 			assertEquals( 0, results.size() );
-			q = em.createNativeQuery( "select * from Item i where (i.intVal is null) and (:iVal is null)" );
+			q = em.createNativeQuery( "select * from Item i where (i.int_val is null) and (:iVal is null)" );
 			q.setParameter( p, null );
 			results = q.getResultList();
 			assertEquals( 1, results.size() );
-			q = em.createNativeQuery( "select * from Item i where i.intVal is null or i.intVal = :iVal" );
+			q = em.createNativeQuery( "select * from Item i where i.int_val is null or i.int_val = :iVal" );
 			q.setParameter( p, null );
 			results = q.getResultList();
 			assertEquals( 1, results.size() );

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/loaders/SqlSelectTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/loaders/SqlSelectTest.java
@@ -47,17 +47,17 @@ public class SqlSelectTest {
 
 	@Entity
 	@Table(name = "With_Sql_Select")
-	@SQLSelect(sql = "select * from With_Sql_Select where Sql_Select_id = ?",
+	@SQLSelect(sql = "select * from With_Sql_Select where sql_select_id = ?",
 			querySpaces = "With_Sql_Select")
 	static class WithSqlSelect {
 		@Id @GeneratedValue
-		@Column(name = "Sql_Select_id")
+		@Column(name = "sql_select_id")
 		Long id;
 		String name;
 		@ElementCollection
 		@CollectionTable(name = "With_Uuids",
-				joinColumns = @JoinColumn(name = "Sql_Select_id", referencedColumnName = "Sql_Select_id"))
-		@SQLSelect(sql = "select Random_Uuids as uuid from With_Uuids where Sql_Select_id = ?",
+				joinColumns = @JoinColumn(name = "sql_select_id", referencedColumnName = "sql_select_id"))
+		@SQLSelect(sql = "select Random_Uuids as uuid from With_Uuids where sql_select_id = ?",
 				resultSetMapping = @SqlResultSetMapping(name = "",
 						columns = @ColumnResult(name = "uuid", type = UUID.class)),
 				querySpaces = "With_Uuids")

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/formula/FormulaNativeQueryTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/formula/FormulaNativeQueryTest.java
@@ -8,6 +8,8 @@ package org.hibernate.orm.test.mapping.formula;
 
 import java.util.Collections;
 import java.util.List;
+
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
@@ -76,7 +78,7 @@ public class FormulaNativeQueryTest {
 		scope.inTransaction(
 				session -> {
 					Query<Foo> query = session.createNativeQuery(
-							"SELECT ft.*, abs(locationEnd - locationStart) as distance FROM foo_table ft",
+							"SELECT ft.*, abs(location_end - location_start) as distance FROM foo_table ft",
 							Foo.class
 					);
 					List<Foo> list = query.getResultList();
@@ -90,11 +92,11 @@ public class FormulaNativeQueryTest {
 		scope.inTransaction(
 				session -> {
 					NativeQuery query = session.createNativeQuery(
-							"SELECT ft.*, abs(ft.locationEnd - locationStart) as d FROM foo_table ft" );
+							"SELECT ft.*, abs(ft.location_end - location_start) as d FROM foo_table ft" );
 					query.addRoot( "ft", Foo.class )
 							.addProperty( "id", "id" )
-							.addProperty( "locationStart", "locationStart" )
-							.addProperty( "locationEnd", "locationEnd" )
+							.addProperty( "locationStart", "location_start" )
+							.addProperty( "locationEnd", "location_end" )
 							.addProperty( "distance", "d" );
 					List<Foo> list = query.getResultList();
 					assertThat( list, hasSize( 3 ) );
@@ -107,7 +109,7 @@ public class FormulaNativeQueryTest {
 		scope.inTransaction(
 				session -> {
 					NativeQuery query = session.createNativeQuery(
-							"SELECT ft.id as {ft.id}, ft.locationStart as {ft.locationStart}, ft.locationEnd as {ft.locationEnd}, abs(ft.locationEnd - locationStart) as {ft.distance} FROM foo_table ft" )
+							"SELECT ft.id as {ft.id}, ft.location_start as {ft.locationStart}, ft.location_end as {ft.locationEnd}, abs(ft.location_end - location_start) as {ft.distance} FROM foo_table ft" )
 							.addEntity( "ft", Foo.class );
 					query.setProperties( Collections.singletonMap( "distance", "distance" ) );
 					List<Foo> list = query.getResultList();
@@ -153,6 +155,7 @@ public class FormulaNativeQueryTest {
 			this.id = id;
 		}
 
+		@Column(name = "location_start")
 		public int getLocationStart() {
 			return locationStart;
 		}
@@ -160,6 +163,7 @@ public class FormulaNativeQueryTest {
 			this.locationStart = locationStart;
 		}
 
+		@Column(name = "location_end")
 		public int getLocationEnd() {
 			return locationEnd;
 		}
@@ -167,7 +171,7 @@ public class FormulaNativeQueryTest {
 			this.locationEnd = locationEnd;
 		}
 
-		@Formula("abs(locationEnd - locationStart)")
+		@Formula("abs(location_end - location_start)")
 		public int getDistance() {
 			return distance;
 		}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/query/NativeQueryWithDuplicateColumnTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/query/NativeQueryWithDuplicateColumnTest.java
@@ -121,18 +121,18 @@ public class NativeQueryWithDuplicateColumnTest {
 	public static class Book {
 		@Id
 		@GeneratedValue
-		@Column(name = "BOOK_ID")
+		@Column(name = "book_id")
 		private Long id;
 
 		@ManyToOne(targetEntity = Publisher.class, fetch = FetchType.LAZY)
-		@JoinColumn(name = "PUBLISHER_FK")
+		@JoinColumn(name = "publisher_fk")
 		private Publisher publisher;
 
-		@Column(name = "PUBLISHER_FK", nullable = false, insertable = false, updatable = false)
+		@Column(name = "publisher_fk", nullable = false, insertable = false, updatable = false)
 		@Access(AccessType.FIELD)
 		private Long publisherFk;
 
-		@Column(name = "TITLE")
+		@Column(name = "title")
 		private String title;
 
 		public Book() {

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/query/sql/NativeQueryResultBuilderTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/query/sql/NativeQueryResultBuilderTests.java
@@ -60,7 +60,7 @@ public class NativeQueryResultBuilderTests {
 	public void fullyImplicitTest(SessionFactoryScope scope) {
 		scope.inTransaction(
 				session -> {
-					final String sql = "select theString, theInteger, id from EntityOfBasics";
+					final String sql = "select the_string, the_integer, id from EntityOfBasics";
 					final NativeQueryImplementor<?> query = session.createNativeQuery( sql );
 
 					final List<?> results = query.list();
@@ -91,7 +91,7 @@ public class NativeQueryResultBuilderTests {
 							.isNotInstanceOf( SQLServerDialect.class )
 							.isNotInstanceOf( SybaseDialect.class )
 							.isNotInstanceOf( OracleDialect.class );
-					final String sql = "select count(theString) from EntityOfBasics";
+					final String sql = "select count(the_string) from EntityOfBasics";
 					final NativeQueryImplementor<?> query = session.createNativeQuery( sql );
 
 					final List<?> results = query.list();
@@ -109,12 +109,12 @@ public class NativeQueryResultBuilderTests {
 	public void explicitOrderTest(SessionFactoryScope scope) {
 		scope.inTransaction(
 				session -> {
-					final String sql = "select theString, theInteger, id from EntityOfBasics";
+					final String sql = "select the_string, the_integer, id from EntityOfBasics";
 					final NativeQueryImplementor<?> query = session.createNativeQuery( sql );
 					// notice the reverse order from the select clause
 					query.addScalar( "id" );
-					query.addScalar( "theInteger" );
-					query.addScalar( "theString" );
+					query.addScalar( "the_integer" );
+					query.addScalar( "the_string" );
 
 					final List<?> results = query.list();
 					assertThat( results.size(), is( 1 ) );

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/sql/SQLTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/sql/SQLTest.java
@@ -284,7 +284,7 @@ public class SQLTest extends BaseEntityManagerFunctionalTestCase {
         doInJPA(this::entityManagerFactory, entityManager -> {
 			//tag::sql-jpa-entity-query-explicit-result-set-example[]
 			List<Person> persons = entityManager.createNativeQuery(
-				"SELECT id, name, nickName, address, createdOn, version " +
+				"SELECT id, name, nick_name, address, created_on, version " +
 				"FROM Person", Person.class)
 			.getResultList();
 			//end::sql-jpa-entity-query-explicit-result-set-example[]
@@ -298,7 +298,7 @@ public class SQLTest extends BaseEntityManagerFunctionalTestCase {
 			Session session = entityManager.unwrap(Session.class);
 			//tag::sql-hibernate-entity-query-explicit-result-set-example[]
 			List<Person> persons = session.createNativeQuery(
-				"SELECT id, name, nickName, address, createdOn, version " +
+				"SELECT id, name, nick_name, address, created_on, version " +
 				"FROM Person", Person.class)
 			.list();
 			//end::sql-hibernate-entity-query-explicit-result-set-example[]

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/sql/hand/query/NativeSQLQueriesTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/sql/hand/query/NativeSQLQueriesTest.java
@@ -82,21 +82,21 @@ import static org.junit.jupiter.api.Assertions.fail;
 public class NativeSQLQueriesTest {
 
 	protected String getOrganizationFetchJoinEmploymentSQL() {
-		return "SELECT org.ORGID as {org.id}, " +
-				"        org.NAME as {org.name}, " +
-				"        emp.EMPLOYER as {emp.key}, " +
-				"        emp.EMPID as {emp.element}, " +
+		return "SELECT org.orgid as {org.id}, " +
+				"        org.name as {org.name}, " +
+				"        emp.employer as {emp.key}, " +
+				"        emp.empid as {emp.element}, " +
 				"        {emp.element.*}  " +
 				"FROM ORGANIZATION org " +
-				"    LEFT OUTER JOIN EMPLOYMENT emp ON org.ORGID = emp.EMPLOYER";
+				"    LEFT OUTER JOIN EMPLOYMENT emp ON org.orgid = emp.employer";
 	}
 
 	protected String getOrganizationJoinEmploymentSQL() {
-		return "SELECT org.ORGID as {org.id}, " +
-				"        org.NAME as {org.name}, " +
+		return "SELECT org.orgid as {org.id}, " +
+				"        org.name as {org.name}, " +
 				"        {emp.*}  " +
 				"FROM ORGANIZATION org " +
-				"    LEFT OUTER JOIN EMPLOYMENT emp ON org.ORGID = emp.EMPLOYER";
+				"    LEFT OUTER JOIN EMPLOYMENT emp ON org.orgid = emp.employer";
 	}
 
 	protected String getEmploymentSQL() {
@@ -104,28 +104,28 @@ public class NativeSQLQueriesTest {
 	}
 
 	protected String getEmploymentSQLMixedScalarEntity() {
-		return "SELECT e.*, e.EMPLOYER as employerid  FROM EMPLOYMENT e" ;
+		return "SELECT e.*, e.employer as employerid  FROM EMPLOYMENT e" ;
 	}
 
 	protected String getOrgEmpRegionSQL() {
-		return "select {org.*}, {emp.*}, emp.REGIONCODE " +
+		return "select {org.*}, {emp.*}, emp.region_code " +
 				"from ORGANIZATION org " +
-				"     left outer join EMPLOYMENT emp on org.ORGID = emp.EMPLOYER";
+				"     left outer join EMPLOYMENT emp on org.orgid = emp.employer";
 	}
 
 	protected String getOrgEmpPersonSQL() {
 		return "select {org.*}, {emp.*}, {pers.*} " +
 				"from ORGANIZATION org " +
-				"    join EMPLOYMENT emp on org.ORGID = emp.EMPLOYER " +
-				"    join PERSON pers on pers.PERID = emp.EMPLOYEE ";
+				"    join EMPLOYMENT emp on org.orgid = emp.employer " +
+				"    join PERSON pers on pers.perid = emp.employee ";
 	}
 
 	protected String getDescriptionsSQL() {
-		return "select DESCRIPTION from TEXT_HOLDER";
+		return "select description from TEXT_HOLDER";
 	}
 
 	protected String getPhotosSQL() {
-		return "select PHOTO from IMAGE_HOLDER";
+		return "select photo from IMAGE_HOLDER";
 	}
 
 	@Test
@@ -200,7 +200,7 @@ public class NativeSQLQueriesTest {
 					List l = session.createNativeQuery( getOrgEmpRegionSQL() )
 							.addEntity("org", Organization.class)
 							.addJoin("emp", "org.employments")
-							.addScalar("regionCode", StandardBasicTypes.STRING )
+							.addScalar("region_code", StandardBasicTypes.STRING )
 							.list();
 					assertEquals( 2, l.size() );
 
@@ -217,7 +217,7 @@ public class NativeSQLQueriesTest {
 				session -> {
 					List l = session.createNativeQuery( "select {org.*}, {emp.*} " +
 																"from ORGANIZATION org " +
-																"     left outer join EMPLOYMENT emp on org.ORGID = emp.EMPLOYER, ORGANIZATION org2" )
+																"     left outer join EMPLOYMENT emp on org.orgid = emp.employer, ORGANIZATION org2" )
 							.addEntity("org", Organization.class)
 							.addJoin("emp", "org.employments")
 							.setResultListTransformer( new ResultListTransformer() {
@@ -324,7 +324,7 @@ public class NativeSQLQueriesTest {
 					Map m = (Map) result.get(0);
 					assertEquals( 2, result.size() );
 					assertEquals( 1, m.size() );
-					assertTrue( m.containsKey("NAME") );
+					assertTrue( m.containsKey("name") );
 				}
 		);
 
@@ -581,7 +581,7 @@ public class NativeSQLQueriesTest {
 					m = (Map) list.get(0);
 					assertTrue(m.containsKey("EMPID"));
 					assertTrue(m.containsKey("AMOUNT"));
-					assertTrue(m.containsKey("ENDDATE"));
+					assertTrue(m.containsKey("END_DATE"));
 					assertEquals(8, m.size());
 
 					list = session.createNativeQuery( getEmploymentSQLMixedScalarEntity() ).addScalar( "employerid" ).addEntity( Employment.class ).list();
@@ -686,18 +686,18 @@ public class NativeSQLQueriesTest {
 		scope.inTransaction(
 				session -> {
 					String sql =
-							"SELECT org.ORGID 		as orgid," +
-									"       org.NAME 		as name," +
-									"       emp.EMPID 		as empid," +
-									"       emp.EMPLOYEE 	as employee," +
-									"       emp.EMPLOYER 	as employer," +
-									"       emp.STARTDATE 	as startDate," +
-									"       emp.ENDDATE 	as endDate," +
-									"       emp.REGIONCODE 	as regionCode," +
-									"       emp.AMOUNT 		as AMOUNT," +
-									"       emp.CURRENCY 	as CURRENCY" +
+							"SELECT org.orgid 		as orgid," +
+									"       org.name 		as name," +
+									"       emp.empid 		as empid," +
+									"       emp.employee 	as employee," +
+									"       emp.employer 	as employer," +
+									"       emp.start_date 	as start_date," +
+									"       emp.end_date 	as end_date," +
+									"       emp.region_code 	as region_code," +
+									"       emp.amount 		as amount," +
+									"       emp.currency 	as currency" +
 									" FROM 	ORGANIZATION org" +
-									"    LEFT OUTER JOIN EMPLOYMENT emp ON org.ORGID = emp.EMPLOYER";
+									"    LEFT OUTER JOIN EMPLOYMENT emp ON org.orgid = emp.employer";
 
 					// as a control, lets apply an existing rs mapping
 					NativeQuery sqlQuery = session.createNativeQuery( sql, "org-description" );
@@ -759,7 +759,7 @@ public class NativeSQLQueriesTest {
 					session.flush();
 					session.clear();
 
-					List l = session.createNativeQuery( "select name, id, flength, name as scalarName from Speech", "speech" ).list();
+					List l = session.createNativeQuery( "select name, id, flength, name as scalar_name from Speech", "speech" ).list();
 					assertEquals( l.size(), 1 );
 
 					t.rollback();

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/type/LongListTypeContributorTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/type/LongListTypeContributorTest.java
@@ -70,7 +70,7 @@ public class LongListTypeContributorTest extends EntityManagerFactoryBasedFuncti
 		inTransaction( em -> {
 
 			SpecialItem item = (SpecialItem) em.createNativeQuery(
-							"SELECT * FROM special_table WHERE longList = ?", SpecialItem.class )
+							"SELECT * FROM special_table WHERE long_list = ?", SpecialItem.class )
 					.setParameter( 1, longList )
 					.getSingleResult();
 
@@ -79,7 +79,7 @@ public class LongListTypeContributorTest extends EntityManagerFactoryBasedFuncti
 
 		inTransaction( em -> {
 			SpecialItem item = (SpecialItem) em.createNativeQuery(
-							"SELECT * FROM special_table WHERE longList = :longList", SpecialItem.class )
+							"SELECT * FROM special_table WHERE long_list = :longList", SpecialItem.class )
 					.setParameter( "longList", longList )
 					.getSingleResult();
 
@@ -95,7 +95,7 @@ public class LongListTypeContributorTest extends EntityManagerFactoryBasedFuncti
 		@Column(length = 30)
 		private String name;
 
-		@Column(columnDefinition = "VARCHAR(255)")
+		@Column(name = "long_list", columnDefinition = "VARCHAR(255)")
 		private LongList longList;
 
 		public SpecialItem() {

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/typeparameters/TypeParameterTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/typeparameters/TypeParameterTest.java
@@ -68,7 +68,7 @@ public class TypeParameterTest {
 				new Work() {
 					@Override
 					public void execute(Connection connection) throws SQLException {
-						final String sql = "SELECT * FROM STRANGE_TYPED_OBJECT WHERE ID=?";
+						final String sql = "SELECT * FROM STRANGE_TYPED_OBJECT WHERE id=?";
 						PreparedStatement statement = ( (SessionImplementor) s ).getJdbcCoordinator()
 								.getStatementPreparer()
 								.prepareStatement( sql );
@@ -80,16 +80,16 @@ public class TypeParameterTest {
 						assertTrue( "A row should have been returned", resultSet.next() );
 						assertTrue(
 								"Default value should have been mapped to null",
-								resultSet.getObject( "VALUE_ONE" ) == null
+								resultSet.getObject( "value_one" ) == null
 						);
 						assertTrue(
 								"Default value should have been mapped to null",
-								resultSet.getObject( "VALUE_TWO" ) == null
+								resultSet.getObject( "value_two" ) == null
 						);
-						assertEquals( "Non-Default value should not be changed", resultSet.getInt( "VALUE_THREE" ), 5 );
+						assertEquals( "Non-Default value should not be changed", resultSet.getInt( "value_three" ), 5 );
 						assertTrue(
 								"Default value should have been mapped to null",
-								resultSet.getObject( "VALUE_FOUR" ) == null
+								resultSet.getObject( "value_four" ) == null
 						);
 					}
 				}

--- a/hibernate-core/src/test/resources/org/hibernate/orm/test/annotations/idclass/xml/HabitatSpeciesLink.xml
+++ b/hibernate-core/src/test/resources/org/hibernate/orm/test/annotations/idclass/xml/HabitatSpeciesLink.xml
@@ -15,14 +15,14 @@
                 class="org.hibernate.orm.test.annotations.idclass.xml.HabitatSpeciesLink$HabitatSpeciesLinkId"/>
         <named-native-query name="testQuery"
                             result-class="org.hibernate.orm.test.annotations.idclass.xml.HabitatSpeciesLink">
-            <query>select * from HABITAT_SPECIES_LINK link where link.HABITAT_LINK = 1</query>
+            <query>select * from HABITAT_SPECIES_LINK link where link.habitat_link = 1</query>
         </named-native-query>
         <attributes>
             <id name="habitatId">
-                <column name="HABITAT_LINK"/>
+                <column name="habitat_link"/>
             </id>
             <id name="speciesId">
-                <column name="SPECIES_LINK"/>
+                <column name="species_link"/>
             </id>
         </attributes>
     </entity>

--- a/hibernate-core/src/test/resources/org/hibernate/orm/test/sql/hand/query/NativeSQLQueries.hbm.xml
+++ b/hibernate-core/src/test/resources/org/hibernate/orm/test/sql/hand/query/NativeSQLQueries.hbm.xml
@@ -18,51 +18,51 @@
 <hibernate-mapping package="org.hibernate.orm.test.sql.hand" default-access="field">
 	   
 	<class name="Organization" table="ORGANIZATION">
-		<id name="id" unsaved-value="0" column="ORGID">
+		<id name="id" unsaved-value="0" column="orgid">
 			<generator class="increment"/>
 		</id>
-		<property name="name" column="NAME" not-null="true"/>
+		<property name="name" column="name" not-null="true"/>
 		<set lazy="true" name="employments" 
 			inverse="true">
-			<key column="EMPLOYER"/> <!-- only needed for DDL generation -->
+			<key column="employer"/> <!-- only needed for DDL generation -->
 			<one-to-many class="Employment"/>
 		</set>
 	</class>
 	
 	<class name="Person" table="PERSON">
-		<id name="id" unsaved-value="0" column="PERID">
+		<id name="id" unsaved-value="0" column="perid">
 			<generator class="increment"/>
 		</id>
-		<property name="name" column="NAME" not-null="true"/>
+		<property name="name" column="name" not-null="true"/>
 	</class>
 
 	<class name="Group" table="GROUPP">
-		<id name="id" unsaved-value="0" column="ID">
+		<id name="id" unsaved-value="0" column="id">
 			<generator class="increment"/>
 		</id>
-		<property name="name" column="NAME" not-null="true"/>
+		<property name="name" column="name" not-null="true"/>
 		<list name="persons" table="GROUP_PERSON"
 			cascade="none" inverse="false" lazy="true">
-			<key column="GROUP_ID"	/>
-			<list-index column="POS" />
-			<many-to-many class="Person" column="PERSON_ID" />
+			<key column="group_id"	/>
+			<list-index column="pos" />
+			<many-to-many class="Person" column="person_id" />
 		</list>
 	</class>
 	
 	<class name="Employment" table="EMPLOYMENT">
-		<id name="employmentId" unsaved-value="0" column="EMPID">
+		<id name="employmentId" unsaved-value="0" column="empid">
 			<generator class="increment"/>
 		</id>
-		<many-to-one name="employee" column="EMPLOYEE" not-null="true" update="false"/>
-		<many-to-one name="employer" column="EMPLOYER" not-null="true" update="false"/>
-		<property name="startDate" column="STARTDATE" not-null="false"/>
-		<property name="endDate" column="ENDDATE" insert="false"/>
-		<property name="regionCode" column="REGIONCODE" update="false"/>
+		<many-to-one name="employee" column="employee" not-null="true" update="false"/>
+		<many-to-one name="employer" column="employer" not-null="true" update="false"/>
+		<property name="startDate" column="start_date" not-null="false"/>
+		<property name="endDate" column="end_date" insert="false"/>
+		<property name="regionCode" column="region_code" update="false"/>
 		<component name="salary" class="org.hibernate.orm.test.sql.hand.MonetaryAmountUserType">
-			<property name="value" column="AMOUNT">
+			<property name="value" column="amount">
 				<type name="float"/>
 			</property>
-			<property name="currency" column="CURRENCY"/>
+			<property name="currency" column="currency"/>
 		</component>
 	</class>
 	
@@ -73,8 +73,8 @@
 	  </composite-id>
 	  
 	  <many-to-one name="product">
-	    <column name="PROD_ORGID"/>
-	    <column name="PROD_NO"/>
+	    <column name="prod_orgid"/>
+	    <column name="prod_no"/>
 	  </many-to-one>
 	  <many-to-one name="person"/>
 	</class>
@@ -89,8 +89,8 @@
 	  
 	  <set name="orders" inverse="true">
 	  	<key>
-	  		<column name="PROD_ORGID"/>
-	  		<column name="PROD_NO"/>	  		
+	  		<column name="prod_orgid"/>
+	  		<column name="prod_no"/>
 	  	</key>
 	  	<one-to-many class="Order"/>
 	  </set>
@@ -129,18 +129,18 @@
         <id name="id" column="id">
             <generator class="increment"/>
         </id>
-        <property name="description" column="DESCRIPTION" type="text" length="15000"/>
+        <property name="description" column="description" type="text" length="15000"/>
     </class>
 
     <class name="ImageHolder" table="IMAGE_HOLDER">
         <id name="id" column="id">
             <generator class="increment"/>
         </id>
-        <property name="photo" column="PHOTO" type="image" length="15000"/>
+        <property name="photo" column="photo" type="image" length="15000"/>
     </class>    
 
     <resultset name="org-emp-regionCode">
-        <return-scalar column="regionCode" type="string"/>
+        <return-scalar column="region_code" type="string"/>
         <return alias="org" class="Organization"/>
         <return-join alias="emp" property="org.employments"/>
     </resultset>
@@ -176,7 +176,7 @@
             <return-property name="name" column="name"/>
             <return-property name="length" column="flength"/>
         </return>
-        <return-scalar column="scalarName"/>
+        <return-scalar column="scalar_name"/>
     </resultset>
 
     <sql-query name="spaceship" resultset-ref="spaceship-vol">
@@ -192,14 +192,14 @@
 	</sql-query>
 
     <sql-query name="orgNamesOnly">
-		<return-scalar column="NAME" type="string"/>
-		SELECT org.NAME FROM ORGANIZATION org
+		<return-scalar column="name" type="string"/>
+		SELECT org.name FROM ORGANIZATION org
 	</sql-query>
 
 	<sql-query name="orgNamesAndOrgs">
 		<return-scalar column="thename" type="string"/>
 		<return alias="org" class="Organization"/>
-		SELECT org.NAME AS thename, org.NAME AS {org.name}, org.ORGID AS {org.id} 
+		SELECT org.name AS thename, org.name AS {org.name}, org.orgid AS {org.id}
 		FROM ORGANIZATION org
 		ORDER BY thename
 	</sql-query>
@@ -207,7 +207,7 @@
 	<sql-query name="orgsAndOrgNames">
 		<return alias="org" class="Organization"/>
 		<return-scalar column="thename" type="string"/>
-		SELECT org.NAME AS thename, org.NAME AS {org.name}, org.ORGID AS {org.id} 
+		SELECT org.name AS thename, org.name AS {org.name}, org.orgid AS {org.id}
 		FROM ORGANIZATION org
 		ORDER BY thename
 	</sql-query>	
@@ -215,7 +215,7 @@
 	<sql-query name="orgIdsAndOrgNames">
 		<return-scalar column="orgid" type="long"/>
 		<return-scalar column="thename" type="string"/>
-		SELECT NAME AS thename, ORGID AS orgid
+		SELECT name AS thename, orgid AS orgid
 		FROM ORGANIZATION
 		ORDER BY thename
 	</sql-query>
@@ -233,82 +233,82 @@
 
 	<sql-query name="organizationEmploymentsExplicitAliases">
 		<load-collection alias="empcol" role="Organization.employments"/>
-		SELECT empcol.EMPLOYER as {empcol.key}, empcol.EMPID as {empcol.element}, {empcol.element.*} 
+		SELECT empcol.employer as {empcol.key}, empcol.empid as {empcol.element}, {empcol.element.*}
 		FROM EMPLOYMENT empcol
-		WHERE EMPLOYER = :id
-		ORDER BY STARTDATE ASC, EMPLOYEE ASC
+		WHERE employer = :id
+		ORDER BY start_date ASC, employee ASC
 	</sql-query>	
 
 	<sql-query name="organizationreturnproperty">
 		<return alias="org" class="Organization">
-            <return-property name="id" column="ORGID"/>
-            <return-property name="name" column="NAME"/>
+            <return-property name="id" column="orgid"/>
+            <return-property name="name" column="name"/>
 		</return>
 		<return-join alias="emp" property="org.employments">
-			<return-property name="key" column="EMPLOYER"/>
-			<return-property name="element" column="EMPID"/>			
-			<return-property name="element.employee" column="EMPLOYEE"/>
-			<return-property name="element.employer" column="EMPLOYER"/>			
-			<return-property name="element.startDate" column="XSTARTDATE"/>
-			<return-property name="element.endDate" column="ENDDATE"/>			
-			<return-property name="element.regionCode" column="REGIONCODE"/>			
-			<return-property name="element.employmentId" column="EMPID"/>						
-			<return-property name="element.salary.value" column="AMOUNT1"/>
-			<return-property name="element.salary.currency" column="CURRENCY"/>
+			<return-property name="key" column="employer"/>
+			<return-property name="element" column="empid"/>
+			<return-property name="element.employee" column="employee"/>
+			<return-property name="element.employer" column="employer"/>
+			<return-property name="element.startDate" column="xstart_date"/>
+			<return-property name="element.endDate" column="end_date"/>
+			<return-property name="element.regionCode" column="region_code"/>
+			<return-property name="element.employmentId" column="empid"/>
+			<return-property name="element.salary.value" column="amount1"/>
+			<return-property name="element.salary.currency" column="currency"/>
 		</return-join>
-		SELECT org.ORGID as orgid,
-            org.NAME as name,
-            emp.EMPID as empid,
-            emp.EMPLOYEE as employee,
-            emp.EMPLOYER as employer,
-            emp.STARTDATE as xstartDate,
-            emp.ENDDATE as endDate,
-            emp.REGIONCODE as regionCode,
-            emp.AMOUNT as AMOUNT1,
-            emp.CURRENCY as CURRENCY
+		SELECT org.orgid as orgid,
+            org.name as name,
+            emp.empid as empid,
+            emp.employee as employee,
+            emp.employer as employer,
+            emp.start_date as xstart_date,
+            emp.end_date as end_date,
+            emp.region_code as region_code,
+            emp.amount as amount1,
+            emp.currency as currency
         FROM ORGANIZATION org
-			LEFT OUTER JOIN EMPLOYMENT emp ON org.ORGID = emp.EMPLOYER
-		ORDER BY org.NAME DESC
+			LEFT OUTER JOIN EMPLOYMENT emp ON org.orgid = emp.employer
+		ORDER BY org.name DESC
 	</sql-query>
 
     
 	<sql-query name="organizationautodetect" resultset-ref="org-description">
 	<!--  equal to "organizationpropertyreturn" but since no {} nor return-property are used hibernate will fallback to use the columns directly from the mapping -->
-        SELECT org.ORGID as orgid,
-            org.NAME as name,
-            emp.EMPID as empid,
-            emp.EMPLOYEE as employee,
-            emp.EMPLOYER as employer,
-            emp.STARTDATE as startDate,
-            emp.ENDDATE as endDate,
-            emp.REGIONCODE as regionCode,
-            emp.AMOUNT as AMOUNT,
-            emp.CURRENCY as CURRENCY
+        SELECT org.orgid as orgid,
+            org.name as name,
+            emp.empid as empid,
+            emp.employee as employee,
+            emp.employer as employer,
+            emp.start_date as start_date,
+            emp.end_date as end_date,
+            emp.region_code as region_code,
+            emp.amount as amount,
+            emp.currency as currency
 		FROM ORGANIZATION org
-			LEFT OUTER JOIN EMPLOYMENT emp ON org.ORGID = emp.EMPLOYER
+			LEFT OUTER JOIN EMPLOYMENT emp ON org.orgid = emp.employer
 	</sql-query>
 
 	<sql-query name="manyToManyFetch">
         <![CDATA[
-        	SELECT 	groupp.ID as group_id,
-        			groupp.NAME as group_name,
-        			group_person.PERSON_ID as group_person_personId,
-        			group_person.GROUP_ID as group_person_groupId,
-        			group_person.POS as group_person_pos,
-        			person.PERID as person_id,
-        			person.NAME as person_name
+        	SELECT 	groupp.id as group_id,
+        			groupp.name as group_name,
+        			group_person.person_id as group_person_person_id,
+        			group_person.group_id as group_person_group_id,
+        			group_person.pos as group_person_pos,
+        			person.perid as person_id,
+        			person.name as person_name
 			FROM 	GROUPP groupp,
 					GROUP_PERSON group_person,
 					PERSON person
-			WHERE 	groupp.ID = group_person.GROUP_ID
-					and person.PERID = group_person.PERSON_ID
+			WHERE 	groupp.id = group_person.group_id
+					and person.perid = group_person.person_id
        ]]>
         <return alias="groupp" class="Group">
             <return-property name="id" column="group_id" />
             <return-property name="name" column="group_name" />
         </return>
         <return-join alias="group_person" property="groupp.persons">
-            <return-property name="key" column="group_person_groupId" />
+            <return-property name="key" column="group_person_group_id" />
             <return-property name="index" column="group_person_pos" />
             <return-property name="element" column="person_id" />
             <return-property name="element.id" column="person_id" />

--- a/hibernate-core/src/test/resources/org/hibernate/orm/test/stateless/Document.hbm.xml
+++ b/hibernate-core/src/test/resources/org/hibernate/orm/test/stateless/Document.hbm.xml
@@ -19,7 +19,7 @@
 
 	<class name="Document">
 		<id name="name"/>
-		<timestamp name="lastModified"/>
+		<timestamp name="lastModified" column="last_modified"/>
 		<property name="text"/>
 	</class>
 

--- a/hibernate-core/src/test/resources/org/hibernate/orm/test/typeparameters/Widget.hbm.xml
+++ b/hibernate-core/src/test/resources/org/hibernate/orm/test/typeparameters/Widget.hbm.xml
@@ -15,17 +15,17 @@
 	</typedef>
 
     <class name="Widget" table="STRANGE_TYPED_OBJECT">
-        <id name="id" column="ID">
+        <id name="id" column="id">
             <generator class="increment"/>
         </id>
-        <property name="valueOne" column="VALUE_ONE">
+        <property name="valueOne" column="value_one">
 			<type name="org.hibernate.orm.test.typeparameters.DefaultValueIntegerType">
 				<param name="default">1</param>
 			</type>
 		</property>
-        <property name="valueTwo" column="VALUE_TWO" type="nullToTwo"/>
-        <property name="valueThree" column="VALUE_THREE" type="nullToMinusOne"/>
-        <property name="valueFour" column="VALUE_FOUR">
+        <property name="valueTwo" column="value_two" type="nullToTwo"/>
+        <property name="valueThree" column="value_three" type="nullToMinusOne"/>
+        <property name="valueFour" column="value_four">
 			<type name="nullToTwo">
 				<param name="default">-5</param>
 			</type>

--- a/hibernate-envers/src/test/java/org/hibernate/orm/test/envers/integration/multiplerelations/GroupMemberTest.java
+++ b/hibernate-envers/src/test/java/org/hibernate/orm/test/envers/integration/multiplerelations/GroupMemberTest.java
@@ -88,9 +88,9 @@ public class GroupMemberTest extends BaseEnversJPAFunctionalTestCase {
 		return TransactionUtil.doInJPA( this::entityManagerFactory, entityManager -> {
 			final Session session = entityManager.unwrap( Session.class );
 			final Query query = session.createNativeQuery(
-							"SELECT uniqueGroup_id FROM GroupMember_AUD ORDER BY REV DESC"
+							"SELECT unique_group_id FROM GroupMember_AUD ORDER BY REV DESC"
 					)
-					.addScalar( "uniqueGroup_id", StandardBasicTypes.INTEGER )
+					.addScalar( "unique_group_id", StandardBasicTypes.INTEGER )
 					.setMaxResults( 1 );
 			final Object result = query.getSingleResult();
 			assertNotNull( result );
@@ -106,7 +106,7 @@ public class GroupMemberTest extends BaseEnversJPAFunctionalTestCase {
 		private Integer id;
 
 		@ManyToOne
-		@JoinColumn(name = "uniqueGroup_id", insertable = false, updatable = false)
+		@JoinColumn(name = "unique_group_id", insertable = false, updatable = false)
 		private UniqueGroup uniqueGroup;
 
 		@ManyToMany(mappedBy = "members")
@@ -150,7 +150,7 @@ public class GroupMemberTest extends BaseEnversJPAFunctionalTestCase {
 		private Integer id;
 
 		@OneToMany
-		@JoinColumn(name = "uniqueGroup_id")
+		@JoinColumn(name = "unique_group_id")
 		@AuditMappedBy(mappedBy = "uniqueGroup")
 		private Set<GroupMember> members = new HashSet<>();
 

--- a/hibernate-envers/src/test/java/org/hibernate/orm/test/envers/integration/nativequery/SimpleEntity.java
+++ b/hibernate-envers/src/test/java/org/hibernate/orm/test/envers/integration/nativequery/SimpleEntity.java
@@ -6,6 +6,7 @@
  */
 package org.hibernate.orm.test.envers.integration.nativequery;
 
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
@@ -22,6 +23,7 @@ public class SimpleEntity {
 	@GeneratedValue
 	private Long id;
 
+	@Column(name = "string_field")
 	private String stringField;
 
 	public SimpleEntity() {

--- a/hibernate-testing/src/main/java/org/hibernate/testing/orm/domain/gambit/EntityOfBasics.java
+++ b/hibernate-testing/src/main/java/org/hibernate/testing/orm/domain/gambit/EntityOfBasics.java
@@ -98,6 +98,7 @@ public class EntityOfBasics {
 		this.id = id;
 	}
 
+	@Column(name = "the_string")
 	public String getTheString() {
 		return theString;
 	}
@@ -106,6 +107,7 @@ public class EntityOfBasics {
 		this.theString = theString;
 	}
 
+	@Column(name = "the_integer")
 	public Integer getTheInteger() {
 		return theInteger;
 	}
@@ -114,6 +116,7 @@ public class EntityOfBasics {
 		this.theInteger = theInteger;
 	}
 
+	@Column(name = "the_int")
 	public int getTheInt() {
 		return theInt;
 	}
@@ -122,6 +125,7 @@ public class EntityOfBasics {
 		this.theInt = theInt;
 	}
 
+	@Column(name = "the_short")
 	public short getTheShort() {
 		return theShort;
 	}
@@ -130,6 +134,7 @@ public class EntityOfBasics {
 		this.theShort = theShort;
 	}
 
+	@Column(name = "the_double")
 	public double getTheDouble() {
 		return theDouble;
 	}
@@ -138,6 +143,7 @@ public class EntityOfBasics {
 		this.theDouble = theDouble;
 	}
 
+	@Column(name = "the_url")
 	public URL getTheUrl() {
 		return theUrl;
 	}
@@ -146,6 +152,7 @@ public class EntityOfBasics {
 		this.theUrl = theUrl;
 	}
 
+	@Column(name = "the_clob")
 	public Clob getTheClob() {
 		return theClob;
 	}
@@ -164,7 +171,7 @@ public class EntityOfBasics {
 	}
 
 	@Enumerated( EnumType.STRING )
-	@Column( length = 1 )
+	@Column( name = "single_char_gender", length = 1 )
 	public Gender getSingleCharGender() {
 		return singleCharGender;
 	}
@@ -193,6 +200,7 @@ public class EntityOfBasics {
 		this.ordinalGender = ordinalGender;
 	}
 
+	@Column(name = "the_date")
 	@Temporal( TemporalType.DATE )
 	public Date getTheDate() {
 		return theDate;
@@ -202,6 +210,7 @@ public class EntityOfBasics {
 		this.theDate = theDate;
 	}
 
+	@Column(name = "the_time")
 	@Temporal( TemporalType.TIME )
 	public Date getTheTime() {
 		return theTime;
@@ -211,6 +220,7 @@ public class EntityOfBasics {
 		this.theTime = theTime;
 	}
 
+	@Column(name = "the_timestamp")
 	@Temporal( TemporalType.TIMESTAMP )
 	public Date getTheTimestamp() {
 		return theTimestamp;
@@ -220,6 +230,7 @@ public class EntityOfBasics {
 		this.theTimestamp = theTimestamp;
 	}
 
+	@Column(name = "the_instant")
 	@Temporal( TemporalType.TIMESTAMP )
 	public Instant getTheInstant() {
 		return theInstant;
@@ -229,6 +240,7 @@ public class EntityOfBasics {
 		this.theInstant = theInstant;
 	}
 
+	@Column(name = "the_local_date_time")
 	public LocalDateTime getTheLocalDateTime() {
 		return theLocalDateTime;
 	}
@@ -237,6 +249,7 @@ public class EntityOfBasics {
 		this.theLocalDateTime = theLocalDateTime;
 	}
 
+	@Column(name = "the_local_date")
 	public LocalDate getTheLocalDate() {
 		return theLocalDate;
 	}
@@ -245,6 +258,7 @@ public class EntityOfBasics {
 		this.theLocalDate = theLocalDate;
 	}
 
+	@Column(name = "the_local_time")
 	public LocalTime getTheLocalTime() {
 		return theLocalTime;
 	}
@@ -253,6 +267,7 @@ public class EntityOfBasics {
 		this.theLocalTime = theLocalTime;
 	}
 
+	@Column(name = "the_offset_date_time")
 	public OffsetDateTime getTheOffsetDateTime() {
 		return theOffsetDateTime;
 	}
@@ -261,6 +276,7 @@ public class EntityOfBasics {
 		this.theOffsetDateTime = theOffsetDateTime;
 	}
 
+	@Column(name = "the_zoned_date_time")
 	public ZonedDateTime getTheZonedDateTime() {
 		return theZonedDateTime;
 	}
@@ -269,6 +285,7 @@ public class EntityOfBasics {
 		this.theZonedDateTime = theZonedDateTime;
 	}
 
+	@Column(name = "the_duration")
 	public Duration getTheDuration() {
 		return theDuration;
 	}
@@ -286,6 +303,7 @@ public class EntityOfBasics {
 		this.theUuid = theUuid;
 	}
 
+	@Column(name = "the_boolean")
 	public Boolean isTheBoolean() {
 		return theBoolean;
 	}
@@ -294,6 +312,7 @@ public class EntityOfBasics {
 		this.theBoolean = theBoolean;
 	}
 
+	@Column(name = "the_numeric_boolean")
 	@JdbcTypeCode( Types.INTEGER )
 	public Boolean isTheNumericBoolean() {
 		return theNumericBoolean;
@@ -303,6 +322,7 @@ public class EntityOfBasics {
 		this.theNumericBoolean = theNumericBoolean;
 	}
 
+	@Column(name = "the_string_boolean")
 	@JdbcTypeCode( Types.CHAR )
 	public Boolean isTheStringBoolean() {
 		return theStringBoolean;
@@ -322,6 +342,7 @@ public class EntityOfBasics {
 	}
 
 	@Convert( converter = MutableValueConverter.class )
+	@Column(name = "mutable_value")
 	public MutableValue getMutableValue() {
 		return mutableValue;
 	}

--- a/hibernate-testing/src/main/java/org/hibernate/testing/orm/domain/userguide/CreditCardPayment.java
+++ b/hibernate-testing/src/main/java/org/hibernate/testing/orm/domain/userguide/CreditCardPayment.java
@@ -6,6 +6,7 @@
  */
 package org.hibernate.testing.orm.domain.userguide;
 
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 
 /**
@@ -14,6 +15,7 @@ import jakarta.persistence.Entity;
 //tag::hql-examples-domain-model-example[]
 @Entity
 public class CreditCardPayment extends Payment {
+	@Column(name = "card_number")
 	String cardNumber;
 
 	public void setCardNumber(String cardNumber) {

--- a/hibernate-testing/src/main/java/org/hibernate/testing/orm/domain/userguide/Person.java
+++ b/hibernate-testing/src/main/java/org/hibernate/testing/orm/domain/userguide/Person.java
@@ -13,6 +13,7 @@ import java.util.List;
 import java.util.Map;
 
 import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
 import jakarta.persistence.ColumnResult;
 import jakarta.persistence.ConstructorResult;
 import jakarta.persistence.ElementCollection;
@@ -52,7 +53,7 @@ import jakarta.persistence.Version;
 		query =
 				"SELECT " +
 						"   name, " +
-						"   nickName " +
+						"   nick_name " +
 						"FROM Person "
 )
 //end::sql-multiple-scalar-values-NamedNativeQuery-example[]
@@ -62,7 +63,7 @@ import jakarta.persistence.Version;
 		query =
 				"select " +
 						"   name, " +
-						"   nickName " +
+						"   nick_name " +
 						"from Person ",
 		resultSetMapping = "name_and_nickName_dto"
 )
@@ -74,9 +75,9 @@ import jakarta.persistence.Version;
 				"select " +
 						"   p.id AS \"id\", " +
 						"   p.name AS \"name\", " +
-						"   p.nickName AS \"nickName\", " +
+						"   p.nick_name AS \"nick_name\", " +
 						"   p.address AS \"address\", " +
-						"   p.createdOn AS \"createdOn\", " +
+						"   p.created_on AS \"created_on\", " +
 						"   p.version AS \"version\" " +
 						"from Person p " +
 						"where p.name LIKE :name",
@@ -90,9 +91,9 @@ import jakarta.persistence.Version;
 				"select " +
 						"   pr.id AS \"pr.id\", " +
 						"   pr.name AS \"pr.name\", " +
-						"   pr.nickName AS \"pr.nickName\", " +
+						"   pr.nick_name AS \"pr.nick_name\", " +
 						"   pr.address AS \"pr.address\", " +
-						"   pr.createdOn AS \"pr.createdOn\", " +
+						"   pr.created_on AS \"pr.created_on\", " +
 						"   pr.version AS \"pr.version\", " +
 						"   ph.id AS \"ph.id\", " +
 						"   ph.person_id AS \"ph.person_id\", " +
@@ -113,9 +114,9 @@ import jakarta.persistence.Version;
 						fields = {
 								@FieldResult( name = "id", column = "pr.id" ),
 								@FieldResult( name = "name", column = "pr.name" ),
-								@FieldResult( name = "nickName", column = "pr.nickName" ),
+								@FieldResult( name = "nickName", column = "pr.nick_name" ),
 								@FieldResult( name = "address", column = "pr.address" ),
-								@FieldResult( name = "createdOn", column = "pr.createdOn" ),
+								@FieldResult( name = "createdOn", column = "pr.created_on" ),
 								@FieldResult( name = "version", column = "pr.version" ),
 						}
 				),
@@ -138,7 +139,7 @@ import jakarta.persistence.Version;
 				targetClass = PersonNames.class,
 				columns = {
 						@ColumnResult(name = "name"),
-						@ColumnResult(name = "nickName")
+						@ColumnResult(name = "nick_name")
 				}
 		)
 )
@@ -193,10 +194,12 @@ public class Person {
 
 	private String name;
 
+	@Column(name = "nick_name")
 	private String nickName;
 
 	private String address;
 
+	@Column(name = "created_on")
 	private LocalDateTime createdOn;
 
 	@OneToMany(mappedBy = "person", cascade = CascadeType.ALL)

--- a/hibernate-testing/src/main/java/org/hibernate/testing/orm/domain/userguide/PersonPhoneCount.java
+++ b/hibernate-testing/src/main/java/org/hibernate/testing/orm/domain/userguide/PersonPhoneCount.java
@@ -6,6 +6,8 @@
  */
 package org.hibernate.testing.orm.domain.userguide;
 
+import jakarta.persistence.Column;
+
 /**
  * @author Vlad Mihalcea
  */
@@ -13,6 +15,7 @@ public class PersonPhoneCount {
 
 	private final String name;
 
+	@Column(name = "phone_count")
 	private final Number phoneCount;
 
 	public PersonPhoneCount(String name, Number phoneCount) {

--- a/hibernate-testing/src/main/java/org/hibernate/testing/orm/domain/userguide/Phone.java
+++ b/hibernate-testing/src/main/java/org/hibernate/testing/orm/domain/userguide/Phone.java
@@ -46,7 +46,7 @@ import jakarta.persistence.SqlResultSetMapping;
 //tag::sql-multiple-scalar-values-dto-NamedNativeQuery-hibernate-example[]
 @NamedNativeQuery(
 		name = "get_person_phone_count",
-		query = "select pr.name AS name, count(*) AS phoneCount " +
+		query = "select pr.name AS name, count(*) AS phone_count " +
 				"from Phone p " +
 				"join Person pr ON pr.id = p.person_id " +
 				"group BY pr.name",
@@ -60,7 +60,7 @@ import jakarta.persistence.SqlResultSetMapping;
 				targetClass = PersonPhoneCount.class,
 				columns = {
 						@ColumnResult(name = "name"),
-						@ColumnResult(name = "phoneCount")
+						@ColumnResult(name = "phone_count")
 				}
 		)
 )


### PR DESCRIPTION
Some unit tests with Informix are failing because Informix interprets identifiers in lowercase. Setting the physical naming strategy globally for all unit tests also doesn't make sense because many tests have hardcoded expected values. The solution is to change the column mapping in problematic tests to lowercase values to accommodate all dialects.

https://www.ibm.com/docs/en/informix-servers/12.10?topic=variable-specify-field-names

This topic was discussed here: https://hibernate.zulipchat.com/#narrow/stream/132096-hibernate-user/topic/Global.20hibernate.20properties.20for.20unit.20tests