### PR TITLE
HHH-19104 backport to 6.6; Envers - Reset ReflectionTools cache on disintegration

### DIFF
--- a/hibernate-envers/src/main/java/org/hibernate/envers/boot/internal/EnversIntegrator.java
+++ b/hibernate-envers/src/main/java/org/hibernate/envers/boot/internal/EnversIntegrator.java
@@ -20,6 +20,7 @@ import org.hibernate.envers.event.spi.EnversPostUpdateEventListenerImpl;
 import org.hibernate.envers.event.spi.EnversPreCollectionRemoveEventListenerImpl;
 import org.hibernate.envers.event.spi.EnversPreCollectionUpdateEventListenerImpl;
 import org.hibernate.envers.event.spi.EnversPreUpdateEventListenerImpl;
+import org.hibernate.envers.internal.tools.ReflectionTools;
 import org.hibernate.event.service.spi.EventListenerRegistry;
 import org.hibernate.event.spi.EventType;
 import org.hibernate.integrator.spi.Integrator;
@@ -119,6 +120,6 @@ public class EnversIntegrator implements Integrator {
 
 	@Override
 	public void disintegrate(SessionFactoryImplementor sessionFactory, SessionFactoryServiceRegistry serviceRegistry) {
-		// nothing to do
+		ReflectionTools.reset();
 	}
 }

--- a/hibernate-envers/src/main/java/org/hibernate/envers/internal/tools/ReflectionTools.java
+++ b/hibernate-envers/src/main/java/org/hibernate/envers/internal/tools/ReflectionTools.java
@@ -186,4 +186,9 @@ public abstract class ReflectionTools {
 			throw new ClassLoadingException( "Unable to load class [" + name + "]", e );
 		}
 	}
+
+	public static void reset() {
+		SETTER_CACHE.clear();
+		GETTER_CACHE.clear();
+	}
 }


### PR DESCRIPTION
Backport of https://github.com/hibernate/hibernate-orm/pull/9699 to 6.6.

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-19104
<!-- Hibernate GitHub Bot issue links end -->