### PR TITLE
HHH-18961 JtaIsolationDelegate, obtaining connection : NPE when SQLExceptionConversionDelegate#convert returns null

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/resource/transaction/backend/jta/internal/JtaIsolationDelegate.java
+++ b/hibernate-core/src/main/java/org/hibernate/resource/transaction/backend/jta/internal/JtaIsolationDelegate.java
@@ -203,7 +203,11 @@ public class JtaIsolationDelegate implements IsolationDelegate {
 			}
 		}
 		catch (SQLException e) {
-			throw sqlExceptionConverter().apply( e, "unable to obtain isolated JDBC connection" );
+			final JDBCException jdbcException = sqlExceptionConverter().apply( e, "unable to obtain isolated JDBC connection" );
+			if ( jdbcException == null ) {
+				throw new HibernateException( "Unable to obtain isolated JDBC connection", e );
+			}
+			throw jdbcException;
 		}
 	}
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/txn/JtaObtainConnectionExceptionTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/txn/JtaObtainConnectionExceptionTest.java
@@ -1,0 +1,113 @@
+/*
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.jpa.txn;
+
+import jakarta.transaction.HeuristicMixedException;
+import jakarta.transaction.HeuristicRollbackException;
+import jakarta.transaction.InvalidTransactionException;
+import jakarta.transaction.NotSupportedException;
+import jakarta.transaction.RollbackException;
+import jakarta.transaction.SystemException;
+import jakarta.transaction.Transaction;
+import jakarta.transaction.TransactionManager;
+import org.hibernate.HibernateException;
+import org.hibernate.engine.jdbc.connections.spi.JdbcConnectionAccess;
+import org.hibernate.jdbc.AbstractReturningWork;
+import org.hibernate.resource.transaction.backend.jta.internal.JtaIsolationDelegate;
+import org.hibernate.testing.orm.junit.JiraKey;
+import org.junit.jupiter.api.Test;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+
+import static org.junit.jupiter.api.Assertions.assertThrowsExactly;
+
+@JiraKey("HHH-18961")
+public class JtaObtainConnectionExceptionTest {
+
+	@Test
+	public void testIt() {
+		final JtaIsolationDelegate isolationDelegate = new JtaIsolationDelegate(
+				new ObtainConnectionSqlExceptionConnectionAccess(),
+				null,
+				new TransactionManagerImpl() );
+
+		assertThrowsExactly( HibernateException.class, () ->
+				isolationDelegate.delegateWork(
+						new AbstractReturningWork<>() {
+							@Override
+							public Object execute(Connection connection) {
+								return null;
+							}
+						},
+						false
+				)
+		);
+	}
+
+	public static class ObtainConnectionSqlExceptionConnectionAccess implements JdbcConnectionAccess {
+		@Override
+		public Connection obtainConnection() throws SQLException {
+			throw new SQLException( "No connection" );
+		}
+
+		@Override
+		public void releaseConnection(Connection connection) throws SQLException {
+
+		}
+
+		@Override
+		public boolean supportsAggressiveRelease() {
+			return false;
+		}
+	}
+
+	public static class TransactionManagerImpl implements TransactionManager {
+		@Override
+		public void begin() throws NotSupportedException, SystemException {
+
+		}
+
+		@Override
+		public void commit()
+				throws RollbackException, HeuristicMixedException, HeuristicRollbackException, SecurityException, IllegalStateException, SystemException {
+		}
+
+		@Override
+		public int getStatus() throws SystemException {
+			return 0;
+		}
+
+		@Override
+		public Transaction getTransaction() throws SystemException {
+			return null;
+		}
+
+		@Override
+		public void resume(Transaction transaction)
+				throws InvalidTransactionException, IllegalStateException, SystemException {
+		}
+
+		@Override
+		public void rollback() throws IllegalStateException, SecurityException, SystemException {
+
+		}
+
+		@Override
+		public void setRollbackOnly() throws IllegalStateException, SystemException {
+
+		}
+
+		@Override
+		public void setTransactionTimeout(int i) throws SystemException {
+
+		}
+
+		@Override
+		public Transaction suspend() throws SystemException {
+			return null;
+		}
+	}
+}


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-18961

https://github.com/hibernate/hibernate-orm/pull/9464 backport for 6.6
<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
