### PR TITLE
HHH-15557 fix problem when orm plugin is applied before Java plugin

### DIFF
--- a/tooling/hibernate-gradle-plugin/src/main/java/org/hibernate/orm/tooling/gradle/HibernateOrmPlugin.java
+++ b/tooling/hibernate-gradle-plugin/src/main/java/org/hibernate/orm/tooling/gradle/HibernateOrmPlugin.java
@@ -14,7 +14,6 @@ import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.Task;
 import org.gradle.api.file.DirectoryProperty;
-import org.gradle.api.plugins.JvmEcosystemPlugin;
 import org.gradle.api.tasks.SourceSet;
 
 import org.hibernate.orm.tooling.gradle.enhance.EnhancementHelper;
@@ -25,24 +24,28 @@ import org.hibernate.orm.tooling.gradle.enhance.EnhancementHelper;
 public class HibernateOrmPlugin implements Plugin<Project> {
 	@Override
 	public void apply(Project project) {
-		// for SourceSet support and other JVM goodies
-		project.getPlugins().apply( JvmEcosystemPlugin.class );
+		project.getPluginManager().withPlugin( "java", plugin -> {
 
-		project.getLogger().debug( "Adding Hibernate extensions to the build [{}]", project.getPath() );
-		final HibernateOrmSpec ormDsl = project.getExtensions().create( HibernateOrmSpec.DSL_NAME,  HibernateOrmSpec.class, project );
+			project.getLogger().debug( "Adding Hibernate extensions to the build [{}]", project.getPath() );
+			final HibernateOrmSpec ormDsl = project.getExtensions().create(
+					HibernateOrmSpec.DSL_NAME,
+					HibernateOrmSpec.class,
+					project
+			);
 
-		prepareEnhancement( ormDsl, project );
-		prepareHbmTransformation( ormDsl, project );
+			prepareEnhancement( ormDsl, project );
+			prepareHbmTransformation( ormDsl, project );
 
 
-		//noinspection ConstantConditions
-		project.getDependencies().add(
-				"implementation",
-				ormDsl.getUseSameVersion().map( (use) -> use
-						? "org.hibernate.orm:hibernate-core:" + HibernateVersion.version
-						: null
-				)
-		);
+			//noinspection ConstantConditions
+			project.getDependencies().add(
+					"implementation",
+					ormDsl.getUseSameVersion().map( (use) -> use
+							? "org.hibernate.orm:hibernate-core:" + HibernateVersion.version
+							: null
+					)
+			);
+		} );
 	}
 
 	private void prepareEnhancement(HibernateOrmSpec ormDsl, Project project) {


### PR DESCRIPTION
<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

There was a report that the build.gradle file contained in the project stubs generated by start.spring.io did not compile (see spring-io/start.spring.io#1078) that identified [HHH-15557](https://hibernate.atlassian.net/browse/HHH-15557) as the underlying issue.

Here is my attempt to fix it following the approach suggested in the [Gradle docs](https://docs.gradle.org/7.6.2/userguide/implementing_gradle_plugins.html#reacting_to_plugins).

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------


[HHH-15557]: https://hibernate.atlassian.net/browse/HHH-15557?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ