### PR TITLE
HHH-18309 Oracle LimitHandler does not seem to handle maxrows correctly for native queries

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/dialect/pagination/Oracle12LimitHandler.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/pagination/Oracle12LimitHandler.java
@@ -33,10 +33,17 @@ public class Oracle12LimitHandler extends AbstractLimitHandler {
 
 	@Override
 	public String processSql(String sql, Limit limit, QueryOptions queryOptions) {
+		final boolean hasFirstRow = hasFirstRow( limit );
+		final boolean hasMaxRows = hasMaxRows( limit );
+
+		if ( !hasFirstRow && !hasMaxRows ) {
+			return sql;
+		}
+
 		return processSql(
 				sql,
-				hasFirstRow( limit ),
-				hasMaxRows( limit ),
+				hasFirstRow,
+				hasMaxRows,
 				queryOptions.getLockOptions()
 		);
 	}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/query/NativeQueryLimitOffsetTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/query/NativeQueryLimitOffsetTest.java
@@ -12,6 +12,7 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 
 import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.Jira;
 import org.hibernate.testing.orm.junit.JiraKey;
 import org.hibernate.testing.orm.junit.SessionFactory;
 import org.hibernate.testing.orm.junit.SessionFactoryScope;
@@ -89,6 +90,24 @@ public class NativeQueryLimitOffsetTest {
 					assertEquals( 3, l.size() );
 				}
 		);
+	}
+
+	@Test
+	@Jira( "https://hibernate.atlassian.net/browse/HHH-18309" )
+	public void testLimitOffsetZeroValue(SessionFactoryScope scope) {
+		scope.inTransaction( session -> {
+			List<Long> l = session.createNativeQuery( "select id from Person where name like :name", Long.class )
+					.setParameter( "name", "J%" )
+					.setFirstResult( 0 )
+					.getResultList();
+			assertEquals( 5, l.size() );
+
+			l = session.createNativeQuery( "select id from Person where name like :name", Long.class )
+					.setParameter( "name", "J%" )
+					.setMaxResults( 0 )
+					.getResultList();
+			assertEquals( 0, l.size() );
+		} );
 	}
 
 	@Entity(name = "Person")


### PR DESCRIPTION
<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

https://hibernate.atlassian.net/browse/HHH-18309

Backport of #8743 

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
