### PR TITLE
HHH-18405: Fixes in user guide (Chapter 4 and appendices)

### DIFF
--- a/documentation/src/main/asciidoc/userguide/chapters/bootstrap/Bootstrap.adoc
+++ b/documentation/src/main/asciidoc/userguide/chapters/bootstrap/Bootstrap.adoc
@@ -241,7 +241,7 @@ include::{example-dir-boot}/BootstrapTest.java[tags=bootstrap-jpa-compliant-Enti
 ====
 If you don't want to provide a `persistence.xml` configuration file, Jakarta Persistence allows you to provide all the configuration options in a
 {jpaJavadocUrlPrefix}spi/PersistenceUnitInfo.html[`PersistenceUnitInfo`] implementation and call
-https://docs.jboss.org/hibernate/orm/{majorMinorVersion}/javadocs/org/hibernate/jpa/HibernatePersistenceProvider.html#createContainerEntityManagerFactory-jakarta.persistence.spi.PersistenceUnitInfo-java.util.Map-[`HibernatePersistenceProvider#createContainerEntityManagerFactory()`].
+{doc-version-base-url}/javadocs/org/hibernate/jpa/HibernatePersistenceProvider.html#createContainerEntityManagerFactory(jakarta.persistence.spi.PersistenceUnitInfo,java.util.Map)[`HibernatePersistenceProvider#createContainerEntityManagerFactory()`].
 ====
 
 To inject the default Persistence Context, you can use the {jpaJavadocUrlPrefix}PersistenceContext.html[`@PersistenceContext`] annotation.

--- a/documentation/src/main/asciidoc/userguide/chapters/bootstrap/Bootstrap.adoc
+++ b/documentation/src/main/asciidoc/userguide/chapters/bootstrap/Bootstrap.adoc
@@ -21,7 +21,6 @@ During the bootstrap process, you might want to customize Hibernate behavior so 
 
 This section discusses the process of bootstrapping a Hibernate `SessionFactory`.
 Specifically, it addresses the bootstrapping APIs.
-For a discussion of the legacy bootstrapping API, see <<appendices/Legacy_Bootstrap.adoc#appendix-legacy-bootstrap,Legacy Bootstrapping>>.
 
 [[bootstrap-native-registry]]
 ==== Building the ServiceRegistry


### PR DESCRIPTION
<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

[Please describe here what your change is about]
Fixing some errors found in user guide, namely:

- Broken link to unused appendix `Legacy_Bootstrap.adoc`
- Link rendering and reference to external javadoc

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-18405
<!-- Hibernate GitHub Bot issue links end -->