### PR TITLE
HHH-18965 give some love to org.hibernate.Transaction

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/Transaction.java
+++ b/hibernate-core/src/main/java/org/hibernate/Transaction.java
@@ -10,6 +10,10 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 
 import org.hibernate.resource.transaction.spi.TransactionStatus;
 
+import java.util.function.Consumer;
+
+import static org.hibernate.resource.transaction.backend.jta.internal.StatusTranslator.translate;
+
 /**
  * Represents a resource-local transaction, where <em>resource-local</em> is interpreted
  * by Hibernate to mean any transaction under the control of Hibernate. That is to say,
@@ -38,37 +42,188 @@ import org.hibernate.resource.transaction.spi.TransactionStatus;
  *
  * @author Anton van Straaten
  * @author Steve Ebersole
+ * @author Gavin King
  *
  * @see Session#beginTransaction()
  */
 public interface Transaction extends EntityTransaction {
 	/**
 	 * Get the current {@linkplain TransactionStatus status} of this transaction.
+	 *
+	 * @apiNote {@link TransactionStatus} belongs to an SPI package, and so this
+	 *          operation is a (fairly harmless) layer-breaker. Prefer the use
+	 *          of {@link #isActive}, {@link #isComplete}, {@link #wasStarted},
+	 *          {@link #wasSuccessful}, {@link #wasFailure}, or
+	 *          {@link #isInCompletionProcess} according to need.
+	 *
 	 */
 	TransactionStatus getStatus();
 
 	/**
-	 * Register a user {@link Synchronization synchronization callback} for this transaction.
+	 * Is this transaction still active?
+	 * <p>
+	 * A transaction which has been {@linkplain #markRollbackOnly marked for rollback}
+	 * is still considered active, and is still able to perform work. To determine if
+	 * a transaction has been marked for rollback, call {@link #getRollbackOnly()}.
 	 *
-	 * @param synchronization The {@link Synchronization} callback to register.
+	 * @return {@code true} if the {@linkplain #getStatus status}
+	 *         is {@link TransactionStatus#ACTIVE} or
+	 *         {@link TransactionStatus#MARKED_ROLLBACK}
+	 */
+	default boolean isActive() {
+		return switch (getStatus()) {
+			case ACTIVE, MARKED_ROLLBACK -> true;
+			default -> false;
+		};
+	}
+
+	/**
+	 * Is this transaction currently in the completion process?
+	 * <p>
+	 * Note that a {@link Synchronization} is called <em>before</em> and <em>after</em>
+	 * the completion process. Therefore, this state is not usually observable to the
+	 * client program logic.
 	 *
-	 * @throws HibernateException Indicates a problem registering the synchronization.
+	 * @return {@code true} if the {@linkplain #getStatus status}
+	 *         is {@link TransactionStatus#COMMITTING} or
+	 *         {@link TransactionStatus#ROLLING_BACK}
+	 *
+	 * @since 7.0
+	 */
+	@Incubating
+	default boolean isInCompletionProcess() {
+		return switch (getStatus()) {
+			case COMMITTING, ROLLING_BACK -> true;
+			default -> false;
+		};
+	}
+
+	/**
+	 * Is this transaction complete?
+	 *
+	 * @return {@code true} if the {@linkplain #getStatus status}
+	 *         is {@link TransactionStatus#COMMITTED},
+	 *         {@link TransactionStatus#ROLLED_BACK},
+	 *         {@link TransactionStatus#FAILED_COMMIT}, or
+	 *         {@link TransactionStatus#FAILED_ROLLBACK}
+	 *
+	 * @since 7.0
+	 */
+	@Incubating
+	default boolean isComplete() {
+		return switch (getStatus()) {
+			case COMMITTED, ROLLED_BACK, FAILED_COMMIT, FAILED_ROLLBACK -> true;
+			default -> false;
+		};
+	}
+
+	/**
+	 * Was this transaction already started?
+	 *
+	 * @return {@code true} if the {@linkplain #getStatus status} is
+	 *         anything other than {@link TransactionStatus#NOT_ACTIVE}
+	 *
+	 * @since 7.0
+	 */
+	@Incubating
+	default boolean wasStarted() {
+		return getStatus() != TransactionStatus.NOT_ACTIVE;
+	}
+
+	/**
+	 * Was this transaction already successfully committed?
+	 *
+	 * @return {@code true} if the {@linkplain #getStatus status}
+	 *         is {@link TransactionStatus#COMMITTED}
+	 *
+	 * @since 7.0
+	 */
+	@Incubating
+	default boolean wasSuccessful() {
+		return getStatus() == TransactionStatus.COMMITTED;
+	}
+
+	/**
+	 * Was this transaction a failure? Here we consider a successful rollback,
+	 * a failed commit, or a failed rollback to amount to transaction failure.
+	 *
+	 * @return {@code true} if the {@linkplain #getStatus status}
+	 *         is {@link TransactionStatus#ROLLED_BACK},
+	 *         {@link TransactionStatus#FAILED_COMMIT},
+	 *         {@link TransactionStatus#FAILED_ROLLBACK}
+	 *
+	 * @since 7.0
+	 */
+	@Incubating
+	default boolean wasFailure() {
+		return switch (getStatus()) {
+			case ROLLED_BACK, FAILED_COMMIT, FAILED_ROLLBACK -> true;
+			default -> false;
+		};
+	}
+
+	/**
+	 * Register an action which will be called during the "before completion" phase.
+	 *
+	 * @since 7.0
+	 */
+	@Incubating
+	default void runBeforeCompletion(Runnable action) {
+		registerSynchronization( new Synchronization() {
+			@Override
+			public void beforeCompletion() {
+				action.run();
+			}
+			@Override
+			public void afterCompletion(int status) {
+			}
+		} );
+	}
+
+	/**
+	 * Register an action which will be called during the "after completion" phase.
+	 *
+	 * @since 7.0
+	 */
+	@Incubating
+	default void runAfterCompletion(Consumer<TransactionStatus> action) {
+		registerSynchronization( new Synchronization() {
+			@Override
+			public void beforeCompletion() {
+			}
+			@Override
+			public void afterCompletion(int status) {
+				action.accept( translate( status ) );
+			}
+		} );
+	}
+
+	/**
+	 * Register a {@linkplain Synchronization synchronization callback} for this transaction.
+	 *
+	 * @param synchronization The {@link Synchronization} callback to register
+	 *
+	 * @apiNote {@link Synchronization} is a type defined by JTA, but this operation does
+	 *          not depend on the use of JTA for transaction management. Prefer the use of
+	 *          the methods {@link #runBeforeCompletion} and {@link #runAfterCompletion}
+	 *          for convenience.
 	 */
 	void registerSynchronization(Synchronization synchronization);
 
 	/**
-	 * Set the transaction timeout for any transaction started by any subsequent call to
-	 * {@link #begin} on this instance.
+	 * Set the transaction timeout for any transaction started by a subsequent call to
+	 * {@link #begin} on this instance of {@code Transaction}.
 	 *
-	 * @param seconds The number of seconds before a timeout.
+	 * @param seconds The number of seconds before a timeout
 	 */
 	void setTimeout(int seconds);
 
 	/**
-	 * Retrieve the transaction timeout set for this instance. A negative integer indicates
-	 * that no timeout has been set.
+	 * Retrieve the transaction timeout set for this instance.
+	 * <p>
+	 * A {@code null} return value indicates that no timeout has been set.
 	 *
-	 * @return The timeout, in seconds.
+	 * @return the timeout, in seconds, or {@code null}
 	 */
 	@Nullable Integer getTimeout();
 

--- a/hibernate-core/src/main/java/org/hibernate/cfg/TransactionSettings.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/TransactionSettings.java
@@ -157,8 +157,10 @@ public interface TransactionSettings {
 	 *
 	 * @settingDefault {@code false} (disabled)
 	 *
-	 * @apiNote Generally speaking, all access to transactional data should be done in a transaction.
+	 * @apiNote Generally speaking, all access to transactional data should be
+	 *          done in a transaction. Use of this setting is discouraged.
 	 *
+	 * @see org.hibernate.boot.spi.SessionFactoryOptions#isInitializeLazyStateOutsideTransactionsEnabled
 	 * @see org.hibernate.boot.SessionFactoryBuilder#applyLazyInitializationOutsideTransaction(boolean)
 	 */
 	@Unsafe
@@ -177,9 +179,11 @@ public interface TransactionSettings {
 	 *
 	 * @settingDefault {@code false} (disabled)
 	 *
-	 * @apiNote Generally speaking, all access to transactional data should be done in a transaction.
-	 * Combining this with second-level caching, e.g., will cause problems.
+	 * @apiNote Generally speaking, all access to transactional data should be
+	 *          done in a transaction. Combining this with second-level caching
+	 *          is not safe. Use of this setting is discouraged.
 	 *
+	 * @see org.hibernate.boot.spi.SessionFactoryOptions#isAllowOutOfTransactionUpdateOperations
 	 * @see org.hibernate.boot.SessionFactoryBuilder#allowOutOfTransactionUpdateOperations(boolean)
 	 *
 	 * @since 5.2

--- a/hibernate-core/src/main/java/org/hibernate/collection/spi/AbstractPersistentCollection.java
+++ b/hibernate-core/src/main/java/org/hibernate/collection/spi/AbstractPersistentCollection.java
@@ -19,7 +19,6 @@ import org.hibernate.AssertionFailure;
 import org.hibernate.FlushMode;
 import org.hibernate.HibernateException;
 import org.hibernate.LazyInitializationException;
-import org.hibernate.engine.internal.ForeignKeys;
 import org.hibernate.engine.spi.CollectionEntry;
 import org.hibernate.engine.spi.EntityEntry;
 import org.hibernate.engine.spi.PersistenceContext;
@@ -31,8 +30,8 @@ import org.hibernate.internal.CoreMessageLogger;
 import org.hibernate.internal.SessionFactoryRegistry;
 import org.hibernate.internal.util.MarkerObject;
 import org.hibernate.internal.util.collections.IdentitySet;
+import org.hibernate.metamodel.mapping.EntityIdentifierMapping;
 import org.hibernate.persister.collection.CollectionPersister;
-import org.hibernate.persister.entity.EntityPersister;
 import org.hibernate.resource.transaction.spi.TransactionStatus;
 import org.hibernate.type.BasicType;
 import org.hibernate.type.CompositeType;
@@ -40,7 +39,15 @@ import org.hibernate.type.Type;
 
 import org.checkerframework.checker.nullness.qual.Nullable;
 
+import static org.hibernate.engine.internal.ForeignKeys.getEntityIdentifier;
+import static org.hibernate.engine.internal.ForeignKeys.getEntityIdentifierIfNotUnsaved;
+import static org.hibernate.engine.internal.ForeignKeys.isNotTransient;
 import static org.hibernate.pretty.MessageHelper.collectionInfoString;
+import static org.hibernate.resource.transaction.spi.TransactionStatus.FAILED_COMMIT;
+import static org.hibernate.resource.transaction.spi.TransactionStatus.FAILED_ROLLBACK;
+import static org.hibernate.resource.transaction.spi.TransactionStatus.MARKED_ROLLBACK;
+import static org.hibernate.resource.transaction.spi.TransactionStatus.ROLLED_BACK;
+import static org.hibernate.resource.transaction.spi.TransactionStatus.ROLLING_BACK;
 
 /**
  * Base class implementing {@link PersistentCollection}
@@ -152,6 +159,8 @@ public abstract class AbstractPersistentCollection<E> implements Serializable, P
 							if ( entry != null ) {
 								final CollectionPersister persister = entry.getLoadedPersister();
 								if ( persister.isExtraLazy() ) {
+									// TODO: support for extra-lazy collections was
+									//       dropped so this code should be obsolete
 									if ( hasQueuedOperations() ) {
 										session.flush();
 									}
@@ -208,6 +217,9 @@ public abstract class AbstractPersistentCollection<E> implements Serializable, P
 		T doWork();
 	}
 
+	/**
+	 * Support for {@link org.hibernate.cfg.AvailableSettings#ENABLE_LAZY_LOAD_NO_TRANS}.
+	 */
 	private <T> T withTemporarySessionIfNeeded(LazyInitializationWork<T> lazyInitializationWork) {
 		SharedSessionContractImplementor tempSession = null;
 
@@ -278,7 +290,7 @@ public abstract class AbstractPersistentCollection<E> implements Serializable, P
 					tempSession.close();
 				}
 				catch (Exception e) {
-					LOG.warn( "Unable to close temporary session used to load lazy collection associated to no session" );
+					LOG.unableToCloseTemporarySession();
 				}
 			}
 			else {
@@ -657,51 +669,53 @@ public abstract class AbstractPersistentCollection<E> implements Serializable, P
 	@Override
 	public final boolean unsetSession(SharedSessionContractImplementor currentSession) {
 		prepareForPossibleLoadingOutsideTransaction();
-		if ( currentSession == this.session ) {
+		if ( currentSession == session ) {
 			if ( !isTempSession ) {
 				if ( hasQueuedOperations() ) {
-					final String collectionInfoString = collectionInfoString( getRole(), getKey() );
-					try {
-						final TransactionStatus transactionStatus =
-								session.getTransactionCoordinator().getTransactionDriverControl().getStatus();
-						if ( transactionStatus.isOneOf(
-								TransactionStatus.ROLLED_BACK,
-								TransactionStatus.MARKED_ROLLBACK,
-								TransactionStatus.FAILED_COMMIT,
-								TransactionStatus.FAILED_ROLLBACK,
-								TransactionStatus.ROLLING_BACK
-						) ) {
-							// It was due to a rollback.
-							LOG.queuedOperationWhenDetachFromSessionOnRollback( collectionInfoString );
-						}
-						else {
-							// We don't know why the collection is being detached.
-							// Just log the info.
-							LOG.queuedOperationWhenDetachFromSession( collectionInfoString );
-						}
-					}
-					catch (Exception e) {
-						// We don't know why the collection is being detached.
-						// Just log the info.
-						LOG.queuedOperationWhenDetachFromSession( collectionInfoString );
-					}
+					logDiscardedQueuedOperations();
 				}
 				if ( allowLoadOutsideTransaction
 						&& !initialized
 						&& session.getLoadQueryInfluencers().hasEnabledFilters() ) {
-					final String collectionInfoString = collectionInfoString( getRole(), getKey() );
-					LOG.enabledFiltersWhenDetachFromSession( collectionInfoString );
+					LOG.enabledFiltersWhenDetachFromSession( collectionInfoString( getRole(), getKey() ) );
 				}
-				this.session = null;
+				session = null;
 			}
 			return true;
 		}
 		else {
-			if ( this.session != null ) {
-				LOG.logCannotUnsetUnexpectedSessionInCollection( generateUnexpectedSessionStateMessage( currentSession ) );
+			if ( session != null ) {
+				LOG.logCannotUnsetUnexpectedSessionInCollection( unexpectedSessionStateMessage( currentSession ) );
 			}
 			return false;
 		}
+	}
+
+	private void logDiscardedQueuedOperations() {
+		try {
+			if ( wasTransactionRolledBack() ) {
+				// It was due to a rollback.
+				if ( LOG.isDebugEnabled()) {
+					LOG.queuedOperationWhenDetachFromSessionOnRollback( collectionInfoString( getRole(), getKey() ) );
+				}
+			}
+			else {
+				// We don't know why the collection is being detached.
+				// Just log the info.
+				LOG.queuedOperationWhenDetachFromSession( collectionInfoString( getRole(), getKey() ) );
+			}
+		}
+		catch (Exception e) {
+			// We don't know why the collection is being detached.
+			// Just log the info.
+			LOG.queuedOperationWhenDetachFromSession( collectionInfoString( getRole(), getKey() ) );
+		}
+	}
+
+	private boolean wasTransactionRolledBack() {
+		final TransactionStatus status =
+				session.getTransactionCoordinator().getTransactionDriverControl().getStatus();
+		return status.isOneOf( ROLLED_BACK, MARKED_ROLLBACK, FAILED_COMMIT, FAILED_ROLLBACK, ROLLING_BACK );
 	}
 
 	protected void prepareForPossibleLoadingOutsideTransaction() {
@@ -722,7 +736,7 @@ public abstract class AbstractPersistentCollection<E> implements Serializable, P
 			return false;
 		}
 		else if ( this.session != null ) {
-			final String msg = generateUnexpectedSessionStateMessage( session );
+			final String msg = unexpectedSessionStateMessage( session );
 			if ( isConnectedToSession() ) {
 				throw new HibernateException(
 						"Illegal attempt to associate a collection with two open sessions: " + msg
@@ -739,7 +753,7 @@ public abstract class AbstractPersistentCollection<E> implements Serializable, P
 		return true;
 	}
 
-	private String generateUnexpectedSessionStateMessage(SharedSessionContractImplementor session) {
+	private String unexpectedSessionStateMessage(SharedSessionContractImplementor session) {
 		// NOTE: If this.session != null, this.session may be operating on this collection
 		// (e.g., by changing this.role, this.key, or even this.session) in a different thread.
 
@@ -751,32 +765,25 @@ public abstract class AbstractPersistentCollection<E> implements Serializable, P
 		final String roleCurrent = role;
 		final Object keyCurrent = key;
 
-		final StringBuilder sb = new StringBuilder( "Collection : " );
+		final StringBuilder message = new StringBuilder( "Collection : " );
 		if ( roleCurrent != null ) {
-			sb.append( collectionInfoString( roleCurrent, keyCurrent ) );
+			message.append( collectionInfoString( roleCurrent, keyCurrent ) );
 		}
 		else {
 			final CollectionEntry ce = session.getPersistenceContextInternal().getCollectionEntry( this );
 			if ( ce != null ) {
-				sb.append(
-						collectionInfoString(
-								ce.getLoadedPersister(),
-								this,
-								ce.getLoadedKey(),
-								session
-						)
-				);
+				message.append( collectionInfoString( ce.getLoadedPersister(), this, ce.getLoadedKey(), session ) );
 			}
 			else {
-				sb.append( "<unknown>" );
+				message.append( "<unknown>" );
 			}
 		}
 		// only include the collection contents if debug logging
 		if ( LOG.isDebugEnabled() ) {
 			final String collectionContents = wasInitialized() ? toString() : "<uninitialized>";
-			sb.append( "\nCollection contents: [" ).append( collectionContents ).append( "]" );
+			message.append( "\nCollection contents: [" ).append( collectionContents ).append( "]" );
 		}
-		return sb.toString();
+		return message.toString();
 	}
 
 	@Override
@@ -792,18 +799,11 @@ public abstract class AbstractPersistentCollection<E> implements Serializable, P
 		// Selecting a type used in where part of update statement
 		// (must match condition in org.hibernate.persister.collection.BasicCollectionPersister#doUpdateRows).
 		// See HHH-9474
-		final Type whereType;
-		if ( persister.hasIndex() ) {
-			whereType = persister.getIndexType();
-		}
-		else {
-			whereType = persister.getElementType();
-		}
-		if ( whereType instanceof CompositeType ) {
-			final CompositeType componentIndexType = (CompositeType) whereType;
-			return componentIndexType.hasNullProperty();
-		}
-		return false;
+		final Type whereType = persister.hasIndex()
+				? persister.getIndexType()
+				: persister.getElementType();
+		return whereType instanceof CompositeType compositeType
+			&& compositeType.hasNullProperty();
 	}
 
 	@Override
@@ -1261,11 +1261,10 @@ public abstract class AbstractPersistentCollection<E> implements Serializable, P
 			return oldElements;
 		}
 
-		final EntityPersister entityDescriptor = session.getFactory()
-				.getRuntimeMetamodels()
-				.getMappingMetamodel()
-				.getEntityDescriptor( entityName );
-		final Type idType = entityDescriptor.getIdentifierType();
+		final Type idType =
+				session.getFactory().getMappingMetamodel()
+						.getEntityDescriptor( entityName )
+						.getIdentifierType();
 		final boolean useIdDirect = mayUseIdDirect( idType );
 
 		// create the collection holding the Orphans
@@ -1276,13 +1275,13 @@ public abstract class AbstractPersistentCollection<E> implements Serializable, P
 		final java.util.Set<Object> currentSaving = new IdentitySet<>();
 		final PersistenceContext persistenceContext = session.getPersistenceContextInternal();
 		for ( Object current : currentElements ) {
-			if ( current != null && ForeignKeys.isNotTransient( entityName, current, null, session ) ) {
+			if ( current != null && isNotTransient( entityName, current, null, session ) ) {
 				final EntityEntry ee = persistenceContext.getEntry( current );
 				if ( ee != null && ee.getStatus() == Status.SAVING ) {
 					currentSaving.add( current );
 				}
 				else {
-					final Object currentId = ForeignKeys.getEntityIdentifierIfNotUnsaved(
+					final Object currentId = getEntityIdentifierIfNotUnsaved(
 							entityName,
 							current,
 							session
@@ -1295,7 +1294,7 @@ public abstract class AbstractPersistentCollection<E> implements Serializable, P
 		// iterate over the *old* list
 		for ( E old : oldElements ) {
 			if ( !currentSaving.contains( old ) ) {
-				final Object oldId = ForeignKeys.getEntityIdentifier( entityName, old, session );
+				final Object oldId = getEntityIdentifier( entityName, old, session );
 				if ( oldId != null && !currentIds.contains( useIdDirect ? oldId : new TypedValue( idType, oldId ) ) ) {
 					res.add( old );
 				}
@@ -1306,12 +1305,12 @@ public abstract class AbstractPersistentCollection<E> implements Serializable, P
 	}
 
 	private static boolean mayUseIdDirect(Type idType) {
-		if ( idType instanceof BasicType<?> ) {
-			final Class<?> javaType = ( (BasicType<?>) idType ).getJavaType();
+		if ( idType instanceof BasicType<?> basicType ) {
+			final Class<?> javaType = basicType.getJavaType();
 			return javaType == String.class
-					|| javaType == Integer.class
-					|| javaType == Long.class
-					|| javaType == UUID.class;
+				|| javaType == Integer.class
+				|| javaType == Long.class
+				|| javaType == UUID.class;
 		}
 		return false;
 	}
@@ -1329,16 +1328,17 @@ public abstract class AbstractPersistentCollection<E> implements Serializable, P
 			Object entityInstance,
 			String entityName,
 			SharedSessionContractImplementor session) {
-		if ( entityInstance != null && ForeignKeys.isNotTransient( entityName, entityInstance, null, session ) ) {
-			final EntityPersister entityDescriptor = session.getFactory()
-					.getRuntimeMetamodels()
-					.getMappingMetamodel()
-					.getEntityDescriptor( entityName );
-			final Object idOfCurrent = ForeignKeys.getEntityIdentifierIfNotUnsaved( entityName, entityInstance, session );
+		if ( entityInstance != null
+				&& isNotTransient( entityName, entityInstance, null, session ) ) {
+			final EntityIdentifierMapping identifierMapping =
+					session.getFactory().getMappingMetamodel()
+							.getEntityDescriptor( entityName )
+							.getIdentifierMapping();
+			final Object idOfCurrent = getEntityIdentifierIfNotUnsaved( entityName, entityInstance, session );
 			final Iterator<?> itr = list.iterator();
 			while ( itr.hasNext() ) {
-				final Object idOfOld = ForeignKeys.getEntityIdentifierIfNotUnsaved( entityName, itr.next(), session );
-				if ( entityDescriptor.getIdentifierMapping().areEqual( idOfCurrent, idOfOld, session ) ) {
+				final Object idOfOld = getEntityIdentifierIfNotUnsaved( entityName, itr.next(), session );
+				if ( identifierMapping.areEqual( idOfCurrent, idOfOld, session ) ) {
 					itr.remove();
 					break;
 				}

--- a/hibernate-core/src/main/java/org/hibernate/engine/spi/CollectionEntry.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/spi/CollectionEntry.java
@@ -91,7 +91,7 @@ public final class CollectionEntry implements Serializable {
 		this.loadedKey = loadedKey;
 
 		this.loadedPersister = loadedPersister;
-		this.role = ( loadedPersister == null ? null : loadedPersister.getRole() );
+		this.role = loadedPersister == null ? null : loadedPersister.getRole();
 
 		collection.setSnapshot( loadedKey, role, null );
 

--- a/hibernate-core/src/main/java/org/hibernate/engine/transaction/internal/TransactionImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/transaction/internal/TransactionImpl.java
@@ -80,9 +80,7 @@ public class TransactionImpl implements TransactionImplementor {
 	@Override
 	public void commit() {
 		// allow MARKED_ROLLBACK to propagate through to transactionDriverControl
-		// the boolean passed to isActive indicates whether MARKED_ROLLBACK should
-		// be considered active
-		if ( !isActive( true ) ) {
+		if ( !isActive() ) {
 			// we have a transaction that is inactive and has not been marked for rollback only
 			throw new IllegalStateException( "Transaction not successfully started" );
 		}
@@ -129,13 +127,6 @@ public class TransactionImpl implements TransactionImplementor {
 
 	@Override
 	public boolean isActive() {
-		// old behavior considered TransactionStatus#MARKED_ROLLBACK as active
-//		return isActive( jpaCompliance.isJpaTransactionComplianceEnabled() ? false : true );
-		return isActive( true );
-	}
-
-	@Override
-	public boolean isActive(boolean isMarkedForRollbackConsideredActive) {
 		if ( transactionDriverControl == null ) {
 			if ( session.isOpen() ) {
 				transactionDriverControl = transactionCoordinator.getTransactionDriverControl();
@@ -144,7 +135,7 @@ public class TransactionImpl implements TransactionImplementor {
 				return false;
 			}
 		}
-		return transactionDriverControl.isActive( isMarkedForRollbackConsideredActive );
+		return transactionDriverControl.isActive();
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/engine/transaction/spi/TransactionImplementor.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/transaction/spi/TransactionImplementor.java
@@ -4,23 +4,15 @@
  */
 package org.hibernate.engine.transaction.spi;
 
-import org.hibernate.HibernateException;
 import org.hibernate.Transaction;
-import org.hibernate.resource.transaction.spi.TransactionStatus;
 
 /**
  * Defines the "internal contract" for an implementation of {@link Transaction}.
  *
  * @author Steve Ebersole
+ *
+ * @deprecated This is no longer needed
  */
+@Deprecated(since = "7.0", forRemoval = true)
 public interface TransactionImplementor extends Transaction {
-	/**
-	 * Indicate whether a resource transaction is in progress.
-	 *
-	 * @param isMarkedRollbackConsideredActive whether to consider {@link TransactionStatus#MARKED_ROLLBACK} as active.
-	 *
-	 * @return boolean indicating whether transaction is in progress
-	 * @throws HibernateException if an unexpected error condition is encountered.
-	 */
-	boolean isActive(boolean isMarkedRollbackConsideredActive);
 }

--- a/hibernate-core/src/main/java/org/hibernate/internal/CoreMessageLogger.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/CoreMessageLogger.java
@@ -342,6 +342,10 @@ public interface CoreMessageLogger extends BasicLogger {
 	void unableToConstructCurrentSessionContext(String impl, @Cause Throwable e);
 
 	@LogMessage(level = WARN)
+	@Message(value = "Unable to close temporary session used to load lazy collection associated to no session", id = 303)
+	void unableToCloseTemporarySession();
+
+	@LogMessage(level = WARN)
 	@Message(value = "Could not copy system properties, system properties will be ignored", id = 304)
 	void unableToCopySystemProperties();
 

--- a/hibernate-core/src/main/java/org/hibernate/internal/SessionImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/SessionImpl.java
@@ -450,16 +450,18 @@ public class SessionImpl
 	private boolean isTransactionInProgressAndNotMarkedForRollback() {
 		if ( waitingForAutoClose ) {
 			return getSessionFactory().isOpen()
-				&& isTransactionActive();
+				&& isTransactionActiveAndNotMarkedForRollback();
 		}
 		else {
 			return !isClosed()
-				&& isTransactionActive();
+				&& isTransactionActiveAndNotMarkedForRollback();
 		}
 	}
 
-	private boolean isTransactionActive() {
-		return getTransactionCoordinator().isTransactionActive( false );
+	private boolean isTransactionActiveAndNotMarkedForRollback() {
+		final TransactionCoordinator transactionCoordinator = getTransactionCoordinator();
+		return transactionCoordinator.isJoined()
+			&& transactionCoordinator.getTransactionDriverControl().isActiveAndNoMarkedForRollback();
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/resource/jdbc/internal/AbstractLogicalConnectionImplementor.java
+++ b/hibernate-core/src/main/java/org/hibernate/resource/jdbc/internal/AbstractLogicalConnectionImplementor.java
@@ -84,6 +84,7 @@ public abstract class AbstractLogicalConnectionImplementor implements LogicalCon
 	public void commit() {
 		try {
 			log.trace( "Preparing to commit transaction via JDBC Connection.commit()" );
+			status = TransactionStatus.COMMITTING;
 			if ( isPhysicallyConnected() ) {
 				getConnectionForTransactionManagement().commit();
 			}
@@ -124,6 +125,7 @@ public abstract class AbstractLogicalConnectionImplementor implements LogicalCon
 	public void rollback() {
 		try {
 			log.trace( "Preparing to rollback transaction via JDBC Connection.rollback()" );
+			status = TransactionStatus.ROLLING_BACK;
 			if ( isPhysicallyConnected() ) {
 				getConnectionForTransactionManagement().rollback();
 			}

--- a/hibernate-core/src/main/java/org/hibernate/resource/transaction/backend/jta/internal/JtaTransactionAdapterTransactionManagerImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/resource/transaction/backend/jta/internal/JtaTransactionAdapterTransactionManagerImpl.java
@@ -85,7 +85,11 @@ public class JtaTransactionAdapterTransactionManagerImpl implements JtaTransacti
 	@Override
 	public TransactionStatus getStatus() {
 		try {
-			return StatusTranslator.translate( transactionManager.getStatus() );
+			final TransactionStatus status = StatusTranslator.translate( transactionManager.getStatus() );
+			if ( status == null ) {
+				throw new TransactionException( "TransactionManager reported transaction status as unknown" );
+			}
+			return status;
 		}
 		catch (SystemException e) {
 			throw new TransactionException( "JTA TransactionManager#getStatus failed", e );

--- a/hibernate-core/src/main/java/org/hibernate/resource/transaction/backend/jta/internal/JtaTransactionAdapterUserTransactionImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/resource/transaction/backend/jta/internal/JtaTransactionAdapterUserTransactionImpl.java
@@ -86,10 +86,14 @@ public class JtaTransactionAdapterUserTransactionImpl implements JtaTransactionA
 	@Override
 	public TransactionStatus getStatus() {
 		try {
-			return StatusTranslator.translate( userTransaction.getStatus() );
+			final TransactionStatus status = StatusTranslator.translate( userTransaction.getStatus() );
+			if ( status == null ) {
+				throw new TransactionException( "UserTransaction reported transaction status as unknown" );
+			}
+			return status;
 		}
 		catch (SystemException e) {
-			throw new TransactionException( "JTA TransactionManager#getStatus failed", e );
+			throw new TransactionException( "JTA UserTransaction#getStatus failed", e );
 		}
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/resource/transaction/backend/jta/internal/JtaTransactionCoordinatorImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/resource/transaction/backend/jta/internal/JtaTransactionCoordinatorImpl.java
@@ -395,7 +395,7 @@ public class JtaTransactionCoordinatorImpl implements TransactionCoordinator, Sy
 		public void begin() {
 			errorIfInvalid();
 			jtaTransactionAdapter.begin();
-			JtaTransactionCoordinatorImpl.this.joinJtaTransaction();
+			joinJtaTransaction();
 		}
 
 		protected void errorIfInvalid() {

--- a/hibernate-core/src/main/java/org/hibernate/resource/transaction/backend/jta/internal/StatusTranslator.java
+++ b/hibernate-core/src/main/java/org/hibernate/resource/transaction/backend/jta/internal/StatusTranslator.java
@@ -6,7 +6,7 @@ package org.hibernate.resource.transaction.backend.jta.internal;
 
 import jakarta.transaction.Status;
 
-import org.hibernate.TransactionException;
+import org.hibernate.AssertionFailure;
 import org.hibernate.resource.transaction.spi.TransactionStatus;
 
 /**
@@ -15,42 +15,19 @@ import org.hibernate.resource.transaction.spi.TransactionStatus;
 public class StatusTranslator {
 
 	public static TransactionStatus translate(int status) {
-		TransactionStatus transactionStatus = null;
-		switch ( status ) {
-			case Status.STATUS_ACTIVE:
-				transactionStatus = TransactionStatus.ACTIVE;
-				break;
-			case Status.STATUS_PREPARED:
-				transactionStatus = TransactionStatus.ACTIVE;
-				break;
-			case Status.STATUS_PREPARING:
-				transactionStatus = TransactionStatus.ACTIVE;
-				break;
-			case Status.STATUS_COMMITTING:
-				transactionStatus = TransactionStatus.COMMITTING;
-				break;
-			case Status.STATUS_ROLLING_BACK:
-				transactionStatus = TransactionStatus.ROLLING_BACK;
-				break;
-			case Status.STATUS_NO_TRANSACTION:
-				transactionStatus = TransactionStatus.NOT_ACTIVE;
-				break;
-			case Status.STATUS_COMMITTED:
-				transactionStatus = TransactionStatus.COMMITTED;
-				break;
-			case Status.STATUS_ROLLEDBACK:
-				transactionStatus = TransactionStatus.ROLLED_BACK;
-				break;
-			case Status.STATUS_MARKED_ROLLBACK:
-				transactionStatus = TransactionStatus.MARKED_ROLLBACK;
-				break;
-			default:
-				break;
-		}
-		if ( transactionStatus == null ) {
-			throw new TransactionException( "TransactionManager reported transaction status as unknown" );
-		}
-		return transactionStatus;
+		return switch ( status ) {
+			case Status.STATUS_ACTIVE -> TransactionStatus.ACTIVE;
+			case Status.STATUS_PREPARED -> TransactionStatus.ACTIVE;
+			case Status.STATUS_PREPARING -> TransactionStatus.ACTIVE;
+			case Status.STATUS_COMMITTING -> TransactionStatus.COMMITTING;
+			case Status.STATUS_ROLLING_BACK -> TransactionStatus.ROLLING_BACK;
+			case Status.STATUS_NO_TRANSACTION -> TransactionStatus.NOT_ACTIVE;
+			case Status.STATUS_COMMITTED -> TransactionStatus.COMMITTED;
+			case Status.STATUS_ROLLEDBACK -> TransactionStatus.ROLLED_BACK;
+			case Status.STATUS_MARKED_ROLLBACK -> TransactionStatus.MARKED_ROLLBACK;
+			case Status.STATUS_UNKNOWN -> null;
+			default -> throw new AssertionFailure( "Unknown transaction status code: " + status );
+		};
 	}
 
 }

--- a/hibernate-core/src/main/java/org/hibernate/resource/transaction/spi/TransactionCoordinator.java
+++ b/hibernate-core/src/main/java/org/hibernate/resource/transaction/spi/TransactionCoordinator.java
@@ -98,12 +98,8 @@ public interface TransactionCoordinator {
 	int getTimeOut();
 
 	default boolean isTransactionActive() {
-		return isTransactionActive( true );
-	}
-
-	default boolean isTransactionActive(boolean isMarkedRollbackConsideredActive) {
 		return isJoined()
-			&& getTransactionDriverControl().isActive( isMarkedRollbackConsideredActive );
+			&& getTransactionDriverControl().isActive();
 	}
 
 	default void invalidate(){}
@@ -134,10 +130,13 @@ public interface TransactionCoordinator {
 
 		void markRollbackOnly();
 
-		default boolean isActive(boolean isMarkedRollbackConsideredActive) {
+		default boolean isActive() {
 			final TransactionStatus status = getStatus();
-			return status == ACTIVE
-				|| isMarkedRollbackConsideredActive && status == MARKED_ROLLBACK;
+			return status == ACTIVE || status == MARKED_ROLLBACK;
+		}
+
+		default boolean isActiveAndNoMarkedForRollback() {
+			return getStatus() == ACTIVE;
 		}
 
 		// todo : org.hibernate.Transaction will need access to register local Synchronizations.

--- a/hibernate-core/src/main/java/org/hibernate/resource/transaction/spi/TransactionStatus.java
+++ b/hibernate-core/src/main/java/org/hibernate/resource/transaction/spi/TransactionStatus.java
@@ -50,6 +50,11 @@ public enum TransactionStatus {
 	 */
 	ROLLING_BACK;
 
+	public boolean isActive() {
+		return this == ACTIVE
+			|| this == MARKED_ROLLBACK;
+	}
+
 	public boolean isOneOf(TransactionStatus... statuses) {
 		for ( TransactionStatus status : statuses ) {
 			if ( this == status ) {
@@ -64,10 +69,8 @@ public enum TransactionStatus {
 	}
 
 	public boolean canRollback() {
-		return isOneOf(
-				TransactionStatus.ACTIVE,
-				TransactionStatus.FAILED_COMMIT,
-				TransactionStatus.MARKED_ROLLBACK
-		);
+		return this == ACTIVE
+			|| this == FAILED_COMMIT
+			|| this == MARKED_ROLLBACK;
 	}
 }

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/NamedQueryTransactionFailureTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/NamedQueryTransactionFailureTest.java
@@ -20,7 +20,6 @@ import org.mockito.Mockito;
 import static org.hibernate.testing.transaction.TransactionUtil.doInJPA;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.when;
@@ -59,7 +58,7 @@ public class NamedQueryTransactionFailureTest extends BaseEntityManagerFunctiona
 		TransactionCoordinator.TransactionDriver transactionDriver = Mockito.mock( TransactionCoordinator.TransactionDriver.class);
 		when( transactionCoordinator.getTransactionDriverControl() ).thenReturn( transactionDriver );
 		when( transactionCoordinator.isActive() ).thenReturn( true );
-		when( transactionDriver.isActive( anyBoolean() ) ).thenReturn( false );
+		when( transactionDriver.isActive() ).thenReturn( false );
 
 		doNothing().when( transactionCoordinator ).pulse();
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/transactions/TransactionLifecycleTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/transactions/TransactionLifecycleTest.java
@@ -1,0 +1,114 @@
+/*
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.transactions;
+
+import org.hibernate.Session;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@SessionFactory
+@DomainModel
+public class TransactionLifecycleTest {
+	@Test
+	void testCommit(SessionFactoryScope scope) {
+		Session session = scope.getSessionFactory().openSession();
+		assertFalse( session.getTransaction().wasStarted() );
+		session.getTransaction().begin();
+		assertTrue( session.getTransaction().wasStarted() );
+		assertTrue( session.getTransaction().isActive() );
+		session.getTransaction().runBeforeCompletion( () -> {
+			assertTrue( session.getTransaction().wasStarted() );
+			assertFalse( session.getTransaction().isInCompletionProcess() );
+			assertFalse( session.getTransaction().isComplete() );
+			assertTrue( session.getTransaction().isActive() );
+		} );
+		session.getTransaction().runAfterCompletion( status -> {
+			assertTrue( session.getTransaction().wasStarted() );
+			assertFalse( session.getTransaction().isInCompletionProcess() );
+			assertTrue( session.getTransaction().isComplete() );
+			assertFalse( session.getTransaction().isActive() );
+			assertTrue( session.getTransaction().wasSuccessful() );
+			assertFalse( session.getTransaction().wasFailure() );
+		} );
+		session.getTransaction().commit();
+		assertTrue( session.getTransaction().wasStarted() );
+		assertFalse( session.getTransaction().isInCompletionProcess() );
+		assertTrue( session.getTransaction().isComplete() );
+		assertFalse( session.getTransaction().isActive() );
+		assertTrue( session.getTransaction().wasSuccessful() );
+		assertFalse( session.getTransaction().wasFailure() );
+		session.close();
+	}
+
+	@Test
+	void testRollback(SessionFactoryScope scope) {
+		Session session = scope.getSessionFactory().openSession();
+		assertFalse( session.getTransaction().wasStarted() );
+		session.getTransaction().begin();
+		assertTrue( session.getTransaction().wasStarted() );
+		assertTrue( session.getTransaction().isActive() );
+		session.getTransaction().runBeforeCompletion( () -> {
+			assertTrue( session.getTransaction().wasStarted() );
+			assertFalse( session.getTransaction().isInCompletionProcess() );
+			assertFalse( session.getTransaction().isComplete() );
+			assertTrue( session.getTransaction().isActive() );
+		} );
+		session.getTransaction().runAfterCompletion( status -> {
+			assertTrue( session.getTransaction().wasStarted() );
+			assertFalse( session.getTransaction().isInCompletionProcess() );
+			assertTrue( session.getTransaction().isComplete() );
+			assertFalse( session.getTransaction().isActive() );
+			assertFalse( session.getTransaction().wasSuccessful() );
+			assertTrue( session.getTransaction().wasFailure() );
+		} );
+		session.getTransaction().rollback();
+		assertTrue( session.getTransaction().wasStarted() );
+		assertFalse( session.getTransaction().isInCompletionProcess() );
+		assertTrue( session.getTransaction().isComplete() );
+		assertFalse( session.getTransaction().isActive() );
+		assertFalse( session.getTransaction().wasSuccessful() );
+		assertTrue( session.getTransaction().wasFailure() );
+		session.close();
+	}
+
+	@Test
+	void testRollbackOnly(SessionFactoryScope scope) {
+		Session session = scope.getSessionFactory().openSession();
+		assertFalse( session.getTransaction().wasStarted() );
+		session.getTransaction().begin();
+		assertTrue( session.getTransaction().wasStarted() );
+		assertTrue( session.getTransaction().isActive() );
+		session.getTransaction().setRollbackOnly();
+		session.getTransaction().runBeforeCompletion( () -> {
+			assertTrue( session.getTransaction().wasStarted() );
+			assertFalse( session.getTransaction().isInCompletionProcess() );
+			assertFalse( session.getTransaction().isComplete() );
+			assertTrue( session.getTransaction().isActive() );
+			assertTrue( session.getTransaction().getRollbackOnly() );
+		} );
+		session.getTransaction().runAfterCompletion( status -> {
+			assertTrue( session.getTransaction().wasStarted() );
+			assertFalse( session.getTransaction().isInCompletionProcess() );
+			assertTrue( session.getTransaction().isComplete() );
+			assertFalse( session.getTransaction().isActive() );
+			assertFalse( session.getTransaction().wasSuccessful() );
+			assertTrue( session.getTransaction().wasFailure() );
+		} );
+		assertTrue( session.getTransaction().getRollbackOnly() );
+		session.getTransaction().commit();
+		assertTrue( session.getTransaction().wasStarted() );
+		assertFalse( session.getTransaction().isInCompletionProcess() );
+		assertTrue( session.getTransaction().isComplete() );
+		assertFalse( session.getTransaction().isActive() );
+		assertFalse( session.getTransaction().wasSuccessful() );
+		assertTrue( session.getTransaction().wasFailure() );
+		session.close();
+	}
+}


### PR DESCRIPTION
also clean up some stuff in AbstractPersistentCollection

Unfortunately TransactionStatus is an SPI type, which makes its use in the API of Transaction a bit wrong. Also, it's weird to see dependence on an interface defined by JPA. (However these are relatively harmless aesthetic points, so I decided not to deprecate anything.) Instead I've added alternative "convenience" operations.

Note on terminology: a transaction which has been "marked for rollback only" is still an active transaction! You can still do work in it, and that work will still be atomically rolled back when the transaction completes. Apparently there was some confusion on this at some point, which was later fixed, but some evidence of the confusion was left behind in code.

<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

[Please describe here what your change is about]

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
