### PR TITLE
Revert publish task dependency on release changes

### DIFF
--- a/gradle/published-java-module.gradle
+++ b/gradle/published-java-module.gradle
@@ -8,10 +8,8 @@
 apply from: rootProject.file( 'gradle/java-module.gradle' )
 apply from: rootProject.file( 'gradle/publishing.gradle' )
 
-tasks.register("publishReleaseArtifacts") {
-	// mirror for `:release:publishReleaseArtifacts`
-	dependsOn tasks.release
-}
+// Make sure that the publishReleaseArtifacts task of the release module runs the release task of this sub module
+tasks.getByPath( ':release:publishReleaseArtifacts' ).dependsOn tasks.release
 
 configurations {
 	javadocSources {

--- a/hibernate-platform/hibernate-platform.gradle
+++ b/hibernate-platform/hibernate-platform.gradle
@@ -70,8 +70,7 @@ publishingExtension.publications.named("publishedArtifacts", MavenPublication) {
     from components.javaPlatform
 }
 
-tasks.register("publishReleaseArtifacts") {
-    // mirror for `:release:publishReleaseArtifacts`
+project( ":release" ).getTasks().named( "publishReleaseArtifacts" ).configure {
     dependsOn tasks.release
 }
 

--- a/tooling/hibernate-gradle-plugin/hibernate-gradle-plugin.gradle
+++ b/tooling/hibernate-gradle-plugin/hibernate-gradle-plugin.gradle
@@ -84,10 +84,8 @@ tasks.release.dependsOn tasks.publishPlugins
 // local publishing (SNAPSHOT testing)
 tasks.publish.dependsOn tasks.publishPlugins
 
-tasks.register("publishReleaseArtifacts") {
-	// mirror for `:release:publishReleaseArtifacts`
-	dependsOn tasks.release
-}
+// Make sure that the publishReleaseArtifacts task of the release module runs the release task of this sub module
+tasks.getByPath( ':release:publishReleaseArtifacts' ).dependsOn tasks.release
 
 // local publishing (SNAPSHOT testing)
 publishing {


### PR DESCRIPTION
<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

Reverts changes from [this commit](https://github.com/hibernate/hibernate-orm/commit/57b9191c8c669fe278bb1ce69b338fccfe33d6cc) to the `release` task dependencies.

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
