### PR TITLE
HHH 18705 - Hibernate processor creates bad TypedReferenceQuery when @Entity have name attribute

### DIFF
--- a/tooling/metamodel-generator/src/main/java/org/hibernate/processor/annotation/AnnotationMeta.java
+++ b/tooling/metamodel-generator/src/main/java/org/hibernate/processor/annotation/AnnotationMeta.java
@@ -13,16 +13,18 @@ import org.hibernate.processor.model.Metamodel;
 import org.hibernate.processor.util.Constants;
 import org.hibernate.processor.validation.ProcessorSessionFactory;
 import org.hibernate.processor.validation.Validation;
-import org.hibernate.query.criteria.JpaEntityJoin;
-import org.hibernate.query.criteria.JpaRoot;
-import org.hibernate.query.criteria.JpaSelection;
+import org.hibernate.query.sqm.SqmExpressible;
 import org.hibernate.query.sqm.tree.SqmStatement;
-import org.hibernate.query.sqm.tree.select.SqmSelectClause;
 import org.hibernate.query.sqm.tree.select.SqmSelectStatement;
+import org.hibernate.query.sqm.tree.select.SqmSelectableNode;
+import org.hibernate.type.descriptor.java.JavaType;
 
 import javax.lang.model.element.AnnotationMirror;
 import javax.lang.model.element.AnnotationValue;
 import javax.lang.model.element.Element;
+import javax.lang.model.element.ModuleElement;
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.util.Elements;
 import java.util.List;
 
 import static java.lang.Character.isJavaIdentifierStart;
@@ -33,6 +35,7 @@ import static org.hibernate.processor.util.Constants.TYPED_QUERY_REFERENCE;
 import static org.hibernate.processor.util.TypeUtils.containsAnnotation;
 import static org.hibernate.processor.util.TypeUtils.getAnnotationMirror;
 import static org.hibernate.processor.util.TypeUtils.getAnnotationValue;
+import static org.hibernate.processor.validation.ProcessorSessionFactory.findEntityByUnqualifiedName;
 
 public abstract class AnnotationMeta implements Metamodel {
 
@@ -139,24 +142,23 @@ public abstract class AnnotationMeta implements Metamodel {
 		}
 	}
 
-	private static @Nullable String resultType(SqmSelectStatement<?> selectStatement) {
-		final JpaSelection<?> selection = selectStatement.getSelection();
-		if (selection == null) {
-			return null;
-		}
-		else if (selection instanceof SqmSelectClause from) {
-			return from.getSelectionItems().size() > 1
-					? "Object[]"
-					: from.getSelectionItems().get(0).getJavaTypeName();
-		}
-		else if (selection instanceof JpaRoot<?> root) {
-			return root.getModel().getTypeName();
-		}
-		else if (selection instanceof JpaEntityJoin<?, ?> join) {
-			return join.getModel().getTypeName();
+	private @Nullable String resultType(SqmSelectStatement<?> selectStatement) {
+		final JavaType<?> javaType = selectStatement.getSelection().getJavaTypeDescriptor();
+		if ( javaType != null ) {
+			return javaType.getTypeName();
 		}
 		else {
-			return selection.getJavaTypeName();
+			final List<SqmSelectableNode<?>> items =
+					selectStatement.getQuerySpec().getSelectClause().getSelectionItems();
+			final SqmExpressible<?> expressible;
+			if ( items.size() == 1 && ( expressible = items.get( 0 ).getExpressible() ) != null ) {
+				final String typeName = expressible.getTypeName();
+				final TypeElement entityType = entityType( typeName );
+				return entityType == null ? typeName : entityType.getQualifiedName().toString();
+			}
+			else {
+				return "Object[]";
+			}
 		}
 	}
 
@@ -285,5 +287,27 @@ public abstract class AnnotationMeta implements Metamodel {
 				super.syntaxError( recognizer, offendingSymbol, line, charPositionInLine, message, e );
 			}
 		}
+	}
+
+	private @Nullable TypeElement entityType(String entityName) {
+		final Context context = getContext();
+		final Elements elementUtils = context.getElementUtils();
+		final String qualifiedName = context.qualifiedNameForEntityName(entityName);
+		if ( qualifiedName != null ) {
+			return elementUtils.getTypeElement(qualifiedName);
+		}
+		TypeElement symbol =
+				findEntityByUnqualifiedName( entityName,
+						elementUtils.getModuleElement("") );
+		if ( symbol != null ) {
+			return symbol;
+		}
+		for ( ModuleElement module : elementUtils.getAllModuleElements() ) {
+			symbol = findEntityByUnqualifiedName( entityName, module );
+			if ( symbol != null ) {
+				return symbol;
+			}
+		}
+		return null;
 	}
 }

--- a/tooling/metamodel-generator/src/main/java/org/hibernate/processor/util/SqmTypeUtils.java
+++ b/tooling/metamodel-generator/src/main/java/org/hibernate/processor/util/SqmTypeUtils.java
@@ -1,0 +1,38 @@
+/*
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.processor.util;
+
+import org.hibernate.processor.Context;
+import org.hibernate.query.sqm.SqmExpressible;
+import org.hibernate.query.sqm.tree.select.SqmSelectStatement;
+import org.hibernate.query.sqm.tree.select.SqmSelectableNode;
+
+import javax.lang.model.element.TypeElement;
+import java.util.List;
+
+public final class SqmTypeUtils {
+	private SqmTypeUtils() {
+	}
+
+	public static String resultType(SqmSelectStatement<?> selectStatement, Context context) {
+		final String javaTypeName = selectStatement.getSelection().getJavaTypeName();
+		if ( javaTypeName != null ) {
+			return javaTypeName;
+		}
+		else {
+			final List<SqmSelectableNode<?>> items =
+					selectStatement.getQuerySpec().getSelectClause().getSelectionItems();
+			final SqmExpressible<?> expressible;
+			if ( items.size() == 1 && (expressible = items.get( 0 ).getExpressible()) != null ) {
+				final String typeName = expressible.getTypeName();
+				final TypeElement entityType = context.entityType( typeName );
+				return entityType == null ? typeName : entityType.getQualifiedName().toString();
+			}
+			else {
+				return "Object[]";
+			}
+		}
+	}
+}

--- a/tooling/metamodel-generator/src/test/java/org/hibernate/processor/test/namedentity/Book.java
+++ b/tooling/metamodel-generator/src/test/java/org/hibernate/processor/test/namedentity/Book.java
@@ -1,0 +1,18 @@
+/*
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.processor.test.namedentity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.NamedQuery;
+
+@Entity(name = "Liber")
+@NamedQuery(name = "findAllBooks", query = "from Liber")
+public class Book {
+	@Id
+	private Integer id;
+
+	private String name;
+}

--- a/tooling/metamodel-generator/src/test/java/org/hibernate/processor/test/namedentity/NamedEntityTest.java
+++ b/tooling/metamodel-generator/src/test/java/org/hibernate/processor/test/namedentity/NamedEntityTest.java
@@ -1,0 +1,40 @@
+/*
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.processor.test.namedentity;
+
+import jakarta.persistence.TypedQueryReference;
+import org.hibernate.processor.test.util.CompilationTest;
+import org.hibernate.processor.test.util.WithClasses;
+import org.junit.Test;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+
+import static org.hibernate.processor.test.util.TestUtil.assertMetamodelClassGeneratedFor;
+import static org.hibernate.processor.test.util.TestUtil.assertPresenceOfFieldInMetamodelFor;
+import static org.hibernate.processor.test.util.TestUtil.getFieldFromMetamodelFor;
+import static org.hibernate.processor.test.util.TestUtil.getMetaModelSourceAsString;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class NamedEntityTest extends CompilationTest {
+
+	@Test
+	@WithClasses(Book.class)
+	public void test() {
+		System.out.println( getMetaModelSourceAsString( Book.class ) );
+
+		assertMetamodelClassGeneratedFor( Book.class );
+
+		assertPresenceOfFieldInMetamodelFor( Book.class, "QUERY_FIND_ALL_BOOKS" );
+		final Field field = getFieldFromMetamodelFor( Book.class, "_findAllBooks_" );
+		assertEquals( TypedQueryReference.class, field.getType() );
+		final Type genericType = field.getGenericType();
+		assertTrue( genericType instanceof ParameterizedType );
+		final ParameterizedType parameterizedType = (ParameterizedType) genericType;
+		assertEquals( Book.class, parameterizedType.getActualTypeArguments()[0] );
+	}
+}


### PR DESCRIPTION
See Jira Issue [HHH-18705](https://hibernate.atlassian.net/browse/HHH-18705)

Problem can be quickly, but ugly, solved by copy & paste (with small adjustments) methods `returnType` and `entityType` from class `org.hibernate.processor.annotation.NamedQueryMethod`.

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------


[HHH-18705]: https://hibernate.atlassian.net/browse/HHH-18705?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ