### PR TITLE
HHH-18312 Fix for Informix nationalized JDBC types support

### DIFF
--- a/docker_db.sh
+++ b/docker_db.sh
@@ -952,7 +952,7 @@ informix() {
 
 informix_14_10() {
     $PRIVILEGED_CLI $CONTAINER_CLI rm -f informix || true
-    $PRIVILEGED_CLI $CONTAINER_CLI run --name informix --privileged -p 9088:9088 -e LICENSE=accept -d icr.io/informix/informix-developer-database:14.10.FC9W1DE
+    $PRIVILEGED_CLI $CONTAINER_CLI run --name informix --privileged -p 9088:9088 -e LICENSE=accept -e GL_USEGLU=1 -d icr.io/informix/informix-developer-database:14.10.FC9W1DE
     echo "Starting Informix. This can take a few minutes"
     # Give the container some time to start
     OUTPUT=
@@ -962,7 +962,7 @@ informix_14_10() {
         OUTPUT=$($PRIVILEGED_CLI $CONTAINER_CLI logs informix 2>&1)
         if [[ $OUTPUT == *"Server Started"* ]]; then
           sleep 15
-          $PRIVILEGED_CLI $CONTAINER_CLI exec informix bash -l -c "echo \"execute function task('create dbspace from storagepool', 'datadbs', '100 MB', '4');execute function task('create sbspace from storagepool', 'sbspace', '20 M', '0');create database dev in datadbs with log nlscase sensitive;\" > post_init.sql;dbaccess sysadmin post_init.sql"
+          $PRIVILEGED_CLI $CONTAINER_CLI exec informix bash -l -c "export DB_LOCALE=en_US.utf8;export CLIENT_LOCALE=en_US.utf8;echo \"execute function task('create dbspace from storagepool', 'datadbs', '100 MB', '4');execute function task('create sbspace from storagepool', 'sbspace', '20 M', '0');create database dev in datadbs with log;\" > post_init.sql;dbaccess sysadmin post_init.sql"
           break;
         fi
         n=$((n+1))
@@ -978,7 +978,7 @@ informix_14_10() {
 
 informix_12_10() {
     $PRIVILEGED_CLI $CONTAINER_CLI rm -f informix || true
-    $PRIVILEGED_CLI $CONTAINER_CLI run --name informix --privileged -p 9088:9088 -e LICENSE=accept -d ibmcom/informix-developer-database:12.10.FC12W1DE
+    $PRIVILEGED_CLI $CONTAINER_CLI run --name informix --privileged -p 9088:9088 -e LICENSE=accept -e GL_USEGLU=1 -d ibmcom/informix-developer-database:12.10.FC12W1DE
     echo "Starting Informix. This can take a few minutes"
     # Give the container some time to start
     OUTPUT=
@@ -988,7 +988,7 @@ informix_12_10() {
         OUTPUT=$($PRIVILEGED_CLI $CONTAINER_CLI logs informix 2>&1)
         if [[ $OUTPUT == *"login Information"* ]]; then
           sleep 15
-          $PRIVILEGED_CLI $CONTAINER_CLI exec informix bash -l -c "echo \"execute function task('create dbspace from storagepool', 'datadbs', '100 MB', '4');execute function task('create sbspace from storagepool', 'sbspace', '20 M', '0');create database dev in datadbs with log nlscase sensitive;\" > post_init.sql;dbaccess sysadmin post_init.sql"
+          $PRIVILEGED_CLI $CONTAINER_CLI exec informix bash -l -c "export DB_LOCALE=en_US.utf8;export CLIENT_LOCALE=en_US.utf8;echo \"execute function task('create dbspace from storagepool', 'datadbs', '100 MB', '4');execute function task('create sbspace from storagepool', 'sbspace', '20 M', '0');create database dev in datadbs with log;\" > post_init.sql;dbaccess sysadmin post_init.sql"
           break;
         fi
         n=$((n+1))

--- a/gradle/databases.gradle
+++ b/gradle/databases.gradle
@@ -295,7 +295,7 @@ ext {
                         'jdbc.driver': 'com.informix.jdbc.IfxDriver',
                         'jdbc.user'  : 'informix',
                         'jdbc.pass'  : 'in4mix',
-                        'jdbc.url'   : 'jdbc:informix-sqli://' + dbHost + ':9088/dev:INFORMIXSERVER=informix;user=informix;password=in4mix;DELIMIDENT=Y',
+                        'jdbc.url'   : 'jdbc:informix-sqli://' + dbHost + ':9088/dev:INFORMIXSERVER=informix;user=informix;password=in4mix;DELIMIDENT=Y;DB_LOCALE=en_US.utf8',
                         'jdbc.datasource' : 'com.informix.jdbc.IfxDriver',
 //                        'jdbc.datasource' : 'com.informix.jdbcx.IfxDataSource',
                         'connection.init_sql' : ''

--- a/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/InformixDialect.java
+++ b/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/InformixDialect.java
@@ -6,6 +6,8 @@
  */
 package org.hibernate.community.dialect;
 
+import java.sql.Types;
+
 import org.hibernate.boot.Metadata;
 import org.hibernate.boot.model.FunctionContributions;
 import org.hibernate.boot.model.TypeContributions;
@@ -65,6 +67,8 @@ import org.hibernate.sql.exec.spi.JdbcOperation;
 import org.hibernate.tool.schema.extract.spi.SequenceInformationExtractor;
 import org.hibernate.tool.schema.internal.StandardForeignKeyExporter;
 import org.hibernate.tool.schema.spi.Exporter;
+import org.hibernate.type.descriptor.jdbc.ClobJdbcType;
+import org.hibernate.type.descriptor.jdbc.spi.JdbcTypeRegistry;
 import org.hibernate.type.descriptor.sql.DdlType;
 import org.hibernate.type.descriptor.sql.internal.CapacityDependentDdlType;
 import org.hibernate.type.descriptor.sql.spi.DdlTypeRegistry;
@@ -717,5 +721,17 @@ public class InformixDialect extends Dialect {
 	@Override
 	public String getNoColumnsInsertString() {
 		return "values (0)";
+	}
+
+	@Override
+	public boolean supportsNationalizedMethods(){
+		return false;
+	}
+
+	@Override
+	public void contributeTypes(TypeContributions typeContributions, ServiceRegistry serviceRegistry) {
+		super.contributeTypes( typeContributions, serviceRegistry );
+		final JdbcTypeRegistry jdbcTypeRegistry = typeContributions.getTypeConfiguration().getJdbcTypeRegistry();
+		jdbcTypeRegistry.addDescriptor( Types.NCLOB, ClobJdbcType.DEFAULT );
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/dialect/Dialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/Dialect.java
@@ -9,6 +9,7 @@ package org.hibernate.dialect;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.io.Reader;
 import java.sql.Blob;
 import java.sql.CallableStatement;
 import java.sql.Clob;
@@ -4368,6 +4369,18 @@ public abstract class Dialect implements ConversionContext, TypeContributor, Fun
 	 */
 	public NationalizationSupport getNationalizationSupport() {
 		return NationalizationSupport.EXPLICIT;
+	}
+
+	/**
+	 * Checks whether the JDBC driver implements methods for handling nationalized character data types
+	 * {@link ResultSet#getNString(int)} / {@link java.sql.PreparedStatement#setNString(int, String)},
+	 * {@link ResultSet#getNClob(int)} /{@link java.sql.PreparedStatement#setNClob(int, NClob)},
+	 * {@link ResultSet#getNCharacterStream(int)} / {@link java.sql.PreparedStatement#setNCharacterStream(int, Reader, long)}
+	 *
+	 * @return {@code true} if the driver implements these methods
+	 */
+	public boolean supportsNationalizedMethods(){
+		return true;
 	}
 
 	/**

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/jdbc/JsonAsStringJdbcType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/jdbc/JsonAsStringJdbcType.java
@@ -120,7 +120,7 @@ public class JsonAsStringJdbcType extends JsonJdbcType implements AdjustableJdbc
 				protected void doBind(PreparedStatement st, X value, int index, WrapperOptions options)
 						throws SQLException {
 					final String json = ( (JsonAsStringJdbcType) getJdbcType() ).toString( value, getJavaType(), options );
-					if (options.getDialect().supportsNationalizedMethods()) {
+					if ( options.getDialect().supportsNationalizedMethods() ) {
 						st.setNString( index, json );
 					}
 					else {
@@ -132,7 +132,7 @@ public class JsonAsStringJdbcType extends JsonJdbcType implements AdjustableJdbc
 				protected void doBind(CallableStatement st, X value, String name, WrapperOptions options)
 						throws SQLException {
 					final String json = ( (JsonAsStringJdbcType) getJdbcType() ).toString( value, getJavaType(), options );
-					if (options.getDialect().supportsNationalizedMethods()) {
+					if ( options.getDialect().supportsNationalizedMethods() ) {
 						st.setNString( name, json );
 					}
 					else {
@@ -152,7 +152,7 @@ public class JsonAsStringJdbcType extends JsonJdbcType implements AdjustableJdbc
 			return new BasicExtractor<>( javaType, this ) {
 				@Override
 				protected X doExtract(ResultSet rs, int paramIndex, WrapperOptions options) throws SQLException {
-					if (options.getDialect().supportsNationalizedMethods()) {
+					if ( options.getDialect().supportsNationalizedMethods() ) {
 						return fromString( rs.getNString( paramIndex ), getJavaType(), options );
 					}
 					else {
@@ -163,7 +163,7 @@ public class JsonAsStringJdbcType extends JsonJdbcType implements AdjustableJdbc
 				@Override
 				protected X doExtract(CallableStatement statement, int index, WrapperOptions options)
 						throws SQLException {
-					if (options.getDialect().supportsNationalizedMethods()) {
+					if ( options.getDialect().supportsNationalizedMethods() ) {
 						return fromString( statement.getNString( index ), getJavaType(), options );
 					}
 					else {
@@ -174,7 +174,7 @@ public class JsonAsStringJdbcType extends JsonJdbcType implements AdjustableJdbc
 				@Override
 				protected X doExtract(CallableStatement statement, String name, WrapperOptions options)
 						throws SQLException {
-					if (options.getDialect().supportsNationalizedMethods()) {
+					if ( options.getDialect().supportsNationalizedMethods() ) {
 						return fromString( statement.getNString( name ), getJavaType(), options );
 					}
 					else {

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/jdbc/JsonAsStringJdbcType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/jdbc/JsonAsStringJdbcType.java
@@ -120,14 +120,24 @@ public class JsonAsStringJdbcType extends JsonJdbcType implements AdjustableJdbc
 				protected void doBind(PreparedStatement st, X value, int index, WrapperOptions options)
 						throws SQLException {
 					final String json = ( (JsonAsStringJdbcType) getJdbcType() ).toString( value, getJavaType(), options );
-					st.setNString( index, json );
+					if (options.getDialect().supportsNationalizedMethods()) {
+						st.setNString( index, json );
+					}
+					else {
+						st.setString( index, json );
+					}
 				}
 
 				@Override
 				protected void doBind(CallableStatement st, X value, String name, WrapperOptions options)
 						throws SQLException {
 					final String json = ( (JsonAsStringJdbcType) getJdbcType() ).toString( value, getJavaType(), options );
-					st.setNString( name, json );
+					if (options.getDialect().supportsNationalizedMethods()) {
+						st.setNString( name, json );
+					}
+					else {
+						st.setString( name, json );
+					}
 				}
 			};
 		}
@@ -142,19 +152,34 @@ public class JsonAsStringJdbcType extends JsonJdbcType implements AdjustableJdbc
 			return new BasicExtractor<>( javaType, this ) {
 				@Override
 				protected X doExtract(ResultSet rs, int paramIndex, WrapperOptions options) throws SQLException {
-					return fromString( rs.getNString( paramIndex ), getJavaType(), options );
+					if (options.getDialect().supportsNationalizedMethods()) {
+						return fromString( rs.getNString( paramIndex ), getJavaType(), options );
+					}
+					else {
+						return fromString( rs.getString( paramIndex ), getJavaType(), options );
+					}
 				}
 
 				@Override
 				protected X doExtract(CallableStatement statement, int index, WrapperOptions options)
 						throws SQLException {
-					return fromString( statement.getNString( index ), getJavaType(), options );
+					if (options.getDialect().supportsNationalizedMethods()) {
+						return fromString( statement.getNString( index ), getJavaType(), options );
+					}
+					else {
+						return fromString( statement.getString( index ), getJavaType(), options );
+					}
 				}
 
 				@Override
 				protected X doExtract(CallableStatement statement, String name, WrapperOptions options)
 						throws SQLException {
-					return fromString( statement.getNString( name ), getJavaType(), options );
+					if (options.getDialect().supportsNationalizedMethods()) {
+						return fromString( statement.getNString( name ), getJavaType(), options );
+					}
+					else {
+						return fromString( statement.getString( name ), getJavaType(), options );
+					}
 				}
 
 			};

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/jdbc/NClobJdbcType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/jdbc/NClobJdbcType.java
@@ -46,7 +46,7 @@ public abstract class NClobJdbcType implements JdbcType {
 		return new BasicExtractor<>( javaType, this ) {
 			@Override
 			protected X doExtract(ResultSet rs, int paramIndex, WrapperOptions options) throws SQLException {
-				if (options.getDialect().supportsNationalizedMethods()) {
+				if ( options.getDialect().supportsNationalizedMethods() ) {
 					return javaType.wrap( rs.getNClob( paramIndex ), options );
 				}
 				else {
@@ -57,7 +57,7 @@ public abstract class NClobJdbcType implements JdbcType {
 			@Override
 			protected X doExtract(CallableStatement statement, int index, WrapperOptions options)
 					throws SQLException {
-				if (options.getDialect().supportsNationalizedMethods()) {
+				if ( options.getDialect().supportsNationalizedMethods() ) {
 					return javaType.wrap( statement.getNClob( index ), options );
 				}
 				else {
@@ -68,7 +68,7 @@ public abstract class NClobJdbcType implements JdbcType {
 			@Override
 			protected X doExtract(CallableStatement statement, String name, WrapperOptions options)
 					throws SQLException {
-				if (options.getDialect().supportsNationalizedMethods()) {
+				if ( options.getDialect().supportsNationalizedMethods() ) {
 					return javaType.wrap( statement.getNClob( name ), options );
 				}
 				else {
@@ -145,7 +145,7 @@ public abstract class NClobJdbcType implements JdbcType {
 				@Override
 				protected void doBind(PreparedStatement st, X value, int index, WrapperOptions options)
 						throws SQLException {
-					if (options.getDialect().supportsNationalizedMethods()) {
+					if ( options.getDialect().supportsNationalizedMethods() ) {
 						st.setNString( index, javaType.unwrap( value, String.class, options ) );
 					}
 					else {
@@ -156,7 +156,7 @@ public abstract class NClobJdbcType implements JdbcType {
 				@Override
 				protected void doBind(CallableStatement st, X value, String name, WrapperOptions options)
 						throws SQLException {
-					if (options.getDialect().supportsNationalizedMethods()) {
+					if ( options.getDialect().supportsNationalizedMethods() ) {
 						st.setNString( name, javaType.unwrap( value, String.class, options ) );
 					}
 					else {
@@ -170,7 +170,7 @@ public abstract class NClobJdbcType implements JdbcType {
 			return new BasicExtractor<>( javaType, this ) {
 				@Override
 				protected X doExtract(ResultSet rs, int paramIndex, WrapperOptions options) throws SQLException {
-					if (options.getDialect().supportsNationalizedMethods()) {
+					if ( options.getDialect().supportsNationalizedMethods() ) {
 						return javaType.wrap( rs.getNString( paramIndex ), options );
 					}
 					else {
@@ -181,7 +181,7 @@ public abstract class NClobJdbcType implements JdbcType {
 				@Override
 				protected X doExtract(CallableStatement statement, int index, WrapperOptions options)
 						throws SQLException {
-					if (options.getDialect().supportsNationalizedMethods()) {
+					if ( options.getDialect().supportsNationalizedMethods() ) {
 						return javaType.wrap( statement.getNString( index ), options );
 					}
 					else {
@@ -192,7 +192,7 @@ public abstract class NClobJdbcType implements JdbcType {
 				@Override
 				protected X doExtract(CallableStatement statement, String name, WrapperOptions options)
 						throws SQLException {
-					if (options.getDialect().supportsNationalizedMethods()) {
+					if ( options.getDialect().supportsNationalizedMethods() ) {
 						return javaType.wrap( statement.getNString( name ), options );
 					}
 					else {
@@ -220,7 +220,7 @@ public abstract class NClobJdbcType implements JdbcType {
 				@Override
 				protected void doBind(PreparedStatement st, X value, int index, WrapperOptions options)
 						throws SQLException {
-					if (options.getDialect().supportsNationalizedMethods()) {
+					if ( options.getDialect().supportsNationalizedMethods() ) {
 						st.setNClob( index, javaType.unwrap( value, NClob.class, options ) );
 					}
 					else {
@@ -231,7 +231,7 @@ public abstract class NClobJdbcType implements JdbcType {
 				@Override
 				protected void doBind(CallableStatement st, X value, String name, WrapperOptions options)
 						throws SQLException {
-					if (options.getDialect().supportsNationalizedMethods()) {
+					if ( options.getDialect().supportsNationalizedMethods() ) {
 						st.setNClob( name, javaType.unwrap( value, NClob.class, options ) );
 					}
 					else {
@@ -260,7 +260,7 @@ public abstract class NClobJdbcType implements JdbcType {
 				protected void doBind(PreparedStatement st, X value, int index, WrapperOptions options)
 						throws SQLException {
 					final CharacterStream characterStream = javaType.unwrap( value, CharacterStream.class, options );
-					if (options.getDialect().supportsNationalizedMethods()) {
+					if ( options.getDialect().supportsNationalizedMethods() ) {
 						st.setNCharacterStream( index, characterStream.asReader(), characterStream.getLength() );
 					}
 					else {
@@ -272,7 +272,7 @@ public abstract class NClobJdbcType implements JdbcType {
 				protected void doBind(CallableStatement st, X value, String name, WrapperOptions options)
 						throws SQLException {
 					final CharacterStream characterStream = javaType.unwrap( value, CharacterStream.class, options );
-					if (options.getDialect().supportsNationalizedMethods()) {
+					if ( options.getDialect().supportsNationalizedMethods() ) {
 						st.setNCharacterStream( name, characterStream.asReader(), characterStream.getLength() );
 					}
 					else {
@@ -300,7 +300,7 @@ public abstract class NClobJdbcType implements JdbcType {
 				@Override
 				protected void doBind(PreparedStatement st, X value, int index, WrapperOptions options)
 						throws SQLException {
-					if (options.getDialect().supportsNationalizedMethods()) {
+					if ( options.getDialect().supportsNationalizedMethods() ) {
 						st.setNString( index, javaType.unwrap( value, String.class, options ) );
 					}
 					else {
@@ -311,7 +311,7 @@ public abstract class NClobJdbcType implements JdbcType {
 				@Override
 				protected void doBind(CallableStatement st, X value, String name, WrapperOptions options)
 						throws SQLException {
-					if (options.getDialect().supportsNationalizedMethods()) {
+					if ( options.getDialect().supportsNationalizedMethods() ) {
 						st.setNString( name, javaType.unwrap( value, String.class, options ) );
 					}
 					else {
@@ -326,7 +326,7 @@ public abstract class NClobJdbcType implements JdbcType {
 			return new BasicExtractor<>( javaType, this ) {
 				@Override
 				protected X doExtract(ResultSet rs, int paramIndex, WrapperOptions options) throws SQLException {
-					if (options.getDialect().supportsNationalizedMethods()) {
+					if ( options.getDialect().supportsNationalizedMethods() ) {
 						return javaType.wrap( rs.getNString( paramIndex ), options );
 					}
 					else {
@@ -337,7 +337,7 @@ public abstract class NClobJdbcType implements JdbcType {
 				@Override
 				protected X doExtract(CallableStatement statement, int index, WrapperOptions options)
 						throws SQLException {
-					if (options.getDialect().supportsNationalizedMethods()) {
+					if ( options.getDialect().supportsNationalizedMethods() ) {
 						return javaType.wrap( statement.getNString( index ), options );
 					}
 					else {
@@ -348,7 +348,7 @@ public abstract class NClobJdbcType implements JdbcType {
 				@Override
 				protected X doExtract(CallableStatement statement, String name, WrapperOptions options)
 						throws SQLException {
-					if (options.getDialect().supportsNationalizedMethods()) {
+					if ( options.getDialect().supportsNationalizedMethods() ) {
 						return javaType.wrap( statement.getNString( name ), options );
 					}
 					else {

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/jdbc/NClobJdbcType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/jdbc/NClobJdbcType.java
@@ -46,19 +46,34 @@ public abstract class NClobJdbcType implements JdbcType {
 		return new BasicExtractor<>( javaType, this ) {
 			@Override
 			protected X doExtract(ResultSet rs, int paramIndex, WrapperOptions options) throws SQLException {
-				return javaType.wrap( rs.getNClob( paramIndex ), options );
+				if (options.getDialect().supportsNationalizedMethods()) {
+					return javaType.wrap( rs.getNClob( paramIndex ), options );
+				}
+				else {
+					return javaType.wrap( rs.getClob( paramIndex ), options );
+				}
 			}
 
 			@Override
 			protected X doExtract(CallableStatement statement, int index, WrapperOptions options)
 					throws SQLException {
-				return javaType.wrap( statement.getNClob( index ), options );
+				if (options.getDialect().supportsNationalizedMethods()) {
+					return javaType.wrap( statement.getNClob( index ), options );
+				}
+				else {
+					return javaType.wrap( statement.getClob( index ), options );
+				}
 			}
 
 			@Override
 			protected X doExtract(CallableStatement statement, String name, WrapperOptions options)
 					throws SQLException {
-				return javaType.wrap( statement.getNClob( name ), options );
+				if (options.getDialect().supportsNationalizedMethods()) {
+					return javaType.wrap( statement.getNClob( name ), options );
+				}
+				else {
+					return javaType.wrap( statement.getClob( name ), options );
+				}
 			}
 		};
 	}
@@ -102,19 +117,19 @@ public abstract class NClobJdbcType implements JdbcType {
 				protected void doBind(PreparedStatement st, X value, int index, WrapperOptions options)
 						throws SQLException {
 					getDescriptor( value, options ).getNClobBinder( javaType ).doBind( st, value, index, options );
-				}
+					}
 
 				@Override
 				protected void doBind(CallableStatement st, X value, String name, WrapperOptions options)
 						throws SQLException {
 					getDescriptor( value, options ).getNClobBinder( javaType ).doBind( st, value, name, options );
-				}
+					}
 			};
-		}
+				}
 	};
 
 	public static final NClobJdbcType STRING_BINDING = new NClobJdbcType() {
-		@Override
+				@Override
 		public String toString() {
 			return "NClobTypeDescriptor(STRING_BINDING)";
 		}
@@ -130,13 +145,23 @@ public abstract class NClobJdbcType implements JdbcType {
 				@Override
 				protected void doBind(PreparedStatement st, X value, int index, WrapperOptions options)
 						throws SQLException {
-					st.setNString( index, javaType.unwrap( value, String.class, options ) );
+					if (options.getDialect().supportsNationalizedMethods()) {
+						st.setNString( index, javaType.unwrap( value, String.class, options ) );
+					}
+					else {
+						st.setString( index, javaType.unwrap( value, String.class, options ) );
+					}
 				}
 
 				@Override
 				protected void doBind(CallableStatement st, X value, String name, WrapperOptions options)
 						throws SQLException {
-					st.setNString( name, javaType.unwrap( value, String.class, options ) );
+					if (options.getDialect().supportsNationalizedMethods()) {
+						st.setNString( name, javaType.unwrap( value, String.class, options ) );
+					}
+					else {
+						st.setString( name, javaType.unwrap( value, String.class, options ) );
+					}
 				}
 			};
 		}
@@ -145,19 +170,34 @@ public abstract class NClobJdbcType implements JdbcType {
 			return new BasicExtractor<>( javaType, this ) {
 				@Override
 				protected X doExtract(ResultSet rs, int paramIndex, WrapperOptions options) throws SQLException {
-					return javaType.wrap( rs.getNString( paramIndex ), options );
+					if (options.getDialect().supportsNationalizedMethods()) {
+						return javaType.wrap( rs.getNString( paramIndex ), options );
+					}
+					else {
+						return javaType.wrap( rs.getString( paramIndex ), options );
+					}
 				}
 
 				@Override
 				protected X doExtract(CallableStatement statement, int index, WrapperOptions options)
 						throws SQLException {
-					return javaType.wrap( statement.getNString( index ), options );
+					if (options.getDialect().supportsNationalizedMethods()) {
+						return javaType.wrap( statement.getNString( index ), options );
+					}
+					else {
+						return javaType.wrap( statement.getString( index ), options );
+					}
 				}
 
 				@Override
 				protected X doExtract(CallableStatement statement, String name, WrapperOptions options)
 						throws SQLException {
-					return javaType.wrap( statement.getNString( name ), options );
+					if (options.getDialect().supportsNationalizedMethods()) {
+						return javaType.wrap( statement.getNString( name ), options );
+					}
+					else {
+						return javaType.wrap( statement.getString( name ), options );
+					}
 				}
 			};
 		}
@@ -180,13 +220,23 @@ public abstract class NClobJdbcType implements JdbcType {
 				@Override
 				protected void doBind(PreparedStatement st, X value, int index, WrapperOptions options)
 						throws SQLException {
-					st.setNClob( index, javaType.unwrap( value, NClob.class, options ) );
+					if (options.getDialect().supportsNationalizedMethods()) {
+						st.setNClob( index, javaType.unwrap( value, NClob.class, options ) );
+					}
+					else {
+						st.setClob( index, javaType.unwrap( value, NClob.class, options ) );
+					}
 				}
 
 				@Override
 				protected void doBind(CallableStatement st, X value, String name, WrapperOptions options)
 						throws SQLException {
-					st.setNClob( name, javaType.unwrap( value, NClob.class, options ) );
+					if (options.getDialect().supportsNationalizedMethods()) {
+						st.setNClob( name, javaType.unwrap( value, NClob.class, options ) );
+					}
+					else {
+						st.setClob( name, javaType.unwrap( value, NClob.class, options ) );
+					}
 				}
 			};
 		}
@@ -210,14 +260,24 @@ public abstract class NClobJdbcType implements JdbcType {
 				protected void doBind(PreparedStatement st, X value, int index, WrapperOptions options)
 						throws SQLException {
 					final CharacterStream characterStream = javaType.unwrap( value, CharacterStream.class, options );
-					st.setNCharacterStream( index, characterStream.asReader(), characterStream.getLength() );
+					if (options.getDialect().supportsNationalizedMethods()) {
+						st.setNCharacterStream( index, characterStream.asReader(), characterStream.getLength() );
+					}
+					else {
+						st.setCharacterStream( index, characterStream.asReader(), characterStream.getLength() );
+					}
 				}
 
 				@Override
 				protected void doBind(CallableStatement st, X value, String name, WrapperOptions options)
 						throws SQLException {
 					final CharacterStream characterStream = javaType.unwrap( value, CharacterStream.class, options );
-					st.setNCharacterStream( name, characterStream.asReader(), characterStream.getLength() );
+					if (options.getDialect().supportsNationalizedMethods()) {
+						st.setNCharacterStream( name, characterStream.asReader(), characterStream.getLength() );
+					}
+					else {
+						st.setCharacterStream( name, characterStream.asReader(), characterStream.getLength() );
+					}
 				}
 			};
 		}
@@ -240,13 +300,23 @@ public abstract class NClobJdbcType implements JdbcType {
 				@Override
 				protected void doBind(PreparedStatement st, X value, int index, WrapperOptions options)
 						throws SQLException {
-					st.setNString( index, javaType.unwrap( value, String.class, options ) );
+					if (options.getDialect().supportsNationalizedMethods()) {
+						st.setNString( index, javaType.unwrap( value, String.class, options ) );
+					}
+					else {
+						st.setString( index, javaType.unwrap( value, String.class, options ) );
+					}
 				}
 
 				@Override
 				protected void doBind(CallableStatement st, X value, String name, WrapperOptions options)
 						throws SQLException {
-					st.setNString( name, javaType.unwrap( value, String.class, options ) );
+					if (options.getDialect().supportsNationalizedMethods()) {
+						st.setNString( name, javaType.unwrap( value, String.class, options ) );
+					}
+					else {
+						st.setString( name, javaType.unwrap( value, String.class, options ) );
+					}
 				}
 			};
 		}
@@ -256,19 +326,34 @@ public abstract class NClobJdbcType implements JdbcType {
 			return new BasicExtractor<>( javaType, this ) {
 				@Override
 				protected X doExtract(ResultSet rs, int paramIndex, WrapperOptions options) throws SQLException {
-					return javaType.wrap( rs.getNString( paramIndex ), options );
+					if (options.getDialect().supportsNationalizedMethods()) {
+						return javaType.wrap( rs.getNString( paramIndex ), options );
+					}
+					else {
+						return javaType.wrap( rs.getString( paramIndex ), options );
+					}
 				}
 
 				@Override
 				protected X doExtract(CallableStatement statement, int index, WrapperOptions options)
 						throws SQLException {
-					return javaType.wrap( statement.getNString( index ), options );
+					if (options.getDialect().supportsNationalizedMethods()) {
+						return javaType.wrap( statement.getNString( index ), options );
+					}
+					else {
+						return javaType.wrap( statement.getString( index ), options );
+					}
 				}
 
 				@Override
 				protected X doExtract(CallableStatement statement, String name, WrapperOptions options)
 						throws SQLException {
-					return javaType.wrap( statement.getNString( name ), options );
+					if (options.getDialect().supportsNationalizedMethods()) {
+						return javaType.wrap( statement.getNString( name ), options );
+					}
+					else {
+						return javaType.wrap( statement.getString( name ), options );
+					}
 				}
 			};
 		}

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/jdbc/NVarcharJdbcType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/jdbc/NVarcharJdbcType.java
@@ -106,13 +106,23 @@ public class NVarcharJdbcType implements AdjustableJdbcType {
 		return new BasicBinder<>( javaType, this ) {
 			@Override
 			protected void doBind(PreparedStatement st, X value, int index, WrapperOptions options) throws SQLException {
-				st.setNString( index, javaType.unwrap( value, String.class, options ) );
+				if (options.getDialect().supportsNationalizedMethods()) {
+					st.setNString( index, javaType.unwrap( value, String.class, options ) );
+				}
+				else {
+					st.setString( index, javaType.unwrap( value, String.class, options ) );
+				}
 			}
 
 			@Override
 			protected void doBind(CallableStatement st, X value, String name, WrapperOptions options)
 					throws SQLException {
-				st.setNString( name, javaType.unwrap( value, String.class, options ) );
+				if (options.getDialect().supportsNationalizedMethods()) {
+					st.setNString( name, javaType.unwrap( value, String.class, options ) );
+				}
+				else {
+					st.setString( name, javaType.unwrap( value, String.class, options ) );
+				}
 			}
 		};
 	}
@@ -122,17 +132,32 @@ public class NVarcharJdbcType implements AdjustableJdbcType {
 		return new BasicExtractor<>( javaType, this ) {
 			@Override
 			protected X doExtract(ResultSet rs, int paramIndex, WrapperOptions options) throws SQLException {
-				return javaType.wrap( rs.getNString( paramIndex ), options );
+				if (options.getDialect().supportsNationalizedMethods()) {
+					return javaType.wrap( rs.getNString( paramIndex ), options );
+				}
+				else {
+					return javaType.wrap( rs.getString( paramIndex ), options );
+				}
 			}
 
 			@Override
 			protected X doExtract(CallableStatement statement, int index, WrapperOptions options) throws SQLException {
-				return javaType.wrap( statement.getNString( index ), options );
+				if (options.getDialect().supportsNationalizedMethods()) {
+					return javaType.wrap( statement.getNString( index ), options );
+				}
+				else {
+					return javaType.wrap( statement.getString( index ), options );
+				}
 			}
 
 			@Override
 			protected X doExtract(CallableStatement statement, String name, WrapperOptions options) throws SQLException {
-				return javaType.wrap( statement.getNString( name ), options );
+				if (options.getDialect().supportsNationalizedMethods()) {
+					return javaType.wrap( statement.getNString( name ), options );
+				}
+				else {
+					return javaType.wrap( statement.getString( name ), options );
+				}
 			}
 		};
 	}

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/jdbc/NVarcharJdbcType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/jdbc/NVarcharJdbcType.java
@@ -106,7 +106,7 @@ public class NVarcharJdbcType implements AdjustableJdbcType {
 		return new BasicBinder<>( javaType, this ) {
 			@Override
 			protected void doBind(PreparedStatement st, X value, int index, WrapperOptions options) throws SQLException {
-				if (options.getDialect().supportsNationalizedMethods()) {
+				if ( options.getDialect().supportsNationalizedMethods() ) {
 					st.setNString( index, javaType.unwrap( value, String.class, options ) );
 				}
 				else {
@@ -117,7 +117,7 @@ public class NVarcharJdbcType implements AdjustableJdbcType {
 			@Override
 			protected void doBind(CallableStatement st, X value, String name, WrapperOptions options)
 					throws SQLException {
-				if (options.getDialect().supportsNationalizedMethods()) {
+				if ( options.getDialect().supportsNationalizedMethods() ) {
 					st.setNString( name, javaType.unwrap( value, String.class, options ) );
 				}
 				else {
@@ -132,7 +132,7 @@ public class NVarcharJdbcType implements AdjustableJdbcType {
 		return new BasicExtractor<>( javaType, this ) {
 			@Override
 			protected X doExtract(ResultSet rs, int paramIndex, WrapperOptions options) throws SQLException {
-				if (options.getDialect().supportsNationalizedMethods()) {
+				if ( options.getDialect().supportsNationalizedMethods() ) {
 					return javaType.wrap( rs.getNString( paramIndex ), options );
 				}
 				else {
@@ -142,7 +142,7 @@ public class NVarcharJdbcType implements AdjustableJdbcType {
 
 			@Override
 			protected X doExtract(CallableStatement statement, int index, WrapperOptions options) throws SQLException {
-				if (options.getDialect().supportsNationalizedMethods()) {
+				if ( options.getDialect().supportsNationalizedMethods() ) {
 					return javaType.wrap( statement.getNString( index ), options );
 				}
 				else {
@@ -152,7 +152,7 @@ public class NVarcharJdbcType implements AdjustableJdbcType {
 
 			@Override
 			protected X doExtract(CallableStatement statement, String name, WrapperOptions options) throws SQLException {
-				if (options.getDialect().supportsNationalizedMethods()) {
+				if ( options.getDialect().supportsNationalizedMethods() ) {
 					return javaType.wrap( statement.getNString( name ), options );
 				}
 				else {

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/jdbc/XmlAsStringJdbcType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/jdbc/XmlAsStringJdbcType.java
@@ -130,7 +130,7 @@ public class XmlAsStringJdbcType extends XmlJdbcType implements AdjustableJdbcTy
 							getJavaType(),
 							options
 					);
-					if (options.getDialect().supportsNationalizedMethods()) {
+					if ( options.getDialect().supportsNationalizedMethods() ) {
 						st.setNString( index, xml );
 					}
 					else {
@@ -146,7 +146,7 @@ public class XmlAsStringJdbcType extends XmlJdbcType implements AdjustableJdbcTy
 							getJavaType(),
 							options
 					);
-					if (options.getDialect().supportsNationalizedMethods()) {
+					if ( options.getDialect().supportsNationalizedMethods() ) {
 						st.setNString( name, xml );
 					}
 					else {
@@ -189,7 +189,7 @@ public class XmlAsStringJdbcType extends XmlJdbcType implements AdjustableJdbcTy
 
 				@Override
 				protected X doExtract(ResultSet rs, int paramIndex, WrapperOptions options) throws SQLException {
-					if (options.getDialect().supportsNationalizedMethods()) {
+					if ( options.getDialect().supportsNationalizedMethods() ) {
 						return getObject( rs.getNString( paramIndex ), options );
 					}
 					else {
@@ -200,7 +200,7 @@ public class XmlAsStringJdbcType extends XmlJdbcType implements AdjustableJdbcTy
 				@Override
 				protected X doExtract(CallableStatement statement, int index, WrapperOptions options)
 						throws SQLException {
-					if (options.getDialect().supportsNationalizedMethods()) {
+					if ( options.getDialect().supportsNationalizedMethods() ) {
 						return getObject( statement.getNString( index ), options );
 					}
 					else {
@@ -211,7 +211,7 @@ public class XmlAsStringJdbcType extends XmlJdbcType implements AdjustableJdbcTy
 				@Override
 				protected X doExtract(CallableStatement statement, String name, WrapperOptions options)
 						throws SQLException {
-					if (options.getDialect().supportsNationalizedMethods()) {
+					if ( options.getDialect().supportsNationalizedMethods() ) {
 						return getObject( statement.getNString( name ), options );
 					}
 					else {

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/jdbc/XmlAsStringJdbcType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/jdbc/XmlAsStringJdbcType.java
@@ -130,7 +130,12 @@ public class XmlAsStringJdbcType extends XmlJdbcType implements AdjustableJdbcTy
 							getJavaType(),
 							options
 					);
-					st.setNString( index, xml );
+					if (options.getDialect().supportsNationalizedMethods()) {
+						st.setNString( index, xml );
+					}
+					else {
+						st.setString( index, xml );
+					}
 				}
 
 				@Override
@@ -141,7 +146,12 @@ public class XmlAsStringJdbcType extends XmlJdbcType implements AdjustableJdbcTy
 							getJavaType(),
 							options
 					);
-					st.setNString( name, xml );
+					if (options.getDialect().supportsNationalizedMethods()) {
+						st.setNString( name, xml );
+					}
+					else {
+						st.setString( name, xml );
+					}
 				}
 			};
 		}
@@ -179,19 +189,34 @@ public class XmlAsStringJdbcType extends XmlJdbcType implements AdjustableJdbcTy
 
 				@Override
 				protected X doExtract(ResultSet rs, int paramIndex, WrapperOptions options) throws SQLException {
-					return getObject( rs.getNString( paramIndex ), options );
+					if (options.getDialect().supportsNationalizedMethods()) {
+						return getObject( rs.getNString( paramIndex ), options );
+					}
+					else {
+						return getObject( rs.getString( paramIndex ), options );
+					}
 				}
 
 				@Override
 				protected X doExtract(CallableStatement statement, int index, WrapperOptions options)
 						throws SQLException {
-					return getObject( statement.getNString( index ), options );
+					if (options.getDialect().supportsNationalizedMethods()) {
+						return getObject( statement.getNString( index ), options );
+					}
+					else {
+						return getObject( statement.getString( index ), options );
+					}
 				}
 
 				@Override
 				protected X doExtract(CallableStatement statement, String name, WrapperOptions options)
 						throws SQLException {
-					return getObject( statement.getNString( name ), options );
+					if (options.getDialect().supportsNationalizedMethods()) {
+						return getObject( statement.getNString( name ), options );
+					}
+					else {
+						return getObject( statement.getString( name ), options );
+					}
 				}
 
 				private X getObject(String xml, WrapperOptions options) throws SQLException {

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/nationalized/MaterializedNClobBindTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/nationalized/MaterializedNClobBindTest.java
@@ -15,6 +15,8 @@ import java.sql.SQLException;
 import java.sql.Types;
 import java.util.TimeZone;
 
+import org.hibernate.dialect.Dialect;
+import org.hibernate.dialect.H2Dialect;
 import org.hibernate.engine.jdbc.LobCreator;
 import org.hibernate.engine.jdbc.NonContextualLobCreator;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
@@ -85,6 +87,7 @@ public class MaterializedNClobBindTest {
 
 	private class MockWrapperOptions implements WrapperOptions {
 		private final boolean useStreamForLobBinding;
+		private final Dialect dialect = new H2Dialect();
 
 		public MockWrapperOptions(boolean useStreamForLobBinding) {
 			this.useStreamForLobBinding = useStreamForLobBinding;
@@ -118,6 +121,11 @@ public class MaterializedNClobBindTest {
 		@Override
 		public TimeZone getJdbcTimeZone() {
 			return null;
+		}
+
+		@Override
+		public Dialect getDialect() {
+			return dialect;
 		}
 	}
 


### PR DESCRIPTION
<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

Solution similar to DB2Dialect, which was accepted for issue HHH-12753:

```
jdbcTypeRegistry.addDescriptor(Types.NCHAR, CharJdbcType.INSTANCE);
jdbcTypeRegistry.addDescriptor(Types.NVARCHAR, VarcharJdbcType.INSTANCE);
jdbcTypeRegistry.addDescriptor(Types.LONGNVARCHAR, LongVarcharJdbcType.INSTANCE);
```

This is not entirely correct, because in this way the table schema is also created directly with the type (`CHAR / VARCHAR / LONGVARCHAR`) even though the database supports the types (`NCHAR / NVARCHAR / LONGNVARCHAR`). Therefore, it is only necessary to replace calls to `setNString()` with `setString()` within the `doBind()` methods. There may be another way to solve this, so that the creation of the schema is preserved even with the data types `NCHAR / NVARCHAR / LONGNVARCHAR` and at the same time `doBind() / doExtract()` are used as with the basic types (`getString() / setString()`). Since the `NCLOB` data type does not exist, replacing `CLOB` seems fine to me.

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-18312
<!-- Hibernate GitHub Bot issue links end -->