### PR TITLE
HHH-19005 Memory leak modify String to StringBuilder

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/engine/jdbc/internal/BasicFormatterImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/jdbc/internal/BasicFormatterImpl.java
@@ -85,11 +85,14 @@ public class BasicFormatterImpl implements Formatter {
 					case "`":
 					case "\"":
 						String t;
+						StringBuilder sb = new StringBuilder();
+						sb.append(this.token);
 						do {
 							t = tokens.nextToken();
-							token += t;
+							sb.append(t);
 						}
 						while ( !lcToken.equals( t ) && tokens.hasMoreTokens() );
+						this.token = sb.toString();
 						lcToken = token;
 						misc();
 						break;
@@ -97,11 +100,14 @@ public class BasicFormatterImpl implements Formatter {
 					// see SQLServerDialect.openQuote and SQLServerDialect.closeQuote
 					case "[":
 						String tt;
+						StringBuilder sb2 = new StringBuilder();
+						sb2.append(this.token);
 						do {
 							tt = tokens.nextToken();
-							token += tt;
+							sb2.append(tt);
 						}
 						while ( !"]".equals( tt ) && tokens.hasMoreTokens() );
+						this.token = sb2.toString();
 						lcToken = token;
 						misc();
 						break;
@@ -390,8 +396,8 @@ public class BasicFormatterImpl implements Formatter {
 			newline();
 			afterBeginBeforeEnd = false;
 			afterByOrSetOrFromOrSelect = "by".equals( lcToken )
-					|| "set".equals( lcToken )
-					|| "from".equals( lcToken );
+										 || "set".equals( lcToken )
+										 || "from".equals( lcToken );
 		}
 
 		private void beginNewClause() {


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-19005

Hello.

When It is json, there are some memory leak.

These are the results of the modified code and the existing code when tested locally.
![image](https://github.com/user-attachments/assets/948c23d9-1b94-4e3e-be87-871c5d23d56b)


This problem doesn't normally occur, but it makes a difference if you are performing json. This occurs when tokenizing json and formatting it while passing the switch statement within the perform method. Therefore, it seems better to change this code to StringBuilder as shown below.