### PR TITLE
Adjust how signing task is enabled/disabled

### DIFF
--- a/gradle/published-java-module.gradle
+++ b/gradle/published-java-module.gradle
@@ -123,39 +123,35 @@ var signingExtension = project.getExtensions().getByType(SigningExtension) as Si
 signingExtension.sign publishing.publications.publishedArtifacts
 
 gradle.taskGraph.whenReady { TaskExecutionGraph graph ->
-	boolean wasSigningRequested = false
 	boolean wasPublishingRequested = false
 
 	graph.allTasks.each {task ->
-		if ( task instanceof Sign ) {
-			wasSigningRequested = true
-		}
-		else if ( task instanceof PublishToMavenRepository ) {
+		if ( task instanceof PublishToMavenRepository ) {
 			wasPublishingRequested = true
 		}
 	}
 
+	var signingKey = resolveSigningKey()
+	var signingPassword = resolveSigningPassphrase()
+
 	if ( wasPublishingRequested ) {
+		if ( signingKey == null || signingPassword == null ) {
+			throw new RuntimeException("Cannot perform signing without GPG details.")
+		}
+
 		def ossrhUser = System.getenv().get( "ORG_GRADLE_PROJECT_sonatypeUsername" )
 		def ossrhPass = System.getenv().get( "ORG_GRADLE_PROJECT_sonatypePassword" )
 		if ( ossrhUser == null || ossrhPass == null ) {
 			throw new RuntimeException( "Cannot perform publishing to OSSRH without credentials." )
 		}
 		logger.lifecycle "Publishing {} : {} : {}", project.group, project.name, project.version
-	}
 
-	if ( wasSigningRequested || wasPublishingRequested ) {
 		// signing was explicitly requested and/or we are publishing to Sonatype OSSRH
 		// 		- we need the signing to happen
 		signingExtension.required = true
-
-		var signingKey = resolveSigningKey()
-		var signingPassword = resolveSigningPassphrase()
 		signingExtension.useInMemoryPgpKeys( signingKey, signingPassword )
 	}
-	else {
-		// signing was not explicitly requested and we are not publishing to OSSRH,
-		// 		- disable all Sign tasks
+	else if ( signingKey == null || signingPassword == null ) {
 		tasks.withType( Sign ).each { t-> t.enabled = false }
 	}
 }
@@ -171,15 +167,11 @@ static String resolveSigningKey() {
 		return new File( keyFile ).text
 	}
 
-	throw new RuntimeException( "Cannot perform signing without GPG details." )
+	return null
 }
 
 static String resolveSigningPassphrase() {
-	var passphrase = System.getenv().get( "SIGNING_GPG_PASSPHRASE" )
-	if ( passphrase == null ) {
-		throw new RuntimeException( "Cannot perform signing without GPG details." )
-	}
-	return passphrase
+	return System.getenv().get( "SIGNING_GPG_PASSPHRASE" )
 }
 
 


### PR DESCRIPTION
This should be closer to what's happening in the 6.6 branch. 
Signing tasks are present when you try to publish to maven local, even though not requested explicitly. I initially thought about ignoring signing when there's a `PublishToMavenLocal` task present, but I realised that 6.6 uses a similar script, and that's the approach taken there. 

as for the `okhttp-digest` turned out, it's already backported to 6.2, so nothing to be done here. 

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
