### PR TITLE
HHH-18764 Fix incorrect type resolution in ManyToOneType dirty check

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/type/ManyToOneType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/ManyToOneType.java
@@ -250,7 +250,7 @@ public class ManyToOneType extends EntityType {
 		}
 		Object oldid = getIdentifier( old, session );
 		Object newid = getIdentifier( current, session );
-		return getIdentifierType( session ).isDirty( oldid, newid, session );
+		return getIdentifierOrUniqueKeyType( session.getFactory() ).isDirty( oldid, newid, session );
 	}
 
 	@Override
@@ -268,7 +268,7 @@ public class ManyToOneType extends EntityType {
 			}
 			Object oldid = getIdentifier( old, session );
 			Object newid = getIdentifier( current, session );
-			return getIdentifierType( session ).isDirty( oldid, newid, checkable, session );
+			return getIdentifierOrUniqueKeyType( session.getFactory() ).isDirty( oldid, newid, checkable, session );
 		}
 
 	}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/associations/ManyToOneUniqueKeyReferenceWithCustomIdTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/associations/ManyToOneUniqueKeyReferenceWithCustomIdTest.java
@@ -1,0 +1,195 @@
+/*
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.associations;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import org.hibernate.HibernateException;
+import org.hibernate.annotations.NaturalId;
+import org.hibernate.annotations.Type;
+import org.hibernate.engine.spi.SharedSessionContractImplementor;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.JiraKey;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.hibernate.usertype.EnhancedUserType;
+import org.junit.jupiter.api.Test;
+
+import java.io.Serializable;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Types;
+
+/**
+ * @author Kowsar Atazadeh
+ */
+@SessionFactory
+@DomainModel(annotatedClasses =
+		{ManyToOneUniqueKeyReferenceWithCustomIdTest.Phone.class, ManyToOneUniqueKeyReferenceWithCustomIdTest.User.class})
+@JiraKey("HHH-18764")
+public class ManyToOneUniqueKeyReferenceWithCustomIdTest {
+
+	@Test
+	void test(SessionFactoryScope scope) {
+		scope.inTransaction( session -> {
+			Phone phone = new Phone();
+
+			User user1 = new User( new CustomId( "u1" ), "Kowsar" );
+			session.persist( user1 );
+			phone.setUser( user1 );
+			session.persist( phone );
+
+			User user2 = new User( new CustomId( "u2" ), "Someone" );
+			session.persist( user2 );
+			phone.setUser( user2 );
+			session.persist( phone );
+		} );
+	}
+
+	@Entity(name = "Phone")
+	static class Phone {
+		@Id
+		@GeneratedValue
+		Long id;
+
+		@ManyToOne(fetch = FetchType.LAZY)
+		@JoinColumn(referencedColumnName = "name", nullable = false)
+		User user;
+
+		public Long getId() {
+			return id;
+		}
+
+		public void setId(Long id) {
+			this.id = id;
+		}
+
+		public User getUser() {
+			return user;
+		}
+
+		public void setUser(User user) {
+			this.user = user;
+		}
+	}
+
+	@Entity(name = "_User")
+	static class User {
+		@Id
+		@Type(CustomIdType.class)
+		CustomId id;
+
+		@NaturalId
+		String name;
+
+		public User() {
+		}
+
+		public User(CustomId id, String name) {
+			this.id = id;
+			this.name = name;
+		}
+
+		public String getName() {
+			return name;
+		}
+
+		public void setName(String name) {
+			this.name = name;
+		}
+
+		public CustomId getId() {
+			return id;
+		}
+
+		public void setId(CustomId id) {
+			this.id = id;
+		}
+	}
+
+	static class CustomIdType implements EnhancedUserType<CustomId> {
+		@Override
+		public String toSqlLiteral(CustomId value) {
+			return "'" + value.toString() + "'";
+		}
+
+		@Override
+		public String toString(CustomId value) throws HibernateException {
+			return value.toString();
+		}
+
+		@Override
+		public void nullSafeSet(PreparedStatement st, CustomId value, int position,
+								SharedSessionContractImplementor session) throws SQLException {
+			st.setObject( position, value.toString(), getSqlType() );
+		}
+
+		@Override
+		public CustomId nullSafeGet(ResultSet rs, int position, SharedSessionContractImplementor session)
+				throws SQLException {
+			String idValue = rs.getString( position );
+			return idValue != null ? fromStringValue( idValue ) : null;
+		}
+
+		@Override
+		public CustomId fromStringValue(CharSequence sequence) throws HibernateException {
+			return new CustomId( sequence.toString() );
+		}
+
+		@Override
+		public int getSqlType() {
+			return Types.VARCHAR;
+		}
+
+		@Override
+		public Class<CustomId> returnedClass() {
+			return CustomId.class;
+		}
+
+		@Override
+		public CustomId deepCopy(CustomId value) {
+			return new CustomId( value.getId() );
+		}
+
+		@Override
+		public boolean isMutable() {
+			return false;
+		}
+
+		@Override
+		public boolean equals(CustomId x, CustomId y) {
+			return EnhancedUserType.super.equals( x, y );
+		}
+	}
+
+	static class CustomId implements Serializable {
+		private String id;
+
+		public CustomId() {
+		}
+
+		public CustomId(String id) {
+			this.id = id;
+		}
+
+		@Override
+		public String toString() {
+			return id;
+		}
+
+		public String getId() {
+			return id;
+		}
+
+		public void setId(String id) {
+			this.id = id;
+		}
+	}
+}


### PR DESCRIPTION
This pull request addresses a bug in the `isDirty` method when dealing with ManyToOne associations that are referenced by a unique key instead of a primary key, particularly when the primary key is a custom type.

This bug stems from a mismatch in how `isDirty` checks for changes: while it correctly retrieves the unique key value using `getIdentifier`, it incorrectly relies on `getIdentifierType`, which only considers the primary key type. This results in unexpected behavior—in this case, a `ClassCastException` when attempting to call the custom ID type's equals method.

The fix replaces `getIdentifierType` with `getIdentifierOrUniqueKeyType`, ensuring that `isDirty` correctly accounts for both primary keys and unique keys. This issue is demonstrated in the unit test `ManyToOneUniqueKeyReferenceWithCustomIdTest`.

----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-18764
<!-- Hibernate GitHub Bot issue links end -->