### PR TITLE
Backport to 6.6 of HHH-13547 (remove logging of BatchImpl rethrown exceptions)

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/engine/jdbc/batch/JdbcBatchLogging.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/jdbc/batch/JdbcBatchLogging.java
@@ -15,8 +15,8 @@ import org.jboss.logging.annotations.Message;
 import org.jboss.logging.annotations.MessageLogger;
 import org.jboss.logging.annotations.ValidIdRange;
 
-import static org.jboss.logging.Logger.Level.ERROR;
 import static org.jboss.logging.Logger.Level.INFO;
+import static org.jboss.logging.Logger.Level.WARN;
 
 /**
  * Sub-system logging related to JDBC batch execution
@@ -35,11 +35,7 @@ public interface JdbcBatchLogging extends BasicLogger {
 	Logger BATCH_LOGGER = Logger.getLogger( NAME );
 	JdbcBatchLogging BATCH_MESSAGE_LOGGER = Logger.getMessageLogger( JdbcBatchLogging.class, NAME );
 
-	@LogMessage(level = ERROR)
-	@Message(id = 100501, value = "Exception executing batch [%s], SQL: %s")
-	void unableToExecuteBatch(Exception e, String sql );
-
-	@LogMessage(level = ERROR)
+	@LogMessage(level = WARN)
 	@Message(id = 100502, value = "Unable to release batch statement...")
 	void unableToReleaseBatchStatement();
 

--- a/hibernate-core/src/main/java/org/hibernate/engine/jdbc/batch/internal/BatchImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/jdbc/batch/internal/BatchImpl.java
@@ -290,12 +290,10 @@ public class BatchImpl implements Batch {
 				}
 				catch (SQLException e) {
 					abortBatch( e );
-					BATCH_MESSAGE_LOGGER.unableToExecuteBatch( e, sql );
 					throw sqlExceptionHelper.convert( e, "could not execute batch", sql );
 				}
 				catch (RuntimeException re) {
 					abortBatch( re );
-					BATCH_MESSAGE_LOGGER.unableToExecuteBatch( re, sql );
 					throw re;
 				}
 			} );


### PR DESCRIPTION
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-13547
<!-- Hibernate GitHub Bot issue links end -->