### PR TITLE
[6.6 Backport] HHH-19107 fix @EmbeddedId with CrudRepository

### DIFF
--- a/tooling/metamodel-generator/src/jakartaData/java/org/hibernate/processor/test/data/embeddedid/EmbeddedIdTest.java
+++ b/tooling/metamodel-generator/src/jakartaData/java/org/hibernate/processor/test/data/embeddedid/EmbeddedIdTest.java
@@ -1,0 +1,26 @@
+/*
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.processor.test.data.embeddedid;
+
+import org.hibernate.processor.test.util.CompilationTest;
+import org.hibernate.processor.test.util.WithClasses;
+import org.junit.Test;
+
+import static org.hibernate.processor.test.util.TestUtil.assertMetamodelClassGeneratedFor;
+import static org.hibernate.processor.test.util.TestUtil.getMetaModelSourceAsString;
+
+/**
+ * @author Gavin King
+ */
+public class EmbeddedIdTest extends CompilationTest {
+	@Test
+	@WithClasses({ Thing.class, ThingRepo.class })
+	public void test() {
+		System.out.println( getMetaModelSourceAsString( ThingRepo.class ) );
+		assertMetamodelClassGeneratedFor( Thing.class, true );
+		assertMetamodelClassGeneratedFor( Thing.class );
+		assertMetamodelClassGeneratedFor( ThingRepo.class );
+	}
+}

--- a/tooling/metamodel-generator/src/jakartaData/java/org/hibernate/processor/test/data/embeddedid/Thing.java
+++ b/tooling/metamodel-generator/src/jakartaData/java/org/hibernate/processor/test/data/embeddedid/Thing.java
@@ -1,0 +1,20 @@
+/*
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.processor.test.data.embeddedid;
+
+import jakarta.persistence.Embeddable;
+import jakarta.persistence.EmbeddedId;
+import jakarta.persistence.Entity;
+
+@Entity
+public class Thing {
+	@Embeddable
+	public static class Id {
+		long id;
+		String key;
+	}
+
+	@EmbeddedId Id id;
+}

--- a/tooling/metamodel-generator/src/jakartaData/java/org/hibernate/processor/test/data/embeddedid/ThingRepo.java
+++ b/tooling/metamodel-generator/src/jakartaData/java/org/hibernate/processor/test/data/embeddedid/ThingRepo.java
@@ -1,0 +1,15 @@
+/*
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.processor.test.data.embeddedid;
+
+import jakarta.data.repository.CrudRepository;
+import jakarta.data.repository.Find;
+import jakarta.data.repository.Repository;
+
+@Repository
+public interface ThingRepo extends CrudRepository<Thing, Thing.Id> {
+	@Find
+	Thing thing(Thing.Id id);
+}

--- a/tooling/metamodel-generator/src/main/java/org/hibernate/processor/annotation/AnnotationMetaEntity.java
+++ b/tooling/metamodel-generator/src/main/java/org/hibernate/processor/annotation/AnnotationMetaEntity.java
@@ -2136,7 +2136,7 @@ public class AnnotationMetaEntity extends AnnotationMeta {
 		final AccessType accessType = getAccessType(entityType);
 		final String nextToken = tokens.nextToken();
 		for ( Element member : context.getAllMembers(entityType) ) {
-			if ( isIdRef(nextToken) && hasAnnotation( member, ID) ) {
+			if ( isIdRef(nextToken) && hasAnnotation(member, ID, EMBEDDED_ID) ) {
 				return member;
 			}
 			final Element match =


### PR DESCRIPTION
(cherry picked from commit 05677ebbc39ed45c1c0a2562bd46812f0ded80ec)

Basically a backport to 6.6 of HHH-19107

----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
