### PR TITLE
Remove redundant methods `isBatchLoadable()`

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/persister/collection/AbstractCollectionPersister.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/collection/AbstractCollectionPersister.java
@@ -1483,11 +1483,6 @@ public abstract class AbstractCollectionPersister
 	}
 
 	@Override
-	public boolean isBatchLoadable() {
-		return batchSize > 1;
-	}
-
-	@Override
 	public String getMappedByProperty() {
 		return mappedByProperty;
 	}

--- a/hibernate-core/src/main/java/org/hibernate/persister/entity/AbstractEntityPersister.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/entity/AbstractEntityPersister.java
@@ -1681,11 +1681,6 @@ public abstract class AbstractEntityPersister
 	}
 
 	@Override
-	public boolean isBatchLoadable() {
-		return batchSize > 1;
-	}
-
-	@Override
 	public int getBatchSize() {
 		return batchSize;
 	}


### PR DESCRIPTION
The method implementation is identical to default method


<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
