### PR TITLE
[6.6 Backport] HHH-19106 deconstruct inherited annotations before printing them

### DIFF
--- a/tooling/metamodel-generator/src/jakartaData/java/org/hibernate/processor/test/data/eg/Bookshop.java
+++ b/tooling/metamodel-generator/src/jakartaData/java/org/hibernate/processor/test/data/eg/Bookshop.java
@@ -11,17 +11,19 @@ import jakarta.validation.constraints.NotNull;
 
 import java.util.List;
 
+import static jakarta.transaction.Transactional.TxType.REQUIRES_NEW;
+
 @Repository
 public interface Bookshop extends CrudRepository<Book,String> {
     @Find
-    @Transactional
+    @Transactional(REQUIRES_NEW)
     List<Book> byPublisher(String publisher_name);
 
     @Find
     List<Book> byTitle(@Nonnull String title);
 
     @Query("select isbn where title like ?1 order by isbn")
-	String[] ssns(@NotBlank String title);
+    String[] ssns(@NotBlank String title);
 
     @Query("select count(this) where title like ?1 order by isbn")
     long count1(@NotNull String title);
@@ -33,7 +35,7 @@ public interface Bookshop extends CrudRepository<Book,String> {
     int length(@Nonnull String title);
 
     @Query("select count(this)")
-	long countAll();
+    long countAll();
 
     @Query("where isbn in :isbns and type = Book")
     List<Book> books(List<String> isbns);


### PR DESCRIPTION
(cherry-picked from commit 225d9b3b0befdf348b6089e8eb9639df06c49711)

Basically a backport to 6.6 of HHH-19106

----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------