### PR TITLE
HHH-18982 make BeanContainer loadable as a Java service

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/boot/internal/TypeBeanInstanceProducer.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/internal/TypeBeanInstanceProducer.java
@@ -7,13 +7,14 @@ package org.hibernate.boot.internal;
 import org.hibernate.InstantiationException;
 import org.hibernate.Internal;
 import org.hibernate.engine.config.spi.ConfigurationService;
-import org.hibernate.internal.util.ReflectHelper;
 import org.hibernate.resource.beans.spi.BeanInstanceProducer;
 import org.hibernate.type.spi.TypeBootstrapContext;
 import org.hibernate.service.ServiceRegistry;
 
 import java.lang.reflect.Constructor;
 import java.util.Map;
+
+import static org.hibernate.internal.util.ReflectHelper.getConstructorOrNull;
 
 /**
  * {@link BeanInstanceProducer} implementation for building beans related to custom types.
@@ -32,8 +33,8 @@ public class TypeBeanInstanceProducer implements BeanInstanceProducer, TypeBoots
 
 	@Override
 	public <B> B produceBeanInstance(Class<B> beanType) {
-		final Constructor<B> bootstrapContextAwareConstructor =
-				ReflectHelper.getConstructorOrNull( beanType, TypeBootstrapContext.class );
+		final Constructor<? extends B> bootstrapContextAwareConstructor =
+				getConstructorOrNull( beanType, TypeBootstrapContext.class );
 		if ( bootstrapContextAwareConstructor != null ) {
 			try {
 				return bootstrapContextAwareConstructor.newInstance( this );
@@ -43,7 +44,7 @@ public class TypeBeanInstanceProducer implements BeanInstanceProducer, TypeBoots
 			}
 		}
 		else {
-			final Constructor<B> constructor = ReflectHelper.getConstructorOrNull( beanType );
+			final Constructor<? extends B> constructor = getConstructorOrNull( beanType );
 			if ( constructor != null ) {
 				try {
 					return constructor.newInstance();

--- a/hibernate-core/src/main/java/org/hibernate/boot/model/internal/GeneratorBinder.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/internal/GeneratorBinder.java
@@ -476,11 +476,11 @@ public class GeneratorBinder {
 	 * @param beanContainer an optional {@code BeanContainer}
 	 * @param generatorClass a class which implements {@code Generator}
 	 */
-	private static Generator instantiateGeneratorAsBean(
+	private static <T extends Generator> Generator instantiateGeneratorAsBean(
 			Annotation annotation,
 			BeanContainer beanContainer,
 			GeneratorCreationContext creationContext,
-			Class<? extends Generator> generatorClass,
+			Class<T> generatorClass,
 			MemberDetails memberDetails,
 			Class<? extends Annotation> annotationType) {
 		return Helper.getBean(

--- a/hibernate-core/src/main/java/org/hibernate/resource/beans/container/internal/CdiBeanContainerBuilder.java
+++ b/hibernate-core/src/main/java/org/hibernate/resource/beans/container/internal/CdiBeanContainerBuilder.java
@@ -4,101 +4,38 @@
  */
 package org.hibernate.resource.beans.container.internal;
 
-import java.lang.reflect.Constructor;
-import java.lang.reflect.InvocationTargetException;
-import java.util.Locale;
-
-import org.hibernate.HibernateException;
-import org.hibernate.boot.registry.classloading.spi.ClassLoaderService;
+import jakarta.enterprise.inject.spi.BeanManager;
+import org.hibernate.AssertionFailure;
+import org.hibernate.cfg.AvailableSettings;
 import org.hibernate.engine.config.spi.ConfigurationService;
 import org.hibernate.engine.config.spi.StandardConverters;
-import org.hibernate.internal.util.ReflectHelper;
-import org.hibernate.cfg.AvailableSettings;
 import org.hibernate.resource.beans.container.spi.BeanContainer;
-import org.hibernate.resource.beans.spi.ManagedBeanRegistryInitiator;
+import org.hibernate.resource.beans.container.spi.ExtendedBeanManager;
 import org.hibernate.service.ServiceRegistry;
 
 /**
- * Helper class for helping deal with the reflection calls relating to CDI
- * in terms of building CDI-based {@link BeanContainer}
- * instance
- *
- * We need to avoid statically linking CDI classed into the ClassLoader which
- * would lead to errors if CDI is not available on the classpath.
+ * Helper class for building a CDI-based {@link BeanContainer}.
  *
  * @author Steve Ebersole
  */
 public class CdiBeanContainerBuilder {
-	private static final String CONTAINER_FQN_IMMEDIATE = "org.hibernate.resource.beans.container.internal.CdiBeanContainerImmediateAccessImpl";
-	private static final String CONTAINER_FQN_DELAYED = "org.hibernate.resource.beans.container.internal.CdiBeanContainerDelayedAccessImpl";
-	private static final String CONTAINER_FQN_EXTENDED = "org.hibernate.resource.beans.container.internal.CdiBeanContainerExtendedAccessImpl";
 
-	private static final String BEAN_MANAGER_EXTENSION_FQN = "org.hibernate.resource.beans.container.spi.ExtendedBeanManager";
-
-	public static BeanContainer fromBeanManagerReference(
-			Object beanManagerRef,
-			ServiceRegistry serviceRegistry) {
-		final ClassLoaderService classLoaderService = serviceRegistry.requireService( ClassLoaderService.class );
-		final Class<?> beanManagerClass = ManagedBeanRegistryInitiator.cdiBeanManagerClass( classLoaderService );
-		final Class<?> extendedBeanManagerClass = getHibernateClass( BEAN_MANAGER_EXTENSION_FQN );
-
-		final Class<? extends BeanContainer> containerClass;
-		final Class<?> ctorArgType;
-
-		if ( extendedBeanManagerClass.isInstance( beanManagerRef ) ) {
-			containerClass = getHibernateClass( CONTAINER_FQN_EXTENDED );
-			ctorArgType = extendedBeanManagerClass;
+	public static BeanContainer fromBeanManagerReference(Object beanManager, ServiceRegistry serviceRegistry) {
+		if ( beanManager instanceof ExtendedBeanManager extendedBeanManager ) {
+			return new CdiBeanContainerExtendedAccessImpl( extendedBeanManager );
+		}
+		else if ( beanManager instanceof BeanManager cdiBeanManager ) {
+			return delayCdiAccess( serviceRegistry )
+					? new CdiBeanContainerDelayedAccessImpl( cdiBeanManager )
+					: new CdiBeanContainerImmediateAccessImpl( cdiBeanManager );
 		}
 		else {
-			ctorArgType = beanManagerClass;
-
-			final ConfigurationService cfgService = serviceRegistry.requireService( ConfigurationService.class );
-			final boolean delayAccessToCdi = cfgService.getSetting( AvailableSettings.DELAY_CDI_ACCESS, StandardConverters.BOOLEAN, false );
-			if ( delayAccessToCdi ) {
-				containerClass = getHibernateClass( CONTAINER_FQN_DELAYED );
-			}
-			else {
-				containerClass = getHibernateClass( CONTAINER_FQN_IMMEDIATE );
-			}
-		}
-
-		try {
-			final Constructor<? extends BeanContainer> ctor = containerClass.getDeclaredConstructor( ctorArgType );
-			try {
-				ReflectHelper.ensureAccessibility( ctor );
-				return ctor.newInstance( ctorArgType.cast( beanManagerRef ) );
-			}
-			catch (InvocationTargetException e) {
-				throw new HibernateException( "Problem building " + containerClass.getName(), e.getCause() );
-			}
-			catch (Exception e) {
-				throw new HibernateException( "Problem building " + containerClass.getName(), e );
-			}
-		}
-		catch (NoSuchMethodException e) {
-			throw new HibernateException(
-					String.format(
-							Locale.ENGLISH,
-							"Could not locate proper %s constructor",
-							containerClass.getName()
-					),
-					e
-			);
+			throw new AssertionFailure( "Unsupported bean manager: " + beanManager );
 		}
 	}
 
-	@SuppressWarnings("unchecked")
-	private static <T> Class<T> getHibernateClass(String fqn) {
-		// we use this Class's ClassLoader...
-		try {
-			return  (Class<T>) Class.forName(
-					fqn,
-					true,
-					CdiBeanContainerBuilder.class.getClassLoader()
-			);
-		}
-		catch (ClassNotFoundException e) {
-			throw new HibernateException( "Unable to locate Hibernate class by name via reflection : " + fqn, e );
-		}
+	private static boolean delayCdiAccess(ServiceRegistry serviceRegistry) {
+		return serviceRegistry.requireService( ConfigurationService.class )
+				.getSetting( AvailableSettings.DELAY_CDI_ACCESS, StandardConverters.BOOLEAN, false );
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/resource/beans/container/internal/CdiBeanContainerBuilder.java
+++ b/hibernate-core/src/main/java/org/hibernate/resource/beans/container/internal/CdiBeanContainerBuilder.java
@@ -6,12 +6,13 @@ package org.hibernate.resource.beans.container.internal;
 
 import jakarta.enterprise.inject.spi.BeanManager;
 import org.hibernate.AssertionFailure;
-import org.hibernate.cfg.AvailableSettings;
 import org.hibernate.engine.config.spi.ConfigurationService;
 import org.hibernate.engine.config.spi.StandardConverters;
 import org.hibernate.resource.beans.container.spi.BeanContainer;
 import org.hibernate.resource.beans.container.spi.ExtendedBeanManager;
 import org.hibernate.service.ServiceRegistry;
+
+import static org.hibernate.cfg.ManagedBeanSettings.DELAY_CDI_ACCESS;
 
 /**
  * Helper class for building a CDI-based {@link BeanContainer}.
@@ -36,6 +37,6 @@ public class CdiBeanContainerBuilder {
 
 	private static boolean delayCdiAccess(ServiceRegistry serviceRegistry) {
 		return serviceRegistry.requireService( ConfigurationService.class )
-				.getSetting( AvailableSettings.DELAY_CDI_ACCESS, StandardConverters.BOOLEAN, false );
+				.getSetting( DELAY_CDI_ACCESS, StandardConverters.BOOLEAN, false );
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/resource/beans/container/internal/CdiBeanContainerDelayedAccessImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/resource/beans/container/internal/CdiBeanContainerDelayedAccessImpl.java
@@ -14,11 +14,10 @@ import org.hibernate.resource.beans.spi.BeanInstanceProducer;
 /**
  * @author Steve Ebersole
  */
-@SuppressWarnings("unused")
 public class CdiBeanContainerDelayedAccessImpl extends AbstractCdiBeanContainer {
 	private final BeanManager beanManager;
 
-	private CdiBeanContainerDelayedAccessImpl(BeanManager beanManager) {
+	CdiBeanContainerDelayedAccessImpl(BeanManager beanManager) {
 		this.beanManager = beanManager;
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/resource/beans/container/internal/CdiBeanContainerExtendedAccessImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/resource/beans/container/internal/CdiBeanContainerExtendedAccessImpl.java
@@ -5,7 +5,6 @@
 package org.hibernate.resource.beans.container.internal;
 
 import jakarta.enterprise.inject.spi.BeanManager;
-
 import org.hibernate.Internal;
 import org.hibernate.resource.beans.container.spi.AbstractCdiBeanContainer;
 import org.hibernate.resource.beans.container.spi.BeanLifecycleStrategy;
@@ -14,7 +13,7 @@ import org.hibernate.resource.beans.container.spi.ContainedBeanImplementor;
 import org.hibernate.resource.beans.container.spi.ExtendedBeanManager;
 import org.hibernate.resource.beans.spi.BeanInstanceProducer;
 
-import org.jboss.logging.Logger;
+import static org.hibernate.resource.beans.internal.BeansMessageLogger.BEANS_MSG_LOGGER;
 
 /**
  * @author Steve Ebersole
@@ -23,15 +22,13 @@ public class CdiBeanContainerExtendedAccessImpl
 		extends AbstractCdiBeanContainer
 		implements ExtendedBeanManager.LifecycleListener {
 
-	// NOTE : we continue to use the deprecated form for now since that is what WildFly needs for the time being still
-
-	private static final Logger log = Logger.getLogger( CdiBeanContainerExtendedAccessImpl.class );
+	// NOTE : we continue to use the deprecated form for now since that is what WildFly needs for the time being
 
 	private BeanManager usableBeanManager;
 
 	CdiBeanContainerExtendedAccessImpl(ExtendedBeanManager beanManager) {
 		beanManager.registerLifecycleListener( this );
-		log.debugf( "Extended access requested to CDI BeanManager : %s", beanManager );
+		BEANS_MSG_LOGGER.extendedAccessToBeanManager();
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/resource/beans/container/internal/CdiBeanContainerExtendedAccessImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/resource/beans/container/internal/CdiBeanContainerExtendedAccessImpl.java
@@ -19,7 +19,6 @@ import org.jboss.logging.Logger;
 /**
  * @author Steve Ebersole
  */
-@SuppressWarnings("unused")
 public class CdiBeanContainerExtendedAccessImpl
 		extends AbstractCdiBeanContainer
 		implements ExtendedBeanManager.LifecycleListener {
@@ -30,7 +29,7 @@ public class CdiBeanContainerExtendedAccessImpl
 
 	private BeanManager usableBeanManager;
 
-	private CdiBeanContainerExtendedAccessImpl(ExtendedBeanManager beanManager) {
+	CdiBeanContainerExtendedAccessImpl(ExtendedBeanManager beanManager) {
 		beanManager.registerLifecycleListener( this );
 		log.debugf( "Extended access requested to CDI BeanManager : %s", beanManager );
 	}

--- a/hibernate-core/src/main/java/org/hibernate/resource/beans/container/internal/CdiBeanContainerImmediateAccessImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/resource/beans/container/internal/CdiBeanContainerImmediateAccessImpl.java
@@ -5,24 +5,22 @@
 package org.hibernate.resource.beans.container.internal;
 
 import jakarta.enterprise.inject.spi.BeanManager;
-
 import org.hibernate.resource.beans.container.spi.AbstractCdiBeanContainer;
 import org.hibernate.resource.beans.container.spi.BeanLifecycleStrategy;
 import org.hibernate.resource.beans.container.spi.ContainedBeanImplementor;
 import org.hibernate.resource.beans.spi.BeanInstanceProducer;
 
-import org.jboss.logging.Logger;
+import static org.hibernate.resource.beans.internal.BeansMessageLogger.BEANS_MSG_LOGGER;
 
 /**
  * @author Steve Ebersole
  */
 public class CdiBeanContainerImmediateAccessImpl extends AbstractCdiBeanContainer {
-	private static final Logger log = Logger.getLogger( CdiBeanContainerImmediateAccessImpl.class );
 
 	private final BeanManager beanManager;
 
 	CdiBeanContainerImmediateAccessImpl(BeanManager beanManager) {
-		log.debugf( "Standard access requested to CDI BeanManager : %s", beanManager );
+		BEANS_MSG_LOGGER.standardAccessToBeanManager();
 		this.beanManager = beanManager;
 	}
 
@@ -36,7 +34,8 @@ public class CdiBeanContainerImmediateAccessImpl extends AbstractCdiBeanContaine
 			Class<B> beanType,
 			BeanLifecycleStrategy lifecycleStrategy,
 			BeanInstanceProducer fallbackProducer) {
-		final ContainedBeanImplementor<B> bean = lifecycleStrategy.createBean( beanType, fallbackProducer, this );
+		final ContainedBeanImplementor<B> bean =
+				lifecycleStrategy.createBean( beanType, fallbackProducer, this );
 		bean.initialize();
 		return bean;
 	}
@@ -47,12 +46,8 @@ public class CdiBeanContainerImmediateAccessImpl extends AbstractCdiBeanContaine
 			Class<B> beanType,
 			BeanLifecycleStrategy lifecycleStrategy,
 			BeanInstanceProducer fallbackProducer) {
-		final ContainedBeanImplementor<B> bean = lifecycleStrategy.createBean(
-				name,
-				beanType,
-				fallbackProducer,
-				this
-		);
+		final ContainedBeanImplementor<B> bean =
+				lifecycleStrategy.createBean( name, beanType, fallbackProducer, this );
 		bean.initialize();
 		return bean;
 	}

--- a/hibernate-core/src/main/java/org/hibernate/resource/beans/container/internal/CdiBeanContainerImmediateAccessImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/resource/beans/container/internal/CdiBeanContainerImmediateAccessImpl.java
@@ -16,13 +16,12 @@ import org.jboss.logging.Logger;
 /**
  * @author Steve Ebersole
  */
-@SuppressWarnings("unused")
 public class CdiBeanContainerImmediateAccessImpl extends AbstractCdiBeanContainer {
 	private static final Logger log = Logger.getLogger( CdiBeanContainerImmediateAccessImpl.class );
 
 	private final BeanManager beanManager;
 
-	private CdiBeanContainerImmediateAccessImpl(BeanManager beanManager) {
+	CdiBeanContainerImmediateAccessImpl(BeanManager beanManager) {
 		log.debugf( "Standard access requested to CDI BeanManager : %s", beanManager );
 		this.beanManager = beanManager;
 	}

--- a/hibernate-core/src/main/java/org/hibernate/resource/beans/container/internal/ContainerManagedLifecycleStrategy.java
+++ b/hibernate-core/src/main/java/org/hibernate/resource/beans/container/internal/ContainerManagedLifecycleStrategy.java
@@ -199,7 +199,7 @@ public class ContainerManagedLifecycleStrategy implements BeanLifecycleStrategy 
 				return root.select( beanType, new NamedBeanQualifier( beanName ) );
 			}
 			catch (Exception e) {
-				throw new NoSuchBeanException( "Bean class not known to CDI : " + beanType.getName(), e );
+				throw new NoSuchBeanException( "Bean class not known to CDI: " + beanType.getName(), e );
 			}
 		}
 

--- a/hibernate-core/src/main/java/org/hibernate/resource/beans/container/internal/JpaCompliantLifecycleStrategy.java
+++ b/hibernate-core/src/main/java/org/hibernate/resource/beans/container/internal/JpaCompliantLifecycleStrategy.java
@@ -141,8 +141,8 @@ public class JpaCompliantLifecycleStrategy implements BeanLifecycleStrategy {
 				beanInstance = fallbackProducer.produceBeanInstance( beanType );
 
 				try {
-					if ( this.creationalContext != null ) {
-						this.creationalContext.release();
+					if ( creationalContext != null ) {
+						creationalContext.release();
 					}
 				}
 				catch (Exception ignore) {

--- a/hibernate-core/src/main/java/org/hibernate/resource/beans/container/spi/AbstractCdiBeanContainer.java
+++ b/hibernate-core/src/main/java/org/hibernate/resource/beans/container/spi/AbstractCdiBeanContainer.java
@@ -13,9 +13,10 @@ import java.util.function.Consumer;
 import org.hibernate.resource.beans.container.internal.CdiBasedBeanContainer;
 import org.hibernate.resource.beans.container.internal.ContainerManagedLifecycleStrategy;
 import org.hibernate.resource.beans.container.internal.JpaCompliantLifecycleStrategy;
-import org.hibernate.resource.beans.internal.BeansMessageLogger;
 import org.hibernate.resource.beans.internal.Helper;
 import org.hibernate.resource.beans.spi.BeanInstanceProducer;
+
+import static org.hibernate.resource.beans.internal.BeansMessageLogger.BEANS_MSG_LOGGER;
 
 /**
  * @author Steve Ebersole
@@ -34,7 +35,6 @@ public abstract class AbstractCdiBeanContainer implements CdiBasedBeanContainer 
 				: createBean( beanType, lifecycleOptions, fallbackProducer );
 	}
 
-	@SuppressWarnings("unchecked")
 	private <B> ContainedBean<B> getCacheableBean(
 			Class<B> beanType,
 			LifecycleOptions lifecycleOptions,
@@ -43,6 +43,7 @@ public abstract class AbstractCdiBeanContainer implements CdiBasedBeanContainer 
 
 		final ContainedBeanImplementor<?> existing = beanCache.get( beanCacheKey );
 		if ( existing != null ) {
+			//noinspection unchecked
 			return (ContainedBeanImplementor<B>) existing;
 		}
 
@@ -77,15 +78,11 @@ public abstract class AbstractCdiBeanContainer implements CdiBasedBeanContainer 
 			Class<B> beanType,
 			LifecycleOptions lifecycleOptions,
 			BeanInstanceProducer fallbackProducer) {
-		if ( lifecycleOptions.canUseCachedReferences() ) {
-			return getCacheableBean( beanName, beanType, lifecycleOptions, fallbackProducer );
-		}
-		else {
-			return createBean( beanName, beanType, lifecycleOptions, fallbackProducer );
-		}
+		return lifecycleOptions.canUseCachedReferences()
+				? getCacheableBean( beanName, beanType, lifecycleOptions, fallbackProducer )
+				: createBean( beanName, beanType, lifecycleOptions, fallbackProducer );
 	}
 
-	@SuppressWarnings("unchecked")
 	private <B> ContainedBeanImplementor<B> getCacheableBean(
 			String beanName,
 			Class<B> beanType,
@@ -95,10 +92,12 @@ public abstract class AbstractCdiBeanContainer implements CdiBasedBeanContainer 
 
 		final ContainedBeanImplementor<?> existing = beanCache.get( beanCacheKey );
 		if ( existing != null ) {
+			//noinspection unchecked
 			return (ContainedBeanImplementor<B>) existing;
 		}
 
-		final ContainedBeanImplementor<B> bean = createBean( beanName, beanType, lifecycleOptions, fallbackProducer );
+		final ContainedBeanImplementor<B> bean =
+				createBean( beanName, beanType, lifecycleOptions, fallbackProducer );
 		beanCache.put( beanCacheKey, bean );
 		return bean;
 	}
@@ -133,7 +132,7 @@ public abstract class AbstractCdiBeanContainer implements CdiBasedBeanContainer 
 
 	@Override
 	public final void stop() {
-		BeansMessageLogger.BEANS_MSG_LOGGER.stoppingBeanContainer( this );
+		BEANS_MSG_LOGGER.stoppingBeanContainer( this );
 		forEachBean( ContainedBeanImplementor::release );
 		registeredBeans.clear();
 		beanCache.clear();

--- a/hibernate-core/src/main/java/org/hibernate/resource/beans/container/spi/BeanContainer.java
+++ b/hibernate-core/src/main/java/org/hibernate/resource/beans/container/spi/BeanContainer.java
@@ -5,6 +5,7 @@
 package org.hibernate.resource.beans.container.spi;
 
 import org.hibernate.resource.beans.spi.BeanInstanceProducer;
+import org.hibernate.service.JavaServiceLoadable;
 import org.hibernate.service.spi.Stoppable;
 
 /**
@@ -19,6 +20,7 @@ import org.hibernate.service.spi.Stoppable;
  *
  * @author Steve Ebersole
  */
+@JavaServiceLoadable
 public interface BeanContainer extends Stoppable {
 	interface LifecycleOptions {
 		boolean canUseCachedReferences();

--- a/hibernate-core/src/main/java/org/hibernate/resource/beans/internal/BeansMessageLogger.java
+++ b/hibernate-core/src/main/java/org/hibernate/resource/beans/internal/BeansMessageLogger.java
@@ -17,7 +17,6 @@ import java.lang.invoke.MethodHandles;
 
 import static org.jboss.logging.Logger.Level.DEBUG;
 import static org.jboss.logging.Logger.Level.INFO;
-import static org.jboss.logging.Logger.Level.WARN;
 
 /**
  * @author Steve Ebersole
@@ -33,20 +32,11 @@ public interface BeansMessageLogger {
 
 	BeansMessageLogger BEANS_MSG_LOGGER = Logger.getMessageLogger( MethodHandles.lookup(), BeansMessageLogger.class, LOGGER_NAME );
 
-	@LogMessage( level = WARN )
-	@Message(
-			id = 10005001,
-			value = "An explicit CDI BeanManager reference [%s] was passed to Hibernate, " +
-					"but CDI is not available on the Hibernate ClassLoader. This is likely " +
-					"going to lead to exceptions later on in bootstrap."
-	)
-	void beanManagerButCdiNotAvailable(Object cdiBeanManagerReference);
-
 	@LogMessage( level = INFO )
 	@Message(
 			id = 10005002,
 			value = "No explicit CDI BeanManager reference was passed to Hibernate, " +
-					"but CDI is available on the Hibernate ClassLoader."
+					"but CDI is available on the Hibernate class loader"
 	)
 	void noBeanManagerButCdiAvailable();
 
@@ -56,4 +46,18 @@ public interface BeansMessageLogger {
 			value = "Stopping BeanContainer: %s"
 	)
 	void stoppingBeanContainer(BeanContainer beanContainer);
+
+	@LogMessage( level = DEBUG )
+	@Message(
+			id = 10005006,
+			value = "Standard access to BeanManager"
+	)
+	void standardAccessToBeanManager();
+
+	@LogMessage( level = DEBUG )
+	@Message(
+			id = 10005007,
+			value = "Extended access to BeanManager"
+	)
+	void extendedAccessToBeanManager();
 }

--- a/hibernate-core/src/main/java/org/hibernate/resource/beans/internal/FallbackBeanInstanceProducer.java
+++ b/hibernate-core/src/main/java/org/hibernate/resource/beans/internal/FallbackBeanInstanceProducer.java
@@ -36,7 +36,7 @@ public class FallbackBeanInstanceProducer implements BeanInstanceProducer {
 	public <B> B produceBeanInstance(Class<B> beanType) {
 		log.tracef( "Creating ManagedBean(%s) using direct instantiation", beanType.getName() );
 		try {
-			Constructor<B> constructor = beanType.getDeclaredConstructor();
+			final Constructor<B> constructor = beanType.getDeclaredConstructor();
 			constructor.setAccessible( true );
 			return constructor.newInstance();
 		}

--- a/hibernate-core/src/main/java/org/hibernate/service/spi/ServiceException.java
+++ b/hibernate-core/src/main/java/org/hibernate/service/spi/ServiceException.java
@@ -3,6 +3,7 @@
  * Copyright Red Hat Inc. and Hibernate Authors
  */
 package org.hibernate.service.spi;
+
 import org.hibernate.HibernateException;
 
 /**


### PR DESCRIPTION
also remove unnecessary use of reflection for creation of the CDI `BeanContainer`

<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

[Please describe here what your change is about]

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-18982
<!-- Hibernate GitHub Bot issue links end -->