### PR TITLE
Fix upload of Develocity build scans

### DIFF
--- a/.github/workflows/ci-report.yml
+++ b/.github/workflows/ci-report.yml
@@ -66,11 +66,11 @@ jobs:
         run: |
           shopt -s nullglob # Don't run the loop below if there are no artifacts
           status=0
+          mkdir -p ~/.gradle/
           for build_scan_data_directory in /tmp/downloaded-build-scan-data/*
           do
             rm -rf ~/.gradle/build-scan-data
-            mkdir -p ~/.gradle/build-scan-data
-            tar -xzf "$build_scan_data_directory/build-scan-data.tgz" -C ~/.gradle/build-scan-data \
+            mv "$build_scan_data_directory" ~/.gradle/build-scan-data \
             && ./gradlew --no-build-cache buildScanPublishPrevious || status=1
           done
           exit $status

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,12 +114,9 @@ jobs:
           POPULATE_REMOTE_GRADLE_CACHE: ${{ github.event_name == 'push' && github.repository == 'hibernate/hibernate-orm' && 'true' || 'false' }}
           DEVELOCITY_ACCESS_KEY: "${{ secrets.DEVELOCITY_ACCESS_KEY }}"
 
-      # For jobs running on 'pull_request', tar and upload build scan data.
+      # For jobs running on 'pull_request', upload build scan data.
       # The actual publishing must be done in a separate job (see ci-report.yml).
       # We don't write to the remote cache as that would be unsafe.
-      - name: Tar build scan content pushed to subsequent jobs
-        if: "${{ github.event_name == 'pull_request' && !cancelled() }}"
-        run: tar -czf build-scan-data.tgz -C ~/.gradle/build-scan-data .
       - name: Upload GitHub Actions artifact for the Develocity build scan
         uses: actions/upload-artifact@v4
         if: "${{ github.event_name == 'pull_request' && !cancelled() }}"
@@ -219,13 +216,10 @@ jobs:
           RUNID: ${{ github.run_number }}
         run: ./ci/build-github.sh
         shell: bash
-      # Tar and upload build scan data.
+      # Upload build scan data.
       # The actual publishing must be done in a separate job (see ci-report.yml).
       # We don't write to the remote cache as that would be unsafe.
       # That's even on push, because we do not trust Atlas runners to hold secrets: they are shared infrastructure.
-      - name: Tar build scan content pushed to subsequent jobs
-        if: "${{ !cancelled() }}"
-        run: tar -czf build-scan-data.tgz -C ~/.gradle/build-scan-data .
       - name: Upload GitHub Actions artifact for the Develocity build scan
         uses: actions/upload-artifact@v4
         if: "${{ !cancelled() }}"


### PR DESCRIPTION
Don't tar them, as this was broken: we ended up uploading the build-scan-data directory instead of the tar, while still expecting a tar when dowloading, which made everything fail.

We don't need tars anyway, as workflow artifacts are already zipped.

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
