### PR TITLE
HHH-18770 NPE when using the JFR integration with JFR disabled

### DIFF
--- a/hibernate-jfr/src/main/java/org/hibernate/event/jfr/internal/JfrEventManager.java
+++ b/hibernate-jfr/src/main/java/org/hibernate/event/jfr/internal/JfrEventManager.java
@@ -452,7 +452,7 @@ public class JfrEventManager implements EventManager {
 	public void completePartialFlushEvent(
 			HibernateMonitoringEvent hibernateMonitoringEvent,
 			AutoFlushEvent event) {
-		if ( event != null ) {
+		if ( event != null && hibernateMonitoringEvent != null) {
 			final PartialFlushEvent flushEvent = (PartialFlushEvent) hibernateMonitoringEvent;
 			flushEvent.end();
 			if ( flushEvent.shouldCommit() ) {

--- a/hibernate-jfr/src/test/java/org/hibernate/event/jfr/flush/AutoFlushTestsJfrDisabled.java
+++ b/hibernate-jfr/src/test/java/org/hibernate/event/jfr/flush/AutoFlushTestsJfrDisabled.java
@@ -1,0 +1,60 @@
+/*
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.event.jfr.flush;
+
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.JiraKey;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.junit.jupiter.api.Test;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+
+
+@DomainModel(annotatedClasses = {
+		AutoFlushTestsJfrDisabled.TestEntity.class,
+})
+@SessionFactory
+@JiraKey(value = "HHH-18770")
+public class AutoFlushTestsJfrDisabled {
+
+	/**
+	 * Execute a query (and a flush) with the jfr module on the classpath but jfr disabled
+	 */
+	@Test
+	public void testFlushEventWithPartialFlushEventDisabled(SessionFactoryScope scope) {
+		scope.inTransaction(
+				session -> {
+					TestEntity entity = new TestEntity( 1, "name_1" );
+					session.persist( entity );
+					session.createQuery( "select t from TestEntity t" ).list();
+
+					session.remove( entity );
+				}
+		);
+	}
+
+	@Entity(name = "TestEntity")
+	public static class TestEntity {
+		@Id
+		private Integer id;
+
+		private String name;
+
+		public TestEntity() {
+		}
+
+		public TestEntity(Integer id, String name) {
+			this.id = id;
+			this.name = name;
+		}
+
+		public void setName(String name) {
+			this.name = name;
+		}
+	}
+
+}


### PR DESCRIPTION
<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->


[HHH-18770](https://hibernate.atlassian.net/browse/HHH-18770) Run the autoflush test without enabling JFR


[HHH-18770]: https://hibernate.atlassian.net/browse/HHH-18770?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
