### PR TITLE
HHH-18684 : If no @AnyDiscriminatorValue is returned, the entity name…

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/persister/collection/AbstractCollectionPersister.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/collection/AbstractCollectionPersister.java
@@ -309,7 +309,7 @@ public abstract class AbstractCollectionPersister
 				final BasicValue discriminatorDescriptor = any.getDiscriminatorDescriptor();
 				final AnyType anyType = any.getType();
 				final MetaType metaType = (MetaType) anyType.getDiscriminatorType();
-				final Object discriminatorValue = metaType.getEntityNameToDiscriminatorValueMap().get( ownerPersister.getEntityName() );
+				Object discriminatorValue = metaType.resolveDiscriminatorValue( ownerPersister.getEntityName() );
 				final BasicType<Object> discriminatorBaseType = (BasicType<Object>) metaType.getBaseType();
 				final String discriminatorLiteral = discriminatorBaseType.getJdbcLiteralFormatter().toJdbcLiteral(
 						discriminatorValue,

--- a/hibernate-core/src/main/java/org/hibernate/type/MetaType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/MetaType.java
@@ -8,6 +8,7 @@ import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 
 import org.hibernate.HibernateException;
 import org.hibernate.MappingException;
@@ -57,6 +58,16 @@ public class MetaType extends AbstractType {
 
 	public Map<String,Object> getEntityNameToDiscriminatorValueMap(){
 		return entityNameToDiscriminatorValueMap;
+	}
+
+	public Object resolveDiscriminatorValue(String entityName) {
+		return Optional.ofNullable(
+				getEntityNameToDiscriminatorValueMap().get( entityName ) ).orElse( entityName );
+	}
+
+	public String resolveEntityName(String discriminatorValue) {
+		return Optional.ofNullable(
+				getDiscriminatorValuesToEntityNameMap().get( discriminatorValue ) ).orElse( discriminatorValue );
 	}
 
 	public int[] getSqlTypeCodes(MappingContext mappingContext) throws MappingException {

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/manytoone/ManyToOneWithAnyTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/manytoone/ManyToOneWithAnyTest.java
@@ -8,7 +8,6 @@ import java.util.Set;
 
 import org.hibernate.Session;
 import org.hibernate.annotations.Any;
-import org.hibernate.annotations.AnyDiscriminatorValue;
 import org.hibernate.annotations.AnyKeyJavaClass;
 import org.hibernate.cfg.JdbcSettings;
 
@@ -45,6 +44,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 		integrationSettings = @Setting(name = JdbcSettings.SHOW_SQL, value = "true")
 )
 @JiraKey("HHH-15722")
+@JiraKey("HHH-18684")
 class ManyToOneWithAnyTest {
 
 	@Test
@@ -117,8 +117,6 @@ class ManyToOneWithAnyTest {
 
 		@Any
 		@AnyKeyJavaClass(Long.class)
-		@AnyDiscriminatorValue(entity = Shop.class, discriminator = "S")
-		@AnyDiscriminatorValue(entity = Library.class, discriminator = "L")
 		@Column(name = "STORE_ROLE")
 		@JoinColumn(name = "STORE_ID")
 		private Store store;

--- a/hibernate-core/src/test/java/org/hibernate/type/MetaTypeResolveTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/type/MetaTypeResolveTest.java
@@ -1,0 +1,72 @@
+/*
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.type;
+
+import org.hibernate.testing.orm.junit.JiraKey;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Test {@link MetaType#resolveDiscriminatorValue(String)} and {@link MetaType#resolveEntityName(String)}
+ *
+ * @author Vincent Bouthinon
+ */
+@JiraKey("HHH-18684")
+class MetaTypeResolveTest {
+
+	@Test
+	void resolveDiscriminatorValue_must_return_the_discriminator_value_when_the_entity_name_exist() {
+		// Given
+		Map<Object, String> discriminatorValuesToEntityNameMap = new HashMap<>();
+		discriminatorValuesToEntityNameMap.put( "dog", Dog.class.getCanonicalName() );
+		MetaType metaType = new MetaType( discriminatorValuesToEntityNameMap, null );
+		// When
+		Object discriminatorValue = metaType.resolveDiscriminatorValue( Dog.class.getCanonicalName() );
+		// Then
+		assertThat( discriminatorValue ).isEqualTo( "dog" );
+	}
+
+	@Test
+	void resolveDiscriminatorValue_must_return_the_entity_name_when_the_entity_name_dont_exist() {
+		// Given
+		Map<Object, String> discriminatorValuesToEntityNameMap = new HashMap<>();
+		discriminatorValuesToEntityNameMap.put( "anotherClass", MetaTypeResolveTest.class.getCanonicalName() );
+		MetaType metaType = new MetaType( discriminatorValuesToEntityNameMap, null );
+		// When
+		Object discriminatorValue = metaType.resolveDiscriminatorValue( Dog.class.getCanonicalName() );
+		// Then
+		assertThat( discriminatorValue ).isEqualTo( Dog.class.getCanonicalName() );
+	}
+
+	@Test
+	void resolveEntityName_must_return_the_entity_name_when_the_discriminator_value_exist() {
+		// Given
+		Map<Object, String> discriminatorValuesToEntityNameMap = new HashMap<>();
+		discriminatorValuesToEntityNameMap.put( "dog", Dog.class.getCanonicalName() );
+		MetaType metaType = new MetaType( discriminatorValuesToEntityNameMap, null );
+		// When
+		Object resolveEntityName = metaType.resolveEntityName( "dog" );
+		// Then
+		assertThat( resolveEntityName ).isEqualTo( Dog.class.getCanonicalName() );
+	}
+
+	@Test
+	void resolveEntityName_must_return_discriminator_value_when_the_entity_name_dont_exist() {
+		// Given
+		Map<Object, String> discriminatorValuesToEntityNameMap = new HashMap<>();
+		MetaType metaType = new MetaType( discriminatorValuesToEntityNameMap, null );
+		// When
+		Object resolveEntityName = metaType.resolveEntityName( Dog.class.getCanonicalName() );
+		// Then
+		assertThat( resolveEntityName ).isEqualTo( Dog.class.getCanonicalName() );
+	}
+
+	private static class Dog {
+	}
+}


### PR DESCRIPTION
For complete the PR : HHH-15722 : @OneToMany mappedBy with a @Any
It is proposed to add this feature :
If no @AnyDiscriminatorValue is returned, the entity name is used as the discriminator value.

This follows the discussions we had on Zulip.