### PR TITLE
HHH-18326 Inefficient identity hash code computation tracking persistent instances

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/bytecode/enhance/internal/bytebuddy/CodeTemplates.java
+++ b/hibernate-core/src/main/java/org/hibernate/bytecode/enhance/internal/bytebuddy/CodeTemplates.java
@@ -19,7 +19,9 @@ import org.hibernate.bytecode.enhance.spi.EnhancerConstants;
 import org.hibernate.bytecode.enhance.spi.interceptor.LazyAttributeLoadingInterceptor;
 import org.hibernate.collection.spi.PersistentCollection;
 import org.hibernate.engine.spi.CompositeOwner;
+import org.hibernate.engine.spi.EntityEntry;
 import org.hibernate.engine.spi.ExtendedSelfDirtinessTracker;
+import org.hibernate.engine.spi.ManagedEntity;
 import org.hibernate.engine.spi.PersistentAttributeInterceptor;
 import org.hibernate.internal.util.collections.ArrayHelper;
 
@@ -36,6 +38,26 @@ import net.bytebuddy.jar.asm.Opcodes;
 import static org.hibernate.engine.internal.ManagedTypeHelper.asCompositeTracker;
 
 class CodeTemplates {
+
+	static class SetPersistenceInfo {
+		@Advice.OnMethodExit
+		static void $$_hibernate_setOwner(
+				@Advice.Argument(0) EntityEntry entityEntry,
+				@Advice.Argument(1) ManagedEntity previous,
+				@Advice.Argument(2) ManagedEntity next,
+				@Advice.Argument(3) int instanceId,
+				@Advice.Return(readOnly = false) EntityEntry previousEntry,
+				@Advice.FieldValue(value = EnhancerConstants.ENTITY_ENTRY_FIELD_NAME, readOnly = false) EntityEntry entityEntryField,
+				@Advice.FieldValue(value = EnhancerConstants.PREVIOUS_FIELD_NAME, readOnly = false) ManagedEntity previousField,
+				@Advice.FieldValue(value = EnhancerConstants.NEXT_FIELD_NAME, readOnly = false) ManagedEntity nextField,
+				@Advice.FieldValue(value = EnhancerConstants.INSTANCE_ID_FIELD_NAME, readOnly = false) int instanceIdField) {
+			previousEntry = entityEntryField;
+			entityEntryField = entityEntry;
+			previousField = previous;
+			nextField = next;
+			instanceIdField = instanceId;
+		}
+	}
 
 	static class SetOwner {
 		@Advice.OnMethodEnter

--- a/hibernate-core/src/main/java/org/hibernate/bytecode/enhance/internal/bytebuddy/EnhancerImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/bytecode/enhance/internal/bytebuddy/EnhancerImpl.java
@@ -225,6 +225,14 @@ public class EnhancerImpl implements Enhancer {
 					EnhancerConstants.USE_TRACKER_SETTER_NAME
 			);
 
+			builder = addFieldWithGetterAndSetter(
+					builder,
+					constants.TypeIntegerPrimitive,
+					EnhancerConstants.INSTANCE_ID_FIELD_NAME,
+					EnhancerConstants.INSTANCE_ID_GETTER_NAME,
+					EnhancerConstants.INSTANCE_ID_SETTER_NAME
+			);
+
 			builder = addInterceptorHandling( builder, managedCtClass );
 
 			if ( enhancementContext.doDirtyCheckingInline( managedCtClass ) ) {

--- a/hibernate-core/src/main/java/org/hibernate/bytecode/enhance/internal/bytebuddy/EnhancerImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/bytecode/enhance/internal/bytebuddy/EnhancerImpl.java
@@ -233,6 +233,13 @@ public class EnhancerImpl implements Enhancer {
 					EnhancerConstants.INSTANCE_ID_SETTER_NAME
 			);
 
+			builder = addSetPersistenceInfoMethod(
+					builder,
+					constants.TypeEntityEntry,
+					constants.TypeManagedEntity,
+					constants.TypeIntegerPrimitive
+			);
+
 			builder = addInterceptorHandling( builder, managedCtClass );
 
 			if ( enhancementContext.doDirtyCheckingInline( managedCtClass ) ) {
@@ -690,6 +697,19 @@ public class EnhancerImpl implements Enhancer {
 				.defineMethod( setterName, constants.TypeVoid, constants.methodModifierPUBLIC )
 						.withParameters( type )
 						.intercept( FieldAccessor.ofField( fieldName ) );
+	}
+
+	private DynamicType.Builder<?> addSetPersistenceInfoMethod(
+			DynamicType.Builder<?> builder,
+			TypeDefinition entityEntryType,
+			TypeDefinition managedEntityType,
+			TypeDefinition intType) {
+		return builder
+				// returns previous entity entry
+				.defineMethod( EnhancerConstants.PERSISTENCE_INFO_SETTER_NAME, entityEntryType, constants.methodModifierPUBLIC )
+				// previous, next, instance-id
+				.withParameters( entityEntryType, managedEntityType, managedEntityType, intType )
+				.intercept( constants.implementationSetPersistenceInfo );
 	}
 
 	private List<AnnotatedFieldDescription> collectCollectionFields(TypeDescription managedCtClass) {

--- a/hibernate-core/src/main/java/org/hibernate/bytecode/enhance/internal/bytebuddy/EnhancerImplConstants.java
+++ b/hibernate-core/src/main/java/org/hibernate/bytecode/enhance/internal/bytebuddy/EnhancerImplConstants.java
@@ -74,6 +74,7 @@ public final class EnhancerImplConstants {
 	//Frequently used Types for method signatures:
 	final TypeDefinition TypeVoid = TypeDescription.ForLoadedType.of( void.class );
 	final TypeDefinition TypeBooleanPrimitive = TypeDescription.ForLoadedType.of( boolean.class );
+	final TypeDefinition TypeIntegerPrimitive = TypeDescription.ForLoadedType.of( int.class );
 	final TypeDefinition TypeManagedEntity = TypeDescription.ForLoadedType.of( ManagedEntity.class );
 	final TypeDefinition TypeEntityEntry = TypeDescription.ForLoadedType.of( EntityEntry.class );
 	final TypeDefinition TypePersistentAttributeInterceptor = TypeDescription.ForLoadedType.of( PersistentAttributeInterceptor.class );

--- a/hibernate-core/src/main/java/org/hibernate/bytecode/enhance/internal/bytebuddy/EnhancerImplConstants.java
+++ b/hibernate-core/src/main/java/org/hibernate/bytecode/enhance/internal/bytebuddy/EnhancerImplConstants.java
@@ -51,6 +51,7 @@ public final class EnhancerImplConstants {
 	final Advice adviceInitializeLazyAttributeLoadingInterceptor;
 	final Implementation implementationSetOwner;
 	final Implementation implementationClearOwner;
+	final Implementation implementationSetPersistenceInfo;
 
 	//Frequently used Modifiers:
 	final int methodModifierPUBLIC = ModifierContributor.Resolver.of( List.of( Visibility.PUBLIC ) ).resolve();
@@ -118,6 +119,8 @@ public final class EnhancerImplConstants {
 		this.implementationSetOwner = Advice.to( CodeTemplates.SetOwner.class, adviceLocator )
 				.wrap( StubMethod.INSTANCE );
 		this.implementationClearOwner = Advice.to( CodeTemplates.ClearOwner.class, adviceLocator )
+				.wrap( StubMethod.INSTANCE );
+		this.implementationSetPersistenceInfo = Advice.to( CodeTemplates.SetPersistenceInfo.class, adviceLocator )
 				.wrap( StubMethod.INSTANCE );
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/bytecode/enhance/spi/EnhancerConstants.java
+++ b/hibernate-core/src/main/java/org/hibernate/bytecode/enhance/spi/EnhancerConstants.java
@@ -184,6 +184,10 @@ public final class EnhancerConstants {
 	public static final String USE_TRACKER_GETTER_NAME = "$$_hibernate_useTracker";
 	public static final String USE_TRACKER_SETTER_NAME = "$$_hibernate_setUseTracker";
 
+	public static final String INSTANCE_ID_FIELD_NAME = "$$_hibernate_instanceId";
+	public static final String INSTANCE_ID_GETTER_NAME = "$$_hibernate_getInstanceId";
+	public static final String INSTANCE_ID_SETTER_NAME = "$$_hibernate_setInstanceId";
+
 
 	private EnhancerConstants() {
 	}

--- a/hibernate-core/src/main/java/org/hibernate/bytecode/enhance/spi/EnhancerConstants.java
+++ b/hibernate-core/src/main/java/org/hibernate/bytecode/enhance/spi/EnhancerConstants.java
@@ -188,6 +188,8 @@ public final class EnhancerConstants {
 	public static final String INSTANCE_ID_GETTER_NAME = "$$_hibernate_getInstanceId";
 	public static final String INSTANCE_ID_SETTER_NAME = "$$_hibernate_setInstanceId";
 
+	public static final String PERSISTENCE_INFO_SETTER_NAME = "$$_hibernate_setPersistenceInfo";
+
 
 	private EnhancerConstants() {
 	}

--- a/hibernate-core/src/main/java/org/hibernate/collection/spi/AbstractPersistentCollection.java
+++ b/hibernate-core/src/main/java/org/hibernate/collection/spi/AbstractPersistentCollection.java
@@ -79,6 +79,8 @@ public abstract class AbstractPersistentCollection<E> implements Serializable, P
 	private String sessionFactoryUuid;
 	private boolean allowLoadOutsideTransaction;
 
+	private transient int instanceId;
+
 	/**
 	 * Not called by Hibernate, but used by non-JDK serialization,
 	 * eg. SOAP libraries.
@@ -1362,4 +1364,13 @@ public abstract class AbstractPersistentCollection<E> implements Serializable, P
 		this.owner = owner;
 	}
 
+	@Override
+	public int $$_hibernate_getInstanceId() {
+		return instanceId;
+	}
+
+	@Override
+	public void $$_hibernate_setInstanceId(int instanceId) {
+		this.instanceId = instanceId;
+	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/collection/spi/PersistentCollection.java
+++ b/hibernate-core/src/main/java/org/hibernate/collection/spi/PersistentCollection.java
@@ -11,6 +11,7 @@ import java.util.List;
 
 import org.hibernate.HibernateException;
 import org.hibernate.Incubating;
+import org.hibernate.engine.spi.InstanceIdentity;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.metamodel.mapping.PluralAttributeMapping;
 import org.hibernate.persister.collection.CollectionPersister;
@@ -52,7 +53,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
  * @author Gavin King
  */
 @Incubating
-public interface PersistentCollection<E> extends LazyInitializable {
+public interface PersistentCollection<E> extends LazyInitializable, InstanceIdentity {
 	/**
 	 * Get the owning entity. Note that the owner is only
 	 * set during the flush cycle, and when a new collection

--- a/hibernate-core/src/main/java/org/hibernate/engine/internal/StatefulPersistenceContext.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/internal/StatefulPersistenceContext.java
@@ -134,7 +134,7 @@ public class StatefulPersistenceContext implements PersistenceContext {
 	private InstanceIdentityMap<PersistentCollection<?>, CollectionEntry> collectionEntries;
 
 	// Current collection instance id
-	private transient int currentCollectionInstanceId;
+	private transient int currentCollectionInstanceId = 1;
 
 	// Collection wrappers, by the CollectionKey
 	private HashMap<CollectionKey, PersistentCollection<?>> collectionsByKey;
@@ -258,7 +258,10 @@ public class StatefulPersistenceContext implements PersistenceContext {
 
 		final SharedSessionContractImplementor session = getSession();
 		if ( collectionEntries != null ) {
-			collectionEntries.forEach( (k, v) -> k.unsetSession( session ) );
+			collectionEntries.forEach( (k, v) -> {
+				k.$$_hibernate_setInstanceId( 0 );
+				k.unsetSession( session );
+			} );
 		}
 
 		arrayHolders = null;
@@ -270,7 +273,7 @@ public class StatefulPersistenceContext implements PersistenceContext {
 		collectionsByKey = null;
 		nonlazyCollections = null;
 		collectionEntries = null;
-		currentCollectionInstanceId = 0;
+		currentCollectionInstanceId = 1;
 		unownedCollections = null;
 		nullifiableEntityKeys = null;
 		deletedUnloadedEntityKeys = null;
@@ -1132,6 +1135,7 @@ public class StatefulPersistenceContext implements PersistenceContext {
 		if ( this.collectionEntries == null ) {
 			this.collectionEntries = new InstanceIdentityMap<>();
 		}
+		assert collection.$$_hibernate_getInstanceId() == 0;
 		collection.$$_hibernate_setInstanceId( nextCollectionInstanceId() );
 		this.collectionEntries.put( collection, entry );
 	}
@@ -2183,7 +2187,9 @@ public class StatefulPersistenceContext implements PersistenceContext {
 	@Override
 	public CollectionEntry removeCollectionEntry(PersistentCollection<?> collection) {
 		if ( collectionEntries != null ) {
-			return collectionEntries.remove( collection.$$_hibernate_getInstanceId(), collection );
+			final int instanceId = collection.$$_hibernate_getInstanceId();
+			collection.$$_hibernate_setInstanceId( 0 );
+			return collectionEntries.remove( instanceId, collection );
 		}
 		else {
 			return null;

--- a/hibernate-core/src/main/java/org/hibernate/engine/internal/StatefulPersistenceContext.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/internal/StatefulPersistenceContext.java
@@ -55,7 +55,7 @@ import org.hibernate.event.spi.PostLoadEvent;
 import org.hibernate.event.spi.PostLoadEventListener;
 import org.hibernate.internal.CoreMessageLogger;
 import org.hibernate.internal.util.collections.CollectionHelper;
-import org.hibernate.internal.util.collections.IdentityMap;
+import org.hibernate.internal.util.collections.InstanceIdentityMap;
 import org.hibernate.metamodel.spi.MappingMetamodelImplementor;
 import org.hibernate.persister.collection.CollectionPersister;
 import org.hibernate.persister.entity.EntityPersister;
@@ -131,7 +131,10 @@ public class StatefulPersistenceContext implements PersistenceContext {
 	private IdentityHashMap<Object, PersistentCollection<?>> arrayHolders;
 
 	// Identity map of CollectionEntry instances, by the collection wrapper
-	private IdentityMap<PersistentCollection<?>, CollectionEntry> collectionEntries;
+	private InstanceIdentityMap<PersistentCollection<?>, CollectionEntry> collectionEntries;
+
+	// Current collection instance id
+	private transient int currentCollectionInstanceId;
 
 	// Collection wrappers, by the CollectionKey
 	private HashMap<CollectionKey, PersistentCollection<?>> collectionsByKey;
@@ -255,7 +258,7 @@ public class StatefulPersistenceContext implements PersistenceContext {
 
 		final SharedSessionContractImplementor session = getSession();
 		if ( collectionEntries != null ) {
-			IdentityMap.onEachKey( collectionEntries, k -> k.unsetSession( session ) );
+			collectionEntries.forEach( (k, v) -> k.unsetSession( session ) );
 		}
 
 		arrayHolders = null;
@@ -267,6 +270,7 @@ public class StatefulPersistenceContext implements PersistenceContext {
 		collectionsByKey = null;
 		nonlazyCollections = null;
 		collectionEntries = null;
+		currentCollectionInstanceId = 0;
 		unownedCollections = null;
 		nullifiableEntityKeys = null;
 		deletedUnloadedEntityKeys = null;
@@ -613,7 +617,7 @@ public class StatefulPersistenceContext implements PersistenceContext {
 
 	@Override
 	public CollectionEntry getCollectionEntry(PersistentCollection<?> coll) {
-		return collectionEntries == null ? null : collectionEntries.get( coll );
+		return collectionEntries == null ? null : collectionEntries.get( coll.$$_hibernate_getInstanceId(), coll );
 	}
 
 	@Override
@@ -725,7 +729,7 @@ public class StatefulPersistenceContext implements PersistenceContext {
 
 	@Override
 	public boolean containsCollection(PersistentCollection<?> collection) {
-		return collectionEntries != null && collectionEntries.containsKey( collection );
+		return collectionEntries != null && collectionEntries.containsKey( collection.$$_hibernate_getInstanceId(), collection );
 	}
 
 	@Override
@@ -1082,8 +1086,7 @@ public class StatefulPersistenceContext implements PersistenceContext {
 					"Replacement of not directly accessible collection found: " + oldCollection.getRole() );
 		}
 		assert !collection.isDirectlyAccessible();
-		final IdentityMap<PersistentCollection<?>, CollectionEntry> collectionEntries = getOrInitializeCollectionEntries();
-		final CollectionEntry oldEntry = collectionEntries.remove( oldCollection );
+		final CollectionEntry oldEntry = collectionEntries.remove( oldCollection.$$_hibernate_getInstanceId(), oldCollection );
 		final CollectionEntry entry;
 		if ( oldEntry.getLoadedPersister() != null ) {
 			// This is an already existing/loaded collection so ensure the loadedPersister is initialized
@@ -1093,7 +1096,7 @@ public class StatefulPersistenceContext implements PersistenceContext {
 			// A newly wrapped collection
 			entry = new CollectionEntry( persister, collection );
 		}
-		collectionEntries.put( collection, entry );
+		putCollectionEntry( collection, entry );
 		final Object key = collection.getKey();
 		if ( key != null ) {
 			final CollectionKey collectionKey = new CollectionKey( entry.getLoadedPersister(), key );
@@ -1112,7 +1115,7 @@ public class StatefulPersistenceContext implements PersistenceContext {
 	 * @param key The key of the collection's entry.
 	 */
 	private void addCollection(PersistentCollection<?> coll, CollectionEntry entry, Object key) {
-		getOrInitializeCollectionEntries().put( coll, entry );
+		putCollectionEntry( coll, entry );
 		final CollectionKey collectionKey = new CollectionKey( entry.getLoadedPersister(), key );
 		final PersistentCollection<?> old = addCollectionByKey( collectionKey, coll );
 		if ( old != null ) {
@@ -1125,11 +1128,12 @@ public class StatefulPersistenceContext implements PersistenceContext {
 		}
 	}
 
-	private IdentityMap<PersistentCollection<?>, CollectionEntry> getOrInitializeCollectionEntries() {
+	private void putCollectionEntry(PersistentCollection<?> collection, CollectionEntry entry) {
 		if ( this.collectionEntries == null ) {
-			this.collectionEntries = IdentityMap.instantiateSequenced( INIT_COLL_SIZE );
+			this.collectionEntries = new InstanceIdentityMap<>();
 		}
-		return this.collectionEntries;
+		collection.$$_hibernate_setInstanceId( nextCollectionInstanceId() );
+		this.collectionEntries.put( collection, entry );
 	}
 
 	/**
@@ -1140,7 +1144,7 @@ public class StatefulPersistenceContext implements PersistenceContext {
 	 */
 	private void addCollection(PersistentCollection<?> collection, CollectionPersister persister) {
 		final CollectionEntry ce = new CollectionEntry( persister, collection );
-		getOrInitializeCollectionEntries().put( collection, ce );
+		putCollectionEntry( collection, ce );
 	}
 
 	@Override
@@ -1375,11 +1379,15 @@ public class StatefulPersistenceContext implements PersistenceContext {
 		return collectionEntries;
 	}
 
+	private int nextCollectionInstanceId() {
+		return currentCollectionInstanceId++;
+	}
+
 	@Override
 	public void forEachCollectionEntry(BiConsumer<PersistentCollection<?>, CollectionEntry> action, boolean concurrent) {
 		if ( collectionEntries != null ) {
 			if ( concurrent ) {
-				for ( Entry<PersistentCollection<?>,CollectionEntry> entry : IdentityMap.concurrentEntries( collectionEntries ) ) {
+				for ( Entry<PersistentCollection<?>,CollectionEntry> entry : collectionEntries.toArray() ) {
 					action.accept( entry.getKey(), entry.getValue() );
 				}
 			}
@@ -2032,7 +2040,7 @@ public class StatefulPersistenceContext implements PersistenceContext {
 				final PersistentCollection<?> pc = (PersistentCollection<?>) ois.readObject();
 				final CollectionEntry ce = CollectionEntry.deserialize( ois, session );
 				pc.setCurrentSession( session );
-				rtn.getOrInitializeCollectionEntries().put( pc, ce );
+				rtn.putCollectionEntry( pc, ce );
 			}
 
 			count = ois.readInt();
@@ -2174,7 +2182,12 @@ public class StatefulPersistenceContext implements PersistenceContext {
 
 	@Override
 	public CollectionEntry removeCollectionEntry(PersistentCollection<?> collection) {
-		return collectionEntries == null ? null : collectionEntries.remove(collection);
+		if ( collectionEntries != null ) {
+			return collectionEntries.remove( collection.$$_hibernate_getInstanceId(), collection );
+		}
+		else {
+			return null;
+		}
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/engine/spi/InstanceIdentity.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/spi/InstanceIdentity.java
@@ -1,0 +1,25 @@
+/*
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.engine.spi;
+
+/**
+ * Contract for classes whose instances are uniquely identifiable through a simple {@code int} value,
+ * and can be mapped via {@link org.hibernate.internal.util.collections.InstanceIdentityMap}.
+ */
+public interface InstanceIdentity {
+	/**
+	 * Retrieve the unique identifier of this instance
+	 *
+	 * @return the unique instance identifier
+	 */
+	int $$_hibernate_getInstanceId();
+
+	/**
+	 * Set the value of the unique identifier for this instance
+	 *
+	 * @param instanceId the unique identifier value to set
+	 */
+	void $$_hibernate_setInstanceId(int instanceId);
+}

--- a/hibernate-core/src/main/java/org/hibernate/engine/spi/ManagedEntity.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/spi/ManagedEntity.java
@@ -128,4 +128,26 @@ public interface ManagedEntity extends Managed, InstanceIdentity {
 		return this;
 	}
 
+	/**
+	 * Utility method that allows injecting all persistence-related information on the managed entity at once.
+	 *
+	 * @param entityEntry the {@link EntityEntry} associated with this entity instance
+	 * @param previous the previous entry
+	 * @param next the next entry
+	 * @param instanceId unique identifier for this instance
+	 * @return the previous {@link EntityEntry} contained in this managed entity, or {@code null}
+	 * @see #$$_hibernate_setEntityEntry(EntityEntry)
+	 * @see #$$_hibernate_setPreviousManagedEntity(ManagedEntity)
+	 * @see #$$_hibernate_setNextManagedEntity(ManagedEntity)
+	 * @see #$$_hibernate_setInstanceId(int)
+	 * @since 7.0
+	 */
+	default EntityEntry $$_hibernate_setPersistenceInfo(EntityEntry entityEntry, ManagedEntity previous, ManagedEntity next, int instanceId) {
+		final EntityEntry oldEntry = $$_hibernate_getEntityEntry();
+		$$_hibernate_setEntityEntry( entityEntry );
+		$$_hibernate_setPreviousManagedEntity( previous );
+		$$_hibernate_setNextManagedEntity( next );
+		$$_hibernate_setInstanceId( instanceId );
+		return oldEntry;
+	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/engine/spi/ManagedEntity.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/spi/ManagedEntity.java
@@ -21,7 +21,7 @@ package org.hibernate.engine.spi;
  *
  * @author Steve Ebersole
  */
-public interface ManagedEntity extends Managed {
+public interface ManagedEntity extends Managed, InstanceIdentity {
 	/**
 	 * Obtain a reference to the entity instance.
 	 *

--- a/hibernate-core/src/main/java/org/hibernate/event/internal/AbstractFlushingEventListener.java
+++ b/hibernate-core/src/main/java/org/hibernate/event/internal/AbstractFlushingEventListener.java
@@ -34,7 +34,7 @@ import org.hibernate.event.spi.FlushEvent;
 import org.hibernate.event.spi.PersistContext;
 import org.hibernate.internal.CoreMessageLogger;
 import org.hibernate.internal.util.EntityPrinter;
-import org.hibernate.internal.util.collections.IdentityMap;
+import org.hibernate.internal.util.collections.InstanceIdentityMap;
 import org.hibernate.persister.entity.EntityPersister;
 
 import org.jboss.logging.Logger;
@@ -190,7 +190,7 @@ public abstract class AbstractFlushingEventListener {
 				persistenceContext.getCollectionEntries();
 		if ( collectionEntries != null ) {
 			for ( Map.Entry<PersistentCollection<?>, CollectionEntry> entry :
-					( (IdentityMap<PersistentCollection<?>, CollectionEntry>) collectionEntries ).entryArray() ) {
+					( (InstanceIdentityMap<PersistentCollection<?>, CollectionEntry>) collectionEntries ).toArray() ) {
 				entry.getValue().preFlush( entry.getKey() );
 			}
 		}
@@ -271,7 +271,7 @@ public abstract class AbstractFlushingEventListener {
 		}
 		else {
 			count = collectionEntries.size();
-			for ( Map.Entry<PersistentCollection<?>, CollectionEntry> me : ( (IdentityMap<PersistentCollection<?>, CollectionEntry>) collectionEntries ).entryArray() ) {
+			for ( Map.Entry<PersistentCollection<?>, CollectionEntry> me : ( (InstanceIdentityMap<PersistentCollection<?>, CollectionEntry>) collectionEntries ).toArray() ) {
 				final CollectionEntry ce = me.getValue();
 				if ( !ce.isReached() && !ce.isIgnore() ) {
 					Collections.processUnreachableCollection( me.getKey(), session );

--- a/hibernate-core/src/main/java/org/hibernate/internal/StatelessSessionImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/StatelessSessionImpl.java
@@ -1038,6 +1038,7 @@ public class StatelessSessionImpl extends AbstractSharedSessionContract implemen
 					}
 				}
 				finally {
+					collection.$$_hibernate_setInstanceId( 0 );
 					collection.unsetSession( this );
 					if ( persistenceContext.isLoadFinished() ) {
 						persistenceContext.clear();

--- a/hibernate-core/src/main/java/org/hibernate/internal/util/collections/AbstractPagedArray.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/util/collections/AbstractPagedArray.java
@@ -1,0 +1,217 @@
+/*
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.internal.util.collections;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+
+/**
+ * Array-like structures that organizes elements in {@link Page}s, automatically allocating
+ * more as needed. Access to data via absolute index is efficient as it requires
+ * a constant amount of operations.
+ *
+ * @param <E> the type of elements contained in the array
+ */
+public class AbstractPagedArray<E> {
+	// It's important that capacity is a power of 2 to allow calculating page index and offset within the page
+	// with simple division and modulo operations; also static final so JIT can inline these operations.
+	private static final int PAGE_CAPACITY = 1 << 5; // 32, 16 key + value pairs
+
+	/**
+	 * Represents a page of {@link #PAGE_CAPACITY} objects in the overall array.
+	 */
+	protected static final class Page<E> {
+		private final Object[] elements;
+		private int lastNotEmptyOffset;
+
+		public Page() {
+			elements = new Object[PAGE_CAPACITY];
+			lastNotEmptyOffset = -1;
+		}
+
+		/**
+		 * Clears the contents of the page.
+		 */
+		public void clear() {
+			// We need to null out everything to prevent GC nepotism (see https://hibernate.atlassian.net/browse/HHH-19047)
+			Arrays.fill( elements, 0, lastNotEmptyOffset + 1, null );
+			lastNotEmptyOffset = -1;
+		}
+
+		/**
+		 * Set the provided element at the specified offset.
+		 *
+		 * @param offset the offset in the page where to set the element
+		 * @param element the element to set
+		 * @return the previous element at {@code offset} if one existed, or {@code null}
+		 */
+		public E set(int offset, Object element) {
+			if ( offset >= PAGE_CAPACITY ) {
+				throw new IllegalArgumentException( "The required offset is beyond page capacity" );
+			}
+			final Object old = elements[offset];
+			if ( element != null ) {
+				if ( offset > lastNotEmptyOffset ) {
+					lastNotEmptyOffset = offset;
+				}
+			}
+			else if ( lastNotEmptyOffset == offset && old != null ) {
+				// must search backward for the first not empty offset
+				int i = offset;
+				for ( ; i >= 0; i-- ) {
+					if ( elements[i] != null ) {
+						break;
+					}
+				}
+				lastNotEmptyOffset = i;
+			}
+			elements[offset] = element;
+			//noinspection unchecked
+			return (E) old;
+		}
+
+		/**
+		 * Get the element at the specified offset.
+		 *
+		 * @param offset the offset in the page where to set the element
+		 * @return the element at {@code index} if one existed, or {@code null}
+		 */
+		public E get(final int offset) {
+			if ( offset >= PAGE_CAPACITY ) {
+				throw new IllegalArgumentException( "The required offset is beyond page capacity" );
+			}
+			if ( offset > lastNotEmptyOffset ) {
+				return null;
+			}
+			//noinspection unchecked
+			return (E) elements[offset];
+		}
+
+		int lastNotEmptyOffset() {
+			return lastNotEmptyOffset;
+		}
+	}
+
+	protected final ArrayList<Page<E>> elementPages;
+
+	public AbstractPagedArray() {
+		elementPages = new ArrayList<>();
+	}
+
+	protected static int toPageIndex(final int index) {
+		return index / PAGE_CAPACITY;
+	}
+
+	protected static int toPageOffset(final int index) {
+		return index % PAGE_CAPACITY;
+	}
+
+	/**
+	 * Utility methods that retrieves an {@link Page} based on the absolute index in the array.
+	 *
+	 * @param index the absolute index of the array
+	 * @return the page corresponding to the provided index, or {@code null}
+	 */
+	protected Page<E> getPage(int index) {
+		final int pageIndex = toPageIndex( index );
+		if ( pageIndex < elementPages.size() ) {
+			return elementPages.get( pageIndex );
+		}
+		return null;
+	}
+
+	/**
+	 * Returns the element from the array at the specified index
+	 *
+	 * @param index the absolute index in the underlying array
+	 * @return the value contained in the array at the specified position, or {@code null}
+	 */
+	protected E get(int index) {
+		final Page<E> page = getPage( index );
+		return page != null ? page.get( toPageOffset( index ) ) : null;
+	}
+
+	/**
+	 * Sets the specified index to the provided element
+	 *
+	 * @param index the absolute index in the underlying array
+	 * @param element the element to set
+	 * @return the value previously contained in the array at the specified position, or {@code null}
+	 */
+	protected E set(int index, E element) {
+		final Page<E> page = getOrCreateEntryPage( index );
+		return page.set( toPageOffset( index ), element );
+	}
+
+	/**
+	 * Utility methods that retrieves or initializes a {@link Page} based on the absolute index in the array.
+	 *
+	 * @param index the absolute index of the array
+	 * @return the page corresponding to the provided index
+	 */
+	protected Page<E> getOrCreateEntryPage(int index) {
+		final int pages = elementPages.size();
+		final int pageIndex = toPageIndex( index );
+		if ( pageIndex < pages ) {
+			final Page<E> page = elementPages.get( pageIndex );
+			if ( page != null ) {
+				return page;
+			}
+			final Page<E> newPage = new Page<>();
+			elementPages.set( pageIndex, newPage );
+			return newPage;
+		}
+		elementPages.ensureCapacity( pageIndex + 1 );
+		for ( int i = pages; i < pageIndex; i++ ) {
+			elementPages.add( null );
+		}
+		final Page<E> page = new Page<>();
+		elementPages.add( page );
+		return page;
+	}
+
+	public void clear() {
+		for ( Page<E> entryPage : elementPages ) {
+			entryPage.clear();
+		}
+		elementPages.clear();
+		elementPages.trimToSize();
+	}
+
+	protected abstract class PagedArrayIterator<T> implements Iterator<T> {
+		int index; // current absolute index in the array
+		boolean indexValid; // to avoid unnecessary next computation
+
+		@Override
+		public boolean hasNext() {
+			for ( int i = toPageIndex( index ); i < elementPages.size(); i++ ) {
+				final Page<E> page = elementPages.get( i );
+				if ( page != null ) {
+					for ( int j = toPageOffset( index ); j <= page.lastNotEmptyOffset; j++ ) {
+						if ( page.get( j ) != null ) {
+							index = i * PAGE_CAPACITY + j;
+							return indexValid = true;
+						}
+					}
+				}
+			}
+			index = elementPages.size() * PAGE_CAPACITY;
+			return false;
+		}
+
+		protected int nextIndex() {
+			if ( !indexValid && !hasNext() ) {
+				throw new NoSuchElementException();
+			}
+
+			indexValid = false;
+			int lastReturnedIndex = index;
+			index++;
+			return lastReturnedIndex;
+		}
+	}
+}

--- a/hibernate-core/src/main/java/org/hibernate/internal/util/collections/InstanceIdentityMap.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/util/collections/InstanceIdentityMap.java
@@ -1,0 +1,386 @@
+/*
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.internal.util.collections;
+
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
+import org.hibernate.engine.spi.InstanceIdentity;
+import org.hibernate.internal.build.AllowReflection;
+
+import java.lang.reflect.Array;
+import java.util.AbstractCollection;
+import java.util.AbstractMap;
+import java.util.AbstractSet;
+import java.util.Collection;
+import java.util.ConcurrentModificationException;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.function.BiConsumer;
+
+/**
+ * {@link Map} implementation of based on {@link InstanceIdentity}, similar to {@link InstanceIdentityStore}.
+ * This collection also stores values using an array-like structure that automatically grows as needed
+ * but, contrary to the store, it initializes {@link Map.Entry}s eagerly to optimize iteration
+ * performance and avoid type-pollution issues when checking the type of contained objects.
+ * <p>
+ * Methods accessing / modifying the map with {@link Object} typed parameters will need
+ * to type check against the instance identity interface which might be inefficient,
+ * so it's recommended to use the position (int) based variant of those methods.
+ */
+public class InstanceIdentityMap<K extends InstanceIdentity, V> extends AbstractPagedArray<Map.Entry<K, V>>
+		implements Map<K, V> {
+	private int size;
+
+	@Override
+	public int size() {
+		return size;
+	}
+
+	@Override
+	public boolean isEmpty() {
+		return size == 0;
+	}
+
+	/**
+	 * Returns {@code true} if this map contains a mapping for the specified instance id.
+	 *
+	 * @param instanceId the instance id whose associated value is to be returned
+	 * @param key key instance to double-check instance equality
+	 * @return {@code true} if this map contains a mapping for the specified instance id
+	 * @implNote This method accesses the backing array with the provided instance id, but performs an instance
+	 * equality check ({@code ==}) with the provided key to ensure it corresponds to the mapped one
+	 */
+	public boolean containsKey(int instanceId, Object key) {
+		return get( instanceId, key ) != null;
+	}
+
+	/**
+	 * @inheritDoc
+	 * @implNote This only works for {@link InstanceIdentity} keys, and it's inefficient
+	 * since we need to do a type check. Prefer using {@link #containsKey(int, Object)}.
+	 */
+	@Override
+	public boolean containsKey(Object key) {
+		if ( key instanceof InstanceIdentity instance ) {
+			return containsKey( instance.$$_hibernate_getInstanceId(), instance );
+		}
+		throw new ClassCastException( "Provided key does not support instance identity" );
+	}
+
+	@Override
+	public boolean containsValue(Object value) {
+		for ( V v : values() ) {
+			if ( Objects.equals( value, v ) ) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	/**
+	 * Tests if the specified key-value mapping is in the map.
+	 *
+	 * @param key possible key, must be an instance of {@link InstanceIdentity}
+	 * @param value possible value
+	 * @return {@code true} if and only if the specified key-value mapping is in the map
+	 */
+	private boolean containsMapping(Object key, Object value) {
+		if ( key instanceof InstanceIdentity instance ) {
+			return get( instance.$$_hibernate_getInstanceId(), instance ) == value;
+		}
+		throw new ClassCastException( "Provided key does not support instance identity" );
+	}
+
+	/**
+	 * Returns the value to which the specified instance id is mapped, or {@code null} if this map
+	 * contains no mapping for the instance id.
+	 *
+	 * @param instanceId the instance id whose associated value is to be returned
+	 * @param key key instance to double-check instance equality
+	 * @return the value to which the specified instance id is mapped,
+	 * or {@code null} if this map contains no mapping for the instance id
+	 * @implNote This method accesses the backing array with the provided instance id, but performs an instance
+	 * equality check ({@code ==}) with the provided key to ensure it corresponds to the mapped one
+	 */
+	public @Nullable V get(int instanceId, Object key) {
+		final Entry<K, V> entry = get( instanceId );
+		if ( entry != null && entry.getKey() == key ) {
+			return entry.getValue();
+		}
+		return null;
+	}
+
+	/**
+	 * @inheritDoc
+	 * @implNote This only works for {@link InstanceIdentity} keys, and it's inefficient
+	 * since we need to do a type check. Prefer using {@link #get(int, Object)}.
+	 */
+	@Override
+	public @Nullable V get(Object key) {
+		if ( key instanceof InstanceIdentity instance ) {
+			return get( instance.$$_hibernate_getInstanceId(), instance );
+		}
+		throw new ClassCastException( "Provided key does not support instance identity" );
+	}
+
+	@Override
+	public @Nullable V put(K key, V value) {
+		if ( key == null ) {
+			throw new NullPointerException( "This map does not support null keys" );
+		}
+
+		final int instanceId = key.$$_hibernate_getInstanceId();
+		final Map.Entry<K, V> old = set( instanceId, new AbstractMap.SimpleImmutableEntry<>( key, value ) );
+		if ( old == null ) {
+			size++;
+			return null;
+		}
+		else {
+			return old.getValue();
+		}
+	}
+
+	/**
+	 * Removes the mapping for an instance id from this map if it is present (optional operation).
+	 *
+	 * @param instanceId the instance id whose associated value is to be returned
+	 * @param key key instance to double-check instance equality
+	 * @return the previous value associated with {@code instanceId}, or {@code null} if there was no mapping for it.
+	 * @implNote This method accesses the backing array with the provided instance id, but performs an instance
+	 * equality check ({@code ==}) with the provided key to ensure it corresponds to the mapped one
+	 */
+	public @Nullable V remove(int instanceId, Object key) {
+		final Page<Map.Entry<K, V>> page = getPage( instanceId );
+		if ( page != null ) {
+			final int pageOffset = toPageOffset( instanceId );
+			final Map.Entry<K, V> entry = page.set( pageOffset, null );
+			// Check that the provided instance really matches with the key contained in the map
+			if ( entry != null ) {
+				if ( entry.getKey() == key ) {
+					size--;
+					return entry.getValue();
+				}
+				else {
+					// If it doesn't, reset the array value to the old key
+					page.set( pageOffset, entry );
+				}
+			}
+		}
+		return null;
+	}
+
+	/**
+	 * @inheritDoc
+	 * @implNote This only works for {@link InstanceIdentity} keys, and it's inefficient
+	 * since we need to do a type check. Prefer using {@link #remove(int, Object)}.
+	 */
+	@Override
+	public @Nullable V remove(Object key) {
+		if ( key instanceof InstanceIdentity instance ) {
+			return remove( instance.$$_hibernate_getInstanceId(), instance );
+		}
+		throw new ClassCastException( "Provided key does not support instance identity" );
+	}
+
+	@Override
+	public void putAll(Map<? extends K, ? extends V> m) {
+		for ( Entry<? extends K, ? extends V> entry : m.entrySet() ) {
+			put( entry.getKey(), entry.getValue() );
+		}
+	}
+
+	@Override
+	public @Nullable V putIfAbsent(K key, V value) {
+		V v = get( key.$$_hibernate_getInstanceId(), key );
+		if ( v == null ) {
+			v = put( key, value );
+		}
+		return v;
+	}
+
+	@Override
+	public void clear() {
+		super.clear();
+		size = 0;
+	}
+
+	@Override
+	public @NonNull Set<K> keySet() {
+		return new KeySet();
+	}
+
+	@Override
+	public @NonNull Collection<V> values() {
+		return new Values();
+	}
+
+	@Override
+	public @NonNull Set<Map.Entry<K, V>> entrySet() {
+		return new EntrySet();
+	}
+
+	@Override
+	public void forEach(BiConsumer<? super K, ? super V> action) {
+		for ( final Page<Map.Entry<K, V>> page : elementPages ) {
+			if ( page != null ) {
+				for ( int j = 0; j <= page.lastNotEmptyOffset(); j++ ) {
+					final Map.Entry<K, V> entry = page.get( j );
+					if ( entry != null ) {
+						action.accept( entry.getKey(), entry.getValue() );
+					}
+				}
+			}
+		}
+	}
+
+	public Map.Entry<K, V>[] toArray() {
+		//noinspection unchecked
+		return entrySet().toArray( new Map.Entry[0] );
+	}
+
+	private class KeyIterator extends PagedArrayIterator<K> {
+		@Override
+		public K next() {
+			return get( nextIndex() ).getKey();
+		}
+	}
+
+	private class ValueIterator extends PagedArrayIterator<V> {
+		@Override
+		public V next() {
+			return get( nextIndex() ).getValue();
+		}
+	}
+
+	private class EntryIterator extends PagedArrayIterator<Map.Entry<K, V>> {
+		@Override
+		public Map.Entry<K, V> next() {
+			return new Entry( nextIndex() );
+		}
+
+		private class Entry implements Map.Entry<K, V> {
+			private final int index;
+
+			private Entry(int index) {
+				this.index = index;
+			}
+
+			@Override
+			public K getKey() {
+				return get( index ).getKey();
+			}
+
+			@Override
+			public V getValue() {
+				return get( index ).getValue();
+			}
+
+			@Override
+			public V setValue(V value) {
+				throw new UnsupportedOperationException();
+			}
+
+			@Override
+			public boolean equals(Object o) {
+				return o instanceof Map.Entry<?, ?> e
+					&& Objects.equals( e.getKey(), getKey() )
+					&& Objects.equals( e.getValue(), getValue() );
+			}
+
+			@Override
+			public int hashCode() {
+				return getKey().hashCode() ^ Objects.hashCode( getValue() );
+			}
+
+			@Override
+			public String toString() {
+				return getKey() + "=" + getValue();
+			}
+		}
+	}
+
+	private class KeySet extends AbstractSet<K> {
+		@Override
+		public @NonNull Iterator<K> iterator() {
+			return new KeyIterator();
+		}
+
+		@Override
+		public int size() {
+			return InstanceIdentityMap.this.size();
+		}
+
+		@Override
+		public boolean contains(Object o) {
+			return containsKey( o );
+		}
+	}
+
+	private class Values extends AbstractCollection<V> {
+		@Override
+		public @NonNull Iterator<V> iterator() {
+			return new ValueIterator();
+		}
+
+		@Override
+		public int size() {
+			return InstanceIdentityMap.this.size();
+		}
+	}
+
+	private class EntrySet extends AbstractSet<Entry<K, V>> {
+		@Override
+		public @NonNull Iterator<Entry<K, V>> iterator() {
+			return new EntryIterator();
+		}
+
+		@Override
+		public int size() {
+			return InstanceIdentityMap.this.size();
+		}
+
+		@Override
+		public boolean contains(Object o) {
+			return o instanceof Entry<?, ?> entry
+				&& containsMapping( entry.getKey(), entry.getValue() );
+		}
+
+		@Override
+		public @NonNull Object @NonNull [] toArray() {
+			return toArray( new Object[0] );
+		}
+
+		@Override
+		@AllowReflection
+		@SuppressWarnings("unchecked")
+		public <T> @NonNull T @NonNull [] toArray(T[] a) {
+			int size = size();
+			if ( a.length < size ) {
+				a = (T[]) Array.newInstance( a.getClass().getComponentType(), size );
+			}
+			int i = 0;
+			for ( Page<Entry<K, V>> page : elementPages ) {
+				if ( page != null ) {
+					for ( int j = 0; j <= page.lastNotEmptyOffset(); j++ ) {
+						final Map.Entry<K, V> entry;
+						if ( (entry = page.get( j )) != null ) {
+							a[i++] = (T) entry;
+						}
+					}
+				}
+			}
+			// fewer elements than expected or concurrent modification from other thread detected
+			if ( i < size ) {
+				throw new ConcurrentModificationException();
+			}
+			if ( i < a.length ) {
+				a[i] = null;
+			}
+			return a;
+		}
+	}
+}

--- a/hibernate-core/src/main/java/org/hibernate/internal/util/collections/InstanceIdentityStore.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/util/collections/InstanceIdentityStore.java
@@ -1,0 +1,101 @@
+/*
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.internal.util.collections;
+
+import org.checkerframework.checker.nullness.qual.Nullable;
+import org.hibernate.engine.spi.InstanceIdentity;
+
+/**
+ * Utility collection that takes advantage of {@link InstanceIdentity}'s identifier to store objects.
+ * The store is based on {@link AbstractPagedArray} and it stores element using their instance-id
+ * as index.
+ * <p>
+ * Both keys and values are stored in this array, requiring very few allocations to keep track of the pair.
+ * The downside to this is we cannot easily access the key, especially if asking for a specific type, since
+ * that would cause type-pollution issues at the call site that would degrade performance.
+ *
+ * @param <V> the type of values contained in this store
+ */
+public class InstanceIdentityStore<V> extends AbstractPagedArray<Object> {
+	/**
+	 * Utility to derive the key index from an instance-id, keys are stored in every 2 positions in the array
+	 *
+	 * @param instanceId the instance identifier
+	 * @return the index of the corresponding key instance in the array
+	 */
+	private static int toKeyIndex(int instanceId) {
+		return instanceId * 2;
+	}
+
+	/**
+	 * Returns the value to which the specified instance id is mapped, or {@code null} if this store
+	 * contains no mapping for the instance id.
+	 *
+	 * @param instanceId the instance id whose associated value is to be returned
+	 * @param key key instance to double-check instance equality
+	 * @return the value to which the specified instance id is mapped,
+	 * or {@code null} if this map contains no mapping for the instance id
+	 * @implNote This method accesses the backing array with the provided instance id, but performs an instance
+	 * equality check ({@code ==}) with the provided key to ensure it corresponds to the mapped one
+	 */
+	public @Nullable V get(int instanceId, Object key) {
+		final int keyIndex = toKeyIndex( instanceId );
+		final Page<Object> page = getPage( keyIndex );
+		if ( page != null ) {
+			final int offset = toPageOffset( keyIndex );
+			final Object k = page.get( offset );
+			if ( k == key ) {
+				//noinspection unchecked
+				return (V) page.get( offset + 1 );
+			}
+		}
+		return null;
+	}
+
+	/**
+	 * Associates the specified value with the specified key in this store (optional operation). If the store
+	 * previously contained a mapping for the key, the old value is replaced by the specified value.
+	 *
+	 * @param key key with which the specified value is to be associated
+	 * @param value value to be associated with the specified key
+	 */
+	public <K extends InstanceIdentity> void put(K key, V value) {
+		if ( key == null ) {
+			throw new NullPointerException( "This store does not support null keys" );
+		}
+
+		final int instanceId = key.$$_hibernate_getInstanceId();
+		final int keyIndex = toKeyIndex( instanceId );
+		final Page<Object> page = getOrCreateEntryPage( keyIndex );
+		final int pageOffset = toPageOffset( keyIndex );
+		page.set( pageOffset, key );
+		page.set( pageOffset + 1, value );
+	}
+
+	/**
+	 * Removes the mapping for an instance id from this store if it is present (optional operation).
+	 *
+	 * @param instanceId the instance id whose associated value is to be returned
+	 * @param key key instance to double-check instance equality
+	 * @implNote This method accesses the backing array with the provided instance id, but performs an instance
+	 * equality check ({@code ==}) with the provided key to ensure it corresponds to the mapped one
+	 */
+	public void remove(int instanceId, Object key) {
+		final int keyIndex = toKeyIndex( instanceId );
+		final Page<Object> page = getPage( keyIndex );
+		if ( page != null ) {
+			final int pageOffset = toPageOffset( keyIndex );
+			Object k = page.set( pageOffset, null );
+			// Check that the provided instance really matches with the key contained in the store
+			if ( k == key ) {
+				page.set( pageOffset + 1, null );
+			}
+			else {
+				// If it doesn't, reset the array value to the old key
+				page.set( pageOffset, k );
+			}
+		}
+	}
+}

--- a/hibernate-core/src/main/java/org/hibernate/internal/util/collections/InstanceIdentityStore.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/util/collections/InstanceIdentityStore.java
@@ -7,10 +7,15 @@ package org.hibernate.internal.util.collections;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.hibernate.engine.spi.InstanceIdentity;
 
+import java.util.ConcurrentModificationException;
+
 /**
  * Utility collection that takes advantage of {@link InstanceIdentity}'s identifier to store objects.
  * The store is based on {@link AbstractPagedArray} and it stores element using their instance-id
  * as index.
+ * <p>
+ * Instance ids are considered to start from 1, and if two instances are found to have the
+ * same identifier a {@link java.util.ConcurrentModificationException will be thrown}.
  * <p>
  * Both keys and values are stored in this array, requiring very few allocations to keep track of the pair.
  * The downside to this is we cannot easily access the key, especially if asking for a specific type, since
@@ -26,7 +31,7 @@ public class InstanceIdentityStore<V> extends AbstractPagedArray<Object> {
 	 * @return the index of the corresponding key instance in the array
 	 */
 	private static int toKeyIndex(int instanceId) {
-		return instanceId * 2;
+		return (instanceId - 1) * 2;
 	}
 
 	/**
@@ -41,6 +46,10 @@ public class InstanceIdentityStore<V> extends AbstractPagedArray<Object> {
 	 * equality check ({@code ==}) with the provided key to ensure it corresponds to the mapped one
 	 */
 	public @Nullable V get(int instanceId, Object key) {
+		if ( instanceId <= 0 ) {
+			return null;
+		}
+
 		final int keyIndex = toKeyIndex( instanceId );
 		final Page<Object> page = getPage( keyIndex );
 		if ( page != null ) {
@@ -49,6 +58,12 @@ public class InstanceIdentityStore<V> extends AbstractPagedArray<Object> {
 			if ( k == key ) {
 				//noinspection unchecked
 				return (V) page.get( offset + 1 );
+			}
+			else {
+				throw new ConcurrentModificationException(
+						"Found a different instance corresponding to instanceId [" + instanceId +
+						"], this might indicate a concurrent access to this persistence context."
+				);
 			}
 		}
 		return null;
@@ -61,12 +76,14 @@ public class InstanceIdentityStore<V> extends AbstractPagedArray<Object> {
 	 * @param key key with which the specified value is to be associated
 	 * @param value value to be associated with the specified key
 	 */
-	public <K extends InstanceIdentity> void put(K key, V value) {
+	public void put(Object key, int instanceId, V value) {
 		if ( key == null ) {
 			throw new NullPointerException( "This store does not support null keys" );
 		}
+		else if ( instanceId <= 0 ) {
+			throw new IllegalArgumentException( "Instance ID must be a positive value" );
+		}
 
-		final int instanceId = key.$$_hibernate_getInstanceId();
 		final int keyIndex = toKeyIndex( instanceId );
 		final Page<Object> page = getOrCreateEntryPage( keyIndex );
 		final int pageOffset = toPageOffset( keyIndex );
@@ -83,6 +100,10 @@ public class InstanceIdentityStore<V> extends AbstractPagedArray<Object> {
 	 * equality check ({@code ==}) with the provided key to ensure it corresponds to the mapped one
 	 */
 	public void remove(int instanceId, Object key) {
+		if ( instanceId <= 0 ) {
+			return;
+		}
+
 		final int keyIndex = toKeyIndex( instanceId );
 		final Page<Object> page = getPage( keyIndex );
 		if ( page != null ) {
@@ -93,8 +114,10 @@ public class InstanceIdentityStore<V> extends AbstractPagedArray<Object> {
 				page.set( pageOffset + 1, null );
 			}
 			else {
-				// If it doesn't, reset the array value to the old key
-				page.set( pageOffset, k );
+				throw new ConcurrentModificationException(
+						"Found a different instance corresponding to instanceId [" + instanceId +
+						"], this might indicate a concurrent access to this persistence context."
+				);
 			}
 		}
 	}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhance/version/SimpleEntity.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhance/version/SimpleEntity.java
@@ -67,4 +67,14 @@ public class SimpleEntity implements ManagedEntity {
 	public boolean $$_hibernate_useTracker() {
 		return false;
 	}
+
+	@Override
+	public int $$_hibernate_getInstanceId() {
+		return 0;
+	}
+
+	@Override
+	public void $$_hibernate_setInstanceId(int id) {
+
+	}
 }

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/basic/BasicSessionTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/basic/BasicSessionTest.java
@@ -81,6 +81,8 @@ public class BasicSessionTest {
 		private transient ManagedEntity previous;
 		@Transient
 		private transient ManagedEntity next;
+		@Transient
+		private transient int instanceId;
 
 		MyEntity() {
 		}
@@ -132,6 +134,16 @@ public class BasicSessionTest {
 		@Override
 		public boolean $$_hibernate_useTracker() {
 			return false;
+		}
+
+		@Override
+		public int $$_hibernate_getInstanceId() {
+			return instanceId;
+		}
+
+		@Override
+		public void $$_hibernate_setInstanceId(int id) {
+			this.instanceId = id;
 		}
 	}
 }

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/cache/ByteCodeEnhancedImmutableReferenceCacheTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/cache/ByteCodeEnhancedImmutableReferenceCacheTest.java
@@ -238,6 +238,8 @@ public class ByteCodeEnhancedImmutableReferenceCacheTest extends BaseCoreFunctio
 		private transient ManagedEntity previous;
 		@Transient
 		private transient ManagedEntity next;
+		@Transient
+		private transient int instanceId;
 
 		public MyEnhancedReferenceData(Integer id, String name, String theValue) {
 			this.id = id;
@@ -315,6 +317,16 @@ public class ByteCodeEnhancedImmutableReferenceCacheTest extends BaseCoreFunctio
 		@Override
 		public boolean $$_hibernate_useTracker() {
 			return false;
+		}
+
+		@Override
+		public int $$_hibernate_getInstanceId() {
+			return instanceId;
+		}
+
+		@Override
+		public void $$_hibernate_setInstanceId(int id) {
+			this.instanceId = id;
 		}
 	}
 }

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/pc/InstanceIdentityTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/pc/InstanceIdentityTest.java
@@ -1,0 +1,187 @@
+/*
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.pc;
+
+import jakarta.persistence.ElementCollection;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import org.hibernate.annotations.Immutable;
+import org.hibernate.collection.spi.PersistentCollection;
+import org.hibernate.engine.spi.ManagedEntity;
+import org.hibernate.testing.bytecode.enhancement.extension.BytecodeEnhanced;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DomainModel(annotatedClasses = {
+		InstanceIdentityTest.ImmutableEntity.class,
+		InstanceIdentityTest.EntityWithCollections.class,
+})
+@SessionFactory
+@BytecodeEnhanced
+public class InstanceIdentityTest {
+	@Test
+	public void testEnhancedImmutableEntity(SessionFactoryScope scope) {
+		scope.inTransaction( session -> {
+			final ImmutableEntity entity1 = new ImmutableEntity( 1, "entity_1" );
+			session.persist( entity1 );
+
+			// false warning, bytecode enhancement of the test class will make the cast work
+			assertThat( ((ManagedEntity) entity1).$$_hibernate_getInstanceId() ).isGreaterThanOrEqualTo( 0 );
+			assertThat( session.contains( entity1 ) ).isTrue();
+
+			final ImmutableEntity entity2 = new ImmutableEntity( 2, "entity_2" );
+			session.persist( entity2 );
+			final ImmutableEntity entity3 = new ImmutableEntity( 3, "entity_3" );
+			session.persist( entity3 );
+		} );
+
+		scope.inSession( session -> {
+			assertThat( session.find( ImmutableEntity.class, 1 ) ).isNotNull().extracting( ImmutableEntity::getName )
+					.isEqualTo( "entity_1" );
+
+			final List<ImmutableEntity> immutableEntities = session.createQuery(
+					"from ImmutableEntity",
+					ImmutableEntity.class
+			).getResultList();
+
+			assertThat( immutableEntities ).hasSize( 3 );
+
+			// test find again, this time from 1st level cache
+			final ImmutableEntity entity2 = session.find( ImmutableEntity.class, 2 );
+			assertThat( entity2 ).isNotNull().extracting( ImmutableEntity::getName )
+					.isEqualTo( "entity_2" );
+
+			session.detach( entity2 );
+			assertThat( session.contains( entity2 ) ).isFalse();
+		} );
+	}
+
+	@Test
+	public void testPersistentCollections(SessionFactoryScope scope) {
+		scope.inTransaction( session -> {
+			final ImmutableEntity immutableEntity = new ImmutableEntity( 4, "entity_4" );
+			session.persist( immutableEntity );
+			final EntityWithCollections entity = new EntityWithCollections( 1 );
+			entity.getStringList().addAll( List.of( "one", "two" ) );
+			entity.getEntityMap().put( "4", immutableEntity );
+			session.persist( entity );
+
+			assertThat( entity.getStringList() ).isInstanceOf( PersistentCollection.class );
+			final PersistentCollection<?> persistentList = (PersistentCollection<?>) entity.getStringList();
+			assertThat( persistentList.$$_hibernate_getInstanceId() ).isGreaterThanOrEqualTo( 0 );
+
+			assertThat( entity.getEntityMap() ).isInstanceOf( PersistentCollection.class );
+			final PersistentCollection<?> persistentMap = (PersistentCollection<?>) entity.getEntityMap();
+			assertThat( persistentMap.$$_hibernate_getInstanceId() ).isGreaterThanOrEqualTo( 0 );
+
+			assertThat( session.getPersistenceContextInternal().getCollectionEntries() ).isNotNull()
+					.containsKeys( persistentList, persistentMap );
+		} );
+
+		scope.inTransaction( session -> {
+			final EntityWithCollections entity = session.find( EntityWithCollections.class, 1 );
+			entity.getStringList().add( "three" );
+			entity.getEntityMap().clear();
+		} );
+
+		scope.inSession( session -> {
+			final EntityWithCollections entity = session.find( EntityWithCollections.class, 1 );
+			assertThat( entity.getStringList() ).hasSize( 3 ).containsExactly( "one", "two", "three" );
+			assertThat( entity.getEntityMap() ).isEmpty();
+		} );
+	}
+
+	@AfterEach
+	public void tearDown(SessionFactoryScope scope) {
+		scope.getSessionFactory().getSchemaManager().truncateMappedObjects();
+	}
+
+	@Immutable
+	@Entity(name = "ImmutableEntity")
+	static class ImmutableEntity {
+		@Id
+		private Integer id;
+
+		private String name;
+
+		public ImmutableEntity() {
+		}
+
+		public ImmutableEntity(Integer id, String name) {
+			this.id = id;
+			this.name = name;
+		}
+
+		public Integer getId() {
+			return id;
+		}
+
+		public void setId(Integer id) {
+			this.id = id;
+		}
+
+		public String getName() {
+			return name;
+		}
+
+		public void setName(String name) {
+			this.name = name;
+		}
+	}
+
+	@Entity(name = "EntityWithCollections")
+	static class EntityWithCollections {
+		@Id
+		private Integer id;
+
+		@ElementCollection
+		private List<String> stringList = new ArrayList<>();
+
+		@OneToMany
+		private Map<String, ImmutableEntity> entityMap = new HashMap<>();
+
+		public EntityWithCollections() {
+		}
+
+		public EntityWithCollections(Integer id) {
+			this.id = id;
+		}
+
+		public Integer getId() {
+			return id;
+		}
+
+		public void setId(Integer id) {
+			this.id = id;
+		}
+
+		public List<String> getStringList() {
+			return stringList;
+		}
+
+		public void setStringList(List<String> stringList) {
+			this.stringList = stringList;
+		}
+
+		public Map<String, ImmutableEntity> getEntityMap() {
+			return entityMap;
+		}
+
+		public void setEntityMap(Map<String, ImmutableEntity> entityMap) {
+			this.entityMap = entityMap;
+		}
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/util/InstanceIdentityMapTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/util/InstanceIdentityMapTest.java
@@ -70,7 +70,7 @@ public class InstanceIdentityMapTest {
 
 	@Test
 	public void testMapIteration() {
-		for ( int i = 0; i < 100; i++ ) {
+		for ( int i = 1; i <= 100; i++ ) {
 			testMap.put( new TestInstance( i ), "instance_" + i );
 		}
 
@@ -78,7 +78,7 @@ public class InstanceIdentityMapTest {
 
 		final AtomicInteger count = new AtomicInteger();
 		testMap.forEach( (k, v) -> {
-			assertThat( k.$$_hibernate_getInstanceId() ).isBetween( 0, 99 );
+			assertThat( k.$$_hibernate_getInstanceId() ).isBetween( 1, 100 );
 			assertThat( v ).isEqualTo( "instance_" + k.$$_hibernate_getInstanceId() );
 			count.getAndIncrement();
 		} );
@@ -88,7 +88,7 @@ public class InstanceIdentityMapTest {
 	@Test
 	public void testSets() {
 		final Map<TestInstance, String> map = new HashMap<TestInstance, String>();
-		for ( int i = 0; i < 100; i++ ) {
+		for ( int i = 1; i <= 100; i++ ) {
 			map.put( new TestInstance( i ), "instance_" + i );
 		}
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/util/InstanceIdentityMapTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/util/InstanceIdentityMapTest.java
@@ -1,0 +1,102 @@
+/*
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.util;
+
+import org.hibernate.engine.spi.InstanceIdentity;
+import org.hibernate.internal.util.collections.InstanceIdentityMap;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
+
+public class InstanceIdentityMapTest {
+	private final InstanceIdentityMap<TestInstance, String> testMap = new InstanceIdentityMap<>();
+
+	private static final class TestInstance implements InstanceIdentity {
+		private int instanceId;
+
+		public TestInstance(int instanceId) {
+			this.instanceId = instanceId;
+		}
+
+		@Override
+		public void $$_hibernate_setInstanceId(int instanceId) {
+			this.instanceId = instanceId;
+		}
+
+		@Override
+		public int $$_hibernate_getInstanceId() {
+			return instanceId;
+		}
+	}
+
+	@AfterEach
+	public void setUp() {
+		testMap.clear();
+	}
+
+	@Test
+	public void testSimpleMapOperations() {
+		final TestInstance i1 = new TestInstance( 1 );
+		final TestInstance i2 = new TestInstance( 2 );
+		final TestInstance i3 = new TestInstance( 3 );
+		testMap.put( i1, "instance_1" );
+		testMap.putIfAbsent( i2, "instance_2" );
+		//noinspection RedundantCollectionOperation
+		testMap.putAll( Map.of( i3, "instance_3" ) );
+		assertThat( testMap ).hasSize( 3 ).containsKeys( i1, i2, i3 )
+				.containsValues( "instance_1", "instance_2", "instance_3" );
+
+		testMap.remove( i1 );
+		assertThat( testMap ).hasSize( 2 ).doesNotContainKeys( i1 );
+
+		testMap.remove( i2 );
+		assertThat( testMap ).hasSize( 1 ).doesNotContainKeys( i1, i2 );
+
+		final TestInstance i3New = new TestInstance( 3 );
+		testMap.put( i3New, "new_instance_3" );
+		assertThat( testMap ).hasSize( 1 ).containsExactly( entry( i3New, "new_instance_3" ) );
+
+		testMap.clear();
+		assertThat( testMap ).isEmpty();
+	}
+
+	@Test
+	public void testMapIteration() {
+		for ( int i = 0; i < 100; i++ ) {
+			testMap.put( new TestInstance( i ), "instance_" + i );
+		}
+
+		assertThat( testMap ).hasSize( 100 );
+
+		final AtomicInteger count = new AtomicInteger();
+		testMap.forEach( (k, v) -> {
+			assertThat( k.$$_hibernate_getInstanceId() ).isBetween( 0, 99 );
+			assertThat( v ).isEqualTo( "instance_" + k.$$_hibernate_getInstanceId() );
+			count.getAndIncrement();
+		} );
+		assertThat( count.get() ).isEqualTo( 100 );
+	}
+
+	@Test
+	public void testSets() {
+		final Map<TestInstance, String> map = new HashMap<TestInstance, String>();
+		for ( int i = 0; i < 100; i++ ) {
+			map.put( new TestInstance( i ), "instance_" + i );
+		}
+
+		testMap.putAll( map );
+		assertThat( testMap ).hasSize( 100 );
+
+		assertThat( testMap.keySet() ).hasSize( 100 ).containsAll( map.keySet() );
+		assertThat( testMap.values() ).hasSize( 100 ).containsAll( map.values() );
+		assertThat( testMap.entrySet() ).hasSize( 100 ).containsAll( map.entrySet() );
+	}
+}


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-18326

This PR tries to address the performance impact of relying on identity hashes to track persistent instances. See the initial benchmark results for the current state here: https://github.com/hibernate/hibernate-orm-benchmark/pull/15.

This strategy is using a unique `int` (but could be `long` too) **instance id** that is assigned once an entity/collection is made persistent, and through that maps instances to a new collection (`InstanceIdentityMap`) that simply stores information in an array using the unique id as index. This allows us to avoid relying on identity hash code for:
- **immutable** bytecode-enhanced entities
- persistent collections


I will add more details on the proposed change along with benchmarks results of using the new strategy in the linked `hibernate-orm-benchmarks` PR, but to synthetize them here:
- querying 100 immutable bytecode-enhanced entities, we get `8.4%` more ops/s than before and we align with the result of mutable entities (that do not need to rely on a map at all); increasing the entity count to `1_000` the result is similar, with `9.5%` more ops/s. Looking at the flamegraphs `StatefulPersistenceContext.addEntry` matches are basically aligned between mutable `true` and `false` tests.
- querying 100 entities containing collections, we get `18.3%` more ops/s with a mapping of only 2 collections (increasing to more than `50%` for 7+ collections) if we're not initializing the associations (matches for `StatefulPersistenceContext.addCollection` go down from `17.4%` to `1.8%`; if we do initialize the collections lazily (i.e. 1 additional query for each collection) we still get a very relevant performance increase with a 5-10% improvement in ops/s for 2 to 7 mapped collections, dropping to just 1% with 16 mapped collections.

Note this solution requires a change in the bytecode-enhanced entity classes, adding a new field to store the required unique ID. Other than that, only the `ManagedEntity` and `PersistentCollection` SPI interfaces have been changed. Marking this as draft as it will probably need to wait until after 7.0.0 is released.

----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-19070
<!-- Hibernate GitHub Bot issue links end -->