### PR TITLE
HHH-18610 add test for issue

### DIFF
--- a/hibernate-core/src/test/java/org/hibernate/orm/test/query/sql/ClassIdNativeQueryTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/query/sql/ClassIdNativeQueryTest.java
@@ -79,6 +79,22 @@ public class ClassIdNativeQueryTest {
 		);
 	}
 
+	@Test
+	@JiraKey( "HHH-18610" )
+	public void testNativeQueryWithResultClassAndPlaceholders(SessionFactoryScope scope) {
+		scope.inTransaction(
+				session -> {
+					NativeQuery<Book> query = session
+							.createNativeQuery(
+									"select {book.*} from BOOK_T book", Book.class );
+					query.addEntity( "book", Book.class );
+					List<Book> results = query.list();
+
+					assertEquals( 1, results.size() );
+				}
+		);
+	}
+
 	@Entity(name = "Book")
 	@IdClass(BookPK.class)
 	@Table(name = "BOOK_T")


### PR DESCRIPTION
```
Column "fileid1_0_0_" not found [42122-224]
org.h2.jdbc.JdbcSQLSyntaxErrorException: Column "fileid1_0_0_" not found [42122-224]
	at org.h2.message.DbException.getJdbcSQLException(DbException.java:514)
	at org.h2.message.DbException.getJdbcSQLException(DbException.java:489)
	at org.h2.message.DbException.get(DbException.java:223)
	at org.h2.message.DbException.get(DbException.java:199)
	at org.h2.jdbc.JdbcResultSet.getColumnIndex(JdbcResultSet.java:3492)
	at org.h2.jdbc.JdbcResultSet.findColumn(JdbcResultSet.java:178)
	at org.hibernate.sql.results.jdbc.internal.AbstractResultSetAccess.resolveColumnPosition(AbstractResultSetAccess.java:63)
	at org.hibernate.query.results.ResultsHelper.lambda$resolveSqlExpression$0(ResultsHelper.java:61)
	at org.hibernate.query.results.DomainResultCreationStateImpl.resolveSqlExpression(DomainResultCreationStateImpl.java:280)
	at org.hibernate.query.results.ResultsHelper.resolveSqlExpression(ResultsHelper.java:55)
	at org.hibernate.query.results.dynamic.DynamicResultBuilderEntityStandard.resolveSqlSelection(DynamicResultBuilderEntityStandard.java:328)
	at org.hibernate.query.results.dynamic.DynamicResultBuilderEntityStandard.lambda$buildResultOrFetch$4(DynamicResultBuilderEntityStandard.java:260)
	at org.hibernate.metamodel.mapping.internal.SelectableMappingsImpl.forEachSelectable(SelectableMappingsImpl.java:192)
	at org.hibernate.metamodel.mapping.internal.AbstractEmbeddableMapping.forEachSelectable(AbstractEmbeddableMapping.java:593)
	at org.hibernate.metamodel.mapping.EmbeddableValuedModelPart.forEachSelectable(EmbeddableValuedModelPart.java:128)
	at org.hibernate.metamodel.mapping.ModelPart.forEachSelectable(ModelPart.java:130)
	at org.hibernate.metamodel.mapping.ValuedModelPart.forEachSelectable(ValuedModelPart.java:38)
	at org.hibernate.query.results.dynamic.DynamicResultBuilderEntityStandard.buildResultOrFetch(DynamicResultBuilderEntityStandard.java:260)
	at org.hibernate.query.results.dynamic.DynamicResultBuilderEntityStandard.buildResult(DynamicResultBuilderEntityStandard.java:144)
	at org.hibernate.query.results.dynamic.DynamicResultBuilderEntityStandard.buildResult(DynamicResultBuilderEntityStandard.java:49)
	at org.hibernate.query.results.ResultSetMappingImpl.resolve(ResultSetMappingImpl.java:226)
	at org.hibernate.sql.exec.internal.JdbcSelectExecutorStandardImpl.resolveJdbcValuesSource(JdbcSelectExecutorStandardImpl.java:338)
	at org.hibernate.sql.exec.internal.JdbcSelectExecutorStandardImpl.doExecuteQuery(JdbcSelectExecutorStandardImpl.java:135)
	at org.hibernate.sql.exec.internal.JdbcSelectExecutorStandardImpl.executeQuery(JdbcSelectExecutorStandardImpl.java:100)
	at org.hibernate.sql.exec.spi.JdbcSelectExecutor.executeQuery(JdbcSelectExecutor.java:64)
	at org.hibernate.sql.exec.spi.JdbcSelectExecutor.list(JdbcSelectExecutor.java:138)
	at org.hibernate.sql.exec.spi.JdbcSelectExecutor.list(JdbcSelectExecutor.java:115)
	at org.hibernate.sql.exec.spi.JdbcSelectExecutor.list(JdbcSelectExecutor.java:105)
	at org.hibernate.query.sql.internal.NativeSelectQueryPlanImpl.performList(NativeSelectQueryPlanImpl.java:133)
	at org.hibernate.query.sql.internal.NativeQueryImpl.doList(NativeQueryImpl.java:627)
	at org.hibernate.query.spi.AbstractSelectionQuery.list(AbstractSelectionQuery.java:135)
```

<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

[Please describe here what your change is about]

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-18610
<!-- Hibernate GitHub Bot issue links end -->