### PR TITLE
Remove incorrect mention of HHH-19098 in changelog

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -13,9 +13,6 @@ https://hibernate.atlassian.net/projects/HHH/versions/32416
     * [HHH-18901] - AnnotationFormatError: Duplicate annotation for class: interface org.hibernate.bytecode.enhance.spi.EnhancementInfo
     * [HHH-18069] - NullPointerException when unioning partition results
 
-** Improvement
-    * [HHH-19098] - Disable implicit loading of the default import script
-
 ** Task
     * [HHH-19050] - Allow configuration of EntityManagerFactoryBuilderImpl to override the BytecodeProvider instance
     * [HHH-18928] - Consider the default Access Type as per Spec section 2.3.1 and skip enhancement of properties accessor


### PR DESCRIPTION
Automation was buggy and closed the issue before the fix was even merged.

----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
