### PR TITLE
[6.6] HHH-18819 Error resolving persistent property of @MapperSuperclass if subtype @Embeddable used as @IdClass

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/metamodel/internal/MetadataContext.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/internal/MetadataContext.java
@@ -575,15 +575,24 @@ public class MetadataContext {
 		return null;
 	}
 
-	private EmbeddableTypeImpl<?> applyIdClassMetadata(Component idClassComponent) {
-		final JavaTypeRegistry registry = getTypeConfiguration()
-				.getJavaTypeRegistry();
-		final Class<?> componentClass = idClassComponent.getComponentClass();
-		final JavaType<?> javaType = registry.resolveManagedTypeDescriptor( componentClass );
+	private <Y> EmbeddableTypeImpl<Y> applyIdClassMetadata(Component idClassComponent) {
+		final JavaType<Y> javaType =
+				getTypeConfiguration().getJavaTypeRegistry()
+						.resolveManagedTypeDescriptor( idClassComponent.getComponentClass() );
 
-		final EmbeddableTypeImpl<?> embeddableType = new EmbeddableTypeImpl<>(
+		final MappedSuperclass mappedSuperclass = idClassComponent.getMappedSuperclass();
+		final MappedSuperclassDomainType<? super Y> superType;
+		if ( mappedSuperclass != null ) {
+			//noinspection unchecked
+			superType = (MappedSuperclassDomainType<? super Y>) locateMappedSuperclassType( mappedSuperclass );
+		}
+		else {
+			superType = null;
+		}
+
+		final EmbeddableTypeImpl<Y> embeddableType = new EmbeddableTypeImpl<>(
 				javaType,
-				null,
+				superType,
 				null,
 				false,
 				getJpaMetamodel()

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/metamodel/EmbeddableMetaModelTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/metamodel/EmbeddableMetaModelTest.java
@@ -28,6 +28,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 		Person.class,
 		Measurement.class,
 		Height.class,
+		WeightClass.class,
+		Weight.class,
 } )
 public class EmbeddableMetaModelTest {
 	@Test
@@ -59,6 +61,20 @@ public class EmbeddableMetaModelTest {
 			assertEquals( MAPPED_SUPERCLASS, embeddable.getSuperType().getPersistenceType() );
 			assertEquals( Measurement.class, embeddable.getSuperType().getJavaType() );
 			assertNotNull( Height_.height );
+			assertNotNull( Measurement_.unit );
+		} );
+	}
+
+	@Test
+	@Jira( "https://hibernate.atlassian.net/browse/HHH-18819" )
+	public void testIdClass(EntityManagerFactoryScope scope) {
+		scope.inTransaction( entityManager -> {
+			final EmbeddableDomainType<Weight> embeddable = (EmbeddableDomainType<Weight>) entityManager.getMetamodel()
+					.embeddable( Weight.class );
+			assertNotNull( embeddable.getSuperType() );
+			assertEquals( MAPPED_SUPERCLASS, embeddable.getSuperType().getPersistenceType() );
+			assertEquals( Measurement.class, embeddable.getSuperType().getJavaType() );
+			assertNotNull( Weight_.weight );
 			assertNotNull( Measurement_.unit );
 		} );
 	}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/metamodel/Weight.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/metamodel/Weight.java
@@ -1,0 +1,15 @@
+/*
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.metamodel;
+
+import jakarta.persistence.Embeddable;
+
+/**
+ * @author Marco Belladelli
+ */
+@Embeddable
+public class Weight extends Measurement {
+	private float weight;
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/metamodel/WeightClass.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/metamodel/WeightClass.java
@@ -1,0 +1,24 @@
+/*
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.metamodel;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.IdClass;
+
+/**
+ * @author Marco Belladelli
+ */
+@Entity
+@IdClass(Weight.class)
+public class WeightClass {
+	@Id
+	private String unit;
+
+	@Id
+	private float weight;
+
+	private String description;
+}


### PR DESCRIPTION
<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

https://hibernate.atlassian.net/browse/HHH-18819

Backport of https://github.com/hibernate/hibernate-orm/pull/9584

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
