### PR TITLE
HHH-17949 Fix upsert handling when optimistic locking is involved

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/dialect/SqlAstTranslatorWithUpsert.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/SqlAstTranslatorWithUpsert.java
@@ -215,7 +215,7 @@ public class SqlAstTranslatorWithUpsert<T extends JdbcOperation> extends Abstrac
 					appendSql(" and ");
 				}
 				binding.getColumnReference().appendColumnForWrite( this, "t" );
-				appendSql("<=");
+				appendSql("=");
 				binding.getValueExpression().accept( this );
 			}
 		}

--- a/hibernate-core/src/main/java/org/hibernate/sql/model/jdbc/OptionalTableUpdateOperation.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/model/jdbc/OptionalTableUpdateOperation.java
@@ -386,21 +386,24 @@ public class OptionalTableUpdateOperation implements SelfExecutingUpdateOperatio
 
 			final BindingGroup bindingGroup = jdbcValueBindings.getBindingGroup( tableMapping.getTableName() );
 			if ( bindingGroup != null ) {
-				bindingGroup.forEachBinding( (binding) -> {
-					try {
-						binding.getValueBinder().bind(
-								insertStatement,
-								binding.getValue(),
-								binding.getPosition(),
-								session
-						);
-					}
-					catch (SQLException e) {
-						throw session.getJdbcServices().getSqlExceptionHelper().convert(
-								e,
-								"Unable to bind parameter for upsert insert",
-								jdbcInsert.getSqlString()
-						);
+				bindingGroup.forEachBinding( binding -> {
+					// Skip parameter bindings for e.g. optimistic version check
+					if ( binding.getPosition() <= jdbcInsert.getParameterBinders().size() ) {
+						try {
+							binding.getValueBinder().bind(
+									insertStatement,
+									binding.getValue(),
+									binding.getPosition(),
+									session
+							);
+						}
+						catch (SQLException e) {
+							throw session.getJdbcServices().getSqlExceptionHelper().convert(
+									e,
+									"Unable to bind parameter for upsert insert",
+									jdbcInsert.getSqlString()
+							);
+						}
 					}
 				} );
 			}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/stateless/UpsertVersionedTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/stateless/UpsertVersionedTest.java
@@ -3,12 +3,7 @@ package org.hibernate.orm.test.stateless;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jakarta.persistence.Version;
-import org.hibernate.dialect.H2Dialect;
-import org.hibernate.dialect.OracleDialect;
-import org.hibernate.dialect.PostgreSQLDialect;
-import org.hibernate.dialect.SQLServerDialect;
 import org.hibernate.testing.orm.junit.DomainModel;
-import org.hibernate.testing.orm.junit.RequiresDialect;
 import org.hibernate.testing.orm.junit.SessionFactory;
 import org.hibernate.testing.orm.junit.SessionFactoryScope;
 import org.junit.jupiter.api.Test;
@@ -18,10 +13,6 @@ import static org.junit.Assert.assertEquals;
 @SessionFactory
 @DomainModel(annotatedClasses = UpsertVersionedTest.Record.class)
 public class UpsertVersionedTest {
-    @RequiresDialect(OracleDialect.class)
-    @RequiresDialect(H2Dialect.class)
-    @RequiresDialect(SQLServerDialect.class)
-    @RequiresDialect(value = PostgreSQLDialect.class, matchSubTypes = false)
     @Test void test(SessionFactoryScope scope) {
         scope.inStatelessTransaction(s-> {
             s.upsert(new Record(123L,null,"hello earth"));
@@ -32,21 +23,21 @@ public class UpsertVersionedTest {
             assertEquals("hello mars",s.get(Record.class,456L).message);
         });
         scope.inStatelessTransaction(s-> {
-            s.upsert(new Record(123L,1L,"goodbye earth"));
+            s.upsert(new Record(123L,0L,"goodbye earth"));
         });
         scope.inStatelessTransaction(s-> {
             assertEquals("goodbye earth",s.get(Record.class,123L).message);
             assertEquals("hello mars",s.get(Record.class,456L).message);
         });
         scope.inStatelessTransaction(s-> {
-            s.upsert(new Record(456L,4L,"goodbye mars"));
+            s.upsert(new Record(456L,3L,"goodbye mars"));
         });
         scope.inStatelessTransaction(s-> {
             assertEquals("goodbye earth",s.get(Record.class,123L).message);
             assertEquals("goodbye mars",s.get(Record.class,456L).message);
         });
     }
-    @Entity
+    @Entity(name = "Record")
     static class Record {
         @Id Long id;
         @Version Long version;


### PR DESCRIPTION
[HHH-17949](https://hibernate.atlassian.net/browse/HHH-17949)

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------


[HHH-17949]: https://hibernate.atlassian.net/browse/HHH-17949?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ