### PR TITLE
HHH-18296 When JDBC drivers generate SQLWarnings with a "success" SQLState, log that at a lower level than WARN

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/dialect/temptable/TemporaryTableHelper.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/temptable/TemporaryTableHelper.java
@@ -188,7 +188,7 @@ public class TemporaryTableHelper {
 		}
 
 		@Override
-		protected void logWarning(String description, String message) {
+		protected void log(String sqlState, String description, String message) {
 			log.debug( description );
 			log.debug( message );
 		}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/schemagen/SchemaCreateDropExtraWarningsTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/schemagen/SchemaCreateDropExtraWarningsTest.java
@@ -1,0 +1,52 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.orm.test.jpa.schemagen;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.hibernate.SessionFactory;
+import org.hibernate.dialect.PostgreSQLDialect;
+import org.hibernate.engine.jdbc.spi.SqlExceptionHelper;
+
+import org.hibernate.testing.orm.junit.EntityManagerFactoryScope;
+import org.hibernate.testing.orm.junit.JiraKey;
+import org.hibernate.testing.orm.junit.Jpa;
+import org.hibernate.testing.orm.junit.Logger;
+import org.hibernate.testing.orm.junit.MessageKeyInspection;
+import org.hibernate.testing.orm.junit.MessageKeyWatcher;
+import org.hibernate.testing.orm.junit.RequiresDialect;
+import org.junit.jupiter.api.Test;
+
+import org.jboss.logging.Logger.Level;
+
+@JiraKey("HHH-18296")
+@Jpa(annotatedClasses = {
+		Document.class
+})
+@RequiresDialect(value = PostgreSQLDialect.class, comment = "Only the PostgreSQL driver is known to generate 'success' warnings on table drop")
+@MessageKeyInspection(messageKey = "SQL Warning", logger = @Logger(loggerNameClass = SqlExceptionHelper.class))
+public class SchemaCreateDropExtraWarningsTest {
+	@Test
+	public void testLogLevels(EntityManagerFactoryScope scope, MessageKeyWatcher watcher) {
+		// In order to reproduce the problem,
+		// we need a DDL DROP to be executed on entity tables that *do not exist*.
+		// The Hibernate startup should have executed one, but we cannot guarantee the tables didn't exist at that point.
+		// So we just run a DROP again: this time, we're sure the tables don't exist,
+		// and worst case we'll just get duplicate warnings, which assertions below should handle just fine.
+		scope.getEntityManagerFactory().unwrap( SessionFactory.class )
+				.getSchemaManager()
+				.dropMappedObjects( false );
+
+		assertThat( watcher.getTriggeredEvents() )
+				.isNotEmpty() // We do expect SQLWarnings with PostgreSQL
+				.allSatisfy( event -> assertThat( event.getLevel() )
+						// But these SQLWarnings are not technically warnings: their SQLState starts with 00,
+						// making them "success" messages.
+						// See https://en.wikipedia.org/wiki/SQLSTATE
+						.isEqualTo( Level.DEBUG ) );
+	}
+}

--- a/hibernate-testing/src/main/java/org/hibernate/testing/orm/junit/LoggingEvent.java
+++ b/hibernate-testing/src/main/java/org/hibernate/testing/orm/junit/LoggingEvent.java
@@ -1,0 +1,22 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html
+ */
+package org.hibernate.testing.orm.junit;
+
+import org.jboss.logging.Logger;
+
+/**
+ * An event caught by logging inspections.
+ *
+ * @see MessageKeyWatcher#getTriggeredEvents()
+ */
+public interface LoggingEvent {
+
+	Logger.Level getLevel();
+
+	String getMessage();
+
+}

--- a/hibernate-testing/src/main/java/org/hibernate/testing/orm/junit/LoggingEventImpl.java
+++ b/hibernate-testing/src/main/java/org/hibernate/testing/orm/junit/LoggingEventImpl.java
@@ -1,0 +1,37 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html
+ */
+package org.hibernate.testing.orm.junit;
+
+import org.jboss.logging.Logger;
+
+public class LoggingEventImpl implements LoggingEvent {
+	private final Logger.Level level;
+	private final String message;
+
+	public LoggingEventImpl(Logger.Level level, String message) {
+		this.level = level;
+		this.message = message;
+	}
+
+	@Override
+	public String toString() {
+		return "LoggingEventImpl{" +
+				"level=" + level +
+				", message='" + message + '\'' +
+				'}';
+	}
+
+	@Override
+	public Logger.Level getLevel() {
+		return level;
+	}
+
+	@Override
+	public String getMessage() {
+		return message;
+	}
+}

--- a/hibernate-testing/src/main/java/org/hibernate/testing/orm/junit/MessageKeyWatcher.java
+++ b/hibernate-testing/src/main/java/org/hibernate/testing/orm/junit/MessageKeyWatcher.java
@@ -7,6 +7,7 @@
 package org.hibernate.testing.orm.junit;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * @author Steve Ebersole
@@ -16,9 +17,19 @@ public interface MessageKeyWatcher {
 
 	boolean wasTriggered();
 
-	List<String> getTriggeredMessages();
+	List<LoggingEvent> getTriggeredEvents();
 
-	String getFirstTriggeredMessage();
+	default List<String> getTriggeredMessages() {
+		return getTriggeredEvents().stream().map( LoggingEvent::getMessage ).collect( Collectors.toList() );
+	}
+
+	LoggingEvent getFirstTriggeredEvent();
+
+	default String getFirstTriggeredMessage() {
+		LoggingEvent firstEvent = getFirstTriggeredEvent();
+		return firstEvent == null ? null : firstEvent.getMessage();
+	}
 
 	void reset();
+
 }

--- a/hibernate-testing/src/main/java/org/hibernate/testing/orm/junit/MessageKeyWatcherImpl.java
+++ b/hibernate-testing/src/main/java/org/hibernate/testing/orm/junit/MessageKeyWatcherImpl.java
@@ -15,12 +15,12 @@ import org.hibernate.testing.logger.LogListener;
 import org.jboss.logging.Logger;
 
 /**
- * MessageIdWatcher implementation
+ * MessageKeyWatcher implementation
  */
 public class MessageKeyWatcherImpl implements MessageKeyWatcher, LogListener {
 	private final String messageKey;
 	private final List<String> loggerNames = new ArrayList<>();
-	private final List<String> triggeredMessages = new ArrayList<>();
+	private final List<LoggingEvent> triggeredEvents = new ArrayList<>();
 
 	public MessageKeyWatcherImpl(String messageKey) {
 		this.messageKey = messageKey;
@@ -77,36 +77,36 @@ public class MessageKeyWatcherImpl implements MessageKeyWatcher, LogListener {
 
 	@Override
 	public boolean wasTriggered() {
-		return ! triggeredMessages.isEmpty();
+		return ! triggeredEvents.isEmpty();
 	}
 
 	@Override
-	public List<String> getTriggeredMessages() {
-		return triggeredMessages;
+	public List<LoggingEvent> getTriggeredEvents() {
+		return triggeredEvents;
 	}
 
 	@Override
-	public String getFirstTriggeredMessage() {
-		return triggeredMessages.isEmpty() ? null : triggeredMessages.get( 0 );
+	public LoggingEvent getFirstTriggeredEvent() {
+		return triggeredEvents.isEmpty() ? null : triggeredEvents.get( 0 );
 	}
 
 	@Override
 	public void reset() {
-		triggeredMessages.clear();
+		triggeredEvents.clear();
 	}
 
 	@Override
 	public void loggedEvent(Logger.Level level, String renderedMessage, Throwable thrown) {
 		if ( renderedMessage != null ) {
 			if ( renderedMessage.startsWith( messageKey ) ) {
-				triggeredMessages.add( renderedMessage );
+				triggeredEvents.add( new LoggingEventImpl( level, renderedMessage ) );
 			}
 		}
 	}
 
 	@Override
 	public String toString() {
-		return "MessageIdWatcherImpl{" +
+		return "MessageKeyWatcherImpl{" +
 				"messageKey='" + messageKey + '\'' +
 				", loggerNames=" + loggerNames +
 				'}';


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-18296

This gets rid of noise when dropping non-existing tables with the PostgreSQL JDBC driver in particular.

See also https://github.com/quarkusio/quarkus/issues/16204 and in particular https://github.com/quarkusio/quarkus/issues/16204#issuecomment-2182317973

I think the change is safe, because:

* the SQL state is `null` by default in `SQLWarning`, so a JDBC driver not setting it would get the current behavior.
* I wouldn't expect a JDBC driver to set the SQL state to a String starting with `00` by default, since the SQL state has clearly defined meaning.