### PR TITLE
HHH-18773 Deduplicate result initializers to avoid double initialization issues

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/sql/results/jdbc/internal/JdbcValuesMappingResolutionImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/jdbc/internal/JdbcValuesMappingResolutionImpl.java
@@ -4,7 +4,7 @@
  */
 package org.hibernate.sql.results.jdbc.internal;
 
-import java.util.ArrayList;
+import java.util.LinkedHashSet;
 
 import org.hibernate.sql.results.graph.DomainResultAssembler;
 import org.hibernate.sql.results.graph.Initializer;
@@ -37,7 +37,7 @@ public class JdbcValuesMappingResolutionImpl implements JdbcValuesMappingResolut
 	}
 
 	private static Initializer<?>[] getResultInitializers(DomainResultAssembler<?>[] resultAssemblers) {
-		final ArrayList<Initializer<?>> initializers = new ArrayList<>( resultAssemblers.length );
+		final LinkedHashSet<Initializer<?>> initializers = new LinkedHashSet<>( resultAssemblers.length );
 		for ( DomainResultAssembler<?> resultAssembler : resultAssemblers ) {
 			resultAssembler.forEachResultAssembler( (initializer, list) -> list.add( initializer ), initializers );
 		}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/query/SelectJoinedAssociationMultipleTimesTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/query/SelectJoinedAssociationMultipleTimesTest.java
@@ -1,0 +1,58 @@
+/*
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.query;
+
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+
+@DomainModel(annotatedClasses = {
+		SelectJoinedAssociationMultipleTimesTest.Book.class
+})
+@SessionFactory
+public class SelectJoinedAssociationMultipleTimesTest {
+
+	@Test
+	public void test(SessionFactoryScope scope) {
+		scope.inTransaction(
+				session -> {
+					// Add a proxy first to trigger the error
+					session.getReference( Book.class, 1 );
+					session.createSelectionQuery( "select b b1, b b2 from Book b", Object[].class ).getResultList();
+				}
+		);
+	}
+
+	@BeforeEach
+	public void prepareTestData(SessionFactoryScope scope) {
+		scope.inTransaction( (session) -> session.persist( new Book( 1, "First book" ) ) );
+	}
+
+	@AfterEach
+	public void dropTestData(SessionFactoryScope scope) {
+		scope.inTransaction( (session) -> session.createMutationQuery( "delete Book" ).executeUpdate() );
+	}
+
+	@Entity( name = "Book")
+	public static class Book {
+		@Id
+		private Integer id;
+		private String name;
+
+		public Book() {
+		}
+
+		public Book(Integer id, String name) {
+			this.id = id;
+			this.name = name;
+		}
+	}
+}


### PR DESCRIPTION
<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

[Please describe here what your change is about]

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-18773
<!-- Hibernate GitHub Bot issue links end -->