### PR TITLE
HHH-18421: Updated association documents to call out a lazy loading limitation

### DIFF
--- a/documentation/src/main/asciidoc/userguide/chapters/domain/associations.adoc
+++ b/documentation/src/main/asciidoc/userguide/chapters/domain/associations.adoc
@@ -13,6 +13,14 @@ Associations describe how two or more entities form a relationship based on a da
 `@ManyToOne` is the most common association, having a direct equivalent in the relational database as well (e.g. foreign key),
 and so it establishes a relationship between a child entity and a parent.
 
+[NOTE]
+====
+A `@ManyToOne` association that is mapped to an entity using a unique key that is not the primary key will be fetched eagerly even
+if the fetch strategy is set to `FetchType.LAZY`. This can lead to N+1 query issues if the fetch mode is set to `FetchMode.SELECT` which would be the default for a lazy loaded entity.
+
+This is because proxying by unique keys other than the primary key is https://hibernate.atlassian.net/browse/HHH-18421[not yet supported].
+====
+
 [[associations-many-to-one-example]]
 .`@ManyToOne` association
 ====
@@ -157,6 +165,14 @@ then we can annotate the association with the `orphanRemoval` attribute and diss
 The `@OneToOne` association can either be unidirectional or bidirectional.
 A unidirectional association follows the relational database foreign key semantics, the client-side owning the relationship.
 A bidirectional association features a `mappedBy` `@OneToOne` parent side too.
+
+[NOTE]
+====
+A `@OneToOne` association that is mapped to an entity using a unique key that is not the primary key will be fetched eagerly even
+if the fetch strategy is set to `FetchType.LAZY`. This can lead to N+1 query issues if the fetch mode is set to `FetchMode.SELECT` which would be the default for a lazy loaded entity.
+
+This is because proxying by unique keys other than the primary key is https://hibernate.atlassian.net/browse/HHH-18421[not yet supported].
+====
 
 [[associations-one-to-one-unidirectional]]
 ===== Unidirectional `@OneToOne`


### PR DESCRIPTION
This updates the association documentation to include a note on both the `@OneToOne` and `@ManyToOne` joins to call out that there is a limitation on lazy loading if an entity was joined using a key other than the primary key and that those entities will be loaded eagerly.

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-18421
<!-- Hibernate GitHub Bot issue links end -->