### PR TITLE
HHH-18928 Consider the default Access Type as per Spec section 2.3.1 and skip enhancement of properties accessor

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/bytecode/internal/bytebuddy/BytecodeProviderImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/bytecode/internal/bytebuddy/BytecodeProviderImpl.java
@@ -1199,8 +1199,8 @@ public class BytecodeProviderImpl implements BytecodeProvider {
 			if ( getter instanceof GetterMethodImpl ) {
 				getterMember = getter.getMethod();
 			}
-			else if ( getter instanceof GetterFieldImpl ) {
-				getterMember = getter.getMember();
+			else if ( getter instanceof GetterFieldImpl getterField ) {
+				getterMember = getterField.getField();
 			}
 			else {
 				throw new InvalidPropertyAccessorException(

--- a/hibernate-core/src/main/java/org/hibernate/property/access/internal/PropertyAccessEnhancedImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/property/access/internal/PropertyAccessEnhancedImpl.java
@@ -4,6 +4,9 @@
  */
 package org.hibernate.property.access.internal;
 
+import jakarta.persistence.AccessType;
+import org.checkerframework.checker.nullness.qual.Nullable;
+import org.hibernate.property.access.spi.EnhancedGetterFieldImpl;
 import org.hibernate.property.access.spi.EnhancedSetterImpl;
 import org.hibernate.property.access.spi.EnhancedSetterMethodImpl;
 import org.hibernate.property.access.spi.Getter;
@@ -17,9 +20,7 @@ import org.hibernate.property.access.spi.Setter;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 
-import jakarta.persistence.AccessType;
-import org.checkerframework.checker.nullness.qual.Nullable;
-
+import static org.hibernate.internal.util.ReflectHelper.findField;
 import static org.hibernate.internal.util.ReflectHelper.findSetterMethod;
 import static org.hibernate.internal.util.ReflectHelper.getterMethodOrNull;
 import static org.hibernate.property.access.internal.AccessStrategyHelper.fieldOrNull;
@@ -41,10 +42,12 @@ public class PropertyAccessEnhancedImpl implements PropertyAccess {
 			PropertyAccessStrategy strategy,
 			Class<?> containerJavaType,
 			String propertyName,
-			@Nullable AccessType getterAccessType) {
+			@Nullable AccessType classAccessType) {
 		this.strategy = strategy;
 
-		final AccessType propertyAccessType = resolveAccessType( getterAccessType, containerJavaType, propertyName );
+		final AccessType propertyAccessType = classAccessType == null ?
+				AccessStrategyHelper.getAccessType( containerJavaType, propertyName ) :
+				classAccessType;
 
 		switch ( propertyAccessType ) {
 			case FIELD: {
@@ -65,10 +68,8 @@ public class PropertyAccessEnhancedImpl implements PropertyAccess {
 							"Could not locate getter for property named [" + containerJavaType.getName() + "#" + propertyName + "]"
 					);
 				}
-				final Method setterMethod = findSetterMethod( containerJavaType, propertyName, getterMethod.getReturnType() );
-
-				this.getter = new GetterMethodImpl( containerJavaType, propertyName, getterMethod );
-				this.setter = new EnhancedSetterMethodImpl( containerJavaType, propertyName, setterMethod );
+				this.getter = propertyGetter( classAccessType, containerJavaType, propertyName, getterMethod );
+				this.setter = propertySetter( classAccessType, containerJavaType, propertyName, getterMethod.getReturnType() );
 				break;
 			}
 			default: {
@@ -79,12 +80,31 @@ public class PropertyAccessEnhancedImpl implements PropertyAccess {
 		}
 	}
 
-	private static AccessType resolveAccessType(@Nullable AccessType getterAccessType, Class<?> containerJavaType, String propertyName) {
-		if ( getterAccessType != null ) {
-			// this should indicate FIELD access
-			return getterAccessType;
+	private static Getter propertyGetter(@Nullable AccessType classAccessType, Class<?> containerJavaType, String propertyName, Method getterMethod) {
+		if ( classAccessType != null ) {
+			final AccessType explicitAccessType = AccessStrategyHelper.getAccessType( containerJavaType, propertyName );
+			if ( explicitAccessType == AccessType.FIELD ) {
+				// We need to default to FIELD unless we have an explicit AccessType to avoid unnecessary initializations
+				final Field field = findField( containerJavaType, propertyName );
+				return new EnhancedGetterFieldImpl( containerJavaType, propertyName, field, getterMethod );
+			}
 		}
-		return AccessStrategyHelper.getAccessType( containerJavaType, propertyName );
+		// when classAccessType is null know PROPERTY is the explicit access type
+		return new GetterMethodImpl( containerJavaType, propertyName, getterMethod );
+	}
+
+	private static Setter propertySetter(@Nullable AccessType classAccessType, Class<?> containerJavaType, String propertyName, Class<?> fieldType) {
+		if ( classAccessType != null ) {
+			final AccessType explicitAccessType = AccessStrategyHelper.getAccessType( containerJavaType, propertyName );
+			if ( explicitAccessType == AccessType.FIELD ) {
+				// We need to default to FIELD unless we have an explicit AccessType to avoid unnecessary initializations
+				final Field field = findField( containerJavaType, propertyName );
+				return new EnhancedSetterImpl( containerJavaType, propertyName, field );
+			}
+		}
+		// when classAccessType is null know PROPERTY is the explicit access type
+		final Method setterMethod = findSetterMethod( containerJavaType, propertyName, fieldType );
+		return new EnhancedSetterMethodImpl( containerJavaType, propertyName, setterMethod );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/property/access/internal/PropertyAccessStrategyEnhancedImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/property/access/internal/PropertyAccessStrategyEnhancedImpl.java
@@ -29,18 +29,18 @@ public class PropertyAccessStrategyEnhancedImpl implements PropertyAccessStrateg
 		};
 	}
 
-	private final @Nullable AccessType getterAccessType;
+	private final @Nullable AccessType classAccessType;
 
 	public static PropertyAccessStrategyEnhancedImpl STANDARD = new PropertyAccessStrategyEnhancedImpl( null );
 	public static PropertyAccessStrategyEnhancedImpl FIELD = new PropertyAccessStrategyEnhancedImpl( AccessType.FIELD );
 	public static PropertyAccessStrategyEnhancedImpl PROPERTY = new PropertyAccessStrategyEnhancedImpl( AccessType.PROPERTY );
 
-	public PropertyAccessStrategyEnhancedImpl(@Nullable AccessType getterAccessType) {
-		this.getterAccessType = getterAccessType;
+	public PropertyAccessStrategyEnhancedImpl(@Nullable AccessType classAccessType) {
+		this.classAccessType = classAccessType;
 	}
 
 	@Override
 	public PropertyAccess buildPropertyAccess(Class<?> containerJavaType, final String propertyName, boolean setterRequired) {
-		return new PropertyAccessEnhancedImpl( this, containerJavaType, propertyName, getterAccessType );
+		return new PropertyAccessEnhancedImpl( this, containerJavaType, propertyName, classAccessType );
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/property/access/internal/PropertyAccessStrategyEnhancedImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/property/access/internal/PropertyAccessStrategyEnhancedImpl.java
@@ -19,16 +19,21 @@ import org.checkerframework.checker.nullness.qual.Nullable;
  */
 public class PropertyAccessStrategyEnhancedImpl implements PropertyAccessStrategy {
 	public static PropertyAccessStrategyEnhancedImpl with(AccessType getterAccessType) {
-		if ( getterAccessType == AccessType.FIELD ) {
-			return FIELD;
+		if ( getterAccessType == null ) {
+			return STANDARD;
 		}
-		return STANDARD;
+
+		return switch ( getterAccessType ) {
+			case FIELD -> FIELD;
+			case PROPERTY -> PROPERTY;
+		};
 	}
 
 	private final @Nullable AccessType getterAccessType;
 
 	public static PropertyAccessStrategyEnhancedImpl STANDARD = new PropertyAccessStrategyEnhancedImpl( null );
 	public static PropertyAccessStrategyEnhancedImpl FIELD = new PropertyAccessStrategyEnhancedImpl( AccessType.FIELD );
+	public static PropertyAccessStrategyEnhancedImpl PROPERTY = new PropertyAccessStrategyEnhancedImpl( AccessType.PROPERTY );
 
 	public PropertyAccessStrategyEnhancedImpl(@Nullable AccessType getterAccessType) {
 		this.getterAccessType = getterAccessType;

--- a/hibernate-core/src/main/java/org/hibernate/property/access/internal/PropertyAccessStrategyResolverStandardImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/property/access/internal/PropertyAccessStrategyResolverStandardImpl.java
@@ -6,6 +6,7 @@ package org.hibernate.property.access.internal;
 
 import org.hibernate.HibernateException;
 import org.hibernate.boot.registry.selector.spi.StrategySelector;
+import org.hibernate.boot.spi.AccessType;
 import org.hibernate.internal.util.StringHelper;
 import org.hibernate.metamodel.RepresentationMode;
 import org.hibernate.property.access.spi.BuiltInPropertyAccessStrategies;
@@ -38,8 +39,11 @@ public class PropertyAccessStrategyResolverStandardImpl implements PropertyAcces
 				|| BuiltInPropertyAccessStrategies.MIXED.getExternalName().equals( explicitAccessStrategyName ) ) {
 			//type-cache-pollution agent: it's crucial to use the ManagedTypeHelper rather than attempting a direct cast
 			if ( isManagedType( containerClass ) ) {
-				if ( BuiltInPropertyAccessStrategies.FIELD.getExternalName().equals( explicitAccessStrategyName ) ) {
+				if ( AccessType.FIELD.getType().equals( explicitAccessStrategyName ) ) {
 					return PropertyAccessStrategyEnhancedImpl.FIELD;
+				}
+				else if ( AccessType.PROPERTY.getType().equals( explicitAccessStrategyName ) ) {
+					return PropertyAccessStrategyEnhancedImpl.PROPERTY;
 				}
 				return PropertyAccessStrategyEnhancedImpl.STANDARD;
 			}

--- a/hibernate-core/src/main/java/org/hibernate/property/access/spi/EnhancedGetterFieldImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/property/access/spi/EnhancedGetterFieldImpl.java
@@ -1,0 +1,41 @@
+/*
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.property.access.spi;
+
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.hibernate.Internal;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Member;
+import java.lang.reflect.Method;
+
+import static org.hibernate.internal.util.NullnessUtil.castNonNull;
+
+/**
+ * A specialized Getter implementation for handling getting values from
+ * a bytecode-enhanced Class. The reason we need specialized handling
+ * is to produce the correct {@link java.lang.reflect.Member} while
+ * using the {@link Field} to access values and ensure correct functionality.
+ *
+ * @author Steve Ebersole
+ * @author Luis Barreiro
+ */
+@Internal
+public class EnhancedGetterFieldImpl extends GetterFieldImpl {
+	public EnhancedGetterFieldImpl(Class<?> containerClass, String propertyName, Field field, Method getterMethod) {
+		super( containerClass, propertyName, field, getterMethod );
+		assert getterMethod != null;
+	}
+
+	@Override
+	public @NonNull Method getMethod() {
+		return castNonNull( super.getMethod() );
+	}
+
+	@Override
+	public Member getMember() {
+		return getMethod();
+	}
+}

--- a/hibernate-core/src/main/java/org/hibernate/property/access/spi/GetterFieldImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/property/access/spi/GetterFieldImpl.java
@@ -33,11 +33,14 @@ public class GetterFieldImpl implements Getter {
 	private final @Nullable Method getterMethod;
 
 	public GetterFieldImpl(Class<?> containerClass, String propertyName, Field field) {
+		this ( containerClass, propertyName, field, ReflectHelper.findGetterMethodForFieldAccess( field, propertyName ) );
+	}
+
+	GetterFieldImpl(Class<?> containerClass, String propertyName, Field field, Method getterMethod) {
 		this.containerClass = containerClass;
 		this.propertyName = propertyName;
 		this.field = field;
-
-		this.getterMethod = ReflectHelper.findGetterMethodForFieldAccess( field, propertyName );
+		this.getterMethod = getterMethod;
 	}
 
 	@Override
@@ -76,9 +79,13 @@ public class GetterFieldImpl implements Getter {
 		return field.getGenericType();
 	}
 
+	public Field getField() {
+		return field;
+	}
+
 	@Override
 	public Member getMember() {
-		return field;
+		return getField();
 	}
 
 	@Override

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/access/PropertyAccessMemberTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/access/PropertyAccessMemberTest.java
@@ -1,0 +1,99 @@
+/*
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.bytecode.enhancement.access;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.metamodel.Attribute;
+import jakarta.persistence.metamodel.ManagedType;
+import jakarta.persistence.metamodel.Metamodel;
+import org.hibernate.testing.bytecode.enhancement.extension.BytecodeEnhanced;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Member;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * @author Scott Marlow
+ */
+@SessionFactory
+@DomainModel(annotatedClasses = {
+		PropertyAccessMemberTest.PropertyEntity.class,
+		PropertyAccessMemberTest.FieldEntity.class
+})
+@BytecodeEnhanced
+public class PropertyAccessMemberTest {
+	@Test
+	public void testPropertyAccessMember(SessionFactoryScope scope) {
+		scope.inTransaction( entityManager -> {
+			final Metamodel metaModel = entityManager.getMetamodel();
+			final ManagedType<PropertyEntity> managedType = metaModel.managedType( PropertyEntity.class );
+			final Attribute<PropertyEntity, ?> attribute = managedType.getDeclaredAttribute( "total" );
+			final Member member = attribute.getJavaMember();
+			assertEquals( "getTotal", member.getName() );
+		} );
+	}
+
+	@Test
+	public void testFieldAccessMember(SessionFactoryScope scope) {
+		scope.inTransaction( entityManager -> {
+			final Metamodel metaModel = entityManager.getMetamodel();
+			final ManagedType<FieldEntity> managedType = metaModel.managedType( FieldEntity.class );
+			final Attribute<FieldEntity, ?> attribute = managedType.getDeclaredAttribute( "total" );
+			final Member member = attribute.getJavaMember();
+			assertEquals( "total", member.getName() );
+		} );
+	}
+
+	@Entity(name = "PropertyEntity")
+	static class PropertyEntity {
+		private int id;
+		private int total;
+
+		@Id
+		public int getId() {
+			return id;
+		}
+
+		public void setId(int id) {
+			this.id = id;
+		}
+
+		public int getTotal() {
+			return total;
+		}
+
+		public void setTotal(int total) {
+			this.total = total;
+		}
+	}
+
+	@Entity(name = "FieldEntity")
+	static class FieldEntity {
+		@Id
+		private int id;
+		private int total;
+
+		public int getId() {
+			return id;
+		}
+
+		public void setId(int id) {
+			this.id = id;
+		}
+
+		public int getTotal() {
+			return total;
+		}
+
+		public void setTotal(int total) {
+			this.total = total;
+		}
+	}
+}


### PR DESCRIPTION
<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

https://hibernate.atlassian.net/browse/HHH-18928

When defaulting to `PROPERTY` access at the class-level by deducing it from annotations, we still need to access properties via fields: if we try to use the instrumented getter/setter methods of bytecode-enhanced entities in Hibernate internal code, we would trigger unnecessary/unwanted lazy property initializations, resulting in test failures. Note that this was the case even before https://github.com/hibernate/hibernate-orm/commit/90227d94bdda269bda5d91409045485f125ab778. 

I've implemented a workaround for this in the last commit, where we still report the correct `Member` for class-level `PROPERTY` access while actually using the field under the hood.

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
