### PR TITLE
HHH-18824. Test showing many queries on insert.

### DIFF
--- a/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/join/Book.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/join/Book.java
@@ -1,0 +1,45 @@
+package org.hibernate.orm.test.annotations.join;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.JoinTable;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+
+import java.util.Collection;
+
+@Entity
+@Table(name = "BOOKS")
+public class Book {
+
+	private long bookId;
+
+	private Collection<Page> pages;
+
+	@Id
+	@GeneratedValue
+	@Column(name = "BOOK_ID")
+	public long getBookId() {
+		return bookId;
+	}
+
+	public void setBookId(long userid) {
+		this.bookId = userid;
+	}
+
+	@OneToMany(fetch = FetchType.LAZY)
+	@JoinTable(name = "BOOK_PAGES",
+			joinColumns = @JoinColumn(name = "T_BOOK_ID", referencedColumnName = "BOOK_ID"),
+			inverseJoinColumns = @JoinColumn(name = "T_PAGE_ID", referencedColumnName = "PAGE_ID"))
+	public Collection<Page> getPages() {
+		return pages;
+	}
+
+	public void setPages(Collection<Page> groups) {
+		this.pages = groups;
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/join/Page.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/join/Page.java
@@ -1,0 +1,25 @@
+package org.hibernate.orm.test.annotations.join;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import jakarta.persistence.Column;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+
+@Entity
+@Table(name = "PAGES")
+public class Page {
+	private long pageId;
+
+	@Id
+	@GeneratedValue
+	@Column(name = "PAGE_ID")
+	public long getPageId() {
+		return pageId;
+	}
+
+	public void setPageId(long groupId) {
+		this.pageId = groupId;
+	}
+}
+


### PR DESCRIPTION
[A test showing inefficient query behavior on a @OneToMany relation with a JoinTable]

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-18824
<!-- Hibernate GitHub Bot issue links end -->