### PR TITLE
HHH-18947 Changed UUID v 7 implementation for better entropy

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/id/uuid/UuidVersion7Strategy.java
+++ b/hibernate-core/src/main/java/org/hibernate/id/uuid/UuidVersion7Strategy.java
@@ -13,7 +13,6 @@ import org.hibernate.Internal;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.id.UUIDGenerationStrategy;
 
-import static java.time.temporal.ChronoUnit.MILLIS;
 
 /**
  * Implements UUID Version 7 generation strategy as defined by the <a href="https://datatracker.ietf.org/doc/html/rfc9562#name-uuid-version-7">RFC 9562</a>.
@@ -26,8 +25,7 @@ import static java.time.temporal.ChronoUnit.MILLIS;
  *         to guarantee additional monotonicity.
  *     </li>
  *     <li>2 bits - variant field, set to 0b10.</li>
- *     <li>14 bits - counter to guarantee additional monotonicity, resets to 0 when timestamp changes. </li>
- *     <li>48 bits - pseudorandom data to provide uniqueness.</li>
+ *     <li>62 bits - pseudorandom counter to guarantee additional monotonicity, uniqueness, and good entropy.</li>
  * </ul>
  *
  * @author Cedomir Igaly
@@ -37,6 +35,8 @@ import static java.time.temporal.ChronoUnit.MILLIS;
  */
 public class UuidVersion7Strategy implements UUIDGenerationStrategy, UuidValueGenerator {
 
+	private static final long MAX_RANDOM_SEQUENCE = 0x3FFF_FFFF_FFFF_FFFFL;
+
 	public static final UuidVersion7Strategy INSTANCE = new UuidVersion7Strategy();
 
 	private static class Holder {
@@ -44,36 +44,37 @@ public class UuidVersion7Strategy implements UUIDGenerationStrategy, UuidValueGe
 
 	}
 
-	public record State(Instant lastTimestamp, int lastSequence) {
+	public record State(Instant lastTimestamp, long lastSequence, long nanos) {
+
+		State(Instant lastTimestamp, long lastSequence) {
+			this( lastTimestamp, lastSequence, nanos( lastTimestamp ) );
+		}
+
 		public long millis() {
 			return lastTimestamp.toEpochMilli();
 		}
 
-		public long nanos() {
-			return (long) ( ( lastTimestamp.getNano() % 1_000_000L ) * 0.004096 );
+		private static long nanos(Instant timestamp) {
+			return (long) ((timestamp.getNano() % 1_000_000L) * 0.004096);
 		}
 
 		public State getNextState() {
 			final Instant now = Instant.now();
-			if ( lastTimestamp.toEpochMilli() < now.toEpochMilli() ) {
-				return new State(
-						now.truncatedTo( MILLIS ),
-						randomSequence()
-				);
+			if ( lastTimestamp.toEpochMilli() < now.toEpochMilli() ||
+				lastTimestamp.toEpochMilli() == now.toEpochMilli() && nanos < nanos( now ) ) {
+				return new State( now, randomSequence() );
 			}
-			else if ( lastSequence == 0x3FFF ) {
-				return new State(
-						lastTimestamp.plusMillis( 1 ),
-						Holder.numberGenerator.nextInt( 1 << 14 )
-				);
+			final long nextSequence = lastSequence + Holder.numberGenerator.nextLong( 0xFFFF_FFFFL );
+			if ( nextSequence > MAX_RANDOM_SEQUENCE ) {
+				return new State( lastTimestamp.plusNanos( 250 ), randomSequence() );
 			}
 			else {
-				return new State( lastTimestamp, lastSequence + 1 );
+				return new State( lastTimestamp, nextSequence );
 			}
 		}
 
-		private static int randomSequence() {
-			return Holder.numberGenerator.nextInt( 1 << 14 );
+		private static long randomSequence() {
+			return Holder.numberGenerator.nextLong( MAX_RANDOM_SEQUENCE );
 		}
 	}
 
@@ -81,11 +82,11 @@ public class UuidVersion7Strategy implements UUIDGenerationStrategy, UuidValueGe
 
 	@Internal
 	public UuidVersion7Strategy() {
-		this( Instant.EPOCH, Integer.MIN_VALUE );
+		this( Instant.EPOCH, Holder.numberGenerator.nextLong( MAX_RANDOM_SEQUENCE ) );
 	}
 
 	@Internal
-	public UuidVersion7Strategy(final Instant initialTimestamp, final int initialSequence) {
+	public UuidVersion7Strategy(final Instant initialTimestamp, final long initialSequence) {
 		this.lastState = new AtomicReference<>( new State( initialTimestamp, initialSequence ) );
 	}
 
@@ -115,14 +116,8 @@ public class UuidVersion7Strategy implements UUIDGenerationStrategy, UuidValueGe
 				| state.nanos() & 0xFFFL,
 				// LSB bits 0-1 - variant = 4
 				0x8000_0000_0000_0000L
-				// LSB bits 2-15 - counter
-				| (long) state.lastSequence << 48
-				// LSB bits 16-63 - pseudorandom data
-				| randomNode()
+				// LSB bits 2-15 - pseudorandom counter
+				| state.lastSequence
 		);
-	}
-
-	private static long randomNode() {
-		return Holder.numberGenerator.nextLong( 0x1_0000_0000_0000L ) | 0x1000_0000_0000L;
 	}
 }


### PR DESCRIPTION
Jira issue [HHH-18947](https://hibernate.atlassian.net/browse/HHH-18947)

Changes suggested here are using randomly created 62 bytes counter (instead of current 14 bits counter, and  48 bits random bytes) that is incrementing by random value for each new generated UUID. This is improving entropy, and it is now comparable to that of UUID v6.

<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

[Please describe here what your change is about]

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------


[HHH-18947]: https://hibernate.atlassian.net/browse/HHH-18947?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ