### PR TITLE
HHH-17612 DefaultRevisionEntity: Illegal argument on static metamodel field injection

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/internal/JpaMetamodelImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/internal/JpaMetamodelImpl.java
@@ -26,6 +26,7 @@ import org.hibernate.boot.model.NamedEntityGraphDefinition;
 import org.hibernate.boot.registry.classloading.spi.ClassLoaderService;
 import org.hibernate.boot.registry.classloading.spi.ClassLoadingException;
 import org.hibernate.boot.spi.MetadataImplementor;
+import org.hibernate.engine.config.spi.ConfigurationService;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.graph.internal.RootGraphImpl;
 import org.hibernate.graph.spi.AttributeNodeImplementor;
@@ -69,6 +70,8 @@ import jakarta.persistence.metamodel.EmbeddableType;
 import jakarta.persistence.metamodel.EntityType;
 import jakarta.persistence.metamodel.ManagedType;
 import jakarta.persistence.metamodel.Type;
+
+import static org.hibernate.engine.config.spi.StandardConverters.BOOLEAN;
 
 /**
  *
@@ -145,6 +148,10 @@ public class JpaMetamodelImpl implements JpaMetamodelImplementor, Serializable {
 		final ManagedDomainType<?> managedType = managedTypeByName.get( entityName );
 		if ( !( managedType instanceof EntityDomainType<?> ) ) {
 			return null;
+		}
+		if ( managedType instanceof MappedSuperclassEntityTypeImpl<?> ) {
+			final MappedSuperclassEntityTypeImpl<?> customType = (MappedSuperclassEntityTypeImpl<?>) managedType;
+			log.warn( "Using unsupported entity type: " + customType.getTypeName() );
 		}
 		//noinspection unchecked
 		return (EntityDomainType<X>) managedType;
@@ -232,6 +239,10 @@ public class JpaMetamodelImpl implements JpaMetamodelImplementor, Serializable {
 		final ManagedType<?> type = managedTypeByClass.get( cls );
 		if ( !( type instanceof EntityDomainType<?> ) ) {
 			throw new IllegalArgumentException( "Not an entity: " + cls.getName() );
+		}
+		if ( type instanceof MappedSuperclassEntityTypeImpl<?> ) {
+			final MappedSuperclassEntityTypeImpl<?> customType = (MappedSuperclassEntityTypeImpl<?>) type;
+			log.warn( "Using unsupported entity type: " + customType.getTypeName() );
 		}
 		//noinspection unchecked
 		return (EntityDomainType<X>) type;
@@ -661,6 +672,69 @@ public class JpaMetamodelImpl implements JpaMetamodelImplementor, Serializable {
 		} );
 
 		applyNamedEntityGraphs( namedEntityGraphDefinitions );
+
+		// UGH! This really sucks
+		registerEnversEntityTypes();
+	}
+
+	/**
+	 * @deprecated Workaround for hibernate-envers, should be removed after migrating to the new entity classes
+	 */
+	@Deprecated( forRemoval = true, since = "6.6" )
+	private void registerEnversEntityTypes() {
+		final ConfigurationService cfg = serviceRegistry.requireService( ConfigurationService.class );
+
+		final boolean trackEntitiesChanged = cfg.getSetting(
+				"org.hibernate.envers.track_entities_changed_in_revision",
+				BOOLEAN,
+				false
+		);
+		final boolean nativeIdEnabled = cfg.getSetting(
+				"org.hibernate.envers.use_revision_entity_with_native_id",
+				BOOLEAN,
+				true
+		);
+		final String mappedSuperclassName;
+		final String entityName;
+		if ( trackEntitiesChanged ) {
+			if ( nativeIdEnabled ) {
+				mappedSuperclassName = "org.hibernate.envers.DefaultTrackingModifiedEntitiesRevisionEntity";
+				entityName = "org.hibernate.envers.internal.entities.mappings.DefaultTrackingModifiedEntitiesRevisionEntityImpl";
+			}
+			else {
+				mappedSuperclassName = "org.hibernate.envers.enhanced.SequenceIdTrackingModifiedEntitiesRevisionEntity";
+				entityName = "org.hibernate.envers.internal.entities.mappings.enhanced.SequenceIdTrackingModifiedEntitiesRevisionEntityImpl";
+			}
+		}
+		else {
+			if ( nativeIdEnabled ) {
+				mappedSuperclassName = "org.hibernate.envers.DefaultRevisionEntity";
+				entityName = "org.hibernate.envers.internal.entities.mappings.DefaultRevisionEntityImpl";
+			}
+			else {
+				mappedSuperclassName = "org.hibernate.envers.enhanced.SequenceIdRevisionEntity";
+				entityName = "org.hibernate.envers.internal.entities.mappings.enhanced.SequenceIdRevisionEntityImpl";
+			}
+		}
+
+		final ManagedDomainType<?> domainType = managedTypeByName.get( entityName );
+		if ( domainType != null ) {
+			assert domainType instanceof EntityDomainType<?>;
+			final MappedSuperclassEntityTypeImpl<?> customType = new MappedSuperclassEntityTypeImpl<>(
+					(EntityDomainType<?>) domainType,
+					this
+			);
+			managedTypeByName.put( mappedSuperclassName, customType );
+			( (MappingMetamodelImpl) mappingMetamodel ).copyPersisterForEntityName( entityName, mappedSuperclassName );
+			try {
+				final Class<Object> mappedSuperclass = serviceRegistry.requireService( ClassLoaderService.class )
+						.classForName( mappedSuperclassName );
+				managedTypeByClass.put( mappedSuperclass, customType );
+			}
+			catch (ClassLoadingException e) {
+				// ignored
+			}
+		}
 	}
 
 	public static void addAllowedEnumLiteralsToEnumTypesMap(

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/internal/MappedSuperclassEntityTypeImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/internal/MappedSuperclassEntityTypeImpl.java
@@ -1,0 +1,90 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html
+ */
+package org.hibernate.metamodel.model.domain.internal;
+
+import java.util.Collection;
+
+import org.hibernate.metamodel.model.domain.AbstractIdentifiableType;
+import org.hibernate.metamodel.model.domain.DomainType;
+import org.hibernate.metamodel.model.domain.EntityDomainType;
+import org.hibernate.metamodel.model.domain.IdentifiableDomainType;
+import org.hibernate.metamodel.model.domain.MappedSuperclassDomainType;
+import org.hibernate.metamodel.model.domain.spi.JpaMetamodelImplementor;
+import org.hibernate.query.sqm.SqmPathSource;
+import org.hibernate.query.sqm.tree.domain.SqmPath;
+
+/**
+ * @deprecated Intended as a temporary workaround only
+ */
+@Deprecated( since = "6.6", forRemoval = true )
+public class MappedSuperclassEntityTypeImpl<J> extends AbstractIdentifiableType<J>
+		implements EntityDomainType<J>, MappedSuperclassDomainType<J> {
+	final EntityDomainType<J> delegate;
+
+	public MappedSuperclassEntityTypeImpl(EntityDomainType<J> delegate, JpaMetamodelImplementor metamodel) {
+		super(
+				delegate.getTypeName(),
+				delegate.getExpressibleJavaType(),
+				(IdentifiableDomainType<? super J>) delegate.getSuperType(),
+				delegate.hasIdClass(),
+				delegate.hasSingleIdAttribute(),
+				delegate.hasVersionAttribute(),
+				metamodel
+		);
+		this.delegate = delegate;
+	}
+
+	@Override
+	public MappedSuperclassEntityTypeImpl<J> getSqmType() {
+		return this;
+	}
+
+	@Override
+	public Collection getSubTypes() {
+		return delegate.getSubTypes();
+	}
+
+	@Override
+	public String getHibernateEntityName() {
+		return delegate.getHibernateEntityName();
+	}
+
+	@Override
+	public String getName() {
+		return delegate.getName();
+	}
+
+	@Override
+	public BindableType getBindableType() {
+		return delegate.getBindableType();
+	}
+
+	@Override
+	public PersistenceType getPersistenceType() {
+		return delegate.getPersistenceType();
+	}
+
+	@Override
+	public String getPathName() {
+		return delegate.getPathName();
+	}
+
+	@Override
+	public DomainType<J> getSqmPathType() {
+		return delegate.getSqmPathType();
+	}
+
+	@Override
+	public SqmPathSource<?> findSubPathSource(String name) {
+		return delegate.findSubPathSource( name );
+	}
+
+	@Override
+	public SqmPath<J> createSqmPath(SqmPath<?> lhs, SqmPathSource<?> intermediatePathSource) {
+		return delegate.createSqmPath( lhs, intermediatePathSource );
+	}
+}

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/internal/MappingMetamodelImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/internal/MappingMetamodelImpl.java
@@ -21,6 +21,7 @@ import java.util.stream.Stream;
 
 import org.hibernate.EntityNameResolver;
 import org.hibernate.HibernateException;
+import org.hibernate.Internal;
 import org.hibernate.MappingException;
 import org.hibernate.UnknownEntityTypeException;
 import org.hibernate.boot.registry.classloading.spi.ClassLoaderService;
@@ -896,5 +897,18 @@ public class MappingMetamodelImpl extends QueryParameterBindingTypeResolverImpl
 		}
 
 		return null;
+	}
+
+	/**
+	 * Internal method, allows mapping a persister for one entity name to another entity name
+	 * @deprecated Workaround for hibernate-envers, should be removed after migrating to the new entity classes
+	 */
+	@Internal
+	@Deprecated( forRemoval = true, since = "6.6" )
+	public void copyPersisterForEntityName(String oldEntityName, String newEntityName) {
+		final EntityPersister entityPersister = entityPersisterMap.get( oldEntityName );
+		if ( entityPersister != null ) {
+			entityPersisterMap.put( newEntityName, entityPersister );
+		}
 	}
 }

--- a/hibernate-envers/src/main/java/org/hibernate/envers/configuration/internal/RevisionInfoConfiguration.java
+++ b/hibernate-envers/src/main/java/org/hibernate/envers/configuration/internal/RevisionInfoConfiguration.java
@@ -39,6 +39,10 @@ import org.hibernate.envers.enhanced.SequenceIdRevisionEntity;
 import org.hibernate.envers.enhanced.SequenceIdTrackingModifiedEntitiesRevisionEntity;
 import org.hibernate.envers.internal.entities.PropertyData;
 import org.hibernate.envers.internal.entities.RevisionTimestampData;
+import org.hibernate.envers.internal.entities.mappings.DefaultRevisionEntityImpl;
+import org.hibernate.envers.internal.entities.mappings.DefaultTrackingModifiedEntitiesRevisionEntityImpl;
+import org.hibernate.envers.internal.entities.mappings.enhanced.SequenceIdRevisionEntityImpl;
+import org.hibernate.envers.internal.entities.mappings.enhanced.SequenceIdTrackingModifiedEntitiesRevisionEntityImpl;
 import org.hibernate.envers.internal.revisioninfo.DefaultRevisionInfoGenerator;
 import org.hibernate.envers.internal.revisioninfo.DefaultTrackingModifiedEntitiesRevisionInfoGenerator;
 import org.hibernate.envers.internal.revisioninfo.ModifiedEntityNamesReader;
@@ -285,7 +289,6 @@ public class RevisionInfoConfiguration {
 		public RevisionEntityResolver(MetadataImplementor metadata, ReflectionManager reflectionManager) {
 			this.metadata = metadata;
 			this.reflectionManager = reflectionManager;
-			this.revisionInfoEntityName = getDefaultEntityName();
 			this.revisionInfoIdData = createPropertyData( "id", "field" );
 			this.revisionInfoTimestampData = createPropertyData( "timestamp", "field" );
 			this.modifiedEntityNamesData = createPropertyData( "modifiedEntityNames", "field" );
@@ -294,15 +297,6 @@ public class RevisionInfoConfiguration {
 
 			// automatically initiates a revision entity search over metadata sources
 			locateRevisionEntityMapping();
-		}
-
-		private String getDefaultEntityName() {
-			if ( configuration.isNativeIdEnabled() ) {
-				return DefaultRevisionEntity.class.getName();
-			}
-			else {
-				return SequenceIdRevisionEntity.class.getName();
-			}
 		}
 
 		private void locateRevisionEntityMapping() {
@@ -388,15 +382,15 @@ public class RevisionInfoConfiguration {
 
 				if ( configuration.isTrackEntitiesChanged() ) {
 					revisionInfoClass = configuration.isNativeIdEnabled()
-							? DefaultTrackingModifiedEntitiesRevisionEntity.class
-							: SequenceIdTrackingModifiedEntitiesRevisionEntity.class;
-					revisionInfoEntityName = revisionInfoClass.getName();
+							? DefaultTrackingModifiedEntitiesRevisionEntityImpl.class
+							: SequenceIdTrackingModifiedEntitiesRevisionEntityImpl.class;
 				}
 				else {
 					revisionInfoClass = configuration.isNativeIdEnabled()
-							? DefaultRevisionEntity.class
-							: SequenceIdRevisionEntity.class;
+							? DefaultRevisionEntityImpl.class
+							: SequenceIdRevisionEntityImpl.class;
 				}
+				revisionInfoEntityName = revisionInfoClass.getName();
 
 				timestampValueResolver = createRevisionTimestampResolver(
 						revisionInfoClass,

--- a/hibernate-envers/src/main/java/org/hibernate/envers/internal/entities/mappings/DefaultRevisionEntityImpl.java
+++ b/hibernate-envers/src/main/java/org/hibernate/envers/internal/entities/mappings/DefaultRevisionEntityImpl.java
@@ -1,0 +1,17 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.envers.internal.entities.mappings;
+
+import jakarta.persistence.Entity;
+import org.hibernate.envers.DefaultRevisionEntity;
+
+/**
+ * @author Marco Belladelli
+ */
+@Entity
+public class DefaultRevisionEntityImpl extends DefaultRevisionEntity {
+}

--- a/hibernate-envers/src/main/java/org/hibernate/envers/internal/entities/mappings/DefaultTrackingModifiedEntitiesRevisionEntityImpl.java
+++ b/hibernate-envers/src/main/java/org/hibernate/envers/internal/entities/mappings/DefaultTrackingModifiedEntitiesRevisionEntityImpl.java
@@ -1,0 +1,17 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.envers.internal.entities.mappings;
+
+import jakarta.persistence.Entity;
+import org.hibernate.envers.DefaultTrackingModifiedEntitiesRevisionEntity;
+
+/**
+ * @author Marco Belladelli
+ */
+@Entity
+public class DefaultTrackingModifiedEntitiesRevisionEntityImpl extends DefaultTrackingModifiedEntitiesRevisionEntity {
+}

--- a/hibernate-envers/src/main/java/org/hibernate/envers/internal/entities/mappings/enhanced/SequenceIdRevisionEntityImpl.java
+++ b/hibernate-envers/src/main/java/org/hibernate/envers/internal/entities/mappings/enhanced/SequenceIdRevisionEntityImpl.java
@@ -1,0 +1,17 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.envers.internal.entities.mappings.enhanced;
+
+import jakarta.persistence.Entity;
+import org.hibernate.envers.enhanced.SequenceIdRevisionEntity;
+
+/**
+ * @author Marco Belladelli
+ */
+@Entity
+public class SequenceIdRevisionEntityImpl extends SequenceIdRevisionEntity {
+}

--- a/hibernate-envers/src/main/java/org/hibernate/envers/internal/entities/mappings/enhanced/SequenceIdTrackingModifiedEntitiesRevisionEntityImpl.java
+++ b/hibernate-envers/src/main/java/org/hibernate/envers/internal/entities/mappings/enhanced/SequenceIdTrackingModifiedEntitiesRevisionEntityImpl.java
@@ -1,0 +1,17 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.envers.internal.entities.mappings.enhanced;
+
+import jakarta.persistence.Entity;
+import org.hibernate.envers.enhanced.SequenceIdTrackingModifiedEntitiesRevisionEntity;
+
+/**
+ * @author Marco Belladelli
+ */
+@Entity
+public class SequenceIdTrackingModifiedEntitiesRevisionEntityImpl extends SequenceIdTrackingModifiedEntitiesRevisionEntity {
+}

--- a/hibernate-envers/src/main/java/org/hibernate/envers/internal/entities/mappings/package-info.java
+++ b/hibernate-envers/src/main/java/org/hibernate/envers/internal/entities/mappings/package-info.java
@@ -1,0 +1,19 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+
+/**
+ * Contains empty implementations that are the {@link jakarta.persistence.Entity entity}
+ * subtypes, simply inheriting from the default revision entities which are mapped as
+ * {@link jakarta.persistence.MappedSuperclass mapped-superclass}es.
+ * <p>
+ * This is needed to allow for the correct injection of the static-metamodel {@code class_}
+ * meta-type field of both the default revision entities and the mapped-superclass from which
+ * custom ones might extend from.
+ *
+ * @author Marco Belladelli
+ */
+package org.hibernate.envers.internal.entities.mappings;

--- a/hibernate-envers/src/test/java/org/hibernate/orm/test/envers/ModelContributorSmokeTests.java
+++ b/hibernate-envers/src/test/java/org/hibernate/orm/test/envers/ModelContributorSmokeTests.java
@@ -12,15 +12,13 @@ import jakarta.persistence.Table;
 
 import org.hibernate.boot.spi.MetadataImplementor;
 import org.hibernate.envers.Audited;
-import org.hibernate.envers.DefaultRevisionEntity;
+import org.hibernate.envers.internal.entities.mappings.DefaultRevisionEntityImpl;
 import org.hibernate.mapping.PersistentClass;
 
 import org.hibernate.testing.orm.junit.DomainModel;
 import org.hibernate.testing.orm.junit.DomainModelScope;
 
 import org.junit.jupiter.api.Test;
-
-import org.hamcrest.Matchers;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
@@ -47,7 +45,7 @@ public class ModelContributorSmokeTests {
 		);
 
 		checkModel(
-				domainModel.getEntityBinding( DefaultRevisionEntity.class.getName() ),
+				domainModel.getEntityBinding( DefaultRevisionEntityImpl.class.getName() ),
 				"envers"
 		);
 

--- a/hibernate-envers/src/test/java/org/hibernate/orm/test/envers/integration/metamodel/RevisionEntitiesMetamodelTest.java
+++ b/hibernate-envers/src/test/java/org/hibernate/orm/test/envers/integration/metamodel/RevisionEntitiesMetamodelTest.java
@@ -1,0 +1,99 @@
+/*
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.envers.integration.metamodel;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.boot.MetadataSources;
+import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
+import org.hibernate.engine.spi.SessionFactoryImplementor;
+import org.hibernate.envers.Audited;
+import org.hibernate.envers.configuration.EnversSettings;
+import org.hibernate.internal.HEMLogging;
+import org.hibernate.metamodel.internal.MetadataContext;
+import org.hibernate.testing.logger.LogInspectionHelper;
+import org.hibernate.testing.logger.TriggerOnPrefixLogListener;
+import org.hibernate.testing.orm.junit.Jira;
+import org.hibernate.testing.util.ServiceRegistryUtil;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+
+import java.time.Instant;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Marco Belladelli
+ */
+@Jira( "https://hibernate.atlassian.net/browse/HHH-17612" )
+@TestInstance( TestInstance.Lifecycle.PER_CLASS )
+public class RevisionEntitiesMetamodelTest {
+	private TriggerOnPrefixLogListener trigger;
+
+	@BeforeAll
+	public void setUp() {
+		trigger = new TriggerOnPrefixLogListener( "HHH015007: Illegal argument on static metamodel field injection" );
+		LogInspectionHelper.registerListener( trigger, HEMLogging.messageLogger( MetadataContext.class ) );
+	}
+
+	@Test
+	public void testDefaultRevisionEntity() {
+		try (final SessionFactoryImplementor ignored = buildSessionFactory( false, true )) {
+			assertThat( trigger.wasTriggered() ).isFalse();
+		}
+	}
+
+	@Test
+	public void testSequenceIdRevisionEntity() {
+		try (final SessionFactoryImplementor ignored = buildSessionFactory( false, false )) {
+			assertThat( trigger.wasTriggered() ).isFalse();
+		}
+	}
+
+	@Test
+	public void testDefaultTrackingModifiedEntitiesRevisionEntity() {
+		try (final SessionFactoryImplementor ignored = buildSessionFactory( true, true )) {
+			assertThat( trigger.wasTriggered() ).isFalse();
+		}
+	}
+
+	@Test
+	public void testSequenceIdTrackingModifiedEntitiesRevisionEntity() {
+		try (final SessionFactoryImplementor ignored = buildSessionFactory( true, false )) {
+			assertThat( trigger.wasTriggered() ).isFalse();
+		}
+	}
+
+	@SuppressWarnings( "resource" )
+	private static SessionFactoryImplementor buildSessionFactory(boolean trackEntities, boolean nativeId) {
+		final StandardServiceRegistryBuilder registryBuilder = ServiceRegistryUtil.serviceRegistryBuilder();
+		registryBuilder.applySetting( EnversSettings.TRACK_ENTITIES_CHANGED_IN_REVISION, trackEntities );
+		registryBuilder.applySetting( EnversSettings.USE_REVISION_ENTITY_WITH_NATIVE_ID, nativeId );
+		return new MetadataSources( registryBuilder.build() )
+				.addAnnotatedClasses( Customer.class )
+				.buildMetadata()
+				.buildSessionFactory()
+				.unwrap( SessionFactoryImplementor.class );
+	}
+
+	@Audited
+	@Entity( name = "Customer" )
+	@SuppressWarnings( "unused" )
+	public static class Customer {
+		@Id
+		private Long id;
+
+		private String firstName;
+
+		private String lastName;
+
+		@Column( name = "created_on" )
+		@CreationTimestamp
+		private Instant createdOn;
+	}
+}

--- a/hibernate-envers/src/test/java/org/hibernate/orm/test/envers/integration/query/RevisionEntityQueryTest.java
+++ b/hibernate-envers/src/test/java/org/hibernate/orm/test/envers/integration/query/RevisionEntityQueryTest.java
@@ -1,0 +1,142 @@
+/*
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.envers.integration.query;
+
+import java.util.List;
+
+import org.hibernate.envers.enhanced.SequenceIdRevisionEntity;
+import org.hibernate.envers.query.AuditEntity;
+import org.hibernate.orm.test.envers.BaseEnversJPAFunctionalTestCase;
+import org.hibernate.orm.test.envers.Priority;
+import org.hibernate.orm.test.envers.entities.StrIntTestEntity;
+import org.hibernate.orm.test.envers.entities.ids.EmbId;
+import org.hibernate.orm.test.envers.entities.ids.EmbIdTestEntity;
+import org.hibernate.orm.test.envers.entities.ids.MulId;
+import org.hibernate.orm.test.envers.entities.ids.MulIdTestEntity;
+
+import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.criteria.CriteriaBuilder;
+import jakarta.persistence.criteria.CriteriaQuery;
+import jakarta.persistence.criteria.Root;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Marco Belladelli
+ */
+public class RevisionEntityQueryTest extends BaseEnversJPAFunctionalTestCase {
+	@Override
+	protected Class<?>[] getAnnotatedClasses() {
+		return new Class[] { StrIntTestEntity.class, MulIdTestEntity.class, EmbIdTestEntity.class };
+	}
+
+	@Test
+	@Priority( 10 )
+	public void initData() {
+		// Revision 1
+		final EntityManager em = getEntityManager();
+		em.getTransaction().begin();
+
+		StrIntTestEntity site1 = new StrIntTestEntity( "a", 10 );
+		StrIntTestEntity site2 = new StrIntTestEntity( "a", 10 );
+		StrIntTestEntity site3 = new StrIntTestEntity( "b", 5 );
+
+		em.persist( site1 );
+		em.persist( site2 );
+		em.persist( site3 );
+
+		final Integer id1 = site1.getId();
+		final Integer id2 = site2.getId();
+		final Integer id3 = site3.getId();
+
+		em.getTransaction().commit();
+
+		// Revision 2
+		em.getTransaction().begin();
+
+		final MulId mulId1 = new MulId( 1, 2 );
+		em.persist( new MulIdTestEntity( mulId1.getId1(), mulId1.getId2(), "data" ) );
+
+		final EmbId embId1 = new EmbId( 3, 4 );
+		em.persist( new EmbIdTestEntity( embId1, "something" ) );
+
+		site1 = em.find( StrIntTestEntity.class, id1 );
+		site2 = em.find( StrIntTestEntity.class, id2 );
+
+		site1.setStr1( "aBc" );
+		site2.setNumber( 20 );
+
+		em.getTransaction().commit();
+
+		// Revision 3
+		em.getTransaction().begin();
+
+		site3 = em.find( StrIntTestEntity.class, id3 );
+
+		site3.setStr1( "a" );
+
+		em.getTransaction().commit();
+
+		// Revision 4
+		em.getTransaction().begin();
+
+		site1 = em.find( StrIntTestEntity.class, id1 );
+
+		em.remove( site1 );
+
+		em.getTransaction().commit();
+	}
+
+	@Test
+	public void testRevisionEntityHqlQuery() {
+		final EntityManager em = getEntityManager();
+		em.getTransaction().begin();
+
+		// note: simple name never worked, even before creating new dedicated entity classes, but fqn did
+		final List<SequenceIdRevisionEntity> resultList = em.createQuery(
+				String.format( "select e from %s e", SequenceIdRevisionEntity.class.getName() ),
+				SequenceIdRevisionEntity.class
+		).getResultList();
+
+		assertThat( resultList ).hasSize( 4 );
+
+		em.getTransaction().commit();
+	}
+
+	@Test
+	public void testRevisionEntityCriteriaQuery() {
+		final EntityManager em = getEntityManager();
+		em.getTransaction().begin();
+
+		final CriteriaBuilder criteriaBuilder = em.getCriteriaBuilder();
+		final CriteriaQuery<Integer> query = criteriaBuilder.createQuery( Integer.class );
+		final Root<?> from = query.from( SequenceIdRevisionEntity.class );
+		final List<Integer> resultList = em.createQuery( query.select( from.get( "id" ) ) ).getResultList();
+
+		assertThat( resultList ).hasSize( 4 ).allSatisfy( Assertions::assertNotNull );
+
+		em.getTransaction().commit();
+	}
+
+	@Test
+	public void testQueryForRevisionsOfEntity() {
+		final EntityManager em = getEntityManager();
+		em.getTransaction().begin();
+
+		//noinspection unchecked
+		final List<Object> resultList = getAuditReader().createQuery()
+				.forRevisionsOfEntity( StrIntTestEntity.class, true )
+				.add( AuditEntity.id().eq( 1 ) )
+				.add( AuditEntity.revisionNumber().between( 1, 3 ) )
+				.getResultList();
+
+		assertThat( resultList ).hasSize( 2 ).allMatch( r -> r instanceof SequenceIdRevisionEntity );
+
+		em.getTransaction().commit();
+	}
+}

--- a/hibernate-envers/src/test/java/org/hibernate/orm/test/envers/integration/reventity/DifferentDBSchemaTest.java
+++ b/hibernate-envers/src/test/java/org/hibernate/orm/test/envers/integration/reventity/DifferentDBSchemaTest.java
@@ -13,6 +13,7 @@ import jakarta.persistence.EntityManager;
 import org.hibernate.cfg.Environment;
 import org.hibernate.dialect.H2Dialect;
 import org.hibernate.envers.configuration.EnversSettings;
+import org.hibernate.envers.internal.entities.mappings.enhanced.SequenceIdRevisionEntityImpl;
 import org.hibernate.orm.test.envers.BaseEnversJPAFunctionalTestCase;
 import org.hibernate.orm.test.envers.Priority;
 import org.hibernate.orm.test.envers.entities.StrTestEntity;
@@ -70,7 +71,7 @@ public class DifferentDBSchemaTest extends BaseEnversJPAFunctionalTestCase {
 
 	@Test
 	public void testRevinfoSchemaName() {
-		Table revisionTable = metadata().getEntityBinding( "org.hibernate.envers.enhanced.SequenceIdRevisionEntity" )
+		Table revisionTable = metadata().getEntityBinding( SequenceIdRevisionEntityImpl.class.getName() )
 				.getTable();
 		assert SCHEMA_NAME.equals( revisionTable.getSchema() );
 	}

--- a/hibernate-envers/src/test/java/org/hibernate/orm/test/envers/integration/reventity/removal/AbstractRevisionEntityRemovalTest.java
+++ b/hibernate-envers/src/test/java/org/hibernate/orm/test/envers/integration/reventity/removal/AbstractRevisionEntityRemovalTest.java
@@ -36,8 +36,7 @@ public abstract class AbstractRevisionEntityRemovalTest extends BaseEnversJPAFun
 	@Override
 	protected Class<?>[] getAnnotatedClasses() {
 		return new Class<?>[] {
-				StrTestEntity.class, ListOwnedEntity.class, ListOwningEntity.class,
-				getRevisionEntityClass()
+				StrTestEntity.class, ListOwnedEntity.class, ListOwningEntity.class
 		};
 	}
 

--- a/hibernate-envers/src/test/java/org/hibernate/orm/test/envers/integration/reventity/removal/RemoveTrackingRevisionEntity.java
+++ b/hibernate-envers/src/test/java/org/hibernate/orm/test/envers/integration/reventity/removal/RemoveTrackingRevisionEntity.java
@@ -8,8 +8,8 @@ package org.hibernate.orm.test.envers.integration.reventity.removal;
 
 import java.util.Map;
 
-import org.hibernate.envers.enhanced.SequenceIdTrackingModifiedEntitiesRevisionEntity;
 
+import org.hibernate.envers.internal.entities.mappings.enhanced.SequenceIdTrackingModifiedEntitiesRevisionEntityImpl;
 import org.hibernate.testing.DialectChecks;
 import org.hibernate.testing.RequiresDialectFeature;
 
@@ -26,6 +26,6 @@ public class RemoveTrackingRevisionEntity extends AbstractRevisionEntityRemovalT
 
 	@Override
 	protected Class<?> getRevisionEntityClass() {
-		return SequenceIdTrackingModifiedEntitiesRevisionEntity.class;
+		return SequenceIdTrackingModifiedEntitiesRevisionEntityImpl.class;
 	}
 }


### PR DESCRIPTION
<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

https://hibernate.atlassian.net/browse/HHH-17612

Backport of https://github.com/hibernate/hibernate-orm/pull/9027, including a temporary workaround to allow for queries on the default revision entity types to continue working.

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
