### PR TITLE
HHH-18339 Set support filter clause to True for H2

### DIFF
--- a/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/H2LegacySqlAstTranslator.java
+++ b/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/H2LegacySqlAstTranslator.java
@@ -411,4 +411,9 @@ public class H2LegacySqlAstTranslator<T extends JdbcOperation> extends AbstractS
 	protected boolean supportsJoinInMutationStatementSubquery() {
 		return false;
 	}
+
+	@Override
+	public boolean supportsFilterClause() {
+		return getDialect().getVersion().isSameOrAfter( 1, 4, 197 );
+	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/dialect/H2SqlAstTranslator.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/H2SqlAstTranslator.java
@@ -384,4 +384,10 @@ public class H2SqlAstTranslator<T extends JdbcOperation> extends SqlAstTranslato
 	protected boolean supportsJoinInMutationStatementSubquery() {
 		return false;
 	}
+
+	@Override
+	public boolean supportsFilterClause() {
+		// Introduction of FILTER clause https://github.com/h2database/h2database/commit/9e6dbf3baa57000f670826ede431dc7fb4cd9d9c
+		return true;
+	}
 }


### PR DESCRIPTION
<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

H2 supports the filter clause (as it can be seen [here](https://www.h2database.com/html/functions-aggregate.html)) but in the H2SqlAstTranslator the supportsFilterClause is not overridden to be set to true.

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-18339
<!-- Hibernate GitHub Bot issue links end -->