### PR TITLE
HHH-19009 correction of the inheritance syntax used with GraphParser

### DIFF
--- a/hibernate-core/src/test/java/org/hibernate/orm/test/graph/EntityGraphsTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/graph/EntityGraphsTest.java
@@ -13,7 +13,6 @@ import org.hibernate.graph.spi.RootGraphImplementor;
 import org.hibernate.metamodel.model.domain.EntityDomainType;
 import org.hibernate.testing.orm.junit.JiraKey;
 import org.junit.Assert;
-import org.junit.Ignore;
 import org.junit.Test;
 
 public class EntityGraphsTest extends AbstractEntityGraphTest {
@@ -64,10 +63,9 @@ public class EntityGraphsTest extends AbstractEntityGraphTest {
 	}
 
 	@Test
-	@Ignore("Cannot run due to Hibernate bug: https://hibernate.atlassian.net/browse/HHH-10378")
 	public void testEqualLinksWithSubclassesEqual() {
-		EntityGraph<GraphParsingTestEntity> a = parseGraph( "linkToOne(name), linkToOne:MockSubentity(description)" );
-		EntityGraph<GraphParsingTestEntity> b = parseGraph( "linkToOne:MockSubentity(description), linkToOne(name)" );
+		EntityGraph<GraphParsingTestEntity> a = parseGraph( "linkToOne(name), linkToOne(GraphParsingTestSubentity:description)" );
+		EntityGraph<GraphParsingTestEntity> b = parseGraph( "linkToOne(GraphParsingTestSubentity:description), linkToOne(name)" );
 		Assert.assertTrue( EntityGraphs.areEqual( a, b ) );
 	}
 
@@ -87,7 +85,7 @@ public class EntityGraphsTest extends AbstractEntityGraphTest {
 
 	@Test
 	public void testDifferentLinksEqual3() {
-		EntityGraph<GraphParsingTestEntity> a = parseGraph( "linkToOne(name), linkToOne:MockSubentity(description)" );
+		EntityGraph<GraphParsingTestEntity> a = parseGraph( "linkToOne(name), linkToOne(GraphParsingTestSubentity:description)" );
 		EntityGraph<GraphParsingTestEntity> b = parseGraph( "linkToOne(name, description)" );
 		Assert.assertFalse( EntityGraphs.areEqual( a, b ) );
 	}


### PR DESCRIPTION
Correction of the inheritance syntax used with GraphParser

<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

[Please describe here what your change is about]

Some test in the file EntityGraphsTest not use the good syntax for representing inheritance with GraphParser. 

For example, it represents inheritance like this: 
`linkToOne:MockSubentity(description)`
instead of the syntax provided by GraphLanguageParser : 
`linkToOne(MockSubentity:description)`

MockSubentity also does not exist and must be replaced by GraphParsingTestSubentity

https://hibernate.atlassian.net/browse/HHH-19009

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
