### PR TITLE
Enable the check to verify that the license agreement is present in a PR description

### DIFF
--- a/.github/hibernate-github-bot.yml
+++ b/.github/hibernate-github-bot.yml
@@ -61,3 +61,5 @@ develocity:
         replacement: "$1"
       - pattern: "main|HEAD|\\d+.\\d+|PR-\\d+"
         replacement: "" # Just remove these tags
+licenseAgreement:
+  enabled: true


### PR DESCRIPTION
This should add another check to PRs to verify that a user hasn't removed the "license text" part from the PR. 

I tested this a bit with Search and my bot-playground repositories. It should be working ok now, but if anyone notices some false-failures -- please let me know. 

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
