### PR TITLE
HHH-15422 Pick up `CurrentTenantIdentifierResolver` and `MultiTenantConnectionProvider` from BeanContainer if not explicit set

### DIFF
--- a/documentation/src/main/asciidoc/introduction/Advanced.adoc
+++ b/documentation/src/main/asciidoc/introduction/Advanced.adoc
@@ -320,6 +320,7 @@ To make use of multi-tenancy, we'll usually need to set at least one of these co
 | `hibernate.multi_tenant_connection_provider`  | Specifies the `MultiTenantConnectionProvider`
 |===
 
+Do not configure those properties if you would like the configured `BeanContainer` provide the implementation.
 A longer discussion of multi-tenancy may be found in the {multitenacy-doc}[User Guide].
 
 [[custom-sql]]

--- a/documentation/src/main/asciidoc/userguide/chapters/multitenancy/MultiTenancy.adoc
+++ b/documentation/src/main/asciidoc/userguide/chapters/multitenancy/MultiTenancy.adoc
@@ -118,6 +118,7 @@ The `MultiTenantConnectionProvider` to use can be specified in a number of ways:
 
 * Use the `hibernate.multi_tenant_connection_provider` setting.
 It could name a `MultiTenantConnectionProvider` instance, a `MultiTenantConnectionProvider` implementation class reference or a `MultiTenantConnectionProvider` implementation class name.
+* Provided by the configured `BeanContainer`.
 * Passed directly to the `org.hibernate.boot.registry.StandardServiceRegistryBuilder`.
 * If none of the above options match, but the settings do specify a `hibernate.connection.datasource` value,
 Hibernate will assume it should use the specific `DataSourceBasedMultiTenantConnectionProviderImpl` implementation which works on a number of pretty reasonable assumptions when running inside of an app server and using one `javax.sql.DataSource` per tenant.
@@ -161,7 +162,7 @@ include::{example-dir-multitenancy}/AbstractMultiTenancyTest.java[tags=multitena
 
 `org.hibernate.context.spi.CurrentTenantIdentifierResolver` is a contract for Hibernate to be able to resolve what the application considers the current tenant identifier.
 The implementation to use can be either passed directly to `Configuration` via its `setCurrentTenantIdentifierResolver` method,
-or be specified via the `hibernate.tenant_identifier_resolver` setting.
+or be specified via the `hibernate.tenant_identifier_resolver` setting, or be provided by the configured `BeanContainer`.
 
 There are two situations where `CurrentTenantIdentifierResolver` is used:
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/connections/ConnectionProviderFromBeanContainerTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/connections/ConnectionProviderFromBeanContainerTest.java
@@ -1,0 +1,104 @@
+/*
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.connections;
+
+import org.hibernate.cfg.AvailableSettings;
+import org.hibernate.dialect.H2Dialect;
+import org.hibernate.engine.jdbc.connections.spi.ConnectionProvider;
+import org.hibernate.resource.beans.container.spi.BeanContainer;
+import org.hibernate.resource.beans.container.spi.ContainedBean;
+import org.hibernate.resource.beans.spi.BeanInstanceProducer;
+import org.hibernate.service.ServiceRegistry;
+import org.hibernate.testing.junit4.BaseUnitTestCase;
+import org.hibernate.testing.orm.junit.RequiresDialect;
+import org.hibernate.testing.util.ServiceRegistryUtil;
+import org.junit.Test;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.hibernate.cfg.JdbcSettings.CONNECTION_PROVIDER;
+import static org.junit.Assert.assertSame;
+
+/**
+ * @author Yanming Zhou
+ */
+@RequiresDialect(H2Dialect.class)
+public class ConnectionProviderFromBeanContainerTest extends BaseUnitTestCase {
+
+	private final ConnectionProvider dummyConnectionProvider = new DummyConnectionProvider();
+
+	private Map<String, Object> createSettings() {
+		Map<String, Object> settings = new HashMap<>();
+		settings.put( AvailableSettings.ALLOW_EXTENSIONS_IN_CDI, "true" );
+		settings.put( AvailableSettings.BEAN_CONTAINER, new BeanContainer() {
+			@Override
+			@SuppressWarnings("unchecked")
+			public <B> ContainedBean<B> getBean(
+					Class<B> beanType,
+					LifecycleOptions lifecycleOptions,
+					BeanInstanceProducer fallbackProducer) {
+				return () -> (B) ( beanType == DummyConnectionProvider.class ?
+						dummyConnectionProvider : fallbackProducer.produceBeanInstance( beanType ) );
+			}
+
+			@Override
+			public <B> ContainedBean<B> getBean(
+					String name,
+					Class<B> beanType,
+					LifecycleOptions lifecycleOptions,
+					BeanInstanceProducer fallbackProducer) {
+				return () -> (B) fallbackProducer.produceBeanInstance( beanType );
+			}
+
+			@Override
+			public void stop() {
+
+			}
+		} );
+		return settings;
+	}
+
+	@Test
+	public void testProviderFromBeanContainerInUse() {
+		Map<String, Object> settings = createSettings();
+		settings.putIfAbsent( CONNECTION_PROVIDER, DummyConnectionProvider.class.getName() );
+		try ( ServiceRegistry serviceRegistry = ServiceRegistryUtil.serviceRegistryBuilder()
+				.applySettings( settings ).build() ) {
+			ConnectionProvider providerInUse = serviceRegistry.getService( ConnectionProvider.class );
+			assertSame( dummyConnectionProvider, providerInUse );
+		}
+	}
+
+	public static class DummyConnectionProvider implements ConnectionProvider {
+
+		@Override
+		public boolean isUnwrappableAs(Class<?> unwrapType) {
+			return false;
+		}
+
+		@Override
+		public <T> T unwrap(Class<T> unwrapType) {
+			return null;
+		}
+
+		@Override
+		public Connection getConnection() throws SQLException {
+			return null;
+		}
+
+		@Override
+		public void closeConnection(Connection connection) throws SQLException {
+
+		}
+
+		@Override
+		public boolean supportsAggressiveRelease() {
+			return false;
+		}
+	};
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/multitenancy/AbstractMultiTenancyTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/multitenancy/AbstractMultiTenancyTest.java
@@ -55,9 +55,9 @@ public abstract class AbstractMultiTenancyTest extends BaseUnitTestCase {
 	protected static final String FRONT_END_TENANT = "front_end";
 	protected static final String BACK_END_TENANT = "back_end";
 
-	private Map<String, ConnectionProvider> connectionProviderMap = new HashMap<>();
+	protected Map<String, ConnectionProvider> connectionProviderMap = new HashMap<>();
 
-	private SessionFactory sessionFactory;
+	protected SessionFactory sessionFactory;
 
 	public AbstractMultiTenancyTest() {
 		init();
@@ -67,13 +67,15 @@ public abstract class AbstractMultiTenancyTest extends BaseUnitTestCase {
 	private void init() {
 		registerConnectionProvider(FRONT_END_TENANT);
 		registerConnectionProvider(BACK_END_TENANT);
+		sessionFactory = sessionFactory(createSettings());
+	}
 
+	protected Map<String, Object> createSettings() {
 		Map<String, Object> settings = new HashMap<>();
 
 		settings.put(AvailableSettings.MULTI_TENANT_CONNECTION_PROVIDER,
-			new ConfigurableMultiTenantConnectionProvider(connectionProviderMap));
-
-		sessionFactory = sessionFactory(settings);
+				new ConfigurableMultiTenantConnectionProvider(connectionProviderMap));
+		return settings;
 	}
 	//end::multitenacy-hibernate-MultiTenantConnectionProvider-example[]
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/multitenancy/beancontainer/AbstractTenantResolverBeanContainerTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/multitenancy/beancontainer/AbstractTenantResolverBeanContainerTest.java
@@ -1,0 +1,34 @@
+/*
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.multitenancy.beancontainer;
+
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.JiraKey;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+/**
+ * @author Yanming Zhou
+ */
+@JiraKey("HHH-15422")
+@SessionFactory
+@DomainModel(annotatedClasses = TestEntity.class)
+abstract class AbstractTenantResolverBeanContainerTest {
+
+	@Test
+	void tentantIdShouldBeFilled(SessionFactoryScope scope) {
+		scope.inTransaction( s -> {
+			TestEntity entity = new TestEntity();
+			s.persist( entity );
+			s.flush();
+			assertThat( entity.getTenant(), is( TestCurrentTenantIdentifierResolver.FIXED_TENANT ) );
+		} );
+	}
+
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/multitenancy/beancontainer/MultiTenantConnectionProviderFromBeanContainerTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/multitenancy/beancontainer/MultiTenantConnectionProviderFromBeanContainerTest.java
@@ -1,0 +1,80 @@
+/*
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.multitenancy.beancontainer;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.hibernate.cfg.AvailableSettings;
+import org.hibernate.dialect.H2Dialect;
+import org.hibernate.engine.jdbc.connections.spi.MultiTenantConnectionProvider;
+import org.hibernate.internal.SessionFactoryImpl;
+import org.hibernate.orm.test.multitenancy.AbstractMultiTenancyTest;
+import org.hibernate.orm.test.multitenancy.ConfigurableMultiTenantConnectionProvider;
+import org.hibernate.resource.beans.container.spi.BeanContainer;
+import org.hibernate.resource.beans.container.spi.ContainedBean;
+import org.hibernate.resource.beans.spi.BeanInstanceProducer;
+
+import org.hibernate.testing.orm.junit.RequiresDialect;
+import org.junit.Test;
+
+import static org.junit.Assert.assertSame;
+
+/**
+ * @author Yanming Zhou
+ */
+@RequiresDialect(H2Dialect.class)
+public class MultiTenantConnectionProviderFromBeanContainerTest extends AbstractMultiTenancyTest {
+
+	private ConfigurableMultiTenantConnectionProvider providerFromBeanContainer;
+
+	@Override
+	protected Map<String, Object> createSettings() {
+		Map<String, Object> settings = new HashMap<>();
+
+		providerFromBeanContainer = new ConfigurableMultiTenantConnectionProvider( connectionProviderMap);
+		settings.put( AvailableSettings.ALLOW_EXTENSIONS_IN_CDI, "true" );
+		settings.put( AvailableSettings.BEAN_CONTAINER, new BeanContainer() {
+			@Override
+			@SuppressWarnings("unchecked")
+			public <B> ContainedBean<B> getBean(
+					Class<B> beanType,
+					LifecycleOptions lifecycleOptions,
+					BeanInstanceProducer fallbackProducer) {
+				return () -> (B) ( beanType == MultiTenantConnectionProvider.class ? providerFromBeanContainer : fallbackProducer.produceBeanInstance( beanType ) );
+			}
+
+			@Override
+			public <B> ContainedBean<B> getBean(
+					String name,
+					Class<B> beanType,
+					LifecycleOptions lifecycleOptions,
+					BeanInstanceProducer fallbackProducer) {
+				return () -> (B) fallbackProducer.produceBeanInstance( beanType );
+			}
+
+			@Override
+			public void stop() {
+
+			}
+		} );
+		return settings;
+	}
+
+	@Override
+	protected String tenantUrl(String originalUrl, String tenantIdentifier) {
+		return originalUrl.replace("db1", tenantIdentifier);
+	}
+
+	@Test
+	public void testProviderInUse() {
+		MultiTenantConnectionProvider<?> providerInUse = ((SessionFactoryImpl) sessionFactory).getServiceRegistry().getService( MultiTenantConnectionProvider.class );
+		assertSame( providerInUse, expectedProviderInUse());
+	}
+
+	protected MultiTenantConnectionProvider<?> expectedProviderInUse() {
+		return providerFromBeanContainer;
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/multitenancy/beancontainer/MultiTenantConnectionProviderFromSettingsOverBeanContainerTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/multitenancy/beancontainer/MultiTenantConnectionProviderFromSettingsOverBeanContainerTest.java
@@ -1,0 +1,36 @@
+/*
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.multitenancy.beancontainer;
+
+import java.util.Map;
+
+import org.hibernate.cfg.AvailableSettings;
+import org.hibernate.dialect.H2Dialect;
+import org.hibernate.engine.jdbc.connections.spi.MultiTenantConnectionProvider;
+import org.hibernate.orm.test.multitenancy.ConfigurableMultiTenantConnectionProvider;
+
+import org.hibernate.testing.orm.junit.RequiresDialect;
+
+/**
+ * @author Yanming Zhou
+ */
+@RequiresDialect(H2Dialect.class)
+public class MultiTenantConnectionProviderFromSettingsOverBeanContainerTest extends MultiTenantConnectionProviderFromBeanContainerTest {
+
+	private ConfigurableMultiTenantConnectionProvider providerFromSettings;
+
+	@Override
+	protected Map<String, Object> createSettings() {
+		Map<String, Object> settings = super.createSettings();
+		providerFromSettings = new ConfigurableMultiTenantConnectionProvider(connectionProviderMap);
+		settings.put(AvailableSettings.MULTI_TENANT_CONNECTION_PROVIDER, providerFromSettings);
+		return settings;
+	}
+
+	@Override
+	protected MultiTenantConnectionProvider<?> expectedProviderInUse() {
+		return providerFromSettings;
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/multitenancy/beancontainer/TenantResolverFromBeanContainerTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/multitenancy/beancontainer/TenantResolverFromBeanContainerTest.java
@@ -1,0 +1,36 @@
+/*
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.multitenancy.beancontainer;
+
+import org.hibernate.cfg.AvailableSettings;
+import org.hibernate.context.spi.CurrentTenantIdentifierResolver;
+
+import org.hibernate.testing.orm.junit.ServiceRegistry;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.hibernate.testing.orm.junit.Setting;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+/**
+ * @author Yanming Zhou
+ */
+@ServiceRegistry(
+		settings = {
+				@Setting(name = AvailableSettings.ALLOW_EXTENSIONS_IN_CDI, value = "true"),
+				@Setting(name = AvailableSettings.BEAN_CONTAINER, value = "org.hibernate.orm.test.multitenancy.beancontainer.TestBeanContainer")
+		}
+)
+public class TenantResolverFromBeanContainerTest extends AbstractTenantResolverBeanContainerTest {
+
+	@Test
+	void tenantResolverFromBeanContainerShouldBeUsed(SessionFactoryScope scope) {
+		CurrentTenantIdentifierResolver<?> tenantResolver = scope.getSessionFactory().getCurrentTenantIdentifierResolver();
+		assertThat(tenantResolver, is(TestCurrentTenantIdentifierResolver.INSTANCE_FOR_BEAN_CONTAINER));
+	}
+
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/multitenancy/beancontainer/TenantResolverFromSettingsOverBeanContainerTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/multitenancy/beancontainer/TenantResolverFromSettingsOverBeanContainerTest.java
@@ -1,0 +1,39 @@
+/*
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.multitenancy.beancontainer;
+
+import org.hibernate.cfg.AvailableSettings;
+import org.hibernate.context.spi.CurrentTenantIdentifierResolver;
+
+import org.hibernate.testing.orm.junit.ServiceRegistry;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.hibernate.testing.orm.junit.Setting;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+/**
+ * @author Yanming Zhou
+ */
+@ServiceRegistry(
+		settings = {
+				@Setting(name = AvailableSettings.ALLOW_EXTENSIONS_IN_CDI, value = "true"),
+				@Setting(name = AvailableSettings.MULTI_TENANT_IDENTIFIER_RESOLVER, value = "org.hibernate.orm.test.multitenancy.beancontainer.TestCurrentTenantIdentifierResolver"),
+				@Setting(name = AvailableSettings.BEAN_CONTAINER, value = "org.hibernate.orm.test.multitenancy.beancontainer.TestBeanContainer")
+		}
+)
+public class TenantResolverFromSettingsOverBeanContainerTest extends AbstractTenantResolverBeanContainerTest {
+
+	@Test
+	void tenantResolverFromSettingsShouldBeUsed(SessionFactoryScope scope) {
+		CurrentTenantIdentifierResolver<?> tenantResolver = scope.getSessionFactory().getCurrentTenantIdentifierResolver();
+		assertThat(tenantResolver, instanceOf(TestCurrentTenantIdentifierResolver.class));
+		assertThat(tenantResolver, is(not(TestCurrentTenantIdentifierResolver.INSTANCE_FOR_BEAN_CONTAINER)));
+	}
+
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/multitenancy/beancontainer/TestBeanContainer.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/multitenancy/beancontainer/TestBeanContainer.java
@@ -2,10 +2,9 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later
  * Copyright Red Hat Inc. and Hibernate Authors
  */
-package org.hibernate.orm.test.idgen.userdefined;
+package org.hibernate.orm.test.multitenancy.beancontainer;
 
-import java.util.concurrent.atomic.AtomicLong;
-
+import org.hibernate.context.spi.CurrentTenantIdentifierResolver;
 import org.hibernate.resource.beans.container.spi.BeanContainer;
 import org.hibernate.resource.beans.container.spi.ContainedBean;
 import org.hibernate.resource.beans.spi.BeanInstanceProducer;
@@ -14,17 +13,15 @@ import org.hibernate.resource.beans.spi.BeanInstanceProducer;
  * @author Yanming Zhou
  */
 @SuppressWarnings("unchecked")
-public class SimpleBeanContainer implements BeanContainer {
-
-	public static final long INITIAL_VALUE = 23L;
+public class TestBeanContainer implements BeanContainer {
 
 	@Override
 	public <B> ContainedBean<B> getBean(
 			Class<B> beanType,
 			LifecycleOptions lifecycleOptions,
 			BeanInstanceProducer fallbackProducer) {
-		return () -> (B) ( beanType == SimpleGenerator.class ?
-				new SimpleGenerator( new AtomicLong( INITIAL_VALUE ) ) : fallbackProducer.produceBeanInstance( beanType ) );
+		return () -> (B) ( beanType == CurrentTenantIdentifierResolver.class ?
+				TestCurrentTenantIdentifierResolver.INSTANCE_FOR_BEAN_CONTAINER : fallbackProducer.produceBeanInstance( beanType ) );
 	}
 
 	@Override

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/multitenancy/beancontainer/TestCurrentTenantIdentifierResolver.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/multitenancy/beancontainer/TestCurrentTenantIdentifierResolver.java
@@ -1,0 +1,27 @@
+/*
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.multitenancy.beancontainer;
+
+import org.hibernate.context.spi.CurrentTenantIdentifierResolver;
+
+/**
+ * @author Yanming Zhou
+ */
+public class TestCurrentTenantIdentifierResolver implements CurrentTenantIdentifierResolver<String> {
+
+		public static final String FIXED_TENANT = "FIXED";
+
+		public static final CurrentTenantIdentifierResolver<String> INSTANCE_FOR_BEAN_CONTAINER = new TestCurrentTenantIdentifierResolver();
+
+		@Override
+		public boolean validateExistingCurrentSessions() {
+			return false;
+		}
+
+		@Override
+		public String resolveCurrentTenantIdentifier() {
+			return FIXED_TENANT;
+		}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/multitenancy/beancontainer/TestEntity.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/multitenancy/beancontainer/TestEntity.java
@@ -1,0 +1,48 @@
+/*
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.multitenancy.beancontainer;
+
+import org.hibernate.annotations.TenantId;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+
+/**
+ * @author Yanming Zhou
+ */
+@Entity
+public class TestEntity {
+
+	@Id
+	@GeneratedValue
+	public Long id;
+
+	private String name;
+
+	@TenantId
+	private String tenant;
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+
+	public String getTenant() {
+		return tenant;
+	}
+
+	public void setTenant(String tenant) {
+		this.tenant = tenant;
+	}
+
+	public Long getId() {
+		return id;
+	}
+
+}


### PR DESCRIPTION
<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

[Please describe here what your change is about]

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-15422
<!-- Hibernate GitHub Bot issue links end -->