### PR TITLE
 HHH-18520 Upgrade to hibernate-models 0.9.0 + HHH-18521 Leverage hibernate-models ModelsConfiguration

### DIFF
--- a/hibernate-core/hibernate-core.gradle
+++ b/hibernate-core/hibernate-core.gradle
@@ -28,6 +28,7 @@ dependencies {
     api jakartaLibs.jta
 
     implementation libs.hibernateModels
+    implementation libs.hibernateModelsJandex
     implementation libs.jandex
     implementation libs.classmate
     implementation libs.byteBuddy
@@ -65,6 +66,7 @@ dependencies {
     }
     testImplementation "joda-time:joda-time:2.3"
     testImplementation dbLibs.h2
+    testImplementation libs.hibernateModelsJandex
 
     testRuntimeOnly libs.byteBuddy
     testRuntimeOnly testLibs.weld

--- a/hibernate-core/src/main/java/org/hibernate/boot/internal/InFlightMetadataCollectorImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/internal/InFlightMetadataCollectorImpl.java
@@ -105,8 +105,8 @@ import org.hibernate.mapping.Table;
 import org.hibernate.metamodel.CollectionClassification;
 import org.hibernate.metamodel.mapping.DiscriminatorType;
 import org.hibernate.metamodel.spi.EmbeddableInstantiator;
-import org.hibernate.models.internal.SourceModelBuildingContextImpl;
 import org.hibernate.models.spi.ClassDetails;
+import org.hibernate.models.spi.ModelsConfiguration;
 import org.hibernate.models.spi.SourceModelBuildingContext;
 import org.hibernate.query.named.NamedObjectRepository;
 import org.hibernate.query.sqm.function.SqmFunctionDescriptor;
@@ -228,11 +228,13 @@ public class InFlightMetadataCollectorImpl implements InFlightMetadataCollector,
 	private static SourceModelBuildingContext createModelBuildingContext(BootstrapContext bootstrapContext) {
 		final ClassLoaderService classLoaderService = bootstrapContext.getServiceRegistry().getService( ClassLoaderService.class );
 		final ClassLoaderServiceLoading classLoading = new ClassLoaderServiceLoading( classLoaderService );
-		return new SourceModelBuildingContextImpl(
-				classLoading,
-				bootstrapContext.getJandexView(),
-				ModelsHelper::preFillRegistries
-		);
+
+		final ModelsConfiguration modelsConfiguration = new ModelsConfiguration();
+		modelsConfiguration.setClassLoading(classLoading);
+//		modelsConfiguration.setExplicitContextProvider(  );
+		modelsConfiguration.configValue( "hibernate.models.jandex.index", bootstrapContext.getJandexView() );
+		modelsConfiguration.setRegistryPrimer( ModelsHelper::preFillRegistries );
+		return modelsConfiguration.bootstrap();
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/model/internal/PropertyInferredData.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/internal/PropertyInferredData.java
@@ -8,6 +8,7 @@ package org.hibernate.boot.model.internal;
 
 import org.hibernate.MappingException;
 import org.hibernate.annotations.Target;
+import org.hibernate.boot.models.internal.ModelsHelper;
 import org.hibernate.boot.spi.AccessType;
 import org.hibernate.boot.spi.MetadataBuildingContext;
 import org.hibernate.boot.spi.PropertyData;
@@ -87,8 +88,11 @@ public class PropertyInferredData implements PropertyData {
 		if ( targetAnnotation != null ) {
 			final String targetName = targetAnnotation.value();
 			final SourceModelBuildingContext sourceModelBuildingContext = sourceModelContext;
-			final ClassDetails classDetails = sourceModelBuildingContext.getClassDetailsRegistry()
-					.resolveClassDetails( targetName );
+			final ClassDetails classDetails = ModelsHelper.resolveClassDetails(
+					targetName,
+					sourceModelBuildingContext.getClassDetailsRegistry(),
+					() -> new DynamicClassDetails( targetName, sourceModelContext )
+			);
 			return new ClassTypeDetailsImpl( classDetails, TypeDetails.Kind.CLASS );
 		}
 
@@ -117,8 +121,11 @@ public class PropertyInferredData implements PropertyData {
 		final org.hibernate.boot.internal.Target annotationUsage = propertyMember.getDirectAnnotationUsage( org.hibernate.boot.internal.Target.class );
 		if ( annotationUsage != null ) {
 			final String targetName = annotationUsage.value();
-			final ClassDetails classDetails = sourceModelBuildingContext.getClassDetailsRegistry()
-					.resolveClassDetails( targetName );
+			final ClassDetails classDetails = ModelsHelper.resolveClassDetails(
+					targetName,
+					sourceModelBuildingContext.getClassDetailsRegistry(),
+					() -> new DynamicClassDetails( targetName, sourceModelBuildingContext )
+			);
 			return new ClassTypeDetailsImpl( classDetails, TypeDetails.Kind.CLASS );
 		}
 
@@ -169,4 +176,6 @@ public class PropertyInferredData implements PropertyData {
 	public ClassDetails getDeclaringClass() {
 		return declaringClass;
 	}
+
+
 }

--- a/hibernate-core/src/main/java/org/hibernate/boot/model/internal/PropertyInferredData.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/internal/PropertyInferredData.java
@@ -87,10 +87,8 @@ public class PropertyInferredData implements PropertyData {
 		if ( targetAnnotation != null ) {
 			final String targetName = targetAnnotation.value();
 			final SourceModelBuildingContext sourceModelBuildingContext = sourceModelContext;
-			final ClassDetails classDetails = sourceModelBuildingContext.getClassDetailsRegistry().resolveClassDetails(
-					targetName,
-					name -> new DynamicClassDetails( targetName, sourceModelBuildingContext )
-			);
+			final ClassDetails classDetails = sourceModelBuildingContext.getClassDetailsRegistry()
+					.resolveClassDetails( targetName );
 			return new ClassTypeDetailsImpl( classDetails, TypeDetails.Kind.CLASS );
 		}
 
@@ -119,10 +117,8 @@ public class PropertyInferredData implements PropertyData {
 		final org.hibernate.boot.internal.Target annotationUsage = propertyMember.getDirectAnnotationUsage( org.hibernate.boot.internal.Target.class );
 		if ( annotationUsage != null ) {
 			final String targetName = annotationUsage.value();
-			final ClassDetails classDetails = sourceModelBuildingContext.getClassDetailsRegistry().resolveClassDetails(
-					targetName,
-					name -> new DynamicClassDetails( targetName, sourceModelBuildingContext )
-			);
+			final ClassDetails classDetails = sourceModelBuildingContext.getClassDetailsRegistry()
+					.resolveClassDetails( targetName );
 			return new ClassTypeDetailsImpl( classDetails, TypeDetails.Kind.CLASS );
 		}
 

--- a/hibernate-core/src/main/java/org/hibernate/boot/model/process/spi/MetadataBuildingProcess.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/process/spi/MetadataBuildingProcess.java
@@ -72,7 +72,8 @@ import org.hibernate.engine.config.spi.ConfigurationService;
 import org.hibernate.engine.config.spi.StandardConverters;
 import org.hibernate.engine.jdbc.spi.JdbcServices;
 import org.hibernate.mapping.Table;
-import org.hibernate.models.internal.jandex.JandexIndexerHelper;
+import org.hibernate.models.internal.MutableClassDetailsRegistry;
+import org.hibernate.models.jandex.internal.JandexIndexerHelper;
 import org.hibernate.models.spi.ClassDetails;
 import org.hibernate.models.spi.ClassDetailsRegistry;
 import org.hibernate.models.spi.ClassLoading;
@@ -458,7 +459,7 @@ public class MetadataBuildingProcess {
 		xmlProcessingResult.apply( xmlPreProcessingResult.getPersistenceUnitMetadata() );
 
 		return new DomainModelSource(
-				classDetailsRegistry.makeImmutableCopy(),
+				classDetailsRegistry,
 				jandexIndex,
 				allKnownClassNames,
 				modelCategorizationCollector.getGlobalRegistrations(),
@@ -516,40 +517,6 @@ public class MetadataBuildingProcess {
 
 		return CompositeIndex.create( suppliedJandexIndex, jandexIndexer.complete() );
 	}
-//
-//	public static void preFillRegistries(RegistryPrimer.Contributions contributions, SourceModelBuildingContext buildingContext) {
-//		OrmAnnotationHelper.forEachOrmAnnotation( contributions::registerAnnotation );
-//
-//		final IndexView jandexIndex = buildingContext.getJandexIndex();
-//		if ( jandexIndex == null ) {
-//			return;
-//		}
-//
-//		final ClassDetailsRegistry classDetailsRegistry = buildingContext.getClassDetailsRegistry();
-//		final AnnotationDescriptorRegistry annotationDescriptorRegistry = buildingContext.getAnnotationDescriptorRegistry();
-//
-//		for ( ClassInfo knownClass : jandexIndex.getKnownClasses() ) {
-//			final String className = knownClass.name().toString();
-//
-//			if ( knownClass.isAnnotation() ) {
-//				// it is always safe to load the annotation classes - we will never be enhancing them
-//				//noinspection rawtypes
-//				final Class annotationClass = buildingContext
-//						.getClassLoading()
-//						.classForName( className );
-//				//noinspection unchecked
-//				annotationDescriptorRegistry.resolveDescriptor(
-//						annotationClass,
-//						(t) -> JdkBuilders.buildAnnotationDescriptor( annotationClass, buildingContext )
-//				);
-//			}
-//
-//			classDetailsRegistry.resolveClassDetails(
-//					className,
-//					(name) -> new JandexClassDetails( knownClass, buildingContext )
-//			);
-//		}
-//	}
 
 	private static void processAdditionalMappingContributions(
 			InFlightMetadataCollectorImpl metadataCollector,
@@ -628,6 +595,7 @@ public class MetadataBuildingProcess {
 			additionalClassDetails.add( classDetails );
 			metadataCollector.getSourceModelBuildingContext()
 					.getClassDetailsRegistry()
+					.as( MutableClassDetailsRegistry.class )
 					.addClassDetails( classDetails.getName(), classDetails );
 		}
 

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/AccessJpaAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/AccessJpaAnnotation.java
@@ -7,15 +7,11 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
-import org.hibernate.boot.models.JpaAnnotations;
 import org.hibernate.models.spi.SourceModelBuildingContext;
 
-import org.jboss.jandex.AnnotationInstance;
-
 import jakarta.persistence.Access;
-
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJandexValue;
 
 @SuppressWarnings({ "ClassExplicitlyAnnotation", "unused" })
 @jakarta.annotation.Generated("org.hibernate.orm.build.annotations.ClassGeneratorProcessor")
@@ -39,8 +35,8 @@ public class AccessJpaAnnotation implements Access {
 	/**
 	 * Used in creating annotation instances from Jandex variant
 	 */
-	public AccessJpaAnnotation(AnnotationInstance annotation, SourceModelBuildingContext modelContext) {
-		this.value = extractJandexValue( annotation, JpaAnnotations.ACCESS, "value", modelContext );
+	public AccessJpaAnnotation(Map<String, Object> attributeValues, SourceModelBuildingContext modelContext) {
+		this.value = (jakarta.persistence.AccessType) attributeValues.get( "value" );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/AnyAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/AnyAnnotation.java
@@ -7,15 +7,11 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
 import org.hibernate.annotations.Any;
-import org.hibernate.boot.models.HibernateAnnotations;
 import org.hibernate.boot.models.annotations.spi.AttributeMarker;
 import org.hibernate.models.spi.SourceModelBuildingContext;
-
-import org.jboss.jandex.AnnotationInstance;
-
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJandexValue;
 
 @SuppressWarnings({ "ClassExplicitlyAnnotation", "unused" })
 @jakarta.annotation.Generated("org.hibernate.orm.build.annotations.ClassGeneratorProcessor")
@@ -42,9 +38,9 @@ public class AnyAnnotation implements Any, AttributeMarker, AttributeMarker.Fetc
 	/**
 	 * Used in creating annotation instances from Jandex variant
 	 */
-	public AnyAnnotation(AnnotationInstance annotation, SourceModelBuildingContext modelContext) {
-		this.fetch = extractJandexValue( annotation, HibernateAnnotations.ANY, "fetch", modelContext );
-		this.optional = extractJandexValue( annotation, HibernateAnnotations.ANY, "optional", modelContext );
+	public AnyAnnotation(Map<String, Object> attributeValues, SourceModelBuildingContext modelContext) {
+		this.fetch = (jakarta.persistence.FetchType) attributeValues.get( "fetch" );
+		this.optional = (boolean) attributeValues.get( "optional" );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/AnyDiscriminatorAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/AnyDiscriminatorAnnotation.java
@@ -7,14 +7,10 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
 import org.hibernate.annotations.AnyDiscriminator;
-import org.hibernate.boot.models.HibernateAnnotations;
 import org.hibernate.models.spi.SourceModelBuildingContext;
-
-import org.jboss.jandex.AnnotationInstance;
-
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJandexValue;
 
 @SuppressWarnings({ "ClassExplicitlyAnnotation", "unused" })
 @jakarta.annotation.Generated("org.hibernate.orm.build.annotations.ClassGeneratorProcessor")
@@ -38,8 +34,8 @@ public class AnyDiscriminatorAnnotation implements AnyDiscriminator {
 	/**
 	 * Used in creating annotation instances from Jandex variant
 	 */
-	public AnyDiscriminatorAnnotation(AnnotationInstance annotation, SourceModelBuildingContext modelContext) {
-		this.value = extractJandexValue( annotation, HibernateAnnotations.ANY_DISCRIMINATOR, "value", modelContext );
+	public AnyDiscriminatorAnnotation(Map<String, Object> attributeValues, SourceModelBuildingContext modelContext) {
+		this.value = (jakarta.persistence.DiscriminatorType) attributeValues.get( "value" );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/AnyDiscriminatorValueAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/AnyDiscriminatorValueAnnotation.java
@@ -7,14 +7,10 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
 import org.hibernate.annotations.AnyDiscriminatorValue;
-import org.hibernate.boot.models.HibernateAnnotations;
 import org.hibernate.models.spi.SourceModelBuildingContext;
-
-import org.jboss.jandex.AnnotationInstance;
-
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJandexValue;
 
 @SuppressWarnings({ "ClassExplicitlyAnnotation", "unused" })
 @jakarta.annotation.Generated("org.hibernate.orm.build.annotations.ClassGeneratorProcessor")
@@ -39,19 +35,9 @@ public class AnyDiscriminatorValueAnnotation implements AnyDiscriminatorValue {
 	/**
 	 * Used in creating annotation instances from Jandex variant
 	 */
-	public AnyDiscriminatorValueAnnotation(AnnotationInstance annotation, SourceModelBuildingContext modelContext) {
-		this.discriminator = extractJandexValue(
-				annotation,
-				HibernateAnnotations.ANY_DISCRIMINATOR_VALUE,
-				"discriminator",
-				modelContext
-		);
-		this.entity = extractJandexValue(
-				annotation,
-				HibernateAnnotations.ANY_DISCRIMINATOR_VALUE,
-				"entity",
-				modelContext
-		);
+	public AnyDiscriminatorValueAnnotation(Map<String, Object> attributeValues, SourceModelBuildingContext modelContext) {
+		this.discriminator = (String) attributeValues.get( "discriminator" );
+		this.entity = (Class<?>) attributeValues.get( "entity" );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/AnyDiscriminatorValuesAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/AnyDiscriminatorValuesAnnotation.java
@@ -6,18 +6,15 @@
  */
 package org.hibernate.boot.models.annotations.internal;
 
+import java.lang.annotation.Annotation;
+import java.util.Map;
+
 import org.hibernate.annotations.AnyDiscriminatorValue;
+import org.hibernate.annotations.AnyDiscriminatorValues;
 import org.hibernate.boot.models.HibernateAnnotations;
 import org.hibernate.boot.models.annotations.spi.RepeatableContainer;
 import org.hibernate.models.spi.SourceModelBuildingContext;
 
-import org.jboss.jandex.AnnotationInstance;
-
-import java.lang.annotation.Annotation;
-
-import org.hibernate.annotations.AnyDiscriminatorValues;
-
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJandexValue;
 import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJdkValue;
 
 @SuppressWarnings({ "ClassExplicitlyAnnotation", "unused" })
@@ -49,13 +46,8 @@ public class AnyDiscriminatorValuesAnnotation
 	/**
 	 * Used in creating annotation instances from Jandex variant
 	 */
-	public AnyDiscriminatorValuesAnnotation(AnnotationInstance annotation, SourceModelBuildingContext modelContext) {
-		this.value = extractJandexValue(
-				annotation,
-				HibernateAnnotations.ANY_DISCRIMINATOR_VALUES,
-				"value",
-				modelContext
-		);
+	public AnyDiscriminatorValuesAnnotation(Map<String, Object> attributeValues, SourceModelBuildingContext modelContext) {
+		this.value = (AnyDiscriminatorValue[]) attributeValues.get( "value" );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/AnyKeTypeAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/AnyKeTypeAnnotation.java
@@ -7,14 +7,10 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
 import org.hibernate.boot.internal.AnyKeyType;
-import org.hibernate.boot.models.XmlAnnotations;
 import org.hibernate.models.spi.SourceModelBuildingContext;
-
-import org.jboss.jandex.AnnotationInstance;
-
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJandexValue;
 
 @SuppressWarnings({ "ClassExplicitlyAnnotation", "unused" })
 @jakarta.annotation.Generated("org.hibernate.orm.build.annotations.ClassGeneratorProcessor")
@@ -37,8 +33,8 @@ public class AnyKeTypeAnnotation implements AnyKeyType {
 	/**
 	 * Used in creating annotation instances from Jandex variant
 	 */
-	public AnyKeTypeAnnotation(AnnotationInstance annotation, SourceModelBuildingContext modelContext) {
-		this.value = extractJandexValue( annotation, XmlAnnotations.ANY_KEY_TYPE, "value", modelContext );
+	public AnyKeTypeAnnotation(Map<String, Object> attributeValues, SourceModelBuildingContext modelContext) {
+		this.value = (String) attributeValues.get( "value" );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/AnyKeyJavaClassAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/AnyKeyJavaClassAnnotation.java
@@ -7,13 +7,10 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
 import org.hibernate.annotations.AnyKeyJavaClass;
 import org.hibernate.models.spi.SourceModelBuildingContext;
-
-import org.jboss.jandex.AnnotationInstance;
-
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJandexValue;
 
 @SuppressWarnings({ "ClassExplicitlyAnnotation", "unused" })
 @jakarta.annotation.Generated("org.hibernate.orm.build.annotations.ClassGeneratorProcessor")
@@ -36,13 +33,8 @@ public class AnyKeyJavaClassAnnotation implements AnyKeyJavaClass {
 	/**
 	 * Used in creating annotation instances from Jandex variant
 	 */
-	public AnyKeyJavaClassAnnotation(AnnotationInstance annotation, SourceModelBuildingContext modelContext) {
-		this.value = extractJandexValue(
-				annotation,
-				org.hibernate.boot.models.HibernateAnnotations.ANY_KEY_JAVA_CLASS,
-				"value",
-				modelContext
-		);
+	public AnyKeyJavaClassAnnotation(Map<String, Object> attributeValues, SourceModelBuildingContext modelContext) {
+		this.value = (Class<?>) attributeValues.get( "value" );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/AnyKeyJavaTypeAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/AnyKeyJavaTypeAnnotation.java
@@ -7,14 +7,11 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
 import org.hibernate.annotations.AnyKeyJavaType;
 import org.hibernate.models.spi.SourceModelBuildingContext;
 import org.hibernate.type.descriptor.java.BasicJavaType;
-
-import org.jboss.jandex.AnnotationInstance;
-
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJandexValue;
 
 @SuppressWarnings({ "ClassExplicitlyAnnotation", "unused" })
 @jakarta.annotation.Generated("org.hibernate.orm.build.annotations.ClassGeneratorProcessor")
@@ -37,13 +34,8 @@ public class AnyKeyJavaTypeAnnotation implements AnyKeyJavaType {
 	/**
 	 * Used in creating annotation instances from Jandex variant
 	 */
-	public AnyKeyJavaTypeAnnotation(AnnotationInstance annotation, SourceModelBuildingContext modelContext) {
-		this.value = extractJandexValue(
-				annotation,
-				org.hibernate.boot.models.HibernateAnnotations.ANY_KEY_JAVA_TYPE,
-				"value",
-				modelContext
-		);
+	public AnyKeyJavaTypeAnnotation(Map<String, Object> attributeValues, SourceModelBuildingContext modelContext) {
+		this.value = (Class<? extends BasicJavaType<?>>) attributeValues.get( "value" );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/AnyKeyJdbcTypeAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/AnyKeyJdbcTypeAnnotation.java
@@ -7,14 +7,11 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
 import org.hibernate.annotations.AnyKeyJdbcType;
 import org.hibernate.models.spi.SourceModelBuildingContext;
 import org.hibernate.type.descriptor.jdbc.JdbcType;
-
-import org.jboss.jandex.AnnotationInstance;
-
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJandexValue;
 
 @SuppressWarnings({ "ClassExplicitlyAnnotation", "unused" })
 @jakarta.annotation.Generated("org.hibernate.orm.build.annotations.ClassGeneratorProcessor")
@@ -37,13 +34,8 @@ public class AnyKeyJdbcTypeAnnotation implements AnyKeyJdbcType {
 	/**
 	 * Used in creating annotation instances from Jandex variant
 	 */
-	public AnyKeyJdbcTypeAnnotation(AnnotationInstance annotation, SourceModelBuildingContext modelContext) {
-		this.value = extractJandexValue(
-				annotation,
-				org.hibernate.boot.models.HibernateAnnotations.ANY_KEY_JDBC_TYPE,
-				"value",
-				modelContext
-		);
+	public AnyKeyJdbcTypeAnnotation(Map<String, Object> attributeValues, SourceModelBuildingContext modelContext) {
+		this.value = (Class<? extends JdbcType>) attributeValues.get( "value" );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/AnyKeyJdbcTypeCodeAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/AnyKeyJdbcTypeCodeAnnotation.java
@@ -7,13 +7,10 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
 import org.hibernate.annotations.AnyKeyJdbcTypeCode;
 import org.hibernate.models.spi.SourceModelBuildingContext;
-
-import org.jboss.jandex.AnnotationInstance;
-
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJandexValue;
 
 @SuppressWarnings({ "ClassExplicitlyAnnotation", "unused" })
 @jakarta.annotation.Generated("org.hibernate.orm.build.annotations.ClassGeneratorProcessor")
@@ -36,13 +33,8 @@ public class AnyKeyJdbcTypeCodeAnnotation implements AnyKeyJdbcTypeCode {
 	/**
 	 * Used in creating annotation instances from Jandex variant
 	 */
-	public AnyKeyJdbcTypeCodeAnnotation(AnnotationInstance annotation, SourceModelBuildingContext modelContext) {
-		this.value = extractJandexValue(
-				annotation,
-				org.hibernate.boot.models.HibernateAnnotations.ANY_KEY_JDBC_TYPE_CODE,
-				"value",
-				modelContext
-		);
+	public AnyKeyJdbcTypeCodeAnnotation(Map<String, Object> attributeValues, SourceModelBuildingContext modelContext) {
+		this.value = (int) attributeValues.get( "value" );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/AnyKeyTypeXmlAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/AnyKeyTypeXmlAnnotation.java
@@ -7,14 +7,11 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
 import org.hibernate.boot.internal.Abstract;
 import org.hibernate.boot.internal.AnyKeyType;
 import org.hibernate.models.spi.SourceModelBuildingContext;
-
-import org.jboss.jandex.AnnotationInstance;
-
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJandexValue;
 
 /**
  * @author Steve Ebersole
@@ -39,13 +36,8 @@ public class AnyKeyTypeXmlAnnotation implements AnyKeyType {
 	/**
 	 * Used in creating annotation instances from Jandex variant
 	 */
-	public AnyKeyTypeXmlAnnotation(AnnotationInstance annotation, SourceModelBuildingContext modelContext) {
-		this.value = extractJandexValue(
-				annotation,
-				org.hibernate.boot.models.XmlAnnotations.ANY_KEY_TYPE,
-				"value",
-				modelContext
-		);
+	public AnyKeyTypeXmlAnnotation(Map<String, Object> attributeValues, SourceModelBuildingContext modelContext) {
+		this.value = (String) attributeValues.get( "value" );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/ArrayAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/ArrayAnnotation.java
@@ -7,14 +7,10 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
 import org.hibernate.annotations.Array;
-import org.hibernate.boot.models.HibernateAnnotations;
 import org.hibernate.models.spi.SourceModelBuildingContext;
-
-import org.jboss.jandex.AnnotationInstance;
-
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJandexValue;
 
 @SuppressWarnings({ "ClassExplicitlyAnnotation", "unused" })
 @jakarta.annotation.Generated("org.hibernate.orm.build.annotations.ClassGeneratorProcessor")
@@ -37,8 +33,8 @@ public class ArrayAnnotation implements Array {
 	/**
 	 * Used in creating annotation instances from Jandex variant
 	 */
-	public ArrayAnnotation(AnnotationInstance annotation, SourceModelBuildingContext modelContext) {
-		this.length = extractJandexValue( annotation, HibernateAnnotations.ARRAY, "length", modelContext );
+	public ArrayAnnotation(Map<String, Object> attributeValues, SourceModelBuildingContext modelContext) {
+		this.length = (int) attributeValues.get( "length" );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/AssociationOverrideJpaAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/AssociationOverrideJpaAnnotation.java
@@ -7,16 +7,15 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
 import org.hibernate.boot.models.JpaAnnotations;
 import org.hibernate.models.spi.SourceModelBuildingContext;
 
-import org.jboss.jandex.AnnotationInstance;
 
 import jakarta.persistence.AssociationOverride;
 
 import static org.hibernate.boot.models.JpaAnnotations.ASSOCIATION_OVERRIDE;
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJandexValue;
 import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJdkValue;
 
 @SuppressWarnings({ "ClassExplicitlyAnnotation", "unused" })
@@ -50,11 +49,13 @@ public class AssociationOverrideJpaAnnotation implements AssociationOverride {
 	/**
 	 * Used in creating annotation instances from Jandex variant
 	 */
-	public AssociationOverrideJpaAnnotation(AnnotationInstance annotation, SourceModelBuildingContext modelContext) {
-		this.name = extractJandexValue( annotation, ASSOCIATION_OVERRIDE, "name", modelContext );
-		this.joinColumns = extractJandexValue( annotation, ASSOCIATION_OVERRIDE, "joinColumns", modelContext );
-		this.foreignKey = extractJandexValue( annotation, ASSOCIATION_OVERRIDE, "foreignKey", modelContext );
-		this.joinTable = extractJandexValue( annotation, ASSOCIATION_OVERRIDE, "joinTable", modelContext );
+	public AssociationOverrideJpaAnnotation(
+			Map<String, Object> attributeValues,
+			SourceModelBuildingContext modelContext) {
+		this.name = (String) attributeValues.get( "name" );
+		this.joinColumns = (jakarta.persistence.JoinColumn[]) attributeValues.get( "joinColumns" );
+		this.foreignKey = (jakarta.persistence.ForeignKey) attributeValues.get( "foreignKey" );
+		this.joinTable = (jakarta.persistence.JoinTable) attributeValues.get( "joinTable" );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/AssociationOverridesJpaAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/AssociationOverridesJpaAnnotation.java
@@ -7,15 +7,13 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
 import org.hibernate.boot.models.JpaAnnotations;
 import org.hibernate.models.spi.SourceModelBuildingContext;
 
-import org.jboss.jandex.AnnotationInstance;
-
 import jakarta.persistence.AssociationOverrides;
 
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJandexValue;
 import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJdkValue;
 
 @SuppressWarnings({ "ClassExplicitlyAnnotation", "unused" })
@@ -39,8 +37,10 @@ public class AssociationOverridesJpaAnnotation implements AssociationOverrides {
 	/**
 	 * Used in creating annotation instances from Jandex variant
 	 */
-	public AssociationOverridesJpaAnnotation(AnnotationInstance annotation, SourceModelBuildingContext modelContext) {
-		this.value = extractJandexValue( annotation, JpaAnnotations.ASSOCIATION_OVERRIDES, "value", modelContext );
+	public AssociationOverridesJpaAnnotation(
+			Map<String, Object> attributeValues,
+			SourceModelBuildingContext modelContext) {
+		this.value = (jakarta.persistence.AssociationOverride[]) attributeValues.get( "value" );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/AttributeAccessorAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/AttributeAccessorAnnotation.java
@@ -7,9 +7,9 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
 import org.hibernate.annotations.AttributeAccessor;
-import org.hibernate.boot.models.HibernateAnnotations;
 import org.hibernate.models.spi.SourceModelBuildingContext;
 
 import org.jboss.jandex.AnnotationInstance;
@@ -41,14 +41,10 @@ public class AttributeAccessorAnnotation implements AttributeAccessor {
 	/**
 	 * Used in creating annotation instances from Jandex variant
 	 */
-	public AttributeAccessorAnnotation(AnnotationInstance annotation, SourceModelBuildingContext modelContext) {
-		this.value = extractJandexValue( annotation, HibernateAnnotations.ATTRIBUTE_ACCESSOR, "value", modelContext );
-		this.strategy = extractJandexValue(
-				annotation,
-				HibernateAnnotations.ATTRIBUTE_ACCESSOR,
-				"strategy",
-				modelContext
-		);
+	public AttributeAccessorAnnotation(Map<String, Object> attributeValues, SourceModelBuildingContext modelContext) {
+		this.value = (String) attributeValues.get( "value" );
+		this.strategy = (Class<? extends org.hibernate.property.access.spi.PropertyAccessStrategy>) attributeValues
+				.get( "strategy" );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/AttributeBinderTypeAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/AttributeBinderTypeAnnotation.java
@@ -7,13 +7,10 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
 import org.hibernate.annotations.AttributeBinderType;
 import org.hibernate.models.spi.SourceModelBuildingContext;
-
-import org.jboss.jandex.AnnotationInstance;
-
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJandexValue;
 
 @SuppressWarnings({ "ClassExplicitlyAnnotation", "unused" })
 @jakarta.annotation.Generated("org.hibernate.orm.build.annotations.ClassGeneratorProcessor")
@@ -36,13 +33,8 @@ public class AttributeBinderTypeAnnotation implements AttributeBinderType {
 	/**
 	 * Used in creating annotation instances from Jandex variant
 	 */
-	public AttributeBinderTypeAnnotation(AnnotationInstance annotation, SourceModelBuildingContext modelContext) {
-		this.binder = extractJandexValue(
-				annotation,
-				org.hibernate.boot.models.HibernateAnnotations.ATTRIBUTE_BINDER_TYPE,
-				"binder",
-				modelContext
-		);
+	public AttributeBinderTypeAnnotation(Map<String, Object> attributeValues, SourceModelBuildingContext modelContext) {
+		this.binder = (Class<? extends org.hibernate.binder.AttributeBinder<?>>) attributeValues.get( "binder" );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/AttributeOverrideJpaAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/AttributeOverrideJpaAnnotation.java
@@ -7,15 +7,13 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
 import org.hibernate.boot.models.JpaAnnotations;
 import org.hibernate.models.spi.SourceModelBuildingContext;
 
-import org.jboss.jandex.AnnotationInstance;
-
 import jakarta.persistence.AttributeOverride;
 
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJandexValue;
 import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJdkValue;
 
 @SuppressWarnings({ "ClassExplicitlyAnnotation", "unused" })
@@ -42,9 +40,9 @@ public class AttributeOverrideJpaAnnotation implements AttributeOverride {
 	/**
 	 * Used in creating annotation instances from Jandex variant
 	 */
-	public AttributeOverrideJpaAnnotation(AnnotationInstance annotation, SourceModelBuildingContext modelContext) {
-		this.name = extractJandexValue( annotation, JpaAnnotations.ATTRIBUTE_OVERRIDE, "name", modelContext );
-		this.column = extractJandexValue( annotation, JpaAnnotations.ATTRIBUTE_OVERRIDE, "column", modelContext );
+	public AttributeOverrideJpaAnnotation(Map<String, Object> attributeValues, SourceModelBuildingContext modelContext) {
+		this.name = (String) attributeValues.get( "name" );
+		this.column = (jakarta.persistence.Column) attributeValues.get( "column" );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/AttributeOverridesJpaAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/AttributeOverridesJpaAnnotation.java
@@ -7,15 +7,13 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
 import org.hibernate.boot.models.JpaAnnotations;
 import org.hibernate.models.spi.SourceModelBuildingContext;
 
-import org.jboss.jandex.AnnotationInstance;
-
 import jakarta.persistence.AttributeOverrides;
 
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJandexValue;
 import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJdkValue;
 
 @SuppressWarnings({ "ClassExplicitlyAnnotation", "unused" })
@@ -39,8 +37,8 @@ public class AttributeOverridesJpaAnnotation implements AttributeOverrides {
 	/**
 	 * Used in creating annotation instances from Jandex variant
 	 */
-	public AttributeOverridesJpaAnnotation(AnnotationInstance annotation, SourceModelBuildingContext modelContext) {
-		this.value = extractJandexValue( annotation, JpaAnnotations.ATTRIBUTE_OVERRIDES, "value", modelContext );
+	public AttributeOverridesJpaAnnotation(Map<String, Object> attributeValues, SourceModelBuildingContext modelContext) {
+		this.value = (jakarta.persistence.AttributeOverride[]) attributeValues.get( "value" );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/BagAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/BagAnnotation.java
@@ -6,13 +6,11 @@
  */
 package org.hibernate.boot.models.annotations.internal;
 
-import org.hibernate.models.spi.SourceModelBuildingContext;
-
-import org.jboss.jandex.AnnotationInstance;
-
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
 import org.hibernate.annotations.Bag;
+import org.hibernate.models.spi.SourceModelBuildingContext;
 
 @SuppressWarnings({ "ClassExplicitlyAnnotation", "unused" })
 @jakarta.annotation.Generated("org.hibernate.orm.build.annotations.ClassGeneratorProcessor")
@@ -32,7 +30,7 @@ public class BagAnnotation implements Bag {
 	/**
 	 * Used in creating annotation instances from Jandex variant
 	 */
-	public BagAnnotation(AnnotationInstance annotation, SourceModelBuildingContext modelContext) {
+	public BagAnnotation(Map<String, Object> attributeValues, SourceModelBuildingContext modelContext) {
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/BasicJpaAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/BasicJpaAnnotation.java
@@ -7,16 +7,12 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
-import org.hibernate.boot.models.JpaAnnotations;
 import org.hibernate.boot.models.annotations.spi.AttributeMarker;
 import org.hibernate.models.spi.SourceModelBuildingContext;
 
-import org.jboss.jandex.AnnotationInstance;
-
 import jakarta.persistence.Basic;
-
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJandexValue;
 
 @SuppressWarnings({ "ClassExplicitlyAnnotation", "unused" })
 @jakarta.annotation.Generated("org.hibernate.orm.build.annotations.ClassGeneratorProcessor")
@@ -45,9 +41,9 @@ public class BasicJpaAnnotation
 	/**
 	 * Used in creating annotation instances from Jandex variant
 	 */
-	public BasicJpaAnnotation(AnnotationInstance annotation, SourceModelBuildingContext modelContext) {
-		this.fetch = extractJandexValue( annotation, JpaAnnotations.BASIC, "fetch", modelContext );
-		this.optional = extractJandexValue( annotation, JpaAnnotations.BASIC, "optional", modelContext );
+	public BasicJpaAnnotation(Map<String, Object> attributeValues, SourceModelBuildingContext modelContext) {
+		this.fetch = (jakarta.persistence.FetchType) attributeValues.get( "fetch" );
+		this.optional = (boolean) attributeValues.get( "optional" );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/BatchSizeAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/BatchSizeAnnotation.java
@@ -7,14 +7,10 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
 import org.hibernate.annotations.BatchSize;
-import org.hibernate.boot.models.HibernateAnnotations;
 import org.hibernate.models.spi.SourceModelBuildingContext;
-
-import org.jboss.jandex.AnnotationInstance;
-
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJandexValue;
 
 @SuppressWarnings({ "ClassExplicitlyAnnotation", "unused" })
 @jakarta.annotation.Generated("org.hibernate.orm.build.annotations.ClassGeneratorProcessor")
@@ -37,8 +33,8 @@ public class BatchSizeAnnotation implements BatchSize {
 	/**
 	 * Used in creating annotation instances from Jandex variant
 	 */
-	public BatchSizeAnnotation(AnnotationInstance annotation, SourceModelBuildingContext modelContext) {
-		this.size = extractJandexValue( annotation, HibernateAnnotations.BATCH_SIZE, "size", modelContext );
+	public BatchSizeAnnotation(Map<String, Object> attributeValues, SourceModelBuildingContext modelContext) {
+		this.size = (int) attributeValues.get( "size" );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/CacheAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/CacheAnnotation.java
@@ -7,14 +7,10 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
 import org.hibernate.annotations.Cache;
-import org.hibernate.boot.models.HibernateAnnotations;
 import org.hibernate.models.spi.SourceModelBuildingContext;
-
-import org.jboss.jandex.AnnotationInstance;
-
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJandexValue;
 
 @SuppressWarnings({ "ClassExplicitlyAnnotation", "unused" })
 @jakarta.annotation.Generated("org.hibernate.orm.build.annotations.ClassGeneratorProcessor")
@@ -46,11 +42,11 @@ public class CacheAnnotation implements Cache {
 	/**
 	 * Used in creating annotation instances from Jandex variant
 	 */
-	public CacheAnnotation(AnnotationInstance annotation, SourceModelBuildingContext modelContext) {
-		this.usage = extractJandexValue( annotation, HibernateAnnotations.CACHE, "usage", modelContext );
-		this.region = extractJandexValue( annotation, HibernateAnnotations.CACHE, "region", modelContext );
-		this.includeLazy = extractJandexValue( annotation, HibernateAnnotations.CACHE, "includeLazy", modelContext );
-		this.include = extractJandexValue( annotation, HibernateAnnotations.CACHE, "include", modelContext );
+	public CacheAnnotation(Map<String, Object> attributeValues, SourceModelBuildingContext modelContext) {
+		this.usage = (org.hibernate.annotations.CacheConcurrencyStrategy) attributeValues.get( "usage" );
+		this.region = (String) attributeValues.get( "region" );
+		this.includeLazy = (boolean) attributeValues.get( "includeLazy" );
+		this.include = (String) attributeValues.get( "include" );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/CacheableJpaAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/CacheableJpaAnnotation.java
@@ -7,15 +7,11 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
-import org.hibernate.boot.models.JpaAnnotations;
 import org.hibernate.models.spi.SourceModelBuildingContext;
 
-import org.jboss.jandex.AnnotationInstance;
-
 import jakarta.persistence.Cacheable;
-
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJandexValue;
 
 @SuppressWarnings({ "ClassExplicitlyAnnotation", "unused" })
 @jakarta.annotation.Generated("org.hibernate.orm.build.annotations.ClassGeneratorProcessor")
@@ -39,8 +35,8 @@ public class CacheableJpaAnnotation implements Cacheable {
 	/**
 	 * Used in creating annotation instances from Jandex variant
 	 */
-	public CacheableJpaAnnotation(AnnotationInstance annotation, SourceModelBuildingContext modelContext) {
-		this.value = extractJandexValue( annotation, JpaAnnotations.CACHEABLE, "value", modelContext );
+	public CacheableJpaAnnotation(Map<String, Object> attributeValues, SourceModelBuildingContext modelContext) {
+		this.value = (boolean) attributeValues.get( "value" );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/CascadeAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/CascadeAnnotation.java
@@ -7,14 +7,10 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
 import org.hibernate.annotations.Cascade;
-import org.hibernate.boot.models.HibernateAnnotations;
 import org.hibernate.models.spi.SourceModelBuildingContext;
-
-import org.jboss.jandex.AnnotationInstance;
-
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJandexValue;
 
 @SuppressWarnings({ "ClassExplicitlyAnnotation", "unused" })
 @jakarta.annotation.Generated("org.hibernate.orm.build.annotations.ClassGeneratorProcessor")
@@ -37,8 +33,8 @@ public class CascadeAnnotation implements Cascade {
 	/**
 	 * Used in creating annotation instances from Jandex variant
 	 */
-	public CascadeAnnotation(AnnotationInstance annotation, SourceModelBuildingContext modelContext) {
-		this.value = extractJandexValue( annotation, HibernateAnnotations.CASCADE, "value", modelContext );
+	public CascadeAnnotation(Map<String, Object> attributeValues, SourceModelBuildingContext modelContext) {
+		this.value = (org.hibernate.annotations.CascadeType[]) attributeValues.get( "value" );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/CheckAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/CheckAnnotation.java
@@ -7,13 +7,10 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
 import org.hibernate.annotations.Check;
 import org.hibernate.models.spi.SourceModelBuildingContext;
-
-import org.jboss.jandex.AnnotationInstance;
-
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJandexValue;
 
 @SuppressWarnings({ "ClassExplicitlyAnnotation", "unused" })
 @jakarta.annotation.Generated("org.hibernate.orm.build.annotations.ClassGeneratorProcessor")
@@ -39,19 +36,9 @@ public class CheckAnnotation implements Check {
 	/**
 	 * Used in creating annotation instances from Jandex variant
 	 */
-	public CheckAnnotation(AnnotationInstance annotation, SourceModelBuildingContext modelContext) {
-		this.name = extractJandexValue(
-				annotation,
-				org.hibernate.boot.models.HibernateAnnotations.CHECK,
-				"name",
-				modelContext
-		);
-		this.constraints = extractJandexValue(
-				annotation,
-				org.hibernate.boot.models.HibernateAnnotations.CHECK,
-				"constraints",
-				modelContext
-		);
+	public CheckAnnotation(Map<String, Object> attributeValues, SourceModelBuildingContext modelContext) {
+		this.name = (String) attributeValues.get( "name" );
+		this.constraints = (String) attributeValues.get( "constraints" );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/CheckConstraintJpaAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/CheckConstraintJpaAnnotation.java
@@ -7,15 +7,11 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
-import org.hibernate.boot.models.JpaAnnotations;
 import org.hibernate.models.spi.SourceModelBuildingContext;
 
-import org.jboss.jandex.AnnotationInstance;
-
 import jakarta.persistence.CheckConstraint;
-
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJandexValue;
 
 @SuppressWarnings({ "ClassExplicitlyAnnotation", "unused" })
 @jakarta.annotation.Generated("org.hibernate.orm.build.annotations.ClassGeneratorProcessor")
@@ -45,10 +41,10 @@ public class CheckConstraintJpaAnnotation implements CheckConstraint {
 	/**
 	 * Used in creating annotation instances from Jandex variant
 	 */
-	public CheckConstraintJpaAnnotation(AnnotationInstance annotation, SourceModelBuildingContext modelContext) {
-		this.name = extractJandexValue( annotation, JpaAnnotations.CHECK_CONSTRAINT, "name", modelContext );
-		this.constraint = extractJandexValue( annotation, JpaAnnotations.CHECK_CONSTRAINT, "constraint", modelContext );
-		this.options = extractJandexValue( annotation, JpaAnnotations.CHECK_CONSTRAINT, "options", modelContext );
+	public CheckConstraintJpaAnnotation(Map<String, Object> attributeValues, SourceModelBuildingContext modelContext) {
+		this.name = (String) attributeValues.get( "name" );
+		this.constraint = (String) attributeValues.get( "constraint" );
+		this.options = (String) attributeValues.get( "options" );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/ChecksAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/ChecksAnnotation.java
@@ -7,6 +7,7 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
 import org.hibernate.annotations.Check;
 import org.hibernate.annotations.Checks;
@@ -14,9 +15,6 @@ import org.hibernate.boot.models.HibernateAnnotations;
 import org.hibernate.boot.models.annotations.spi.RepeatableContainer;
 import org.hibernate.models.spi.SourceModelBuildingContext;
 
-import org.jboss.jandex.AnnotationInstance;
-
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJandexValue;
 import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJdkValue;
 
 @SuppressWarnings({ "ClassExplicitlyAnnotation", "unused" })
@@ -40,8 +38,8 @@ public class ChecksAnnotation implements Checks, RepeatableContainer<Check> {
 	/**
 	 * Used in creating annotation instances from Jandex variant
 	 */
-	public ChecksAnnotation(AnnotationInstance annotation, SourceModelBuildingContext modelContext) {
-		this.value = extractJandexValue( annotation, HibernateAnnotations.CHECKS, "value", modelContext );
+	public ChecksAnnotation(Map<String, Object> attributeValues, SourceModelBuildingContext modelContext) {
+		this.value = (Check[]) attributeValues.get( "value" );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/CollateAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/CollateAnnotation.java
@@ -7,14 +7,10 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
 import org.hibernate.annotations.Collate;
-import org.hibernate.boot.models.HibernateAnnotations;
 import org.hibernate.models.spi.SourceModelBuildingContext;
-
-import org.jboss.jandex.AnnotationInstance;
-
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJandexValue;
 
 @SuppressWarnings({ "ClassExplicitlyAnnotation", "unused" })
 @jakarta.annotation.Generated("org.hibernate.orm.build.annotations.ClassGeneratorProcessor")
@@ -37,8 +33,8 @@ public class CollateAnnotation implements Collate {
 	/**
 	 * Used in creating annotation instances from Jandex variant
 	 */
-	public CollateAnnotation(AnnotationInstance annotation, SourceModelBuildingContext modelContext) {
-		this.value = extractJandexValue( annotation, HibernateAnnotations.COLLATE, "value", modelContext );
+	public CollateAnnotation(Map<String, Object> attributeValues, SourceModelBuildingContext modelContext) {
+		this.value = (String) attributeValues.get( "value" );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/CollectionClassificationXmlAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/CollectionClassificationXmlAnnotation.java
@@ -7,15 +7,11 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
 import org.hibernate.boot.internal.CollectionClassification;
 import org.hibernate.boot.internal.LimitedCollectionClassification;
-import org.hibernate.boot.models.XmlAnnotations;
 import org.hibernate.models.spi.SourceModelBuildingContext;
-
-import org.jboss.jandex.AnnotationInstance;
-
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJandexValue;
 
 @SuppressWarnings({ "ClassExplicitlyAnnotation", "unused" })
 @jakarta.annotation.Generated("org.hibernate.orm.build.annotations.ClassGeneratorProcessor")
@@ -41,9 +37,9 @@ public class CollectionClassificationXmlAnnotation implements CollectionClassifi
 	 * Used in creating annotation instances from Jandex variant
 	 */
 	public CollectionClassificationXmlAnnotation(
-			AnnotationInstance annotation,
+			Map<String, Object> attributeValues,
 			SourceModelBuildingContext modelContext) {
-		this.value = extractJandexValue( annotation, XmlAnnotations.COLLECTION_CLASSIFICATION, "value", modelContext );
+		this.value = (LimitedCollectionClassification) attributeValues.get( "value" );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/CollectionIdAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/CollectionIdAnnotation.java
@@ -7,15 +7,13 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
 import org.hibernate.annotations.CollectionId;
 import org.hibernate.boot.models.HibernateAnnotations;
 import org.hibernate.boot.models.JpaAnnotations;
 import org.hibernate.models.spi.SourceModelBuildingContext;
 
-import org.jboss.jandex.AnnotationInstance;
-
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJandexValue;
 import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJdkValue;
 
 @SuppressWarnings({ "ClassExplicitlyAnnotation", "unused" })
@@ -46,20 +44,11 @@ public class CollectionIdAnnotation implements CollectionId {
 	/**
 	 * Used in creating annotation instances from Jandex variant
 	 */
-	public CollectionIdAnnotation(AnnotationInstance annotation, SourceModelBuildingContext modelContext) {
-		this.column = extractJandexValue( annotation, HibernateAnnotations.COLLECTION_ID, "column", modelContext );
-		this.generatorImplementation = extractJandexValue(
-				annotation,
-				HibernateAnnotations.COLLECTION_ID,
-				"generatorImplementation",
-				modelContext
-		);
-		this.generator = extractJandexValue(
-				annotation,
-				HibernateAnnotations.COLLECTION_ID,
-				"generator",
-				modelContext
-		);
+	public CollectionIdAnnotation(Map<String, Object> attributeValues, SourceModelBuildingContext modelContext) {
+		this.column = (jakarta.persistence.Column) attributeValues.get( "column" );
+		this.generatorImplementation = (Class<? extends org.hibernate.id.IdentifierGenerator>) attributeValues
+				.get( "generatorImplementation" );
+		this.generator = (String) attributeValues.get( "generator" );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/CollectionIdJavaTypeAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/CollectionIdJavaTypeAnnotation.java
@@ -7,14 +7,10 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
 import org.hibernate.annotations.CollectionIdJavaType;
-import org.hibernate.boot.models.HibernateAnnotations;
 import org.hibernate.models.spi.SourceModelBuildingContext;
-
-import org.jboss.jandex.AnnotationInstance;
-
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJandexValue;
 
 @SuppressWarnings({ "ClassExplicitlyAnnotation", "unused" })
 @jakarta.annotation.Generated("org.hibernate.orm.build.annotations.ClassGeneratorProcessor")
@@ -37,13 +33,8 @@ public class CollectionIdJavaTypeAnnotation implements CollectionIdJavaType {
 	/**
 	 * Used in creating annotation instances from Jandex variant
 	 */
-	public CollectionIdJavaTypeAnnotation(AnnotationInstance annotation, SourceModelBuildingContext modelContext) {
-		this.value = extractJandexValue(
-				annotation,
-				HibernateAnnotations.COLLECTION_ID_JAVA_TYPE,
-				"value",
-				modelContext
-		);
+	public CollectionIdJavaTypeAnnotation(Map<String, Object> attributeValues, SourceModelBuildingContext modelContext) {
+		this.value = (Class<? extends org.hibernate.type.descriptor.java.BasicJavaType<?>>) attributeValues.get( "value" );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/CollectionIdJdbcTypeAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/CollectionIdJdbcTypeAnnotation.java
@@ -7,15 +7,11 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
 import org.hibernate.annotations.CollectionIdJdbcType;
-import org.hibernate.boot.models.HibernateAnnotations;
 import org.hibernate.models.spi.SourceModelBuildingContext;
 import org.hibernate.type.descriptor.jdbc.JdbcType;
-
-import org.jboss.jandex.AnnotationInstance;
-
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJandexValue;
 
 @SuppressWarnings({ "ClassExplicitlyAnnotation", "unused" })
 @jakarta.annotation.Generated("org.hibernate.orm.build.annotations.ClassGeneratorProcessor")
@@ -38,13 +34,8 @@ public class CollectionIdJdbcTypeAnnotation implements CollectionIdJdbcType {
 	/**
 	 * Used in creating annotation instances from Jandex variant
 	 */
-	public CollectionIdJdbcTypeAnnotation(AnnotationInstance annotation, SourceModelBuildingContext modelContext) {
-		this.value = extractJandexValue(
-				annotation,
-				HibernateAnnotations.COLLECTION_ID_JDBC_TYPE,
-				"value",
-				modelContext
-		);
+	public CollectionIdJdbcTypeAnnotation(Map<String, Object> attributeValues, SourceModelBuildingContext modelContext) {
+		this.value = (Class<? extends JdbcType>) attributeValues.get( "value" );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/CollectionIdJdbcTypeCodeAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/CollectionIdJdbcTypeCodeAnnotation.java
@@ -7,14 +7,10 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
 import org.hibernate.annotations.CollectionIdJdbcTypeCode;
-import org.hibernate.boot.models.HibernateAnnotations;
 import org.hibernate.models.spi.SourceModelBuildingContext;
-
-import org.jboss.jandex.AnnotationInstance;
-
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJandexValue;
 
 @SuppressWarnings({ "ClassExplicitlyAnnotation", "unused" })
 @jakarta.annotation.Generated("org.hibernate.orm.build.annotations.ClassGeneratorProcessor")
@@ -39,13 +35,8 @@ public class CollectionIdJdbcTypeCodeAnnotation implements CollectionIdJdbcTypeC
 	/**
 	 * Used in creating annotation instances from Jandex variant
 	 */
-	public CollectionIdJdbcTypeCodeAnnotation(AnnotationInstance annotation, SourceModelBuildingContext modelContext) {
-		this.value = extractJandexValue(
-				annotation,
-				HibernateAnnotations.COLLECTION_ID_JDBC_TYPE_CODE,
-				"value",
-				modelContext
-		);
+	public CollectionIdJdbcTypeCodeAnnotation(Map<String, Object> attributeValues, SourceModelBuildingContext modelContext) {
+		this.value = (int) attributeValues.get( "value" );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/CollectionIdMutabilityAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/CollectionIdMutabilityAnnotation.java
@@ -7,14 +7,10 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
 import org.hibernate.annotations.CollectionIdMutability;
-import org.hibernate.boot.models.HibernateAnnotations;
 import org.hibernate.models.spi.SourceModelBuildingContext;
-
-import org.jboss.jandex.AnnotationInstance;
-
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJandexValue;
 
 @SuppressWarnings({ "ClassExplicitlyAnnotation", "unused" })
 @jakarta.annotation.Generated("org.hibernate.orm.build.annotations.ClassGeneratorProcessor")
@@ -39,13 +35,8 @@ public class CollectionIdMutabilityAnnotation implements CollectionIdMutability 
 	/**
 	 * Used in creating annotation instances from Jandex variant
 	 */
-	public CollectionIdMutabilityAnnotation(AnnotationInstance annotation, SourceModelBuildingContext modelContext) {
-		this.value = extractJandexValue(
-				annotation,
-				HibernateAnnotations.COLLECTION_ID_MUTABILITY,
-				"value",
-				modelContext
-		);
+	public CollectionIdMutabilityAnnotation(Map<String, Object> attributeValues, SourceModelBuildingContext modelContext) {
+		this.value = (Class<? extends org.hibernate.type.descriptor.java.MutabilityPlan<?>>) attributeValues.get( "value" );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/CollectionIdTypeAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/CollectionIdTypeAnnotation.java
@@ -7,14 +7,12 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
 import org.hibernate.annotations.CollectionIdType;
 import org.hibernate.models.spi.SourceModelBuildingContext;
 
-import org.jboss.jandex.AnnotationInstance;
-
 import static org.hibernate.boot.models.HibernateAnnotations.COLLECTION_ID_TYPE;
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJandexValue;
 import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJdkValue;
 
 @SuppressWarnings({ "ClassExplicitlyAnnotation", "unused" })
@@ -41,14 +39,9 @@ public class CollectionIdTypeAnnotation implements CollectionIdType {
 	/**
 	 * Used in creating annotation instances from Jandex variant
 	 */
-	public CollectionIdTypeAnnotation(AnnotationInstance annotation, SourceModelBuildingContext modelContext) {
-		this.value = extractJandexValue( annotation, COLLECTION_ID_TYPE, "value", modelContext );
-		this.parameters = extractJandexValue(
-				annotation,
-				COLLECTION_ID_TYPE,
-				"parameters",
-				modelContext
-		);
+	public CollectionIdTypeAnnotation(Map<String, Object> attributeValues, SourceModelBuildingContext modelContext) {
+		this.value = (Class<? extends org.hibernate.usertype.UserType<?>>) attributeValues.get( "value" );
+		this.parameters = (org.hibernate.annotations.Parameter[]) attributeValues.get( "parameters" );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/CollectionTableJpaAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/CollectionTableJpaAnnotation.java
@@ -7,6 +7,7 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
 import org.hibernate.boot.jaxb.mapping.spi.JaxbCollectionTableImpl;
 import org.hibernate.boot.models.JpaAnnotations;
@@ -16,12 +17,9 @@ import org.hibernate.boot.models.xml.internal.db.JoinColumnProcessing;
 import org.hibernate.boot.models.xml.spi.XmlDocumentContext;
 import org.hibernate.models.spi.SourceModelBuildingContext;
 
-import org.jboss.jandex.AnnotationInstance;
-
 import jakarta.persistence.CollectionTable;
 
 import static org.hibernate.boot.models.JpaAnnotations.COLLECTION_TABLE;
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJandexValue;
 import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJdkValue;
 import static org.hibernate.boot.models.xml.internal.XmlAnnotationHelper.applyCatalog;
 import static org.hibernate.boot.models.xml.internal.XmlAnnotationHelper.applyOptionalString;
@@ -73,25 +71,15 @@ public class CollectionTableJpaAnnotation implements CollectionTable, CommonTabl
 	/**
 	 * Used in creating annotation instances from Jandex variant
 	 */
-	public CollectionTableJpaAnnotation(AnnotationInstance annotation, SourceModelBuildingContext modelContext) {
-		this.name = extractJandexValue( annotation, COLLECTION_TABLE, "name", modelContext );
-		this.catalog = extractJandexValue( annotation, COLLECTION_TABLE, "catalog", modelContext );
-		this.schema = extractJandexValue( annotation, COLLECTION_TABLE, "schema", modelContext );
-		this.joinColumns = extractJandexValue(
-				annotation,
-				COLLECTION_TABLE,
-				"joinColumns",
-				modelContext
-		);
-		this.foreignKey = extractJandexValue( annotation, COLLECTION_TABLE, "foreignKey", modelContext );
-		this.uniqueConstraints = extractJandexValue(
-				annotation,
-				COLLECTION_TABLE,
-				"uniqueConstraints",
-				modelContext
-		);
-		this.indexes = extractJandexValue( annotation, COLLECTION_TABLE, "indexes", modelContext );
-		this.options = extractJandexValue( annotation, COLLECTION_TABLE, "options", modelContext );
+	public CollectionTableJpaAnnotation(Map<String, Object> attributeValues, SourceModelBuildingContext modelContext) {
+		this.name = (String) attributeValues.get( "name" );
+		this.catalog = (String) attributeValues.get( "catalog" );
+		this.schema = (String) attributeValues.get( "schema" );
+		this.joinColumns = (jakarta.persistence.JoinColumn[]) attributeValues.get( "joinColumns" );
+		this.foreignKey = (jakarta.persistence.ForeignKey) attributeValues.get( "foreignKey" );
+		this.uniqueConstraints = (jakarta.persistence.UniqueConstraint[]) attributeValues.get( "uniqueConstraints" );
+		this.indexes = (jakarta.persistence.Index[]) attributeValues.get( "indexes" );
+		this.options = (String) attributeValues.get( "options" );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/CollectionTypeAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/CollectionTypeAnnotation.java
@@ -7,14 +7,12 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
 import org.hibernate.annotations.CollectionType;
 import org.hibernate.models.spi.SourceModelBuildingContext;
 
-import org.jboss.jandex.AnnotationInstance;
-
 import static org.hibernate.boot.models.HibernateAnnotations.COLLECTION_TYPE;
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJandexValue;
 import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJdkValue;
 
 @SuppressWarnings({ "ClassExplicitlyAnnotation", "unused" })
@@ -41,14 +39,9 @@ public class CollectionTypeAnnotation implements CollectionType {
 	/**
 	 * Used in creating annotation instances from Jandex variant
 	 */
-	public CollectionTypeAnnotation(AnnotationInstance annotation, SourceModelBuildingContext modelContext) {
-		this.type = extractJandexValue( annotation, COLLECTION_TYPE, "type", modelContext );
-		this.parameters = extractJandexValue(
-				annotation,
-				COLLECTION_TYPE,
-				"parameters",
-				modelContext
-		);
+	public CollectionTypeAnnotation(Map<String, Object> attributeValues, SourceModelBuildingContext modelContext) {
+		this.type = (Class<? extends org.hibernate.usertype.UserCollectionType>) attributeValues.get( "type" );
+		this.parameters = (org.hibernate.annotations.Parameter[]) attributeValues.get( "parameters" );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/CollectionTypeRegistrationAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/CollectionTypeRegistrationAnnotation.java
@@ -7,14 +7,12 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
 import org.hibernate.annotations.CollectionTypeRegistration;
 import org.hibernate.models.spi.SourceModelBuildingContext;
 
-import org.jboss.jandex.AnnotationInstance;
-
 import static org.hibernate.boot.models.HibernateAnnotations.COLLECTION_TYPE_REGISTRATION;
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJandexValue;
 import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJdkValue;
 
 @SuppressWarnings({ "ClassExplicitlyAnnotation", "unused" })
@@ -46,26 +44,11 @@ public class CollectionTypeRegistrationAnnotation implements CollectionTypeRegis
 	 * Used in creating annotation instances from Jandex variant
 	 */
 	public CollectionTypeRegistrationAnnotation(
-			AnnotationInstance annotation,
+			Map<String, Object> attributeValues,
 			SourceModelBuildingContext modelContext) {
-		this.classification = extractJandexValue(
-				annotation,
-				COLLECTION_TYPE_REGISTRATION,
-				"classification",
-				modelContext
-		);
-		this.type = extractJandexValue(
-				annotation,
-				COLLECTION_TYPE_REGISTRATION,
-				"type",
-				modelContext
-		);
-		this.parameters = extractJandexValue(
-				annotation,
-				COLLECTION_TYPE_REGISTRATION,
-				"parameters",
-				modelContext
-		);
+		this.classification = (org.hibernate.metamodel.CollectionClassification) attributeValues.get( "classification" );
+		this.type = (Class<? extends org.hibernate.usertype.UserCollectionType>) attributeValues.get( "type" );
+		this.parameters = (org.hibernate.annotations.Parameter[]) attributeValues.get( "parameters" );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/CollectionTypeRegistrationsAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/CollectionTypeRegistrationsAnnotation.java
@@ -7,6 +7,7 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
 import org.hibernate.annotations.CollectionTypeRegistration;
 import org.hibernate.annotations.CollectionTypeRegistrations;
@@ -14,9 +15,6 @@ import org.hibernate.boot.models.HibernateAnnotations;
 import org.hibernate.boot.models.annotations.spi.RepeatableContainer;
 import org.hibernate.models.spi.SourceModelBuildingContext;
 
-import org.jboss.jandex.AnnotationInstance;
-
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJandexValue;
 import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJdkValue;
 
 @SuppressWarnings({ "ClassExplicitlyAnnotation", "unused" })
@@ -49,14 +47,9 @@ public class CollectionTypeRegistrationsAnnotation
 	 * Used in creating annotation instances from Jandex variant
 	 */
 	public CollectionTypeRegistrationsAnnotation(
-			AnnotationInstance annotation,
+			Map<String, Object> attributeValues,
 			SourceModelBuildingContext modelContext) {
-		this.value = extractJandexValue(
-				annotation,
-				HibernateAnnotations.COLLECTION_TYPE_REGISTRATIONS,
-				"value",
-				modelContext
-		);
+		this.value = (CollectionTypeRegistration[]) attributeValues.get( "value" );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/ColumnDefaultAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/ColumnDefaultAnnotation.java
@@ -7,14 +7,10 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
 import org.hibernate.annotations.ColumnDefault;
-import org.hibernate.boot.models.HibernateAnnotations;
 import org.hibernate.models.spi.SourceModelBuildingContext;
-
-import org.jboss.jandex.AnnotationInstance;
-
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJandexValue;
 
 @SuppressWarnings({ "ClassExplicitlyAnnotation", "unused" })
 @jakarta.annotation.Generated("org.hibernate.orm.build.annotations.ClassGeneratorProcessor")
@@ -37,8 +33,8 @@ public class ColumnDefaultAnnotation implements ColumnDefault {
 	/**
 	 * Used in creating annotation instances from Jandex variant
 	 */
-	public ColumnDefaultAnnotation(AnnotationInstance annotation, SourceModelBuildingContext modelContext) {
-		this.value = extractJandexValue( annotation, HibernateAnnotations.COLUMN_DEFAULT, "value", modelContext );
+	public ColumnDefaultAnnotation(Map<String, Object> attributeValues, SourceModelBuildingContext modelContext) {
+		this.value = (String) attributeValues.get( "value" );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/ColumnJpaAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/ColumnJpaAnnotation.java
@@ -7,6 +7,7 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
 import org.hibernate.boot.jaxb.mapping.spi.JaxbColumnImpl;
 import org.hibernate.boot.models.JpaAnnotations;
@@ -18,11 +19,8 @@ import org.hibernate.boot.models.xml.spi.XmlDocumentContext;
 import org.hibernate.internal.util.StringHelper;
 import org.hibernate.models.spi.SourceModelBuildingContext;
 
-import org.jboss.jandex.AnnotationInstance;
-
 import jakarta.persistence.Column;
 
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJandexValue;
 import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJdkValue;
 
 @SuppressWarnings({ "ClassExplicitlyAnnotation", "unused" })
@@ -95,26 +93,21 @@ public class ColumnJpaAnnotation implements Column,
 	/**
 	 * Used in creating annotation instances from Jandex variant
 	 */
-	public ColumnJpaAnnotation(AnnotationInstance annotation, SourceModelBuildingContext modelContext) {
-		this.name = extractJandexValue( annotation, JpaAnnotations.COLUMN, "name", modelContext );
-		this.unique = extractJandexValue( annotation, JpaAnnotations.COLUMN, "unique", modelContext );
-		this.nullable = extractJandexValue( annotation, JpaAnnotations.COLUMN, "nullable", modelContext );
-		this.insertable = extractJandexValue( annotation, JpaAnnotations.COLUMN, "insertable", modelContext );
-		this.updatable = extractJandexValue( annotation, JpaAnnotations.COLUMN, "updatable", modelContext );
-		this.columnDefinition = extractJandexValue(
-				annotation,
-				JpaAnnotations.COLUMN,
-				"columnDefinition",
-				modelContext
-		);
-		this.options = extractJandexValue( annotation, JpaAnnotations.COLUMN, "options", modelContext );
-		this.table = extractJandexValue( annotation, JpaAnnotations.COLUMN, "table", modelContext );
-		this.length = extractJandexValue( annotation, JpaAnnotations.COLUMN, "length", modelContext );
-		this.precision = extractJandexValue( annotation, JpaAnnotations.COLUMN, "precision", modelContext );
-		this.scale = extractJandexValue( annotation, JpaAnnotations.COLUMN, "scale", modelContext );
-		this.secondPrecision = extractJandexValue( annotation, JpaAnnotations.COLUMN, "secondPrecision", modelContext );
-		this.check = extractJandexValue( annotation, JpaAnnotations.COLUMN, "check", modelContext );
-		this.comment = extractJandexValue( annotation, JpaAnnotations.COLUMN, "comment", modelContext );
+	public ColumnJpaAnnotation(Map<String, Object> attributeValues, SourceModelBuildingContext modelContext) {
+		this.name = (String) attributeValues.get( "name" );
+		this.unique = (boolean) attributeValues.get( "unique" );
+		this.nullable = (boolean) attributeValues.get( "nullable" );
+		this.insertable = (boolean) attributeValues.get( "insertable" );
+		this.updatable = (boolean) attributeValues.get( "updatable" );
+		this.columnDefinition = (String) attributeValues.get( "columnDefinition" );
+		this.options = (String) attributeValues.get( "options" );
+		this.table = (String) attributeValues.get( "table" );
+		this.length = (int) attributeValues.get( "length" );
+		this.precision = (int) attributeValues.get( "precision" );
+		this.scale = (int) attributeValues.get( "scale" );
+		this.secondPrecision = (int) attributeValues.get( "secondPrecision" );
+		this.check = (jakarta.persistence.CheckConstraint[]) attributeValues.get( "check" );
+		this.comment = (String) attributeValues.get( "comment" );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/ColumnResultJpaAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/ColumnResultJpaAnnotation.java
@@ -7,15 +7,11 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
-import org.hibernate.boot.models.JpaAnnotations;
 import org.hibernate.models.spi.SourceModelBuildingContext;
 
-import org.jboss.jandex.AnnotationInstance;
-
 import jakarta.persistence.ColumnResult;
-
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJandexValue;
 
 @SuppressWarnings({ "ClassExplicitlyAnnotation", "unused" })
 @jakarta.annotation.Generated("org.hibernate.orm.build.annotations.ClassGeneratorProcessor")
@@ -41,9 +37,9 @@ public class ColumnResultJpaAnnotation implements ColumnResult {
 	/**
 	 * Used in creating annotation instances from Jandex variant
 	 */
-	public ColumnResultJpaAnnotation(AnnotationInstance annotation, SourceModelBuildingContext modelContext) {
-		this.name = extractJandexValue( annotation, JpaAnnotations.COLUMN_RESULT, "name", modelContext );
-		this.type = extractJandexValue( annotation, JpaAnnotations.COLUMN_RESULT, "type", modelContext );
+	public ColumnResultJpaAnnotation(Map<String, Object> attributeValues, SourceModelBuildingContext modelContext) {
+		this.name = (String) attributeValues.get( "name" );
+		this.type = (Class<?>) attributeValues.get( "type" );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/ColumnTransformerAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/ColumnTransformerAnnotation.java
@@ -7,14 +7,10 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
 import org.hibernate.annotations.ColumnTransformer;
-import org.hibernate.boot.models.HibernateAnnotations;
 import org.hibernate.models.spi.SourceModelBuildingContext;
-
-import org.jboss.jandex.AnnotationInstance;
-
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJandexValue;
 
 @SuppressWarnings({ "ClassExplicitlyAnnotation", "unused" })
 @jakarta.annotation.Generated("org.hibernate.orm.build.annotations.ClassGeneratorProcessor")
@@ -44,15 +40,10 @@ public class ColumnTransformerAnnotation implements ColumnTransformer {
 	/**
 	 * Used in creating annotation instances from Jandex variant
 	 */
-	public ColumnTransformerAnnotation(AnnotationInstance annotation, SourceModelBuildingContext modelContext) {
-		this.forColumn = extractJandexValue(
-				annotation,
-				HibernateAnnotations.COLUMN_TRANSFORMER,
-				"forColumn",
-				modelContext
-		);
-		this.read = extractJandexValue( annotation, HibernateAnnotations.COLUMN_TRANSFORMER, "read", modelContext );
-		this.write = extractJandexValue( annotation, HibernateAnnotations.COLUMN_TRANSFORMER, "write", modelContext );
+	public ColumnTransformerAnnotation(Map<String, Object> attributeValues, SourceModelBuildingContext modelContext) {
+		this.forColumn = (String) attributeValues.get( "forColumn" );
+		this.read = (String) attributeValues.get( "read" );
+		this.write = (String) attributeValues.get( "write" );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/ColumnTransformersAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/ColumnTransformersAnnotation.java
@@ -7,6 +7,7 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
 import org.hibernate.annotations.ColumnTransformer;
 import org.hibernate.annotations.ColumnTransformers;
@@ -14,9 +15,6 @@ import org.hibernate.boot.models.HibernateAnnotations;
 import org.hibernate.boot.models.annotations.spi.RepeatableContainer;
 import org.hibernate.models.spi.SourceModelBuildingContext;
 
-import org.jboss.jandex.AnnotationInstance;
-
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJandexValue;
 import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJdkValue;
 
 @SuppressWarnings({ "ClassExplicitlyAnnotation", "unused" })
@@ -31,8 +29,8 @@ public class ColumnTransformersAnnotation implements ColumnTransformers, Repeata
 		this.value = extractJdkValue( annotation, HibernateAnnotations.COLUMN_TRANSFORMERS, "value", modelContext );
 	}
 
-	public ColumnTransformersAnnotation(AnnotationInstance annotation, SourceModelBuildingContext modelContext) {
-		this.value = extractJandexValue( annotation, HibernateAnnotations.COLUMN_TRANSFORMERS, "value", modelContext );
+	public ColumnTransformersAnnotation(Map<String, Object> attributeValues, SourceModelBuildingContext modelContext) {
+		this.value = (ColumnTransformer[]) attributeValues.get( "value" );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/ColumnsAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/ColumnsAnnotation.java
@@ -7,15 +7,13 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
 import org.hibernate.annotations.Columns;
 import org.hibernate.boot.models.HibernateAnnotations;
 import org.hibernate.models.spi.AnnotationDescriptor;
 import org.hibernate.models.spi.SourceModelBuildingContext;
 
-import org.jboss.jandex.AnnotationInstance;
-
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJandexValue;
 import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJdkValue;
 
 @SuppressWarnings({ "ClassExplicitlyAnnotation", "unused" })
@@ -41,8 +39,8 @@ public class ColumnsAnnotation implements Columns {
 	/**
 	 * Used in creating annotation instances from Jandex variant
 	 */
-	public ColumnsAnnotation(AnnotationInstance annotation, SourceModelBuildingContext modelContext) {
-		this.columns = extractJandexValue( annotation, HibernateAnnotations.COLUMNS, "columns", modelContext );
+	public ColumnsAnnotation(Map<String, Object> attributeValues, SourceModelBuildingContext modelContext) {
+		this.columns = (jakarta.persistence.Column[]) attributeValues.get( "columns" );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/CommentAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/CommentAnnotation.java
@@ -7,14 +7,10 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
 import org.hibernate.annotations.Comment;
-import org.hibernate.boot.models.HibernateAnnotations;
 import org.hibernate.models.spi.SourceModelBuildingContext;
-
-import org.jboss.jandex.AnnotationInstance;
-
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJandexValue;
 
 @SuppressWarnings({ "ClassExplicitlyAnnotation", "unused" })
 @jakarta.annotation.Generated("org.hibernate.orm.build.annotations.ClassGeneratorProcessor")
@@ -40,9 +36,9 @@ public class CommentAnnotation implements Comment {
 	/**
 	 * Used in creating annotation instances from Jandex variant
 	 */
-	public CommentAnnotation(AnnotationInstance annotation, SourceModelBuildingContext modelContext) {
-		this.value = extractJandexValue( annotation, HibernateAnnotations.COMMENT, "value", modelContext );
-		this.on = extractJandexValue( annotation, HibernateAnnotations.COMMENT, "on", modelContext );
+	public CommentAnnotation(Map<String, Object> attributeValues, SourceModelBuildingContext modelContext) {
+		this.value = (String) attributeValues.get( "value" );
+		this.on = (String) attributeValues.get( "on" );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/CommentsAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/CommentsAnnotation.java
@@ -7,15 +7,13 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
 import org.hibernate.annotations.Comments;
 import org.hibernate.boot.models.HibernateAnnotations;
 import org.hibernate.boot.models.annotations.spi.RepeatableContainer;
 import org.hibernate.models.spi.SourceModelBuildingContext;
 
-import org.jboss.jandex.AnnotationInstance;
-
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJandexValue;
 import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJdkValue;
 
 @SuppressWarnings({ "ClassExplicitlyAnnotation", "unused" })
@@ -40,8 +38,8 @@ public class CommentsAnnotation implements Comments, RepeatableContainer<org.hib
 	/**
 	 * Used in creating annotation instances from Jandex variant
 	 */
-	public CommentsAnnotation(AnnotationInstance annotation, SourceModelBuildingContext modelContext) {
-		this.value = extractJandexValue( annotation, HibernateAnnotations.COMMENTS, "value", modelContext );
+	public CommentsAnnotation(Map<String, Object> attributeValues, SourceModelBuildingContext modelContext) {
+		this.value = (org.hibernate.annotations.Comment[]) attributeValues.get( "value" );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/CompositeTypeAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/CompositeTypeAnnotation.java
@@ -7,14 +7,10 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
 import org.hibernate.annotations.CompositeType;
-import org.hibernate.boot.models.HibernateAnnotations;
 import org.hibernate.models.spi.SourceModelBuildingContext;
-
-import org.jboss.jandex.AnnotationInstance;
-
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJandexValue;
 
 @SuppressWarnings({ "ClassExplicitlyAnnotation", "unused" })
 @jakarta.annotation.Generated("org.hibernate.orm.build.annotations.ClassGeneratorProcessor")
@@ -37,8 +33,8 @@ public class CompositeTypeAnnotation implements CompositeType {
 	/**
 	 * Used in creating annotation instances from Jandex variant
 	 */
-	public CompositeTypeAnnotation(AnnotationInstance annotation, SourceModelBuildingContext modelContext) {
-		this.value = extractJandexValue( annotation, HibernateAnnotations.COMPOSITE_TYPE, "value", modelContext );
+	public CompositeTypeAnnotation(Map<String, Object> attributeValues, SourceModelBuildingContext modelContext) {
+		this.value = (Class<? extends org.hibernate.usertype.CompositeUserType<?>>) attributeValues.get( "value" );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/CompositeTypeRegistrationAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/CompositeTypeRegistrationAnnotation.java
@@ -7,14 +7,10 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
 import org.hibernate.annotations.CompositeTypeRegistration;
-import org.hibernate.boot.models.HibernateAnnotations;
 import org.hibernate.models.spi.SourceModelBuildingContext;
-
-import org.jboss.jandex.AnnotationInstance;
-
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJandexValue;
 
 @SuppressWarnings({ "ClassExplicitlyAnnotation", "unused" })
 @jakarta.annotation.Generated("org.hibernate.orm.build.annotations.ClassGeneratorProcessor")
@@ -41,19 +37,9 @@ public class CompositeTypeRegistrationAnnotation implements CompositeTypeRegistr
 	/**
 	 * Used in creating annotation instances from Jandex variant
 	 */
-	public CompositeTypeRegistrationAnnotation(AnnotationInstance annotation, SourceModelBuildingContext modelContext) {
-		this.embeddableClass = extractJandexValue(
-				annotation,
-				HibernateAnnotations.COMPOSITE_TYPE_REGISTRATION,
-				"embeddableClass",
-				modelContext
-		);
-		this.userType = extractJandexValue(
-				annotation,
-				HibernateAnnotations.COMPOSITE_TYPE_REGISTRATION,
-				"userType",
-				modelContext
-		);
+	public CompositeTypeRegistrationAnnotation(Map<String, Object> attributeValues, SourceModelBuildingContext modelContext) {
+		this.embeddableClass = (Class<?>) attributeValues.get( "embeddableClass" );
+		this.userType = (Class<? extends org.hibernate.usertype.CompositeUserType<?>>) attributeValues.get( "userType" );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/CompositeTypeRegistrationsAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/CompositeTypeRegistrationsAnnotation.java
@@ -7,6 +7,7 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
 import org.hibernate.annotations.CompositeTypeRegistration;
 import org.hibernate.annotations.CompositeTypeRegistrations;
@@ -14,9 +15,6 @@ import org.hibernate.boot.models.HibernateAnnotations;
 import org.hibernate.boot.models.annotations.spi.RepeatableContainer;
 import org.hibernate.models.spi.SourceModelBuildingContext;
 
-import org.jboss.jandex.AnnotationInstance;
-
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJandexValue;
 import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJdkValue;
 
 @SuppressWarnings({ "ClassExplicitlyAnnotation", "unused" })
@@ -49,14 +47,9 @@ public class CompositeTypeRegistrationsAnnotation
 	 * Used in creating annotation instances from Jandex variant
 	 */
 	public CompositeTypeRegistrationsAnnotation(
-			AnnotationInstance annotation,
+			Map<String, Object> attributeValues,
 			SourceModelBuildingContext modelContext) {
-		this.value = extractJandexValue(
-				annotation,
-				HibernateAnnotations.COMPOSITE_TYPE_REGISTRATIONS,
-				"value",
-				modelContext
-		);
+		this.value = (CompositeTypeRegistration[]) attributeValues.get( "value" );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/ConcreteProxyAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/ConcreteProxyAnnotation.java
@@ -6,17 +6,11 @@
  */
 package org.hibernate.boot.models.annotations.internal;
 
-import org.hibernate.models.internal.OrmAnnotationDescriptor;
-import org.hibernate.models.spi.SourceModelBuildingContext;
-import org.hibernate.models.spi.AnnotationDescriptor;
-import org.hibernate.models.spi.AttributeDescriptor;
-
-import org.jboss.jandex.AnnotationInstance;
-import org.jboss.jandex.AnnotationValue;
-
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
 import org.hibernate.annotations.ConcreteProxy;
+import org.hibernate.models.spi.SourceModelBuildingContext;
 
 @SuppressWarnings({ "ClassExplicitlyAnnotation", "unused" })
 @jakarta.annotation.Generated("org.hibernate.orm.build.annotations.ClassGeneratorProcessor")
@@ -37,7 +31,7 @@ public class ConcreteProxyAnnotation implements ConcreteProxy {
 	/**
 	 * Used in creating annotation instances from Jandex variant
 	 */
-	public ConcreteProxyAnnotation(AnnotationInstance annotation, SourceModelBuildingContext modelContext) {
+	public ConcreteProxyAnnotation(Map<String, Object> attributeValues, SourceModelBuildingContext modelContext) {
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/ConstructorResultJpaAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/ConstructorResultJpaAnnotation.java
@@ -7,15 +7,13 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
 import org.hibernate.models.spi.SourceModelBuildingContext;
-
-import org.jboss.jandex.AnnotationInstance;
 
 import jakarta.persistence.ConstructorResult;
 
 import static org.hibernate.boot.models.JpaAnnotations.CONSTRUCTOR_RESULT;
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJandexValue;
 import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJdkValue;
 
 @SuppressWarnings({ "ClassExplicitlyAnnotation", "unused" })
@@ -42,9 +40,11 @@ public class ConstructorResultJpaAnnotation implements ConstructorResult {
 	/**
 	 * Used in creating annotation instances from Jandex variant
 	 */
-	public ConstructorResultJpaAnnotation(AnnotationInstance annotation, SourceModelBuildingContext modelContext) {
-		this.targetClass = extractJandexValue( annotation, CONSTRUCTOR_RESULT, "targetClass", modelContext );
-		this.columns = extractJandexValue( annotation, CONSTRUCTOR_RESULT, "columns", modelContext );
+	public ConstructorResultJpaAnnotation(
+			Map<String, Object> attributeValues,
+			SourceModelBuildingContext modelContext) {
+		this.targetClass = (Class<?>) attributeValues.get( "targetClass" );
+		this.columns = (jakarta.persistence.ColumnResult[]) attributeValues.get( "columns" );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/ConvertJpaAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/ConvertJpaAnnotation.java
@@ -7,16 +7,11 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
-import org.hibernate.boot.models.JpaAnnotations;
 import org.hibernate.models.spi.SourceModelBuildingContext;
 
-import org.jboss.jandex.AnnotationInstance;
-
 import jakarta.persistence.Convert;
-
-import static org.hibernate.boot.models.JpaAnnotations.CONVERT;
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJandexValue;
 
 @SuppressWarnings({ "ClassExplicitlyAnnotation", "unused" })
 @jakarta.annotation.Generated("org.hibernate.orm.build.annotations.ClassGeneratorProcessor")
@@ -47,15 +42,10 @@ public class ConvertJpaAnnotation implements Convert {
 	/**
 	 * Used in creating annotation instances from Jandex variant
 	 */
-	public ConvertJpaAnnotation(AnnotationInstance annotation, SourceModelBuildingContext modelContext) {
-		this.converter = extractJandexValue( annotation, CONVERT, "converter", modelContext );
-		this.attributeName = extractJandexValue( annotation, CONVERT, "attributeName", modelContext );
-		this.disableConversion = extractJandexValue(
-				annotation,
-				CONVERT,
-				"disableConversion",
-				modelContext
-		);
+	public ConvertJpaAnnotation(Map<String, Object> attributeValues, SourceModelBuildingContext modelContext) {
+		this.converter = (Class<? extends jakarta.persistence.AttributeConverter>) attributeValues.get( "converter" );
+		this.attributeName = (String) attributeValues.get( "attributeName" );
+		this.disableConversion = (boolean) attributeValues.get( "disableConversion" );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/ConverterJpaAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/ConverterJpaAnnotation.java
@@ -7,15 +7,11 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
-import org.hibernate.boot.models.JpaAnnotations;
 import org.hibernate.models.spi.SourceModelBuildingContext;
 
-import org.jboss.jandex.AnnotationInstance;
-
 import jakarta.persistence.Converter;
-
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJandexValue;
 
 @SuppressWarnings({ "ClassExplicitlyAnnotation", "unused" })
 @jakarta.annotation.Generated("org.hibernate.orm.build.annotations.ClassGeneratorProcessor")
@@ -40,8 +36,8 @@ public class ConverterJpaAnnotation implements Converter {
 	/**
 	 * Used in creating annotation instances from Jandex variant
 	 */
-	public ConverterJpaAnnotation(AnnotationInstance annotation, SourceModelBuildingContext modelContext) {
-		this.autoApply = extractJandexValue( annotation, JpaAnnotations.CONVERTER, "autoApply", modelContext );
+	public ConverterJpaAnnotation(Map<String, Object> attributeValues, SourceModelBuildingContext modelContext) {
+		this.autoApply = (boolean) attributeValues.get( "autoApply" );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/ConverterRegistrationAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/ConverterRegistrationAnnotation.java
@@ -7,14 +7,10 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
 import org.hibernate.annotations.ConverterRegistration;
-import org.hibernate.boot.models.HibernateAnnotations;
 import org.hibernate.models.spi.SourceModelBuildingContext;
-
-import org.jboss.jandex.AnnotationInstance;
-
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJandexValue;
 
 @SuppressWarnings({ "ClassExplicitlyAnnotation", "unused" })
 @jakarta.annotation.Generated("org.hibernate.orm.build.annotations.ClassGeneratorProcessor")
@@ -43,25 +39,12 @@ public class ConverterRegistrationAnnotation implements ConverterRegistration {
 	/**
 	 * Used in creating annotation instances from Jandex variant
 	 */
-	public ConverterRegistrationAnnotation(AnnotationInstance annotation, SourceModelBuildingContext modelContext) {
-		this.converter = extractJandexValue(
-				annotation,
-				HibernateAnnotations.CONVERTER_REGISTRATION,
-				"converter",
-				modelContext
-		);
-		this.domainType = extractJandexValue(
-				annotation,
-				HibernateAnnotations.CONVERTER_REGISTRATION,
-				"domainType",
-				modelContext
-		);
-		this.autoApply = extractJandexValue(
-				annotation,
-				HibernateAnnotations.CONVERTER_REGISTRATION,
-				"autoApply",
-				modelContext
-		);
+	public ConverterRegistrationAnnotation(
+			Map<String, Object> attributeValues,
+			SourceModelBuildingContext modelContext) {
+		this.converter = (Class<? extends jakarta.persistence.AttributeConverter<?, ?>>) attributeValues.get( "converter" );
+		this.domainType = (Class<?>) attributeValues.get( "domainType" );
+		this.autoApply = (boolean) attributeValues.get( "autoApply" );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/ConverterRegistrationsAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/ConverterRegistrationsAnnotation.java
@@ -7,6 +7,7 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
 import org.hibernate.annotations.ConverterRegistration;
 import org.hibernate.annotations.ConverterRegistrations;
@@ -14,9 +15,6 @@ import org.hibernate.boot.models.HibernateAnnotations;
 import org.hibernate.boot.models.annotations.spi.RepeatableContainer;
 import org.hibernate.models.spi.SourceModelBuildingContext;
 
-import org.jboss.jandex.AnnotationInstance;
-
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJandexValue;
 import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJdkValue;
 
 @SuppressWarnings({ "ClassExplicitlyAnnotation", "unused" })
@@ -43,13 +41,10 @@ public class ConverterRegistrationsAnnotation
 	/**
 	 * Used in creating annotation instances from Jandex variant
 	 */
-	public ConverterRegistrationsAnnotation(AnnotationInstance annotation, SourceModelBuildingContext modelContext) {
-		this.value = extractJandexValue(
-				annotation,
-				HibernateAnnotations.CONVERTER_REGISTRATIONS,
-				"value",
-				modelContext
-		);
+	public ConverterRegistrationsAnnotation(
+			Map<String, Object> attributeValues,
+			SourceModelBuildingContext modelContext) {
+		this.value = (ConverterRegistration[]) attributeValues.get( "value" );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/ConvertsJpaAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/ConvertsJpaAnnotation.java
@@ -6,16 +6,15 @@
  */
 package org.hibernate.boot.models.annotations.internal;
 
+import java.lang.annotation.Annotation;
+import java.util.Map;
+
+import org.hibernate.boot.models.JpaAnnotations;
 import org.hibernate.boot.models.annotations.spi.RepeatableContainer;
 import org.hibernate.models.spi.SourceModelBuildingContext;
 
-import org.jboss.jandex.AnnotationInstance;
-
-import java.lang.annotation.Annotation;
-
 import jakarta.persistence.Converts;
 
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJandexValue;
 import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJdkValue;
 
 @SuppressWarnings({ "ClassExplicitlyAnnotation", "unused" })
@@ -35,7 +34,7 @@ public class ConvertsJpaAnnotation implements Converts, RepeatableContainer<jaka
 	public ConvertsJpaAnnotation(Converts annotation, SourceModelBuildingContext modelContext) {
 		this.value = extractJdkValue(
 				annotation,
-				org.hibernate.boot.models.JpaAnnotations.CONVERTS,
+				JpaAnnotations.CONVERTS,
 				"value",
 				modelContext
 		);
@@ -44,13 +43,8 @@ public class ConvertsJpaAnnotation implements Converts, RepeatableContainer<jaka
 	/**
 	 * Used in creating annotation instances from Jandex variant
 	 */
-	public ConvertsJpaAnnotation(AnnotationInstance annotation, SourceModelBuildingContext modelContext) {
-		this.value = extractJandexValue(
-				annotation,
-				org.hibernate.boot.models.JpaAnnotations.CONVERTS,
-				"value",
-				modelContext
-		);
+	public ConvertsJpaAnnotation(Map<String, Object> attributeValues, SourceModelBuildingContext modelContext) {
+		this.value = (jakarta.persistence.Convert[]) attributeValues.get( "value" );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/CreationTimestampAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/CreationTimestampAnnotation.java
@@ -7,14 +7,10 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
 import org.hibernate.annotations.CreationTimestamp;
-import org.hibernate.boot.models.HibernateAnnotations;
 import org.hibernate.models.spi.SourceModelBuildingContext;
-
-import org.jboss.jandex.AnnotationInstance;
-
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJandexValue;
 
 @SuppressWarnings({ "ClassExplicitlyAnnotation", "unused" })
 @jakarta.annotation.Generated("org.hibernate.orm.build.annotations.ClassGeneratorProcessor")
@@ -38,8 +34,8 @@ public class CreationTimestampAnnotation implements CreationTimestamp {
 	/**
 	 * Used in creating annotation instances from Jandex variant
 	 */
-	public CreationTimestampAnnotation(AnnotationInstance annotation, SourceModelBuildingContext modelContext) {
-		this.source = extractJandexValue( annotation, HibernateAnnotations.CREATION_TIMESTAMP, "source", modelContext );
+	public CreationTimestampAnnotation(Map<String, Object> attributeValues, SourceModelBuildingContext modelContext) {
+		this.source = (org.hibernate.annotations.SourceType) attributeValues.get( "source" );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/CurrentTimestampAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/CurrentTimestampAnnotation.java
@@ -7,14 +7,11 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
 import org.hibernate.annotations.CurrentTimestamp;
-import org.hibernate.boot.models.HibernateAnnotations;
 import org.hibernate.models.spi.SourceModelBuildingContext;
 
-import org.jboss.jandex.AnnotationInstance;
-
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJandexValue;
 import static org.hibernate.generator.EventType.INSERT;
 import static org.hibernate.generator.EventType.UPDATE;
 
@@ -43,9 +40,9 @@ public class CurrentTimestampAnnotation implements CurrentTimestamp {
 	/**
 	 * Used in creating annotation instances from Jandex variant
 	 */
-	public CurrentTimestampAnnotation(AnnotationInstance annotation, SourceModelBuildingContext modelContext) {
-		this.event = extractJandexValue( annotation, HibernateAnnotations.CURRENT_TIMESTAMP, "event", modelContext );
-		this.source = extractJandexValue( annotation, HibernateAnnotations.CURRENT_TIMESTAMP, "source", modelContext );
+	public CurrentTimestampAnnotation(Map<String, Object> attributeValues, SourceModelBuildingContext modelContext) {
+		this.event = (org.hibernate.generator.EventType[]) attributeValues.get( "event" );
+		this.source = (org.hibernate.annotations.SourceType) attributeValues.get( "source" );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/DiscriminatorColumnJpaAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/DiscriminatorColumnJpaAnnotation.java
@@ -7,6 +7,7 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
 import org.hibernate.boot.jaxb.mapping.spi.JaxbDiscriminatorColumnImpl;
 import org.hibernate.boot.models.annotations.spi.ColumnDetails;
@@ -14,11 +15,7 @@ import org.hibernate.boot.models.xml.spi.XmlDocumentContext;
 import org.hibernate.internal.util.StringHelper;
 import org.hibernate.models.spi.SourceModelBuildingContext;
 
-import org.jboss.jandex.AnnotationInstance;
-
 import jakarta.persistence.DiscriminatorColumn;
-
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJandexValue;
 
 @SuppressWarnings({ "ClassExplicitlyAnnotation", "unused" })
 @jakarta.annotation.Generated("org.hibernate.orm.build.annotations.ClassGeneratorProcessor")
@@ -55,37 +52,14 @@ public class DiscriminatorColumnJpaAnnotation implements DiscriminatorColumn, Co
 	/**
 	 * Used in creating annotation instances from Jandex variant
 	 */
-	public DiscriminatorColumnJpaAnnotation(AnnotationInstance annotation, SourceModelBuildingContext modelContext) {
-		this.name = extractJandexValue(
-				annotation,
-				org.hibernate.boot.models.JpaAnnotations.DISCRIMINATOR_COLUMN,
-				"name",
-				modelContext
-		);
-		this.discriminatorType = extractJandexValue(
-				annotation,
-				org.hibernate.boot.models.JpaAnnotations.DISCRIMINATOR_COLUMN,
-				"discriminatorType",
-				modelContext
-		);
-		this.columnDefinition = extractJandexValue(
-				annotation,
-				org.hibernate.boot.models.JpaAnnotations.DISCRIMINATOR_COLUMN,
-				"columnDefinition",
-				modelContext
-		);
-		this.options = extractJandexValue(
-				annotation,
-				org.hibernate.boot.models.JpaAnnotations.DISCRIMINATOR_COLUMN,
-				"options",
-				modelContext
-		);
-		this.length = extractJandexValue(
-				annotation,
-				org.hibernate.boot.models.JpaAnnotations.DISCRIMINATOR_COLUMN,
-				"length",
-				modelContext
-		);
+	public DiscriminatorColumnJpaAnnotation(
+			Map<String, Object> attributeValues,
+			SourceModelBuildingContext modelContext) {
+		this.name = (String) attributeValues.get( "name" );
+		this.discriminatorType = (jakarta.persistence.DiscriminatorType) attributeValues.get( "discriminatorType" );
+		this.columnDefinition = (String) attributeValues.get( "columnDefinition" );
+		this.options = (String) attributeValues.get( "options" );
+		this.length = (int) attributeValues.get( "length" );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/DiscriminatorFormulaAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/DiscriminatorFormulaAnnotation.java
@@ -7,13 +7,10 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
 import org.hibernate.annotations.DiscriminatorFormula;
 import org.hibernate.models.spi.SourceModelBuildingContext;
-
-import org.jboss.jandex.AnnotationInstance;
-
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJandexValue;
 
 @SuppressWarnings({ "ClassExplicitlyAnnotation", "unused" })
 @jakarta.annotation.Generated("org.hibernate.orm.build.annotations.ClassGeneratorProcessor")
@@ -39,19 +36,11 @@ public class DiscriminatorFormulaAnnotation implements DiscriminatorFormula {
 	/**
 	 * Used in creating annotation instances from Jandex variant
 	 */
-	public DiscriminatorFormulaAnnotation(AnnotationInstance annotation, SourceModelBuildingContext modelContext) {
-		this.value = extractJandexValue(
-				annotation,
-				org.hibernate.boot.models.HibernateAnnotations.DISCRIMINATOR_FORMULA,
-				"value",
-				modelContext
-		);
-		this.discriminatorType = extractJandexValue(
-				annotation,
-				org.hibernate.boot.models.HibernateAnnotations.DISCRIMINATOR_FORMULA,
-				"discriminatorType",
-				modelContext
-		);
+	public DiscriminatorFormulaAnnotation(
+			Map<String, Object> attributeValues,
+			SourceModelBuildingContext modelContext) {
+		this.value = (String) attributeValues.get( "value" );
+		this.discriminatorType = (jakarta.persistence.DiscriminatorType) attributeValues.get( "discriminatorType" );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/DiscriminatorOptionsAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/DiscriminatorOptionsAnnotation.java
@@ -7,14 +7,10 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
 import org.hibernate.annotations.DiscriminatorOptions;
-import org.hibernate.boot.models.HibernateAnnotations;
 import org.hibernate.models.spi.SourceModelBuildingContext;
-
-import org.jboss.jandex.AnnotationInstance;
-
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJandexValue;
 
 @SuppressWarnings({ "ClassExplicitlyAnnotation", "unused" })
 @jakarta.annotation.Generated("org.hibernate.orm.build.annotations.ClassGeneratorProcessor")
@@ -41,19 +37,9 @@ public class DiscriminatorOptionsAnnotation implements DiscriminatorOptions {
 	/**
 	 * Used in creating annotation instances from Jandex variant
 	 */
-	public DiscriminatorOptionsAnnotation(AnnotationInstance annotation, SourceModelBuildingContext modelContext) {
-		this.force = extractJandexValue(
-				annotation,
-				HibernateAnnotations.DISCRIMINATOR_OPTIONS,
-				"force",
-				modelContext
-		);
-		this.insert = extractJandexValue(
-				annotation,
-				HibernateAnnotations.DISCRIMINATOR_OPTIONS,
-				"insert",
-				modelContext
-		);
+	public DiscriminatorOptionsAnnotation(Map<String, Object> attributeValues, SourceModelBuildingContext modelContext) {
+		this.force = (boolean) attributeValues.get( "force");
+		this.insert = (boolean) attributeValues.get( "insert");
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/DiscriminatorValueJpaAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/DiscriminatorValueJpaAnnotation.java
@@ -7,15 +7,11 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
-import org.hibernate.boot.models.JpaAnnotations;
 import org.hibernate.models.spi.SourceModelBuildingContext;
 
-import org.jboss.jandex.AnnotationInstance;
-
 import jakarta.persistence.DiscriminatorValue;
-
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJandexValue;
 
 @SuppressWarnings({ "ClassExplicitlyAnnotation", "unused" })
 @jakarta.annotation.Generated("org.hibernate.orm.build.annotations.ClassGeneratorProcessor")
@@ -38,8 +34,10 @@ public class DiscriminatorValueJpaAnnotation implements DiscriminatorValue {
 	/**
 	 * Used in creating annotation instances from Jandex variant
 	 */
-	public DiscriminatorValueJpaAnnotation(AnnotationInstance annotation, SourceModelBuildingContext modelContext) {
-		this.value = extractJandexValue( annotation, JpaAnnotations.DISCRIMINATOR_VALUE, "value", modelContext );
+	public DiscriminatorValueJpaAnnotation(
+			Map<String, Object> attributeValues,
+			SourceModelBuildingContext modelContext) {
+		this.value = (String) attributeValues.get( "value" );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/DynamicInsertAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/DynamicInsertAnnotation.java
@@ -7,15 +7,10 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
 import org.hibernate.annotations.DynamicInsert;
-import org.hibernate.boot.models.HibernateAnnotations;
 import org.hibernate.models.spi.SourceModelBuildingContext;
-
-import org.jboss.jandex.AnnotationInstance;
-
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJandexValue;
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJdkValue;
 
 @SuppressWarnings({ "ClassExplicitlyAnnotation", "unused" })
 @jakarta.annotation.Generated("org.hibernate.orm.build.annotations.ClassGeneratorProcessor")
@@ -36,7 +31,7 @@ public class DynamicInsertAnnotation implements DynamicInsert {
 	/**
 	 * Used in creating annotation instances from Jandex variant
 	 */
-	public DynamicInsertAnnotation(AnnotationInstance annotation, SourceModelBuildingContext modelContext) {
+	public DynamicInsertAnnotation(Map<String, Object> attributeValues, SourceModelBuildingContext modelContext) {
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/DynamicUpdateAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/DynamicUpdateAnnotation.java
@@ -7,14 +7,10 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
 import org.hibernate.annotations.DynamicUpdate;
-import org.hibernate.boot.models.HibernateAnnotations;
 import org.hibernate.models.spi.SourceModelBuildingContext;
-
-import org.jboss.jandex.AnnotationInstance;
-
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJandexValue;
 
 @SuppressWarnings({ "ClassExplicitlyAnnotation", "unused" })
 @jakarta.annotation.Generated("org.hibernate.orm.build.annotations.ClassGeneratorProcessor")
@@ -36,7 +32,7 @@ public class DynamicUpdateAnnotation implements DynamicUpdate {
 	/**
 	 * Used in creating annotation instances from Jandex variant
 	 */
-	public DynamicUpdateAnnotation(AnnotationInstance annotation, SourceModelBuildingContext modelContext) {
+	public DynamicUpdateAnnotation(Map<String, Object> attributeValues, SourceModelBuildingContext modelContext) {
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/ElementCollectionJpaAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/ElementCollectionJpaAnnotation.java
@@ -7,16 +7,12 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
-import org.hibernate.boot.models.JpaAnnotations;
 import org.hibernate.boot.models.annotations.spi.AttributeMarker;
 import org.hibernate.models.spi.SourceModelBuildingContext;
 
-import org.jboss.jandex.AnnotationInstance;
-
 import jakarta.persistence.ElementCollection;
-
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJandexValue;
 
 @SuppressWarnings({ "ClassExplicitlyAnnotation", "unused" })
 @jakarta.annotation.Generated("org.hibernate.orm.build.annotations.ClassGeneratorProcessor")
@@ -43,14 +39,11 @@ public class ElementCollectionJpaAnnotation implements ElementCollection, Attrib
 	/**
 	 * Used in creating annotation instances from Jandex variant
 	 */
-	public ElementCollectionJpaAnnotation(AnnotationInstance annotation, SourceModelBuildingContext modelContext) {
-		this.targetClass = extractJandexValue(
-				annotation,
-				JpaAnnotations.ELEMENT_COLLECTION,
-				"targetClass",
-				modelContext
-		);
-		this.fetch = extractJandexValue( annotation, JpaAnnotations.ELEMENT_COLLECTION, "fetch", modelContext );
+	public ElementCollectionJpaAnnotation(
+			Map<String, Object> attributeValues,
+			SourceModelBuildingContext modelContext) {
+		this.targetClass = (Class<?>) attributeValues.get( "targetClass" );
+		this.fetch = (jakarta.persistence.FetchType) attributeValues.get( "fetch" );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/EmbeddableInstantiatorAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/EmbeddableInstantiatorAnnotation.java
@@ -7,14 +7,10 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
 import org.hibernate.annotations.EmbeddableInstantiator;
-import org.hibernate.boot.models.HibernateAnnotations;
 import org.hibernate.models.spi.SourceModelBuildingContext;
-
-import org.jboss.jandex.AnnotationInstance;
-
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJandexValue;
 
 @SuppressWarnings({ "ClassExplicitlyAnnotation", "unused" })
 @jakarta.annotation.Generated("org.hibernate.orm.build.annotations.ClassGeneratorProcessor")
@@ -39,13 +35,10 @@ public class EmbeddableInstantiatorAnnotation implements EmbeddableInstantiator 
 	/**
 	 * Used in creating annotation instances from Jandex variant
 	 */
-	public EmbeddableInstantiatorAnnotation(AnnotationInstance annotation, SourceModelBuildingContext modelContext) {
-		this.value = extractJandexValue(
-				annotation,
-				HibernateAnnotations.EMBEDDABLE_INSTANTIATOR,
-				"value",
-				modelContext
-		);
+	public EmbeddableInstantiatorAnnotation(
+			Map<String, Object> attributeValues,
+			SourceModelBuildingContext modelContext) {
+		this.value = (Class<? extends org.hibernate.metamodel.spi.EmbeddableInstantiator>) attributeValues.get( "value" );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/EmbeddableInstantiatorRegistrationAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/EmbeddableInstantiatorRegistrationAnnotation.java
@@ -7,14 +7,10 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
 import org.hibernate.annotations.EmbeddableInstantiatorRegistration;
-import org.hibernate.boot.models.HibernateAnnotations;
 import org.hibernate.models.spi.SourceModelBuildingContext;
-
-import org.jboss.jandex.AnnotationInstance;
-
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJandexValue;
 
 @SuppressWarnings({ "ClassExplicitlyAnnotation", "unused" })
 @jakarta.annotation.Generated("org.hibernate.orm.build.annotations.ClassGeneratorProcessor")
@@ -42,20 +38,11 @@ public class EmbeddableInstantiatorRegistrationAnnotation implements EmbeddableI
 	 * Used in creating annotation instances from Jandex variant
 	 */
 	public EmbeddableInstantiatorRegistrationAnnotation(
-			AnnotationInstance annotation,
+			Map<String, Object> attributeValues,
 			SourceModelBuildingContext modelContext) {
-		this.embeddableClass = extractJandexValue(
-				annotation,
-				HibernateAnnotations.EMBEDDABLE_INSTANTIATOR_REGISTRATION,
-				"embeddableClass",
-				modelContext
-		);
-		this.instantiator = extractJandexValue(
-				annotation,
-				HibernateAnnotations.EMBEDDABLE_INSTANTIATOR_REGISTRATION,
-				"instantiator",
-				modelContext
-		);
+		this.embeddableClass = (Class<?>) attributeValues.get( "embeddableClass" );
+		this.instantiator = (Class<? extends org.hibernate.metamodel.spi.EmbeddableInstantiator>) attributeValues
+				.get( "instantiator" );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/EmbeddableInstantiatorRegistrationsAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/EmbeddableInstantiatorRegistrationsAnnotation.java
@@ -7,6 +7,7 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
 import org.hibernate.annotations.EmbeddableInstantiatorRegistration;
 import org.hibernate.annotations.EmbeddableInstantiatorRegistrations;
@@ -14,9 +15,6 @@ import org.hibernate.boot.models.HibernateAnnotations;
 import org.hibernate.boot.models.annotations.spi.RepeatableContainer;
 import org.hibernate.models.spi.SourceModelBuildingContext;
 
-import org.jboss.jandex.AnnotationInstance;
-
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJandexValue;
 import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJdkValue;
 
 @SuppressWarnings({ "ClassExplicitlyAnnotation", "unused" })
@@ -49,14 +47,9 @@ public class EmbeddableInstantiatorRegistrationsAnnotation
 	 * Used in creating annotation instances from Jandex variant
 	 */
 	public EmbeddableInstantiatorRegistrationsAnnotation(
-			AnnotationInstance annotation,
+			Map<String, Object> attributeValues,
 			SourceModelBuildingContext modelContext) {
-		this.value = extractJandexValue(
-				annotation,
-				HibernateAnnotations.EMBEDDABLE_INSTANTIATOR_REGISTRATIONS,
-				"value",
-				modelContext
-		);
+		this.value = (EmbeddableInstantiatorRegistration[]) attributeValues.get( "value" );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/EmbeddableJpaAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/EmbeddableJpaAnnotation.java
@@ -6,11 +6,10 @@
  */
 package org.hibernate.boot.models.annotations.internal;
 
-import org.hibernate.models.spi.SourceModelBuildingContext;
-
-import org.jboss.jandex.AnnotationInstance;
-
 import java.lang.annotation.Annotation;
+import java.util.Map;
+
+import org.hibernate.models.spi.SourceModelBuildingContext;
 
 import jakarta.persistence.Embeddable;
 
@@ -33,7 +32,7 @@ public class EmbeddableJpaAnnotation implements Embeddable {
 	/**
 	 * Used in creating annotation instances from Jandex variant
 	 */
-	public EmbeddableJpaAnnotation(AnnotationInstance annotation, SourceModelBuildingContext modelContext) {
+	public EmbeddableJpaAnnotation(Map<String, Object> attributeValues, SourceModelBuildingContext modelContext) {
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/EmbeddedIdJpaAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/EmbeddedIdJpaAnnotation.java
@@ -6,11 +6,10 @@
  */
 package org.hibernate.boot.models.annotations.internal;
 
-import org.hibernate.models.spi.SourceModelBuildingContext;
-
-import org.jboss.jandex.AnnotationInstance;
-
 import java.lang.annotation.Annotation;
+import java.util.Map;
+
+import org.hibernate.models.spi.SourceModelBuildingContext;
 
 import jakarta.persistence.EmbeddedId;
 
@@ -32,7 +31,7 @@ public class EmbeddedIdJpaAnnotation implements EmbeddedId {
 	/**
 	 * Used in creating annotation instances from Jandex variant
 	 */
-	public EmbeddedIdJpaAnnotation(AnnotationInstance annotation, SourceModelBuildingContext modelContext) {
+	public EmbeddedIdJpaAnnotation(Map<String, Object> attributeValues, SourceModelBuildingContext modelContext) {
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/EmbeddedJpaAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/EmbeddedJpaAnnotation.java
@@ -6,11 +6,10 @@
  */
 package org.hibernate.boot.models.annotations.internal;
 
-import org.hibernate.models.spi.SourceModelBuildingContext;
-
-import org.jboss.jandex.AnnotationInstance;
-
 import java.lang.annotation.Annotation;
+import java.util.Map;
+
+import org.hibernate.models.spi.SourceModelBuildingContext;
 
 import jakarta.persistence.Embedded;
 
@@ -33,7 +32,7 @@ public class EmbeddedJpaAnnotation implements Embedded {
 	/**
 	 * Used in creating annotation instances from Jandex variant
 	 */
-	public EmbeddedJpaAnnotation(AnnotationInstance annotation, SourceModelBuildingContext modelContext) {
+	public EmbeddedJpaAnnotation(Map<String, Object> attributeValues, SourceModelBuildingContext modelContext) {
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/EntityJpaAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/EntityJpaAnnotation.java
@@ -7,15 +7,11 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
-import org.hibernate.boot.models.JpaAnnotations;
 import org.hibernate.models.spi.SourceModelBuildingContext;
 
-import org.jboss.jandex.AnnotationInstance;
-
 import jakarta.persistence.Entity;
-
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJandexValue;
 
 @SuppressWarnings({ "ClassExplicitlyAnnotation", "unused" })
 @jakarta.annotation.Generated("org.hibernate.orm.build.annotations.ClassGeneratorProcessor")
@@ -39,8 +35,8 @@ public class EntityJpaAnnotation implements Entity {
 	/**
 	 * Used in creating annotation instances from Jandex variant
 	 */
-	public EntityJpaAnnotation(AnnotationInstance annotation, SourceModelBuildingContext modelContext) {
-		this.name = extractJandexValue( annotation, JpaAnnotations.ENTITY, "name", modelContext );
+	public EntityJpaAnnotation(Map<String, Object> attributeValues, SourceModelBuildingContext modelContext) {
+		this.name = (String) attributeValues.get( "name" );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/EntityListenersJpaAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/EntityListenersJpaAnnotation.java
@@ -7,15 +7,11 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
-import org.hibernate.boot.models.JpaAnnotations;
 import org.hibernate.models.spi.SourceModelBuildingContext;
 
-import org.jboss.jandex.AnnotationInstance;
-
 import jakarta.persistence.EntityListeners;
-
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJandexValue;
 
 @SuppressWarnings({ "ClassExplicitlyAnnotation", "unused" })
 @jakarta.annotation.Generated("org.hibernate.orm.build.annotations.ClassGeneratorProcessor")
@@ -38,8 +34,8 @@ public class EntityListenersJpaAnnotation implements EntityListeners {
 	/**
 	 * Used in creating annotation instances from Jandex variant
 	 */
-	public EntityListenersJpaAnnotation(AnnotationInstance annotation, SourceModelBuildingContext modelContext) {
-		this.value = extractJandexValue( annotation, JpaAnnotations.ENTITY_LISTENERS, "value", modelContext );
+	public EntityListenersJpaAnnotation(Map<String, Object> attributeValues, SourceModelBuildingContext modelContext) {
+		this.value = (Class<?>[]) attributeValues.get( "value" );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/EntityResultJpaAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/EntityResultJpaAnnotation.java
@@ -7,15 +7,11 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
-import org.hibernate.boot.models.JpaAnnotations;
 import org.hibernate.models.spi.SourceModelBuildingContext;
 
-import org.jboss.jandex.AnnotationInstance;
-
 import jakarta.persistence.EntityResult;
-
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJandexValue;
 
 @SuppressWarnings({ "ClassExplicitlyAnnotation", "unused" })
 @jakarta.annotation.Generated("org.hibernate.orm.build.annotations.ClassGeneratorProcessor")
@@ -47,16 +43,11 @@ public class EntityResultJpaAnnotation implements EntityResult {
 	/**
 	 * Used in creating annotation instances from Jandex variant
 	 */
-	public EntityResultJpaAnnotation(AnnotationInstance annotation, SourceModelBuildingContext modelContext) {
-		this.entityClass = extractJandexValue( annotation, JpaAnnotations.ENTITY_RESULT, "entityClass", modelContext );
-		this.lockMode = extractJandexValue( annotation, JpaAnnotations.ENTITY_RESULT, "lockMode", modelContext );
-		this.fields = extractJandexValue( annotation, JpaAnnotations.ENTITY_RESULT, "fields", modelContext );
-		this.discriminatorColumn = extractJandexValue(
-				annotation,
-				JpaAnnotations.ENTITY_RESULT,
-				"discriminatorColumn",
-				modelContext
-		);
+	public EntityResultJpaAnnotation(Map<String, Object> attributeValues, SourceModelBuildingContext modelContext) {
+		this.entityClass = (Class<?>) attributeValues.get( "entityClass" );
+		this.lockMode = (jakarta.persistence.LockModeType) attributeValues.get( "lockMode" );
+		this.fields = (jakarta.persistence.FieldResult[]) attributeValues.get( "fields" );
+		this.discriminatorColumn = (String) attributeValues.get( "discriminatorColumn" );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/EnumeratedJpaAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/EnumeratedJpaAnnotation.java
@@ -7,15 +7,11 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
-import org.hibernate.boot.models.JpaAnnotations;
 import org.hibernate.models.spi.SourceModelBuildingContext;
 
-import org.jboss.jandex.AnnotationInstance;
-
 import jakarta.persistence.Enumerated;
-
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJandexValue;
 
 @SuppressWarnings({ "ClassExplicitlyAnnotation", "unused" })
 @jakarta.annotation.Generated("org.hibernate.orm.build.annotations.ClassGeneratorProcessor")
@@ -39,8 +35,8 @@ public class EnumeratedJpaAnnotation implements Enumerated {
 	/**
 	 * Used in creating annotation instances from Jandex variant
 	 */
-	public EnumeratedJpaAnnotation(AnnotationInstance annotation, SourceModelBuildingContext modelContext) {
-		this.value = extractJandexValue( annotation, JpaAnnotations.ENUMERATED, "value", modelContext );
+	public EnumeratedJpaAnnotation(Map<String, Object> attributeValues, SourceModelBuildingContext modelContext) {
+		this.value = (jakarta.persistence.EnumType) attributeValues.get( "value" );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/EnumeratedValueJpaAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/EnumeratedValueJpaAnnotation.java
@@ -7,10 +7,9 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
 import org.hibernate.models.spi.SourceModelBuildingContext;
-
-import org.jboss.jandex.AnnotationInstance;
 
 import jakarta.persistence.EnumeratedValue;
 
@@ -32,7 +31,7 @@ public class EnumeratedValueJpaAnnotation implements EnumeratedValue {
 	/**
 	 * Used in creating annotation instances from Jandex variant
 	 */
-	public EnumeratedValueJpaAnnotation(AnnotationInstance annotation, SourceModelBuildingContext modelContext) {
+	public EnumeratedValueJpaAnnotation(Map<String, Object> attributeValues, SourceModelBuildingContext modelContext) {
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/ExcludeDefaultListenersJpaAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/ExcludeDefaultListenersJpaAnnotation.java
@@ -6,11 +6,10 @@
  */
 package org.hibernate.boot.models.annotations.internal;
 
-import org.hibernate.models.spi.SourceModelBuildingContext;
-
-import org.jboss.jandex.AnnotationInstance;
-
 import java.lang.annotation.Annotation;
+import java.util.Map;
+
+import org.hibernate.models.spi.SourceModelBuildingContext;
 
 import jakarta.persistence.ExcludeDefaultListeners;
 
@@ -36,7 +35,7 @@ public class ExcludeDefaultListenersJpaAnnotation implements ExcludeDefaultListe
 	 * Used in creating annotation instances from Jandex variant
 	 */
 	public ExcludeDefaultListenersJpaAnnotation(
-			AnnotationInstance annotation,
+			Map<String, Object> attributeValues,
 			SourceModelBuildingContext modelContext) {
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/ExcludeSuperclassListenersJpaAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/ExcludeSuperclassListenersJpaAnnotation.java
@@ -6,11 +6,10 @@
  */
 package org.hibernate.boot.models.annotations.internal;
 
-import org.hibernate.models.spi.SourceModelBuildingContext;
-
-import org.jboss.jandex.AnnotationInstance;
-
 import java.lang.annotation.Annotation;
+import java.util.Map;
+
+import org.hibernate.models.spi.SourceModelBuildingContext;
 
 import jakarta.persistence.ExcludeSuperclassListeners;
 
@@ -36,7 +35,7 @@ public class ExcludeSuperclassListenersJpaAnnotation implements ExcludeSuperclas
 	 * Used in creating annotation instances from Jandex variant
 	 */
 	public ExcludeSuperclassListenersJpaAnnotation(
-			AnnotationInstance annotation,
+			Map<String, Object> attributeValues,
 			SourceModelBuildingContext modelContext) {
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/ExtendsXmlAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/ExtendsXmlAnnotation.java
@@ -7,14 +7,10 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
 import org.hibernate.boot.internal.Extends;
-import org.hibernate.boot.models.XmlAnnotations;
 import org.hibernate.models.spi.SourceModelBuildingContext;
-
-import org.jboss.jandex.AnnotationInstance;
-
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJandexValue;
 
 @SuppressWarnings({ "ClassExplicitlyAnnotation", "unused" })
 @jakarta.annotation.Generated("org.hibernate.orm.build.annotations.ClassGeneratorProcessor")
@@ -37,8 +33,8 @@ public class ExtendsXmlAnnotation implements Extends {
 	/**
 	 * Used in creating annotation instances from Jandex variant
 	 */
-	public ExtendsXmlAnnotation(AnnotationInstance annotation, SourceModelBuildingContext modelContext) {
-		this.superType = extractJandexValue( annotation, XmlAnnotations.EXTENDS, "superType", modelContext );
+	public ExtendsXmlAnnotation(Map<String, Object> attributeValues, SourceModelBuildingContext modelContext) {
+		this.superType = (String) attributeValues.get( "superType" );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/FetchAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/FetchAnnotation.java
@@ -7,14 +7,10 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
 import org.hibernate.annotations.Fetch;
-import org.hibernate.boot.models.HibernateAnnotations;
 import org.hibernate.models.spi.SourceModelBuildingContext;
-
-import org.jboss.jandex.AnnotationInstance;
-
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJandexValue;
 
 @SuppressWarnings({ "ClassExplicitlyAnnotation", "unused" })
 @jakarta.annotation.Generated("org.hibernate.orm.build.annotations.ClassGeneratorProcessor")
@@ -37,8 +33,8 @@ public class FetchAnnotation implements Fetch {
 	/**
 	 * Used in creating annotation instances from Jandex variant
 	 */
-	public FetchAnnotation(AnnotationInstance annotation, SourceModelBuildingContext modelContext) {
-		this.value = extractJandexValue( annotation, HibernateAnnotations.FETCH, "value", modelContext );
+	public FetchAnnotation(Map<String, Object> attributeValues, SourceModelBuildingContext modelContext) {
+		this.value = (org.hibernate.annotations.FetchMode) attributeValues.get( "value" );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/FetchProfileAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/FetchProfileAnnotation.java
@@ -7,14 +7,12 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
 import org.hibernate.annotations.FetchProfile;
 import org.hibernate.boot.models.HibernateAnnotations;
 import org.hibernate.models.spi.SourceModelBuildingContext;
 
-import org.jboss.jandex.AnnotationInstance;
-
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJandexValue;
 import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJdkValue;
 
 @SuppressWarnings({ "ClassExplicitlyAnnotation", "unused" })
@@ -46,14 +44,9 @@ public class FetchProfileAnnotation implements FetchProfile {
 	/**
 	 * Used in creating annotation instances from Jandex variant
 	 */
-	public FetchProfileAnnotation(AnnotationInstance annotation, SourceModelBuildingContext modelContext) {
-		this.name = extractJandexValue( annotation, HibernateAnnotations.FETCH_PROFILE, "name", modelContext );
-		this.fetchOverrides = extractJandexValue(
-				annotation,
-				HibernateAnnotations.FETCH_PROFILE,
-				"fetchOverrides",
-				modelContext
-		);
+	public FetchProfileAnnotation(Map<String, Object> attributeValues, SourceModelBuildingContext modelContext) {
+		this.name = (String) attributeValues.get( "name" );
+		this.fetchOverrides = (FetchOverride[]) attributeValues.get( "fetchOverrides" );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/FetchProfileOverrideAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/FetchProfileOverrideAnnotation.java
@@ -7,14 +7,10 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
 import org.hibernate.annotations.FetchProfileOverride;
-import org.hibernate.boot.models.DialectOverrideAnnotations;
 import org.hibernate.models.spi.SourceModelBuildingContext;
-
-import org.jboss.jandex.AnnotationInstance;
-
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJandexValue;
 
 @SuppressWarnings({ "ClassExplicitlyAnnotation", "unused" })
 @jakarta.annotation.Generated("org.hibernate.orm.build.annotations.ClassGeneratorProcessor")
@@ -44,25 +40,12 @@ public class FetchProfileOverrideAnnotation implements FetchProfileOverride {
 	/**
 	 * Used in creating annotation instances from Jandex variant
 	 */
-	public FetchProfileOverrideAnnotation(AnnotationInstance annotation, SourceModelBuildingContext modelContext) {
-		this.mode = extractJandexValue(
-				annotation,
-				DialectOverrideAnnotations.FETCH_PROFILE_OVERRIDE,
-				"mode",
-				modelContext
-		);
-		this.fetch = extractJandexValue(
-				annotation,
-				DialectOverrideAnnotations.FETCH_PROFILE_OVERRIDE,
-				"fetch",
-				modelContext
-		);
-		this.profile = extractJandexValue(
-				annotation,
-				DialectOverrideAnnotations.FETCH_PROFILE_OVERRIDE,
-				"profile",
-				modelContext
-		);
+	public FetchProfileOverrideAnnotation(
+			Map<String, Object> attributeValues,
+			SourceModelBuildingContext modelContext) {
+		this.mode = (org.hibernate.annotations.FetchMode) attributeValues.get( "mode" );
+		this.fetch = (jakarta.persistence.FetchType) attributeValues.get( "fetch" );
+		this.profile = (String) attributeValues.get( "profile" );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/FetchProfileOverridesAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/FetchProfileOverridesAnnotation.java
@@ -7,15 +7,13 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
 import org.hibernate.annotations.FetchProfileOverrides;
 import org.hibernate.boot.models.DialectOverrideAnnotations;
 import org.hibernate.boot.models.annotations.spi.RepeatableContainer;
 import org.hibernate.models.spi.SourceModelBuildingContext;
 
-import org.jboss.jandex.AnnotationInstance;
-
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJandexValue;
 import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJdkValue;
 
 @SuppressWarnings({ "ClassExplicitlyAnnotation", "unused" })
@@ -45,13 +43,10 @@ public class FetchProfileOverridesAnnotation
 	/**
 	 * Used in creating annotation instances from Jandex variant
 	 */
-	public FetchProfileOverridesAnnotation(AnnotationInstance annotation, SourceModelBuildingContext modelContext) {
-		this.value = extractJandexValue(
-				annotation,
-				DialectOverrideAnnotations.FETCH_PROFILE_OVERRIDES,
-				"value",
-				modelContext
-		);
+	public FetchProfileOverridesAnnotation(
+			Map<String, Object> attributeValues,
+			SourceModelBuildingContext modelContext) {
+		this.value = (org.hibernate.annotations.FetchProfileOverride[]) attributeValues.get( "value" );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/FetchProfilesAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/FetchProfilesAnnotation.java
@@ -7,6 +7,7 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
 import org.hibernate.annotations.FetchProfile;
 import org.hibernate.annotations.FetchProfiles;
@@ -14,9 +15,6 @@ import org.hibernate.boot.models.HibernateAnnotations;
 import org.hibernate.boot.models.annotations.spi.RepeatableContainer;
 import org.hibernate.models.spi.SourceModelBuildingContext;
 
-import org.jboss.jandex.AnnotationInstance;
-
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJandexValue;
 import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJdkValue;
 
 @SuppressWarnings({ "ClassExplicitlyAnnotation", "unused" })
@@ -40,8 +38,8 @@ public class FetchProfilesAnnotation implements FetchProfiles, RepeatableContain
 	/**
 	 * Used in creating annotation instances from Jandex variant
 	 */
-	public FetchProfilesAnnotation(AnnotationInstance annotation, SourceModelBuildingContext modelContext) {
-		this.value = extractJandexValue( annotation, HibernateAnnotations.FETCH_PROFILES, "value", modelContext );
+	public FetchProfilesAnnotation(Map<String, Object> attributeValues, SourceModelBuildingContext modelContext) {
+		this.value = (FetchProfile[]) attributeValues.get( "value" );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/FieldResultJpaAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/FieldResultJpaAnnotation.java
@@ -7,15 +7,11 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
-import org.hibernate.boot.models.JpaAnnotations;
 import org.hibernate.models.spi.SourceModelBuildingContext;
 
-import org.jboss.jandex.AnnotationInstance;
-
 import jakarta.persistence.FieldResult;
-
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJandexValue;
 
 @SuppressWarnings({ "ClassExplicitlyAnnotation", "unused" })
 @jakarta.annotation.Generated("org.hibernate.orm.build.annotations.ClassGeneratorProcessor")
@@ -40,9 +36,9 @@ public class FieldResultJpaAnnotation implements FieldResult {
 	/**
 	 * Used in creating annotation instances from Jandex variant
 	 */
-	public FieldResultJpaAnnotation(AnnotationInstance annotation, SourceModelBuildingContext modelContext) {
-		this.name = extractJandexValue( annotation, JpaAnnotations.FIELD_RESULT, "name", modelContext );
-		this.column = extractJandexValue( annotation, JpaAnnotations.FIELD_RESULT, "column", modelContext );
+	public FieldResultJpaAnnotation(Map<String, Object> attributeValues, SourceModelBuildingContext modelContext) {
+		this.name = (String) attributeValues.get( "name" );
+		this.column = (String) attributeValues.get( "column" );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/FilterAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/FilterAnnotation.java
@@ -7,6 +7,7 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
 import org.hibernate.annotations.Filter;
 import org.hibernate.boot.jaxb.mapping.spi.JaxbFilterImpl;
@@ -17,9 +18,6 @@ import org.hibernate.boot.models.xml.spi.XmlDocumentContext;
 import org.hibernate.internal.util.StringHelper;
 import org.hibernate.models.spi.SourceModelBuildingContext;
 
-import org.jboss.jandex.AnnotationInstance;
-
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJandexValue;
 import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJdkValue;
 
 @SuppressWarnings({ "ClassExplicitlyAnnotation", "unused" })
@@ -52,16 +50,11 @@ public class FilterAnnotation implements Filter, FilterDetails {
 	/**
 	 * Used in creating annotation instances from Jandex variant
 	 */
-	public FilterAnnotation(AnnotationInstance annotation, SourceModelBuildingContext modelContext) {
-		this.name = extractJandexValue( annotation, HibernateAnnotations.FILTER, "name", modelContext );
-		this.condition = extractJandexValue( annotation, HibernateAnnotations.FILTER, "condition", modelContext );
-		this.deduceAliasInjectionPoints = extractJandexValue(
-				annotation,
-				HibernateAnnotations.FILTER,
-				"deduceAliasInjectionPoints",
-				modelContext
-		);
-		this.aliases = extractJandexValue( annotation, HibernateAnnotations.FILTER, "aliases", modelContext );
+	public FilterAnnotation(Map<String, Object> attributeValues, SourceModelBuildingContext modelContext) {
+		this.name = (String) attributeValues.get( "name" );
+		this.condition = (String) attributeValues.get( "condition" );
+		this.deduceAliasInjectionPoints = (boolean) attributeValues.get( "deduceAliasInjectionPoints" );
+		this.aliases = (org.hibernate.annotations.SqlFragmentAlias[]) attributeValues.get( "aliases" );
 	}
 
 

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/FilterDefAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/FilterDefAnnotation.java
@@ -7,14 +7,12 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
 import org.hibernate.annotations.FilterDef;
 import org.hibernate.boot.models.HibernateAnnotations;
 import org.hibernate.models.spi.SourceModelBuildingContext;
 
-import org.jboss.jandex.AnnotationInstance;
-
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJandexValue;
 import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJdkValue;
 
 @SuppressWarnings({ "ClassExplicitlyAnnotation", "unused" })
@@ -49,27 +47,12 @@ public class FilterDefAnnotation implements FilterDef {
 	/**
 	 * Used in creating annotation instances from Jandex variant
 	 */
-	public FilterDefAnnotation(AnnotationInstance annotation, SourceModelBuildingContext modelContext) {
-		this.name = extractJandexValue( annotation, HibernateAnnotations.FILTER_DEF, "name", modelContext );
-		this.defaultCondition = extractJandexValue(
-				annotation,
-				HibernateAnnotations.FILTER_DEF,
-				"defaultCondition",
-				modelContext
-		);
-		this.autoEnabled = extractJandexValue(
-				annotation,
-				HibernateAnnotations.FILTER_DEF,
-				"autoEnabled",
-				modelContext
-		);
-		this.applyToLoadByKey = extractJandexValue(
-				annotation,
-				HibernateAnnotations.FILTER_DEF,
-				"applyToLoadByKey",
-				modelContext
-		);
-		this.parameters = extractJandexValue( annotation, HibernateAnnotations.FILTER_DEF, "parameters", modelContext );
+	public FilterDefAnnotation(Map<String, Object> attributeValues, SourceModelBuildingContext modelContext) {
+		this.name = (String) attributeValues.get( "name" );
+		this.defaultCondition = (String) attributeValues.get( "defaultCondition" );
+		this.autoEnabled = (boolean) attributeValues.get( "autoEnabled" );
+		this.applyToLoadByKey = (boolean) attributeValues.get( "applyToLoadByKey" );
+		this.parameters = (org.hibernate.annotations.ParamDef[]) attributeValues.get( "parameters" );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/FilterDefsAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/FilterDefsAnnotation.java
@@ -7,6 +7,7 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
 import org.hibernate.annotations.FilterDef;
 import org.hibernate.annotations.FilterDefs;
@@ -14,9 +15,6 @@ import org.hibernate.boot.models.HibernateAnnotations;
 import org.hibernate.boot.models.annotations.spi.RepeatableContainer;
 import org.hibernate.models.spi.SourceModelBuildingContext;
 
-import org.jboss.jandex.AnnotationInstance;
-
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJandexValue;
 import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJdkValue;
 
 @SuppressWarnings({ "ClassExplicitlyAnnotation", "unused" })
@@ -40,8 +38,8 @@ public class FilterDefsAnnotation implements FilterDefs, RepeatableContainer<Fil
 	/**
 	 * Used in creating annotation instances from Jandex variant
 	 */
-	public FilterDefsAnnotation(AnnotationInstance annotation, SourceModelBuildingContext modelContext) {
-		this.value = extractJandexValue( annotation, HibernateAnnotations.FILTER_DEFS, "value", modelContext );
+	public FilterDefsAnnotation(Map<String, Object> attributeValues, SourceModelBuildingContext modelContext) {
+		this.value = (FilterDef[]) attributeValues.get( "value" );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/FilterJoinTableAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/FilterJoinTableAnnotation.java
@@ -7,6 +7,7 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
 import org.hibernate.annotations.FilterJoinTable;
 import org.hibernate.boot.jaxb.mapping.spi.JaxbFilterImpl;
@@ -16,10 +17,7 @@ import org.hibernate.boot.models.xml.spi.XmlDocumentContext;
 import org.hibernate.internal.util.StringHelper;
 import org.hibernate.models.spi.SourceModelBuildingContext;
 
-import org.jboss.jandex.AnnotationInstance;
-
 import static org.hibernate.boot.models.HibernateAnnotations.FILTER_JOIN_TABLE;
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJandexValue;
 import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJdkValue;
 
 @SuppressWarnings({ "ClassExplicitlyAnnotation", "unused" })
@@ -52,16 +50,11 @@ public class FilterJoinTableAnnotation implements FilterJoinTable, FilterDetails
 	/**
 	 * Used in creating annotation instances from Jandex variant
 	 */
-	public FilterJoinTableAnnotation(AnnotationInstance annotation, SourceModelBuildingContext modelContext) {
-		this.name = extractJandexValue( annotation, FILTER_JOIN_TABLE, "name", modelContext );
-		this.condition = extractJandexValue( annotation, FILTER_JOIN_TABLE, "condition", modelContext );
-		this.deduceAliasInjectionPoints = extractJandexValue(
-				annotation,
-				FILTER_JOIN_TABLE,
-				"deduceAliasInjectionPoints",
-				modelContext
-		);
-		this.aliases = extractJandexValue( annotation, FILTER_JOIN_TABLE, "aliases", modelContext );
+	public FilterJoinTableAnnotation(Map<String, Object> attributeValues, SourceModelBuildingContext modelContext) {
+		this.name = (String) attributeValues.get( "name" );
+		this.condition = (String) attributeValues.get( "condition" );
+		this.deduceAliasInjectionPoints = (boolean) attributeValues.get( "deduceAliasInjectionPoints" );
+		this.aliases = (org.hibernate.annotations.SqlFragmentAlias[]) attributeValues.get( "aliases" );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/FilterJoinTablesAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/FilterJoinTablesAnnotation.java
@@ -7,6 +7,7 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
 import org.hibernate.annotations.FilterJoinTable;
 import org.hibernate.annotations.FilterJoinTables;
@@ -14,9 +15,6 @@ import org.hibernate.boot.models.HibernateAnnotations;
 import org.hibernate.boot.models.annotations.spi.RepeatableContainer;
 import org.hibernate.models.spi.SourceModelBuildingContext;
 
-import org.jboss.jandex.AnnotationInstance;
-
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJandexValue;
 import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJdkValue;
 
 @SuppressWarnings({ "ClassExplicitlyAnnotation", "unused" })
@@ -40,8 +38,8 @@ public class FilterJoinTablesAnnotation implements FilterJoinTables, RepeatableC
 	/**
 	 * Used in creating annotation instances from Jandex variant
 	 */
-	public FilterJoinTablesAnnotation(AnnotationInstance annotation, SourceModelBuildingContext modelContext) {
-		this.value = extractJandexValue( annotation, HibernateAnnotations.FILTER_JOIN_TABLES, "value", modelContext );
+	public FilterJoinTablesAnnotation(Map<String, Object> attributeValues, SourceModelBuildingContext modelContext) {
+		this.value = (FilterJoinTable[]) attributeValues.get( "value" );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/FiltersAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/FiltersAnnotation.java
@@ -7,6 +7,7 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
 import org.hibernate.annotations.Filter;
 import org.hibernate.annotations.Filters;
@@ -14,9 +15,6 @@ import org.hibernate.boot.models.HibernateAnnotations;
 import org.hibernate.boot.models.annotations.spi.RepeatableContainer;
 import org.hibernate.models.spi.SourceModelBuildingContext;
 
-import org.jboss.jandex.AnnotationInstance;
-
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJandexValue;
 import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJdkValue;
 
 @SuppressWarnings({ "ClassExplicitlyAnnotation", "unused" })
@@ -40,8 +38,8 @@ public class FiltersAnnotation implements Filters, RepeatableContainer<Filter> {
 	/**
 	 * Used in creating annotation instances from Jandex variant
 	 */
-	public FiltersAnnotation(AnnotationInstance annotation, SourceModelBuildingContext modelContext) {
-		this.value = extractJandexValue( annotation, HibernateAnnotations.FILTERS, "value", modelContext );
+	public FiltersAnnotation(Map<String, Object> attributeValues, SourceModelBuildingContext modelContext) {
+		this.value = (Filter[]) attributeValues.get( "value" );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/ForeignKeyJpaAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/ForeignKeyJpaAnnotation.java
@@ -7,15 +7,11 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
-import org.hibernate.boot.models.JpaAnnotations;
 import org.hibernate.models.spi.SourceModelBuildingContext;
 
-import org.jboss.jandex.AnnotationInstance;
-
 import jakarta.persistence.ForeignKey;
-
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJandexValue;
 
 @SuppressWarnings({ "ClassExplicitlyAnnotation", "unused" })
 @jakarta.annotation.Generated("org.hibernate.orm.build.annotations.ClassGeneratorProcessor")
@@ -48,16 +44,11 @@ public class ForeignKeyJpaAnnotation implements ForeignKey {
 	/**
 	 * Used in creating annotation instances from Jandex variant
 	 */
-	public ForeignKeyJpaAnnotation(AnnotationInstance annotation, SourceModelBuildingContext modelContext) {
-		this.name = extractJandexValue( annotation, JpaAnnotations.FOREIGN_KEY, "name", modelContext );
-		this.value = extractJandexValue( annotation, JpaAnnotations.FOREIGN_KEY, "value", modelContext );
-		this.foreignKeyDefinition = extractJandexValue(
-				annotation,
-				JpaAnnotations.FOREIGN_KEY,
-				"foreignKeyDefinition",
-				modelContext
-		);
-		this.options = extractJandexValue( annotation, JpaAnnotations.FOREIGN_KEY, "options", modelContext );
+	public ForeignKeyJpaAnnotation(Map<String, Object> attributeValues, SourceModelBuildingContext modelContext) {
+		this.name = (String) attributeValues.get( "name" );
+		this.value = (jakarta.persistence.ConstraintMode) attributeValues.get( "value" );
+		this.foreignKeyDefinition = (String) attributeValues.get( "foreignKeyDefinition" );
+		this.options = (String) attributeValues.get( "options" );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/FormulaAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/FormulaAnnotation.java
@@ -7,14 +7,10 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
 import org.hibernate.annotations.Formula;
-import org.hibernate.boot.models.HibernateAnnotations;
 import org.hibernate.models.spi.SourceModelBuildingContext;
-
-import org.jboss.jandex.AnnotationInstance;
-
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJandexValue;
 
 @SuppressWarnings({ "ClassExplicitlyAnnotation", "unused" })
 @jakarta.annotation.Generated("org.hibernate.orm.build.annotations.ClassGeneratorProcessor")
@@ -37,8 +33,8 @@ public class FormulaAnnotation implements Formula {
 	/**
 	 * Used in creating annotation instances from Jandex variant
 	 */
-	public FormulaAnnotation(AnnotationInstance annotation, SourceModelBuildingContext modelContext) {
-		this.value = extractJandexValue( annotation, HibernateAnnotations.FORMULA, "value", modelContext );
+	public FormulaAnnotation(Map<String, Object> attributeValues, SourceModelBuildingContext modelContext) {
+		this.value = (String) attributeValues.get( "value" );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/FractionalSecondsAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/FractionalSecondsAnnotation.java
@@ -7,14 +7,10 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
 import org.hibernate.annotations.FractionalSeconds;
-import org.hibernate.boot.models.HibernateAnnotations;
 import org.hibernate.models.spi.SourceModelBuildingContext;
-
-import org.jboss.jandex.AnnotationInstance;
-
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJandexValue;
 
 @SuppressWarnings({ "ClassExplicitlyAnnotation", "unused" })
 @jakarta.annotation.Generated("org.hibernate.orm.build.annotations.ClassGeneratorProcessor")
@@ -37,8 +33,8 @@ public class FractionalSecondsAnnotation implements FractionalSeconds {
 	/**
 	 * Used in creating annotation instances from Jandex variant
 	 */
-	public FractionalSecondsAnnotation(AnnotationInstance annotation, SourceModelBuildingContext modelContext) {
-		this.value = extractJandexValue( annotation, HibernateAnnotations.FRACTIONAL_SECONDS, "value", modelContext );
+	public FractionalSecondsAnnotation(Map<String, Object> attributeValues, SourceModelBuildingContext modelContext) {
+		this.value = (int) attributeValues.get( "value" );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/GeneratedAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/GeneratedAnnotation.java
@@ -7,15 +7,11 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
 import org.hibernate.annotations.Generated;
-import org.hibernate.boot.models.HibernateAnnotations;
 import org.hibernate.generator.EventType;
 import org.hibernate.models.spi.SourceModelBuildingContext;
-
-import org.jboss.jandex.AnnotationInstance;
-
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJandexValue;
 
 @SuppressWarnings({ "ClassExplicitlyAnnotation", "unused" })
 @jakarta.annotation.Generated("org.hibernate.orm.build.annotations.ClassGeneratorProcessor")
@@ -45,10 +41,10 @@ public class GeneratedAnnotation implements Generated {
 	/**
 	 * Used in creating annotation instances from Jandex variant
 	 */
-	public GeneratedAnnotation(AnnotationInstance annotation, SourceModelBuildingContext modelContext) {
-		this.event = extractJandexValue( annotation, HibernateAnnotations.GENERATED, "event", modelContext );
-		this.sql = extractJandexValue( annotation, HibernateAnnotations.GENERATED, "sql", modelContext );
-		this.writable = extractJandexValue( annotation, HibernateAnnotations.GENERATED, "writable", modelContext );
+	public GeneratedAnnotation(Map<String, Object> attributeValues, SourceModelBuildingContext modelContext) {
+		this.event = (EventType[]) attributeValues.get( "event" );
+		this.sql = (String) attributeValues.get( "sql" );
+		this.writable = (boolean) attributeValues.get( "writable" );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/GeneratedColumnAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/GeneratedColumnAnnotation.java
@@ -7,14 +7,10 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
 import org.hibernate.annotations.GeneratedColumn;
-import org.hibernate.boot.models.HibernateAnnotations;
 import org.hibernate.models.spi.SourceModelBuildingContext;
-
-import org.jboss.jandex.AnnotationInstance;
-
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJandexValue;
 
 @SuppressWarnings({ "ClassExplicitlyAnnotation", "unused" })
 @jakarta.annotation.Generated("org.hibernate.orm.build.annotations.ClassGeneratorProcessor")
@@ -37,8 +33,8 @@ public class GeneratedColumnAnnotation implements GeneratedColumn {
 	/**
 	 * Used in creating annotation instances from Jandex variant
 	 */
-	public GeneratedColumnAnnotation(AnnotationInstance annotation, SourceModelBuildingContext modelContext) {
-		this.value = extractJandexValue( annotation, HibernateAnnotations.GENERATED_COLUMN, "value", modelContext );
+	public GeneratedColumnAnnotation(Map<String, Object> attributeValues, SourceModelBuildingContext modelContext) {
+		this.value = (String) attributeValues.get( "value" );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/GeneratedValueJpaAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/GeneratedValueJpaAnnotation.java
@@ -7,15 +7,11 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
-import org.hibernate.boot.models.JpaAnnotations;
 import org.hibernate.models.spi.SourceModelBuildingContext;
 
-import org.jboss.jandex.AnnotationInstance;
-
 import jakarta.persistence.GeneratedValue;
-
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJandexValue;
 
 @SuppressWarnings({ "ClassExplicitlyAnnotation", "unused" })
 @jakarta.annotation.Generated("org.hibernate.orm.build.annotations.ClassGeneratorProcessor")
@@ -42,9 +38,9 @@ public class GeneratedValueJpaAnnotation implements GeneratedValue {
 	/**
 	 * Used in creating annotation instances from Jandex variant
 	 */
-	public GeneratedValueJpaAnnotation(AnnotationInstance annotation, SourceModelBuildingContext modelContext) {
-		this.strategy = extractJandexValue( annotation, JpaAnnotations.GENERATED_VALUE, "strategy", modelContext );
-		this.generator = extractJandexValue( annotation, JpaAnnotations.GENERATED_VALUE, "generator", modelContext );
+	public GeneratedValueJpaAnnotation(Map<String, Object> attributeValues, SourceModelBuildingContext modelContext) {
+		this.strategy = (jakarta.persistence.GenerationType) attributeValues.get( "strategy" );
+		this.generator = (String) attributeValues.get( "generator" );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/GenericGeneratorAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/GenericGeneratorAnnotation.java
@@ -7,14 +7,12 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
 import org.hibernate.annotations.GenericGenerator;
 import org.hibernate.boot.models.HibernateAnnotations;
 import org.hibernate.models.spi.SourceModelBuildingContext;
 
-import org.jboss.jandex.AnnotationInstance;
-
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJandexValue;
 import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJdkValue;
 
 @SuppressWarnings({ "ClassExplicitlyAnnotation", "unused" })
@@ -52,21 +50,11 @@ public class GenericGeneratorAnnotation implements GenericGenerator {
 	/**
 	 * Used in creating annotation instances from Jandex variant
 	 */
-	public GenericGeneratorAnnotation(AnnotationInstance annotation, SourceModelBuildingContext modelContext) {
-		this.name = extractJandexValue( annotation, HibernateAnnotations.GENERIC_GENERATOR, "name", modelContext );
-		this.type = extractJandexValue( annotation, HibernateAnnotations.GENERIC_GENERATOR, "type", modelContext );
-		this.strategy = extractJandexValue(
-				annotation,
-				HibernateAnnotations.GENERIC_GENERATOR,
-				"strategy",
-				modelContext
-		);
-		this.parameters = extractJandexValue(
-				annotation,
-				HibernateAnnotations.GENERIC_GENERATOR,
-				"parameters",
-				modelContext
-		);
+	public GenericGeneratorAnnotation(Map<String, Object> attributeValues, SourceModelBuildingContext modelContext) {
+		this.name = (String) attributeValues.get( "name" );
+		this.type = (Class<? extends org.hibernate.generator.Generator>) attributeValues.get( "type" );
+		this.strategy = (String) attributeValues.get( "strategy" );
+		this.parameters = (org.hibernate.annotations.Parameter[]) attributeValues.get( "parameters" );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/GenericGeneratorsAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/GenericGeneratorsAnnotation.java
@@ -7,6 +7,7 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
 import org.hibernate.annotations.GenericGenerator;
 import org.hibernate.annotations.GenericGenerators;
@@ -14,9 +15,6 @@ import org.hibernate.boot.models.HibernateAnnotations;
 import org.hibernate.boot.models.annotations.spi.RepeatableContainer;
 import org.hibernate.models.spi.SourceModelBuildingContext;
 
-import org.jboss.jandex.AnnotationInstance;
-
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJandexValue;
 import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJdkValue;
 
 @SuppressWarnings({ "ClassExplicitlyAnnotation", "unused" })
@@ -40,8 +38,8 @@ public class GenericGeneratorsAnnotation implements GenericGenerators, Repeatabl
 	/**
 	 * Used in creating annotation instances from Jandex variant
 	 */
-	public GenericGeneratorsAnnotation(AnnotationInstance annotation, SourceModelBuildingContext modelContext) {
-		this.value = extractJandexValue( annotation, HibernateAnnotations.GENERIC_GENERATORS, "value", modelContext );
+	public GenericGeneratorsAnnotation(Map<String, Object> attributeValues, SourceModelBuildingContext modelContext) {
+		this.value = (GenericGenerator[]) attributeValues.get( "value" );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/HQLSelectAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/HQLSelectAnnotation.java
@@ -7,14 +7,10 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
 import org.hibernate.annotations.HQLSelect;
-import org.hibernate.boot.models.HibernateAnnotations;
 import org.hibernate.models.spi.SourceModelBuildingContext;
-
-import org.jboss.jandex.AnnotationInstance;
-
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJandexValue;
 
 @SuppressWarnings({ "ClassExplicitlyAnnotation", "unused" })
 @jakarta.annotation.Generated("org.hibernate.orm.build.annotations.ClassGeneratorProcessor")
@@ -39,8 +35,8 @@ public class HQLSelectAnnotation implements HQLSelect {
 	/**
 	 * Used in creating annotation instances from Jandex variant
 	 */
-	public HQLSelectAnnotation(AnnotationInstance annotation, SourceModelBuildingContext modelContext) {
-		this.query = extractJandexValue( annotation, HibernateAnnotations.HQL_SELECT, "query", modelContext );
+	public HQLSelectAnnotation(Map<String, Object> attributeValues, SourceModelBuildingContext modelContext) {
+		this.query = (String) attributeValues.get( "query" );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/IdClassJpaAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/IdClassJpaAnnotation.java
@@ -7,15 +7,11 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
-import org.hibernate.boot.models.JpaAnnotations;
 import org.hibernate.models.spi.SourceModelBuildingContext;
 
-import org.jboss.jandex.AnnotationInstance;
-
 import jakarta.persistence.IdClass;
-
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJandexValue;
 
 @SuppressWarnings({ "ClassExplicitlyAnnotation", "unused" })
 @jakarta.annotation.Generated("org.hibernate.orm.build.annotations.ClassGeneratorProcessor")
@@ -38,8 +34,8 @@ public class IdClassJpaAnnotation implements IdClass {
 	/**
 	 * Used in creating annotation instances from Jandex variant
 	 */
-	public IdClassJpaAnnotation(AnnotationInstance annotation, SourceModelBuildingContext modelContext) {
-		this.value = extractJandexValue( annotation, JpaAnnotations.ID_CLASS, "value", modelContext );
+	public IdClassJpaAnnotation(Map<String, Object> attributeValues, SourceModelBuildingContext modelContext) {
+		this.value = (Class<?>) attributeValues.get( "value" );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/IdGeneratorTypeAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/IdGeneratorTypeAnnotation.java
@@ -7,14 +7,10 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
 import org.hibernate.annotations.IdGeneratorType;
-import org.hibernate.boot.models.HibernateAnnotations;
 import org.hibernate.models.spi.SourceModelBuildingContext;
-
-import org.jboss.jandex.AnnotationInstance;
-
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJandexValue;
 
 @SuppressWarnings({ "ClassExplicitlyAnnotation", "unused" })
 @jakarta.annotation.Generated("org.hibernate.orm.build.annotations.ClassGeneratorProcessor")
@@ -37,8 +33,8 @@ public class IdGeneratorTypeAnnotation implements IdGeneratorType {
 	/**
 	 * Used in creating annotation instances from Jandex variant
 	 */
-	public IdGeneratorTypeAnnotation(AnnotationInstance annotation, SourceModelBuildingContext modelContext) {
-		this.value = extractJandexValue( annotation, HibernateAnnotations.ID_GENERATOR_TYPE, "value", modelContext );
+	public IdGeneratorTypeAnnotation(Map<String, Object> attributeValues, SourceModelBuildingContext modelContext) {
+		this.value = (Class<? extends org.hibernate.generator.Generator>) attributeValues.get( "value" );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/IdJpaAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/IdJpaAnnotation.java
@@ -7,10 +7,9 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
 import org.hibernate.models.spi.SourceModelBuildingContext;
-
-import org.jboss.jandex.AnnotationInstance;
 
 import jakarta.persistence.Id;
 
@@ -32,7 +31,7 @@ public class IdJpaAnnotation implements Id {
 	/**
 	 * Used in creating annotation instances from Jandex variant
 	 */
-	public IdJpaAnnotation(AnnotationInstance annotation, SourceModelBuildingContext modelContext) {
+	public IdJpaAnnotation(Map<String, Object> attributeValues, SourceModelBuildingContext modelContext) {
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/ImmutableAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/ImmutableAnnotation.java
@@ -7,11 +7,10 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
 import org.hibernate.annotations.Immutable;
 import org.hibernate.models.spi.SourceModelBuildingContext;
-
-import org.jboss.jandex.AnnotationInstance;
 
 @SuppressWarnings({ "ClassExplicitlyAnnotation", "unused" })
 @jakarta.annotation.Generated("org.hibernate.orm.build.annotations.ClassGeneratorProcessor")
@@ -32,7 +31,7 @@ public class ImmutableAnnotation implements Immutable {
 	/**
 	 * Used in creating annotation instances from Jandex variant
 	 */
-	public ImmutableAnnotation(AnnotationInstance annotation, SourceModelBuildingContext modelContext) {
+	public ImmutableAnnotation(Map<String, Object> attributeValues, SourceModelBuildingContext modelContext) {
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/ImportedAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/ImportedAnnotation.java
@@ -7,14 +7,10 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
 import org.hibernate.annotations.Imported;
-import org.hibernate.boot.models.HibernateAnnotations;
 import org.hibernate.models.spi.SourceModelBuildingContext;
-
-import org.jboss.jandex.AnnotationInstance;
-
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJandexValue;
 
 @SuppressWarnings({ "ClassExplicitlyAnnotation", "unused" })
 @jakarta.annotation.Generated("org.hibernate.orm.build.annotations.ClassGeneratorProcessor")
@@ -38,8 +34,8 @@ public class ImportedAnnotation implements Imported {
 	/**
 	 * Used in creating annotation instances from Jandex variant
 	 */
-	public ImportedAnnotation(AnnotationInstance annotation, SourceModelBuildingContext modelContext) {
-		this.rename = extractJandexValue( annotation, HibernateAnnotations.IMPORTED, "rename", modelContext );
+	public ImportedAnnotation(Map<String, Object> attributeValues, SourceModelBuildingContext modelContext) {
+		this.rename = (String) attributeValues.get( "rename" );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/IndexJpaAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/IndexJpaAnnotation.java
@@ -7,15 +7,11 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
-import org.hibernate.boot.models.JpaAnnotations;
 import org.hibernate.models.spi.SourceModelBuildingContext;
 
-import org.jboss.jandex.AnnotationInstance;
-
 import jakarta.persistence.Index;
-
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJandexValue;
 
 @SuppressWarnings({ "ClassExplicitlyAnnotation", "unused" })
 @jakarta.annotation.Generated("org.hibernate.orm.build.annotations.ClassGeneratorProcessor")
@@ -47,11 +43,11 @@ public class IndexJpaAnnotation implements Index {
 	/**
 	 * Used in creating annotation instances from Jandex variant
 	 */
-	public IndexJpaAnnotation(AnnotationInstance annotation, SourceModelBuildingContext modelContext) {
-		this.name = extractJandexValue( annotation, JpaAnnotations.INDEX, "name", modelContext );
-		this.columnList = extractJandexValue( annotation, JpaAnnotations.INDEX, "columnList", modelContext );
-		this.unique = extractJandexValue( annotation, JpaAnnotations.INDEX, "unique", modelContext );
-		this.options = extractJandexValue( annotation, JpaAnnotations.INDEX, "options", modelContext );
+	public IndexJpaAnnotation(Map<String, Object> attributeValues, SourceModelBuildingContext modelContext) {
+		this.name = (String) attributeValues.get( "name" );
+		this.columnList = (String) attributeValues.get( "columnList" );
+		this.unique = (boolean) attributeValues.get( "unique" );
+		this.options = (String) attributeValues.get( "options" );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/InheritanceJpaAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/InheritanceJpaAnnotation.java
@@ -7,15 +7,11 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
-import org.hibernate.boot.models.JpaAnnotations;
 import org.hibernate.models.spi.SourceModelBuildingContext;
 
-import org.jboss.jandex.AnnotationInstance;
-
 import jakarta.persistence.Inheritance;
-
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJandexValue;
 
 @SuppressWarnings({ "ClassExplicitlyAnnotation", "unused" })
 @jakarta.annotation.Generated("org.hibernate.orm.build.annotations.ClassGeneratorProcessor")
@@ -39,8 +35,8 @@ public class InheritanceJpaAnnotation implements Inheritance {
 	/**
 	 * Used in creating annotation instances from Jandex variant
 	 */
-	public InheritanceJpaAnnotation(AnnotationInstance annotation, SourceModelBuildingContext modelContext) {
-		this.strategy = extractJandexValue( annotation, JpaAnnotations.INHERITANCE, "strategy", modelContext );
+	public InheritanceJpaAnnotation(Map<String, Object> attributeValues, SourceModelBuildingContext modelContext) {
+		this.strategy = (jakarta.persistence.InheritanceType) attributeValues.get( "strategy" );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/InstantiatorAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/InstantiatorAnnotation.java
@@ -7,14 +7,10 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
 import org.hibernate.annotations.Instantiator;
-import org.hibernate.boot.models.HibernateAnnotations;
 import org.hibernate.models.spi.SourceModelBuildingContext;
-
-import org.jboss.jandex.AnnotationInstance;
-
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJandexValue;
 
 @SuppressWarnings({ "ClassExplicitlyAnnotation", "unused" })
 @jakarta.annotation.Generated("org.hibernate.orm.build.annotations.ClassGeneratorProcessor")
@@ -37,8 +33,8 @@ public class InstantiatorAnnotation implements Instantiator {
 	/**
 	 * Used in creating annotation instances from Jandex variant
 	 */
-	public InstantiatorAnnotation(AnnotationInstance annotation, SourceModelBuildingContext modelContext) {
-		this.value = extractJandexValue( annotation, HibernateAnnotations.INSTANTIATOR, "value", modelContext );
+	public InstantiatorAnnotation(Map<String, Object> attributeValues, SourceModelBuildingContext modelContext) {
+		this.value = (String[]) attributeValues.get( "value" );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/JavaTypeAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/JavaTypeAnnotation.java
@@ -7,14 +7,10 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
 import org.hibernate.annotations.JavaType;
-import org.hibernate.boot.models.HibernateAnnotations;
 import org.hibernate.models.spi.SourceModelBuildingContext;
-
-import org.jboss.jandex.AnnotationInstance;
-
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJandexValue;
 
 @SuppressWarnings({ "ClassExplicitlyAnnotation", "unused" })
 @jakarta.annotation.Generated("org.hibernate.orm.build.annotations.ClassGeneratorProcessor")
@@ -37,8 +33,8 @@ public class JavaTypeAnnotation implements JavaType {
 	/**
 	 * Used in creating annotation instances from Jandex variant
 	 */
-	public JavaTypeAnnotation(AnnotationInstance annotation, SourceModelBuildingContext modelContext) {
-		this.value = extractJandexValue( annotation, HibernateAnnotations.JAVA_TYPE, "value", modelContext );
+	public JavaTypeAnnotation(Map<String, Object> attributeValues, SourceModelBuildingContext modelContext) {
+		this.value = (Class<? extends org.hibernate.type.descriptor.java.BasicJavaType<?>>) attributeValues.get( "value" );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/JavaTypeRegistrationAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/JavaTypeRegistrationAnnotation.java
@@ -7,14 +7,10 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
 import org.hibernate.annotations.JavaTypeRegistration;
-import org.hibernate.boot.models.HibernateAnnotations;
 import org.hibernate.models.spi.SourceModelBuildingContext;
-
-import org.jboss.jandex.AnnotationInstance;
-
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJandexValue;
 
 @SuppressWarnings({ "ClassExplicitlyAnnotation", "unused" })
 @jakarta.annotation.Generated("org.hibernate.orm.build.annotations.ClassGeneratorProcessor")
@@ -39,19 +35,12 @@ public class JavaTypeRegistrationAnnotation implements JavaTypeRegistration {
 	/**
 	 * Used in creating annotation instances from Jandex variant
 	 */
-	public JavaTypeRegistrationAnnotation(AnnotationInstance annotation, SourceModelBuildingContext modelContext) {
-		this.javaType = extractJandexValue(
-				annotation,
-				HibernateAnnotations.JAVA_TYPE_REGISTRATION,
-				"javaType",
-				modelContext
-		);
-		this.descriptorClass = extractJandexValue(
-				annotation,
-				HibernateAnnotations.JAVA_TYPE_REGISTRATION,
-				"descriptorClass",
-				modelContext
-		);
+	public JavaTypeRegistrationAnnotation(
+			Map<String, Object> attributeValues,
+			SourceModelBuildingContext modelContext) {
+		this.javaType = (Class<?>) attributeValues.get( "javaType" );
+		this.descriptorClass = (Class<? extends org.hibernate.type.descriptor.java.BasicJavaType<?>>) attributeValues
+				.get( "descriptorClass" );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/JavaTypeRegistrationsAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/JavaTypeRegistrationsAnnotation.java
@@ -7,6 +7,7 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
 import org.hibernate.annotations.JavaTypeRegistration;
 import org.hibernate.annotations.JavaTypeRegistrations;
@@ -14,9 +15,6 @@ import org.hibernate.boot.models.HibernateAnnotations;
 import org.hibernate.boot.models.annotations.spi.RepeatableContainer;
 import org.hibernate.models.spi.SourceModelBuildingContext;
 
-import org.jboss.jandex.AnnotationInstance;
-
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJandexValue;
 import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJdkValue;
 
 @SuppressWarnings({ "ClassExplicitlyAnnotation", "unused" })
@@ -41,13 +39,10 @@ public class JavaTypeRegistrationsAnnotation
 	/**
 	 * Used in creating annotation instances from Jandex variant
 	 */
-	public JavaTypeRegistrationsAnnotation(AnnotationInstance annotation, SourceModelBuildingContext modelContext) {
-		this.value = extractJandexValue(
-				annotation,
-				HibernateAnnotations.JAVA_TYPE_REGISTRATIONS,
-				"value",
-				modelContext
-		);
+	public JavaTypeRegistrationsAnnotation(
+			Map<String, Object> attributeValues,
+			SourceModelBuildingContext modelContext) {
+		this.value = (JavaTypeRegistration[]) attributeValues.get( "value" );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/JdbcTypeAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/JdbcTypeAnnotation.java
@@ -7,14 +7,10 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
 import org.hibernate.annotations.JdbcType;
-import org.hibernate.boot.models.HibernateAnnotations;
 import org.hibernate.models.spi.SourceModelBuildingContext;
-
-import org.jboss.jandex.AnnotationInstance;
-
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJandexValue;
 
 @SuppressWarnings({ "ClassExplicitlyAnnotation", "unused" })
 @jakarta.annotation.Generated("org.hibernate.orm.build.annotations.ClassGeneratorProcessor")
@@ -37,8 +33,8 @@ public class JdbcTypeAnnotation implements JdbcType {
 	/**
 	 * Used in creating annotation instances from Jandex variant
 	 */
-	public JdbcTypeAnnotation(AnnotationInstance annotation, SourceModelBuildingContext modelContext) {
-		this.value = extractJandexValue( annotation, HibernateAnnotations.JDBC_TYPE, "value", modelContext );
+	public JdbcTypeAnnotation(Map<String, Object> attributeValues, SourceModelBuildingContext modelContext) {
+		this.value = (Class<? extends org.hibernate.type.descriptor.jdbc.JdbcType>) attributeValues.get( "value" );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/JdbcTypeCodeAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/JdbcTypeCodeAnnotation.java
@@ -7,14 +7,10 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
 import org.hibernate.annotations.JdbcTypeCode;
-import org.hibernate.boot.models.HibernateAnnotations;
 import org.hibernate.models.spi.SourceModelBuildingContext;
-
-import org.jboss.jandex.AnnotationInstance;
-
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJandexValue;
 
 @SuppressWarnings({ "ClassExplicitlyAnnotation", "unused" })
 @jakarta.annotation.Generated("org.hibernate.orm.build.annotations.ClassGeneratorProcessor")
@@ -37,8 +33,8 @@ public class JdbcTypeCodeAnnotation implements JdbcTypeCode {
 	/**
 	 * Used in creating annotation instances from Jandex variant
 	 */
-	public JdbcTypeCodeAnnotation(AnnotationInstance annotation, SourceModelBuildingContext modelContext) {
-		this.value = extractJandexValue( annotation, HibernateAnnotations.JDBC_TYPE_CODE, "value", modelContext );
+	public JdbcTypeCodeAnnotation(Map<String, Object> attributeValues, SourceModelBuildingContext modelContext) {
+		this.value = (int) attributeValues.get( "value" );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/JdbcTypeRegistrationAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/JdbcTypeRegistrationAnnotation.java
@@ -7,14 +7,10 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
 import org.hibernate.annotations.JdbcTypeRegistration;
-import org.hibernate.boot.models.HibernateAnnotations;
 import org.hibernate.models.spi.SourceModelBuildingContext;
-
-import org.jboss.jandex.AnnotationInstance;
-
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJandexValue;
 
 @SuppressWarnings({ "ClassExplicitlyAnnotation", "unused" })
 @jakarta.annotation.Generated("org.hibernate.orm.build.annotations.ClassGeneratorProcessor")
@@ -40,19 +36,11 @@ public class JdbcTypeRegistrationAnnotation implements JdbcTypeRegistration {
 	/**
 	 * Used in creating annotation instances from Jandex variant
 	 */
-	public JdbcTypeRegistrationAnnotation(AnnotationInstance annotation, SourceModelBuildingContext modelContext) {
-		this.value = extractJandexValue(
-				annotation,
-				HibernateAnnotations.JDBC_TYPE_REGISTRATION,
-				"value",
-				modelContext
-		);
-		this.registrationCode = extractJandexValue(
-				annotation,
-				HibernateAnnotations.JDBC_TYPE_REGISTRATION,
-				"registrationCode",
-				modelContext
-		);
+	public JdbcTypeRegistrationAnnotation(
+			Map<String, Object> attributeValues,
+			SourceModelBuildingContext modelContext) {
+		this.value = (Class<? extends org.hibernate.type.descriptor.jdbc.JdbcType>) attributeValues.get( "value" );
+		this.registrationCode = (int) attributeValues.get( "registrationCode" );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/JdbcTypeRegistrationsAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/JdbcTypeRegistrationsAnnotation.java
@@ -7,15 +7,13 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
 import org.hibernate.annotations.JdbcTypeRegistrations;
 import org.hibernate.boot.models.HibernateAnnotations;
 import org.hibernate.boot.models.annotations.spi.RepeatableContainer;
 import org.hibernate.models.spi.SourceModelBuildingContext;
 
-import org.jboss.jandex.AnnotationInstance;
-
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJandexValue;
 import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJdkValue;
 
 @SuppressWarnings({ "ClassExplicitlyAnnotation", "unused" })
@@ -40,13 +38,10 @@ public class JdbcTypeRegistrationsAnnotation
 	/**
 	 * Used in creating annotation instances from Jandex variant
 	 */
-	public JdbcTypeRegistrationsAnnotation(AnnotationInstance annotation, SourceModelBuildingContext modelContext) {
-		this.value = extractJandexValue(
-				annotation,
-				HibernateAnnotations.JDBC_TYPE_REGISTRATIONS,
-				"value",
-				modelContext
-		);
+	public JdbcTypeRegistrationsAnnotation(
+			Map<String, Object> attributeValues,
+			SourceModelBuildingContext modelContext) {
+		this.value = (org.hibernate.annotations.JdbcTypeRegistration[]) attributeValues.get( "value" );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/JoinColumnJpaAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/JoinColumnJpaAnnotation.java
@@ -7,6 +7,7 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
 import org.hibernate.boot.jaxb.mapping.spi.JaxbColumnImpl;
 import org.hibernate.boot.jaxb.mapping.spi.JaxbJoinColumnImpl;
@@ -23,7 +24,6 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.MapKeyJoinColumn;
 import jakarta.persistence.PrimaryKeyJoinColumn;
 
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJandexValue;
 import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJdkValue;
 
 @SuppressWarnings({ "ClassExplicitlyAnnotation", "unused" })
@@ -81,29 +81,19 @@ public class JoinColumnJpaAnnotation implements JoinColumn {
 	/**
 	 * Used in creating annotation instances from Jandex variant
 	 */
-	public JoinColumnJpaAnnotation(AnnotationInstance annotation, SourceModelBuildingContext modelContext) {
-		this.name = extractJandexValue( annotation, JpaAnnotations.JOIN_COLUMN, "name", modelContext );
-		this.referencedColumnName = extractJandexValue(
-				annotation,
-				JpaAnnotations.JOIN_COLUMN,
-				"referencedColumnName",
-				modelContext
-		);
-		this.unique = extractJandexValue( annotation, JpaAnnotations.JOIN_COLUMN, "unique", modelContext );
-		this.nullable = extractJandexValue( annotation, JpaAnnotations.JOIN_COLUMN, "nullable", modelContext );
-		this.insertable = extractJandexValue( annotation, JpaAnnotations.JOIN_COLUMN, "insertable", modelContext );
-		this.updatable = extractJandexValue( annotation, JpaAnnotations.JOIN_COLUMN, "updatable", modelContext );
-		this.columnDefinition = extractJandexValue(
-				annotation,
-				JpaAnnotations.JOIN_COLUMN,
-				"columnDefinition",
-				modelContext
-		);
-		this.options = extractJandexValue( annotation, JpaAnnotations.JOIN_COLUMN, "options", modelContext );
-		this.table = extractJandexValue( annotation, JpaAnnotations.JOIN_COLUMN, "table", modelContext );
-		this.foreignKey = extractJandexValue( annotation, JpaAnnotations.JOIN_COLUMN, "foreignKey", modelContext );
-		this.check = extractJandexValue( annotation, JpaAnnotations.JOIN_COLUMN, "check", modelContext );
-		this.comment = extractJandexValue( annotation, JpaAnnotations.JOIN_COLUMN, "comment", modelContext );
+	public JoinColumnJpaAnnotation(Map<String, Object> attributeValues, SourceModelBuildingContext modelContext) {
+		this.name = (String) attributeValues.get( "name" );
+		this.referencedColumnName = (String) attributeValues.get( "referencedColumnName" );
+		this.unique = (boolean) attributeValues.get( "unique" );
+		this.nullable = (boolean) attributeValues.get( "nullable" );
+		this.insertable = (boolean) attributeValues.get( "insertable" );
+		this.updatable = (boolean) attributeValues.get( "updatable" );
+		this.columnDefinition = (String) attributeValues.get( "columnDefinition" );
+		this.options = (String) attributeValues.get( "options" );
+		this.table = (String) attributeValues.get( "table" );
+		this.foreignKey = (jakarta.persistence.ForeignKey) attributeValues.get( "foreignKey" );
+		this.check = (jakarta.persistence.CheckConstraint[]) attributeValues.get( "check" );
+		this.comment = (String) attributeValues.get( "comment" );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/JoinColumnOrFormulaAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/JoinColumnOrFormulaAnnotation.java
@@ -7,16 +7,14 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
 import org.hibernate.annotations.JoinColumnOrFormula;
 import org.hibernate.boot.models.HibernateAnnotations;
 import org.hibernate.boot.models.JpaAnnotations;
 import org.hibernate.models.spi.SourceModelBuildingContext;
 
-import org.jboss.jandex.AnnotationInstance;
-
 import static org.hibernate.boot.models.HibernateAnnotations.JOIN_COLUMN_OR_FORMULA;
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJandexValue;
 import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJdkValue;
 
 @SuppressWarnings({ "ClassExplicitlyAnnotation", "unused" })
@@ -44,9 +42,9 @@ public class JoinColumnOrFormulaAnnotation implements JoinColumnOrFormula {
 	/**
 	 * Used in creating annotation instances from Jandex variant
 	 */
-	public JoinColumnOrFormulaAnnotation(AnnotationInstance annotation, SourceModelBuildingContext modelContext) {
-		this.formula = extractJandexValue( annotation, JOIN_COLUMN_OR_FORMULA, "formula", modelContext );
-		this.column = extractJandexValue( annotation, JOIN_COLUMN_OR_FORMULA, "column", modelContext );
+	public JoinColumnOrFormulaAnnotation(Map<String, Object> attributeValues, SourceModelBuildingContext modelContext) {
+		this.formula = (org.hibernate.annotations.JoinFormula) attributeValues.get( "formula" );
+		this.column = (jakarta.persistence.JoinColumn) attributeValues.get( "column" );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/JoinColumnsJpaAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/JoinColumnsJpaAnnotation.java
@@ -7,6 +7,7 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
 import org.hibernate.boot.models.JpaAnnotations;
 import org.hibernate.boot.models.annotations.spi.RepeatableContainer;
@@ -17,7 +18,6 @@ import org.jboss.jandex.AnnotationInstance;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.JoinColumns;
 
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJandexValue;
 import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJdkValue;
 
 @SuppressWarnings({ "ClassExplicitlyAnnotation", "unused" })
@@ -44,9 +44,9 @@ public class JoinColumnsJpaAnnotation implements JoinColumns, RepeatableContaine
 	/**
 	 * Used in creating annotation instances from Jandex variant
 	 */
-	public JoinColumnsJpaAnnotation(AnnotationInstance annotation, SourceModelBuildingContext modelContext) {
-		this.value = extractJandexValue( annotation, JpaAnnotations.JOIN_COLUMNS, "value", modelContext );
-		this.foreignKey = extractJandexValue( annotation, JpaAnnotations.JOIN_COLUMNS, "foreignKey", modelContext );
+	public JoinColumnsJpaAnnotation(Map<String, Object> attributeValues, SourceModelBuildingContext modelContext) {
+		this.value = (JoinColumn[]) attributeValues.get( "value" );
+		this.foreignKey = (jakarta.persistence.ForeignKey) attributeValues.get( "foreignKey" );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/JoinColumnsOrFormulasAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/JoinColumnsOrFormulasAnnotation.java
@@ -7,6 +7,7 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
 import org.hibernate.annotations.JoinColumnOrFormula;
 import org.hibernate.annotations.JoinColumnsOrFormulas;
@@ -14,9 +15,6 @@ import org.hibernate.boot.models.HibernateAnnotations;
 import org.hibernate.boot.models.annotations.spi.RepeatableContainer;
 import org.hibernate.models.spi.SourceModelBuildingContext;
 
-import org.jboss.jandex.AnnotationInstance;
-
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJandexValue;
 import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJdkValue;
 
 @SuppressWarnings({ "ClassExplicitlyAnnotation", "unused" })
@@ -46,13 +44,10 @@ public class JoinColumnsOrFormulasAnnotation
 	/**
 	 * Used in creating annotation instances from Jandex variant
 	 */
-	public JoinColumnsOrFormulasAnnotation(AnnotationInstance annotation, SourceModelBuildingContext modelContext) {
-		this.value = extractJandexValue(
-				annotation,
-				HibernateAnnotations.JOIN_COLUMNS_OR_FORMULAS,
-				"value",
-				modelContext
-		);
+	public JoinColumnsOrFormulasAnnotation(
+			Map<String, Object> attributeValues,
+			SourceModelBuildingContext modelContext) {
+		this.value = (JoinColumnOrFormula[]) attributeValues.get( "value" );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/JoinFormulaAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/JoinFormulaAnnotation.java
@@ -7,14 +7,10 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
 import org.hibernate.annotations.JoinFormula;
-import org.hibernate.boot.models.HibernateAnnotations;
 import org.hibernate.models.spi.SourceModelBuildingContext;
-
-import org.jboss.jandex.AnnotationInstance;
-
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJandexValue;
 
 @SuppressWarnings({ "ClassExplicitlyAnnotation", "unused" })
 @jakarta.annotation.Generated("org.hibernate.orm.build.annotations.ClassGeneratorProcessor")
@@ -40,14 +36,9 @@ public class JoinFormulaAnnotation implements JoinFormula {
 	/**
 	 * Used in creating annotation instances from Jandex variant
 	 */
-	public JoinFormulaAnnotation(AnnotationInstance annotation, SourceModelBuildingContext modelContext) {
-		this.value = extractJandexValue( annotation, HibernateAnnotations.JOIN_FORMULA, "value", modelContext );
-		this.referencedColumnName = extractJandexValue(
-				annotation,
-				HibernateAnnotations.JOIN_FORMULA,
-				"referencedColumnName",
-				modelContext
-		);
+	public JoinFormulaAnnotation(Map<String, Object> attributeValues, SourceModelBuildingContext modelContext) {
+		this.value = (String) attributeValues.get( "value" );
+		this.referencedColumnName = (String) attributeValues.get( "referencedColumnName" );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/JoinTableJpaAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/JoinTableJpaAnnotation.java
@@ -8,6 +8,7 @@ package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
 import java.util.List;
+import java.util.Map;
 
 import org.hibernate.boot.jaxb.mapping.spi.JaxbJoinColumnImpl;
 import org.hibernate.boot.jaxb.mapping.spi.JaxbJoinTableImpl;
@@ -19,11 +20,8 @@ import org.hibernate.boot.models.xml.spi.XmlDocumentContext;
 import org.hibernate.internal.util.collections.CollectionHelper;
 import org.hibernate.models.spi.SourceModelBuildingContext;
 
-import org.jboss.jandex.AnnotationInstance;
-
 import jakarta.persistence.JoinTable;
 
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJandexValue;
 import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJdkValue;
 import static org.hibernate.boot.models.xml.internal.XmlAnnotationHelper.applyCatalog;
 import static org.hibernate.boot.models.xml.internal.XmlAnnotationHelper.applyOptionalString;
@@ -102,34 +100,19 @@ public class JoinTableJpaAnnotation implements JoinTable, CommonTableDetails {
 	/**
 	 * Used in creating annotation instances from Jandex variant
 	 */
-	public JoinTableJpaAnnotation(AnnotationInstance annotation, SourceModelBuildingContext modelContext) {
-		this.name = extractJandexValue( annotation, JpaAnnotations.JOIN_TABLE, "name", modelContext );
-		this.catalog = extractJandexValue( annotation, JpaAnnotations.JOIN_TABLE, "catalog", modelContext );
-		this.schema = extractJandexValue( annotation, JpaAnnotations.JOIN_TABLE, "schema", modelContext );
-		this.joinColumns = extractJandexValue( annotation, JpaAnnotations.JOIN_TABLE, "joinColumns", modelContext );
-		this.inverseJoinColumns = extractJandexValue(
-				annotation,
-				JpaAnnotations.JOIN_TABLE,
-				"inverseJoinColumns",
-				modelContext
-		);
-		this.foreignKey = extractJandexValue( annotation, JpaAnnotations.JOIN_TABLE, "foreignKey", modelContext );
-		this.inverseForeignKey = extractJandexValue(
-				annotation,
-				JpaAnnotations.JOIN_TABLE,
-				"inverseForeignKey",
-				modelContext
-		);
-		this.uniqueConstraints = extractJandexValue(
-				annotation,
-				JpaAnnotations.JOIN_TABLE,
-				"uniqueConstraints",
-				modelContext
-		);
-		this.indexes = extractJandexValue( annotation, JpaAnnotations.JOIN_TABLE, "indexes", modelContext );
-		this.check = extractJandexValue( annotation, JpaAnnotations.JOIN_TABLE, "check", modelContext );
-		this.comment = extractJandexValue( annotation, JpaAnnotations.JOIN_TABLE, "comment", modelContext );
-		this.options = extractJandexValue( annotation, JpaAnnotations.JOIN_TABLE, "options", modelContext );
+	public JoinTableJpaAnnotation(Map<String, Object> attributeValues, SourceModelBuildingContext modelContext) {
+		this.name = (String) attributeValues.get( "name" );
+		this.catalog = (String) attributeValues.get( "catalog" );
+		this.schema = (String) attributeValues.get( "schema" );
+		this.joinColumns = (jakarta.persistence.JoinColumn[]) attributeValues.get( "joinColumns" );
+		this.inverseJoinColumns = (jakarta.persistence.JoinColumn[]) attributeValues.get( "inverseJoinColumns" );
+		this.foreignKey = (jakarta.persistence.ForeignKey) attributeValues.get( "foreignKey" );
+		this.inverseForeignKey = (jakarta.persistence.ForeignKey) attributeValues.get( "inverseForeignKey" );
+		this.uniqueConstraints = (jakarta.persistence.UniqueConstraint[]) attributeValues.get( "uniqueConstraints" );
+		this.indexes = (jakarta.persistence.Index[]) attributeValues.get( "indexes" );
+		this.check = (jakarta.persistence.CheckConstraint[]) attributeValues.get( "check" );
+		this.comment = (String) attributeValues.get( "comment" );
+		this.options = (String) attributeValues.get( "options" );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/LazyGroupAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/LazyGroupAnnotation.java
@@ -7,14 +7,10 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
 import org.hibernate.annotations.LazyGroup;
-import org.hibernate.boot.models.HibernateAnnotations;
 import org.hibernate.models.spi.SourceModelBuildingContext;
-
-import org.jboss.jandex.AnnotationInstance;
-
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJandexValue;
 
 @SuppressWarnings({ "ClassExplicitlyAnnotation", "unused" })
 @jakarta.annotation.Generated("org.hibernate.orm.build.annotations.ClassGeneratorProcessor")
@@ -37,8 +33,8 @@ public class LazyGroupAnnotation implements LazyGroup {
 	/**
 	 * Used in creating annotation instances from Jandex variant
 	 */
-	public LazyGroupAnnotation(AnnotationInstance annotation, SourceModelBuildingContext modelContext) {
-		this.value = extractJandexValue( annotation, HibernateAnnotations.LAZY_GROUP, "value", modelContext );
+	public LazyGroupAnnotation(Map<String, Object> attributeValues, SourceModelBuildingContext modelContext) {
+		this.value = (String) attributeValues.get( "value" );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/ListIndexBaseAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/ListIndexBaseAnnotation.java
@@ -7,14 +7,10 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
 import org.hibernate.annotations.ListIndexBase;
-import org.hibernate.boot.models.HibernateAnnotations;
 import org.hibernate.models.spi.SourceModelBuildingContext;
-
-import org.jboss.jandex.AnnotationInstance;
-
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJandexValue;
 
 @SuppressWarnings({ "ClassExplicitlyAnnotation", "unused" })
 @jakarta.annotation.Generated("org.hibernate.orm.build.annotations.ClassGeneratorProcessor")
@@ -38,8 +34,8 @@ public class ListIndexBaseAnnotation implements ListIndexBase {
 	/**
 	 * Used in creating annotation instances from Jandex variant
 	 */
-	public ListIndexBaseAnnotation(AnnotationInstance annotation, SourceModelBuildingContext modelContext) {
-		this.value = extractJandexValue( annotation, HibernateAnnotations.LIST_INDEX_BASE, "value", modelContext );
+	public ListIndexBaseAnnotation(Map<String, Object> attributeValues, SourceModelBuildingContext modelContext) {
+		this.value = (int) attributeValues.get( "value" );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/ListIndexJavaTypeAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/ListIndexJavaTypeAnnotation.java
@@ -7,14 +7,10 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
 import org.hibernate.annotations.ListIndexJavaType;
-import org.hibernate.boot.models.HibernateAnnotations;
 import org.hibernate.models.spi.SourceModelBuildingContext;
-
-import org.jboss.jandex.AnnotationInstance;
-
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJandexValue;
 
 @SuppressWarnings({ "ClassExplicitlyAnnotation", "unused" })
 @jakarta.annotation.Generated("org.hibernate.orm.build.annotations.ClassGeneratorProcessor")
@@ -37,8 +33,8 @@ public class ListIndexJavaTypeAnnotation implements ListIndexJavaType {
 	/**
 	 * Used in creating annotation instances from Jandex variant
 	 */
-	public ListIndexJavaTypeAnnotation(AnnotationInstance annotation, SourceModelBuildingContext modelContext) {
-		this.value = extractJandexValue( annotation, HibernateAnnotations.LIST_INDEX_JAVA_TYPE, "value", modelContext );
+	public ListIndexJavaTypeAnnotation(Map<String, Object> attributeValues, SourceModelBuildingContext modelContext) {
+		this.value = (Class<? extends org.hibernate.type.descriptor.java.BasicJavaType<?>>) attributeValues.get( "value" );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/ListIndexJdbcTypeAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/ListIndexJdbcTypeAnnotation.java
@@ -7,14 +7,10 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
 import org.hibernate.annotations.ListIndexJdbcType;
-import org.hibernate.boot.models.HibernateAnnotations;
 import org.hibernate.models.spi.SourceModelBuildingContext;
-
-import org.jboss.jandex.AnnotationInstance;
-
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJandexValue;
 
 @SuppressWarnings({ "ClassExplicitlyAnnotation", "unused" })
 @jakarta.annotation.Generated("org.hibernate.orm.build.annotations.ClassGeneratorProcessor")
@@ -37,8 +33,8 @@ public class ListIndexJdbcTypeAnnotation implements ListIndexJdbcType {
 	/**
 	 * Used in creating annotation instances from Jandex variant
 	 */
-	public ListIndexJdbcTypeAnnotation(AnnotationInstance annotation, SourceModelBuildingContext modelContext) {
-		this.value = extractJandexValue( annotation, HibernateAnnotations.LIST_INDEX_JDBC_TYPE, "value", modelContext );
+	public ListIndexJdbcTypeAnnotation(Map<String, Object> attributeValues, SourceModelBuildingContext modelContext) {
+		this.value = (Class<? extends org.hibernate.type.descriptor.jdbc.JdbcType>) attributeValues.get( "value" );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/ListIndexJdbcTypeCodeAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/ListIndexJdbcTypeCodeAnnotation.java
@@ -7,14 +7,10 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
 import org.hibernate.annotations.ListIndexJdbcTypeCode;
-import org.hibernate.boot.models.HibernateAnnotations;
 import org.hibernate.models.spi.SourceModelBuildingContext;
-
-import org.jboss.jandex.AnnotationInstance;
-
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJandexValue;
 
 @SuppressWarnings({ "ClassExplicitlyAnnotation", "unused" })
 @jakarta.annotation.Generated("org.hibernate.orm.build.annotations.ClassGeneratorProcessor")
@@ -37,13 +33,10 @@ public class ListIndexJdbcTypeCodeAnnotation implements ListIndexJdbcTypeCode {
 	/**
 	 * Used in creating annotation instances from Jandex variant
 	 */
-	public ListIndexJdbcTypeCodeAnnotation(AnnotationInstance annotation, SourceModelBuildingContext modelContext) {
-		this.value = extractJandexValue(
-				annotation,
-				HibernateAnnotations.LIST_INDEX_JDBC_TYPE_CODE,
-				"value",
-				modelContext
-		);
+	public ListIndexJdbcTypeCodeAnnotation(
+			Map<String, Object> attributeValues,
+			SourceModelBuildingContext modelContext) {
+		this.value = (int) attributeValues.get( "value" );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/LobJpaAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/LobJpaAnnotation.java
@@ -7,10 +7,9 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
 import org.hibernate.models.spi.SourceModelBuildingContext;
-
-import org.jboss.jandex.AnnotationInstance;
 
 import jakarta.persistence.Lob;
 
@@ -33,7 +32,7 @@ public class LobJpaAnnotation implements Lob {
 	/**
 	 * Used in creating annotation instances from Jandex variant
 	 */
-	public LobJpaAnnotation(AnnotationInstance annotation, SourceModelBuildingContext modelContext) {
+	public LobJpaAnnotation(Map<String, Object> attributeValues, SourceModelBuildingContext modelContext) {
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/ManyToAnyAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/ManyToAnyAnnotation.java
@@ -7,14 +7,10 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
 import org.hibernate.annotations.ManyToAny;
-import org.hibernate.boot.models.HibernateAnnotations;
 import org.hibernate.models.spi.SourceModelBuildingContext;
-
-import org.jboss.jandex.AnnotationInstance;
-
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJandexValue;
 
 @SuppressWarnings({ "ClassExplicitlyAnnotation", "unused" })
 @jakarta.annotation.Generated("org.hibernate.orm.build.annotations.ClassGeneratorProcessor")
@@ -38,8 +34,8 @@ public class ManyToAnyAnnotation implements ManyToAny {
 	/**
 	 * Used in creating annotation instances from Jandex variant
 	 */
-	public ManyToAnyAnnotation(AnnotationInstance annotation, SourceModelBuildingContext modelContext) {
-		this.fetch = extractJandexValue( annotation, HibernateAnnotations.MANY_TO_ANY, "fetch", modelContext );
+	public ManyToAnyAnnotation(Map<String, Object> attributeValues, SourceModelBuildingContext modelContext) {
+		this.fetch = (jakarta.persistence.FetchType) attributeValues.get( "fetch" );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/ManyToManyJpaAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/ManyToManyJpaAnnotation.java
@@ -7,16 +7,12 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
-import org.hibernate.boot.models.JpaAnnotations;
 import org.hibernate.boot.models.annotations.spi.AttributeMarker;
 import org.hibernate.models.spi.SourceModelBuildingContext;
 
-import org.jboss.jandex.AnnotationInstance;
-
 import jakarta.persistence.ManyToMany;
-
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJandexValue;
 
 @SuppressWarnings({ "ClassExplicitlyAnnotation", "unused" })
 @jakarta.annotation.Generated("org.hibernate.orm.build.annotations.ClassGeneratorProcessor")
@@ -52,11 +48,11 @@ public class ManyToManyJpaAnnotation implements ManyToMany,
 	/**
 	 * Used in creating annotation instances from Jandex variant
 	 */
-	public ManyToManyJpaAnnotation(AnnotationInstance annotation, SourceModelBuildingContext modelContext) {
-		this.targetEntity = extractJandexValue( annotation, JpaAnnotations.MANY_TO_MANY, "targetEntity", modelContext );
-		this.cascade = extractJandexValue( annotation, JpaAnnotations.MANY_TO_MANY, "cascade", modelContext );
-		this.fetch = extractJandexValue( annotation, JpaAnnotations.MANY_TO_MANY, "fetch", modelContext );
-		this.mappedBy = extractJandexValue( annotation, JpaAnnotations.MANY_TO_MANY, "mappedBy", modelContext );
+	public ManyToManyJpaAnnotation(Map<String, Object> attributeValues, SourceModelBuildingContext modelContext) {
+		this.targetEntity = (Class<?>) attributeValues.get( "targetEntity" );
+		this.cascade = (jakarta.persistence.CascadeType[]) attributeValues.get( "cascade" );
+		this.fetch = (jakarta.persistence.FetchType) attributeValues.get( "fetch" );
+		this.mappedBy = (String) attributeValues.get( "mappedBy" );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/ManyToOneJpaAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/ManyToOneJpaAnnotation.java
@@ -7,16 +7,12 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
-import org.hibernate.boot.models.JpaAnnotations;
 import org.hibernate.boot.models.annotations.spi.AttributeMarker;
 import org.hibernate.models.spi.SourceModelBuildingContext;
 
-import org.jboss.jandex.AnnotationInstance;
-
 import jakarta.persistence.ManyToOne;
-
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJandexValue;
 
 @SuppressWarnings({ "ClassExplicitlyAnnotation", "unused" })
 @jakarta.annotation.Generated("org.hibernate.orm.build.annotations.ClassGeneratorProcessor")
@@ -53,11 +49,11 @@ public class ManyToOneJpaAnnotation implements ManyToOne,
 	/**
 	 * Used in creating annotation instances from Jandex variant
 	 */
-	public ManyToOneJpaAnnotation(AnnotationInstance annotation, SourceModelBuildingContext modelContext) {
-		this.targetEntity = extractJandexValue( annotation, JpaAnnotations.MANY_TO_ONE, "targetEntity", modelContext );
-		this.cascade = extractJandexValue( annotation, JpaAnnotations.MANY_TO_ONE, "cascade", modelContext );
-		this.fetch = extractJandexValue( annotation, JpaAnnotations.MANY_TO_ONE, "fetch", modelContext );
-		this.optional = extractJandexValue( annotation, JpaAnnotations.MANY_TO_ONE, "optional", modelContext );
+	public ManyToOneJpaAnnotation(Map<String, Object> attributeValues, SourceModelBuildingContext modelContext) {
+		this.targetEntity = (Class<?>) attributeValues.get( "targetEntity" );
+		this.cascade = (jakarta.persistence.CascadeType[]) attributeValues.get( "cascade" );
+		this.fetch = (jakarta.persistence.FetchType) attributeValues.get( "fetch" );
+		this.optional = (boolean) attributeValues.get( "optional" );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/MapKeyClassJpaAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/MapKeyClassJpaAnnotation.java
@@ -7,15 +7,11 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
-import org.hibernate.boot.models.JpaAnnotations;
 import org.hibernate.models.spi.SourceModelBuildingContext;
 
-import org.jboss.jandex.AnnotationInstance;
-
 import jakarta.persistence.MapKeyClass;
-
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJandexValue;
 
 @SuppressWarnings({ "ClassExplicitlyAnnotation", "unused" })
 @jakarta.annotation.Generated("org.hibernate.orm.build.annotations.ClassGeneratorProcessor")
@@ -38,8 +34,8 @@ public class MapKeyClassJpaAnnotation implements MapKeyClass {
 	/**
 	 * Used in creating annotation instances from Jandex variant
 	 */
-	public MapKeyClassJpaAnnotation(AnnotationInstance annotation, SourceModelBuildingContext modelContext) {
-		this.value = extractJandexValue( annotation, JpaAnnotations.MAP_KEY_CLASS, "value", modelContext );
+	public MapKeyClassJpaAnnotation(Map<String, Object> attributeValues, SourceModelBuildingContext modelContext) {
+		this.value = (Class<?>) attributeValues.get( "value" );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/MapKeyColumnJpaAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/MapKeyColumnJpaAnnotation.java
@@ -7,20 +7,16 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
 import org.hibernate.boot.jaxb.mapping.spi.JaxbMapKeyColumnImpl;
-import org.hibernate.boot.models.JpaAnnotations;
 import org.hibernate.boot.models.annotations.spi.ColumnDetails;
 import org.hibernate.boot.models.xml.spi.XmlDocumentContext;
 import org.hibernate.internal.util.StringHelper;
 import org.hibernate.models.spi.SourceModelBuildingContext;
 
-import org.jboss.jandex.AnnotationInstance;
-
 import jakarta.persistence.Column;
 import jakarta.persistence.MapKeyColumn;
-
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJandexValue;
 
 @SuppressWarnings({ "ClassExplicitlyAnnotation", "unused" })
 @jakarta.annotation.Generated("org.hibernate.orm.build.annotations.ClassGeneratorProcessor")
@@ -80,23 +76,18 @@ public class MapKeyColumnJpaAnnotation implements MapKeyColumn,
 	/**
 	 * Used in creating annotation instances from Jandex variant
 	 */
-	public MapKeyColumnJpaAnnotation(AnnotationInstance annotation, SourceModelBuildingContext modelContext) {
-		this.name = extractJandexValue( annotation, JpaAnnotations.MAP_KEY_COLUMN, "name", modelContext );
-		this.unique = extractJandexValue( annotation, JpaAnnotations.MAP_KEY_COLUMN, "unique", modelContext );
-		this.nullable = extractJandexValue( annotation, JpaAnnotations.MAP_KEY_COLUMN, "nullable", modelContext );
-		this.insertable = extractJandexValue( annotation, JpaAnnotations.MAP_KEY_COLUMN, "insertable", modelContext );
-		this.updatable = extractJandexValue( annotation, JpaAnnotations.MAP_KEY_COLUMN, "updatable", modelContext );
-		this.columnDefinition = extractJandexValue(
-				annotation,
-				JpaAnnotations.MAP_KEY_COLUMN,
-				"columnDefinition",
-				modelContext
-		);
-		this.options = extractJandexValue( annotation, JpaAnnotations.MAP_KEY_COLUMN, "options", modelContext );
-		this.table = extractJandexValue( annotation, JpaAnnotations.MAP_KEY_COLUMN, "table", modelContext );
-		this.length = extractJandexValue( annotation, JpaAnnotations.MAP_KEY_COLUMN, "length", modelContext );
-		this.precision = extractJandexValue( annotation, JpaAnnotations.MAP_KEY_COLUMN, "precision", modelContext );
-		this.scale = extractJandexValue( annotation, JpaAnnotations.MAP_KEY_COLUMN, "scale", modelContext );
+	public MapKeyColumnJpaAnnotation(Map<String, Object> attributeValues, SourceModelBuildingContext modelContext) {
+		this.name = (String) attributeValues.get( "name" );
+		this.unique = (boolean) attributeValues.get( "unique" );
+		this.nullable = (boolean) attributeValues.get( "nullable" );
+		this.insertable = (boolean) attributeValues.get( "insertable" );
+		this.updatable = (boolean) attributeValues.get( "updatable" );
+		this.columnDefinition = (String) attributeValues.get( "columnDefinition" );
+		this.options = (String) attributeValues.get( "options" );
+		this.table = (String) attributeValues.get( "table" );
+		this.length = (int) attributeValues.get( "length" );
+		this.precision = (int) attributeValues.get( "precision" );
+		this.scale = (int) attributeValues.get( "scale" );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/MapKeyCompositeTypeAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/MapKeyCompositeTypeAnnotation.java
@@ -7,14 +7,10 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
 import org.hibernate.annotations.MapKeyCompositeType;
-import org.hibernate.boot.models.HibernateAnnotations;
 import org.hibernate.models.spi.SourceModelBuildingContext;
-
-import org.jboss.jandex.AnnotationInstance;
-
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJandexValue;
 
 @SuppressWarnings({ "ClassExplicitlyAnnotation", "unused" })
 @jakarta.annotation.Generated("org.hibernate.orm.build.annotations.ClassGeneratorProcessor")
@@ -37,13 +33,8 @@ public class MapKeyCompositeTypeAnnotation implements MapKeyCompositeType {
 	/**
 	 * Used in creating annotation instances from Jandex variant
 	 */
-	public MapKeyCompositeTypeAnnotation(AnnotationInstance annotation, SourceModelBuildingContext modelContext) {
-		this.value = extractJandexValue(
-				annotation,
-				HibernateAnnotations.MAP_KEY_COMPOSITE_TYPE,
-				"value",
-				modelContext
-		);
+	public MapKeyCompositeTypeAnnotation(Map<String, Object> attributeValues, SourceModelBuildingContext modelContext) {
+		this.value = (Class<? extends org.hibernate.usertype.CompositeUserType<?>>) attributeValues.get( "value" );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/MapKeyEnumeratedJpaAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/MapKeyEnumeratedJpaAnnotation.java
@@ -7,15 +7,11 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
-import org.hibernate.boot.models.JpaAnnotations;
 import org.hibernate.models.spi.SourceModelBuildingContext;
 
-import org.jboss.jandex.AnnotationInstance;
-
 import jakarta.persistence.MapKeyEnumerated;
-
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJandexValue;
 
 @SuppressWarnings({ "ClassExplicitlyAnnotation", "unused" })
 @jakarta.annotation.Generated("org.hibernate.orm.build.annotations.ClassGeneratorProcessor")
@@ -39,8 +35,8 @@ public class MapKeyEnumeratedJpaAnnotation implements MapKeyEnumerated {
 	/**
 	 * Used in creating annotation instances from Jandex variant
 	 */
-	public MapKeyEnumeratedJpaAnnotation(AnnotationInstance annotation, SourceModelBuildingContext modelContext) {
-		this.value = extractJandexValue( annotation, JpaAnnotations.MAP_KEY_ENUMERATED, "value", modelContext );
+	public MapKeyEnumeratedJpaAnnotation(Map<String, Object> attributeValues, SourceModelBuildingContext modelContext) {
+		this.value = (jakarta.persistence.EnumType) attributeValues.get( "value" );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/MapKeyJavaTypeAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/MapKeyJavaTypeAnnotation.java
@@ -7,14 +7,10 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
 import org.hibernate.annotations.MapKeyJavaType;
-import org.hibernate.boot.models.HibernateAnnotations;
 import org.hibernate.models.spi.SourceModelBuildingContext;
-
-import org.jboss.jandex.AnnotationInstance;
-
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJandexValue;
 
 @SuppressWarnings({ "ClassExplicitlyAnnotation", "unused" })
 @jakarta.annotation.Generated("org.hibernate.orm.build.annotations.ClassGeneratorProcessor")
@@ -37,8 +33,8 @@ public class MapKeyJavaTypeAnnotation implements MapKeyJavaType {
 	/**
 	 * Used in creating annotation instances from Jandex variant
 	 */
-	public MapKeyJavaTypeAnnotation(AnnotationInstance annotation, SourceModelBuildingContext modelContext) {
-		this.value = extractJandexValue( annotation, HibernateAnnotations.MAP_KEY_JAVA_TYPE, "value", modelContext );
+	public MapKeyJavaTypeAnnotation(Map<String, Object> attributeValues, SourceModelBuildingContext modelContext) {
+		this.value = (Class<? extends org.hibernate.type.descriptor.java.BasicJavaType<?>>) attributeValues.get( "value" );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/MapKeyJdbcTypeAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/MapKeyJdbcTypeAnnotation.java
@@ -7,14 +7,10 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
 import org.hibernate.annotations.MapKeyJdbcType;
-import org.hibernate.boot.models.HibernateAnnotations;
 import org.hibernate.models.spi.SourceModelBuildingContext;
-
-import org.jboss.jandex.AnnotationInstance;
-
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJandexValue;
 
 @SuppressWarnings({ "ClassExplicitlyAnnotation", "unused" })
 @jakarta.annotation.Generated("org.hibernate.orm.build.annotations.ClassGeneratorProcessor")
@@ -37,8 +33,8 @@ public class MapKeyJdbcTypeAnnotation implements MapKeyJdbcType {
 	/**
 	 * Used in creating annotation instances from Jandex variant
 	 */
-	public MapKeyJdbcTypeAnnotation(AnnotationInstance annotation, SourceModelBuildingContext modelContext) {
-		this.value = extractJandexValue( annotation, HibernateAnnotations.MAP_KEY_JDBC_TYPE, "value", modelContext );
+	public MapKeyJdbcTypeAnnotation(Map<String, Object> attributeValues, SourceModelBuildingContext modelContext) {
+		this.value = (Class<? extends org.hibernate.type.descriptor.jdbc.JdbcType>) attributeValues.get( "value" );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/MapKeyJdbcTypeCodeAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/MapKeyJdbcTypeCodeAnnotation.java
@@ -7,14 +7,10 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
 import org.hibernate.annotations.MapKeyJdbcTypeCode;
-import org.hibernate.boot.models.HibernateAnnotations;
 import org.hibernate.models.spi.SourceModelBuildingContext;
-
-import org.jboss.jandex.AnnotationInstance;
-
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJandexValue;
 
 @SuppressWarnings({ "ClassExplicitlyAnnotation", "unused" })
 @jakarta.annotation.Generated("org.hibernate.orm.build.annotations.ClassGeneratorProcessor")
@@ -37,13 +33,8 @@ public class MapKeyJdbcTypeCodeAnnotation implements MapKeyJdbcTypeCode {
 	/**
 	 * Used in creating annotation instances from Jandex variant
 	 */
-	public MapKeyJdbcTypeCodeAnnotation(AnnotationInstance annotation, SourceModelBuildingContext modelContext) {
-		this.value = extractJandexValue(
-				annotation,
-				HibernateAnnotations.MAP_KEY_JDBC_TYPE_CODE,
-				"value",
-				modelContext
-		);
+	public MapKeyJdbcTypeCodeAnnotation(Map<String, Object> attributeValues, SourceModelBuildingContext modelContext) {
+		this.value = (int) attributeValues.get( "value" );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/MapKeyJoinColumnJpaAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/MapKeyJoinColumnJpaAnnotation.java
@@ -7,6 +7,7 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
 import org.hibernate.boot.jaxb.mapping.spi.JaxbMapKeyJoinColumnImpl;
 import org.hibernate.boot.models.JpaAnnotations;
@@ -15,11 +16,8 @@ import org.hibernate.boot.models.xml.spi.XmlDocumentContext;
 import org.hibernate.internal.util.StringHelper;
 import org.hibernate.models.spi.SourceModelBuildingContext;
 
-import org.jboss.jandex.AnnotationInstance;
-
 import jakarta.persistence.MapKeyJoinColumn;
 
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJandexValue;
 import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJdkValue;
 
 @SuppressWarnings({ "ClassExplicitlyAnnotation", "unused" })
@@ -71,42 +69,17 @@ public class MapKeyJoinColumnJpaAnnotation implements MapKeyJoinColumn {
 	/**
 	 * Used in creating annotation instances from Jandex variant
 	 */
-	public MapKeyJoinColumnJpaAnnotation(AnnotationInstance annotation, SourceModelBuildingContext modelContext) {
-		this.name = extractJandexValue( annotation, JpaAnnotations.MAP_KEY_JOIN_COLUMN, "name", modelContext );
-		this.referencedColumnName = extractJandexValue(
-				annotation,
-				JpaAnnotations.MAP_KEY_JOIN_COLUMN,
-				"referencedColumnName",
-				modelContext
-		);
-		this.unique = extractJandexValue( annotation, JpaAnnotations.MAP_KEY_JOIN_COLUMN, "unique", modelContext );
-		this.nullable = extractJandexValue( annotation, JpaAnnotations.MAP_KEY_JOIN_COLUMN, "nullable", modelContext );
-		this.insertable = extractJandexValue(
-				annotation,
-				JpaAnnotations.MAP_KEY_JOIN_COLUMN,
-				"insertable",
-				modelContext
-		);
-		this.updatable = extractJandexValue(
-				annotation,
-				JpaAnnotations.MAP_KEY_JOIN_COLUMN,
-				"updatable",
-				modelContext
-		);
-		this.columnDefinition = extractJandexValue(
-				annotation,
-				JpaAnnotations.MAP_KEY_JOIN_COLUMN,
-				"columnDefinition",
-				modelContext
-		);
-		this.options = extractJandexValue( annotation, JpaAnnotations.MAP_KEY_JOIN_COLUMN, "options", modelContext );
-		this.table = extractJandexValue( annotation, JpaAnnotations.MAP_KEY_JOIN_COLUMN, "table", modelContext );
-		this.foreignKey = extractJandexValue(
-				annotation,
-				JpaAnnotations.MAP_KEY_JOIN_COLUMN,
-				"foreignKey",
-				modelContext
-		);
+	public MapKeyJoinColumnJpaAnnotation(Map<String, Object> attributeValues, SourceModelBuildingContext modelContext) {
+		this.name = (String) attributeValues.get( "name" );
+		this.referencedColumnName = (String) attributeValues.get( "referencedColumnName" );
+		this.unique = (boolean) attributeValues.get( "unique" );
+		this.nullable = (boolean) attributeValues.get( "nullable" );
+		this.insertable = (boolean) attributeValues.get( "insertable" );
+		this.updatable = (boolean) attributeValues.get( "updatable" );
+		this.columnDefinition = (String) attributeValues.get( "columnDefinition" );
+		this.options = (String) attributeValues.get( "options" );
+		this.table = (String) attributeValues.get( "table" );
+		this.foreignKey = (jakarta.persistence.ForeignKey) attributeValues.get( "foreignKey" );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/MapKeyJoinColumnsJpaAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/MapKeyJoinColumnsJpaAnnotation.java
@@ -7,17 +7,15 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
 import org.hibernate.boot.models.JpaAnnotations;
 import org.hibernate.boot.models.annotations.spi.RepeatableContainer;
 import org.hibernate.models.spi.SourceModelBuildingContext;
 
-import org.jboss.jandex.AnnotationInstance;
-
 import jakarta.persistence.MapKeyJoinColumn;
 import jakarta.persistence.MapKeyJoinColumns;
 
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJandexValue;
 import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJdkValue;
 
 @SuppressWarnings({ "ClassExplicitlyAnnotation", "unused" })
@@ -49,14 +47,11 @@ public class MapKeyJoinColumnsJpaAnnotation implements MapKeyJoinColumns, Repeat
 	/**
 	 * Used in creating annotation instances from Jandex variant
 	 */
-	public MapKeyJoinColumnsJpaAnnotation(AnnotationInstance annotation, SourceModelBuildingContext modelContext) {
-		this.value = extractJandexValue( annotation, JpaAnnotations.MAP_KEY_JOIN_COLUMNS, "value", modelContext );
-		this.foreignKey = extractJandexValue(
-				annotation,
-				JpaAnnotations.MAP_KEY_JOIN_COLUMNS,
-				"foreignKey",
-				modelContext
-		);
+	public MapKeyJoinColumnsJpaAnnotation(
+			Map<String, Object> attributeValues,
+			SourceModelBuildingContext modelContext) {
+		this.value = (MapKeyJoinColumn[]) attributeValues.get( "value" );
+		this.foreignKey = (jakarta.persistence.ForeignKey) attributeValues.get( "foreignKey" );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/MapKeyJpaAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/MapKeyJpaAnnotation.java
@@ -7,15 +7,11 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
-import org.hibernate.boot.models.JpaAnnotations;
 import org.hibernate.models.spi.SourceModelBuildingContext;
 
-import org.jboss.jandex.AnnotationInstance;
-
 import jakarta.persistence.MapKey;
-
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJandexValue;
 
 @SuppressWarnings({ "ClassExplicitlyAnnotation", "unused" })
 @jakarta.annotation.Generated("org.hibernate.orm.build.annotations.ClassGeneratorProcessor")
@@ -39,8 +35,8 @@ public class MapKeyJpaAnnotation implements MapKey {
 	/**
 	 * Used in creating annotation instances from Jandex variant
 	 */
-	public MapKeyJpaAnnotation(AnnotationInstance annotation, SourceModelBuildingContext modelContext) {
-		this.name = extractJandexValue( annotation, JpaAnnotations.MAP_KEY, "name", modelContext );
+	public MapKeyJpaAnnotation(Map<String, Object> attributeValues, SourceModelBuildingContext modelContext) {
+		this.name = (String) attributeValues.get( "name" );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/MapKeyMutabilityAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/MapKeyMutabilityAnnotation.java
@@ -7,14 +7,10 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
 import org.hibernate.annotations.MapKeyMutability;
-import org.hibernate.boot.models.HibernateAnnotations;
 import org.hibernate.models.spi.SourceModelBuildingContext;
-
-import org.jboss.jandex.AnnotationInstance;
-
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJandexValue;
 
 @SuppressWarnings({ "ClassExplicitlyAnnotation", "unused" })
 @jakarta.annotation.Generated("org.hibernate.orm.build.annotations.ClassGeneratorProcessor")
@@ -37,8 +33,9 @@ public class MapKeyMutabilityAnnotation implements MapKeyMutability {
 	/**
 	 * Used in creating annotation instances from Jandex variant
 	 */
-	public MapKeyMutabilityAnnotation(AnnotationInstance annotation, SourceModelBuildingContext modelContext) {
-		this.value = extractJandexValue( annotation, HibernateAnnotations.MAP_KEY_MUTABILITY, "value", modelContext );
+	public MapKeyMutabilityAnnotation(Map<String, Object> attributeValues, SourceModelBuildingContext modelContext) {
+		this.value = (Class<? extends org.hibernate.type.descriptor.java.MutabilityPlan<?>>) attributeValues
+				.get( "value" );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/MapKeyTemporalJpaAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/MapKeyTemporalJpaAnnotation.java
@@ -7,15 +7,11 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
-import org.hibernate.boot.models.JpaAnnotations;
 import org.hibernate.models.spi.SourceModelBuildingContext;
 
-import org.jboss.jandex.AnnotationInstance;
-
 import jakarta.persistence.MapKeyTemporal;
-
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJandexValue;
 
 @SuppressWarnings({ "ClassExplicitlyAnnotation", "unused" })
 @jakarta.annotation.Generated("org.hibernate.orm.build.annotations.ClassGeneratorProcessor")
@@ -38,8 +34,8 @@ public class MapKeyTemporalJpaAnnotation implements MapKeyTemporal {
 	/**
 	 * Used in creating annotation instances from Jandex variant
 	 */
-	public MapKeyTemporalJpaAnnotation(AnnotationInstance annotation, SourceModelBuildingContext modelContext) {
-		this.value = extractJandexValue( annotation, JpaAnnotations.MAP_KEY_TEMPORAL, "value", modelContext );
+	public MapKeyTemporalJpaAnnotation(Map<String, Object> attributeValues, SourceModelBuildingContext modelContext) {
+		this.value = (jakarta.persistence.TemporalType) attributeValues.get( "value" );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/MapKeyTypeAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/MapKeyTypeAnnotation.java
@@ -7,14 +7,12 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
 import org.hibernate.annotations.MapKeyType;
 import org.hibernate.boot.models.HibernateAnnotations;
 import org.hibernate.models.spi.SourceModelBuildingContext;
 
-import org.jboss.jandex.AnnotationInstance;
-
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJandexValue;
 import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJdkValue;
 
 @SuppressWarnings({ "ClassExplicitlyAnnotation", "unused" })
@@ -41,14 +39,9 @@ public class MapKeyTypeAnnotation implements MapKeyType {
 	/**
 	 * Used in creating annotation instances from Jandex variant
 	 */
-	public MapKeyTypeAnnotation(AnnotationInstance annotation, SourceModelBuildingContext modelContext) {
-		this.value = extractJandexValue( annotation, HibernateAnnotations.MAP_KEY_TYPE, "value", modelContext );
-		this.parameters = extractJandexValue(
-				annotation,
-				HibernateAnnotations.MAP_KEY_TYPE,
-				"parameters",
-				modelContext
-		);
+	public MapKeyTypeAnnotation(Map<String, Object> attributeValues, SourceModelBuildingContext modelContext) {
+		this.value = (Class<? extends org.hibernate.usertype.UserType<?>>) attributeValues.get( "value" );
+		this.parameters = (org.hibernate.annotations.Parameter[]) attributeValues.get( "parameters" );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/MappedSuperclassJpaAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/MappedSuperclassJpaAnnotation.java
@@ -7,10 +7,9 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
 import org.hibernate.models.spi.SourceModelBuildingContext;
-
-import org.jboss.jandex.AnnotationInstance;
 
 import jakarta.persistence.MappedSuperclass;
 
@@ -34,7 +33,7 @@ public class MappedSuperclassJpaAnnotation implements MappedSuperclass {
 	/**
 	 * Used in creating annotation instances from Jandex variant
 	 */
-	public MappedSuperclassJpaAnnotation(AnnotationInstance annotation, SourceModelBuildingContext modelContext) {
+	public MappedSuperclassJpaAnnotation(Map<String, Object> attributeValues, SourceModelBuildingContext modelContext) {
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/MapsIdJpaAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/MapsIdJpaAnnotation.java
@@ -7,15 +7,11 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
-import org.hibernate.boot.models.JpaAnnotations;
 import org.hibernate.models.spi.SourceModelBuildingContext;
 
-import org.jboss.jandex.AnnotationInstance;
-
 import jakarta.persistence.MapsId;
-
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJandexValue;
 
 @SuppressWarnings({ "ClassExplicitlyAnnotation", "unused" })
 @jakarta.annotation.Generated("org.hibernate.orm.build.annotations.ClassGeneratorProcessor")
@@ -39,8 +35,8 @@ public class MapsIdJpaAnnotation implements MapsId {
 	/**
 	 * Used in creating annotation instances from Jandex variant
 	 */
-	public MapsIdJpaAnnotation(AnnotationInstance annotation, SourceModelBuildingContext modelContext) {
-		this.value = extractJandexValue( annotation, JpaAnnotations.MAPS_ID, "value", modelContext );
+	public MapsIdJpaAnnotation(Map<String, Object> attributeValues, SourceModelBuildingContext modelContext) {
+		this.value = (String) attributeValues.get( "value" );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/MutabilityAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/MutabilityAnnotation.java
@@ -7,14 +7,10 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
 import org.hibernate.annotations.Mutability;
-import org.hibernate.boot.models.HibernateAnnotations;
 import org.hibernate.models.spi.SourceModelBuildingContext;
-
-import org.jboss.jandex.AnnotationInstance;
-
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJandexValue;
 
 @SuppressWarnings({ "ClassExplicitlyAnnotation", "unused" })
 @jakarta.annotation.Generated("org.hibernate.orm.build.annotations.ClassGeneratorProcessor")
@@ -37,8 +33,9 @@ public class MutabilityAnnotation implements Mutability {
 	/**
 	 * Used in creating annotation instances from Jandex variant
 	 */
-	public MutabilityAnnotation(AnnotationInstance annotation, SourceModelBuildingContext modelContext) {
-		this.value = extractJandexValue( annotation, HibernateAnnotations.MUTABILITY, "value", modelContext );
+	public MutabilityAnnotation(Map<String, Object> attributeValues, SourceModelBuildingContext modelContext) {
+		this.value = (Class<? extends org.hibernate.type.descriptor.java.MutabilityPlan<?>>) attributeValues
+				.get( "value" );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/NamedAttributeNodeJpaAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/NamedAttributeNodeJpaAnnotation.java
@@ -7,15 +7,11 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
-import org.hibernate.boot.models.JpaAnnotations;
 import org.hibernate.models.spi.SourceModelBuildingContext;
 
-import org.jboss.jandex.AnnotationInstance;
-
 import jakarta.persistence.NamedAttributeNode;
-
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJandexValue;
 
 @SuppressWarnings({ "ClassExplicitlyAnnotation", "unused" })
 @jakarta.annotation.Generated("org.hibernate.orm.build.annotations.ClassGeneratorProcessor")
@@ -44,15 +40,12 @@ public class NamedAttributeNodeJpaAnnotation implements NamedAttributeNode {
 	/**
 	 * Used in creating annotation instances from Jandex variant
 	 */
-	public NamedAttributeNodeJpaAnnotation(AnnotationInstance annotation, SourceModelBuildingContext modelContext) {
-		this.value = extractJandexValue( annotation, JpaAnnotations.NAMED_ATTRIBUTE_NODE, "value", modelContext );
-		this.subgraph = extractJandexValue( annotation, JpaAnnotations.NAMED_ATTRIBUTE_NODE, "subgraph", modelContext );
-		this.keySubgraph = extractJandexValue(
-				annotation,
-				JpaAnnotations.NAMED_ATTRIBUTE_NODE,
-				"keySubgraph",
-				modelContext
-		);
+	public NamedAttributeNodeJpaAnnotation(
+			Map<String, Object> attributeValues,
+			SourceModelBuildingContext modelContext) {
+		this.value = (String) attributeValues.get( "value" );
+		this.subgraph = (String) attributeValues.get( "subgraph" );
+		this.keySubgraph = (String) attributeValues.get( "keySubgraph" );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/NamedEntityGraphJpaAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/NamedEntityGraphJpaAnnotation.java
@@ -7,15 +7,13 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
 import org.hibernate.models.spi.SourceModelBuildingContext;
-
-import org.jboss.jandex.AnnotationInstance;
 
 import jakarta.persistence.NamedEntityGraph;
 
 import static org.hibernate.boot.models.JpaAnnotations.NAMED_ENTITY_GRAPH;
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJandexValue;
 import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJdkValue;
 
 @SuppressWarnings({ "ClassExplicitlyAnnotation", "unused" })
@@ -52,27 +50,12 @@ public class NamedEntityGraphJpaAnnotation implements NamedEntityGraph {
 	/**
 	 * Used in creating annotation instances from Jandex variant
 	 */
-	public NamedEntityGraphJpaAnnotation(AnnotationInstance annotation, SourceModelBuildingContext modelContext) {
-		this.name = extractJandexValue( annotation, NAMED_ENTITY_GRAPH, "name", modelContext );
-		this.attributeNodes = extractJandexValue(
-				annotation,
-				NAMED_ENTITY_GRAPH,
-				"attributeNodes",
-				modelContext
-		);
-		this.includeAllAttributes = extractJandexValue(
-				annotation,
-				NAMED_ENTITY_GRAPH,
-				"includeAllAttributes",
-				modelContext
-		);
-		this.subgraphs = extractJandexValue( annotation, NAMED_ENTITY_GRAPH, "subgraphs", modelContext );
-		this.subclassSubgraphs = extractJandexValue(
-				annotation,
-				NAMED_ENTITY_GRAPH,
-				"subclassSubgraphs",
-				modelContext
-		);
+	public NamedEntityGraphJpaAnnotation(Map<String, Object> attributeValues, SourceModelBuildingContext modelContext) {
+		this.name = (String) attributeValues.get( "name" );
+		this.attributeNodes = (jakarta.persistence.NamedAttributeNode[]) attributeValues.get( "attributeNodes" );
+		this.includeAllAttributes = (boolean) attributeValues.get( "includeAllAttributes" );
+		this.subgraphs = (jakarta.persistence.NamedSubgraph[]) attributeValues.get( "subgraphs" );
+		this.subclassSubgraphs = (jakarta.persistence.NamedSubgraph[]) attributeValues.get( "subclassSubgraphs" );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/NamedEntityGraphsJpaAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/NamedEntityGraphsJpaAnnotation.java
@@ -7,17 +7,15 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
 import org.hibernate.boot.models.JpaAnnotations;
 import org.hibernate.boot.models.annotations.spi.RepeatableContainer;
 import org.hibernate.models.spi.SourceModelBuildingContext;
 
-import org.jboss.jandex.AnnotationInstance;
-
 import jakarta.persistence.NamedEntityGraph;
 import jakarta.persistence.NamedEntityGraphs;
 
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJandexValue;
 import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJdkValue;
 
 @SuppressWarnings({ "ClassExplicitlyAnnotation", "unused" })
@@ -41,8 +39,10 @@ public class NamedEntityGraphsJpaAnnotation implements NamedEntityGraphs, Repeat
 	/**
 	 * Used in creating annotation instances from Jandex variant
 	 */
-	public NamedEntityGraphsJpaAnnotation(AnnotationInstance annotation, SourceModelBuildingContext modelContext) {
-		this.value = extractJandexValue( annotation, JpaAnnotations.NAMED_ENTITY_GRAPHS, "value", modelContext );
+	public NamedEntityGraphsJpaAnnotation(
+			Map<String, Object> attributeValues,
+			SourceModelBuildingContext modelContext) {
+		this.value = (NamedEntityGraph[]) attributeValues.get( "value" );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/NamedNativeQueriesAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/NamedNativeQueriesAnnotation.java
@@ -7,16 +7,14 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
 import org.hibernate.annotations.NamedNativeQueries;
 import org.hibernate.annotations.NamedNativeQuery;
 import org.hibernate.boot.models.annotations.spi.RepeatableContainer;
 import org.hibernate.models.spi.SourceModelBuildingContext;
 
-import org.jboss.jandex.AnnotationInstance;
-
 import static org.hibernate.boot.models.HibernateAnnotations.NAMED_NATIVE_QUERIES;
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJandexValue;
 import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJdkValue;
 
 @SuppressWarnings({ "ClassExplicitlyAnnotation", "unused" })
@@ -40,8 +38,8 @@ public class NamedNativeQueriesAnnotation implements NamedNativeQueries, Repeata
 	/**
 	 * Used in creating annotation instances from Jandex variant
 	 */
-	public NamedNativeQueriesAnnotation(AnnotationInstance annotation, SourceModelBuildingContext modelContext) {
-		this.value = extractJandexValue( annotation, NAMED_NATIVE_QUERIES, "value", modelContext );
+	public NamedNativeQueriesAnnotation(Map<String, Object> attributeValues, SourceModelBuildingContext modelContext) {
+		this.value = (NamedNativeQuery[]) attributeValues.get( "value" );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/NamedNativeQueriesJpaAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/NamedNativeQueriesJpaAnnotation.java
@@ -7,17 +7,15 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
 import org.hibernate.boot.models.JpaAnnotations;
 import org.hibernate.boot.models.annotations.spi.RepeatableContainer;
 import org.hibernate.models.spi.SourceModelBuildingContext;
 
-import org.jboss.jandex.AnnotationInstance;
-
 import jakarta.persistence.NamedNativeQueries;
 import jakarta.persistence.NamedNativeQuery;
 
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJandexValue;
 import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJdkValue;
 
 @SuppressWarnings({ "ClassExplicitlyAnnotation", "unused" })
@@ -41,8 +39,10 @@ public class NamedNativeQueriesJpaAnnotation implements NamedNativeQueries, Repe
 	/**
 	 * Used in creating annotation instances from Jandex variant
 	 */
-	public NamedNativeQueriesJpaAnnotation(AnnotationInstance annotation, SourceModelBuildingContext modelContext) {
-		this.value = extractJandexValue( annotation, JpaAnnotations.NAMED_NATIVE_QUERIES, "value", modelContext );
+	public NamedNativeQueriesJpaAnnotation(
+			Map<String, Object> attributeValues,
+			SourceModelBuildingContext modelContext) {
+		this.value = (NamedNativeQuery[]) attributeValues.get( "value" );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/NamedNativeQueryAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/NamedNativeQueryAnnotation.java
@@ -9,6 +9,7 @@ package org.hibernate.boot.models.annotations.internal;
 import java.lang.annotation.Annotation;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 import org.hibernate.CacheMode;
 import org.hibernate.annotations.FlushModeType;
@@ -21,13 +22,8 @@ import org.hibernate.internal.util.collections.CollectionHelper;
 import org.hibernate.models.spi.MutableClassDetails;
 import org.hibernate.models.spi.SourceModelBuildingContext;
 
-import org.jboss.jandex.AnnotationInstance;
-
 import jakarta.persistence.CacheRetrieveMode;
 import jakarta.persistence.CacheStoreMode;
-
-import static org.hibernate.boot.models.HibernateAnnotations.NAMED_NATIVE_QUERY;
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJandexValue;
 
 @SuppressWarnings({ "ClassExplicitlyAnnotation", "unused" })
 @jakarta.annotation.Generated("org.hibernate.orm.build.annotations.ClassGeneratorProcessor")
@@ -48,6 +44,9 @@ public class NamedNativeQueryAnnotation implements NamedNativeQuery {
 	String[] querySpaces;
 	boolean callable;
 
+	/**
+	 * Used in creating dynamic annotation instances (e.g. from XML)
+	 */
 	public NamedNativeQueryAnnotation(SourceModelBuildingContext modelContext) {
 		resultClass = void.class;
 		resultSetMapping = "";
@@ -64,6 +63,9 @@ public class NamedNativeQueryAnnotation implements NamedNativeQuery {
 		callable = false;
 	}
 
+	/**
+	 * Used in creating annotation instances from JDK variant
+	 */
 	public NamedNativeQueryAnnotation(NamedNativeQuery annotation, SourceModelBuildingContext modelContext) {
 		this.name = annotation.name();
 		this.query = annotation.query();
@@ -86,22 +88,25 @@ public class NamedNativeQueryAnnotation implements NamedNativeQuery {
 		this.callable = annotation.callable();
 	}
 
-	public NamedNativeQueryAnnotation(AnnotationInstance annotation, SourceModelBuildingContext modelContext) {
-		this.name = extractJandexValue( annotation, NAMED_NATIVE_QUERY, "name", modelContext );
-		this.query = extractJandexValue( annotation, NAMED_NATIVE_QUERY, "query", modelContext );
-		this.resultClass = extractJandexValue( annotation, NAMED_NATIVE_QUERY, "resultClass", modelContext );
-		this.resultSetMapping = extractJandexValue( annotation, NAMED_NATIVE_QUERY, "resultSetMapping", modelContext );
-		this.flushMode = extractJandexValue( annotation, NAMED_NATIVE_QUERY, "flushMode", modelContext );
-		this.cacheable = extractJandexValue( annotation, NAMED_NATIVE_QUERY, "cacheable", modelContext );
-		this.cacheRegion = extractJandexValue( annotation, NAMED_NATIVE_QUERY, "cacheRegion", modelContext );
-		this.fetchSize = extractJandexValue( annotation, NAMED_NATIVE_QUERY, "fetchSize", modelContext );
-		this.timeout = extractJandexValue( annotation, NAMED_NATIVE_QUERY, "timeout", modelContext );
-		this.comment = extractJandexValue( annotation, NAMED_NATIVE_QUERY, "comment", modelContext );
-		this.cacheStoreMode = extractJandexValue( annotation, NAMED_NATIVE_QUERY, "cacheStoreMode", modelContext );
-		this.cacheRetrieveMode = extractJandexValue( annotation, NAMED_NATIVE_QUERY, "cacheRetrieveMode", modelContext );
-		this.readOnly = extractJandexValue( annotation, NAMED_NATIVE_QUERY, "readOnly", modelContext );
-		this.querySpaces = extractJandexValue( annotation, NAMED_NATIVE_QUERY, "querySpaces", modelContext );
-		this.callable = extractJandexValue( annotation, NAMED_NATIVE_QUERY, "callable", modelContext );
+	/**
+	 * Used in creating annotation instances from Jandex variant
+	 */
+	public NamedNativeQueryAnnotation(Map<String, Object> attributeValues, SourceModelBuildingContext modelContext) {
+		this.name = (String) attributeValues.get( "name" );
+		this.query = (String) attributeValues.get( "query" );
+		this.resultClass = (Class<?>) attributeValues.get( "resultClass" );
+		this.resultSetMapping = (String) attributeValues.get( "resultSetMapping" );
+		this.flushMode = (FlushModeType) attributeValues.get( "flushMode" );
+		this.cacheable = (boolean) attributeValues.get( "cacheable" );
+		this.cacheRegion = (String) attributeValues.get( "cacheRegion" );
+		this.fetchSize = (int) attributeValues.get( "fetchSize" );
+		this.timeout = (int) attributeValues.get( "timeout" );
+		this.comment = (String) attributeValues.get( "comment" );
+		this.cacheStoreMode = (CacheStoreMode) attributeValues.get( "cacheStoreMode" );
+		this.cacheRetrieveMode = (CacheRetrieveMode) attributeValues.get( "cacheRetrieveMode" );
+		this.readOnly = (boolean) attributeValues.get( "readOnly" );
+		this.querySpaces = (String[]) attributeValues.get( "querySpaces" );
+		this.callable = (boolean) attributeValues.get( "callable" );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/NamedNativeQueryJpaAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/NamedNativeQueryJpaAnnotation.java
@@ -7,6 +7,7 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
 import org.hibernate.boot.jaxb.mapping.spi.JaxbNamedNativeQueryImpl;
 import org.hibernate.boot.models.JpaAnnotations;
@@ -16,11 +17,8 @@ import org.hibernate.internal.util.StringHelper;
 import org.hibernate.models.spi.MutableClassDetails;
 import org.hibernate.models.spi.SourceModelBuildingContext;
 
-import org.jboss.jandex.AnnotationInstance;
-
 import jakarta.persistence.NamedNativeQuery;
 
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJandexValue;
 import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJdkValue;
 
 @SuppressWarnings({ "ClassExplicitlyAnnotation", "unused" })
@@ -64,25 +62,15 @@ public class NamedNativeQueryJpaAnnotation implements NamedNativeQuery {
 	/**
 	 * Used in creating annotation instances from Jandex variant
 	 */
-	public NamedNativeQueryJpaAnnotation(AnnotationInstance annotation, SourceModelBuildingContext modelContext) {
-		this.name = extractJandexValue( annotation, JpaAnnotations.NAMED_NATIVE_QUERY, "name", modelContext );
-		this.query = extractJandexValue( annotation, JpaAnnotations.NAMED_NATIVE_QUERY, "query", modelContext );
-		this.hints = extractJandexValue( annotation, JpaAnnotations.NAMED_NATIVE_QUERY, "hints", modelContext );
-		this.resultClass = extractJandexValue(
-				annotation,
-				JpaAnnotations.NAMED_NATIVE_QUERY,
-				"resultClass",
-				modelContext
-		);
-		this.resultSetMapping = extractJandexValue(
-				annotation,
-				JpaAnnotations.NAMED_NATIVE_QUERY,
-				"resultSetMapping",
-				modelContext
-		);
-		this.entities = extractJandexValue( annotation, JpaAnnotations.NAMED_NATIVE_QUERY, "entities", modelContext );
-		this.classes = extractJandexValue( annotation, JpaAnnotations.NAMED_NATIVE_QUERY, "classes", modelContext );
-		this.columns = extractJandexValue( annotation, JpaAnnotations.NAMED_NATIVE_QUERY, "columns", modelContext );
+	public NamedNativeQueryJpaAnnotation(Map<String, Object> attributeValues, SourceModelBuildingContext modelContext) {
+		this.name = (String) attributeValues.get( "name" );
+		this.query = (String) attributeValues.get( "query" );
+		this.hints = (jakarta.persistence.QueryHint[]) attributeValues.get( "hints" );
+		this.resultClass = (Class<?>) attributeValues.get( "resultClass" );
+		this.resultSetMapping = (String) attributeValues.get( "resultSetMapping" );
+		this.entities = (jakarta.persistence.EntityResult[]) attributeValues.get( "entities" );
+		this.classes = (jakarta.persistence.ConstructorResult[]) attributeValues.get( "classes" );
+		this.columns = (jakarta.persistence.ColumnResult[]) attributeValues.get( "columns" );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/NamedQueriesAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/NamedQueriesAnnotation.java
@@ -7,16 +7,14 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
 import org.hibernate.annotations.NamedQueries;
 import org.hibernate.annotations.NamedQuery;
 import org.hibernate.boot.models.annotations.spi.RepeatableContainer;
 import org.hibernate.models.spi.SourceModelBuildingContext;
 
-import org.jboss.jandex.AnnotationInstance;
-
 import static org.hibernate.boot.models.HibernateAnnotations.NAMED_QUERIES;
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJandexValue;
 import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJdkValue;
 
 @SuppressWarnings({ "ClassExplicitlyAnnotation", "unused" })
@@ -40,8 +38,8 @@ public class NamedQueriesAnnotation implements NamedQueries, RepeatableContainer
 	/**
 	 * Used in creating annotation instances from Jandex variant
 	 */
-	public NamedQueriesAnnotation(AnnotationInstance annotation, SourceModelBuildingContext modelContext) {
-		this.value = extractJandexValue( annotation, NAMED_QUERIES, "value", modelContext );
+	public NamedQueriesAnnotation(Map<String, Object> attributeValues, SourceModelBuildingContext modelContext) {
+		this.value = (NamedQuery[]) attributeValues.get( "value" );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/NamedQueriesJpaAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/NamedQueriesJpaAnnotation.java
@@ -7,17 +7,15 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
 import org.hibernate.boot.models.JpaAnnotations;
 import org.hibernate.boot.models.annotations.spi.RepeatableContainer;
 import org.hibernate.models.spi.SourceModelBuildingContext;
 
-import org.jboss.jandex.AnnotationInstance;
-
 import jakarta.persistence.NamedQueries;
 import jakarta.persistence.NamedQuery;
 
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJandexValue;
 import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJdkValue;
 
 @SuppressWarnings({ "ClassExplicitlyAnnotation", "unused" })
@@ -41,8 +39,8 @@ public class NamedQueriesJpaAnnotation implements NamedQueries, RepeatableContai
 	/**
 	 * Used in creating annotation instances from Jandex variant
 	 */
-	public NamedQueriesJpaAnnotation(AnnotationInstance annotation, SourceModelBuildingContext modelContext) {
-		this.value = extractJandexValue( annotation, JpaAnnotations.NAMED_QUERIES, "value", modelContext );
+	public NamedQueriesJpaAnnotation(Map<String, Object> attributeValues, SourceModelBuildingContext modelContext) {
+		this.value = (NamedQuery[]) attributeValues.get( "value" );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/NamedQueryAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/NamedQueryAnnotation.java
@@ -7,6 +7,7 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
 import org.hibernate.CacheMode;
 import org.hibernate.annotations.FlushModeType;
@@ -16,13 +17,9 @@ import org.hibernate.boot.models.xml.spi.XmlDocumentContext;
 import org.hibernate.internal.util.StringHelper;
 import org.hibernate.models.spi.SourceModelBuildingContext;
 
-import org.jboss.jandex.AnnotationInstance;
-
 import jakarta.persistence.CacheRetrieveMode;
 import jakarta.persistence.CacheStoreMode;
 
-import static org.hibernate.boot.models.HibernateAnnotations.NAMED_QUERY;
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJandexValue;
 import static org.hibernate.boot.models.xml.internal.QueryProcessing.interpretFlushMode;
 
 @SuppressWarnings({ "ClassExplicitlyAnnotation", "unused" })
@@ -41,6 +38,9 @@ public class NamedQueryAnnotation implements NamedQuery {
 	CacheRetrieveMode cacheRetrieveMode;
 	boolean readOnly;
 
+	/**
+	 * Used in creating dynamic annotation instances (e.g. from XML)
+	 */
 	public NamedQueryAnnotation(SourceModelBuildingContext modelContext) {
 		resultClass = void.class;
 		flushMode = FlushModeType.PERSISTENCE_CONTEXT;
@@ -54,6 +54,9 @@ public class NamedQueryAnnotation implements NamedQuery {
 		readOnly = false;
 	}
 
+	/**
+	 * Used in creating annotation instances from JDK and Jandes variant
+	 */
 	public NamedQueryAnnotation(NamedQuery annotation, SourceModelBuildingContext modelContext) {
 		this.name = annotation.name();
 		this.query = annotation.query();
@@ -73,19 +76,22 @@ public class NamedQueryAnnotation implements NamedQuery {
 		this.readOnly = annotation.readOnly();
 	}
 
-	public NamedQueryAnnotation(AnnotationInstance annotation, SourceModelBuildingContext modelContext) {
-		this.name = extractJandexValue( annotation, NAMED_QUERY, "name", modelContext );
-		this.query = extractJandexValue( annotation, NAMED_QUERY, "query", modelContext );
-		this.resultClass = extractJandexValue( annotation, NAMED_QUERY, "resultClass", modelContext );
-		this.flushMode = extractJandexValue( annotation, NAMED_QUERY, "flushMode", modelContext );
-		this.cacheable = extractJandexValue( annotation, NAMED_QUERY, "cacheable", modelContext );
-		this.cacheRegion = extractJandexValue( annotation, NAMED_QUERY, "cacheRegion", modelContext );
-		this.fetchSize = extractJandexValue( annotation, NAMED_QUERY, "fetchSize", modelContext );
-		this.timeout = extractJandexValue( annotation, NAMED_QUERY, "timeout", modelContext );
-		this.comment = extractJandexValue( annotation, NAMED_QUERY, "comment", modelContext );
-		this.cacheStoreMode = extractJandexValue( annotation, NAMED_QUERY, "cacheStoreMode", modelContext );
-		this.cacheRetrieveMode = extractJandexValue( annotation, NAMED_QUERY, "cacheRetrieveMode", modelContext );
-		this.readOnly = extractJandexValue( annotation, NAMED_QUERY, "readOnly", modelContext );
+	/**
+	 * Used in creating annotation instances from Jandex variant
+	 */
+	public NamedQueryAnnotation(Map<String, Object> attributeValues, SourceModelBuildingContext modelContext) {
+		this.name = (String) attributeValues.get( "name" );
+		this.query = (String) attributeValues.get( "query" );
+		this.resultClass = (Class<?>) attributeValues.get( "resultClass" );
+		this.flushMode = (FlushModeType) attributeValues.get( "flushMode" );
+		this.cacheable = (boolean) attributeValues.get( "cacheable" );
+		this.cacheRegion = (String) attributeValues.get( "cacheRegion" );
+		this.fetchSize = (int) attributeValues.get( "fetchSize" );
+		this.timeout = (int) attributeValues.get( "timeout" );
+		this.comment = (String) attributeValues.get( "comment" );
+		this.cacheStoreMode = (CacheStoreMode) attributeValues.get( "cacheStoreMode" );
+		this.cacheRetrieveMode = (CacheRetrieveMode) attributeValues.get( "cacheRetrieveMode" );
+		this.readOnly = (boolean) attributeValues.get( "readOnly" );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/NamedQueryJpaAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/NamedQueryJpaAnnotation.java
@@ -7,6 +7,7 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
 import org.hibernate.boot.jaxb.mapping.spi.JaxbNamedHqlQueryImpl;
 import org.hibernate.boot.models.JpaAnnotations;
@@ -14,11 +15,8 @@ import org.hibernate.boot.models.xml.internal.QueryProcessing;
 import org.hibernate.boot.models.xml.spi.XmlDocumentContext;
 import org.hibernate.models.spi.SourceModelBuildingContext;
 
-import org.jboss.jandex.AnnotationInstance;
-
 import jakarta.persistence.NamedQuery;
 
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJandexValue;
 import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJdkValue;
 import static org.hibernate.internal.util.NullnessHelper.coalesce;
 
@@ -54,12 +52,12 @@ public class NamedQueryJpaAnnotation implements NamedQuery {
 	/**
 	 * Used in creating annotation instances from Jandex variant
 	 */
-	public NamedQueryJpaAnnotation(AnnotationInstance annotation, SourceModelBuildingContext modelContext) {
-		this.name = extractJandexValue( annotation, JpaAnnotations.NAMED_QUERY, "name", modelContext );
-		this.query = extractJandexValue( annotation, JpaAnnotations.NAMED_QUERY, "query", modelContext );
-		this.resultClass = extractJandexValue( annotation, JpaAnnotations.NAMED_QUERY, "resultClass", modelContext );
-		this.lockMode = extractJandexValue( annotation, JpaAnnotations.NAMED_QUERY, "lockMode", modelContext );
-		this.hints = extractJandexValue( annotation, JpaAnnotations.NAMED_QUERY, "hints", modelContext );
+	public NamedQueryJpaAnnotation(Map<String, Object> attributeValues, SourceModelBuildingContext modelContext) {
+		this.name = (String) attributeValues.get( "name" );
+		this.query = (String) attributeValues.get( "query" );
+		this.resultClass = (Class<?>) attributeValues.get( "resultClass" );
+		this.lockMode = (jakarta.persistence.LockModeType) attributeValues.get( "lockMode" );
+		this.hints = (jakarta.persistence.QueryHint[]) attributeValues.get( "hints" );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/NamedStoredProcedureQueriesJpaAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/NamedStoredProcedureQueriesJpaAnnotation.java
@@ -7,17 +7,15 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
 import org.hibernate.boot.models.JpaAnnotations;
 import org.hibernate.boot.models.annotations.spi.RepeatableContainer;
 import org.hibernate.models.spi.SourceModelBuildingContext;
 
-import org.jboss.jandex.AnnotationInstance;
-
 import jakarta.persistence.NamedStoredProcedureQueries;
 import jakarta.persistence.NamedStoredProcedureQuery;
 
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJandexValue;
 import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJdkValue;
 
 @SuppressWarnings({ "ClassExplicitlyAnnotation", "unused" })
@@ -50,14 +48,9 @@ public class NamedStoredProcedureQueriesJpaAnnotation
 	 * Used in creating annotation instances from Jandex variant
 	 */
 	public NamedStoredProcedureQueriesJpaAnnotation(
-			AnnotationInstance annotation,
+			Map<String, Object> attributeValues,
 			SourceModelBuildingContext modelContext) {
-		this.value = extractJandexValue(
-				annotation,
-				JpaAnnotations.NAMED_STORED_PROCEDURE_QUERIES,
-				"value",
-				modelContext
-		);
+		this.value = (NamedStoredProcedureQuery[]) attributeValues.get( "value" );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/NamedStoredProcedureQueryJpaAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/NamedStoredProcedureQueryJpaAnnotation.java
@@ -7,6 +7,7 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
 import org.hibernate.boot.jaxb.mapping.spi.JaxbNamedStoredProcedureQueryImpl;
 import org.hibernate.boot.models.JpaAnnotations;
@@ -14,11 +15,8 @@ import org.hibernate.boot.models.xml.internal.QueryProcessing;
 import org.hibernate.boot.models.xml.spi.XmlDocumentContext;
 import org.hibernate.models.spi.SourceModelBuildingContext;
 
-import org.jboss.jandex.AnnotationInstance;
-
 import jakarta.persistence.NamedStoredProcedureQuery;
 
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJandexValue;
 import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJdkValue;
 
 @SuppressWarnings({ "ClassExplicitlyAnnotation", "unused" })
@@ -64,39 +62,14 @@ public class NamedStoredProcedureQueryJpaAnnotation implements NamedStoredProced
 	 * Used in creating annotation instances from Jandex variant
 	 */
 	public NamedStoredProcedureQueryJpaAnnotation(
-			AnnotationInstance annotation,
+			Map<String, Object> attributeValues,
 			SourceModelBuildingContext modelContext) {
-		this.name = extractJandexValue( annotation, JpaAnnotations.NAMED_STORED_PROCEDURE_QUERY, "name", modelContext );
-		this.procedureName = extractJandexValue(
-				annotation,
-				JpaAnnotations.NAMED_STORED_PROCEDURE_QUERY,
-				"procedureName",
-				modelContext
-		);
-		this.parameters = extractJandexValue(
-				annotation,
-				JpaAnnotations.NAMED_STORED_PROCEDURE_QUERY,
-				"parameters",
-				modelContext
-		);
-		this.resultClasses = extractJandexValue(
-				annotation,
-				JpaAnnotations.NAMED_STORED_PROCEDURE_QUERY,
-				"resultClasses",
-				modelContext
-		);
-		this.resultSetMappings = extractJandexValue(
-				annotation,
-				JpaAnnotations.NAMED_STORED_PROCEDURE_QUERY,
-				"resultSetMappings",
-				modelContext
-		);
-		this.hints = extractJandexValue(
-				annotation,
-				JpaAnnotations.NAMED_STORED_PROCEDURE_QUERY,
-				"hints",
-				modelContext
-		);
+		this.name = (String) attributeValues.get( "name" );
+		this.procedureName = (String) attributeValues.get( "procedureName" );
+		this.parameters = (jakarta.persistence.StoredProcedureParameter[]) attributeValues.get( "parameters" );
+		this.resultClasses = (Class[]) attributeValues.get( "resultClasses" );
+		this.resultSetMappings = (String[]) attributeValues.get( "resultSetMappings" );
+		this.hints = (jakarta.persistence.QueryHint[]) attributeValues.get( "hints" );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/NamedSubgraphJpaAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/NamedSubgraphJpaAnnotation.java
@@ -7,15 +7,13 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
 import org.hibernate.models.spi.SourceModelBuildingContext;
-
-import org.jboss.jandex.AnnotationInstance;
 
 import jakarta.persistence.NamedSubgraph;
 
 import static org.hibernate.boot.models.JpaAnnotations.NAMED_SUBGRAPH;
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJandexValue;
 import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJdkValue;
 
 @SuppressWarnings({ "ClassExplicitlyAnnotation", "unused" })
@@ -44,15 +42,10 @@ public class NamedSubgraphJpaAnnotation implements NamedSubgraph {
 	/**
 	 * Used in creating annotation instances from Jandex variant
 	 */
-	public NamedSubgraphJpaAnnotation(AnnotationInstance annotation, SourceModelBuildingContext modelContext) {
-		this.name = extractJandexValue( annotation, NAMED_SUBGRAPH, "name", modelContext );
-		this.type = extractJandexValue( annotation, NAMED_SUBGRAPH, "type", modelContext );
-		this.attributeNodes = extractJandexValue(
-				annotation,
-				NAMED_SUBGRAPH,
-				"attributeNodes",
-				modelContext
-		);
+	public NamedSubgraphJpaAnnotation(Map<String, Object> attributeValues, SourceModelBuildingContext modelContext) {
+		this.name = (String) attributeValues.get( "name" );
+		this.type = (Class<?>) attributeValues.get( "type" );
+		this.attributeNodes = (jakarta.persistence.NamedAttributeNode[]) attributeValues.get( "attributeNodes" );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/NationalizedAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/NationalizedAnnotation.java
@@ -7,11 +7,10 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
 import org.hibernate.annotations.Nationalized;
 import org.hibernate.models.spi.SourceModelBuildingContext;
-
-import org.jboss.jandex.AnnotationInstance;
 
 @SuppressWarnings({ "ClassExplicitlyAnnotation", "unused" })
 @jakarta.annotation.Generated("org.hibernate.orm.build.annotations.ClassGeneratorProcessor")
@@ -32,7 +31,7 @@ public class NationalizedAnnotation implements Nationalized {
 	/**
 	 * Used in creating annotation instances from Jandex variant
 	 */
-	public NationalizedAnnotation(AnnotationInstance annotation, SourceModelBuildingContext modelContext) {
+	public NationalizedAnnotation(Map<String, Object> attributeValues, SourceModelBuildingContext modelContext) {
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/NaturalIdAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/NaturalIdAnnotation.java
@@ -7,14 +7,10 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
 import org.hibernate.annotations.NaturalId;
-import org.hibernate.boot.models.HibernateAnnotations;
 import org.hibernate.models.spi.SourceModelBuildingContext;
-
-import org.jboss.jandex.AnnotationInstance;
-
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJandexValue;
 
 @SuppressWarnings({ "ClassExplicitlyAnnotation", "unused" })
 @jakarta.annotation.Generated("org.hibernate.orm.build.annotations.ClassGeneratorProcessor")
@@ -38,8 +34,8 @@ public class NaturalIdAnnotation implements NaturalId {
 	/**
 	 * Used in creating annotation instances from Jandex variant
 	 */
-	public NaturalIdAnnotation(AnnotationInstance annotation, SourceModelBuildingContext modelContext) {
-		this.mutable = extractJandexValue( annotation, HibernateAnnotations.NATURAL_ID, "mutable", modelContext );
+	public NaturalIdAnnotation(Map<String, Object> attributeValues, SourceModelBuildingContext modelContext) {
+		this.mutable = (boolean) attributeValues.get( "mutable" );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/NaturalIdCacheAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/NaturalIdCacheAnnotation.java
@@ -7,14 +7,10 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
 import org.hibernate.annotations.NaturalIdCache;
-import org.hibernate.boot.models.HibernateAnnotations;
 import org.hibernate.models.spi.SourceModelBuildingContext;
-
-import org.jboss.jandex.AnnotationInstance;
-
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJandexValue;
 
 @SuppressWarnings({ "ClassExplicitlyAnnotation", "unused" })
 @jakarta.annotation.Generated("org.hibernate.orm.build.annotations.ClassGeneratorProcessor")
@@ -38,8 +34,8 @@ public class NaturalIdCacheAnnotation implements NaturalIdCache {
 	/**
 	 * Used in creating annotation instances from Jandex variant
 	 */
-	public NaturalIdCacheAnnotation(AnnotationInstance annotation, SourceModelBuildingContext modelContext) {
-		this.region = extractJandexValue( annotation, HibernateAnnotations.NATURAL_ID_CACHE, "region", modelContext );
+	public NaturalIdCacheAnnotation(Map<String, Object> attributeValues, SourceModelBuildingContext modelContext) {
+		this.region = (String) attributeValues.get( "region" );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/NotFoundAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/NotFoundAnnotation.java
@@ -7,14 +7,10 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
 import org.hibernate.annotations.NotFound;
-import org.hibernate.boot.models.HibernateAnnotations;
 import org.hibernate.models.spi.SourceModelBuildingContext;
-
-import org.jboss.jandex.AnnotationInstance;
-
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJandexValue;
 
 @SuppressWarnings({ "ClassExplicitlyAnnotation", "unused" })
 @jakarta.annotation.Generated("org.hibernate.orm.build.annotations.ClassGeneratorProcessor")
@@ -38,8 +34,8 @@ public class NotFoundAnnotation implements NotFound {
 	/**
 	 * Used in creating annotation instances from Jandex variant
 	 */
-	public NotFoundAnnotation(AnnotationInstance annotation, SourceModelBuildingContext modelContext) {
-		this.action = extractJandexValue( annotation, HibernateAnnotations.NOT_FOUND, "action", modelContext );
+	public NotFoundAnnotation(Map<String, Object> attributeValues, SourceModelBuildingContext modelContext) {
+		this.action = (org.hibernate.annotations.NotFoundAction) attributeValues.get( "action" );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/OnDeleteAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/OnDeleteAnnotation.java
@@ -7,14 +7,10 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
 import org.hibernate.annotations.OnDelete;
-import org.hibernate.boot.models.HibernateAnnotations;
 import org.hibernate.models.spi.SourceModelBuildingContext;
-
-import org.jboss.jandex.AnnotationInstance;
-
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJandexValue;
 
 @SuppressWarnings({ "ClassExplicitlyAnnotation", "unused" })
 @jakarta.annotation.Generated("org.hibernate.orm.build.annotations.ClassGeneratorProcessor")
@@ -37,8 +33,8 @@ public class OnDeleteAnnotation implements OnDelete {
 	/**
 	 * Used in creating annotation instances from Jandex variant
 	 */
-	public OnDeleteAnnotation(AnnotationInstance annotation, SourceModelBuildingContext modelContext) {
-		this.action = extractJandexValue( annotation, HibernateAnnotations.ON_DELETE, "action", modelContext );
+	public OnDeleteAnnotation(Map<String, Object> attributeValues, SourceModelBuildingContext modelContext) {
+		this.action = (org.hibernate.annotations.OnDeleteAction) attributeValues.get( "action" );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/OneToManyJpaAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/OneToManyJpaAnnotation.java
@@ -7,16 +7,12 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
-import org.hibernate.boot.models.JpaAnnotations;
 import org.hibernate.boot.models.annotations.spi.AttributeMarker;
 import org.hibernate.models.spi.SourceModelBuildingContext;
 
-import org.jboss.jandex.AnnotationInstance;
-
 import jakarta.persistence.OneToMany;
-
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJandexValue;
 
 @SuppressWarnings({ "ClassExplicitlyAnnotation", "unused" })
 @jakarta.annotation.Generated("org.hibernate.orm.build.annotations.ClassGeneratorProcessor")
@@ -52,17 +48,12 @@ public class OneToManyJpaAnnotation implements OneToMany, AttributeMarker.Fetcha
 	/**
 	 * Used in creating annotation instances from Jandex variant
 	 */
-	public OneToManyJpaAnnotation(AnnotationInstance annotation, SourceModelBuildingContext modelContext) {
-		this.targetEntity = extractJandexValue( annotation, JpaAnnotations.ONE_TO_MANY, "targetEntity", modelContext );
-		this.cascade = extractJandexValue( annotation, JpaAnnotations.ONE_TO_MANY, "cascade", modelContext );
-		this.fetch = extractJandexValue( annotation, JpaAnnotations.ONE_TO_MANY, "fetch", modelContext );
-		this.mappedBy = extractJandexValue( annotation, JpaAnnotations.ONE_TO_MANY, "mappedBy", modelContext );
-		this.orphanRemoval = extractJandexValue(
-				annotation,
-				JpaAnnotations.ONE_TO_MANY,
-				"orphanRemoval",
-				modelContext
-		);
+	public OneToManyJpaAnnotation(Map<String, Object> attributeValues, SourceModelBuildingContext modelContext) {
+		this.targetEntity = (Class<?>) attributeValues.get( "targetEntity" );
+		this.cascade = (jakarta.persistence.CascadeType[]) attributeValues.get( "cascade" );
+		this.fetch = (jakarta.persistence.FetchType) attributeValues.get( "fetch" );
+		this.mappedBy = (String) attributeValues.get( "mappedBy" );
+		this.orphanRemoval = (boolean) attributeValues.get( "orphanRemoval" );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/OneToOneJpaAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/OneToOneJpaAnnotation.java
@@ -7,16 +7,12 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
-import org.hibernate.boot.models.JpaAnnotations;
 import org.hibernate.boot.models.annotations.spi.AttributeMarker;
 import org.hibernate.models.spi.SourceModelBuildingContext;
 
-import org.jboss.jandex.AnnotationInstance;
-
 import jakarta.persistence.OneToOne;
-
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJandexValue;
 
 @SuppressWarnings({ "ClassExplicitlyAnnotation", "unused" })
 @jakarta.annotation.Generated("org.hibernate.orm.build.annotations.ClassGeneratorProcessor")
@@ -56,13 +52,13 @@ public class OneToOneJpaAnnotation
 	/**
 	 * Used in creating annotation instances from Jandex variant
 	 */
-	public OneToOneJpaAnnotation(AnnotationInstance annotation, SourceModelBuildingContext modelContext) {
-		this.targetEntity = extractJandexValue( annotation, JpaAnnotations.ONE_TO_ONE, "targetEntity", modelContext );
-		this.cascade = extractJandexValue( annotation, JpaAnnotations.ONE_TO_ONE, "cascade", modelContext );
-		this.fetch = extractJandexValue( annotation, JpaAnnotations.ONE_TO_ONE, "fetch", modelContext );
-		this.optional = extractJandexValue( annotation, JpaAnnotations.ONE_TO_ONE, "optional", modelContext );
-		this.mappedBy = extractJandexValue( annotation, JpaAnnotations.ONE_TO_ONE, "mappedBy", modelContext );
-		this.orphanRemoval = extractJandexValue( annotation, JpaAnnotations.ONE_TO_ONE, "orphanRemoval", modelContext );
+	public OneToOneJpaAnnotation(Map<String, Object> attributeValues, SourceModelBuildingContext modelContext) {
+		this.targetEntity = (Class<?>) attributeValues.get( "targetEntity" );
+		this.cascade = (jakarta.persistence.CascadeType[]) attributeValues.get( "cascade" );
+		this.fetch = (jakarta.persistence.FetchType) attributeValues.get( "fetch" );
+		this.optional = (boolean) attributeValues.get( "optional" );
+		this.mappedBy = (String) attributeValues.get( "mappedBy" );
+		this.orphanRemoval = (boolean) attributeValues.get( "orphanRemoval" );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/OptimisticLockAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/OptimisticLockAnnotation.java
@@ -7,14 +7,10 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
 import org.hibernate.annotations.OptimisticLock;
-import org.hibernate.boot.models.HibernateAnnotations;
 import org.hibernate.models.spi.SourceModelBuildingContext;
-
-import org.jboss.jandex.AnnotationInstance;
-
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJandexValue;
 
 @SuppressWarnings({ "ClassExplicitlyAnnotation", "unused" })
 @jakarta.annotation.Generated("org.hibernate.orm.build.annotations.ClassGeneratorProcessor")
@@ -37,13 +33,8 @@ public class OptimisticLockAnnotation implements OptimisticLock {
 	/**
 	 * Used in creating annotation instances from Jandex variant
 	 */
-	public OptimisticLockAnnotation(AnnotationInstance annotation, SourceModelBuildingContext modelContext) {
-		this.excluded = extractJandexValue(
-				annotation,
-				HibernateAnnotations.OPTIMISTIC_LOCK,
-				"excluded",
-				modelContext
-		);
+	public OptimisticLockAnnotation(Map<String, Object> attributeValues, SourceModelBuildingContext modelContext) {
+		this.excluded = (boolean) attributeValues.get( "excluded" );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/OptimisticLockingAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/OptimisticLockingAnnotation.java
@@ -7,14 +7,10 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
 import org.hibernate.annotations.OptimisticLocking;
-import org.hibernate.boot.models.HibernateAnnotations;
 import org.hibernate.models.spi.SourceModelBuildingContext;
-
-import org.jboss.jandex.AnnotationInstance;
-
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJandexValue;
 
 @SuppressWarnings({ "ClassExplicitlyAnnotation", "unused" })
 @jakarta.annotation.Generated("org.hibernate.orm.build.annotations.ClassGeneratorProcessor")
@@ -38,8 +34,8 @@ public class OptimisticLockingAnnotation implements OptimisticLocking {
 	/**
 	 * Used in creating annotation instances from Jandex variant
 	 */
-	public OptimisticLockingAnnotation(AnnotationInstance annotation, SourceModelBuildingContext modelContext) {
-		this.type = extractJandexValue( annotation, HibernateAnnotations.OPTIMISTIC_LOCKING, "type", modelContext );
+	public OptimisticLockingAnnotation(Map<String, Object> attributeValues, SourceModelBuildingContext modelContext) {
+		this.type = (org.hibernate.annotations.OptimisticLockType) attributeValues.get( "type" );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/OrderByAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/OrderByAnnotation.java
@@ -7,30 +7,35 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
 import org.hibernate.annotations.OrderBy;
-import org.hibernate.boot.models.HibernateAnnotations;
 import org.hibernate.models.spi.SourceModelBuildingContext;
-
-import org.jboss.jandex.AnnotationInstance;
-
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJandexValue;
 
 @SuppressWarnings({ "ClassExplicitlyAnnotation", "unused" })
 @jakarta.annotation.Generated("org.hibernate.orm.build.annotations.ClassGeneratorProcessor")
 public class OrderByAnnotation implements OrderBy {
 	private String clause;
 
+	/**
+	 * Used in creating dynamic annotation instances (e.g. from XML)
+	 */
 	public OrderByAnnotation(SourceModelBuildingContext modelContext) {
 		this.clause = "";
 	}
 
+	/**
+	 * Used in creating annotation instances from JDK variant
+	 */
 	public OrderByAnnotation(OrderBy annotation, SourceModelBuildingContext modelContext) {
 		clause = annotation.clause();
 	}
 
-	public OrderByAnnotation(AnnotationInstance annotation, SourceModelBuildingContext modelContext) {
-		clause = extractJandexValue( annotation, HibernateAnnotations.ORDER_BY, "clause", modelContext );
+	/**
+	 * Used in creating annotation instances from Jandex variant
+	 */
+	public OrderByAnnotation(Map<String, Object> attributeValues, SourceModelBuildingContext modelContext) {
+		clause = (String) attributeValues.get( "clause" );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/OrderByJpaAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/OrderByJpaAnnotation.java
@@ -7,15 +7,11 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
-import org.hibernate.boot.models.JpaAnnotations;
 import org.hibernate.models.spi.SourceModelBuildingContext;
 
-import org.jboss.jandex.AnnotationInstance;
-
 import jakarta.persistence.OrderBy;
-
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJandexValue;
 
 @SuppressWarnings({ "ClassExplicitlyAnnotation", "unused" })
 @jakarta.annotation.Generated("org.hibernate.orm.build.annotations.ClassGeneratorProcessor")
@@ -39,8 +35,8 @@ public class OrderByJpaAnnotation implements OrderBy {
 	/**
 	 * Used in creating annotation instances from Jandex variant
 	 */
-	public OrderByJpaAnnotation(AnnotationInstance annotation, SourceModelBuildingContext modelContext) {
-		this.value = extractJandexValue( annotation, JpaAnnotations.ORDER_BY, "value", modelContext );
+	public OrderByJpaAnnotation(Map<String, Object> attributeValues, SourceModelBuildingContext modelContext) {
+		this.value = (String) attributeValues.get( "value" );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/OrderColumnJpaAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/OrderColumnJpaAnnotation.java
@@ -7,19 +7,15 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
 import org.hibernate.boot.jaxb.mapping.spi.JaxbOrderColumnImpl;
-import org.hibernate.boot.models.JpaAnnotations;
 import org.hibernate.boot.models.annotations.spi.ColumnDetails;
 import org.hibernate.boot.models.xml.spi.XmlDocumentContext;
 import org.hibernate.internal.util.StringHelper;
 import org.hibernate.models.spi.SourceModelBuildingContext;
 
-import org.jboss.jandex.AnnotationInstance;
-
 import jakarta.persistence.OrderColumn;
-
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJandexValue;
 
 @SuppressWarnings({ "ClassExplicitlyAnnotation", "unused" })
 @jakarta.annotation.Generated("org.hibernate.orm.build.annotations.ClassGeneratorProcessor")
@@ -62,18 +58,13 @@ public class OrderColumnJpaAnnotation implements OrderColumn,
 	/**
 	 * Used in creating annotation instances from Jandex variant
 	 */
-	public OrderColumnJpaAnnotation(AnnotationInstance annotation, SourceModelBuildingContext modelContext) {
-		this.name = extractJandexValue( annotation, JpaAnnotations.ORDER_COLUMN, "name", modelContext );
-		this.nullable = extractJandexValue( annotation, JpaAnnotations.ORDER_COLUMN, "nullable", modelContext );
-		this.insertable = extractJandexValue( annotation, JpaAnnotations.ORDER_COLUMN, "insertable", modelContext );
-		this.updatable = extractJandexValue( annotation, JpaAnnotations.ORDER_COLUMN, "updatable", modelContext );
-		this.columnDefinition = extractJandexValue(
-				annotation,
-				JpaAnnotations.ORDER_COLUMN,
-				"columnDefinition",
-				modelContext
-		);
-		this.options = extractJandexValue( annotation, JpaAnnotations.ORDER_COLUMN, "options", modelContext );
+	public OrderColumnJpaAnnotation(Map<String, Object> attributeValues, SourceModelBuildingContext modelContext) {
+		this.name = (String) attributeValues.get( "name" );
+		this.nullable = (boolean) attributeValues.get( "nullable" );
+		this.insertable = (boolean) attributeValues.get( "insertable" );
+		this.updatable = (boolean) attributeValues.get( "updatable" );
+		this.columnDefinition = (String) attributeValues.get( "columnDefinition" );
+		this.options = (String) attributeValues.get( "options" );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/OverriddenCheckAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/OverriddenCheckAnnotation.java
@@ -7,20 +7,17 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
 import org.hibernate.annotations.Check;
 import org.hibernate.annotations.DialectOverride;
-import org.hibernate.boot.models.DialectOverrideAnnotations;
 import org.hibernate.boot.models.HibernateAnnotations;
 import org.hibernate.boot.models.annotations.spi.AbstractOverrider;
 import org.hibernate.boot.models.annotations.spi.DialectOverrider;
 import org.hibernate.models.spi.AnnotationDescriptor;
 import org.hibernate.models.spi.SourceModelBuildingContext;
 
-import org.jboss.jandex.AnnotationInstance;
-
 import static org.hibernate.boot.models.DialectOverrideAnnotations.DIALECT_OVERRIDE_CHECK;
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJandexValue;
 import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJdkValue;
 
 /**
@@ -32,9 +29,15 @@ public class OverriddenCheckAnnotation
 		implements DialectOverride.Check, DialectOverrider<Check> {
 	private Check override;
 
+	/**
+	 * Used in creating dynamic annotation instances (e.g. from XML)
+	 */
 	public OverriddenCheckAnnotation(SourceModelBuildingContext modelContext) {
 	}
 
+	/**
+	 * Used in creating annotation instances from JDK variant
+	 */
 	public OverriddenCheckAnnotation(DialectOverride.Check annotation, SourceModelBuildingContext modelContext) {
 		dialect( annotation.dialect() );
 		before( annotation.before() );
@@ -42,9 +45,12 @@ public class OverriddenCheckAnnotation
 		override( extractJdkValue( annotation, DIALECT_OVERRIDE_CHECK, "override", modelContext ) );
 	}
 
-	public OverriddenCheckAnnotation(AnnotationInstance annotation, SourceModelBuildingContext modelContext) {
-		super( annotation, DIALECT_OVERRIDE_CHECK, modelContext );
-		override( extractJandexValue( annotation, DIALECT_OVERRIDE_CHECK, "override", modelContext ) );
+	/**
+	 * Used in creating annotation instances from Jandex variant
+	 */
+	public OverriddenCheckAnnotation(Map<String, Object> attributeValues, SourceModelBuildingContext modelContext) {
+		super( attributeValues, DIALECT_OVERRIDE_CHECK, modelContext );
+		override( (Check) attributeValues.get( "override" ) );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/OverriddenChecksAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/OverriddenChecksAnnotation.java
@@ -7,15 +7,13 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
 import org.hibernate.annotations.DialectOverride;
 import org.hibernate.boot.models.DialectOverrideAnnotations;
 import org.hibernate.boot.models.annotations.spi.RepeatableContainer;
 import org.hibernate.models.spi.SourceModelBuildingContext;
 
-import org.jboss.jandex.AnnotationInstance;
-
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJandexValue;
 import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJdkValue;
 
 /**
@@ -26,20 +24,24 @@ public class OverriddenChecksAnnotation
 		implements DialectOverride.Checks, RepeatableContainer<DialectOverride.Check> {
 	private DialectOverride.Check[] value;
 
+	/**
+	 * Used in creating dynamic annotation instances (e.g. from XML)
+	 */
 	public OverriddenChecksAnnotation(SourceModelBuildingContext modelContext) {
 	}
 
-	public OverriddenChecksAnnotation(DialectOverride.Checks source, SourceModelBuildingContext modelContext) {
-		value( extractJdkValue( source, DialectOverrideAnnotations.DIALECT_OVERRIDE_CHECKS, "value", modelContext ) );
+	/**
+	 * Used in creating annotation instances from JDK variant
+	 */
+	public OverriddenChecksAnnotation(DialectOverride.Checks annotation, SourceModelBuildingContext modelContext) {
+		value( extractJdkValue( annotation, DialectOverrideAnnotations.DIALECT_OVERRIDE_CHECKS, "value", modelContext ) );
 	}
 
-	public OverriddenChecksAnnotation(AnnotationInstance source, SourceModelBuildingContext modelContext) {
-		value( extractJandexValue(
-				source,
-				DialectOverrideAnnotations.DIALECT_OVERRIDE_CHECKS,
-				"value",
-				modelContext
-		) );
+	/**
+	 * Used in creating annotation instances from Jandex variant
+	 */
+	public OverriddenChecksAnnotation(Map<String, Object> attributeValues, SourceModelBuildingContext modelContext) {
+		value( (DialectOverride.Check[]) attributeValues.get( "value" ) );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/OverriddenColumnDefaultAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/OverriddenColumnDefaultAnnotation.java
@@ -7,20 +7,17 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
 import org.hibernate.annotations.ColumnDefault;
 import org.hibernate.annotations.DialectOverride;
-import org.hibernate.boot.models.DialectOverrideAnnotations;
 import org.hibernate.boot.models.HibernateAnnotations;
 import org.hibernate.boot.models.annotations.spi.AbstractOverrider;
 import org.hibernate.boot.models.annotations.spi.DialectOverrider;
 import org.hibernate.models.spi.AnnotationDescriptor;
 import org.hibernate.models.spi.SourceModelBuildingContext;
 
-import org.jboss.jandex.AnnotationInstance;
-
 import static org.hibernate.boot.models.DialectOverrideAnnotations.DIALECT_OVERRIDE_COLUMN_DEFAULT;
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJandexValue;
 import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJdkValue;
 
 /**
@@ -32,9 +29,15 @@ public class OverriddenColumnDefaultAnnotation
 		implements DialectOverride.ColumnDefault, DialectOverrider<ColumnDefault> {
 	private ColumnDefault override;
 
+	/**
+	 * Used in creating dynamic annotation instances (e.g. from XML)
+	 */
 	public OverriddenColumnDefaultAnnotation(SourceModelBuildingContext modelContext) {
 	}
 
+	/**
+	 * Used in creating annotation instances from JDK variant
+	 */
 	public OverriddenColumnDefaultAnnotation(
 			DialectOverride.ColumnDefault annotation,
 			SourceModelBuildingContext modelContext) {
@@ -44,9 +47,14 @@ public class OverriddenColumnDefaultAnnotation
 		override( extractJdkValue( annotation, DIALECT_OVERRIDE_COLUMN_DEFAULT, "override", modelContext ) );
 	}
 
-	public OverriddenColumnDefaultAnnotation(AnnotationInstance annotation, SourceModelBuildingContext modelContext) {
-		super( annotation, DIALECT_OVERRIDE_COLUMN_DEFAULT, modelContext );
-		override( extractJandexValue( annotation, DIALECT_OVERRIDE_COLUMN_DEFAULT, "override", modelContext ) );
+	/**
+	 * Used in creating annotation instances from Jandex variant
+	 */
+	public OverriddenColumnDefaultAnnotation(
+			Map<String, Object> attributeValues,
+			SourceModelBuildingContext modelContext) {
+		super( attributeValues, DIALECT_OVERRIDE_COLUMN_DEFAULT, modelContext );
+		override( (ColumnDefault) attributeValues.get( "override" ) );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/OverriddenColumnDefaultsAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/OverriddenColumnDefaultsAnnotation.java
@@ -7,15 +7,13 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
 import org.hibernate.annotations.DialectOverride;
 import org.hibernate.boot.models.annotations.spi.RepeatableContainer;
 import org.hibernate.models.spi.SourceModelBuildingContext;
 
-import org.jboss.jandex.AnnotationInstance;
-
 import static org.hibernate.boot.models.DialectOverrideAnnotations.DIALECT_OVERRIDE_COLUMN_DEFAULTS;
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJandexValue;
 import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJdkValue;
 
 /**
@@ -45,8 +43,10 @@ public class OverriddenColumnDefaultsAnnotation
 	/**
 	 * Used in creating annotation instances from Jandex variant
 	 */
-	public OverriddenColumnDefaultsAnnotation(AnnotationInstance annotation, SourceModelBuildingContext modelContext) {
-		this.value = extractJandexValue( annotation, DIALECT_OVERRIDE_COLUMN_DEFAULTS, "value", modelContext );
+	public OverriddenColumnDefaultsAnnotation(
+			Map<String, Object> attributeValues,
+			SourceModelBuildingContext modelContext) {
+		this.value = (DialectOverride.ColumnDefault[]) attributeValues.get( "value" );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/OverriddenDiscriminatorFormulaAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/OverriddenDiscriminatorFormulaAnnotation.java
@@ -7,20 +7,17 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
 import org.hibernate.annotations.DialectOverride;
 import org.hibernate.annotations.DiscriminatorFormula;
-import org.hibernate.boot.models.DialectOverrideAnnotations;
 import org.hibernate.boot.models.HibernateAnnotations;
 import org.hibernate.boot.models.annotations.spi.AbstractOverrider;
 import org.hibernate.boot.models.annotations.spi.DialectOverrider;
 import org.hibernate.models.spi.AnnotationDescriptor;
 import org.hibernate.models.spi.SourceModelBuildingContext;
 
-import org.jboss.jandex.AnnotationInstance;
-
 import static org.hibernate.boot.models.DialectOverrideAnnotations.DIALECT_OVERRIDE_DISCRIMINATOR_FORMULA;
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJandexValue;
 import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJdkValue;
 
 /**
@@ -32,9 +29,15 @@ public class OverriddenDiscriminatorFormulaAnnotation
 		implements DialectOverride.DiscriminatorFormula, DialectOverrider<DiscriminatorFormula> {
 	private DiscriminatorFormula override;
 
+	/**
+	 * Used in creating dynamic annotation instances (e.g. from XML)
+	 */
 	public OverriddenDiscriminatorFormulaAnnotation(SourceModelBuildingContext modelContext) {
 	}
 
+	/**
+	 * Used in creating annotation instances from JDK variant
+	 */
 	public OverriddenDiscriminatorFormulaAnnotation(
 			DialectOverride.DiscriminatorFormula annotation,
 			SourceModelBuildingContext modelContext) {
@@ -44,11 +47,14 @@ public class OverriddenDiscriminatorFormulaAnnotation
 		override( extractJdkValue( annotation, DIALECT_OVERRIDE_DISCRIMINATOR_FORMULA, "override", modelContext ) );
 	}
 
+	/**
+	 * Used in creating annotation instances from Jandex variant
+	 */
 	public OverriddenDiscriminatorFormulaAnnotation(
-			AnnotationInstance annotation,
+			Map<String, Object> attributeValues,
 			SourceModelBuildingContext modelContext) {
-		super( annotation, DIALECT_OVERRIDE_DISCRIMINATOR_FORMULA, modelContext );
-		override( extractJandexValue( annotation, DIALECT_OVERRIDE_DISCRIMINATOR_FORMULA, "override", modelContext ) );
+		super( attributeValues, DIALECT_OVERRIDE_DISCRIMINATOR_FORMULA, modelContext );
+		override( (DiscriminatorFormula) attributeValues.get( "override" ) );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/OverriddenDiscriminatorFormulasAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/OverriddenDiscriminatorFormulasAnnotation.java
@@ -7,15 +7,13 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
 import org.hibernate.annotations.DialectOverride;
 import org.hibernate.boot.models.annotations.spi.RepeatableContainer;
 import org.hibernate.models.spi.SourceModelBuildingContext;
 
-import org.jboss.jandex.AnnotationInstance;
-
 import static org.hibernate.boot.models.DialectOverrideAnnotations.DIALECT_OVERRIDE_DISCRIMINATOR_FORMULAS;
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJandexValue;
 import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJdkValue;
 
 /**
@@ -46,9 +44,9 @@ public class OverriddenDiscriminatorFormulasAnnotation
 	 * Used in creating annotation instances from Jandex variant
 	 */
 	public OverriddenDiscriminatorFormulasAnnotation(
-			AnnotationInstance annotation,
+			Map<String, Object> attributeValues,
 			SourceModelBuildingContext modelContext) {
-		this.value = extractJandexValue( annotation, DIALECT_OVERRIDE_DISCRIMINATOR_FORMULAS, "value", modelContext );
+		this.value = (DialectOverride.DiscriminatorFormula[]) attributeValues.get( "value" );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/OverriddenFilterDefOverridesAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/OverriddenFilterDefOverridesAnnotation.java
@@ -7,15 +7,13 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
 import org.hibernate.annotations.DialectOverride;
 import org.hibernate.boot.models.annotations.spi.RepeatableContainer;
 import org.hibernate.models.spi.SourceModelBuildingContext;
 
-import org.jboss.jandex.AnnotationInstance;
-
 import static org.hibernate.boot.models.DialectOverrideAnnotations.DIALECT_OVERRIDE_FILTER_DEF_OVERRIDES;
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJandexValue;
 import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJdkValue;
 
 /**
@@ -45,9 +43,9 @@ public class OverriddenFilterDefOverridesAnnotation
 	 * Used in creating annotation instances from Jandex variant
 	 */
 	public OverriddenFilterDefOverridesAnnotation(
-			AnnotationInstance annotation,
+			Map<String, Object> attributeValues,
 			SourceModelBuildingContext modelContext) {
-		this.value = extractJandexValue( annotation, DIALECT_OVERRIDE_FILTER_DEF_OVERRIDES, "value", modelContext );
+		this.value = (DialectOverride.FilterDefs[]) attributeValues.get( "value" );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/OverriddenFilterDefsAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/OverriddenFilterDefsAnnotation.java
@@ -7,6 +7,7 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
 import org.hibernate.annotations.DialectOverride;
 import org.hibernate.annotations.FilterDefs;
@@ -16,10 +17,7 @@ import org.hibernate.boot.models.annotations.spi.DialectOverrider;
 import org.hibernate.models.spi.AnnotationDescriptor;
 import org.hibernate.models.spi.SourceModelBuildingContext;
 
-import org.jboss.jandex.AnnotationInstance;
-
 import static org.hibernate.boot.models.DialectOverrideAnnotations.DIALECT_OVERRIDE_FILTER_DEFS;
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJandexValue;
 import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJdkValue;
 
 /**
@@ -31,19 +29,32 @@ public class OverriddenFilterDefsAnnotation
 		implements DialectOverride.FilterDefs, DialectOverrider<FilterDefs> {
 	private FilterDefs override;
 
+	/**
+	 * Used in creating dynamic annotation instances (e.g. from XML)
+	 */
 	public OverriddenFilterDefsAnnotation(SourceModelBuildingContext modelContext) {
 	}
 
-	public OverriddenFilterDefsAnnotation(DialectOverride.FilterDefs source, SourceModelBuildingContext modelContext) {
-		dialect( source.dialect() );
-		before( source.before() );
-		sameOrAfter( source.sameOrAfter() );
-		override( extractJdkValue( source, DIALECT_OVERRIDE_FILTER_DEFS, "override", modelContext ) );
+	/**
+	 * Used in creating annotation instances from JDK variant
+	 */
+	public OverriddenFilterDefsAnnotation(
+			DialectOverride.FilterDefs annotation,
+			SourceModelBuildingContext modelContext) {
+		dialect( annotation.dialect() );
+		before( annotation.before() );
+		sameOrAfter( annotation.sameOrAfter() );
+		override( extractJdkValue( annotation, DIALECT_OVERRIDE_FILTER_DEFS, "override", modelContext ) );
 	}
 
-	public OverriddenFilterDefsAnnotation(AnnotationInstance source, SourceModelBuildingContext modelContext) {
-		super( source, DIALECT_OVERRIDE_FILTER_DEFS, modelContext );
-		override( extractJandexValue( source, DIALECT_OVERRIDE_FILTER_DEFS, "override", modelContext ) );
+	/**
+	 * Used in creating annotation instances from Jandex variant
+	 */
+	public OverriddenFilterDefsAnnotation(
+			Map<String, Object> attributeValues,
+			SourceModelBuildingContext modelContext) {
+		super( attributeValues, DIALECT_OVERRIDE_FILTER_DEFS, modelContext );
+		override( (FilterDefs) attributeValues.get( "override" ) );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/OverriddenFilterOverridesAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/OverriddenFilterOverridesAnnotation.java
@@ -7,15 +7,13 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
 import org.hibernate.annotations.DialectOverride;
 import org.hibernate.boot.models.annotations.spi.RepeatableContainer;
 import org.hibernate.models.spi.SourceModelBuildingContext;
 
-import org.jboss.jandex.AnnotationInstance;
-
 import static org.hibernate.boot.models.DialectOverrideAnnotations.DIALECT_OVERRIDE_FILTER_OVERRIDES;
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJandexValue;
 import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJdkValue;
 
 /**
@@ -44,8 +42,10 @@ public class OverriddenFilterOverridesAnnotation
 	/**
 	 * Used in creating annotation instances from Jandex variant
 	 */
-	public OverriddenFilterOverridesAnnotation(AnnotationInstance annotation, SourceModelBuildingContext modelContext) {
-		this.value = extractJandexValue( annotation, DIALECT_OVERRIDE_FILTER_OVERRIDES, "value", modelContext );
+	public OverriddenFilterOverridesAnnotation(
+			Map<String, Object> attributeValues,
+			SourceModelBuildingContext modelContext) {
+		this.value = (DialectOverride.Filters[]) attributeValues.get( "value" );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/OverriddenFiltersAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/OverriddenFiltersAnnotation.java
@@ -7,20 +7,17 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
 import org.hibernate.annotations.DialectOverride;
 import org.hibernate.annotations.Filters;
-import org.hibernate.boot.models.DialectOverrideAnnotations;
 import org.hibernate.boot.models.HibernateAnnotations;
 import org.hibernate.boot.models.annotations.spi.AbstractOverrider;
 import org.hibernate.boot.models.annotations.spi.DialectOverrider;
 import org.hibernate.models.spi.AnnotationDescriptor;
 import org.hibernate.models.spi.SourceModelBuildingContext;
 
-import org.jboss.jandex.AnnotationInstance;
-
 import static org.hibernate.boot.models.DialectOverrideAnnotations.DIALECT_OVERRIDE_FILTERS;
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJandexValue;
 import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJdkValue;
 
 /**
@@ -32,19 +29,32 @@ public class OverriddenFiltersAnnotation
 		implements DialectOverride.Filters, DialectOverrider<Filters> {
 	private Filters override;
 
+	/**
+	 * Used in creating dynamic annotation instances (e.g. from XML)
+	 */
 	public OverriddenFiltersAnnotation(SourceModelBuildingContext sourceModelContext) {
 	}
 
-	public OverriddenFiltersAnnotation(DialectOverride.Filters source, SourceModelBuildingContext sourceModelContext) {
-		dialect( source.dialect() );
-		before( source.before() );
-		sameOrAfter( source.sameOrAfter() );
-		override( extractJdkValue( source, DIALECT_OVERRIDE_FILTERS, "override", sourceModelContext ) );
+	/**
+	 * Used in creating annotation instances from JDK variant
+	 */
+	public OverriddenFiltersAnnotation(
+			DialectOverride.Filters annotation,
+			SourceModelBuildingContext sourceModelContext) {
+		dialect( annotation.dialect() );
+		before( annotation.before() );
+		sameOrAfter( annotation.sameOrAfter() );
+		override( extractJdkValue( annotation, DIALECT_OVERRIDE_FILTERS, "override", sourceModelContext ) );
 	}
 
-	public OverriddenFiltersAnnotation(AnnotationInstance source, SourceModelBuildingContext sourceModelContext) {
-		super( source, DIALECT_OVERRIDE_FILTERS, sourceModelContext );
-		override( extractJandexValue( source, DIALECT_OVERRIDE_FILTERS, "override", sourceModelContext ) );
+	/**
+	 * Used in creating annotation instances from Jandex variant
+	 */
+	public OverriddenFiltersAnnotation(
+			Map<String, Object> attributeValues,
+			SourceModelBuildingContext sourceModelContext) {
+		super( attributeValues, DIALECT_OVERRIDE_FILTERS, sourceModelContext );
+		override( (Filters) attributeValues.get( "override" ) );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/OverriddenFormulaAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/OverriddenFormulaAnnotation.java
@@ -7,6 +7,7 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
 import org.hibernate.annotations.DialectOverride;
 import org.hibernate.annotations.Formula;
@@ -16,10 +17,7 @@ import org.hibernate.boot.models.annotations.spi.DialectOverrider;
 import org.hibernate.models.spi.AnnotationDescriptor;
 import org.hibernate.models.spi.SourceModelBuildingContext;
 
-import org.jboss.jandex.AnnotationInstance;
-
 import static org.hibernate.boot.models.DialectOverrideAnnotations.DIALECT_OVERRIDE_FORMULA;
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJandexValue;
 import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJdkValue;
 
 /**
@@ -31,19 +29,32 @@ public class OverriddenFormulaAnnotation
 		implements DialectOverride.Formula, DialectOverrider<Formula> {
 	private Formula override;
 
+	/**
+	 * Used in creating dynamic annotation instances (e.g. from XML)
+	 */
 	public OverriddenFormulaAnnotation(SourceModelBuildingContext sourceModelContext) {
 	}
 
-	public OverriddenFormulaAnnotation(DialectOverride.Formula source, SourceModelBuildingContext sourceModelContext) {
-		dialect( source.dialect() );
-		before( source.before() );
-		sameOrAfter( source.sameOrAfter() );
-		override( extractJdkValue( source, DIALECT_OVERRIDE_FORMULA, "override", sourceModelContext ) );
+	/**
+	 * Used in creating annotation instances from JDK variant
+	 */
+	public OverriddenFormulaAnnotation(
+			DialectOverride.Formula annotation,
+			SourceModelBuildingContext sourceModelContext) {
+		dialect( annotation.dialect() );
+		before( annotation.before() );
+		sameOrAfter( annotation.sameOrAfter() );
+		override( extractJdkValue( annotation, DIALECT_OVERRIDE_FORMULA, "override", sourceModelContext ) );
 	}
 
-	public OverriddenFormulaAnnotation(AnnotationInstance source, SourceModelBuildingContext sourceModelContext) {
-		super( source, DIALECT_OVERRIDE_FORMULA, sourceModelContext );
-		override( extractJandexValue( source, DIALECT_OVERRIDE_FORMULA, "override", sourceModelContext ) );
+	/**
+	 * Used in creating annotation instances from Jandex variant
+	 */
+	public OverriddenFormulaAnnotation(
+			Map<String, Object> attributeValues,
+			SourceModelBuildingContext sourceModelContext) {
+		super( attributeValues, DIALECT_OVERRIDE_FORMULA, sourceModelContext );
+		override( (Formula) attributeValues.get( "override" ) );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/OverriddenFormulasAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/OverriddenFormulasAnnotation.java
@@ -7,15 +7,13 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
 import org.hibernate.annotations.DialectOverride;
 import org.hibernate.boot.models.annotations.spi.RepeatableContainer;
 import org.hibernate.models.spi.SourceModelBuildingContext;
 
-import org.jboss.jandex.AnnotationInstance;
-
 import static org.hibernate.boot.models.DialectOverrideAnnotations.DIALECT_OVERRIDE_FORMULAS;
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJandexValue;
 import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJdkValue;
 
 /**
@@ -42,8 +40,8 @@ public class OverriddenFormulasAnnotation
 	/**
 	 * Used in creating annotation instances from Jandex variant
 	 */
-	public OverriddenFormulasAnnotation(AnnotationInstance annotation, SourceModelBuildingContext modelContext) {
-		this.value = extractJandexValue( annotation, DIALECT_OVERRIDE_FORMULAS, "value", modelContext );
+	public OverriddenFormulasAnnotation(Map<String, Object> attributeValues, SourceModelBuildingContext modelContext) {
+		this.value = (DialectOverride.Formula[]) attributeValues.get( "value" );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/OverriddenGeneratedColumnAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/OverriddenGeneratedColumnAnnotation.java
@@ -7,6 +7,7 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
 import org.hibernate.annotations.DialectOverride;
 import org.hibernate.annotations.GeneratedColumn;
@@ -16,10 +17,7 @@ import org.hibernate.boot.models.annotations.spi.DialectOverrider;
 import org.hibernate.models.spi.AnnotationDescriptor;
 import org.hibernate.models.spi.SourceModelBuildingContext;
 
-import org.jboss.jandex.AnnotationInstance;
-
 import static org.hibernate.boot.models.DialectOverrideAnnotations.DIALECT_OVERRIDE_GENERATED_COLUMN;
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJandexValue;
 import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJdkValue;
 
 /**
@@ -31,23 +29,32 @@ public class OverriddenGeneratedColumnAnnotation
 		implements DialectOverride.GeneratedColumn, DialectOverrider<GeneratedColumn> {
 	private GeneratedColumn override;
 
+	/**
+	 * Used in creating dynamic annotation instances (e.g. from XML)
+	 */
 	public OverriddenGeneratedColumnAnnotation(SourceModelBuildingContext sourceModelContext) {
 	}
 
+	/**
+	 * Used in creating annotation instances from JDK variant
+	 */
 	public OverriddenGeneratedColumnAnnotation(
-			DialectOverride.GeneratedColumn source,
+			DialectOverride.GeneratedColumn annotation,
 			SourceModelBuildingContext sourceModelContext) {
-		dialect( source.dialect() );
-		before( source.before() );
-		sameOrAfter( source.sameOrAfter() );
-		override( extractJdkValue( source, DIALECT_OVERRIDE_GENERATED_COLUMN, "override", sourceModelContext ) );
+		dialect( annotation.dialect() );
+		before( annotation.before() );
+		sameOrAfter( annotation.sameOrAfter() );
+		override( extractJdkValue( annotation, DIALECT_OVERRIDE_GENERATED_COLUMN, "override", sourceModelContext ) );
 	}
 
+	/**
+	 * Used in creating annotation instances from Jandex variant
+	 */
 	public OverriddenGeneratedColumnAnnotation(
-			AnnotationInstance source,
+			Map<String, Object> attributeValues,
 			SourceModelBuildingContext sourceModelContext) {
-		super( source, DIALECT_OVERRIDE_GENERATED_COLUMN, sourceModelContext );
-		override( extractJandexValue( source, DIALECT_OVERRIDE_GENERATED_COLUMN, "override", sourceModelContext ) );
+		super( attributeValues, DIALECT_OVERRIDE_GENERATED_COLUMN, sourceModelContext );
+		override( (GeneratedColumn) attributeValues.get( "override" ) );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/OverriddenGeneratedColumnsAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/OverriddenGeneratedColumnsAnnotation.java
@@ -7,15 +7,13 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
 import org.hibernate.annotations.DialectOverride;
 import org.hibernate.boot.models.annotations.spi.RepeatableContainer;
 import org.hibernate.models.spi.SourceModelBuildingContext;
 
-import org.jboss.jandex.AnnotationInstance;
-
 import static org.hibernate.boot.models.DialectOverrideAnnotations.DIALECT_OVERRIDE_GENERATED_COLUMNS;
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJandexValue;
 import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJdkValue;
 
 /**
@@ -45,9 +43,9 @@ public class OverriddenGeneratedColumnsAnnotation
 	 * Used in creating annotation instances from Jandex variant
 	 */
 	public OverriddenGeneratedColumnsAnnotation(
-			AnnotationInstance annotation,
+			Map<String, Object> attributeValues,
 			SourceModelBuildingContext modelContext) {
-		this.value = extractJandexValue( annotation, DIALECT_OVERRIDE_GENERATED_COLUMNS, "value", modelContext );
+		this.value = (DialectOverride.GeneratedColumn[]) attributeValues.get( "value" );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/OverriddenJoinFormulaAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/OverriddenJoinFormulaAnnotation.java
@@ -7,6 +7,7 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
 import org.hibernate.annotations.DialectOverride;
 import org.hibernate.annotations.JoinFormula;
@@ -16,10 +17,7 @@ import org.hibernate.boot.models.annotations.spi.DialectOverrider;
 import org.hibernate.models.spi.AnnotationDescriptor;
 import org.hibernate.models.spi.SourceModelBuildingContext;
 
-import org.jboss.jandex.AnnotationInstance;
-
 import static org.hibernate.boot.models.DialectOverrideAnnotations.DIALECT_OVERRIDE_JOIN_FORMULA;
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJandexValue;
 import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJdkValue;
 
 /**
@@ -31,21 +29,32 @@ public class OverriddenJoinFormulaAnnotation
 		implements DialectOverride.JoinFormula, DialectOverrider<JoinFormula> {
 	private JoinFormula override;
 
+	/**
+	 * Used in creating dynamic annotation instances (e.g. from XML)
+	 */
 	public OverriddenJoinFormulaAnnotation(SourceModelBuildingContext sourceModelContext) {
 	}
 
+	/**
+	 * Used in creating annotation instances from JDK variant
+	 */
 	public OverriddenJoinFormulaAnnotation(
-			DialectOverride.JoinFormula source,
+			DialectOverride.JoinFormula annotation,
 			SourceModelBuildingContext sourceModelContext) {
-		dialect( source.dialect() );
-		before( source.before() );
-		sameOrAfter( source.sameOrAfter() );
-		override( extractJdkValue( source, DIALECT_OVERRIDE_JOIN_FORMULA, "override", sourceModelContext ) );
+		dialect( annotation.dialect() );
+		before( annotation.before() );
+		sameOrAfter( annotation.sameOrAfter() );
+		override( extractJdkValue( annotation, DIALECT_OVERRIDE_JOIN_FORMULA, "override", sourceModelContext ) );
 	}
 
-	public OverriddenJoinFormulaAnnotation(AnnotationInstance source, SourceModelBuildingContext sourceModelContext) {
-		super( source, DIALECT_OVERRIDE_JOIN_FORMULA, sourceModelContext );
-		override( extractJandexValue( source, DIALECT_OVERRIDE_JOIN_FORMULA, "override", sourceModelContext ) );
+	/**
+	 * Used in creating annotation instances from Jandex variant
+	 */
+	public OverriddenJoinFormulaAnnotation(
+			Map<String, Object> attributeValues,
+			SourceModelBuildingContext sourceModelContext) {
+		super( attributeValues, DIALECT_OVERRIDE_JOIN_FORMULA, sourceModelContext );
+		override( (JoinFormula) attributeValues.get( "override" ) );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/OverriddenJoinFormulasAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/OverriddenJoinFormulasAnnotation.java
@@ -7,15 +7,13 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
 import org.hibernate.annotations.DialectOverride;
 import org.hibernate.boot.models.annotations.spi.RepeatableContainer;
 import org.hibernate.models.spi.SourceModelBuildingContext;
 
-import org.jboss.jandex.AnnotationInstance;
-
 import static org.hibernate.boot.models.DialectOverrideAnnotations.DIALECT_OVERRIDE_JOIN_FORMULAS;
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJandexValue;
 import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJdkValue;
 
 /**
@@ -44,8 +42,10 @@ public class OverriddenJoinFormulasAnnotation
 	/**
 	 * Used in creating annotation instances from Jandex variant
 	 */
-	public OverriddenJoinFormulasAnnotation(AnnotationInstance annotation, SourceModelBuildingContext modelContext) {
-		this.value = extractJandexValue( annotation, DIALECT_OVERRIDE_JOIN_FORMULAS, "value", modelContext );
+	public OverriddenJoinFormulasAnnotation(
+			Map<String, Object> attributeValues,
+			SourceModelBuildingContext modelContext) {
+		this.value = (DialectOverride.JoinFormula[]) attributeValues.get( "value" );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/OverriddenOrderByAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/OverriddenOrderByAnnotation.java
@@ -7,6 +7,7 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
 import org.hibernate.annotations.DialectOverride;
 import org.hibernate.annotations.OrderBy;
@@ -16,10 +17,7 @@ import org.hibernate.boot.models.annotations.spi.DialectOverrider;
 import org.hibernate.models.spi.AnnotationDescriptor;
 import org.hibernate.models.spi.SourceModelBuildingContext;
 
-import org.jboss.jandex.AnnotationInstance;
-
 import static org.hibernate.boot.models.DialectOverrideAnnotations.DIALECT_OVERRIDE_ORDER_BY;
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJandexValue;
 import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJdkValue;
 
 /**
@@ -31,19 +29,32 @@ public class OverriddenOrderByAnnotation
 		implements DialectOverride.OrderBy, DialectOverrider<OrderBy> {
 	private OrderBy override;
 
+	/**
+	 * Used in creating dynamic annotation instances (e.g. from XML)
+	 */
 	public OverriddenOrderByAnnotation(SourceModelBuildingContext sourceModelContext) {
 	}
 
-	public OverriddenOrderByAnnotation(DialectOverride.OrderBy source, SourceModelBuildingContext sourceModelContext) {
-		dialect( source.dialect() );
-		before( source.before() );
-		sameOrAfter( source.sameOrAfter() );
-		override( extractJdkValue( source, DIALECT_OVERRIDE_ORDER_BY, "override", sourceModelContext ) );
+	/**
+	 * Used in creating annotation instances from JDK variant
+	 */
+	public OverriddenOrderByAnnotation(
+			DialectOverride.OrderBy annotation,
+			SourceModelBuildingContext sourceModelContext) {
+		dialect( annotation.dialect() );
+		before( annotation.before() );
+		sameOrAfter( annotation.sameOrAfter() );
+		override( extractJdkValue( annotation, DIALECT_OVERRIDE_ORDER_BY, "override", sourceModelContext ) );
 	}
 
-	public OverriddenOrderByAnnotation(AnnotationInstance source, SourceModelBuildingContext sourceModelContext) {
-		super( source, DIALECT_OVERRIDE_ORDER_BY, sourceModelContext );
-		override( extractJandexValue( source, DIALECT_OVERRIDE_ORDER_BY, "override", sourceModelContext ) );
+	/**
+	 * Used in creating annotation instances from Jandex variant
+	 */
+	public OverriddenOrderByAnnotation(
+			Map<String, Object> attributeValues,
+			SourceModelBuildingContext sourceModelContext) {
+		super( attributeValues, DIALECT_OVERRIDE_ORDER_BY, sourceModelContext );
+		override( (OrderBy) attributeValues.get( "override" ) );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/OverriddenOrderBysAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/OverriddenOrderBysAnnotation.java
@@ -7,15 +7,13 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
 import org.hibernate.annotations.DialectOverride;
 import org.hibernate.boot.models.annotations.spi.RepeatableContainer;
 import org.hibernate.models.spi.SourceModelBuildingContext;
 
-import org.jboss.jandex.AnnotationInstance;
-
 import static org.hibernate.boot.models.DialectOverrideAnnotations.DIALECT_OVERRIDE_ORDER_BYS;
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJandexValue;
 import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJdkValue;
 
 /**
@@ -42,8 +40,8 @@ public class OverriddenOrderBysAnnotation
 	/**
 	 * Used in creating annotation instances from Jandex variant
 	 */
-	public OverriddenOrderBysAnnotation(AnnotationInstance annotation, SourceModelBuildingContext modelContext) {
-		this.value = extractJandexValue( annotation, DIALECT_OVERRIDE_ORDER_BYS, "value", modelContext );
+	public OverriddenOrderBysAnnotation(Map<String, Object> attributeValues, SourceModelBuildingContext modelContext) {
+		this.value = (DialectOverride.OrderBy[]) attributeValues.get( "value" );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/OverriddenSQLDeleteAllAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/OverriddenSQLDeleteAllAnnotation.java
@@ -7,6 +7,7 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
 import org.hibernate.annotations.DialectOverride;
 import org.hibernate.annotations.SQLDeleteAll;
@@ -16,10 +17,7 @@ import org.hibernate.boot.models.annotations.spi.DialectOverrider;
 import org.hibernate.models.spi.AnnotationDescriptor;
 import org.hibernate.models.spi.SourceModelBuildingContext;
 
-import org.jboss.jandex.AnnotationInstance;
-
 import static org.hibernate.boot.models.DialectOverrideAnnotations.DIALECT_OVERRIDE_SQL_DELETE_ALL;
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJandexValue;
 import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJdkValue;
 
 /**
@@ -31,21 +29,32 @@ public class OverriddenSQLDeleteAllAnnotation
 		implements DialectOverride.SQLDeleteAll, DialectOverrider<SQLDeleteAll> {
 	private SQLDeleteAll override;
 
+	/**
+	 * Used in creating dynamic annotation instances (e.g. from XML)
+	 */
 	public OverriddenSQLDeleteAllAnnotation(SourceModelBuildingContext sourceModelContext) {
 	}
 
+	/**
+	 * Used in creating annotation instances from JDK variant
+	 */
 	public OverriddenSQLDeleteAllAnnotation(
-			DialectOverride.SQLDeleteAll source,
+			DialectOverride.SQLDeleteAll annotation,
 			SourceModelBuildingContext sourceModelContext) {
-		dialect( source.dialect() );
-		before( source.before() );
-		sameOrAfter( source.sameOrAfter() );
-		override( extractJdkValue( source, DIALECT_OVERRIDE_SQL_DELETE_ALL, "override", sourceModelContext ) );
+		dialect( annotation.dialect() );
+		before( annotation.before() );
+		sameOrAfter( annotation.sameOrAfter() );
+		override( extractJdkValue( annotation, DIALECT_OVERRIDE_SQL_DELETE_ALL, "override", sourceModelContext ) );
 	}
 
-	public OverriddenSQLDeleteAllAnnotation(AnnotationInstance source, SourceModelBuildingContext sourceModelContext) {
-		super( source, DIALECT_OVERRIDE_SQL_DELETE_ALL, sourceModelContext );
-		override( extractJandexValue( source, DIALECT_OVERRIDE_SQL_DELETE_ALL, "override", sourceModelContext ) );
+	/**
+	 * Used in creating annotation instances from Jandex variant
+	 */
+	public OverriddenSQLDeleteAllAnnotation(
+			Map<String, Object> attributeValues,
+			SourceModelBuildingContext sourceModelContext) {
+		super( attributeValues, DIALECT_OVERRIDE_SQL_DELETE_ALL, sourceModelContext );
+		override( (SQLDeleteAll) attributeValues.get( "override" ) );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/OverriddenSQLDeleteAllsAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/OverriddenSQLDeleteAllsAnnotation.java
@@ -7,15 +7,13 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
 import org.hibernate.annotations.DialectOverride;
 import org.hibernate.boot.models.annotations.spi.RepeatableContainer;
 import org.hibernate.models.spi.SourceModelBuildingContext;
 
-import org.jboss.jandex.AnnotationInstance;
-
 import static org.hibernate.boot.models.DialectOverrideAnnotations.DIALECT_OVERRIDE_SQL_DELETE_ALLS;
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJandexValue;
 import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJdkValue;
 
 /**
@@ -44,8 +42,10 @@ public class OverriddenSQLDeleteAllsAnnotation
 	/**
 	 * Used in creating annotation instances from Jandex variant
 	 */
-	public OverriddenSQLDeleteAllsAnnotation(AnnotationInstance annotation, SourceModelBuildingContext modelContext) {
-		this.value = extractJandexValue( annotation, DIALECT_OVERRIDE_SQL_DELETE_ALLS, "value", modelContext );
+	public OverriddenSQLDeleteAllsAnnotation(
+			Map<String, Object> attributeValues,
+			SourceModelBuildingContext modelContext) {
+		this.value = (DialectOverride.SQLDeleteAll[]) attributeValues.get( "value" );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/OverriddenSQLDeleteAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/OverriddenSQLDeleteAnnotation.java
@@ -7,6 +7,7 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
 import org.hibernate.annotations.DialectOverride;
 import org.hibernate.annotations.SQLDelete;
@@ -16,10 +17,7 @@ import org.hibernate.boot.models.annotations.spi.DialectOverrider;
 import org.hibernate.models.spi.AnnotationDescriptor;
 import org.hibernate.models.spi.SourceModelBuildingContext;
 
-import org.jboss.jandex.AnnotationInstance;
-
 import static org.hibernate.boot.models.DialectOverrideAnnotations.DIALECT_OVERRIDE_SQL_DELETE;
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJandexValue;
 import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJdkValue;
 
 /**
@@ -31,21 +29,32 @@ public class OverriddenSQLDeleteAnnotation
 		implements DialectOverride.SQLDelete, DialectOverrider<SQLDelete> {
 	private SQLDelete override;
 
+	/**
+	 * Used in creating dynamic annotation instances (e.g. from XML)
+	 */
 	public OverriddenSQLDeleteAnnotation(SourceModelBuildingContext sourceModelContext) {
 	}
 
+	/**
+	 * Used in creating annotation instances from JDK variant
+	 */
 	public OverriddenSQLDeleteAnnotation(
-			DialectOverride.SQLDelete source,
+			DialectOverride.SQLDelete annotation,
 			SourceModelBuildingContext sourceModelContext) {
-		dialect( source.dialect() );
-		before( source.before() );
-		sameOrAfter( source.sameOrAfter() );
-		override( extractJdkValue( source, DIALECT_OVERRIDE_SQL_DELETE, "override", sourceModelContext ) );
+		dialect( annotation.dialect() );
+		before( annotation.before() );
+		sameOrAfter( annotation.sameOrAfter() );
+		override( extractJdkValue( annotation, DIALECT_OVERRIDE_SQL_DELETE, "override", sourceModelContext ) );
 	}
 
-	public OverriddenSQLDeleteAnnotation(AnnotationInstance source, SourceModelBuildingContext sourceModelContext) {
-		super( source, DIALECT_OVERRIDE_SQL_DELETE, sourceModelContext );
-		override( extractJandexValue( source, DIALECT_OVERRIDE_SQL_DELETE, "override", sourceModelContext ) );
+	/**
+	 * Used in creating annotation instances from Jandex variant
+	 */
+	public OverriddenSQLDeleteAnnotation(
+			Map<String, Object> attributeValues,
+			SourceModelBuildingContext sourceModelContext) {
+		super( attributeValues, DIALECT_OVERRIDE_SQL_DELETE, sourceModelContext );
+		override( (SQLDelete) attributeValues.get( "override" ) );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/OverriddenSQLDeletesAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/OverriddenSQLDeletesAnnotation.java
@@ -7,15 +7,13 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
 import org.hibernate.annotations.DialectOverride;
 import org.hibernate.boot.models.annotations.spi.RepeatableContainer;
 import org.hibernate.models.spi.SourceModelBuildingContext;
 
-import org.jboss.jandex.AnnotationInstance;
-
 import static org.hibernate.boot.models.DialectOverrideAnnotations.DIALECT_OVERRIDE_SQL_DELETES;
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJandexValue;
 import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJdkValue;
 
 /**
@@ -26,17 +24,28 @@ public class OverriddenSQLDeletesAnnotation
 		implements DialectOverride.SQLDeletes, RepeatableContainer<DialectOverride.SQLDelete> {
 	private DialectOverride.SQLDelete[] value;
 
+	/**
+	 * Used in creating dynamic annotation instances (e.g. from XML)
+	 */
 	public OverriddenSQLDeletesAnnotation(SourceModelBuildingContext modelContext) {
 	}
 
+	/**
+	 * Used in creating annotation instances from JDK variant
+	 */
 	public OverriddenSQLDeletesAnnotation(
 			DialectOverride.SQLDeletes annotation,
 			SourceModelBuildingContext modelContext) {
 		this.value = extractJdkValue( annotation, DIALECT_OVERRIDE_SQL_DELETES, "value", modelContext );
 	}
 
-	public OverriddenSQLDeletesAnnotation(AnnotationInstance annotation, SourceModelBuildingContext modelContext) {
-		this.value = extractJandexValue( annotation, DIALECT_OVERRIDE_SQL_DELETES, "value", modelContext );
+	/**
+	 * Used in creating annotation instances from Jandex variant
+	 */
+	public OverriddenSQLDeletesAnnotation(
+			Map<String, Object> attributeValues,
+			SourceModelBuildingContext modelContext) {
+		this.value = (DialectOverride.SQLDelete[]) attributeValues.get( "value" );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/OverriddenSQLInsertAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/OverriddenSQLInsertAnnotation.java
@@ -7,6 +7,7 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
 import org.hibernate.annotations.DialectOverride;
 import org.hibernate.annotations.SQLInsert;
@@ -16,10 +17,7 @@ import org.hibernate.boot.models.annotations.spi.DialectOverrider;
 import org.hibernate.models.spi.AnnotationDescriptor;
 import org.hibernate.models.spi.SourceModelBuildingContext;
 
-import org.jboss.jandex.AnnotationInstance;
-
 import static org.hibernate.boot.models.DialectOverrideAnnotations.DIALECT_OVERRIDE_SQL_INSERT;
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJandexValue;
 import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJdkValue;
 
 /**
@@ -31,21 +29,32 @@ public class OverriddenSQLInsertAnnotation
 		implements DialectOverride.SQLInsert, DialectOverrider<SQLInsert> {
 	private SQLInsert override;
 
+	/**
+	 * Used in creating dynamic annotation instances (e.g. from XML)
+	 */
 	public OverriddenSQLInsertAnnotation(SourceModelBuildingContext sourceModelContext) {
 	}
 
+	/**
+	 * Used in creating annotation instances from JDK variant
+	 */
 	public OverriddenSQLInsertAnnotation(
-			DialectOverride.SQLInsert source,
+			DialectOverride.SQLInsert annotation,
 			SourceModelBuildingContext sourceModelContext) {
-		dialect( source.dialect() );
-		before( source.before() );
-		sameOrAfter( source.sameOrAfter() );
-		override( extractJdkValue( source, DIALECT_OVERRIDE_SQL_INSERT, "override", sourceModelContext ) );
+		dialect( annotation.dialect() );
+		before( annotation.before() );
+		sameOrAfter( annotation.sameOrAfter() );
+		override( extractJdkValue( annotation, DIALECT_OVERRIDE_SQL_INSERT, "override", sourceModelContext ) );
 	}
 
-	public OverriddenSQLInsertAnnotation(AnnotationInstance source, SourceModelBuildingContext sourceModelContext) {
-		super( source, DIALECT_OVERRIDE_SQL_INSERT, sourceModelContext );
-		override( extractJandexValue( source, DIALECT_OVERRIDE_SQL_INSERT, "override", sourceModelContext ) );
+	/**
+	 * Used in creating annotation instances from Jandex variant
+	 */
+	public OverriddenSQLInsertAnnotation(
+			Map<String, Object> attributeValues,
+			SourceModelBuildingContext sourceModelContext) {
+		super( attributeValues, DIALECT_OVERRIDE_SQL_INSERT, sourceModelContext );
+		override( (SQLInsert) attributeValues.get( "override" ) );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/OverriddenSQLInsertsAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/OverriddenSQLInsertsAnnotation.java
@@ -7,6 +7,7 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
 import org.hibernate.annotations.DialectOverride;
 import org.hibernate.boot.models.annotations.spi.RepeatableContainer;
@@ -26,17 +27,28 @@ public class OverriddenSQLInsertsAnnotation
 		implements DialectOverride.SQLInserts, RepeatableContainer<DialectOverride.SQLInsert> {
 	private DialectOverride.SQLInsert[] value;
 
+	/**
+	 * Used in creating dynamic annotation instances (e.g. from XML)
+	 */
 	public OverriddenSQLInsertsAnnotation(SourceModelBuildingContext sourceModelBuildingContext) {
 	}
 
+	/**
+	 * Used in creating annotation instances from JDK variant
+	 */
 	public OverriddenSQLInsertsAnnotation(
 			DialectOverride.SQLInserts annotation,
 			SourceModelBuildingContext modelContext) {
 		this.value = extractJdkValue( annotation, DIALECT_OVERRIDE_SQL_INSERTS, "value", modelContext );
 	}
 
-	public OverriddenSQLInsertsAnnotation(AnnotationInstance annotation, SourceModelBuildingContext modelContext) {
-		this.value = extractJandexValue( annotation, DIALECT_OVERRIDE_SQL_INSERTS, "value", modelContext );
+	/**
+	 * Used in creating annotation instances from Jandex variant
+	 */
+	public OverriddenSQLInsertsAnnotation(
+			Map<String, Object> attributeValues,
+			SourceModelBuildingContext modelContext) {
+		this.value = (DialectOverride.SQLInsert[]) attributeValues.get( "value" );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/OverriddenSQLOrderAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/OverriddenSQLOrderAnnotation.java
@@ -7,6 +7,7 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
 import org.hibernate.annotations.DialectOverride;
 import org.hibernate.annotations.SQLOrder;
@@ -16,10 +17,7 @@ import org.hibernate.boot.models.annotations.spi.DialectOverrider;
 import org.hibernate.models.spi.AnnotationDescriptor;
 import org.hibernate.models.spi.SourceModelBuildingContext;
 
-import org.jboss.jandex.AnnotationInstance;
-
 import static org.hibernate.boot.models.DialectOverrideAnnotations.DIALECT_OVERRIDE_SQL_ORDER;
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJandexValue;
 import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJdkValue;
 
 /**
@@ -31,21 +29,32 @@ public class OverriddenSQLOrderAnnotation
 		implements DialectOverride.SQLOrder, DialectOverrider<SQLOrder> {
 	private SQLOrder override;
 
+	/**
+	 * Used in creating dynamic annotation instances (e.g. from XML)
+	 */
 	public OverriddenSQLOrderAnnotation(SourceModelBuildingContext sourceModelContext) {
 	}
 
+	/**
+	 * Used in creating annotation instances from JDK variant
+	 */
 	public OverriddenSQLOrderAnnotation(
-			DialectOverride.SQLOrder source,
+			DialectOverride.SQLOrder annotation,
 			SourceModelBuildingContext sourceModelContext) {
-		dialect( source.dialect() );
-		before( source.before() );
-		sameOrAfter( source.sameOrAfter() );
-		override( extractJdkValue( source, DIALECT_OVERRIDE_SQL_ORDER, "override", sourceModelContext ) );
+		dialect( annotation.dialect() );
+		before( annotation.before() );
+		sameOrAfter( annotation.sameOrAfter() );
+		override( extractJdkValue( annotation, DIALECT_OVERRIDE_SQL_ORDER, "override", sourceModelContext ) );
 	}
 
-	public OverriddenSQLOrderAnnotation(AnnotationInstance source, SourceModelBuildingContext sourceModelContext) {
-		super( source, DIALECT_OVERRIDE_SQL_ORDER, sourceModelContext );
-		override( extractJandexValue( source, DIALECT_OVERRIDE_SQL_ORDER, "override", sourceModelContext ) );
+	/**
+	 * Used in creating annotation instances from Jandex variant
+	 */
+	public OverriddenSQLOrderAnnotation(
+			Map<String, Object> attributeValues,
+			SourceModelBuildingContext sourceModelContext) {
+		super( attributeValues, DIALECT_OVERRIDE_SQL_ORDER, sourceModelContext );
+		override( (SQLOrder) attributeValues.get( "override" ) );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/OverriddenSQLOrdersAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/OverriddenSQLOrdersAnnotation.java
@@ -7,16 +7,14 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
 import org.hibernate.annotations.DialectOverride;
 import org.hibernate.annotations.DialectOverride.SQLOrders;
 import org.hibernate.boot.models.annotations.spi.RepeatableContainer;
 import org.hibernate.models.spi.SourceModelBuildingContext;
 
-import org.jboss.jandex.AnnotationInstance;
-
 import static org.hibernate.boot.models.DialectOverrideAnnotations.DIALECT_OVERRIDE_SQL_ORDERS;
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJandexValue;
 import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJdkValue;
 
 @SuppressWarnings({ "ClassExplicitlyAnnotation", "unused" })
@@ -41,8 +39,8 @@ public class OverriddenSQLOrdersAnnotation
 	/**
 	 * Used in creating annotation instances from Jandex variant
 	 */
-	public OverriddenSQLOrdersAnnotation(AnnotationInstance annotation, SourceModelBuildingContext modelContext) {
-		this.value = extractJandexValue( annotation, DIALECT_OVERRIDE_SQL_ORDERS, "value", modelContext );
+	public OverriddenSQLOrdersAnnotation(Map<String, Object> attributeValues, SourceModelBuildingContext modelContext) {
+		this.value = (DialectOverride.SQLOrder[]) attributeValues.get( "value" );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/OverriddenSQLRestrictionAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/OverriddenSQLRestrictionAnnotation.java
@@ -7,6 +7,7 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
 import org.hibernate.annotations.DialectOverride;
 import org.hibernate.annotations.SQLRestriction;
@@ -16,11 +17,8 @@ import org.hibernate.boot.models.annotations.spi.DialectOverrider;
 import org.hibernate.models.spi.AnnotationDescriptor;
 import org.hibernate.models.spi.SourceModelBuildingContext;
 
-import org.jboss.jandex.AnnotationInstance;
-
 import static org.hibernate.boot.models.DialectOverrideAnnotations.DIALECT_OVERRIDE_SQL_ORDER;
 import static org.hibernate.boot.models.DialectOverrideAnnotations.DIALECT_OVERRIDE_SQL_RESTRICTION;
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJandexValue;
 import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJdkValue;
 
 /**
@@ -32,23 +30,32 @@ public class OverriddenSQLRestrictionAnnotation
 		implements DialectOverride.SQLRestriction, DialectOverrider<SQLRestriction> {
 	private SQLRestriction override;
 
+	/**
+	 * Used in creating dynamic annotation instances (e.g. from XML)
+	 */
 	public OverriddenSQLRestrictionAnnotation(SourceModelBuildingContext sourceModelContext) {
 	}
 
+	/**
+	 * Used in creating annotation instances from JDK variant
+	 */
 	public OverriddenSQLRestrictionAnnotation(
-			DialectOverride.SQLRestriction source,
+			DialectOverride.SQLRestriction annotation,
 			SourceModelBuildingContext sourceModelContext) {
-		dialect( source.dialect() );
-		before( source.before() );
-		sameOrAfter( source.sameOrAfter() );
-		override( extractJdkValue( source, DIALECT_OVERRIDE_SQL_RESTRICTION, "override", sourceModelContext ) );
+		dialect( annotation.dialect() );
+		before( annotation.before() );
+		sameOrAfter( annotation.sameOrAfter() );
+		override( extractJdkValue( annotation, DIALECT_OVERRIDE_SQL_RESTRICTION, "override", sourceModelContext ) );
 	}
 
+	/**
+	 * Used in creating annotation instances from Jandex variant
+	 */
 	public OverriddenSQLRestrictionAnnotation(
-			AnnotationInstance source,
+			Map<String, Object> attributeValues,
 			SourceModelBuildingContext sourceModelContext) {
-		super( source, DIALECT_OVERRIDE_SQL_ORDER, sourceModelContext );
-		override( extractJandexValue( source, DIALECT_OVERRIDE_SQL_RESTRICTION, "override", sourceModelContext ) );
+		super( attributeValues, DIALECT_OVERRIDE_SQL_ORDER, sourceModelContext );
+		override( (SQLRestriction) attributeValues.get( "override" ) );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/OverriddenSQLRestrictionsAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/OverriddenSQLRestrictionsAnnotation.java
@@ -7,6 +7,7 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
 import org.hibernate.annotations.DialectOverride;
 import org.hibernate.annotations.DialectOverride.SQLRestrictions;
@@ -14,9 +15,6 @@ import org.hibernate.boot.models.DialectOverrideAnnotations;
 import org.hibernate.boot.models.annotations.spi.RepeatableContainer;
 import org.hibernate.models.spi.SourceModelBuildingContext;
 
-import org.jboss.jandex.AnnotationInstance;
-
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJandexValue;
 import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJdkValue;
 
 @SuppressWarnings({ "ClassExplicitlyAnnotation", "unused" })
@@ -46,13 +44,10 @@ public class OverriddenSQLRestrictionsAnnotation
 	/**
 	 * Used in creating annotation instances from Jandex variant
 	 */
-	public OverriddenSQLRestrictionsAnnotation(AnnotationInstance annotation, SourceModelBuildingContext modelContext) {
-		this.value = extractJandexValue(
-				annotation,
-				DialectOverrideAnnotations.DIALECT_OVERRIDE_SQL_RESTRICTIONS,
-				"value",
-				modelContext
-		);
+	public OverriddenSQLRestrictionsAnnotation(
+			Map<String, Object> attributeValues,
+			SourceModelBuildingContext modelContext) {
+		this.value = (DialectOverride.SQLRestriction[]) attributeValues.get( "value" );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/OverriddenSQLSelectAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/OverriddenSQLSelectAnnotation.java
@@ -7,6 +7,7 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
 import org.hibernate.annotations.DialectOverride;
 import org.hibernate.annotations.SQLSelect;
@@ -16,10 +17,7 @@ import org.hibernate.boot.models.annotations.spi.DialectOverrider;
 import org.hibernate.models.spi.AnnotationDescriptor;
 import org.hibernate.models.spi.SourceModelBuildingContext;
 
-import org.jboss.jandex.AnnotationInstance;
-
 import static org.hibernate.boot.models.DialectOverrideAnnotations.DIALECT_OVERRIDE_SQL_SELECT;
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJandexValue;
 import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJdkValue;
 
 /**
@@ -31,9 +29,15 @@ public class OverriddenSQLSelectAnnotation
 		implements DialectOverride.SQLSelect, DialectOverrider<SQLSelect> {
 	private SQLSelect override;
 
+	/**
+	 * Used in creating dynamic annotation instances (e.g. from XML)
+	 */
 	public OverriddenSQLSelectAnnotation(SourceModelBuildingContext modelContext) {
 	}
 
+	/**
+	 * Used in creating annotation instances from JDK variant
+	 */
 	public OverriddenSQLSelectAnnotation(
 			DialectOverride.SQLSelect annotation,
 			SourceModelBuildingContext modelContext) {
@@ -43,9 +47,12 @@ public class OverriddenSQLSelectAnnotation
 		override( extractJdkValue( annotation, DIALECT_OVERRIDE_SQL_SELECT, "override", modelContext ) );
 	}
 
-	public OverriddenSQLSelectAnnotation(AnnotationInstance annotation, SourceModelBuildingContext modelContext) {
-		super( annotation, DIALECT_OVERRIDE_SQL_SELECT, modelContext );
-		override( extractJandexValue( annotation, DIALECT_OVERRIDE_SQL_SELECT, "override", modelContext ) );
+	/**
+	 * Used in creating annotation instances from Jandex variant
+	 */
+	public OverriddenSQLSelectAnnotation(Map<String, Object> attributeValues, SourceModelBuildingContext modelContext) {
+		super( attributeValues, DIALECT_OVERRIDE_SQL_SELECT, modelContext );
+		override( (SQLSelect) attributeValues.get( "override" ) );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/OverriddenSQLSelectsAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/OverriddenSQLSelectsAnnotation.java
@@ -7,6 +7,7 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
 import org.hibernate.annotations.DialectOverride;
 import org.hibernate.annotations.DialectOverride.SQLRestrictions;
@@ -14,9 +15,6 @@ import org.hibernate.boot.models.DialectOverrideAnnotations;
 import org.hibernate.boot.models.annotations.spi.RepeatableContainer;
 import org.hibernate.models.spi.SourceModelBuildingContext;
 
-import org.jboss.jandex.AnnotationInstance;
-
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJandexValue;
 import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJdkValue;
 
 @SuppressWarnings({ "ClassExplicitlyAnnotation", "unused" })
@@ -46,13 +44,10 @@ public class OverriddenSQLSelectsAnnotation
 	/**
 	 * Used in creating annotation instances from Jandex variant
 	 */
-	public OverriddenSQLSelectsAnnotation(AnnotationInstance annotation, SourceModelBuildingContext modelContext) {
-		this.value = extractJandexValue(
-				annotation,
-				DialectOverrideAnnotations.DIALECT_OVERRIDE_SQL_RESTRICTIONS,
-				"value",
-				modelContext
-		);
+	public OverriddenSQLSelectsAnnotation(
+			Map<String, Object> attributeValues,
+			SourceModelBuildingContext modelContext) {
+		this.value = (DialectOverride.SQLSelect[]) attributeValues.get( "value" );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/OverriddenSQLUpdateAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/OverriddenSQLUpdateAnnotation.java
@@ -7,6 +7,7 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
 import org.hibernate.annotations.DialectOverride;
 import org.hibernate.annotations.SQLUpdate;
@@ -16,10 +17,7 @@ import org.hibernate.boot.models.annotations.spi.DialectOverrider;
 import org.hibernate.models.spi.AnnotationDescriptor;
 import org.hibernate.models.spi.SourceModelBuildingContext;
 
-import org.jboss.jandex.AnnotationInstance;
-
 import static org.hibernate.boot.models.DialectOverrideAnnotations.DIALECT_OVERRIDE_SQL_UPDATE;
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJandexValue;
 import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJdkValue;
 
 /**
@@ -31,21 +29,32 @@ public class OverriddenSQLUpdateAnnotation
 		implements DialectOverride.SQLUpdate, DialectOverrider<SQLUpdate> {
 	private SQLUpdate override;
 
+	/**
+	 * Used in creating dynamic annotation instances (e.g. from XML)
+	 */
 	public OverriddenSQLUpdateAnnotation(SourceModelBuildingContext sourceModelContext) {
 	}
 
+	/**
+	 * Used in creating annotation instances from JDK variant
+	 */
 	public OverriddenSQLUpdateAnnotation(
-			DialectOverride.SQLUpdate source,
+			DialectOverride.SQLUpdate annotation,
 			SourceModelBuildingContext sourceModelContext) {
-		dialect( source.dialect() );
-		before( source.before() );
-		sameOrAfter( source.sameOrAfter() );
-		override( extractJdkValue( source, DIALECT_OVERRIDE_SQL_UPDATE, "override", sourceModelContext ) );
+		dialect( annotation.dialect() );
+		before( annotation.before() );
+		sameOrAfter( annotation.sameOrAfter() );
+		override( extractJdkValue( annotation, DIALECT_OVERRIDE_SQL_UPDATE, "override", sourceModelContext ) );
 	}
 
-	public OverriddenSQLUpdateAnnotation(AnnotationInstance source, SourceModelBuildingContext sourceModelContext) {
-		super( source, DIALECT_OVERRIDE_SQL_UPDATE, sourceModelContext );
-		override( extractJandexValue( source, DIALECT_OVERRIDE_SQL_UPDATE, "override", sourceModelContext ) );
+	/**
+	 * Used in creating annotation instances from Jandex variant
+	 */
+	public OverriddenSQLUpdateAnnotation(
+			Map<String, Object> attributeValues,
+			SourceModelBuildingContext sourceModelContext) {
+		super( attributeValues, DIALECT_OVERRIDE_SQL_UPDATE, sourceModelContext );
+		override( (SQLUpdate) attributeValues.get( "override" ) );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/OverriddenSQLUpdatesAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/OverriddenSQLUpdatesAnnotation.java
@@ -7,15 +7,13 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
 import org.hibernate.annotations.DialectOverride;
 import org.hibernate.boot.models.annotations.spi.RepeatableContainer;
 import org.hibernate.models.spi.SourceModelBuildingContext;
 
-import org.jboss.jandex.AnnotationInstance;
-
 import static org.hibernate.boot.models.DialectOverrideAnnotations.DIALECT_OVERRIDE_SQL_UPDATES;
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJandexValue;
 import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJdkValue;
 
 /**
@@ -26,19 +24,28 @@ public class OverriddenSQLUpdatesAnnotation
 		implements DialectOverride.SQLUpdates, RepeatableContainer<DialectOverride.SQLUpdate> {
 	private DialectOverride.SQLUpdate[] value;
 
+	/**
+	 * Used in creating dynamic annotation instances (e.g. from XML)
+	 */
 	public OverriddenSQLUpdatesAnnotation(SourceModelBuildingContext sourceModelBuildingContext) {
 	}
 
+	/**
+	 * Used in creating annotation instances from JDK variant
+	 */
 	public OverriddenSQLUpdatesAnnotation(
 			DialectOverride.SQLUpdates annotation,
 			SourceModelBuildingContext sourceModelContext) {
 		this.value = extractJdkValue( annotation, DIALECT_OVERRIDE_SQL_UPDATES, "value", sourceModelContext );
 	}
 
+	/**
+	 * Used in creating annotation instances from Jandex variant
+	 */
 	public OverriddenSQLUpdatesAnnotation(
-			AnnotationInstance annotation,
+			Map<String, Object> attributeValues,
 			SourceModelBuildingContext sourceModelContext) {
-		this.value = extractJandexValue( annotation, DIALECT_OVERRIDE_SQL_UPDATES, "value", sourceModelContext );
+		this.value = (DialectOverride.SQLUpdate[]) attributeValues.get( "value" );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/OverrideVersionAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/OverrideVersionAnnotation.java
@@ -7,11 +7,10 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
 import org.hibernate.annotations.DialectOverride;
 import org.hibernate.models.spi.SourceModelBuildingContext;
-
-import org.jboss.jandex.AnnotationInstance;
 
 @SuppressWarnings({ "ClassExplicitlyAnnotation", "unused" })
 @jakarta.annotation.Generated("org.hibernate.orm.build.annotations.ClassGeneratorProcessor")
@@ -19,17 +18,27 @@ public class OverrideVersionAnnotation implements DialectOverride.Version {
 	private int major;
 	private int minor;
 
+	/**
+	 * Used in creating dynamic annotation instances (e.g. from XML)
+	 */
 	public OverrideVersionAnnotation(SourceModelBuildingContext modelContext) {
 		this.minor = 0;
 	}
 
+	/**
+	 * Used in creating annotation instances from JDK variant
+	 */
 	public OverrideVersionAnnotation(DialectOverride.Version annotation, SourceModelBuildingContext modelContext) {
 		major( annotation.major() );
 		minor( annotation.minor() );
 	}
 
-	public OverrideVersionAnnotation(AnnotationInstance annotation, SourceModelBuildingContext modelContext) {
-		throw new UnsupportedOperationException( "Not implemented yet" );
+	/**
+	 * Used in creating annotation instances from Jandex variant
+	 */
+	public OverrideVersionAnnotation(Map<String, Object> attributeValues, SourceModelBuildingContext modelContext) {
+		major( (Integer) attributeValues.get( "major" ) );
+		minor( (Integer) attributeValues.get( "minor" ) );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/ParamDefAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/ParamDefAnnotation.java
@@ -7,14 +7,10 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
 import org.hibernate.annotations.ParamDef;
-import org.hibernate.boot.models.HibernateAnnotations;
 import org.hibernate.models.spi.SourceModelBuildingContext;
-
-import org.jboss.jandex.AnnotationInstance;
-
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJandexValue;
 
 @SuppressWarnings({ "ClassExplicitlyAnnotation", "unused" })
 @jakarta.annotation.Generated("org.hibernate.orm.build.annotations.ClassGeneratorProcessor")
@@ -42,10 +38,10 @@ public class ParamDefAnnotation implements ParamDef {
 	/**
 	 * Used in creating annotation instances from Jandex variant
 	 */
-	public ParamDefAnnotation(AnnotationInstance annotation, SourceModelBuildingContext modelContext) {
-		this.name = extractJandexValue( annotation, HibernateAnnotations.PARAM_DEF, "name", modelContext );
-		this.type = extractJandexValue( annotation, HibernateAnnotations.PARAM_DEF, "type", modelContext );
-		this.resolver = extractJandexValue( annotation, HibernateAnnotations.PARAM_DEF, "resolver", modelContext );
+	public ParamDefAnnotation(Map<String, Object> attributeValues, SourceModelBuildingContext modelContext) {
+		this.name = (String) attributeValues.get( "name" );
+		this.type = (Class<?>) attributeValues.get( "type" );
+		this.resolver = (Class<? extends java.util.function.Supplier>) attributeValues.get( "resolver" );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/ParameterAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/ParameterAnnotation.java
@@ -7,14 +7,10 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
 import org.hibernate.annotations.Parameter;
-import org.hibernate.boot.models.HibernateAnnotations;
 import org.hibernate.models.spi.SourceModelBuildingContext;
-
-import org.jboss.jandex.AnnotationInstance;
-
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJandexValue;
 
 @SuppressWarnings({ "ClassExplicitlyAnnotation", "unused" })
 @jakarta.annotation.Generated("org.hibernate.orm.build.annotations.ClassGeneratorProcessor")
@@ -39,9 +35,9 @@ public class ParameterAnnotation implements Parameter {
 	/**
 	 * Used in creating annotation instances from Jandex variant
 	 */
-	public ParameterAnnotation(AnnotationInstance annotation, SourceModelBuildingContext modelContext) {
-		this.name = extractJandexValue( annotation, HibernateAnnotations.PARAMETER, "name", modelContext );
-		this.value = extractJandexValue( annotation, HibernateAnnotations.PARAMETER, "value", modelContext );
+	public ParameterAnnotation(Map<String, Object> attributeValues, SourceModelBuildingContext modelContext) {
+		this.name = (String) attributeValues.get( "name" );
+		this.value = (String) attributeValues.get( "value" );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/ParentAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/ParentAnnotation.java
@@ -7,11 +7,10 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
 import org.hibernate.annotations.Parent;
 import org.hibernate.models.spi.SourceModelBuildingContext;
-
-import org.jboss.jandex.AnnotationInstance;
 
 @SuppressWarnings({ "ClassExplicitlyAnnotation", "unused" })
 @jakarta.annotation.Generated("org.hibernate.orm.build.annotations.ClassGeneratorProcessor")
@@ -32,7 +31,7 @@ public class ParentAnnotation implements Parent {
 	/**
 	 * Used in creating annotation instances from Jandex variant
 	 */
-	public ParentAnnotation(AnnotationInstance annotation, SourceModelBuildingContext modelContext) {
+	public ParentAnnotation(Map<String, Object> attributeValues, SourceModelBuildingContext modelContext) {
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/PartitionKeyAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/PartitionKeyAnnotation.java
@@ -7,11 +7,10 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
 import org.hibernate.annotations.PartitionKey;
 import org.hibernate.models.spi.SourceModelBuildingContext;
-
-import org.jboss.jandex.AnnotationInstance;
 
 @SuppressWarnings({ "ClassExplicitlyAnnotation", "unused" })
 @jakarta.annotation.Generated("org.hibernate.orm.build.annotations.ClassGeneratorProcessor")
@@ -32,7 +31,7 @@ public class PartitionKeyAnnotation implements PartitionKey {
 	/**
 	 * Used in creating annotation instances from Jandex variant
 	 */
-	public PartitionKeyAnnotation(AnnotationInstance annotation, SourceModelBuildingContext modelContext) {
+	public PartitionKeyAnnotation(Map<String, Object> attributeValues, SourceModelBuildingContext modelContext) {
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/PostLoadJpaAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/PostLoadJpaAnnotation.java
@@ -7,10 +7,9 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
 import org.hibernate.models.spi.SourceModelBuildingContext;
-
-import org.jboss.jandex.AnnotationInstance;
 
 import jakarta.persistence.PostLoad;
 
@@ -33,7 +32,7 @@ public class PostLoadJpaAnnotation implements PostLoad {
 	/**
 	 * Used in creating annotation instances from Jandex variant
 	 */
-	public PostLoadJpaAnnotation(AnnotationInstance annotation, SourceModelBuildingContext modelContext) {
+	public PostLoadJpaAnnotation(Map<String, Object> attributeValues, SourceModelBuildingContext modelContext) {
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/PostPersistJpaAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/PostPersistJpaAnnotation.java
@@ -7,10 +7,9 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
 import org.hibernate.models.spi.SourceModelBuildingContext;
-
-import org.jboss.jandex.AnnotationInstance;
 
 import jakarta.persistence.PostPersist;
 
@@ -33,7 +32,7 @@ public class PostPersistJpaAnnotation implements PostPersist {
 	/**
 	 * Used in creating annotation instances from Jandex variant
 	 */
-	public PostPersistJpaAnnotation(AnnotationInstance annotation, SourceModelBuildingContext modelContext) {
+	public PostPersistJpaAnnotation(Map<String, Object> attributeValues, SourceModelBuildingContext modelContext) {
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/PostRemoveJpaAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/PostRemoveJpaAnnotation.java
@@ -7,10 +7,9 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
 import org.hibernate.models.spi.SourceModelBuildingContext;
-
-import org.jboss.jandex.AnnotationInstance;
 
 import jakarta.persistence.PostRemove;
 
@@ -32,7 +31,7 @@ public class PostRemoveJpaAnnotation implements PostRemove {
 	/**
 	 * Used in creating annotation instances from Jandex variant
 	 */
-	public PostRemoveJpaAnnotation(AnnotationInstance annotation, SourceModelBuildingContext modelContext) {
+	public PostRemoveJpaAnnotation(Map<String, Object> attributeValues, SourceModelBuildingContext modelContext) {
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/PostUpdateJpaAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/PostUpdateJpaAnnotation.java
@@ -7,10 +7,9 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
 import org.hibernate.models.spi.SourceModelBuildingContext;
-
-import org.jboss.jandex.AnnotationInstance;
 
 import jakarta.persistence.PostUpdate;
 
@@ -33,7 +32,7 @@ public class PostUpdateJpaAnnotation implements PostUpdate {
 	/**
 	 * Used in creating annotation instances from Jandex variant
 	 */
-	public PostUpdateJpaAnnotation(AnnotationInstance annotation, SourceModelBuildingContext modelContext) {
+	public PostUpdateJpaAnnotation(Map<String, Object> attributeValues, SourceModelBuildingContext modelContext) {
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/PrePersistJpaAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/PrePersistJpaAnnotation.java
@@ -7,10 +7,9 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
 import org.hibernate.models.spi.SourceModelBuildingContext;
-
-import org.jboss.jandex.AnnotationInstance;
 
 import jakarta.persistence.PrePersist;
 
@@ -33,7 +32,7 @@ public class PrePersistJpaAnnotation implements PrePersist {
 	/**
 	 * Used in creating annotation instances from Jandex variant
 	 */
-	public PrePersistJpaAnnotation(AnnotationInstance annotation, SourceModelBuildingContext modelContext) {
+	public PrePersistJpaAnnotation(Map<String, Object> attributeValues, SourceModelBuildingContext modelContext) {
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/PreRemoveJpaAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/PreRemoveJpaAnnotation.java
@@ -7,10 +7,9 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
 import org.hibernate.models.spi.SourceModelBuildingContext;
-
-import org.jboss.jandex.AnnotationInstance;
 
 import jakarta.persistence.PreRemove;
 
@@ -33,7 +32,7 @@ public class PreRemoveJpaAnnotation implements PreRemove {
 	/**
 	 * Used in creating annotation instances from Jandex variant
 	 */
-	public PreRemoveJpaAnnotation(AnnotationInstance annotation, SourceModelBuildingContext modelContext) {
+	public PreRemoveJpaAnnotation(Map<String, Object> attributeValues, SourceModelBuildingContext modelContext) {
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/PreUpdateJpaAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/PreUpdateJpaAnnotation.java
@@ -7,10 +7,9 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
 import org.hibernate.models.spi.SourceModelBuildingContext;
-
-import org.jboss.jandex.AnnotationInstance;
 
 import jakarta.persistence.PreUpdate;
 
@@ -32,7 +31,7 @@ public class PreUpdateJpaAnnotation implements PreUpdate {
 	/**
 	 * Used in creating annotation instances from Jandex variant
 	 */
-	public PreUpdateJpaAnnotation(AnnotationInstance annotation, SourceModelBuildingContext modelContext) {
+	public PreUpdateJpaAnnotation(Map<String, Object> attributeValues, SourceModelBuildingContext modelContext) {
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/PrimaryKeyJoinColumnJpaAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/PrimaryKeyJoinColumnJpaAnnotation.java
@@ -7,6 +7,7 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
 import org.hibernate.boot.jaxb.mapping.spi.JaxbPrimaryKeyJoinColumnImpl;
 import org.hibernate.boot.models.JpaAnnotations;
@@ -16,12 +17,9 @@ import org.hibernate.boot.models.xml.spi.XmlDocumentContext;
 import org.hibernate.internal.util.StringHelper;
 import org.hibernate.models.spi.SourceModelBuildingContext;
 
-import org.jboss.jandex.AnnotationInstance;
-
 import jakarta.persistence.PrimaryKeyJoinColumn;
 
 import static org.hibernate.boot.models.JpaAnnotations.PRIMARY_KEY_JOIN_COLUMN;
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJandexValue;
 import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJdkValue;
 
 @SuppressWarnings({ "ClassExplicitlyAnnotation", "unused" })
@@ -58,32 +56,14 @@ public class PrimaryKeyJoinColumnJpaAnnotation implements PrimaryKeyJoinColumn, 
 	/**
 	 * Used in creating annotation instances from Jandex variant
 	 */
-	public PrimaryKeyJoinColumnJpaAnnotation(AnnotationInstance annotation, SourceModelBuildingContext modelContext) {
-		this.name = extractJandexValue( annotation, PRIMARY_KEY_JOIN_COLUMN, "name", modelContext );
-		this.referencedColumnName = extractJandexValue(
-				annotation,
-				PRIMARY_KEY_JOIN_COLUMN,
-				"referencedColumnName",
-				modelContext
-		);
-		this.columnDefinition = extractJandexValue(
-				annotation,
-				PRIMARY_KEY_JOIN_COLUMN,
-				"columnDefinition",
-				modelContext
-		);
-		this.options = extractJandexValue(
-				annotation,
-				PRIMARY_KEY_JOIN_COLUMN,
-				"options",
-				modelContext
-		);
-		this.foreignKey = extractJandexValue(
-				annotation,
-				PRIMARY_KEY_JOIN_COLUMN,
-				"foreignKey",
-				modelContext
-		);
+	public PrimaryKeyJoinColumnJpaAnnotation(
+			Map<String, Object> attributeValues,
+			SourceModelBuildingContext modelContext) {
+		this.name = (String) attributeValues.get( "name" );
+		this.referencedColumnName = (String) attributeValues.get( "referencedColumnName" );
+		this.columnDefinition = (String) attributeValues.get( "columnDefinition" );
+		this.options = (String) attributeValues.get( "options" );
+		this.foreignKey = (jakarta.persistence.ForeignKey) attributeValues.get( "foreignKey" );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/PrimaryKeyJoinColumnsJpaAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/PrimaryKeyJoinColumnsJpaAnnotation.java
@@ -7,17 +7,15 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
 import org.hibernate.boot.models.JpaAnnotations;
 import org.hibernate.boot.models.annotations.spi.RepeatableContainer;
 import org.hibernate.models.spi.SourceModelBuildingContext;
 
-import org.jboss.jandex.AnnotationInstance;
-
 import jakarta.persistence.PrimaryKeyJoinColumn;
 import jakarta.persistence.PrimaryKeyJoinColumns;
 
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJandexValue;
 import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJdkValue;
 
 @SuppressWarnings({ "ClassExplicitlyAnnotation", "unused" })
@@ -54,14 +52,11 @@ public class PrimaryKeyJoinColumnsJpaAnnotation
 	/**
 	 * Used in creating annotation instances from Jandex variant
 	 */
-	public PrimaryKeyJoinColumnsJpaAnnotation(AnnotationInstance annotation, SourceModelBuildingContext modelContext) {
-		this.value = extractJandexValue( annotation, JpaAnnotations.PRIMARY_KEY_JOIN_COLUMNS, "value", modelContext );
-		this.foreignKey = extractJandexValue(
-				annotation,
-				JpaAnnotations.PRIMARY_KEY_JOIN_COLUMNS,
-				"foreignKey",
-				modelContext
-		);
+	public PrimaryKeyJoinColumnsJpaAnnotation(
+			Map<String, Object> attributeValues,
+			SourceModelBuildingContext modelContext) {
+		this.value = (PrimaryKeyJoinColumn[]) attributeValues.get( "value" );
+		this.foreignKey = (jakarta.persistence.ForeignKey) attributeValues.get( "foreignKey" );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/PropertyRefAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/PropertyRefAnnotation.java
@@ -7,14 +7,10 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
 import org.hibernate.annotations.PropertyRef;
-import org.hibernate.boot.models.HibernateAnnotations;
 import org.hibernate.models.spi.SourceModelBuildingContext;
-
-import org.jboss.jandex.AnnotationInstance;
-
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJandexValue;
 
 @SuppressWarnings({ "ClassExplicitlyAnnotation", "unused" })
 @jakarta.annotation.Generated("org.hibernate.orm.build.annotations.ClassGeneratorProcessor")
@@ -37,8 +33,8 @@ public class PropertyRefAnnotation implements PropertyRef {
 	/**
 	 * Used in creating annotation instances from Jandex variant
 	 */
-	public PropertyRefAnnotation(AnnotationInstance annotation, SourceModelBuildingContext modelContext) {
-		this.value = extractJandexValue( annotation, HibernateAnnotations.PROPERTY_REF, "value", modelContext );
+	public PropertyRefAnnotation(Map<String, Object> attributeValues, SourceModelBuildingContext modelContext) {
+		this.value = (String) attributeValues.get( "value" );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/QueryCacheLayoutAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/QueryCacheLayoutAnnotation.java
@@ -7,14 +7,10 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
 import org.hibernate.annotations.QueryCacheLayout;
-import org.hibernate.boot.models.HibernateAnnotations;
 import org.hibernate.models.spi.SourceModelBuildingContext;
-
-import org.jboss.jandex.AnnotationInstance;
-
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJandexValue;
 
 @SuppressWarnings({ "ClassExplicitlyAnnotation", "unused" })
 @jakarta.annotation.Generated("org.hibernate.orm.build.annotations.ClassGeneratorProcessor")
@@ -38,8 +34,8 @@ public class QueryCacheLayoutAnnotation implements QueryCacheLayout {
 	/**
 	 * Used in creating annotation instances from Jandex variant
 	 */
-	public QueryCacheLayoutAnnotation(AnnotationInstance annotation, SourceModelBuildingContext modelContext) {
-		this.layout = extractJandexValue( annotation, HibernateAnnotations.QUERY_CACHE_LAYOUT, "layout", modelContext );
+	public QueryCacheLayoutAnnotation(Map<String, Object> attributeValues, SourceModelBuildingContext modelContext) {
+		this.layout = (org.hibernate.annotations.CacheLayout) attributeValues.get( "layout" );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/QueryHintJpaAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/QueryHintJpaAnnotation.java
@@ -7,15 +7,11 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
-import org.hibernate.boot.models.JpaAnnotations;
 import org.hibernate.models.spi.SourceModelBuildingContext;
 
-import org.jboss.jandex.AnnotationInstance;
-
 import jakarta.persistence.QueryHint;
-
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJandexValue;
 
 @SuppressWarnings({ "ClassExplicitlyAnnotation", "unused" })
 @jakarta.annotation.Generated("org.hibernate.orm.build.annotations.ClassGeneratorProcessor")
@@ -40,9 +36,9 @@ public class QueryHintJpaAnnotation implements QueryHint {
 	/**
 	 * Used in creating annotation instances from Jandex variant
 	 */
-	public QueryHintJpaAnnotation(AnnotationInstance annotation, SourceModelBuildingContext modelContext) {
-		this.name = extractJandexValue( annotation, JpaAnnotations.QUERY_HINT, "name", modelContext );
-		this.value = extractJandexValue( annotation, JpaAnnotations.QUERY_HINT, "value", modelContext );
+	public QueryHintJpaAnnotation(Map<String, Object> attributeValues, SourceModelBuildingContext modelContext) {
+		this.name = (String) attributeValues.get( "name" );
+		this.value = (String) attributeValues.get( "value" );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/RowIdAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/RowIdAnnotation.java
@@ -7,14 +7,10 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
 import org.hibernate.annotations.RowId;
-import org.hibernate.boot.models.HibernateAnnotations;
 import org.hibernate.models.spi.SourceModelBuildingContext;
-
-import org.jboss.jandex.AnnotationInstance;
-
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJandexValue;
 
 @SuppressWarnings({ "ClassExplicitlyAnnotation", "unused" })
 @jakarta.annotation.Generated("org.hibernate.orm.build.annotations.ClassGeneratorProcessor")
@@ -38,8 +34,8 @@ public class RowIdAnnotation implements RowId {
 	/**
 	 * Used in creating annotation instances from Jandex variant
 	 */
-	public RowIdAnnotation(AnnotationInstance annotation, SourceModelBuildingContext modelContext) {
-		this.value = extractJandexValue( annotation, HibernateAnnotations.ROW_ID, "value", modelContext );
+	public RowIdAnnotation(Map<String, Object> attributeValues, SourceModelBuildingContext modelContext) {
+		this.value = (String) attributeValues.get( "value" );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/SQLDeleteAllAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/SQLDeleteAllAnnotation.java
@@ -7,16 +7,11 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
 import org.hibernate.annotations.SQLDeleteAll;
-import org.hibernate.boot.models.HibernateAnnotations;
 import org.hibernate.boot.models.annotations.spi.CustomSqlDetails;
 import org.hibernate.models.spi.SourceModelBuildingContext;
-
-import org.jboss.jandex.AnnotationInstance;
-
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJandexValue;
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJdkValue;
 
 @SuppressWarnings({ "ClassExplicitlyAnnotation", "unused" })
 @jakarta.annotation.Generated("org.hibernate.orm.build.annotations.ClassGeneratorProcessor")
@@ -51,12 +46,12 @@ public class SQLDeleteAllAnnotation implements SQLDeleteAll, CustomSqlDetails {
 	/**
 	 * Used in creating annotation instances from Jandex variant
 	 */
-	public SQLDeleteAllAnnotation(AnnotationInstance annotation, SourceModelBuildingContext modelContext) {
-		this.sql = extractJandexValue( annotation, HibernateAnnotations.SQL_DELETE_ALL, "sql", modelContext );
-		this.callable = extractJandexValue( annotation, HibernateAnnotations.SQL_DELETE_ALL, "callable", modelContext );
-		this.verify = extractJandexValue( annotation, HibernateAnnotations.SQL_DELETE_ALL, "verify", modelContext );
-		this.check = extractJandexValue( annotation, HibernateAnnotations.SQL_DELETE_ALL, "check", modelContext );
-		this.table = extractJandexValue( annotation, HibernateAnnotations.SQL_DELETE_ALL, "table", modelContext );
+	public SQLDeleteAllAnnotation(Map<String, Object> attributeValues, SourceModelBuildingContext modelContext) {
+		this.sql = (String) attributeValues.get( "sql" );
+		this.callable = (boolean) attributeValues.get( "callable" );
+		this.verify = (Class<? extends org.hibernate.jdbc.Expectation>) attributeValues.get( "verify" );
+		this.check = (org.hibernate.annotations.ResultCheckStyle) attributeValues.get( "check" );
+		this.table = (String) attributeValues.get( "table" );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/SQLDeleteAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/SQLDeleteAnnotation.java
@@ -7,16 +7,11 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
 import org.hibernate.annotations.SQLDelete;
-import org.hibernate.boot.models.HibernateAnnotations;
 import org.hibernate.boot.models.annotations.spi.CustomSqlDetails;
 import org.hibernate.models.spi.SourceModelBuildingContext;
-
-import org.jboss.jandex.AnnotationInstance;
-
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJandexValue;
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJdkValue;
 
 @SuppressWarnings({ "ClassExplicitlyAnnotation", "unused" })
 @jakarta.annotation.Generated("org.hibernate.orm.build.annotations.ClassGeneratorProcessor")
@@ -51,12 +46,12 @@ public class SQLDeleteAnnotation implements SQLDelete, CustomSqlDetails {
 	/**
 	 * Used in creating annotation instances from Jandex variant
 	 */
-	public SQLDeleteAnnotation(AnnotationInstance annotation, SourceModelBuildingContext modelContext) {
-		this.sql = extractJandexValue( annotation, HibernateAnnotations.SQL_DELETE, "sql", modelContext );
-		this.callable = extractJandexValue( annotation, HibernateAnnotations.SQL_DELETE, "callable", modelContext );
-		this.verify = extractJandexValue( annotation, HibernateAnnotations.SQL_DELETE, "verify", modelContext );
-		this.check = extractJandexValue( annotation, HibernateAnnotations.SQL_DELETE, "check", modelContext );
-		this.table = extractJandexValue( annotation, HibernateAnnotations.SQL_DELETE, "table", modelContext );
+	public SQLDeleteAnnotation(Map<String, Object> attributeValues, SourceModelBuildingContext modelContext) {
+		this.sql = (String) attributeValues.get( "sql" );
+		this.callable = (boolean) attributeValues.get( "callable" );
+		this.verify = (Class<? extends org.hibernate.jdbc.Expectation>) attributeValues.get( "verify" );
+		this.check = (org.hibernate.annotations.ResultCheckStyle) attributeValues.get( "check" );
+		this.table = (String) attributeValues.get( "table" );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/SQLDeletesAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/SQLDeletesAnnotation.java
@@ -6,18 +6,15 @@
  */
 package org.hibernate.boot.models.annotations.internal;
 
+import java.lang.annotation.Annotation;
+import java.util.Map;
+
 import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.SQLDeletes;
 import org.hibernate.boot.models.HibernateAnnotations;
 import org.hibernate.boot.models.annotations.spi.RepeatableContainer;
 import org.hibernate.models.spi.SourceModelBuildingContext;
 
-import org.jboss.jandex.AnnotationInstance;
-
-import java.lang.annotation.Annotation;
-
-import org.hibernate.annotations.SQLDeletes;
-
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJandexValue;
 import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJdkValue;
 
 @SuppressWarnings({ "ClassExplicitlyAnnotation", "unused" })
@@ -41,8 +38,8 @@ public class SQLDeletesAnnotation implements SQLDeletes, RepeatableContainer<SQL
 	/**
 	 * Used in creating annotation instances from Jandex variant
 	 */
-	public SQLDeletesAnnotation(AnnotationInstance annotation, SourceModelBuildingContext modelContext) {
-		this.value = extractJandexValue( annotation, HibernateAnnotations.SQL_DELETES, "value", modelContext );
+	public SQLDeletesAnnotation(Map<String, Object> attributeValues, SourceModelBuildingContext modelContext) {
+		this.value = (SQLDelete[]) attributeValues.get( "value" );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/SQLInsertAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/SQLInsertAnnotation.java
@@ -7,16 +7,11 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
 import org.hibernate.annotations.SQLInsert;
-import org.hibernate.boot.models.HibernateAnnotations;
 import org.hibernate.boot.models.annotations.spi.CustomSqlDetails;
 import org.hibernate.models.spi.SourceModelBuildingContext;
-
-import org.jboss.jandex.AnnotationInstance;
-
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJandexValue;
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJdkValue;
 
 @SuppressWarnings({ "ClassExplicitlyAnnotation", "unused" })
 @jakarta.annotation.Generated("org.hibernate.orm.build.annotations.ClassGeneratorProcessor")
@@ -51,12 +46,12 @@ public class SQLInsertAnnotation implements SQLInsert, CustomSqlDetails {
 	/**
 	 * Used in creating annotation instances from Jandex variant
 	 */
-	public SQLInsertAnnotation(AnnotationInstance annotation, SourceModelBuildingContext modelContext) {
-		this.sql = extractJandexValue( annotation, HibernateAnnotations.SQL_INSERT, "sql", modelContext );
-		this.callable = extractJandexValue( annotation, HibernateAnnotations.SQL_INSERT, "callable", modelContext );
-		this.verify = extractJandexValue( annotation, HibernateAnnotations.SQL_INSERT, "verify", modelContext );
-		this.check = extractJandexValue( annotation, HibernateAnnotations.SQL_INSERT, "check", modelContext );
-		this.table = extractJandexValue( annotation, HibernateAnnotations.SQL_INSERT, "table", modelContext );
+	public SQLInsertAnnotation(Map<String, Object> attributeValues, SourceModelBuildingContext modelContext) {
+		this.sql = (String) attributeValues.get( "sql" );
+		this.callable = (boolean) attributeValues.get( "callable" );
+		this.verify = (Class<? extends org.hibernate.jdbc.Expectation>) attributeValues.get( "verify" );
+		this.check = (org.hibernate.annotations.ResultCheckStyle) attributeValues.get( "check" );
+		this.table = (String) attributeValues.get( "table" );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/SQLInsertsAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/SQLInsertsAnnotation.java
@@ -7,6 +7,7 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
 import org.hibernate.annotations.SQLInsert;
 import org.hibernate.annotations.SQLInserts;
@@ -14,9 +15,6 @@ import org.hibernate.boot.models.HibernateAnnotations;
 import org.hibernate.boot.models.annotations.spi.RepeatableContainer;
 import org.hibernate.models.spi.SourceModelBuildingContext;
 
-import org.jboss.jandex.AnnotationInstance;
-
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJandexValue;
 import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJdkValue;
 
 @SuppressWarnings({ "ClassExplicitlyAnnotation", "unused" })
@@ -40,8 +38,8 @@ public class SQLInsertsAnnotation implements SQLInserts, RepeatableContainer<SQL
 	/**
 	 * Used in creating annotation instances from Jandex variant
 	 */
-	public SQLInsertsAnnotation(AnnotationInstance annotation, SourceModelBuildingContext modelContext) {
-		this.value = extractJandexValue( annotation, HibernateAnnotations.SQL_INSERTS, "value", modelContext );
+	public SQLInsertsAnnotation(Map<String, Object> attributeValues, SourceModelBuildingContext modelContext) {
+		this.value = (SQLInsert[]) attributeValues.get( "value" );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/SQLJoinTableRestrictionAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/SQLJoinTableRestrictionAnnotation.java
@@ -7,14 +7,10 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
 import org.hibernate.annotations.SQLJoinTableRestriction;
-import org.hibernate.boot.models.HibernateAnnotations;
 import org.hibernate.models.spi.SourceModelBuildingContext;
-
-import org.jboss.jandex.AnnotationInstance;
-
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJandexValue;
 
 @SuppressWarnings({ "ClassExplicitlyAnnotation", "unused" })
 @jakarta.annotation.Generated("org.hibernate.orm.build.annotations.ClassGeneratorProcessor")
@@ -39,13 +35,10 @@ public class SQLJoinTableRestrictionAnnotation implements SQLJoinTableRestrictio
 	/**
 	 * Used in creating annotation instances from Jandex variant
 	 */
-	public SQLJoinTableRestrictionAnnotation(AnnotationInstance annotation, SourceModelBuildingContext modelContext) {
-		this.value = extractJandexValue(
-				annotation,
-				HibernateAnnotations.SQL_JOIN_TABLE_RESTRICTION,
-				"value",
-				modelContext
-		);
+	public SQLJoinTableRestrictionAnnotation(
+			Map<String, Object> attributeValues,
+			SourceModelBuildingContext modelContext) {
+		this.value = (String) attributeValues.get( "value" );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/SQLOrderAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/SQLOrderAnnotation.java
@@ -7,14 +7,10 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
 import org.hibernate.annotations.SQLOrder;
-import org.hibernate.boot.models.HibernateAnnotations;
 import org.hibernate.models.spi.SourceModelBuildingContext;
-
-import org.jboss.jandex.AnnotationInstance;
-
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJandexValue;
 
 @SuppressWarnings({ "ClassExplicitlyAnnotation", "unused" })
 @jakarta.annotation.Generated("org.hibernate.orm.build.annotations.ClassGeneratorProcessor")
@@ -37,8 +33,8 @@ public class SQLOrderAnnotation implements SQLOrder {
 	/**
 	 * Used in creating annotation instances from Jandex variant
 	 */
-	public SQLOrderAnnotation(AnnotationInstance annotation, SourceModelBuildingContext modelContext) {
-		this.value = extractJandexValue( annotation, HibernateAnnotations.SQL_ORDER, "value", modelContext );
+	public SQLOrderAnnotation(Map<String, Object> attributeValues, SourceModelBuildingContext modelContext) {
+		this.value = (String) attributeValues.get( "value" );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/SQLRestrictionAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/SQLRestrictionAnnotation.java
@@ -7,14 +7,10 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
 import org.hibernate.annotations.SQLRestriction;
-import org.hibernate.boot.models.HibernateAnnotations;
 import org.hibernate.models.spi.SourceModelBuildingContext;
-
-import org.jboss.jandex.AnnotationInstance;
-
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJandexValue;
 
 @SuppressWarnings({ "ClassExplicitlyAnnotation", "unused" })
 @jakarta.annotation.Generated("org.hibernate.orm.build.annotations.ClassGeneratorProcessor")
@@ -37,8 +33,8 @@ public class SQLRestrictionAnnotation implements SQLRestriction {
 	/**
 	 * Used in creating annotation instances from Jandex variant
 	 */
-	public SQLRestrictionAnnotation(AnnotationInstance annotation, SourceModelBuildingContext modelContext) {
-		this.value = extractJandexValue( annotation, HibernateAnnotations.SQL_RESTRICTION, "value", modelContext );
+	public SQLRestrictionAnnotation(Map<String, Object> attributeValues, SourceModelBuildingContext modelContext) {
+		this.value = (String) attributeValues.get( "value" );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/SQLSelectAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/SQLSelectAnnotation.java
@@ -7,15 +7,13 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
 import org.hibernate.annotations.SQLSelect;
 import org.hibernate.boot.models.JpaAnnotations;
 import org.hibernate.models.spi.SourceModelBuildingContext;
 
-import org.jboss.jandex.AnnotationInstance;
-
 import static org.hibernate.boot.models.HibernateAnnotations.SQL_SELECT;
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJandexValue;
 import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJdkValue;
 
 @SuppressWarnings({ "ClassExplicitlyAnnotation", "unused" })
@@ -46,20 +44,10 @@ public class SQLSelectAnnotation implements SQLSelect {
 	/**
 	 * Used in creating annotation instances from Jandex variant
 	 */
-	public SQLSelectAnnotation(AnnotationInstance annotation, SourceModelBuildingContext modelContext) {
-		this.sql = extractJandexValue( annotation, SQL_SELECT, "sql", modelContext );
-		this.resultSetMapping = extractJandexValue(
-				annotation,
-				SQL_SELECT,
-				"resultSetMapping",
-				modelContext
-		);
-		this.querySpaces = extractJandexValue(
-				annotation,
-				SQL_SELECT,
-				"querySpaces",
-				modelContext
-		);
+	public SQLSelectAnnotation(Map<String, Object> attributeValues, SourceModelBuildingContext modelContext) {
+		this.sql = (String) attributeValues.get( "sql" );
+		this.resultSetMapping = (jakarta.persistence.SqlResultSetMapping) attributeValues.get( "resultSetMapping" );
+		this.querySpaces = (String[]) attributeValues.get( "querySpaces" );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/SQLUpdateAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/SQLUpdateAnnotation.java
@@ -7,16 +7,11 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
 import org.hibernate.annotations.SQLUpdate;
-import org.hibernate.boot.models.HibernateAnnotations;
 import org.hibernate.boot.models.annotations.spi.CustomSqlDetails;
 import org.hibernate.models.spi.SourceModelBuildingContext;
-
-import org.jboss.jandex.AnnotationInstance;
-
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJandexValue;
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJdkValue;
 
 @SuppressWarnings({ "ClassExplicitlyAnnotation", "unused" })
 @jakarta.annotation.Generated("org.hibernate.orm.build.annotations.ClassGeneratorProcessor")
@@ -51,12 +46,12 @@ public class SQLUpdateAnnotation implements SQLUpdate, CustomSqlDetails {
 	/**
 	 * Used in creating annotation instances from Jandex variant
 	 */
-	public SQLUpdateAnnotation(AnnotationInstance annotation, SourceModelBuildingContext modelContext) {
-		this.sql = extractJandexValue( annotation, HibernateAnnotations.SQL_UPDATE, "sql", modelContext );
-		this.callable = extractJandexValue( annotation, HibernateAnnotations.SQL_UPDATE, "callable", modelContext );
-		this.verify = extractJandexValue( annotation, HibernateAnnotations.SQL_UPDATE, "verify", modelContext );
-		this.check = extractJandexValue( annotation, HibernateAnnotations.SQL_UPDATE, "check", modelContext );
-		this.table = extractJandexValue( annotation, HibernateAnnotations.SQL_UPDATE, "table", modelContext );
+	public SQLUpdateAnnotation(Map<String, Object> attributeValues, SourceModelBuildingContext modelContext) {
+		this.sql = (String) attributeValues.get( "sql" );
+		this.callable = (boolean) attributeValues.get( "callable" );
+		this.verify = (Class<? extends org.hibernate.jdbc.Expectation>) attributeValues.get( "verify" );
+		this.check = (org.hibernate.annotations.ResultCheckStyle) attributeValues.get( "check" );
+		this.table = (String) attributeValues.get( "table" );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/SQLUpdatesAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/SQLUpdatesAnnotation.java
@@ -7,6 +7,7 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
 import org.hibernate.annotations.SQLUpdate;
 import org.hibernate.annotations.SQLUpdates;
@@ -14,9 +15,6 @@ import org.hibernate.boot.models.HibernateAnnotations;
 import org.hibernate.boot.models.annotations.spi.RepeatableContainer;
 import org.hibernate.models.spi.SourceModelBuildingContext;
 
-import org.jboss.jandex.AnnotationInstance;
-
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJandexValue;
 import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJdkValue;
 
 @SuppressWarnings({ "ClassExplicitlyAnnotation", "unused" })
@@ -40,8 +38,8 @@ public class SQLUpdatesAnnotation implements SQLUpdates, RepeatableContainer<SQL
 	/**
 	 * Used in creating annotation instances from Jandex variant
 	 */
-	public SQLUpdatesAnnotation(AnnotationInstance annotation, SourceModelBuildingContext modelContext) {
-		this.value = extractJandexValue( annotation, HibernateAnnotations.SQL_UPDATES, "value", modelContext );
+	public SQLUpdatesAnnotation(Map<String, Object> attributeValues, SourceModelBuildingContext modelContext) {
+		this.value = (SQLUpdate[]) attributeValues.get( "value" );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/SecondaryRowAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/SecondaryRowAnnotation.java
@@ -7,14 +7,10 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
 import org.hibernate.annotations.SecondaryRow;
-import org.hibernate.boot.models.HibernateAnnotations;
 import org.hibernate.models.spi.SourceModelBuildingContext;
-
-import org.jboss.jandex.AnnotationInstance;
-
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJandexValue;
 
 @SuppressWarnings({ "ClassExplicitlyAnnotation", "unused" })
 @jakarta.annotation.Generated("org.hibernate.orm.build.annotations.ClassGeneratorProcessor")
@@ -44,10 +40,10 @@ public class SecondaryRowAnnotation implements SecondaryRow {
 	/**
 	 * Used in creating annotation instances from Jandex variant
 	 */
-	public SecondaryRowAnnotation(AnnotationInstance annotation, SourceModelBuildingContext modelContext) {
-		this.table = extractJandexValue( annotation, HibernateAnnotations.SECONDARY_ROW, "table", modelContext );
-		this.owned = extractJandexValue( annotation, HibernateAnnotations.SECONDARY_ROW, "owned", modelContext );
-		this.optional = extractJandexValue( annotation, HibernateAnnotations.SECONDARY_ROW, "optional", modelContext );
+	public SecondaryRowAnnotation(Map<String, Object> attributeValues, SourceModelBuildingContext modelContext) {
+		this.table = (String) attributeValues.get( "table" );
+		this.owned = (boolean) attributeValues.get( "owned" );
+		this.optional = (boolean) attributeValues.get( "optional" );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/SecondaryRowsAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/SecondaryRowsAnnotation.java
@@ -7,6 +7,7 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
 import org.hibernate.annotations.SecondaryRow;
 import org.hibernate.annotations.SecondaryRows;
@@ -14,9 +15,6 @@ import org.hibernate.boot.models.HibernateAnnotations;
 import org.hibernate.boot.models.annotations.spi.RepeatableContainer;
 import org.hibernate.models.spi.SourceModelBuildingContext;
 
-import org.jboss.jandex.AnnotationInstance;
-
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJandexValue;
 import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJdkValue;
 
 @SuppressWarnings({ "ClassExplicitlyAnnotation", "unused" })
@@ -40,8 +38,8 @@ public class SecondaryRowsAnnotation implements SecondaryRows, RepeatableContain
 	/**
 	 * Used in creating annotation instances from Jandex variant
 	 */
-	public SecondaryRowsAnnotation(AnnotationInstance annotation, SourceModelBuildingContext modelContext) {
-		this.value = extractJandexValue( annotation, HibernateAnnotations.SECONDARY_ROWS, "value", modelContext );
+	public SecondaryRowsAnnotation(Map<String, Object> attributeValues, SourceModelBuildingContext modelContext) {
+		this.value = (SecondaryRow[]) attributeValues.get( "value" );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/SecondaryTableJpaAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/SecondaryTableJpaAnnotation.java
@@ -7,6 +7,7 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
 import org.hibernate.boot.jaxb.mapping.spi.JaxbSecondaryTableImpl;
 import org.hibernate.boot.models.JpaAnnotations;
@@ -16,11 +17,8 @@ import org.hibernate.boot.models.xml.internal.db.JoinColumnProcessing;
 import org.hibernate.boot.models.xml.spi.XmlDocumentContext;
 import org.hibernate.models.spi.SourceModelBuildingContext;
 
-import org.jboss.jandex.AnnotationInstance;
-
 import jakarta.persistence.SecondaryTable;
 
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJandexValue;
 import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJdkValue;
 import static org.hibernate.boot.models.xml.internal.XmlAnnotationHelper.applyOptionalString;
 import static org.hibernate.boot.models.xml.internal.XmlAnnotationHelper.collectCheckConstraints;
@@ -85,27 +83,17 @@ public class SecondaryTableJpaAnnotation implements SecondaryTable, CommonTableD
 	/**
 	 * Used in creating annotation instances from Jandex variant
 	 */
-	public SecondaryTableJpaAnnotation(AnnotationInstance annotation, SourceModelBuildingContext modelContext) {
-		this.name = extractJandexValue( annotation, JpaAnnotations.SECONDARY_TABLE, "name", modelContext );
-		this.catalog = extractJandexValue( annotation, JpaAnnotations.SECONDARY_TABLE, "catalog", modelContext );
-		this.schema = extractJandexValue( annotation, JpaAnnotations.SECONDARY_TABLE, "schema", modelContext );
-		this.pkJoinColumns = extractJandexValue(
-				annotation,
-				JpaAnnotations.SECONDARY_TABLE,
-				"pkJoinColumns",
-				modelContext
-		);
-		this.foreignKey = extractJandexValue( annotation, JpaAnnotations.SECONDARY_TABLE, "foreignKey", modelContext );
-		this.uniqueConstraints = extractJandexValue(
-				annotation,
-				JpaAnnotations.SECONDARY_TABLE,
-				"uniqueConstraints",
-				modelContext
-		);
-		this.indexes = extractJandexValue( annotation, JpaAnnotations.SECONDARY_TABLE, "indexes", modelContext );
-		this.check = extractJandexValue( annotation, JpaAnnotations.SECONDARY_TABLE, "check", modelContext );
-		this.comment = extractJandexValue( annotation, JpaAnnotations.SECONDARY_TABLE, "comment", modelContext );
-		this.options = extractJandexValue( annotation, JpaAnnotations.SECONDARY_TABLE, "options", modelContext );
+	public SecondaryTableJpaAnnotation(Map<String, Object> attributeValues, SourceModelBuildingContext modelContext) {
+		this.name = (String) attributeValues.get( "name" );
+		this.catalog = (String) attributeValues.get( "catalog" );
+		this.schema = (String) attributeValues.get( "schema" );
+		this.pkJoinColumns = (jakarta.persistence.PrimaryKeyJoinColumn[]) attributeValues.get( "pkJoinColumns" );
+		this.foreignKey = (jakarta.persistence.ForeignKey) attributeValues.get( "foreignKey" );
+		this.uniqueConstraints = (jakarta.persistence.UniqueConstraint[]) attributeValues.get( "uniqueConstraints" );
+		this.indexes = (jakarta.persistence.Index[]) attributeValues.get( "indexes" );
+		this.check = (jakarta.persistence.CheckConstraint[]) attributeValues.get( "check" );
+		this.comment = (String) attributeValues.get( "comment" );
+		this.options = (String) attributeValues.get( "options" );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/SecondaryTablesJpaAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/SecondaryTablesJpaAnnotation.java
@@ -7,17 +7,15 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
 import org.hibernate.boot.models.JpaAnnotations;
 import org.hibernate.boot.models.annotations.spi.RepeatableContainer;
 import org.hibernate.models.spi.SourceModelBuildingContext;
 
-import org.jboss.jandex.AnnotationInstance;
-
 import jakarta.persistence.SecondaryTable;
 import jakarta.persistence.SecondaryTables;
 
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJandexValue;
 import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJdkValue;
 
 @SuppressWarnings({ "ClassExplicitlyAnnotation", "unused" })
@@ -41,8 +39,8 @@ public class SecondaryTablesJpaAnnotation implements SecondaryTables, Repeatable
 	/**
 	 * Used in creating annotation instances from Jandex variant
 	 */
-	public SecondaryTablesJpaAnnotation(AnnotationInstance annotation, SourceModelBuildingContext modelContext) {
-		this.value = extractJandexValue( annotation, JpaAnnotations.SECONDARY_TABLES, "value", modelContext );
+	public SecondaryTablesJpaAnnotation(Map<String, Object> attributeValues, SourceModelBuildingContext modelContext) {
+		this.value = (SecondaryTable[]) attributeValues.get( "value" );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/SequenceGeneratorJpaAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/SequenceGeneratorJpaAnnotation.java
@@ -7,15 +7,11 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
-import org.hibernate.boot.models.JpaAnnotations;
 import org.hibernate.models.spi.SourceModelBuildingContext;
 
-import org.jboss.jandex.AnnotationInstance;
-
 import jakarta.persistence.SequenceGenerator;
-
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJandexValue;
 
 @SuppressWarnings({ "ClassExplicitlyAnnotation", "unused" })
 @jakarta.annotation.Generated("org.hibernate.orm.build.annotations.ClassGeneratorProcessor")
@@ -57,29 +53,16 @@ public class SequenceGeneratorJpaAnnotation implements SequenceGenerator {
 	/**
 	 * Used in creating annotation instances from Jandex variant
 	 */
-	public SequenceGeneratorJpaAnnotation(AnnotationInstance annotation, SourceModelBuildingContext modelContext) {
-		this.name = extractJandexValue( annotation, JpaAnnotations.SEQUENCE_GENERATOR, "name", modelContext );
-		this.sequenceName = extractJandexValue(
-				annotation,
-				JpaAnnotations.SEQUENCE_GENERATOR,
-				"sequenceName",
-				modelContext
-		);
-		this.catalog = extractJandexValue( annotation, JpaAnnotations.SEQUENCE_GENERATOR, "catalog", modelContext );
-		this.schema = extractJandexValue( annotation, JpaAnnotations.SEQUENCE_GENERATOR, "schema", modelContext );
-		this.initialValue = extractJandexValue(
-				annotation,
-				JpaAnnotations.SEQUENCE_GENERATOR,
-				"initialValue",
-				modelContext
-		);
-		this.allocationSize = extractJandexValue(
-				annotation,
-				JpaAnnotations.SEQUENCE_GENERATOR,
-				"allocationSize",
-				modelContext
-		);
-		this.options = extractJandexValue( annotation, JpaAnnotations.SEQUENCE_GENERATOR, "options", modelContext );
+	public SequenceGeneratorJpaAnnotation(
+			Map<String, Object> attributeValues,
+			SourceModelBuildingContext modelContext) {
+		this.name = (String) attributeValues.get( "name" );
+		this.sequenceName = (String) attributeValues.get( "sequenceName" );
+		this.catalog = (String) attributeValues.get( "catalog" );
+		this.schema = (String) attributeValues.get( "schema" );
+		this.initialValue = (int) attributeValues.get( "initialValue" );
+		this.allocationSize = (int) attributeValues.get( "allocationSize" );
+		this.options = (String) attributeValues.get( "options" );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/SequenceGeneratorsJpaAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/SequenceGeneratorsJpaAnnotation.java
@@ -7,6 +7,7 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
 import org.hibernate.boot.models.JpaAnnotations;
 import org.hibernate.boot.models.annotations.spi.RepeatableContainer;
@@ -41,8 +42,8 @@ public class SequenceGeneratorsJpaAnnotation implements SequenceGenerators, Repe
 	/**
 	 * Used in creating annotation instances from Jandex variant
 	 */
-	public SequenceGeneratorsJpaAnnotation(AnnotationInstance annotation, SourceModelBuildingContext modelContext) {
-		this.value = extractJandexValue( annotation, JpaAnnotations.SEQUENCE_GENERATORS, "value", modelContext );
+	public SequenceGeneratorsJpaAnnotation(Map<String, Object> attributeValues, SourceModelBuildingContext modelContext) {
+		this.value = (SequenceGenerator[]) attributeValues.get( "value" );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/SoftDeleteAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/SoftDeleteAnnotation.java
@@ -7,14 +7,10 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
 import org.hibernate.annotations.SoftDelete;
-import org.hibernate.boot.models.HibernateAnnotations;
 import org.hibernate.models.spi.SourceModelBuildingContext;
-
-import org.jboss.jandex.AnnotationInstance;
-
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJandexValue;
 
 @SuppressWarnings({ "ClassExplicitlyAnnotation", "unused" })
 @jakarta.annotation.Generated("org.hibernate.orm.build.annotations.ClassGeneratorProcessor")
@@ -48,17 +44,13 @@ public class SoftDeleteAnnotation implements SoftDelete {
 	/**
 	 * Used in creating annotation instances from Jandex variant
 	 */
-	public SoftDeleteAnnotation(AnnotationInstance annotation, SourceModelBuildingContext modelContext) {
-		this.columnName = extractJandexValue(
-				annotation,
-				HibernateAnnotations.SOFT_DELETE,
-				"columnName",
-				modelContext
-		);
-		this.strategy = extractJandexValue( annotation, HibernateAnnotations.SOFT_DELETE, "strategy", modelContext );
-		this.options = extractJandexValue( annotation, HibernateAnnotations.SOFT_DELETE, "options", modelContext );
-		this.comment = extractJandexValue( annotation, HibernateAnnotations.SOFT_DELETE, "comment", modelContext );
-		this.converter = extractJandexValue( annotation, HibernateAnnotations.SOFT_DELETE, "converter", modelContext );
+	public SoftDeleteAnnotation(Map<String, Object> attributeValues, SourceModelBuildingContext modelContext) {
+		this.columnName = (String) attributeValues.get( "columnName" );
+		this.strategy = (org.hibernate.annotations.SoftDeleteType) attributeValues.get( "strategy" );
+		this.options = (String) attributeValues.get( "options" );
+		this.comment = (String) attributeValues.get( "comment" );
+		this.converter = (Class<? extends jakarta.persistence.AttributeConverter<Boolean, ?>>) attributeValues.
+				get( "converter" );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/SortComparatorAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/SortComparatorAnnotation.java
@@ -7,14 +7,10 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
 import org.hibernate.annotations.SortComparator;
-import org.hibernate.boot.models.HibernateAnnotations;
 import org.hibernate.models.spi.SourceModelBuildingContext;
-
-import org.jboss.jandex.AnnotationInstance;
-
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJandexValue;
 
 @SuppressWarnings({ "ClassExplicitlyAnnotation", "unused" })
 @jakarta.annotation.Generated("org.hibernate.orm.build.annotations.ClassGeneratorProcessor")
@@ -37,8 +33,8 @@ public class SortComparatorAnnotation implements SortComparator {
 	/**
 	 * Used in creating annotation instances from Jandex variant
 	 */
-	public SortComparatorAnnotation(AnnotationInstance annotation, SourceModelBuildingContext modelContext) {
-		this.value = extractJandexValue( annotation, HibernateAnnotations.SORT_COMPARATOR, "value", modelContext );
+	public SortComparatorAnnotation(Map<String, Object> attributeValues, SourceModelBuildingContext modelContext) {
+		this.value = (Class<? extends java.util.Comparator<?>>) attributeValues.get( "value" );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/SortNaturalAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/SortNaturalAnnotation.java
@@ -7,11 +7,10 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
 import org.hibernate.annotations.SortNatural;
 import org.hibernate.models.spi.SourceModelBuildingContext;
-
-import org.jboss.jandex.AnnotationInstance;
 
 @SuppressWarnings({ "ClassExplicitlyAnnotation", "unused" })
 @jakarta.annotation.Generated("org.hibernate.orm.build.annotations.ClassGeneratorProcessor")
@@ -32,7 +31,7 @@ public class SortNaturalAnnotation implements SortNatural {
 	/**
 	 * Used in creating annotation instances from Jandex variant
 	 */
-	public SortNaturalAnnotation(AnnotationInstance annotation, SourceModelBuildingContext modelContext) {
+	public SortNaturalAnnotation(Map<String, Object> attributeValues, SourceModelBuildingContext modelContext) {
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/SourceAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/SourceAnnotation.java
@@ -7,14 +7,10 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
 import org.hibernate.annotations.Source;
-import org.hibernate.boot.models.HibernateAnnotations;
 import org.hibernate.models.spi.SourceModelBuildingContext;
-
-import org.jboss.jandex.AnnotationInstance;
-
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJandexValue;
 
 @SuppressWarnings({ "ClassExplicitlyAnnotation", "unused" })
 @jakarta.annotation.Generated("org.hibernate.orm.build.annotations.ClassGeneratorProcessor")
@@ -38,8 +34,8 @@ public class SourceAnnotation implements Source {
 	/**
 	 * Used in creating annotation instances from Jandex variant
 	 */
-	public SourceAnnotation(AnnotationInstance annotation, SourceModelBuildingContext modelContext) {
-		this.value = extractJandexValue( annotation, HibernateAnnotations.SOURCE, "value", modelContext );
+	public SourceAnnotation(Map<String, Object> attributeValues, SourceModelBuildingContext modelContext) {
+		this.value = (org.hibernate.annotations.SourceType) attributeValues.get( "value" );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/SqlFragmentAliasAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/SqlFragmentAliasAnnotation.java
@@ -7,14 +7,10 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
 import org.hibernate.annotations.SqlFragmentAlias;
-import org.hibernate.boot.models.HibernateAnnotations;
 import org.hibernate.models.spi.SourceModelBuildingContext;
-
-import org.jboss.jandex.AnnotationInstance;
-
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJandexValue;
 
 @SuppressWarnings({ "ClassExplicitlyAnnotation", "unused" })
 @jakarta.annotation.Generated("org.hibernate.orm.build.annotations.ClassGeneratorProcessor")
@@ -43,10 +39,10 @@ public class SqlFragmentAliasAnnotation implements SqlFragmentAlias {
 	/**
 	 * Used in creating annotation instances from Jandex variant
 	 */
-	public SqlFragmentAliasAnnotation(AnnotationInstance annotation, SourceModelBuildingContext modelContext) {
-		this.alias = extractJandexValue( annotation, HibernateAnnotations.SQL_FRAGMENT_ALIAS, "alias", modelContext );
-		this.table = extractJandexValue( annotation, HibernateAnnotations.SQL_FRAGMENT_ALIAS, "table", modelContext );
-		this.entity = extractJandexValue( annotation, HibernateAnnotations.SQL_FRAGMENT_ALIAS, "entity", modelContext );
+	public SqlFragmentAliasAnnotation(Map<String, Object> attributeValues, SourceModelBuildingContext modelContext) {
+		this.alias = (String) attributeValues.get( "alias" );
+		this.table = (String) attributeValues.get( "table" );
+		this.entity = (Class<?>) attributeValues.get( "entity" );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/SqlResultSetMappingJpaAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/SqlResultSetMappingJpaAnnotation.java
@@ -7,15 +7,13 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
 import org.hibernate.boot.models.JpaAnnotations;
 import org.hibernate.models.spi.SourceModelBuildingContext;
 
-import org.jboss.jandex.AnnotationInstance;
-
 import jakarta.persistence.SqlResultSetMapping;
 
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJandexValue;
 import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJdkValue;
 
 @SuppressWarnings({ "ClassExplicitlyAnnotation", "unused" })
@@ -48,16 +46,13 @@ public class SqlResultSetMappingJpaAnnotation implements SqlResultSetMapping {
 	/**
 	 * Used in creating annotation instances from Jandex variant
 	 */
-	public SqlResultSetMappingJpaAnnotation(AnnotationInstance annotation, SourceModelBuildingContext modelContext) {
-		this.name = extractJandexValue( annotation, JpaAnnotations.SQL_RESULT_SET_MAPPING, "name", modelContext );
-		this.entities = extractJandexValue(
-				annotation,
-				JpaAnnotations.SQL_RESULT_SET_MAPPING,
-				"entities",
-				modelContext
-		);
-		this.classes = extractJandexValue( annotation, JpaAnnotations.SQL_RESULT_SET_MAPPING, "classes", modelContext );
-		this.columns = extractJandexValue( annotation, JpaAnnotations.SQL_RESULT_SET_MAPPING, "columns", modelContext );
+	public SqlResultSetMappingJpaAnnotation(
+			Map<String, Object> attributeValues,
+			SourceModelBuildingContext modelContext) {
+		this.name = (String) attributeValues.get( "name" );
+		this.entities = (jakarta.persistence.EntityResult[]) attributeValues.get( "entities" );
+		this.classes = (jakarta.persistence.ConstructorResult[]) attributeValues.get( "classes" );
+		this.columns = (jakarta.persistence.ColumnResult[]) attributeValues.get( "columns" );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/SqlResultSetMappingsJpaAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/SqlResultSetMappingsJpaAnnotation.java
@@ -7,17 +7,15 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
 import org.hibernate.boot.models.JpaAnnotations;
 import org.hibernate.boot.models.annotations.spi.RepeatableContainer;
 import org.hibernate.models.spi.SourceModelBuildingContext;
 
-import org.jboss.jandex.AnnotationInstance;
-
 import jakarta.persistence.SqlResultSetMapping;
 import jakarta.persistence.SqlResultSetMappings;
 
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJandexValue;
 import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJdkValue;
 
 @SuppressWarnings({ "ClassExplicitlyAnnotation", "unused" })
@@ -42,8 +40,10 @@ public class SqlResultSetMappingsJpaAnnotation
 	/**
 	 * Used in creating annotation instances from Jandex variant
 	 */
-	public SqlResultSetMappingsJpaAnnotation(AnnotationInstance annotation, SourceModelBuildingContext modelContext) {
-		this.value = extractJandexValue( annotation, JpaAnnotations.SQL_RESULT_SET_MAPPINGS, "value", modelContext );
+	public SqlResultSetMappingsJpaAnnotation(
+			Map<String, Object> attributeValues,
+			SourceModelBuildingContext modelContext) {
+		this.value = (SqlResultSetMapping[]) attributeValues.get( "value" );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/StoredProcedureParameterJpaAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/StoredProcedureParameterJpaAnnotation.java
@@ -7,18 +7,14 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
 import org.hibernate.boot.jaxb.mapping.spi.JaxbStoredProcedureParameterImpl;
-import org.hibernate.boot.models.JpaAnnotations;
 import org.hibernate.boot.models.xml.spi.XmlDocumentContext;
 import org.hibernate.internal.util.StringHelper;
 import org.hibernate.models.spi.SourceModelBuildingContext;
 
-import org.jboss.jandex.AnnotationInstance;
-
 import jakarta.persistence.StoredProcedureParameter;
-
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJandexValue;
 
 @SuppressWarnings({ "ClassExplicitlyAnnotation", "unused" })
 @jakarta.annotation.Generated("org.hibernate.orm.build.annotations.ClassGeneratorProcessor")
@@ -50,11 +46,11 @@ public class StoredProcedureParameterJpaAnnotation implements StoredProcedurePar
 	 * Used in creating annotation instances from Jandex variant
 	 */
 	public StoredProcedureParameterJpaAnnotation(
-			AnnotationInstance annotation,
+			Map<String, Object> attributeValues,
 			SourceModelBuildingContext modelContext) {
-		this.name = extractJandexValue( annotation, JpaAnnotations.STORED_PROCEDURE_PARAMETER, "name", modelContext );
-		this.mode = extractJandexValue( annotation, JpaAnnotations.STORED_PROCEDURE_PARAMETER, "mode", modelContext );
-		this.type = extractJandexValue( annotation, JpaAnnotations.STORED_PROCEDURE_PARAMETER, "type", modelContext );
+		this.name = (String) attributeValues.get( "name" );
+		this.mode = (jakarta.persistence.ParameterMode) attributeValues.get( "mode" );
+		this.type = (Class<?>) attributeValues.get( "type" );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/StructAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/StructAnnotation.java
@@ -7,15 +7,10 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
 import org.hibernate.annotations.Struct;
-import org.hibernate.boot.models.HibernateAnnotations;
 import org.hibernate.models.spi.SourceModelBuildingContext;
-
-import org.jboss.jandex.AnnotationInstance;
-
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJandexValue;
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJdkValue;
 
 @SuppressWarnings({ "ClassExplicitlyAnnotation", "unused" })
 @jakarta.annotation.Generated("org.hibernate.orm.build.annotations.ClassGeneratorProcessor")
@@ -45,11 +40,11 @@ public class StructAnnotation implements Struct {
 	/**
 	 * Used in creating annotation instances from Jandex variant
 	 */
-	public StructAnnotation(AnnotationInstance annotation, SourceModelBuildingContext modelContext) {
-		this.name = extractJandexValue( annotation, HibernateAnnotations.STRUCT, "name", modelContext );
-		this.catalog = extractJandexValue( annotation, HibernateAnnotations.STRUCT, "catalog", modelContext );
-		this.schema = extractJandexValue( annotation, HibernateAnnotations.STRUCT, "schema", modelContext );
-		this.attributes = extractJandexValue( annotation, HibernateAnnotations.STRUCT, "attributes", modelContext );
+	public StructAnnotation(Map<String, Object> attributeValues, SourceModelBuildingContext modelContext) {
+		this.name = (String) attributeValues.get( "name" );
+		this.catalog = (String) attributeValues.get( "catalog" );
+		this.schema = (String) attributeValues.get( "schema" );
+		this.attributes = (String[]) attributeValues.get( "attributes" );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/SubselectAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/SubselectAnnotation.java
@@ -7,14 +7,10 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
 import org.hibernate.annotations.Subselect;
-import org.hibernate.boot.models.HibernateAnnotations;
 import org.hibernate.models.spi.SourceModelBuildingContext;
-
-import org.jboss.jandex.AnnotationInstance;
-
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJandexValue;
 
 @SuppressWarnings({ "ClassExplicitlyAnnotation", "unused" })
 @jakarta.annotation.Generated("org.hibernate.orm.build.annotations.ClassGeneratorProcessor")
@@ -37,8 +33,8 @@ public class SubselectAnnotation implements Subselect {
 	/**
 	 * Used in creating annotation instances from Jandex variant
 	 */
-	public SubselectAnnotation(AnnotationInstance annotation, SourceModelBuildingContext modelContext) {
-		this.value = extractJandexValue( annotation, HibernateAnnotations.SUBSELECT, "value", modelContext );
+	public SubselectAnnotation(Map<String, Object> attributeValues, SourceModelBuildingContext modelContext) {
+		this.value = (String) attributeValues.get( "value" );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/SynchronizeAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/SynchronizeAnnotation.java
@@ -7,14 +7,10 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
 import org.hibernate.annotations.Synchronize;
-import org.hibernate.boot.models.HibernateAnnotations;
 import org.hibernate.models.spi.SourceModelBuildingContext;
-
-import org.jboss.jandex.AnnotationInstance;
-
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJandexValue;
 
 @SuppressWarnings({ "ClassExplicitlyAnnotation", "unused" })
 @jakarta.annotation.Generated("org.hibernate.orm.build.annotations.ClassGeneratorProcessor")
@@ -40,9 +36,9 @@ public class SynchronizeAnnotation implements Synchronize {
 	/**
 	 * Used in creating annotation instances from Jandex variant
 	 */
-	public SynchronizeAnnotation(AnnotationInstance annotation, SourceModelBuildingContext modelContext) {
-		this.value = extractJandexValue( annotation, HibernateAnnotations.SYNCHRONIZE, "value", modelContext );
-		this.logical = extractJandexValue( annotation, HibernateAnnotations.SYNCHRONIZE, "logical", modelContext );
+	public SynchronizeAnnotation(Map<String, Object> attributeValues, SourceModelBuildingContext modelContext) {
+		this.value = (String[]) attributeValues.get( "value" );
+		this.logical = (boolean) attributeValues.get( "logical" );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/TableGeneratorJpaAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/TableGeneratorJpaAnnotation.java
@@ -7,21 +7,18 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
 import org.hibernate.boot.jaxb.mapping.spi.JaxbTableGeneratorImpl;
-import org.hibernate.boot.models.JpaAnnotations;
 import org.hibernate.boot.models.annotations.spi.IndexCollector;
 import org.hibernate.boot.models.annotations.spi.UniqueConstraintCollector;
 import org.hibernate.boot.models.xml.spi.XmlDocumentContext;
 import org.hibernate.internal.util.StringHelper;
 import org.hibernate.models.spi.SourceModelBuildingContext;
 
-import org.jboss.jandex.AnnotationInstance;
-
 import jakarta.persistence.TableGenerator;
 
 import static org.hibernate.boot.models.JpaAnnotations.TABLE_GENERATOR;
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJandexValue;
 import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJdkValue;
 import static org.hibernate.boot.models.xml.internal.XmlAnnotationHelper.collectIndexes;
 import static org.hibernate.boot.models.xml.internal.XmlAnnotationHelper.collectUniqueConstraints;
@@ -81,49 +78,19 @@ public class TableGeneratorJpaAnnotation implements TableGenerator, UniqueConstr
 	/**
 	 * Used in creating annotation instances from Jandex variant
 	 */
-	public TableGeneratorJpaAnnotation(AnnotationInstance annotation, SourceModelBuildingContext modelContext) {
-		this.name = extractJandexValue( annotation, TABLE_GENERATOR, "name", modelContext );
-		this.table = extractJandexValue( annotation, TABLE_GENERATOR, "table", modelContext );
-		this.catalog = extractJandexValue( annotation, TABLE_GENERATOR, "catalog", modelContext );
-		this.schema = extractJandexValue( annotation, TABLE_GENERATOR, "schema", modelContext );
-		this.pkColumnName = extractJandexValue(
-				annotation,
-				TABLE_GENERATOR,
-				"pkColumnName",
-				modelContext
-		);
-		this.valueColumnName = extractJandexValue(
-				annotation,
-				TABLE_GENERATOR,
-				"valueColumnName",
-				modelContext
-		);
-		this.pkColumnValue = extractJandexValue(
-				annotation,
-				TABLE_GENERATOR,
-				"pkColumnValue",
-				modelContext
-		);
-		this.initialValue = extractJandexValue(
-				annotation,
-				TABLE_GENERATOR,
-				"initialValue",
-				modelContext
-		);
-		this.allocationSize = extractJandexValue(
-				annotation,
-				TABLE_GENERATOR,
-				"allocationSize",
-				modelContext
-		);
-		this.uniqueConstraints = extractJandexValue(
-				annotation,
-				TABLE_GENERATOR,
-				"uniqueConstraints",
-				modelContext
-		);
-		this.indexes = extractJandexValue( annotation, TABLE_GENERATOR, "indexes", modelContext );
-		this.options = extractJandexValue( annotation, TABLE_GENERATOR, "options", modelContext );
+	public TableGeneratorJpaAnnotation(Map<String, Object> attributeValues, SourceModelBuildingContext modelContext) {
+		this.name = (String) attributeValues.get( "name" );
+		this.table = (String) attributeValues.get( "table" );
+		this.catalog = (String) attributeValues.get( "catalog" );
+		this.schema = (String) attributeValues.get( "schema" );
+		this.pkColumnName = (String) attributeValues.get( "pkColumnName" );
+		this.valueColumnName = (String) attributeValues.get( "valueColumnName" );
+		this.pkColumnValue = (String) attributeValues.get( "pkColumnValue" );
+		this.initialValue = (int) attributeValues.get( "initialValue" );
+		this.allocationSize = (int) attributeValues.get( "allocationSize" );
+		this.uniqueConstraints = (jakarta.persistence.UniqueConstraint[]) attributeValues.get( "uniqueConstraints" );
+		this.indexes = (jakarta.persistence.Index[]) attributeValues.get( "indexes" );
+		this.options = (String) attributeValues.get( "options" );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/TableGeneratorsJpaAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/TableGeneratorsJpaAnnotation.java
@@ -7,17 +7,15 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
 import org.hibernate.boot.models.JpaAnnotations;
 import org.hibernate.boot.models.annotations.spi.RepeatableContainer;
 import org.hibernate.models.spi.SourceModelBuildingContext;
 
-import org.jboss.jandex.AnnotationInstance;
-
 import jakarta.persistence.TableGenerator;
 import jakarta.persistence.TableGenerators;
 
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJandexValue;
 import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJdkValue;
 
 @SuppressWarnings({ "ClassExplicitlyAnnotation", "unused" })
@@ -41,8 +39,8 @@ public class TableGeneratorsJpaAnnotation implements TableGenerators, Repeatable
 	/**
 	 * Used in creating annotation instances from Jandex variant
 	 */
-	public TableGeneratorsJpaAnnotation(AnnotationInstance annotation, SourceModelBuildingContext modelContext) {
-		this.value = extractJandexValue( annotation, JpaAnnotations.TABLE_GENERATORS, "value", modelContext );
+	public TableGeneratorsJpaAnnotation(Map<String, Object> attributeValues, SourceModelBuildingContext modelContext) {
+		this.value = (TableGenerator[]) attributeValues.get( "value" );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/TableJpaAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/TableJpaAnnotation.java
@@ -7,6 +7,7 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
 import org.hibernate.boot.jaxb.mapping.spi.JaxbTableImpl;
 import org.hibernate.boot.models.JpaAnnotations;
@@ -14,11 +15,8 @@ import org.hibernate.boot.models.annotations.spi.CommonTableDetails;
 import org.hibernate.boot.models.xml.spi.XmlDocumentContext;
 import org.hibernate.models.spi.SourceModelBuildingContext;
 
-import org.jboss.jandex.AnnotationInstance;
-
 import jakarta.persistence.Table;
 
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJandexValue;
 import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJdkValue;
 import static org.hibernate.boot.models.xml.internal.XmlAnnotationHelper.applyCatalog;
 import static org.hibernate.boot.models.xml.internal.XmlAnnotationHelper.applyOptionalString;
@@ -70,20 +68,15 @@ public class TableJpaAnnotation implements Table, CommonTableDetails {
 	/**
 	 * Used in creating annotation instances from Jandex variant
 	 */
-	public TableJpaAnnotation(AnnotationInstance annotation, SourceModelBuildingContext modelContext) {
-		this.name = extractJandexValue( annotation, JpaAnnotations.TABLE, "name", modelContext );
-		this.catalog = extractJandexValue( annotation, JpaAnnotations.TABLE, "catalog", modelContext );
-		this.schema = extractJandexValue( annotation, JpaAnnotations.TABLE, "schema", modelContext );
-		this.uniqueConstraints = extractJandexValue(
-				annotation,
-				JpaAnnotations.TABLE,
-				"uniqueConstraints",
-				modelContext
-		);
-		this.indexes = extractJandexValue( annotation, JpaAnnotations.TABLE, "indexes", modelContext );
-		this.check = extractJandexValue( annotation, JpaAnnotations.TABLE, "check", modelContext );
-		this.comment = extractJandexValue( annotation, JpaAnnotations.TABLE, "comment", modelContext );
-		this.options = extractJandexValue( annotation, JpaAnnotations.TABLE, "options", modelContext );
+	public TableJpaAnnotation(Map<String, Object> attributeValues, SourceModelBuildingContext modelContext) {
+		this.name = (String) attributeValues.get( "name" );
+		this.catalog = (String) attributeValues.get( "catalog" );
+		this.schema = (String) attributeValues.get( "schema" );
+		this.uniqueConstraints = (jakarta.persistence.UniqueConstraint[]) attributeValues.get( "uniqueConstraints" );
+		this.indexes = (jakarta.persistence.Index[]) attributeValues.get( "indexes" );
+		this.check = (jakarta.persistence.CheckConstraint[]) attributeValues.get( "check" );
+		this.comment = (String) attributeValues.get( "comment" );
+		this.options = (String) attributeValues.get( "options" );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/TargetLegacyAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/TargetLegacyAnnotation.java
@@ -7,14 +7,10 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
 import org.hibernate.annotations.Target;
-import org.hibernate.boot.models.HibernateAnnotations;
 import org.hibernate.models.spi.SourceModelBuildingContext;
-
-import org.jboss.jandex.AnnotationInstance;
-
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJandexValue;
 
 @SuppressWarnings({ "ClassExplicitlyAnnotation", "unused" })
 @jakarta.annotation.Generated("org.hibernate.orm.build.annotations.ClassGeneratorProcessor")
@@ -37,8 +33,8 @@ public class TargetLegacyAnnotation implements Target {
 	/**
 	 * Used in creating annotation instances from Jandex variant
 	 */
-	public TargetLegacyAnnotation(AnnotationInstance annotation, SourceModelBuildingContext modelContext) {
-		this.value = extractJandexValue( annotation, HibernateAnnotations.TARGET_LEGACY, "value", modelContext );
+	public TargetLegacyAnnotation(Map<String, Object> attributeValues, SourceModelBuildingContext modelContext) {
+		this.value = (Class<?>) attributeValues.get( "value" );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/TargetXmlAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/TargetXmlAnnotation.java
@@ -7,11 +7,10 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
 import org.hibernate.boot.internal.Target;
 import org.hibernate.models.spi.SourceModelBuildingContext;
-
-import org.jboss.jandex.AnnotationInstance;
 
 @SuppressWarnings({ "ClassExplicitlyAnnotation", "unused" })
 @jakarta.annotation.Generated("org.hibernate.orm.build.annotations.ClassGeneratorProcessor")
@@ -25,7 +24,7 @@ public class TargetXmlAnnotation implements Target {
 		throw new UnsupportedOperationException( "Should only ever be sourced from XML" );
 	}
 
-	public TargetXmlAnnotation(AnnotationInstance annotation, SourceModelBuildingContext modelContext) {
+	public TargetXmlAnnotation(Map<String, Object> attributeValues, SourceModelBuildingContext modelContext) {
 		throw new UnsupportedOperationException( "Should only ever be sourced from XML" );
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/TemporalJpaAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/TemporalJpaAnnotation.java
@@ -7,15 +7,11 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
-import org.hibernate.boot.models.JpaAnnotations;
 import org.hibernate.models.spi.SourceModelBuildingContext;
 
-import org.jboss.jandex.AnnotationInstance;
-
 import jakarta.persistence.Temporal;
-
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJandexValue;
 
 @SuppressWarnings({ "ClassExplicitlyAnnotation", "unused" })
 @jakarta.annotation.Generated("org.hibernate.orm.build.annotations.ClassGeneratorProcessor")
@@ -38,8 +34,8 @@ public class TemporalJpaAnnotation implements Temporal {
 	/**
 	 * Used in creating annotation instances from Jandex variant
 	 */
-	public TemporalJpaAnnotation(AnnotationInstance annotation, SourceModelBuildingContext modelContext) {
-		this.value = extractJandexValue( annotation, JpaAnnotations.TEMPORAL, "value", modelContext );
+	public TemporalJpaAnnotation(Map<String, Object> attributeValues, SourceModelBuildingContext modelContext) {
+		this.value = (jakarta.persistence.TemporalType) attributeValues.get( "value" );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/TenantIdAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/TenantIdAnnotation.java
@@ -7,11 +7,10 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
 import org.hibernate.annotations.TenantId;
 import org.hibernate.models.spi.SourceModelBuildingContext;
-
-import org.jboss.jandex.AnnotationInstance;
 
 @SuppressWarnings({ "ClassExplicitlyAnnotation", "unused" })
 @jakarta.annotation.Generated("org.hibernate.orm.build.annotations.ClassGeneratorProcessor")
@@ -32,7 +31,7 @@ public class TenantIdAnnotation implements TenantId {
 	/**
 	 * Used in creating annotation instances from Jandex variant
 	 */
-	public TenantIdAnnotation(AnnotationInstance annotation, SourceModelBuildingContext modelContext) {
+	public TenantIdAnnotation(Map<String, Object> attributeValues, SourceModelBuildingContext modelContext) {
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/TimeZoneColumnAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/TimeZoneColumnAnnotation.java
@@ -7,14 +7,10 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
 import org.hibernate.annotations.TimeZoneColumn;
-import org.hibernate.boot.models.HibernateAnnotations;
 import org.hibernate.models.spi.SourceModelBuildingContext;
-
-import org.jboss.jandex.AnnotationInstance;
-
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJandexValue;
 
 @SuppressWarnings({ "ClassExplicitlyAnnotation", "unused" })
 @jakarta.annotation.Generated("org.hibernate.orm.build.annotations.ClassGeneratorProcessor")
@@ -56,29 +52,14 @@ public class TimeZoneColumnAnnotation implements TimeZoneColumn {
 	/**
 	 * Used in creating annotation instances from Jandex variant
 	 */
-	public TimeZoneColumnAnnotation(AnnotationInstance annotation, SourceModelBuildingContext modelContext) {
-		this.name = extractJandexValue( annotation, HibernateAnnotations.TIME_ZONE_COLUMN, "name", modelContext );
-		this.insertable = extractJandexValue(
-				annotation,
-				HibernateAnnotations.TIME_ZONE_COLUMN,
-				"insertable",
-				modelContext
-		);
-		this.updatable = extractJandexValue(
-				annotation,
-				HibernateAnnotations.TIME_ZONE_COLUMN,
-				"updatable",
-				modelContext
-		);
-		this.columnDefinition = extractJandexValue(
-				annotation,
-				HibernateAnnotations.TIME_ZONE_COLUMN,
-				"columnDefinition",
-				modelContext
-		);
-		this.table = extractJandexValue( annotation, HibernateAnnotations.TIME_ZONE_COLUMN, "table", modelContext );
-		this.options = extractJandexValue( annotation, HibernateAnnotations.TIME_ZONE_COLUMN, "options", modelContext );
-		this.comment = extractJandexValue( annotation, HibernateAnnotations.TIME_ZONE_COLUMN, "comment", modelContext );
+	public TimeZoneColumnAnnotation(Map<String, Object> attributeValues, SourceModelBuildingContext modelContext) {
+		this.name = (String) attributeValues.get( "name" );
+		this.insertable = (boolean) attributeValues.get( "insertable" );
+		this.updatable = (boolean) attributeValues.get( "updatable" );
+		this.columnDefinition = (String) attributeValues.get( "columnDefinition" );
+		this.table = (String) attributeValues.get( "table" );
+		this.options = (String) attributeValues.get( "options" );
+		this.comment = (String) attributeValues.get( "comment" );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/TimeZoneStorageAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/TimeZoneStorageAnnotation.java
@@ -7,14 +7,10 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
 import org.hibernate.annotations.TimeZoneStorage;
-import org.hibernate.boot.models.HibernateAnnotations;
 import org.hibernate.models.spi.SourceModelBuildingContext;
-
-import org.jboss.jandex.AnnotationInstance;
-
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJandexValue;
 
 @SuppressWarnings({ "ClassExplicitlyAnnotation", "unused" })
 @jakarta.annotation.Generated("org.hibernate.orm.build.annotations.ClassGeneratorProcessor")
@@ -38,8 +34,8 @@ public class TimeZoneStorageAnnotation implements TimeZoneStorage {
 	/**
 	 * Used in creating annotation instances from Jandex variant
 	 */
-	public TimeZoneStorageAnnotation(AnnotationInstance annotation, SourceModelBuildingContext modelContext) {
-		this.value = extractJandexValue( annotation, HibernateAnnotations.TIME_ZONE_STORAGE, "value", modelContext );
+	public TimeZoneStorageAnnotation(Map<String, Object> attributeValues, SourceModelBuildingContext modelContext) {
+		this.value = (org.hibernate.annotations.TimeZoneStorageType) attributeValues.get( "value" );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/TransientJpaAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/TransientJpaAnnotation.java
@@ -7,10 +7,9 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
 import org.hibernate.models.spi.SourceModelBuildingContext;
-
-import org.jboss.jandex.AnnotationInstance;
 
 import jakarta.persistence.Transient;
 
@@ -32,7 +31,7 @@ public class TransientJpaAnnotation implements Transient {
 	/**
 	 * Used in creating annotation instances from Jandex variant
 	 */
-	public TransientJpaAnnotation(AnnotationInstance annotation, SourceModelBuildingContext modelContext) {
+	public TransientJpaAnnotation(Map<String, Object> attributeValues, SourceModelBuildingContext modelContext) {
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/TypeAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/TypeAnnotation.java
@@ -7,14 +7,12 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
 import org.hibernate.annotations.Type;
 import org.hibernate.boot.models.HibernateAnnotations;
 import org.hibernate.models.spi.SourceModelBuildingContext;
 
-import org.jboss.jandex.AnnotationInstance;
-
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJandexValue;
 import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJdkValue;
 
 @SuppressWarnings({ "ClassExplicitlyAnnotation", "unused" })
@@ -41,9 +39,9 @@ public class TypeAnnotation implements Type {
 	/**
 	 * Used in creating annotation instances from Jandex variant
 	 */
-	public TypeAnnotation(AnnotationInstance annotation, SourceModelBuildingContext modelContext) {
-		this.value = extractJandexValue( annotation, HibernateAnnotations.TYPE, "value", modelContext );
-		this.parameters = extractJandexValue( annotation, HibernateAnnotations.TYPE, "parameters", modelContext );
+	public TypeAnnotation(Map<String, Object> attributeValues, SourceModelBuildingContext modelContext) {
+		this.value = (Class<? extends org.hibernate.usertype.UserType<?>>) attributeValues.get( "value" );
+		this.parameters = (org.hibernate.annotations.Parameter[]) attributeValues.get( "parameters" );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/TypeBinderTypeAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/TypeBinderTypeAnnotation.java
@@ -7,14 +7,10 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
 import org.hibernate.annotations.TypeBinderType;
-import org.hibernate.boot.models.HibernateAnnotations;
 import org.hibernate.models.spi.SourceModelBuildingContext;
-
-import org.jboss.jandex.AnnotationInstance;
-
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJandexValue;
 
 @SuppressWarnings({ "ClassExplicitlyAnnotation", "unused" })
 @jakarta.annotation.Generated("org.hibernate.orm.build.annotations.ClassGeneratorProcessor")
@@ -37,8 +33,8 @@ public class TypeBinderTypeAnnotation implements TypeBinderType {
 	/**
 	 * Used in creating annotation instances from Jandex variant
 	 */
-	public TypeBinderTypeAnnotation(AnnotationInstance annotation, SourceModelBuildingContext modelContext) {
-		this.binder = extractJandexValue( annotation, HibernateAnnotations.TYPE_BINDER_TYPE, "binder", modelContext );
+	public TypeBinderTypeAnnotation(Map<String, Object> attributeValues, SourceModelBuildingContext modelContext) {
+		this.binder = (Class<? extends org.hibernate.binder.TypeBinder<?>>) attributeValues.get( "binder" );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/TypeRegistrationAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/TypeRegistrationAnnotation.java
@@ -7,14 +7,10 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
 import org.hibernate.annotations.TypeRegistration;
-import org.hibernate.boot.models.HibernateAnnotations;
 import org.hibernate.models.spi.SourceModelBuildingContext;
-
-import org.jboss.jandex.AnnotationInstance;
-
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJandexValue;
 
 @SuppressWarnings({ "ClassExplicitlyAnnotation", "unused" })
 @jakarta.annotation.Generated("org.hibernate.orm.build.annotations.ClassGeneratorProcessor")
@@ -39,19 +35,9 @@ public class TypeRegistrationAnnotation implements TypeRegistration {
 	/**
 	 * Used in creating annotation instances from Jandex variant
 	 */
-	public TypeRegistrationAnnotation(AnnotationInstance annotation, SourceModelBuildingContext modelContext) {
-		this.basicClass = extractJandexValue(
-				annotation,
-				HibernateAnnotations.TYPE_REGISTRATION,
-				"basicClass",
-				modelContext
-		);
-		this.userType = extractJandexValue(
-				annotation,
-				HibernateAnnotations.TYPE_REGISTRATION,
-				"userType",
-				modelContext
-		);
+	public TypeRegistrationAnnotation(Map<String, Object> attributeValues, SourceModelBuildingContext modelContext) {
+		this.basicClass = (Class<?>) attributeValues.get( "basicClass" );
+		this.userType = (Class<? extends org.hibernate.usertype.UserType<?>>) attributeValues.get( "userType" );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/TypeRegistrationsAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/TypeRegistrationsAnnotation.java
@@ -7,6 +7,7 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
 import org.hibernate.annotations.TypeRegistration;
 import org.hibernate.annotations.TypeRegistrations;
@@ -14,9 +15,6 @@ import org.hibernate.boot.models.HibernateAnnotations;
 import org.hibernate.boot.models.annotations.spi.RepeatableContainer;
 import org.hibernate.models.spi.SourceModelBuildingContext;
 
-import org.jboss.jandex.AnnotationInstance;
-
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJandexValue;
 import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJdkValue;
 
 @SuppressWarnings({ "ClassExplicitlyAnnotation", "unused" })
@@ -40,8 +38,8 @@ public class TypeRegistrationsAnnotation implements TypeRegistrations, Repeatabl
 	/**
 	 * Used in creating annotation instances from Jandex variant
 	 */
-	public TypeRegistrationsAnnotation(AnnotationInstance annotation, SourceModelBuildingContext modelContext) {
-		this.value = extractJandexValue( annotation, HibernateAnnotations.TYPE_REGISTRATIONS, "value", modelContext );
+	public TypeRegistrationsAnnotation(Map<String, Object> attributeValues, SourceModelBuildingContext modelContext) {
+		this.value = (TypeRegistration[]) attributeValues.get( "value" );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/UniqueConstraintJpaAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/UniqueConstraintJpaAnnotation.java
@@ -7,15 +7,11 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
-import org.hibernate.boot.models.JpaAnnotations;
 import org.hibernate.models.spi.SourceModelBuildingContext;
 
-import org.jboss.jandex.AnnotationInstance;
-
 import jakarta.persistence.UniqueConstraint;
-
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJandexValue;
 
 @SuppressWarnings({ "ClassExplicitlyAnnotation", "unused" })
 @jakarta.annotation.Generated("org.hibernate.orm.build.annotations.ClassGeneratorProcessor")
@@ -44,15 +40,10 @@ public class UniqueConstraintJpaAnnotation implements UniqueConstraint {
 	/**
 	 * Used in creating annotation instances from Jandex variant
 	 */
-	public UniqueConstraintJpaAnnotation(AnnotationInstance annotation, SourceModelBuildingContext modelContext) {
-		this.name = extractJandexValue( annotation, JpaAnnotations.UNIQUE_CONSTRAINT, "name", modelContext );
-		this.columnNames = extractJandexValue(
-				annotation,
-				JpaAnnotations.UNIQUE_CONSTRAINT,
-				"columnNames",
-				modelContext
-		);
-		this.options = extractJandexValue( annotation, JpaAnnotations.UNIQUE_CONSTRAINT, "options", modelContext );
+	public UniqueConstraintJpaAnnotation(Map<String, Object> attributeValues, SourceModelBuildingContext modelContext) {
+		this.name = (String) attributeValues.get( "name" );
+		this.columnNames = (String[]) attributeValues.get( "columnNames" );
+		this.options = (String) attributeValues.get( "options" );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/UpdateTimestampAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/UpdateTimestampAnnotation.java
@@ -7,14 +7,10 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
 import org.hibernate.annotations.UpdateTimestamp;
-import org.hibernate.boot.models.HibernateAnnotations;
 import org.hibernate.models.spi.SourceModelBuildingContext;
-
-import org.jboss.jandex.AnnotationInstance;
-
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJandexValue;
 
 @SuppressWarnings({ "ClassExplicitlyAnnotation", "unused" })
 @jakarta.annotation.Generated("org.hibernate.orm.build.annotations.ClassGeneratorProcessor")
@@ -38,8 +34,8 @@ public class UpdateTimestampAnnotation implements UpdateTimestamp {
 	/**
 	 * Used in creating annotation instances from Jandex variant
 	 */
-	public UpdateTimestampAnnotation(AnnotationInstance annotation, SourceModelBuildingContext modelContext) {
-		this.source = extractJandexValue( annotation, HibernateAnnotations.UPDATE_TIMESTAMP, "source", modelContext );
+	public UpdateTimestampAnnotation(Map<String, Object> attributeValues, SourceModelBuildingContext modelContext) {
+		this.source = (org.hibernate.annotations.SourceType) attributeValues.get( "source" );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/UuidGeneratorAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/UuidGeneratorAnnotation.java
@@ -7,15 +7,11 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
 import org.hibernate.annotations.UuidGenerator;
-import org.hibernate.boot.models.HibernateAnnotations;
 import org.hibernate.id.uuid.UuidValueGenerator;
 import org.hibernate.models.spi.SourceModelBuildingContext;
-
-import org.jboss.jandex.AnnotationInstance;
-
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJandexValue;
 
 @SuppressWarnings({ "ClassExplicitlyAnnotation", "unused" })
 @jakarta.annotation.Generated("org.hibernate.orm.build.annotations.ClassGeneratorProcessor")
@@ -42,8 +38,9 @@ public class UuidGeneratorAnnotation implements UuidGenerator {
 	/**
 	 * Used in creating annotation instances from Jandex variant
 	 */
-	public UuidGeneratorAnnotation(AnnotationInstance annotation, SourceModelBuildingContext modelContext) {
-		this.style = extractJandexValue( annotation, HibernateAnnotations.UUID_GENERATOR, "style", modelContext );
+	public UuidGeneratorAnnotation(Map<String, Object> attributeValues, SourceModelBuildingContext modelContext) {
+		this.style = (Style) attributeValues.get( "style" );
+		this.algorithm = (Class<? extends UuidValueGenerator>) attributeValues.get( "algorithm" );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/ValueGenerationTypeAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/ValueGenerationTypeAnnotation.java
@@ -7,14 +7,10 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
 import org.hibernate.annotations.ValueGenerationType;
-import org.hibernate.boot.models.HibernateAnnotations;
 import org.hibernate.models.spi.SourceModelBuildingContext;
-
-import org.jboss.jandex.AnnotationInstance;
-
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJandexValue;
 
 @SuppressWarnings({ "ClassExplicitlyAnnotation", "unused" })
 @jakarta.annotation.Generated("org.hibernate.orm.build.annotations.ClassGeneratorProcessor")
@@ -37,13 +33,8 @@ public class ValueGenerationTypeAnnotation implements ValueGenerationType {
 	/**
 	 * Used in creating annotation instances from Jandex variant
 	 */
-	public ValueGenerationTypeAnnotation(AnnotationInstance annotation, SourceModelBuildingContext modelContext) {
-		this.generatedBy = extractJandexValue(
-				annotation,
-				HibernateAnnotations.VALUE_GENERATION_TYPE,
-				"generatedBy",
-				modelContext
-		);
+	public ValueGenerationTypeAnnotation(Map<String, Object> attributeValues, SourceModelBuildingContext modelContext) {
+		this.generatedBy = (Class<? extends org.hibernate.generator.Generator>) attributeValues.get( "generatedBy" );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/VersionJpaAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/VersionJpaAnnotation.java
@@ -7,10 +7,9 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
 import org.hibernate.models.spi.SourceModelBuildingContext;
-
-import org.jboss.jandex.AnnotationInstance;
 
 import jakarta.persistence.Version;
 
@@ -32,7 +31,7 @@ public class VersionJpaAnnotation implements Version {
 	/**
 	 * Used in creating annotation instances from Jandex variant
 	 */
-	public VersionJpaAnnotation(AnnotationInstance annotation, SourceModelBuildingContext modelContext) {
+	public VersionJpaAnnotation(Map<String, Object> attributeValues, SourceModelBuildingContext modelContext) {
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/ViewAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/ViewAnnotation.java
@@ -7,14 +7,10 @@
 package org.hibernate.boot.models.annotations.internal;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
 import org.hibernate.annotations.View;
-import org.hibernate.boot.models.HibernateAnnotations;
 import org.hibernate.models.spi.SourceModelBuildingContext;
-
-import org.jboss.jandex.AnnotationInstance;
-
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJandexValue;
 
 @SuppressWarnings({ "ClassExplicitlyAnnotation", "unused" })
 @jakarta.annotation.Generated("org.hibernate.orm.build.annotations.ClassGeneratorProcessor")
@@ -38,8 +34,8 @@ public class ViewAnnotation implements View {
 	/**
 	 * Used in creating annotation instances from Jandex variant
 	 */
-	public ViewAnnotation(AnnotationInstance annotation, SourceModelBuildingContext modelContext) {
-		this.query = extractJandexValue( annotation, HibernateAnnotations.VIEW, "query", modelContext );
+	public ViewAnnotation(Map<String, Object> attributeValues, SourceModelBuildingContext modelContext) {
+		this.query = (String) attributeValues.get( "query" );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/spi/AbstractOverrider.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/spi/AbstractOverrider.java
@@ -7,17 +7,13 @@
 package org.hibernate.boot.models.annotations.spi;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
 import org.hibernate.annotations.DialectOverride;
-import org.hibernate.boot.models.DialectOverrideAnnotations;
 import org.hibernate.dialect.DatabaseVersion;
 import org.hibernate.dialect.Dialect;
 import org.hibernate.models.spi.AnnotationDescriptor;
 import org.hibernate.models.spi.SourceModelBuildingContext;
-
-import org.jboss.jandex.AnnotationInstance;
-
-import static org.hibernate.boot.models.internal.OrmAnnotationHelper.extractJandexValue;
 
 /**
  * Base support for {@linkplain DialectOverrider} annotations
@@ -33,12 +29,12 @@ public abstract class AbstractOverrider<O extends Annotation> implements Dialect
 	}
 
 	public AbstractOverrider(
-			AnnotationInstance annotation,
+			Map<String, Object> attributeValues,
 			AnnotationDescriptor<?> descriptor,
 			SourceModelBuildingContext modelContext) {
-		dialect( extractJandexValue( annotation, descriptor, "dialect", modelContext ) );
-		before( extractJandexValue( annotation, descriptor, "before", modelContext ) );
-		sameOrAfter( extractJandexValue( annotation, descriptor, "sameOrAfter", modelContext ) );
+		dialect( (Class<? extends Dialect>) attributeValues.get( "dialect" ) );
+		before( (DialectOverride.Version) attributeValues.get( "before" ) );
+		sameOrAfter( (DialectOverride.Version) attributeValues.get( "sameOrAfter" ) );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/categorize/internal/ClassLoaderServiceLoading.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/categorize/internal/ClassLoaderServiceLoading.java
@@ -7,6 +7,12 @@
 package org.hibernate.boot.models.categorize.internal;
 
 import java.net.URL;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.ServiceLoader;
+import java.util.Set;
 
 import org.hibernate.boot.registry.classloading.spi.ClassLoaderService;
 import org.hibernate.models.spi.ClassLoading;
@@ -36,5 +42,10 @@ public class ClassLoaderServiceLoading implements ClassLoading {
 	@Override
 	public URL locateResource(String resourceName) {
 		return classLoaderService.locateResource( resourceName );
+	}
+
+	@Override
+	public <S> Collection<S> loadJavaServices(Class<S> serviceType) {
+		return classLoaderService.loadJavaServices( serviceType );
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/categorize/spi/ManagedResourcesProcessor.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/categorize/spi/ManagedResourcesProcessor.java
@@ -31,8 +31,8 @@ import org.hibernate.boot.registry.classloading.spi.ClassLoaderService;
 import org.hibernate.boot.registry.classloading.spi.ClassLoadingException;
 import org.hibernate.boot.spi.BootstrapContext;
 import org.hibernate.boot.spi.MetadataBuildingOptions;
-import org.hibernate.models.internal.SourceModelBuildingContextImpl;
-import org.hibernate.models.internal.jandex.JandexIndexerHelper;
+import org.hibernate.models.internal.BasicModelBuildingContextImpl;
+import org.hibernate.models.jandex.internal.JandexIndexerHelper;
 import org.hibernate.models.spi.AnnotationDescriptorRegistry;
 import org.hibernate.models.spi.ClassDetails;
 import org.hibernate.models.spi.ClassDetailsRegistry;
@@ -103,9 +103,8 @@ public class ManagedResourcesProcessor {
 		// At this point we know all managed class names across all sources.
 		// Resolve the Jandex Index and build the SourceModelBuildingContext.
 		final IndexView jandexIndex = resolveJandexIndex( allKnownClassNames, bootstrapContext.getJandexView(), classLoading );
-		final SourceModelBuildingContextImpl sourceModelBuildingContext = new SourceModelBuildingContextImpl(
+		final BasicModelBuildingContextImpl sourceModelBuildingContext = new BasicModelBuildingContextImpl(
 				classLoading,
-				jandexIndex,
 				ModelsHelper::preFillRegistries
 		);
 
@@ -174,16 +173,11 @@ public class ManagedResourcesProcessor {
 		// OUTPUTS:
 		//		- CategorizedDomainModel
 
-		final ClassDetailsRegistry classDetailsRegistryImmutable = classDetailsRegistry
-				.makeImmutableCopy();
-
-		final AnnotationDescriptorRegistry annotationDescriptorRegistryImmutable = descriptorRegistry
-				.makeImmutableCopy();
 
 		// Collect the entity hierarchies based on the set of `rootEntities`
 		final ModelCategorizationContextImpl mappingBuildingContext = new ModelCategorizationContextImpl(
-				classDetailsRegistryImmutable,
-				annotationDescriptorRegistryImmutable,
+				classDetailsRegistry,
+				descriptorRegistry,
 				globalRegistrations
 		);
 
@@ -212,8 +206,8 @@ public class ManagedResourcesProcessor {
 		return modelCategorizationCollector.createResult(
 				entityHierarchies,
 				xmlPreProcessingResult.getPersistenceUnitMetadata(),
-				classDetailsRegistryImmutable,
-				annotationDescriptorRegistryImmutable
+				classDetailsRegistry,
+				descriptorRegistry
 		);
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/internal/ModelsHelper.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/internal/ModelsHelper.java
@@ -6,10 +6,15 @@
  */
 package org.hibernate.boot.models.internal;
 
+import java.util.function.Supplier;
+
 import org.hibernate.annotations.TenantId;
+import org.hibernate.models.internal.MutableClassDetailsRegistry;
 import org.hibernate.models.internal.jdk.JdkBuilders;
+import org.hibernate.models.jandex.internal.JandexClassDetails;
 import org.hibernate.models.jandex.spi.JandexModelBuildingContext;
 import org.hibernate.models.spi.AnnotationDescriptorRegistry;
+import org.hibernate.models.spi.ClassDetails;
 import org.hibernate.models.spi.ClassDetailsRegistry;
 import org.hibernate.models.spi.RegistryPrimer;
 import org.hibernate.models.spi.SourceModelBuildingContext;
@@ -51,8 +56,26 @@ public class ModelsHelper {
 					);
 				}
 
-				classDetailsRegistry.resolveClassDetails( className );
+				resolveClassDetails(
+						className,
+						classDetailsRegistry,
+						() -> new JandexClassDetails( knownClass, buildingContext )
+				);
 			}
 		}
+	}
+
+	public static ClassDetails resolveClassDetails(
+			String className,
+			ClassDetailsRegistry classDetailsRegistry,
+			Supplier<ClassDetails> classDetailsSupplier) {
+		ClassDetails classDetails = classDetailsRegistry.findClassDetails( className );
+		if ( classDetails != null ) {
+			return classDetails;
+		}
+		classDetails = classDetailsSupplier.get();
+		classDetailsRegistry.as( MutableClassDetailsRegistry.class )
+				.addClassDetails( className, classDetails );
+		return classDetails;
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/internal/ModelsHelper.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/internal/ModelsHelper.java
@@ -7,8 +7,8 @@
 package org.hibernate.boot.models.internal;
 
 import org.hibernate.annotations.TenantId;
-import org.hibernate.models.internal.jandex.JandexClassDetails;
 import org.hibernate.models.internal.jdk.JdkBuilders;
+import org.hibernate.models.jandex.spi.JandexModelBuildingContext;
 import org.hibernate.models.spi.AnnotationDescriptorRegistry;
 import org.hibernate.models.spi.ClassDetailsRegistry;
 import org.hibernate.models.spi.RegistryPrimer;
@@ -26,34 +26,33 @@ public class ModelsHelper {
 
 		buildingContext.getAnnotationDescriptorRegistry().getDescriptor( TenantId.class );
 
-		final IndexView jandexIndex = buildingContext.getJandexIndex();
-		if ( jandexIndex == null ) {
-			return;
-		}
-
-		final ClassDetailsRegistry classDetailsRegistry = buildingContext.getClassDetailsRegistry();
-		final AnnotationDescriptorRegistry annotationDescriptorRegistry = buildingContext.getAnnotationDescriptorRegistry();
-
-		for ( ClassInfo knownClass : jandexIndex.getKnownClasses() ) {
-			final String className = knownClass.name().toString();
-
-			if ( knownClass.isAnnotation() ) {
-				// it is always safe to load the annotation classes - we will never be enhancing them
-				//noinspection rawtypes
-				final Class annotationClass = buildingContext
-						.getClassLoading()
-						.classForName( className );
-				//noinspection unchecked
-				annotationDescriptorRegistry.resolveDescriptor(
-						annotationClass,
-						(t) -> JdkBuilders.buildAnnotationDescriptor( annotationClass, buildingContext )
-				);
+		if ( buildingContext instanceof JandexModelBuildingContext ) {
+			final IndexView jandexIndex = buildingContext.as( JandexModelBuildingContext.class ).getJandexIndex();
+			if ( jandexIndex == null ) {
+				return;
 			}
 
-			classDetailsRegistry.resolveClassDetails(
-					className,
-					(name) -> new JandexClassDetails( knownClass, buildingContext )
-			);
+			final ClassDetailsRegistry classDetailsRegistry = buildingContext.getClassDetailsRegistry();
+			final AnnotationDescriptorRegistry annotationDescriptorRegistry = buildingContext.getAnnotationDescriptorRegistry();
+
+			for ( ClassInfo knownClass : jandexIndex.getKnownClasses() ) {
+				final String className = knownClass.name().toString();
+
+				if ( knownClass.isAnnotation() ) {
+					// it is always safe to load the annotation classes - we will never be enhancing them
+					//noinspection rawtypes
+					final Class annotationClass = buildingContext
+							.getClassLoading()
+							.classForName( className );
+					//noinspection unchecked
+					annotationDescriptorRegistry.resolveDescriptor(
+							annotationClass,
+							(t) -> JdkBuilders.buildAnnotationDescriptor( annotationClass, buildingContext )
+					);
+				}
+
+				classDetailsRegistry.resolveClassDetails( className );
+			}
 		}
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/internal/OrmAnnotationHelper.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/internal/OrmAnnotationHelper.java
@@ -15,7 +15,6 @@ import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
-import java.util.Map;
 import java.util.function.Consumer;
 
 import org.hibernate.boot.models.DialectOverrideAnnotations;
@@ -23,13 +22,13 @@ import org.hibernate.boot.models.HibernateAnnotations;
 import org.hibernate.boot.models.JpaAnnotations;
 import org.hibernate.boot.models.XmlAnnotations;
 import org.hibernate.models.AnnotationAccessException;
+import org.hibernate.models.jandex.spi.JandexModelBuildingContext;
+import org.hibernate.models.jandex.spi.JandexValueExtractor;
 import org.hibernate.models.spi.AnnotationDescriptor;
 import org.hibernate.models.spi.AttributeDescriptor;
-import org.hibernate.models.spi.JandexValueExtractor;
 import org.hibernate.models.spi.SourceModelBuildingContext;
 
 import org.jboss.jandex.AnnotationInstance;
-import org.jboss.jandex.AnnotationValue;
 
 /**
  * @author Steve Ebersole
@@ -76,7 +75,8 @@ public class OrmAnnotationHelper {
 	}
 
 	public static <V> V extractJandexValue(AnnotationInstance jandexAnnotation, AttributeDescriptor<V> attributeDescriptor, SourceModelBuildingContext modelContext) {
-		final JandexValueExtractor<V> extractor = attributeDescriptor.getTypeDescriptor().createJandexValueExtractor( modelContext );
+		final JandexValueExtractor<V> extractor = modelContext.as( JandexModelBuildingContext.class )
+				.getJandexValueExtractor( attributeDescriptor.getTypeDescriptor() );
 		return extractor.extractValue( jandexAnnotation, attributeDescriptor, modelContext );
 //		final AnnotationValue value = jandexAnnotation.value( attributeDescriptor.getName() );
 //		return attributeDescriptor

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/xml/internal/ManagedTypeProcessor.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/xml/internal/ManagedTypeProcessor.java
@@ -32,6 +32,7 @@ import org.hibernate.boot.models.annotations.internal.AttributeAccessorAnnotatio
 import org.hibernate.boot.models.annotations.internal.CacheAnnotation;
 import org.hibernate.boot.models.annotations.internal.CacheableJpaAnnotation;
 import org.hibernate.boot.models.annotations.internal.ExtendsXmlAnnotation;
+import org.hibernate.boot.models.internal.ModelsHelper;
 import org.hibernate.boot.models.xml.internal.attr.BasicAttributeProcessing;
 import org.hibernate.boot.models.xml.internal.attr.BasicIdAttributeProcessing;
 import org.hibernate.boot.models.xml.internal.attr.CommonAttributeProcessing;
@@ -100,7 +101,19 @@ public class ManagedTypeProcessor {
 
 			memberAdjuster = ManagedTypeProcessor::adjustDynamicTypeMember;
 			classAccessType = AccessType.FIELD;
-			classDetails = (MutableClassDetails) classDetailsRegistry.resolveClassDetails( jaxbEntity.getName() );
+			classDetails = (MutableClassDetails) ModelsHelper.resolveClassDetails(
+					jaxbEntity.getName(),
+					classDetailsRegistry,
+					() ->
+							new DynamicClassDetails(
+									jaxbEntity.getName(),
+									null,
+									false,
+									null,
+									null,
+									xmlDocumentContext.getModelBuildingContext()
+							)
+			);
 
 			prepareDynamicClass( classDetails, jaxbEntity, xmlDocumentContext );
 		}
@@ -934,8 +947,15 @@ public class ManagedTypeProcessor {
 				throw new ModelsException( "Embeddable did not define class nor name" );
 			}
 			// no class == dynamic...
-			classDetails = (MutableClassDetails) classDetailsRegistry
-					.resolveClassDetails( jaxbEmbeddable.getName() );
+			classDetails = (MutableClassDetails) ModelsHelper.resolveClassDetails(
+					jaxbEmbeddable.getName(),
+					classDetailsRegistry,
+					() ->
+							new DynamicClassDetails(
+									jaxbEmbeddable.getName(),
+									xmlDocumentContext.getModelBuildingContext()
+							)
+			);
 			classAccessType = AccessType.FIELD;
 			memberAdjuster = ManagedTypeProcessor::adjustDynamicTypeMember;
 

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/xml/spi/XmlDocumentContext.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/xml/spi/XmlDocumentContext.java
@@ -20,6 +20,7 @@ import org.hibernate.boot.jaxb.mapping.spi.JaxbEmbeddedMapping;
 import org.hibernate.boot.jaxb.mapping.spi.JaxbPersistentAttribute;
 import org.hibernate.boot.jaxb.mapping.spi.JaxbPluralAttribute;
 import org.hibernate.boot.jaxb.mapping.spi.JaxbUserTypeImpl;
+import org.hibernate.boot.models.internal.ModelsHelper;
 import org.hibernate.boot.models.xml.internal.XmlAnnotationHelper;
 import org.hibernate.boot.spi.BootstrapContext;
 import org.hibernate.boot.spi.EffectiveMappingDefaults;
@@ -137,8 +138,11 @@ public interface XmlDocumentContext {
 			// <embedded/>, <embedded-id/>
 			final String target = jaxbEmbeddedMapping.getTarget();
 			if ( isNotEmpty( target ) ) {
-				return (MutableClassDetails) getModelBuildingContext().getClassDetailsRegistry()
-						.resolveClassDetails( target );
+				return (MutableClassDetails) ModelsHelper.resolveClassDetails(
+						target,
+						getModelBuildingContext().getClassDetailsRegistry(),
+						() -> new DynamicClassDetails( target, getModelBuildingContext() )
+				);
 			}
 			// fall through to exception
 		}
@@ -146,8 +150,18 @@ public interface XmlDocumentContext {
 		if ( jaxbPersistentAttribute instanceof JaxbAssociationAttribute jaxbAssociationAttribute ) {
 			final String target = jaxbAssociationAttribute.getTargetEntity();
 			if ( isNotEmpty( target ) ) {
-				return (MutableClassDetails) getModelBuildingContext().getClassDetailsRegistry()
-						.resolveClassDetails( target );
+				return (MutableClassDetails) ModelsHelper.resolveClassDetails(
+						target,
+						getModelBuildingContext().getClassDetailsRegistry(),
+						() -> new DynamicClassDetails(
+								target,
+								null,
+								false,
+								null,
+								null,
+								getModelBuildingContext()
+						)
+				);
 			}
 			// fall through to exception
 		}

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/xml/spi/XmlDocumentContext.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/xml/spi/XmlDocumentContext.java
@@ -137,10 +137,8 @@ public interface XmlDocumentContext {
 			// <embedded/>, <embedded-id/>
 			final String target = jaxbEmbeddedMapping.getTarget();
 			if ( isNotEmpty( target ) ) {
-				return (MutableClassDetails) getModelBuildingContext().getClassDetailsRegistry().resolveClassDetails(
-						target,
-						(name) -> new DynamicClassDetails( target, getModelBuildingContext() )
-				);
+				return (MutableClassDetails) getModelBuildingContext().getClassDetailsRegistry()
+						.resolveClassDetails( target );
 			}
 			// fall through to exception
 		}
@@ -148,17 +146,8 @@ public interface XmlDocumentContext {
 		if ( jaxbPersistentAttribute instanceof JaxbAssociationAttribute jaxbAssociationAttribute ) {
 			final String target = jaxbAssociationAttribute.getTargetEntity();
 			if ( isNotEmpty( target ) ) {
-				return (MutableClassDetails) getModelBuildingContext().getClassDetailsRegistry().resolveClassDetails(
-						target,
-						(name) -> new DynamicClassDetails(
-								target,
-								null,
-								false,
-								null,
-								null,
-								getModelBuildingContext()
-						)
-				);
+				return (MutableClassDetails) getModelBuildingContext().getClassDetailsRegistry()
+						.resolveClassDetails( target );
 			}
 			// fall through to exception
 		}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/xml/ejb3/Ejb3XmlTestCase.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/xml/ejb3/Ejb3XmlTestCase.java
@@ -20,7 +20,7 @@ import org.hibernate.boot.models.xml.spi.XmlProcessingResult;
 import org.hibernate.boot.models.xml.spi.XmlProcessor;
 import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
 import org.hibernate.boot.spi.BootstrapContext;
-import org.hibernate.models.internal.SourceModelBuildingContextImpl;
+import org.hibernate.models.internal.BasicModelBuildingContextImpl;
 import org.hibernate.models.spi.ClassDetails;
 import org.hibernate.models.spi.FieldDetails;
 import org.hibernate.models.spi.MemberDetails;
@@ -91,9 +91,8 @@ public abstract class Ejb3XmlTestCase extends BaseUnitTestCase {
 				persistenceUnitMetadata
 		);
 
-		final SourceModelBuildingContext modelBuildingContext = new SourceModelBuildingContextImpl(
+		final SourceModelBuildingContext modelBuildingContext = new BasicModelBuildingContextImpl(
 				SIMPLE_CLASS_LOADING,
-				null,
 				(contributions, inFlightContext) -> {
 					OrmAnnotationHelper.forEachOrmAnnotation( contributions::registerAnnotation );
 				}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/boot/models/SourceModelTestHelperSmokeTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/boot/models/SourceModelTestHelperSmokeTests.java
@@ -7,7 +7,7 @@
 package org.hibernate.orm.test.boot.models;
 
 import org.hibernate.models.AnnotationAccessException;
-import org.hibernate.models.internal.jandex.JandexClassDetails;
+import org.hibernate.models.jandex.internal.JandexClassDetails;
 import org.hibernate.models.spi.AnnotationDescriptor;
 import org.hibernate.models.spi.ClassDetails;
 import org.hibernate.models.spi.FieldDetails;

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/intg/AdditionalMappingContributorTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/intg/AdditionalMappingContributorTests.java
@@ -11,20 +11,13 @@ import java.io.InputStream;
 import java.util.List;
 
 import org.hibernate.boot.ResourceStreamLocator;
-import org.hibernate.boot.models.HibernateAnnotations;
-import org.hibernate.boot.models.JpaAnnotations;
-import org.hibernate.boot.models.annotations.internal.EntityJpaAnnotation;
 import org.hibernate.boot.spi.AdditionalMappingContributions;
 import org.hibernate.boot.spi.AdditionalMappingContributor;
 import org.hibernate.boot.spi.InFlightMetadataCollector;
 import org.hibernate.boot.spi.MetadataBuildingContext;
 import org.hibernate.mapping.PersistentClass;
-import org.hibernate.models.internal.dynamic.DynamicClassDetails;
-import org.hibernate.models.internal.dynamic.DynamicFieldDetails;
-import org.hibernate.models.internal.jdk.JdkClassDetails;
 import org.hibernate.models.spi.ClassDetails;
 import org.hibernate.models.spi.ClassDetailsRegistry;
-import org.hibernate.models.spi.MutableMemberDetails;
 
 import org.hibernate.testing.orm.junit.BootstrapServiceRegistry;
 import org.hibernate.testing.orm.junit.BootstrapServiceRegistry.JavaService;
@@ -43,7 +36,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author Steve Ebersole
- *
  * @implNote hibernate-envers is already a full testing of contributing a {@code hbm.xml}
  * document; so we skip that here until if/when we transition it to use a better approach
  */
@@ -105,13 +97,17 @@ public class AdditionalMappingContributorTests {
 	@DomainModel
 	@SessionFactory
 	@SuppressWarnings("JUnitMalformedDeclaration")
-	void verifyJdkClassDetailsContributions(DomainModelScope domainModelScope, SessionFactoryScope sessionFactoryScope) {
-		final PersistentClass entity4Binding = domainModelScope.getDomainModel().getEntityBinding( Entity4.class.getName() );
+	void verifyJdkClassDetailsContributions(
+			DomainModelScope domainModelScope,
+			SessionFactoryScope sessionFactoryScope) {
+		final PersistentClass entity4Binding = domainModelScope.getDomainModel()
+				.getEntityBinding( Entity4.class.getName() );
 		assertThat( entity4Binding ).isNotNull();
 		assertThat( entity4Binding.getIdentifierProperty() ).isNotNull();
 		assertThat( entity4Binding.getProperties() ).hasSize( 1 );
 
-		final PersistentClass entity5Binding = domainModelScope.getDomainModel().getEntityBinding( Entity5.class.getName() );
+		final PersistentClass entity5Binding = domainModelScope.getDomainModel()
+				.getEntityBinding( Entity5.class.getName() );
 		assertThat( entity5Binding ).isNotNull();
 		assertThat( entity5Binding.getIdentifierProperty() ).isNotNull();
 		assertThat( entity5Binding.getProperties() ).hasSize( 1 );
@@ -137,7 +133,9 @@ public class AdditionalMappingContributorTests {
 	@DomainModel
 	@SessionFactory
 	@SuppressWarnings("JUnitMalformedDeclaration")
-	void verifyDynamicClassDetailsContributions(DomainModelScope domainModelScope, SessionFactoryScope sessionFactoryScope) {
+	void verifyDynamicClassDetailsContributions(
+			DomainModelScope domainModelScope,
+			SessionFactoryScope sessionFactoryScope) {
 		final PersistentClass entity6Binding = domainModelScope.getDomainModel().getEntityBinding( "Entity6" );
 		assertThat( entity6Binding ).isNotNull();
 		assertThat( entity6Binding.getIdentifierProperty() ).isNotNull();
@@ -150,12 +148,12 @@ public class AdditionalMappingContributorTests {
 		} );
 	}
 
-	@Entity( name = "Entity1" )
-	@Table( name = "Entity1" )
+	@Entity(name = "Entity1")
+	@Table(name = "Entity1")
 	public static class Entity1 {
-	    @Id
-	    private Integer id;
-	    @Basic
+		@Id
+		private Integer id;
+		@Basic
 		private String name;
 
 		@SuppressWarnings("unused")
@@ -182,12 +180,12 @@ public class AdditionalMappingContributorTests {
 	}
 
 
-	@Entity( name = "Entity2" )
-	@Table( name = "Entity2" )
+	@Entity(name = "Entity2")
+	@Table(name = "Entity2")
 	public static class Entity2 {
-	    @Id
-	    private Integer id;
-	    @Basic
+		@Id
+		private Integer id;
+		@Basic
 		private String name;
 
 		@SuppressWarnings("unused")
@@ -213,12 +211,12 @@ public class AdditionalMappingContributorTests {
 		}
 	}
 
-	@Entity( name = "Entity3" )
-	@Table( name = "Entity3" )
+	@Entity(name = "Entity3")
+	@Table(name = "Entity3")
 	public static class Entity3 {
-	    @Id
-	    private Integer id;
-	    @Basic
+		@Id
+		private Integer id;
+		@Basic
 		private String name;
 
 		@SuppressWarnings("unused")
@@ -245,8 +243,8 @@ public class AdditionalMappingContributorTests {
 	}
 
 	@SuppressWarnings("unused")
-	@Entity(name="Entity4")
-	@Table(name="Entity4")
+	@Entity(name = "Entity4")
+	@Table(name = "Entity4")
 	public static class Entity4 {
 		@Id
 		private Integer id;
@@ -277,7 +275,8 @@ public class AdditionalMappingContributorTests {
 				InFlightMetadataCollector metadata,
 				ResourceStreamLocator resourceStreamLocator,
 				MetadataBuildingContext buildingContext) {
-			try ( final InputStream stream = resourceStreamLocator.locateResourceStream( "mappings/intg/contributed-mapping.xml" ) ) {
+			try (final InputStream stream = resourceStreamLocator.locateResourceStream(
+					"mappings/intg/contributed-mapping.xml" )) {
 				contributions.contributeBinding( stream );
 			}
 			catch (IOException e) {
@@ -297,50 +296,24 @@ public class AdditionalMappingContributorTests {
 					.getSourceModelBuildingContext()
 					.getClassDetailsRegistry();
 
-			contributeEntity4Details( contributions, buildingContext, classDetailsRegistry );
-			contributeEntity5Details( contributions, buildingContext, classDetailsRegistry );
+			contributeEntity4Details( contributions, classDetailsRegistry );
+			contributeEntity5Details( contributions, classDetailsRegistry );
 		}
 
 		private static void contributeEntity4Details(
 				AdditionalMappingContributions contributions,
-				MetadataBuildingContext buildingContext,
 				ClassDetailsRegistry classDetailsRegistry) {
 			final ClassDetails entity4Details = classDetailsRegistry.resolveClassDetails(
-					Entity4.class.getName(),
-					(name, modelBuildingContext) -> {
-						assertThat( name ).isEqualTo( Entity4.class.getName() );
-						assertThat( modelBuildingContext ).isSameAs( buildingContext.getMetadataCollector().getSourceModelBuildingContext() );
-						return new JdkClassDetails( Entity4.class, modelBuildingContext );
-					}
+					Entity4.class.getName()
 			);
 			contributions.contributeManagedClass( entity4Details );
 		}
 
 		private static void contributeEntity5Details(
 				AdditionalMappingContributions contributions,
-				MetadataBuildingContext buildingContext,
 				ClassDetailsRegistry classDetailsRegistry) {
 			final ClassDetails entity5Details = classDetailsRegistry.resolveClassDetails(
-					Entity5.class.getName(),
-					(name, modelBuildingContext) -> {
-						assertThat( name ).isEqualTo( Entity5.class.getName() );
-						assertThat( modelBuildingContext ).isSameAs( buildingContext.getMetadataCollector().getSourceModelBuildingContext() );
-						final JdkClassDetails jdkClassDetails = new JdkClassDetails(
-								Entity5.class,
-								modelBuildingContext
-						);
-
-						final EntityJpaAnnotation entityUsage = (EntityJpaAnnotation) jdkClassDetails.applyAnnotationUsage(
-								JpaAnnotations.ENTITY,
-								modelBuildingContext
-						);
-						entityUsage.name( "___Entity5___" );
-
-						final MutableMemberDetails idField = (MutableMemberDetails) jdkClassDetails.findFieldByName( "id" );
-						idField.applyAnnotationUsage( JpaAnnotations.ID, modelBuildingContext );
-
-						return jdkClassDetails;
-					}
+					Entity5.class.getName()
 			);
 			contributions.contributeManagedClass( entity5Details );
 		}
@@ -356,46 +329,14 @@ public class AdditionalMappingContributorTests {
 			final ClassDetailsRegistry classDetailsRegistry = buildingContext.getMetadataCollector()
 					.getSourceModelBuildingContext()
 					.getClassDetailsRegistry();
-			contributeEntity6Details( contributions, buildingContext, classDetailsRegistry );
+			contributeEntity6Details( contributions, classDetailsRegistry );
 		}
 
 		private void contributeEntity6Details(
 				AdditionalMappingContributions contributions,
-				MetadataBuildingContext buildingContext,
 				ClassDetailsRegistry classDetailsRegistry) {
 			final ClassDetails entity6Details = classDetailsRegistry.resolveClassDetails(
-					"Entity6",
-					(name, modelBuildingContext) -> {
-						assertThat( name ).isEqualTo( "Entity6" );
-						assertThat( modelBuildingContext ).isSameAs( buildingContext.getMetadataCollector().getSourceModelBuildingContext() );
-
-						final DynamicClassDetails classDetails = new DynamicClassDetails( "Entity6", modelBuildingContext );
-						final EntityJpaAnnotation entityUsage = (EntityJpaAnnotation) classDetails.applyAnnotationUsage(
-								JpaAnnotations.ENTITY,
-								modelBuildingContext
-						);
-						entityUsage.name( "Entity6" );
-
-						final DynamicFieldDetails idMember = classDetails.applyAttribute(
-								"id",
-								classDetailsRegistry.resolveClassDetails( Integer.class.getName() ),
-								false,
-								false,
-								modelBuildingContext
-						);
-						idMember.applyAnnotationUsage( JpaAnnotations.ID, modelBuildingContext );
-
-						final DynamicFieldDetails nameMember = classDetails.applyAttribute(
-								"name",
-								classDetailsRegistry.resolveClassDetails( String.class.getName() ),
-								false,
-								false,
-								modelBuildingContext
-						);
-						nameMember.applyAnnotationUsage( HibernateAnnotations.NATIONALIZED, modelBuildingContext );
-
-						return classDetails;
-					}
+					"Entity6"
 			);
 			contributions.contributeManagedClass( entity6Details );
 		}

--- a/settings.gradle
+++ b/settings.gradle
@@ -76,7 +76,7 @@ dependencyResolutionManagement {
             def byteBuddyVersion = version "byteBuddy", "1.14.18"
             def classmateVersion = version "classmate", "1.5.1"
             def geolatteVersion = version "geolatte", "1.9.1"
-            def hibernateModelsVersion = version "hibernateModels", "0.8.6"
+            def hibernateModelsVersion = version "hibernateModels", "0.9.0"
             def jandexVersion = version "jandex", "3.2.0"
             def jacksonVersion = version "jackson", "2.17.0"
             def jbossLoggingVersion = version "jbossLogging", "3.6.0.Final"
@@ -107,6 +107,7 @@ dependencyResolutionManagement {
             library( "loggingProcessor", "org.jboss.logging", "jboss-logging-processor" ).versionRef( jbossLoggingToolVersion )
 
             library( "hibernateModels", "org.hibernate.models", "hibernate-models" ).versionRef( hibernateModelsVersion )
+            library( "hibernateModelsJandex", "org.hibernate.models", "hibernate-models-jandex" ).versionRef( hibernateModelsVersion )
             library( "jandex", "io.smallrye", "jandex" ).versionRef( jandexVersion )
             library( "classmate", "com.fasterxml", "classmate" ).versionRef( classmateVersion )
 


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-18520 Upgrade to hibernate-models 0.9.0
https://hibernate.atlassian.net/browse/HHH-18521 Leverage hibernate-models ModelsConfiguration

need to finish replacing the constructors for Annotations used by Jandex
 
<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
