### PR TITLE
HHH-18719 Previous row state reuse can provide detaches entities to the consumer

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/engine/spi/EntityHolder.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/spi/EntityHolder.java
@@ -67,4 +67,9 @@ public interface EntityHolder {
 	 * Whether the entity is already initialized or will be initialized through an initializer eventually.
 	 */
 	boolean isEventuallyInitialized();
+
+	/**
+	 * Whether the entity is detached.
+	 */
+	boolean isDetached();
 }

--- a/hibernate-core/src/main/java/org/hibernate/engine/spi/PersistenceContext.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/spi/PersistenceContext.java
@@ -864,4 +864,12 @@ public interface PersistenceContext {
 	 * @return This persistence context's natural-id helper
 	 */
 	NaturalIdResolutions getNaturalIdResolutions();
+
+	/**
+		Remove the {@link EntityHolder} and set its state to DETACHED
+	 */
+	default @Nullable EntityHolder detachEntity(EntityKey key) {
+		EntityHolder entityHolder = removeEntityHolder( key );
+		return entityHolder;
+	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/event/internal/DefaultEvictEventListener.java
+++ b/hibernate-core/src/main/java/org/hibernate/event/internal/DefaultEvictEventListener.java
@@ -59,7 +59,7 @@ public class DefaultEvictEventListener implements EvictEventListener {
 					.getMappingMetamodel()
 					.getEntityDescriptor( lazyInitializer.getEntityName() );
 			final EntityKey key = source.generateEntityKey( id, persister );
-			final EntityHolder holder = persistenceContext.removeEntityHolder( key );
+			final EntityHolder holder = persistenceContext.detachEntity( key );
 			// if the entity has been evicted then its holder is null
 			if ( holder != null && !lazyInitializer.isUninitialized() ) {
 				final Object entity = holder.getEntity();

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/entity/internal/EntityInitializerImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/entity/internal/EntityInitializerImpl.java
@@ -565,7 +565,7 @@ public class EntityInitializerImpl extends AbstractInitializer<EntityInitializer
 		}
 
 		if ( oldEntityKey != null && previousRowReuse && oldEntityInstance != null
-				&& areKeysEqual( oldEntityKey.getIdentifier(), id ) ) {
+				&& areKeysEqual( oldEntityKey.getIdentifier(), id ) && !oldEntityHolder.isDetached() ) {
 			data.setState( State.INITIALIZED );
 			data.entityKey = oldEntityKey;
 			data.setInstance( oldEntityInstance );

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/DetachedPreviousRowStateTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/DetachedPreviousRowStateTest.java
@@ -1,0 +1,177 @@
+/*
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.jpa;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityGraph;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Subgraph;
+import jakarta.persistence.Table;
+import jakarta.persistence.criteria.CriteriaBuilder;
+import jakarta.persistence.criteria.CriteriaQuery;
+import jakarta.persistence.criteria.Root;
+import org.hibernate.Hibernate;
+import org.hibernate.jpa.SpecHints;
+import org.hibernate.testing.orm.junit.EntityManagerFactoryScope;
+import org.hibernate.testing.orm.junit.JiraKey;
+import org.hibernate.testing.orm.junit.Jpa;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Réda Housni Alaoui
+ */
+@Jpa(annotatedClasses = {
+		DetachedPreviousRowStateTest.Version.class,
+		DetachedPreviousRowStateTest.Product.class,
+		DetachedPreviousRowStateTest.Description.class,
+		DetachedPreviousRowStateTest.LocalizedDescription.class
+})
+class DetachedPreviousRowStateTest {
+
+	@BeforeEach
+	void setupData(EntityManagerFactoryScope scope) {
+		scope.inTransaction( em -> {
+			Product product = new Product();
+			em.persist( product );
+
+			Description description = new Description( product );
+			em.persist( description );
+
+			LocalizedDescription englishDescription = new LocalizedDescription( description );
+			em.persist( englishDescription );
+			LocalizedDescription frenchDescription = new LocalizedDescription( description );
+			em.persist( frenchDescription );
+		} );
+	}
+
+	@AfterEach
+	void cleanupData(EntityManagerFactoryScope scope) {
+		scope.inTransaction( em -> {
+			em.createQuery( "delete from LocalizedDescription l" ).executeUpdate();
+			em.createQuery( "delete from Description d" ).executeUpdate();
+			em.createQuery( "delete from Product p" ).executeUpdate();
+		} );
+	}
+
+	@Test
+	@JiraKey(value = "HHH-18719")
+	void test(EntityManagerFactoryScope scope) {
+		scope.inTransaction( em -> {
+			CriteriaBuilder cb = em.getCriteriaBuilder();
+			CriteriaQuery<LocalizedDescription> query = cb.createQuery( LocalizedDescription.class );
+			Root<LocalizedDescription> root = query.from( LocalizedDescription.class );
+			query.select( root );
+
+			EntityGraph<LocalizedDescription> localizedDescriptionGraph =
+					em.createEntityGraph( LocalizedDescription.class );
+			Subgraph<Object> descriptionGraph = localizedDescriptionGraph.addSubgraph( "description" );
+			Subgraph<Object> productGraph = descriptionGraph.addSubgraph( "product" );
+			productGraph.addSubgraph( "versions" );
+
+			AtomicInteger resultCount = new AtomicInteger();
+
+			em.createQuery( query )
+					.setHint( SpecHints.HINT_SPEC_LOAD_GRAPH, localizedDescriptionGraph )
+					.getResultStream()
+					.forEach( localizedDescription -> {
+						resultCount.incrementAndGet();
+
+						assertThat( em.contains( localizedDescription.description.product ) )
+								.withFailMessage( "'localizedDescription.description.product' is detached" )
+								.isTrue();
+						assertThat( Hibernate.isInitialized( localizedDescription.description.product ) )
+								.withFailMessage( "'localizedDescription.description.product' is not initialized" )
+								.isTrue();
+
+						em.flush();
+						em.clear();
+					} );
+
+			assertThat( resultCount.get() ).isEqualTo( 2 );
+		} );
+	}
+
+	@Entity(name = "Version")
+	@Table(name = "version_tbl")
+	public static class Version {
+
+		@Id
+		@GeneratedValue
+		private long id;
+
+		private String description;
+
+		@ManyToOne(fetch = FetchType.LAZY)
+		private Product product;
+	}
+
+	@Entity(name = "Product")
+	@Table(name = "product_tbl")
+	public static class Product {
+		@Id
+		@GeneratedValue
+		private long id;
+
+		private String description;
+
+		@OneToMany(mappedBy = "product")
+		private final List<Version> versions = new ArrayList<>();
+	}
+
+	@Entity(name = "Description")
+	@Table(name = "description_tbl")
+	public static class Description {
+		@Id
+		@GeneratedValue
+		private long id;
+
+		private String description;
+
+		@OneToOne(fetch = FetchType.LAZY)
+		private Product product;
+
+		public Description() {
+		}
+
+		public Description(Product product) {
+			this.product = product;
+		}
+	}
+
+	@Entity(name = "LocalizedDescription")
+	@Table(name = "localized_description_tbl")
+	public static class LocalizedDescription {
+
+		@Id
+		@GeneratedValue
+		private long id;
+
+		private String localizedDescription;
+
+		@ManyToOne(fetch = FetchType.LAZY)
+		private Description description;
+
+		public LocalizedDescription() {
+		}
+
+		public LocalizedDescription(Description description) {
+			this.description = description;
+		}
+	}
+
+}


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-18719

https://github.com/hibernate/hibernate-orm/pull/9102 backport to 6.6

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
