### PR TITLE
Hhh 18771 index out of bounds exception by list initializer for list index base

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/ListInitializer.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/ListInitializer.java
@@ -121,10 +121,13 @@ public class ListInitializer extends AbstractImmediateCollectionInitializer<Abst
 		final Initializer<?> initializer = elementAssembler.getInitializer();
 		if ( initializer != null ) {
 			final RowProcessingState rowProcessingState = data.getRowProcessingState();
-			final Integer index = listIndexAssembler.assemble( rowProcessingState );
+			Integer index = listIndexAssembler.assemble( rowProcessingState );
 			if ( index != null ) {
 				final PersistentList<?> list = getCollectionInstance( data );
 				assert list != null;
+				if ( listIndexBase != 0 ) {
+					index -= listIndexBase;
+				}
 				initializer.resolveInstance( list.get( index ), rowProcessingState );
 			}
 		}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/collections/OrderColumnListIndexBaseTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/collections/OrderColumnListIndexBaseTest.java
@@ -9,16 +9,12 @@ import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
-import jakarta.persistence.CascadeType;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.Id;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.OneToMany;
-import jakarta.persistence.OrderColumn;
 
-import org.hibernate.annotations.ListIndexBase;
-import org.hibernate.annotations.NaturalId;
+import jakarta.persistence.*;
+
+import jakarta.persistence.CascadeType;
+import org.hibernate.annotations.*;
+import org.hibernate.annotations.Cache;
 import org.hibernate.orm.test.jpa.BaseEntityManagerFunctionalTestCase;
 
 import org.junit.Test;
@@ -48,6 +44,10 @@ public class OrderColumnListIndexBaseTest extends BaseEntityManagerFunctionalTes
 			entityManager.persist(person);
 			person.addPhone(new Phone(1L, "landline", "028-234-9876"));
 			person.addPhone(new Phone(2L, "mobile", "072-122-9876"));
+			person.getChildren().add(new Person( 2L));
+			person.getChildren().add(new Person( 3L));
+			person.getChildren().get(0).setMother(person);
+			person.getChildren().get(1).setMother(person);
 			//end::collections-customizing-ordered-list-ordinal-persist-example[]
 		});
 		doInAutoCommit( st -> {
@@ -66,8 +66,33 @@ public class OrderColumnListIndexBaseTest extends BaseEntityManagerFunctionalTes
 				throw new RuntimeException( e );
 			}
 		} );
+		doInAutoCommit( st -> {
+			try (ResultSet rs = st.executeQuery( "select child_id, pos from parent_child_relationships" )) {
+				while ( rs.next() ) {
+					final long id = rs.getLong( 1 );
+					if ( id == 2 ) {
+						assertEquals( 200, rs.getInt( 2 ) );
+					}
+					else if ( id == 3 ) {
+						assertEquals( 201, rs.getInt( 2 ) );
+					}
+				}
+			}
+			catch (SQLException e) {
+				throw new RuntimeException( e );
+			}
+		} );
+		doInJPA(this::entityManagerFactory, entityManager -> {
+			Phone phone = entityManager.find(  Phone.class, 1L);
+			Person person = phone.getPerson();
+			List<Person> children = person.getChildren();
+			assertEquals(2, children.size());
+			assertEquals(2L, children.get(0).id.longValue());
+			assertEquals(3L, children.get(1).id.longValue());
+		});
 		doInJPA(this::entityManagerFactory, entityManager -> {
 			Person person = entityManager.find(  Person.class, 1L);
+			assertEquals(2, person.getPhones().size());
 			person.addPhone(new Phone(3L, "fax", "099-234-9876"));
 			entityManager.persist(person);
 		});
@@ -100,17 +125,29 @@ public class OrderColumnListIndexBaseTest extends BaseEntityManagerFunctionalTes
 	}
 
 	@Entity(name = "Person")
+	@Cacheable
+	@Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
 	public static class Person {
 
 		@Id
 		private Long id;
 
 		//tag::collections-customizing-ordered-list-ordinal-mapping-example[]
-		@OneToMany(mappedBy = "person", cascade = CascadeType.ALL)
+		@OneToMany(fetch = FetchType.EAGER, mappedBy = "person", cascade = CascadeType.ALL)
 		@OrderColumn(name = "order_id")
 		@ListIndexBase(100)
 		private List<Phone> phones = new ArrayList<>();
 		//end::collections-customizing-ordered-list-ordinal-mapping-example[]
+
+		@ManyToMany(fetch = FetchType.EAGER, cascade = CascadeType.ALL)
+		@JoinTable(name = "parent_child_relationships", joinColumns = @JoinColumn(name = "parent_id"), inverseJoinColumns = @JoinColumn(name = "child_id"))
+		@OrderColumn(name = "pos")
+		@ListIndexBase(200)
+		private List<Person> children = new ArrayList<>();
+
+		@ManyToOne
+		@JoinColumn(name = "mother_id")
+		private Person mother;
 
 		public Person() {
 		}
@@ -126,6 +163,18 @@ public class OrderColumnListIndexBaseTest extends BaseEntityManagerFunctionalTes
 		public void addPhone(Phone phone) {
 			phones.add(phone);
 			phone.setPerson(this);
+		}
+
+		public List<Person> getChildren() {
+			return children;
+		}
+
+		public Person getMother() {
+			return mother;
+		}
+
+		public void setMother(Person mother) {
+			this.mother = mother;
 		}
 
 		public void removePhone(Phone phone) {


### PR DESCRIPTION
In complex scenarios eager entity initialization involving multi level hierarchy fetching via JOIN and a List attribute with @ListIndexBase(n) where n >= List.size, an IndexOutOfBoundException may be thrown. This PR tests and fixes this issue which is described in [HHH-18771 JIRA bug report](https://hibernate.atlassian.net/jira/software/c/projects/HHH/issues/HHH-18771).

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
