### PR TITLE
fix some obvious defect in javadoc for resource/transaction package

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/resource/transaction/backend/jta/internal/DdlTransactionIsolatorJtaImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/resource/transaction/backend/jta/internal/DdlTransactionIsolatorJtaImpl.java
@@ -81,7 +81,7 @@ public class DdlTransactionIsolatorJtaImpl implements DdlTransactionIsolator {
 				}
 			}
 			catch (SQLException e) {
-				throw jdbcContext.getSqlExceptionHelper().convert( e, "Unable set JDBC Connection for DDL execution to autocommit" );
+				throw jdbcContext.getSqlExceptionHelper().convert( e, "Unable to set JDBC Connection for DDL execution to autocommit" );
 			}
 		}
 		return jdbcConnection;

--- a/hibernate-core/src/main/java/org/hibernate/resource/transaction/backend/jta/internal/JtaTransactionCoordinatorImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/resource/transaction/backend/jta/internal/JtaTransactionCoordinatorImpl.java
@@ -376,7 +376,7 @@ public class JtaTransactionCoordinatorImpl implements TransactionCoordinator, Sy
 
 	/**
 	 * Implementation of the LocalInflow for this TransactionCoordinator.  Allows the
-	 * local transaction ({@link org.hibernate.Transaction} to callback into this
+	 * local transaction ({@link org.hibernate.Transaction}) to callback into this
 	 * TransactionCoordinator for the purpose of driving the underlying JTA transaction.
 	 */
 	public class TransactionDriverControlImpl implements TransactionDriver {

--- a/hibernate-core/src/main/java/org/hibernate/resource/transaction/backend/jta/internal/synchronization/SynchronizationCallbackCoordinatorTrackingImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/resource/transaction/backend/jta/internal/synchronization/SynchronizationCallbackCoordinatorTrackingImpl.java
@@ -35,7 +35,7 @@ public class SynchronizationCallbackCoordinatorTrackingImpl extends Synchronizat
 		// 		1) on initialization, and
 		// 		2) after "after completion" handling is finished.
 		//
-		// Here we use that to "clear out" all 'delayed after-completion" state.  The registrationThreadId will
+		// Here we use that to "clear out" all "delayed after-completion" state.  The registrationThreadId will
 		// "lazily" be re-populated on the next synchronizationRegistered call to allow for the potential of the
 		// next Session transaction occurring on a different thread (though that transaction would need to completely
 		// operate on that thread).
@@ -46,7 +46,7 @@ public class SynchronizationCallbackCoordinatorTrackingImpl extends Synchronizat
 	public void afterCompletion(int status) {
 		log.tracef( "Synchronization coordinator: afterCompletion(status=%s)", status );
 
-		// The whole concept of "tracking" comes down to this code block..
+		// The whole concept of "tracking" comes down to this code block.
 		// Essentially we need to see if we can process the callback immediately.  So here we check whether the
 		// current call is happening on the same thread as the thread under which we registered the Synchronization.
 		// As far as we know, this can only ever happen in the rollback case where the transaction had been rolled

--- a/hibernate-core/src/main/java/org/hibernate/resource/transaction/backend/jta/internal/synchronization/SynchronizationCallbackTarget.java
+++ b/hibernate-core/src/main/java/org/hibernate/resource/transaction/backend/jta/internal/synchronization/SynchronizationCallbackTarget.java
@@ -8,7 +8,7 @@ package org.hibernate.resource.transaction.backend.jta.internal.synchronization;
  * Defines "inflow" for JTA transactions from the perspective of Hibernate's registered JTA Synchronization
  * back into the TransactionCoordinator by means of the SynchronizationCallbackCoordinator.
  * <p>
- * That's a mouthful :)  The way it works is like this...<ul>
+ * That's a mouthful, :).  The way it works is like this...<ul>
  *     <li>
  *         Hibernate will register a JTA {@link jakarta.transaction.Synchronization} implementation
  *         ({@link RegisteredSynchronization}) which allows

--- a/hibernate-core/src/main/java/org/hibernate/resource/transaction/spi/TransactionCoordinatorBuilder.java
+++ b/hibernate-core/src/main/java/org/hibernate/resource/transaction/spi/TransactionCoordinatorBuilder.java
@@ -20,7 +20,7 @@ import org.hibernate.tool.schema.internal.exec.JdbcContext;
  */
 public interface TransactionCoordinatorBuilder extends Service {
 	/**
-	 * Access to options to are specific to each {@link TransactionCoordinator} instance.
+	 * Access to options that are specific to each {@link TransactionCoordinator} instance.
 	 */
 	interface Options {
 		/**

--- a/hibernate-core/src/main/java/org/hibernate/resource/transaction/spi/TransactionCoordinatorOwner.java
+++ b/hibernate-core/src/main/java/org/hibernate/resource/transaction/spi/TransactionCoordinatorOwner.java
@@ -37,7 +37,7 @@ public interface TransactionCoordinatorOwner {
 	}
 
 	/**
-	 * A after-begin callback from the coordinator to its owner.
+	 * An after-begin callback from the coordinator to its owner.
 	 */
 	void afterTransactionBegin();
 


### PR DESCRIPTION

----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------

Recently worked on transaction stuff in mongoDB and found some obvious defects in the javadoc for `resource/transaction` package.
