### PR TITLE
HHH-18409 byte[] instance variables annotated with @NaturalId cannot be found with a natural ID query

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/CompoundNaturalIdMapping.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/CompoundNaturalIdMapping.java
@@ -5,7 +5,6 @@
 package org.hibernate.metamodel.mapping.internal;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.function.BiConsumer;
@@ -246,7 +245,15 @@ public class CompoundNaturalIdMapping extends AbstractNaturalIdMapping implement
 
 	@Override
 	public boolean areEqual(Object one, Object other, SharedSessionContractImplementor session) {
-		return Arrays.equals( (Object[]) one, (Object[]) other );
+		final Object[] one1 = (Object[]) one;
+		final Object[] other1 = (Object[]) other;
+		final List<SingularAttributeMapping> naturalIdAttributes = getNaturalIdAttributes();
+		for ( int i = 0; i < naturalIdAttributes.size(); i++ ) {
+			if ( !naturalIdAttributes.get( i ).areEqual( one1[i], other1[i], session ) ) {
+				return false;
+			}
+		}
+		return true;
 	}
 
 	@Override

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/naturalid/ByteArrayNaturalIdTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/naturalid/ByteArrayNaturalIdTest.java
@@ -1,0 +1,85 @@
+/*
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.annotations.naturalid;
+
+import org.hibernate.annotations.NaturalId;
+
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.JiraKey;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+
+@DomainModel(
+		annotatedClasses = {
+				ByteArrayNaturalIdTest.TestEntity.class,
+		}
+)
+@SessionFactory
+@JiraKey("HHH-18409")
+public class ByteArrayNaturalIdTest {
+
+	private static final String NATURAL_ID_1 = "N1";
+
+	@AfterEach
+	public void tearDown(SessionFactoryScope scope) {
+		scope.inTransaction(
+				session ->
+						session.createMutationQuery( "delete TestEntity" ).executeUpdate()
+		);
+	}
+
+	@Test
+	public void testSelectByNaturalId(SessionFactoryScope scope) {
+		scope.inTransaction(
+				session -> {
+					TestEntity entity = new TestEntity( 1L, new byte[] { 1, 2 }, NATURAL_ID_1 );
+					session.persist( entity );
+					TestEntity testEntity = session.byNaturalId( TestEntity.class )
+							.using( "naturalId2", NATURAL_ID_1 )
+							.using( "naturalId1", new byte[] { 1, 2 } )
+							.load();
+
+					assertThat( testEntity ).as( "Loading the entity by its natural id failed" ).isNotNull();
+					TestEntity testEntity2 = session.byNaturalId( TestEntity.class )
+							.using( "naturalId2", NATURAL_ID_1 )
+							.using( "naturalId1", new byte[] { 1, 3 } )
+							.load();
+					assertThat( testEntity2 ).as( "Loading the entity using wrong natural id failed" ).isNull();
+
+				}
+		);
+	}
+
+	@Entity(name = "TestEntity")
+	public static class TestEntity {
+		@Id
+		private Long id;
+
+		@NaturalId
+		private byte[] naturalId1;
+
+		@NaturalId
+		private String naturalId2;
+
+		public TestEntity() {
+		}
+
+		public TestEntity(Long id, byte[] naturalId1, String naturalId2) {
+			this.id = id;
+			this.naturalId1 = naturalId1;
+			this.naturalId2 = naturalId2;
+		}
+
+
+	}
+}


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-18409 

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
