### PR TITLE
Update userguide about natural-ids

### DIFF
--- a/documentation/src/main/asciidoc/userguide/chapters/domain/natural_id.adoc
+++ b/documentation/src/main/asciidoc/userguide/chapters/domain/natural_id.adoc
@@ -8,11 +8,12 @@
 :extrasdir: extras
 
 Natural ids represent domain model unique identifiers that have a meaning in the real world too.
-Even if a natural id does not make a good primary key (surrogate keys being usually preferred), it's still useful to tell Hibernate about it.
-As we will see later, Hibernate provides a dedicated, efficient API for loading an entity by its natural id much like it offers for loading by identifier (PK).
 
 [IMPORTANT]
 ====
+NaturalId Annotations are a proprietary Hibernate feature and not a part of JPA. They should only be used
+if you intent to use NaturalIdLoadAccess, which is also a proprietary hibernate feature.
+
 All values used in a natural id must be non-nullable.
 
 For natural id mappings using a to-one association, this precludes the use of not-found


### PR DESCRIPTION
And this is my last attempt to do anyhting about this.

See #7724
> It's also disabled whenever the whole second-level cache is disabled, and it's easy to disable the second-level cache (it's even disabled by default).

This satement is missleading. This has never been about the "regular" second level-level cache.  Yes you can turn off the regular second level cache and thats fine. However this has never been about the second level cache. Its about the field 'resolutionsByEntity' inside NaturalIdResolutionsImpl. There is currently no way to stop hibernate from constantly playing around with this map.  second-level cache or not hibernate always updates this map.

Just run MutableNaturelIdTest (or any other test about NaturalIds) and put a breakepoint in NaturalIdResolutionsImpl. Second layer cache is off (by default) and hibernate is still updating its resolution cache.

![grafik](https://github.com/user-attachments/assets/3c68b6d8-b92e-45aa-ba08-7aca3c44bed2)
 

 




<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
