### PR TITLE
 Graphpocalypse: deprecated funkily-named methods of Graph

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/graph/AttributeNode.java
+++ b/hibernate-core/src/main/java/org/hibernate/graph/AttributeNode.java
@@ -6,7 +6,8 @@ package org.hibernate.graph;
 
 
 import jakarta.persistence.Subgraph;
-import org.hibernate.metamodel.model.domain.ManagedDomainType;
+import jakarta.persistence.metamodel.ManagedType;
+import org.hibernate.Incubating;
 import org.hibernate.metamodel.model.domain.PersistentAttribute;
 
 import java.util.Map;
@@ -51,6 +52,8 @@ public interface AttributeNode<J> extends GraphNode<J>, jakarta.persistence.Attr
 
 	/**
 	 * All value subgraphs rooted at this node.
+	 * <p>
+	 * Includes treated subgraphs.
 	 *
 	 * @see jakarta.persistence.AttributeNode#getSubgraphs
 	 */
@@ -58,6 +61,8 @@ public interface AttributeNode<J> extends GraphNode<J>, jakarta.persistence.Attr
 
 	/**
 	 * All key subgraphs rooted at this node.
+	 * <p>
+	 * Includes treated subgraphs.
 	 *
 	 * @see jakarta.persistence.AttributeNode#getKeySubgraphs
 	 */
@@ -89,6 +94,11 @@ public interface AttributeNode<J> extends GraphNode<J>, jakarta.persistence.Attr
 	 * Create and return a new value {@link SubGraph} rooted at this node,
 	 * with the given type, which may be a subtype of the value type,
 	 * or return an existing such {@link SubGraph} if there is one.
+	 * <p>
+	 * If the given type is a proper subtype of the value type, the result
+	 * is a treated subgraph.
+	 *
+	 * @param subtype The type or treated type of the value type
 	 */
 	<S> SubGraph<S> makeSubGraph(Class<S> subtype);
 
@@ -96,6 +106,11 @@ public interface AttributeNode<J> extends GraphNode<J>, jakarta.persistence.Attr
 	 * Create and return a new value {@link SubGraph} rooted at this node,
 	 * with the given type, which may be a subtype of the key type,
 	 * or return an existing such {@link SubGraph} if there is one.
+	 * <p>
+	 * If the given type is a proper subtype of the key type, the result
+	 * is a treated subgraph.
+	 *
+	 * @param subtype The type or treated type of the key type
 	 */
 	<S> SubGraph<S> makeKeySubGraph(Class<S> subtype);
 
@@ -103,13 +118,25 @@ public interface AttributeNode<J> extends GraphNode<J>, jakarta.persistence.Attr
 	 * Create and return a new value {@link SubGraph} rooted at this node,
 	 * with the given type, which may be a subtype of the value type,
 	 * or return an existing such {@link SubGraph} if there is one.
+	 * <p>
+	 * If the given type is a proper subtype of the value type, the result
+	 * is a treated subgraph.
+	 *
+	 * @param subtype The type or treated type of the value type
 	 */
-	<S> SubGraph<S> makeSubGraph(ManagedDomainType<S> subtype);
+	@Incubating
+	<S> SubGraph<S> makeSubGraph(ManagedType<S> subtype);
 
 	/**
 	 * Create and return a new value {@link SubGraph} rooted at this node,
 	 * with the given type, which may be a subtype of the key type,
 	 * or return an existing such {@link SubGraph} if there is one.
+	 * <p>
+	 * If the given type is a proper subtype of the key type, the result
+	 * is a treated subgraph.
+	 *
+	 * @param subtype The type or treated type of the key type
 	 */
-	<S> SubGraph<S> makeKeySubGraph(ManagedDomainType<S> subtype);
+	@Incubating
+	<S> SubGraph<S> makeKeySubGraph(ManagedType<S> subtype);
 }

--- a/hibernate-core/src/main/java/org/hibernate/graph/EntityGraphs.java
+++ b/hibernate-core/src/main/java/org/hibernate/graph/EntityGraphs.java
@@ -141,7 +141,7 @@ public final class EntityGraphs {
 	 * @since 7.0
 	 */
 	public <S> Subgraph<S> addTreatedSubgraph(Graph<? super S> graph, Class<S> subtype) {
-		return ((org.hibernate.graph.Graph<? super S>) graph).addTreatedSubGraph( subtype );
+		return ((org.hibernate.graph.Graph<? super S>) graph).addTreatedSubgraph( subtype );
 	}
 
 	/**

--- a/hibernate-core/src/main/java/org/hibernate/graph/RootGraph.java
+++ b/hibernate-core/src/main/java/org/hibernate/graph/RootGraph.java
@@ -33,9 +33,4 @@ public interface RootGraph<J> extends Graph<J>, EntityGraph<J> {
 	default <T> SubGraph<? extends T> addSubclassSubgraph(Class<? extends T> type) {
 		return (SubGraph<? extends T>) addTreatedSubgraph( (Class<? extends J>) type );
 	}
-
-	@Override
-	default <S extends J> SubGraph<S> addTreatedSubgraph(Class<S> type) {
-		return addTreatedSubGraph( type );
-	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/graph/internal/AbstractGraph.java
+++ b/hibernate-core/src/main/java/org/hibernate/graph/internal/AbstractGraph.java
@@ -9,6 +9,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import jakarta.persistence.metamodel.ManagedType;
 import jakarta.persistence.metamodel.MapAttribute;
 import jakarta.persistence.metamodel.PluralAttribute;
 import jakarta.persistence.metamodel.Type;
@@ -306,7 +307,7 @@ public abstract class AbstractGraph<J> extends AbstractGraphNode<J> implements G
 	}
 
 	@Override
-	public <AJ> SubGraphImplementor<AJ> addSubGraph(PersistentAttribute<? super J, ? super AJ> attribute, ManagedDomainType<AJ> subtype) {
+	public <AJ> SubGraphImplementor<AJ> addTreatedSubgraph(PersistentAttribute<? super J, ? super AJ> attribute, ManagedType<AJ> subtype) {
 		return findOrCreateAttributeNode( attribute ).makeSubGraph( subtype );
 	}
 
@@ -316,7 +317,7 @@ public abstract class AbstractGraph<J> extends AbstractGraphNode<J> implements G
 	}
 
 	@Override
-	public <AJ> SubGraphImplementor<AJ> addElementSubGraph(PluralPersistentAttribute<? super J, ?, ? super AJ> attribute, ManagedDomainType<AJ> type) {
+	public <AJ> SubGraphImplementor<AJ> addTreatedElementSubgraph(PluralPersistentAttribute<? super J, ?, ? super AJ> attribute, ManagedType<AJ> type) {
 		return findOrCreateAttributeNode( attribute ).makeSubGraph( type );
 	}
 
@@ -326,7 +327,7 @@ public abstract class AbstractGraph<J> extends AbstractGraphNode<J> implements G
 	}
 
 	@Override
-	public <AJ> SubGraphImplementor<AJ> addKeySubGraph(MapPersistentAttribute<? super J, ? super AJ, ?> attribute, ManagedDomainType<AJ> subtype) {
+	public <AJ> SubGraphImplementor<AJ> addTreatedMapKeySubgraph(MapPersistentAttribute<? super J, ? super AJ, ?> attribute, ManagedType<AJ> subtype) {
 		return findOrCreateAttributeNode( attribute ).makeKeySubGraph( subtype );
 	}
 
@@ -350,7 +351,7 @@ public abstract class AbstractGraph<J> extends AbstractGraphNode<J> implements G
 	public <K> SubGraphImplementor<K> addTreatedMapKeySubgraph(
 			MapAttribute<? super J, ? super K, ?> attribute,
 			Class<K> type) {
-		return addMapKeySubgraph( attribute ).addTreatedSubGraph( type );
+		return addMapKeySubgraph( attribute ).addTreatedSubgraph( type );
 	}
 
 	@Override @SuppressWarnings("unchecked") // The JPA API is unsafe by nature
@@ -373,11 +374,16 @@ public abstract class AbstractGraph<J> extends AbstractGraphNode<J> implements G
 	public <E> SubGraphImplementor<E> addTreatedElementSubgraph(
 			PluralAttribute<? super J, ?, ? super E> attribute,
 			Class<E> type) {
-		return addElementSubgraph( attribute ).addTreatedSubGraph( type );
+		return addElementSubgraph( attribute ).addTreatedSubgraph( type );
 	}
 
 	@Override
-	public <S extends J> SubGraphImplementor<S> addTreatedSubGraph(ManagedDomainType<S> type) {
+	public <Y> SubGraphImplementor<Y> addTreatedSubgraph(Attribute<? super J, ? super Y> attribute, Class<Y> type) {
+		return addSubgraph( attribute ).addTreatedSubgraph( type );
+	}
+
+	@Override
+	public <S extends J> SubGraphImplementor<S> addTreatedSubgraph(ManagedType<S> type) {
 		verifyMutability();
 		if ( getGraphedType().equals( type ) ) {
 			//noinspection unchecked
@@ -387,7 +393,7 @@ public abstract class AbstractGraph<J> extends AbstractGraphNode<J> implements G
 			final Class<S> javaType = type.getJavaType();
 			final SubGraphImplementor<S> castSubgraph = getTreatedSubgraphForPut( javaType );
 			if ( castSubgraph == null ) {
-				final SubGraphImpl<S> subgraph = new SubGraphImpl<>( type, true );
+				final SubGraphImpl<S> subgraph = new SubGraphImpl<>( (ManagedDomainType<S>) type, true );
 				treatedSubgraphs.put( javaType, subgraph );
 				return subgraph;
 			}
@@ -398,8 +404,8 @@ public abstract class AbstractGraph<J> extends AbstractGraphNode<J> implements G
 	}
 
 	@Override
-	public <S extends J> SubGraphImplementor<S> addTreatedSubGraph(Class<S> type) {
-		return addTreatedSubGraph( getGraphedType().getMetamodel().managedType( type ) );
+	public <S extends J> SubGraphImplementor<S> addTreatedSubgraph(Class<S> type) {
+		return addTreatedSubgraph( getGraphedType().getMetamodel().managedType( type ) );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/graph/internal/AttributeNodeImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/graph/internal/AttributeNodeImpl.java
@@ -4,6 +4,7 @@
  */
 package org.hibernate.graph.internal;
 
+import jakarta.persistence.metamodel.ManagedType;
 import org.hibernate.graph.CannotContainSubGraphException;
 import org.hibernate.graph.spi.AttributeNodeImplementor;
 import org.hibernate.graph.spi.SubGraphImplementor;
@@ -93,21 +94,21 @@ public class AttributeNodeImpl<J,V,K>
 		}
 		@SuppressWarnings("unchecked")
 		final Class<? extends V> castSuptype = (Class<? extends V>) subtype;
-		final SubGraphImplementor<? extends V> result = makeSubGraph().addTreatedSubGraph( castSuptype );
+		final SubGraphImplementor<? extends V> result = makeSubGraph().addTreatedSubgraph( castSuptype );
 		//noinspection unchecked
 		return (SubGraphImplementor<S>) result;
 	}
 
 	@Override
-	public <S> SubGraphImplementor<S> makeSubGraph(ManagedDomainType<S> subtype) {
+	public <S> SubGraphImplementor<S> makeSubGraph(ManagedType<S> subtype) {
 		final ManagedDomainType<V> managedType = asManagedType( valueGraphType );
-		final Class<S> javaType = subtype.getBindableJavaType();
+		final Class<S> javaType = subtype.getJavaType();
 		if ( !managedType.getBindableJavaType().isAssignableFrom( javaType ) ) {
 			throw new IllegalArgumentException( "Not a subtype: " + javaType.getName() );
 		}
 		@SuppressWarnings("unchecked")
 		final ManagedDomainType<? extends V> castType = (ManagedDomainType<? extends V>) subtype;
-		final SubGraphImplementor<? extends V> result = makeSubGraph().addTreatedSubGraph( castType );
+		final SubGraphImplementor<? extends V> result = makeSubGraph().addTreatedSubgraph( castType );
 		//noinspection unchecked
 		return (SubGraphImplementor<S>) result;
 	}
@@ -131,22 +132,22 @@ public class AttributeNodeImpl<J,V,K>
 		}
 		@SuppressWarnings("unchecked")
 		final Class<? extends K> castType = (Class<? extends K>) subtype;
-		final SubGraphImplementor<? extends K> result = makeKeySubGraph().addTreatedSubGraph( castType );
+		final SubGraphImplementor<? extends K> result = makeKeySubGraph().addTreatedSubgraph( castType );
 		//noinspection unchecked
 		return (SubGraphImplementor<S>) result;
 	}
 
 	@Override
-	public <S> SubGraphImplementor<S> makeKeySubGraph(ManagedDomainType<S> subtype) {
+	public <S> SubGraphImplementor<S> makeKeySubGraph(ManagedType<S> subtype) {
 		checkMap();
 		final ManagedDomainType<K> type = asManagedType( keyGraphType );
-		final Class<S> javaType = subtype.getBindableJavaType();
+		final Class<S> javaType = subtype.getJavaType();
 		if ( !type.getBindableJavaType().isAssignableFrom( javaType ) ) {
 			throw new IllegalArgumentException( "Not a key subtype: " + javaType.getName() );
 		}
 		@SuppressWarnings("unchecked")
 		final ManagedDomainType<? extends K> castType = (ManagedDomainType<? extends K>) subtype;
-		final SubGraphImplementor<? extends K> result = makeKeySubGraph().addTreatedSubGraph( castType );
+		final SubGraphImplementor<? extends K> result = makeKeySubGraph().addTreatedSubgraph( castType );
 		//noinspection unchecked
 		return (SubGraphImplementor<S>) result;
 	}

--- a/hibernate-core/src/main/java/org/hibernate/graph/spi/AttributeNodeImplementor.java
+++ b/hibernate-core/src/main/java/org/hibernate/graph/spi/AttributeNodeImplementor.java
@@ -4,8 +4,8 @@
  */
 package org.hibernate.graph.spi;
 
+import jakarta.persistence.metamodel.ManagedType;
 import org.hibernate.graph.AttributeNode;
-import org.hibernate.metamodel.model.domain.ManagedDomainType;
 
 import java.util.Map;
 
@@ -34,10 +34,10 @@ public interface AttributeNodeImplementor<J> extends AttributeNode<J>, GraphNode
 	<S> SubGraphImplementor<S> makeKeySubGraph(Class<S> subtype);
 
 	@Override
-	<S> SubGraphImplementor<S> makeSubGraph(ManagedDomainType<S> subtype);
+	<S> SubGraphImplementor<S> makeSubGraph(ManagedType<S> subtype);
 
 	@Override
-	<S> SubGraphImplementor<S> makeKeySubGraph(ManagedDomainType<S> subtype);
+	<S> SubGraphImplementor<S> makeKeySubGraph(ManagedType<S> subtype);
 
 	void merge(AttributeNodeImplementor<J> other);
 

--- a/hibernate-core/src/main/java/org/hibernate/graph/spi/GraphImplementor.java
+++ b/hibernate-core/src/main/java/org/hibernate/graph/spi/GraphImplementor.java
@@ -7,10 +7,15 @@ package org.hibernate.graph.spi;
 import java.util.List;
 import java.util.Map;
 
+import jakarta.persistence.metamodel.Attribute;
+import jakarta.persistence.metamodel.ManagedType;
+import jakarta.persistence.metamodel.MapAttribute;
+import jakarta.persistence.metamodel.PluralAttribute;
+import org.hibernate.Incubating;
 import org.hibernate.Internal;
-import org.hibernate.graph.CannotBecomeEntityGraphException;
+import org.hibernate.graph.AttributeNode;
 import org.hibernate.graph.Graph;
-import org.hibernate.metamodel.model.domain.ManagedDomainType;
+import org.hibernate.graph.SubGraph;
 import org.hibernate.metamodel.model.domain.MapPersistentAttribute;
 import org.hibernate.metamodel.model.domain.PersistentAttribute;
 import org.hibernate.metamodel.model.domain.PluralPersistentAttribute;
@@ -30,11 +35,12 @@ public interface GraphImplementor<J> extends Graph<J>, GraphNodeImplementor<J> {
 	@Internal
 	void mergeInternal(GraphImplementor<J> graph);
 
-	@Override @Deprecated(forRemoval = true)
-	RootGraphImplementor<J> makeRootGraph(String name, boolean mutable)
-			throws CannotBecomeEntityGraphException;
+	@Override
+	@Deprecated(forRemoval = true)
+	RootGraphImplementor<J> makeRootGraph(String name, boolean mutable);
 
-	@Override @Deprecated(forRemoval = true)
+	@Override
+	@Deprecated(forRemoval = true)
 	SubGraphImplementor<J> makeSubGraph(boolean mutable);
 
 	@Override
@@ -55,7 +61,6 @@ public interface GraphImplementor<J> extends Graph<J>, GraphNodeImplementor<J> {
 
 	<AJ> AttributeNodeImplementor<AJ> findOrCreateAttributeNode(PersistentAttribute<? super J, AJ> attribute);
 
-	@Override
 	<AJ> AttributeNodeImplementor<AJ> addAttributeNode(PersistentAttribute<? super J, AJ> attribute);
 
 	@Override
@@ -70,14 +75,13 @@ public interface GraphImplementor<J> extends Graph<J>, GraphNodeImplementor<J> {
 	@Override
 	<AJ> SubGraphImplementor<AJ> addSubGraph(PersistentAttribute<? super J, ? super AJ> attribute, Class<AJ> subtype);
 
-	@Override
-	<AJ> SubGraphImplementor<AJ> addSubGraph(PersistentAttribute<? super J, ? super AJ> attribute, ManagedDomainType<AJ> subtype);
+	<AJ> SubGraphImplementor<AJ> addTreatedSubgraph(PersistentAttribute<? super J, ? super AJ> attribute, ManagedType<AJ> subtype);
 
-	@Override
+	@Incubating
 	<AJ> SubGraphImplementor<AJ> addElementSubGraph(PluralPersistentAttribute<? super J, ?, ? super AJ> attribute, Class<AJ> type);
 
-	@Override
-	<AJ> SubGraphImplementor<AJ> addElementSubGraph(PluralPersistentAttribute<? super J, ?, ? super AJ> attribute, ManagedDomainType<AJ> type);
+	@Incubating
+	<AJ> SubGraphImplementor<AJ> addTreatedElementSubgraph(PluralPersistentAttribute<? super J, ?, ? super AJ> attribute, ManagedType<AJ> type);
 
 	@Override
 	<AJ> SubGraphImplementor<AJ> addKeySubGraph(String attributeName);
@@ -88,13 +92,87 @@ public interface GraphImplementor<J> extends Graph<J>, GraphNodeImplementor<J> {
 	@Override
 	<AJ> SubGraphImplementor<AJ> addKeySubGraph(MapPersistentAttribute<? super J, ? super AJ, ?> attribute, Class<AJ> subtype);
 
-	@Override
-	<AJ> SubGraphImplementor<AJ> addKeySubGraph(MapPersistentAttribute<? super J, ? super AJ, ?> attribute, ManagedDomainType<AJ> subtype);
+	<AJ> SubGraphImplementor<AJ> addTreatedMapKeySubgraph(MapPersistentAttribute<? super J, ? super AJ, ?> attribute, ManagedType<AJ> subtype);
 
 	@Override
-	<Y extends J> SubGraphImplementor<Y> addTreatedSubGraph(Class<Y> type);
+	<Y extends J> SubGraphImplementor<Y> addTreatedSubgraph(Class<Y> type);
 
-	<Y extends J> SubGraphImplementor<Y> addTreatedSubGraph(ManagedDomainType<Y> type);
+	<Y extends J> SubGraphImplementor<Y> addTreatedSubgraph(ManagedType<Y> type);
 
 	Map<Class<? extends J>, SubGraphImplementor<? extends J>> getSubGraphs();
+
+	@Override
+	default <Y> AttributeNode<Y> getAttributeNode(String attributeName) {
+		return findAttributeNode( attributeName );
+	}
+
+	@Override
+	default <Y> AttributeNode<Y> getAttributeNode(Attribute<? super J, Y> attribute) {
+		return findAttributeNode( (PersistentAttribute<? super J, Y>) attribute );
+	}
+
+	@Override
+	default <Y> AttributeNode<Y> addAttributeNode(Attribute<? super J, Y> attribute) {
+		return addAttributeNode( (PersistentAttribute<? super J, Y>) attribute );
+	}
+
+	@Override
+	default <X> SubGraphImplementor<X> addSubgraph(String attributeName, Class<X> type) {
+		return addSubGraph( attributeName ).addTreatedSubgraph( type );
+	}
+
+	@Override
+	default <X> SubGraphImplementor<X> addSubgraph(Attribute<? super J, X> attribute) {
+		return addSubGraph( (PersistentAttribute<? super J, X>) attribute );
+	}
+
+	@Override
+	default <Y> SubGraphImplementor<Y> addTreatedSubgraph(Attribute<? super J, ? super Y> attribute, Class<Y> type) {
+		return addSubGraph( (PersistentAttribute<? super J, ? super Y>) attribute ).addTreatedSubgraph( type );
+	}
+
+	@Override
+	default <AJ> SubGraph<AJ> addTreatedSubgraph(Attribute<? super J, ? super AJ> attribute, ManagedType<AJ> type) {
+		return addSubGraph( (PersistentAttribute<? super J, ? super AJ>) attribute ).addTreatedSubgraph( type );
+	}
+
+	@Override
+	default <E> SubGraphImplementor<E> addTreatedElementSubgraph(PluralAttribute<? super J, ?, ? super E> attribute, Class<E> type) {
+		return addElementSubGraph( (PluralPersistentAttribute<? super J, ?, ? super E>) attribute, type );
+	}
+
+	@Override
+	default <AJ> SubGraph<AJ> addTreatedElementSubgraph(PluralAttribute<? super J, ?, ? super AJ> attribute, ManagedType<AJ> type) {
+		return addTreatedElementSubgraph( (PluralPersistentAttribute<? super J, ?, ? super AJ>) attribute, type );
+	}
+
+	@Override
+	default <X> SubGraphImplementor<X> addKeySubgraph(String attributeName) {
+		return addKeySubGraph( attributeName );
+	}
+
+	@Override
+	default <X> SubGraphImplementor<X> addKeySubgraph(String attributeName, Class<X> type) {
+		return addKeySubGraph( attributeName ).addTreatedSubgraph( type );
+	}
+
+	@Override
+	default <K> SubGraphImplementor<K> addTreatedMapKeySubgraph(MapAttribute<? super J, ? super K, ?> attribute, Class<K> type) {
+		return addKeySubGraph( (MapPersistentAttribute<? super J, ? super K, ?>) attribute, type );
+	}
+
+	@Override
+	default <AJ> SubGraph<AJ> addTreatedMapKeySubgraph(MapAttribute<? super J, ? super AJ, ?> attribute, ManagedType<AJ> type) {
+		return addTreatedMapKeySubgraph( (MapPersistentAttribute<? super J, ? super AJ, ?>) attribute, type );
+	}
+
+	@Override
+	default boolean hasAttributeNode(String attributeName) {
+		return getAttributeNode( attributeName ) != null;
+	}
+
+	@Override
+	default boolean hasAttributeNode(Attribute<? super J, ?> attribute) {
+		return getAttributeNode( attribute ) != null;
+	}
 }


### PR DESCRIPTION
 All of these methods now exist in the JPA supertype,  without the funky naming. We need to guide users away from the non-standard ones, especially in light of the ugliness.

<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

[Please describe here what your change is about]

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
