### PR TITLE
document the difference in semantics of FlushMode.AUTO 

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/boot/spi/SessionFactoryOptions.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/spi/SessionFactoryOptions.java
@@ -92,8 +92,8 @@ public interface SessionFactoryOptions extends QueryEngineOptions {
 	JpaCompliance getJpaCompliance();
 
 	/**
-	 * Was building of the SessionFactory initiated through JPA bootstrapping, or
-	 * through Hibernate's native bootstrapping?
+	 * Was building of the {@link org.hibernate.SessionFactory} initiated through JPA
+	 * bootstrapping, or through Hibernate-native bootstrapping?
 	 *
 	 * @return {@code true} indicates the SessionFactory was built through JPA
 	 * bootstrapping; {@code false} indicates it was built through native bootstrapping.

--- a/hibernate-core/src/main/java/org/hibernate/query/NativeQuery.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/NativeQuery.java
@@ -82,6 +82,18 @@ import java.util.Map;
  *     {@link #addSynchronizedEntityName}, or
  *     {@link #addSynchronizedQuerySpace}.
  * </ul>
+ * <p>
+ * When the affected tables are not known to Hibernate, the behavior depends
+ * on whether Hibernate is operating in fully JPA-compliant mode.
+ * <ul>
+ * <li>In JPA-compliant mode, {@link FlushModeType#AUTO} specifies that the
+ *     session should be flushed before execution of a native query when the
+ *     affected tables are not known.
+ * <li>Otherwise, when Hibernate is not operating in JPA-compliant mode,
+ *     {@code AUTO} specifies that the session is <em>not</em> flushed before
+ *     execution of a native query, unless the affected tables are known and
+ *     Hibernate determines that a flush is required.
+ * </ul>
  *
  * @author Gavin King
  * @author Steve Ebersole


### PR DESCRIPTION
... between JPA bootstrap and native Hibernate.

<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

[Please describe here what your change is about]

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
