### PR TITLE
HHH-18749 deprecate Session.get()

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/Session.java
+++ b/hibernate-core/src/main/java/org/hibernate/Session.java
@@ -828,7 +828,11 @@ public interface Session extends SharedSessionContract, EntityManager {
 	 * @param id an identifier
 	 *
 	 * @return a persistent instance or null
+	 *
+	 * @deprecated Because the semantics of this method may change in a future release.
+	 *             Use {@link #find(Class, Object)} instead.
 	 */
+	@Deprecated(since = "7")
 	<T> T get(Class<T> entityType, Object id);
 
 	/**
@@ -848,7 +852,11 @@ public interface Session extends SharedSessionContract, EntityManager {
 	 * @return a persistent instance or null
 	 *
 	 * @see #get(Class, Object, LockOptions)
+	 *
+	 * @deprecated The semantics of this method may change in a future release.
+	 *             Use {@link #find(Class, Object, LockMode)} instead.
 	 */
+	@Deprecated(since = "7")
 	<T> T get(Class<T> entityType, Object id, LockMode lockMode);
 
 	/**
@@ -862,7 +870,11 @@ public interface Session extends SharedSessionContract, EntityManager {
 	 * @param lockOptions the lock mode
 	 *
 	 * @return a persistent instance or null
+	 *
+	 * @deprecated The semantics of this method may change in a future release.
+	 *             Use {@link #find(Class, Object, LockOptions)} instead.
 	 */
+	@Deprecated(since = "7")
 	<T> T get(Class<T> entityType, Object id, LockOptions lockOptions);
 
 	/**
@@ -875,7 +887,10 @@ public interface Session extends SharedSessionContract, EntityManager {
 	 * @param id an identifier
 	 *
 	 * @return a persistent instance or null
+	 *
+	 * @deprecated The semantics of this method may change in a future release.
 	 */
+	@Deprecated(since = "7")
 	Object get(String entityName, Object id);
 
 	/**
@@ -893,7 +908,10 @@ public interface Session extends SharedSessionContract, EntityManager {
 	 * @return a persistent instance or null
 	 *
 	 * @see #get(String, Object, LockOptions)
+	 *
+	 * @deprecated The semantics of this method may change in a future release.
 	 */
+	@Deprecated(since = "7")
 	Object get(String entityName, Object id, LockMode lockMode);
 
 	/**
@@ -907,7 +925,10 @@ public interface Session extends SharedSessionContract, EntityManager {
 	 * @param lockOptions contains the lock mode
 	 *
 	 * @return a persistent instance or null
+	 *
+	 * @deprecated The semantics of this method may change in a future release.
 	 */
+	@Deprecated(since = "7")
 	Object get(String entityName, Object id, LockOptions lockOptions);
 
 	/**


### PR DESCRIPTION
This method is essentially redundant as things stand today, and I want to open up the possibility of changing its semantics in the future.

<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

[Please describe here what your change is about]

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-18749
<!-- Hibernate GitHub Bot issue links end -->