### PR TITLE
Use Java 22 bytecode in tests when testing against OpenJDK 22+

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -64,7 +64,7 @@ dependencyResolutionManagement {
 
             // Gradle does bytecode transformation on tests.
             // You can't use bytecode higher than what Gradle supports, even with toolchains.
-            version "maxSupportedBytecode", "21"
+            version "maxSupportedBytecode", "22"
         }
         libs {
             def antlrVersion = version "antlr", "4.13.0"


### PR DESCRIPTION
Because we upgraded to Gradle 8.8 some time ago, which supports Java 22. See https://docs.gradle.org/8.8/release-notes.html

----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
