### PR TITLE
HHH-18693 Hibernate Processor does not handle inner types

### DIFF
--- a/hibernate-core/src/test/java/org/hibernate/orm/test/collection/bag/PersistentBagContainsTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/collection/bag/PersistentBagContainsTest.java
@@ -14,6 +14,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 
+import org.hibernate.annotations.processing.Exclude;
 import org.hibernate.testing.orm.junit.JiraKey;
 import org.hibernate.testing.orm.junit.DomainModel;
 import org.hibernate.testing.orm.junit.SessionFactory;
@@ -34,6 +35,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 		}
 )
 @SessionFactory
+@Exclude
 public class PersistentBagContainsTest {
 
 	/**

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/event/entity/MergeListPreAndPostPersistTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/event/entity/MergeListPreAndPostPersistTest.java
@@ -13,6 +13,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.OneToMany;
 
 import org.hibernate.Session;
+import org.hibernate.annotations.processing.Exclude;
 import org.hibernate.event.service.spi.EventListenerRegistry;
 import org.hibernate.event.spi.EventType;
 import org.hibernate.event.spi.PostInsertEvent;
@@ -31,6 +32,7 @@ import static org.junit.Assert.assertEquals;
  * @author Gail Badner
  */
 @JiraKey( value = "HHH-9979")
+@Exclude
 public class MergeListPreAndPostPersistTest extends BaseCoreFunctionalTestCase {
 
 	protected Class[] getAnnotatedClasses() {

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/hql/QuotedIdentifierTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/hql/QuotedIdentifierTest.java
@@ -6,6 +6,7 @@ package org.hibernate.orm.test.hql;
 
 import java.util.List;
 
+import org.hibernate.annotations.processing.Exclude;
 import org.hibernate.testing.junit4.BaseCoreFunctionalTestCase;
 import org.junit.After;
 import org.junit.Before;
@@ -24,6 +25,7 @@ import static org.junit.Assert.assertEquals;
 /**
  * @author Christian Beikov
  */
+@Exclude
 public class QuotedIdentifierTest extends BaseCoreFunctionalTestCase {
 
 	private Person person;

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/schemaupdate/SchemaUpdateWithUseJdbcMetadataDefaultsSettingToFalseAndQuotedNameTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/schemaupdate/SchemaUpdateWithUseJdbcMetadataDefaultsSettingToFalseAndQuotedNameTest.java
@@ -14,6 +14,7 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 
+import org.hibernate.annotations.processing.Exclude;
 import org.hibernate.boot.MetadataSources;
 import org.hibernate.boot.registry.StandardServiceRegistry;
 import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
@@ -36,6 +37,7 @@ import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
 
 @JiraKey(value = "HHH-13788")
+@Exclude
 public class SchemaUpdateWithUseJdbcMetadataDefaultsSettingToFalseAndQuotedNameTest {
 
 	private File updateOutputFile;

--- a/tooling/metamodel-generator/src/jakartaData/java/org/hibernate/processor/test/data/innerclass/Dummy.java
+++ b/tooling/metamodel-generator/src/jakartaData/java/org/hibernate/processor/test/data/innerclass/Dummy.java
@@ -1,0 +1,82 @@
+/*
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.processor.test.data.innerclass;
+
+import jakarta.persistence.Embeddable;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.MappedSuperclass;
+import jakarta.persistence.NamedQuery;
+
+public class Dummy {
+	@Entity(name = "Inner")
+	@NamedQuery(name = "allInner", query = "from Inner")
+	public static class Inner extends Persona {
+		@Id
+		Integer id;
+
+		String name;
+
+		public Integer getId() {
+			return id;
+		}
+
+		@Override
+		public void setId(Integer id) {
+			this.id = id;
+		}
+
+		@Override
+		public String getName() {
+			return name;
+		}
+
+		@Override
+		public void setName(String name) {
+			this.name = name;
+		}
+	}
+
+	@Embeddable
+	public static class DummyEmbeddable {
+		private String name;
+		private int value;
+
+		public String getName() {
+			return name;
+		}
+
+		public void setName(String name) {
+			this.name = name;
+		}
+
+		public int getValue() {
+			return value;
+		}
+
+		public void setValue(int value) {
+			this.value = value;
+		}
+	}
+
+	@MappedSuperclass
+	public abstract static class Persona {
+		private String city;
+
+		public String getCity() {
+			return city;
+		}
+
+		public void setCity(String city) {
+			this.city = city;
+		}
+
+		public abstract void setId(Integer id);
+
+		public abstract String getName();
+
+		public abstract void setName(String name);
+	}
+}

--- a/tooling/metamodel-generator/src/jakartaData/java/org/hibernate/processor/test/data/innerclass/InnerClassTest.java
+++ b/tooling/metamodel-generator/src/jakartaData/java/org/hibernate/processor/test/data/innerclass/InnerClassTest.java
@@ -1,0 +1,86 @@
+/*
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.processor.test.data.innerclass;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.NamedQuery;
+import org.hibernate.processor.test.data.innerclass.InnerClassTest.One.Two;
+import org.hibernate.processor.test.util.CompilationTest;
+import org.hibernate.processor.test.util.WithClasses;
+import org.junit.Test;
+
+import static org.hibernate.processor.test.util.TestUtil.assertMetamodelClassGeneratedFor;
+import static org.hibernate.processor.test.util.TestUtil.assertNoMetamodelClassGeneratedFor;
+import static org.hibernate.processor.test.util.TestUtil.getMetaModelSourceAsString;
+import static org.junit.Assert.assertEquals;
+
+public class InnerClassTest extends CompilationTest {
+
+	@WithClasses({Person.class, Dummy.class, Inner.class, Two.class})
+	@Test
+	public void test() {
+		System.out.println( getMetaModelSourceAsString( InnerClassTest.class ) );
+		System.out.println( getMetaModelSourceAsString( Dummy.class ) );
+		System.out.println( getMetaModelSourceAsString( Person.class ) );
+		System.out.println( getMetaModelSourceAsString( InnerClassTest.class, true ) );
+		System.out.println( getMetaModelSourceAsString( Dummy.class, true ) );
+		System.out.println( getMetaModelSourceAsString( Person.class, true ) );
+		assertEquals(
+				getMetaModelSourceAsString( Inner.class ),
+				getMetaModelSourceAsString( Two.class )
+		);
+		assertEquals(
+				getMetaModelSourceAsString( Inner.class, true ),
+				getMetaModelSourceAsString( Two.class, true )
+		);
+		assertMetamodelClassGeneratedFor( Inner.class );
+		assertMetamodelClassGeneratedFor( Inner.class, true );
+		assertMetamodelClassGeneratedFor( Two.class );
+		assertMetamodelClassGeneratedFor( Two.class, true );
+		assertMetamodelClassGeneratedFor( Dummy.Inner.class );
+		assertMetamodelClassGeneratedFor( Dummy.Inner.class, true );
+		assertMetamodelClassGeneratedFor( Person.class );
+		assertMetamodelClassGeneratedFor( Person.class, true );
+		assertMetamodelClassGeneratedFor( Person.PersonId.class );
+		assertNoMetamodelClassGeneratedFor( Dummy.class );
+		assertMetamodelClassGeneratedFor( Dummy.DummyEmbeddable.class );
+		/*assertNoMetamodelClassGeneratedFor( Dummy.class );*/
+	}
+
+	@Entity(name = "Inner")
+	@NamedQuery(name = "allInner", query = "from Inner")
+	public static class Inner {
+		@Id
+		Integer id;
+
+		String address;
+
+		public Integer getId() {
+			return id;
+		}
+
+		public void setId(Integer id) {
+			this.id = id;
+		}
+
+		public String getAddress() {
+			return address;
+		}
+
+		public void setAddress(String address) {
+			this.address = address;
+		}
+	}
+
+	static class One {
+		@Entity
+		static class Two {
+			@Id
+			Integer id;
+			String value;
+		}
+	}
+}

--- a/tooling/metamodel-generator/src/jakartaData/java/org/hibernate/processor/test/data/innerclass/Person.java
+++ b/tooling/metamodel-generator/src/jakartaData/java/org/hibernate/processor/test/data/innerclass/Person.java
@@ -1,0 +1,44 @@
+/*
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.processor.test.data.innerclass;
+
+import jakarta.persistence.Embeddable;
+import jakarta.persistence.EmbeddedId;
+import jakarta.persistence.Entity;
+
+/**
+ * @author Hardy Ferentschik
+ */
+@Entity
+public class Person {
+	@EmbeddedId
+	private PersonId id;
+
+	private String address;
+
+	@Embeddable
+	public static class PersonId {
+		private String name;
+		private String snn;
+
+		public String getName() {
+			return name;
+		}
+
+		public void setName(String name) {
+			this.name = name;
+		}
+
+		public String getSnn() {
+			return snn;
+		}
+
+		public void setSnn(String snn) {
+			this.snn = snn;
+		}
+	}
+
+
+}

--- a/tooling/metamodel-generator/src/main/java/org/hibernate/processor/ClassWriter.java
+++ b/tooling/metamodel-generator/src/main/java/org/hibernate/processor/ClassWriter.java
@@ -4,11 +4,16 @@
  */
 package org.hibernate.processor;
 
+import org.hibernate.processor.annotation.InnerClassMetaAttribute;
 import org.hibernate.processor.model.MetaAttribute;
 import org.hibernate.processor.model.Metamodel;
+import org.hibernate.processor.util.StringUtil;
 
 import javax.annotation.processing.FilerException;
+import javax.lang.model.element.Element;
 import javax.lang.model.element.ElementKind;
+import javax.lang.model.element.Modifier;
+import javax.lang.model.element.PackageElement;
 import javax.lang.model.element.TypeElement;
 import javax.tools.Diagnostic;
 import javax.tools.FileObject;
@@ -18,7 +23,12 @@ import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.time.OffsetDateTime;
 import java.time.format.DateTimeFormatter;
+import java.util.Arrays;
 import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.hibernate.processor.util.TypeUtils.isMemberType;
 
 /**
  * Helper class to write the actual metamodel class using the  {@link javax.annotation.processing.Filer} API.
@@ -39,7 +49,7 @@ public final class ClassWriter {
 			String body = generateBody( entity, context ).toString();
 
 			FileObject fo = context.getProcessingEnvironment().getFiler().createSourceFile(
-					getFullyQualifiedClassName( entity, metaModelPackage ),
+					getFullyQualifiedClassName( entity ),
 					entity.getElement()
 			);
 			OutputStream os = fo.openOutputStream();
@@ -102,6 +112,15 @@ public final class ClassWriter {
 
 			final List<MetaAttribute> members = entity.getMembers();
 			for ( MetaAttribute metaMember : members ) {
+				if ( metaMember instanceof InnerClassMetaAttribute innerClass ) {
+					generateBody( innerClass.getMetaEntity(), context )
+							.toString().lines()
+							.forEach(line -> pw.println('\t' + line));
+					context.markGenerated( innerClass.getMetaEntity() );
+				}
+			}
+
+			for ( MetaAttribute metaMember : members ) {
 				if ( metaMember.hasStringAttribute() ) {
 					metaMember.getAttributeNameDeclarationString().lines()
 							.forEach(line -> pw.println('\t' + line));
@@ -133,16 +152,29 @@ public final class ClassWriter {
 	}
 
 	private static void printClassDeclaration(Metamodel entity, PrintWriter pw) {
-		pw.print( "public " );
+		if ( isMemberType( entity.getElement() ) ) {
+			final Set<Modifier> modifiers = entity.getElement().getModifiers();
+			if ( modifiers.contains( Modifier.PUBLIC ) ) {
+				pw.print( "public " );
+			}
+			else if ( modifiers.contains( Modifier.PROTECTED ) ) {
+				pw.print( "protected " );
+			}
+			pw.print( "static " );
+		}
+		else {
+			pw.print( "public " );
+		}
 		if ( !entity.isImplementation() && !entity.isJakartaDataStyle() ) {
 			pw.print( "abstract " );
 		}
 		pw.print( entity.isJakartaDataStyle() ? "interface " : "class " );
 		pw.print( getGeneratedClassName(entity) );
 
-		String superClassName = entity.getSupertypeName();
-		if ( superClassName != null ) {
-			pw.print( " extends " + getGeneratedSuperclassName(entity, superClassName) );
+		final Element superTypeElement = entity.getSuperTypeElement();
+		if ( superTypeElement != null ) {
+			pw.print( " extends " +
+					entity.importType(getGeneratedSuperclassName( superTypeElement, entity.isJakartaDataStyle() )) );
 		}
 		if ( entity.isImplementation() ) {
 			pw.print( entity.getElement().getKind() == ElementKind.CLASS ? " extends " : " implements " );
@@ -152,13 +184,21 @@ public final class ClassWriter {
 		pw.println( " {" );
 	}
 
-	private static String getFullyQualifiedClassName(Metamodel entity, String metaModelPackage) {
-		String fullyQualifiedClassName = "";
-		if ( !metaModelPackage.isEmpty() ) {
-			fullyQualifiedClassName = fullyQualifiedClassName + metaModelPackage + ".";
+	private static String getFullyQualifiedClassName(Metamodel entity) {
+		final String metaModelPackage = entity.getPackageName();
+		final String packageNamePrefix = !metaModelPackage.isEmpty() ? metaModelPackage + "." : "";
+		final String className;
+		if ( entity.getElement().getKind() == ElementKind.PACKAGE ) {
+			className = getGeneratedClassName( entity );
 		}
-		fullyQualifiedClassName = fullyQualifiedClassName + getGeneratedClassName( entity );
-		return fullyQualifiedClassName;
+		else {
+			className = Arrays.stream(
+							entity.getQualifiedName().substring( packageNamePrefix.length() ).split( "\\." ) )
+					.map( StringUtil::removeDollar )
+					.map( part -> entity.isJakartaDataStyle() ? '_' + part : part + '_' )
+					.collect( Collectors.joining( "." ) );
+		}
+		return packageNamePrefix + className;
 	}
 
 	private static String getGeneratedClassName(Metamodel entity) {
@@ -166,20 +206,14 @@ public final class ClassWriter {
 		return entity.isJakartaDataStyle() ? '_' + className : className + '_';
 	}
 
-	private static String getGeneratedSuperclassName(Metamodel entity, String superClassName) {
-		if ( entity.isJakartaDataStyle() ) {
-			int lastDot = superClassName.lastIndexOf('.');
-			if ( lastDot<0 ) {
-				return '_' + superClassName;
-			}
-			else {
-				return superClassName.substring(0,lastDot+1)
-						+ '_' + superClassName.substring(lastDot+1);
-			}
-		}
-		else {
-			return superClassName + '_';
-		}
+	private static String getGeneratedSuperclassName(Element superClassElement, boolean jakartaDataStyle) {
+		final TypeElement typeElement = (TypeElement) superClassElement;
+		final String simpleName = typeElement.getSimpleName().toString();
+		final Element enclosingElement = typeElement.getEnclosingElement();
+		return (enclosingElement instanceof TypeElement
+				? getGeneratedSuperclassName( enclosingElement, jakartaDataStyle )
+				: ((PackageElement) enclosingElement).getQualifiedName().toString())
+				+ "." + (jakartaDataStyle ? '_' + simpleName : simpleName + '_');
 	}
 
 	private static String writeGeneratedAnnotation(Metamodel entity, Context context) {
@@ -227,6 +261,7 @@ public final class ClassWriter {
 		final String annotation = entity.isJakartaDataStyle()
 				? "jakarta.data.metamodel.StaticMetamodel"
 				: "jakarta.persistence.metamodel.StaticMetamodel";
-		return "@" + entity.importType( annotation ) + "(" + entity.getSimpleName() + ".class)";
+		final String simpleName = entity.importType( entity.getQualifiedName() );
+		return "@" + entity.importType( annotation ) + "(" + simpleName + ".class)";
 	}
 }

--- a/tooling/metamodel-generator/src/main/java/org/hibernate/processor/Context.java
+++ b/tooling/metamodel-generator/src/main/java/org/hibernate/processor/Context.java
@@ -304,6 +304,15 @@ public final class Context {
 		return dataMetaEmbeddables.values();
 	}
 
+	public @Nullable Metamodel getMetamodel(String qualifiedName) {
+		if ( metaEntities.containsKey( qualifiedName ) ) {
+			return metaEntities.get( qualifiedName );
+		}
+		else {
+			return metaEmbeddables.get( qualifiedName );
+		}
+	}
+
 	public @Nullable Metamodel getMetaAuxiliary(String qualifiedName) {
 		return metaAuxiliaries.get( qualifiedName );
 	}

--- a/tooling/metamodel-generator/src/main/java/org/hibernate/processor/annotation/AnnotationMetaPackage.java
+++ b/tooling/metamodel-generator/src/main/java/org/hibernate/processor/annotation/AnnotationMetaPackage.java
@@ -11,6 +11,7 @@ import org.hibernate.processor.model.ImportContext;
 import org.hibernate.processor.model.MetaAttribute;
 
 import javax.lang.model.element.AnnotationMirror;
+import javax.lang.model.element.Element;
 import javax.lang.model.element.PackageElement;
 import javax.tools.Diagnostic;
 import java.util.ArrayList;
@@ -69,7 +70,7 @@ public class AnnotationMetaPackage extends AnnotationMeta {
 	}
 
 	@Override
-	public @Nullable String getSupertypeName() {
+	public @Nullable Element getSuperTypeElement() {
 		return null;
 	}
 

--- a/tooling/metamodel-generator/src/main/java/org/hibernate/processor/annotation/DefaultConstructor.java
+++ b/tooling/metamodel-generator/src/main/java/org/hibernate/processor/annotation/DefaultConstructor.java
@@ -66,7 +66,7 @@ public class DefaultConstructor implements MetaAttribute {
 		final StringBuilder declaration = new StringBuilder();
 		declaration
 				.append('\n');
-		if ( annotationMetaEntity.getSupertypeName() == null ) {
+		if ( annotationMetaEntity.getSuperTypeElement() == null ) {
 			declaration
 					.append("@")
 					.append(annotationMetaEntity.importType("jakarta.persistence.PersistenceUnit"));

--- a/tooling/metamodel-generator/src/main/java/org/hibernate/processor/annotation/InnerClassMetaAttribute.java
+++ b/tooling/metamodel-generator/src/main/java/org/hibernate/processor/annotation/InnerClassMetaAttribute.java
@@ -1,0 +1,73 @@
+/*
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.processor.annotation;
+
+import org.hibernate.processor.model.MetaAttribute;
+import org.hibernate.processor.model.Metamodel;
+
+public class InnerClassMetaAttribute implements MetaAttribute {
+
+	private final AnnotationMeta metaEntity;
+
+	public InnerClassMetaAttribute(AnnotationMeta parent) {
+		this.metaEntity = parent;
+	}
+
+	public AnnotationMeta getMetaEntity() {
+		return metaEntity;
+	}
+
+	@Override
+	public boolean hasTypedAttribute() {
+		return true;
+	}
+
+	@Override
+	public boolean hasStringAttribute() {
+		return false;
+	}
+
+	@Override
+	public String getAttributeDeclarationString() {
+//		final StringBuilder decl = new StringBuilder()
+//				.append("\n/**\n * Static ID class for {@link ")
+//				.append( parent.getQualifiedName() )
+//				.append( "}\n **/\n" )
+//				.append( "public record Id" );
+//		String delimiter = "(";
+//		for ( MetaAttribute component : components ) {
+//			decl.append( delimiter ).append( parent.importType( component.getTypeDeclaration() ) )
+//					.append( ' ' ).append( component.getPropertyName() );
+//			delimiter = ", ";
+//		}
+//		return decl.append( ") {}" ).toString();
+		return "";
+	}
+
+	@Override
+	public String getAttributeNameDeclarationString() {
+		return "";
+	}
+
+	@Override
+	public String getMetaType() {
+		return "";
+	}
+
+	@Override
+	public String getPropertyName() {
+		return "";
+	}
+
+	@Override
+	public String getTypeDeclaration() {
+		return "";
+	}
+
+	@Override
+	public Metamodel getHostingEntity() {
+		return metaEntity;
+	}
+}

--- a/tooling/metamodel-generator/src/main/java/org/hibernate/processor/annotation/NonManagedMetamodel.java
+++ b/tooling/metamodel-generator/src/main/java/org/hibernate/processor/annotation/NonManagedMetamodel.java
@@ -1,0 +1,39 @@
+/*
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.processor.annotation;
+
+import org.checkerframework.checker.nullness.qual.Nullable;
+import org.hibernate.processor.Context;
+
+import javax.lang.model.element.TypeElement;
+
+public class NonManagedMetamodel extends AnnotationMetaEntity {
+
+	public NonManagedMetamodel(TypeElement element, Context context, boolean jakartaDataStaticMetamodel, @Nullable AnnotationMeta parent) {
+		super( element, context, false, jakartaDataStaticMetamodel, parent );
+	}
+
+	public static NonManagedMetamodel create(
+			TypeElement element, Context context,
+			boolean jakartaDataStaticMetamodel,
+			@Nullable AnnotationMetaEntity parent) {
+		final NonManagedMetamodel metamodel =
+				new NonManagedMetamodel( element, context, jakartaDataStaticMetamodel, parent );
+		if ( parent != null ) {
+			metamodel.setParentElement( parent.getElement() );
+			parent.addInnerClass( metamodel );
+		}
+		return metamodel;
+	}
+
+	protected void init() {
+		// Initialization is not needed when non-managed class
+	}
+
+	@Override
+	public String javadoc() {
+		return "";
+	}
+}

--- a/tooling/metamodel-generator/src/main/java/org/hibernate/processor/annotation/RepositoryConstructor.java
+++ b/tooling/metamodel-generator/src/main/java/org/hibernate/processor/annotation/RepositoryConstructor.java
@@ -67,7 +67,7 @@ public class RepositoryConstructor implements MetaAttribute {
 		final StringBuilder declaration = new StringBuilder();
 		declaration
 				.append('\n');
-		if ( annotationMetaEntity.getSupertypeName() == null ) {
+		if ( annotationMetaEntity.getSuperTypeElement() == null ) {
 			declaration
 					.append("protected ");
 			if ( !dataRepository ) {
@@ -96,7 +96,7 @@ public class RepositoryConstructor implements MetaAttribute {
 				.append(" ")
 				.append(sessionVariableName)
 				.append(") {\n");
-		if ( annotationMetaEntity.getSupertypeName() != null ) {
+		if ( annotationMetaEntity.getSuperTypeElement() != null ) {
 			declaration
 					.append("\tsuper(")
 					.append(sessionVariableName)
@@ -112,7 +112,7 @@ public class RepositoryConstructor implements MetaAttribute {
 		}
 		declaration
 				.append("}");
-		if ( annotationMetaEntity.getSupertypeName() == null ) {
+		if ( annotationMetaEntity.getSuperTypeElement() == null ) {
 			declaration
 					.append("\n\n");
 			if (addOverrideAnnotation) {

--- a/tooling/metamodel-generator/src/main/java/org/hibernate/processor/model/Metamodel.java
+++ b/tooling/metamodel-generator/src/main/java/org/hibernate/processor/model/Metamodel.java
@@ -19,7 +19,7 @@ public interface Metamodel extends ImportContext {
 
 	String getQualifiedName();
 
-	@Nullable String getSupertypeName();
+	@Nullable Element getSuperTypeElement();
 
 	String getPackageName();
 

--- a/tooling/metamodel-generator/src/main/java/org/hibernate/processor/util/StringUtil.java
+++ b/tooling/metamodel-generator/src/main/java/org/hibernate/processor/util/StringUtil.java
@@ -98,6 +98,9 @@ public final class StringUtil {
 	}
 
 	public static String getUpperUnderscoreCaseFromLowerCamelCase(String lowerCamelCaseString) {
+		if ( lowerCamelCaseString.length() == 1 && isUpperCase( lowerCamelCaseString.charAt( 0 ) ) ) {
+			return "_" + lowerCamelCaseString;
+		}
 		final StringBuilder result = new StringBuilder();
 		int position = 0;
 		while ( position < lowerCamelCaseString.length() ) {
@@ -115,5 +118,17 @@ public final class StringUtil {
 		return string.length() > 1
 			&& isUpperCase( string.charAt( 0 ) )
 			&& isUpperCase( string.charAt( 1 ) );
+	}
+
+	/**
+	 * If this is an "intermediate" class providing {@code @Query}
+	 * annotations for the query by magical method name crap, then
+	 * by convention it will be named with a trailing $ sign. Strip
+	 * that off, so we get the standard constructor.
+	 */
+	public static String removeDollar(String simpleName) {
+		return simpleName.endsWith("$")
+				? simpleName.substring(0, simpleName.length()-1)
+				: simpleName;
 	}
 }

--- a/tooling/metamodel-generator/src/main/java/org/hibernate/processor/util/TypeUtils.java
+++ b/tooling/metamodel-generator/src/main/java/org/hibernate/processor/util/TypeUtils.java
@@ -598,7 +598,7 @@ public final class TypeUtils {
 		}
 	}
 
-	public static @Nullable String findMappedSuperClass(Metamodel entity, Context context) {
+	public static @Nullable Element findMappedSuperElement(Metamodel entity, Context context) {
 		final Element element = entity.getElement();
 		if ( element instanceof TypeElement typeElement ) {
 			TypeMirror superClass = typeElement.getSuperclass();
@@ -607,7 +607,7 @@ public final class TypeUtils {
 				final DeclaredType declaredType = (DeclaredType) superClass;
 				final TypeElement superClassElement = (TypeElement) declaredType.asElement();
 				if ( extendsSuperMetaModel( superClassElement, entity.isMetaComplete(), context ) ) {
-					return superClassElement.getQualifiedName().toString();
+					return superClassElement;
 				}
 				superClass = superClassElement.getSuperclass();
 			}
@@ -665,6 +665,10 @@ public final class TypeUtils {
 			superclass = typeElement.getSuperclass();
 		}
 		return false;
+	}
+
+	public static boolean isMemberType(Element element) {
+		return element.getEnclosingElement() instanceof TypeElement;
 	}
 
 	static class EmbeddedAttributeVisitor extends SimpleTypeVisitor8<@Nullable TypeElement, Element> {

--- a/tooling/metamodel-generator/src/main/java/org/hibernate/processor/validation/ProcessorSessionFactory.java
+++ b/tooling/metamodel-generator/src/main/java/org/hibernate/processor/validation/ProcessorSessionFactory.java
@@ -477,7 +477,8 @@ public abstract class ProcessorSessionFactory extends MockSessionFactory {
 			&& findPropertyByPath(entityClass, fieldName, getDefaultAccessType(entityClass)) != null;
 	}
 
-	private TypeElement findEntityClass(String entityName) {
+	@Override
+	public TypeElement findEntityClass(String entityName) {
 		if (entityName == null) {
 			return null;
 		}

--- a/tooling/metamodel-generator/src/main/java/org/hibernate/processor/xml/XmlMetaEntity.java
+++ b/tooling/metamodel-generator/src/main/java/org/hibernate/processor/xml/XmlMetaEntity.java
@@ -53,7 +53,7 @@ import static org.hibernate.processor.util.StringUtil.determineFullyQualifiedCla
 import static org.hibernate.processor.util.StringUtil.isFullyQualified;
 import static org.hibernate.processor.util.StringUtil.packageNameFromFullyQualifiedName;
 import static org.hibernate.processor.util.TypeUtils.extractClosestRealTypeAsString;
-import static org.hibernate.processor.util.TypeUtils.findMappedSuperClass;
+import static org.hibernate.processor.util.TypeUtils.findMappedSuperElement;
 import static org.hibernate.processor.util.TypeUtils.getElementKindForAccessType;
 
 /**
@@ -165,8 +165,8 @@ public class XmlMetaEntity implements Metamodel {
 	}
 
 	@Override
-	public @Nullable String getSupertypeName() {
-		return findMappedSuperClass( this, context );
+	public @Nullable Element getSuperTypeElement() {
+		return findMappedSuperElement( this, context );
 	}
 
 	public List<MetaAttribute> getMembers() {

--- a/tooling/metamodel-generator/src/test/java/org/hibernate/processor/test/innerclass/Dummy.java
+++ b/tooling/metamodel-generator/src/test/java/org/hibernate/processor/test/innerclass/Dummy.java
@@ -1,0 +1,82 @@
+/*
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.processor.test.innerclass;
+
+import jakarta.persistence.Embeddable;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.MappedSuperclass;
+import jakarta.persistence.NamedQuery;
+
+public class Dummy {
+	@Entity(name = "Inner")
+	@NamedQuery(name = "allInner", query = "from Inner")
+	public static class Inner extends Persona {
+		@Id
+		Integer id;
+
+		String name;
+
+		public Integer getId() {
+			return id;
+		}
+
+		@Override
+		public void setId(Integer id) {
+			this.id = id;
+		}
+
+		@Override
+		public String getName() {
+			return name;
+		}
+
+		@Override
+		public void setName(String name) {
+			this.name = name;
+		}
+	}
+
+	@Embeddable
+	public static class DummyEmbeddable {
+		private String name;
+		private int value;
+
+		public String getName() {
+			return name;
+		}
+
+		public void setName(String name) {
+			this.name = name;
+		}
+
+		public int getValue() {
+			return value;
+		}
+
+		public void setValue(int value) {
+			this.value = value;
+		}
+	}
+
+	@MappedSuperclass
+	public abstract static class Persona {
+		private String city;
+
+		public String getCity() {
+			return city;
+		}
+
+		public void setCity(String city) {
+			this.city = city;
+		}
+
+		public abstract void setId(Integer id);
+
+		public abstract String getName();
+
+		public abstract void setName(String name);
+	}
+}

--- a/tooling/metamodel-generator/src/test/java/org/hibernate/processor/test/innerclass/InnerClassTest.java
+++ b/tooling/metamodel-generator/src/test/java/org/hibernate/processor/test/innerclass/InnerClassTest.java
@@ -1,0 +1,75 @@
+/*
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.processor.test.innerclass;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.NamedQuery;
+import org.hibernate.processor.test.innerclass.InnerClassTest.One.Two;
+import org.hibernate.processor.test.util.CompilationTest;
+import org.hibernate.processor.test.util.WithClasses;
+import org.junit.Test;
+
+import static org.hibernate.processor.test.util.TestUtil.assertMetamodelClassGeneratedFor;
+import static org.hibernate.processor.test.util.TestUtil.assertNoMetamodelClassGeneratedFor;
+import static org.hibernate.processor.test.util.TestUtil.getMetaModelSourceAsString;
+import static org.junit.Assert.assertEquals;
+
+public class InnerClassTest extends CompilationTest {
+
+	@WithClasses({Person.class, Dummy.class, Inner.class, Two.class})
+	@Test
+	public void test() {
+		System.out.println( getMetaModelSourceAsString( InnerClassTest.class ) );
+		System.out.println( getMetaModelSourceAsString( Dummy.class ) );
+		System.out.println( getMetaModelSourceAsString( Person.class ) );
+		assertEquals(
+				getMetaModelSourceAsString( Inner.class ),
+				getMetaModelSourceAsString( Two.class )
+		);
+		assertMetamodelClassGeneratedFor( Inner.class );
+		assertMetamodelClassGeneratedFor( Two.class );
+		assertMetamodelClassGeneratedFor( Dummy.Inner.class );
+		assertMetamodelClassGeneratedFor( Person.class );
+		assertMetamodelClassGeneratedFor( Person.PersonId.class );
+		assertNoMetamodelClassGeneratedFor( Dummy.class );
+		assertMetamodelClassGeneratedFor( Dummy.DummyEmbeddable.class );
+		System.out.println( getMetaModelSourceAsString( Dummy.DummyEmbeddable.class ) );
+	}
+
+	@Entity(name = "Inner")
+	@NamedQuery(name = "allInner", query = "from Inner")
+	public static class Inner {
+		@Id
+		Integer id;
+
+		String address;
+
+		public Integer getId() {
+			return id;
+		}
+
+		public void setId(Integer id) {
+			this.id = id;
+		}
+
+		public String getAddress() {
+			return address;
+		}
+
+		public void setAddress(String address) {
+			this.address = address;
+		}
+	}
+
+	static class One {
+		@Entity
+		static class Two {
+			@Id
+			Integer id;
+			String value;
+		}
+	}
+}

--- a/tooling/metamodel-generator/src/test/java/org/hibernate/processor/test/innerclass/Person.java
+++ b/tooling/metamodel-generator/src/test/java/org/hibernate/processor/test/innerclass/Person.java
@@ -1,0 +1,44 @@
+/*
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.processor.test.innerclass;
+
+import jakarta.persistence.Embeddable;
+import jakarta.persistence.EmbeddedId;
+import jakarta.persistence.Entity;
+
+/**
+ * @author Hardy Ferentschik
+ */
+@Entity
+public class Person {
+	@EmbeddedId
+	private PersonId id;
+
+	private String address;
+
+	@Embeddable
+	public static class PersonId {
+		private String name;
+		private String snn;
+
+		public String getName() {
+			return name;
+		}
+
+		public void setName(String name) {
+			this.name = name;
+		}
+
+		public String getSnn() {
+			return snn;
+		}
+
+		public void setSnn(String snn) {
+			this.snn = snn;
+		}
+	}
+
+
+}

--- a/tooling/metamodel-generator/src/test/java/org/hibernate/processor/test/separatecompilationunits/SeparateCompilationUnitsTest.java
+++ b/tooling/metamodel-generator/src/test/java/org/hibernate/processor/test/separatecompilationunits/SeparateCompilationUnitsTest.java
@@ -28,7 +28,12 @@ public class SeparateCompilationUnitsTest extends CompilationTest {
 		String entityMetaModel = getMetaModelSourceAsString( Entity.class );
 		assertTrue(
 				entityMetaModel.contains(
-						"extends org.hibernate.processor.test.separatecompilationunits.superclass.MappedSuperclass"
+						"import org.hibernate.processor.test.separatecompilationunits.superclass.MappedSuperclass_;"
+				)
+		);
+		assertTrue(
+				entityMetaModel.contains(
+						"extends MappedSuperclass_"
 				)
 		);
 	}

--- a/tooling/metamodel-generator/src/test/java/org/hibernate/processor/test/util/CompilationStatement.java
+++ b/tooling/metamodel-generator/src/test/java/org/hibernate/processor/test/util/CompilationStatement.java
@@ -100,6 +100,9 @@ public class CompilationStatement extends Statement {
 	}
 
 	private String getPathToSource(Class<?> testClass) {
+		if ( testClass.isMemberClass() ) {
+			return getPathToSource( testClass.getDeclaringClass() );
+		}
 		return TestUtil.getSourceBaseDir( testClass ).getAbsolutePath() + File.separator + testClass.getName()
 				.replace( PACKAGE_SEPARATOR, File.separator ) + ".java";
 	}

--- a/tooling/metamodel-generator/src/test/java/org/hibernate/processor/test/util/TestUtil.java
+++ b/tooling/metamodel-generator/src/test/java/org/hibernate/processor/test/util/TestUtil.java
@@ -335,6 +335,9 @@ public class TestUtil {
 	}
 
 	public static File getMetaModelSourceFileFor(Class<?> clazz, boolean prefix) {
+		if ( clazz.isMemberClass() ) {
+			return getMetaModelSourceFileFor( clazz.getEnclosingClass(), prefix );
+		}
 		String metaModelClassName = getMetaModelClassName(clazz, prefix);
 		// generate the file name
 		String fileName = metaModelClassName.replace( PACKAGE_SEPARATOR, PATH_SEPARATOR );
@@ -351,13 +354,17 @@ public class TestUtil {
 	}
 
 	private static String getMetaModelClassName(Class<?> clazz, boolean prefix) {
-		return prefix
-				? clazz.getPackageName() + '.' + META_MODEL_CLASS_POSTFIX + clazz.getSimpleName()
-				: clazz.getName() + META_MODEL_CLASS_POSTFIX;
+		final String packageName = clazz.getPackageName();
+		return prefix ? packageName + '.' + META_MODEL_CLASS_POSTFIX + clazz.getName().substring( packageName.length() + 1 )
+				.replaceAll( "\\$", "\\$_" )
+				: packageName + clazz.getName().substring( packageName.length() )
+						.replaceAll( "\\$", "_\\$" ) + META_MODEL_CLASS_POSTFIX;
 	}
 
 	private static String getMetaModelClassName(String className) {
-		return className + META_MODEL_CLASS_POSTFIX;
+		final int index = className.lastIndexOf( '.' );
+		final String packageName = className.substring( 0, index + 1 );
+		return packageName + className.substring( packageName.length() ).replaceAll( "\\$", "_\\$" ) + META_MODEL_CLASS_POSTFIX;
 	}
 
 	public static String getMetaModelSourceAsString(Class<?> clazz) {


### PR DESCRIPTION
See Jira Issue [HHH-18693](https://hibernate.atlassian.net/browse/HHH-18693)

This is still work in progress, not to be merged with main branch, at least not immediately.

For each (static) inner non-private class one meta-model class will be generated. 

Naming is as follows. If we have:
```
class A {
    ...
    @Entity
    static class B {
        ...
    }
    ...
}
```

Generated class will be named `A_B_`

----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------


[HHH-18693]: https://hibernate.atlassian.net/browse/HHH-18693?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ