### PR TITLE
HHH-19008 Clean up FastSessionServices which had become a bucket to dump things in

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/action/internal/CollectionAction.java
+++ b/hibernate-core/src/main/java/org/hibernate/action/internal/CollectionAction.java
@@ -13,6 +13,7 @@ import org.hibernate.collection.spi.PersistentCollection;
 import org.hibernate.engine.spi.ComparableExecutable;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.event.spi.EventSource;
+import org.hibernate.event.service.spi.EventListenerGroups;
 import org.hibernate.internal.FastSessionServices;
 import org.hibernate.persister.collection.CollectionPersister;
 
@@ -197,10 +198,19 @@ public abstract class CollectionAction implements ComparableExecutable {
 
 	/**
 	 * Convenience method for all subclasses.
-	 * @return the {@link FastSessionServices} instance from the SessionFactory.
+	 * @return the {@link EventListenerGroups} instance from the {@code SessionFactory}.
 	 */
+	protected EventListenerGroups getEventListenerGroups() {
+		return session.getFactory().getEventListenerGroups();
+	}
+
+	/**
+	 * @deprecated This is a layer-breaker
+	 */
+	@Deprecated(since = "7.0", forRemoval = true)
 	protected FastSessionServices getFastSessionServices() {
 		return session.getFactory().getFastSessionServices();
 	}
+
 
 }

--- a/hibernate-core/src/main/java/org/hibernate/action/internal/CollectionRecreateAction.java
+++ b/hibernate-core/src/main/java/org/hibernate/action/internal/CollectionRecreateAction.java
@@ -68,7 +68,7 @@ public final class CollectionRecreateAction extends CollectionAction {
 	}
 
 	private void preRecreate() {
-		getFastSessionServices().eventListenerGroup_PRE_COLLECTION_RECREATE
+		getEventListenerGroups().eventListenerGroup_PRE_COLLECTION_RECREATE
 				.fireLazyEventOnEachListener( this::newPreCollectionRecreateEvent,
 						PreCollectionRecreateEventListener::onPreRecreateCollection );
 	}
@@ -78,7 +78,7 @@ public final class CollectionRecreateAction extends CollectionAction {
 	}
 
 	private void postRecreate() {
-		getFastSessionServices().eventListenerGroup_POST_COLLECTION_RECREATE
+		getEventListenerGroups().eventListenerGroup_POST_COLLECTION_RECREATE
 				.fireLazyEventOnEachListener( this::newPostCollectionRecreateEvent,
 						PostCollectionRecreateEventListener::onPostRecreateCollection );
 	}

--- a/hibernate-core/src/main/java/org/hibernate/action/internal/CollectionRemoveAction.java
+++ b/hibernate-core/src/main/java/org/hibernate/action/internal/CollectionRemoveAction.java
@@ -138,7 +138,7 @@ public final class CollectionRemoveAction extends CollectionAction {
 	}
 
 	private void preRemove() {
-		getFastSessionServices().eventListenerGroup_PRE_COLLECTION_REMOVE
+		getEventListenerGroups().eventListenerGroup_PRE_COLLECTION_REMOVE
 				.fireLazyEventOnEachListener( this::newPreCollectionRemoveEvent,
 						PreCollectionRemoveEventListener::onPreRemoveCollection );
 	}
@@ -148,7 +148,7 @@ public final class CollectionRemoveAction extends CollectionAction {
 	}
 
 	private void postRemove() {
-		getFastSessionServices().eventListenerGroup_POST_COLLECTION_REMOVE
+		getEventListenerGroups().eventListenerGroup_POST_COLLECTION_REMOVE
 				.fireLazyEventOnEachListener( this::newPostCollectionRemoveEvent,
 						PostCollectionRemoveEventListener::onPostRemoveCollection );
 	}

--- a/hibernate-core/src/main/java/org/hibernate/action/internal/CollectionUpdateAction.java
+++ b/hibernate-core/src/main/java/org/hibernate/action/internal/CollectionUpdateAction.java
@@ -108,7 +108,7 @@ public final class CollectionUpdateAction extends CollectionAction {
 	}
 
 	private void preUpdate() {
-		getFastSessionServices().eventListenerGroup_PRE_COLLECTION_UPDATE
+		getEventListenerGroups().eventListenerGroup_PRE_COLLECTION_UPDATE
 				.fireLazyEventOnEachListener( this::newPreCollectionUpdateEvent,
 						PreCollectionUpdateEventListener::onPreUpdateCollection );
 	}
@@ -118,7 +118,7 @@ public final class CollectionUpdateAction extends CollectionAction {
 	}
 
 	private void postUpdate() {
-		getFastSessionServices().eventListenerGroup_POST_COLLECTION_UPDATE
+		getEventListenerGroups().eventListenerGroup_POST_COLLECTION_UPDATE
 				.fireLazyEventOnEachListener( this::newPostCollectionUpdateEvent,
 						PostCollectionUpdateEventListener::onPostUpdateCollection );
 	}

--- a/hibernate-core/src/main/java/org/hibernate/action/internal/EntityAction.java
+++ b/hibernate-core/src/main/java/org/hibernate/action/internal/EntityAction.java
@@ -10,6 +10,7 @@ import org.hibernate.action.spi.BeforeTransactionCompletionProcess;
 import org.hibernate.engine.spi.ComparableExecutable;
 import org.hibernate.engine.spi.EntityEntry;
 import org.hibernate.event.spi.EventSource;
+import org.hibernate.event.service.spi.EventListenerGroups;
 import org.hibernate.internal.FastSessionServices;
 import org.hibernate.persister.entity.EntityPersister;
 
@@ -192,10 +193,17 @@ public abstract class EntityAction
 
 	/**
 	 * Convenience method for all subclasses.
-	 * @return the {@link FastSessionServices} instance from the SessionFactory.
+	 * @return the {@link EventListenerGroups} instance from the {@code SessionFactory}.
 	 */
+	protected EventListenerGroups getEventListenerGroups() {
+		return session.getFactory().getEventListenerGroups();
+	}
+
+	/**
+	 * @deprecated This is a layer-breaker
+	 */
+	@Deprecated(since = "7.0", forRemoval = true)
 	protected FastSessionServices getFastSessionServices() {
 		return session.getFactory().getFastSessionServices();
 	}
-
 }

--- a/hibernate-core/src/main/java/org/hibernate/action/internal/EntityDeleteAction.java
+++ b/hibernate-core/src/main/java/org/hibernate/action/internal/EntityDeleteAction.java
@@ -199,7 +199,7 @@ public class EntityDeleteAction extends EntityAction {
 
 	protected boolean preDelete() {
 		final EventListenerGroup<PreDeleteEventListener> listenerGroup
-				= getFastSessionServices().eventListenerGroup_PRE_DELETE;
+				= getEventListenerGroups().eventListenerGroup_PRE_DELETE;
 		if ( listenerGroup.isEmpty() ) {
 			return false;
 		}
@@ -214,7 +214,7 @@ public class EntityDeleteAction extends EntityAction {
 	}
 
 	protected void postDelete() {
-		getFastSessionServices().eventListenerGroup_POST_DELETE
+		getEventListenerGroups().eventListenerGroup_POST_DELETE
 				.fireLazyEventOnEachListener( this::newPostDeleteEvent, PostDeleteEventListener::onPostDelete );
 	}
 
@@ -224,7 +224,7 @@ public class EntityDeleteAction extends EntityAction {
 
 	protected void postCommitDelete(boolean success) {
 		final EventListenerGroup<PostDeleteEventListener> eventListeners
-				= getFastSessionServices().eventListenerGroup_POST_COMMIT_DELETE;
+				= getEventListenerGroups().eventListenerGroup_POST_COMMIT_DELETE;
 		if (success) {
 			eventListeners.fireLazyEventOnEachListener( this::newPostDeleteEvent, PostDeleteEventListener::onPostDelete );
 		}
@@ -251,7 +251,7 @@ public class EntityDeleteAction extends EntityAction {
 
 	@Override
 	protected boolean hasPostCommitEventListeners() {
-		for ( PostDeleteEventListener listener: getFastSessionServices().eventListenerGroup_POST_COMMIT_DELETE.listeners() ) {
+		for ( PostDeleteEventListener listener: getEventListenerGroups().eventListenerGroup_POST_COMMIT_DELETE.listeners() ) {
 			if ( listener.requiresPostCommitHandling( getPersister() ) ) {
 				return true;
 			}

--- a/hibernate-core/src/main/java/org/hibernate/action/internal/EntityIdentityInsertAction.java
+++ b/hibernate-core/src/main/java/org/hibernate/action/internal/EntityIdentityInsertAction.java
@@ -139,7 +139,7 @@ public class EntityIdentityInsertAction extends AbstractEntityInsertAction  {
 	@Override
 	protected boolean hasPostCommitEventListeners() {
 		final EventListenerGroup<PostInsertEventListener> group
-				= getFastSessionServices().eventListenerGroup_POST_COMMIT_INSERT;
+				= getEventListenerGroups().eventListenerGroup_POST_COMMIT_INSERT;
 		for ( PostInsertEventListener listener : group.listeners() ) {
 			if ( listener.requiresPostCommitHandling( getPersister() ) ) {
 				return true;
@@ -163,7 +163,7 @@ public class EntityIdentityInsertAction extends AbstractEntityInsertAction  {
 			getSession().getPersistenceContextInternal()
 					.replaceDelayedEntityIdentityInsertKeys( delayedEntityKey, generatedId );
 		}
-		getFastSessionServices().eventListenerGroup_POST_INSERT
+		getEventListenerGroups().eventListenerGroup_POST_INSERT
 				.fireLazyEventOnEachListener( this::newPostInsertEvent, PostInsertEventListener::onPostInsert );
 	}
 
@@ -172,7 +172,7 @@ public class EntityIdentityInsertAction extends AbstractEntityInsertAction  {
 	}
 
 	protected void postCommitInsert(boolean success) {
-		getFastSessionServices().eventListenerGroup_POST_COMMIT_INSERT
+		getEventListenerGroups().eventListenerGroup_POST_COMMIT_INSERT
 			.fireLazyEventOnEachListener( this::newPostInsertEvent,
 					success ? PostInsertEventListener::onPostInsert : this::postCommitInsertOnFailure );
 	}
@@ -189,7 +189,7 @@ public class EntityIdentityInsertAction extends AbstractEntityInsertAction  {
 
 	protected boolean preInsert() {
 		final EventListenerGroup<PreInsertEventListener> listenerGroup
-				= getFastSessionServices().eventListenerGroup_PRE_INSERT;
+				= getEventListenerGroups().eventListenerGroup_PRE_INSERT;
 		if ( listenerGroup.isEmpty() ) {
 			// NO_VETO
 			return false;

--- a/hibernate-core/src/main/java/org/hibernate/action/internal/EntityInsertAction.java
+++ b/hibernate-core/src/main/java/org/hibernate/action/internal/EntityInsertAction.java
@@ -210,7 +210,7 @@ public class EntityInsertAction extends AbstractEntityInsertAction {
 	}
 
 	protected void postInsert() {
-		getFastSessionServices()
+		getEventListenerGroups()
 				.eventListenerGroup_POST_INSERT
 				.fireLazyEventOnEachListener( this::newPostInsertEvent, PostInsertEventListener::onPostInsert );
 	}
@@ -220,7 +220,7 @@ public class EntityInsertAction extends AbstractEntityInsertAction {
 	}
 
 	protected void postCommitInsert(boolean success) {
-		getFastSessionServices().eventListenerGroup_POST_COMMIT_INSERT
+		getEventListenerGroups().eventListenerGroup_POST_COMMIT_INSERT
 				.fireLazyEventOnEachListener( this::newPostInsertEvent,
 						success ? PostInsertEventListener::onPostInsert : this::postCommitOnFailure );
 	}
@@ -237,7 +237,7 @@ public class EntityInsertAction extends AbstractEntityInsertAction {
 
 	protected boolean preInsert() {
 		final EventListenerGroup<PreInsertEventListener> listenerGroup
-				= getFastSessionServices().eventListenerGroup_PRE_INSERT;
+				= getEventListenerGroups().eventListenerGroup_PRE_INSERT;
 		if ( listenerGroup.isEmpty() ) {
 			return false;
 		}
@@ -298,7 +298,7 @@ public class EntityInsertAction extends AbstractEntityInsertAction {
 	@Override
 	protected boolean hasPostCommitEventListeners() {
 		final EventListenerGroup<PostInsertEventListener> group
-				= getFastSessionServices().eventListenerGroup_POST_COMMIT_INSERT;
+				= getEventListenerGroups().eventListenerGroup_POST_COMMIT_INSERT;
 		for ( PostInsertEventListener listener : group.listeners() ) {
 			if ( listener.requiresPostCommitHandling( getPersister() ) ) {
 				return true;

--- a/hibernate-core/src/main/java/org/hibernate/action/internal/EntityUpdateAction.java
+++ b/hibernate-core/src/main/java/org/hibernate/action/internal/EntityUpdateAction.java
@@ -352,7 +352,7 @@ public class EntityUpdateAction extends EntityAction {
 
 	protected boolean preUpdate() {
 		final EventListenerGroup<PreUpdateEventListener> listenerGroup
-				= getFastSessionServices().eventListenerGroup_PRE_UPDATE;
+				= getEventListenerGroups().eventListenerGroup_PRE_UPDATE;
 		if ( listenerGroup.isEmpty() ) {
 			return false;
 		}
@@ -368,7 +368,7 @@ public class EntityUpdateAction extends EntityAction {
 	}
 
 	protected void postUpdate() {
-		getFastSessionServices().eventListenerGroup_POST_UPDATE
+		getEventListenerGroups().eventListenerGroup_POST_UPDATE
 				.fireLazyEventOnEachListener( this::newPostUpdateEvent, PostUpdateEventListener::onPostUpdate );
 	}
 
@@ -377,7 +377,7 @@ public class EntityUpdateAction extends EntityAction {
 	}
 
 	protected void postCommitUpdate(boolean success) {
-		getFastSessionServices().eventListenerGroup_POST_COMMIT_UPDATE
+		getEventListenerGroups().eventListenerGroup_POST_COMMIT_UPDATE
 				.fireLazyEventOnEachListener( this::newPostUpdateEvent,
 						success ? PostUpdateEventListener::onPostUpdate : this::onPostCommitFailure );
 	}
@@ -395,7 +395,7 @@ public class EntityUpdateAction extends EntityAction {
 	@Override
 	protected boolean hasPostCommitEventListeners() {
 		final EventListenerGroup<PostUpdateEventListener> group
-				= getFastSessionServices().eventListenerGroup_POST_COMMIT_UPDATE;
+				= getEventListenerGroups().eventListenerGroup_POST_COMMIT_UPDATE;
 		for ( PostUpdateEventListener listener : group.listeners() ) {
 			if ( listener.requiresPostCommitHandling( getPersister() ) ) {
 				return true;

--- a/hibernate-core/src/main/java/org/hibernate/boot/internal/BootstrapContextImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/internal/BootstrapContextImpl.java
@@ -35,6 +35,7 @@ import org.hibernate.metamodel.spi.ManagedTypeRepresentationResolver;
 import org.hibernate.query.sqm.function.SqmFunctionDescriptor;
 import org.hibernate.query.sqm.function.SqmFunctionRegistry;
 import org.hibernate.resource.beans.spi.BeanInstanceProducer;
+import org.hibernate.resource.beans.spi.ManagedBeanRegistry;
 import org.hibernate.type.BasicType;
 import org.hibernate.type.spi.TypeConfiguration;
 
@@ -53,8 +54,10 @@ public class BootstrapContextImpl implements BootstrapContext {
 	private final SqmFunctionRegistry sqmFunctionRegistry;
 	private final MutableJpaCompliance jpaCompliance;
 
+	private final ClassLoaderService classLoaderService;
 	private final ClassLoaderAccessImpl classLoaderAccess;
 	private final BeanInstanceProducer beanInstanceProducer;
+	private final ManagedBeanRegistry managedBeanRegistry;
 
 	private boolean isJpaBootstrap;
 
@@ -72,6 +75,7 @@ public class BootstrapContextImpl implements BootstrapContext {
 	private HashMap<Class<?>, ConverterDescriptor> attributeConverterDescriptorMap;
 	private ArrayList<CacheRegionDefinition> cacheRegionDefinitions;
 	private final ManagedTypeRepresentationResolver representationStrategySelector;
+	private ConfigurationService configurationService;
 
 	public BootstrapContextImpl(
 			StandardServiceRegistry serviceRegistry,
@@ -80,7 +84,8 @@ public class BootstrapContextImpl implements BootstrapContext {
 		this.classmateContext = new ClassmateContext();
 		this.metadataBuildingOptions = metadataBuildingOptions;
 
-		this.classLoaderAccess = new ClassLoaderAccessImpl( serviceRegistry.getService( ClassLoaderService.class ) );
+		this.classLoaderService = serviceRegistry.getService( ClassLoaderService.class );
+		this.classLoaderAccess = new ClassLoaderAccessImpl( classLoaderService );
 
 		final StrategySelector strategySelector = serviceRegistry.requireService( StrategySelector.class );
 		final ConfigurationService configService = serviceRegistry.requireService( ConfigurationService.class );
@@ -103,6 +108,9 @@ public class BootstrapContextImpl implements BootstrapContext {
 		this.typeConfiguration = new TypeConfiguration();
 		this.beanInstanceProducer = new TypeBeanInstanceProducer( configService, serviceRegistry );
 		this.sqmFunctionRegistry = new SqmFunctionRegistry();
+
+		this.managedBeanRegistry = serviceRegistry.requireService( ManagedBeanRegistry.class );
+		this.configurationService = serviceRegistry.requireService( ConfigurationService.class );
 	}
 
 	@Override
@@ -133,6 +141,21 @@ public class BootstrapContextImpl implements BootstrapContext {
 	@Override
 	public MetadataBuildingOptions getMetadataBuildingOptions() {
 		return metadataBuildingOptions;
+	}
+
+	@Override
+	public ClassLoaderService getClassLoaderService() {
+		return classLoaderService;
+	}
+
+	@Override
+	public ManagedBeanRegistry getManagedBeanRegistry() {
+		return managedBeanRegistry;
+	}
+
+	@Override
+	public ConfigurationService getConfigurationService() {
+		return configurationService;
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/internal/ClassLoaderAccessImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/internal/ClassLoaderAccessImpl.java
@@ -82,9 +82,9 @@ public class ClassLoaderAccessImpl implements ClassLoaderAccess {
 	private boolean isSafeClass(String name) {
 		// classes in any of these packages are safe to load through the "live" ClassLoader
 		return name.startsWith( "java." )
-				|| name.startsWith( "javax." )
-				|| name.startsWith( "jakarta." )
-				|| name.startsWith( "org.hibernate." );
+			|| name.startsWith( "javax." )
+			|| name.startsWith( "jakarta." )
+			|| name.startsWith( "org.hibernate." );
 
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/boot/internal/InFlightMetadataCollectorImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/internal/InFlightMetadataCollectorImpl.java
@@ -228,7 +228,7 @@ public class InFlightMetadataCollectorImpl
 	}
 
 	private static SourceModelBuildingContext createModelBuildingContext(BootstrapContext bootstrapContext) {
-		final ClassLoaderService classLoaderService = bootstrapContext.getServiceRegistry().getService( ClassLoaderService.class );
+		final ClassLoaderService classLoaderService = bootstrapContext.getClassLoaderService();
 		final ClassLoaderServiceLoading classLoading = new ClassLoaderServiceLoading( classLoaderService );
 
 		final ModelsConfiguration modelsConfiguration = new ModelsConfiguration();

--- a/hibernate-core/src/main/java/org/hibernate/boot/internal/MetadataImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/internal/MetadataImpl.java
@@ -165,24 +165,10 @@ public class MetadataImpl implements MetadataImplementor, Serializable {
 
 	@Override
 	public SessionFactoryBuilder getSessionFactoryBuilder() {
-		final SessionFactoryBuilderImplementor defaultBuilder =
-				metadataBuildingOptions.getServiceRegistry()
-						.requireService( SessionFactoryBuilderService.class )
-						.createSessionFactoryBuilder( this, bootstrapContext );
-		final SessionFactoryBuilder builder = discoverBuilder( defaultBuilder );
-		return builder != null ? builder : defaultBuilder;
-
-	}
-
-	private SessionFactoryBuilder discoverBuilder(SessionFactoryBuilderImplementor defaultBuilder) {
-		final java.util.Collection<SessionFactoryBuilderFactory> discoveredBuilderFactories =
-				metadataBuildingOptions.getServiceRegistry().requireService( ClassLoaderService.class )
-						.loadJavaServices( SessionFactoryBuilderFactory.class );
-
+		final SessionFactoryBuilderImplementor defaultBuilder = getFactoryBuilder();
 		SessionFactoryBuilder builder = null;
 		List<String> activeFactoryNames = null;
-
-		for ( SessionFactoryBuilderFactory discoveredBuilderFactory : discoveredBuilderFactories ) {
+		for ( SessionFactoryBuilderFactory discoveredBuilderFactory : getSessionFactoryBuilderFactories() ) {
 			final SessionFactoryBuilder returnedBuilder =
 					discoveredBuilderFactory.getSessionFactoryBuilder( this, defaultBuilder );
 			if ( returnedBuilder != null ) {
@@ -200,7 +186,22 @@ public class MetadataImpl implements MetadataImplementor, Serializable {
 							join( ", ", activeFactoryNames )
 			);
 		}
-		return builder;
+
+		return builder == null ? defaultBuilder : builder;
+	}
+
+	private Iterable<SessionFactoryBuilderFactory> getSessionFactoryBuilderFactories() {
+		return getClassLoaderService().loadJavaServices( SessionFactoryBuilderFactory.class );
+	}
+
+	private SessionFactoryBuilderImplementor getFactoryBuilder() {
+		return metadataBuildingOptions.getServiceRegistry()
+				.requireService( SessionFactoryBuilderService.class )
+				.createSessionFactoryBuilder( this, bootstrapContext );
+	}
+
+	private ClassLoaderService getClassLoaderService() {
+		return metadataBuildingOptions.getServiceRegistry().requireService( ClassLoaderService.class );
 	}
 
 	@Override
@@ -490,13 +491,10 @@ public class MetadataImpl implements MetadataImplementor, Serializable {
 	public void initSessionFactory(SessionFactoryImplementor sessionFactory) {
 		final ServiceRegistryImplementor sessionFactoryServiceRegistry = sessionFactory.getServiceRegistry();
 		assert sessionFactoryServiceRegistry != null;
+		final ConfigurationService configurationService = bootstrapContext.getConfigurationService();
+		final ClassLoaderService classLoaderService = bootstrapContext.getClassLoaderService();
 		final EventListenerRegistry eventListenerRegistry =
 				sessionFactoryServiceRegistry.requireService( EventListenerRegistry.class );
-		final ConfigurationService configurationService =
-				sessionFactoryServiceRegistry.requireService( ConfigurationService.class );
-		final ClassLoaderService classLoaderService =
-				sessionFactoryServiceRegistry.requireService( ClassLoaderService.class );
-
 		for ( Map.Entry<String,Object> entry : configurationService.getSettings().entrySet() ) {
 			final String propertyName = entry.getKey();
 			if ( propertyName.startsWith( EVENT_LISTENER_PREFIX ) ) {

--- a/hibernate-core/src/main/java/org/hibernate/boot/internal/NamedProcedureCallDefinitionImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/internal/NamedProcedureCallDefinitionImpl.java
@@ -133,9 +133,7 @@ public class NamedProcedureCallDefinitionImpl implements NamedProcedureCallDefin
 	}
 
 	private ResultSetMapping buildResultSetMapping(String registeredName, SessionFactoryImplementor sessionFactory) {
-		return sessionFactory
-				.getFastSessionServices()
-				.getJdbcValuesMappingProducerProvider()
+		return sessionFactory.getJdbcValuesMappingProducerProvider()
 				.buildResultSetMapping( registeredName, false, sessionFactory );
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/boot/internal/SessionFactoryOptionsBuilder.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/internal/SessionFactoryOptionsBuilder.java
@@ -16,10 +16,16 @@ import java.util.TimeZone;
 import java.util.concurrent.Callable;
 import java.util.function.Supplier;
 
+import jakarta.persistence.CacheRetrieveMode;
+import jakarta.persistence.CacheStoreMode;
+import jakarta.persistence.PessimisticLockScope;
+import org.hibernate.CacheMode;
 import org.hibernate.CustomEntityDirtinessStrategy;
 import org.hibernate.EntityNameResolver;
+import org.hibernate.FlushMode;
 import org.hibernate.HibernateException;
 import org.hibernate.Interceptor;
+import org.hibernate.LockOptions;
 import org.hibernate.SessionEventListener;
 import org.hibernate.SessionFactoryObserver;
 import org.hibernate.TimeZoneStorageStrategy;
@@ -50,6 +56,10 @@ import org.hibernate.internal.CoreMessageLogger;
 import org.hibernate.internal.EmptyInterceptor;
 import org.hibernate.internal.util.NullnessHelper;
 import org.hibernate.internal.util.config.ConfigurationHelper;
+import org.hibernate.jpa.HibernateHints;
+import org.hibernate.jpa.LegacySpecHints;
+import org.hibernate.jpa.SpecHints;
+import org.hibernate.jpa.internal.util.CacheModeHelper;
 import org.hibernate.jpa.spi.JpaCompliance;
 import org.hibernate.jpa.spi.MutableJpaCompliance;
 import org.hibernate.proxy.EntityNotFoundDelegate;
@@ -73,57 +83,15 @@ import org.hibernate.type.format.jaxb.JaxbXmlFormatMapper;
 
 import jakarta.persistence.criteria.Nulls;
 
-import static org.hibernate.cfg.AvailableSettings.ALLOW_JTA_TRANSACTION_ACCESS;
-import static org.hibernate.cfg.AvailableSettings.ALLOW_UPDATE_OUTSIDE_TRANSACTION;
-import static org.hibernate.cfg.AvailableSettings.AUTO_CLOSE_SESSION;
-import static org.hibernate.cfg.AvailableSettings.AUTO_EVICT_COLLECTION_CACHE;
-import static org.hibernate.cfg.AvailableSettings.AUTO_SESSION_EVENTS_LISTENER;
-import static org.hibernate.cfg.AvailableSettings.BATCH_VERSIONED_DATA;
-import static org.hibernate.cfg.AvailableSettings.CACHE_REGION_PREFIX;
-import static org.hibernate.cfg.AvailableSettings.CALLABLE_NAMED_PARAMS_ENABLED;
-import static org.hibernate.cfg.AvailableSettings.CHECK_NULLABILITY;
-import static org.hibernate.cfg.AvailableSettings.CONNECTION_HANDLING;
-import static org.hibernate.cfg.AvailableSettings.CRITERIA_VALUE_HANDLING_MODE;
-import static org.hibernate.cfg.AvailableSettings.CUSTOM_ENTITY_DIRTINESS_STRATEGY;
-import static org.hibernate.cfg.AvailableSettings.DEFAULT_BATCH_FETCH_SIZE;
-import static org.hibernate.cfg.AvailableSettings.DEFAULT_CATALOG;
-import static org.hibernate.cfg.AvailableSettings.DEFAULT_SCHEMA;
-import static org.hibernate.cfg.AvailableSettings.DELAY_ENTITY_LOADER_CREATIONS;
-import static org.hibernate.cfg.AvailableSettings.DISCARD_PC_ON_CLOSE;
-import static org.hibernate.cfg.AvailableSettings.ENABLE_LAZY_LOAD_NO_TRANS;
-import static org.hibernate.cfg.AvailableSettings.FAIL_ON_PAGINATION_OVER_COLLECTION_FETCH;
-import static org.hibernate.cfg.AvailableSettings.FLUSH_BEFORE_COMPLETION;
-import static org.hibernate.cfg.AvailableSettings.GENERATE_STATISTICS;
-import static org.hibernate.cfg.AvailableSettings.IMMUTABLE_ENTITY_UPDATE_QUERY_HANDLING_MODE;
-import static org.hibernate.cfg.AvailableSettings.INTERCEPTOR;
-import static org.hibernate.cfg.AvailableSettings.IN_CLAUSE_PARAMETER_PADDING;
-import static org.hibernate.cfg.AvailableSettings.JDBC_TIME_ZONE;
-import static org.hibernate.cfg.AvailableSettings.JPA_CALLBACKS_ENABLED;
-import static org.hibernate.cfg.AvailableSettings.JTA_TRACK_BY_THREAD;
-import static org.hibernate.cfg.AvailableSettings.MAX_FETCH_DEPTH;
-import static org.hibernate.cfg.AvailableSettings.MULTI_TENANT_IDENTIFIER_RESOLVER;
-import static org.hibernate.cfg.AvailableSettings.ORDER_INSERTS;
-import static org.hibernate.cfg.AvailableSettings.ORDER_UPDATES;
-import static org.hibernate.cfg.AvailableSettings.PREFER_USER_TRANSACTION;
-import static org.hibernate.cfg.AvailableSettings.QUERY_CACHE_FACTORY;
-import static org.hibernate.cfg.AvailableSettings.QUERY_STARTUP_CHECKING;
-import static org.hibernate.cfg.AvailableSettings.QUERY_STATISTICS_MAX_SIZE;
-import static org.hibernate.cfg.AvailableSettings.SESSION_FACTORY_NAME;
-import static org.hibernate.cfg.AvailableSettings.SESSION_FACTORY_NAME_IS_JNDI;
-import static org.hibernate.cfg.AvailableSettings.SESSION_SCOPED_INTERCEPTOR;
-import static org.hibernate.cfg.AvailableSettings.STATEMENT_BATCH_SIZE;
-import static org.hibernate.cfg.AvailableSettings.STATEMENT_FETCH_SIZE;
-import static org.hibernate.cfg.AvailableSettings.STATEMENT_INSPECTOR;
-import static org.hibernate.cfg.AvailableSettings.USE_DIRECT_REFERENCE_CACHE_ENTRIES;
-import static org.hibernate.cfg.AvailableSettings.USE_GET_GENERATED_KEYS;
-import static org.hibernate.cfg.AvailableSettings.USE_IDENTIFIER_ROLLBACK;
-import static org.hibernate.cfg.AvailableSettings.USE_MINIMAL_PUTS;
-import static org.hibernate.cfg.AvailableSettings.USE_QUERY_CACHE;
-import static org.hibernate.cfg.AvailableSettings.USE_SCROLLABLE_RESULTSET;
-import static org.hibernate.cfg.AvailableSettings.USE_SECOND_LEVEL_CACHE;
-import static org.hibernate.cfg.AvailableSettings.USE_SQL_COMMENTS;
-import static org.hibernate.cfg.AvailableSettings.USE_STRUCTURED_CACHE;
-import static org.hibernate.cfg.AvailableSettings.USE_SUBSELECT_FETCH;
+import static java.util.Collections.unmodifiableMap;
+import static org.hibernate.cfg.AvailableSettings.*;
+import static org.hibernate.cfg.AvailableSettings.JAKARTA_LOCK_SCOPE;
+import static org.hibernate.cfg.AvailableSettings.JAKARTA_LOCK_TIMEOUT;
+import static org.hibernate.cfg.AvailableSettings.JPA_LOCK_TIMEOUT;
+import static org.hibernate.cfg.CacheSettings.JAKARTA_SHARED_CACHE_RETRIEVE_MODE;
+import static org.hibernate.cfg.CacheSettings.JAKARTA_SHARED_CACHE_STORE_MODE;
+import static org.hibernate.cfg.CacheSettings.JPA_SHARED_CACHE_RETRIEVE_MODE;
+import static org.hibernate.cfg.CacheSettings.JPA_SHARED_CACHE_STORE_MODE;
 import static org.hibernate.cfg.CacheSettings.QUERY_CACHE_LAYOUT;
 import static org.hibernate.cfg.PersistenceSettings.UNOWNED_ASSOCIATION_TRANSIENT_CHECK;
 import static org.hibernate.cfg.QuerySettings.DEFAULT_NULL_ORDERING;
@@ -132,6 +100,7 @@ import static org.hibernate.cfg.QuerySettings.PORTABLE_INTEGER_DIVISION;
 import static org.hibernate.cfg.QuerySettings.XML_FUNCTIONS_ENABLED;
 import static org.hibernate.engine.config.spi.StandardConverters.BOOLEAN;
 import static org.hibernate.internal.CoreLogging.messageLogger;
+import static org.hibernate.internal.LockOptionsHelper.applyPropertiesToLockOptions;
 import static org.hibernate.internal.log.DeprecationLogger.DEPRECATION_LOGGER;
 import static org.hibernate.internal.util.PropertiesHelper.map;
 import static org.hibernate.internal.util.StringHelper.isEmpty;
@@ -140,6 +109,7 @@ import static org.hibernate.internal.util.config.ConfigurationHelper.getBoolean;
 import static org.hibernate.internal.util.config.ConfigurationHelper.getInt;
 import static org.hibernate.internal.util.config.ConfigurationHelper.getInteger;
 import static org.hibernate.internal.util.config.ConfigurationHelper.getString;
+import static org.hibernate.jpa.internal.util.CacheModeHelper.interpretCacheMode;
 import static org.hibernate.type.format.jackson.JacksonIntegration.getJsonJacksonFormatMapperOrNull;
 import static org.hibernate.type.format.jackson.JacksonIntegration.getXMLJacksonFormatMapperOrNull;
 import static org.hibernate.type.format.jakartajson.JakartaJsonIntegration.getJakartaJsonBFormatMapperOrNull;
@@ -283,6 +253,12 @@ public class SessionFactoryOptionsBuilder implements SessionFactoryOptions {
 
 	private final int queryStatisticsMaxSize;
 
+	private final Map<String, Object> defaultSessionProperties;
+	private final CacheStoreMode defaultCacheStoreMode;
+	private final CacheRetrieveMode defaultCacheRetrieveMode;
+	private final CacheMode initialSessionCacheMode;
+	private final FlushMode initialSessionFlushMode;
+	private final LockOptions defaultLockOptions;
 
 	@SuppressWarnings( "unchecked" )
 	public SessionFactoryOptionsBuilder(StandardServiceRegistry serviceRegistry, BootstrapContext context) {
@@ -295,14 +271,14 @@ public class SessionFactoryOptionsBuilder implements SessionFactoryOptions {
 
 		final Dialect dialect = jdbcServices.getJdbcEnvironment().getDialect();
 
-		final Map<String,Object> configurationSettings = new HashMap<>();
-		configurationSettings.putAll( map( dialect.getDefaultProperties() ) );
-		configurationSettings.putAll( configurationService.getSettings() );
+		final Map<String,Object> settings = new HashMap<>();
+		settings.putAll( map( dialect.getDefaultProperties() ) );
+		settings.putAll( configurationService.getSettings() );
 
 		this.beanManagerReference = NullnessHelper.coalesceSuppliedValues(
-				() -> configurationSettings.get( AvailableSettings.JAKARTA_CDI_BEAN_MANAGER ),
+				() -> settings.get( AvailableSettings.JAKARTA_CDI_BEAN_MANAGER ),
 				() -> {
-					final Object value = configurationSettings.get( AvailableSettings.CDI_BEAN_MANAGER );
+					final Object value = settings.get( AvailableSettings.CDI_BEAN_MANAGER );
 					if ( value != null ) {
 						DEPRECATION_LOGGER.deprecatedSetting(
 								AvailableSettings.CDI_BEAN_MANAGER,
@@ -313,67 +289,66 @@ public class SessionFactoryOptionsBuilder implements SessionFactoryOptions {
 				}
 		);
 
-		this.validatorFactoryReference = configurationSettings.getOrDefault(
+		this.validatorFactoryReference = settings.getOrDefault(
 				AvailableSettings.JPA_VALIDATION_FACTORY,
-				configurationSettings.get( AvailableSettings.JAKARTA_VALIDATION_FACTORY )
+				settings.get( AvailableSettings.JAKARTA_VALIDATION_FACTORY )
 		);
+
 		this.jsonFormatMapper = determineJsonFormatMapper(
-				configurationSettings.get( AvailableSettings.JSON_FORMAT_MAPPER ),
+				settings.get( AvailableSettings.JSON_FORMAT_MAPPER ),
 				strategySelector
 		);
 		this.xmlFormatMapper = determineXmlFormatMapper(
-				configurationSettings.get( AvailableSettings.XML_FORMAT_MAPPER ),
+				settings.get( AvailableSettings.XML_FORMAT_MAPPER ),
 				strategySelector,
-				this.xmlFormatMapperLegacyFormatEnabled = context.getMetadataBuildingOptions().isXmlFormatMapperLegacyFormatEnabled()
+				this.xmlFormatMapperLegacyFormatEnabled =
+						context.getMetadataBuildingOptions().isXmlFormatMapperLegacyFormatEnabled()
 		);
 
-		this.sessionFactoryName = (String) configurationSettings.get( SESSION_FACTORY_NAME );
-		this.sessionFactoryNameAlsoJndiName = configurationService.getSetting(
-				SESSION_FACTORY_NAME_IS_JNDI,
-				BOOLEAN,
-				true
-		);
-		this.jtaTransactionAccessEnabled = configurationService.getSetting(
-				ALLOW_JTA_TRANSACTION_ACCESS,
-				BOOLEAN,
-				true
-		);
+		this.sessionFactoryName = (String) settings.get( SESSION_FACTORY_NAME );
+		this.sessionFactoryNameAlsoJndiName =
+				configurationService.getSetting( SESSION_FACTORY_NAME_IS_JNDI, BOOLEAN, true );
+		this.jtaTransactionAccessEnabled =
+				configurationService.getSetting( ALLOW_JTA_TRANSACTION_ACCESS, BOOLEAN, true );
 
-		this.flushBeforeCompletionEnabled = configurationService.getSetting( FLUSH_BEFORE_COMPLETION, BOOLEAN, true );
-		this.autoCloseSessionEnabled = configurationService.getSetting( AUTO_CLOSE_SESSION, BOOLEAN, false );
+		this.flushBeforeCompletionEnabled =
+				configurationService.getSetting( FLUSH_BEFORE_COMPLETION, BOOLEAN, true );
+		this.autoCloseSessionEnabled =
+				configurationService.getSetting( AUTO_CLOSE_SESSION, BOOLEAN, false );
 
-		this.statisticsEnabled = configurationService.getSetting( GENERATE_STATISTICS, BOOLEAN, false );
-		this.interceptor = determineInterceptor( configurationSettings, strategySelector );
-		this.statelessInterceptorSupplier = determineStatelessInterceptor( configurationSettings, strategySelector );
-		this.statementInspector = strategySelector.resolveStrategy(
-				StatementInspector.class,
-				configurationSettings.get( STATEMENT_INSPECTOR )
-		);
+		this.statisticsEnabled =
+				configurationService.getSetting( GENERATE_STATISTICS, BOOLEAN, false );
 
-		// todo : expose this from builder?
-		final String autoSessionEventsListenerName = (String) configurationSettings.get( AUTO_SESSION_EVENTS_LISTENER );
-		final Class<? extends SessionEventListener> autoSessionEventsListener = autoSessionEventsListenerName == null
-				? null
-				: strategySelector.selectStrategyImplementor( SessionEventListener.class, autoSessionEventsListenerName );
+		this.interceptor = determineInterceptor( settings, strategySelector );
+		this.statelessInterceptorSupplier = determineStatelessInterceptor( settings, strategySelector );
 
-		this.baselineSessionEventsListenerBuilder = new BaselineSessionEventsListenerBuilder( autoSessionEventsListener );
+		this.statementInspector =
+				strategySelector.resolveStrategy( StatementInspector.class,
+						settings.get( STATEMENT_INSPECTOR ) );
 
-		this.customEntityDirtinessStrategy = strategySelector.resolveDefaultableStrategy(
-				CustomEntityDirtinessStrategy.class,
-				configurationSettings.get( CUSTOM_ENTITY_DIRTINESS_STRATEGY ),
-				DefaultCustomEntityDirtinessStrategy.INSTANCE
-		);
+
+		this.baselineSessionEventsListenerBuilder =
+				new BaselineSessionEventsListenerBuilder(
+						getAutoSessionEventsListener( settings, strategySelector ) );
+
+		this.customEntityDirtinessStrategy =
+				strategySelector.resolveDefaultableStrategy( CustomEntityDirtinessStrategy.class,
+						settings.get( CUSTOM_ENTITY_DIRTINESS_STRATEGY ),
+						DefaultCustomEntityDirtinessStrategy.INSTANCE );
 
 		this.entityNotFoundDelegate = StandardEntityNotFoundDelegate.INSTANCE;
-		this.identifierRollbackEnabled = configurationService.getSetting( USE_IDENTIFIER_ROLLBACK, BOOLEAN, false );
-		this.checkNullability = configurationService.getSetting( CHECK_NULLABILITY, BOOLEAN, true );
-		this.initializeLazyStateOutsideTransactions = configurationService.getSetting( ENABLE_LAZY_LOAD_NO_TRANS, BOOLEAN, false );
+
+		this.identifierRollbackEnabled =
+				configurationService.getSetting( USE_IDENTIFIER_ROLLBACK, BOOLEAN, false );
+		this.checkNullability =
+				configurationService.getSetting( CHECK_NULLABILITY, BOOLEAN, true );
+		this.initializeLazyStateOutsideTransactions =
+				configurationService.getSetting( ENABLE_LAZY_LOAD_NO_TRANS, BOOLEAN, false );
 
 		this.multiTenancyEnabled = JdbcEnvironmentImpl.isMultiTenancyEnabled( serviceRegistry );
-		this.currentTenantIdentifierResolver = strategySelector.resolveStrategy(
-				CurrentTenantIdentifierResolver.class,
-				configurationSettings.get( MULTI_TENANT_IDENTIFIER_RESOLVER )
-		);
+		this.currentTenantIdentifierResolver =
+				strategySelector.resolveStrategy( CurrentTenantIdentifierResolver.class,
+						settings.get( MULTI_TENANT_IDENTIFIER_RESOLVER ) );
 		if ( this.currentTenantIdentifierResolver == null ) {
 			this.currentTenantIdentifierResolver = Helper.getBean(
 				Helper.getBeanContainer( serviceRegistry ),
@@ -384,78 +359,45 @@ public class SessionFactoryOptionsBuilder implements SessionFactoryOptions {
 			);
 		}
 
-		this.delayBatchFetchLoaderCreations = configurationService.getSetting( DELAY_ENTITY_LOADER_CREATIONS, BOOLEAN, true );
-		this.defaultBatchFetchSize = getInt( DEFAULT_BATCH_FETCH_SIZE, configurationSettings, -1 );
-		this.subselectFetchEnabled = getBoolean( USE_SUBSELECT_FETCH, configurationSettings );
-		this.maximumFetchDepth = getInteger( MAX_FETCH_DEPTH, configurationSettings );
+		this.delayBatchFetchLoaderCreations =
+				configurationService.getSetting( DELAY_ENTITY_LOADER_CREATIONS, BOOLEAN, true );
 
-		final Object defaultNullPrecedence = configurationSettings.get( DEFAULT_NULL_ORDERING );
-		if ( defaultNullPrecedence instanceof Nulls jpaValue ) {
-			this.defaultNullPrecedence = jpaValue;
-		}
-		else if ( defaultNullPrecedence instanceof NullPrecedence hibernateValue ) {
-			this.defaultNullPrecedence = hibernateValue.getJpaValue();
-		}
-		else if ( defaultNullPrecedence instanceof String ) {
-			this.defaultNullPrecedence = NullPrecedenceHelper.parse( (String) defaultNullPrecedence );
-		}
-		else if ( defaultNullPrecedence != null ) {
-			throw new IllegalArgumentException( "Configuration property " + DEFAULT_NULL_ORDERING
-					+ " value [" + defaultNullPrecedence + "] is not supported" );
-		}
-		this.orderUpdatesEnabled = getBoolean( ORDER_UPDATES, configurationSettings );
-		this.orderInsertsEnabled = getBoolean( ORDER_INSERTS, configurationSettings );
+		this.defaultBatchFetchSize = getInt( DEFAULT_BATCH_FETCH_SIZE, settings, -1 );
+		this.subselectFetchEnabled = getBoolean( USE_SUBSELECT_FETCH, settings );
+		this.maximumFetchDepth = getInteger( MAX_FETCH_DEPTH, settings );
 
-		this.callbacksEnabled = getBoolean( JPA_CALLBACKS_ENABLED, configurationSettings, true );
+		this.defaultNullPrecedence = getDefaultNullPrecedence( settings.get( DEFAULT_NULL_ORDERING ) );
+
+		this.orderUpdatesEnabled = getBoolean( ORDER_UPDATES, settings );
+		this.orderInsertsEnabled = getBoolean( ORDER_INSERTS, settings );
+
+		this.callbacksEnabled = getBoolean( JPA_CALLBACKS_ENABLED, settings, true );
 
 		this.jtaTrackByThread = configurationService.getSetting( JTA_TRACK_BY_THREAD, BOOLEAN, true );
 
-		final String hqlTranslatorImplFqn = extractPropertyValue(
-				AvailableSettings.SEMANTIC_QUERY_PRODUCER,
-				configurationSettings
-		);
-		this.hqlTranslator = resolveHqlTranslator(
-				hqlTranslatorImplFqn,
-				serviceRegistry,
-				strategySelector
-		);
+		final String hqlTranslatorImplFqn =
+				extractPropertyValue( AvailableSettings.SEMANTIC_QUERY_PRODUCER, settings );
+		this.hqlTranslator = resolveHqlTranslator( hqlTranslatorImplFqn, serviceRegistry, strategySelector );
 
-		final String sqmTranslatorFactoryImplFqn = extractPropertyValue(
-				AvailableSettings.SEMANTIC_QUERY_TRANSLATOR,
-				configurationSettings
-		);
-		this.sqmTranslatorFactory = resolveSqmTranslator(
-				sqmTranslatorFactoryImplFqn,
-				strategySelector
-		);
+		final String sqmTranslatorFactoryImplFqn =
+				extractPropertyValue( AvailableSettings.SEMANTIC_QUERY_TRANSLATOR, settings );
+		this.sqmTranslatorFactory = resolveSqmTranslator( sqmTranslatorFactoryImplFqn, strategySelector );
 
+		final String sqmMutationStrategyImplName =
+				extractPropertyValue( AvailableSettings.QUERY_MULTI_TABLE_MUTATION_STRATEGY, settings );
+		this.sqmMultiTableMutationStrategy =
+				resolveSqmMutationStrategy( sqmMutationStrategyImplName, serviceRegistry, strategySelector );
+		final String sqmInsertStrategyImplName =
+				extractPropertyValue( AvailableSettings.QUERY_MULTI_TABLE_INSERT_STRATEGY, settings );
+		this.sqmMultiTableInsertStrategy =
+				resolveSqmInsertStrategy( sqmInsertStrategyImplName, serviceRegistry, strategySelector );
 
-		final String sqmMutationStrategyImplName = extractPropertyValue(
-				AvailableSettings.QUERY_MULTI_TABLE_MUTATION_STRATEGY,
-				configurationSettings
-		);
+		this.useOfJdbcNamedParametersEnabled =
+				configurationService.getSetting( CALLABLE_NAMED_PARAMS_ENABLED, BOOLEAN, true );
 
-		this.sqmMultiTableMutationStrategy = resolveSqmMutationStrategy(
-				sqmMutationStrategyImplName,
-				serviceRegistry,
-				strategySelector
-		);
+		this.namedQueryStartupCheckingEnabled =
+				configurationService.getSetting( QUERY_STARTUP_CHECKING, BOOLEAN, true );
 
-		final String sqmInsertStrategyImplName = ConfigurationHelper.extractValue(
-				AvailableSettings.QUERY_MULTI_TABLE_INSERT_STRATEGY,
-				configurationSettings,
-				() -> null
-		);
-
-		this.sqmMultiTableInsertStrategy = resolveSqmInsertStrategy(
-				sqmInsertStrategyImplName,
-				serviceRegistry,
-				strategySelector
-		);
-
-		this.useOfJdbcNamedParametersEnabled = configurationService.getSetting( CALLABLE_NAMED_PARAMS_ENABLED, BOOLEAN, true );
-
-		this.namedQueryStartupCheckingEnabled = configurationService.getSetting( QUERY_STARTUP_CHECKING, BOOLEAN, true );
 		this.preferJavaTimeJdbcTypes = MetadataBuildingContext.isPreferJavaTimeJdbcTypesEnabled( configurationService );
 		this.preferNativeEnumTypes = MetadataBuildingContext.isPreferNativeEnumTypesEnabled( configurationService );
 		this.preferredSqlTypeCodeForBoolean = ConfigurationHelper.getPreferredSqlTypeCodeForBoolean( serviceRegistry );
@@ -467,34 +409,26 @@ public class SessionFactoryOptionsBuilder implements SessionFactoryOptions {
 
 		final RegionFactory regionFactory = serviceRegistry.getService( RegionFactory.class );
 		if ( !(regionFactory instanceof NoCachingRegionFactory) ) {
-			this.secondLevelCacheEnabled = configurationService.getSetting( USE_SECOND_LEVEL_CACHE, BOOLEAN, true );
-			this.queryCacheEnabled = configurationService.getSetting( USE_QUERY_CACHE, BOOLEAN, false );
-			this.queryCacheLayout = configurationService.getSetting(
-					QUERY_CACHE_LAYOUT,
-					value -> CacheLayout.valueOf( value.toString().toUpperCase( Locale.ROOT ) ),
-					CacheLayout.FULL
-			);
-			this.timestampsCacheFactory = strategySelector.resolveDefaultableStrategy(
-					TimestampsCacheFactory.class,
-					configurationSettings.get( QUERY_CACHE_FACTORY ),
-					StandardTimestampsCacheFactory.INSTANCE
-			);
-			this.cacheRegionPrefix = extractPropertyValue(
-					CACHE_REGION_PREFIX,
-					configurationSettings
-			);
-			this.minimalPutsEnabled = configurationService.getSetting(
-					USE_MINIMAL_PUTS,
-					BOOLEAN,
-					regionFactory.isMinimalPutsEnabledByDefault()
-			);
-			this.structuredCacheEntriesEnabled = configurationService.getSetting( USE_STRUCTURED_CACHE, BOOLEAN, false );
-			this.directReferenceCacheEntriesEnabled = configurationService.getSetting(
-					USE_DIRECT_REFERENCE_CACHE_ENTRIES,
-					BOOLEAN,
-					false
-			);
-			this.autoEvictCollectionCache = configurationService.getSetting( AUTO_EVICT_COLLECTION_CACHE, BOOLEAN, false );
+			this.secondLevelCacheEnabled =
+					configurationService.getSetting( USE_SECOND_LEVEL_CACHE, BOOLEAN, true );
+			this.queryCacheEnabled =
+					configurationService.getSetting( USE_QUERY_CACHE, BOOLEAN, false );
+			this.cacheRegionPrefix = extractPropertyValue( CACHE_REGION_PREFIX, settings );
+			this.queryCacheLayout =
+					configurationService.getSetting( QUERY_CACHE_LAYOUT,
+							value -> CacheLayout.valueOf( value.toString().toUpperCase( Locale.ROOT ) ),
+							CacheLayout.FULL );
+			this.timestampsCacheFactory =
+					strategySelector.resolveDefaultableStrategy( TimestampsCacheFactory.class,
+							settings.get( QUERY_CACHE_FACTORY ), StandardTimestampsCacheFactory.INSTANCE );
+			this.minimalPutsEnabled =
+					configurationService.getSetting( USE_MINIMAL_PUTS, BOOLEAN, regionFactory.isMinimalPutsEnabledByDefault() );
+			this.structuredCacheEntriesEnabled =
+					configurationService.getSetting( USE_STRUCTURED_CACHE, BOOLEAN, false );
+			this.directReferenceCacheEntriesEnabled =
+					configurationService.getSetting( USE_DIRECT_REFERENCE_CACHE_ENTRIES, BOOLEAN, false );
+			this.autoEvictCollectionCache =
+					configurationService.getSetting( AUTO_EVICT_COLLECTION_CACHE, BOOLEAN, false );
 		}
 		else {
 			this.secondLevelCacheEnabled = false;
@@ -509,156 +443,144 @@ public class SessionFactoryOptionsBuilder implements SessionFactoryOptions {
 		}
 
 		try {
-			this.schemaAutoTooling = SchemaAutoTooling.interpret( (String) configurationSettings.get( AvailableSettings.HBM2DDL_AUTO ) );
+			this.schemaAutoTooling =
+					SchemaAutoTooling.interpret( (String) settings.get( AvailableSettings.HBM2DDL_AUTO ) );
 		}
 		catch (Exception e) {
 			log.warn( e.getMessage() + "  Ignoring" );
 		}
 
-
 		final ExtractedDatabaseMetaData meta = jdbcServices.getExtractedMetaDataSupport();
-
-		this.tempTableDdlTransactionHandling = TempTableDdlTransactionHandling.NONE;
 		if ( meta.doesDataDefinitionCauseTransactionCommit() ) {
-			if ( meta.supportsDataDefinitionInTransaction() ) {
-				this.tempTableDdlTransactionHandling = TempTableDdlTransactionHandling.ISOLATE_AND_TRANSACT;
-			}
-			else {
-				this.tempTableDdlTransactionHandling = TempTableDdlTransactionHandling.ISOLATE;
-			}
+			this.tempTableDdlTransactionHandling =
+					meta.supportsDataDefinitionInTransaction()
+							? TempTableDdlTransactionHandling.ISOLATE_AND_TRANSACT
+							: TempTableDdlTransactionHandling.ISOLATE;
+		}
+		else {
+			this.tempTableDdlTransactionHandling = TempTableDdlTransactionHandling.NONE;
 		}
 
-		this.jdbcBatchSize = getInt( STATEMENT_BATCH_SIZE, configurationSettings, 1 );
-		if ( disallowBatchUpdates( dialect, meta ) ) {
-			this.jdbcBatchSize = 0;
-		}
+		this.jdbcBatchSize = disallowBatchUpdates( dialect, meta ) ? 0
+				: getInt( STATEMENT_BATCH_SIZE, settings, 1 );
 
-		this.jdbcBatchVersionedData = getBoolean( BATCH_VERSIONED_DATA, configurationSettings, true );
-		this.scrollableResultSetsEnabled = getBoolean(
-				USE_SCROLLABLE_RESULTSET,
-				configurationSettings,
-				meta.supportsScrollableResults()
-		);
-		this.getGeneratedKeysEnabled = getBoolean(
-				USE_GET_GENERATED_KEYS,
-				configurationSettings,
-				meta.supportsGetGeneratedKeys()
-		);
-		this.jdbcFetchSize = getInteger( STATEMENT_FETCH_SIZE, configurationSettings );
+		this.jdbcBatchVersionedData = getBoolean( BATCH_VERSIONED_DATA, settings, true );
 
-		this.connectionHandlingMode = interpretConnectionHandlingMode( configurationSettings, serviceRegistry );
-		this.connectionProviderDisablesAutoCommit = getBoolean(
-				AvailableSettings.CONNECTION_PROVIDER_DISABLES_AUTOCOMMIT,
-				configurationSettings,
-				false
-		);
+		this.scrollableResultSetsEnabled =
+				getBoolean( USE_SCROLLABLE_RESULTSET, settings, meta.supportsScrollableResults() );
+		this.getGeneratedKeysEnabled =
+				getBoolean( USE_GET_GENERATED_KEYS, settings, meta.supportsGetGeneratedKeys() );
 
-		this.commentsEnabled = getBoolean( USE_SQL_COMMENTS, configurationSettings );
+		this.jdbcFetchSize = getInteger( STATEMENT_FETCH_SIZE, settings );
 
-		this.preferUserTransaction = getBoolean( PREFER_USER_TRANSACTION, configurationSettings  );
+		this.connectionHandlingMode = interpretConnectionHandlingMode( settings, serviceRegistry );
 
-		this.allowOutOfTransactionUpdateOperations = getBoolean(
-				ALLOW_UPDATE_OUTSIDE_TRANSACTION,
-				configurationSettings
-		);
+		this.connectionProviderDisablesAutoCommit =
+				getBoolean( AvailableSettings.CONNECTION_PROVIDER_DISABLES_AUTOCOMMIT, settings, false );
 
-		this.releaseResourcesOnCloseEnabled = getBoolean(
-				DISCARD_PC_ON_CLOSE,
-				configurationSettings
-		);
+		this.commentsEnabled = getBoolean( USE_SQL_COMMENTS, settings );
 
-		Object jdbcTimeZoneValue = configurationSettings.get(
-				JDBC_TIME_ZONE
-		);
+		this.preferUserTransaction = getBoolean( PREFER_USER_TRANSACTION, settings  );
 
-		if ( jdbcTimeZoneValue instanceof TimeZone timeZone ) {
-			this.jdbcTimeZone = timeZone;
-		}
-		else if ( jdbcTimeZoneValue instanceof ZoneId zoneId ) {
-			this.jdbcTimeZone = TimeZone.getTimeZone( zoneId );
-		}
-		else if ( jdbcTimeZoneValue instanceof String string ) {
-			this.jdbcTimeZone = TimeZone.getTimeZone( ZoneId.of( string ) );
-		}
-		else if ( jdbcTimeZoneValue != null ) {
-			throw new IllegalArgumentException( "Configuration property " + JDBC_TIME_ZONE
-					+ " value [" + jdbcTimeZoneValue + "] is not supported" );
-		}
+		this.allowOutOfTransactionUpdateOperations = getBoolean( ALLOW_UPDATE_OUTSIDE_TRANSACTION, settings );
 
-		this.criteriaValueHandlingMode = ValueHandlingMode.interpret(
-				configurationSettings.get( CRITERIA_VALUE_HANDLING_MODE )
-		);
-		this.criteriaCopyTreeEnabled = getBoolean(
-				AvailableSettings.CRITERIA_COPY_TREE,
-				configurationSettings,
-				jpaBootstrap
-		);
+		this.releaseResourcesOnCloseEnabled = getBoolean( DISCARD_PC_ON_CLOSE, settings );
 
-		this.nativeJdbcParametersIgnored = getBoolean(
-				AvailableSettings.NATIVE_IGNORE_JDBC_PARAMETERS,
-				configurationSettings,
-				false
-		);
+		this.jdbcTimeZone = getJdbcTimeZone( settings.get( JDBC_TIME_ZONE ) );
+
+		this.criteriaValueHandlingMode = ValueHandlingMode.interpret( settings.get( CRITERIA_VALUE_HANDLING_MODE ) );
+		this.criteriaCopyTreeEnabled = getBoolean( AvailableSettings.CRITERIA_COPY_TREE, settings, jpaBootstrap );
+
+		this.nativeJdbcParametersIgnored =
+				getBoolean( AvailableSettings.NATIVE_IGNORE_JDBC_PARAMETERS, settings, false );
 
 		// added the boolean parameter in case we want to define some form of "all" as discussed
 		this.jpaCompliance = context.getJpaCompliance();
 
-		this.failOnPaginationOverCollectionFetchEnabled = getBoolean(
-				FAIL_ON_PAGINATION_OVER_COLLECTION_FETCH,
-				configurationSettings
-		);
+		this.failOnPaginationOverCollectionFetchEnabled =
+				getBoolean( FAIL_ON_PAGINATION_OVER_COLLECTION_FETCH, settings );
 
-		this.immutableEntityUpdateQueryHandlingMode = ImmutableEntityUpdateQueryHandlingMode.interpret(
-				configurationSettings.get( IMMUTABLE_ENTITY_UPDATE_QUERY_HANDLING_MODE )
-		);
+		this.immutableEntityUpdateQueryHandlingMode =
+				ImmutableEntityUpdateQueryHandlingMode.interpret(
+						settings.get( IMMUTABLE_ENTITY_UPDATE_QUERY_HANDLING_MODE ) );
 
-		this.defaultCatalog = getString( DEFAULT_CATALOG, configurationSettings );
-		this.defaultSchema = getString( DEFAULT_SCHEMA, configurationSettings );
+		this.defaultCatalog = getString( DEFAULT_CATALOG, settings );
+		this.defaultSchema = getString( DEFAULT_SCHEMA, settings );
 
-		this.inClauseParameterPaddingEnabled = getBoolean(
-				IN_CLAUSE_PARAMETER_PADDING,
-				configurationSettings
-		);
+		this.inClauseParameterPaddingEnabled = getBoolean( IN_CLAUSE_PARAMETER_PADDING, settings );
 
-		this.portableIntegerDivisionEnabled = getBoolean(
-				PORTABLE_INTEGER_DIVISION,
-				configurationSettings
-		);
-		this.jsonFunctionsEnabled = getBoolean(
-				JSON_FUNCTIONS_ENABLED,
-				configurationSettings
-		);
-		this.xmlFunctionsEnabled = getBoolean(
-				XML_FUNCTIONS_ENABLED,
-				configurationSettings
-		);
+		this.portableIntegerDivisionEnabled = getBoolean( PORTABLE_INTEGER_DIVISION, settings );
 
-		this.queryStatisticsMaxSize = getInt(
-				QUERY_STATISTICS_MAX_SIZE,
-				configurationSettings,
-				Statistics.DEFAULT_QUERY_STATISTICS_MAX_SIZE
-		);
+		this.jsonFunctionsEnabled = getBoolean( JSON_FUNCTIONS_ENABLED, settings );
+		this.xmlFunctionsEnabled = getBoolean( XML_FUNCTIONS_ENABLED, settings );
 
-		this.unownedAssociationTransientCheck = getBoolean(
-				UNOWNED_ASSOCIATION_TRANSIENT_CHECK,
-				configurationSettings,
-				isJpaBootstrap()
-		);
+		this.queryStatisticsMaxSize =
+				getInt( QUERY_STATISTICS_MAX_SIZE, settings, Statistics.DEFAULT_QUERY_STATISTICS_MAX_SIZE );
 
-		this.passProcedureParameterNames = ConfigurationHelper.getBoolean(
-				AvailableSettings.QUERY_PASS_PROCEDURE_PARAMETER_NAMES,
-				configurationSettings,
-				false
-		);
+		this.unownedAssociationTransientCheck =
+				getBoolean( UNOWNED_ASSOCIATION_TRANSIENT_CHECK, settings, isJpaBootstrap() );
 
-		this.preferJdbcDatetimeTypes = ConfigurationHelper.getBoolean(
-				AvailableSettings.NATIVE_PREFER_JDBC_DATETIME_TYPES,
-				configurationSettings,
-				false
-		);
+		this.passProcedureParameterNames =
+				getBoolean( AvailableSettings.QUERY_PASS_PROCEDURE_PARAMETER_NAMES, settings, false );
+
+		this.preferJdbcDatetimeTypes =
+				getBoolean( AvailableSettings.NATIVE_PREFER_JDBC_DATETIME_TYPES, settings, false );
+
+		this.defaultSessionProperties = initializeDefaultSessionProperties( configurationService );
+
+		this.defaultCacheStoreMode = defaultCacheStoreMode( defaultSessionProperties );
+		this.defaultCacheRetrieveMode = defaultCacheRetrieveMode( defaultSessionProperties );
+		this.initialSessionCacheMode = interpretCacheMode( defaultCacheStoreMode, defaultCacheRetrieveMode );
+
+		this.defaultLockOptions = defaultLockOptions( defaultSessionProperties );
+		this.initialSessionFlushMode = defaultFlushMode( defaultSessionProperties );
 	}
 
-	private boolean disallowBatchUpdates(Dialect dialect, ExtractedDatabaseMetaData meta) {
+	private TimeZone getJdbcTimeZone(Object jdbcTimeZoneValue) {
+		if ( jdbcTimeZoneValue instanceof TimeZone timeZone ) {
+			return timeZone;
+		}
+		else if ( jdbcTimeZoneValue instanceof ZoneId zoneId ) {
+			return TimeZone.getTimeZone( zoneId );
+		}
+		else if ( jdbcTimeZoneValue instanceof String string ) {
+			return TimeZone.getTimeZone( ZoneId.of( string ) );
+		}
+		else if ( jdbcTimeZoneValue != null ) {
+			throw new IllegalArgumentException( "Configuration property " + JDBC_TIME_ZONE
+												+ " value [" + jdbcTimeZoneValue + "] is not supported" );
+		}
+		else {
+			return null;
+		}
+	}
+
+	private Nulls getDefaultNullPrecedence(Object defaultNullPrecedence) {
+		if ( defaultNullPrecedence instanceof Nulls jpaValue ) {
+			return jpaValue;
+		}
+		else if ( defaultNullPrecedence instanceof NullPrecedence hibernateValue ) {
+			return hibernateValue.getJpaValue();
+		}
+		else if ( defaultNullPrecedence instanceof String string ) {
+			return NullPrecedenceHelper.parse( string );
+		}
+		else if ( defaultNullPrecedence != null ) {
+			throw new IllegalArgumentException( "Configuration property " + DEFAULT_NULL_ORDERING
+					+ " value [" + defaultNullPrecedence + "] is not supported" );
+		}
+		else {
+			return null;
+		}
+	}
+
+	private static Class<? extends SessionEventListener> getAutoSessionEventsListener(Map<String, Object> configurationSettings, StrategySelector strategySelector) {
+		// todo : expose this from builder?
+		final String name = (String) configurationSettings.get( AUTO_SESSION_EVENTS_LISTENER );
+		return name == null ? null : strategySelector.selectStrategyImplementor( SessionEventListener.class, name );
+	}
+
+	private static boolean disallowBatchUpdates(Dialect dialect, ExtractedDatabaseMetaData meta) {
 		final Boolean dialectAnswer = dialect.supportsBatchUpdates();
 		return dialectAnswer != null ? !dialectAnswer : !meta.supportsBatchUpdates();
 	}
@@ -1324,11 +1246,21 @@ public class SessionFactoryOptionsBuilder implements SessionFactoryOptions {
 
 	@Override
 	public FormatMapper getJsonFormatMapper() {
+		if ( jsonFormatMapper == null ) {
+			throw new HibernateException(
+					"Could not find a FormatMapper for the JSON format, which is required for mapping JSON types. JSON FormatMapper configuration is automatic, but requires that you have either Jackson or a JSONB implementation like Yasson on the class path."
+			);
+		}
 		return jsonFormatMapper;
 	}
 
 	@Override
 	public FormatMapper getXmlFormatMapper() {
+		if ( xmlFormatMapper == null ) {
+			throw new HibernateException(
+					"Could not find a FormatMapper for the XML format, which is required for mapping XML types. XML FormatMapper configuration is automatic, but requires that you have either Jackson XML or a JAXB implementation like Glassfish JAXB on the class path."
+			);
+		}
 		return xmlFormatMapper;
 	}
 
@@ -1635,5 +1567,100 @@ public class SessionFactoryOptionsBuilder implements SessionFactoryOptions {
 			jpaCompliance = mutableJpaCompliance().immutableCopy();
 		}
 		return this;
+	}
+
+	@Override
+	public CacheStoreMode getCacheStoreMode(final Map<String, Object> properties) {
+		return properties == null ? defaultCacheStoreMode : defaultCacheStoreMode( properties );
+	}
+
+	@Override
+	public CacheRetrieveMode getCacheRetrieveMode(Map<String, Object> properties) {
+		return properties == null ? defaultCacheRetrieveMode : defaultCacheRetrieveMode( properties );
+	}
+
+	private static CacheRetrieveMode defaultCacheRetrieveMode(Map<String, Object> settings) {
+		final CacheRetrieveMode cacheRetrieveMode = (CacheRetrieveMode) settings.get( JPA_SHARED_CACHE_RETRIEVE_MODE );
+		return cacheRetrieveMode == null
+				? (CacheRetrieveMode) settings.get( JAKARTA_SHARED_CACHE_RETRIEVE_MODE )
+				: cacheRetrieveMode;
+	}
+
+	private static CacheStoreMode defaultCacheStoreMode(Map<String, Object> settings) {
+		final CacheStoreMode cacheStoreMode = (CacheStoreMode) settings.get( JPA_SHARED_CACHE_STORE_MODE );
+		return cacheStoreMode == null
+				? (CacheStoreMode) settings.get( JAKARTA_SHARED_CACHE_STORE_MODE )
+				: cacheStoreMode;
+	}
+
+	@Override
+	public CacheMode getInitialSessionCacheMode() {
+		return initialSessionCacheMode;
+	}
+
+	@Override
+	public FlushMode getInitialSessionFlushMode() {
+		return initialSessionFlushMode;
+	}
+
+	@Override
+	public LockOptions getDefaultLockOptions() {
+		return defaultLockOptions;
+	}
+
+	private static FlushMode defaultFlushMode(Map<String, Object> defaultSessionProperties) {
+		final Object setMode = defaultSessionProperties.get( HibernateHints.HINT_FLUSH_MODE );
+		return org.hibernate.jpa.internal.util.ConfigurationHelper.getFlushMode( setMode, FlushMode.AUTO );
+	}
+
+	private static LockOptions defaultLockOptions(Map<String, Object> defaultSessionProperties) {
+		final LockOptions lockOptions = new LockOptions();
+		applyPropertiesToLockOptions( defaultSessionProperties, () -> lockOptions );
+		return lockOptions;
+	}
+
+	@Override
+	public Map<String, Object> getDefaultSessionProperties() {
+		return defaultSessionProperties;
+	}
+
+	private Map<String, Object> initializeDefaultSessionProperties(ConfigurationService configurationService) {
+		final HashMap<String,Object> settings = new HashMap<>();
+
+		//Static defaults:
+		settings.putIfAbsent( HibernateHints.HINT_FLUSH_MODE, FlushMode.AUTO.name() );
+		settings.putIfAbsent( JPA_LOCK_SCOPE, PessimisticLockScope.EXTENDED.name() );
+		settings.putIfAbsent( JAKARTA_LOCK_SCOPE, PessimisticLockScope.EXTENDED.name() );
+		settings.putIfAbsent( JPA_LOCK_TIMEOUT, LockOptions.WAIT_FOREVER );
+		settings.putIfAbsent( JAKARTA_LOCK_TIMEOUT, LockOptions.WAIT_FOREVER );
+		settings.putIfAbsent( JPA_SHARED_CACHE_RETRIEVE_MODE, CacheModeHelper.DEFAULT_RETRIEVE_MODE );
+		settings.putIfAbsent( JAKARTA_SHARED_CACHE_RETRIEVE_MODE, CacheModeHelper.DEFAULT_RETRIEVE_MODE );
+		settings.putIfAbsent( JPA_SHARED_CACHE_STORE_MODE, CacheModeHelper.DEFAULT_STORE_MODE );
+		settings.putIfAbsent( JAKARTA_SHARED_CACHE_STORE_MODE, CacheModeHelper.DEFAULT_STORE_MODE );
+
+		//Defaults defined by SessionFactory configuration:
+		final String[] ENTITY_MANAGER_SPECIFIC_PROPERTIES = {
+				SpecHints.HINT_SPEC_LOCK_SCOPE,
+				SpecHints.HINT_SPEC_LOCK_TIMEOUT,
+				SpecHints.HINT_SPEC_QUERY_TIMEOUT,
+				SpecHints.HINT_SPEC_CACHE_RETRIEVE_MODE,
+				SpecHints.HINT_SPEC_CACHE_STORE_MODE,
+
+				HibernateHints.HINT_FLUSH_MODE,
+
+				LegacySpecHints.HINT_JAVAEE_LOCK_SCOPE,
+				LegacySpecHints.HINT_JAVAEE_LOCK_TIMEOUT,
+				LegacySpecHints.HINT_JAVAEE_CACHE_RETRIEVE_MODE,
+				LegacySpecHints.HINT_JAVAEE_CACHE_STORE_MODE,
+				LegacySpecHints.HINT_JAVAEE_QUERY_TIMEOUT
+		};
+
+		final Map<String, Object> configurationServiceSettings = configurationService.getSettings();
+		for ( String key : ENTITY_MANAGER_SPECIFIC_PROPERTIES ) {
+			if ( configurationServiceSettings.containsKey( key ) ) {
+				settings.put( key, configurationServiceSettings.get( key ) );
+			}
+		}
+		return unmodifiableMap( settings );
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/boot/model/internal/AnnotationBinder.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/internal/AnnotationBinder.java
@@ -253,8 +253,7 @@ public final class AnnotationBinder {
 			AnnotationTarget annotatedElement,
 			MetadataBuildingContext context) {
 		final ManagedBeanRegistry managedBeanRegistry =
-				context.getBootstrapContext().getServiceRegistry()
-						.getService( ManagedBeanRegistry.class );
+				context.getBootstrapContext().getManagedBeanRegistry();
 
 		final SourceModelBuildingContext sourceModelContext = sourceContext( context );
 

--- a/hibernate-core/src/main/java/org/hibernate/boot/model/internal/AnnotationHelper.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/internal/AnnotationHelper.java
@@ -15,7 +15,6 @@ import org.hibernate.dialect.Dialect;
 import org.hibernate.metamodel.mapping.JdbcMapping;
 import org.hibernate.resource.beans.internal.FallbackBeanInstanceProducer;
 import org.hibernate.resource.beans.spi.ManagedBean;
-import org.hibernate.resource.beans.spi.ManagedBeanRegistry;
 import org.hibernate.type.BasicType;
 import org.hibernate.type.CustomType;
 import org.hibernate.type.descriptor.converter.internal.JpaAttributeConverterImpl;
@@ -49,15 +48,13 @@ public class AnnotationHelper {
 		final BootstrapContext bootstrapContext = context.getBootstrapContext();
 		final UserType<?> userType = !context.getBuildingOptions().isAllowExtensionsInCdi()
 				? FallbackBeanInstanceProducer.INSTANCE.produceBeanInstance( userTypeClass )
-				: bootstrapContext.getServiceRegistry().requireService( ManagedBeanRegistry.class ).getBean( userTypeClass ).getBeanInstance();
+				: bootstrapContext.getManagedBeanRegistry().getBean( userTypeClass ).getBeanInstance();
 		return new CustomType<>( userType, bootstrapContext.getTypeConfiguration() );
 	}
 
 	public static JdbcMapping resolveAttributeConverter(Class<AttributeConverter<?, ?>> type, MetadataBuildingContext context) {
 		final BootstrapContext bootstrapContext = context.getBootstrapContext();
-		final ManagedBean<AttributeConverter<?, ?>> bean = bootstrapContext.getServiceRegistry()
-				.requireService( ManagedBeanRegistry.class )
-				.getBean( type );
+		final ManagedBean<AttributeConverter<?, ?>> bean = bootstrapContext.getManagedBeanRegistry().getBean( type );
 
 		final TypeConfiguration typeConfiguration = bootstrapContext.getTypeConfiguration();
 		final JavaTypeRegistry jtdRegistry = typeConfiguration.getJavaTypeRegistry();
@@ -155,8 +152,7 @@ public class AnnotationHelper {
 			return FallbackBeanInstanceProducer.INSTANCE.produceBeanInstance( javaTypeClass );
 		}
 		else {
-			return context.getBootstrapContext().getServiceRegistry()
-					.requireService( ManagedBeanRegistry.class )
+			return context.getBootstrapContext().getManagedBeanRegistry()
 					.getBean( javaTypeClass )
 					.getBeanInstance();
 		}

--- a/hibernate-core/src/main/java/org/hibernate/boot/model/internal/BasicValueBinder.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/internal/BasicValueBinder.java
@@ -504,8 +504,7 @@ public class BasicValueBinder implements JdbcTypeIndicators {
 	}
 
 	private ManagedBeanRegistry getManagedBeanRegistry() {
-		return buildingContext.getBootstrapContext().getServiceRegistry()
-				.requireService(ManagedBeanRegistry.class);
+		return buildingContext.getBootstrapContext().getManagedBeanRegistry();
 	}
 
 	private void prepareMapKey(

--- a/hibernate-core/src/main/java/org/hibernate/boot/model/internal/CollectionBinder.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/internal/CollectionBinder.java
@@ -877,7 +877,8 @@ public abstract class CollectionBinder {
 						property.getDeclaringType().getName() + "#" + property.getName(),
 						typeRegistration.getImplementation(),
 						typeRegistration.getParameters(),
-						context.getMetadataCollector()
+						context.getBootstrapContext(),
+						context.getMetadataCollector().getMetadataBuildingOptions().isAllowExtensionsInCdi()
 				),
 				classification,
 				context
@@ -912,7 +913,8 @@ public abstract class CollectionBinder {
 				property.getDeclaringType().getName() + "." + property.getName(),
 				typeAnnotation.type(),
 				PropertiesHelper.map( extractParameters( typeAnnotation ) ),
-				context.getMetadataCollector()
+				context.getBootstrapContext(),
+				context.getMetadataCollector().getMetadataBuildingOptions().isAllowExtensionsInCdi()
 		);
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/boot/model/internal/EmbeddableBinder.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/internal/EmbeddableBinder.java
@@ -51,7 +51,6 @@ import org.hibernate.property.access.internal.PropertyAccessStrategyCompositeUse
 import org.hibernate.property.access.internal.PropertyAccessStrategyGetterImpl;
 import org.hibernate.property.access.spi.PropertyAccessStrategy;
 import org.hibernate.resource.beans.internal.FallbackBeanInstanceProducer;
-import org.hibernate.resource.beans.spi.ManagedBeanRegistry;
 import org.hibernate.type.BasicType;
 import org.hibernate.usertype.CompositeUserType;
 
@@ -598,9 +597,7 @@ public class EmbeddableBinder {
 			FallbackBeanInstanceProducer.INSTANCE.produceBeanInstance( compositeUserTypeClass );
 		}
 
-		return context.getBootstrapContext()
-				.getServiceRegistry()
-				.requireService( ManagedBeanRegistry.class )
+		return context.getBootstrapContext().getManagedBeanRegistry()
 				.getBean( compositeUserTypeClass )
 				.getBeanInstance();
 	}

--- a/hibernate-core/src/main/java/org/hibernate/boot/model/internal/FilterDefBinder.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/internal/FilterDefBinder.java
@@ -21,7 +21,6 @@ import org.hibernate.metamodel.mapping.JdbcMapping;
 import org.hibernate.models.spi.AnnotationTarget;
 import org.hibernate.models.spi.SourceModelBuildingContext;
 import org.hibernate.resource.beans.spi.ManagedBean;
-import org.hibernate.resource.beans.spi.ManagedBeanRegistry;
 import org.hibernate.type.descriptor.java.JavaType;
 import org.hibernate.usertype.UserType;
 
@@ -106,9 +105,8 @@ public class FilterDefBinder {
 	private static ManagedBean<? extends Supplier<?>> resolveParamResolver(Class<? extends Supplier> resolverClass, MetadataBuildingContext context) {
 		assert resolverClass != Supplier.class;
 		final BootstrapContext bootstrapContext = context.getBootstrapContext();
-		return (ManagedBean<? extends Supplier<?>>) bootstrapContext.getServiceRegistry()
-						.requireService(ManagedBeanRegistry.class)
-						.getBean(resolverClass, bootstrapContext.getCustomTypeProducer());
+		return (ManagedBean<? extends Supplier<?>>) bootstrapContext.getManagedBeanRegistry()
+						.getBean( resolverClass, bootstrapContext.getCustomTypeProducer() );
 	}
 
 	@SuppressWarnings("unchecked")

--- a/hibernate-core/src/main/java/org/hibernate/boot/model/internal/GeneratorStrategies.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/internal/GeneratorStrategies.java
@@ -6,7 +6,6 @@ package org.hibernate.boot.model.internal;
 
 import jakarta.persistence.GenerationType;
 import org.hibernate.MappingException;
-import org.hibernate.boot.registry.classloading.spi.ClassLoaderService;
 import org.hibernate.boot.spi.MetadataBuildingContext;
 import org.hibernate.dialect.Dialect;
 import org.hibernate.generator.Generator;
@@ -103,7 +102,8 @@ public class GeneratorStrategies {
 				return GUIDGenerator.class;
 		}
 		final Class<? extends Generator> clazz =
-				idValue.getServiceRegistry().requireService( ClassLoaderService.class )
+				idValue.getBuildingContext().getBootstrapContext()
+						.getClassLoaderService()
 						.classForName( strategy );
 		if ( !Generator.class.isAssignableFrom( clazz ) ) {
 			// in principle, this shouldn't happen, since @GenericGenerator

--- a/hibernate-core/src/main/java/org/hibernate/boot/model/internal/QueryBinder.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/internal/QueryBinder.java
@@ -29,7 +29,6 @@ import org.hibernate.boot.query.NamedHqlQueryDefinition;
 import org.hibernate.boot.query.NamedNativeQueryDefinition;
 import org.hibernate.boot.query.NamedProcedureCallDefinition;
 import org.hibernate.boot.query.SqlResultSetMappingDescriptor;
-import org.hibernate.boot.registry.classloading.spi.ClassLoaderService;
 import org.hibernate.boot.spi.MetadataBuildingContext;
 import org.hibernate.internal.CoreMessageLogger;
 import org.hibernate.internal.log.DeprecationLogger;
@@ -194,7 +193,7 @@ public abstract class QueryBinder {
 
 		if ( annotatedClass != null ) {
 			builder.setResultClass(
-					context.getBootstrapContext().getServiceRegistry().requireService( ClassLoaderService.class )
+					context.getBootstrapContext().getClassLoaderService()
 							.classForName( annotatedClass.getClassName() )
 			);
 		}

--- a/hibernate-core/src/main/java/org/hibernate/boot/model/process/internal/NamedConverterResolution.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/process/internal/NamedConverterResolution.java
@@ -13,7 +13,6 @@ import org.hibernate.annotations.Immutable;
 import org.hibernate.boot.model.convert.internal.ClassBasedConverterDescriptor;
 import org.hibernate.boot.model.convert.spi.ConverterDescriptor;
 import org.hibernate.boot.model.convert.spi.JpaAttributeConverterCreationContext;
-import org.hibernate.boot.registry.classloading.spi.ClassLoaderService;
 import org.hibernate.boot.spi.MetadataBuildingContext;
 import org.hibernate.mapping.BasicValue;
 import org.hibernate.metamodel.mapping.JdbcMapping;
@@ -68,8 +67,7 @@ public class NamedConverterResolution<J> implements BasicValue.Resolution<J> {
 		final String converterClassName = name.substring( ConverterDescriptor.TYPE_NAME_PREFIX.length() );
 
 		final ClassBasedConverterDescriptor converterDescriptor = new ClassBasedConverterDescriptor(
-				context.getBootstrapContext().getServiceRegistry()
-						.requireService( ClassLoaderService.class )
+				context.getBootstrapContext().getClassLoaderService()
 						.classForName( converterClassName ),
 				context.getBootstrapContext().getClassmateContext()
 		);

--- a/hibernate-core/src/main/java/org/hibernate/boot/model/process/internal/ScanningCoordinator.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/process/internal/ScanningCoordinator.java
@@ -64,7 +64,7 @@ public class ScanningCoordinator {
 
 		final ClassLoaderAccess classLoaderAccess = new ClassLoaderAccessImpl(
 				bootstrapContext.getJpaTempClassLoader(),
-				bootstrapContext.getServiceRegistry().requireService( ClassLoaderService.class )
+				bootstrapContext.getClassLoaderService()
 		);
 
 		// NOTE : the idea with JandexInitializer/JandexInitManager was to allow adding classes
@@ -88,10 +88,10 @@ public class ScanningCoordinator {
 
 		if ( scannerSetting == null ) {
 			// No custom Scanner specified, use the StandardScanner
-			final Iterator<ScannerFactory> iterator = bootstrapContext.getServiceRegistry()
-					.requireService( ClassLoaderService.class )
-					.loadJavaServices( ScannerFactory.class )
-					.iterator();
+			final Iterator<ScannerFactory> iterator =
+					bootstrapContext.getClassLoaderService()
+							.loadJavaServices( ScannerFactory.class )
+							.iterator();
 			if ( iterator.hasNext() ) {
 				// todo: check for multiple scanner and in case raise a warning?
 				final ScannerFactory factory = iterator.next();
@@ -195,8 +195,7 @@ public class ScanningCoordinator {
 			XmlMappingBinderAccess xmlMappingBinderAccess) {
 
 		final ScanEnvironment scanEnvironment = bootstrapContext.getScanEnvironment();
-		final ClassLoaderService classLoaderService =
-				bootstrapContext.getServiceRegistry().requireService( ClassLoaderService.class );
+		final ClassLoaderService classLoaderService = bootstrapContext.getClassLoaderService();
 
 
 		// mapping files ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/hibernate-core/src/main/java/org/hibernate/boot/model/process/spi/MetadataBuildingProcess.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/process/spi/MetadataBuildingProcess.java
@@ -184,7 +184,7 @@ public class MetadataBuildingProcess {
 			final BootstrapContext bootstrapContext,
 			final MetadataBuildingOptions options) {
 
-		final ClassLoaderService classLoaderService = bootstrapContext.getServiceRegistry().getService( ClassLoaderService.class );
+		final ClassLoaderService classLoaderService = bootstrapContext.getClassLoaderService();
 		assert classLoaderService != null;
 		final InFlightMetadataCollectorImpl metadataCollector = new InFlightMetadataCollectorImpl( bootstrapContext, options );
 
@@ -692,9 +692,7 @@ public class MetadataBuildingProcess {
 			BootstrapContext bootstrapContext,
 			MetadataBuildingOptions options,
 			InFlightMetadataCollector metadataCollector) {
-		final ClassLoaderService classLoaderService =
-				options.getServiceRegistry().requireService(ClassLoaderService.class);
-
+		final ClassLoaderService classLoaderService = bootstrapContext.getClassLoaderService();
 		final TypeConfiguration typeConfiguration = bootstrapContext.getTypeConfiguration();
 		final StandardServiceRegistry serviceRegistry = bootstrapContext.getServiceRegistry();
 		final JdbcTypeRegistry jdbcTypeRegistry = typeConfiguration.getJdbcTypeRegistry();

--- a/hibernate-core/src/main/java/org/hibernate/boot/model/source/internal/annotations/AnnotationMetadataSourceProcessorImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/source/internal/annotations/AnnotationMetadataSourceProcessorImpl.java
@@ -61,8 +61,7 @@ public class AnnotationMetadataSourceProcessorImpl implements MetadataSourceProc
 		this.domainModelSource = domainModelSource;
 		this.rootMetadataBuildingContext = rootMetadataBuildingContext;
 
-		final MetadataBuildingOptions metadataBuildingOptions = rootMetadataBuildingContext.getBuildingOptions();
-		this.classLoaderService = metadataBuildingOptions.getServiceRegistry().getService( ClassLoaderService.class );
+		this.classLoaderService = rootMetadataBuildingContext.getBootstrapContext().getClassLoaderService();
 		assert classLoaderService != null;
 
 		final ConverterRegistry converterRegistry = rootMetadataBuildingContext.getMetadataCollector().getConverterRegistry();

--- a/hibernate-core/src/main/java/org/hibernate/boot/model/source/internal/hbm/AuxiliaryDatabaseObjectBinder.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/source/internal/hbm/AuxiliaryDatabaseObjectBinder.java
@@ -8,7 +8,6 @@ import org.hibernate.boot.jaxb.hbm.spi.JaxbHbmAuxiliaryDatabaseObjectType;
 import org.hibernate.boot.jaxb.hbm.spi.JaxbHbmDialectScopeType;
 import org.hibernate.boot.model.relational.AuxiliaryDatabaseObject;
 import org.hibernate.boot.model.relational.SimpleAuxiliaryDatabaseObject;
-import org.hibernate.boot.registry.classloading.spi.ClassLoaderService;
 import org.hibernate.boot.registry.classloading.spi.ClassLoadingException;
 
 /**
@@ -29,11 +28,10 @@ public class AuxiliaryDatabaseObjectBinder {
 		if ( auxDbObjectMapping.getDefinition() != null ) {
 			final String auxDbObjectImplClass = auxDbObjectMapping.getDefinition().getClazz();
 			try {
-				auxDbObject = (AuxiliaryDatabaseObject) context.getBuildingOptions()
-						.getServiceRegistry()
-						.requireService( ClassLoaderService.class )
-						.classForName( auxDbObjectImplClass )
-						.newInstance();
+				auxDbObject = (AuxiliaryDatabaseObject)
+						context.getBootstrapContext().getClassLoaderService()
+								.classForName( auxDbObjectImplClass )
+								.newInstance();
 			}
 			catch (ClassLoadingException cle) {
 				throw cle;

--- a/hibernate-core/src/main/java/org/hibernate/boot/model/source/internal/hbm/ModelBinder.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/source/internal/hbm/ModelBinder.java
@@ -139,7 +139,6 @@ import org.hibernate.mapping.UnionSubclass;
 import org.hibernate.mapping.UniqueKey;
 import org.hibernate.mapping.Value;
 import org.hibernate.resource.beans.internal.FallbackBeanInstanceProducer;
-import org.hibernate.resource.beans.spi.ManagedBeanRegistry;
 import org.hibernate.spi.NavigablePath;
 import org.hibernate.tuple.GenerationTiming;
 import org.hibernate.type.AbstractSingleColumnStandardBasicType;
@@ -2271,7 +2270,7 @@ public class ModelBinder {
 		}
 		else {
 			final ClassLoaderService classLoaderService =
-					bootstrapContext.getServiceRegistry().requireService( ClassLoaderService.class );
+					bootstrapContext.getClassLoaderService();
 			try {
 				final Object typeInstance = typeInstance( typeName, classLoaderService.classForName( typeName ) );
 
@@ -2309,8 +2308,7 @@ public class ModelBinder {
 		}
 		else {
 			final String beanName = typeName + ":" + TypeDefinition.NAME_COUNTER.getAndIncrement();
-			return metadataBuildingContext.getBootstrapContext()
-					.getServiceRegistry().requireService( ManagedBeanRegistry.class )
+			return metadataBuildingContext.getBootstrapContext().getManagedBeanRegistry()
 					.getBean( beanName, typeJavaType ).getBeanInstance();
 		}
 	}
@@ -2537,8 +2535,7 @@ public class ModelBinder {
 						}
 						else {
 							compositeUserType = (CompositeUserType<?>) sourceDocument.getBootstrapContext()
-									.getServiceRegistry()
-									.requireService( ManagedBeanRegistry.class )
+									.getManagedBeanRegistry()
 									.getBean( componentClass )
 									.getBeanInstance();
 						}

--- a/hibernate-core/src/main/java/org/hibernate/boot/model/source/internal/hbm/TypeDefinitionBinder.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/source/internal/hbm/TypeDefinitionBinder.java
@@ -6,7 +6,6 @@ package org.hibernate.boot.model.source.internal.hbm;
 
 import org.hibernate.boot.jaxb.hbm.spi.JaxbHbmTypeDefinitionType;
 import org.hibernate.boot.model.TypeDefinition;
-import org.hibernate.boot.registry.classloading.spi.ClassLoaderService;
 
 import org.jboss.logging.Logger;
 
@@ -28,8 +27,7 @@ public class TypeDefinitionBinder {
 
 		final TypeDefinition definition = new TypeDefinition(
 				typeDefinitionBinding.getName(),
-				context.getBuildingOptions().getServiceRegistry()
-						.requireService( ClassLoaderService.class )
+				context.getBootstrapContext().getClassLoaderService()
 						.classForName( typeDefinitionBinding.getClazz() ),
 				null,
 				ConfigParameterHelper.extractConfigParameters( typeDefinitionBinding )

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/spi/FilterDefRegistration.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/spi/FilterDefRegistration.java
@@ -74,10 +74,7 @@ public class FilterDefRegistration {
 	}
 
 	public FilterDefinition toFilterDefinition(MetadataBuildingContext buildingContext) {
-		final ManagedBeanRegistry beanRegistry = buildingContext
-				.getBootstrapContext()
-				.getServiceRegistry()
-				.getService( ManagedBeanRegistry.class );
+		final ManagedBeanRegistry beanRegistry = buildingContext.getBootstrapContext().getManagedBeanRegistry();
 
 		final Map<String, JdbcMapping> parameterJdbcMappings;
 		if ( CollectionHelper.isEmpty( parameterTypes ) ) {

--- a/hibernate-core/src/main/java/org/hibernate/boot/spi/AbstractDelegatingSessionFactoryOptions.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/spi/AbstractDelegatingSessionFactoryOptions.java
@@ -8,9 +8,14 @@ import java.util.Map;
 import java.util.TimeZone;
 import java.util.function.Supplier;
 
+import jakarta.persistence.CacheRetrieveMode;
+import jakarta.persistence.CacheStoreMode;
+import org.hibernate.CacheMode;
 import org.hibernate.CustomEntityDirtinessStrategy;
 import org.hibernate.EntityNameResolver;
+import org.hibernate.FlushMode;
 import org.hibernate.Interceptor;
+import org.hibernate.LockOptions;
 import org.hibernate.SessionFactoryObserver;
 import org.hibernate.TimeZoneStorageStrategy;
 import org.hibernate.annotations.CacheLayout;
@@ -536,5 +541,35 @@ public class AbstractDelegatingSessionFactoryOptions implements SessionFactoryOp
 	@Override
 	public boolean isPreferJdbcDatetimeTypesInNativeQueriesEnabled() {
 		return delegate.isPreferJdbcDatetimeTypesInNativeQueriesEnabled();
+	}
+
+	@Override
+	public CacheStoreMode getCacheStoreMode(Map<String, Object> properties) {
+		return delegate.getCacheStoreMode( properties );
+	}
+
+	@Override
+	public CacheRetrieveMode getCacheRetrieveMode(Map<String, Object> properties) {
+		return delegate.getCacheRetrieveMode( properties );
+	}
+
+	@Override
+	public Map<String, Object> getDefaultSessionProperties() {
+		return delegate.getDefaultSessionProperties();
+	}
+
+	@Override
+	public CacheMode getInitialSessionCacheMode() {
+		return delegate.getInitialSessionCacheMode();
+	}
+
+	@Override
+	public FlushMode getInitialSessionFlushMode() {
+		return delegate.getInitialSessionFlushMode();
+	}
+
+	@Override
+	public LockOptions getDefaultLockOptions() {
+		return delegate.getDefaultLockOptions();
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/boot/spi/BootstrapContext.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/spi/BootstrapContext.java
@@ -16,11 +16,14 @@ import org.hibernate.boot.archive.spi.ArchiveDescriptorFactory;
 import org.hibernate.boot.model.convert.spi.ConverterDescriptor;
 import org.hibernate.boot.model.relational.AuxiliaryDatabaseObject;
 import org.hibernate.boot.registry.StandardServiceRegistry;
+import org.hibernate.boot.registry.classloading.spi.ClassLoaderService;
+import org.hibernate.engine.config.spi.ConfigurationService;
 import org.hibernate.jpa.spi.MutableJpaCompliance;
 import org.hibernate.metamodel.spi.ManagedTypeRepresentationResolver;
 import org.hibernate.query.sqm.function.SqmFunctionDescriptor;
 import org.hibernate.query.sqm.function.SqmFunctionRegistry;
 import org.hibernate.resource.beans.spi.BeanInstanceProducer;
+import org.hibernate.resource.beans.spi.ManagedBeanRegistry;
 import org.hibernate.type.BasicType;
 import org.hibernate.type.spi.TypeConfiguration;
 
@@ -68,6 +71,21 @@ public interface BootstrapContext {
 	 * Options specific to building the {@linkplain Metadata boot metamodel}
 	 */
 	MetadataBuildingOptions getMetadataBuildingOptions();
+
+	/**
+	 * Access to the {@link ClassLoaderService}.
+	 */
+	ClassLoaderService getClassLoaderService();
+
+	/**
+	 * Access to the {@link ManagedBeanRegistry}.
+	 */
+	ManagedBeanRegistry getManagedBeanRegistry();
+
+	/**
+	 * Access to the {@link ConfigurationService}.
+	 */
+	ConfigurationService getConfigurationService();
 
 	/**
 	 * Whether the bootstrap was initiated from JPA bootstrapping.

--- a/hibernate-core/src/main/java/org/hibernate/boot/spi/SessionFactoryOptions.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/spi/SessionFactoryOptions.java
@@ -4,14 +4,20 @@
  */
 package org.hibernate.boot.spi;
 
+import java.util.Map;
 import java.util.TimeZone;
 import java.util.function.Supplier;
 
+import jakarta.persistence.CacheRetrieveMode;
+import jakarta.persistence.CacheStoreMode;
+import org.hibernate.CacheMode;
 import org.hibernate.CustomEntityDirtinessStrategy;
 import org.hibernate.EntityNameResolver;
+import org.hibernate.FlushMode;
 import org.hibernate.Incubating;
 import org.hibernate.Interceptor;
 import org.hibernate.Internal;
+import org.hibernate.LockOptions;
 import org.hibernate.SessionFactoryObserver;
 import org.hibernate.TimeZoneStorageStrategy;
 import org.hibernate.annotations.CacheLayout;
@@ -615,4 +621,29 @@ public interface SessionFactoryOptions extends QueryEngineOptions {
 	 * @see org.hibernate.cfg.QuerySettings#NATIVE_PREFER_JDBC_DATETIME_TYPES
 	 */
 	boolean isPreferJdbcDatetimeTypesInNativeQueriesEnabled();
+
+	/**
+	 * @param properties the Session properties
+	 * @return either the CacheStoreMode as defined in the Session specific properties,
+	 *         or as defined in the properties shared across all sessions (the defaults).
+	 */
+	CacheStoreMode getCacheStoreMode(Map<String, Object> properties);
+
+	/**
+	 * @param properties the Session properties
+	 * @return either the CacheRetrieveMode as defined in the Session specific properties,
+	 *         or as defined in the properties shared across all sessions (the defaults).
+	 */
+	CacheRetrieveMode getCacheRetrieveMode(Map<String, Object> properties);
+
+	CacheMode getInitialSessionCacheMode();
+
+	FlushMode getInitialSessionFlushMode();
+
+	LockOptions getDefaultLockOptions();
+
+	/**
+	 * Default session properties
+	 */
+	Map<String, Object> getDefaultSessionProperties();
 }

--- a/hibernate-core/src/main/java/org/hibernate/cache/internal/CollectionCacheInvalidator.java
+++ b/hibernate-core/src/main/java/org/hibernate/cache/internal/CollectionCacheInvalidator.java
@@ -88,8 +88,7 @@ public class CollectionCacheInvalidator
 			// Nothing to do, if caching is disabled
 			return;
 		}
-		final EventListenerRegistry eventListenerRegistry =
-				sessionFactory.getServiceRegistry().requireService( EventListenerRegistry.class );
+		final EventListenerRegistry eventListenerRegistry = sessionFactory.getEventListenerRegistry();
 		eventListenerRegistry.appendListeners( EventType.POST_INSERT, this );
 		eventListenerRegistry.appendListeners( EventType.POST_DELETE, this );
 		eventListenerRegistry.appendListeners( EventType.POST_UPDATE, this );

--- a/hibernate-core/src/main/java/org/hibernate/cache/spi/entry/StandardCacheEntryImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/cache/spi/entry/StandardCacheEntryImpl.java
@@ -143,7 +143,7 @@ public class StandardCacheEntryImpl implements CacheEntry {
 							.setId( id )
 							.setPersister( persister );
 			session.getFactory()
-					.getFastSessionServices()
+					.getEventListenerGroups()
 					.eventListenerGroup_PRE_LOAD
 					.fireEventOnEachListener( preLoadEvent, PreLoadEventListener::onPreLoad );
 

--- a/hibernate-core/src/main/java/org/hibernate/dialect/Dialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/Dialect.java
@@ -1972,7 +1972,7 @@ public abstract class Dialect implements ConversionContext, TypeContributor, Fun
 			if ( original == null && target == null ) {
 				return null;
 			}
-			final JdbcServices jdbcServices = session.getFactory().getFastSessionServices().jdbcServices;
+			final JdbcServices jdbcServices = session.getFactory().getJdbcServices();
 			try {
 				final LobCreator lobCreator = jdbcServices.getLobCreator( session );
 				return original == null
@@ -1989,7 +1989,7 @@ public abstract class Dialect implements ConversionContext, TypeContributor, Fun
 			if ( original == null && target == null ) {
 				return null;
 			}
-			final JdbcServices jdbcServices = session.getFactory().getFastSessionServices().jdbcServices;
+			final JdbcServices jdbcServices = session.getFactory().getJdbcServices();
 			try {
 				final LobCreator lobCreator = jdbcServices.getLobCreator( session );
 				return original == null
@@ -2006,7 +2006,7 @@ public abstract class Dialect implements ConversionContext, TypeContributor, Fun
 			if ( original == null && target == null ) {
 				return null;
 			}
-			final JdbcServices jdbcServices = session.getFactory().getFastSessionServices().jdbcServices;
+			final JdbcServices jdbcServices = session.getFactory().getJdbcServices();
 			try {
 				final LobCreator lobCreator = jdbcServices.getLobCreator( session );
 				return original == null

--- a/hibernate-core/src/main/java/org/hibernate/dialect/temptable/StandardTemporaryTableExporter.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/temptable/StandardTemporaryTableExporter.java
@@ -100,8 +100,8 @@ public class StandardTemporaryTableExporter implements TemporaryTableExporter {
 			Function<SharedSessionContractImplementor, String> sessionUidAccess,
 			SharedSessionContractImplementor session) {
 		if ( idTable.getSessionUidColumn() != null ) {
-			final ParameterMarkerStrategy parameterMarkerStrategy = session.getSessionFactory()
-					.getFastSessionServices().parameterMarkerStrategy;
+			final ParameterMarkerStrategy parameterMarkerStrategy =
+					session.getSessionFactory().getParameterMarkerStrategy();
 			return getTruncateTableCommand() + " " + idTable.getQualifiedTableName()
 					+ " where " + idTable.getSessionUidColumn().getColumnName() + " = "
 					+ parameterMarkerStrategy.createMarker( 1, null );

--- a/hibernate-core/src/main/java/org/hibernate/engine/internal/EntityEntryContext.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/internal/EntityEntryContext.java
@@ -6,7 +6,6 @@ package org.hibernate.engine.internal;
 
 import org.hibernate.HibernateException;
 import org.hibernate.LockMode;
-import org.hibernate.boot.registry.classloading.spi.ClassLoaderService;
 import org.hibernate.bytecode.enhance.spi.interceptor.LazyAttributeLoadingInterceptor;
 import org.hibernate.engine.spi.EntityEntry;
 import org.hibernate.engine.spi.ManagedEntity;
@@ -521,19 +520,19 @@ public class EntityEntryContext {
 		return context;
 	}
 
-	private static EntityEntry deserializeEntityEntry(char[] entityEntryClassNameArr, ObjectInputStream ois, StatefulPersistenceContext rtn){
+	private static EntityEntry deserializeEntityEntry(
+			char[] entityEntryClassNames, ObjectInputStream ois, StatefulPersistenceContext persistenceContext){
 		EntityEntry entry = null;
 
-		final String entityEntryClassName = new String( entityEntryClassNameArr );
+		final String entityEntryClassName = new String( entityEntryClassNames );
 		final Class<?> entityEntryClass =
-				rtn.getSession().getFactory().getServiceRegistry()
-						.requireService( ClassLoaderService.class )
+				persistenceContext.getSession().getFactory().getClassLoaderService()
 						.classForName( entityEntryClassName );
 
 		try {
 			final Method deserializeMethod =
 					entityEntryClass.getDeclaredMethod( "deserialize", ObjectInputStream.class, PersistenceContext.class );
-			entry = (EntityEntry) deserializeMethod.invoke( null, ois, rtn );
+			entry = (EntityEntry) deserializeMethod.invoke( null, ois, persistenceContext );
 		}
 		catch (NoSuchMethodException | InvocationTargetException | IllegalAccessException e) {
 			log.errorf( "Enable to deserialize [%s]", entityEntryClassName );

--- a/hibernate-core/src/main/java/org/hibernate/engine/internal/SessionEventListenerManagerImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/internal/SessionEventListenerManagerImpl.java
@@ -6,6 +6,7 @@ package org.hibernate.engine.internal;
 
 import java.io.Serializable;
 import java.util.Arrays;
+import java.util.List;
 import java.util.Objects;
 
 import org.hibernate.SessionEventListener;
@@ -21,6 +22,11 @@ public class SessionEventListenerManagerImpl implements SessionEventListenerMana
 	public SessionEventListenerManagerImpl(SessionEventListener... initialListener) {
 		//no need for defensive copies until the array is mutated:
 		this.listeners = initialListener;
+	}
+
+	public SessionEventListenerManagerImpl(List<SessionEventListener> initialListener) {
+		//no need for defensive copies until the array is mutated:
+		this.listeners = initialListener.toArray( new SessionEventListener[0] );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/engine/internal/StatefulPersistenceContext.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/internal/StatefulPersistenceContext.java
@@ -444,7 +444,7 @@ public class StatefulPersistenceContext implements PersistenceContext {
 		final Callback callback = processingState.getExecutionContext().getCallback();
 		if ( processingState.getLoadingEntityHolders() != null ) {
 			final EventListenerGroup<PostLoadEventListener> listenerGroup =
-					getSession().getFactory().getFastSessionServices().eventListenerGroup_POST_LOAD;
+					getSession().getFactory().getEventListenerGroups().eventListenerGroup_POST_LOAD;
 			final PostLoadEvent postLoadEvent = processingState.getPostLoadEvent();
 			for ( final EntityHolder holder : processingState.getLoadingEntityHolders() ) {
 				processLoadedEntityHolder( holder, listenerGroup, postLoadEvent, callback, holderConsumer );

--- a/hibernate-core/src/main/java/org/hibernate/engine/spi/SessionFactoryDelegatingImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/spi/SessionFactoryDelegatingImpl.java
@@ -35,8 +35,10 @@ import org.hibernate.cache.spi.CacheImplementor;
 import org.hibernate.context.spi.CurrentTenantIdentifierResolver;
 import org.hibernate.engine.jdbc.spi.JdbcServices;
 import org.hibernate.engine.profile.FetchProfile;
+import org.hibernate.event.spi.EntityCopyObserverFactory;
 import org.hibernate.event.spi.EventEngine;
 import org.hibernate.graph.spi.RootGraphImplementor;
+import org.hibernate.event.service.spi.EventListenerGroups;
 import org.hibernate.internal.FastSessionServices;
 import org.hibernate.metamodel.MappingMetamodel;
 import org.hibernate.metamodel.model.domain.JpaMetamodel;
@@ -47,6 +49,8 @@ import org.hibernate.query.criteria.HibernateCriteriaBuilder;
 import org.hibernate.query.spi.QueryEngine;
 import org.hibernate.relational.SchemaManager;
 import org.hibernate.service.spi.ServiceRegistryImplementor;
+import org.hibernate.sql.ast.spi.ParameterMarkerStrategy;
+import org.hibernate.sql.results.jdbc.spi.JdbcValuesMappingProducerProvider;
 import org.hibernate.stat.spi.StatisticsImplementor;
 import org.hibernate.generator.Generator;
 import org.hibernate.type.Type;
@@ -114,7 +118,7 @@ public class SessionFactoryDelegatingImpl implements SessionFactoryImplementor, 
 
 	@Override
 	public SchemaManager getSchemaManager() {
-		return delegate().getSchemaManager();
+		return delegate.getSchemaManager();
 	}
 
 	@Override
@@ -405,5 +409,25 @@ public class SessionFactoryDelegatingImpl implements SessionFactoryImplementor, 
 	@Override
 	public Class<?> classForName(String className) {
 		return delegate.classForName( className );
+	}
+
+	@Override
+	public EventListenerGroups getEventListenerGroups() {
+		return delegate.getEventListenerGroups();
+	}
+
+	@Override
+	public ParameterMarkerStrategy getParameterMarkerStrategy() {
+		return delegate.getParameterMarkerStrategy();
+	}
+
+	@Override
+	public JdbcValuesMappingProducerProvider getJdbcValuesMappingProducerProvider() {
+		return delegate.getJdbcValuesMappingProducerProvider();
+	}
+
+	@Override
+	public EntityCopyObserverFactory getEntityCopyObserver() {
+		return delegate.getEntityCopyObserver();
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/engine/spi/SessionFactoryDelegatingImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/spi/SessionFactoryDelegatingImpl.java
@@ -30,11 +30,13 @@ import org.hibernate.SessionFactoryObserver;
 import org.hibernate.StatelessSession;
 import org.hibernate.StatelessSessionBuilder;
 import org.hibernate.boot.model.relational.SqlStringGenerationContext;
+import org.hibernate.boot.registry.classloading.spi.ClassLoaderService;
 import org.hibernate.boot.spi.SessionFactoryOptions;
 import org.hibernate.cache.spi.CacheImplementor;
 import org.hibernate.context.spi.CurrentTenantIdentifierResolver;
 import org.hibernate.engine.jdbc.spi.JdbcServices;
 import org.hibernate.engine.profile.FetchProfile;
+import org.hibernate.event.service.spi.EventListenerRegistry;
 import org.hibernate.event.spi.EntityCopyObserverFactory;
 import org.hibernate.event.spi.EventEngine;
 import org.hibernate.graph.spi.RootGraphImplementor;
@@ -48,6 +50,7 @@ import org.hibernate.query.BindableType;
 import org.hibernate.query.criteria.HibernateCriteriaBuilder;
 import org.hibernate.query.spi.QueryEngine;
 import org.hibernate.relational.SchemaManager;
+import org.hibernate.resource.beans.spi.ManagedBeanRegistry;
 import org.hibernate.service.spi.ServiceRegistryImplementor;
 import org.hibernate.sql.ast.spi.ParameterMarkerStrategy;
 import org.hibernate.sql.results.jdbc.spi.JdbcValuesMappingProducerProvider;
@@ -429,5 +432,20 @@ public class SessionFactoryDelegatingImpl implements SessionFactoryImplementor, 
 	@Override
 	public EntityCopyObserverFactory getEntityCopyObserver() {
 		return delegate.getEntityCopyObserver();
+	}
+
+	@Override
+	public ClassLoaderService getClassLoaderService() {
+		return delegate.getClassLoaderService();
+	}
+
+	@Override
+	public ManagedBeanRegistry getManagedBeanRegistry() {
+		return delegate.getManagedBeanRegistry();
+	}
+
+	@Override
+	public EventListenerRegistry getEventListenerRegistry() {
+		return delegate.getEventListenerRegistry();
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/engine/spi/SessionFactoryImplementor.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/spi/SessionFactoryImplementor.java
@@ -7,15 +7,18 @@ package org.hibernate.engine.spi;
 import java.util.Collection;
 
 import org.hibernate.CustomEntityDirtinessStrategy;
+import org.hibernate.Incubating;
 import org.hibernate.Internal;
 import org.hibernate.SessionFactory;
 import org.hibernate.SessionFactoryObserver;
 import org.hibernate.boot.model.relational.SqlStringGenerationContext;
+import org.hibernate.boot.registry.classloading.spi.ClassLoaderService;
 import org.hibernate.boot.spi.SessionFactoryOptions;
 import org.hibernate.cache.spi.CacheImplementor;
 import org.hibernate.context.spi.CurrentTenantIdentifierResolver;
 import org.hibernate.engine.jdbc.spi.JdbcServices;
 import org.hibernate.engine.profile.FetchProfile;
+import org.hibernate.event.service.spi.EventListenerRegistry;
 import org.hibernate.event.spi.EntityCopyObserverFactory;
 import org.hibernate.event.spi.EventEngine;
 import org.hibernate.graph.spi.RootGraphImplementor;
@@ -26,6 +29,7 @@ import org.hibernate.metamodel.spi.RuntimeMetamodelsImplementor;
 import org.hibernate.proxy.EntityNotFoundDelegate;
 import org.hibernate.query.spi.QueryParameterBindingTypeResolver;
 import org.hibernate.query.sqm.spi.SqmCreationContext;
+import org.hibernate.resource.beans.spi.ManagedBeanRegistry;
 import org.hibernate.service.spi.ServiceRegistryImplementor;
 import org.hibernate.sql.ast.spi.ParameterMarkerStrategy;
 import org.hibernate.sql.ast.spi.SqlAstCreationContext;
@@ -158,6 +162,7 @@ public interface SessionFactoryImplementor
 	 *
 	 * @since 7.0
 	 */
+	@Internal @Incubating
 	EventListenerGroups getEventListenerGroups();
 
 	/**
@@ -172,17 +177,38 @@ public interface SessionFactoryImplementor
 	/**
 	 * @since 7.0
 	 */
+	@Incubating
 	ParameterMarkerStrategy getParameterMarkerStrategy();
 
 	/**
 	 * @since 7.0
 	 */
+	@Incubating
 	JdbcValuesMappingProducerProvider getJdbcValuesMappingProducerProvider();
 
 	/**
 	 * @since 7.0
 	 */
+	@Incubating
 	EntityCopyObserverFactory getEntityCopyObserver();
+
+	/**
+	 * @since 7.0
+	 */
+	@Incubating
+	ClassLoaderService getClassLoaderService();
+
+	/**
+	 * @since 7.0
+	 */
+	@Incubating
+	ManagedBeanRegistry getManagedBeanRegistry();
+
+	/**
+	 * @since 7.0
+	 */
+	@Incubating
+	EventListenerRegistry getEventListenerRegistry();
 
 	/**
 	 * Return an instance of {@link WrapperOptions} which is not backed by a session,
@@ -214,5 +240,4 @@ public interface SessionFactoryImplementor
 	 * The best guess entity name for an entity not in an association
 	 */
 	String bestGuessEntityName(Object object);
-
 }

--- a/hibernate-core/src/main/java/org/hibernate/engine/spi/SessionFactoryImplementor.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/spi/SessionFactoryImplementor.java
@@ -7,6 +7,7 @@ package org.hibernate.engine.spi;
 import java.util.Collection;
 
 import org.hibernate.CustomEntityDirtinessStrategy;
+import org.hibernate.Internal;
 import org.hibernate.SessionFactory;
 import org.hibernate.SessionFactoryObserver;
 import org.hibernate.boot.model.relational.SqlStringGenerationContext;
@@ -15,8 +16,10 @@ import org.hibernate.cache.spi.CacheImplementor;
 import org.hibernate.context.spi.CurrentTenantIdentifierResolver;
 import org.hibernate.engine.jdbc.spi.JdbcServices;
 import org.hibernate.engine.profile.FetchProfile;
+import org.hibernate.event.spi.EntityCopyObserverFactory;
 import org.hibernate.event.spi.EventEngine;
 import org.hibernate.graph.spi.RootGraphImplementor;
+import org.hibernate.event.service.spi.EventListenerGroups;
 import org.hibernate.internal.FastSessionServices;
 import org.hibernate.metamodel.spi.MappingMetamodelImplementor;
 import org.hibernate.metamodel.spi.RuntimeMetamodelsImplementor;
@@ -24,7 +27,9 @@ import org.hibernate.proxy.EntityNotFoundDelegate;
 import org.hibernate.query.spi.QueryParameterBindingTypeResolver;
 import org.hibernate.query.sqm.spi.SqmCreationContext;
 import org.hibernate.service.spi.ServiceRegistryImplementor;
+import org.hibernate.sql.ast.spi.ParameterMarkerStrategy;
 import org.hibernate.sql.ast.spi.SqlAstCreationContext;
+import org.hibernate.sql.results.jdbc.spi.JdbcValuesMappingProducerProvider;
 import org.hibernate.stat.spi.StatisticsImplementor;
 import org.hibernate.generator.Generator;
 import org.hibernate.type.descriptor.WrapperOptions;
@@ -149,9 +154,35 @@ public interface SessionFactoryImplementor
 	JavaType<Object> getTenantIdentifierJavaType();
 
 	/**
-	 * @return the {@link FastSessionServices} instance associated with this factory
+	 * Access to the event listener groups.
+	 *
+	 * @since 7.0
 	 */
+	EventListenerGroups getEventListenerGroups();
+
+	/**
+	 * @return the {@link FastSessionServices} instance associated with this factory
+	 *
+	 * @deprecated {@link FastSessionServices} belongs to an internal non-SPI package,
+	 *             and so this operation is a layer-breaker
+	 */
+	@Internal @Deprecated(since = "7.0", forRemoval = true)
 	FastSessionServices getFastSessionServices();
+
+	/**
+	 * @since 7.0
+	 */
+	ParameterMarkerStrategy getParameterMarkerStrategy();
+
+	/**
+	 * @since 7.0
+	 */
+	JdbcValuesMappingProducerProvider getJdbcValuesMappingProducerProvider();
+
+	/**
+	 * @since 7.0
+	 */
+	EntityCopyObserverFactory getEntityCopyObserver();
 
 	/**
 	 * Return an instance of {@link WrapperOptions} which is not backed by a session,

--- a/hibernate-core/src/main/java/org/hibernate/event/internal/AbstractFlushingEventListener.java
+++ b/hibernate-core/src/main/java/org/hibernate/event/internal/AbstractFlushingEventListener.java
@@ -209,7 +209,7 @@ public abstract class AbstractFlushingEventListener {
 
 		final EventSource source = event.getSession();
 		final EventListenerGroup<FlushEntityEventListener> flushListeners =
-				event.getFactory().getFastSessionServices().eventListenerGroup_FLUSH_ENTITY;
+				event.getFactory().getEventListenerGroups().eventListenerGroup_FLUSH_ENTITY;
 
 		// Among other things, updateReachables() recursively loads all
 		// collections that are changing roles. This might cause entities

--- a/hibernate-core/src/main/java/org/hibernate/event/internal/DefaultDeleteEventListener.java
+++ b/hibernate-core/src/main/java/org/hibernate/event/internal/DefaultDeleteEventListener.java
@@ -24,6 +24,7 @@ import org.hibernate.engine.spi.EntityEntry;
 import org.hibernate.engine.spi.EntityKey;
 import org.hibernate.engine.spi.PersistenceContext;
 import org.hibernate.engine.spi.Status;
+import org.hibernate.event.service.spi.EventListenerGroups;
 import org.hibernate.event.spi.DeleteContext;
 import org.hibernate.event.spi.DeleteEvent;
 import org.hibernate.event.spi.DeleteEventListener;
@@ -31,7 +32,6 @@ import org.hibernate.event.spi.EventSource;
 import org.hibernate.internal.CoreLogging;
 import org.hibernate.internal.CoreMessageLogger;
 import org.hibernate.internal.EmptyInterceptor;
-import org.hibernate.internal.FastSessionServices;
 import org.hibernate.jpa.event.spi.CallbackRegistry;
 import org.hibernate.jpa.event.spi.CallbackRegistryConsumer;
 import org.hibernate.jpa.event.spi.CallbackType;
@@ -298,14 +298,14 @@ public class DefaultDeleteEventListener implements DeleteEventListener,	Callback
 	}
 
 	private static boolean hasCustomEventListeners(EventSource source) {
-		FastSessionServices fss = source.getFactory().getFastSessionServices();
+		final EventListenerGroups eventListenerGroups = source.getFactory().getEventListenerGroups();
 		// Bean Validation adds a PRE_DELETE listener
 		// and Envers adds a POST_DELETE listener
-		return fss.eventListenerGroup_PRE_DELETE.count() > 0
-			|| fss.eventListenerGroup_POST_COMMIT_DELETE.count() > 0
-			|| fss.eventListenerGroup_POST_DELETE.count() > 1
-			|| fss.eventListenerGroup_POST_DELETE.count() == 1
-				&& !(fss.eventListenerGroup_POST_DELETE.listeners().iterator().next()
+		return eventListenerGroups.eventListenerGroup_PRE_DELETE.count() > 0
+			|| eventListenerGroups.eventListenerGroup_POST_COMMIT_DELETE.count() > 0
+			|| eventListenerGroups.eventListenerGroup_POST_DELETE.count() > 1
+			|| eventListenerGroups.eventListenerGroup_POST_DELETE.count() == 1
+				&& !(eventListenerGroups.eventListenerGroup_POST_DELETE.listeners().iterator().next()
 						instanceof PostDeleteEventListenerStandardImpl);
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/event/internal/DefaultMergeEventListener.java
+++ b/hibernate-core/src/main/java/org/hibernate/event/internal/DefaultMergeEventListener.java
@@ -81,7 +81,8 @@ public class DefaultMergeEventListener
 	@Override
 	public void onMerge(MergeEvent event) throws HibernateException {
 		final EventSource session = event.getSession();
-		final EntityCopyObserver entityCopyObserver = createEntityCopyObserver( session );
+		final EntityCopyObserver entityCopyObserver =
+				session.getFactory().getEntityCopyObserver().createEntityCopyObserver();
 		final MergeContext mergeContext = new MergeContext( session, entityCopyObserver );
 		try {
 			onMerge( event, mergeContext );
@@ -91,10 +92,6 @@ public class DefaultMergeEventListener
 			entityCopyObserver.clear();
 			mergeContext.clear();
 		}
-	}
-
-	private EntityCopyObserver createEntityCopyObserver(final EventSource session) {
-		return session.getFactory().getFastSessionServices().entityCopyObserverFactory.createEntityCopyObserver();
 	}
 
 	/**

--- a/hibernate-core/src/main/java/org/hibernate/event/service/spi/EventListenerGroups.java
+++ b/hibernate-core/src/main/java/org/hibernate/event/service/spi/EventListenerGroups.java
@@ -1,0 +1,145 @@
+/*
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.event.service.spi;
+
+import org.hibernate.Incubating;
+import org.hibernate.Internal;
+import org.hibernate.event.spi.AutoFlushEventListener;
+import org.hibernate.event.spi.ClearEventListener;
+import org.hibernate.event.spi.DeleteEventListener;
+import org.hibernate.event.spi.DirtyCheckEventListener;
+import org.hibernate.event.spi.EventType;
+import org.hibernate.event.spi.EvictEventListener;
+import org.hibernate.event.spi.FlushEntityEventListener;
+import org.hibernate.event.spi.FlushEventListener;
+import org.hibernate.event.spi.InitializeCollectionEventListener;
+import org.hibernate.event.spi.LoadEventListener;
+import org.hibernate.event.spi.LockEventListener;
+import org.hibernate.event.spi.MergeEventListener;
+import org.hibernate.event.spi.PersistEventListener;
+import org.hibernate.event.spi.PostCollectionRecreateEventListener;
+import org.hibernate.event.spi.PostCollectionRemoveEventListener;
+import org.hibernate.event.spi.PostCollectionUpdateEventListener;
+import org.hibernate.event.spi.PostDeleteEventListener;
+import org.hibernate.event.spi.PostInsertEventListener;
+import org.hibernate.event.spi.PostLoadEventListener;
+import org.hibernate.event.spi.PostUpdateEventListener;
+import org.hibernate.event.spi.PostUpsertEventListener;
+import org.hibernate.event.spi.PreCollectionRecreateEventListener;
+import org.hibernate.event.spi.PreCollectionRemoveEventListener;
+import org.hibernate.event.spi.PreCollectionUpdateEventListener;
+import org.hibernate.event.spi.PreDeleteEventListener;
+import org.hibernate.event.spi.PreInsertEventListener;
+import org.hibernate.event.spi.PreLoadEventListener;
+import org.hibernate.event.spi.PreUpdateEventListener;
+import org.hibernate.event.spi.PreUpsertEventListener;
+import org.hibernate.event.spi.RefreshEventListener;
+import org.hibernate.event.spi.ReplicateEventListener;
+import org.hibernate.service.ServiceRegistry;
+
+import java.util.Objects;
+
+/**
+ * Holds the {@link org.hibernate.event.spi event} listener groups for the various event types.
+ *
+ * @author Sanne Grinovero
+ * @author Gavin King
+ *
+ * @since 7.0
+ */
+@Internal @Incubating
+public class EventListenerGroups {
+
+	// All session events need to be iterated frequently;
+	// CollectionAction and EventAction also need most of these very frequently:
+	public final EventListenerGroup<AutoFlushEventListener> eventListenerGroup_AUTO_FLUSH;
+	public final EventListenerGroup<ClearEventListener> eventListenerGroup_CLEAR;
+	public final EventListenerGroup<DeleteEventListener> eventListenerGroup_DELETE;
+	public final EventListenerGroup<DirtyCheckEventListener> eventListenerGroup_DIRTY_CHECK;
+	public final EventListenerGroup<EvictEventListener> eventListenerGroup_EVICT;
+	public final EventListenerGroup<FlushEntityEventListener> eventListenerGroup_FLUSH_ENTITY;
+	public final EventListenerGroup<FlushEventListener> eventListenerGroup_FLUSH;
+	public final EventListenerGroup<InitializeCollectionEventListener> eventListenerGroup_INIT_COLLECTION;
+	public final EventListenerGroup<LoadEventListener> eventListenerGroup_LOAD;
+	public final EventListenerGroup<LockEventListener> eventListenerGroup_LOCK;
+	public final EventListenerGroup<MergeEventListener> eventListenerGroup_MERGE;
+	public final EventListenerGroup<PersistEventListener> eventListenerGroup_PERSIST;
+	public final EventListenerGroup<PersistEventListener> eventListenerGroup_PERSIST_ONFLUSH;
+	public final EventListenerGroup<PostCollectionRecreateEventListener> eventListenerGroup_POST_COLLECTION_RECREATE;
+	public final EventListenerGroup<PostCollectionRemoveEventListener> eventListenerGroup_POST_COLLECTION_REMOVE;
+	public final EventListenerGroup<PostCollectionUpdateEventListener> eventListenerGroup_POST_COLLECTION_UPDATE;
+	public final EventListenerGroup<PostDeleteEventListener> eventListenerGroup_POST_COMMIT_DELETE;
+	public final EventListenerGroup<PostDeleteEventListener> eventListenerGroup_POST_DELETE;
+	public final EventListenerGroup<PostInsertEventListener> eventListenerGroup_POST_COMMIT_INSERT;
+	public final EventListenerGroup<PostInsertEventListener> eventListenerGroup_POST_INSERT;
+	public final EventListenerGroup<PostLoadEventListener> eventListenerGroup_POST_LOAD; //Frequently used by 2LC initialization:
+	public final EventListenerGroup<PostUpdateEventListener> eventListenerGroup_POST_COMMIT_UPDATE;
+	public final EventListenerGroup<PostUpdateEventListener> eventListenerGroup_POST_UPDATE;
+	public final EventListenerGroup<PostUpsertEventListener> eventListenerGroup_POST_UPSERT;
+	public final EventListenerGroup<PreCollectionRecreateEventListener> eventListenerGroup_PRE_COLLECTION_RECREATE;
+	public final EventListenerGroup<PreCollectionRemoveEventListener> eventListenerGroup_PRE_COLLECTION_REMOVE;
+	public final EventListenerGroup<PreCollectionUpdateEventListener> eventListenerGroup_PRE_COLLECTION_UPDATE;
+	public final EventListenerGroup<PreDeleteEventListener> eventListenerGroup_PRE_DELETE;
+	public final EventListenerGroup<PreInsertEventListener> eventListenerGroup_PRE_INSERT;
+	public final EventListenerGroup<PreLoadEventListener> eventListenerGroup_PRE_LOAD;
+	public final EventListenerGroup<PreUpdateEventListener> eventListenerGroup_PRE_UPDATE;
+	public final EventListenerGroup<PreUpsertEventListener> eventListenerGroup_PRE_UPSERT;
+	public final EventListenerGroup<RefreshEventListener> eventListenerGroup_REFRESH;
+	public final EventListenerGroup<ReplicateEventListener> eventListenerGroup_REPLICATE;
+
+	private static <T> EventListenerGroup<T> listeners(EventListenerRegistry listenerRegistry, EventType<T> type) {
+		return listenerRegistry.getEventListenerGroup( type );
+	}
+
+	public EventListenerGroups(ServiceRegistry serviceRegistry) {
+		Objects.requireNonNull( serviceRegistry );
+
+		final EventListenerRegistry eventListenerRegistry =
+				serviceRegistry.requireService( EventListenerRegistry.class );
+
+		// Pre-compute all iterators on Event listeners:
+
+		this.eventListenerGroup_AUTO_FLUSH = listeners( eventListenerRegistry, EventType.AUTO_FLUSH );
+		this.eventListenerGroup_CLEAR = listeners( eventListenerRegistry, EventType.CLEAR );
+		this.eventListenerGroup_DELETE = listeners( eventListenerRegistry, EventType.DELETE );
+		this.eventListenerGroup_DIRTY_CHECK = listeners( eventListenerRegistry, EventType.DIRTY_CHECK );
+		this.eventListenerGroup_EVICT = listeners( eventListenerRegistry, EventType.EVICT );
+		this.eventListenerGroup_FLUSH = listeners( eventListenerRegistry, EventType.FLUSH );
+		this.eventListenerGroup_FLUSH_ENTITY = listeners( eventListenerRegistry, EventType.FLUSH_ENTITY );
+		this.eventListenerGroup_INIT_COLLECTION = listeners( eventListenerRegistry, EventType.INIT_COLLECTION );
+		this.eventListenerGroup_LOAD = listeners( eventListenerRegistry, EventType.LOAD );
+		this.eventListenerGroup_LOCK = listeners( eventListenerRegistry, EventType.LOCK );
+		this.eventListenerGroup_MERGE = listeners( eventListenerRegistry, EventType.MERGE );
+		this.eventListenerGroup_PERSIST = listeners( eventListenerRegistry, EventType.PERSIST );
+		this.eventListenerGroup_PERSIST_ONFLUSH = listeners( eventListenerRegistry, EventType.PERSIST_ONFLUSH );
+		this.eventListenerGroup_POST_COLLECTION_RECREATE = listeners( eventListenerRegistry,
+				EventType.POST_COLLECTION_RECREATE );
+		this.eventListenerGroup_POST_COLLECTION_REMOVE = listeners( eventListenerRegistry,
+				EventType.POST_COLLECTION_REMOVE );
+		this.eventListenerGroup_POST_COLLECTION_UPDATE = listeners( eventListenerRegistry,
+				EventType.POST_COLLECTION_UPDATE );
+		this.eventListenerGroup_POST_COMMIT_DELETE = listeners( eventListenerRegistry, EventType.POST_COMMIT_DELETE );
+		this.eventListenerGroup_POST_COMMIT_INSERT = listeners( eventListenerRegistry, EventType.POST_COMMIT_INSERT );
+		this.eventListenerGroup_POST_COMMIT_UPDATE = listeners( eventListenerRegistry, EventType.POST_COMMIT_UPDATE );
+		this.eventListenerGroup_POST_DELETE = listeners( eventListenerRegistry, EventType.POST_DELETE );
+		this.eventListenerGroup_POST_INSERT = listeners( eventListenerRegistry, EventType.POST_INSERT );
+		this.eventListenerGroup_POST_LOAD = listeners( eventListenerRegistry, EventType.POST_LOAD );
+		this.eventListenerGroup_POST_UPDATE = listeners( eventListenerRegistry, EventType.POST_UPDATE );
+		this.eventListenerGroup_POST_UPSERT = listeners( eventListenerRegistry, EventType.POST_UPSERT );
+		this.eventListenerGroup_PRE_COLLECTION_RECREATE = listeners( eventListenerRegistry,
+				EventType.PRE_COLLECTION_RECREATE );
+		this.eventListenerGroup_PRE_COLLECTION_REMOVE = listeners( eventListenerRegistry,
+				EventType.PRE_COLLECTION_REMOVE );
+		this.eventListenerGroup_PRE_COLLECTION_UPDATE = listeners( eventListenerRegistry,
+				EventType.PRE_COLLECTION_UPDATE );
+		this.eventListenerGroup_PRE_DELETE = listeners( eventListenerRegistry, EventType.PRE_DELETE );
+		this.eventListenerGroup_PRE_INSERT = listeners( eventListenerRegistry, EventType.PRE_INSERT );
+		this.eventListenerGroup_PRE_LOAD = listeners( eventListenerRegistry, EventType.PRE_LOAD );
+		this.eventListenerGroup_PRE_UPDATE = listeners( eventListenerRegistry, EventType.PRE_UPDATE );
+		this.eventListenerGroup_PRE_UPSERT = listeners( eventListenerRegistry, EventType.PRE_UPSERT );
+		this.eventListenerGroup_REFRESH = listeners( eventListenerRegistry, EventType.REFRESH );
+		this.eventListenerGroup_REPLICATE = listeners( eventListenerRegistry, EventType.REPLICATE );
+	}
+}

--- a/hibernate-core/src/main/java/org/hibernate/internal/AbstractSharedSessionContract.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/AbstractSharedSessionContract.java
@@ -32,6 +32,7 @@ import org.hibernate.SessionException;
 import org.hibernate.Transaction;
 import org.hibernate.UnknownEntityTypeException;
 import org.hibernate.binder.internal.TenantIdBinder;
+import org.hibernate.boot.spi.SessionFactoryOptions;
 import org.hibernate.cache.spi.CacheTransactionSynchronization;
 import org.hibernate.context.spi.CurrentTenantIdentifierResolver;
 import org.hibernate.dialect.Dialect;
@@ -107,7 +108,6 @@ import org.hibernate.resource.jdbc.spi.StatementInspector;
 import org.hibernate.resource.transaction.TransactionRequiredForJoinException;
 import org.hibernate.resource.transaction.backend.jta.internal.JtaTransactionCoordinatorImpl;
 import org.hibernate.resource.transaction.spi.TransactionCoordinator;
-import org.hibernate.resource.transaction.spi.TransactionCoordinatorBuilder;
 
 import jakarta.persistence.FlushModeType;
 import jakarta.persistence.TransactionRequiredException;
@@ -148,6 +148,8 @@ public abstract class AbstractSharedSessionContract implements SharedSessionCont
 	private static final CoreMessageLogger log = CoreLogging.messageLogger( SessionImpl.class );
 
 	private transient SessionFactoryImpl factory;
+	private transient SessionFactoryOptions factoryOptions;
+	private transient JdbcServices jdbcServices;
 	protected transient FastSessionServices fastSessionServices;
 
 	private UUID sessionIdentifier;
@@ -191,18 +193,21 @@ public abstract class AbstractSharedSessionContract implements SharedSessionCont
 
 	public AbstractSharedSessionContract(SessionFactoryImpl factory, SessionCreationOptions options) {
 		this.factory = factory;
+		this.factoryOptions = factory.getSessionFactoryOptions();
+		this.jdbcServices = factory.getJdbcServices();
 
 		fastSessionServices = factory.getFastSessionServices();
 		cacheTransactionSync = factory.getCache().getRegionFactory().createTransactionContext( this );
 		flushMode = options.getInitialSessionFlushMode();
-		tenantIdentifier = getTenantId( factory, options );
+		tenantIdentifier = getTenantId( factoryOptions, options );
 		interceptor = interpret( options.getInterceptor() );
 		jdbcTimeZone = options.getJdbcTimeZone();
-		sessionEventsManager = createSessionEventsManager(options);
+		sessionEventsManager = createSessionEventsManager( factoryOptions, options );
 		entityNameResolver = new CoordinatingEntityNameResolver( factory, interceptor );
-		setCriteriaCopyTreeEnabled( factory.getSessionFactoryOptions().isCriteriaCopyTreeEnabled() );
-		setNativeJdbcParametersIgnored( factory.getSessionFactoryOptions().getNativeJdbcParametersIgnored() );
-		setCacheMode( fastSessionServices.initialSessionCacheMode );
+
+		setCriteriaCopyTreeEnabled( factoryOptions.isCriteriaCopyTreeEnabled() );
+		setNativeJdbcParametersIgnored( factoryOptions.getNativeJdbcParametersIgnored() );
+		setCacheMode( factoryOptions.getInitialSessionCacheMode() );
 
 		final StatementInspector statementInspector = interpret( options.getStatementInspector() );
 
@@ -229,9 +234,13 @@ public abstract class AbstractSharedSessionContract implements SharedSessionCont
 			// This must happen *after* the JdbcSessionContext was initialized,
 			// because some calls retrieve this context indirectly via Session getters.
 			jdbcCoordinator = createJdbcCoordinator( options );
-			transactionCoordinator = fastSessionServices.transactionCoordinatorBuilder
+			transactionCoordinator = fastSessionServices.getTransactionCoordinatorBuilder()
 					.buildTransactionCoordinator( jdbcCoordinator, this );
 		}
+	}
+
+	final SessionFactoryOptions getSessionFactoryOptions() {
+		return factoryOptions;
 	}
 
 	private static boolean isTransactionCoordinatorShared(SessionCreationOptions options) {
@@ -249,8 +258,7 @@ public abstract class AbstractSharedSessionContract implements SharedSessionCont
 				final CurrentTenantIdentifierResolver<Object> resolver = factory.getCurrentTenantIdentifierResolver();
 				if ( resolver==null || !resolver.isRoot( tenantIdentifier ) ) {
 					// turn on the filter, unless this is the "root" tenant with access to all partitions
-					loadQueryInfluencers
-							.enableFilter( TenantIdBinder.FILTER_NAME )
+					loadQueryInfluencers.enableFilter( TenantIdBinder.FILTER_NAME )
 							.setParameter( TenantIdBinder.PARAMETER_NAME, tenantIdentifier );
 				}
 			}
@@ -259,21 +267,17 @@ public abstract class AbstractSharedSessionContract implements SharedSessionCont
 
 	private void logInconsistentOptions(SharedSessionCreationOptions sharedOptions) {
 		if ( sharedOptions.shouldAutoJoinTransactions() ) {
-			log.debug(
-					"Session creation specified 'autoJoinTransactions', which is invalid in conjunction " +
-							"with sharing JDBC connection between sessions; ignoring"
-			);
+			log.debug( "Session creation specified 'autoJoinTransactions', which is invalid in conjunction " +
+							"with sharing JDBC connection between sessions; ignoring" );
 		}
 		if ( sharedOptions.getPhysicalConnectionHandlingMode() != connectionHandlingMode ) {
-			log.debug(
-					"Session creation specified 'PhysicalConnectionHandlingMode' which is invalid in conjunction " +
-							"with sharing JDBC connection between sessions; ignoring"
-			);
+			log.debug( "Session creation specified 'PhysicalConnectionHandlingMode' which is invalid in conjunction " +
+							"with sharing JDBC connection between sessions; ignoring" );
 		}
 	}
 
 	private JdbcCoordinatorImpl createJdbcCoordinator(SessionCreationOptions options) {
-		return new JdbcCoordinatorImpl( options.getConnection(), this, fastSessionServices.jdbcServices );
+		return new JdbcCoordinatorImpl( options.getConnection(), this, getJdbcServices() );
 	}
 
 	private JdbcSessionContextImpl createJdbcSessionContext(StatementInspector statementInspector) {
@@ -281,8 +285,8 @@ public abstract class AbstractSharedSessionContract implements SharedSessionCont
 				factory,
 				statementInspector,
 				connectionHandlingMode,
-				fastSessionServices.jdbcServices,
-				fastSessionServices.batchBuilder,
+				getJdbcServices(),
+				fastSessionServices.getBatchBuilder(),
 				// TODO: this object is deprecated and should be removed
 				new JdbcEventHandler(
 						factory.getStatistics(),
@@ -293,19 +297,25 @@ public abstract class AbstractSharedSessionContract implements SharedSessionCont
 		);
 	}
 
-	private Object getTenantId( SessionFactoryImpl factory, SessionCreationOptions options ) {
+	private static Object getTenantId( SessionFactoryOptions factoryOptions, SessionCreationOptions options ) {
 		final Object tenantIdentifier = options.getTenantIdentifierValue();
-		if ( factory.getSessionFactoryOptions().isMultiTenancyEnabled() && tenantIdentifier == null ) {
+		if ( factoryOptions.isMultiTenancyEnabled() && tenantIdentifier == null ) {
 			throw new HibernateException( "SessionFactory configured for multi-tenancy, but no tenant identifier specified" );
 		}
 		return tenantIdentifier;
 	}
 
-	private SessionEventListenerManager createSessionEventsManager(SessionCreationOptions options) {
-		final List<SessionEventListener> customSessionEventListener = options.getCustomSessionEventListener();
-		return customSessionEventListener == null
-				? new SessionEventListenerManagerImpl( fastSessionServices.defaultSessionEventListeners.buildBaseline() )
-				: new SessionEventListenerManagerImpl( customSessionEventListener.toArray( new SessionEventListener[0] ) );
+	private static SessionEventListenerManager createSessionEventsManager(
+			SessionFactoryOptions factoryOptions, SessionCreationOptions options) {
+		final List<SessionEventListener> customListeners = options.getCustomSessionEventListener();
+		if ( customListeners == null ) {
+			final SessionEventListener[] baseline =
+					factoryOptions.getBaselineSessionEventsListenerBuilder().buildBaseline();
+			return new SessionEventListenerManagerImpl( baseline );
+		}
+		else {
+			return new SessionEventListenerManagerImpl( customListeners );
+		}
 	}
 
 	/**
@@ -317,7 +327,7 @@ public abstract class AbstractSharedSessionContract implements SharedSessionCont
 	public Integer getConfiguredJdbcBatchSize() {
 		final Integer sessionJdbcBatchSize = jdbcBatchSize;
 		return sessionJdbcBatchSize == null
-				? fastSessionServices.defaultJdbcBatchSize
+				? getSessionFactoryOptions().getJdbcBatchSize()
 				: sessionJdbcBatchSize;
 	}
 
@@ -354,7 +364,7 @@ public abstract class AbstractSharedSessionContract implements SharedSessionCont
 		// We do not want an exception to be thrown if the transaction
 		// is not accessible. If the transaction is not accessible,
 		// then return null.
-		return fastSessionServices.isJtaTransactionAccessible ? accessTransaction() : null;
+		return isTransactionAccessible() ? accessTransaction() : null;
 	}
 
 	protected void addSharedSessionTransactionObserver(TransactionCoordinator transactionCoordinator) {
@@ -467,7 +477,7 @@ public abstract class AbstractSharedSessionContract implements SharedSessionCont
 				delayedAfterCompletion();
 			}
 			catch ( HibernateException e ) {
-				if ( getFactory().getSessionFactoryOptions().isJpaBootstrap() ) {
+				if ( getSessionFactoryOptions().isJpaBootstrap() ) {
 					throw getExceptionConverter().convert( e );
 				}
 				else {
@@ -553,14 +563,24 @@ public abstract class AbstractSharedSessionContract implements SharedSessionCont
 
 	@Override
 	public void checkTransactionNeededForUpdateOperation(String exceptionMessage) {
-		if ( fastSessionServices.disallowOutOfTransactionUpdateOperations && !isTransactionInProgress() ) {
+		if ( !getSessionFactoryOptions().isAllowOutOfTransactionUpdateOperations()
+				&& !isTransactionInProgress() ) {
 			throw new TransactionRequiredException( exceptionMessage );
 		}
 	}
 
+	private boolean isTransactionAccessible() {
+		// JPA requires that access not be provided to the transaction when using JTA.
+		// This is overridden when SessionFactoryOptions isJtaTransactionAccessEnabled() is true.
+		final SessionFactoryOptions sessionFactoryOptions = getSessionFactoryOptions();
+		return sessionFactoryOptions.isJtaTransactionAccessEnabled() // defaults to false in JPA bootstrap
+			|| !sessionFactoryOptions.getJpaCompliance().isJpaTransactionComplianceEnabled()
+			|| !fastSessionServices.getTransactionCoordinatorBuilder().isJta();
+	}
+
 	@Override
 	public Transaction getTransaction() throws HibernateException {
-		if ( ! fastSessionServices.isJtaTransactionAccessible ) {
+		if ( !isTransactionAccessible(  ) ) {
 			throw new IllegalStateException(
 					"Transaction is not accessible when using JTA with JPA-compliant transaction access enabled"
 			);
@@ -675,10 +695,10 @@ public abstract class AbstractSharedSessionContract implements SharedSessionCont
 	public JdbcConnectionAccess getJdbcConnectionAccess() {
 		// See class-level JavaDocs for a discussion of the concurrent-access safety of this method
 		if ( jdbcConnectionAccess == null ) {
-			if ( ! fastSessionServices.requiresMultiTenantConnectionProvider ) {
+			if ( !getSessionFactoryOptions().isMultiTenancyEnabled() ) {
 				jdbcConnectionAccess = new NonContextualJdbcConnectionAccess(
 						getEventListenerManager(),
-						fastSessionServices.connectionProvider,
+						fastSessionServices.getConnectionProvider(),
 						this
 				);
 			}
@@ -686,7 +706,7 @@ public abstract class AbstractSharedSessionContract implements SharedSessionCont
 				jdbcConnectionAccess = new ContextualJdbcConnectionAccess(
 						getTenantIdentifierValue(),
 						getEventListenerManager(),
-						fastSessionServices.multiTenantConnectionProvider,
+						fastSessionServices.getMultiTenantConnectionProvider(),
 						this
 				);
 			}
@@ -706,27 +726,27 @@ public abstract class AbstractSharedSessionContract implements SharedSessionCont
 
 	@Override
 	public boolean useStreamForLobBinding() {
-		return fastSessionServices.useStreamForLobBinding;
+		return getJdbcServices().getJdbcEnvironment().getDialect().useInputStreamToInsertBlob();
 	}
 
 	@Override
 	public int getPreferredSqlTypeCodeForBoolean() {
-		return fastSessionServices.preferredSqlTypeCodeForBoolean;
+		return getSessionFactoryOptions().getPreferredSqlTypeCodeForBoolean();
 	}
 
 	@Override
 	public LobCreator getLobCreator() {
-		return fastSessionServices.jdbcServices.getLobCreator( this );
+		return getJdbcServices().getLobCreator( this );
 	}
 
 	@Override
 	public Dialect getDialect() {
-		return fastSessionServices.dialect;
+		return getJdbcServices().getJdbcEnvironment().getDialect();
 	}
 
 	@Override
 	public TypeConfiguration getTypeConfiguration() {
-		return fastSessionServices.typeConfiguration;
+		return factory.getTypeConfiguration();
 	}
 
 	@Override
@@ -753,7 +773,7 @@ public abstract class AbstractSharedSessionContract implements SharedSessionCont
 
 	@Override
 	public JdbcServices getJdbcServices() {
-		return getFactory().getJdbcServices();
+		return jdbcServices;
 	}
 
 	@Override
@@ -1429,7 +1449,7 @@ public abstract class AbstractSharedSessionContract implements SharedSessionCont
 
 	@Override
 	public EventMonitor getEventMonitor() {
-		return fastSessionServices.eventMonitor;
+		return fastSessionServices.getEventMonitor();
 	}
 
 	@Override
@@ -1570,12 +1590,12 @@ public abstract class AbstractSharedSessionContract implements SharedSessionCont
 
 	@Override
 	public FormatMapper getXmlFormatMapper() {
-		return fastSessionServices.getXmlFormatMapper();
+		return getSessionFactoryOptions().getXmlFormatMapper();
 	}
 
 	@Override
 	public FormatMapper getJsonFormatMapper() {
-		return fastSessionServices.getJsonFormatMapper();
+		return getSessionFactoryOptions().getJsonFormatMapper();
 	}
 
 	@Serial
@@ -1628,16 +1648,23 @@ public abstract class AbstractSharedSessionContract implements SharedSessionCont
 		//		-- see above
 
 		factory = SessionFactoryImpl.deserialize( ois );
+		factoryOptions = factory.getSessionFactoryOptions();
+		jdbcServices = factory.getJdbcServices();
 		fastSessionServices = factory.getFastSessionServices();
-		sessionEventsManager = new SessionEventListenerManagerImpl( fastSessionServices.defaultSessionEventListeners.buildBaseline() );
+
+		//TODO: this isn't quite right, see createSessionEventsManager()
+		final SessionEventListener[] baseline =
+				factoryOptions.getBaselineSessionEventsListenerBuilder()
+						.buildBaseline();
+		sessionEventsManager = new SessionEventListenerManagerImpl( baseline );
+
 		jdbcSessionContext = createJdbcSessionContext( (StatementInspector) ois.readObject() );
 		jdbcCoordinator = JdbcCoordinatorImpl.deserialize( ois, this );
 
 		cacheTransactionSync = factory.getCache().getRegionFactory().createTransactionContext( this );
-
-		transactionCoordinator = factory.getServiceRegistry()
-				.requireService( TransactionCoordinatorBuilder.class )
-				.buildTransactionCoordinator( jdbcCoordinator, this );
+		transactionCoordinator =
+				fastSessionServices.getTransactionCoordinatorBuilder()
+						.buildTransactionCoordinator( jdbcCoordinator, this );
 
 		entityNameResolver = new CoordinatingEntityNameResolver( factory, interceptor );
 	}

--- a/hibernate-core/src/main/java/org/hibernate/internal/FastSessionServices.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/FastSessionServices.java
@@ -5,12 +5,12 @@
 package org.hibernate.internal;
 
 import org.hibernate.boot.registry.classloading.spi.ClassLoaderService;
+import org.hibernate.boot.spi.SessionFactoryOptions;
 import org.hibernate.engine.config.spi.ConfigurationService;
 import org.hibernate.engine.jdbc.batch.spi.BatchBuilder;
 import org.hibernate.engine.jdbc.connections.spi.ConnectionProvider;
 import org.hibernate.engine.jdbc.connections.spi.MultiTenantConnectionProvider;
 import org.hibernate.engine.jdbc.spi.JdbcServices;
-import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.event.monitor.internal.EmptyEventMonitor;
 import org.hibernate.event.monitor.spi.EventMonitor;
 import org.hibernate.event.spi.EntityCopyObserverFactory;
@@ -42,7 +42,7 @@ import java.util.Collection;
  *
  * @author Sanne Grinovero
  */
-public final class FastSessionServices extends EventListenerGroups {
+public class FastSessionServices extends EventListenerGroups {
 
 	private final ConnectionProvider connectionProvider;
 	private final MultiTenantConnectionProvider<Object> multiTenantConnectionProvider;
@@ -57,9 +57,8 @@ public final class FastSessionServices extends EventListenerGroups {
 	private final ManagedBeanRegistry managedBeanRegistry;
 	private final ConfigurationService configurationService;
 
-	FastSessionServices(SessionFactoryImplementor sessionFactory) {
-		super( sessionFactory.getServiceRegistry() );
-		final ServiceRegistry serviceRegistry = sessionFactory.getServiceRegistry();
+	FastSessionServices(ServiceRegistry serviceRegistry, SessionFactoryOptions factoryOptions) {
+		super( serviceRegistry );
 
 		//Some "hot" services:
 		classLoaderService = serviceRegistry.requireService( ClassLoaderService.class );
@@ -72,7 +71,7 @@ public final class FastSessionServices extends EventListenerGroups {
 		managedBeanRegistry = serviceRegistry.getService( ManagedBeanRegistry.class );
 		configurationService = serviceRegistry.getService( ConfigurationService.class );
 
-		final boolean multiTenancyEnabled = sessionFactory.getSessionFactoryOptions().isMultiTenancyEnabled();
+		final boolean multiTenancyEnabled = factoryOptions.isMultiTenancyEnabled();
 		connectionProvider =
 				multiTenancyEnabled ? null : serviceRegistry.getService( ConnectionProvider.class );
 		multiTenantConnectionProvider =

--- a/hibernate-core/src/main/java/org/hibernate/internal/FastSessionServices.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/FastSessionServices.java
@@ -4,19 +4,7 @@
  */
 package org.hibernate.internal;
 
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Objects;
-import java.util.TimeZone;
-
-import org.hibernate.CacheMode;
-import org.hibernate.FlushMode;
-import org.hibernate.HibernateException;
-import org.hibernate.LockOptions;
 import org.hibernate.boot.registry.classloading.spi.ClassLoaderService;
-import org.hibernate.boot.spi.SessionFactoryOptions;
-import org.hibernate.dialect.Dialect;
 import org.hibernate.engine.jdbc.batch.spi.BatchBuilder;
 import org.hibernate.engine.jdbc.connections.spi.ConnectionProvider;
 import org.hibernate.engine.jdbc.connections.spi.MultiTenantConnectionProvider;
@@ -24,335 +12,107 @@ import org.hibernate.engine.jdbc.spi.JdbcServices;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.event.monitor.internal.EmptyEventMonitor;
 import org.hibernate.event.monitor.spi.EventMonitor;
-import org.hibernate.event.service.spi.EventListenerGroup;
-import org.hibernate.event.service.spi.EventListenerRegistry;
-import org.hibernate.event.spi.*;
-import org.hibernate.jpa.HibernateHints;
-import org.hibernate.jpa.LegacySpecHints;
-import org.hibernate.jpa.SpecHints;
-import org.hibernate.jpa.internal.util.CacheModeHelper;
-import org.hibernate.jpa.internal.util.ConfigurationHelper;
+import org.hibernate.event.spi.EntityCopyObserverFactory;
+import org.hibernate.event.service.spi.EventListenerGroups;
 import org.hibernate.resource.transaction.spi.TransactionCoordinatorBuilder;
-import org.hibernate.service.spi.ServiceRegistryImplementor;
+import org.hibernate.service.ServiceRegistry;
 import org.hibernate.sql.ast.spi.ParameterMarkerStrategy;
 import org.hibernate.sql.results.jdbc.spi.JdbcValuesMappingProducerProvider;
-import org.hibernate.type.format.FormatMapper;
 
-import jakarta.persistence.CacheRetrieveMode;
-import jakarta.persistence.CacheStoreMode;
-import jakarta.persistence.PessimisticLockScope;
-import org.hibernate.type.spi.TypeConfiguration;
-
-import static java.util.Collections.unmodifiableMap;
-import static org.hibernate.cfg.AvailableSettings.JAKARTA_LOCK_SCOPE;
-import static org.hibernate.cfg.AvailableSettings.JAKARTA_LOCK_TIMEOUT;
-import static org.hibernate.cfg.AvailableSettings.JAKARTA_SHARED_CACHE_RETRIEVE_MODE;
-import static org.hibernate.cfg.AvailableSettings.JAKARTA_SHARED_CACHE_STORE_MODE;
-import static org.hibernate.cfg.AvailableSettings.JPA_LOCK_SCOPE;
-import static org.hibernate.cfg.AvailableSettings.JPA_LOCK_TIMEOUT;
-import static org.hibernate.cfg.AvailableSettings.JPA_SHARED_CACHE_RETRIEVE_MODE;
-import static org.hibernate.cfg.AvailableSettings.JPA_SHARED_CACHE_STORE_MODE;
-import static org.hibernate.internal.LockOptionsHelper.applyPropertiesToLockOptions;
+import java.util.Collection;
 
 /**
  * Internal component.
  * <p>
- * Collects any components that any Session implementation will likely need
- * for faster access and reduced allocations.
- * Conceptually this acts as an immutable caching intermediary between Session
- * and SessionFactory.
+ * Collects services that any Session implementation will likely need for faster access
+ * and reduced allocations. Conceptually this acts as an immutable caching intermediary
+ * between Session and ServiceRegistry.
  * <p>
  * Designed to be immutable, shared across Session instances, and created infrequently,
  * possibly only once per SessionFactory.
  * <p>
  * If the Session is requiring to retrieve (or compute) anything from the SessionFactory,
- * and this computation would result in the same outcome for any Session created on
- * this same SessionFactory, then it belongs in a final field of this class.
+ * and this computation would result in the same outcome for any Session created on this
+ * same SessionFactory, then it belongs in a final field of this class.
  * <p>
  * Finally, consider also limiting the size of each Session: some fields could be good
  * candidates to be replaced with access via this object.
  *
  * @author Sanne Grinovero
  */
-public final class FastSessionServices {
+public final class FastSessionServices extends EventListenerGroups {
 
-	/**
-	 * Default session properties
-	 */
-	final Map<String, Object> defaultSessionProperties;
-
-	// All session events need to be iterated frequently; CollectionAction and EventAction also need
-	// most of these very frequently:
-	public final EventListenerGroup<AutoFlushEventListener> eventListenerGroup_AUTO_FLUSH;
-	public final EventListenerGroup<ClearEventListener> eventListenerGroup_CLEAR;
-	public final EventListenerGroup<DeleteEventListener> eventListenerGroup_DELETE;
-	public final EventListenerGroup<DirtyCheckEventListener> eventListenerGroup_DIRTY_CHECK;
-	public final EventListenerGroup<EvictEventListener> eventListenerGroup_EVICT;
-	public final EventListenerGroup<FlushEntityEventListener> eventListenerGroup_FLUSH_ENTITY;
-	public final EventListenerGroup<FlushEventListener> eventListenerGroup_FLUSH;
-	public final EventListenerGroup<InitializeCollectionEventListener> eventListenerGroup_INIT_COLLECTION;
-	public final EventListenerGroup<LoadEventListener> eventListenerGroup_LOAD;
-	public final EventListenerGroup<LockEventListener> eventListenerGroup_LOCK;
-	public final EventListenerGroup<MergeEventListener> eventListenerGroup_MERGE;
-	public final EventListenerGroup<PersistEventListener> eventListenerGroup_PERSIST;
-	public final EventListenerGroup<PersistEventListener> eventListenerGroup_PERSIST_ONFLUSH;
-	public final EventListenerGroup<PostCollectionRecreateEventListener> eventListenerGroup_POST_COLLECTION_RECREATE;
-	public final EventListenerGroup<PostCollectionRemoveEventListener> eventListenerGroup_POST_COLLECTION_REMOVE;
-	public final EventListenerGroup<PostCollectionUpdateEventListener> eventListenerGroup_POST_COLLECTION_UPDATE;
-	public final EventListenerGroup<PostDeleteEventListener> eventListenerGroup_POST_COMMIT_DELETE;
-	public final EventListenerGroup<PostDeleteEventListener> eventListenerGroup_POST_DELETE;
-	public final EventListenerGroup<PostInsertEventListener> eventListenerGroup_POST_COMMIT_INSERT;
-	public final EventListenerGroup<PostInsertEventListener> eventListenerGroup_POST_INSERT;
-	public final EventListenerGroup<PostLoadEventListener> eventListenerGroup_POST_LOAD; //Frequently used by 2LC initialization:
-	public final EventListenerGroup<PostUpdateEventListener> eventListenerGroup_POST_COMMIT_UPDATE;
-	public final EventListenerGroup<PostUpdateEventListener> eventListenerGroup_POST_UPDATE;
-	public final EventListenerGroup<PostUpsertEventListener> eventListenerGroup_POST_UPSERT;
-	public final EventListenerGroup<PreCollectionRecreateEventListener> eventListenerGroup_PRE_COLLECTION_RECREATE;
-	public final EventListenerGroup<PreCollectionRemoveEventListener> eventListenerGroup_PRE_COLLECTION_REMOVE;
-	public final EventListenerGroup<PreCollectionUpdateEventListener> eventListenerGroup_PRE_COLLECTION_UPDATE;
-	public final EventListenerGroup<PreDeleteEventListener> eventListenerGroup_PRE_DELETE;
-	public final EventListenerGroup<PreInsertEventListener> eventListenerGroup_PRE_INSERT;
-	public final EventListenerGroup<PreLoadEventListener> eventListenerGroup_PRE_LOAD;
-	public final EventListenerGroup<PreUpdateEventListener> eventListenerGroup_PRE_UPDATE;
-	public final EventListenerGroup<PreUpsertEventListener> eventListenerGroup_PRE_UPSERT;
-	public final EventListenerGroup<RefreshEventListener> eventListenerGroup_REFRESH;
-	public final EventListenerGroup<ReplicateEventListener> eventListenerGroup_REPLICATE;
-
-	// Fields used only from within this package
-	final boolean disallowOutOfTransactionUpdateOperations;
-	final boolean requiresMultiTenantConnectionProvider;
-	final ConnectionProvider connectionProvider;
-	final MultiTenantConnectionProvider<Object> multiTenantConnectionProvider;
-	final ClassLoaderService classLoaderService;
-	final TransactionCoordinatorBuilder transactionCoordinatorBuilder;
-	final EventMonitor eventMonitor;
-	final boolean isJtaTransactionAccessible;
-	final CacheMode initialSessionCacheMode;
-	final FlushMode initialSessionFlushMode;
-	final boolean discardOnClose;
-	final BaselineSessionEventsListenerBuilder defaultSessionEventListeners;
-	final LockOptions defaultLockOptions;
-	final int defaultJdbcBatchSize;
-
-	// Expose certain fields outside this package
-	// (but they are still considered internal)
-	public final Dialect dialect;
-	public final TypeConfiguration typeConfiguration;
-	public final JdbcServices jdbcServices;
-	public final boolean useStreamForLobBinding;
-	public final int preferredSqlTypeCodeForBoolean;
-	public final TimeZone jdbcTimeZone;
-	public final EntityCopyObserverFactory entityCopyObserverFactory;
-	public final BatchBuilder batchBuilder;
-	public final ParameterMarkerStrategy parameterMarkerStrategy;
-
-	// Private fields (probably don't really belong here)
-	private final CacheStoreMode defaultCacheStoreMode;
-	private final CacheRetrieveMode defaultCacheRetrieveMode;
-	private final FormatMapper jsonFormatMapper;
-	private final FormatMapper xmlFormatMapper;
+	private final ConnectionProvider connectionProvider;
+	private final MultiTenantConnectionProvider<Object> multiTenantConnectionProvider;
+	private final ClassLoaderService classLoaderService;
+	private final TransactionCoordinatorBuilder transactionCoordinatorBuilder;
+	private final EventMonitor eventMonitor;
+	private final JdbcServices jdbcServices;
+	private final EntityCopyObserverFactory entityCopyObserverFactory;
+	private final BatchBuilder batchBuilder;
+	private final ParameterMarkerStrategy parameterMarkerStrategy;
 	private final JdbcValuesMappingProducerProvider jdbcValuesMappingProducerProvider;
 
 	FastSessionServices(SessionFactoryImplementor sessionFactory) {
-		Objects.requireNonNull( sessionFactory );
-		final ServiceRegistryImplementor serviceRegistry = sessionFactory.getServiceRegistry();
-		final JdbcServices jdbcServices = sessionFactory.getJdbcServices();
-		final SessionFactoryOptions sessionFactoryOptions = sessionFactory.getSessionFactoryOptions();
-
-		// Pre-compute all iterators on Event listeners:
-		final EventListenerRegistry eventListenerRegistry = serviceRegistry.requireService( EventListenerRegistry.class );
-		this.eventListenerGroup_AUTO_FLUSH = listeners( eventListenerRegistry, EventType.AUTO_FLUSH );
-		this.eventListenerGroup_CLEAR = listeners( eventListenerRegistry, EventType.CLEAR );
-		this.eventListenerGroup_DELETE = listeners( eventListenerRegistry, EventType.DELETE );
-		this.eventListenerGroup_DIRTY_CHECK = listeners( eventListenerRegistry, EventType.DIRTY_CHECK );
-		this.eventListenerGroup_EVICT = listeners( eventListenerRegistry, EventType.EVICT );
-		this.eventListenerGroup_FLUSH = listeners( eventListenerRegistry, EventType.FLUSH );
-		this.eventListenerGroup_FLUSH_ENTITY = listeners( eventListenerRegistry, EventType.FLUSH_ENTITY );
-		this.eventListenerGroup_INIT_COLLECTION = listeners( eventListenerRegistry, EventType.INIT_COLLECTION );
-		this.eventListenerGroup_LOAD = listeners( eventListenerRegistry, EventType.LOAD );
-		this.eventListenerGroup_LOCK = listeners( eventListenerRegistry, EventType.LOCK );
-		this.eventListenerGroup_MERGE = listeners( eventListenerRegistry, EventType.MERGE );
-		this.eventListenerGroup_PERSIST = listeners( eventListenerRegistry, EventType.PERSIST );
-		this.eventListenerGroup_PERSIST_ONFLUSH = listeners( eventListenerRegistry, EventType.PERSIST_ONFLUSH );
-		this.eventListenerGroup_POST_COLLECTION_RECREATE = listeners( eventListenerRegistry, EventType.POST_COLLECTION_RECREATE );
-		this.eventListenerGroup_POST_COLLECTION_REMOVE = listeners( eventListenerRegistry, EventType.POST_COLLECTION_REMOVE );
-		this.eventListenerGroup_POST_COLLECTION_UPDATE = listeners( eventListenerRegistry, EventType.POST_COLLECTION_UPDATE );
-		this.eventListenerGroup_POST_COMMIT_DELETE = listeners( eventListenerRegistry, EventType.POST_COMMIT_DELETE );
-		this.eventListenerGroup_POST_COMMIT_INSERT = listeners( eventListenerRegistry, EventType.POST_COMMIT_INSERT );
-		this.eventListenerGroup_POST_COMMIT_UPDATE = listeners( eventListenerRegistry, EventType.POST_COMMIT_UPDATE );
-		this.eventListenerGroup_POST_DELETE = listeners( eventListenerRegistry, EventType.POST_DELETE );
-		this.eventListenerGroup_POST_INSERT = listeners( eventListenerRegistry, EventType.POST_INSERT );
-		this.eventListenerGroup_POST_LOAD = listeners( eventListenerRegistry, EventType.POST_LOAD );
-		this.eventListenerGroup_POST_UPDATE = listeners( eventListenerRegistry, EventType.POST_UPDATE );
-		this.eventListenerGroup_POST_UPSERT = listeners( eventListenerRegistry, EventType.POST_UPSERT );
-		this.eventListenerGroup_PRE_COLLECTION_RECREATE = listeners( eventListenerRegistry, EventType.PRE_COLLECTION_RECREATE );
-		this.eventListenerGroup_PRE_COLLECTION_REMOVE = listeners( eventListenerRegistry, EventType.PRE_COLLECTION_REMOVE );
-		this.eventListenerGroup_PRE_COLLECTION_UPDATE = listeners( eventListenerRegistry, EventType.PRE_COLLECTION_UPDATE );
-		this.eventListenerGroup_PRE_DELETE = listeners( eventListenerRegistry, EventType.PRE_DELETE );
-		this.eventListenerGroup_PRE_INSERT = listeners( eventListenerRegistry, EventType.PRE_INSERT );
-		this.eventListenerGroup_PRE_LOAD = listeners( eventListenerRegistry, EventType.PRE_LOAD );
-		this.eventListenerGroup_PRE_UPDATE = listeners( eventListenerRegistry, EventType.PRE_UPDATE );
-		this.eventListenerGroup_PRE_UPSERT = listeners( eventListenerRegistry, EventType.PRE_UPSERT );
-		this.eventListenerGroup_REFRESH = listeners( eventListenerRegistry, EventType.REFRESH );
-		this.eventListenerGroup_REPLICATE = listeners( eventListenerRegistry, EventType.REPLICATE );
-
-		//Other highly useful constants:
-		this.dialect = jdbcServices.getJdbcEnvironment().getDialect();
-		this.typeConfiguration = sessionFactory.getTypeConfiguration();
-		this.disallowOutOfTransactionUpdateOperations = !sessionFactoryOptions.isAllowOutOfTransactionUpdateOperations();
-		this.useStreamForLobBinding = dialect.useInputStreamToInsertBlob();
-		this.preferredSqlTypeCodeForBoolean = sessionFactoryOptions.getPreferredSqlTypeCodeForBoolean();
-		this.defaultJdbcBatchSize = sessionFactoryOptions.getJdbcBatchSize();
-		this.jdbcTimeZone = sessionFactoryOptions.getJdbcTimeZone();
-		this.requiresMultiTenantConnectionProvider = sessionFactory.getSessionFactoryOptions().isMultiTenancyEnabled();
-		this.parameterMarkerStrategy = serviceRegistry.getService( ParameterMarkerStrategy.class );
+		super( sessionFactory.getServiceRegistry() );
+		final ServiceRegistry serviceRegistry = sessionFactory.getServiceRegistry();
 
 		//Some "hot" services:
-		this.connectionProvider = requiresMultiTenantConnectionProvider
-				? null
-				: serviceRegistry.getService( ConnectionProvider.class );
-		this.multiTenantConnectionProvider = requiresMultiTenantConnectionProvider
-				? serviceRegistry.requireService( MultiTenantConnectionProvider.class )
-				: null;
 		this.classLoaderService = serviceRegistry.requireService( ClassLoaderService.class );
 		this.transactionCoordinatorBuilder = serviceRegistry.getService( TransactionCoordinatorBuilder.class );
 		this.jdbcServices = serviceRegistry.requireService( JdbcServices.class );
 		this.entityCopyObserverFactory = serviceRegistry.requireService( EntityCopyObserverFactory.class );
 		this.jdbcValuesMappingProducerProvider = serviceRegistry.getService( JdbcValuesMappingProducerProvider.class );
-
-		this.isJtaTransactionAccessible = isTransactionAccessible( sessionFactory, transactionCoordinatorBuilder );
-
-		this.defaultSessionProperties = initializeDefaultSessionProperties( sessionFactory );
-		this.defaultCacheStoreMode = determineCacheStoreMode( defaultSessionProperties );
-		this.defaultCacheRetrieveMode = determineCacheRetrieveMode( defaultSessionProperties );
-		this.initialSessionCacheMode = CacheModeHelper.interpretCacheMode( defaultCacheStoreMode, defaultCacheRetrieveMode );
-		this.discardOnClose = sessionFactoryOptions.isReleaseResourcesOnCloseEnabled();
-		this.defaultSessionEventListeners = sessionFactoryOptions.getBaselineSessionEventsListenerBuilder();
-		this.defaultLockOptions = initializeDefaultLockOptions( defaultSessionProperties );
-		this.initialSessionFlushMode = initializeDefaultFlushMode( defaultSessionProperties );
-		this.jsonFormatMapper = sessionFactoryOptions.getJsonFormatMapper();
-		this.xmlFormatMapper = sessionFactoryOptions.getXmlFormatMapper();
+		this.parameterMarkerStrategy = serviceRegistry.getService( ParameterMarkerStrategy.class );
 		this.batchBuilder = serviceRegistry.getService( BatchBuilder.class );
+
+		final boolean multiTenancyEnabled = sessionFactory.getSessionFactoryOptions().isMultiTenancyEnabled();
+		this.connectionProvider =
+				multiTenancyEnabled ? null : serviceRegistry.getService( ConnectionProvider.class );
+		this.multiTenantConnectionProvider =
+				multiTenancyEnabled ? serviceRegistry.requireService( MultiTenantConnectionProvider.class ) : null;
 
 		final Collection<EventMonitor> eventMonitors = classLoaderService.loadJavaServices( EventMonitor.class );
 		this.eventMonitor = eventMonitors.isEmpty() ? new EmptyEventMonitor() : eventMonitors.iterator().next();
 	}
 
-	private static FlushMode initializeDefaultFlushMode(Map<String, Object> defaultSessionProperties) {
-		Object setMode = defaultSessionProperties.get( HibernateHints.HINT_FLUSH_MODE );
-		return ConfigurationHelper.getFlushMode( setMode, FlushMode.AUTO );
-	}
-
-	private static LockOptions initializeDefaultLockOptions(final Map<String, Object> defaultSessionProperties) {
-		final LockOptions lockOptions = new LockOptions();
-		applyPropertiesToLockOptions( defaultSessionProperties, () -> lockOptions );
-		return lockOptions;
-	}
-
-	private static <T> EventListenerGroup<T> listeners(EventListenerRegistry elr, EventType<T> type) {
-		return elr.getEventListenerGroup( type );
-	}
-
-	private static boolean isTransactionAccessible(
-			SessionFactoryImplementor factory,
-			TransactionCoordinatorBuilder transactionCoordinatorBuilder) {
-		// JPA requires that access not be provided to the transaction when using JTA.
-		// This is overridden when SessionFactoryOptions isJtaTransactionAccessEnabled() is true.
-		return !factory.getSessionFactoryOptions().getJpaCompliance().isJpaTransactionComplianceEnabled()
-			|| !transactionCoordinatorBuilder.isJta()
-			|| factory.getSessionFactoryOptions().isJtaTransactionAccessEnabled();
-	}
-
-	private static Map<String, Object> initializeDefaultSessionProperties(SessionFactoryImplementor factory) {
-		final HashMap<String,Object> settings = new HashMap<>();
-
-		//Static defaults:
-		settings.putIfAbsent( HibernateHints.HINT_FLUSH_MODE, FlushMode.AUTO.name() );
-		settings.putIfAbsent( JPA_LOCK_SCOPE, PessimisticLockScope.EXTENDED.name() );
-		settings.putIfAbsent( JAKARTA_LOCK_SCOPE, PessimisticLockScope.EXTENDED.name() );
-		settings.putIfAbsent( JPA_LOCK_TIMEOUT, LockOptions.WAIT_FOREVER );
-		settings.putIfAbsent( JAKARTA_LOCK_TIMEOUT, LockOptions.WAIT_FOREVER );
-		settings.putIfAbsent( JPA_SHARED_CACHE_RETRIEVE_MODE, CacheModeHelper.DEFAULT_RETRIEVE_MODE );
-		settings.putIfAbsent( JAKARTA_SHARED_CACHE_RETRIEVE_MODE, CacheModeHelper.DEFAULT_RETRIEVE_MODE );
-		settings.putIfAbsent( JPA_SHARED_CACHE_STORE_MODE, CacheModeHelper.DEFAULT_STORE_MODE );
-		settings.putIfAbsent( JAKARTA_SHARED_CACHE_STORE_MODE, CacheModeHelper.DEFAULT_STORE_MODE );
-
-		//Defaults defined by SessionFactory configuration:
-		final String[] ENTITY_MANAGER_SPECIFIC_PROPERTIES = {
-				SpecHints.HINT_SPEC_LOCK_SCOPE,
-				SpecHints.HINT_SPEC_LOCK_TIMEOUT,
-				SpecHints.HINT_SPEC_QUERY_TIMEOUT,
-				SpecHints.HINT_SPEC_CACHE_RETRIEVE_MODE,
-				SpecHints.HINT_SPEC_CACHE_STORE_MODE,
-
-				HibernateHints.HINT_FLUSH_MODE,
-
-				LegacySpecHints.HINT_JAVAEE_LOCK_SCOPE,
-				LegacySpecHints.HINT_JAVAEE_LOCK_TIMEOUT,
-				LegacySpecHints.HINT_JAVAEE_CACHE_RETRIEVE_MODE,
-				LegacySpecHints.HINT_JAVAEE_CACHE_STORE_MODE,
-				LegacySpecHints.HINT_JAVAEE_QUERY_TIMEOUT
-		};
-		final Map<String, Object> properties = factory.getProperties();
-		for ( String key : ENTITY_MANAGER_SPECIFIC_PROPERTIES ) {
-			if ( properties.containsKey( key ) ) {
-				settings.put( key, properties.get( key ) );
-			}
-		}
-		return unmodifiableMap( settings );
-	}
-
-	/**
-	 * @param properties the Session properties
-	 * @return either the CacheStoreMode as defined in the Session specific properties,
-	 *         or as defined in the properties shared across all sessions (the defaults).
-	 */
-	CacheStoreMode getCacheStoreMode(final Map<String, Object> properties) {
-		return properties == null ? defaultCacheStoreMode : determineCacheStoreMode( properties );
-	}
-
-	/**
-	 * @param properties the Session properties
-	 * @return either the CacheRetrieveMode as defined in the Session specific properties,
-	 *         or as defined in the properties shared across all sessions (the defaults).
-	 */
-	CacheRetrieveMode getCacheRetrieveMode(Map<String, Object> properties) {
-		return properties == null ? defaultCacheRetrieveMode : determineCacheRetrieveMode( properties );
-	}
-
-	private static CacheRetrieveMode determineCacheRetrieveMode(Map<String, Object> settings) {
-		final CacheRetrieveMode cacheRetrieveMode = (CacheRetrieveMode) settings.get( JPA_SHARED_CACHE_RETRIEVE_MODE );
-		return cacheRetrieveMode == null
-				? (CacheRetrieveMode) settings.get( JAKARTA_SHARED_CACHE_RETRIEVE_MODE )
-				: cacheRetrieveMode;
-	}
-
-	private static CacheStoreMode determineCacheStoreMode(Map<String, Object> settings) {
-		final CacheStoreMode cacheStoreMode = (CacheStoreMode) settings.get( JPA_SHARED_CACHE_STORE_MODE );
-		return cacheStoreMode == null
-				? (CacheStoreMode) settings.get( JAKARTA_SHARED_CACHE_STORE_MODE )
-				: cacheStoreMode;
-	}
-
 	public JdbcValuesMappingProducerProvider getJdbcValuesMappingProducerProvider() {
-		return this.jdbcValuesMappingProducerProvider;
+		return jdbcValuesMappingProducerProvider;
 	}
 
-	public FormatMapper getJsonFormatMapper() {
-		if ( jsonFormatMapper == null ) {
-			throw new HibernateException(
-					"Could not find a FormatMapper for the JSON format, which is required for mapping JSON types. JSON FormatMapper configuration is automatic, but requires that you have either Jackson or a JSONB implementation like Yasson on the class path."
-			);
-		}
-		return jsonFormatMapper;
+	public ConnectionProvider getConnectionProvider() {
+		return connectionProvider;
 	}
 
-	public FormatMapper getXmlFormatMapper() {
-		if ( xmlFormatMapper == null ) {
-			throw new HibernateException(
-					"Could not find a FormatMapper for the XML format, which is required for mapping XML types. XML FormatMapper configuration is automatic, but requires that you have either Jackson XML or a JAXB implementation like Glassfish JAXB on the class path."
-			);
-		}
-		return xmlFormatMapper;
+	public MultiTenantConnectionProvider<Object> getMultiTenantConnectionProvider() {
+		return multiTenantConnectionProvider;
+	}
+
+	public ClassLoaderService getClassLoaderService() {
+		return classLoaderService;
+	}
+
+	public TransactionCoordinatorBuilder getTransactionCoordinatorBuilder() {
+		return transactionCoordinatorBuilder;
+	}
+
+	public EventMonitor getEventMonitor() {
+		return eventMonitor;
+	}
+
+	public JdbcServices getJdbcServices() {
+		return jdbcServices;
+	}
+
+	public EntityCopyObserverFactory getEntityCopyObserverFactory() {
+		return entityCopyObserverFactory;
+	}
+
+	public BatchBuilder getBatchBuilder() {
+		return batchBuilder;
+	}
+
+	public ParameterMarkerStrategy getParameterMarkerStrategy() {
+		return parameterMarkerStrategy;
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/internal/LockOptionsHelper.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/LockOptionsHelper.java
@@ -18,7 +18,7 @@ import static org.hibernate.cfg.AvailableSettings.JAKARTA_LOCK_TIMEOUT;
 import static org.hibernate.cfg.AvailableSettings.JPA_LOCK_SCOPE;
 import static org.hibernate.cfg.AvailableSettings.JPA_LOCK_TIMEOUT;
 
-final class LockOptionsHelper {
+public final class LockOptionsHelper {
 
 	private LockOptionsHelper() {
 		//utility class, not to be constructed

--- a/hibernate-core/src/main/java/org/hibernate/internal/SessionFactoryBasedWrapperOptions.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/SessionFactoryBasedWrapperOptions.java
@@ -24,11 +24,9 @@ import org.hibernate.type.spi.TypeConfiguration;
 class SessionFactoryBasedWrapperOptions implements WrapperOptions {
 
 	private final SessionFactoryImplementor factory;
-	private final FastSessionServices fastSessionServices;
 
 	SessionFactoryBasedWrapperOptions(SessionFactoryImplementor factory) {
 		this.factory = factory;
-		fastSessionServices = factory.getFastSessionServices();
 	}
 
 	@Override
@@ -38,41 +36,41 @@ class SessionFactoryBasedWrapperOptions implements WrapperOptions {
 
 	@Override
 	public boolean useStreamForLobBinding() {
-		return fastSessionServices.useStreamForLobBinding;
+		return factory.getJdbcServices().getJdbcEnvironment().getDialect().useInputStreamToInsertBlob();
 	}
 
 	@Override
 	public int getPreferredSqlTypeCodeForBoolean() {
-		return fastSessionServices.preferredSqlTypeCodeForBoolean;
+		return factory.getSessionFactoryOptions().getPreferredSqlTypeCodeForBoolean();
 	}
 
 	@Override
 	public LobCreator getLobCreator() {
-		return fastSessionServices.jdbcServices.getLobCreator( getSession() );
+		return factory.getJdbcServices().getLobCreator( getSession() );
 	}
 
 	@Override
 	public TimeZone getJdbcTimeZone() {
-		return fastSessionServices.jdbcTimeZone;
+		return factory.getSessionFactoryOptions().getJdbcTimeZone();
 	}
 
 	@Override
 	public Dialect getDialect() {
-		return fastSessionServices.dialect;
+		return factory.getJdbcServices().getJdbcEnvironment().getDialect();
 	}
 
 	@Override
 	public TypeConfiguration getTypeConfiguration() {
-		return fastSessionServices.typeConfiguration;
+		return factory.getTypeConfiguration();
 	}
 
 	@Override
 	public FormatMapper getXmlFormatMapper() {
-		return fastSessionServices.getXmlFormatMapper();
+		return factory.getSessionFactoryOptions().getXmlFormatMapper();
 	}
 
 	@Override
 	public FormatMapper getJsonFormatMapper() {
-		return fastSessionServices.getJsonFormatMapper();
+		return factory.getSessionFactoryOptions().getJsonFormatMapper();
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/internal/SessionFactoryImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/SessionFactoryImpl.java
@@ -64,7 +64,9 @@ import org.hibernate.engine.spi.SessionBuilderImplementor;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.engine.spi.SessionImplementor;
 import org.hibernate.engine.transaction.jta.platform.spi.JtaPlatform;
+import org.hibernate.event.spi.EntityCopyObserverFactory;
 import org.hibernate.event.spi.EventEngine;
+import org.hibernate.event.service.spi.EventListenerGroups;
 import org.hibernate.generator.Generator;
 import org.hibernate.graph.spi.RootGraphImplementor;
 import org.hibernate.integrator.spi.Integrator;
@@ -104,6 +106,8 @@ import org.hibernate.service.ServiceRegistry;
 import org.hibernate.service.spi.ServiceRegistryImplementor;
 import org.hibernate.service.spi.SessionFactoryServiceRegistry;
 import org.hibernate.service.spi.SessionFactoryServiceRegistryFactory;
+import org.hibernate.sql.ast.spi.ParameterMarkerStrategy;
+import org.hibernate.sql.results.jdbc.spi.JdbcValuesMappingProducerProvider;
 import org.hibernate.stat.spi.StatisticsImplementor;
 import org.hibernate.type.Type;
 import org.hibernate.type.descriptor.WrapperOptions;
@@ -340,6 +344,26 @@ public class SessionFactoryImpl extends QueryParameterBindingTypeResolverImpl im
 				// it is not great how we pass in an instance to
 				// an incompletely-initialized instance here:
 				.buildServiceRegistry( self, options );
+	}
+
+	@Override
+	public EventListenerGroups getEventListenerGroups() {
+		return fastSessionServices;
+	}
+
+	@Override
+	public ParameterMarkerStrategy getParameterMarkerStrategy() {
+		return fastSessionServices.getParameterMarkerStrategy();
+	}
+
+	@Override
+	public JdbcValuesMappingProducerProvider getJdbcValuesMappingProducerProvider() {
+		return fastSessionServices.getJdbcValuesMappingProducerProvider();
+	}
+
+	@Override
+	public EntityCopyObserverFactory getEntityCopyObserver() {
+		return fastSessionServices.getEntityCopyObserverFactory();
 	}
 
 	class IntegratorObserver implements SessionFactoryObserver {
@@ -788,7 +812,7 @@ public class SessionFactoryImpl extends QueryParameterBindingTypeResolverImpl im
 
 	@Override
 	public PersistenceUnitTransactionType getTransactionType() {
-		return fastSessionServices.transactionCoordinatorBuilder.isJta()
+		return fastSessionServices.getTransactionCoordinatorBuilder().isJta()
 				? PersistenceUnitTransactionType.JTA
 				: PersistenceUnitTransactionType.RESOURCE_LOCAL;
 

--- a/hibernate-core/src/main/java/org/hibernate/internal/SessionFactoryImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/SessionFactoryImpl.java
@@ -284,7 +284,7 @@ public class SessionFactoryImpl extends QueryParameterBindingTypeResolverImpl im
 			runtimeMetamodels = runtimeMetamodelsImpl;
 			final MappingMetamodelImpl mappingMetamodelImpl = new MappingMetamodelImpl( typeConfiguration, serviceRegistry );
 			runtimeMetamodelsImpl.setMappingMetamodel( mappingMetamodelImpl );
-			fastSessionServices = new FastSessionServices( this );
+			fastSessionServices = new FastSessionServices( serviceRegistry, sessionFactoryOptions );
 			mappingMetamodelImpl.finishInitialization(
 					new ModelCreationContext( bootstrapContext, bootMetamodel, mappingMetamodelImpl, typeConfiguration ) );
 			runtimeMetamodelsImpl.setJpaMetamodel( mappingMetamodelImpl.getJpaMetamodel() );
@@ -317,7 +317,7 @@ public class SessionFactoryImpl extends QueryParameterBindingTypeResolverImpl im
 				close();
 			}
 			catch (Exception closeException) {
-				LOG.debugf( "Eating error closing the SessionFactory after a failed attempt to start it" );
+				LOG.debug( "Eating error closing the SessionFactory after a failed attempt to start it" );
 			}
 			throw e;
 		}
@@ -342,7 +342,7 @@ public class SessionFactoryImpl extends QueryParameterBindingTypeResolverImpl im
 			SessionFactoryImplementor self) {
 		return options.getServiceRegistry()
 				.requireService( SessionFactoryServiceRegistryFactory.class )
-				// it is not great how we pass in an instance to
+				// it is not great how we pass a reference to
 				// an incompletely-initialized instance here:
 				.buildServiceRegistry( self, options );
 	}

--- a/hibernate-core/src/main/java/org/hibernate/internal/StatelessSessionImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/StatelessSessionImpl.java
@@ -1051,7 +1051,7 @@ public class StatelessSessionImpl extends AbstractSharedSessionContract implemen
 
 	@Override
 	public boolean isAutoCloseSessionEnabled() {
-		return getFactory().getSessionFactoryOptions().isAutoCloseSessionEnabled();
+		return getSessionFactoryOptions().isAutoCloseSessionEnabled();
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/jpa/boot/internal/EntityManagerFactoryBuilderImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/jpa/boot/internal/EntityManagerFactoryBuilderImpl.java
@@ -393,8 +393,7 @@ public class EntityManagerFactoryBuilderImpl implements EntityManagerFactoryBuil
 			}
 		}
 
-		metamodelBuilder.getBootstrapContext().getServiceRegistry()
-				.requireService( ClassLoaderService.class )
+		metamodelBuilder.getBootstrapContext().getClassLoaderService()
 				.loadJavaServices( MetadataBuilderContributor.class )
 				.forEach( contributor -> contributor.contribute( metamodelBuilder ) );
 	}
@@ -1357,8 +1356,7 @@ public class EntityManagerFactoryBuilderImpl implements EntityManagerFactoryBuil
 		if ( typeContributorList != null ) {
 			typeContributorList.getTypeContributors().forEach( metamodelBuilder::applyTypes );
 		}
-		metamodelBuilder.getBootstrapContext().getServiceRegistry()
-				.requireService( ClassLoaderService.class )
+		metamodelBuilder.getBootstrapContext().getClassLoaderService()
 				.loadJavaServices( TypeContributor.class )
 				.forEach( metamodelBuilder::applyTypes );
 	}

--- a/hibernate-core/src/main/java/org/hibernate/mapping/Array.java
+++ b/hibernate-core/src/main/java/org/hibernate/mapping/Array.java
@@ -56,7 +56,7 @@ public class Array extends List {
 		}
 		else {
 			try {
-				return classForName( elementClassName, getMetadata() );
+				return classForName( elementClassName, getBuildingContext().getBootstrapContext() );
 			}
 			catch (ClassLoadingException e) {
 				throw new MappingException( e );

--- a/hibernate-core/src/main/java/org/hibernate/mapping/Collection.java
+++ b/hibernate-core/src/main/java/org/hibernate/mapping/Collection.java
@@ -15,6 +15,7 @@ import java.util.function.Supplier;
 import org.hibernate.FetchMode;
 import org.hibernate.MappingException;
 import org.hibernate.annotations.CacheLayout;
+import org.hibernate.boot.spi.BootstrapContext;
 import org.hibernate.boot.spi.MetadataBuildingContext;
 import org.hibernate.boot.spi.MetadataImplementor;
 import org.hibernate.collection.internal.CustomCollectionTypeSemantics;
@@ -232,7 +233,7 @@ public abstract sealed class Collection
 		if ( comparator == null && comparatorClassName != null ) {
 			@SuppressWarnings("rawtypes")
 			final Class<? extends Comparator> clazz =
-					classForName( Comparator.class, comparatorClassName, getMetadata() );
+					classForName( Comparator.class, comparatorClassName, getBuildingContext().getBootstrapContext() );
 			try {
 				comparator = clazz.getConstructor().newInstance();
 			}
@@ -480,11 +481,14 @@ public abstract sealed class Collection
 	}
 
 	private ManagedBean<? extends UserCollectionType> userTypeBean() {
-		final MetadataImplementor metadata = getMetadata();
-		return createUserTypeBean( role,
-				classForName( UserCollectionType.class, typeName, metadata ),
+		final BootstrapContext bootstrapContext = getBuildingContext().getBootstrapContext();
+		return createUserTypeBean(
+				role,
+				classForName( UserCollectionType.class, typeName, bootstrapContext ),
 				PropertiesHelper.map( typeParameters ),
-				metadata );
+				bootstrapContext,
+				getMetadata().getMetadataBuildingOptions().isAllowExtensionsInCdi()
+		);
 	}
 
 	public CollectionType getCollectionType() {

--- a/hibernate-core/src/main/java/org/hibernate/mapping/PersistentClass.java
+++ b/hibernate-core/src/main/java/org/hibernate/mapping/PersistentClass.java
@@ -43,6 +43,7 @@ import static org.hibernate.engine.spi.ExecuteUpdateResultCheckStyle.expectation
 import static org.hibernate.internal.util.StringHelper.qualify;
 import static org.hibernate.internal.util.StringHelper.root;
 import static org.hibernate.mapping.MappingHelper.checkPropertyColumnDuplication;
+import static org.hibernate.mapping.MappingHelper.classForName;
 import static org.hibernate.sql.Template.collectColumnNames;
 
 /**
@@ -170,7 +171,7 @@ public abstract sealed class PersistentClass
 
 		try {
 			if ( mappedClass == null ) {
-				mappedClass = getClassLoaderAccess().classForName( className );
+				mappedClass = classForName( className, metadataBuildingContext.getBootstrapContext() );
 			}
 			return mappedClass;
 		}
@@ -185,7 +186,7 @@ public abstract sealed class PersistentClass
 		}
 		try {
 			if ( proxyInterface == null ) {
-				proxyInterface = getClassLoaderAccess().classForName( proxyInterfaceName );
+				proxyInterface = classForName( proxyInterfaceName, metadataBuildingContext.getBootstrapContext() );
 			}
 			return proxyInterface;
 		}

--- a/hibernate-core/src/main/java/org/hibernate/mapping/SimpleValue.java
+++ b/hibernate-core/src/main/java/org/hibernate/mapping/SimpleValue.java
@@ -284,18 +284,19 @@ public abstract class SimpleValue implements KeyValue {
 
 	void setAttributeConverterDescriptor(String typeName) {
 		final String converterClassName = typeName.substring( TYPE_NAME_PREFIX.length() );
+		final MetadataBuildingContext context = getBuildingContext();
 		@SuppressWarnings("unchecked")
 		final Class<? extends AttributeConverter<?,?>> clazz =
 				(Class<? extends AttributeConverter<?,?>>)
-						classForName( AttributeConverter.class, converterClassName, getMetadata() );
+						classForName( AttributeConverter.class, converterClassName,
+								context.getBootstrapContext() );
 		attributeConverterDescriptor =
 				new ClassBasedConverterDescriptor( clazz, false,
-						getBuildingContext().getBootstrapContext().getClassmateContext() );
+						context.getBootstrapContext().getClassmateContext() );
 	}
 
 	ClassLoaderService classLoaderService() {
-		return getMetadata().getMetadataBuildingOptions().getServiceRegistry()
-				.requireService( ClassLoaderService.class );
+		return getBuildingContext().getBootstrapContext().getClassLoaderService();
 	}
 
 	public void makeVersion() {
@@ -702,10 +703,7 @@ public abstract class SimpleValue implements KeyValue {
 				new JpaAttributeConverterCreationContext() {
 					@Override
 					public ManagedBeanRegistry getManagedBeanRegistry() {
-						return getMetadata()
-								.getMetadataBuildingOptions()
-								.getServiceRegistry()
-								.requireService( ManagedBeanRegistry.class );
+						return getBuildingContext().getBootstrapContext().getManagedBeanRegistry();
 					}
 
 					@Override

--- a/hibernate-core/src/main/java/org/hibernate/mapping/ToOne.java
+++ b/hibernate-core/src/main/java/org/hibernate/mapping/ToOne.java
@@ -93,9 +93,7 @@ public abstract sealed class ToOne
 	@Override
 	public void setTypeUsingReflection(String className, String propertyName) throws MappingException {
 		if ( referencedEntityName == null ) {
-			final ClassLoaderService cls =
-					getMetadata().getMetadataBuildingOptions().getServiceRegistry()
-							.requireService( ClassLoaderService.class );
+			final ClassLoaderService cls = getBuildingContext().getBootstrapContext().getClassLoaderService();
 			referencedEntityName = ReflectHelper.reflectedPropertyClass( className, propertyName, cls ).getName();
 		}
 	}

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/internal/AttributeFactory.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/internal/AttributeFactory.java
@@ -286,15 +286,14 @@ public class AttributeFactory {
 			final java.util.Collection<String> embeddableSubclasses = component.getDiscriminatorValues().values();
 			final java.util.Map<String, EmbeddableTypeImpl<?>> domainTypes = new HashMap<>();
 			domainTypes.put( embeddableType.getTypeName(), embeddableType );
-			final ClassLoaderService cls = context.getJpaMetamodel().getServiceRegistry().requireService(
-					ClassLoaderService.class
-			);
+			final ClassLoaderService classLoaderService =
+					context.getRuntimeModelCreationContext().getBootstrapContext().getClassLoaderService();
 			for ( final String subclassName : embeddableSubclasses ) {
 				if ( domainTypes.containsKey( subclassName ) ) {
 					assert subclassName.equals( embeddableType.getTypeName() );
 					continue;
 				}
-				final Class<?> subclass = cls.classForName( subclassName );
+				final Class<?> subclass = classLoaderService.classForName( subclassName );
 				final EmbeddableTypeImpl<?> subType = new EmbeddableTypeImpl<>(
 						context.getJavaTypeRegistry().resolveManagedTypeDescriptor( subclass ),
 						domainTypes.get( component.getSuperclass( subclassName ) ),

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/internal/EmbeddableRepresentationStrategyPojo.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/internal/EmbeddableRepresentationStrategyPojo.java
@@ -251,10 +251,7 @@ public class EmbeddableRepresentationStrategyPojo implements EmbeddableRepresent
 		if ( bootDescriptor.isPolymorphic() ) {
 			final Collection<String> subclassNames = bootDescriptor.getDiscriminatorValues().values();
 			final Map<String, Class<?>> result = new HashMap<>( subclassNames.size() );
-			final ClassLoaderService classLoaderService = creationContext.getMetadata()
-					.getMetadataBuildingOptions()
-					.getServiceRegistry()
-					.requireService( ClassLoaderService.class );
+			final ClassLoaderService classLoaderService = creationContext.getBootstrapContext().getClassLoaderService();
 			for ( final String subclassName : subclassNames ) {
 				final Class<?> embeddableClass;
 				if ( subclassName.equals( bootDescriptor.getComponentClassName() ) ) {

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/internal/EntityRepresentationStrategyPojoStandard.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/internal/EntityRepresentationStrategyPojoStandard.java
@@ -135,7 +135,8 @@ public class EntityRepresentationStrategyPojoStandard implements EntityRepresent
 
 		this.strategySelector = creationContext.getServiceRegistry().getService( StrategySelector.class );
 
-		final BytecodeProvider bytecodeProvider = creationContext.getBootstrapContext().getServiceRegistry().requireService( BytecodeProvider.class );
+		final BytecodeProvider bytecodeProvider =
+				creationContext.getBootstrapContext().getServiceRegistry().requireService( BytecodeProvider.class );
 
 		this.proxyFactory = resolveProxyFactory(
 				bootDescriptor,

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/internal/ManagedTypeRepresentationResolverStandard.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/internal/ManagedTypeRepresentationResolverStandard.java
@@ -19,7 +19,6 @@ import org.hibernate.metamodel.spi.ManagedTypeRepresentationResolver;
 import org.hibernate.metamodel.spi.RuntimeModelCreationContext;
 import org.hibernate.persister.entity.EntityPersister;
 import org.hibernate.resource.beans.internal.FallbackBeanInstanceProducer;
-import org.hibernate.resource.beans.spi.ManagedBeanRegistry;
 import org.hibernate.usertype.CompositeUserType;
 
 /**
@@ -84,11 +83,10 @@ public class ManagedTypeRepresentationResolverStandard implements ManagedTypeRep
 				compositeUserType = FallbackBeanInstanceProducer.INSTANCE.produceBeanInstance( userTypeClass );
 			}
 			else {
-				compositeUserType = creationContext.getBootstrapContext()
-						.getServiceRegistry()
-						.requireService( ManagedBeanRegistry.class )
-						.getBean( userTypeClass )
-						.getBeanInstance();
+				compositeUserType =
+						creationContext.getBootstrapContext().getManagedBeanRegistry()
+								.getBean( userTypeClass )
+								.getBeanInstance();
 			}
 		}
 		else {
@@ -101,11 +99,10 @@ public class ManagedTypeRepresentationResolverStandard implements ManagedTypeRep
 				customInstantiator = FallbackBeanInstanceProducer.INSTANCE.produceBeanInstance( instantiatorClass );
 			}
 			else {
-				customInstantiator = creationContext.getBootstrapContext()
-						.getServiceRegistry()
-						.requireService( ManagedBeanRegistry.class )
-						.getBean( instantiatorClass )
-						.getBeanInstance();
+				customInstantiator =
+						creationContext.getBootstrapContext().getManagedBeanRegistry()
+								.getBean( instantiatorClass )
+								.getBeanInstance();
 			}
 		}
 		else if ( compositeUserType != null ) {

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/internal/MetadataContext.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/internal/MetadataContext.java
@@ -111,9 +111,10 @@ public class MetadataContext {
 			MetadataImplementor bootMetamodel,
 			JpaStaticMetamodelPopulationSetting jpaStaticMetaModelPopulationSetting,
 			JpaMetamodelPopulationSetting jpaMetaModelPopulationSetting,
-			RuntimeModelCreationContext runtimeModelCreationContext) {
+			RuntimeModelCreationContext runtimeModelCreationContext,
+			ClassLoaderService classLoaderService) {
 		this.jpaMetamodel = jpaMetamodel;
-		this.classLoaderService = jpaMetamodel.getServiceRegistry().getService( ClassLoaderService.class );
+		this.classLoaderService = classLoaderService;
 		this.metamodel = mappingMetamodel;
 		this.knownMappedSuperclasses = bootMetamodel.getMappedSuperclassMappingsCopy();
 		this.typeConfiguration = runtimeModelCreationContext.getTypeConfiguration();

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/SimpleNaturalIdMapping.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/SimpleNaturalIdMapping.java
@@ -292,7 +292,7 @@ public class SimpleNaturalIdMapping extends AbstractNaturalIdMapping
 	}
 
 	private Dialect getDialect() {
-		return sessionFactory.getFastSessionServices().jdbcServices.getDialect();
+		return sessionFactory.getJdbcServices().getDialect();
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/internal/JpaMetamodelImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/internal/JpaMetamodelImpl.java
@@ -93,6 +93,7 @@ public class JpaMetamodelImpl implements JpaMetamodelImplementor, Serializable {
 	private final TypeConfiguration typeConfiguration;
 	private final MappingMetamodel mappingMetamodel;
 	private final ServiceRegistry serviceRegistry;
+	private final ClassLoaderService classLoaderService;
 
 	private final Map<String, ManagedDomainType<?>> managedTypeByName = new TreeMap<>();
 	private final Map<Class<?>, ManagedDomainType<?>> managedTypeByClass = new HashMap<>();
@@ -117,6 +118,7 @@ public class JpaMetamodelImpl implements JpaMetamodelImplementor, Serializable {
 		this.typeConfiguration = typeConfiguration;
 		this.mappingMetamodel = mappingMetamodel;
 		this.serviceRegistry = serviceRegistry;
+		this.classLoaderService = serviceRegistry.getService( ClassLoaderService.class );
 	}
 
 	@Override
@@ -326,8 +328,6 @@ public class JpaMetamodelImpl implements JpaMetamodelImplementor, Serializable {
 			return enumJavaType;
 		}
 		else {
-			final ClassLoaderService classLoaderService =
-					serviceRegistry.requireService( ClassLoaderService.class );
 			try {
 				final Class<?> clazz = classLoaderService.classForName( className );
 				if ( clazz == null || !clazz.isEnum() ) {
@@ -375,10 +375,7 @@ public class JpaMetamodelImpl implements JpaMetamodelImplementor, Serializable {
 	}
 
 	private Field getJavaField(String className, String fieldName) throws NoSuchFieldException {
-		final Class<?> namedClass =
-				getServiceRegistry()
-						.requireService( ClassLoaderService.class )
-						.classForName( className );
+		final Class<?> namedClass = classLoaderService.classForName( className );
 		if ( namedClass != null ) {
 			return namedClass.getDeclaredField( fieldName );
 		}
@@ -633,8 +630,7 @@ public class JpaMetamodelImpl implements JpaMetamodelImplementor, Serializable {
 
 	private <X> Class<X> resolveRequestedClass(String entityName) {
 		try {
-			return getServiceRegistry().requireService( ClassLoaderService.class )
-					.classForName( entityName );
+			return classLoaderService.classForName( entityName );
 		}
 		catch (ClassLoadingException e) {
 			return null;
@@ -736,7 +732,8 @@ public class JpaMetamodelImpl implements JpaMetamodelImplementor, Serializable {
 				bootMetamodel,
 				jpaStaticMetaModelPopulationSetting,
 				jpaMetaModelPopulationSetting,
-				runtimeModelCreationContext
+				runtimeModelCreationContext,
+				runtimeModelCreationContext.getBootstrapContext().getClassLoaderService()
 		);
 
 

--- a/hibernate-core/src/main/java/org/hibernate/query/internal/ResultMementoBasicStandard.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/internal/ResultMementoBasicStandard.java
@@ -85,8 +85,7 @@ public class ResultMementoBasicStandard implements ResultMementoBasic {
 			final Class<? extends AttributeConverter<?, ?>> converterClass =
 					(Class<? extends AttributeConverter<?, ?>>) definedType;
 			final ManagedBean<? extends AttributeConverter<?,?>> converterBean =
-					sessionFactory.getServiceRegistry().requireService( ManagedBeanRegistry.class )
-							.getBean( converterClass );
+					sessionFactory.getManagedBeanRegistry().getBean( converterClass );
 			final JavaType<? extends AttributeConverter<?,?>> converterJtd =
 					typeConfiguration.getJavaTypeRegistry().getDescriptor( converterClass );
 
@@ -115,8 +114,7 @@ public class ResultMementoBasicStandard implements ResultMementoBasic {
 			else {
 				final JavaTypeRegistry jtdRegistry = typeConfiguration.getJavaTypeRegistry();
 				final JavaType<Object> registeredJtd = jtdRegistry.getDescriptor( definedType );
-				final ManagedBeanRegistry beanRegistry =
-						sessionFactory.getServiceRegistry().requireService( ManagedBeanRegistry.class );
+				final ManagedBeanRegistry beanRegistry = sessionFactory.getManagedBeanRegistry();
 				if ( BasicType.class.isAssignableFrom( registeredJtd.getJavaTypeClass() ) ) {
 					final ManagedBean<BasicType<?>> typeBean =
 							(ManagedBean) beanRegistry.getBean( registeredJtd.getJavaTypeClass() );

--- a/hibernate-core/src/main/java/org/hibernate/query/results/ResultSetMapping.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/results/ResultSetMapping.java
@@ -95,9 +95,7 @@ public interface ResultSetMapping extends JdbcValuesMappingProducer {
 	}
 
 	static ResultSetMapping resolveResultSetMapping(String name, boolean isDynamic, SessionFactoryImplementor sessionFactory) {
-		return sessionFactory
-				.getFastSessionServices()
-				.getJdbcValuesMappingProducerProvider()
+		return sessionFactory.getJdbcValuesMappingProducerProvider()
 				.buildResultSetMapping( name, isDynamic, sessionFactory );
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/query/results/internal/dynamic/DynamicResultBuilderBasicConverted.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/results/internal/dynamic/DynamicResultBuilderBasicConverted.java
@@ -56,7 +56,7 @@ public class DynamicResultBuilderBasicConverted<O,R> implements DynamicResultBui
 			Class<? extends AttributeConverter<O, R>> converterJavaType,
 			SessionFactoryImplementor sessionFactory) {
 		this.columnAlias = columnAlias;
-		final ManagedBeanRegistry beans = sessionFactory.getServiceRegistry().requireService( ManagedBeanRegistry.class );
+		final ManagedBeanRegistry beans = sessionFactory.getManagedBeanRegistry();
 		final JavaTypeRegistry javaTypeRegistry = sessionFactory.getTypeConfiguration().getJavaTypeRegistry();
 		this.basicValueConverter = new JpaAttributeConverterImpl<>(
 				beans.getBean( converterJavaType ),

--- a/hibernate-core/src/main/java/org/hibernate/service/internal/SessionFactoryServiceRegistryFactoryImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/service/internal/SessionFactoryServiceRegistryFactoryImpl.java
@@ -29,10 +29,13 @@ public class SessionFactoryServiceRegistryFactoryImpl implements SessionFactoryS
 	public SessionFactoryServiceRegistry buildServiceRegistry(
 			SessionFactoryImplementor sessionFactory,
 			SessionFactoryOptions options) {
-		final ClassLoaderService cls = options.getServiceRegistry().requireService( ClassLoaderService.class );
-		final SessionFactoryServiceRegistryBuilderImpl builder = new SessionFactoryServiceRegistryBuilderImpl( theBasicServiceRegistry );
+		final ClassLoaderService classLoaderService =
+				options.getServiceRegistry().requireService( ClassLoaderService.class );
+		final SessionFactoryServiceRegistryBuilderImpl builder =
+				new SessionFactoryServiceRegistryBuilderImpl( theBasicServiceRegistry );
 
-		for ( SessionFactoryServiceContributor contributor : cls.loadJavaServices( SessionFactoryServiceContributor.class ) ) {
+		for ( SessionFactoryServiceContributor contributor :
+				classLoaderService.loadJavaServices( SessionFactoryServiceContributor.class ) ) {
 			contributor.contribute( builder );
 		}
 

--- a/hibernate-core/src/main/java/org/hibernate/service/internal/SessionFactoryServiceRegistryImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/service/internal/SessionFactoryServiceRegistryImpl.java
@@ -76,9 +76,8 @@ public class SessionFactoryServiceRegistryImpl
 
 	@Override
 	public <R extends Service> void configureService(ServiceBinding<R> serviceBinding) {
-		if ( serviceBinding.getService() instanceof Configurable ) {
-			( (Configurable) serviceBinding.getService() )
-					.configure( requireService( ConfigurationService.class ).getSettings() );
+		if ( serviceBinding.getService() instanceof Configurable configurable ) {
+			configurable.configure( requireService( ConfigurationService.class ).getSettings() );
 		}
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/service/internal/SessionFactoryServiceRegistryImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/service/internal/SessionFactoryServiceRegistryImpl.java
@@ -50,7 +50,8 @@ public class SessionFactoryServiceRegistryImpl
 			List<ProvidedService<?>> providedServices,
 			SessionFactoryImplementor sessionFactory,
 			SessionFactoryOptions sessionFactoryOptions) {
-		SessionFactoryServiceRegistryImpl instance = new SessionFactoryServiceRegistryImpl( parent, sessionFactory, sessionFactoryOptions);
+		final SessionFactoryServiceRegistryImpl instance =
+				new SessionFactoryServiceRegistryImpl( parent, sessionFactory, sessionFactoryOptions );
 		instance.initialize( initiators, providedServices );
 		return instance;
 	}

--- a/hibernate-core/src/main/java/org/hibernate/sql/Delete.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/Delete.java
@@ -27,7 +27,7 @@ public class Delete implements RestrictionRenderingContext {
 	private int parameterCount;
 
 	public Delete(SessionFactoryImplementor factory) {
-		this( factory.getFastSessionServices().parameterMarkerStrategy );
+		this( factory.getParameterMarkerStrategy() );
 	}
 
 	public Delete(ParameterMarkerStrategy parameterMarkerStrategy) {

--- a/hibernate-core/src/main/java/org/hibernate/sql/Insert.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/Insert.java
@@ -36,8 +36,8 @@ public class Insert {
 
 	public Insert(SessionFactoryImplementor sessionFactory) {
 		this(
-				sessionFactory.getFastSessionServices().dialect,
-				sessionFactory.getFastSessionServices().parameterMarkerStrategy
+				sessionFactory.getJdbcServices().getJdbcEnvironment().getDialect(),
+				sessionFactory.getParameterMarkerStrategy()
 		);
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/sql/Update.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/Update.java
@@ -30,7 +30,7 @@ public class Update implements RestrictionRenderingContext {
 	private int parameterCount;
 
 	public Update(SessionFactoryImplementor factory) {
-		this( factory.getFastSessionServices().parameterMarkerStrategy );
+		this( factory.getParameterMarkerStrategy() );
 	}
 
 	public Update(ParameterMarkerStrategy parameterMarkerStrategy) {

--- a/hibernate-core/src/main/java/org/hibernate/sql/ast/spi/AbstractSqlAstTranslator.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/ast/spi/AbstractSqlAstTranslator.java
@@ -860,9 +860,7 @@ public abstract class AbstractSqlAstTranslator<T extends JdbcOperation> implemen
 	}
 
 	private JdbcValuesMappingProducer buildJdbcValuesMappingProducer(SelectStatement selectStatement) {
-		return getSessionFactory()
-				.getFastSessionServices()
-				.getJdbcValuesMappingProducerProvider()
+		return getSessionFactory().getJdbcValuesMappingProducerProvider()
 				.buildMappingProducer( selectStatement, getSessionFactory() );
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/entity/internal/EntityInitializerImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/entity/internal/EntityInitializerImpl.java
@@ -1722,7 +1722,7 @@ public class EntityInitializerImpl extends AbstractInitializer<EntityInitializer
 					.setPersister( data.concreteDescriptor );
 
 			session.getFactory()
-					.getFastSessionServices()
+					.getEventListenerGroups()
 					.eventListenerGroup_PRE_LOAD
 					.fireEventOnEachListener( preLoadEvent, PreLoadEventListener::onPreLoad );
 		}

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/spi/JsonJavaType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/spi/JsonJavaType.java
@@ -26,7 +26,7 @@ public class JsonJavaType<T> extends FormatMapperBasedJavaType<T> {
 
 	@Override
 	protected FormatMapper getFormatMapper(TypeConfiguration typeConfiguration) {
-		return typeConfiguration.getSessionFactory().getFastSessionServices().getJsonFormatMapper();
+		return typeConfiguration.getJsonFormatMapper();
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/spi/XmlJavaType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/spi/XmlJavaType.java
@@ -26,7 +26,7 @@ public class XmlJavaType<T> extends FormatMapperBasedJavaType<T> {
 
 	@Override
 	protected FormatMapper getFormatMapper(TypeConfiguration typeConfiguration) {
-		return typeConfiguration.getSessionFactory().getFastSessionServices().getXmlFormatMapper();
+		return typeConfiguration.getXmlFormatMapper();
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/type/spi/TypeConfiguration.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/spi/TypeConfiguration.java
@@ -75,6 +75,7 @@ import org.hibernate.type.descriptor.jdbc.JdbcType;
 import org.hibernate.type.descriptor.jdbc.JdbcTypeIndicators;
 import org.hibernate.type.descriptor.jdbc.spi.JdbcTypeRegistry;
 import org.hibernate.type.descriptor.sql.spi.DdlTypeRegistry;
+import org.hibernate.type.format.FormatMapper;
 import org.hibernate.type.internal.BasicTypeImpl;
 import org.hibernate.type.internal.ParameterizedTypeImpl;
 
@@ -917,5 +918,15 @@ public class TypeConfiguration implements SessionFactoryObserver, Serializable {
 
 	private ManagedBeanRegistry getManagedBeanRegistry() {
 		return scope.getServiceRegistry().requireService( ManagedBeanRegistry.class );
+	}
+
+	@Internal @Incubating // find a new home for this operation
+	public final FormatMapper getJsonFormatMapper() {
+		return getSessionFactory().getSessionFactoryOptions().getJsonFormatMapper();
+	}
+
+	@Internal @Incubating // find a new home for this operation
+	public final FormatMapper getXmlFormatMapper() {
+		return getSessionFactory().getSessionFactoryOptions().getXmlFormatMapper();
 	}
 }

--- a/hibernate-core/src/test/java/org/hibernate/event/PreUpdateEventListenerVetoTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/event/PreUpdateEventListenerVetoTest.java
@@ -9,7 +9,6 @@ import jakarta.persistence.Id;
 import jakarta.persistence.Version;
 
 import org.hibernate.engine.spi.SessionFactoryImplementor;
-import org.hibernate.event.service.spi.EventListenerRegistry;
 import org.hibernate.event.spi.EventType;
 
 import org.hibernate.testing.orm.junit.JiraKey;
@@ -36,8 +35,7 @@ public class PreUpdateEventListenerVetoTest extends BaseSessionFactoryFunctional
 
 	@Override
 	protected void sessionFactoryBuilt(SessionFactoryImplementor factory) {
-		factory.getServiceRegistry().requireService( EventListenerRegistry.class )
-				.appendListeners( EventType.PRE_UPDATE, event -> true );
+		factory.getEventListenerRegistry().appendListeners( EventType.PRE_UPDATE, event -> true );
 	}
 
 	@BeforeEach

--- a/hibernate-core/src/test/java/org/hibernate/event/service/internal/EventListenerGroupAppendListenerTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/event/service/internal/EventListenerGroupAppendListenerTest.java
@@ -9,7 +9,6 @@ import java.lang.reflect.Field;
 import org.hibernate.event.internal.DefaultMergeEventListener;
 import org.hibernate.event.service.spi.DuplicationStrategy;
 import org.hibernate.event.service.spi.EventListenerGroup;
-import org.hibernate.event.service.spi.EventListenerRegistry;
 import org.hibernate.event.spi.EventType;
 import org.hibernate.event.spi.MergeEventListener;
 import org.hibernate.jpa.event.spi.CallbackRegistry;
@@ -62,8 +61,7 @@ public class EventListenerGroupAppendListenerTest extends BaseSessionFactoryFunc
 		inTransaction( session -> {
 
 			EventListenerGroup<MergeEventListener> group =
-					sessionFactory().getServiceRegistry()
-							.requireService( EventListenerRegistry.class )
+					sessionFactory().getEventListenerRegistry()
 							.getEventListenerGroup( EventType.MERGE );
 			if ( duplicationStrategy != null ) {
 				group.addDuplicationStrategy( duplicationStrategy );

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/boot/models/BootstrapContextTesting.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/boot/models/BootstrapContextTesting.java
@@ -35,6 +35,7 @@ import org.hibernate.metamodel.spi.ManagedTypeRepresentationResolver;
 import org.hibernate.query.sqm.function.SqmFunctionDescriptor;
 import org.hibernate.query.sqm.function.SqmFunctionRegistry;
 import org.hibernate.resource.beans.spi.BeanInstanceProducer;
+import org.hibernate.resource.beans.spi.ManagedBeanRegistry;
 import org.hibernate.type.BasicType;
 import org.hibernate.type.internal.BasicTypeImpl;
 import org.hibernate.type.spi.TypeConfiguration;
@@ -57,8 +58,11 @@ public class BootstrapContextTesting implements BootstrapContext {
 	private final SqmFunctionRegistry sqmFunctionRegistry;
 	private final MutableJpaCompliance jpaCompliance;
 
+	private final ClassLoaderService classLoaderService;
 	private final ClassLoaderAccessImpl classLoaderAccess;
 	private final BeanInstanceProducer beanInstanceProducer;
+	private final ManagedBeanRegistry managedBeanRegistry;
+	private final ConfigurationService configurationService;
 
 	private boolean isJpaBootstrap;
 
@@ -85,7 +89,8 @@ public class BootstrapContextTesting implements BootstrapContext {
 		this.classmateContext = new ClassmateContext();
 		this.metadataBuildingOptions = metadataBuildingOptions;
 
-		this.classLoaderAccess = new ClassLoaderAccessImpl( serviceRegistry.getService( ClassLoaderService.class ) );
+		this.classLoaderService = serviceRegistry.getService( ClassLoaderService.class );
+		this.classLoaderAccess = new ClassLoaderAccessImpl( classLoaderService );
 
 		final StrategySelector strategySelector = serviceRegistry.getService( StrategySelector.class );
 		final ConfigurationService configService = serviceRegistry.getService( ConfigurationService.class );
@@ -108,7 +113,9 @@ public class BootstrapContextTesting implements BootstrapContext {
 		this.typeConfiguration = new TypeConfiguration();
 		this.beanInstanceProducer = new TypeBeanInstanceProducer( configService, serviceRegistry );
 		this.sqmFunctionRegistry = new SqmFunctionRegistry();
-	}
+
+		this.managedBeanRegistry = serviceRegistry.requireService( ManagedBeanRegistry.class );
+		this.configurationService = serviceRegistry.requireService( ConfigurationService.class );	}
 
 	@Override
 	public StandardServiceRegistry getServiceRegistry() {
@@ -138,6 +145,21 @@ public class BootstrapContextTesting implements BootstrapContext {
 	@Override
 	public MetadataBuildingOptions getMetadataBuildingOptions() {
 		return metadataBuildingOptions;
+	}
+
+	@Override
+	public ClassLoaderService getClassLoaderService() {
+		return classLoaderService;
+	}
+
+	@Override
+	public ManagedBeanRegistry getManagedBeanRegistry() {
+		return managedBeanRegistry;
+	}
+
+	@Override
+	public ConfigurationService getConfigurationService() {
+		return configurationService;
 	}
 
 	@Override

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/bootstrap/scanning/PackagedEntityManagerTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/bootstrap/scanning/PackagedEntityManagerTest.java
@@ -302,9 +302,8 @@ public class PackagedEntityManagerTest extends PackagingTestCase {
 		emf = Persistence.createEntityManagerFactory( "manager1", ServiceRegistryUtil.createBaseSettings() );
 		EntityManager em = emf.createEntityManager();
 		try {
-			EventListenerRegistry listenerRegistry = em.unwrap( SharedSessionContractImplementor.class ).getFactory()
-					.getServiceRegistry()
-					.getService( EventListenerRegistry.class );
+			EventListenerRegistry listenerRegistry =
+					em.unwrap( SharedSessionContractImplementor.class ).getFactory().getEventListenerRegistry();
 			assertEquals(
 					listenerRegistry.getEventListenerGroup( EventType.PRE_INSERT ).count(),
 					listenerRegistry.getEventListenerGroup( EventType.PRE_UPDATE ).count() + 1,

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/bootstrap/scanning/ScanningCoordinatorTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/bootstrap/scanning/ScanningCoordinatorTest.java
@@ -90,6 +90,7 @@ public class ScanningCoordinatorTest {
 		when( bootstrapContext.getMetadataBuildingOptions() ).thenReturn( metadataBuildingOptions );
 
 		when( serviceRegistry.requireService( ClassLoaderService.class ) ).thenReturn( classLoaderService );
+		when( bootstrapContext.getClassLoaderService() ).thenReturn( classLoaderService );
 
 		when( metadataBuildingOptions.isXmlMappingEnabled() ).thenReturn( true );
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/lazy/LazyProxyOnEnhancedEntityTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/lazy/LazyProxyOnEnhancedEntityTest.java
@@ -60,7 +60,7 @@ public class LazyProxyOnEnhancedEntityTest {
 
 	@Test
 	public void test(SessionFactoryScope scope) {
-		EventListenerRegistry registry = scope.getSessionFactory().getServiceRegistry().getService( EventListenerRegistry.class );
+		EventListenerRegistry registry = scope.getSessionFactory().getEventListenerRegistry();
 		registry.prependListeners( EventType.LOAD, new ImmediateLoadTrap() );
 
 		scope.inTransaction( em -> {

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/cdi/general/hibernatesearch/HibernateSearchSimulatedIntegrator.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/cdi/general/hibernatesearch/HibernateSearchSimulatedIntegrator.java
@@ -63,7 +63,7 @@ public class HibernateSearchSimulatedIntegrator implements Integrator, BeanConta
 			Metadata metadata,
 			BootstrapContext bootstrapContext,
 			SessionFactoryImplementor sessionFactory) {
-		ManagedBeanRegistry registry = sessionFactory.getServiceRegistry().getService( ManagedBeanRegistry.class );
+		ManagedBeanRegistry registry = bootstrapContext.getManagedBeanRegistry();
 
 		BeanContainer beanContainer = registry.getBeanContainer();
 		assertThat( beanContainer, CoreMatchers.notNullValue() );

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/cdi/lifecycle/ExtendedBeanManagerSmokeTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/cdi/lifecycle/ExtendedBeanManagerSmokeTests.java
@@ -73,7 +73,7 @@ public class ExtendedBeanManagerSmokeTests {
 
 	private static void assertApplied(ExtendedBeanManagerImpl ref, EntityManagerFactory emf) {
 		final SessionFactoryImplementor sfi = emf.unwrap( SessionFactoryImplementor.class );
-		final ManagedBeanRegistry beanRegistry = sfi.getServiceRegistry().getService( ManagedBeanRegistry.class );
+		final ManagedBeanRegistry beanRegistry = sfi.getManagedBeanRegistry();
 		assertThat( beanRegistry.getBeanContainer() ).isInstanceOf( CdiBeanContainerExtendedAccessImpl.class );
 
 		final CdiBeanContainerExtendedAccessImpl extensionWrapper = (CdiBeanContainerExtendedAccessImpl) beanRegistry.getBeanContainer();

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/event/PreInsertEventListenerVetoBidirectionalTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/event/PreInsertEventListenerVetoBidirectionalTest.java
@@ -14,7 +14,6 @@ import jakarta.persistence.OneToOne;
 import org.hibernate.action.internal.EntityActionVetoException;
 import org.hibernate.event.service.spi.EventListenerRegistry;
 import org.hibernate.event.spi.EventType;
-import org.hibernate.event.spi.PreInsertEventListener;
 
 import org.hibernate.testing.DialectChecks;
 import org.hibernate.testing.RequiresDialectFeature;
@@ -39,11 +38,10 @@ public class PreInsertEventListenerVetoBidirectionalTest extends BaseCoreFunctio
 	@Override
 	protected void afterSessionFactoryBuilt() {
 		super.afterSessionFactoryBuilt();
-		EventListenerRegistry registry = sessionFactory().getServiceRegistry()
-				.getService( EventListenerRegistry.class );
+		EventListenerRegistry registry = sessionFactory().getEventListenerRegistry();
 		registry.appendListeners(
 				EventType.PRE_INSERT,
-				(PreInsertEventListener) event -> event.getEntity() instanceof Parent
+				event -> event.getEntity() instanceof Parent
 		);
 	}
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/event/PreInsertEventListenerVetoUnidirectionalTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/event/PreInsertEventListenerVetoUnidirectionalTest.java
@@ -14,7 +14,6 @@ import jakarta.persistence.OneToOne;
 import org.hibernate.action.internal.EntityActionVetoException;
 import org.hibernate.event.service.spi.EventListenerRegistry;
 import org.hibernate.event.spi.EventType;
-import org.hibernate.event.spi.PreInsertEventListener;
 
 import org.hibernate.testing.DialectChecks;
 import org.hibernate.testing.RequiresDialectFeature;
@@ -39,10 +38,10 @@ public class PreInsertEventListenerVetoUnidirectionalTest extends BaseCoreFuncti
 	@Override
 	protected void afterSessionFactoryBuilt() {
 		super.afterSessionFactoryBuilt();
-		EventListenerRegistry registry = sessionFactory().getServiceRegistry().getService( EventListenerRegistry.class );
+		EventListenerRegistry registry = sessionFactory().getEventListenerRegistry();
 		registry.appendListeners(
 				EventType.PRE_INSERT,
-				(PreInsertEventListener) event -> event.getEntity() instanceof Parent
+				event -> event.getEntity() instanceof Parent
 		);
 	}
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/event/collection/CollectionListeners.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/event/collection/CollectionListeners.java
@@ -147,7 +147,7 @@ public class CollectionListeners {
 		postCollectionRemoveListener = new PostCollectionRemoveListener( this );
 		postCollectionUpdateListener = new PostCollectionUpdateListener( this );
 
-		EventListenerRegistry registry = ( (SessionFactoryImplementor) sf ).getServiceRegistry().getService( EventListenerRegistry.class );
+		EventListenerRegistry registry = ( (SessionFactoryImplementor) sf ).getEventListenerRegistry();
 		registry.setListeners( EventType.INIT_COLLECTION, initializeCollectionListener );
 
 		registry.setListeners( EventType.PRE_COLLECTION_RECREATE, preCollectionRecreateListener );

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/event/collection/detached/AggregatedCollectionEventListener.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/event/collection/detached/AggregatedCollectionEventListener.java
@@ -154,8 +154,7 @@ public class AggregatedCollectionEventListener
 			}
 			listener = new AggregatedCollectionEventListener();
 
-			final EventListenerRegistry listenerRegistry = sessionFactory.getServiceRegistry()
-					.getService( EventListenerRegistry.class );
+			final EventListenerRegistry listenerRegistry = sessionFactory.getEventListenerRegistry();
 			listenerRegistry.appendListeners( EventType.INIT_COLLECTION, listener );
 			listenerRegistry.appendListeners( EventType.PRE_COLLECTION_RECREATE, listener );
 			listenerRegistry.appendListeners( EventType.POST_COLLECTION_RECREATE, listener );

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/event/collection/detached/MultipleCollectionListeners.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/event/collection/detached/MultipleCollectionListeners.java
@@ -170,7 +170,7 @@ public class MultipleCollectionListeners {
 				this);
 		postCollectionRemoveListener = new PostCollectionRemoveListener(this);
 		postCollectionUpdateListener = new PostCollectionUpdateListener(this);
-		EventListenerRegistry registry = ( (SessionFactoryImplementor) sf ).getServiceRegistry().getService( EventListenerRegistry.class );
+		EventListenerRegistry registry = ( (SessionFactoryImplementor) sf ).getEventListenerRegistry();
 		registry.setListeners( EventType.INIT_COLLECTION, initializeCollectionListener );
 
 		registry.setListeners( EventType.PRE_COLLECTION_RECREATE, preCollectionRecreateListener );

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/event/entity/MergeListPreAndPostPersistTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/event/entity/MergeListPreAndPostPersistTest.java
@@ -130,8 +130,7 @@ public class MergeListPreAndPostPersistTest extends BaseCoreFunctionalTestCase {
 
 	private void addEntityListeners(final Order order) {
 
-		EventListenerRegistry registry = sessionFactory().getServiceRegistry()
-				.getService( EventListenerRegistry.class );
+		EventListenerRegistry registry = sessionFactory().getEventListenerRegistry();
 		registry.setListeners(
 				EventType.PRE_INSERT,
 				new PreInsertEventListener() {

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/event/entity/MergeListPreAndPostPersistWithIdentityTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/event/entity/MergeListPreAndPostPersistWithIdentityTest.java
@@ -136,8 +136,7 @@ public class MergeListPreAndPostPersistWithIdentityTest extends BaseCoreFunction
 
 	private void addEntityListeners(final Order order) {
 
-		EventListenerRegistry registry = sessionFactory().getServiceRegistry()
-				.getService( EventListenerRegistry.class );
+		EventListenerRegistry registry = sessionFactory().getEventListenerRegistry();
 		registry.setListeners(
 				EventType.PRE_INSERT,
 				new PreInsertEventListener() {

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/events/AutoFlushEventListenerTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/events/AutoFlushEventListenerTest.java
@@ -12,7 +12,6 @@ import org.hibernate.HibernateException;
 import org.hibernate.boot.Metadata;
 import org.hibernate.boot.spi.BootstrapContext;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
-import org.hibernate.event.service.spi.EventListenerRegistry;
 import org.hibernate.event.spi.AutoFlushEvent;
 import org.hibernate.event.spi.AutoFlushEventListener;
 import org.hibernate.event.spi.EventType;
@@ -114,7 +113,7 @@ public class AutoFlushEventListenerTest {
 				Metadata metadata,
 				BootstrapContext bootstrapContext,
 				SessionFactoryImplementor sessionFactory) {
-			sessionFactory.getServiceRegistry().getService( EventListenerRegistry.class ).appendListeners(
+			sessionFactory.getEventListenerRegistry().appendListeners(
 					EventType.AUTO_FLUSH,
 					LISTENER
 			);

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/events/CallbackTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/events/CallbackTest.java
@@ -12,7 +12,6 @@ import org.hibernate.boot.registry.BootstrapServiceRegistryBuilder;
 import org.hibernate.boot.spi.BootstrapContext;
 import org.hibernate.cfg.Configuration;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
-import org.hibernate.event.service.spi.EventListenerRegistry;
 import org.hibernate.event.spi.DeleteContext;
 import org.hibernate.event.spi.DeleteEvent;
 import org.hibernate.event.spi.DeleteEventListener;
@@ -67,7 +66,7 @@ public class CallbackTest extends BaseCoreFunctionalTestCase {
 					}
 
 					private void integrate(SessionFactoryImplementor sessionFactory) {
-						sessionFactory.getServiceRegistry().getService( EventListenerRegistry.class ).setListeners(
+						sessionFactory.getEventListenerRegistry().setListeners(
 								EventType.DELETE,
 								listener
 						);

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/events/ClearEventListenerTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/events/ClearEventListenerTest.java
@@ -7,7 +7,6 @@ package org.hibernate.orm.test.events;
 import org.hibernate.boot.Metadata;
 import org.hibernate.boot.spi.BootstrapContext;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
-import org.hibernate.event.service.spi.EventListenerRegistry;
 import org.hibernate.event.spi.ClearEvent;
 import org.hibernate.event.spi.ClearEventListener;
 import org.hibernate.event.spi.EventType;
@@ -85,7 +84,7 @@ public class ClearEventListenerTest {
 		}
 
 		private void integrate(SessionFactoryImplementor sessionFactory) {
-			sessionFactory.getServiceRegistry().getService( EventListenerRegistry.class ).setListeners(
+			sessionFactory.getEventListenerRegistry().setListeners(
 					EventType.CLEAR,
 					LISTENER
 			);

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/events/ListenerTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/events/ListenerTest.java
@@ -23,7 +23,6 @@ import jakarta.persistence.Transient;
 
 import org.hibernate.HibernateException;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
-import org.hibernate.event.service.spi.EventListenerRegistry;
 import org.hibernate.event.spi.EventType;
 import org.hibernate.event.spi.LoadEvent;
 import org.hibernate.event.spi.LoadEventListener;
@@ -54,10 +53,7 @@ public class ListenerTest extends BaseEntityManagerFunctionalTestCase {
 		doInJPA( this::entityManagerFactory, entityManager -> {
 			//tag::events-interceptors-load-listener-example-part1[]
 			EntityManagerFactory entityManagerFactory = entityManagerFactory();
-			SessionFactoryImplementor sessionFactory = entityManagerFactory.unwrap( SessionFactoryImplementor.class );
-			sessionFactory
-				.getServiceRegistry()
-				.getService( EventListenerRegistry.class )
+			entityManagerFactory.unwrap( SessionFactoryImplementor.class ).getEventListenerRegistry()
 				.prependListeners( EventType.LOAD, new SecuredLoadEntityListener() );
 
 			Customer customer = entityManager.find( Customer.class, customerId );

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/fetchstrategyhelper/FetchStrategyDeterminationTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/fetchstrategyhelper/FetchStrategyDeterminationTests.java
@@ -9,10 +9,8 @@ import org.hibernate.annotations.FetchMode;
 import org.hibernate.engine.FetchStyle;
 import org.hibernate.engine.FetchTiming;
 import org.hibernate.metamodel.mapping.AttributeMapping;
-import org.hibernate.persister.entity.AbstractEntityPersister;
 import org.hibernate.persister.entity.EntityPersister;
 import org.hibernate.sql.results.graph.FetchOptions;
-import org.hibernate.type.AssociationType;
 
 import org.hibernate.testing.junit4.BaseCoreFunctionalTestCase;
 import org.junit.Test;
@@ -56,20 +54,20 @@ public class FetchStrategyDeterminationTests extends BaseCoreFunctionalTestCase 
 		assertEquals( mappedFetchOptions.getTiming(), FetchTiming.IMMEDIATE );
 		assertEquals( mappedFetchOptions.getStyle(), FetchStyle.SELECT );
 	}
-
-	private org.hibernate.FetchMode determineFetchMode(Class<?> entityClass, String path) {
-		AbstractEntityPersister entityPersister = (AbstractEntityPersister)
-				sessionFactory().getMappingMetamodel().getEntityDescriptor(entityClass.getName());
-		int index = entityPersister.getPropertyIndex( path );
-		return  entityPersister.getFetchMode( index );
-	}
-
-	private AssociationType determineAssociationType(Class<?> entityClass, String path) {
-		AbstractEntityPersister entityPersister = (AbstractEntityPersister)
-				sessionFactory().getMappingMetamodel().getEntityDescriptor(entityClass.getName());
-		int index = entityPersister.getPropertyIndex( path );
-		return (AssociationType) entityPersister.getSubclassPropertyType( index );
-	}
+//
+//	private org.hibernate.FetchMode determineFetchMode(Class<?> entityClass, String path) {
+//		AbstractEntityPersister entityPersister = (AbstractEntityPersister)
+//				sessionFactory().getMappingMetamodel().getEntityDescriptor(entityClass.getName());
+//		int index = entityPersister.getPropertyIndex( path );
+//		return  entityPersister.getFetchMode( index );
+//	}
+//
+//	private AssociationType determineAssociationType(Class<?> entityClass, String path) {
+//		AbstractEntityPersister entityPersister = (AbstractEntityPersister)
+//				sessionFactory().getMappingMetamodel().getEntityDescriptor(entityClass.getName());
+//		int index = entityPersister.getPropertyIndex( path );
+//		return (AssociationType) entityPersister.getSubclassPropertyType( index );
+//	}
 
 	protected Class<?>[] getAnnotatedClasses() {
 		return new Class[] {

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/flush/TestAutoFlushBeforeQueryExecution.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/flush/TestAutoFlushBeforeQueryExecution.java
@@ -18,7 +18,6 @@ import org.hibernate.engine.spi.ActionQueue;
 import org.hibernate.engine.spi.PersistenceContext;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.engine.spi.SessionImplementor;
-import org.hibernate.event.service.spi.EventListenerRegistry;
 import org.hibernate.event.spi.EventType;
 import org.hibernate.event.spi.PreUpdateEvent;
 import org.hibernate.event.spi.PreUpdateEventListener;
@@ -218,7 +217,7 @@ public class TestAutoFlushBeforeQueryExecution extends BaseCoreFunctionalTestCas
 					}
 
 					private void integrate(SessionFactoryImplementor sessionFactory) {
-						sessionFactory.getServiceRegistry().getService( EventListenerRegistry.class )
+						sessionFactory.getEventListenerRegistry()
 								.getEventListenerGroup( EventType.PRE_UPDATE )
 								.appendListener( InitializingPreUpdateEventListener.INSTANCE );
 					}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/flush/TestCollectionInitializingDuringFlush.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/flush/TestCollectionInitializingDuringFlush.java
@@ -8,7 +8,6 @@ import org.hibernate.Hibernate;
 import org.hibernate.boot.Metadata;
 import org.hibernate.boot.spi.BootstrapContext;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
-import org.hibernate.event.service.spi.EventListenerRegistry;
 import org.hibernate.event.spi.EventType;
 import org.hibernate.event.spi.PreUpdateEvent;
 import org.hibernate.event.spi.PreUpdateEventListener;
@@ -102,7 +101,7 @@ public class TestCollectionInitializingDuringFlush {
 		}
 
 		private void integrate(SessionFactoryImplementor sessionFactory) {
-			sessionFactory.getServiceRegistry().getService( EventListenerRegistry.class )
+			sessionFactory.getEventListenerRegistry()
 					.getEventListenerGroup( EventType.PRE_UPDATE )
 					.appendListener( InitializingPreUpdateEventListener.INSTANCE );
 		}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/keymanytoone/bidir/component/EagerKeyManyToOneTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/keymanytoone/bidir/component/EagerKeyManyToOneTest.java
@@ -13,7 +13,6 @@ import org.hibernate.boot.Metadata;
 import org.hibernate.boot.spi.BootstrapContext;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.event.internal.DefaultLoadEventListener;
-import org.hibernate.event.service.spi.EventListenerRegistry;
 import org.hibernate.event.spi.EventType;
 import org.hibernate.event.spi.LoadEvent;
 import org.hibernate.event.spi.LoadEventListener;
@@ -52,7 +51,7 @@ public class EagerKeyManyToOneTest {
 		}
 
 		private void integrate(SessionFactoryImplementor sessionFactory) {
-			sessionFactory.getServiceRegistry().getService( EventListenerRegistry.class ).prependListeners(
+			sessionFactory.getEventListenerRegistry().prependListeners(
 					EventType.LOAD,
 					new CustomLoadListener()
 			);

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/loading/multiLoad/MultiLoadSubSelectCollectionDialectWithLimitTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/loading/multiLoad/MultiLoadSubSelectCollectionDialectWithLimitTest.java
@@ -112,7 +112,7 @@ public class MultiLoadSubSelectCollectionDialectWithLimitTest {
 	@JiraKey(value = "HHH-12740")
 	public void testSubselect(SessionFactoryScope scope) {
 		final SQLStatementInspector statementInspector = scope.getCollectingStatementInspector();
-		final Dialect dialect = scope.getSessionFactory().getFastSessionServices().jdbcServices.getDialect();
+		final Dialect dialect = scope.getSessionFactory().getJdbcServices().getDialect();
 		statementInspector.clear();
 
 		scope.inTransaction(

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/loading/multiLoad/MultiLoadTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/loading/multiLoad/MultiLoadTest.java
@@ -100,8 +100,7 @@ public class MultiLoadTest {
 					);
 
 					final Dialect dialect = session.getSessionFactory()
-							.getFastSessionServices()
-							.jdbcServices
+							.getJdbcServices()
 							.getDialect();
 					if ( MultiKeyLoadHelper.supportsSqlArrayType( dialect ) ) {
 						assertThat( paramCount, is( 1 ) );
@@ -353,10 +352,7 @@ public class MultiLoadTest {
 							'?'
 					);
 
-					final Dialect dialect = session.getSessionFactory()
-							.getFastSessionServices()
-							.jdbcServices
-							.getDialect();
+					final Dialect dialect = session.getSessionFactory().getJdbcServices().getDialect();
 					if ( MultiKeyLoadHelper.supportsSqlArrayType( dialect ) ) {
 						assertThat( paramCount, is( 1 ) );
 					}
@@ -418,10 +414,7 @@ public class MultiLoadTest {
 							'?'
 					);
 
-					final Dialect dialect = session.getSessionFactory()
-							.getFastSessionServices()
-							.jdbcServices
-							.getDialect();
+					final Dialect dialect = session.getSessionFactory().getJdbcServices().getDialect();
 					if ( MultiKeyLoadHelper.supportsSqlArrayType( dialect ) ) {
 						assertThat( paramCount, is( 1 ) );
 					}
@@ -459,10 +452,7 @@ public class MultiLoadTest {
 							'?'
 					);
 
-					final Dialect dialect = session.getSessionFactory()
-							.getFastSessionServices()
-							.jdbcServices
-							.getDialect();
+					final Dialect dialect = session.getSessionFactory().getJdbcServices().getDialect();
 					if ( MultiKeyLoadHelper.supportsSqlArrayType( dialect ) ) {
 						assertThat( paramCount, is( 1 ) );
 					}
@@ -506,10 +496,7 @@ public class MultiLoadTest {
 							'?'
 					);
 
-					final Dialect dialect = session.getSessionFactory()
-							.getFastSessionServices()
-							.jdbcServices
-							.getDialect();
+					final Dialect dialect = session.getSessionFactory().getJdbcServices().getDialect();
 					if ( MultiKeyLoadHelper.supportsSqlArrayType( dialect ) ) {
 						assertThat( paramCount, is( 1 ) );
 					}
@@ -546,10 +533,7 @@ public class MultiLoadTest {
 							'?'
 					);
 
-					final Dialect dialect = session.getSessionFactory()
-							.getFastSessionServices()
-							.jdbcServices
-							.getDialect();
+					final Dialect dialect = session.getSessionFactory().getJdbcServices().getDialect();
 					if ( MultiKeyLoadHelper.supportsSqlArrayType( dialect ) ) {
 						assertThat( paramCount, is( 1 ) );
 					}
@@ -592,10 +576,7 @@ public class MultiLoadTest {
 							'?'
 					);
 
-					final Dialect dialect = session.getSessionFactory()
-							.getFastSessionServices()
-							.jdbcServices
-							.getDialect();
+					final Dialect dialect = session.getSessionFactory().getJdbcServices().getDialect();
 					if ( MultiKeyLoadHelper.supportsSqlArrayType( dialect ) ) {
 						assertThat( paramCount, is( 1 ) );
 					}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/converted/converter/AttributeConverterTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/converted/converter/AttributeConverterTest.java
@@ -77,9 +77,7 @@ public class AttributeConverterTest extends BaseUnitTestCase {
 		try {
 			cfg.addAttributeConverter( BlowsUpConverter.class );
 			try ( final SessionFactoryImplementor sessionFactory = (SessionFactoryImplementor) cfg.buildSessionFactory() ) {
-				final ManagedBeanRegistry managedBeanRegistry = sessionFactory
-						.getServiceRegistry()
-						.getService( ManagedBeanRegistry.class );
+				final ManagedBeanRegistry managedBeanRegistry = sessionFactory.getManagedBeanRegistry();
 				final ManagedBean<BlowsUpConverter> converterBean = managedBeanRegistry.getBean( BlowsUpConverter.class );
 				converterBean.getBeanInstance();
 				fail( "expecting an exception" );

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/sharedSession/SessionWithSharedConnectionTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/sharedSession/SessionWithSharedConnectionTest.java
@@ -194,7 +194,7 @@ public class SessionWithSharedConnectionTest {
 
 		final String postCommitMessage = "post commit was called";
 
-		EventListenerRegistry eventListenerRegistry = scope.getSessionFactory().getServiceRegistry().getService(EventListenerRegistry.class);
+		EventListenerRegistry eventListenerRegistry = scope.getSessionFactory().getEventListenerRegistry();
 		//register a post commit listener
 		eventListenerRegistry.appendListeners(
 				EventType.POST_COMMIT_INSERT,

--- a/hibernate-envers/src/main/java/org/hibernate/envers/configuration/internal/metadata/ComponentMetadataGenerator.java
+++ b/hibernate-envers/src/main/java/org/hibernate/envers/configuration/internal/metadata/ComponentMetadataGenerator.java
@@ -20,7 +20,6 @@ import org.hibernate.metamodel.internal.EmbeddableCompositeUserTypeInstantiator;
 import org.hibernate.metamodel.internal.EmbeddableInstantiatorPojoIndirecting;
 import org.hibernate.metamodel.spi.EmbeddableInstantiator;
 import org.hibernate.resource.beans.internal.FallbackBeanInstanceProducer;
-import org.hibernate.resource.beans.spi.ManagedBeanRegistry;
 import org.hibernate.usertype.CompositeUserType;
 
 /**
@@ -55,11 +54,10 @@ public final class ComponentMetadataGenerator extends AbstractMetadataGenerator 
 				instantiator = FallbackBeanInstanceProducer.INSTANCE.produceBeanInstance( propComponent.getCustomInstantiator() );
 			}
 			else {
-				instantiator = getMetadataBuildingContext().getBootstrapContext()
-						.getServiceRegistry()
-						.getService( ManagedBeanRegistry.class )
-						.getBean( propComponent.getCustomInstantiator() )
-						.getBeanInstance();
+				instantiator =
+						getMetadataBuildingContext().getBootstrapContext().getManagedBeanRegistry()
+								.getBean( propComponent.getCustomInstantiator() )
+								.getBeanInstance();
 			}
 		}
 		else if ( propComponent.getTypeName() != null ) {
@@ -72,11 +70,10 @@ public final class ComponentMetadataGenerator extends AbstractMetadataGenerator 
 				instantiator = new EmbeddableCompositeUserTypeInstantiator( (CompositeUserType) compositeUserType );
 			}
 			else {
-				final CompositeUserType<Object> compositeUserType = (CompositeUserType<Object>) getMetadataBuildingContext().getBootstrapContext()
-						.getServiceRegistry()
-						.getService( ManagedBeanRegistry.class )
-						.getBean( userTypeClass )
-						.getBeanInstance();
+				final CompositeUserType<Object> compositeUserType = (CompositeUserType<Object>)
+						getMetadataBuildingContext().getBootstrapContext().getManagedBeanRegistry()
+								.getBean( userTypeClass )
+								.getBeanInstance();
 				instantiator = new EmbeddableCompositeUserTypeInstantiator( compositeUserType );
 			}
 		}

--- a/hibernate-testing/src/main/java/org/hibernate/testing/boot/BootstrapContextImpl.java
+++ b/hibernate-testing/src/main/java/org/hibernate/testing/boot/BootstrapContextImpl.java
@@ -11,6 +11,7 @@ import org.hibernate.boot.CacheRegionDefinition;
 import org.hibernate.boot.archive.scan.spi.ScanEnvironment;
 import org.hibernate.boot.archive.scan.spi.ScanOptions;
 import org.hibernate.boot.archive.spi.ArchiveDescriptorFactory;
+import org.hibernate.boot.registry.classloading.spi.ClassLoaderService;
 import org.hibernate.boot.spi.ClassmateContext;
 import org.hibernate.boot.internal.MetadataBuilderImpl;
 import org.hibernate.boot.model.convert.spi.ConverterDescriptor;
@@ -20,12 +21,14 @@ import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
 import org.hibernate.boot.spi.BootstrapContext;
 import org.hibernate.boot.spi.ClassLoaderAccess;
 import org.hibernate.boot.spi.MetadataBuildingOptions;
+import org.hibernate.engine.config.spi.ConfigurationService;
 import org.hibernate.jpa.spi.MutableJpaCompliance;
 import org.hibernate.metamodel.internal.ManagedTypeRepresentationResolverStandard;
 import org.hibernate.metamodel.spi.ManagedTypeRepresentationResolver;
 import org.hibernate.query.sqm.function.SqmFunctionDescriptor;
 import org.hibernate.query.sqm.function.SqmFunctionRegistry;
 import org.hibernate.resource.beans.spi.BeanInstanceProducer;
+import org.hibernate.resource.beans.spi.ManagedBeanRegistry;
 import org.hibernate.type.BasicType;
 import org.hibernate.type.spi.TypeConfiguration;
 
@@ -72,6 +75,21 @@ public class BootstrapContextImpl implements BootstrapContext {
 	@Override
 	public MetadataBuildingOptions getMetadataBuildingOptions() {
 		return delegate.getMetadataBuildingOptions();
+	}
+
+	@Override
+	public ClassLoaderService getClassLoaderService() {
+		return delegate.getClassLoaderService();
+	}
+
+	@Override
+	public ManagedBeanRegistry getManagedBeanRegistry() {
+		return delegate.getManagedBeanRegistry();
+	}
+
+	@Override
+	public ConfigurationService getConfigurationService() {
+		return delegate.getConfigurationService();
 	}
 
 	@Override

--- a/tooling/metamodel-generator/src/main/java/org/hibernate/processor/validation/MockSessionFactory.java
+++ b/tooling/metamodel-generator/src/main/java/org/hibernate/processor/validation/MockSessionFactory.java
@@ -580,7 +580,6 @@ public abstract class MockSessionFactory
 	@Override
 	public void setCheckNullability(boolean enabled) {}
 
-
 	private static class MockMappingDefaults implements MappingDefaults {
 		@Override
 		public String getImplicitSchemaName() {


### PR DESCRIPTION
introduce `EventListenerGroups`

<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

[Please describe here what your change is about]

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
