### PR TITLE
HHH-17888 - Remove support for MariaDB versions older than 10.5

### DIFF
--- a/docker_db.sh
+++ b/docker_db.sh
@@ -114,9 +114,9 @@ mariadb_wait_until_start()
     fi
 }
 
-mariadb_10_4() {
+mariadb_10_5() {
     $CONTAINER_CLI rm -f mariadb || true
-    $CONTAINER_CLI run --name mariadb -e MARIADB_USER=hibernate_orm_test -e MARIADB_PASSWORD=hibernate_orm_test -e MARIADB_DATABASE=hibernate_orm_test -e MARIADB_ROOT_PASSWORD=hibernate_orm_test -p3306:3306 -d docker.io/mariadb:10.4.33 --character-set-server=utf8mb4 --collation-server=utf8mb4_bin --skip-character-set-client-handshake --lower_case_table_names=2
+    $CONTAINER_CLI run --name mariadb -e MARIADB_USER=hibernate_orm_test -e MARIADB_PASSWORD=hibernate_orm_test -e MARIADB_DATABASE=hibernate_orm_test -e MARIADB_ROOT_PASSWORD=hibernate_orm_test -p3306:3306 -d docker.io/mariadb:10.5.25 --character-set-server=utf8mb4 --collation-server=utf8mb4_bin --skip-character-set-client-handshake --lower_case_table_names=2
     mariadb_wait_until_start
 }
 
@@ -980,7 +980,7 @@ if [ -z ${1} ]; then
     echo -e "\tmariadb_11_4"
     echo -e "\tmariadb_11_1"
     echo -e "\tmariadb_10_11"
-    echo -e "\tmariadb_10_4"
+    echo -e "\tmariadb_10_5"
     echo -e "\tmssql"
     echo -e "\tmssql_2022"
     echo -e "\tmssql_2017"

--- a/hibernate-core/src/main/java/org/hibernate/dialect/MariaDBDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/MariaDBDialect.java
@@ -44,13 +44,13 @@ import static org.hibernate.type.SqlTypes.UUID;
 import static org.hibernate.type.SqlTypes.VARBINARY;
 
 /**
- * A {@linkplain Dialect SQL dialect} for MariaDB 10.3 and above.
+ * A {@linkplain Dialect SQL dialect} for MariaDB 10.5 and above.
  *
  * @author Vlad Mihalcea
  * @author Gavin King
  */
 public class MariaDBDialect extends MySQLDialect {
-	private static final DatabaseVersion MINIMUM_VERSION = DatabaseVersion.make( 10, 4 );
+	private static final DatabaseVersion MINIMUM_VERSION = DatabaseVersion.make( 10, 5 );
 	private static final DatabaseVersion MYSQL57 = DatabaseVersion.make( 5, 7 );
 
 	public MariaDBDialect() {
@@ -192,7 +192,7 @@ public class MariaDBDialect extends MySQLDialect {
 
 	@Override
 	public boolean supportsIfExistsAfterAlterTable() {
-		return getVersion().isSameOrAfter( 10, 5 );
+		return true;
 	}
 
 	@Override
@@ -248,7 +248,7 @@ public class MariaDBDialect extends MySQLDialect {
 	 */
 	@Override
 	public boolean supportsInsertReturning() {
-		return getVersion().isSameOrAfter( 10, 5 );
+		return true;
 	}
 
 	@Override

--- a/nightly.Jenkinsfile
+++ b/nightly.Jenkinsfile
@@ -29,7 +29,7 @@ stage('Configure') {
 		// Minimum supported versions
 		new BuildEnvironment( dbName: 'hsqldb_2_6' ),
 		new BuildEnvironment( dbName: 'mysql_8_0' ),
-		new BuildEnvironment( dbName: 'mariadb_10_4' ),
+		new BuildEnvironment( dbName: 'mariadb_10_5' ),
 		new BuildEnvironment( dbName: 'postgresql_12' ),
 		new BuildEnvironment( dbName: 'edb_12' ),
 		new BuildEnvironment( dbName: 'db2_10_5', longRunning: true ),
@@ -116,11 +116,11 @@ stage('Build') {
 									sh "./docker_db.sh mysql_8_0"
 									state[buildEnv.tag]['containerName'] = "mysql"
 									break;
-								case "mariadb_10_4":
+								case "mariadb_10_5":
 									docker.withRegistry('https://index.docker.io/v1/', 'hibernateci.hub.docker.com') {
 										docker.image('mariadb:10.4.31').pull()
 									}
-									sh "./docker_db.sh mariadb_10_4"
+									sh "./docker_db.sh mariadb_10_5"
 									state[buildEnv.tag]['containerName'] = "mariadb"
 									break;
 								case "postgresql_12":


### PR DESCRIPTION
<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

[Please describe here what your change is about]

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-17888
<!-- Hibernate GitHub Bot issue links end -->