### PR TITLE
HHH-19010  get rid of inheritance of SessionFactoryImplementor from query creation context stuff

### DIFF
--- a/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/InformixSqmToSqlAstConverter.java
+++ b/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/InformixSqmToSqlAstConverter.java
@@ -50,11 +50,11 @@ public class InformixSqmToSqlAstConverter<T extends Statement> extends BaseSqmTo
 
 	@Override
 	public QuerySpec visitQuerySpec(SqmQuerySpec<?> sqmQuerySpec) {
-		final boolean needsDummy = this.needsDummyTableGroup;
-		this.needsDummyTableGroup = false;
+		final boolean needsDummy = needsDummyTableGroup;
+		needsDummyTableGroup = false;
 		try {
 			final QuerySpec querySpec = super.visitQuerySpec( sqmQuerySpec );
-			if ( this.needsDummyTableGroup ) {
+			if ( needsDummyTableGroup ) {
 				querySpec.getFromClause().addRoot(
 						new StandardTableGroup(
 								true,
@@ -70,7 +70,7 @@ public class InformixSqmToSqlAstConverter<T extends Statement> extends BaseSqmTo
 			return querySpec;
 		}
 		finally {
-			this.needsDummyTableGroup = needsDummy;
+			needsDummyTableGroup = needsDummy;
 		}
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/SessionFactory.java
+++ b/hibernate-core/src/main/java/org/hibernate/SessionFactory.java
@@ -145,8 +145,9 @@ public interface SessionFactory extends EntityManagerFactory, Referenceable, Ser
 	String getJndiName();
 
 	/**
-	 * Obtain a {@linkplain SessionBuilder session builder} for creating
-	 * new {@link Session}s with certain customized options.
+	 * Obtain a {@linkplain org.hibernate.SessionBuilder session builder}
+	 * for creating new instances of {@link org.hibernate.Session} with
+	 * certain customized options.
 	 *
 	 * @return The session builder
 	 */
@@ -455,6 +456,26 @@ public interface SessionFactory extends EntityManagerFactory, Referenceable, Ser
 	default boolean containsFetchProfileDefinition(String name) {
 		return getDefinedFilterNames().contains( name );
 	}
+
+	/**
+	 * The name assigned to this {@code SessionFactory}, if any.
+	 * <ul>
+	 * <li>When bootstrapping via JPA, this is the persistence unit name.
+	 * <li>Otherwise, the name may be specified by the configuration property
+	 *     {@value org.hibernate.cfg.PersistenceSettings#SESSION_FACTORY_NAME}.
+	 * </ul>
+	 * <p>
+	 * If {@value org.hibernate.cfg.PersistenceSettings#SESSION_FACTORY_NAME_IS_JNDI}
+	 * is enabled, then this name is used to bind this object to JNDI, unless
+	 * {@value org.hibernate.cfg.PersistenceSettings#SESSION_FACTORY_JNDI_NAME}
+	 * is also specified.
+	 *
+	 * @see org.hibernate.cfg.PersistenceSettings#SESSION_FACTORY_NAME
+	 * @see org.hibernate.cfg.PersistenceSettings#SESSION_FACTORY_NAME_IS_JNDI
+	 * @see jakarta.persistence.spi.PersistenceUnitInfo#getPersistenceUnitName
+	 */
+	@Override
+	String getName();
 
 	/**
 	 * Get the {@linkplain SessionFactoryOptions options} used to build this factory.

--- a/hibernate-core/src/main/java/org/hibernate/boot/query/HbmResultSetMappingDescriptor.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/query/HbmResultSetMappingDescriptor.java
@@ -4,17 +4,6 @@
  */
 package org.hibernate.boot.query;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
-import java.util.Set;
-import java.util.StringTokenizer;
-import java.util.function.Supplier;
-
 import org.hibernate.LockMode;
 import org.hibernate.MappingException;
 import org.hibernate.boot.BootLogging;
@@ -43,10 +32,9 @@ import org.hibernate.metamodel.mapping.EntityDiscriminatorMapping;
 import org.hibernate.metamodel.mapping.EntityMappingType;
 import org.hibernate.metamodel.mapping.PluralAttributeMapping;
 import org.hibernate.persister.collection.CollectionPersister;
+import org.hibernate.query.internal.FetchMementoBasicStandard;
 import org.hibernate.query.internal.FetchMementoEmbeddableStandard;
 import org.hibernate.query.internal.FetchMementoEntityStandard;
-import org.hibernate.spi.NavigablePath;
-import org.hibernate.query.internal.FetchMementoBasicStandard;
 import org.hibernate.query.internal.FetchMementoHbmStandard;
 import org.hibernate.query.internal.FetchMementoHbmStandard.FetchParentMemento;
 import org.hibernate.query.internal.NamedResultSetMappingMementoImpl;
@@ -58,10 +46,22 @@ import org.hibernate.query.named.FetchMemento;
 import org.hibernate.query.named.FetchMementoBasic;
 import org.hibernate.query.named.NamedResultSetMappingMemento;
 import org.hibernate.query.named.ResultMemento;
+import org.hibernate.spi.NavigablePath;
 import org.hibernate.sql.results.graph.Fetchable;
 import org.hibernate.sql.results.graph.FetchableContainer;
 import org.hibernate.sql.results.graph.entity.EntityValuedFetchable;
 import org.hibernate.type.BasicType;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import java.util.StringTokenizer;
+import java.util.function.Supplier;
 
 /**
  * Boot-time descriptor of a result set mapping as defined in an {@code hbm.xml} file
@@ -372,10 +372,8 @@ public class HbmResultSetMappingDescriptor implements NamedResultSetMappingDescr
 					registrationName
 			);
 
-			final EntityMappingType entityDescriptor = resolutionContext
-					.getSessionFactory()
-					.getRuntimeMetamodels()
-					.getEntityMappingType( entityName );
+			final EntityMappingType entityDescriptor =
+					resolutionContext.getMappingMetamodel().getEntityDescriptor( entityName );
 			applyFetchJoins( joinDescriptorsAccess, tableAlias, propertyFetchDescriptors );
 
 			final NavigablePath entityPath = new NavigablePath( entityName );
@@ -421,10 +419,8 @@ public class HbmResultSetMappingDescriptor implements NamedResultSetMappingDescr
 		@Override
 		public FetchParentMemento resolveParentMemento(ResultSetMappingResolutionContext resolutionContext) {
 			if ( thisAsParentMemento == null ) {
-				final EntityMappingType entityDescriptor = resolutionContext
-						.getSessionFactory()
-						.getRuntimeMetamodels()
-						.getEntityMappingType( entityName );
+				final EntityMappingType entityDescriptor =
+						resolutionContext.getMappingMetamodel().getEntityDescriptor( entityName );
 				thisAsParentMemento = new HbmFetchParentMemento(
 						new NavigablePath( entityDescriptor.getEntityName() ),
 						entityDescriptor
@@ -916,10 +912,9 @@ public class HbmResultSetMappingDescriptor implements NamedResultSetMappingDescr
 		@Override
 		public FetchParentMemento resolveParentMemento(ResultSetMappingResolutionContext resolutionContext) {
 			if ( thisAsParentMemento == null ) {
-				final CollectionPersister collectionDescriptor = resolutionContext.getSessionFactory()
-						.getRuntimeMetamodels()
-						.getMappingMetamodel()
-						.getCollectionDescriptor( collectionPath.getFullPath() );
+				final CollectionPersister collectionDescriptor =
+						resolutionContext.getMappingMetamodel()
+								.getCollectionDescriptor( collectionPath.getFullPath() );
 
 				thisAsParentMemento = new HbmFetchParentMemento( collectionPath, collectionDescriptor.getAttributeMapping() );
 			}
@@ -957,10 +952,9 @@ public class HbmResultSetMappingDescriptor implements NamedResultSetMappingDescr
 			);
 
 			if ( hibernateTypeName != null ) {
-				final BasicType<?> namedType = resolutionContext.getSessionFactory()
-						.getTypeConfiguration()
-						.getBasicTypeRegistry()
-						.getRegisteredType( hibernateTypeName );
+				final BasicType<?> namedType =
+						resolutionContext.getTypeConfiguration().getBasicTypeRegistry()
+								.getRegisteredType( hibernateTypeName );
 
 				if ( namedType == null ) {
 					throw new IllegalArgumentException( "Could not resolve named type : " + hibernateTypeName );

--- a/hibernate-core/src/main/java/org/hibernate/boot/query/SqlResultSetMappingDescriptor.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/query/SqlResultSetMappingDescriptor.java
@@ -12,10 +12,8 @@ import java.util.Map;
 
 import org.hibernate.LockMode;
 import org.hibernate.MappingException;
-import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.internal.util.StringHelper;
 import org.hibernate.internal.util.collections.ArrayHelper;
-import org.hibernate.metamodel.RuntimeMetamodels;
 import org.hibernate.metamodel.mapping.BasicValuedModelPart;
 import org.hibernate.metamodel.mapping.EntityDiscriminatorMapping;
 import org.hibernate.metamodel.mapping.EntityMappingType;
@@ -214,10 +212,9 @@ public class SqlResultSetMappingDescriptor implements NamedResultSetMappingDescr
 					(mapping) -> argumentResultMementos.add( mapping.resolve( resolutionContext ) )
 			);
 
-			final SessionFactoryImplementor sessionFactory = resolutionContext.getSessionFactory();
-			final JavaType<?> targetJtd = sessionFactory.getTypeConfiguration()
-					.getJavaTypeRegistry()
-					.getDescriptor( targetJavaType );
+			final JavaType<?> targetJtd =
+					resolutionContext.getTypeConfiguration().getJavaTypeRegistry()
+							.getDescriptor( targetJavaType );
 
 			return new ResultMementoInstantiationStandard( targetJtd, argumentResultMementos );
 		}
@@ -270,8 +267,8 @@ public class SqlResultSetMappingDescriptor implements NamedResultSetMappingDescr
 
 		@Override
 		public ResultMemento resolve(ResultSetMappingResolutionContext resolutionContext) {
-			final RuntimeMetamodels runtimeMetamodels = resolutionContext.getSessionFactory().getRuntimeMetamodels();
-			final EntityMappingType entityDescriptor = runtimeMetamodels.getEntityMappingType( entityName );
+			final EntityMappingType entityDescriptor =
+					resolutionContext.getMappingMetamodel().getEntityDescriptor( entityName );
 
 			final FetchMementoBasic discriminatorMemento = resolveDiscriminatorMemento(
 					entityDescriptor,
@@ -366,8 +363,8 @@ public class SqlResultSetMappingDescriptor implements NamedResultSetMappingDescr
 
 		@Override
 		public ResultMemento asResultMemento(NavigablePath path, ResultSetMappingResolutionContext resolutionContext) {
-			final RuntimeMetamodels runtimeMetamodels = resolutionContext.getSessionFactory().getRuntimeMetamodels();
-			final EntityMappingType entityMapping = runtimeMetamodels.getEntityMappingType( entityName );
+			final EntityMappingType entityMapping =
+					resolutionContext.getMappingMetamodel().getEntityDescriptor( entityName );
 
 			final ModelPart subPart = entityMapping.findSubPart( propertyPath, null );
 
@@ -386,8 +383,8 @@ public class SqlResultSetMappingDescriptor implements NamedResultSetMappingDescr
 
 		@Override
 		public FetchMemento resolve(ResultSetMappingResolutionContext resolutionContext) {
-			final RuntimeMetamodels runtimeMetamodels = resolutionContext.getSessionFactory().getRuntimeMetamodels();
-			final EntityMappingType entityMapping = runtimeMetamodels.getEntityMappingType( entityName );
+			final EntityMappingType entityMapping =
+					resolutionContext.getMappingMetamodel().getEntityDescriptor( entityName );
 
 			ModelPart subPart = entityMapping.findSubPart(
 					propertyPathParts[0],

--- a/hibernate-core/src/main/java/org/hibernate/dialect/function/AggregateWindowEmulationQueryTransformer.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/function/AggregateWindowEmulationQueryTransformer.java
@@ -10,7 +10,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.metamodel.mapping.BasicValuedMapping;
 import org.hibernate.metamodel.mapping.JdbcMapping;
 import org.hibernate.metamodel.model.domain.ReturnableType;
@@ -92,8 +91,6 @@ public class AggregateWindowEmulationQueryTransformer implements QueryTransforme
 			CteContainer cteContainer,
 			QuerySpec querySpec,
 			SqmToSqlAstConverter converter) {
-		final SessionFactoryImplementor factory = converter.getCreationContext()
-				.getSessionFactory();
 		final QuerySpec outerQuerySpec = new QuerySpec( querySpec.isRoot() );
 		final String identifierVariable = "hhh_";
 		final NavigablePath navigablePath = new NavigablePath(
@@ -400,7 +397,7 @@ public class AggregateWindowEmulationQueryTransformer implements QueryTransforme
 				columnNames,
 				false,
 				true,
-				factory
+				converter.getCreationContext().getSessionFactory()
 		);
 		outerQuerySpec.getFromClause().addRoot( queryPartTableGroup );
 

--- a/hibernate-core/src/main/java/org/hibernate/dialect/function/AvgFunction.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/function/AvgFunction.java
@@ -14,6 +14,7 @@ import org.hibernate.metamodel.mapping.BasicValuedMapping;
 import org.hibernate.metamodel.mapping.JdbcMapping;
 import org.hibernate.metamodel.model.domain.DomainType;
 import org.hibernate.metamodel.model.domain.ReturnableType;
+import org.hibernate.query.BindingContext;
 import org.hibernate.query.sqm.SqmExpressible;
 import org.hibernate.query.sqm.function.AbstractSqmSelfRenderingFunctionDescriptor;
 import org.hibernate.query.sqm.function.FunctionKind;
@@ -150,7 +151,7 @@ public class AvgFunction extends AbstractSqmSelfRenderingFunctionDescriptor {
 		public void validate(
 				List<? extends SqmTypedNode<?>> arguments,
 				String functionName,
-				TypeConfiguration typeConfiguration) {
+				BindingContext bindingContext) {
 			if ( arguments.size() != 1 ) {
 				throw new FunctionArgumentException(
 						String.format(
@@ -166,7 +167,7 @@ public class AvgFunction extends AbstractSqmSelfRenderingFunctionDescriptor {
 			final SqmExpressible<?> expressible = argument.getExpressible();
 			final DomainType<?> domainType;
 			if ( expressible != null && ( domainType = expressible.getSqmType() ) != null ) {
-				final JdbcType jdbcType = getJdbcType( domainType, typeConfiguration );
+				final JdbcType jdbcType = getJdbcType( domainType, bindingContext.getTypeConfiguration() );
 				if ( !isNumeric( jdbcType ) ) {
 					throw new FunctionArgumentException(
 							String.format(
@@ -230,7 +231,8 @@ public class AvgFunction extends AbstractSqmSelfRenderingFunctionDescriptor {
 			if ( impliedType != null ) {
 				return impliedType;
 			}
-			final JdbcMapping jdbcMapping = ( (Expression) arguments.get( 0 ) ).getExpressionType().getSingleJdbcMapping();
+			Expression expression = (Expression) arguments.get( 0 );
+			final JdbcMapping jdbcMapping = expression.getExpressionType().getSingleJdbcMapping();
 			if ( jdbcMapping instanceof BasicPluralType<?, ?> ) {
 				return (BasicValuedMapping) jdbcMapping;
 			}

--- a/hibernate-core/src/main/java/org/hibernate/dialect/function/ChrLiteralEmulation.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/function/ChrLiteralEmulation.java
@@ -9,6 +9,7 @@ import java.util.Locale;
 
 import org.hibernate.QueryException;
 import org.hibernate.metamodel.model.domain.ReturnableType;
+import org.hibernate.query.BindingContext;
 import org.hibernate.query.sqm.function.AbstractSqmSelfRenderingFunctionDescriptor;
 import org.hibernate.query.sqm.produce.function.ArgumentTypesValidator;
 import org.hibernate.query.sqm.produce.function.ArgumentsValidator;
@@ -41,7 +42,7 @@ public class ChrLiteralEmulation extends AbstractSqmSelfRenderingFunctionDescrip
 								StandardArgumentsValidators.exactly(1),
 								new ArgumentsValidator() {
 									@Override
-									public void validate(List<? extends SqmTypedNode<?>> arguments, String functionName, TypeConfiguration typeConfiguration) {
+									public void validate(List<? extends SqmTypedNode<?>> arguments, String functionName, BindingContext bindingContext) {
 										if ( !( arguments.get( 0 ) instanceof SqmLiteral<?> ) ) {
 											throw new QueryException(
 													String.format(

--- a/hibernate-core/src/main/java/org/hibernate/dialect/function/CteGenerateSeriesFunction.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/function/CteGenerateSeriesFunction.java
@@ -150,8 +150,9 @@ public class CteGenerateSeriesFunction extends NumberSeriesGenerateSeriesFunctio
 		}
 
 		public static CteStatement createSeriesCte(int maxSeriesSize, SqmToSqlAstConverter converter) {
-			final BasicType<Long> longType = converter.getCreationContext().getTypeConfiguration()
-					.getBasicTypeForJavaType( Long.class );
+			final BasicType<Long> longType =
+					converter.getCreationContext().getTypeConfiguration()
+							.getBasicTypeForJavaType( Long.class );
 			final Expression one = new UnparsedNumericLiteral<>( "1", NumericTypeCategory.LONG, longType );
 			final List<CteColumn> cteColumns = List.of( new CteColumn( "i", longType ) );
 

--- a/hibernate-core/src/main/java/org/hibernate/dialect/function/DynamicDispatchFunction.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/function/DynamicDispatchFunction.java
@@ -7,6 +7,7 @@ package org.hibernate.dialect.function;
 import java.util.List;
 
 import org.hibernate.metamodel.model.domain.ReturnableType;
+import org.hibernate.query.BindingContext;
 import org.hibernate.query.spi.QueryEngine;
 import org.hibernate.query.sqm.function.FunctionKind;
 import org.hibernate.query.sqm.function.SelfRenderingSqmFunction;
@@ -16,7 +17,6 @@ import org.hibernate.query.sqm.produce.function.ArgumentsValidator;
 import org.hibernate.query.sqm.tree.SqmTypedNode;
 import org.hibernate.query.sqm.tree.predicate.SqmPredicate;
 import org.hibernate.query.sqm.tree.select.SqmOrderByClause;
-import org.hibernate.type.spi.TypeConfiguration;
 
 /**
  * A function that dynamically dispatches to other functions,
@@ -61,10 +61,7 @@ public class DynamicDispatchFunction implements SqmFunctionDescriptor, Arguments
 			List<? extends SqmTypedNode<?>> arguments,
 			ReturnableType<T> impliedResultType,
 			QueryEngine queryEngine) {
-		final SqmFunctionDescriptor functionDescriptor = validateGetFunction(
-				arguments,
-				queryEngine.getTypeConfiguration()
-		);
+		final SqmFunctionDescriptor functionDescriptor = validateGetFunction( arguments, queryEngine );
 		return functionDescriptor.generateSqmExpression( arguments, impliedResultType, queryEngine );
 	}
 
@@ -74,10 +71,7 @@ public class DynamicDispatchFunction implements SqmFunctionDescriptor, Arguments
 			SqmPredicate filter,
 			ReturnableType<T> impliedResultType,
 			QueryEngine queryEngine) {
-		final SqmFunctionDescriptor functionDescriptor = validateGetFunction(
-				arguments,
-				queryEngine.getTypeConfiguration()
-		);
+		final SqmFunctionDescriptor functionDescriptor = validateGetFunction( arguments, queryEngine );
 		return functionDescriptor.generateAggregateSqmExpression(
 				arguments,
 				filter,
@@ -93,10 +87,7 @@ public class DynamicDispatchFunction implements SqmFunctionDescriptor, Arguments
 			SqmOrderByClause withinGroupClause,
 			ReturnableType<T> impliedResultType,
 			QueryEngine queryEngine) {
-		final SqmFunctionDescriptor functionDescriptor = validateGetFunction(
-				arguments,
-				queryEngine.getTypeConfiguration()
-		);
+		final SqmFunctionDescriptor functionDescriptor = validateGetFunction( arguments, queryEngine );
 		return functionDescriptor.generateOrderedSetAggregateSqmExpression(
 				arguments,
 				filter,
@@ -114,10 +105,7 @@ public class DynamicDispatchFunction implements SqmFunctionDescriptor, Arguments
 			Boolean fromFirst,
 			ReturnableType<T> impliedResultType,
 			QueryEngine queryEngine) {
-		final SqmFunctionDescriptor functionDescriptor = validateGetFunction(
-				arguments,
-				queryEngine.getTypeConfiguration()
-		);
+		final SqmFunctionDescriptor functionDescriptor = validateGetFunction( arguments, queryEngine );
 		return functionDescriptor.generateWindowSqmExpression(
 				arguments,
 				filter,
@@ -137,13 +125,13 @@ public class DynamicDispatchFunction implements SqmFunctionDescriptor, Arguments
 	public void validate(
 			List<? extends SqmTypedNode<?>> arguments,
 			String functionName,
-			TypeConfiguration typeConfiguration) {
-		validateGetFunction( arguments, typeConfiguration );
+			BindingContext bindingContext) {
+		validateGetFunction( arguments, bindingContext );
 	}
 
 	private SqmFunctionDescriptor validateGetFunction(
 			List<? extends SqmTypedNode<?>> arguments,
-			TypeConfiguration typeConfiguration) {
+			BindingContext bindingContext) {
 		RuntimeException exception = null;
 		for ( String overload : functionNames ) {
 			final SqmFunctionDescriptor functionDescriptor = functionRegistry.findFunctionDescriptor( overload );
@@ -151,7 +139,7 @@ public class DynamicDispatchFunction implements SqmFunctionDescriptor, Arguments
 				throw new IllegalArgumentException( "No function registered under the name '" + overload + "'" );
 			}
 			try {
-				functionDescriptor.getArgumentsValidator().validate( arguments, overload, typeConfiguration );
+				functionDescriptor.getArgumentsValidator().validate( arguments, overload, bindingContext );
 				return functionDescriptor;
 			}
 			catch (RuntimeException ex) {

--- a/hibernate-core/src/main/java/org/hibernate/dialect/function/FormatFunction.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/function/FormatFunction.java
@@ -221,9 +221,7 @@ public class FormatFunction extends AbstractSqmFunctionDescriptor implements Fun
 					final FunctionRenderer substringFunction = getFunction( walker, "substring", 3 );
 					final BasicType<String> stringType = typeConfiguration.getBasicTypeRegistry()
 							.resolve( StandardBasicTypes.STRING );
-					final Dialect dialect =
-							walker.getCreationContext().getSessionFactory().getJdbcServices()
-									.getDialect();
+					final Dialect dialect = walker.getCreationContext().getDialect();
 					Expression formatExpression = null;
 					final StringBuilder sb = new StringBuilder();
 					final StringBuilderSqlAppender sqlAppender = new StringBuilderSqlAppender( sb );
@@ -425,13 +423,12 @@ public class FormatFunction extends AbstractSqmFunctionDescriptor implements Fun
 
 		private FunctionRenderer getFunction(SqmToSqlAstConverter walker, String name) {
 			return (FunctionRenderer)
-					walker.getCreationContext().getSessionFactory().getQueryEngine()
-							.getSqmFunctionRegistry().findFunctionDescriptor( name );
+					walker.getCreationContext().getSqmFunctionRegistry().findFunctionDescriptor( name );
 		}
 
 		private FunctionRenderer getFunction(SqmToSqlAstConverter walker, String name, int argumentCount) {
 			final SqmFunctionDescriptor functionDescriptor =
-					walker.getCreationContext().getSessionFactory().getQueryEngine().getSqmFunctionRegistry()
+					walker.getCreationContext().getSqmFunctionRegistry()
 							.findFunctionDescriptor( name );
 			if ( functionDescriptor instanceof MultipatternSqmFunctionDescriptor multipatternSqmFunctionDescriptor ) {
 				return (FunctionRenderer) multipatternSqmFunctionDescriptor.getFunction( argumentCount );

--- a/hibernate-core/src/main/java/org/hibernate/dialect/function/GenerateSeriesArgumentValidator.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/function/GenerateSeriesArgumentValidator.java
@@ -6,13 +6,13 @@ package org.hibernate.dialect.function;
 
 import org.hibernate.metamodel.mapping.JdbcMapping;
 import org.hibernate.metamodel.model.domain.DomainType;
+import org.hibernate.query.BindingContext;
 import org.hibernate.query.sqm.SqmExpressible;
 import org.hibernate.query.sqm.produce.function.ArgumentsValidator;
 import org.hibernate.query.sqm.produce.function.FunctionArgumentException;
 import org.hibernate.query.sqm.produce.function.StandardArgumentsValidators;
 import org.hibernate.query.sqm.tree.SqmTypedNode;
 import org.hibernate.type.descriptor.jdbc.JdbcType;
-import org.hibernate.type.spi.TypeConfiguration;
 
 import java.util.List;
 import java.util.Locale;
@@ -32,8 +32,8 @@ public class GenerateSeriesArgumentValidator implements ArgumentsValidator {
 	public void validate(
 			List<? extends SqmTypedNode<?>> arguments,
 			String functionName,
-			TypeConfiguration typeConfiguration) {
-		delegate.validate( arguments, functionName, typeConfiguration );
+			BindingContext bindingContext) {
+		delegate.validate( arguments, functionName, bindingContext );
 
 		final SqmTypedNode<?> start = arguments.get( 0 );
 		final SqmTypedNode<?> stop = arguments.get( 1 );

--- a/hibernate-core/src/main/java/org/hibernate/dialect/function/InverseDistributionFunction.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/function/InverseDistributionFunction.java
@@ -189,7 +189,7 @@ public class InverseDistributionFunction extends AbstractSqmSelfRenderingFunctio
 					return basicValuedMapping;
 				}
 				try {
-					return walker.getCreationContext().getSessionFactory().getMappingMetamodel()
+					return walker.getCreationContext().getMappingMetamodel()
 							.resolveMappingExpressible( getNodeType(), walker.getFromClauseAccess()::getTableGroup );
 				}
 				catch (Exception e) {

--- a/hibernate-core/src/main/java/org/hibernate/dialect/function/NumberSeriesGenerateSeriesFunction.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/function/NumberSeriesGenerateSeriesFunction.java
@@ -5,7 +5,6 @@
 package org.hibernate.dialect.function;
 
 import org.checkerframework.checker.nullness.qual.Nullable;
-import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.internal.util.NullnessHelper;
 import org.hibernate.metamodel.mapping.BasicValuedMapping;
 import org.hibernate.metamodel.mapping.CollectionPart;
@@ -28,6 +27,7 @@ import org.hibernate.query.sqm.tree.expression.NumericTypeCategory;
 import org.hibernate.sql.Template;
 import org.hibernate.sql.ast.SqlAstTranslator;
 import org.hibernate.sql.ast.spi.SqlAppender;
+import org.hibernate.sql.ast.spi.SqlAstCreationContext;
 import org.hibernate.sql.ast.tree.SqlAstNode;
 import org.hibernate.sql.ast.tree.cte.CteContainer;
 import org.hibernate.sql.ast.tree.expression.BinaryArithmeticExpression;
@@ -107,8 +107,8 @@ public abstract class NumberSeriesGenerateSeriesFunction extends GenerateSeriesF
 	public static Expression add(Expression left, Expression right, SqmToSqlAstConverter converter) {
 		if ( right instanceof org.hibernate.sql.ast.tree.expression.Duration duration ) {
 			final BasicType<?> nodeType = (BasicType<?>) left.getExpressionType().getSingleJdbcMapping();
-			final FunctionRenderer timestampadd = (FunctionRenderer) converter.getCreationContext().getSessionFactory()
-					.getQueryEngine().getSqmFunctionRegistry().findFunctionDescriptor( "timestampadd" );
+			final FunctionRenderer timestampadd = (FunctionRenderer) converter.getCreationContext()
+					.getSqmFunctionRegistry().findFunctionDescriptor( "timestampadd" );
 			return new SelfRenderingFunctionSqlAstExpression(
 					"timestampadd",
 					timestampadd,
@@ -155,10 +155,11 @@ public abstract class NumberSeriesGenerateSeriesFunction extends GenerateSeriesF
 
 	static Expression castToTimestamp(SqlAstNode node, SqmToSqlAstConverter converter) {
 		final BasicType<?> nodeType = (BasicType<?>) ((Expression) node).getExpressionType().getSingleJdbcMapping();
-		final FunctionRenderer cast = (FunctionRenderer) converter.getCreationContext().getSessionFactory().getQueryEngine()
-				.getSqmFunctionRegistry().findFunctionDescriptor( "cast" );
-		final BasicType<?> timestampType = converter.getCreationContext().getTypeConfiguration()
-				.getBasicTypeForJavaType( Timestamp.class );
+		final FunctionRenderer cast = (FunctionRenderer)
+				converter.getCreationContext().getSqmFunctionRegistry().findFunctionDescriptor( "cast" );
+		final BasicType<?> timestampType =
+				converter.getCreationContext().getTypeConfiguration()
+						.getBasicTypeForJavaType( Timestamp.class );
 		return new SelfRenderingFunctionSqlAstExpression(
 				"cast",
 				cast,
@@ -211,8 +212,7 @@ public abstract class NumberSeriesGenerateSeriesFunction extends GenerateSeriesF
 			else {
 				predicateContainer = querySpec;
 			}
-			final BasicType<Integer> integerType = converter.getCreationContext()
-					.getSessionFactory()
+			final BasicType<Integer> integerType = converter.getSqmCreationContext()
 					.getNodeBuilder()
 					.getIntegerType();
 			final Expression oneBasedOrdinal = new ColumnReference(
@@ -247,8 +247,7 @@ public abstract class NumberSeriesGenerateSeriesFunction extends GenerateSeriesF
 			}
 			else {
 				// When start < stop, step must be positive and value is only valid if it's less than or equal to stop
-				final BasicType<Boolean> booleanType = converter.getCreationContext()
-						.getSessionFactory()
+				final BasicType<Boolean> booleanType = converter.getSqmCreationContext()
 						.getNodeBuilder()
 						.getBooleanType();
 				final Predicate positiveProgress = new Junction(
@@ -438,8 +437,10 @@ public abstract class NumberSeriesGenerateSeriesFunction extends GenerateSeriesF
 		}
 
 		private static String timestampadd(String startExpression, String stepExpression, JdbcMapping type, org.hibernate.sql.ast.tree.expression.Duration duration, SqmToSqlAstConverter converter) {
-			final FunctionRenderer renderer = (FunctionRenderer) converter.getCreationContext().getSessionFactory()
-					.getQueryEngine().getSqmFunctionRegistry().findFunctionDescriptor( "timestampadd" );
+			final SqlAstCreationContext creationContext = converter.getCreationContext();
+
+			final FunctionRenderer renderer = (FunctionRenderer) creationContext.getSqmFunctionRegistry()
+					.findFunctionDescriptor( "timestampadd" );
 			final QuerySpec fakeQuery = new QuerySpec( true );
 			fakeQuery.getSelectClause().addSqlSelection( new SqlSelectionImpl(
 					new SelfRenderingFunctionSqlAstExpression(
@@ -454,9 +455,9 @@ public abstract class NumberSeriesGenerateSeriesFunction extends GenerateSeriesF
 							type
 					)
 			) );
-			final SqlAstTranslator<JdbcOperationQuerySelect> translator = converter.getCreationContext()
-					.getSessionFactory().getJdbcServices().getDialect().getSqlAstTranslatorFactory()
-					.buildSelectTranslator( converter.getCreationContext().getSessionFactory(), new SelectStatement( fakeQuery ) );
+			final SqlAstTranslator<JdbcOperationQuerySelect> translator =
+					creationContext.getDialect().getSqlAstTranslatorFactory()
+							.buildSelectTranslator( creationContext.getSessionFactory(), new SelectStatement( fakeQuery ) );
 			final JdbcOperationQuerySelect operation = translator.translate( null, QueryOptions.NONE );
 			final String sqlString = operation.getSqlString();
 			assert sqlString.startsWith( "select " );
@@ -483,11 +484,11 @@ public abstract class NumberSeriesGenerateSeriesFunction extends GenerateSeriesF
 
 		private String getExpression(Expression expression, String tableIdentifierVariable, String syntheticColumnName, SqmToSqlAstConverter walker) {
 			if ( expression instanceof Literal literal ) {
-				final SessionFactoryImplementor sessionFactory = walker.getCreationContext().getSessionFactory();
 				//noinspection unchecked
+				final SqlAstCreationContext creationContext = walker.getCreationContext();
 				return literal.getJdbcMapping().getJdbcLiteralFormatter()
-						.toJdbcLiteral( literal.getLiteralValue(), sessionFactory.getJdbcServices().getDialect(),
-								sessionFactory.getWrapperOptions() );
+						.toJdbcLiteral( literal.getLiteralValue(), creationContext.getDialect(),
+								creationContext.getWrapperOptions() );
 			}
 			else if ( expression instanceof ColumnReference columnReference ) {
 				return columnReference.getExpressionText();

--- a/hibernate-core/src/main/java/org/hibernate/dialect/function/TruncFunction.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/function/TruncFunction.java
@@ -8,6 +8,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.hibernate.metamodel.model.domain.ReturnableType;
+import org.hibernate.query.BindingContext;
 import org.hibernate.query.spi.QueryEngine;
 import org.hibernate.query.sqm.NodeBuilder;
 import org.hibernate.query.common.TemporalUnit;
@@ -215,12 +216,12 @@ public class TruncFunction extends AbstractSqmFunctionDescriptor {
 		public void validate(
 				List<? extends SqmTypedNode<?>> arguments,
 				String functionName,
-				TypeConfiguration typeConfiguration) {
+				BindingContext bindingContext) {
 			if ( arguments.size() == 2 && arguments.get( 1 ) instanceof SqmExtractUnit ) {
-				DATETIME_VALIDATOR.validate( arguments, functionName, typeConfiguration );
+				DATETIME_VALIDATOR.validate( arguments, functionName, bindingContext );
 			}
 			else {
-				NUMERIC_VALIDATOR.validate( arguments, functionName, typeConfiguration );
+				NUMERIC_VALIDATOR.validate( arguments, functionName, bindingContext );
 			}
 		}
 	}

--- a/hibernate-core/src/main/java/org/hibernate/dialect/function/array/AbstractArrayFillFunction.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/function/array/AbstractArrayFillFunction.java
@@ -55,7 +55,7 @@ public abstract class AbstractArrayFillFunction extends AbstractSqmSelfRendering
 						: null;
 			}
 			else {
-				return converter.getCreationContext().getSessionFactory().getTypeConfiguration().getBasicTypeRegistry()
+				return converter.getCreationContext().getTypeConfiguration().getBasicTypeRegistry()
 						.getRegisteredType( Integer.class );
 			}
 		}

--- a/hibernate-core/src/main/java/org/hibernate/dialect/function/array/AbstractArrayPositionFunction.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/function/array/AbstractArrayPositionFunction.java
@@ -42,7 +42,6 @@ public abstract class AbstractArrayPositionFunction extends AbstractSqmSelfRende
 					public @Nullable MappingModelExpressible<?> resolveFunctionArgumentType(List<? extends SqmTypedNode<?>> arguments, int argumentIndex, SqmToSqlAstConverter converter) {
 						if ( argumentIndex == 2 ) {
 							return converter.getCreationContext()
-									.getSessionFactory()
 									.getTypeConfiguration()
 									.standardBasicTypeForJavaType( Integer.class );
 						}

--- a/hibernate-core/src/main/java/org/hibernate/dialect/function/array/ArrayAndElementArgumentTypeResolver.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/function/array/ArrayAndElementArgumentTypeResolver.java
@@ -43,7 +43,7 @@ public class ArrayAndElementArgumentTypeResolver extends AbstractFunctionArgumen
 					if ( expressible != null ) {
 						return DdlTypeHelper.resolveArrayType(
 								(DomainType<?>) expressible.getSingleJdbcMapping(),
-								converter.getCreationContext().getSessionFactory().getTypeConfiguration()
+								converter.getCreationContext().getTypeConfiguration()
 						);
 					}
 				}

--- a/hibernate-core/src/main/java/org/hibernate/dialect/function/array/ArrayAndElementArgumentValidator.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/function/array/ArrayAndElementArgumentValidator.java
@@ -6,12 +6,12 @@ package org.hibernate.dialect.function.array;
 
 import java.util.List;
 
+import org.hibernate.query.BindingContext;
 import org.hibernate.query.sqm.SqmExpressible;
 import org.hibernate.query.sqm.produce.function.ArgumentsValidator;
 import org.hibernate.query.sqm.produce.function.FunctionArgumentException;
 import org.hibernate.query.sqm.tree.SqmTypedNode;
 import org.hibernate.type.BasicType;
-import org.hibernate.type.spi.TypeConfiguration;
 
 /**
  * A {@link ArgumentsValidator} that validates the array type is compatible with the element type.
@@ -31,8 +31,8 @@ public class ArrayAndElementArgumentValidator extends ArrayArgumentValidator {
 	public void validate(
 			List<? extends SqmTypedNode<?>> arguments,
 			String functionName,
-			TypeConfiguration typeConfiguration) {
-		final BasicType<?> expectedElementType = getElementType( arguments, functionName, typeConfiguration );
+			BindingContext bindingContext) {
+		final BasicType<?> expectedElementType = getElementType( arguments, functionName, bindingContext );
 		for ( int elementIndex : elementIndexes ) {
 			if ( elementIndex < arguments.size() ) {
 				final SqmTypedNode<?> elementArgument = arguments.get( elementIndex );

--- a/hibernate-core/src/main/java/org/hibernate/dialect/function/array/ArrayArgumentValidator.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/function/array/ArrayArgumentValidator.java
@@ -6,13 +6,13 @@ package org.hibernate.dialect.function.array;
 
 import java.util.List;
 
+import org.hibernate.query.BindingContext;
 import org.hibernate.query.sqm.SqmExpressible;
 import org.hibernate.query.sqm.produce.function.ArgumentsValidator;
 import org.hibernate.query.sqm.produce.function.FunctionArgumentException;
 import org.hibernate.query.sqm.tree.SqmTypedNode;
 import org.hibernate.type.BasicPluralType;
 import org.hibernate.type.BasicType;
-import org.hibernate.type.spi.TypeConfiguration;
 
 /**
  * A {@link ArgumentsValidator} that validates the array type is compatible with the element type.
@@ -31,22 +31,22 @@ public class ArrayArgumentValidator implements ArgumentsValidator {
 	public void validate(
 			List<? extends SqmTypedNode<?>> arguments,
 			String functionName,
-			TypeConfiguration typeConfiguration) {
-		getElementType( arguments, functionName, typeConfiguration );
+			BindingContext bindingContext) {
+		getElementType( arguments, functionName, bindingContext );
 	}
 
 	protected BasicType<?> getElementType(
 			List<? extends SqmTypedNode<?>> arguments,
 			String functionName,
-			TypeConfiguration typeConfiguration) {
-		return getElementType( arrayIndex, arguments, functionName, typeConfiguration );
+			BindingContext bindingContext) {
+		return getElementType( arrayIndex, arguments, functionName, bindingContext );
 	}
 
 	protected BasicPluralType<?, ?> getPluralType(
 			int arrayIndex,
 			List<? extends SqmTypedNode<?>> arguments,
 			String functionName,
-			TypeConfiguration typeConfiguration) {
+			BindingContext bindingContext) {
 		final SqmTypedNode<?> arrayArgument = arguments.get( arrayIndex );
 		final SqmExpressible<?> expressible = arrayArgument.getExpressible();
 		if ( expressible == null ) {
@@ -75,7 +75,7 @@ public class ArrayArgumentValidator implements ArgumentsValidator {
 			int arrayIndex,
 			List<? extends SqmTypedNode<?>> arguments,
 			String functionName,
-			TypeConfiguration typeConfiguration) {
-		return getPluralType( arrayIndex, arguments, functionName, typeConfiguration ).getElementType();
+			BindingContext bindingContext) {
+		return getPluralType( arrayIndex, arguments, functionName, bindingContext ).getElementType();
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/dialect/function/array/ArrayConstructorFunction.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/function/array/ArrayConstructorFunction.java
@@ -6,12 +6,11 @@ package org.hibernate.dialect.function.array;
 
 import java.util.List;
 
-import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.metamodel.mapping.JdbcMappingContainer;
 import org.hibernate.metamodel.model.domain.ReturnableType;
+import org.hibernate.query.BindingContext;
 import org.hibernate.query.sqm.SqmExpressible;
 import org.hibernate.query.sqm.function.AbstractSqmSelfRenderingFunctionDescriptor;
-import org.hibernate.query.sqm.internal.TypecheckUtil;
 import org.hibernate.query.sqm.produce.function.ArgumentsValidator;
 import org.hibernate.query.sqm.produce.function.FunctionArgumentException;
 import org.hibernate.query.sqm.produce.function.StandardFunctionArgumentTypeResolvers;
@@ -21,7 +20,8 @@ import org.hibernate.sql.ast.spi.SqlAppender;
 import org.hibernate.sql.ast.tree.SqlAstNode;
 import org.hibernate.sql.ast.tree.expression.Expression;
 import org.hibernate.type.BottomType;
-import org.hibernate.type.spi.TypeConfiguration;
+
+import static org.hibernate.query.sqm.internal.TypecheckUtil.areTypesComparable;
 
 public class ArrayConstructorFunction extends AbstractSqmSelfRenderingFunctionDescriptor {
 
@@ -75,8 +75,7 @@ public class ArrayConstructorFunction extends AbstractSqmSelfRenderingFunctionDe
 		public void validate(
 				List<? extends SqmTypedNode<?>> arguments,
 				String functionName,
-				TypeConfiguration typeConfiguration) {
-			final SessionFactoryImplementor sessionFactory = typeConfiguration.getSessionFactory();
+				BindingContext bindingContext) {
 			final int size = arguments.size();
 			SqmExpressible<?> firstType = null;
 			for ( int i = 0; i < size; i++ ) {
@@ -84,7 +83,7 @@ public class ArrayConstructorFunction extends AbstractSqmSelfRenderingFunctionDe
 				if ( firstType == null ) {
 					firstType = argument;
 				}
-				else if ( !TypecheckUtil.areTypesComparable( firstType, argument, sessionFactory ) ) {
+				else if ( !areTypesComparable( firstType, argument, bindingContext ) ) {
 					throw new FunctionArgumentException(
 							String.format(
 									"All array arguments must have a compatible type compatible to the first argument type [%s], but argument %d has type '%s'",

--- a/hibernate-core/src/main/java/org/hibernate/dialect/function/array/ArrayContainsArgumentTypeResolver.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/function/array/ArrayContainsArgumentTypeResolver.java
@@ -36,7 +36,7 @@ public class ArrayContainsArgumentTypeResolver extends AbstractFunctionArgumentT
 					else {
 						return DdlTypeHelper.resolveArrayType(
 								(DomainType<?>) expressible.getSingleJdbcMapping(),
-								converter.getCreationContext().getSessionFactory().getTypeConfiguration()
+								converter.getCreationContext().getTypeConfiguration()
 						);
 					}
 				}

--- a/hibernate-core/src/main/java/org/hibernate/dialect/function/array/ArrayContainsArgumentValidator.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/function/array/ArrayContainsArgumentValidator.java
@@ -6,12 +6,12 @@ package org.hibernate.dialect.function.array;
 
 import java.util.List;
 
+import org.hibernate.query.BindingContext;
 import org.hibernate.query.sqm.SqmExpressible;
 import org.hibernate.query.sqm.produce.function.ArgumentsValidator;
 import org.hibernate.query.sqm.produce.function.FunctionArgumentException;
 import org.hibernate.query.sqm.tree.SqmTypedNode;
 import org.hibernate.type.BasicPluralType;
-import org.hibernate.type.spi.TypeConfiguration;
 
 /**
  * A {@link ArgumentsValidator} that validates the arguments for the {@code array_contains} function.
@@ -28,9 +28,9 @@ public class ArrayContainsArgumentValidator extends ArrayArgumentValidator {
 	public void validate(
 			List<? extends SqmTypedNode<?>> arguments,
 			String functionName,
-			TypeConfiguration typeConfiguration) {
+			BindingContext bindingContext) {
 		final BasicPluralType<?, ?> haystackType =
-				getPluralType( 0, arguments, functionName, typeConfiguration );
+				getPluralType( 0, arguments, functionName, bindingContext );
 		final SqmExpressible<?> expressible = arguments.get( 1 ).getExpressible();
 		final SqmExpressible<?> needleType = expressible == null ? null : expressible.getSqmType();
 		if ( haystackType!= null && needleType != null

--- a/hibernate-core/src/main/java/org/hibernate/dialect/function/array/ArrayIncludesArgumentValidator.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/function/array/ArrayIncludesArgumentValidator.java
@@ -6,11 +6,11 @@ package org.hibernate.dialect.function.array;
 
 import java.util.List;
 
+import org.hibernate.query.BindingContext;
 import org.hibernate.query.sqm.produce.function.ArgumentsValidator;
 import org.hibernate.query.sqm.produce.function.FunctionArgumentException;
 import org.hibernate.query.sqm.tree.SqmTypedNode;
 import org.hibernate.type.BasicPluralType;
-import org.hibernate.type.spi.TypeConfiguration;
 
 /**
  * A {@link ArgumentsValidator} that validates the arguments for the {@code array_includes} function.
@@ -27,11 +27,11 @@ public class ArrayIncludesArgumentValidator extends ArrayArgumentValidator {
 	public void validate(
 			List<? extends SqmTypedNode<?>> arguments,
 			String functionName,
-			TypeConfiguration typeConfiguration) {
+			BindingContext bindingContext) {
 		final BasicPluralType<?, ?> haystackType =
-				getPluralType( 0, arguments, functionName, typeConfiguration );
+				getPluralType( 0, arguments, functionName, bindingContext );
 		final BasicPluralType<?, ?> needleType =
-				getPluralType( 1, arguments, functionName, typeConfiguration );
+				getPluralType( 1, arguments, functionName, bindingContext );
 		if ( haystackType != null && needleType != null
 				&& !haystackType.equals( needleType )
 				&& !haystackType.getElementType().equals( needleType ) ) {

--- a/hibernate-core/src/main/java/org/hibernate/dialect/function/array/ArraysOfSameTypeArgumentValidator.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/function/array/ArraysOfSameTypeArgumentValidator.java
@@ -8,12 +8,12 @@ import java.util.List;
 import java.util.Objects;
 
 import org.hibernate.metamodel.model.domain.DomainType;
+import org.hibernate.query.BindingContext;
 import org.hibernate.query.sqm.SqmExpressible;
 import org.hibernate.query.sqm.produce.function.ArgumentsValidator;
 import org.hibernate.query.sqm.produce.function.FunctionArgumentException;
 import org.hibernate.query.sqm.tree.SqmTypedNode;
 import org.hibernate.type.BasicPluralType;
-import org.hibernate.type.spi.TypeConfiguration;
 
 /**
  * A {@link ArgumentsValidator} that validates all arguments are of the same array type.
@@ -26,7 +26,7 @@ public class ArraysOfSameTypeArgumentValidator implements ArgumentsValidator {
 	public void validate(
 			List<? extends SqmTypedNode<?>> arguments,
 			String functionName,
-			TypeConfiguration typeConfiguration) {
+			BindingContext bindingContext) {
 		BasicPluralType<?, ?> arrayType = null;
 		for ( int i = 0; i < arguments.size(); i++ ) {
 			final SqmExpressible<?> expressible = arguments.get( i ).getExpressible();

--- a/hibernate-core/src/main/java/org/hibernate/dialect/function/array/H2UnnestFunction.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/function/array/H2UnnestFunction.java
@@ -109,8 +109,7 @@ public class H2UnnestFunction extends UnnestFunction {
 									tg -> tg.findTableGroupJoin( functionTableGroup ) == null ? null : tg
 							);
 							final TableGroupJoin join = parentTableGroup.findTableGroupJoin( functionTableGroup );
-							final BasicType<Integer> integerType = walker.getCreationContext()
-									.getSessionFactory()
+							final BasicType<Integer> integerType = walker.getSqmCreationContext()
 									.getNodeBuilder()
 									.getIntegerType();
 							final Expression lhs = new SelfRenderingExpression() {

--- a/hibernate-core/src/main/java/org/hibernate/dialect/function/json/H2JsonTableFunction.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/function/json/H2JsonTableFunction.java
@@ -60,9 +60,10 @@ import org.hibernate.type.SqlTypes;
 import org.hibernate.type.spi.TypeConfiguration;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Set;
+
+import static java.util.Collections.emptyList;
 
 
 /**
@@ -161,8 +162,7 @@ public class H2JsonTableFunction extends JsonTableFunction {
 				else {
 					predicateContainer = querySpec;
 				}
-				final BasicType<Integer> integerType = converter.getCreationContext()
-						.getSessionFactory()
+				final BasicType<Integer> integerType = converter.getSqmCreationContext()
 						.getNodeBuilder()
 						.getIntegerType();
 				final Expression jsonDocument;
@@ -221,20 +221,19 @@ public class H2JsonTableFunction extends JsonTableFunction {
 										maximumArraySize,
 										lastArrayIndex
 								),
-								Collections.emptyList(),
+								emptyList(),
 								null,
 								null
 						),
 						tableIdentifierVariable + "_synthetic_",
-						Collections.emptyList(),
+						emptyList(),
 						Set.of( "" ),
 						false,
 						false,
 						true,
 						converter.getCreationContext().getSessionFactory()
 				);
-				final BasicType<Integer> integerType = converter.getCreationContext()
-						.getSessionFactory()
+				final BasicType<Integer> integerType = converter.getSqmCreationContext()
 						.getNodeBuilder()
 						.getIntegerType();
 
@@ -751,8 +750,8 @@ public class H2JsonTableFunction extends JsonTableFunction {
 				//noinspection unchecked
 				final String sqlLiteral = defaultExpression.getJdbcMapping().getJdbcLiteralFormatter().toJdbcLiteral(
 						defaultExpression.getLiteralValue(),
-						converter.getCreationContext().getSessionFactory().getJdbcServices().getDialect(),
-						converter.getCreationContext().getSessionFactory().getWrapperOptions()
+						converter.getCreationContext().getDialect(),
+						converter.getCreationContext().getWrapperOptions()
 				);
 				sb.append( sqlLiteral );
 				sb.append( ')' );

--- a/hibernate-core/src/main/java/org/hibernate/dialect/function/json/JsonObjectArgumentsValidator.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/function/json/JsonObjectArgumentsValidator.java
@@ -9,6 +9,7 @@ import java.util.List;
 import org.hibernate.metamodel.mapping.JdbcMapping;
 import org.hibernate.metamodel.mapping.JdbcMappingContainer;
 import org.hibernate.metamodel.model.domain.DomainType;
+import org.hibernate.query.BindingContext;
 import org.hibernate.query.sqm.SqmExpressible;
 import org.hibernate.query.sqm.produce.function.ArgumentsValidator;
 import org.hibernate.query.sqm.produce.function.FunctionArgumentException;
@@ -19,7 +20,6 @@ import org.hibernate.sql.ast.tree.SqlAstNode;
 import org.hibernate.sql.ast.tree.expression.Expression;
 import org.hibernate.sql.ast.tree.expression.JsonNullBehavior;
 import org.hibernate.type.descriptor.java.JavaType;
-import org.hibernate.type.spi.TypeConfiguration;
 
 import static org.hibernate.query.sqm.produce.function.ArgumentTypesValidator.checkArgumentType;
 import static org.hibernate.query.sqm.produce.function.ArgumentTypesValidator.isUnknownExpressionType;
@@ -31,7 +31,7 @@ public class JsonObjectArgumentsValidator implements ArgumentsValidator {
 	public void validate(
 			List<? extends SqmTypedNode<?>> arguments,
 			String functionName,
-			TypeConfiguration typeConfiguration) {
+			BindingContext bindingContext) {
 		if ( !arguments.isEmpty() ) {
 			final SqmTypedNode<?> lastArgument = arguments.get( arguments.size() - 1 );
 			final int argumentsCount;

--- a/hibernate-core/src/main/java/org/hibernate/dialect/function/json/OracleJsonTableFunction.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/function/json/OracleJsonTableFunction.java
@@ -5,7 +5,6 @@
 package org.hibernate.dialect.function.json;
 
 import org.hibernate.dialect.Dialect;
-import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.metamodel.mapping.JdbcMapping;
 import org.hibernate.metamodel.mapping.SelectableMapping;
 import org.hibernate.metamodel.mapping.SelectablePath;
@@ -118,9 +117,8 @@ public class OracleJsonTableFunction extends JsonTableFunction {
 			if ( isEncodedBoolean( type ) ) {
 				//noinspection unchecked
 				final JdbcLiteralFormatter<Object> jdbcLiteralFormatter = type.getJdbcLiteralFormatter();
-				final SessionFactoryImplementor sessionFactory = converter.getCreationContext().getSessionFactory();
-				final Dialect dialect = sessionFactory.getJdbcServices().getDialect();
-				final WrapperOptions wrapperOptions = sessionFactory.getWrapperOptions();
+				final Dialect dialect = converter.getCreationContext().getDialect();
+				final WrapperOptions wrapperOptions = converter.getCreationContext().getWrapperOptions();
 				final Object trueValue = type.convertToRelationalValue( true );
 				final Object falseValue = type.convertToRelationalValue( false );
 				final String trueFragment = jdbcLiteralFormatter.toJdbcLiteral( trueValue, dialect, wrapperOptions );

--- a/hibernate-core/src/main/java/org/hibernate/dialect/function/xml/DB2XmlTableFunction.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/function/xml/DB2XmlTableFunction.java
@@ -5,7 +5,6 @@
 package org.hibernate.dialect.function.xml;
 
 import org.hibernate.dialect.Dialect;
-import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.metamodel.mapping.JdbcMapping;
 import org.hibernate.metamodel.mapping.SelectableMapping;
 import org.hibernate.metamodel.mapping.SelectablePath;
@@ -83,9 +82,8 @@ public class DB2XmlTableFunction extends XmlTableFunction {
 			if ( isBoolean( type ) ) {
 				//noinspection unchecked
 				final JdbcLiteralFormatter<Object> jdbcLiteralFormatter = type.getJdbcLiteralFormatter();
-				final SessionFactoryImplementor sessionFactory = converter.getCreationContext().getSessionFactory();
-				final Dialect dialect = sessionFactory.getJdbcServices().getDialect();
-				final WrapperOptions wrapperOptions = sessionFactory.getWrapperOptions();
+				final Dialect dialect = converter.getCreationContext().getDialect();
+				final WrapperOptions wrapperOptions = converter.getCreationContext().getWrapperOptions();
 				final Object trueValue = type.convertToRelationalValue( true );
 				final Object falseValue = type.convertToRelationalValue( false );
 				final String trueFragment = jdbcLiteralFormatter.toJdbcLiteral( trueValue, dialect, wrapperOptions );

--- a/hibernate-core/src/main/java/org/hibernate/dialect/function/xml/HANAXmlTableFunction.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/function/xml/HANAXmlTableFunction.java
@@ -437,9 +437,8 @@ public class HANAXmlTableFunction extends XmlTableFunction {
 			if ( isBoolean( type ) ) {
 				//noinspection unchecked
 				final JdbcLiteralFormatter<Object> jdbcLiteralFormatter = type.getJdbcLiteralFormatter();
-				final SessionFactoryImplementor sessionFactory = converter.getCreationContext().getSessionFactory();
-				final Dialect dialect = sessionFactory.getJdbcServices().getDialect();
-				final WrapperOptions wrapperOptions = sessionFactory.getWrapperOptions();
+				final Dialect dialect = converter.getCreationContext().getDialect();
+				final WrapperOptions wrapperOptions = converter.getCreationContext().getWrapperOptions();
 				final Object trueValue = type.convertToRelationalValue( true );
 				final Object falseValue = type.convertToRelationalValue( false );
 				final String trueFragment = jdbcLiteralFormatter.toJdbcLiteral( trueValue, dialect, wrapperOptions );

--- a/hibernate-core/src/main/java/org/hibernate/dialect/function/xml/OracleXmlTableFunction.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/function/xml/OracleXmlTableFunction.java
@@ -5,7 +5,6 @@
 package org.hibernate.dialect.function.xml;
 
 import org.hibernate.dialect.Dialect;
-import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.metamodel.mapping.JdbcMapping;
 import org.hibernate.metamodel.mapping.SelectableMapping;
 import org.hibernate.metamodel.mapping.SelectablePath;
@@ -48,9 +47,8 @@ public class OracleXmlTableFunction extends XmlTableFunction {
 			if ( isEncodedBoolean( type ) ) {
 				//noinspection unchecked
 				final JdbcLiteralFormatter<Object> jdbcLiteralFormatter = type.getJdbcLiteralFormatter();
-				final SessionFactoryImplementor sessionFactory = converter.getCreationContext().getSessionFactory();
-				final Dialect dialect = sessionFactory.getJdbcServices().getDialect();
-				final WrapperOptions wrapperOptions = sessionFactory.getWrapperOptions();
+				final Dialect dialect = converter.getCreationContext().getDialect();
+				final WrapperOptions wrapperOptions = converter.getCreationContext().getWrapperOptions();
 				final Object trueValue = type.convertToRelationalValue( true );
 				final Object falseValue = type.convertToRelationalValue( false );
 				final String trueFragment = jdbcLiteralFormatter.toJdbcLiteral( trueValue, dialect, wrapperOptions );

--- a/hibernate-core/src/main/java/org/hibernate/dialect/function/xml/SybaseASEXmlTableFunction.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/function/xml/SybaseASEXmlTableFunction.java
@@ -6,7 +6,6 @@ package org.hibernate.dialect.function.xml;
 
 import org.hibernate.QueryException;
 import org.hibernate.dialect.Dialect;
-import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.metamodel.mapping.JdbcMapping;
 import org.hibernate.metamodel.mapping.SelectableMapping;
 import org.hibernate.metamodel.mapping.SelectablePath;
@@ -126,8 +125,8 @@ public class SybaseASEXmlTableFunction extends XmlTableFunction {
 			if ( arguments.xmlDocument() instanceof Literal documentLiteral ) {
 				documentFragment = documentLiteral.getJdbcMapping().getJdbcLiteralFormatter().toJdbcLiteral(
 						documentLiteral.getLiteralValue(),
-						converter.getCreationContext().getSessionFactory().getJdbcServices().getDialect(),
-						converter.getCreationContext().getSessionFactory().getWrapperOptions()
+						converter.getCreationContext().getDialect(),
+						converter.getCreationContext().getWrapperOptions()
 				);
 			}
 			else if ( arguments.xmlDocument() instanceof ColumnReference columnReference ) {
@@ -169,9 +168,8 @@ public class SybaseASEXmlTableFunction extends XmlTableFunction {
 			if ( isBoolean( type ) ) {
 				//noinspection unchecked
 				final JdbcLiteralFormatter<Object> jdbcLiteralFormatter = type.getJdbcLiteralFormatter();
-				final SessionFactoryImplementor sessionFactory = converter.getCreationContext().getSessionFactory();
-				final Dialect dialect = sessionFactory.getJdbcServices().getDialect();
-				final WrapperOptions wrapperOptions = sessionFactory.getWrapperOptions();
+				final Dialect dialect = converter.getCreationContext().getDialect();
+				final WrapperOptions wrapperOptions = converter.getCreationContext().getWrapperOptions();
 				final Object trueValue = type.convertToRelationalValue( true );
 				final Object falseValue = type.convertToRelationalValue( false );
 				final String trueFragment = jdbcLiteralFormatter.toJdbcLiteral( trueValue, dialect, wrapperOptions );

--- a/hibernate-core/src/main/java/org/hibernate/dialect/function/xml/XmlElementFunction.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/function/xml/XmlElementFunction.java
@@ -9,6 +9,7 @@ import java.util.Map;
 
 import org.hibernate.dialect.XmlHelper;
 import org.hibernate.metamodel.model.domain.ReturnableType;
+import org.hibernate.query.BindingContext;
 import org.hibernate.query.spi.QueryEngine;
 import org.hibernate.query.sqm.function.AbstractSqmSelfRenderingFunctionDescriptor;
 import org.hibernate.query.sqm.function.FunctionKind;
@@ -52,7 +53,7 @@ public class XmlElementFunction extends AbstractSqmSelfRenderingFunctionDescript
 							public void validate(
 									List<? extends SqmTypedNode<?>> arguments,
 									String functionName,
-									TypeConfiguration typeConfiguration) {
+									BindingContext bindingContext) {
 								//noinspection unchecked
 								final String elementName = ( (SqmLiteral<String>) arguments.get( 0 ) ).getLiteralValue();
 								if ( !XmlHelper.isValidXmlName( elementName ) ) {

--- a/hibernate-core/src/main/java/org/hibernate/dialect/function/xml/XmlForestFunction.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/function/xml/XmlForestFunction.java
@@ -8,6 +8,7 @@ import java.util.List;
 
 import org.hibernate.dialect.XmlHelper;
 import org.hibernate.metamodel.model.domain.ReturnableType;
+import org.hibernate.query.BindingContext;
 import org.hibernate.query.sqm.function.AbstractSqmSelfRenderingFunctionDescriptor;
 import org.hibernate.query.sqm.function.FunctionKind;
 import org.hibernate.query.sqm.produce.function.ArgumentsValidator;
@@ -39,7 +40,7 @@ public class XmlForestFunction extends AbstractSqmSelfRenderingFunctionDescripto
 							public void validate(
 									List<? extends SqmTypedNode<?>> arguments,
 									String functionName,
-									TypeConfiguration typeConfiguration) {
+									BindingContext bindingContext) {
 								for ( int i = 0; i < arguments.size(); i++ ) {
 									SqmTypedNode<?> argument = arguments.get( i );
 									if ( !( argument instanceof SqmNamedExpression<?> namedExpression ) ) {

--- a/hibernate-core/src/main/java/org/hibernate/engine/spi/LoadQueryInfluencers.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/spi/LoadQueryInfluencers.java
@@ -354,7 +354,8 @@ public class LoadQueryInfluencers implements Serializable {
 	private boolean isSubselectFetchEnabledInProfile(CollectionPersister persister) {
 		if ( hasEnabledFetchProfiles() ) {
 			for ( String profile : getEnabledFetchProfileNames() ) {
-				final FetchProfile fetchProfile = persister.getFactory().getFetchProfile( profile )	;
+				final FetchProfile fetchProfile =
+						persister.getFactory().getSqlTranslationEngine().getFetchProfile( profile )	;
 				if ( fetchProfile != null ) {
 					final Fetch fetch = fetchProfile.getFetchByRole( persister.getRole() );
 					if ( fetch != null && fetch.getMethod() == SUBSELECT) {
@@ -375,7 +376,7 @@ public class LoadQueryInfluencers implements Serializable {
 	private boolean hasSubselectLoadableCollectionsEnabledInProfile(EntityPersister persister) {
 		if ( hasEnabledFetchProfiles() ) {
 			for ( String profile : getEnabledFetchProfileNames() ) {
-				if ( persister.getFactory().getFetchProfile( profile )
+				if ( persister.getFactory().getSqlTranslationEngine().getFetchProfile( profile )
 						.hasSubselectLoadableCollectionsEnabled( persister ) ) {
 					return true;
 				}

--- a/hibernate-core/src/main/java/org/hibernate/engine/spi/LoadQueryInfluencers.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/spi/LoadQueryInfluencers.java
@@ -5,7 +5,6 @@
 package org.hibernate.engine.spi;
 
 import java.io.Serializable;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
@@ -27,7 +26,9 @@ import org.hibernate.persister.entity.EntityPersister;
 
 import org.checkerframework.checker.nullness.qual.Nullable;
 
+import static java.util.Collections.emptyMap;
 import static java.util.Collections.emptySet;
+import static java.util.Collections.unmodifiableSet;
 import static org.hibernate.engine.FetchStyle.SUBSELECT;
 
 /**
@@ -73,8 +74,8 @@ public class LoadQueryInfluencers implements Serializable {
 		batchSize = options.getDefaultBatchFetchSize();
 		subselectFetchEnabled = options.isSubselectFetchEnabled();
 		effectiveEntityGraph = new EffectiveEntityGraph();
-		for (FilterDefinition filterDefinition : sessionFactory.getAutoEnabledFilters()) {
-			FilterImpl filter = new FilterImpl( filterDefinition );
+		for ( FilterDefinition filterDefinition : sessionFactory.getAutoEnabledFilters() ) {
+			final FilterImpl filter = new FilterImpl( filterDefinition );
 			if ( enabledFilters == null ) {
 				enabledFilters = new TreeMap<>();
 			}
@@ -158,7 +159,7 @@ public class LoadQueryInfluencers implements Serializable {
 	public Map<String,Filter> getEnabledFilters() {
 		final TreeMap<String, Filter> enabledFilters = this.enabledFilters;
 		if ( enabledFilters == null ) {
-			return Collections.emptyMap();
+			return emptyMap();
 		}
 		else {
 			// First, validate all the enabled filters...
@@ -175,27 +176,17 @@ public class LoadQueryInfluencers implements Serializable {
 	 * @return an unmodifiable Set of enabled filter names.
 	 */
 	public Set<String> getEnabledFilterNames() {
-		if ( enabledFilters == null ) {
-			return emptySet();
-		}
-		else {
-			return Collections.unmodifiableSet( enabledFilters.keySet() );
-		}
+		return enabledFilters == null ? emptySet() : unmodifiableSet( enabledFilters.keySet() );
 	}
 
 	public @Nullable Filter getEnabledFilter(String filterName) {
-		if ( enabledFilters == null ) {
-			return null;
-		}
-		else {
-			return enabledFilters.get( filterName );
-		}
+		return enabledFilters == null ? null : enabledFilters.get( filterName );
 	}
 
 	public Filter enableFilter(String filterName) {
-		FilterImpl filter = new FilterImpl( sessionFactory.getFilterDefinition( filterName ) );
+		final FilterImpl filter = new FilterImpl( sessionFactory.getFilterDefinition( filterName ) );
 		if ( enabledFilters == null ) {
-			this.enabledFilters = new TreeMap<>();
+			enabledFilters = new TreeMap<>();
 		}
 		enabledFilters.put( filterName, filter );
 		return filter;
@@ -269,7 +260,8 @@ public class LoadQueryInfluencers implements Serializable {
 	}
 
 	@Internal
-	public @Nullable HashSet<String> adjustFetchProfiles(@Nullable Set<String> disabledFetchProfiles, @Nullable Set<String> enabledFetchProfiles) {
+	public @Nullable HashSet<String> adjustFetchProfiles(
+			@Nullable Set<String> disabledFetchProfiles, @Nullable Set<String> enabledFetchProfiles) {
 		final HashSet<String> currentEnabledFetchProfileNames = this.enabledFetchProfileNames;
 		final HashSet<String> oldFetchProfiles;
 		if ( currentEnabledFetchProfileNames == null || currentEnabledFetchProfileNames.isEmpty() ) {

--- a/hibernate-core/src/main/java/org/hibernate/engine/spi/SessionFactoryDelegatingImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/spi/SessionFactoryDelegatingImpl.java
@@ -47,6 +47,7 @@ import org.hibernate.metamodel.spi.RuntimeMetamodelsImplementor;
 import org.hibernate.proxy.EntityNotFoundDelegate;
 import org.hibernate.query.criteria.HibernateCriteriaBuilder;
 import org.hibernate.query.spi.QueryEngine;
+import org.hibernate.query.sql.spi.SqlTranslationEngine;
 import org.hibernate.relational.SchemaManager;
 import org.hibernate.resource.beans.spi.ManagedBeanRegistry;
 import org.hibernate.service.spi.ServiceRegistryImplementor;
@@ -278,11 +279,6 @@ public class SessionFactoryDelegatingImpl implements SessionFactoryImplementor, 
 	}
 
 	@Override
-	public Integer getMaximumFetchDepth() {
-		return delegate.getMaximumFetchDepth();
-	}
-
-	@Override
 	public void addObserver(SessionFactoryObserver observer) {
 		delegate.addObserver( observer );
 	}
@@ -343,6 +339,11 @@ public class SessionFactoryDelegatingImpl implements SessionFactoryImplementor, 
 	}
 
 	@Override
+	public SqlTranslationEngine getSqlTranslationEngine() {
+		return delegate.getSqlTranslationEngine();
+	}
+
+	@Override
 	public Reference getReference() throws NamingException {
 		return delegate.getReference();
 	}
@@ -390,11 +391,6 @@ public class SessionFactoryDelegatingImpl implements SessionFactoryImplementor, 
 	@Override
 	public <T> List<EntityGraph<? super T>> findEntityGraphsByType(Class<T> entityClass) {
 		return delegate.findEntityGraphsByType(entityClass);
-	}
-
-	@Override
-	public Class<?> classForName(String className) {
-		return delegate.classForName( className );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/engine/spi/SessionFactoryImplementor.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/spi/SessionFactoryImplementor.java
@@ -52,23 +52,13 @@ import org.hibernate.type.spi.TypeConfiguration;
  */
 public interface SessionFactoryImplementor extends MappingContext, SessionFactory {
 	/**
-	 * Get the UUID for this {@code SessionFactory}.
+	 * The UUID assigned to this {@code SessionFactory}.
 	 * <p>
-	 * The value is generated as a {@link java.util.UUID}, but kept as a String.
-	 *
-	 * @return The UUID for this {@code SessionFactory}.
+	 * The value is generated as a {@link java.util.UUID}, but kept as a string.
 	 *
 	 * @see org.hibernate.internal.SessionFactoryRegistry#getSessionFactory
 	 */
 	String getUuid();
-
-	/**
-	 * Access to the name (if one) assigned to the {@code SessionFactory}
-	 *
-	 * @return The name for the {@code SessionFactory}
-	 */
-	@Override
-	String getName();
 
 	/**
 	 * Overrides {@link SessionFactory#openSession()} to widen the return type:
@@ -80,34 +70,65 @@ public interface SessionFactoryImplementor extends MappingContext, SessionFactor
 	@Override
 	SessionImplementor openSession();
 
+	/**
+	 * Obtain a {@linkplain org.hibernate.SessionBuilder session builder}
+	 * for creating new instances of {@link org.hibernate.Session} with
+	 * certain customized options.
+	 */
 	@Override
 	SessionBuilderImplementor withOptions();
 
 	/**
-	 * Get a non-transactional "current" session (used by hibernate-envers)
+	 * Get a non-transactional "current" session.
+	 *
+	 * @apiNote This is used by {@code hibernate-envers}.
 	 */
 	SessionImplementor openTemporarySession();
 
+	/**
+	 * Obtain the {@link CacheImplementor}.
+	 */
 	@Override
 	CacheImplementor getCache();
 
+	/**
+	 * Obtain the {@link StatisticsImplementor}.
+	 */
 	@Override
 	StatisticsImplementor getStatistics();
 
+	/**
+	 * Obtain the {@link TypeConfiguration}
+	 */
 	TypeConfiguration getTypeConfiguration();
 
+	/**
+	 * Obtain the {@link RuntimeMetamodelsImplementor}
+	 */
 	RuntimeMetamodelsImplementor getRuntimeMetamodels();
 
+	/**
+	 * Obtain the {@link MappingMetamodelImplementor}
+	 */
 	default MappingMetamodelImplementor getMappingMetamodel() {
 		return getRuntimeMetamodels().getMappingMetamodel();
 	}
 
+	/**
+	 * Obtain the {@link JpaMetamodel}
+	 */
 	default JpaMetamodel getJpaMetamodel() {
 		return getRuntimeMetamodels().getJpaMetamodel();
 	}
 
+	/**
+	 * Obtain the {@link QueryEngine}
+	 */
 	QueryEngine getQueryEngine();
 
+	/**
+	 * Obtain the {@link SqlTranslationEngine}
+	 */
 	SqlTranslationEngine getSqlTranslationEngine();
 
 	/**
@@ -123,11 +144,14 @@ public interface SessionFactoryImplementor extends MappingContext, SessionFactor
 	EventEngine getEventEngine();
 
 	/**
-	 * Retrieve fetch profile by name.
+	 * Retrieve a {@linkplain FetchProfile fetch profile} by name.
 	 *
 	 * @param name The name of the profile to retrieve.
 	 * @return The profile definition
+	 *
+	 * @deprecated Use {@link SqlTranslationEngine#getFetchProfile(String)}
 	 */
+	@Deprecated(since = "7.0", forRemoval = true)
 	FetchProfile getFetchProfile(String name);
 
 	/**
@@ -138,25 +162,37 @@ public interface SessionFactoryImplementor extends MappingContext, SessionFactor
 	@Deprecated(since = "7", forRemoval = true)
 	Generator getGenerator(String rootEntityName);
 
+	/**
+	 * Obtain the {@link EntityNotFoundDelegate}
+	 */
 	EntityNotFoundDelegate getEntityNotFoundDelegate();
 
+	/**
+	 * Register a {@link SessionFactoryObserver} of this factory.
+	 */
 	void addObserver(SessionFactoryObserver observer);
 
+	/**
+	 * Obtain the {@link CustomEntityDirtinessStrategy}
+	 */
 	//todo make a Service ?
 	CustomEntityDirtinessStrategy getCustomEntityDirtinessStrategy();
 
+	/**
+	 * Obtain the {@link CurrentTenantIdentifierResolver}
+	 */
 	//todo make a Service ?
 	CurrentTenantIdentifierResolver<Object> getCurrentTenantIdentifierResolver();
 
 	/**
-	 * The java type to use for a tenant identifier.
+	 * The {@link JavaType} to use for a tenant identifier.
 	 *
 	 * @since 6.4
 	 */
 	JavaType<Object> getTenantIdentifierJavaType();
 
 	/**
-	 * Access to the event listener groups.
+	 * Access to the {@linkplain EventListenerGroups event listener groups}.
 	 *
 	 * @since 7.0
 	 */
@@ -164,36 +200,48 @@ public interface SessionFactoryImplementor extends MappingContext, SessionFactor
 	EventListenerGroups getEventListenerGroups();
 
 	/**
+	 * Obtain the {@link ParameterMarkerStrategy} service.
+	 *
 	 * @since 7.0
 	 */
 	@Incubating
 	ParameterMarkerStrategy getParameterMarkerStrategy();
 
 	/**
+	 * Obtain the {@link JdbcServices} service.
+	 *
 	 * @since 7.0
 	 */
 	@Incubating
 	JdbcValuesMappingProducerProvider getJdbcValuesMappingProducerProvider();
 
 	/**
+	 * Obtain the {@link EntityCopyObserverFactory} service.
+	 *
 	 * @since 7.0
 	 */
 	@Incubating
 	EntityCopyObserverFactory getEntityCopyObserver();
 
 	/**
+	 * Obtain the {@link ClassLoaderService}.
+	 *
 	 * @since 7.0
 	 */
 	@Incubating
 	ClassLoaderService getClassLoaderService();
 
 	/**
+	 * Obtain the {@link ManagedBeanRegistry} service.
+	 *
 	 * @since 7.0
 	 */
 	@Incubating
 	ManagedBeanRegistry getManagedBeanRegistry();
 
 	/**
+	 * Obtain the {@link EventListenerRegistry} service.
+	 *
 	 * @since 7.0
 	 */
 	@Incubating
@@ -207,16 +255,35 @@ public interface SessionFactoryImplementor extends MappingContext, SessionFactor
 	 */
 	WrapperOptions getWrapperOptions();
 
+	/**
+	 * Get the {@linkplain SessionFactoryOptions options} used to build this factory.
+	 */
 	@Override
 	SessionFactoryOptions getSessionFactoryOptions();
 
+	/**
+	 * Obtain the {@linkplain FilterDefinition definition of a filter} by name.
+	 *
+	 * @param filterName The name of a declared filter
+	 */
 	@Override
 	FilterDefinition getFilterDefinition(String filterName);
 
+	/**
+	 * Obtain a collection of {@link FilterDefinition}s representing all the
+	 * {@linkplain org.hibernate.annotations.FilterDef#autoEnabled auto-enabled}
+	 * filters.
+	 */
 	Collection<FilterDefinition> getAutoEnabledFilters();
 
+	/**
+	 * Obtain the {@link JdbcServices} service.
+	 */
 	JdbcServices getJdbcServices();
 
+	/**
+	 * Obtain the {@link SqlStringGenerationContext}.
+	 */
 	SqlStringGenerationContext getSqlStringGenerationContext();
 
 	// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/hibernate-core/src/main/java/org/hibernate/engine/spi/SessionFactoryImplementor.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/spi/SessionFactoryImplementor.java
@@ -23,14 +23,15 @@ import org.hibernate.event.spi.EntityCopyObserverFactory;
 import org.hibernate.event.spi.EventEngine;
 import org.hibernate.graph.spi.RootGraphImplementor;
 import org.hibernate.event.service.spi.EventListenerGroups;
+import org.hibernate.metamodel.model.domain.JpaMetamodel;
 import org.hibernate.metamodel.spi.MappingMetamodelImplementor;
 import org.hibernate.metamodel.spi.RuntimeMetamodelsImplementor;
 import org.hibernate.proxy.EntityNotFoundDelegate;
-import org.hibernate.query.sqm.spi.SqmCreationContext;
+import org.hibernate.query.spi.QueryEngine;
+import org.hibernate.query.sql.spi.SqlTranslationEngine;
 import org.hibernate.resource.beans.spi.ManagedBeanRegistry;
 import org.hibernate.service.spi.ServiceRegistryImplementor;
 import org.hibernate.sql.ast.spi.ParameterMarkerStrategy;
-import org.hibernate.sql.ast.spi.SqlAstCreationContext;
 import org.hibernate.sql.results.jdbc.spi.JdbcValuesMappingProducerProvider;
 import org.hibernate.stat.spi.StatisticsImplementor;
 import org.hibernate.generator.Generator;
@@ -49,8 +50,7 @@ import org.hibernate.type.spi.TypeConfiguration;
  * @author Gavin King
  * @author Steve Ebersole
  */
-public interface SessionFactoryImplementor
-		extends MappingContext, SessionFactory, SqmCreationContext, SqlAstCreationContext {
+public interface SessionFactoryImplementor extends MappingContext, SessionFactory {
 	/**
 	 * Get the UUID for this {@code SessionFactory}.
 	 * <p>
@@ -81,19 +81,6 @@ public interface SessionFactoryImplementor
 	SessionImplementor openSession();
 
 	@Override
-	TypeConfiguration getTypeConfiguration();
-
-	@Override
-	default SessionFactoryImplementor getSessionFactory() {
-		return this;
-	}
-
-	@Override
-	default MappingMetamodelImplementor getMappingMetamodel() {
-		return getRuntimeMetamodels().getMappingMetamodel();
-	}
-
-	@Override
 	SessionBuilderImplementor withOptions();
 
 	/**
@@ -107,7 +94,21 @@ public interface SessionFactoryImplementor
 	@Override
 	StatisticsImplementor getStatistics();
 
+	TypeConfiguration getTypeConfiguration();
+
 	RuntimeMetamodelsImplementor getRuntimeMetamodels();
+
+	default MappingMetamodelImplementor getMappingMetamodel() {
+		return getRuntimeMetamodels().getMappingMetamodel();
+	}
+
+	default JpaMetamodel getJpaMetamodel() {
+		return getRuntimeMetamodels().getJpaMetamodel();
+	}
+
+	QueryEngine getQueryEngine();
+
+	SqlTranslationEngine getSqlTranslationEngine();
 
 	/**
 	 * Access to the {@code ServiceRegistry} for this {@code SessionFactory}.
@@ -228,4 +229,5 @@ public interface SessionFactoryImplementor
 	 * The best guess entity name for an entity not in an association
 	 */
 	String bestGuessEntityName(Object object);
+
 }

--- a/hibernate-core/src/main/java/org/hibernate/internal/FetchProfileHelper.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/FetchProfileHelper.java
@@ -42,7 +42,8 @@ public class FetchProfileHelper {
 		return fetchProfiles;
 	}
 
-	static void addFetchProfiles(MetadataImplementor bootMetamodel, RuntimeMetamodels runtimeMetamodels, Map<String, FetchProfile> fetchProfiles) {
+	static void addFetchProfiles(
+			MetadataImplementor bootMetamodel, RuntimeMetamodels runtimeMetamodels, Map<String, FetchProfile> fetchProfiles) {
 		for ( org.hibernate.mapping.FetchProfile mappingProfile : bootMetamodel.getFetchProfiles() ) {
 			final FetchProfile fetchProfile = createFetchProfile( runtimeMetamodels.getMappingMetamodel(), mappingProfile );
 			fetchProfiles.put( fetchProfile.getName(), fetchProfile );

--- a/hibernate-core/src/main/java/org/hibernate/internal/FetchProfileHelper.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/FetchProfileHelper.java
@@ -33,16 +33,21 @@ import static org.hibernate.engine.profile.DefaultFetchProfile.HIBERNATE_DEFAULT
  */
 public class FetchProfileHelper {
 
+	@SuppressWarnings("unused")
 	public static Map<String, FetchProfile> getFetchProfiles(
 			MetadataImplementor bootMetamodel,
 			RuntimeMetamodels runtimeMetamodels) {
 		final Map<String, FetchProfile> fetchProfiles = new HashMap<>();
+		addFetchProfiles( bootMetamodel, runtimeMetamodels, fetchProfiles );
+		return fetchProfiles;
+	}
+
+	static void addFetchProfiles(MetadataImplementor bootMetamodel, RuntimeMetamodels runtimeMetamodels, Map<String, FetchProfile> fetchProfiles) {
 		for ( org.hibernate.mapping.FetchProfile mappingProfile : bootMetamodel.getFetchProfiles() ) {
 			final FetchProfile fetchProfile = createFetchProfile( runtimeMetamodels.getMappingMetamodel(), mappingProfile );
 			fetchProfiles.put( fetchProfile.getName(), fetchProfile );
 		}
 		fetchProfiles.put( HIBERNATE_DEFAULT_PROFILE, new DefaultFetchProfile( runtimeMetamodels ) );
-		return fetchProfiles;
 	}
 
 	private static FetchProfile createFetchProfile(
@@ -53,7 +58,9 @@ public class FetchProfileHelper {
 		for ( org.hibernate.mapping.FetchProfile.Fetch mappingFetch : mappingProfile.getFetches() ) {
 			// resolve the persister owning the fetch
 			final EntityPersister owner = getEntityPersister( mappingMetamodel, fetchProfile, mappingFetch );
-			( (FetchProfileAffectee) owner ).registerAffectingFetchProfile( profileName);
+			if ( owner instanceof FetchProfileAffectee fetchProfileAffectee ) {
+				fetchProfileAffectee.registerAffectingFetchProfile( profileName );
+			}
 
 			final Association association = new Association( owner, mappingFetch.getAssociation() );
 			final FetchStyle fetchStyle = fetchStyle( mappingFetch.getMethod() );
@@ -62,8 +69,8 @@ public class FetchProfileHelper {
 			// validate the specified association fetch
 			final ModelPart fetchablePart = owner.findByPath( association.getAssociationPath() );
 			validateFetchablePart( fetchablePart, profileName, association );
-			if ( fetchablePart instanceof FetchProfileAffectee ) {
-				( (FetchProfileAffectee) fetchablePart ).registerAffectingFetchProfile( profileName );
+			if ( fetchablePart instanceof FetchProfileAffectee fetchProfileAffectee ) {
+				fetchProfileAffectee.registerAffectingFetchProfile( profileName );
 			}
 
 			// then register the association with the FetchProfile
@@ -73,16 +80,11 @@ public class FetchProfileHelper {
 	}
 
 	private static FetchStyle fetchStyle(FetchMode fetchMode) {
-		switch ( fetchMode ) {
-			case JOIN:
-				return FetchStyle.JOIN;
-			case SELECT:
-				return FetchStyle.SELECT;
-			case SUBSELECT:
-				return FetchStyle.SUBSELECT;
-			default:
-				throw new IllegalArgumentException( "Unknown FetchMode" );
-		}
+		return switch ( fetchMode ) {
+			case JOIN -> FetchStyle.JOIN;
+			case SELECT -> FetchStyle.SELECT;
+			case SUBSELECT -> FetchStyle.SUBSELECT;
+		};
 	}
 
 	private static void validateFetchablePart(ModelPart fetchablePart, String profileName, Association association) {

--- a/hibernate-core/src/main/java/org/hibernate/internal/SessionImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/SessionImpl.java
@@ -3016,7 +3016,8 @@ public class SessionImpl
 		// filter, which will fail when called before FilterImpl#afterDeserialize( factory );
 		// Instead lookup the filter by name and then call FilterImpl#afterDeserialize( factory ).
 		for ( String filterName : loadQueryInfluencers.getEnabledFilterNames() ) {
-			( (FilterImpl) loadQueryInfluencers.getEnabledFilter( filterName ) ).afterDeserialize( getFactory() );
+			( (FilterImpl) loadQueryInfluencers.getEnabledFilter( filterName ) )
+					.afterDeserialize( getFactory() );
 		}
 
 		eventListenerGroups = getFactory().getEventListenerGroups();

--- a/hibernate-core/src/main/java/org/hibernate/loader/ast/internal/AbstractNaturalIdLoader.java
+++ b/hibernate-core/src/main/java/org/hibernate/loader/ast/internal/AbstractNaturalIdLoader.java
@@ -120,7 +120,7 @@ public abstract class AbstractNaturalIdLoader<T> implements NaturalIdLoader<T> {
 						(fetchParent, creationState) -> ImmutableFetchList.EMPTY,
 						true,
 						new LoadQueryInfluencers( sessionFactory ),
-						sessionFactory
+						sessionFactory.getSqlTranslationEngine()
 				),
 				session
 		);
@@ -192,7 +192,7 @@ public abstract class AbstractNaturalIdLoader<T> implements NaturalIdLoader<T> {
 				fetchProcessor,
 				true,
 				new LoadQueryInfluencers( sessionFactory ),
-				sessionFactory
+				sessionFactory.getSqlTranslationEngine()
 		);
 
 		final TableGroup rootTableGroup = entityDescriptor.createRootTableGroup(

--- a/hibernate-core/src/main/java/org/hibernate/loader/ast/internal/DatabaseSnapshotExecutor.java
+++ b/hibernate-core/src/main/java/org/hibernate/loader/ast/internal/DatabaseSnapshotExecutor.java
@@ -74,7 +74,7 @@ class DatabaseSnapshotExecutor {
 				(fetchParent, creationState) -> ImmutableFetchList.EMPTY,
 				true,
 				new LoadQueryInfluencers( sessionFactory ),
-				sessionFactory
+				sessionFactory.getSqlTranslationEngine()
 		);
 
 		final NavigablePath rootPath = new NavigablePath( entityDescriptor.getEntityName() );

--- a/hibernate-core/src/main/java/org/hibernate/loader/ast/internal/LoaderSelectBuilder.java
+++ b/hibernate-core/src/main/java/org/hibernate/loader/ast/internal/LoaderSelectBuilder.java
@@ -41,6 +41,7 @@ import org.hibernate.metamodel.mapping.internal.EmbeddedAttributeMapping;
 import org.hibernate.metamodel.mapping.internal.SimpleForeignKeyDescriptor;
 import org.hibernate.metamodel.mapping.internal.ToOneAttributeMapping;
 import org.hibernate.metamodel.mapping.ordering.OrderByFragment;
+import org.hibernate.metamodel.model.domain.JpaMetamodel;
 import org.hibernate.query.sqm.ComparisonOperator;
 import org.hibernate.spi.EntityIdentifierNavigablePath;
 import org.hibernate.spi.NavigablePath;
@@ -119,7 +120,7 @@ public class LoaderSelectBuilder {
 			Consumer<JdbcParameter> jdbcParameterConsumer,
 			SessionFactoryImplementor sessionFactory) {
 		final LoaderSelectBuilder process = new LoaderSelectBuilder(
-				sessionFactory,
+				sessionFactory.getSqlTranslationEngine(),
 				loadable,
 				partsToSelect,
 				singletonList( restrictedPart ),
@@ -127,7 +128,7 @@ public class LoaderSelectBuilder {
 				1,
 				loadQueryInfluencers,
 				lockOptions,
-				determineGraphTraversalState( loadQueryInfluencers, sessionFactory ),
+				determineGraphTraversalState( loadQueryInfluencers, sessionFactory.getJpaMetamodel() ),
 				true,
 				jdbcParameterConsumer
 		);
@@ -146,7 +147,7 @@ public class LoaderSelectBuilder {
 			JdbcParameter jdbcArrayParameter,
 			SessionFactoryImplementor sessionFactory) {
 		final LoaderSelectBuilder builder = new LoaderSelectBuilder(
-				sessionFactory,
+				sessionFactory.getSqlTranslationEngine(),
 				loadable,
 				null,
 				singletonList( restrictedPart ),
@@ -154,7 +155,7 @@ public class LoaderSelectBuilder {
 				-1,
 				influencers,
 				lockOptions,
-				determineGraphTraversalState( influencers, sessionFactory ),
+				determineGraphTraversalState( influencers, sessionFactory.getJpaMetamodel() ),
 				true,
 				null
 		);
@@ -239,7 +240,7 @@ public class LoaderSelectBuilder {
 			Consumer<JdbcParameter> jdbcParameterConsumer,
 			SessionFactoryImplementor sessionFactory) {
 		final LoaderSelectBuilder process = new LoaderSelectBuilder(
-				sessionFactory,
+				sessionFactory.getSqlTranslationEngine(),
 				loadable,
 				partsToSelect,
 				restrictedPart,
@@ -264,7 +265,7 @@ public class LoaderSelectBuilder {
 			Consumer<JdbcParameter> jdbcParameterConsumer,
 			SessionFactoryImplementor sessionFactory) {
 		final LoaderSelectBuilder process = new LoaderSelectBuilder(
-				sessionFactory,
+				sessionFactory.getSqlTranslationEngine(),
 				loadable,
 				partsToSelect,
 				restrictedParts,
@@ -292,7 +293,7 @@ public class LoaderSelectBuilder {
 			Consumer<JdbcParameter> jdbcParameterConsumer,
 			SessionFactoryImplementor sessionFactory) {
 		final LoaderSelectBuilder process = new LoaderSelectBuilder(
-				sessionFactory,
+				sessionFactory.getSqlTranslationEngine(),
 				loadable,
 				partsToSelect,
 				restrictedParts,
@@ -300,7 +301,7 @@ public class LoaderSelectBuilder {
 				numberOfKeysToLoad,
 				loadQueryInfluencers,
 				lockOptions,
-				determineGraphTraversalState( loadQueryInfluencers, sessionFactory ),
+				determineGraphTraversalState( loadQueryInfluencers, sessionFactory.getJpaMetamodel() ),
 				forceIdentifierSelection,
 				jdbcParameterConsumer
 		);
@@ -330,7 +331,7 @@ public class LoaderSelectBuilder {
 			Consumer<JdbcParameter> jdbcParameterConsumer,
 			SessionFactoryImplementor sessionFactory) {
 		final LoaderSelectBuilder process = new LoaderSelectBuilder(
-				sessionFactory,
+				sessionFactory.getSqlTranslationEngine(),
 				attributeMapping,
 				null,
 				attributeMapping.getKeyDescriptor(),
@@ -410,7 +411,7 @@ public class LoaderSelectBuilder {
 				numberOfKeysToLoad,
 				loadQueryInfluencers,
 				lockOptions != null ? lockOptions : LockOptions.NONE,
-				determineGraphTraversalState( loadQueryInfluencers, creationContext.getSessionFactory() ),
+				determineGraphTraversalState( loadQueryInfluencers, creationContext.getJpaMetamodel() ),
 				determineWhetherToForceIdSelection( numberOfKeysToLoad, restrictedParts ),
 				jdbcParameterConsumer
 		);
@@ -462,7 +463,7 @@ public class LoaderSelectBuilder {
 
 	private static EntityGraphTraversalState determineGraphTraversalState(
 			LoadQueryInfluencers loadQueryInfluencers,
-			SessionFactoryImplementor sessionFactory) {
+			JpaMetamodel jpaMetamodel) {
 		if ( loadQueryInfluencers != null ) {
 			final EffectiveEntityGraph effectiveEntityGraph = loadQueryInfluencers.getEffectiveEntityGraph();
 			if ( effectiveEntityGraph != null ) {
@@ -472,7 +473,7 @@ public class LoaderSelectBuilder {
 					return new StandardEntityGraphTraversalStateImpl(
 							graphSemantic,
 							rootGraphImplementor,
-							sessionFactory.getJpaMetamodel()
+							jpaMetamodel
 					);
 				}
 			}
@@ -872,8 +873,8 @@ public class LoaderSelectBuilder {
 						final String fetchableRole = fetchable.getNavigableRole().getFullPath();
 
 						for ( String enabledFetchProfileName : loadQueryInfluencers.getEnabledFetchProfileNames() ) {
-							final FetchProfile enabledFetchProfile = creationContext.getSessionFactory()
-									.getFetchProfile( enabledFetchProfileName );
+							final FetchProfile enabledFetchProfile =
+									creationContext.getFetchProfile( enabledFetchProfileName );
 							final org.hibernate.engine.profile.Fetch profileFetch =
 									enabledFetchProfile.getFetchByRole( fetchableRole );
 							if ( profileFetch != null ) {

--- a/hibernate-core/src/main/java/org/hibernate/loader/ast/internal/SingleIdEntityLoaderStandardImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/loader/ast/internal/SingleIdEntityLoaderStandardImpl.java
@@ -36,7 +36,8 @@ public class SingleIdEntityLoaderStandardImpl<T> extends SingleIdEntityLoaderSup
 		this(
 				entityDescriptor,
 				loadQueryInfluencers,
-				(lockOptions, influencers) -> createLoadPlan( entityDescriptor, lockOptions, influencers, influencers.getSessionFactory() )
+				(lockOptions, influencers) ->
+						createLoadPlan( entityDescriptor, lockOptions, influencers, influencers.getSessionFactory() )
 		);
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/ForeignKeyDescriptor.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/ForeignKeyDescriptor.java
@@ -194,7 +194,6 @@ public interface ForeignKeyDescriptor extends VirtualModelPart, ValuedModelPart 
 	interface Side {
 		Nature getNature();
 		ValuedModelPart getModelPart();
-
 	}
 
 	boolean isEmbedded();

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/AbstractDiscriminatorMapping.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/AbstractDiscriminatorMapping.java
@@ -137,7 +137,7 @@ public abstract class AbstractDiscriminatorMapping implements EntityDiscriminato
 				resolveSqlExpression( navigablePath, jdbcMappingToUse, tableGroup, creationState ),
 				jdbcMappingToUse.getJdbcJavaType(),
 				fetchParent,
-				creationState.getCreationContext().getSessionFactory().getTypeConfiguration()
+				creationState.getCreationContext().getTypeConfiguration()
 		);
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/AnyDiscriminatorPart.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/AnyDiscriminatorPart.java
@@ -7,7 +7,6 @@ package org.hibernate.metamodel.mapping.internal;
 import org.hibernate.cache.MutableCacheKeyBuilder;
 import org.hibernate.engine.FetchStyle;
 import org.hibernate.engine.FetchTiming;
-import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.internal.util.IndexedConsumer;
 import org.hibernate.metamodel.mapping.DiscriminatedAssociationModelPart;
@@ -313,7 +312,6 @@ public class AnyDiscriminatorPart implements DiscriminatorMapping, FetchOptions 
 			String resultVariable,
 			DomainResultCreationState creationState) {
 		final SqlAstCreationState sqlAstCreationState = creationState.getSqlAstCreationState();
-		final SessionFactoryImplementor sessionFactory = sqlAstCreationState.getCreationContext().getSessionFactory();
 		final FromClauseAccess fromClauseAccess = sqlAstCreationState.getFromClauseAccess();
 		final SqlExpressionResolver sqlExpressionResolver = sqlAstCreationState.getSqlExpressionResolver();
 
@@ -327,7 +325,7 @@ public class AnyDiscriminatorPart implements DiscriminatorMapping, FetchOptions 
 				columnReference,
 				jdbcMapping().getJdbcJavaType(),
 				fetchParent,
-				sessionFactory.getTypeConfiguration()
+				sqlAstCreationState.getCreationContext().getTypeConfiguration()
 		);
 
 		return new BasicFetch<>(
@@ -407,7 +405,7 @@ public class AnyDiscriminatorPart implements DiscriminatorMapping, FetchOptions 
 				resolveSqlExpression( navigablePath, null, tableGroup, sqlAstCreationState ),
 				jdbcMapping().getJdbcJavaType(),
 				null,
-				creationState.getSqlAstCreationState().getCreationContext().getSessionFactory().getTypeConfiguration()
+				creationState.getSqlAstCreationState().getCreationContext().getTypeConfiguration()
 		);
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/AnyKeyPart.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/AnyKeyPart.java
@@ -8,7 +8,6 @@ import java.util.function.BiConsumer;
 
 import org.hibernate.engine.FetchStyle;
 import org.hibernate.engine.FetchTiming;
-import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.internal.util.IndexedConsumer;
 import org.hibernate.metamodel.mapping.BasicValuedModelPart;
@@ -219,10 +218,6 @@ public class AnyKeyPart implements BasicValuedModelPart, FetchOptions {
 		final SqlExpressionResolver sqlExpressionResolver = creationState
 				.getSqlAstCreationState()
 				.getSqlExpressionResolver();
-		final SessionFactoryImplementor sessionFactory = creationState
-				.getSqlAstCreationState()
-				.getCreationContext()
-				.getSessionFactory();
 
 		final TableGroup tableGroup = fromClauseAccess.getTableGroup( fetchParent.getNavigablePath().getParent() );
 		final TableReference tableReference = tableGroup.resolveTableReference( fetchablePath, table );
@@ -236,7 +231,7 @@ public class AnyKeyPart implements BasicValuedModelPart, FetchOptions {
 				columnReference,
 				jdbcMapping.getJdbcJavaType(),
 				fetchParent,
-				sessionFactory.getTypeConfiguration()
+				creationState.getSqlAstCreationState().getCreationContext().getTypeConfiguration()
 		);
 
 		return new BasicFetch<>(
@@ -371,7 +366,7 @@ public class AnyKeyPart implements BasicValuedModelPart, FetchOptions {
 				),
 				jdbcMapping.getJdbcJavaType(),
 				null,
-				creationState.getSqlAstCreationState().getCreationContext().getSessionFactory().getTypeConfiguration()
+				creationState.getSqlAstCreationState().getCreationContext().getTypeConfiguration()
 		);
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/BasicAttributeMapping.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/BasicAttributeMapping.java
@@ -355,7 +355,7 @@ public class BasicAttributeMapping
 				),
 				jdbcMapping.getJdbcJavaType(),
 				fetchParent,
-				creationState.getSqlAstCreationState().getCreationContext().getSessionFactory().getTypeConfiguration()
+				creationState.getSqlAstCreationState().getCreationContext().getTypeConfiguration()
 		);
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/BasicValuedCollectionPart.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/BasicValuedCollectionPart.java
@@ -205,7 +205,7 @@ public class BasicValuedCollectionPart
 				),
 				getJdbcMapping().getJdbcJavaType(),
 				fetchParent,
-				creationState.getSqlAstCreationState().getCreationContext().getSessionFactory().getTypeConfiguration()
+				creationState.getSqlAstCreationState().getCreationContext().getTypeConfiguration()
 		);
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/CollectionIdentifierDescriptorImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/CollectionIdentifierDescriptorImpl.java
@@ -9,7 +9,6 @@ import java.util.function.BiConsumer;
 import org.hibernate.cache.MutableCacheKeyBuilder;
 import org.hibernate.engine.FetchStyle;
 import org.hibernate.engine.FetchTiming;
-import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.internal.util.IndexedConsumer;
 import org.hibernate.metamodel.mapping.CollectionIdentifierDescriptor;
@@ -255,8 +254,6 @@ public class CollectionIdentifierDescriptorImpl implements CollectionIdentifierD
 		final TableGroup tableGroup = fromClauseAccess.getTableGroup( fetchablePath.getParent() );
 
 		final SqlAstCreationState astCreationState = creationState.getSqlAstCreationState();
-		final SqlAstCreationContext astCreationContext = astCreationState.getCreationContext();
-		final SessionFactoryImplementor sessionFactory = astCreationContext.getSessionFactory();
 		final SqlExpressionResolver sqlExpressionResolver = astCreationState.getSqlExpressionResolver();
 
 		final SqlSelection sqlSelection = sqlExpressionResolver.resolveSqlSelection(
@@ -266,7 +263,7 @@ public class CollectionIdentifierDescriptorImpl implements CollectionIdentifierD
 				),
 				type.getJdbcJavaType(),
 				fetchParent,
-				sessionFactory.getTypeConfiguration()
+				astCreationState.getCreationContext().getTypeConfiguration()
 		);
 
 		return new BasicFetch<>(
@@ -286,7 +283,6 @@ public class CollectionIdentifierDescriptorImpl implements CollectionIdentifierD
 			DomainResultCreationState creationState) {
 		final SqlAstCreationState astCreationState = creationState.getSqlAstCreationState();
 		final SqlAstCreationContext astCreationContext = astCreationState.getCreationContext();
-		final SessionFactoryImplementor sessionFactory = astCreationContext.getSessionFactory();
 		final SqlExpressionResolver sqlExpressionResolver = astCreationState.getSqlExpressionResolver();
 
 		final SqlSelection sqlSelection = sqlExpressionResolver.resolveSqlSelection(
@@ -296,7 +292,7 @@ public class CollectionIdentifierDescriptorImpl implements CollectionIdentifierD
 				),
 				type.getJdbcJavaType(),
 				null,
-				sessionFactory.getTypeConfiguration()
+				astCreationContext.getTypeConfiguration()
 		);
 
 		return new BasicResult<>(

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/CompoundNaturalIdMapping.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/CompoundNaturalIdMapping.java
@@ -285,7 +285,7 @@ public class CompoundNaturalIdMapping extends AbstractNaturalIdMapping implement
 		assert navigablePath.getLocalName().equals( NaturalIdMapping.PART_NAME );
 
 		final JavaType<Object[]> jtd =
-				creationState.getSqlAstCreationState().getCreationContext().getSessionFactory()
+				creationState.getSqlAstCreationState().getCreationContext()
 						.getTypeConfiguration().getJavaTypeRegistry()
 						.getDescriptor( Object[].class );
 

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/EntityRowIdMappingImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/EntityRowIdMappingImpl.java
@@ -99,7 +99,7 @@ public class EntityRowIdMappingImpl implements EntityRowIdMapping {
 				sqlExpressionResolver.resolveSqlExpression( columnTableReference, this ),
 				rowIdType.getJdbcJavaType(),
 				null,
-				sqlAstCreationState.getCreationContext().getSessionFactory().getTypeConfiguration()
+				sqlAstCreationState.getCreationContext().getTypeConfiguration()
 		);
 
 		return new BasicResult<>(

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/EntityVersionMappingImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/EntityVersionMappingImpl.java
@@ -245,7 +245,7 @@ public class EntityVersionMappingImpl implements EntityVersionMapping, FetchOpti
 				sqlExpressionResolver.resolveSqlExpression( columnTableReference, this ),
 				versionBasicType.getJdbcJavaType(),
 				fetchParent,
-				sqlAstCreationState.getCreationContext().getSessionFactory().getTypeConfiguration()
+				sqlAstCreationState.getCreationContext().getTypeConfiguration()
 		);
 
 		return new BasicFetch<>(
@@ -318,7 +318,7 @@ public class EntityVersionMappingImpl implements EntityVersionMapping, FetchOpti
 				sqlExpressionResolver.resolveSqlExpression( columnTableReference, this ),
 				versionBasicType.getJdbcJavaType(),
 				null,
-				sqlAstCreationState.getCreationContext().getSessionFactory().getTypeConfiguration()
+				sqlAstCreationState.getCreationContext().getTypeConfiguration()
 		);
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/SimpleForeignKeyDescriptor.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/SimpleForeignKeyDescriptor.java
@@ -386,7 +386,7 @@ public class SimpleForeignKeyDescriptor implements ForeignKeyDescriptor, BasicVa
 				sqlExpressionResolver.resolveSqlExpression( tableReference, selectableMapping ),
 				javaType,
 				fetchParent,
-				sqlAstCreationState.getCreationContext().getSessionFactory().getTypeConfiguration()
+				sqlAstCreationState.getCreationContext().getTypeConfiguration()
 		);
 
 		final JdbcMappingContainer selectionType = sqlSelection.getExpressionType();

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/ordering/ast/OrderingExpression.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/ordering/ast/OrderingExpression.java
@@ -50,8 +50,7 @@ public interface OrderingExpression extends Node {
 		}
 		else {
 			final QueryEngine queryEngine =
-					creationState.getCreationContext().getSessionFactory()
-							.getQueryEngine();
+					creationState.getSqmCreationContext().getQueryEngine();
 			final SqmToSqlAstConverter converter =
 					creationState instanceof SqmToSqlAstConverter sqmToSqlAstConverter
 							? sqmToSqlAstConverter

--- a/hibernate-core/src/main/java/org/hibernate/persister/collection/AbstractCollectionPersister.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/collection/AbstractCollectionPersister.java
@@ -941,7 +941,7 @@ public abstract class AbstractCollectionPersister
 				(fetchParent, creationState) -> ImmutableFetchList.EMPTY,
 				true,
 				new LoadQueryInfluencers( factory ),
-				factory
+				factory.getSqlTranslationEngine()
 		);
 
 		final NavigablePath entityPath = new NavigablePath( attributeMapping.getRootPathName() );

--- a/hibernate-core/src/main/java/org/hibernate/persister/entity/AbstractEntityPersister.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/entity/AbstractEntityPersister.java
@@ -1838,7 +1838,7 @@ public abstract class AbstractEntityPersister
 				this::fetchProcessor,
 				true,
 				new LoadQueryInfluencers( factory ),
-				factory
+				factory.getSqlTranslationEngine()
 		);
 
 		final NavigablePath entityPath = new NavigablePath( getRootPathName() );

--- a/hibernate-core/src/main/java/org/hibernate/persister/entity/ExplicitSqlStringGenerationContext.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/entity/ExplicitSqlStringGenerationContext.java
@@ -38,6 +38,10 @@ public class ExplicitSqlStringGenerationContext implements SqlStringGenerationCo
 				: toIdentifier( factory.getSessionFactoryOptions().getDefaultSchema() );
 	}
 
+	private JdbcEnvironment getJdbcEnvironment() {
+		return factory.getJdbcServices().getJdbcEnvironment();
+	}
+
 	@Override
 	public Dialect getDialect() {
 		return factory.getJdbcServices().getDialect();
@@ -45,7 +49,7 @@ public class ExplicitSqlStringGenerationContext implements SqlStringGenerationCo
 
 	@Override
 	public Identifier toIdentifier(String text) {
-		return factory.getJdbcServices().getJdbcEnvironment().getIdentifierHelper().toIdentifier( text );
+		return getJdbcEnvironment().getIdentifierHelper().toIdentifier( text );
 	}
 
 	@Override
@@ -64,9 +68,8 @@ public class ExplicitSqlStringGenerationContext implements SqlStringGenerationCo
 	}
 
 	private QualifiedObjectNameFormatter nameFormater() {
-		final JdbcEnvironment jdbcEnvironment = factory.getJdbcServices().getJdbcEnvironment();
 		//noinspection deprecation
-		return jdbcEnvironment.getQualifiedObjectNameFormatter();
+		return getJdbcEnvironment().getQualifiedObjectNameFormatter();
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/procedure/internal/ProcedureCallImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/procedure/internal/ProcedureCallImpl.java
@@ -567,7 +567,8 @@ public class ProcedureCallImpl<R>
 			return null;
 		}
 		else {
-			final SqmExpressible<T> sqmExpressible = parameterType.resolveExpressible( getSessionFactory() );
+			final SqmExpressible<T> sqmExpressible =
+					parameterType.resolveExpressible( getSessionFactory().getQueryEngine().getCriteriaBuilder() );
 			assert sqmExpressible != null;
 
 			return sqmExpressible.getExpressibleJavaType().getJavaTypeClass();

--- a/hibernate-core/src/main/java/org/hibernate/procedure/internal/ProcedureParameterImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/procedure/internal/ProcedureParameterImpl.java
@@ -111,7 +111,7 @@ public class ProcedureParameterImpl<T> extends AbstractQueryParameter<T> impleme
 		final OutputableType<T> typeToUse = (OutputableType<T>) BindingTypeHelper.INSTANCE.resolveTemporalPrecision(
 				binding == null ? null : binding.getExplicitTemporalPrecision(),
 				bindableType,
-				session.getFactory()
+				session.getFactory().getQueryEngine().getCriteriaBuilder()
 		);
 
 		final String jdbcParamName;

--- a/hibernate-core/src/main/java/org/hibernate/procedure/internal/ScalarDomainResultBuilder.java
+++ b/hibernate-core/src/main/java/org/hibernate/procedure/internal/ScalarDomainResultBuilder.java
@@ -15,6 +15,7 @@ import org.hibernate.sql.results.graph.basic.BasicResult;
 import org.hibernate.sql.results.jdbc.spi.JdbcValuesMetadata;
 import org.hibernate.type.BasicType;
 import org.hibernate.type.descriptor.java.JavaType;
+import org.hibernate.type.spi.TypeConfiguration;
 
 /**
  * @author Steve Ebersole
@@ -36,8 +37,10 @@ public class ScalarDomainResultBuilder<T> implements ResultBuilder {
 			JdbcValuesMetadata jdbcResultsMetadata,
 			int resultPosition,
 			DomainResultCreationState domainResultCreationState) {
-		final SqlExpressionResolver sqlExpressionResolver = domainResultCreationState.getSqlAstCreationState()
-				.getSqlExpressionResolver();
+		final SqlExpressionResolver sqlExpressionResolver =
+				domainResultCreationState.getSqlAstCreationState().getSqlExpressionResolver();
+		final TypeConfiguration typeConfiguration =
+				domainResultCreationState.getSqlAstCreationState().getCreationContext().getTypeConfiguration();
 		final SqlSelection sqlSelection = sqlExpressionResolver.resolveSqlSelection(
 				sqlExpressionResolver.resolveSqlExpression(
 						SqlExpressionResolver.createColumnReferenceKey(
@@ -47,17 +50,14 @@ public class ScalarDomainResultBuilder<T> implements ResultBuilder {
 							final BasicType<?> basicType = jdbcResultsMetadata.resolveType(
 									resultPosition + 1,
 									typeDescriptor,
-									processingState.getSqlAstCreationState().getCreationContext().getSessionFactory()
+									typeConfiguration
 							);
 							return new ResultSetMappingSqlSelection( resultPosition, (BasicValuedMapping) basicType );
 						}
 				),
 				typeDescriptor,
 				null,
-				domainResultCreationState.getSqlAstCreationState()
-						.getCreationContext()
-						.getSessionFactory()
-						.getTypeConfiguration()
+				typeConfiguration
 		);
 		return new BasicResult<>(
 				sqlSelection.getValuesArrayPosition(),

--- a/hibernate-core/src/main/java/org/hibernate/procedure/internal/Util.java
+++ b/hibernate-core/src/main/java/org/hibernate/procedure/internal/Util.java
@@ -7,7 +7,7 @@ package org.hibernate.procedure.internal;
 import java.util.function.Consumer;
 
 import org.hibernate.internal.util.collections.ArrayHelper;
-import org.hibernate.metamodel.spi.MappingMetamodelImplementor;
+import org.hibernate.metamodel.MappingMetamodel;
 import org.hibernate.persister.entity.EntityPersister;
 import org.hibernate.query.UnknownSqlResultSetMappingException;
 import org.hibernate.query.internal.ResultSetMappingResolutionContext;
@@ -52,8 +52,7 @@ public class Util {
 			ResultSetMapping resultSetMapping,
 			Consumer<String> querySpaceConsumer,
 			ResultSetMappingResolutionContext context) {
-		final NamedObjectRepository namedObjectRepository =
-				context.getSessionFactory().getQueryEngine().getNamedObjectRepository();
+		final NamedObjectRepository namedObjectRepository = context.getNamedObjectRepository();
 		for ( String resultSetMappingName : resultSetMappingNames ) {
 			final NamedResultSetMappingMemento memento =
 					namedObjectRepository.getResultSetMappingMemento( resultSetMappingName );
@@ -73,7 +72,7 @@ public class Util {
 			ResultSetMapping resultSetMapping,
 			Consumer<String> querySpaceConsumer,
 			ResultSetMappingResolutionContext context) {
-		final MappingMetamodelImplementor mappingMetamodel = context.getSessionFactory().getRuntimeMetamodels().getMappingMetamodel();
+		final MappingMetamodel mappingMetamodel = context.getMappingMetamodel();
 		final JavaTypeRegistry javaTypeRegistry = mappingMetamodel.getTypeConfiguration().getJavaTypeRegistry();
 
 		for ( Class<?> resultSetMappingClass : resultSetMappingClasses ) {

--- a/hibernate-core/src/main/java/org/hibernate/query/BindingContext.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/BindingContext.java
@@ -23,7 +23,5 @@ public interface BindingContext {
 
 	MappingMetamodel getMappingMetamodel();
 
-	default TypeConfiguration getTypeConfiguration() {
-		return getJpaMetamodel().getTypeConfiguration();
-	}
+	TypeConfiguration getTypeConfiguration();
 }

--- a/hibernate-core/src/main/java/org/hibernate/query/BindingContext.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/BindingContext.java
@@ -16,6 +16,11 @@ import org.hibernate.type.spi.TypeConfiguration;
  * @author Gavin King
  *
  * @since 7
+ *
+ * @see BindableType#resolveExpressible(BindingContext)
+ * @see org.hibernate.query.sqm.SqmExpressible#resolveExpressible(BindingContext)
+ * @see org.hibernate.query.sqm.produce.function.ArgumentsValidator#validate(java.util.List, String, BindingContext)
+ * @see org.hibernate.query.sqm.internal.TypecheckUtil
  */
 @Incubating
 public interface BindingContext {

--- a/hibernate-core/src/main/java/org/hibernate/query/internal/QueryEngineImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/internal/QueryEngineImpl.java
@@ -14,6 +14,8 @@ import org.hibernate.engine.jdbc.spi.JdbcServices;
 import org.hibernate.engine.query.spi.NativeQueryInterpreter;
 import org.hibernate.internal.CoreLogging;
 import org.hibernate.internal.util.config.ConfigurationHelper;
+import org.hibernate.metamodel.MappingMetamodel;
+import org.hibernate.metamodel.model.domain.JpaMetamodel;
 import org.hibernate.query.BindingContext;
 import org.hibernate.query.hql.HqlTranslator;
 import org.hibernate.query.hql.internal.StandardHqlTranslator;
@@ -51,27 +53,75 @@ public class QueryEngineImpl implements QueryEngine {
 
 	private static final Logger LOG_HQL_FUNCTIONS = CoreLogging.logger("org.hibernate.HQL_FUNCTIONS");
 
-	public static QueryEngineImpl from(
+	private final TypeConfiguration typeConfiguration;
+	private final NamedObjectRepository namedObjectRepository;
+	private final NativeQueryInterpreter nativeQueryInterpreter;
+	private final BindingContext bindingContext;
+	private final ClassLoaderService classLoaderService;
+	private final QueryInterpretationCache interpretationCache;
+	private final NodeBuilder nodeBuilder;
+	private final HqlTranslator hqlTranslator;
+	private final SqmTranslatorFactory sqmTranslatorFactory;
+	private final SqmFunctionRegistry sqmFunctionRegistry;
+	private final Dialect dialect;
+
+	public QueryEngineImpl(
 			MetadataImplementor metadata,
 			QueryEngineOptions options,
-			SqmCreationContext sqmCreationContext,
+			BindingContext context,
 			ServiceRegistryImplementor serviceRegistry,
 			Map<String,Object> properties,
 			String name) {
-		final Dialect dialect = serviceRegistry.requireService( JdbcServices.class ).getDialect();
-		return new QueryEngineImpl(
-				metadata.getTypeConfiguration(),
-				resolveHqlTranslator( options, dialect, sqmCreationContext, new SqmCreationOptionsStandard( options ) ),
-				resolveSqmTranslatorFactory( options, dialect ),
-				createFunctionRegistry( serviceRegistry, metadata, options, dialect ),
-				metadata.buildNamedQueryRepository(),
-				buildInterpretationCache( serviceRegistry, properties ),
-				serviceRegistry.getService(NativeQueryInterpreter.class),
-				sqmCreationContext,
-				options,
-				options.getUuid(),
-				name
-		);
+		this.dialect = serviceRegistry.requireService( JdbcServices.class ).getDialect();
+		this.bindingContext = context;
+		this.typeConfiguration = metadata.getTypeConfiguration();
+		this.sqmFunctionRegistry = createFunctionRegistry( serviceRegistry, metadata, options, dialect );
+		this.sqmTranslatorFactory = resolveSqmTranslatorFactory( options, dialect );
+		this.namedObjectRepository = metadata.buildNamedQueryRepository();
+		this.interpretationCache = buildInterpretationCache( serviceRegistry, properties );
+		this.nativeQueryInterpreter = serviceRegistry.getService( NativeQueryInterpreter.class );
+		this.classLoaderService = serviceRegistry.getService( ClassLoaderService.class );
+		// here we have something nasty: we need to pass a reference to the current object to
+		// create the NodeBuilder, but then we need the NodeBuilder to create the HqlTranslator
+		// and that's only because we're using the NodeBuilder as the SqmCreationContext
+		this.nodeBuilder = createCriteriaBuilder( context, this, options, options.getUuid(), name );
+		this.hqlTranslator = resolveHqlTranslator( options, dialect, nodeBuilder );
+	}
+
+	private static SqmCriteriaNodeBuilder createCriteriaBuilder(
+			BindingContext context, QueryEngine engine, QueryEngineOptions options,
+			String uuid, String name) {
+		return new SqmCriteriaNodeBuilder( uuid, name, engine, options, context );
+	}
+
+	private static HqlTranslator resolveHqlTranslator(
+			QueryEngineOptions options,
+			Dialect dialect,
+			SqmCreationContext sqmCreationContext) {
+		final SqmCreationOptions sqmCreationOptions = new SqmCreationOptionsStandard( options );
+		if ( options.getCustomHqlTranslator() != null ) {
+			return options.getCustomHqlTranslator();
+		}
+		else if ( dialect.getHqlTranslator() != null ) {
+			return dialect.getHqlTranslator();
+		}
+		else {
+			return new StandardHqlTranslator( sqmCreationContext, sqmCreationOptions );
+		}
+	}
+
+	private static SqmTranslatorFactory resolveSqmTranslatorFactory(
+			QueryEngineOptions runtimeOptions,
+			Dialect dialect) {
+		if ( runtimeOptions.getCustomSqmTranslatorFactory() != null ) {
+			return runtimeOptions.getCustomSqmTranslatorFactory();
+		}
+		else if ( dialect.getSqmTranslatorFactory() != null ) {
+			return dialect.getSqmTranslatorFactory();
+		}
+		else {
+			return new StandardSqmTranslatorFactory();
+		}
 	}
 
 	private static SqmFunctionRegistry createFunctionRegistry(
@@ -103,72 +153,6 @@ public class QueryEngineImpl implements QueryEngine {
 		}
 
 		return sqmFunctionRegistry;
-	}
-
-	private final TypeConfiguration typeConfiguration;
-	private final NamedObjectRepository namedObjectRepository;
-	private final NativeQueryInterpreter nativeQueryInterpreter;
-	private final QueryInterpretationCache interpretationCache;
-	private final NodeBuilder criteriaBuilder;
-	private final HqlTranslator hqlTranslator;
-	private final SqmTranslatorFactory sqmTranslatorFactory;
-	private final SqmFunctionRegistry sqmFunctionRegistry;
-
-	private QueryEngineImpl(
-			TypeConfiguration typeConfiguration,
-			HqlTranslator hqlTranslator,
-			SqmTranslatorFactory sqmTranslatorFactory,
-			SqmFunctionRegistry functionRegistry,
-			NamedObjectRepository namedObjectRepository,
-			QueryInterpretationCache interpretationCache,
-			NativeQueryInterpreter nativeQueryInterpreter,
-			BindingContext context,
-			QueryEngineOptions options,
-			String uuid, String name) {
-		this.typeConfiguration = typeConfiguration;
-		this.sqmFunctionRegistry = functionRegistry;
-		this.sqmTranslatorFactory = sqmTranslatorFactory;
-		this.hqlTranslator = hqlTranslator;
-		this.namedObjectRepository = namedObjectRepository;
-		this.interpretationCache = interpretationCache;
-		this.nativeQueryInterpreter = nativeQueryInterpreter;
-		this.criteriaBuilder = createCriteriaBuilder( context, options, uuid, name );
-	}
-
-	private SqmCriteriaNodeBuilder createCriteriaBuilder(
-			BindingContext context, QueryEngineOptions options,
-			String uuid, String name) {
-		return new SqmCriteriaNodeBuilder( uuid, name, this, options, context );
-	}
-
-	private static HqlTranslator resolveHqlTranslator(
-			QueryEngineOptions runtimeOptions,
-			Dialect dialect,
-			SqmCreationContext sqmCreationContext,
-			SqmCreationOptions sqmCreationOptions) {
-		if ( runtimeOptions.getCustomHqlTranslator() != null ) {
-			return runtimeOptions.getCustomHqlTranslator();
-		}
-		else if ( dialect.getHqlTranslator() != null ) {
-			return dialect.getHqlTranslator();
-		}
-		else {
-			return new StandardHqlTranslator( sqmCreationContext, sqmCreationOptions );
-		}
-	}
-
-	private static SqmTranslatorFactory resolveSqmTranslatorFactory(
-			QueryEngineOptions runtimeOptions,
-			Dialect dialect) {
-		if ( runtimeOptions.getCustomSqmTranslatorFactory() != null ) {
-			return runtimeOptions.getCustomSqmTranslatorFactory();
-		}
-		else if ( dialect.getSqmTranslatorFactory() != null ) {
-			return dialect.getSqmTranslatorFactory();
-		}
-		else {
-			return new StandardSqmTranslatorFactory();
-		}
 	}
 
 	private static List<FunctionContributor> sortedFunctionContributors(ServiceRegistry serviceRegistry) {
@@ -227,7 +211,12 @@ public class QueryEngineImpl implements QueryEngine {
 
 	@Override
 	public NodeBuilder getCriteriaBuilder() {
-		return criteriaBuilder;
+		return nodeBuilder;
+	}
+
+	@Override
+	public ClassLoaderService getClassLoaderService() {
+		return classLoaderService;
 	}
 
 	@Override
@@ -253,6 +242,21 @@ public class QueryEngineImpl implements QueryEngine {
 	@Override
 	public SqmFunctionRegistry getSqmFunctionRegistry() {
 		return sqmFunctionRegistry;
+	}
+
+	@Override
+	public JpaMetamodel getJpaMetamodel() {
+		return bindingContext.getJpaMetamodel();
+	}
+
+	@Override
+	public MappingMetamodel getMappingMetamodel() {
+		return bindingContext.getMappingMetamodel();
+	}
+
+	@Override
+	public Dialect getDialect() {
+		return dialect;
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/query/internal/QueryParameterBindingImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/internal/QueryParameterBindingImpl.java
@@ -18,6 +18,7 @@ import org.hibernate.query.QueryParameter;
 import org.hibernate.query.spi.QueryParameterBinding;
 import org.hibernate.query.spi.QueryParameterBindingTypeResolver;
 import org.hibernate.query.spi.QueryParameterBindingValidator;
+import org.hibernate.query.sqm.NodeBuilder;
 import org.hibernate.query.sqm.SqmExpressible;
 import org.hibernate.query.sqm.tree.expression.NullSqmExpressible;
 import org.hibernate.type.descriptor.java.JavaType;
@@ -93,6 +94,10 @@ public class QueryParameterBindingImpl<T> implements QueryParameterBinding<T>, J
 	@Override
 	public QueryParameter<T> getQueryParameter() {
 		return queryParameter;
+	}
+
+	private NodeBuilder getCriteriaBuilder() {
+		return sessionFactory.getQueryEngine().getCriteriaBuilder();
 	}
 
 	// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -243,12 +248,12 @@ public class QueryParameterBindingImpl<T> implements QueryParameterBinding<T>, J
 	private void setExplicitTemporalPrecision(TemporalType precision) {
 		explicitTemporalPrecision = precision;
 		if ( bindType == null || JavaTypeHelper.isTemporal( determineJavaType( bindType ) ) ) {
-			bindType = BindingTypeHelper.INSTANCE.resolveTemporalPrecision( precision, bindType, sessionFactory );
+			bindType = BindingTypeHelper.INSTANCE.resolveTemporalPrecision( precision, bindType, getCriteriaBuilder() );
 		}
 	}
 
 	private JavaType<? super T> determineJavaType(BindableType<? super T> bindType) {
-		final SqmExpressible<? super T> sqmExpressible = bindType.resolveExpressible( sessionFactory );
+		final SqmExpressible<? super T> sqmExpressible = bindType.resolveExpressible( getCriteriaBuilder() );
 		assert sqmExpressible != null;
 		return sqmExpressible.getExpressibleJavaType();
 	}
@@ -281,15 +286,15 @@ public class QueryParameterBindingImpl<T> implements QueryParameterBinding<T>, J
 	}
 
 	private void validate(Object value) {
-		QueryParameterBindingValidator.INSTANCE.validate( getBindType(), value, sessionFactory );
+		QueryParameterBindingValidator.INSTANCE.validate( getBindType(), value, getCriteriaBuilder() );
 	}
 
 	private void validate(Object value, BindableType<?> clarifiedType) {
-		QueryParameterBindingValidator.INSTANCE.validate( clarifiedType, value, sessionFactory );
+		QueryParameterBindingValidator.INSTANCE.validate( clarifiedType, value, getCriteriaBuilder() );
 	}
 
 	private void validate(Object value, TemporalType clarifiedTemporalType) {
-		QueryParameterBindingValidator.INSTANCE.validate( getBindType(), value, clarifiedTemporalType, sessionFactory );
+		QueryParameterBindingValidator.INSTANCE.validate( getBindType(), value, clarifiedTemporalType, getCriteriaBuilder() );
 	}
 
 	@Override
@@ -332,7 +337,7 @@ public class QueryParameterBindingImpl<T> implements QueryParameterBinding<T>, J
 			return null;
 		}
 		else {
-			final SqmExpressible<? super T> sqmExpressible = parameterType.resolveExpressible( sessionFactory );
+			final SqmExpressible<? super T> sqmExpressible = parameterType.resolveExpressible( getCriteriaBuilder() );
 			assert sqmExpressible != null;
 			return sqmExpressible.getExpressibleJavaType().coerce( value, this );
 		}

--- a/hibernate-core/src/main/java/org/hibernate/query/internal/ResultMementoBasicStandard.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/internal/ResultMementoBasicStandard.java
@@ -7,7 +7,6 @@ package org.hibernate.query.internal;
 import java.lang.reflect.ParameterizedType;
 import java.util.function.Consumer;
 
-import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.metamodel.mapping.BasicValuedMapping;
 import org.hibernate.query.named.ResultMementoBasic;
 import org.hibernate.query.results.ResultBuilderBasicValued;
@@ -72,69 +71,69 @@ public class ResultMementoBasicStandard implements ResultMementoBasic {
 			ResultSetMappingResolutionContext context) {
 		this.explicitColumnName = definition.name();
 
-		final SessionFactoryImplementor sessionFactory = context.getSessionFactory();
-		final TypeConfiguration typeConfiguration = sessionFactory.getTypeConfiguration();
-
 		final Class<?> definedType = definition.type();
-
 		if ( void.class == definedType ) {
 			builder = new CompleteResultBuilderBasicValuedStandard( explicitColumnName, null, null );
 		}
-		else if ( AttributeConverter.class.isAssignableFrom( definedType ) ) {
-			@SuppressWarnings("unchecked")
-			final Class<? extends AttributeConverter<?, ?>> converterClass =
-					(Class<? extends AttributeConverter<?, ?>>) definedType;
-			final ManagedBean<? extends AttributeConverter<?,?>> converterBean =
-					sessionFactory.getManagedBeanRegistry().getBean( converterClass );
-			final JavaType<? extends AttributeConverter<?,?>> converterJtd =
-					typeConfiguration.getJavaTypeRegistry().getDescriptor( converterClass );
-
-			final ParameterizedType parameterizedType =
-					extractAttributeConverterParameterizedType( converterBean.getBeanClass() );
-
-			builder = new CompleteResultBuilderBasicValuedConverted(
-					explicitColumnName,
-					converterBean,
-					converterJtd,
-					determineDomainJavaType( parameterizedType, typeConfiguration.getJavaTypeRegistry() ),
-					resolveUnderlyingMapping( parameterizedType, typeConfiguration )
-			);
-		}
 		else {
-			final BasicType<?> explicitType;
-			final JavaType<?> explicitJavaType;
+			final TypeConfiguration typeConfiguration = context.getTypeConfiguration();
+			final ManagedBeanRegistry managedBeanRegistry = context.getSessionFactory().getManagedBeanRegistry();
 
-			// see if this is a registered BasicType...
-			final BasicType<Object> registeredBasicType =
-					typeConfiguration.getBasicTypeRegistry().getRegisteredType( definedType.getName() );
-			if ( registeredBasicType != null ) {
-				explicitType = registeredBasicType;
-				explicitJavaType = registeredBasicType.getJavaTypeDescriptor();
+			if ( AttributeConverter.class.isAssignableFrom( definedType ) ) {
+				@SuppressWarnings("unchecked")
+				final Class<? extends AttributeConverter<?, ?>> converterClass =
+						(Class<? extends AttributeConverter<?, ?>>) definedType;
+				final ManagedBean<? extends AttributeConverter<?,?>> converterBean =
+						managedBeanRegistry.getBean( converterClass );
+				final JavaType<? extends AttributeConverter<?,?>> converterJtd =
+						typeConfiguration.getJavaTypeRegistry().getDescriptor( converterClass );
+
+				final ParameterizedType parameterizedType =
+						extractAttributeConverterParameterizedType( converterBean.getBeanClass() );
+
+				builder = new CompleteResultBuilderBasicValuedConverted(
+						explicitColumnName,
+						converterBean,
+						converterJtd,
+						determineDomainJavaType( parameterizedType, typeConfiguration.getJavaTypeRegistry() ),
+						resolveUnderlyingMapping( parameterizedType, typeConfiguration )
+				);
 			}
 			else {
-				final JavaTypeRegistry jtdRegistry = typeConfiguration.getJavaTypeRegistry();
-				final JavaType<Object> registeredJtd = jtdRegistry.getDescriptor( definedType );
-				final ManagedBeanRegistry beanRegistry = sessionFactory.getManagedBeanRegistry();
-				if ( BasicType.class.isAssignableFrom( registeredJtd.getJavaTypeClass() ) ) {
-					final ManagedBean<BasicType<?>> typeBean =
-							(ManagedBean) beanRegistry.getBean( registeredJtd.getJavaTypeClass() );
-					explicitType = typeBean.getBeanInstance();
-					explicitJavaType = explicitType.getJavaTypeDescriptor();
-				}
-				else if ( UserType.class.isAssignableFrom( registeredJtd.getJavaTypeClass() ) ) {
-					final ManagedBean<UserType<?>> userTypeBean =
-							(ManagedBean) beanRegistry.getBean( registeredJtd.getJavaTypeClass() );
-					// todo (6.0) : is this the best approach?  or should we keep a Class<? extends UserType> -> @Type mapping somewhere?
-					explicitType = new CustomType<>( userTypeBean.getBeanInstance(), typeConfiguration );
-					explicitJavaType = explicitType.getJavaTypeDescriptor();
+				final BasicType<?> explicitType;
+				final JavaType<?> explicitJavaType;
+
+				// see if this is a registered BasicType...
+				final BasicType<Object> registeredBasicType =
+						typeConfiguration.getBasicTypeRegistry().getRegisteredType( definedType.getName() );
+				if ( registeredBasicType != null ) {
+					explicitType = registeredBasicType;
+					explicitJavaType = registeredBasicType.getJavaTypeDescriptor();
 				}
 				else {
-					explicitType = null;
-					explicitJavaType = jtdRegistry.getDescriptor( definedType );
+					final JavaTypeRegistry jtdRegistry = typeConfiguration.getJavaTypeRegistry();
+					final JavaType<Object> registeredJtd = jtdRegistry.getDescriptor( definedType );
+					if ( BasicType.class.isAssignableFrom( registeredJtd.getJavaTypeClass() ) ) {
+						final ManagedBean<BasicType<?>> typeBean =
+								(ManagedBean) managedBeanRegistry.getBean( registeredJtd.getJavaTypeClass() );
+						explicitType = typeBean.getBeanInstance();
+						explicitJavaType = explicitType.getJavaTypeDescriptor();
+					}
+					else if ( UserType.class.isAssignableFrom( registeredJtd.getJavaTypeClass() ) ) {
+						final ManagedBean<UserType<?>> userTypeBean =
+								(ManagedBean) managedBeanRegistry.getBean( registeredJtd.getJavaTypeClass() );
+						// todo (6.0) : is this the best approach?  or should we keep a Class<? extends UserType> -> @Type mapping somewhere?
+						explicitType = new CustomType<>( userTypeBean.getBeanInstance(), typeConfiguration );
+						explicitJavaType = explicitType.getJavaTypeDescriptor();
+					}
+					else {
+						explicitType = null;
+						explicitJavaType = jtdRegistry.getDescriptor( definedType );
+					}
 				}
-			}
 
-			builder = new CompleteResultBuilderBasicValuedStandard( explicitColumnName, explicitType, explicitJavaType );
+				builder = new CompleteResultBuilderBasicValuedStandard( explicitColumnName, explicitType, explicitJavaType );
+			}
 		}
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/query/internal/ResultSetMappingResolutionContext.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/internal/ResultSetMappingResolutionContext.java
@@ -5,6 +5,9 @@
 package org.hibernate.query.internal;
 
 import org.hibernate.engine.spi.SessionFactoryImplementor;
+import org.hibernate.metamodel.MappingMetamodel;
+import org.hibernate.query.named.NamedObjectRepository;
+import org.hibernate.type.spi.TypeConfiguration;
 
 /**
  * Context ("parameter object") used in resolving a {@link NamedResultSetMappingMementoImpl}
@@ -14,4 +17,16 @@ import org.hibernate.engine.spi.SessionFactoryImplementor;
 @FunctionalInterface
 public interface ResultSetMappingResolutionContext {
 	SessionFactoryImplementor getSessionFactory();
+
+	default MappingMetamodel getMappingMetamodel() {
+		return getSessionFactory().getMappingMetamodel();
+	}
+
+	default TypeConfiguration getTypeConfiguration() {
+		return getSessionFactory().getTypeConfiguration();
+	}
+
+	default NamedObjectRepository getNamedObjectRepository() {
+		return getSessionFactory().getQueryEngine().getNamedObjectRepository();
+	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/query/results/internal/Builders.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/results/internal/Builders.java
@@ -10,6 +10,7 @@ import java.util.Locale;
 
 import org.hibernate.LockMode;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
+import org.hibernate.metamodel.MappingMetamodel;
 import org.hibernate.metamodel.RuntimeMetamodels;
 import org.hibernate.metamodel.mapping.AttributeMapping;
 import org.hibernate.metamodel.mapping.BasicValuedModelPart;
@@ -19,7 +20,6 @@ import org.hibernate.metamodel.mapping.SingularAttributeMapping;
 import org.hibernate.metamodel.mapping.internal.DiscriminatedAssociationAttributeMapping;
 import org.hibernate.metamodel.mapping.internal.EntityCollectionPart;
 import org.hibernate.metamodel.mapping.internal.ToOneAttributeMapping;
-import org.hibernate.metamodel.spi.MappingMetamodelImplementor;
 import org.hibernate.persister.entity.EntityPersister;
 import org.hibernate.query.NativeQuery;
 import org.hibernate.query.internal.ResultSetMappingResolutionContext;
@@ -246,15 +246,12 @@ public class Builders {
 	public static ResultBuilder resultClassBuilder(
 			Class<?> resultMappingClass,
 			ResultSetMappingResolutionContext resolutionContext) {
-		return resultClassBuilder( resultMappingClass, resolutionContext.getSessionFactory() );
+		return resultClassBuilder( resultMappingClass, resolutionContext.getMappingMetamodel() );
 	}
 
 	public static ResultBuilder resultClassBuilder(
 			Class<?> resultMappingClass,
-			SessionFactoryImplementor sessionFactory) {
-		final MappingMetamodelImplementor mappingMetamodel =
-				sessionFactory.getRuntimeMetamodels()
-						.getMappingMetamodel();
+			MappingMetamodel mappingMetamodel) {
 		final EntityMappingType entityMappingType = mappingMetamodel.findEntityDescriptor( resultMappingClass );
 		if ( entityMappingType != null ) {
 			// the resultClass is an entity

--- a/hibernate-core/src/main/java/org/hibernate/query/results/internal/ResultSetMappingImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/results/internal/ResultSetMappingImpl.java
@@ -308,7 +308,9 @@ public class ResultSetMappingImpl implements ResultSetMapping {
 			JdbcValuesMetadata jdbcResultsMetadata,
 			SessionFactoryImplementor sessionFactory) {
 		final int jdbcPosition = valuesArrayPosition + 1;
-		final BasicType<?> jdbcMapping = jdbcResultsMetadata.resolveType( jdbcPosition, null, sessionFactory );
+		final BasicType<?> jdbcMapping =
+				jdbcResultsMetadata.resolveType( jdbcPosition, null,
+						sessionFactory.getTypeConfiguration() );
 
 		final String name = jdbcResultsMetadata.resolveColumnName( jdbcPosition );
 

--- a/hibernate-core/src/main/java/org/hibernate/query/results/internal/complete/CompleteResultBuilderBasicValuedStandard.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/results/internal/complete/CompleteResultBuilderBasicValuedStandard.java
@@ -4,7 +4,6 @@
  */
 package org.hibernate.query.results.internal.complete;
 
-import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.metamodel.mapping.BasicValuedMapping;
 import org.hibernate.query.results.ResultBuilder;
 import org.hibernate.query.results.internal.DomainResultCreationStateImpl;
@@ -16,6 +15,7 @@ import org.hibernate.sql.results.graph.DomainResultCreationState;
 import org.hibernate.sql.results.graph.basic.BasicResult;
 import org.hibernate.sql.results.jdbc.spi.JdbcValuesMetadata;
 import org.hibernate.type.descriptor.java.JavaType;
+import org.hibernate.type.spi.TypeConfiguration;
 
 import java.util.Objects;
 
@@ -90,7 +90,7 @@ public class CompleteResultBuilderBasicValuedStandard implements CompleteResultB
 			JdbcValuesMetadata jdbcResultsMetadata,
 			DomainResultCreationStateImpl creationStateImpl,
 			String columnName, int jdbcPosition) {
-		final SessionFactoryImplementor sessionFactory = creationStateImpl.getSessionFactory();
+		final TypeConfiguration typeConfiguration = creationStateImpl.getCreationContext().getTypeConfiguration();
 		return creationStateImpl.resolveSqlSelection(
 				creationStateImpl.resolveSqlExpression(
 						SqlExpressionResolver.createColumnReferenceKey( columnName ),
@@ -103,7 +103,7 @@ public class CompleteResultBuilderBasicValuedStandard implements CompleteResultB
 								basicType = jdbcResultsMetadata.resolveType(
 										jdbcPosition,
 										explicitJavaType,
-										sessionFactory
+										typeConfiguration
 								);
 							}
 							final int valuesArrayPosition = ResultsHelper.jdbcPositionToValuesArrayPosition( jdbcPosition );
@@ -112,7 +112,7 @@ public class CompleteResultBuilderBasicValuedStandard implements CompleteResultB
 				),
 				explicitJavaType,
 				null,
-				sessionFactory.getTypeConfiguration()
+				typeConfiguration
 		);
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/query/results/internal/dynamic/DynamicFetchBuilderLegacy.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/results/internal/dynamic/DynamicFetchBuilderLegacy.java
@@ -316,8 +316,7 @@ public class DynamicFetchBuilderLegacy
 				),
 				selectableMapping.getJdbcMapping().getJdbcJavaType(),
 				null,
-				domainResultCreationState.getSqlAstCreationState().getCreationContext()
-						.getSessionFactory().getTypeConfiguration()
+				domainResultCreationState.getSqlAstCreationState().getCreationContext().getTypeConfiguration()
 		);
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/query/results/internal/dynamic/DynamicFetchBuilderStandard.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/results/internal/dynamic/DynamicFetchBuilderStandard.java
@@ -193,8 +193,7 @@ public class DynamicFetchBuilderStandard
 					),
 					selectableMapping.getJdbcMapping().getJdbcJavaType(),
 					null,
-					domainResultCreationState.getSqlAstCreationState().getCreationContext()
-							.getSessionFactory().getTypeConfiguration()
+					domainResultCreationState.getSqlAstCreationState().getCreationContext().getTypeConfiguration()
 			);
 		};
 	}

--- a/hibernate-core/src/main/java/org/hibernate/query/results/internal/dynamic/DynamicResultBuilderAttribute.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/results/internal/dynamic/DynamicResultBuilderAttribute.java
@@ -103,8 +103,7 @@ public class DynamicResultBuilderAttribute implements DynamicResultBuilder, Nati
 				),
 				attributeMapping.getJdbcMapping().getJdbcJavaType(),
 				null,
-				domainResultCreationState.getSqlAstCreationState().getCreationContext()
-						.getSessionFactory().getTypeConfiguration()
+				domainResultCreationState.getSqlAstCreationState().getCreationContext().getTypeConfiguration()
 		);
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/query/results/internal/dynamic/DynamicResultBuilderBasicConverted.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/results/internal/dynamic/DynamicResultBuilderBasicConverted.java
@@ -21,6 +21,7 @@ import org.hibernate.type.BasicType;
 import org.hibernate.type.descriptor.converter.internal.JpaAttributeConverterImpl;
 import org.hibernate.type.descriptor.converter.spi.BasicValueConverter;
 import org.hibernate.type.descriptor.java.spi.JavaTypeRegistry;
+import org.hibernate.type.spi.TypeConfiguration;
 
 import java.util.Objects;
 
@@ -82,7 +83,7 @@ public class DynamicResultBuilderBasicConverted<O,R> implements DynamicResultBui
 			int resultPosition,
 			DomainResultCreationState domainResultCreationState) {
 		final SqlAstCreationState sqlAstCreationState = domainResultCreationState.getSqlAstCreationState();
-		final SessionFactoryImplementor sessionFactory = sqlAstCreationState.getCreationContext().getSessionFactory();
+		final TypeConfiguration typeConfiguration = sqlAstCreationState.getCreationContext().getTypeConfiguration();
 		final SqlExpressionResolver sqlExpressionResolver = sqlAstCreationState.getSqlExpressionResolver();
 
 		final String columnName =
@@ -92,12 +93,11 @@ public class DynamicResultBuilderBasicConverted<O,R> implements DynamicResultBui
 		final SqlSelection sqlSelection = sqlExpressionResolver.resolveSqlSelection(
 				sqlExpressionResolver.resolveSqlExpression(
 						SqlExpressionResolver.createColumnReferenceKey( columnName ),
-						state ->
-								resultSetMappingSqlSelection( jdbcResultsMetadata, resultPosition, sessionFactory )
+						state -> resultSetMappingSqlSelection( jdbcResultsMetadata, resultPosition, typeConfiguration )
 				),
 				basicValueConverter.getRelationalJavaType(),
 				null,
-				sessionFactory.getTypeConfiguration()
+				typeConfiguration
 		);
 
 		return new BasicResult<>(
@@ -112,7 +112,7 @@ public class DynamicResultBuilderBasicConverted<O,R> implements DynamicResultBui
 	}
 
 	private ResultSetMappingSqlSelection resultSetMappingSqlSelection(
-			JdbcValuesMetadata jdbcResultsMetadata, int resultPosition, SessionFactoryImplementor sessionFactory) {
+			JdbcValuesMetadata jdbcResultsMetadata, int resultPosition, TypeConfiguration typeConfiguration) {
 		final int jdbcPosition =
 				columnAlias != null
 						? jdbcResultsMetadata.resolveColumnPosition( columnAlias )
@@ -120,7 +120,7 @@ public class DynamicResultBuilderBasicConverted<O,R> implements DynamicResultBui
 		final BasicType<?> basicType = jdbcResultsMetadata.resolveType(
 				jdbcPosition,
 				basicValueConverter.getRelationalJavaType(),
-				sessionFactory
+				typeConfiguration
 		);
 		final int valuesArrayPosition = ResultsHelper.jdbcPositionToValuesArrayPosition( jdbcPosition );
 		return new ResultSetMappingSqlSelection( valuesArrayPosition, (BasicValuedMapping) basicType );

--- a/hibernate-core/src/main/java/org/hibernate/query/results/internal/dynamic/DynamicResultBuilderBasicStandard.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/results/internal/dynamic/DynamicResultBuilderBasicStandard.java
@@ -4,7 +4,6 @@
  */
 package org.hibernate.query.results.internal.dynamic;
 
-import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.metamodel.mapping.BasicValuedMapping;
 import org.hibernate.metamodel.mapping.JdbcMapping;
 import org.hibernate.query.NativeQuery;
@@ -20,6 +19,7 @@ import org.hibernate.sql.results.jdbc.spi.JdbcValuesMetadata;
 import org.hibernate.type.BasicType;
 import org.hibernate.type.descriptor.converter.spi.BasicValueConverter;
 import org.hibernate.type.descriptor.java.JavaType;
+import org.hibernate.type.spi.TypeConfiguration;
 
 import java.util.Objects;
 
@@ -120,12 +120,12 @@ public class DynamicResultBuilderBasicStandard implements DynamicResultBuilderBa
 			int resultPosition,
 			DomainResultCreationState domainResultCreationState) {
 		final SqlAstCreationState sqlAstCreationState = domainResultCreationState.getSqlAstCreationState();
-		final SessionFactoryImplementor sessionFactory = sqlAstCreationState.getCreationContext().getSessionFactory();
+		final TypeConfiguration typeConfiguration = sqlAstCreationState.getCreationContext().getTypeConfiguration();
 		final SqlExpressionResolver sqlExpressionResolver = sqlAstCreationState.getSqlExpressionResolver();
 
 		final Expression expression = sqlExpressionResolver.resolveSqlExpression(
 				SqlExpressionResolver.createColumnReferenceKey( columnName ),
-				state -> resultSetMappingSqlSelection( jdbcResultsMetadata, sessionFactory )
+				state -> resultSetMappingSqlSelection( jdbcResultsMetadata, typeConfiguration )
 		);
 
 		final JavaType<?> javaType;
@@ -146,7 +146,7 @@ public class DynamicResultBuilderBasicStandard implements DynamicResultBuilderBa
 				expression,
 				jdbcJavaType,
 				null,
-				sessionFactory.getTypeConfiguration()
+				typeConfiguration
 		);
 
 		// StandardRowReader expects there to be a JavaType as part of the ResultAssembler.
@@ -164,7 +164,7 @@ public class DynamicResultBuilderBasicStandard implements DynamicResultBuilderBa
 	}
 
 	private ResultSetMappingSqlSelection resultSetMappingSqlSelection(
-			JdbcValuesMetadata jdbcResultsMetadata, SessionFactoryImplementor sessionFactory) {
+			JdbcValuesMetadata jdbcResultsMetadata, TypeConfiguration typeConfiguration) {
 		final int jdbcPosition =
 				columnPosition > 0
 						? columnPosition
@@ -173,7 +173,7 @@ public class DynamicResultBuilderBasicStandard implements DynamicResultBuilderBa
 		final BasicType<?> basicType =
 				explicitType != null
 						? explicitType
-						: jdbcResultsMetadata.resolveType( jdbcPosition, explicitJavaType, sessionFactory );
+						: jdbcResultsMetadata.resolveType( jdbcPosition, explicitJavaType, typeConfiguration );
 		return new ResultSetMappingSqlSelection( valuesArrayPosition, (BasicValuedMapping) basicType );
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/query/results/internal/dynamic/DynamicResultBuilderEntityStandard.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/results/internal/dynamic/DynamicResultBuilderEntityStandard.java
@@ -297,9 +297,7 @@ public class DynamicResultBuilderEntityStandard
 				),
 				discriminatorMapping.getJdbcMapping().getJdbcJavaType(),
 				null,
-				domainResultCreationState.getSqlAstCreationState()
-						.getCreationContext()
-						.getSessionFactory()
+				domainResultCreationState.getSqlAstCreationState().getCreationContext()
 						.getTypeConfiguration()
 		);
 	}
@@ -325,9 +323,7 @@ public class DynamicResultBuilderEntityStandard
 				),
 				selectableMapping.getJdbcMapping().getJdbcJavaType(),
 				null,
-				domainResultCreationState.getSqlAstCreationState()
-						.getCreationContext()
-						.getSessionFactory()
+				domainResultCreationState.getSqlAstCreationState().getCreationContext()
 						.getTypeConfiguration()
 		);
 	}

--- a/hibernate-core/src/main/java/org/hibernate/query/results/internal/implicit/ImplicitFetchBuilderBasic.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/results/internal/implicit/ImplicitFetchBuilderBasic.java
@@ -103,7 +103,7 @@ public class ImplicitFetchBuilderBasic implements ImplicitFetchBuilder, FetchBui
 				fetchable.getJdbcMapping().getJdbcJavaType(),
 				parent,
 				domainResultCreationState.getSqlAstCreationState().getCreationContext()
-						.getSessionFactory().getTypeConfiguration()
+						.getTypeConfiguration()
 		);
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/query/results/internal/implicit/ImplicitResultClassBuilder.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/results/internal/implicit/ImplicitResultClassBuilder.java
@@ -5,7 +5,6 @@
 package org.hibernate.query.results.internal.implicit;
 
 import jakarta.persistence.NamedNativeQuery;
-import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.metamodel.mapping.BasicValuedMapping;
 import org.hibernate.query.results.ResultBuilder;
 import org.hibernate.query.results.internal.ResultSetMappingSqlSelection;
@@ -40,8 +39,7 @@ public class ImplicitResultClassBuilder implements ResultBuilder {
 		assert resultPosition == 0;
 
 		final SqlAstCreationState sqlAstCreationState = domainResultCreationState.getSqlAstCreationState();
-		final SessionFactoryImplementor sessionFactory = sqlAstCreationState.getCreationContext().getSessionFactory();
-		final TypeConfiguration typeConfiguration = sessionFactory.getTypeConfiguration();
+		final TypeConfiguration typeConfiguration = sqlAstCreationState.getCreationContext().getTypeConfiguration();
 		final SqlExpressionResolver sqlExpressionResolver = sqlAstCreationState.getSqlExpressionResolver();
 
 		final int jdbcResultPosition = 1;

--- a/hibernate-core/src/main/java/org/hibernate/query/spi/AbstractCommonQueryContract.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/spi/AbstractCommonQueryContract.java
@@ -767,7 +767,8 @@ public abstract class AbstractCommonQueryContract implements CommonQueryContract
 
 
 	private boolean isInstance(BindableType<?> parameterType, Object value) {
-		final SqmExpressible<?> sqmExpressible = parameterType.resolveExpressible( getSession().getFactory() );
+		final SqmExpressible<?> sqmExpressible =
+				parameterType.resolveExpressible( getSession().getFactory().getQueryEngine().getCriteriaBuilder() );
 		assert sqmExpressible != null;
 
 		return sqmExpressible.getExpressibleJavaType().isInstance( value );

--- a/hibernate-core/src/main/java/org/hibernate/query/spi/QueryEngine.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/spi/QueryEngine.java
@@ -5,13 +5,16 @@
 package org.hibernate.query.spi;
 
 import org.hibernate.Incubating;
+import org.hibernate.Internal;
+import org.hibernate.boot.registry.classloading.spi.ClassLoaderService;
+import org.hibernate.dialect.Dialect;
 import org.hibernate.engine.query.spi.NativeQueryInterpreter;
+import org.hibernate.query.BindingContext;
 import org.hibernate.query.hql.HqlTranslator;
 import org.hibernate.query.named.NamedObjectRepository;
 import org.hibernate.query.sqm.NodeBuilder;
 import org.hibernate.query.sqm.function.SqmFunctionRegistry;
 import org.hibernate.query.sqm.sql.SqmTranslatorFactory;
-import org.hibernate.type.spi.TypeConfiguration;
 
 /**
  * Aggregation and encapsulation of the components Hibernate uses
@@ -21,7 +24,7 @@ import org.hibernate.type.spi.TypeConfiguration;
  * @author Gavin King
  */
 @Incubating
-public interface QueryEngine {
+public interface QueryEngine extends BindingContext {
 
 	/**
 	 * The default soft reference count.
@@ -34,9 +37,9 @@ public interface QueryEngine {
 
 	SqmFunctionRegistry getSqmFunctionRegistry();
 
-	TypeConfiguration getTypeConfiguration();
-
 	NodeBuilder getCriteriaBuilder();
+
+	Dialect getDialect();
 
 	void close();
 
@@ -47,6 +50,12 @@ public interface QueryEngine {
 	HqlTranslator getHqlTranslator();
 
 	SqmTranslatorFactory getSqmTranslatorFactory();
+
+	/**
+	 * Avoid use of this, because Hibernate Processor can't do class loading
+	 */
+	@Internal
+	ClassLoaderService getClassLoaderService();
 
 	default <R> HqlInterpretation<R> interpretHql(String hql, Class<R> resultType) {
 		return getInterpretationCache().resolveHqlInterpretation( hql, resultType, getHqlTranslator() );

--- a/hibernate-core/src/main/java/org/hibernate/query/sql/internal/SqlTranslationEngineImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sql/internal/SqlTranslationEngineImpl.java
@@ -1,0 +1,60 @@
+/*
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.query.sql.internal;
+
+import org.hibernate.engine.profile.FetchProfile;
+import org.hibernate.engine.spi.SessionFactoryImplementor;
+import org.hibernate.metamodel.model.domain.JpaMetamodel;
+import org.hibernate.metamodel.spi.MappingMetamodelImplementor;
+import org.hibernate.query.sql.spi.SqlTranslationEngine;
+import org.hibernate.type.spi.TypeConfiguration;
+
+public class SqlTranslationEngineImpl implements SqlTranslationEngine {
+
+	//TODO: consider unifying with SqlStringGenerationContextImpl
+
+	private final SessionFactoryImplementor factory;
+	private final TypeConfiguration typeConfiguration;
+
+	public SqlTranslationEngineImpl(SessionFactoryImplementor factory, TypeConfiguration typeConfiguration) {
+		this.factory = factory;
+		this.typeConfiguration = typeConfiguration;
+	}
+
+	@Override
+	public SessionFactoryImplementor getSessionFactory() {
+		return factory;
+	}
+
+	@Override
+	public MappingMetamodelImplementor getMappingMetamodel() {
+		return factory.getMappingMetamodel();
+	}
+
+	@Override
+	public Integer getMaximumFetchDepth() {
+		return factory.getSessionFactoryOptions().getMaximumFetchDepth();
+	}
+
+	@Override
+	public boolean isJpaQueryComplianceEnabled() {
+		return factory.getSessionFactoryOptions().getJpaCompliance().isJpaQueryComplianceEnabled();
+	}
+
+	@Override
+	public JpaMetamodel getJpaMetamodel() {
+		return factory.getJpaMetamodel();
+	}
+
+	@Override
+	public FetchProfile getFetchProfile(String name) {
+		return factory.getFetchProfile( name );
+	}
+
+	@Override
+	public TypeConfiguration getTypeConfiguration() {
+		return typeConfiguration;
+	}
+}

--- a/hibernate-core/src/main/java/org/hibernate/query/sql/internal/SqlTranslationEngineImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sql/internal/SqlTranslationEngineImpl.java
@@ -11,16 +11,31 @@ import org.hibernate.metamodel.spi.MappingMetamodelImplementor;
 import org.hibernate.query.sql.spi.SqlTranslationEngine;
 import org.hibernate.type.spi.TypeConfiguration;
 
+import java.util.Map;
+import java.util.Set;
+
+import static java.util.Collections.unmodifiableSet;
+
 public class SqlTranslationEngineImpl implements SqlTranslationEngine {
 
 	//TODO: consider unifying with SqlStringGenerationContextImpl
 
 	private final SessionFactoryImplementor factory;
 	private final TypeConfiguration typeConfiguration;
+	private final Map<String, FetchProfile> fetchProfiles;
 
-	public SqlTranslationEngineImpl(SessionFactoryImplementor factory, TypeConfiguration typeConfiguration) {
+	public SqlTranslationEngineImpl(
+			SessionFactoryImplementor factory,
+			TypeConfiguration typeConfiguration,
+			Map<String, FetchProfile> fetchProfiles) {
 		this.factory = factory;
 		this.typeConfiguration = typeConfiguration;
+		this.fetchProfiles = fetchProfiles;
+	}
+
+	@Override
+	public TypeConfiguration getTypeConfiguration() {
+		return typeConfiguration;
 	}
 
 	@Override
@@ -50,11 +65,16 @@ public class SqlTranslationEngineImpl implements SqlTranslationEngine {
 
 	@Override
 	public FetchProfile getFetchProfile(String name) {
-		return factory.getFetchProfile( name );
+		return fetchProfiles.get( name );
 	}
 
 	@Override
-	public TypeConfiguration getTypeConfiguration() {
-		return typeConfiguration;
+	public boolean containsFetchProfileDefinition(String name) {
+		return fetchProfiles.containsKey( name );
+	}
+
+	@Override
+	public Set<String> getDefinedFetchProfileNames() {
+		return unmodifiableSet( fetchProfiles.keySet() );
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/query/sql/spi/SqlTranslationEngine.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sql/spi/SqlTranslationEngine.java
@@ -1,0 +1,22 @@
+/*
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.query.sql.spi;
+
+import org.hibernate.Incubating;
+import org.hibernate.sql.ast.spi.SqlAstCreationContext;
+
+/**
+ * Introduced as an analog of {@link org.hibernate.query.spi.QueryEngine}
+ * and/or {@link org.hibernate.query.sqm.NodeBuilder} for the SQL
+ * translation and rendering phases. For now there is nothing here.
+ *
+ * @since 7.0
+ *
+ * @author Gavin King
+ */
+@Incubating
+public interface SqlTranslationEngine extends SqlAstCreationContext {
+	// TODO: consider implementing SqlStringGenerationContext
+}

--- a/hibernate-core/src/main/java/org/hibernate/query/sql/spi/SqlTranslationEngine.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sql/spi/SqlTranslationEngine.java
@@ -7,6 +7,8 @@ package org.hibernate.query.sql.spi;
 import org.hibernate.Incubating;
 import org.hibernate.sql.ast.spi.SqlAstCreationContext;
 
+import java.util.Set;
+
 /**
  * Introduced as an analog of {@link org.hibernate.query.spi.QueryEngine}
  * and/or {@link org.hibernate.query.sqm.NodeBuilder} for the SQL
@@ -19,4 +21,8 @@ import org.hibernate.sql.ast.spi.SqlAstCreationContext;
 @Incubating
 public interface SqlTranslationEngine extends SqlAstCreationContext {
 	// TODO: consider implementing SqlStringGenerationContext
+
+	boolean containsFetchProfileDefinition(String name);
+
+	Set<String> getDefinedFetchProfileNames();
 }

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/NodeBuilder.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/NodeBuilder.java
@@ -21,7 +21,6 @@ import org.hibernate.jpa.spi.JpaCompliance;
 import org.hibernate.metamodel.model.domain.JpaMetamodel;
 import org.hibernate.query.ImmutableEntityUpdateQueryHandlingMode;
 import org.hibernate.query.NullPrecedence;
-import org.hibernate.query.BindingContext;
 import org.hibernate.query.SortDirection;
 import org.hibernate.query.criteria.HibernateCriteriaBuilder;
 import org.hibernate.query.criteria.JpaCastTarget;
@@ -35,7 +34,7 @@ import org.hibernate.query.criteria.JpaSearchedCase;
 import org.hibernate.query.criteria.JpaSelection;
 import org.hibernate.query.criteria.JpaSimpleCase;
 import org.hibernate.query.criteria.JpaWindow;
-import org.hibernate.query.spi.QueryEngine;
+import org.hibernate.query.sqm.spi.SqmCreationContext;
 import org.hibernate.query.sqm.tree.delete.SqmDeleteStatement;
 import org.hibernate.query.sqm.tree.domain.SqmBagJoin;
 import org.hibernate.query.sqm.tree.domain.SqmListJoin;
@@ -66,7 +65,6 @@ import org.hibernate.query.sqm.tree.select.SqmSortSpecification;
 import org.hibernate.query.sqm.tree.select.SqmSubQuery;
 import org.hibernate.query.sqm.tree.update.SqmUpdateStatement;
 import org.hibernate.type.BasicType;
-import org.hibernate.type.spi.TypeConfiguration;
 
 import jakarta.persistence.Tuple;
 import jakarta.persistence.criteria.CollectionJoin;
@@ -88,14 +86,19 @@ import jakarta.persistence.criteria.Subquery;
  * @author Steve Ebersole
  */
 @SuppressWarnings("unchecked")
-public interface NodeBuilder extends HibernateCriteriaBuilder, BindingContext {
-	JpaMetamodel getDomainModel();
+public interface NodeBuilder extends HibernateCriteriaBuilder, SqmCreationContext {
+	default JpaMetamodel getDomainModel() {
+		return getJpaMetamodel();
+	}
 
-	TypeConfiguration getTypeConfiguration();
+	default boolean isJpaQueryComplianceEnabled() {
+		return getJpaCompliance().isJpaQueryComplianceEnabled();
+	}
 
-	boolean isJpaQueryComplianceEnabled();
-
-	QueryEngine getQueryEngine();
+	@Override
+	default NodeBuilder getNodeBuilder() {
+		return this;
+	}
 
 	<R> SqmTuple<R> tuple(
 			Class<R> tupleType,

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/function/AbstractSqmFunctionDescriptor.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/function/AbstractSqmFunctionDescriptor.java
@@ -98,7 +98,7 @@ public abstract class AbstractSqmFunctionDescriptor implements SqmFunctionDescri
 			List<? extends SqmTypedNode<?>> arguments,
 			ReturnableType<T> impliedResultType,
 			QueryEngine queryEngine) {
-		argumentsValidator.validate( arguments, getName(), queryEngine.getTypeConfiguration() );
+		argumentsValidator.validate( arguments, getName(), queryEngine );
 
 		return generateSqmFunctionExpression(
 				arguments,
@@ -113,7 +113,7 @@ public abstract class AbstractSqmFunctionDescriptor implements SqmFunctionDescri
 			SqmPredicate filter,
 			ReturnableType<T> impliedResultType,
 			QueryEngine queryEngine) {
-		argumentsValidator.validate( arguments, getName(), queryEngine.getTypeConfiguration() );
+		argumentsValidator.validate( arguments, getName(), queryEngine );
 
 		return generateSqmAggregateFunctionExpression(
 				arguments,
@@ -130,7 +130,7 @@ public abstract class AbstractSqmFunctionDescriptor implements SqmFunctionDescri
 			SqmOrderByClause withinGroupClause,
 			ReturnableType<T> impliedResultType,
 			QueryEngine queryEngine) {
-		argumentsValidator.validate( arguments, getName(), queryEngine.getTypeConfiguration() );
+		argumentsValidator.validate( arguments, getName(), queryEngine );
 
 		return generateSqmOrderedSetAggregateFunctionExpression(
 				arguments,
@@ -149,7 +149,7 @@ public abstract class AbstractSqmFunctionDescriptor implements SqmFunctionDescri
 			Boolean fromFirst,
 			ReturnableType<T> impliedResultType,
 			QueryEngine queryEngine) {
-		argumentsValidator.validate( arguments, getName(), queryEngine.getTypeConfiguration() );
+		argumentsValidator.validate( arguments, getName(), queryEngine );
 
 		return generateSqmWindowFunctionExpression(
 				arguments,

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/function/AbstractSqmSetReturningFunctionDescriptor.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/function/AbstractSqmSetReturningFunctionDescriptor.java
@@ -82,7 +82,7 @@ public abstract class AbstractSqmSetReturningFunctionDescriptor implements SqmSe
 	public final <T> SelfRenderingSqmSetReturningFunction<T> generateSqmExpression(
 			List<? extends SqmTypedNode<?>> arguments,
 			QueryEngine queryEngine) {
-		argumentsValidator.validate( arguments, getName(), queryEngine.getTypeConfiguration() );
+		argumentsValidator.validate( arguments, getName(), queryEngine );
 
 		return generateSqmSetReturningFunctionExpression( arguments, queryEngine );
 	}

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/function/SelfRenderingSqmFunction.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/function/SelfRenderingSqmFunction.java
@@ -201,10 +201,8 @@ public class SelfRenderingSqmFunction<T> extends SqmFunction<T> {
 			mapping = returnTypeResolver.resolveFunctionReturnType(
 					() -> {
 						try {
-							final MappingMetamodelImplementor domainModel = walker.getCreationContext()
-									.getSessionFactory()
-									.getRuntimeMetamodels()
-									.getMappingMetamodel();
+							final MappingMetamodelImplementor domainModel =
+									walker.getCreationContext().getMappingMetamodel();
 							return (BasicValuedMapping) domainModel.resolveMappingExpressible(
 									getNodeType(),
 									walker.getFromClauseAccess()::getTableGroup

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/function/SelfRenderingSqmSetReturningFunction.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/function/SelfRenderingSqmSetReturningFunction.java
@@ -225,7 +225,8 @@ public class SelfRenderingSqmSetReturningFunction<T> extends SqmSetReturningFunc
 				tableGroupProducer.getCompatibleTableExpressions(),
 				lateral,
 				canUseInnerJoins,
-				getFunctionRenderer().rendersIdentifierVariable( arguments, walker.getCreationContext().getSessionFactory() ),
+				getFunctionRenderer()
+						.rendersIdentifierVariable( arguments, walker.getCreationContext().getSessionFactory() ),
 				walker.getCreationContext().getSessionFactory()
 		);
 	}

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/internal/ConcreteSqmSelectQueryPlan.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/internal/ConcreteSqmSelectQueryPlan.java
@@ -479,7 +479,7 @@ public class ConcreteSqmSelectQueryPlan<R> implements SelectQueryPlan<R> {
 								domainParameterXref,
 								executionContext.getQueryParameterBindings(),
 								executionContext.getSession().getLoadQueryInfluencers(),
-								sessionFactory,
+								sessionFactory.getSqlTranslationEngine(),
 								true
 						)
 						.translate();

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/internal/SimpleDeleteQueryPlan.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/internal/SimpleDeleteQueryPlan.java
@@ -194,14 +194,15 @@ public class SimpleDeleteQueryPlan implements NonSelectQueryPlan {
 
 	protected SqlAstTranslator<? extends JdbcOperationQueryMutation> createTranslator(DomainQueryExecutionContext executionContext) {
 		final SessionFactoryImplementor factory = executionContext.getSession().getFactory();
-		final SqmTranslator<? extends MutationStatement> translator = factory.getQueryEngine().getSqmTranslatorFactory().createMutationTranslator(
-				sqmDelete,
-				executionContext.getQueryOptions(),
-				domainParameterXref,
-				executionContext.getQueryParameterBindings(),
-				executionContext.getSession().getLoadQueryInfluencers(),
-				factory
-		);
+		final SqmTranslator<? extends MutationStatement> translator =
+				factory.getQueryEngine().getSqmTranslatorFactory().createMutationTranslator(
+						sqmDelete,
+						executionContext.getQueryOptions(),
+						domainParameterXref,
+						executionContext.getQueryParameterBindings(),
+						executionContext.getSession().getLoadQueryInfluencers(),
+						factory.getSqlTranslationEngine()
+				);
 		//noinspection unchecked
 		sqmInterpretation = (SqmTranslation<? extends AbstractUpdateOrDeleteStatement>) translator.translate();
 

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/internal/SimpleInsertQueryPlan.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/internal/SimpleInsertQueryPlan.java
@@ -46,14 +46,15 @@ public class SimpleInsertQueryPlan implements NonSelectQueryPlan {
 	private SqlAstTranslator<? extends JdbcOperationQueryMutation> createInsertTranslator(DomainQueryExecutionContext executionContext) {
 		final SessionFactoryImplementor factory = executionContext.getSession().getFactory();
 
-		final SqmTranslation<? extends MutationStatement> sqmInterpretation = factory.getQueryEngine().getSqmTranslatorFactory()
-				.createMutationTranslator(
+		final SqmTranslation<? extends MutationStatement> sqmInterpretation =
+				factory.getQueryEngine().getSqmTranslatorFactory()
+						.createMutationTranslator(
 								sqmInsert,
 								executionContext.getQueryOptions(),
 								domainParameterXref,
 								executionContext.getQueryParameterBindings(),
 								executionContext.getSession().getLoadQueryInfluencers(),
-								factory
+								factory.getSqlTranslationEngine()
 						)
 						.translate();
 

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/internal/SimpleUpdateQueryPlan.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/internal/SimpleUpdateQueryPlan.java
@@ -101,7 +101,7 @@ public class SimpleUpdateQueryPlan implements NonSelectQueryPlan {
 								domainParameterXref,
 								executionContext.getQueryParameterBindings(),
 								executionContext.getSession().getLoadQueryInfluencers(),
-								factory
+								factory.getSqlTranslationEngine()
 						)
 						.translate();
 

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/internal/SqmCriteriaNodeBuilder.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/internal/SqmCriteriaNodeBuilder.java
@@ -210,12 +210,16 @@ public class SqmCriteriaNodeBuilder implements NodeBuilder, Serializable {
 		this.criteriaValueHandlingMode = options.getCriteriaValueHandlingMode();
 		this.immutableEntityUpdateQueryHandlingMode = options.getImmutableEntityUpdateQueryHandlingMode();
 		this.bindingContext = bindingContext;
+		this.extensions = loadExtensions();
+	}
+
+	private Map<Class<? extends HibernateCriteriaBuilder>, HibernateCriteriaBuilder> loadExtensions() {
 		// load registered criteria builder extensions
-		this.extensions = new HashMap<>();
+		final Map<Class<? extends HibernateCriteriaBuilder>, HibernateCriteriaBuilder> extensions = new HashMap<>();
 		for ( CriteriaBuilderExtension extension : ServiceLoader.load( CriteriaBuilderExtension.class ) ) {
-			HibernateCriteriaBuilder builder = extension.extend( this );
-			extensions.put( extension.getRegistrationKey(), builder );
+			extensions.put( extension.getRegistrationKey(), extension.extend( this ) );
 		}
+		return extensions;
 	}
 
 	@Override
@@ -225,7 +229,7 @@ public class SqmCriteriaNodeBuilder implements NodeBuilder, Serializable {
 
 	@Override
 	public TypeConfiguration getTypeConfiguration() {
-		return getQueryEngine().getTypeConfiguration();
+		return bindingContext.getTypeConfiguration();
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/internal/SqmMappingModelHelper.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/internal/SqmMappingModelHelper.java
@@ -6,7 +6,6 @@ package org.hibernate.query.sqm.internal;
 
 import java.util.function.Function;
 
-import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.metamodel.MappingMetamodel;
 import org.hibernate.metamodel.mapping.CollectionPart;
 import org.hibernate.metamodel.mapping.EntityMappingType;
@@ -59,11 +58,10 @@ public class SqmMappingModelHelper {
 	 */
 	public static EntityPersister resolveEntityPersister(
 			EntityDomainType<?> entityType,
-			SessionFactoryImplementor sessionFactory) {
+			MappingMetamodel mappingMetamodel) {
 		// Our EntityTypeImpl#getType impl returns the Hibernate entity-name
 		// which is exactly what we want
-		final String hibernateEntityName = entityType.getHibernateEntityName();
-		return sessionFactory.getRuntimeMetamodels().getMappingMetamodel().getEntityDescriptor( hibernateEntityName );
+		return mappingMetamodel.getEntityDescriptor( entityType.getHibernateEntityName() );
 	}
 
 	public static <J> SqmPathSource<J> resolveSqmKeyPathSource(
@@ -258,7 +256,7 @@ public class SqmMappingModelHelper {
 			if ( treatTarget.getPersistenceType() == Type.PersistenceType.ENTITY ) {
 				return resolveEntityPersister(
 						( (EntityDomainType<?>) treatTarget ),
-						converter.getCreationContext().getSessionFactory()
+						converter.getCreationContext().getMappingMetamodel()
 				);
 			}
 		}

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/mutation/internal/ExpressionDomainResultProducer.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/mutation/internal/ExpressionDomainResultProducer.java
@@ -58,7 +58,7 @@ public class ExpressionDomainResultProducer implements DomainResultProducer<Obje
 				expression,
 				expression.getExpressionType().getSingleJdbcMapping().getJdbcJavaType(),
 				null,
-				sqlAstCreationState.getCreationContext().getSessionFactory().getTypeConfiguration()
+				sqlAstCreationState.getCreationContext().getTypeConfiguration()
 		);
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/mutation/internal/MatchingIdSelectionHelper.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/mutation/internal/MatchingIdSelectionHelper.java
@@ -265,7 +265,7 @@ public class MatchingIdSelectionHelper {
 						domainParameterXref,
 						executionContext.getQueryParameterBindings(),
 						executionContext.getSession().getLoadQueryInfluencers(),
-						factory,
+						factory.getSqlTranslationEngine(),
 						true
 				);
 		final SqmTranslation<SelectStatement> translation = translator.translate();

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/mutation/internal/cte/AbstractCteMutationHandler.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/mutation/internal/cte/AbstractCteMutationHandler.java
@@ -19,6 +19,7 @@ import org.hibernate.metamodel.mapping.MappingModelExpressible;
 import org.hibernate.metamodel.mapping.ModelPart;
 import org.hibernate.metamodel.mapping.SqlExpressible;
 import org.hibernate.query.spi.DomainQueryExecutionContext;
+import org.hibernate.query.spi.QueryEngine;
 import org.hibernate.query.sqm.internal.DomainParameterXref;
 import org.hibernate.query.sqm.internal.SqmJdbcExecutionContextAdapter;
 import org.hibernate.query.sqm.internal.SqmUtil;
@@ -119,7 +120,7 @@ public abstract class AbstractCteMutationHandler extends AbstractMutationHandler
 				executionContext.getQueryOptions(),
 				executionContext.getSession().getLoadQueryInfluencers(),
 				executionContext.getQueryParameterBindings(),
-				factory
+				factory.getSqlTranslationEngine()
 		);
 		final Map<SqmParameter<?>, List<JdbcParameter>> parameterResolutions;
 		if ( domainParameterXref.getSqmParameterCount() == 0 ) {
@@ -214,12 +215,12 @@ public abstract class AbstractCteMutationHandler extends AbstractMutationHandler
 	protected Expression createCountStar(
 			SessionFactoryImplementor factory,
 			MultiTableSqmMutationConverter sqmConverter) {
-		final SqmExpression<?> arg = new SqmStar( factory.getNodeBuilder() );
-		return factory.getQueryEngine().getSqmFunctionRegistry().findFunctionDescriptor( "count" ).generateSqmExpression(
-				arg,
-				null,
-				factory.getQueryEngine()
-		).convertToSqlAst( sqmConverter );
+		final QueryEngine queryEngine = factory.getQueryEngine();
+		final SqmExpression<?> arg = new SqmStar( queryEngine.getCriteriaBuilder() );
+		return queryEngine.getSqmFunctionRegistry()
+				.findFunctionDescriptor( "count" )
+				.generateSqmExpression( arg, null, queryEngine )
+				.convertToSqlAst( sqmConverter );
 	}
 
 	protected Predicate createIdSubQueryPredicate(

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/mutation/internal/cte/CteInsertHandler.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/mutation/internal/cte/CteInsertHandler.java
@@ -34,6 +34,7 @@ import org.hibernate.query.results.internal.TableGroupImpl;
 import org.hibernate.query.spi.DomainQueryExecutionContext;
 import org.hibernate.query.sqm.BinaryArithmeticOperator;
 import org.hibernate.query.sqm.ComparisonOperator;
+import org.hibernate.query.sqm.NodeBuilder;
 import org.hibernate.query.sqm.SetOperator;
 import org.hibernate.query.sqm.internal.DomainParameterXref;
 import org.hibernate.query.sqm.internal.SqmJdbcExecutionContextAdapter;
@@ -156,12 +157,12 @@ public class CteInsertHandler implements InsertHandler {
 		return cteTable;
 	}
 
-	public SessionFactoryImplementor getSessionFactory() {
-		return sessionFactory;
-	}
-
 	public DomainParameterXref getDomainParameterXref() {
 		return domainParameterXref;
+	}
+
+	private NodeBuilder getCriteriaBuilder() {
+		return sessionFactory.getQueryEngine().getCriteriaBuilder();
 	}
 
 	@Override
@@ -184,7 +185,7 @@ public class CteInsertHandler implements InsertHandler {
 				executionContext.getQueryOptions(),
 				executionContext.getSession().getLoadQueryInfluencers(),
 				executionContext.getQueryParameterBindings(),
-				factory
+				factory.getSqlTranslationEngine()
 		);
 		final TableGroup insertingTableGroup = sqmConverter.getMutatingTableGroup();
 
@@ -611,12 +612,10 @@ public class CteInsertHandler implements InsertHandler {
 	protected Expression createCountStar(
 			SessionFactoryImplementor factory,
 			MultiTableSqmMutationConverter sqmConverter) {
-		final SqmExpression<?> arg = new SqmStar( factory.getNodeBuilder() );
-		return factory.getQueryEngine().getSqmFunctionRegistry().findFunctionDescriptor( "count" ).generateSqmExpression(
-				arg,
-				null,
-				factory.getQueryEngine()
-		).convertToSqlAst( sqmConverter );
+		final SqmExpression<?> arg = new SqmStar( getCriteriaBuilder() );
+		return factory.getQueryEngine().getSqmFunctionRegistry().findFunctionDescriptor( "count" )
+				.generateSqmExpression( arg, null, factory.getQueryEngine() )
+				.convertToSqlAst( sqmConverter );
 	}
 
 	protected String addDmlCtes(
@@ -1032,11 +1031,12 @@ public class CteInsertHandler implements InsertHandler {
 			statement.addCteStatement( new CteStatement( dmlResultCte, insertStatement ) );
 		}
 		else {
+			final NodeBuilder nodeBuilder = getCriteriaBuilder();
 			// Build an exists subquery clause to only insert if no row with a matching constraint column value exists i.e.
 			// insert into target (c1, c2)
 			// select e.c1, e.c2 from HTE_target e
 			// where not exists (select 1 from target excluded where e.c1=excluded.c1 and e.c2=excluded.c2)
-			final BasicType<Boolean> booleanType = sessionFactory.getNodeBuilder().getBooleanType();
+			final BasicType<Boolean> booleanType = nodeBuilder.getBooleanType();
 			final List<String> constraintColumnNames = conflictClause.getConstraintColumnNames();
 			final QuerySpec insertQuerySpec = (QuerySpec) insertStatement.getSourceSelectStatement();
 			final QuerySpec subquery = new QuerySpec( false, 1 );
@@ -1057,14 +1057,14 @@ public class CteInsertHandler implements InsertHandler {
 					sessionFactory
 			);
 			subquery.getSelectClause().addSqlSelection(
-					new SqlSelectionImpl( new QueryLiteral<>( 1, sessionFactory.getNodeBuilder().getIntegerType() ) )
+					new SqlSelectionImpl( new QueryLiteral<>( 1, nodeBuilder.getIntegerType() ) )
 			);
 			subquery.getFromClause().addRoot( tableGroup );
 			List<String> columnsToMatch;
 			if ( constraintColumnNames.isEmpty() ) {
 				// Assume the primary key columns
 				Predicate predicate = buildColumnMatchPredicate(
-						columnsToMatch = Arrays.asList( ( (EntityPersister) entityDescriptor).getKeyColumns( tableIndex ) ),
+						columnsToMatch = Arrays.asList( ((EntityPersister) entityDescriptor).getKeyColumns( tableIndex ) ),
 						insertStatement,
 						false,
 						true
@@ -1157,7 +1157,7 @@ public class CteInsertHandler implements InsertHandler {
 					matchCteSubquery.getSelectClause().addSqlSelection(
 							new SqlSelectionImpl( new QueryLiteral<>(
 									1,
-									sessionFactory.getNodeBuilder().getIntegerType()
+									getCriteriaBuilder().getIntegerType()
 							) )
 					);
 					matchCteSubquery.getFromClause().addRoot( updateSubquery.getFromClause().getRoots().get( 0 ) );
@@ -1231,7 +1231,7 @@ public class CteInsertHandler implements InsertHandler {
 			InsertSelectStatement dmlStatement,
 			boolean errorIfMissing,
 			boolean compareAgainstSelectItems) {
-		final BasicType<Boolean> booleanType = sessionFactory.getNodeBuilder().getBooleanType();
+		final BasicType<Boolean> booleanType = getCriteriaBuilder().getBooleanType();
 		final QuerySpec insertQuerySpec = (QuerySpec) dmlStatement.getSourceSelectStatement();
 		Predicate predicate = null;
 		OUTER: for ( String constraintColumnName : constraintColumnNames ) {

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/mutation/internal/inline/InlineUpdateHandler.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/mutation/internal/inline/InlineUpdateHandler.java
@@ -103,17 +103,17 @@ public class InlineUpdateHandler implements UpdateHandler {
 		final List<Expression> inListExpressions = matchingIdsPredicateProducer.produceIdExpressionList( ids, entityDescriptor );
 
 		//noinspection unchecked
-		final SqmTranslation<UpdateStatement> translation = (SqmTranslation<UpdateStatement>) sessionFactory.getQueryEngine()
-				.getSqmTranslatorFactory()
-				.createMutationTranslator(
-						sqmUpdate,
-						executionContext.getQueryOptions(),
-						domainParameterXref,
-						executionContext.getQueryParameterBindings(),
-						executionContext.getSession().getLoadQueryInfluencers(),
-						sessionFactory
-				)
-				.translate();
+		final SqmTranslation<UpdateStatement> translation = (SqmTranslation<UpdateStatement>)
+				sessionFactory.getQueryEngine().getSqmTranslatorFactory()
+						.createMutationTranslator(
+								sqmUpdate,
+								executionContext.getQueryOptions(),
+								domainParameterXref,
+								executionContext.getQueryParameterBindings(),
+								executionContext.getSession().getLoadQueryInfluencers(),
+								sessionFactory.getSqlTranslationEngine()
+						)
+						.translate();
 		final TableGroup updatingTableGroup = translation.getSqlAst().getFromClause().getRoots().get( 0 );
 
 		// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/mutation/internal/temptable/AbstractDeleteExecutionDelegate.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/mutation/internal/temptable/AbstractDeleteExecutionDelegate.java
@@ -59,7 +59,7 @@ public abstract class AbstractDeleteExecutionDelegate implements TableBasedDelet
 				queryOptions,
 				loadQueryInfluencers,
 				queryParameterBindings,
-				getSessionFactory()
+				sessionFactory.getSqlTranslationEngine()
 		);
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/mutation/internal/temptable/InsertExecutionDelegate.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/mutation/internal/temptable/InsertExecutionDelegate.java
@@ -322,7 +322,7 @@ public class InsertExecutionDelegate implements TableBasedInsertHandler.Executio
 			querySpec.setFetchClauseExpression(
 					new QueryLiteral<>(
 							1,
-							executionContext.getSession().getFactory().getNodeBuilder() .getIntegerType()
+							executionContext.getSession().getFactory().getQueryEngine().getCriteriaBuilder().getIntegerType()
 					),
 					FetchClauseType.ROWS_ONLY
 			);

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/mutation/internal/temptable/TableBasedInsertHandler.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/mutation/internal/temptable/TableBasedInsertHandler.java
@@ -124,7 +124,7 @@ public class TableBasedInsertHandler implements InsertHandler {
 				executionContext.getQueryOptions(),
 				executionContext.getSession().getLoadQueryInfluencers(),
 				executionContext.getQueryParameterBindings(),
-				sessionFactory
+				sessionFactory.getSqlTranslationEngine()
 		);
 
 		final TableGroup insertingTableGroup = converterDelegate.getMutatingTableGroup();

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/mutation/internal/temptable/TableBasedUpdateHandler.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/mutation/internal/temptable/TableBasedUpdateHandler.java
@@ -104,7 +104,7 @@ public class TableBasedUpdateHandler
 				executionContext.getQueryOptions(),
 				executionContext.getSession().getLoadQueryInfluencers(),
 				executionContext.getQueryParameterBindings(),
-				sessionFactory
+				sessionFactory.getSqlTranslationEngine()
 		);
 
 		final TableGroup updatingTableGroup = converterDelegate.getMutatingTableGroup();

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/produce/function/ArgumentTypesValidator.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/produce/function/ArgumentTypesValidator.java
@@ -11,6 +11,7 @@ import org.hibernate.Internal;
 import org.hibernate.metamodel.MappingMetamodel;
 import org.hibernate.metamodel.mapping.JdbcMapping;
 import org.hibernate.metamodel.mapping.JdbcMappingContainer;
+import org.hibernate.query.BindingContext;
 import org.hibernate.query.sqm.SqmExpressible;
 import org.hibernate.query.sqm.tree.SqmTypedNode;
 import org.hibernate.query.sqm.tree.expression.SqmCollation;
@@ -24,7 +25,6 @@ import org.hibernate.type.BasicType;
 import org.hibernate.type.JavaObjectType;
 import org.hibernate.type.descriptor.java.JavaType;
 import org.hibernate.type.descriptor.jdbc.JdbcType;
-import org.hibernate.type.spi.TypeConfiguration;
 
 import static org.hibernate.query.sqm.produce.function.FunctionParameterType.COMPARABLE;
 import static org.hibernate.type.descriptor.java.JavaTypeHelper.isUnknown;
@@ -71,8 +71,8 @@ public class ArgumentTypesValidator implements ArgumentsValidator {
 	public void validate(
 			List<? extends SqmTypedNode<?>> arguments,
 			String functionName,
-			TypeConfiguration typeConfiguration) {
-		delegate.validate( arguments, functionName, typeConfiguration);
+			BindingContext bindingContext) {
+		delegate.validate( arguments, functionName, bindingContext );
 		int count = 0;
 		for (SqmTypedNode<?> argument : arguments) {
 //			JdbcTypeIndicators indicators = typeConfiguration.getCurrentBaseSqlTypeIndicators();

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/produce/function/ArgumentsValidator.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/produce/function/ArgumentsValidator.java
@@ -4,6 +4,7 @@
  */
 package org.hibernate.query.sqm.produce.function;
 
+import org.hibernate.query.BindingContext;
 import org.hibernate.query.sqm.tree.SqmTypedNode;
 import org.hibernate.sql.ast.tree.SqlAstNode;
 import org.hibernate.type.spi.TypeConfiguration;
@@ -22,8 +23,22 @@ public interface ArgumentsValidator {
 
 	/**
 	 * Perform validation that may be done using the {@link SqmTypedNode} tree and assigned Java types.
+	 *
+	 * @since 7.0
 	 */
-	default void validate(List<? extends SqmTypedNode<?>> arguments, String functionName, TypeConfiguration typeConfiguration) {}
+	default void validate(List<? extends SqmTypedNode<?>> arguments, String functionName, BindingContext bindingContext) {
+		validate( arguments, functionName, bindingContext.getTypeConfiguration() );
+	}
+
+	/**
+	 * Perform validation that may be done using the {@link SqmTypedNode} tree and assigned Java types.
+	 *
+	 * @deprecated Implement {@link #validate(List, String, BindingContext)} instead
+	 */
+	@Deprecated(since = "7.0", forRemoval = true)
+	default void validate(List<? extends SqmTypedNode<?>> arguments, String functionName, TypeConfiguration typeConfiguration) {
+		throw new UnsupportedOperationException( "Deprecated operation not implemented" );
+	}
 
 	/**
 	 * Pretty-print the signature of the argument list.

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/produce/function/FunctionArgumentTypeResolver.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/produce/function/FunctionArgumentTypeResolver.java
@@ -58,7 +58,7 @@ public interface FunctionArgumentTypeResolver {
 						new NamedSqmFunctionDescriptor( "", false, null, null ),
 						null,
 						arguments,
-						converter.getCreationContext().getSessionFactory().getNodeBuilder()
+						converter.getSqmCreationContext().getNodeBuilder()
 				) {
 					@Override
 					public Expression convertToSqlAst(SqmToSqlAstConverter walker) {

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/produce/function/StandardArgumentsValidators.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/produce/function/StandardArgumentsValidators.java
@@ -4,8 +4,8 @@
  */
 package org.hibernate.query.sqm.produce.function;
 
+import org.hibernate.query.BindingContext;
 import org.hibernate.query.sqm.tree.SqmTypedNode;
-import org.hibernate.type.spi.TypeConfiguration;
 
 import java.util.List;
 import java.util.Locale;
@@ -27,6 +27,13 @@ public final class StandardArgumentsValidators {
 	 */
 	public static final ArgumentsValidator NONE = new ArgumentsValidator() {
 		@Override
+		public void validate(
+				List<? extends SqmTypedNode<?>> arguments,
+				String functionName,
+				BindingContext bindingContext) {
+			// nothing to do
+		}
+		@Override
 		public String getSignature() {
 			return "([arg0[, ...]])";
 		}
@@ -40,7 +47,7 @@ public final class StandardArgumentsValidators {
 		public void validate(
 				List<? extends SqmTypedNode<?>> arguments,
 				String functionName,
-				TypeConfiguration typeConfiguration) {
+				BindingContext bindingContext) {
 			if ( !arguments.isEmpty() ) {
 				throw new FunctionArgumentException(
 						String.format(
@@ -68,7 +75,7 @@ public final class StandardArgumentsValidators {
 			public void validate(
 					List<? extends SqmTypedNode<?>> arguments,
 					String functionName,
-					TypeConfiguration typeConfiguration) {
+					BindingContext bindingContext) {
 				if ( arguments.size() < minNumOfArgs ) {
 					throw new FunctionArgumentException(
 							String.format(
@@ -105,7 +112,7 @@ public final class StandardArgumentsValidators {
 			public void validate(
 					List<? extends SqmTypedNode<?>> arguments,
 					String functionName,
-					TypeConfiguration typeConfiguration) {
+					BindingContext bindingContext) {
 				if ( arguments.size() != number ) {
 					throw new FunctionArgumentException(
 							String.format(
@@ -144,7 +151,7 @@ public final class StandardArgumentsValidators {
 			public void validate(
 					List<? extends SqmTypedNode<?>> arguments,
 					String functionName,
-					TypeConfiguration typeConfiguration) {
+					BindingContext bindingContext) {
 				if ( arguments.size() > maxNumOfArgs ) {
 					throw new FunctionArgumentException(
 							String.format(
@@ -179,7 +186,7 @@ public final class StandardArgumentsValidators {
 			public void validate(
 					List<? extends SqmTypedNode<?>> arguments,
 					String functionName,
-					TypeConfiguration typeConfiguration) {
+					BindingContext bindingContext) {
 				if (arguments.size() < minNumOfArgs || arguments.size() > maxNumOfArgs) {
 					throw new FunctionArgumentException(
 							String.format(
@@ -218,7 +225,7 @@ public final class StandardArgumentsValidators {
 			public void validate(
 					List<? extends SqmTypedNode<?>> arguments,
 					String functionName,
-					TypeConfiguration typeConfiguration) {
+					BindingContext bindingContext) {
 				for ( SqmTypedNode<?> argument : arguments ) {
 					Class<?> argType = argument.getNodeJavaType().getJavaTypeClass();
 					if ( !javaType.isAssignableFrom( argType ) ) {
@@ -247,11 +254,11 @@ public final class StandardArgumentsValidators {
 			public void validate(
 					List<? extends SqmTypedNode<?>> arguments,
 					String functionName,
-					TypeConfiguration typeConfiguration) {
+					BindingContext bindingContext) {
 				validators.forEach( individualValidator -> individualValidator.validate(
 						arguments,
 						functionName,
-						typeConfiguration
+						bindingContext
 				) );
 			}
 		};

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/produce/function/internal/SetReturningFunctionTypeResolverBuilder.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/produce/function/internal/SetReturningFunctionTypeResolverBuilder.java
@@ -170,10 +170,9 @@ public class SetReturningFunctionTypeResolverBuilder implements SetReturningFunc
 		}
 
 		private String determineIndexSelectionExpression(SelectableMapping[] selectableMappings, String tableIdentifierVariable, SqmToSqlAstConverter walker) {
-			final String defaultOrdinalityColumnName = walker.getCreationContext().getSessionFactory()
-					.getJdbcServices()
-					.getDialect()
-					.getDefaultOrdinalityColumnName();
+			final String defaultOrdinalityColumnName =
+					walker.getCreationContext().getDialect()
+							.getDefaultOrdinalityColumnName();
 			String name = defaultOrdinalityColumnName == null ? "i" : defaultOrdinalityColumnName;
 			OUTER: for ( int i = 0; i < selectableMappings.length; i++ ) {
 				for ( SelectableMapping selectableMapping : selectableMappings ) {

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/spi/SqmCreationContext.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/spi/SqmCreationContext.java
@@ -5,6 +5,8 @@
 package org.hibernate.query.sqm.spi;
 
 import org.hibernate.Incubating;
+import org.hibernate.metamodel.MappingMetamodel;
+import org.hibernate.metamodel.model.domain.JpaMetamodel;
 import org.hibernate.query.BindingContext;
 import org.hibernate.query.spi.QueryEngine;
 import org.hibernate.query.sqm.NodeBuilder;
@@ -27,5 +29,17 @@ public interface SqmCreationContext extends BindingContext {
 	 *          objects are not available to the query validator
 	 *          in Hibernate Processor at compilation time.
 	 */
-	Class<?> classForName(String className);
+	default Class<?> classForName(String className) {
+		return getQueryEngine().getClassLoaderService().classForName( className );
+	}
+
+	@Override
+	default MappingMetamodel getMappingMetamodel() {
+		return getQueryEngine().getMappingMetamodel();
+	}
+
+	@Override
+	default JpaMetamodel getJpaMetamodel() {
+		return getQueryEngine().getJpaMetamodel();
+	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/sql/internal/BasicValuedPathInterpretation.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/sql/internal/BasicValuedPathInterpretation.java
@@ -53,10 +53,7 @@ public class BasicValuedPathInterpretation<T> extends AbstractSqmPathInterpretat
 		if ( lhs instanceof SqmTreatedPath<?, ?> && ( (SqmTreatedPath<?, ?>) lhs ).getTreatTarget().getPersistenceType() == ENTITY ) {
 			final EntityDomainType<?> treatTargetDomainType = (EntityDomainType<?>) ( (SqmTreatedPath<?, ?>) lhs ).getTreatTarget();
 
-			final MappingMetamodel mappingMetamodel = sqlAstCreationState.getCreationContext()
-					.getSessionFactory()
-					.getRuntimeMetamodels()
-					.getMappingMetamodel();
+			final MappingMetamodel mappingMetamodel = sqlAstCreationState.getCreationContext().getMappingMetamodel();
 			final EntityPersister treatEntityDescriptor = mappingMetamodel.findEntityDescriptor( treatTargetDomainType.getHibernateEntityName() );
 			final MappingType tableGroupMappingType = tableGroup.getModelPart().getPartMappingType();
 			if ( tableGroupMappingType instanceof EntityMappingType
@@ -71,11 +68,8 @@ public class BasicValuedPathInterpretation<T> extends AbstractSqmPathInterpretat
 		else {
 			modelPartContainer = tableGroup.getModelPart();
 			if ( jpaQueryComplianceEnabled && lhs.getNodeType() instanceof EntityDomainType<?> entityDomainType ) {
-				final MappingMetamodel mappingMetamodel = sqlAstCreationState.getCreationContext()
-						.getSessionFactory()
-						.getRuntimeMetamodels()
-						.getMappingMetamodel();
-				treatTarget = mappingMetamodel.findEntityDescriptor( entityDomainType.getHibernateEntityName() );
+				treatTarget = sqlAstCreationState.getCreationContext().getMappingMetamodel()
+						.findEntityDescriptor( entityDomainType.getHibernateEntityName() );
 			}
 		}
 

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/sql/internal/EmbeddableValuedExpression.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/sql/internal/EmbeddableValuedExpression.java
@@ -73,9 +73,7 @@ public class EmbeddableValuedExpression<T> implements Expression, DomainResultPr
 		final EmbeddableMappingType mappingType = mapping.getEmbeddableTypeDescriptor();
 		final int numberOfAttributeMappings = mappingType.getNumberOfAttributeMappings();
 		final SqlAstCreationState sqlAstCreationState = creationState.getSqlAstCreationState();
-		final TypeConfiguration typeConfiguration = sqlAstCreationState.getCreationContext()
-				.getSessionFactory()
-				.getTypeConfiguration();
+		final TypeConfiguration typeConfiguration = sqlAstCreationState.getCreationContext().getTypeConfiguration();
 		final SqlExpressionResolver sqlExpressionResolver = sqlAstCreationState.getSqlExpressionResolver();
 		for ( int i = 0; i < numberOfAttributeMappings; i++ ) {
 			final AttributeMapping attributeMapping = mappingType.getAttributeMapping( i );

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/sql/internal/EmbeddableValuedPathInterpretation.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/sql/internal/EmbeddableValuedPathInterpretation.java
@@ -45,10 +45,7 @@ public class EmbeddableValuedPathInterpretation<T> extends AbstractSqmPathInterp
 		final TableGroup tableGroup = sqlAstCreationState.getFromClauseAccess().getTableGroup( lhs.getNavigablePath() );
 		EntityMappingType treatTarget = null;
 		if ( jpaQueryComplianceEnabled ) {
-			final MappingMetamodel mappingMetamodel = sqlAstCreationState.getCreationContext()
-					.getSessionFactory()
-					.getRuntimeMetamodels()
-					.getMappingMetamodel();
+			final MappingMetamodel mappingMetamodel = sqlAstCreationState.getCreationContext().getMappingMetamodel();
 			if ( lhs instanceof SqmTreatedPath<?, ?> && ( (SqmTreatedPath<?, ?>) lhs ).getTreatTarget().getPersistenceType() == ENTITY ) {
 				final EntityDomainType<?> treatTargetDomainType = (EntityDomainType<?>) ( (SqmTreatedPath<?, ?>) lhs ).getTreatTarget();
 				treatTarget = mappingMetamodel.findEntityDescriptor( treatTargetDomainType.getHibernateEntityName() );

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/sql/internal/EntityValuedPathInterpretation.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/sql/internal/EntityValuedPathInterpretation.java
@@ -287,10 +287,7 @@ public class EntityValuedPathInterpretation<T> extends AbstractSqmPathInterpreta
 		if ( expandToAllColumns ) {
 			// Expand to all columns of the entity mapping type to ensure a correct group / order by expression,
 			// or use only the primary key if the dialect supports functional dependency
-			final Dialect dialect = sqlAstCreationState.getCreationContext()
-					.getSessionFactory()
-					.getJdbcServices()
-					.getDialect();
+			final Dialect dialect = sqlAstCreationState.getCreationContext().getDialect();
 			final EntityMappingType entityMappingType = mapping.getEntityMappingType();
 			final EntityIdentifierMapping identifierMapping = entityMappingType.getIdentifierMapping();
 			final List<Expression> expressions = new ArrayList<>( identifierMapping.getJdbcTypeCount() );

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/sql/internal/SqmParameterInterpretation.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/sql/internal/SqmParameterInterpretation.java
@@ -98,7 +98,7 @@ public class SqmParameterInterpretation implements Expression, DomainResultProdu
 				resolvedExpression,
 				jdbcJavaType,
 				null,
-				creationState.getSqlAstCreationState().getCreationContext().getSessionFactory().getTypeConfiguration()
+				creationState.getSqlAstCreationState().getCreationContext().getTypeConfiguration()
 		);
 
 		return new BasicResult(
@@ -135,7 +135,7 @@ public class SqmParameterInterpretation implements Expression, DomainResultProdu
 				resolvedExpression,
 				resolvedExpression.getExpressionType().getSingleJdbcMapping().getMappedJavaType(),
 				null,
-				creationState.getSqlAstCreationState().getCreationContext().getSessionFactory().getTypeConfiguration()
+				creationState.getSqlAstCreationState().getCreationContext().getTypeConfiguration()
 		);
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/tuple/internal/AnonymousTupleBasicValuedModelPart.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/tuple/internal/AnonymousTupleBasicValuedModelPart.java
@@ -287,7 +287,7 @@ public class AnonymousTupleBasicValuedModelPart implements OwnedValuedModelPart,
 				expression,
 				getJdbcMapping().getJdbcJavaType(),
 				fetchParent,
-				creationState.getCreationContext().getSessionFactory().getTypeConfiguration()
+				creationState.getCreationContext().getTypeConfiguration()
 		);
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/sql/ast/spi/SqlAstCreationContext.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/ast/spi/SqlAstCreationContext.java
@@ -4,9 +4,13 @@
  */
 package org.hibernate.sql.ast.spi;
 
+import org.hibernate.dialect.Dialect;
+import org.hibernate.engine.profile.FetchProfile;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.metamodel.spi.MappingMetamodelImplementor;
 import org.hibernate.query.BindingContext;
+import org.hibernate.query.sqm.function.SqmFunctionRegistry;
+import org.hibernate.type.descriptor.WrapperOptions;
 
 /**
  * The "context" in which creation of SQL AST occurs.  Provides
@@ -16,12 +20,21 @@ import org.hibernate.query.BindingContext;
  */
 public interface SqlAstCreationContext extends BindingContext {
 	/**
-	 * The SessionFactory
+	 * Avoid calling this method directly, as much as possible.
+	 * SQL AST creation should not depend on the existence of
+	 * a session factory, so if you need to obtain this object,
+	 * there's something wrong with the design.
+	 * <p>
+	 * Currently this is only called when creating a
+	 * {@link org.hibernate.sql.ast.tree.from.TableGroup},
+	 * but we will introduce a new sort of creation context
+	 * for that, probably.
 	 */
+	@Deprecated
 	SessionFactoryImplementor getSessionFactory();
 
 	/**
-	 * The runtime MappingMetamodelImplementor
+	 * The runtime {@link MappingMetamodelImplementor}
 	 */
 	MappingMetamodelImplementor getMappingMetamodel();
 
@@ -30,4 +43,28 @@ public interface SqlAstCreationContext extends BindingContext {
 	 * defines a limit to how deep we should join for fetches.
 	 */
 	Integer getMaximumFetchDepth();
+
+	/**
+	 * @see org.hibernate.jpa.spi.JpaCompliance#isJpaQueryComplianceEnabled
+	 */
+	boolean isJpaQueryComplianceEnabled();
+
+	/**
+	 * Obtain the definition of a named {@link FetchProfile}.
+	 *
+	 * @param name The name of the fetch profile
+	 */
+	FetchProfile getFetchProfile(String name);
+
+	default SqmFunctionRegistry getSqmFunctionRegistry() {
+		return getSessionFactory().getQueryEngine().getSqmFunctionRegistry();
+	}
+
+	default Dialect getDialect() {
+		return getSessionFactory().getQueryEngine().getDialect();
+	}
+
+	default WrapperOptions getWrapperOptions() {
+		return getSessionFactory().getWrapperOptions();
+	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/sql/ast/spi/SqlAstCreationContext.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/ast/spi/SqlAstCreationContext.java
@@ -56,14 +56,24 @@ public interface SqlAstCreationContext extends BindingContext {
 	 */
 	FetchProfile getFetchProfile(String name);
 
+	/**
+	 * Obtain the {@link SqmFunctionRegistry}.
+	 */
 	default SqmFunctionRegistry getSqmFunctionRegistry() {
 		return getSessionFactory().getQueryEngine().getSqmFunctionRegistry();
 	}
 
+	/**
+	 * Obtain the {@link Dialect}.
+	 */
 	default Dialect getDialect() {
 		return getSessionFactory().getQueryEngine().getDialect();
 	}
 
+	/**
+	 * Obtain the "incomplete" {@link WrapperOptions} that would be
+	 * returned by {@link SessionFactoryImplementor#getWrapperOptions()}.
+	 */
 	default WrapperOptions getWrapperOptions() {
 		return getSessionFactory().getWrapperOptions();
 	}

--- a/hibernate-core/src/main/java/org/hibernate/sql/ast/spi/SqlAstCreationState.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/ast/spi/SqlAstCreationState.java
@@ -9,6 +9,7 @@ import org.hibernate.LockMode;
 import org.hibernate.engine.spi.LoadQueryInfluencers;
 import org.hibernate.metamodel.mapping.ordering.OrderByFragment;
 import org.hibernate.persister.entity.EntityNameUse;
+import org.hibernate.query.sqm.spi.SqmCreationContext;
 import org.hibernate.sql.ast.tree.from.TableGroup;
 
 /**
@@ -28,6 +29,10 @@ public interface SqlAstCreationState {
 	SqlAliasBaseGenerator getSqlAliasBaseGenerator();
 
 	LoadQueryInfluencers getLoadQueryInfluencers();
+
+	default SqmCreationContext getSqmCreationContext() {
+		return getCreationContext().getSessionFactory().getQueryEngine().getCriteriaBuilder();
+	}
 
 	boolean applyOnlyLoadByKeyFilters();
 

--- a/hibernate-core/src/main/java/org/hibernate/sql/ast/tree/expression/CaseSearchedExpression.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/ast/tree/expression/CaseSearchedExpression.java
@@ -66,10 +66,7 @@ public class CaseSearchedExpression implements Expression, DomainResultProducer 
 						this,
 						type.getJdbcMapping().getJdbcJavaType(),
 						null,
-						creationState.getSqlAstCreationState()
-								.getCreationContext()
-								.getSessionFactory()
-								.getTypeConfiguration()
+						creationState.getSqlAstCreationState().getCreationContext().getTypeConfiguration()
 				);
 
 		return new BasicResult(

--- a/hibernate-core/src/main/java/org/hibernate/sql/ast/tree/expression/Over.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/ast/tree/expression/Over.java
@@ -136,7 +136,7 @@ public class Over<T> implements Expression, DomainResultProducer<T> {
 				this,
 				expression.getExpressionType().getSingleJdbcMapping().getJdbcJavaType(),
 				null,
-				creationState.getCreationContext().getSessionFactory().getTypeConfiguration()
+				creationState.getCreationContext().getTypeConfiguration()
 		);
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/sql/ast/tree/expression/QueryLiteral.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/ast/tree/expression/QueryLiteral.java
@@ -66,10 +66,7 @@ public class QueryLiteral<T> implements Literal, DomainResultProducer<T> {
 						this,
 						expressible.getJdbcMapping().getJdbcJavaType(),
 						null,
-						creationState.getSqlAstCreationState()
-								.getCreationContext()
-								.getSessionFactory()
-								.getTypeConfiguration()
+						creationState.getSqlAstCreationState().getCreationContext().getTypeConfiguration()
 				);
 
 		return new BasicResult<>(

--- a/hibernate-core/src/main/java/org/hibernate/sql/ast/tree/expression/UnparsedNumericLiteral.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/ast/tree/expression/UnparsedNumericLiteral.java
@@ -74,8 +74,10 @@ public class UnparsedNumericLiteral<N extends Number> implements Literal, Domain
 
 	@Override
 	public DomainResult<N> createDomainResult(String resultVariable, DomainResultCreationState creationState) {
-		final SqlExpressionResolver sqlExpressionResolver = creationState.getSqlAstCreationState().getSqlExpressionResolver();
-		final TypeConfiguration typeConfiguration = creationState.getSqlAstCreationState().getCreationContext().getSessionFactory().getTypeConfiguration();
+		final SqlExpressionResolver sqlExpressionResolver =
+				creationState.getSqlAstCreationState().getSqlExpressionResolver();
+		final TypeConfiguration typeConfiguration =
+				creationState.getSqlAstCreationState().getCreationContext().getTypeConfiguration();
 
 		final SqlSelection sqlSelection = sqlExpressionResolver.resolveSqlSelection(
 				this,

--- a/hibernate-core/src/main/java/org/hibernate/sql/exec/internal/JdbcSelectExecutorStandardImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/exec/internal/JdbcSelectExecutorStandardImpl.java
@@ -433,11 +433,7 @@ public class JdbcSelectExecutorStandardImpl implements JdbcSelectExecutor {
 			if ( columnNames == null ) {
 				initializeArrays();
 			}
-			final BasicType<J> basicType = resultSetAccess.resolveType(
-					position,
-					explicitJavaType,
-					typeConfiguration
-			);
+			final BasicType<J> basicType = resultSetAccess.resolveType( position, explicitJavaType, typeConfiguration );
 			types[position - 1] = basicType;
 			return basicType;
 		}

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/embeddable/internal/AggregateEmbeddableFetchImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/embeddable/internal/AggregateEmbeddableFetchImpl.java
@@ -92,9 +92,7 @@ public class AggregateEmbeddableFetchImpl extends AbstractFetchParent
 		final TableReference tableReference = tableGroup.getPrimaryTableReference();
 		final SelectableMapping selectableMapping = fetchContainer.getAggregateMapping();
 		final Expression expression = sqlExpressionResolver.resolveSqlExpression( tableReference, selectableMapping );
-		final TypeConfiguration typeConfiguration = sqlAstCreationState.getCreationContext()
-				.getSessionFactory()
-				.getTypeConfiguration();
+		final TypeConfiguration typeConfiguration = sqlAstCreationState.getCreationContext().getTypeConfiguration();
 		final SqlSelection aggregateSelection = sqlExpressionResolver.resolveSqlSelection(
 				expression,
 				typeConfiguration.getJavaTypeRegistry().resolveDescriptor( Object[].class ),

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/embeddable/internal/AggregateEmbeddableResultImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/embeddable/internal/AggregateEmbeddableResultImpl.java
@@ -94,9 +94,7 @@ public class AggregateEmbeddableResultImpl<T> extends AbstractFetchParent implem
 		final TableReference tableReference = tableGroup.getPrimaryTableReference();
 		final SelectableMapping selectableMapping = embeddedPartDescriptor.getEmbeddableTypeDescriptor().getAggregateMapping();
 		final Expression expression = sqlExpressionResolver.resolveSqlExpression( tableReference, selectableMapping );
-		final TypeConfiguration typeConfiguration = sqlAstCreationState.getCreationContext()
-				.getSessionFactory()
-				.getTypeConfiguration();
+		final TypeConfiguration typeConfiguration = sqlAstCreationState.getCreationContext().getTypeConfiguration();
 		final SqlSelection aggregateSelection = sqlExpressionResolver.resolveSqlSelection(
 				expression,
 				// Using the Object[] type here, so that a different JDBC extractor is chosen

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/embeddable/internal/EmbeddableExpressionResultImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/embeddable/internal/EmbeddableExpressionResultImpl.java
@@ -52,9 +52,7 @@ public class EmbeddableExpressionResultImpl<T> extends AbstractFetchParent imple
 		final EmbeddableMappingType mappingType = modelPart.getEmbeddableTypeDescriptor();
 		final int numberOfAttributeMappings = mappingType.getNumberOfAttributeMappings();
 		final SqlAstCreationState sqlAstCreationState = creationState.getSqlAstCreationState();
-		final TypeConfiguration typeConfiguration = sqlAstCreationState.getCreationContext()
-				.getSessionFactory()
-				.getTypeConfiguration();
+		final TypeConfiguration typeConfiguration = sqlAstCreationState.getCreationContext().getTypeConfiguration();
 		final SqlExpressionResolver sqlExpressionResolver = sqlAstCreationState.getSqlExpressionResolver();
 		for ( int i = 0; i < numberOfAttributeMappings; i++ ) {
 			final BasicAttributeMapping attribute = (BasicAttributeMapping) mappingType.getAttributeMapping( i );

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/embeddable/internal/EmbeddableInitializerImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/embeddable/internal/EmbeddableInitializerImpl.java
@@ -10,7 +10,6 @@ import java.util.function.BiConsumer;
 
 import org.hibernate.bytecode.enhance.spi.LazyPropertyInitializer;
 import org.hibernate.engine.internal.ManagedTypeHelper;
-import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.metamodel.mapping.AttributeMapping;
 import org.hibernate.metamodel.mapping.EmbeddableMappingType;
 import org.hibernate.metamodel.mapping.EmbeddableValuedModelPart;
@@ -57,7 +56,6 @@ public class EmbeddableInitializerImpl extends AbstractInitializer<EmbeddableIni
 	private final @Nullable InitializerParent<InitializerData> parent;
 	private final boolean isResultInitializer;
 	private final boolean isPartOfKey;
-	private final SessionFactoryImplementor sessionFactory;
 
 	protected final DomainResultAssembler<?>[][] assemblers;
 	protected final BasicResultAssembler<?> discriminatorAssembler;
@@ -115,7 +113,6 @@ public class EmbeddableInitializerImpl extends AbstractInitializer<EmbeddableIni
 
 		this.isPartOfKey = embedded.isEntityIdentifierMapping() || Initializer.isPartOfKey( navigablePath, parent );
 		// We never want to create empty composites for the FK target or PK, otherwise collections would break
-		this.sessionFactory = creationState.getSqlAstCreationContext().getSessionFactory();
 		final Collection<EmbeddableMappingType.ConcreteEmbeddableType> concreteEmbeddableTypes = embeddableMappingType.getConcreteEmbeddableTypes();
 		final DomainResultAssembler<?>[][] assemblers = new DomainResultAssembler[concreteEmbeddableTypes.isEmpty() ? 1 : concreteEmbeddableTypes.size()][];
 		final @Nullable Initializer<InitializerData>[][] subInitializers = new Initializer[assemblers.length][];

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/embeddable/internal/NonAggregatedIdentifierMappingInitializer.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/embeddable/internal/NonAggregatedIdentifierMappingInitializer.java
@@ -8,7 +8,6 @@ import java.util.function.BiConsumer;
 import java.util.function.Function;
 
 import org.hibernate.bytecode.enhance.spi.LazyPropertyInitializer;
-import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.metamodel.mapping.AttributeMapping;
 import org.hibernate.metamodel.mapping.EmbeddableMappingType;
 import org.hibernate.metamodel.mapping.EmbeddableValuedModelPart;
@@ -52,7 +51,6 @@ public class NonAggregatedIdentifierMappingInitializer extends AbstractInitializ
 	private final EmbeddableMappingType representationEmbeddable;
 	private final EmbeddableInstantiator embeddableInstantiator;
 	private final @Nullable InitializerParent<?> parent;
-	private final SessionFactoryImplementor sessionFactory;
 	private final boolean isResultInitializer;
 
 	private final DomainResultAssembler<?>[] assemblers;
@@ -123,8 +121,6 @@ public class NonAggregatedIdentifierMappingInitializer extends AbstractInitializ
 		this.representationEmbeddable = embedded.getMappedIdEmbeddableTypeDescriptor();
 		this.embeddableInstantiator = representationEmbeddable.getRepresentationStrategy().getInstantiator();
 		this.hasIdClass = embedded.hasContainingClass() && virtualIdEmbeddable != representationEmbeddable;
-
-		this.sessionFactory = creationState.getSqlAstCreationContext().getSessionFactory();
 
 		final int size = virtualIdEmbeddable.getNumberOfFetchables();
 		final DomainResultAssembler<?>[] assemblers = new DomainResultAssembler[size];

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/internal/SqlSelectionImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/internal/SqlSelectionImpl.java
@@ -157,7 +157,7 @@ public class SqlSelectionImpl implements SqlSelection, SqlExpressionAccess {
 			final BasicType<Object> resolvedType = jdbcResultsMetadata.resolveType(
 					jdbcPosition,
 					null,
-					sessionFactory
+					sessionFactory.getTypeConfiguration()
 			);
 			return new ResolvedSqlSelection(
 					jdbcPosition,

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/jdbc/internal/StandardJdbcValuesMapping.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/jdbc/internal/StandardJdbcValuesMapping.java
@@ -115,10 +115,11 @@ public class StandardJdbcValuesMapping implements JdbcValuesMapping {
 		}
 		final AssemblerCreationStateImpl creationState = new AssemblerCreationStateImpl(
 				this,
-				sessionFactory
+				sessionFactory.getSqlTranslationEngine()
 		);
 
-		DomainResultAssembler<?>[] domainResultAssemblers = resolveAssemblers( creationState ).toArray(new DomainResultAssembler[0]);
+		DomainResultAssembler<?>[] domainResultAssemblers =
+				resolveAssemblers( creationState ).toArray(new DomainResultAssembler[0]);
 		creationState.initializerMap.logInitializers();
 		return this.resolution = new JdbcValuesMappingResolutionImpl(
 				domainResultAssemblers,
@@ -148,7 +149,7 @@ public class StandardJdbcValuesMapping implements JdbcValuesMapping {
 
 	private static class AssemblerCreationStateImpl implements AssemblerCreationState {
 		private final JdbcValuesMapping jdbcValuesMapping;
-		private final SessionFactoryImplementor sessionFactory;
+		private final SqlAstCreationContext sqlAstCreationContexty;
 		//custom Map<NavigablePath, Initializer>
 		private final NavigablePathMapToInitializer initializerMap = new NavigablePathMapToInitializer();
 		private final InitializersList.Builder initializerListBuilder = new InitializersList.Builder();
@@ -159,9 +160,9 @@ public class StandardJdbcValuesMapping implements JdbcValuesMapping {
 
 		public AssemblerCreationStateImpl(
 				JdbcValuesMapping jdbcValuesMapping,
-				SessionFactoryImplementor sessionFactory) {
+				SqlAstCreationContext sqlAstCreationContexty) {
 			this.jdbcValuesMapping = jdbcValuesMapping;
-			this.sessionFactory = sessionFactory;
+			this.sqlAstCreationContexty = sqlAstCreationContexty;
 		}
 
 		@Override
@@ -256,7 +257,7 @@ public class StandardJdbcValuesMapping implements JdbcValuesMapping {
 
 		@Override
 		public SqlAstCreationContext getSqlAstCreationContext() {
-			return sessionFactory;
+			return sqlAstCreationContexty;
 		}
 
 	}

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/jdbc/spi/JdbcValuesMetadata.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/jdbc/spi/JdbcValuesMetadata.java
@@ -31,7 +31,11 @@ public interface JdbcValuesMetadata {
 
 	/**
 	 * Determine the mapping to use for a particular position in the result
+	 *
+	 * @deprecated The existence of this method encourages people to pass around
+	 * references to the SessionFactoryImplementor when they don't need it
 	 */
+	@Deprecated(since = "7.0", forRemoval = true)
 	default <J> BasicType<J> resolveType(
 			int position,
 			JavaType<J> explicitJavaType,

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/spi/UnknownBasicJavaType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/spi/UnknownBasicJavaType.java
@@ -22,6 +22,7 @@ public final class UnknownBasicJavaType<T> extends AbstractJavaType<T> {
 	public UnknownBasicJavaType(Class<T> type) {
 		this( type, type.getTypeName() );
 	}
+
 	public UnknownBasicJavaType(Class<T> type, String typeName) {
 		super( type );
 		this.typeName = typeName;
@@ -40,6 +41,17 @@ public final class UnknownBasicJavaType<T> extends AbstractJavaType<T> {
 	@Override
 	public String getTypeName() {
 		return typeName;
+	}
+
+	@Override
+	public Type getJavaType() {
+		final Type type = super.getJavaType();
+		if ( type == null ) {
+			throw new UnsupportedOperationException( "Unloadable Java type: " + typeName );
+		}
+		else {
+			return type;
+		}
 	}
 
 	@Override

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/entitygraph/ast/CriteriaEntityGraphTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/entitygraph/ast/CriteriaEntityGraphTest.java
@@ -408,7 +408,7 @@ public class CriteriaEntityGraphTest implements SessionFactoryScopeAware {
 				( (QuerySqmImpl<?>) hqlQuery ).getDomainParameterXref(),
 				query.getParameterBindings(),
 				loadQueryInfluencers,
-				session.getSessionFactory(),
+				session.getSessionFactory().getSqlTranslationEngine(),
 				true
 		);
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/entitygraph/ast/HqlEntityGraphTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/entitygraph/ast/HqlEntityGraphTest.java
@@ -406,7 +406,7 @@ public class HqlEntityGraphTest implements SessionFactoryScopeAware {
 				( (QuerySqmImpl<?>) hqlQuery ).getDomainParameterXref(),
 				query.getParameterBindings(),
 				loadQueryInfluencers,
-				session.getSessionFactory(),
+				session.getSessionFactory().getSqlTranslationEngine(),
 				true
 		);
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/query/criteria/MultiSelectTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/query/criteria/MultiSelectTests.java
@@ -33,7 +33,7 @@ public class MultiSelectTests {
 	@Test
 	public void simpleArrayTest(SessionFactoryScope scope) {
 		scope.inTransaction( (session) -> {
-			final CriteriaBuilder nodeBuilder = session.getFactory().getNodeBuilder();
+			final CriteriaBuilder nodeBuilder = session.getFactory().getQueryEngine().getCriteriaBuilder();
 
 			final CriteriaQuery criteria = nodeBuilder.createQuery();
 			final Root<BasicEntity> root = criteria.from( BasicEntity.class );
@@ -57,7 +57,7 @@ public class MultiSelectTests {
 	@Test
 	public void multiselectArrayTest(SessionFactoryScope scope) {
 		scope.inTransaction( (session) -> {
-			final CriteriaBuilder nodeBuilder = session.getFactory().getNodeBuilder();
+			final CriteriaBuilder nodeBuilder = session.getFactory().getQueryEngine().getCriteriaBuilder();
 
 			final CriteriaQuery criteria = nodeBuilder.createQuery();
 			final Root<BasicEntity> root = criteria.from( BasicEntity.class );
@@ -79,7 +79,7 @@ public class MultiSelectTests {
 	@Test
 	public void typedArrayTest(SessionFactoryScope scope) {
 		scope.inTransaction( (session) -> {
-			final CriteriaBuilder nodeBuilder = session.getFactory().getNodeBuilder();
+			final CriteriaBuilder nodeBuilder = session.getFactory().getQueryEngine().getCriteriaBuilder();
 
 			final CriteriaQuery<Object[]> criteria = nodeBuilder.createQuery(Object[].class);
 			final Root<BasicEntity> root = criteria.from( BasicEntity.class );
@@ -103,7 +103,7 @@ public class MultiSelectTests {
 	@Test
 	public void simpleTupleTest(SessionFactoryScope scope) {
 		scope.inTransaction( (session) -> {
-			final CriteriaBuilder nodeBuilder = session.getFactory().getNodeBuilder();
+			final CriteriaBuilder nodeBuilder = session.getFactory().getQueryEngine().getCriteriaBuilder();
 
 			final CriteriaQuery<Tuple> criteria = nodeBuilder.createTupleQuery();
 			final Root<BasicEntity> root = criteria.from( BasicEntity.class );
@@ -127,7 +127,7 @@ public class MultiSelectTests {
 	@Test
 	public void typedTupleTest(SessionFactoryScope scope) {
 		scope.inTransaction( (session) -> {
-			final CriteriaBuilder nodeBuilder = session.getFactory().getNodeBuilder();
+			final CriteriaBuilder nodeBuilder = session.getFactory().getQueryEngine().getCriteriaBuilder();
 
 			final CriteriaQuery<Tuple> criteria = nodeBuilder.createQuery( Tuple.class );
 			final Root<BasicEntity> root = criteria.from( BasicEntity.class );
@@ -151,7 +151,7 @@ public class MultiSelectTests {
 	@Test
 	public void multiSelectTupleTest(SessionFactoryScope scope) {
 		scope.inTransaction( (session) -> {
-			final CriteriaBuilder nodeBuilder = session.getFactory().getNodeBuilder();
+			final CriteriaBuilder nodeBuilder = session.getFactory().getQueryEngine().getCriteriaBuilder();
 
 			final CriteriaQuery<Tuple> criteria = nodeBuilder.createTupleQuery();
 			final Root<BasicEntity> root = criteria.from( BasicEntity.class );
@@ -173,7 +173,7 @@ public class MultiSelectTests {
 	@Test
 	public void arrayTupleTest(SessionFactoryScope scope) {
 		scope.inTransaction( (session) -> {
-			final CriteriaBuilder nodeBuilder = session.getFactory().getNodeBuilder();
+			final CriteriaBuilder nodeBuilder = session.getFactory().getQueryEngine().getCriteriaBuilder();
 
 			final CriteriaQuery<Tuple> criteria = nodeBuilder.createTupleQuery();
 			final Root<BasicEntity> root = criteria.from( BasicEntity.class );
@@ -197,7 +197,7 @@ public class MultiSelectTests {
 	@Test
 	public void singleSelectionTupleTest(SessionFactoryScope scope) {
 		scope.inTransaction( (session) -> {
-			final CriteriaBuilder nodeBuilder = session.getFactory().getNodeBuilder();
+			final CriteriaBuilder nodeBuilder = session.getFactory().getQueryEngine().getCriteriaBuilder();
 
 			final CriteriaQuery criteria = nodeBuilder.createTupleQuery();
 			final Root<BasicEntity> root = criteria.from( BasicEntity.class );
@@ -217,7 +217,7 @@ public class MultiSelectTests {
 	@Test
 	public void tupleSelectionArrayTest(SessionFactoryScope scope) {
 		scope.inTransaction( (session) -> {
-			final CriteriaBuilder nodeBuilder = session.getFactory().getNodeBuilder();
+			final CriteriaBuilder nodeBuilder = session.getFactory().getQueryEngine().getCriteriaBuilder();
 
 			final CriteriaQuery<Tuple> criteria = nodeBuilder.createTupleQuery();
 			final Root<BasicEntity> root = criteria.from( BasicEntity.class );

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/query/hql/EntityJoinTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/query/hql/EntityJoinTest.java
@@ -194,7 +194,7 @@ public class EntityJoinTest {
 											DomainParameterXref.EMPTY,
 											QueryParameterBindingsImpl.EMPTY,
 											new LoadQueryInfluencers( factory ),
-											factory,
+											factory.getSqlTranslationEngine(),
 											true
 									)
 									.translate();

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/query/sqm/BaseSqmUnitTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/query/sqm/BaseSqmUnitTest.java
@@ -6,6 +6,8 @@ package org.hibernate.orm.test.query.sqm;
 
 import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
 import org.hibernate.cfg.AvailableSettings;
+import org.hibernate.dialect.Dialect;
+import org.hibernate.engine.profile.FetchProfile;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.loader.ast.spi.AfterLoadAction;
@@ -91,6 +93,21 @@ public abstract class BaseSqmUnitTest
 
 	@Override
 	public Integer getMaximumFetchDepth() {
-		return sessionFactory().getMaximumFetchDepth();
+		return sessionFactory().getSessionFactoryOptions().getMaximumFetchDepth();
+	}
+
+	@Override
+	public boolean isJpaQueryComplianceEnabled() {
+		return strictJpaCompliance();
+	}
+
+	@Override
+	public Dialect getDialect() {
+		return sessionFactory().getQueryEngine().getDialect();
+	}
+
+	@Override
+	public FetchProfile getFetchProfile(String name) {
+		return sessionFactory().getFetchProfile( name );
 	}
 }

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/sql/ast/SmokeTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/sql/ast/SmokeTests.java
@@ -116,7 +116,7 @@ public class SmokeTests {
 							( (QuerySqmImpl<?>) hqlQuery ).getDomainParameterXref(),
 							query.getParameterBindings(),
 							session.getLoadQueryInfluencers(),
-							scope.getSessionFactory(),
+							scope.getSessionFactory().getSqlTranslationEngine(),
 							true
 					);
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/sql/ast/SqlAstHelper.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/sql/ast/SqlAstHelper.java
@@ -27,7 +27,7 @@ public class SqlAstHelper {
 				hqlQuery.getDomainParameterXref(),
 				query.getParameterBindings(),
 				session.getLoadQueryInfluencers(),
-				session.getFactory(),
+				session.getFactory().getSqlTranslationEngine(),
 				true
 		);
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/sql/results/AbstractResultTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/sql/results/AbstractResultTests.java
@@ -35,7 +35,7 @@ public class AbstractResultTests {
 						DomainParameterXref.from( sqm ),
 						parameterBindings,
 						new LoadQueryInfluencers( sessionFactory ),
-						sessionFactory,
+						sessionFactory.getSqlTranslationEngine(),
 						true
 				)
 				.translate()

--- a/hibernate-envers/src/main/java/org/hibernate/envers/function/OrderByFragmentFunction.java
+++ b/hibernate-envers/src/main/java/org/hibernate/envers/function/OrderByFragmentFunction.java
@@ -196,11 +196,9 @@ public class OrderByFragmentFunction extends AbstractSqmFunctionDescriptor {
 			final TableGroup tableGroup = ( (FromClauseIndex) walker.getFromClauseAccess() ).findTableGroup(
 					sqmAlias
 			);
-			final CollectionPersister collectionDescriptor = walker.getCreationContext()
-					.getSessionFactory()
-						.getRuntimeMetamodels()
-						.getMappingMetamodel()
-					.findCollectionDescriptor( attributeRole );
+			final CollectionPersister collectionDescriptor =
+					walker.getCreationContext().getMappingMetamodel()
+							.findCollectionDescriptor( attributeRole );
 			final PluralAttributeMapping pluralAttribute = collectionDescriptor.getAttributeMapping();
 			final QuerySpec queryPart = (QuerySpec) ( (SqlAstQueryPartProcessingState) walker.getCurrentProcessingState() ).getInflightQueryPart();
 			final OrderByFragment fragment;

--- a/hibernate-envers/src/test/java/org/hibernate/orm/test/envers/performance/AbstractEntityManagerTest.java
+++ b/hibernate-envers/src/test/java/org/hibernate/orm/test/envers/performance/AbstractEntityManagerTest.java
@@ -4,12 +4,9 @@
  */
 package org.hibernate.orm.test.envers.performance;
 
-import java.io.IOException;
 import java.util.Arrays;
 import java.util.Properties;
 
-import org.hibernate.boot.registry.BootstrapServiceRegistryBuilder;
-import org.hibernate.boot.registry.internal.StandardServiceRegistryImpl;
 import org.hibernate.cfg.AvailableSettings;
 import org.hibernate.cfg.Environment;
 import org.hibernate.dialect.Dialect;
@@ -37,8 +34,6 @@ import jakarta.persistence.EntityManager;
 public abstract class AbstractEntityManagerTest extends AbstractEnversTest {
 	public static final Dialect DIALECT = DialectContext.getDialect();
 
-	private EntityManagerFactoryBuilderImpl entityManagerFactoryBuilder;
-	private StandardServiceRegistryImpl serviceRegistry;
 	private SessionFactoryImplementor emf;
 	private EntityManager entityManager;
 	private AuditReader auditReader;
@@ -70,11 +65,11 @@ public abstract class AbstractEntityManagerTest extends AbstractEnversTest {
 	}
 
 	@BeforeClassOnce
-	public void init() throws IOException {
+	public void init() {
 		init( true, getAuditStrategy() );
 	}
 
-	protected void init(boolean audited, String auditStrategy) throws IOException {
+	protected void init(boolean audited, String auditStrategy) {
 		this.audited = audited;
 
 		Properties configurationProperties = new Properties();
@@ -86,7 +81,7 @@ public abstract class AbstractEntityManagerTest extends AbstractEnversTest {
 			configurationProperties.setProperty( AvailableSettings.HBM2DDL_AUTO, "create-drop" );
 			configurationProperties.setProperty( EnversSettings.USE_REVISION_ENTITY_WITH_NATIVE_ID, "false" );
 		}
-		if ( auditStrategy != null && !"".equals( auditStrategy ) ) {
+		if ( auditStrategy != null && !auditStrategy.isEmpty() ) {
 			configurationProperties.setProperty( "org.hibernate.envers.audit_strategy", auditStrategy );
 		}
 
@@ -94,16 +89,14 @@ public abstract class AbstractEntityManagerTest extends AbstractEnversTest {
 
 		configurationProperties.put( AvailableSettings.LOADED_CLASSES, Arrays.asList( getAnnotatedClasses() ) );
 
-		entityManagerFactoryBuilder = (EntityManagerFactoryBuilderImpl) Bootstrap.getEntityManagerFactoryBuilder(
-				new PersistenceUnitDescriptorAdapter(),
-				configurationProperties
-		);
+		EntityManagerFactoryBuilderImpl entityManagerFactoryBuilder =
+				(EntityManagerFactoryBuilderImpl)
+						Bootstrap.getEntityManagerFactoryBuilder(
+								new PersistenceUnitDescriptorAdapter(),
+								configurationProperties
+						);
 
 		emf = entityManagerFactoryBuilder.build().unwrap( SessionFactoryImplementor.class );
-
-		serviceRegistry = (StandardServiceRegistryImpl) emf.getSessionFactory()
-				.getServiceRegistry()
-				.getParentServiceRegistry();
 
 		newEntityManager();
 	}
@@ -114,10 +107,6 @@ public abstract class AbstractEntityManagerTest extends AbstractEnversTest {
 
 	protected boolean createSchema() {
 		return true;
-	}
-
-	private BootstrapServiceRegistryBuilder createBootstrapRegistryBuilder() {
-		return new BootstrapServiceRegistryBuilder();
 	}
 
 	@AfterClassOnce

--- a/hibernate-vector/src/main/java/org/hibernate/vector/VectorArgumentTypeResolver.java
+++ b/hibernate-vector/src/main/java/org/hibernate/vector/VectorArgumentTypeResolver.java
@@ -37,10 +37,7 @@ public class VectorArgumentTypeResolver extends AbstractFunctionArgumentTypeReso
 			}
 		}
 
-		return converter.getCreationContext()
-				.getSessionFactory()
-				.getTypeConfiguration()
-				.getBasicTypeRegistry()
+		return converter.getCreationContext().getTypeConfiguration().getBasicTypeRegistry()
 				.resolve( StandardBasicTypes.VECTOR );
 	}
 }

--- a/hibernate-vector/src/main/java/org/hibernate/vector/VectorArgumentValidator.java
+++ b/hibernate-vector/src/main/java/org/hibernate/vector/VectorArgumentValidator.java
@@ -7,6 +7,7 @@ package org.hibernate.vector;
 import java.util.List;
 
 import org.hibernate.metamodel.model.domain.DomainType;
+import org.hibernate.query.BindingContext;
 import org.hibernate.query.sqm.SqmExpressible;
 import org.hibernate.query.sqm.produce.function.ArgumentsValidator;
 import org.hibernate.query.sqm.produce.function.FunctionArgumentException;
@@ -27,7 +28,7 @@ public class VectorArgumentValidator implements ArgumentsValidator {
 	public void validate(
 			List<? extends SqmTypedNode<?>> arguments,
 			String functionName,
-			TypeConfiguration typeConfiguration) {
+			BindingContext bindingContext) {
 		for ( int i = 0; i < arguments.size(); i++ ) {
 			final SqmExpressible<?> expressible = arguments.get( i ).getExpressible();
 			final DomainType<?> type;

--- a/hibernate-vector/src/main/java/org/hibernate/vector/VectorArgumentValidator.java
+++ b/hibernate-vector/src/main/java/org/hibernate/vector/VectorArgumentValidator.java
@@ -13,9 +13,7 @@ import org.hibernate.query.sqm.produce.function.ArgumentsValidator;
 import org.hibernate.query.sqm.produce.function.FunctionArgumentException;
 import org.hibernate.query.sqm.tree.SqmTypedNode;
 import org.hibernate.type.BasicPluralType;
-import org.hibernate.type.BasicType;
 import org.hibernate.type.SqlTypes;
-import org.hibernate.type.spi.TypeConfiguration;
 
 /**
  * A {@link ArgumentsValidator} that validates the arguments are all vector types i.e. {@link org.hibernate.type.SqlTypes#VECTOR}.
@@ -46,18 +44,10 @@ public class VectorArgumentValidator implements ArgumentsValidator {
 	}
 
 	private static boolean isVectorType(SqmExpressible<?> vectorType) {
-		if ( !( vectorType instanceof BasicPluralType<?, ?> ) ) {
-			return false;
-		}
-
-		switch ( ( (BasicType<?>) vectorType ).getJdbcType().getDefaultSqlTypeCode() ) {
-			case SqlTypes.VECTOR:
-			case SqlTypes.VECTOR_INT8:
-			case SqlTypes.VECTOR_FLOAT32:
-			case SqlTypes.VECTOR_FLOAT64:
-				return true;
-			default:
-				return false;
-		}
+		return vectorType instanceof BasicPluralType<?, ?> basicPluralType
+			&& switch ( basicPluralType.getJdbcType().getDefaultSqlTypeCode() ) {
+			case SqlTypes.VECTOR, SqlTypes.VECTOR_INT8, SqlTypes.VECTOR_FLOAT32, SqlTypes.VECTOR_FLOAT64 -> true;
+			default -> false;
+		};
 	}
 }

--- a/tooling/metamodel-generator/src/main/java/org/hibernate/processor/validation/MockSessionFactory.java
+++ b/tooling/metamodel-generator/src/main/java/org/hibernate/processor/validation/MockSessionFactory.java
@@ -239,7 +239,7 @@ public abstract class MockSessionFactory
 
 		nodeBuilder = new SqmCriteriaNodeBuilder("", "", this, this, this);
 
-		sqlTranslationEngine = new SqlTranslationEngineImpl(this, typeConfiguration);
+		sqlTranslationEngine = new SqlTranslationEngineImpl(this, typeConfiguration, emptyMap() );
 	}
 
 	@Override

--- a/tooling/metamodel-generator/src/main/java/org/hibernate/processor/validation/Validation.java
+++ b/tooling/metamodel-generator/src/main/java/org/hibernate/processor/validation/Validation.java
@@ -21,6 +21,7 @@ import org.hibernate.query.hql.spi.SqmCreationOptions;
 import org.hibernate.query.sqm.EntityTypeException;
 import org.hibernate.query.sqm.PathElementException;
 import org.hibernate.query.sqm.TerminalPathException;
+import org.hibernate.query.sqm.spi.SqmCreationContext;
 import org.hibernate.query.sqm.tree.SqmStatement;
 import org.hibernate.type.descriptor.java.spi.JdbcTypeRecommendationException;
 
@@ -103,17 +104,18 @@ public class Validation {
 
 	private static SemanticQueryBuilder<?> createSemanticQueryBuilder(
 			@Nullable TypeMirror returnType, String hql, SessionFactoryImplementor factory) {
+		final SqmCreationContext context = factory.getQueryEngine().getCriteriaBuilder();
 		if ( returnType != null && returnType.getKind() == TypeKind.DECLARED ) {
 			final DeclaredType declaredType = (DeclaredType) returnType;
 			final TypeElement typeElement = (TypeElement) declaredType.asElement();
 			final String typeName = typeElement.getQualifiedName().toString();
 			final String shortName = typeElement.getSimpleName().toString();
 			return isEntity( typeElement )
-					? new SemanticQueryBuilder<>( typeName, shortName, getHibernateEntityName(typeElement), CREATION_OPTIONS, factory, hql )
-					: new SemanticQueryBuilder<>( typeName, shortName, Object[].class, CREATION_OPTIONS, factory, hql );
+					? new SemanticQueryBuilder<>( typeName, shortName, getHibernateEntityName(typeElement), CREATION_OPTIONS, context, hql )
+					: new SemanticQueryBuilder<>( typeName, shortName, Object[].class, CREATION_OPTIONS, context, hql );
 		}
 		else {
-			return new SemanticQueryBuilder<>( Object[].class, CREATION_OPTIONS, factory, hql );
+			return new SemanticQueryBuilder<>( Object[].class, CREATION_OPTIONS, context, hql );
 		}
 	}
 


### PR DESCRIPTION
Let's make the `NodeBuilder` the thing that is the `SqmCreationContext`, and introduce a new thing that performs a similar role for `SqlAstCreationContext`. The reason here is twofold:

- it is part of my long struggle to decouple query parsing/typing from the `SessionFactory`, in order to make `HibernateProcessor` less of a hack and I guess more robust
- `SessionFactoryImplementor` was already starting to be polluted with weird little operations that didn't belong there. That will only get worse with time.

<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

[Please describe here what your change is about]

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-19010
<!-- Hibernate GitHub Bot issue links end -->