### PR TITLE
HHH-19005 Memory leak modify String to StringBuilder

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/engine/jdbc/internal/BasicFormatterImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/jdbc/internal/BasicFormatterImpl.java
@@ -70,7 +70,7 @@ public class BasicFormatterImpl implements Formatter {
 			while ( tokens.hasMoreTokens() ) {
 				token = tokens.nextToken();
 
-				if ( "-".equals(token) && result.toString().endsWith("-") ) {
+				if ( "-".equals( token ) && result.toString().endsWith( "-" ) ) {
 					do {
 						result.append( token );
 						token = tokens.nextToken();
@@ -78,18 +78,21 @@ public class BasicFormatterImpl implements Formatter {
 					while ( !"\n".equals( token ) && tokens.hasMoreTokens() );
 				}
 
-				lcToken = token.toLowerCase(Locale.ROOT);
-				switch (lcToken) {
+				lcToken = token.toLowerCase( Locale.ROOT );
+				switch ( lcToken ) {
 
 					case "'":
 					case "`":
 					case "\"":
 						String t;
+						StringBuilder sb = new StringBuilder();
+						sb.append( this.token );
 						do {
 							t = tokens.nextToken();
-							token += t;
+							sb.append( t );
 						}
 						while ( !lcToken.equals( t ) && tokens.hasMoreTokens() );
+						this.token = sb.toString();
 						lcToken = token;
 						misc();
 						break;
@@ -97,11 +100,14 @@ public class BasicFormatterImpl implements Formatter {
 					// see SQLServerDialect.openQuote and SQLServerDialect.closeQuote
 					case "[":
 						String tt;
+						StringBuilder sb2 = new StringBuilder();
+						sb2.append( this.token );
 						do {
 							tt = tokens.nextToken();
-							token += tt;
+							sb2.append( tt );
 						}
 						while ( !"]".equals( tt ) && tokens.hasMoreTokens() );
+						this.token = sb2.toString();
 						lcToken = token;
 						misc();
 						break;
@@ -238,7 +244,7 @@ public class BasicFormatterImpl implements Formatter {
 		}
 
 		private void comma() {
-			if ( afterByOrSetOrFromOrSelect && inFunction==0 ) {
+			if ( afterByOrSetOrFromOrSelect && inFunction == 0 ) {
 				commaAfterByOrFromOrSelect();
 			}
 //			else if ( afterOn && inFunction==0 ) {
@@ -313,7 +319,7 @@ public class BasicFormatterImpl implements Formatter {
 
 		private void misc() {
 			out();
-			if ( afterInsert && inFunction==0 ) {
+			if ( afterInsert && inFunction == 0 ) {
 				newline();
 				afterInsert = false;
 			}
@@ -329,7 +335,7 @@ public class BasicFormatterImpl implements Formatter {
 		}
 
 		private void updateOrInsertOrDelete() {
-			if ( indent>1  ) {
+			if ( indent > 1 ) {
 				//probably just the insert SQL function
 				out();
 			}
@@ -367,7 +373,7 @@ public class BasicFormatterImpl implements Formatter {
 
 		private void out() {
 			if ( result.charAt( result.length() - 1 ) == ',' ) {
-				result.append(" ");
+				result.append( " " );
 			}
 			result.append( token );
 		}
@@ -507,7 +513,7 @@ public class BasicFormatterImpl implements Formatter {
 
 		private void newline() {
 			result.append( System.lineSeparator() )
-					.append( INDENT_STRING.repeat(indent) );
+					.append( INDENT_STRING.repeat( indent ) );
 			beginLine = true;
 		}
 	}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/jdbc/util/BasicFormatterTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/jdbc/util/BasicFormatterTest.java
@@ -21,7 +21,6 @@ import static org.junit.Assert.assertFalse;
  * @author Steve Ebersole
  */
 public class BasicFormatterTest extends BaseUnitTestCase {
-
 	@Test
 	public void testNoLoss() {
 		assertNoLoss( "insert into Address (city, state, zip, \"from\") values (?, ?, ?, 'insert value')" );
@@ -47,6 +46,30 @@ public class BasicFormatterTest extends BaseUnitTestCase {
 				"(select p.pid from Address where city = 'Boston') union (select p.pid from Address where city = 'Taipei')"
 		);
 		assertNoLoss( "select group0.[order] as order0 from [Group] group0 where group0.[order]=?1" );
+		assertNoLoss( """
+						INSERT INTO TEST_TABLE (JSON) VALUES
+						('{
+						"apiVersion": "2.0",
+						"data": {
+							"updated": "2010-01-07T19:58:42.949Z",
+							"totalItems": 800,
+							"startIndex": 1,
+							"itemsPerPage": 1,
+							"items": [
+							{
+								"id": "hYB0mn5zh2c",
+								"uploaded": "2007-06-05T22:07:03.000Z",
+								"updated": "2010-01-07T13:26:50.000Z",
+								"uploader": "GoogleDeveloperDay",
+								"category": "News",
+								"title": "Google Developers Day US - Maps API Introduction",
+								"description": "Google Maps API Introduction ..."
+							}
+							]
+						}
+						}')
+					"""
+		);
 	}
 
 	@Test


### PR DESCRIPTION
<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

https://hibernate.atlassian.net/browse/HHH-19005

Hello.

When It is json, there are some memory leak.

These are the results of the modified code and the existing code when tested locally.
![image](https://github.com/user-attachments/assets/948c23d9-1b94-4e3e-be87-871c5d23d56b)


This problem doesn't normally occur, but it makes a difference if you are performing json. This occurs when tokenizing json and formatting it while passing the switch statement within the perform method. Therefore, it seems better to change this code to StringBuilder as shown below.


<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
