### PR TITLE
use Objects.requireNonNull in generated code for repositories

### DIFF
--- a/tooling/metamodel-generator/src/main/java/org/hibernate/processor/annotation/AbstractAnnotatedMethod.java
+++ b/tooling/metamodel-generator/src/main/java/org/hibernate/processor/annotation/AbstractAnnotatedMethod.java
@@ -17,6 +17,7 @@ import static org.hibernate.processor.annotation.AnnotationMetaEntity.usingReact
 import static org.hibernate.processor.annotation.AnnotationMetaEntity.usingReactiveSessionAccess;
 import static org.hibernate.processor.annotation.AnnotationMetaEntity.usingStatelessSession;
 import static org.hibernate.processor.util.Constants.ENTITY_MANAGER;
+import static org.hibernate.processor.util.Constants.OBJECTS;
 import static org.hibernate.processor.util.TypeUtils.hasAnnotation;
 
 /**
@@ -75,5 +76,16 @@ public abstract class AbstractAnnotatedMethod implements MetaAttribute {
 		else {
 			return emptyList();
 		}
+	}
+
+	void nullCheck(StringBuilder declaration, String paramName) {
+		declaration
+				.append('\t')
+				.append(annotationMetaEntity.staticImport(OBJECTS, "requireNonNull"))
+				.append('(')
+				.append(paramName.replace('.', '$'))
+				.append(", \"Null ")
+				.append(paramName)
+				.append("\");\n");
 	}
 }

--- a/tooling/metamodel-generator/src/main/java/org/hibernate/processor/annotation/AbstractCriteriaMethod.java
+++ b/tooling/metamodel-generator/src/main/java/org/hibernate/processor/annotation/AbstractCriteriaMethod.java
@@ -114,15 +114,6 @@ public abstract class AbstractCriteriaMethod extends AbstractFinderMethod {
 		}
 	}
 
-	private static void nullCheck(StringBuilder declaration, String paramName) {
-		declaration
-				.append("\tif (")
-				.append(paramName.replace('.', '$'))
-				.append(" == null) throw new IllegalArgumentException(\"Null ")
-				.append(paramName)
-				.append("\");\n");
-	}
-
 	void where(StringBuilder declaration, List<String> paramTypes) {
 		declaration
 				.append("\t_query.where(");

--- a/tooling/metamodel-generator/src/main/java/org/hibernate/processor/annotation/IdFinderMethod.java
+++ b/tooling/metamodel-generator/src/main/java/org/hibernate/processor/annotation/IdFinderMethod.java
@@ -180,13 +180,4 @@ public class IdFinderMethod extends AbstractFinderMethod {
 		declaration
 				.append(")");
 	}
-
-	private static void nullCheck(StringBuilder declaration, String parameterName) {
-		declaration
-				.append("\tif (")
-				.append(parameterName)
-				.append(" == null) throw new IllegalArgumentException(\"Null ")
-				.append(parameterName)
-				.append("\");\n");
-	}
 }

--- a/tooling/metamodel-generator/src/main/java/org/hibernate/processor/annotation/LifecycleMethod.java
+++ b/tooling/metamodel-generator/src/main/java/org/hibernate/processor/annotation/LifecycleMethod.java
@@ -56,7 +56,7 @@ public class LifecycleMethod extends AbstractAnnotatedMethod {
 	public String getAttributeDeclarationString() {
 		StringBuilder declaration = new StringBuilder();
 		preamble(declaration);
-		nullCheck(declaration);
+		nullCheck(declaration, parameterName);
 		declaration.append("\ttry {\n");
 		delegateCall(declaration);
 		returnArgument(declaration);
@@ -192,15 +192,6 @@ public class LifecycleMethod extends AbstractAnnotatedMethod {
 					? entityType
 					: "void";
 		}
-	}
-
-	private void nullCheck(StringBuilder declaration) {
-		declaration
-				.append("\tif (")
-				.append(parameterName)
-				.append(" == null) throw new IllegalArgumentException(\"Null ")
-				.append(parameterName)
-				.append("\");\n");
 	}
 
 	private void convertException(StringBuilder declaration, String exception, String convertedException) {

--- a/tooling/metamodel-generator/src/main/java/org/hibernate/processor/util/Constants.java
+++ b/tooling/metamodel-generator/src/main/java/org/hibernate/processor/util/Constants.java
@@ -123,6 +123,7 @@ public final class Constants {
 	public static final String MAP_ATTRIBUTE = "jakarta.persistence.metamodel.MapAttribute";
 
 	public static final String JAVA_OBJECT = "java.lang.Object";
+	public static final String OBJECTS = "java.util.Objects";
 	public static final String ITERABLE = "java.lang.Iterable";
 	public static final String COLLECTION = "java.util.Collection";
 	public static final String LIST = "java.util.List";


### PR DESCRIPTION
instead of directly throwing IllegalArgumentException

<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

[Please describe here what your change is about]

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
