### PR TITLE
HHH-18515 Unrecognized discriminator value exception when running native query on entity with discriminator column

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/MappedDiscriminatorConverter.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/MappedDiscriminatorConverter.java
@@ -11,7 +11,9 @@ import org.hibernate.metamodel.mapping.internal.DiscriminatorValueDetailsImpl;
 import org.hibernate.metamodel.model.domain.NavigableRole;
 import org.hibernate.metamodel.spi.MappingMetamodelImplementor;
 import org.hibernate.type.BasicType;
+import org.hibernate.type.descriptor.java.CharacterJavaType;
 import org.hibernate.type.descriptor.java.JavaType;
+import org.hibernate.type.descriptor.java.StringJavaType;
 
 import java.util.List;
 import java.util.Map;
@@ -109,6 +111,23 @@ public class MappedDiscriminatorConverter<O,R> extends DiscriminatorConverter<O,
 		final DiscriminatorValueDetails notNullMatch = discriminatorValueToEntityNameMap.get( NOT_NULL_DISCRIMINATOR );
 		if ( notNullMatch != null ) {
 			return notNullMatch;
+		}
+
+		if ( value.getClass().isEnum() ) {
+			final Object enumValue;
+			if ( getRelationalJavaType() instanceof StringJavaType ) {
+				enumValue = ( (Enum) value ).name();
+			}
+			else if ( getRelationalJavaType() instanceof CharacterJavaType ) {
+				enumValue = ( (Enum) value ).name().charAt( 0 );
+			}
+			else {
+				enumValue = ( (Enum) value ).ordinal();
+			}
+			final DiscriminatorValueDetails enumMatch = discriminatorValueToEntityNameMap.get( enumValue );
+			if ( enumMatch != null ) {
+				return enumMatch;
+			}
 		}
 
 		throw new HibernateException( "Unrecognized discriminator value: " + value );

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/query/NativeQueryAndDiscriminatorTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/query/NativeQueryAndDiscriminatorTest.java
@@ -1,0 +1,116 @@
+/*
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.query;
+
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.JiraKey;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.DiscriminatorColumn;
+import jakarta.persistence.DiscriminatorType;
+import jakarta.persistence.DiscriminatorValue;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Id;
+import jakarta.persistence.Inheritance;
+import jakarta.persistence.InheritanceType;
+import jakarta.persistence.Table;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+@DomainModel(
+		annotatedClasses = {
+				NativeQueryAndDiscriminatorTest.BaseEntity.class,
+				NativeQueryAndDiscriminatorTest.TestEntity.class
+		}
+)
+@SessionFactory
+@JiraKey("HHH-18515")
+public class NativeQueryAndDiscriminatorTest {
+
+
+	@BeforeEach
+	public void setUp(SessionFactoryScope scope) {
+		scope.inTransaction(
+				session -> {
+					TestEntity e = new TestEntity( 1l, "test", EntityDiscriminator.T );
+					session.persist( e );
+				}
+		);
+	}
+
+	@AfterEach
+	public void tearDown(SessionFactoryScope scope) {
+		scope.inTransaction(
+				session -> {
+					session.createMutationQuery( "delete TestEntity" ).executeUpdate();
+				}
+		);
+	}
+
+	@Test
+	public void testNativeQuery(SessionFactoryScope scope) {
+		scope.inTransaction(
+				session -> {
+					BaseEntity entity = session.createNativeQuery(
+									"select * from BASE_ENTITY where id = :id",
+									BaseEntity.class
+							)
+							.setParameter( "id", 1l )
+							.getSingleResult();
+					assertThat( entity ).isNotNull();
+				}
+		);
+	}
+
+
+	@Entity(name = "BaseEntity")
+	@Table(name = "BASE_ENTITY")
+	@Inheritance(strategy = InheritanceType.SINGLE_TABLE)
+	@DiscriminatorColumn(name = "discriminator", discriminatorType = DiscriminatorType.CHAR)
+	@DiscriminatorValue("B")
+	public static class BaseEntity {
+
+		@Id
+		private Long id;
+
+		private String name;
+
+		@Column(insertable = false, updatable = false)
+		@Enumerated(EnumType.STRING)
+		private EntityDiscriminator discriminator;
+
+		public BaseEntity() {
+		}
+
+		public BaseEntity(Long id, String name, EntityDiscriminator discriminator) {
+			this.id = id;
+			this.name = name;
+			this.discriminator = discriminator;
+		}
+	}
+
+	@Entity(name = "TestEntity")
+	@DiscriminatorValue("T")
+	public static class TestEntity extends BaseEntity {
+
+		public TestEntity() {
+		}
+
+		public TestEntity(Long id, String name, EntityDiscriminator discriminator) {
+			super( id, name, discriminator );
+		}
+	}
+
+	enum EntityDiscriminator {
+		T;
+	}
+}


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-18515 

I know it is a kind of a hack but with native query having a properties with the same name of the descriptor but type enum not able to find an easy solution without introducing overhead and massive changes

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
