### PR TITLE
HHH-18679 throw exception when columnValues is null while addKeyColumn

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/exception/MissingAttributeException.java
+++ b/hibernate-core/src/main/java/org/hibernate/exception/MissingAttributeException.java
@@ -1,0 +1,29 @@
+/*
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.exception;
+
+import org.hibernate.HibernateException;
+
+/**
+ * An attribute required, but it is missing.
+ * There are a number of possible underlying causes, including:
+ * <ul>
+ * <li>Missing annotation attribute,
+ * <li>Missing configuration
+ * </ul>
+ *
+ * @author Bao Ngo
+ */
+public class MissingAttributeException extends HibernateException {
+
+	/**
+	 * Constructs a {@code MissingAttributeException} using the given exception message.
+	 *
+	 * @param message The message explaining the reason for the exception
+	 */
+	public MissingAttributeException(String message) {
+		super( message );
+	}
+}

--- a/hibernate-core/src/main/java/org/hibernate/persister/entity/mutation/EntityTableMapping.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/entity/mutation/EntityTableMapping.java
@@ -410,5 +410,10 @@ public class EntityTableMapping implements TableMapping {
 		public String getCustomWriteExpression() {
 			return null;
 		}
+
+		@Override
+		public String toString() {
+			return "{%s - %s}".formatted( tableName, columnName );
+		}
 	}
 }

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/persister/entity/InvalidMutationOperationGroupTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/persister/entity/InvalidMutationOperationGroupTest.java
@@ -1,0 +1,56 @@
+/*
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.persister.entity;
+
+import org.hibernate.annotations.Generated;
+
+import org.hibernate.dialect.H2Dialect;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.RequiresDialect;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+
+import org.junit.jupiter.api.Test;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import org.assertj.core.api.Assertions;
+
+/**
+ * @author Bao Ngo
+ */
+@SessionFactory
+@DomainModel(
+		annotatedClasses = InvalidMutationOperationGroupTest.GeneratedWithWritableAndNullSqlOnIdEntity.class
+)
+@RequiresDialect(H2Dialect.class)
+public class InvalidMutationOperationGroupTest {
+
+	@Test
+	public void testGenerateStaticOperationGroupInvalidCase(SessionFactoryScope scope) {
+		Assertions.assertThatThrownBy( () -> scope.inTransaction( session -> {} ))
+				.getCause()
+				.hasMessageStartingWith( "Column value is missing. Could not generate value for" );
+	}
+
+	@Entity
+	@Table(name = "DUMMY1")
+	static class GeneratedWithWritableAndNullSqlOnIdEntity {
+
+		@Id
+		@Generated(writable = true)
+		private Long id;
+
+		public Long getId() {
+			return id;
+		}
+
+		public void setId(Long id) {
+			this.id = id;
+		}
+	}
+
+}


### PR DESCRIPTION
<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

Currently, the code will throw NPE when annotating the id with `@Generated(writable = true)` WITHOUT sql attribute
This fix is about throwing a dedicated exception instead of NPE as we can not handle any further.

![image](https://github.com/user-attachments/assets/47735aa2-b6a4-49a1-8ec6-53f66d1bff3e)
Note: I'm a new contributor, so my code might be bad. Please give me advices/suggestions if the PR is so stupid, I will do my best to fix it. Thank you so much


<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-18679
<!-- Hibernate GitHub Bot issue links end -->