### PR TITLE
HHH-17914 - correct the NPE protection in AbstractCollectionPersister.logStaticSQL()

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/persister/collection/AbstractCollectionPersister.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/collection/AbstractCollectionPersister.java
@@ -718,25 +718,22 @@ public abstract class AbstractCollectionPersister
 
 		MODEL_MUTATION_LOGGER.debugf( "Static SQL for collection: %s", getRole() );
 
-		if ( getRowMutationOperations().hasInsertRow() ) {
-			final String insertRowSql = getRowMutationOperations().getInsertRowOperation().getSqlString();
-			if ( insertRowSql != null ) {
-				MODEL_MUTATION_LOGGER.debugf( " Row insert: %s", insertRowSql );
-			}
+		final JdbcMutationOperation insertRowOperation = getRowMutationOperations().getInsertRowOperation();
+		final String insertRowSql = insertRowOperation != null ? insertRowOperation.getSqlString() : null;
+		if ( insertRowSql != null ) {
+			MODEL_MUTATION_LOGGER.debugf( " Row insert: %s", insertRowSql );
 		}
 
-		if ( getRowMutationOperations().hasUpdateRow() ) {
-			final String updateRowSql = getRowMutationOperations().getUpdateRowOperation().getSqlString();
-			if ( updateRowSql != null ) {
-				MODEL_MUTATION_LOGGER.debugf( " Row update: %s", updateRowSql );
-			}
+		final JdbcMutationOperation updateRowOperation = getRowMutationOperations().getUpdateRowOperation();
+		final String updateRowSql = updateRowOperation != null ? updateRowOperation.getSqlString() : null;
+		if ( updateRowSql != null ) {
+			MODEL_MUTATION_LOGGER.debugf( " Row update: %s", updateRowSql );
 		}
 
-		if ( getRowMutationOperations().hasDeleteRow() ) {
-			final String deleteRowSql = getRowMutationOperations().getDeleteRowOperation().getSqlString();
-			if ( deleteRowSql != null ) {
-				MODEL_MUTATION_LOGGER.debugf( " Row delete: %s", deleteRowSql );
-			}
+		final JdbcMutationOperation deleteRowOperation = getRowMutationOperations().getDeleteRowOperation();
+		final String deleteRowSql = deleteRowOperation != null ? deleteRowOperation.getSqlString() : null;
+		if ( deleteRowSql != null ) {
+			MODEL_MUTATION_LOGGER.debugf( " Row delete: %s", deleteRowSql );
 		}
 
 		final String deleteAllSql = getRemoveCoordinator().getSqlString();


### PR DESCRIPTION
Checking if `getRowMutationOperations().hasInsertRow()` (e.g.) is not enough to avoid a possible NPE at `getRowMutationOperations().getInsertRowOperation().getSqlString()` since `getInsertRowOperation()` can still return null

<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

[Please describe here what your change is about]

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-17914
<!-- Hibernate GitHub Bot issue links end -->