### PR TITLE
escalate some annotation deprecations to forRemoval=true

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/annotations/AttributeAccessor.java
+++ b/hibernate-core/src/main/java/org/hibernate/annotations/AttributeAccessor.java
@@ -48,7 +48,7 @@ public @interface AttributeAccessor {
 	 *
 	 * @deprecated use {@link #strategy()}
 	 */
-	@Deprecated(since = "6.0")
+	@Deprecated(since = "6.0", forRemoval = true)
 	String value() default "";
 	/**
 	 * A class implementing {@link PropertyAccessStrategy}.

--- a/hibernate-core/src/main/java/org/hibernate/annotations/Cascade.java
+++ b/hibernate-core/src/main/java/org/hibernate/annotations/Cascade.java
@@ -32,7 +32,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  * @deprecated Use the JPA-defined
  *             {@link jakarta.persistence.CascadeType}
  */
-@Deprecated(since = "7")
+@Deprecated(since = "7", forRemoval = true)
 @Target({METHOD, FIELD})
 @Retention(RUNTIME)
 public @interface Cascade {

--- a/hibernate-core/src/main/java/org/hibernate/annotations/CascadeType.java
+++ b/hibernate-core/src/main/java/org/hibernate/annotations/CascadeType.java
@@ -30,9 +30,11 @@ import org.hibernate.ReplicationMode;
  * @see Cascade
  *
  * @deprecated Use the JPA-defined
- *             {@link jakarta.persistence.CascadeType}
+ *             {@link jakarta.persistence.CascadeType}.
+ *             This enumeration will be removed to alleviate the
+ *             duplication in naming.
  */
-@Deprecated(since = "7")
+@Deprecated(since = "7", forRemoval = true)
 public enum CascadeType {
 	/**
 	 * Includes all types listed here.

--- a/hibernate-core/src/main/java/org/hibernate/annotations/Checks.java
+++ b/hibernate-core/src/main/java/org/hibernate/annotations/Checks.java
@@ -15,10 +15,13 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 /**
  * A list of {@link Check}s.
  *
+ * @deprecated since {@link Check} is deprecated.
+ *
  * @author Gavin King
  */
 @Target({TYPE, METHOD, FIELD})
 @Retention(RUNTIME)
+@Deprecated(since = "7")
 public @interface Checks {
 	Check[] value();
 }

--- a/hibernate-core/src/main/java/org/hibernate/annotations/FlushModeType.java
+++ b/hibernate-core/src/main/java/org/hibernate/annotations/FlushModeType.java
@@ -17,9 +17,10 @@ import org.hibernate.query.QueryFlushMode;
  * @see NamedQuery#flushMode
  * @see NamedNativeQuery#flushMode
  *
- * @deprecated use {@link QueryFlushMode}
+ * @deprecated Use {@link QueryFlushMode}. This enumeration will be removed to alleviate
+ *             the duplication in naming with {@link jakarta.persistence.FlushModeType}.
  */
-@Deprecated(since="7")
+@Deprecated(since="7", forRemoval = true)
 public enum FlushModeType {
 	/**
 	 * Corresponds to {@link org.hibernate.FlushMode#ALWAYS}.

--- a/hibernate-core/src/main/java/org/hibernate/annotations/GenericGenerator.java
+++ b/hibernate-core/src/main/java/org/hibernate/annotations/GenericGenerator.java
@@ -66,7 +66,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 @Target({PACKAGE, TYPE, METHOD, FIELD})
 @Retention(RUNTIME)
 @Repeatable(GenericGenerators.class)
-@Deprecated(since = "6.5")
+@Deprecated(since = "6.5", forRemoval = true)
 public @interface GenericGenerator {
 	/**
 	 * The name of the identifier generator. This is the name that may be specified by
@@ -93,7 +93,7 @@ public @interface GenericGenerator {
 	 *
 	 * @deprecated use {@link #type()} for typesafety
 	 */
-	@Deprecated(since="6.2")
+	@Deprecated(since="6.2", forRemoval = true)
 	String strategy() default "native";
 	/**
 	 * Parameters to be passed to {@link org.hibernate.id.IdentifierGenerator#configure}

--- a/hibernate-core/src/main/java/org/hibernate/annotations/GenericGenerators.java
+++ b/hibernate-core/src/main/java/org/hibernate/annotations/GenericGenerators.java
@@ -20,7 +20,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  */
 @Target({PACKAGE, TYPE})
 @Retention(RUNTIME)
-@Deprecated(since = "6.5")
+@Deprecated(since = "6.5", forRemoval = true)
 public @interface GenericGenerators {
 	/**
 	 * The aggregated generators.

--- a/hibernate-core/src/main/java/org/hibernate/annotations/NamedNativeQuery.java
+++ b/hibernate-core/src/main/java/org/hibernate/annotations/NamedNativeQuery.java
@@ -80,7 +80,7 @@ public @interface NamedNativeQuery {
 	 *
 	 * @deprecated use {@link #flush()}
 	 */
-	@Deprecated(since = "7")
+	@Deprecated(since = "7", forRemoval = true)
 	FlushModeType flushMode() default FlushModeType.PERSISTENCE_CONTEXT;
 
 	/**
@@ -182,6 +182,6 @@ public @interface NamedNativeQuery {
 	 *
 	 * @see org.hibernate.jpa.HibernateHints#HINT_CALLABLE_FUNCTION
 	 */
-	@Deprecated( since = "6.0" )
+	@Deprecated(since = "6.0", forRemoval = true)
 	boolean callable() default false;
 }

--- a/hibernate-core/src/main/java/org/hibernate/annotations/NamedQuery.java
+++ b/hibernate-core/src/main/java/org/hibernate/annotations/NamedQuery.java
@@ -75,7 +75,7 @@ public @interface NamedQuery {
 	 *
 	 * @deprecated use {@link #flush()}
 	 */
-	@Deprecated(since = "7")
+	@Deprecated(since = "7", forRemoval = true)
 	FlushModeType flushMode() default FlushModeType.PERSISTENCE_CONTEXT;
 
 	/**

--- a/hibernate-core/src/main/java/org/hibernate/annotations/ResultCheckStyle.java
+++ b/hibernate-core/src/main/java/org/hibernate/annotations/ResultCheckStyle.java
@@ -24,7 +24,7 @@ import org.hibernate.jdbc.Expectation;
  *
  * @deprecated Use an {@link Expectation} class instead.
  */
-@Deprecated(since = "6.5")
+@Deprecated(since = "6.5", forRemoval = true)
 public enum ResultCheckStyle {
 	/**
 	 * No return code checking. Might mean that no checks are required, or that

--- a/hibernate-core/src/main/java/org/hibernate/annotations/SQLDelete.java
+++ b/hibernate-core/src/main/java/org/hibernate/annotations/SQLDelete.java
@@ -59,7 +59,7 @@ public @interface SQLDelete {
 	 *
 	 * @deprecated use {@link #verify()} with an {@link Expectation} class
 	 */
-	@Deprecated(since = "6.5")
+	@Deprecated(since = "6.5", forRemoval = true)
 	ResultCheckStyle check() default ResultCheckStyle.NONE;
 
 	/**

--- a/hibernate-core/src/main/java/org/hibernate/annotations/SQLDeleteAll.java
+++ b/hibernate-core/src/main/java/org/hibernate/annotations/SQLDeleteAll.java
@@ -47,7 +47,7 @@ public @interface SQLDeleteAll {
 	 *
 	 * @deprecated use {@link #verify()} with an {@link Expectation} class
 	 */
-	@Deprecated(since = "6.5")
+	@Deprecated(since = "6.5", forRemoval = true)
 	ResultCheckStyle check() default ResultCheckStyle.NONE;
 
 	/**

--- a/hibernate-core/src/main/java/org/hibernate/annotations/SQLInsert.java
+++ b/hibernate-core/src/main/java/org/hibernate/annotations/SQLInsert.java
@@ -75,7 +75,7 @@ public @interface SQLInsert {
 	 *
 	 * @deprecated use {@link #verify()} with an {@link Expectation} class
 	 */
-	@Deprecated(since = "6.5")
+	@Deprecated(since = "6.5", forRemoval = true)
 	ResultCheckStyle check() default ResultCheckStyle.NONE;
 
 	/**

--- a/hibernate-core/src/main/java/org/hibernate/annotations/SQLUpdate.java
+++ b/hibernate-core/src/main/java/org/hibernate/annotations/SQLUpdate.java
@@ -78,7 +78,7 @@ public @interface SQLUpdate {
 	 *
 	 * @deprecated use {@link #verify()} with an {@link Expectation} class
 	 */
-	@Deprecated(since = "6.5")
+	@Deprecated(since = "6.5", forRemoval = true)
 	ResultCheckStyle check() default ResultCheckStyle.NONE;
 
 	/**


### PR DESCRIPTION
especially the enums which names collide with JPA

<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

[Please describe here what your change is about]

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
