### PR TITLE
HHH-18322 Constructor with argument of superclass type not recognized as matching constructor

### DIFF
--- a/hibernate-core/src/test/java/org/hibernate/orm/test/query/hql/instantiation/MatchingConstructorTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/query/hql/instantiation/MatchingConstructorTest.java
@@ -1,0 +1,156 @@
+package org.hibernate.orm.test.query.hql.instantiation;
+
+import org.hibernate.annotations.Imported;
+
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.Jira;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@DomainModel(
+		annotatedClasses = { MatchingConstructorTest.TestEntity.class }
+)
+@SessionFactory
+@Jira("https://hibernate.atlassian.net/browse/HHH-18322")
+public class MatchingConstructorTest {
+
+	@BeforeAll
+	public void prepareData(final SessionFactoryScope scope) {
+		scope.inTransaction(
+				session -> session.save( new TestEntity( 1, 42, "test", 13 ) )
+		);
+	}
+
+	@AfterAll
+	public void cleanUpData(final SessionFactoryScope scope) {
+		scope.inTransaction(
+				session -> session.createQuery( "delete TestEntity" ).executeUpdate()
+		);
+	}
+
+	@Test
+	void testImplicitConstructor(final SessionFactoryScope scope) {
+		scope.inSession( session -> {
+			final var result = session.createQuery(
+							"select num, str from TestEntity",
+							ConstructorDto.class
+					)
+					.setMaxResults( 1 ).getSingleResult();
+			assertEquals( 42, result.getNum() );
+			assertEquals( "test", result.getStr() );
+		} );
+	}
+
+	@Test
+	void testImplicitConstructorWithPrimitive(final SessionFactoryScope scope) {
+		scope.inSession( session -> {
+			final var result = session.createQuery(
+							"select intValue, str from TestEntity",
+							ConstructorWithPrimitiveDto.class
+					)
+					.setMaxResults( 1 ).getSingleResult();
+			assertEquals( 13, result.getIntValue() );
+			assertEquals( "test", result.getStr() );
+		} );
+	}
+
+	@Entity(name = "TestEntity")
+	public static class TestEntity {
+		@Id
+		private Integer id;
+
+		private Integer num;
+
+		private String str;
+
+		private int intValue;
+
+		public TestEntity() {
+		}
+
+		public TestEntity(final Integer id, final Integer num, final String str, final int intValue) {
+			this.id = id;
+			this.num = num;
+			this.str = str;
+			this.intValue = intValue;
+		}
+
+		public Integer getId() {
+			return id;
+		}
+
+		public void setId(final Integer id) {
+			this.id = id;
+		}
+
+		public Integer getNum() {
+			return num;
+		}
+
+		public void setNum(final Integer num) {
+			this.num = num;
+		}
+
+		public String getStr() {
+			return str;
+		}
+
+		public void setStr(final String str) {
+			this.str = str;
+		}
+
+		public int getIntValue() {
+			return intValue;
+		}
+
+		public void setIntValue(final int intValue) {
+			this.intValue = intValue;
+		}
+	}
+
+	@Imported
+	public static class ConstructorDto {
+		private final Number num;
+		private final String str;
+
+		public ConstructorDto(final Number num, final String str) {
+			this.num = num;
+			this.str = str;
+		}
+
+		public Number getNum() {
+			return num;
+		}
+
+		public String getStr() {
+			return str;
+		}
+	}
+
+	@Imported
+	public static class ConstructorWithPrimitiveDto {
+		private final int intValue;
+		private final String str;
+
+		public ConstructorWithPrimitiveDto(final int intValue, final String str) {
+			this.intValue = intValue;
+			this.str = str;
+		}
+
+		public int getIntValue() {
+			return intValue;
+		}
+
+		public String getStr() {
+			return str;
+		}
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/query/hql/instantiation/MatchingConstructorTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/query/hql/instantiation/MatchingConstructorTest.java
@@ -25,7 +25,7 @@ public class MatchingConstructorTest {
 	@BeforeAll
 	public void prepareData(final SessionFactoryScope scope) {
 		scope.inTransaction(
-				session -> session.save( new TestEntity( 1, 42, "test", 13 ) )
+				session -> session.persist( new TestEntity( 1, 42, "test", 13 ) )
 		);
 	}
 


### PR DESCRIPTION
<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

Jira issue HHH-18322[](https://hibernate.atlassian.net/browse/HHH-18322)

If constructor with exact argument types does not exists `NoSuchMethodException` is throws even when matching constructor (e.g. one accepting superclass argument) exists.

To solve the problem, in case when no exact constructor exists, try finding one that matches as fallback

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
