### PR TITLE
HHH-18928 metamodel test failure when entity class is enhanced.

### DIFF
--- a/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/metamodel/MetamodelJavaTypeTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/metamodel/MetamodelJavaTypeTest.java
@@ -1,0 +1,85 @@
+/*
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.bytecode.enhancement.metamodel;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.metamodel.Attribute;
+import jakarta.persistence.metamodel.ManagedType;
+import jakarta.persistence.metamodel.Metamodel;
+import org.hibernate.testing.bytecode.enhancement.extension.BytecodeEnhanced;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Member;
+import java.util.Collection;
+import java.util.Vector;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+	/**
+	 * @author Scott Marlow
+	 */
+	@BytecodeEnhanced
+	@SessionFactory
+	public class MetamodelJavaTypeTest {
+
+		@Test
+		@DomainModel( annotatedClasses = SimpleEntity.class )
+		public void basicManagedTest(SessionFactoryScope scope) {
+			SimpleEntity entity = new SimpleEntity();
+			scope.inTransaction( entityManager -> {
+				entityManager.persist( entity );
+				Metamodel metaModel = entityManager.getMetamodel();
+				ManagedType<SimpleEntity> managedType = metaModel.managedType( SimpleEntity.class );
+				Attribute<SimpleEntity,?> attribute = managedType.getDeclaredAttribute( "total" );
+				Member member = attribute.getJavaMember();
+				assertEquals( "getTotal", member.getName() );
+			} );
+
+		}
+
+		// --- //
+
+		@Entity
+		private static class SimpleEntity {
+
+			int id;
+			int total;
+
+			Collection itemNames = new Vector();
+
+			public SimpleEntity() {
+			}
+
+			public SimpleEntity(int total) {
+				this.total = total;
+			}
+
+			public SimpleEntity(int id, int total) {
+				this.total = total;
+				this.id = id;
+			}
+
+			@Id
+			public int getId() {
+				return id;
+			}
+
+			public void setId(int id) {
+				this.id = id;
+			}
+
+			public int getTotal() {
+				return total;
+			}
+
+			public void setTotal(int total) {
+				this.total = total;
+			}
+		}
+	}


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-18928

This is for a Jakarta EE 10 Platform TCK failure that occurs with the ORM 6.6 branch that is described in https://hibernate.atlassian.net/browse/HHH-18928?focusedCommentId=118297

The test fails currently with:

> Enhanced:MetamodelJavaTypeTest > initializationError FAILED
>     java.lang.RuntimeException at DomainModelExtension.java:60

Perhaps the test is in the wrong folder for combining both Metamodel + bytecode enhancement testing?  

@mbladel I think we talked last year on zulip about needing a test that reproduces the Jakarta EE 10 Platform TCK test failure when using bytecode enhancement with a Metamodel test.  

Fyi, the TCK test has been passing fine only when bytecode enhancement is disabled.