### PR TITLE
Backport of HHH-18841 to 6.6 branch - Create `_identifierMapper` as a synthetic attribute

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/boot/model/internal/EntityBinder.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/internal/EntityBinder.java
@@ -105,6 +105,7 @@ import org.hibernate.mapping.RootClass;
 import org.hibernate.mapping.SimpleValue;
 import org.hibernate.mapping.SingleTableSubclass;
 import org.hibernate.mapping.Subclass;
+import org.hibernate.mapping.SyntheticProperty;
 import org.hibernate.mapping.Table;
 import org.hibernate.mapping.TableOwner;
 import org.hibernate.mapping.UnionSubclass;
@@ -550,7 +551,7 @@ public class EntityBinder {
 				propertyAccessor,
 				isIdClass
 		);
-		final Property mapperProperty = new Property();
+		final Property mapperProperty = new SyntheticProperty();
 		mapperProperty.setName( NavigablePath.IDENTIFIER_MAPPER_PROPERTY );
 		mapperProperty.setUpdateable( false );
 		mapperProperty.setInsertable( false );

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/id/idClass/IdClassSyntheticAttributesTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/id/idClass/IdClassSyntheticAttributesTest.java
@@ -1,0 +1,38 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.orm.test.id.idClass;
+
+import org.hibernate.mapping.PersistentClass;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.DomainModelScope;
+import org.hibernate.testing.orm.junit.Jira;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DomainModel(
+        annotatedClasses = MyEntity.class
+)
+@SessionFactory
+public class IdClassSyntheticAttributesTest {
+
+    @Jira("https://hibernate.atlassian.net/browse/HHH-18841")
+    @Test
+    public void test(DomainModelScope scope) {
+        final PersistentClass entityBinding = scope.getDomainModel().getEntityBinding(MyEntity.class.getName());
+        assertThat(entityBinding.getProperties()).hasSize(2)
+                .anySatisfy(p -> {
+                    assertThat(p.isSynthetic()).isTrue();
+                    assertThat(p.getName()).isEqualTo("_identifierMapper");
+                })
+                .anySatisfy(p -> {
+                    assertThat(p.isSynthetic()).isFalse();
+                    assertThat(p.getName()).isEqualTo("notes");
+                });
+    }
+}


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-18841

A backport of  https://github.com/hibernate/hibernate-orm/pull/9236 to 6.6

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
