### PR TITLE
HHH-18569 Prevent resolving subtype attribute paths when using string-typed Criteria API methods

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/query/hql/internal/BasicDotIdentifierConsumer.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/hql/internal/BasicDotIdentifierConsumer.java
@@ -145,7 +145,10 @@ public class BasicDotIdentifierConsumer implements DotIdentifierConsumer {
 				if ( pathRootByExposedNavigable != null ) {
 					// identifier is an "unqualified attribute reference"
 					validateAsRoot( pathRootByExposedNavigable );
-					final SqmPath<?> sqmPath = pathRootByExposedNavigable.get( identifier );
+					final SqmPath<?> sqmPath = pathRootByExposedNavigable.get(
+							identifier,
+							creationState.getCreationContext().getJpaMetamodel()
+					);
 					return isTerminal ? sqmPath : new DomainPathPart( sqmPath );
 				}
 			}

--- a/hibernate-core/src/main/java/org/hibernate/query/hql/internal/SemanticQueryBuilder.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/hql/internal/SemanticQueryBuilder.java
@@ -3403,7 +3403,7 @@ public class SemanticQueryBuilder<R> extends HqlParserBaseVisitor<Object> implem
 						+ "' of 'id()' is a '" + identifiableType.getTypeName()
 						+ "' and does not have a well-defined '@Id' attribute" );
 			}
-			return sqmPath.get( identifierDescriptor.getPathName() );
+			return sqmPath.get( identifierDescriptor.getPathName(), creationContext.getJpaMetamodel() );
 		}
 		else if ( sqmPath instanceof SqmAnyValuedSimplePath<?> ) {
 			return sqmPath.resolvePathPart( AnyKeyPart.KEY_NAME, true, processingStateStack.getCurrent().getCreationState() );

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/SqmPathSource.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/SqmPathSource.java
@@ -81,7 +81,7 @@ public interface SqmPathSource<J> extends SqmExpressible<J>, Bindable<J>, SqmExp
 	}
 
 	/**
-	 * Find a {@link SqmPathSource} by name relative to this source.
+	 * Find a {@link SqmPathSource} by name relative to this source and all its subtypes.
 	 *
 	 * @throws IllegalStateException to indicate that this source cannot be de-referenced
 	 * @throws IllegalArgumentException if the subPathSource is not found

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/domain/AbstractSqmFrom.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/domain/AbstractSqmFrom.java
@@ -191,7 +191,7 @@ public abstract class AbstractSqmFrom<O,T> extends AbstractSqmPath<T> implements
 		if ( resolvedPath != null ) {
 			return resolvedPath;
 		}
-		final SqmPath<?> sqmPath = get( name );
+		final SqmPath<?> sqmPath = get( name, nodeBuilder().getJpaMetamodel() );
 		creationState.getProcessingStateStack().getCurrent().getPathRegistry().register( sqmPath );
 		return sqmPath;
 	}
@@ -412,8 +412,8 @@ public abstract class AbstractSqmFrom<O,T> extends AbstractSqmPath<T> implements
 	@Override
 	@SuppressWarnings("unchecked")
 	public <X, Y> SqmAttributeJoin<X, Y> join(String attributeName, JoinType jt) {
-		final SqmPathSource<?> subPathSource =
-				getReferencedPathSource().getSubPathSource( attributeName, nodeBuilder().getJpaMetamodel() );
+		final SqmPathSource<Y> subPathSource = (SqmPathSource<Y>) getReferencedPathSource()
+				.getSubPathSource( attributeName );
 		return (SqmAttributeJoin<X, Y>) buildJoin( subPathSource, SqmJoinType.from( jt ), false );
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/domain/AbstractSqmPath.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/domain/AbstractSqmPath.java
@@ -18,6 +18,7 @@ import org.hibernate.metamodel.mapping.EntityDiscriminatorMapping;
 import org.hibernate.metamodel.model.domain.DomainType;
 import org.hibernate.metamodel.model.domain.EmbeddableDomainType;
 import org.hibernate.metamodel.model.domain.EntityDomainType;
+import org.hibernate.metamodel.model.domain.JpaMetamodel;
 import org.hibernate.metamodel.model.domain.ManagedDomainType;
 import org.hibernate.metamodel.model.domain.PersistentAttribute;
 import org.hibernate.query.sqm.NodeBuilder;
@@ -193,9 +194,15 @@ public abstract class AbstractSqmPath<T> extends AbstractSqmExpression<T> implem
 	@Override
 	@SuppressWarnings("unchecked")
 	public SqmPath<?> get(String attributeName) {
-		final SqmPathSource<?> subNavigable =
-				getResolvedModel().getSubPathSource( attributeName, nodeBuilder().getJpaMetamodel() );
+		final SqmPathSource<?> subNavigable = getResolvedModel().getSubPathSource( attributeName );
 		return resolvePath( attributeName, subNavigable );
+	}
+
+	@Override
+	@SuppressWarnings("unchecked")
+	public SqmPath<?> get(String attributeName, JpaMetamodel metamodel) {
+		final SqmPathSource<?> subPathSource = getResolvedModel().getSubPathSource( attributeName, metamodel );
+		return resolvePath( attributeName, subPathSource );
 	}
 
 	protected <X> SqmPath<X> resolvePath(PersistentAttribute<?, X> attribute) {

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/domain/SqmAnyValuedSimplePath.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/domain/SqmAnyValuedSimplePath.java
@@ -77,7 +77,7 @@ public class SqmAnyValuedSimplePath<T> extends AbstractSqmSimplePath<T> {
 			String name,
 			boolean isTerminal,
 			SqmCreationState creationState) {
-		final SqmPath<?> sqmPath = get( name );
+		final SqmPath<?> sqmPath = get( name, nodeBuilder().getJpaMetamodel() );
 		creationState.getProcessingStateStack().getCurrent().getPathRegistry().register( sqmPath );
 		return sqmPath;
 	}

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/domain/SqmElementAggregateFunction.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/domain/SqmElementAggregateFunction.java
@@ -100,7 +100,7 @@ public class SqmElementAggregateFunction<T> extends AbstractSqmSpecificPluralPar
 			String name,
 			boolean isTerminal,
 			SqmCreationState creationState) {
-		final SqmPath<?> sqmPath = get( name );
+		final SqmPath<?> sqmPath = get( name, nodeBuilder().getJpaMetamodel() );
 		creationState.getProcessingStateStack().getCurrent().getPathRegistry().register( sqmPath );
 		return sqmPath;
 	}

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/domain/SqmEmbeddedValuedSimplePath.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/domain/SqmEmbeddedValuedSimplePath.java
@@ -84,7 +84,7 @@ public class SqmEmbeddedValuedSimplePath<T>
 			String name,
 			boolean isTerminal,
 			SqmCreationState creationState) {
-		final SqmPath<?> sqmPath = get( name );
+		final SqmPath<?> sqmPath = get( name, nodeBuilder().getJpaMetamodel() );
 		creationState.getProcessingStateStack().getCurrent().getPathRegistry().register( sqmPath );
 		return sqmPath;
 	}

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/domain/SqmEntityValuedSimplePath.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/domain/SqmEntityValuedSimplePath.java
@@ -51,7 +51,7 @@ public class SqmEntityValuedSimplePath<T> extends AbstractSqmSimplePath<T> {
 			String name,
 			boolean isTerminal,
 			SqmCreationState creationState) {
-		final SqmPath<?> sqmPath = get( name );
+		final SqmPath<?> sqmPath = get( name, nodeBuilder().getJpaMetamodel() );
 		creationState.getProcessingStateStack().getCurrent().getPathRegistry().register( sqmPath );
 		return sqmPath;
 	}

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/domain/SqmFkExpression.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/domain/SqmFkExpression.java
@@ -83,7 +83,7 @@ public class SqmFkExpression<T> extends AbstractSqmPath<T> {
 
 	@Override
 	public SqmPath<?> resolvePathPart(String name, boolean isTerminal, SqmCreationState creationState) {
-		final SqmPath<?> sqmPath = get( name );
+		final SqmPath<?> sqmPath = get( name, nodeBuilder().getJpaMetamodel() );
 		creationState.getProcessingStateStack().getCurrent().getPathRegistry().register( sqmPath );
 		return sqmPath;
 	}

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/domain/SqmFunctionPath.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/domain/SqmFunctionPath.java
@@ -105,7 +105,7 @@ public class SqmFunctionPath<T> extends AbstractSqmPath<T> {
 			String name,
 			boolean isTerminal,
 			SqmCreationState creationState) {
-		final SqmPath<?> sqmPath = get( name );
+		final SqmPath<?> sqmPath = get( name, nodeBuilder().getJpaMetamodel() );
 		creationState.getProcessingStateStack().getCurrent().getPathRegistry().register( sqmPath );
 		return sqmPath;
 	}

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/domain/SqmIndexAggregateFunction.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/domain/SqmIndexAggregateFunction.java
@@ -102,7 +102,7 @@ public class SqmIndexAggregateFunction<T> extends AbstractSqmSpecificPluralPartP
 			String name,
 			boolean isTerminal,
 			SqmCreationState creationState) {
-		final SqmPath<?> sqmPath = get( name );
+		final SqmPath<?> sqmPath = get( name, nodeBuilder().getJpaMetamodel() );
 		creationState.getProcessingStateStack().getCurrent().getPathRegistry().register( sqmPath );
 		return sqmPath;
 	}

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/domain/SqmIndexedCollectionAccessPath.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/domain/SqmIndexedCollectionAccessPath.java
@@ -66,7 +66,7 @@ public class SqmIndexedCollectionAccessPath<T> extends AbstractSqmPath<T> implem
 			String name,
 			boolean isTerminal,
 			SqmCreationState creationState) {
-		final SqmPath<?> sqmPath = get( name );
+		final SqmPath<?> sqmPath = get( name, nodeBuilder().getJpaMetamodel() );
 		creationState.getProcessingStateStack().getCurrent().getPathRegistry().register( sqmPath );
 		return sqmPath;
 	}

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/domain/SqmPath.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/domain/SqmPath.java
@@ -15,6 +15,7 @@ import jakarta.persistence.metamodel.SingularAttribute;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 import org.hibernate.metamodel.model.domain.EntityDomainType;
+import org.hibernate.metamodel.model.domain.JpaMetamodel;
 import org.hibernate.query.SemanticException;
 import org.hibernate.query.criteria.JpaPath;
 import org.hibernate.query.hql.spi.SemanticPathPart;
@@ -174,6 +175,16 @@ public interface SqmPath<T> extends SqmExpression<T>, SemanticPathPart, JpaPath<
 
 	@Override
 	<Y> SqmPath<Y> get(String attributeName);
+
+	/**
+	 * Same as {@link #get(String)}, but implementations of this method will also return paths
+	 * from attribute names which are specified in inheritance subtypes of the current path.
+	 *
+	 * @see SqmPathSource#findSubPathSource(String, JpaMetamodel)
+	 */
+	default <Y> SqmPath<Y> get(String attributeName, JpaMetamodel metamodel) {
+		return get( attributeName );
+	}
 
 	@Override
 	SqmPath<T> copy(SqmCopyContext context);

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/domain/SqmPluralValuedSimplePath.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/domain/SqmPluralValuedSimplePath.java
@@ -101,7 +101,7 @@ public class SqmPluralValuedSimplePath<E> extends AbstractSqmSimplePath<E> {
 					+ "' refers to a collection and so element attribute '" + name
 					+ "' may not be referenced directly (use element() function)" );
 		}
-		final SqmPath<?> sqmPath = get( name );
+		final SqmPath<?> sqmPath = get( name, nodeBuilder().getJpaMetamodel() );
 		creationState.getProcessingStateStack().getCurrent().getPathRegistry().register( sqmPath );
 		return sqmPath;
 	}

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/domain/SqmSetJoin.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/domain/SqmSetJoin.java
@@ -18,11 +18,9 @@ import org.hibernate.query.criteria.JpaSetJoin;
 import org.hibernate.query.sqm.NodeBuilder;
 import org.hibernate.query.sqm.tree.SqmCopyContext;
 import org.hibernate.query.sqm.tree.SqmJoinType;
-import org.hibernate.query.sqm.tree.from.SqmAttributeJoin;
 import org.hibernate.query.sqm.tree.from.SqmFrom;
 
 import jakarta.persistence.criteria.Expression;
-import jakarta.persistence.criteria.JoinType;
 import jakarta.persistence.criteria.Predicate;
 
 /**
@@ -157,11 +155,4 @@ public class SqmSetJoin<O, E>
 		}
 		return treat;
 	}
-
-	@Override
-	public <X, Y> SqmAttributeJoin<X, Y> fetch(String attributeName) {
-		return fetch( attributeName, JoinType.INNER);
-	}
-
-
 }

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/domain/SqmTreatedEmbeddedValuedSimplePath.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/domain/SqmTreatedEmbeddedValuedSimplePath.java
@@ -103,7 +103,7 @@ public class SqmTreatedEmbeddedValuedSimplePath<T, S extends T> extends SqmEmbed
 
 	@Override
 	public SqmPath<?> resolvePathPart(String name, boolean isTerminal, SqmCreationState creationState) {
-		final SqmPath<?> sqmPath = get( name );
+		final SqmPath<?> sqmPath = get( name, nodeBuilder().getJpaMetamodel() );
 		creationState.getProcessingStateStack().getCurrent().getPathRegistry().register( sqmPath );
 		return sqmPath;
 	}

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/domain/SqmTreatedRoot.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/domain/SqmTreatedRoot.java
@@ -110,7 +110,7 @@ public class SqmTreatedRoot extends SqmRoot implements SqmTreatedFrom {
 			String name,
 			boolean isTerminal,
 			SqmCreationState creationState) {
-		final SqmPath<?> sqmPath = get( name );
+		final SqmPath<?> sqmPath = get( name, nodeBuilder().getJpaMetamodel() );
 		creationState.getProcessingStateStack().getCurrent().getPathRegistry().register( sqmPath );
 		return sqmPath;
 	}

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/select/SqmQuerySpec.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/select/SqmQuerySpec.java
@@ -494,9 +494,9 @@ public class SqmQuerySpec<T> extends SqmQueryPart<T>
 		}
 
 		for ( SqmRoot<?> root : roots ) {
-			validateFetchOwners( selectedFromSet, root, root );
+			validateFetchOwners( selectedFromSet, root );
 			for ( SqmFrom<?, ?> sqmTreat : root.getSqmTreats() ) {
-				validateFetchOwners( selectedFromSet, root, sqmTreat );
+				validateFetchOwners( selectedFromSet, sqmTreat );
 			}
 		}
 	}
@@ -543,12 +543,12 @@ public class SqmQuerySpec<T> extends SqmQueryPart<T>
 		}
 	}
 
-	private void validateFetchOwners(Set<SqmFrom<?, ?>> selectedFromSet, SqmFrom<?, ?> owner, SqmFrom<?, ?> joinContainer) {
+	private void validateFetchOwners(Set<SqmFrom<?, ?>> selectedFromSet, SqmFrom<?, ?> joinContainer) {
 		for ( SqmJoin<?, ?> sqmJoin : joinContainer.getSqmJoins() ) {
 			if ( sqmJoin instanceof SqmAttributeJoin<?, ?> ) {
 				final SqmAttributeJoin<?, ?> attributeJoin = (SqmAttributeJoin<?, ?>) sqmJoin;
 				if ( attributeJoin.isFetched() ) {
-					assertFetchOwner( selectedFromSet, owner, sqmJoin );
+					assertFetchOwner( selectedFromSet, attributeJoin.getLhs(), sqmJoin );
 					// Only need to check the first level
 					continue;
 				}
@@ -557,14 +557,14 @@ public class SqmQuerySpec<T> extends SqmQueryPart<T>
 				if ( sqmTreat instanceof SqmAttributeJoin<?, ?> ) {
 					final SqmAttributeJoin<?, ?> attributeJoin = (SqmAttributeJoin<?, ?>) sqmTreat;
 					if ( attributeJoin.isFetched() ) {
-						assertFetchOwner( selectedFromSet, owner, attributeJoin );
+						assertFetchOwner( selectedFromSet, attributeJoin.getLhs(), attributeJoin );
 						// Only need to check the first level
 						continue;
 					}
 				}
-				validateFetchOwners( selectedFromSet, sqmJoin, sqmTreat );
+				validateFetchOwners( selectedFromSet, sqmTreat );
 			}
-			validateFetchOwners( selectedFromSet, sqmJoin, sqmJoin );
+			validateFetchOwners( selectedFromSet, sqmJoin );
 		}
 	}
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/inheritance/TreatedSubclassSameTypeTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/inheritance/TreatedSubclassSameTypeTest.java
@@ -62,11 +62,6 @@ public class TreatedSubclassSameTypeTest {
 	}
 
 	@Test
-	public void testJoin(SessionFactoryScope scope) {
-		executeQuery( scope, criteria -> criteria.from( MyEntity1.class ), false );
-	}
-
-	@Test
 	public void testJoinOnTreatedSubtype(SessionFactoryScope scope) {
 		executeQuery( scope, criteria -> criteria.from( MySubEntity1.class ), true );
 	}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/joinedsubclass/JoinedSubclassTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/joinedsubclass/JoinedSubclassTest.java
@@ -106,7 +106,7 @@ public class JoinedSubclassTest {
 
 			Root<Person> root = criteria.from( Person.class );
 
-			criteria.where( criteriaBuilder.gt( root.get( "salary" ), new BigDecimal( 100 ) ) );
+			criteria.where( criteriaBuilder.gt( criteriaBuilder.treat( root, Employee.class ).get( "salary" ), new BigDecimal( 100 ) ) );
 
 			result = s.createQuery( criteria ).list();
 //			result = s.createCriteria( Person.class )

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/criteria/CriteriaSubtypeAttributesTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/criteria/CriteriaSubtypeAttributesTest.java
@@ -1,0 +1,307 @@
+/*
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.jpa.criteria;
+
+import java.util.List;
+
+import org.hibernate.Hibernate;
+import org.hibernate.SessionFactory;
+
+import org.hibernate.query.sqm.PathElementException;
+import org.hibernate.testing.orm.junit.EntityManagerFactoryScope;
+import org.hibernate.testing.orm.junit.Jira;
+import org.hibernate.testing.orm.junit.Jpa;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.criteria.CriteriaBuilder;
+import jakarta.persistence.criteria.CriteriaQuery;
+import jakarta.persistence.criteria.Root;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Fail.fail;
+
+/**
+ * @author Marco Belladelli
+ */
+@Jpa( annotatedClasses = {
+		CriteriaSubtypeAttributesTest.ParentEntity.class,
+		CriteriaSubtypeAttributesTest.ChildEntity.class,
+		CriteriaSubtypeAttributesTest.AssociatedEntity.class,
+} )
+@Jira( "https://hibernate.atlassian.net/browse/HHH-18569" )
+public class CriteriaSubtypeAttributesTest {
+	@Test
+	public void testGetParentAttribute(EntityManagerFactoryScope scope) {
+		// parent root
+		scope.inTransaction( entityManager -> {
+			final CriteriaBuilder cb = entityManager.getCriteriaBuilder();
+			final CriteriaQuery<ParentEntity> cq = cb.createQuery( ParentEntity.class );
+			final Root<ParentEntity> parent = cq.from( ParentEntity.class );
+			cq.where( cb.isNotNull( parent.get( "name" ) ) );
+			assertResult( entityManager.createQuery( cq ).getResultList(), 2, "name", true );
+		} );
+		// child root
+		scope.inTransaction( entityManager -> {
+			final CriteriaBuilder cb = entityManager.getCriteriaBuilder();
+			final CriteriaQuery<ChildEntity> cq = cb.createQuery( ChildEntity.class );
+			final Root<ChildEntity> parent = cq.from( ChildEntity.class );
+			cq.where( cb.isNotNull( parent.get( "name" ) ) );
+			assertResult( entityManager.createQuery( cq ).getResultList(), 1, "name", true );
+		} );
+	}
+
+	@Test
+	public void testGetSubtypeAttribute(EntityManagerFactoryScope scope) {
+		// parent root
+		scope.inTransaction( entityManager -> {
+			final CriteriaBuilder cb = entityManager.getCriteriaBuilder();
+			final CriteriaQuery<ParentEntity> cq = cb.createQuery( ParentEntity.class );
+			final Root<ParentEntity> parent = cq.from( ParentEntity.class );
+			try {
+				cq.where( cb.isNotNull( parent.get( "age" ) ) );
+				fail( "Invoking get() for a subtype attribute on a supertype root should not be allowed" );
+			}
+			catch (Exception e) {
+				assertThat( e ).isInstanceOf( PathElementException.class ).hasMessageContaining( "Could not resolve attribute" );
+			}
+		} );
+		// child root
+		scope.inTransaction( entityManager -> {
+			final CriteriaBuilder cb = entityManager.getCriteriaBuilder();
+			final CriteriaQuery<ChildEntity> cq = cb.createQuery( ChildEntity.class );
+			final Root<ChildEntity> child = cq.from( ChildEntity.class );
+			cq.where( cb.isNotNull( child.get( "age" ) ) );
+			assertResult( entityManager.createQuery( cq ).getResultList(), 1, "age", true );
+		} );
+		// parent root treat as child
+		scope.inTransaction( entityManager -> {
+			final CriteriaBuilder cb = entityManager.getCriteriaBuilder();
+			final CriteriaQuery<ChildEntity> cq = cb.createQuery( ChildEntity.class );
+			final Root<ParentEntity> parent = cq.from( ParentEntity.class );
+			final Root<ChildEntity> treated = cb.treat( parent, ChildEntity.class );
+			cq.select( treated );
+			cq.where( cb.isNotNull( treated.get( "age" ) ) );
+			assertResult( entityManager.createQuery( cq ).getResultList(), 1, "age", true );
+		} );
+	}
+
+	@Test
+	public void testJoinParentAttribute(EntityManagerFactoryScope scope) {
+		// parent root
+		scope.inTransaction( entityManager -> {
+			final CriteriaBuilder cb = entityManager.getCriteriaBuilder();
+			final CriteriaQuery<ParentEntity> cq = cb.createQuery( ParentEntity.class );
+			final Root<ParentEntity> parent = cq.from( ParentEntity.class );
+			parent.join( "association" );
+			assertResult( entityManager.createQuery( cq ).getResultList(), 2, "association", false );
+		} );
+		// child root
+		scope.inTransaction( entityManager -> {
+			final CriteriaBuilder cb = entityManager.getCriteriaBuilder();
+			final CriteriaQuery<ChildEntity> cq = cb.createQuery( ChildEntity.class );
+			final Root<ChildEntity> child = cq.from( ChildEntity.class );
+			child.join( "association" );
+			assertResult( entityManager.createQuery( cq ).getResultList(), 1, "association", false );
+		} );
+	}
+
+	@Test
+	public void testJoinSubtypeAttribute(EntityManagerFactoryScope scope) {
+		// parent root
+		scope.inTransaction( entityManager -> {
+			final CriteriaBuilder cb = entityManager.getCriteriaBuilder();
+			final CriteriaQuery<ParentEntity> cq = cb.createQuery( ParentEntity.class );
+			final Root<ParentEntity> parent = cq.from( ParentEntity.class );
+			try {
+				parent.join( "childAssociation" );
+				fail( "Invoking join() for a subtype attribute on a supertype root should not be allowed" );
+			}
+			catch (Exception e) {
+				assertThat( e ).isInstanceOf( PathElementException.class ).hasMessageContaining( "Could not resolve attribute" );
+			}
+		} );
+		// child root
+		scope.inTransaction( entityManager -> {
+			final CriteriaBuilder cb = entityManager.getCriteriaBuilder();
+			final CriteriaQuery<ChildEntity> cq = cb.createQuery( ChildEntity.class );
+			final Root<ChildEntity> child = cq.from( ChildEntity.class );
+			child.join( "childAssociation" );
+			assertResult( entityManager.createQuery( cq ).getResultList(), 1, "childAssociation", false );
+		} );
+		// parent root treat as child
+		scope.inTransaction( entityManager -> {
+			final CriteriaBuilder cb = entityManager.getCriteriaBuilder();
+			final CriteriaQuery<ChildEntity> cq = cb.createQuery( ChildEntity.class );
+			final Root<ParentEntity> parent = cq.from( ParentEntity.class );
+			final Root<ChildEntity> treated = cb.treat( parent, ChildEntity.class );
+			cq.select( treated );
+			treated.join( "childAssociation" );
+			assertResult( entityManager.createQuery( cq ).getResultList(), 1, "childAssociation", false );
+		} );
+	}
+
+	@Test
+	public void testFetchParentAttribute(EntityManagerFactoryScope scope) {
+		// parent root
+		scope.inTransaction( entityManager -> {
+			final CriteriaBuilder cb = entityManager.getCriteriaBuilder();
+			final CriteriaQuery<ParentEntity> cq = cb.createQuery( ParentEntity.class );
+			final Root<ParentEntity> parent = cq.from( ParentEntity.class );
+			parent.fetch( "association" );
+			assertResult( entityManager.createQuery( cq ).getResultList(), 2, "association", true );
+		} );
+		// child root
+		scope.inTransaction( entityManager -> {
+			final CriteriaBuilder cb = entityManager.getCriteriaBuilder();
+			final CriteriaQuery<ChildEntity> cq = cb.createQuery( ChildEntity.class );
+			final Root<ChildEntity> child = cq.from( ChildEntity.class );
+			child.fetch( "association" );
+			assertResult( entityManager.createQuery( cq ).getResultList(), 1, "association", true );
+		} );
+	}
+
+	@Test
+	public void testFetchSubtypeAttribute(EntityManagerFactoryScope scope) {
+		// parent root
+		scope.inTransaction( entityManager -> {
+			final CriteriaBuilder cb = entityManager.getCriteriaBuilder();
+			final CriteriaQuery<ParentEntity> cq = cb.createQuery( ParentEntity.class );
+			final Root<ParentEntity> parent = cq.from( ParentEntity.class );
+			try {
+				parent.fetch( "childAssociation" );
+				fail( "Invoking fetch() for a subtype attribute on a supertype root should not be allowed" );
+			}
+			catch (Exception e) {
+				assertThat( e ).isInstanceOf( PathElementException.class ).hasMessageContaining( "Could not resolve attribute" );
+			}
+		} );
+		// child root
+		scope.inTransaction( entityManager -> {
+			final CriteriaBuilder cb = entityManager.getCriteriaBuilder();
+			final CriteriaQuery<ChildEntity> cq = cb.createQuery( ChildEntity.class );
+			final Root<ChildEntity> child = cq.from( ChildEntity.class );
+			child.fetch( "childAssociation" );
+			assertResult( entityManager.createQuery( cq ).getResultList(), 1, "childAssociation", true );
+		} );
+		// parent root treat as child
+		scope.inTransaction( entityManager -> {
+			final CriteriaBuilder cb = entityManager.getCriteriaBuilder();
+			final CriteriaQuery<ChildEntity> cq = cb.createQuery( ChildEntity.class );
+			final Root<ParentEntity> parent = cq.from( ParentEntity.class );
+			final Root<ChildEntity> treated = cb.treat( parent, ChildEntity.class );
+			cq.select( treated );
+			treated.fetch( "childAssociation" );
+			assertResult( entityManager.createQuery( cq ).getResultList(), 1, "childAssociation", true );
+		} );
+	}
+
+	private void assertResult(
+			final List<? extends ParentEntity> result,
+			int size,
+			String attributeName,
+			boolean initialized) {
+		assertThat( result ).hasSize( size )
+				.extracting( attributeName )
+				.allMatch( r -> Hibernate.isInitialized( r ) || !initialized );
+		if ( size == 1 ) {
+			assertThat( result.get( 0 ) ).isExactlyInstanceOf( ChildEntity.class );
+		}
+	}
+
+	@BeforeAll
+	public void setUp(EntityManagerFactoryScope scope) {
+		scope.inTransaction( entityManager -> {
+			final AssociatedEntity associated1 = new AssociatedEntity( 1L, "associated_1" );
+			entityManager.persist( associated1 );
+			final AssociatedEntity associated2 = new AssociatedEntity( 2L, "associated_2" );
+			entityManager.persist( associated2 );
+			entityManager.persist( new ChildEntity( associated1, "child", associated2, 2 ) );
+			final AssociatedEntity associated3 = new AssociatedEntity( 3L, "associated_3" );
+			entityManager.persist( associated3 );
+			entityManager.persist( new ParentEntity( associated3, "parent" ) );
+		} );
+	}
+
+	@AfterAll
+	public void tearDown(EntityManagerFactoryScope scope) {
+		scope.getEntityManagerFactory().unwrap( SessionFactory.class ).getSchemaManager().truncateMappedObjects();
+	}
+
+	@Entity( name = "ParentEntity" )
+	static class ParentEntity {
+		@Id
+		@GeneratedValue
+		private Long id;
+
+		@ManyToOne( fetch = FetchType.LAZY )
+		private AssociatedEntity association;
+
+		private String name;
+
+		public ParentEntity() {
+		}
+
+		public ParentEntity(AssociatedEntity association, String name) {
+			this.name = name;
+			this.association = association;
+		}
+
+		public String getName() {
+			return name;
+		}
+	}
+
+	@Entity( name = "ChildEntity" )
+	static class ChildEntity extends ParentEntity {
+		@ManyToOne( fetch = FetchType.LAZY )
+		private AssociatedEntity childAssociation;
+
+		@Column( name = "age_col" )
+		private Integer age;
+
+		public ChildEntity() {
+		}
+
+		public ChildEntity(AssociatedEntity association, String name, AssociatedEntity childAssociation, Integer age) {
+			super( association, name );
+			this.childAssociation = childAssociation;
+			this.age = age;
+		}
+
+		public AssociatedEntity getChildAssociation() {
+			return childAssociation;
+		}
+	}
+
+	@Entity( name = "AssociatedEntity" )
+	@Table( name = "association_test" )
+	static class AssociatedEntity {
+		@Id
+		private Long id;
+
+		private String name;
+
+		public AssociatedEntity() {
+		}
+
+		public AssociatedEntity(Long id, String name) {
+			this.id = id;
+			this.name = name;
+		}
+
+		public String getName() {
+			return name;
+		}
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/query/CorrelatedPluralJoinInheritanceTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/query/CorrelatedPluralJoinInheritanceTest.java
@@ -99,12 +99,15 @@ public class CorrelatedPluralJoinInheritanceTest {
 	}
 
 	@Test
-	public void testImplicitTreat(EntityManagerFactoryScope scope) {
+	public void testExplicitTreat(EntityManagerFactoryScope scope) {
 		scope.inTransaction( entityManager -> {
 			final CriteriaBuilder cb = entityManager.getCriteriaBuilder();
 			final CriteriaQuery<ContinuousData> criteriaQuery = cb.createQuery( ContinuousData.class );
 			final Root<ContinuousData> root = criteriaQuery.from( ContinuousData.class );
-			criteriaQuery.where( createExistsPredicate( root, criteriaQuery, cb, "storedTags" ) );
+			final Subquery<String> subquery = criteriaQuery.subquery( String.class );
+			final Root<ContinuousData> root2 = subquery.correlate( root );
+			subquery.select( root2.get( "id" ) ).where( cb.treat( root2, StoredContinuousData.class ).join( "storedTags" ).get( "id" ).in( "a", "b" ) );
+			criteriaQuery.where( cb.exists( subquery ) );
 			final List<ContinuousData> resultList = entityManager.createQuery( criteriaQuery ).getResultList();
 			assertThat( resultList ).hasSize( 1 );
 		} );

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/inheritance/discriminator/DiscriminatorTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/inheritance/discriminator/DiscriminatorTest.java
@@ -177,7 +177,7 @@ public class DiscriminatorTest {
 					CriteriaBuilder criteriaBuilder = s.getCriteriaBuilder();
 					CriteriaQuery<Person> criteria = criteriaBuilder.createQuery( Person.class );
 					Root<Person> root = criteria.from( Person.class );
-					criteria.where( criteriaBuilder.gt( root.get( "salary" ), new BigDecimal( 100 ) ) );
+					criteria.where( criteriaBuilder.gt( criteriaBuilder.treat( root, Employee.class ).get( "salary" ), new BigDecimal( 100 ) ) );
 					result = s.createQuery( criteria ).list();
 //					result = s.createCriteria(Person.class)
 //							.add( Property.forName( "salary").gt( new BigDecimal( 100) ) )

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/inheritance/discriminator/SimpleInheritanceTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/inheritance/discriminator/SimpleInheritanceTest.java
@@ -182,7 +182,7 @@ public class SimpleInheritanceTest {
 					CriteriaBuilder criteriaBuilder = s.getCriteriaBuilder();
 					CriteriaQuery<Person> criteria = criteriaBuilder.createQuery( Person.class );
 					Root<Person> root = criteria.from( Person.class );
-					criteria.where( criteriaBuilder.gt( root.get( "salary" ), new BigDecimal( 100 ) ) );
+					criteria.where( criteriaBuilder.gt( criteriaBuilder.treat( root, Employee.class ).get( "salary" ), new BigDecimal( 100 ) ) );
 
 					result = s.createQuery( criteria ).list();
 //					result = s.createCriteria( Person.class )

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/query/criteria/CriteriaInheritanceJoinTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/query/criteria/CriteriaInheritanceJoinTest.java
@@ -92,7 +92,7 @@ public class CriteriaInheritanceJoinTest {
 			final CriteriaBuilder cb = session.getCriteriaBuilder();
 			final CriteriaQuery<Address> cq = cb.createQuery( Address.class );
 			final Root<Address> addressRoot = cq.from( Address.class );
-			final Join<Address, Street> join = addressRoot.join( "street" );
+			final Join<Address, Street> join = cb.treat( addressRoot, StreetAddress.class ).join( "street" );
 			cq.select( addressRoot ).where( cb.equal( join.get( "name" ), "Via Roma" ) );
 			final Address result = session.createQuery( cq ).getSingleResult();
 			assertThat( result ).isInstanceOf( StreetAddress.class );

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/unionsubclass2/UnionSubclassTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/unionsubclass2/UnionSubclassTest.java
@@ -160,7 +160,7 @@ public class UnionSubclassTest {
 					CriteriaBuilder criteriaBuilder = s.getCriteriaBuilder();
 					CriteriaQuery<Person> criteria = criteriaBuilder.createQuery( Person.class );
 					Root<Person> root = criteria.from( Person.class );
-					criteria.where( criteriaBuilder.gt( root.get( "salary" ), new BigDecimal( 100 ) ) );
+					criteria.where( criteriaBuilder.gt( criteriaBuilder.treat( root, Employee.class ).get( "salary" ), new BigDecimal( 100 ) ) );
 
 					result = s.createQuery( criteria ).list();
 

--- a/migration-guide.adoc
+++ b/migration-guide.adoc
@@ -318,6 +318,13 @@ must be explicitly set to true.
 
 The signature of the `Configurable#configure` method changed from accepting just a `ServiceRegistry` instance to the new `GeneratorCreationContext` interface, which exposes a lot more useful information when configuring the generator itself. The old signature has been deprecated for removal, so you should migrate any custom `Configurable` generator implementation to the new one.
 
+[[criteria-implicit-treat]]
+== Criteria API and inheritance subtypes attributes
+
+It was previously possible to use the string version of the `jakarta.persistence.criteria.Path#get` and `jakarta.persistence.criteria.From#join` methods with names of attributes defined in an inheritance subtype of the type represented by the path expression. This was handled internally by implicitly treating the path as the subtype which defines said attribute. Since Hibernate 7.0, the Criteria API will no longer allow retrieving subtype attributes this way, and it's going to require an explicit `jakarta.persistence.criteria.CriteriaBuilder#treat` to be called on the path first to downcast it to the subtype which defines the attribute.
+
+Implicit treats are still going to be applied when an HQL query dereferences a path belonging to an inheritance subtype.
+
 [[hbm-transform]]
 == hbm.xml Transformation
 


### PR DESCRIPTION
<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

https://hibernate.atlassian.net/browse/HHH-18569

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
