### PR TITLE
HHH-19122 - Leverage org.gradlex.maven-plugin-development for hibernate-maven-plugin

### DIFF
--- a/tooling/hibernate-maven-plugin/hibernate-maven-plugin.gradle
+++ b/tooling/hibernate-maven-plugin/hibernate-maven-plugin.gradle
@@ -8,7 +8,7 @@
 plugins {
     id "local.java-module"
     id "local.publishing"
-    id "org.hibernate.build.maven-embedder"
+    id "org.gradlex.maven-plugin-development" version "1.0.3"
 }
 
 description = 'Maven plugin to integrate aspects of Hibernate into your build.'
@@ -17,9 +17,10 @@ dependencies {
     implementation project( ":hibernate-core" )
 
     implementation "org.apache.maven:maven-plugin-api:3.6.3"
-    implementation "org.apache.maven.plugin-tools:maven-plugin-annotations:3.6.0"
     implementation "org.apache.maven:maven-project:2.2.1"
     implementation "org.apache.maven.shared:file-management:3.1.0"
+
+    compileOnly "org.apache.maven.plugin-tools:maven-plugin-annotations:3.6.0"
 }
 
 def releasePrepareTask = tasks.register("releasePrepare") {
@@ -48,6 +49,9 @@ var publishingExtension = project.getExtensions().getByType(PublishingExtension)
 publishingExtension.publications.named("publishedArtifacts") {
     from components.java
 
+    // Adjust the pom for 3 things:
+    //      1. set packaging to maven-plugin (org.gradlex.maven-plugin-development does not in my testing)
+    //      2. scope of org.apache.maven dependencies
     pom.withXml {
         asNode()
                 .version
@@ -61,77 +65,10 @@ publishingExtension.publications.named("publishedArtifacts") {
                     dependency.groupId.text().startsWith('org.apache.maven')
                 }
                 .each { dependency ->
-                    if (dependency.groupId.text().startsWith('org.apache.maven.shared')) {
-                        dependency.scope*.value = 'compile'
-                    } else {
+                    if (!dependency.groupId.text().startsWith('org.apache.maven.shared')) {
                         dependency.scope*.value = 'provided'
                     }
                 }
-        asNode()
-                .dependencies
-                .dependency
-                .findAll { dependency ->
-                    dependency.groupId.text().startsWith('org.hibernate.orm')
-                }
-                .each { dependency ->
-                    dependency.scope*.value = 'compile'
-                }
-        asNode()
-                .dependencies
-                .plus {
-                    def plugins = build().appendNode('plugins')
-                    def pluginPlugin = plugins.appendNode('plugin')
-                    pluginPlugin.appendNode('groupId', 'org.apache.maven.plugins')
-                    pluginPlugin.appendNode('artifactId', 'maven-plugin-plugin')
-                    pluginPlugin.appendNode('version', '3.15.0')
-                    def pluginConfiguration = pluginPlugin.appendNode('configuration')
-                    pluginConfiguration.appendNode('goalPrefix', 'plugin')
-                    pluginConfiguration.appendNode('outputDirectory', layout.buildDirectory.dir('generated/sources/plugin-descriptors/META-INF/maven').get().getAsFile().getAbsolutePath() )
-                    def invokerPlugin = plugins.appendNode('plugin');
-                    invokerPlugin.appendNode('groupId', 'org.apache.maven.plugins')
-                    invokerPlugin.appendNode('artifactId', 'maven-invoker-plugin')
-                    invokerPlugin.appendNode('version', '3.8.0')
-                    def invokerConfiguration = invokerPlugin.appendNode('configuration');
-                    invokerConfiguration.appendNode('debug', 'true');
-                    invokerConfiguration.appendNode('mavenExecutable', 'mvnw');
-                    def scriptVariables = invokerConfiguration.appendNode('scriptVariables');
-                    scriptVariables.appendNode('hibernateCoreJarPath', layout.buildDirectory.file('maven-embedder/maven-local/org/hibernate/orm/hibernate-core/' + project.version + '/hibernate-core-' + project.version + '.jar').get().getAsFile().getAbsolutePath())
-                }
     }
 }
 
-// Following tasks need to be performed:
-// 1. Compile the Java classes
-// 2. Copy the source tree to the working directory
-// 3. Copy the compiled Java classes to the working directory
-// 4. Install the 'hibernate-core' dependency in the local Maven repo
-// 5. Install the 'hibernate-scan-jandex' dependency in the local Maven repo
-// 6. Generate the pom.xml file for the Maven plugin
-// 7. Generate the Maven plugin descriptor
-// 8. Create the jar for the Maven plugin
-// 9. Install the Maven plugin descriptor in the local Maven repo
-// 10. Run the integration tests
-
-// Prepare the working directory
-tasks.register('prepareWorkspace', Copy) {
-    into('target/maven-embedder/workspace')
-    // copy the plugin pom
-    with( copySpec {
-        from('target/publications/publishedArtifacts/pom-default.xml')
-        rename('pom-default.xml', 'pom.xml')
-        dependsOn('generatePomFileForPublishedArtifactsPublication')
-    })
-    // copy the compiled java classes
-    into('target/classes') {
-        with( copySpec {
-            from('target/classes/java/main')
-            dependsOn('compileJava')
-        })
-    }
-    // copy the integration tests
-    into('src/it') {
-        with( copySpec {
-            from('src/it')
-        })
-    }
-}


### PR DESCRIPTION
HHH-19122 - Leverage org.gradlex.maven-plugin-development for hibernate-maven-plugin

<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

Fixes the ability to publish artifacts to maven-local.  

Does remove functional/integration testing of the plugin, however.  See https://hibernate.atlassian.net/browse/HHH-19123

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
