### PR TITLE
HHH-18587 Implement Oracle array functions using set operations

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/dialect/OracleSqlAstTranslator.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/OracleSqlAstTranslator.java
@@ -42,6 +42,7 @@ import org.hibernate.sql.ast.tree.from.ValuesTableReference;
 import org.hibernate.sql.ast.tree.insert.ConflictClause;
 import org.hibernate.sql.ast.tree.insert.InsertSelectStatement;
 import org.hibernate.sql.ast.tree.insert.Values;
+import org.hibernate.sql.ast.tree.predicate.InArrayPredicate;
 import org.hibernate.sql.ast.tree.predicate.InSubQueryPredicate;
 import org.hibernate.sql.ast.tree.predicate.Predicate;
 import org.hibernate.sql.ast.tree.select.QueryGroup;
@@ -121,6 +122,15 @@ public class OracleSqlAstTranslator<T extends JdbcOperation> extends SqlAstTrans
 	@Override
 	protected boolean needsRecursiveKeywordInWithClause() {
 		return false;
+	}
+
+	@Override
+	public void visitInArrayPredicate(InArrayPredicate inArrayPredicate) {
+		// column in (select column_value from(?) )
+		inArrayPredicate.getTestExpression().accept( this );
+		appendSql( " in (select column_value from table(" );
+		inArrayPredicate.getArrayParameter().accept( this );
+		appendSql( "))" );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/dialect/function/array/OracleArrayIncludesFunction.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/function/array/OracleArrayIncludesFunction.java
@@ -8,14 +8,11 @@ package org.hibernate.dialect.function.array;
 
 import java.util.List;
 
-import org.hibernate.metamodel.mapping.JdbcMapping;
-import org.hibernate.metamodel.mapping.JdbcMappingContainer;
 import org.hibernate.query.ReturnableType;
 import org.hibernate.sql.ast.SqlAstTranslator;
 import org.hibernate.sql.ast.spi.SqlAppender;
 import org.hibernate.sql.ast.tree.SqlAstNode;
 import org.hibernate.sql.ast.tree.expression.Expression;
-import org.hibernate.type.BasicPluralType;
 import org.hibernate.type.spi.TypeConfiguration;
 
 public class OracleArrayIncludesFunction extends AbstractArrayIncludesFunction {
@@ -31,17 +28,27 @@ public class OracleArrayIncludesFunction extends AbstractArrayIncludesFunction {
 			ReturnableType<?> returnType,
 			SqlAstTranslator<?> walker) {
 		final Expression haystackExpression = (Expression) sqlAstArguments.get( 0 );
-		final String arrayTypeName = DdlTypeHelper.getTypeName(
-				haystackExpression.getExpressionType(),
-				walker.getSessionFactory().getTypeConfiguration()
-		);
-		sqlAppender.appendSql( arrayTypeName );
-		sqlAppender.append( "_includes(" );
-		haystackExpression.accept( walker );
-		sqlAppender.append( ',' );
-		sqlAstArguments.get( 1 ).accept( walker );
-		sqlAppender.append( ',' );
-		sqlAppender.append( nullable ? "1" : "0" );
-		sqlAppender.append( ")>0" );
+		if ( nullable ) {
+			final String arrayTypeName = DdlTypeHelper.getTypeName(
+					haystackExpression.getExpressionType(),
+					walker.getSessionFactory().getTypeConfiguration()
+					);
+			sqlAppender.appendSql( arrayTypeName );
+			sqlAppender.append( "_includes(" );
+			haystackExpression.accept( walker );
+			sqlAppender.append( ',' );
+			sqlAstArguments.get( 1 ).accept( walker );
+			sqlAppender.append( ',' );
+			sqlAppender.append( "1" );
+			sqlAppender.append( ")>0" );
+		}
+		else {
+			sqlAppender.append( " not exists ((select column_value from table (" );
+			sqlAstArguments.get( 1 ).accept( walker );
+			sqlAppender.append( ")) minus (select column_value from table(" );
+			haystackExpression.accept( walker );
+			sqlAppender.append( ")))" );
+		}
+		
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/dialect/function/array/OracleArrayIntersectsFunction.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/function/array/OracleArrayIntersectsFunction.java
@@ -28,18 +28,27 @@ public class OracleArrayIntersectsFunction extends AbstractArrayIntersectsFuncti
 			ReturnableType<?> returnType,
 			SqlAstTranslator<?> walker) {
 		final Expression haystackExpression = (Expression) sqlAstArguments.get( 0 );
-		final String arrayTypeName = DdlTypeHelper.getTypeName(
-				haystackExpression.getExpressionType(),
-				walker.getSessionFactory().getTypeConfiguration()
-		);
-		sqlAppender.appendSql( arrayTypeName );
-		sqlAppender.append( "_intersects(" );
-		haystackExpression.accept( walker );
-		sqlAppender.append( ',' );
-		sqlAstArguments.get( 1 ).accept( walker );
-		sqlAppender.append( ',' );
-		sqlAppender.append( nullable ? "1" : "0" );
-		sqlAppender.append( ")>0" );
+		if ( nullable ) {
+			final String arrayTypeName = DdlTypeHelper.getTypeName(
+					haystackExpression.getExpressionType(),
+					walker.getSessionFactory().getTypeConfiguration()
+					);
+			sqlAppender.appendSql( arrayTypeName );
+			sqlAppender.append( "_intersects(" );
+			haystackExpression.accept( walker );
+			sqlAppender.append( ',' );
+			sqlAstArguments.get( 1 ).accept( walker );
+			sqlAppender.append( ',' );
+			sqlAppender.append( "1" );
+			sqlAppender.append( ")>0" );
+		}
+		else {
+			sqlAppender.append( " exists (select 1 from (table (" );
+			sqlAstArguments.get( 1 ).accept( walker );
+			sqlAppender.append( ") join (table (" );
+			haystackExpression.accept( walker );
+			sqlAppender.append( ")) using (column_value)))" );
+		}
 	}
 
 }


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-18587

Implement the functions `array_contains`, `array_includes` and `array_intersects` using set operations on Oracle. This is done using the [column_value pseudocolumn](https://docs.oracle.com/en/database/oracle/oracle-database/23/sqlrf/COLUMN_VALUE-Pseudocolumn.html) and the `TABLE` function. Similar to this

```sql
SELECT *
  FROM entity
 WHERE needle IN (SELECT column_value FROM TABLE(?))
```

With Oracle 23 we could also use


```sql
SELECT *
  FROM entity
 WHERE needle = ANY (SELECT column_value FROM TABLE(?))
```

But this wouldn't work in Oracle 19.

The `_nullable` variants keep calling the stored procedures.

----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
