### PR TITLE
Add approval for TCK run

### DIFF
--- a/ci/jpa-3.2-tck.Jenkinsfile
+++ b/ci/jpa-3.2-tck.Jenkinsfile
@@ -20,9 +20,7 @@ else {
 }
 
 pipeline {
-    agent {
-        label 'LongDuration'
-    }
+    agent none
     tools {
         jdk 'OpenJDK 17 Latest'
     }
@@ -39,133 +37,145 @@ pipeline {
         choice(name: 'RDBMS', choices: ['postgresql','mysql','mssql','oracle','db2','sybase'], description: 'The JDK base image version to use for the TCK image.')
 	}
     stages {
-        stage('Build') {
+        stage('Checks') {
         	steps {
-				script {
-					docker.withRegistry('https://index.docker.io/v1/', 'hibernateci.hub.docker.com') {
-						docker.image('openjdk:17-jdk').pull()
-					}
-				}
-				dir('hibernate') {
-					checkout scm
-					withEnv([
-							"DISABLE_REMOTE_GRADLE_CACHE=true"
-					]) {
-                        sh './gradlew clean publishToMavenLocal -x test --no-scan --no-daemon --no-build-cache --stacktrace -PmavenMirror=nexus-load-balancer-c4cf05fd92f43ef8.elb.us-east-1.amazonaws.com'
-                        // For some reason, Gradle does not publish hibernate-platform and hibernate-testing
-                        // to the local maven repository with the previous command,
-                        // but requires an extra run instead
-                        sh './gradlew :hibernate-testing:publishToMavenLocal :hibernate-platform:publishToMavenLocal -x test --no-scan --no-daemon --no-build-cache --stacktrace -PmavenMirror=nexus-load-balancer-c4cf05fd92f43ef8.elb.us-east-1.amazonaws.com'
-					}
-					script {
-						env.HIBERNATE_VERSION = sh (
-							script: "grep hibernateVersion gradle/version.properties|cut -d'=' -f2",
-							returnStdout: true
-						).trim()
-						switch (params.RDBMS) {
-							case "mysql":
-								docker.withRegistry('https://index.docker.io/v1/', 'hibernateci.hub.docker.com') {
-									docker.image('mysql:8.2.0').pull()
-								}
-								sh "./docker_db.sh mysql"
-								break;
-							case "mssql":
-								docker.image('mcr.microsoft.com/mssql/server@sha256:5439be9edc3b514cf647bcd3651779fa13f487735a985f40cbdcfecc60fea273').pull()
-								sh "./docker_db.sh mssql"
-								break;
-							case "oracle":
-								docker.withRegistry('https://index.docker.io/v1/', 'hibernateci.hub.docker.com') {
-									docker.image('gvenzl/oracle-free:23').pull()
-								}
-								sh "./docker_db.sh oracle"
-								break;
-							case "postgresql":
-								docker.withRegistry('https://index.docker.io/v1/', 'hibernateci.hub.docker.com') {
-									docker.image('postgis/postgis:16-3.4').pull()
-								}
-								sh "./docker_db.sh postgresql"
-								break;
-							case "db2":
-								docker.image('icr.io/db2_community/db2:11.5.9.0').pull()
-								sh "./docker_db.sh db2"
-								break;
-							case "sybase":
-								docker.withRegistry('https://index.docker.io/v1/', 'hibernateci.hub.docker.com') {
-									docker.image('nguoianphu/docker-sybase').pull()
-								}
-								sh "./docker_db.sh sybase"
-								break;
-						}
-					}
-				}
-				dir('tck') {
-					checkout changelog: false, poll: false, scm: [$class: 'GitSCM', branches: [[name: '*/main']], extensions: [], userRemoteConfigs: [[url: 'https://github.com/hibernate/jakarta-tck-runner.git']]]
-					script {
-						withCredentials([file(credentialsId: 'sybase-jconnect-driver', variable: 'jconnect_driver')]) {
-							sh 'cp -f $jconnect_driver ./jpa-3.2/jconn42.jar'
-							if ( params.TCK_URL == null || params.TCK_URL.isEmpty() ) {
-								sh "cd jpa-3.2; docker build -f Dockerfile.${params.IMAGE_JDK} -t jakarta-tck-runner --build-arg TCK_VERSION=${params.TCK_VERSION} --build-arg TCK_SHA=${params.TCK_SHA} ."
-							}
-							else {
-								sh "cd jpa-3.2; docker build -f Dockerfile.${params.IMAGE_JDK} -t jakarta-tck-runner --build-arg TCK_VERSION=${params.TCK_VERSION} --build-arg TCK_SHA=${params.TCK_SHA} --build-arg 'TCK_URL=${params.TCK_URL}' ."
-							}
-						}
-					}
-				}
-			}
-		}
-		stage('Run TCK') {
-			steps {
-				script {
-					def containerName
-					if ( params.RDBMS == 'postgresql' ) {
-						containerName = 'postgres'
-					}
-					else {
-						containerName = params.RDBMS
-					}
-					def dockerRunOptions = "--network=tck-net -e DB_HOST=${containerName}"
-                    sh """ \
-                        while IFS= read -r container; do
-                            docker network disconnect tck-net \$container || true
-                        done <<< \$(docker network inspect tck-net --format '{{range \$k, \$v := .Containers}}{{print \$k}}{{end}}' 2>/dev/null || true)
-                        docker network rm -f tck-net
-                        docker network create tck-net
-                        docker network connect tck-net ${containerName}
-                    """
-					sh """ \
-						rm -Rf ./results
-						docker rm -f tck || true
-						docker run -v ~/.m2/repository:/home/jenkins/.m2/repository:z ${dockerRunOptions} -e MAVEN_OPTS=-Dmaven.repo.local=/home/jenkins/.m2/repository -e RDBMS=${params.RDBMS} -e HIBERNATE_VERSION=$HIBERNATE_VERSION --name tck jakarta-tck-runner || true
-						docker cp tck:/tck/persistence-tck/bin/target/failsafe-reports ./results
-						docker cp tck:/tck/persistence-tck/bin/target/test-reports ./results
-					"""
-				}
-				archiveArtifacts artifacts: 'results/**'
-				script {
-					failures = sh (
-						script: """ \
-							while read line; do
-							  if [[ "\$line" = *'-error" style="display:none;">' ]]; then
-								prefix1='<tr class="a" id="'
-								prefix2='<tr class="b" id="'
-								suffix='-error" style="display:none;">'
-								line=\${line#"\$prefix1"}
-								line=\${line#"\$prefix2"}
-								test=\${line%"\$suffix"}
-								echo "\$test"
-							  fi
-							done <results/test-reports/failsafe-report.html
-						""",
-						returnStdout: true
-					).trim()
-					if ( !failures.isEmpty() ) {
-						echo "Some TCK tests failed:"
-						echo failures
-						currentBuild.result = 'FAILURE'
-					}
-				}
-			}
+                requireApprovalForPullRequest 'hibernate'
+            }
+        }
+        stage('TCK') {
+            agent {
+                label 'LongDuration'
+            }
+            stages {
+                stage('Build') {
+                    steps {
+                        script {
+                            docker.withRegistry('https://index.docker.io/v1/', 'hibernateci.hub.docker.com') {
+                                docker.image('openjdk:17-jdk').pull()
+                            }
+                        }
+                        dir('hibernate') {
+                            checkout scm
+                            withEnv([
+                                    "DISABLE_REMOTE_GRADLE_CACHE=true"
+                            ]) {
+                                sh './gradlew clean publishToMavenLocal -x test --no-scan --no-daemon --no-build-cache --stacktrace -PmavenMirror=nexus-load-balancer-c4cf05fd92f43ef8.elb.us-east-1.amazonaws.com'
+                                // For some reason, Gradle does not publish hibernate-platform and hibernate-testing
+                                // to the local maven repository with the previous command,
+                                // but requires an extra run instead
+                                sh './gradlew :hibernate-testing:publishToMavenLocal :hibernate-platform:publishToMavenLocal -x test --no-scan --no-daemon --no-build-cache --stacktrace -PmavenMirror=nexus-load-balancer-c4cf05fd92f43ef8.elb.us-east-1.amazonaws.com'
+                            }
+                            script {
+                                env.HIBERNATE_VERSION = sh (
+                                    script: "grep hibernateVersion gradle/version.properties|cut -d'=' -f2",
+                                    returnStdout: true
+                                ).trim()
+                                switch (params.RDBMS) {
+                                    case "mysql":
+                                        docker.withRegistry('https://index.docker.io/v1/', 'hibernateci.hub.docker.com') {
+                                            docker.image('mysql:8.2.0').pull()
+                                        }
+                                        sh "./docker_db.sh mysql"
+                                        break;
+                                    case "mssql":
+                                        docker.image('mcr.microsoft.com/mssql/server@sha256:5439be9edc3b514cf647bcd3651779fa13f487735a985f40cbdcfecc60fea273').pull()
+                                        sh "./docker_db.sh mssql"
+                                        break;
+                                    case "oracle":
+                                        docker.withRegistry('https://index.docker.io/v1/', 'hibernateci.hub.docker.com') {
+                                            docker.image('gvenzl/oracle-free:23').pull()
+                                        }
+                                        sh "./docker_db.sh oracle"
+                                        break;
+                                    case "postgresql":
+                                        docker.withRegistry('https://index.docker.io/v1/', 'hibernateci.hub.docker.com') {
+                                            docker.image('postgis/postgis:16-3.4').pull()
+                                        }
+                                        sh "./docker_db.sh postgresql"
+                                        break;
+                                    case "db2":
+                                        docker.image('icr.io/db2_community/db2:11.5.9.0').pull()
+                                        sh "./docker_db.sh db2"
+                                        break;
+                                    case "sybase":
+                                        docker.withRegistry('https://index.docker.io/v1/', 'hibernateci.hub.docker.com') {
+                                            docker.image('nguoianphu/docker-sybase').pull()
+                                        }
+                                        sh "./docker_db.sh sybase"
+                                        break;
+                                }
+                            }
+                        }
+                        dir('tck') {
+                            checkout changelog: false, poll: false, scm: [$class: 'GitSCM', branches: [[name: '*/main']], extensions: [], userRemoteConfigs: [[url: 'https://github.com/hibernate/jakarta-tck-runner.git']]]
+                            script {
+                                withCredentials([file(credentialsId: 'sybase-jconnect-driver', variable: 'jconnect_driver')]) {
+                                    sh 'cp -f $jconnect_driver ./jpa-3.2/jconn42.jar'
+                                    if ( params.TCK_URL == null || params.TCK_URL.isEmpty() ) {
+                                        sh "cd jpa-3.2; docker build -f Dockerfile.${params.IMAGE_JDK} -t jakarta-tck-runner --build-arg TCK_VERSION=${params.TCK_VERSION} --build-arg TCK_SHA=${params.TCK_SHA} ."
+                                    }
+                                    else {
+                                        sh "cd jpa-3.2; docker build -f Dockerfile.${params.IMAGE_JDK} -t jakarta-tck-runner --build-arg TCK_VERSION=${params.TCK_VERSION} --build-arg TCK_SHA=${params.TCK_SHA} --build-arg 'TCK_URL=${params.TCK_URL}' ."
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+                stage('Run TCK') {
+                    steps {
+                        script {
+                            def containerName
+                            if ( params.RDBMS == 'postgresql' ) {
+                                containerName = 'postgres'
+                            }
+                            else {
+                                containerName = params.RDBMS
+                            }
+                            def dockerRunOptions = "--network=tck-net -e DB_HOST=${containerName}"
+                            sh """ \
+                                while IFS= read -r container; do
+                                    docker network disconnect tck-net \$container || true
+                                done <<< \$(docker network inspect tck-net --format '{{range \$k, \$v := .Containers}}{{print \$k}}{{end}}' 2>/dev/null || true)
+                                docker network rm -f tck-net
+                                docker network create tck-net
+                                docker network connect tck-net ${containerName}
+                            """
+                            sh """ \
+                                rm -Rf ./results
+                                docker rm -f tck || true
+                                docker run -v ~/.m2/repository:/home/jenkins/.m2/repository:z ${dockerRunOptions} -e MAVEN_OPTS=-Dmaven.repo.local=/home/jenkins/.m2/repository -e RDBMS=${params.RDBMS} -e HIBERNATE_VERSION=$HIBERNATE_VERSION --name tck jakarta-tck-runner || true
+                                docker cp tck:/tck/persistence-tck/bin/target/failsafe-reports ./results
+                                docker cp tck:/tck/persistence-tck/bin/target/test-reports ./results
+                            """
+                        }
+                        archiveArtifacts artifacts: 'results/**'
+                        script {
+                            failures = sh (
+                                script: """ \
+                                    while read line; do
+                                      if [[ "\$line" = *'-error" style="display:none;">' ]]; then
+                                        prefix1='<tr class="a" id="'
+                                        prefix2='<tr class="b" id="'
+                                        suffix='-error" style="display:none;">'
+                                        line=\${line#"\$prefix1"}
+                                        line=\${line#"\$prefix2"}
+                                        test=\${line%"\$suffix"}
+                                        echo "\$test"
+                                      fi
+                                    done <results/test-reports/failsafe-report.html
+                                """,
+                                returnStdout: true
+                            ).trim()
+                            if ( !failures.isEmpty() ) {
+                                echo "Some TCK tests failed:"
+                                echo failures
+                                currentBuild.result = 'FAILURE'
+                            }
+                        }
+                    }
+                }
+            }
         }
     }
     post {


### PR DESCRIPTION
And move Jenkins "input" steps outside of nodes/agents, so that we don't keep a node reserved while we're waiting for input. See best practice 6 in https://www.cloudbees.com/blog/top-10-best-practices-jenkins-pipeline-plugin

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
