### PR TITLE
correct variable naming defects in SqmTranslatorFactory and StandardSqmTranslatorFactory

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/sql/SqmTranslatorFactory.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/sql/SqmTranslatorFactory.java
@@ -15,7 +15,8 @@ import org.hibernate.sql.ast.tree.MutationStatement;
 import org.hibernate.sql.ast.tree.select.SelectStatement;
 
 /**
- * Factory for various
+ * Factory for various {@link SqmTranslator}s
+ *
  * @author Steve Ebersole
  */
 public interface SqmTranslatorFactory {
@@ -29,7 +30,7 @@ public interface SqmTranslatorFactory {
 			boolean deduplicateSelectionItems);
 
 	SqmTranslator<? extends MutationStatement> createMutationTranslator(
-			SqmDmlStatement<?> sqmDeleteStatement,
+			SqmDmlStatement<?> sqmDmlStatement,
 			QueryOptions queryOptions,
 			DomainParameterXref domainParameterXref,
 			QueryParameterBindings domainParameterBindings,

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/sql/StandardSqmTranslatorFactory.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/sql/StandardSqmTranslatorFactory.java
@@ -44,14 +44,14 @@ public class StandardSqmTranslatorFactory implements SqmTranslatorFactory {
 
 	@Override
 	public SqmTranslator<? extends MutationStatement> createMutationTranslator(
-			SqmDmlStatement<?> sqmDeleteStatement,
+			SqmDmlStatement<?> sqmDmlStatement,
 			QueryOptions queryOptions,
 			DomainParameterXref domainParameterXref,
 			QueryParameterBindings domainParameterBindings,
 			LoadQueryInfluencers loadQueryInfluencers,
 			SqlAstCreationContext creationContext) {
 		return new StandardSqmTranslator<>(
-				sqmDeleteStatement,
+				sqmDmlStatement,
 				queryOptions,
 				domainParameterXref,
 				domainParameterBindings,


### PR DESCRIPTION
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------

confusing naming. seems obvious defect.