### PR TITLE
HHH-18547, HHH-17114 add default implementations to UserType

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/type/EnumType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/EnumType.java
@@ -221,7 +221,8 @@ public class EnumType<T extends Enum<T>>
 	}
 
 	@Override
-	public T nullSafeGet(ResultSet rs, int position, SharedSessionContractImplementor session, Object owner) throws SQLException {
+	public T nullSafeGet(ResultSet rs, int position, SharedSessionContractImplementor session)
+			throws SQLException {
 		verifyConfigured();
 		return jdbcType.getExtractor( enumJavaType ).extract( rs, position, session );
 	}
@@ -233,7 +234,8 @@ public class EnumType<T extends Enum<T>>
 	}
 
 	@Override
-	public void nullSafeSet(PreparedStatement st, T value, int index, SharedSessionContractImplementor session) throws HibernateException, SQLException {
+	public void nullSafeSet(PreparedStatement st, T value, int index, SharedSessionContractImplementor session)
+			throws SQLException {
 		verifyConfigured();
 		jdbcType.getBinder( enumJavaType ).bind( st, value, index, session );
 	}

--- a/hibernate-core/src/main/java/org/hibernate/usertype/BaseUserTypeSupport.java
+++ b/hibernate-core/src/main/java/org/hibernate/usertype/BaseUserTypeSupport.java
@@ -82,7 +82,7 @@ public abstract class BaseUserTypeSupport<T> implements UserType<T> {
 	}
 
 	@Override
-	public T nullSafeGet(ResultSet rs, int position, SharedSessionContractImplementor session, Object owner) throws SQLException {
+	public T nullSafeGet(ResultSet rs, int position, SharedSessionContractImplementor session) throws SQLException {
 		ensureResolved();
 		return jdbcValueExtractor.extract( rs, position, session );
 	}

--- a/hibernate-core/src/main/java/org/hibernate/usertype/StaticUserTypeSupport.java
+++ b/hibernate-core/src/main/java/org/hibernate/usertype/StaticUserTypeSupport.java
@@ -115,7 +115,8 @@ public class StaticUserTypeSupport<T> implements UserType<T> {
 	}
 
 	@Override
-	public T nullSafeGet(ResultSet rs, int position, SharedSessionContractImplementor session, Object owner) throws SQLException {
+	public T nullSafeGet(ResultSet rs, int position, SharedSessionContractImplementor session)
+			throws SQLException {
 		final Object extracted = jdbcValueExtractor.extract( rs, position, session );
 
 		if ( valueConverter != null ) {
@@ -127,7 +128,8 @@ public class StaticUserTypeSupport<T> implements UserType<T> {
 	}
 
 	@Override
-	public void nullSafeSet(PreparedStatement st, T value, int index, SharedSessionContractImplementor session) throws SQLException {
+	public void nullSafeSet(PreparedStatement st, T value, int index, SharedSessionContractImplementor session)
+			throws SQLException {
 		final Object valueToBind;
 		if ( valueConverter != null ) {
 			valueToBind = valueConverter.toRelationalValue( value );

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/embeddables/DollarValueUserType.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/embeddables/DollarValueUserType.java
@@ -42,7 +42,8 @@ public class DollarValueUserType implements UserType<DollarValue> {
 	}
 
 	@Override
-	public DollarValue nullSafeGet(ResultSet rs, int position, SharedSessionContractImplementor session, Object owner) throws SQLException {
+	public DollarValue nullSafeGet(ResultSet rs, int position, SharedSessionContractImplementor session)
+			throws SQLException {
 		return new DollarValue( rs.getBigDecimal( position ) );
 	}
 
@@ -51,7 +52,7 @@ public class DollarValueUserType implements UserType<DollarValue> {
 			PreparedStatement st,
 			DollarValue value,
 			int index,
-			SharedSessionContractImplementor session) throws HibernateException, SQLException {
+			SharedSessionContractImplementor session) throws SQLException {
 		st.setBigDecimal(index, value.getAmount());
 	}
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/embeddables/MyDateUserType.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/embeddables/MyDateUserType.java
@@ -42,7 +42,8 @@ public class MyDateUserType implements UserType<MyDate> {
 	}
 
 	@Override
-	public MyDate nullSafeGet(ResultSet rs, int position, SharedSessionContractImplementor session, Object owner) throws SQLException {
+	public MyDate nullSafeGet(ResultSet rs, int position, SharedSessionContractImplementor session)
+			throws SQLException {
 		return new MyDate( rs.getDate( position ) );
 	}
 
@@ -51,7 +52,7 @@ public class MyDateUserType implements UserType<MyDate> {
 			PreparedStatement st,
 			MyDate value,
 			int index,
-			SharedSessionContractImplementor session) throws HibernateException, SQLException {
+			SharedSessionContractImplementor session) throws SQLException {
 		st.setDate(index, new java.sql.Date(value.getDate().getTime()));
 	}
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/enumerated/custom_types/FirstLetterType.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/enumerated/custom_types/FirstLetterType.java
@@ -26,7 +26,8 @@ public class FirstLetterType extends org.hibernate.type.EnumType<FirstLetter> {
 	}
 
 	@Override
-	public FirstLetter nullSafeGet(ResultSet rs, int position, SharedSessionContractImplementor session, Object owner) throws SQLException {
+	public FirstLetter nullSafeGet(ResultSet rs, int position, SharedSessionContractImplementor session)
+			throws SQLException {
 		String persistValue = (String) rs.getObject( position );
 		if ( rs.wasNull() ) {
 			return null;
@@ -36,7 +37,7 @@ public class FirstLetterType extends org.hibernate.type.EnumType<FirstLetter> {
 
 	@Override
 	public void nullSafeSet(PreparedStatement st, FirstLetter value, int index, SharedSessionContractImplementor session)
-			throws HibernateException, SQLException {
+			throws SQLException {
 		if ( value == null ) {
 			st.setNull( index, getSqlType() );
 		}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/enumerated/custom_types/LastNumberType.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/enumerated/custom_types/LastNumberType.java
@@ -26,7 +26,8 @@ public class LastNumberType extends org.hibernate.type.EnumType<LastNumber> {
 	}
 
 	@Override
-	public LastNumber nullSafeGet(ResultSet rs, int position, SharedSessionContractImplementor session, Object owner) throws SQLException {
+	public LastNumber nullSafeGet(ResultSet rs, int position, SharedSessionContractImplementor session)
+			throws SQLException {
 		String persistValue = (String) rs.getObject( position );
 		if ( rs.wasNull() ) {
 			return null;
@@ -36,7 +37,7 @@ public class LastNumberType extends org.hibernate.type.EnumType<LastNumber> {
 
 	@Override
 	public void nullSafeSet(PreparedStatement st, LastNumber value, int index, SharedSessionContractImplementor session)
-			throws HibernateException, SQLException {
+			throws SQLException {
 		if ( value == null ) {
 			st.setNull( index, getSqlType() );
 		}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/generics/StateType.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/generics/StateType.java
@@ -41,14 +41,16 @@ public class StateType implements UserType<State> {
 	}
 
 	@Override
-	public State nullSafeGet(ResultSet rs, int position, SharedSessionContractImplementor session, Object owner) throws SQLException {
+	public State nullSafeGet(ResultSet rs, int position, SharedSessionContractImplementor session)
+			throws SQLException {
 		int result = rs.getInt( position );
 		if ( rs.wasNull() ) return null;
 		return State.values()[result];
 	}
 
 	@Override
-	public void nullSafeSet(PreparedStatement st, State value, int index, SharedSessionContractImplementor session) throws HibernateException, SQLException {
+	public void nullSafeSet(PreparedStatement st, State value, int index, SharedSessionContractImplementor session)
+			throws HibernateException, SQLException {
 		if (value == null) {
 			st.setNull( index, Types.INTEGER );
 		}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/type/dynamicparameterized/MyGenericType.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/type/dynamicparameterized/MyGenericType.java
@@ -51,12 +51,14 @@ public class MyGenericType implements UserType<Object>, DynamicParameterizedType
     }
 
 	@Override
-	public void nullSafeSet(PreparedStatement st, Object value, int index, SharedSessionContractImplementor session) throws SQLException {
+	public void nullSafeSet(PreparedStatement st, Object value, int index, SharedSessionContractImplementor session)
+			throws SQLException {
 		st.setString( index, null );
 	}
 
 	@Override
-	public Object nullSafeGet(ResultSet rs, int position, SharedSessionContractImplementor session, Object owner) throws SQLException {
+	public Object nullSafeGet(ResultSet rs, int position, SharedSessionContractImplementor session)
+			throws SQLException {
 		return null;
 	}
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/type/dynamicparameterized/MyStringType.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/type/dynamicparameterized/MyStringType.java
@@ -98,12 +98,14 @@ public class MyStringType implements UserType<String>, DynamicParameterizedType 
 	}
 
 	@Override
-	public void nullSafeSet(PreparedStatement st, String value, int index, SharedSessionContractImplementor session) throws SQLException {
+	public void nullSafeSet(PreparedStatement st, String value, int index, SharedSessionContractImplementor session)
+			throws SQLException {
 		st.setString( index, this.value );
 	}
 
 	@Override
-	public String nullSafeGet(ResultSet rs, int position, SharedSessionContractImplementor session, Object owner) throws SQLException {
+	public String nullSafeGet(ResultSet rs, int position, SharedSessionContractImplementor session)
+			throws SQLException {
 		return rs.getString( position );
 	}
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/boot/models/xml/MyUserType.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/boot/models/xml/MyUserType.java
@@ -41,7 +41,7 @@ public class MyUserType implements UserType<UUID> {
 	}
 
 	@Override
-	public UUID nullSafeGet(ResultSet rs, int position, SharedSessionContractImplementor session, Object owner)
+	public UUID nullSafeGet(ResultSet rs, int position, SharedSessionContractImplementor session)
 			throws SQLException {
 		return null;
 	}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/cdi/lifecycle/ExtendedBeanManagerNotAvailableDuringCustomUserTypeInitTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/cdi/lifecycle/ExtendedBeanManagerNotAvailableDuringCustomUserTypeInitTest.java
@@ -93,13 +93,15 @@ public class ExtendedBeanManagerNotAvailableDuringCustomUserTypeInitTest {
 		}
 
 		@Override
-		public Object nullSafeGet(ResultSet rs, int i, SharedSessionContractImplementor sharedSessionContractImplementor, Object o) throws SQLException {
+		public Object nullSafeGet(ResultSet rs, int i, SharedSessionContractImplementor sharedSessionContractImplementor)
+				throws SQLException {
 			String xmldoc = rs.getString(i);
 			return rs.wasNull() ? null : xmldoc;
 		}
 
 		@Override
-		public void nullSafeSet(PreparedStatement st, Object value, int index, SharedSessionContractImplementor session) throws HibernateException, SQLException  {
+		public void nullSafeSet(PreparedStatement st, Object value, int index, SharedSessionContractImplementor session)
+				throws SQLException  {
 			if (value == null) {
 				st.setNull(index, Types.OTHER);
 			} else {

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/cdi/type/UrlType.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/cdi/type/UrlType.java
@@ -60,12 +60,14 @@ public class UrlType implements UserType<URL> {
 	}
 
 	@Override
-	public URL nullSafeGet(ResultSet rs, int position, SharedSessionContractImplementor session, Object owner) throws SQLException {
+	public URL nullSafeGet(ResultSet rs, int position, SharedSessionContractImplementor session)
+			throws SQLException {
 		throw new UnsupportedOperationException( "Not used" );
 	}
 
 	@Override
-	public void nullSafeSet(PreparedStatement st, URL value, int index, SharedSessionContractImplementor session) throws SQLException {
+	public void nullSafeSet(PreparedStatement st, URL value, int index, SharedSessionContractImplementor session)
+			throws SQLException {
 		throw new UnsupportedOperationException( "Not used" );
 	}
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/hql/ClassificationType.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/hql/ClassificationType.java
@@ -59,7 +59,8 @@ public class ClassificationType implements EnhancedUserType<Classification>, Val
 	}
 
 	@Override
-	public Classification nullSafeGet(ResultSet rs, int position, SharedSessionContractImplementor session, Object owner) throws SQLException {
+	public Classification nullSafeGet(ResultSet rs, int position, SharedSessionContractImplementor session)
+			throws SQLException {
 		final int intValue = rs.getInt( position );
 		if ( rs.wasNull() ) {
 			return null;
@@ -68,7 +69,8 @@ public class ClassificationType implements EnhancedUserType<Classification>, Val
 	}
 
 	@Override
-	public void nullSafeSet(PreparedStatement st, Classification value, int index, SharedSessionContractImplementor session) throws HibernateException, SQLException {
+	public void nullSafeSet(PreparedStatement st, Classification value, int index, SharedSessionContractImplementor session)
+			throws SQLException {
 		if ( value == null ) {
 			st.setNull( index, Types.INTEGER );
 		}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/id/usertype/UserTypeComparableIdTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/id/usertype/UserTypeComparableIdTest.java
@@ -131,7 +131,7 @@ public class UserTypeComparableIdTest {
 		}
 
 		@Override
-		public CustomId nullSafeGet(ResultSet rs, int position, SharedSessionContractImplementor session, Object owner)
+		public CustomId nullSafeGet(ResultSet rs, int position, SharedSessionContractImplementor session)
 				throws SQLException {
 			Long value = rs.getLong( position );
 
@@ -143,7 +143,7 @@ public class UserTypeComparableIdTest {
 				PreparedStatement preparedStatement,
 				CustomId customId,
 				int index,
-				SharedSessionContractImplementor sessionImplementor) throws HibernateException, SQLException {
+				SharedSessionContractImplementor sessionImplementor) throws SQLException {
 			if ( customId == null ) {
 				preparedStatement.setNull( index, Types.BIGINT );
 			}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/id/usertype/UserTypeNonComparableIdTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/id/usertype/UserTypeNonComparableIdTest.java
@@ -118,7 +118,7 @@ public class UserTypeNonComparableIdTest {
 		}
 
 		@Override
-		public CustomId nullSafeGet(ResultSet rs, int position, SharedSessionContractImplementor session, Object owner)
+		public CustomId nullSafeGet(ResultSet rs, int position, SharedSessionContractImplementor session)
 				throws SQLException {
 			Long value = rs.getLong( position );
 
@@ -130,7 +130,7 @@ public class UserTypeNonComparableIdTest {
 				PreparedStatement preparedStatement,
 				CustomId customId,
 				int index,
-				SharedSessionContractImplementor sessionImplementor) throws HibernateException, SQLException {
+				SharedSessionContractImplementor sessionImplementor) throws SQLException {
 			if ( customId == null ) {
 				preparedStatement.setNull( index, Types.BIGINT );
 			}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/query/QueryParametersValidationTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/query/QueryParametersValidationTest.java
@@ -133,7 +133,8 @@ public class QueryParametersValidationTest extends BaseEntityManagerFunctionalTe
 		}
 
 		@Override
-		public Boolean nullSafeGet(ResultSet rs, int position, SharedSessionContractImplementor session, Object owner) throws SQLException {
+		public Boolean nullSafeGet(ResultSet rs, int position, SharedSessionContractImplementor session)
+				throws SQLException {
 			return "Y".equals( rs.getString( position ) );
 		}
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/query/TypedValueParametersTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/query/TypedValueParametersTest.java
@@ -161,7 +161,8 @@ public class TypedValueParametersTest {
 		}
 
 		@Override
-		public List<String> nullSafeGet(ResultSet rs, int position, SharedSessionContractImplementor session, Object owner) throws SQLException {
+		public List<String> nullSafeGet(ResultSet rs, int position, SharedSessionContractImplementor session)
+				throws SQLException {
 			String string = rs.getString( position );
 
 			if (rs.wasNull()) {

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/basic/RepeatedMappingUserTypeTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/basic/RepeatedMappingUserTypeTests.java
@@ -129,8 +129,7 @@ public class RepeatedMappingUserTypeTests {
 		public SortedSet<Integer> nullSafeGet(
 				ResultSet rs,
 				int position,
-				SharedSessionContractImplementor session,
-				Object owner) throws SQLException {
+				SharedSessionContractImplementor session) throws SQLException {
 			return convertToEntityAttribute( rs.getString( position ) );
 		}
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/basic/bitset/BitSetUserType.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/basic/bitset/BitSetUserType.java
@@ -49,7 +49,7 @@ public class BitSetUserType implements UserType<BitSet> {
 
     @Override
     public BitSet nullSafeGet(ResultSet rs, int position,
-                              SharedSessionContractImplementor session, Object owner)
+                              SharedSessionContractImplementor session)
             throws SQLException {
         String columnValue = rs.getString(position);
         if (rs.wasNull()) {

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/usertypes/EnumUserType.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/usertypes/EnumUserType.java
@@ -62,7 +62,8 @@ public class EnumUserType<T extends Enum<T>> implements UserType<T>, Parameteriz
 	}
 
 	@Override
-	public T nullSafeGet(ResultSet rs, int position, SharedSessionContractImplementor session, Object owner) throws SQLException {
+	public T nullSafeGet(ResultSet rs, int position, SharedSessionContractImplementor session)
+			throws SQLException {
 		final String name = rs.getString( position );
 		if ( rs.wasNull() ) {
 			return null;
@@ -79,7 +80,7 @@ public class EnumUserType<T extends Enum<T>> implements UserType<T>, Parameteriz
 			PreparedStatement preparedStatement,
 			T value,
 			int index,
-			SharedSessionContractImplementor session) throws HibernateException, SQLException {
+			SharedSessionContractImplementor session) throws SQLException {
 		if ( null == value ) {
 			preparedStatement.setNull( index, Types.VARCHAR );
 		}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/usertypes/UserTypeFunctionsTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/usertypes/UserTypeFunctionsTest.java
@@ -134,7 +134,7 @@ public class UserTypeFunctionsTest {
 		}
 
 		@Override
-		public YearMonth nullSafeGet(ResultSet rs, int position, SharedSessionContractImplementor session, Object owner)
+		public YearMonth nullSafeGet(ResultSet rs, int position, SharedSessionContractImplementor session)
 				throws SQLException {
 			int intValue = rs.getInt( position );
 			if ( rs.wasNull() ) {

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/rowid/RowIdType.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/rowid/RowIdType.java
@@ -41,13 +41,14 @@ public class RowIdType implements UserType<Object>{
 	}
 
 	@Override
-	public Object nullSafeGet(ResultSet rs, int position, SharedSessionContractImplementor session, Object owner) throws SQLException {
+	public Object nullSafeGet(ResultSet rs, int position, SharedSessionContractImplementor session)
+			throws SQLException {
 		return rs.getObject( position );
 	}
 
 	@Override
 	public void nullSafeSet(PreparedStatement st, Object value, int index, SharedSessionContractImplementor session)
-			throws HibernateException, SQLException {
+			throws SQLException {
 		throw new UnsupportedOperationException();
 	}
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/type/BasicTypeRegistryTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/type/BasicTypeRegistryTest.java
@@ -141,7 +141,7 @@ public class BasicTypeRegistryTest extends BaseUnitTestCase {
 		}
 
 		@Override
-		public Object nullSafeGet(ResultSet rs, int position, SharedSessionContractImplementor session, Object owner) throws SQLException {
+		public Object nullSafeGet(ResultSet rs, int position, SharedSessionContractImplementor session) throws SQLException {
 			return null;
 		}
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/type/contributor/ArrayType.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/type/contributor/ArrayType.java
@@ -66,12 +66,14 @@ public class ArrayType implements UserType<Array>, BindableType<Array>, BasicVal
     }
 
     @Override
-    public Array nullSafeGet(ResultSet rs, int position, SharedSessionContractImplementor session, Object owner) throws SQLException {
+    public Array nullSafeGet(ResultSet rs, int position, SharedSessionContractImplementor session)
+            throws SQLException {
         return jdbcType.getExtractor( javaType ).extract( rs, position, session );
     }
 
     @Override
-    public void nullSafeSet(PreparedStatement st, Array value, int index, SharedSessionContractImplementor session) throws SQLException {
+    public void nullSafeSet(PreparedStatement st, Array value, int index, SharedSessionContractImplementor session)
+            throws SQLException {
         jdbcType.getBinder( javaType ).bind( st, value, index, session );
     }
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/type/contributor/usertype/StringWrapperUserType.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/type/contributor/usertype/StringWrapperUserType.java
@@ -51,7 +51,8 @@ public class StringWrapperUserType implements UserType<StringWrapper> {
     }
 
     @Override
-    public StringWrapper nullSafeGet(ResultSet rs, int position, SharedSessionContractImplementor session, Object owner) throws SQLException {
+    public StringWrapper nullSafeGet(ResultSet rs, int position, SharedSessionContractImplementor session)
+            throws SQLException {
         String columnValue = (String) rs.getObject( position );
         log.debugv( "Result set column {0} value is {1}", position, columnValue );
         return columnValue == null ? null : fromString( columnValue );
@@ -60,7 +61,7 @@ public class StringWrapperUserType implements UserType<StringWrapper> {
     @Override
     public void nullSafeSet(
             PreparedStatement st, StringWrapper value, int index, SharedSessionContractImplementor session)
-            throws HibernateException, SQLException {
+            throws SQLException {
         if ( value == null ) {
             log.debugv("Binding null to parameter {0} ",index);
             st.setNull( index, Types.VARCHAR );

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/typeparameters/DefaultValueIntegerType.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/typeparameters/DefaultValueIntegerType.java
@@ -49,14 +49,15 @@ public class DefaultValueIntegerType implements UserType<Integer>, Parameterized
 	}
 
 	@Override
-	public Integer nullSafeGet(ResultSet rs, int position, SharedSessionContractImplementor session, Object owner) throws SQLException {
+	public Integer nullSafeGet(ResultSet rs, int position, SharedSessionContractImplementor session)
+			throws SQLException {
 		Number result = (Number) rs.getObject( position );
 		return result == null ? defaultValue : Integer.valueOf( result.intValue() );
 	}
 
 	@Override
 	public void nullSafeSet(PreparedStatement st, Integer value, int index, SharedSessionContractImplementor session)
-			throws HibernateException, SQLException {
+			throws SQLException {
 		if ( value == null || defaultValue.equals( value ) ) {
 			log.trace( "binding null to parameter: " + index );
 			st.setNull( index, Types.INTEGER );

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/version/UserVersionTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/version/UserVersionTest.java
@@ -143,8 +143,7 @@ public class UserVersionTest extends BaseSessionFactoryFunctionalTest {
 		public CustomVersion nullSafeGet(
 				ResultSet resultSet,
 				int position,
-				SharedSessionContractImplementor session,
-				Object owner) throws HibernateException, SQLException {
+				SharedSessionContractImplementor session) throws SQLException {
 			return new CustomVersion( resultSet.getLong( position ) );
 		}
 
@@ -153,7 +152,7 @@ public class UserVersionTest extends BaseSessionFactoryFunctionalTest {
 				PreparedStatement statement,
 				CustomVersion value,
 				int index,
-				SharedSessionContractImplementor session) throws HibernateException, SQLException {
+				SharedSessionContractImplementor session) throws SQLException {
 			statement.setLong( index, value.getRev() );
 		}
 

--- a/hibernate-envers/src/main/java/org/hibernate/envers/internal/entities/RevisionTypeType.java
+++ b/hibernate-envers/src/main/java/org/hibernate/envers/internal/entities/RevisionTypeType.java
@@ -37,7 +37,8 @@ public class RevisionTypeType implements UserType<RevisionType>, Serializable {
 	}
 
 	@Override
-	public RevisionType nullSafeGet(ResultSet rs, int position, SharedSessionContractImplementor session, Object owner) throws SQLException {
+	public RevisionType nullSafeGet(ResultSet rs, int position, SharedSessionContractImplementor session)
+			throws SQLException {
 		byte byteValue = rs.getByte( position );
 		if ( rs.wasNull() ) {
 			return null;
@@ -47,12 +48,12 @@ public class RevisionTypeType implements UserType<RevisionType>, Serializable {
 
 	@Override
 	public void nullSafeSet(PreparedStatement preparedStatement, RevisionType value, int index, SharedSessionContractImplementor session)
-			throws HibernateException, SQLException {
+			throws SQLException {
 		if ( value == null ) {
 			preparedStatement.setNull( index, Types.TINYINT );
 		}
 		else {
-			preparedStatement.setByte( index, ( (RevisionType) value ).getRepresentation() );
+			preparedStatement.setByte( index, value.getRepresentation() );
 		}
 	}
 

--- a/hibernate-envers/src/test/java/org/hibernate/orm/test/envers/entities/customtype/ParametrizedTestUserType.java
+++ b/hibernate-envers/src/test/java/org/hibernate/orm/test/envers/entities/customtype/ParametrizedTestUserType.java
@@ -38,13 +38,14 @@ public class ParametrizedTestUserType implements UserType<String>, Parameterized
 	}
 
 	@Override
-	public String nullSafeGet(ResultSet rs, int position, SharedSessionContractImplementor session, Object owner) throws SQLException {
+	public String nullSafeGet(ResultSet rs, int position, SharedSessionContractImplementor session)
+			throws SQLException {
 		final String string = rs.getString( position );
 		return rs.wasNull() ? null : string;
 	}
 
 	public void nullSafeSet(PreparedStatement st, String value, int index, SharedSessionContractImplementor session)
-			throws HibernateException, SQLException {
+			throws SQLException {
 		if ( value != null ) {
 			if ( !value.startsWith( param1 ) ) {
 				value = param1 + value;

--- a/hibernate-envers/src/test/java/org/hibernate/orm/test/envers/entities/ids/CustomEnumUserType.java
+++ b/hibernate-envers/src/test/java/org/hibernate/orm/test/envers/entities/ids/CustomEnumUserType.java
@@ -45,7 +45,8 @@ public class CustomEnumUserType implements UserType<CustomEnum> {
 	}
 
 	@Override
-	public CustomEnum nullSafeGet(ResultSet rs, int position, SharedSessionContractImplementor session, Object owner) throws SQLException {
+	public CustomEnum nullSafeGet(ResultSet rs, int position, SharedSessionContractImplementor session)
+			throws SQLException {
 		String name = rs.getString( position );
 		if ( rs.wasNull() ) {
 			return null;
@@ -54,7 +55,7 @@ public class CustomEnumUserType implements UserType<CustomEnum> {
 	}
 
 	public void nullSafeSet(PreparedStatement st, CustomEnum value, int index, SharedSessionContractImplementor session)
-			throws HibernateException, SQLException {
+			throws SQLException {
 		if ( value == null ) {
 			st.setNull( index, Types.VARCHAR );
 		}

--- a/hibernate-envers/src/test/java/org/hibernate/orm/test/envers/integration/components/dynamic/AgeType.java
+++ b/hibernate-envers/src/test/java/org/hibernate/orm/test/envers/integration/components/dynamic/AgeType.java
@@ -39,13 +39,14 @@ public class AgeType implements UserType<Age> {
 	}
 
 	@Override
-	public Age nullSafeGet(ResultSet rs, int position, SharedSessionContractImplementor session, Object owner) throws SQLException {
+	public Age nullSafeGet(ResultSet rs, int position, SharedSessionContractImplementor session)
+			throws SQLException {
 		return new Age( rs.getInt( position ) );
 	}
 
 	@Override
 	public void nullSafeSet(PreparedStatement st, Age value, int index, SharedSessionContractImplementor session)
-			throws HibernateException, SQLException {
+			throws SQLException {
 		st.setInt( index, value.getAgeInYears() );
 	}
 

--- a/tooling/metamodel-generator/src/test/java/org/hibernate/processor/test/collectionbasictype/CommaDelimitedStringsMapType.java
+++ b/tooling/metamodel-generator/src/test/java/org/hibernate/processor/test/collectionbasictype/CommaDelimitedStringsMapType.java
@@ -32,11 +32,8 @@ public class CommaDelimitedStringsMapType extends StaticUserTypeSupport<Map<Stri
     }
 
     @Override
-    public Map<String,String> nullSafeGet(
-            ResultSet rs,
-            int position,
-            SharedSessionContractImplementor session,
-            Object owner) throws SQLException {
+    public Map<String,String> nullSafeGet(ResultSet rs, int position, SharedSessionContractImplementor session)
+            throws SQLException {
         final Object extracted = getJdbcValueExtractor().extract( rs, position, session );
         if ( extracted == null ) {
             return null;
@@ -46,7 +43,8 @@ public class CommaDelimitedStringsMapType extends StaticUserTypeSupport<Map<Stri
     }
 
     @Override
-    public void nullSafeSet(PreparedStatement st, Map<String,String> value, int index, SharedSessionContractImplementor session) throws SQLException {
+    public void nullSafeSet(PreparedStatement st, Map<String,String> value, int index, SharedSessionContractImplementor session)
+            throws SQLException {
         final String stringValue = getJavaType().toString( value );
         getJdbcValueBinder().bind( st, stringValue, index, session );
     }


### PR DESCRIPTION
and deprecate the wrong-signature `nullSafeGet()` method

<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

[Please describe here what your change is about]

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-17114
https://hibernate.atlassian.net/browse/HHH-18547
<!-- Hibernate GitHub Bot issue links end -->