### PR TITLE
HHH-18487 align version unsaved-value with semantics of persist()

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/engine/internal/UnsavedValueFactory.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/internal/UnsavedValueFactory.java
@@ -21,6 +21,8 @@ import org.hibernate.type.descriptor.java.JavaType;
 import org.hibernate.type.descriptor.java.VersionJavaType;
 import org.hibernate.type.descriptor.java.spi.PrimitiveJavaType;
 
+import static org.hibernate.engine.internal.Versioning.isNullInitialVersion;
+
 /**
  * Helper for dealing with unsaved value handling
  *
@@ -81,25 +83,20 @@ public class UnsavedValueFactory {
 	public static <T> VersionValue getUnsavedVersionValue(
 			KeyValue bootVersionMapping,
 			VersionJavaType<T> jtd,
-			Long length,
-			Integer precision,
-			Integer scale,
 			Getter getter,
-			Supplier<?> templateInstanceAccess,
-			SessionFactoryImplementor sessionFactory) {
+			Supplier<?> templateInstanceAccess) {
 		final String unsavedValue = bootVersionMapping.getNullValue();
 		if ( unsavedValue == null ) {
 			if ( getter != null && templateInstanceAccess != null ) {
-				Object templateInstance = templateInstanceAccess.get();
+				final Object templateInstance = templateInstanceAccess.get();
 				@SuppressWarnings("unchecked")
 				final T defaultValue = (T) getter.get( templateInstance );
-
-				// if the version of a newly instantiated object is not the same
-				// as the version seed value, use that as the unsaved-value
-				final T seedValue = jtd.seed( length, precision, scale, mockSession( sessionFactory ) );
-				return jtd.areEqual( seedValue, defaultValue )
-						? VersionValue.UNDEFINED
-						: new VersionValue( defaultValue );
+				// if the version of a newly instantiated object is null
+				// or a negative number, use that value as the unsaved-value,
+				// otherwise assume it's the initial version set by program
+				return isNullInitialVersion( defaultValue )
+						? new VersionValue( defaultValue )
+						: VersionValue.UNDEFINED;
 			}
 			else {
 				return VersionValue.UNDEFINED;

--- a/hibernate-core/src/main/java/org/hibernate/engine/internal/Versioning.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/internal/Versioning.java
@@ -6,7 +6,6 @@
  */
 package org.hibernate.engine.internal;
 
-import org.hibernate.Remove;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.internal.CoreMessageLogger;
 import org.hibernate.metamodel.mapping.EntityVersionMapping;
@@ -87,43 +86,12 @@ public final class Versioning {
 	}
 
 	/**
-	 * Create an initial optimistic locking value according the {@link VersionJavaType}
-	 * contract for the version property <em>if required</em> and inject it into the
-	 * snapshot state.
-	 *
-	 * @param fields The current snapshot state
-	 * @param versionProperty The index of the version property
-	 * @param versionMapping The version mapping
-	 * @param session The originating session
-	 * @return True if we injected a new version value into the fields array; false
-	 * otherwise.
-	 *
-	 * @deprecated Use {@link #seedVersion(Object, Object[], EntityPersister, SharedSessionContractImplementor)}
-	 */
-	@Deprecated(since = "6.2") @Remove
-	public static boolean seedVersion(
-			Object[] fields,
-			int versionProperty,
-			EntityVersionMapping versionMapping,
-			SharedSessionContractImplementor session) {
-		final Object initialVersion = fields[versionProperty];
-		if ( isNullInitialVersion( initialVersion ) ) {
-			fields[versionProperty] = seed( versionMapping, session );
-			return true;
-		}
-		else {
-			LOG.tracev( "Using initial version: {0}", initialVersion );
-			return false;
-		}
-	}
-
-	/**
 	 * Determines if the value of the assigned  version property should be considered
 	 * a "null" value, that is, if it is literally {@code null}, or if it is a negative
 	 * integer.
 	 *
 	 * @param initialVersion The value initially assigned to a version property
-	 * @return {@code} if the value shoudl be considered null for this purpose
+	 * @return {@code} if the value should be considered null for this purpose
 	 */
 	public static boolean isNullInitialVersion(Object initialVersion) {
 		return initialVersion == null

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/EntityVersionMappingImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/EntityVersionMappingImpl.java
@@ -54,7 +54,7 @@ public class EntityVersionMappingImpl implements EntityVersionMapping, FetchOpti
 	private final Integer scale;
 	private final Integer temporalPrecision;
 
-	private final BasicType versionBasicType;
+	private final BasicType<?> versionBasicType;
 
 	private final VersionValue unsavedValueStrategy;
 
@@ -90,15 +90,10 @@ public class EntityVersionMappingImpl implements EntityVersionMapping, FetchOpti
 		unsavedValueStrategy = UnsavedValueFactory.getUnsavedVersionValue(
 				(KeyValue) bootEntityDescriptor.getVersion().getValue(),
 				(VersionJavaType<?>) versionBasicType.getJavaTypeDescriptor(),
-				length,
-				precision,
-				scale,
-				declaringType
-						.getRepresentationStrategy()
+				declaringType.getRepresentationStrategy()
 						.resolvePropertyAccess( bootEntityDescriptor.getVersion() )
 						.getGetter(),
-				templateInstanceAccess,
-				creationProcess.getCreationContext().getSessionFactory()
+				templateInstanceAccess
 		);
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/sql/exec/internal/VersionTypeSeedParameterSpecification.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/exec/internal/VersionTypeSeedParameterSpecification.java
@@ -10,10 +10,8 @@ import java.sql.PreparedStatement;
 import java.sql.SQLException;
 
 import org.hibernate.metamodel.mapping.EntityVersionMapping;
-import org.hibernate.metamodel.mapping.JdbcMapping;
 import org.hibernate.sql.exec.spi.ExecutionContext;
 import org.hibernate.sql.exec.spi.JdbcParameterBindings;
-import org.hibernate.type.descriptor.java.VersionJavaType;
 
 /**
  * Parameter bind specification used for optimistic lock version seeding (from insert statements).

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/VersionJavaType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/VersionJavaType.java
@@ -16,6 +16,10 @@ import org.hibernate.engine.spi.SharedSessionContractImplementor;
 public interface VersionJavaType<T> extends JavaType<T> {
 	/**
 	 * Generate an initial version.
+	 * <p>
+	 * Note that this operation is only used when the program sets a null or negative
+	 * number as the value of the entity version field. It is not called when the
+	 * program sets the version field to a sensible-looking version.
 	 *
 	 * @param length The length of the type
 	 * @param precision The precision of the type

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/ops/MergeExplicitInitialVersionTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/ops/MergeExplicitInitialVersionTest.java
@@ -1,0 +1,71 @@
+package org.hibernate.orm.test.ops;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Version;
+import org.hibernate.testing.orm.junit.EntityManagerFactoryScope;
+import org.hibernate.testing.orm.junit.Jpa;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@Jpa(annotatedClasses = {MergeExplicitInitialVersionTest.E.class,
+        MergeExplicitInitialVersionTest.F.class,
+        MergeExplicitInitialVersionTest.G.class})
+public class MergeExplicitInitialVersionTest {
+    @Test public void testGeneratedId(EntityManagerFactoryScope scope) {
+        E e = new E();
+        scope.inTransaction(s->s.persist(e));
+        assertEquals(e.version, 1);
+        e.text = "hello";
+        E e2 = scope.fromTransaction(s->s.merge(e));
+        assertEquals(e2.version, 2);
+    }
+    @Test public void testAssignedId(EntityManagerFactoryScope scope) {
+        F f = new F();
+        scope.inTransaction(s->s.persist(f));
+        assertEquals(f.version, 1);
+        f.text = "hello";
+        F f2 = scope.fromTransaction(s->s.merge(f));
+        assertEquals(f2.version, 2);
+    }
+    @Test public void testNegativeVersion(EntityManagerFactoryScope scope) {
+        G g = new G();
+        scope.inTransaction(s->s.persist(g));
+        assertEquals(g.version, 0);
+        g.text = "hello";
+        G g2 = scope.fromTransaction(s->s.merge(g));
+        assertEquals(g2.version, 1);
+    }
+
+    @Entity
+    static class E {
+        @Id
+        @GeneratedValue
+        long id;
+        @Version
+        int version = 1;
+        String text;
+    }
+
+    @Entity
+    static class F {
+        @Id
+        long id = 5;
+        @Version
+        int version = 1;
+        String text;
+    }
+
+    @Entity
+    static class G {
+        @Id
+        @GeneratedValue
+        long id;
+        @Version
+        int version = -1;
+        String text;
+    }
+
+}


### PR DESCRIPTION
This was wrong for code like:

```java
@Version int version = 1;
```

<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

[Please describe here what your change is about]

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-18487
<!-- Hibernate GitHub Bot issue links end -->