### PR TITLE
HHH-18518 change implementation to capture MySQL custom versions better

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/dialect/MySQLDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/MySQLDialect.java
@@ -17,6 +17,8 @@ import java.util.Calendar;
 import java.util.Date;
 import java.util.TimeZone;
 
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import org.hibernate.Length;
 import org.hibernate.LockOptions;
 import org.hibernate.PessimisticLockException;
@@ -212,12 +214,12 @@ public class MySQLDialect extends Dialect {
 	protected static DatabaseVersion createVersion(DialectResolutionInfo info, DatabaseVersion defaultVersion) {
 		final String versionString = info.getDatabaseVersion();
 		if ( versionString != null ) {
-			final String[] components = versionString.split( "\\." );
-			if ( components.length >= 3 ) {
+			final Matcher matcher = Pattern.compile("^(\\d+)\\.(\\d+)\\.(\\d+).*").matcher(versionString);
+			if ( matcher.matches() && matcher.groupCount() >= 3  ) {
 				try {
-					final int majorVersion = Integer.parseInt( components[0] );
-					final int minorVersion = Integer.parseInt( components[1] );
-					final int patchLevel = Integer.parseInt( components[2] );
+					final int majorVersion = Integer.parseInt( matcher.group(1));
+					final int minorVersion = Integer.parseInt( matcher.group(2) );
+					final int patchLevel = Integer.parseInt( matcher.group(3) );
 					return DatabaseVersion.make( majorVersion, minorVersion, patchLevel );
 				}
 				catch (NumberFormatException ex) {

--- a/hibernate-core/src/main/java/org/hibernate/dialect/MySQLDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/MySQLDialect.java
@@ -17,8 +17,6 @@ import java.util.Calendar;
 import java.util.Date;
 import java.util.TimeZone;
 
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 import org.hibernate.Length;
 import org.hibernate.LockOptions;
 import org.hibernate.PessimisticLockException;
@@ -214,12 +212,12 @@ public class MySQLDialect extends Dialect {
 	protected static DatabaseVersion createVersion(DialectResolutionInfo info, DatabaseVersion defaultVersion) {
 		final String versionString = info.getDatabaseVersion();
 		if ( versionString != null ) {
-			final Matcher matcher = Pattern.compile("^(\\d+)\\.(\\d+)\\.(\\d+).*").matcher(versionString);
-			if ( matcher.matches() && matcher.groupCount() >= 3  ) {
+			final String[] components = StringHelper.split(".-", versionString);
+			if ( components.length >= 3 ) {
 				try {
-					final int majorVersion = Integer.parseInt( matcher.group(1));
-					final int minorVersion = Integer.parseInt( matcher.group(2) );
-					final int patchLevel = Integer.parseInt( matcher.group(3) );
+					final int majorVersion = Integer.parseInt( components[0] );
+					final int minorVersion = Integer.parseInt( components[1] );
+					final int patchLevel = Integer.parseInt( components[2] );
 					return DatabaseVersion.make( majorVersion, minorVersion, patchLevel );
 				}
 				catch (NumberFormatException ex) {

--- a/hibernate-core/src/test/java/org/hibernate/dialect/MySQLDialectDatabaseVersionTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/dialect/MySQLDialectDatabaseVersionTest.java
@@ -1,0 +1,97 @@
+package org.hibernate.dialect;
+
+import java.util.Map;
+import org.hibernate.engine.jdbc.dialect.spi.DialectResolutionInfo;
+import org.hibernate.testing.RequiresDialect;
+import org.hibernate.testing.TestForIssue;
+import org.hibernate.testing.junit4.BaseUnitTestCase;
+import org.junit.Test;
+
+
+import static org.junit.Assert.assertEquals;
+
+@RequiresDialect(MySQLDialect.class)
+@TestForIssue(jiraKey = "HHH-18518")
+public class MySQLDialectDatabaseVersionTest extends BaseUnitTestCase {
+
+	@Test
+	public void versionWithSuffix() {
+		String version = "8.0.37-azure";
+		Dialect dialect = new MySQLDialect( new TestingMySQLDialectResolutionInfo( version ) );
+
+		assertEquals(8, dialect.getVersion().getMajor());
+		assertEquals(0, dialect.getVersion().getMinor());
+		assertEquals(37, dialect.getVersion().getMicro());
+	}
+	
+	@Test
+	public void releaseVersion() {
+		String version = "8.0.37";
+		Dialect dialect = new MySQLDialect( new TestingMySQLDialectResolutionInfo( version ) );
+
+		assertEquals(8, dialect.getVersion().getMajor());
+		assertEquals(0, dialect.getVersion().getMinor());
+		assertEquals(37, dialect.getVersion().getMicro());
+	}
+
+	static final class TestingMySQLDialectResolutionInfo implements DialectResolutionInfo {
+		private final String databaseVersion;
+
+		TestingMySQLDialectResolutionInfo(String databaseVersion) {
+			this.databaseVersion = databaseVersion;
+		}
+
+
+		@Override
+		public String getDatabaseName() {
+			return "MySQL";
+		}
+
+		@Override
+		public String getDatabaseVersion() {
+			return this.databaseVersion;
+		}
+
+		@Override
+		public int getDatabaseMajorVersion() {
+			return 8;
+		}
+
+		@Override
+		public int getDatabaseMinorVersion() {
+			return 0;
+		}
+
+		@Override
+		public String getDriverName() {
+			return "MySQL JDBC Driver";
+		}
+
+		@Override
+		public int getDriverMajorVersion() {
+			return 8;
+		}
+
+		@Override
+		public int getDriverMinorVersion() {
+			return 3;
+		}
+
+		@Override
+		public String getSQLKeywords() {
+			return "";
+		}
+
+		@Override
+		public String toString() {
+			return "8.3.0";
+		}
+
+		@Override
+		public Map<String, Object> getConfigurationValues() {
+			return Map.of();
+		}
+		
+	}
+
+}


### PR DESCRIPTION
Fixing version detection to be able to run hibernate on a server using mysql in azure. 
The detection logic also handles the cases it did before, but does no longer crash when suffixes are added, like e.g azure does for their versions.
<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-18518
<!-- Hibernate GitHub Bot issue links end -->