### PR TITLE
HHH-18901 possible fix for Duplicate annotation for class: interface org.hibernate.bytecode.enhance.spi.EnhancementInfo: @org.hibernate.bytecode.enhance.spi.EnhancementInfo(version="6.6.3.Final")" During WildFly TCK testing

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/bytecode/enhance/internal/bytebuddy/CoreTypePool.java
+++ b/hibernate-core/src/main/java/org/hibernate/bytecode/enhance/internal/bytebuddy/CoreTypePool.java
@@ -36,7 +36,7 @@ public class CoreTypePool extends TypePool.AbstractBase implements TypePool {
 	 */
 	public CoreTypePool() {
 		//By default optimise for jakarta annotations, and java util collections
-		this("jakarta.", "java.", "org.hibernate.annotations.");
+		this("jakarta.", "java.", "org.hibernate.annotations.", "org.hibernate.bytecode.enhance.spi.");
 	}
 
 	/**

--- a/hibernate-core/src/main/java/org/hibernate/bytecode/enhance/internal/bytebuddy/EnhancerImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/bytecode/enhance/internal/bytebuddy/EnhancerImpl.java
@@ -132,7 +132,6 @@ public class EnhancerImpl implements Enhancer {
 		}
 		finally {
 			typePool.deregisterClassNameAndBytes( safeClassName );
-			typePool.clear();
 		}
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/bytecode/enhance/internal/bytebuddy/EnhancerImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/bytecode/enhance/internal/bytebuddy/EnhancerImpl.java
@@ -132,6 +132,7 @@ public class EnhancerImpl implements Enhancer {
 		}
 		finally {
 			typePool.deregisterClassNameAndBytes( safeClassName );
+			typePool.clear();
 		}
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/bytecode/enhance/internal/bytebuddy/ModelTypePool.java
+++ b/hibernate-core/src/main/java/org/hibernate/bytecode/enhance/internal/bytebuddy/ModelTypePool.java
@@ -105,4 +105,9 @@ public class ModelTypePool extends TypePool.Default implements EnhancerClassLoca
 		return locator;
 	}
 
+	@Override
+	public void clear() {
+		super.clear();
+		resolutions.clear();
+	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/bytecode/enhance/internal/bytebuddy/ModelTypePool.java
+++ b/hibernate-core/src/main/java/org/hibernate/bytecode/enhance/internal/bytebuddy/ModelTypePool.java
@@ -105,9 +105,4 @@ public class ModelTypePool extends TypePool.Default implements EnhancerClassLoca
 		return locator;
 	}
 
-	@Override
-	public void clear() {
-		super.clear();
-		resolutions.clear();
-	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/bytecode/enhance/internal/bytebuddy/OverridingClassFileLocator.java
+++ b/hibernate-core/src/main/java/org/hibernate/bytecode/enhance/internal/bytebuddy/OverridingClassFileLocator.java
@@ -11,6 +11,8 @@ import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 
 import net.bytebuddy.dynamic.ClassFileLocator;
+import org.hibernate.internal.CoreLogging;
+import org.hibernate.internal.CoreMessageLogger;
 
 /**
  * Allows wrapping another ClassFileLocator to add the ability to define
@@ -20,7 +22,7 @@ public final class OverridingClassFileLocator implements ClassFileLocator {
 
 	private final ConcurrentHashMap<String, Resolution> registeredResolutions = new ConcurrentHashMap<>();
 	private final ClassFileLocator parent;
-
+	private static final CoreMessageLogger log = CoreLogging.messageLogger(OverridingClassFileLocator.class);
 	public OverridingClassFileLocator(final ClassFileLocator parent) {
 		this.parent = Objects.requireNonNull( parent );
 	}
@@ -29,9 +31,11 @@ public final class OverridingClassFileLocator implements ClassFileLocator {
 	public Resolution locate(final String name) throws IOException {
 		final Resolution resolution = registeredResolutions.get( name );
 		if ( resolution != null ) {
+			log.trace(String.format("OverridingClassFileLocator.registeredResolutions cache hit Resolution for class %s", name));
 			return resolution;
 		}
 		else {
+			log.trace(String.format("OverridingClassFileLocator.registeredResolutions cache miss Resolution for class %s", name));
 			return parent.locate( name );
 		}
 	}


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-18901

Add clear method to ModelTypePool which seems to avoid the duplicate annotation problem.

Also add TRACE logging to show cache hit/miss in OverridingClassFileLocator to possibly help explore if this pull request negatively impacts the improvements made for resolving https://hibernate.atlassian.net/browse/HHH-18011 (Parallel entity enhancement causes a classloader cache stampede).