### PR TITLE
HHH-18855: Subselect fetches not always generated in the same situation

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/engine/spi/SubselectFetch.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/spi/SubselectFetch.java
@@ -89,22 +89,6 @@ public class SubselectFetch {
 	public static RegistrationHandler createRegistrationHandler(
 			BatchFetchQueue batchFetchQueue,
 			SelectStatement sqlAst,
-			TableGroup tableGroup,
-			JdbcParametersList jdbcParameters,
-			JdbcParameterBindings jdbcParameterBindings) {
-
-		return new StandardRegistrationHandler(
-				batchFetchQueue,
-				sqlAst,
-				tableGroup,
-				jdbcParameters,
-				jdbcParameterBindings
-		);
-	}
-
-	public static RegistrationHandler createRegistrationHandler(
-			BatchFetchQueue batchFetchQueue,
-			SelectStatement sqlAst,
 			JdbcParametersList jdbcParameters,
 			JdbcParameterBindings jdbcParameterBindings) {
 		final List<TableGroup> roots = sqlAst.getQuerySpec().getFromClause().getRoots();
@@ -113,18 +97,20 @@ public class SubselectFetch {
 			return NO_OP_REG_HANDLER;
 		}
 
-		return createRegistrationHandler( batchFetchQueue, sqlAst, roots.get( 0 ), jdbcParameters, jdbcParameterBindings );
+		return new StandardRegistrationHandler(
+				batchFetchQueue,
+				sqlAst,
+				jdbcParameters,
+				jdbcParameterBindings
+		);
 	}
 
 	public interface RegistrationHandler {
 		void addKey(EntityHolder holder);
 	}
 
-	private static final RegistrationHandler NO_OP_REG_HANDLER = new RegistrationHandler() {
-		@Override
-		public void addKey(EntityHolder holder) {
-		}
-	} ;
+	private static final RegistrationHandler NO_OP_REG_HANDLER = holder -> {
+	};
 
 	public static class StandardRegistrationHandler implements RegistrationHandler {
 		private final BatchFetchQueue batchFetchQueue;
@@ -136,7 +122,6 @@ public class SubselectFetch {
 		private StandardRegistrationHandler(
 				BatchFetchQueue batchFetchQueue,
 				SelectStatement loadingSqlAst,
-				TableGroup ownerTableGroup,
 				JdbcParametersList loadingJdbcParameters,
 				JdbcParameterBindings loadingJdbcParameterBindings) {
 			this.batchFetchQueue = batchFetchQueue;

--- a/hibernate-core/src/main/java/org/hibernate/loader/ast/internal/SingleIdLoadPlan.java
+++ b/hibernate-core/src/main/java/org/hibernate/loader/ast/internal/SingleIdLoadPlan.java
@@ -4,22 +4,18 @@
  */
 package org.hibernate.loader.ast.internal;
 
-import java.util.List;
-
 import org.hibernate.LockOptions;
 import org.hibernate.engine.jdbc.env.spi.JdbcEnvironment;
 import org.hibernate.engine.jdbc.spi.JdbcServices;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
+import org.hibernate.engine.spi.SubselectFetch;
 import org.hibernate.loader.ast.spi.Loadable;
 import org.hibernate.metamodel.mapping.EntityMappingType;
 import org.hibernate.metamodel.mapping.ModelPart;
 import org.hibernate.query.internal.SimpleQueryOptions;
-import org.hibernate.query.spi.QueryOptions;
-import org.hibernate.query.spi.QueryOptionsAdapter;
 import org.hibernate.sql.ast.SqlAstTranslatorFactory;
 import org.hibernate.sql.ast.tree.select.SelectStatement;
-import org.hibernate.sql.exec.internal.BaseExecutionContext;
 import org.hibernate.sql.exec.internal.CallbackImpl;
 import org.hibernate.sql.exec.internal.JdbcParameterBindingsImpl;
 import org.hibernate.sql.exec.spi.Callback;
@@ -30,12 +26,13 @@ import org.hibernate.sql.results.internal.RowTransformerStandardImpl;
 import org.hibernate.sql.results.spi.ListResultsConsumer;
 import org.hibernate.sql.results.spi.RowTransformer;
 
+import java.util.List;
+
 /**
  * Describes a plan for loading an entity by identifier.
  *
- * @implNote Made up of (1) a SQL AST for the SQL SELECT and (2) the `ModelPart` used as the restriction
- *
  * @author Steve Ebersole
+ * @implNote Made up of (1) a SQL AST for the SQL SELECT and (2) the `ModelPart` used as the restriction
  */
 // todo (6.0) : this can generically define a load-by-uk as well.
 // only the SQL AST and `restrictivePart` vary and they are passed as constructor args
@@ -43,6 +40,7 @@ public class SingleIdLoadPlan<T> implements SingleEntityLoadPlan {
 	private final EntityMappingType entityMappingType;
 	private final ModelPart restrictivePart;
 	private final LockOptions lockOptions;
+	private final SelectStatement sqlAst;
 	private final JdbcOperationQuerySelect jdbcSelect;
 	private final JdbcParametersList jdbcParameters;
 
@@ -57,18 +55,14 @@ public class SingleIdLoadPlan<T> implements SingleEntityLoadPlan {
 		this.restrictivePart = restrictivePart;
 		this.lockOptions = lockOptions.makeCopy();
 		this.jdbcParameters = jdbcParameters;
+		this.sqlAst = sqlAst;
 		final JdbcServices jdbcServices = sessionFactory.getJdbcServices();
 		final JdbcEnvironment jdbcEnvironment = jdbcServices.getJdbcEnvironment();
 		final SqlAstTranslatorFactory sqlAstTranslatorFactory = jdbcEnvironment.getSqlAstTranslatorFactory();
 		this.jdbcSelect = sqlAstTranslatorFactory.buildSelectTranslator( sessionFactory, sqlAst )
 				.translate(
 						null,
-						new QueryOptionsAdapter() {
-							@Override
-							public LockOptions getLockOptions() {
-								return lockOptions;
-							}
-						}
+						new SimpleQueryOptions( lockOptions, null )
 				);
 	}
 
@@ -137,23 +131,32 @@ public class SingleIdLoadPlan<T> implements SingleEntityLoadPlan {
 			);
 		}
 		assert offset == jdbcParameters.size();
-		final QueryOptions queryOptions = new SimpleQueryOptions( lockOptions, readOnly );
 		final Callback callback = new CallbackImpl();
+		final SubselectFetch.RegistrationHandler subselectRegistrationHandler = SubselectFetch.createRegistrationHandler(
+				session.getPersistenceContextInternal().getBatchFetchQueue(),
+				sqlAst,
+				jdbcParameters,
+				jdbcParameterBindings
+		);
 
 		final List<T> list = session.getJdbcServices().getJdbcSelectExecutor().list(
 				jdbcSelect,
 				jdbcParameterBindings,
 				new SingleIdExecutionContext(
-						session,
-						entityInstance,
 						restrictedValue,
+						entityInstance,
 						entityMappingType.getRootEntityDescriptor(),
-						queryOptions,
+						readOnly,
+						lockOptions,
+						subselectRegistrationHandler,
+						session,
 						callback
 				),
 				getRowTransformer(),
 				null,
-				singleResultExpected ? ListResultsConsumer.UniqueSemantic.ASSERT : ListResultsConsumer.UniqueSemantic.FILTER,
+				singleResultExpected ?
+						ListResultsConsumer.UniqueSemantic.ASSERT :
+						ListResultsConsumer.UniqueSemantic.FILTER,
 				1
 		);
 
@@ -164,53 +167,5 @@ public class SingleIdLoadPlan<T> implements SingleEntityLoadPlan {
 		final T entity = list.get( 0 );
 		callback.invokeAfterLoadActions( entity, entityMappingType, session );
 		return entity;
-	}
-
-	private static class SingleIdExecutionContext extends BaseExecutionContext {
-		private final Object entityInstance;
-		private final Object restrictedValue;
-		private final EntityMappingType rootEntityDescriptor;
-		private final QueryOptions queryOptions;
-		private final Callback callback;
-
-		public SingleIdExecutionContext(
-				SharedSessionContractImplementor session,
-				Object entityInstance,
-				Object restrictedValue,
-				EntityMappingType rootEntityDescriptor, QueryOptions queryOptions,
-				Callback callback) {
-			super( session );
-			this.entityInstance = entityInstance;
-			this.restrictedValue = restrictedValue;
-			this.rootEntityDescriptor = rootEntityDescriptor;
-			this.queryOptions = queryOptions;
-			this.callback = callback;
-		}
-
-		@Override
-		public Object getEntityInstance() {
-			return entityInstance;
-		}
-
-		@Override
-		public Object getEntityId() {
-			return restrictedValue;
-		}
-
-		@Override
-		public EntityMappingType getRootEntityDescriptor() {
-			return rootEntityDescriptor;
-		}
-
-		@Override
-		public QueryOptions getQueryOptions() {
-			return queryOptions;
-		}
-
-		@Override
-		public Callback getCallback() {
-			return callback;
-		}
-
 	}
 }

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/fetch/GenerateSubselectsOnJoinedAssociationTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/fetch/GenerateSubselectsOnJoinedAssociationTest.java
@@ -1,0 +1,145 @@
+/*
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.fetch;
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinTable;
+import jakarta.persistence.ManyToMany;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+
+import org.hibernate.Hibernate;
+import org.hibernate.annotations.Fetch;
+import org.hibernate.annotations.FetchMode;
+import org.hibernate.engine.spi.BatchFetchQueue;
+import org.hibernate.engine.spi.EntityKey;
+import org.hibernate.engine.spi.SessionImplementor;
+import org.hibernate.persister.entity.EntityPersister;
+
+import org.hibernate.testing.orm.junit.EntityManagerFactoryScope;
+import org.hibernate.testing.orm.junit.Jpa;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+
+@Jpa(annotatedClasses = {
+		GenerateSubselectsOnJoinedAssociationTest.LazySelectRoot.class,
+		GenerateSubselectsOnJoinedAssociationTest.LazySelectNode.class
+})
+public class GenerateSubselectsOnJoinedAssociationTest {
+
+	@BeforeAll
+	static void setup(final EntityManagerFactoryScope scope) {
+		scope.inTransaction( em -> {
+			final LazySelectNode rootNode = new LazySelectNode();
+			rootNode.id = 10;
+
+			final LazySelectNode child1 = new LazySelectNode();
+			child1.id = 20;
+
+			final LazySelectNode child2 = new LazySelectNode();
+			child2.id = 30;
+
+			final LazySelectRoot root = new LazySelectRoot();
+			root.id = 1;
+
+			root.nodes.add( rootNode );
+			root.nodes.add( child1 );
+			root.nodes.add( child2 );
+			rootNode.root = root;
+			rootNode.children.add( child2 );
+			rootNode.children.add( child1 );
+			child1.root = root;
+			child2.root = root;
+
+			em.persist( root );
+		} );
+	}
+
+	@Test
+	void testSubselectFetchingFromFind(final EntityManagerFactoryScope scope) {
+		final LazySelectRoot root = scope.fromTransaction( em -> {
+			final SessionImplementor session = em.unwrap( SessionImplementor.class );
+			final EntityPersister persister = session.getEntityPersister( null, new LazySelectNode() );
+			final EntityKey key1 = session.generateEntityKey( 10, persister );
+			final EntityKey key2 = session.generateEntityKey( 20, persister );
+			final EntityKey key3 = session.generateEntityKey( 30, persister );
+
+			final LazySelectRoot in = em.find( LazySelectRoot.class, 1L );
+
+			final BatchFetchQueue batchFetchQueue = session.getPersistenceContextInternal().getBatchFetchQueue();
+			assertThat( batchFetchQueue.getSubselect( key1 ), is( notNullValue() ) );
+			assertThat( batchFetchQueue.getSubselect( key2 ), is( notNullValue() ) );
+			assertThat( batchFetchQueue.getSubselect( key3 ), is( notNullValue() ) );
+
+			return in;
+		} );
+
+		for ( final LazySelectNode node : root.nodes ) {
+			assertThat( Hibernate.isInitialized( ( (LazySelectNode) Hibernate.unproxy( node ) ).children ),
+						is( false )
+			);
+		}
+	}
+
+	@Test
+	void testSubselectFetchingFromQuery(final EntityManagerFactoryScope scope) {
+		final LazySelectRoot root = scope.fromTransaction( em -> {
+			final SessionImplementor session = em.unwrap( SessionImplementor.class );
+			final EntityPersister persister = session.getEntityPersister( null, new LazySelectNode() );
+			final EntityKey key1 = session.generateEntityKey( 10, persister );
+			final EntityKey key2 = session.generateEntityKey( 20, persister );
+			final EntityKey key3 = session.generateEntityKey( 30, persister );
+
+			final LazySelectRoot in = em.createQuery( "select r from root r join fetch r.nodes where r.id = ?1",
+													  LazySelectRoot.class ).setParameter( 1, 1 ).getSingleResult();
+
+			final BatchFetchQueue batchFetchQueue = session.getPersistenceContextInternal().getBatchFetchQueue();
+			assertThat( batchFetchQueue.getSubselect( key1 ), is( notNullValue() ) );
+			assertThat( batchFetchQueue.getSubselect( key2 ), is( notNullValue() ) );
+			assertThat( batchFetchQueue.getSubselect( key3 ), is( notNullValue() ) );
+			return in;
+		} );
+
+		for ( final LazySelectNode node : root.nodes ) {
+			assertThat( Hibernate.isInitialized( ( (LazySelectNode) Hibernate.unproxy( node ) ).children ),
+						is( false )
+			);
+		}
+	}
+
+	@Entity(name = "root")
+	public static class LazySelectRoot {
+		@Id
+		public Integer id;
+
+		@OneToMany(cascade = CascadeType.ALL, fetch = FetchType.EAGER, mappedBy = "root")
+		public Set<LazySelectNode> nodes = new HashSet<>();
+	}
+
+	@Entity(name = "node")
+	public static class LazySelectNode {
+
+		@Id
+		public Integer id;
+
+		@ManyToOne(cascade = CascadeType.ALL)
+		public LazySelectRoot root;
+
+		@ManyToMany(cascade = CascadeType.ALL)
+		@JoinTable(name = "RELATIONSHIPS")
+		@Fetch(FetchMode.SUBSELECT)
+		public final Set<LazySelectNode> children = new HashSet<>();
+	}
+}


### PR DESCRIPTION
<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

I have come to the conclusion that this must be a bug, because the same query is executed but the effect is different. Here is a testcase that will succeed when fixed.

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-18855
<!-- Hibernate GitHub Bot issue links end -->