### PR TITLE
HHH-18451 Fix CheckConstraints for Booleans with null value converters

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/mapping/BasicValue.java
+++ b/hibernate-core/src/main/java/org/hibernate/mapping/BasicValue.java
@@ -555,7 +555,7 @@ public class BasicValue extends SimpleValue implements JdbcTypeIndicators, Resol
 
 		@Override
 		public R toRelationalValue(Boolean domainValue) {
-			return underlyingJpaConverter.toRelationalValue( !domainValue );
+			return underlyingJpaConverter.toRelationalValue( domainValue != null ? !domainValue : null );
 		}
 
 		@Override

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/BooleanJavaType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/BooleanJavaType.java
@@ -193,10 +193,7 @@ public class BooleanJavaType extends AbstractClassJavaType<Boolean> implements
 						(BasicValueConverter<Boolean, ?>) converter;
 				final Object falseValue = stringConverter.toRelationalValue( false );
 				final Object trueValue = stringConverter.toRelationalValue( true );
-				String[] values = new String[] {
-						falseValue != null ? falseValue.toString() : null,
-						trueValue != null ? trueValue.toString() : null
-				};
+				final String[] values = getPossibleStringValues( stringConverter, falseValue, trueValue );
 				return dialect.getCheckCondition( columnName, values );
 			}
 			else if ( jdbcType.isInteger() ) {
@@ -205,13 +202,48 @@ public class BooleanJavaType extends AbstractClassJavaType<Boolean> implements
 						(BasicValueConverter<Boolean, ? extends Number>) converter;
 				final Number falseValue = numericConverter.toRelationalValue( false );
 				final Number trueValue = numericConverter.toRelationalValue( true );
-				Long[] values = new Long[] {
-						falseValue != null ? Long.valueOf(falseValue.longValue()) : null,
-						trueValue != null ? Long.valueOf(trueValue.longValue()) : null
-				};
+				Long[] values = getPossibleNumericValues( numericConverter, falseValue, trueValue );
 				return dialect.getCheckCondition( columnName, values );
 			}
 		}
 		return null;
+	}
+
+	private static Long[] getPossibleNumericValues(
+			BasicValueConverter<Boolean, ? extends Number> numericConverter,
+			Number falseValue,
+			Number trueValue) {
+		Number nullValue = null;
+		try {
+			nullValue = numericConverter.toRelationalValue( null );
+		}
+		catch ( NullPointerException ignored ) {
+		}
+		Long[] values = new Long[nullValue != null ? 3 : 2];
+		values[0] = falseValue != null ? falseValue.longValue() : null;
+		values[1] = trueValue != null ? trueValue.longValue() : null;
+		if ( nullValue != null ) {
+			values[2] = nullValue.longValue();
+		}
+		return values;
+	}
+
+	private static String[] getPossibleStringValues(
+			BasicValueConverter<Boolean, ?> stringConverter,
+			Object falseValue,
+			Object trueValue) {
+		Object nullValue = null;
+		try {
+			nullValue =  stringConverter.toRelationalValue( null);
+		}
+		catch ( NullPointerException ignored ) {
+		}
+		final String[] values = new String[nullValue != null ? 3 : 2];
+		values[0] = falseValue != null ? falseValue.toString() : null;
+		values[1] = trueValue != null ? trueValue.toString() : null;
+		if ( nullValue != null ) {
+			values[2] =  nullValue.toString();
+		}
+		return values;
 	}
 }

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/type/java/BooleanJavaTypeDescriptorTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/type/java/BooleanJavaTypeDescriptorTest.java
@@ -64,6 +64,15 @@ public class BooleanJavaTypeDescriptorTest {
     }
 
     @Test
+    public void testCheckConditionShouldReturnCorrectStatementWhen1And0AndNullIntegerGiven() {
+        // given
+        // when
+        String checkCondition = underTest.getCheckCondition("is_active", IntegerJdbcType.INSTANCE, new TriStateBooleanConverter(), new AnyDialect());
+        // then
+        assertEquals("is_active in (0,1,-1)", checkCondition);
+    }
+
+    @Test
     public void testWrapShouldReturnTrueWhenYStringGiven() {
         // given
         // when
@@ -154,6 +163,40 @@ public class BooleanJavaTypeDescriptorTest {
         @Override
         public Boolean convertToEntityAttribute(Integer dbData) {
             return dbData != null && dbData == 1;
+        }
+
+        @Override
+        public @Nullable Boolean toDomainValue(@Nullable Integer relationalForm) {
+            return convertToEntityAttribute(relationalForm);
+        }
+
+        @Override
+        public @Nullable Integer toRelationalValue(@Nullable Boolean domainForm) {
+            return convertToDatabaseColumn(domainForm);
+        }
+
+        @Override
+        public JavaType<Boolean> getDomainJavaType() {
+            return BooleanJavaType.INSTANCE;
+        }
+
+        @Override
+        public JavaType<Integer> getRelationalJavaType() {
+            return IntegerJavaType.INSTANCE;
+        }
+    }
+
+    private static class TriStateBooleanConverter implements AttributeConverter<Boolean, Integer>, BasicValueConverter<Boolean, Integer> {
+        @Override
+        public Integer convertToDatabaseColumn(Boolean attribute) {
+            if (attribute == null) return -1;
+            return  attribute ? 1 : 0;
+        }
+
+        @Override
+        public Boolean convertToEntityAttribute(Integer dbData) {
+            if (dbData == null || dbData == -1) return null;
+            return dbData == 1;
         }
 
         @Override


### PR DESCRIPTION
This PR should fix the issue of Boolean Converters which change null values not being included in the check constraints generated. See the JIRA Issue for a detailed example.


----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-18451
<!-- Hibernate GitHub Bot issue links end -->