### PR TITLE
HHH-18635 Avoid using `bigdatetime` column type on Sybase jconn when not necessary

### DIFF
--- a/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/SybaseASELegacyDialect.java
+++ b/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/SybaseASELegacyDialect.java
@@ -123,13 +123,8 @@ public class SybaseASELegacyDialect extends SybaseLegacyDialect {
 		// But with jTDS we can't use them as the driver can't handle the types
 		if ( getVersion().isSameOrAfter( 15, 5 ) && getDriverKind() != SybaseDriverKind.JTDS ) {
 			ddlTypeRegistry.addDescriptor(
-					CapacityDependentDdlType.builder( DATE, "bigdatetime", "bigdatetime", this )
-							.withTypeCapacity( 3, "datetime" )
-							.build()
-			);
-			ddlTypeRegistry.addDescriptor(
-					CapacityDependentDdlType.builder( TIME, "bigdatetime", "bigdatetime", this )
-							.withTypeCapacity( 3, "datetime" )
+					CapacityDependentDdlType.builder( TIME, "bigtime", "bigtime", this )
+							.withTypeCapacity( 3, "time" )
 							.build()
 			);
 			ddlTypeRegistry.addDescriptor(

--- a/hibernate-core/src/main/java/org/hibernate/dialect/SybaseASEDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/SybaseASEDialect.java
@@ -140,13 +140,8 @@ public class SybaseASEDialect extends SybaseDialect {
 		// But with jTDS we can't use them as the driver can't handle the types
 		if ( getDriverKind() != SybaseDriverKind.JTDS ) {
 			ddlTypeRegistry.addDescriptor(
-					CapacityDependentDdlType.builder( DATE, "bigdatetime", "bigdatetime", this )
-							.withTypeCapacity( 3, "datetime" )
-							.build()
-			);
-			ddlTypeRegistry.addDescriptor(
-					CapacityDependentDdlType.builder( TIME, "bigdatetime", "bigdatetime", this )
-							.withTypeCapacity( 3, "datetime" )
+					CapacityDependentDdlType.builder( TIME, "bigtime", "bigtime", this )
+							.withTypeCapacity( 3, "time" )
 							.build()
 			);
 			ddlTypeRegistry.addDescriptor(

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/query/NativeQueryWithDatetimesTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/query/NativeQueryWithDatetimesTest.java
@@ -10,6 +10,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import org.hibernate.dialect.OracleDialect;
 import org.hibernate.dialect.PostgresPlusDialect;
+
 import org.hibernate.testing.orm.junit.EntityManagerFactoryScope;
 import org.hibernate.testing.orm.junit.Jpa;
 import org.hibernate.testing.orm.junit.SkipForDialect;


### PR DESCRIPTION
<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

[Please describe here what your change is about]

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-18635
<!-- Hibernate GitHub Bot issue links end -->