### PR TITLE
Backport HHH-18832 + HHH-18833 to branch 6.6 - Configuration to fail bytecode enhancement instead of skipping it on unsupported models + fix for @Transient properties

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/bytecode/enhance/internal/bytebuddy/ByteBuddyEnhancementContext.java
+++ b/hibernate-core/src/main/java/org/hibernate/bytecode/enhance/internal/bytebuddy/ByteBuddyEnhancementContext.java
@@ -24,6 +24,7 @@ import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.dynamic.scaffold.MethodGraph;
 import net.bytebuddy.matcher.ElementMatcher;
 import net.bytebuddy.pool.TypePool;
+import org.hibernate.bytecode.enhance.spi.UnsupportedEnhancementStrategy;
 
 import static net.bytebuddy.matcher.ElementMatchers.isGetter;
 
@@ -104,6 +105,10 @@ class ByteBuddyEnhancementContext {
 
 	public void registerDiscoveredType(TypeDescription typeDescription, Type.PersistenceType type) {
 		enhancementContext.registerDiscoveredType( new UnloadedTypeDescription( typeDescription ), type );
+	}
+
+	public UnsupportedEnhancementStrategy getUnsupportedEnhancementStrategy() {
+		return enhancementContext.getUnsupportedEnhancementStrategy();
 	}
 
 	public void discoverCompositeTypes(TypeDescription managedCtClass, TypePool typePool) {

--- a/hibernate-core/src/main/java/org/hibernate/bytecode/enhance/internal/bytebuddy/EnhancerImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/bytecode/enhance/internal/bytebuddy/EnhancerImpl.java
@@ -465,6 +465,11 @@ public class EnhancerImpl implements Enhancer {
 			methodFieldName = methodFieldName.substring(0, 1).toLowerCase() + methodFieldName.substring(1);
 			TypeList typeList = methodDescription.getDeclaredAnnotations().asTypeList();
 			if (typeList.stream().anyMatch(typeDefinitions ->
+					(typeDefinitions.getName().equals("jakarta.persistence.Transient")))) {
+				// transient property so ignore it
+				continue;
+			}
+			if (typeList.stream().anyMatch(typeDefinitions ->
 					(typeDefinitions.getName().contains("jakarta.persistence")))) {
 				propertyHasAnnotation = true;
 			}

--- a/hibernate-core/src/main/java/org/hibernate/bytecode/enhance/internal/bytebuddy/EnhancerImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/bytecode/enhance/internal/bytebuddy/EnhancerImpl.java
@@ -25,6 +25,7 @@ import net.bytebuddy.implementation.FieldAccessor;
 import net.bytebuddy.implementation.FixedValue;
 import net.bytebuddy.implementation.Implementation;
 import net.bytebuddy.implementation.StubMethod;
+import org.hibernate.AssertionFailure;
 import org.hibernate.Version;
 import org.hibernate.bytecode.enhance.VersionMismatchException;
 import org.hibernate.bytecode.enhance.internal.tracker.CompositeOwnerTracker;
@@ -35,6 +36,7 @@ import org.hibernate.bytecode.enhance.spi.EnhancementInfo;
 import org.hibernate.bytecode.enhance.spi.Enhancer;
 import org.hibernate.bytecode.enhance.spi.EnhancerConstants;
 import org.hibernate.bytecode.enhance.spi.UnloadedField;
+import org.hibernate.bytecode.enhance.spi.UnsupportedEnhancementStrategy;
 import org.hibernate.bytecode.enhance.spi.interceptor.LazyAttributeLoadingInterceptor;
 import org.hibernate.bytecode.internal.bytebuddy.ByteBuddyState;
 import org.hibernate.engine.spi.CompositeOwner;
@@ -173,7 +175,7 @@ public class EnhancerImpl implements Enhancer {
 		}
 
 		if ( enhancementContext.isEntityClass( managedCtClass ) ) {
-			if ( hasUnsupportedAttributeNaming( managedCtClass ) ) {
+			if ( checkUnsupportedAttributeNaming( managedCtClass ) ) {
 				// do not enhance classes with mismatched names for PROPERTY-access persistent attributes
 				return null;
 			}
@@ -337,7 +339,7 @@ public class EnhancerImpl implements Enhancer {
 			return createTransformer( managedCtClass ).applyTo( builder );
 		}
 		else if ( enhancementContext.isCompositeClass( managedCtClass ) ) {
-			if ( hasUnsupportedAttributeNaming( managedCtClass ) ) {
+			if ( checkUnsupportedAttributeNaming( managedCtClass ) ) {
 				// do not enhance classes with mismatched names for PROPERTY-access persistent attributes
 				return null;
 			}
@@ -377,7 +379,7 @@ public class EnhancerImpl implements Enhancer {
 		else if ( enhancementContext.isMappedSuperclassClass( managedCtClass ) ) {
 
 			// Check for HHH-16572 (PROPERTY attributes with mismatched field and method names)
-			if ( hasUnsupportedAttributeNaming( managedCtClass ) ) {
+			if ( checkUnsupportedAttributeNaming( managedCtClass ) ) {
 				return null;
 			}
 
@@ -401,8 +403,22 @@ public class EnhancerImpl implements Enhancer {
 	 * Check whether an entity class ({@code managedCtClass}) has mismatched names between a persistent field and its
 	 * getter/setter when using {@link AccessType#PROPERTY}, which Hibernate does not currently support for enhancement.
 	 * See https://hibernate.atlassian.net/browse/HHH-16572
+	 *
+	 * @return {@code true} if enhancement of the class must be {@link org.hibernate.bytecode.enhance.spi.UnsupportedEnhancementStrategy#SKIP skipped}
+	 * because it has mismatched names.
+	 * {@code false} if enhancement of the class must proceed, either because it doesn't have any mismatched names,
+	 * or because {@link org.hibernate.bytecode.enhance.spi.UnsupportedEnhancementStrategy#LEGACY legacy mode} was opted into.
+	 * @throws EnhancementException if enhancement of the class must {@link org.hibernate.bytecode.enhance.spi.UnsupportedEnhancementStrategy#FAIL abort} because it has mismatched names.
 	 */
-	private boolean hasUnsupportedAttributeNaming(TypeDescription managedCtClass) {
+	@SuppressWarnings("deprecation")
+	private boolean checkUnsupportedAttributeNaming(TypeDescription managedCtClass) {
+		var strategy = enhancementContext.getUnsupportedEnhancementStrategy();
+		if ( UnsupportedEnhancementStrategy.LEGACY.equals( strategy ) ) {
+			// Don't check anything and act as if there was nothing unsupported in the class.
+			// This is unsafe but that's what LEGACY is about.
+			return false;
+		}
+
 		// For process access rules, See https://jakarta.ee/specifications/persistence/3.2/jakarta-persistence-spec-3.2#default-access-type
 		// and https://jakarta.ee/specifications/persistence/3.2/jakarta-persistence-spec-3.2#a122
 		//
@@ -464,10 +480,23 @@ public class EnhancerImpl implements Enhancer {
 					}
 				}
 			}
-			if (propertyHasAnnotation && !propertyNameMatchesFieldName) {
-				log.debugf("Skipping enhancement of [%s]: due to class [%s] not having a property accessor method name matching field name [%s]",
-						managedCtClass, methodDescription.getDeclaringType().getActualName(), methodFieldName);
-				return true;
+			if ( propertyHasAnnotation && !propertyNameMatchesFieldName ) {
+				switch ( strategy ) {
+					case SKIP:
+						log.debugf(
+								"Skipping enhancement of [%s] because no field named [%s] could be found for property accessor method [%s]."
+										+ " To fix this, make sure all property accessor methods have a matching field.",
+								managedCtClass.getName(), methodFieldName, methodDescription.getName() );
+						return true;
+					case FAIL:
+						throw new EnhancementException( String.format(
+								"Enhancement of [%s] failed because no field named [%s] could be found for property accessor method [%s]."
+										+ " To fix this, make sure all property accessor methods have a matching field.",
+								managedCtClass.getName(), methodFieldName, methodDescription.getName() ) );
+					default:
+						// We shouldn't even be in this method if using LEGACY, see top of this method.
+						throw new AssertionFailure( "Unexpected strategy at this point: " + strategy );
+				}
 			}
 		}
 		return false;

--- a/hibernate-core/src/main/java/org/hibernate/bytecode/enhance/spi/EnhancementContext.java
+++ b/hibernate-core/src/main/java/org/hibernate/bytecode/enhance/spi/EnhancementContext.java
@@ -7,6 +7,7 @@
 package org.hibernate.bytecode.enhance.spi;
 
 import jakarta.persistence.metamodel.Type;
+import org.hibernate.Incubating;
 
 /**
  * The context for performing an enhancement.  Enhancement can happen in any number of ways:<ul>
@@ -146,4 +147,15 @@ public interface EnhancementContext {
 	boolean isDiscoveredType(UnloadedClass classDescriptor);
 
 	void registerDiscoveredType(UnloadedClass classDescriptor, Type.PersistenceType type);
+
+	/**
+	 * @return The expected behavior when encountering a class that cannot be enhanced,
+	 * in particular when attribute names don't match field names.
+	 * @see <a href="https://hibernate.atlassian.net/browse/HHH-16572">HHH-16572</a>
+	 * @see <a href="https://hibernate.atlassian.net/browse/HHH-18833">HHH-18833</a>
+	 */
+	@Incubating
+	default UnsupportedEnhancementStrategy getUnsupportedEnhancementStrategy() {
+		return UnsupportedEnhancementStrategy.SKIP;
+	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/bytecode/enhance/spi/UnsupportedEnhancementStrategy.java
+++ b/hibernate-core/src/main/java/org/hibernate/bytecode/enhance/spi/UnsupportedEnhancementStrategy.java
@@ -1,0 +1,40 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.bytecode.enhance.spi;
+
+import org.hibernate.Incubating;
+
+/**
+ * The expected behavior when encountering a class that cannot be enhanced,
+ * in particular when attribute names don't match field names.
+ *
+ * @see org.hibernate.bytecode.enhance.spi.EnhancementContext#getUnsupportedEnhancementStrategy
+ */
+@Incubating
+public enum UnsupportedEnhancementStrategy {
+
+	/**
+	 * When a class cannot be enhanced, skip enhancement for that class only.
+	 */
+	SKIP,
+	/**
+	 * When a class cannot be enhanced, throw an exception with an actionable message.
+	 */
+	FAIL,
+	/**
+	 * Legacy behavior: when a class cannot be enhanced, ignore that fact and try to enhance it anyway.
+	 * <p>
+	 * <strong>This is utterly unsafe and may cause errors, unpredictable behavior, and data loss.</strong>
+	 * <p>
+	 * Intended only for internal use in contexts with rigid backwards compatibility requirements.
+	 *
+	 * @deprecated Use {@link #SKIP} or {@link #FAIL} instead.
+	 */
+	@Deprecated
+	LEGACY
+
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/access/InvalidPropertyNameTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/access/InvalidPropertyNameTest.java
@@ -1,8 +1,18 @@
 package org.hibernate.orm.test.bytecode.enhancement.access;
 
-import jakarta.persistence.*;
+import jakarta.persistence.Access;
+import jakarta.persistence.AccessType;
+import jakarta.persistence.Basic;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.persistence.Transient;
 import org.hibernate.testing.bytecode.enhancement.extension.BytecodeEnhanced;
-import org.hibernate.testing.orm.junit.*;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.FailureExpected;
+import org.hibernate.testing.orm.junit.JiraKey;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
@@ -11,16 +21,17 @@ import static org.assertj.core.api.Assertions.assertThat;
 @DomainModel(
 		annotatedClasses = {
 				InvalidPropertyNameTest.SomeEntity.class,
+				InvalidPropertyNameTest.SomeEntityWithFalsePositive.class
 		}
 )
 @SessionFactory
-@JiraKey("HHH-16572")
 @BytecodeEnhanced
 public class InvalidPropertyNameTest {
 
 
 	@Test
 	@FailureExpected(jiraKey = "HHH-16572")
+	@JiraKey("HHH-16572")
 	public void test(SessionFactoryScope scope) {
 		scope.inTransaction( session -> {
 			session.persist( new SomeEntity( 1L, "field", "property" ) );
@@ -39,15 +50,40 @@ public class InvalidPropertyNameTest {
 		} );
 	}
 
-	@AfterEach
-	public void cleanup(SessionFactoryScope scope) {
-		// uncomment the following when @FailureExpected is removed above
-		// scope.inTransaction( session -> {
-		//	session.remove( session.get( SomeEntity.class, 1L ) );
-		// PropertyAccessTest} );
+	@Test
+	@JiraKey("HHH-18832")
+	public void testNoFalsePositive(SessionFactoryScope scope) {
+		scope.inTransaction( session -> {
+			session.persist( new SomeEntityWithFalsePositive( 1L, "property1-initial", "property2-initial" ) );
+		} );
+
+		// Before HHH-18832 was fixed, lazy-loading enhancement was (incorrectly) skipped,
+		// resulting at best in `property1` being null in the code below,
+		// at worst in other errors such as java.lang.NoSuchMethodError: 'java.lang.String org.hibernate.orm.test.bytecode.enhancement.access.InvalidPropertyNameTest$SomeEntityWithFalsePositive.$$_hibernate_read_property1()'
+		// (see https://hibernate.zulipchat.com/#narrow/channel/132094-hibernate-orm-dev/topic/HHH-16572/near/481330806)
+		scope.inTransaction( session -> {
+			SomeEntityWithFalsePositive entity = session.getReference( SomeEntityWithFalsePositive.class, 1L );
+			// Lazy-loading triggered by field access
+			// Proves bytecode enhancement is effective
+			assertThat( entity.property1 ).isEqualTo( "property1-initial" );
+		} );
+
+		scope.inTransaction( session -> {
+			SomeEntityWithFalsePositive entity = session.getReference( SomeEntityWithFalsePositive.class, 1L );
+			// Proves bytecode enhancement is effective even for the transient method
+			assertThat( entity.getProperty() ).isEqualTo( "property1-initial property2-initial" );
+		} );
 	}
 
-	@Entity
+	@AfterEach
+	public void cleanup(SessionFactoryScope scope) {
+		scope.inTransaction( session -> {
+			session.createQuery( "delete from SomeEntity" ).executeUpdate();
+			session.createQuery( "delete from SomeEntityWithFalsePositive" ).executeUpdate();
+		} );
+	}
+
+	@Entity(name = "SomeEntity")
 	@Table(name = "SOME_ENTITY")
 	static class SomeEntity {
 		@Id
@@ -82,6 +118,55 @@ public class InvalidPropertyNameTest {
 
 		public void setPropertyMethod(String property) {
 			this.property = property;
+		}
+	}
+
+	@Entity(name = "SomeEntityWithFalsePositive")
+	static class SomeEntityWithFalsePositive {
+
+		private Long id;
+
+		private String property1;
+
+		private String property2;
+
+		public SomeEntityWithFalsePositive() {
+		}
+
+		public SomeEntityWithFalsePositive(Long id, String property1, String property2) {
+			this.id = id;
+			this.property1 = property1;
+			this.property2 = property2;
+		}
+
+		@Id
+		public long getId() {
+			return id;
+		}
+
+		public void setId(long id) {
+			this.id = id;
+		}
+
+		public String getProperty1() {
+			return property1;
+		}
+
+		public void setProperty1(String property1) {
+			this.property1 = property1;
+		}
+
+		public String getProperty2() {
+			return property2;
+		}
+
+		public void setProperty2(String property2) {
+			this.property2 = property2;
+		}
+
+		@Transient
+		public String getProperty() {
+			return property1 + " " + property2;
 		}
 	}
 }

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/access/UnsupportedEnhancementStrategyTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/access/UnsupportedEnhancementStrategyTest.java
@@ -1,0 +1,131 @@
+/*
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.bytecode.enhancement.access;
+
+import jakarta.persistence.Access;
+import jakarta.persistence.AccessType;
+import jakarta.persistence.Basic;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import org.hibernate.bytecode.enhance.internal.bytebuddy.EnhancerImpl;
+import org.hibernate.bytecode.enhance.spi.EnhancementContext;
+import org.hibernate.bytecode.enhance.spi.EnhancementException;
+import org.hibernate.bytecode.enhance.spi.Enhancer;
+import org.hibernate.bytecode.enhance.spi.UnsupportedEnhancementStrategy;
+import org.hibernate.bytecode.internal.bytebuddy.ByteBuddyState;
+import org.hibernate.bytecode.spi.ByteCodeHelper;
+import org.hibernate.testing.bytecode.enhancement.EnhancerTestContext;
+import org.hibernate.testing.orm.junit.JiraKey;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@JiraKey("HHH-18833")
+public class UnsupportedEnhancementStrategyTest {
+
+	@Test
+	public void skip() throws IOException {
+		var context = new EnhancerTestContext() {
+			@Override
+			public UnsupportedEnhancementStrategy getUnsupportedEnhancementStrategy() {
+				// This is currently the default, but we don't care about what's the default here
+				return UnsupportedEnhancementStrategy.SKIP;
+			}
+		};
+		byte[] originalBytes = getAsBytes( SomeEntity.class );
+		byte[] enhancedBytes = doEnhance( SomeEntity.class, originalBytes, context );
+		assertThat( enhancedBytes ).isNull(); // null means "not enhanced"
+	}
+
+	@Test
+	public void fail() throws IOException {
+		var context = new EnhancerTestContext() {
+			@Override
+			public UnsupportedEnhancementStrategy getUnsupportedEnhancementStrategy() {
+				return UnsupportedEnhancementStrategy.FAIL;
+			}
+		};
+		byte[] originalBytes = getAsBytes( SomeEntity.class );
+		assertThatThrownBy( () -> doEnhance( SomeEntity.class, originalBytes, context ) )
+				.isInstanceOf( EnhancementException.class )
+				.hasMessageContainingAll(
+						String.format(
+								"Enhancement of [%s] failed because no field named [%s] could be found for property accessor method [%s].",
+								SomeEntity.class.getName(), "propertyMethod", "getPropertyMethod" ),
+						"To fix this, make sure all property accessor methods have a matching field."
+				);
+	}
+
+	@Test
+	@SuppressWarnings("deprecation")
+	public void legacy() throws IOException {
+		var context = new EnhancerTestContext() {
+			@Override
+			public UnsupportedEnhancementStrategy getUnsupportedEnhancementStrategy() {
+				// This is currently the default, but we don't care about what's the default here
+				return UnsupportedEnhancementStrategy.LEGACY;
+			}
+		};
+		byte[] originalBytes = getAsBytes( SomeEntity.class );
+		byte[] enhancedBytes = doEnhance( SomeEntity.class, originalBytes, context );
+		assertThat( enhancedBytes ).isNotNull(); // non-null means enhancement _was_ performed
+	}
+
+	private byte[] doEnhance(Class<SomeEntity> someEntityClass, byte[] originalBytes, EnhancementContext context) {
+		final ByteBuddyState byteBuddyState = new ByteBuddyState();
+		final Enhancer enhancer = new EnhancerImpl( context, byteBuddyState );
+		return enhancer.enhance( someEntityClass.getName(), originalBytes );
+	}
+
+	private byte[] getAsBytes(Class<?> clazz) throws IOException {
+		final String classFile = clazz.getName().replace( '.', '/' ) + ".class";
+		try (InputStream classFileStream = clazz.getClassLoader().getResourceAsStream( classFile )) {
+			return ByteCodeHelper.readByteCode( classFileStream );
+		}
+	}
+
+	@Entity
+	@Table(name = "SOME_ENTITY")
+	static class SomeEntity {
+		@Id
+		Long id;
+
+		@Basic
+		String field;
+
+		String property;
+
+		public SomeEntity() {
+		}
+
+		public SomeEntity(Long id, String field, String property) {
+			this.id = id;
+			this.field = field;
+			this.property = property;
+		}
+
+		/**
+		 * The following property accessor methods are purposely named incorrectly to
+		 * not match the "property" field.  The HHH-16572 change ensures that
+		 * this entity is not (bytecode) enhanced.  Eventually further changes will be made
+		 * such that this entity is enhanced in which case the FailureExpected can be removed
+		 * and the cleanup() uncommented.
+		 */
+		@Basic
+		@Access(AccessType.PROPERTY)
+		public String getPropertyMethod() {
+			return "from getter: " + property;
+		}
+
+		public void setPropertyMethod(String property) {
+			this.property = property;
+		}
+	}
+}


### PR DESCRIPTION
* [HHH-18833](https://hibernate.atlassian.net/browse/HHH-18833): Configuration to fail bytecode enhancement instead of skipping it on unsupported models
* [HHH-18832](https://hibernate.atlassian.net/browse/HHH-18832): Bytecode enhancement skipped for entities with "compute-only" @Transient properties

Backport of #9222 and #9223 to branch 6.6

[HHH-18833]: https://hibernate.atlassian.net/browse/HHH-18833?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[HHH-18832]: https://hibernate.atlassian.net/browse/HHH-18832?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ