### PR TITLE
Fix contributing remark about jira keys in commit messages

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -78,7 +78,7 @@ Do your thing!
 ## Commit
 
 * Make commits of logical units
-* Be sure to **use the JIRA issue key** in the commit message.  This is how JIRA will pick
+* Be sure to start each commit message using the **JIRA issue key**, this is how JIRA will pick
 up the related commits and display them on the JIRA issue
 * Make sure you have added the necessary tests for your changes
 * Run _all_ the tests to ensure nothing else was accidentally broken


### PR DESCRIPTION
<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
