### PR TITLE
HHH-18519 - Add vararg method to HibernatePersistenceConfiguration for supplying mappings

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/jpa/HibernatePersistenceConfiguration.java
+++ b/hibernate-core/src/main/java/org/hibernate/jpa/HibernatePersistenceConfiguration.java
@@ -6,6 +6,8 @@
  */
 package org.hibernate.jpa;
 
+import java.util.Collection;
+import java.util.Collections;
 import java.util.Map;
 import java.util.Objects;
 
@@ -15,8 +17,10 @@ import org.hibernate.cfg.CacheSettings;
 import org.hibernate.cfg.JdbcSettings;
 import org.hibernate.cfg.JpaComplianceSettings;
 import org.hibernate.cfg.MappingSettings;
+import org.hibernate.cfg.SchemaToolingSettings;
 import org.hibernate.cfg.StatisticsSettings;
 import org.hibernate.resource.jdbc.spi.StatementInspector;
+import org.hibernate.tool.schema.Action;
 
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.EntityManagerFactory;
@@ -26,6 +30,8 @@ import jakarta.persistence.SharedCacheMode;
 import jakarta.persistence.ValidationMode;
 
 /**
+ * Hibernate extension to the Jakarta Persistence PersistenceConfiguration contract.
+ *
  * @author Steve Ebersole
  */
 public class HibernatePersistenceConfiguration extends PersistenceConfiguration {
@@ -300,6 +306,61 @@ public class HibernatePersistenceConfiguration extends PersistenceConfiguration 
 	 */
 	public HibernatePersistenceConfiguration collectStatistics(boolean enabled) {
 		property( StatisticsSettings.GENERATE_STATISTICS, enabled );
+		return this;
+	}
+
+	/**
+	 * Add the specified classes as {@linkplain #managedClasses() managed classes}.
+	 *
+	 * @see #managedClass
+	 */
+	public HibernatePersistenceConfiguration managedClasses(Class<?>... managedClasses) {
+		Collections.addAll( managedClasses(), managedClasses );
+		return this;
+	}
+
+	/**
+	 * Add the specified classes as {@linkplain #managedClasses() managed classes}.
+	 *
+	 * @see #managedClass
+	 */
+	public HibernatePersistenceConfiguration managedClasses(Collection<Class<?>> managedClasses) {
+		managedClasses().addAll( managedClasses );
+		return this;
+	}
+
+	/**
+	 * Add the specified resource names as {@linkplain #mappingFiles() mapping files}.
+	 *
+	 * @see #mappingFiles
+	 */
+	public HibernatePersistenceConfiguration mappingFiles(String... names) {
+		Collections.addAll( mappingFiles(), names );
+		return this;
+	}
+
+	/**
+	 * Add the specified resource names as {@linkplain #mappingFiles() mapping files}.
+	 *
+	 * @see #mappingFiles
+	 */
+	public HibernatePersistenceConfiguration mappingFiles(Collection<String> names) {
+		mappingFiles().addAll( names );
+		return this;
+	}
+
+	/**
+	 * Specify the {@linkplain Action action} to take in terms of automatic
+	 * database schema tooling.
+	 *
+	 * @apiNote This only controls tooling as exported directly to the database.  To
+	 * output tooling commands to scripts, use {@linkplain #properties(Map) config properties}
+	 * instead with appropriate {@linkplain SchemaToolingSettings settings}.
+	 *
+	 * @see SchemaToolingSettings#HBM2DDL_AUTO
+	 */
+	public HibernatePersistenceConfiguration schemaToolingAction(Action action) {
+		property( SchemaToolingSettings.HBM2DDL_AUTO, action );
 		return this;
 	}
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/boot/PersistenceConfigurationTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/boot/PersistenceConfigurationTests.java
@@ -6,11 +6,18 @@
  */
 package org.hibernate.orm.test.jpa.boot;
 
+import java.util.List;
+
 import org.hibernate.dialect.H2Dialect;
+import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.jpa.HibernatePersistenceConfiguration;
+import org.hibernate.tool.schema.Action;
 
 import org.hibernate.testing.env.TestingDatabaseInfo;
+import org.hibernate.testing.orm.domain.library.Book;
+import org.hibernate.testing.orm.domain.library.Person;
 import org.hibernate.testing.orm.junit.RequiresDialect;
+import org.hibernate.testing.transaction.TransactionUtil2;
 import org.junit.jupiter.api.Test;
 
 import jakarta.persistence.EntityManagerFactory;
@@ -108,6 +115,40 @@ public class PersistenceConfigurationTests {
 				assert emf.isOpen();
 			}
 			//end::example-bootstrap-standard-HibernatePersistenceConfiguration[]
+		}
+	}
+	
+	@Test
+	@RequiresDialect( H2Dialect.class )
+	public void testVarargs() {
+		final PersistenceConfiguration cfg = new HibernatePersistenceConfiguration( "emf" )
+				.jdbcUrl( "jdbc:h2:mem:db1" )
+				.jdbcUsername( "sa" )
+				.jdbcPassword( "" )
+				.schemaToolingAction( Action.CREATE_DROP )
+				.managedClasses( Book.class, Person.class );
+		try (EntityManagerFactory emf = cfg.createEntityManagerFactory()) {
+			assert emf.isOpen();
+			TransactionUtil2.inTransaction( emf.unwrap( SessionFactoryImplementor.class ), (em) -> {
+				em.createSelectionQuery( "from Book", Book.class ).list();
+			} );
+		}
+	}
+
+	@Test
+	@RequiresDialect( H2Dialect.class )
+	public void testVarargs2() {
+		final PersistenceConfiguration cfg = new HibernatePersistenceConfiguration( "emf" )
+				.jdbcUrl( "jdbc:h2:mem:db1" )
+				.jdbcUsername( "sa" )
+				.jdbcPassword( "" )
+				.schemaToolingAction( Action.CREATE_DROP )
+				.managedClasses( List.of( Book.class, Person.class ) );
+		try (EntityManagerFactory emf = cfg.createEntityManagerFactory()) {
+			assert emf.isOpen();
+			TransactionUtil2.inTransaction( emf.unwrap( SessionFactoryImplementor.class ), (em) -> {
+				em.createSelectionQuery( "from Book", Book.class ).list();
+			} );
 		}
 	}
 }


### PR DESCRIPTION
HHH-18519 - Add vararg method to HibernatePersistenceConfiguration for supplying mappings

Also adds support for auto schema export.

----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
