### PR TITLE
HHH-18598 HHH-15591 Add order column to owned one-to-many unique constraint for `LIST` semantics collections

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/boot/model/internal/CollectionBinder.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/internal/CollectionBinder.java
@@ -2763,6 +2763,7 @@ public abstract class CollectionBinder {
 				targetEntity,
 				joinColumns,
 				key,
+				null,
 				false,
 				buildingContext
 		);
@@ -2821,9 +2822,14 @@ public abstract class CollectionBinder {
 				collection.getOwner(),
 				joinColumns,
 				value,
+				getIndexColumnForUniqueConstraint(),
 				unique,
 				buildingContext
 		);
+	}
+
+	protected IndexColumn getIndexColumnForUniqueConstraint() {
+		return null;
 	}
 
 	private void bindUnownedManyToManyInverseForeignKey(

--- a/hibernate-core/src/main/java/org/hibernate/boot/model/internal/EntityBinder.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/internal/EntityBinder.java
@@ -1973,7 +1973,7 @@ public class EntityBinder {
 		join.setKey( key );
 		setForeignKeyNameIfDefined( join );
 		key.setOnDeleteAction( null );
-		bindForeignKey( persistentClass, null, joinColumns, key, false, context );
+		bindForeignKey( persistentClass, null, joinColumns, key, null,false, context );
 		key.sortProperties();
 		join.createPrimaryKey();
 		join.createForeignKey();

--- a/hibernate-core/src/main/java/org/hibernate/boot/model/internal/JoinedSubclassFkSecondPass.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/internal/JoinedSubclassFkSecondPass.java
@@ -43,6 +43,6 @@ public class JoinedSubclassFkSecondPass extends FkSecondPass {
 
 	@Override
 	public void doSecondPass(Map<String, PersistentClass> persistentClasses) throws MappingException {
-		TableBinder.bindForeignKey( entity.getSuperclass(), entity, columns, value, false, buildingContext );
+		TableBinder.bindForeignKey( entity.getSuperclass(), entity, columns, value, null, false, buildingContext );
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/boot/model/internal/ListBinder.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/internal/ListBinder.java
@@ -114,4 +114,9 @@ public class ListBinder extends CollectionBinder {
 			referenced.addProperty( backref );
 		}
 	}
+
+	@Override
+	protected IndexColumn getIndexColumnForUniqueConstraint() {
+		return indexColumn;
+	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/boot/model/internal/TableBinder.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/internal/TableBinder.java
@@ -7,6 +7,7 @@
 package org.hibernate.boot.model.internal;
 
 import java.lang.invoke.MethodHandles;
+import java.util.ArrayList;
 import java.util.List;
 
 import org.hibernate.AnnotationException;
@@ -557,6 +558,7 @@ public class TableBinder {
 			PersistentClass destinationEntity,
 			AnnotatedJoinColumns joinColumns,
 			SimpleValue value,
+			IndexColumn index,
 			boolean unique,
 			MetadataBuildingContext buildingContext) {
 		final PersistentClass associatedClass;
@@ -591,7 +593,18 @@ public class TableBinder {
 		}
 		value.createForeignKey( referencedEntity, joinColumns );
 		if ( unique ) {
+			createUniqueKey(value, index, buildingContext);
+		}
+	}
+
+	private static void createUniqueKey(SimpleValue value, IndexColumn index, MetadataBuildingContext buildingContext) {
+		if ( index == null ) {
 			value.createUniqueKey( buildingContext );
+		}
+		else if ( !value.hasFormula() && value.getColumnSpan() > 0 ) {
+			final List<Column> columns = new ArrayList<>( value.getConstraintColumns() );
+			columns.add( index.getMappingColumn() );
+			value.getTable().createUniqueKey( columns, buildingContext );
 		}
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/boot/model/internal/ToOneFkSecondPass.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/internal/ToOneFkSecondPass.java
@@ -129,7 +129,7 @@ public class ToOneFkSecondPass extends FkSecondPass {
 						buildingContext
 				);
 			}
-			TableBinder.bindForeignKey( targetEntity, persistentClass, columns, manyToOne, unique, buildingContext );
+			TableBinder.bindForeignKey( targetEntity, persistentClass, columns, manyToOne, null, unique, buildingContext );
 			if ( !manyToOne.isIgnoreNotFound() ) {
 				manyToOne.createPropertyRefConstraints( persistentClasses );
 			}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/onetomany/OneToManyOrderedListJoinTableTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/onetomany/OneToManyOrderedListJoinTableTest.java
@@ -1,0 +1,174 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html
+ */
+package org.hibernate.orm.test.mapping.onetomany;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.Jira;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinTable;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.OrderColumn;
+import jakarta.persistence.Table;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Marco Belladelli
+ */
+@DomainModel( annotatedClasses = {
+		OneToManyOrderedListJoinTableTest.Post.class,
+		OneToManyOrderedListJoinTableTest.Comment.class,
+} )
+@SessionFactory
+@Jira( "https://hibernate.atlassian.net/browse/HHH-18598" )
+@Jira( "https://hibernate.atlassian.net/browse/HHH-15591" )
+public class OneToManyOrderedListJoinTableTest {
+	@Test
+	public void testNormalAddAndRemove(SessionFactoryScope scope) {
+		scope.inTransaction( session -> {
+			final List<Comment> comments = session.find( Post.class, 1L ).getComments();
+			final Comment comment = new Comment( 3L, "comment_3" );
+			session.persist( comment );
+			comments.add( comment );
+		} );
+		scope.inTransaction( session -> {
+			final List<Comment> comments = session.find( Post.class, 1L ).getComments();
+			assertThat( comments ).extracting( Comment::getId ).containsExactly( 1L, 2L, 3L );
+			comments.remove( 2 );
+			comments.remove( 1 );
+		} );
+		scope.inSession( session -> {
+			final List<Comment> comments = session.find( Post.class, 1L ).getComments();
+			assertThat( comments ).extracting( Comment::getId ).containsExactly( 1L );
+		} );
+	}
+
+	@Test
+	public void testSwapElementsAtZeroAndOne(SessionFactoryScope scope) {
+		scope.inTransaction( session -> {
+			final List<Comment> comments = session.find( Post.class, 1L ).getComments();
+			final Comment comment1 = comments.get( 0 );
+			final Comment comment2 = comments.get( 1 );
+			comments.set( 0, comment2 );
+			comments.set( 1, comment1 );
+		} );
+		scope.inSession( session -> {
+			final List<Comment> comments = session.find( Post.class, 1L ).getComments();
+			assertThat( comments ).extracting( Comment::getId ).containsExactly( 2L, 1L );
+		} );
+	}
+
+	@Test
+	public void testAddAtZeroDeleteAtTwo(SessionFactoryScope scope) {
+		scope.inTransaction( session -> {
+			final List<Comment> comments = session.find( Post.class, 1L ).getComments();
+			final Comment comment = new Comment( 3L, "comment_3" );
+			session.persist( comment );
+			comments.add( 0, comment );
+			comments.remove( 2 );
+		} );
+		scope.inSession( session -> {
+			final List<Comment> comments = session.find( Post.class, 1L ).getComments();
+			assertThat( comments ).extracting( Comment::getId ).containsExactly( 3L, 1L );
+		} );
+	}
+
+	@Test
+	public void testAddSameElementTwice(SessionFactoryScope scope) {
+		scope.inTransaction( session -> {
+			final List<Comment> comments = session.find( Post.class, 1L ).getComments();
+			comments.add( comments.size(), comments.get( 0 ) );
+			assertThat( comments ).hasSize( 3 );
+		} );
+		scope.inSession( session -> {
+			final List<Comment> comments = session.find( Post.class, 1L ).getComments();
+			assertThat( comments ).extracting( Comment::getId ).containsExactly( 1L, 2L, 1L );
+			assertThat( comments.get( 0 ) ).isSameAs( comments.get( 2 ) );
+		} );
+	}
+
+	@BeforeEach
+	public void setUp(SessionFactoryScope scope) {
+		scope.inTransaction( session -> {
+			final Post post = new Post();
+			post.setId( 1L );
+			session.persist( post );
+
+			final String[] strings = new String[] { "comment_1", "comment_2" };
+			for ( int i = 0; i < strings.length; i++ ) {
+				final Comment comment = new Comment( (long) i + 1, strings[i] );
+				post.getComments().add( comment );
+				session.persist( comment );
+			}
+		} );
+	}
+
+	@AfterEach
+	public void tearDown(SessionFactoryScope scope) {
+		scope.getSessionFactory().getSchemaManager().truncateMappedObjects();
+	}
+
+	@Entity( name = "Post" )
+	static class Post {
+		@Id
+		private Long id;
+
+		@OneToMany
+		@JoinTable( name = "post_comments" )
+		@OrderColumn( name = "order_col" )
+		private List<Comment> comments = new ArrayList<>();
+
+		public void setId(Long id) {
+			this.id = id;
+		}
+
+		public Long getId() {
+			return id;
+		}
+
+		public List<Comment> getComments() {
+			return comments;
+		}
+	}
+
+	@Entity( name = "Comment" )
+	@Table( name = "comment_table" )
+	static class Comment {
+		@Id
+		private Long id;
+
+		@Column( name = "text_col" )
+		private String text;
+
+		public Comment() {
+		}
+
+		public Comment(Long id, String text) {
+			this.id = id;
+			this.text = text;
+		}
+
+		public Long getId() {
+			return id;
+		}
+
+		public String getText() {
+			return text;
+		}
+	}
+}


### PR DESCRIPTION
<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-18598
https://hibernate.atlassian.net/browse/HHH-15591
<!-- Hibernate GitHub Bot issue links end -->