### PR TITLE
HHH-18378 Avoid reusing existing joins for entity-graph fetches if they're included in the where clause

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/internal/SqmUtil.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/internal/SqmUtil.java
@@ -65,6 +65,7 @@ import org.hibernate.query.sqm.tree.from.SqmFrom;
 import org.hibernate.query.sqm.tree.from.SqmJoin;
 import org.hibernate.query.sqm.tree.from.SqmQualifiedJoin;
 import org.hibernate.query.sqm.tree.from.SqmRoot;
+import org.hibernate.query.sqm.tree.predicate.SqmWhereClause;
 import org.hibernate.query.sqm.tree.select.SqmOrderByClause;
 import org.hibernate.query.sqm.tree.select.SqmQueryPart;
 import org.hibernate.query.sqm.tree.select.SqmQuerySpec;
@@ -90,6 +91,7 @@ import org.hibernate.type.spi.TypeConfiguration;
 
 import static java.util.stream.Collectors.toList;
 import static org.hibernate.internal.util.NullnessUtil.castNonNull;
+import static org.hibernate.internal.util.collections.CollectionHelper.arrayList;
 import static org.hibernate.query.sqm.tree.jpa.ParameterCollector.collectParameters;
 
 /**
@@ -217,6 +219,15 @@ public class SqmUtil {
 		return false;
 	}
 
+	public static List<NavigablePath> getWhereClauseNavigablePaths(SqmQuerySpec<?> querySpec) {
+		final SqmWhereClause where = querySpec.getWhereClause();
+		if ( where == null || where.getPredicate() == null ) {
+			return Collections.emptyList();
+		}
+
+		return collectNavigablePaths( List.of( where.getPredicate() ) );
+	}
+
 	public static List<NavigablePath> getGroupByNavigablePaths(SqmQuerySpec<?> querySpec) {
 		final List<SqmExpression<?>> expressions = querySpec.getGroupByClauseExpressions();
 		if ( expressions.isEmpty() ) {
@@ -240,7 +251,7 @@ public class SqmUtil {
 	}
 
 	private static List<NavigablePath> collectNavigablePaths(final List<SqmExpression<?>> expressions) {
-		final List<NavigablePath> navigablePaths = new ArrayList<>( expressions.size() );
+		final List<NavigablePath> navigablePaths = arrayList( expressions.size() );
 		final SqmPathVisitor pathVisitor = new SqmPathVisitor( path -> navigablePaths.add( path.getNavigablePath() ) );
 		for ( final SqmExpression<?> expression : expressions ) {
 			if ( expression instanceof SqmAliasedNodeRef ) {

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/sql/BaseSqmToSqlAstConverter.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/sql/BaseSqmToSqlAstConverter.java
@@ -8396,7 +8396,10 @@ public abstract class BaseSqmToSqlAstConverter<T extends Statement> extends Base
 									joinProducer,
 									joinProducer.determineSqlJoinType( lhs, null, true )
 							);
-							if ( compatibleTableGroup == null ) {
+							final SqmQueryPart<?> queryPart = getCurrentSqmQueryPart();
+							if ( compatibleTableGroup == null
+									// If the compatible table group is used in the where clause it cannot be reused for fetching
+									|| ( queryPart != null && queryPart.getFirstQuerySpec().whereClauseContains( compatibleTableGroup.getNavigablePath(), this ) ) ) {
 								final TableGroupJoin tableGroupJoin = joinProducer.createTableGroupJoin(
 										fetchablePath,
 										lhs,

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/select/SqmQuerySpec.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/select/SqmQuerySpec.java
@@ -630,14 +630,25 @@ public class SqmQuerySpec<T> extends SqmQueryPart<T>
 	}
 
 	@Internal
+	public boolean whereClauseContains(NavigablePath navigablePath, SqmToSqlAstConverter sqlAstConverter) {
+		if ( whereClause == null ) {
+			return false;
+		}
+		return isSameOrParent(
+				navigablePath,
+				sqlAstConverter.resolveMetadata( this, SqmUtil::getWhereClauseNavigablePaths )
+		);
+	}
+
+	@Internal
 	public boolean groupByClauseContains(NavigablePath navigablePath, SqmToSqlAstConverter sqlAstConverter) {
 		if ( groupByClauseExpressions.isEmpty() ) {
 			return false;
 		}
-		return navigablePathsContain( sqlAstConverter.resolveMetadata(
-				this,
-				SqmUtil::getGroupByNavigablePaths
-		), navigablePath );
+		return isSameOrChildren(
+				navigablePath,
+				sqlAstConverter.resolveMetadata( this, SqmUtil::getGroupByNavigablePaths )
+		);
 	}
 
 	@Internal
@@ -646,15 +657,24 @@ public class SqmQuerySpec<T> extends SqmQueryPart<T>
 		if ( orderByClause == null || orderByClause.getSortSpecifications().isEmpty() ) {
 			return false;
 		}
-		return navigablePathsContain( sqlAstConverter.resolveMetadata(
-				this,
-				SqmUtil::getOrderByNavigablePaths
-		), navigablePath );
+		return isSameOrChildren(
+				navigablePath,
+				sqlAstConverter.resolveMetadata( this, SqmUtil::getOrderByNavigablePaths )
+		);
 	}
 
-	private boolean navigablePathsContain(List<NavigablePath> navigablePaths, NavigablePath navigablePath) {
+	private boolean isSameOrChildren(NavigablePath navigablePath, List<NavigablePath> navigablePaths) {
 		for ( NavigablePath path : navigablePaths ) {
 			if ( path.isParentOrEqual( navigablePath ) ) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	private boolean isSameOrParent(NavigablePath navigablePath, List<NavigablePath> navigablePaths) {
+		for ( NavigablePath path : navigablePaths ) {
+			if ( navigablePath.isParentOrEqual( path ) ) {
 				return true;
 			}
 		}


### PR DESCRIPTION
<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

https://hibernate.atlassian.net/browse/HHH-18378

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
