### PR TITLE
HHH-18406 Oracle: schema update fails to create entity table if one of the fields is an array

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/tool/schema/internal/AbstractSchemaMigrator.java
+++ b/hibernate-core/src/main/java/org/hibernate/tool/schema/internal/AbstractSchemaMigrator.java
@@ -59,6 +59,8 @@ import static org.hibernate.engine.config.spi.StandardConverters.STRING;
 import static org.hibernate.internal.util.StringHelper.isEmpty;
 import static org.hibernate.tool.schema.UniqueConstraintSchemaUpdateStrategy.DROP_RECREATE_QUIETLY;
 import static org.hibernate.tool.schema.UniqueConstraintSchemaUpdateStrategy.SKIP;
+import static org.hibernate.tool.schema.internal.SchemaCreatorImpl.createUserDefinedTypes;
+import static org.hibernate.tool.schema.internal.SchemaDropperImpl.dropUserDefinedTypes;
 
 /**
  * Base implementation of {@link SchemaMigrator}.
@@ -195,6 +197,9 @@ public abstract class AbstractSchemaMigrator implements SchemaMigrator {
 			}
 		}
 
+		// Drop all UDTs
+		dropUserDefinedTypes( metadata, options, schemaFilter, dialect, formatter, sqlGenerationContext, targets );
+
 		// Create before-table AuxiliaryDatabaseObjects
 		for ( AuxiliaryDatabaseObject auxiliaryDatabaseObject : database.getAuxiliaryDatabaseObjects() ) {
 			if ( auxiliaryDatabaseObject.beforeTablesOnCreation()
@@ -208,6 +213,9 @@ public abstract class AbstractSchemaMigrator implements SchemaMigrator {
 				);
 			}
 		}
+
+		// Recreate all UDTs
+		createUserDefinedTypes( metadata, options, schemaFilter, dialect, formatter, sqlGenerationContext, targets );
 
 		boolean tryToCreateCatalogs = false;
 		boolean tryToCreateSchemas = false;

--- a/hibernate-core/src/main/java/org/hibernate/tool/schema/internal/SchemaCreatorImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/tool/schema/internal/SchemaCreatorImpl.java
@@ -497,7 +497,7 @@ public class SchemaCreatorImpl implements SchemaCreator {
 		}
 	}
 
-	private static void createUserDefinedTypes(
+	static void createUserDefinedTypes(
 			Metadata metadata,
 			ExecutionOptions options,
 			SchemaFilter schemaFilter,

--- a/hibernate-core/src/main/java/org/hibernate/tool/schema/internal/SchemaDropperImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/tool/schema/internal/SchemaDropperImpl.java
@@ -391,7 +391,7 @@ public class SchemaDropperImpl implements SchemaDropper {
 		}
 	}
 
-	private static void dropUserDefinedTypes(
+	static void dropUserDefinedTypes(
 			Metadata metadata,
 			ExecutionOptions options,
 			SchemaFilter schemaFilter,

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/schemaupdate/SchemaUpdateArrayPropertiesTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/schemaupdate/SchemaUpdateArrayPropertiesTest.java
@@ -1,0 +1,88 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html
+ */
+package org.hibernate.orm.test.schemaupdate;
+
+import java.math.BigInteger;
+import java.util.EnumSet;
+
+import org.hibernate.Session;
+import org.hibernate.SessionFactory;
+import org.hibernate.annotations.Array;
+import org.hibernate.boot.Metadata;
+import org.hibernate.boot.MetadataSources;
+import org.hibernate.boot.registry.StandardServiceRegistry;
+import org.hibernate.cfg.Environment;
+import org.hibernate.tool.hbm2ddl.SchemaExport;
+import org.hibernate.tool.hbm2ddl.SchemaUpdate;
+import org.hibernate.tool.schema.TargetType;
+
+import org.hibernate.testing.orm.junit.Jira;
+import org.hibernate.testing.util.ServiceRegistryUtil;
+import org.junit.jupiter.api.Test;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Marco Belladelli
+ */
+@Jira( "https://hibernate.atlassian.net/browse/HHH-18406" )
+public class SchemaUpdateArrayPropertiesTest {
+	@Test
+	public void testUpdateExisting() {
+		final StandardServiceRegistry ssr = ServiceRegistryUtil.serviceRegistryBuilder()
+				.applySetting( Environment.HBM2DDL_AUTO, "none" )
+				.build();
+		final Metadata metadata = new MetadataSources( ssr ).addAnnotatedClass( TestEntity.class ).buildMetadata();
+		// First create the schema
+		new SchemaExport().createOnly( EnumSet.of( TargetType.DATABASE ), metadata );
+		// Then update the existing table
+		new SchemaUpdate().execute( EnumSet.of( TargetType.DATABASE ), metadata );
+		// Verify a query works as expected
+		try (final SessionFactory sf = metadata.getSessionFactoryBuilder().build()) {
+			try (Session session = sf.openSession()) {
+				assertThat( session.find( TestEntity.class, 1 ) ).isNull();
+			}
+			sf.getSchemaManager().dropMappedObjects( false );
+		}
+	}
+
+	@Test
+	public void testUpdateNew() {
+		final StandardServiceRegistry ssr = ServiceRegistryUtil.serviceRegistryBuilder()
+				.applySetting( Environment.HBM2DDL_AUTO, "none" )
+				.build();
+		final Metadata metadata = new MetadataSources( ssr ).addAnnotatedClass( TestEntity.class ).buildMetadata();
+		// Update should create the schema and all necessary types
+		new SchemaUpdate().execute( EnumSet.of( TargetType.DATABASE ), metadata );
+		// Verify a query works as expected
+		try (final SessionFactory sf = metadata.getSessionFactoryBuilder().build()) {
+			try (Session session = sf.openSession()) {
+				assertThat( session.find( TestEntity.class, 1 ) ).isNull();
+			}
+			sf.getSchemaManager().dropMappedObjects( false );
+		}
+	}
+
+	@Entity( name = "TestEntity" )
+	static class TestEntity {
+		@Id
+		@GeneratedValue
+		private Integer id;
+
+		private Integer[] integerArray;
+
+		@Array( length = 3 )
+		private String[] stringArrayAnnotated;
+
+		@Array( length = 5 )
+		private BigInteger[] bigIntegerArrayAnnotated;
+	}
+}


### PR DESCRIPTION
<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

https://hibernate.atlassian.net/browse/HHH-18406

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
