### PR TITLE
HHH-18960 Hibernate Processor - when query parameter allows multiple value binding parameter in generated query should be collection

### DIFF
--- a/tooling/metamodel-generator/src/jakartaData/java/org/hibernate/processor/test/data/multivaluebinding/Post.java
+++ b/tooling/metamodel-generator/src/jakartaData/java/org/hibernate/processor/test/data/multivaluebinding/Post.java
@@ -1,0 +1,20 @@
+/*
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.processor.test.data.multivaluebinding;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.NamedQuery;
+
+@Entity
+@NamedQuery(name = "#getPostsByName", query = "from Post p where p.name in (:names)")
+public class Post {
+	@Id
+	Integer id;
+
+	String name;
+
+	Integer value;
+}

--- a/tooling/metamodel-generator/src/jakartaData/java/org/hibernate/processor/test/data/multivaluebinding/PostRepository.java
+++ b/tooling/metamodel-generator/src/jakartaData/java/org/hibernate/processor/test/data/multivaluebinding/PostRepository.java
@@ -1,0 +1,19 @@
+/*
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.processor.test.data.multivaluebinding;
+
+import jakarta.data.repository.DataRepository;
+import jakarta.data.repository.Query;
+import jakarta.data.repository.Repository;
+
+import java.util.Collection;
+import java.util.List;
+
+@Repository
+public interface PostRepository extends DataRepository<Post, Integer> {
+
+	@Query("from Post p where p.name in (:names)")
+	List<Post> getPostsByName(Collection<String> names);
+}

--- a/tooling/metamodel-generator/src/jakartaData/java/org/hibernate/processor/test/data/multivaluebinding/TopicPostTest.java
+++ b/tooling/metamodel-generator/src/jakartaData/java/org/hibernate/processor/test/data/multivaluebinding/TopicPostTest.java
@@ -1,0 +1,53 @@
+/*
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.processor.test.data.multivaluebinding;
+
+import jakarta.persistence.EntityManager;
+import org.hibernate.processor.test.util.CompilationTest;
+import org.hibernate.processor.test.util.WithClasses;
+import org.junit.Test;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.util.Collection;
+import java.util.List;
+
+import static org.hibernate.processor.test.util.TestUtil.assertMetamodelClassGeneratedFor;
+import static org.hibernate.processor.test.util.TestUtil.assertPresenceOfMethodInMetamodelFor;
+import static org.hibernate.processor.test.util.TestUtil.getMetaModelSourceAsString;
+import static org.hibernate.processor.test.util.TestUtil.getMethodFromMetamodelFor;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
+
+public class TopicPostTest extends CompilationTest {
+	@Test
+	@WithClasses({Post.class, PostRepository.class})
+	public void test() {
+		assertMetamodelClassGeneratedFor( Post.class, true );
+		assertMetamodelClassGeneratedFor( Post.class );
+		assertMetamodelClassGeneratedFor( PostRepository.class );
+
+		assertPresenceOfMethodInMetamodelFor( Post.class, "getPostsByName", EntityManager.class, List.class );
+		final Method method = getMethodFromMetamodelFor( Post.class, "getPostsByName", EntityManager.class, List.class );
+		final Type methodParam = method.getGenericParameterTypes()[1];
+		if ( methodParam instanceof ParameterizedType parameterized ) {
+			assertEquals( String.class, parameterized.getActualTypeArguments()[0] );
+		}
+		else {
+			fail();
+		}
+
+		assertPresenceOfMethodInMetamodelFor( PostRepository.class, "getPostsByName", Collection.class );
+		final Method repositoryMethod = getMethodFromMetamodelFor( PostRepository.class, "getPostsByName", Collection.class );
+		final Type repositoryMethodParam = repositoryMethod.getGenericParameterTypes()[0];
+		if ( repositoryMethodParam instanceof ParameterizedType parameterized ) {
+			assertEquals( String.class, parameterized.getActualTypeArguments()[0] );
+		}
+		else {
+			fail();
+		}
+	}
+}

--- a/tooling/metamodel-generator/src/main/java/org/hibernate/processor/annotation/AnnotationMetaEntity.java
+++ b/tooling/metamodel-generator/src/main/java/org/hibernate/processor/annotation/AnnotationMetaEntity.java
@@ -64,6 +64,7 @@ import jakarta.persistence.AccessType;
 import static java.beans.Introspector.decapitalize;
 import static java.lang.Boolean.FALSE;
 import static java.util.Collections.emptyList;
+import static java.util.Objects.requireNonNullElse;
 import static java.util.stream.Collectors.toList;
 import static javax.lang.model.util.ElementFilter.fieldsIn;
 import static javax.lang.model.util.ElementFilter.methodsIn;
@@ -2738,11 +2739,13 @@ public class AnnotationMetaEntity extends AnnotationMeta {
 		if ( queryParamType!=null
 				//TODO: arguments of functions get assigned "unknown" which sucks
 				&& !"unknown".equals(queryParamType) ) {
+			final String realQueryParamType =
+					requireNonNullElse( context.qualifiedNameForEntityName( queryParamType ), queryParamType );
 			if ( param.getName() != null ) {
-				checkNamedParameter(param, paramNames, paramTypes, method, mirror, value, queryParamType);
+				checkNamedParameter(param, paramNames, paramTypes, method, mirror, value, realQueryParamType);
 			}
 			else if ( param.getPosition() != null ) {
-				checkOrdinalParameter(param, paramNames, paramTypes, method, mirror, value, queryParamType);
+				checkOrdinalParameter(param, paramNames, paramTypes, method, mirror, value, realQueryParamType);
 			}
 		}
 	}

--- a/tooling/metamodel-generator/src/main/java/org/hibernate/processor/annotation/NamedQueryMethod.java
+++ b/tooling/metamodel-generator/src/main/java/org/hibernate/processor/annotation/NamedQueryMethod.java
@@ -148,10 +148,20 @@ class NamedQueryMethod implements MetaAttribute {
 				declaration
 						.append(", ");
 			}
-			declaration
-					.append(parameterType(param))
-					.append(" ")
-					.append(parameterName(param));
+			if ( param.allowMultiValuedBinding() ) {
+				declaration
+						.append(annotationMeta.importType(Constants.LIST))
+						.append('<')
+						.append( parameterType( param ) )
+						.append("> ")
+						.append( parameterName( param ) );
+			}
+			else {
+				declaration
+						.append( parameterType( param ) )
+						.append( " " )
+						.append( parameterName( param ) );
+			}
 		}
 		declaration
 				.append(')');


### PR DESCRIPTION
Jira issue [HHH-18960](https://hibernate.atlassian.net/browse/HHH-18960)

Currently when named query parameter allows multiple value binding (like parameters for `in`), in generated query it is represented as raw type instead of `List` (or, possibly, `Collection`). Same problem is present when generating meta model class for Jakarta Data repository.

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------


[HHH-18960]: https://hibernate.atlassian.net/browse/HHH-18960?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ