### PR TITLE
HHH-18992 Revert a change

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/internal/NaturalIdMultiLoadAccessStandard.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/NaturalIdMultiLoadAccessStandard.java
@@ -34,7 +34,7 @@ public class NaturalIdMultiLoadAccessStandard<T> implements NaturalIdMultiLoadAc
 
 	private Integer batchSize;
 	private boolean returnOfDeletedEntitiesEnabled;
-	private boolean orderedReturnEnabled = false;
+	private boolean orderedReturnEnabled = true;
 
 	public NaturalIdMultiLoadAccessStandard(EntityPersister entityDescriptor, SessionImpl session) {
 		this.entityDescriptor = entityDescriptor;

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/loading/multiLoad/MultiLoadLockingTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/loading/multiLoad/MultiLoadLockingTest.java
@@ -22,17 +22,21 @@ import org.hibernate.annotations.CacheConcurrencyStrategy;
 import org.hibernate.annotations.NaturalId;
 import org.hibernate.cfg.AvailableSettings;
 import org.hibernate.dialect.Dialect;
+import org.hibernate.dialect.HSQLDialect;
 import org.hibernate.dialect.PostgreSQLDialect;
 import org.hibernate.dialect.PostgreSQLSqlAstTranslator;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.sql.ast.tree.Statement;
 import org.hibernate.testing.jdbc.SQLStatementInspector;
 import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.FailureExpected;
 import org.hibernate.testing.orm.junit.JiraKey;
 import org.hibernate.testing.orm.junit.ServiceRegistry;
 import org.hibernate.testing.orm.junit.SessionFactory;
 import org.hibernate.testing.orm.junit.SessionFactoryScope;
 import org.hibernate.testing.orm.junit.Setting;
+import org.hibernate.testing.orm.junit.SkipForDialect;
+import org.hibernate.testing.orm.junit.SkipForDialectGroup;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -57,6 +61,15 @@ import jakarta.persistence.Id;
 		}
 )
 @JiraKey(value = "HHH-18992")
+@FailureExpected(reason = "Ordered loading by multiple natural-id values is not yet supported", jiraKey = "HHH-19115")
+// TODO remove the SkipForDialectGroup when the @FailureExpected is removed
+@SkipForDialectGroup(
+		// The tests don't actually fail for the dialects below, skipping them so that the non-occurring expected failure doesn't fail the Test case
+		value = {
+				@SkipForDialect(dialectClass = PostgreSQLDialect.class, matchSubTypes = true),
+				@SkipForDialect(dialectClass = HSQLDialect.class),
+		}
+)
 public class MultiLoadLockingTest {
 
 	private SQLStatementInspector sqlStatementInspector;


### PR DESCRIPTION
- revert change made by commit 7292aacf5dfd2b43775fb1a9846a6ae4748732a4
- disable the MultiLoadLockTest for now (until https://hibernate.atlassian.net/browse/HHH-19115 is implemented)
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-18992
<!-- Hibernate GitHub Bot issue links end -->