### PR TITLE
Update Envers.adoc

### DIFF
--- a/documentation/src/main/asciidoc/userguide/chapters/envers/Envers.adoc
+++ b/documentation/src/main/asciidoc/userguide/chapters/envers/Envers.adoc
@@ -982,7 +982,7 @@ include::{example-dir-envers}/QueryAuditTest.java[tags=revisions-of-entity-query
 The second additional feature you can use in queries for revisions is the ability to _maximize_/_minimize_ a property.
 
 For example, if you want to select the smallest possible revision at which the value of the `createdOn`
-attribute was larger then a given value,
+attribute was larger than a given value,
 you can run the following query:
 
 [[revisions-of-entity-query-minimize-example]]


### PR DESCRIPTION
Fixes an incorrect usage of "then" vs "than" in envers documentation

----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
