### PR TITLE
HHH-18516 - Ignore @AttributeOverride for map key when checking type of map value

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/boot/model/internal/CollectionBinder.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/internal/CollectionBinder.java
@@ -2355,13 +2355,17 @@ public abstract class CollectionBinder {
 		}
 		else {
 			//force in case of attribute override
-			final boolean attributeOverride = property.hasDirectAnnotationUsage( AttributeOverride.class )
-					|| property.hasDirectAnnotationUsage( AttributeOverrides.class );
+			final boolean attributeOverride = mappingDefinedAttributeOverrideOnElement(property);
 			// todo : force in the case of Convert annotation(s) with embedded paths (beyond key/value prefixes)?
 			return isEmbedded || attributeOverride
 					? EMBEDDABLE
 					: buildingContext.getMetadataCollector().getClassType( elementClass );
 		}
+	}
+
+	protected boolean mappingDefinedAttributeOverrideOnElement(MemberDetails property) {
+		return property.hasDirectAnnotationUsage( AttributeOverride.class )
+				|| property.hasDirectAnnotationUsage( AttributeOverrides.class );
 	}
 
 	static AnnotatedColumns createElementColumnsIfNecessary(

--- a/hibernate-core/src/main/java/org/hibernate/boot/model/internal/MapBinder.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/internal/MapBinder.java
@@ -109,6 +109,26 @@ public class MapBinder extends CollectionBinder {
 		};
 	}
 
+	@Override
+	protected boolean mappingDefinedAttributeOverrideOnElement(MemberDetails property) {
+		if ( property.hasDirectAnnotationUsage( AttributeOverride.class ) ) {
+			return namedMapValue( property.getDirectAnnotationUsage( AttributeOverride.class ) );
+		}
+		if ( property.hasDirectAnnotationUsage( AttributeOverrides.class ) ) {
+			final AttributeOverrides annotations = property.getDirectAnnotationUsage( AttributeOverrides.class );
+			for ( AttributeOverride attributeOverride : annotations.value() ) {
+				if ( namedMapValue( attributeOverride ) ) {
+					return true;
+				}
+			}
+		}
+		return false;
+	}
+
+	private boolean namedMapValue(AttributeOverride annotation) {
+		return annotation.name().startsWith( "value." );
+	}
+
 	private void makeOneToManyMapKeyColumnNullableIfNotInProperty(MemberDetails property) {
 		final Map map = (Map) this.collection;
 		if ( map.isOneToMany() && property.hasDirectAnnotationUsage( MapKeyColumn.class ) ) {

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/attributeoverride/MapAttributeOverrideTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/attributeoverride/MapAttributeOverrideTest.java
@@ -1,0 +1,45 @@
+package org.hibernate.orm.test.annotations.attributeoverride;
+
+import java.time.LocalTime;
+import java.util.Map;
+
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.JiraKey;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.junit.jupiter.api.Test;
+
+import jakarta.persistence.metamodel.EntityType;
+import jakarta.persistence.metamodel.MapAttribute;
+
+import static jakarta.persistence.metamodel.Type.PersistenceType.BASIC;
+import static jakarta.persistence.metamodel.Type.PersistenceType.EMBEDDABLE;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DomainModel(
+		annotatedClasses = {
+				Schedule.class,
+				Route.class
+		}
+)
+@SessionFactory
+class MapAttributeOverrideTest {
+
+	@Test
+	@JiraKey("HHH-18516")
+	void testMapOfEmbeddableKeysWithAttributeOverridesAndBasicValues(SessionFactoryScope sessionFactoryScope) {
+		sessionFactoryScope.inTransaction(session -> {
+			EntityType<Schedule> scheduleType = session.getMetamodel().entity(Schedule.class);
+			MapAttribute<? super Schedule, ?, ?> departuresMapAttribute = scheduleType.getMap("departures");
+			// Presence of @AttributeOverride-s for the key should only affect the type of the key, but not the type of the value
+			assertThat(departuresMapAttribute.getKeyType().getPersistenceType()).isEqualTo(EMBEDDABLE);
+			assertThat(departuresMapAttribute.getElementType().getPersistenceType()).isEqualTo(BASIC);
+
+			session.persist(new Schedule(Map.of(
+					new Route("Hamburg", "Vienna"), LocalTime.NOON,
+					new Route("Warsaw", "Barcelona"), LocalTime.MIDNIGHT
+			)));
+			assertThat(session.createQuery("FROM Schedule s", Schedule.class).getResultCount()).isOne();
+		});
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/attributeoverride/Route.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/attributeoverride/Route.java
@@ -1,0 +1,18 @@
+package org.hibernate.orm.test.annotations.attributeoverride;
+
+import jakarta.persistence.Embeddable;
+
+@Embeddable
+public class Route {
+
+	private String origin;
+	private String destination;
+
+	public Route() {
+	}
+
+	public Route(String origin, String destination) {
+		this.origin = origin;
+		this.destination = destination;
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/attributeoverride/Schedule.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/attributeoverride/Schedule.java
@@ -1,0 +1,32 @@
+package org.hibernate.orm.test.annotations.attributeoverride;
+
+import java.time.LocalTime;
+import java.util.Map;
+
+import jakarta.persistence.AttributeOverride;
+import jakarta.persistence.Column;
+import jakarta.persistence.ElementCollection;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+
+@Entity
+public class Schedule {
+
+	@Id
+	@GeneratedValue
+	private Long id;
+
+	@ElementCollection
+	@Column(name = "time")
+	@AttributeOverride(name = "key.origin", column = @Column(name = "orig"))
+	@AttributeOverride(name = "key.destination", column = @Column(name = "dest"))
+	private Map<Route, LocalTime> departures;
+
+	public Schedule() {
+	}
+
+	public Schedule(Map<Route, LocalTime> departures) {
+		this.departures = departures;
+	}
+}


### PR DESCRIPTION
When determining the type of the collection element, `CollectionBinder` considers it to be embeddable if there are `@AttributeOverride`-s on corresponding member (property or method) . This doesn't work when collection is a map (handled by `MapBinder` which extends `CollectionBinder`) because with maps `@AttributeOverride`-s can be specified not only for the map value but also for the map key, and only the former should affect the type of the collection element (map value). 

This PR makes the `@AttributeOverride` check customizable and adds an override in `MapBinder` to only check for `@AttributeOverride`-s that apply to the map value.

----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-18516
<!-- Hibernate GitHub Bot issue links end -->