### PR TITLE
HHH-18783 cast(x as Character) on MySQL and Maria

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/dialect/MySQLSqlAstTranslator.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/MySQLSqlAstTranslator.java
@@ -4,10 +4,6 @@
  */
 package org.hibernate.dialect;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Locale;
-
 import org.hibernate.engine.jdbc.Size;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.internal.util.collections.Stack;
@@ -40,6 +36,10 @@ import org.hibernate.sql.ast.tree.update.UpdateStatement;
 import org.hibernate.sql.exec.internal.JdbcOperationQueryInsertImpl;
 import org.hibernate.sql.exec.spi.JdbcOperation;
 import org.hibernate.sql.exec.spi.JdbcOperationQueryInsert;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
 
 /**
  * A SQL AST translator for MySQL.
@@ -81,9 +81,15 @@ public class MySQLSqlAstTranslator<T extends JdbcOperation> extends AbstractSqlA
 				case "varchar":
 				case "nchar":
 				case "nvarchar":
-					return castTarget.getLength() == null
-							? "char"
-							: ( "char(" + castTarget.getLength() + ")" );
+					if ( castTarget.getLength() == null ) {
+						if ( castTarget.getJdbcMapping().getJdbcJavaType().getJavaType() == Character.class ) {
+							return "char(1)";
+						}
+						else {
+							return "char";
+						}
+					}
+					return "char(" + castTarget.getLength() + ")";
 				case "binary":
 				case "varbinary":
 					return castTarget.getLength() == null

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/query/hql/FunctionTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/query/hql/FunctionTests.java
@@ -1131,7 +1131,6 @@ public class FunctionTests {
 
 	@Test
 	@SkipForDialect( dialectClass = AltibaseDialect.class, reason = "Altibase cast to char does not do truncatation")
-	@SkipForDialect( dialectClass = MySQLDialect.class, matchSubTypes = true, reason = "MySQL cast does not do truncatation")
 	public void testCastFunctionWithLength(SessionFactoryScope scope) {
 		scope.inTransaction(
 				session -> {


### PR DESCRIPTION
This is more testing that work in progress. If you like the idea, feel free to use it, but do not merge it.

[HHH-18783](https://hibernate.atlassian.net/browse/HHH-18783)


<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

          Method getSqlType for java.lang.Character without length should return "char(1)", not "char"

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------


[HHH-18783]: https://hibernate.atlassian.net/browse/HHH-18783?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ