### PR TITLE
HHH-18319 fix wrong statement in user guide regarding auto-flush in event of native Session and query

### DIFF
--- a/documentation/src/main/asciidoc/userguide/chapters/flushing/Flushing.adoc
+++ b/documentation/src/main/asciidoc/userguide/chapters/flushing/Flushing.adoc
@@ -124,7 +124,7 @@ include::{example-dir-flushing}/AutoFlushTest.java[tags=flushing-auto-flush-sql-
 ====
 
 If you bootstrap Hibernate natively, and not through Jakarta Persistence, by default,
-the `Session` API will trigger a flush automatically when executing a native query.
+the `Session` API won't trigger a flush automatically when executing a native query.
 
 [[flushing-auto-flush-sql-native-example]]
 .Automatic flushing on native SQL using `Session`


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-18319

It seems a mis-statement about auto-flush in event of native Session and native SQL. I might be wrong but it is so confusing.