### PR TITLE
HHH-19096 Adjust `SelectionQuery#setEntityGraph(..)` to accept entity graphs of supertypes

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/query/Query.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/Query.java
@@ -915,7 +915,7 @@ public interface Query<R> extends SelectionQuery<R>, MutationQuery, TypedQuery<R
 	Query<R> setHint(String hintName, Object value);
 
 	@Override
-	Query<R> setEntityGraph(EntityGraph<R> graph, GraphSemantic semantic);
+	Query<R> setEntityGraph(EntityGraph<? super R> graph, GraphSemantic semantic);
 
 	@Override
 	Query<R> enableFetchProfile(String profileName);

--- a/hibernate-core/src/main/java/org/hibernate/query/SelectionQuery.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/SelectionQuery.java
@@ -293,7 +293,7 @@ public interface SelectionQuery<R> extends CommonQueryContract {
 	 *
 	 * @since 6.3
 	 */
-	SelectionQuery<R> setEntityGraph(EntityGraph<R> graph, GraphSemantic semantic);
+	SelectionQuery<R> setEntityGraph(EntityGraph<? super R> graph, GraphSemantic semantic);
 
 	/**
 	 * Enable the {@linkplain org.hibernate.annotations.FetchProfile fetch

--- a/hibernate-core/src/main/java/org/hibernate/query/spi/AbstractQuery.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/spi/AbstractQuery.java
@@ -128,7 +128,7 @@ public abstract class AbstractQuery<R>
 	}
 
 	@Override
-	public QueryImplementor<R> setEntityGraph(EntityGraph<R> graph, GraphSemantic semantic) {
+	public QueryImplementor<R> setEntityGraph(EntityGraph<? super R> graph, GraphSemantic semantic) {
 		super.setEntityGraph( graph, semantic );
 		return this;
 	}

--- a/hibernate-core/src/main/java/org/hibernate/query/spi/AbstractSelectionQuery.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/spi/AbstractSelectionQuery.java
@@ -372,8 +372,8 @@ public abstract class AbstractSelectionQuery<R>
 	}
 
 	@Override
-	public SelectionQuery<R> setEntityGraph(EntityGraph<R> graph, GraphSemantic semantic) {
-		applyGraph( (RootGraphImplementor<R>) graph, semantic );
+	public SelectionQuery<R> setEntityGraph(EntityGraph<? super R> graph, GraphSemantic semantic) {
+		applyGraph( (RootGraphImplementor<? super R>) graph, semantic );
 		return this;
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/internal/QuerySqmImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/internal/QuerySqmImpl.java
@@ -810,7 +810,7 @@ public class QuerySqmImpl<R>
 	}
 
 	@Override
-	public Query<R> setEntityGraph(EntityGraph<R> graph, GraphSemantic semantic) {
+	public Query<R> setEntityGraph(EntityGraph<? super R> graph, GraphSemantic semantic) {
 		super.setEntityGraph( graph, semantic );
 		return this;
 	}

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/spi/DelegatingSqmSelectionQueryImplementor.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/spi/DelegatingSqmSelectionQueryImplementor.java
@@ -157,7 +157,7 @@ public abstract class DelegatingSqmSelectionQueryImplementor<R> implements SqmSe
 	}
 
 	@Override
-	public SqmSelectionQueryImplementor<R> setEntityGraph(EntityGraph<R> graph, GraphSemantic semantic) {
+	public SqmSelectionQueryImplementor<R> setEntityGraph(EntityGraph<? super R> graph, GraphSemantic semantic) {
 		getDelegate().setEntityGraph( graph, semantic );
 		return this;
 	}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/fetchprofile/NewGraphTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/fetchprofile/NewGraphTest.java
@@ -9,11 +9,14 @@ import org.hibernate.annotations.NaturalId;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.graph.GraphSemantic;
 import org.hibernate.graph.RootGraph;
+import org.hibernate.query.SelectionQuery;
 import org.hibernate.testing.orm.junit.DomainModel;
 import org.hibernate.testing.orm.junit.SessionFactory;
 import org.hibernate.testing.orm.junit.SessionFactoryScope;
 import org.junit.jupiter.api.Test;
 
+import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
 import static jakarta.persistence.FetchType.LAZY;
@@ -22,7 +25,8 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @SessionFactory
-@DomainModel(annotatedClasses = {NewGraphTest.class, NewGraphTest.E.class, NewGraphTest.F.class, NewGraphTest.G.class, NewGraphTest.H.class})
+@DomainModel(annotatedClasses = {NewGraphTest.class, NewGraphTest.E.class, NewGraphTest.F.class, NewGraphTest.G.class, NewGraphTest.H.class,
+				NewGraphTest.A.class, NewGraphTest.Aa.class, NewGraphTest.B.class})
 public class NewGraphTest {
 
 	@Test void testByIdEntityGraph(SessionFactoryScope scope) {
@@ -276,6 +280,66 @@ public class NewGraphTest {
 		assertTrue( isInitialized( ee.f ) );
 	}
 
+	@Test
+	void subTypeEntityGraph(SessionFactoryScope scope) {
+		scope.inTransaction( s -> {
+			A a = new A();
+			Aa aa = new Aa();
+			B b1 = new B();
+			B b2 = new B();
+			B b3 = new B();
+			b1.a = a;
+			a.bs = new HashSet<>();
+			a.bs.add( b1 );
+
+			b2.a = aa;
+			aa.bs = new HashSet<>();
+			aa.bs.add( b2 );
+
+			b3.a = aa;
+			aa.bss = new HashSet<>();
+			aa.bss.add( b3 );
+
+			s.persist( a );
+			s.persist( aa );
+			s.persist( b1 );
+			s.persist( b2 );
+			s.persist( b3 );
+		} );
+
+		A a = scope.fromSession( s ->
+				s.createSelectionQuery( "from A", A.class )
+						.setMaxResults( 1 )
+						.getSingleResult() );
+		assertFalse( isInitialized( a.bs ) );
+
+		List<Aa> as = scope.fromSession( s -> {
+			SelectionQuery<Aa> query = s.createSelectionQuery( "from Aa", Aa.class );
+			RootGraph<A> graph = s.createEntityGraph(A.class);
+			graph.addAttributeNodes("bs");
+			return query
+					.setEntityGraph( graph, GraphSemantic.FETCH )
+					.getResultList();
+		} );
+		for ( Aa el : as ) {
+			assertTrue( isInitialized( el.bs ) );
+			assertFalse( isInitialized( el.bss ) );
+		}
+
+		as = scope.fromSession( s -> {
+			SelectionQuery<Aa> query = s.createSelectionQuery( "from Aa", Aa.class );
+			RootGraph<Aa> graph = s.createEntityGraph(Aa.class);
+			graph.addAttributeNodes("bs", "bss");
+			return query
+					.setEntityGraph( graph, GraphSemantic.FETCH )
+					.getResultList();
+		} );
+		for ( Aa el : as ) {
+			assertTrue( isInitialized( el.bs ) );
+			assertTrue( isInitialized( el.bss ) );
+		}
+	}
+
 	@Entity(name = "E")
 	static class E {
 		@Id @GeneratedValue
@@ -306,5 +370,35 @@ public class NewGraphTest {
 		@Id @GeneratedValue
 		Long id;
 		@ManyToOne G g;
+	}
+
+	@Entity(name = "A")
+	static class A {
+		@Id @GeneratedValue
+		Long id;
+
+		@OneToMany(mappedBy = "a")
+		Set<B> bs;
+	}
+
+	@Entity(name = "Aa")
+	static class Aa extends A {
+		@Id @GeneratedValue
+		Long id;
+
+		@OneToMany(mappedBy = "aa")
+		Set<B> bss;
+	}
+
+	@Entity(name = "B")
+	static class B {
+		@Id @GeneratedValue
+		Long id;
+
+		@ManyToOne(fetch = LAZY)
+		A a;
+
+		@ManyToOne(fetch = LAZY)
+		Aa aa;
 	}
 }


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-19096

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
