### PR TITLE
Revert "HHH-18543 Skip GenericCompositeUserTypeTest for JVM OpenJ9"

### DIFF
--- a/hibernate-core/src/test/java/org/hibernate/orm/test/cut/generic/GenericCompositeUserTypeTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/cut/generic/GenericCompositeUserTypeTest.java
@@ -5,7 +5,6 @@ import org.hibernate.testing.orm.junit.DomainModel;
 import org.hibernate.testing.orm.junit.SessionFactory;
 import org.hibernate.testing.orm.junit.SessionFactoryScope;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
 
 @JiraKey(value = "HHH-17019")
@@ -18,7 +17,6 @@ import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 public class GenericCompositeUserTypeTest {
 
 	@Test
-	@DisabledIfSystemProperty(named = "java.vm.name", matches = "\\b.*OpenJ9.*\\b", disabledReason = "https://github.com/eclipse-openj9/openj9/issues/19369")
 	public void hhh17019Test(SessionFactoryScope scope) {
 		scope.inTransaction( session -> {
 			EnumPlaceholder<Weekdays, Weekdays> placeholder = new EnumPlaceholder<>( Weekdays.MONDAY, Weekdays.SUNDAY );


### PR DESCRIPTION
This reverts commit 7e4df3f805c6155ba3f534230958862b1fbbdba6. (https://hibernate.atlassian.net/browse/HHH-18543)


<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
