### PR TITLE
HHH-18808 Fix the bug of wrong logging output when keyword is used as identifier in HqlParser.g4

### DIFF
--- a/hibernate-core/src/main/antlr/org/hibernate/grammars/hql/HqlParser.g4
+++ b/hibernate-core/src/main/antlr/org/hibernate/grammars/hql/HqlParser.g4
@@ -14,12 +14,6 @@ options {
 package org.hibernate.grammars.hql;
 }
 
-@members {
-	protected void logUseOfReservedWordAsIdentifier(Token token) {
-	}
-}
-
-
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 // Statements
 
@@ -1851,7 +1845,7 @@ xmltableDefaultClause
  nakedIdentifier
 	: IDENTIFIER
 	| QUOTED_IDENTIFIER
-	| (ABSENT
+	| ABSENT
 	| ALL
 	| AND
 	| ANY
@@ -2057,17 +2051,14 @@ xmltableDefaultClause
 	| XMLQUERY
 	| XMLTABLE
 	| YEAR
-	| ZONED) {
-		logUseOfReservedWordAsIdentifier( getCurrentToken() );
-	}
+	| ZONED
 	;
+
 identifier
 	: nakedIdentifier
-	| (FULL
+	| FULL
 	| INNER
 	| LEFT
 	| OUTER
-	| RIGHT) {
-		logUseOfReservedWordAsIdentifier( getCurrentToken() );
-	}
+	| RIGHT
 	;

--- a/hibernate-core/src/main/java/org/hibernate/query/hql/internal/HqlParseTreeBuilder.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/hql/internal/HqlParseTreeBuilder.java
@@ -4,15 +4,10 @@
  */
 package org.hibernate.query.hql.internal;
 
-import org.hibernate.grammars.hql.HqlLexer;
-import org.hibernate.grammars.hql.HqlParser;
-import org.hibernate.query.hql.HqlLogging;
-
-import org.jboss.logging.Logger;
-
 import org.antlr.v4.runtime.CharStreams;
 import org.antlr.v4.runtime.CommonTokenStream;
-import org.antlr.v4.runtime.Token;
+import org.hibernate.grammars.hql.HqlLexer;
+import org.hibernate.grammars.hql.HqlParser;
 
 /**
  * Leverages ANTLR to build a parse tree from an HQL query.
@@ -20,9 +15,6 @@ import org.antlr.v4.runtime.Token;
  * @author Steve Ebersole
  */
 public class HqlParseTreeBuilder {
-	private static final Logger LOGGER = HqlLogging.subLogger( "reservedWordAsIdentifier" );
-	private static final boolean DEBUG_ENABLED = LOGGER.isDebugEnabled();
-
 	/**
 	 * Singleton access
 	 */
@@ -34,13 +26,6 @@ public class HqlParseTreeBuilder {
 
 	public HqlParser buildHqlParser(String hql, HqlLexer hqlLexer) {
 		// Build the parser
-		return new HqlParser( new CommonTokenStream( hqlLexer ) ) {
-			@Override
-			protected void logUseOfReservedWordAsIdentifier(Token token) {
-				if ( DEBUG_ENABLED ) {
-					LOGGER.debugf( "Encountered use of reserved word as identifier : %s", token.getText() );
-				}
-			}
-		};
+		return new HqlParser( new CommonTokenStream( hqlLexer ) );
 	}
 }


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-18808

Not sure why not move the keyword list into HqlLexer.g4, which would simplify a lot and I think we could still overwrite HqlLexer class. But here is a quick and effective bug fix.