### PR TITLE
HHH-18069 NullPointerException when unioning partition results (backport to 6.6)

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/sql/BaseSqmToSqlAstConverter.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/sql/BaseSqmToSqlAstConverter.java
@@ -1990,9 +1990,13 @@ public abstract class BaseSqmToSqlAstConverter<T extends Statement> extends Base
 		sqmQueryPartStack.push( queryGroup );
 		pushProcessingState( processingState );
 
+		FromClauseIndex firstQueryPartIndex = null;
+		SqlAstProcessingState firstPoppedProcessingState = null;
 		try {
 			newQueryParts.add( visitQueryPart( queryParts.get( 0 ) ) );
 
+			firstQueryPartIndex = lastPoppedFromClauseIndex;
+			firstPoppedProcessingState = lastPoppedProcessingState;
 			collector.setSqmAliasedNodeCollector(
 					(SqmAliasedNodeCollector) lastPoppedProcessingState.getSqlExpressionResolver()
 			);
@@ -2010,6 +2014,8 @@ public abstract class BaseSqmToSqlAstConverter<T extends Statement> extends Base
 		finally {
 			popProcessingStateStack();
 			sqmQueryPartStack.pop();
+			lastPoppedFromClauseIndex = firstQueryPartIndex;
+			lastPoppedProcessingState = firstPoppedProcessingState;
 		}
 	}
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/query/hql/set/UnionOfPartitionResultsTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/query/hql/set/UnionOfPartitionResultsTest.java
@@ -1,0 +1,139 @@
+/*
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.query.hql.set;
+
+import java.time.LocalDate;
+
+import org.hibernate.query.Query;
+
+import org.hibernate.testing.orm.junit.DialectFeatureChecks;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.FailureExpected;
+import org.hibernate.testing.orm.junit.RequiresDialectFeature;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.junit.jupiter.api.Test;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
+
+/**
+ * @author Jan Schatteman
+ */
+@DomainModel (
+		annotatedClasses = { UnionOfPartitionResultsTest.Apple.class, UnionOfPartitionResultsTest.Pie.class }
+)
+@SessionFactory
+public class UnionOfPartitionResultsTest {
+
+	@Test
+	@FailureExpected
+	@RequiresDialectFeature(feature = DialectFeatureChecks.SupportsUnion.class)
+	public void testUnionOfPartitionResults(SessionFactoryScope scope) {
+		scope.inTransaction(
+				session -> {
+					String q =
+							"SELECT new CurrentApple(id, bakedPie.id, dir) " +
+							"FROM (" +
+								"(" +
+									"SELECT id id, bakedPie bakedPie, bakedOn bakedOn, MAX(bakedOn) OVER (PARTITION BY bakedPie.id) mbo, -1 dir " +
+									"FROM Apple c " +
+									"WHERE bakedPie.id IN (1,2,3,4) AND bakedOn <= :now" +
+								") UNION ALL (" +
+									"SELECT id id, bakedPie bakedPie, bakedOn bakedOn, MIN(bakedOn) OVER (PARTITION BY bakedPie.id) mbo, 1 dir " +
+									"FROM Apple c " +
+									"WHERE bakedPie.id IN (1,2,3,4) AND bakedOn > :now" +
+								")" +
+							") " +
+							"WHERE bakedOn = mbo ORDER BY dir";
+
+					Query<CurrentApple> query = session.createQuery( q, CurrentApple.class );
+					query.setParameter( "now", LocalDate.now());
+
+					query.getSingleResult();
+				}
+		);
+	}
+
+	public static class CurrentApple {
+		private final int id;
+		private final int pieId;
+		private final int dir;
+
+		public CurrentApple(int id, int pieId, int dir) {
+			this.id = id;
+			this.pieId = pieId;
+			this.dir = dir;
+		}
+		public int getDir() {
+			return dir;
+		}
+		public int getId() {
+			return id;
+		}
+		public int getPieId() {
+			return pieId;
+		}
+	}
+
+	@Entity(name = "Apple")
+	public static class Apple {
+		@Id
+		@GeneratedValue(strategy = GenerationType.IDENTITY)
+		private Integer id;
+		private LocalDate bakedOn;
+		@ManyToOne
+		private Pie bakedPie;
+
+		public Integer getId() {
+			return id;
+		}
+		public Apple setId(Integer id) {
+			this.id = id;
+			return this;
+		}
+		public LocalDate getBakedOn() {
+			return bakedOn;
+		}
+		public Apple setBakedOn(LocalDate bakedOn) {
+			this.bakedOn = bakedOn;
+			return this;
+		}
+		public Pie getBakedPie() {
+			return bakedPie;
+		}
+		public Apple setBakedPie(Pie bakedPie) {
+			this.bakedPie = bakedPie;
+			return this;
+		}
+	}
+
+	@Entity(name = "Pie")
+	public static class Pie {
+		@Id
+		@GeneratedValue(strategy = GenerationType.IDENTITY)
+		private Integer id;
+		private String taste;
+
+		public Integer getId() {
+			return id;
+		}
+		public Pie setId(Integer id) {
+			this.id = id;
+			return this;
+		}
+		public String getTaste() {
+			return taste;
+		}
+		public Pie setTaste(String taste) {
+			this.taste = taste;
+			return this;
+		}
+	}
+
+}


### PR DESCRIPTION
Backporting patch for Jira issue [HHH-18069](https://hibernate.atlassian.net/browse/HHH-18069) to `6.6`

This patch is also fixing Jira issue [HHH-18985](https://hibernate.atlassian.net/browse/HHH-18985)

[Please describe here what your change is about]

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------


[HHH-18069]: https://hibernate.atlassian.net/browse/HHH-18069?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[HHH-18985]: https://hibernate.atlassian.net/browse/HHH-18985?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ