### PR TITLE
Update and migrate to asciidoc gradle plugin `3.3.2`

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ buildscript {
 		classpath 'org.hibernate.build.gradle:hibernate-matrix-testing:3.0.0.Final'
 		classpath 'org.hibernate.build.gradle:version-injection-plugin:1.0.0'
 		classpath 'gradle.plugin.com.github.lburgazzoli:gradle-karaf-plugin:0.5.1'
-		classpath 'org.asciidoctor:asciidoctor-gradle-plugin:1.5.7'
+		classpath 'org.asciidoctor:asciidoctor-gradle-jvm:3.3.2'
 		classpath 'de.thetaphi:forbiddenapis:3.0.1'
 	}
 }

--- a/documentation/documentation.gradle
+++ b/documentation/documentation.gradle
@@ -1,5 +1,5 @@
 import org.apache.tools.ant.filters.ReplaceTokens
-import org.asciidoctor.gradle.AsciidoctorTask
+import org.asciidoctor.gradle.jvm.AsciidoctorTask
 
 /*
  * Hibernate, Relational Persistence for Idiomatic Java
@@ -28,7 +28,7 @@ rootProject.subprojects { subproject ->
 
 apply from: rootProject.file( 'gradle/java-module.gradle' )
 
-apply plugin: 'org.asciidoctor.convert'
+apply plugin: 'org.asciidoctor.jvm.convert'
 
 apply plugin: 'hibernate-matrix-testing'
 
@@ -179,8 +179,6 @@ task renderTopicalGuides(type: AsciidoctorTask, group: 'Documentation') {
     description = 'Renders the  Topical Guides in HTML format using Asciidoctor.'
     sourceDir = file( 'src/main/asciidoc/topical' )
     outputDir = new File("$buildDir/asciidoc/topical/html_single")
-	backends "html5"
-	separateOutputDirs false
 	options logDocuments: true
 	attributes  icons: 'font',
 				experimental: true,
@@ -204,8 +202,6 @@ task renderGettingStartedGuides(type: AsciidoctorTask, group: 'Documentation') {
         include 'index.adoc'
     }
     outputDir = new File("$buildDir/asciidoc/quickstart/html_single")
-	backends "html5"
-	separateOutputDirs false
 	options logDocuments: true
 	attributes  icons: 'font', experimental: true, 'source-highlighter': 'prettify'
 }
@@ -234,8 +230,6 @@ task renderUserGuide(type: AsciidoctorTask, group: 'Documentation') {
         include 'Hibernate_User_Guide.adoc'
     }
     outputDir = new File("$buildDir/asciidoc/userguide/html_single")
-    backends "html5"
-    separateOutputDirs false
     options logDocuments: true
 	attributes icons: 'font', experimental: true,
 			   'source-highlighter': 'prettify',
@@ -270,8 +264,6 @@ task renderIntegrationGuide(type: AsciidoctorTask, group: 'Documentation') {
 		include 'Hibernate_Integration_Guide.adoc'
 	}
 	outputDir = new File("$buildDir/asciidoc/integrationguide/html_single")
-	backends "html5"
-	separateOutputDirs false
 	options logDocuments: true
 	attributes  icons: 'font',
 				experimental: true,
@@ -318,3 +310,10 @@ buildDocsForPublishing.dependsOn renderIntegrationGuide
 
 checkstyleMain.exclude '**/org/hibernate/userguide/model/*'
 
+tasks.withType(AsciidoctorTask).configureEach {
+	baseDirFollowsSourceDir()
+	outputOptions {
+		separateOutputDirs = false
+		backends 'html5'
+	}
+}


### PR DESCRIPTION
Older versions cannot correctly resolve dependencies

----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
