### PR TITLE
HHH-18471 Since 6.2.2 Dialect SybaseAnywhereDialect does not render table names in the selection query

### DIFF
--- a/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/SybaseAnywhereSqlAstTranslator.java
+++ b/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/SybaseAnywhereSqlAstTranslator.java
@@ -125,6 +125,7 @@ public class SybaseAnywhereSqlAstTranslator<T extends JdbcOperation> extends Abs
 			// Just always return true because SQL Server doesn't support the FOR UPDATE clause
 			return true;
 		}
+		super.renderNamedTableReference( tableReference, lockMode );
 		return false;
 	}
 


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-18471

https://github.com/hibernate/hibernate-orm/pull/8969 6.6 backport

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
