### PR TITLE
HHH-18384 @JoinColumnsOrFormulas broken

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/boot/model/internal/EmbeddableBinder.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/internal/EmbeddableBinder.java
@@ -648,7 +648,7 @@ public class EmbeddableBinder {
 		//embeddable elements can have type defs
 		final PropertyContainer container =
 				new PropertyContainer( returnedClassOrElement, annotatedClass, propertyAccessor );
-		addElementsOfClass( classElements, container, context);
+		addElementsOfClass( classElements, container, context, 0 );
 		//add elements of the embeddable's mapped superclasses
 		ClassDetails subclass = returnedClassOrElement;
 		ClassDetails superClass;
@@ -659,7 +659,7 @@ public class EmbeddableBinder {
 					annotatedClass,
 					propertyAccessor
 			);
-			addElementsOfClass( classElements, superContainer, context );
+			addElementsOfClass( classElements, superContainer, context, 0 );
 			if ( subclassToSuperclass != null ) {
 				subclassToSuperclass.put( subclass.getName(), superClass.getName() );
 			}
@@ -690,7 +690,7 @@ public class EmbeddableBinder {
 			assert put == null;
 			// collect property of subclass
 			final PropertyContainer superContainer = new PropertyContainer( subclass, superclass, propertyAccessor );
-			addElementsOfClass( classElements, superContainer, context );
+			addElementsOfClass( classElements, superContainer, context, 0 );
 			// recursively do that same for all subclasses
 			collectSubclassElements(
 					propertyAccessor,
@@ -764,7 +764,7 @@ public class EmbeddableBinder {
 						entityAtStake,
 						propertyAccessor
 				);
-				addElementsOfClass( baseClassElements, container, context );
+				addElementsOfClass( baseClassElements, container, context, 0 );
 				baseReturnedClassOrElement = baseReturnedClassOrElement.determineRawClass().getGenericSuperType();
 			}
 			return baseClassElements;

--- a/hibernate-core/src/main/java/org/hibernate/boot/model/internal/EntityBinder.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/internal/EntityBinder.java
@@ -633,7 +633,8 @@ public class EntityBinder {
 				inferredData.getPropertyType(),
 				propertyAccessor
 		);
-		addElementsOfClass( baseClassElements, propContainer, context, 0 );
+		final int idPropertyCount = addElementsOfClass( baseClassElements, propContainer, context, 0 );
+		assert idPropertyCount == 1;
 		//Id properties are on top and there is only one
 		return baseClassElements.get( 0 );
 	}

--- a/hibernate-core/src/main/java/org/hibernate/boot/model/internal/EntityBinder.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/internal/EntityBinder.java
@@ -633,7 +633,7 @@ public class EntityBinder {
 				inferredData.getPropertyType(),
 				propertyAccessor
 		);
-		addElementsOfClass( baseClassElements, propContainer, context );
+		addElementsOfClass( baseClassElements, propContainer, context, 0 );
 		//Id properties are on top and there is only one
 		return baseClassElements.get( 0 );
 	}

--- a/hibernate-core/src/main/java/org/hibernate/boot/model/internal/InheritanceState.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/internal/InheritanceState.java
@@ -235,12 +235,11 @@ public class InheritanceState {
 						classDetails,
 						accessType
 				);
-				int currentIdPropertyCount = addElementsOfClass(
+				idPropertyCount = addElementsOfClass(
 						elements,
 						propertyContainer,
-						buildingContext
-				);
-				idPropertyCount += currentIdPropertyCount;
+						buildingContext,
+						idPropertyCount );
 			}
 
 			if ( idPropertyCount == 0 && !inheritanceState.hasParents() ) {

--- a/hibernate-core/src/main/java/org/hibernate/boot/model/internal/PropertyBinder.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/internal/PropertyBinder.java
@@ -585,8 +585,8 @@ public class PropertyBinder {
 	 * @param propertyContainer Metadata about a class and its properties
 	 * @param idPropertyCounter number of id properties already present in list of {@link PropertyData} instances
 	 *
-	 * @return total number of id properties found after iterating the elements of
-	 * {@code annotatedClass} using the determined access strategy
+	 * @return total number of id properties found after iterating the elements of {@code annotatedClass}
+	 * using the determined access strategy (starting from the provided {@code idPropertyCounter})
 	 */
 	static int addElementsOfClass(
 			List<PropertyData> elements,
@@ -602,7 +602,8 @@ public class PropertyBinder {
 			PropertyContainer propertyContainer,
 			MemberDetails property,
 			List<PropertyData> inFlightPropertyDataList,
-			MetadataBuildingContext context, int idPropertyCounter) {
+			MetadataBuildingContext context,
+			int idPropertyCounter) {
 		// see if inFlightPropertyDataList already contains a PropertyData for this name,
 		// and if so, skip it...
 		for ( PropertyData propertyData : inFlightPropertyDataList ) {

--- a/hibernate-core/src/main/java/org/hibernate/boot/model/internal/PropertyBinder.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/internal/PropertyBinder.java
@@ -593,7 +593,7 @@ public class PropertyBinder {
 			MetadataBuildingContext context) {
 		int idPropertyCounter = 0;
 		for ( MemberDetails property : propertyContainer.propertyIterator() ) {
-			idPropertyCounter += addProperty( propertyContainer, property, elements, context );
+			idPropertyCounter = addProperty( propertyContainer, property, elements, context, idPropertyCounter );
 		}
 		return idPropertyCounter;
 	}
@@ -602,20 +602,19 @@ public class PropertyBinder {
 			PropertyContainer propertyContainer,
 			MemberDetails property,
 			List<PropertyData> inFlightPropertyDataList,
-			MetadataBuildingContext context) {
+			MetadataBuildingContext context, int idPropertyCounter) {
 		// see if inFlightPropertyDataList already contains a PropertyData for this name,
 		// and if so, skip it...
 		for ( PropertyData propertyData : inFlightPropertyDataList ) {
 			if ( propertyData.getPropertyName().equals( property.resolveAttributeName() ) ) {
 				checkIdProperty( property, propertyData );
 				// EARLY EXIT!!!
-				return 0;
+				return idPropertyCounter;
 			}
 		}
 
 		final ClassDetails declaringClass = propertyContainer.getDeclaringClass();
 		final TypeVariableScope ownerType = propertyContainer.getTypeAtStake();
-		int idPropertyCounter = 0;
 		final PropertyData propertyAnnotatedElement = new PropertyInferredData(
 				declaringClass,
 				ownerType,
@@ -628,7 +627,7 @@ public class PropertyBinder {
 		// before any association by Hibernate
 		final MemberDetails element = propertyAnnotatedElement.getAttributeMember();
 		if ( hasIdAnnotation( element ) ) {
-			inFlightPropertyDataList.add( 0, propertyAnnotatedElement );
+			inFlightPropertyDataList.add( idPropertyCounter, propertyAnnotatedElement );
 			handleIdProperty( propertyContainer, context, declaringClass, ownerType, element );
 			if ( hasToOneAnnotation( element ) ) {
 				context.getMetadataCollector()

--- a/hibernate-core/src/main/java/org/hibernate/boot/model/internal/PropertyBinder.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/internal/PropertyBinder.java
@@ -583,15 +583,15 @@ public class PropertyBinder {
 	/**
 	 * @param elements List of {@link PropertyData} instances
 	 * @param propertyContainer Metadata about a class and its properties
+	 * @param idPropertyCounter number of id properties already present in list of {@link PropertyData} instances
 	 *
-	 * @return the number of id properties found while iterating the elements of
-	 *         {@code annotatedClass} using the determined access strategy
+	 * @return total number of id properties found after iterating the elements of
+	 * {@code annotatedClass} using the determined access strategy
 	 */
 	static int addElementsOfClass(
 			List<PropertyData> elements,
 			PropertyContainer propertyContainer,
-			MetadataBuildingContext context) {
-		int idPropertyCounter = 0;
+			MetadataBuildingContext context, int idPropertyCounter) {
 		for ( MemberDetails property : propertyContainer.propertyIterator() ) {
 			idPropertyCounter = addProperty( propertyContainer, property, elements, context, idPropertyCounter );
 		}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/boot/models/hbm/joinformula/JoinColumnAndFormulaTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/boot/models/hbm/joinformula/JoinColumnAndFormulaTests.java
@@ -13,7 +13,6 @@ import org.hibernate.mapping.Value;
 
 import org.hibernate.testing.orm.junit.DomainModel;
 import org.hibernate.testing.orm.junit.DomainModelScope;
-import org.hibernate.testing.orm.junit.FailureExpected;
 import org.hibernate.testing.orm.junit.ServiceRegistry;
 import org.hibernate.testing.orm.junit.Setting;
 import org.junit.jupiter.api.Test;
@@ -40,7 +39,6 @@ public class JoinColumnAndFormulaTests {
 	@Test
 	@ServiceRegistry( settings = @Setting( name= MappingSettings.TRANSFORM_HBM_XML, value = "true" ) )
 	@DomainModel( xmlMappings = "mappings/models/hbm/joinformula/many-to-one-join-column-and-formula.xml" )
-	@FailureExpected( reason = "@JoinColumnsOrFormulas broken", jiraKey = "https://hibernate.atlassian.net/browse/HHH-18384" )
 	void testHbmXmlTransformed(DomainModelScope domainModelScope) {
 		verifyMapping( domainModelScope );
 	}


### PR DESCRIPTION
See Jira issue [HHH-18384](https://hibernate.atlassian.net/browse/HHH-18384)

In `org.hibernate.boot.model.internal.PropertyBinder#addProperty`element annotated with `@Id` should be added before not annotated elements, but after previously added annotated elements

Additionally, preserving hierarchy order.

----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------


[HHH-18384]: https://hibernate.atlassian.net/browse/HHH-18384?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ