### PR TITLE
Informix Blob locator fix

### DIFF
--- a/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/InformixDialect.java
+++ b/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/InformixDialect.java
@@ -532,6 +532,16 @@ public class InformixDialect extends Dialect {
 	}
 
 	@Override
+	public boolean supportsLobValueChangePropagation() {
+		return false;
+	}
+
+	@Override
+	public boolean supportsUnboundedLobLocatorMaterialization() {
+		return false;
+	}
+
+	@Override
 	public boolean isCurrentTimestampSelectStringCallable() {
 		return false;
 	}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/lob/BlobLocatorTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/lob/BlobLocatorTest.java
@@ -45,7 +45,7 @@ public class BlobLocatorTest extends BaseCoreFunctionalTestCase {
 
 	@Test
 	@RequiresDialectFeature(
-			value = DialectChecks.SupportsUnboundedLobLocatorMaterializationCheck.class,
+			value = DialectChecks.SupportsExpectedLobUsagePattern.class,
 			comment = "database/driver does not support materializing a LOB locator outside the owning transaction"
 	)
 	public void testBoundedBlobLocatorAccess() throws Throwable {


### PR DESCRIPTION
<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

In my opinion, the test `org.hibernate.orm.test.lob.BlobLocatorTest#testBoundedBlobLocatorAccess` should not require the dialect feature `DialectChecks.SupportsUnboundedLobLocatorMaterializationCheck`. It does not test the case where the dialect supports access to BLOBs within a transaction.

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
