### PR TITLE
initial expermental changes for HHH-18901 + HHH-18928 with more changes expected

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/bytecode/enhance/internal/bytebuddy/EnhancerImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/bytecode/enhance/internal/bytebuddy/EnhancerImpl.java
@@ -132,6 +132,7 @@ public class EnhancerImpl implements Enhancer {
 		}
 		finally {
 			typePool.deregisterClassNameAndBytes( safeClassName );
+			typePool.clear();
 		}
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/bytecode/enhance/internal/bytebuddy/ModelTypePool.java
+++ b/hibernate-core/src/main/java/org/hibernate/bytecode/enhance/internal/bytebuddy/ModelTypePool.java
@@ -105,4 +105,9 @@ public class ModelTypePool extends TypePool.Default implements EnhancerClassLoca
 		return locator;
 	}
 
+	@Override
+	public void clear() {
+		super.clear();
+		resolutions.clear();
+	}
 }


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-18901
https://hibernate.atlassian.net/browse/HHH-18928

HHH-18901 - needs further checking/testing to see what further changes are needed.  This change mainly ensures that the cache is cleared after each instrumentation.

HHH-18928 - has initial change to check if there are annotations on any property accessors.  More changes are expected for HHH-18928.
