### PR TITLE
HHH-18714 add support for inheritance in entity graph

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/graph/internal/AbstractGraph.java
+++ b/hibernate-core/src/main/java/org/hibernate/graph/internal/AbstractGraph.java
@@ -19,23 +19,28 @@ import org.hibernate.graph.SubGraph;
 import org.hibernate.graph.spi.AttributeNodeImplementor;
 import org.hibernate.graph.spi.GraphImplementor;
 import org.hibernate.graph.spi.RootGraphImplementor;
+import org.hibernate.graph.spi.SubGraphImplementor;
 import org.hibernate.metamodel.model.domain.EntityDomainType;
 import org.hibernate.metamodel.model.domain.ManagedDomainType;
 import org.hibernate.metamodel.model.domain.PersistentAttribute;
+import org.hibernate.metamodel.model.domain.internal.DomainModelHelper;
 import org.hibernate.query.sqm.SqmPathSource;
 
 import jakarta.persistence.metamodel.Attribute;
 
 import static java.util.Collections.emptyList;
+import static java.util.Collections.emptyMap;
 
 /**
- *  Base class for {@link RootGraph} and {@link SubGraph} implementations.
+ * Base class for {@link RootGraph} and {@link SubGraph} implementations.
  *
  * @author Steve Ebersole
  */
 public abstract class AbstractGraph<J> extends AbstractGraphNode<J> implements GraphImplementor<J> {
 	private final ManagedDomainType<J> managedType;
-	private Map<PersistentAttribute<?,?>, AttributeNodeImplementor<?>> attrNodeMap;
+
+	private Map<PersistentAttribute<?, ?>, AttributeNodeImplementor<?>> attrNodeMap;
+	private Map<Class<? extends J>, SubGraphImplementor<? extends J>> subclassSubgraphs;
 
 	public AbstractGraph(ManagedDomainType<J> managedType, boolean mutable) {
 		super( mutable );
@@ -45,12 +50,50 @@ public abstract class AbstractGraph<J> extends AbstractGraphNode<J> implements G
 	protected AbstractGraph(GraphImplementor<J> original, boolean mutable) {
 		this( original.getGraphedType(), mutable );
 		this.attrNodeMap = new ConcurrentHashMap<>( original.getAttributeNodeList().size() );
+		this.subclassSubgraphs = Map.copyOf( original.getSubclassSubgraphs() );
 		original.visitAttributeNodes(
 				node -> attrNodeMap.put(
 						node.getAttributeDescriptor(),
 						node.makeCopy( mutable )
 				)
 		);
+	}
+
+	@Override
+	public Map<Class<? extends J>, SubGraphImplementor<? extends J>> getSubclassSubgraphs() {
+		return subclassSubgraphs == null ? emptyMap() : subclassSubgraphs;
+	}
+
+	@Override
+	public <S extends J> SubGraphImplementor<S> getSubclassSubgraph(Class<S> subtype) {
+		return subclassSubgraphs == null ? null : (SubGraphImplementor) subclassSubgraphs.get( subtype );
+	}
+
+	@Override
+	public <S extends J> SubGraphImplementor<S> addTreatedSubgraph(Class<S> subType) {
+		if ( subclassSubgraphs == null ) {
+			this.subclassSubgraphs = new HashMap<>();
+		}
+
+		final SubGraphImplementor<S> existingSubgraph = (SubGraphImplementor) subclassSubgraphs.get( subType );
+
+		if ( existingSubgraph != null ) {
+			return existingSubgraph;
+		}
+
+		ManagedDomainType<S> subTypeEntityDomainType = DomainModelHelper.findSubType( this.managedType, subType );
+
+		SubGraphImplementor<S> subgraph = new SubGraphImpl<S>( subTypeEntityDomainType, (GraphImplementor) this, true );
+
+		subclassSubgraphs.put( subType, subgraph );
+
+		return subgraph;
+	}
+
+	@Override
+	public <Y> SubGraphImplementor<Y> addTreatedSubgraph(Attribute<? super J, ? super Y> attribute, Class<Y> type) {
+		AttributeNodeImplementor<Y> attributeNode = findOrCreateAttributeNode( attribute.getName() );
+		return attributeNode.makeSubGraph( type );
 	}
 
 	@Override
@@ -61,7 +104,7 @@ public abstract class AbstractGraph<J> extends AbstractGraphNode<J> implements G
 	@Override
 	public RootGraphImplementor<J> makeRootGraph(String name, boolean mutable) {
 		if ( getGraphedType() instanceof EntityDomainType ) {
-			return new RootGraphImpl<>( name, this, mutable);
+			return new RootGraphImpl<>( name, this, mutable );
 		}
 
 		throw new CannotBecomeEntityGraphException(
@@ -76,9 +119,24 @@ public abstract class AbstractGraph<J> extends AbstractGraphNode<J> implements G
 			return;
 		}
 
+		other
+				.getSubclassSubgraphs()
+				.forEach( (otherSubType, otherSubTypeSubgraph) -> {
+
+					var alreadyExistingSubtypeSubgraph = subclassSubgraphs.get( otherSubType );
+					if ( alreadyExistingSubtypeSubgraph == null ) {
+						subclassSubgraphs.put( otherSubType, otherSubTypeSubgraph );
+					}
+					else {
+						alreadyExistingSubtypeSubgraph.merge( (GraphImplementor) otherSubTypeSubgraph );
+					}
+
+				} );
+
+
 		for ( AttributeNodeImplementor<?> attributeNode : other.getAttributeNodeImplementors() ) {
 			final AttributeNodeImplementor<?> localAttributeNode = findAttributeNode(
-					(PersistentAttribute<? super J,?>) attributeNode.getAttributeDescriptor()
+					(PersistentAttribute<? super J, ?>) attributeNode.getAttributeDescriptor()
 			);
 			if ( localAttributeNode != null ) {
 				// keep the local one, but merge in the incoming one
@@ -146,8 +204,8 @@ public abstract class AbstractGraph<J> extends AbstractGraphNode<J> implements G
 			attrNodeMap.put( incomingAttributeNode.getAttributeDescriptor(), attributeNode );
 		}
 		else {
-			@SuppressWarnings("rawtypes")
-			final AttributeNodeImplementor attributeNodeFinal = attributeNode;
+			@SuppressWarnings("rawtypes") final AttributeNodeImplementor attributeNodeFinal = attributeNode;
+			attributeNodeFinal.getSubgraph().merge( this );
 			incomingAttributeNode.visitSubGraphs(
 					// we assume the subGraph has been properly copied if needed
 					(subType, subGraph) -> attributeNodeFinal.addSubGraph( subGraph )
@@ -161,7 +219,7 @@ public abstract class AbstractGraph<J> extends AbstractGraphNode<J> implements G
 	@SuppressWarnings("unchecked")
 	public <AJ> AttributeNodeImplementor<AJ> findAttributeNode(String attributeName) {
 		PersistentAttribute<? super J, ?> attribute = managedType.findAttributeInSuperTypes( attributeName );
-		if ( attribute instanceof SqmPathSource && ( (SqmPathSource<?>) attribute ).isGeneric() ) {
+		if ( attribute instanceof SqmPathSource && ((SqmPathSource<?>) attribute).isGeneric() ) {
 			attribute = managedType.findConcreteGenericAttribute( attributeName );
 		}
 		return attribute == null ? null : findAttributeNode( (PersistentAttribute<? super J, AJ>) attribute );
@@ -185,7 +243,8 @@ public abstract class AbstractGraph<J> extends AbstractGraphNode<J> implements G
 	}
 
 	@Override
-	public <AJ> AttributeNodeImplementor<AJ> addAttributeNode(String attributeName) throws CannotContainSubGraphException {
+	public <AJ> AttributeNodeImplementor<AJ> addAttributeNode(String attributeName)
+			throws CannotContainSubGraphException {
 		return findOrCreateAttributeNode( attributeName );
 	}
 
@@ -208,7 +267,8 @@ public abstract class AbstractGraph<J> extends AbstractGraphNode<J> implements G
 		}
 	}
 
-	@Override @SafeVarargs
+	@Override
+	@SafeVarargs
 	public final void addAttributeNodes(Attribute<? super J, ?>... attributes) {
 		for ( int i = 0; i < attributes.length; i++ ) {
 			addAttributeNode( attributes[i] );
@@ -245,7 +305,7 @@ public abstract class AbstractGraph<J> extends AbstractGraphNode<J> implements G
 		}
 
 		if ( attrNode == null ) {
-			attrNode = new AttributeNodeImpl<>(attribute, isMutable());
+			attrNode = new AttributeNodeImpl<>( attribute, isMutable() );
 			attrNodeMap.put( attribute, attrNode );
 		}
 

--- a/hibernate-core/src/main/java/org/hibernate/graph/internal/AttributeNodeImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/graph/internal/AttributeNodeImpl.java
@@ -4,6 +4,7 @@
  */
 package org.hibernate.graph.internal;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
@@ -20,6 +21,7 @@ import org.hibernate.metamodel.model.domain.PersistentAttribute;
 import org.hibernate.metamodel.model.domain.SimpleDomainType;
 
 import org.hibernate.metamodel.model.domain.internal.DomainModelHelper;
+
 import org.jboss.logging.Logger;
 
 import static java.util.Collections.emptyMap;
@@ -35,11 +37,12 @@ public class AttributeNodeImpl<J>
 		implements AttributeNodeImplementor<J> {
 	private final PersistentAttribute<?, J> attribute;
 
-	private Map<Class<? extends J>, SubGraphImplementor<? extends J>> subGraphMap;
 	private Map<Class<? extends J>, SubGraphImplementor<? extends J>> keySubGraphMap;
+	private SubGraphImplementor<J> subgraph;
+
 
 	public <X> AttributeNodeImpl(PersistentAttribute<X, J> attribute, boolean mutable) {
-		this(attribute, null, null, mutable);
+		this( attribute, null, null, mutable );
 	}
 
 	/**
@@ -47,12 +50,12 @@ public class AttributeNodeImpl<J>
 	 */
 	private AttributeNodeImpl(
 			PersistentAttribute<?, J> attribute,
-			Map<Class<? extends J>, SubGraphImplementor<? extends J>> subGraphMap,
+			SubGraphImplementor<J> subgraph,
 			Map<Class<? extends J>, SubGraphImplementor<? extends J>> keySubGraphMap,
 			boolean mutable) {
 		super( mutable );
 		this.attribute = attribute;
-		this.subGraphMap = subGraphMap;
+		this.subgraph = subgraph;
 		this.keySubGraphMap = keySubGraphMap;
 	}
 
@@ -68,7 +71,24 @@ public class AttributeNodeImpl<J>
 
 	@Override
 	public Map<Class<? extends J>, SubGraphImplementor<? extends J>> getSubGraphMap() {
-		return subGraphMap == null ? emptyMap() : subGraphMap;
+		if ( this.subgraph == null ) {
+			return emptyMap();
+		}
+
+		var subclassSubgraphs = subgraph.getSubclassSubgraphs();
+
+		if ( subclassSubgraphs.isEmpty() ) {
+			return Collections.singletonMap( subgraph.getClassType(), subgraph );
+		}
+
+		subclassSubgraphs.put( subgraph.getClassType(), subgraph );
+
+		return subclassSubgraphs;
+	}
+
+	@Override
+	public SubGraphImplementor<J> getSubgraph() {
+		return subgraph;
 	}
 
 	@Override
@@ -91,12 +111,21 @@ public class AttributeNodeImpl<J>
 		return internalMakeSubgraph( subtype );
 	}
 
+	@SuppressWarnings({"unchecked"})
 	private <S extends J> SubGraphImplementor<S> internalMakeSubgraph(ManagedDomainType<S> type) {
 		assert type != null;
+
 		log.debugf( "Making sub-graph : ( (%s) %s )", type.getTypeName(), getAttributeName() );
-		final SubGraphImplementor<S> subGraph = DomainModelHelper.makeSubGraph( type, type.getBindableJavaType() );
-		internalAddSubGraph( subGraph );
-		return subGraph;
+
+		if ( this.subgraph == null ) {
+			this.subgraph = new SubGraphImpl<>( valueGraphTypeAsManaged(), true );
+		}
+
+		if ( type.equals( valueGraphTypeAsManaged() ) ) {
+			return (SubGraphImplementor<S>) this.subgraph;
+		}
+
+		return this.subgraph.addTreatedSubgraph( type.getJavaType() );
 	}
 
 	@SuppressWarnings("unchecked")
@@ -122,17 +151,29 @@ public class AttributeNodeImpl<J>
 	private <S extends J> SubGraphImplementor<S> internalMakeSubgraph(Class<S> subType) {
 		verifyMutability();
 		final ManagedDomainType<S> managedType = valueGraphTypeAsManaged();
-		return internalMakeSubgraph( findSubType( managedType, subType == null ? managedType.getJavaType() : subType ) );
+		return internalMakeSubgraph( findSubType(
+				managedType,
+				subType == null ? managedType.getJavaType() : subType
+		) );
 	}
 
-	protected void internalAddSubGraph(SubGraphImplementor<? extends J> subGraph) {
+	protected <S extends J> void internalAddSubGraph(SubGraphImplementor<S> subGraph) {
 		log.tracef( "Adding sub-graph : ( (%s) %s )", subGraph.getGraphedType().getTypeName(), getAttributeName() );
-		if ( subGraphMap == null ) {
-			subGraphMap = new HashMap<>();
+
+		if ( this.subgraph == null ) {
+			this.subgraph = new SubGraphImpl<>( valueGraphTypeAsManaged(), true );
 		}
-		final SubGraphImplementor<? extends J> previous = subGraphMap.put( subGraph.getClassType(), subGraph );
-		if ( previous != null ) {
-			log.debugf( "Adding sub-graph [%s] over-wrote existing [%s]", subGraph, previous );
+
+		ManagedDomainType<S> incomingSubGraphType = subGraph.getGraphedType();
+
+		if ( incomingSubGraphType.equals( this.subgraph.getGraphedType() ) ) {
+			this.subgraph.merge( subGraph );
+			return;
+		}
+
+		if ( this.subgraph.getGraphedType().getSubTypes().contains( incomingSubGraphType ) ) {
+			var subclassSubgraph = this.subgraph.addTreatedSubgraph( incomingSubGraphType.getBindableJavaType() );
+			subclassSubgraph.merge( subGraph );
 		}
 	}
 
@@ -218,7 +259,10 @@ public class AttributeNodeImpl<J>
 	@Override
 	public AttributeNodeImplementor<J> makeCopy(boolean mutable) {
 		return new AttributeNodeImpl<>(
-				this.attribute, makeMapCopy( mutable, subGraphMap ), makeMapCopy( mutable, keySubGraphMap ), mutable
+				this.attribute,
+				this.subgraph == null ? null : this.subgraph.makeCopy( mutable ),
+				makeMapCopy( mutable, keySubGraphMap ),
+				mutable
 		);
 	}
 
@@ -230,32 +274,22 @@ public class AttributeNodeImpl<J>
 		}
 		else {
 			return nodeMap.entrySet().stream()
-					.map(entry -> Map.entry( entry.getKey(), entry.getValue().makeCopy( mutable ) ))
-					.collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+					.map( entry -> Map.entry( entry.getKey(), entry.getValue().makeCopy( mutable ) ) )
+					.collect( Collectors.toMap( Map.Entry::getKey, Map.Entry::getValue ) );
 		}
 	}
 
 	@Override
+	@SuppressWarnings({"unchecked", "rawtypes"})
 	public void merge(AttributeNodeImplementor<?> attributeNode) {
-		attributeNode.visitSubGraphs(
-				(incomingSubType, incomingGraph) -> {
-					SubGraphImplementor<?> existing;
-					if ( subGraphMap == null ) {
-						subGraphMap = new HashMap<>();
-						existing = null;
-					}
-					else {
-						existing = subGraphMap.get( incomingSubType );
-					}
 
-					if ( existing != null ) {
-						existing.merge( (GraphImplementor) incomingGraph );
-					}
-					else {
-						internalAddSubGraph( (SubGraphImplementor) incomingGraph.makeCopy( true ) );
-					}
-				}
-		);
+
+		if ( this.subgraph != null ) {
+			this.subgraph.merge( (SubGraphImplementor) attributeNode.getSubgraph() );
+		}
+		else {
+			this.subgraph = (SubGraphImplementor) attributeNode.getSubgraph();
+		}
 
 		attributeNode.visitKeySubGraphs(
 				(incomingSubType, incomingGraph) -> {

--- a/hibernate-core/src/main/java/org/hibernate/graph/internal/RootGraphImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/graph/internal/RootGraphImpl.java
@@ -10,7 +10,6 @@ import org.hibernate.graph.spi.RootGraphImplementor;
 import org.hibernate.graph.spi.SubGraphImplementor;
 import org.hibernate.metamodel.model.domain.EntityDomainType;
 
-import jakarta.persistence.metamodel.Attribute;
 import jakarta.persistence.metamodel.MapAttribute;
 import jakarta.persistence.metamodel.PluralAttribute;
 
@@ -63,18 +62,6 @@ public class RootGraphImpl<J> extends AbstractGraph<J> implements RootGraphImple
 	}
 
 	@Override
-	public <S extends J> SubGraphImplementor<S> addTreatedSubgraph(Class<S> type) {
-		//noinspection unchecked,rawtypes
-		return new SubGraphImpl(this, false );
-	}
-
-	@Override
-	public <Y> SubGraphImplementor<Y> addTreatedSubgraph(Attribute<? super J, ? super Y> attribute, Class<Y> type) {
-		//noinspection unchecked
-		return (SubGraphImplementor<Y>) super.makeRootGraph( name, false );
-	}
-
-	@Override
 	public <E> SubGraphImplementor<E> addTreatedElementSubgraph(
 			PluralAttribute<? super J, ?, ? super E> attribute,
 			Class<E> type) {
@@ -88,7 +75,7 @@ public class RootGraphImpl<J> extends AbstractGraph<J> implements RootGraphImple
 
 	@Override
 	public <T1> SubGraphImplementor<? extends T1> addSubclassSubgraph(Class<? extends T1> type) {
-		throw new UnsupportedOperationException();
+		return addTreatedSubgraph( (Class) type );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/graph/internal/SubGraphImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/graph/internal/SubGraphImpl.java
@@ -4,10 +4,10 @@
  */
 package org.hibernate.graph.internal;
 
+import org.hibernate.graph.spi.GraphImplementor;
 import org.hibernate.graph.spi.SubGraphImplementor;
 import org.hibernate.metamodel.model.domain.ManagedDomainType;
 
-import jakarta.persistence.metamodel.Attribute;
 import jakarta.persistence.metamodel.MapAttribute;
 import jakarta.persistence.metamodel.PluralAttribute;
 
@@ -18,17 +18,24 @@ import jakarta.persistence.metamodel.PluralAttribute;
  */
 public class SubGraphImpl<J> extends AbstractGraph<J> implements SubGraphImplementor<J> {
 
+	private GraphImplementor<J> parent = null;
+
 	public SubGraphImpl(ManagedDomainType<J> managedType, boolean mutable) {
 		super( managedType, mutable );
 	}
 
 	public SubGraphImpl(AbstractGraph<J> original, boolean mutable) {
-		super(original, mutable);
+		super( original, mutable );
+	}
+
+	protected SubGraphImpl(ManagedDomainType<J> managedType, GraphImplementor<J> parent, boolean mutable) {
+		this( managedType, mutable );
+		this.parent = parent;
 	}
 
 	@Override
 	public SubGraphImplementor<J> makeCopy(boolean mutable) {
-		return new SubGraphImpl<>(this, mutable);
+		return new SubGraphImpl<>( this, mutable );
 	}
 
 	@Override
@@ -39,11 +46,6 @@ public class SubGraphImpl<J> extends AbstractGraph<J> implements SubGraphImpleme
 	@Override
 	public <AJ> SubGraphImplementor<AJ> addKeySubGraph(String attributeName) {
 		return super.addKeySubGraph( attributeName );
-	}
-
-	@Override
-	public <Y> SubGraphImplementor<Y> addTreatedSubgraph(Attribute<? super J, ? super Y> attribute, Class<Y> type) {
-		return null;
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/graph/spi/AttributeNodeImplementor.java
+++ b/hibernate-core/src/main/java/org/hibernate/graph/spi/AttributeNodeImplementor.java
@@ -6,6 +6,7 @@ package org.hibernate.graph.spi;
 
 import java.util.Map;
 import java.util.function.BiConsumer;
+
 import jakarta.persistence.Subgraph;
 
 import org.hibernate.graph.AttributeNode;
@@ -20,7 +21,10 @@ import org.hibernate.metamodel.model.domain.ManagedDomainType;
  */
 public interface AttributeNodeImplementor<J> extends AttributeNode<J>, GraphNodeImplementor<J> {
 	Map<Class<? extends J>, SubGraphImplementor<? extends J>> getSubGraphMap();
+
 	Map<Class<? extends J>, SubGraphImplementor<? extends J>> getKeySubGraphMap();
+
+	SubGraphImplementor<J> getSubgraph();
 
 	default void visitSubGraphs(BiConsumer<Class<? extends J>, SubGraphImplementor<? extends J>> consumer) {
 		getSubGraphMap().forEach( consumer );

--- a/hibernate-core/src/main/java/org/hibernate/graph/spi/GraphImplementor.java
+++ b/hibernate-core/src/main/java/org/hibernate/graph/spi/GraphImplementor.java
@@ -5,6 +5,7 @@
 package org.hibernate.graph.spi;
 
 import java.util.List;
+import java.util.Map;
 import java.util.function.Consumer;
 
 import org.hibernate.graph.AttributeNode;
@@ -27,6 +28,13 @@ public interface GraphImplementor<J> extends Graph<J>, GraphNodeImplementor<J> {
 
 	void merge(GraphImplementor<? extends J> other);
 
+	<S extends J> SubGraphImplementor<S> getSubclassSubgraph(Class<S> subType);
+
+	Map<Class<? extends J>, SubGraphImplementor<? extends J>> getSubclassSubgraphs();
+
+	<S extends J> SubGraphImplementor<S> addTreatedSubgraph(Class<S> subType);
+
+	<Y> SubGraphImplementor<Y> addTreatedSubgraph(Attribute<? super J, ? super Y> attribute, Class<Y> type);
 
 	// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 	// Covariant returns
@@ -88,7 +96,7 @@ public interface GraphImplementor<J> extends Graph<J>, GraphNodeImplementor<J> {
 	@SuppressWarnings("unchecked")
 	default <AJ> AttributeNodeImplementor<AJ> findOrCreateAttributeNode(String name) {
 		PersistentAttribute<? super J, ?> attribute = getGraphedType().getAttribute( name );
-		if ( attribute instanceof SqmPathSource && ( (SqmPathSource<?>) attribute ).isGeneric() ) {
+		if ( attribute instanceof SqmPathSource && ((SqmPathSource<?>) attribute).isGeneric() ) {
 			attribute = getGraphedType().findConcreteGenericAttribute( name );
 		}
 

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/internal/JpaMetamodelImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/internal/JpaMetamodelImpl.java
@@ -9,6 +9,7 @@ import java.io.Serial;
 import java.io.Serializable;
 import java.lang.reflect.Field;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -73,7 +74,6 @@ import static org.hibernate.metamodel.internal.InjectionHelper.injectEntityGraph
 import static org.hibernate.metamodel.internal.InjectionHelper.injectTypedQueryReference;
 
 /**
- *
  * @author Steve Ebersole
  */
 public class JpaMetamodelImpl implements JpaMetamodelImplementor, Serializable {
@@ -106,7 +106,7 @@ public class JpaMetamodelImpl implements JpaMetamodelImplementor, Serializable {
 	private final Map<Class<?>, String> entityProxyInterfaceMap = new HashMap<>();
 
 	private final Map<String, ImportInfo<?>> nameToImportMap = new ConcurrentHashMap<>();
-	private final Map<String,Object> knownInvalidnameToImportMap = new ConcurrentHashMap<>();
+	private final Map<String, Object> knownInvalidnameToImportMap = new ConcurrentHashMap<>();
 
 
 	public JpaMetamodelImpl(
@@ -143,13 +143,14 @@ public class JpaMetamodelImpl implements JpaMetamodelImplementor, Serializable {
 	public <X> ManagedDomainType<X> managedType(String typeName) {
 		final ManagedDomainType<X> managedType = findManagedType( typeName );
 		if ( managedType == null ) {
-			throw new IllegalArgumentException("Not a managed type: " + typeName);
+			throw new IllegalArgumentException( "Not a managed type: " + typeName );
 		}
 		return managedType;
 	}
 
 	@Override
-	@Nullable public EntityDomainType<?> findEntityType(@Nullable String entityName) {
+	@Nullable
+	public EntityDomainType<?> findEntityType(@Nullable String entityName) {
 		if ( entityName == null ) {
 			return null;
 		}
@@ -162,18 +163,19 @@ public class JpaMetamodelImpl implements JpaMetamodelImplementor, Serializable {
 		final EntityDomainType<?> entityType = findEntityType( entityName );
 		if ( entityType == null ) {
 			// per JPA
-			throw new IllegalArgumentException("Not an entity: " + entityName);
+			throw new IllegalArgumentException( "Not an entity: " + entityName );
 		}
 		return entityType;
 	}
 
 	@Override
-	@Nullable public EmbeddableDomainType<?> findEmbeddableType(@Nullable String embeddableName) {
+	@Nullable
+	public EmbeddableDomainType<?> findEmbeddableType(@Nullable String embeddableName) {
 		if ( embeddableName == null ) {
 			return null;
 		}
 		final ManagedDomainType<?> managedType = managedTypeByName.get( embeddableName );
-		if ( !( managedType instanceof EmbeddableDomainType<?> embeddableDomainType) ) {
+		if ( !(managedType instanceof EmbeddableDomainType<?> embeddableDomainType) ) {
 			return null;
 		}
 		return embeddableDomainType;
@@ -183,7 +185,7 @@ public class JpaMetamodelImpl implements JpaMetamodelImplementor, Serializable {
 	public EmbeddableDomainType<?> embeddable(String embeddableName) {
 		final EmbeddableDomainType<?> embeddableType = findEmbeddableType( embeddableName );
 		if ( embeddableType == null ) {
-			throw new IllegalArgumentException("Not an embeddable: " + embeddableName);
+			throw new IllegalArgumentException( "Not an embeddable: " + embeddableName );
 		}
 		return embeddableType;
 	}
@@ -226,7 +228,8 @@ public class JpaMetamodelImpl implements JpaMetamodelImplementor, Serializable {
 	}
 
 	@Override
-	@Nullable public <X> ManagedDomainType<X> findManagedType(Class<X> cls) {
+	@Nullable
+	public <X> ManagedDomainType<X> findManagedType(Class<X> cls) {
 		//noinspection unchecked
 		return (ManagedDomainType<X>) managedTypeByClass.get( cls );
 	}
@@ -242,9 +245,10 @@ public class JpaMetamodelImpl implements JpaMetamodelImplementor, Serializable {
 	}
 
 	@Override
-	@Nullable public <X> EntityDomainType<X> findEntityType(Class<X> cls) {
+	@Nullable
+	public <X> EntityDomainType<X> findEntityType(Class<X> cls) {
 		final ManagedType<?> type = managedTypeByClass.get( cls );
-		if ( !( type instanceof EntityDomainType<?> ) ) {
+		if ( !(type instanceof EntityDomainType<?>) ) {
 			return null;
 		}
 		//noinspection unchecked
@@ -263,7 +267,7 @@ public class JpaMetamodelImpl implements JpaMetamodelImplementor, Serializable {
 	@Override
 	public @Nullable <X> EmbeddableDomainType<X> findEmbeddableType(Class<X> cls) {
 		final ManagedType<?> type = managedTypeByClass.get( cls );
-		if ( !( type instanceof EmbeddableDomainType<?> ) ) {
+		if ( !(type instanceof EmbeddableDomainType<?>) ) {
 			return null;
 		}
 		//noinspection unchecked
@@ -281,7 +285,7 @@ public class JpaMetamodelImpl implements JpaMetamodelImplementor, Serializable {
 
 	private Collection<ManagedDomainType<?>> getAllManagedTypes() {
 		// should never happen
-		return switch (jpaMetaModelPopulationSetting) {
+		return switch ( jpaMetaModelPopulationSetting ) {
 			case IGNORE_UNSUPPORTED -> managedTypeByClass.values();
 			case ENABLED -> managedTypeByName.values();
 			case DISABLED -> emptySet();
@@ -311,7 +315,7 @@ public class JpaMetamodelImpl implements JpaMetamodelImplementor, Serializable {
 
 	@Override
 	public @Nullable Set<String> getEnumTypesForValue(String enumValue) {
-		return allowedEnumLiteralsToEnumTypeNames.get( enumValue);
+		return allowedEnumLiteralsToEnumTypeNames.get( enumValue );
 	}
 
 	@Override
@@ -388,7 +392,8 @@ public class JpaMetamodelImpl implements JpaMetamodelImplementor, Serializable {
 		}
 	}
 
-	@Override @SuppressWarnings("unchecked")
+	@Override
+	@SuppressWarnings("unchecked")
 	public <T> RootGraphImplementor<T> findEntityGraphByName(String name) {
 		return (RootGraphImplementor<T>) entityGraphMap.get( name );
 	}
@@ -403,8 +408,8 @@ public class JpaMetamodelImpl implements JpaMetamodelImplementor, Serializable {
 			final List<RootGraphImplementor<? super T>> results = new ArrayList<>();
 			for ( RootGraphImplementor<?> entityGraph : entityGraphMap.values() ) {
 				if ( entityGraph.appliesTo( entityType ) ) {
-					@SuppressWarnings("unchecked")
-					final RootGraphImplementor<? super T> result = (RootGraphImplementor<? super T>) entityGraph;
+					@SuppressWarnings(
+							"unchecked") final RootGraphImplementor<? super T> result = (RootGraphImplementor<? super T>) entityGraph;
 					results.add( result );
 				}
 			}
@@ -490,19 +495,50 @@ public class JpaMetamodelImpl implements JpaMetamodelImplementor, Serializable {
 			if ( entityType == null ) {
 				throw new IllegalArgumentException(
 						"Attempted to register named entity graph [" + definition.getRegisteredName()
-								+ "] for unknown entity [" + definition.getEntityName() + "]"
+						+ "] for unknown entity [" + definition.getEntityName() + "]"
 
 				);
 			}
+
 			final NamedEntityGraph namedEntityGraph = definition.getAnnotation();
 			final RootGraphImpl<?> entityGraph =
-					createRootGraph( definition.getRegisteredName(), entityType,
-							namedEntityGraph.includeAllAttributes() );
-			if ( namedEntityGraph.attributeNodes() != null ) {
-				applyNamedAttributeNodes( namedEntityGraph.attributeNodes(), namedEntityGraph, entityGraph );
-			}
+					createEntityGraph(
+							namedEntityGraph,
+							definition.getRegisteredName(),
+							entityType,
+							namedEntityGraph.includeAllAttributes()
+					);
+
 			entityGraphMap.put( definition.getRegisteredName(), entityGraph );
 		}
+	}
+
+	private <T> RootGraphImpl<T> createEntityGraph(
+			NamedEntityGraph namedEntityGraph,
+			String registeredName,
+			EntityDomainType<T> entityType,
+			boolean includeAllAttributes) {
+		final RootGraphImpl<T> entityGraph =
+				createRootGraph( registeredName, entityType, includeAllAttributes );
+
+		if ( namedEntityGraph.subclassSubgraphs() != null ) {
+			Arrays
+					.stream( namedEntityGraph.subclassSubgraphs() )
+					.forEach( subclassSubgraph -> {
+						var subgraph = entityGraph.addTreatedSubgraph( (Class) subclassSubgraph.type() );
+						applyNamedAttributeNodes(
+								subclassSubgraph.attributeNodes(),
+								namedEntityGraph,
+								subgraph
+						);
+					} );
+		}
+
+		if ( namedEntityGraph.attributeNodes() != null ) {
+			applyNamedAttributeNodes( namedEntityGraph.attributeNodes(), namedEntityGraph, entityGraph );
+		}
+
+		return entityGraph;
 	}
 
 	private static <T> RootGraphImpl<T> createRootGraph(
@@ -521,31 +557,42 @@ public class JpaMetamodelImpl implements JpaMetamodelImplementor, Serializable {
 			NamedEntityGraph namedEntityGraph,
 			GraphImplementor<?> graphNode) {
 		for ( NamedAttributeNode namedAttributeNode : namedAttributeNodes ) {
-			final AttributeNodeImplementor<?> attributeNode =
-					graphNode.findOrCreateAttributeNode( namedAttributeNode.value() );
+			final String value = namedAttributeNode.value();
+			AttributeNodeImplementor<?> attributeNode = graphNode.addAttributeNode( value );
+
 			if ( isNotEmpty( namedAttributeNode.subgraph() ) ) {
 				applyNamedSubgraphs(
 						namedEntityGraph,
 						namedAttributeNode.subgraph(),
-						attributeNode.makeSubGraph()
+						attributeNode,
+						false
 				);
 			}
 			if ( isNotEmpty( namedAttributeNode.keySubgraph() ) ) {
 				applyNamedSubgraphs(
 						namedEntityGraph,
 						namedAttributeNode.keySubgraph(),
-						attributeNode.makeKeySubGraph()
+						attributeNode,
+						true
 				);
 			}
 		}
 	}
 
-	private void applyNamedSubgraphs(
+	@SuppressWarnings({"unchecked", "rawtypes"})
+	private <T> void applyNamedSubgraphs(
 			NamedEntityGraph namedEntityGraph,
 			String subgraphName,
-			SubGraphImplementor<?> subgraph) {
+			AttributeNodeImplementor<T> attributeNode, Boolean isKeySubGraph) {
 		for ( NamedSubgraph namedSubgraph : namedEntityGraph.subgraphs() ) {
 			if ( subgraphName.equals( namedSubgraph.name() ) ) {
+				var isDefaultSubgraphType = namedSubgraph.type().equals( void.class );
+				Class subGraphType = isDefaultSubgraphType ? null : namedSubgraph.type();
+				SubGraphImplementor<?> subgraph = isKeySubGraph ?
+						attributeNode.makeKeySubGraph( subGraphType ) :
+						attributeNode
+								.makeSubGraph( subGraphType );
+
 				applyNamedAttributeNodes(
 						namedSubgraph.attributeNodes(),
 						namedEntityGraph,
@@ -609,8 +656,8 @@ public class JpaMetamodelImpl implements JpaMetamodelImplementor, Serializable {
 					// incorrect results
 					final ManagedDomainType<?> superType = managedType.getSuperType();
 					if ( superType != null
-							&& superType.getPersistenceType() == Type.PersistenceType.ENTITY
-							&& javaType.isAssignableFrom( superType.getJavaType() ) ) {
+						&& superType.getPersistenceType() == Type.PersistenceType.ENTITY
+						&& javaType.isAssignableFrom( superType.getJavaType() ) ) {
 						continue;
 					}
 
@@ -630,7 +677,8 @@ public class JpaMetamodelImpl implements JpaMetamodelImplementor, Serializable {
 			}
 		}
 
-		throw new EntityTypeException( "Could not resolve entity class '" + javaType.getName() + "'", javaType.getName() );
+		throw new EntityTypeException( "Could not resolve entity class '" + javaType.getName() + "'",
+				javaType.getName() );
 	}
 
 	@Override
@@ -718,7 +766,7 @@ public class JpaMetamodelImpl implements JpaMetamodelImplementor, Serializable {
 				-> injectTypedQueryReference( definition, namedQueryMetamodelClass( definition, context ) ) );
 		bootMetamodel.visitNamedNativeQueryDefinitions( definition
 				-> injectTypedQueryReference( definition, namedQueryMetamodelClass( definition, context ) ) );
-		bootMetamodel.getNamedEntityGraphs().values().forEach(definition
+		bootMetamodel.getNamedEntityGraphs().values().forEach( definition
 				-> injectEntityGraph( definition, graphMetamodelClass( definition, context ), this ) );
 	}
 
@@ -762,8 +810,7 @@ public class JpaMetamodelImpl implements JpaMetamodelImplementor, Serializable {
 			PersistentClass persistentClass,
 			MetadataContext context,
 			final TypeConfiguration typeConfiguration) {
-		@SuppressWarnings("unchecked")
-		final EntityDomainType<T> entityType =
+		@SuppressWarnings("unchecked") final EntityDomainType<T> entityType =
 				(EntityDomainType<T>)
 						context.locateEntityType( persistentClass );
 		return entityType == null
@@ -815,8 +862,7 @@ public class JpaMetamodelImpl implements JpaMetamodelImplementor, Serializable {
 			MappedSuperclass mappedSuperclass,
 			MetadataContext context,
 			TypeConfiguration typeConfiguration) {
-		@SuppressWarnings("unchecked")
-		final MappedSuperclassDomainType<T> mappedSuperclassType =
+		@SuppressWarnings("unchecked") final MappedSuperclassDomainType<T> mappedSuperclassType =
 				(MappedSuperclassDomainType<T>)
 						context.locateMappedSuperclassType( mappedSuperclass );
 		return mappedSuperclassType == null

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/internal/StandardEntityGraphTraversalStateImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/internal/StandardEntityGraphTraversalStateImpl.java
@@ -4,7 +4,6 @@
  */
 package org.hibernate.sql.results.internal;
 
-import java.util.Map;
 import java.util.Objects;
 
 import org.hibernate.engine.FetchTiming;
@@ -13,11 +12,13 @@ import org.hibernate.graph.spi.AttributeNodeImplementor;
 import org.hibernate.graph.spi.GraphImplementor;
 import org.hibernate.graph.spi.RootGraphImplementor;
 import org.hibernate.graph.spi.SubGraphImplementor;
+import org.hibernate.metamodel.mapping.AttributeMapping;
 import org.hibernate.metamodel.mapping.CollectionPart;
 import org.hibernate.metamodel.mapping.NonAggregatedIdentifierMapping;
 import org.hibernate.metamodel.mapping.PluralAttributeMapping;
 import org.hibernate.metamodel.mapping.internal.EntityCollectionPart;
 import org.hibernate.metamodel.model.domain.JpaMetamodel;
+import org.hibernate.metamodel.model.domain.ManagedDomainType;
 import org.hibernate.sql.results.graph.EntityGraphTraversalState;
 import org.hibernate.sql.results.graph.FetchParent;
 import org.hibernate.sql.results.graph.Fetchable;
@@ -55,34 +56,37 @@ public class StandardEntityGraphTraversalStateImpl implements EntityGraphTravers
 		}
 
 		final GraphImplementor<?> previousContextRoot = currentGraphContext;
-		final AttributeNodeImplementor<?> attributeNode = appliesTo( fetchParent )
-				? currentGraphContext.findAttributeNode( fetchable.getFetchableName() )
-				: null;
+		final AttributeNodeImplementor<?> attributeNode = getAttributeNode( fetchParent, fetchable );
 
 		currentGraphContext = null;
 		final FetchStrategy fetchStrategy;
 		if ( attributeNode != null ) {
 			fetchStrategy = new FetchStrategy( FetchTiming.IMMEDIATE, true );
-			final Map<? extends Class<?>, ? extends SubGraphImplementor<?>> subgraphMap;
-			final Class<?> subgraphMapKey;
-			if ( fetchable instanceof PluralAttributeMapping ) {
-				final PluralAttributeMapping pluralAttributeMapping = (PluralAttributeMapping) fetchable;
+			Class<?> subgraphType = null;
+			final SubGraphImplementor<?> attributeNodeSubgraph = attributeNode.getSubgraph();
+			if ( fetchable instanceof PluralAttributeMapping pluralAttributeMapping ) {
 				if ( exploreKeySubgraph ) {
-					subgraphMap = attributeNode.getKeySubGraphMap();
-					subgraphMapKey = getEntityCollectionPartJavaClass( pluralAttributeMapping.getIndexDescriptor() );
+					final var keySubgraphMap = attributeNode.getKeySubGraphMap();
+					final var subgraphMapKey = getEntityCollectionPartJavaClass(
+							pluralAttributeMapping.getIndexDescriptor() );
+					currentGraphContext = keySubgraphMap.get( subgraphMapKey );
 				}
 				else {
-					subgraphMap = attributeNode.getSubGraphMap();
-					subgraphMapKey = getEntityCollectionPartJavaClass( pluralAttributeMapping.getElementDescriptor() );
+					subgraphType = getEntityCollectionPartJavaClass( pluralAttributeMapping.getElementDescriptor() );
 				}
 			}
 			else {
 				assert !exploreKeySubgraph;
-				subgraphMap = attributeNode.getSubGraphMap();
-				subgraphMapKey = fetchable.getJavaType().getJavaTypeClass();
+				subgraphType = fetchable.getJavaType().getJavaTypeClass();
 			}
-			if ( subgraphMap != null && subgraphMapKey != null ) {
-				currentGraphContext = subgraphMap.get( subgraphMapKey );
+
+			if ( attributeNodeSubgraph != null && subgraphType != null ) {
+				if ( subgraphType.equals( attributeNodeSubgraph.getClassType() ) ) {
+					currentGraphContext = attributeNodeSubgraph;
+				}
+				else {
+					currentGraphContext = attributeNodeSubgraph.getSubclassSubgraph( (Class) subgraphType );
+				}
 			}
 		}
 		else if ( graphSemantic == GraphSemantic.FETCH ) {
@@ -93,6 +97,46 @@ public class StandardEntityGraphTraversalStateImpl implements EntityGraphTravers
 		}
 		return new TraversalResult( previousContextRoot, fetchStrategy );
 	}
+
+	@SuppressWarnings({"unchecked", "rawtypes"})
+	private AttributeNodeImplementor<?> getAttributeNode(FetchParent fetchParent, Fetchable fetchable) {
+		if ( !appliesTo( fetchParent ) ) {
+			return null;
+		}
+
+		AttributeNodeImplementor<?> attributeNode = currentGraphContext.findAttributeNode(
+				fetchable.getFetchableName() );
+
+		if ( attributeNode != null ) {
+			return attributeNode;
+		}
+
+		if ( !(fetchable instanceof AttributeMapping attributeMapping) ) {
+			return null;
+		}
+
+		var declaringType = attributeMapping.getDeclaringType().getJavaType().getJavaTypeClass();
+		ManagedDomainType managedDeclaringType = metamodel.findManagedType( declaringType );
+
+		if ( managedDeclaringType == null ) {
+			return null;
+		}
+
+		var currentGraphSubTypes = currentGraphContext.getGraphedType().getSubTypes();
+
+		if ( !currentGraphSubTypes.contains( managedDeclaringType ) ) {
+			return null;
+		}
+
+		var subclassSubgraph = currentGraphContext.getSubclassSubgraph( managedDeclaringType.getJavaType() );
+
+		if ( subclassSubgraph == null ) {
+			return null;
+		}
+
+		return subclassSubgraph.findAttributeNode( fetchable.getFetchableName() );
+	}
+
 
 	private Class<?> getEntityCollectionPartJavaClass(CollectionPart collectionPart) {
 		if ( collectionPart instanceof EntityCollectionPart ) {

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/entitygraph/EntityGraphWithInheritanceTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/entitygraph/EntityGraphWithInheritanceTest.java
@@ -1,0 +1,250 @@
+/*
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.entitygraph;
+
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+
+import org.hibernate.Hibernate;
+import org.hibernate.graph.GraphSemantic;
+
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.JiraKey;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.DiscriminatorColumn;
+import jakarta.persistence.DiscriminatorType;
+import jakarta.persistence.DiscriminatorValue;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Inheritance;
+import jakarta.persistence.InheritanceType;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Lansana DIOMANDE
+ */
+@DomainModel(
+		annotatedClasses = {
+				EntityGraphWithInheritanceTest.Person.class,
+				EntityGraphWithInheritanceTest.Student.class,
+				EntityGraphWithInheritanceTest.Teacher.class,
+				EntityGraphWithInheritanceTest.School.class,
+				EntityGraphWithInheritanceTest.Course.class,
+				EntityGraphWithInheritanceTest.FreeCourse.class,
+				EntityGraphWithInheritanceTest.PayingCourse.class
+		}
+)
+@SessionFactory
+@JiraKey(value = "HHH-18714")
+public class EntityGraphWithInheritanceTest {
+
+	private static Long STUDENT_ID = 1L;
+
+	@BeforeAll
+	public void setup(SessionFactoryScope scope) {
+		scope.inTransaction( session -> {
+			var frenchTeacher = new Teacher();
+			frenchTeacher.firstname = "John 2";
+			frenchTeacher.lastname = "DOE";
+			frenchTeacher.id = 2L;
+
+			var frenchCourse = new PayingCourse();
+			frenchCourse.id = 1L;
+			frenchCourse.name = "French";
+			frenchCourse.moneyReceiver = frenchTeacher;
+
+			var student = new Student();
+			student.id = STUDENT_ID;
+			student.firstname = "John";
+			student.lastname = "Doe";
+
+			var school = new School();
+			school.name = "Fake";
+			school.id = 1l;
+
+			student.school = school;
+
+			student.courses = new ArrayList<>() {{
+				add( frenchCourse );
+			}};
+
+			session.persist( student );
+		} );
+	}
+
+	@AfterAll
+	public void clean(SessionFactoryScope scope) {
+		scope.getSessionFactory().getSchemaManager().truncateMappedObjects();
+	}
+
+	@Test
+	public void testWithoutGraph(SessionFactoryScope scope) {
+		scope.inTransaction(
+				session -> {
+					var person = session.find(
+							Person.class,
+							STUDENT_ID
+					);
+
+					session.detach( person );
+
+					assertThat( person ).isInstanceOf( Student.class );
+
+					var student = (Student) person;
+
+					assertThat( Hibernate.isInitialized( student.courses ) ).isFalse();
+					assertThat( Hibernate.isInitialized( student.school ) ).isFalse();
+				}
+		);
+	}
+
+	@Test
+	public void testWhenGraphHasSubclassSubgraph(SessionFactoryScope scope) {
+		scope.inTransaction(
+				session -> {
+
+					var graph = session.createEntityGraph( Person.class );
+
+					var studentSubGraph = graph.addTreatedSubgraph( Student.class );
+					studentSubGraph.addAttributeNode( "school" );
+					studentSubGraph.addAttributeNode( "courses" );
+
+
+					var person = session.find(
+							Person.class,
+							STUDENT_ID,
+							Collections.singletonMap( GraphSemantic.FETCH.getJakartaHintName(), graph )
+					);
+
+					session.detach( person );
+
+					assertThat( person ).isInstanceOf( Student.class );
+
+					var student = (Student) person;
+
+					assertThat( Hibernate.isInitialized( student.school ) ).isTrue();
+					assertThat( Hibernate.isInitialized( student.courses ) ).isTrue();
+					assertThat( student.courses ).allSatisfy( course -> {
+						assertThat( course ).isInstanceOf( PayingCourse.class );
+						var payingCourse = (PayingCourse) course;
+						assertThat( Hibernate.isInitialized( payingCourse.moneyReceiver ) ).isFalse();
+					} );
+				}
+		);
+	}
+
+
+	@Test
+	public void testWhenGraphHasSubclassSubgraphLinkedWithSubgraphThatHasInheritance(SessionFactoryScope scope) {
+		scope.inTransaction(
+				session -> {
+
+					var graph = session.createEntityGraph( Person.class );
+
+					var studentSubGraph = graph.addTreatedSubgraph( Student.class );
+					studentSubGraph.addAttributeNode( "school" );
+					studentSubGraph.addAttributeNode( "courses" );
+
+					var payingCourseSubgraph = studentSubGraph
+							.addSubgraph( "courses", PayingCourse.class );
+
+					payingCourseSubgraph.addSubgraph( "moneyReceiver" );
+
+					var person = session.find(
+							Person.class,
+							STUDENT_ID,
+							Collections.singletonMap( GraphSemantic.FETCH.getJakartaHintName(), graph )
+					);
+
+					session.detach( person );
+
+					assertThat( person ).isInstanceOf( Student.class );
+
+					var student = (Student) person;
+
+					assertThat( Hibernate.isInitialized( student.school ) ).isTrue();
+					assertThat( Hibernate.isInitialized( student.courses ) ).isTrue();
+					assertThat( student.courses ).allSatisfy( course -> {
+						assertThat( course ).isInstanceOf( PayingCourse.class );
+						var payingCourse = (PayingCourse) course;
+						assertThat( Hibernate.isInitialized( payingCourse.moneyReceiver ) ).isTrue();
+					} );
+				}
+		);
+	}
+
+
+	@Entity(name = "Person")
+	@Inheritance(strategy = InheritanceType.JOINED)
+	@DiscriminatorColumn(name = "person_type", discriminatorType = DiscriminatorType.STRING)
+	public static abstract class Person {
+		@Id
+		Long id;
+		String firstname;
+		String lastname;
+
+	}
+
+	@Entity(name = "Student")
+	@DiscriminatorValue("student")
+	public static class Student extends Person {
+
+		@ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+		School school;
+
+		@OneToMany(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+		List<Course> courses;
+	}
+
+
+	@Entity(name = "Teacher")
+	@DiscriminatorValue("teacher")
+	public static class Teacher extends Person {
+	}
+
+
+	@Entity(name = "School")
+	public static class School {
+		@Id
+		Long id;
+		String name;
+	}
+
+	@Entity(name = "Course")
+	@DiscriminatorColumn(name = "course_type", discriminatorType = DiscriminatorType.STRING)
+	public static abstract class Course {
+		@Id
+		Long id;
+		String name;
+	}
+
+	@Entity(name = "FreeCourse")
+	public static class FreeCourse extends Course {
+	}
+
+	@Entity(name = "PayingCourse")
+	@DiscriminatorValue("paying")
+	public static class PayingCourse extends Course {
+
+		@ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+		Teacher moneyReceiver;
+	}
+
+
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/entitygraph/named/multiple/NamedEntityGraphsWithInheritanceTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/entitygraph/named/multiple/NamedEntityGraphsWithInheritanceTest.java
@@ -1,0 +1,207 @@
+/*
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.entitygraph.named.multiple;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import org.hibernate.Hibernate;
+import org.hibernate.graph.GraphSemantic;
+
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.JiraKey;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.DiscriminatorColumn;
+import jakarta.persistence.DiscriminatorType;
+import jakarta.persistence.DiscriminatorValue;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Inheritance;
+import jakarta.persistence.InheritanceType;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.NamedAttributeNode;
+import jakarta.persistence.NamedEntityGraph;
+import jakarta.persistence.NamedSubgraph;
+import jakarta.persistence.OneToMany;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+
+/**
+ * @author Lansana DIOMANDE
+ */
+@DomainModel(
+		annotatedClasses = {
+				NamedEntityGraphsWithInheritanceTest.Person.class,
+				NamedEntityGraphsWithInheritanceTest.Student.class,
+				NamedEntityGraphsWithInheritanceTest.Teacher.class,
+				NamedEntityGraphsWithInheritanceTest.School.class,
+				NamedEntityGraphsWithInheritanceTest.Course.class,
+				NamedEntityGraphsWithInheritanceTest.FreeCourse.class,
+				NamedEntityGraphsWithInheritanceTest.PayingCourse.class
+		}
+)
+@SessionFactory
+@JiraKey(value = "HHH-18714")
+public class NamedEntityGraphsWithInheritanceTest {
+
+
+	private static Long STUDENT_ID = 1L;
+
+	@BeforeAll
+	public void setup(SessionFactoryScope scope) {
+		scope.inTransaction( session -> {
+			var frenchTeacher = new Teacher();
+			frenchTeacher.firstname = "John 2";
+			frenchTeacher.lastname = "DOE";
+			frenchTeacher.id = 2L;
+
+			var frenchCourse = new PayingCourse();
+			frenchCourse.id = 1L;
+			frenchCourse.name = "French";
+			frenchCourse.moneyReceiver = frenchTeacher;
+
+			var student = new Student();
+			student.id = STUDENT_ID;
+			student.firstname = "John";
+			student.lastname = "Doe";
+
+			var school = new School();
+			school.name = "Fake";
+			school.id = 1l;
+
+			student.school = school;
+
+			student.courses = new ArrayList<>() {{
+				add( frenchCourse );
+			}};
+
+			session.persist( student );
+		} );
+	}
+
+	@AfterAll
+	public void clean(SessionFactoryScope scope) {
+		scope.getSessionFactory().getSchemaManager().truncateMappedObjects();
+	}
+
+
+	@Test
+	public void testWhenGraphHasSubclassSubgraphLinkedWithSubgraphThatHasInheritance(SessionFactoryScope scope) {
+		scope.inTransaction(
+				session -> {
+
+					var graph = session.getEntityGraph(
+							"graph_having_subclasssubgraph_linked_with_subgraph_that_has_inheritance" );
+
+					var person = session.find(
+							Person.class,
+							STUDENT_ID,
+							Collections.singletonMap( GraphSemantic.FETCH.getJakartaHintName(), graph )
+					);
+
+					session.detach( person );
+
+					assertThat( person ).isInstanceOf( Student.class );
+
+					var student = (Student) person;
+
+					assertThat( Hibernate.isInitialized( student.school ) ).isTrue();
+					assertThat( Hibernate.isInitialized( student.courses ) ).isTrue();
+					assertThat( student.courses ).allSatisfy( course -> {
+						assertThat( course ).isInstanceOf( PayingCourse.class );
+						var payingCourse = (PayingCourse) course;
+						assertThat( Hibernate.isInitialized( payingCourse.moneyReceiver ) ).isTrue();
+					} );
+				}
+		);
+	}
+
+
+	@NamedEntityGraph(
+			name = "graph_having_subclasssubgraph_linked_with_subgraph_that_has_inheritance",
+			subgraphs = {
+					@NamedSubgraph(name = "course_sub_graph", type = PayingCourse.class, attributeNodes = {
+							@NamedAttributeNode("moneyReceiver")
+					})
+			},
+			subclassSubgraphs = {
+					@NamedSubgraph(
+							name = "notUsed",
+							type = Student.class,
+							attributeNodes = {
+									@NamedAttributeNode(value = "school"),
+									@NamedAttributeNode(value = "courses", subgraph = "course_sub_graph")
+							}
+					)
+			}
+	)
+	@Entity(name = "Person")
+	@Inheritance(strategy = InheritanceType.JOINED)
+	@DiscriminatorColumn(name = "person_type", discriminatorType = DiscriminatorType.STRING)
+	public static abstract class Person {
+		@Id
+		Long id;
+		String firstname;
+		String lastname;
+
+	}
+
+	@Entity(name = "Student")
+	@DiscriminatorValue("student")
+	public static class Student extends Person {
+
+		@ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+		School school;
+
+		@OneToMany(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+		List<Course> courses;
+	}
+
+
+	@Entity(name = "Teacher")
+	@DiscriminatorValue("teacher")
+	public static class Teacher extends Person {
+	}
+
+
+	@Entity(name = "School")
+	public static class School {
+		@Id
+		Long id;
+		String name;
+	}
+
+	@Entity(name = "Course")
+	@DiscriminatorColumn(name = "course_type", discriminatorType = DiscriminatorType.STRING)
+	public static abstract class Course {
+		@Id
+		Long id;
+		String name;
+	}
+
+	@Entity(name = "FreeCourse")
+	public static class FreeCourse extends Course {
+	}
+
+	@Entity(name = "PayingCourse")
+	@DiscriminatorValue("paying")
+	public static class PayingCourse extends Course {
+
+		@ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+		Teacher moneyReceiver;
+	}
+
+
+}


### PR DESCRIPTION
<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

[Please describe here what your change is about]
This change enables support for inheritance with EntityGraphs as described in the JPA specification. 
I've added some functions such as `addTreatedSubgraph` to facilitate future integration with Hibernate 7 (Jpa 3.2).
The ticket related to my proposal: https://hibernate.atlassian.net/browse/HHH-18714 

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
