### PR TITLE
Tests with current_timestamp requires Dialect UsesStandardCurrentTimestampFunction feature

### DIFF
--- a/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/InformixDialect.java
+++ b/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/InformixDialect.java
@@ -661,6 +661,11 @@ public class InformixDialect extends Dialect {
 		appender.appendSql( datetimeFormat( format ).result() );
 	}
 
+	@Override
+	public boolean supportsStandardCurrentTimestampFunction() {
+		return false;
+	}
+
 	public static Replacer datetimeFormat(String format) {
 		return new Replacer( format, "'", "" )
 				.replace("%", "%%")

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/generated/ComplexValueGenerationTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/generated/ComplexValueGenerationTests.java
@@ -25,15 +25,14 @@ import org.hibernate.annotations.ColumnDefault;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.Generated;
 import org.hibernate.annotations.UpdateTimestamp;
-import org.hibernate.dialect.MySQLDialect;
-import org.hibernate.dialect.SybaseDialect;
-import org.hibernate.dialect.TiDBDialect;
 import org.hibernate.generator.EventType;
 
+
+import org.hibernate.testing.orm.junit.DialectFeatureChecks;
 import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.RequiresDialectFeature;
 import org.hibernate.testing.orm.junit.SessionFactory;
 import org.hibernate.testing.orm.junit.SessionFactoryScope;
-import org.hibernate.testing.orm.junit.SkipForDialect;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
@@ -47,9 +46,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 /**
  * @author Steve Ebersole
  */
-@SkipForDialect(dialectClass = SybaseDialect.class, matchSubTypes = true, reason = "CURRENT_TIMESTAMP not supported as default value in Sybase")
-@SkipForDialect(dialectClass = MySQLDialect.class, reason = "See HHH-10196")
-@SkipForDialect(dialectClass = TiDBDialect.class, reason = "See HHH-10196")
+
+@RequiresDialectFeature( feature = DialectFeatureChecks.CurrentTimestampHasMicrosecondPrecision.class )
+@RequiresDialectFeature( feature = DialectFeatureChecks.UsesStandardCurrentTimestampFunction.class )
 @DomainModel( annotatedClasses = ComplexValueGenerationTests.AuditedEntity.class )
 @SessionFactory
 @SuppressWarnings("JUnitMalformedDeclaration")

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/generated/DatabaseValueGenerationTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/generated/DatabaseValueGenerationTest.java
@@ -13,13 +13,11 @@ import java.util.EnumSet;
 
 import org.hibernate.annotations.ValueGenerationType;
 import org.hibernate.dialect.Dialect;
-import org.hibernate.dialect.SybaseDialect;
 import org.hibernate.generator.EventType;
 import org.hibernate.generator.EventTypeSets;
 import org.hibernate.generator.OnExecutionGenerator;
 import org.hibernate.orm.test.jpa.BaseEntityManagerFunctionalTestCase;
 
-import org.hibernate.testing.SkipForDialect;
 import org.junit.Test;
 
 import jakarta.persistence.Column;
@@ -32,7 +30,6 @@ import static org.hibernate.testing.transaction.TransactionUtil.doInJPA;
 /**
  * @author Vlad Mihalcea
  */
-@SkipForDialect(value = SybaseDialect.class, comment = "Sybase doesn't seem to support current_timestamp")
 public class DatabaseValueGenerationTest extends BaseEntityManagerFunctionalTestCase {
 
 	@Override

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/generated/DefaultGeneratedValueTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/generated/DefaultGeneratedValueTest.java
@@ -25,21 +25,20 @@ import org.hibernate.annotations.ColumnDefault;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.Generated;
 import org.hibernate.annotations.UpdateTimestamp;
-import org.hibernate.dialect.MySQLDialect;
-import org.hibernate.dialect.SybaseDialect;
-import org.hibernate.dialect.TiDBDialect;
 import org.hibernate.generator.EventType;
 import org.hibernate.generator.internal.CurrentTimestampGeneration;
 import org.hibernate.orm.test.annotations.MutableClock;
 import org.hibernate.orm.test.annotations.MutableClockSettingProvider;
 
+
+import org.hibernate.testing.orm.junit.DialectFeatureChecks;
 import org.hibernate.testing.orm.junit.DomainModel;
 import org.hibernate.testing.orm.junit.JiraKey;
+import org.hibernate.testing.orm.junit.RequiresDialectFeature;
 import org.hibernate.testing.orm.junit.ServiceRegistry;
 import org.hibernate.testing.orm.junit.SessionFactory;
 import org.hibernate.testing.orm.junit.SessionFactoryScope;
 import org.hibernate.testing.orm.junit.SettingProvider;
-import org.hibernate.testing.orm.junit.SkipForDialect;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -60,9 +59,8 @@ import static org.junit.Assert.assertTrue;
  * @author Steve Ebersole
  * @author Gunnar Morling
  */
-@SkipForDialect( dialectClass = SybaseDialect.class, matchSubTypes = true, reason = "CURRENT_TIMESTAMP not supported as default value in Sybase" )
-@SkipForDialect( dialectClass = MySQLDialect.class, reason = "See HHH-10196" )
-@SkipForDialect( dialectClass = TiDBDialect.class, reason = "See HHH-10196" )
+@RequiresDialectFeature( feature = DialectFeatureChecks.CurrentTimestampHasMicrosecondPrecision.class )
+@RequiresDialectFeature( feature = DialectFeatureChecks.UsesStandardCurrentTimestampFunction.class )
 @ServiceRegistry(settingProviders = @SettingProvider(settingName = CurrentTimestampGeneration.CLOCK_SETTING_NAME, provider = MutableClockSettingProvider.class))
 @DomainModel( annotatedClasses = DefaultGeneratedValueTest.TheEntity.class )
 @SessionFactory

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/generated/temporals/MultipleGeneratedValuesTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/generated/temporals/MultipleGeneratedValuesTests.java
@@ -37,7 +37,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 @DomainModel( annotatedClasses = MultipleGeneratedValuesTests.GeneratedInstantEntity.class )
 @SessionFactory
 @RequiresDialectFeature(feature = DialectFeatureChecks.CurrentTimestampHasMicrosecondPrecision.class, comment = "Without this, we might not see an update to the timestamp")
-@SkipForDialect( dialectClass = SybaseASEDialect.class, matchSubTypes = true, reason = "CURRENT_TIMESTAMP not supported in insert/update in Sybase ASE. Also see https://groups.google.com/g/comp.databases.sybase/c/j-RxPnF3img" )
+@RequiresDialectFeature( feature = DialectFeatureChecks.UsesStandardCurrentTimestampFunction.class )
 @SkipForDialect( dialectClass = SQLServerDialect.class, matchSubTypes = true, reason = "CURRENT_TIMESTAMP has millisecond precision" )
 public class MultipleGeneratedValuesTests {
 	@Test

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/generated/temporals/ProposedGeneratedTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/generated/temporals/ProposedGeneratedTests.java
@@ -9,7 +9,6 @@ package org.hibernate.orm.test.mapping.generated.temporals;
 import java.time.Instant;
 
 import org.hibernate.HibernateError;
-import org.hibernate.dialect.SybaseASEDialect;
 import org.hibernate.generator.EventType;
 
 import org.hibernate.testing.orm.junit.DialectFeatureChecks;
@@ -17,7 +16,6 @@ import org.hibernate.testing.orm.junit.DomainModel;
 import org.hibernate.testing.orm.junit.RequiresDialectFeature;
 import org.hibernate.testing.orm.junit.SessionFactory;
 import org.hibernate.testing.orm.junit.SessionFactoryScope;
-import org.hibernate.testing.orm.junit.SkipForDialect;
 import org.junit.jupiter.api.Test;
 
 import jakarta.persistence.Entity;
@@ -34,7 +32,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 @DomainModel( annotatedClasses = ProposedGeneratedTests.GeneratedInstantEntity.class )
 @SessionFactory
 @RequiresDialectFeature(feature = DialectFeatureChecks.CurrentTimestampHasMicrosecondPrecision.class, comment = "Without this, we might not see an update to the timestamp")
-@SkipForDialect( dialectClass = SybaseASEDialect.class, matchSubTypes = true, reason = "CURRENT_TIMESTAMP not supported in insert/update in Sybase ASE. Also see https://groups.google.com/g/comp.databases.sybase/c/j-RxPnF3img" )
+@RequiresDialectFeature( feature = DialectFeatureChecks.UsesStandardCurrentTimestampFunction.class )
 public class ProposedGeneratedTests {
 	@Test
 	public void test(SessionFactoryScope scope) throws InterruptedException {

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/query/hql/FunctionTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/query/hql/FunctionTests.java
@@ -9,6 +9,7 @@ package org.hibernate.orm.test.query.hql;
 import org.hamcrest.Matchers;
 import org.hibernate.QueryException;
 import org.hibernate.community.dialect.AltibaseDialect;
+import org.hibernate.community.dialect.InformixDialect;
 import org.hibernate.dialect.CockroachDialect;
 import org.hibernate.dialect.DB2Dialect;
 import org.hibernate.community.dialect.DerbyDialect;
@@ -568,6 +569,7 @@ public class FunctionTests {
 
 	@Test
 	@SkipForDialect(dialectClass = DerbyDialect.class, reason = "Derby doesn't support any form of date truncation")
+	@SkipForDialect(dialectClass = InformixDialect.class, reason = "Informix doesn't support any form of date truncation")
 	public void testDateTruncFunction(SessionFactoryScope scope) {
 		scope.inTransaction(
 				session -> {

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/temporal/TimestampPropertyTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/temporal/TimestampPropertyTest.java
@@ -12,15 +12,14 @@ import java.util.Date;
 
 import org.hibernate.annotations.ColumnDefault;
 import org.hibernate.annotations.Generated;
-import org.hibernate.dialect.MySQLDialect;
-import org.hibernate.dialect.SybaseDialect;
 import org.hibernate.query.Query;
 import org.hibernate.type.StandardBasicTypes;
 
+import org.hibernate.testing.orm.junit.DialectFeatureChecks;
 import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.RequiresDialectFeature;
 import org.hibernate.testing.orm.junit.SessionFactory;
 import org.hibernate.testing.orm.junit.SessionFactoryScope;
-import org.hibernate.testing.orm.junit.SkipForDialect;
 import org.junit.jupiter.api.Test;
 
 import jakarta.persistence.GeneratedValue;
@@ -43,8 +42,8 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
  * @author Gail Badner
  */
 @SuppressWarnings("JUnitMalformedDeclaration")
-@SkipForDialect(dialectClass = MySQLDialect.class, matchSubTypes = true, reason = "CURRENT_TIMESTAMP not supported as default value in MySQL")
-@SkipForDialect(dialectClass = SybaseDialect.class, matchSubTypes = true, reason = "CURRENT_TIMESTAMP not supported as default value in Sybase")
+@RequiresDialectFeature(feature = DialectFeatureChecks.CurrentTimestampHasMicrosecondPrecision.class, comment = "Without this, we might not see an update to the timestamp")
+@RequiresDialectFeature( feature = DialectFeatureChecks.UsesStandardCurrentTimestampFunction.class )
 @DomainModel(
 		annotatedClasses = TimestampPropertyTest.Entity.class
 )


### PR DESCRIPTION
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
