### PR TITLE
AbstractSqmParameter.allowMultiValuedBinding() returning true for non collection/array

### DIFF
--- a/tooling/metamodel-generator/src/jakartaData/java/org/hibernate/processor/test/data/multivaluebinding/Post.java
+++ b/tooling/metamodel-generator/src/jakartaData/java/org/hibernate/processor/test/data/multivaluebinding/Post.java
@@ -10,6 +10,7 @@ import jakarta.persistence.NamedQuery;
 
 @Entity
 @NamedQuery(name = "#getPostsByName", query = "from Post p where p.name in (:names)")
+@NamedQuery(name = "#getPostsByNameIgnoreCase", query = "from Post p where p.name = lower(:name)")
 public class Post {
 	@Id
 	Integer id;

--- a/tooling/metamodel-generator/src/jakartaData/java/org/hibernate/processor/test/data/multivaluebinding/PostRepository.java
+++ b/tooling/metamodel-generator/src/jakartaData/java/org/hibernate/processor/test/data/multivaluebinding/PostRepository.java
@@ -16,4 +16,7 @@ public interface PostRepository extends DataRepository<Post, Integer> {
 
 	@Query("from Post p where p.name in (:names)")
 	List<Post> getPostsByName(Collection<String> names);
+
+	@Query("from Post p where p.name = lower(:name)")
+	List<Post> getPostsByNameIgnoreCase(String name);
 }

--- a/tooling/metamodel-generator/src/jakartaData/java/org/hibernate/processor/test/data/multivaluebinding/TopicPostTest.java
+++ b/tooling/metamodel-generator/src/jakartaData/java/org/hibernate/processor/test/data/multivaluebinding/TopicPostTest.java
@@ -48,5 +48,9 @@ public class TopicPostTest extends CompilationTest {
 		else {
 			fail();
 		}
+
+		assertPresenceOfMethodInMetamodelFor( PostRepository.class, "getPostsByNameIgnoreCase", String.class );
+
+		assertPresenceOfMethodInMetamodelFor( Post.class, "getPostsByNameIgnoreCase", EntityManager.class, String.class );
 	}
 }


### PR DESCRIPTION
Only added simple query to existing test class `org.hibernate.processor.test.data.multivaluebinding.TopicPostTest`
```
from Post p where p.name = lower(:name)
```

Parameter is properly handled in `PostRepository_`, but not in Ṗost_`.  Former can be expected since there method parameter type are retrieved from method signature.

Two things are wrong - lesser evil is that parameter type has not been recognized as `String`, but this will still create usable method. Much bigger problem is that due to fact that allow multi value binding returns false parameter type is `List`.

Tested with `SqmNamedParameter`, very likely that same problem is with `SqmPositionalParameter` as well.

Possible source of problem may be `org.hibernate.query.hql.internal.SemanticQueryBuilder#visitFinalFunctionArgument`, but I may be very wrong.

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
