### PR TITLE
HHH-18500 Gradle plugin crashes on module-info when extended enhancement is set

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/bytecode/enhance/internal/bytebuddy/PersistentAttributeTransformer.java
+++ b/hibernate-core/src/main/java/org/hibernate/bytecode/enhance/internal/bytebuddy/PersistentAttributeTransformer.java
@@ -145,7 +145,10 @@ final class PersistentAttributeTransformer implements AsmVisitorWrapper.ForDecla
 		}
 		TypeDefinition managedCtSuperclass = managedCtClass.getSuperClass();
 
-		if ( enhancementContext.isEntityClass( managedCtSuperclass.asErasure() ) ) {
+		// If managedCtSuperclass is null, managedCtClass can be either interface or module-info.
+		// Interfaces are already filtered-out, and module-info does not have any fields to enhance
+		// so we can safely return empty list.
+		if ( managedCtSuperclass == null || enhancementContext.isEntityClass( managedCtSuperclass.asErasure() ) ) {
 			return Collections.emptyList();
 		}
 		else if ( !enhancementContext.isMappedSuperclassClass( managedCtSuperclass.asErasure() ) ) {

--- a/tooling/hibernate-gradle-plugin/src/test/java/org/hibernate/orm/tooling/gradle/ModuleInfoProjectTests.java
+++ b/tooling/hibernate-gradle-plugin/src/test/java/org/hibernate/orm/tooling/gradle/ModuleInfoProjectTests.java
@@ -1,0 +1,53 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html.
+ */
+package org.hibernate.orm.tooling.gradle;
+
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+
+/**
+ * Basic functional tests
+ *
+ * @author Steve Ebersole
+ */
+class ModuleInfoProjectTests extends TestsBase {
+
+	@Override
+	protected String getProjectName() {
+		return "simple-moduleinfo";
+	}
+
+	@Override
+	protected String getSourceSetName() {
+		return "main";
+	}
+
+	@Override
+	protected String getLanguageName() {
+		return "java";
+	}
+
+	@Override
+	protected String getCompileTaskName() {
+		return "compileJava";
+	}
+
+	@Test
+	@Override
+	public void testEnhancement(@TempDir Path projectDir) throws Exception {
+		super.testEnhancement( projectDir );
+	}
+
+	@Test
+	@Override
+	public void testEnhancementUpToDate(@TempDir Path projectDir) throws Exception {
+		super.testEnhancementUpToDate( projectDir );
+	}
+}

--- a/tooling/hibernate-gradle-plugin/src/test/resources/projects/simple-moduleinfo/build.gradle
+++ b/tooling/hibernate-gradle-plugin/src/test/resources/projects/simple-moduleinfo/build.gradle
@@ -1,0 +1,40 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html
+ */
+
+plugins {
+    id 'java'
+    id 'org.hibernate.orm'
+}
+
+repositories {
+    mavenCentral()
+
+    maven {
+        name 'jboss-snapshots-repository'
+        url 'https://repository.jboss.org/nexus/content/repositories/snapshots'
+    }
+}
+
+dependencies {
+    // NOTE : The version used here is irrelevant in terms of testing the plugin.
+    // We just need a resolvable version
+    implementation 'org.hibernate.orm:hibernate-core:6.1.0.Final'
+    implementation 'jakarta.annotation:jakarta.annotation-api:2.1.1'
+}
+
+hibernate {
+    useSameVersion = false
+    enhancement {
+        enableLazyInitialization.set(true)
+        lazyInitialization = true
+
+        enableDirtyTracking.set(true)
+        dirtyTracking = true
+
+        enableExtendedEnhancement.set(true)
+    }
+}

--- a/tooling/hibernate-gradle-plugin/src/test/resources/projects/simple-moduleinfo/src/main/java/TheEmbeddable.java
+++ b/tooling/hibernate-gradle-plugin/src/test/resources/projects/simple-moduleinfo/src/main/java/TheEmbeddable.java
@@ -1,0 +1,29 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html.
+ */
+import jakarta.persistence.Embeddable;
+
+@Embeddable
+public class TheEmbeddable {
+	private String valueOne;
+	private String valueTwo;
+
+	public String getValueOne() {
+		return valueOne;
+	}
+
+	public void setValueOne(String valueOne) {
+		this.valueOne = valueOne;
+	}
+
+	public String getValueTwo() {
+		return valueTwo;
+	}
+
+	public void setValueTwo(String valueTwo) {
+		this.valueTwo = valueTwo;
+	}
+}

--- a/tooling/hibernate-gradle-plugin/src/test/resources/projects/simple-moduleinfo/src/main/java/TheEntity.java
+++ b/tooling/hibernate-gradle-plugin/src/test/resources/projects/simple-moduleinfo/src/main/java/TheEntity.java
@@ -1,0 +1,88 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html.
+ */
+import jakarta.persistence.ElementCollection;
+import jakarta.persistence.Embedded;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+
+import org.hibernate.annotations.BatchSize;
+
+import java.util.Set;
+
+@Entity
+@BatchSize( size = 20 )
+public class TheEntity {
+	@Id
+	private Integer id;
+	private String name;
+
+	@Embedded
+	private TheEmbeddable theEmbeddable;
+
+	@ManyToOne
+	@JoinColumn
+	private TheEntity theManyToOne;
+
+	@OneToMany( mappedBy = "theManyToOne" )
+	private Set<TheEntity> theOneToMany;
+
+	@ElementCollection
+	@JoinColumn( name = "owner_id" )
+	private Set<TheEmbeddable> theEmbeddableCollection;
+
+
+	public Integer getId() {
+		return id;
+	}
+
+	public void setId(Integer id) {
+		this.id = id;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+
+	public TheEmbeddable getTheEmbeddable() {
+		return theEmbeddable;
+	}
+
+	public void setTheEmbeddable(TheEmbeddable theEmbeddable) {
+		this.theEmbeddable = theEmbeddable;
+	}
+
+	public TheEntity getTheManyToOne() {
+		return theManyToOne;
+	}
+
+	public void setTheManyToOne(TheEntity theManyToOne) {
+		this.theManyToOne = theManyToOne;
+	}
+
+	public Set<TheEntity> getTheOneToMany() {
+		return theOneToMany;
+	}
+
+	public void setTheOneToMany(Set<TheEntity> theOneToMany) {
+		this.theOneToMany = theOneToMany;
+	}
+
+	public Set<TheEmbeddable> getTheEmbeddableCollection() {
+		return theEmbeddableCollection;
+	}
+
+	public void setTheEmbeddableCollection(Set<TheEmbeddable> theEmbeddableCollection) {
+		this.theEmbeddableCollection = theEmbeddableCollection;
+	}
+}

--- a/tooling/hibernate-gradle-plugin/src/test/resources/projects/simple-moduleinfo/src/main/java/module-info.java
+++ b/tooling/hibernate-gradle-plugin/src/test/resources/projects/simple-moduleinfo/src/main/java/module-info.java
@@ -1,0 +1,5 @@
+module test {
+    requires org.hibernate.orm.core;
+    requires jakarta.persistence;
+    requires jakarta.annotation;
+}


### PR DESCRIPTION
See Jira issue [HHH-18500](https://hibernate.atlassian.net/browse/HHH-18500)

When Hibernate Gradle plugin is used with extended enhancement set to true, it will throw NPE on module-info. This is caused by fact that module-info does not have super class. Solution is simple null check to avoid NPE.



<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------


[HHH-18500]: https://hibernate.atlassian.net/browse/HHH-18500?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ