### PR TITLE
HHH-19047 Prevent GC nepotism from affecting data structures not explicitly cleaning up old elements

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/internal/util/collections/StandardStack.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/util/collections/StandardStack.java
@@ -19,6 +19,7 @@ import java.util.function.Function;
  * @author Sanne Grinovero
  * @author Marco Belladelli
  */
+@SuppressWarnings("unchecked")
 public final class StandardStack<T> implements Stack<T> {
 
 	private Object[] elements;
@@ -107,8 +108,8 @@ public final class StandardStack<T> implements Stack<T> {
 
 	@Override
 	public void clear() {
-		for ( int i = 0; i < top; i++ ) {
-			elements[i] = null;
+		if ( elements != null ) {
+			Arrays.fill( elements, 0, top, null );
 		}
 		top = 0;
 	}
@@ -145,7 +146,10 @@ public final class StandardStack<T> implements Stack<T> {
 	private void grow() {
 		final int oldCapacity = elements.length;
 		final int jump = ( oldCapacity < 64 ) ? ( oldCapacity + 2 ) : ( oldCapacity >> 1 );
-		elements = Arrays.copyOf( elements, oldCapacity + jump );
+		final Object[] newElements = Arrays.copyOf( elements, oldCapacity + jump );
+		// Prevents GC nepotism on the old array elements, see HHH-19047
+		Arrays.fill( elements, null );
+		elements = newElements;
 	}
 
 }


### PR DESCRIPTION
<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

https://hibernate.atlassian.net/browse/HHH-19047

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
