### PR TITLE
HHH-18664 Allow primitive-type parameters in constructors used to build query result types

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/internal/ConcreteSqmSelectQueryPlan.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/internal/ConcreteSqmSelectQueryPlan.java
@@ -287,7 +287,11 @@ public class ConcreteSqmSelectQueryPlan<R> implements SelectQueryPlan<R> {
 					}
 					else if ( isClass( resultType ) ) {
 						try {
-							return new RowTransformerConstructorImpl<>( resultType, tupleMetadata );
+							return new RowTransformerConstructorImpl<>(
+									resultType,
+									tupleMetadata,
+									sqm.nodeBuilder().getTypeConfiguration()
+							);
 						}
 						catch (InstantiationException ie) {
 							return new RowTransformerCheckingImpl<>( resultType );
@@ -310,7 +314,11 @@ public class ConcreteSqmSelectQueryPlan<R> implements SelectQueryPlan<R> {
 						return (RowTransformer<T>) new RowTransformerMapImpl( tupleMetadata );
 					}
 					else if ( isClass( resultType ) ) {
-						return new RowTransformerConstructorImpl<>( resultType, tupleMetadata );
+						return new RowTransformerConstructorImpl<>(
+								resultType,
+								tupleMetadata,
+								sqm.nodeBuilder().getTypeConfiguration()
+						);
 					}
 					else {
 						throw new QueryTypeMismatchException( "Result type '" + resultType.getSimpleName()

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/instantiation/internal/InstantiationHelper.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/instantiation/internal/InstantiationHelper.java
@@ -55,12 +55,20 @@ public class InstantiationHelper {
 	}
 
 	public static boolean isConstructorCompatible(Class<?> javaClass, List<Class<?>> argTypes, TypeConfiguration typeConfiguration) {
-		for ( Constructor<?> constructor : javaClass.getDeclaredConstructors() ) {
-			if ( isConstructorCompatible( constructor, argTypes, typeConfiguration) ) {
-				return true;
+		return findMatchingConstructor( javaClass, argTypes, typeConfiguration ) != null;
+	}
+
+	public static <T> Constructor<T> findMatchingConstructor(
+			Class<T> type,
+			List<Class<?>> argumentTypes,
+			TypeConfiguration typeConfiguration) {
+		for ( final Constructor<?> constructor : type.getDeclaredConstructors() ) {
+			if ( isConstructorCompatible( constructor, argumentTypes, typeConfiguration ) ) {
+				//noinspection unchecked
+				return (Constructor<T>) constructor;
 			}
 		}
-		return false;
+		return null;
 	}
 
 	public static boolean isConstructorCompatible(


### PR DESCRIPTION
<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

https://hibernate.atlassian.net/browse/HHH-18664

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
