### PR TITLE
remove modules which don't contain APIs from aggregated Javadoc

### DIFF
--- a/documentation/documentation.gradle
+++ b/documentation/documentation.gradle
@@ -139,29 +139,22 @@ dependencies {
 	core project( ':hibernate-core' )
 	javadocSources project( path: ':hibernate-core', configuration: 'javadocSources' )
 
-	testing project( ':hibernate-testing' )
-	javadocSources project( path: ':hibernate-testing', configuration: 'javadocSources' )
-
 	envers project( ':hibernate-envers' )
 	javadocSources project( path: ':hibernate-envers', configuration: 'javadocSources' )
 
+	testing project( ':hibernate-testing' )
+
 	spatial project( ':hibernate-spatial' )
-	javadocSources project( path: ':hibernate-spatial', configuration: 'javadocSources' )
 
 	agroal project( ':hibernate-agroal' )
-	javadocSources project( path: ':hibernate-agroal', configuration: 'javadocSources' )
 
 	c3p0 project( ':hibernate-c3p0' )
-	javadocSources project( path: ':hibernate-c3p0', configuration: 'javadocSources' )
 
 	hikaricp project( ':hibernate-hikaricp' )
-	javadocSources project( path: ':hibernate-hikaricp', configuration: 'javadocSources' )
 
 	jcache project( ':hibernate-jcache' )
-	javadocSources project( path: ':hibernate-jcache', configuration: 'javadocSources' )
 
 	jpamodelgen project( ':hibernate-processor' )
-	javadocSources project( path: ':hibernate-processor', configuration: 'javadocSources' )
 
 	javadocClasspath libs.loggingAnnotations
 	javadocClasspath jakartaLibs.validation

--- a/hibernate-core/src/main/java/org/hibernate/query/MutationQuery.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/MutationQuery.java
@@ -47,7 +47,7 @@ import jakarta.persistence.TemporalType;
  *     and ordinal parameters defined by the query.
  * </ul>
  * <pre>
- * session.createMutationQuery("delete Draft where lastUpdated < local date - ?1 year")
+ * session.createMutationQuery("delete Draft where lastUpdated &lt; local date - ?1 year")
  *         .setParameter(1, years)
  *         .executeUpdate();
  * </pre>


### PR DESCRIPTION
These modules don't contain APIs which are called by users or implemented by integrators. Including them in the generated Javadoc results in confusion for users and makes the Javadoc much more difficult to navigate and consume.

In particular, we definitely don't want packages like these included in the main Javadoc distribution for Hibernate ORM:

-  `org.hibernate.testing.orm.domain.gambit`
-  `org.hibernate.testing.orm.domain.helpdesk`

"Good documentation" isn't about having the maximum possible quantity of documentation; it's about having documentation where people actually have a hope of finding what they're looking for. In general, generated Javadoc is entirely useless except when we've actually taken time to actually write meaningful and readable prose. If all I need is a list of classes and their methods, my IDE is quite capable of presenting that information to me.

Worse, documentation for things that aren't API appears to invite users to interact with these things, which is precisely what we don't want them to do!

I'm leaving Envers alone, but I'm honestly not even sure if the Envers packages belong here, since it doesn't look like anyone has actually spent much time writing Javadoc for these packages. If Envers Javadoc is useful, it would be
better to put it in a separate Javadoc build, IMO.


<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
