### PR TITLE
Do not rely on Expressly for Hibernate Validator message interpolation

### DIFF
--- a/hibernate-c3p0/hibernate-c3p0.gradle
+++ b/hibernate-c3p0/hibernate-c3p0.gradle
@@ -16,6 +16,5 @@ dependencies {
     testImplementation project( ':hibernate-testing' )
     testImplementation jakartaLibs.validation
     testImplementation testLibs.validator
-    testRuntimeOnly testLibs.expressly
 }
 

--- a/hibernate-c3p0/src/test/resources/META-INF/validation.xml
+++ b/hibernate-c3p0/src/test/resources/META-INF/validation.xml
@@ -1,0 +1,15 @@
+<!--
+  ~ Hibernate, Relational Persistence for Idiomatic Java
+  ~
+  ~ License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+  ~ See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+  -->
+<validation-config
+        xmlns="https://jakarta.ee/xml/ns/validation/configuration"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="https://jakarta.ee/xml/ns/validation/configuration
+            https://jakarta.ee/xml/ns/validation/validation-configuration-3.0.xsd"
+        version="3.0">
+
+    <message-interpolator>org.hibernate.validator.messageinterpolation.ParameterMessageInterpolator</message-interpolator>
+</validation-config>

--- a/hibernate-core/hibernate-core.gradle
+++ b/hibernate-core/hibernate-core.gradle
@@ -56,7 +56,6 @@ dependencies {
     testImplementation jakartaLibs.cdi
     testImplementation jakartaLibs.jacc
     testImplementation jakartaLibs.validation
-    testImplementation testLibs.expressly
     testImplementation( testLibs.validator ) {
         // for test runtime
         transitive = true

--- a/hibernate-core/src/test/resources/META-INF/validation.xml
+++ b/hibernate-core/src/test/resources/META-INF/validation.xml
@@ -1,0 +1,15 @@
+<!--
+  ~ Hibernate, Relational Persistence for Idiomatic Java
+  ~
+  ~ License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+  ~ See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+  -->
+<validation-config
+        xmlns="https://jakarta.ee/xml/ns/validation/configuration"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="https://jakarta.ee/xml/ns/validation/configuration
+            https://jakarta.ee/xml/ns/validation/validation-configuration-3.0.xsd"
+        version="3.0">
+
+    <message-interpolator>org.hibernate.validator.messageinterpolation.ParameterMessageInterpolator</message-interpolator>
+</validation-config>

--- a/hibernate-spatial/hibernate-spatial.gradle
+++ b/hibernate-spatial/hibernate-spatial.gradle
@@ -29,7 +29,6 @@ dependencies {
 	testImplementation jdbcLibs.postgresql
 	testImplementation jdbcLibs.h2gis
 
-	testRuntimeOnly testLibs.expressly
 	testRuntimeOnly 'jaxen:jaxen:1.1'
 	testRuntimeOnly libs.byteBuddy
 }

--- a/hibernate-spatial/src/test/resources/META-INF/validation.xml
+++ b/hibernate-spatial/src/test/resources/META-INF/validation.xml
@@ -1,0 +1,15 @@
+<!--
+  ~ Hibernate, Relational Persistence for Idiomatic Java
+  ~
+  ~ License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+  ~ See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+  -->
+<validation-config
+        xmlns="https://jakarta.ee/xml/ns/validation/configuration"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="https://jakarta.ee/xml/ns/validation/configuration
+            https://jakarta.ee/xml/ns/validation/validation-configuration-3.0.xsd"
+        version="3.0">
+
+    <message-interpolator>org.hibernate.validator.messageinterpolation.ParameterMessageInterpolator</message-interpolator>
+</validation-config>

--- a/settings.gradle
+++ b/settings.gradle
@@ -186,10 +186,8 @@ dependencyResolutionManagement {
             def jfrUnitVersion = version "jfrUnit", "1.0.0.Alpha2"
 
             def hibernateValidatorVersion = version "hibernateValidator", "9.0.0.Beta3"
-            def expresslyVersion = version "expressly", "6.0.0-M1"
 
             library( "validator", "org.hibernate.validator", "hibernate-validator" ).versionRef( hibernateValidatorVersion )
-            library( "expressly", "org.glassfish.expressly", "expressly" ).versionRef( expresslyVersion )
 
             library( "junit5Api", "org.junit.jupiter", "junit-jupiter-api" ).versionRef( junit5Version )
             library( "junit5Engine", "org.junit.jupiter", "junit-jupiter-engine" ).versionRef( junit5Version )


### PR DESCRIPTION
Hey @gavinking 😃 I thought you might be somewhat interested in this one. 

I'm not sure how ORM wants to test that integration with the Validation spec, since the spec itself somewhat tells that the EL is a "must", but HV can work without it too.

see also https://docs.jboss.org/hibernate/validator/9.0/reference/en-US/html_single/#non-el-message-interpolator

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
