### PR TITLE
Allow Hibernate Reactive to implement PersistenceContext

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/engine/internal/StatefulPersistenceContext.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/internal/StatefulPersistenceContext.java
@@ -330,10 +330,7 @@ class StatefulPersistenceContext implements PersistenceContext {
 		}
 		else {
 			final Object[] snapshot = persister.getDatabaseSnapshot( id, session );
-			if ( entitySnapshotsByKey == null ) {
-				entitySnapshotsByKey = CollectionHelper.mapOfSize( INIT_COLL_SIZE );
-			}
-			entitySnapshotsByKey.put( key, snapshot == null ? NO_ROW : snapshot );
+			getOrInitializeEntitySnapshotsByKey().put( key, snapshot == null ? NO_ROW : snapshot );
 			return snapshot;
 		}
 	}
@@ -1187,7 +1184,8 @@ class StatefulPersistenceContext implements PersistenceContext {
 		initializeNonLazyCollections( PersistentCollection::forceInitialization );
 	}
 
-	protected void initializeNonLazyCollections(Consumer<PersistentCollection<?>> initializeAction ) {
+	@Override
+	public void initializeNonLazyCollections(Consumer<PersistentCollection<?>> initializeAction ) {
 		if ( loadCounter == 0 ) {
 			LOG.trace( "Initializing non-lazy collections" );
 
@@ -1312,6 +1310,21 @@ class StatefulPersistenceContext implements PersistenceContext {
 			}
 		}
 		return result;
+	}
+
+	// Used by Hibernate Reactive
+	@Override
+	public Map<EntityKey, Object> getEntitySnapshotsByKey() {
+		return entitySnapshotsByKey;
+	}
+
+	// Used by Hibernate Reactive
+	@Override
+	public Map<EntityKey, Object> getOrInitializeEntitySnapshotsByKey() {
+		if ( entitySnapshotsByKey == null ) {
+			entitySnapshotsByKey = CollectionHelper.mapOfSize( INIT_COLL_SIZE );
+		}
+		return entitySnapshotsByKey;
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/engine/spi/PersistenceContext.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/spi/PersistenceContext.java
@@ -445,6 +445,18 @@ public interface PersistenceContext {
 	void initializeNonLazyCollections() throws HibernateException;
 
 	/**
+	 * Force initialization of all non-lazy collections encountered during
+	 * the current two-phase load (actually, this is a no-op, unless this
+	 * is the "outermost" load) allowing to customize how the initialization
+	 *  should occur
+	 *
+	 * @see #initializeNonLazyCollections()
+	 * @param initializeAction the function that initialize the collection
+	 */
+	// Used by Hibernate Reactive
+	void initializeNonLazyCollections(Consumer<PersistentCollection<?>> initializeAction);
+
+	/**
 	 * Get the {@code PersistentCollection} object for an array
 	 */
 	PersistentCollection<?> getCollectionHolder(Object array);
@@ -532,6 +544,14 @@ public interface PersistenceContext {
 	 */
 	@Internal
 	Map<EntityKey,Object> getEntitiesByKey();
+
+	// Used by Hibernate Reactive
+	@Internal
+	Map<EntityKey,Object> getEntitySnapshotsByKey();
+
+	// Used by Hibernate Reactive
+	@Internal
+	Map<EntityKey,Object> getOrInitializeEntitySnapshotsByKey();
 
 	/**
 	 * Doubly internal


### PR DESCRIPTION
In Hibernate Reactive, [ReactivePersistenceContextAdapter](https://github.com/hibernate/hibernate-reactive/blob/89f7cf20df9778fc4f1ced298ebead22d7c4ae00/hibernate-reactive-core/src/main/java/org/hibernate/reactive/engine/impl/ReactivePersistenceContextAdapter.java#L34) extends `StatefulPersistenceContext`.

But, [this change](https://github.com/hibernate/hibernate-orm/commit/1f87e47dfc429b662e0f7a06a575b90aa3d3b023?diff=unified#diff-b1b37f6d0ff0e2632cdd8194a9db6155e75b29cec62ffd03368e569868aea8feL92) makes the class package-private.

I've fixed the build in Hibernate Reactive buy moving the class to the same package, but is it possible to make it `protected` instead?

By the way, the current build using the ORM snapshots is here: [wip/3.0](https://github.com/hibernate/hibernate-reactive/tree/wip/3.0)

----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-19080
<!-- Hibernate GitHub Bot issue links end -->