### PR TITLE
HHH-18503 ID select criteria query fails with joined + discriminator inheritance when entity has subtypes

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/persister/entity/AbstractEntityPersister.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/entity/AbstractEntityPersister.java
@@ -5816,8 +5816,7 @@ public abstract class AbstractEntityPersister
 
 	private ModelPart getIdentifierModelPart(String name, EntityMappingType treatTargetType) {
 		final EntityIdentifierMapping identifierMapping = getIdentifierMappingForJoin();
-		if ( identifierMapping instanceof NonAggregatedIdentifierMapping ) {
-			NonAggregatedIdentifierMapping mapping = (NonAggregatedIdentifierMapping) identifierMapping;
+		if ( identifierMapping instanceof final NonAggregatedIdentifierMapping mapping ) {
 			final ModelPart subPart = mapping.findSubPart( name, treatTargetType );
 			if ( subPart != null ) {
 				return subPart;

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/sql/BaseSqmToSqlAstConverter.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/sql/BaseSqmToSqlAstConverter.java
@@ -3022,10 +3022,20 @@ public abstract class BaseSqmToSqlAstConverter<T extends Statement> extends Base
 								parentType.getRootEntityDescriptor().getEntityName()
 						);
 					}
+					final EntityDiscriminatorMapping discriminator = parentType.getDiscriminatorMapping();
+					final String entityName;
+					if ( discriminator != null && discriminator.hasPhysicalColumn() && !parentType.getSubMappingTypes().isEmpty() ) {
+						// This is needed to preserve optimization for joined + discriminator inheritance
+						// see JoinedSubclassEntityPersister#getIdentifierMappingForJoin
+						entityName = parentType.getRootEntityDescriptor().getEntityName();
+					}
+					else {
+						entityName = parentType.getEntityName();
+					}
 					registerEntityNameUsage(
 							tableGroup,
 							EntityNameUse.EXPRESSION,
-							parentType.getEntityName()
+							entityName
 					);
 				}
 				else {

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/inheritance/join/JoinedHierarchyDiscIdSelectTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/inheritance/join/JoinedHierarchyDiscIdSelectTest.java
@@ -1,0 +1,106 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.orm.test.inheritance.join;
+
+import java.io.Serializable;
+import java.util.List;
+
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.Jira;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import jakarta.persistence.DiscriminatorColumn;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Inheritance;
+import jakarta.persistence.InheritanceType;
+import jakarta.persistence.criteria.CriteriaBuilder;
+import jakarta.persistence.criteria.CriteriaQuery;
+import jakarta.persistence.criteria.Root;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DomainModel( annotatedClasses = {
+		JoinedHierarchyDiscIdSelectTest.DooredVehicle.class,
+		JoinedHierarchyDiscIdSelectTest.BaseVehicle.class,
+		JoinedHierarchyDiscIdSelectTest.BaseEntity.class,
+} )
+@SessionFactory
+@Jira( "https://hibernate.atlassian.net/browse/HHH-18503" )
+public class JoinedHierarchyDiscIdSelectTest {
+	@ParameterizedTest
+	@ValueSource( classes = {
+			DooredVehicle.class,
+			BaseVehicle.class,
+			BaseEntity.class,
+	} )
+	void testSelectCriteriaId(Class<?> klass, SessionFactoryScope scope) {
+		scope.inTransaction( session -> {
+			final CriteriaBuilder criteriaBuilder = session.getCriteriaBuilder();
+			final CriteriaQuery<Long> criteriaQuery = criteriaBuilder.createQuery( Long.class );
+			final Root<?> root = criteriaQuery.from( klass );
+			criteriaQuery.select( root.get( "id" ) );
+			final List<Long> resultList = session.createQuery( criteriaQuery ).getResultList();
+			assertThat( resultList ).hasSize( 1 ).containsOnly( 1L );
+		} );
+	}
+
+	@ParameterizedTest
+	@ValueSource( classes = {
+			DooredVehicle.class,
+			BaseVehicle.class,
+			BaseEntity.class,
+	} )
+	void testSelectId(Class<?> klass, SessionFactoryScope scope) {
+		scope.inTransaction( session -> {
+			final Long result = session.createQuery(
+					String.format( "select id from %s", klass.getSimpleName() ),
+					Long.class
+			).getSingleResult();
+			assertThat( result ).isEqualTo( 1L );
+		} );
+	}
+
+	@BeforeAll
+	public void setUp(SessionFactoryScope scope) {
+		scope.inTransaction( session -> session.persist( DooredVehicle.create( 1L ) ) );
+	}
+
+	@AfterAll
+	public void tearDown(SessionFactoryScope scope) {
+		scope.getSessionFactory().getSchemaManager().truncateMappedObjects();
+	}
+
+	@Entity( name = "DooredVehicle" )
+	static class DooredVehicle extends BaseVehicle {
+		public String doorType;
+
+		public static DooredVehicle create(Long id) {
+			DooredVehicle vehicle = new DooredVehicle();
+			vehicle.id = id;
+			return vehicle;
+		}
+	}
+
+	@Entity( name = "BaseVehicle" )
+	static class BaseVehicle extends BaseEntity {
+		public String bodyType;
+	}
+
+	@Entity( name = "BaseEntity" )
+	@DiscriminatorColumn( name = "type" )
+	@Inheritance( strategy = InheritanceType.JOINED )
+	static class BaseEntity implements Serializable {
+		@Id
+		public Long id;
+	}
+}


### PR DESCRIPTION
<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

https://hibernate.atlassian.net/browse/HHH-18503

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
