### PR TITLE
HHH-19011 fix incorrect placement of table comment with @Comment

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/binder/internal/CommentBinder.java
+++ b/hibernate-core/src/main/java/org/hibernate/binder/internal/CommentBinder.java
@@ -40,21 +40,25 @@ public class CommentBinder implements AttributeBinder<Comment>, TypeBinder<Comme
 			if ( on.isEmpty() || table.getName().equalsIgnoreCase( on ) ) {
 				table.setComment( text );
 			}
-			// but if 'on' is explicit, it can go on a column
-			Value element = collection.getElement();
-			for ( Column column : element.getColumns() ) {
-				if ( column.getName().equalsIgnoreCase( on ) ) {
-					column.setComment( text );
+			else {
+				// but if 'on' is explicit, it can go on a column
+				for ( Column column : table.getColumns() ) {
+					if ( column.getName().equalsIgnoreCase( on ) ) {
+						column.setComment( text );
+						return;
+					}
 				}
+				throw new AnnotationException( "No matching column for '@Comment(on=\"" + on + "\")'" );
 			}
-			//TODO: list index / map key columns
 		}
 		else {
 			for ( Column column : value.getColumns() ) {
 				if ( on.isEmpty() || column.getName().equalsIgnoreCase( on ) ) {
 					column.setComment( text );
+					return;
 				}
 			}
+			throw new AnnotationException( "No matching column for '@Comment(on=\"" + on + "\")'" );
 		}
 	}
 
@@ -67,12 +71,16 @@ public class CommentBinder implements AttributeBinder<Comment>, TypeBinder<Comme
 		if ( on.isEmpty() || primary.getName().equalsIgnoreCase( on ) ) {
 			primary.setComment( text );
 		}
-		// but if 'on' is explicit, it can go on a secondary table
-		for ( Join join : entity.getJoins() ) {
-			Table secondary = join.getTable();
-			if ( secondary.getName().equalsIgnoreCase( on ) ) {
-				secondary.setComment( text );
+		else {
+			// but if 'on' is explicit, it can go on a secondary table
+			for ( Join join : entity.getJoins() ) {
+				Table secondary = join.getTable();
+				if ( secondary.getName().equalsIgnoreCase( on ) ) {
+					secondary.setComment( text );
+					return;
+				}
 			}
+			throw new AnnotationException( "No matching column for '@Comment(on=\"" + on + "\")'" );
 		}
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/binder/internal/CommentBinder.java
+++ b/hibernate-core/src/main/java/org/hibernate/binder/internal/CommentBinder.java
@@ -35,7 +35,7 @@ public class CommentBinder implements AttributeBinder<Comment>, TypeBinder<Comme
 					+ "' was annotated '@Comment'");
 		}
 		else if ( value instanceof Collection collection ) {
-			Table table = collection.getTable();
+			Table table = collection.getCollectionTable();
 			// by default, the comment goes on the table
 			if ( on.isEmpty() || table.getName().equalsIgnoreCase( on ) ) {
 				table.setComment( text );


### PR DESCRIPTION
This annotation is deprecated in 7, but I guess this is a candidate for backport

<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

[Please describe here what your change is about]

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-19011
<!-- Hibernate GitHub Bot issue links end -->