### PR TITLE
Request revive method `hasNonReadOnlyEntities`

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/engine/spi/PersistenceContext.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/spi/PersistenceContext.java
@@ -101,10 +101,10 @@ public interface PersistenceContext {
 	 */
 	void clear();
 
-//	/**
-//	 * @return false if we know for certain that all the entities are read-only
-//	 */
-//	boolean hasNonReadOnlyEntities();
+	/**
+	 * @return false if we know for certain that all the entities are read-only
+	 */
+	boolean hasNonReadOnlyEntities();
 
 	/**
 	 * Set the status of an entry


### PR DESCRIPTION
Hi,

I'm a regular user of Hibernate and have been using it extensively. Recently, I've been studying the internal workings of the @Transactional annotation, particularly the difference in behavior when readOnly is set to true and false.

During my debugging process, I noticed that the hasNonReadOnlyEntities method in the PersistenceContext class has been commented out by Gavin King. However, the variable it refers to still exists, and I believe it would be beneficial to either uncomment this method or provide an alternative getter method.

In this commit, I have simply uncommented the hasNonReadOnlyEntities method in the interface. This change would greatly aid in understanding and working with the read-only behavior of transactions in Hibernate.

Thank you for your consideration.

<img width="877" alt="스크린샷 2024-07-06 오후 3 53 12" src="https://github.com/hibernate/hibernate-orm/assets/37995817/a767a623-522f-413a-a621-8c3108e3d804">

----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
