### PR TITLE
Remove duplicated space before `when matched`

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/dialect/SqlAstTranslatorWithMerge.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/SqlAstTranslatorWithMerge.java
@@ -242,7 +242,7 @@ public abstract class SqlAstTranslatorWithMerge<T extends JdbcOperation> extends
 	}
 
 	private void renderWhenMatched(List<ColumnValueBinding> optimisticLockBindings) {
-		appendSql( " when matched" );
+		appendSql( "when matched" );
 		for (int i = 0; i < optimisticLockBindings.size(); i++) {
 			final ColumnValueBinding binding = optimisticLockBindings.get( i );
 			appendSql(" and ");

--- a/hibernate-core/src/main/java/org/hibernate/dialect/SqlAstTranslatorWithUpsert.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/SqlAstTranslatorWithUpsert.java
@@ -193,7 +193,7 @@ public class SqlAstTranslatorWithUpsert<T extends JdbcOperation> extends Abstrac
 		final List<ColumnValueBinding> valueBindings = optionalTableUpdate.getValueBindings();
 		final List<ColumnValueBinding> optimisticLockBindings = optionalTableUpdate.getOptimisticLockBindings();
 
-		appendSql( " when matched then update set " );
+		appendSql( "when matched then update set " );
 		for ( int i = 0; i < valueBindings.size(); i++ ) {
 			final ColumnValueBinding binding = valueBindings.get( i );
 			if ( i > 0 ) {


### PR DESCRIPTION
Running `org.hibernate.orm.test.stateless.UpsertTest`:

Before -> `merge into "UpsertTest$Record" as t using (select cast(? as bigint) id, cast(? as varchar) message) as s on (t.id=s.id) when not matched then insert (id, message) values (s.id, s.message)  when matched then update set message=s.message`
After  -> `merge into "UpsertTest$Record" as t using (select cast(? as bigint) id, cast(? as varchar) message) as s on (t.id=s.id) when not matched then insert (id, message) values (s.id, s.message) when matched then update set message=s.message`

<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

[Please describe here what your change is about]

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
