### PR TITLE
[6.6] Produce develocity reports on all Jenkins CI runs for PRs

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -229,7 +229,7 @@ void ciBuild(buildEnv, String args) {
 			}
 		}
 	}
-	else if ( buildEnv.node && buildEnv.node != 's390x' ) { // We couldn't get the code below to work on s390x for some reason.
+	else if ( buildEnv.node != 's390x' ) { // We couldn't get the code below to work on s390x for some reason.
 		// Pull request: we can't pass credentials to the build, since we'd be exposing secrets to e.g. tests.
 		// We do the build first, then publish the build scan separately.
 		tryFinally({


### PR DESCRIPTION
We were incorrectly skipping these reports for runs that didn't have a specific CI node set (like JDK version runs for PRs to the 6.6 branch).

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
