### PR TITLE
HHH-18575 Fix IllegalStateException while passing multi-valued BigDecimal as parameter

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/sql/BaseSqmToSqlAstConverter.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/sql/BaseSqmToSqlAstConverter.java
@@ -6283,7 +6283,14 @@ public abstract class BaseSqmToSqlAstConverter<T extends Statement> extends Base
 					final QueryParameterBinding<?> binding = domainParameterBindings.getBinding(
 							domainParameterXref.getQueryParameter( expression )
 					);
-					final Object bindValue = binding.getBindValue();
+					final Object bindValue;
+					if ( binding.isMultiValued() ) {
+						final Collection<?> bindValues = binding.getBindValues();
+						bindValue = !bindValues.isEmpty() ? bindValues.iterator().next() : null;
+					}
+					else {
+						bindValue = binding.getBindValue();
+					}
 					if ( bindValue != null ) {
 						if ( bindValue instanceof BigInteger ) {
 							int precision = bindValue.toString().length() - ( ( (BigInteger) bindValue ).signum() < 0 ? 1 : 0 );

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/query/hql/MultiValuedParameterTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/query/hql/MultiValuedParameterTest.java
@@ -6,6 +6,7 @@
  */
 package org.hibernate.orm.test.query.hql;
 
+import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.time.LocalDate;
 import java.util.ArrayList;
@@ -28,6 +29,7 @@ import jakarta.persistence.Id;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * @author Andrea Boriero
@@ -100,6 +102,20 @@ public class MultiValuedParameterTest extends BaseSessionFactoryFunctionalTest {
 			assertThat( resultList.size(), is( 3 ) );
 			assertThat( resultList, is( ids ) );
 		} );
+	}
+
+	@Test
+	@Jira( "https://hibernate.atlassian.net/browse/HHH-18575" )
+	void testMultiValuedBigDecimals() {
+		inTransaction( session -> {
+			assertEquals(
+					1,
+					session.createQuery("SELECT 1 WHERE :value IN (:list)", Integer.class)
+							.setParameter( "value", BigDecimal.valueOf( 2.0))
+							.setParameter("list", List.of(BigDecimal.valueOf(2.0), BigDecimal.valueOf(3.0)))
+							.getSingleResult()
+			);
+		});
 	}
 
 	@AfterAll


### PR DESCRIPTION
Fix 
```
java.lang.IllegalStateException: Binding is multi-valued; illegal call to #getBindValue

	at org.hibernate.query.internal.QueryParameterBindingImpl.getBindValue(QueryParameterBindingImpl.java:100)
	at org.hibernate.query.sqm.sql.BaseSqmToSqlAstConverter.resolveSqmParameter(BaseSqmToSqlAstConverter.java:6283)
	at org.hibernate.query.sqm.sql.BaseSqmToSqlAstConverter.consumeSqmParameter(BaseSqmToSqlAstConverter.java:5861)
	at org.hibernate.query.sqm.sql.BaseSqmToSqlAstConverter.consumeSingleSqmParameter(BaseSqmToSqlAstConverter.java:5950)
	at org.hibernate.query.sqm.sql.BaseSqmToSqlAstConverter.processInSingleParameter(BaseSqmToSqlAstConverter.java:8178)
	at org.hibernate.query.sqm.sql.BaseSqmToSqlAstConverter.processInSingleHqlParameter(BaseSqmToSqlAstConverter.java:8135)
	at org.hibernate.query.sqm.sql.BaseSqmToSqlAstConverter.processInListWithSingleParameter(BaseSqmToSqlAstConverter.java:8124)
```

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-18575
<!-- Hibernate GitHub Bot issue links end -->