### PR TITLE
HHH-18337 SequenceStyleGenerator not respecting physical naming strategy

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/boot/model/internal/GeneratorBinder.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/internal/GeneratorBinder.java
@@ -560,7 +560,7 @@ public class GeneratorBinder {
 
 	/**
 	 * If the given {@link Generator} also implements {@link Configurable},
-	 * call its {@link Configurable#configure(Type, Properties, ServiceRegistry)
+	 * call its {@link Configurable#configure(GeneratorCreationContext, Properties)
 	 * configure()} method.
 	 */
 	private static void callConfigure(
@@ -568,15 +568,14 @@ public class GeneratorBinder {
 			Generator generator,
 			Map<String, Object> configuration,
 			SimpleValue identifierValue) {
-		if ( generator instanceof Configurable ) {
-			final Configurable configurable = (Configurable) generator;
+		if ( generator instanceof final Configurable configurable ) {
 			final Properties parameters = collectParameters(
 					identifierValue,
 					creationContext.getDatabase().getDialect(),
 					creationContext.getRootClass(),
 					configuration
 			);
-			configurable.configure( identifierValue.getType(), parameters, creationContext.getServiceRegistry() );
+			configurable.configure( creationContext, parameters );
 		}
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/boot/model/internal/GeneratorParameters.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/internal/GeneratorParameters.java
@@ -15,6 +15,7 @@ import org.hibernate.cfg.AvailableSettings;
 import org.hibernate.dialect.Dialect;
 import org.hibernate.engine.config.spi.ConfigurationService;
 import org.hibernate.engine.config.spi.StandardConverters;
+import org.hibernate.generator.GeneratorCreationContext;
 import org.hibernate.id.Configurable;
 import org.hibernate.id.IdentifierGenerator;
 import org.hibernate.id.OptimizableGenerator;
@@ -38,7 +39,7 @@ import java.util.Properties;
 
 /**
  * Responsible for setting up the parameters which are passed to
- * {@link Configurable#configure(Type, Properties, ServiceRegistry)}
+ * {@link Configurable#configure(GeneratorCreationContext, Properties)}
  * when a {@link Configurable} generator is instantiated.
  *
  * @since 7.0
@@ -51,7 +52,7 @@ public class GeneratorParameters {
 
 	/**
 	 * Collect the parameters which should be passed to
-	 * {@link Configurable#configure(Type, Properties, ServiceRegistry)}.
+	 * {@link Configurable#configure(GeneratorCreationContext, Properties)}.
 	 */
 	public static Properties collectParameters(
 			SimpleValue identifierValue,

--- a/hibernate-core/src/main/java/org/hibernate/generator/GeneratorCreationContext.java
+++ b/hibernate-core/src/main/java/org/hibernate/generator/GeneratorCreationContext.java
@@ -12,6 +12,7 @@ import org.hibernate.mapping.PersistentClass;
 import org.hibernate.mapping.Property;
 import org.hibernate.mapping.RootClass;
 import org.hibernate.service.ServiceRegistry;
+import org.hibernate.type.Type;
 
 /**
  * An object passed as a parameter to the constructor or
@@ -34,4 +35,7 @@ public interface GeneratorCreationContext {
 	RootClass getRootClass();
 
 	Property getProperty();
+	default Type getType() {
+		return getProperty().getType();
+	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/id/Configurable.java
+++ b/hibernate-core/src/main/java/org/hibernate/id/Configurable.java
@@ -11,6 +11,7 @@ import java.util.Properties;
 import org.hibernate.MappingException;
 import org.hibernate.boot.model.relational.Database;
 import org.hibernate.boot.model.relational.SqlStringGenerationContext;
+import org.hibernate.generator.GeneratorCreationContext;
 import org.hibernate.service.ServiceRegistry;
 import org.hibernate.type.Type;
 
@@ -22,6 +23,13 @@ import org.hibernate.type.Type;
  */
 public interface Configurable {
 	/**
+	 * @deprecated Use {@link #configure(GeneratorCreationContext, Properties)} instead
+	 */
+	@Deprecated( since = "7.0", forRemoval = true )
+	default void configure(Type type, Properties parameters, ServiceRegistry serviceRegistry) throws MappingException {
+	}
+
+	/**
 	 * Configure this instance, given the value of parameters
 	 * specified by the user as XML {@code <param>} elements and
 	 * {@link org.hibernate.annotations.Parameter @Parameter}
@@ -32,13 +40,14 @@ public interface Configurable {
 	 * then this method is always called before
 	 * {@link org.hibernate.boot.model.relational.ExportableProducer#registerExportables(Database)},
 	 *
-	 * @param type The id property type descriptor
+	 * @param creationContext Access to the generator creation context
 	 * @param parameters param values, keyed by parameter name
-	 * @param serviceRegistry Access to service that may be needed.
 	 *
 	 * @throws MappingException when there's something wrong with the given parameters
 	 */
-	void configure(Type type, Properties parameters, ServiceRegistry serviceRegistry) throws MappingException;
+	default void configure(GeneratorCreationContext creationContext, Properties parameters) throws MappingException {
+		configure( creationContext.getType(), parameters, creationContext.getServiceRegistry() );
+	};
 
 	/**
 	 * Initializes this instance, pre-generating SQL if necessary.

--- a/hibernate-core/src/main/java/org/hibernate/id/ForeignGenerator.java
+++ b/hibernate-core/src/main/java/org/hibernate/id/ForeignGenerator.java
@@ -10,6 +10,7 @@ import java.util.Properties;
 
 import org.hibernate.MappingException;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
+import org.hibernate.generator.GeneratorCreationContext;
 import org.hibernate.service.ServiceRegistry;
 import org.hibernate.type.Type;
 
@@ -68,7 +69,7 @@ public class ForeignGenerator implements IdentifierGenerator {
 
 
 	@Override
-	public void configure(Type type, Properties parameters, ServiceRegistry serviceRegistry) throws MappingException {
+	public void configure(GeneratorCreationContext creationContext, Properties parameters) throws MappingException {
 		propertyName = parameters.getProperty( PROPERTY );
 		entityName = parameters.getProperty( ENTITY_NAME );
 		if ( propertyName==null ) {

--- a/hibernate-core/src/main/java/org/hibernate/id/IdentifierGenerator.java
+++ b/hibernate-core/src/main/java/org/hibernate/id/IdentifierGenerator.java
@@ -17,6 +17,8 @@ import org.hibernate.boot.model.relational.SqlStringGenerationContext;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.generator.EventType;
 import org.hibernate.generator.EventTypeSets;
+import org.hibernate.generator.Generator;
+import org.hibernate.generator.GeneratorCreationContext;
 import org.hibernate.service.ServiceRegistry;
 import org.hibernate.generator.BeforeExecutionGenerator;
 import org.hibernate.type.Type;
@@ -39,7 +41,7 @@ import static org.hibernate.generator.EventTypeSets.INSERT_ONLY;
  * {@code ExportableProducer}, in case the implementation needs to export
  * objects to the database as part of the process of schema export.
  * <p>
- * The {@link #configure(Type, Properties, ServiceRegistry)} method accepts
+ * The {@link #configure(GeneratorCreationContext, Properties)} method accepts
  * a properties object containing named values. These include:
  * <ul>
  * <li>several "standard" parameters with keys defined as static members of
@@ -104,7 +106,7 @@ public interface IdentifierGenerator extends BeforeExecutionGenerator, Exportabl
 	 * for example, a sequence or tables.
 	 * <p>
 	 * This method is called just once, after
-	 * {@link #configure(Type, Properties, ServiceRegistry)}.
+	 * {@link #configure(GeneratorCreationContext, Properties)}.
 	 *
 	 * @param database The database instance
 	 */

--- a/hibernate-core/src/main/java/org/hibernate/id/IncrementGenerator.java
+++ b/hibernate-core/src/main/java/org/hibernate/id/IncrementGenerator.java
@@ -22,6 +22,7 @@ import org.hibernate.dialect.Dialect;
 import org.hibernate.engine.jdbc.env.spi.IdentifierHelper;
 import org.hibernate.engine.jdbc.env.spi.JdbcEnvironment;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
+import org.hibernate.generator.GeneratorCreationContext;
 import org.hibernate.internal.CoreLogging;
 import org.hibernate.internal.CoreMessageLogger;
 import org.hibernate.service.ServiceRegistry;
@@ -85,10 +86,10 @@ public class IncrementGenerator implements IdentifierGenerator {
 	}
 
 	@Override
-	public void configure(Type type, Properties parameters, ServiceRegistry serviceRegistry) throws MappingException {
-		returnClass = type.getReturnedClass();
+	public void configure(GeneratorCreationContext creationContext, Properties parameters) throws MappingException {
+		returnClass = creationContext.getType().getReturnedClass();
 
-		final JdbcEnvironment jdbcEnvironment = serviceRegistry.requireService( JdbcEnvironment.class );
+		final JdbcEnvironment jdbcEnvironment = creationContext.getServiceRegistry().requireService( JdbcEnvironment.class );
 		final IdentifierHelper identifierHelper = jdbcEnvironment.getIdentifierHelper();
 
 		column = parameters.getProperty( COLUMN );

--- a/hibernate-core/src/main/java/org/hibernate/id/PersistentIdentifierGenerator.java
+++ b/hibernate-core/src/main/java/org/hibernate/id/PersistentIdentifierGenerator.java
@@ -8,6 +8,7 @@ package org.hibernate.id;
 
 import java.util.Properties;
 
+import org.hibernate.generator.GeneratorCreationContext;
 import org.hibernate.service.ServiceRegistry;
 import org.hibernate.type.Type;
 
@@ -15,7 +16,7 @@ import org.hibernate.type.Type;
  * An {@link IdentifierGenerator} that requires creation of database objects.
  * <p>
  * All instances have access to a special mapping parameter in their
- * {@link #configure(Type, Properties, ServiceRegistry)} method: schema
+ * {@link #configure(GeneratorCreationContext, Properties)} method: schema
  *
  * @author Gavin King
  * @author Steve Ebersole

--- a/hibernate-core/src/main/java/org/hibernate/id/PostInsertIdentifierGenerator.java
+++ b/hibernate-core/src/main/java/org/hibernate/id/PostInsertIdentifierGenerator.java
@@ -8,8 +8,9 @@ package org.hibernate.id;
 
 import org.hibernate.generator.EventType;
 import org.hibernate.generator.EventTypeSets;
-import org.hibernate.service.ServiceRegistry;
+import org.hibernate.generator.GeneratorCreationContext;
 import org.hibernate.generator.OnExecutionGenerator;
+import org.hibernate.service.ServiceRegistry;
 import org.hibernate.type.Type;
 
 import java.util.EnumSet;

--- a/hibernate-core/src/main/java/org/hibernate/id/SelectGenerator.java
+++ b/hibernate-core/src/main/java/org/hibernate/id/SelectGenerator.java
@@ -9,9 +9,9 @@ package org.hibernate.id;
 import java.util.Properties;
 
 import org.hibernate.dialect.Dialect;
+import org.hibernate.generator.GeneratorCreationContext;
 import org.hibernate.generator.OnExecutionGenerator;
 import org.hibernate.persister.entity.EntityPersister;
-import org.hibernate.service.ServiceRegistry;
 import org.hibernate.type.Type;
 
 import static org.hibernate.generator.internal.NaturalIdHelper.getNaturalIdPropertyNames;
@@ -87,7 +87,7 @@ public class SelectGenerator
 	private String uniqueKeyPropertyName;
 
 	@Override
-	public void configure(Type type, Properties parameters, ServiceRegistry serviceRegistry) {
+	public void configure(GeneratorCreationContext creationContext, Properties parameters) {
 		uniqueKeyPropertyName = parameters.getProperty( KEY );
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/id/UUIDGenerator.java
+++ b/hibernate-core/src/main/java/org/hibernate/id/UUIDGenerator.java
@@ -14,10 +14,10 @@ import org.hibernate.MappingException;
 import org.hibernate.boot.registry.classloading.spi.ClassLoaderService;
 import org.hibernate.boot.registry.classloading.spi.ClassLoadingException;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
+import org.hibernate.generator.GeneratorCreationContext;
 import org.hibernate.id.uuid.StandardRandomStrategy;
 import org.hibernate.internal.CoreLogging;
 import org.hibernate.internal.CoreMessageLogger;
-import org.hibernate.service.ServiceRegistry;
 import org.hibernate.type.Type;
 import org.hibernate.type.descriptor.java.UUIDJavaType;
 
@@ -50,7 +50,7 @@ public class UUIDGenerator implements IdentifierGenerator {
 	private UUIDJavaType.ValueTransformer valueTransformer;
 
 	@Override
-	public void configure(Type type, Properties parameters, ServiceRegistry serviceRegistry) throws MappingException {
+	public void configure(GeneratorCreationContext creationContext, Properties parameters) throws MappingException {
 		// check first for an explicit strategy instance
 		strategy = (UUIDGenerationStrategy) parameters.get( UUID_GEN_STRATEGY );
 
@@ -60,7 +60,7 @@ public class UUIDGenerator implements IdentifierGenerator {
 			if ( strategyClassName != null ) {
 				try {
 					final Class<?> strategyClass =
-							serviceRegistry.requireService( ClassLoaderService.class )
+							creationContext.getServiceRegistry().requireService( ClassLoaderService.class )
 									.classForName( strategyClassName );
 					try {
 						strategy = (UUIDGenerationStrategy) strategyClass.newInstance();
@@ -80,6 +80,7 @@ public class UUIDGenerator implements IdentifierGenerator {
 			strategy = StandardRandomStrategy.INSTANCE;
 		}
 
+		final Type type = creationContext.getType();
 		if ( UUID.class.isAssignableFrom( type.getReturnedClass() ) ) {
 			valueTransformer = UUIDJavaType.PassThroughTransformer.INSTANCE;
 		}

--- a/hibernate-core/src/main/java/org/hibernate/id/UUIDHexGenerator.java
+++ b/hibernate-core/src/main/java/org/hibernate/id/UUIDHexGenerator.java
@@ -10,9 +10,9 @@ import java.util.Properties;
 
 import org.hibernate.MappingException;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
+import org.hibernate.generator.GeneratorCreationContext;
 import org.hibernate.internal.CoreLogging;
 import org.hibernate.internal.CoreMessageLogger;
-import org.hibernate.service.ServiceRegistry;
 import org.hibernate.type.Type;
 
 import static org.hibernate.internal.util.config.ConfigurationHelper.getString;
@@ -53,7 +53,7 @@ public class UUIDHexGenerator extends AbstractUUIDGenerator {
 
 
 	@Override
-	public void configure(Type type, Properties parameters, ServiceRegistry serviceRegistry) throws MappingException {
+	public void configure(GeneratorCreationContext creationContext, Properties parameters) throws MappingException {
 		sep = getString( SEPARATOR, parameters, "" );
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/id/enhanced/TableGenerator.java
+++ b/hibernate-core/src/main/java/org/hibernate/id/enhanced/TableGenerator.java
@@ -36,6 +36,7 @@ import org.hibernate.engine.spi.SessionEventListenerManager;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.event.spi.EventManager;
 import org.hibernate.event.spi.HibernateMonitoringEvent;
+import org.hibernate.generator.GeneratorCreationContext;
 import org.hibernate.id.ExportableColumn;
 import org.hibernate.id.IdentifierGeneratorHelper;
 import org.hibernate.id.IntegralDataTypeHolder;
@@ -332,10 +333,11 @@ public class TableGenerator implements PersistentIdentifierGenerator {
 	}
 
 	@Override
-	public void configure(Type type, Properties parameters, ServiceRegistry serviceRegistry) throws MappingException {
+	public void configure(GeneratorCreationContext creationContext, Properties parameters) throws MappingException {
+		final ServiceRegistry serviceRegistry = creationContext.getServiceRegistry();
 		storeLastUsedValue = serviceRegistry.requireService( ConfigurationService.class )
 				.getSetting( AvailableSettings.TABLE_GENERATOR_STORE_LAST_USED, StandardConverters.BOOLEAN, true );
-		identifierType = type;
+		identifierType = creationContext.getType();
 
 		final JdbcEnvironment jdbcEnvironment = serviceRegistry.requireService( JdbcEnvironment.class );
 

--- a/hibernate-core/src/main/java/org/hibernate/mapping/SimpleValue.java
+++ b/hibernate-core/src/main/java/org/hibernate/mapping/SimpleValue.java
@@ -1051,6 +1051,11 @@ public abstract class SimpleValue implements KeyValue {
 			return rootClass.getIdentifierProperty();
 		}
 
+		@Override
+		public Type getType() {
+			return SimpleValue.this.getType();
+		}
+
 		// we could add these if it helps integrate old infrastructure
 //		@Override
 //		public Properties getParameters() {

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/id/SequenceStyleGeneratorBehavesLikeSequeceHiloGeneratorWitZeroIncrementSizeTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/id/SequenceStyleGeneratorBehavesLikeSequeceHiloGeneratorWitZeroIncrementSizeTest.java
@@ -11,15 +11,23 @@ import java.util.Properties;
 import org.hibernate.Session;
 import org.hibernate.boot.Metadata;
 import org.hibernate.boot.MetadataSources;
+import org.hibernate.boot.model.relational.Database;
 import org.hibernate.boot.registry.StandardServiceRegistry;
 import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
 import org.hibernate.boot.spi.MetadataBuildingContext;
+import org.hibernate.boot.spi.MetadataImplementor;
 import org.hibernate.cfg.AvailableSettings;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.engine.spi.SessionImplementor;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
+import org.hibernate.generator.GeneratorCreationContext;
 import org.hibernate.id.enhanced.SequenceStyleGenerator;
+import org.hibernate.mapping.PersistentClass;
+import org.hibernate.mapping.Property;
+import org.hibernate.mapping.RootClass;
+import org.hibernate.service.ServiceRegistry;
 import org.hibernate.type.StandardBasicTypes;
+import org.hibernate.type.Type;
 
 import org.hibernate.testing.boot.MetadataBuildingContextTestingImpl;
 import org.hibernate.testing.orm.junit.BaseUnitTest;
@@ -27,6 +35,7 @@ import org.hibernate.testing.orm.junit.DialectFeatureChecks.SupportsSequences;
 import org.hibernate.testing.orm.junit.RequiresDialectFeature;
 import org.hibernate.testing.transaction.TransactionUtil;
 import org.hibernate.testing.util.ServiceRegistryUtil;
+import org.hibernate.testing.util.uuid.IdGeneratorCreationContext;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -63,12 +72,51 @@ public class SequenceStyleGeneratorBehavesLikeSequeceHiloGeneratorWitZeroIncreme
 		properties.setProperty( SequenceStyleGenerator.OPT_PARAM, "legacy-hilo" );
 		properties.setProperty( SequenceStyleGenerator.INCREMENT_PARAM, "0" ); // JPA allocationSize of 1
 		generator.configure(
-				buildingContext.getBootstrapContext()
-						.getTypeConfiguration()
-						.getBasicTypeRegistry()
-						.resolve( StandardBasicTypes.LONG ),
-				properties,
-				serviceRegistry
+				new GeneratorCreationContext() {
+					@Override
+					public Database getDatabase() {
+						return buildingContext.getMetadataCollector().getDatabase();
+					}
+
+					@Override
+					public ServiceRegistry getServiceRegistry() {
+						return serviceRegistry;
+					}
+
+					@Override
+					public String getDefaultCatalog() {
+						return "";
+					}
+
+					@Override
+					public String getDefaultSchema() {
+						return "";
+					}
+
+					@Override
+					public PersistentClass getPersistentClass() {
+						return null;
+					}
+
+					@Override
+					public RootClass getRootClass() {
+						return null;
+					}
+
+					@Override
+					public Property getProperty() {
+						return null;
+					}
+
+					@Override
+					public Type getType() {
+						return buildingContext.getBootstrapContext()
+								.getTypeConfiguration()
+								.getBasicTypeRegistry()
+								.resolve( StandardBasicTypes.LONG );
+					}
+				},
+				properties
 		);
 
 		final Metadata metadata = new MetadataSources( serviceRegistry ).buildMetadata();

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/id/sequence/PooledWithCustomNamingStrategyTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/id/sequence/PooledWithCustomNamingStrategyTest.java
@@ -1,0 +1,167 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html
+ */
+package org.hibernate.orm.test.id.sequence;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.Statement;
+
+import org.hibernate.SessionFactory;
+import org.hibernate.boot.MetadataSources;
+import org.hibernate.boot.model.naming.Identifier;
+import org.hibernate.boot.model.naming.PhysicalNamingStrategy;
+import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
+import org.hibernate.boot.spi.MetadataImplementor;
+import org.hibernate.cfg.AvailableSettings;
+import org.hibernate.cfg.Environment;
+import org.hibernate.dialect.H2Dialect;
+import org.hibernate.engine.jdbc.connections.internal.DriverManagerConnectionProviderImpl;
+import org.hibernate.engine.jdbc.connections.spi.ConnectionProvider;
+import org.hibernate.engine.jdbc.env.spi.JdbcEnvironment;
+import org.hibernate.engine.spi.SessionFactoryImplementor;
+import org.hibernate.internal.util.PropertiesHelper;
+
+import org.hibernate.testing.orm.junit.BaseUnitTest;
+import org.hibernate.testing.orm.junit.Jira;
+import org.hibernate.testing.orm.junit.RequiresDialect;
+import org.hibernate.testing.util.ServiceRegistryUtil;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.SequenceGenerator;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hibernate.testing.transaction.TransactionUtil2.inTransaction;
+import static org.junit.jupiter.api.Assertions.fail;
+
+/**
+ * @author Marco Belladelli
+ */
+@BaseUnitTest
+@RequiresDialect( H2Dialect.class )
+@Jira( "https://hibernate.atlassian.net/browse/HHH-18337" )
+public class PooledWithCustomNamingStrategyTest {
+	@Test
+	public void testWrongIncrementSize() {
+		final StandardServiceRegistryBuilder registryBuilder = ServiceRegistryUtil.serviceRegistryBuilder();
+		registryBuilder.applySetting( AvailableSettings.PHYSICAL_NAMING_STRATEGY, MyPhysicalNamingStrategy.INSTANCE );
+		final MetadataImplementor metadata = (MetadataImplementor) new MetadataSources( registryBuilder.build() )
+				.addAnnotatedClass( WrongEntity.class )
+				.buildMetadata();
+		try (final SessionFactory sf = metadata.buildSessionFactory()) {
+			fail( "Default increment size of [50] should not work with the database sequence increment size [1]." );
+		}
+		catch (Exception e) {
+			assertThat( e.getMessage() ).isEqualTo(
+					"The increment size of the [MY_SEQ] sequence is set to [50] in the entity " +
+							"mapping while the associated database sequence increment size is [5]."
+			);
+		}
+	}
+
+	@Test
+	public void testRightIncrementSize() {
+		final StandardServiceRegistryBuilder registryBuilder = ServiceRegistryUtil.serviceRegistryBuilder();
+		registryBuilder.applySetting( AvailableSettings.PHYSICAL_NAMING_STRATEGY, MyPhysicalNamingStrategy.INSTANCE );
+		final MetadataImplementor metadata = (MetadataImplementor) new MetadataSources( registryBuilder.build() )
+				.addAnnotatedClass( RightEntity.class )
+				.buildMetadata();
+		try (final SessionFactoryImplementor sf = (SessionFactoryImplementor) metadata.buildSessionFactory()) {
+			// session factory should be created correctly
+			inTransaction( sf, session -> session.persist( new RightEntity() ) );
+			inTransaction( sf, session -> {
+				final RightEntity result = session.createQuery( "from RightEntity", RightEntity.class )
+						.getSingleResult();
+				assertThat( result.id ).isNotNull();
+			} );
+		}
+		catch (Exception e) {
+			fail( "Expected configured increment size of [1] to be compatible with the existing sequence" );
+		}
+	}
+
+	ConnectionProvider connectionProvider;
+
+	@BeforeAll
+	public void setUp() {
+		final DriverManagerConnectionProviderImpl provider = new DriverManagerConnectionProviderImpl();
+		provider.configure( PropertiesHelper.map( Environment.getProperties() ) );
+		connectionProvider = provider;
+		try (final Connection connection = connectionProvider.getConnection();
+			 final Statement statement = connection.createStatement()) {
+			statement.execute( "create sequence MY_SEQ start with 1 increment by 5" );
+			statement.execute( "create table RightEntity(id bigint not null, primary key (id))" );
+		}
+		catch (SQLException e) {
+			throw new RuntimeException( "Failed to setup the test", e );
+		}
+	}
+
+	@AfterAll
+	public void tearDown() {
+		try (final Connection connection = connectionProvider.getConnection();
+			 final Statement statement = connection.createStatement()) {
+			statement.execute( "drop sequence MY_SEQ" );
+			statement.execute( "drop table RightEntity" );
+		}
+		catch (SQLException e) {
+		}
+	}
+
+	@Entity( name = "WrongEntity" )
+	static class WrongEntity {
+		@Id
+		@GeneratedValue( strategy = GenerationType.SEQUENCE, generator = "my-sequence-generator" )
+		@SequenceGenerator( name = "my-sequence-generator", sequenceName = "REPLACE_SEQ" )
+		private Long id;
+	}
+
+	@Entity( name = "RightEntity" )
+	static class RightEntity {
+		@Id
+		@GeneratedValue( strategy = GenerationType.SEQUENCE, generator = "my-sequence-generator" )
+		@SequenceGenerator( name = "my-sequence-generator", sequenceName = "REPLACE_SEQ", allocationSize = 5 )
+		private Long id;
+	}
+
+	static class MyPhysicalNamingStrategy implements PhysicalNamingStrategy {
+		static MyPhysicalNamingStrategy INSTANCE = new MyPhysicalNamingStrategy();
+
+		@Override
+		public Identifier toPhysicalCatalogName(Identifier logicalName, JdbcEnvironment jdbcEnvironment) {
+			return logicalName;
+		}
+
+		@Override
+		public Identifier toPhysicalSchemaName(Identifier logicalName, JdbcEnvironment jdbcEnvironment) {
+			return logicalName;
+		}
+
+		@Override
+		public Identifier toPhysicalTableName(Identifier logicalName, JdbcEnvironment jdbcEnvironment) {
+			return logicalName;
+		}
+
+		@Override
+		public Identifier toPhysicalSequenceName(Identifier logicalName, JdbcEnvironment jdbcEnvironment) {
+			return Identifier.toIdentifier(
+					logicalName.getText().replaceAll( "REPLACE_", "MY_" ),
+					logicalName.isQuoted()
+			);
+		}
+
+		@Override
+		public Identifier toPhysicalColumnName(Identifier logicalName, JdbcEnvironment jdbcEnvironment) {
+			return logicalName;
+		}
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/idgen/enhanced/table/Db2GenerationTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/idgen/enhanced/table/Db2GenerationTest.java
@@ -15,14 +15,22 @@ import org.hibernate.boot.model.relational.SqlStringGenerationContext;
 import org.hibernate.boot.model.relational.internal.SqlStringGenerationContextImpl;
 import org.hibernate.boot.registry.StandardServiceRegistry;
 import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
+import org.hibernate.boot.spi.MetadataImplementor;
 import org.hibernate.cfg.AvailableSettings;
 import org.hibernate.dialect.DB2Dialect;
+import org.hibernate.generator.GeneratorCreationContext;
 import org.hibernate.id.enhanced.TableGenerator;
+import org.hibernate.mapping.PersistentClass;
+import org.hibernate.mapping.Property;
+import org.hibernate.mapping.RootClass;
 import org.hibernate.mapping.Table;
+import org.hibernate.service.ServiceRegistry;
 import org.hibernate.type.StandardBasicTypes;
+import org.hibernate.type.Type;
 
 import org.hibernate.testing.TestForIssue;
 import org.hibernate.testing.util.ServiceRegistryUtil;
+import org.hibernate.testing.util.uuid.IdGeneratorCreationContext;
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.Matchers.containsString;
@@ -38,19 +46,58 @@ public class Db2GenerationTest {
 				.build();
 
 		try {
-			final Metadata metadata = new MetadataSources( ssr ).buildMetadata();
+			final MetadataImplementor metadata = (MetadataImplementor) new MetadataSources( ssr ).buildMetadata();
 
 			assertEquals( 0, metadata.getDatabase().getDefaultNamespace().getTables().size() );
 
 			final TableGenerator generator = new TableGenerator();
 
 			generator.configure(
-					metadata.getDatabase()
-							.getTypeConfiguration()
-							.getBasicTypeRegistry()
-							.resolve( StandardBasicTypes.INTEGER ),
-					new Properties(),
-					ssr
+					new GeneratorCreationContext() {
+						@Override
+						public Database getDatabase() {
+							return metadata.getDatabase();
+						}
+
+						@Override
+						public ServiceRegistry getServiceRegistry() {
+							return ssr;
+						}
+
+						@Override
+						public String getDefaultCatalog() {
+							return "";
+						}
+
+						@Override
+						public String getDefaultSchema() {
+							return "";
+						}
+
+						@Override
+						public PersistentClass getPersistentClass() {
+							return null;
+						}
+
+						@Override
+						public RootClass getRootClass() {
+							return null;
+						}
+
+						@Override
+						public Property getProperty() {
+							return null;
+						}
+
+						@Override
+						public Type getType() {
+							return metadata.getDatabase()
+									.getTypeConfiguration()
+									.getBasicTypeRegistry()
+									.resolve( StandardBasicTypes.INTEGER );
+						}
+					},
+					new Properties()
 			);
 
 			generator.registerExportables( metadata.getDatabase() );

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/idgen/userdefined/NativeGenerator.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/idgen/userdefined/NativeGenerator.java
@@ -53,9 +53,9 @@ public class NativeGenerator
     }
 
     @Override
-    public void configure(Type type, Properties parameters, ServiceRegistry serviceRegistry) {
+    public void configure(GeneratorCreationContext creationContext, Properties parameters) {
         if ( generator instanceof Configurable ) {
-            ((Configurable) generator).configure( type, parameters, serviceRegistry );
+            ((Configurable) generator).configure( creationContext, parameters );
         }
     }
 

--- a/migration-guide.adoc
+++ b/migration-guide.adoc
@@ -240,6 +240,10 @@ specify a name for JNDI binding.  The new behavior is as follows (assuming `hibe
 Hibernate can use the persistence-unit name for binding into JNDI as well, but `hibernate.session_factory_name_is_jndi`
 must be explicitly set to true.
 
+[[configurable-generators]]
+== Configurable generators
+
+The signature of the `Configurable#configure` method changed from accepting just a `ServiceRegistry` instance to the new `GeneratorCreationContext` interface, which exposes a lot more useful information when configuring the generator itself. The old signature has been deprecated for removal, so you should migrate any custom `Configurable` generator implementation to the new one.
 
 [[hbm-transform]]
 == hbm.xml Transformation


### PR DESCRIPTION
<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

https://hibernate.atlassian.net/browse/HHH-18337

Alternative solution to https://github.com/hibernate/hibernate-orm/pull/8776 on `main` (7.0), changing the `Configurable#configure` method signature to accept a `GeneratorCreationContext`.

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
