### PR TITLE
Provide a non-"internal" way to access empty QueryParameterBindings

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/query/spi/QueryParameterBindings.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/spi/QueryParameterBindings.java
@@ -12,6 +12,7 @@ import org.hibernate.Incubating;
 import org.hibernate.cache.spi.QueryKey;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.query.QueryParameter;
+import org.hibernate.query.internal.QueryParameterBindingsImpl;
 
 /**
  * Manages all the parameter bindings for a particular query.
@@ -89,7 +90,7 @@ public interface QueryParameterBindings {
 	};
 
 	/**
-	 * @deprecated Use {@link org.hibernate.query.internal.QueryParameterBindingsImpl#EMPTY} instead
+	 * @deprecated Use {@link #empty()} instead.
 	 */
 	@Deprecated(forRemoval = true, since = "6.6")
 	QueryParameterBindings NO_PARAM_BINDINGS = new QueryParameterBindings() {
@@ -131,4 +132,8 @@ public interface QueryParameterBindings {
 			return NO_PARAMETER_BINDING_MEMENTO;
 		}
 	};
+
+	static QueryParameterBindings empty() {
+		return QueryParameterBindingsImpl.EMPTY;
+	}
 }


### PR DESCRIPTION
Hey @beikov , Search is using the `NO_PARAM_BINDINGS` and now that it got marked for removal, the suggested alternative is in an internal package ... maybe we can just add a static method to the interface for the empty bindings instead?

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
