### PR TITLE
HHH-18675. Ignore generic, synthetic property in JPA-model

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/mapping/Property.java
+++ b/hibernate-core/src/main/java/org/hibernate/mapping/Property.java
@@ -477,7 +477,7 @@ public class Property implements Serializable, MetaAttributable {
 	}
 
 	public Property copy() {
-		final Property property = new Property();
+		final Property property = this instanceof SyntheticProperty ? new SyntheticProperty() : new Property();
 		property.setName( getName() );
 		property.setValue( getValue() );
 		property.setCascade( getCascade() );

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/internal/MetadataContext.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/internal/MetadataContext.java
@@ -55,8 +55,8 @@ import java.util.Set;
 import java.util.function.BiFunction;
 
 import static java.util.Collections.unmodifiableMap;
+import static java.util.Objects.nonNull;
 import static org.hibernate.metamodel.internal.InjectionHelper.injectField;
-
 
 /**
  * Defines a context for storing information during the building of the {@link MappingMetamodelImpl}.
@@ -274,9 +274,10 @@ public class MetadataContext {
 			attribute = factoryFunction.apply( entityType, genericProperty );
 			if ( !property.isGeneric() ) {
 				final PersistentAttribute<X, ?> concreteAttribute = factoryFunction.apply( entityType, property );
-				@SuppressWarnings("unchecked")
-				final AttributeContainer<X> attributeContainer = (AttributeContainer<X>) entityType;
-				attributeContainer.getInFlightAccess().addConcreteGenericAttribute( concreteAttribute );
+				if (nonNull(concreteAttribute)) {
+					@SuppressWarnings("unchecked") final AttributeContainer<X> attributeContainer = (AttributeContainer<X>) entityType;
+					attributeContainer.getInFlightAccess().addConcreteGenericAttribute(concreteAttribute);
+				}
 			}
 		}
 		else {

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/internal/MetadataContext.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/internal/MetadataContext.java
@@ -55,7 +55,6 @@ import java.util.Set;
 import java.util.function.BiFunction;
 
 import static java.util.Collections.unmodifiableMap;
-import static java.util.Objects.nonNull;
 import static org.hibernate.metamodel.internal.InjectionHelper.injectField;
 
 /**
@@ -274,9 +273,9 @@ public class MetadataContext {
 			attribute = factoryFunction.apply( entityType, genericProperty );
 			if ( !property.isGeneric() ) {
 				final PersistentAttribute<X, ?> concreteAttribute = factoryFunction.apply( entityType, property );
-				if (nonNull(concreteAttribute)) {
+				if ( concreteAttribute != null ) {
 					@SuppressWarnings("unchecked") final AttributeContainer<X> attributeContainer = (AttributeContainer<X>) entityType;
-					attributeContainer.getInFlightAccess().addConcreteGenericAttribute(concreteAttribute);
+					attributeContainer.getInFlightAccess().addConcreteGenericAttribute( concreteAttribute );
 				}
 			}
 		}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/manytomany/generic/ManyToManyGenericTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/manytomany/generic/ManyToManyGenericTest.java
@@ -1,0 +1,96 @@
+/*
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.manytomany.generic;
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.JoinTable;
+import jakarta.persistence.ManyToMany;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import org.hibernate.testing.orm.junit.EntityManagerFactoryScope;
+import org.hibernate.testing.orm.junit.Jpa;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+
+@Jpa(
+		annotatedClasses = {
+				ManyToManyGenericTest.NodeTree.class,
+				ManyToManyGenericTest.GenericNode.class
+		}
+)
+public class ManyToManyGenericTest {
+
+	@Test
+	void testSelfReferencingGeneric(final EntityManagerFactoryScope scope) {
+		final UUID treeId = scope.fromTransaction(em -> {
+			final NodeTree tree = new NodeTree();
+			final GenericNode<?> root = new GenericNode<>();
+			root.tree = tree;
+			final GenericNode<?> branch = new GenericNode<>();
+			branch.tree = tree;
+			tree.nodes.add(root);
+			tree.nodes.add(branch);
+			root.children.add(branch);
+			em.persist(tree);
+			return tree.id;
+		});
+
+		final NodeTree nodeTree = scope.fromEntityManager(em -> em.find(NodeTree.class, treeId));
+
+		assertThat(nodeTree, is(notNullValue()));
+		assertThat(nodeTree.id, is(treeId));
+		assertThat(nodeTree.nodes, iterableWithSize(2));
+		assertThat(nodeTree.nodes, containsInAnyOrder(List.of(
+				hasProperty("children", iterableWithSize(1)),
+				hasProperty("children", emptyIterable())
+		)));
+	}
+
+	@Entity(name = "tree")
+	public static class NodeTree {
+		@Id
+		@GeneratedValue(strategy = GenerationType.UUID)
+		public UUID id;
+
+		@OneToMany(mappedBy = "tree", fetch = FetchType.EAGER, cascade = CascadeType.ALL)
+		public Set<GenericNode<?>> nodes = new HashSet<>();
+	}
+
+	@Entity(name = "node")
+	public static class GenericNode<T> {
+
+		@Id
+		@GeneratedValue(strategy = GenerationType.UUID)
+		public UUID id;
+
+		@ManyToOne(optional = false)
+		@JoinColumn(name = "TREE_ID")
+		public NodeTree tree;
+
+		@ManyToMany(fetch = FetchType.EAGER, cascade = {CascadeType.PERSIST, CascadeType.DETACH})
+		@JoinTable(name = "NODE_CHILDREN",
+				joinColumns = {@JoinColumn(name = "TREE_ID", referencedColumnName = "TREE_ID"), @JoinColumn(name = "NODE_ID", referencedColumnName = "ID")},
+				inverseJoinColumns = {@JoinColumn(name = "CHILD_ID", referencedColumnName = "ID")}
+		)
+		private final Set<GenericNode<?>> children = new HashSet<>();
+
+		public Set<GenericNode<?>> getChildren() {
+			return children;
+		}
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/manytomany/generic/ManyToManyNonGenericTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/manytomany/generic/ManyToManyNonGenericTest.java
@@ -1,0 +1,106 @@
+/*
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.manytomany.generic;
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.JoinTable;
+import jakarta.persistence.ManyToMany;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import org.hibernate.testing.orm.junit.EntityManagerFactoryScope;
+import org.hibernate.testing.orm.junit.Jpa;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.emptyIterable;
+import static org.hamcrest.Matchers.hasProperty;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.iterableWithSize;
+import static org.hamcrest.Matchers.notNullValue;
+
+@Jpa(
+		annotatedClasses = {
+				ManyToManyNonGenericTest.NodeTree.class,
+				ManyToManyNonGenericTest.Node.class
+		}
+)
+public class ManyToManyNonGenericTest {
+
+	@Test
+	void testSelfReferencingGeneric(final EntityManagerFactoryScope scope) {
+		final UUID treeId = scope.fromTransaction(em -> {
+			final NodeTree tree = new NodeTree();
+			final Node root = new Node();
+			root.tree = tree;
+			final Node branch = new Node();
+			branch.tree = tree;
+			tree.nodes.add(root);
+			tree.nodes.add(branch);
+			root.children.add(branch);
+			em.persist(tree);
+			return tree.id;
+		});
+
+		final NodeTree nodeTree = scope.fromEntityManager(em -> em.find(NodeTree.class, treeId));
+
+		assertThat(nodeTree, is(notNullValue()));
+		assertThat(nodeTree.id, is(treeId));
+		assertThat(nodeTree.nodes, iterableWithSize(2));
+		assertThat(nodeTree.nodes, containsInAnyOrder(List.of(
+				hasProperty("children", iterableWithSize(1)),
+				hasProperty("children", emptyIterable())
+		)));
+	}
+
+	@Entity(name = "tree")
+	public static class NodeTree {
+		@Id
+		@GeneratedValue(strategy = GenerationType.UUID)
+		public UUID id;
+
+		@OneToMany(mappedBy = "tree", fetch = FetchType.EAGER, cascade = CascadeType.ALL)
+		public Set<Node> nodes = new HashSet<>();
+	}
+
+	@Entity(name = "node")
+	public static class Node {
+
+		@Id
+		@GeneratedValue(strategy = GenerationType.UUID)
+		public UUID id;
+
+		@ManyToOne(optional = false)
+		@JoinColumn(name = "TREE_ID")
+		public NodeTree tree;
+
+		@ManyToMany(fetch = FetchType.EAGER, cascade = {CascadeType.PERSIST, CascadeType.DETACH})
+		@JoinTable(name = "NODE_CHILDREN",
+				joinColumns = {@JoinColumn(name = "TREE_ID", referencedColumnName = "TREE_ID"), @JoinColumn(name = "NODE_ID", referencedColumnName = "ID")},
+				inverseJoinColumns = {@JoinColumn(name = "CHILD_ID", referencedColumnName = "ID")}
+		)
+		private final Set<Node> children = new HashSet<>();
+
+		public Set<Node> getChildren() {
+			return children;
+		}
+
+		@Override
+		public String toString() {
+			return "node [%s] parent of %s".formatted(id, children.stream().map(n -> n.id).toList());
+		}
+	}
+}


### PR DESCRIPTION
<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

Hibernate should not map synthetic properties. However by copying the synthetic property the synthetic aspect is not copied. To circumvent this create a SyntheticProperty on copying. And ignore the property in the jpa-model.

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-18675
<!-- Hibernate GitHub Bot issue links end -->