### PR TITLE
HHH-19079 ComponentType.replace can cause ArrayIndexOutOfBoundsException when used with embeddable inheritance

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/type/ComponentType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/ComponentType.java
@@ -431,7 +431,7 @@ public class ComponentType extends AbstractType implements CompositeTypeImplemen
 	@Override
 	public Object[] getPropertyValues(Object component) {
 		if (component == null) {
-			return new Object[propertySpan];
+			return new Object[propertySpan + discriminatorColumnSpan];
 		}
 		else if ( component instanceof Object[] ) {
 			// A few calls to hashCode pass the property values already in an

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/inheritance/EmbeddableInheritanceReplaceTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/inheritance/EmbeddableInheritanceReplaceTest.java
@@ -1,0 +1,124 @@
+/*
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.inheritance;
+
+import jakarta.persistence.DiscriminatorColumn;
+import jakarta.persistence.DiscriminatorType;
+import jakarta.persistence.DiscriminatorValue;
+import jakarta.persistence.Embeddable;
+import jakarta.persistence.Embedded;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.JiraKey;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.junit.jupiter.api.Test;
+
+@DomainModel(annotatedClasses = {
+		EmbeddableInheritanceReplaceTest.Emb.class,
+		EmbeddableInheritanceReplaceTest.Base.class,
+		EmbeddableInheritanceReplaceTest.Next.class,
+		EmbeddableInheritanceReplaceTest.Ent.class
+})
+@SessionFactory
+@JiraKey("HHH-19079")
+public class EmbeddableInheritanceReplaceTest {
+
+	@Test
+	void merge(SessionFactoryScope scope) {
+		scope.inTransaction( session -> {
+			final var history = new Ent();
+			history.setBase( new Emb( 42, "Hello, World!" ) );
+
+			session.merge( history );
+		} );
+	}
+
+	@Embeddable
+	@DiscriminatorValue("E")
+	public static final class Emb extends Next {
+
+		Emb() {
+		}
+
+		public Emb(int num, String str) {
+			super( num, str );
+		}
+	}
+
+	@Embeddable
+	@DiscriminatorColumn(name = "etype", discriminatorType = DiscriminatorType.CHAR)
+	@DiscriminatorValue("b")
+	public static class Base {
+
+		protected int num;
+
+		protected Base() {
+		}
+
+		public Base(int num, String str) {
+			this.num = num;
+		}
+
+		public int getNum() {
+			return num;
+		}
+
+		public void setNum(int num) {
+			this.num = num;
+		}
+	}
+
+	@Embeddable
+	@DiscriminatorValue("n")
+	public static class Next extends Base {
+
+		private String str;
+
+		public Next(int num, String str) {
+			super( num, str );
+			this.str = str;
+		}
+
+		public Next() {
+		}
+	}
+
+	@Entity(name = "Ent")
+	public static class Ent {
+
+		@Id
+		@GeneratedValue
+		private Integer id;
+
+		@Embedded
+		private Base base;
+
+		public Ent() {
+		}
+
+		public Ent(final Integer id) {
+			this.id = id;
+		}
+
+		public Integer getId() {
+			return id;
+		}
+
+		public void setId(Integer id) {
+			this.id = id;
+		}
+
+		public Base getBase() {
+			return base;
+		}
+
+		public void setBase(Base base) {
+			this.base = base;
+		}
+	}
+}


### PR DESCRIPTION
Jira issue [HHH-19079](https://hibernate.atlassian.net/browse/HHH-19079)

When method `org.hibernate.type.ComponentType#getPropertyValues(java.lang.Object)` is invoked with `null` parameter, number of discriminator columns should be added to number of properties


<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------


[HHH-19079]: https://hibernate.atlassian.net/browse/HHH-19079?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ