### PR TITLE
HHH-18584 disallow "ambiguous" queries for the deprecated createQuery…

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/query/QueryProducer.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/QueryProducer.java
@@ -36,32 +36,36 @@ public interface QueryProducer {
 	 * is inferred:
 	 * <ul>
 	 * <li>if there is exactly one root entity in the {@code from}
-	 *     clause, then that root entity is the only element of the
-	 *     select list, or
-	 * <li>otherwise, if there are multiple root entities in the
-	 *     {@code from} clause, then the select list contains every
-	 *     root entity and every non-{@code fetch} joined entity.
+	 *     clause, and it has no non-{@code fetch} joins, then that
+	 *     root entity is the only element of the select list, or
+	 * <li>if there is an entity with the alias {@code this}, then
+	 *     that entity is the only element of the select list, or
+	 * <li>otherwise, the query is considered ambiguous, and this
+	 *     method throws a {@link SemanticException}.
 	 * </ul>
+	 * <p>
+	 * The query must have an explicit {@code from} clause, which
+	 * can never be inferred.
+	 *
+	 * @deprecated The overloaded form
+	 * {@link #createQuery(String, Class)} which takes a result type
+	 * is strongly recommended in preference to this method, since it
+	 * returns a typed {@code Query} object, and because it is able to
+	 * use the given result type to infer the {@code select} list, and
+	 * even sometimes the {@code from} clause. Alternatively,
+	 * {@link #createSelectionQuery(String, Class)} is preferred for
+	 * queries, and {@link #createMutationQuery(String)} for insert,
+	 * update, and delete statements.
 	 *
 	 * @apiNote Returns a raw {@code Query} type instead of a wildcard
 	 * type {@code Query<?>}, to match the signature of the JPA method
 	 * {@link jakarta.persistence.EntityManager#createQuery(String)}.
-	 *
-	 * @implNote This method interprets some queries with an implicit
-	 * {@code select} list in a quite unintuitive way. In some future
-	 * release, this method will be modified to throw an exception
-	 * when passed a query with a missing {@code select}. For now, use
-	 * {@link #createQuery(String, Class)} to avoid ambiguity.
 	 *
 	 * @param queryString The HQL query
 	 *
 	 * @return The {@link Query} instance for manipulation and execution
 	 *
 	 * @see jakarta.persistence.EntityManager#createQuery(String)
-	 *
-	 * @deprecated use {@link #createQuery(String, Class)},
-	 * {@link #createSelectionQuery(String, Class)}, or
-	 * {@link #createMutationQuery(String)} depending on intention
 	 */
 	@Deprecated(since = "6.0") @SuppressWarnings("rawtypes")
 	Query createQuery(String queryString);
@@ -95,11 +99,21 @@ public interface QueryProducer {
 	 *     as specified above.
 	 * </ul>
 	 * <p>
+	 * If a query has no explicit {@code from} clause, and the given
+	 * result type is an entity type, the root entity is inferred to
+	 * be the result type.
+	 * <p>
+	 * Passing {@code Object.class} as the query result type is not
+	 * recommended. In this special case, this method has the same
+	 * semantics as the overload {@link #createQuery(String)}.
+	 * <p>
 	 * The returned {@code Query} may be executed by calling
 	 * {@link Query#getResultList()} or {@link Query#getSingleResult()}.
 	 *
 	 * @param queryString The HQL query
-	 * @param resultClass The type of the query result
+	 * @param resultClass The {@link Class} object representing the
+	 *                    query result type, which should not be
+	 *                    {@code Object.class}
 	 * @return The {@link Query} instance for manipulation and execution
 	 *
 	 * @see jakarta.persistence.EntityManager#createQuery(String,Class)
@@ -247,23 +261,28 @@ public interface QueryProducer {
 	 * select list is inferred:
 	 * <ul>
 	 * <li>if there is exactly one root entity in the {@code from}
-	 *     clause, then that root entity is the only element of the
-	 *     select list, or
-	 * <li>otherwise, if there are multiple root entities in the
-	 *     {@code from} clause, then the select list contains every
-	 *     root entity and every non-{@code fetch} joined entity.
+	 *     clause, and it has no non-{@code fetch} joins, then that
+	 *     root entity is the only element of the select list, or
+	 * <li>if there is an entity with the alias {@code this}, then
+	 *     that entity is the only element of the select list, or
+	 * <li>otherwise, the query is considered ambiguous, and this
+	 *     method throws a {@link SemanticException}.
 	 * </ul>
+	 * <p>
+	 * The query must have an explicit {@code from} clause, which
+	 * can never be inferred.
 	 *
-	 * @implNote This method interprets some queries with an implicit
-	 * {@code select} list in a quite unintuitive way. In some future
-	 * release, this method will be modified to throw an exception
-	 * when passed a query with a missing {@code select}. For now, use
-	 * {@link #createSelectionQuery(String, Class)} to avoid ambiguity.
+	 * @deprecated The overloaded form
+	 * {@link #createSelectionQuery(String, Class)} which takes a
+	 * result type is strongly recommended in preference to this
+	 * method, since it returns a typed {@code SelectionQuery} object,
+	 * and because it is able to use the given result type to infer
+	 * the {@code select} list, and even sometimes the {@code from}
+	 * clause.
 	 *
 	 * @throws IllegalSelectQueryException if the given HQL query
-	 * is an insert, update or delete query
-	 *
-	 * @deprecated Use {@link #createSelectionQuery(String, Class)}
+	 *         is an {@code insert}, {@code update} or {@code delete}
+	 *         statement
 	 */
 	@Deprecated(since = "6.3")
 	SelectionQuery<?> createSelectionQuery(String hqlString);
@@ -297,17 +316,27 @@ public interface QueryProducer {
 	 *     as specified above.
 	 * </ul>
 	 * <p>
+	 * If a query has no explicit {@code from} clause, and the given
+	 * result type is an entity type, the root entity is inferred to
+	 * be the result type.
+	 * <p>
+	 * Passing {@code Object.class} as the query result type is not
+	 * recommended. In this special case, this method has the same
+	 * semantics as the overload {@link #createSelectionQuery(String)}.
+	 * <p>
 	 * The returned {@code Query} may be executed by calling
 	 * {@link Query#getResultList()} or {@link Query#getSingleResult()}.
 
-	 * @param hqlString The HQL query as a string
+	 * @param hqlString The HQL {@code select} query as a string
 	 * @param resultType The {@link Class} object representing the
-	 *                   query result type
+	 *                   query result type, which should not be
+	 *                   {@code Object.class}
 	 *
 	 * @see jakarta.persistence.EntityManager#createQuery(String)
 	 *
 	 * @throws IllegalSelectQueryException if the given HQL query
-	 * is an insert, update or delete query
+	 *         is an {@code insert}, {@code update} or {@code delete}
+	 *         statement
 	 */
 	<R> SelectionQuery<R> createSelectionQuery(String hqlString, Class<R> resultType);
 
@@ -323,8 +352,11 @@ public interface QueryProducer {
 	 * Create a {@link MutationQuery} reference for the given HQL insert,
 	 * update, or delete statement.
 	 *
+	 * @param hqlString The HQL {@code insert}, {@code update}, or
+	 *                  {@code delete} statement
+	 *
 	 * @throws IllegalMutationQueryException if the given HQL query
-	 * is a select query
+	 *         is a {@code select} query
 	 */
 	MutationQuery createMutationQuery(String hqlString);
 

--- a/hibernate-core/src/main/java/org/hibernate/query/hql/internal/SemanticQueryBuilder.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/hql/internal/SemanticQueryBuilder.java
@@ -1286,10 +1286,10 @@ public class SemanticQueryBuilder<R> extends HqlParserBaseVisitor<Object> implem
 		}
 	}
 
-	@SuppressWarnings("rawtypes")
 	private EntityDomainType<R> getResultEntity() {
 		final JpaMetamodelImplementor jpaMetamodel = creationContext.getJpaMetamodel();
 		if ( expectedResultEntity != null ) {
+			@SuppressWarnings("rawtypes")
 			final EntityDomainType entityDescriptor = jpaMetamodel.entity( expectedResultEntity );
 			if ( entityDescriptor == null ) {
 				throw new SemanticException( "Query has no 'from' clause, and the result type '"
@@ -1331,7 +1331,8 @@ public class SemanticQueryBuilder<R> extends HqlParserBaseVisitor<Object> implem
 				// we found an entity with the alias 'this'
 				// assigned explicitly, JPA says we should
 				// infer the select list 'select this'
-				SqmSelectClause selectClause = new SqmSelectClause( false, 1, nodeBuilder );
+				final SqmSelectClause selectClause =
+						new SqmSelectClause( false, 1, nodeBuilder );
 				selectClause.addSelection( new SqmSelection<>( sqmRoot, "this", nodeBuilder) );
 				return selectClause;
 			}
@@ -1353,7 +1354,7 @@ public class SemanticQueryBuilder<R> extends HqlParserBaseVisitor<Object> implem
 				// we may safely assume the query returns that entity
 				if ( fromClause.getNumberOfRoots() == 1 ) {
 					final SqmRoot<?> sqmRoot = fromClause.getRoots().get(0);
-					if ( sqmRoot.hasTrueJoin() ) {
+					if ( sqmRoot.hasImplicitlySelectableJoin() ) {
 						// the entity has joins, and doesn't explicitly have
 						// the alias 'this', so the 'select' list cannot be
 						// inferred
@@ -1365,7 +1366,8 @@ public class SemanticQueryBuilder<R> extends HqlParserBaseVisitor<Object> implem
 					// 'this', and that we should infer 'select this', but we
 					// accept even the case where the entity has an explicit
 					// alias, and infer 'select explicit_alias'
-					SqmSelectClause selectClause = new SqmSelectClause( false, 1, nodeBuilder );
+					final SqmSelectClause selectClause =
+							new SqmSelectClause( false, 1, nodeBuilder );
 					selectClause.addSelection( new SqmSelection<>( sqmRoot, sqmRoot.getAlias(), nodeBuilder) );
 					return selectClause;
 				}
@@ -1398,7 +1400,8 @@ public class SemanticQueryBuilder<R> extends HqlParserBaseVisitor<Object> implem
 					else {
 						// exactly one root entity, return it
 						// (joined entities are not returned)
-						final SqmSelectClause selectClause = new SqmSelectClause( false, 1, nodeBuilder );
+						final SqmSelectClause selectClause =
+								new SqmSelectClause( false, 1, nodeBuilder );
 						selectClause.addSelection( new SqmSelection<>( sqmRoot, sqmRoot.getAlias(), nodeBuilder) );
 						return selectClause;
 					}

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/domain/AbstractSqmFrom.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/domain/AbstractSqmFrom.java
@@ -60,6 +60,7 @@ import jakarta.persistence.metamodel.PluralAttribute;
 import jakarta.persistence.metamodel.SetAttribute;
 import jakarta.persistence.metamodel.SingularAttribute;
 
+import static org.hibernate.metamodel.AttributeClassification.EMBEDDED;
 import static org.hibernate.query.sqm.internal.SqmUtil.findCompatibleFetchJoin;
 
 /**
@@ -298,10 +299,18 @@ public abstract class AbstractSqmFrom<O,T> extends AbstractSqmPath<T> implements
 
 	@Override
 	public Set<Join<T, ?>> getJoins() {
-		//noinspection unchecked
-		return (Set<Join<T, ?>>) (Set<?>) getSqmJoins().stream()
-				.filter( sqmJoin -> sqmJoin instanceof SqmAttributeJoin && !( (SqmAttributeJoin<?, ?>) sqmJoin ).isFetched() )
+		return getSqmJoins().stream()
+				.filter( sqmJoin -> sqmJoin instanceof SqmAttributeJoin<?,?> attributeJoin
+						&& !attributeJoin.isFetched() )
 				.collect( Collectors.toSet() );
+	}
+
+	@Override
+	public boolean hasTrueJoin() {
+		return getSqmJoins().stream()
+				.anyMatch( sqmJoin -> sqmJoin instanceof SqmAttributeJoin<?,?> attributeJoin
+						&& !attributeJoin.isFetched()
+						&& attributeJoin.getAttribute().getAttributeClassification()!=EMBEDDED );
 	}
 
 	@Override
@@ -644,7 +653,8 @@ public abstract class AbstractSqmFrom<O,T> extends AbstractSqmPath<T> implements
 	public Set<Fetch<T, ?>> getFetches() {
 		//noinspection unchecked
 		return (Set<Fetch<T, ?>>) (Set<?>) getSqmJoins().stream()
-				.filter( sqmJoin -> sqmJoin instanceof SqmAttributeJoin && ( (SqmAttributeJoin<?, ?>) sqmJoin ).isFetched() )
+				.filter( sqmJoin -> sqmJoin instanceof SqmAttributeJoin<?,?> attributeJoin
+						&& attributeJoin.isFetched() )
 				.collect( Collectors.toSet() );
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/domain/AbstractSqmPluralJoin.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/domain/AbstractSqmPluralJoin.java
@@ -35,7 +35,15 @@ public abstract class AbstractSqmPluralJoin<L,C,E>
 			SqmJoinType joinType,
 			boolean fetched,
 			NodeBuilder nodeBuilder) {
-		super( lhs, joinedNavigable, alias, joinType, fetched, nodeBuilder );
+		super(
+				lhs,
+				joinedNavigable.createNavigablePath( lhs, alias ),
+				joinedNavigable,
+				alias,
+				joinType,
+				fetched,
+				nodeBuilder
+		);
 	}
 
 	protected AbstractSqmPluralJoin(

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/domain/SqmSingularJoin.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/domain/SqmSingularJoin.java
@@ -15,7 +15,6 @@ import org.hibernate.metamodel.model.domain.TreatableDomainType;
 import org.hibernate.query.sqm.SemanticQueryWalker;
 import org.hibernate.spi.NavigablePath;
 import org.hibernate.query.sqm.NodeBuilder;
-import org.hibernate.query.sqm.SqmJoinable;
 import org.hibernate.query.sqm.tree.SqmCopyContext;
 import org.hibernate.query.sqm.tree.SqmJoinType;
 import org.hibernate.query.sqm.tree.from.SqmFrom;
@@ -25,6 +24,7 @@ import org.hibernate.query.sqm.tree.from.SqmTreatedAttributeJoin;
  * @author Steve Ebersole
  */
 public class SqmSingularJoin<O,T> extends AbstractSqmAttributeJoin<O,T> implements SqmSingularValuedJoin<O,T> {
+
 	public SqmSingularJoin(
 			SqmFrom<?,O> lhs,
 			SingularPersistentAttribute<O, T> joinedNavigable,
@@ -32,17 +32,15 @@ public class SqmSingularJoin<O,T> extends AbstractSqmAttributeJoin<O,T> implemen
 			SqmJoinType joinType,
 			boolean fetched,
 			NodeBuilder nodeBuilder) {
-		super( lhs, joinedNavigable, alias, joinType, fetched, nodeBuilder );
-	}
-
-	public SqmSingularJoin(
-			SqmFrom<?,O> lhs,
-			SqmJoinable<? extends O, T> joinedNavigable,
-			String alias,
-			SqmJoinType joinType,
-			boolean fetched,
-			NodeBuilder nodeBuilder) {
-		super( lhs, joinedNavigable, alias, joinType, fetched, nodeBuilder );
+		super(
+				lhs,
+				joinedNavigable.createNavigablePath( lhs, alias ),
+				joinedNavigable,
+				alias,
+				joinType,
+				fetched,
+				nodeBuilder
+		);
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/from/SqmAttributeJoin.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/from/SqmAttributeJoin.java
@@ -30,7 +30,7 @@ public interface SqmAttributeJoin<O,T> extends SqmJoin<O,T>, JpaFetch<O,T>, JpaJ
 
 	@Override
 	default boolean isImplicitlySelectable() {
-		return !isFetched();
+		return !isFetched() && !isImplicitJoin();
 	}
 
 	@Override
@@ -39,7 +39,15 @@ public interface SqmAttributeJoin<O,T> extends SqmJoin<O,T>, JpaFetch<O,T>, JpaJ
 	@Override
 	JavaType<T> getJavaTypeDescriptor();
 
+	/**
+	 * Is this a fetch join?
+	 */
 	boolean isFetched();
+
+	/**
+	 * Is this an implicit join inferred from a path expression?
+	 */
+	boolean isImplicitJoin();
 
 	@Internal
 	void clearFetched();

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/from/SqmFrom.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/from/SqmFrom.java
@@ -16,6 +16,7 @@ import jakarta.persistence.metamodel.MapAttribute;
 import jakarta.persistence.metamodel.SetAttribute;
 import jakarta.persistence.metamodel.SingularAttribute;
 
+import org.hibernate.Incubating;
 import org.hibernate.metamodel.model.domain.EntityDomainType;
 import org.hibernate.query.criteria.JpaFrom;
 import org.hibernate.query.sqm.SqmPathSource;
@@ -99,6 +100,9 @@ public interface SqmFrom<L, R> extends SqmVisitableNode, SqmPath<R>, JpaFrom<L, 
 
 	@Override
 	<Y> SqmEntityJoin<R, Y> join(Class<Y> entityClass, JoinType joinType);
+
+	@Incubating
+	boolean hasTrueJoin();
 
 	@Override
 	<A> SqmSingularJoin<R, A> join(SingularAttribute<? super R, A> attribute);

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/from/SqmFrom.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/from/SqmFrom.java
@@ -102,7 +102,7 @@ public interface SqmFrom<L, R> extends SqmVisitableNode, SqmPath<R>, JpaFrom<L, 
 	<Y> SqmEntityJoin<R, Y> join(Class<Y> entityClass, JoinType joinType);
 
 	@Incubating
-	boolean hasTrueJoin();
+	boolean hasImplicitlySelectableJoin();
 
 	@Override
 	<A> SqmSingularJoin<R, A> join(SingularAttribute<? super R, A> attribute);

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/select/SqmSelectClause.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/select/SqmSelectClause.java
@@ -10,13 +10,14 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-import org.hibernate.internal.util.collections.CollectionHelper;
 import org.hibernate.query.criteria.JpaSelection;
 import org.hibernate.query.sqm.NodeBuilder;
 import org.hibernate.query.sqm.tree.AbstractSqmNode;
 import org.hibernate.query.sqm.tree.SqmCopyContext;
 import org.hibernate.query.sqm.tree.expression.SqmExpression;
 import org.hibernate.type.descriptor.java.JavaType;
+
+import static org.hibernate.internal.util.collections.CollectionHelper.arrayList;
 
 /**
  * The semantic select clause.  Defined as a list of individual selections.
@@ -40,7 +41,7 @@ public class SqmSelectClause extends AbstractSqmNode implements SqmAliasedExpres
 			NodeBuilder nodeBuilder) {
 		super( nodeBuilder );
 		this.distinct = distinct;
-		this.selections = CollectionHelper.arrayList( expectedNumberOfSelections );
+		this.selections = arrayList( expectedNumberOfSelections );
 	}
 
 	@Override

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/collectionelement/EmbeddableCollectionElementWithLazyManyToOneTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/collectionelement/EmbeddableCollectionElementWithLazyManyToOneTest.java
@@ -139,7 +139,7 @@ public class EmbeddableCollectionElementWithLazyManyToOneTest {
 		scope.inTransaction(
 				session ->
 						assertFalse( session.createQuery(
-								"from Parent p join p.containedChildren c where c.child.id is not null" )
+								"from Parent p join p.containedChildren c where c.child.id is not null", Parent.class )
 											 .getResultList()
 											 .isEmpty() )
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/embedded/many2one/EmbeddableWithMany2OneTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/embedded/many2one/EmbeddableWithMany2OneTest.java
@@ -31,9 +31,9 @@ public class EmbeddableWithMany2OneTest {
 	public void testJoinAcrossEmbedded(SessionFactoryScope scope) {
 		scope.inTransaction(
 				session -> {
-					session.createQuery( "from Person p join p.address as a join a.country as c where c.name = 'US'" )
+					session.createQuery( "from Person p join p.address as a join a.country as c where c.name = 'US'", Person.class )
 							.list();
-					session.createQuery( "from Person p join p.address as a join a.country as c where c.id = 'US'" )
+					session.createQuery( "from Person p join p.address as a join a.country as c where c.id = 'US'", Person.class )
 							.list();
 				}
 		);

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/idmanytoone/IdManyToOneTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/idmanytoone/IdManyToOneTest.java
@@ -56,7 +56,7 @@ public class IdManyToOneTest extends BaseCoreFunctionalTestCase {
 	@TestForIssue( jiraKey = "HHH-7767" )
     public void testCriteriaRestrictionOnIdManyToOne() {
 		inTransaction( s -> {
-			s.createQuery( "from Course c join c.students cs join cs.student s where s.name = 'Foo'" ).list();
+			s.createQuery( "from Course c join c.students cs join cs.student s where s.name = 'Foo'", Object[].class ).list();
 
 			CriteriaBuilder criteriaBuilder = s.getCriteriaBuilder();
 			CriteriaQuery<Course> criteria = criteriaBuilder.createQuery( Course.class );

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/refcolnames/misc/Misc0Test.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/refcolnames/misc/Misc0Test.java
@@ -29,7 +29,7 @@ public class Misc0Test {
             s.persist(a);
             s.persist(b);
 
-            s.createQuery("from B join entityA").getSingleResult();
+            s.createQuery("from B join entityA", EntityB.class).getSingleResult();
         });
     }
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/refcolnames/misc/Misc1Test.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/refcolnames/misc/Misc1Test.java
@@ -26,7 +26,7 @@ public class Misc1Test {
             s.persist(a);
             s.persist(b);
 
-            s.createQuery("from B join entityA").getSingleResult();
+            s.createQuery("from B join entityA", EntityB.class).getSingleResult();
         });
     }
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/associations/FieldWithUnderscoreTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/associations/FieldWithUnderscoreTest.java
@@ -14,8 +14,8 @@ import org.junit.jupiter.api.Test;
 public class FieldWithUnderscoreTest {
 
     @Test void test(SessionFactoryScope scope) {
-        scope.inSession(s -> s.createSelectionQuery("from B join _a").getResultList());
-        scope.inSession(s -> s.createSelectionQuery("from B left join fetch _a").getResultList());
+        scope.inSession(s -> s.createSelectionQuery("from B join _a", B.class).getResultList());
+        scope.inSession(s -> s.createSelectionQuery("from B left join fetch _a", B.class).getResultList());
     }
 
     @Entity(name = "A")

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/bootstrap/binding/annotations/embedded/EmbeddedTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/bootstrap/binding/annotations/embedded/EmbeddedTest.java
@@ -608,7 +608,7 @@ public class EmbeddedTest {
 		scope.inTransaction(
 				session -> {
 					InternetProvider internetProviderQueried =
-							(InternetProvider) session.createQuery( "from InternetProvider" ).uniqueResult();
+							session.createQuery( "from InternetProvider", InternetProvider.class ).uniqueResult();
 					assertFalse( Hibernate.isInitialized( internetProviderQueried.getOwner().getTopManagement() ) );
 
 				}
@@ -617,8 +617,7 @@ public class EmbeddedTest {
 		scope.inTransaction(
 				session -> {
 					InternetProvider internetProviderQueried =
-							(InternetProvider) session.createQuery(
-									"from InternetProvider i join fetch i.owner.topManagement" )
+							session.createQuery( "from InternetProvider i join fetch i.owner.topManagement", InternetProvider.class )
 									.uniqueResult();
 					assertTrue( Hibernate.isInitialized( internetProviderQueried.getOwner().getTopManagement() ) );
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/cid/CompositeIdTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/cid/CompositeIdTest.java
@@ -135,7 +135,7 @@ public class CompositeIdTest {
 					}
 					statementInspector.assertExecutedCount( 1 );
 					statementInspector.clear();
-					iter = session.createQuery( "from Order o join o.lineItems li" ).list().iterator();
+					iter = session.createQuery( "from Order o join o.lineItems li", Order.class ).list().iterator();
 					statementInspector.assertExecutedCount( 2 );
 					statementInspector.clear();
 					while ( iter.hasNext() ) {

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/compositeelement/CompositeElementTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/compositeelement/CompositeElementTest.java
@@ -126,7 +126,7 @@ public class CompositeElementTest extends BaseNonConfigCoreFunctionalTestCase {
 			c = (Child) p.getChildren().iterator().next();
 			assertEquals( 1, c.getPosition() );
 
-			p = (Parent) s.createQuery( "from Parent p join p.children c where c.position = 1" ).uniqueResult();
+			p = s.createQuery( "from Parent p join p.children c where c.position = 1", Parent.class ).uniqueResult();
 			c = (Child) p.getChildren().iterator().next();
 			assertEquals( 1, c.getPosition() );
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/cuk/CompositePropertyRefTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/cuk/CompositePropertyRefTest.java
@@ -96,7 +96,7 @@ public class CompositePropertyRefTest {
 					}
 					session.clear();
 
-					l = session.createQuery( "from Person p left join p.accounts" ).list();
+					l = session.createQuery( "from Person p left join p.accounts", Person.class ).list();
 					for ( int i = 0; i < 2; i++ ) {
 						Person px = (Person) l.get( i );
 						Set accounts = px.getAccounts();

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/formulajoin/FormulaJoinTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/formulajoin/FormulaJoinTest.java
@@ -63,7 +63,7 @@ public class FormulaJoinTest extends BaseCoreFunctionalTestCase {
 
 		s = openSession();
 		tx = s.beginTransaction();
-		List l = s.createQuery("from Root m left join m.detail d").list();
+		List l = s.createQuery("from Root m left join m.detail d", Object[].class).list();
 		assertEquals( l.size(), 1 );
 		tx.commit();
 		s.close();

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/hql/ASTParserLoadingTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/hql/ASTParserLoadingTest.java
@@ -944,10 +944,10 @@ public class ASTParserLoadingTest extends BaseCoreFunctionalTestCase {
 			inTransaction(
 					s,
 					session -> {
-						s.createQuery( "from Animal a join a.offspring o where o.description = 'xyz'" ).list();
-						s.createQuery( "from Animal a join a.offspring o where o.father.description = 'xyz'" ).list();
-						s.createQuery( "from Animal a join a.offspring o order by o.description" ).list();
-						s.createQuery( "from Animal a join a.offspring o order by o.father.description" ).list();
+						s.createQuery( "from Animal a join a.offspring o where o.description = 'xyz'", Object[].class ).list();
+						s.createQuery( "from Animal a join a.offspring o where o.father.description = 'xyz'", Object[].class ).list();
+						s.createQuery( "from Animal a join a.offspring o order by o.description", Object[].class ).list();
+						s.createQuery( "from Animal a join a.offspring o order by o.father.description", Object[].class ).list();
 					}
 			);
 
@@ -1285,7 +1285,7 @@ public class ASTParserLoadingTest extends BaseCoreFunctionalTestCase {
 
 		s = openSession();
 		s.beginTransaction();
-		Object [] result = ( Object [] ) s.createQuery( "from User u, Human h where u.human = h" ).uniqueResult();
+		Object [] result = s.createQuery( "from User u, Human h where u.human = h", Object[].class ).uniqueResult();
 		assertNotNull( result );
 		assertEquals( u.getUserName(), ( (User) result[0] ).getUserName() );
 		assertEquals( h.getName().getFirst(), ( (Human) result[1] ).getName().getFirst() );
@@ -1650,11 +1650,11 @@ public class ASTParserLoadingTest extends BaseCoreFunctionalTestCase {
 		// TODO : setEntity() currently will not work here, but that would be *very* nice
 		// does not work because the corresponding EntityType is then used as the "bind type" rather
 		// than the "discovered" AnyType...
-		s.createQuery( "from PropertySet p where p.someSpecificProperty = :ssp" ).setParameter( "ssp", redValue ).list();
+		s.createQuery( "from PropertySet p where p.someSpecificProperty = :ssp", PropertySet.class ).setParameter( "ssp", redValue ).list();
 
-		s.createQuery( "from PropertySet p where p.someSpecificProperty.id is not null" ).list();
+		s.createQuery( "from PropertySet p where p.someSpecificProperty.id is not null", PropertySet.class ).list();
 
-		s.createQuery( "from PropertySet p join p.generalProperties gp where gp.id is not null" ).list();
+		s.createQuery( "from PropertySet p join p.generalProperties gp where gp.id is not null", PropertySet.class ).list();
 
 		s.remove( s.getReference( PropertySet.class, id ) );
 
@@ -3803,7 +3803,7 @@ public class ASTParserLoadingTest extends BaseCoreFunctionalTestCase {
 		public SyntaxChecker checkList() {
 			Session s = openSession();
 			s.beginTransaction();
-			Query query = s.createQuery( hql );
+			Query query = s.createQuery( hql, Object[].class );
 			preparer.prepare( query );
 			query.list();
 			s.getTransaction().commit();
@@ -3814,7 +3814,7 @@ public class ASTParserLoadingTest extends BaseCoreFunctionalTestCase {
 		public SyntaxChecker checkScroll() {
 			Session s = openSession();
 			s.beginTransaction();
-			Query query = s.createQuery( hql );
+			Query query = s.createQuery( hql, Object[].class );
 			preparer.prepare( query );
 			query.scroll().close();
 			s.getTransaction().commit();

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/hql/SubQueryTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/hql/SubQueryTest.java
@@ -17,7 +17,6 @@ import jakarta.persistence.Table;
 
 import org.hibernate.Session;
 
-import org.hibernate.testing.FailureExpected;
 import org.hibernate.testing.TestForIssue;
 import org.hibernate.testing.junit4.BaseCoreFunctionalTestCase;
 import org.junit.Test;
@@ -114,7 +113,7 @@ public class SubQueryTest extends BaseCoreFunctionalTestCase {
 		String qry = "from Root as r " +
 				"where r.branch.branchName = 'branch' " +
 				"  and exists( from r.branch.leaves as s where s.leafName = 'leaf1')";
-		Root rootQueried = (Root) s.createQuery( qry ).uniqueResult();
+		Root rootQueried = s.createQuery( qry, Root.class ).uniqueResult();
 		assertEquals( root.rootName, rootQueried.rootName );
 		assertEquals( root.branch.branchName, rootQueried.branch.branchName );
 		assertEquals( leaf1.leafName, rootQueried.branch.leaves.get( 0 ).leafName );

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/hql/WithClauseTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/hql/WithClauseTest.java
@@ -80,29 +80,29 @@ public class WithClauseTest {
 		scope.inTransaction(
 				(session) -> {
 					// one-to-many
-					List list = session.createQuery( "from Human h inner join h.offspring as o with o.bodyWeight < :someLimit" )
+					List list = session.createQuery( "from Human h inner join h.offspring as o with o.bodyWeight < :someLimit", Human.class )
 							.setParameter( "someLimit", 1 )
 							.list();
 					assertTrue( list.isEmpty(), "ad-hoc on did not take effect" );
 
 					// many-to-one
-					list = session.createQuery( "from Animal a inner join a.mother as m with m.bodyWeight < :someLimit" )
+					list = session.createQuery( "from Animal a inner join a.mother as m with m.bodyWeight < :someLimit", Animal.class )
 							.setParameter( "someLimit", 1 )
 							.list();
 					assertTrue( list.isEmpty(), "ad-hoc on did not take effect" );
 
-					list = session.createQuery( "from Human h inner join h.friends f with f.bodyWeight < :someLimit" )
+					list = session.createQuery( "from Human h inner join h.friends f with f.bodyWeight < :someLimit", Human.class )
 							.setParameter( "someLimit", 25 )
 							.list();
 					assertTrue( !list.isEmpty(), "ad-hoc on did take effect" );
 
 					// many-to-many
-					list = session.createQuery( "from Human h inner join h.friends as f with f.nickName like 'bubba'" )
+					list = session.createQuery( "from Human h inner join h.friends as f with f.nickName like 'bubba'", Human.class )
 							.list();
 					assertTrue( list.isEmpty(), "ad-hoc on did not take effect" );
 
 					// http://opensource.atlassian.com/projects/hibernate/browse/HHH-1930
-					list = session.createQuery( "from Human h inner join h.nickNames as nicknames with nicknames = 'abc'" )
+					list = session.createQuery( "from Human h inner join h.nickNames as nicknames with nicknames = 'abc'", Human.class )
 							.list();
 					assertTrue( list.isEmpty(), "ad-hoc on did not take effect" );
 
@@ -114,7 +114,7 @@ public class WithClauseTest {
 	public void testWithClauseWithImplicitJoin(SessionFactoryScope scope) {
 		scope.inTransaction(
 				(session) -> {
-					List list = session.createQuery( "from Human h inner join h.offspring o with o.mother.father = :cousin" )
+					List list = session.createQuery( "from Human h inner join h.offspring o with o.mother.father = :cousin", Object[].class )
 							.setParameter( "cousin", session.getReference( Human.class, Long.valueOf( "123" ) ) )
 							.list();
 					assertTrue( list.isEmpty(), "ad-hoc did take effect" );
@@ -167,7 +167,7 @@ public class WithClauseTest {
 				(session) -> {
 					// Since friends has a join table, we will first left join all friends and then do the WITH clause on the target entity table join
 					// Normally this produces 2 results which is wrong and can only be circumvented by converting the join table and target entity table join to a subquery
-					List list = session.createQuery( "from Human h left join h.friends as f with f.nickName like 'bubba' where h.description = 'father'" )
+					List list = session.createQuery( "from Human h left join h.friends as f with f.nickName like 'bubba' where h.description = 'father'", Object[].class )
 							.list();
 					assertEquals( 1, list.size(), "subquery rewriting of join table did not take effect" );
 				}
@@ -180,7 +180,7 @@ public class WithClauseTest {
 		scope.inTransaction(
 				(session) -> {
 					// Like testWithClauseAsSubquery but uses equal operator since it render differently in SQL
-					List list = session.createQuery( "from Human h left join h.friends as f with f.nickName = 'bubba' where h.description = 'father'" )
+					List list = session.createQuery( "from Human h left join h.friends as f with f.nickName = 'bubba' where h.description = 'father'", Object[].class )
 							.list();
 					assertEquals( 1, list.size(), "subquery rewriting of join table did not take effect" );
 				}
@@ -194,7 +194,7 @@ public class WithClauseTest {
 				(session) -> {
 					// Since family has a join table, we will first left join all family members and then do the WITH clause on the target entity table join
 					// Normally this produces 2 results which is wrong and can only be circumvented by converting the join table and target entity table join to a subquery
-					List list = session.createQuery( "from Human h left join h.family as f with key(f) like 'son1' where h.description = 'father'" )
+					List list = session.createQuery( "from Human h left join h.family as f with key(f) like 'son1' where h.description = 'father'", Object[].class )
 							.list();
 					assertEquals( 1, list.size(), "subquery rewriting of join table did not take effect" );
 				}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/idbag/IdBagTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/idbag/IdBagTest.java
@@ -85,7 +85,7 @@ public class IdBagTest {
 					session.persist( plebs );
 					session.persist( admins );
 
-					List l = session.createQuery( "from User u join u.groups g" ).list();
+					List l = session.createQuery( "from User u join u.groups g", User.class ).list();
 					assertEquals( 1, l.size() );
 
 					session.clear();

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/inheritance/discriminator/MappedSuperclassExtendsEntityTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/inheritance/discriminator/MappedSuperclassExtendsEntityTest.java
@@ -64,7 +64,7 @@ public class MappedSuperclassExtendsEntityTest {
 		scope.inTransaction(
 				s ->
 						s.createQuery(
-								"FROM TestEntity e JOIN e.parents p1 JOIN p1.entities JOIN p1.entities2 JOIN e.parents2 p2 JOIN p2.entities JOIN p2.entities2" )
+								"FROM TestEntity e JOIN e.parents p1 JOIN p1.entities JOIN p1.entities2 JOIN e.parents2 p2 JOIN p2.entities JOIN p2.entities2", Object[].class )
 								.getResultList()
 		);
 	}
@@ -75,7 +75,7 @@ public class MappedSuperclassExtendsEntityTest {
 		// Make sure that the produced query for th
 		scope.inTransaction(
 				s ->
-						s.createQuery( "from TestEntity" ).list()
+						s.createQuery( "from TestEntity", TestEntity.class ).list()
 		);
 	}
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/criteria/valuehandlingmode/inline/NonPkAssociationEqualityPredicateTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/criteria/valuehandlingmode/inline/NonPkAssociationEqualityPredicateTest.java
@@ -65,7 +65,7 @@ public class NonPkAssociationEqualityPredicateTest {
 		scope.inTransaction(
 				entityManager -> {
 					// This fails because we compare a ToOne with non-PK to something with a EntityValuedModelPart which defaults to the PK mapping
-					entityManager.createQuery( "from Order o, Customer c where o.customer = c" ).getResultList();
+					entityManager.createQuery( "from Order o, Customer c where o.customer = c", Object[].class ).getResultList();
 				}
 		);
 	}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/ql/TreatKeywordTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/ql/TreatKeywordTest.java
@@ -23,11 +23,9 @@ import java.util.List;
 import java.util.Set;
 
 import org.hibernate.Session;
-import org.hibernate.Transaction;
 
 import org.junit.Test;
 
-import org.hibernate.testing.FailureExpected;
 import org.hibernate.testing.TestForIssue;
 import org.hibernate.testing.junit4.BaseCoreFunctionalTestCase;
 
@@ -54,13 +52,13 @@ public class TreatKeywordTest extends BaseCoreFunctionalTestCase {
 		// todo : assert invalid naming of non-subclasses in TREAT statement
 		Session s = openSession();
 
-		s.createQuery( "from DiscriminatorEntity e join treat(e.other as DiscriminatorEntitySubclass) o" ).list();
-		s.createQuery( "from DiscriminatorEntity e join treat(e.other as DiscriminatorEntitySubSubclass) o" ).list();
-		s.createQuery( "from DiscriminatorEntitySubclass e join treat(e.other as DiscriminatorEntitySubSubclass) o" ).list();
+		s.createQuery( "from DiscriminatorEntity e join treat(e.other as DiscriminatorEntitySubclass) o", Object[].class ).list();
+		s.createQuery( "from DiscriminatorEntity e join treat(e.other as DiscriminatorEntitySubSubclass) o", Object[].class ).list();
+		s.createQuery( "from DiscriminatorEntitySubclass e join treat(e.other as DiscriminatorEntitySubSubclass) o", Object[].class ).list();
 
-		s.createQuery( "from JoinedEntity e join treat(e.other as JoinedEntitySubclass) o" ).list();
-		s.createQuery( "from JoinedEntity e join treat(e.other as JoinedEntitySubSubclass) o" ).list();
-		s.createQuery( "from JoinedEntitySubclass e join treat(e.other as JoinedEntitySubSubclass) o" ).list();
+		s.createQuery( "from JoinedEntity e join treat(e.other as JoinedEntitySubclass) o", Object[].class ).list();
+		s.createQuery( "from JoinedEntity e join treat(e.other as JoinedEntitySubSubclass) o", Object[].class ).list();
+		s.createQuery( "from JoinedEntitySubclass e join treat(e.other as JoinedEntitySubSubclass) o", Object[].class ).list();
 
 		s.close();
 	}
@@ -81,19 +79,19 @@ public class TreatKeywordTest extends BaseCoreFunctionalTestCase {
 		s.beginTransaction();
 
 		// in select clause
-		List result = s.createQuery( "select e from DiscriminatorEntity e" ).list();
+		List result = s.createQuery( "select e from DiscriminatorEntity e", Object[].class ).list();
 		assertEquals( 2, result.size() );
-		result = s.createQuery( "select treat (e as DiscriminatorEntitySubclass) from DiscriminatorEntity e" ).list();
+		result = s.createQuery( "select treat (e as DiscriminatorEntitySubclass) from DiscriminatorEntity e", Object[].class ).list();
 		assertEquals( 1, result.size() );
-		result = s.createQuery( "select treat (e as DiscriminatorEntitySubSubclass) from DiscriminatorEntity e" ).list();
+		result = s.createQuery( "select treat (e as DiscriminatorEntitySubSubclass) from DiscriminatorEntity e", Object[].class ).list();
 		assertEquals( 0, result.size() );
 
 		// in join
-		result = s.createQuery( "from DiscriminatorEntity e inner join e.other" ).list();
+		result = s.createQuery( "from DiscriminatorEntity e inner join e.other", DiscriminatorEntity.class ).list();
 		assertEquals( 1, result.size() );
-		result = s.createQuery( "from DiscriminatorEntity e inner join treat (e.other as DiscriminatorEntitySubclass)" ).list();
+		result = s.createQuery( "from DiscriminatorEntity e inner join treat (e.other as DiscriminatorEntitySubclass)", DiscriminatorEntity.class ).list();
 		assertEquals( 0, result.size() );
-		result = s.createQuery( "from DiscriminatorEntity e inner join treat (e.other as DiscriminatorEntitySubSubclass)" ).list();
+		result = s.createQuery( "from DiscriminatorEntity e inner join treat (e.other as DiscriminatorEntitySubSubclass)", DiscriminatorEntity.class ).list();
 		assertEquals( 0, result.size() );
 
 		s.close();
@@ -133,11 +131,11 @@ public class TreatKeywordTest extends BaseCoreFunctionalTestCase {
 		assertEquals( 0, result.size() );
 
 		// in join
-		result = s.createQuery( "from JoinedEntity e inner join e.other" ).list();
+		result = s.createQuery( "from JoinedEntity e inner join e.other", JoinedEntity.class ).list();
 		assertEquals( 1, result.size() );
-		result = s.createQuery( "from JoinedEntity e inner join treat (e.other as JoinedEntitySubclass)" ).list();
+		result = s.createQuery( "from JoinedEntity e inner join treat (e.other as JoinedEntitySubclass)", JoinedEntity.class ).list();
 		assertEquals( 0, result.size() );
-		result = s.createQuery( "from JoinedEntity e inner join treat (e.other as JoinedEntitySubSubclass)" ).list();
+		result = s.createQuery( "from JoinedEntity e inner join treat (e.other as JoinedEntitySubSubclass)", JoinedEntity.class ).list();
 		assertEquals( 0, result.size() );
 
 		s.close();

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/legacy/ABCTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/legacy/ABCTest.java
@@ -62,7 +62,7 @@ public class ABCTest {
 					getCache( scope ).evictEntityData( D.class );
 					getCache( scope ).evictEntityData( A.class );
 					assertThat(
-							session.createQuery( "from D d join d.reverse r join d.inverse i where i = r" )
+							session.createQuery( "from D d join d.reverse r join d.inverse i where i = r", Object[].class )
 									.list().size(),
 							is( 1 )
 					);

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/locking/warning/LockNoneWarmingTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/locking/warning/LockNoneWarmingTest.java
@@ -78,7 +78,7 @@ public class LockNoneWarmingTest extends BaseCoreFunctionalTestCase {
 	@Test
 	public void testQuerySetLockModeNONEDoNotLogAWarnMessageWhenTheDialectUseFollowOnLockingIsTrue() {
 		try (Session s = openSession();) {
-			final Query query = s.createQuery( "from Item i join i.bids b where name = :name" );
+			final Query query = s.createQuery( "from Item i join i.bids b where name = :name", Object[].class );
 			query.setParameter( "name", "ZZZZ" );
 			query.setLockMode( "i", LockMode.NONE );
 			query.setLockMode( "b", LockMode.NONE );

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/map/MapIndexFormulaTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/map/MapIndexFormulaTest.java
@@ -43,16 +43,16 @@ public class MapIndexFormulaTest {
 	public void testIndexFunctionOnManyToManyMap(SessionFactoryScope scope) {
 		scope.inTransaction(
 				session -> {
-					session.createQuery( "from Group g join g.users u where g.name = 'something' and index(u) = 'nada'" )
+					session.createQuery( "from Group g join g.users u where g.name = 'something' and index(u) = 'nada'", Group.class )
 							.list();
 					session.createQuery(
-									"from Group g where g.name = 'something' and minindex(g.users) = 'nada'" )
+									"from Group g where g.name = 'something' and minindex(g.users) = 'nada'", Group.class )
 							.list();
 					session.createQuery(
-									"from Group g where g.name = 'something' and maxindex(g.users) = 'nada'" )
+									"from Group g where g.name = 'something' and maxindex(g.users) = 'nada'", Group.class )
 							.list();
 					session.createQuery(
-									"from Group g where g.name = 'something' and maxindex(g.users) = 'nada' and maxindex(g.users) = 'nada'" )
+									"from Group g where g.name = 'something' and maxindex(g.users) = 'nada' and maxindex(g.users) = 'nada'", Group.class )
 							.list();
 				}
 		);

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/inheritance/discriminator/MultiInheritanceImplicitDowncastTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/inheritance/discriminator/MultiInheritanceImplicitDowncastTest.java
@@ -87,7 +87,7 @@ public class MultiInheritanceImplicitDowncastTest {
 	public void testIllegalBaseJoin(SessionFactoryScope scope) {
 		try {
 			scope.inSession(
-					s -> s.createQuery( "from PolymorphicPropertyBase p left join p.base b left join b.relation1" )
+					s -> s.createQuery( "from PolymorphicPropertyBase p left join p.base b left join b.relation1", PolymorphicPropertyBase.class )
 			);
 		}
 		catch (IllegalArgumentException ex) {

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/readwrite/AbstractReadWriteTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/readwrite/AbstractReadWriteTests.java
@@ -64,7 +64,7 @@ public abstract class AbstractReadWriteTests {
 
 		scope.inTransaction(
 				(session) -> {
-					session.createQuery( "from ReadWriteEntity a, ReadWriteEntity b" ).list();
+					session.createQuery( "from ReadWriteEntity a, ReadWriteEntity b", Object[].class ).list();
 				}
 		);
 	}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/orphan/one2one/pk/unidirectional/DeleteOneToOneOrphansTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/orphan/one2one/pk/unidirectional/DeleteOneToOneOrphansTest.java
@@ -61,7 +61,7 @@ public class DeleteOneToOneOrphansTest {
 					assertEquals( 1, results.size() );
 					Employee emp = (Employee) results.get( 0 );
 					assertNotNull( emp.getInfo() );
-					results = session.createQuery( "from Employee e, EmployeeInfo i where e.info = i" ).list();
+					results = session.createQuery( "from Employee e, EmployeeInfo i where e.info = i", Object[].class ).list();
 					assertEquals( 1, results.size() );
 					Object[] result = (Object[]) results.get( 0 );
 					emp = (Employee) result[0];

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/orphan/onetomany/DeleteOneToManyOrphansTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/orphan/onetomany/DeleteOneToManyOrphansTest.java
@@ -75,7 +75,7 @@ public class DeleteOneToManyOrphansTest {
 
 		scope.inTransaction(
 				session -> {
-					Product product = ( session.get( Product.class, p.getId() ) );
+					Product product = session.get( Product.class, p.getId() );
 					assertEquals( 0, product.getFeatures().size() );
 					List results = session.createQuery( "from Feature" ).list();
 					assertEquals( 0, results.size() );

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/propertyref/basic/PropertyRefTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/propertyref/basic/PropertyRefTest.java
@@ -177,7 +177,7 @@ public class PropertyRefTest {
 					}
 					session.clear();
 
-					l = session.createQuery( "from Person p left join p.accounts a" ).list();
+					l = session.createQuery( "from Person p left join p.accounts a", Person.class ).list();
 					for ( int i = 0; i < 2; i++ ) {
 						Person px = (Person) l.get( i );
 						assertFalse( Hibernate.isInitialized( px.getAccounts() ) );

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/query/sqm/exec/CrossJoinTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/query/sqm/exec/CrossJoinTest.java
@@ -23,7 +23,7 @@ public class CrossJoinTest {
 		final String QRY_STRING = "from SimpleEntity e1, SimpleEntity e2 where e1.id = e2.id and e1.someDate = {ts '2018-01-01 00:00:00'}";
 		scope.inTransaction(
 				session -> {
-					session.createQuery( QRY_STRING ).list();
+					session.createQuery( QRY_STRING, Object[].class ).list();
 				}
 		);
 	}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/querycache/AbstractQueryCacheResultTransformerTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/querycache/AbstractQueryCacheResultTransformerTest.java
@@ -21,7 +21,6 @@ import org.hibernate.PropertyNotFoundException;
 import org.hibernate.Session;
 import org.hibernate.cfg.AvailableSettings;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
-import org.hibernate.internal.util.ReflectHelper;
 import org.hibernate.proxy.HibernateProxy;
 import org.hibernate.query.Query;
 import org.hibernate.query.criteria.JpaCriteriaQuery;
@@ -79,9 +78,10 @@ public abstract class AbstractQueryCacheResultTransformerTest {
 
 		@Override
 		protected Object getResults(Session s, boolean isSingleResult) {
-			Query query = getQuery( s ).setCacheable( getQueryCacheMode() != CacheMode.IGNORE ).setCacheMode(
-					getQueryCacheMode() );
-			return ( isSingleResult ? query.uniqueResult() : query.list() );
+			Query query = getQuery( s )
+					.setCacheable( getQueryCacheMode() != CacheMode.IGNORE )
+					.setCacheMode( getQueryCacheMode() );
+			return isSingleResult ? query.uniqueResult() : query.list();
 		}
 	}
 
@@ -258,8 +258,7 @@ public abstract class AbstractQueryCacheResultTransformerTest {
 		HqlExecutor hqlExecutor = new HqlExecutor() {
 			@Override
 			public Query getQuery(Session s) {
-				return s.createQuery(
-								"from Student s left join s.enrolments e left join e.course c order by s.studentNumber" )
+				return s.createQuery("from Student s left join s.enrolments e left join e.course c order by s.studentNumber", Student.class )
 						.setResultTransformer( Transformers.ALIAS_TO_ENTITY_MAP );
 			}
 		};
@@ -312,8 +311,7 @@ public abstract class AbstractQueryCacheResultTransformerTest {
 		HqlExecutor hqlExecutor = new HqlExecutor() {
 			@Override
 			public Query getQuery(Session s) {
-				return s.createQuery(
-								"from Student s left join s.preferredCourse p left join s.addresses a order by s.studentNumber" )
+				return s.createQuery("from Student s left join s.preferredCourse p left join s.addresses a order by s.studentNumber", Student.class )
 						.setResultTransformer( Transformers.ALIAS_TO_ENTITY_MAP );
 			}
 		};
@@ -377,8 +375,7 @@ public abstract class AbstractQueryCacheResultTransformerTest {
 		HqlExecutor hqlExecutor = new HqlExecutor() {
 			@Override
 			public Query getQuery(Session s) {
-				return s.createQuery(
-								"from Student s left join s.addresses a left join s.preferredCourse order by s.studentNumber" )
+				return s.createQuery("from Student s left join s.addresses a left join s.preferredCourse order by s.studentNumber", Student.class )
 						.setResultTransformer( Transformers.ALIAS_TO_ENTITY_MAP );
 			}
 		};
@@ -910,8 +907,7 @@ public abstract class AbstractQueryCacheResultTransformerTest {
 		HqlExecutor hqlExecutor = new HqlExecutor() {
 			@Override
 			public Query getQuery(Session s) {
-				return s.createQuery(
-						"select s, pc from Student s left join fetch s.enrolments left join s.preferredCourse pc order by s.studentNumber" );
+				return s.createQuery("select s, pc from Student s left join fetch s.enrolments left join s.preferredCourse pc order by s.studentNumber", Object[].class );
 			}
 		};
 		ResultChecker checker = results -> {
@@ -963,9 +959,7 @@ public abstract class AbstractQueryCacheResultTransformerTest {
 		HqlExecutor hqlSelectNewMapExecutor = new HqlExecutor() {
 			@Override
 			public Query getQuery(Session s) {
-				return s.createQuery(
-						"select pc, s from Student s left join fetch s.enrolments left join s.preferredCourse pc order by s.studentNumber"
-				);
+				return s.createQuery("select pc, s from Student s left join fetch s.enrolments left join s.preferredCourse pc order by s.studentNumber", Object[].class);
 			}
 		};
 		ResultChecker checker = results -> {
@@ -1075,7 +1069,7 @@ public abstract class AbstractQueryCacheResultTransformerTest {
 		HqlExecutor hqlExecutor = new HqlExecutor() {
 			@Override
 			public Query getQuery(Session s) {
-				return s.createQuery( "from Student s left join fetch s.enrolments e order by s.studentNumber" );
+				return s.createQuery( "from Student s left join fetch s.enrolments e order by s.studentNumber", Student.class );
 			}
 		};
 
@@ -1129,14 +1123,14 @@ public abstract class AbstractQueryCacheResultTransformerTest {
 		HqlExecutor hqlExecutorUnaliased = new HqlExecutor() {
 			@Override
 			public Query getQuery(Session s) {
-				return s.createQuery( "from Student s left join fetch s.addresses order by s.studentNumber" );
+				return s.createQuery( "from Student s left join fetch s.addresses order by s.studentNumber", Student.class );
 			}
 		};
 
 		HqlExecutor hqlExecutorAliased = new HqlExecutor() {
 			@Override
 			public Query getQuery(Session s) {
-				return s.createQuery( "from Student s left join fetch s.addresses a order by s.studentNumber" );
+				return s.createQuery( "from Student s left join fetch s.addresses a order by s.studentNumber", Student.class );
 			}
 		};
 
@@ -1188,7 +1182,7 @@ public abstract class AbstractQueryCacheResultTransformerTest {
 		HqlExecutor hqlExecutorUnaliased = new HqlExecutor() {
 			@Override
 			public Query getQuery(Session s) {
-				return s.createQuery( "from Student s left join fetch s.preferredCourse order by s.studentNumber" );
+				return s.createQuery( "from Student s left join fetch s.preferredCourse order by s.studentNumber", Student.class );
 			}
 		};
 
@@ -1196,7 +1190,7 @@ public abstract class AbstractQueryCacheResultTransformerTest {
 			@Override
 			public Query getQuery(Session s) {
 				return s.createQuery(
-						"from Student s left join fetch s.preferredCourse pCourse order by s.studentNumber" );
+						"from Student s left join fetch s.preferredCourse pCourse order by s.studentNumber", Student.class );
 			}
 		};
 
@@ -1363,7 +1357,7 @@ public abstract class AbstractQueryCacheResultTransformerTest {
 			@Override
 			public Query getQuery(Session s) {
 				return s.createQuery(
-						"select s.name, s from Enrolment e left join e.student s left join fetch s.preferredCourse order by s.studentNumber"
+						"select s.name, s from Enrolment e left join e.student s left join fetch s.preferredCourse order by s.studentNumber", Object[].class
 				);
 			}
 		};
@@ -1418,13 +1412,13 @@ public abstract class AbstractQueryCacheResultTransformerTest {
 			@Override
 			public Query getQuery(Session s) {
 				return s.createQuery(
-						"select s, s.enrolments from Student s left join s.enrolments order by s.studentNumber" );
+						"select s, s.enrolments from Student s left join s.enrolments order by s.studentNumber", Object[].class );
 			}
 		};
 		HqlExecutor hqlExecutorAliased = new HqlExecutor() {
 			@Override
 			public Query getQuery(Session s) {
-				return s.createQuery( "select s, e from Student s left join s.enrolments e order by s.studentNumber" );
+				return s.createQuery( "select s, e from Student s left join s.enrolments e order by s.studentNumber", Object[].class );
 			}
 		};
 		ResultChecker checker = results -> {
@@ -1467,13 +1461,13 @@ public abstract class AbstractQueryCacheResultTransformerTest {
 		HqlExecutor hqlExecutorUnaliased = new HqlExecutor() {
 			@Override
 			public Query getQuery(Session s) {
-				return s.createQuery( "from Student s left join s.addresses order by s.studentNumber" );
+				return s.createQuery( "from Student s left join s.addresses order by s.studentNumber", Student.class );
 			}
 		};
 		HqlExecutor hqlExecutorAliased = new HqlExecutor() {
 			@Override
 			public Query getQuery(Session s) {
-				return s.createQuery( "from Student s left join s.addresses a order by s.studentNumber" );
+				return s.createQuery( "from Student s left join s.addresses a order by s.studentNumber", Student.class );
 			}
 		};
 		ResultChecker checker = results -> {
@@ -1524,7 +1518,7 @@ public abstract class AbstractQueryCacheResultTransformerTest {
 			@Override
 			protected Query getQuery(Session s) {
 				return s.createQuery(
-						"select s, p from Student s left join s.preferredCourse p order by s.studentNumber" );
+						"select s, p from Student s left join s.preferredCourse p order by s.studentNumber", Object[].class );
 			}
 		};
 		ResultChecker checker = results -> {
@@ -1563,7 +1557,7 @@ public abstract class AbstractQueryCacheResultTransformerTest {
 		HqlExecutor hqlExecutor = new HqlExecutor() {
 			@Override
 			public Query getQuery(Session s) {
-				return s.createQuery( "select e.student as student from Enrolment e order by e.studentNumber" )
+				return s.createQuery( "select e.student as student from Enrolment e order by e.studentNumber", Student.class )
 						.setResultTransformer( Transformers.ALIAS_TO_ENTITY_MAP );
 			}
 		};
@@ -1624,7 +1618,7 @@ public abstract class AbstractQueryCacheResultTransformerTest {
 			@Override
 			public Query getQuery(Session s) {
 				return s.createQuery(
-								"select e.student as student, e.semester as semester, e.year as year, e.course as course from Enrolment e order by e.studentNumber" )
+								"select e.student as student, e.semester as semester, e.year as year, e.course as course from Enrolment e order by e.studentNumber", Object[].class )
 						.setResultTransformer( Transformers.ALIAS_TO_ENTITY_MAP );
 			}
 		};
@@ -1689,7 +1683,7 @@ public abstract class AbstractQueryCacheResultTransformerTest {
 			@Override
 			public Query getQuery(Session s) {
 				return s.createQuery(
-								"select e.student as student, e.semester, e.year, e.course as course from Enrolment e order by e.studentNumber" )
+								"select e.student as student, e.semester, e.year, e.course as course from Enrolment e order by e.studentNumber", Object.class )
 						.setResultTransformer( Transformers.ALIAS_TO_ENTITY_MAP );
 			}
 		};
@@ -1745,7 +1739,7 @@ public abstract class AbstractQueryCacheResultTransformerTest {
 			@Override
 			public Query getQuery(Session s) {
 				return s.createQuery(
-								"select min( e.studentNumber ) as minStudentNumber, max( e.studentNumber ) as maxStudentNumber from Enrolment e" )
+								"select min( e.studentNumber ) as minStudentNumber, max( e.studentNumber ) as maxStudentNumber from Enrolment e", Object[].class )
 						.setResultTransformer( Transformers.ALIAS_TO_ENTITY_MAP );
 			}
 		};
@@ -1996,7 +1990,7 @@ public abstract class AbstractQueryCacheResultTransformerTest {
 			@Override
 			public Query getQuery(Session s) {
 				return s.createQuery(
-								"select e.student, e.semester, e.year, e.course from Enrolment e  where e.studentNumber = :studentNumber" )
+								"select e.student, e.semester, e.year, e.course from Enrolment e  where e.studentNumber = :studentNumber", Object[].class )
 						.setParameter( "studentNumber", shermanEnrolmentExpected.getStudentNumber() );
 			}
 		};
@@ -2057,7 +2051,7 @@ public abstract class AbstractQueryCacheResultTransformerTest {
 			@Override
 			public Query getQuery(Session s) {
 				return s.createQuery(
-						"select e.student, e.semester, e.year, e.course from Enrolment e order by e.studentNumber" );
+						"select e.student, e.semester, e.year, e.course from Enrolment e order by e.studentNumber", Object[].class );
 			}
 		};
 		ResultChecker checker = results -> {
@@ -2123,7 +2117,7 @@ public abstract class AbstractQueryCacheResultTransformerTest {
 			@Override
 			public Query getQuery(Session s) {
 				return s.createQuery(
-						"select e.student as st, e.semester as sem, e.year as yr, e.course as c from Enrolment e order by e.studentNumber" );
+						"select e.student as st, e.semester as sem, e.year as yr, e.course as c from Enrolment e order by e.studentNumber", Object[].class );
 			}
 		};
 		ResultChecker checker = results -> {
@@ -2214,7 +2208,7 @@ public abstract class AbstractQueryCacheResultTransformerTest {
 			@Override
 			public Query getQuery(Session s) {
 				return s.createQuery(
-						"select min( e.studentNumber ) as minStudentNumber, max( e.studentNumber ) as maxStudentNumber from Enrolment e" );
+						"select min( e.studentNumber ) as minStudentNumber, max( e.studentNumber ) as maxStudentNumber from Enrolment e", Object[].class );
 			}
 		};
 		ResultChecker checker = results -> {
@@ -2257,7 +2251,7 @@ public abstract class AbstractQueryCacheResultTransformerTest {
 		HqlExecutor hqlExecutor = new HqlExecutor() {
 			@Override
 			public Query getQuery(Session s) {
-				return s.createQuery( "select st.name as studentName from Student st order by st.studentNumber" )
+				return s.createQuery( "select st.name as studentName from Student st order by st.studentNumber", PersonName.class )
 						.setResultTransformer( Transformers.aliasToBean( StudentDTO.class ) );
 			}
 		};
@@ -2315,8 +2309,7 @@ public abstract class AbstractQueryCacheResultTransformerTest {
 		HqlExecutor hqlExecutor = new HqlExecutor() {
 			@Override
 			public Query getQuery(Session s) {
-				return s.createQuery(
-								"select st.name as studentName, co.description as courseDescription from Enrolment e join e.student st join e.course co order by e.studentNumber" )
+				return s.createQuery("select st.name as studentName, co.description as courseDescription from Enrolment e join e.student st join e.course co order by e.studentNumber", Object[].class )
 						.setResultTransformer( Transformers.aliasToBean( StudentDTO.class ) );
 			}
 		};
@@ -2370,8 +2363,7 @@ public abstract class AbstractQueryCacheResultTransformerTest {
 		HqlExecutor hqlExecutor = new HqlExecutor() {
 			@Override
 			public Query getQuery(Session s) {
-				return s.createQuery(
-						"select st.name as studentName, co.description as courseDescription from Enrolment e join e.student st join e.course co order by e.studentNumber" );
+				return s.createQuery("select st.name as studentName, co.description as courseDescription from Enrolment e join e.student st join e.course co order by e.studentNumber", Object[].class );
 			}
 		};
 		ResultChecker checker = results -> {
@@ -2437,8 +2429,7 @@ public abstract class AbstractQueryCacheResultTransformerTest {
 		HqlExecutor hqlExecutor = new HqlExecutor() {
 			@Override
 			public Query getQuery(Session s) {
-				return s.createQuery(
-								"select st.name as studentName, 'lame description' as courseDescription from Enrolment e join e.student st join e.course co order by e.studentNumber" )
+				return s.createQuery("select st.name as studentName, 'lame description' as courseDescription from Enrolment e join e.student st join e.course co order by e.studentNumber", Object[].class )
 						.setResultTransformer( Transformers.aliasToBean( StudentDTO.class ) );
 			}
 		};
@@ -2494,8 +2485,7 @@ public abstract class AbstractQueryCacheResultTransformerTest {
 		HqlExecutor hqlExecutor = new HqlExecutor() {
 			@Override
 			public Query getQuery(Session s) {
-				return s.createQuery(
-								"select st.name as studentName, co.description as courseDescription from Enrolment e join e.student st join e.course co order by e.studentNumber" )
+				return s.createQuery("select st.name as studentName, co.description as courseDescription from Enrolment e join e.student st join e.course co order by e.studentNumber", Object[].class )
 						.setResultTransformer( Transformers.aliasToBean( StudentDTO.class ) );
 			}
 		};
@@ -2545,8 +2535,7 @@ public abstract class AbstractQueryCacheResultTransformerTest {
 		HqlExecutor hqlExecutor = new HqlExecutor() {
 			@Override
 			public Query getQuery(Session s) {
-				return s.createQuery(
-						"select new org.hibernate.orm.test.querycache.StudentDTO(s.name) from Student s order by s.studentNumber" );
+				return s.createQuery("select new org.hibernate.orm.test.querycache.StudentDTO(s.name) from Student s order by s.studentNumber", StudentDTO.class );
 			}
 		};
 		ResultChecker checker = results -> {
@@ -2596,8 +2585,7 @@ public abstract class AbstractQueryCacheResultTransformerTest {
 		HqlExecutor hqlExecutor = new HqlExecutor() {
 			@Override
 			public Query getQuery(Session s) {
-				return s.createQuery(
-						"select new org.hibernate.orm.test.querycache.StudentDTO(s.name) from Student s order by s.studentNumber" );
+				return s.createQuery("select new org.hibernate.orm.test.querycache.StudentDTO(s.name) from Student s order by s.studentNumber", StudentDTO.class );
 			}
 		};
 		ResultChecker checker = results -> {
@@ -2653,8 +2641,7 @@ public abstract class AbstractQueryCacheResultTransformerTest {
 		HqlExecutor hqlExecutor = new HqlExecutor() {
 			@Override
 			public Query getQuery(Session s) {
-				return s.createQuery(
-						"select new Student(s.studentNumber, s.name) from Student s order by s.studentNumber" );
+				return s.createQuery("select new Student(s.studentNumber, s.name) from Student s order by s.studentNumber", Student.class );
 			}
 		};
 		ResultChecker checker = results -> {
@@ -2710,7 +2697,7 @@ public abstract class AbstractQueryCacheResultTransformerTest {
 		HqlExecutor hqlExecutor = new HqlExecutor() {
 			@Override
 			public Query getQuery(Session s) {
-				return s.createQuery( "select new Student(555L, s.name) from Student s order by s.studentNumber" );
+				return s.createQuery( "select new Student(555L, s.name) from Student s order by s.studentNumber", Student.class );
 			}
 		};
 		ResultChecker checker = results -> {
@@ -2761,7 +2748,7 @@ public abstract class AbstractQueryCacheResultTransformerTest {
 		HqlExecutor hqlExecutor = new HqlExecutor() {
 			@Override
 			public Query getQuery(Session s) {
-				return s.createQuery( "select new list(s.studentNumber, s.name) from Student s order by s.studentNumber" );
+				return s.createQuery( "select new list(s.studentNumber, s.name) from Student s order by s.studentNumber", List.class );
 			}
 		};
 		ResultChecker checker = results -> {
@@ -2808,8 +2795,7 @@ public abstract class AbstractQueryCacheResultTransformerTest {
 		HqlExecutor hqlExecutor = new HqlExecutor() {
 			@Override
 			public Query getQuery(Session s) {
-				return s.createQuery(
-						"select new map(s.studentNumber as sNumber, s.name as sName) from Student s order by s.studentNumber" );
+				return s.createQuery("select new map(s.studentNumber as sNumber, s.name as sName) from Student s order by s.studentNumber", Map.class );
 			}
 		};
 		ResultChecker checker = results -> {
@@ -2858,8 +2844,7 @@ public abstract class AbstractQueryCacheResultTransformerTest {
 		HqlExecutor hqlSelectNewMapExecutor = new HqlExecutor() {
 			@Override
 			public Query getQuery(Session s) {
-				return s.createQuery(
-						"select new map(s as s, pc as pc) from Student s left join s.preferredCourse pc left join fetch s.enrolments order by s.studentNumber" );
+				return s.createQuery("select new map(s as s, pc as pc) from Student s left join s.preferredCourse pc left join fetch s.enrolments order by s.studentNumber", Map.class );
 			}
 		};
 		ResultChecker checker = results -> {

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/ternary/TernaryTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/ternary/TernaryTest.java
@@ -81,9 +81,9 @@ public class TernaryTest extends BaseCoreFunctionalTestCase {
 
 		s = openSession();
 		t = s.beginTransaction();
-		List l = s.createQuery("from Employee e join e.managerBySite m where m.name='Bob'").list();
+		List l = s.createQuery("from Employee e join e.managerBySite m where m.name='Bob'", Object[].class).list();
 		assertEquals( l.size(), 0 );
-		l = s.createQuery("from Employee e join e.managerBySite m where m.name='Tom'").list();
+		l = s.createQuery("from Employee e join e.managerBySite m where m.name='Tom'", Object[].class).list();
 		assertEquals( l.size(), 2 );
 		t.commit();
 		s.close();
@@ -103,7 +103,7 @@ public class TernaryTest extends BaseCoreFunctionalTestCase {
 		}
 		assertTrue(total==3);
 
-		l = s.createQuery("from Employee e left join e.managerBySite m left join m.managerBySite m2").list();
+		l = s.createQuery("from Employee e left join e.managerBySite m left join m.managerBySite m2", Object[].class).list();
 
 		// clean up...
 		l = s.createQuery("from Employee e left join fetch e.managerBySite").list();
@@ -124,7 +124,7 @@ public class TernaryTest extends BaseCoreFunctionalTestCase {
 	public void testIndexRelatedFunctions() {
 		Session session = openSession();
 		session.beginTransaction();
-		session.createQuery( "from Employee e join e.managerBySite as m where index(m) is not null" )
+		session.createQuery( "from Employee e join e.managerBySite as m where index(m) is not null", Object[].class )
 				.list();
 		session.createQuery( "from Employee e where minIndex(e.managerBySite) is not null" )
 				.list();


### PR DESCRIPTION
…() method

and add support for using 'this' alias to infer the 'select' list (JPA 3.2)

<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

[Please describe here what your change is about]

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-18584
<!-- Hibernate GitHub Bot issue links end -->