### PR TITLE
HHH-18983 work on Generators

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/boot/model/internal/AbstractEntityIdGeneratorResolver.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/internal/AbstractEntityIdGeneratorResolver.java
@@ -137,7 +137,9 @@ public abstract class AbstractEntityIdGeneratorResolver implements IdGeneratorRe
 	}
 
 	private Annotation findGeneratorAnnotation(AnnotationTarget annotationTarget) {
-		final List<? extends Annotation> metaAnnotated = annotationTarget.getMetaAnnotated( IdGeneratorType.class, buildingContext.getMetadataCollector().getSourceModelBuildingContext() );
+		final List<? extends Annotation> metaAnnotated =
+				annotationTarget.getMetaAnnotated( IdGeneratorType.class,
+						buildingContext.getMetadataCollector().getSourceModelBuildingContext() );
 		if ( CollectionHelper.size( metaAnnotated ) > 0 ) {
 			return metaAnnotated.get( 0 );
 		}
@@ -149,12 +151,14 @@ public abstract class AbstractEntityIdGeneratorResolver implements IdGeneratorRe
 		// Handle a few legacy Hibernate generators...
 		final String nameFromGeneratedValue = generatedValue.generator();
 		if ( !nameFromGeneratedValue.isBlank() ) {
-			final Class<? extends Generator> legacyNamedGenerator = mapLegacyNamedGenerator( nameFromGeneratedValue, idValue );
+			final Class<? extends Generator> legacyNamedGenerator =
+					mapLegacyNamedGenerator( nameFromGeneratedValue, idValue );
 			if ( legacyNamedGenerator != null ) {
 				final Map<String,String> configuration = buildLegacyGeneratorConfig();
 				//noinspection unchecked,rawtypes
 				GeneratorBinder.createGeneratorFrom(
-						new IdentifierGeneratorDefinition( nameFromGeneratedValue, legacyNamedGenerator.getName(), configuration ),
+						new IdentifierGeneratorDefinition( nameFromGeneratedValue,
+								legacyNamedGenerator.getName(), configuration ),
 						idValue,
 						(Map) configuration,
 						buildingContext

--- a/hibernate-core/src/main/java/org/hibernate/boot/model/internal/GeneratorBinder.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/internal/GeneratorBinder.java
@@ -28,6 +28,7 @@ import org.hibernate.boot.models.spi.GlobalRegistrar;
 import org.hibernate.boot.spi.InFlightMetadataCollector;
 import org.hibernate.boot.spi.MetadataBuildingContext;
 import org.hibernate.boot.spi.PropertyData;
+import org.hibernate.engine.config.spi.ConfigurationService;
 import org.hibernate.generator.AnnotationBasedGenerator;
 import org.hibernate.generator.Assigned;
 import org.hibernate.generator.BeforeExecutionGenerator;
@@ -46,6 +47,7 @@ import org.hibernate.mapping.GeneratorCreator;
 import org.hibernate.mapping.KeyValue;
 import org.hibernate.mapping.PersistentClass;
 import org.hibernate.mapping.SimpleValue;
+import org.hibernate.mapping.Value;
 import org.hibernate.models.spi.AnnotationTarget;
 import org.hibernate.models.spi.MemberDetails;
 import org.hibernate.models.spi.SourceModelBuildingContext;
@@ -344,16 +346,10 @@ public class GeneratorBinder {
 	}
 
 	private static void checkGeneratorInterfaces(Class<? extends Generator> generatorClass) {
-		// we don't yet support the additional "fancy" operations of
-		// IdentifierGenerator with regular generators, though this
-		// would be extremely easy to add if anyone asks for it
+		// A regular value generator should not implement legacy IdentifierGenerator
 		if ( IdentifierGenerator.class.isAssignableFrom( generatorClass ) ) {
 			throw new AnnotationException("Generator class '" + generatorClass.getName()
 					+ "' implements 'IdentifierGenerator' and may not be used with '@ValueGenerationType'");
-		}
-		if ( ExportableProducer.class.isAssignableFrom( generatorClass ) ) {
-			throw new AnnotationException("Generator class '" + generatorClass.getName()
-					+ "' implements 'ExportableProducer' and may not be used with '@ValueGenerationType'");
 		}
 	}
 
@@ -363,6 +359,7 @@ public class GeneratorBinder {
 	 */
 	private static GeneratorCreator generatorCreator(
 			MemberDetails memberDetails,
+			Value value,
 			Annotation annotation,
 			BeanContainer beanContainer) {
 		final Class<? extends Annotation> annotationType = annotation.annotationType();
@@ -372,19 +369,40 @@ public class GeneratorBinder {
 		checkGeneratorClass( generatorClass );
 		checkGeneratorInterfaces( generatorClass );
 		return creationContext -> {
-			final Generator generator = instantiateGenerator(
-					annotation,
-					beanContainer,
-					creationContext,
-					generatorClass,
-					memberDetails,
-					annotationType
-			);
-			callInitialize( annotation, memberDetails, creationContext, generator );
-			//TODO: callConfigure( creationContext, generator, emptyMap(), identifierValue );
+			final Generator generator =
+					instantiateAndInitializeGenerator(
+							value,
+							annotation,
+							beanContainer,
+							creationContext,
+							generatorClass,
+							memberDetails,
+							annotationType
+					);
 			checkVersionGenerationAlways( memberDetails, generator );
 			return generator;
 		};
+	}
+
+	private static Generator instantiateAndInitializeGenerator(
+			Value value,
+			Annotation annotation,
+			BeanContainer beanContainer,
+			GeneratorCreationContext creationContext,
+			Class<? extends Generator> generatorClass,
+			MemberDetails memberDetails,
+			Class<? extends Annotation> annotationType) {
+		final Generator generator = instantiateGenerator(
+				annotation,
+				beanContainer,
+				creationContext,
+				generatorClass,
+				memberDetails,
+				annotationType
+		);
+		callInitialize( annotation, memberDetails, creationContext, generator );
+		callConfigure( creationContext, generator, emptyMap(), value );
+		return generator;
 	}
 
 	/**
@@ -403,7 +421,8 @@ public class GeneratorBinder {
 		checkGeneratorClass( generatorClass );
 		return creationContext -> {
 			final Generator generator =
-					instantiateGenerator(
+					instantiateAndInitializeGenerator(
+							identifierValue,
 							annotation,
 							beanContainer,
 							creationContext,
@@ -411,8 +430,6 @@ public class GeneratorBinder {
 							idAttributeMember,
 							annotationType
 					);
-			callInitialize( annotation, idAttributeMember, creationContext, generator );
-			callConfigure( creationContext, generator, emptyMap(), identifierValue );
 			checkIdGeneratorTiming( annotationType, generator );
 			return generator;
 		};
@@ -610,13 +627,14 @@ public class GeneratorBinder {
 			GeneratorCreationContext creationContext,
 			Generator generator,
 			Map<String, Object> configuration,
-			SimpleValue identifierValue) {
+			Value value) {
 		if ( generator instanceof Configurable configurable ) {
 			final Properties parameters = collectParameters(
-					identifierValue,
+					value,
 					creationContext.getDatabase().getDialect(),
 					creationContext.getRootClass(),
-					configuration
+					configuration,
+					creationContext.getServiceRegistry().requireService( ConfigurationService.class )
 			);
 			configurable.configure( creationContext, parameters );
 		}
@@ -838,13 +856,13 @@ public class GeneratorBinder {
 	 */
 	static GeneratorCreator createValueGeneratorFromAnnotations(
 			PropertyHolder holder, String propertyName,
-			MemberDetails property, MetadataBuildingContext context) {
+			Value value, MemberDetails property, MetadataBuildingContext context) {
 		final List<? extends Annotation> generatorAnnotations =
 				property.getMetaAnnotated( ValueGenerationType.class,
 						context.getMetadataCollector().getSourceModelBuildingContext() );
 		return switch ( generatorAnnotations.size() ) {
 			case 0 -> null;
-			case 1 -> generatorCreator( property, generatorAnnotations.get(0), beanContainer( context ) );
+			case 1 -> generatorCreator( property, value, generatorAnnotations.get(0), beanContainer( context ) );
 			default -> throw new AnnotationException( "Property '" + qualify( holder.getPath(), propertyName )
 					+ "' has too many generator annotations: " + generatorAnnotations );
 		};

--- a/hibernate-core/src/main/java/org/hibernate/boot/model/internal/GeneratorBinder.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/internal/GeneratorBinder.java
@@ -125,7 +125,7 @@ public class GeneratorBinder {
 						determineImpliedGenerator( strategy, strategyGeneratorClassName, localGenerators );
 				if ( impliedGenerator != null ) {
 					configuration.putAll( impliedGenerator.getParameters() );
-					instantiateGeneratorBean( identifierValue, strategyGeneratorClassName, configuration, context );
+					instantiateNamedStrategyGenerator( identifierValue, strategyGeneratorClassName, configuration, context );
 					return;
 				}
 			}
@@ -550,9 +550,7 @@ public class GeneratorBinder {
 	 * @param beanContainer an optional {@code BeanContainer}
 	 * @param generatorClass a class which implements {@code Generator}
 	 */
-	public static <T extends Generator> T instantiateGenerator(
-			BeanContainer beanContainer,
-			Class<T> generatorClass) {
+	public static <T extends Generator> T instantiateGenerator(BeanContainer beanContainer, Class<T> generatorClass) {
 		return beanContainer != null
 				? instantiateGeneratorAsBean( beanContainer, generatorClass )
 				: instantiateGeneratorViaDefaultConstructor( generatorClass );
@@ -682,7 +680,7 @@ public class GeneratorBinder {
 			Map<String, Object> configuration,
 			MetadataBuildingContext context) {
 		configuration.putAll( defaultedGenerator.getParameters() );
-		instantiateGeneratorBean( idValue, defaultedGenerator.getStrategy(), configuration, context );
+		instantiateNamedStrategyGenerator( idValue, defaultedGenerator.getStrategy(), configuration, context );
 	}
 
 
@@ -690,12 +688,7 @@ public class GeneratorBinder {
 			IdentifierGeneratorDefinition defaultedGenerator,
 			SimpleValue idValue,
 			MetadataBuildingContext context) {
-		createGeneratorFrom(
-				defaultedGenerator,
-				idValue,
-				buildConfigurationMap( idValue ),
-				context
-		);
+		createGeneratorFrom( defaultedGenerator, idValue, buildConfigurationMap( idValue ), context );
 	}
 
 	private static Map<String, Object> buildConfigurationMap(KeyValue idValue) {
@@ -760,11 +753,11 @@ public class GeneratorBinder {
 			identifierValue.setCustomIdGeneratorCreator( ASSIGNED_IDENTIFIER_GENERATOR_CREATOR );
 		}
 		else {
-			instantiateGeneratorBean( identifierValue, generatorStrategy, configuration, context );
+			instantiateNamedStrategyGenerator( identifierValue, generatorStrategy, configuration, context );
 		}
 	}
 
-	private static void instantiateGeneratorBean(
+	private static void instantiateNamedStrategyGenerator(
 			SimpleValue identifierValue,
 			String generatorStrategy,
 			Map<String, Object> configuration,
@@ -773,6 +766,8 @@ public class GeneratorBinder {
 		identifierValue.setCustomIdGeneratorCreator( creationContext -> {
 			final Generator identifierGenerator =
 					instantiateGenerator( beanContainer, generatorClass( generatorStrategy, identifierValue ) );
+			// in this code path, there's no generator annotation,
+			// and therefore no need to call initialize()
 			callConfigure( creationContext, identifierGenerator, configuration, identifierValue );
 			if ( identifierGenerator instanceof IdentityGenerator) {
 				identifierValue.setColumnToIdentity();

--- a/hibernate-core/src/main/java/org/hibernate/boot/model/internal/GeneratorParameters.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/internal/GeneratorParameters.java
@@ -96,25 +96,21 @@ public class GeneratorParameters {
 			RootClass rootClass,
 			BiConsumer<String,String> parameterCollector) {
 
-		final ConfigurationService configService = identifierValue
-				.getMetadata()
-				.getMetadataBuildingOptions()
-				.getServiceRegistry()
-				.requireService( ConfigurationService.class );
+		final ConfigurationService configService =
+				identifierValue.getMetadata().getMetadataBuildingOptions()
+						.getServiceRegistry().requireService( ConfigurationService.class );
 
 		// default initial value and allocation size per-JPA defaults
 		parameterCollector.accept( INITIAL_PARAM, String.valueOf( DEFAULT_INITIAL_VALUE ) );
 		parameterCollector.accept( INCREMENT_PARAM,	String.valueOf( defaultIncrement( configService ) ) );
 
-		collectBaselineProperties( identifierValue, dialect, rootClass, parameterCollector );
+		collectBaselineProperties( identifierValue, dialect, rootClass, parameterCollector, configService );
 	}
 
 	public static int fallbackAllocationSize(Annotation generatorAnnotation, MetadataBuildingContext buildingContext) {
 		if ( generatorAnnotation == null ) {
-			final ConfigurationService configService = buildingContext
-					.getBootstrapContext()
-					.getServiceRegistry()
-					.requireService( ConfigurationService.class );
+			final ConfigurationService configService = buildingContext.getBootstrapContext()
+					.getServiceRegistry().requireService( ConfigurationService.class );
 			final String idNamingStrategy = configService.getSetting( ID_DB_STRUCTURE_NAMING_STRATEGY, StandardConverters.STRING );
 			if ( LegacyNamingStrategy.STRATEGY_NAME.equals( idNamingStrategy )
 					|| LegacyNamingStrategy.class.getName().equals( idNamingStrategy )
@@ -127,18 +123,12 @@ public class GeneratorParameters {
 		return OptimizableGenerator.DEFAULT_INCREMENT_SIZE;
 	}
 
-	public static void collectBaselineProperties(
+	static void collectBaselineProperties(
 			SimpleValue identifierValue,
 			Dialect dialect,
 			RootClass rootClass,
-			BiConsumer<String,String> parameterCollector) {
-
-		final ConfigurationService configService = identifierValue
-				.getMetadata()
-				.getMetadataBuildingOptions()
-				.getServiceRegistry()
-				.requireService( ConfigurationService.class );
-
+			BiConsumer<String,String> parameterCollector,
+			ConfigurationService configService) {
 		//init the table here instead of earlier, so that we can get a quoted table name
 		//TODO: would it be better to simply pass the qualified table name, instead of
 		//	  splitting it up into schema/catalog/table names
@@ -172,7 +162,8 @@ public class GeneratorParameters {
 			parameterCollector.accept( IMPLICIT_NAME_BASE, tableName );
 		}
 
-		parameterCollector.accept( CONTRIBUTOR_NAME, identifierValue.getBuildingContext().getCurrentContributorName() );
+		parameterCollector.accept( CONTRIBUTOR_NAME,
+				identifierValue.getBuildingContext().getCurrentContributorName() );
 
 		final Map<String, Object> settings = configService.getSettings();
 		if ( settings.containsKey( AvailableSettings.PREFERRED_POOLED_OPTIMIZER ) ) {
@@ -181,7 +172,6 @@ public class GeneratorParameters {
 					(String) settings.get( AvailableSettings.PREFERRED_POOLED_OPTIMIZER )
 			);
 		}
-
 	}
 
 	public static String identityTablesString(Dialect dialect, RootClass rootClass) {

--- a/hibernate-core/src/main/java/org/hibernate/boot/model/internal/GeneratorParameters.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/internal/GeneratorParameters.java
@@ -27,12 +27,12 @@ import org.hibernate.internal.CoreLogging;
 import org.hibernate.internal.CoreMessageLogger;
 import org.hibernate.mapping.Column;
 import org.hibernate.mapping.RootClass;
-import org.hibernate.mapping.SimpleValue;
 import org.hibernate.mapping.Table;
 
 import jakarta.persistence.SequenceGenerator;
 import jakarta.persistence.TableGenerator;
 import jakarta.persistence.UniqueConstraint;
+import org.hibernate.mapping.Value;
 
 import static org.hibernate.cfg.MappingSettings.ID_DB_STRUCTURE_NAMING_STRATEGY;
 import static org.hibernate.id.IdentifierGenerator.CONTRIBUTOR_NAME;
@@ -66,24 +66,13 @@ public class GeneratorParameters {
 	 * {@link Configurable#configure(GeneratorCreationContext, Properties)}.
 	 */
 	public static Properties collectParameters(
-			SimpleValue identifierValue,
-			Dialect dialect,
-			RootClass rootClass) {
-		final Properties params = new Properties();
-		collectParameters( identifierValue, dialect, rootClass, params::put );
-		return params;
-	}
-
-	/**
-	 * Collect the parameters which should be passed to
-	 * {@link Configurable#configure(GeneratorCreationContext, Properties)}.
-	 */
-	public static Properties collectParameters(
-			SimpleValue identifierValue,
+			Value identifierValue,
 			Dialect dialect,
 			RootClass rootClass,
-			Map<String, Object> configuration) {
-		final Properties params = collectParameters( identifierValue, dialect, rootClass );
+			Map<String, Object> configuration,
+			ConfigurationService configService) {
+		final Properties params = new Properties();
+		collectParameters( identifierValue, dialect, rootClass, params::put, configService );
 		if ( configuration != null ) {
 			params.putAll( configuration );
 		}
@@ -91,15 +80,11 @@ public class GeneratorParameters {
 	}
 
 	public static void collectParameters(
-			SimpleValue identifierValue,
+			Value identifierValue,
 			Dialect dialect,
 			RootClass rootClass,
-			BiConsumer<String,String> parameterCollector) {
-
-		final ConfigurationService configService =
-				identifierValue.getMetadata().getMetadataBuildingOptions()
-						.getServiceRegistry().requireService( ConfigurationService.class );
-
+			BiConsumer<String, String> parameterCollector,
+			ConfigurationService configService) {
 		// default initial value and allocation size per-JPA defaults
 		parameterCollector.accept( INITIAL_PARAM, String.valueOf( DEFAULT_INITIAL_VALUE ) );
 		parameterCollector.accept( INCREMENT_PARAM,	String.valueOf( defaultIncrement( configService ) ) );
@@ -124,7 +109,7 @@ public class GeneratorParameters {
 	}
 
 	static void collectBaselineProperties(
-			SimpleValue identifierValue,
+			Value identifierValue,
 			Dialect dialect,
 			RootClass rootClass,
 			BiConsumer<String,String> parameterCollector,

--- a/hibernate-core/src/main/java/org/hibernate/boot/model/internal/IdGeneratorResolverSecondPass.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/internal/IdGeneratorResolverSecondPass.java
@@ -412,7 +412,6 @@ public class IdGeneratorResolverSecondPass extends AbstractEntityIdGeneratorReso
 		GeneratorAnnotationHelper.handleTableGenerator(
 				nameFromGeneratedValue,
 				generatorAnnotation,
-				entityMapping,
 				idValue,
 				idMember,
 				buildingContext

--- a/hibernate-core/src/main/java/org/hibernate/boot/model/internal/PropertyBinder.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/internal/PropertyBinder.java
@@ -450,7 +450,7 @@ public class PropertyBinder {
 	private void handleValueGeneration(Property property) {
 		if ( memberDetails != null ) {
 			property.setValueGeneratorCreator(
-					createValueGeneratorFromAnnotations( holder, name, memberDetails, buildingContext ) );
+					createValueGeneratorFromAnnotations( holder, name, value, memberDetails, buildingContext ) );
 		}
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/boot/model/internal/StrictIdGeneratorResolverSecondPass.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/internal/StrictIdGeneratorResolverSecondPass.java
@@ -116,7 +116,6 @@ public class StrictIdGeneratorResolverSecondPass extends AbstractEntityIdGenerat
 			handleTableGenerator(
 					entityMapping.getJpaEntityName(),
 					globalMatch.configuration(),
-					entityMapping,
 					idValue,
 					idMember,
 					buildingContext
@@ -127,7 +126,6 @@ public class StrictIdGeneratorResolverSecondPass extends AbstractEntityIdGenerat
 		handleTableGenerator(
 				entityMapping.getJpaEntityName(),
 				new TableGeneratorJpaAnnotation( metadataCollector.getSourceModelBuildingContext() ),
-				entityMapping,
 				idValue,
 				idMember,
 				buildingContext
@@ -145,7 +143,6 @@ public class StrictIdGeneratorResolverSecondPass extends AbstractEntityIdGenerat
 			handleTableGenerator(
 					generatedValue.generator(),
 					globalMatch.configuration(),
-					entityMapping,
 					idValue,
 					idMember,
 					buildingContext
@@ -157,7 +154,6 @@ public class StrictIdGeneratorResolverSecondPass extends AbstractEntityIdGenerat
 		handleTableGenerator(
 				generatedValue.generator(),
 				new TableGeneratorJpaAnnotation( generatedValue.generator(), metadataCollector.getSourceModelBuildingContext() ),
-				entityMapping,
 				idValue,
 				idMember,
 				buildingContext
@@ -197,7 +193,6 @@ public class StrictIdGeneratorResolverSecondPass extends AbstractEntityIdGenerat
 			handleTableGenerator(
 					globalRegistrationName,
 					globalTableMatch.configuration(),
-					entityMapping,
 					idValue,
 					idMember,
 					buildingContext

--- a/hibernate-core/src/main/java/org/hibernate/cfg/ManagedBeanSettings.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/ManagedBeanSettings.java
@@ -50,8 +50,8 @@ public interface ManagedBeanSettings {
 	 * <p>
 	 * Note that for CDI-based containers setting this is not necessary - simply
 	 * pass the {@link jakarta.enterprise.inject.spi.BeanManager} to use via
-	 * {@link #CDI_BEAN_MANAGER} and optionally specify {@link #DELAY_CDI_ACCESS}.
-	 * This setting useful to integrate non-CDI bean containers such as Spring.
+	 * {@link #JAKARTA_CDI_BEAN_MANAGER} and optionally specify {@link #DELAY_CDI_ACCESS}.
+	 * This setting is useful to integrate non-CDI bean containers such as Spring.
 	 *
 	 * @since 5.3
 	 */

--- a/hibernate-core/src/main/java/org/hibernate/generator/Generator.java
+++ b/hibernate-core/src/main/java/org/hibernate/generator/Generator.java
@@ -49,6 +49,10 @@ import static org.hibernate.generator.EventType.UPDATE;
  * <li>declare a only default constructor, in which case it will not receive parameters.
  * </ul>
  * <p>
+ * A {@code Generator} may be a managed bean (for example, a CDI bean) instantiated by the
+ * {@linkplain org.hibernate.resource.beans.container.spi.BeanContainer bean container}. In this
+ * case, only the first of these options, {@code AnnotationBasedGenerator}, is available.
+ * <p>
  * A generator must implement {@link #getEventTypes()} to specify the events for which it should be
  * called to produce a new value. {@link EventTypeSets} provides a convenient list of possibilities.
  * <p>

--- a/hibernate-core/src/main/java/org/hibernate/id/NativeGenerator.java
+++ b/hibernate-core/src/main/java/org/hibernate/id/NativeGenerator.java
@@ -6,11 +6,11 @@ package org.hibernate.id;
 
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.SequenceGenerator;
-import org.hibernate.boot.model.internal.GeneratorParameters;
 import org.hibernate.boot.model.relational.Database;
 import org.hibernate.boot.model.relational.ExportableProducer;
 import org.hibernate.boot.model.relational.SqlStringGenerationContext;
 import org.hibernate.dialect.Dialect;
+import org.hibernate.engine.config.spi.ConfigurationService;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.generator.AnnotationBasedGenerator;
 import org.hibernate.generator.BeforeExecutionGenerator;
@@ -22,7 +22,6 @@ import org.hibernate.id.enhanced.SequenceStyleGenerator;
 import org.hibernate.id.enhanced.TableGenerator;
 import org.hibernate.id.insert.InsertGeneratedIdentifierDelegate;
 import org.hibernate.id.uuid.UuidGenerator;
-import org.hibernate.mapping.SimpleValue;
 import org.hibernate.persister.entity.EntityPersister;
 
 import java.lang.reflect.Member;
@@ -30,6 +29,7 @@ import java.util.EnumSet;
 import java.util.Map;
 import java.util.Properties;
 
+import static org.hibernate.boot.model.internal.GeneratorParameters.collectParameters;
 import static org.hibernate.id.IdentifierGenerator.GENERATOR_NAME;
 import static org.hibernate.id.OptimizableGenerator.INCREMENT_PARAM;
 
@@ -169,11 +169,12 @@ public class NativeGenerator
 	private static void applyCommonConfiguration(
 			Map<String, Object> mapRef,
 			GeneratorCreationContext context) {
-		GeneratorParameters.collectParameters(
-				(SimpleValue) context.getProperty().getValue(),
+		collectParameters(
+				context.getProperty().getValue(),
 				context.getDatabase().getDialect(),
 				context.getRootClass(),
-				mapRef::put
+				mapRef::put,
+				context.getServiceRegistry().requireService( ConfigurationService.class )
 		);
 		mapRef.put( INCREMENT_PARAM, 1 );
 	}

--- a/hibernate-core/src/main/java/org/hibernate/id/NativeGenerator.java
+++ b/hibernate-core/src/main/java/org/hibernate/id/NativeGenerator.java
@@ -42,7 +42,8 @@ import static org.hibernate.id.OptimizableGenerator.INCREMENT_PARAM;
  * @author Steve Ebersole
  */
 public class NativeGenerator
-		implements OnExecutionGenerator, BeforeExecutionGenerator, Configurable, ExportableProducer, AnnotationBasedGenerator<org.hibernate.annotations.NativeGenerator> {
+		implements OnExecutionGenerator, BeforeExecutionGenerator, Configurable, ExportableProducer,
+						AnnotationBasedGenerator<org.hibernate.annotations.NativeGenerator> {
 	private GenerationType generationType;
 	private org.hibernate.annotations.NativeGenerator annotation;
 	private Generator dialectNativeGenerator;

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/tuple/internal/AnonymousTupleType.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/tuple/internal/AnonymousTupleType.java
@@ -231,8 +231,7 @@ public class AnonymousTupleType<T> implements TupleType<T>, DomainType<T>, Retur
 
 	@Override
 	public JavaType<T> getExpressibleJavaType() {
-		//noinspection unchecked
-		return (JavaType<T>) javaTypeDescriptor;
+		return javaTypeDescriptor;
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/resource/beans/container/spi/BeanContainer.java
+++ b/hibernate-core/src/main/java/org/hibernate/resource/beans/container/spi/BeanContainer.java
@@ -8,9 +8,14 @@ import org.hibernate.resource.beans.spi.BeanInstanceProducer;
 import org.hibernate.service.spi.Stoppable;
 
 /**
- * Represents a backend "bean container" - CDI, Spring, etc
+ * Abstracts any kind of container for managed beans, for example,
+ * the CDI {@link jakarta.enterprise.inject.spi.BeanManager}. A
+ * custom bean container may be integrated with Hibernate by
+ * implementing this interface and specifying the implementation
+ * using {@value org.hibernate.cfg.AvailableSettings#BEAN_CONTAINER}.
  *
  * @see org.hibernate.cfg.AvailableSettings#BEAN_CONTAINER
+ * @see org.hibernate.resource.beans.container.internal.CdiBasedBeanContainer
  *
  * @author Steve Ebersole
  */

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/idgen/userdefined/ExportableValueGeneratorTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/idgen/userdefined/ExportableValueGeneratorTest.java
@@ -1,0 +1,103 @@
+/*
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.idgen.userdefined;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityManagerFactory;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import org.hibernate.annotations.ValueGenerationType;
+import org.hibernate.boot.model.naming.Identifier;
+import org.hibernate.boot.model.relational.Database;
+import org.hibernate.boot.model.relational.ExportableProducer;
+import org.hibernate.boot.model.relational.Sequence;
+import org.hibernate.dialect.Dialect;
+import org.hibernate.dialect.MySQLDialect;
+import org.hibernate.dialect.SybaseASEDialect;
+import org.hibernate.generator.EventType;
+import org.hibernate.generator.EventTypeSets;
+import org.hibernate.generator.OnExecutionGenerator;
+import org.hibernate.testing.orm.junit.EntityManagerFactoryScope;
+import org.hibernate.testing.orm.junit.Jpa;
+import org.hibernate.testing.orm.junit.SkipForDialect;
+import org.junit.jupiter.api.Test;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.util.EnumSet;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@Jpa(annotatedClasses = ExportableValueGeneratorTest.WithExportableGenerator.class)
+@SkipForDialect( dialectClass = SybaseASEDialect.class )
+@SkipForDialect( dialectClass = MySQLDialect.class)
+public class ExportableValueGeneratorTest {
+
+	@Test void test(EntityManagerFactoryScope scope) {
+		final EntityManagerFactory entityManagerFactory = scope.getEntityManagerFactory();
+		final WithExportableGenerator first = new WithExportableGenerator();
+		entityManagerFactory.runInTransaction( entityManager -> entityManager.persist( first ) );
+		int firstSequenceVal = entityManagerFactory.callInTransaction( entityManager ->
+				entityManager.find( WithExportableGenerator.class, first.uuid ).sequenceVal );
+		assertEquals( 1, firstSequenceVal );
+		final WithExportableGenerator second = new WithExportableGenerator();
+		entityManagerFactory.runInTransaction( entityManager -> entityManager.persist( second ) );
+		int secondSequenceVal = entityManagerFactory.callInTransaction( entityManager ->
+				entityManager.find( WithExportableGenerator.class, second.uuid ).sequenceVal );
+		assertEquals( 2, secondSequenceVal );
+	}
+
+	@ValueGenerationType(generatedBy = OnExecutionSequenceGenerator.class)
+	@Retention(RetentionPolicy.RUNTIME)
+	@interface OnExecutionSequence {
+		String sequenceName();
+	}
+
+	public static class OnExecutionSequenceGenerator implements OnExecutionGenerator, ExportableProducer {
+
+		final String sequenceName;
+
+		public OnExecutionSequenceGenerator(OnExecutionSequence annotation) {
+			sequenceName = annotation.sequenceName();
+		}
+
+		@Override
+		public void registerExportables(Database database) {
+			Identifier testseq = Identifier.toIdentifier( sequenceName );
+			database.getDefaultNamespace()
+					.registerSequence( testseq,
+							new Sequence( "OnExecutionSequenceGenerator", null, null, testseq ) );
+		}
+
+		@Override
+		public boolean referenceColumnsInSql(Dialect dialect) {
+			return true;
+		}
+
+		@Override
+		public boolean writePropertyValue() {
+			return false;
+		}
+
+		@Override
+		public String[] getReferencedColumnValues(Dialect dialect) {
+			return new String[] { dialect.getSequenceSupport().getSelectSequenceNextValString( sequenceName ) };
+		}
+
+		@Override
+		public EnumSet<EventType> getEventTypes() {
+			return EventTypeSets.INSERT_ONLY;
+		}
+	}
+
+	@Entity(name ="WithExportableGenerator")
+	static class WithExportableGenerator {
+		@Id @GeneratedValue
+		UUID uuid;
+		@OnExecutionSequence(sequenceName = "exported_sequence")
+		int sequenceVal;
+	}
+}


### PR DESCRIPTION
This PR allows regular "value" (i.e. non-`@Id`) generators to implement `Configurable` and `ExportableProducer`, finally putting them on equal footing with id generators.

See https://hibernate.atlassian.net/browse/HHH-18983.

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
