### PR TITLE
HHH-19091Metamodel classes are not generated from inner interfaces

### DIFF
--- a/tooling/metamodel-generator/src/main/java/org/hibernate/processor/ClassWriter.java
+++ b/tooling/metamodel-generator/src/main/java/org/hibernate/processor/ClassWriter.java
@@ -257,7 +257,10 @@ public final class ClassWriter {
 	}
 
 	private static String getGeneratedSuperclassName(Element superClassElement, boolean jakartaDataStyle) {
-		final TypeElement typeElement = (TypeElement) superClassElement;
+		return getGeneratedClassName( (TypeElement) superClassElement, jakartaDataStyle );
+	}
+
+	private static String getGeneratedClassName(TypeElement typeElement, boolean jakartaDataStyle) {
 		final String simpleName = typeElement.getSimpleName().toString();
 		final Element enclosingElement = typeElement.getEnclosingElement();
 		return (enclosingElement instanceof TypeElement

--- a/tooling/metamodel-generator/src/main/java/org/hibernate/processor/HibernateProcessor.java
+++ b/tooling/metamodel-generator/src/main/java/org/hibernate/processor/HibernateProcessor.java
@@ -86,7 +86,7 @@ import static org.hibernate.processor.util.TypeUtils.containsAnnotation;
 import static org.hibernate.processor.util.TypeUtils.getAnnotationMirror;
 import static org.hibernate.processor.util.TypeUtils.getAnnotationValue;
 import static org.hibernate.processor.util.TypeUtils.hasAnnotation;
-import static org.hibernate.processor.util.TypeUtils.isClassOrRecordType;
+import static org.hibernate.processor.util.TypeUtils.isClassRecordOrInterfaceType;
 import static org.hibernate.processor.util.TypeUtils.isMemberType;
 
 /**
@@ -369,7 +369,8 @@ public class HibernateProcessor extends AbstractProcessor {
 			final TypeElement typeElement = context.getElementUtils().getTypeElement( elementName );
 			try {
 				final AnnotationMetaEntity metaEntity =
-						AnnotationMetaEntity.create( typeElement, context );
+						AnnotationMetaEntity.create( typeElement, context,
+								parentMetadata( typeElement, context::getMetaEntity ) );
 				context.addMetaAuxiliary( metaEntity.getQualifiedName(), metaEntity );
 				context.removeElementToRedo( elementName );
 			}
@@ -410,7 +411,8 @@ public class HibernateProcessor extends AbstractProcessor {
 							|| provider.getValue().toString().equalsIgnoreCase("hibernate") ) {
 						context.logMessage( Diagnostic.Kind.OTHER, "Processing repository class '" + element + "'" );
 						final AnnotationMetaEntity metaEntity =
-								AnnotationMetaEntity.create( typeElement, context );
+								AnnotationMetaEntity.create( typeElement, context,
+										parentMetadata( parent, context::getMetaEntity ) );
 						if ( metaEntity.isInitialized() ) {
 							context.addMetaAuxiliary( metaEntity.getQualifiedName(), metaEntity );
 						}
@@ -422,7 +424,8 @@ public class HibernateProcessor extends AbstractProcessor {
 						if ( hasAnnotation( member, HQL, SQL, FIND ) ) {
 							context.logMessage( Diagnostic.Kind.OTHER, "Processing annotated class '" + element + "'" );
 							final AnnotationMetaEntity metaEntity =
-									AnnotationMetaEntity.create( typeElement, context );
+									AnnotationMetaEntity.create( typeElement, context,
+											parentMetadata( parent, context::getMetaEntity ) );
 							context.addMetaAuxiliary( metaEntity.getQualifiedName(), metaEntity );
 							break;
 						}
@@ -442,9 +445,9 @@ public class HibernateProcessor extends AbstractProcessor {
 					}
 				}
 			}
-			if ( isClassOrRecordType( element ) ) {
+			if ( isClassRecordOrInterfaceType( element ) ) {
 				for ( final Element child : element.getEnclosedElements() ) {
-					if ( isClassOrRecordType( child ) ) {
+					if ( isClassRecordOrInterfaceType( child ) ) {
 						processElement( child, element );
 					}
 				}
@@ -481,7 +484,8 @@ public class HibernateProcessor extends AbstractProcessor {
 	private void createMetaModelClasses() {
 
 		for ( Metamodel aux : context.getMetaAuxiliaries() ) {
-			if ( !context.isAlreadyGenerated(aux) ) {
+			if ( !context.isAlreadyGenerated(aux)
+				&& !isClassRecordOrInterfaceType( aux.getElement().getEnclosingElement() ) ) {
 				context.logMessage( Diagnostic.Kind.OTHER,
 						"Writing metamodel for auxiliary '" + aux + "'" );
 				ClassWriter.writeFile( aux, context );
@@ -623,7 +627,7 @@ public class HibernateProcessor extends AbstractProcessor {
 	}
 
 	private void handleRootElementAnnotationMirrors(final Element element, @Nullable Element parent) {
-		if ( isClassOrRecordType( element ) ) {
+		if ( isClassRecordOrInterfaceType( element ) ) {
 			if ( isEntityOrEmbeddable( element ) ) {
 				final TypeElement typeElement = (TypeElement) element;
 				indexEntityName( typeElement );
@@ -741,7 +745,8 @@ public class HibernateProcessor extends AbstractProcessor {
 	private void handleRootElementAuxiliaryAnnotationMirrors(final Element element) {
 		if ( element instanceof TypeElement ) {
 			final AnnotationMetaEntity metaEntity =
-					AnnotationMetaEntity.create( (TypeElement) element, context );
+					AnnotationMetaEntity.create( (TypeElement) element, context,
+							parentMetadata( element.getEnclosingElement(), context::getMetaEntity ) );
 			context.addMetaAuxiliary( metaEntity.getQualifiedName(), metaEntity );
 		}
 		else if ( element instanceof PackageElement ) {

--- a/tooling/metamodel-generator/src/main/java/org/hibernate/processor/annotation/AbstractCriteriaMethod.java
+++ b/tooling/metamodel-generator/src/main/java/org/hibernate/processor/annotation/AbstractCriteriaMethod.java
@@ -7,9 +7,11 @@ package org.hibernate.processor.annotation;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 import javax.lang.model.element.ExecutableElement;
+import javax.lang.model.element.TypeElement;
 import java.util.List;
 import java.util.StringTokenizer;
 
+import static org.hibernate.processor.util.TypeUtils.getGeneratedClassFullyQualifiedName;
 import static org.hibernate.processor.util.TypeUtils.isPrimitive;
 
 /**
@@ -185,11 +187,13 @@ public abstract class AbstractCriteriaMethod extends AbstractFinderMethod {
 	private void path(StringBuilder declaration, String paramName) {
 		final StringTokenizer tokens = new StringTokenizer(paramName, ".");
 		String typeName = entity;
-		while ( typeName!= null && tokens.hasMoreTokens() ) {
+		while ( typeName != null && tokens.hasMoreTokens() ) {
+			final TypeElement typeElement = annotationMetaEntity.getContext().getElementUtils()
+					.getTypeElement( typeName );
 			final String memberName = tokens.nextToken();
 			declaration
 					.append(".get(")
-					.append(annotationMetaEntity.importType(typeName + '_'))
+					.append( annotationMetaEntity.importType( getGeneratedClassFullyQualifiedName( typeElement, false ) ) )
 					.append('.')
 					.append(memberName)
 					.append(')');

--- a/tooling/metamodel-generator/src/main/java/org/hibernate/processor/annotation/AbstractQueryMethod.java
+++ b/tooling/metamodel-generator/src/main/java/org/hibernate/processor/annotation/AbstractQueryMethod.java
@@ -8,6 +8,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 import org.hibernate.AssertionFailure;
 
 import javax.lang.model.element.ExecutableElement;
+import javax.lang.model.element.TypeElement;
 import java.util.List;
 import java.util.Set;
 
@@ -36,6 +37,7 @@ import static org.hibernate.processor.util.Constants.QUERY;
 import static org.hibernate.processor.util.Constants.SESSION_TYPES;
 import static org.hibernate.processor.util.Constants.STREAM;
 import static org.hibernate.processor.util.Constants.TYPED_QUERY;
+import static org.hibernate.processor.util.TypeUtils.getGeneratedClassFullyQualifiedName;
 import static org.hibernate.processor.util.TypeUtils.isPrimitive;
 
 /**
@@ -310,12 +312,15 @@ public abstract class AbstractQueryMethod extends AbstractAnnotatedMethod {
 							.append( ")\n" );
 				}
 			}
-			else if ( isRangeParam(paramType) ) {
+			else if ( isRangeParam(paramType) && returnTypeName!= null ) {
+				final TypeElement entityElement = annotationMetaEntity.getContext().getElementUtils()
+						.getTypeElement( returnTypeName );
 				declaration
 						.append("\t\t\t.addRestriction(")
 						.append(annotationMetaEntity.importType(HIB_RESTRICTION))
 						.append(".restrict(")
-						.append(annotationMetaEntity.importType(returnTypeName + '_'))
+						.append(annotationMetaEntity.importType(
+										getGeneratedClassFullyQualifiedName( entityElement, false ) ))
 						.append('.')
 						.append(paramName)
 						.append(", ")

--- a/tooling/metamodel-generator/src/main/java/org/hibernate/processor/annotation/AnnotationMetaEntity.java
+++ b/tooling/metamodel-generator/src/main/java/org/hibernate/processor/annotation/AnnotationMetaEntity.java
@@ -184,8 +184,8 @@ public class AnnotationMetaEntity extends AnnotationMeta {
 						jakartaDataStaticModel ) );
 	}
 
-	public static AnnotationMetaEntity create(TypeElement element, Context context) {
-		return create( element,context, false, false, false, null );
+	public static AnnotationMetaEntity create(TypeElement element, Context context, @Nullable AnnotationMetaEntity parent) {
+		return create( element,context, false, false, false, parent );
 	}
 
 	public static AnnotationMetaEntity create(

--- a/tooling/metamodel-generator/src/test/java/org/hibernate/processor/test/innerclass/InnerInterfaceTest.java
+++ b/tooling/metamodel-generator/src/test/java/org/hibernate/processor/test/innerclass/InnerInterfaceTest.java
@@ -1,0 +1,53 @@
+/*
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.processor.test.innerclass;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import org.hibernate.annotations.processing.Find;
+import org.hibernate.annotations.processing.HQL;
+import org.hibernate.processor.test.util.CompilationTest;
+import org.hibernate.processor.test.util.WithClasses;
+import org.junit.Test;
+
+import static org.hibernate.processor.test.util.TestUtil.assertMetamodelClassGeneratedFor;
+import static org.hibernate.processor.test.util.TestUtil.assertPresenceOfMethodInMetamodelFor;
+import static org.hibernate.processor.test.util.TestUtil.getMetaModelSourceAsString;
+
+@WithClasses({InnerInterfaceTest.MyEntity.class, InnerInterfaceTest.Queries.class})
+public class InnerInterfaceTest extends CompilationTest {
+
+	@Entity
+	public static class MyEntity {
+		@Id
+		@GeneratedValue
+		public Long id;
+		public String foo;
+	}
+
+	public interface Queries {
+		@HQL("where foo = :foo")
+		MyEntity findEntities(String foo);
+
+		@Find
+		MyEntity findEntitiesHql(String foo);
+	}
+
+
+	@Test
+	public void test() {
+		System.out.println( getMetaModelSourceAsString( InnerInterfaceTest.MyEntity.class ) );
+		System.out.println( getMetaModelSourceAsString( InnerInterfaceTest.Queries.class ) );
+		assertMetamodelClassGeneratedFor( InnerInterfaceTest.MyEntity.class );
+		assertMetamodelClassGeneratedFor( InnerInterfaceTest.Queries.class );
+
+		assertPresenceOfMethodInMetamodelFor( InnerInterfaceTest.Queries.class, "findEntities",
+				EntityManager.class, String.class );
+		assertPresenceOfMethodInMetamodelFor( InnerInterfaceTest.Queries.class, "findEntitiesHql",
+				EntityManager.class, String.class );
+	}
+}


### PR DESCRIPTION
Jira issue [HHH-19091](https://hibernate.atlassian.net/browse/HHH-19091)

Changed implementation to generate metamodel classes from interfaces in a similar way as earlier from classes and records

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------


[HHH-19091]: https://hibernate.atlassian.net/browse/HHH-19091?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ