### PR TITLE
HHH-18341 Fix the delimiter hardcoding defect in AbstractAttributeKey

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/boot/model/source/spi/AbstractAttributeKey.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/source/spi/AbstractAttributeKey.java
@@ -6,9 +6,6 @@
  */
 package org.hibernate.boot.model.source.spi;
 
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-
 import org.hibernate.internal.util.StringHelper;
 
 /**
@@ -17,11 +14,6 @@ import org.hibernate.internal.util.StringHelper;
 public abstract class AbstractAttributeKey {
 	// todo : replace this with "{element}"
 	private static final String COLLECTION_ELEMENT = "collection&&element";
-	private static final String DOT_COLLECTION_ELEMENT = '.' + COLLECTION_ELEMENT;
-	private static final Pattern DOT_COLLECTION_ELEMENT_PATTERN = Pattern.compile(
-			DOT_COLLECTION_ELEMENT,
-			Pattern.LITERAL
-	);
 
 	private final AbstractAttributeKey parent;
 	private final String property;
@@ -138,11 +130,11 @@ public abstract class AbstractAttributeKey {
 	 * marker ({@link #COLLECTION_ELEMENT}.
 	 */
 	public boolean isPartOfCollectionElement() {
-		return fullPath.contains( DOT_COLLECTION_ELEMENT );
+		return fullPath.contains( getDelimiter() + COLLECTION_ELEMENT );
 	}
 
 	public String stripCollectionElementMarker() {
-		return DOT_COLLECTION_ELEMENT_PATTERN.matcher( fullPath ).replaceAll( Matcher.quoteReplacement( "" ) );
+		return fullPath.replace( getDelimiter() + COLLECTION_ELEMENT, "" );
 	}
 
 	@Override

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/boot/model/source/AttributePathTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/boot/model/source/AttributePathTest.java
@@ -6,6 +6,7 @@
  */
 package org.hibernate.orm.test.boot.model.source;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
@@ -15,6 +16,7 @@ import org.junit.Test;
 
 /**
  * @author Guillaume Smet
+ * @author Nathan Xu
  */
 public class AttributePathTest {
 
@@ -24,8 +26,15 @@ public class AttributePathTest {
 		AttributePath attributePath = AttributePath.parse( "items.collection&&element.name" );
 
 		assertFalse( attributePath.isCollectionElement() );
+		assertTrue( attributePath.isPartOfCollectionElement() );
+
 		assertTrue( attributePath.getParent().isCollectionElement() );
+		assertTrue( attributePath.getParent().isPartOfCollectionElement() );
+
 		assertFalse( attributePath.getParent().getParent().isCollectionElement() );
+		assertFalse( attributePath.getParent().getParent().isPartOfCollectionElement() );
+
+		assertEquals( "items.name", attributePath.stripCollectionElementMarker() );
 	}
 
 }


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-18341

```
        protected abstract char getDelimiter();
	... ...
	
	/**
	 * Does any part represent a collection-element reference?
	 *
	 * @return {@code true} if this part or any parent part is a collection element
	 * marker ({@link #COLLECTION_ELEMENT}.
	 */
	public boolean isPartOfCollectionElement() {
		return fullPath.contains( DOT_COLLECTION_ELEMENT );
	}

	public String stripCollectionElementMarker() {
		return DOT_COLLECTION_ELEMENT_PATTERN.matcher( fullPath ).replaceAll( Matcher.quoteReplacement( "" ) );
	}

```

As you can see above, the “.” was hardcoded despite the existence of getDelimiter(), thus defeating the purpose of this flexibility design.