### PR TITLE
HHH-18522 Drop hard requirements on Jandex

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/boot/MetadataBuilder.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/MetadataBuilder.java
@@ -21,7 +21,6 @@ import org.hibernate.query.sqm.function.SqmFunctionDescriptor;
 import org.hibernate.type.BasicType;
 import org.hibernate.usertype.UserType;
 
-import org.jboss.jandex.IndexView;
 
 import jakarta.persistence.AttributeConverter;
 import jakarta.persistence.SharedCacheMode;
@@ -148,7 +147,7 @@ public interface MetadataBuilder {
 	 *
 	 * @return {@code this}, for method chaining
 	 */
-	MetadataBuilder applyIndexView(IndexView jandexView);
+	MetadataBuilder applyIndexView(Object jandexView);
 
 	/**
 	 * Specify the options to be used in performing scanning.

--- a/hibernate-core/src/main/java/org/hibernate/boot/internal/BootstrapContextImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/internal/BootstrapContextImpl.java
@@ -38,7 +38,6 @@ import org.hibernate.resource.beans.spi.BeanInstanceProducer;
 import org.hibernate.type.BasicType;
 import org.hibernate.type.spi.TypeConfiguration;
 
-import org.jboss.jandex.IndexView;
 import org.jboss.logging.Logger;
 
 /**
@@ -66,7 +65,7 @@ public class BootstrapContextImpl implements BootstrapContext {
 	private Object scannerSetting;
 	private ArchiveDescriptorFactory archiveDescriptorFactory;
 
-	private IndexView jandexView;
+	private Object jandexView;
 
 	private HashMap<String,SqmFunctionDescriptor> sqlFunctionMap;
 	private ArrayList<AuxiliaryDatabaseObject> auxiliaryDatabaseObjectList;
@@ -182,7 +181,7 @@ public class BootstrapContextImpl implements BootstrapContext {
 	}
 
 	@Override
-	public IndexView getJandexView() {
+	public Object getJandexView() {
 		return jandexView;
 	}
 
@@ -300,7 +299,7 @@ public class BootstrapContextImpl implements BootstrapContext {
 		this.archiveDescriptorFactory = factory;
 	}
 
-	void injectJandexView(IndexView jandexView) {
+	void injectJandexView(Object jandexView) {
 		log.debugf( "Injecting Jandex IndexView [%s] into BootstrapContext; was [%s]", jandexView, this.jandexView );
 		this.jandexView = jandexView;
 	}

--- a/hibernate-core/src/main/java/org/hibernate/boot/internal/MetadataBuilderImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/internal/MetadataBuilderImpl.java
@@ -86,7 +86,6 @@ import org.hibernate.type.spi.TypeConfiguration;
 import org.hibernate.usertype.CompositeUserType;
 import org.hibernate.usertype.UserType;
 
-import org.jboss.jandex.IndexView;
 
 import jakarta.persistence.AttributeConverter;
 import jakarta.persistence.ConstraintMode;
@@ -213,7 +212,7 @@ public class MetadataBuilderImpl implements MetadataBuilderImplementor, TypeCont
 	}
 
 	@Override
-	public MetadataBuilder applyIndexView(IndexView jandexView) {
+	public MetadataBuilder applyIndexView(Object jandexView) {
 		this.bootstrapContext.injectJandexView( jandexView );
 		return this;
 	}

--- a/hibernate-core/src/main/java/org/hibernate/boot/model/process/spi/MetadataBuildingProcess.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/process/spi/MetadataBuildingProcess.java
@@ -71,10 +71,8 @@ import org.hibernate.engine.config.spi.StandardConverters;
 import org.hibernate.engine.jdbc.spi.JdbcServices;
 import org.hibernate.mapping.Table;
 import org.hibernate.models.internal.MutableClassDetailsRegistry;
-import org.hibernate.models.jandex.internal.JandexIndexerHelper;
 import org.hibernate.models.spi.ClassDetails;
 import org.hibernate.models.spi.ClassDetailsRegistry;
-import org.hibernate.models.spi.ClassLoading;
 import org.hibernate.models.spi.SourceModelBuildingContext;
 import org.hibernate.type.BasicType;
 import org.hibernate.type.BasicTypeRegistry;
@@ -95,9 +93,6 @@ import org.hibernate.type.internal.NamedBasicTypeImpl;
 import org.hibernate.type.spi.TypeConfiguration;
 import org.hibernate.usertype.CompositeUserType;
 
-import org.jboss.jandex.CompositeIndex;
-import org.jboss.jandex.IndexView;
-import org.jboss.jandex.Indexer;
 
 import jakarta.persistence.AttributeConverter;
 
@@ -398,10 +393,6 @@ public class MetadataBuildingProcess {
 		} );
 		managedResources.getAnnotatedClassReferences().forEach( (clazz) -> allKnownClassNames.add( clazz.getName() ) );
 
-		// At this point we know all managed class names across all sources.
-		// Resolve the Jandex Index and build the SourceModelBuildingContext.
-		final IndexView jandexIndex = resolveJandexIndex( allKnownClassNames, bootstrapContext.getJandexView(), sourceModelBuildingContext.getClassLoading() );
-
 		// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 		// 	- process metadata-complete XML
 		//	- collect overlay XML
@@ -424,7 +415,6 @@ public class MetadataBuildingProcess {
 		final DomainModelCategorizationCollector modelCategorizationCollector = new DomainModelCategorizationCollector(
 				areIdGeneratorsGlobal,
 				metadataCollector.getGlobalRegistrations(),
-				jandexIndex,
 				sourceModelBuildingContext
 		);
 
@@ -458,7 +448,6 @@ public class MetadataBuildingProcess {
 
 		return new DomainModelSource(
 				classDetailsRegistry,
-				jandexIndex,
 				allKnownClassNames,
 				modelCategorizationCollector.getGlobalRegistrations(),
 				rootMappingDefaults,
@@ -489,31 +478,6 @@ public class MetadataBuildingProcess {
 				applyKnownClass( classDetails.getSuperClass(), categorizedClassNames, classDetailsRegistry, modelCategorizationCollector );
 			}
 		}
-	}
-
-	public static IndexView resolveJandexIndex(
-			List<String> allKnownClassNames,
-			IndexView suppliedJandexIndex,
-			ClassLoading classLoading) {
-		// todo : we could build a new Jandex (Composite)Index that includes the `managedResources#getAnnotatedClassNames`
-		// 		and all classes from `managedResources#getXmlMappingBindings`.  Only really worth it in the case
-		//		of runtime enhancement.  This would definitely need to be toggle-able.
-		//		+
-		//		For now, let's not as it does not matter for this PoC
-		if ( 1 == 1 ) {
-			return suppliedJandexIndex;
-		}
-
-		final Indexer jandexIndexer = new Indexer();
-		for ( String knownClassName : allKnownClassNames ) {
-			JandexIndexerHelper.apply( knownClassName, jandexIndexer, classLoading );
-		}
-
-		if ( suppliedJandexIndex == null ) {
-			return jandexIndexer.complete();
-		}
-
-		return CompositeIndex.create( suppliedJandexIndex, jandexIndexer.complete() );
 	}
 
 	private static void processAdditionalMappingContributions(

--- a/hibernate-core/src/main/java/org/hibernate/boot/model/source/internal/annotations/DomainModelSource.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/source/internal/annotations/DomainModelSource.java
@@ -14,14 +14,11 @@ import org.hibernate.boot.models.spi.GlobalRegistrations;
 import org.hibernate.boot.models.xml.spi.PersistenceUnitMetadata;
 import org.hibernate.models.spi.ClassDetailsRegistry;
 
-import org.jboss.jandex.IndexView;
-
 /**
  * @author Steve Ebersole
  */
 public class DomainModelSource {
 	private final ClassDetailsRegistry classDetailsRegistry;
-	private final IndexView jandexIndex;
 	private final GlobalRegistrations globalRegistrations;
 	private final RootMappingDefaults effectiveMappingDefaults;
 	private final PersistenceUnitMetadata persistenceUnitMetadata;
@@ -29,13 +26,11 @@ public class DomainModelSource {
 
 	public DomainModelSource(
 			ClassDetailsRegistry classDetailsRegistry,
-			IndexView jandexIndex,
 			List<String> allKnownClassNames,
 			GlobalRegistrations globalRegistrations,
 			RootMappingDefaults effectiveMappingDefaults,
 			PersistenceUnitMetadata persistenceUnitMetadata) {
 		this.classDetailsRegistry = classDetailsRegistry;
-		this.jandexIndex = jandexIndex;
 		this.allKnownClassNames = allKnownClassNames;
 		this.globalRegistrations = globalRegistrations;
 		this.effectiveMappingDefaults = effectiveMappingDefaults;
@@ -44,10 +39,6 @@ public class DomainModelSource {
 
 	public ClassDetailsRegistry getClassDetailsRegistry() {
 		return classDetailsRegistry;
-	}
-
-	public IndexView getJandexIndex() {
-		return jandexIndex;
 	}
 
 	public GlobalRegistrations getGlobalRegistrations() {

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/categorize/internal/CategorizedDomainModelImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/categorize/internal/CategorizedDomainModelImpl.java
@@ -15,8 +15,6 @@ import org.hibernate.models.spi.AnnotationDescriptorRegistry;
 import org.hibernate.models.spi.ClassDetails;
 import org.hibernate.models.spi.ClassDetailsRegistry;
 
-import org.jboss.jandex.IndexView;
-
 /**
  * @author Steve Ebersole
  */
@@ -28,13 +26,11 @@ public class CategorizedDomainModelImpl implements CategorizedDomainModel {
 
 	private final ClassDetailsRegistry classDetailsRegistry;
 	private final AnnotationDescriptorRegistry annotationDescriptorRegistry;
-	private final IndexView jandexIndex;
 	private final PersistenceUnitMetadata persistenceUnitMetadata;
 
 	public CategorizedDomainModelImpl(
 			ClassDetailsRegistry classDetailsRegistry,
 			AnnotationDescriptorRegistry annotationDescriptorRegistry,
-			IndexView jandexIndex,
 			PersistenceUnitMetadata persistenceUnitMetadata,
 			Set<EntityHierarchy> entityHierarchies,
 			Map<String, ClassDetails> mappedSuperclasses,
@@ -47,7 +43,6 @@ public class CategorizedDomainModelImpl implements CategorizedDomainModel {
 		this.mappedSuperclasses = mappedSuperclasses;
 		this.embeddables = embeddables;
 		this.globalRegistrations = globalRegistrations;
-		this.jandexIndex = jandexIndex;
 	}
 
 	@Override
@@ -58,11 +53,6 @@ public class CategorizedDomainModelImpl implements CategorizedDomainModel {
 	@Override
 	public AnnotationDescriptorRegistry getAnnotationDescriptorRegistry() {
 		return annotationDescriptorRegistry;
-	}
-
-	@Override
-	public IndexView getJandexIndex() {
-		return jandexIndex;
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/categorize/spi/CategorizedDomainModel.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/categorize/spi/CategorizedDomainModel.java
@@ -15,8 +15,6 @@ import org.hibernate.models.spi.AnnotationDescriptorRegistry;
 import org.hibernate.models.spi.ClassDetails;
 import org.hibernate.models.spi.ClassDetailsRegistry;
 
-import org.jboss.jandex.IndexView;
-
 /**
  * The application's domain model, understood at a very rudimentary level - we know
  * a class is an entity, a mapped-superclass, ...  And we know about persistent attributes,
@@ -37,8 +35,6 @@ public interface CategorizedDomainModel {
 	 * Registry of all known {@linkplain java.lang.annotation.Annotation} descriptors (classes)
 	 */
 	AnnotationDescriptorRegistry getAnnotationDescriptorRegistry();
-
-	IndexView getJandexIndex();
 
 	PersistenceUnitMetadata getPersistenceUnitMetadata();
 

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/internal/DomainModelCategorizationCollector.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/internal/DomainModelCategorizationCollector.java
@@ -24,8 +24,6 @@ import org.hibernate.models.spi.ClassDetails;
 import org.hibernate.models.spi.ClassDetailsRegistry;
 import org.hibernate.models.spi.SourceModelBuildingContext;
 
-import org.jboss.jandex.IndexView;
-
 import jakarta.persistence.AttributeConverter;
 import jakarta.persistence.Converter;
 import jakarta.persistence.Embeddable;
@@ -40,7 +38,6 @@ import jakarta.persistence.MappedSuperclass;
 
 public class DomainModelCategorizationCollector {
 	private final boolean areIdGeneratorsGlobal;
-	private final IndexView jandexIndex;
 
 	private final GlobalRegistrationsImpl globalRegistrations;
 	private final SourceModelBuildingContext modelsContext;
@@ -52,10 +49,8 @@ public class DomainModelCategorizationCollector {
 	public DomainModelCategorizationCollector(
 			boolean areIdGeneratorsGlobal,
 			GlobalRegistrations globalRegistrations,
-			IndexView jandexIndex,
 			SourceModelBuildingContext modelsContext) {
 		this.areIdGeneratorsGlobal = areIdGeneratorsGlobal;
-		this.jandexIndex = jandexIndex;
 		this.globalRegistrations = (GlobalRegistrationsImpl) globalRegistrations;
 		this.modelsContext = modelsContext;
 	}
@@ -176,7 +171,6 @@ public class DomainModelCategorizationCollector {
 		return new CategorizedDomainModelImpl(
 				classDetailsRegistry,
 				annotationDescriptorRegistry,
-				jandexIndex,
 				persistenceUnitMetadata,
 				entityHierarchies,
 				mappedSuperclasses,

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/internal/ModelsHelper.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/internal/ModelsHelper.java
@@ -8,17 +8,11 @@ import java.util.function.Supplier;
 
 import org.hibernate.annotations.TenantId;
 import org.hibernate.models.internal.MutableClassDetailsRegistry;
-import org.hibernate.models.internal.jdk.JdkBuilders;
-import org.hibernate.models.jandex.internal.JandexClassDetails;
-import org.hibernate.models.jandex.spi.JandexModelBuildingContext;
-import org.hibernate.models.spi.AnnotationDescriptorRegistry;
 import org.hibernate.models.spi.ClassDetails;
 import org.hibernate.models.spi.ClassDetailsRegistry;
 import org.hibernate.models.spi.RegistryPrimer;
 import org.hibernate.models.spi.SourceModelBuildingContext;
 
-import org.jboss.jandex.ClassInfo;
-import org.jboss.jandex.IndexView;
 
 /**
  * @author Steve Ebersole
@@ -29,38 +23,38 @@ public class ModelsHelper {
 
 		buildingContext.getAnnotationDescriptorRegistry().getDescriptor( TenantId.class );
 
-		if ( buildingContext instanceof JandexModelBuildingContext ) {
-			final IndexView jandexIndex = buildingContext.as( JandexModelBuildingContext.class ).getJandexIndex();
-			if ( jandexIndex == null ) {
-				return;
-			}
-
-			final ClassDetailsRegistry classDetailsRegistry = buildingContext.getClassDetailsRegistry();
-			final AnnotationDescriptorRegistry annotationDescriptorRegistry = buildingContext.getAnnotationDescriptorRegistry();
-
-			for ( ClassInfo knownClass : jandexIndex.getKnownClasses() ) {
-				final String className = knownClass.name().toString();
-
-				if ( knownClass.isAnnotation() ) {
-					// it is always safe to load the annotation classes - we will never be enhancing them
-					//noinspection rawtypes
-					final Class annotationClass = buildingContext
-							.getClassLoading()
-							.classForName( className );
-					//noinspection unchecked
-					annotationDescriptorRegistry.resolveDescriptor(
-							annotationClass,
-							(t) -> JdkBuilders.buildAnnotationDescriptor( annotationClass, buildingContext )
-					);
-				}
-
-				resolveClassDetails(
-						className,
-						classDetailsRegistry,
-						() -> new JandexClassDetails( knownClass, buildingContext )
-				);
-			}
-		}
+//		if ( buildingContext instanceof JandexModelBuildingContext ) {
+//			final IndexView jandexIndex = buildingContext.as( JandexModelBuildingContext.class ).getJandexIndex();
+//			if ( jandexIndex == null ) {
+//				return;
+//			}
+//
+//			final ClassDetailsRegistry classDetailsRegistry = buildingContext.getClassDetailsRegistry();
+//			final AnnotationDescriptorRegistry annotationDescriptorRegistry = buildingContext.getAnnotationDescriptorRegistry();
+//
+//			for ( ClassInfo knownClass : jandexIndex.getKnownClasses() ) {
+//				final String className = knownClass.name().toString();
+//
+//				if ( knownClass.isAnnotation() ) {
+//					// it is always safe to load the annotation classes - we will never be enhancing them
+//					//noinspection rawtypes
+//					final Class annotationClass = buildingContext
+//							.getClassLoading()
+//							.classForName( className );
+//					//noinspection unchecked
+//					annotationDescriptorRegistry.resolveDescriptor(
+//							annotationClass,
+//							(t) -> JdkBuilders.buildAnnotationDescriptor( annotationClass, buildingContext )
+//					);
+//				}
+//
+//				resolveClassDetails(
+//						className,
+//						classDetailsRegistry,
+//						() -> new JandexClassDetails( knownClass, buildingContext )
+//				);
+//			}
+//		}
 	}
 
 	public static ClassDetails resolveClassDetails(

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/internal/OrmAnnotationHelper.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/internal/OrmAnnotationHelper.java
@@ -20,13 +20,10 @@ import org.hibernate.boot.models.HibernateAnnotations;
 import org.hibernate.boot.models.JpaAnnotations;
 import org.hibernate.boot.models.XmlAnnotations;
 import org.hibernate.models.AnnotationAccessException;
-import org.hibernate.models.jandex.spi.JandexModelBuildingContext;
-import org.hibernate.models.jandex.spi.JandexValueExtractor;
 import org.hibernate.models.spi.AnnotationDescriptor;
 import org.hibernate.models.spi.AttributeDescriptor;
 import org.hibernate.models.spi.SourceModelBuildingContext;
 
-import org.jboss.jandex.AnnotationInstance;
 
 /**
  * @author Steve Ebersole
@@ -70,22 +67,6 @@ public class OrmAnnotationHelper {
 	public static <V, A extends Annotation> V extractJdkValue(A jdkAnnotation, AnnotationDescriptor<A> annotationDescriptor, String attributeName, SourceModelBuildingContext modelContext) {
 		final AttributeDescriptor<V> attributeDescriptor = annotationDescriptor.getAttribute( attributeName );
 		return extractJdkValue( jdkAnnotation, attributeDescriptor, modelContext );
-	}
-
-	public static <V> V extractJandexValue(AnnotationInstance jandexAnnotation, AttributeDescriptor<V> attributeDescriptor, SourceModelBuildingContext modelContext) {
-		final JandexValueExtractor<V> extractor = modelContext.as( JandexModelBuildingContext.class )
-				.getJandexValueExtractor( attributeDescriptor.getTypeDescriptor() );
-		return extractor.extractValue( jandexAnnotation, attributeDescriptor, modelContext );
-//		final AnnotationValue value = jandexAnnotation.value( attributeDescriptor.getName() );
-//		return attributeDescriptor
-//				.getTypeDescriptor()
-//				.createJandexValueConverter( modelContext )
-//				.convert( value, modelContext );
-	}
-
-	public static <V, A extends Annotation> V extractJandexValue(AnnotationInstance jandexAnnotation, AnnotationDescriptor<A> annotationDescriptor, String attributeName, SourceModelBuildingContext modelContext) {
-		final AttributeDescriptor<V> attributeDescriptor = annotationDescriptor.getAttribute( attributeName );
-		return extractJandexValue( jandexAnnotation, attributeDescriptor, modelContext );
 	}
 
 	public static List<Annotation> extractAnnotationTypeAnnotations(Class<? extends Annotation> annotationType) {

--- a/hibernate-core/src/main/java/org/hibernate/boot/spi/AbstractDelegatingMetadataBuilderImplementor.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/spi/AbstractDelegatingMetadataBuilderImplementor.java
@@ -23,8 +23,6 @@ import org.hibernate.query.sqm.function.SqmFunctionDescriptor;
 import org.hibernate.type.BasicType;
 import org.hibernate.usertype.UserType;
 
-import org.jboss.jandex.IndexView;
-
 import jakarta.persistence.AttributeConverter;
 import jakarta.persistence.SharedCacheMode;
 
@@ -98,7 +96,7 @@ public abstract class AbstractDelegatingMetadataBuilderImplementor<T extends Met
 	}
 
 	@Override
-	public MetadataBuilder applyIndexView(IndexView jandexView) {
+	public MetadataBuilder applyIndexView(Object jandexView) {
 		delegate.applyIndexView( jandexView );
 		return getThis();
 	}

--- a/hibernate-core/src/main/java/org/hibernate/boot/spi/BootstrapContext.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/spi/BootstrapContext.java
@@ -25,8 +25,6 @@ import org.hibernate.resource.beans.spi.BeanInstanceProducer;
 import org.hibernate.type.BasicType;
 import org.hibernate.type.spi.TypeConfiguration;
 
-import org.jboss.jandex.IndexView;
-
 /**
  * Defines a context for things available during the process of bootstrapping
  * a {@link org.hibernate.SessionFactory} which are expected to be cleaned up
@@ -151,14 +149,14 @@ public interface BootstrapContext {
 
 	/**
 	 * Access to the Jandex index passed by call to
-	 * {@link org.hibernate.boot.MetadataBuilder#applyIndexView(IndexView)}, if any.
+	 * {@link org.hibernate.boot.MetadataBuilder#applyIndexView(Object)}, if any.
 	 *
 	 * @apiNote Jandex is currently not used, see
 	 *          <a href="https://github.com/hibernate/hibernate-orm/wiki/Roadmap7.0">the roadmap</a>
 	 *
 	 * @return The Jandex index
 	 */
-	IndexView getJandexView();
+	Object getJandexView();
 
 	/**
 	 * Access to any SQL functions explicitly registered with the

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/xml/ejb3/Ejb3XmlTestCase.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/xml/ejb3/Ejb3XmlTestCase.java
@@ -104,7 +104,6 @@ public abstract class Ejb3XmlTestCase extends BaseUnitTestCase {
 		final DomainModelCategorizationCollector modelCategorizationCollector = new DomainModelCategorizationCollector(
 				true,
 				globalRegistrations,
-				null,
 				modelBuildingContext
 		);
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/boot/models/SourceModelTestHelper.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/boot/models/SourceModelTestHelper.java
@@ -297,7 +297,6 @@ public class SourceModelTestHelper {
 		final DomainModelCategorizationCollector modelCategorizationCollector = new DomainModelCategorizationCollector(
 				true,
 				globalRegistrations,
-				jandexIndex,
 				sourceModelBuildingContext
 		);
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/boot/models/xml/XmlProcessingSmokeTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/boot/models/xml/XmlProcessingSmokeTests.java
@@ -132,7 +132,6 @@ public class XmlProcessingSmokeTests {
 		final DomainModelCategorizationCollector collector = new DomainModelCategorizationCollector(
 				false,
 				new GlobalRegistrationsImpl( buildingContext, new BootstrapContextImpl() ),
-				null,
 				buildingContext
 		);
 		collectedXmlResources.getDocuments().forEach( jaxbEntityMappings -> {

--- a/hibernate-testing/src/main/java/org/hibernate/testing/boot/BootstrapContextImpl.java
+++ b/hibernate-testing/src/main/java/org/hibernate/testing/boot/BootstrapContextImpl.java
@@ -29,7 +29,6 @@ import org.hibernate.resource.beans.spi.BeanInstanceProducer;
 import org.hibernate.type.BasicType;
 import org.hibernate.type.spi.TypeConfiguration;
 
-import org.jboss.jandex.IndexView;
 
 /**
  * @author Andrea Boriero
@@ -121,7 +120,7 @@ public class BootstrapContextImpl implements BootstrapContext {
 	}
 
 	@Override
-	public IndexView getJandexView() {
+	public Object getJandexView() {
 		return delegate.getJandexView();
 	}
 


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-18522

the only remaining Jandex dependencies are in `org.hibernate.boot.archive.scan.spi.ClassFileArchiveEntryHandler`

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
