### PR TITLE
HHH-18439 fix handling of null values in query cache

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/sql/results/jdbc/internal/JdbcValuesCacheHit.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/jdbc/internal/JdbcValuesCacheHit.java
@@ -223,7 +223,10 @@ public class JdbcValuesCacheHit extends AbstractJdbcValues {
 			return null;
 		}
 		final Object row = cachedResults.get( position + offset );
-		if ( valueIndexesToCacheIndexes == null ) {
+		if (row == null) {
+			return null;
+		}
+		else if ( valueIndexesToCacheIndexes == null ) {
 			return ( (Object[]) row )[valueIndex];
 		}
 		else if ( row.getClass() != Object[].class ) {

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/querycache/QueryCacheTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/querycache/QueryCacheTest.java
@@ -30,6 +30,8 @@ import org.hibernate.stat.spi.StatisticsImplementor;
 import org.hibernate.transform.Transformers;
 import org.hibernate.type.Type;
 
+import org.assertj.core.api.Assertions;
+
 import org.hibernate.testing.TestForIssue;
 import org.hibernate.testing.orm.junit.DomainModel;
 import org.hibernate.testing.orm.junit.ServiceRegistry;
@@ -760,6 +762,47 @@ public class QueryCacheTest {
 			if ( blockLatch != null ) {
 				blockLatch.countDown();
 			}
+		}
+	}
+
+	@Test
+	@TestForIssue(jiraKey = "HHH-18439")
+	void testNullValuesInQueryCache(SessionFactoryScope scope) throws Exception {
+		scope.getSessionFactory().getCache().evictQueryRegions();
+		scope.getSessionFactory().getStatistics().clear();
+
+		scope.inTransaction( session -> {
+			var item1 = new Item();
+			item1.setName( "name" );
+			item1.setDescription( "description" );
+
+			var item2 = new Item();
+			item2.setName( "fooName" );
+			// description explicitly has a null value
+
+			session.persist( item1 );
+			session.persist( item2 );
+		} );
+
+		// First execution puts entity in query cache, second execution loads entity from query cache
+		// -> check that the mapping of null values works when loading from the query cache
+		for ( int i = 0; i < 2; i++ ) {
+			scope.inTransaction( session -> {
+				// test single result
+				var result1 = session.createQuery(
+								"select description from Item i where i.name='fooName'",
+								String.class
+						)
+						.setCacheable( true )
+						.list();
+				Assertions.assertThat( result1 ).hasSize( 1 ).containsOnlyNulls();
+
+				// test multiple results
+				var result2 = session.createQuery( "select description from Item", String.class )
+						.setCacheable( true )
+						.list();
+				Assertions.assertThat( result2 ).containsExactlyInAnyOrder( "description", null );
+			} );
 		}
 	}
 }

--- a/hibernate-core/src/test/resources/org/hibernate/orm/test/querycache/Item.hbm.xml
+++ b/hibernate-core/src/test/resources/org/hibernate/orm/test/querycache/Item.hbm.xml
@@ -17,7 +17,7 @@
 			<generator class="native"/>
 		</id>
 		<property name="name" not-null="true"/>
-		<property name="description" not-null="true"/>
+		<property name="description"/>
     </class>
 
 </hibernate-mapping>


### PR DESCRIPTION
[HHH-18439](https://hibernate.atlassian.net/browse/HHH-18439): NullPointerException when access data from query cache

The problem was in JdbcValueCacheHit#getCurrentRowValue where a single null value in a cached query result would result in a NullPointerException.

----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------


[HHH-18439]: https://hibernate.atlassian.net/browse/HHH-18439?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ