### PR TITLE
HHH-18610 "SQLGrammarException: Unable to find column position by name" when using Single Table Inheritance with a strict JDBC driver such as PostgreSQL

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/generator/values/GeneratedValueBasicResultBuilder.java
+++ b/hibernate-core/src/main/java/org/hibernate/generator/values/GeneratedValueBasicResultBuilder.java
@@ -16,6 +16,7 @@ import org.hibernate.sql.ast.spi.SqlSelection;
 import org.hibernate.sql.ast.tree.from.TableGroup;
 import org.hibernate.sql.ast.tree.from.TableReference;
 import org.hibernate.sql.results.graph.DomainResultCreationState;
+import org.hibernate.sql.results.graph.Fetchable;
 import org.hibernate.sql.results.graph.basic.BasicResult;
 import org.hibernate.sql.results.jdbc.spi.JdbcValuesMetadata;
 
@@ -60,7 +61,7 @@ public class GeneratedValueBasicResultBuilder implements ResultBuilder {
 	public BasicResult<?> buildResult(
 			JdbcValuesMetadata jdbcResultsMetadata,
 			int resultPosition,
-			BiFunction<String, String, DynamicFetchBuilderLegacy> legacyFetchResolver,
+			BiFunction<String, Fetchable, DynamicFetchBuilderLegacy> legacyFetchResolver,
 			DomainResultCreationState domainResultCreationState) {
 		final DomainResultCreationStateImpl creationStateImpl = impl( domainResultCreationState );
 

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/EntityIdentifierMapping.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/EntityIdentifierMapping.java
@@ -13,6 +13,7 @@ import org.hibernate.event.spi.MergeContext;
 import jakarta.persistence.EmbeddedId;
 import jakarta.persistence.Id;
 import jakarta.persistence.IdClass;
+import org.hibernate.sql.results.graph.Fetchable;
 
 
 /**
@@ -22,7 +23,7 @@ import jakarta.persistence.IdClass;
  * @see EmbeddedId
  * @see Nature
  */
-public interface EntityIdentifierMapping extends ValuedModelPart {
+public interface EntityIdentifierMapping extends ValuedModelPart, Fetchable {
 
 	String ID_ROLE_NAME = "{id}";
 	String LEGACY_ID_NAME = "id";

--- a/hibernate-core/src/main/java/org/hibernate/procedure/internal/EntityDomainResultBuilder.java
+++ b/hibernate-core/src/main/java/org/hibernate/procedure/internal/EntityDomainResultBuilder.java
@@ -16,6 +16,7 @@ import org.hibernate.query.results.complete.EntityResultImpl;
 import org.hibernate.query.results.dynamic.DynamicFetchBuilderLegacy;
 import org.hibernate.query.results.implicit.ImplicitFetchBuilderBasic;
 import org.hibernate.sql.results.graph.DomainResultCreationState;
+import org.hibernate.sql.results.graph.Fetchable;
 import org.hibernate.sql.results.graph.entity.EntityResult;
 import org.hibernate.sql.results.jdbc.spi.JdbcValuesMetadata;
 
@@ -57,7 +58,7 @@ public class EntityDomainResultBuilder implements ResultBuilder {
 	public EntityResult buildResult(
 			JdbcValuesMetadata jdbcResultsMetadata,
 			int resultPosition,
-			BiFunction<String, String, DynamicFetchBuilderLegacy> legacyFetchResolver,
+			BiFunction<String, Fetchable, DynamicFetchBuilderLegacy> legacyFetchResolver,
 			DomainResultCreationState domainResultCreationState) {
 
 		return new EntityResultImpl(

--- a/hibernate-core/src/main/java/org/hibernate/procedure/internal/ScalarDomainResultBuilder.java
+++ b/hibernate-core/src/main/java/org/hibernate/procedure/internal/ScalarDomainResultBuilder.java
@@ -14,6 +14,7 @@ import org.hibernate.sql.ast.spi.SqlExpressionResolver;
 import org.hibernate.sql.ast.spi.SqlSelection;
 import org.hibernate.sql.results.graph.DomainResult;
 import org.hibernate.sql.results.graph.DomainResultCreationState;
+import org.hibernate.sql.results.graph.Fetchable;
 import org.hibernate.sql.results.graph.basic.BasicResult;
 import org.hibernate.sql.results.jdbc.spi.JdbcValuesMetadata;
 import org.hibernate.type.BasicType;
@@ -38,7 +39,7 @@ public class ScalarDomainResultBuilder<T> implements ResultBuilder {
 	public DomainResult<T> buildResult(
 			JdbcValuesMetadata jdbcResultsMetadata,
 			int resultPosition,
-			BiFunction<String, String, DynamicFetchBuilderLegacy> legacyFetchResolver,
+			BiFunction<String, Fetchable, DynamicFetchBuilderLegacy> legacyFetchResolver,
 			DomainResultCreationState domainResultCreationState) {
 		final SqlExpressionResolver sqlExpressionResolver = domainResultCreationState.getSqlAstCreationState()
 				.getSqlExpressionResolver();

--- a/hibernate-core/src/main/java/org/hibernate/query/NativeQuery.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/NativeQuery.java
@@ -28,6 +28,7 @@ import org.hibernate.metamodel.mapping.EntityMappingType;
 import org.hibernate.metamodel.mapping.PluralAttributeMapping;
 import org.hibernate.metamodel.model.domain.BasicDomainType;
 import org.hibernate.spi.NavigablePath;
+import org.hibernate.sql.results.graph.Fetchable;
 import org.hibernate.transform.ResultTransformer;
 import org.hibernate.type.BasicTypeReference;
 
@@ -504,6 +505,8 @@ public interface NativeQuery<T> extends Query<T>, SynchronizeableQuery {
 		String getTableAlias();
 
 		String getOwnerAlias();
+
+		Fetchable getFetchable();
 
 		String getFetchableName();
 

--- a/hibernate-core/src/main/java/org/hibernate/query/internal/FetchMementoHbmStandard.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/internal/FetchMementoHbmStandard.java
@@ -30,6 +30,7 @@ import org.hibernate.sql.results.graph.FetchableContainer;
 public class FetchMementoHbmStandard implements FetchMemento, FetchMemento.Parent {
 
 	private static final String ELEMENT_PREFIX = "element.";
+	private static final int ELEMENT_PREFIX_LENGTH = 8;
 
 	public interface FetchParentMemento {
 		NavigablePath getNavigablePath();
@@ -74,55 +75,110 @@ public class FetchMementoHbmStandard implements FetchMemento, FetchMemento.Paren
 			Parent parent,
 			Consumer<String> querySpaceConsumer,
 			ResultSetMappingResolutionContext context) {
-		final Map<String, FetchBuilder> fetchBuilderMap = new HashMap<>();
-		fetchMementoMap.forEach(
-				(attrName, fetchMemento) -> fetchBuilderMap.put(
-						attrName,
-						fetchMemento.resolve(this, querySpaceConsumer, context )
-				)
-		);
-		final DynamicResultBuilderEntityStandard resultBuilder;
-		if ( fetchable instanceof PluralAttributeMapping ) {
-			resultBuilder = new DynamicResultBuilderEntityStandard(
-					(EntityMappingType) ( (PluralAttributeMapping) fetchable ).getElementDescriptor().getPartMappingType(),
-					tableAlias,
-					navigablePath
-			);
-			FetchBuilder element = fetchBuilderMap.get( "element" );
-			if ( element != null ) {
-				if ( element instanceof DynamicFetchBuilder ) {
-					resultBuilder.addIdColumnAliases(
-							( (DynamicFetchBuilder) element ).getColumnAliases().toArray( new String[0] )
-					);
-				}
-				else {
-					resultBuilder.addIdColumnAliases(
-							( (CompleteFetchBuilderEntityValuedModelPart) element ).getColumnAliases().toArray( new String[0] )
-					);
-				}
-			}
-			FetchBuilder index = fetchBuilderMap.get( "index" );
-			if ( index != null ) {
-				resultBuilder.addFetchBuilder( CollectionPart.Nature.INDEX.getName(), index );
-			}
-			for ( Map.Entry<String, FetchBuilder> entry : fetchBuilderMap.entrySet() ) {
-				if ( entry.getKey().startsWith( ELEMENT_PREFIX ) ) {
-					resultBuilder.addFetchBuilder( entry.getKey().substring( ELEMENT_PREFIX.length() ), entry.getValue() );
-				}
-			}
+		if ( fetchable instanceof PluralAttributeMapping pluralAttributeMapping ) {
+			return resolve( pluralAttributeMapping, querySpaceConsumer, context );
 		}
 		else {
-			resultBuilder = new DynamicResultBuilderEntityStandard(
-					( (ToOneAttributeMapping) fetchable ).getEntityMappingType(),
-					tableAlias,
-					navigablePath
-			);
-			fetchBuilderMap.forEach( resultBuilder::addFetchBuilder );
+			return resolve( (ToOneAttributeMapping) fetchable, querySpaceConsumer, context );
 		}
+	}
+
+	private FetchBuilder resolve(
+			PluralAttributeMapping pluralAttributeMapping,
+			Consumer<String> querySpaceConsumer,
+			ResultSetMappingResolutionContext context) {
+		final DynamicResultBuilderEntityStandard resultBuilder;
+		EntityMappingType partMappingType = (EntityMappingType) pluralAttributeMapping.getElementDescriptor()
+				.getPartMappingType();
+		resultBuilder = new DynamicResultBuilderEntityStandard(
+				partMappingType,
+				tableAlias,
+				navigablePath
+		);
+		final Map<Fetchable, FetchBuilder> fetchBuilderMap = new HashMap<>();
+		fetchMementoMap.forEach(
+				(attrName, fetchMemento) -> {
+					final FetchBuilder fetchBuilder = fetchMemento.resolve( this, querySpaceConsumer, context );
+
+					if ( attrName.equals( "element" ) ) {
+						if ( fetchBuilder instanceof DynamicFetchBuilder dynamicFetchBuilder ) {
+							resultBuilder.addIdColumnAliases(
+									dynamicFetchBuilder.getColumnAliases().toArray( new String[0] )
+							);
+						}
+						else {
+							resultBuilder.addIdColumnAliases(
+									((CompleteFetchBuilderEntityValuedModelPart) fetchBuilder).getColumnAliases()
+											.toArray( new String[0] )
+							);
+						}
+						fetchBuilderMap.put(
+								pluralAttributeMapping.getElementDescriptor(),
+								fetchBuilder
+						);
+					}
+					else if ( attrName.equals( "index" ) ) {
+						final CollectionPart indexDescriptor = pluralAttributeMapping.getIndexDescriptor();
+						resultBuilder.addFetchBuilder( indexDescriptor, fetchBuilder );
+						fetchBuilderMap.put(
+								indexDescriptor,
+								fetchBuilder
+						);
+					}
+					else if ( attrName.startsWith( ELEMENT_PREFIX ) ) {
+						final Fetchable attributeMapping = (Fetchable) partMappingType.findByPath(
+								attrName.substring( ELEMENT_PREFIX_LENGTH ) );
+						resultBuilder.addFetchBuilder( attributeMapping, fetchBuilder );
+						fetchBuilderMap.put(
+								attributeMapping,
+								fetchBuilder
+						);
+					}
+					else {
+						final Fetchable attributeMapping = (Fetchable) partMappingType.findByPath( attrName );
+						resultBuilder.addFetchBuilder( attributeMapping, fetchBuilder );
+						fetchBuilderMap.put(
+								attributeMapping,
+								fetchBuilder
+						);
+					}
+				}
+		);
 		return new DynamicFetchBuilderLegacy(
 				tableAlias,
 				ownerTableAlias,
-				fetchable.getFetchableName(),
+				fetchable,
+				keyColumnNames,
+				fetchBuilderMap,
+				resultBuilder
+		);
+	}
+
+	private FetchBuilder resolve(
+			ToOneAttributeMapping toOneAttributeMapping,
+			Consumer<String> querySpaceConsumer,
+			ResultSetMappingResolutionContext context) {
+		final Map<Fetchable, FetchBuilder> fetchBuilderMap = new HashMap<>();
+		fetchMementoMap.forEach(
+				(attrName, fetchMemento) ->
+						fetchBuilderMap.put(
+								(Fetchable) toOneAttributeMapping.findSubPart( attrName ),
+								fetchMemento.resolve( this, querySpaceConsumer, context )
+						)
+		);
+		final DynamicResultBuilderEntityStandard resultBuilder;
+		resultBuilder = new DynamicResultBuilderEntityStandard(
+				toOneAttributeMapping.getEntityMappingType(),
+				tableAlias,
+				navigablePath
+		);
+		fetchBuilderMap.forEach( (fetchable, fetchBuilder) ->
+				resultBuilder.addFetchBuilder( fetchable, fetchBuilder )
+		);
+		return new DynamicFetchBuilderLegacy(
+				tableAlias,
+				ownerTableAlias,
+				fetchable,
 				keyColumnNames,
 				fetchBuilderMap,
 				resultBuilder

--- a/hibernate-core/src/main/java/org/hibernate/query/internal/ResultMementoEntityJpa.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/internal/ResultMementoEntityJpa.java
@@ -23,6 +23,7 @@ import org.hibernate.query.results.complete.CompleteResultBuilderEntityJpa;
 import org.hibernate.query.results.complete.DelayedFetchBuilderBasicPart;
 import org.hibernate.query.results.implicit.ImplicitFetchBuilderBasic;
 import org.hibernate.spi.NavigablePath;
+import org.hibernate.sql.results.graph.Fetchable;
 
 /**
  * @author Steve Ebersole
@@ -70,13 +71,13 @@ public class ResultMementoEntityJpa implements ResultMementoEntity, FetchMemento
 			}
 		}
 
-		final HashMap<String, FetchBuilder> explicitFetchBuilderMap = new HashMap<>();
+		final HashMap<Fetchable, FetchBuilder> explicitFetchBuilderMap = new HashMap<>();
 
 		// If there are no explicit fetches, we don't register DELAYED builders to get implicit fetching of all basic fetchables
 		if ( !explicitFetchMementoMap.isEmpty() ) {
 			explicitFetchMementoMap.forEach(
 					(relativePath, fetchMemento) -> explicitFetchBuilderMap.put(
-							relativePath,
+							(Fetchable) entityDescriptor.findByPath( relativePath ),
 							fetchMemento.resolve( this, querySpaceConsumer, context )
 					)
 			);
@@ -87,13 +88,13 @@ public class ResultMementoEntityJpa implements ResultMementoEntity, FetchMemento
 					attributeMapping -> {
 						final BasicValuedModelPart basicPart = attributeMapping.asBasicValuedModelPart();
 						if ( basicPart != null ) {
-							final Function<String, FetchBuilder> fetchBuilderCreator = k -> new DelayedFetchBuilderBasicPart(
-									navigablePath.append( k ),
+							final Function<Fetchable, FetchBuilder> fetchBuilderCreator = k -> new DelayedFetchBuilderBasicPart(
+									navigablePath.append( k.getFetchableName() ),
 									basicPart,
 									isEnhancedForLazyLoading
 							);
 							explicitFetchBuilderMap.computeIfAbsent(
-									attributeMapping.getFetchableName(),
+									attributeMapping,
 									fetchBuilderCreator
 							);
 						}

--- a/hibernate-core/src/main/java/org/hibernate/query/internal/ResultMementoEntityStandard.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/internal/ResultMementoEntityStandard.java
@@ -19,6 +19,7 @@ import org.hibernate.query.results.BasicValuedFetchBuilder;
 import org.hibernate.query.results.FetchBuilder;
 import org.hibernate.query.results.ResultBuilderEntityValued;
 import org.hibernate.query.results.complete.CompleteResultBuilderEntityStandard;
+import org.hibernate.sql.results.graph.Fetchable;
 
 /**
  * @author Steve Ebersole
@@ -64,11 +65,11 @@ public class ResultMementoEntityStandard implements ResultMementoEntity, FetchMe
 				? (BasicValuedFetchBuilder) discriminatorMemento.resolve( this, querySpaceConsumer, context )
 				: null;
 
-		final HashMap<String, FetchBuilder> fetchBuilderMap = new HashMap<>();
+		final HashMap<Fetchable, FetchBuilder> fetchBuilderMap = new HashMap<>();
 
 		fetchMementoMap.forEach(
 				(attrName, fetchMemento) -> fetchBuilderMap.put(
-						attrName,
+						(Fetchable) entityDescriptor.findByPath( attrName ),
 						fetchMemento.resolve(this, querySpaceConsumer, context )
 				)
 		);

--- a/hibernate-core/src/main/java/org/hibernate/query/results/BasicValuedFetchBuilder.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/results/BasicValuedFetchBuilder.java
@@ -10,6 +10,7 @@ import org.hibernate.spi.NavigablePath;
 import org.hibernate.query.results.dynamic.DynamicFetchBuilderLegacy;
 import org.hibernate.sql.results.graph.DomainResultCreationState;
 import org.hibernate.sql.results.graph.FetchParent;
+import org.hibernate.sql.results.graph.Fetchable;
 import org.hibernate.sql.results.graph.basic.BasicFetch;
 import org.hibernate.sql.results.jdbc.spi.JdbcValuesMetadata;
 
@@ -22,6 +23,6 @@ public interface BasicValuedFetchBuilder extends FetchBuilder {
 			FetchParent parent,
 			NavigablePath fetchPath,
 			JdbcValuesMetadata jdbcResultsMetadata,
-			BiFunction<String, String, DynamicFetchBuilderLegacy> legacyFetchResolver,
+			BiFunction<String, Fetchable, DynamicFetchBuilderLegacy> legacyFetchResolver,
 			DomainResultCreationState domainResultCreationState);
 }

--- a/hibernate-core/src/main/java/org/hibernate/query/results/Builders.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/results/Builders.java
@@ -235,8 +235,8 @@ public class Builders {
 		return new DynamicResultBuilderEntityCalculated( entityMapping, tableAlias, explicitLockMode );
 	}
 
-	public static DynamicFetchBuilderLegacy fetch(String tableAlias, String ownerTableAlias, String joinPropertyName) {
-		return new DynamicFetchBuilderLegacy( tableAlias, ownerTableAlias, joinPropertyName, new ArrayList<>(), new HashMap<>() );
+	public static DynamicFetchBuilderLegacy fetch(String tableAlias, String ownerTableAlias, Fetchable fetchable) {
+		return new DynamicFetchBuilderLegacy( tableAlias, ownerTableAlias, fetchable, new ArrayList<>(), new HashMap<>() );
 	}
 
 	public static ResultBuilder resultClassBuilder(
@@ -269,7 +269,7 @@ public class Builders {
 			DomainResultCreationState creationState) {
 		final BasicValuedModelPart basicValuedFetchable = fetchable.asBasicValuedModelPart();
 		if ( basicValuedFetchable != null ) {
-			return new ImplicitFetchBuilderBasic( fetchPath, basicValuedFetchable, creationState );
+			return new ImplicitFetchBuilderBasic( fetchPath, fetchable, basicValuedFetchable, creationState );
 		}
 
 		if ( fetchable instanceof EmbeddableValuedFetchable ) {

--- a/hibernate-core/src/main/java/org/hibernate/query/results/FetchBuilder.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/results/FetchBuilder.java
@@ -14,6 +14,7 @@ import org.hibernate.sql.results.graph.DomainResult;
 import org.hibernate.sql.results.graph.DomainResultCreationState;
 import org.hibernate.sql.results.graph.Fetch;
 import org.hibernate.sql.results.graph.FetchParent;
+import org.hibernate.sql.results.graph.Fetchable;
 import org.hibernate.sql.results.jdbc.spi.JdbcValuesMetadata;
 
 /**
@@ -29,10 +30,10 @@ public interface FetchBuilder {
 			FetchParent parent,
 			NavigablePath fetchPath,
 			JdbcValuesMetadata jdbcResultsMetadata,
-			BiFunction<String, String, DynamicFetchBuilderLegacy> legacyFetchResolver,
+			BiFunction<String, Fetchable, DynamicFetchBuilderLegacy> legacyFetchResolver,
 			DomainResultCreationState domainResultCreationState);
 
-	default void visitFetchBuilders(BiConsumer<String, FetchBuilder> consumer) {
+	default void visitFetchBuilders(BiConsumer<Fetchable, FetchBuilder> consumer) {
 	}
 
 	FetchBuilder cacheKeyInstance();

--- a/hibernate-core/src/main/java/org/hibernate/query/results/ImplicitAttributeFetchBuilder.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/results/ImplicitAttributeFetchBuilder.java
@@ -14,6 +14,7 @@ import org.hibernate.query.results.implicit.ImplicitFetchBuilder;
 import org.hibernate.sql.results.graph.DomainResultCreationState;
 import org.hibernate.sql.results.graph.Fetch;
 import org.hibernate.sql.results.graph.FetchParent;
+import org.hibernate.sql.results.graph.Fetchable;
 import org.hibernate.sql.results.jdbc.spi.JdbcValuesMetadata;
 
 /**
@@ -40,7 +41,7 @@ public class ImplicitAttributeFetchBuilder implements FetchBuilder, ImplicitFetc
 			FetchParent parent,
 			NavigablePath fetchPath,
 			JdbcValuesMetadata jdbcResultsMetadata,
-			BiFunction<String, String, DynamicFetchBuilderLegacy> legacyFetchResolver,
+			BiFunction<String, Fetchable, DynamicFetchBuilderLegacy> legacyFetchResolver,
 			DomainResultCreationState domainResultCreationState) {
 		assert fetchPath.equals( navigablePath );
 

--- a/hibernate-core/src/main/java/org/hibernate/query/results/ResultBuilder.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/results/ResultBuilder.java
@@ -11,6 +11,7 @@ import org.hibernate.Incubating;
 import org.hibernate.query.results.dynamic.DynamicFetchBuilderLegacy;
 import org.hibernate.sql.results.graph.DomainResult;
 import org.hibernate.sql.results.graph.DomainResultCreationState;
+import org.hibernate.sql.results.graph.Fetchable;
 import org.hibernate.sql.results.jdbc.spi.JdbcValuesMetadata;
 
 /**
@@ -24,13 +25,13 @@ public interface ResultBuilder {
 	DomainResult<?> buildResult(
 			JdbcValuesMetadata jdbcResultsMetadata,
 			int resultPosition,
-			BiFunction<String, String, DynamicFetchBuilderLegacy> legacyFetchResolver,
+			BiFunction<String, Fetchable, DynamicFetchBuilderLegacy> legacyFetchResolver,
 			DomainResultCreationState domainResultCreationState);
 
 	Class<?> getJavaType();
 
 	ResultBuilder cacheKeyInstance();
 
-	default void visitFetchBuilders(BiConsumer<String, FetchBuilder> consumer) {
+	default void visitFetchBuilders(BiConsumer<Fetchable, FetchBuilder> consumer) {
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/query/results/ResultBuilderBasicValued.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/results/ResultBuilderBasicValued.java
@@ -8,6 +8,7 @@ import java.util.function.BiFunction;
 
 import org.hibernate.query.results.dynamic.DynamicFetchBuilderLegacy;
 import org.hibernate.sql.results.graph.DomainResultCreationState;
+import org.hibernate.sql.results.graph.Fetchable;
 import org.hibernate.sql.results.graph.basic.BasicResult;
 import org.hibernate.sql.results.jdbc.spi.JdbcValuesMetadata;
 
@@ -21,6 +22,6 @@ public interface ResultBuilderBasicValued extends ResultBuilder {
 	BasicResult<?> buildResult(
 			JdbcValuesMetadata jdbcResultsMetadata,
 			int resultPosition,
-			BiFunction<String, String, DynamicFetchBuilderLegacy> legacyFetchResolver,
+			BiFunction<String, Fetchable, DynamicFetchBuilderLegacy> legacyFetchResolver,
 			DomainResultCreationState domainResultCreationState);
 }

--- a/hibernate-core/src/main/java/org/hibernate/query/results/ResultBuilderEmbeddable.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/results/ResultBuilderEmbeddable.java
@@ -8,6 +8,7 @@ import java.util.function.BiFunction;
 
 import org.hibernate.query.results.dynamic.DynamicFetchBuilderLegacy;
 import org.hibernate.sql.results.graph.DomainResultCreationState;
+import org.hibernate.sql.results.graph.Fetchable;
 import org.hibernate.sql.results.graph.embeddable.EmbeddableResult;
 import org.hibernate.sql.results.jdbc.spi.JdbcValuesMetadata;
 
@@ -19,6 +20,6 @@ public interface ResultBuilderEmbeddable extends ResultBuilder {
 	EmbeddableResult buildResult(
 			JdbcValuesMetadata jdbcResultsMetadata,
 			int resultPosition,
-			BiFunction<String, String, DynamicFetchBuilderLegacy> legacyFetchResolver,
+			BiFunction<String, Fetchable, DynamicFetchBuilderLegacy> legacyFetchResolver,
 			DomainResultCreationState domainResultCreationState);
 }

--- a/hibernate-core/src/main/java/org/hibernate/query/results/ResultBuilderEntityValued.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/results/ResultBuilderEntityValued.java
@@ -8,6 +8,7 @@ import java.util.function.BiFunction;
 
 import org.hibernate.query.results.dynamic.DynamicFetchBuilderLegacy;
 import org.hibernate.sql.results.graph.DomainResultCreationState;
+import org.hibernate.sql.results.graph.Fetchable;
 import org.hibernate.sql.results.graph.entity.EntityResult;
 import org.hibernate.sql.results.jdbc.spi.JdbcValuesMetadata;
 
@@ -21,6 +22,6 @@ public interface ResultBuilderEntityValued extends ResultBuilder {
 	EntityResult buildResult(
 			JdbcValuesMetadata jdbcResultsMetadata,
 			int resultPosition,
-			BiFunction<String, String, DynamicFetchBuilderLegacy> legacyFetchResolver,
+			BiFunction<String, Fetchable, DynamicFetchBuilderLegacy> legacyFetchResolver,
 			DomainResultCreationState domainResultCreationState);
 }

--- a/hibernate-core/src/main/java/org/hibernate/query/results/ResultSetMappingImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/results/ResultSetMappingImpl.java
@@ -27,6 +27,7 @@ import org.hibernate.query.named.NamedResultSetMappingMemento;
 import org.hibernate.query.results.dynamic.DynamicFetchBuilderLegacy;
 import org.hibernate.sql.ast.spi.SqlSelection;
 import org.hibernate.sql.results.graph.DomainResult;
+import org.hibernate.sql.results.graph.Fetchable;
 import org.hibernate.sql.results.graph.basic.BasicResult;
 import org.hibernate.sql.results.graph.entity.EntityResult;
 import org.hibernate.sql.results.jdbc.spi.JdbcValuesMapping;
@@ -43,7 +44,7 @@ public class ResultSetMappingImpl implements ResultSetMapping {
 	private final String mappingIdentifier;
 	private final boolean isDynamic;
 	private List<ResultBuilder> resultBuilders;
-	private Map<String, Map<String, DynamicFetchBuilderLegacy>> legacyFetchBuilders;
+	private Map<String, Map<Fetchable, DynamicFetchBuilderLegacy>> legacyFetchBuilders;
 
 	public ResultSetMappingImpl(String mappingIdentifier) {
 		this( mappingIdentifier, false );
@@ -71,15 +72,15 @@ public class ResultSetMappingImpl implements ResultSetMapping {
 			this.legacyFetchBuilders = null;
 		}
 		else {
-			final Map<String, Map<String, DynamicFetchBuilderLegacy>> legacyFetchBuilders = new HashMap<>( original.legacyFetchBuilders.size() );
-			for ( Map.Entry<String, Map<String, DynamicFetchBuilderLegacy>> entry : original.legacyFetchBuilders.entrySet() ) {
-				final Map<String, DynamicFetchBuilderLegacy> newValue = new HashMap<>( entry.getValue().size() );
-				for ( Map.Entry<String, DynamicFetchBuilderLegacy> builderEntry : entry.getValue().entrySet() ) {
+			final Map<String, Map<Fetchable, DynamicFetchBuilderLegacy>> builders = new HashMap<>( original.legacyFetchBuilders.size() );
+			for ( Map.Entry<String, Map<Fetchable, DynamicFetchBuilderLegacy>> entry : original.legacyFetchBuilders.entrySet() ) {
+				final Map<Fetchable, DynamicFetchBuilderLegacy> newValue = new HashMap<>( entry.getValue().size() );
+				for ( Map.Entry<Fetchable, DynamicFetchBuilderLegacy> builderEntry : entry.getValue().entrySet() ) {
 					newValue.put( builderEntry.getKey(), builderEntry.getValue().cacheKeyInstance() );
 				}
-				legacyFetchBuilders.put( entry.getKey(), newValue );
+				builders.put( entry.getKey(), newValue );
 			}
-			this.legacyFetchBuilders = legacyFetchBuilders;
+			this.legacyFetchBuilders = builders;
 		}
 	}
 
@@ -122,7 +123,7 @@ public class ResultSetMappingImpl implements ResultSetMapping {
 			return;
 		}
 
-		for ( Map.Entry<String, Map<String, DynamicFetchBuilderLegacy>> entry : legacyFetchBuilders.entrySet() ) {
+		for ( Map.Entry<String, Map<Fetchable, DynamicFetchBuilderLegacy>> entry : legacyFetchBuilders.entrySet() ) {
 			for ( DynamicFetchBuilderLegacy fetchBuilder : entry.getValue().values() ) {
 				resultBuilderConsumer.accept( fetchBuilder );
 			}
@@ -139,7 +140,7 @@ public class ResultSetMappingImpl implements ResultSetMapping {
 
 	@Override
 	public void addLegacyFetchBuilder(DynamicFetchBuilderLegacy fetchBuilder) {
-		final Map<String, DynamicFetchBuilderLegacy> existingFetchBuildersByOwner;
+		final Map<Fetchable, DynamicFetchBuilderLegacy> existingFetchBuildersByOwner;
 
 		if ( legacyFetchBuilders == null ) {
 			legacyFetchBuilders = new HashMap<>();
@@ -149,7 +150,7 @@ public class ResultSetMappingImpl implements ResultSetMapping {
 			existingFetchBuildersByOwner = legacyFetchBuilders.get( fetchBuilder.getOwnerAlias() );
 		}
 
-		final Map<String, DynamicFetchBuilderLegacy> fetchBuildersByOwner;
+		final Map<Fetchable, DynamicFetchBuilderLegacy> fetchBuildersByOwner;
 		if ( existingFetchBuildersByOwner == null ) {
 			fetchBuildersByOwner = new HashMap<>();
 			legacyFetchBuilders.put( fetchBuilder.getOwnerAlias(), fetchBuildersByOwner );
@@ -158,7 +159,7 @@ public class ResultSetMappingImpl implements ResultSetMapping {
 			fetchBuildersByOwner = existingFetchBuildersByOwner;
 		}
 
-		final DynamicFetchBuilderLegacy previousBuilder = fetchBuildersByOwner.put( fetchBuilder.getFetchableName(), fetchBuilder );
+		final DynamicFetchBuilderLegacy previousBuilder = fetchBuildersByOwner.put( fetchBuilder.getFetchable(), fetchBuilder );
 		if ( previousBuilder != null ) {
 			// todo (6.0) : error?  log?  nothing?
 		}

--- a/hibernate-core/src/main/java/org/hibernate/query/results/ResultsHelper.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/results/ResultsHelper.java
@@ -4,6 +4,7 @@
  */
 package org.hibernate.query.results;
 
+import org.hibernate.metamodel.mapping.EntityDiscriminatorMapping;
 import org.hibernate.metamodel.mapping.EntityIdentifierMapping;
 import org.hibernate.metamodel.mapping.ModelPart;
 import org.hibernate.metamodel.mapping.SelectableMapping;
@@ -19,6 +20,7 @@ import org.hibernate.sql.results.graph.basic.BasicFetch;
 import org.hibernate.sql.results.jdbc.spi.JdbcValuesMetadata;
 
 import static org.hibernate.sql.ast.spi.SqlExpressionResolver.createColumnReferenceKey;
+import static org.hibernate.sql.ast.spi.SqlExpressionResolver.createDiscriminatorColumnReferenceKey;
 
 /**
  * @author Steve Ebersole
@@ -61,6 +63,25 @@ public class ResultsHelper {
 					final int jdbcPosition = jdbcValuesMetadata.resolveColumnPosition( columnAlias );
 					final int valuesArrayPosition = jdbcPositionToValuesArrayPosition( jdbcPosition );
 					return new ResultSetMappingSqlSelection( valuesArrayPosition, selectableMapping.getJdbcMapping() );
+				}
+		);
+	}
+
+	public static Expression resolveSqlExpression(
+			DomainResultCreationStateImpl resolver,
+			JdbcValuesMetadata jdbcValuesMetadata,
+			TableReference tableReference,
+			EntityDiscriminatorMapping discriminatorMapping,
+			String columnAlias) {
+		return resolver.resolveSqlExpression(
+				createDiscriminatorColumnReferenceKey(
+						tableReference,
+						discriminatorMapping
+				),
+				processingState -> {
+					final int jdbcPosition = jdbcValuesMetadata.resolveColumnPosition( columnAlias );
+					final int valuesArrayPosition = jdbcPositionToValuesArrayPosition( jdbcPosition );
+					return new ResultSetMappingSqlSelection( valuesArrayPosition, discriminatorMapping.getJdbcMapping() );
 				}
 		);
 	}

--- a/hibernate-core/src/main/java/org/hibernate/query/results/complete/CompleteFetchBuilderBasicPart.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/results/complete/CompleteFetchBuilderBasicPart.java
@@ -25,6 +25,7 @@ import org.hibernate.sql.ast.tree.from.TableGroup;
 import org.hibernate.sql.ast.tree.from.TableReference;
 import org.hibernate.sql.results.graph.DomainResultCreationState;
 import org.hibernate.sql.results.graph.FetchParent;
+import org.hibernate.sql.results.graph.Fetchable;
 import org.hibernate.sql.results.graph.basic.BasicFetch;
 import org.hibernate.sql.results.jdbc.spi.JdbcValuesMetadata;
 
@@ -74,7 +75,7 @@ public class CompleteFetchBuilderBasicPart implements CompleteFetchBuilder, Basi
 			FetchParent parent,
 			NavigablePath fetchPath,
 			JdbcValuesMetadata jdbcResultsMetadata,
-			BiFunction<String, String, DynamicFetchBuilderLegacy> legacyFetchResolver,
+			BiFunction<String, Fetchable, DynamicFetchBuilderLegacy> legacyFetchResolver,
 			DomainResultCreationState domainResultCreationState) {
 		final DomainResultCreationStateImpl creationStateImpl = impl( domainResultCreationState );
 

--- a/hibernate-core/src/main/java/org/hibernate/query/results/complete/CompleteFetchBuilderEmbeddableValuedModelPart.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/results/complete/CompleteFetchBuilderEmbeddableValuedModelPart.java
@@ -19,6 +19,7 @@ import org.hibernate.sql.ast.tree.from.TableReference;
 import org.hibernate.sql.results.graph.DomainResultCreationState;
 import org.hibernate.sql.results.graph.Fetch;
 import org.hibernate.sql.results.graph.FetchParent;
+import org.hibernate.sql.results.graph.Fetchable;
 import org.hibernate.sql.results.jdbc.spi.JdbcValuesMetadata;
 
 import static org.hibernate.query.results.ResultsHelper.impl;
@@ -72,7 +73,7 @@ public class CompleteFetchBuilderEmbeddableValuedModelPart
 			FetchParent parent,
 			NavigablePath fetchPath,
 			JdbcValuesMetadata jdbcResultsMetadata,
-			BiFunction<String, String, DynamicFetchBuilderLegacy> legacyFetchResolver,
+			BiFunction<String, Fetchable, DynamicFetchBuilderLegacy> legacyFetchResolver,
 			DomainResultCreationState domainResultCreationState) {
 		assert fetchPath.equals( navigablePath );
 		final DomainResultCreationStateImpl creationStateImpl = impl( domainResultCreationState );

--- a/hibernate-core/src/main/java/org/hibernate/query/results/complete/CompleteFetchBuilderEntityValuedModelPart.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/results/complete/CompleteFetchBuilderEntityValuedModelPart.java
@@ -19,6 +19,7 @@ import org.hibernate.sql.ast.tree.from.TableReference;
 import org.hibernate.sql.results.graph.DomainResultCreationState;
 import org.hibernate.sql.results.graph.Fetch;
 import org.hibernate.sql.results.graph.FetchParent;
+import org.hibernate.sql.results.graph.Fetchable;
 import org.hibernate.sql.results.graph.entity.EntityValuedFetchable;
 import org.hibernate.sql.results.jdbc.spi.JdbcValuesMetadata;
 
@@ -73,7 +74,7 @@ public class CompleteFetchBuilderEntityValuedModelPart
 			FetchParent parent,
 			NavigablePath fetchPath,
 			JdbcValuesMetadata jdbcResultsMetadata,
-			BiFunction<String, String, DynamicFetchBuilderLegacy> legacyFetchResolver,
+			BiFunction<String, Fetchable, DynamicFetchBuilderLegacy> legacyFetchResolver,
 			DomainResultCreationState domainResultCreationState) {
 		assert fetchPath.equals( navigablePath );
 		final DomainResultCreationStateImpl creationStateImpl = impl( domainResultCreationState );

--- a/hibernate-core/src/main/java/org/hibernate/query/results/complete/CompleteResultBuilderBasicModelPart.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/results/complete/CompleteResultBuilderBasicModelPart.java
@@ -16,6 +16,7 @@ import org.hibernate.sql.ast.spi.SqlSelection;
 import org.hibernate.sql.ast.tree.from.TableGroup;
 import org.hibernate.sql.ast.tree.from.TableReference;
 import org.hibernate.sql.results.graph.DomainResultCreationState;
+import org.hibernate.sql.results.graph.Fetchable;
 import org.hibernate.sql.results.graph.basic.BasicResult;
 import org.hibernate.sql.results.jdbc.spi.JdbcValuesMetadata;
 
@@ -65,7 +66,7 @@ public class CompleteResultBuilderBasicModelPart
 	public BasicResult<?> buildResult(
 			JdbcValuesMetadata jdbcResultsMetadata,
 			int resultPosition,
-			BiFunction<String, String, DynamicFetchBuilderLegacy> legacyFetchResolver,
+			BiFunction<String, Fetchable, DynamicFetchBuilderLegacy> legacyFetchResolver,
 			DomainResultCreationState domainResultCreationState) {
 		final DomainResultCreationStateImpl creationStateImpl = impl( domainResultCreationState );
 

--- a/hibernate-core/src/main/java/org/hibernate/query/results/complete/CompleteResultBuilderBasicValuedConverted.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/results/complete/CompleteResultBuilderBasicValuedConverted.java
@@ -9,6 +9,7 @@ import java.util.function.BiFunction;
 
 import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.metamodel.mapping.BasicValuedMapping;
+import org.hibernate.sql.results.graph.Fetchable;
 import org.hibernate.type.descriptor.converter.internal.JpaAttributeConverterImpl;
 import org.hibernate.query.results.DomainResultCreationStateImpl;
 import org.hibernate.query.results.ResultBuilder;
@@ -71,7 +72,7 @@ public class CompleteResultBuilderBasicValuedConverted<O,R> implements CompleteR
 	public BasicResult<?> buildResult(
 			JdbcValuesMetadata jdbcResultsMetadata,
 			int resultPosition,
-			BiFunction<String, String, DynamicFetchBuilderLegacy> legacyFetchResolver,
+			BiFunction<String, Fetchable, DynamicFetchBuilderLegacy> legacyFetchResolver,
 			DomainResultCreationState domainResultCreationState) {
 		final DomainResultCreationStateImpl creationStateImpl = impl( domainResultCreationState );
 		final SessionFactoryImplementor sessionFactory = creationStateImpl.getSessionFactory();

--- a/hibernate-core/src/main/java/org/hibernate/query/results/complete/CompleteResultBuilderBasicValuedStandard.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/results/complete/CompleteResultBuilderBasicValuedStandard.java
@@ -18,6 +18,7 @@ import org.hibernate.query.results.dynamic.DynamicFetchBuilderLegacy;
 import org.hibernate.sql.ast.spi.SqlExpressionResolver;
 import org.hibernate.sql.ast.spi.SqlSelection;
 import org.hibernate.sql.results.graph.DomainResultCreationState;
+import org.hibernate.sql.results.graph.Fetchable;
 import org.hibernate.sql.results.graph.basic.BasicResult;
 import org.hibernate.sql.results.jdbc.spi.JdbcValuesMetadata;
 import org.hibernate.type.descriptor.java.JavaType;
@@ -67,7 +68,7 @@ public class CompleteResultBuilderBasicValuedStandard implements CompleteResultB
 	public BasicResult<?> buildResult(
 			JdbcValuesMetadata jdbcResultsMetadata,
 			int resultPosition,
-			BiFunction<String, String, DynamicFetchBuilderLegacy> legacyFetchResolver,
+			BiFunction<String, Fetchable, DynamicFetchBuilderLegacy> legacyFetchResolver,
 			DomainResultCreationState domainResultCreationState) {
 		final DomainResultCreationStateImpl creationStateImpl = impl( domainResultCreationState );
 		final SessionFactoryImplementor sessionFactory = creationStateImpl.getSessionFactory();

--- a/hibernate-core/src/main/java/org/hibernate/query/results/complete/CompleteResultBuilderCollectionStandard.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/results/complete/CompleteResultBuilderCollectionStandard.java
@@ -24,6 +24,7 @@ import org.hibernate.sql.ast.spi.SqlAliasBaseConstant;
 import org.hibernate.sql.ast.tree.from.TableGroup;
 import org.hibernate.sql.results.graph.DomainResult;
 import org.hibernate.sql.results.graph.DomainResultCreationState;
+import org.hibernate.sql.results.graph.Fetchable;
 import org.hibernate.sql.results.jdbc.spi.JdbcValuesMetadata;
 
 import static org.hibernate.query.results.ResultsHelper.impl;
@@ -91,7 +92,7 @@ public class CompleteResultBuilderCollectionStandard implements CompleteResultBu
 	public DomainResult<?> buildResult(
 			JdbcValuesMetadata jdbcResultsMetadata,
 			int resultPosition,
-			BiFunction<String, String, DynamicFetchBuilderLegacy> legacyFetchResolver,
+			BiFunction<String, Fetchable, DynamicFetchBuilderLegacy> legacyFetchResolver,
 			DomainResultCreationState domainResultCreationState) {
 		final DomainResultCreationStateImpl creationStateImpl = impl( domainResultCreationState );
 		final SessionFactoryImplementor sessionFactory = creationStateImpl.getSessionFactory();

--- a/hibernate-core/src/main/java/org/hibernate/query/results/complete/CompleteResultBuilderEntityJpa.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/results/complete/CompleteResultBuilderEntityJpa.java
@@ -21,6 +21,7 @@ import org.hibernate.query.results.dynamic.DynamicFetchBuilderLegacy;
 import org.hibernate.spi.NavigablePath;
 import org.hibernate.sql.ast.spi.SqlAliasBase;
 import org.hibernate.sql.results.graph.DomainResultCreationState;
+import org.hibernate.sql.results.graph.Fetchable;
 import org.hibernate.sql.results.graph.entity.EntityResult;
 import org.hibernate.sql.results.jdbc.spi.JdbcValuesMetadata;
 
@@ -39,14 +40,14 @@ public class CompleteResultBuilderEntityJpa implements CompleteResultBuilderEnti
 	private final EntityMappingType entityDescriptor;
 	private final LockMode lockMode;
 	private final BasicValuedFetchBuilder discriminatorFetchBuilder;
-	private final HashMap<String, FetchBuilder> explicitFetchBuilderMap;
+	private final HashMap<Fetchable, FetchBuilder> explicitFetchBuilderMap;
 
 	public CompleteResultBuilderEntityJpa(
 			NavigablePath navigablePath,
 			EntityMappingType entityDescriptor,
 			LockMode lockMode,
 			BasicValuedFetchBuilder discriminatorFetchBuilder,
-			HashMap<String, FetchBuilder> explicitFetchBuilderMap) {
+			HashMap<Fetchable, FetchBuilder> explicitFetchBuilderMap) {
 		this.navigablePath = navigablePath;
 		this.entityDescriptor = entityDescriptor;
 		this.lockMode = lockMode;
@@ -87,7 +88,7 @@ public class CompleteResultBuilderEntityJpa implements CompleteResultBuilderEnti
 	public EntityResult buildResult(
 			JdbcValuesMetadata jdbcResultsMetadata,
 			int resultPosition,
-			BiFunction<String, String, DynamicFetchBuilderLegacy> legacyFetchResolver,
+			BiFunction<String, Fetchable, DynamicFetchBuilderLegacy> legacyFetchResolver,
 			DomainResultCreationState domainResultCreationState) {
 		final String implicitAlias = entityDescriptor.getSqlAliasStem() + resultPosition;
 		final SqlAliasBase sqlAliasBase = domainResultCreationState.getSqlAliasBaseManager().createSqlAliasBase( implicitAlias );
@@ -139,7 +140,7 @@ public class CompleteResultBuilderEntityJpa implements CompleteResultBuilderEnti
 	}
 
 	@Override
-	public void visitFetchBuilders(BiConsumer<String, FetchBuilder> consumer) {
+	public void visitFetchBuilders(BiConsumer<Fetchable, FetchBuilder> consumer) {
 		explicitFetchBuilderMap.forEach( consumer );
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/query/results/complete/CompleteResultBuilderEntityStandard.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/results/complete/CompleteResultBuilderEntityStandard.java
@@ -22,6 +22,7 @@ import org.hibernate.query.results.ResultsHelper;
 import org.hibernate.query.results.dynamic.DynamicFetchBuilderLegacy;
 import org.hibernate.sql.ast.spi.SqlAliasBaseConstant;
 import org.hibernate.sql.results.graph.DomainResultCreationState;
+import org.hibernate.sql.results.graph.Fetchable;
 import org.hibernate.sql.results.graph.entity.EntityResult;
 import org.hibernate.sql.results.jdbc.spi.JdbcValuesMetadata;
 
@@ -34,7 +35,7 @@ public class CompleteResultBuilderEntityStandard implements CompleteResultBuilde
 	private final EntityMappingType entityDescriptor;
 	private final LockMode lockMode;
 	private final BasicValuedFetchBuilder discriminatorFetchBuilder;
-	private final HashMap<String, FetchBuilder> explicitFetchBuilderMap;
+	private final HashMap<Fetchable, FetchBuilder> explicitFetchBuilderMap;
 
 	public CompleteResultBuilderEntityStandard(
 			String tableAlias,
@@ -42,7 +43,7 @@ public class CompleteResultBuilderEntityStandard implements CompleteResultBuilde
 			EntityMappingType entityDescriptor,
 			LockMode lockMode,
 			BasicValuedFetchBuilder discriminatorFetchBuilder,
-			HashMap<String, FetchBuilder> explicitFetchBuilderMap) {
+			HashMap<Fetchable, FetchBuilder> explicitFetchBuilderMap) {
 		this.tableAlias = tableAlias;
 		this.navigablePath = navigablePath;
 		this.entityDescriptor = entityDescriptor;
@@ -120,7 +121,7 @@ public class CompleteResultBuilderEntityStandard implements CompleteResultBuilde
 	public EntityResult buildResult(
 			JdbcValuesMetadata jdbcResultsMetadata,
 			int resultPosition,
-			BiFunction<String, String, DynamicFetchBuilderLegacy> legacyFetchResolver,
+			BiFunction<String, Fetchable, DynamicFetchBuilderLegacy> legacyFetchResolver,
 			DomainResultCreationState domainResultCreationState) {
 		final DomainResultCreationStateImpl impl = ResultsHelper.impl( domainResultCreationState );
 		impl.disallowPositionalSelections();
@@ -169,7 +170,7 @@ public class CompleteResultBuilderEntityStandard implements CompleteResultBuilde
 	}
 
 	@Override
-	public void visitFetchBuilders(BiConsumer<String, FetchBuilder> consumer) {
+	public void visitFetchBuilders(BiConsumer<Fetchable, FetchBuilder> consumer) {
 		explicitFetchBuilderMap.forEach( consumer );
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/query/results/complete/CompleteResultBuilderInstantiation.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/results/complete/CompleteResultBuilderInstantiation.java
@@ -14,6 +14,7 @@ import org.hibernate.query.results.dynamic.DynamicFetchBuilderLegacy;
 import org.hibernate.query.results.ResultBuilder;
 import org.hibernate.sql.results.graph.DomainResult;
 import org.hibernate.sql.results.graph.DomainResultCreationState;
+import org.hibernate.sql.results.graph.Fetchable;
 import org.hibernate.sql.results.graph.instantiation.internal.ArgumentDomainResult;
 import org.hibernate.sql.results.graph.instantiation.internal.DynamicInstantiationResultImpl;
 import org.hibernate.sql.results.jdbc.spi.JdbcValuesMetadata;
@@ -51,7 +52,7 @@ public class CompleteResultBuilderInstantiation
 	public DomainResult<?> buildResult(
 			JdbcValuesMetadata jdbcResultsMetadata,
 			int resultPosition,
-			BiFunction<String, String, DynamicFetchBuilderLegacy> legacyFetchResolver,
+			BiFunction<String, Fetchable, DynamicFetchBuilderLegacy> legacyFetchResolver,
 			DomainResultCreationState domainResultCreationState) {
 		final List<ArgumentDomainResult<?>> argumentDomainResults = new ArrayList<>( argumentResultBuilders.size() );
 

--- a/hibernate-core/src/main/java/org/hibernate/query/results/complete/DelayedFetchBuilderBasicPart.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/results/complete/DelayedFetchBuilderBasicPart.java
@@ -16,6 +16,7 @@ import org.hibernate.query.results.FetchBuilder;
 import org.hibernate.query.results.dynamic.DynamicFetchBuilderLegacy;
 import org.hibernate.sql.results.graph.DomainResultCreationState;
 import org.hibernate.sql.results.graph.FetchParent;
+import org.hibernate.sql.results.graph.Fetchable;
 import org.hibernate.sql.results.graph.basic.BasicFetch;
 import org.hibernate.sql.results.jdbc.spi.JdbcValuesMetadata;
 
@@ -57,7 +58,7 @@ public class DelayedFetchBuilderBasicPart
 			FetchParent parent,
 			NavigablePath fetchPath,
 			JdbcValuesMetadata jdbcResultsMetadata,
-			BiFunction<String, String, DynamicFetchBuilderLegacy> legacyFetchResolver,
+			BiFunction<String, Fetchable, DynamicFetchBuilderLegacy> legacyFetchResolver,
 			DomainResultCreationState domainResultCreationState) {
 		return new BasicFetch<>(
 				-1,

--- a/hibernate-core/src/main/java/org/hibernate/query/results/dynamic/DynamicFetchBuilderContainer.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/results/dynamic/DynamicFetchBuilderContainer.java
@@ -5,6 +5,7 @@
 package org.hibernate.query.results.dynamic;
 
 import org.hibernate.query.results.FetchBuilder;
+import org.hibernate.sql.results.graph.Fetchable;
 
 /**
  * @author Steve Ebersole
@@ -13,22 +14,22 @@ public interface DynamicFetchBuilderContainer {
 	/**
 	 * Locate an explicit fetch definition for the named fetchable
 	 */
-	FetchBuilder findFetchBuilder(String fetchableName);
+	FetchBuilder findFetchBuilder(Fetchable fetchable);
 
 	/**
 	 * Add a property mapped to a single column.
 	 */
-	DynamicFetchBuilderContainer addProperty(String propertyName, String columnAlias);
+	DynamicFetchBuilderContainer addProperty(Fetchable fetchable, String columnAlias);
 
 	/**
 	 * Add a property mapped to multiple columns
 	 */
-	DynamicFetchBuilderContainer addProperty(String propertyName, String... columnAliases);
+	DynamicFetchBuilderContainer addProperty(Fetchable fetchable, String... columnAliases);
 
 	/**
 	 * Add a property whose columns can later be defined using {@link DynamicFetchBuilder#addColumnAlias}
 	 */
-	DynamicFetchBuilder addProperty(String propertyName);
+	DynamicFetchBuilder addProperty(Fetchable fetchable);
 
-	void addFetchBuilder(String propertyName, FetchBuilder fetchBuilder);
+	void addFetchBuilder(Fetchable fetchable, FetchBuilder fetchBuilder);
 }

--- a/hibernate-core/src/main/java/org/hibernate/query/results/dynamic/DynamicFetchBuilderLegacy.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/results/dynamic/DynamicFetchBuilderLegacy.java
@@ -13,11 +13,14 @@ import java.util.function.BiFunction;
 
 import org.hibernate.LockMode;
 import org.hibernate.engine.FetchTiming;
-import org.hibernate.metamodel.mapping.AttributeMapping;
 import org.hibernate.metamodel.mapping.CollectionPart;
+import org.hibernate.metamodel.mapping.EntityAssociationMapping;
 import org.hibernate.metamodel.mapping.ForeignKeyDescriptor;
 import org.hibernate.metamodel.mapping.PluralAttributeMapping;
 import org.hibernate.metamodel.mapping.SelectableMapping;
+import org.hibernate.metamodel.mapping.ValuedModelPart;
+import org.hibernate.metamodel.mapping.internal.EmbeddedAttributeMapping;
+import org.hibernate.metamodel.mapping.internal.EntityCollectionPart;
 import org.hibernate.metamodel.mapping.internal.ToOneAttributeMapping;
 import org.hibernate.query.NativeQuery;
 import org.hibernate.query.results.DomainResultCreationStateImpl;
@@ -34,6 +37,7 @@ import org.hibernate.sql.ast.tree.from.TableReference;
 import org.hibernate.sql.results.graph.DomainResultCreationState;
 import org.hibernate.sql.results.graph.Fetch;
 import org.hibernate.sql.results.graph.FetchParent;
+import org.hibernate.sql.results.graph.Fetchable;
 import org.hibernate.sql.results.jdbc.spi.JdbcValuesMetadata;
 
 import static org.hibernate.query.results.ResultsHelper.impl;
@@ -44,39 +48,37 @@ import static org.hibernate.query.results.ResultsHelper.impl;
  */
 public class DynamicFetchBuilderLegacy implements DynamicFetchBuilder, NativeQuery.FetchReturn, DynamicFetchBuilderContainer {
 
-	private static final String ELEMENT_PREFIX = CollectionPart.Nature.ELEMENT.getName() + ".";
-	private static final String INDEX_PREFIX = CollectionPart.Nature.INDEX.getName() + ".";
+	private static final String ELEMENT_PREFIX = "element.";
+	private static final int ELEMENT_PREFIX_LENGTH = 8;
 
 	private final String tableAlias;
 
 	private final String ownerTableAlias;
-	private final String fetchableName;
+	private final Fetchable fetchable;
 
 	private final List<String> columnNames;
-	private final Map<String, FetchBuilder> fetchBuilderMap;
+	private final Map<Fetchable, FetchBuilder> fetchBuilderMap;
 	private final DynamicResultBuilderEntityStandard resultBuilderEntity;
-
-	private LockMode lockMode;
 
 	public DynamicFetchBuilderLegacy(
 			String tableAlias,
 			String ownerTableAlias,
-			String fetchableName,
+			Fetchable fetchable,
 			List<String> columnNames,
-			Map<String, FetchBuilder> fetchBuilderMap) {
-		this( tableAlias, ownerTableAlias, fetchableName, columnNames, fetchBuilderMap, null );
+			Map<Fetchable, FetchBuilder> fetchBuilderMap) {
+		this( tableAlias, ownerTableAlias, fetchable, columnNames, fetchBuilderMap, null );
 	}
 
 	public DynamicFetchBuilderLegacy(
 			String tableAlias,
 			String ownerTableAlias,
-			String fetchableName,
+			Fetchable fetchable,
 			List<String> columnNames,
-			Map<String, FetchBuilder> fetchBuilderMap,
+			Map<Fetchable, FetchBuilder> fetchBuilderMap,
 			DynamicResultBuilderEntityStandard resultBuilderEntity) {
 		this.tableAlias = tableAlias;
 		this.ownerTableAlias = ownerTableAlias;
-		this.fetchableName = fetchableName;
+		this.fetchable = fetchable;
 		this.columnNames = columnNames;
 		this.fetchBuilderMap = fetchBuilderMap;
 		this.resultBuilderEntity = resultBuilderEntity;
@@ -93,26 +95,71 @@ public class DynamicFetchBuilderLegacy implements DynamicFetchBuilder, NativeQue
 	}
 
 	@Override
+	public Fetchable getFetchable() {
+		return fetchable;
+	}
+
+	@Override
 	public String getFetchableName() {
-		return fetchableName;
+		return fetchable.getFetchableName();
+	}
+
+	@Override
+	public NativeQuery.FetchReturn setLockMode(LockMode lockMode) {
+		return this;
+	}
+
+	@Override
+	public NativeQuery.FetchReturn addProperty(String propertyName, String columnAlias) {
+		addProperty( resolveFetchable( propertyName ), columnAlias );
+		return this;
+	}
+
+	private Fetchable resolveFetchable(String propertyName) {
+		if ( fetchable instanceof EntityAssociationMapping attributeMapping ) {
+			return (Fetchable) attributeMapping.findByPath( propertyName );
+		}
+		else if ( fetchable instanceof PluralAttributeMapping pluralAttributeMapping ) {
+			if ( propertyName.equals( "key" ) ) {
+				return pluralAttributeMapping.getIndexDescriptor();
+			}
+			else if ( propertyName.equals( "element" ) ) {
+				return pluralAttributeMapping.getElementDescriptor().getCollectionAttribute();
+			}
+			else {
+				final CollectionPart elementDescriptor = pluralAttributeMapping.getElementDescriptor();
+				if ( elementDescriptor instanceof EntityCollectionPart entityCollectionPart ) {
+					if ( propertyName.startsWith( ELEMENT_PREFIX ) ) {
+						propertyName = propertyName.substring( ELEMENT_PREFIX_LENGTH );
+					}
+					return (Fetchable) entityCollectionPart.getEntityMappingType().findByPath( propertyName );
+				}
+			}
+		}
+		throw new UnsupportedOperationException( "Unsupported fetchable type: " + fetchable.getClass().getName() );
+	}
+
+	@Override
+	public NativeQuery.ReturnProperty addProperty(String propertyName) {
+		return addProperty( resolveFetchable( propertyName ) );
 	}
 
 	@Override
 	public DynamicFetchBuilderLegacy cacheKeyInstance() {
-		final Map<String, FetchBuilder> fetchBuilderMap;
+		final Map<Fetchable, FetchBuilder> fetchBuilderMap;
 		if ( this.fetchBuilderMap == null ) {
 			fetchBuilderMap = null;
 		}
 		else {
 			fetchBuilderMap = new HashMap<>( this.fetchBuilderMap.size() );
-			for ( Map.Entry<String, FetchBuilder> entry : this.fetchBuilderMap.entrySet() ) {
+			for ( Map.Entry<Fetchable, FetchBuilder> entry : this.fetchBuilderMap.entrySet() ) {
 				fetchBuilderMap.put( entry.getKey(), entry.getValue().cacheKeyInstance() );
 			}
 		}
 		return new DynamicFetchBuilderLegacy(
 				tableAlias,
 				ownerTableAlias,
-				fetchableName,
+				fetchable,
 				columnNames == null ? null : List.copyOf( columnNames ),
 				fetchBuilderMap,
 				resultBuilderEntity == null ? null : resultBuilderEntity.cacheKeyInstance()
@@ -124,17 +171,14 @@ public class DynamicFetchBuilderLegacy implements DynamicFetchBuilder, NativeQue
 			FetchParent parent,
 			NavigablePath fetchPath,
 			JdbcValuesMetadata jdbcResultsMetadata,
-			BiFunction<String, String, DynamicFetchBuilderLegacy> legacyFetchResolver,
+			BiFunction<String, Fetchable, DynamicFetchBuilderLegacy> legacyFetchResolver,
 			DomainResultCreationState domainResultCreationState) {
 		final DomainResultCreationStateImpl creationState = impl( domainResultCreationState );
 		final TableGroup ownerTableGroup = creationState.getFromClauseAccess().findByAlias( ownerTableAlias );
-		final AttributeMapping attributeMapping = parent.getReferencedMappingContainer()
-				.findContainingEntityMapping()
-				.findDeclaredAttributeMapping( fetchableName );
 		final TableGroup tableGroup;
-		if ( attributeMapping instanceof TableGroupJoinProducer ) {
+		if ( fetchable instanceof TableGroupJoinProducer ) {
 			final SqlAliasBase sqlAliasBase = new SqlAliasBaseConstant( tableAlias );
-			final TableGroupJoin tableGroupJoin = ( (TableGroupJoinProducer) attributeMapping ).createTableGroupJoin(
+			final TableGroupJoin tableGroupJoin = ( (TableGroupJoinProducer) fetchable ).createTableGroupJoin(
 					fetchPath,
 					ownerTableGroup,
 					tableAlias,
@@ -151,70 +195,73 @@ public class DynamicFetchBuilderLegacy implements DynamicFetchBuilder, NativeQue
 			tableGroup = ownerTableGroup;
 		}
 
-		if ( columnNames != null ) {
+		if ( !columnNames.isEmpty() ) {
 			final ForeignKeyDescriptor keyDescriptor;
-			if ( attributeMapping instanceof PluralAttributeMapping ) {
-				final PluralAttributeMapping pluralAttributeMapping = (PluralAttributeMapping) attributeMapping;
-				keyDescriptor = pluralAttributeMapping.getKeyDescriptor();
-			}
-			else {
-				// Not sure if this fetch builder can also be used with other attribute mappings
-				assert attributeMapping instanceof ToOneAttributeMapping;
-
-				final ToOneAttributeMapping toOneAttributeMapping = (ToOneAttributeMapping) attributeMapping;
-				keyDescriptor = toOneAttributeMapping.getForeignKeyDescriptor();
-			}
-
-			if ( !columnNames.isEmpty() ) {
-				keyDescriptor.forEachSelectable(
-						(selectionIndex, selectableMapping) -> {
-							resolveSqlSelection(
-									columnNames.get( selectionIndex ),
-									tableGroup.resolveTableReference(
-											fetchPath,
-											keyDescriptor.getKeyPart(),
-											selectableMapping.getContainingTableExpression()
-									),
-									selectableMapping,
-									jdbcResultsMetadata,
-									domainResultCreationState
-							);
-						}
+			if ( fetchable instanceof EmbeddedAttributeMapping embeddedAttributeMapping ) {
+				embeddedAttributeMapping.forEachSelectable(
+						(selectionIndex, selectableMapping) ->
+								resolveSqlSelection(
+										columnNames.get( selectionIndex ),
+										tableGroup.resolveTableReference(
+												fetchPath,
+												(ValuedModelPart) selectableMapping,
+												selectableMapping.getContainingTableExpression()
+										),
+										selectableMapping,
+										jdbcResultsMetadata,
+										domainResultCreationState
+								)
 				);
 			}
+			else {
+				if ( fetchable instanceof PluralAttributeMapping pluralAttributeMapping ) {
+					keyDescriptor = pluralAttributeMapping.getKeyDescriptor();
+				}
+				else {
+					// Not sure if this fetch builder can also be used with other attribute mappings
+					assert fetchable instanceof ToOneAttributeMapping;
 
+					final ToOneAttributeMapping toOneAttributeMapping = (ToOneAttributeMapping) fetchable;
+					keyDescriptor = toOneAttributeMapping.getForeignKeyDescriptor();
+				}
+
+				keyDescriptor.forEachSelectable(
+						(selectionIndex, selectableMapping) ->
+								resolveSqlSelection(
+										columnNames.get( selectionIndex ),
+										tableGroup.resolveTableReference(
+												fetchPath,
+												keyDescriptor.getKeyPart(),
+												selectableMapping.getContainingTableExpression()
+										),
+										selectableMapping,
+										jdbcResultsMetadata,
+										domainResultCreationState
+								)
+				);
+			}
 			// We process the fetch builder such that it contains a resultBuilderEntity before calling this method in ResultSetMappingProcessor
 			if ( resultBuilderEntity != null ) {
 				return resultBuilderEntity.buildFetch(
 						parent,
-						attributeMapping,
+						fetchable,
 						jdbcResultsMetadata,
 						creationState
 				);
 			}
 		}
 		try {
-			final Map.Entry<String, NavigablePath> currentRelativePath = creationState.getCurrentRelativePath();
-			final String prefix;
-			if ( currentRelativePath == null ) {
-				prefix = "";
-			}
-			else {
-				prefix = currentRelativePath.getKey()
-						.replace( ELEMENT_PREFIX, "" )
-						.replace( INDEX_PREFIX, "" ) + ".";
-			}
 			creationState.pushExplicitFetchMementoResolver(
-					relativePath -> {
-						if ( relativePath.startsWith( prefix ) ) {
-							return findFetchBuilder( relativePath.substring( prefix.length() ) );
+					fetchable -> {
+						if ( fetchable != null ) {
+							return findFetchBuilder( fetchable );
 						}
 						return null;
 					}
 			);
 			return parent.generateFetchableFetch(
-					attributeMapping,
-					parent.resolveNavigablePath( attributeMapping ),
+					fetchable,
+					parent.resolveNavigablePath( fetchable ),
 					FetchTiming.IMMEDIATE,
 					true,
 					null,
@@ -224,6 +271,11 @@ public class DynamicFetchBuilderLegacy implements DynamicFetchBuilder, NativeQue
 		finally {
 			creationState.popExplicitFetchMementoResolver();
 		}
+	}
+
+	@Override
+	public void visitFetchBuilders(BiConsumer<Fetchable, FetchBuilder> consumer) {
+		fetchBuilderMap.forEach( consumer );
 	}
 
 	private void resolveSqlSelection(
@@ -262,32 +314,27 @@ public class DynamicFetchBuilderLegacy implements DynamicFetchBuilder, NativeQue
 	}
 
 	@Override
-	public NativeQuery.FetchReturn setLockMode(LockMode lockMode) {
-		this.lockMode = lockMode;
-		return this;
-	}
-
-	@Override
-	public DynamicFetchBuilderLegacy addProperty(String propertyName, String columnAlias) {
-		addProperty( propertyName ).addColumnAlias( columnAlias );
-		return this;
-	}
-
-	@Override
-	public DynamicFetchBuilder addProperty(String propertyName) {
-		DynamicFetchBuilderStandard fetchBuilder = new DynamicFetchBuilderStandard( propertyName );
-		fetchBuilderMap.put( propertyName, fetchBuilder );
+	public DynamicFetchBuilder addProperty(Fetchable fetchable) {
+		DynamicFetchBuilderStandard fetchBuilder = new DynamicFetchBuilderStandard( fetchable );
+		fetchBuilderMap.put( fetchable, fetchBuilder );
 		return fetchBuilder;
 	}
 
 	@Override
-	public FetchBuilder findFetchBuilder(String fetchableName) {
-		return fetchBuilderMap.get( fetchableName );
+	public FetchBuilder findFetchBuilder(Fetchable fetchable) {
+		return fetchBuilderMap.get( fetchable );
 	}
 
 	@Override
-	public DynamicFetchBuilderContainer addProperty(String propertyName, String... columnAliases) {
-		final DynamicFetchBuilder fetchBuilder = addProperty( propertyName );
+	public DynamicFetchBuilderContainer addProperty(Fetchable fetchable, String columnAlias) {
+		final DynamicFetchBuilder fetchBuilder = addProperty( fetchable );
+		fetchBuilder.addColumnAlias( columnAlias );
+		return this;
+	}
+
+	@Override
+	public DynamicFetchBuilderContainer addProperty(Fetchable fetchable, String... columnAliases) {
+		final DynamicFetchBuilder fetchBuilder = addProperty( fetchable );
 		for ( String columnAlias : columnAliases ) {
 			fetchBuilder.addColumnAlias( columnAlias );
 		}
@@ -295,14 +342,14 @@ public class DynamicFetchBuilderLegacy implements DynamicFetchBuilder, NativeQue
 	}
 
 	@Override
-	public void addFetchBuilder(String propertyName, FetchBuilder fetchBuilder) {
-		fetchBuilderMap.put( propertyName, fetchBuilder );
+	public void addFetchBuilder(Fetchable fetchable, FetchBuilder fetchBuilder) {
+		fetchBuilderMap.put( fetchable, fetchBuilder );
 	}
 
-	@Override
-	public void visitFetchBuilders(BiConsumer<String, FetchBuilder> consumer) {
-		fetchBuilderMap.forEach( consumer );
-	}
+//	@Override
+//	public void visitFetchBuilders(BiConsumer<Fetchable, FetchBuilder> consumer) {
+//		fetchBuilderMap.forEach( consumer );
+//	}
 
 	@Override
 	public boolean equals(Object o) {
@@ -316,7 +363,7 @@ public class DynamicFetchBuilderLegacy implements DynamicFetchBuilder, NativeQue
 		final DynamicFetchBuilderLegacy that = (DynamicFetchBuilderLegacy) o;
 		return tableAlias.equals( that.tableAlias )
 				&& ownerTableAlias.equals( that.ownerTableAlias )
-				&& fetchableName.equals( that.fetchableName )
+				&& fetchable.equals( that.fetchable )
 				&& Objects.equals( columnNames, that.columnNames )
 				&& Objects.equals( fetchBuilderMap, that.fetchBuilderMap )
 				&& Objects.equals( resultBuilderEntity, that.resultBuilderEntity );
@@ -326,7 +373,7 @@ public class DynamicFetchBuilderLegacy implements DynamicFetchBuilder, NativeQue
 	public int hashCode() {
 		int result = tableAlias.hashCode();
 		result = 31 * result + ownerTableAlias.hashCode();
-		result = 31 * result + fetchableName.hashCode();
+		result = 31 * result + fetchable.hashCode();
 		result = 31 * result + ( columnNames != null ? columnNames.hashCode() : 0 );
 		result = 31 * result + ( fetchBuilderMap != null ? fetchBuilderMap.hashCode() : 0 );
 		result = 31 * result + ( resultBuilderEntity != null ? resultBuilderEntity.hashCode() : 0 );

--- a/hibernate-core/src/main/java/org/hibernate/query/results/dynamic/DynamicFetchBuilderLegacy.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/results/dynamic/DynamicFetchBuilderLegacy.java
@@ -60,6 +60,8 @@ public class DynamicFetchBuilderLegacy implements DynamicFetchBuilder, NativeQue
 	private final Map<Fetchable, FetchBuilder> fetchBuilderMap;
 	private final DynamicResultBuilderEntityStandard resultBuilderEntity;
 
+	private LockMode lockMode;
+
 	public DynamicFetchBuilderLegacy(
 			String tableAlias,
 			String ownerTableAlias,
@@ -106,6 +108,7 @@ public class DynamicFetchBuilderLegacy implements DynamicFetchBuilder, NativeQue
 
 	@Override
 	public NativeQuery.FetchReturn setLockMode(LockMode lockMode) {
+		this.lockMode = lockMode;
 		return this;
 	}
 
@@ -176,6 +179,9 @@ public class DynamicFetchBuilderLegacy implements DynamicFetchBuilder, NativeQue
 		final DomainResultCreationStateImpl creationState = impl( domainResultCreationState );
 		final TableGroup ownerTableGroup = creationState.getFromClauseAccess().findByAlias( ownerTableAlias );
 		final TableGroup tableGroup;
+		if ( lockMode != null ) {
+			domainResultCreationState.getSqlAstCreationState().registerLockMode( tableAlias, lockMode );
+		}
 		if ( fetchable instanceof TableGroupJoinProducer ) {
 			final SqlAliasBase sqlAliasBase = new SqlAliasBaseConstant( tableAlias );
 			final TableGroupJoin tableGroupJoin = ( (TableGroupJoinProducer) fetchable ).createTableGroupJoin(
@@ -346,11 +352,6 @@ public class DynamicFetchBuilderLegacy implements DynamicFetchBuilder, NativeQue
 		fetchBuilderMap.put( fetchable, fetchBuilder );
 	}
 
-//	@Override
-//	public void visitFetchBuilders(BiConsumer<Fetchable, FetchBuilder> consumer) {
-//		fetchBuilderMap.forEach( consumer );
-//	}
-
 	@Override
 	public boolean equals(Object o) {
 		if ( this == o ) {
@@ -364,6 +365,7 @@ public class DynamicFetchBuilderLegacy implements DynamicFetchBuilder, NativeQue
 		return tableAlias.equals( that.tableAlias )
 				&& ownerTableAlias.equals( that.ownerTableAlias )
 				&& fetchable.equals( that.fetchable )
+				&& lockMode.equals( that.lockMode )
 				&& Objects.equals( columnNames, that.columnNames )
 				&& Objects.equals( fetchBuilderMap, that.fetchBuilderMap )
 				&& Objects.equals( resultBuilderEntity, that.resultBuilderEntity );
@@ -374,6 +376,7 @@ public class DynamicFetchBuilderLegacy implements DynamicFetchBuilder, NativeQue
 		int result = tableAlias.hashCode();
 		result = 31 * result + ownerTableAlias.hashCode();
 		result = 31 * result + fetchable.hashCode();
+		result = 31 * result + lockMode.hashCode();
 		result = 31 * result + ( columnNames != null ? columnNames.hashCode() : 0 );
 		result = 31 * result + ( fetchBuilderMap != null ? fetchBuilderMap.hashCode() : 0 );
 		result = 31 * result + ( resultBuilderEntity != null ? resultBuilderEntity.hashCode() : 0 );

--- a/hibernate-core/src/main/java/org/hibernate/query/results/dynamic/DynamicResultBuilderAttribute.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/results/dynamic/DynamicResultBuilderAttribute.java
@@ -16,6 +16,7 @@ import org.hibernate.sql.ast.spi.SqlExpressionResolver;
 import org.hibernate.sql.ast.spi.SqlSelection;
 import org.hibernate.sql.results.graph.DomainResult;
 import org.hibernate.sql.results.graph.DomainResultCreationState;
+import org.hibernate.sql.results.graph.Fetchable;
 import org.hibernate.sql.results.graph.basic.BasicResult;
 import org.hibernate.sql.results.jdbc.spi.JdbcValuesMetadata;
 
@@ -76,7 +77,7 @@ public class DynamicResultBuilderAttribute implements DynamicResultBuilder, Nati
 	public DomainResult<?> buildResult(
 			JdbcValuesMetadata jdbcResultsMetadata,
 			int resultPosition,
-			BiFunction<String, String, DynamicFetchBuilderLegacy> legacyFetchResolver,
+			BiFunction<String, Fetchable, DynamicFetchBuilderLegacy> legacyFetchResolver,
 			DomainResultCreationState domainResultCreationState) {
 		final DomainResultCreationStateImpl domainResultCreationStateImpl = impl( domainResultCreationState );
 

--- a/hibernate-core/src/main/java/org/hibernate/query/results/dynamic/DynamicResultBuilderBasicConverted.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/results/dynamic/DynamicResultBuilderBasicConverted.java
@@ -11,6 +11,7 @@ import jakarta.persistence.AttributeConverter;
 
 import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.metamodel.mapping.BasicValuedMapping;
+import org.hibernate.sql.results.graph.Fetchable;
 import org.hibernate.type.descriptor.converter.internal.JpaAttributeConverterImpl;
 import org.hibernate.type.descriptor.converter.spi.BasicValueConverter;
 import org.hibernate.query.results.ResultsHelper;
@@ -92,7 +93,7 @@ public class DynamicResultBuilderBasicConverted<O,R> implements DynamicResultBui
 	public BasicResult<?> buildResult(
 			JdbcValuesMetadata jdbcResultsMetadata,
 			int resultPosition,
-			BiFunction<String, String, DynamicFetchBuilderLegacy> legacyFetchResolver,
+			BiFunction<String, Fetchable, DynamicFetchBuilderLegacy> legacyFetchResolver,
 			DomainResultCreationState domainResultCreationState) {
 		final TypeConfiguration typeConfiguration = domainResultCreationState.getSqlAstCreationState()
 				.getCreationContext()

--- a/hibernate-core/src/main/java/org/hibernate/query/results/dynamic/DynamicResultBuilderBasicStandard.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/results/dynamic/DynamicResultBuilderBasicStandard.java
@@ -8,6 +8,7 @@ import java.util.Objects;
 import java.util.function.BiFunction;
 
 import org.hibernate.metamodel.mapping.JdbcMapping;
+import org.hibernate.sql.results.graph.Fetchable;
 import org.hibernate.type.descriptor.converter.spi.BasicValueConverter;
 import org.hibernate.query.NativeQuery;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
@@ -118,7 +119,7 @@ public class DynamicResultBuilderBasicStandard implements DynamicResultBuilderBa
 	public BasicResult<?> buildResult(
 			JdbcValuesMetadata jdbcResultsMetadata,
 			int resultPosition,
-			BiFunction<String, String, DynamicFetchBuilderLegacy> legacyFetchResolver,
+			BiFunction<String, Fetchable, DynamicFetchBuilderLegacy> legacyFetchResolver,
 			DomainResultCreationState domainResultCreationState) {
 		final SessionFactoryImplementor sessionFactory = domainResultCreationState.getSqlAstCreationState()
 				.getCreationContext()

--- a/hibernate-core/src/main/java/org/hibernate/query/results/dynamic/DynamicResultBuilderEntity.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/results/dynamic/DynamicResultBuilderEntity.java
@@ -8,6 +8,7 @@ import java.util.function.BiFunction;
 
 import org.hibernate.query.results.ResultBuilderEntityValued;
 import org.hibernate.sql.results.graph.DomainResultCreationState;
+import org.hibernate.sql.results.graph.Fetchable;
 import org.hibernate.sql.results.graph.entity.EntityResult;
 import org.hibernate.sql.results.jdbc.spi.JdbcValuesMetadata;
 
@@ -19,6 +20,6 @@ public interface DynamicResultBuilderEntity extends DynamicResultBuilder, Result
 	EntityResult buildResult(
 			JdbcValuesMetadata jdbcResultsMetadata,
 			int resultPosition,
-			BiFunction<String, String, DynamicFetchBuilderLegacy> legacyFetchResolver,
+			BiFunction<String, Fetchable, DynamicFetchBuilderLegacy> legacyFetchResolver,
 			DomainResultCreationState domainResultCreationState);
 }

--- a/hibernate-core/src/main/java/org/hibernate/query/results/dynamic/DynamicResultBuilderEntityCalculated.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/results/dynamic/DynamicResultBuilderEntityCalculated.java
@@ -15,6 +15,7 @@ import org.hibernate.spi.NavigablePath;
 import org.hibernate.sql.ast.spi.SqlAliasBaseConstant;
 import org.hibernate.sql.ast.tree.from.TableGroup;
 import org.hibernate.sql.results.graph.DomainResultCreationState;
+import org.hibernate.sql.results.graph.Fetchable;
 import org.hibernate.sql.results.graph.entity.EntityResult;
 import org.hibernate.sql.results.jdbc.spi.JdbcValuesMetadata;
 
@@ -106,7 +107,7 @@ public class DynamicResultBuilderEntityCalculated implements DynamicResultBuilde
 	public EntityResult buildResult(
 			JdbcValuesMetadata jdbcResultsMetadata,
 			int resultPosition,
-			BiFunction<String, String, DynamicFetchBuilderLegacy> legacyFetchResolver,
+			BiFunction<String, Fetchable, DynamicFetchBuilderLegacy> legacyFetchResolver,
 			DomainResultCreationState domainResultCreationState) {
 		final DomainResultCreationStateImpl creationStateImpl = ResultsHelper.impl( domainResultCreationState );
 

--- a/hibernate-core/src/main/java/org/hibernate/query/results/dynamic/DynamicResultBuilderEntityStandard.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/results/dynamic/DynamicResultBuilderEntityStandard.java
@@ -7,7 +7,6 @@ package org.hibernate.query.results.dynamic;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 import java.util.function.BiFunction;
 import java.util.function.Function;
@@ -15,13 +14,11 @@ import java.util.function.Function;
 import org.hibernate.LockMode;
 import org.hibernate.engine.FetchTiming;
 import org.hibernate.metamodel.mapping.CollectionPart;
-import org.hibernate.metamodel.mapping.EntityIdentifierMapping;
 import org.hibernate.metamodel.mapping.EntityMappingType;
 import org.hibernate.metamodel.mapping.ModelPart;
 import org.hibernate.metamodel.mapping.PluralAttributeMapping;
 import org.hibernate.metamodel.mapping.SelectableMapping;
 import org.hibernate.metamodel.mapping.internal.ManyToManyCollectionPart;
-import org.hibernate.metamodel.mapping.internal.SingleAttributeIdentifierMapping;
 import org.hibernate.query.NativeQuery;
 import org.hibernate.query.results.DomainResultCreationStateImpl;
 import org.hibernate.query.results.FetchBuilder;
@@ -48,9 +45,6 @@ import static org.hibernate.query.results.ResultsHelper.impl;
 public class DynamicResultBuilderEntityStandard
 		extends AbstractFetchBuilderContainer<DynamicResultBuilderEntityStandard>
 		implements DynamicResultBuilderEntity, NativeQuery.RootReturn {
-
-	private static final String ELEMENT_PREFIX = CollectionPart.Nature.ELEMENT.getName() + ".";
-	private static final String INDEX_PREFIX = CollectionPart.Nature.INDEX.getName() + ".";
 
 	private final NavigablePath navigablePath;
 
@@ -138,7 +132,7 @@ public class DynamicResultBuilderEntityStandard
 	public EntityResult buildResult(
 			JdbcValuesMetadata jdbcResultsMetadata,
 			int resultPosition,
-			BiFunction<String, String, DynamicFetchBuilderLegacy> legacyFetchResolver,
+			BiFunction<String, Fetchable, DynamicFetchBuilderLegacy> legacyFetchResolver,
 			DomainResultCreationState domainResultCreationState) {
 		return buildResultOrFetch(
 				(tableGroup) -> (EntityResult) entityMapping.createDomainResult(
@@ -278,27 +272,10 @@ public class DynamicResultBuilderEntityStandard
 		}
 
 		try {
-			final Map.Entry<String, NavigablePath> currentRelativePath = creationState.getCurrentRelativePath();
-			final String prefix;
-			if ( currentRelativePath == null ) {
-				prefix = "";
-			}
-			else {
-				prefix = currentRelativePath.getKey()
-						.replace( ELEMENT_PREFIX, "" )
-						.replace( INDEX_PREFIX, "" ) + ".";
-			}
 			creationState.pushExplicitFetchMementoResolver(
-					relativePath -> {
-						if ( relativePath.startsWith( prefix ) ) {
-							final int startIndex;
-							if ( relativePath.regionMatches( prefix.length(), ELEMENT_PREFIX, 0, ELEMENT_PREFIX.length() ) ) {
-								startIndex = prefix.length() + ELEMENT_PREFIX.length();
-							}
-							else {
-								startIndex = prefix.length();
-							}
-							return findFetchBuilder( relativePath.substring( startIndex ) );
+					f -> {
+						if ( f != null ) {
+							return findFetchBuilder( f );
 						}
 						return null;
 					}
@@ -311,11 +288,7 @@ public class DynamicResultBuilderEntityStandard
 	}
 
 	private FetchBuilder findIdFetchBuilder() {
-		final EntityIdentifierMapping identifierMapping = entityMapping.getIdentifierMapping();
-		if ( identifierMapping instanceof SingleAttributeIdentifierMapping ) {
-			return findFetchBuilder( ( (SingleAttributeIdentifierMapping) identifierMapping ).getAttributeName() );
-		}
-		return findFetchBuilder( identifierMapping.getPartName() );
+		return findFetchBuilder( entityMapping.getIdentifierMapping() );
 	}
 
 	private void resolveSqlSelection(
@@ -352,6 +325,18 @@ public class DynamicResultBuilderEntityStandard
 	public DynamicResultBuilderEntityStandard setDiscriminatorAlias(String columnName) {
 		this.discriminatorColumnName = columnName;
 		return this;
+	}
+
+	@Override
+	public NativeQuery.RootReturn addProperty(String propertyName, String columnAlias) {
+		final ModelPart subPart = entityMapping.findSubPart( propertyName );
+		addProperty( (Fetchable) subPart, columnAlias );
+		return this;
+	}
+
+	@Override
+	public NativeQuery.ReturnProperty addProperty(String propertyName) {
+		return addProperty( (Fetchable) entityMapping.findSubPart( propertyName ) );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/query/results/dynamic/DynamicResultBuilderEntityStandard.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/results/dynamic/DynamicResultBuilderEntityStandard.java
@@ -14,6 +14,7 @@ import java.util.function.Function;
 import org.hibernate.LockMode;
 import org.hibernate.engine.FetchTiming;
 import org.hibernate.metamodel.mapping.CollectionPart;
+import org.hibernate.metamodel.mapping.EntityDiscriminatorMapping;
 import org.hibernate.metamodel.mapping.EntityMappingType;
 import org.hibernate.metamodel.mapping.ModelPart;
 import org.hibernate.metamodel.mapping.PluralAttributeMapping;
@@ -262,7 +263,7 @@ public class DynamicResultBuilderEntityStandard
 		}
 
 		if ( discriminatorColumnName != null ) {
-			resolveSqlSelection(
+			resolveDiscriminatorSqlSelection(
 					discriminatorColumnName,
 					tableReference,
 					entityMapping.getDiscriminatorMapping(),
@@ -285,6 +286,25 @@ public class DynamicResultBuilderEntityStandard
 		finally {
 			creationState.popExplicitFetchMementoResolver();
 		}
+	}
+
+	private static void resolveDiscriminatorSqlSelection(String columnAlias, TableReference tableReference, EntityDiscriminatorMapping discriminatorMapping, JdbcValuesMetadata jdbcResultsMetadata, DomainResultCreationState domainResultCreationState) {
+		final DomainResultCreationStateImpl creationStateImpl = impl( domainResultCreationState );
+		creationStateImpl.resolveSqlSelection(
+				ResultsHelper.resolveSqlExpression(
+						creationStateImpl,
+						jdbcResultsMetadata,
+						tableReference,
+						discriminatorMapping,
+						columnAlias
+				),
+				discriminatorMapping.getJdbcMapping().getJdbcJavaType(),
+				null,
+				domainResultCreationState.getSqlAstCreationState()
+						.getCreationContext()
+						.getSessionFactory()
+						.getTypeConfiguration()
+		);
 	}
 
 	private FetchBuilder findIdFetchBuilder() {

--- a/hibernate-core/src/main/java/org/hibernate/query/results/dynamic/DynamicResultBuilderInstantiation.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/results/dynamic/DynamicResultBuilderInstantiation.java
@@ -14,6 +14,7 @@ import org.hibernate.query.results.Builders;
 import org.hibernate.query.results.ResultBuilderInstantiationValued;
 import org.hibernate.sql.results.graph.DomainResult;
 import org.hibernate.sql.results.graph.DomainResultCreationState;
+import org.hibernate.sql.results.graph.Fetchable;
 import org.hibernate.sql.results.graph.instantiation.internal.ArgumentDomainResult;
 import org.hibernate.sql.results.graph.instantiation.internal.DynamicInstantiationResultImpl;
 import org.hibernate.sql.results.jdbc.spi.JdbcValuesMetadata;
@@ -104,7 +105,7 @@ public class DynamicResultBuilderInstantiation<J>
 	public DomainResult<?> buildResult(
 			JdbcValuesMetadata jdbcResultsMetadata,
 			int resultPosition,
-			BiFunction<String, String, DynamicFetchBuilderLegacy> legacyFetchResolver,
+			BiFunction<String, Fetchable, DynamicFetchBuilderLegacy> legacyFetchResolver,
 			DomainResultCreationState domainResultCreationState) {
 		if ( argumentResultBuilders.isEmpty() ) {
 			throw new IllegalStateException( "DynamicResultBuilderInstantiation defined no arguments" );

--- a/hibernate-core/src/main/java/org/hibernate/query/results/dynamic/LegacyFetchResolver.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/results/dynamic/LegacyFetchResolver.java
@@ -5,6 +5,7 @@
 package org.hibernate.query.results.dynamic;
 
 import org.hibernate.query.NativeQuery;
+import org.hibernate.sql.results.graph.Fetchable;
 
 /**
  * Contract for handling Hibernate's legacy way of representing fetches through
@@ -17,5 +18,5 @@ import org.hibernate.query.NativeQuery;
  */
 @FunctionalInterface
 public interface LegacyFetchResolver {
-	DynamicFetchBuilderLegacy resolve(String ownerTableAlias, String fetchedPartPath);
+	DynamicFetchBuilderLegacy resolve(String ownerTableAlias, Fetchable fetched);
 }

--- a/hibernate-core/src/main/java/org/hibernate/query/results/implicit/ImplicitFetchBuilderBasic.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/results/implicit/ImplicitFetchBuilderBasic.java
@@ -21,6 +21,7 @@ import org.hibernate.sql.ast.tree.expression.Expression;
 import org.hibernate.sql.ast.tree.from.TableGroup;
 import org.hibernate.sql.results.graph.DomainResultCreationState;
 import org.hibernate.sql.results.graph.FetchParent;
+import org.hibernate.sql.results.graph.Fetchable;
 import org.hibernate.sql.results.graph.basic.BasicFetch;
 import org.hibernate.sql.results.jdbc.spi.JdbcValuesMetadata;
 
@@ -42,13 +43,14 @@ public class ImplicitFetchBuilderBasic implements ImplicitFetchBuilder, BasicVal
 
 	public ImplicitFetchBuilderBasic(
 			NavigablePath fetchPath,
-			BasicValuedModelPart fetchable,
+			Fetchable fetchable,
+			BasicValuedModelPart basicValuedModelPart,
 			DomainResultCreationState creationState) {
 		this.fetchPath = fetchPath;
-		this.fetchable = fetchable;
+		this.fetchable = basicValuedModelPart;
 		final DomainResultCreationStateImpl creationStateImpl = impl( creationState );
-		final Function<String, FetchBuilder> fetchBuilderResolver = creationStateImpl.getCurrentExplicitFetchMementoResolver();
-		this.fetchBuilder = fetchBuilderResolver.apply( fetchable.getFetchableName() );
+		final Function<Fetchable, FetchBuilder> fetchBuilderResolver = creationStateImpl.getCurrentExplicitFetchMementoResolver();
+		this.fetchBuilder = fetchBuilderResolver.apply( fetchable );
 	}
 
 	@Override
@@ -61,7 +63,7 @@ public class ImplicitFetchBuilderBasic implements ImplicitFetchBuilder, BasicVal
 			FetchParent parent,
 			NavigablePath fetchPath,
 			JdbcValuesMetadata jdbcResultsMetadata,
-			BiFunction<String, String, DynamicFetchBuilderLegacy> legacyFetchResolver,
+			BiFunction<String, Fetchable, DynamicFetchBuilderLegacy> legacyFetchResolver,
 			DomainResultCreationState domainResultCreationState) {
 		if ( fetchBuilder != null ) {
 			return (BasicFetch<?>) fetchBuilder.buildFetch(
@@ -145,9 +147,9 @@ public class ImplicitFetchBuilderBasic implements ImplicitFetchBuilder, BasicVal
 	}
 
 	@Override
-	public void visitFetchBuilders(BiConsumer<String, FetchBuilder> consumer) {
+	public void visitFetchBuilders(BiConsumer<Fetchable, FetchBuilder> consumer) {
 		if ( fetchBuilder != null ) {
-			consumer.accept( fetchPath.getLocalName(), fetchBuilder );
+			consumer.accept( fetchable, fetchBuilder );
 		}
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/query/results/implicit/ImplicitFetchBuilderDiscriminatedAssociation.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/results/implicit/ImplicitFetchBuilderDiscriminatedAssociation.java
@@ -17,6 +17,7 @@ import org.hibernate.sql.ast.tree.from.TableGroupJoin;
 import org.hibernate.sql.results.graph.DomainResultCreationState;
 import org.hibernate.sql.results.graph.Fetch;
 import org.hibernate.sql.results.graph.FetchParent;
+import org.hibernate.sql.results.graph.Fetchable;
 import org.hibernate.sql.results.jdbc.spi.JdbcValuesMetadata;
 
 import static org.hibernate.query.results.ResultsHelper.impl;
@@ -43,7 +44,7 @@ public class ImplicitFetchBuilderDiscriminatedAssociation implements ImplicitFet
 			FetchParent parent,
 			NavigablePath fetchPath,
 			JdbcValuesMetadata jdbcResultsMetadata,
-			BiFunction<String, String, DynamicFetchBuilderLegacy> legacyFetchResolver,
+			BiFunction<String, Fetchable, DynamicFetchBuilderLegacy> legacyFetchResolver,
 			DomainResultCreationState creationState) {
 		final DomainResultCreationStateImpl creationStateImpl = impl( creationState );
 

--- a/hibernate-core/src/main/java/org/hibernate/query/results/implicit/ImplicitFetchBuilderEmbeddable.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/results/implicit/ImplicitFetchBuilderEmbeddable.java
@@ -36,7 +36,7 @@ import static org.hibernate.query.results.ResultsHelper.impl;
 public class ImplicitFetchBuilderEmbeddable implements ImplicitFetchBuilder {
 	private final NavigablePath fetchPath;
 	private final EmbeddableValuedFetchable fetchable;
-	private final Map<NavigablePath, FetchBuilder> fetchBuilders;
+	private final Map<Fetchable, FetchBuilder> fetchBuilders;
 
 	public ImplicitFetchBuilderEmbeddable(
 			NavigablePath fetchPath,
@@ -45,22 +45,20 @@ public class ImplicitFetchBuilderEmbeddable implements ImplicitFetchBuilder {
 		this.fetchPath = fetchPath;
 		this.fetchable = fetchable;
 		final DomainResultCreationStateImpl creationStateImpl = impl( creationState );
-		final Map.Entry<String, NavigablePath> relativePath = creationStateImpl.getCurrentRelativePath();
-		final Function<String, FetchBuilder> fetchBuilderResolver = creationStateImpl.getCurrentExplicitFetchMementoResolver();
+		final Function<Fetchable, FetchBuilder> fetchBuilderResolver = creationStateImpl.getCurrentExplicitFetchMementoResolver();
 		final int size = fetchable.getNumberOfFetchables();
-		final Map<NavigablePath, FetchBuilder> fetchBuilders = CollectionHelper.linkedMapOfSize( size );
+		final Map<Fetchable, FetchBuilder> fetchBuilders = CollectionHelper.linkedMapOfSize( size );
 		for ( int i = 0; i < size; i++ ) {
 			final Fetchable subFetchable = fetchable.getFetchable( i );
-			final NavigablePath subFetchPath = relativePath.getValue().append( subFetchable.getFetchableName() );
-			final FetchBuilder explicitFetchBuilder = fetchBuilderResolver.apply( subFetchPath.getFullPath() );
+			final FetchBuilder explicitFetchBuilder = fetchBuilderResolver.apply( subFetchable );
 			if ( explicitFetchBuilder == null ) {
 				fetchBuilders.put(
-						subFetchPath,
+						subFetchable,
 						Builders.implicitFetchBuilder( fetchPath, subFetchable, creationStateImpl )
 				);
 			}
 			else {
-				fetchBuilders.put( subFetchPath, explicitFetchBuilder );
+				fetchBuilders.put( subFetchable, explicitFetchBuilder );
 			}
 		}
 		this.fetchBuilders = fetchBuilders;
@@ -69,13 +67,13 @@ public class ImplicitFetchBuilderEmbeddable implements ImplicitFetchBuilder {
 	private ImplicitFetchBuilderEmbeddable(ImplicitFetchBuilderEmbeddable original) {
 		this.fetchPath = original.fetchPath;
 		this.fetchable = original.fetchable;
-		final Map<NavigablePath, FetchBuilder> fetchBuilders;
+		final Map<Fetchable, FetchBuilder> fetchBuilders;
 		if ( original.fetchBuilders.isEmpty() ) {
 			fetchBuilders = Collections.emptyMap();
 		}
 		else {
 			fetchBuilders = new HashMap<>( original.fetchBuilders.size() );
-			for ( Map.Entry<NavigablePath, FetchBuilder> entry : original.fetchBuilders.entrySet() ) {
+			for ( Map.Entry<Fetchable, FetchBuilder> entry : original.fetchBuilders.entrySet() ) {
 				fetchBuilders.put( entry.getKey(), entry.getValue().cacheKeyInstance() );
 			}
 		}
@@ -92,7 +90,7 @@ public class ImplicitFetchBuilderEmbeddable implements ImplicitFetchBuilder {
 			FetchParent parent,
 			NavigablePath fetchPath,
 			JdbcValuesMetadata jdbcResultsMetadata,
-			BiFunction<String, String, DynamicFetchBuilderLegacy> legacyFetchResolver,
+			BiFunction<String, Fetchable, DynamicFetchBuilderLegacy> legacyFetchResolver,
 			DomainResultCreationState creationState) {
 		final DomainResultCreationStateImpl creationStateImpl = impl( creationState );
 
@@ -168,7 +166,7 @@ public class ImplicitFetchBuilderEmbeddable implements ImplicitFetchBuilder {
 	}
 
 	@Override
-	public void visitFetchBuilders(BiConsumer<String, FetchBuilder> consumer) {
-		fetchBuilders.forEach( (k, v) -> consumer.accept( k.getLocalName(), v ) );
+	public void visitFetchBuilders(BiConsumer<Fetchable, FetchBuilder> consumer) {
+		fetchBuilders.forEach( (k, v) -> consumer.accept( k, v ) );
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/query/results/implicit/ImplicitFetchBuilderEntity.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/results/implicit/ImplicitFetchBuilderEntity.java
@@ -36,7 +36,7 @@ import static org.hibernate.query.results.ResultsHelper.impl;
 public class ImplicitFetchBuilderEntity implements ImplicitFetchBuilder {
 	private final NavigablePath fetchPath;
 	private final ToOneAttributeMapping fetchable;
-	private final Map<NavigablePath, FetchBuilder> fetchBuilders;
+	private final Map<Fetchable, FetchBuilder> fetchBuilders;
 
 	public ImplicitFetchBuilderEntity(
 			NavigablePath fetchPath,
@@ -45,26 +45,25 @@ public class ImplicitFetchBuilderEntity implements ImplicitFetchBuilder {
 		this.fetchPath = fetchPath;
 		this.fetchable = fetchable;
 		final DomainResultCreationStateImpl creationStateImpl = impl( creationState );
-		final Map.Entry<String, NavigablePath> relativePath = creationStateImpl.getCurrentRelativePath();
-		final Function<String, FetchBuilder> fetchBuilderResolver = creationStateImpl.getCurrentExplicitFetchMementoResolver();
+		final Function<Fetchable, FetchBuilder> fetchBuilderResolver = creationStateImpl.getCurrentExplicitFetchMementoResolver();
 		ForeignKeyDescriptor foreignKeyDescriptor = fetchable.getForeignKeyDescriptor();
 		final String associationKeyPropertyName;
-		final NavigablePath associationKeyFetchPath;
+		final Fetchable associationKey;
 		if ( fetchable.getReferencedPropertyName() == null ) {
 			associationKeyPropertyName = fetchable.getEntityMappingType().getIdentifierMapping().getPartName();
-			associationKeyFetchPath = relativePath.getValue().append( associationKeyPropertyName );
+			associationKey = (Fetchable) fetchable.findSubPart( associationKeyPropertyName );
 		}
 		else {
 			associationKeyPropertyName = fetchable.getReferencedPropertyName();
-			NavigablePath path = relativePath.getValue();
+			String keyName = associationKeyPropertyName;
 			for ( String part : StringHelper.split( ".", associationKeyPropertyName ) ) {
-				path = path.append( part );
+				keyName = part;
 			}
-			associationKeyFetchPath = path;
+			associationKey = (Fetchable) fetchable.findSubPart( keyName );
 		}
 		final FetchBuilder explicitAssociationKeyFetchBuilder = fetchBuilderResolver
-				.apply( relativePath.getKey() + "." + associationKeyPropertyName );
-		final Map<NavigablePath, FetchBuilder> fetchBuilders;
+				.apply( fetchable );
+		final Map<Fetchable, FetchBuilder> fetchBuilders;
 		if ( explicitAssociationKeyFetchBuilder == null ) {
 			final MappingType partMappingType = foreignKeyDescriptor.getPartMappingType();
 			if ( partMappingType instanceof EmbeddableMappingType ) {
@@ -73,16 +72,15 @@ public class ImplicitFetchBuilderEntity implements ImplicitFetchBuilder {
 				fetchBuilders = CollectionHelper.linkedMapOfSize( size );
 				for ( int i = 0; i < size; i++ ) {
 					final Fetchable subFetchable = embeddableValuedModelPart.getFetchable( i );
-					final NavigablePath subFetchPath = associationKeyFetchPath.append( subFetchable.getFetchableName() );
-					final FetchBuilder explicitFetchBuilder = fetchBuilderResolver.apply( subFetchPath.getFullPath() );
+					final FetchBuilder explicitFetchBuilder = fetchBuilderResolver.apply( subFetchable );
 					if ( explicitFetchBuilder == null ) {
 						fetchBuilders.put(
-								subFetchPath,
+								subFetchable,
 								Builders.implicitFetchBuilder( fetchPath, subFetchable, creationStateImpl )
 						);
 					}
 					else {
-						fetchBuilders.put( subFetchPath, explicitFetchBuilder );
+						fetchBuilders.put( subFetchable, explicitFetchBuilder );
 					}
 				}
 			}
@@ -91,7 +89,7 @@ public class ImplicitFetchBuilderEntity implements ImplicitFetchBuilder {
 			}
 		}
 		else {
-			fetchBuilders = Collections.singletonMap( associationKeyFetchPath, explicitAssociationKeyFetchBuilder );
+			fetchBuilders = Collections.singletonMap( associationKey, explicitAssociationKeyFetchBuilder );
 		}
 		this.fetchBuilders = fetchBuilders;
 	}
@@ -99,13 +97,13 @@ public class ImplicitFetchBuilderEntity implements ImplicitFetchBuilder {
 	private ImplicitFetchBuilderEntity(ImplicitFetchBuilderEntity original) {
 		this.fetchPath = original.fetchPath;
 		this.fetchable = original.fetchable;
-		final Map<NavigablePath, FetchBuilder> fetchBuilders;
+		final Map<Fetchable, FetchBuilder> fetchBuilders;
 		if ( original.fetchBuilders.isEmpty() ) {
 			fetchBuilders = Collections.emptyMap();
 		}
 		else {
 			fetchBuilders = new HashMap<>( original.fetchBuilders.size() );
-			for ( Map.Entry<NavigablePath, FetchBuilder> entry : original.fetchBuilders.entrySet() ) {
+			for ( Map.Entry<Fetchable, FetchBuilder> entry : original.fetchBuilders.entrySet() ) {
 				fetchBuilders.put( entry.getKey(), entry.getValue().cacheKeyInstance() );
 			}
 		}
@@ -122,7 +120,7 @@ public class ImplicitFetchBuilderEntity implements ImplicitFetchBuilder {
 			FetchParent parent,
 			NavigablePath fetchPath,
 			JdbcValuesMetadata jdbcResultsMetadata,
-			BiFunction<String, String, DynamicFetchBuilderLegacy> legacyFetchResolver,
+			BiFunction<String, Fetchable, DynamicFetchBuilderLegacy> legacyFetchResolver,
 			DomainResultCreationState creationState) {
 		final Fetch fetch = parent.generateFetchableFetch(
 				fetchable,
@@ -147,8 +145,8 @@ public class ImplicitFetchBuilderEntity implements ImplicitFetchBuilder {
 	}
 
 	@Override
-	public void visitFetchBuilders(BiConsumer<String, FetchBuilder> consumer) {
-		fetchBuilders.forEach( (k, v) -> consumer.accept( k.getLocalName(), v ) );
+	public void visitFetchBuilders(BiConsumer<Fetchable, FetchBuilder> consumer) {
+		fetchBuilders.forEach( (k, v) -> consumer.accept( k, v ) );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/query/results/implicit/ImplicitFetchBuilderEntityPart.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/results/implicit/ImplicitFetchBuilderEntityPart.java
@@ -14,6 +14,7 @@ import org.hibernate.query.results.dynamic.DynamicFetchBuilderLegacy;
 import org.hibernate.sql.results.graph.DomainResultCreationState;
 import org.hibernate.sql.results.graph.Fetch;
 import org.hibernate.sql.results.graph.FetchParent;
+import org.hibernate.sql.results.graph.Fetchable;
 import org.hibernate.sql.results.jdbc.spi.JdbcValuesMetadata;
 
 /**
@@ -38,7 +39,7 @@ public class ImplicitFetchBuilderEntityPart implements ImplicitFetchBuilder {
 			FetchParent parent,
 			NavigablePath fetchPath,
 			JdbcValuesMetadata jdbcResultsMetadata,
-			BiFunction<String, String, DynamicFetchBuilderLegacy> legacyFetchResolver,
+			BiFunction<String, Fetchable, DynamicFetchBuilderLegacy> legacyFetchResolver,
 			DomainResultCreationState creationState) {
 		return parent.generateFetchableFetch(
 				fetchable,

--- a/hibernate-core/src/main/java/org/hibernate/query/results/implicit/ImplicitFetchBuilderPlural.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/results/implicit/ImplicitFetchBuilderPlural.java
@@ -13,6 +13,7 @@ import org.hibernate.query.results.dynamic.DynamicFetchBuilderLegacy;
 import org.hibernate.sql.results.graph.DomainResultCreationState;
 import org.hibernate.sql.results.graph.Fetch;
 import org.hibernate.sql.results.graph.FetchParent;
+import org.hibernate.sql.results.graph.Fetchable;
 import org.hibernate.sql.results.jdbc.spi.JdbcValuesMetadata;
 
 
@@ -41,7 +42,7 @@ public class ImplicitFetchBuilderPlural implements ImplicitFetchBuilder {
 			FetchParent parent,
 			NavigablePath fetchPath,
 			JdbcValuesMetadata jdbcResultsMetadata,
-			BiFunction<String, String, DynamicFetchBuilderLegacy> legacyFetchResolver,
+			BiFunction<String, Fetchable, DynamicFetchBuilderLegacy> legacyFetchResolver,
 			DomainResultCreationState creationState) {
 
 		final Fetch fetch = parent.generateFetchableFetch(

--- a/hibernate-core/src/main/java/org/hibernate/query/results/implicit/ImplicitModelPartResultBuilderBasic.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/results/implicit/ImplicitModelPartResultBuilderBasic.java
@@ -15,6 +15,7 @@ import org.hibernate.query.results.ResultsHelper;
 import org.hibernate.query.results.dynamic.DynamicFetchBuilderLegacy;
 import org.hibernate.sql.ast.tree.from.TableGroup;
 import org.hibernate.sql.results.graph.DomainResultCreationState;
+import org.hibernate.sql.results.graph.Fetchable;
 import org.hibernate.sql.results.graph.basic.BasicResult;
 import org.hibernate.sql.results.jdbc.spi.JdbcValuesMetadata;
 
@@ -45,7 +46,7 @@ public class ImplicitModelPartResultBuilderBasic
 	public BasicResult<?> buildResult(
 			JdbcValuesMetadata jdbcResultsMetadata,
 			int resultPosition,
-			BiFunction<String, String, DynamicFetchBuilderLegacy> legacyFetchResolver,
+			BiFunction<String, Fetchable, DynamicFetchBuilderLegacy> legacyFetchResolver,
 			DomainResultCreationState domainResultCreationState) {
 		final DomainResultCreationStateImpl creationStateImpl = ResultsHelper.impl( domainResultCreationState );
 

--- a/hibernate-core/src/main/java/org/hibernate/query/results/implicit/ImplicitModelPartResultBuilderEmbeddable.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/results/implicit/ImplicitModelPartResultBuilderEmbeddable.java
@@ -17,6 +17,7 @@ import org.hibernate.sql.ast.SqlAstJoinType;
 import org.hibernate.sql.ast.tree.from.TableGroup;
 import org.hibernate.sql.ast.tree.from.TableGroupJoin;
 import org.hibernate.sql.results.graph.DomainResultCreationState;
+import org.hibernate.sql.results.graph.Fetchable;
 import org.hibernate.sql.results.graph.embeddable.EmbeddableResult;
 import org.hibernate.sql.results.jdbc.spi.JdbcValuesMetadata;
 
@@ -50,7 +51,7 @@ public class ImplicitModelPartResultBuilderEmbeddable
 	public EmbeddableResult buildResult(
 			JdbcValuesMetadata jdbcResultsMetadata,
 			int resultPosition,
-			BiFunction<String, String, DynamicFetchBuilderLegacy> legacyFetchResolver,
+			BiFunction<String, Fetchable, DynamicFetchBuilderLegacy> legacyFetchResolver,
 			DomainResultCreationState domainResultCreationState) {
 		final DomainResultCreationStateImpl creationStateImpl = ResultsHelper.impl( domainResultCreationState );
 		creationStateImpl.disallowPositionalSelections();

--- a/hibernate-core/src/main/java/org/hibernate/query/results/implicit/ImplicitModelPartResultBuilderEntity.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/results/implicit/ImplicitModelPartResultBuilderEntity.java
@@ -16,6 +16,7 @@ import org.hibernate.query.results.ResultsHelper;
 import org.hibernate.query.results.dynamic.DynamicFetchBuilderLegacy;
 import org.hibernate.sql.ast.tree.from.TableGroup;
 import org.hibernate.sql.results.graph.DomainResultCreationState;
+import org.hibernate.sql.results.graph.Fetchable;
 import org.hibernate.sql.results.graph.entity.EntityResult;
 import org.hibernate.sql.results.jdbc.spi.JdbcValuesMetadata;
 
@@ -53,7 +54,7 @@ public class ImplicitModelPartResultBuilderEntity
 	public EntityResult buildResult(
 			JdbcValuesMetadata jdbcResultsMetadata,
 			int resultPosition,
-			BiFunction<String, String, DynamicFetchBuilderLegacy> legacyFetchResolver,
+			BiFunction<String, Fetchable, DynamicFetchBuilderLegacy> legacyFetchResolver,
 			DomainResultCreationState domainResultCreationState) {
 		final DomainResultCreationStateImpl creationStateImpl = ResultsHelper.impl( domainResultCreationState );
 		creationStateImpl.disallowPositionalSelections();

--- a/hibernate-core/src/main/java/org/hibernate/query/results/implicit/ImplicitResultClassBuilder.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/results/implicit/ImplicitResultClassBuilder.java
@@ -15,6 +15,7 @@ import org.hibernate.sql.ast.spi.SqlExpressionResolver;
 import org.hibernate.sql.ast.spi.SqlSelection;
 import org.hibernate.sql.results.graph.DomainResult;
 import org.hibernate.sql.results.graph.DomainResultCreationState;
+import org.hibernate.sql.results.graph.Fetchable;
 import org.hibernate.sql.results.graph.basic.BasicResult;
 import org.hibernate.sql.results.jdbc.spi.JdbcValuesMetadata;
 import org.hibernate.type.BasicType;
@@ -39,7 +40,7 @@ public class ImplicitResultClassBuilder implements ResultBuilder {
 	public DomainResult<?> buildResult(
 			JdbcValuesMetadata jdbcResultsMetadata,
 			int resultPosition,
-			BiFunction<String, String, DynamicFetchBuilderLegacy> legacyFetchResolver,
+			BiFunction<String, Fetchable, DynamicFetchBuilderLegacy> legacyFetchResolver,
 			DomainResultCreationState domainResultCreationState) {
 		assert resultPosition == 0;
 

--- a/hibernate-core/src/main/java/org/hibernate/sql/ast/spi/SqlExpressionResolver.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/ast/spi/SqlExpressionResolver.java
@@ -6,10 +6,10 @@ package org.hibernate.sql.ast.spi;
 
 import java.util.function.Function;
 
+import org.hibernate.metamodel.mapping.EntityDiscriminatorMapping;
 import org.hibernate.metamodel.mapping.JdbcMapping;
 import org.hibernate.metamodel.mapping.SelectableMapping;
 import org.hibernate.metamodel.mapping.SelectablePath;
-import org.hibernate.metamodel.mapping.internal.DiscriminatorTypeImpl;
 import org.hibernate.sql.ast.tree.expression.ColumnReference;
 import org.hibernate.sql.ast.tree.expression.Expression;
 import org.hibernate.sql.ast.tree.expression.NestedColumnReference;
@@ -91,6 +91,15 @@ public interface SqlExpressionResolver {
 		return createColumnReferenceKey( tableReference, selectable.getSelectablePath(), selectable.getJdbcMapping() );
 	}
 
+	/**
+	 * Convenience form for creating a key from TableReference and EntityDiscriminatorMapping
+	 */
+	static ColumnReferenceKey createDiscriminatorColumnReferenceKey(TableReference tableReference, EntityDiscriminatorMapping discriminatorMapping) {
+		assert tableReference.containsAffectedTableName( discriminatorMapping.getContainingTableExpression() )
+				: String.format( ROOT, "Expecting tables to match between TableReference (%s) and SelectableMapping (%s)", tableReference.getTableId(), discriminatorMapping.getContainingTableExpression() );
+		return createColumnReferenceKey( tableReference, discriminatorMapping.getSelectablePath(), discriminatorMapping.getUnderlyingJdbcMapping() );
+	}
+
 	default Expression resolveSqlExpression(TableReference tableReference, SelectableMapping selectableMapping) {
 		return resolveSqlExpression(
 				createColumnReferenceKey( tableReference, selectableMapping ),
@@ -127,12 +136,7 @@ public interface SqlExpressionResolver {
 		public ColumnReferenceKey(String tableQualifier, SelectablePath selectablePath, JdbcMapping jdbcMapping) {
 			this.tableQualifier = tableQualifier;
 			this.selectablePath = selectablePath;
-			if ( jdbcMapping instanceof DiscriminatorTypeImpl discriminatorType ) {
-				this.jdbcMapping = discriminatorType.getUnderlyingJdbcMapping();
-			}
-			else {
-				this.jdbcMapping = jdbcMapping;
-			}
+			this.jdbcMapping = jdbcMapping;
 		}
 
 		@Override

--- a/hibernate-core/src/main/java/org/hibernate/sql/ast/spi/SqlExpressionResolver.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/ast/spi/SqlExpressionResolver.java
@@ -9,6 +9,7 @@ import java.util.function.Function;
 import org.hibernate.metamodel.mapping.JdbcMapping;
 import org.hibernate.metamodel.mapping.SelectableMapping;
 import org.hibernate.metamodel.mapping.SelectablePath;
+import org.hibernate.metamodel.mapping.internal.DiscriminatorTypeImpl;
 import org.hibernate.sql.ast.tree.expression.ColumnReference;
 import org.hibernate.sql.ast.tree.expression.Expression;
 import org.hibernate.sql.ast.tree.expression.NestedColumnReference;
@@ -126,7 +127,12 @@ public interface SqlExpressionResolver {
 		public ColumnReferenceKey(String tableQualifier, SelectablePath selectablePath, JdbcMapping jdbcMapping) {
 			this.tableQualifier = tableQualifier;
 			this.selectablePath = selectablePath;
-			this.jdbcMapping = jdbcMapping;
+			if ( jdbcMapping instanceof DiscriminatorTypeImpl discriminatorType ) {
+				this.jdbcMapping = discriminatorType.getUnderlyingJdbcMapping();
+			}
+			else {
+				this.jdbcMapping = jdbcMapping;
+			}
 		}
 
 		@Override

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/inheritance/SingleTableNativeQueryTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/inheritance/SingleTableNativeQueryTest.java
@@ -1,0 +1,456 @@
+/*
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.inheritance;
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.DiscriminatorColumn;
+import jakarta.persistence.DiscriminatorType;
+import jakarta.persistence.DiscriminatorValue;
+import jakarta.persistence.Embeddable;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Inheritance;
+import jakarta.persistence.InheritanceType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.JiraKey;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.core.Is.is;
+
+@JiraKey("HHH-18610")
+@DomainModel(
+		annotatedClasses = {
+				SingleTableNativeQueryTest.Toy.class,
+				SingleTableNativeQueryTest.Color.class,
+				SingleTableNativeQueryTest.Family.class,
+				SingleTableNativeQueryTest.Person.class,
+				SingleTableNativeQueryTest.Child.class,
+				SingleTableNativeQueryTest.Man.class,
+				SingleTableNativeQueryTest.Woman.class
+		}
+)
+@SessionFactory
+public class SingleTableNativeQueryTest {
+
+	@BeforeEach
+	public void setUp(SessionFactoryScope scope) {
+		scope.inTransaction(
+				session -> {
+					Toy marioToy;
+					Toy fidgetSpinner;
+					Man john;
+					Woman jane;
+					Child susan;
+					Child mark;
+					Family family;
+					List<Child> children;
+					List<Person> familyMembers;
+
+					marioToy = new Toy( 1L, "Super Mario retro Mushroom" );
+					fidgetSpinner = new Toy( 2L, "Fidget Spinner" );
+					john = new Man( "John", "Riding Roller Coasters" );
+					jane = new Woman( "Jane", "Hippotherapist" );
+					susan = new Child( "Susan", marioToy );
+					mark = new Child( "Mark", fidgetSpinner );
+					family = new Family( "McCloud" );
+					children = new ArrayList<>( Arrays.asList( susan, mark ) );
+					familyMembers = Arrays.asList( john, jane, susan, mark );
+
+
+					session.persist( marioToy );
+					session.persist( fidgetSpinner );
+
+					jane.setColor( new Color( "pink" ) );
+					jane.setHusband( john );
+					jane.setChildren( children );
+
+					john.setColor( new Color( "blue" ) );
+					john.setWife( jane );
+					john.setChildren( children );
+
+					for ( Child child : children ) {
+						child.setFather( john );
+						child.setMother( jane );
+					}
+
+					for ( Person person : familyMembers ) {
+						family.add( person );
+					}
+
+					session.persist( family );
+				} );
+	}
+
+	@AfterEach
+	public void tearDown(SessionFactoryScope scope) {
+		scope.getSessionFactory().getSchemaManager().truncateMappedObjects();
+	}
+
+	@Test
+	public void itShouldGetPersons(SessionFactoryScope scope) {
+		scope.inTransaction(
+				session -> {
+					List<Object> results = session.createNativeQuery( "select {p.*} from person p order by p.name",
+							Object.class ).addEntity( "p", Person.class ).list();
+					assertThat( results.stream().map( p -> ((Person) p).getName() ).collect( Collectors.toList() ),
+							contains( "Jane", "John", "Mark", "Susan" ) );
+				}
+		);
+	}
+
+	@Test
+	public void itShouldGetWife(SessionFactoryScope scope) {
+		scope.inTransaction(
+				session -> {
+					List<Object[]> results = session.createNativeQuery(
+									"select {m.*}, {w.*} from person m left join person w on m.wife_name = w.name where m.TYPE = 'MAN'",
+									Object[].class )
+							.addEntity( "m", Person.class )
+							.addEntity( "w", Person.class )
+							.list();
+					assertThat( results.size(), is( 1 ) );
+					assertThat( results.get( 0 )[0], instanceOf( Man.class ) );
+					assertThat( ((Man) results.get( 0 )[0]).getName(), is( "John" ) );
+					assertThat( results.get( 0 )[1], instanceOf( Woman.class ) );
+					assertThat( ((Woman) results.get( 0 )[1]).getName(), is( "Jane" ) );
+				}
+		);
+	}
+
+	@Test
+	public void itShouldGetFamilyMembers(SessionFactoryScope scope) {
+		scope.inTransaction(
+				session -> {
+					List<Object> results = session.createNativeQuery( "select {f.*} from family f", Object.class )
+							.addEntity( "f", Family.class ).list();
+					Family family = (Family) results.get( 0 );
+					List<Person> members = family.getMembers();
+					assertThat( members.size(), is( 4 ) );
+				}
+		);
+	}
+
+	@Embeddable
+	public static class Color {
+		@Column(name = "color")
+		private String attributes;
+
+		public Color() {
+		}
+
+		public Color(final String attributes) {
+			this.attributes = attributes;
+		}
+
+		public String getAttributes() {
+			return attributes;
+		}
+
+		public void setAttributes(final String attributes) {
+			this.attributes = attributes;
+		}
+	}
+
+	@Entity(name = "Family")
+	@Table(name = "family")
+	public static class Family {
+
+		@Id
+		private String name;
+
+		@OneToMany(mappedBy = "familyName", cascade = CascadeType.ALL, orphanRemoval = true)
+		private List<Person> members = new ArrayList<>();
+
+		public Family() {
+		}
+
+		public Family(String name) {
+			this.name = name;
+		}
+
+		public String getName() {
+			return name;
+		}
+
+		public void setName(String name) {
+			this.name = name;
+		}
+
+		public List<Person> getMembers() {
+			return members;
+		}
+
+		public void setMembers(List<Person> members) {
+			this.members = members;
+		}
+
+		public void add(Person person) {
+			person.setFamilyName( this );
+			members.add( person );
+		}
+
+		@Override
+		public String toString() {
+			return "Family [name=" + name + "]";
+		}
+	}
+
+	@Entity(name = "Person")
+	@Table(name = "person")
+	@Inheritance(strategy = InheritanceType.SINGLE_TABLE)
+	@DiscriminatorColumn(name = "TYPE", discriminatorType = DiscriminatorType.STRING)
+	public static class Person {
+
+		@Id
+		private String name;
+
+		@ManyToOne
+		private Family familyName;
+
+		public Person() {
+		}
+
+		public Person(String name) {
+			this.name = name;
+		}
+
+
+		public String getName() {
+			return name;
+		}
+
+		public void setName(String name) {
+			this.name = name;
+		}
+
+		public Family getFamilyName() {
+			return familyName;
+		}
+
+		public void setFamilyName(Family familyName) {
+			this.familyName = familyName;
+		}
+
+		@Override
+		public String toString() {
+			return name;
+		}
+	}
+
+
+	@Entity(name = "Toy")
+	@Table(name = "toy")
+	public static class Toy {
+
+		@Id
+		private Long id;
+
+		private String name;
+
+		@OneToMany(mappedBy = "favoriteThing", cascade = CascadeType.ALL, orphanRemoval = true)
+		List<Child> favorite = new ArrayList<>();
+
+		public Toy() {
+		}
+
+		public Toy(final Long id, final String name) {
+			this.id = id;
+			this.name = name;
+		}
+
+		public Long getId() {
+			return id;
+		}
+
+		public void setId(final Long id) {
+			this.id = id;
+		}
+
+		public String getName() {
+			return name;
+		}
+
+		public void setName(final String name) {
+			this.name = name;
+		}
+	}
+
+	@Entity(name = "Child")
+	@DiscriminatorValue("CHILD")
+	public static class Child extends Person {
+
+		@ManyToOne
+		@JoinColumn(name = "fav_toy")
+		private Toy favoriteThing;
+
+		@ManyToOne
+		private Woman mother;
+
+		@ManyToOne
+		private Man father;
+
+		public Child() {
+		}
+
+		public Child(String name, Toy favouriteThing) {
+			super( name );
+			this.favoriteThing = favouriteThing;
+		}
+
+		public Toy getFavoriteThing() {
+			return favoriteThing;
+		}
+
+		public void setFavoriteThing(Toy favouriteThing) {
+			this.favoriteThing = favouriteThing;
+		}
+
+		public Man getFather() {
+			return father;
+		}
+
+		public void setFather(Man father) {
+			this.father = father;
+		}
+
+		public Woman getMother() {
+			return mother;
+		}
+
+		public void setMother(Woman mother) {
+			this.mother = mother;
+		}
+	}
+
+	@Entity(name = "Man")
+	@DiscriminatorValue("MAN")
+	public static class Man extends Person {
+
+		private Color color;
+
+		@Column(name = "fav_hobby")
+		private String favoriteThing;
+
+		@OneToOne
+		private Woman wife;
+
+		@OneToMany(mappedBy = "father")
+		private List<Child> children = new ArrayList<>();
+
+		public Man() {
+		}
+
+		public Man(String name, String favoriteThing) {
+			super( name );
+			this.favoriteThing = favoriteThing;
+		}
+
+		public String getFavoriteThing() {
+			return favoriteThing;
+		}
+
+		public void setFavoriteThing(String favoriteThing) {
+			this.favoriteThing = favoriteThing;
+		}
+
+		public Woman getWife() {
+			return wife;
+		}
+
+		public void setWife(Woman wife) {
+			this.wife = wife;
+		}
+
+		public List<Child> getChildren() {
+			return children;
+		}
+
+		public void setChildren(List<Child> children) {
+			this.children = children;
+		}
+
+		public Color getColor() {
+			return color;
+		}
+
+		public void setColor(final Color color) {
+			this.color = color;
+		}
+	}
+
+	@Entity(name = "Woman")
+	@DiscriminatorValue("WOMAN")
+	public static class Woman extends Person {
+
+		private Color color;
+
+		private String job;
+
+		@OneToOne
+		private Man husband;
+
+		@OneToMany(mappedBy = "mother")
+		private List<Child> children = new ArrayList<>();
+
+		public Woman() {
+		}
+
+		public Woman(String name, String job) {
+			super( name );
+			this.job = job;
+		}
+
+
+		public String getJob() {
+			return job;
+		}
+
+		public void setJob(String job) {
+			this.job = job;
+		}
+
+		public Man getHusband() {
+			return husband;
+		}
+
+		public void setHusband(Man husband) {
+			this.husband = husband;
+		}
+
+		public List<Child> getChildren() {
+			return children;
+		}
+
+		public void setChildren(List<Child> children) {
+			this.children = children;
+		}
+
+		public Color getColor() {
+			return color;
+		}
+
+		public void setColor(final Color color) {
+			this.color = color;
+		}
+	}
+}


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-18610

the main change is to use `Fetchable` instead of the simple attribute name as key for `FetchBuilders`, this should fix the problem with subclasses having properties with the same name but different columns.

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
