### PR TITLE
Reproducer of HHH-18236: Unrecognized enum discriminator with native query

### DIFF
--- a/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/Book.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/Book.java
@@ -1,0 +1,36 @@
+package org.hibernate.orm.test.jpa;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.DiscriminatorColumn;
+import jakarta.persistence.DiscriminatorValue;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Id;
+import jakarta.persistence.Inheritance;
+import jakarta.persistence.InheritanceType;
+import org.hibernate.annotations.DynamicInsert;
+
+@Entity
+@Inheritance(strategy = InheritanceType.SINGLE_TABLE)
+@DiscriminatorColumn(name="TYPE_BOOK")
+@DiscriminatorValue("MAIN")
+@DynamicInsert
+public class Book {
+    @Id
+    public String isbn;
+    
+    public String title;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "TYPE_BOOK", insertable = false, updatable = false, nullable = false)
+    protected BookType bookType;
+
+    public Book() {
+    }
+
+    public Book(String isbn, String title) {
+        this.isbn = isbn;
+        this.title = title;
+    }
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/BookType.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/BookType.java
@@ -1,0 +1,6 @@
+package org.hibernate.orm.test.jpa;
+
+public enum BookType {
+    MAIN,
+    SUB
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/SubBook.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/SubBook.java
@@ -1,0 +1,24 @@
+package org.hibernate.orm.test.jpa;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.DiscriminatorValue;
+import jakarta.persistence.Entity;
+import org.hibernate.annotations.DynamicInsert;
+
+@Entity
+@DiscriminatorValue("SUB")
+@DynamicInsert
+public class SubBook extends Book {
+
+    @Column
+    public String subdata;
+
+    public SubBook() {
+    }
+    
+    public SubBook(String isbn, String title, String subdata) {
+        this.isbn = isbn;
+        this.title = title;
+        this.subdata = subdata;
+    }
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/query/QueryTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/query/QueryTest.java
@@ -32,8 +32,10 @@ import org.hibernate.dialect.PostgreSQLDialect;
 import org.hibernate.dialect.PostgresPlusDialect;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.orm.test.jpa.BaseEntityManagerFunctionalTestCase;
+import org.hibernate.orm.test.jpa.Book;
 import org.hibernate.orm.test.jpa.Distributor;
 import org.hibernate.orm.test.jpa.Item;
+import org.hibernate.orm.test.jpa.SubBook;
 import org.hibernate.orm.test.jpa.Wallet;
 import org.hibernate.stat.Statistics;
 
@@ -64,7 +66,9 @@ public class QueryTest extends BaseEntityManagerFunctionalTestCase {
 				Distributor.class,
 				Wallet.class,
 				Employee.class,
-				Contractor.class
+				Contractor.class,
+				Book.class,
+				SubBook.class,
 		};
 	}
 
@@ -1582,4 +1586,24 @@ public class QueryTest extends BaseEntityManagerFunctionalTestCase {
 			entityManager.close();
 		}
 	}
+
+	@Test
+	@TestForIssue(jiraKey = "HHH-18236")
+	public void test18236() {
+		EntityManager em = getOrCreateEntityManager();
+		try {
+			em.getTransaction().begin();
+			em.persist( new Book("9781932394153", "Hibernate in Action") );
+			em.flush();
+
+			List results = em.createNativeQuery("select b.* from book b", Book.class).getResultList();
+			assertEquals(1, results.size());
+		}
+		finally {
+			em.getTransaction().rollback();
+			em.close();
+		}
+
+	}
+
 }


### PR DESCRIPTION
I have an error while trying to upgrade hibernate in my app, so I have opened HHH-18236 with a sample app reproducing the error.
I tried to debug the issue, see my last comment in the issue.
Not sure about how to debug more, I have made a unit test which show the bug in this PR.
Most probably not a well coded test but I hope it can help fix the issue.

----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
