### PR TITLE
HHH-18693 Hibernate Processor does not handle inner @Entity, @Embeddable, ... types

### DIFF
--- a/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/CreationTimestampTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/CreationTimestampTest.java
@@ -38,7 +38,7 @@ public class CreationTimestampTest extends BaseEntityManagerFunctionalTestCase {
 	}
 
 	@Entity(name = "Event")
-	private static class Event {
+	static class Event {
 
 		@Id
 		@GeneratedValue

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/UpdateTimestampTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/UpdateTimestampTest.java
@@ -38,7 +38,7 @@ public class UpdateTimestampTest extends BaseEntityManagerFunctionalTestCase {
 	}
 
 	@Entity(name = "Event")
-	private static class Event {
+	static class Event {
 
 		@Id
 		@GeneratedValue

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/bootstrap/registry/classloading/HibernateCallbacksTestAction.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/bootstrap/registry/classloading/HibernateCallbacksTestAction.java
@@ -34,7 +34,7 @@ public class HibernateCallbacksTestAction extends HibernateLoadingTestAction {
 	}
 
 	@Entity(name = "booking")
-	private static class Booking {
+	static class Booking {
 		@Id Long id;
 		@Transient String legacyIdentifier;
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/association/InheritedAttributeAssociationTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/association/InheritedAttributeAssociationTest.java
@@ -44,7 +44,7 @@ public class InheritedAttributeAssociationTest {
 	// --- //
 
 	@Entity
-	private static class Author {
+	static class Author {
 
 		@Id
 		@GeneratedValue
@@ -60,7 +60,7 @@ public class InheritedAttributeAssociationTest {
 	@MappedSuperclass
 	@Inheritance(strategy = InheritanceType.SINGLE_TABLE)
 	@DiscriminatorColumn(name = "type", discriminatorType = DiscriminatorType.STRING)
-	private static abstract class Item {
+	static abstract class Item {
 
 		@Id
 		@GeneratedValue
@@ -72,6 +72,6 @@ public class InheritedAttributeAssociationTest {
 
 	@Entity
 	@DiscriminatorValue("child")
-	private static class ChildItem extends Item {
+	static class ChildItem extends Item {
 	}
 }

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/association/ManyToManyAssociationListTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/association/ManyToManyAssociationListTest.java
@@ -41,7 +41,7 @@ public class ManyToManyAssociationListTest {
 	// -- //
 
 	@Entity
-	private static class Group {
+	static class Group {
 
 		@Id
 		Long id;
@@ -63,7 +63,7 @@ public class ManyToManyAssociationListTest {
 	}
 
 	@Entity
-	private static class User {
+	static class User {
 
 		@Id
 		Long id;

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/association/ManyToManyAssociationTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/association/ManyToManyAssociationTest.java
@@ -68,7 +68,7 @@ public class ManyToManyAssociationTest {
 	// -- //
 
 	@Entity
-	private static class Group {
+	static class Group {
 
 		@Id
 		Long id;
@@ -90,7 +90,7 @@ public class ManyToManyAssociationTest {
 	}
 
 	@Entity
-	private static class User {
+	static class User {
 
 		@Id
 		Long id;

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/association/OneToManyAssociationTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/association/OneToManyAssociationTest.java
@@ -67,7 +67,7 @@ public class OneToManyAssociationTest {
 	// --- //
 
 	@Entity
-	private static class Customer {
+	static class Customer {
 
 		@Id
 		Long id;
@@ -97,7 +97,7 @@ public class OneToManyAssociationTest {
 	}
 
 	@Entity
-	private static class CustomerInventory {
+	static class CustomerInventory {
 
 		@Id
 		Long id;

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/association/OneToOneAssociationTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/association/OneToOneAssociationTest.java
@@ -71,7 +71,7 @@ public class OneToOneAssociationTest {
 	// --- //
 
 	@Entity
-	private static class Customer {
+	static class Customer {
 
 		@Id
 		Long id;
@@ -89,7 +89,7 @@ public class OneToOneAssociationTest {
 	}
 
 	@Entity
-	private static class User {
+	static class User {
 
 		@Id
 		Long id;

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/basic/BasicEnhancementTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/basic/BasicEnhancementTest.java
@@ -124,7 +124,7 @@ public class BasicEnhancementTest {
 	// --- //
 
 	@Entity
-	private static class SimpleEntity {
+	static class SimpleEntity {
 
 		Object anUnspecifiedObject;
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/basic/ExtendedAssociationManagementTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/basic/ExtendedAssociationManagementTest.java
@@ -53,7 +53,7 @@ public class ExtendedAssociationManagementTest {
 	// --- //
 
 	@Entity
-	private static class Customer {
+	static class Customer {
 
 		@Id
 		Long id;
@@ -67,7 +67,7 @@ public class ExtendedAssociationManagementTest {
 	}
 
 	@Entity
-	private static class User {
+	static class User {
 
 		@Id
 		Long id;

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/basic/InheritedTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/basic/InheritedTest.java
@@ -92,7 +92,7 @@ public class InheritedTest {
 	// --- //
 
 	@Entity
-	private static abstract class Person {
+	static abstract class Person {
 
 		Object anUnspecifiedObject;
 
@@ -116,7 +116,7 @@ public class InheritedTest {
 	}
 
 	@Entity
-	private static class Employee extends Person {
+	static class Employee extends Person {
 
 		String title;
 
@@ -134,7 +134,7 @@ public class InheritedTest {
 	}
 
 	@Entity
-	private static class Contractor extends Person {
+	static class Contractor extends Person {
 
 		Integer rate;
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/basic/MappedSuperclassTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/basic/MappedSuperclassTest.java
@@ -79,7 +79,7 @@ public class MappedSuperclassTest {
 	// --- //
 
 	@MappedSuperclass
-	private static class Person {
+	static class Person {
 
 		Object anUnspecifiedObject;
 
@@ -102,7 +102,7 @@ public class MappedSuperclassTest {
 	}
 
 	@Entity
-	private static class Employee extends Person {
+	static class Employee extends Person {
 
 		String title;
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/dirty/DirtyTrackingEmbeddableTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/dirty/DirtyTrackingEmbeddableTest.java
@@ -38,7 +38,7 @@ public class DirtyTrackingEmbeddableTest {
 	// --- //
 
 	@Embeddable
-	private static class Address1 {
+	static class Address1 {
 		String street1;
 		String street2;
 		String city;
@@ -47,7 +47,7 @@ public class DirtyTrackingEmbeddableTest {
 		String phone;
 	}
 
-	private static class Address2 {
+	static class Address2 {
 		String street1;
 		String street2;
 		String city;
@@ -57,7 +57,7 @@ public class DirtyTrackingEmbeddableTest {
 	}
 
 	@Entity
-	private static class SimpleEntity {
+	static class SimpleEntity {
 
 		@Id
 		Long id;

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/dirty/DirtyTrackingTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/dirty/DirtyTrackingTest.java
@@ -100,7 +100,7 @@ public class DirtyTrackingTest {
 	// --- //
 
 	@Embeddable
-	private static class Address {
+	static class Address {
 		@Embedded
 		Country country;
 		String street1;
@@ -112,12 +112,12 @@ public class DirtyTrackingTest {
 	}
 
 	@Embeddable
-	private static class Country {
+	static class Country {
 		String name;
 	}
 
 	@Entity
-	private static class SimpleEntity {
+	static class SimpleEntity {
 
 		@Id
 		Long id;
@@ -149,7 +149,7 @@ public class DirtyTrackingTest {
 	}
 
 	@Entity
-	private static class OtherEntity {
+	static class OtherEntity {
 		@Id
 		Long id;
 		String name;

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/merge/MergeEnhancedEntityDynamicUpdateTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/merge/MergeEnhancedEntityDynamicUpdateTest.java
@@ -131,7 +131,7 @@ public class MergeEnhancedEntityDynamicUpdateTest extends BaseCoreFunctionalTest
 	@Table( name = "PERSON" )
 	@DynamicUpdate
 	@DynamicInsert
-	private static class Person {
+	static class Person {
 
 		@Id
 		Long id;
@@ -155,7 +155,7 @@ public class MergeEnhancedEntityDynamicUpdateTest extends BaseCoreFunctionalTest
 	@Table( name = "PERSON_ADDRESS" )
 	@DynamicUpdate
 	@DynamicInsert
-	private static class PersonAddress {
+	static class PersonAddress {
 
 		@Id
 		Long id;
@@ -168,7 +168,7 @@ public class MergeEnhancedEntityDynamicUpdateTest extends BaseCoreFunctionalTest
 	@Table(name = "NULLABLE_PERSON")
 	@DynamicUpdate
 	@DynamicInsert
-	private static class NullablePerson {
+	static class NullablePerson {
 
 		@Id
 		Long id;

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/caching/mocked/ReadWriteCacheTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/caching/mocked/ReadWriteCacheTest.java
@@ -266,7 +266,7 @@ public class ReadWriteCacheTest extends BaseCoreFunctionalTestCase {
 	@Entity(name = "Book")
 	@Cacheable
 	@org.hibernate.annotations.Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
-	private static final class Book {
+	static final class Book {
 
 		@Id
 		private Long id;

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/dialect/functional/HANACalcViewTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/dialect/functional/HANACalcViewTest.java
@@ -165,7 +165,7 @@ public class HANACalcViewTest extends BaseCoreFunctionalTestCase {
 
 	@Entity(name = "CVEntity")
 	@Table(name = CALC_VIEW_NAME)
-	private static class CVEntity {
+	static class CVEntity {
 
 		private String dummydummy;
 		private double dummydouble;

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/event/MergeContextTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/event/MergeContextTest.java
@@ -425,7 +425,7 @@ public class MergeContextTest extends BaseCoreFunctionalTestCase {
 	}
 
 	@Entity
-	private static class Simple {
+	static class Simple {
 		@Id
 		private int value;
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/event/entity/MergeListPreAndPostPersistTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/event/entity/MergeListPreAndPostPersistTest.java
@@ -67,7 +67,7 @@ public class MergeListPreAndPostPersistTest extends BaseCoreFunctionalTestCase {
 	}
 
 	@Entity(name = "`Order`")
-	private static class Order {
+	static class Order {
 		@Id
 		public Long id;
 
@@ -99,7 +99,7 @@ public class MergeListPreAndPostPersistTest extends BaseCoreFunctionalTestCase {
 	}
 
 	@Entity(name = "Item")
-	private static class Item {
+	static class Item {
 		@Id
 		public Long id;
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/event/entity/MergeListPreAndPostPersistWithIdentityTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/event/entity/MergeListPreAndPostPersistWithIdentityTest.java
@@ -74,7 +74,7 @@ public class MergeListPreAndPostPersistWithIdentityTest extends BaseCoreFunction
 	}
 
 	@Entity
-	private static class Order {
+	static class Order {
 		@Id
 		public Long id;
 
@@ -106,7 +106,7 @@ public class MergeListPreAndPostPersistWithIdentityTest extends BaseCoreFunction
 	}
 
 	@Entity
-	private static class Item {
+	static class Item {
 		@Id
 		@GeneratedValue(strategy = GenerationType.IDENTITY)
 		public Long id;

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/EntityManagerClosedTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/EntityManagerClosedTest.java
@@ -661,7 +661,7 @@ public class EntityManagerClosedTest extends BaseEntityManagerFunctionalTestCase
 	}
 
 	@Entity(name = "AnEntity")
-	private static class AnEntity {
+	static class AnEntity {
 		@Id
 		private long id;
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/callbacks/PreUpdateCustomEntityDirtinessStrategyTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/callbacks/PreUpdateCustomEntityDirtinessStrategyTest.java
@@ -122,7 +122,7 @@ public class PreUpdateCustomEntityDirtinessStrategyTest
 
 	@Entity(name = "Person")
 	@DynamicUpdate
-	private static class Person {
+	static class Person {
 		@Id
 		@GeneratedValue
 		private int id;

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/callbacks/PreUpdateDirtyCheckingInterceptorTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/callbacks/PreUpdateDirtyCheckingInterceptorTest.java
@@ -96,7 +96,7 @@ public class PreUpdateDirtyCheckingInterceptorTest
 
 	@Entity(name = "Person")
 	@DynamicUpdate
-	private static class Person {
+	static class Person {
 		@Id
 		@GeneratedValue
 		private int id;

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/quote/QuoteTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/quote/QuoteTest.java
@@ -134,7 +134,7 @@ public class QuoteTest extends BaseNonConfigCoreFunctionalTestCase {
 
 	@Entity( name = "Item" )
 	@Inheritance(strategy = InheritanceType.TABLE_PER_CLASS)
-	private static abstract class Item {
+	static abstract class Item {
 
 		@Id @GeneratedValue
 		@Column(name = "`ID`")
@@ -150,7 +150,7 @@ public class QuoteTest extends BaseNonConfigCoreFunctionalTestCase {
 
 	@Entity
 	@Table(name = "`CoNTaiNeR`")
-	private static class Container extends Item {
+	static class Container extends Item {
 
 		@OneToMany(mappedBy = "parent", targetEntity = Item.class)
 		private Set<Item> items = new HashSet<Item>( 0 );
@@ -158,6 +158,6 @@ public class QuoteTest extends BaseNonConfigCoreFunctionalTestCase {
 
 	@Entity
 	@Table(name = "`SimpleItem`")
-	private static class SimpleItem extends Item {
+	static class SimpleItem extends Item {
 	}
 }

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/quote/TableGeneratorQuotingTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/quote/TableGeneratorQuotingTest.java
@@ -88,7 +88,7 @@ public class TableGeneratorQuotingTest {
 
 	@Entity
 	@Table(name = "test_entity")
-	private static class TestEntity {
+	static class TestEntity {
 		@Id
 		@GeneratedValue(strategy = GenerationType.TABLE)
 		private int id;

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/schematools/PrimaryKeyColumnOrderTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/schematools/PrimaryKeyColumnOrderTest.java
@@ -187,7 +187,7 @@ public class PrimaryKeyColumnOrderTest extends BaseSessionFactoryFunctionalTest 
 
 	@Embeddable
 	public static class EntityId implements Serializable {
-		private int A;
-		private int B;
+		private int a;
+		private int b;
 	}
 }

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/schemavalidation/IdentityGenerationValidationTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/schemavalidation/IdentityGenerationValidationTest.java
@@ -50,7 +50,7 @@ public class IdentityGenerationValidationTest extends BaseCoreFunctionalTestCase
 
 	@Entity
 	@Table(name = "test_entity")
-	private static class TestEntity {
+	static class TestEntity {
 		@Id
 		@GeneratedValue(strategy = GenerationType.IDENTITY)
 		private Long id;

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/schemavalidation/SynonymValidationTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/schemavalidation/SynonymValidationTest.java
@@ -154,7 +154,7 @@ public class SynonymValidationTest extends BaseSessionFactoryFunctionalTest {
 
 	@Entity
 	@Table(name = "test_entity")
-	private static class TestEntity {
+	static class TestEntity {
 		@Id
 		private Long id;
 
@@ -190,7 +190,7 @@ public class SynonymValidationTest extends BaseSessionFactoryFunctionalTest {
 
 	@Entity
 	@Table(name = "test_synonym")
-	private static class TestEntityWithSynonym {
+	static class TestEntityWithSynonym {
 		@Id
 		private Long id;
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/schemavalidation/ViewValidationTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/schemavalidation/ViewValidationTest.java
@@ -104,7 +104,7 @@ public class ViewValidationTest extends BaseCoreFunctionalTestCase {
 
 	@Entity
 	@Table(name = "test_entity")
-	private static class TestEntity {
+	static class TestEntity {
 		@Id
 		private Long id;
 
@@ -141,7 +141,7 @@ public class ViewValidationTest extends BaseCoreFunctionalTestCase {
 
 	@Entity
 	@Table(name = "test_synonym")
-	private static class TestEntityWithSynonym {
+	static class TestEntityWithSynonym {
 		@Id
 		private Long id;
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/sorted/map/SortComparatorTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/sorted/map/SortComparatorTest.java
@@ -77,7 +77,7 @@ public class SortComparatorTest extends BaseNonConfigCoreFunctionalTestCase {
 
 	@Entity(name = "Owner")
 	@Table(name = "Owner")
-	private static class Owner {
+	static class Owner {
 
 		@Id
 		@GeneratedValue
@@ -91,7 +91,7 @@ public class SortComparatorTest extends BaseNonConfigCoreFunctionalTestCase {
 
 	@Entity(name = "Cat")
 	@Table(name = "Cat")
-	private static class Cat implements Comparable<Cat> {
+	static class Cat implements Comparable<Cat> {
 
 		@Id
 		@GeneratedValue

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/sorted/map/SortNaturalTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/sorted/map/SortNaturalTest.java
@@ -74,7 +74,7 @@ public class SortNaturalTest extends BaseNonConfigCoreFunctionalTestCase {
 
 	@Entity(name = "Owner")
 	@Table(name = "Owner")
-	private static class Owner {
+	static class Owner {
 
 		@Id
 		@GeneratedValue
@@ -88,7 +88,7 @@ public class SortNaturalTest extends BaseNonConfigCoreFunctionalTestCase {
 
 	@Entity(name = "Cat")
 	@Table(name = "Cat")
-	private static class Cat implements Comparable<Cat> {
+	static class Cat implements Comparable<Cat> {
 
 		@Id
 		@GeneratedValue

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/sorted/set/SortComparatorTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/sorted/set/SortComparatorTest.java
@@ -68,7 +68,7 @@ public class SortComparatorTest extends BaseNonConfigCoreFunctionalTestCase {
 
 	@Entity(name = "Owner")
 	@Table(name = "Owner")
-	private static class Owner {
+	static class Owner {
 
 		@Id
 		@GeneratedValue
@@ -81,7 +81,7 @@ public class SortComparatorTest extends BaseNonConfigCoreFunctionalTestCase {
 
 	@Entity(name = "Cat")
 	@Table(name = "Cat")
-	private static class Cat implements Comparable<Cat> {
+	static class Cat implements Comparable<Cat> {
 
 		@Id
 		@GeneratedValue

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/sorted/set/SortNaturalTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/sorted/set/SortNaturalTest.java
@@ -66,7 +66,7 @@ public class SortNaturalTest extends BaseNonConfigCoreFunctionalTestCase {
 
 	@Entity(name = "Owner")
 	@Table(name = "Owner")
-	private static class Owner {
+	static class Owner {
 
 		@Id
 		@GeneratedValue
@@ -79,7 +79,7 @@ public class SortNaturalTest extends BaseNonConfigCoreFunctionalTestCase {
 
 	@Entity(name = "Cat")
 	@Table(name = "Cat")
-	private static class Cat implements Comparable<Cat> {
+	static class Cat implements Comparable<Cat> {
 
 		@Id
 		@GeneratedValue

--- a/tooling/metamodel-generator/src/main/java/org/hibernate/processor/ClassWriter.java
+++ b/tooling/metamodel-generator/src/main/java/org/hibernate/processor/ClassWriter.java
@@ -4,6 +4,7 @@
  */
 package org.hibernate.processor;
 
+import jakarta.annotation.Nullable;
 import org.hibernate.processor.model.MetaAttribute;
 import org.hibernate.processor.model.Metamodel;
 
@@ -43,7 +44,7 @@ public final class ClassWriter {
 					getFullyQualifiedClassName( entity, metaModelPackage ),
 					entity.getElement()
 			);
-//			System.out.printf( "Generating metadata for %s => %s%n", entity.getQualifiedName(), fo.getName() );
+			/*System.out.printf( "Generating metadata for %s => %s%n", entity.getQualifiedName(), fo.getName() );*/
 			OutputStream os = fo.openOutputStream();
 			PrintWriter pw = new PrintWriter( os );
 
@@ -144,8 +145,14 @@ public final class ClassWriter {
 
 		String superClassName = entity.getSupertypeName();
 		if ( superClassName != null ) {
-			System.out.printf( "Superclass %s, entity %s%n", superClassName, context.getMetaEntity( superClassName ) );
-			pw.print( " extends " + getGeneratedSuperclassName(entity, superClassName) );
+			/*System.out.printf( "Superclass %s, entity %s%n", superClassName, context.getMetaEntity( superClassName ) );*/
+			Metamodel superClassEntity = context.getMetaEntity( superClassName );
+			if (superClassEntity == null) {
+				superClassEntity = context.getMetaEmbeddable( superClassName );
+			}
+			/*if (superClassEntity==null)throw new NullPointerException(
+					"Class %s, superclass %s".formatted( entity.getQualifiedName(), superClassName ) );*/
+			pw.print( " extends " + getGeneratedSuperclassName(entity, superClassName, superClassEntity ) );
 		}
 		if ( entity.isImplementation() ) {
 			pw.print( entity.getElement().getKind() == ElementKind.CLASS ? " extends " : " implements " );
@@ -169,7 +176,7 @@ public final class ClassWriter {
 		return entity.isJakartaDataStyle() ? '_' + className : className + '_';
 	}
 
-	private static String getGeneratedSuperclassName(Metamodel entity, String superClassName) {
+	private static String getGeneratedSuperclassName(Metamodel entity, String superClassName, @Nullable Metamodel superClassEntity) {
 		if ( entity.isJakartaDataStyle() ) {
 			int lastDot = superClassName.lastIndexOf('.');
 			if ( lastDot<0 ) {
@@ -181,23 +188,26 @@ public final class ClassWriter {
 			}
 		}
 		else {
-			final Metamodel superClassEntity = entity.getContext().getMetaEntity( superClassName );
 			final String className =
 					superClassEntity == null ? null :
 							superClassEntity.getSimpleName().replace( '.', '_' );
-			System.out.printf( "Super class name for %s%n", entity.getQualifiedName() );
+			/*System.out.printf( "Super class name for %s%n", entity.getQualifiedName() );
 			System.out.printf( "Super class name %s, class name %s%n", superClassName, className );
 			System.out.printf( "Superclass name %s %s vs %s%n",
 					superClassEntity != null ? superClassEntity.getQualifiedName() : null,
 					superClassName + '_',
-					superClassEntity == null ? null : getGeneratedClassName( superClassEntity ) );
+					superClassEntity == null ? null : getGeneratedClassName( superClassEntity ) );*/
 			/*return entity.getSimpleName().replace( '.', '_' ) + '_';*/
 			/*return superClassName + '_';*/
 			if ( superClassEntity == null ) {
-				//throw new NullPointerException();
+//				throw new NullPointerException();
+				System.err.printf( "Super class entity is null for %s, class %s%n",
+						superClassName, entity.getQualifiedName() );
 				return superClassName + '_';
 			}
-			return getGeneratedClassName( superClassEntity );
+//			return getGeneratedClassName( superClassEntity );
+			return getFullyQualifiedClassName( superClassEntity, superClassEntity.getPackageName() );
+			//return superClassName + '_';
 		}
 	}
 

--- a/tooling/metamodel-generator/src/main/java/org/hibernate/processor/ClassWriter.java
+++ b/tooling/metamodel-generator/src/main/java/org/hibernate/processor/ClassWriter.java
@@ -162,7 +162,7 @@ public final class ClassWriter {
 	}
 
 	private static String getGeneratedClassName(Metamodel entity) {
-		final String className = entity.getSimpleName();
+		final String className = entity.getSimpleName().replace( '.', '_' );
 		return entity.isJakartaDataStyle() ? '_' + className : className + '_';
 	}
 

--- a/tooling/metamodel-generator/src/main/java/org/hibernate/processor/HibernateProcessor.java
+++ b/tooling/metamodel-generator/src/main/java/org/hibernate/processor/HibernateProcessor.java
@@ -410,7 +410,9 @@ public class HibernateProcessor extends AbstractProcessor {
 				}
 			}
 			for (final  Element child : element.getEnclosedElements()) {
-				processElement( child );
+				if ( isClassOrRecordType( child ) ) {
+					processElement( child );
+				}
 			}
 		}
 		catch ( ProcessLaterException processLaterException ) {

--- a/tooling/metamodel-generator/src/main/java/org/hibernate/processor/HibernateProcessor.java
+++ b/tooling/metamodel-generator/src/main/java/org/hibernate/processor/HibernateProcessor.java
@@ -362,6 +362,7 @@ public class HibernateProcessor extends AbstractProcessor {
 		}
 
 		for ( Element element : roundEnvironment.getRootElements() ) {
+			System.out.printf( "[365] Processing element %s%n", element );
 			processElement( element );
 		}
 	}
@@ -374,6 +375,7 @@ public class HibernateProcessor extends AbstractProcessor {
 				// skip it completely
 			}
 			else if ( isEntityOrEmbeddable( element ) ) {
+				System.out.printf( "[378] Processing annotated entity class %s%n", element );
 				context.logMessage( Diagnostic.Kind.OTHER, "Processing annotated entity class '" + element + "'" );
 				handleRootElementAnnotationMirrors( element );
 			}
@@ -411,6 +413,7 @@ public class HibernateProcessor extends AbstractProcessor {
 			}
 			for (final  Element child : element.getEnclosedElements()) {
 				if ( isClassOrRecordType( child ) ) {
+					System.out.printf( "[416] Processing child element %s%n", child );
 					processElement( child );
 				}
 			}
@@ -570,6 +573,8 @@ public class HibernateProcessor extends AbstractProcessor {
 				final String qualifiedName = typeElement.getQualifiedName().toString();
 				final Metamodel alreadyExistingMetaEntity =
 						tryGettingExistingEntityFromContext( typeElement, qualifiedName );
+				System.out.printf( "Metamodel for %s, %s => %s%n",
+						typeElement, qualifiedName, alreadyExistingMetaEntity );
 				if ( alreadyExistingMetaEntity != null && alreadyExistingMetaEntity.isMetaComplete() ) {
 					context.logMessage(
 							Diagnostic.Kind.OTHER,
@@ -583,6 +588,7 @@ public class HibernateProcessor extends AbstractProcessor {
 							AnnotationMetaEntity.create( typeElement, context,
 									requiresLazyMemberInitialization,
 									true, false );
+					System.out.printf( "Meta entity => %s%n", metaEntity );
 					if ( alreadyExistingMetaEntity != null ) {
 						metaEntity.mergeInMembers( alreadyExistingMetaEntity );
 					}

--- a/tooling/metamodel-generator/src/main/java/org/hibernate/processor/HibernateProcessor.java
+++ b/tooling/metamodel-generator/src/main/java/org/hibernate/processor/HibernateProcessor.java
@@ -411,10 +411,12 @@ public class HibernateProcessor extends AbstractProcessor {
 					}
 				}
 			}
-			for (final  Element child : element.getEnclosedElements()) {
-				if ( isClassOrRecordType( child ) ) {
-					System.out.printf( "[416] Processing child element %s%n", child );
-					processElement( child );
+			if ( isClassOrRecordType( element ) ) {
+				for ( final Element child : element.getEnclosedElements() ) {
+					if ( isClassOrRecordType( child ) ) {
+						System.out.printf( "[416] Processing child element %s%n", child );
+						processElement( child );
+					}
 				}
 			}
 		}

--- a/tooling/metamodel-generator/src/main/java/org/hibernate/processor/HibernateProcessor.java
+++ b/tooling/metamodel-generator/src/main/java/org/hibernate/processor/HibernateProcessor.java
@@ -362,7 +362,12 @@ public class HibernateProcessor extends AbstractProcessor {
 		}
 
 		for ( Element element : roundEnvironment.getRootElements() ) {
-			System.out.printf( "[365] Processing element %s%n", element );
+//			if ( element instanceof TypeElement type ) {
+//				System.out.printf( "Processing %s: %s%n", element.getKind(), type.getQualifiedName() );
+//			}
+//			else {
+//				System.out.printf( "Processing %s: %s%n", element.getKind(), element.getSimpleName() );
+//			}
 			processElement( element );
 		}
 	}
@@ -375,7 +380,6 @@ public class HibernateProcessor extends AbstractProcessor {
 				// skip it completely
 			}
 			else if ( isEntityOrEmbeddable( element ) ) {
-				System.out.printf( "[378] Processing annotated entity class %s%n", element );
 				context.logMessage( Diagnostic.Kind.OTHER, "Processing annotated entity class '" + element + "'" );
 				handleRootElementAnnotationMirrors( element );
 			}
@@ -414,7 +418,6 @@ public class HibernateProcessor extends AbstractProcessor {
 			if ( isClassOrRecordType( element ) ) {
 				for ( final Element child : element.getEnclosedElements() ) {
 					if ( isClassOrRecordType( child ) ) {
-						System.out.printf( "[416] Processing child element %s%n", child );
 						processElement( child );
 					}
 				}
@@ -575,8 +578,6 @@ public class HibernateProcessor extends AbstractProcessor {
 				final String qualifiedName = typeElement.getQualifiedName().toString();
 				final Metamodel alreadyExistingMetaEntity =
 						tryGettingExistingEntityFromContext( typeElement, qualifiedName );
-				System.out.printf( "Metamodel for %s, %s => %s%n",
-						typeElement, qualifiedName, alreadyExistingMetaEntity );
 				if ( alreadyExistingMetaEntity != null && alreadyExistingMetaEntity.isMetaComplete() ) {
 					context.logMessage(
 							Diagnostic.Kind.OTHER,
@@ -590,7 +591,6 @@ public class HibernateProcessor extends AbstractProcessor {
 							AnnotationMetaEntity.create( typeElement, context,
 									requiresLazyMemberInitialization,
 									true, false );
-					System.out.printf( "Meta entity => %s%n", metaEntity );
 					if ( alreadyExistingMetaEntity != null ) {
 						metaEntity.mergeInMembers( alreadyExistingMetaEntity );
 					}

--- a/tooling/metamodel-generator/src/main/java/org/hibernate/processor/HibernateProcessor.java
+++ b/tooling/metamodel-generator/src/main/java/org/hibernate/processor/HibernateProcessor.java
@@ -34,6 +34,7 @@ import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.io.Writer;
+import java.net.URLEncoder;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
@@ -41,6 +42,7 @@ import java.util.Map;
 import java.util.Set;
 
 import static java.lang.Boolean.parseBoolean;
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static javax.lang.model.util.ElementFilter.fieldsIn;
 import static javax.lang.model.util.ElementFilter.methodsIn;
 import static org.hibernate.processor.HibernateProcessor.ADD_GENERATED_ANNOTATION;
@@ -731,7 +733,7 @@ public class HibernateProcessor extends AbstractProcessor {
 					.createResource(
 							StandardLocation.SOURCE_OUTPUT,
 							ENTITY_INDEX,
-							entityName,
+							URLEncoder.encode(entityName, UTF_8),
 							processingEnvironment.getElementUtils().getTypeElement( className )
 					)
 					.openWriter()) {

--- a/tooling/metamodel-generator/src/main/java/org/hibernate/processor/annotation/AnnotationMeta.java
+++ b/tooling/metamodel-generator/src/main/java/org/hibernate/processor/annotation/AnnotationMeta.java
@@ -19,6 +19,7 @@ import org.hibernate.query.criteria.JpaSelection;
 import org.hibernate.query.sqm.tree.SqmStatement;
 import org.hibernate.query.sqm.tree.select.SqmSelectClause;
 import org.hibernate.query.sqm.tree.select.SqmSelectStatement;
+import org.hibernate.type.descriptor.java.JavaType;
 
 import javax.lang.model.element.AnnotationMirror;
 import javax.lang.model.element.AnnotationValue;
@@ -147,7 +148,8 @@ public abstract class AnnotationMeta implements Metamodel {
 					: from.getSelectionItems().get(0).getJavaTypeName();
 		}
 		else if (selection instanceof JpaRoot<?> root) {
-			return root.getModel().getTypeName();
+			final JavaType<?> javaType = root.getModel().getExpressibleJavaType();
+			return javaType != null ? javaType.getTypeName() : root.getModel().getTypeName();
 		}
 		else if (selection instanceof JpaEntityJoin<?, ?> join) {
 			return join.getModel().getTypeName();

--- a/tooling/metamodel-generator/src/main/java/org/hibernate/processor/annotation/AnnotationMetaEntity.java
+++ b/tooling/metamodel-generator/src/main/java/org/hibernate/processor/annotation/AnnotationMetaEntity.java
@@ -54,6 +54,7 @@ import javax.tools.Diagnostic;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -217,11 +218,24 @@ public class AnnotationMetaEntity extends AnnotationMeta {
 
 	@Override
 	public final String getSimpleName() {
-		return removeDollar( element.getSimpleName().toString() );
+		if ( element.getNestingKind().isNested() ) {
+			final var strings = new ArrayList<String>();
+			for ( TypeElement el = element;; el = (TypeElement) el.getEnclosingElement() ) {
+				strings.add( removeDollar( el.getSimpleName().toString() ) );
+				if ( !el.getNestingKind().isNested() ) {
+					break;
+				}
+			}
+			Collections.reverse( strings );
+			return String.join( ".", strings );
+		}
+		else {
+			return removeDollar( element.getSimpleName().toString() );
+		}
 	}
 
 	private String getConstructorName() {
-		return getSimpleName() + '_';
+		return getSimpleName().replace( '.', '_' ) + '_';
 	}
 
 	/**

--- a/tooling/metamodel-generator/src/main/java/org/hibernate/processor/validation/MockSessionFactory.java
+++ b/tooling/metamodel-generator/src/main/java/org/hibernate/processor/validation/MockSessionFactory.java
@@ -114,6 +114,8 @@ import org.hibernate.type.MapType;
 import org.hibernate.type.SetType;
 import org.hibernate.type.SqlTypes;
 import org.hibernate.type.Type;
+import org.hibernate.type.descriptor.WrapperOptions;
+import org.hibernate.type.descriptor.java.BasicJavaType;
 import org.hibernate.type.descriptor.java.EnumJavaType;
 import org.hibernate.type.descriptor.java.JavaType;
 import org.hibernate.type.descriptor.java.spi.UnknownBasicJavaType;
@@ -121,6 +123,7 @@ import org.hibernate.type.descriptor.jdbc.JdbcTypeIndicators;
 import org.hibernate.type.descriptor.jdbc.ObjectJdbcType;
 import org.hibernate.type.spi.TypeConfiguration;
 
+import javax.lang.model.element.TypeElement;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -286,6 +289,8 @@ public abstract class MockSessionFactory
 	abstract MockCollectionPersister createMockCollectionPersister(String role);
 
 	abstract boolean isEntityDefined(String entityName);
+
+	abstract TypeElement findEntityClass(String entityName);
 
 	abstract String findEntityName(String typeName);
 
@@ -792,7 +797,9 @@ public abstract class MockSessionFactory
 		@Override
 		public EntityDomainType<?> entity(String entityName) {
 			if ( isEntityDefined(entityName) ) {
-				return new MockEntityDomainType<>(entityName);
+				final TypeElement entityClass = findEntityClass( entityName );
+				final String entityTypeName = entityClass == null ? entityName : entityClass.getQualifiedName().toString();
+				return new MockEntityDomainType<>(entityName, new MockJavaType<>( entityTypeName ));
 			}
 			else {
 				return null;
@@ -825,7 +832,7 @@ public abstract class MockSessionFactory
 		@Override
 		public <X> EntityDomainType<X> findEntityType(Class<X> cls) {
 			if ( isEntityDefined( cls.getName() ) ) {
-				return new MockEntityDomainType<>( cls.getName() );
+				return new MockEntityDomainType<>( cls.getName(), new MockJavaType<X>( cls.getName() ));
 			}
 			else {
 				return null;
@@ -887,6 +894,39 @@ public abstract class MockSessionFactory
 		public JpaCompliance getJpaCompliance() {
 			return jpaCompliance;
 		}
+
+		private static class MockJavaType<X> implements BasicJavaType<X> {
+			private final String typeName;
+
+			public MockJavaType(String typeName) {
+				this.typeName = typeName;
+			}
+
+			@Override
+			public <X1> X1 unwrap(X value, Class<X1> type, WrapperOptions options) {
+				return null;
+			}
+
+			@Override
+			public <X1> X wrap(X1 value, WrapperOptions options) {
+				return null;
+			}
+
+			@Override
+			public String getTypeName() {
+				return typeName;
+			}
+
+			@Override
+			public Class<X> getJavaTypeClass() {
+				try {
+					return (Class<X>) Class.forName( typeName );
+				}
+				catch (ClassNotFoundException e) {
+					return null;
+				}
+			}
+		}
 	}
 
 	@Nullable Set<String> getEnumTypesForValue(String value) {
@@ -909,8 +949,8 @@ public abstract class MockSessionFactory
 
 	class MockEntityDomainType<X> extends EntityTypeImpl<X> {
 
-		public MockEntityDomainType(String entityName) {
-			super(entityName, entityName, false, true, false, null, null,
+		public MockEntityDomainType(String entityName, JavaType<X> javaType) {
+			super(entityName, entityName, false, true, false, javaType, null,
 					metamodel.getJpaMetamodel());
 		}
 
@@ -994,7 +1034,8 @@ public abstract class MockSessionFactory
 				if (!entry.getValue().getEntityName().equals(getHibernateEntityName())
 						&& isSubtype(entry.getValue().getEntityName(), getHibernateEntityName())) {
 					PersistentAttribute<? super Object, ?> subattribute
-							= new MockEntityDomainType<>(entry.getValue().getEntityName()).findAttribute(name);
+							= new MockEntityDomainType<>(entry.getValue().getEntityName(), new MockJpaMetamodelImpl.MockJavaType<>(entry.getValue().getEntityName()) )
+							.findAttribute(name);
 					if (subattribute != null) {
 						return (SqmPathSource<?>) subattribute;
 					}
@@ -1040,7 +1081,7 @@ public abstract class MockSessionFactory
 					owner,
 					name,
 					AttributeClassification.MANY_TO_ONE,
-					new MockEntityDomainType<>(type.getName()),
+					new MockEntityDomainType<>(type.getName(), new MockJpaMetamodelImpl.MockJavaType<>(type.getName())),
 					null,
 					null,
 					false,
@@ -1098,7 +1139,9 @@ public abstract class MockSessionFactory
 	private DomainType<?> getDomainType(String entityName, CollectionType collectionType, ManagedDomainType<?> owner, Type elementType) {
 		if ( elementType.isEntityType() ) {
 			String associatedEntityName = collectionType.getAssociatedEntityName(MockSessionFactory.this);
-			return new MockEntityDomainType<>(associatedEntityName);
+			final TypeElement associatedEntityEntityClass = findEntityClass( associatedEntityName );
+			final String associatedEntityTypeName = associatedEntityEntityClass == null ? associatedEntityName : associatedEntityEntityClass.getQualifiedName().toString();
+			return new MockEntityDomainType<>(associatedEntityName, new MockJpaMetamodelImpl.MockJavaType<>(associatedEntityTypeName));
 		}
 		else if ( elementType.isComponentType() ) {
 			CompositeType compositeType = (CompositeType) elementType;

--- a/tooling/metamodel-generator/src/main/java/org/hibernate/processor/validation/ProcessorSessionFactory.java
+++ b/tooling/metamodel-generator/src/main/java/org/hibernate/processor/validation/ProcessorSessionFactory.java
@@ -495,7 +495,7 @@ public abstract class ProcessorSessionFactory extends MockSessionFactory {
 			&& findPropertyByPath(entityClass, fieldName, getDefaultAccessType(entityClass)) != null;
 	}
 
-	private TypeElement findEntityClass(String entityName) {
+	public TypeElement findEntityClass(String entityName) {
 		if (entityName == null) {
 			return null;
 		}

--- a/tooling/metamodel-generator/src/test/java/org/hibernate/processor/test/innerclass/Dummy.java
+++ b/tooling/metamodel-generator/src/test/java/org/hibernate/processor/test/innerclass/Dummy.java
@@ -7,14 +7,34 @@ package org.hibernate.processor.test.innerclass;
 import jakarta.persistence.Embeddable;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
+import jakarta.persistence.MappedSuperclass;
 
 public class Dummy {
 	@Entity
-	public static class Inner {
+	public static class Inner extends Persona {
 		@Id
 		Integer id;
 
 		String name;
+
+		public Integer getId() {
+			return id;
+		}
+
+		@Override
+		public void setId(Integer id) {
+			this.id = id;
+		}
+
+		@Override
+		public String getName() {
+			return name;
+		}
+
+		@Override
+		public void setName(String name) {
+			this.name = name;
+		}
 	}
 
 	@Embeddable
@@ -37,5 +57,24 @@ public class Dummy {
 		public void setValue(int value) {
 			this.value = value;
 		}
+	}
+
+	@MappedSuperclass
+	public abstract static class Persona {
+		private String city;
+
+		public String getCity() {
+			return city;
+		}
+
+		public void setCity(String city) {
+			this.city = city;
+		}
+
+		public abstract void setId(Integer id);
+
+		public abstract String getName();
+
+		public abstract void setName(String name);
 	}
 }

--- a/tooling/metamodel-generator/src/test/java/org/hibernate/processor/test/innerclass/Dummy.java
+++ b/tooling/metamodel-generator/src/test/java/org/hibernate/processor/test/innerclass/Dummy.java
@@ -1,0 +1,41 @@
+/*
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.processor.test.innerclass;
+
+import jakarta.persistence.Embeddable;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+
+public class Dummy {
+	@Entity
+	public static class Inner {
+		@Id
+		Integer id;
+
+		String name;
+	}
+
+	@Embeddable
+	public static class DummyEmbeddable {
+		private String name;
+		private int value;
+
+		public String getName() {
+			return name;
+		}
+
+		public void setName(String name) {
+			this.name = name;
+		}
+
+		public int getValue() {
+			return value;
+		}
+
+		public void setValue(int value) {
+			this.value = value;
+		}
+	}
+}

--- a/tooling/metamodel-generator/src/test/java/org/hibernate/processor/test/innerclass/Dummy.java
+++ b/tooling/metamodel-generator/src/test/java/org/hibernate/processor/test/innerclass/Dummy.java
@@ -8,9 +8,11 @@ import jakarta.persistence.Embeddable;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jakarta.persistence.MappedSuperclass;
+import jakarta.persistence.NamedQuery;
 
 public class Dummy {
-	@Entity
+	@Entity(name = "Inner")
+	@NamedQuery(name = "allInner", query = "from Inner")
 	public static class Inner extends Persona {
 		@Id
 		Integer id;

--- a/tooling/metamodel-generator/src/test/java/org/hibernate/processor/test/innerclass/InnerClassTest.java
+++ b/tooling/metamodel-generator/src/test/java/org/hibernate/processor/test/innerclass/InnerClassTest.java
@@ -5,18 +5,24 @@
 package org.hibernate.processor.test.innerclass;
 
 import org.hibernate.processor.test.util.CompilationTest;
-import org.hibernate.processor.test.util.TestUtil;
 import org.hibernate.processor.test.util.WithClasses;
 import org.junit.Test;
+
+import static org.hibernate.processor.test.util.TestUtil.assertMetamodelClassGeneratedFor;
+import static org.hibernate.processor.test.util.TestUtil.getMetaModelSourceAsString;
 
 public class InnerClassTest extends CompilationTest {
 
 	@WithClasses({Person.class, Dummy.class})
 	@Test
 	public void test() {
-		System.out.println( TestUtil.getMetaModelSourceAsString( Person.class ) );
-		System.out.println( TestUtil.getMetaModelSourceAsString( Person.PersonId.class ) );
-		System.out.println( TestUtil.getMetaModelSourceAsString( Dummy.DummyEmbeddable.class ) );
-		System.out.println( TestUtil.getMetaModelSourceAsString( Dummy.Inner.class ) );
+		assertMetamodelClassGeneratedFor( Person.class );
+		assertMetamodelClassGeneratedFor( Person.PersonId.class );
+		assertMetamodelClassGeneratedFor( Dummy.DummyEmbeddable.class );
+		assertMetamodelClassGeneratedFor( Dummy.Inner.class );
+		System.out.println( getMetaModelSourceAsString( Person.class ) );
+		System.out.println( getMetaModelSourceAsString( Person.PersonId.class ) );
+		System.out.println( getMetaModelSourceAsString( Dummy.DummyEmbeddable.class ) );
+		System.out.println( getMetaModelSourceAsString( Dummy.Inner.class ) );
 	}
 }

--- a/tooling/metamodel-generator/src/test/java/org/hibernate/processor/test/innerclass/InnerClassTest.java
+++ b/tooling/metamodel-generator/src/test/java/org/hibernate/processor/test/innerclass/InnerClassTest.java
@@ -4,25 +4,58 @@
  */
 package org.hibernate.processor.test.innerclass;
 
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.NamedQuery;
 import org.hibernate.processor.test.util.CompilationTest;
 import org.hibernate.processor.test.util.WithClasses;
 import org.junit.Test;
 
 import static org.hibernate.processor.test.util.TestUtil.assertMetamodelClassGeneratedFor;
 import static org.hibernate.processor.test.util.TestUtil.assertNoMetamodelClassGeneratedFor;
+import static org.hibernate.processor.test.util.TestUtil.getMetaModelSourceAsString;
 
 public class InnerClassTest extends CompilationTest {
 
-	@WithClasses({Person.class, Dummy.class})
+	@WithClasses({Person.class, Dummy.class, Inner.class})
 	@Test
 	public void test() {
+		assertMetamodelClassGeneratedFor( Inner.class );
+		System.out.println( getMetaModelSourceAsString( Inner.class ) );
+		assertMetamodelClassGeneratedFor( Dummy.Inner.class );
+		System.out.println( getMetaModelSourceAsString( Dummy.Inner.class ) );
 		assertMetamodelClassGeneratedFor( Person.class );
+		System.out.println( getMetaModelSourceAsString( Person.class ) );
 		assertMetamodelClassGeneratedFor( Person.PersonId.class );
+		System.out.println( getMetaModelSourceAsString( Person.PersonId.class ) );
 		assertNoMetamodelClassGeneratedFor( Dummy.class );
 		assertMetamodelClassGeneratedFor( Dummy.DummyEmbeddable.class );
-		assertMetamodelClassGeneratedFor( Dummy.Inner.class );
-		/*assertMetamodelClassGeneratedFor( Dummy.Persona.class );*/
-//		assertMetamodelClassGeneratedFor( Persona.class );
+		System.out.println( getMetaModelSourceAsString( Dummy.DummyEmbeddable.class ) );
+	}
+
+	@Entity(name = "Inner")
+	@NamedQuery(name = "allInner", query = "from Inner")
+	public static class Inner {
+		@Id
+		Integer id;
+
+		String address;
+
+		public Integer getId() {
+			return id;
+		}
+
+		public void setId(Integer id) {
+			this.id = id;
+		}
+
+		public String getAddress() {
+			return address;
+		}
+
+		public void setAddress(String address) {
+			this.address = address;
+		}
 	}
 
 //	@MappedSuperclass

--- a/tooling/metamodel-generator/src/test/java/org/hibernate/processor/test/innerclass/InnerClassTest.java
+++ b/tooling/metamodel-generator/src/test/java/org/hibernate/processor/test/innerclass/InnerClassTest.java
@@ -21,5 +21,26 @@ public class InnerClassTest extends CompilationTest {
 		assertNoMetamodelClassGeneratedFor( Dummy.class );
 		assertMetamodelClassGeneratedFor( Dummy.DummyEmbeddable.class );
 		assertMetamodelClassGeneratedFor( Dummy.Inner.class );
+		/*assertMetamodelClassGeneratedFor( Dummy.Persona.class );*/
+//		assertMetamodelClassGeneratedFor( Persona.class );
 	}
+
+//	@MappedSuperclass
+//	public abstract static class Persona {
+//		private String name;
+//
+//		public String getName() {
+//			return name;
+//		}
+//
+//		public void setName(String name) {
+//			this.name = name;
+//		}
+//
+//		public abstract void setId(Long id);
+//
+//		public abstract String getCity();
+//
+//		public abstract void setCity(String city);
+//	}
 }

--- a/tooling/metamodel-generator/src/test/java/org/hibernate/processor/test/innerclass/InnerClassTest.java
+++ b/tooling/metamodel-generator/src/test/java/org/hibernate/processor/test/innerclass/InnerClassTest.java
@@ -7,12 +7,11 @@ package org.hibernate.processor.test.innerclass;
 import org.hibernate.processor.test.util.CompilationTest;
 import org.hibernate.processor.test.util.TestUtil;
 import org.hibernate.processor.test.util.WithClasses;
-
 import org.junit.Test;
 
 public class InnerClassTest extends CompilationTest {
 
-	@WithClasses({ Person.class })
+	@WithClasses({Person.class, Dummy.class})
 	@Test
 	public void test() {
 		System.out.println( TestUtil.getMetaModelSourceAsString( Person.class ) );

--- a/tooling/metamodel-generator/src/test/java/org/hibernate/processor/test/innerclass/InnerClassTest.java
+++ b/tooling/metamodel-generator/src/test/java/org/hibernate/processor/test/innerclass/InnerClassTest.java
@@ -9,7 +9,7 @@ import org.hibernate.processor.test.util.WithClasses;
 import org.junit.Test;
 
 import static org.hibernate.processor.test.util.TestUtil.assertMetamodelClassGeneratedFor;
-import static org.hibernate.processor.test.util.TestUtil.getMetaModelSourceAsString;
+import static org.hibernate.processor.test.util.TestUtil.assertNoMetamodelClassGeneratedFor;
 
 public class InnerClassTest extends CompilationTest {
 
@@ -18,11 +18,8 @@ public class InnerClassTest extends CompilationTest {
 	public void test() {
 		assertMetamodelClassGeneratedFor( Person.class );
 		assertMetamodelClassGeneratedFor( Person.PersonId.class );
+		assertNoMetamodelClassGeneratedFor( Dummy.class );
 		assertMetamodelClassGeneratedFor( Dummy.DummyEmbeddable.class );
 		assertMetamodelClassGeneratedFor( Dummy.Inner.class );
-		System.out.println( getMetaModelSourceAsString( Person.class ) );
-		System.out.println( getMetaModelSourceAsString( Person.PersonId.class ) );
-		System.out.println( getMetaModelSourceAsString( Dummy.DummyEmbeddable.class ) );
-		System.out.println( getMetaModelSourceAsString( Dummy.Inner.class ) );
 	}
 }

--- a/tooling/metamodel-generator/src/test/java/org/hibernate/processor/test/innerclass/InnerClassTest.java
+++ b/tooling/metamodel-generator/src/test/java/org/hibernate/processor/test/innerclass/InnerClassTest.java
@@ -1,0 +1,20 @@
+/*
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.processor.test.innerclass;
+
+import org.hibernate.processor.test.util.CompilationTest;
+import org.hibernate.processor.test.util.TestUtil;
+import org.hibernate.processor.test.util.WithClasses;
+
+import org.junit.Test;
+
+public class InnerClassTest extends CompilationTest {
+
+	@WithClasses({ Person.class })
+	@Test
+	public void test() {
+		System.out.println( TestUtil.getMetaModelSourceAsString( Person.class ) );
+	}
+}

--- a/tooling/metamodel-generator/src/test/java/org/hibernate/processor/test/innerclass/InnerClassTest.java
+++ b/tooling/metamodel-generator/src/test/java/org/hibernate/processor/test/innerclass/InnerClassTest.java
@@ -15,5 +15,8 @@ public class InnerClassTest extends CompilationTest {
 	@Test
 	public void test() {
 		System.out.println( TestUtil.getMetaModelSourceAsString( Person.class ) );
+		System.out.println( TestUtil.getMetaModelSourceAsString( Person.PersonId.class ) );
+		System.out.println( TestUtil.getMetaModelSourceAsString( Dummy.DummyEmbeddable.class ) );
+		System.out.println( TestUtil.getMetaModelSourceAsString( Dummy.Inner.class ) );
 	}
 }

--- a/tooling/metamodel-generator/src/test/java/org/hibernate/processor/test/innerclass/Person.java
+++ b/tooling/metamodel-generator/src/test/java/org/hibernate/processor/test/innerclass/Person.java
@@ -1,0 +1,44 @@
+/*
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.processor.test.innerclass;
+
+import jakarta.persistence.Embeddable;
+import jakarta.persistence.EmbeddedId;
+import jakarta.persistence.Entity;
+
+/**
+ * @author Hardy Ferentschik
+ */
+@Entity
+public class Person {
+	@EmbeddedId
+	private PersonId id;
+
+	private String address;
+
+	@Embeddable
+	public static class PersonId {
+		private String name;
+		private String snn;
+
+		public String getName() {
+			return name;
+		}
+
+		public void setName(String name) {
+			this.name = name;
+		}
+
+		public String getSnn() {
+			return snn;
+		}
+
+		public void setSnn(String snn) {
+			this.snn = snn;
+		}
+	}
+
+
+}

--- a/tooling/metamodel-generator/src/test/java/org/hibernate/processor/test/util/CompilationStatement.java
+++ b/tooling/metamodel-generator/src/test/java/org/hibernate/processor/test/util/CompilationStatement.java
@@ -100,6 +100,9 @@ public class CompilationStatement extends Statement {
 	}
 
 	private String getPathToSource(Class<?> testClass) {
+		if ( testClass.isMemberClass() ) {
+			return getPathToSource( testClass.getDeclaringClass() );
+		}
 		return TestUtil.getSourceBaseDir( testClass ).getAbsolutePath() + File.separator + testClass.getName()
 				.replace( PACKAGE_SEPARATOR, File.separator ) + ".java";
 	}

--- a/tooling/metamodel-generator/src/test/java/org/hibernate/processor/test/util/TestUtil.java
+++ b/tooling/metamodel-generator/src/test/java/org/hibernate/processor/test/util/TestUtil.java
@@ -351,9 +351,12 @@ public class TestUtil {
 	}
 
 	private static String getMetaModelClassName(Class<?> clazz, boolean prefix) {
-		return prefix
-				? clazz.getPackageName() + '.' + META_MODEL_CLASS_POSTFIX + clazz.getSimpleName()
-				: clazz.getName() + META_MODEL_CLASS_POSTFIX;
+		final String packageName = clazz.getPackageName();
+		if ( prefix ) {
+			return packageName + '.' + META_MODEL_CLASS_POSTFIX + clazz.getSimpleName();
+		}
+		return packageName
+				+ clazz.getName().substring( packageName.length() ).replace( '$', '_' ) + META_MODEL_CLASS_POSTFIX;
 	}
 
 	private static String getMetaModelClassName(String className) {


### PR DESCRIPTION
See Jira Issue [HHH-18693](https://hibernate.atlassian.net/browse/HHH-18693)

This is still work in progress, not to be merged with main branch, at least not immediately.

For each (static) inner non-private class one meta-model class will be generated. 

Naming is as follows. If we have:
```
class A {
    ...
    @Entity
    static class B {
        ...
    }
    ...
}
```

Generated class will be named `A_B_`

Some existing test classes were changed to make inner classes non-private. Otherwise  such class could not be referenced from meta model class.
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------


[HHH-18693]: https://hibernate.atlassian.net/browse/HHH-18693?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ