### PR TITLE
Use specific Jenkins nodes for releases

### DIFF
--- a/ci/release/Jenkinsfile
+++ b/ci/release/Jenkinsfile
@@ -65,7 +65,7 @@ def checkoutReleaseScripts() {
 
 pipeline {
 	agent {
-		label 'Worker&&Containers'
+		label 'Release'
 	}
 	triggers {
 		// Run every week Sunday midnight

--- a/ci/snapshot-publish.Jenkinsfile
+++ b/ci/snapshot-publish.Jenkinsfile
@@ -12,7 +12,7 @@ if (currentBuild.getBuildCauses().toString().contains('BranchIndexingCause')) {
 
 pipeline {
     agent {
-        label 'Fedora'
+        label 'Release'
     }
     tools {
         jdk 'OpenJDK 17 Latest'


### PR DESCRIPTION
This should be safer as these nodes are only used once.

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
