### PR TITLE
Backport HHH-18972 to branch 6.6 - Upgrade to ByteBuddy 1.15.11

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -36,11 +36,11 @@ stage('Configure') {
 		// even if we don't use these features, just enabling them can cause side effects
 		// and it's useful to test that.
 		new BuildEnvironment( testJdkVersion: '23', testJdkLauncherArgs: '--enable-preview' ),
+		new BuildEnvironment( testJdkVersion: '24', testJdkLauncherArgs: '--enable-preview' ),
 		// The following JDKs aren't supported by Hibernate ORM out-of-the box yet:
 		// they require the use of -Dnet.bytebuddy.experimental=true.
 		// Make sure to remove that argument as soon as possible
 		// -- generally that requires upgrading bytebuddy after the JDK goes GA.
-		new BuildEnvironment( testJdkVersion: '24', testJdkLauncherArgs: '--enable-preview -Dnet.bytebuddy.experimental=true' ),
 		new BuildEnvironment( testJdkVersion: '25', testJdkLauncherArgs: '--enable-preview -Dnet.bytebuddy.experimental=true' )
 	];
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -36,12 +36,12 @@ stage('Configure') {
 		// even if we don't use these features, just enabling them can cause side effects
 		// and it's useful to test that.
 		new BuildEnvironment( testJdkVersion: '23', testJdkLauncherArgs: '--enable-preview' ),
-		new BuildEnvironment( testJdkVersion: '23', testJdkLauncherArgs: '--enable-preview' ),
 		// The following JDKs aren't supported by Hibernate ORM out-of-the box yet:
 		// they require the use of -Dnet.bytebuddy.experimental=true.
 		// Make sure to remove that argument as soon as possible
 		// -- generally that requires upgrading bytebuddy after the JDK goes GA.
-		new BuildEnvironment( testJdkVersion: '24', testJdkLauncherArgs: '--enable-preview -Dnet.bytebuddy.experimental=true' )
+		new BuildEnvironment( testJdkVersion: '24', testJdkLauncherArgs: '--enable-preview -Dnet.bytebuddy.experimental=true' ),
+		new BuildEnvironment( testJdkVersion: '25', testJdkLauncherArgs: '--enable-preview -Dnet.bytebuddy.experimental=true' )
 	];
 
 	helper.configure {

--- a/settings.gradle
+++ b/settings.gradle
@@ -70,7 +70,7 @@ dependencyResolutionManagement {
             def antlrVersion = version "antlr", "4.13.0"
             // WARNING: When upgrading to a version of bytebuddy that supports a new bytecode version,
             // make sure to remove the now unnecessary net.bytebuddy.experimental=true in relevant CI jobs (Jenkinsfile).
-            def byteBuddyVersion = version "byteBuddy", "1.14.18"
+            def byteBuddyVersion = version "byteBuddy", "1.15.11"
             def classmateVersion = version "classmate", "1.5.1"
             def geolatteVersion = version "geolatte", "1.9.1"
             def hcannVersion = version "hcann", "7.0.3.Final"


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-18972

Backport of #9477 to branch 6.6.

Potentially more impacting here, as we're upgrading from Bytebuddy 1.14 (on `main` we were already on Bytebuddy 1.15). Creating as draft so we can see the impact.

See also https://github.com/wildfly/wildfly/pull/18588