### PR TITLE
Fix effective batching bug described in HHH-18571

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/engine/spi/LoadQueryInfluencers.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/spi/LoadQueryInfluencers.java
@@ -325,7 +325,7 @@ public class LoadQueryInfluencers implements Serializable {
 	}
 
 	public boolean effectivelyBatchLoadable(CollectionPersister persister) {
-		return batchSize > 1 || persister.isBatchLoadable();
+		return persister.isBatchLoadable() || effectiveBatchSize( persister ) > 1;
 	}
 
 	public int effectiveBatchSize(EntityPersister persister) {
@@ -336,7 +336,7 @@ public class LoadQueryInfluencers implements Serializable {
 	}
 
 	public boolean effectivelyBatchLoadable(EntityPersister persister) {
-		return batchSize > 1 || persister.isBatchLoadable();
+		return persister.isBatchLoadable() || effectiveBatchSize( persister ) > 1;
 	}
 
 	public boolean getSubselectFetchEnabled() {

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/engine/spi/LoadQueryInfluencersTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/engine/spi/LoadQueryInfluencersTest.java
@@ -1,0 +1,139 @@
+package org.hibernate.orm.test.engine.spi;
+
+import java.util.Set;
+
+import org.hibernate.annotations.BatchSize;
+import org.hibernate.cfg.AvailableSettings;
+import org.hibernate.engine.spi.LoadQueryInfluencers;
+import org.hibernate.metamodel.model.domain.NavigableRole;
+import org.hibernate.persister.collection.CollectionPersister;
+import org.hibernate.persister.entity.EntityPersister;
+
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.ServiceRegistry;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.hibernate.testing.orm.junit.Setting;
+import org.junit.jupiter.api.Test;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@DomainModel(annotatedClasses = {
+		LoadQueryInfluencersTest.EntityWithBatchSize1.class,
+		LoadQueryInfluencersTest.ChildEntity.class
+})
+@SessionFactory
+@ServiceRegistry(
+		settings = {
+				@Setting(name = AvailableSettings.DEFAULT_BATCH_FETCH_SIZE, value = "100")
+		}
+)
+public class LoadQueryInfluencersTest {
+
+	@Test
+	public void usesCustomEntityBatchSizeForEffectivelyBatchLoadable(SessionFactoryScope scope) {
+		scope.inSession(
+				(nonTransactedSession) -> {
+					LoadQueryInfluencers influencers = new LoadQueryInfluencers( nonTransactedSession.getSessionFactory() );
+					assertTrue( influencers.getBatchSize() > 1, "Expecting default batch size > 1" );
+
+					EntityPersister persister = nonTransactedSession.getSessionFactory()
+							.getRuntimeMetamodels()
+							.getMappingMetamodel()
+							.getEntityDescriptor( EntityWithBatchSize1.class );
+
+					assertFalse( persister.isBatchLoadable(), "Incorrect persister batch loadable." );
+					assertEquals( 1, influencers.effectiveBatchSize( persister ), "Incorrect effective batch size." );
+					assertFalse(
+							influencers.effectivelyBatchLoadable( persister ),
+							"Incorrect effective batch loadable."
+					);
+				}
+		);
+	}
+
+	@Test
+	public void usesCustomCollectionBatchSizeForEffectivelyBatchLoadable(SessionFactoryScope scope) {
+		scope.inSession(
+				(nonTransactedSession) -> {
+					LoadQueryInfluencers influencers = new LoadQueryInfluencers( nonTransactedSession.getSessionFactory() );
+					assertTrue( influencers.getBatchSize() > 1, "Expecting default batch size > 1" );
+
+					EntityPersister entityPersister = nonTransactedSession.getSessionFactory()
+							.getRuntimeMetamodels()
+							.getMappingMetamodel()
+							.getEntityDescriptor( EntityWithBatchSize1.class );
+
+					NavigableRole collectionRole = entityPersister.getNavigableRole()
+							.append( "childrenWithBatchSize1" );
+
+					CollectionPersister persister = nonTransactedSession.getSessionFactory()
+							.getRuntimeMetamodels()
+							.getMappingMetamodel()
+							.findCollectionDescriptor( collectionRole.getFullPath() );
+
+					assertFalse( persister.isBatchLoadable(), "Incorrect persister batch loadable." );
+					assertEquals( 1, influencers.effectiveBatchSize( persister ), "Incorrect effective batch size." );
+					assertFalse(
+							influencers.effectivelyBatchLoadable( persister ),
+							"Incorrect effective batch loadable."
+					);
+				}
+		);
+	}
+
+
+	@Entity
+	@Table(name = "EntityWithBatchSize1")
+	@BatchSize(size = 1)
+	public class EntityWithBatchSize1 {
+		@Id
+		@GeneratedValue(strategy = GenerationType.IDENTITY)
+		private Long id;
+
+		@OneToMany
+		@BatchSize(size = 1)
+		private Set<ChildEntity> childrenWithBatchSize1;
+
+		public Long getId() {
+			return id;
+		}
+
+		public void setId(Long id) {
+			this.id = id;
+		}
+
+		public Set<ChildEntity> getChildrenWithBatchSize1() {
+			return childrenWithBatchSize1;
+		}
+
+		public void setChildrenWithBatchSize1(Set<ChildEntity> childrenWithBatchSize1) {
+			this.childrenWithBatchSize1 = childrenWithBatchSize1;
+		}
+	}
+
+	@Entity
+	@Table(name = "ChildEntity")
+	public class ChildEntity {
+		@Id
+		@GeneratedValue(strategy = GenerationType.IDENTITY)
+		private Long id;
+
+		public Long getId() {
+			return id;
+		}
+
+		public void setId(Long id) {
+			this.id = id;
+		}
+	}
+}


### PR DESCRIPTION
<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

This pull request adds a test case and fix for Jira issue HHH-18571.

https://hibernate.atlassian.net/browse/HHH-18571

The load query influencer here correctly handles override batch sizing vs. global default batch size to determine whether and entity or collection is effectively batch loadable.

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
