### PR TITLE
HHH-18754 Improve HQLParser's error listener usage

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/query/hql/internal/StandardHqlTranslator.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/hql/internal/StandardHqlTranslator.java
@@ -4,8 +4,6 @@
  */
 package org.hibernate.query.hql.internal;
 
-import java.util.BitSet;
-
 import org.antlr.v4.runtime.CommonToken;
 import org.antlr.v4.runtime.InputMismatchException;
 import org.antlr.v4.runtime.NoViableAltException;
@@ -29,13 +27,11 @@ import org.hibernate.query.sqm.tree.SqmStatement;
 
 import org.antlr.v4.runtime.ANTLRErrorListener;
 import org.antlr.v4.runtime.BailErrorStrategy;
+import org.antlr.v4.runtime.BaseErrorListener;
 import org.antlr.v4.runtime.DefaultErrorStrategy;
-import org.antlr.v4.runtime.Parser;
 import org.antlr.v4.runtime.RecognitionException;
 import org.antlr.v4.runtime.Recognizer;
-import org.antlr.v4.runtime.atn.ATNConfigSet;
 import org.antlr.v4.runtime.atn.PredictionMode;
-import org.antlr.v4.runtime.dfa.DFA;
 import org.antlr.v4.runtime.misc.ParseCancellationException;
 
 import static java.util.stream.Collectors.toList;
@@ -49,7 +45,6 @@ public class StandardHqlTranslator implements HqlTranslator {
 
 	private final SqmCreationContext sqmCreationContext;
 	private final SqmCreationOptions sqmCreationOptions;
-
 
 	public StandardHqlTranslator(
 			SqmCreationContext sqmCreationContext,
@@ -101,30 +96,9 @@ public class StandardHqlTranslator implements HqlTranslator {
 		// Build the parse tree
 		final HqlParser hqlParser = HqlParseTreeBuilder.INSTANCE.buildHqlParser( hql, hqlLexer );
 
-		ANTLRErrorListener errorListener = new ANTLRErrorListener() {
-			@Override
-			public void syntaxError(Recognizer<?, ?> recognizer, Object offendingSymbol, int line, int charPositionInLine, String msg, RecognitionException e) {
-				throw new SyntaxException( prettifyAntlrError( offendingSymbol, line, charPositionInLine, msg, e, hql, true ), hql );
-			}
-
-			@Override
-			public void reportAmbiguity(Parser recognizer, DFA dfa, int startIndex, int stopIndex, boolean exact, BitSet ambigAlts, ATNConfigSet configs) {
-			}
-
-			@Override
-			public void reportAttemptingFullContext(Parser recognizer, DFA dfa, int startIndex, int stopIndex, BitSet conflictingAlts, ATNConfigSet configs) {
-			}
-
-			@Override
-			public void reportContextSensitivity(Parser recognizer, DFA dfa, int startIndex, int stopIndex, int prediction, ATNConfigSet configs) {
-			}
-		};
-
 		// try to use SLL(k)-based parsing first - its faster
-		hqlLexer.addErrorListener( errorListener );
 		hqlParser.getInterpreter().setPredictionMode( PredictionMode.SLL );
 		hqlParser.removeErrorListeners();
-		hqlParser.addErrorListener( errorListener );
 		hqlParser.setErrorHandler( new BailErrorStrategy() );
 
 		try {
@@ -138,6 +112,14 @@ public class StandardHqlTranslator implements HqlTranslator {
 			// fall back to LL(k)-based parsing
 			hqlParser.getInterpreter().setPredictionMode( PredictionMode.LL );
 			hqlParser.setErrorHandler( new DefaultErrorStrategy() );
+
+			final ANTLRErrorListener errorListener = new BaseErrorListener() {
+				@Override
+				public void syntaxError(Recognizer<?, ?> recognizer, Object offendingSymbol, int line, int charPositionInLine, String msg, RecognitionException e) {
+					throw new SyntaxException( prettifyAntlrError( offendingSymbol, line, charPositionInLine, msg, e, hql, true ), hql );
+				}
+			};
+			hqlParser.addErrorListener( errorListener );
 
 			return hqlParser.statement();
 		}

--- a/tooling/metamodel-generator/src/main/java/org/hibernate/processor/validation/Validation.java
+++ b/tooling/metamodel-generator/src/main/java/org/hibernate/processor/validation/Validation.java
@@ -120,10 +120,10 @@ public class Validation {
 	private static HqlParser.StatementContext parseAndCheckSyntax(String hql, Handler handler) {
 		final HqlLexer hqlLexer = HqlParseTreeBuilder.INSTANCE.buildHqlLexer( hql );
 		final HqlParser hqlParser = HqlParseTreeBuilder.INSTANCE.buildHqlParser( hql, hqlLexer );
-		hqlLexer.addErrorListener( handler );
+
 		hqlParser.getInterpreter().setPredictionMode( PredictionMode.SLL );
 		hqlParser.removeErrorListeners();
-		hqlParser.addErrorListener( handler );
+
 		hqlParser.setErrorHandler( new BailErrorStrategy() );
 
 		try {
@@ -137,6 +137,7 @@ public class Validation {
 			// fall back to LL(k)-based parsing
 			hqlParser.getInterpreter().setPredictionMode( PredictionMode.LL );
 			hqlParser.setErrorHandler( new DefaultErrorStrategy() );
+			hqlParser.addErrorListener( handler );
 
 			return hqlParser.statement();
 		}


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-18754

Below is the code pattern for HQL parsing (at `org.hibernate.query.hql.internal.StandardHqlTranslator`):

```
// Build the lexer
final HqlLexer hqlLexer = HqlParseTreeBuilder.INSTANCE.buildHqlLexer( hql );

// Build the parse tree
final HqlParser hqlParser = HqlParseTreeBuilder.INSTANCE.buildHqlParser( hql, hqlLexer );

ANTLRErrorListener errorListener = new ANTLRErrorListener() {
	@Override
	public void syntaxError(Recognizer<?, ?> recognizer, Object offendingSymbol, int line, int charPositionInLine, String msg, RecognitionException e) {
		throw new SyntaxException( prettifyAntlrError( offendingSymbol, line, charPositionInLine, msg, e, hql, true ), hql );
	}

	@Override
	public void reportAmbiguity(Parser recognizer, DFA dfa, int startIndex, int stopIndex, boolean exact, BitSet ambigAlts, ATNConfigSet configs) {
	}

	@Override
	public void reportAttemptingFullContext(Parser recognizer, DFA dfa, int startIndex, int stopIndex, BitSet conflictingAlts, ATNConfigSet configs) {
	}

	@Override
	public void reportContextSensitivity(Parser recognizer, DFA dfa, int startIndex, int stopIndex, int prediction, ATNConfigSet configs) {
	}
};

// try to use SLL(k)-based parsing first - its faster
hqlLexer.addErrorListener( errorListener );
hqlParser.getInterpreter().setPredictionMode( PredictionMode.SLL );
hqlParser.removeErrorListeners();
hqlParser.addErrorListener( errorListener );
hqlParser.setErrorHandler( new BailErrorStrategy() );

try {
	return hqlParser.statement();
}
catch ( ParseCancellationException e) {
	// reset the input token stream and parser state
	hqlLexer.reset();
	hqlParser.reset();

	// fall back to LL(k)-based parsing
	hqlParser.getInterpreter().setPredictionMode( PredictionMode.LL );
	hqlParser.setErrorHandler( new DefaultErrorStrategy() );

	return hqlParser.statement();
}
catch ( ParsingException ex ) {
	// Note that this is supposed to represent a bug in the parser
	// Ee wrap and rethrow in order to attach the HQL query to the error
	throw new QueryException( "Failed to interpret HQL syntax [" + ex.getMessage() + "]", hql, ex );
}
```

firstly it is confusing to add the error listener BEFORE setting mode to SLL, then afterwards add it again (empty the listnerers first), as if the error listener will be used during the SLL setting statement (it won’t for it is simply a variable setting) as below:
```
hqlLexer.addErrorListener( errorListener );
hqlParser.getInterpreter().setPredictionMode( PredictionMode.SLL );
hqlParser.removeErrorListeners();
hqlParser.addErrorListener( errorListener ); 
```

but this is minor.

So I guess the two-step approach might be from this article [Improving the performance of an ANTLR parser - Strumenta](https://tomassetti.me/improving-the-performance-of-an-antlr-parser/) , but there is no reason to set error listener to both steps for the following reasons:

if SLL failed and the error listener takes effect, there might be possibility that the second LL step succeeds, then user got confused by the error message;

if SLL failed and then LL failed as well, user will be notified twice. LL step won’t skip error listener notification and I think in this scenario, LL step’s error listener message suffices.

Most seriously, given we throw SyntaxError exception in the syntaxError() method in the error listener, the LL step would be totally skipped!!

All in all, it seems there is no reason to use error listener for the first SLL step. What really matters might be the final step. So moving the error listener creation and setting logic into the LL step makes more sense (needless to say, it would improve perf by avoiding unnecessary processing) as below:

```
hqlParser.getInterpreter().setPredictionMode( PredictionMode.SLL );
hqlParser.removeErrorListeners();
hqlParser.setErrorHandler( new BailErrorStrategy() );

try {
	return hqlParser.statement();
}
catch ( ParseCancellationException e) {
	// reset the input token stream and parser state
	hqlLexer.reset();
	hqlParser.reset();

	// fall back to LL(k)-based parsing
	hqlParser.getInterpreter().setPredictionMode( PredictionMode.LL );
	hqlParser.setErrorHandler( new DefaultErrorStrategy() );
	
	ANTLRErrorListener errorListener = new ANTLRErrorListener() {
		@Override
		public void syntaxError(Recognizer<?, ?> recognizer, Object offendingSymbol, int line, int charPositionInLine, String msg, RecognitionException e) {
			throw new SyntaxException( prettifyAntlrError( offendingSymbol, line, charPositionInLine, msg, e, hql, true ), hql );
		}

		@Override
		public void reportAmbiguity(Parser recognizer, DFA dfa, int startIndex, int stopIndex, boolean exact, BitSet ambigAlts, ATNConfigSet configs) {
		}

		@Override
		public void reportAttemptingFullContext(Parser recognizer, DFA dfa, int startIndex, int stopIndex, BitSet conflictingAlts, ATNConfigSet configs) {
		}

		@Override
		public void reportContextSensitivity(Parser recognizer, DFA dfa, int startIndex, int stopIndex, int prediction, ATNConfigSet configs) {
		}
	};
	hqlParser.addErrorListener( errorListener );

	return hqlParser.statement();
}
```
