### PR TITLE
HHH-17840 Fix `H2FormatJsonJdbcType` deprecation

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/jdbc/H2FormatJsonJdbcType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/jdbc/H2FormatJsonJdbcType.java
@@ -18,7 +18,7 @@ import org.hibernate.sql.ast.spi.SqlAppender;
  * @author Marco Belladelli
  * @deprecated Use {@link org.hibernate.dialect.H2JsonJdbcType} instead
  */
-@Deprecated(forRemoval = true, since = "6.6")
+@Deprecated(forRemoval = true, since = "6.5")
 public class H2FormatJsonJdbcType extends JsonJdbcType {
 	/**
 	 * Singleton access


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-17840
<!-- Hibernate GitHub Bot issue links end -->