### PR TITLE
HHH-18560: fix for invalid queries executed on DB2i AS/400 machine

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/dialect/DB2iDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/DB2iDialect.java
@@ -6,6 +6,7 @@
  */
 package org.hibernate.dialect;
 
+import org.hibernate.LockOptions;
 import org.hibernate.boot.model.FunctionContributions;
 import org.hibernate.dialect.function.CommonFunctionFactory;
 import org.hibernate.dialect.identity.DB2IdentityColumnSupport;
@@ -40,6 +41,9 @@ public class DB2iDialect extends DB2Dialect {
 
 	private final static DatabaseVersion MINIMUM_VERSION = DatabaseVersion.make( 7, 1 );
 	final static DatabaseVersion DB2_LUW_VERSION = DB2Dialect.MINIMUM_VERSION;
+
+	private static final String FOR_UPDATE_SQL = " for update with rs";
+	private static final String FOR_UPDATE_SKIP_LOCKED_SQL = FOR_UPDATE_SQL + " skip locked data";
 
 	public DB2iDialect(DialectResolutionInfo info) {
 		this( info.makeCopyOrDefault( MINIMUM_VERSION ) );
@@ -124,6 +128,7 @@ public class DB2iDialect extends DB2Dialect {
 		}
 	}
 
+
 	@Override
 	public LimitHandler getLimitHandler() {
 		return getVersion().isSameOrAfter(7, 3)
@@ -170,5 +175,36 @@ public class DB2iDialect extends DB2Dialect {
 	@Override
 	public String getRowIdColumnString(String rowId) {
 		return rowId( rowId ) + " rowid not null generated always";
+	}
+
+	@Override
+	public String getForUpdateString() {
+		return FOR_UPDATE_SQL;
+	}
+
+	@Override
+	public String getForUpdateSkipLockedString() {
+		return supportsSkipLocked()
+				? FOR_UPDATE_SKIP_LOCKED_SQL
+				: FOR_UPDATE_SQL;
+	}
+
+	@Override
+	public String getForUpdateSkipLockedString(String aliases) {
+		return getForUpdateSkipLockedString();
+	}
+
+	@Override
+	public String getWriteLockString(int timeout) {
+		return timeout == LockOptions.SKIP_LOCKED && supportsSkipLocked()
+				? FOR_UPDATE_SKIP_LOCKED_SQL
+				: FOR_UPDATE_SQL;
+	}
+
+	@Override
+	public String getReadLockString(int timeout) {
+		return timeout == LockOptions.SKIP_LOCKED && supportsSkipLocked()
+				? FOR_UPDATE_SKIP_LOCKED_SQL
+				: FOR_UPDATE_SQL;
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/dialect/DB2iSqlAstTranslator.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/DB2iSqlAstTranslator.java
@@ -60,4 +60,9 @@ public class DB2iSqlAstTranslator<T extends JdbcOperation> extends DB2SqlAstTran
 	public DatabaseVersion getDB2Version() {
 		return DB2_LUW_VERSION;
 	}
+
+	@Override
+	protected String getForUpdate() {
+		return " for update with rs";
+	}
 }

--- a/hibernate-core/src/test/java/org/hibernate/dialect/DB2iDialectTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/dialect/DB2iDialectTest.java
@@ -1,0 +1,69 @@
+package org.hibernate.dialect;
+
+import org.hibernate.testing.orm.junit.JiraKey;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class DB2iDialectTest {
+
+    private static final String EXPECTED_FOR_UPDATE = " for update with rs";
+    private static final String EXPECTED_FOR_UPDATE_SKIP_LOCK = " for update with rs skip locked data";
+
+    private DB2iDialect dialect;
+
+    @BeforeEach
+    void setUp() {
+        dialect = new DB2iDialect();
+    }
+
+    @Test
+    @JiraKey("HHH-18560")
+    void getForUpdateString() {
+        String actual = dialect.getForUpdateString();
+        assertEquals(EXPECTED_FOR_UPDATE, actual);
+    }
+
+    @Test
+    @JiraKey("HHH-18560")
+    void getForUpdateSkipLockedString() {
+        String actual = dialect.getForUpdateSkipLockedString();
+        assertEquals(EXPECTED_FOR_UPDATE_SKIP_LOCK, actual);
+    }
+
+    @Test
+    @JiraKey("HHH-18560")
+    void testGetForUpdateSkipLockedString() {
+        String actual = dialect.getForUpdateSkipLockedString("alias");
+        assertEquals(EXPECTED_FOR_UPDATE_SKIP_LOCK, actual);
+    }
+
+    @Test
+    @JiraKey("HHH-18560")
+    void getWriteLockString_skiplocked() {
+        String actual = dialect.getWriteLockString(-2);
+        assertEquals(EXPECTED_FOR_UPDATE_SKIP_LOCK, actual);
+    }
+
+    @Test
+    @JiraKey("HHH-18560")
+    void getWriteLockString() {
+        String actual = dialect.getWriteLockString(0);
+        assertEquals(EXPECTED_FOR_UPDATE, actual);
+    }
+
+    @Test
+    @JiraKey("HHH-18560")
+    void getReadLockString() {
+        String actual = dialect.getReadLockString(0);
+        assertEquals(EXPECTED_FOR_UPDATE, actual);
+    }
+
+    @Test
+    @JiraKey("HHH-18560")
+    void getReadLockString_skipLocked() {
+        String actual = dialect.getReadLockString(-2);
+        assertEquals(EXPECTED_FOR_UPDATE_SKIP_LOCK, actual);
+    }
+}


### PR DESCRIPTION
Implementing a fix for HHH-18560 by re-introducing DB2 i-series compatible queries from 5.6 that were lost (regression in my view). 

DB2Dialect from version 6.x implements methods with 'share/update-lock'-clauses, which aren't supported by DB2 i-series.
https://www.ibm.com/docs/en/i/7.5?topic=statement-isolation-clause

I made overwritten versions of these methods in the DB2iDialect where I did not include a lock clause, as the only option on i-series is an 'exclusive' lock, which seems excessive. And on the IBM docs caution with this clause is advised.

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
