### PR TITLE
HHH-16512 test for is null query on OneToOne relation

### DIFF
--- a/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/criteria/query/one_to_one/CriteriaOneToOneTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/criteria/query/one_to_one/CriteriaOneToOneTest.java
@@ -1,0 +1,184 @@
+/*
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.jpa.criteria.query.one_to_one;
+
+import java.util.List;
+
+import org.hibernate.orm.test.jpa.BaseEntityManagerFunctionalTestCase;
+
+import org.hibernate.testing.orm.junit.JiraKey;
+import org.hibernate.testing.transaction.TransactionUtil;
+import org.junit.Before;
+import org.junit.Test;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.criteria.CriteriaBuilder;
+import jakarta.persistence.criteria.CriteriaQuery;
+import jakarta.persistence.criteria.Join;
+import jakarta.persistence.criteria.JoinType;
+import jakarta.persistence.criteria.Predicate;
+import jakarta.persistence.criteria.Root;
+
+import static org.junit.Assert.assertEquals;
+
+
+public class CriteriaOneToOneTest extends BaseEntityManagerFunctionalTestCase {
+
+	@Before
+	public void persist() {
+		TransactionUtil.doInJPA( this::entityManagerFactory, (EntityManager session) -> {
+
+					User user1 = new User( "user1" );
+					User user2 = new User( "user2" );
+
+					Customer customer1 = new Customer( "customer1" );
+					Customer customer2 = new Customer( "customer2" );
+
+					user2.setCustomer( customer2 );
+					customer2.setUser( user2 );
+
+					session.persist( customer1 );
+					session.persist( customer2 );
+					session.persist( user1 );
+					session.persist( user2 );
+				});
+	}
+
+	@Test
+	@JiraKey("HHH-16512")
+	public void testCustomerWithoutUser() {
+
+
+		TransactionUtil.doInJPA( this::entityManagerFactory, (EntityManager session) -> {
+
+			final CriteriaBuilder cb = session.getCriteriaBuilder();
+
+			//isNull predicate with direction Customer -> User
+			final CriteriaQuery<Customer> customerUserIsNullQuery = cb.createQuery( Customer.class );
+			final Root<Customer> customerUserIsNullRoot = customerUserIsNullQuery.from( Customer.class );
+			customerUserIsNullQuery.where( cb.isNull( customerUserIsNullRoot.get( "user" ) ) );
+			List<Customer> customerUserIsNullResults = session.createQuery( customerUserIsNullQuery )
+					.getResultList();
+			assertEquals( 1, customerUserIsNullResults.size() );
+
+			//isNull predicate on ID of Customer via Join with direction User -> Customer
+			final CriteriaQuery<User> userJoinCustomerQuery = cb.createQuery( User.class );
+			Root<User> userJoinCustomerQueryRoot = userJoinCustomerQuery.from( User.class );
+			final Join<User, Customer> customerJoin = userJoinCustomerQueryRoot.join( "customer", JoinType.LEFT );
+			final Predicate isCustomerIDNullPredicate = cb.isNull( customerJoin.get( "id" ) );
+			userJoinCustomerQuery.where( isCustomerIDNullPredicate );
+			List<User> userJoinCustomerResults = session.createQuery( userJoinCustomerQuery ).getResultList();
+			assertEquals( 1, userJoinCustomerResults.size() );
+
+			//isNull predicate on Customer via Join with direction User -> Customer (should do the same as the one above)
+			final CriteriaQuery<User> userCustomerIsNullQuery = cb.createQuery( User.class );
+			final Root<User> userCustomerIsNullRoot = userCustomerIsNullQuery.from( User.class );
+			userCustomerIsNullQuery.where( cb.isNull( userCustomerIsNullRoot.get( "customer" ) ) );
+			List<User> userCustomerIsNullResults = session.createQuery( userCustomerIsNullQuery )
+					.getResultList();
+			assertEquals( 1, userCustomerIsNullResults.size() );
+		});
+	}
+
+	@Override
+	protected Class<?>[] getAnnotatedClasses() {
+		return new Class[]{ User.class, Customer.class };
+	}
+
+	/**
+	 * @author Janario Oliveira
+	 */
+	@Entity
+	public static class Customer {
+		@Id
+		@GeneratedValue
+		private Integer id;
+		private String name;
+
+		@OneToOne
+		@JoinColumn(name = "user_id")
+		private User user;
+
+		protected Customer() {
+		}
+
+		public Customer(String name) {
+			this.name = name;
+		}
+
+		public User getUser() {
+			return user;
+		}
+
+		public void setUser(User user) {
+			this.user = user;
+		}
+
+		@Override
+		public boolean equals(Object o) {
+			if ( !( o instanceof Customer ) ) {
+				return false;
+			}
+
+			Customer seller = (Customer) o;
+			return name.equals( seller.name );
+		}
+
+		@Override
+		public int hashCode() {
+			return name.hashCode();
+		}
+	}
+
+	/**
+	 * @author Janario Oliveira
+	 */
+	@Entity
+	public static class User {
+		@Id
+		@GeneratedValue
+		private Integer id;
+		private String name;
+
+		@OneToOne(mappedBy = "user")
+		private Customer customer;
+
+		protected User() {
+		}
+
+		public User(String name) {
+			this.name = name;
+		}
+
+		public Customer getCustomer() {
+			return customer;
+		}
+
+		public void setCustomer(Customer customer) {
+			this.customer = customer;
+		}
+
+		@Override
+		public boolean equals(Object o) {
+			if ( !( o instanceof User ) ) {
+				return false;
+			}
+
+			User customer = (User) o;
+			return name.equals( customer.name );
+
+		}
+
+		@Override
+		public int hashCode() {
+			return name.hashCode();
+		}
+	}
+}


### PR DESCRIPTION
<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

HHH-16512 describes a problem when querying OneToOne relations the "wrong" way around, because an inner join was used in combination with a "is null" query. This seems to be fixed in the current main branch, but nevertheless, this test should be included to prevent any regressions and have a reference to where the issue was officially fixed.

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
