### PR TITLE
Fix `.gitattributes` / `.gitignore`

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,17 @@
-* text eol=lf
+# By default, detect text files automatically, and use whatever line terminators make sense for the OS
+* text=auto
+
+# Java files are text, and we want Java-friendly readable hunk headers for diff
+*.java text diff=java
+
+# Force LF/CRLF format for files that are known to require it.
+*.sh text eol=lf
+*.bat text eol=crlf
+
+# For some reason the above is not enough, in particular for gradlew.bat,
+# as some commands (git status, git add --renormalize) will still change its line endings to LF.
+# So, we explicitly tell git not to mess with *.bat line endings.
+# It's annoying as git won't show diffs for these files anymore,
+# but that's the best I could come up with after an hour of head-scratching.
+*.bat binary
+

--- a/.github/hibernate-github-bot.yml
+++ b/.github/hibernate-github-bot.yml
@@ -5,6 +5,7 @@ jira:
   ignoreFiles:
     # Git
     - ".git*"
+    - "*/.git*"
     - ".mailmap"
     # Gradle
     - "gradlew*"
@@ -19,6 +20,7 @@ jira:
     - "ci/"
     - "databases/"
     - "*.sh"
+    - "*.bat"
     - "Jenkinsfile"
     - "*/Jenkinsfile"
     - "*.Jenkinsfile"
@@ -37,6 +39,8 @@ jira:
     - "release/"
     - "rules/"
     - "shared/"
+    - ".sdkmanrc"
+    - "*/.sdkmanrc"
 develocity:
   buildScan:
     addCheck: true

--- a/.gitignore
+++ b/.gitignore
@@ -16,9 +16,7 @@ lib
 
 # IntelliJ specific files/directories
 out
-.idea
-!.idea/codeStyles/Project.xml
-!.idea/inspectionProfiles/Project_Default.xml
+# See .idea/.gitignore for more precise rules in that directory
 *.ipr
 *.iws
 *.iml
@@ -47,10 +45,9 @@ ObjectStore
 *.hprof
 /.nb-gradle/
 
-# Additional databases used in local envs
-databases/mysql/
-databases/postgis/
-
 # Vim
 *.swp
 *.swo
+
+# SDKman, used by some module maintainers
+.sdkmanrc

--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,9 @@
+*
+!.gitignore
+
+# See https://stackoverflow.com/a/67976259/6692043
+!codeStyles/
+!codeStyles/Project.xml
+!codeStyles/codeStyleConfig.xml
+!inspectionProfiles/
+!inspectionProfiles/Project_Default.xml

--- a/.release/.gitignore
+++ b/.release/.gitignore
@@ -1,2 +1,3 @@
 # The folder into which we checkout our release scripts into
 *
+!.gitignore

--- a/databases/.gitignore
+++ b/databases/.gitignore
@@ -1,4 +1,0 @@
-!mariadb/
-!pgsql/
-!derby/
-./

--- a/drivers/.gitignore
+++ b/drivers/.gitignore
@@ -1,1 +1,3 @@
-**/*
+*
+!.gitignore
+!README.adoc

--- a/hibernate-spatial/.gitignore
+++ b/hibernate-spatial/.gitignore
@@ -1,1 +1,0 @@
-.sdkmanrc

--- a/hibernate-spatial/.sdkmanrc
+++ b/hibernate-spatial/.sdkmanrc
@@ -1,4 +1,0 @@
-# Enable auto-env through the sdkman_auto_env config
-# Add key=value pairs of SDKs to use below
-java=8.0.252.hs-adpt
-


### PR DESCRIPTION
Following our discussion here about the current `.gitattributes` messing up checked-in JAR files: https://hibernate.zulipchat.com/#narrow/channel/132094-hibernate-orm-dev/topic/7.2E0.20Beta2.20.2F.206.2E6.2E2/near/481975242
I think this matches @beikov 's original intent more closely, and is safer.

I also noticed a few conflicting/incorrect `.gitignore` files, so I tried to fix what I could...

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
