### PR TITLE
Allow Jenkins to parse the release Jenkinsfile before cancelling non-release triggers

### DIFF
--- a/ci/release/Jenkinsfile
+++ b/ci/release/Jenkinsfile
@@ -23,32 +23,6 @@ print "INFO: env.PROJECT = ${env.PROJECT}"
 print "INFO: env.JIRA_KEY = ${env.JIRA_KEY}"
 
 // --------------------------------------------
-// Build conditions
-
-// Avoid running the pipeline on branch indexing
-if (currentBuild.getBuildCauses().toString().contains('BranchIndexingCause')) {
-	print "INFO: Build skipped due to trigger being Branch Indexing"
-	currentBuild.result = 'NOT_BUILT'
-	return
-}
-
-def manualRelease = currentBuild.getBuildCauses().toString().contains( 'UserIdCause' )
-def cronRelease = currentBuild.getBuildCauses().toString().contains( 'TimerTriggerCause' )
-
-// Only do automatic release on branches where we opted in
-if ( !manualRelease && !cronRelease ) {
-	print "INFO: Build skipped because automated releases on push are disabled on this branch."
-	currentBuild.result = 'NOT_BUILT'
-	return
-}
-
-if ( !manualRelease && cronRelease && !RELEASE_ON_SCHEDULE ) {
-	print "INFO: Build skipped because automated releases are disabled on this branch. See constant RELEASE_ON_SCHEDULE in ci/release/Jenkinsfile"
-	currentBuild.result = 'NOT_BUILT'
-	return
-}
-
-// --------------------------------------------
 // Reusable methods
 
 def checkoutReleaseScripts() {
@@ -63,6 +37,9 @@ def checkoutReleaseScripts() {
 // --------------------------------------------
 // Pipeline
 
+// NOTE: this job checks pre-conditions
+// and may cancel itself before even running,
+// see "Build conditions" at the bottom of this file.
 pipeline {
 	agent {
 		label 'Worker&&Containers'
@@ -284,4 +261,34 @@ pipeline {
  			}
  		}
  	}
+}
+
+// --------------------------------------------
+// Build conditions
+
+// Note this code is at the end of the file for a reason:
+// this code gets executed after Jenkins parses the Jenkinsfile (so that Jenkins knows about the build's parameters/options)
+// but before Jenkins runs the build (so that we can cancel it before an agent is even started).
+
+// Avoid running the pipeline on branch indexing
+if (currentBuild.getBuildCauses().toString().contains('BranchIndexingCause')) {
+	print "INFO: Build skipped due to trigger being Branch Indexing"
+	currentBuild.result = 'NOT_BUILT'
+	return
+}
+
+def manualRelease = currentBuild.getBuildCauses().toString().contains( 'UserIdCause' )
+def cronRelease = currentBuild.getBuildCauses().toString().contains( 'TimerTriggerCause' )
+
+// Only do automatic release on branches where we opted in
+if ( !manualRelease && !cronRelease ) {
+	print "INFO: Build skipped because automated releases on push are disabled on this branch."
+	currentBuild.result = 'NOT_BUILT'
+	return
+}
+
+if ( !manualRelease && cronRelease && !RELEASE_ON_SCHEDULE ) {
+	print "INFO: Build skipped because automated releases are disabled on this branch. See constant RELEASE_ON_SCHEDULE in ci/release/Jenkinsfile"
+	currentBuild.result = 'NOT_BUILT'
+	return
 }


### PR DESCRIPTION
This way, we can update parameters/options and have Jenkins take them into account for the next build upon branch indexing or push, even though we don't release on branch indexing or push.

NOTE: This is untested. Depending on how Jenkinsfiles get executed, this may or may not work.

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
