### PR TITLE
HHH-19085 NPE when using null value in CriteriaUpdate

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/internal/SqmCriteriaNodeBuilder.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/internal/SqmCriteriaNodeBuilder.java
@@ -2063,6 +2063,10 @@ public class SqmCriteriaNodeBuilder implements NodeBuilder, Serializable {
 	 * Creates an expression for the value with the given "type inference" information
 	 */
 	public <T> SqmExpression<T> value(T value, SqmExpression<? extends T> typeInferenceSource) {
+		if (value == null) {
+			return (SqmExpression<T>)nullLiteral( typeInferenceSource.getNodeType().getExpressibleJavaType().getJavaTypeClass() );
+		}
+
 		if ( value instanceof SqmExpression<?> ) {
 			//noinspection unchecked
 			return (SqmExpression<T>) value;


### PR DESCRIPTION
<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

Fix for [HHH-19085](https://hibernate.atlassian.net/browse/HHH-19085)

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------


[HHH-19085]: https://hibernate.atlassian.net/browse/HHH-19085?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ