### PR TITLE
HHH-18916 - Extends Dialect#addQueryHints support for join queries

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/dialect/Dialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/Dialect.java
@@ -279,7 +279,7 @@ public abstract class Dialect implements ConversionContext, TypeContributor, Fun
 	private static final Pattern ESCAPE_CLOSING_COMMENT_PATTERN = Pattern.compile( "\\*/" );
 	private static final Pattern ESCAPE_OPENING_COMMENT_PATTERN = Pattern.compile( "/\\*" );
 	private static final Pattern QUERY_PATTERN = Pattern.compile(
-		"^\\s*(select\\b.+?\\bfrom\\b.+?)(\\b(?:natural )?(?:left |right )?(?:inner |outer )?join.+?\\b)?(\\bwhere\\b.+?)$");
+		"^\\s*(select\\b.+?\\bfrom\\b.+?)(\\b(?:natural )?(?:left |right |full )?(?:inner |outer |cross )?join.+?\\b)?(\\bwhere\\b.+?)$");
 
 	private static final CoreMessageLogger LOG = Logger.getMessageLogger( MethodHandles.lookup(), CoreMessageLogger.class, Dialect.class.getName() );
 

--- a/hibernate-core/src/test/java/org/hibernate/dialect/DialectTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/dialect/DialectTest.java
@@ -1,0 +1,53 @@
+/*
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.dialect;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.stream.Stream;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+/**
+ * Check if IndexQueryHintHandler handles correctly simple query and query with JOIN
+ *
+ * @author Rguihard
+ */
+class DialectTest {
+
+	static Stream<Arguments> _addQueryHints() {
+		final Stream.Builder<Arguments> builder = Stream.builder();
+
+		final String hints = "MY_INDEX";
+		final String simpleQuery = "select COUNT(*) from TEST t1_0 where column1 = 'value'";
+		builder.add(
+			Arguments.of("Simple query : hint",
+				"select COUNT(*) from TEST t1_0  use index (MY_INDEX) where column1 = 'value'", simpleQuery, hints));
+		final String joinQueryUsing = "select COUNT(*) from TEST t1_0 join TEST2 t2_0 using(column2) where field = 'value'";
+		builder.add(Arguments.of("Join query with using : hint",
+			"select COUNT(*) from TEST t1_0  use index (MY_INDEX) join TEST2 t2_0 using(column2) where field = 'value'",
+			joinQueryUsing, hints));
+		final String joinQueryOn = "select COUNT(*) from TEST t1_0 join TEST2 t2_0 on t1_0.column2 = t2_0.column2 where field = 'value'";
+		builder.add(Arguments.of("Join query with on : hint",
+			"select COUNT(*) from TEST t1_0  use index (MY_INDEX) join TEST2 t2_0 on t1_0.column2 = t2_0.column2 where field = 'value'",
+			joinQueryOn, hints));
+		final String leftJoinQuery = "select COUNT(*) from TEST t1_0 left join TEST2 t2_0 on t1_0.column2 = t2_0.column2 and t1_0.column3 = t2_0.column3 where field = 'value'";
+		builder.add(Arguments.of("Left join query with on : hint",
+			"select COUNT(*) from TEST t1_0  use index (MY_INDEX) left join TEST2 t2_0 on t1_0.column2 = t2_0.column2 and t1_0.column3 = t2_0.column3 where field = 'value'",
+			leftJoinQuery, hints));
+
+		return builder.build();
+	}
+
+	@MethodSource("_addQueryHints")
+	@ParameterizedTest
+	void addQueryHints(String description, String expected, String query, String hints) {
+		final String queryWithHint = MySQLDialect.addQueryHints(query, hints);
+		assertEquals(expected, queryWithHint, description);
+	}
+
+}


### PR DESCRIPTION
In case of query with left join, the existing QUERY_PATTERN of Dialect class doesn't permits to correctly append query hint (aka use index) to the query. The result is an invalid SQL query

Example of code that not works
```
myEntity.join(MyEntity_.other, JoinType.LEFT)
[...]
final TypedQuery<MyEntity> query = em.createQuery(cq);
if (query instanceof final org.hibernate.query.Query<CommandeStock> hibernateQuery) {
	hibernateQuery.addQueryHint("MY_INDEX");
}
```

Those changes aimed to improve QUERY_PATTERN. Now the regex handles queries with usuals join keywords like natural, left/right, inner/outer join.

Unit tests was appended to check existing behavior and new one.

<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

[Please describe here what your change is about]

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-18916
<!-- Hibernate GitHub Bot issue links end -->