### PR TITLE
HHH-18780 Use column type information to generate union subclass null casts

### DIFF
--- a/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/PostgreSQLLegacyDialect.java
+++ b/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/PostgreSQLLegacyDialect.java
@@ -56,6 +56,8 @@ import org.hibernate.internal.util.JdbcExceptionHelper;
 import org.hibernate.mapping.AggregateColumn;
 import org.hibernate.mapping.Table;
 import org.hibernate.metamodel.mapping.EntityMappingType;
+import org.hibernate.metamodel.mapping.SqlExpressible;
+import org.hibernate.metamodel.mapping.SqlTypedMapping;
 import org.hibernate.metamodel.spi.RuntimeModelCreationContext;
 import org.hibernate.procedure.internal.PostgreSQLCallableStatementSupport;
 import org.hibernate.procedure.spi.CallableStatementSupport;
@@ -948,6 +950,14 @@ public class PostgreSQLLegacyDialect extends Dialect {
 	public String getSelectClauseNullString(int sqlType, TypeConfiguration typeConfiguration) {
 		// Workaround for postgres bug #1453
 		return "cast(null as " + typeConfiguration.getDdlTypeRegistry().getDescriptor( sqlType ).getRawTypeName() + ")";
+	}
+
+	@Override
+	public String getSelectClauseNullString(SqlTypedMapping sqlType, TypeConfiguration typeConfiguration) {
+		final String castTypeName = typeConfiguration.getDdlTypeRegistry()
+				.getDescriptor( sqlType.getJdbcMapping().getJdbcType().getDdlTypeCode() )
+				.getCastTypeName( sqlType.toSize(), (SqlExpressible) sqlType.getJdbcMapping(), typeConfiguration.getDdlTypeRegistry() );
+		return "cast(null as " + castTypeName + ")";
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/dialect/Dialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/Dialect.java
@@ -82,6 +82,7 @@ import org.hibernate.mapping.Table;
 import org.hibernate.mapping.UniqueKey;
 import org.hibernate.mapping.UserDefinedType;
 import org.hibernate.metamodel.mapping.EntityMappingType;
+import org.hibernate.metamodel.mapping.SqlTypedMapping;
 import org.hibernate.metamodel.spi.RuntimeModelCreationContext;
 import org.hibernate.persister.entity.EntityPersister;
 import org.hibernate.persister.entity.mutation.EntityMutationTarget;
@@ -3084,9 +3085,29 @@ public abstract class Dialect implements ConversionContext, TypeContributor, Fun
 	 * @param sqlType The {@link Types} type code.
 	 * @param typeConfiguration The type configuration
 	 * @return The appropriate select clause value fragment.
+	 * @deprecated Use {@link #getSelectClauseNullString(SqlTypedMapping, TypeConfiguration)} instead
 	 */
+	@Deprecated(forRemoval = true)
 	public String getSelectClauseNullString(int sqlType, TypeConfiguration typeConfiguration) {
 		return "null";
+	}
+
+	/**
+	 * Given a type mapping, return the expression
+	 * for a literal null value of that type, to use in a {@code select}
+	 * clause.
+	 * <p>
+	 * The {@code select} query will be an element of a {@code UNION}
+	 * or {@code UNION ALL}.
+	 *
+	 * @implNote Some databases require an explicit type cast.
+	 *
+	 * @param sqlTypeMapping The type mapping.
+	 * @param typeConfiguration The type configuration
+	 * @return The appropriate select clause value fragment.
+	 */
+	public String getSelectClauseNullString(SqlTypedMapping sqlTypeMapping, TypeConfiguration typeConfiguration) {
+		return getSelectClauseNullString( sqlTypeMapping.getJdbcMapping().getJdbcType().getDdlTypeCode(), typeConfiguration );
 	}
 
 	/**

--- a/hibernate-core/src/main/java/org/hibernate/dialect/DialectDelegateWrapper.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/DialectDelegateWrapper.java
@@ -57,6 +57,7 @@ import org.hibernate.mapping.Table;
 import org.hibernate.mapping.UniqueKey;
 import org.hibernate.mapping.UserDefinedType;
 import org.hibernate.metamodel.mapping.EntityMappingType;
+import org.hibernate.metamodel.mapping.SqlTypedMapping;
 import org.hibernate.metamodel.spi.RuntimeModelCreationContext;
 import org.hibernate.persister.entity.EntityPersister;
 import org.hibernate.persister.entity.mutation.EntityMutationTarget;
@@ -721,6 +722,16 @@ public class DialectDelegateWrapper extends Dialect {
 	@Override
 	public String getSelectClauseNullString(int sqlType, TypeConfiguration typeConfiguration) {
 		return wrapped.getSelectClauseNullString( sqlType, typeConfiguration );
+	}
+
+	@Override
+	public String getSelectClauseNullString(SqlTypedMapping sqlTypeMapping, TypeConfiguration typeConfiguration) {
+		return wrapped.getSelectClauseNullString( sqlTypeMapping, typeConfiguration );
+	}
+
+	@Override
+	public boolean stripsTrailingSpacesFromChar() {
+		return wrapped.stripsTrailingSpacesFromChar();
 	}
 
 	@Override

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/dialect/PostgreSQLDialectTestCase.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/dialect/PostgreSQLDialectTestCase.java
@@ -9,6 +9,7 @@ import java.sql.CallableStatement;
 import java.sql.SQLException;
 
 import org.hibernate.JDBCException;
+import org.hibernate.Length;
 import org.hibernate.LockMode;
 import org.hibernate.LockOptions;
 import org.hibernate.PessimisticLockException;
@@ -26,8 +27,12 @@ import org.hibernate.exception.spi.SQLExceptionConversionDelegate;
 import org.hibernate.mapping.Table;
 import org.hibernate.mapping.UniqueKey;
 
+import org.hibernate.metamodel.mapping.internal.SqlTypedMappingImpl;
+import org.hibernate.query.sqm.function.SqmFunctionRegistry;
+import org.hibernate.testing.orm.junit.DialectFeatureChecks;
 import org.hibernate.testing.orm.junit.JiraKey;
 import org.hibernate.testing.junit4.BaseUnitTestCase;
+import org.hibernate.type.spi.TypeConfiguration;
 import org.junit.Test;
 
 import org.mockito.Mockito;
@@ -148,6 +153,41 @@ public class PostgreSQLDialectTestCase extends BaseUnitTestCase {
 		);
 
 		assertEquals("alter table if exists table_name drop constraint if exists unique_something", sql );
+	}
+
+	@Test
+	@JiraKey( value = "HHH-18780" )
+	public void testTextVsVarchar() {
+		PostgreSQLDialect dialect = new PostgreSQLDialect();
+
+		final TypeConfiguration typeConfiguration = new TypeConfiguration();
+		final SqmFunctionRegistry functionRegistry = new SqmFunctionRegistry();
+		typeConfiguration.scope( new DialectFeatureChecks.FakeMetadataBuildingContext( typeConfiguration, functionRegistry ) );
+		final DialectFeatureChecks.FakeTypeContributions typeContributions = new DialectFeatureChecks.FakeTypeContributions( typeConfiguration );
+		final DialectFeatureChecks.FakeFunctionContributions functionContributions = new DialectFeatureChecks.FakeFunctionContributions(
+				dialect,
+				typeConfiguration,
+				functionRegistry
+		);
+		dialect.contribute( typeContributions, typeConfiguration.getServiceRegistry() );
+		dialect.initializeFunctionRegistry( functionContributions );
+		final String varcharNullString = dialect.getSelectClauseNullString(
+				new SqlTypedMappingImpl( typeConfiguration.getBasicTypeForJavaType( String.class ) ),
+				typeConfiguration
+		);
+		final String textNullString = dialect.getSelectClauseNullString(
+				new SqlTypedMappingImpl(
+						null,
+						(long) Length.LONG32,
+						null,
+						null,
+						null,
+						typeConfiguration.getBasicTypeForJavaType( String.class )
+				),
+				typeConfiguration
+		);
+		assertEquals("cast(null as varchar)", varcharNullString);
+		assertEquals("cast(null as text)", textNullString);
 	}
 
 	private static class MockSqlStringGenerationContext implements SqlStringGenerationContext {

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/hql/joinedSubclass/JoinedSubclassNativeQueryTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/hql/joinedSubclass/JoinedSubclassNativeQueryTest.java
@@ -6,12 +6,13 @@ package org.hibernate.orm.test.hql.joinedSubclass;
 
 import org.hibernate.cfg.AvailableSettings;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
-import org.hibernate.type.SqlTypes;
+import org.hibernate.metamodel.mapping.internal.SqlTypedMappingImpl;
 
 import org.hibernate.testing.orm.junit.JiraKey;
 import org.hibernate.testing.orm.junit.DomainModel;
 import org.hibernate.testing.orm.junit.SessionFactory;
 import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.hibernate.type.spi.TypeConfiguration;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
@@ -61,10 +62,14 @@ public class JoinedSubclassNativeQueryTest {
 		scope.inTransaction(
 				session -> {
 					final SessionFactoryImplementor sessionFactory = scope.getSessionFactory();
+					final TypeConfiguration typeConfiguration = sessionFactory.getTypeConfiguration();
 					final String nullColumnString = sessionFactory
 							.getJdbcServices()
 							.getDialect()
-							.getSelectClauseNullString( SqlTypes.VARCHAR, sessionFactory.getTypeConfiguration() );
+							.getSelectClauseNullString(
+									new SqlTypedMappingImpl( typeConfiguration.getBasicTypeForJavaType( String.class ) ),
+									typeConfiguration
+							);
 					// PostgreSQLDialect#getSelectClauseNullString produces e.g. `null::text` which we interpret as parameter,
 					// so workaround this problem by configuring to ignore JDBC parameters
 					session.setProperty( AvailableSettings.NATIVE_IGNORE_JDBC_PARAMETERS, true );

--- a/hibernate-testing/src/main/java/org/hibernate/testing/orm/junit/DialectFeatureChecks.java
+++ b/hibernate-testing/src/main/java/org/hibernate/testing/orm/junit/DialectFeatureChecks.java
@@ -1090,7 +1090,7 @@ abstract public class DialectFeatureChecks {
 		return sqmFunctionRegistry;
 	}
 
-	private static class FakeTypeContributions implements TypeContributions {
+	public static class FakeTypeContributions implements TypeContributions {
 		private final TypeConfiguration typeConfiguration;
 
 		public FakeTypeContributions(TypeConfiguration typeConfiguration) {
@@ -1103,7 +1103,7 @@ abstract public class DialectFeatureChecks {
 		}
 	}
 
-	private static class FakeFunctionContributions implements FunctionContributions {
+	public static class FakeFunctionContributions implements FunctionContributions {
 		private final Dialect dialect;
 		private final TypeConfiguration typeConfiguration;
 		private final SqmFunctionRegistry functionRegistry;


### PR DESCRIPTION
<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-18780
<!-- Hibernate GitHub Bot issue links end -->