### PR TITLE
alternative possible mitigation for Oracle fetch size issue

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/dialect/OracleDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/OracleDialect.java
@@ -11,6 +11,7 @@ import java.sql.SQLException;
 import java.sql.Types;
 import java.time.temporal.ChronoField;
 import java.time.temporal.TemporalAccessor;
+import java.util.Properties;
 import java.util.TimeZone;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -19,6 +20,7 @@ import org.hibernate.Length;
 import org.hibernate.QueryTimeoutException;
 import org.hibernate.boot.model.FunctionContributions;
 import org.hibernate.boot.model.TypeContributions;
+import org.hibernate.cfg.JdbcSettings;
 import org.hibernate.dialect.aggregate.AggregateSupport;
 import org.hibernate.dialect.aggregate.OracleAggregateSupport;
 import org.hibernate.dialect.function.CommonFunctionFactory;
@@ -212,6 +214,8 @@ public class OracleDialect extends Dialect {
 
 	protected final int driverMinorVersion;
 
+	private final int defaultFetchSize;
+
 
 	public OracleDialect() {
 		this( MINIMUM_VERSION );
@@ -222,6 +226,7 @@ public class OracleDialect extends Dialect {
 		autonomous = false;
 		extended = false;
 		applicationContinuity = false;
+		defaultFetchSize = -1;
 		driverMajorVersion = 19;
 		driverMinorVersion = 0;
 	}
@@ -235,6 +240,7 @@ public class OracleDialect extends Dialect {
 		autonomous = serverConfiguration.isAutonomous();
 		extended = serverConfiguration.isExtended();
 		applicationContinuity = serverConfiguration.isApplicationContinuity();
+		defaultFetchSize = serverConfiguration.getDefaultFetchSize();
 		this.driverMinorVersion = serverConfiguration.getDriverMinorVersion();
 		this.driverMajorVersion = serverConfiguration.getDriverMajorVersion();
 	}
@@ -288,6 +294,15 @@ public class OracleDialect extends Dialect {
 	@Override
 	protected DatabaseVersion getMinimumSupportedVersion() {
 		return MINIMUM_VERSION;
+	}
+
+	@Override
+	public Properties getDefaultProperties() {
+		final Properties defaultProperties = super.getDefaultProperties();
+		if ( defaultFetchSize > 0 && defaultFetchSize < 200 ) {
+			defaultProperties.setProperty( JdbcSettings.STATEMENT_FETCH_SIZE, Integer.toString( 1024 ) );
+		}
+		return defaultProperties;
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/dialect/OracleServerConfiguration.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/OracleServerConfiguration.java
@@ -30,6 +30,7 @@ public class OracleServerConfiguration {
 	private final boolean autonomous;
 	private final boolean extended;
 	private final boolean applicationContinuity;
+	private final int defaultFetchSize;
 	private final int driverMajorVersion;
 	private final int driverMinorVersion;
 
@@ -53,8 +54,12 @@ public class OracleServerConfiguration {
 		return driverMinorVersion;
 	}
 
+	public int getDefaultFetchSize() {
+		return defaultFetchSize;
+	}
+
 	public OracleServerConfiguration(boolean autonomous, boolean extended) {
-		this( autonomous, extended, false, 19, 0 );
+		this( autonomous, extended, false, -1, 19, 0 );
 	}
 
 	public OracleServerConfiguration(
@@ -62,18 +67,20 @@ public class OracleServerConfiguration {
 			boolean extended,
 			int driverMajorVersion,
 			int driverMinorVersion) {
-		this(autonomous, extended, false, driverMajorVersion, driverMinorVersion);
+		this(autonomous, extended, false, -1, driverMajorVersion, driverMinorVersion);
 	}
 
 	public OracleServerConfiguration(
 			boolean autonomous,
 			boolean extended,
 			boolean applicationContinuity,
+			int defaultFetchSize,
 			int driverMajorVersion,
 			int driverMinorVersion) {
 		this.autonomous = autonomous;
 		this.extended = extended;
 		this.applicationContinuity = applicationContinuity;
+		this.defaultFetchSize = defaultFetchSize;
 		this.driverMajorVersion = driverMajorVersion;
 		this.driverMinorVersion = driverMinorVersion;
 	}
@@ -82,6 +89,7 @@ public class OracleServerConfiguration {
 		Boolean extended = null;
 		Boolean autonomous = null;
 		Boolean applicationContinuity = null;
+		int defaultFetchSize = -1;
 		Integer majorVersion = null;
 		Integer minorVersion = null;
 		final DatabaseMetaData databaseMetaData = info.getDatabaseMetadata();
@@ -94,6 +102,8 @@ public class OracleServerConfiguration {
 				final Connection c = databaseMetaData.getConnection();
 
 				try (final Statement statement = c.createStatement()) {
+
+					defaultFetchSize = statement.getFetchSize();
 
 					// Use Oracle JDBC replay statistics information to determine if this
 					// connection is protected by Application Continuity
@@ -185,7 +195,8 @@ public class OracleServerConfiguration {
 			}
 
 		}
-		return new OracleServerConfiguration( autonomous, extended, applicationContinuity, majorVersion, minorVersion );
+		return new OracleServerConfiguration( autonomous, extended, applicationContinuity, defaultFetchSize,
+				majorVersion, minorVersion );
 	}
 
 	private static boolean isAutonomous(String cloudServiceParam) {


### PR DESCRIPTION
This is a second option (alternative to #9632), simply silently override the default if the user did not set it.

<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

[Please describe here what your change is about]

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
