### PR TITLE
HHH-18466 Test and fix regression from 5.6.15.Final where a mutable natural IDs query cannot find an entity

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/NaturalIdMapping.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/NaturalIdMapping.java
@@ -50,8 +50,9 @@ public interface NaturalIdMapping extends VirtualModelPart {
 	List<SingularAttributeMapping> getNaturalIdAttributes();
 
 	/**
-	 * Whether the natural-id is immutable.  This is the same as saying that none of
-	 * the attributes are mutable
+	 * Whether the natural-id is mutable.  
+	 * 
+	 * @apiNote For compound natural-ids, this is true if any of the attributes are mutable.
 	 */
 	boolean isMutable();
 

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/CompoundNaturalIdMapping.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/CompoundNaturalIdMapping.java
@@ -89,12 +89,12 @@ public class CompoundNaturalIdMapping extends AbstractNaturalIdMapping implement
 		for ( int i = 0; i < attributes.size(); i++ ) {
 			final SingularAttributeMapping attributeMapping = attributes.get( i );
 			final AttributeMetadata metadata = attributeMapping.getAttributeMetadata();
-			if ( ! metadata.isUpdatable() ) {
-				return false;
+			if ( metadata.isUpdatable() ) {
+				return true;
 			}
 		}
 
-		return true;
+		return false;
 	}
 
 	@Override

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/identifier/MutableNaturalIdsTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/identifier/MutableNaturalIdsTest.java
@@ -1,0 +1,151 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html
+ */
+package org.hibernate.orm.test.mapping.identifier;
+
+import static org.hibernate.testing.transaction.TransactionUtil.doInJPA;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+
+import org.hibernate.Session;
+import org.hibernate.annotations.NaturalId;
+import org.hibernate.internal.SessionImpl;
+import org.hibernate.orm.test.jpa.BaseEntityManagerFunctionalTestCase;
+import org.junit.Test;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+
+/**
+ * @author Gary Gregory
+ */
+public class MutableNaturalIdsTest extends BaseEntityManagerFunctionalTestCase {
+
+	private static final String FIELD_1 = "email1";
+	private static final String FIELD_2 = "email2";
+	private static final String FIELD_3 = "email3";
+
+	private static final String OLD_VALUE_1 = "john1@acme.com";
+	private static final String OLD_VALUE_2 = "john2@acme.com";
+	private static final String OLD_VALUE_3 = "john3@acme.com";
+
+	private static final String NEW_VALUE_1 = "john.doe1@acme.com";
+	private static final String NEW_VALUE_2 = "john.doe2@acme.com";
+
+	@Override
+	protected Class<?>[] getAnnotatedClasses() {
+		return new Class<?>[] {
+			Author.class
+		};
+	}
+
+	@Test
+	public void test() {
+		doInJPA(this::entityManagerFactory, entityManager -> {
+			Author author = new Author();
+			author.setId(1L);
+			author.setName("John Doe");
+			author.setEmail1(OLD_VALUE_1);
+			author.setEmail2(OLD_VALUE_2);
+			author.setEmail3(OLD_VALUE_3);
+
+			entityManager.persist(author);
+		});
+		doInJPA(this::entityManagerFactory, entityManager -> {
+			Author author = entityManager
+				.unwrap(Session.class)
+				.byNaturalId(Author.class)
+				.using(FIELD_1, OLD_VALUE_1)
+				.using(FIELD_2, OLD_VALUE_2)
+				.using(FIELD_3, OLD_VALUE_3)
+				.load();
+
+			author.setEmail1(NEW_VALUE_1);
+			author.setEmail2(NEW_VALUE_2);
+
+			assertNull(
+				entityManager
+					.unwrap(Session.class)
+					.byNaturalId(Author.class)
+					.setSynchronizationEnabled(false)
+					.using(FIELD_1, NEW_VALUE_1)
+					.using(FIELD_2, NEW_VALUE_2)
+					.using(FIELD_3, OLD_VALUE_3)
+					.load()
+			);
+
+			assertSame(author,
+				entityManager
+					.unwrap(Session.class)
+					.byNaturalId(Author.class)
+					.setSynchronizationEnabled(true)
+					.using(FIELD_1, NEW_VALUE_1)
+					.using(FIELD_2, NEW_VALUE_2)
+					.using(FIELD_3, OLD_VALUE_3)
+					.load()
+			);
+		});
+	}
+
+	@Entity(name = "Author")
+	public static class Author {
+
+		@Id
+		private Long id;
+
+		private String name;
+
+		@NaturalId(mutable = true)
+		private String email1;
+
+		@NaturalId(mutable = true)
+		private String email2;
+
+		@NaturalId
+		private String email3;
+
+		public Long getId() {
+			return id;
+		}
+
+		public void setId(Long id) {
+			this.id = id;
+		}
+
+		public String getName() {
+			return name;
+		}
+
+		public void setName(String name) {
+			this.name = name;
+		}
+
+		public String getEmail1() {
+			return email1;
+		}
+
+		public String getEmail2() {
+			return email2;
+		}
+
+		public String getEmail3() {
+			return email3;
+		}
+
+		public void setEmail1(String email) {
+			this.email1 = email;
+		}
+
+		public void setEmail2(String email2) {
+			this.email2 = email2;
+		}
+
+		public void setEmail3(String email3) {
+			this.email3 = email3;
+		}
+
+	}
+}


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-18466

This test demonstrates a regression from 5.6.15.Final: When you have an entity with more than one `@NaturalID` instance variable (some mutable, some not), and you mutate those (mutable) fields, that entity can no longer be found. There is no workaround that I can find.

This PR is a failing test called `MutableNaturalIdsTest`

Tested with:
```
openjdk version "21.0.3" 2024-04-16 LTS
OpenJDK Runtime Environment Temurin-21.0.3+9 (build 21.0.3+9-LTS)
OpenJDK 64-Bit Server VM Temurin-21.0.3+9 (build 21.0.3+9-LTS, mixed mode, sharing)
```
and
```
openjdk version "17.0.11" 2024-04-16
OpenJDK Runtime Environment Temurin-17.0.11+9 (build 17.0.11+9)
OpenJDK 64-Bit Server VM Temurin-17.0.11+9 (build 17.0.11+9, mixed mode, sharing)
```
Tested from the `hibernate-core` folder with:
```
..\gradlew test -Pdb=h2 --tests org.hibernate.orm.test.mapping.identifier.MutableNaturalIdsTest
```
Our actual DB is PostgreSQL.