### PR TITLE
Use returnClass parameter in call to EntityManager.createNamedQuery in generated methods

### DIFF
--- a/tooling/metamodel-generator/src/main/java/org/hibernate/processor/annotation/NamedQueryMethod.java
+++ b/tooling/metamodel-generator/src/main/java/org/hibernate/processor/annotation/NamedQueryMethod.java
@@ -71,7 +71,9 @@ class NamedQueryMethod implements MetaAttribute {
 				.append(sessionVariableName)
 				.append(".createNamedQuery(")
 				.append(fieldName())
-				.append(")");
+				.append(", ")
+				.append( annotationMeta.importType( resultType( select, annotationMeta.getContext() ) ) )
+				.append( ".class)");
 		for ( SqmParameter<?> param : sortedParameters ) {
 			declaration
 					.append("\n\t\t\t.setParameter(")


### PR DESCRIPTION
Minor change. Creating named query as `TypedQuery` is avoiding (irritating) compilation warnings

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
