### PR TITLE
HHH-18286 Add Setting to fail Bootstrapping on Metadata Access Failure

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/cfg/JdbcSettings.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/JdbcSettings.java
@@ -490,6 +490,21 @@ public interface JdbcSettings extends C3p0Settings, ProxoolSettings, AgroalSetti
 	 */
 	String ALLOW_METADATA_ON_BOOT = "hibernate.boot.allow_jdbc_metadata_access";
 
+	/**
+	 * Whether failures to access the JDBC {@linkplain java.sql.DatabaseMetaData metadata} should be ignored and the
+	 * bootstrapping process should continue. Hibernate then uses a default JDBC
+	 * {@linkplain org.hibernate.engine.jdbc.env.spi.JdbcEnvironment environment}.
+	 * <p/>
+	 * Failures to access the metadata can result in unexpected runtime errors when accessing the database, since the
+	 * default JDBC environment might not correctly represent the capabilities of the underlying database.
+	 * <p/>
+	 * This setting only takes effect when the {@link #ALLOW_METADATA_ON_BOOT} setting is activated.
+	 *
+	 * @settingDefault {@code true}
+	 * @see #ALLOW_METADATA_ON_BOOT
+	 * @since 6.6
+	 */
+	String IGNORE_METADATA_ACCESS_FAILURE_ON_BOOT = "hibernate.boot.ignore_jdbc_metadata_access_failure";
 
 	// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 	// Deprecated Hibernate settings

--- a/hibernate-core/src/main/java/org/hibernate/engine/jdbc/env/internal/JdbcEnvironmentInitiator.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/jdbc/env/internal/JdbcEnvironmentInitiator.java
@@ -13,13 +13,13 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.StringTokenizer;
 
+import org.hibernate.HibernateException;
 import org.hibernate.boot.registry.StandardServiceInitiator;
 import org.hibernate.cfg.JdbcSettings;
 import org.hibernate.dialect.DatabaseVersion;
 import org.hibernate.dialect.Dialect;
 import org.hibernate.engine.config.spi.ConfigurationService;
 import org.hibernate.engine.jdbc.batch.spi.BatchBuilder;
-import org.hibernate.engine.jdbc.connections.internal.ConnectionProviderInitiator;
 import org.hibernate.engine.jdbc.connections.internal.DatabaseConnectionInfoImpl;
 import org.hibernate.engine.jdbc.connections.spi.ConnectionProvider;
 import org.hibernate.engine.jdbc.connections.spi.DatabaseConnectionInfo;
@@ -321,7 +321,7 @@ public class JdbcEnvironmentInitiator implements StandardServiceInitiator<JdbcEn
 			return temporaryJdbcSessionOwner.transactionCoordinator.createIsolationDelegate().delegateWork(
 					new AbstractReturningWork<>() {
 						@Override
-						public JdbcEnvironmentImpl execute(Connection connection) {
+						public JdbcEnvironmentImpl execute(Connection connection) throws SQLException {
 							try {
 								final DatabaseMetaData metadata = connection.getMetaData();
 								logDatabaseAndDriver( metadata );
@@ -357,7 +357,12 @@ public class JdbcEnvironmentInitiator implements StandardServiceInitiator<JdbcEn
 								);
 							}
 							catch (SQLException e) {
-								log.unableToObtainConnectionMetadata( e );
+								if ( shouldIgnoreMetadataAccessFailure( configurationValues ) ) {
+									log.unableToObtainConnectionMetadata( e );
+								}
+								else {
+									throw e;
+								}
 							}
 
 							// accessing the JDBC metadata failed
@@ -387,10 +392,23 @@ public class JdbcEnvironmentInitiator implements StandardServiceInitiator<JdbcEn
 			);
 		}
 		catch ( Exception e ) {
-			log.unableToObtainConnectionToQueryMetadata( e );
+			if ( shouldIgnoreMetadataAccessFailure( configurationValues ) ) {
+				log.unableToObtainConnectionToQueryMetadata( e );
+			}
+			else {
+				throw new HibernateException( "Unable to access JDBC metadata", e );
+			}
 		}
 		// accessing the JDBC metadata failed
 		return getJdbcEnvironmentWithDefaults( configurationValues, registry, dialectFactory );
+	}
+
+	private static boolean shouldIgnoreMetadataAccessFailure(Map<String, Object> configurationValues) {
+		return getBoolean(
+				JdbcSettings.IGNORE_METADATA_ACCESS_FAILURE_ON_BOOT,
+				configurationValues,
+				true
+		);
 	}
 
 	private static void logDatabaseAndDriver(DatabaseMetaData dbmd) throws SQLException {


### PR DESCRIPTION
A failure to access the JDBC connection metadata while bootstrapping Hibernate can lead to ClassCastExceptions during runtime when the Oracle JDBC driver is used and a BLOB is created by the NonContextualLobCreator. To avoid this issue, a new JDBC setting is introduced, which lets the bootstrapping fail when the connection metadata cannot be obtained.

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
