### PR TITLE
HHH-19017: Reproduce Class Cast Exception for PersistentAttributeInterceptable

### DIFF
--- a/hibernate-core/src/test/java/org/hibernate/orm/test/lazyonetoone/LazyOneToOneWithEntityGraphTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/lazyonetoone/LazyOneToOneWithEntityGraphTest.java
@@ -1,0 +1,89 @@
+package org.hibernate.orm.test.lazyonetoone;
+
+import java.util.List;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.NamedAttributeNode;
+import jakarta.persistence.NamedEntityGraph;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.OneToOne;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.junit.jupiter.api.Test;
+
+@DomainModel(
+    annotatedClasses = {
+        LazyOneToOneWithEntityGraphTest.Company.class,
+        LazyOneToOneWithEntityGraphTest.Employee.class,
+        LazyOneToOneWithEntityGraphTest.Project.class
+    }
+)
+@SessionFactory
+public class LazyOneToOneWithEntityGraphTest {
+  @Test
+  void reproducerTest(SessionFactoryScope scope) {
+    scope.inTransaction(session -> {
+      // Create company
+      Company company = new Company();
+      company.id = 1L;
+      company.name = "Hibernate";
+      session.persist(company);
+
+      // Create project
+      Project project = new Project();
+      project.id = 1L;
+      session.persist(project);
+
+      // Create employee
+      Employee employee = new Employee();
+      employee.id = 1L;
+      employee.company = company;
+      employee.projects = List.of(project);
+      session.persist(employee);
+    });
+
+    scope.inTransaction(session -> {
+      // Load employee using entity graph
+      Employee employee = session.createQuery(
+              "select e from Employee e where e.id = :id", Employee.class)
+          .setParameter("id", 1L)
+          .setHint("javax.persistence.fetchgraph", session.getEntityGraph("employee.projects"))
+          .getSingleResult();
+    });
+  }
+
+  @Entity(name = "Company")
+  public static class Company {
+    @Id
+    private Long id;
+
+    private String name;
+  }
+
+  @Entity(name = "Employee")
+  @NamedEntityGraph(
+      name = "employee.projects",
+      attributeNodes = @NamedAttributeNode("projects")
+  )
+  public static class Employee {
+    @Id
+    private Long id;
+
+    @OneToOne
+    @JoinColumn(name = "company_name", referencedColumnName = "name")
+    private Company company;
+
+    @OneToMany(fetch = FetchType.LAZY)
+    private List<Project> projects;
+  }
+
+  @Entity(name = "Project")
+  public static class Project {
+    @Id
+    private Long id;
+  }
+}


### PR DESCRIPTION
Reproducer for https://hibernate.atlassian.net/browse/HHH-19017

This is not a fix, just a reproducer for an issue I encountered after upgrading to Hibernate 6.6 (from 6.5). I originally thought that the issue was confined to `@OneToOne(FetchType.LAZY)` but this test also fails for `FetchType.EAGER`. I believe the preconditions to reproduce this are
  1. `@OneToOne` property on a model
  2. `@JoinColumn` to a unique key (other than `@Id`)
  3. `@EntityGraph` being applied

This test should reproduce a `ClassCastException` that's [thrown here](https://github.com/hibernate/hibernate-orm/blob/f0f96916adb5adbba56ed19f583343559d16576b/hibernate-core/src/main/java/org/hibernate/engine/internal/ManagedTypeHelper.java#L285).

Related Change:
  - https://github.com/hibernate/hibernate-orm/pull/8812