### PR TITLE
HHH-13915 : Prevent state sharing in basic proxies.

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/bytecode/internal/bytebuddy/BasicProxyFactoryImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/bytecode/internal/bytebuddy/BasicProxyFactoryImpl.java
@@ -24,7 +24,6 @@ public class BasicProxyFactoryImpl implements BasicProxyFactory {
 	private static final String PROXY_NAMING_SUFFIX = "HibernateBasicProxy";
 
 	private final Class proxyClass;
-	private final ProxyConfiguration.Interceptor interceptor;
 	private final Constructor proxyClassConstructor;
 
 	@SuppressWarnings({ "unchecked", "rawtypes" })
@@ -54,7 +53,7 @@ public class BasicProxyFactoryImpl implements BasicProxyFactory {
 							.intercept( byteBuddyState.getProxyDefinitionHelpers().getInterceptorFieldAccessor() )
 				)
 		);
-		this.interceptor = new PassThroughInterceptor( proxyClass.getName() );
+
 		try {
 			proxyClassConstructor = proxyClass.getConstructor();
 		}
@@ -76,7 +75,9 @@ public class BasicProxyFactoryImpl implements BasicProxyFactory {
 		if ( proxyConfiguration == null ) {
 			throw new HibernateException( "Produced proxy does not correctly implement ProxyConfiguration" );
 		}
-		proxyConfiguration.$$_hibernate_set_interceptor( this.interceptor );
+		// Create a dedicated interceptor for the proxy. This is required as the interceptor is stateful.
+		final ProxyConfiguration.Interceptor interceptor = new PassThroughInterceptor( proxyClass.getName() );
+		proxyConfiguration.$$_hibernate_set_interceptor( interceptor );
 		return instance;
 	}
 

--- a/hibernate-core/src/test/java/org/hibernate/bytecode/internal/bytebuddy/ByteBuddyBasicProxyFactoryTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/bytecode/internal/bytebuddy/ByteBuddyBasicProxyFactoryTest.java
@@ -13,12 +13,12 @@ import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import org.hibernate.testing.orm.junit.JiraKey;
 import org.junit.Test;
 
-@JiraKey(value = "HHH-12786")
 public class ByteBuddyBasicProxyFactoryTest {
 
 	private static final BasicProxyFactoryImpl BASIC_PROXY_FACTORY = new BasicProxyFactoryImpl( Entity.class, null, new ByteBuddyState() );
 
 	@Test
+	@JiraKey(value = "HHH-12786")
 	public void testEqualsHashCode() {
 		Object entityProxy = BASIC_PROXY_FACTORY.getProxy();
 
@@ -30,6 +30,7 @@ public class ByteBuddyBasicProxyFactoryTest {
 	}
 
 	@Test
+	@JiraKey(value = "HHH-12786")
 	public void testToString() {
 		Object entityProxy = BASIC_PROXY_FACTORY.getProxy();
 
@@ -37,6 +38,7 @@ public class ByteBuddyBasicProxyFactoryTest {
 	}
 
 	@Test
+	@JiraKey(value = "HHH-12786")
 	public void testGetterSetter() {
 		Entity entityProxy = (Entity) BASIC_PROXY_FACTORY.getProxy();
 
@@ -50,10 +52,21 @@ public class ByteBuddyBasicProxyFactoryTest {
 	}
 
 	@Test
+	@JiraKey(value = "HHH-12786")
 	public void testNonGetterSetterMethod() {
 		Entity entityProxy = (Entity) BASIC_PROXY_FACTORY.getProxy();
 
 		assertNull( entityProxy.otherMethod() );
+	}
+
+	@Test
+	@JiraKey(value = "HHH-13915")
+	public void testProxiesDoNotShareState() {
+		Entity entityAProxy = (Entity) BASIC_PROXY_FACTORY.getProxy();
+		entityAProxy.setString( "John Irving" );
+
+		Entity entityBProxy = (Entity) BASIC_PROXY_FACTORY.getProxy();
+		assertNull( entityBProxy.getString() );
 	}
 
 	public static class Entity {


### PR DESCRIPTION
Basic proxies were being created with a shared interceptor.  As the interceptor is stateful, this lead to cross-thread data leakage and thus intermittently broken persistence. This mod creates an interceptor per proxy, preventing leaking of state.

(Originally submitted by [@bighenry](https://github.com/bighenry) for 5.6)

----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-13915
<!-- Hibernate GitHub Bot issue links end -->