### PR TITLE
HHH-18358 Metemodel generator does not resolving entity type literals

### DIFF
--- a/tooling/metamodel-generator/src/main/java/org/hibernate/processor/validation/MockSessionFactory.java
+++ b/tooling/metamodel-generator/src/main/java/org/hibernate/processor/validation/MockSessionFactory.java
@@ -280,6 +280,8 @@ public abstract class MockSessionFactory
 
 	abstract boolean isEntityDefined(String entityName);
 
+	abstract String findEntityName(String typeName);
+
 	abstract String qualifyName(String entityName);
 
 	abstract boolean isAttributeDefined(String entityName, String fieldName);
@@ -799,6 +801,12 @@ public abstract class MockSessionFactory
 			else {
 				return null;
 			}
+		}
+
+		@Override
+		public <X> ManagedDomainType<X> managedType(String typeName) {
+			final String entityName = findEntityName( typeName );
+			return entityName == null ? null : entity( entityName );
 		}
 
 		@Override

--- a/tooling/metamodel-generator/src/main/java/org/hibernate/processor/validation/ProcessorSessionFactory.java
+++ b/tooling/metamodel-generator/src/main/java/org/hibernate/processor/validation/ProcessorSessionFactory.java
@@ -426,6 +426,16 @@ public abstract class ProcessorSessionFactory extends MockSessionFactory {
 	}
 
 	@Override
+	String findEntityName(String typeName) {
+		for ( final Map.Entry<String, String> e : entityNameMappings.entrySet() ) {
+			if ( typeName.equals( e.getKey() ) || typeName.equals( e.getValue() ) ) {
+				return e.getKey();
+			}
+		}
+		return null;
+	}
+
+	@Override
 	String qualifyName(String entityName) {
 		TypeElement entityClass = findEntityClass(entityName);
 		return entityClass == null ? null : entityClass.getSimpleName().toString();

--- a/tooling/metamodel-generator/src/test/java/org/hibernate/processor/test/typeliteral/TypeLiteralTest.java
+++ b/tooling/metamodel-generator/src/test/java/org/hibernate/processor/test/typeliteral/TypeLiteralTest.java
@@ -1,0 +1,37 @@
+package org.hibernate.processor.test.typeliteral;
+
+import org.hibernate.processor.test.util.CompilationTest;
+import org.hibernate.processor.test.util.TestForIssue;
+import org.hibernate.processor.test.util.TestUtil;
+import org.hibernate.processor.test.util.WithClasses;
+
+import org.junit.Test;
+
+import jakarta.persistence.EntityManager;
+
+import static org.hibernate.processor.test.util.TestUtil.assertMetamodelClassGeneratedFor;
+import static org.hibernate.processor.test.util.TestUtil.assertPresenceOfFieldInMetamodelFor;
+import static org.hibernate.processor.test.util.TestUtil.assertPresenceOfMethodInMetamodelFor;
+
+public class TypeLiteralTest extends CompilationTest {
+
+	@Test
+	@WithClasses(
+			value = {},
+			sources = "org.hibernate.processor.test.typeliteral.Simple"
+	)
+	@TestForIssue(jiraKey = "HHH-18358")
+	public void namedQueryWithTypeLiteral() {
+		final String entityClass = "org.hibernate.processor.test.typeliteral.Simple";
+
+		System.out.println( TestUtil.getMetaModelSourceAsString( entityClass ) );
+
+		assertMetamodelClassGeneratedFor( entityClass );
+
+		assertPresenceOfFieldInMetamodelFor( entityClass, "QUERY_SIMPLE" );
+		assertPresenceOfFieldInMetamodelFor( entityClass, "QUERY_LONGER" );
+
+		assertPresenceOfMethodInMetamodelFor( entityClass, "simple", EntityManager.class );
+		assertPresenceOfMethodInMetamodelFor( entityClass, "longer", EntityManager.class );
+	}
+}

--- a/tooling/metamodel-generator/src/test/resources/org/hibernate/processor/test/typeliteral/Simple.java
+++ b/tooling/metamodel-generator/src/test/resources/org/hibernate/processor/test/typeliteral/Simple.java
@@ -1,0 +1,17 @@
+package org.hibernate.processor.test.typeliteral;
+
+import org.hibernate.annotations.NamedQuery;
+import org.hibernate.annotations.processing.CheckHQL;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+
+@Entity
+@CheckHQL
+@NamedQuery(name = "#simple", query = "select s from Simple s where type(s) = Simple")
+@NamedQuery(name = "#longer", query = "select s from Simple s where type(s) = org.hibernate.processor.test.typeliteral.Simple")
+public class Simple {
+	@Id
+	private Integer id;
+	private String value;
+}


### PR DESCRIPTION
<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

See Jira issue [HHH-18358](https://hibernate.atlassian.net/browse/HHH-18358)

When generating metamodel named query defined as

```@NamedQuery(name = "#simple", query = "select s from Simple s where type(s) = Simple")```

causing generation to fail with error message

```Could not interpret path expression 'Simple'```

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------


[HHH-18358]: https://hibernate.atlassian.net/browse/HHH-18358?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ