### PR TITLE
HHH-18306 - Implicit instantiation for queries with single selectionitem broken

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/internal/AbstractSharedSessionContract.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/AbstractSharedSessionContract.java
@@ -828,12 +828,7 @@ public abstract class AbstractSharedSessionContract implements SharedSessionCont
 
 	protected <R> HqlInterpretation<R> interpretHql(String hql, Class<R> resultType) {
 		final QueryEngine queryEngine = getFactory().getQueryEngine();
-		return queryEngine.getInterpretationCache()
-				.resolveHqlInterpretation(
-						hql,
-						resultType,
-						queryEngine.getHqlTranslator()
-				);
+		return queryEngine.interpretHql( hql, resultType );
 	}
 
 	protected static void checkSelectionQuery(String hql, HqlInterpretation<?> hqlInterpretation) {

--- a/hibernate-core/src/main/java/org/hibernate/query/SelectionQuery.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/SelectionQuery.java
@@ -407,17 +407,6 @@ public interface SelectionQuery<R> extends CommonQueryContract {
 	 */
 	SelectionQuery<R> setFirstResult(int startPosition);
 
-//	/**
-//	 * Set the page of results to return.
-//	 *
-//	 * @param pageNumber the page to return, where pages are numbered from zero
-//	 * @param pageSize the number of results per page
-//	 *
-//	 * @since 6.3
-//	 */
-//	@Incubating
-//	SelectionQuery<R> setPage(int pageSize, int pageNumber);
-
 	/**
 	 * Set the {@linkplain Page page} of results to return.
 	 *

--- a/hibernate-core/src/main/java/org/hibernate/query/spi/QueryEngine.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/spi/QueryEngine.java
@@ -49,5 +49,9 @@ public interface QueryEngine {
 	HqlTranslator getHqlTranslator();
 
 	SqmTranslatorFactory getSqmTranslatorFactory();
+
+	default <R> HqlInterpretation<R> interpretHql(String hql, Class<R> resultType) {
+		return getInterpretationCache().resolveHqlInterpretation( hql, resultType, getHqlTranslator() );
+	}
 }
 

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/internal/SqmSelectionQueryImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/internal/SqmSelectionQueryImpl.java
@@ -107,11 +107,11 @@ public class SqmSelectionQueryImpl<R> extends AbstractSqmSelectionQuery<R>
 		this.parameterBindings = QueryParameterBindingsImpl.from( parameterMetadata, session.getFactory() );
 
 		this.expectedResultType = expectedResultType;
-//		visitQueryReturnType( sqm.getQueryPart(), expectedResultType, getSessionFactory() );
+		visitQueryReturnType( sqm.getQueryPart(), expectedResultType, getSessionFactory() );
 		this.resultType = determineResultType( sqm );
+		this.tupleMetadata = buildTupleMetadata( sqm, expectedResultType );
 
 		setComment( hql );
-		this.tupleMetadata = buildTupleMetadata( sqm, expectedResultType );
 	}
 
 	private Class<?> determineResultType(SqmSelectStatement<?> sqm) {

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/query/results/BasicCriteriaResultTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/query/results/BasicCriteriaResultTests.java
@@ -30,7 +30,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 /**
  * @author Steve Ebersole
  */
-@DomainModel( annotatedClasses = SimpleEntity.class )
+@DomainModel( annotatedClasses = {SimpleEntity.class, Dto.class, Dto2.class } )
 @SessionFactory
 public class BasicCriteriaResultTests {
 	@BeforeEach

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/query/results/BasicHqlResultTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/query/results/BasicHqlResultTests.java
@@ -21,7 +21,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 /**
  * @author Steve Ebersole
  */
-@DomainModel( annotatedClasses = SimpleEntity.class )
+@DomainModel( annotatedClasses = {SimpleEntity.class, Dto.class, Dto2.class } )
 @SessionFactory
 public class BasicHqlResultTests {
 	@BeforeEach

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/query/results/Dto.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/query/results/Dto.java
@@ -1,0 +1,31 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html.
+ */
+package org.hibernate.orm.test.query.results;
+
+import org.hibernate.annotations.Imported;
+
+/**
+ * @author Steve Ebersole
+ */
+@Imported
+public class Dto {
+	private final Integer key;
+	private final String text;
+
+	public Dto(Integer key, String text) {
+		this.key = key;
+		this.text = text;
+	}
+
+	public Integer getKey() {
+		return key;
+	}
+
+	public String getText() {
+		return text;
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/query/results/Dto2.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/query/results/Dto2.java
@@ -1,0 +1,25 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html.
+ */
+package org.hibernate.orm.test.query.results;
+
+import org.hibernate.annotations.Imported;
+
+/**
+ * @author Steve Ebersole
+ */
+@Imported
+public class Dto2 {
+	private final String text;
+
+	public Dto2(String text) {
+		this.text = text;
+	}
+
+	public String getText() {
+		return text;
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/query/results/ImplicitInstantiationTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/query/results/ImplicitInstantiationTests.java
@@ -1,0 +1,140 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html.
+ */
+package org.hibernate.orm.test.query.results;
+
+import org.hibernate.query.criteria.HibernateCriteriaBuilder;
+import org.hibernate.query.criteria.JpaCriteriaQuery;
+import org.hibernate.query.criteria.JpaRoot;
+
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.FailureExpected;
+import org.hibernate.testing.orm.junit.Jira;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Steve Ebersole
+ */
+@DomainModel(annotatedClasses = {SimpleEntity.class, SimpleComposite.class, Dto.class, Dto2.class})
+@SessionFactory
+@SuppressWarnings("JUnitMalformedDeclaration")
+public class ImplicitInstantiationTests {
+	@BeforeEach
+	void prepareTestData(SessionFactoryScope sessions) {
+		sessions.inTransaction( (session) -> {
+			session.persist( new SimpleEntity( 1, "first", new SimpleComposite( "value1", "value2" ) ) );
+		} );
+	}
+
+	@AfterEach
+	public void dropTestData(SessionFactoryScope sessions) {
+		sessions.inTransaction( (session) -> {
+			session.createMutationQuery( "delete SimpleEntity" ).executeUpdate();
+		});
+	}
+
+	@Test
+	void testCreateQuery(SessionFactoryScope sessions) {
+		sessions.inTransaction( (session) -> {
+			final Dto rtn = session.createQuery( Queries.ID_NAME, Dto.class ).getSingleResultOrNull();
+			assertThat( rtn ).isNotNull();
+			assertThat( rtn.getKey() ).isEqualTo( 1 );
+			assertThat( rtn.getText() ).isEqualTo( "first" );
+		} );
+
+		sessions.inTransaction( (session) -> {
+			final Dto rtn = session.createQuery( Queries.ID_COMP_VAL, Dto.class ).getSingleResultOrNull();
+			assertThat( rtn ).isNotNull();
+			assertThat( rtn.getKey() ).isEqualTo( 1 );
+			assertThat( rtn.getText() ).isEqualTo( "value1" );
+		} );
+	}
+
+	@Test
+	void testCreateSelectionQuery(SessionFactoryScope sessions) {
+		sessions.inTransaction( (session) -> {
+			final Dto rtn = session.createSelectionQuery( Queries.ID_NAME, Dto.class ).getSingleResultOrNull();
+			assertThat( rtn ).isNotNull();
+			assertThat( rtn.getKey() ).isEqualTo( 1 );
+			assertThat( rtn.getText() ).isEqualTo( "first" );
+		} );
+
+		sessions.inTransaction( (session) -> {
+			final Dto rtn = session.createSelectionQuery( Queries.ID_COMP_VAL, Dto.class ).getSingleResultOrNull();
+			assertThat( rtn ).isNotNull();
+			assertThat( rtn.getKey() ).isEqualTo( 1 );
+			assertThat( rtn.getText() ).isEqualTo( "value1" );
+		} );
+	}
+
+	@Test
+	void testCriteria(SessionFactoryScope sessions) {
+		sessions.inTransaction( (session) -> {
+			final HibernateCriteriaBuilder criteriaBuilder = session.getCriteriaBuilder();
+
+			final JpaCriteriaQuery<Dto> criteria = criteriaBuilder.createQuery( Dto.class );
+			final JpaRoot<SimpleEntity> root = criteria.from( SimpleEntity.class );
+			criteria.multiselect( root.get( "id" ), root.get( "name" ) );
+			final Dto rtn = session.createQuery( criteria ).getSingleResultOrNull();
+			assertThat( rtn ).isNotNull();
+			assertThat( rtn.getKey() ).isEqualTo( 1 );
+			assertThat( rtn.getText() ).isEqualTo( "first" );
+		} );
+	}
+
+	@Test
+	@Jira( "https://hibernate.atlassian.net/browse/HHH-18306" )
+	void testCreateQuerySingleSelectItem(SessionFactoryScope sessions) {
+		sessions.inTransaction( (session) -> {
+			final Dto2 rtn = session.createQuery( Queries.NAME, Dto2.class ).getSingleResultOrNull();
+			assertThat( rtn ).isNotNull();
+			assertThat( rtn.getText() ).isEqualTo( "first" );
+		} );
+
+		sessions.inTransaction( (session) -> {
+			final Dto2 rtn = session.createQuery( Queries.COMP_VAL, Dto2.class ).getSingleResultOrNull();
+			assertThat( rtn ).isNotNull();
+			assertThat( rtn.getText() ).isEqualTo( "value1" );
+		} );
+	}
+
+	@Test
+	@Jira( "https://hibernate.atlassian.net/browse/HHH-18306" )
+	void testCreateSelectionQuerySingleSelectItem(SessionFactoryScope sessions) {
+		sessions.inTransaction( (session) -> {
+			final Dto2 rtn = session.createSelectionQuery( Queries.NAME, Dto2.class ).getSingleResultOrNull();
+			assertThat( rtn ).isNotNull();
+			assertThat( rtn.getText() ).isEqualTo( "first" );
+		} );
+
+		sessions.inTransaction( (session) -> {
+			final Dto2 rtn = session.createSelectionQuery( Queries.COMP_VAL, Dto2.class ).getSingleResultOrNull();
+			assertThat( rtn ).isNotNull();
+			assertThat( rtn.getText() ).isEqualTo( "value1" );
+		} );
+	}
+
+	@Test
+	@Jira( "https://hibernate.atlassian.net/browse/HHH-18306" )
+	void testCriteriaSingleSelectItem(SessionFactoryScope sessions) {
+		sessions.inTransaction( (session) -> {
+			final HibernateCriteriaBuilder criteriaBuilder = session.getCriteriaBuilder();
+
+			final JpaCriteriaQuery<Dto2> criteria = criteriaBuilder.createQuery( Dto2.class );
+			final JpaRoot<SimpleEntity> root = criteria.from( SimpleEntity.class );
+			criteria.multiselect( root.get( "name" ) );
+			final Dto2 rtn = session.createQuery( criteria ).getSingleResultOrNull();
+			assertThat( rtn ).isNotNull();
+			assertThat( rtn.getText() ).isEqualTo( "first" );
+		} );
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/query/results/InvalidReturnTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/query/results/InvalidReturnTests.java
@@ -1,0 +1,147 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html.
+ */
+package org.hibernate.orm.test.query.results;
+
+import org.hibernate.query.QueryTypeMismatchException;
+
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.Jira;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.fail;
+
+/**
+ * @author Steve Ebersole
+ */
+@Jira( "https://hibernate.atlassian.net/browse/HHH-18401" )
+@DomainModel(annotatedClasses = {SimpleEntity.class, SimpleComposite.class, Dto.class, Dto2.class})
+@SessionFactory
+@SuppressWarnings("JUnitMalformedDeclaration")
+public class InvalidReturnTests {
+
+	@Test
+	void testCreateQuery(SessionFactoryScope sessions) {
+		sessions.inTransaction( (session) -> {
+			try {
+				session.createQuery( Queries.ENTITY, SimpleComposite.class );
+				fail( "Expecting a QueryTypeMismatchException" );
+			}
+			catch (QueryTypeMismatchException expected) {
+			}
+
+			try {
+				session.createQuery( Queries.ENTITY, Dto.class );
+				fail( "Expecting a QueryTypeMismatchException" );
+			}
+			catch (QueryTypeMismatchException expected) {
+			}
+
+			try {
+				session.createQuery( Queries.ENTITY_NO_SELECT, SimpleComposite.class );
+				fail( "Expecting a QueryTypeMismatchException" );
+			}
+			catch (QueryTypeMismatchException expected) {
+			}
+
+			try {
+				session.createQuery( Queries.COMPOSITE, SimpleEntity.class );
+				fail( "Expecting a QueryTypeMismatchException" );
+			}
+			catch (QueryTypeMismatchException expected) {
+			}
+
+			try {
+				session.createQuery( Queries.ID_NAME_DTO, SimpleEntity.class );
+				fail( "Expecting a QueryTypeMismatchException" );
+			}
+			catch (QueryTypeMismatchException expected) {
+			}
+		} );
+	}
+
+	@Test
+	void testCreateSelectionQuery(SessionFactoryScope sessions) {
+		sessions.inTransaction( (session) -> {
+			try {
+				session.createSelectionQuery( Queries.ENTITY, SimpleComposite.class );
+				fail( "Expecting a QueryTypeMismatchException" );
+			}
+			catch (QueryTypeMismatchException expected) {
+			}
+
+			try {
+				session.createSelectionQuery( Queries.ENTITY_NO_SELECT, Dto.class );
+				fail( "Expecting a QueryTypeMismatchException" );
+			}
+			catch (QueryTypeMismatchException expected) {
+			}
+
+			try {
+				session.createSelectionQuery( Queries.ENTITY_NO_SELECT, SimpleComposite.class );
+				fail( "Expecting a QueryTypeMismatchException" );
+			}
+			catch (QueryTypeMismatchException expected) {
+			}
+
+			try {
+				session.createSelectionQuery( Queries.COMPOSITE, SimpleEntity.class );
+				fail( "Expecting a QueryTypeMismatchException" );
+			}
+			catch (QueryTypeMismatchException expected) {
+			}
+
+			try {
+				session.createSelectionQuery( Queries.ID_NAME_DTO, SimpleEntity.class );
+				fail( "Expecting a QueryTypeMismatchException" );
+			}
+			catch (QueryTypeMismatchException expected) {
+			}
+		} );
+	}
+
+	@Test
+	void testNamedQuery(SessionFactoryScope sessions) {
+		sessions.inTransaction( (session) -> {
+			try {
+				session.createNamedQuery( Queries.NAMED_ENTITY, SimpleComposite.class );
+				fail( "Expecting a QueryTypeMismatchException" );
+			}
+			catch (QueryTypeMismatchException expected) {
+			}
+
+			try {
+				session.createNamedQuery( Queries.NAMED_ENTITY_NO_SELECT, Dto.class );
+				fail( "Expecting a QueryTypeMismatchException" );
+			}
+			catch (QueryTypeMismatchException expected) {
+			}
+
+			try {
+				session.createNamedQuery( Queries.NAMED_ENTITY_NO_SELECT, SimpleComposite.class );
+				fail( "Expecting a QueryTypeMismatchException" );
+			}
+			catch (QueryTypeMismatchException expected) {
+			}
+
+			try {
+				session.createNamedQuery( Queries.NAMED_COMPOSITE, SimpleEntity.class );
+				fail( "Expecting a QueryTypeMismatchException" );
+			}
+			catch (QueryTypeMismatchException expected) {
+			}
+
+			try {
+				session.createNamedQuery( Queries.NAMED_ID_NAME_DTO, SimpleEntity.class );
+				fail( "Expecting a QueryTypeMismatchException" );
+			}
+			catch (QueryTypeMismatchException expected) {
+			}
+		} );
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/query/results/Queries.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/query/results/Queries.java
@@ -1,0 +1,40 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html.
+ */
+package org.hibernate.orm.test.query.results;
+
+/**
+ * @author Steve Ebersole
+ */
+public class Queries {
+	public static final String ENTITY = "select e from SimpleEntity e";
+	public static final String ENTITY_NO_SELECT = "from SimpleEntity e";
+
+	public static final String COMPOSITE = "select e.composite from SimpleEntity e";
+	public static final String NAME = "select e.name from SimpleEntity e";
+	public static final String COMP_VAL = "select e.composite.value1 from SimpleEntity e";
+
+	public static final String ID_NAME = "select e.id, e.name from SimpleEntity e";
+	public static final String ID_COMP_VAL = "select e.id, e.composite.value1 from SimpleEntity e";
+
+	public static final String ID_NAME_DTO = "select new Dto(e.id, e.name) from SimpleEntity e";
+	public static final String ID_COMP_VAL_DTO = "select new Dto(e.id, e.composite.value1) from SimpleEntity e";
+
+	public static final String NAME_DTO = "select new Dto2(e.name) from SimpleEntity e";
+	public static final String COMP_VAL_DTO = "select new Dto2(e.composite.value1) from SimpleEntity e";
+
+	public static final String NAMED_ENTITY = "entity";
+	public static final String NAMED_ENTITY_NO_SELECT = "entity-no-select";
+	public static final String NAMED_COMPOSITE = "composite";
+	public static final String NAMED_NAME = "name";
+	public static final String NAMED_COMP_VAL = "comp-val";
+	public static final String NAMED_ID_NAME = "id-name";
+	public static final String NAMED_ID_COMP_VAL = "id-comp-val";
+	public static final String NAMED_ID_NAME_DTO = "id-name-dto";
+	public static final String NAMED_ID_COMP_VAL_DTO = "id-comp-val-dto";
+	public static final String NAMED_NAME_DTO = "name-dto";
+	public static final String NAMED_COMP_VAL_DTO = "comp-val-dto";
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/query/results/SimpleEntity.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/query/results/SimpleEntity.java
@@ -7,8 +7,8 @@
 package org.hibernate.orm.test.query.results;
 
 import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
+import jakarta.persistence.NamedQuery;
 import jakarta.persistence.Table;
 
 /**
@@ -16,6 +16,17 @@ import jakarta.persistence.Table;
  */
 @Entity(name = "SimpleEntity")
 @Table(name = "simple_entity")
+@NamedQuery(name= Queries.NAMED_ENTITY, query = Queries.ENTITY)
+@NamedQuery(name= Queries.NAMED_ENTITY_NO_SELECT, query = Queries.ENTITY_NO_SELECT)
+@NamedQuery(name= Queries.NAMED_COMPOSITE, query = Queries.COMPOSITE)
+@NamedQuery(name= Queries.NAMED_NAME, query = Queries.NAME)
+@NamedQuery(name= Queries.NAMED_COMP_VAL, query = Queries.COMP_VAL)
+@NamedQuery(name= Queries.NAMED_ID_NAME, query = Queries.ID_NAME)
+@NamedQuery(name= Queries.NAMED_ID_COMP_VAL, query = Queries.ID_COMP_VAL)
+@NamedQuery(name= Queries.NAMED_ID_NAME_DTO, query = Queries.ID_NAME_DTO)
+@NamedQuery(name= Queries.NAMED_ID_COMP_VAL_DTO, query = Queries.ID_COMP_VAL_DTO)
+@NamedQuery(name= Queries.NAMED_NAME_DTO, query = Queries.NAME_DTO)
+@NamedQuery(name= Queries.NAMED_COMP_VAL_DTO, query = Queries.COMP_VAL_DTO)
 public class SimpleEntity {
 	@Id
 	public Integer id;

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/query/results/TypedQueryCreationTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/query/results/TypedQueryCreationTests.java
@@ -1,0 +1,202 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html.
+ */
+package org.hibernate.orm.test.query.results;
+
+import org.hibernate.query.criteria.HibernateCriteriaBuilder;
+import org.hibernate.query.criteria.JpaCriteriaQuery;
+import org.hibernate.query.criteria.JpaRoot;
+
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.Jira;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Steve Ebersole
+ */
+@Jira( "https://hibernate.atlassian.net/browse/HHH-18401" )
+@DomainModel(annotatedClasses = {SimpleEntity.class, SimpleComposite.class, Dto.class, Dto2.class})
+@SessionFactory
+@SuppressWarnings("JUnitMalformedDeclaration")
+public class TypedQueryCreationTests {
+	@BeforeEach
+	void prepareTestData(SessionFactoryScope sessions) {
+		sessions.inTransaction( (session) -> {
+			session.persist( new SimpleEntity( 1, "first", new SimpleComposite( "value1", "value2" ) ) );
+		} );
+	}
+
+	@AfterEach
+	public void dropTestData(SessionFactoryScope sessions) {
+		sessions.inTransaction( (session) -> {
+			session.createMutationQuery( "delete SimpleEntity" ).executeUpdate();
+		});
+	}
+
+	@Test
+	void testCreateQuery(SessionFactoryScope sessions) {
+		sessions.inTransaction( (session) -> {
+			final SimpleEntity rtn = session.createQuery( Queries.ENTITY, SimpleEntity.class ).getSingleResultOrNull();
+			assertThat( rtn ).isNotNull();
+			assertThat( rtn.id ).isEqualTo( 1 );
+		} );
+
+		sessions.inTransaction( (session) -> {
+			final SimpleEntity rtn = session.createQuery( Queries.ENTITY_NO_SELECT, SimpleEntity.class ).getSingleResultOrNull();
+			assertThat( rtn ).isNotNull();
+			assertThat( rtn.id ).isEqualTo( 1 );
+		} );
+
+		sessions.inTransaction( (session) -> {
+			final SimpleComposite rtn = session.createQuery( Queries.COMPOSITE, SimpleComposite.class ).getSingleResultOrNull();
+			assertThat( rtn ).isNotNull();
+			assertThat( rtn.value1 ).isEqualTo( "value1" );
+			assertThat( rtn.value2 ).isEqualTo( "value2" );
+		} );
+
+		sessions.inTransaction( (session) -> {
+			final Dto rtn = session.createQuery( Queries.ID_NAME_DTO, Dto.class ).getSingleResultOrNull();
+			assertThat( rtn ).isNotNull();
+			assertThat( rtn.getKey() ).isEqualTo( 1 );
+			assertThat( rtn.getText() ).isEqualTo( "first" );
+		} );
+
+		sessions.inTransaction( (session) -> {
+			final Dto rtn = session.createQuery( Queries.ID_COMP_VAL_DTO, Dto.class ).getSingleResultOrNull();
+			assertThat( rtn ).isNotNull();
+			assertThat( rtn.getKey() ).isEqualTo( 1 );
+			assertThat( rtn.getText() ).isEqualTo( "value1" );
+		} );
+
+		sessions.inTransaction( (session) -> {
+			final String rtn = session.createQuery( Queries.NAME, String.class ).getSingleResultOrNull();
+			assertThat( rtn ).isNotNull();
+			assertThat( rtn ).isEqualTo( "first" );
+		} );
+
+		sessions.inTransaction( (session) -> {
+			final String rtn = session.createQuery( Queries.COMP_VAL, String.class ).getSingleResultOrNull();
+			assertThat( rtn ).isNotNull();
+			assertThat( rtn ).isEqualTo( "value1" );
+		} );
+	}
+
+	@Test
+	void testCreateSelectionQuery(SessionFactoryScope sessions) {
+		sessions.inTransaction( (session) -> {
+			final SimpleEntity rtn = session.createSelectionQuery( Queries.ENTITY, SimpleEntity.class ).getSingleResultOrNull();
+			assertThat( rtn ).isNotNull();
+			assertThat( rtn.id ).isEqualTo( 1 );
+		} );
+
+		sessions.inTransaction( (session) -> {
+			final SimpleEntity rtn = session.createSelectionQuery( Queries.ENTITY_NO_SELECT, SimpleEntity.class ).getSingleResultOrNull();
+			assertThat( rtn ).isNotNull();
+			assertThat( rtn.id ).isEqualTo( 1 );
+		} );
+
+		sessions.inTransaction( (session) -> {
+			final SimpleComposite rtn = session.createSelectionQuery( Queries.COMPOSITE, SimpleComposite.class ).getSingleResultOrNull();
+			assertThat( rtn ).isNotNull();
+			assertThat( rtn.value1 ).isEqualTo( "value1" );
+			assertThat( rtn.value2 ).isEqualTo( "value2" );
+		} );
+
+		sessions.inTransaction( (session) -> {
+			final Dto rtn = session.createSelectionQuery( Queries.ID_NAME_DTO, Dto.class ).getSingleResultOrNull();
+			assertThat( rtn ).isNotNull();
+			assertThat( rtn.getKey() ).isEqualTo( 1 );
+			assertThat( rtn.getText() ).isEqualTo( "first" );
+		} );
+
+		sessions.inTransaction( (session) -> {
+			final Dto rtn = session.createSelectionQuery( Queries.ID_COMP_VAL_DTO, Dto.class ).getSingleResultOrNull();
+			assertThat( rtn ).isNotNull();
+			assertThat( rtn.getKey() ).isEqualTo( 1 );
+			assertThat( rtn.getText() ).isEqualTo( "value1" );
+		} );
+
+		sessions.inTransaction( (session) -> {
+			final String rtn = session.createSelectionQuery( Queries.NAME, String.class ).getSingleResultOrNull();
+			assertThat( rtn ).isNotNull();
+			assertThat( rtn ).isEqualTo( "first" );
+		} );
+
+		sessions.inTransaction( (session) -> {
+			final String rtn = session.createSelectionQuery( Queries.COMP_VAL, String.class ).getSingleResultOrNull();
+			assertThat( rtn ).isNotNull();
+			assertThat( rtn ).isEqualTo( "value1" );
+		} );
+	}
+
+	@Test
+	void testCreateNamedQuery(SessionFactoryScope sessions) {
+		sessions.inTransaction( (session) -> {
+			final SimpleEntity rtn = session.createNamedQuery( Queries.NAMED_ENTITY, SimpleEntity.class ).getSingleResultOrNull();
+			assertThat( rtn ).isNotNull();
+			assertThat( rtn.id ).isEqualTo( 1 );
+		} );
+
+		sessions.inTransaction( (session) -> {
+			final SimpleEntity rtn = session.createNamedQuery( Queries.NAMED_ENTITY_NO_SELECT, SimpleEntity.class ).getSingleResultOrNull();
+			assertThat( rtn ).isNotNull();
+			assertThat( rtn.id ).isEqualTo( 1 );
+		} );
+
+		sessions.inTransaction( (session) -> {
+			final SimpleComposite rtn = session.createNamedQuery( Queries.NAMED_COMPOSITE, SimpleComposite.class ).getSingleResultOrNull();
+			assertThat( rtn ).isNotNull();
+			assertThat( rtn.value1 ).isEqualTo( "value1" );
+			assertThat( rtn.value2 ).isEqualTo( "value2" );
+		} );
+
+		sessions.inTransaction( (session) -> {
+			final Dto rtn = session.createNamedQuery( Queries.NAMED_ID_NAME_DTO, Dto.class ).getSingleResultOrNull();
+			assertThat( rtn ).isNotNull();
+			assertThat( rtn.getKey() ).isEqualTo( 1 );
+			assertThat( rtn.getText() ).isEqualTo( "first" );
+		} );
+
+		sessions.inTransaction( (session) -> {
+			final Dto rtn = session.createNamedQuery( Queries.NAMED_ID_COMP_VAL_DTO, Dto.class ).getSingleResultOrNull();
+			assertThat( rtn ).isNotNull();
+			assertThat( rtn.getKey() ).isEqualTo( 1 );
+			assertThat( rtn.getText() ).isEqualTo( "value1" );
+		} );
+
+		sessions.inTransaction( (session) -> {
+			final String rtn = session.createNamedQuery( Queries.NAMED_NAME, String.class ).getSingleResultOrNull();
+			assertThat( rtn ).isNotNull();
+			assertThat( rtn ).isEqualTo( "first" );
+		} );
+
+		sessions.inTransaction( (session) -> {
+			final String rtn = session.createNamedQuery( Queries.NAMED_COMP_VAL, String.class ).getSingleResultOrNull();
+			assertThat( rtn ).isNotNull();
+			assertThat( rtn ).isEqualTo( "value1" );
+		} );
+	}
+
+	@Test
+	void testCriteria(SessionFactoryScope sessions) {
+		sessions.inTransaction( (session) -> {
+			final HibernateCriteriaBuilder criteriaBuilder = session.getCriteriaBuilder();
+
+			final JpaCriteriaQuery<SimpleEntity> criteria = criteriaBuilder.createQuery( SimpleEntity.class );
+			final JpaRoot<SimpleEntity> root = criteria.from( SimpleEntity.class );
+			criteria.select( root );
+			final SimpleEntity rtn = session.createQuery( criteria ).getSingleResultOrNull();
+			assertThat( rtn ).isNotNull();
+			assertThat( rtn.id ).isEqualTo( 1 );
+		} );
+	}
+}


### PR DESCRIPTION
HHH-18306 - Implicit instantiation for queries with single selectionitem broken
HHH-18401 - SelectionQuery needs better validation of query return type

----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
