### PR TITLE
HHH-18869 Schema validation fails with MariaDB when entity field is of type BigDecimal[]

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/dialect/MariaDBDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/MariaDBDialect.java
@@ -6,6 +6,7 @@ package org.hibernate.dialect;
 
 import java.sql.DatabaseMetaData;
 import java.sql.SQLException;
+import java.sql.Types;
 
 import org.hibernate.boot.model.FunctionContributions;
 import org.hibernate.boot.model.TypeContributions;
@@ -312,5 +313,12 @@ public class MariaDBDialect extends MySQLDialect {
 	@Override
 	public String getDual() {
 		return "dual";
+	}
+
+	@Override
+	public boolean equivalentTypes(int typeCode1, int typeCode2) {
+		return typeCode1 == Types.LONGVARCHAR && typeCode2 == SqlTypes.JSON
+			|| typeCode1 == SqlTypes.JSON && typeCode2 == Types.LONGVARCHAR
+			|| super.equivalentTypes( typeCode1, typeCode2 );
 	}
 }

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/schemavalidation/MariaDbJsonColumnValidationTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/schemavalidation/MariaDbJsonColumnValidationTest.java
@@ -1,0 +1,62 @@
+/*
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.schemavalidation;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import org.hibernate.dialect.MariaDBDialect;
+import org.hibernate.testing.junit4.BaseNonConfigCoreFunctionalTestCase;
+import org.hibernate.testing.orm.junit.JiraKey;
+import org.hibernate.testing.orm.junit.RequiresDialect;
+import org.hibernate.tool.hbm2ddl.SchemaValidator;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.math.BigDecimal;
+
+@JiraKey(value = "HHH-18869")
+@RequiresDialect(value = MariaDBDialect.class)
+public class MariaDbJsonColumnValidationTest extends BaseNonConfigCoreFunctionalTestCase {
+	@Override
+	protected Class<?>[] getAnnotatedClasses() {
+		return new Class[] {Foo.class};
+	}
+
+	@Before
+	public void init() {
+		try {
+			inTransaction( session -> {
+						try {
+							session.createNativeMutationQuery( "drop table Foo" ).executeUpdate();
+						}
+						catch (Exception e) {
+							throw new RuntimeException( e );
+						}
+					}
+			);
+			inTransaction( session ->
+					session.createNativeMutationQuery(
+							"create table Foo (id integer not null, bigDecimals json, primary key (id)) engine=InnoDB"
+					).executeUpdate()
+			);
+		}
+		catch (Exception ignored) {
+		}
+	}
+
+	@Test
+	public void testSchemaValidation() {
+		new SchemaValidator().validate( metadata() );
+	}
+
+	@Entity(name = "Foo")
+	@Table(name = "Foo")
+	public static class Foo {
+		@Id
+		public Integer id;
+		public BigDecimal[] bigDecimals;
+	}
+}


### PR DESCRIPTION
Jira issue [HHH-18869](https://hibernate.atlassian.net/browse/HHH-18869)

JSON is an alias for LONGTEXT (see [JSON Data Type](https://mariadb.com/kb/en/json-data-type/) in MariaDB Knowledge Base)

Simple fix is to override `org.hibernate.dialect.Dialect#equivalentTypes` for `MariaDBDialect` to return true when comparing those two types.


<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------


[HHH-18869]: https://hibernate.atlassian.net/browse/HHH-18869?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ