### PR TITLE
HHH-18324 Upgrade to Jandex 3.2.0

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -72,7 +72,7 @@ dependencyResolutionManagement {
             def classmateVersion = version "classmate", "1.5.1"
             def geolatteVersion = version "geolatte", "1.8.2"
             def hcannVersion = version "hcann", "7.0.1.Final"
-            def jandexVersion = version "jandex", "3.1.2"
+            def jandexVersion = version "jandex", "3.2.0"
             def jacksonVersion = version "jackson", "2.17.0"
             def jbossLoggingVersion = version "jbossLogging", "3.5.0.Final"
             def jbossLoggingToolVersion = version "jbossLoggingTool", "2.2.1.Final"


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-18324

This update keeps popping up for Hibernate Search. It would be nice if we could update it in ORM, as the Jandex version in Search is aligned with the one in ORM.

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
