### PR TITLE
remove unused close(Statement) and close(ResultSet) from JdbcCoordinatorImpl

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/engine/jdbc/internal/JdbcCoordinatorImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/jdbc/internal/JdbcCoordinatorImpl.java
@@ -4,15 +4,6 @@
  */
 package org.hibernate.engine.jdbc.internal;
 
-import java.io.IOException;
-import java.io.ObjectInputStream;
-import java.io.ObjectOutputStream;
-import java.sql.Connection;
-import java.sql.ResultSet;
-import java.sql.SQLException;
-import java.sql.Statement;
-import java.util.function.Supplier;
-
 import org.hibernate.ConnectionReleaseMode;
 import org.hibernate.HibernateException;
 import org.hibernate.TransactionException;
@@ -20,7 +11,6 @@ import org.hibernate.engine.jdbc.batch.JdbcBatchLogging;
 import org.hibernate.engine.jdbc.batch.spi.Batch;
 import org.hibernate.engine.jdbc.batch.spi.BatchKey;
 import org.hibernate.engine.jdbc.mutation.group.PreparedStatementGroup;
-import org.hibernate.engine.jdbc.spi.InvalidatableWrapper;
 import org.hibernate.engine.jdbc.spi.JdbcCoordinator;
 import org.hibernate.engine.jdbc.spi.JdbcServices;
 import org.hibernate.engine.jdbc.spi.JdbcWrapper;
@@ -39,6 +29,14 @@ import org.hibernate.resource.jdbc.internal.ResourceRegistryStandardImpl;
 import org.hibernate.resource.jdbc.spi.JdbcSessionOwner;
 import org.hibernate.resource.jdbc.spi.LogicalConnectionImplementor;
 import org.hibernate.resource.transaction.backend.jdbc.spi.JdbcResourceTransaction;
+
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.function.Supplier;
 
 import static org.hibernate.ConnectionReleaseMode.AFTER_STATEMENT;
 
@@ -355,71 +353,6 @@ public class JdbcCoordinatorImpl implements JdbcCoordinator {
 	@Override
 	public void disableReleases() {
 		releasesEnabled = false;
-	}
-
-	protected void close(Statement statement) {
-		LOG.tracev( "Closing prepared statement [{0}]", statement );
-
-		// Important for Statement caching -- some DBs (especially Sybase) log warnings on every Statement under
-		// certain situations.
-		sqlExceptionHelper().logAndClearWarnings( statement );
-
-		if ( statement instanceof InvalidatableWrapper ) {
-			@SuppressWarnings("unchecked")
-			final InvalidatableWrapper<Statement> wrapper = (InvalidatableWrapper<Statement>) statement;
-			close( wrapper.getWrappedObject() );
-			wrapper.invalidate();
-		}
-		else {
-			try {
-				// if we are unable to "clean" the prepared statement,
-				// we do not close it
-				try {
-					if ( statement.getMaxRows() != 0 ) {
-						statement.setMaxRows( 0 );
-					}
-					if ( statement.getQueryTimeout() != 0 ) {
-						statement.setQueryTimeout( 0 );
-					}
-				}
-				catch( SQLException sqle ) {
-					// there was a problem "cleaning" the prepared statement
-					if ( LOG.isDebugEnabled() ) {
-						LOG.debugf( "Exception clearing maxRows/queryTimeout [%s]", sqle.getMessage() );
-					}
-					// EARLY EXIT!!!
-					return;
-				}
-				statement.close();
-				if ( lastQuery == statement ) {
-					lastQuery = null;
-				}
-			}
-			catch ( Exception e ) {
-				LOG.debugf( "Unable to release JDBC statement [%s]", e.getMessage() );
-			}
-		}
-	}
-
-
-	protected void close(ResultSet resultSet) {
-		LOG.tracev( "Closing result set [{0}]", resultSet );
-
-		if ( resultSet instanceof InvalidatableWrapper ) {
-			@SuppressWarnings("unchecked")
-			final InvalidatableWrapper<ResultSet> wrapper = (InvalidatableWrapper<ResultSet>) resultSet;
-			close( wrapper.getWrappedObject() );
-			wrapper.invalidate();
-			return;
-		}
-
-		try {
-			resultSet.close();
-		}
-		catch ( Exception e ) {
-			// try to handle general errors more elegantly
-			LOG.debugf( "Unable to release JDBC result set [%s]", e.getMessage() );
-		}
 	}
 
 	@Override


### PR DESCRIPTION
Seems the two protected methods in `org.hibernate.engine.jdbc.internal.JdbcCoordinatorImpl` was copied to `org.hibernate.resource.jdbc.internal.ResourceRegistryStandardImpl` when working on https://hibernate.atlassian.net/browse/HHH-9747

Furthermore, these two dangling methods are never used anywhere.

not 100% sure, though.

----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
