### PR TITLE
HHH-18892 add portable sha() and md5() functions to HQL

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/dialect/CockroachDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/CockroachDialect.java
@@ -413,7 +413,6 @@ public class CockroachDialect extends Dialect {
 		functionFactory.substr();
 		functionFactory.reverse();
 		functionFactory.repeat();
-		functionFactory.md5();
 		functionFactory.sha1();
 		functionFactory.octetLength();
 		functionFactory.bitLength();
@@ -503,6 +502,9 @@ public class CockroachDialect extends Dialect {
 				new PostgreSQLTruncFunction( true, functionContributions.getTypeConfiguration() )
 		);
 		functionContributions.getFunctionRegistry().registerAlternateKey( "truncate", "trunc" );
+
+		functionFactory.sha( "digest(?1, 'sha256')" );
+		functionFactory.md5( "digest(?1, 'md5')" );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/dialect/DB2Dialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/DB2Dialect.java
@@ -452,6 +452,9 @@ public class DB2Dialect extends Dialect {
 
 		functionFactory.unnest_db2( getMaximumSeriesSize() );
 		functionFactory.generateSeries_recursive( getMaximumSeriesSize(), false, true );
+
+		functionFactory.sha( "hash(?1, 2)" );
+		functionFactory.md5( "hash(?1, 0)" );
 	}
 
 	/**

--- a/hibernate-core/src/main/java/org/hibernate/dialect/H2Dialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/H2Dialect.java
@@ -368,6 +368,9 @@ public class H2Dialect extends Dialect {
 		functionFactory.unnest_h2( getMaximumArraySize() );
 		functionFactory.generateSeries_h2( getMaximumSeriesSize() );
 		functionFactory.jsonTable_h2( getMaximumArraySize() );
+
+		functionFactory.sha( "hash('SHA-256', ?1)" );
+		functionFactory.md5( "hash('MD5', ?1)" );
 	}
 
 	/**

--- a/hibernate-core/src/main/java/org/hibernate/dialect/HANADialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/HANADialect.java
@@ -517,6 +517,9 @@ public class HANADialect extends Dialect {
 
 //		functionFactory.xmlextract();
 		functionFactory.generateSeries_hana( getMaximumSeriesSize() );
+
+		functionFactory.sha( "hash_sha256(?1)" );
+		functionFactory.md5( "hash_md5(?1)" );
 	}
 
 	/**

--- a/hibernate-core/src/main/java/org/hibernate/dialect/MySQLDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/MySQLDialect.java
@@ -590,7 +590,6 @@ public class MySQLDialect extends Dialect {
 		functionFactory.space();
 		functionFactory.repeat();
 		functionFactory.pad_space();
-		functionFactory.md5();
 		functionFactory.yearMonthDay();
 		functionFactory.hourMinuteSecond();
 		functionFactory.dayofweekmonthyear();
@@ -606,7 +605,6 @@ public class MySQLDialect extends Dialect {
 		functionFactory.crc32();
 		functionFactory.sha1();
 		functionFactory.sha2();
-		functionFactory.sha();
 		functionFactory.bitLength();
 		functionFactory.octetLength();
 		functionFactory.ascii();
@@ -688,6 +686,9 @@ public class MySQLDialect extends Dialect {
 		if ( supportsRecursiveCTE() ) {
 			functionFactory.generateSeries_recursive( getMaximumSeriesSize(), false, false );
 		}
+
+		functionFactory.sha( "unhex(sha2(?1, 256))" );
+		functionFactory.md5( "unhex(md5(?1))" );
 	}
 
 	/**

--- a/hibernate-core/src/main/java/org/hibernate/dialect/OracleDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/OracleDialect.java
@@ -440,6 +440,9 @@ public class OracleDialect extends Dialect {
 		functionFactory.unnest_oracle();
 		functionFactory.generateSeries_recursive( getMaximumSeriesSize(), true, false );
 		functionFactory.jsonTable_oracle();
+
+		functionFactory.sha( "standard_hash(?1, 'SHA256')" );
+		functionFactory.md5( "standard_hash(?1, 'MD5')" );
 	}
 
 	/**

--- a/hibernate-core/src/main/java/org/hibernate/dialect/PostgreSQLDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/PostgreSQLDialect.java
@@ -550,7 +550,6 @@ public class PostgreSQLDialect extends Dialect {
 		functionFactory.pi();
 		functionFactory.trim2();
 		functionFactory.repeat();
-		functionFactory.md5();
 		functionFactory.initcap();
 		functionFactory.substr();
 		functionFactory.substring_substr();
@@ -690,6 +689,9 @@ public class PostgreSQLDialect extends Dialect {
 			functionFactory.unnest_postgresql();
 		}
 		functionFactory.generateSeries( null, "ordinality", false );
+
+		functionFactory.sha( "sha256(?1)" );
+		functionFactory.md5( "decode(md5(?1), 'hex')" );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/dialect/SQLServerDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/SQLServerDialect.java
@@ -487,6 +487,9 @@ public class SQLServerDialect extends AbstractTransactSQLDialect {
 				functionFactory.generateSeries_recursive( getMaximumSeriesSize(), false, false );
 			}
 		}
+
+		functionFactory.sha( "hashbytes('SHA2_256', ?1)" );
+		functionFactory.md5( "hashbytes('MD5', ?1)" );
 	}
 
 	/**

--- a/hibernate-core/src/main/java/org/hibernate/dialect/function/CommonFunctionFactory.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/function/CommonFunctionFactory.java
@@ -68,6 +68,7 @@ public class CommonFunctionFactory {
 	private final BasicType<Boolean> booleanType;
 	private final BasicType<Character> characterType;
 	private final BasicType<String> stringType;
+	private final BasicType<byte[]> binaryType;
 	private final BasicType<Integer> integerType;
 	private final BasicType<Long> longType;
 	private final BasicType<Double> doubleType;
@@ -90,6 +91,7 @@ public class CommonFunctionFactory {
 		characterType = basicTypeRegistry.resolve(StandardBasicTypes.CHARACTER);
 		booleanType = basicTypeRegistry.resolve(StandardBasicTypes.BOOLEAN);
 		stringType = basicTypeRegistry.resolve(StandardBasicTypes.STRING);
+		binaryType = basicTypeRegistry.resolve(StandardBasicTypes.BINARY);
 		integerType = basicTypeRegistry.resolve(StandardBasicTypes.INTEGER);
 		doubleType = basicTypeRegistry.resolve(StandardBasicTypes.DOUBLE);
 	}
@@ -813,6 +815,7 @@ public class CommonFunctionFactory {
 		functionRegistry.registerAlternateKey( "repeat", "replicate" );
 	}
 
+	@Deprecated(since = "7")
 	public void md5() {
 		functionRegistry.namedDescriptorBuilder( "md5" )
 				.setInvariantType(stringType)
@@ -2313,6 +2316,7 @@ public class CommonFunctionFactory {
 				.register();
 	}
 
+	@Deprecated(since = "7")
 	public void crc32() {
 		functionRegistry.namedDescriptorBuilder( "crc32" )
 				.setInvariantType(integerType)
@@ -2321,6 +2325,23 @@ public class CommonFunctionFactory {
 				.register();
 	}
 
+	public void md5(String pattern) {
+		functionRegistry.patternDescriptorBuilder( "md5", pattern )
+				.setInvariantType(binaryType)
+				.setParameterTypes( STRING )
+				.setExactArgumentCount( 1 )
+				.register();
+	}
+
+	public void sha(String pattern) {
+		functionRegistry.patternDescriptorBuilder( "sha", pattern )
+				.setInvariantType(binaryType)
+				.setParameterTypes( STRING )
+				.setExactArgumentCount( 1 )
+				.register();
+	}
+
+	@Deprecated(since = "7")
 	public void sha1() {
 		functionRegistry.namedDescriptorBuilder( "sha1" )
 				.setInvariantType(stringType)
@@ -2329,6 +2350,7 @@ public class CommonFunctionFactory {
 				.register();
 	}
 
+	@Deprecated(since = "7")
 	public void sha2() {
 		functionRegistry.namedDescriptorBuilder( "sha2" )
 				.setInvariantType(stringType)
@@ -2337,6 +2359,7 @@ public class CommonFunctionFactory {
 				.register();
 	}
 
+	@Deprecated(since = "7")
 	public void sha() {
 		functionRegistry.namedDescriptorBuilder( "sha" )
 				.setInvariantType(stringType)

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/query/hql/FunctionTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/query/hql/FunctionTests.java
@@ -15,6 +15,7 @@ import org.hibernate.dialect.CockroachDialect;
 import org.hibernate.dialect.DB2Dialect;
 import org.hibernate.community.dialect.DerbyDialect;
 import org.hibernate.dialect.H2Dialect;
+import org.hibernate.dialect.HANADialect;
 import org.hibernate.dialect.HSQLDialect;
 import org.hibernate.dialect.MariaDBDialect;
 import org.hibernate.dialect.MySQLDialect;
@@ -47,6 +48,8 @@ import org.junit.jupiter.api.Test;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 import java.sql.Time;
 import java.sql.Timestamp;
 import java.time.Duration;
@@ -2594,6 +2597,27 @@ public class FunctionTests {
 					.getSingleResultOrNull();
 			byte[] bytes = s.createSelectionQuery("select column(e.ctid as binary) from EntityOfBasics e", byte[].class)
 					.getSingleResultOrNull();
+		});
+	}
+
+	@Test
+	@RequiresDialect(PostgreSQLDialect.class)
+	@RequiresDialect(MySQLDialect.class)
+	@RequiresDialect(OracleDialect.class)
+	@RequiresDialect(DB2Dialect.class)
+	@RequiresDialect(SQLServerDialect.class)
+	@RequiresDialect(H2Dialect.class)
+	@RequiresDialect(HANADialect.class)
+	@RequiresDialect(CockroachDialect.class)
+	public void testSha256Function(SessionFactoryScope scope) {
+		scope.inTransaction(s -> {
+			byte[] bytes = s.createSelectionQuery("select sha('hello')", byte[].class).getSingleResult();
+			try {
+				assertArrayEquals( MessageDigest.getInstance( "SHA-256" ).digest("hello".getBytes()), bytes );
+			}
+			catch (NoSuchAlgorithmException e) {
+				throw new RuntimeException( e );
+			}
 		});
 	}
 }


### PR DESCRIPTION
<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

[Please describe here what your change is about]

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-18892
<!-- Hibernate GitHub Bot issue links end -->