### PR TITLE
HHH-19104 Envers - Reset ReflectionTools cache on disintegration

### DIFF
--- a/hibernate-envers/src/main/java/org/hibernate/envers/boot/internal/EnversIntegrator.java
+++ b/hibernate-envers/src/main/java/org/hibernate/envers/boot/internal/EnversIntegrator.java
@@ -18,6 +18,7 @@ import org.hibernate.envers.event.spi.EnversPostUpdateEventListenerImpl;
 import org.hibernate.envers.event.spi.EnversPreCollectionRemoveEventListenerImpl;
 import org.hibernate.envers.event.spi.EnversPreCollectionUpdateEventListenerImpl;
 import org.hibernate.envers.event.spi.EnversPreUpdateEventListenerImpl;
+import org.hibernate.envers.internal.tools.ReflectionTools;
 import org.hibernate.event.service.spi.EventListenerRegistry;
 import org.hibernate.event.spi.EventType;
 import org.hibernate.integrator.spi.Integrator;
@@ -117,6 +118,6 @@ public class EnversIntegrator implements Integrator {
 
 	@Override
 	public void disintegrate(SessionFactoryImplementor sessionFactory, SessionFactoryServiceRegistry serviceRegistry) {
-		// nothing to do
+		ReflectionTools.reset();
 	}
 }

--- a/hibernate-envers/src/main/java/org/hibernate/envers/internal/tools/ReflectionTools.java
+++ b/hibernate-envers/src/main/java/org/hibernate/envers/internal/tools/ReflectionTools.java
@@ -152,4 +152,9 @@ public abstract class ReflectionTools {
 			throw new ClassLoadingException( "Unable to load class [" + name + "]", e );
 		}
 	}
+
+	public static void reset() {
+		SETTER_CACHE.clear();
+		GETTER_CACHE.clear();
+	}
 }


### PR DESCRIPTION
Should hopefully fix https://hibernate.atlassian.net/browse/HHH-19104 by clearing the caches in `ReflectionTools` when disintegrating Envers.

Note that it has been a while since my last contribution here so let me know if things need to be adjusted.

I also would appreciate if we could backport to 6.6 (it applies cleanly).

Initially reported here: https://github.com/quarkusio/quarkus/issues/46102.

----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
