### PR TITLE
HHH-18784 TableMigrator shouldn't alter column length if length is not explicitly-set

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/tool/schema/internal/ColumnDefinitions.java
+++ b/hibernate-core/src/main/java/org/hibernate/tool/schema/internal/ColumnDefinitions.java
@@ -51,7 +51,7 @@ class ColumnDefinitions {
 	}
 
 	static boolean hasMatchingLength(Column column, ColumnInformation columnInformation, Metadata metadata, Dialect dialect) {
-		if ( !column.getSqlType( metadata ).contains("(") ) {
+		if ( !column.isExplicit() || !column.getSqlType( metadata ).contains("(") ) {
 			// the DDL type does not explicitly specify a length,
 			// and so we do not require an exact match
 			return true;

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/schemaupdate/ColumnLengthTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/schemaupdate/ColumnLengthTest.java
@@ -1,0 +1,107 @@
+/*
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.schemaupdate;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import org.hibernate.boot.MetadataSources;
+import org.hibernate.boot.registry.StandardServiceRegistry;
+import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
+import org.hibernate.boot.spi.MetadataImplementor;
+import org.hibernate.dialect.H2Dialect;
+import org.hibernate.testing.junit4.BaseCoreFunctionalTestCase;
+import org.hibernate.testing.orm.junit.JiraKey;
+import org.hibernate.testing.orm.junit.RequiresDialect;
+import org.hibernate.testing.transaction.TransactionUtil;
+import org.hibernate.testing.util.ServiceRegistryUtil;
+import org.hibernate.tool.hbm2ddl.SchemaUpdate;
+import org.hibernate.tool.schema.TargetType;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.nio.file.Files;
+import java.util.EnumSet;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+/**
+ * @author Yanming Zhou
+ */
+@JiraKey("HHH-18784")
+@RequiresDialect(H2Dialect.class)
+public class ColumnLengthTest extends BaseCoreFunctionalTestCase {
+
+	private File output;
+
+	@Override
+	protected Class<?>[] getAnnotatedClasses() {
+		return new Class<?>[] { TestEntity.class };
+	}
+
+	@Before
+	public void setUp() throws IOException {
+		output = File.createTempFile( "update_script", ".sql" );
+		output.deleteOnExit();
+		TransactionUtil.doInHibernate( this::sessionFactory, session -> {
+			session.createNativeQuery( "DROP TABLE IF EXISTS en CASCADE" ).executeUpdate();
+			session.createNativeQuery(
+					"CREATE TABLE en ( " +
+							"  `ID` integer NOT NULL, " +
+							"  `TEXT` varchar(1000), " +
+							"  `DECIMAL` numeric(38, 4), " +
+							"   PRIMARY KEY (`ID`)" +
+							")" )
+					.executeUpdate();
+		} );
+	}
+
+	@After
+	public void tearDown() {
+		TransactionUtil.doInHibernate( this::sessionFactory, session -> {
+			session.createNativeQuery( "DROP TABLE en CASCADE" ).executeUpdate();
+		} );
+		output.delete();
+	}
+
+	@Test
+	public void testUpdateIsNotExecuted() throws Exception {
+		StandardServiceRegistry ssr = ServiceRegistryUtil.serviceRegistryBuilder()
+				.build();
+		try {
+			final MetadataSources metadataSources = new MetadataSources( ssr );
+			metadataSources.addAnnotatedClass( TestEntity.class );
+			MetadataImplementor metadata = (MetadataImplementor) metadataSources.buildMetadata();
+			metadata.orderColumns( false );
+			new SchemaUpdate()
+					.setHaltOnError( true )
+					.setOutputFile( output.getAbsolutePath() )
+					.setFormat( false )
+					.execute( EnumSet.of( TargetType.SCRIPT, TargetType.DATABASE ), metadata );
+
+			String fileContent = new String( Files.readAllBytes( output.toPath() ) );
+			assertThat( fileContent ).isEmpty();
+		}
+		finally {
+			StandardServiceRegistryBuilder.destroy( ssr );
+		}
+	}
+
+
+	@Entity(name = "en")
+	@Table(name = "en")
+	public static class TestEntity {
+		@Id
+		private Integer id;
+
+		private String text;
+
+		private BigDecimal decimal;
+	}
+}


### PR DESCRIPTION
<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

[Please describe here what your change is about]

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-18784
<!-- Hibernate GitHub Bot issue links end -->