### PR TITLE
HHH-18629 Fix inconsistent column alias generated while result class is used for placeholder

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/internal/AbstractSharedSessionContract.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/AbstractSharedSessionContract.java
@@ -969,7 +969,8 @@ public abstract class AbstractSharedSessionContract implements SharedSessionCont
 			query.setTupleTransformer( NativeQueryListTransformer.INSTANCE );
 		}
 		else if ( getFactory().getMappingMetamodel().isEntityClass( resultClass ) ) {
-			query.addEntity( resultClass, LockMode.READ );
+			// use empty string as tableAlias to identify it as implicit
+			query.addEntity( "", resultClass, LockMode.READ );
 		}
 		else if ( resultClass != Object.class && resultClass != Object[].class ) {
 			if ( isClass( resultClass ) && !hasJavaTypeDescriptor( resultClass ) ) {

--- a/hibernate-core/src/main/java/org/hibernate/query/results/ResultSetMapping.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/results/ResultSetMapping.java
@@ -78,6 +78,11 @@ public interface ResultSetMapping extends JdbcValuesMappingProducer {
 	void addResultBuilder(ResultBuilder resultBuilder);
 
 	/**
+	 * Remove a builder
+	 */
+	void removeResultBuilder(ResultBuilder resultBuilder);
+
+	/**
 	 * Add a legacy fetch builder
 	 */
 	void addLegacyFetchBuilder(DynamicFetchBuilderLegacy fetchBuilder);

--- a/hibernate-core/src/main/java/org/hibernate/query/results/ResultSetMappingImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/results/ResultSetMappingImpl.java
@@ -138,6 +138,11 @@ public class ResultSetMappingImpl implements ResultSetMapping {
 	}
 
 	@Override
+	public void removeResultBuilder(ResultBuilder resultBuilder) {
+		resultBuilders.remove( resultBuilder );
+	}
+
+	@Override
 	public void addLegacyFetchBuilder(DynamicFetchBuilderLegacy fetchBuilder) {
 		final Map<String, DynamicFetchBuilderLegacy> existingFetchBuildersByOwner;
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/query/sql/ClassIdNativeQueryTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/query/sql/ClassIdNativeQueryTest.java
@@ -79,6 +79,22 @@ public class ClassIdNativeQueryTest {
 		);
 	}
 
+	@Test
+	@JiraKey( "HHH-18629" )
+	public void testNativeQueryWithResultClassAndPlaceholders(SessionFactoryScope scope) {
+		scope.inTransaction(
+				session -> {
+					NativeQuery<Book> query = session
+							.createNativeQuery(
+									"select {book.*} from BOOK_T book", Book.class );
+					query.addEntity( "book", Book.class );
+					List<Book> results = query.list();
+
+					assertEquals( 1, results.size() );
+				}
+		);
+	}
+
 	@Entity(name = "Book")
 	@IdClass(BookPK.class)
 	@Table(name = "BOOK_T")


### PR DESCRIPTION
wrong fileid’s alias fileid1_0_0_ is used instead of fileid1_0_1_ while transforming ResultSet to Book.

```
Column "fileid1_0_0_" not found [42122-224]
org.h2.jdbc.JdbcSQLSyntaxErrorException: Column "fileid1_0_0_" not found [42122-224]
	at org.h2.message.DbException.getJdbcSQLException(DbException.java:514)
	at org.h2.message.DbException.getJdbcSQLException(DbException.java:489)
	at org.h2.message.DbException.get(DbException.java:223)
	at org.h2.message.DbException.get(DbException.java:199)
	at org.h2.jdbc.JdbcResultSet.getColumnIndex(JdbcResultSet.java:3492)
	at org.h2.jdbc.JdbcResultSet.findColumn(JdbcResultSet.java:178)
	at org.hibernate.sql.results.jdbc.internal.AbstractResultSetAccess.resolveColumnPosition(AbstractResultSetAccess.java:63)
```

<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

[Please describe here what your change is about]

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-18629
<!-- Hibernate GitHub Bot issue links end -->