### PR TITLE
Changes for Hibernate Reactive

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/dialect/JsonHelper.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/JsonHelper.java
@@ -42,7 +42,6 @@ import org.hibernate.type.descriptor.java.PrimitiveByteArrayJavaType;
 import org.hibernate.type.descriptor.jdbc.AggregateJdbcType;
 import org.hibernate.type.descriptor.jdbc.ArrayJdbcType;
 import org.hibernate.type.descriptor.jdbc.JdbcType;
-import org.hibernate.type.descriptor.jdbc.JsonArrayJdbcType;
 
 import static org.hibernate.dialect.StructHelper.getEmbeddedPart;
 import static org.hibernate.dialect.StructHelper.instantiate;
@@ -363,16 +362,17 @@ public class JsonHelper {
 		return (X) values;
 	}
 
+	// This is also used by Hibernate Reactive
 	public static <X> X arrayFromString(
 			JavaType<X> javaType,
-			JsonArrayJdbcType jsonArrayJdbcType,
+			JdbcType elementJdbcType,
 			String string,
 			WrapperOptions options) throws SQLException {
 		if ( string == null ) {
 			return null;
 		}
 		final JavaType<?> elementJavaType = ((BasicPluralJavaType<?>) javaType).getElementJavaType();
-		final Class<?> preferredJavaTypeClass = jsonArrayJdbcType.getElementJdbcType().getPreferredJavaTypeClass( options );
+		final Class<?> preferredJavaTypeClass = elementJdbcType.getPreferredJavaTypeClass( options );
 		final JavaType<?> jdbcJavaType;
 		if ( preferredJavaTypeClass == null || preferredJavaTypeClass == elementJavaType.getJavaTypeClass() ) {
 			jdbcJavaType = elementJavaType;
@@ -390,7 +390,7 @@ public class JsonHelper {
 				arrayList,
 				elementJavaType,
 				jdbcJavaType,
-				jsonArrayJdbcType.getElementJdbcType()
+				elementJdbcType
 		);
 		assert string.charAt( i - 1 ) == ']';
 		return javaType.wrap( arrayList, options );

--- a/hibernate-core/src/main/java/org/hibernate/id/enhanced/TableStructure.java
+++ b/hibernate-core/src/main/java/org/hibernate/id/enhanced/TableStructure.java
@@ -111,6 +111,13 @@ public class TableStructure implements DatabaseStructure {
 		return physicalTableName;
 	}
 
+	/*
+	 * Used by Hibernate Reactive
+	 */
+	public Identifier getLogicalValueColumnNameIdentifier() {
+		return logicalValueColumnNameIdentifier;
+	}
+
 	@Override
 	public int getInitialValue() {
 		return initialValue;

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/spi/RuntimeModelCreationContext.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/spi/RuntimeModelCreationContext.java
@@ -14,8 +14,11 @@ import org.hibernate.engine.jdbc.spi.JdbcServices;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.generator.Generator;
 import org.hibernate.mapping.GeneratorSettings;
+import org.hibernate.mapping.PersistentClass;
+import org.hibernate.persister.entity.EntityPersister;
 import org.hibernate.query.sqm.function.SqmFunctionRegistry;
 import org.hibernate.service.ServiceRegistry;
+import org.hibernate.tuple.entity.EntityMetamodel;
 import org.hibernate.type.descriptor.java.spi.JavaTypeRegistry;
 import org.hibernate.type.spi.TypeConfiguration;
 
@@ -64,4 +67,11 @@ public interface RuntimeModelCreationContext {
 	Map<String, Generator> getGenerators();
 
 	GeneratorSettings getGeneratorSettings();
+
+	/*
+	 * Used by Hibernate Reactive
+	 */
+	default EntityMetamodel createEntityMetamodel(PersistentClass persistentClass, EntityPersister persister) {
+		return new EntityMetamodel( persistentClass, persister, this );
+	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/persister/entity/AbstractEntityPersister.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/entity/AbstractEntityPersister.java
@@ -469,11 +469,38 @@ public abstract class AbstractEntityPersister
 	private List<UniqueKeyEntry> uniqueKeyEntries = null; //lazily initialized
 	private ConcurrentHashMap<String,SingleIdArrayLoadPlan> nonLazyPropertyLoadPlansByName;
 
+	/**
+	 * A factory for the creation of an EntityMetamodel.
+	 * <p>
+	 * Hibernate Reactive uses it to pass its own entity metamodel class
+	 * and adapt the identifier generators.
+	 */
+	public static class EntityMetamodelFactory {
+		public EntityMetamodel createEntityMetamodel(
+				PersistentClass persistentClass,
+				EntityPersister persister,
+				RuntimeModelCreationContext creationContext) {
+			return new EntityMetamodel( persistentClass, persister, creationContext );
+		}
+	}
+
 	public AbstractEntityPersister(
 			final PersistentClass persistentClass,
 			final EntityDataAccess cacheAccessStrategy,
 			final NaturalIdDataAccess naturalIdRegionAccessStrategy,
 			final RuntimeModelCreationContext creationContext) throws HibernateException {
+		this( persistentClass, cacheAccessStrategy, naturalIdRegionAccessStrategy, creationContext, new EntityMetamodelFactory() );
+	}
+
+	/*
+	 * Used by Hibernate Reactive
+	 */
+	public AbstractEntityPersister(
+			final PersistentClass persistentClass,
+			final EntityDataAccess cacheAccessStrategy,
+			final NaturalIdDataAccess naturalIdRegionAccessStrategy,
+			final RuntimeModelCreationContext creationContext,
+			final EntityMetamodelFactory entityMetamodelFactory) throws HibernateException {
 		this.jpaEntityName = persistentClass.getJpaEntityName();
 
 		//set it here, but don't call it, since it's still uninitialized!
@@ -500,7 +527,7 @@ public abstract class AbstractEntityPersister
 			isLazyPropertiesCacheable = true;
 		}
 
-		entityMetamodel = new EntityMetamodel( persistentClass, this, creationContext );
+		entityMetamodel = entityMetamodelFactory.createEntityMetamodel( persistentClass, this, creationContext );
 
 		entityEntryFactory = entityMetamodel.isMutable()
 				? MutableEntityEntryFactory.INSTANCE

--- a/hibernate-core/src/main/java/org/hibernate/persister/entity/AbstractEntityPersister.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/entity/AbstractEntityPersister.java
@@ -469,38 +469,11 @@ public abstract class AbstractEntityPersister
 	private List<UniqueKeyEntry> uniqueKeyEntries = null; //lazily initialized
 	private ConcurrentHashMap<String,SingleIdArrayLoadPlan> nonLazyPropertyLoadPlansByName;
 
-	/**
-	 * A factory for the creation of an EntityMetamodel.
-	 * <p>
-	 * Hibernate Reactive uses it to pass its own entity metamodel class
-	 * and adapt the identifier generators.
-	 */
-	public static class EntityMetamodelFactory {
-		public EntityMetamodel createEntityMetamodel(
-				PersistentClass persistentClass,
-				EntityPersister persister,
-				RuntimeModelCreationContext creationContext) {
-			return new EntityMetamodel( persistentClass, persister, creationContext );
-		}
-	}
-
 	public AbstractEntityPersister(
 			final PersistentClass persistentClass,
 			final EntityDataAccess cacheAccessStrategy,
 			final NaturalIdDataAccess naturalIdRegionAccessStrategy,
 			final RuntimeModelCreationContext creationContext) throws HibernateException {
-		this( persistentClass, cacheAccessStrategy, naturalIdRegionAccessStrategy, creationContext, new EntityMetamodelFactory() );
-	}
-
-	/*
-	 * Used by Hibernate Reactive
-	 */
-	public AbstractEntityPersister(
-			final PersistentClass persistentClass,
-			final EntityDataAccess cacheAccessStrategy,
-			final NaturalIdDataAccess naturalIdRegionAccessStrategy,
-			final RuntimeModelCreationContext creationContext,
-			final EntityMetamodelFactory entityMetamodelFactory) throws HibernateException {
 		this.jpaEntityName = persistentClass.getJpaEntityName();
 
 		//set it here, but don't call it, since it's still uninitialized!
@@ -527,7 +500,7 @@ public abstract class AbstractEntityPersister
 			isLazyPropertiesCacheable = true;
 		}
 
-		entityMetamodel = entityMetamodelFactory.createEntityMetamodel( persistentClass, this, creationContext );
+		entityMetamodel = creationContext.createEntityMetamodel( persistentClass, this );
 
 		entityEntryFactory = entityMetamodel.isMutable()
 				? MutableEntityEntryFactory.INSTANCE

--- a/hibernate-core/src/main/java/org/hibernate/persister/entity/JoinedSubclassEntityPersister.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/entity/JoinedSubclassEntityPersister.java
@@ -160,20 +160,7 @@ public class JoinedSubclassEntityPersister extends AbstractEntityPersister {
 			final EntityDataAccess cacheAccessStrategy,
 			final NaturalIdDataAccess naturalIdRegionAccessStrategy,
 			final RuntimeModelCreationContext creationContext) throws HibernateException {
-		this( persistentClass, cacheAccessStrategy, naturalIdRegionAccessStrategy, creationContext, new EntityMetamodelFactory());
-	}
-
-	/*
-	 * Used by Hibernate Reactive
-	 */
-	public JoinedSubclassEntityPersister(
-			final PersistentClass persistentClass,
-			final EntityDataAccess cacheAccessStrategy,
-			final NaturalIdDataAccess naturalIdRegionAccessStrategy,
-			final RuntimeModelCreationContext creationContext,
-			final EntityMetamodelFactory entityMetamodelFactory) throws HibernateException {
-
-		super( persistentClass, cacheAccessStrategy, naturalIdRegionAccessStrategy, creationContext, entityMetamodelFactory );
+		super( persistentClass, cacheAccessStrategy, naturalIdRegionAccessStrategy, creationContext );
 
 		final Dialect dialect = creationContext.getDialect();
 		final SqmFunctionRegistry functionRegistry = creationContext.getFunctionRegistry();

--- a/hibernate-core/src/main/java/org/hibernate/persister/entity/JoinedSubclassEntityPersister.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/entity/JoinedSubclassEntityPersister.java
@@ -160,8 +160,20 @@ public class JoinedSubclassEntityPersister extends AbstractEntityPersister {
 			final EntityDataAccess cacheAccessStrategy,
 			final NaturalIdDataAccess naturalIdRegionAccessStrategy,
 			final RuntimeModelCreationContext creationContext) throws HibernateException {
+		this( persistentClass, cacheAccessStrategy, naturalIdRegionAccessStrategy, creationContext, new EntityMetamodelFactory());
+	}
 
-		super( persistentClass, cacheAccessStrategy, naturalIdRegionAccessStrategy, creationContext );
+	/*
+	 * Used by Hibernate Reactive
+	 */
+	public JoinedSubclassEntityPersister(
+			final PersistentClass persistentClass,
+			final EntityDataAccess cacheAccessStrategy,
+			final NaturalIdDataAccess naturalIdRegionAccessStrategy,
+			final RuntimeModelCreationContext creationContext,
+			final EntityMetamodelFactory entityMetamodelFactory) throws HibernateException {
+
+		super( persistentClass, cacheAccessStrategy, naturalIdRegionAccessStrategy, creationContext, entityMetamodelFactory );
 
 		final Dialect dialect = creationContext.getDialect();
 		final SqmFunctionRegistry functionRegistry = creationContext.getFunctionRegistry();

--- a/hibernate-core/src/main/java/org/hibernate/persister/entity/SingleTableEntityPersister.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/entity/SingleTableEntityPersister.java
@@ -114,8 +114,20 @@ public class SingleTableEntityPersister extends AbstractEntityPersister {
 			final EntityDataAccess cacheAccessStrategy,
 			final NaturalIdDataAccess naturalIdRegionAccessStrategy,
 			final RuntimeModelCreationContext creationContext) throws HibernateException {
+		this( persistentClass, cacheAccessStrategy, naturalIdRegionAccessStrategy, creationContext, new EntityMetamodelFactory() );
+	}
 
-		super( persistentClass, cacheAccessStrategy, naturalIdRegionAccessStrategy, creationContext );
+	/*
+	 * Used by Hibernate Reactive
+	 */
+	public SingleTableEntityPersister(
+			final PersistentClass persistentClass,
+			final EntityDataAccess cacheAccessStrategy,
+			final NaturalIdDataAccess naturalIdRegionAccessStrategy,
+			final RuntimeModelCreationContext creationContext,
+			final EntityMetamodelFactory entityMetamodelFactory) throws HibernateException {
+
+		super( persistentClass, cacheAccessStrategy, naturalIdRegionAccessStrategy, creationContext, entityMetamodelFactory );
 
 		final Dialect dialect = creationContext.getDialect();
 		final SqmFunctionRegistry functionRegistry = creationContext.getFunctionRegistry();

--- a/hibernate-core/src/main/java/org/hibernate/persister/entity/SingleTableEntityPersister.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/entity/SingleTableEntityPersister.java
@@ -114,20 +114,7 @@ public class SingleTableEntityPersister extends AbstractEntityPersister {
 			final EntityDataAccess cacheAccessStrategy,
 			final NaturalIdDataAccess naturalIdRegionAccessStrategy,
 			final RuntimeModelCreationContext creationContext) throws HibernateException {
-		this( persistentClass, cacheAccessStrategy, naturalIdRegionAccessStrategy, creationContext, new EntityMetamodelFactory() );
-	}
-
-	/*
-	 * Used by Hibernate Reactive
-	 */
-	public SingleTableEntityPersister(
-			final PersistentClass persistentClass,
-			final EntityDataAccess cacheAccessStrategy,
-			final NaturalIdDataAccess naturalIdRegionAccessStrategy,
-			final RuntimeModelCreationContext creationContext,
-			final EntityMetamodelFactory entityMetamodelFactory) throws HibernateException {
-
-		super( persistentClass, cacheAccessStrategy, naturalIdRegionAccessStrategy, creationContext, entityMetamodelFactory );
+		super( persistentClass, cacheAccessStrategy, naturalIdRegionAccessStrategy, creationContext );
 
 		final Dialect dialect = creationContext.getDialect();
 		final SqmFunctionRegistry functionRegistry = creationContext.getFunctionRegistry();

--- a/hibernate-core/src/main/java/org/hibernate/persister/entity/UnionSubclassEntityPersister.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/entity/UnionSubclassEntityPersister.java
@@ -95,7 +95,19 @@ public class UnionSubclassEntityPersister extends AbstractEntityPersister {
 			final EntityDataAccess cacheAccessStrategy,
 			final NaturalIdDataAccess naturalIdRegionAccessStrategy,
 			final RuntimeModelCreationContext creationContext) throws HibernateException {
-		super( persistentClass, cacheAccessStrategy, naturalIdRegionAccessStrategy, creationContext );
+		this( persistentClass, cacheAccessStrategy, naturalIdRegionAccessStrategy, creationContext, new EntityMetamodelFactory() );
+	}
+
+	/*
+	 * Used by Hibernate Reactive
+	 */
+	public UnionSubclassEntityPersister(
+			final PersistentClass persistentClass,
+			final EntityDataAccess cacheAccessStrategy,
+			final NaturalIdDataAccess naturalIdRegionAccessStrategy,
+			final RuntimeModelCreationContext creationContext,
+			final EntityMetamodelFactory entityMetamodelFactory) throws HibernateException {
+		super( persistentClass, cacheAccessStrategy, naturalIdRegionAccessStrategy, creationContext, entityMetamodelFactory );
 
 		validateGenerator();
 

--- a/hibernate-core/src/main/java/org/hibernate/persister/entity/UnionSubclassEntityPersister.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/entity/UnionSubclassEntityPersister.java
@@ -95,19 +95,7 @@ public class UnionSubclassEntityPersister extends AbstractEntityPersister {
 			final EntityDataAccess cacheAccessStrategy,
 			final NaturalIdDataAccess naturalIdRegionAccessStrategy,
 			final RuntimeModelCreationContext creationContext) throws HibernateException {
-		this( persistentClass, cacheAccessStrategy, naturalIdRegionAccessStrategy, creationContext, new EntityMetamodelFactory() );
-	}
-
-	/*
-	 * Used by Hibernate Reactive
-	 */
-	public UnionSubclassEntityPersister(
-			final PersistentClass persistentClass,
-			final EntityDataAccess cacheAccessStrategy,
-			final NaturalIdDataAccess naturalIdRegionAccessStrategy,
-			final RuntimeModelCreationContext creationContext,
-			final EntityMetamodelFactory entityMetamodelFactory) throws HibernateException {
-		super( persistentClass, cacheAccessStrategy, naturalIdRegionAccessStrategy, creationContext, entityMetamodelFactory );
+		super( persistentClass, cacheAccessStrategy, naturalIdRegionAccessStrategy, creationContext );
 
 		validateGenerator();
 

--- a/hibernate-core/src/main/java/org/hibernate/persister/entity/mutation/AbstractMutationCoordinator.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/entity/mutation/AbstractMutationCoordinator.java
@@ -82,8 +82,7 @@ public abstract class AbstractMutationCoordinator {
 			case 0:
 				return MutationOperationGroupFactory.noOperations( mutationGroup );
 			case 1: {
-				final MutationOperation operation = mutationGroup.getSingleTableMutation()
-						.createMutationOperation( valuesAnalysis, factory() );
+				final MutationOperation operation = createOperation( valuesAnalysis, mutationGroup.getSingleTableMutation() );
 				return operation == null
 						? MutationOperationGroupFactory.noOperations( mutationGroup )
 						: MutationOperationGroupFactory.singleOperation( mutationGroup, operation );
@@ -114,6 +113,13 @@ public abstract class AbstractMutationCoordinator {
 				return MutationOperationGroupFactory.manyOperations( mutationGroup.getMutationType(), entityPersister, operations );
 			}
 		}
+	}
+
+	/*
+	 * Used by Hibernate Reactive
+	 */
+	protected MutationOperation createOperation(ValuesAnalysis valuesAnalysis, TableMutation<?> singleTableMutation) {
+		return singleTableMutation.createMutationOperation( valuesAnalysis, factory() );
 	}
 
 	protected void handleValueGeneration(

--- a/hibernate-core/src/main/java/org/hibernate/sql/model/jdbc/DeleteOrUpsertOperation.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/model/jdbc/DeleteOrUpsertOperation.java
@@ -44,7 +44,6 @@ public class DeleteOrUpsertOperation implements SelfExecutingUpdateOperation {
 
 	private final OptionalTableUpdate optionalTableUpdate;
 
-
 	public DeleteOrUpsertOperation(
 			EntityMutationTarget mutationTarget,
 			EntityTableMapping tableMapping,
@@ -54,6 +53,16 @@ public class DeleteOrUpsertOperation implements SelfExecutingUpdateOperation {
 		this.tableMapping = tableMapping;
 		this.upsertOperation = upsertOperation;
 		this.optionalTableUpdate = optionalTableUpdate;
+	}
+
+	/*
+	 * Used by Hibernate Reactive
+	 */
+	protected DeleteOrUpsertOperation(DeleteOrUpsertOperation original) {
+		this.mutationTarget = original.mutationTarget;
+		this.tableMapping = original.tableMapping;
+		this.upsertOperation = original.upsertOperation;
+		this.optionalTableUpdate = original.optionalTableUpdate;
 	}
 
 	@Override
@@ -196,5 +205,19 @@ public class DeleteOrUpsertOperation implements SelfExecutingUpdateOperation {
 				.executeUpdate( updateStatement, statementDetails.getSqlString() );
 
 		MODEL_MUTATION_LOGGER.tracef( "`%s` rows upserted into `%s`", rowCount, tableMapping.getTableName() );
+	}
+
+	/*
+	 * Used by Hibernate Reactive
+	 */
+	public UpsertOperation getUpsertOperation() {
+		return upsertOperation;
+	}
+
+	/*
+	 * Used by Hibernate Reactive
+	 */
+	public OptionalTableUpdate getOptionalTableUpdate() {
+		return optionalTableUpdate;
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/sql/model/jdbc/OptionalTableUpdateOperation.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/model/jdbc/OptionalTableUpdateOperation.java
@@ -263,7 +263,10 @@ public class OptionalTableUpdateOperation implements SelfExecutingUpdateOperatio
 		}
 	}
 
-	private JdbcDeleteMutation createJdbcDelete(SharedSessionContractImplementor session) {
+	/*
+	 * Used by Hibernate Reactive
+	 */
+	protected JdbcDeleteMutation createJdbcDelete(SharedSessionContractImplementor session) {
 		final TableDelete tableDelete;
 		if ( tableMapping.getDeleteDetails() != null
 				&& tableMapping.getDeleteDetails().getCustomSql() != null ) {
@@ -305,39 +308,7 @@ public class OptionalTableUpdateOperation implements SelfExecutingUpdateOperatio
 			JdbcValueBindings jdbcValueBindings,
 			SharedSessionContractImplementor session) {
 		MODEL_MUTATION_LOGGER.tracef( "#performUpdate(%s)", tableMapping.getTableName() );
-
-		final TableUpdate<JdbcMutationOperation> tableUpdate;
-		if ( tableMapping.getUpdateDetails() != null
-				&& tableMapping.getUpdateDetails().getCustomSql() != null ) {
-			tableUpdate = new TableUpdateCustomSql(
-					new MutatingTableReference( tableMapping ),
-					mutationTarget,
-					"upsert update for " + mutationTarget.getRolePath(),
-					valueBindings,
-					keyBindings,
-					optimisticLockBindings,
-					parameters
-			);
-		}
-		else {
-			tableUpdate = new TableUpdateStandard(
-					new MutatingTableReference( tableMapping ),
-					mutationTarget,
-					"upsert update for " + mutationTarget.getRolePath(),
-					valueBindings,
-					keyBindings,
-					optimisticLockBindings,
-					parameters
-			);
-		}
-
-		final SqlAstTranslator<JdbcMutationOperation> translator = session
-				.getJdbcServices()
-				.getJdbcEnvironment()
-				.getSqlAstTranslatorFactory()
-				.buildModelMutationTranslator( tableUpdate, session.getFactory() );
-
-		final JdbcMutationOperation jdbcUpdate = translator.translate( null, MutationQueryOptions.INSTANCE );
+		final JdbcMutationOperation jdbcUpdate = createJdbcUpdate( session );
 
 		final PreparedStatementGroupSingleTable statementGroup = new PreparedStatementGroupSingleTable( jdbcUpdate, session );
 		final PreparedStatementDetails statementDetails = statementGroup.resolvePreparedStatementDetails( tableMapping.getTableName() );
@@ -372,6 +343,44 @@ public class OptionalTableUpdateOperation implements SelfExecutingUpdateOperatio
 					statementDetails.getSqlString()
 			);
 		}
+	}
+
+	/*
+	 * Used by Hibernate Reactive
+	 */
+	protected JdbcMutationOperation createJdbcUpdate(SharedSessionContractImplementor session) {
+		final TableUpdate<JdbcMutationOperation> tableUpdate;
+		if ( tableMapping.getUpdateDetails() != null
+				&& tableMapping.getUpdateDetails().getCustomSql() != null ) {
+			tableUpdate = new TableUpdateCustomSql(
+					new MutatingTableReference( tableMapping ),
+					mutationTarget,
+					"upsert update for " + mutationTarget.getRolePath(),
+					valueBindings,
+					keyBindings,
+					optimisticLockBindings,
+					parameters
+			);
+		}
+		else {
+			tableUpdate = new TableUpdateStandard(
+					new MutatingTableReference( tableMapping ),
+					mutationTarget,
+					"upsert update for " + mutationTarget.getRolePath(),
+					valueBindings,
+					keyBindings,
+					optimisticLockBindings,
+					parameters
+			);
+		}
+
+		final SqlAstTranslator<JdbcMutationOperation> translator = session
+				.getJdbcServices()
+				.getJdbcEnvironment()
+				.getSqlAstTranslatorFactory()
+				.buildModelMutationTranslator( tableUpdate, session.getFactory() );
+
+		return translator.translate( null, MutationQueryOptions.INSTANCE );
 	}
 
 	private void performInsert(JdbcValueBindings jdbcValueBindings, SharedSessionContractImplementor session) {
@@ -414,7 +423,10 @@ public class OptionalTableUpdateOperation implements SelfExecutingUpdateOperatio
 		}
 	}
 
-	private JdbcInsertMutation createJdbcInsert(SharedSessionContractImplementor session) {
+	/*
+	 * Used by Hibernate Reactive
+	 */
+	protected JdbcInsertMutation createJdbcInsert(SharedSessionContractImplementor session) {
 		final TableInsert tableInsert;
 		if ( tableMapping.getInsertDetails() != null
 				&& tableMapping.getInsertDetails().getCustomSql() != null ) {

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/entity/internal/AbstractNonJoinedEntityFetch.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/entity/internal/AbstractNonJoinedEntityFetch.java
@@ -142,11 +142,10 @@ public abstract class AbstractNonJoinedEntityFetch implements EntityFetch,
 	public DomainResultAssembler<?> createAssembler(
 			InitializerParent<?> parent,
 			AssemblerCreationState creationState) {
-		final EntityInitializer<?> entityInitializer =
-				creationState.resolveInitializer( this, parent, this )
-						.asEntityInitializer();
+		final EntityInitializer<?> entityInitializer = creationState.resolveInitializer( this, parent, this )
+				.asEntityInitializer();
 		assert entityInitializer != null;
-		return new EntityAssembler<>( getFetchedMapping().getJavaType(), entityInitializer );
+		return buildEntityAssembler( entityInitializer );
 	}
 
 	@Override
@@ -160,4 +159,10 @@ public abstract class AbstractNonJoinedEntityFetch implements EntityFetch,
 	@Override
 	public abstract EntityInitializer<?> createInitializer(InitializerParent<?> parent, AssemblerCreationState creationState);
 
+	/**
+	 * Used By Hibernate Reactive
+	 */
+	protected EntityAssembler<?> buildEntityAssembler(EntityInitializer<?> entityInitializer) {
+		return new EntityAssembler<>( getFetchedMapping().getJavaType(), entityInitializer );
+	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/entity/internal/EntityFetchJoinedImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/entity/internal/EntityFetchJoinedImpl.java
@@ -129,9 +129,14 @@ public class EntityFetchJoinedImpl implements EntityFetch, FetchParent, Initiali
 	public DomainResultAssembler<?> createAssembler(
 			InitializerParent<?> parent,
 			AssemblerCreationState creationState) {
-		return new EntityAssembler<>( getFetchedMapping().getJavaType(),
-				creationState.resolveInitializer( this, parent, this )
-						.asEntityInitializer() );
+		return buildEntityAssembler( creationState.resolveInitializer( this, parent, this ).asEntityInitializer() );
+	}
+
+	/**
+	 * Used by Hibernate Reactive
+	 */
+	protected EntityAssembler<?> buildEntityAssembler(EntityInitializer<?> entityInitializer) {
+		return new EntityAssembler<>( getFetchedMapping().getJavaType(), entityInitializer );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/tool/schema/extract/internal/AbstractInformationExtractorImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/tool/schema/extract/internal/AbstractInformationExtractorImpl.java
@@ -638,7 +638,10 @@ public abstract class AbstractInformationExtractorImpl implements InformationExt
 		}
 	}
 
-	private ColumnInformationImpl columnInformation(TableInformation tableInformation, ResultSet resultSet)
+	/*
+	 * Hibernate Reactive overrides this
+	 */
+	protected ColumnInformationImpl columnInformation(TableInformation tableInformation, ResultSet resultSet)
 			throws SQLException {
 		return new ColumnInformationImpl(
 				tableInformation,
@@ -864,7 +867,10 @@ public abstract class AbstractInformationExtractorImpl implements InformationExt
 		}
 	}
 
-	private Boolean interpretTruthValue(String nullable) {
+	/*
+	 * Used by Hibernate Reactive
+	 */
+	protected Boolean interpretTruthValue(String nullable) {
 		if ( "yes".equalsIgnoreCase( nullable ) ) {
 			return Boolean.TRUE;
 		}


### PR DESCRIPTION
Fix [HHH-18854](https://hibernate.atlassian.net/browse/HHH-18854) (I think)

These changes make it possible for me to use Hibernate Reactive with ORM 7 and Postgres.
I still need to fix some issues with the other databases, but I don't think I will have more changes to include for now.

Basically, I needed some way to intercept the creation of the id generator.

[HHH-18854]: https://hibernate.atlassian.net/browse/HHH-18854?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ