### PR TITLE
HHH-18488 Make Hibernate ORM's builds more reproducible

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,7 +38,6 @@ plugins {
 
 apply from: file( 'gradle/module.gradle' )
 
-
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 // Release Task
 

--- a/ci/compare-build-results.sh
+++ b/ci/compare-build-results.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+
+# This is a simple script to check if builds are reproducible. The steps are:
+# 1. Build ORM with `./gradlew --no-daemon clean publishToMavenLocal --no-build-cache -Dmaven.repo.local=some-path/out/build1`
+# 2. Build ORM with `./gradlew --no-daemon clean publishToMavenLocal --no-build-cache -Dmaven.repo.local=some-path/out/build2` second time pointing to a different local maven repository to publish
+# 3. Compare the build results with sh ./ci/compare-build-results.sh some-path/out/build1 some-path/out/build2
+# 4. The generated .buildcompare file will also contain the diffscope commands to see/compare the problematic build artifacts
+
+outputDir1=$1
+outputDir2=$2
+outputDir1=${outputDir1%/}
+outputDir2=${outputDir2%/}
+
+ok=()
+okFiles=()
+ko=()
+koFiles=()
+
+for f in `find ${outputDir1} -type f | grep -v "javadoc.jar$" | grep -v "maven-metadata-local.xml$" | sort`
+do
+  flocal=${f#$outputDir1}
+  #  echo "comparing ${flocal}"
+  sha1=`shasum -a 512 $f | cut -f 1 -d ' '`
+  sha2=`shasum -a 512 $outputDir2$flocal | cut -f 1 -d ' '`
+  #  echo "$sha1"
+  #  echo "$sha2"
+  if [ "$sha1" = "$sha2" ]; then
+    ok+=($flocal)
+    okFiles+=(${flocal##*/})
+  else
+    ko+=($flocal)
+    koFiles+=(${flocal##*/})
+  fi
+done
+
+# generate .buildcompare
+buildcompare=".buildcompare"
+echo "ok=${#ok[@]}" >> ${buildcompare}
+echo "ko=${#ko[@]}" >> ${buildcompare}
+echo "okFiles=\"${okFiles[@]}\"" >> ${buildcompare}
+echo "koFiles=\"${koFiles[@]}\"" >> ${buildcompare}
+echo "" >> ${buildcompare}
+echo "# see what caused the mismatch in the checksum by executing the following diffscope commands" >> ${buildcompare}
+for f in ${ko[@]}
+do
+  echo "# diffoscope $outputDir1$f $outputDir2$f" >> ${buildcompare}
+done
+
+if [ ${#ko[@]} -eq 0 ]; then
+    exit 0
+else
+   exit 1
+fi

--- a/gradle/java-module.gradle
+++ b/gradle/java-module.gradle
@@ -185,10 +185,13 @@ tasks.withType( JavaCompile ) {
 	options.fork = true
 	options.forkOptions.memoryMaximumSize = '768m'
 
-//	javaCompileTask.options.compilerArgs += [
+	options.compilerArgs += [
+			// disable adding @Generated annotation in the logger impls to make
+			// the logging annotation processor create the same sources each time.
+			"-Aorg.jboss.logging.tools.addGeneratedAnnotation=false"
 //			"-nowarn",
 //			"-encoding", "UTF-8"
-//	]
+	]
 }
 
 

--- a/gradle/java-module.gradle
+++ b/gradle/java-module.gradle
@@ -57,6 +57,15 @@ if ( !project.description ) {
 	project.description = "The Hibernate ORM $project.name module"
 }
 
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+// Reproducible Builds
+
+// https://docs.gradle.org/current/userguide/working_with_files.html#sec:reproducible_archives
+// Configure archive tasks to produce reproducible archives:
+tasks.withType(AbstractArchiveTask).configureEach {
+	preserveFileTimestamps = false
+	reproducibleFileOrder = true
+}
 
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 // Configurations and Dependencies

--- a/hibernate-c3p0/src/main/java/org/hibernate/c3p0/internal/C3P0MessageLogger.java
+++ b/hibernate-c3p0/src/main/java/org/hibernate/c3p0/internal/C3P0MessageLogger.java
@@ -15,6 +15,8 @@ import org.jboss.logging.annotations.Message;
 import org.jboss.logging.annotations.MessageLogger;
 import org.jboss.logging.annotations.ValidIdRange;
 
+import java.lang.invoke.MethodHandles;
+
 import static org.jboss.logging.Logger.Level.WARN;
 
 /**
@@ -32,7 +34,7 @@ import static org.jboss.logging.Logger.Level.WARN;
 public interface C3P0MessageLogger extends ConnectionInfoLogger {
 	String NAME = ConnectionInfoLogger.LOGGER_NAME + ".c3p0";
 
-	C3P0MessageLogger C3P0_MSG_LOGGER = Logger.getMessageLogger( C3P0MessageLogger.class, NAME );
+	C3P0MessageLogger C3P0_MSG_LOGGER = Logger.getMessageLogger( MethodHandles.lookup(), C3P0MessageLogger.class, NAME );
 
 	/**
 	 * Log a message (WARN) about conflicting {@code hibernate.c3p0.XYZ} and {@code c3p0.XYZ} settings

--- a/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/CockroachLegacyDialect.java
+++ b/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/CockroachLegacyDialect.java
@@ -6,6 +6,7 @@
  */
 package org.hibernate.community.dialect;
 
+import java.lang.invoke.MethodHandles;
 import java.sql.DatabaseMetaData;
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -120,7 +121,7 @@ import static org.hibernate.type.descriptor.DateTimeUtils.appendAsTimestampWithM
  */
 public class CockroachLegacyDialect extends Dialect {
 
-	private static final CoreMessageLogger LOG = Logger.getMessageLogger( CoreMessageLogger.class, CockroachLegacyDialect.class.getName() );
+	private static final CoreMessageLogger LOG = Logger.getMessageLogger( MethodHandles.lookup(), CoreMessageLogger.class, CockroachLegacyDialect.class.getName() );
 	// KNOWN LIMITATIONS:
 	// * no support for java.sql.Clob
 

--- a/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/HSQLLegacyDialect.java
+++ b/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/HSQLLegacyDialect.java
@@ -6,6 +6,7 @@
  */
 package org.hibernate.community.dialect;
 
+import java.lang.invoke.MethodHandles;
 import java.sql.DatabaseMetaData;
 import java.sql.SQLException;
 import java.sql.Types;
@@ -95,6 +96,7 @@ import static org.hibernate.type.SqlTypes.NUMERIC;
  */
 public class HSQLLegacyDialect extends Dialect {
 	private static final CoreMessageLogger LOG = Logger.getMessageLogger(
+			MethodHandles.lookup(),
 			CoreMessageLogger.class,
 			org.hibernate.community.dialect.HSQLLegacyDialect.class.getName()
 	);

--- a/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/RDMSOS2200Dialect.java
+++ b/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/RDMSOS2200Dialect.java
@@ -6,6 +6,7 @@
  */
 package org.hibernate.community.dialect;
 
+import java.lang.invoke.MethodHandles;
 import java.sql.Types;
 
 import org.hibernate.LockMode;
@@ -81,6 +82,7 @@ import static org.hibernate.type.SqlTypes.VARCHAR;
  */
 public class RDMSOS2200Dialect extends Dialect {
 	private static final CoreMessageLogger LOG = Logger.getMessageLogger(
+			MethodHandles.lookup(),
 			CoreMessageLogger.class,
 			RDMSOS2200Dialect.class.getName()
 	);

--- a/hibernate-core/src/main/java/org/hibernate/LazyInitializationException.java
+++ b/hibernate-core/src/main/java/org/hibernate/LazyInitializationException.java
@@ -10,6 +10,8 @@ import org.hibernate.internal.CoreMessageLogger;
 
 import org.jboss.logging.Logger;
 
+import java.lang.invoke.MethodHandles;
+
 /**
  * Indicates an attempt to access unfetched data outside the context
  * of an open stateful {@link Session}.
@@ -24,6 +26,7 @@ import org.jboss.logging.Logger;
 public class LazyInitializationException extends HibernateException {
 
 	private static final CoreMessageLogger LOG = Logger.getMessageLogger(
+			MethodHandles.lookup(),
 			CoreMessageLogger.class,
 			LazyInitializationException.class.getName()
 	);

--- a/hibernate-core/src/main/java/org/hibernate/Version.java
+++ b/hibernate-core/src/main/java/org/hibernate/Version.java
@@ -11,6 +11,8 @@ import org.hibernate.internal.build.AllowSysOut;
 
 import org.jboss.logging.Logger;
 
+import java.lang.invoke.MethodHandles;
+
 /**
  * Information about the version of Hibernate.
  *
@@ -41,7 +43,7 @@ public final class Version {
 	 * Logs the Hibernate version (using {@link #getVersionString()}) to the logging system.
 	 */
 	public static void logVersion() {
-		Logger.getMessageLogger( CoreMessageLogger.class, Version.class.getName() ).version( getVersionString() );
+		Logger.getMessageLogger( MethodHandles.lookup(), CoreMessageLogger.class, Version.class.getName() ).version( getVersionString() );
 	}
 
 	/**

--- a/hibernate-core/src/main/java/org/hibernate/action/internal/UnresolvedEntityInsertActions.java
+++ b/hibernate-core/src/main/java/org/hibernate/action/internal/UnresolvedEntityInsertActions.java
@@ -9,6 +9,7 @@ package org.hibernate.action.internal;
 import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
+import java.lang.invoke.MethodHandles;
 import java.util.IdentityHashMap;
 import java.util.Map;
 import java.util.Set;
@@ -45,8 +46,9 @@ import static org.hibernate.pretty.MessageHelper.infoString;
  */
 public class UnresolvedEntityInsertActions {
 	private static final CoreMessageLogger LOG = Logger.getMessageLogger(
-				CoreMessageLogger.class,
-				UnresolvedEntityInsertActions.class.getName()
+			MethodHandles.lookup(),
+			CoreMessageLogger.class,
+			UnresolvedEntityInsertActions.class.getName()
 	);
 
 	private static final int INIT_SIZE = 5;

--- a/hibernate-core/src/main/java/org/hibernate/boot/beanvalidation/BeanValidationEventListener.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/beanvalidation/BeanValidationEventListener.java
@@ -6,6 +6,7 @@
  */
 package org.hibernate.boot.beanvalidation;
 
+import java.lang.invoke.MethodHandles;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
@@ -47,6 +48,7 @@ public class BeanValidationEventListener
 		implements PreInsertEventListener, PreUpdateEventListener, PreDeleteEventListener, PreUpsertEventListener {
 
 	private static final CoreMessageLogger LOG = Logger.getMessageLogger(
+			MethodHandles.lookup(),
 			CoreMessageLogger.class,
 			BeanValidationEventListener.class.getName()
 	);

--- a/hibernate-core/src/main/java/org/hibernate/boot/beanvalidation/BeanValidationIntegrator.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/beanvalidation/BeanValidationIntegrator.java
@@ -6,6 +6,7 @@
  */
 package org.hibernate.boot.beanvalidation;
 
+import java.lang.invoke.MethodHandles;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.Set;
@@ -30,6 +31,7 @@ import org.jboss.logging.Logger;
  */
 public class BeanValidationIntegrator implements Integrator {
 	private static final CoreMessageLogger LOG = Logger.getMessageLogger(
+			MethodHandles.lookup(),
 			CoreMessageLogger.class,
 			BeanValidationIntegrator.class.getName()
 	);

--- a/hibernate-core/src/main/java/org/hibernate/boot/beanvalidation/TypeSafeActivator.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/beanvalidation/TypeSafeActivator.java
@@ -7,6 +7,7 @@
 package org.hibernate.boot.beanvalidation;
 
 import java.lang.annotation.Annotation;
+import java.lang.invoke.MethodHandles;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -60,7 +61,7 @@ import static org.hibernate.cfg.ValidationSettings.JPA_VALIDATION_FACTORY;
  */
 class TypeSafeActivator {
 
-	private static final CoreMessageLogger LOG = Logger.getMessageLogger(CoreMessageLogger.class, TypeSafeActivator.class.getName());
+	private static final CoreMessageLogger LOG = Logger.getMessageLogger( MethodHandles.lookup(), CoreMessageLogger.class, TypeSafeActivator.class.getName() );
 
 	/**
 	 * Used to validate a supplied ValidatorFactory instance as being castable to ValidatorFactory.

--- a/hibernate-core/src/main/java/org/hibernate/boot/jaxb/JaxbLogger.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/jaxb/JaxbLogger.java
@@ -14,6 +14,8 @@ import org.jboss.logging.Logger;
 import org.jboss.logging.annotations.MessageLogger;
 import org.jboss.logging.annotations.ValidIdRange;
 
+import java.lang.invoke.MethodHandles;
+
 /**
  * @author Steve Ebersole
  */
@@ -25,5 +27,5 @@ import org.jboss.logging.annotations.ValidIdRange;
 )
 public interface JaxbLogger extends BasicLogger {
 	String LOGGER_NAME = BootLogging.NAME + ".jaxb";
-	JaxbLogger JAXB_LOGGER = Logger.getMessageLogger( JaxbLogger.class, LOGGER_NAME );
+	JaxbLogger JAXB_LOGGER = Logger.getMessageLogger( MethodHandles.lookup(), JaxbLogger.class, LOGGER_NAME );
 }

--- a/hibernate-core/src/main/java/org/hibernate/boot/jaxb/hbm/spi/TableInformationContainer.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/jaxb/hbm/spi/TableInformationContainer.java
@@ -20,5 +20,4 @@ public interface TableInformationContainer {
 
 	String getSubselect();
 
-	String getSubselectAttribute();
 }

--- a/hibernate-core/src/main/java/org/hibernate/boot/model/internal/AnnotatedColumn.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/internal/AnnotatedColumn.java
@@ -6,6 +6,7 @@
  */
 package org.hibernate.boot.model.internal;
 
+import java.lang.invoke.MethodHandles;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -68,7 +69,7 @@ import static org.hibernate.internal.util.StringHelper.nullIfEmpty;
  */
 public class AnnotatedColumn {
 
-	private static final CoreMessageLogger LOG = Logger.getMessageLogger(CoreMessageLogger.class, AnnotatedColumn.class.getName());
+	private static final CoreMessageLogger LOG = Logger.getMessageLogger( MethodHandles.lookup(), CoreMessageLogger.class, AnnotatedColumn.class.getName() );
 
 	private Column mappingColumn;
 	private boolean insertable = true;

--- a/hibernate-core/src/main/java/org/hibernate/boot/model/internal/BasicValueBinder.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/internal/BasicValueBinder.java
@@ -7,6 +7,7 @@
 package org.hibernate.boot.model.internal;
 
 import java.io.Serializable;
+import java.lang.invoke.MethodHandles;
 import java.lang.reflect.ParameterizedType;
 import java.util.Collection;
 import java.util.Collections;
@@ -113,7 +114,7 @@ public class BasicValueBinder implements JdbcTypeIndicators {
 	//      forward this class should undergo major changes: see the comments in #setType
 	//		but as always the "design" of these classes make it unclear exactly how to change it properly.
 
-	private static final CoreMessageLogger LOG = Logger.getMessageLogger( CoreMessageLogger.class, BasicValueBinder.class.getName() );
+	private static final CoreMessageLogger LOG = Logger.getMessageLogger( MethodHandles.lookup(), CoreMessageLogger.class, BasicValueBinder.class.getName() );
 
 	public enum Kind {
 		ATTRIBUTE( ValueMappingAccess.INSTANCE ),

--- a/hibernate-core/src/main/java/org/hibernate/boot/model/internal/CollectionBinder.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/internal/CollectionBinder.java
@@ -7,6 +7,7 @@
 package org.hibernate.boot.model.internal;
 
 import java.lang.annotation.Annotation;
+import java.lang.invoke.MethodHandles;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
@@ -186,7 +187,7 @@ import static org.hibernate.mapping.MappingHelper.createLocalUserCollectionTypeB
  * @author Emmanuel Bernard
  */
 public abstract class CollectionBinder {
-	private static final CoreMessageLogger LOG = Logger.getMessageLogger(CoreMessageLogger.class, CollectionBinder.class.getName());
+	private static final CoreMessageLogger LOG = Logger.getMessageLogger( MethodHandles.lookup(), CoreMessageLogger.class, CollectionBinder.class.getName() );
 
 	private static final List<Class<?>> INFERRED_CLASS_PRIORITY = List.of(
 			List.class,

--- a/hibernate-core/src/main/java/org/hibernate/boot/model/internal/CollectionSecondPass.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/internal/CollectionSecondPass.java
@@ -6,6 +6,7 @@
  */
 package org.hibernate.boot.model.internal;
 
+import java.lang.invoke.MethodHandles;
 import java.util.Map;
 
 import org.hibernate.MappingException;
@@ -27,7 +28,7 @@ import org.jboss.logging.Logger;
  */
 public abstract class CollectionSecondPass implements SecondPass {
 
-	private static final CoreMessageLogger LOG = Logger.getMessageLogger(CoreMessageLogger.class, CollectionSecondPass.class.getName());
+	private static final CoreMessageLogger LOG = Logger.getMessageLogger( MethodHandles.lookup(), CoreMessageLogger.class, CollectionSecondPass.class.getName() );
 
 	private final Collection collection;
 

--- a/hibernate-core/src/main/java/org/hibernate/boot/model/internal/EntityBinder.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/internal/EntityBinder.java
@@ -7,6 +7,7 @@
 package org.hibernate.boot.model.internal;
 
 import java.lang.annotation.Annotation;
+import java.lang.invoke.MethodHandles;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -171,7 +172,7 @@ import static org.hibernate.internal.util.collections.CollectionHelper.isNotEmpt
  */
 public class EntityBinder {
 
-	private static final CoreMessageLogger LOG = Logger.getMessageLogger( CoreMessageLogger.class, EntityBinder.class.getName() );
+	private static final CoreMessageLogger LOG = Logger.getMessageLogger( MethodHandles.lookup(), CoreMessageLogger.class, EntityBinder.class.getName() );
 	private static final String NATURAL_ID_CACHE_SUFFIX = "##NaturalId";
 
 	private MetadataBuildingContext context;

--- a/hibernate-core/src/main/java/org/hibernate/boot/model/internal/PropertyBinder.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/internal/PropertyBinder.java
@@ -7,6 +7,7 @@
 package org.hibernate.boot.model.internal;
 
 import java.lang.annotation.Annotation;
+import java.lang.invoke.MethodHandles;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Map;
@@ -102,7 +103,7 @@ import static org.hibernate.internal.util.StringHelper.qualify;
  * @author Emmanuel Bernard
  */
 public class PropertyBinder {
-	private static final CoreMessageLogger LOG = Logger.getMessageLogger( CoreMessageLogger.class, PropertyBinder.class.getName() );
+	private static final CoreMessageLogger LOG = Logger.getMessageLogger( MethodHandles.lookup(), CoreMessageLogger.class, PropertyBinder.class.getName() );
 
 	private MetadataBuildingContext buildingContext;
 

--- a/hibernate-core/src/main/java/org/hibernate/boot/model/internal/PropertyContainer.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/internal/PropertyContainer.java
@@ -9,6 +9,7 @@
 
 package org.hibernate.boot.model.internal;
 
+import java.lang.invoke.MethodHandles;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
@@ -56,7 +57,7 @@ import jakarta.persistence.Transient;
  */
 public class PropertyContainer {
 
-	private static final CoreMessageLogger LOG = Logger.getMessageLogger(CoreMessageLogger.class, PropertyContainer.class.getName());
+	private static final CoreMessageLogger LOG = Logger.getMessageLogger( MethodHandles.lookup(), CoreMessageLogger.class, PropertyContainer.class.getName() );
 
 	/**
 	 * The class for which this container is created.

--- a/hibernate-core/src/main/java/org/hibernate/boot/model/internal/QueryBinder.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/internal/QueryBinder.java
@@ -6,6 +6,7 @@
  */
 package org.hibernate.boot.model.internal;
 
+import java.lang.invoke.MethodHandles;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
@@ -67,7 +68,7 @@ import static org.hibernate.internal.util.collections.CollectionHelper.setOf;
  * @author Emmanuel Bernard
  */
 public abstract class QueryBinder {
-	private static final CoreMessageLogger LOG = Logger.getMessageLogger(CoreMessageLogger.class, QueryBinder.class.getName());
+	private static final CoreMessageLogger LOG = Logger.getMessageLogger( MethodHandles.lookup(), CoreMessageLogger.class, QueryBinder.class.getName() );
 
 	public static void bindQuery(
 			NamedQuery namedQuery,

--- a/hibernate-core/src/main/java/org/hibernate/boot/model/internal/TableBinder.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/internal/TableBinder.java
@@ -6,6 +6,7 @@
  */
 package org.hibernate.boot.model.internal;
 
+import java.lang.invoke.MethodHandles;
 import java.util.List;
 
 import org.hibernate.AnnotationException;
@@ -57,7 +58,7 @@ import static org.hibernate.internal.util.StringHelper.unquote;
  * @author Emmanuel Bernard
  */
 public class TableBinder {
-	private static final CoreMessageLogger LOG = Logger.getMessageLogger( CoreMessageLogger.class, TableBinder.class.getName() );
+	private static final CoreMessageLogger LOG = Logger.getMessageLogger( MethodHandles.lookup(), CoreMessageLogger.class, TableBinder.class.getName() );
 
 	private MetadataBuildingContext buildingContext;
 

--- a/hibernate-core/src/main/java/org/hibernate/boot/model/source/internal/hbm/Helper.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/source/internal/hbm/Helper.java
@@ -185,8 +185,7 @@ public class Helper {
 			String rowId,
 			String comment,
 			String checkConstraint) {
-		if ( StringHelper.isEmpty( tableInformationContainer.getSubselectAttribute() )
-				&& StringHelper.isEmpty( tableInformationContainer.getSubselect() ) ) {
+		if ( StringHelper.isEmpty( tableInformationContainer.getSubselect() ) ) {
 			return new TableSourceImpl(
 					mappingDocument,
 					tableInformationContainer.getSchema(),
@@ -202,9 +201,7 @@ public class Helper {
 					mappingDocument,
 					tableInformationContainer.getSchema(),
 					tableInformationContainer.getCatalog(),
-					tableInformationContainer.getSubselectAttribute() != null
-							? tableInformationContainer.getSubselectAttribute()
-							: tableInformationContainer.getSubselect(),
+					tableInformationContainer.getSubselect(),
 					tableInformationContainer.getTable() == null
 							? inLineViewNameInferrer.inferInLineViewName()
 							: tableInformationContainer.getTable(),

--- a/hibernate-core/src/main/java/org/hibernate/bytecode/enhance/spi/interceptor/BytecodeInterceptorLogging.java
+++ b/hibernate-core/src/main/java/org/hibernate/bytecode/enhance/spi/interceptor/BytecodeInterceptorLogging.java
@@ -16,6 +16,8 @@ import org.jboss.logging.annotations.Message;
 import org.jboss.logging.annotations.MessageLogger;
 import org.jboss.logging.annotations.ValidIdRange;
 
+import java.lang.invoke.MethodHandles;
+
 import static org.jboss.logging.Logger.Level.WARN;
 
 /**
@@ -32,7 +34,7 @@ public interface BytecodeInterceptorLogging extends BasicLogger {
 	String LOGGER_NAME = BytecodeLogging.LOGGER_NAME + "." + SUB_NAME;
 
 	Logger LOGGER = Logger.getLogger( LOGGER_NAME );
-	BytecodeInterceptorLogging MESSAGE_LOGGER = Logger.getMessageLogger(BytecodeInterceptorLogging.class, LOGGER_NAME );
+	BytecodeInterceptorLogging MESSAGE_LOGGER = Logger.getMessageLogger( MethodHandles.lookup(), BytecodeInterceptorLogging.class, LOGGER_NAME );
 
 	@LogMessage(level = WARN)
 	@Message(

--- a/hibernate-core/src/main/java/org/hibernate/cache/spi/SecondLevelCacheLogger.java
+++ b/hibernate-core/src/main/java/org/hibernate/cache/spi/SecondLevelCacheLogger.java
@@ -16,6 +16,8 @@ import org.jboss.logging.annotations.Message;
 import org.jboss.logging.annotations.MessageLogger;
 import org.jboss.logging.annotations.ValidIdRange;
 
+import java.lang.invoke.MethodHandles;
+
 import static org.jboss.logging.Logger.Level.INFO;
 import static org.jboss.logging.Logger.Level.WARN;
 
@@ -31,7 +33,7 @@ import static org.jboss.logging.Logger.Level.WARN;
 public interface SecondLevelCacheLogger extends BasicLogger {
 	String LOGGER_NAME = SubSystemLogging.BASE + ".cache";
 
-	SecondLevelCacheLogger L2CACHE_LOGGER = Logger.getMessageLogger( SecondLevelCacheLogger.class, LOGGER_NAME );
+	SecondLevelCacheLogger L2CACHE_LOGGER = Logger.getMessageLogger( MethodHandles.lookup(), SecondLevelCacheLogger.class, LOGGER_NAME );
 
 	int NAMESPACE = 90001000;
 

--- a/hibernate-core/src/main/java/org/hibernate/cfg/Environment.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/Environment.java
@@ -8,6 +8,7 @@ package org.hibernate.cfg;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.lang.invoke.MethodHandles;
 import java.util.Properties;
 
 import org.hibernate.HibernateException;
@@ -132,7 +133,7 @@ import org.jboss.logging.Logger;
  */
 @Internal
 public final class Environment implements AvailableSettings {
-	private static final CoreMessageLogger LOG = Logger.getMessageLogger( CoreMessageLogger.class, Environment.class.getName());
+	private static final CoreMessageLogger LOG = Logger.getMessageLogger( MethodHandles.lookup(), CoreMessageLogger.class, Environment.class.getName());
 
 	private static final Properties GLOBAL_PROPERTIES;
 

--- a/hibernate-core/src/main/java/org/hibernate/context/internal/JTASessionContext.java
+++ b/hibernate-core/src/main/java/org/hibernate/context/internal/JTASessionContext.java
@@ -6,6 +6,7 @@
  */
 package org.hibernate.context.internal;
 
+import java.lang.invoke.MethodHandles;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import jakarta.transaction.Synchronization;
@@ -46,6 +47,7 @@ import org.jboss.logging.Logger;
  */
 public class JTASessionContext extends AbstractCurrentSessionContext {
 	private static final CoreMessageLogger LOG = Logger.getMessageLogger(
+			MethodHandles.lookup(),
 			CoreMessageLogger.class,
 			JTASessionContext.class.getName()
 	);

--- a/hibernate-core/src/main/java/org/hibernate/context/internal/ThreadLocalSessionContext.java
+++ b/hibernate-core/src/main/java/org/hibernate/context/internal/ThreadLocalSessionContext.java
@@ -10,6 +10,7 @@ import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.io.Serializable;
+import java.lang.invoke.MethodHandles;
 import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
@@ -60,6 +61,7 @@ import org.jboss.logging.Logger;
  */
 public class ThreadLocalSessionContext extends AbstractCurrentSessionContext {
 	private static final CoreMessageLogger LOG = Logger.getMessageLogger(
+			MethodHandles.lookup(),
 			CoreMessageLogger.class,
 			ThreadLocalSessionContext.class.getName()
 	);

--- a/hibernate-core/src/main/java/org/hibernate/dialect/CockroachDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/CockroachDialect.java
@@ -6,6 +6,7 @@
  */
 package org.hibernate.dialect;
 
+import java.lang.invoke.MethodHandles;
 import java.sql.DatabaseMetaData;
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -122,7 +123,7 @@ import static org.hibernate.type.descriptor.DateTimeUtils.appendAsTimestampWithM
  */
 public class CockroachDialect extends Dialect {
 
-	private static final CoreMessageLogger LOG = Logger.getMessageLogger( CoreMessageLogger.class, CockroachDialect.class.getName() );
+	private static final CoreMessageLogger LOG = Logger.getMessageLogger( MethodHandles.lookup(), CoreMessageLogger.class, CockroachDialect.class.getName() );
 	// KNOWN LIMITATIONS:
 	// * no support for java.sql.Clob
 

--- a/hibernate-core/src/main/java/org/hibernate/dialect/Dialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/Dialect.java
@@ -10,6 +10,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.Reader;
+import java.lang.invoke.MethodHandles;
 import java.sql.Blob;
 import java.sql.CallableStatement;
 import java.sql.Clob;
@@ -313,7 +314,7 @@ public abstract class Dialect implements ConversionContext, TypeContributor, Fun
 	private static final Pattern ESCAPE_CLOSING_COMMENT_PATTERN = Pattern.compile( "\\*/" );
 	private static final Pattern ESCAPE_OPENING_COMMENT_PATTERN = Pattern.compile( "/\\*" );
 
-	private static final CoreMessageLogger LOG = Logger.getMessageLogger( CoreMessageLogger.class, Dialect.class.getName() );
+	private static final CoreMessageLogger LOG = Logger.getMessageLogger( MethodHandles.lookup(), CoreMessageLogger.class, Dialect.class.getName() );
 
 	//needed for converting precision from decimal to binary digits
 	protected static final double LOG_BASE2OF10 = log(10)/log(2);

--- a/hibernate-core/src/main/java/org/hibernate/dialect/DialectLogging.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/DialectLogging.java
@@ -14,6 +14,8 @@ import org.jboss.logging.annotations.Message;
 import org.jboss.logging.annotations.MessageLogger;
 import org.jboss.logging.annotations.ValidIdRange;
 
+import java.lang.invoke.MethodHandles;
+
 import static org.jboss.logging.Logger.Level.DEBUG;
 
 /**
@@ -28,7 +30,7 @@ import static org.jboss.logging.Logger.Level.DEBUG;
 public interface DialectLogging {
 	String LOGGER_NAME = SubSystemLogging.BASE + ".dialect";
 	Logger DIALECT_LOGGER = Logger.getLogger(LOGGER_NAME);
-	DialectLogging DIALECT_MESSAGE_LOGGER = Logger.getMessageLogger(DialectLogging.class, LOGGER_NAME);
+	DialectLogging DIALECT_MESSAGE_LOGGER = Logger.getMessageLogger( MethodHandles.lookup(), DialectLogging.class, LOGGER_NAME );
 
 	@LogMessage(level = DEBUG)
 	@Message(value = "Using dialect: %s", id = 35001)

--- a/hibernate-core/src/main/java/org/hibernate/dialect/function/array/AbstractArrayContainsFunction.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/function/array/AbstractArrayContainsFunction.java
@@ -14,13 +14,15 @@ import org.hibernate.type.spi.TypeConfiguration;
 
 import org.jboss.logging.Logger;
 
+import java.lang.invoke.MethodHandles;
+
 /**
  * Encapsulates the validator, return type and argument type resolvers for the array_contains function.
  * Subclasses only have to implement the rendering.
  */
 public abstract class AbstractArrayContainsFunction extends AbstractSqmSelfRenderingFunctionDescriptor {
 
-	protected static final DeprecationLogger LOG = Logger.getMessageLogger( DeprecationLogger.class, AbstractArrayContainsFunction.class.getName() );
+	protected static final DeprecationLogger LOG = Logger.getMessageLogger( MethodHandles.lookup(), DeprecationLogger.class, AbstractArrayContainsFunction.class.getName() );
 
 	protected final boolean nullable;
 

--- a/hibernate-core/src/main/java/org/hibernate/dialect/lock/PessimisticReadUpdateLockingStrategy.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/lock/PessimisticReadUpdateLockingStrategy.java
@@ -6,6 +6,7 @@
  */
 package org.hibernate.dialect.lock;
 
+import java.lang.invoke.MethodHandles;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
 
@@ -38,6 +39,7 @@ import org.jboss.logging.Logger;
  */
 public class PessimisticReadUpdateLockingStrategy implements LockingStrategy {
 	private static final CoreMessageLogger LOG = Logger.getMessageLogger(
+			MethodHandles.lookup(),
 			CoreMessageLogger.class,
 			PessimisticReadUpdateLockingStrategy.class.getName()
 	);

--- a/hibernate-core/src/main/java/org/hibernate/dialect/lock/PessimisticWriteUpdateLockingStrategy.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/lock/PessimisticWriteUpdateLockingStrategy.java
@@ -6,6 +6,7 @@
  */
 package org.hibernate.dialect.lock;
 
+import java.lang.invoke.MethodHandles;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
 
@@ -38,6 +39,7 @@ import org.jboss.logging.Logger;
  */
 public class PessimisticWriteUpdateLockingStrategy implements LockingStrategy {
 	private static final CoreMessageLogger LOG = Logger.getMessageLogger(
+			MethodHandles.lookup(),
 			CoreMessageLogger.class,
 			PessimisticWriteUpdateLockingStrategy.class.getName()
 	);

--- a/hibernate-core/src/main/java/org/hibernate/dialect/lock/UpdateLockingStrategy.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/lock/UpdateLockingStrategy.java
@@ -6,6 +6,7 @@
  */
 package org.hibernate.dialect.lock;
 
+import java.lang.invoke.MethodHandles;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
 
@@ -36,6 +37,7 @@ import org.jboss.logging.Logger;
  */
 public class UpdateLockingStrategy implements LockingStrategy {
 	private static final CoreMessageLogger LOG = Logger.getMessageLogger(
+			MethodHandles.lookup(),
 			CoreMessageLogger.class,
 			UpdateLockingStrategy.class.getName()
 	);

--- a/hibernate-core/src/main/java/org/hibernate/engine/config/internal/ConfigurationServiceImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/config/internal/ConfigurationServiceImpl.java
@@ -6,6 +6,7 @@
  */
 package org.hibernate.engine.config.internal;
 
+import java.lang.invoke.MethodHandles;
 import java.util.Collections;
 import java.util.Map;
 
@@ -29,6 +30,7 @@ import org.checkerframework.checker.nullness.qual.PolyNull;
  */
 public class ConfigurationServiceImpl implements ConfigurationService, ServiceRegistryAwareService {
 	private static final CoreMessageLogger LOG = Logger.getMessageLogger(
+			MethodHandles.lookup(),
 			CoreMessageLogger.class,
 			ConfigurationServiceImpl.class.getName()
 	);

--- a/hibernate-core/src/main/java/org/hibernate/engine/internal/BatchFetchQueueHelper.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/internal/BatchFetchQueueHelper.java
@@ -7,6 +7,7 @@
 package org.hibernate.engine.internal;
 
 import java.io.Serializable;
+import java.lang.invoke.MethodHandles;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -27,6 +28,7 @@ import static java.util.Arrays.asList;
  */
 public class BatchFetchQueueHelper {
 	private static final CoreMessageLogger LOG = Logger.getMessageLogger(
+			MethodHandles.lookup(),
 			CoreMessageLogger.class,
 			BatchFetchQueueHelper.class.getName()
 	);

--- a/hibernate-core/src/main/java/org/hibernate/engine/internal/Collections.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/internal/Collections.java
@@ -24,6 +24,8 @@ import org.hibernate.type.CollectionType;
 
 import org.jboss.logging.Logger;
 
+import java.lang.invoke.MethodHandles;
+
 /**
  * Implements book-keeping for the collection persistence by reachability algorithm
  *
@@ -31,6 +33,7 @@ import org.jboss.logging.Logger;
  */
 public final class Collections {
 	private static final CoreMessageLogger LOG = Logger.getMessageLogger(
+			MethodHandles.lookup(),
 			CoreMessageLogger.class,
 			Collections.class.getName()
 	);

--- a/hibernate-core/src/main/java/org/hibernate/engine/internal/StatefulPersistenceContext.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/internal/StatefulPersistenceContext.java
@@ -11,6 +11,7 @@ import java.io.InvalidObjectException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.io.Serializable;
+import java.lang.invoke.MethodHandles;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -92,6 +93,7 @@ import static org.hibernate.engine.internal.ManagedTypeHelper.isPersistentAttrib
  */
 public class StatefulPersistenceContext implements PersistenceContext {
 	private static final CoreMessageLogger LOG = Logger.getMessageLogger(
+			MethodHandles.lookup(),
 			CoreMessageLogger.class,
 			StatefulPersistenceContext.class.getName()
 	);

--- a/hibernate-core/src/main/java/org/hibernate/engine/internal/Versioning.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/internal/Versioning.java
@@ -14,6 +14,8 @@ import org.hibernate.type.descriptor.java.VersionJavaType;
 
 import org.jboss.logging.Logger;
 
+import java.lang.invoke.MethodHandles;
+
 import static org.hibernate.generator.EventType.INSERT;
 import static org.hibernate.generator.EventType.UPDATE;
 
@@ -24,6 +26,7 @@ import static org.hibernate.generator.EventType.UPDATE;
  */
 public final class Versioning {
 	private static final CoreMessageLogger LOG = Logger.getMessageLogger(
+			MethodHandles.lookup(),
 			CoreMessageLogger.class,
 			Versioning.class.getName()
 	);

--- a/hibernate-core/src/main/java/org/hibernate/engine/jdbc/JdbcLogging.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/jdbc/JdbcLogging.java
@@ -15,6 +15,8 @@ import org.jboss.logging.annotations.Message;
 import org.jboss.logging.annotations.MessageLogger;
 import org.jboss.logging.annotations.ValidIdRange;
 
+import java.lang.invoke.MethodHandles;
+
 import static org.jboss.logging.Logger.Level.WARN;
 
 /**
@@ -32,7 +34,7 @@ public interface JdbcLogging extends BasicLogger {
 	String NAME = "org.hibernate.orm.jdbc";
 
 	Logger JDBC_LOGGER = Logger.getLogger( NAME );
-	JdbcLogging JDBC_MESSAGE_LOGGER = Logger.getMessageLogger( JdbcLogging.class, NAME );
+	JdbcLogging JDBC_MESSAGE_LOGGER = Logger.getMessageLogger( MethodHandles.lookup(), JdbcLogging.class, NAME );
 
 	@LogMessage(level = WARN)
 	@Message(

--- a/hibernate-core/src/main/java/org/hibernate/engine/jdbc/batch/JdbcBatchLogging.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/jdbc/batch/JdbcBatchLogging.java
@@ -15,6 +15,8 @@ import org.jboss.logging.annotations.Message;
 import org.jboss.logging.annotations.MessageLogger;
 import org.jboss.logging.annotations.ValidIdRange;
 
+import java.lang.invoke.MethodHandles;
+
 import static org.jboss.logging.Logger.Level.ERROR;
 import static org.jboss.logging.Logger.Level.INFO;
 
@@ -33,7 +35,7 @@ public interface JdbcBatchLogging extends BasicLogger {
 	String NAME = "org.hibernate.orm.jdbc.batch";
 
 	Logger BATCH_LOGGER = Logger.getLogger( NAME );
-	JdbcBatchLogging BATCH_MESSAGE_LOGGER = Logger.getMessageLogger( JdbcBatchLogging.class, NAME );
+	JdbcBatchLogging BATCH_MESSAGE_LOGGER = Logger.getMessageLogger( MethodHandles.lookup(), JdbcBatchLogging.class, NAME );
 
 	@LogMessage(level = ERROR)
 	@Message(id = 100501, value = "Exception executing batch [%s], SQL: %s")

--- a/hibernate-core/src/main/java/org/hibernate/engine/jdbc/env/internal/JdbcEnvironmentInitiator.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/jdbc/env/internal/JdbcEnvironmentInitiator.java
@@ -6,6 +6,7 @@
  */
 package org.hibernate.engine.jdbc.env.internal;
 
+import java.lang.invoke.MethodHandles;
 import java.sql.Connection;
 import java.sql.DatabaseMetaData;
 import java.sql.SQLException;
@@ -79,6 +80,7 @@ import static org.hibernate.internal.util.config.ConfigurationHelper.getInteger;
  */
 public class JdbcEnvironmentInitiator implements StandardServiceInitiator<JdbcEnvironment> {
 	private static final CoreMessageLogger log = Logger.getMessageLogger(
+			MethodHandles.lookup(),
 			CoreMessageLogger.class,
 			JdbcEnvironmentInitiator.class.getName()
 	);

--- a/hibernate-core/src/main/java/org/hibernate/engine/jdbc/env/internal/LobCreationLogging.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/jdbc/env/internal/LobCreationLogging.java
@@ -17,6 +17,8 @@ import org.jboss.logging.annotations.Message;
 import org.jboss.logging.annotations.MessageLogger;
 import org.jboss.logging.annotations.ValidIdRange;
 
+import java.lang.invoke.MethodHandles;
+
 import static org.jboss.logging.Logger.Level.DEBUG;
 
 /**
@@ -32,7 +34,7 @@ public interface LobCreationLogging extends BasicLogger {
 	String NAME = JdbcLogging.NAME + ".lob";
 
 	Logger LOB_LOGGER = Logger.getLogger( NAME );
-	LobCreationLogging LOB_MESSAGE_LOGGER = Logger.getMessageLogger( LobCreationLogging.class, NAME );
+	LobCreationLogging LOB_MESSAGE_LOGGER = Logger.getMessageLogger( MethodHandles.lookup(), LobCreationLogging.class, NAME );
 
 	@LogMessage(level = DEBUG)
 	@Message(value = "Disabling contextual LOB creation as %s is true", id = 10010001)

--- a/hibernate-core/src/main/java/org/hibernate/engine/jdbc/spi/SqlExceptionHelper.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/jdbc/spi/SqlExceptionHelper.java
@@ -6,6 +6,7 @@
  */
 package org.hibernate.engine.jdbc.spi;
 
+import java.lang.invoke.MethodHandles;
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.sql.SQLWarning;
@@ -31,6 +32,7 @@ import org.jboss.logging.Logger.Level;
  */
 public class SqlExceptionHelper {
 	private static final CoreMessageLogger LOG = Logger.getMessageLogger(
+			MethodHandles.lookup(),
 			CoreMessageLogger.class,
 			SqlExceptionHelper.class.getName()
 	);

--- a/hibernate-core/src/main/java/org/hibernate/engine/jdbc/spi/TypeInfo.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/jdbc/spi/TypeInfo.java
@@ -6,6 +6,7 @@
  */
 package org.hibernate.engine.jdbc.spi;
 
+import java.lang.invoke.MethodHandles;
 import java.sql.DatabaseMetaData;
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -23,6 +24,7 @@ import org.jboss.logging.Logger;
  */
 public class TypeInfo {
 	private static final CoreMessageLogger LOG = Logger.getMessageLogger(
+			MethodHandles.lookup(),
 			CoreMessageLogger.class,
 			TypeInfo.class.getName()
 	);

--- a/hibernate-core/src/main/java/org/hibernate/engine/jndi/internal/JndiServiceImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/jndi/internal/JndiServiceImpl.java
@@ -6,6 +6,7 @@
  */
 package org.hibernate.engine.jndi.internal;
 
+import java.lang.invoke.MethodHandles;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Hashtable;
@@ -35,6 +36,7 @@ import org.jboss.logging.Logger;
  */
 final class JndiServiceImpl implements JndiService {
 	private static final CoreMessageLogger LOG = Logger.getMessageLogger(
+			MethodHandles.lookup(),
 			CoreMessageLogger.class,
 			JndiServiceImpl.class.getName()
 	);

--- a/hibernate-core/src/main/java/org/hibernate/engine/spi/CascadingActions.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/spi/CascadingActions.java
@@ -22,6 +22,7 @@ import org.hibernate.internal.CoreMessageLogger;
 import org.hibernate.type.CollectionType;
 import org.jboss.logging.Logger;
 
+import java.lang.invoke.MethodHandles;
 import java.util.Iterator;
 
 import static java.util.Collections.emptyIterator;
@@ -33,6 +34,7 @@ import static org.hibernate.engine.internal.ManagedTypeHelper.isHibernateProxy;
  */
 public class CascadingActions {
 	private static final CoreMessageLogger LOG = Logger.getMessageLogger(
+			MethodHandles.lookup(),
 			CoreMessageLogger.class,
 			CascadingAction.class.getName()
 	);

--- a/hibernate-core/src/main/java/org/hibernate/engine/transaction/jta/platform/internal/JtaPlatformInitiator.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/transaction/jta/platform/internal/JtaPlatformInitiator.java
@@ -6,6 +6,7 @@
  */
 package org.hibernate.engine.transaction.jta.platform.internal;
 
+import java.lang.invoke.MethodHandles;
 import java.util.Map;
 
 import org.hibernate.boot.registry.StandardServiceInitiator;
@@ -28,7 +29,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 public class JtaPlatformInitiator implements StandardServiceInitiator<JtaPlatform> {
 	public static final JtaPlatformInitiator INSTANCE = new JtaPlatformInitiator();
 
-	private static final CoreMessageLogger LOG = Logger.getMessageLogger(CoreMessageLogger.class, JtaPlatformInitiator.class.getName());
+	private static final CoreMessageLogger LOG = Logger.getMessageLogger( MethodHandles.lookup(), CoreMessageLogger.class, JtaPlatformInitiator.class.getName() );
 
 	@Override
 	public Class<JtaPlatform> getServiceInitiated() {

--- a/hibernate-core/src/main/java/org/hibernate/event/internal/AbstractFlushingEventListener.java
+++ b/hibernate-core/src/main/java/org/hibernate/event/internal/AbstractFlushingEventListener.java
@@ -6,6 +6,7 @@
  */
 package org.hibernate.event.internal;
 
+import java.lang.invoke.MethodHandles;
 import java.util.Map;
 
 import org.hibernate.HibernateException;
@@ -51,7 +52,7 @@ import static org.hibernate.engine.internal.Collections.skipRemoval;
  */
 public abstract class AbstractFlushingEventListener implements JpaBootstrapSensitive {
 
-	private static final CoreMessageLogger LOG = Logger.getMessageLogger( CoreMessageLogger.class, AbstractFlushingEventListener.class.getName() );
+	private static final CoreMessageLogger LOG = Logger.getMessageLogger( MethodHandles.lookup(), CoreMessageLogger.class, AbstractFlushingEventListener.class.getName() );
 
 	@Override
 	public void wasJpaBootstrap(boolean wasJpaBootstrap) {

--- a/hibernate-core/src/main/java/org/hibernate/event/internal/DefaultAutoFlushEventListener.java
+++ b/hibernate-core/src/main/java/org/hibernate/event/internal/DefaultAutoFlushEventListener.java
@@ -21,6 +21,8 @@ import org.hibernate.stat.spi.StatisticsImplementor;
 
 import org.jboss.logging.Logger;
 
+import java.lang.invoke.MethodHandles;
+
 /**
  * Defines the default flush event listeners used by hibernate for
  * flushing session state in response to generated auto-flush events.
@@ -29,7 +31,7 @@ import org.jboss.logging.Logger;
  */
 public class DefaultAutoFlushEventListener extends AbstractFlushingEventListener implements AutoFlushEventListener {
 
-	private static final CoreMessageLogger LOG = Logger.getMessageLogger( CoreMessageLogger.class, DefaultAutoFlushEventListener.class.getName() );
+	private static final CoreMessageLogger LOG = Logger.getMessageLogger( MethodHandles.lookup(), CoreMessageLogger.class, DefaultAutoFlushEventListener.class.getName() );
 
 	/**
 	 * Handle the given auto-flush event.

--- a/hibernate-core/src/main/java/org/hibernate/event/internal/DefaultLockEventListener.java
+++ b/hibernate-core/src/main/java/org/hibernate/event/internal/DefaultLockEventListener.java
@@ -24,6 +24,8 @@ import org.hibernate.persister.entity.EntityPersister;
 
 import org.jboss.logging.Logger;
 
+import java.lang.invoke.MethodHandles;
+
 /**
  * Defines the default lock event listeners used by hibernate to lock entities
  * in response to generated lock events.
@@ -33,6 +35,7 @@ import org.jboss.logging.Logger;
 public class DefaultLockEventListener extends AbstractLockUpgradeEventListener implements LockEventListener {
 
 	private static final CoreMessageLogger LOG = Logger.getMessageLogger(
+			MethodHandles.lookup(),
 			CoreMessageLogger.class,
 			DefaultLockEventListener.class.getName()
 	);

--- a/hibernate-core/src/main/java/org/hibernate/generator/internal/SourceGeneration.java
+++ b/hibernate-core/src/main/java/org/hibernate/generator/internal/SourceGeneration.java
@@ -21,6 +21,7 @@ import org.hibernate.type.descriptor.java.JavaType;
 
 import org.jboss.logging.Logger;
 
+import java.lang.invoke.MethodHandles;
 import java.lang.reflect.Member;
 import java.sql.CallableStatement;
 import java.sql.PreparedStatement;
@@ -53,6 +54,7 @@ import static org.hibernate.generator.EventTypeSets.INSERT_AND_UPDATE;
 public class SourceGeneration implements BeforeExecutionGenerator {
 
 	private static final CoreMessageLogger log = Logger.getMessageLogger(
+			MethodHandles.lookup(),
 			CoreMessageLogger.class,
 			SourceGeneration.class.getName()
 	);

--- a/hibernate-core/src/main/java/org/hibernate/id/enhanced/OptimizerFactory.java
+++ b/hibernate-core/src/main/java/org/hibernate/id/enhanced/OptimizerFactory.java
@@ -6,6 +6,7 @@
  */
 package org.hibernate.id.enhanced;
 
+import java.lang.invoke.MethodHandles;
 import java.lang.reflect.Constructor;
 import java.util.Properties;
 
@@ -23,6 +24,7 @@ import static org.hibernate.internal.util.StringHelper.isNotEmpty;
  */
 public class OptimizerFactory {
 	private static final CoreMessageLogger LOG = Logger.getMessageLogger(
+			MethodHandles.lookup(),
 			CoreMessageLogger.class,
 			OptimizerFactory.class.getName()
 	);

--- a/hibernate-core/src/main/java/org/hibernate/id/enhanced/PooledLoOptimizer.java
+++ b/hibernate-core/src/main/java/org/hibernate/id/enhanced/PooledLoOptimizer.java
@@ -7,6 +7,7 @@
 package org.hibernate.id.enhanced;
 
 import java.io.Serializable;
+import java.lang.invoke.MethodHandles;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.locks.ReentrantLock;
@@ -27,6 +28,7 @@ import org.jboss.logging.Logger;
  */
 public class PooledLoOptimizer extends AbstractOptimizer {
 	private static final CoreMessageLogger LOG = Logger.getMessageLogger(
+			MethodHandles.lookup(),
 			CoreMessageLogger.class,
 			PooledLoOptimizer.class.getName()
 	);

--- a/hibernate-core/src/main/java/org/hibernate/id/enhanced/PooledLoThreadLocalOptimizer.java
+++ b/hibernate-core/src/main/java/org/hibernate/id/enhanced/PooledLoThreadLocalOptimizer.java
@@ -7,6 +7,7 @@
 package org.hibernate.id.enhanced;
 
 import java.io.Serializable;
+import java.lang.invoke.MethodHandles;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -28,6 +29,7 @@ import org.jboss.logging.Logger;
  */
 public class PooledLoThreadLocalOptimizer extends AbstractOptimizer {
 	private static final CoreMessageLogger LOG = Logger.getMessageLogger(
+			MethodHandles.lookup(),
 			CoreMessageLogger.class,
 			PooledLoOptimizer.class.getName()
 	);

--- a/hibernate-core/src/main/java/org/hibernate/id/enhanced/PooledOptimizer.java
+++ b/hibernate-core/src/main/java/org/hibernate/id/enhanced/PooledOptimizer.java
@@ -7,6 +7,7 @@
 package org.hibernate.id.enhanced;
 
 import java.io.Serializable;
+import java.lang.invoke.MethodHandles;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.locks.Lock;
@@ -34,6 +35,7 @@ import org.jboss.logging.Logger;
  */
 public class PooledOptimizer extends AbstractOptimizer implements InitialValueAwareOptimizer {
 	private static final CoreMessageLogger log = Logger.getMessageLogger(
+			MethodHandles.lookup(),
 			CoreMessageLogger.class,
 			PooledOptimizer.class.getName()
 	);

--- a/hibernate-core/src/main/java/org/hibernate/id/enhanced/SequenceStructure.java
+++ b/hibernate-core/src/main/java/org/hibernate/id/enhanced/SequenceStructure.java
@@ -6,6 +6,7 @@
  */
 package org.hibernate.id.enhanced;
 
+import java.lang.invoke.MethodHandles;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -32,6 +33,7 @@ import static org.hibernate.id.IdentifierGeneratorHelper.getIntegralDataTypeHold
  */
 public class SequenceStructure implements DatabaseStructure {
 	private static final CoreMessageLogger LOG = Logger.getMessageLogger(
+			MethodHandles.lookup(),
 			CoreMessageLogger.class,
 			SequenceStructure.class.getName()
 	);

--- a/hibernate-core/src/main/java/org/hibernate/id/enhanced/SequenceStyleGenerator.java
+++ b/hibernate-core/src/main/java/org/hibernate/id/enhanced/SequenceStyleGenerator.java
@@ -6,6 +6,7 @@
  */
 package org.hibernate.id.enhanced;
 
+import java.lang.invoke.MethodHandles;
 import java.util.Iterator;
 import java.util.Properties;
 import java.util.Set;
@@ -112,6 +113,7 @@ public class SequenceStyleGenerator
 		implements PersistentIdentifierGenerator, BulkInsertionCapableIdentifierGenerator {
 
 	private static final CoreMessageLogger LOG = Logger.getMessageLogger(
+			MethodHandles.lookup(),
 			CoreMessageLogger.class,
 			SequenceStyleGenerator.class.getName()
 	);

--- a/hibernate-core/src/main/java/org/hibernate/id/enhanced/TableGenerator.java
+++ b/hibernate-core/src/main/java/org/hibernate/id/enhanced/TableGenerator.java
@@ -6,6 +6,7 @@
  */
 package org.hibernate.id.enhanced;
 
+import java.lang.invoke.MethodHandles;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
@@ -133,6 +134,7 @@ import static org.hibernate.internal.util.config.ConfigurationHelper.getString;
  */
 public class TableGenerator implements PersistentIdentifierGenerator {
 	private static final CoreMessageLogger LOG = Logger.getMessageLogger(
+			MethodHandles.lookup(),
 			CoreMessageLogger.class,
 			TableGenerator.class.getName()
 	);

--- a/hibernate-core/src/main/java/org/hibernate/id/enhanced/TableStructure.java
+++ b/hibernate-core/src/main/java/org/hibernate/id/enhanced/TableStructure.java
@@ -6,6 +6,7 @@
  */
 package org.hibernate.id.enhanced;
 
+import java.lang.invoke.MethodHandles;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
@@ -46,6 +47,7 @@ import static org.hibernate.id.IdentifierGeneratorHelper.getIntegralDataTypeHold
  */
 public class TableStructure implements DatabaseStructure {
 	private static final CoreMessageLogger LOG = Logger.getMessageLogger(
+			MethodHandles.lookup(),
 			CoreMessageLogger.class,
 			TableStructure.class.getName()
 	);

--- a/hibernate-core/src/main/java/org/hibernate/internal/CoreLogging.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/CoreLogging.java
@@ -8,6 +8,8 @@ package org.hibernate.internal;
 
 import org.jboss.logging.Logger;
 
+import java.lang.invoke.MethodHandles;
+
 /**
  * Quite sad, really, when you need helpers for generating loggers...
  *
@@ -26,7 +28,7 @@ public class CoreLogging {
 	}
 
 	public static CoreMessageLogger messageLogger(String loggerName) {
-		return Logger.getMessageLogger( CoreMessageLogger.class, loggerName );
+		return Logger.getMessageLogger( MethodHandles.lookup(), CoreMessageLogger.class, loggerName );
 	}
 
 	public static Logger logger(Class classNeedingLogging) {

--- a/hibernate-core/src/main/java/org/hibernate/internal/HEMLogging.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/HEMLogging.java
@@ -8,6 +8,8 @@ package org.hibernate.internal;
 
 import org.jboss.logging.Logger;
 
+import java.lang.invoke.MethodHandles;
+
 /**
  * Sad when you need helpers for generating loggers...
  *
@@ -25,7 +27,7 @@ public class HEMLogging {
 	}
 
 	public static EntityManagerMessageLogger messageLogger(String loggerName) {
-		return Logger.getMessageLogger( EntityManagerMessageLogger .class, loggerName );
+		return Logger.getMessageLogger( MethodHandles.lookup(), EntityManagerMessageLogger .class, loggerName );
 	}
 
 	public static Logger logger(Class<?> classNeedingLogging) {

--- a/hibernate-core/src/main/java/org/hibernate/internal/log/ConnectionAccessLogger.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/log/ConnectionAccessLogger.java
@@ -15,6 +15,8 @@ import org.jboss.logging.annotations.Message;
 import org.jboss.logging.annotations.MessageLogger;
 import org.jboss.logging.annotations.ValidIdRange;
 
+import java.lang.invoke.MethodHandles;
+
 import static org.jboss.logging.Logger.Level.INFO;
 
 /**
@@ -33,6 +35,7 @@ public interface ConnectionAccessLogger extends BasicLogger {
 	 * Static access to the logging instance
 	 */
 	ConnectionAccessLogger INSTANCE = Logger.getMessageLogger(
+			MethodHandles.lookup(),
 			ConnectionAccessLogger.class,
 			LOGGER_NAME
 	);

--- a/hibernate-core/src/main/java/org/hibernate/internal/log/ConnectionInfoLogger.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/log/ConnectionInfoLogger.java
@@ -6,6 +6,7 @@
  */
 package org.hibernate.internal.log;
 
+import java.lang.invoke.MethodHandles;
 import java.sql.SQLException;
 
 import org.jboss.logging.BasicLogger;
@@ -35,7 +36,7 @@ public interface ConnectionInfoLogger extends BasicLogger {
 	/**
 	 * Static access to the logging instance
 	 */
-	ConnectionInfoLogger INSTANCE = Logger.getMessageLogger( ConnectionInfoLogger.class, LOGGER_NAME );
+	ConnectionInfoLogger INSTANCE = Logger.getMessageLogger( MethodHandles.lookup(), ConnectionInfoLogger.class, LOGGER_NAME );
 
 	@LogMessage(level = WARN)
 	@Message(value = "Using built-in connection pool (not intended for production use)", id = 10001002)

--- a/hibernate-core/src/main/java/org/hibernate/internal/log/DeprecationLogger.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/log/DeprecationLogger.java
@@ -7,6 +7,7 @@
 package org.hibernate.internal.log;
 
 import java.lang.annotation.Annotation;
+import java.lang.invoke.MethodHandles;
 
 import org.hibernate.boot.jaxb.SourceType;
 import org.hibernate.cfg.AvailableSettings;
@@ -36,7 +37,7 @@ import static org.jboss.logging.Logger.Level.WARN;
 public interface DeprecationLogger extends BasicLogger {
 	String CATEGORY = SubSystemLogging.BASE + ".deprecation";
 
-	DeprecationLogger DEPRECATION_LOGGER = Logger.getMessageLogger( DeprecationLogger.class, CATEGORY );
+	DeprecationLogger DEPRECATION_LOGGER = Logger.getMessageLogger( MethodHandles.lookup(), DeprecationLogger.class, CATEGORY );
 
 	@LogMessage(level = WARN)
 	@Message(

--- a/hibernate-core/src/main/java/org/hibernate/internal/log/IncubationLogger.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/log/IncubationLogger.java
@@ -12,6 +12,8 @@ import org.jboss.logging.annotations.Message;
 import org.jboss.logging.annotations.MessageLogger;
 import org.jboss.logging.annotations.ValidIdRange;
 
+import java.lang.invoke.MethodHandles;
+
 import static org.jboss.logging.Logger.Level.WARN;
 
 /**
@@ -22,7 +24,7 @@ import static org.jboss.logging.Logger.Level.WARN;
 public interface IncubationLogger {
 	String CATEGORY = SubSystemLogging.BASE + ".incubating";
 
-	IncubationLogger INCUBATION_LOGGER = Logger.getMessageLogger( IncubationLogger.class, CATEGORY );
+	IncubationLogger INCUBATION_LOGGER = Logger.getMessageLogger( MethodHandles.lookup(), IncubationLogger.class, CATEGORY );
 
 	@LogMessage(level = WARN)
 	@Message(

--- a/hibernate-core/src/main/java/org/hibernate/internal/log/UrlMessageBundle.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/log/UrlMessageBundle.java
@@ -6,6 +6,7 @@
  */
 package org.hibernate.internal.log;
 
+import java.lang.invoke.MethodHandles;
 import java.net.URISyntaxException;
 import java.net.URL;
 
@@ -35,7 +36,7 @@ public interface UrlMessageBundle {
 	String LOGGER_NAME = SubSystemLogging.BASE + ".url";
 
 	Logger URL_LOGGER = Logger.getLogger( LOGGER_NAME );
-	UrlMessageBundle URL_MESSAGE_LOGGER = Logger.getMessageLogger( UrlMessageBundle.class, LOGGER_NAME );
+	UrlMessageBundle URL_MESSAGE_LOGGER = Logger.getMessageLogger( MethodHandles.lookup(), UrlMessageBundle.class, LOGGER_NAME );
 
 	/**
 	 * Logs a warning about a malformed URL, caused by a {@link URISyntaxException}

--- a/hibernate-core/src/main/java/org/hibernate/internal/util/xml/DTDEntityResolver.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/util/xml/DTDEntityResolver.java
@@ -8,6 +8,7 @@ package org.hibernate.internal.util.xml;
 
 import java.io.InputStream;
 import java.io.Serializable;
+import java.lang.invoke.MethodHandles;
 
 import org.hibernate.internal.CoreMessageLogger;
 import org.hibernate.internal.util.ConfigHelper;
@@ -44,7 +45,7 @@ import org.xml.sax.InputSource;
 @Deprecated
 public class DTDEntityResolver implements EntityResolver, Serializable {
 
-	private static final CoreMessageLogger LOG = Logger.getMessageLogger( CoreMessageLogger.class, DTDEntityResolver.class.getName() );
+	private static final CoreMessageLogger LOG = Logger.getMessageLogger( MethodHandles.lookup(), CoreMessageLogger.class, DTDEntityResolver.class.getName() );
 
 	private static final String HIBERNATE_NAMESPACE = "http://www.hibernate.org/dtd/";
 	private static final String OLD_HIBERNATE_NAMESPACE = "http://hibernate.sourceforge.net/";

--- a/hibernate-core/src/main/java/org/hibernate/jpa/internal/util/LogHelper.java
+++ b/hibernate-core/src/main/java/org/hibernate/jpa/internal/util/LogHelper.java
@@ -6,6 +6,7 @@
  */
 package org.hibernate.jpa.internal.util;
 
+import java.lang.invoke.MethodHandles;
 import java.net.URL;
 import java.util.Enumeration;
 import java.util.List;
@@ -21,7 +22,7 @@ import org.jboss.logging.Logger;
  * @author Steve Ebersole
  */
 public final class LogHelper {
-	private static final EntityManagerMessageLogger log = Logger.getMessageLogger( EntityManagerMessageLogger.class, LogHelper.class.getName() );
+	private static final EntityManagerMessageLogger log = Logger.getMessageLogger( MethodHandles.lookup(), EntityManagerMessageLogger.class, LogHelper.class.getName() );
 
 	private LogHelper() {
 	}

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/MappingModelCreationLogging.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/MappingModelCreationLogging.java
@@ -13,6 +13,8 @@ import org.jboss.logging.Logger;
 import org.jboss.logging.annotations.MessageLogger;
 import org.jboss.logging.annotations.ValidIdRange;
 
+import java.lang.invoke.MethodHandles;
+
 /**
  * Logger used during mapping-model creation
  *
@@ -28,5 +30,5 @@ public interface MappingModelCreationLogging extends BasicLogger {
 	String LOGGER_NAME = SubSystemLogging.BASE + ".model.mapping.creation";
 
 	Logger MAPPING_MODEL_CREATION_LOGGER = Logger.getLogger( LOGGER_NAME );
-	MappingModelCreationLogging MAPPING_MODEL_CREATION_MESSAGE_LOGGER = Logger.getMessageLogger( MappingModelCreationLogging.class, LOGGER_NAME );
+	MappingModelCreationLogging MAPPING_MODEL_CREATION_MESSAGE_LOGGER = Logger.getMessageLogger( MethodHandles.lookup(), MappingModelCreationLogging.class, LOGGER_NAME );
 }

--- a/hibernate-core/src/main/java/org/hibernate/query/QueryLogging.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/QueryLogging.java
@@ -17,6 +17,8 @@ import org.jboss.logging.annotations.Message;
 import org.jboss.logging.annotations.MessageLogger;
 import org.jboss.logging.annotations.ValidIdRange;
 
+import java.lang.invoke.MethodHandles;
+
 import static org.jboss.logging.Logger.Level.ERROR;
 import static org.jboss.logging.Logger.Level.INFO;
 import static org.jboss.logging.Logger.Level.WARN;
@@ -34,7 +36,7 @@ public interface QueryLogging extends BasicLogger {
 	String LOGGER_NAME = SubSystemLogging.BASE + ".query";
 
 	Logger QUERY_LOGGER = Logger.getLogger( LOGGER_NAME );
-	QueryLogging QUERY_MESSAGE_LOGGER = Logger.getMessageLogger( QueryLogging.class, LOGGER_NAME );
+	QueryLogging QUERY_MESSAGE_LOGGER = Logger.getMessageLogger( MethodHandles.lookup(), QueryLogging.class, LOGGER_NAME );
 
 	static String subLoggerName(String subName) {
 		return LOGGER_NAME + '.' + subName;
@@ -45,7 +47,7 @@ public interface QueryLogging extends BasicLogger {
 	}
 
 	static <T> T subLogger(String subName, Class<T> loggerJavaType) {
-		return Logger.getMessageLogger( loggerJavaType, subLoggerName( subName ) );
+		return Logger.getMessageLogger( MethodHandles.lookup(), loggerJavaType, subLoggerName( subName ) );
 	}
 
 	@LogMessage(level = ERROR)

--- a/hibernate-core/src/main/java/org/hibernate/query/hql/HqlLogging.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/hql/HqlLogging.java
@@ -18,6 +18,8 @@ import org.jboss.logging.annotations.Message;
 import org.jboss.logging.annotations.MessageLogger;
 import org.jboss.logging.annotations.ValidIdRange;
 
+import java.lang.invoke.MethodHandles;
+
 import static org.jboss.logging.Logger.Level.ERROR;
 
 /**
@@ -32,7 +34,7 @@ import static org.jboss.logging.Logger.Level.ERROR;
 public interface HqlLogging extends BasicLogger {
 	String LOGGER_NAME = QueryLogging.LOGGER_NAME + ".hql";
 
-	HqlLogging QUERY_LOGGER = Logger.getMessageLogger( HqlLogging.class, LOGGER_NAME );
+	HqlLogging QUERY_LOGGER = Logger.getMessageLogger( MethodHandles.lookup(), HqlLogging.class, LOGGER_NAME );
 
 	static String subLoggerName(String subName) {
 		return LOGGER_NAME + '.' + subName;
@@ -43,7 +45,7 @@ public interface HqlLogging extends BasicLogger {
 	}
 
 	static <T> T subLogger(String subName, Class<T> loggerJavaType) {
-		return Logger.getMessageLogger( loggerJavaType, subLoggerName( subName ) );
+		return Logger.getMessageLogger( MethodHandles.lookup(), loggerJavaType, subLoggerName( subName ) );
 	}
 
 	@LogMessage(level = ERROR)

--- a/hibernate-core/src/main/java/org/hibernate/resource/beans/internal/BeansMessageLogger.java
+++ b/hibernate-core/src/main/java/org/hibernate/resource/beans/internal/BeansMessageLogger.java
@@ -15,6 +15,8 @@ import org.jboss.logging.annotations.Message;
 import org.jboss.logging.annotations.MessageLogger;
 import org.jboss.logging.annotations.ValidIdRange;
 
+import java.lang.invoke.MethodHandles;
+
 import static org.jboss.logging.Logger.Level.DEBUG;
 import static org.jboss.logging.Logger.Level.INFO;
 import static org.jboss.logging.Logger.Level.WARN;
@@ -31,7 +33,7 @@ import static org.jboss.logging.Logger.Level.WARN;
 public interface BeansMessageLogger {
 	String LOGGER_NAME = SubSystemLogging.BASE + ".beans";
 
-	BeansMessageLogger BEANS_MSG_LOGGER = Logger.getMessageLogger( BeansMessageLogger.class, LOGGER_NAME );
+	BeansMessageLogger BEANS_MSG_LOGGER = Logger.getMessageLogger( MethodHandles.lookup(), BeansMessageLogger.class, LOGGER_NAME );
 
 	@LogMessage( level = WARN )
 	@Message(

--- a/hibernate-core/src/main/java/org/hibernate/sql/ast/tree/SqlAstTreeLogger.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/ast/tree/SqlAstTreeLogger.java
@@ -14,6 +14,8 @@ import org.jboss.logging.Logger;
 import org.jboss.logging.annotations.MessageLogger;
 import org.jboss.logging.annotations.ValidIdRange;
 
+import java.lang.invoke.MethodHandles;
+
 /**
  * Dedicated logger for rendering a SQL AST
  *
@@ -31,6 +33,6 @@ public interface SqlAstTreeLogger extends BasicLogger {
 	/**
 	 * Static access to the logging instance
 	 */
-	SqlAstTreeLogger INSTANCE = Logger.getMessageLogger( SqlAstTreeLogger.class, LOGGER_NAME );
+	SqlAstTreeLogger INSTANCE = Logger.getMessageLogger( MethodHandles.lookup(), SqlAstTreeLogger.class, LOGGER_NAME );
 
 }

--- a/hibernate-core/src/main/java/org/hibernate/sql/exec/SqlExecLogger.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/exec/SqlExecLogger.java
@@ -13,6 +13,8 @@ import org.jboss.logging.Logger;
 import org.jboss.logging.annotations.MessageLogger;
 import org.jboss.logging.annotations.ValidIdRange;
 
+import java.lang.invoke.MethodHandles;
+
 /**
  * @author Steve Ebersole
  */
@@ -25,5 +27,5 @@ import org.jboss.logging.annotations.ValidIdRange;
 public interface SqlExecLogger extends BasicLogger {
 	String LOGGER_NAME = SubSystemLogging.BASE + ".sql.exec";
 
-	SqlExecLogger SQL_EXEC_LOGGER = Logger.getMessageLogger( SqlExecLogger.class, LOGGER_NAME );
+	SqlExecLogger SQL_EXEC_LOGGER = Logger.getMessageLogger( MethodHandles.lookup(), SqlExecLogger.class, LOGGER_NAME );
 }

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/LoadingLogger.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/LoadingLogger.java
@@ -13,6 +13,8 @@ import org.jboss.logging.Logger;
 import org.jboss.logging.annotations.MessageLogger;
 import org.jboss.logging.annotations.ValidIdRange;
 
+import java.lang.invoke.MethodHandles;
+
 /**
  * @author Steve Ebersole
  */
@@ -26,7 +28,7 @@ public interface LoadingLogger extends BasicLogger {
 	String LOGGER_NAME = ResultsLogger.LOGGER_NAME + ".loading";
 
 	Logger LOGGER = Logger.getLogger( LOGGER_NAME );
-	LoadingLogger MESSAGE_LOGGER = Logger.getMessageLogger( LoadingLogger.class, LOGGER_NAME );
+	LoadingLogger MESSAGE_LOGGER = Logger.getMessageLogger( MethodHandles.lookup(), LoadingLogger.class, LOGGER_NAME );
 
 	static String subLoggerName(String subName) {
 		return LOGGER_NAME + "." + subName;

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/ResultsLogger.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/ResultsLogger.java
@@ -13,6 +13,8 @@ import org.jboss.logging.Logger;
 import org.jboss.logging.annotations.MessageLogger;
 import org.jboss.logging.annotations.ValidIdRange;
 
+import java.lang.invoke.MethodHandles;
+
 /**
  * @asciidoc
  *
@@ -34,7 +36,7 @@ public interface ResultsLogger extends BasicLogger {
 	String LOGGER_NAME = SubSystemLogging.BASE + ".results";
 
 	Logger RESULTS_LOGGER = Logger.getLogger( LOGGER_NAME );
-	ResultsLogger RESULTS_MESSAGE_LOGGER = Logger.getMessageLogger( ResultsLogger.class, LOGGER_NAME );
+	ResultsLogger RESULTS_MESSAGE_LOGGER = Logger.getMessageLogger( MethodHandles.lookup(), ResultsLogger.class, LOGGER_NAME );
 
 	// todo (6.0) : make sure sql result processing classes use this logger
 

--- a/hibernate-core/src/main/java/org/hibernate/stat/internal/StatisticsInitiator.java
+++ b/hibernate-core/src/main/java/org/hibernate/stat/internal/StatisticsInitiator.java
@@ -21,13 +21,15 @@ import org.jboss.logging.Logger;
 
 import org.checkerframework.checker.nullness.qual.Nullable;
 
+import java.lang.invoke.MethodHandles;
+
 import static org.hibernate.cfg.StatisticsSettings.STATS_BUILDER;
 
 /**
  * @author Steve Ebersole
  */
 public class StatisticsInitiator implements SessionFactoryServiceInitiator<StatisticsImplementor> {
-	private static final CoreMessageLogger LOG = Logger.getMessageLogger( CoreMessageLogger.class, StatisticsInitiator.class.getName() );
+	private static final CoreMessageLogger LOG = Logger.getMessageLogger( MethodHandles.lookup(), CoreMessageLogger.class, StatisticsInitiator.class.getName() );
 
 	public static final StatisticsInitiator INSTANCE = new StatisticsInitiator();
 

--- a/hibernate-core/src/main/java/org/hibernate/type/CollectionType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/CollectionType.java
@@ -7,6 +7,7 @@
 package org.hibernate.type;
 
 import java.io.Serializable;
+import java.lang.invoke.MethodHandles;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.util.ArrayList;
@@ -59,7 +60,7 @@ import static org.hibernate.proxy.HibernateProxy.extractLazyInitializer;
  */
 public abstract class CollectionType extends AbstractType implements AssociationType {
 
-	private static final CoreMessageLogger LOG = Logger.getMessageLogger(CoreMessageLogger.class, CollectionType.class.getName());
+	private static final CoreMessageLogger LOG = Logger.getMessageLogger( MethodHandles.lookup(), CoreMessageLogger.class, CollectionType.class.getName() );
 
 	@Internal
 	public static final Object UNFETCHED_COLLECTION = new MarkerObject( "UNFETCHED COLLECTION" );

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/DataHelper.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/DataHelper.java
@@ -11,6 +11,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.Reader;
 import java.io.StringReader;
+import java.lang.invoke.MethodHandles;
 import java.sql.Clob;
 import java.sql.SQLException;
 import java.sql.SQLFeatureNotSupportedException;
@@ -34,7 +35,7 @@ public final class DataHelper {
 	/** The size of the buffer we will use to deserialize larger streams */
 	private static final int BUFFER_SIZE = 1024 * 4;
 
-	private static final CoreMessageLogger LOG = Logger.getMessageLogger( CoreMessageLogger.class, DataHelper.class.getName() );
+	private static final CoreMessageLogger LOG = Logger.getMessageLogger( MethodHandles.lookup(), CoreMessageLogger.class, DataHelper.class.getName() );
 
 	public static boolean isNClob(final Class type) {
 		return java.sql.NClob.class.isAssignableFrom( type );

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/LobStreamDataHelper.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/LobStreamDataHelper.java
@@ -17,6 +17,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.Reader;
 import java.io.StringReader;
+import java.lang.invoke.MethodHandles;
 import java.sql.Clob;
 import java.sql.SQLException;
 import java.sql.SQLFeatureNotSupportedException;
@@ -33,7 +34,7 @@ public final class LobStreamDataHelper {
 	/** The size of the buffer we will use to deserialize larger streams */
 	private static final int BUFFER_SIZE = 1024 * 4;
 
-	private static final CoreMessageLogger LOG = Logger.getMessageLogger( CoreMessageLogger.class, LobStreamDataHelper.class.getName() );
+	private static final CoreMessageLogger LOG = Logger.getMessageLogger( MethodHandles.lookup(), CoreMessageLogger.class, LobStreamDataHelper.class.getName() );
 
 	public static boolean isNClob(final Class type) {
 		return java.sql.NClob.class.isAssignableFrom( type );

--- a/hibernate-core/src/main/resources/org/hibernate/xsd/mapping/legacy-mapping-4.0.xsd
+++ b/hibernate-core/src/main/resources/org/hibernate/xsd/mapping/legacy-mapping-4.0.xsd
@@ -493,7 +493,9 @@
                         <xs:group ref="NamedQueryGroup"/>
                     </xs:choice>
                 </xs:sequence>
-                <xs:attributeGroup ref="table-information-group"/>
+                <xs:attribute name="schema" type="xs:string"/>
+                <xs:attribute name="catalog" type="xs:string"/>
+                <xs:attribute name="table" type="xs:string"/>
                 <xs:attribute name="check" type="xs:string"/>
                 <xs:attribute name="discriminator-value" type="xs:string" />
             </xs:extension>
@@ -542,7 +544,9 @@
                         <xs:group ref="NamedQueryGroup"/>
                     </xs:choice>
                 </xs:sequence>
-                <xs:attributeGroup ref="table-information-group"/>
+                <xs:attribute name="schema" type="xs:string"/>
+                <xs:attribute name="catalog" type="xs:string"/>
+                <xs:attribute name="table" type="xs:string"/>
                 <xs:attribute name="check" type="xs:string"/>
             </xs:extension>
         </xs:complexContent>
@@ -746,7 +750,9 @@
                     <xs:group ref="CustomSqlDmlCollectionGroup"/>
                     <xs:element name="filter" minOccurs="0" maxOccurs="unbounded" type="filter-type"/>
                 </xs:sequence>
-                <xs:attributeGroup ref="table-information-group"/>
+                <xs:attribute name="schema" type="xs:string"/>
+                <xs:attribute name="catalog" type="xs:string"/>
+                <xs:attribute name="table" type="xs:string"/>
                 <xs:attributeGroup ref="plural-basic-attribute-group"/>
                 <xs:attribute name="embed-xml" type="xs:boolean"/>
                 <xs:attribute name="fetch" type="FetchStyleWithSubselectEnum"/>
@@ -792,7 +798,9 @@
                     <xs:group ref="CustomSqlDmlCollectionGroup"/>
                     <xs:element name="filter" minOccurs="0" maxOccurs="unbounded" type="filter-type"/>
                 </xs:sequence>
-                <xs:attributeGroup ref="table-information-group"/>
+                <xs:attribute name="schema" type="xs:string"/>
+                <xs:attribute name="catalog" type="xs:string"/>
+                <xs:attribute name="table" type="xs:string"/>
                 <xs:attribute name="access" type="xs:string"/>
                 <xs:attribute name="batch-size" default="-1" type="xs:int"/>
                 <xs:attribute name="cascade" type="xs:string"/>
@@ -832,7 +840,9 @@
                     <xs:group ref="CustomSqlDmlCollectionGroup"/>
                     <xs:element name="filter" minOccurs="0" maxOccurs="unbounded" type="filter-type"/>
                 </xs:sequence>
-                <xs:attributeGroup ref="table-information-group"/>
+                <xs:attribute name="schema" type="xs:string"/>
+                <xs:attribute name="catalog" type="xs:string"/>
+                <xs:attribute name="table" type="xs:string"/>
                 <xs:attributeGroup ref="plural-basic-attribute-group"/>
                 <xs:attribute name="embed-xml" type="xs:boolean"/>
                 <xs:attribute name="fetch" type="FetchStyleWithSubselectEnum"/>
@@ -864,7 +874,9 @@
                     <xs:group ref="CustomSqlDmlCollectionGroup"/>
                     <xs:element name="filter" minOccurs="0" maxOccurs="unbounded" type="filter-type"/>
                 </xs:sequence>
-                <xs:attributeGroup ref="table-information-group"/>
+                <xs:attribute name="schema" type="xs:string"/>
+                <xs:attribute name="catalog" type="xs:string"/>
+                <xs:attribute name="table" type="xs:string"/>
                 <xs:attributeGroup ref="plural-basic-attribute-group"/>
                 <xs:attribute name="embed-xml" type="xs:boolean"/>
                 <xs:attribute name="fetch" type="FetchStyleWithSubselectEnum"/>
@@ -899,7 +911,9 @@
                     <xs:group ref="CustomSqlDmlCollectionGroup"/>
                     <xs:element name="filter" minOccurs="0" maxOccurs="unbounded" type="filter-type"/>
                 </xs:sequence>
-                <xs:attributeGroup ref="table-information-group"/>
+                <xs:attribute name="schema" type="xs:string"/>
+                <xs:attribute name="catalog" type="xs:string"/>
+                <xs:attribute name="table" type="xs:string"/>
                 <xs:attributeGroup ref="plural-basic-attribute-group"/>
                 <xs:attribute name="embed-xml" type="xs:boolean"/>
                 <xs:attribute name="fetch" type="FetchStyleWithSubselectEnum"/>
@@ -929,7 +943,9 @@
                     <xs:group ref="CustomSqlDmlCollectionGroup"/>
                     <xs:element name="filter" minOccurs="0" maxOccurs="unbounded" type="filter-type"/>
                 </xs:sequence>
-                <xs:attributeGroup ref="table-information-group"/>
+                <xs:attribute name="schema" type="xs:string"/>
+                <xs:attribute name="catalog" type="xs:string"/>
+                <xs:attribute name="table" type="xs:string"/>
                 <xs:attributeGroup ref="plural-basic-attribute-group"/>
                 <xs:attribute name="embed-xml" type="xs:boolean"/>
                 <xs:attribute name="fetch" type="FetchStyleWithSubselectEnum"/>
@@ -1386,7 +1402,9 @@
             </xs:choice>
             <xs:group ref="CustomSqlDmlGroup"/>
         </xs:sequence>
-        <xs:attributeGroup ref="table-information-group"/>
+        <xs:attribute name="schema" type="xs:string"/>
+        <xs:attribute name="catalog" type="xs:string"/>
+        <xs:attribute name="table" type="xs:string"/>
         <xs:attribute name="fetch" default="join" type="FetchStyleEnum"/>
         <xs:attribute name="inverse" default="false" type="xs:boolean"/>
         <xs:attribute name="optional" default="false" type="xs:boolean"/>
@@ -1634,7 +1652,9 @@
                     <xs:element name="loader" minOccurs="0" type="loader-type"/>
                     <xs:group ref="CustomSqlDmlCollectionGroup"/>
                 </xs:sequence>
-                <xs:attributeGroup ref="table-information-group"/>
+                <xs:attribute name="schema" type="xs:string"/>
+                <xs:attribute name="catalog" type="xs:string"/>
+                <xs:attribute name="table" type="xs:string"/>
                 <xs:attribute name="access" type="xs:string"/>
                 <xs:attribute name="batch-size" default="-1" type="xs:int"/>
                 <xs:attribute name="check" type="xs:string"/>
@@ -1853,15 +1873,6 @@
         <xs:attribute name="collection-type" type="xs:string"/>
         <xs:attribute name="persister" type="ClassNameType"/>
     </xs:attributeGroup>
-    <xs:attributeGroup name="table-information-group">
-        <xs:attribute name="schema" type="xs:string"/>
-        <xs:attribute name="catalog" type="xs:string"/>
-        <xs:attribute name="table" type="xs:string"/>
-        <!-- default: unqualified class name -->
-        <xs:attribute name="subselect" type="xs:string"/>
-    </xs:attributeGroup>
-
-
 
     <!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
     <!-- Enums -->

--- a/hibernate-core/src/main/xjb/hbm-mapping-bindings.xjb
+++ b/hibernate-core/src/main/xjb/hbm-mapping-bindings.xjb
@@ -375,10 +375,6 @@
 			<jaxb:property name="columnAttribute"/>
 		</jaxb:bindings>
 
-		<jaxb:bindings node="//xsd:attributeGroup[@name='table-information-group']//xsd:attribute[@name='subselect']">
-			<jaxb:property name="subselectAttribute"/>
-		</jaxb:bindings>
-
 		<jaxb:bindings node="//xsd:complexType[@name='multi-tenancy-type']//xsd:attribute[@name='column']">
 			<jaxb:property name="columnAttribute"/>
 		</jaxb:bindings>

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/formula/JoinFormulaManyToOneNotIgnoreLazyFetchingTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/formula/JoinFormulaManyToOneNotIgnoreLazyFetchingTest.java
@@ -7,6 +7,7 @@
 package org.hibernate.orm.test.annotations.formula;
 
 import java.io.Serializable;
+import java.lang.invoke.MethodHandles;
 import java.util.List;
 
 import org.hibernate.annotations.JoinColumnOrFormula;
@@ -44,7 +45,7 @@ public class JoinFormulaManyToOneNotIgnoreLazyFetchingTest extends BaseEntityMan
 
 	@Rule
 	public LoggerInspectionRule logInspection = new LoggerInspectionRule(
-			Logger.getMessageLogger( CoreMessageLogger.class, ToOneBinder.class.getName() )
+			Logger.getMessageLogger( MethodHandles.lookup(), CoreMessageLogger.class, ToOneBinder.class.getName() )
 	);
 
 	private final Triggerable triggerable = logInspection.watchForLogMessages( "HHH000491" );

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/formula/JoinFormulaOneToOneNotIgnoreLazyFetchingTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/formula/JoinFormulaOneToOneNotIgnoreLazyFetchingTest.java
@@ -7,6 +7,7 @@
 package org.hibernate.orm.test.annotations.formula;
 
 import java.io.Serializable;
+import java.lang.invoke.MethodHandles;
 import java.util.List;
 
 import org.hibernate.annotations.JoinColumnOrFormula;
@@ -44,7 +45,7 @@ public class JoinFormulaOneToOneNotIgnoreLazyFetchingTest extends BaseEntityMana
 
 	@Rule
 	public LoggerInspectionRule logInspection = new LoggerInspectionRule(
-			Logger.getMessageLogger( CoreMessageLogger.class, ToOneBinder.class.getName() )
+			Logger.getMessageLogger( MethodHandles.lookup(), CoreMessageLogger.class, ToOneBinder.class.getName() )
 	);
 
 	private final Triggerable triggerable = logInspection.watchForLogMessages( "HHH000491" );

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/formula/ManyToManyNotIgnoreLazyFetchingTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/formula/ManyToManyNotIgnoreLazyFetchingTest.java
@@ -7,6 +7,7 @@
 package org.hibernate.orm.test.annotations.formula;
 
 import java.io.Serializable;
+import java.lang.invoke.MethodHandles;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -46,7 +47,7 @@ public class ManyToManyNotIgnoreLazyFetchingTest extends BaseEntityManagerFuncti
 
 	@Rule
 	public LoggerInspectionRule logInspection = new LoggerInspectionRule(
-			Logger.getMessageLogger( CoreMessageLogger.class, AnnotationBinder.class.getName() )
+			Logger.getMessageLogger( MethodHandles.lookup(), CoreMessageLogger.class, AnnotationBinder.class.getName() )
 	);
 
 	private Triggerable triggerable = logInspection.watchForLogMessages( "HHH000491" );

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/immutable/ImmutableEntityUpdateQueryHandlingModeWarningTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/immutable/ImmutableEntityUpdateQueryHandlingModeWarningTest.java
@@ -18,9 +18,10 @@ import org.junit.Test;
 
 import org.jboss.logging.Logger;
 
+import java.lang.invoke.MethodHandles;
+
 import static org.hibernate.testing.transaction.TransactionUtil.doInHibernate;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
 
 /**
  * @author Vlad Mihalcea
@@ -30,7 +31,7 @@ public class ImmutableEntityUpdateQueryHandlingModeWarningTest extends BaseNonCo
 
 	@Rule
 	public LoggerInspectionRule logInspection = new LoggerInspectionRule(
-			Logger.getMessageLogger( CoreMessageLogger.class, SqmUpdateStatement.class.getName() ) );
+			Logger.getMessageLogger( MethodHandles.lookup(), CoreMessageLogger.class, SqmUpdateStatement.class.getName() ) );
 
 	@Override
 	protected Class[] getAnnotatedClasses() {

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/override/inheritance/EntityInheritanceAttributeOverrideTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/override/inheritance/EntityInheritanceAttributeOverrideTest.java
@@ -24,6 +24,8 @@ import org.jboss.logging.Logger;
 import org.junit.Rule;
 import org.junit.jupiter.api.Test;
 
+import java.lang.invoke.MethodHandles;
+
 import static org.junit.jupiter.api.Assertions.fail;
 
 
@@ -35,7 +37,7 @@ public class EntityInheritanceAttributeOverrideTest extends EntityManagerFactory
 
 	@Rule
 	public LoggerInspectionRule logInspection = new LoggerInspectionRule(
-			Logger.getMessageLogger( CoreMessageLogger.class, EntityBinder.class.getName() ) );
+			Logger.getMessageLogger( MethodHandles.lookup(), CoreMessageLogger.class, EntityBinder.class.getName() ) );
 
 	@Override
 	public Class<?>[] getAnnotatedClasses() {

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/uniqueconstraint/UniqueConstraintBatchingTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/uniqueconstraint/UniqueConstraintBatchingTest.java
@@ -26,6 +26,8 @@ import org.jboss.logging.Logger;
 
 import jakarta.persistence.PersistenceException;
 
+import java.lang.invoke.MethodHandles;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -48,7 +50,7 @@ public class UniqueConstraintBatchingTest {
 
 	@Rule
 	public LoggerInspectionRule logInspection = new LoggerInspectionRule(
-			Logger.getMessageLogger( CoreMessageLogger.class, SqlExceptionHelper.class.getName() ) );
+			Logger.getMessageLogger( MethodHandles.lookup(), CoreMessageLogger.class, SqlExceptionHelper.class.getName() ) );
 
 	private Triggerable triggerable;
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/xml/ejb3/OrmVersion1SupportedTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/xml/ejb3/OrmVersion1SupportedTest.java
@@ -20,6 +20,8 @@ import org.junit.Test;
 
 import org.jboss.logging.Logger;
 
+import java.lang.invoke.MethodHandles;
+
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 
@@ -34,6 +36,7 @@ public class OrmVersion1SupportedTest extends BaseCoreFunctionalTestCase {
 	@Rule
 	public LoggerInspectionRule logInspection = new LoggerInspectionRule(
 			Logger.getMessageLogger(
+					MethodHandles.lookup(),
 					CoreMessageLogger.class,
 					"org.hibernate.internal.util.xml.ErrorLogger"
 			)

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/boot/database/metadata/MetadataAccessTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/boot/database/metadata/MetadataAccessTests.java
@@ -10,6 +10,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.hibernate.dialect.SimpleDatabaseVersion.ZERO_VERSION;
 import static org.junit.jupiter.api.Assertions.fail;
 
+import java.lang.invoke.MethodHandles;
 import java.lang.reflect.Field;
 import java.util.stream.Stream;
 
@@ -60,7 +61,7 @@ public class MetadataAccessTests {
 	@RegisterExtension
 	public LoggerInspectionExtension logger = LoggerInspectionExtension
 			.builder().setLogger(
-					Logger.getMessageLogger( CoreMessageLogger.class, Dialect.class.getName() )
+					Logger.getMessageLogger( MethodHandles.lookup(), CoreMessageLogger.class, Dialect.class.getName() )
 			).build();
 
 	@BeforeEach

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/lazy/proxy/NoProxyFactoryTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/lazy/proxy/NoProxyFactoryTests.java
@@ -30,6 +30,8 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 
+import java.lang.invoke.MethodHandles;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
@@ -42,7 +44,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class NoProxyFactoryTests extends BaseNonConfigCoreFunctionalTestCase {
 	@Rule
 	public LoggerInspectionRule logInspection = new LoggerInspectionRule(
-			Logger.getMessageLogger( CoreMessageLogger.class, EntityRepresentationStrategyPojoStandard.class.getName() )
+			Logger.getMessageLogger( MethodHandles.lookup(), CoreMessageLogger.class, EntityRepresentationStrategyPojoStandard.class.getName() )
 	);
 
 	/**

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/cache/NonRootEntityWithCacheAnnotationTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/cache/NonRootEntityWithCacheAnnotationTest.java
@@ -6,6 +6,7 @@
  */
 package org.hibernate.orm.test.cache;
 
+import java.lang.invoke.MethodHandles;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -44,7 +45,7 @@ public class NonRootEntityWithCacheAnnotationTest {
 
 	@Rule
 	public LoggerInspectionRule logInspection = new LoggerInspectionRule(
-			Logger.getMessageLogger( CoreMessageLogger.class, EntityBinder.class.getName() )
+			Logger.getMessageLogger( MethodHandles.lookup(), CoreMessageLogger.class, EntityBinder.class.getName() )
 	);
 
 	@Test

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/cache/NonRootEntityWithCacheableAnnotationTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/cache/NonRootEntityWithCacheableAnnotationTest.java
@@ -6,6 +6,7 @@
  */
 package org.hibernate.orm.test.cache;
 
+import java.lang.invoke.MethodHandles;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -45,7 +46,7 @@ public class NonRootEntityWithCacheableAnnotationTest {
 
 	@Rule
 	public LoggerInspectionRule logInspection = new LoggerInspectionRule(
-			Logger.getMessageLogger( CoreMessageLogger.class, EntityBinder.class.getName() )
+			Logger.getMessageLogger( MethodHandles.lookup(), CoreMessageLogger.class, EntityBinder.class.getName() )
 	);
 
 	@Test

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/dialect/DialectMinimumVersionTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/dialect/DialectMinimumVersionTest.java
@@ -21,6 +21,8 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 
 import org.jboss.logging.Logger;
 
+import java.lang.invoke.MethodHandles;
+
 /**
  * @author Jan Schatteman
  */
@@ -31,7 +33,7 @@ public class DialectMinimumVersionTest {
 	@RegisterExtension
 	public LoggerInspectionExtension logger = LoggerInspectionExtension
 			.builder().setLogger(
-					Logger.getMessageLogger( CoreMessageLogger.class, Dialect.class.getName()  )
+					Logger.getMessageLogger( MethodHandles.lookup(), CoreMessageLogger.class, Dialect.class.getName()  )
 			).build();
 
 	@BeforeEach

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/dialect/unit/CockroachDialectVersionTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/dialect/unit/CockroachDialectVersionTest.java
@@ -21,6 +21,8 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 
 import org.jboss.logging.Logger;
 
+import java.lang.invoke.MethodHandles;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
@@ -34,7 +36,7 @@ public class CockroachDialectVersionTest {
 	@RegisterExtension
 	public LoggerInspectionExtension logger = LoggerInspectionExtension
 			.builder().setLogger(
-					Logger.getMessageLogger( CoreMessageLogger.class, CockroachDialect.class.getName()  )
+					Logger.getMessageLogger( MethodHandles.lookup(), CoreMessageLogger.class, CockroachDialect.class.getName()  )
 			).build();
 
 	@BeforeEach

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/id/hhh12973/PostgreSQLSequenceGeneratorWithSerialTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/id/hhh12973/PostgreSQLSequenceGeneratorWithSerialTest.java
@@ -7,6 +7,7 @@
 package org.hibernate.orm.test.id.hhh12973;
 
 import java.io.StringReader;
+import java.lang.invoke.MethodHandles;
 import java.sql.Statement;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicLong;
@@ -53,6 +54,7 @@ public class PostgreSQLSequenceGeneratorWithSerialTest extends EntityManagerFact
 	@Rule
 	public LoggerInspectionRule logInspection = new LoggerInspectionRule(
 			Logger.getMessageLogger(
+					MethodHandles.lookup(),
 					CoreMessageLogger.class,
 					SequenceStyleGenerator.class.getName()
 			) );

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/id/hhh12973/SequenceMismatchStrategyFixWithSequenceGeneratorTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/id/hhh12973/SequenceMismatchStrategyFixWithSequenceGeneratorTest.java
@@ -6,6 +6,7 @@
  */
 package org.hibernate.orm.test.id.hhh12973;
 
+import java.lang.invoke.MethodHandles;
 import java.util.EnumSet;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicLong;
@@ -53,6 +54,7 @@ public class SequenceMismatchStrategyFixWithSequenceGeneratorTest extends Entity
 	@Rule
 	public LoggerInspectionRule logInspection = new LoggerInspectionRule(
 			Logger.getMessageLogger(
+					MethodHandles.lookup(),
 					CoreMessageLogger.class,
 					SequenceStyleGenerator.class.getName()
 			)

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/id/hhh12973/SequenceMismatchStrategyLogTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/id/hhh12973/SequenceMismatchStrategyLogTest.java
@@ -6,6 +6,7 @@
  */
 package org.hibernate.orm.test.id.hhh12973;
 
+import java.lang.invoke.MethodHandles;
 import java.util.EnumSet;
 import java.util.Map;
 import jakarta.persistence.Entity;
@@ -51,6 +52,7 @@ public class SequenceMismatchStrategyLogTest extends EntityManagerFactoryBasedFu
 	@Rule
 	public LoggerInspectionRule logInspection = new LoggerInspectionRule(
 			Logger.getMessageLogger(
+					MethodHandles.lookup(),
 					CoreMessageLogger.class,
 					SequenceStyleGenerator.class.getName()
 			)

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/id/hhh12973/SequenceMismatchStrategyWithoutSequenceGeneratorTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/id/hhh12973/SequenceMismatchStrategyWithoutSequenceGeneratorTest.java
@@ -6,6 +6,7 @@
  */
 package org.hibernate.orm.test.id.hhh12973;
 
+import java.lang.invoke.MethodHandles;
 import java.util.EnumSet;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicLong;
@@ -52,6 +53,7 @@ public class SequenceMismatchStrategyWithoutSequenceGeneratorTest extends Entity
 	@Rule
 	public LoggerInspectionRule logInspection = new LoggerInspectionRule(
 			Logger.getMessageLogger(
+					MethodHandles.lookup(),
 					CoreMessageLogger.class,
 					SequenceStyleGenerator.class.getName()
 			)

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/id/sequence/NegativeValueSequenceTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/id/sequence/NegativeValueSequenceTest.java
@@ -35,6 +35,8 @@ import org.junit.jupiter.api.Test;
 
 import org.jboss.logging.Logger;
 
+import java.lang.invoke.MethodHandles;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -46,7 +48,7 @@ public class NegativeValueSequenceTest {
 
 	@Rule
 	public LoggerInspectionRule logInspection = new LoggerInspectionRule(
-			Logger.getMessageLogger( CoreMessageLogger.class, SequenceStyleGenerator.class.getName() )
+			Logger.getMessageLogger( MethodHandles.lookup(), CoreMessageLogger.class, SequenceStyleGenerator.class.getName() )
 	);
 
 	@Test

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/callbacks/PrivateConstructorTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/callbacks/PrivateConstructorTest.java
@@ -34,6 +34,8 @@ import org.junit.jupiter.api.Test;
 
 import org.jboss.logging.Logger;
 
+import java.lang.invoke.MethodHandles;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -46,9 +48,9 @@ public class PrivateConstructorTest {
 
 	@Rule
 	public LoggerInspectionRule logInspection = new LoggerInspectionRule( Logger.getMessageLogger(
+			MethodHandles.lookup(),
 			CoreMessageLogger.class,
-			proxyFactoryClass()
-					.getName()
+			proxyFactoryClass().getName()
 	) );
 
 	@AfterEach

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/persistenceunit/DuplicatePersistenceUnitNameTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/persistenceunit/DuplicatePersistenceUnitNameTest.java
@@ -7,6 +7,7 @@
 package org.hibernate.orm.test.jpa.persistenceunit;
 
 import java.io.IOException;
+import java.lang.invoke.MethodHandles;
 import java.net.URL;
 import java.util.Arrays;
 import java.util.Collections;
@@ -44,7 +45,7 @@ public class DuplicatePersistenceUnitNameTest extends BaseUnitTestCase {
 
 	@Rule
 	public LoggerInspectionRule logInspection = new LoggerInspectionRule(
-			Logger.getMessageLogger( CoreMessageLogger.class, PersistenceXmlParser.class.getName() )
+			Logger.getMessageLogger( MethodHandles.lookup(), CoreMessageLogger.class, PersistenceXmlParser.class.getName() )
 	);
 
 	@Before

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/persistenceunit/PersistenceXmlParserTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/persistenceunit/PersistenceXmlParserTest.java
@@ -10,6 +10,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.hibernate.internal.util.ConfigHelper.findAsResource;
 
 import java.io.IOException;
+import java.lang.invoke.MethodHandles;
 import java.net.URL;
 import java.util.Arrays;
 import java.util.Collections;
@@ -39,7 +40,7 @@ public class PersistenceXmlParserTest {
 
 	@Rule
 	public LoggerInspectionRule logInspection = new LoggerInspectionRule(
-			Logger.getMessageLogger( CoreMessageLogger.class, PersistenceXmlParser.class.getName() )
+			Logger.getMessageLogger( MethodHandles.lookup(), CoreMessageLogger.class, PersistenceXmlParser.class.getName() )
 	);
 
 	@Test

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/locking/warning/LockNoneWarmingTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/locking/warning/LockNoneWarmingTest.java
@@ -7,6 +7,7 @@
 package org.hibernate.orm.test.locking.warning;
 
 import java.io.Serializable;
+import java.lang.invoke.MethodHandles;
 import java.util.HashSet;
 import java.util.Set;
 import jakarta.persistence.Column;
@@ -46,7 +47,7 @@ public class LockNoneWarmingTest extends BaseCoreFunctionalTestCase {
 
 	@Rule
 	public LoggerInspectionRule logInspection = new LoggerInspectionRule(
-			Logger.getMessageLogger( CoreMessageLogger.class, LockNoneWarmingTest.class.getName() )
+			Logger.getMessageLogger( MethodHandles.lookup(), CoreMessageLogger.class, LockNoneWarmingTest.class.getName() )
 	);
 
 	@Override

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/converted/enums/EnumTypeTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/converted/enums/EnumTypeTest.java
@@ -26,6 +26,8 @@ import org.junit.Test;
 
 import org.jboss.logging.Logger;
 
+import java.lang.invoke.MethodHandles;
+
 import static org.hibernate.testing.transaction.TransactionUtil.doInHibernate;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -37,12 +39,14 @@ public class EnumTypeTest extends BaseCoreFunctionalTestCase {
 
 	@Rule
 	public LoggerInspectionRule binderLogInspection = new LoggerInspectionRule( Logger.getMessageLogger(
+			MethodHandles.lookup(),
 			CoreMessageLogger.class,
 			JdbcBindingLogging.NAME
 	) );
 
 	@Rule
 	public LoggerInspectionRule extractorLogInspection = new LoggerInspectionRule( Logger.getMessageLogger(
+			MethodHandles.lookup(),
 			CoreMessageLogger.class,
 			JdbcExtractingLogging.NAME
 	) );

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/generated/delegate/MutationDelegateIdentityTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/generated/delegate/MutationDelegateIdentityTest.java
@@ -6,6 +6,7 @@
  */
 package org.hibernate.orm.test.mapping.generated.delegate;
 
+import java.lang.invoke.MethodHandles;
 import java.util.Date;
 
 import org.hibernate.annotations.ColumnDefault;
@@ -253,7 +254,7 @@ public class MutationDelegateIdentityTest {
 
 	@RegisterExtension
 	public LoggerInspectionExtension logger = LoggerInspectionExtension.builder().setLogger(
-			Logger.getMessageLogger( CoreMessageLogger.class, SqlExceptionHelper.class.getName() )
+			Logger.getMessageLogger( MethodHandles.lookup(), CoreMessageLogger.class, SqlExceptionHelper.class.getName() )
 	).build();
 
 	@BeforeAll

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/generated/delegate/MutationDelegateStatementReleaseTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/generated/delegate/MutationDelegateStatementReleaseTest.java
@@ -6,6 +6,7 @@
  */
 package org.hibernate.orm.test.mapping.generated.delegate;
 
+import java.lang.invoke.MethodHandles;
 import java.util.Date;
 import java.util.Set;
 
@@ -65,6 +66,7 @@ public class MutationDelegateStatementReleaseTest {
 		LogInspectionHelper.registerListener(
 				trigger,
 				Logger.getMessageLogger(
+						MethodHandles.lookup(),
 						CoreMessageLogger.class,
 						ResourceRegistryStandardImpl.class.getName()
 				)

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/onetoone/OneToOneMapsIdChangeParentTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/onetoone/OneToOneMapsIdChangeParentTest.java
@@ -24,6 +24,8 @@ import org.junit.jupiter.api.Test;
 
 import org.jboss.logging.Logger;
 
+import java.lang.invoke.MethodHandles;
+
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
@@ -42,6 +44,7 @@ public class OneToOneMapsIdChangeParentTest {
 	@Rule
 	public LoggerInspectionRule logInspection = new LoggerInspectionRule(
 			Logger.getMessageLogger(
+					MethodHandles.lookup(),
 					CoreMessageLogger.class,
 					UpdateCoordinatorStandard.class.getName()
 			)

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/persister/entity/TemporaryTableStrategyTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/persister/entity/TemporaryTableStrategyTest.java
@@ -6,6 +6,7 @@
  */
 package org.hibernate.orm.test.persister.entity;
 
+import java.lang.invoke.MethodHandles;
 import java.util.Set;
 
 import org.hibernate.dialect.OracleDialect;
@@ -51,7 +52,7 @@ public class TemporaryTableStrategyTest {
 
 	@Rule
 	public LoggerInspectionRule logInspection = new LoggerInspectionRule(
-			Logger.getMessageLogger( CoreMessageLogger.class, GlobalTemporaryTableStrategy.class.getName() )
+			Logger.getMessageLogger( MethodHandles.lookup(), CoreMessageLogger.class, GlobalTemporaryTableStrategy.class.getName() )
 	);
 
 	private final Triggerable triggerable = logInspection.watchForLogMessages( Set.of(

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/query/hql/DynamicMapInstantiationTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/query/hql/DynamicMapInstantiationTest.java
@@ -23,6 +23,8 @@ import jakarta.persistence.Id;
 import jakarta.persistence.Query;
 import jakarta.persistence.Table;
 
+import java.lang.invoke.MethodHandles;
+
 @DomainModel(
 		annotatedClasses = {
 				DynamicMapInstantiationTest.Parent.class
@@ -37,7 +39,7 @@ public class DynamicMapInstantiationTest {
 	@RegisterExtension
 	public LoggerInspectionExtension logger = LoggerInspectionExtension
 			.builder().setLogger(
-					Logger.getMessageLogger( CoreMessageLogger.class, SqmDynamicInstantiation.class.getName() )
+					Logger.getMessageLogger( MethodHandles.lookup(), CoreMessageLogger.class, SqmDynamicInstantiation.class.getName() )
 			).build();
 
 	@BeforeEach

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/schemaupdate/Hbm2ddlCreateOnlyTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/schemaupdate/Hbm2ddlCreateOnlyTest.java
@@ -2,6 +2,7 @@ package org.hibernate.orm.test.schemaupdate;
 
 import static org.junit.Assert.assertFalse;
 
+import java.lang.invoke.MethodHandles;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
@@ -28,7 +29,7 @@ public class Hbm2ddlCreateOnlyTest {
 
 	@Rule
 	public LoggerInspectionRule logInspection = new LoggerInspectionRule( Logger.getMessageLogger(
-			CoreMessageLogger.class, SessionFactoryOptionsBuilder.class.getName() ) );
+			MethodHandles.lookup(), CoreMessageLogger.class, SessionFactoryOptionsBuilder.class.getName() ) );
 
 	@SuppressWarnings({ "rawtypes", "unchecked" })
 	@Test

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/session/AssociateEntityWithTwoSessionsTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/session/AssociateEntityWithTwoSessionsTest.java
@@ -28,6 +28,8 @@ import org.junit.jupiter.api.Test;
 
 import org.jboss.logging.Logger;
 
+import java.lang.invoke.MethodHandles;
+
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
@@ -42,7 +44,7 @@ public class AssociateEntityWithTwoSessionsTest {
 
 	@Rule
 	public LoggerInspectionRule logInspection = new LoggerInspectionRule(
-			Logger.getMessageLogger( CoreMessageLogger.class, AbstractLazyInitializer.class.getName() ) );
+			Logger.getMessageLogger( MethodHandles.lookup(), CoreMessageLogger.class, AbstractLazyInitializer.class.getName() ) );
 
 	@Test
 	@TestForIssue( jiraKey = "HHH-12216" )

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/stateless/StatelessSessionConnectionTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/stateless/StatelessSessionConnectionTest.java
@@ -22,6 +22,8 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 
 import org.jboss.logging.Logger;
 
+import java.lang.invoke.MethodHandles;
+
 import static org.junit.jupiter.api.Assertions.assertFalse;
 
 
@@ -35,6 +37,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 public class StatelessSessionConnectionTest {
 
 	final CoreMessageLogger messageLogger = Logger.getMessageLogger(
+			MethodHandles.lookup(),
 			CoreMessageLogger.class,
 			SequenceStyleGenerator.class.getName()
 	);

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/tool/schema/IndividuallySchemaValidatorImplConnectionTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/tool/schema/IndividuallySchemaValidatorImplConnectionTest.java
@@ -8,6 +8,7 @@ package org.hibernate.orm.test.tool.schema;
 
 import java.io.FileInputStream;
 import java.io.IOException;
+import java.lang.invoke.MethodHandles;
 import java.net.URL;
 import java.sql.Connection;
 import java.sql.SQLException;
@@ -69,7 +70,7 @@ public class IndividuallySchemaValidatorImplConnectionTest extends BaseUnitTestC
 
 	@Rule
 	public LoggerInspectionRule logInspection = new LoggerInspectionRule(
-			Logger.getMessageLogger( CoreMessageLogger.class, IndividuallySchemaValidatorImplConnectionTest.class.getName() ) );
+			Logger.getMessageLogger( MethodHandles.lookup(), CoreMessageLogger.class, IndividuallySchemaValidatorImplConnectionTest.class.getName() ) );
 
 	private StandardServiceRegistry ssr;
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/tool/schema/IndividuallySchemaValidatorImplTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/tool/schema/IndividuallySchemaValidatorImplTest.java
@@ -8,6 +8,7 @@ package org.hibernate.orm.test.tool.schema;
 
 import java.io.FileInputStream;
 import java.io.IOException;
+import java.lang.invoke.MethodHandles;
 import java.net.URL;
 import java.util.HashMap;
 import java.util.Map;
@@ -67,7 +68,7 @@ public class IndividuallySchemaValidatorImplTest extends BaseUnitTestCase {
 
 	@Rule
 	public LoggerInspectionRule logInspection = new LoggerInspectionRule(
-			Logger.getMessageLogger( CoreMessageLogger.class, IndividuallySchemaValidatorImplTest.class.getName() ) );
+			Logger.getMessageLogger( MethodHandles.lookup(), CoreMessageLogger.class, IndividuallySchemaValidatorImplTest.class.getName() ) );
 
 	private StandardServiceRegistry ssr;
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/tool/schema/JtaPlatformLoggingTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/tool/schema/JtaPlatformLoggingTest.java
@@ -6,6 +6,7 @@
  */
 package org.hibernate.orm.test.tool.schema;
 
+import java.lang.invoke.MethodHandles;
 import java.util.Map;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
@@ -35,7 +36,7 @@ public class JtaPlatformLoggingTest extends BaseNonConfigCoreFunctionalTestCase 
 
 	@Rule
 	public LoggerInspectionRule logInspection = new LoggerInspectionRule(
-			Logger.getMessageLogger( CoreMessageLogger.class, JtaPlatformInitiator.class.getName() ) );
+			Logger.getMessageLogger( MethodHandles.lookup(), CoreMessageLogger.class, JtaPlatformInitiator.class.getName() ) );
 
 	private Triggerable triggerable = logInspection.watchForLogMessages( "HHH000490" );
 

--- a/hibernate-envers/src/main/java/org/hibernate/envers/boot/EnversBootLogger.java
+++ b/hibernate-envers/src/main/java/org/hibernate/envers/boot/EnversBootLogger.java
@@ -15,6 +15,8 @@ import org.jboss.logging.annotations.Message;
 import org.jboss.logging.annotations.MessageLogger;
 import org.jboss.logging.annotations.ValidIdRange;
 
+import java.lang.invoke.MethodHandles;
+
 import static org.jboss.logging.Logger.Level.INFO;
 
 /**
@@ -31,6 +33,7 @@ public interface EnversBootLogger extends BasicLogger {
 	String LOGGER_NAME = "org.hibernate.envers.boot";
 
 	EnversBootLogger BOOT_LOGGER = Logger.getMessageLogger(
+			MethodHandles.lookup(),
 			EnversBootLogger.class,
 			LOGGER_NAME
 	);

--- a/hibernate-envers/src/main/java/org/hibernate/envers/configuration/internal/ClassesAuditingData.java
+++ b/hibernate-envers/src/main/java/org/hibernate/envers/configuration/internal/ClassesAuditingData.java
@@ -6,6 +6,7 @@
  */
 package org.hibernate.envers.configuration.internal;
 
+import java.lang.invoke.MethodHandles;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
@@ -37,6 +38,7 @@ import org.jboss.logging.Logger;
  */
 public class ClassesAuditingData {
 	private static final EnversMessageLogger LOG = Logger.getMessageLogger(
+			MethodHandles.lookup(),
 			EnversMessageLogger.class,
 			ClassesAuditingData.class.getName()
 	);

--- a/hibernate-envers/src/main/java/org/hibernate/envers/configuration/internal/metadata/AuditMetadataGenerator.java
+++ b/hibernate-envers/src/main/java/org/hibernate/envers/configuration/internal/metadata/AuditMetadataGenerator.java
@@ -6,6 +6,7 @@
  */
 package org.hibernate.envers.configuration.internal.metadata;
 
+import java.lang.invoke.MethodHandles;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Locale;
@@ -51,6 +52,7 @@ import org.jboss.logging.Logger;
 public final class AuditMetadataGenerator extends AbstractMetadataGenerator {
 
 	private static final EnversMessageLogger LOG = Logger.getMessageLogger(
+			MethodHandles.lookup(),
 			EnversMessageLogger.class,
 			AuditMetadataGenerator.class.getName()
 	);

--- a/hibernate-envers/src/main/java/org/hibernate/envers/configuration/internal/metadata/CollectionMappedByResolver.java
+++ b/hibernate-envers/src/main/java/org/hibernate/envers/configuration/internal/metadata/CollectionMappedByResolver.java
@@ -6,6 +6,7 @@
  */
 package org.hibernate.envers.configuration.internal.metadata;
 
+import java.lang.invoke.MethodHandles;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
@@ -35,6 +36,7 @@ import org.jboss.logging.Logger;
 public class CollectionMappedByResolver {
 
 	private static final EnversMessageLogger LOG = Logger.getMessageLogger(
+			MethodHandles.lookup(),
 			EnversMessageLogger.class,
 			CollectionMappedByResolver.class.getName()
 	);

--- a/hibernate-envers/src/main/java/org/hibernate/envers/configuration/internal/metadata/JoinColumnCollectionMetadataGenerator.java
+++ b/hibernate-envers/src/main/java/org/hibernate/envers/configuration/internal/metadata/JoinColumnCollectionMetadataGenerator.java
@@ -31,6 +31,8 @@ import org.hibernate.type.Type;
 
 import org.jboss.logging.Logger;
 
+import java.lang.invoke.MethodHandles;
+
 /**
  * An implementation of {@link AbstractCollectionMetadataGenerator} that builds collection metadata
  * and association mappings where the association uses a join column mapping.
@@ -40,6 +42,7 @@ import org.jboss.logging.Logger;
 public class JoinColumnCollectionMetadataGenerator extends AbstractCollectionMetadataGenerator {
 
 	private static final EnversMessageLogger LOG = Logger.getMessageLogger(
+			MethodHandles.lookup(),
 			EnversMessageLogger.class,
 			JoinColumnCollectionMetadataGenerator.class.getName()
 	);

--- a/hibernate-envers/src/main/java/org/hibernate/envers/configuration/internal/metadata/MiddleTableCollectionMetadataGenerator.java
+++ b/hibernate-envers/src/main/java/org/hibernate/envers/configuration/internal/metadata/MiddleTableCollectionMetadataGenerator.java
@@ -27,6 +27,8 @@ import org.hibernate.mapping.PersistentClass;
 
 import org.jboss.logging.Logger;
 
+import java.lang.invoke.MethodHandles;
+
 /**
  * An implementation of {@link AbstractCollectionMetadataGenerator} that builds collection metadata
  * and association mappings where the association uses a middle table mapping.
@@ -36,6 +38,7 @@ import org.jboss.logging.Logger;
 public class MiddleTableCollectionMetadataGenerator extends AbstractCollectionMetadataGenerator {
 
 	private static final EnversMessageLogger LOG = Logger.getMessageLogger(
+			MethodHandles.lookup(),
 			EnversMessageLogger.class,
 			MiddleTableCollectionMetadataGenerator.class.getName()
 	);

--- a/hibernate-envers/src/main/java/org/hibernate/envers/internal/EnversLogging.java
+++ b/hibernate-envers/src/main/java/org/hibernate/envers/internal/EnversLogging.java
@@ -8,6 +8,8 @@ package org.hibernate.envers.internal;
 
 import org.jboss.logging.Logger;
 
+import java.lang.invoke.MethodHandles;
+
 /**
  * Sad when you need helpers for generating loggers...
  *
@@ -25,7 +27,7 @@ public class EnversLogging {
 	}
 
 	public static EnversMessageLogger messageLogger(String loggerName) {
-		return Logger.getMessageLogger( EnversMessageLogger .class, loggerName );
+		return Logger.getMessageLogger( MethodHandles.lookup(), EnversMessageLogger .class, loggerName );
 	}
 
 	public static Logger logger(Class classNeedingLogging) {

--- a/hibernate-envers/src/main/java/org/hibernate/envers/internal/reader/FirstLevelCache.java
+++ b/hibernate-envers/src/main/java/org/hibernate/envers/internal/reader/FirstLevelCache.java
@@ -6,6 +6,7 @@
  */
 package org.hibernate.envers.internal.reader;
 
+import java.lang.invoke.MethodHandles;
 import java.util.Map;
 
 import org.hibernate.envers.internal.EnversMessageLogger;
@@ -25,6 +26,7 @@ import static org.hibernate.envers.internal.tools.Triple.make;
  */
 public class FirstLevelCache {
 	private static final EnversMessageLogger LOG = Logger.getMessageLogger(
+			MethodHandles.lookup(),
 			EnversMessageLogger.class,
 			FirstLevelCache.class.getName()
 	);

--- a/hibernate-proxool/src/main/java/org/hibernate/proxool/internal/ProxoolMessageLogger.java
+++ b/hibernate-proxool/src/main/java/org/hibernate/proxool/internal/ProxoolMessageLogger.java
@@ -15,6 +15,8 @@ import org.jboss.logging.annotations.Message;
 import org.jboss.logging.annotations.MessageLogger;
 import org.jboss.logging.annotations.ValidIdRange;
 
+import java.lang.invoke.MethodHandles;
+
 import static org.jboss.logging.Logger.Level.DEBUG;
 
 /**
@@ -31,7 +33,7 @@ import static org.jboss.logging.Logger.Level.DEBUG;
 )
 public interface ProxoolMessageLogger extends ConnectionInfoLogger {
 	String LOGGER_NAME = ConnectionInfoLogger.LOGGER_NAME + ".proxool";
-	ProxoolMessageLogger PROXOOL_MESSAGE_LOGGER = Logger.getMessageLogger( ProxoolMessageLogger.class, LOGGER_NAME );
+	ProxoolMessageLogger PROXOOL_MESSAGE_LOGGER = Logger.getMessageLogger( MethodHandles.lookup(), ProxoolMessageLogger.class, LOGGER_NAME );
 
 	/**
 	 * Logs the name of a named pool to be used for configuration information

--- a/hibernate-spatial/src/main/java/org/hibernate/spatial/HSMessageLogger.java
+++ b/hibernate-spatial/src/main/java/org/hibernate/spatial/HSMessageLogger.java
@@ -16,6 +16,8 @@ import org.jboss.logging.annotations.Message;
 import org.jboss.logging.annotations.MessageLogger;
 import org.jboss.logging.annotations.ValidIdRange;
 
+import java.lang.invoke.MethodHandles;
+
 import static org.jboss.logging.Logger.Level.DEBUG;
 import static org.jboss.logging.Logger.Level.INFO;
 
@@ -35,7 +37,7 @@ public interface HSMessageLogger extends BasicLogger {
 
 	String LOGGER_NAME = "org.hibernate.spatial";
 
-	HSMessageLogger SPATIAL_MSG_LOGGER = Logger.getMessageLogger( HSMessageLogger.class, LOGGER_NAME );
+	HSMessageLogger SPATIAL_MSG_LOGGER = Logger.getMessageLogger( MethodHandles.lookup(), HSMessageLogger.class, LOGGER_NAME );
 
 	@LogMessage(level = INFO)
 	@Message(value = "Hibernate Spatial integration enabled: %s", id = 80000001)

--- a/hibernate-spatial/src/main/java/org/hibernate/spatial/dialect/h2gis/H2GISWkb.java
+++ b/hibernate-spatial/src/main/java/org/hibernate/spatial/dialect/h2gis/H2GISWkb.java
@@ -11,6 +11,7 @@ package org.hibernate.spatial.dialect.h2gis;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.lang.invoke.MethodHandles;
 import java.sql.Blob;
 
 import org.hibernate.HibernateException;
@@ -43,6 +44,7 @@ import org.geolatte.geom.jts.JTS;
 public class H2GISWkb {
 
 	private static final HSMessageLogger LOGGER = Logger.getMessageLogger(
+			MethodHandles.lookup(),
 			HSMessageLogger.class,
 			H2GISWkb.class.getName()
 	);

--- a/hibernate-spatial/src/main/java/org/hibernate/spatial/integration/SpatialService.java
+++ b/hibernate-spatial/src/main/java/org/hibernate/spatial/integration/SpatialService.java
@@ -13,6 +13,8 @@ import org.hibernate.spatial.HSMessageLogger;
 
 import org.jboss.logging.Logger;
 
+import java.lang.invoke.MethodHandles;
+
 /**
  * Central service for spatial integration
  *
@@ -27,6 +29,7 @@ public class SpatialService implements Service {
 	public static final String INTEGRATION_ENABLED = "hibernate.integration.spatial.enabled";
 
 	private static final HSMessageLogger log = Logger.getMessageLogger(
+			MethodHandles.lookup(),
 			HSMessageLogger.class,
 			SpatialService.class.getName()
 	);

--- a/hibernate-spatial/src/test/java/org/hibernate/spatial/dialect/hana/TestHANASpatialFunctions.java
+++ b/hibernate-spatial/src/test/java/org/hibernate/spatial/dialect/hana/TestHANASpatialFunctions.java
@@ -7,6 +7,7 @@
 
 package org.hibernate.spatial.dialect.hana;
 
+import java.lang.invoke.MethodHandles;
 import java.sql.SQLException;
 import java.util.HashMap;
 import java.util.Locale;
@@ -39,6 +40,7 @@ import static java.lang.String.format;
 public class TestHANASpatialFunctions extends SpatialFunctionalTestCase {
 
 	private static final HSMessageLogger LOG = Logger.getMessageLogger(
+			MethodHandles.lookup(),
 			HSMessageLogger.class,
 			TestHANASpatialFunctions.class.getName()
 	);

--- a/hibernate-spatial/src/test/java/org/hibernate/spatial/testing/AbstractExpectationsFactory.java
+++ b/hibernate-spatial/src/test/java/org/hibernate/spatial/testing/AbstractExpectationsFactory.java
@@ -7,6 +7,7 @@
 
 package org.hibernate.spatial.testing;
 
+import java.lang.invoke.MethodHandles;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
@@ -43,6 +44,7 @@ public abstract class AbstractExpectationsFactory {
 	public final static int BOOLEAN = 5;
 	public final static int OBJECT = -1;
 	private static final HSMessageLogger LOG = Logger.getMessageLogger(
+			MethodHandles.lookup(),
 			HSMessageLogger.class,
 			AbstractExpectationsFactory.class.getName()
 	);

--- a/hibernate-testing/src/test/java/org/hibernate/testing/logger/LoggingRuleTest.java
+++ b/hibernate-testing/src/test/java/org/hibernate/testing/logger/LoggingRuleTest.java
@@ -14,6 +14,8 @@ import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
 
+import java.lang.invoke.MethodHandles;
+
 /**
  * Example usage for the JUnit rule to assert logging events
  *
@@ -24,12 +26,12 @@ public class LoggingRuleTest {
 
 	//Taking this specific logger as a representative example of a Logger
 	//(The purpose of this test is not to log but to exercise the logger methods)
-	private static final CoreMessageLogger LOG = Logger.getMessageLogger( CoreMessageLogger.class, SessionImpl.class.getName() );
+	private static final CoreMessageLogger LOG = Logger.getMessageLogger( MethodHandles.lookup(), CoreMessageLogger.class, SessionImpl.class.getName() );
 
 	//We'll generally not be able to access the same LOG *instance* so make sure a fresh lookup
 	//from Logger#getMessageLogger will work fine as well
 	@Rule
-	public LoggerInspectionRule logInspection = new LoggerInspectionRule( Logger.getMessageLogger( CoreMessageLogger.class, SessionImpl.class.getName() ) );
+	public LoggerInspectionRule logInspection = new LoggerInspectionRule( Logger.getMessageLogger( MethodHandles.lookup(), CoreMessageLogger.class, SessionImpl.class.getName() ) );
 
 	@Test
 	public void testRule() {

--- a/settings.gradle
+++ b/settings.gradle
@@ -80,7 +80,7 @@ dependencyResolutionManagement {
             def jandexVersion = version "jandex", "3.2.0"
 			def hcannVersion = version "hcann", "7.0.1.Final"
             def jacksonVersion = version "jackson", "2.17.0"
-            def jbossLoggingVersion = version "jbossLogging", "3.5.0.Final"
+            def jbossLoggingVersion = version "jbossLogging", "3.6.0.Final"
             def jbossLoggingToolVersion = version "jbossLoggingTool", "3.0.1.Final"
 
             def agroalVersion = version "agroal", "2.0"

--- a/tooling/hibernate-ant/src/main/java/org/hibernate/tool/hbm2ddl/DatabaseExporter.java
+++ b/tooling/hibernate-ant/src/main/java/org/hibernate/tool/hbm2ddl/DatabaseExporter.java
@@ -6,6 +6,7 @@
  */
 package org.hibernate.tool.hbm2ddl;
 
+import java.lang.invoke.MethodHandles;
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.sql.SQLWarning;
@@ -25,7 +26,7 @@ import org.jboss.logging.Logger;
  */
 @Deprecated
 class DatabaseExporter implements Exporter {
-	private static final CoreMessageLogger LOG = Logger.getMessageLogger( CoreMessageLogger.class, DatabaseExporter.class.getName() );
+	private static final CoreMessageLogger LOG = Logger.getMessageLogger( MethodHandles.lookup(), CoreMessageLogger.class, DatabaseExporter.class.getName() );
 
 	private final ConnectionHelper connectionHelper;
 	private final SqlExceptionHelper sqlExceptionHelper;

--- a/tooling/hibernate-gradle-plugin/hibernate-gradle-plugin.gradle
+++ b/tooling/hibernate-gradle-plugin/hibernate-gradle-plugin.gradle
@@ -57,6 +57,10 @@ gradlePlugin {
 	}
 }
 
+tasks.withType(AbstractArchiveTask).configureEach {
+	preserveFileTimestamps = false
+	reproducibleFileOrder = true
+}
 
 test {
 	useJUnitPlatform()


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-18488

running the check without the changes leads to sources jar being different + shows problems in the core jar:

```
ok=59
ko=23
okFiles="hibernate-agroal-7.0.0-SNAPSHOT.pom hibernate-ant-7.0.0-SNAPSHOT.pom hibernate-c3p0-7.0.0-SNAPSHOT.pom hibernate-community-dialects-7.0.0-SNAPSHOT.pom hibernate-core-7.0.0-SNAPSHOT.pom hibernate-enhance-maven-plugin-7.0.0-SNAPSHOT.pom hibernate-envers-7.0.0-SNAPSHOT.pom hibernate-graalvm-7.0.0-SNAPSHOT.pom hibernate-hikaricp-7.0.0-SNAPSHOT.pom hibernate-jcache-7.0.0-SNAPSHOT.pom hibernate-jfr-7.0.0-SNAPSHOT.pom hibernate-micrometer-7.0.0-SNAPSHOT.pom hibernate-proxool-7.0.0-SNAPSHOT.pom hibernate-spatial-7.0.0-SNAPSHOT.pom hibernate-testing-7.0.0-SNAPSHOT.pom hibernate-ucp-7.0.0-SNAPSHOT.pom hibernate-vector-7.0.0-SNAPSHOT.pom hibernate-vibur-7.0.0-SNAPSHOT.pom hibernate-agroal-7.0.0-SNAPSHOT.jar hibernate-agroal-7.0.0-SNAPSHOT.pom hibernate-ant-7.0.0-SNAPSHOT.jar hibernate-ant-7.0.0-SNAPSHOT.pom hibernate-c3p0-7.0.0-SNAPSHOT.jar hibernate-c3p0-7.0.0-SNAPSHOT.pom hibernate-community-dialects-7.0.0-SNAPSHOT.jar hibernate-community-dialects-7.0.0-SNAPSHOT.pom hibernate-core-7.0.0-SNAPSHOT.pom hibernate-envers-7.0.0-SNAPSHOT.jar hibernate-envers-7.0.0-SNAPSHOT.pom hibernate-graalvm-7.0.0-SNAPSHOT.jar hibernate-graalvm-7.0.0-SNAPSHOT.pom hibernate-gradle-plugin-7.0.0-SNAPSHOT.pom hibernate-hikaricp-7.0.0-SNAPSHOT.jar hibernate-hikaricp-7.0.0-SNAPSHOT.pom hibernate-jcache-7.0.0-SNAPSHOT.jar hibernate-jcache-7.0.0-SNAPSHOT.pom hibernate-jfr-7.0.0-SNAPSHOT.jar hibernate-jfr-7.0.0-SNAPSHOT.pom hibernate-jpamodelgen-7.0.0-SNAPSHOT.pom hibernate-micrometer-7.0.0-SNAPSHOT.jar hibernate-micrometer-7.0.0-SNAPSHOT.pom hibernate-platform-7.0.0-SNAPSHOT.pom hibernate-processor-7.0.0-SNAPSHOT.jar hibernate-processor-7.0.0-SNAPSHOT.pom hibernate-proxool-7.0.0-SNAPSHOT.jar hibernate-proxool-7.0.0-SNAPSHOT.pom hibernate-spatial-7.0.0-SNAPSHOT.jar hibernate-spatial-7.0.0-SNAPSHOT.pom hibernate-testing-7.0.0-SNAPSHOT.jar hibernate-testing-7.0.0-SNAPSHOT.pom hibernate-ucp-7.0.0-SNAPSHOT.jar hibernate-ucp-7.0.0-SNAPSHOT.pom hibernate-vector-7.0.0-SNAPSHOT.jar hibernate-vector-7.0.0-SNAPSHOT.pom hibernate-vibur-7.0.0-SNAPSHOT.jar hibernate-vibur-7.0.0-SNAPSHOT.pom org.hibernate.orm.gradle.plugin-7.0.0-SNAPSHOT.pom hibernate-enhance-maven-plugin-7.0.0-SNAPSHOT.jar hibernate-enhance-maven-plugin-7.0.0-SNAPSHOT.pom"
koFiles="hibernate-agroal-7.0.0-SNAPSHOT-sources.jar hibernate-ant-7.0.0-SNAPSHOT-sources.jar hibernate-c3p0-7.0.0-SNAPSHOT-sources.jar hibernate-community-dialects-7.0.0-SNAPSHOT-sources.jar hibernate-core-7.0.0-SNAPSHOT.jar hibernate-core-7.0.0-SNAPSHOT-sources.jar hibernate-envers-7.0.0-SNAPSHOT-sources.jar hibernate-graalvm-7.0.0-SNAPSHOT-sources.jar hibernate-gradle-plugin-7.0.0-SNAPSHOT.jar hibernate-gradle-plugin-7.0.0-SNAPSHOT.module hibernate-gradle-plugin-7.0.0-SNAPSHOT-sources.jar hibernate-hikaricp-7.0.0-SNAPSHOT-sources.jar hibernate-jcache-7.0.0-SNAPSHOT-sources.jar hibernate-jfr-7.0.0-SNAPSHOT-sources.jar hibernate-micrometer-7.0.0-SNAPSHOT-sources.jar hibernate-processor-7.0.0-SNAPSHOT-sources.jar hibernate-proxool-7.0.0-SNAPSHOT-sources.jar hibernate-spatial-7.0.0-SNAPSHOT-sources.jar hibernate-testing-7.0.0-SNAPSHOT-sources.jar hibernate-ucp-7.0.0-SNAPSHOT-sources.jar hibernate-vector-7.0.0-SNAPSHOT-sources.jar hibernate-vibur-7.0.0-SNAPSHOT-sources.jar hibernate-enhance-maven-plugin-7.0.0-SNAPSHOT-sources.jar"

# see what caused the mismatch in the checksum by executing the following diffscope commands
# diffoscope out/build1/org/hibernate/orm/hibernate-agroal/7.0.0-SNAPSHOT/hibernate-agroal-7.0.0-SNAPSHOT-sources.jar out/build2/org/hibernate/orm/hibernate-agroal/7.0.0-SNAPSHOT/hibernate-agroal-7.0.0-SNAPSHOT-sources.jar
# diffoscope out/build1/org/hibernate/orm/hibernate-ant/7.0.0-SNAPSHOT/hibernate-ant-7.0.0-SNAPSHOT-sources.jar out/build2/org/hibernate/orm/hibernate-ant/7.0.0-SNAPSHOT/hibernate-ant-7.0.0-SNAPSHOT-sources.jar
# diffoscope out/build1/org/hibernate/orm/hibernate-c3p0/7.0.0-SNAPSHOT/hibernate-c3p0-7.0.0-SNAPSHOT-sources.jar out/build2/org/hibernate/orm/hibernate-c3p0/7.0.0-SNAPSHOT/hibernate-c3p0-7.0.0-SNAPSHOT-sources.jar
# diffoscope out/build1/org/hibernate/orm/hibernate-community-dialects/7.0.0-SNAPSHOT/hibernate-community-dialects-7.0.0-SNAPSHOT-sources.jar out/build2/org/hibernate/orm/hibernate-community-dialects/7.0.0-SNAPSHOT/hibernate-community-dialects-7.0.0-SNAPSHOT-sources.jar
# diffoscope out/build1/org/hibernate/orm/hibernate-core/7.0.0-SNAPSHOT/hibernate-core-7.0.0-SNAPSHOT.jar out/build2/org/hibernate/orm/hibernate-core/7.0.0-SNAPSHOT/hibernate-core-7.0.0-SNAPSHOT.jar
# diffoscope out/build1/org/hibernate/orm/hibernate-core/7.0.0-SNAPSHOT/hibernate-core-7.0.0-SNAPSHOT-sources.jar out/build2/org/hibernate/orm/hibernate-core/7.0.0-SNAPSHOT/hibernate-core-7.0.0-SNAPSHOT-sources.jar
# diffoscope out/build1/org/hibernate/orm/hibernate-envers/7.0.0-SNAPSHOT/hibernate-envers-7.0.0-SNAPSHOT-sources.jar out/build2/org/hibernate/orm/hibernate-envers/7.0.0-SNAPSHOT/hibernate-envers-7.0.0-SNAPSHOT-sources.jar
# diffoscope out/build1/org/hibernate/orm/hibernate-graalvm/7.0.0-SNAPSHOT/hibernate-graalvm-7.0.0-SNAPSHOT-sources.jar out/build2/org/hibernate/orm/hibernate-graalvm/7.0.0-SNAPSHOT/hibernate-graalvm-7.0.0-SNAPSHOT-sources.jar
# diffoscope out/build1/org/hibernate/orm/hibernate-gradle-plugin/7.0.0-SNAPSHOT/hibernate-gradle-plugin-7.0.0-SNAPSHOT.jar out/build2/org/hibernate/orm/hibernate-gradle-plugin/7.0.0-SNAPSHOT/hibernate-gradle-plugin-7.0.0-SNAPSHOT.jar
# diffoscope out/build1/org/hibernate/orm/hibernate-gradle-plugin/7.0.0-SNAPSHOT/hibernate-gradle-plugin-7.0.0-SNAPSHOT.module out/build2/org/hibernate/orm/hibernate-gradle-plugin/7.0.0-SNAPSHOT/hibernate-gradle-plugin-7.0.0-SNAPSHOT.module
# diffoscope out/build1/org/hibernate/orm/hibernate-gradle-plugin/7.0.0-SNAPSHOT/hibernate-gradle-plugin-7.0.0-SNAPSHOT-sources.jar out/build2/org/hibernate/orm/hibernate-gradle-plugin/7.0.0-SNAPSHOT/hibernate-gradle-plugin-7.0.0-SNAPSHOT-sources.jar
# diffoscope out/build1/org/hibernate/orm/hibernate-hikaricp/7.0.0-SNAPSHOT/hibernate-hikaricp-7.0.0-SNAPSHOT-sources.jar out/build2/org/hibernate/orm/hibernate-hikaricp/7.0.0-SNAPSHOT/hibernate-hikaricp-7.0.0-SNAPSHOT-sources.jar
# diffoscope out/build1/org/hibernate/orm/hibernate-jcache/7.0.0-SNAPSHOT/hibernate-jcache-7.0.0-SNAPSHOT-sources.jar out/build2/org/hibernate/orm/hibernate-jcache/7.0.0-SNAPSHOT/hibernate-jcache-7.0.0-SNAPSHOT-sources.jar
# diffoscope out/build1/org/hibernate/orm/hibernate-jfr/7.0.0-SNAPSHOT/hibernate-jfr-7.0.0-SNAPSHOT-sources.jar out/build2/org/hibernate/orm/hibernate-jfr/7.0.0-SNAPSHOT/hibernate-jfr-7.0.0-SNAPSHOT-sources.jar
# diffoscope out/build1/org/hibernate/orm/hibernate-micrometer/7.0.0-SNAPSHOT/hibernate-micrometer-7.0.0-SNAPSHOT-sources.jar out/build2/org/hibernate/orm/hibernate-micrometer/7.0.0-SNAPSHOT/hibernate-micrometer-7.0.0-SNAPSHOT-sources.jar
# diffoscope out/build1/org/hibernate/orm/hibernate-processor/7.0.0-SNAPSHOT/hibernate-processor-7.0.0-SNAPSHOT-sources.jar out/build2/org/hibernate/orm/hibernate-processor/7.0.0-SNAPSHOT/hibernate-processor-7.0.0-SNAPSHOT-sources.jar
# diffoscope out/build1/org/hibernate/orm/hibernate-proxool/7.0.0-SNAPSHOT/hibernate-proxool-7.0.0-SNAPSHOT-sources.jar out/build2/org/hibernate/orm/hibernate-proxool/7.0.0-SNAPSHOT/hibernate-proxool-7.0.0-SNAPSHOT-sources.jar
# diffoscope out/build1/org/hibernate/orm/hibernate-spatial/7.0.0-SNAPSHOT/hibernate-spatial-7.0.0-SNAPSHOT-sources.jar out/build2/org/hibernate/orm/hibernate-spatial/7.0.0-SNAPSHOT/hibernate-spatial-7.0.0-SNAPSHOT-sources.jar
# diffoscope out/build1/org/hibernate/orm/hibernate-testing/7.0.0-SNAPSHOT/hibernate-testing-7.0.0-SNAPSHOT-sources.jar out/build2/org/hibernate/orm/hibernate-testing/7.0.0-SNAPSHOT/hibernate-testing-7.0.0-SNAPSHOT-sources.jar
# diffoscope out/build1/org/hibernate/orm/hibernate-ucp/7.0.0-SNAPSHOT/hibernate-ucp-7.0.0-SNAPSHOT-sources.jar out/build2/org/hibernate/orm/hibernate-ucp/7.0.0-SNAPSHOT/hibernate-ucp-7.0.0-SNAPSHOT-sources.jar
# diffoscope out/build1/org/hibernate/orm/hibernate-vector/7.0.0-SNAPSHOT/hibernate-vector-7.0.0-SNAPSHOT-sources.jar out/build2/org/hibernate/orm/hibernate-vector/7.0.0-SNAPSHOT/hibernate-vector-7.0.0-SNAPSHOT-sources.jar
# diffoscope out/build1/org/hibernate/orm/hibernate-vibur/7.0.0-SNAPSHOT/hibernate-vibur-7.0.0-SNAPSHOT-sources.jar out/build2/org/hibernate/orm/hibernate-vibur/7.0.0-SNAPSHOT/hibernate-vibur-7.0.0-SNAPSHOT-sources.jar
# diffoscope out/build1/org/hibernate/orm/tooling/hibernate-enhance-maven-plugin/7.0.0-SNAPSHOT/hibernate-enhance-maven-plugin-7.0.0-SNAPSHOT-sources.jar out/build2/org/hibernate/orm/tooling/hibernate-enhance-maven-plugin/7.0.0-SNAPSHOT/hibernate-enhance-maven-plugin-7.0.0-SNAPSHOT-sources.jar
```

The problem with core is caused by attribute groups in hbm mapping being rendered in a random order resulting in this kind of differences between jars:

```diff
--- out/build1/org/hibernate/orm/hibernate-core/7.0.0-SNAPSHOT/hibernate-core-7.0.0-SNAPSHOT.jar
+++ out/build2/org/hibernate/orm/hibernate-core/7.0.0-SNAPSHOT/hibernate-core-7.0.0-SNAPSHOT.jar
├── zipinfo -v {}
│ @@ -18909,15 +18909,15 @@
│    minimum file system compatibility required:     MS-DOS, OS/2 or NT FAT
│    minimum software version required to extract:   2.0
│    compression method:                             deflated
│    compression sub-type (deflation):               normal
│    file security status:                           not encrypted
│    extended local header:                          yes
│    file last modified on (DOS date/time):          1980 Feb 1 00:00:00
│ -  32-bit CRC value (hex):                         bc8f81e3
│ +  32-bit CRC value (hex):                         128f25df
│    compressed size:                                3932 bytes
│    uncompressed size:                              15411 bytes
│    length of filename:                             52 characters
│    length of extra field:                          0 bytes
│    length of file comment:                         0 characters
│    disk number on which file begins:               disk 1
│    apparent file type:                             binary
├── org/hibernate/boot/jaxb/hbm/spi/JaxbHbmMapType.class
│ ├── procyon -ec {}
│ │ @@ -70,22 +70,14 @@
│ │      protected String node;
│ │      @XmlAttribute(name = "order-by")
│ │      protected String orderBy;
│ │      @XmlAttribute(name = "outer-join")
│ │      protected JaxbHbmOuterJoinEnum outerJoin;
│ │      @XmlAttribute(name = "sort")
│ │      protected String sort;
│ │ -    @XmlAttribute(name = "schema")
│ │ -    protected String schema;
│ │ -    @XmlAttribute(name = "catalog")
│ │ -    protected String catalog;
│ │ -    @XmlAttribute(name = "table")
│ │ -    protected String table;
│ │ -    @XmlAttribute(name = "subselect")
│ │ -    protected String subselectAttribute;
│ │      @XmlAttribute(name = "name", required = true)
│ │      protected String name;
│ │      @XmlAttribute(name = "access")
│ │      protected String access;
│ │      @XmlAttribute(name = "check")
│ │      protected String check;
│ │      @XmlAttribute(name = "where")
│ │ @@ -100,14 +92,22 @@
│ │      protected Boolean mutable;
│ │      @XmlAttribute(name = "optimistic-lock")
│ │      protected Boolean optimisticLock;
│ │      @XmlAttribute(name = "collection-type")
│ │      protected String collectionType;
│ │      @XmlAttribute(name = "persister")
│ │      protected String persister;
│ │ +    @XmlAttribute(name = "schema")
│ │ +    protected String schema;
│ │ +    @XmlAttribute(name = "catalog")
│ │ +    protected String catalog;
│ │ +    @XmlAttribute(name = "table")
│ │ +    protected String table;
│ │ +    @XmlAttribute(name = "subselect")
│ │ +    protected String subselectAttribute;
│ │      
│ │      public String getSubselect() {
│ │          return this.subselect;
│ │      }
│ │      
│ │      public void setSubselect(final String value) {
│ │          this.subselect = value;
│ │ @@ -342,46 +342,14 @@
│ │          return this.sort;
│ │      }
│ │      
│ │      public void setSort(final String value) {
│ │          this.sort = value;
│ │      }
│ │      
│ │ -    public String getSchema() {
│ │ -        return this.schema;
│ │ -    }
│ │ -    
│ │ -    public void setSchema(final String value) {
│ │ -        this.schema = value;
│ │ -    }
│ │ -    
│ │ -    public String getCatalog() {
│ │ -        return this.catalog;
│ │ -    }
│ │ -    
│ │ -    public void setCatalog(final String value) {
│ │ -        this.catalog = value;
│ │ -    }
│ │ -    
│ │ -    public String getTable() {
│ │ -        return this.table;
│ │ -    }
│ │ -    
│ │ -    public void setTable(final String value) {
│ │ -        this.table = value;
│ │ -    }
│ │ -    
│ │ -    public String getSubselectAttribute() {
│ │ -        return this.subselectAttribute;
│ │ -    }
│ │ -    
│ │ -    public void setSubselectAttribute(final String value) {
│ │ -        this.subselectAttribute = value;
│ │ -    }
│ │ -    
│ │      public String getName() {
│ │          return this.name;
│ │      }
│ │      
│ │      public void setName(final String value) {
│ │          this.name = value;
│ │      }
│ │ @@ -464,8 +432,40 @@
│ │      public String getPersister() {
│ │          return this.persister;
│ │      }
│ │      
│ │      public void setPersister(final String value) {
│ │          this.persister = value;
│ │      }
│ │ +    
│ │ +    public String getSchema() {
│ │ +        return this.schema;
│ │ +    }
│ │ +    
│ │ +    public void setSchema(final String value) {
│ │ +        this.schema = value;
│ │ +    }
│ │ +    
│ │ +    public String getCatalog() {
│ │ +        return this.catalog;
│ │ +    }
│ │ +    
│ │ +    public void setCatalog(final String value) {
│ │ +        this.catalog = value;
│ │ +    }
│ │ +    
│ │ +    public String getTable() {
│ │ +        return this.table;
│ │ +    }
│ │ +    
│ │ +    public void setTable(final String value) {
│ │ +        this.table = value;
│ │ +    }
│ │ +    
│ │ +    public String getSubselectAttribute() {
│ │ +        return this.subselectAttribute;
│ │ +    }
│ │ +    
│ │ +    public void setSubselectAttribute(final String value) {
│ │ +        this.subselectAttribute = value;
│ │ +    }
│ │  }

```

With the changes, all seems to be matching (at least that's what the script says 😃)

@sebersole let me know if you think we should do something differently 😃. (probably best to look by commit since the JBoss logging update generates a lot of noise)

I didn't test if all works after the rebase, will take a look tomorrow. Otherwise it is a copy of the https://github.com/hibernate/hibernate-orm/pull/8784

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
