### PR TITLE
Polishing `EntityVersionMappingImpl`

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/EntityVersionMappingImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/EntityVersionMappingImpl.java
@@ -58,8 +58,6 @@ public class EntityVersionMappingImpl implements EntityVersionMapping, FetchOpti
 
 	private final VersionValue unsavedValueStrategy;
 
-	private BasicAttributeMapping attributeMapping;
-
 	public EntityVersionMappingImpl(
 			RootClass bootEntityDescriptor,
 			Supplier<?> templateInstanceAccess,
@@ -72,8 +70,7 @@ public class EntityVersionMappingImpl implements EntityVersionMapping, FetchOpti
 			Integer scale,
 			Integer temporalPrecision,
 			BasicType<?> versionBasicType,
-			EntityMappingType declaringType,
-			MappingModelCreationProcess creationProcess) {
+			EntityMappingType declaringType) {
 		this.attributeName = attributeName;
 		this.columnDefinition = columnDefinition;
 		this.length = length;

--- a/hibernate-core/src/main/java/org/hibernate/persister/entity/AbstractEntityPersister.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/entity/AbstractEntityPersister.java
@@ -5284,8 +5284,7 @@ public abstract class AbstractEntityPersister
 				column.getScale(),
 				column.getTemporalPrecision(),
 				basicTypeResolution.getLegacyResolvedBasicType(),
-				entityPersister,
-				creationProcess
+				entityPersister
 		);
 	}
 


### PR DESCRIPTION
1. remove unused field `BasicAttributeMapping attributeMapping`
2. remove unused constructor parameter `MappingModelCreationProcess creationProcess`

<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
