### PR TITLE
HHH-18337 - SequenceStyleGenerator not respecting physical naming strategy

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/id/factory/internal/StandardIdentifierGeneratorFactory.java
+++ b/hibernate-core/src/main/java/org/hibernate/id/factory/internal/StandardIdentifierGeneratorFactory.java
@@ -225,7 +225,9 @@ public class StandardIdentifierGeneratorFactory
 
 			if ( identifierGenerator instanceof Configurable ) {
 				final Configurable configurable = (Configurable) identifierGenerator;
-				configurable.create( creationContext );
+				if ( creationContext != null ) {
+					configurable.create( creationContext );
+				}
 				configurable.configure( type, parameters, serviceRegistry );
 			}
 			return identifierGenerator;

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/idgen/userdefined/NativeGenerator.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/idgen/userdefined/NativeGenerator.java
@@ -8,12 +8,15 @@ import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.generator.BeforeExecutionGenerator;
 import org.hibernate.generator.EventType;
 import org.hibernate.generator.Generator;
+import org.hibernate.generator.GeneratorCreationContext;
 import org.hibernate.generator.OnExecutionGenerator;
 import org.hibernate.id.Configurable;
 import org.hibernate.id.PostInsertIdentityPersister;
 import org.hibernate.id.factory.IdentifierGeneratorFactory;
 import org.hibernate.id.factory.spi.CustomIdGeneratorCreationContext;
 import org.hibernate.id.insert.InsertGeneratedIdentifierDelegate;
+import org.hibernate.mapping.PersistentClass;
+import org.hibernate.mapping.Property;
 import org.hibernate.service.ServiceRegistry;
 import org.hibernate.type.Type;
 
@@ -26,10 +29,12 @@ public class NativeGenerator
 
     private final IdentifierGeneratorFactory factory;
     private final String strategy;
+    private final CustomIdGeneratorCreationContext creationContext;
 
     private Generator generator;
 
     public NativeGenerator(NativeId nativeId, Member member, CustomIdGeneratorCreationContext creationContext) {
+        this.creationContext = creationContext;
         factory = creationContext.getIdentifierGeneratorFactory();
 		strategy = creationContext.getDatabase().getDialect().getNativeIdentifierGeneratorStrategy();
         if ( "identity".equals(strategy) ) {
@@ -49,7 +54,12 @@ public class NativeGenerator
 
     @Override
     public void configure(Type type, Properties parameters, ServiceRegistry serviceRegistry) {
-        generator = factory.createIdentifierGenerator(strategy, type, parameters);
+        generator = factory.createIdentifierGenerator(
+                strategy,
+                type,
+                creationContext,
+                parameters
+        );
         //TODO: should use this instead of the deprecated method, but see HHH-18135
 //        GenerationType generationType;
 //        switch (strategy) {


### PR DESCRIPTION
Also change a failing test so it doesn't pass `null` as creation context

<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->


<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-18337
<!-- Hibernate GitHub Bot issue links end -->