### PR TITLE
HHH-18842 Regression: CollectionType.replace() breaks if target is PersistentCollection, but not instance of Collection (e.g. PersistentMap)

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/collection/spi/PersistentArrayHolder.java
+++ b/hibernate-core/src/main/java/org/hibernate/collection/spi/PersistentArrayHolder.java
@@ -7,6 +7,7 @@ package org.hibernate.collection.spi;
 import java.io.Serializable;
 import java.lang.reflect.Array;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Iterator;
@@ -92,6 +93,9 @@ public class PersistentArrayHolder<E> extends AbstractPersistentCollection<E> {
 	public Collection getOrphans(Serializable snapshot, String entityName) throws HibernateException {
 		final Object[] sn = (Object[]) snapshot;
 		final Object[] arr = (Object[]) array;
+		if ( arr.length == 0 ) {
+			return Arrays.asList( sn );
+		}
 		final ArrayList result = new ArrayList();
 		Collections.addAll( result, sn );
 		for ( int i=0; i<sn.length; i++ ) {

--- a/hibernate-core/src/main/java/org/hibernate/engine/internal/Cascade.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/internal/Cascade.java
@@ -601,10 +601,20 @@ public final class Cascade {
 			}
 		}
 
+		// a newly instantiated collection can't have orphans
+		final PersistentCollection<?> persistentCollection;
+		if ( child instanceof PersistentCollection<?> pc ) {
+			persistentCollection = pc;
+		}
+		else {
+			persistentCollection = eventSource.getPersistenceContext()
+					.getCollectionHolder( child );
+		}
+
 		final boolean deleteOrphans = style.hasOrphanDelete()
 				&& action.deleteOrphans()
 				&& elemType instanceof EntityType
-				&& child instanceof PersistentCollection<?> persistentCollection
+				&& persistentCollection != null
 				// a newly instantiated collection can't have orphans
 				&& !persistentCollection.isNewlyInstantiated();
 
@@ -617,7 +627,7 @@ public final class Cascade {
 			// 1. newly instantiated collections
 			// 2. arrays (we can't track orphans for detached arrays)
 			final String entityName = collectionType.getAssociatedEntityName( eventSource.getFactory() );
-			deleteOrphans( eventSource, entityName, (PersistentCollection<?>) child );
+			deleteOrphans( eventSource, entityName, persistentCollection );
 
 			if ( traceEnabled ) {
 				LOG.tracev( "Done deleting orphans for collection: {0}", collectionType.getRole() );

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/orphan/onetomany/merge/MergeCascadeWithMapCollectionTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/orphan/onetomany/merge/MergeCascadeWithMapCollectionTest.java
@@ -1,0 +1,200 @@
+/*
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.jpa.orphan.onetomany.merge;
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.JiraKey;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DomainModel(
+		annotatedClasses = {
+				MergeCascadeWithMapCollectionTest.Parent.class,
+				MergeCascadeWithMapCollectionTest.Child.class,
+		}
+)
+@SessionFactory
+@JiraKey("HHH-18842")
+public class MergeCascadeWithMapCollectionTest {
+
+	private static final Long ID_PARENT_WITHOUT_CHILDREN = 1L;
+	private static final Long ID_PARENT_WITH_CHILDREN = 2L;
+
+	@BeforeEach
+	public void setUp(SessionFactoryScope scope) {
+		scope.inTransaction(
+				session -> {
+					Parent parent = new Parent( ID_PARENT_WITHOUT_CHILDREN, "old name" );
+					session.persist( parent );
+
+					Parent parent2 = new Parent( ID_PARENT_WITH_CHILDREN, "old name" );
+					Child child = new Child( 2l, "Child" );
+					parent2.addChild( child );
+
+					session.persist( child );
+					session.persist( parent2 );
+				}
+		);
+	}
+
+	@AfterEach
+	private void tearDown(SessionFactoryScope scope) {
+		scope.inTransaction(
+				session -> {
+					session.createMutationQuery( "delete from Parent" ).executeUpdate();
+					session.createMutationQuery( "delete from Child" ).executeUpdate();
+				}
+		);
+	}
+
+	@Test
+	public void testMergeParentWihoutChildren(SessionFactoryScope scope) {
+		scope.inTransaction(
+				session -> {
+					Parent parent = new Parent( ID_PARENT_WITHOUT_CHILDREN, "new name" );
+					Parent merged = session.merge( parent );
+					assertThat( merged.getName() ).isEqualTo( "new name" );
+				}
+		);
+	}
+
+	@Test
+	public void testMergeParentWithChildren(SessionFactoryScope scope) {
+		scope.inTransaction(
+				session -> {
+					Parent parent = new Parent( ID_PARENT_WITH_CHILDREN, "new name" );
+					Child child = new Child( 2l, "Child" );
+					parent.addChild( child );
+					Parent merged = session.merge( parent );
+					assertThat( merged.getName() ).isEqualTo( "new name" );
+				}
+		);
+		scope.inTransaction(
+				session -> {
+					Parent parent = session.get( Parent.class, ID_PARENT_WITH_CHILDREN );
+					assertThat( parent.getChildren().size() ).isEqualTo( 1 );
+				}
+		);
+	}
+
+	@Test
+	public void testMergeParentWithChildren2(SessionFactoryScope scope) {
+		scope.inTransaction(
+				session -> {
+					Parent parent = new Parent( ID_PARENT_WITH_CHILDREN, "new name" );
+					session.merge( parent );
+				}
+		);
+		scope.inTransaction(
+				session -> {
+					Parent parent = session.get( Parent.class, ID_PARENT_WITH_CHILDREN );
+					assertThat( parent.getName() ).isEqualTo( "new name" );
+					assertThat( parent.getChildren().size() ).isEqualTo( 0 );
+
+					List<Child> children = session.createQuery( "Select c from Child c", Child.class ).list();
+					assertThat( children.size() ).isEqualTo( 1 );
+				}
+		);
+	}
+
+	@Entity(name = "Parent")
+	public static class Parent {
+
+		@Id
+		private Long id;
+
+		private String name;
+
+		@OneToMany(cascade = CascadeType.MERGE)
+		private Map<String, Child> children;
+
+		public Parent() {
+		}
+
+		public Parent(Long id, String name) {
+			this.id = id;
+			this.name = name;
+		}
+
+		public Long getId() {
+			return id;
+		}
+
+		public void setId(Long id) {
+			this.id = id;
+		}
+
+		public String getName() {
+			return name;
+		}
+
+		public void setName(String name) {
+			this.name = name;
+		}
+
+		public Map<String, Child> getChildren() {
+			return children;
+		}
+
+		public void setChildren(Map<String, Child> children) {
+			this.children = children;
+		}
+
+		public void addChild(Child child) {
+			if ( children == null ) {
+				children = new HashMap<>();
+			}
+			children.put( child.getName(), child );
+		}
+	}
+
+	@Entity(name = "Child")
+	public static class Child {
+
+		@Id
+		private Long id;
+
+		private String name;
+
+		public Child() {
+		}
+
+		public Child(Long id, String name) {
+			this.id = id;
+			this.name = name;
+		}
+
+		public Long getId() {
+			return id;
+		}
+
+		public void setId(Long id) {
+			this.id = id;
+		}
+
+		public String getName() {
+			return name;
+		}
+
+		public void setName(String name) {
+			this.name = name;
+		}
+
+	}
+
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/orphan/onetomany/merge/MergeOrphanRemovalArrayBidirectionalTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/orphan/onetomany/merge/MergeOrphanRemovalArrayBidirectionalTest.java
@@ -1,0 +1,217 @@
+/*
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.jpa.orphan.onetomany.merge;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.JiraKey;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DomainModel(
+		annotatedClasses = {
+				MergeOrphanRemovalArrayBidirectionalTest.Parent.class,
+				MergeOrphanRemovalArrayBidirectionalTest.Child.class,
+		}
+)
+@SessionFactory
+@JiraKey("HHH-18842")
+public class MergeOrphanRemovalArrayBidirectionalTest {
+
+	private static final Long ID_PARENT_WITHOUT_CHILDREN = 1L;
+	private static final Long ID_PARENT_WITH_CHILDREN = 2L;
+
+	@BeforeEach
+	public void setUp(SessionFactoryScope scope) {
+		scope.inTransaction(
+				session -> {
+					Parent parent = new Parent( ID_PARENT_WITHOUT_CHILDREN, "old name" );
+					session.persist( parent );
+
+					Parent parent2 = new Parent( ID_PARENT_WITH_CHILDREN, "old name" );
+					Child child = new Child( 2l, "Child" );
+					Child[] children = new Child[1];
+					children[0] = child;
+					parent2.setChildren( children );
+
+					session.persist( child );
+					session.persist( parent2 );
+				}
+		);
+	}
+
+	@AfterEach
+	private void tearDown(SessionFactoryScope scope) {
+		scope.inTransaction(
+				session -> {
+					session.createMutationQuery( "delete from Child" ).executeUpdate();
+					session.createMutationQuery( "delete from Parent" ).executeUpdate();
+				}
+		);
+	}
+
+	@Test
+	public void testMergeParentWihoutChildren(SessionFactoryScope scope) {
+		scope.inTransaction(
+				session -> {
+					Parent parent = new Parent( ID_PARENT_WITHOUT_CHILDREN, "new name" );
+					Parent merged = session.merge( parent );
+					assertThat( merged.getName() ).isEqualTo( "new name" );
+
+				}
+		);
+	}
+
+	@Test
+	public void testMergeParentWithChildren(SessionFactoryScope scope) {
+		scope.inTransaction(
+				session -> {
+					Parent parent = new Parent( ID_PARENT_WITH_CHILDREN, "new name" );
+					Child child = new Child( 2l, "Child" );
+					Child[] children = new Child[1];
+					children[0] = child;
+					parent.setChildren( children );
+					Parent merged = session.merge( parent );
+					assertThat( merged.getName() ).isEqualTo( "new name" );
+
+				}
+		);
+		scope.inTransaction(
+				session -> {
+					Parent parent = session.get( Parent.class, ID_PARENT_WITH_CHILDREN );
+					assertThat( parent.getChildren().length ).isEqualTo( 1 );
+
+				}
+		);
+	}
+
+	@Test
+	public void testMergeParentWithChildren2(SessionFactoryScope scope) {
+		scope.inTransaction(
+				session -> {
+					Parent parent = new Parent( ID_PARENT_WITH_CHILDREN, "new name" );
+					Parent merged = session.merge( parent );
+
+				}
+		);
+		scope.inTransaction(
+				session -> {
+					Parent parent = session.get( Parent.class, ID_PARENT_WITH_CHILDREN );
+					assertThat( parent.getName() ).isEqualTo( "new name" );
+					assertThat( parent.getChildren().length ).isEqualTo( 0 );
+
+					List<Child> children = session.createQuery( "Select c from Child c", Child.class ).list();
+					assertThat( children.size() ).isEqualTo( 0 );
+				}
+		);
+
+	}
+
+	@Entity(name = "Parent")
+	public static class Parent {
+
+		@Id
+		private Long id;
+
+		private String name;
+
+		@OneToMany(orphanRemoval = true, mappedBy = "parent")
+		private Child[] children;
+
+		public Parent() {
+		}
+
+		public Parent(Long id, String name) {
+			this.id = id;
+			this.name = name;
+		}
+
+		public Long getId() {
+			return id;
+		}
+
+		public void setId(Long id) {
+			this.id = id;
+		}
+
+		public String getName() {
+			return name;
+		}
+
+		public void setName(String name) {
+			this.name = name;
+		}
+
+		public Child[] getChildren() {
+			return children;
+		}
+
+		public void setChildren(Child[] children) {
+			this.children = children;
+			for ( int i = 0; i < children.length; i++ ) {
+				children[i].setParent( this );
+			}
+		}
+
+	}
+
+	@Entity(name = "Child")
+	public static class Child {
+
+		@Id
+		private Long id;
+
+		private String name;
+
+		public Child() {
+		}
+
+		public Child(Long id, String name) {
+			this.id = id;
+			this.name = name;
+		}
+
+		@ManyToOne
+		@JoinColumn
+		private Parent parent;
+
+		public Long getId() {
+			return id;
+		}
+
+		public void setId(Long id) {
+			this.id = id;
+		}
+
+		public String getName() {
+			return name;
+		}
+
+		public void setName(String name) {
+			this.name = name;
+		}
+
+		public Parent getParent() {
+			return parent;
+		}
+
+		public void setParent(Parent parent) {
+			this.parent = parent;
+		}
+	}
+
+}


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-18842

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
