### PR TITLE
HHH-18834 Optimizer query hints are not available in mysql

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/dialect/Dialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/Dialect.java
@@ -4781,15 +4781,22 @@ public abstract class Dialect implements ConversionContext, TypeContributor, Fun
 			String startToken = matcher.group( 1 );
 			String endToken = matcher.group( 2 );
 
+			// optimizer hint
+			if ( hints.startsWith( "/*+" ) && hints.endsWith( "*/" ) ) {
+				return startToken +
+						" " +
+						hints +
+						" " +
+						endToken;
+			}
+
 			return startToken +
 					" use index (" +
 					hints +
 					") " +
 					endToken;
 		}
-		else {
-			return query;
-		}
+		return query;
 	}
 
 	/**


### PR DESCRIPTION
<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

[Please describe here what your change is about]

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-18834
<!-- Hibernate GitHub Bot issue links end -->