### PR TITLE
HHH-18703 : The JoinedSubclassEntityPersister#getTableNameForColumn KO

### DIFF
--- a/hibernate-core/src/test/java/org/hibernate/persister/entity/JoinedSubclassEntityPersisterTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/persister/entity/JoinedSubclassEntityPersisterTest.java
@@ -1,0 +1,72 @@
+/*
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.persister.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Inheritance;
+import jakarta.persistence.Table;
+import org.hibernate.metamodel.MappingMetamodel;
+import org.hibernate.metamodel.model.domain.internal.JpaMetamodelImpl;
+import org.hibernate.testing.orm.junit.EntityManagerFactoryScope;
+import org.hibernate.testing.orm.junit.JiraKey;
+import org.hibernate.testing.orm.junit.Jpa;
+import org.junit.jupiter.api.Test;
+
+import static jakarta.persistence.InheritanceType.JOINED;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * @author Vincent Bouthinon
+ */
+@Jpa(
+		annotatedClasses = {
+				JoinedSubclassEntityPersisterTest.Animal.class,
+				JoinedSubclassEntityPersisterTest.Dog.class,
+		}
+)
+@JiraKey("HHH-18703")
+class JoinedSubclassEntityPersisterTest {
+
+	@Test
+	void the_table_name_must_match_the_attribute_s_column(EntityManagerFactoryScope scope) {
+		scope.inTransaction(
+				entityManager -> {
+					JpaMetamodelImpl metamodel = (JpaMetamodelImpl) entityManager.getMetamodel();
+					MappingMetamodel mappingMetamodel = metamodel.getMappingMetamodel();
+					EntityPersister entityDescriptor = mappingMetamodel.getEntityDescriptor( Dog.class );
+					String table = entityDescriptor.getTableNameForColumn( "name" );
+					assertEquals( "TANIMAL", table );
+				}
+		);
+	}
+
+	@Entity
+	@Inheritance(strategy = JOINED)
+	@Table(name = "TANIMAL")
+	public static class Animal {
+
+		@Id
+		@GeneratedValue
+		public Integer id;
+
+		private String name;
+
+		public String getName() {
+			return name;
+		}
+
+		public void setName(String name) {
+			this.name = name;
+		}
+	}
+
+	@Entity
+	@Table(name = "TDOG")
+	public static class Dog extends Animal {
+
+	}
+}


### PR DESCRIPTION
The JoinedSubclassEntityPersister#getTableNameForColumn method does not return the correct table in the JOINED inheritance strategy.

Cause: one uses a sorted set of tables, the other does not.

Add the test that reproduces the issue.

----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-18703
<!-- Hibernate GitHub Bot issue links end -->