### PR TITLE
HHH-18685 - Proposed solution to enhancement for subclasses of HikariCPConnectionProvider which have already created the HikariDataSource

### DIFF
--- a/hibernate-hikaricp/src/main/java/org/hibernate/hikaricp/internal/HikariCPConnectionProvider.java
+++ b/hibernate-hikaricp/src/main/java/org/hibernate/hikaricp/internal/HikariCPConnectionProvider.java
@@ -55,7 +55,21 @@ public class HikariCPConnectionProvider implements ConnectionProvider, Configura
 			ConnectionInfoLogger.INSTANCE.configureConnectionPool( "HikariCP" );
 
 			hcfg = HikariConfigurationUtil.loadConfiguration( props );
-			hds = new HikariDataSource( hcfg );
+
+			boolean initializedHikariDataSource = false;
+
+			// Support a HikariDataSource already configured by classes which extend this class
+			if(props.containsKey("HikariDataSource")) {
+				Object ohds = props.get("HikariDataSource");
+				if(ohds instanceof HikariDataSource) {
+					hds = (HikariDataSource) ohds;
+					initializedHikariDataSource = true;
+				}
+			}
+			if(!initializedHikariDataSource) {
+				// Default logic if no subclass has configured a HikariDataSource, do so now
+				hds = new HikariDataSource( hcfg );
+			}
 		}
 		catch (Exception e) {
 			ConnectionInfoLogger.INSTANCE.unableToInstantiateConnectionPool( e );


### PR DESCRIPTION
<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

Provide HikariCPConnectionProvider ability to use a pre-configured HikariDataSource already initialized by subclasses.  Many more details in the Jira.

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-18685
<!-- Hibernate GitHub Bot issue links end -->