### PR TITLE
HHH-18439 NullPointerException when access data from query cache

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/internal/SqmUtil.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/internal/SqmUtil.java
@@ -1094,7 +1094,10 @@ public class SqmUtil {
 		}
 
 		final JavaType<?> selectionExpressibleJavaType = selectionExpressible.getExpressibleJavaType();
-		assert selectionExpressibleJavaType != null;
+		if ( selectionExpressibleJavaType == null ) {
+			// nothing we can validate
+			return;
+		}
 
 		final Class<?> selectionExpressibleJavaTypeClass = selectionExpressibleJavaType.getJavaTypeClass();
 		if ( selectionExpressibleJavaTypeClass != Object.class ) {
@@ -1103,7 +1106,7 @@ public class SqmUtil {
 				return;
 			}
 
-			if ( selectionExpressibleJavaType instanceof PrimitiveJavaType<?> primitiveJavaType ) {
+			if ( selectionExpressibleJavaType instanceof final PrimitiveJavaType<?> primitiveJavaType ) {
 				if ( primitiveJavaType.getPrimitiveClass() == resultClass ) {
 					return;
 				}

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/jdbc/internal/JdbcValuesCacheHit.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/jdbc/internal/JdbcValuesCacheHit.java
@@ -176,12 +176,12 @@ public class JdbcValuesCacheHit extends AbstractJdbcValues {
 		if ( valueIndexesToCacheIndexes == null ) {
 			return ( (Object[]) row )[valueIndex];
 		}
-		else if ( row.getClass() != Object[].class ) {
-			assert valueIndexesToCacheIndexes[valueIndex] == 0;
-			return row;
+		else if ( row instanceof Object[] ) {
+			return ( (Object[]) row )[valueIndexesToCacheIndexes[valueIndex]];
 		}
 		else {
-			return ( (Object[]) row )[valueIndexesToCacheIndexes[valueIndex]];
+			assert valueIndexesToCacheIndexes[valueIndex] == 0;
+			return row;
 		}
 	}
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/querycache/QueryCacheNullValueTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/querycache/QueryCacheNullValueTest.java
@@ -1,0 +1,77 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html
+ */
+package org.hibernate.orm.test.querycache;
+
+import org.hibernate.cfg.AvailableSettings;
+import org.hibernate.stat.spi.StatisticsImplementor;
+
+import org.hibernate.testing.orm.domain.gambit.BasicEntity;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.Jira;
+import org.hibernate.testing.orm.junit.ServiceRegistry;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.hibernate.testing.orm.junit.Setting;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Marco Belladelli
+ */
+@DomainModel( annotatedClasses = {
+		BasicEntity.class
+} )
+@SessionFactory( generateStatistics = true )
+@ServiceRegistry( settings = {
+		@Setting( name = AvailableSettings.USE_QUERY_CACHE, value = "true" ),
+		@Setting( name = AvailableSettings.USE_SECOND_LEVEL_CACHE, value = "true" )
+} )
+@Jira( "https://hibernate.atlassian.net/browse/HHH-18439" )
+public class QueryCacheNullValueTest {
+	@Test
+	public void testNullProperty(SessionFactoryScope scope) {
+		executeQuery( scope, "select data from BasicEntity" );
+	}
+
+	@Test
+	public void testNullLiteral(SessionFactoryScope scope) {
+		executeQuery( scope, "select null from BasicEntity" );
+	}
+
+	private static void executeQuery(SessionFactoryScope scope, String hql) {
+		scope.getSessionFactory().getCache().evictQueryRegions();
+		final StatisticsImplementor statistics = scope.getSessionFactory().getStatistics();
+		statistics.clear();
+
+		for ( int i = 0; i < 2; i++ ) {
+			final int hitCount = i;
+			scope.inTransaction( session -> {
+				assertThat( session.createQuery( hql, String.class )
+									.setCacheable( true )
+									.getSingleResult() ).isNull();
+				// 0 hits, 1 miss, 1 put
+				assertThat( statistics.getQueryCacheHitCount() ).isEqualTo( hitCount );
+				assertThat( statistics.getQueryCacheMissCount() ).isEqualTo( 1 );
+				assertThat( statistics.getQueryCachePutCount() ).isEqualTo( 1 );
+				session.clear();
+			} );
+		}
+	}
+
+	@BeforeAll
+	public void setUp(SessionFactoryScope scope) {
+		scope.inTransaction( session -> session.persist( new BasicEntity( 1, null ) ) );
+	}
+
+	@AfterAll
+	public void tearDown(SessionFactoryScope scope) {
+		scope.getSessionFactory().getSchemaManager().truncateMappedObjects();
+	}
+}


### PR DESCRIPTION
<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

https://hibernate.atlassian.net/browse/HHH-18439

Alternative to https://github.com/hibernate/hibernate-orm/pull/8814, which also fixes an assertion error in query result type-check when selecting null literals.

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
