### PR TITLE
Reproducer for HHH-18306 Implicit instantiation of result type for queries with single selection item doesn't work in 6.6 with createQuery

### DIFF
--- a/hibernate-core/src/test/java/org/hibernate/orm/test/query/hql/ImplicitInstantiationTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/query/hql/ImplicitInstantiationTest.java
@@ -38,7 +38,7 @@ public class ImplicitInstantiationTest {
 	}
 
 	@Test
-	public void testRecordInstantiationWithoutAlias(SessionFactoryScope scope) {
+	public void testRecordInstantiationCreateSelectionQuery(SessionFactoryScope scope) {
 		scope.inTransaction(
 				session -> {
 					session.persist(new Thing(1L, "thing"));
@@ -51,7 +51,20 @@ public class ImplicitInstantiationTest {
 	}
 
 	@Test
-	public void testSqlRecordInstantiationWithoutAlias(SessionFactoryScope scope) {
+	public void testRecordInstantiationCreateQuery(SessionFactoryScope scope) {
+		scope.inTransaction(
+				session -> {
+					session.persist(new Thing(1L, "thing"));
+					Record result = session.createQuery("select id, upper(name) from Thing", Record.class).getSingleResult();
+					assertEquals( result.id(), 1L );
+					assertEquals( result.name(), "THING" );
+					session.getTransaction().setRollbackOnly();
+				}
+		);
+	}
+
+	@Test
+	public void testSqlRecordInstantiation(SessionFactoryScope scope) {
 		scope.inTransaction(
 				session -> {
 					session.persist(new Thing(1L, "thing"));

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/query/hql/ImplicitInstantiationTest2.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/query/hql/ImplicitInstantiationTest2.java
@@ -33,11 +33,23 @@ public class ImplicitInstantiationTest2 {
 	}
 
 	@Test
-	public void testRecordInstantiationWithoutAlias(SessionFactoryScope scope) {
+	public void testRecordInstantiationCreateSelectionQuery(SessionFactoryScope scope) {
 		scope.inTransaction(
 				session -> {
 					session.persist(new Thing(1L, "thing"));
 					Record result = session.createSelectionQuery("select upper(name) from Thing", Record.class).getSingleResult();
+					assertEquals( result.name(), "THING" );
+					session.getTransaction().setRollbackOnly();
+				}
+		);
+	}
+
+	@Test
+	public void testRecordInstantiationCreateQuery(SessionFactoryScope scope) {
+		scope.inTransaction(
+				session -> {
+					session.persist(new Thing(1L, "thing"));
+					Record result = session.createQuery("select upper(name) as name from Thing where name is not null", Record.class).getSingleResult();
 					assertEquals( result.name(), "THING" );
 					session.getTransaction().setRollbackOnly();
 				}


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-18306

This is not a fix, just a reproducer.

See  #8606 for proof it used to work in 6.5.