### PR TITLE
Documentation fix for Maven BOM import instructions

### DIFF
--- a/documentation/src/main/asciidoc/quickstart/guides/obtaining.adoc
+++ b/documentation/src/main/asciidoc/quickstart/guides/obtaining.adoc
@@ -101,13 +101,15 @@ To apply the platform (BOM) in Maven
 </dependency>
 
 <dependencyManagement>
-  <dependency>
-    <groupId>org.hibernate.orm</groupId>
-    <artifactId>hibernate-platform</artifactId>
-    <version>{fullVersion}</version>
-    <type>pom</type>
-    <scope>import</scope>
-  </dependency>
+  <dependencies>
+    <dependency>
+      <groupId>org.hibernate.orm</groupId>
+      <artifactId>hibernate-platform</artifactId>
+      <version>{fullVersion}</version>
+      <type>pom</type>
+      <scope>import</scope>
+    </dependency>
+  </dependencies>
 </dependencyManagement>
 ----
 


### PR DESCRIPTION
[Simple documentation fix]
Trivial doc fix to add the missing xml anchor to import the hibernate BOM.

Thanks

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
