### PR TITLE
HHH-18439 fix handling of null values in query cache

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/sql/results/jdbc/internal/JdbcValuesCacheHit.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/jdbc/internal/JdbcValuesCacheHit.java
@@ -173,7 +173,10 @@ public class JdbcValuesCacheHit extends AbstractJdbcValues {
 			return null;
 		}
 		final Object row = cachedResults.get( position + offset );
-		if ( valueIndexesToCacheIndexes == null ) {
+		if ( row == null ) {
+			return null;
+		}
+		else if ( valueIndexesToCacheIndexes == null ) {
 			return ( (Object[]) row )[valueIndex];
 		}
 		else if ( row.getClass() != Object[].class ) {

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/jdbc/internal/JdbcValuesCacheHit.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/jdbc/internal/JdbcValuesCacheHit.java
@@ -173,18 +173,15 @@ public class JdbcValuesCacheHit extends AbstractJdbcValues {
 			return null;
 		}
 		final Object row = cachedResults.get( position + offset );
-		if ( row == null ) {
-			return null;
-		}
-		else if ( valueIndexesToCacheIndexes == null ) {
+		if ( valueIndexesToCacheIndexes == null || valueIndexesToCacheIndexes.length == 0 ) {
 			return ( (Object[]) row )[valueIndex];
 		}
-		else if ( row.getClass() != Object[].class ) {
-			assert valueIndexesToCacheIndexes[valueIndex] == 0;
-			return row;
+		else if ( row instanceof Object[] ) {
+			return ( (Object[]) row )[valueIndexesToCacheIndexes[valueIndex]];
 		}
 		else {
-			return ( (Object[]) row )[valueIndexesToCacheIndexes[valueIndex]];
+			assert valueIndexesToCacheIndexes[valueIndex] == 0;
+			return row;
 		}
 	}
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/querycache/QueryCacheTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/querycache/QueryCacheTest.java
@@ -804,6 +804,13 @@ public class QueryCacheTest {
 						.setCacheable( true )
 						.list();
 				Assertions.assertThat( result2 ).containsExactlyInAnyOrder( "description", null );
+
+				// test select null directly
+				var result3 = session.createQuery( "select null", Object.class )
+						.setCacheable( true )
+						.list();
+				Assertions.assertThat( result3 ).hasSize( 1 ).containsOnlyNulls();
+
 			} );
 		}
 	}

--- a/hibernate-core/src/test/resources/org/hibernate/orm/test/querycache/Item.hbm.xml
+++ b/hibernate-core/src/test/resources/org/hibernate/orm/test/querycache/Item.hbm.xml
@@ -17,7 +17,7 @@
 			<generator class="native"/>
 		</id>
 		<property name="name" not-null="true"/>
-		<property name="description" not-null="true"/>
+		<property name="description"/>
     </class>
 
 </hibernate-mapping>


### PR DESCRIPTION
[HHH-18439](https://hibernate.atlassian.net/browse/HHH-18439): NullPointerException when access data from query cache

The problem was in JdbcValueCacheHit#getCurrentRowValue where a single null value in a cached query result would result in a NullPointerException.

----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------


[HHH-18439]: https://hibernate.atlassian.net/browse/HHH-18439?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ