### PR TITLE
HHH-18755 - Skip test that causes deadlock

### DIFF
--- a/hibernate-core/src/test/java/org/hibernate/orm/test/collection/multisession/MultipleSessionCollectionTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/collection/multisession/MultipleSessionCollectionTest.java
@@ -19,6 +19,7 @@ import jakarta.persistence.OptimisticLockException;
 import org.hibernate.Hibernate;
 import org.hibernate.collection.spi.AbstractPersistentCollection;
 import org.hibernate.collection.spi.PersistentCollection;
+import org.hibernate.dialect.CockroachDialect;
 import org.hibernate.dialect.HSQLDialect;
 import org.hibernate.engine.spi.CollectionEntry;
 
@@ -95,6 +96,7 @@ public class MultipleSessionCollectionTest {
 	@Test
 	@JiraKey("HHH-9518")
 	@SkipForDialect(dialectClass = HSQLDialect.class, reason = "The select triggered by the merge just hang without any exception")
+	@SkipForDialect(dialectClass = CockroachDialect.class, reason = "The merge in the second session causes a deadlock")
 	public void testCopyPersistentCollectionReferenceAfterFlush(SessionFactoryScope scope) {
 		Parent p = new Parent();
 		Child c = new Child();


### PR DESCRIPTION
On CockroachDB the method
`testCopyPersistentCollectionReferenceAfterFlush` causes a deadlock, which is resolved eventually by a TimeoutException.

This problem has been discussed in
https://github.com/cockroachdb/cockroach/issues/61269. The CockroachDB developers do not see this as a bug that needs to be fixed. Therefore we skip this test for CockroachDB.

<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-18755
<!-- Hibernate GitHub Bot issue links end -->