### PR TITLE
HHH-18544 multiload() and findAll() should return existing proxies

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/engine/spi/CascadingActions.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/spi/CascadingActions.java
@@ -91,7 +91,11 @@ public class CascadingActions {
 
 	/**
 	 * @see org.hibernate.Session#lock(Object, LockMode)
+	 *
+	 * @deprecated because {@link org.hibernate.annotations.CascadeType#LOCK}
+	 *             is deprecated
 	 */
+	@Deprecated(since="7", forRemoval = true)
 	public static final CascadingAction<LockOptions> LOCK = new BaseCascadingAction<>() {
 		@Override
 		public void cascade(

--- a/hibernate-core/src/main/java/org/hibernate/loader/ast/internal/MultiIdEntityLoaderArrayParam.java
+++ b/hibernate-core/src/main/java/org/hibernate/loader/ast/internal/MultiIdEntityLoaderArrayParam.java
@@ -218,6 +218,9 @@ public class MultiIdEntityLoaderArrayParam<E> extends AbstractMultiIdEntityLoade
 					// the entity is locally deleted, and the options ask that we not return such entities...
 					entity = null;
 				}
+				else {
+					entity = persistenceContext.proxyFor( entity );
+				}
 			}
 			result.set( resultIndex, entity );
 		}

--- a/hibernate-core/src/main/java/org/hibernate/loader/ast/internal/MultiIdEntityLoaderStandard.java
+++ b/hibernate-core/src/main/java/org/hibernate/loader/ast/internal/MultiIdEntityLoaderStandard.java
@@ -188,6 +188,9 @@ public class MultiIdEntityLoaderStandard<T> extends AbstractMultiIdEntityLoader<
 					// the entity is locally deleted, and the options ask that we not return such entities...
 					entity = null;
 				}
+				else {
+					entity = persistenceContext.proxyFor( entity );
+				}
 			}
 			result.set( position, entity );
 		}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/loading/multiLoad/FindAllTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/loading/multiLoad/FindAllTest.java
@@ -12,6 +12,7 @@ import java.util.List;
 import static org.hibernate.ReadOnlyMode.READ_ONLY;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @SessionFactory
@@ -34,6 +35,11 @@ public class FindAllTest {
             assertEquals("hello earth",all.get(1).message);
             assertTrue(s.isReadOnly(all.get(0)));
             assertTrue(s.isReadOnly(all.get(1)));
+        });
+        scope.inTransaction(s-> {
+            Record record = s.getReference(Record.class, 456L);
+            List<Record> all = s.findAll(Record.class, List.of(456L, 123L));
+            assertSame(record, all.get(0));
         });
     }
     @Entity

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/loading/multiLoad/MultiLoadTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/loading/multiLoad/MultiLoadTest.java
@@ -276,7 +276,7 @@ public class MultiLoadTest {
 		);
 	}
 
-	@Test @FailureExpected(jiraKey = "HHH-18544")
+	@Test
 	public void testBasicMultiLoadWithManagedAndNoCheckingProxied(SessionFactoryScope scope) {
 		scope.inTransaction(
 				session -> {
@@ -290,7 +290,7 @@ public class MultiLoadTest {
 		);
 	}
 
-	@Test @FailureExpected(jiraKey = "HHH-18544")
+	@Test
 	public void testBasicMultiLoadWithManagedAndCheckingProxied(SessionFactoryScope scope) {
 		scope.inTransaction(
 				session -> {


### PR DESCRIPTION
<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

[Please describe here what your change is about]

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-18544
https://hibernate.atlassian.net/browse/HHH-18554
<!-- Hibernate GitHub Bot issue links end -->