### PR TITLE
Do not include the whole Gradle cache in GH Actions caches

### DIFF
--- a/.github/workflows/ci-report.yml
+++ b/.github/workflows/ci-report.yml
@@ -37,13 +37,13 @@ jobs:
           echo "buildtool-monthly-cache-key=${ROOT_CACHE_KEY}-${CURRENT_MONTH}" >> $GITHUB_OUTPUT
           echo "buildtool-monthly-branch-cache-key=${ROOT_CACHE_KEY}-${CURRENT_MONTH}-${CURRENT_BRANCH}" >> $GITHUB_OUTPUT
           echo "buildtool-cache-key=${ROOT_CACHE_KEY}-${CURRENT_MONTH}-${CURRENT_BRANCH}-${CURRENT_DAY}" >> $GITHUB_OUTPUT
-      - name: Restore Maven/Gradle Local Caches
+      - name: Restore Maven/Gradle Dependency/Dist Caches
         uses: actions/cache/restore@v4
         with:
           path: |
             ~/.m2/repository/
             ~/.m2/wrapper/
-            ~/.gradle/caches/
+            ~/.gradle/caches/modules-2
             ~/.gradle/wrapper/
           key: ${{ steps.cache-key.outputs.buildtool-cache-key }}
           restore-keys: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,7 @@ jobs:
           echo "buildtool-monthly-cache-key=${ROOT_CACHE_KEY}-${CURRENT_MONTH}" >> $GITHUB_OUTPUT
           echo "buildtool-monthly-branch-cache-key=${ROOT_CACHE_KEY}-${CURRENT_MONTH}-${CURRENT_BRANCH}" >> $GITHUB_OUTPUT
           echo "buildtool-cache-key=${ROOT_CACHE_KEY}-${CURRENT_MONTH}-${CURRENT_BRANCH}-${CURRENT_DAY}" >> $GITHUB_OUTPUT
-      - name: Cache Maven/Gradle Local Caches
+      - name: Cache Maven/Gradle Dependency/Dist Caches
         id: cache-maven
         uses: actions/cache@v4
         # if it's not a pull request, we restore and save the cache
@@ -80,7 +80,7 @@ jobs:
           path: |
             ~/.m2/repository/
             ~/.m2/wrapper/
-            ~/.gradle/caches/
+            ~/.gradle/caches/modules-2
             ~/.gradle/wrapper/
           # A new cache will be stored daily. After that first store of the day, cache save actions will fail because the cache is immutable but it's not a problem.
           # The whole cache is dropped monthly to prevent unlimited growth.
@@ -89,7 +89,7 @@ jobs:
           restore-keys: |
             ${{ steps.cache-key.outputs.buildtool-monthly-branch-cache-key }}-
             ${{ steps.cache-key.outputs.buildtool-monthly-cache-key }}-
-      - name: Restore Maven/Gradle Local Caches
+      - name: Restore Maven/Gradle Dependency/Dist Caches
         uses: actions/cache/restore@v4
         # if it a pull request, we restore the cache but we don't save it
         if: github.event_name == 'pull_request'
@@ -97,7 +97,7 @@ jobs:
           path: |
             ~/.m2/repository/
             ~/.m2/wrapper/
-            ~/.gradle/caches/
+            ~/.gradle/caches/modules-2
             ~/.gradle/wrapper/
           key: ${{ steps.cache-key.outputs.buildtool-cache-key }}
           restore-keys: |
@@ -180,7 +180,7 @@ jobs:
           echo "buildtool-monthly-cache-key=${ROOT_CACHE_KEY}-${CURRENT_MONTH}" >> $GITHUB_OUTPUT
           echo "buildtool-monthly-branch-cache-key=${ROOT_CACHE_KEY}-${CURRENT_MONTH}-${CURRENT_BRANCH}" >> $GITHUB_OUTPUT
           echo "buildtool-cache-key=${ROOT_CACHE_KEY}-${CURRENT_MONTH}-${CURRENT_BRANCH}-${CURRENT_DAY}" >> $GITHUB_OUTPUT
-      - name: Cache Maven/Gradle Local Caches
+      - name: Cache Maven/Gradle Dependency/Dist Caches
         id: cache-maven
         uses: actions/cache@v4
         # if it's not a pull request, we restore and save the cache
@@ -189,7 +189,7 @@ jobs:
           path: |
             ~/.m2/repository/
             ~/.m2/wrapper/
-            ~/.gradle/caches/
+            ~/.gradle/caches/modules-2
             ~/.gradle/wrapper/
           # A new cache will be stored daily. After that first store of the day, cache save actions will fail because the cache is immutable but it's not a problem.
           # The whole cache is dropped monthly to prevent unlimited growth.
@@ -198,7 +198,7 @@ jobs:
           restore-keys: |
             ${{ steps.cache-key.outputs.buildtool-monthly-branch-cache-key }}-
             ${{ steps.cache-key.outputs.buildtool-monthly-cache-key }}-
-      - name: Restore Maven/Gradle Local Caches
+      - name: Restore Maven/Gradle Dependency/Dist Caches
         uses: actions/cache/restore@v4
         # if it a pull request, we restore the cache but we don't save it
         if: github.event_name == 'pull_request'
@@ -206,7 +206,7 @@ jobs:
           path: |
             ~/.m2/repository/
             ~/.m2/wrapper/
-            ~/.gradle/caches/
+            ~/.gradle/caches/modules-2
             ~/.gradle/wrapper/
           key: ${{ steps.cache-key.outputs.buildtool-cache-key }}
           restore-keys: |


### PR DESCRIPTION
We don't need the whole cache, since most (all?) of it is stored on Develocity already.

Including ./gradle/caches/modules-2 is enough, because that's where Maven dependencies are stored, and *those* are not stored on Develocity.


<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
