### PR TITLE
HHH-18901 Do not enhance if AccessType default is PROPERTY

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/bytecode/enhance/internal/bytebuddy/EnhancerImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/bytecode/enhance/internal/bytebuddy/EnhancerImpl.java
@@ -528,6 +528,11 @@ public class EnhancerImpl implements Enhancer {
 		// Check name of the getter/setter method with persistence annotation and getter/setter method name that doesn't refer to an entity field
 		// and will return false.  If the property accessor method(s) are named to match the field name(s), return true.
 		final AccessType defaultAccessType = determineDefaultAccessType( managedCtClass );
+
+		if ( AccessType.PROPERTY == defaultAccessType) {
+			return true;
+		}
+
 		final MethodList<?> methods = MethodGraph.Compiler.DEFAULT.compile( (TypeDefinition) managedCtClass )
 				.listNodes()
 				.asMethodList()


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-18901

Trying change to not enhance entity classes that have accessType default of PROPERTY.
