### PR TITLE
remove unnecessary Integer.valueOf() in ShirtStringToIntegerConverter

### DIFF
--- a/hibernate-testing/src/main/java/org/hibernate/testing/orm/domain/gambit/Shirt.java
+++ b/hibernate-testing/src/main/java/org/hibernate/testing/orm/domain/gambit/Shirt.java
@@ -62,7 +62,7 @@ public class Shirt {
 		@Override
 		public String convertToEntityAttribute(Integer dbData) {
 			if ( dbData != null ) {
-				switch ( Integer.valueOf( dbData ) ) {
+				switch ( dbData ) {
 					case 1:
 						return "X";
 					case 2:


### PR DESCRIPTION
<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

[Please describe here what your change is about]

- Optimized convertToEntityAttribute method by removing redundant Integer.valueOf() call.
- The dbData parameter is already an Integer, making this conversion unnecessary.
 
This is my first contribution to this project. Please let me know if there's anything I need to improve or if you need any additional information. I'm open to feedback and eager to learn. Thank you.

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
