### PR TITLE
HHH-18681 InterpretationException executing subquery in case-when : o.h.query.sqm.tree.select.SqmSelection.getExpressible() is null

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/query/hql/internal/SemanticQueryBuilder.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/hql/internal/SemanticQueryBuilder.java
@@ -5681,9 +5681,11 @@ public class SemanticQueryBuilder<R> extends HqlParserBaseVisitor<Object> implem
 
 			final List<SqmSelection<?>> selections = subQuery.getQuerySpec().getSelectClause().getSelections();
 			if ( selections.size() == 1 ) {
-				subQuery.applyInferableType( selections.get( 0 ).getExpressible().getSqmType() );
+				final SqmExpressible<?> expressible = selections.get( 0 ).getExpressible();
+				if ( expressible != null ) {
+					subQuery.applyInferableType( expressible.getSqmType() );
+				}
 			}
-
 			return subQuery;
 		}
 		finally {

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/query/SubQuerySelectCaseWhenTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/query/SubQuerySelectCaseWhenTest.java
@@ -1,0 +1,79 @@
+/*
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.query;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.JiraKey;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+
+@DomainModel(
+		annotatedClasses = {
+				SubQuerySelectCaseWhenTest.TestEntity.class,
+		}
+)
+@SessionFactory
+@JiraKey("HHH-18681")
+public class SubQuerySelectCaseWhenTest {
+
+	@BeforeEach
+	public void setUp(SessionFactoryScope scope) {
+		scope.inTransaction(
+				session -> {
+					session.persist( new TestEntity( "A" ) );
+					session.persist( new TestEntity( "B" ) );
+					session.persist( new TestEntity( "C" ) );
+				}
+		);
+	}
+
+	@Test
+	public void testSelectCase(SessionFactoryScope scope) {
+		scope.inTransaction( session -> {
+			List<Integer> result = session.createQuery( "select "
+							+ "		(select "
+							+ "			case "
+							+ "				when "
+							+ "					t.name = ?1 "
+							+ "				then 0 "
+							+ "				else 1 "
+							+ "			end)"
+							+ " from TestEntity t order by t.name", Integer.class )
+					.setParameter( 1, "A" )
+					.list();
+			assertThat( result.size() ).isEqualTo( 3 );
+			assertThat( result.get( 0 ) ).isEqualTo( 0 );
+			assertThat( result.get( 1 ) ).isEqualTo( 1 );
+			assertThat( result.get( 2 ) ).isEqualTo( 1 );
+		} );
+	}
+
+	@Entity(name = "TestEntity")
+	public class TestEntity {
+
+		@Id
+		@GeneratedValue
+		private Long id;
+
+		private String name;
+
+		public TestEntity() {
+		}
+
+		public TestEntity(String name) {
+			this.name = name;
+		}
+	}
+}


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-18681

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
