### PR TITLE
HHH-18450 Inconsistent "SELECT 1" versus "SELECT ?1" with result type Object[]

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/internal/SqmUtil.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/internal/SqmUtil.java
@@ -737,7 +737,7 @@ public class SqmUtil {
 
 	public static boolean isSelectionAssignableToResultType(SqmSelection<?> selection, Class<?> expectedResultType) {
 		if ( expectedResultType == null
-				|| selection != null && selection.getSelectableNode() instanceof SqmParameter ) {
+				|| selection != null && selection.getSelectableNode() instanceof SqmParameter && !expectedResultType.isArray()) {
 			return true;
 		}
 		else if ( selection == null

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/hql/SingleParameterSelectionAsObjectArrayResultTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/hql/SingleParameterSelectionAsObjectArrayResultTest.java
@@ -1,0 +1,29 @@
+package org.hibernate.orm.test.hql;
+
+import org.hibernate.testing.junit4.BaseCoreFunctionalTestCase;
+import org.hibernate.testing.orm.junit.JiraKey;
+import org.junit.Test;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+
+@JiraKey("HHH-18450")
+public class SingleParameterSelectionAsObjectArrayResultTest extends BaseCoreFunctionalTestCase {
+
+	@Test
+	public void singleParameterAsObjectArray() {
+		inSession( s -> {
+			assertArrayEquals(
+					new Object[] { 1 },
+					s.createSelectionQuery( "SELECT ?1", Object[].class )
+							.setParameter( 1, 1 )
+							.getSingleResult()
+			);
+			assertArrayEquals(
+					new Object[] { 1 },
+					s.createSelectionQuery( "SELECT :p1", Object[].class )
+							.setParameter( "p1", 1 )
+							.getSingleResult()
+			);
+		} );
+	}
+}


### PR DESCRIPTION
See Jira issue [HHH-18450](https://hibernate.atlassian.net/browse/HHH-18450)

When single selection is SqmParameter and expected result type is array, use `RowTransformerArrayImpl`, not `RowTransformerSingularReturnImpl`.

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------


[HHH-18450]: https://hibernate.atlassian.net/browse/HHH-18450?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ