### PR TITLE
Allow Hibernate Reactive to skip lazy initialization

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/ToOneAttributeMapping.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/ToOneAttributeMapping.java
@@ -2367,10 +2367,7 @@ public class ToOneAttributeMapping
 		}
 
 		if ( referencedPropertyName != null ) {
-			final LazyInitializer lazyInitializer = HibernateProxy.extractLazyInitializer( domainValue );
-			if ( lazyInitializer != null ) {
-				domainValue = lazyInitializer.getImplementation();
-			}
+			domainValue = lazyInitialize( domainValue );
 			assert getAssociatedEntityMappingType()
 					.getRepresentationStrategy()
 					.getInstantiator()
@@ -2379,6 +2376,18 @@ public class ToOneAttributeMapping
 		}
 
 		return foreignKeyDescriptor.getAssociationKeyFromSide( domainValue, sideNature.inverse(), session );
+	}
+
+	/**
+	 * For Hibernate Reactive, because it doesn't support lazy initialization, it will override this method and skip it
+	 * when possible.
+	 */
+	protected Object lazyInitialize(Object domainValue) {
+		final LazyInitializer lazyInitializer = HibernateProxy.extractLazyInitializer( domainValue );
+		if ( lazyInitializer != null ) {
+			return lazyInitializer.getImplementation();
+		}
+		return domainValue;
 	}
 
 	private static Object extractAttributePathValue(Object domainValue, EntityMappingType entityType, String attributePath) {


### PR DESCRIPTION
The fix for [HHH-18147](https://hibernate.atlassian.net/browse/HHH-18147) add a lazy initialization that causes regressions in Hibernate Reactive.

This change makes it possible to skip the lazy initialization (Hibernate Reactive does not support it anyway) for the time being.

I might find a better solution when I have time.

This change was already part of the changes proposed here: https://github.com/hibernate/hibernate-orm/pull/8662

[HHH-18147]: https://hibernate.atlassian.net/browse/HHH-18147?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-18431
<!-- Hibernate GitHub Bot issue links end -->