### PR TITLE
HHH-19072 The hibernate.session_factory_name configuration property no longer works in Hibernate 7.0.0

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/internal/SessionFactorySettings.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/SessionFactorySettings.java
@@ -19,6 +19,7 @@ import java.util.Map;
 
 import static org.hibernate.cfg.PersistenceSettings.PERSISTENCE_UNIT_NAME;
 import static org.hibernate.cfg.PersistenceSettings.SESSION_FACTORY_JNDI_NAME;
+import static org.hibernate.cfg.PersistenceSettings.SESSION_FACTORY_NAME;
 import static org.hibernate.cfg.ValidationSettings.JAKARTA_VALIDATION_FACTORY;
 import static org.hibernate.cfg.ValidationSettings.JPA_VALIDATION_FACTORY;
 import static org.hibernate.engine.config.spi.StandardConverters.STRING;
@@ -95,6 +96,10 @@ class SessionFactorySettings {
 			return explicitJndiName;
 		}
 		else {
+			final String expliciSessionFactoryname = configService.getSetting( SESSION_FACTORY_NAME, STRING );
+			if ( isNotEmpty( expliciSessionFactoryname ) ) {
+				return expliciSessionFactoryname;
+			}
 			final String unitName = configService.getSetting( PERSISTENCE_UNIT_NAME, STRING );
 			// do not use name for JNDI if explicitly asked not to or if name comes from JPA persistence-unit name
 			final boolean nameIsNotJndiName =

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/internal/SessionFactoryNameSettingTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/internal/SessionFactoryNameSettingTest.java
@@ -1,0 +1,37 @@
+/*
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.internal;
+
+import org.assertj.core.api.Assertions;
+import org.hibernate.SessionFactory;
+import org.hibernate.cfg.AvailableSettings;
+import org.hibernate.testing.orm.junit.EntityManagerFactoryScope;
+import org.hibernate.testing.orm.junit.JiraKey;
+import org.hibernate.testing.orm.junit.Jpa;
+import org.hibernate.testing.orm.junit.Setting;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
+import static org.hibernate.orm.test.internal.SessionFactoryNameSettingTest.SESSION_FACTORY_NAME;
+
+@Jpa(
+		integrationSettings = @Setting(name = AvailableSettings.SESSION_FACTORY_NAME, value = SESSION_FACTORY_NAME)
+)
+@JiraKey("HHH-19072")
+public class SessionFactoryNameSettingTest {
+	public static final String SESSION_FACTORY_NAME = "TEST_SESSION_FACTORY";
+
+	@Test
+	public void testSessionFactoryNameSettingInfluencingSessionFactoryName(EntityManagerFactoryScope scope) {
+		assertThat( scope.getEntityManagerFactory().unwrap( SessionFactory.class ).getName() )
+				.isEqualTo( SESSION_FACTORY_NAME );
+	}
+
+	@Test
+	public void testSessionFactoryNameSettingInfluencingSessionFactoryJndiName(EntityManagerFactoryScope scope) {
+		Assertions.assertThat( scope.getEntityManagerFactory().unwrap( SessionFactory.class ).getJndiName() )
+				.isEqualTo( SESSION_FACTORY_NAME );
+	}
+}


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-19072

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
