### PR TITLE
HHH-18976 Avoid usage of Array.newInstance

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/collection/spi/PersistentArrayHolder.java
+++ b/hibernate-core/src/main/java/org/hibernate/collection/spi/PersistentArrayHolder.java
@@ -18,6 +18,7 @@ import org.hibernate.Incubating;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.internal.CoreLogging;
 import org.hibernate.internal.CoreMessageLogger;
+import org.hibernate.internal.build.AllowReflection;
 import org.hibernate.metamodel.mapping.PluralAttributeMapping;
 import org.hibernate.persister.collection.CollectionPersister;
 import org.hibernate.type.Type;
@@ -34,6 +35,7 @@ import org.hibernate.type.Type;
  * @author Gavin King
  */
 @Incubating
+@AllowReflection // We need the ability to create arrays of the same type as in the model.
 public class PersistentArrayHolder<E> extends AbstractPersistentCollection<E> {
 	private static final CoreMessageLogger LOG = CoreLogging.messageLogger( PersistentArrayHolder.class );
 

--- a/hibernate-core/src/main/java/org/hibernate/dialect/JsonHelper.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/JsonHelper.java
@@ -18,6 +18,7 @@ import java.util.NoSuchElementException;
 import java.util.Objects;
 
 import org.hibernate.Internal;
+import org.hibernate.internal.build.AllowReflection;
 import org.hibernate.internal.util.CharSequenceHelper;
 import org.hibernate.internal.util.collections.ArrayHelper;
 import org.hibernate.metamodel.mapping.EmbeddableMappingType;
@@ -1612,6 +1613,7 @@ public class JsonHelper {
 		}
 
 		@Override
+		@AllowReflection // We need the ability to create arrays of requested types dynamically.
 		public <T> T[] toArray(T[] a) {
 			//noinspection unchecked
 			final T[] r = a.length >= size

--- a/hibernate-core/src/main/java/org/hibernate/dialect/function/array/DdlTypeHelper.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/function/array/DdlTypeHelper.java
@@ -10,6 +10,7 @@ import java.util.List;
 
 import org.hibernate.dialect.Dialect;
 import org.hibernate.engine.jdbc.Size;
+import org.hibernate.internal.build.AllowReflection;
 import org.hibernate.metamodel.mapping.JdbcMappingContainer;
 import org.hibernate.metamodel.mapping.SqlTypedMapping;
 import org.hibernate.metamodel.model.domain.DomainType;
@@ -24,6 +25,7 @@ import org.hibernate.type.spi.TypeConfiguration;
 
 public class DdlTypeHelper {
 	@SuppressWarnings("unchecked")
+	@AllowReflection
 	public static BasicType<?> resolveArrayType(DomainType<?> elementType, TypeConfiguration typeConfiguration) {
 		@SuppressWarnings("unchecked") final BasicPluralJavaType<Object> arrayJavaType = (BasicPluralJavaType<Object>) typeConfiguration.getJavaTypeRegistry()
 				.getDescriptor(

--- a/hibernate-core/src/main/java/org/hibernate/dialect/function/array/JsonArrayViaElementArgumentReturnTypeResolver.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/function/array/JsonArrayViaElementArgumentReturnTypeResolver.java
@@ -8,6 +8,7 @@ import java.lang.reflect.Array;
 import java.util.List;
 import java.util.function.Supplier;
 
+import org.hibernate.internal.build.AllowReflection;
 import org.hibernate.metamodel.mapping.BasicValuedMapping;
 import org.hibernate.metamodel.mapping.MappingModelExpressible;
 import org.hibernate.metamodel.model.domain.DomainType;
@@ -78,6 +79,7 @@ public class JsonArrayViaElementArgumentReturnTypeResolver implements FunctionRe
 		return null;
 	}
 
+	@AllowReflection
 	public static <T> BasicType<?> resolveJsonArrayType(DomainType<T> elementType, TypeConfiguration typeConfiguration) {
 		final Class<?> arrayClass = Array.newInstance( elementType.getBindableJavaType(), 0 ).getClass();
 		@SuppressWarnings("unchecked")

--- a/hibernate-core/src/main/java/org/hibernate/event/service/internal/EventListenerGroupImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/event/service/internal/EventListenerGroupImpl.java
@@ -22,6 +22,7 @@ import org.hibernate.event.service.spi.EventListenerGroup;
 import org.hibernate.event.service.spi.EventListenerRegistrationException;
 import org.hibernate.event.service.spi.JpaBootstrapSensitive;
 import org.hibernate.event.spi.EventType;
+import org.hibernate.internal.build.AllowReflection;
 import org.hibernate.jpa.event.spi.CallbackRegistry;
 import org.hibernate.jpa.event.spi.CallbackRegistryConsumer;
 
@@ -350,6 +351,7 @@ class EventListenerGroupImpl<T> implements EventListenerGroup<T> {
 	}
 
 	@SuppressWarnings("unchecked")
+	@AllowReflection // Possible array types are registered in org.hibernate.graalvm.internal.StaticClassLists.typesNeedingArrayCopy
 	private T[] createListenerArrayForWrite(int len) {
 		return (T[]) Array.newInstance( eventType.baseListenerInterface(), len );
 	}

--- a/hibernate-core/src/main/java/org/hibernate/event/service/internal/EventListenerRegistryImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/event/service/internal/EventListenerRegistryImpl.java
@@ -38,6 +38,7 @@ import org.hibernate.event.service.spi.EventListenerGroup;
 import org.hibernate.event.service.spi.EventListenerRegistrationException;
 import org.hibernate.event.service.spi.EventListenerRegistry;
 import org.hibernate.event.spi.EventType;
+import org.hibernate.internal.build.AllowReflection;
 import org.hibernate.jpa.event.spi.CallbackRegistry;
 
 import static org.hibernate.event.spi.EventType.AUTO_FLUSH;
@@ -122,6 +123,7 @@ public class EventListenerRegistryImpl implements EventListenerRegistry {
 	}
 
 	@SafeVarargs
+	@AllowReflection // Possible array types are registered in org.hibernate.graalvm.internal.StaticClassLists.typesNeedingArrayCopy
 	private <T> T[] resolveListenerInstances(EventType<T> type, Class<? extends T>... listenerClasses) {
 		@SuppressWarnings("unchecked")
 		T[] listeners = (T[]) Array.newInstance( type.baseListenerInterface(), listenerClasses.length );

--- a/hibernate-core/src/main/java/org/hibernate/internal/MultiIdentifierLoadAccessImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/MultiIdentifierLoadAccessImpl.java
@@ -19,7 +19,6 @@ import org.hibernate.engine.spi.SessionImplementor;
 import org.hibernate.graph.GraphSemantic;
 import org.hibernate.graph.RootGraph;
 import org.hibernate.graph.spi.RootGraphImplementor;
-import org.hibernate.loader.ast.internal.LoaderHelper;
 import org.hibernate.persister.entity.EntityPersister;
 import org.hibernate.loader.ast.spi.MultiIdLoadOptions;
 
@@ -191,7 +190,7 @@ class MultiIdentifierLoadAccessImpl<T> implements MultiIdentifierLoadAccess<T>, 
 		}
 		else {
 			return perform( () -> (List<T>) entityPersister.multiLoad(
-					ids.toArray( LoaderHelper.createTypedArray( ids.get( 0 ).getClass(), ids.size() ) ),
+					ids.toArray( new Object[0] ),
 					session,
 					this
 			) );

--- a/hibernate-core/src/main/java/org/hibernate/internal/build/AllowReflection.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/build/AllowReflection.java
@@ -1,0 +1,18 @@
+/*
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.internal.build;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.CONSTRUCTOR;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.TYPE;
+
+@Retention( RetentionPolicy.CLASS )
+@Target({ TYPE, METHOD, CONSTRUCTOR })
+public @interface AllowReflection {
+}

--- a/hibernate-core/src/main/java/org/hibernate/internal/util/collections/ArrayHelper.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/util/collections/ArrayHelper.java
@@ -18,6 +18,7 @@ import java.util.function.Consumer;
 import org.hibernate.HibernateException;
 import org.hibernate.LockMode;
 import org.hibernate.LockOptions;
+import org.hibernate.internal.build.AllowReflection;
 import org.hibernate.type.Type;
 
 public final class ArrayHelper {
@@ -59,6 +60,7 @@ public final class ArrayHelper {
 	}
 
 	@SuppressWarnings("unchecked")
+	@AllowReflection
 	public static <T> T[] filledArray(T value, Class<T> valueJavaType, int size) {
 		final T[] array = (T[]) Array.newInstance( valueJavaType, size );
 		Arrays.fill( array, value );
@@ -202,6 +204,7 @@ public final class ArrayHelper {
 	}
 
 	@SuppressWarnings("unchecked")
+	@AllowReflection
 	public static <T> T[] join(T[] x, T... y) {
 		T[] result = (T[]) Array.newInstance( x.getClass().getComponentType(), x.length + y.length );
 		System.arraycopy( x, 0, result, 0, x.length );
@@ -520,6 +523,7 @@ public final class ArrayHelper {
 	}
 
 	@SuppressWarnings("unchecked")
+	@AllowReflection
 	public static <T> T[] newInstance(Class<T> elementType, int length) {
 		return (T[]) Array.newInstance( elementType, length );
 	}

--- a/hibernate-core/src/main/java/org/hibernate/internal/util/collections/ArrayHelper.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/util/collections/ArrayHelper.java
@@ -522,6 +522,10 @@ public final class ArrayHelper {
 		}
 	}
 
+	/**
+	 * @deprecated Use {@link Array#newInstance(Class, int)} instead.
+	 */
+	@Deprecated
 	@SuppressWarnings("unchecked")
 	@AllowReflection
 	public static <T> T[] newInstance(Class<T> elementType, int length) {

--- a/hibernate-core/src/main/java/org/hibernate/internal/util/collections/ArrayHelper.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/util/collections/ArrayHelper.java
@@ -59,14 +59,6 @@ public final class ArrayHelper {
 		return -1;
 	}
 
-	@SuppressWarnings("unchecked")
-	@AllowReflection
-	public static <T> T[] filledArray(T value, Class<T> valueJavaType, int size) {
-		final T[] array = (T[]) Array.newInstance( valueJavaType, size );
-		Arrays.fill( array, value );
-		return array;
-	}
-
 	public static String[] toStringArray(Object[] objects) {
 		int length = objects.length;
 		String[] result = new String[length];
@@ -521,15 +513,4 @@ public final class ArrayHelper {
 			consumer.accept( array[ i ] );
 		}
 	}
-
-	/**
-	 * @deprecated Use {@link Array#newInstance(Class, int)} instead.
-	 */
-	@Deprecated
-	@SuppressWarnings("unchecked")
-	@AllowReflection
-	public static <T> T[] newInstance(Class<T> elementType, int length) {
-		return (T[]) Array.newInstance( elementType, length );
-	}
-
 }

--- a/hibernate-core/src/main/java/org/hibernate/jpa/event/internal/CallbackRegistryImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/jpa/event/internal/CallbackRegistryImpl.java
@@ -9,6 +9,7 @@ import java.util.Map;
 
 import jakarta.persistence.PersistenceException;
 
+import org.hibernate.internal.build.AllowReflection;
 import org.hibernate.internal.util.collections.ArrayHelper;
 import org.hibernate.internal.util.collections.MapBackedClassValue;
 import org.hibernate.internal.util.collections.ReadOnlyMap;
@@ -168,6 +169,7 @@ final class CallbackRegistryImpl implements CallbackRegistry {
 		private final Map<Class<?>, Callback[]> postUpdates = new HashMap<>();
 		private final Map<Class<?>, Callback[]> postLoads = new HashMap<>();
 
+		@AllowReflection
 		public void registerCallbacks(Class<?> entityClass, Callback[] callbacks) {
 			if ( callbacks != null ) {
 				for ( Callback callback : callbacks ) {

--- a/hibernate-core/src/main/java/org/hibernate/loader/ast/internal/AbstractCollectionBatchLoader.java
+++ b/hibernate-core/src/main/java/org/hibernate/loader/ast/internal/AbstractCollectionBatchLoader.java
@@ -11,6 +11,7 @@ import org.hibernate.engine.spi.LoadQueryInfluencers;
 import org.hibernate.engine.spi.PersistenceContext;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
+import org.hibernate.internal.build.AllowReflection;
 import org.hibernate.loader.ast.spi.CollectionBatchLoader;
 import org.hibernate.metamodel.mapping.NonAggregatedIdentifierMapping;
 import org.hibernate.metamodel.mapping.PluralAttributeMapping;
@@ -126,6 +127,7 @@ public abstract class AbstractCollectionBatchLoader implements CollectionBatchLo
 
 	}
 
+	@AllowReflection
 	Object[] resolveKeysToInitialize(Object keyBeingLoaded, SharedSessionContractImplementor session) {
 		final int length = getDomainBatchSize();
 		final Object[] keysToInitialize = (Object[]) Array.newInstance(

--- a/hibernate-core/src/main/java/org/hibernate/loader/ast/internal/AbstractCollectionBatchLoader.java
+++ b/hibernate-core/src/main/java/org/hibernate/loader/ast/internal/AbstractCollectionBatchLoader.java
@@ -11,15 +11,9 @@ import org.hibernate.engine.spi.LoadQueryInfluencers;
 import org.hibernate.engine.spi.PersistenceContext;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
-import org.hibernate.internal.build.AllowReflection;
 import org.hibernate.loader.ast.spi.CollectionBatchLoader;
-import org.hibernate.metamodel.mapping.NonAggregatedIdentifierMapping;
 import org.hibernate.metamodel.mapping.PluralAttributeMapping;
-import org.hibernate.metamodel.mapping.ValuedModelPart;
-import org.hibernate.metamodel.mapping.internal.IdClassEmbeddable;
 import org.hibernate.sql.results.internal.ResultsHelper;
-
-import java.lang.reflect.Array;
 
 import static org.hibernate.loader.ast.internal.MultiKeyLoadHelper.hasSingleId;
 import static org.hibernate.loader.ast.internal.MultiKeyLoadHelper.trimIdBatch;
@@ -127,13 +121,9 @@ public abstract class AbstractCollectionBatchLoader implements CollectionBatchLo
 
 	}
 
-	@AllowReflection
 	Object[] resolveKeysToInitialize(Object keyBeingLoaded, SharedSessionContractImplementor session) {
 		final int length = getDomainBatchSize();
-		final Object[] keysToInitialize = (Object[]) Array.newInstance(
-				getKeyType( getLoadable().getKeyDescriptor().getKeyPart() ),
-				length
-		);
+		final Object[] keysToInitialize = new Object[length];
 		session.getPersistenceContextInternal().getBatchFetchQueue()
 				.collectBatchLoadableCollectionKeys(
 						length,
@@ -143,16 +133,6 @@ public abstract class AbstractCollectionBatchLoader implements CollectionBatchLo
 				);
 		// now trim down the array to the number of keys we found
 		return trimIdBatch( length, keysToInitialize );
-	}
-
-	protected Class<?> getKeyType(ValuedModelPart keyPart) {
-		if ( keyPart instanceof NonAggregatedIdentifierMapping ) {
-			final IdClassEmbeddable idClassEmbeddable = ( (NonAggregatedIdentifierMapping) keyPart ).getIdClassEmbeddable();
-			if ( idClassEmbeddable != null ) {
-				return idClassEmbeddable.getMappedJavaType().getJavaTypeClass();
-			}
-		}
-		return keyPart.getJavaType().getJavaTypeClass();
 	}
 
 

--- a/hibernate-core/src/main/java/org/hibernate/loader/ast/internal/AbstractMultiIdEntityLoader.java
+++ b/hibernate-core/src/main/java/org/hibernate/loader/ast/internal/AbstractMultiIdEntityLoader.java
@@ -11,7 +11,6 @@ import org.hibernate.engine.jdbc.spi.JdbcServices;
 import org.hibernate.engine.spi.EntityKey;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.event.spi.EventSource;
-import org.hibernate.internal.build.AllowReflection;
 import org.hibernate.loader.ast.spi.MultiIdEntityLoader;
 import org.hibernate.loader.ast.spi.MultiIdLoadOptions;
 import org.hibernate.loader.internal.CacheLoadHelper.PersistenceContextEntry;
@@ -22,7 +21,6 @@ import org.hibernate.sql.ast.SqlAstTranslatorFactory;
 import org.hibernate.sql.exec.spi.JdbcSelectExecutor;
 import org.hibernate.type.descriptor.java.JavaType;
 
-import java.lang.reflect.Array;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -40,15 +38,12 @@ import static org.hibernate.loader.internal.CacheLoadHelper.loadFromSessionCache
 public abstract class AbstractMultiIdEntityLoader<T> implements MultiIdEntityLoader<T> {
 	private final EntityMappingType entityDescriptor;
 	private final SessionFactoryImplementor sessionFactory;
-	private final EntityIdentifierMapping identifierMapping;
-	protected final Object[] idArray;
+	protected final EntityIdentifierMapping identifierMapping;
 
-	@AllowReflection
 	public AbstractMultiIdEntityLoader(EntityMappingType entityDescriptor, SessionFactoryImplementor sessionFactory) {
 		this.entityDescriptor = entityDescriptor;
 		this.sessionFactory = sessionFactory;
 		identifierMapping = getLoadable().getIdentifierMapping();
-		idArray = (Object[]) Array.newInstance( identifierMapping.getJavaType().getJavaTypeClass(), 0 );
 	}
 
 	protected EntityMappingType getEntityDescriptor() {
@@ -303,7 +298,7 @@ public abstract class AbstractMultiIdEntityLoader<T> implements MultiIdEntityLoa
 		}
 		else {
 			// we need to load only some the ids
-			return unresolvedIds.toArray( idArray );
+			return unresolvedIds.toArray( new Object[0] );
 		}
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/loader/ast/internal/AbstractMultiIdEntityLoader.java
+++ b/hibernate-core/src/main/java/org/hibernate/loader/ast/internal/AbstractMultiIdEntityLoader.java
@@ -11,6 +11,7 @@ import org.hibernate.engine.jdbc.spi.JdbcServices;
 import org.hibernate.engine.spi.EntityKey;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.event.spi.EventSource;
+import org.hibernate.internal.build.AllowReflection;
 import org.hibernate.loader.ast.spi.MultiIdEntityLoader;
 import org.hibernate.loader.ast.spi.MultiIdLoadOptions;
 import org.hibernate.loader.internal.CacheLoadHelper.PersistenceContextEntry;
@@ -42,6 +43,7 @@ public abstract class AbstractMultiIdEntityLoader<T> implements MultiIdEntityLoa
 	private final EntityIdentifierMapping identifierMapping;
 	protected final Object[] idArray;
 
+	@AllowReflection
 	public AbstractMultiIdEntityLoader(EntityMappingType entityDescriptor, SessionFactoryImplementor sessionFactory) {
 		this.entityDescriptor = entityDescriptor;
 		this.sessionFactory = sessionFactory;

--- a/hibernate-core/src/main/java/org/hibernate/loader/ast/internal/CollectionBatchLoaderArrayParam.java
+++ b/hibernate-core/src/main/java/org/hibernate/loader/ast/internal/CollectionBatchLoaderArrayParam.java
@@ -32,7 +32,6 @@ import org.hibernate.sql.exec.spi.JdbcParameterBindings;
 import org.hibernate.sql.exec.spi.JdbcParametersList;
 import org.hibernate.sql.results.internal.RowTransformerStandardImpl;
 import org.hibernate.sql.results.spi.ListResultsConsumer;
-import org.hibernate.type.BasicType;
 
 import static org.hibernate.loader.ast.internal.MultiKeyLoadHelper.hasSingleId;
 import static org.hibernate.loader.ast.internal.MultiKeyLoadHelper.trimIdBatch;
@@ -74,11 +73,7 @@ public class CollectionBatchLoaderArrayParam
 				.getClass();
 		keyDomainType = getKeyType( keyDescriptor.getKeyPart() );
 
-		final BasicType<?> arrayBasicType = getSessionFactory().getTypeConfiguration()
-				.getBasicTypeRegistry()
-				.getRegisteredType( jdbcArrayClass );
 		arrayJdbcMapping = MultiKeyLoadHelper.resolveArrayJdbcMapping(
-				arrayBasicType,
 				jdbcMapping,
 				jdbcArrayClass,
 				getSessionFactory()

--- a/hibernate-core/src/main/java/org/hibernate/loader/ast/internal/CollectionBatchLoaderArrayParam.java
+++ b/hibernate-core/src/main/java/org/hibernate/loader/ast/internal/CollectionBatchLoaderArrayParam.java
@@ -13,6 +13,7 @@ import org.hibernate.engine.spi.LoadQueryInfluencers;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.engine.spi.SubselectFetch;
+import org.hibernate.internal.build.AllowReflection;
 import org.hibernate.loader.ast.spi.CollectionBatchLoader;
 import org.hibernate.loader.ast.spi.SqlArrayMultiKeyLoader;
 import org.hibernate.metamodel.mapping.ForeignKeyDescriptor;
@@ -51,6 +52,7 @@ public class CollectionBatchLoaderArrayParam
 	private final SelectStatement sqlSelect;
 	private final JdbcOperationQuerySelect jdbcSelectOperation;
 
+	@AllowReflection
 	public CollectionBatchLoaderArrayParam(
 			int domainBatchSize,
 			LoadQueryInfluencers loadQueryInfluencers,
@@ -115,6 +117,7 @@ public class CollectionBatchLoaderArrayParam
 
 	}
 
+	@AllowReflection
 	private PersistentCollection<?> loadEmbeddable(
 			Object keyBeingLoaded,
 			SharedSessionContractImplementor session,
@@ -216,6 +219,7 @@ public class CollectionBatchLoaderArrayParam
 	}
 
 	@Override
+	@AllowReflection
 	Object[] resolveKeysToInitialize(Object keyBeingLoaded, SharedSessionContractImplementor session) {
 		final ForeignKeyDescriptor keyDescriptor = getLoadable().getKeyDescriptor();
 		if( keyDescriptor.isEmbedded()){

--- a/hibernate-core/src/main/java/org/hibernate/loader/ast/internal/CollectionBatchLoaderArrayParam.java
+++ b/hibernate-core/src/main/java/org/hibernate/loader/ast/internal/CollectionBatchLoaderArrayParam.java
@@ -51,7 +51,6 @@ public class CollectionBatchLoaderArrayParam
 	private final SelectStatement sqlSelect;
 	private final JdbcOperationQuerySelect jdbcSelectOperation;
 
-	@AllowReflection
 	public CollectionBatchLoaderArrayParam(
 			int domainBatchSize,
 			LoadQueryInfluencers loadQueryInfluencers,
@@ -69,13 +68,12 @@ public class CollectionBatchLoaderArrayParam
 
 		final ForeignKeyDescriptor keyDescriptor = getLoadable().getKeyDescriptor();
 		final JdbcMapping jdbcMapping = keyDescriptor.getSingleJdbcMapping();
-		final Class<?> jdbcArrayClass = Array.newInstance( jdbcMapping.getJdbcJavaType().getJavaTypeClass(), 0 )
-				.getClass();
+		final Class<?> jdbcJavaTypeClass = jdbcMapping.getJdbcJavaType().getJavaTypeClass();
 		keyDomainType = getKeyType( keyDescriptor.getKeyPart() );
 
 		arrayJdbcMapping = MultiKeyLoadHelper.resolveArrayJdbcMapping(
 				jdbcMapping,
-				jdbcArrayClass,
+				jdbcJavaTypeClass,
 				getSessionFactory()
 		);
 

--- a/hibernate-core/src/main/java/org/hibernate/loader/ast/internal/EntityBatchLoaderArrayParam.java
+++ b/hibernate-core/src/main/java/org/hibernate/loader/ast/internal/EntityBatchLoaderArrayParam.java
@@ -11,6 +11,7 @@ import java.util.Locale;
 import org.hibernate.LockOptions;
 import org.hibernate.engine.spi.LoadQueryInfluencers;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
+import org.hibernate.internal.build.AllowReflection;
 import org.hibernate.loader.ast.spi.SqlArrayMultiKeyLoader;
 import org.hibernate.metamodel.mapping.BasicEntityIdentifierMapping;
 import org.hibernate.metamodel.mapping.EntityIdentifierMapping;
@@ -58,6 +59,7 @@ public class EntityBatchLoaderArrayParam<T>
 	 * {@link EntityIdentifierMapping} is not available at that time.  On first use, we know we
 	 * have it available
 	 */
+	@AllowReflection
 	public EntityBatchLoaderArrayParam(
 			int domainBatchSize,
 			EntityMappingType entityDescriptor,
@@ -106,6 +108,7 @@ public class EntityBatchLoaderArrayParam<T>
 		return domainBatchSize;
 	}
 
+	@AllowReflection
 	protected Object[] resolveIdsToInitialize(Object pkValue, SharedSessionContractImplementor session) {
 		//TODO: should this really be different to EntityBatchLoaderInPredicate impl?
 		final Class<?> idType = identifierMapping.getJavaType().getJavaTypeClass();

--- a/hibernate-core/src/main/java/org/hibernate/loader/ast/internal/EntityBatchLoaderArrayParam.java
+++ b/hibernate-core/src/main/java/org/hibernate/loader/ast/internal/EntityBatchLoaderArrayParam.java
@@ -4,14 +4,12 @@
  */
 package org.hibernate.loader.ast.internal;
 
-import java.lang.reflect.Array;
 import java.util.Arrays;
 import java.util.Locale;
 
 import org.hibernate.LockOptions;
 import org.hibernate.engine.spi.LoadQueryInfluencers;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
-import org.hibernate.internal.build.AllowReflection;
 import org.hibernate.loader.ast.spi.SqlArrayMultiKeyLoader;
 import org.hibernate.metamodel.mapping.BasicEntityIdentifierMapping;
 import org.hibernate.metamodel.mapping.EntityIdentifierMapping;
@@ -105,11 +103,9 @@ public class EntityBatchLoaderArrayParam<T>
 		return domainBatchSize;
 	}
 
-	@AllowReflection
 	protected Object[] resolveIdsToInitialize(Object pkValue, SharedSessionContractImplementor session) {
 		//TODO: should this really be different to EntityBatchLoaderInPredicate impl?
-		final Class<?> idType = identifierMapping.getJavaType().getJavaTypeClass();
-		final Object[] idsToLoad = (Object[]) Array.newInstance( idType, domainBatchSize );
+		final Object[] idsToLoad = new Object[domainBatchSize];
 		session.getPersistenceContextInternal().getBatchFetchQueue()
 				.collectBatchLoadableEntityIds(
 						domainBatchSize,

--- a/hibernate-core/src/main/java/org/hibernate/loader/ast/internal/EntityBatchLoaderArrayParam.java
+++ b/hibernate-core/src/main/java/org/hibernate/loader/ast/internal/EntityBatchLoaderArrayParam.java
@@ -80,7 +80,6 @@ public class EntityBatchLoaderArrayParam<T>
 		final Class<?> arrayClass =
 				Array.newInstance( identifierMapping.getJavaType().getJavaTypeClass(), 0 ).getClass();
 		arrayJdbcMapping = MultiKeyLoadHelper.resolveArrayJdbcMapping(
-				sessionFactory.getTypeConfiguration().getBasicTypeRegistry().getRegisteredType( arrayClass ),
 				identifierMapping.getJdbcMapping(),
 				arrayClass,
 				sessionFactory

--- a/hibernate-core/src/main/java/org/hibernate/loader/ast/internal/EntityBatchLoaderArrayParam.java
+++ b/hibernate-core/src/main/java/org/hibernate/loader/ast/internal/EntityBatchLoaderArrayParam.java
@@ -59,7 +59,6 @@ public class EntityBatchLoaderArrayParam<T>
 	 * {@link EntityIdentifierMapping} is not available at that time.  On first use, we know we
 	 * have it available
 	 */
-	@AllowReflection
 	public EntityBatchLoaderArrayParam(
 			int domainBatchSize,
 			EntityMappingType entityDescriptor,
@@ -77,11 +76,10 @@ public class EntityBatchLoaderArrayParam<T>
 		}
 
 		identifierMapping = (BasicEntityIdentifierMapping) getLoadable().getIdentifierMapping();
-		final Class<?> arrayClass =
-				Array.newInstance( identifierMapping.getJavaType().getJavaTypeClass(), 0 ).getClass();
+		final Class<?> idClass = identifierMapping.getJavaType().getJavaTypeClass();
 		arrayJdbcMapping = MultiKeyLoadHelper.resolveArrayJdbcMapping(
 				identifierMapping.getJdbcMapping(),
-				arrayClass,
+				idClass,
 				sessionFactory
 		);
 

--- a/hibernate-core/src/main/java/org/hibernate/loader/ast/internal/LoaderHelper.java
+++ b/hibernate-core/src/main/java/org/hibernate/loader/ast/internal/LoaderHelper.java
@@ -169,6 +169,7 @@ public class LoaderHelper {
 	 *
 	 * @param <K> The key type
 	 */
+	@AllowReflection
 	public static <K> K[] normalizeKeys(
 			K[] keys,
 			BasicValuedModelPart keyPart,
@@ -184,7 +185,8 @@ public class LoaderHelper {
 			return keys;
 		}
 
-		final K[] typedArray = createTypedArray( keyClass, keys.length );
+		//noinspection unchecked
+		final K[] typedArray = (K[]) Array.newInstance( keyClass, keys.length );
 		final boolean coerce = !sessionFactory.getJpaMetamodel().getJpaCompliance().isLoadByIdComplianceEnabled();
 		if ( !coerce ) {
 			System.arraycopy( keys, 0, typedArray, 0, keys.length );
@@ -195,18 +197,6 @@ public class LoaderHelper {
 			}
 		}
 		return typedArray;
-	}
-
-	/**
-	 * Creates a typed array, as opposed to a generic {@code Object[]} that holds the typed values
-	 *
-	 * @param elementClass The type of the array elements.  See {@link Class#getComponentType()}
-	 * @param length The length to which the array should be created.  This is usually zero for Hibernate uses
-	 */
-	@AllowReflection
-	public static <X> X[] createTypedArray(Class<X> elementClass, @SuppressWarnings("SameParameterValue") int length) {
-		//noinspection unchecked
-		return (X[]) Array.newInstance( elementClass, length );
 	}
 
 	/**

--- a/hibernate-core/src/main/java/org/hibernate/loader/ast/internal/LoaderHelper.java
+++ b/hibernate-core/src/main/java/org/hibernate/loader/ast/internal/LoaderHelper.java
@@ -21,6 +21,7 @@ import org.hibernate.engine.spi.SubselectFetch;
 import org.hibernate.event.monitor.spi.EventMonitor;
 import org.hibernate.event.spi.EventSource;
 import org.hibernate.event.monitor.spi.DiagnosticEvent;
+import org.hibernate.internal.build.AllowReflection;
 import org.hibernate.loader.LoaderLogging;
 import org.hibernate.metamodel.mapping.BasicValuedModelPart;
 import org.hibernate.metamodel.mapping.EntityMappingType;
@@ -202,6 +203,7 @@ public class LoaderHelper {
 	 * @param elementClass The type of the array elements.  See {@link Class#getComponentType()}
 	 * @param length The length to which the array should be created.  This is usually zero for Hibernate uses
 	 */
+	@AllowReflection
 	public static <X> X[] createTypedArray(Class<X> elementClass, @SuppressWarnings("SameParameterValue") int length) {
 		//noinspection unchecked
 		return (X[]) Array.newInstance( elementClass, length );

--- a/hibernate-core/src/main/java/org/hibernate/loader/ast/internal/MultiIdEntityLoaderArrayParam.java
+++ b/hibernate-core/src/main/java/org/hibernate/loader/ast/internal/MultiIdEntityLoaderArrayParam.java
@@ -49,10 +49,9 @@ public class MultiIdEntityLoaderArrayParam<E> extends AbstractMultiIdEntityLoade
 			EntityMappingType entityDescriptor,
 			SessionFactoryImplementor sessionFactory) {
 		super( entityDescriptor, sessionFactory );
-		final Class<?> idClass = idArray.getClass().getComponentType();
 		arrayJdbcMapping = resolveArrayJdbcMapping(
 				getIdentifierMapping().getJdbcMapping(),
-				idClass,
+				identifierMapping.getJavaType().getJavaTypeClass(),
 				getSessionFactory()
 		);
 		jdbcParameter = new JdbcParameterImpl( arrayJdbcMapping );
@@ -117,7 +116,7 @@ public class MultiIdEntityLoaderArrayParam<E> extends AbstractMultiIdEntityLoade
 
 		final JdbcParameterBindings jdbcParameterBindings = new JdbcParameterBindingsImpl(1);
 		jdbcParameterBindings.addBinding( jdbcParameter,
-				new JdbcParameterBindingImpl( arrayJdbcMapping, idsInBatch.toArray( idArray ) ) );
+				new JdbcParameterBindingImpl( arrayJdbcMapping, idsInBatch ) );
 
 		getJdbcSelectExecutor().executeQuery(
 				getSqlAstTranslatorFactory().buildSelectTranslator( getSessionFactory(), sqlAst )

--- a/hibernate-core/src/main/java/org/hibernate/loader/ast/internal/MultiIdEntityLoaderArrayParam.java
+++ b/hibernate-core/src/main/java/org/hibernate/loader/ast/internal/MultiIdEntityLoaderArrayParam.java
@@ -49,10 +49,10 @@ public class MultiIdEntityLoaderArrayParam<E> extends AbstractMultiIdEntityLoade
 			EntityMappingType entityDescriptor,
 			SessionFactoryImplementor sessionFactory) {
 		super( entityDescriptor, sessionFactory );
-		final Class<?> idArrayClass = idArray.getClass();
+		final Class<?> idClass = idArray.getClass().getComponentType();
 		arrayJdbcMapping = resolveArrayJdbcMapping(
 				getIdentifierMapping().getJdbcMapping(),
-				idArrayClass,
+				idClass,
 				getSessionFactory()
 		);
 		jdbcParameter = new JdbcParameterImpl( arrayJdbcMapping );

--- a/hibernate-core/src/main/java/org/hibernate/loader/ast/internal/MultiIdEntityLoaderArrayParam.java
+++ b/hibernate-core/src/main/java/org/hibernate/loader/ast/internal/MultiIdEntityLoaderArrayParam.java
@@ -51,7 +51,6 @@ public class MultiIdEntityLoaderArrayParam<E> extends AbstractMultiIdEntityLoade
 		super( entityDescriptor, sessionFactory );
 		final Class<?> idArrayClass = idArray.getClass();
 		arrayJdbcMapping = resolveArrayJdbcMapping(
-				getSessionFactory().getTypeConfiguration().getBasicTypeRegistry().getRegisteredType( idArrayClass ),
 				getIdentifierMapping().getJdbcMapping(),
 				idArrayClass,
 				getSessionFactory()

--- a/hibernate-core/src/main/java/org/hibernate/loader/ast/internal/MultiKeyLoadHelper.java
+++ b/hibernate-core/src/main/java/org/hibernate/loader/ast/internal/MultiKeyLoadHelper.java
@@ -27,10 +27,11 @@ public class MultiKeyLoadHelper {
 	}
 
 	public static JdbcMapping resolveArrayJdbcMapping(
-			BasicType<?> arrayBasicType,
 			JdbcMapping keyMapping,
 			Class<?> arrayClass,
 			SessionFactoryImplementor sessionFactory) {
+		BasicType<?> arrayBasicType = sessionFactory.getTypeConfiguration().getBasicTypeRegistry()
+				.getRegisteredType( arrayClass );
 		if ( arrayBasicType != null ) {
 			return arrayBasicType;
 		}

--- a/hibernate-core/src/main/java/org/hibernate/loader/ast/internal/MultiKeyLoadHelper.java
+++ b/hibernate-core/src/main/java/org/hibernate/loader/ast/internal/MultiKeyLoadHelper.java
@@ -28,10 +28,10 @@ public class MultiKeyLoadHelper {
 
 	public static JdbcMapping resolveArrayJdbcMapping(
 			JdbcMapping keyMapping,
-			Class<?> arrayClass,
+			Class<?> elementClass,
 			SessionFactoryImplementor sessionFactory) {
 		BasicType<?> arrayBasicType = sessionFactory.getTypeConfiguration().getBasicTypeRegistry()
-				.getRegisteredType( arrayClass );
+				.getRegisteredArrayType( elementClass );
 		if ( arrayBasicType != null ) {
 			return arrayBasicType;
 		}
@@ -39,9 +39,9 @@ public class MultiKeyLoadHelper {
 		final TypeConfiguration typeConfiguration = sessionFactory.getTypeConfiguration();
 		final JavaTypeRegistry javaTypeRegistry = typeConfiguration.getJavaTypeRegistry();
 
-		final JavaType<Object> rawArrayJavaType = javaTypeRegistry.resolveDescriptor( arrayClass );
-		if ( !(rawArrayJavaType instanceof BasicPluralJavaType<?> arrayJavaType) ) {
-			throw new IllegalArgumentException( "Expecting BasicPluralJavaType for array class `" + arrayClass.getName() + "`, but got `" + rawArrayJavaType + "`" );
+		final JavaType<?> rawArrayJavaType = javaTypeRegistry.resolveArrayDescriptor( elementClass );
+		if ( !(rawArrayJavaType instanceof BasicPluralJavaType<?> arrayJavaType ) ) {
+			throw new IllegalArgumentException( "Expecting BasicPluralJavaType for array class `" + elementClass.getTypeName() + "[]`, but got `" + rawArrayJavaType + "`" );
 		}
 
 		//noinspection unchecked,rawtypes

--- a/hibernate-core/src/main/java/org/hibernate/loader/ast/internal/MultiNaturalIdLoaderArrayParam.java
+++ b/hibernate-core/src/main/java/org/hibernate/loader/ast/internal/MultiNaturalIdLoaderArrayParam.java
@@ -23,8 +23,6 @@ import org.hibernate.sql.ast.tree.select.SelectStatement;
 import org.hibernate.sql.exec.internal.JdbcParameterImpl;
 import org.hibernate.sql.exec.spi.JdbcOperationQuerySelect;
 import org.hibernate.sql.exec.spi.JdbcParameterBindings;
-import org.hibernate.type.BasicType;
-import org.hibernate.type.BasicTypeRegistry;
 
 /**
  * Standard MultiNaturalIdLoader implementation
@@ -77,10 +75,7 @@ public class MultiNaturalIdLoaderArrayParam<E> implements MultiNaturalIdLoader<E
 						? LockOptions.NONE
 						: loadOptions.getLockOptions();
 
-		final BasicTypeRegistry basicTypeRegistry = sessionFactory.getTypeConfiguration().getBasicTypeRegistry();
-		final BasicType<?> arrayBasicType = basicTypeRegistry.getRegisteredType( keyArrayClass );
 		final JdbcMapping arrayJdbcMapping = MultiKeyLoadHelper.resolveArrayJdbcMapping(
-				arrayBasicType,
 				getNaturalIdMapping().getSingleJdbcMapping(),
 				keyArrayClass,
 				sessionFactory

--- a/hibernate-core/src/main/java/org/hibernate/loader/ast/internal/MultiNaturalIdLoaderArrayParam.java
+++ b/hibernate-core/src/main/java/org/hibernate/loader/ast/internal/MultiNaturalIdLoaderArrayParam.java
@@ -29,15 +29,14 @@ import org.hibernate.sql.exec.spi.JdbcParameterBindings;
  */
 public class MultiNaturalIdLoaderArrayParam<E> implements MultiNaturalIdLoader<E>, SqlArrayMultiKeyLoader {
 	private final EntityMappingType entityDescriptor;
-	private final Class<?> keyArrayClass;
+	private final Class<?> keyClass;
 
 	public MultiNaturalIdLoaderArrayParam(EntityMappingType entityDescriptor) {
 		assert entityDescriptor.getNaturalIdMapping() instanceof SimpleNaturalIdMapping;
 
 		this.entityDescriptor = entityDescriptor;
 
-		final Class<?> keyClass = entityDescriptor.getNaturalIdMapping().getJavaType().getJavaTypeClass();
-		this.keyArrayClass = LoaderHelper.createTypedArray( keyClass, 0 ).getClass();
+		this.keyClass = entityDescriptor.getNaturalIdMapping().getJavaType().getJavaTypeClass();
 	}
 
 	@Override
@@ -77,7 +76,7 @@ public class MultiNaturalIdLoaderArrayParam<E> implements MultiNaturalIdLoader<E
 
 		final JdbcMapping arrayJdbcMapping = MultiKeyLoadHelper.resolveArrayJdbcMapping(
 				getNaturalIdMapping().getSingleJdbcMapping(),
-				keyArrayClass,
+				keyClass,
 				sessionFactory
 		);
 		final JdbcParameter jdbcParameter = new JdbcParameterImpl( arrayJdbcMapping );

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/internal/StandardRowReader.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/internal/StandardRowReader.java
@@ -9,6 +9,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.hibernate.engine.spi.EntityKey;
+import org.hibernate.internal.build.AllowReflection;
 import org.hibernate.sql.results.graph.DomainResultAssembler;
 import org.hibernate.sql.results.graph.Initializer;
 import org.hibernate.sql.results.graph.InitializerData;
@@ -130,6 +131,7 @@ public class StandardRowReader<T> implements RowReader<T> {
 	}
 
 	@Override
+	@AllowReflection
 	public T readRow(RowProcessingState rowProcessingState) {
 		coordinateInitializers( rowProcessingState );
 

--- a/hibernate-core/src/main/java/org/hibernate/type/ArrayType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/ArrayType.java
@@ -16,6 +16,7 @@ import org.hibernate.collection.spi.PersistentArrayHolder;
 import org.hibernate.collection.spi.PersistentCollection;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
+import org.hibernate.internal.build.AllowReflection;
 import org.hibernate.metamodel.CollectionClassification;
 import org.hibernate.persister.collection.CollectionPersister;
 
@@ -26,6 +27,7 @@ import static org.hibernate.bytecode.enhance.spi.LazyPropertyInitializer.UNFETCH
  * A type for persistent arrays.
  * @author Gavin King
  */
+@AllowReflection
 public class ArrayType extends CollectionType {
 
 	private final Class<?> elementClass;

--- a/hibernate-core/src/main/java/org/hibernate/type/BasicTypeRegistry.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/BasicTypeRegistry.java
@@ -117,6 +117,10 @@ public class BasicTypeRegistry implements Serializable {
 		return getRegisteredType( javaType.getTypeName() );
 	}
 
+	public BasicType<?> getRegisteredArrayType(java.lang.reflect.Type javaElementType) {
+		return getRegisteredType( javaElementType.getTypeName() + "[]" );
+	}
+
 	public <J> BasicType<J> resolve(BasicTypeReference<J> basicTypeReference) {
 		return getRegisteredType( basicTypeReference.getName() );
 	}

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/converter/internal/ArrayConverter.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/converter/internal/ArrayConverter.java
@@ -6,6 +6,7 @@ package org.hibernate.type.descriptor.converter.internal;
 
 import java.lang.reflect.Array;
 
+import org.hibernate.internal.build.AllowReflection;
 import org.hibernate.type.descriptor.converter.spi.BasicValueConverter;
 import org.hibernate.type.descriptor.java.JavaType;
 
@@ -18,6 +19,7 @@ import org.hibernate.type.descriptor.java.JavaType;
  * @param <T> the unconverted array type
  * @param <S> the converted array type
  */
+@AllowReflection
 public class ArrayConverter<T, S, E, F> implements BasicValueConverter<T, S> {
 
 	private final BasicValueConverter<E, F> elementConverter;

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/converter/internal/CollectionConverter.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/converter/internal/CollectionConverter.java
@@ -7,6 +7,7 @@ package org.hibernate.type.descriptor.converter.internal;
 import java.lang.reflect.Array;
 import java.util.Collection;
 
+import org.hibernate.internal.build.AllowReflection;
 import org.hibernate.type.descriptor.converter.spi.BasicValueConverter;
 import org.hibernate.type.descriptor.java.JavaType;
 import org.hibernate.type.descriptor.java.spi.BasicCollectionJavaType;
@@ -43,6 +44,7 @@ public class CollectionConverter<X extends Collection<Object>, Y> implements Bas
 	}
 
 	@Override
+	@AllowReflection
 	public Y toRelationalValue(X domainForm) {
 		if ( domainForm == null ) {
 			return null;

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/AbstractArrayJavaType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/AbstractArrayJavaType.java
@@ -8,6 +8,7 @@ import java.lang.reflect.Array;
 
 import org.hibernate.MappingException;
 import org.hibernate.dialect.Dialect;
+import org.hibernate.internal.build.AllowReflection;
 import org.hibernate.tool.schema.extract.spi.ColumnTypeInformation;
 import org.hibernate.type.descriptor.converter.internal.ArrayConverter;
 import org.hibernate.type.BasicArrayType;
@@ -20,6 +21,7 @@ import org.hibernate.type.descriptor.jdbc.JdbcType;
 import org.hibernate.type.descriptor.jdbc.JdbcTypeIndicators;
 import org.hibernate.type.spi.TypeConfiguration;
 
+@AllowReflection
 public abstract class AbstractArrayJavaType<T, E> extends AbstractClassJavaType<T>
 		implements BasicPluralJavaType<E> {
 

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/ArrayJavaType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/ArrayJavaType.java
@@ -14,6 +14,7 @@ import org.hibernate.SharedSessionContract;
 import org.hibernate.dialect.Dialect;
 import org.hibernate.engine.jdbc.BinaryStream;
 import org.hibernate.engine.jdbc.internal.ArrayBackedBinaryStream;
+import org.hibernate.internal.build.AllowReflection;
 import org.hibernate.internal.util.SerializationHelper;
 import org.hibernate.tool.schema.extract.spi.ColumnTypeInformation;
 import org.hibernate.type.BasicPluralType;
@@ -29,6 +30,7 @@ import org.hibernate.type.spi.TypeConfiguration;
  * @author Christian Beikov
  * @author Jordan Gigov
  */
+@AllowReflection
 public class ArrayJavaType<T> extends AbstractArrayJavaType<T[], T> {
 
 	public ArrayJavaType(BasicType<T> baseDescriptor) {
@@ -376,6 +378,7 @@ public class ArrayJavaType<T> extends AbstractArrayJavaType<T[], T> {
 		}
 	}
 
+	@AllowReflection
 	private static class ArrayMutabilityPlan<T> implements MutabilityPlan<T[]> {
 
 		private final Class<T> componentClass;

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/ArrayMutabilityPlan.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/ArrayMutabilityPlan.java
@@ -12,7 +12,12 @@ import java.lang.reflect.Array;
  * are immutable, a shallow copy is enough.
  *
  * @author Steve Ebersole
+ *
+ * @deprecated Use {@link ImmutableObjectArrayMutabilityPlan#get()} for object arrays,
+ * or implement a dedicated mutability plan for primitive arrays
+ * (see for example {@link ShortPrimitiveArrayJavaType}'s mutability plan).
  */
+@Deprecated
 public class ArrayMutabilityPlan<T> extends MutableMutabilityPlan<T> {
 	public static final ArrayMutabilityPlan INSTANCE = new ArrayMutabilityPlan();
 

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/ArrayMutabilityPlan.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/ArrayMutabilityPlan.java
@@ -3,6 +3,8 @@
  * Copyright Red Hat Inc. and Hibernate Authors
  */
 package org.hibernate.type.descriptor.java;
+import org.hibernate.internal.build.AllowReflection;
+
 import java.lang.reflect.Array;
 
 /**
@@ -15,6 +17,7 @@ public class ArrayMutabilityPlan<T> extends MutableMutabilityPlan<T> {
 	public static final ArrayMutabilityPlan INSTANCE = new ArrayMutabilityPlan();
 
 	@SuppressWarnings({ "unchecked", "SuspiciousSystemArraycopy" })
+	@AllowReflection
 	public T deepCopyNotNull(T value) {
 		if ( ! value.getClass().isArray() ) {
 			// ugh!  cannot find a way to properly define the type signature here

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/BooleanPrimitiveArrayJavaType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/BooleanPrimitiveArrayJavaType.java
@@ -16,6 +16,7 @@ import org.hibernate.HibernateException;
 import org.hibernate.SharedSessionContract;
 import org.hibernate.engine.jdbc.BinaryStream;
 import org.hibernate.engine.jdbc.internal.ArrayBackedBinaryStream;
+import org.hibernate.internal.build.AllowReflection;
 import org.hibernate.internal.util.SerializationHelper;
 import org.hibernate.type.descriptor.WrapperOptions;
 
@@ -24,6 +25,7 @@ import org.hibernate.type.descriptor.WrapperOptions;
  *
  * @author Christian Beikov
  */
+@AllowReflection // Needed for arbitrary array wrapping/unwrapping
 public class BooleanPrimitiveArrayJavaType extends AbstractArrayJavaType<boolean[], Boolean> {
 
 	public static final BooleanPrimitiveArrayJavaType INSTANCE = new BooleanPrimitiveArrayJavaType();

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/BooleanPrimitiveArrayJavaType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/BooleanPrimitiveArrayJavaType.java
@@ -4,7 +4,6 @@
  */
 package org.hibernate.type.descriptor.java;
 
-import java.io.Serializable;
 import java.lang.reflect.Array;
 import java.sql.SQLException;
 import java.util.ArrayList;
@@ -13,7 +12,6 @@ import java.util.Collection;
 import java.util.List;
 
 import org.hibernate.HibernateException;
-import org.hibernate.SharedSessionContract;
 import org.hibernate.engine.jdbc.BinaryStream;
 import org.hibernate.engine.jdbc.internal.ArrayBackedBinaryStream;
 import org.hibernate.internal.build.AllowReflection;
@@ -185,27 +183,10 @@ public class BooleanPrimitiveArrayJavaType extends AbstractArrayJavaType<boolean
 		throw unknownWrap( value.getClass() );
 	}
 
-	private static class ArrayMutabilityPlan implements MutabilityPlan<boolean[]> {
-
+	private static class ArrayMutabilityPlan extends MutableMutabilityPlan<boolean[]> {
 		@Override
-		public boolean isMutable() {
-			return true;
+		protected boolean[] deepCopyNotNull(boolean[] value) {
+			return value.clone();
 		}
-
-		@Override
-		public boolean[] deepCopy(boolean[] value) {
-			return value == null ? null : value.clone();
-		}
-
-		@Override
-		public Serializable disassemble(boolean[] value, SharedSessionContract session) {
-			return deepCopy( value );
-		}
-
-		@Override
-		public boolean[] assemble(Serializable cached, SharedSessionContract session) {
-			return deepCopy( (boolean[]) cached );
-		}
-
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/ByteArrayJavaType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/ByteArrayJavaType.java
@@ -30,7 +30,7 @@ public class ByteArrayJavaType extends AbstractClassJavaType<Byte[]> {
 
 	@SuppressWarnings("unchecked")
 	public ByteArrayJavaType() {
-		super( Byte[].class, ArrayMutabilityPlan.INSTANCE, IncomparableComparator.INSTANCE );
+		super( Byte[].class, ImmutableObjectArrayMutabilityPlan.get(), IncomparableComparator.INSTANCE );
 	}
 	@Override
 	public boolean areEqual(Byte[] one, Byte[] another) {

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/CharacterArrayJavaType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/CharacterArrayJavaType.java
@@ -29,7 +29,7 @@ public class CharacterArrayJavaType extends AbstractClassJavaType<Character[]> {
 
 	@SuppressWarnings("unchecked")
 	public CharacterArrayJavaType() {
-		super( Character[].class, ArrayMutabilityPlan.INSTANCE, IncomparableComparator.INSTANCE );
+		super( Character[].class, ImmutableObjectArrayMutabilityPlan.get(), IncomparableComparator.INSTANCE );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/DoublePrimitiveArrayJavaType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/DoublePrimitiveArrayJavaType.java
@@ -16,6 +16,7 @@ import org.hibernate.HibernateException;
 import org.hibernate.SharedSessionContract;
 import org.hibernate.engine.jdbc.BinaryStream;
 import org.hibernate.engine.jdbc.internal.ArrayBackedBinaryStream;
+import org.hibernate.internal.build.AllowReflection;
 import org.hibernate.internal.util.SerializationHelper;
 import org.hibernate.type.descriptor.WrapperOptions;
 
@@ -24,6 +25,7 @@ import org.hibernate.type.descriptor.WrapperOptions;
  *
  * @author Christian Beikov
  */
+@AllowReflection // Needed for arbitrary array wrapping/unwrapping
 public class DoublePrimitiveArrayJavaType extends AbstractArrayJavaType<double[], Double> {
 
 	public static final DoublePrimitiveArrayJavaType INSTANCE = new DoublePrimitiveArrayJavaType();

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/DoublePrimitiveArrayJavaType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/DoublePrimitiveArrayJavaType.java
@@ -4,7 +4,6 @@
  */
 package org.hibernate.type.descriptor.java;
 
-import java.io.Serializable;
 import java.lang.reflect.Array;
 import java.sql.SQLException;
 import java.util.ArrayList;
@@ -13,7 +12,6 @@ import java.util.Collection;
 import java.util.List;
 
 import org.hibernate.HibernateException;
-import org.hibernate.SharedSessionContract;
 import org.hibernate.engine.jdbc.BinaryStream;
 import org.hibernate.engine.jdbc.internal.ArrayBackedBinaryStream;
 import org.hibernate.internal.build.AllowReflection;
@@ -185,27 +183,10 @@ public class DoublePrimitiveArrayJavaType extends AbstractArrayJavaType<double[]
 		throw unknownWrap( value.getClass() );
 	}
 
-	private static class ArrayMutabilityPlan implements MutabilityPlan<double[]> {
-
+	private static class ArrayMutabilityPlan extends MutableMutabilityPlan<double[]> {
 		@Override
-		public boolean isMutable() {
-			return true;
+		protected double[] deepCopyNotNull(double[] value) {
+			return value.clone();
 		}
-
-		@Override
-		public double[] deepCopy(double[] value) {
-			return value == null ? null : value.clone();
-		}
-
-		@Override
-		public Serializable disassemble(double[] value, SharedSessionContract session) {
-			return deepCopy( value );
-		}
-
-		@Override
-		public double[] assemble(Serializable cached, SharedSessionContract session) {
-			return deepCopy( (double[]) cached );
-		}
-
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/FloatPrimitiveArrayJavaType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/FloatPrimitiveArrayJavaType.java
@@ -16,6 +16,7 @@ import org.hibernate.HibernateException;
 import org.hibernate.SharedSessionContract;
 import org.hibernate.engine.jdbc.BinaryStream;
 import org.hibernate.engine.jdbc.internal.ArrayBackedBinaryStream;
+import org.hibernate.internal.build.AllowReflection;
 import org.hibernate.internal.util.SerializationHelper;
 import org.hibernate.type.descriptor.WrapperOptions;
 
@@ -24,6 +25,7 @@ import org.hibernate.type.descriptor.WrapperOptions;
  *
  * @author Christian Beikov
  */
+@AllowReflection // Needed for arbitrary array wrapping/unwrapping
 public class FloatPrimitiveArrayJavaType extends AbstractArrayJavaType<float[], Float> {
 
 	public static final FloatPrimitiveArrayJavaType INSTANCE = new FloatPrimitiveArrayJavaType();

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/FloatPrimitiveArrayJavaType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/FloatPrimitiveArrayJavaType.java
@@ -4,7 +4,6 @@
  */
 package org.hibernate.type.descriptor.java;
 
-import java.io.Serializable;
 import java.lang.reflect.Array;
 import java.sql.SQLException;
 import java.util.ArrayList;
@@ -13,7 +12,6 @@ import java.util.Collection;
 import java.util.List;
 
 import org.hibernate.HibernateException;
-import org.hibernate.SharedSessionContract;
 import org.hibernate.engine.jdbc.BinaryStream;
 import org.hibernate.engine.jdbc.internal.ArrayBackedBinaryStream;
 import org.hibernate.internal.build.AllowReflection;
@@ -185,27 +183,10 @@ public class FloatPrimitiveArrayJavaType extends AbstractArrayJavaType<float[], 
 		throw unknownWrap( value.getClass() );
 	}
 
-	private static class ArrayMutabilityPlan implements MutabilityPlan<float[]> {
-
+	private static class ArrayMutabilityPlan extends MutableMutabilityPlan<float[]> {
 		@Override
-		public boolean isMutable() {
-			return true;
+		protected float[] deepCopyNotNull(float[] value) {
+			return value.clone();
 		}
-
-		@Override
-		public float[] deepCopy(float[] value) {
-			return value == null ? null : value.clone();
-		}
-
-		@Override
-		public Serializable disassemble(float[] value, SharedSessionContract session) {
-			return deepCopy( value );
-		}
-
-		@Override
-		public float[] assemble(Serializable cached, SharedSessionContract session) {
-			return deepCopy( (float[]) cached );
-		}
-
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/ImmutableObjectArrayMutabilityPlan.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/ImmutableObjectArrayMutabilityPlan.java
@@ -1,0 +1,26 @@
+/*
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.type.descriptor.java;
+
+/**
+ * A mutability plan for mutable arrays of immutable, non-primitive objects.
+ * <p>
+ * Since the elements themselves are immutable, the deep copy can be implemented with a shallow copy.
+ *
+ * @author Steve Ebersole
+ */
+public final class ImmutableObjectArrayMutabilityPlan<T> extends MutableMutabilityPlan<T[]> {
+	@SuppressWarnings("rawtypes")
+	private static final ImmutableObjectArrayMutabilityPlan INSTANCE = new ImmutableObjectArrayMutabilityPlan();
+
+	@SuppressWarnings("unchecked") // Works for any T
+	public static <T> ImmutableObjectArrayMutabilityPlan<T> get() {
+		return (ImmutableObjectArrayMutabilityPlan<T>) INSTANCE;
+	}
+
+	public T[] deepCopyNotNull(T[] value) {
+		return value.clone();
+	}
+}

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/IntegerPrimitiveArrayJavaType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/IntegerPrimitiveArrayJavaType.java
@@ -16,6 +16,7 @@ import org.hibernate.HibernateException;
 import org.hibernate.SharedSessionContract;
 import org.hibernate.engine.jdbc.BinaryStream;
 import org.hibernate.engine.jdbc.internal.ArrayBackedBinaryStream;
+import org.hibernate.internal.build.AllowReflection;
 import org.hibernate.internal.util.SerializationHelper;
 import org.hibernate.type.descriptor.WrapperOptions;
 
@@ -24,6 +25,7 @@ import org.hibernate.type.descriptor.WrapperOptions;
  *
  * @author Christian Beikov
  */
+@AllowReflection // Needed for arbitrary array wrapping/unwrapping
 public class IntegerPrimitiveArrayJavaType extends AbstractArrayJavaType<int[], Integer> {
 
 	public static final IntegerPrimitiveArrayJavaType INSTANCE = new IntegerPrimitiveArrayJavaType();

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/IntegerPrimitiveArrayJavaType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/IntegerPrimitiveArrayJavaType.java
@@ -4,7 +4,6 @@
  */
 package org.hibernate.type.descriptor.java;
 
-import java.io.Serializable;
 import java.lang.reflect.Array;
 import java.sql.SQLException;
 import java.util.ArrayList;
@@ -13,7 +12,6 @@ import java.util.Collection;
 import java.util.List;
 
 import org.hibernate.HibernateException;
-import org.hibernate.SharedSessionContract;
 import org.hibernate.engine.jdbc.BinaryStream;
 import org.hibernate.engine.jdbc.internal.ArrayBackedBinaryStream;
 import org.hibernate.internal.build.AllowReflection;
@@ -185,27 +183,10 @@ public class IntegerPrimitiveArrayJavaType extends AbstractArrayJavaType<int[], 
 		throw unknownWrap( value.getClass() );
 	}
 
-	private static class ArrayMutabilityPlan implements MutabilityPlan<int[]> {
-
+	private static class ArrayMutabilityPlan extends MutableMutabilityPlan<int[]> {
 		@Override
-		public boolean isMutable() {
-			return true;
+		protected int[] deepCopyNotNull(int[] value) {
+			return value.clone();
 		}
-
-		@Override
-		public int[] deepCopy(int[] value) {
-			return value == null ? null : value.clone();
-		}
-
-		@Override
-		public Serializable disassemble(int[] value, SharedSessionContract session) {
-			return deepCopy( value );
-		}
-
-		@Override
-		public int[] assemble(Serializable cached, SharedSessionContract session) {
-			return deepCopy( (int[]) cached );
-		}
-
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/LongPrimitiveArrayJavaType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/LongPrimitiveArrayJavaType.java
@@ -16,6 +16,7 @@ import org.hibernate.HibernateException;
 import org.hibernate.SharedSessionContract;
 import org.hibernate.engine.jdbc.BinaryStream;
 import org.hibernate.engine.jdbc.internal.ArrayBackedBinaryStream;
+import org.hibernate.internal.build.AllowReflection;
 import org.hibernate.internal.util.SerializationHelper;
 import org.hibernate.type.descriptor.WrapperOptions;
 
@@ -24,6 +25,7 @@ import org.hibernate.type.descriptor.WrapperOptions;
  *
  * @author Christian Beikov
  */
+@AllowReflection // Needed for arbitrary array wrapping/unwrapping
 public class LongPrimitiveArrayJavaType extends AbstractArrayJavaType<long[], Long> {
 
 	public static final LongPrimitiveArrayJavaType INSTANCE = new LongPrimitiveArrayJavaType();

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/LongPrimitiveArrayJavaType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/LongPrimitiveArrayJavaType.java
@@ -4,7 +4,6 @@
  */
 package org.hibernate.type.descriptor.java;
 
-import java.io.Serializable;
 import java.lang.reflect.Array;
 import java.sql.SQLException;
 import java.util.ArrayList;
@@ -13,7 +12,6 @@ import java.util.Collection;
 import java.util.List;
 
 import org.hibernate.HibernateException;
-import org.hibernate.SharedSessionContract;
 import org.hibernate.engine.jdbc.BinaryStream;
 import org.hibernate.engine.jdbc.internal.ArrayBackedBinaryStream;
 import org.hibernate.internal.build.AllowReflection;
@@ -185,27 +183,10 @@ public class LongPrimitiveArrayJavaType extends AbstractArrayJavaType<long[], Lo
 		throw unknownWrap( value.getClass() );
 	}
 
-	private static class ArrayMutabilityPlan implements MutabilityPlan<long[]> {
-
+	private static class ArrayMutabilityPlan extends MutableMutabilityPlan<long[]> {
 		@Override
-		public boolean isMutable() {
-			return true;
+		protected long[] deepCopyNotNull(long[] value) {
+			return value.clone();
 		}
-
-		@Override
-		public long[] deepCopy(long[] value) {
-			return value == null ? null : value.clone();
-		}
-
-		@Override
-		public Serializable disassemble(long[] value, SharedSessionContract session) {
-			return deepCopy( value );
-		}
-
-		@Override
-		public long[] assemble(Serializable cached, SharedSessionContract session) {
-			return deepCopy( (long[]) cached );
-		}
-
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/PrimitiveByteArrayJavaType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/PrimitiveByteArrayJavaType.java
@@ -28,9 +28,8 @@ public class PrimitiveByteArrayJavaType extends AbstractClassJavaType<byte[]>
 		implements VersionJavaType<byte[]> {
 	public static final PrimitiveByteArrayJavaType INSTANCE = new PrimitiveByteArrayJavaType();
 
-	@SuppressWarnings("unchecked")
 	public PrimitiveByteArrayJavaType() {
-		super( byte[].class, ArrayMutabilityPlan.INSTANCE, RowVersionComparator.INSTANCE );
+		super( byte[].class, new ArrayMutabilityPlan(), RowVersionComparator.INSTANCE );
 	}
 
 	@Override
@@ -159,5 +158,12 @@ public class PrimitiveByteArrayJavaType extends AbstractClassJavaType<byte[]>
 			Integer precision,
 			Integer scale, SharedSessionContractImplementor session) {
 		return current;
+	}
+
+	private static class ArrayMutabilityPlan extends MutableMutabilityPlan<byte[]> {
+		@Override
+		protected byte[] deepCopyNotNull(byte[] value) {
+			return value.clone();
+		}
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/PrimitiveCharacterArrayJavaType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/PrimitiveCharacterArrayJavaType.java
@@ -24,7 +24,7 @@ public class PrimitiveCharacterArrayJavaType extends AbstractClassJavaType<char[
 
 	@SuppressWarnings("unchecked")
 	protected PrimitiveCharacterArrayJavaType() {
-		super( char[].class, ArrayMutabilityPlan.INSTANCE, IncomparableComparator.INSTANCE );
+		super( char[].class, new ArrayMutabilityPlan(), IncomparableComparator.INSTANCE );
 	}
 
 	public String toString(char[] value) {
@@ -102,5 +102,12 @@ public class PrimitiveCharacterArrayJavaType extends AbstractClassJavaType<char[
 	@Override
 	public <X> char[] coerce(X value, CoercionContext coercionContext) {
 		return wrap( value, null );
+	}
+
+	private static class ArrayMutabilityPlan extends MutableMutabilityPlan<char[]> {
+		@Override
+		protected char[] deepCopyNotNull(char[] value) {
+			return value.clone();
+		}
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/ShortPrimitiveArrayJavaType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/ShortPrimitiveArrayJavaType.java
@@ -4,7 +4,6 @@
  */
 package org.hibernate.type.descriptor.java;
 
-import java.io.Serializable;
 import java.lang.reflect.Array;
 import java.sql.SQLException;
 import java.util.ArrayList;
@@ -13,7 +12,6 @@ import java.util.Collection;
 import java.util.List;
 
 import org.hibernate.HibernateException;
-import org.hibernate.SharedSessionContract;
 import org.hibernate.engine.jdbc.BinaryStream;
 import org.hibernate.engine.jdbc.internal.ArrayBackedBinaryStream;
 import org.hibernate.internal.build.AllowReflection;
@@ -185,27 +183,10 @@ public class ShortPrimitiveArrayJavaType extends AbstractArrayJavaType<short[], 
 		throw unknownWrap( value.getClass() );
 	}
 
-	private static class ArrayMutabilityPlan implements MutabilityPlan<short[]> {
-
+	private static class ArrayMutabilityPlan extends MutableMutabilityPlan<short[]> {
 		@Override
-		public boolean isMutable() {
-			return true;
+		protected short[] deepCopyNotNull(short[] value) {
+			return value.clone();
 		}
-
-		@Override
-		public short[] deepCopy(short[] value) {
-			return value == null ? null : value.clone();
-		}
-
-		@Override
-		public Serializable disassemble(short[] value, SharedSessionContract session) {
-			return deepCopy( value );
-		}
-
-		@Override
-		public short[] assemble(Serializable cached, SharedSessionContract session) {
-			return deepCopy( (short[]) cached );
-		}
-
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/ShortPrimitiveArrayJavaType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/ShortPrimitiveArrayJavaType.java
@@ -16,6 +16,7 @@ import org.hibernate.HibernateException;
 import org.hibernate.SharedSessionContract;
 import org.hibernate.engine.jdbc.BinaryStream;
 import org.hibernate.engine.jdbc.internal.ArrayBackedBinaryStream;
+import org.hibernate.internal.build.AllowReflection;
 import org.hibernate.internal.util.SerializationHelper;
 import org.hibernate.type.descriptor.WrapperOptions;
 
@@ -24,6 +25,7 @@ import org.hibernate.type.descriptor.WrapperOptions;
  *
  * @author Christian Beikov
  */
+@AllowReflection // Needed for arbitrary array wrapping/unwrapping
 public class ShortPrimitiveArrayJavaType extends AbstractArrayJavaType<short[], Short> {
 
 	public static final ShortPrimitiveArrayJavaType INSTANCE = new ShortPrimitiveArrayJavaType();

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/spi/BasicCollectionJavaType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/spi/BasicCollectionJavaType.java
@@ -21,6 +21,7 @@ import org.hibernate.collection.spi.CollectionSemantics;
 import org.hibernate.dialect.Dialect;
 import org.hibernate.engine.jdbc.BinaryStream;
 import org.hibernate.engine.jdbc.internal.ArrayBackedBinaryStream;
+import org.hibernate.internal.build.AllowReflection;
 import org.hibernate.internal.util.SerializationHelper;
 import org.hibernate.internal.util.collections.CollectionHelper;
 import org.hibernate.metamodel.CollectionClassification;
@@ -46,6 +47,7 @@ import org.hibernate.type.spi.TypeConfiguration;
  * @author Christian Beikov
  */
 @Incubating
+@AllowReflection // Needed for arbitrary array wrapping/unwrapping
 public class BasicCollectionJavaType<C extends Collection<E>, E> extends AbstractJavaType<C> implements
 		BasicPluralJavaType<E> {
 

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/spi/JavaTypeRegistry.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/spi/JavaTypeRegistry.java
@@ -34,7 +34,7 @@ public class JavaTypeRegistry implements JavaTypeBaseline.BaselineTarget, Serial
 	private static final Logger log = Logger.getLogger( JavaTypeRegistry.class );
 
 	private final TypeConfiguration typeConfiguration;
-	private final ConcurrentHashMap<Type, JavaType<?>> descriptorsByType = new ConcurrentHashMap<>();
+	private final ConcurrentHashMap<String, JavaType<?>> descriptorsByTypeName = new ConcurrentHashMap<>();
 
 	public JavaTypeRegistry(TypeConfiguration typeConfiguration) {
 		this.typeConfiguration = typeConfiguration;
@@ -56,7 +56,7 @@ public class JavaTypeRegistry implements JavaTypeBaseline.BaselineTarget, Serial
 	@Override
 	public void addBaselineDescriptor(Type describedJavaType, JavaType<?> descriptor) {
 		performInjections( descriptor );
-		descriptorsByType.put( describedJavaType, descriptor );
+		descriptorsByTypeName.put( describedJavaType.getTypeName(), descriptor );
 	}
 
 	private void performInjections(JavaType<?> descriptor) {
@@ -71,7 +71,7 @@ public class JavaTypeRegistry implements JavaTypeBaseline.BaselineTarget, Serial
 	// descriptor access
 
 	public void forEachDescriptor(Consumer<JavaType<?>> consumer) {
-		descriptorsByType.values().forEach( consumer );
+		descriptorsByTypeName.values().forEach( consumer );
 	}
 
 	public <T> JavaType<T> getDescriptor(Type javaType) {
@@ -79,7 +79,7 @@ public class JavaTypeRegistry implements JavaTypeBaseline.BaselineTarget, Serial
 	}
 
 	public void addDescriptor(JavaType<?> descriptor) {
-		JavaType<?> old = descriptorsByType.put( descriptor.getJavaType(), descriptor );
+		JavaType<?> old = descriptorsByTypeName.put( descriptor.getJavaType().getTypeName(), descriptor );
 		if ( old != null ) {
 			log.debugf(
 					"JavaTypeRegistry entry replaced : %s -> %s (was %s)",
@@ -93,40 +93,51 @@ public class JavaTypeRegistry implements JavaTypeBaseline.BaselineTarget, Serial
 
 	public <J> JavaType<J> findDescriptor(Type javaType) {
 		//noinspection unchecked
-		return (JavaType<J>) descriptorsByType.get( javaType );
+		return (JavaType<J>) descriptorsByTypeName.get( javaType.getTypeName() );
 	}
 
 	public <J> JavaType<J> resolveDescriptor(Type javaType, Supplier<JavaType<J>> creator) {
-		final JavaType<?> cached = descriptorsByType.get( javaType );
+		return resolveDescriptor( javaType.getTypeName(), creator );
+	}
+
+	private <J> JavaType<J> resolveDescriptor(String javaTypeName, Supplier<JavaType<J>> creator) {
+		final JavaType<?> cached = descriptorsByTypeName.get( javaTypeName );
 		if ( cached != null ) {
 			//noinspection unchecked
 			return (JavaType<J>) cached;
 		}
 
 		final JavaType<J> created = creator.get();
-		descriptorsByType.put( javaType, created );
+		descriptorsByTypeName.put( javaTypeName, created );
 		return created;
 	}
 
 	public <J> JavaType<J> resolveDescriptor(Type javaType) {
-		return resolveDescriptor( javaType, (elementJavaType, typeConfiguration) -> {
-			final MutabilityPlan<J> determinedPlan = RegistryHelper.INSTANCE.determineMutabilityPlan(
-					elementJavaType,
-					typeConfiguration
-			);
-			if ( determinedPlan != null ) {
-				return determinedPlan;
-			}
+		return resolveDescriptor( javaType, JavaTypeRegistry::createMutabilityPlan );
+	}
 
-			return MutableMutabilityPlan.INSTANCE;
-		} );
+	private static <J> MutabilityPlan<?> createMutabilityPlan(Type elementJavaType, TypeConfiguration typeConfiguration) {
+		final MutabilityPlan<J> determinedPlan = RegistryHelper.INSTANCE.determineMutabilityPlan(
+				elementJavaType,
+				typeConfiguration
+		);
+		if ( determinedPlan != null ) {
+			return determinedPlan;
+		}
+
+		return MutableMutabilityPlan.INSTANCE;
+	}
+
+	public JavaType<?> resolveArrayDescriptor(Class<?> elementJavaType) {
+		return resolveDescriptor( elementJavaType + "[]",
+				() -> createArrayTypeDescriptor( elementJavaType, JavaTypeRegistry::createMutabilityPlan) );
 	}
 
 	public <J> JavaType<J> resolveDescriptor(
 			Type javaType,
 			BiFunction<Type, TypeConfiguration, MutabilityPlan<?>> mutabilityPlanCreator) {
 		return resolveDescriptor(
-				javaType,
+				javaType.getTypeName(),
 				() -> {
 					if ( javaType instanceof ParameterizedType parameterizedType ) {
 						final JavaType<J> rawType = findDescriptor( parameterizedType.getRawType() );
@@ -134,30 +145,29 @@ public class JavaTypeRegistry implements JavaTypeBaseline.BaselineTarget, Serial
 							return rawType.createJavaType( parameterizedType, typeConfiguration );
 						}
 					}
-					final Type elementJavaType;
-					JavaType<J> elementTypeDescriptor;
-					if ( javaType instanceof Class<?> && ( (Class<?>) javaType ).isArray() ) {
-						elementJavaType = ( (Class<?>) javaType ).getComponentType();
-						elementTypeDescriptor = findDescriptor( elementJavaType );
-					}
-					else {
-						elementJavaType = javaType;
-						elementTypeDescriptor = null;
-					}
-					if ( elementTypeDescriptor == null ) {
+					else if ( javaType instanceof Class<?> javaClass && javaClass.isArray() ) {
 						//noinspection unchecked
-						elementTypeDescriptor = RegistryHelper.INSTANCE.createTypeDescriptor(
-								elementJavaType,
-								() -> (MutabilityPlan<J>) mutabilityPlanCreator.apply( elementJavaType, typeConfiguration ),
-								typeConfiguration
-						);
+						return (JavaType<J>) createArrayTypeDescriptor( javaClass.getComponentType(), mutabilityPlanCreator );
 					}
-					if ( javaType != elementJavaType ) {
-						//noinspection unchecked
-						return (JavaType<J>) new ArrayJavaType<>( elementTypeDescriptor );
-					}
-					return elementTypeDescriptor;
+					return createTypeDescriptor( javaType, mutabilityPlanCreator );
 				}
+		);
+	}
+
+	private <J> JavaType<J[]> createArrayTypeDescriptor(Class<J> elementJavaType, BiFunction<Type, TypeConfiguration, MutabilityPlan<?>> mutabilityPlanCreator) {
+		JavaType<J> elementTypeDescriptor = findDescriptor( elementJavaType );
+		if ( elementTypeDescriptor == null ) {
+			elementTypeDescriptor = createTypeDescriptor( elementJavaType, mutabilityPlanCreator );
+		}
+		return new ArrayJavaType<>( elementTypeDescriptor );
+	}
+
+	private <J> JavaType<J> createTypeDescriptor(Type javaType, BiFunction<Type, TypeConfiguration, MutabilityPlan<?>> mutabilityPlanCreator) {
+		//noinspection unchecked
+		return RegistryHelper.INSTANCE.createTypeDescriptor(
+				javaType,
+				() -> (MutabilityPlan<J>) mutabilityPlanCreator.apply( javaType, typeConfiguration ),
+				typeConfiguration
 		);
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/jdbc/ArrayJdbcType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/jdbc/ArrayJdbcType.java
@@ -17,6 +17,7 @@ import org.hibernate.dialect.StructAttributeValues;
 import org.hibernate.dialect.StructHelper;
 import org.hibernate.engine.jdbc.Size;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
+import org.hibernate.internal.build.AllowReflection;
 import org.hibernate.metamodel.mapping.EmbeddableMappingType;
 import org.hibernate.type.BasicPluralType;
 import org.hibernate.type.descriptor.ValueBinder;
@@ -40,6 +41,7 @@ import static org.hibernate.dialect.StructHelper.instantiate;
  * @author Christian Beikov
  * @author Jordan Gigov
  */
+@AllowReflection // See https://hibernate.atlassian.net/browse/HHH-16809
 public class ArrayJdbcType implements JdbcType {
 
 	private final JdbcType elementJdbcType;

--- a/hibernate-core/src/main/java/org/hibernate/type/format/jaxb/JaxbXmlFormatMapper.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/format/jaxb/JaxbXmlFormatMapper.java
@@ -20,6 +20,7 @@ import javax.xml.namespace.QName;
 
 import jakarta.xml.bind.annotation.XmlElement;
 import org.hibernate.dialect.XmlHelper;
+import org.hibernate.internal.build.AllowReflection;
 import org.hibernate.internal.util.ReflectHelper;
 import org.hibernate.internal.util.collections.CollectionHelper;
 import org.hibernate.sql.ast.spi.StringBuilderSqlAppender;
@@ -70,6 +71,7 @@ public final class JaxbXmlFormatMapper implements FormatMapper {
 	}
 
 	@Override
+	@AllowReflection
 	public <T> T fromString(CharSequence charSequence, JavaType<T> javaType, WrapperOptions wrapperOptions) {
 		if ( javaType.getJavaType() == String.class || javaType.getJavaType() == Object.class ) {
 			return (T) charSequence.toString();

--- a/local-build-plugins/src/main/groovy/local.code-quality.gradle
+++ b/local-build-plugins/src/main/groovy/local.code-quality.gradle
@@ -123,10 +123,14 @@ tasks.forbiddenApisMain {
     //bundledSignatures += ["jdk-system-out", "jdk-non-portable", "jdk-unsafe-${jdkVersions.baseline}"]
     bundledSignatures += ["jdk-system-out", "jdk-non-portable"]
 
+    signaturesFiles += rootProject.files('rules/forbidden-apis.txt')
+    ignoreSignaturesOfMissingClasses = true
+
     suppressAnnotations += [
             "org.hibernate.internal.build.AllowSysOut",
             "org.hibernate.internal.build.AllowPrintStacktrace",
-            "org.hibernate.internal.build.AllowNonPortable"
+            "org.hibernate.internal.build.AllowNonPortable",
+            "org.hibernate.internal.build.AllowReflection"
     ]
 }
 

--- a/rules/forbidden-apis.txt
+++ b/rules/forbidden-apis.txt
@@ -1,0 +1,20 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+# Copyright Red Hat Inc. and Hibernate Authors
+
+# This file is a list of signatures to feed into Forbidden-API.
+# It defines classes/methods to be avoided.
+# See here for the syntax of this file: https://github.com/policeman-tools/forbidden-apis/wiki/SignaturesSyntax
+
+################################################################################################################
+# Reflection-related
+@defaultMessage Use 'new Object[]' instead if possible. This forbidden method requires reflection and may not work in natively compiled applications. If you really must use this forbidden method, annotate the calling method with @AllowReflection.
+
+java.lang.reflect.Array#newInstance(java.lang.Class, int)
+java.lang.reflect.Array#newInstance(java.lang.Class, int[])
+org.hibernate.internal.util.collections.ArrayHelper#newInstance(java.lang.Class, int)
+org.hibernate.internal.util.collections.ArrayHelper#filledArray(java.lang.Object, java.lang.Class, int)
+org.hibernate.internal.util.collections.ArrayHelper#join(java.lang.Object[], java.lang.Object[])
+
+################################################################################################################
+# Misc -- put things here as a last resort, but if possible prefer adding a category above with an actionable message.
+@defaultMessage Should not be used.

--- a/rules/forbidden-apis.txt
+++ b/rules/forbidden-apis.txt
@@ -11,8 +11,6 @@
 
 java.lang.reflect.Array#newInstance(java.lang.Class, int)
 java.lang.reflect.Array#newInstance(java.lang.Class, int[])
-org.hibernate.internal.util.collections.ArrayHelper#newInstance(java.lang.Class, int)
-org.hibernate.internal.util.collections.ArrayHelper#filledArray(java.lang.Object, java.lang.Class, int)
 org.hibernate.internal.util.collections.ArrayHelper#join(java.lang.Object[], java.lang.Object[])
 
 ################################################################################################################


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-18976

Two things in here:

1. Sets up forbiddenapis to forbid usage of `Array.newInstance` (and util methods known to use it) by default. This is mostly as a heads-up to not use it "just because", since the check can be bypassed if necessary by annotating the method with `@AllowReflection`.
2. Reworks a few implementations to avoid usage of `Array.newInstance`. E.g.:
   * use `array.clone()` where relevant (i.e. when we want the same array type with the same length).
   * don't use `Array.newInstance` just to retrieve the `Class` of an array type -- since we ultimately just look use that `Class` to look up a descriptor in a registry.
   * use `new Object[...]` instead where possible (e.g. when the array ends up being used internally only).

This should get rid of most problematic uses of reflection when compiling to native binaries (see Jira issue).
There are still a few uses of `Array.newInstance` but as far as I can see they are completely justified and cannot easily be worked around: array mapping, JSON/XML serialization, instantiation of query result types, ...