### PR TITLE
HHH-18920 Enum parameters in Jakarta Data repository method return type constructor are not properly matched

### DIFF
--- a/tooling/metamodel-generator/src/jakartaData/java/org/hibernate/processor/test/data/selectenumproperty/Topic.java
+++ b/tooling/metamodel-generator/src/jakartaData/java/org/hibernate/processor/test/data/selectenumproperty/Topic.java
@@ -1,0 +1,19 @@
+/*
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.processor.test.data.selectenumproperty;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+
+@Entity
+public class Topic {
+
+	@Id
+	@GeneratedValue
+	private Integer topicId;
+
+	private TopicStatus topicStatus;
+}

--- a/tooling/metamodel-generator/src/jakartaData/java/org/hibernate/processor/test/data/selectenumproperty/TopicData.java
+++ b/tooling/metamodel-generator/src/jakartaData/java/org/hibernate/processor/test/data/selectenumproperty/TopicData.java
@@ -1,0 +1,10 @@
+/*
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.processor.test.data.selectenumproperty;
+
+
+record TopicData(Integer topicId, TopicStatus topicStatus) {
+
+}

--- a/tooling/metamodel-generator/src/jakartaData/java/org/hibernate/processor/test/data/selectenumproperty/TopicRepository.java
+++ b/tooling/metamodel-generator/src/jakartaData/java/org/hibernate/processor/test/data/selectenumproperty/TopicRepository.java
@@ -1,0 +1,18 @@
+/*
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.processor.test.data.selectenumproperty;
+
+import jakarta.data.repository.DataRepository;
+import jakarta.data.repository.Query;
+import jakarta.data.repository.Repository;
+
+import java.util.List;
+
+@Repository
+public interface TopicRepository extends DataRepository<Topic, Integer> {
+
+	@Query("select topicId, topicStatus from Topic")
+	List<TopicData> getTopicData();
+}

--- a/tooling/metamodel-generator/src/jakartaData/java/org/hibernate/processor/test/data/selectenumproperty/TopicStatus.java
+++ b/tooling/metamodel-generator/src/jakartaData/java/org/hibernate/processor/test/data/selectenumproperty/TopicStatus.java
@@ -1,0 +1,20 @@
+/*
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.processor.test.data.selectenumproperty;
+
+public enum TopicStatus {
+	TOPIC_UNLOCKED( 0 ),
+	TOPIC_LOCKED( 1 );
+
+	private final int topicStatus;
+
+	TopicStatus(final int topicStatus) {
+		this.topicStatus = topicStatus;
+	}
+
+	public int topicStatus() {
+		return topicStatus;
+	}
+}

--- a/tooling/metamodel-generator/src/jakartaData/java/org/hibernate/processor/test/data/selectenumproperty/TopicTypeEnumTest.java
+++ b/tooling/metamodel-generator/src/jakartaData/java/org/hibernate/processor/test/data/selectenumproperty/TopicTypeEnumTest.java
@@ -1,0 +1,25 @@
+/*
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.processor.test.data.selectenumproperty;
+
+import org.hibernate.processor.test.util.CompilationTest;
+import org.hibernate.processor.test.util.WithClasses;
+import org.junit.Test;
+
+import static org.hibernate.processor.test.util.TestUtil.assertMetamodelClassGeneratedFor;
+import static org.hibernate.processor.test.util.TestUtil.getMetaModelSourceAsString;
+
+public class TopicTypeEnumTest extends CompilationTest {
+	@Test
+	@WithClasses({Topic.class, TopicRepository.class})
+	public void test() {
+		System.out.println( getMetaModelSourceAsString( Topic.class ) );
+		System.out.println( getMetaModelSourceAsString( Topic.class, true ) );
+		System.out.println( getMetaModelSourceAsString( TopicRepository.class ) );
+		assertMetamodelClassGeneratedFor( Topic.class, true );
+		assertMetamodelClassGeneratedFor( Topic.class );
+		assertMetamodelClassGeneratedFor( TopicRepository.class );
+	}
+}

--- a/tooling/metamodel-generator/src/main/java/org/hibernate/processor/annotation/AnnotationMetaEntity.java
+++ b/tooling/metamodel-generator/src/main/java/org/hibernate/processor/annotation/AnnotationMetaEntity.java
@@ -2678,12 +2678,11 @@ public class AnnotationMetaEntity extends AnnotationMeta {
 
 	private static boolean parameterMatches(VariableElement parameter, JpaSelection<?> item) {
 		final Class<?> javaType = item.getJavaType();
-		return javaType != null && parameterMatches( parameter.asType(), javaType );
+		return javaType != null && parameterMatches( parameter.asType(), javaType, item.getJavaTypeName() );
 	}
 
-	private static boolean parameterMatches(TypeMirror parameterType, Class<?> itemType) {
+	private static boolean parameterMatches(TypeMirror parameterType, Class<?> itemType, String itemTypeName) {
 		final TypeKind kind = parameterType.getKind();
-		final String itemTypeName = itemType.getName();
 		if ( kind == TypeKind.DECLARED ) {
 			final DeclaredType declaredType = (DeclaredType) parameterType;
 			final TypeElement paramTypeElement = (TypeElement) declaredType.asElement();
@@ -2695,7 +2694,7 @@ public class AnnotationMetaEntity extends AnnotationMeta {
 		else if ( kind == TypeKind.ARRAY ) {
 			final ArrayType arrayType = (ArrayType) parameterType;
 			return itemType.isArray()
-				&& parameterMatches( arrayType.getComponentType(), itemType.getComponentType() );
+				&& parameterMatches( arrayType.getComponentType(), itemType.getComponentType(), itemType.getComponentType().getTypeName() );
 		}
 		else {
 			return false;


### PR DESCRIPTION
Jira issue [HHH-18920](https://hibernate.atlassian.net/browse/HHH-18920)

Properly resolving parameter type name when matching selection with constructor parameters.

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------


[HHH-18920]: https://hibernate.atlassian.net/browse/HHH-18920?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ