### PR TITLE
HHH-17847:  fix StoredProcedureQuery.getResultList()

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/result/internal/OutputsImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/result/internal/OutputsImpl.java
@@ -154,22 +154,6 @@ public class OutputsImpl implements Outputs {
 		final ProcedureCallImpl<?> procedureCall = (ProcedureCallImpl<?>) context;
 		final ResultSetMapping resultSetMapping = procedureCall.getResultSetMapping();
 
-		final JavaTypeRegistry javaTypeRegistry = context.getSession()
-				.getTypeConfiguration()
-				.getJavaTypeRegistry();
-		procedureCall.getParameterBindings().visitBindings( (parameterImplementor, queryParameterBinding) -> {
-			final ProcedureParameter<?> parameter = (ProcedureParameter<?>) parameterImplementor;
-			if ( parameter.getMode() == ParameterMode.INOUT ) {
-				final JavaType<?> basicType = javaTypeRegistry.getDescriptor( parameterImplementor.getParameterType() );
-				if ( basicType != null ) {
-					resultSetMapping.addResultBuilder( new ScalarDomainResultBuilder<>( basicType ) );
-				}
-				else {
-					throw new UnsupportedOperationException();
-				}
-			}
-		} );
-
 		final ExecutionContext executionContext = new OutputsExecutionContext( context.getSession() );
 
 		final JdbcValues jdbcValues = new JdbcValuesResultSetImpl(

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/sql/MySQLStoredProcedureTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/sql/MySQLStoredProcedureTest.java
@@ -43,6 +43,7 @@ import jakarta.persistence.ParameterMode;
 import jakarta.persistence.StoredProcedureQuery;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -92,6 +93,15 @@ public class MySQLStoredProcedureTest {
 									"END"
 					);
 					//end::sql-sp-no-out-mysql-example[]
+					//tag::sql-sp-inout-mysql-example[]
+					statement.executeUpdate(
+							"CREATE PROCEDURE sp_inout_phones(INOUT phoneId INT) " +
+									"BEGIN " +
+									"    SELECT MAX(id) INTO phoneId FROM Phone WHERE id > phoneId; " +
+									"    SELECT * FROM Phone LIMIT 2;  " +
+									"END  "
+					);
+					//end::sql-sp-inout-mysql-example[]
 					//tag::sql-function-mysql-example[]
 					statement.executeUpdate(
 							"CREATE FUNCTION fn_count_phones(personId integer)  " +
@@ -161,6 +171,16 @@ public class MySQLStoredProcedureTest {
 			session.doWork( connection -> {
 				try (Statement statement = connection.createStatement()) {
 					statement.executeUpdate( "DROP FUNCTION IF EXISTS fn_count_phones" );
+				}
+				catch (SQLException ignore) {
+				}
+			} );
+		} );
+		scope.inTransaction( entityManager -> {
+			Session session = entityManager.unwrap( Session.class );
+			session.doWork( connection -> {
+				try (Statement statement = connection.createStatement()) {
+					statement.executeUpdate( "DROP PROCEDURE IF EXISTS sp_inout_phones" );
 				}
 				catch (SQLException ignore) {
 				}
@@ -273,6 +293,26 @@ public class MySQLStoredProcedureTest {
 			} );
 			//end::sql-call-function-mysql-example[]
 			assertEquals( Integer.valueOf( 2 ), phoneCount.get() );
+		} );
+	}
+
+	@Test
+	@SuppressWarnings("unchecked")
+	public void testStoredProcedureInOutParameterAndResultList(EntityManagerFactoryScope scope) {
+		scope.inTransaction( entityManager -> {
+			//tag::sql-jpa-call-sp-inout-with-result-list-mysql-example[]
+			StoredProcedureQuery query = entityManager.createStoredProcedureQuery( "sp_inout_phones", Phone.class);
+			query.registerStoredProcedureParameter( 1, Long.class, ParameterMode.INOUT );
+			query.setParameter( 1, 1L );
+			query.execute();
+
+			Long maxId = (Long) query.getOutputParameterValue(1);
+			List supposedToBePhone = query.getResultList();
+			assertEquals(2, maxId);
+			//end::sql-jpa-call-sp-inout-with-result-list-mysql-example[]
+			// now let's see how the JDBC ResultSet is extracted
+			// this test should fail as of Hibernate 6.4.1, each item in the result set is an array: [Phone, Long]
+            assertInstanceOf(Phone.class, supposedToBePhone.get(0));
 		} );
 	}
 }


### PR DESCRIPTION
This is to fix the issue with StoredProcedureQuery getResultList when the parameter has INOUT param.
https://hibernate.atlassian.net/browse/HHH-17847.
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).