### PR TITLE
Add a PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,15 @@
+<!--
+If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
+-->
+
+[Please describe here what your change is about]
+
+<!--
+Please read and do not remove the following lines:
+-->
+----------------------
+By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
+and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
+For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).
+
+----------------------


### PR DESCRIPTION
Add a PR template with the licensing confirmation. I've put it inside the block with lines, as in the case of ORM, the bot can add links to the description, and I think it does this by appending to the bottom of the description.