### PR TITLE
Add Hibernate project icon to IntelliJ

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -7,3 +7,4 @@
 !codeStyles/codeStyleConfig.xml
 !inspectionProfiles/
 !inspectionProfiles/Project_Default.xml
+!icon.svg

--- a/.idea/icon.svg
+++ b/.idea/icon.svg
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Generator: Adobe Illustrator 16.0.1, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" width="256px" height="256px" viewBox="0 0 256 256" enable-background="new 0 0 256 256" xml:space="preserve">
+<g>
+	<polygon fill="#59666C" points="103.4,85.268 54.151,170.661 54.151,170.661 4.94,85.269 54.17,0  "/>
+	<polygon fill="#BCAE79" points="152.66,0.003 54.198,0.003 103.43,85.272 201.916,85.269  "/>
+	<polygon fill="#59666C" points="152.633,170.703 201.88,85.309 201.88,85.309 251.092,170.703 201.861,255.971  "/>
+	<polygon fill="#BCAE79" points="103.374,255.968 201.835,255.968 152.604,170.697 54.117,170.703  "/>
+</g>
+</svg>


### PR DESCRIPTION
it seems nice to have the hibernate icon displayed in IntelliJ toolbar

[Please describe here what your change is about]

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
