### PR TITLE
HHH-18767, HHH-18772 add BatchSize for use with findMultiple()

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/BatchSize.java
+++ b/hibernate-core/src/main/java/org/hibernate/BatchSize.java
@@ -1,0 +1,39 @@
+/*
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate;
+
+import jakarta.persistence.FindOption;
+
+import java.util.List;
+
+/**
+ * Specify a batch size, that is, how many entities should be
+ * fetched in each request to the database, for an invocation of
+ * {@link Session#findMultiple(Class, List, FindOption...)}.
+ * <ul>
+ * <li>By default, the batch sizing strategy is determined by the
+ *     {@linkplain org.hibernate.dialect.Dialect#getBatchLoadSizingStrategy
+ *    SQL dialect}, but
+ * <li>if some {@code batchSize>1} is specified as an
+ *     argument to this method, then that batch size will be used.
+ * </ul>
+ * <p>
+ * If an explicit batch size is set manually, care should be taken
+ * to not exceed the capabilities of the underlying database.
+ * <p>
+ * A batch size is considered a hint. This option has no effect
+ * on {@link Session#find(Class, Object, FindOption...)}.
+ *
+ * @param batchSize The batch size
+ *
+ * @see Session#findMultiple
+ * @see MultiIdentifierLoadAccess#withBatchSize
+ *
+ * @since 7.0
+ *
+ * @author Gavin King
+ */
+public record BatchSize(int batchSize) implements FindOption {
+}

--- a/hibernate-core/src/main/java/org/hibernate/BatchSize.java
+++ b/hibernate-core/src/main/java/org/hibernate/BatchSize.java
@@ -23,6 +23,17 @@ import java.util.List;
  * If an explicit batch size is set manually, care should be taken
  * to not exceed the capabilities of the underlying database.
  * <p>
+ * The performance impact of setting a batch size depends on whether
+ * a SQL array may be used to pass the list of identifiers to the
+ * database:
+ * <ul>
+ * <li>for databases which support standard SQL arrays, a smaller
+ *     batch size might be extremely inefficient compared to a very
+ *     large batch size or no batching at all, but
+ * <li>on the other hand, for databases with no SQL array type, a
+ *     large batch size results in long SQL statements with many JDBC
+ *     parameters.
+ * <p>
  * A batch size is considered a hint. This option has no effect
  * on {@link Session#find(Class, Object, FindOption...)}.
  *

--- a/hibernate-core/src/main/java/org/hibernate/MultiIdentifierLoadAccess.java
+++ b/hibernate-core/src/main/java/org/hibernate/MultiIdentifierLoadAccess.java
@@ -133,6 +133,18 @@ public interface MultiIdentifierLoadAccess<T> {
 	 * If an explicit batch size is set manually, care should be taken
 	 * to not exceed the capabilities of the underlying database.
 	 * <p>
+	 * The performance impact of setting a batch size depends on whether
+	 * a SQL array may be used to pass the list of identifiers to the
+	 * database:
+	 * <ul>
+	 * <li>for databases which support standard SQL arrays, a smaller
+	 *     batch size might be extremely inefficient compared to a very
+	 *     large batch size or no batching at all, but
+	 * <li>on the other hand, for databases with no SQL array type, a
+	 *     large batch size results in long SQL statements with many JDBC
+	 *     parameters.
+	 * </ul>
+	 * <p>
 	 * A batch size is considered a hint.
 	 *
 	 * @param batchSize The batch size

--- a/hibernate-core/src/main/java/org/hibernate/Session.java
+++ b/hibernate-core/src/main/java/org/hibernate/Session.java
@@ -561,6 +561,9 @@ public interface Session extends SharedSessionContract, EntityManager {
 	 * Every object returned by {@code findMultiple()} is either an unproxied instance of the
 	 * given entity class, or a fully-fetched proxy object.
 	 * <p>
+	 * This method accepts {@link BatchSize} as an option, allowing control over the number of
+	 * records retrieved in a single database request.
+	 * <p>
 	 * For more advanced cases, use {@link #byMultipleIds(Class)}, which returns an instance of
 	 * {@link MultiIdentifierLoadAccess}.
 	 *

--- a/hibernate-core/src/main/java/org/hibernate/Session.java
+++ b/hibernate-core/src/main/java/org/hibernate/Session.java
@@ -562,7 +562,16 @@ public interface Session extends SharedSessionContract, EntityManager {
 	 * given entity class, or a fully-fetched proxy object.
 	 * <p>
 	 * This method accepts {@link BatchSize} as an option, allowing control over the number of
-	 * records retrieved in a single database request.
+	 * records retrieved in a single database request. The performance impact of setting a batch
+	 * size depends on whether a SQL array may be used to pass the list of identifiers to the
+	 * database:
+	 * <ul>
+	 * <li>for databases which {@linkplain org.hibernate.dialect.Dialect#supportsStandardArrays
+	 *     support standard SQL arrays}, a smaller batch size might be extremely inefficient
+	 *     compared to a very large batch size or no batching at all, but
+	 * <li>on the other hand, for databases with no SQL array type, a large batch size results
+	 *     in long SQL statements with many JDBC parameters.
+	 * </ul>
 	 * <p>
 	 * For more advanced cases, use {@link #byMultipleIds(Class)}, which returns an instance of
 	 * {@link MultiIdentifierLoadAccess}.

--- a/hibernate-core/src/main/java/org/hibernate/exception/AuthException.java
+++ b/hibernate-core/src/main/java/org/hibernate/exception/AuthException.java
@@ -1,0 +1,37 @@
+/*
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.exception;
+
+import org.hibernate.JDBCException;
+
+import java.sql.SQLException;
+
+/**
+ * A {@link JDBCException} indicating an authentication or authorization failure.
+ *
+ * @since 7.0
+ *
+ * @author Gavin King
+ */
+public class AuthException extends JDBCException {
+	/**
+	 * Constructor for AuthException.
+	 *
+	 * @param root The underlying exception.
+	 */
+	public AuthException(String message, SQLException root) {
+		super( message, root );
+	}
+
+	/**
+	 * Constructor for AuthException.
+	 *
+	 * @param message Optional message.
+	 * @param root    The underlying exception.
+	 */
+	public AuthException(String message, SQLException root, String sql) {
+		super( message, root, sql );
+	}
+}

--- a/hibernate-core/src/main/java/org/hibernate/exception/DataException.java
+++ b/hibernate-core/src/main/java/org/hibernate/exception/DataException.java
@@ -9,7 +9,7 @@ import java.sql.SQLException;
 import org.hibernate.JDBCException;
 
 /**
- * Extends {@link JDBCException} indicating that evaluation of the
+ * A {@link JDBCException} indicating that evaluation of the
  * valid SQL statement against the given data resulted in some
  * illegal operation, mismatched types or incorrect cardinality.
  *
@@ -17,7 +17,7 @@ import org.hibernate.JDBCException;
  */
 public class DataException extends JDBCException {
 	/**
-	 * Constructor for JDBCException.
+	 * Constructor for DataException.
 	 *
 	 * @param root The underlying exception.
 	 */
@@ -26,7 +26,7 @@ public class DataException extends JDBCException {
 	}
 
 	/**
-	 * Constructor for JDBCException.
+	 * Constructor for DataException.
 	 *
 	 * @param message Optional message.
 	 * @param root    The underlying exception.

--- a/hibernate-core/src/main/java/org/hibernate/exception/internal/SQLStateConversionDelegate.java
+++ b/hibernate-core/src/main/java/org/hibernate/exception/internal/SQLStateConversionDelegate.java
@@ -5,11 +5,11 @@
 package org.hibernate.exception.internal;
 
 import java.sql.SQLException;
-import java.util.Set;
 
 import org.hibernate.JDBCException;
 import org.hibernate.PessimisticLockException;
 import org.hibernate.QueryTimeoutException;
+import org.hibernate.exception.AuthException;
 import org.hibernate.exception.ConstraintViolationException;
 import org.hibernate.exception.DataException;
 import org.hibernate.exception.JDBCConnectionException;
@@ -17,60 +17,27 @@ import org.hibernate.exception.LockAcquisitionException;
 import org.hibernate.exception.SQLGrammarException;
 import org.hibernate.exception.spi.AbstractSQLExceptionConversionDelegate;
 import org.hibernate.exception.spi.ConversionContext;
-import org.hibernate.internal.util.JdbcExceptionHelper;
 
 import org.checkerframework.checker.nullness.qual.Nullable;
+
+import static org.hibernate.internal.util.JdbcExceptionHelper.determineSqlStateClassCode;
+import static org.hibernate.internal.util.JdbcExceptionHelper.extractErrorCode;
+import static org.hibernate.internal.util.JdbcExceptionHelper.extractSqlState;
 
 /**
  * A {@link org.hibernate.exception.spi.SQLExceptionConverter} implementation which performs conversion based
  * on the underlying SQLState. Interpretation of a SQL error based on SQLState is not nearly as accurate as
  * using the ErrorCode (which is, however, vendor-specific).
- * <p>
- * SQLState codes are defined by both ANSI SQL specs and X/Open.  Some "classes" are shared, others are
- * specific to one or another, yet others are custom vendor classes.  Unfortunately I have not been able to
- * find a "blessed" list of X/Open codes.  These codes are cobbled together between ANSI SQL spec and error
+ *
+ * @implNote
+ * SQLState codes are defined by both ANSI SQL specs and X/Open. Some "classes" are shared, others are
+ * specific to one or another, yet others are custom vendor classes. Unfortunately I have not been able to
+ * find a "blessed" list of X/Open codes. These codes are cobbled together between ANSI SQL spec and error
  * code tables from few vendor's documentation.
  *
  * @author Steve Ebersole
  */
 public class SQLStateConversionDelegate extends AbstractSQLExceptionConversionDelegate {
-
-	private static final Set<String> SQL_GRAMMAR_CATEGORIES = buildGrammarCategories();
-	private static Set<String> buildGrammarCategories() {
-		return Set.of(
-						"07", 	// "dynamic SQL error"
-						"20",
-						"2A", 	// "direct SQL syntax error or access rule violation"
-						"37",	// "dynamic SQL syntax error or access rule violation"
-						"42",	// "syntax error or access rule violation"
-						"65",	// Oracle specific as far as I can tell
-						"S0"	// MySQL specific as far as I can tell
-		);
-	}
-
-	private static final Set<String> DATA_CATEGORIES = buildDataCategories();
-	private static Set<String> buildDataCategories() {
-		return Set.of(
-				"21",	// "cardinality violation"
-				"22"	// "data exception"
-		);
-	}
-
-	private static final Set<String> INTEGRITY_VIOLATION_CATEGORIES = buildContraintCategories();
-	private static Set<String> buildContraintCategories() {
-		return Set.of(
-				"23",	// "integrity constraint violation"
-				"27",	// "triggered data change violation"
-				"44"	// "with check option violation"
-		);
-	}
-
-	private static final Set<String> CONNECTION_CATEGORIES = buildConnectionCategories();
-	private static Set<String> buildConnectionCategories() {
-		return Set.of(
-				"08"	// "connection exception"
-		);
-	}
 
 	public SQLStateConversionDelegate(ConversionContext conversionContext) {
 		super( conversionContext );
@@ -78,47 +45,55 @@ public class SQLStateConversionDelegate extends AbstractSQLExceptionConversionDe
 
 	@Override
 	public @Nullable JDBCException convert(SQLException sqlException, String message, String sql) {
-		final String sqlState = JdbcExceptionHelper.extractSqlState( sqlException );
-		final int errorCode = JdbcExceptionHelper.extractErrorCode( sqlException );
-
+		final String sqlState = extractSqlState( sqlException );
 		if ( sqlState != null ) {
-			String sqlStateClassCode = JdbcExceptionHelper.determineSqlStateClassCode( sqlState );
-
-			if ( sqlStateClassCode != null ) {
-				if ( SQL_GRAMMAR_CATEGORIES.contains( sqlStateClassCode ) ) {
+			switch ( sqlState ) {
+				case "42501":
+					return new AuthException( message, sqlException, sql );
+				case "40001":
+					return new LockAcquisitionException( message, sqlException, sql );
+				case "40XL1", "40XL2":
+					// Derby "A lock could not be obtained within the time requested."
+					return new PessimisticLockException( message, sqlException, sql );
+				case "70100":
+					// MySQL Query execution was interrupted
+					return new QueryTimeoutException(  message, sqlException, sql );
+				case "72000":
+					if ( extractErrorCode( sqlException ) == 1013 ) {
+						// Oracle user requested cancel of current operation
+						return new QueryTimeoutException(  message, sqlException, sql );
+					}
+			}
+			switch ( determineSqlStateClassCode( sqlState ) ) {
+				case
+					"07", 	// "dynamic SQL error"
+					"20",
+					"2A", 	// "direct SQL syntax error or access rule violation"
+					"37",	// "dynamic SQL syntax error or access rule violation"
+					"42",	// "syntax error or access rule violation"
+					"65",	// Oracle specific as far as I can tell
+					"S0":	// MySQL specific as far as I can tell
 					return new SQLGrammarException( message, sqlException, sql );
-				}
-				else if ( INTEGRITY_VIOLATION_CATEGORIES.contains( sqlStateClassCode ) ) {
+				case
+					"23",	// "integrity constraint violation"
+					"27",	// "triggered data change violation"
+					"44":	// "with check option violation"
 					final String constraintName = getConversionContext()
 							.getViolatedConstraintNameExtractor()
 							.extractConstraintName( sqlException );
 					return new ConstraintViolationException( message, sqlException, sql, constraintName );
-				}
-				else if ( CONNECTION_CATEGORIES.contains( sqlStateClassCode ) ) {
+				case
+					"08":	// "connection exception"
 					return new JDBCConnectionException( message, sqlException, sql );
-				}
-				else if ( DATA_CATEGORIES.contains( sqlStateClassCode ) ) {
+				case
+					"21",	// "cardinality violation"
+					"22":	// "data exception"
 					return new DataException( message, sqlException, sql );
-				}
-			}
-
-			if ( "40001".equals( sqlState ) ) {
-				return new LockAcquisitionException( message, sqlException, sql );
-			}
-
-			if ( "40XL1".equals( sqlState ) || "40XL2".equals( sqlState )) {
-				// Derby "A lock could not be obtained within the time requested."
-				return new PessimisticLockException( message, sqlException, sql );
-			}
-
-			// MySQL Query execution was interrupted
-			if ( "70100".equals( sqlState ) ||
-					// Oracle user requested cancel of current operation
-					( "72000".equals( sqlState ) && errorCode == 1013 ) ) {
-				return new QueryTimeoutException(  message, sqlException, sql );
+				case
+					"28":	// "authentication failure"
+					return new AuthException( message, sqlException, sql );
 			}
 		}
-
 		return null;
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/internal/SessionImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/SessionImpl.java
@@ -24,6 +24,7 @@ import java.util.TimeZone;
 
 import jakarta.persistence.PessimisticLockScope;
 import jakarta.persistence.Timeout;
+import org.hibernate.BatchSize;
 import org.hibernate.CacheMode;
 import org.hibernate.ConnectionAcquisitionMode;
 import org.hibernate.EntityFilterException;
@@ -950,6 +951,7 @@ public class SessionImpl
 		CacheStoreMode storeMode = getCacheStoreMode();
 		CacheRetrieveMode retrieveMode = getCacheRetrieveMode();
 		LockOptions lockOptions = copySessionLockOptions();
+		int batchSize = -1;
 		for ( FindOption option : options ) {
 			if ( option instanceof CacheStoreMode cacheStoreMode ) {
 				storeMode = cacheStoreMode;
@@ -982,8 +984,13 @@ public class SessionImpl
 			else if ( option instanceof ReadOnlyMode ) {
 				loadAccess.withReadOnly( option == ReadOnlyMode.READ_ONLY );
 			}
+			else if ( option instanceof BatchSize batchSizeOption ) {
+				batchSize = batchSizeOption.batchSize();
+			}
 		}
-		loadAccess.with( lockOptions ).with( interpretCacheMode( storeMode, retrieveMode ) );
+		loadAccess.with( lockOptions )
+				.with( interpretCacheMode( storeMode, retrieveMode ) )
+				.withBatchSize( batchSize );
 		return loadAccess;
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/internal/util/JdbcExceptionHelper.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/util/JdbcExceptionHelper.java
@@ -56,9 +56,6 @@ public final class JdbcExceptionHelper {
 	}
 
 	public static String determineSqlStateClassCode(String sqlState) {
-		if ( sqlState == null || sqlState.length() < 2 ) {
-			return sqlState;
-		}
-		return sqlState.substring( 0, 2 );
+		return sqlState == null || sqlState.length() < 2 ? sqlState : sqlState.substring( 0, 2 );
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/internal/util/collections/CollectionHelper.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/util/collections/CollectionHelper.java
@@ -262,7 +262,7 @@ public final class CollectionHelper {
 		return copy;
 	}
 
-	public static boolean isEmpty(Collection collection) {
+	public static boolean isEmpty(Collection<?> collection) {
 		return collection == null || collection.isEmpty();
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/loader/ast/internal/AbstractMultiIdEntityLoader.java
+++ b/hibernate-core/src/main/java/org/hibernate/loader/ast/internal/AbstractMultiIdEntityLoader.java
@@ -4,14 +4,24 @@
  */
 package org.hibernate.loader.ast.internal;
 
+import org.hibernate.LockMode;
+import org.hibernate.LockOptions;
+import org.hibernate.engine.spi.EntityKey;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.event.spi.EventSource;
+import org.hibernate.event.spi.LoadEvent;
+import org.hibernate.event.spi.LoadEventListener;
+import org.hibernate.internal.util.collections.CollectionHelper;
 import org.hibernate.loader.ast.spi.MultiIdEntityLoader;
 import org.hibernate.loader.ast.spi.MultiIdLoadOptions;
 import org.hibernate.metamodel.mapping.EntityIdentifierMapping;
 import org.hibernate.metamodel.mapping.EntityMappingType;
+import org.hibernate.type.descriptor.java.JavaType;
 
+import java.util.ArrayList;
 import java.util.List;
+
+import static org.hibernate.loader.ast.internal.CacheEntityLoaderHelper.loadFromSessionCacheStatic;
 
 /**
  * Base support for {@link MultiIdEntityLoader} implementations.
@@ -57,7 +67,121 @@ public abstract class AbstractMultiIdEntityLoader<T> implements MultiIdEntityLoa
 		}
 	}
 
-	protected abstract <K> List<T> performOrderedMultiLoad(K[] ids, MultiIdLoadOptions loadOptions, EventSource session);
+	protected List<T> performOrderedMultiLoad(
+			Object[] ids,
+			MultiIdLoadOptions loadOptions,
+			EventSource session) {
+		if ( MultiKeyLoadLogging.MULTI_KEY_LOAD_LOGGER.isTraceEnabled() ) {
+			MultiKeyLoadLogging.MULTI_KEY_LOAD_LOGGER.tracef( "#performOrderedMultiLoad(`%s`, ..)",
+					getLoadable().getEntityName() );
+		}
+
+		assert loadOptions.isOrderReturnEnabled();
+
+		final boolean coerce = !getSessionFactory().getJpaMetamodel().getJpaCompliance().isLoadByIdComplianceEnabled();
+		final JavaType<?> idType = getLoadable().getIdentifierMapping().getJavaType();
+
+		final LockOptions lockOptions = loadOptions.getLockOptions() == null
+				? new LockOptions( LockMode.NONE )
+				: loadOptions.getLockOptions();
+
+		final int maxBatchSize = maxBatchSize( ids, loadOptions );
+
+		final List<Object> result = CollectionHelper.arrayList( ids.length );
+
+		final List<Object> idsInBatch = new ArrayList<>();
+		final List<Integer> elementPositionsLoadedByBatch = new ArrayList<>();
+
+		for ( int i = 0; i < ids.length; i++ ) {
+			final Object id = coerce ? idType.coerce( ids[i], session ) : ids[i];
+			final EntityKey entityKey = new EntityKey( id, getLoadable().getEntityPersister() );
+
+			if ( !loadFromCaches( loadOptions, session, id, lockOptions, entityKey, result, i ) ) {
+				// if we did not hit any of the continues above,
+				// then we need to batch load the entity state.
+				idsInBatch.add( id );
+
+				if ( idsInBatch.size() >= maxBatchSize ) {
+					// we've hit the allotted max-batch-size, perform an "intermediate load"
+					loadEntitiesById( idsInBatch, lockOptions, loadOptions, session );
+					idsInBatch.clear();
+				}
+
+				// Save the EntityKey instance for use later
+				result.add( i, entityKey );
+				elementPositionsLoadedByBatch.add( i );
+			}
+		}
+
+		if ( !idsInBatch.isEmpty() ) {
+			// we still have ids to load from the processing above since
+			// the last max-batch-size trigger, perform a load for them
+			loadEntitiesById( idsInBatch, lockOptions, loadOptions, session );
+		}
+
+		// for each result where we set the EntityKey earlier, replace them
+		handleResults( loadOptions, session, elementPositionsLoadedByBatch, result );
+
+		//noinspection unchecked
+		return (List<T>) result;
+	}
+
+	protected abstract int maxBatchSize(Object[] ids, MultiIdLoadOptions loadOptions);
+
+	protected abstract void handleResults(MultiIdLoadOptions loadOptions, EventSource session, List<Integer> elementPositionsLoadedByBatch, List<Object> result);
+
+	protected abstract void loadEntitiesById(List<Object> idsInBatch, LockOptions lockOptions, MultiIdLoadOptions loadOptions, EventSource session);
+
+	protected boolean loadFromCaches(
+			MultiIdLoadOptions loadOptions,
+			EventSource session,
+			Object id,
+			LockOptions lockOptions,
+			EntityKey entityKey,
+			List<Object> result,
+			int i) {
+		if ( loadOptions.isSessionCheckingEnabled() || loadOptions.isSecondLevelCacheCheckingEnabled() ) {
+			final LoadEvent loadEvent = new LoadEvent(
+					id,
+					getLoadable().getJavaType().getJavaTypeClass().getName(),
+					lockOptions,
+					session,
+					LoaderHelper.getReadOnlyFromLoadQueryInfluencers( session )
+			);
+
+			Object managedEntity = null;
+
+			if ( loadOptions.isSessionCheckingEnabled() ) {
+				// look for it in the Session first
+				final CacheEntityLoaderHelper.PersistenceContextEntry persistenceContextEntry =
+						loadFromSessionCacheStatic( loadEvent, entityKey, LoadEventListener.GET );
+				managedEntity = persistenceContextEntry.getEntity();
+
+				if ( managedEntity != null
+						&& !loadOptions.isReturnOfDeletedEntitiesEnabled()
+						&& !persistenceContextEntry.isManaged() ) {
+					// put a null in the result
+					result.add( i, null );
+					return true;
+				}
+			}
+
+			if ( managedEntity == null && loadOptions.isSecondLevelCacheCheckingEnabled() ) {
+				// look for it in the SessionFactory
+				managedEntity = CacheEntityLoaderHelper.INSTANCE.loadFromSecondLevelCache(
+						loadEvent,
+						getLoadable().getEntityPersister(),
+						entityKey
+				);
+			}
+
+			if ( managedEntity != null ) {
+				result.add( i, managedEntity );
+				return true;
+			}
+		}
+		return false;
+	}
 
 	protected abstract <K> List<T> performUnorderedMultiLoad(K[] ids, MultiIdLoadOptions loadOptions, EventSource session);
 

--- a/hibernate-core/src/main/java/org/hibernate/persister/entity/AbstractEntityPersister.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/entity/AbstractEntityPersister.java
@@ -857,7 +857,7 @@ public abstract class AbstractEntityPersister
 	protected MultiIdEntityLoader<Object> buildMultiIdLoader() {
 		final Dialect dialect = factory.getJdbcServices().getDialect();
 		return getIdentifierType() instanceof BasicType && supportsSqlArrayType( dialect )
-				? new MultiIdEntityLoaderArrayParam<>( this, identifierColumnSpan, factory )
+				? new MultiIdEntityLoaderArrayParam<>( this, factory )
 				: new MultiIdEntityLoaderStandard<>( this, identifierColumnSpan, factory );
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/persister/entity/AbstractEntityPersister.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/entity/AbstractEntityPersister.java
@@ -855,13 +855,10 @@ public abstract class AbstractEntityPersister
 	}
 
 	protected MultiIdEntityLoader<Object> buildMultiIdLoader() {
-		if ( getIdentifierType() instanceof BasicType
-				&& supportsSqlArrayType( factory.getJdbcServices().getDialect() ) ) {
-			return new MultiIdEntityLoaderArrayParam<>( this, factory );
-		}
-		else {
-			return new MultiIdEntityLoaderStandard<>( this, identifierColumnSpan, factory );
-		}
+		final Dialect dialect = factory.getJdbcServices().getDialect();
+		return getIdentifierType() instanceof BasicType && supportsSqlArrayType( dialect )
+				? new MultiIdEntityLoaderArrayParam<>( this, identifierColumnSpan, factory )
+				: new MultiIdEntityLoaderStandard<>( this, identifierColumnSpan, factory );
 	}
 
 	private String getIdentitySelectString(Dialect dialect) {


### PR DESCRIPTION
1. Add `BatchSize`, a `FindOption` synonymous with `MultiIdLoadAccess.withBatchSize()`.
3. Make `MultiIdEntityLoaderArrayParam` respect explicit batch sizes.

<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

[Please describe here what your change is about]

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-18767
https://hibernate.atlassian.net/browse/HHH-18772
<!-- Hibernate GitHub Bot issue links end -->