### PR TITLE
HHH-18679 Allow @Generated(writeble=true) on id properties to use assigned identifiers

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/generator/internal/GeneratedGeneration.java
+++ b/hibernate-core/src/main/java/org/hibernate/generator/internal/GeneratedGeneration.java
@@ -6,8 +6,11 @@ package org.hibernate.generator.internal;
 
 import org.hibernate.annotations.Generated;
 import org.hibernate.dialect.Dialect;
+import org.hibernate.engine.spi.SharedSessionContractImplementor;
+import org.hibernate.generator.BeforeExecutionGenerator;
 import org.hibernate.generator.EventType;
 import org.hibernate.generator.OnExecutionGenerator;
+import org.hibernate.persister.entity.EntityPersister;
 
 import java.util.EnumSet;
 
@@ -23,7 +26,7 @@ import static org.hibernate.internal.util.StringHelper.isEmpty;
  * @author Steve Ebersole
  * @author Gunnar Morling
  */
-public class GeneratedGeneration implements OnExecutionGenerator {
+public class GeneratedGeneration implements OnExecutionGenerator, BeforeExecutionGenerator {
 
 	private final EnumSet<EventType> eventTypes;
 	private final boolean writable;
@@ -59,5 +62,33 @@ public class GeneratedGeneration implements OnExecutionGenerator {
 	@Override
 	public boolean writePropertyValue() {
 		return writable && sql==null;
+	}
+
+	@Override
+	public boolean generatedOnExecution() {
+		return true;
+	}
+
+	@Override
+	public boolean generatedOnExecution(Object entity, SharedSessionContractImplementor session) {
+		if ( !writable ) {
+			return true;
+		}
+
+		// When this is the identifier generator and writable is true, allow pre-assigned identifiers
+		final EntityPersister entityPersister = session.getEntityPersister( null, entity );
+		return entityPersister.getGenerator() != this || entityPersister.getIdentifier( entity, session ) == null;
+	}
+
+	@Override
+	public Object generate(SharedSessionContractImplementor session, Object owner, Object currentValue, EventType eventType) {
+		final EntityPersister entityPersister = session.getEntityPersister( null, owner );
+		assert entityPersister.getGenerator() == this;
+		return entityPersister.getIdentifier( owner, session );
+	}
+
+	@Override
+	public boolean allowAssignedIdentifiers() {
+		return writable;
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/persister/entity/mutation/InsertCoordinatorStandard.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/entity/mutation/InsertCoordinatorStandard.java
@@ -24,6 +24,7 @@ import org.hibernate.generator.Generator;
 import org.hibernate.generator.OnExecutionGenerator;
 import org.hibernate.generator.values.GeneratedValues;
 import org.hibernate.generator.values.GeneratedValuesMutationDelegate;
+import org.hibernate.id.IdentifierGenerationException;
 import org.hibernate.metamodel.mapping.AttributeMapping;
 import org.hibernate.metamodel.mapping.AttributeMappingsList;
 import org.hibernate.metamodel.mapping.BasicEntityIdentifierMapping;
@@ -433,11 +434,13 @@ public class InsertCoordinatorStandard extends AbstractMutationCoordinator imple
 				if ( generator.referenceColumnsInSql( dialect ) ) {
 					final BasicEntityIdentifierMapping identifierMapping = (BasicEntityIdentifierMapping) entityPersister().getIdentifierMapping();
 					final String[] columnValues = generator.getReferencedColumnValues( dialect );
-					tableMapping.getKeyMapping().forEachKeyColumn( (i, column) -> tableInsertBuilder.addKeyColumn(
-							column.getColumnName(),
-							columnValues[i],
-							identifierMapping.getJdbcMapping()
-					) );
+					if ( columnValues != null ) {
+						tableMapping.getKeyMapping().forEachKeyColumn( (i, column) -> tableInsertBuilder.addKeyColumn(
+								column.getColumnName(),
+								columnValues[i],
+								identifierMapping.getJdbcMapping()
+						) );
+					}
 				}
 			}
 			else {

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/generated/GeneratedWritableIdTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/generated/GeneratedWritableIdTest.java
@@ -1,0 +1,80 @@
+/*
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.mapping.generated;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import org.hibernate.annotations.ColumnDefault;
+import org.hibernate.annotations.Generated;
+import org.hibernate.dialect.H2Dialect;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.Jira;
+import org.hibernate.testing.orm.junit.RequiresDialect;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Marco Belladelli
+ */
+@DomainModel(annotatedClasses = GeneratedWritableIdTest.TestEntity.class)
+@SessionFactory
+@Jira("https://hibernate.atlassian.net/browse/HHH-18679")
+@RequiresDialect(H2Dialect.class)
+public class GeneratedWritableIdTest {
+	@Test
+	public void testDefaultId(SessionFactoryScope scope) {
+		scope.inTransaction( session -> {
+			final TestEntity entity = new TestEntity( null, "entity_1" );
+			session.persist( entity );
+			session.flush();
+			assertThat( entity.getId() ).isEqualTo( 1L );
+		} );
+	}
+
+	@Test
+	public void testAssignedId(SessionFactoryScope scope) {
+		scope.inTransaction( session -> {
+			final TestEntity entity = new TestEntity( 2L, "entity_2" );
+			session.persist( entity );
+			session.flush();
+			assertThat( entity.getId() ).isEqualTo( 2L );
+		} );
+	}
+
+	@AfterAll
+	public void tearDown(SessionFactoryScope scope) {
+		scope.getSessionFactory().getSchemaManager().truncateMappedObjects();
+	}
+
+	@Entity(name = "TestEntity")
+	static class TestEntity {
+		@Id
+		@Generated(writable = true)
+		@ColumnDefault("1")
+		private Long id;
+
+		private String name;
+
+		public TestEntity() {
+		}
+
+		public TestEntity(Long id, String name) {
+			this.id = id;
+			this.name = name;
+		}
+
+		public Long getId() {
+			return id;
+		}
+
+		public String getName() {
+			return name;
+		}
+	}
+}


### PR DESCRIPTION
<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

https://hibernate.atlassian.net/browse/HHH-18679

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
