### PR TITLE
HHH-18581 Introduce `supportsBindingNullSqlTypeForSetNull()` and `supportsBindingNullForSetObject()` for `Dialect` to optimize binding null

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/dialect/Dialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/Dialect.java
@@ -5635,9 +5635,31 @@ public abstract class Dialect implements ConversionContext, TypeContributor, Fun
 	/**
 	 * Does this dialect support appending table options SQL fragment at the end of the SQL Table creation statement?
 	 *
-	 *  @return {@code true} indicates it does; {@code false} indicates it does not;
+	 * @return {@code true} indicates it does; {@code false} indicates it does not;
 	 */
-	public boolean supportsTableOptions(){
+	public boolean supportsTableOptions() {
+		return false;
+	}
+
+	/**
+	 * Does this dialect support binding {@link Types#NULL} for {@link PreparedStatement#setNull(int, int)}?
+	 * if it does, then call of {@link PreparedStatement#getParameterMetaData()} could be eliminated for better performance.
+	 *
+	 * @return {@code true} indicates it does; {@code false} indicates it does not;
+	 * @see org.hibernate.type.descriptor.jdbc.ObjectNullResolvingJdbcType
+	 */
+	public boolean supportsBindingNullSqlTypeForSetNull() {
+		return false;
+	}
+
+	/**
+	 * Does this dialect support binding {@code null} for {@link PreparedStatement#setObject(int, Object)}?
+	 * if it does, then call of {@link PreparedStatement#getParameterMetaData()} could be eliminated for better performance.
+	 *
+	 * @return {@code true} indicates it does; {@code false} indicates it does not;
+	 * @see org.hibernate.type.descriptor.jdbc.ObjectNullResolvingJdbcType
+	 */
+	public boolean supportsBindingNullForSetObject() {
 		return false;
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/dialect/H2Dialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/H2Dialect.java
@@ -1015,4 +1015,9 @@ public class H2Dialect extends Dialect {
 		return true;
 	}
 
+	@Override
+	public boolean supportsBindingNullSqlTypeForSetNull() {
+		return true;
+	}
+
 }

--- a/hibernate-core/src/main/java/org/hibernate/dialect/MySQLDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/MySQLDialect.java
@@ -1581,4 +1581,9 @@ public class MySQLDialect extends Dialect {
 		}
 		return sqlCheckConstraint;
 	}
+
+	@Override
+	public boolean supportsBindingNullSqlTypeForSetNull() {
+		return true;
+	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/dialect/PostgreSQLDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/PostgreSQLDialect.java
@@ -1558,4 +1558,9 @@ public class PostgreSQLDialect extends Dialect {
 	public boolean supportsFromClauseInUpdate() {
 		return true;
 	}
+
+	@Override
+	public boolean supportsBindingNullSqlTypeForSetNull() {
+		return true;
+	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/dialect/SQLServerDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/SQLServerDialect.java
@@ -1211,4 +1211,9 @@ public class SQLServerDialect extends AbstractTransactSQLDialect {
 		}
 		return "";
 	}
+
+	@Override
+	public boolean supportsBindingNullForSetObject() {
+		return true;
+	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/jdbc/ObjectNullResolvingJdbcType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/jdbc/ObjectNullResolvingJdbcType.java
@@ -42,13 +42,27 @@ public class ObjectNullResolvingJdbcType extends ObjectJdbcType {
 			@Override
 			protected void doBindNull(PreparedStatement st, int index, WrapperOptions options)
 					throws SQLException {
-				st.setNull( index, st.getParameterMetaData().getParameterType( index ) );
+				if ( options.getDialect().supportsBindingNullForSetObject() ) {
+					st.setObject( index, null );
+				}
+				else {
+					final int sqlType = options.getDialect().supportsBindingNullSqlTypeForSetNull() ? Types.NULL
+							: st.getParameterMetaData().getParameterType( index );
+					st.setNull( index, sqlType );
+				}
 			}
 
 			@Override
 			protected void doBindNull(CallableStatement st, String name, WrapperOptions options)
 					throws SQLException {
-				st.setNull( name, Types.JAVA_OBJECT );
+				if ( options.getDialect().supportsBindingNullForSetObject() ) {
+					st.setObject( name, null );
+				}
+				else {
+					final int sqlType = options.getDialect().supportsBindingNullSqlTypeForSetNull() ? Types.NULL
+							: Types.JAVA_OBJECT;
+					st.setNull( name, sqlType );
+				}
 			}
 
 			@Override

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/typedescriptor/NullTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/typedescriptor/NullTest.java
@@ -1,0 +1,100 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.orm.test.typedescriptor;
+
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.JiraKey;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+/**
+ * @author Yanming Zhou
+ */
+@DomainModel(
+		annotatedClasses = NullTest.SimpleEntity.class
+)
+@SessionFactory
+public class NullTest {
+
+	@BeforeEach
+	public void setUp(SessionFactoryScope scope) {
+		scope.inTransaction(
+				session -> session.persist( new SimpleEntity() )
+		);
+	}
+
+	@AfterEach
+	public void tearDown(SessionFactoryScope scope) {
+		scope.inTransaction(
+				session ->
+						session.createMutationQuery( "delete from SimpleEntity" ).executeUpdate()
+		);
+	}
+
+	@Test
+	@JiraKey("HHH-18581")
+	public void passingNullAsParameterOfNativeQuery(SessionFactoryScope scope) {
+		scope.inTransaction(
+				session -> {
+					SimpleEntity persisted = session.createNativeQuery(
+							"select * from SimpleEntity where name is null or name=:name",
+							SimpleEntity.class
+					).setParameter( "name", null ).uniqueResult();
+
+					assertNotNull( persisted );
+				}
+		);
+	}
+
+	@Test
+	public void passingNullAsParameterOfQuery(SessionFactoryScope scope) {
+		scope.inTransaction(
+				session -> {
+					SimpleEntity persisted = session.createQuery(
+							"from SimpleEntity where name is null or name=:name",
+							SimpleEntity.class
+					).setParameter( "name", null ).uniqueResult();
+
+					assertNotNull( persisted );
+				}
+		);
+	}
+
+	@Entity(name = "SimpleEntity")
+	static class SimpleEntity {
+		@Id
+		@GeneratedValue
+		private Integer id;
+
+		private String name;
+
+		public Integer getId() {
+			return id;
+		}
+
+		public void setId(Integer id) {
+			this.id = id;
+		}
+
+		public String getName() {
+			return name;
+		}
+
+		public void setName(String name) {
+			this.name = name;
+		}
+	}
+}


### PR DESCRIPTION
The method `PreparedStatement.getParameterMetaData().getParameterType(int)` call is expensive for some JDBC driver such as pgJDBC, we should avoid it if the driver supports binding `Types.NULL` for `setNull()` or `null` for `setObject()`.

<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-18581
<!-- Hibernate GitHub Bot issue links end -->