### PR TITLE
HHH-18338 o.h.UnknownEntityTypeException: Unable to locate persister thrown when an embeddable object is loaded before the entity it references

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/persister/entity/AbstractEntityPersister.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/entity/AbstractEntityPersister.java
@@ -676,7 +676,7 @@ public abstract class AbstractEntityPersister
 				else {
 					final Column column = (Column) selectable;
 					colNames[k] = column.getQuotedName( dialect );
-					colWriters[k] = column.getWriteExpr( prop.getValue().getSelectableType( factory, k ), dialect );
+					colWriters[k] = column.getWriteExpr( prop.getValue().getSelectableType( creationContext.getMetadata(), k ), dialect );
 				}
 			}
 			propertyColumnNames[i] = colNames;

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/naturalid/NaturalIdAndAssociationTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/naturalid/NaturalIdAndAssociationTest.java
@@ -1,0 +1,118 @@
+package org.hibernate.orm.test.annotations.naturalid;
+
+import java.math.BigDecimal;
+
+import org.hibernate.annotations.NaturalId;
+
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.Jira;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.junit.jupiter.api.Test;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import jakarta.persistence.Embedded;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+
+@DomainModel(
+		annotatedClasses = {
+				NaturalIdAndAssociationTest.PositionEntity.class,
+				NaturalIdAndAssociationTest.ZCurrencyEntity1.class
+		})
+@SessionFactory
+@Jira("HHH-18338")
+public class NaturalIdAndAssociationTest {
+
+	@Test
+	public void testPersist(SessionFactoryScope scope) {
+		scope.inTransaction(
+				session -> {
+					ZCurrencyEntity1 currency = new ZCurrencyEntity1( 1l, "USD" );
+					Amount amount = new Amount( new BigDecimal( "100.00" ), currency );
+					Holding holding = new Holding( amount );
+					PositionEntity positionEntity = new PositionEntity( 1l, "1", holding );
+
+					session.persist( currency );
+					session.persist( positionEntity );
+				}
+		);
+	}
+
+	@Entity(name = "PositionEntity")
+	@Table(name = "POSITION_TABLE")
+	public static class PositionEntity {
+		@Id
+		private Long id;
+
+		private String name;
+
+		@Embedded
+		private Holding holding;
+
+		public PositionEntity() {
+		}
+
+		public PositionEntity(Long id, String name, Holding holding) {
+			this.id = id;
+			this.name = name;
+			this.holding = holding;
+		}
+	}
+
+	@Embeddable
+	public static class Holding {
+		@Embedded
+		private Amount amount;
+
+		public Holding() {
+		}
+
+		public Holding(Amount amount) {
+			this.amount = amount;
+		}
+	}
+
+	@Embeddable
+	public static class Amount {
+
+		private BigDecimal quantity;
+
+		@ManyToOne(fetch = FetchType.LAZY)
+		@JoinColumn(referencedColumnName = "isoCode", nullable = false)
+		private ZCurrencyEntity1 currency;
+
+		public Amount() {
+		}
+
+		public Amount(BigDecimal quantity, ZCurrencyEntity1 currency) {
+			this.quantity = quantity;
+			this.currency = currency;
+		}
+
+	}
+
+	@Entity(name = "ZCurrencyEntity")
+	@Table(name = "CURRENCY")
+	public static class ZCurrencyEntity1 {
+		@Id
+		private Long id;
+
+		@NaturalId
+		private String isoCode;
+
+		public ZCurrencyEntity1() {
+		}
+
+		public ZCurrencyEntity1(Long id, String isoCode) {
+			this.id = id;
+			this.isoCode = isoCode;
+		}
+	}
+
+}


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-18338

`SessionFactoryImplementor` uses the `EntityPersister` to retrieve the type of the Selectable causing an `o.h.UnknownEntityTypeException` to be thrown when  the corresponding `EntityPersister` has not been created yet , using `MetadataImplementor` instead solves this issue.

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
