### PR TITLE
Exclude target folder from spotless to fix gradle compilation cache and add git blame ignore list

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,3 @@
+# Initial commits that enabled spotless automatic formatting
+59731c089e9d649a663c81d9622b54557d6aba37
+4d63ffd98cdead513ab0be0fa23f9787423092d3

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,6 +51,7 @@ GitHub there are a few pre-requisite steps to follow:
 the linked page, this also includes:
     * [set up your local git install](https://help.github.com/articles/set-up-git) 
     * clone your fork
+* Instruct git to ignore certain commits when using `git blame`. From the directory of your local clone, run this: `git config blame.ignoreRevsFile .git-blame-ignore-revs`
 * See the wiki pages for setting up your IDE, whether you use 
 [IntelliJ IDEA](https://hibernate.org/community/contribute/intellij-idea/)
 or [Eclipse](https://hibernate.org/community/contribute/eclipse-ide/)<sup>(1)</sup>.

--- a/gradle/java-module.gradle
+++ b/gradle/java-module.gradle
@@ -472,9 +472,10 @@ spotless {
 	//Don't fail during the check: rather than enforcing guidelines, we use this plugin to fix mistakes automatically.
 	enforceCheck false
 	java {
-		licenseHeaderFile rootProject.file('spotless.license.java')
+		targetExclude( "**/target/**/*.java" )
+		licenseHeaderFile rootProject.file( 'spotless.license.java' )
 		removeUnusedImports()
-		indentWithTabs(4)
+		indentWithTabs( 4 )
 		trimTrailingWhitespace()
 		endWithNewline()
 	}

--- a/hibernate-core/hibernate-core.gradle
+++ b/hibernate-core/hibernate-core.gradle
@@ -282,8 +282,3 @@ tasks.sourcesJar.dependsOn ':hibernate-core:generateGraphParser'
 tasks.sourcesJar.dependsOn ':hibernate-core:generateHqlParser'
 tasks.sourcesJar.dependsOn ':hibernate-core:generateSqlScriptParser'
 tasks.sourcesJar.dependsOn ':hibernate-core:generateOrderingParser'
-
-tasks.spotlessJava.dependsOn ':hibernate-core:generateGraphParser'
-tasks.spotlessJava.dependsOn ':hibernate-core:generateHqlParser'
-tasks.spotlessJava.dependsOn ':hibernate-core:generateSqlScriptParser'
-tasks.spotlessJava.dependsOn ':hibernate-core:generateOrderingParser'


### PR DESCRIPTION
<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

Follow up to https://github.com/hibernate/hibernate-orm/pull/8952

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
