### PR TITLE
HHH-18669 - resolve the driver name from the connection metadata, in case it wasn't explicitly set and access to the database metadata is allowed

### DIFF
--- a/hibernate-agroal/src/main/java/org/hibernate/agroal/internal/AgroalConnectionProvider.java
+++ b/hibernate-agroal/src/main/java/org/hibernate/agroal/internal/AgroalConnectionProvider.java
@@ -9,10 +9,11 @@ package org.hibernate.agroal.internal;
 
 import java.sql.Connection;
 import java.sql.SQLException;
+import java.sql.DatabaseMetaData;
+import javax.sql.DataSource;
 import java.util.Map;
 import java.util.function.Consumer;
 import java.util.function.Function;
-import javax.sql.DataSource;
 
 import org.hibernate.HibernateException;
 import org.hibernate.cfg.AgroalSettings;
@@ -36,6 +37,7 @@ import io.agroal.api.security.NamePrincipal;
 import io.agroal.api.security.SimplePassword;
 
 import static org.hibernate.cfg.AgroalSettings.AGROAL_CONFIG_PREFIX;
+import static org.hibernate.engine.jdbc.env.internal.JdbcEnvironmentInitiator.allowJdbcMetadataAccess;
 
 /**
  * ConnectionProvider based on Agroal connection pool
@@ -64,6 +66,7 @@ public class AgroalConnectionProvider implements ConnectionProvider, Configurabl
 	public static final String CONFIG_PREFIX = AGROAL_CONFIG_PREFIX + ".";
 	private static final long serialVersionUID = 1L;
 	private AgroalDataSource agroalDataSource = null;
+	private boolean isMetadataAccessAllowed = true;
 
 	// --- Configurable
 
@@ -92,6 +95,8 @@ public class AgroalConnectionProvider implements ConnectionProvider, Configurabl
 
 	@Override
 	public void configure(Map<String, Object> props) throws HibernateException {
+		isMetadataAccessAllowed = allowJdbcMetadataAccess( props );
+
 		ConnectionInfoLogger.INSTANCE.configureConnectionPool( "Agroal" );
 		try {
 			AgroalPropertiesReader agroalProperties = new AgroalPropertiesReader( CONFIG_PREFIX )
@@ -139,9 +144,12 @@ public class AgroalConnectionProvider implements ConnectionProvider, Configurabl
 		final AgroalConnectionPoolConfiguration acpc = agroalDataSource.getConfiguration().connectionPoolConfiguration();
 		final AgroalConnectionFactoryConfiguration acfc = acpc.connectionFactoryConfiguration();
 
+
 		return new DatabaseConnectionInfoImpl(
 				acfc.jdbcUrl(),
-				acfc.connectionProviderClass().toString(),
+				// Attempt to resolve the driver name from the dialect, in case it wasn't explicitly set and access to
+				// the database metadata is allowed
+				acfc.connectionProviderClass() != null ? acfc.connectionProviderClass().toString() : extractDriverNameFromMetadata(),
 				dialect.getVersion(),
 				Boolean.toString( acfc.autoCommit() ),
 				acfc.jdbcTransactionIsolation() != null
@@ -150,6 +158,19 @@ public class AgroalConnectionProvider implements ConnectionProvider, Configurabl
 				acpc.minSize(),
 				acpc.minSize()
 		);
+	}
+
+	private String extractDriverNameFromMetadata() {
+		if (isMetadataAccessAllowed) {
+			try ( Connection conn = getConnection() ) {
+				DatabaseMetaData dbmd = conn.getMetaData();
+				return dbmd.getDriverName();
+			}
+			catch (SQLException e) {
+				// Do nothing
+			}
+		}
+		return null;
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/engine/jdbc/env/internal/JdbcEnvironmentInitiator.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/jdbc/env/internal/JdbcEnvironmentInitiator.java
@@ -215,7 +215,7 @@ public class JdbcEnvironmentInitiator implements StandardServiceInitiator<JdbcEn
 	 *
 	 * @see JdbcSettings#ALLOW_METADATA_ON_BOOT
 	 */
-	private static boolean allowJdbcMetadataAccess(Map<String, Object> configurationValues) {
+	public static boolean allowJdbcMetadataAccess(Map<String, Object> configurationValues) {
 		final Boolean allow = getBooleanWrapper( ALLOW_METADATA_ON_BOOT, configurationValues, null );
 		if ( allow != null ) {
 			return allow;


### PR DESCRIPTION
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-18669
<!-- Hibernate GitHub Bot issue links end -->