### PR TITLE
HHH-18750 : @OneToMany with @Any mapped in secondary table KO (ClassCastException

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/ManyToManyCollectionPart.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/ManyToManyCollectionPart.java
@@ -398,7 +398,7 @@ public class ManyToManyCollectionPart extends AbstractEntityCollectionPart imple
 		}
 		else if ( StringHelper.isNotEmpty( bootCollectionDescriptor.getMappedByProperty() ) ) {
 			final ModelPart mappedByPart = resolveNamedTargetPart( bootCollectionDescriptor.getMappedByProperty(), getAssociatedEntityMappingType(), collectionDescriptor );
-			if ( mappedByPart instanceof ToOneAttributeMapping ) {
+			if ( mappedByPart instanceof ToOneAttributeMapping || mappedByPart instanceof DiscriminatedAssociationAttributeMapping ) {
 				////////////////////////////////////////////////
 				// E.g.
 				//
@@ -425,7 +425,7 @@ public class ManyToManyCollectionPart extends AbstractEntityCollectionPart imple
 				final ManyToOne elementDescriptor = (ManyToOne) bootCollectionDescriptor.getElement();
 				assert elementDescriptor.isReferenceToPrimaryKey();
 
-				final String collectionTableName = ( (BasicCollectionPersister) collectionDescriptor ).getTableName();
+				final String collectionTableName = collectionDescriptor.getTableName();
 
 				// this fk will refer to the associated entity's id.  if that id is not ready yet, delay this creation
 				if ( getAssociatedEntityMappingType().getIdentifierMapping() == null ) {

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/manytoone/ManyToOneWithAnyAndSameEntityTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/manytoone/ManyToOneWithAnyAndSameEntityTest.java
@@ -1,0 +1,114 @@
+/*
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.mapping.manytoone;
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.SecondaryTable;
+import jakarta.persistence.Table;
+import org.hibernate.annotations.Any;
+import org.hibernate.annotations.AnyKeyJavaClass;
+import org.hibernate.annotations.Fetch;
+import org.hibernate.annotations.FetchMode;
+import org.hibernate.cfg.JdbcSettings;
+import org.hibernate.testing.orm.junit.EntityManagerFactoryScope;
+import org.hibernate.testing.orm.junit.JiraKey;
+import org.hibernate.testing.orm.junit.Jpa;
+import org.hibernate.testing.orm.junit.Setting;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import static jakarta.persistence.FetchType.LAZY;
+
+/**
+ * Allows testing a @OneToMany mappedBy relationship with a @Any as the return variable and persist in secondary table.
+ *
+ * @author Vincent Bouthinon
+ */
+@Jpa(
+		annotatedClasses = {
+				ManyToOneWithAnyAndSameEntityTest.Actor.class,
+				ManyToOneWithAnyAndSameEntityTest.Contact.class
+		},
+		integrationSettings = @Setting(name = JdbcSettings.SHOW_SQL, value = "true")
+)
+@JiraKey("HHH-18750")
+class ManyToOneWithAnyAndSameEntityTest {
+
+	@Test
+	void testMappingManyToOneMappedByAnyPersistedInSecondaryTable(EntityManagerFactoryScope scope) {
+		scope.inTransaction(
+				entityManager -> {
+					Actor actor = new Actor();
+					actor.addToContacts( new Contact() );
+					entityManager.persist( actor );
+					entityManager.flush();
+					entityManager.clear();
+
+					List<Actor> actors = entityManager.createQuery( "select a from actor a", Actor.class )
+							.getResultList();
+					Assertions.assertEquals( actors.size(), 2 );
+				}
+		);
+	}
+
+
+	@Entity(name = "actor")
+	@Table(name = "TACTOR")
+	public static class Actor {
+
+		@Id
+		@GeneratedValue
+		private Long id;
+
+		@OneToMany(mappedBy = "objetMaitre", cascade = {CascadeType.ALL})
+		@Fetch(FetchMode.SELECT)
+		private Set<Contact> contacts = new HashSet<>();
+
+		public Set<Contact> getContacts() {
+			return contacts;
+		}
+
+		public void setContacts(Set<Contact> contacts) {
+			this.contacts = contacts;
+		}
+
+		public void addToContacts(Contact contact) {
+			this.contacts.add( contact );
+			contact.setObjetMaitre( this );
+		}
+	}
+
+	@Entity(name = "contact")
+	@SecondaryTable(name = "TPERSONNEPHYSIQUE")
+	public static class Contact extends Actor {
+		@Id
+		@GeneratedValue
+		private Long id;
+
+		@Any(fetch = LAZY)
+		@AnyKeyJavaClass(Long.class)
+		@JoinColumn(name = "OBJETMAITRE_ID", table = "TPERSONNEPHYSIQUE")
+		@Column(name = "OBJETMAITRE_ROLE")
+		private Actor objetMaitre;
+
+		public Actor getObjetMaitre() {
+			return objetMaitre;
+		}
+
+		public void setObjetMaitre(Actor objetMaitre) {
+			this.objetMaitre = objetMaitre;
+		}
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/manytoone/ManyToOneWithAnyAndSecondaryTable.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/manytoone/ManyToOneWithAnyAndSecondaryTable.java
@@ -38,13 +38,13 @@ import static jakarta.persistence.FetchType.LAZY;
  */
 @Jpa(
 		annotatedClasses = {
-				ManyToOneWithAnyAndSameEntityTest.Actor.class,
-				ManyToOneWithAnyAndSameEntityTest.Contact.class
+				ManyToOneWithAnyAndSecondaryTable.Actor.class,
+				ManyToOneWithAnyAndSecondaryTable.Contact.class
 		},
 		integrationSettings = @Setting(name = JdbcSettings.SHOW_SQL, value = "true")
 )
 @JiraKey("HHH-18750")
-class ManyToOneWithAnyAndSameEntityTest {
+class ManyToOneWithAnyAndSecondaryTable {
 
 	@Test
 	void testMappingManyToOneMappedByAnyPersistedInSecondaryTable(EntityManagerFactoryScope scope) {


### PR DESCRIPTION
He mistakenly assumes, at first glance, that the mappedBy attribut is not a @ManyToOne or @Any because the mappedBy attribut is mapped in a secondary table and therefore has a join.

The problem appears later during a cast where the instance of type DiscriminatedAssociationAttributeMapping is cast to PluralAttributeMapping.

https://hibernate.atlassian.net/browse/HHH-18750

----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
