### PR TITLE
HHH-18318 fix user guide bootstrap minor link text issue

### DIFF
--- a/documentation/src/main/asciidoc/userguide/chapters/bootstrap/Bootstrap.adoc
+++ b/documentation/src/main/asciidoc/userguide/chapters/bootstrap/Bootstrap.adoc
@@ -242,7 +242,7 @@ include::{example-dir-boot}/BootstrapTest.java[tags=bootstrap-jpa-compliant-Enti
 ====
 If you don't want to provide a `persistence.xml` configuration file, Jakarta Persistence allows you to provide all the configuration options in a
 {jpaJavadocUrlPrefix}spi/PersistenceUnitInfo.html[`PersistenceUnitInfo`] implementation and call
-https://docs.jboss.org/hibernate/orm/{majorMinorVersion}/javadocs/org/hibernate/jpa/HibernatePersistenceProvider.html#createContainerEntityManagerFactory-jakarta.persistence.spi.PersistenceUnitInfo-java.util.Map-[`HibernatePersistenceProvider.html#createContainerEntityManagerFactory`].
+https://docs.jboss.org/hibernate/orm/{majorMinorVersion}/javadocs/org/hibernate/jpa/HibernatePersistenceProvider.html#createContainerEntityManagerFactory-jakarta.persistence.spi.PersistenceUnitInfo-java.util.Map-[`HibernatePersistenceProvider#createContainerEntityManagerFactory()`].
 ====
 
 To inject the default Persistence Context, you can use the {jpaJavadocUrlPrefix}PersistenceContext.html[`@PersistenceContext`] annotation.


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-18318

<img width="1090" alt="Screenshot 2024-06-29 at 08 57 50" src="https://github.com/hibernate/hibernate-orm/assets/8211458/64c2ab77-2f7d-4135-a838-ec0400caf19b">

seems we reuse the link URL as the link text, which is sloppy and inappropriate