### PR TITLE
HHH-18421: Created tests for lazy loading with non-PKs

### DIFF
--- a/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/lazy/Bug.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/lazy/Bug.java
@@ -1,0 +1,53 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.orm.test.annotations.lazy;
+
+import org.hibernate.annotations.NaturalId;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+@Entity
+@Table(name="BUGS")
+public class Bug {
+	@Id
+	@GeneratedValue
+	private Integer id;
+
+	@Column(name="description")
+	private String description;
+
+	@NaturalId
+	private String guid;
+
+	public Integer getId() {
+		return id;
+	}
+
+	public void setId(Integer id) {
+		this.id = id;
+	}
+
+	public String getDescription() {
+		return description;
+	}
+
+	public void setDescription(String description) {
+		this.description = description;
+	}
+
+	public String getGuid() {
+		return guid;
+	}
+
+	public void setGuid(String guid) {
+		this.guid = guid;
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/lazy/Company.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/lazy/Company.java
@@ -1,0 +1,42 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.orm.test.annotations.lazy;
+
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+
+@Entity
+@Table(name="COMPANIES")
+public class Company {
+	@Id
+	@GeneratedValue
+	private Integer id;
+
+	@Column(name="name")
+	private String name;
+
+	public Integer getId() {
+		return id;
+	}
+
+	public void setId(Integer id) {
+		this.id = id;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/lazy/ManyToOneLazyTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/lazy/ManyToOneLazyTest.java
@@ -1,0 +1,165 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.orm.test.annotations.lazy;
+
+import java.util.UUID;
+
+import org.hibernate.Hibernate;
+import org.hibernate.Session;
+import org.hibernate.Transaction;
+
+import org.hibernate.testing.junit4.BaseCoreFunctionalTestCase;
+
+import org.junit.Test;
+
+import jakarta.persistence.criteria.CriteriaBuilder;
+import jakarta.persistence.criteria.CriteriaQuery;
+import jakarta.persistence.criteria.Root;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class ManyToOneLazyTest extends BaseCoreFunctionalTestCase {
+
+	protected boolean isCleanupTestDataRequired() {
+		return true;
+	}
+
+	@Override
+	protected Class[] getAnnotatedClasses() {
+		return new Class[] {
+				Company.class,
+				Person.class,
+				Ticket.class,
+				Bug.class,
+				Reference.class,
+				Update.class,
+				ReplicatedUpdate.class
+		};
+	}
+
+	@Override
+	protected void prepareTest() throws Exception {
+		try (Session writeSession = openSession()) {
+			final Transaction writeTransaction = writeSession.beginTransaction();
+			Company company = new Company();
+			company.setName( "The Company" );
+			writeSession.persist( company );
+
+			Person alice = new Person();
+			alice.setName( "Alice" );
+			alice.setGuid( UUID.randomUUID().toString() );
+			writeSession.persist( alice );
+
+			Person bob = new Person();
+			bob.setName( "Bob" );
+			bob.setGuid( UUID.randomUUID().toString() );
+			writeSession.persist( bob );
+
+			Bug bug = new Bug();
+			bug.setGuid( UUID.randomUUID().toString() );
+			bug.setDescription( "Coffee machine unplugged" );
+			writeSession.persist( bug );
+
+			Reference reference = new Reference();
+			reference.setUrlCode( "TEST-1234" );
+
+			writeSession.persist( reference );
+
+			Ticket ticket = new Ticket();
+			ticket.setTitle( "Coffee machine broken" );
+			ticket.setRequester( bob );
+			ticket.setAssignee( alice );
+			ticket.setCompany(company);
+			ticket.setReference( reference );
+			ticket.setBug( bug );
+			ticket.setGuid( UUID.randomUUID().toString() );
+
+			writeSession.persist( ticket );
+
+			Update update = new Update();
+			update.setBody( "Plugged coffee machine back in" );
+			update.setTicket( ticket );
+
+			writeSession.persist( update );
+
+			ReplicatedUpdate replicatedUpdate = new ReplicatedUpdate();
+			replicatedUpdate.setBody( update.getBody() );
+			replicatedUpdate.setTicket( ticket );
+
+			writeSession.persist( replicatedUpdate );
+
+			writeTransaction.commit();
+		}
+	}
+
+	@Test
+	public void testManyToOneLazyLoadedEntitiesAreOnlyInitializedAfterReference() {
+		try (Session readSession = openSession()) {
+			Ticket ticket = getTicket(readSession);
+
+			// Joined by Id
+			assertFalse( Hibernate.isInitialized( ticket.getCompany() ) );
+			assertEquals( "The Company", ticket.getCompany().getName() );
+			assertTrue( Hibernate.isInitialized( ticket.getCompany() ) );
+
+			// Joined by NaturalId
+			assertFalse( Hibernate.isInitialized( ticket.getAssignee() ) );
+			assertEquals( "Alice", ticket.getAssignee().getName() );
+			assertTrue( Hibernate.isInitialized( ticket.getAssignee() ) );
+
+			// Also Joined by NaturalId
+			assertFalse( Hibernate.isInitialized( ticket.getRequester() ) );
+			assertEquals( "Bob", ticket.getRequester().getName() );
+			assertTrue( Hibernate.isInitialized( ticket.getRequester() ) );
+		}
+	}
+
+	@Test
+	public void testOneToOneLazyLoadedEntitiesAreOnlyInitializedAfterReference() {
+		try (Session readSession = openSession()) {
+			Ticket ticket = getTicket( readSession );
+
+			// Joined by Id
+			assertFalse( Hibernate.isInitialized( ticket.getReference() ) );
+			assertEquals( "TEST-1234", ticket.getReference().getUrlCode() );
+			assertTrue( Hibernate.isInitialized( ticket.getReference() ) );
+
+			// Joined by NaturalId
+			assertFalse( Hibernate.isInitialized( ticket.getBug() ) );
+			assertEquals( "Coffee machine unplugged", ticket.getBug().getDescription() );
+			assertTrue( Hibernate.isInitialized( ticket.getBug() ) );
+		}
+	}
+
+	@Test
+	public void testOneToManyLazyLoadedEntitiesAreOnlyInitializedAfterReference() {
+		try (Session readSession = openSession()) {
+			Ticket ticket = getTicket( readSession );
+
+			// Joined by Id
+			assertFalse( Hibernate.isInitialized( ticket.getUpdates() ) );
+			assertEquals( 1, ticket.getUpdates().size() ); // Size check counts as reference
+			assertTrue( Hibernate.isInitialized( ticket.getUpdates() ) );
+
+			// Joined by Guid
+			assertFalse( Hibernate.isInitialized( ticket.getReplicatedUpdates() ) );
+			assertEquals( 1, ticket.getReplicatedUpdates().size() ); // Size check counts as reference
+			assertTrue( Hibernate.isInitialized( ticket.getReplicatedUpdates() ) );
+		}
+	}
+
+	private Ticket getTicket(Session readSession) {
+		final CriteriaBuilder criteriaBuilder = readSession.getSessionFactory().getCriteriaBuilder();
+		final CriteriaQuery<Ticket> criteria = criteriaBuilder.createQuery( Ticket.class );
+		final Root<Ticket> root = criteria.from( Ticket.class );
+		criteria.where( criteriaBuilder.equal( root.get( "title" ), "Coffee machine broken" ) );
+
+		return session.createQuery(criteria).uniqueResult();
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/lazy/Person.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/lazy/Person.java
@@ -1,0 +1,53 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.orm.test.annotations.lazy;
+
+import org.hibernate.annotations.NaturalId;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+@Entity
+@Table(name="PEOPLE")
+public class Person {
+	@Id
+	@GeneratedValue
+	private Integer id;
+
+	@Column(name="name")
+	private String name;
+
+	@NaturalId
+	private String guid;
+
+	public Integer getId() {
+		return id;
+	}
+
+	public void setId(Integer id) {
+		this.id = id;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+
+	public String getGuid() {
+		return guid;
+	}
+
+	public void setGuid(String guid) {
+		this.guid = guid;
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/lazy/Reference.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/lazy/Reference.java
@@ -1,0 +1,53 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.orm.test.annotations.lazy;
+
+import org.hibernate.annotations.NaturalId;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+
+@Entity
+@Table(name="REFERENCES")
+public class Reference {
+	@Id
+	@GeneratedValue
+	private Integer id;
+
+	@NaturalId
+	private String urlCode;
+
+	@OneToOne(mappedBy = "reference")
+	private Ticket ticket;
+
+	public Integer getId() {
+		return id;
+	}
+
+	public void setId(Integer id) {
+		this.id = id;
+	}
+
+	public String getUrlCode() {
+		return urlCode;
+	}
+
+	public void setUrlCode(String urlCode) {
+		this.urlCode = urlCode;
+	}
+
+	public Ticket getTicket() {
+		return ticket;
+	}
+
+	public void setTicket(Ticket ticket) {
+		this.ticket = ticket;
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/lazy/ReplicatedUpdate.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/lazy/ReplicatedUpdate.java
@@ -1,0 +1,54 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.orm.test.annotations.lazy;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+
+@Entity
+@Table(name="REPLICATED_UPDATES")
+public class ReplicatedUpdate {
+	@Id
+	@GeneratedValue
+	private Integer id;
+
+	@Column(name = "body")
+	private String body;
+
+	@ManyToOne
+	@JoinColumn(name = "ticket_guid", referencedColumnName = "guid")
+	private Ticket ticket;
+
+	public Integer getId() {
+		return id;
+	}
+
+	public void setId(Integer id) {
+		this.id = id;
+	}
+
+	public String getBody() {
+		return body;
+	}
+
+	public void setBody(String body) {
+		this.body = body;
+	}
+
+	public Ticket getTicket() {
+		return ticket;
+	}
+
+	public void setTicket(Ticket ticket) {
+		this.ticket = ticket;
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/lazy/Ticket.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/lazy/Ticket.java
@@ -1,0 +1,143 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.orm.test.annotations.lazy;
+
+import java.util.List;
+
+import org.hibernate.annotations.NaturalId;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+
+@Entity
+@Table(name="TICKETS")
+public class Ticket {
+	@Id
+	@GeneratedValue
+	private Integer id;
+
+	@Column(name="title")
+	private String title;
+
+	@NaturalId
+	private String guid;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "requester_guid", referencedColumnName = "guid")
+	private Person requester;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "assignee_guid", referencedColumnName = "guid")
+	private Person assignee;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "company_id")
+	private Company company;
+
+	@OneToOne(fetch = FetchType.LAZY)
+	private Reference reference;
+
+	@OneToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "bug_guid", referencedColumnName = "guid")
+	private Bug bug;
+
+	@OneToMany(fetch = FetchType.LAZY)
+	@JoinColumn(name = "ticket_id")
+	private List<Update> updates;
+
+	@OneToMany(fetch = FetchType.LAZY)
+	@JoinColumn(name = "ticket_guid", referencedColumnName = "guid")
+	private List<ReplicatedUpdate> replicatedUpdates;
+
+	public Integer getId() {
+		return id;
+	}
+
+	public void setId(Integer id) {
+		this.id = id;
+	}
+
+	public String getGuid() {
+		return guid;
+	}
+
+	public void setGuid(String guid) {
+		this.guid = guid;
+	}
+
+	public String getTitle() {
+		return title;
+	}
+
+	public void setTitle(String title) {
+		this.title = title;
+	}
+
+	public Person getRequester() {
+		return requester;
+	}
+
+	public void setRequester(Person requester) {
+		this.requester = requester;
+	}
+
+	public Person getAssignee() {
+		return assignee;
+	}
+
+	public void setAssignee(Person assignee) {
+		this.assignee = assignee;
+	}
+
+	public Company getCompany() {
+		return company;
+	}
+
+	public void setCompany(Company company) {
+		this.company = company;
+	}
+
+	public Bug getBug() {
+		return bug;
+	}
+
+	public void setBug(Bug bug) {
+		this.bug = bug;
+	}
+
+	public Reference getReference() {
+		return reference;
+	}
+
+	public void setReference(Reference reference) {
+		this.reference = reference;
+	}
+
+	public List<Update> getUpdates() {
+		return updates;
+	}
+
+	public void setUpdates(List<Update> updates) {
+		this.updates = updates;
+	}
+
+	public List<ReplicatedUpdate> getReplicatedUpdates() {
+		return replicatedUpdates;
+	}
+
+	public void setReplicatedUpdates(List<ReplicatedUpdate> replicatedUpdates) {
+		this.replicatedUpdates = replicatedUpdates;
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/lazy/Update.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/lazy/Update.java
@@ -1,0 +1,54 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.orm.test.annotations.lazy;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+
+@Entity
+@Table(name="UPDATES")
+public class Update {
+	@Id
+	@GeneratedValue
+	private Integer id;
+
+	@Column(name = "body")
+	private String body;
+
+	@ManyToOne
+	@JoinColumn(name = "ticket_id")
+	private Ticket ticket;
+
+	public Integer getId() {
+		return id;
+	}
+
+	public void setId(Integer id) {
+		this.id = id;
+	}
+
+	public String getBody() {
+		return body;
+	}
+
+	public void setBody(String body) {
+		this.body = body;
+	}
+
+	public Ticket getTicket() {
+		return ticket;
+	}
+
+	public void setTicket(Ticket ticket) {
+		this.ticket = ticket;
+	}
+}


### PR DESCRIPTION
This adds tests that verify that lazy loading works for OneToOne, ManyToOne, and OneToMany join types. For ticket https://hibernate.atlassian.net/browse/HHH-18421

----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
