### PR TITLE
HHH-18966 update user guide mysql spatial function support

### DIFF
--- a/documentation/src/main/asciidoc/userguide/chapters/query/spatial/Spatial.adoc
+++ b/documentation/src/main/asciidoc/userguide/chapters/query/spatial/Spatial.adoc
@@ -94,13 +94,13 @@ functions largely correspond to those specified in the https://portal.opengeospa
 |`boolean st_overlaps(Geometry, Geometry)` | SFS §2.1.1.2 | {yes} | {yes} | {yes} | {yes} | {yes} | {yes} | {yes}
 |`boolean st_relate(Geometry, Geometry, String)` | SFS §2.1.1.2 | {yes} | {yes} | {no} | {yes} | {yes} | {yes} | {yes}
 |Functions that support Spatial Analysis | | | | | | | |
-|`double st_distance(Geometry, Geometry)` | SFS §2.1.1.3 | {yes} | {yes} | {no} | {yes} | {yes} | {yes} | {yes}
-|`Geometry st_buffer(Geometry, double)` | SFS §2.1.1.3 | {yes} | {yes} | {no} | {yes} | {yes} | {yes} | {yes}
-|`Geometry st_convexhull(Geometry)` | SFS §2.1.1.3 | {yes} | {yes} | {no} | {yes} | {yes} | {yes}^(1)^ | {no}
-|`Geometry st_intersection(Geometry, Geometry)` | SFS §2.1.1.3 | {yes} | {yes} | {no} | {yes} | {yes} | {yes}^(1)^ | {yes}
+|`double st_distance(Geometry, Geometry)` | SFS §2.1.1.3 | {yes} | {yes} | {yes} | {yes} | {yes} | {yes} | {yes}
+|`Geometry st_buffer(Geometry, double)` | SFS §2.1.1.3 | {yes} | {yes} | {yes} | {yes} | {yes} | {yes} | {yes}
+|`Geometry st_convexhull(Geometry)` | SFS §2.1.1.3 | {yes} | {yes} | {yes} | {yes} | {yes} | {yes}^(1)^ | {no}
+|`Geometry st_intersection(Geometry, Geometry)` | SFS §2.1.1.3 | {yes} | {yes} | {yes} | {yes} | {yes} | {yes}^(1)^ | {yes}
 |`Geometry st_geomunion(Geometry, Geometry)` | SFS §2.1.1.3 (renamed from union) | {yes} | {yes} | {no} | {yes} | {yes} | {yes}^(1)^ | {yes}
-|`Geometry st_difference(Geometry, Geometry)` | SFS §2.1.1.3 | {yes} | {yes} | {no} | {yes} | {yes} | {yes}^(1)^ | {yes}
-|`Geometry st_symdifference(Geometry, Geometry)` | SFS §2.1.1.3 | {yes} | {yes} | {no} | {yes} | {yes} | {yes}^(1)^ | {yes}
+|`Geometry st_difference(Geometry, Geometry)` | SFS §2.1.1.3 | {yes} | {yes} | {yes} | {yes} | {yes} | {yes}^(1)^ | {yes}
+|`Geometry st_symdifference(Geometry, Geometry)` | SFS §2.1.1.3 | {yes} | {yes} | {yes} | {yes} | {yes} | {yes}^(1)^ | {yes}
 |Common non-SFS functions | | | | | | | |
 |`boolean st_dwithin(Geometry, Geometry, double)` | Returns true if the geometries are within the specified distance of one another | {yes} | {yes} | {no} | {no} | {yes} | {yes}  | {yes}
 |`Geometry st_transform(Geometry, int)` | Returns a new geometry with its coordinates transformed to the SRID referenced by the integer parameter | {yes} | {yes} | {no} | {no} | {no} | {no}  | {yes}
@@ -138,14 +138,7 @@ In addition to the common spatial functions, the following functions are support
 [[spatial-configuration-dialect-mysql]]
 MySQL::
 
-MySQL versions before 5.6.1 had only limited support for spatial operators.
-Most operators only took account of the minimum bounding rectangles (MBR) of the geometries, and not the geometries themselves.
-+
-This changed in version 5.6.1, when MySQL introduced `ST_*` spatial operators.
-The dialect `MySQLSpatial56Dialect` uses these newer, more precise operators.
-+
-For more information, see this page in the MySQL reference guide (esp. the section https://dev.mysql.com/doc/refman/5.7/en/spatial-relation-functions.html[Functions That Test Spatial Relations Between Geometry Objects])
-
+For more information, see this page in the MySQL reference guide (esp. the section https://dev.mysql.com/doc/refman/8.4/en/spatial-relation-functions.html[Functions That Test Spatial Relations Between Geometry Objects])
 
 [[spatial-configuration-dialect-oracle]]
 Oracle 19c/21c/23ai::


### PR DESCRIPTION
<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

This PR updates the documentation to reflect the availability of several MySQL Spatial Functions based on both the official documentation ([MySQL Spatial Relation Functions](https://dev.mysql.com/doc/refman/5.7/en/spatial-relation-functions.html) and [MySQL Spatial Operator Functions](https://dev.mysql.com/doc/refman/8.4/en/spatial-operator-functions.html)) and personal testing. Specifically, the following functions are confirmed to be available:

ST_Distance
ST_Buffer
ST_ConvexHull
ST_Intersection
ST_Difference
ST_SymDifference

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-18966
<!-- Hibernate GitHub Bot issue links end -->