### PR TITLE
HHH-12836: Improved logging when initiating service

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/engine/transaction/jta/platform/internal/JtaPlatformInitiator.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/transaction/jta/platform/internal/JtaPlatformInitiator.java
@@ -48,7 +48,7 @@ public class JtaPlatformInitiator implements StandardServiceInitiator<JtaPlatfor
 		}
 
 		if ( platform == null ) {
-			LOG.debug( "No JtaPlatform was specified, checking resolver" );
+			LOG.debug( "No JtaPlatform was specified, checking fallback provider" );
 			platform = getFallbackProvider( configurationValues, registry );
 		}
 


### PR DESCRIPTION
Updated logging to indicate fallback provider checking when initiating JTA platform service

Currently, `org.hibernate.engine.transaction.jta.platform.internal.JtaPlatformInitiator#initiateService` is logging the message `"No JtaPlatform was specified, checking resolver"` twice while resolving `org.hibernate.engine.transaction.jta.platform.spi.JtaPlatform` instance. I'm changing the second debug log to indicate the initialization is going through the fallback provider (currently just returning a null)

----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-12836
<!-- Hibernate GitHub Bot issue links end -->