### PR TITLE
HHH-15942 introduce QueryFlushMode

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/FlushMode.java
+++ b/hibernate-core/src/main/java/org/hibernate/FlushMode.java
@@ -18,9 +18,16 @@ import jakarta.persistence.FlushModeType;
  * <p>
  * For example, {@link #COMMIT} specifies that the session flushes
  * automatically when the transaction is about to commit.
+ * <p>
+ * This enumeration represents options which may be
+ * {@linkplain Session#setHibernateFlushMode set at the session
+ * level}, and competes with the JPA-defined enumeration
+ * {@link jakarta.persistence.FlushModeType}. Alternatively, a
+ * {@link org.hibernate.query.QueryFlushMode QueryFlushMode} may
+ * be specified for a given query.
  *
  * @see Session#setHibernateFlushMode
- * @see org.hibernate.query.CommonQueryContract#setHibernateFlushMode
+ * @see org.hibernate.query.QueryFlushMode
  *
  * @author Gavin King
  */

--- a/hibernate-core/src/main/java/org/hibernate/Session.java
+++ b/hibernate-core/src/main/java/org/hibernate/Session.java
@@ -199,7 +199,7 @@ public interface Session extends SharedSessionContract, EntityManager {
 	void flush();
 
 	/**
-	 * Set the current {@link FlushModeType JPA flush mode} for this session.
+	 * Set the current {@linkplain FlushModeType JPA flush mode} for this session.
 	 * <p>
 	 * <em>Flushing</em> is the process of synchronizing the underlying persistent
 	 * store with persistable state held in memory. The current flush mode determines

--- a/hibernate-core/src/main/java/org/hibernate/annotations/FlushModeType.java
+++ b/hibernate-core/src/main/java/org/hibernate/annotations/FlushModeType.java
@@ -6,6 +6,8 @@
  */
 package org.hibernate.annotations;
 
+import org.hibernate.query.QueryFlushMode;
+
 /**
  * Enumeration extending the {@linkplain jakarta.persistence.FlushModeType JPA flush modes}
  * with flush modes specific to Hibernate, and a "null" mode, {@link #PERSISTENCE_CONTEXT},
@@ -14,9 +16,12 @@ package org.hibernate.annotations;
  *
  * @author Carlos Gonzalez-Cadenas
  *
- * @see NamedQuery
- * @see NamedNativeQuery
+ * @see NamedQuery#flushMode
+ * @see NamedNativeQuery#flushMode
+ *
+ * @deprecated use {@link QueryFlushMode}
  */
+@Deprecated(since="7")
 public enum FlushModeType {
 	/**
 	 * Corresponds to {@link org.hibernate.FlushMode#ALWAYS}.

--- a/hibernate-core/src/main/java/org/hibernate/annotations/NamedNativeQuery.java
+++ b/hibernate-core/src/main/java/org/hibernate/annotations/NamedNativeQuery.java
@@ -13,6 +13,7 @@ import java.lang.annotation.Target;
 import jakarta.persistence.CacheRetrieveMode;
 import jakarta.persistence.CacheStoreMode;
 import org.hibernate.CacheMode;
+import org.hibernate.query.QueryFlushMode;
 
 import static java.lang.annotation.ElementType.PACKAGE;
 import static java.lang.annotation.ElementType.TYPE;
@@ -64,11 +65,24 @@ public @interface NamedNativeQuery {
 	String resultSetMapping() default "";
 
 	/**
+	 * Determines whether the session should be flushed before
+	 * executing the query.
+	 *
+	 * @see org.hibernate.query.CommonQueryContract#setQueryFlushMode(QueryFlushMode)
+	 *
+	 * @since 7.0
+	 */
+	QueryFlushMode flush() default QueryFlushMode.DEFAULT;
+
+	/**
 	 * The flush mode for the query.
 	 *
 	 * @see org.hibernate.query.CommonQueryContract#setFlushMode(jakarta.persistence.FlushModeType)
 	 * @see org.hibernate.jpa.HibernateHints#HINT_FLUSH_MODE
+	 *
+	 * @deprecated use {@link #flush()}
 	 */
+	@Deprecated(since = "7")
 	FlushModeType flushMode() default FlushModeType.PERSISTENCE_CONTEXT;
 
 	/**

--- a/hibernate-core/src/main/java/org/hibernate/annotations/NamedQuery.java
+++ b/hibernate-core/src/main/java/org/hibernate/annotations/NamedQuery.java
@@ -15,6 +15,7 @@ import jakarta.persistence.CacheStoreMode;
 import jakarta.persistence.EntityManager;
 
 import org.hibernate.CacheMode;
+import org.hibernate.query.QueryFlushMode;
 
 import static java.lang.annotation.ElementType.PACKAGE;
 import static java.lang.annotation.ElementType.TYPE;
@@ -59,11 +60,24 @@ public @interface NamedQuery {
 	Class<?> resultClass() default void.class;
 
 	/**
+	 * Determines whether the session should be flushed before
+	 * executing the query.
+	 *
+	 * @see org.hibernate.query.CommonQueryContract#setQueryFlushMode(QueryFlushMode)
+	 *
+	 * @since 7.0
+	 */
+	QueryFlushMode flush() default QueryFlushMode.DEFAULT;
+
+	/**
 	 * The flush mode for this query.
 	 *
 	 * @see org.hibernate.query.CommonQueryContract#setFlushMode(jakarta.persistence.FlushModeType)
 	 * @see org.hibernate.jpa.HibernateHints#HINT_FLUSH_MODE
+	 *
+	 * @deprecated use {@link #flush()}
 	 */
+	@Deprecated(since = "7")
 	FlushModeType flushMode() default FlushModeType.PERSISTENCE_CONTEXT;
 
 	/**

--- a/hibernate-core/src/main/java/org/hibernate/boot/model/internal/QueryBinder.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/internal/QueryBinder.java
@@ -16,6 +16,7 @@ import java.util.function.Supplier;
 import org.hibernate.AnnotationException;
 import org.hibernate.CacheMode;
 import org.hibernate.FlushMode;
+import org.hibernate.query.QueryFlushMode;
 import org.hibernate.LockOptions;
 import org.hibernate.annotations.FlushModeType;
 import org.hibernate.annotations.HQLSelect;
@@ -35,6 +36,7 @@ import org.hibernate.boot.spi.MetadataBuildingContext;
 import org.hibernate.internal.CoreMessageLogger;
 import org.hibernate.internal.log.DeprecationLogger;
 import org.hibernate.jpa.HibernateHints;
+import org.hibernate.jpa.internal.util.FlushModeTypeHelper;
 import org.hibernate.models.internal.util.StringHelper;
 import org.hibernate.models.spi.ClassDetails;
 import org.hibernate.models.spi.SourceModelBuildingContext;
@@ -271,7 +273,7 @@ public abstract class QueryBinder {
 				.setCacheMode(getCacheMode(namedNativeQuery.cacheRetrieveMode(), namedNativeQuery.cacheStoreMode()))
 				.setTimeout(timeout < 0 ? null : timeout)
 				.setFetchSize(fetchSize < 0 ? null : fetchSize)
-				.setFlushMode(getFlushMode(namedNativeQuery.flushMode()))
+				.setFlushMode(getFlushMode(namedNativeQuery.flush(), namedNativeQuery.flushMode()))
 				.setReadOnly(namedNativeQuery.readOnly())
 				.setQuerySpaces(querySpaces)
 				.setComment(nullIfEmpty(namedNativeQuery.comment()));
@@ -412,7 +414,7 @@ public abstract class QueryBinder {
 				.setCacheMode(getCacheMode(namedQuery.cacheRetrieveMode(), namedQuery.cacheStoreMode()))
 				.setTimeout(timeout < 0 ? null : timeout)
 				.setFetchSize(fetchSize < 0 ? null : fetchSize)
-				.setFlushMode(getFlushMode(namedQuery.flushMode()))
+				.setFlushMode(getFlushMode(namedQuery.flush(), namedQuery.flushMode()))
 				.setReadOnly(namedQuery.readOnly())
 				.setComment(nullIfEmpty(namedQuery.comment()));
 	}
@@ -420,6 +422,12 @@ public abstract class QueryBinder {
 	private static CacheMode getCacheMode(CacheRetrieveMode cacheRetrieveMode, CacheStoreMode cacheStoreMode) {
 		final CacheMode cacheMode = CacheMode.fromJpaModes( cacheRetrieveMode, cacheStoreMode );
 		return cacheMode == null ? CacheMode.NORMAL : cacheMode;
+	}
+
+	private static FlushMode getFlushMode(QueryFlushMode queryFlushMode, FlushModeType flushModeType) {
+		return queryFlushMode == QueryFlushMode.DEFAULT
+				? getFlushMode( flushModeType )
+				: FlushModeTypeHelper.getFlushMode(queryFlushMode);
 	}
 
 	private static FlushMode getFlushMode(FlushModeType flushModeType) {

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/NamedNativeQueryAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/NamedNativeQueryAnnotation.java
@@ -24,6 +24,7 @@ import org.hibernate.models.spi.SourceModelBuildingContext;
 
 import jakarta.persistence.CacheRetrieveMode;
 import jakarta.persistence.CacheStoreMode;
+import org.hibernate.query.QueryFlushMode;
 
 @SuppressWarnings({ "ClassExplicitlyAnnotation", "unused" })
 @jakarta.annotation.Generated("org.hibernate.orm.build.annotations.ClassGeneratorProcessor")
@@ -33,6 +34,7 @@ public class NamedNativeQueryAnnotation implements NamedNativeQuery {
 	private Class<?> resultClass;
 	private String resultSetMapping;
 	private FlushModeType flushMode;
+	private QueryFlushMode flush;
 	boolean cacheable;
 	String cacheRegion;
 	int fetchSize;
@@ -51,6 +53,7 @@ public class NamedNativeQueryAnnotation implements NamedNativeQuery {
 		resultClass = void.class;
 		resultSetMapping = "";
 		flushMode = FlushModeType.PERSISTENCE_CONTEXT;
+		flush = QueryFlushMode.DEFAULT;
 		cacheable = false;
 		cacheRegion = "";
 		fetchSize = -1;
@@ -72,6 +75,7 @@ public class NamedNativeQueryAnnotation implements NamedNativeQuery {
 		this.resultClass = annotation.resultClass();
 		this.resultSetMapping = annotation.resultSetMapping();
 		this.flushMode = annotation.flushMode();
+		this.flush = annotation.flush();
 		this.cacheable = annotation.cacheable();
 		this.cacheRegion = annotation.cacheRegion();
 		this.fetchSize = annotation.fetchSize();
@@ -97,6 +101,7 @@ public class NamedNativeQueryAnnotation implements NamedNativeQuery {
 		this.resultClass = (Class<?>) attributeValues.get( "resultClass" );
 		this.resultSetMapping = (String) attributeValues.get( "resultSetMapping" );
 		this.flushMode = (FlushModeType) attributeValues.get( "flushMode" );
+		this.flush = (QueryFlushMode) attributeValues.get( "flush" );
 		this.cacheable = (boolean) attributeValues.get( "cacheable" );
 		this.cacheRegion = (String) attributeValues.get( "cacheRegion" );
 		this.fetchSize = (int) attributeValues.get( "fetchSize" );
@@ -150,6 +155,15 @@ public class NamedNativeQueryAnnotation implements NamedNativeQuery {
 
 	public void resultSetMapping(String value) {
 		this.resultSetMapping = value;
+	}
+
+	@Override
+	public QueryFlushMode flush() {
+		return flush;
+	}
+
+	public void flush(QueryFlushMode value) {
+		this.flush = value;
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/NamedQueryAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/NamedQueryAnnotation.java
@@ -19,6 +19,7 @@ import org.hibernate.models.spi.SourceModelBuildingContext;
 
 import jakarta.persistence.CacheRetrieveMode;
 import jakarta.persistence.CacheStoreMode;
+import org.hibernate.query.QueryFlushMode;
 
 import static org.hibernate.boot.models.xml.internal.QueryProcessing.interpretFlushMode;
 
@@ -29,6 +30,7 @@ public class NamedQueryAnnotation implements NamedQuery {
 	private String query;
 	private Class<?> resultClass;
 	private FlushModeType flushMode;
+	private QueryFlushMode flush;
 	boolean cacheable;
 	String cacheRegion;
 	int fetchSize;
@@ -44,6 +46,7 @@ public class NamedQueryAnnotation implements NamedQuery {
 	public NamedQueryAnnotation(SourceModelBuildingContext modelContext) {
 		resultClass = void.class;
 		flushMode = FlushModeType.PERSISTENCE_CONTEXT;
+		flush = QueryFlushMode.DEFAULT;
 		cacheable = false;
 		cacheRegion = "";
 		fetchSize = -1;
@@ -62,6 +65,7 @@ public class NamedQueryAnnotation implements NamedQuery {
 		this.query = annotation.query();
 		this.resultClass = annotation.resultClass();
 		this.flushMode = annotation.flushMode();
+		this.flush = annotation.flush();
 		this.cacheable = annotation.cacheable();
 		this.cacheRegion = annotation.cacheRegion();
 		this.fetchSize = annotation.fetchSize();
@@ -84,6 +88,7 @@ public class NamedQueryAnnotation implements NamedQuery {
 		this.query = (String) attributeValues.get( "query" );
 		this.resultClass = (Class<?>) attributeValues.get( "resultClass" );
 		this.flushMode = (FlushModeType) attributeValues.get( "flushMode" );
+		this.flush = (QueryFlushMode) attributeValues.get( "flush" );
 		this.cacheable = (boolean) attributeValues.get( "cacheable" );
 		this.cacheRegion = (String) attributeValues.get( "cacheRegion" );
 		this.fetchSize = (int) attributeValues.get( "fetchSize" );
@@ -126,6 +131,15 @@ public class NamedQueryAnnotation implements NamedQuery {
 
 	public void resultClass(Class<?> value) {
 		this.resultClass = value;
+	}
+
+	@Override
+	public QueryFlushMode flush() {
+		return flush;
+	}
+
+	public void flush(QueryFlushMode value) {
+		this.flush = value;
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/procedure/ProcedureCall.java
+++ b/hibernate-core/src/main/java/org/hibernate/procedure/ProcedureCall.java
@@ -281,7 +281,7 @@ public interface ProcedureCall
 	@Override
 	ProcedureCall setParameter(int position, Date value, TemporalType temporalType);
 
-	@Override
+	@Override @Deprecated(since = "7")
 	ProcedureCall setFlushMode(FlushModeType flushMode);
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/procedure/internal/ProcedureCallImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/procedure/internal/ProcedureCallImpl.java
@@ -809,7 +809,7 @@ public class ProcedureCallImpl<R>
 				isCacheable(),
 				getCacheRegion(),
 				getCacheMode(),
-				getHibernateFlushMode(),
+				getQueryOptions().getFlushMode(),
 				isReadOnly(),
 				getTimeout(),
 				getFetchSize(),

--- a/hibernate-core/src/main/java/org/hibernate/query/CommonQueryContract.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/CommonQueryContract.java
@@ -52,47 +52,85 @@ import jakarta.persistence.TemporalType;
 public interface CommonQueryContract {
 
 	/**
+	 * The {@link QueryFlushMode} in effect for this query.
+	 * <p>
+	 * By default, this is {@link QueryFlushMode#DEFAULT}, and the
+	 * {@link FlushMode} of the owning {@link Session} determines whether
+	 * it is flushed.
+	 *
+	 * @see Session#getHibernateFlushMode()
+	 *
+	 * @since 7.0
+	 */
+	QueryFlushMode getQueryFlushMode();
+
+	/**
+	 * Set the {@link QueryFlushMode} to use for this query.
+	 *
+	 * @see Session#getHibernateFlushMode()
+	 *
+	 * @since 7.0
+	 */
+	CommonQueryContract setQueryFlushMode(QueryFlushMode queryFlushMode);
+
+	/**
 	 * The JPA {@link FlushModeType} in effect for this query.  By default, the
 	 * query inherits the {@link FlushMode} of the {@link Session} from which
 	 * it originates.
 	 *
-	 * @see #getHibernateFlushMode
-	 * @see Session#getHibernateFlushMode
+	 * @see #getQueryFlushMode()
+	 * @see #getHibernateFlushMode()
+	 * @see Session#getHibernateFlushMode()
+	 *
+	 * @deprecated use {@link #getQueryFlushMode()}
 	 */
+	@Deprecated(since = "7")
 	FlushModeType getFlushMode();
 
 	/**
-	 * Set the {@link FlushMode} in to use for this query.
+	 * Set the {@link FlushMode} to use for this query.
+	 * <p>
+	 * Setting this to {@code null} ultimately indicates to use the
+	 * {@link FlushMode} of the session. Use {@link #setHibernateFlushMode}
+	 * passing {@link FlushMode#MANUAL} instead to indicate that no automatic
+	 * flushing should occur.
 	 *
-	 * @implNote Setting to {@code null} ultimately indicates to use the
-	 * FlushMode of the Session.  Use {@link #setHibernateFlushMode} passing
-	 * {@link FlushMode#MANUAL} instead to indicate that no automatic flushing
-	 * should occur
-	 *
+	 * @see #getQueryFlushMode()
 	 * @see #getHibernateFlushMode()
 	 * @see Session#getHibernateFlushMode()
+	 *
+	 * @deprecated use {@link #setQueryFlushMode(QueryFlushMode)}
 	 */
+	@Deprecated(since = "7")
 	CommonQueryContract setFlushMode(FlushModeType flushMode);
 
 	/**
-	 * The {@link FlushMode} in effect for this query.  By default, the query
+	 * The {@link FlushMode} in effect for this query. By default, the query
 	 * inherits the {@code FlushMode} of the {@link Session} from which it
 	 * originates.
 	 *
-	 * @see Session#getHibernateFlushMode
+	 * @see #getQueryFlushMode()
+	 * @see Session#getHibernateFlushMode()
+	 *
+	 * @deprecated use {@link #getQueryFlushMode()}
 	 */
+	@Deprecated(since = "7")
 	FlushMode getHibernateFlushMode();
 
 	/**
 	 * Set the current {@link FlushMode} in effect for this query.
 	 *
 	 * @implNote Setting to {@code null} ultimately indicates to use the
-	 * {@link FlushMode} of the Session.  Use {@link FlushMode#MANUAL}
+	 * {@link FlushMode} of the session. Use {@link FlushMode#MANUAL}
 	 * instead to indicate that no automatic flushing should occur.
 	 *
+	 * @see #getQueryFlushMode()
 	 * @see #getHibernateFlushMode()
 	 * @see Session#getHibernateFlushMode()
+	 *
+	 * @deprecated use {@link #setQueryFlushMode(QueryFlushMode)}
 	 */
+	@Deprecated(since = "7")
 	CommonQueryContract setHibernateFlushMode(FlushMode flushMode);
 
 	/**

--- a/hibernate-core/src/main/java/org/hibernate/query/MutationQuery.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/MutationQuery.java
@@ -14,7 +14,6 @@ import java.util.Map;
 
 import org.hibernate.FlushMode;
 import org.hibernate.Incubating;
-import org.hibernate.Session;
 
 import jakarta.persistence.FlushModeType;
 import jakarta.persistence.Parameter;
@@ -81,10 +80,10 @@ public interface MutationQuery extends CommonQueryContract {
 	// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 	// Covariant returns
 
-	@Override
+	@Override @Deprecated(since = "7")
 	MutationQuery setFlushMode(FlushModeType flushMode);
 
-	@Override
+	@Override @Deprecated(since = "7")
 	MutationQuery setHibernateFlushMode(FlushMode flushMode);
 
 	@Override
@@ -209,4 +208,7 @@ public interface MutationQuery extends CommonQueryContract {
 
 	@Override
 	MutationQuery setProperties(@SuppressWarnings("rawtypes") Map bean);
+
+	@Override
+	MutationQuery setQueryFlushMode(QueryFlushMode queryFlushMode);
 }

--- a/hibernate-core/src/main/java/org/hibernate/query/NativeQuery.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/NativeQuery.java
@@ -554,10 +554,13 @@ public interface NativeQuery<T> extends Query<T>, SynchronizeableQuery {
 	// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 	// covariant overrides - Query
 
-	@Override
+	@Override @Deprecated(since = "7")
 	NativeQuery<T> setHibernateFlushMode(FlushMode flushMode);
 
 	@Override
+	NativeQuery<T> setQueryFlushMode(QueryFlushMode queryFlushMode);
+
+	@Override @Deprecated(since = "7")
 	NativeQuery<T> setFlushMode(FlushModeType flushMode);
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/query/Query.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/Query.java
@@ -851,8 +851,11 @@ public interface Query<R> extends SelectionQuery<R>, MutationQuery, TypedQuery<R
 	// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 	// covariant overrides - CommonQueryContract
 
-	@Override
+	@Override @Deprecated(since = "7")
 	Query<R> setHibernateFlushMode(FlushMode flushMode);
+
+	@Override
+	Query<R> setQueryFlushMode(QueryFlushMode queryFlushMode);
 
 	@Override
 	Query<R> setCacheable(boolean cacheable);
@@ -914,7 +917,7 @@ public interface Query<R> extends SelectionQuery<R>, MutationQuery, TypedQuery<R
 	@Override
 	Query<R> disableFetchProfile(String profileName);
 
-	@Override
+	@Override @Deprecated(since = "7")
 	Query<R> setFlushMode(FlushModeType flushMode);
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/query/QueryFlushMode.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/QueryFlushMode.java
@@ -1,0 +1,42 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.query;
+
+/**
+ * Enumerates the possible flush modes for execution of a
+ * {@link org.hibernate.query.Query}. An explicitly-specified
+ * {@linkplain Query#setQueryFlushMode(QueryFlushMode)
+ * query-level flush mode} overrides the current
+ * {@linkplain org.hibernate.Session#getHibernateFlushMode()
+ * flush mode of the session}.
+ *
+ * @since 7.0
+ *
+ * @see CommonQueryContract#setQueryFlushMode(QueryFlushMode)
+ * @see org.hibernate.annotations.NamedQuery#flush
+ * @see org.hibernate.annotations.NamedNativeQuery#flush
+ *
+ * @author Gavin King
+ */
+public enum QueryFlushMode {
+	/**
+	 * Flush before executing the query.
+	 */
+	FLUSH,
+	/**
+	 * Do not flush before executing the query.
+	 */
+	NO_FLUSH,
+	/**
+	 * Let the owning {@link org.hibernate.Session session}
+	 * decide whether to flush, depending on its current
+	 * {@link org.hibernate.FlushMode}.
+	 *
+	 * @see org.hibernate.Session#getFlushMode()
+	 */
+	DEFAULT
+}

--- a/hibernate-core/src/main/java/org/hibernate/query/SelectionQuery.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/SelectionQuery.java
@@ -295,11 +295,14 @@ public interface SelectionQuery<R> extends CommonQueryContract {
 	 */
 	SelectionQuery<R> disableFetchProfile(String profileName);
 
-	@Override
+	@Override @Deprecated(since = "7")
 	SelectionQuery<R> setFlushMode(FlushModeType flushMode);
 
-	@Override
+	@Override @Deprecated(since = "7")
 	SelectionQuery<R> setHibernateFlushMode(FlushMode flushMode);
+
+	@Override
+	SelectionQuery<R> setQueryFlushMode(QueryFlushMode queryFlushMode);
 
 	@Override
 	SelectionQuery<R> setTimeout(int timeout);
@@ -421,14 +424,13 @@ public interface SelectionQuery<R> extends CommonQueryContract {
 	 * the query inherits the {@link CacheMode} of the session from which
 	 * it originates.
 	 * <p>
-	 * The {@link CacheMode} here describes reading-from/writing-to the
-	 * entity/collection caches as we process query results. For caching
-	 * of the actual query results, see {@link #isCacheable()} and
-	 * {@link #getCacheRegion()}
+	 * The {@link CacheMode} here affects the use of entity and collection
+	 * caches as the query result set is processed. For caching of the actual
+	 * query results, use {@link #isCacheable()} and {@link #getCacheRegion()}.
 	 * <p>
 	 * In order for this setting to have any affect, second-level caching
-	 * would have to be enabled and the entities/collections in question
-	 * configured for caching.
+	 * must be enabled and the entities and collections must be eligible
+	 * for storage in the second-level cache.
 	 *
 	 * @see Session#getCacheMode()
 	 */
@@ -450,9 +452,9 @@ public interface SelectionQuery<R> extends CommonQueryContract {
 
 	/**
 	 * Set the current {@link CacheMode} in effect for this query.
-	 *
-	 * @implNote Setting it to {@code null} ultimately indicates to use the
-	 *           {@code CacheMode} of the session.
+	 * <p>
+	 * Set it to {@code null} to indicate that the {@code CacheMode}
+	 * of the {@link Session#getCacheMode() session} should be used.
 	 *
 	 * @see #getCacheMode()
 	 * @see Session#setCacheMode(CacheMode)

--- a/hibernate-core/src/main/java/org/hibernate/query/hql/spi/SqmQueryImplementor.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/hql/spi/SqmQueryImplementor.java
@@ -14,6 +14,7 @@ import java.util.Map;
 
 import org.hibernate.CacheMode;
 import org.hibernate.FlushMode;
+import org.hibernate.query.QueryFlushMode;
 import org.hibernate.LockMode;
 import org.hibernate.LockOptions;
 import org.hibernate.graph.GraphSemantic;
@@ -104,8 +105,11 @@ public interface SqmQueryImplementor<R> extends QueryImplementor<R>, SqmQuery, N
 		return setTupleTransformer( transformer ).setResultListTransformer( transformer );
 	}
 
-	@Override
+	@Override @Deprecated(since = "7")
 	SqmQueryImplementor<R> setHibernateFlushMode(FlushMode flushMode);
+
+	@Override
+	SqmQueryImplementor<R> setQueryFlushMode(QueryFlushMode queryFlushMode);
 
 	@Override
 	SqmQueryImplementor<R> setMaxResults(int maxResult);
@@ -116,7 +120,7 @@ public interface SqmQueryImplementor<R> extends QueryImplementor<R>, SqmQuery, N
 	@Override
 	SqmQueryImplementor<R> setHint(String hintName, Object value);
 
-	@Override
+	@Override @Deprecated(since = "7")
 	SqmQueryImplementor<R> setFlushMode(FlushModeType flushMode);
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/query/spi/AbstractCommonQueryContract.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/spi/AbstractCommonQueryContract.java
@@ -17,6 +17,7 @@ import java.util.Set;
 
 import org.hibernate.CacheMode;
 import org.hibernate.FlushMode;
+import org.hibernate.query.QueryFlushMode;
 import org.hibernate.HibernateException;
 import org.hibernate.LockMode;
 import org.hibernate.LockOptions;
@@ -178,7 +179,7 @@ public abstract class AbstractCommonQueryContract implements CommonQueryContract
 		}
 
 		putIfNotNull( hints, HINT_COMMENT, getComment() );
-		putIfNotNull( hints, HINT_FLUSH_MODE, getHibernateFlushMode() );
+		putIfNotNull( hints, HINT_FLUSH_MODE,  getQueryOptions().getFlushMode() );
 
 		putIfNotNull( hints, HINT_READONLY, getQueryOptions().isReadOnly() );
 		putIfNotNull( hints, HINT_FETCH_SIZE, getQueryOptions().getFetchSize() );
@@ -521,12 +522,24 @@ public abstract class AbstractCommonQueryContract implements CommonQueryContract
 
 	@Override
 	public FlushMode getHibernateFlushMode() {
-		return getQueryOptions().getFlushMode();
+		final FlushMode flushMode = getQueryOptions().getFlushMode();
+		return flushMode == null ? getSession().getHibernateFlushMode() : flushMode;
 	}
 
 	@Override
 	public CommonQueryContract setHibernateFlushMode(FlushMode flushMode) {
 		getQueryOptions().setFlushMode( flushMode );
+		return this;
+	}
+
+	@Override
+	public QueryFlushMode getQueryFlushMode() {
+		return FlushModeTypeHelper.getForcedFlushMode( getQueryOptions().getFlushMode() );
+	}
+
+	@Override
+	public CommonQueryContract setQueryFlushMode(QueryFlushMode queryFlushMode) {
+		getQueryOptions().setFlushMode( FlushModeTypeHelper.getFlushMode(queryFlushMode) );
 		return this;
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/query/spi/AbstractQuery.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/spi/AbstractQuery.java
@@ -27,6 +27,7 @@ import jakarta.persistence.TemporalType;
 
 import org.hibernate.CacheMode;
 import org.hibernate.FlushMode;
+import org.hibernate.query.QueryFlushMode;
 import org.hibernate.HibernateException;
 import org.hibernate.LockMode;
 import org.hibernate.LockOptions;
@@ -195,17 +196,20 @@ public abstract class AbstractQuery<R>
 	}
 
 	@Override
+	public QueryImplementor<R> setQueryFlushMode(QueryFlushMode queryFlushMode) {
+		super.setQueryFlushMode(queryFlushMode);
+		return this;
+	}
+
+	@Override
 	public FlushModeType getFlushMode() {
-		getSession().checkOpen();
-		final FlushMode flushMode = getQueryOptions().getFlushMode() == null
-				? getSession().getHibernateFlushMode()
-				: getQueryOptions().getFlushMode();
-		return FlushModeTypeHelper.getFlushModeType( flushMode );
+//		getSession().checkOpen();
+		return FlushModeTypeHelper.getFlushModeType( getHibernateFlushMode() );
 	}
 
 	@Override
 	public QueryImplementor<R> setFlushMode(FlushModeType flushModeType) {
-		getSession().checkOpen();
+//		getSession().checkOpen();
 		setHibernateFlushMode( FlushModeTypeHelper.getFlushMode( flushModeType ) );
 		return this;
 	}
@@ -366,7 +370,7 @@ public abstract class AbstractQuery<R>
 
 		putIfNotNull( hints, HINT_COMMENT, getComment() );
 		putIfNotNull( hints, HINT_FETCH_SIZE, getQueryOptions().getFetchSize() );
-		putIfNotNull( hints, HINT_FLUSH_MODE, getHibernateFlushMode() );
+		putIfNotNull( hints, HINT_FLUSH_MODE,  getQueryOptions().getFlushMode() );
 
 		if ( getCacheMode() != null ) {
 			putIfNotNull( hints, HINT_CACHE_MODE, getCacheMode() );

--- a/hibernate-core/src/main/java/org/hibernate/query/spi/AbstractQuery.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/spi/AbstractQuery.java
@@ -36,7 +36,6 @@ import org.hibernate.graph.GraphSemantic;
 import org.hibernate.internal.CoreLogging;
 import org.hibernate.internal.CoreMessageLogger;
 import org.hibernate.jpa.AvailableHints;
-import org.hibernate.jpa.internal.util.FlushModeTypeHelper;
 import org.hibernate.jpa.internal.util.LockModeTypeHelper;
 import org.hibernate.query.BindableType;
 import org.hibernate.query.IllegalQueryOperationException;
@@ -197,20 +196,13 @@ public abstract class AbstractQuery<R>
 
 	@Override
 	public QueryImplementor<R> setQueryFlushMode(QueryFlushMode queryFlushMode) {
-		super.setQueryFlushMode(queryFlushMode);
+		super.setQueryFlushMode( queryFlushMode );
 		return this;
 	}
 
 	@Override
-	public FlushModeType getFlushMode() {
-//		getSession().checkOpen();
-		return FlushModeTypeHelper.getFlushModeType( getHibernateFlushMode() );
-	}
-
-	@Override
 	public QueryImplementor<R> setFlushMode(FlushModeType flushModeType) {
-//		getSession().checkOpen();
-		setHibernateFlushMode( FlushModeTypeHelper.getFlushMode( flushModeType ) );
+		super.setFlushMode( flushModeType );
 		return this;
 	}
 
@@ -400,7 +392,6 @@ public abstract class AbstractQuery<R>
 	}
 
 	@Override
-	@SuppressWarnings( {"unchecked", "rawtypes"} )
 	public Set<Parameter<?>> getParameters() {
 		return super.getParameters();
 	}

--- a/hibernate-core/src/main/java/org/hibernate/query/spi/AbstractSelectionQuery.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/spi/AbstractSelectionQuery.java
@@ -20,6 +20,7 @@ import java.util.stream.StreamSupport;
 
 import org.hibernate.CacheMode;
 import org.hibernate.FlushMode;
+import org.hibernate.query.QueryFlushMode;
 import org.hibernate.HibernateException;
 import org.hibernate.LockMode;
 import org.hibernate.LockOptions;
@@ -31,6 +32,7 @@ import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.graph.GraphSemantic;
 import org.hibernate.graph.spi.AppliedGraph;
 import org.hibernate.graph.spi.RootGraphImplementor;
+import org.hibernate.jpa.internal.util.FlushModeTypeHelper;
 import org.hibernate.jpa.internal.util.LockModeTypeHelper;
 import org.hibernate.query.BindableType;
 import org.hibernate.query.IllegalQueryOperationException;
@@ -52,7 +54,6 @@ import jakarta.persistence.TemporalType;
 
 import static java.util.Spliterators.spliteratorUnknownSize;
 import static org.hibernate.CacheMode.fromJpaModes;
-import static org.hibernate.FlushMode.fromJpaFlushMode;
 import static org.hibernate.cfg.AvailableSettings.JAKARTA_SHARED_CACHE_RETRIEVE_MODE;
 import static org.hibernate.cfg.AvailableSettings.JAKARTA_SHARED_CACHE_STORE_MODE;
 import static org.hibernate.cfg.AvailableSettings.JPA_SHARED_CACHE_RETRIEVE_MODE;
@@ -167,7 +168,7 @@ public abstract class AbstractSelectionQuery<R>
 		assert sessionFlushMode == null;
 		assert sessionCacheMode == null;
 
-		final FlushMode effectiveFlushMode = getHibernateFlushMode();
+		final FlushMode effectiveFlushMode = getQueryOptions().getFlushMode();
 		if ( effectiveFlushMode != null ) {
 			sessionFlushMode = session.getHibernateFlushMode();
 			session.setHibernateFlushMode( effectiveFlushMode );
@@ -333,12 +334,12 @@ public abstract class AbstractSelectionQuery<R>
 
 	@Override
 	public FlushModeType getFlushMode() {
-		return getQueryOptions().getFlushMode().toJpaFlushMode();
+		return FlushModeTypeHelper.getFlushModeType( getHibernateFlushMode() );
 	}
 
 	@Override
 	public SelectionQuery<R> setFlushMode(FlushModeType flushMode) {
-		getQueryOptions().setFlushMode( fromJpaFlushMode( flushMode ) );
+		getQueryOptions().setFlushMode( FlushModeTypeHelper.getFlushMode( flushMode ) );
 		return this;
 	}
 
@@ -563,6 +564,12 @@ public abstract class AbstractSelectionQuery<R>
 	@Override
 	public SelectionQuery<R> setHibernateFlushMode(FlushMode flushMode) {
 		super.setHibernateFlushMode( flushMode );
+		return this;
+	}
+
+	@Override
+	public SelectionQuery<R> setQueryFlushMode(QueryFlushMode queryFlushMode) {
+		super.setQueryFlushMode(queryFlushMode);
 		return this;
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/query/spi/AbstractSelectionQuery.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/spi/AbstractSelectionQuery.java
@@ -334,18 +334,24 @@ public abstract class AbstractSelectionQuery<R>
 
 	@Override
 	public FlushModeType getFlushMode() {
+		getSession().checkOpen();
 		return FlushModeTypeHelper.getFlushModeType( getHibernateFlushMode() );
 	}
 
 	@Override
 	public SelectionQuery<R> setFlushMode(FlushModeType flushMode) {
+		getSession().checkOpen();
 		getQueryOptions().setFlushMode( FlushModeTypeHelper.getFlushMode( flushMode ) );
 		return this;
 	}
 
 	@Override
 	public SelectionQuery<R> setMaxResults(int maxResult) {
-		super.applyMaxResults( maxResult );
+		if ( maxResult < 0 ) {
+			throw new IllegalArgumentException( "Max results cannot be negative" );
+		}
+		getSession().checkOpen();
+		getQueryOptions().getLimit().setMaxRows(maxResult);
 		return this;
 	}
 
@@ -353,7 +359,7 @@ public abstract class AbstractSelectionQuery<R>
 	public SelectionQuery<R> setFirstResult(int startPosition) {
 		getSession().checkOpen();
 		if ( startPosition < 0 ) {
-			throw new IllegalArgumentException( "first-result value cannot be negative : " + startPosition );
+			throw new IllegalArgumentException( "First result cannot be negative" );
 		}
 		getQueryOptions().getLimit().setFirstRow( startPosition );
 		return this;

--- a/hibernate-core/src/main/java/org/hibernate/query/spi/SqmQuery.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/spi/SqmQuery.java
@@ -13,6 +13,7 @@ import java.util.Date;
 import java.util.Map;
 
 import org.hibernate.FlushMode;
+import org.hibernate.query.QueryFlushMode;
 import org.hibernate.query.BindableType;
 import org.hibernate.query.CommonQueryContract;
 import org.hibernate.query.ParameterMetadata;
@@ -151,6 +152,9 @@ public interface SqmQuery extends CommonQueryContract {
 	@Override
 	SqmQuery setProperties(@SuppressWarnings("rawtypes") Map bean);
 
-	@Override
+	@Override @Deprecated(since = "7")
 	SqmQuery setHibernateFlushMode(FlushMode flushMode);
+
+	@Override
+	SqmQuery setQueryFlushMode(QueryFlushMode queryFlushMode);
 }

--- a/hibernate-core/src/main/java/org/hibernate/query/sql/internal/NativeQueryImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sql/internal/NativeQueryImpl.java
@@ -22,6 +22,7 @@ import java.util.function.Supplier;
 
 import org.hibernate.CacheMode;
 import org.hibernate.FlushMode;
+import org.hibernate.query.QueryFlushMode;
 import org.hibernate.HibernateException;
 import org.hibernate.LockMode;
 import org.hibernate.LockOptions;
@@ -55,7 +56,6 @@ import org.hibernate.query.TupleTransformer;
 import org.hibernate.query.internal.DelegatingDomainQueryExecutionContext;
 import org.hibernate.query.internal.ParameterMetadataImpl;
 import org.hibernate.query.internal.QueryOptionsImpl;
-import org.hibernate.query.internal.QueryParameterBindingsImpl;
 import org.hibernate.query.internal.ResultSetMappingResolutionContext;
 import org.hibernate.query.named.NamedResultSetMappingMemento;
 import org.hibernate.query.results.Builders;
@@ -469,7 +469,7 @@ public class NativeQueryImpl<R>
 				isCacheable(),
 				getCacheRegion(),
 				getCacheMode(),
-				getHibernateFlushMode(),
+				getQueryOptions().getFlushMode(),
 				isReadOnly(),
 				getTimeout(),
 				getFetchSize(),
@@ -607,7 +607,7 @@ public class NativeQueryImpl<R>
 
 	private boolean shouldFlush() {
 		if ( getSession().isTransactionInProgress() ) {
-			FlushMode effectiveFlushMode = getHibernateFlushMode();
+			FlushMode effectiveFlushMode = getQueryOptions().getFlushMode();
 			if ( effectiveFlushMode == null ) {
 				effectiveFlushMode = getSession().getHibernateFlushMode();
 			}
@@ -1177,6 +1177,12 @@ public class NativeQueryImpl<R>
 	@Override
 	public NativeQueryImplementor<R> setHibernateFlushMode(FlushMode flushMode) {
 		super.setHibernateFlushMode( flushMode );
+		return this;
+	}
+
+	@Override
+	public NativeQueryImplementor<R> setQueryFlushMode(QueryFlushMode queryFlushMode) {
+		super.setQueryFlushMode(queryFlushMode);
 		return this;
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/query/sql/spi/NativeQueryImplementor.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sql/spi/NativeQueryImplementor.java
@@ -14,6 +14,7 @@ import java.util.Map;
 
 import org.hibernate.CacheMode;
 import org.hibernate.FlushMode;
+import org.hibernate.query.QueryFlushMode;
 import org.hibernate.Incubating;
 import org.hibernate.LockMode;
 import org.hibernate.LockOptions;
@@ -148,10 +149,13 @@ public interface NativeQueryImplementor<R> extends QueryImplementor<R>, NativeQu
 	@Override
 	NativeQueryImplementor<R> setHint(String hintName, Object value);
 
-	@Override
+	@Override @Deprecated(since = "7")
 	NativeQueryImplementor<R> setHibernateFlushMode(FlushMode flushMode);
 
 	@Override
+	NativeQueryImplementor<R> setQueryFlushMode(QueryFlushMode queryFlushMode);
+
+	@Override @Deprecated(since = "7")
 	NativeQueryImplementor<R> setFlushMode(FlushModeType flushMode);
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/SqmSelectionQuery.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/SqmSelectionQuery.java
@@ -14,6 +14,7 @@ import java.util.Map;
 
 import org.hibernate.CacheMode;
 import org.hibernate.FlushMode;
+import org.hibernate.query.QueryFlushMode;
 import org.hibernate.query.BindableType;
 import org.hibernate.query.QueryParameter;
 import org.hibernate.query.SelectionQuery;
@@ -141,8 +142,11 @@ public interface SqmSelectionQuery<R> extends SqmQuery, SelectionQuery<R> {
 	@Override
 	SqmSelectionQuery<R> setProperties(@SuppressWarnings("rawtypes") Map bean);
 
-	@Override
+	@Override @Deprecated(since = "7")
 	SqmSelectionQuery<R> setHibernateFlushMode(FlushMode flushMode);
+
+	@Override
+	SqmSelectionQuery<R> setQueryFlushMode(QueryFlushMode queryFlushMode);
 
 	@Override
 	SqmSelectionQuery<R> setCacheMode(CacheMode cacheMode);

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/internal/QuerySqmImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/internal/QuerySqmImpl.java
@@ -702,26 +702,26 @@ public class QuerySqmImpl<R>
 
 	@Override
 	public <T> SqmQueryImplementor<T> setTupleTransformer(TupleTransformer<T> transformer) {
-		applyTupleTransformer( transformer );
+		getQueryOptions().setTupleTransformer( transformer );
 		//noinspection unchecked
 		return (SqmQueryImplementor<T>) this;
 	}
 
 	@Override
 	public SqmQueryImplementor<R> setResultListTransformer(ResultListTransformer<R> transformer) {
-		applyResultListTransformer( transformer );
+		getQueryOptions().setResultListTransformer( transformer );
 		return this;
 	}
 
 	@Override
 	public SqmQueryImplementor<R> setMaxResults(int maxResult) {
-		applyMaxResults( maxResult );
+		super.setMaxResults( maxResult );
 		return this;
 	}
 
 	@Override
 	public SqmQueryImplementor<R> setFirstResult(int startPosition) {
-		applyFirstResult( startPosition );
+		super.setFirstResult( startPosition );
 		return this;
 	}
 
@@ -733,13 +733,13 @@ public class QuerySqmImpl<R>
 
 	@Override
 	public SqmQueryImplementor<R> setQueryFlushMode(QueryFlushMode queryFlushMode) {
-		super.setQueryFlushMode(queryFlushMode);
+		super.setQueryFlushMode( queryFlushMode );
 		return this;
 	}
 
 	@Override
 	public SqmQueryImplementor<R> setFlushMode(FlushModeType flushMode) {
-		applyJpaFlushMode( flushMode );
+		super.setFlushMode( flushMode );
 		return this;
 	}
 
@@ -759,11 +759,6 @@ public class QuerySqmImpl<R>
 		verifySelect();
 		getSession().checkOpen( false );
 		return getLockOptions().getLockMode().toJpaLockMode();
-	}
-
-	@Override
-	public FlushModeType getFlushMode() {
-		return getJpaFlushMode();
 	}
 
 	@Override
@@ -819,7 +814,7 @@ public class QuerySqmImpl<R>
 
 	@Override
 	public SqmQueryImplementor<R> setHint(String hintName, Object value) {
-		applyHint( hintName, value );
+		super.setHint( hintName, value );
 		return this;
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/internal/QuerySqmImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/internal/QuerySqmImpl.java
@@ -21,6 +21,7 @@ import java.util.function.Supplier;
 import jakarta.persistence.EntityGraph;
 import org.hibernate.CacheMode;
 import org.hibernate.FlushMode;
+import org.hibernate.query.QueryFlushMode;
 import org.hibernate.HibernateException;
 import org.hibernate.LockMode;
 import org.hibernate.LockOptions;
@@ -35,8 +36,6 @@ import org.hibernate.graph.spi.RootGraphImplementor;
 import org.hibernate.id.BulkInsertionCapableIdentifierGenerator;
 import org.hibernate.id.OptimizableGenerator;
 import org.hibernate.id.enhanced.Optimizer;
-import org.hibernate.internal.CoreLogging;
-import org.hibernate.internal.CoreMessageLogger;
 import org.hibernate.metamodel.mapping.EntityIdentifierMapping;
 import org.hibernate.metamodel.mapping.internal.SingleAttributeIdentifierMapping;
 import org.hibernate.metamodel.model.domain.EntityDomainType;
@@ -123,7 +122,6 @@ import static org.hibernate.query.sqm.internal.SqmUtil.verifyIsNonSelectStatemen
 public class QuerySqmImpl<R>
 		extends AbstractSqmSelectionQuery<R>
 		implements SqmQueryImplementor<R>, InterpretationsKeySource, DomainQueryExecutionContext {
-	private static final CoreMessageLogger LOG = CoreLogging.messageLogger( QuerySqmImpl.class );
 
 	private final String hql;
 	private SqmStatement<R> sqm;
@@ -734,6 +732,12 @@ public class QuerySqmImpl<R>
 	}
 
 	@Override
+	public SqmQueryImplementor<R> setQueryFlushMode(QueryFlushMode queryFlushMode) {
+		super.setQueryFlushMode(queryFlushMode);
+		return this;
+	}
+
+	@Override
 	public SqmQueryImplementor<R> setFlushMode(FlushModeType flushMode) {
 		applyJpaFlushMode( flushMode );
 		return this;
@@ -909,7 +913,7 @@ public class QuerySqmImpl<R>
 					isCacheable(),
 					getCacheRegion(),
 					getCacheMode(),
-					getHibernateFlushMode(),
+					getQueryOptions().getFlushMode(),
 					isReadOnly(),
 					getLockOptions(),
 					getTimeout(),
@@ -929,7 +933,7 @@ public class QuerySqmImpl<R>
 				isCacheable(),
 				getCacheRegion(),
 				getCacheMode(),
-				getHibernateFlushMode(),
+				getQueryOptions().getFlushMode(),
 				isReadOnly(),
 				getLockOptions(),
 				getTimeout(),

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/internal/SqmSelectionQueryImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/internal/SqmSelectionQueryImpl.java
@@ -24,6 +24,7 @@ import jakarta.persistence.TemporalType;
 
 import org.hibernate.CacheMode;
 import org.hibernate.FlushMode;
+import org.hibernate.query.QueryFlushMode;
 import org.hibernate.LockMode;
 import org.hibernate.ScrollMode;
 import org.hibernate.engine.spi.LoadQueryInfluencers;
@@ -548,6 +549,12 @@ public class SqmSelectionQueryImpl<R> extends AbstractSqmSelectionQuery<R>
 	@Override
 	public SqmSelectionQuery<R> setHibernateFlushMode(FlushMode flushMode) {
 		super.setHibernateFlushMode( flushMode );
+		return this;
+	}
+
+	@Override
+	public SqmSelectionQuery<R> setQueryFlushMode(QueryFlushMode queryFlushMode) {
+		super.setQueryFlushMode(queryFlushMode);
 		return this;
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/spi/DelegatingSqmSelectionQueryImplementor.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/spi/DelegatingSqmSelectionQueryImplementor.java
@@ -29,8 +29,10 @@ import org.hibernate.query.KeyedResultList;
 import org.hibernate.query.Order;
 import org.hibernate.query.Page;
 import org.hibernate.query.ParameterMetadata;
+import org.hibernate.query.QueryFlushMode;
 import org.hibernate.query.QueryParameter;
 import org.hibernate.query.spi.QueryOptions;
+import org.hibernate.query.sqm.SqmSelectionQuery;
 import org.hibernate.query.sqm.tree.SqmStatement;
 import org.hibernate.sql.results.spi.ResultsConsumer;
 
@@ -61,6 +63,16 @@ public abstract class DelegatingSqmSelectionQueryImplementor<R> implements SqmSe
 	@Override
 	public FlushMode getHibernateFlushMode() {
 		return getDelegate().getHibernateFlushMode();
+	}
+
+	@Override
+	public QueryFlushMode getQueryFlushMode() {
+		return getDelegate().getQueryFlushMode();
+	}
+
+	@Override
+	public SqmSelectionQuery<R> setQueryFlushMode(QueryFlushMode queryFlushMode) {
+		return getDelegate().setQueryFlushMode( queryFlushMode );
 	}
 
 	@Override

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/query/NamedQueryQueryFlushModeTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/query/NamedQueryQueryFlushModeTest.java
@@ -9,19 +9,16 @@ package org.hibernate.orm.test.jpa.query;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
-
 import org.hibernate.FlushMode;
+import org.hibernate.query.QueryFlushMode;
 import org.hibernate.Session;
-import org.hibernate.annotations.FlushModeType;
 import org.hibernate.annotations.NamedNativeQuery;
 import org.hibernate.annotations.NamedQuery;
 import org.hibernate.query.NativeQuery;
 import org.hibernate.query.Query;
-
-import org.hibernate.testing.orm.junit.JiraKey;
 import org.hibernate.testing.orm.junit.EntityManagerFactoryScope;
+import org.hibernate.testing.orm.junit.JiraKey;
 import org.hibernate.testing.orm.junit.Jpa;
-
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -29,11 +26,11 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 /**
  * @author Yoann Rodiere
  */
-@JiraKey(value = "HHH-12795")
+@JiraKey("HHH-12795")
 @Jpa(annotatedClasses = {
-		NamedQueryFlushModeTest.TestEntity.class
+		NamedQueryQueryFlushModeTest.TestEntity.class
 })
-public class NamedQueryFlushModeTest {
+public class NamedQueryQueryFlushModeTest {
 
 	@Test
 	public void testNamedQueryWithFlushModeManual(EntityManagerFactoryScope scope) {
@@ -56,7 +53,7 @@ public class NamedQueryFlushModeTest {
 				entityManager -> {
 					Session s = entityManager.unwrap( Session.class );
 					Query<?> query = s.getNamedQuery( queryName );
-					assertEquals( FlushMode.COMMIT, query.getHibernateFlushMode() );
+					assertEquals( FlushMode.MANUAL, query.getHibernateFlushMode() );
 					assertEquals( jakarta.persistence.FlushModeType.COMMIT, query.getFlushMode() );
 				}
 		);
@@ -104,21 +101,25 @@ public class NamedQueryFlushModeTest {
 					query = s.getNamedQuery( queryName );
 					assertEquals( FlushMode.MANUAL, query.getHibernateFlushMode() );
 					assertEquals( jakarta.persistence.FlushModeType.COMMIT, query.getFlushMode() );
+					assertEquals( QueryFlushMode.DEFAULT, query.getQueryFlushMode() );
 
 					s.setHibernateFlushMode( FlushMode.COMMIT );
 					query = s.getNamedQuery( queryName );
 					assertEquals( FlushMode.COMMIT, query.getHibernateFlushMode() );
 					assertEquals( jakarta.persistence.FlushModeType.COMMIT, query.getFlushMode() );
+					assertEquals( QueryFlushMode.DEFAULT, query.getQueryFlushMode() );
 
 					s.setHibernateFlushMode( FlushMode.AUTO );
 					query = s.getNamedQuery( queryName );
 					assertEquals( FlushMode.AUTO, query.getHibernateFlushMode() );
 					assertEquals( jakarta.persistence.FlushModeType.AUTO, query.getFlushMode() );
+					assertEquals( QueryFlushMode.DEFAULT, query.getQueryFlushMode() );
 
 					s.setHibernateFlushMode( FlushMode.ALWAYS );
 					query = s.getNamedQuery( queryName );
 					assertEquals( FlushMode.ALWAYS, query.getHibernateFlushMode() );
 					assertEquals( jakarta.persistence.FlushModeType.AUTO, query.getFlushMode() );
+					assertEquals( QueryFlushMode.DEFAULT, query.getQueryFlushMode() );
 				}
 		);
 	}
@@ -131,6 +132,7 @@ public class NamedQueryFlushModeTest {
 					Session s = entityManager.unwrap( Session.class );
 					NativeQuery<?> query = s.getNamedNativeQuery( queryName );
 					assertEquals( FlushMode.MANUAL, query.getHibernateFlushMode() );
+					assertEquals( QueryFlushMode.NO_FLUSH, query.getQueryFlushMode() );
 				}
 		);
 	}
@@ -142,7 +144,8 @@ public class NamedQueryFlushModeTest {
 				entityManager -> {
 					Session s = entityManager.unwrap( Session.class );
 					NativeQuery<?> query = s.getNamedNativeQuery( queryName );
-					assertEquals( FlushMode.COMMIT, query.getHibernateFlushMode() );
+					assertEquals( FlushMode.MANUAL, query.getHibernateFlushMode() );
+					assertEquals( QueryFlushMode.NO_FLUSH, query.getQueryFlushMode() );
 				}
 		);
 	}
@@ -155,6 +158,7 @@ public class NamedQueryFlushModeTest {
 					Session s = entityManager.unwrap( Session.class );
 					NativeQuery<?> query = s.getNamedNativeQuery( queryName );
 					assertEquals( FlushMode.AUTO, query.getHibernateFlushMode() );
+					assertEquals( QueryFlushMode.DEFAULT, query.getQueryFlushMode() );
 				}
 		);
 	}
@@ -167,6 +171,7 @@ public class NamedQueryFlushModeTest {
 					Session s = entityManager.unwrap( Session.class );
 					NativeQuery<?> query = s.getNamedNativeQuery( queryName );
 					assertEquals( FlushMode.ALWAYS, query.getHibernateFlushMode() );
+					assertEquals( QueryFlushMode.FLUSH, query.getQueryFlushMode() );
 				}
 		);
 	}
@@ -209,57 +214,57 @@ public class NamedQueryFlushModeTest {
 	@NamedQuery(
 			name = "NamedQueryFlushModeManual",
 			query = "select e from TestEntity e where e.text = :text",
-			flushMode = FlushModeType.MANUAL
+			flush = QueryFlushMode.NO_FLUSH
 	)
 	@NamedQuery(
 			name = "NamedQueryFlushModeCommit",
 			query = "select e from TestEntity e where e.text = :text",
-			flushMode = FlushModeType.COMMIT
+			flush = QueryFlushMode.NO_FLUSH
 	)
 	@NamedQuery(
 			name = "NamedQueryFlushModeAuto",
 			query = "select e from TestEntity e where e.text = :text",
-			flushMode = FlushModeType.AUTO
+			flush = QueryFlushMode.DEFAULT
 	)
 	@NamedQuery(
 			name = "NamedQueryFlushModeAlways",
 			query = "select e from TestEntity e where e.text = :text",
-			flushMode = FlushModeType.ALWAYS
+			flush = QueryFlushMode.FLUSH
 	)
 	@NamedQuery(
 			name = "NamedQueryFlushModePersistenceContext",
 			query = "select e from TestEntity e where e.text = :text",
-			flushMode = FlushModeType.PERSISTENCE_CONTEXT
+			flush = QueryFlushMode.DEFAULT
 	)
 	@NamedNativeQuery(
 			name = "NamedNativeQueryFlushModeManual",
 			query = "select * from TestEntity e where e.text = :text",
 			resultClass = TestEntity.class,
-			flushMode = FlushModeType.MANUAL
+			flush = QueryFlushMode.NO_FLUSH
 	)
 	@NamedNativeQuery(
 			name = "NamedNativeQueryFlushModeCommit",
 			query = "select * from TestEntity e where e.text = :text",
 			resultClass = TestEntity.class,
-			flushMode = FlushModeType.COMMIT
+			flush = QueryFlushMode.NO_FLUSH
 	)
 	@NamedNativeQuery(
 			name = "NamedNativeQueryFlushModeAuto",
 			query = "select * from TestEntity e where e.text = :text",
 			resultClass = TestEntity.class,
-			flushMode = FlushModeType.AUTO
+			flush = QueryFlushMode.DEFAULT
 	)
 	@NamedNativeQuery(
 			name = "NamedNativeQueryFlushModeAlways",
 			query = "select * from TestEntity e where e.text = :text",
 			resultClass = TestEntity.class,
-			flushMode = FlushModeType.ALWAYS
+			flush = QueryFlushMode.FLUSH
 	)
 	@NamedNativeQuery(
 			name = "NamedNativeQueryFlushModePersistenceContext",
 			query = "select * from TestEntity e where e.text = :text",
 			resultClass = TestEntity.class,
-			flushMode = FlushModeType.PERSISTENCE_CONTEXT
+			flush = QueryFlushMode.DEFAULT
 	)
 
 	public static class TestEntity {


### PR DESCRIPTION
Redo of #5851.

- replaces `FlushModeType` in the annotation package
- much less confusing when applied to a `Query`
  * what do `MANUAL` and `COMMIT` mean for a `Query`?
  * how is `AUTO` useful for a `Query`?

- also make `Query.getHibernateFlushMode()` obey its documented semantics by returning the session flush mode instead of null when unset

<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

[Please describe here what your change is about]

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-15942
<!-- Hibernate GitHub Bot issue links end -->