### PR TITLE
HHH-18491 Do no try to resume non-existant transaction in doInSuspendedTransaction.

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/resource/transaction/backend/jta/internal/JtaIsolationDelegate.java
+++ b/hibernate-core/src/main/java/org/hibernate/resource/transaction/backend/jta/internal/JtaIsolationDelegate.java
@@ -117,7 +117,9 @@ public class JtaIsolationDelegate implements IsolationDelegate {
 		try {
 			// First we suspend any current JTA transaction
 			final Transaction surroundingTransaction = transactionManager.suspend();
-			LOG.debugf( "Surrounding JTA transaction suspended [%s]", surroundingTransaction );
+			if ( surroundingTransaction != null ) {
+				LOG.debugf( "Surrounding JTA transaction suspended [%s]", surroundingTransaction );
+			}
 
 			try {
 				return callable.call();
@@ -127,8 +129,10 @@ public class JtaIsolationDelegate implements IsolationDelegate {
 			}
 			finally {
 				try {
-					transactionManager.resume( surroundingTransaction );
-					LOG.debugf( "Surrounding JTA transaction resumed [%s]", surroundingTransaction );
+					if ( surroundingTransaction != null ) {
+						transactionManager.resume( surroundingTransaction );
+						LOG.debugf( "Surrounding JTA transaction resumed [%s]", surroundingTransaction );
+					}
 				}
 				catch ( Throwable t2 ) {
 					// if the actually work had an error use that, otherwise error based on t


### PR DESCRIPTION
This PR avoid calling  `transactionManager.resume()` in `JtaIsolationDelegate.doInSuspendedTransaction` when no surrounding transaction exists. It fixes an unpleasant warning in Atomikos' transaction manager.

----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-18491
<!-- Hibernate GitHub Bot issue links end -->