### PR TITLE
fixed link to new jakarta-jdbc-password property from the deprecated PASS property

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/cfg/JdbcSettings.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/JdbcSettings.java
@@ -518,7 +518,7 @@ public interface JdbcSettings extends C3p0Settings, ProxoolSettings, AgroalSetti
 	/**
 	 * @see #USER
 	 *
-	 * @deprecated The JPA-standard setting {@link #JAKARTA_JDBC_USER} is now preferred.
+	 * @deprecated The JPA-standard setting {@link #JAKARTA_JDBC_PASSWORD} is now preferred.
 	 */
 	@Deprecated
 	String PASS = "hibernate.connection.password";


### PR DESCRIPTION
deprecated PASS property was linked to the incorrect new property in 'jakarta' namespace.

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
