### PR TITLE
HHH-18490 Static metamodel contains wrong type for Embeddable with generic attribute extending from mapped superclass

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/produce/function/StandardFunctionReturnTypeResolvers.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/produce/function/StandardFunctionReturnTypeResolvers.java
@@ -241,13 +241,8 @@ public class StandardFunctionReturnTypeResolvers {
 	}
 
 	private static SqmExpressible<?> getArgumentExpressible(SqmTypedNode<?> specifiedArgument) {
-		final SqmExpressible<?> expressible = specifiedArgument.getNodeType();
-		final SqmExpressible<?> specifiedArgType = expressible instanceof SqmTypedNode<?>
-				? ( (SqmTypedNode<?>) expressible ).getNodeType()
-				: expressible;
-		return specifiedArgType instanceof SqmPathSource
-				? ( (SqmPathSource<?>) specifiedArgType ).getSqmPathType()
-				: specifiedArgType;
+		final SqmExpressible<?> expressible = specifiedArgument.getExpressible();
+		return expressible != null ? expressible.getSqmType() : null;
 	}
 
 	public static JdbcMapping extractArgumentJdbcMapping(

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/metamodel/generics/embeddable/AbstractValueObject.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/metamodel/generics/embeddable/AbstractValueObject.java
@@ -1,0 +1,34 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html
+ */
+package org.hibernate.orm.test.metamodel.generics.embeddable;
+
+import java.io.Serializable;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.MappedSuperclass;
+
+@MappedSuperclass
+public abstract class AbstractValueObject<V extends Comparable<V>> implements Serializable,
+		Comparable<AbstractValueObject<V>> {
+	public static final String VALUE = "value";
+
+	@Column( name = "value_col" )
+	private V value;
+
+	protected AbstractValueObject() {
+		super();
+	}
+
+	protected AbstractValueObject(final V value) {
+		this.value = value;
+	}
+
+	@Override
+	public int compareTo(final AbstractValueObject<V> object) {
+		return value.compareTo( object.value );
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/metamodel/generics/embeddable/CreationDate.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/metamodel/generics/embeddable/CreationDate.java
@@ -1,0 +1,22 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html
+ */
+package org.hibernate.orm.test.metamodel.generics.embeddable;
+
+import java.util.Date;
+
+import jakarta.persistence.Embeddable;
+
+@Embeddable
+public class CreationDate extends AbstractValueObject<Date> {
+	protected CreationDate() {
+		super();
+	}
+
+	public CreationDate(final Date value) {
+		super( value );
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/metamodel/generics/embeddable/GenericEmbeddableSuperclassMetamodelTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/metamodel/generics/embeddable/GenericEmbeddableSuperclassMetamodelTest.java
@@ -1,0 +1,80 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html
+ */
+package org.hibernate.orm.test.metamodel.generics.embeddable;
+
+import java.util.Date;
+
+import org.hibernate.SessionFactory;
+
+import org.hibernate.testing.orm.junit.EntityManagerFactoryScope;
+import org.hibernate.testing.orm.junit.Jira;
+import org.hibernate.testing.orm.junit.Jpa;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import jakarta.persistence.Tuple;
+import jakarta.persistence.TypedQuery;
+import jakarta.persistence.criteria.CriteriaBuilder;
+import jakarta.persistence.criteria.CriteriaQuery;
+import jakarta.persistence.criteria.Expression;
+import jakarta.persistence.criteria.Path;
+import jakarta.persistence.criteria.Root;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Marco Belladelli
+ */
+@Jpa( annotatedClasses = {
+		Parent.class,
+		AbstractValueObject.class,
+		CreationDate.class,
+		SomeNumber.class,
+		SomeString.class,
+} )
+@Jira( "https://hibernate.atlassian.net/browse/HHH-18490" )
+public class GenericEmbeddableSuperclassMetamodelTest {
+	@SuppressWarnings( { "rawtypes", "unchecked" } )
+	@Test
+	public void test(EntityManagerFactoryScope scope) {
+		scope.inTransaction( entityManager -> {
+			final CriteriaBuilder cb = entityManager.getCriteriaBuilder();
+			final CriteriaQuery<Tuple> cq = cb.createTupleQuery();
+			final Root<Parent> from = cq.from( Parent.class );
+
+			final Path someStringPath = from.get( Parent_.someString ).get( SomeString_.value );
+			final Path someNumberPath = from.get( Parent_.someNumber ).get( SomeNumber_.value );
+			final Path timestampPath = from.get( Parent_.date ).get( CreationDate_.value );
+			final Expression<Integer> maxNumber = cb.max( someNumberPath );
+			final Expression<Date> maxTimestamp = cb.function( "max", Date.class, timestampPath );
+			cq.select( cb.tuple( someStringPath, maxTimestamp, maxNumber ) );
+			cq.groupBy( someStringPath );
+
+			final TypedQuery<Tuple> query = entityManager.createQuery( cq );
+			final Tuple result = query.getSingleResult();
+
+			assertThat( result.get( 0, String.class ) ).isEqualTo( "something" );
+			assertThat( result.get( 1, Date.class ) ).isNotNull();
+			assertThat( result.get( 2, Object.class ) ).isEqualTo( 42 );
+		} );
+	}
+
+	@BeforeAll
+	public void setUp(EntityManagerFactoryScope scope) {
+		scope.inTransaction( entityManager -> entityManager.persist( new Parent(
+				new SomeString( "something" ),
+				new CreationDate( new Date() ),
+				new SomeNumber( 42 )
+		) ) );
+	}
+
+	@AfterAll
+	public void tearDown(EntityManagerFactoryScope scope) {
+		scope.getEntityManagerFactory().unwrap( SessionFactory.class ).getSchemaManager().truncateMappedObjects();
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/metamodel/generics/embeddable/Parent.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/metamodel/generics/embeddable/Parent.java
@@ -1,0 +1,44 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html
+ */
+package org.hibernate.orm.test.metamodel.generics.embeddable;
+
+import jakarta.persistence.AttributeOverride;
+import jakarta.persistence.Column;
+import jakarta.persistence.Embedded;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+
+import static org.hibernate.orm.test.metamodel.generics.embeddable.AbstractValueObject.VALUE;
+
+@Entity
+public class Parent {
+	@Id
+	@GeneratedValue
+	private Long id;
+
+	@Embedded
+	@AttributeOverride( name = VALUE, column = @Column( name = "some_string" ) )
+	private SomeString someString;
+
+	@Embedded
+	@AttributeOverride( name = VALUE, column = @Column( name = "some_date" ) )
+	private CreationDate date;
+
+	@Embedded
+	@AttributeOverride( name = VALUE, column = @Column( name = "some_number" ) )
+	private SomeNumber someNumber;
+
+	public Parent() {
+	}
+
+	public Parent(final SomeString someString, final CreationDate date, final SomeNumber someNumber) {
+		this.someString = someString;
+		this.date = date;
+		this.someNumber = someNumber;
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/metamodel/generics/embeddable/SomeNumber.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/metamodel/generics/embeddable/SomeNumber.java
@@ -1,0 +1,19 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html
+ */
+package org.hibernate.orm.test.metamodel.generics.embeddable;
+
+import jakarta.persistence.Embeddable;
+
+@Embeddable
+public class SomeNumber extends AbstractValueObject<Integer> {
+	protected SomeNumber() {
+	}
+
+	public SomeNumber(final Integer value) {
+		super( value );
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/metamodel/generics/embeddable/SomeString.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/metamodel/generics/embeddable/SomeString.java
@@ -1,0 +1,13 @@
+package org.hibernate.orm.test.metamodel.generics.embeddable;
+
+import jakarta.persistence.Embeddable;
+
+@Embeddable
+public class SomeString extends AbstractValueObject<String> {
+	protected SomeString() {
+	}
+
+	public SomeString(final String value) {
+		super( value );
+	}
+}


### PR DESCRIPTION
<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

https://hibernate.atlassian.net/browse/HHH-18490

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
