### PR TITLE
HHH-18446 Cannot use @JdbcTypeCode(SqlTypes.LONG32VARBINARY) on field with null value

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/jdbc/LongVarbinaryJdbcType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/jdbc/LongVarbinaryJdbcType.java
@@ -14,14 +14,19 @@ import java.sql.Types;
 public class LongVarbinaryJdbcType extends VarbinaryJdbcType {
 	public static final LongVarbinaryJdbcType INSTANCE = new LongVarbinaryJdbcType();
 
-	private final int jdbcTypeCode;
+	private final int defaultSqlTypeCode;
 
 	public LongVarbinaryJdbcType() {
-		this(Types.LONGVARBINARY);
+		this( Types.LONGVARBINARY );
 	}
 
-	public LongVarbinaryJdbcType(int jdbcTypeCode) {
-		this.jdbcTypeCode = jdbcTypeCode;
+	public LongVarbinaryJdbcType(int defaultSqlTypeCode) {
+		this.defaultSqlTypeCode = defaultSqlTypeCode;
+	}
+
+	@Override
+	public int getDefaultSqlTypeCode() {
+		return defaultSqlTypeCode;
 	}
 
 	@Override
@@ -31,6 +36,6 @@ public class LongVarbinaryJdbcType extends VarbinaryJdbcType {
 
 	@Override
 	public int getJdbcTypeCode() {
-		return jdbcTypeCode;
+		return Types.LONGVARBINARY;
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/jdbc/LongVarcharJdbcType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/jdbc/LongVarcharJdbcType.java
@@ -4,12 +4,12 @@
  */
 package org.hibernate.type.descriptor.jdbc;
 
-import java.sql.Types;
-
 import org.hibernate.type.SqlTypes;
 import org.hibernate.type.descriptor.java.JavaType;
 import org.hibernate.type.descriptor.jdbc.spi.JdbcTypeRegistry;
 import org.hibernate.type.spi.TypeConfiguration;
+
+import java.sql.Types;
 
 /**
  * Descriptor for {@link Types#LONGVARCHAR LONGVARCHAR} handling.
@@ -19,14 +19,14 @@ import org.hibernate.type.spi.TypeConfiguration;
 public class LongVarcharJdbcType extends VarcharJdbcType {
 	public static final LongVarcharJdbcType INSTANCE = new LongVarcharJdbcType();
 
-	private final int jdbcTypeCode;
+	private final int defaultSqlTypeCode;
 
 	public LongVarcharJdbcType() {
-		this(Types.LONGVARCHAR);
+		this( Types.LONGVARCHAR );
 	}
 
-	public LongVarcharJdbcType(int jdbcTypeCode) {
-		this.jdbcTypeCode = jdbcTypeCode;
+	public LongVarcharJdbcType(int defaultSqlTypeCode) {
+		this.defaultSqlTypeCode = defaultSqlTypeCode;
 	}
 
 	@Override
@@ -36,7 +36,12 @@ public class LongVarcharJdbcType extends VarcharJdbcType {
 
 	@Override
 	public int getJdbcTypeCode() {
-		return jdbcTypeCode;
+		return Types.LONGVARCHAR;
+	}
+
+	@Override
+	public int getDefaultSqlTypeCode() {
+		return defaultSqlTypeCode;
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/jdbc/internal/JdbcTypeBaseline.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/jdbc/internal/JdbcTypeBaseline.java
@@ -85,12 +85,12 @@ public class JdbcTypeBaseline {
 		target.addDescriptor( BinaryJdbcType.INSTANCE );
 		target.addDescriptor( VarbinaryJdbcType.INSTANCE );
 		target.addDescriptor( LongVarbinaryJdbcType.INSTANCE );
-		target.addDescriptor( new LongVarbinaryJdbcType(SqlTypes.LONG32VARBINARY) );
+		target.addDescriptor( new LongVarbinaryJdbcType( SqlTypes.LONG32VARBINARY) );
 
 		target.addDescriptor( CharJdbcType.INSTANCE );
 		target.addDescriptor( VarcharJdbcType.INSTANCE );
 		target.addDescriptor( LongVarcharJdbcType.INSTANCE );
-		target.addDescriptor( new LongVarcharJdbcType(SqlTypes.LONG32VARCHAR) );
+		target.addDescriptor( new LongVarcharJdbcType( SqlTypes.LONG32VARCHAR) );
 
 		target.addDescriptor( BlobJdbcType.DEFAULT );
 		target.addDescriptor( ClobJdbcType.DEFAULT );
@@ -101,7 +101,7 @@ public class JdbcTypeBaseline {
 		target.addDescriptor( Types.NVARCHAR, VarcharJdbcType.INSTANCE );
 		target.addDescriptor( Types.LONGNVARCHAR, LongVarcharJdbcType.INSTANCE );
 		target.addDescriptor( Types.NCLOB, ClobJdbcType.DEFAULT );
-		target.addDescriptor( new LongVarcharJdbcType(SqlTypes.LONG32NVARCHAR) );
+		target.addDescriptor( new LongVarcharJdbcType( SqlTypes.LONG32NVARCHAR) );
 
 		target.addDescriptor( RowIdJdbcType.INSTANCE );
 	}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/type/LongNullTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/type/LongNullTest.java
@@ -1,0 +1,72 @@
+/*
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.type;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.hibernate.type.SqlTypes;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@DomainModel(annotatedClasses = LongNullTest.Foo.class)
+@SessionFactory
+public class LongNullTest {
+
+	@Entity
+	public static final class Foo {
+		@Id
+		@GeneratedValue
+		private Long id;
+
+		@JdbcTypeCode(SqlTypes.LONG32NVARCHAR)
+		@Column
+		private String field = null;
+
+		@JdbcTypeCode(SqlTypes.LONG32VARCHAR)
+		@Column
+		private String nfield = null;
+
+		@JdbcTypeCode(SqlTypes.LONG32VARBINARY)
+		@Column
+		private byte[] bfield = null;
+	}
+
+	@Test
+	public void testNull(SessionFactoryScope scope) {
+		final var expected = scope.fromTransaction( s -> {
+			final var foo = new Foo();
+			s.persist( foo );
+			return foo;
+		} );
+		final var actual = scope.fromSession( s -> s.find( Foo.class, expected.id ) );
+		assertEquals( expected.field, actual.field );
+		assertEquals( expected.nfield, actual.nfield );
+		assertArrayEquals( expected.bfield, actual.bfield );
+	}
+
+	@Test
+	public void testNonNull(SessionFactoryScope scope) {
+		final var expected = scope.fromTransaction( s -> {
+			final var foo = new Foo();
+			foo.bfield = "ABC".getBytes();
+			foo.field = "DEF";
+			foo.nfield = "GHI";
+			s.persist( foo );
+			return foo;
+		} );
+		final var actual = scope.fromSession( s -> s.find( Foo.class, expected.id ) );
+		assertEquals( expected.field, actual.field );
+		assertEquals( expected.nfield, actual.nfield );
+		assertArrayEquals( expected.bfield, actual.bfield );
+	}
+}


### PR DESCRIPTION
Jira issue [HHH-18446](https://hibernate.atlassian.net/browse/HHH-18446)

Fixing problem by adding (configurable) default SQL type code to LongVarbinaryJdbcType abd LongVarcharJdbcType
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------


[HHH-18446]: https://hibernate.atlassian.net/browse/HHH-18446?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ