### PR TITLE
HHH-18988 Embeddable inheritance + default_schema results in NPE at startup

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/EmbeddableMappingTypeImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/EmbeddableMappingTypeImpl.java
@@ -748,7 +748,7 @@ public class EmbeddableMappingTypeImpl extends AbstractEmbeddableMapping impleme
 		return new ExplicitColumnDiscriminatorMappingImpl(
 				this,
 				name,
-				bootDescriptor.getTable().getName(),
+				bootDescriptor.getTable().getQualifiedName( creationContext.getSqlStringGenerationContext() ),
 				discriminatorColumnExpression,
 				isFormula,
 				!isFormula,

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/columndiscriminator/Author.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/columndiscriminator/Author.java
@@ -1,0 +1,43 @@
+/*
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.columndiscriminator;
+
+import java.util.*;
+
+public class Author {
+	private Long id;
+	private String name;
+	private String email;
+	private List<Book> books = new ArrayList<>();
+
+	public Author(String name, String email) {
+		this.name = name;
+		this.email = email;
+	}
+
+	protected Author() {
+		// default
+	}
+
+	public Long id() {
+		return id;
+	}
+
+	public String name() {
+		return name;
+	}
+
+	public String email() {
+		return email;
+	}
+
+	public List<Book> books() {
+		return books;
+	}
+
+	public void addBook(Book book) {
+		books.add(book);
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/columndiscriminator/Book.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/columndiscriminator/Book.java
@@ -1,0 +1,32 @@
+/*
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.columndiscriminator;
+
+public class Book {
+	private Long id;
+	private String title;
+	private BookDetails details;
+
+	public Book(String title, BookDetails details) {
+		this.title = title;
+		this.details = details;
+	}
+
+	protected Book() {
+		// default
+	}
+
+	public Long id() {
+		return id;
+	}
+
+	public String title() {
+		return title;
+	}
+
+	public BookDetails details() {
+		return details;
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/columndiscriminator/BookDetails.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/columndiscriminator/BookDetails.java
@@ -1,0 +1,21 @@
+/*
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.columndiscriminator;
+
+public abstract class BookDetails {
+	private String information;
+
+	protected BookDetails(String information) {
+		this.information = information;
+	}
+
+	protected BookDetails() {
+		// default
+	}
+
+	public String information() {
+		return information;
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/columndiscriminator/BoringBookDetails.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/columndiscriminator/BoringBookDetails.java
@@ -1,0 +1,22 @@
+/*
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.columndiscriminator;
+
+public class BoringBookDetails extends BookDetails {
+	private String boringInformation;
+
+	public BoringBookDetails(String information, String boringInformation) {
+		super(information);
+		this.boringInformation = boringInformation;
+	}
+
+	public BoringBookDetails() {
+		// default
+	}
+
+	public String boringInformation() {
+		return boringInformation;
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/columndiscriminator/ColumnDiscrimnatorWithSchemaTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/columndiscriminator/ColumnDiscrimnatorWithSchemaTest.java
@@ -1,0 +1,35 @@
+/*
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.columndiscriminator;
+
+import org.hibernate.cfg.AvailableSettings;
+import org.hibernate.cfg.SchemaToolingSettings;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.ServiceRegistry;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.hibernate.testing.orm.junit.Setting;
+import org.junit.jupiter.api.Test;
+
+@DomainModel(xmlMappings = "org/hibernate/orm/test/columndiscriminator/orm.xml")
+@ServiceRegistry(settings = {
+		@Setting(name = AvailableSettings.DEFAULT_SCHEMA, value = "GREET"),
+		@Setting(name = SchemaToolingSettings.JAKARTA_HBM2DDL_CREATE_SCHEMAS, value = "true")
+})
+@SessionFactory
+class ColumnDiscrimnatorWithSchemaTest {
+
+	@Test
+	void testIt(SessionFactoryScope scope) {
+		scope.inTransaction( entityManager -> {
+			var book = new Book( "The Art of Computer Programming",
+					new SpecialBookDetails( "Hardcover", "Computer Science" ) );
+
+			var author = new Author( "Donald Knuth", "dn@cs.com" );
+			author.addBook( book );
+			entityManager.persist( author );
+		} );
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/columndiscriminator/ColumnDiscrimnatorWithSchemaTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/columndiscriminator/ColumnDiscrimnatorWithSchemaTest.java
@@ -6,7 +6,9 @@ package org.hibernate.orm.test.columndiscriminator;
 
 import org.hibernate.cfg.AvailableSettings;
 import org.hibernate.cfg.SchemaToolingSettings;
+import org.hibernate.testing.orm.junit.DialectFeatureChecks.SupportSchemaCreation;
 import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.RequiresDialectFeature;
 import org.hibernate.testing.orm.junit.ServiceRegistry;
 import org.hibernate.testing.orm.junit.SessionFactory;
 import org.hibernate.testing.orm.junit.SessionFactoryScope;
@@ -19,7 +21,15 @@ import org.junit.jupiter.api.Test;
 		@Setting(name = SchemaToolingSettings.JAKARTA_HBM2DDL_CREATE_SCHEMAS, value = "true")
 })
 @SessionFactory
+@RequiresDialectFeature(feature = SupportSchemaCreation.class)
 class ColumnDiscrimnatorWithSchemaTest {
+
+	private ColumnDiscrimnatorWithSchemaTest() {
+	}
+
+	static ColumnDiscrimnatorWithSchemaTest createColumnDiscrimnatorWithSchemaTest() {
+		return new ColumnDiscrimnatorWithSchemaTest();
+	}
 
 	@Test
 	void testIt(SessionFactoryScope scope) {

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/columndiscriminator/SpecialBookDetails.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/columndiscriminator/SpecialBookDetails.java
@@ -1,0 +1,22 @@
+/*
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.columndiscriminator;
+
+public class SpecialBookDetails extends BookDetails {
+	private String specialInformation;
+
+	public SpecialBookDetails(String information, String specialInformation) {
+		super(information);
+		this.specialInformation = specialInformation;
+	}
+
+	protected SpecialBookDetails() {
+		// default
+	}
+
+	public String specialInformation() {
+		return specialInformation;
+	}
+}

--- a/hibernate-core/src/test/resources/org/hibernate/orm/test/columndiscriminator/orm.xml
+++ b/hibernate-core/src/test/resources/org/hibernate/orm/test/columndiscriminator/orm.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<entity-mappings xmlns="https://jakarta.ee/xml/ns/persistence/orm" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                 xsi:schemaLocation="https://jakarta.ee/xml/ns/persistence/orm https://jakarta.ee/xml/ns/persistence/orm/orm_3_1.xsd"
+                 version="3.1">
+    <entity class="org.hibernate.orm.test.columndiscriminator.Book" access="FIELD">
+        <attributes>
+            <id name="id">
+                <generated-value strategy="AUTO"/>
+            </id>
+
+            <embedded name="details"/>
+        </attributes>
+    </entity>
+
+    <entity class="org.hibernate.orm.test.columndiscriminator.Author" access="FIELD">
+        <attributes>
+            <id name="id">
+                <generated-value strategy="AUTO"/>
+            </id>
+
+            <one-to-many name="books" orphan-removal="true">
+                <cascade>
+                    <cascade-all/>
+                </cascade>
+            </one-to-many>
+        </attributes>
+    </entity>
+
+    <embeddable class="org.hibernate.orm.test.columndiscriminator.BookDetails" access="FIELD"/>
+    <embeddable class="org.hibernate.orm.test.columndiscriminator.SpecialBookDetails" access="FIELD"/>
+    <embeddable class="org.hibernate.orm.test.columndiscriminator.BoringBookDetails" access="FIELD"/>
+</entity-mappings>


### PR DESCRIPTION
Jira issue [HHH-18988](https://hibernate.atlassian.net/browse/HHH-18988)

Parameter `tableExpression` in `org.hibernate.metamodel.mapping.internal.ExplicitColumnDiscriminatorMappingImpl` constructor should be qualified. At the moment only table name was used, ignoring schema (and/or catalog) name.

Change has been tested in `6.6` branch, so it can be safely backported.

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------


[HHH-18988]: https://hibernate.atlassian.net/browse/HHH-18988?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ