### PR TITLE
HHH-19017: Address ClassCastException for PersistentAttributeInterceptable

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/entity/internal/EntityDelayedFetchInitializer.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/entity/internal/EntityDelayedFetchInitializer.java
@@ -13,6 +13,7 @@ import org.hibernate.engine.spi.EntityHolder;
 import org.hibernate.engine.spi.EntityKey;
 import org.hibernate.engine.spi.EntityUniqueKey;
 import org.hibernate.engine.spi.PersistenceContext;
+import org.hibernate.engine.spi.PersistentAttributeInterceptable;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.graph.GraphSemantic;
 import org.hibernate.graph.spi.AppliedGraph;
@@ -198,27 +199,34 @@ public class EntityDelayedFetchInitializer
 					if ( referencedModelPart.isLazy() ) {
 						instance = UNFETCHED_PROPERTY;
 					}
-					else if ( getParent().isEntityInitializer() && isLazyByGraph( rowProcessingState ) ) {
-						// todo : manage the case when parent is an EmbeddableInitializer
-						final Object resolvedInstance = getParent().asEntityInitializer()
-								.getResolvedInstance( rowProcessingState );
-						final LazyAttributeLoadingInterceptor persistentAttributeInterceptor = (LazyAttributeLoadingInterceptor) ManagedTypeHelper
-								.asPersistentAttributeInterceptable( resolvedInstance ).$$_hibernate_getInterceptor();
-
-						persistentAttributeInterceptor.addLazyFieldByGraph( navigablePath.getLocalName() );
-						instance = UNFETCHED_PROPERTY;
-					}
 					else {
-						instance = concreteDescriptor.loadByUniqueKey(
-								uniqueKeyPropertyName,
-								data.entityIdentifier,
-								session
-						);
+						// Try to load a PersistentAttributeInterceptable. If we get one, we can add the lazy
+						// field to the interceptor. If we don't get one, we load the entity by unique key.
+						PersistentAttributeInterceptable persistentAttributeInterceptable = null;
+						if ( getParent().isEntityInitializer() && isLazyByGraph( rowProcessingState ) ) {
+							final Object resolvedInstance =
+									getParent().asEntityInitializer().getResolvedInstance( rowProcessingState );
+							persistentAttributeInterceptable =
+									ManagedTypeHelper.asPersistentAttributeInterceptableOrNull( resolvedInstance );
+						}
 
-						// If the entity was not in the Persistence Context, but was found now,
-						// add it to the Persistence Context
-						if ( instance != null ) {
-							persistenceContext.addEntity( euk, instance );
+						if ( persistentAttributeInterceptable != null ) {
+							final LazyAttributeLoadingInterceptor persistentAttributeInterceptor = (LazyAttributeLoadingInterceptor) persistentAttributeInterceptable.$$_hibernate_getInterceptor();
+							persistentAttributeInterceptor.addLazyFieldByGraph( navigablePath.getLocalName() );
+							instance = UNFETCHED_PROPERTY;
+						}
+						else {
+							instance = concreteDescriptor.loadByUniqueKey(
+									uniqueKeyPropertyName,
+									data.entityIdentifier,
+									session
+							);
+
+							// If the entity was not in the Persistence Context, but was found now,
+							// add it to the Persistence Context
+							if ( instance != null ) {
+								persistenceContext.addEntity( euk, instance );
+							}
 						}
 					}
 				}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/lazyonetoone/LazyOneToOneWithEntityGraphTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/lazyonetoone/LazyOneToOneWithEntityGraphTest.java
@@ -1,0 +1,115 @@
+/*
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.lazyonetoone;
+
+import java.util.List;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.NamedAttributeNode;
+import jakarta.persistence.NamedEntityGraph;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.OneToOne;
+import org.hibernate.testing.bytecode.enhancement.extension.BytecodeEnhanced;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static org.hibernate.Hibernate.isInitialized;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@DomainModel(
+	annotatedClasses = {
+		LazyOneToOneWithEntityGraphTest.Company.class,
+		LazyOneToOneWithEntityGraphTest.Employee.class,
+		LazyOneToOneWithEntityGraphTest.Project.class
+	}
+)
+@SessionFactory
+@BytecodeEnhanced(runNotEnhancedAsWell = true)
+public class LazyOneToOneWithEntityGraphTest {
+	@BeforeAll
+	void setUp(SessionFactoryScope scope) {
+		scope.inTransaction(session -> {
+			// Create company
+			Company company = new Company();
+			company.id = 1L;
+			company.name = "Hibernate";
+			session.persist(company);
+
+			// Create project
+			Project project = new Project();
+			project.id = 1L;
+			session.persist(project);
+
+			// Create employee
+			Employee employee = new Employee();
+			employee.id = 1L;
+			employee.company = company;
+			employee.projects = List.of(project);
+			session.persist(employee);
+		});
+	}
+
+	@AfterAll
+	void tearDown(SessionFactoryScope scope) {
+		scope.inTransaction(session -> {
+			scope.getSessionFactory().getSchemaManager().truncateMappedObjects();
+		});
+	}
+
+
+	@Test
+	void reproducerTest(SessionFactoryScope scope) {
+		scope.inTransaction(session -> {
+		// Load employee using entity graph
+		Employee employee = session.createQuery(
+				"select e from Employee e where e.id = :id", Employee.class)
+			.setParameter("id", 1L)
+			.setHint("javax.persistence.fetchgraph", session.getEntityGraph("employee.projects"))
+			.getSingleResult();
+
+		assertTrue(isInitialized(employee.projects));
+		assertEquals("Hibernate", employee.company.name);
+		});
+	}
+
+	@Entity(name = "Company")
+	public static class Company {
+		@Id
+		private Long id;
+
+		private String name;
+	}
+
+	@Entity(name = "Employee")
+	@NamedEntityGraph(
+		name = "employee.projects",
+		attributeNodes = @NamedAttributeNode("projects")
+	)
+	public static class Employee {
+		@Id
+		private Long id;
+
+		@OneToOne
+		@JoinColumn(name = "company_name", referencedColumnName = "name")
+		private Company company;
+
+		@OneToMany(fetch = FetchType.LAZY)
+		private List<Project> projects;
+	}
+
+	@Entity(name = "Project")
+	public static class Project {
+		@Id
+		private Long id;
+	}
+}


### PR DESCRIPTION
<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

A `ClassCastException` is thrown when trying to resolve instances without bytecode enhancement enabled under these preconditions:
  - @OneToOne property on a model
  - @JoinColumn to a unique key (other than @Id)
  - @EntityGraph being applied with attributes that are not the one-to-one

**Related Change in Hibernate 6.6**
  - https://github.com/hibernate/hibernate-orm/pull/8812

**Reproducer**
  - https://github.com/hibernate/hibernate-orm/pull/9560

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-19017
<!-- Hibernate GitHub Bot issue links end -->