### PR TITLE
fix javadoc defect for ColumnWriteFragment

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/sql/model/ast/ColumnWriteFragment.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/model/ast/ColumnWriteFragment.java
@@ -16,7 +16,7 @@ import org.hibernate.sql.ast.tree.expression.Expression;
 
 /**
  * Models a column's value expression within the SQL AST. Used to model:<ul>
- *     <li>a new column's value in an INSERT clause</li>
+ *     <li>a column's value in an INSERT clause</li>
  *     <li>a column's new value in a SET clause</li>
  *     <li>a column's old value in a restriction (optimistic locking)</li>
  * </ul>

--- a/hibernate-core/src/main/java/org/hibernate/sql/model/ast/ColumnWriteFragment.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/model/ast/ColumnWriteFragment.java
@@ -16,7 +16,7 @@ import org.hibernate.sql.ast.tree.expression.Expression;
 
 /**
  * Models a column's value expression within the SQL AST. Used to model:<ul>
- *     <li>a column's new value in a SET clause</li>
+ *     <li>a new column's value in an INSERT clause</li>
  *     <li>a column's new value in a SET clause</li>
  *     <li>a column's old value in a restriction (optimistic locking)</li>
  * </ul>


### PR DESCRIPTION
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------

Seems an obvious Javadoc defact