### PR TITLE
HHH-19126 Plural valued paths should be collection-typed instead of element typed

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/internal/AbstractPluralAttribute.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/internal/AbstractPluralAttribute.java
@@ -153,9 +153,12 @@ public abstract class AbstractPluralAttribute<D, C, E>
 		return getElementType().getJavaType();
 	}
 
+	@SuppressWarnings("unchecked")
 	@Override
 	public SqmPath<E> createSqmPath(SqmPath<?> lhs, SqmPathSource<?> intermediatePathSource) {
-		return new SqmPluralValuedSimplePath<>(
+		// We need an unchecked cast here : PluralPersistentAttribute implements path source with its element type
+		//  but resolving paths from it must produce collection-typed expressions.
+		return (SqmPath<E>) new SqmPluralValuedSimplePath<>(
 				PathHelper.append( lhs, this, intermediatePathSource ),
 				this,
 				lhs,

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/predicate/SqmMemberOfPredicate.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/predicate/SqmMemberOfPredicate.java
@@ -37,7 +37,7 @@ public class SqmMemberOfPredicate extends AbstractNegatableSqmPredicate {
 		this.pluralPath = pluralPath;
 		this.leftHandExpression = leftHandExpression;
 
-		final SimpleDomainType<?> simpleDomainType = pluralPath.getReferencedPathSource().getElementType();
+		final SimpleDomainType<?> simpleDomainType = pluralPath.getPluralAttribute().getElementType();
 
 		if ( !areTypesComparable(leftHandExpression.getNodeType(), simpleDomainType, nodeBuilder.getSessionFactory()) ) {
 			throw new SemanticException(

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/criteria/paths/PluralAttributeExpressionsTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/criteria/paths/PluralAttributeExpressionsTest.java
@@ -9,6 +9,9 @@ package org.hibernate.orm.test.jpa.criteria.paths;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
+
+import jakarta.persistence.criteria.CriteriaBuilder;
 import jakarta.persistence.criteria.CriteriaQuery;
 import jakarta.persistence.criteria.Root;
 
@@ -24,10 +27,11 @@ import org.hibernate.orm.test.jpa.metamodel.Translation;
 import org.hibernate.query.criteria.HibernateCriteriaBuilder;
 import org.hibernate.query.criteria.JpaExpression;
 
-import org.hibernate.testing.TestForIssue;
+import org.hibernate.testing.orm.junit.Jira;
 
 import org.junit.jupiter.api.Test;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.hibernate.testing.transaction.TransactionUtil.doInJPA;
 
 /**
@@ -72,7 +76,7 @@ public class PluralAttributeExpressionsTest extends AbstractMetamodelSpecificTes
 	}
 
 	@Test
-	@TestForIssue( jiraKey = "HHH-11225" )
+	@Jira("https://hibernate.atlassian.net/browse/HHH-11225")
 	public void testElementMapIsEmptyHql() {
 		doInJPA( this::entityManagerFactory, entityManager -> {
 			entityManager.createQuery( "select m from MapEntity m where m.localized is empty" ).getResultList();
@@ -80,7 +84,7 @@ public class PluralAttributeExpressionsTest extends AbstractMetamodelSpecificTes
 	}
 
 	@Test
-	@TestForIssue( jiraKey = "HHH-11225" )
+	@Jira("https://hibernate.atlassian.net/browse/HHH-11225")
 	public void testElementMapIsEmptyCriteria() {
 		doInJPA( this::entityManagerFactory, entityManager -> {
 			final HibernateCriteriaBuilder cb = (HibernateCriteriaBuilder) entityManager.getCriteriaBuilder();
@@ -96,7 +100,7 @@ public class PluralAttributeExpressionsTest extends AbstractMetamodelSpecificTes
 	}
 
 	@Test
-	@TestForIssue( jiraKey = "HHH-11225" )
+	@Jira("https://hibernate.atlassian.net/browse/HHH-11225")
 	public void testEntityMapIsEmptyHql() {
 		doInJPA( this::entityManagerFactory, entityManager -> {
 			entityManager.createQuery( "select a from Article a where a.translations is empty" ).getResultList();
@@ -104,7 +108,7 @@ public class PluralAttributeExpressionsTest extends AbstractMetamodelSpecificTes
 	}
 
 	@Test
-	@TestForIssue( jiraKey = "HHH-11225" )
+	@Jira("https://hibernate.atlassian.net/browse/HHH-11225")
 	public void testEntityMapIsEmptyCriteria() {
 		doInJPA( this::entityManagerFactory, entityManager -> {
 			final HibernateCriteriaBuilder cb = (HibernateCriteriaBuilder) entityManager.getCriteriaBuilder();
@@ -146,7 +150,7 @@ public class PluralAttributeExpressionsTest extends AbstractMetamodelSpecificTes
 	}
 
 	@Test
-	@TestForIssue( jiraKey = "HHH-11225" )
+	@Jira("https://hibernate.atlassian.net/browse/HHH-11225")
 	public void testElementMapSizeHql() {
 		doInJPA( this::entityManagerFactory, entityManager -> {
 			entityManager.createQuery( "select m from MapEntity m where size( m.localized ) > 1" ).getResultList();
@@ -154,7 +158,7 @@ public class PluralAttributeExpressionsTest extends AbstractMetamodelSpecificTes
 	}
 
 	@Test
-	@TestForIssue( jiraKey = "HHH-11225" )
+	@Jira("https://hibernate.atlassian.net/browse/HHH-11225")
 	public void testElementMapSizeCriteria() {
 		doInJPA( this::entityManagerFactory, entityManager -> {
 			final HibernateCriteriaBuilder cb = (HibernateCriteriaBuilder) entityManager.getCriteriaBuilder();
@@ -170,7 +174,7 @@ public class PluralAttributeExpressionsTest extends AbstractMetamodelSpecificTes
 	}
 
 	@Test
-	@TestForIssue( jiraKey = "HHH-11225" )
+	@Jira("https://hibernate.atlassian.net/browse/HHH-11225")
 	public void testEntityMapSizeHql() {
 		doInJPA( this::entityManagerFactory, entityManager -> {
 			entityManager.createQuery( "select a from Article a where size(a.translations) > 1" ).getResultList();
@@ -178,7 +182,7 @@ public class PluralAttributeExpressionsTest extends AbstractMetamodelSpecificTes
 	}
 
 	@Test
-	@TestForIssue( jiraKey = "HHH-11225" )
+	@Jira("https://hibernate.atlassian.net/browse/HHH-11225")
 	public void testEntityMapSizeCriteria() {
 		doInJPA( this::entityManagerFactory, entityManager -> {
 			final HibernateCriteriaBuilder cb = (HibernateCriteriaBuilder) entityManager.getCriteriaBuilder();
@@ -193,4 +197,31 @@ public class PluralAttributeExpressionsTest extends AbstractMetamodelSpecificTes
 		});
 	}
 
+	@Test
+	@Jira("https://hibernate.atlassian.net/browse/HHH-19126")
+	public void testPluralMapPathJavaType() {
+		doInJPA( this::entityManagerFactory, entityManager -> {
+			final CriteriaBuilder cb = entityManager.getCriteriaBuilder();
+
+			final CriteriaQuery<Article> criteria = cb.createQuery( Article.class );
+			final Root<Article> root = criteria.from( Article.class );
+
+			assertThat( root.get( Article_.translations ).getJavaType() ).isEqualTo( Map.class );
+			assertThat( root.get( "translations" ).getJavaType() ).isEqualTo( Map.class );
+		} );
+	}
+
+	@Test
+	@Jira("https://hibernate.atlassian.net/browse/HHH-19126")
+	public void testPluralListPathJavaType() {
+		doInJPA( this::entityManagerFactory, entityManager -> {
+			final CriteriaBuilder cb = entityManager.getCriteriaBuilder();
+
+			final CriteriaQuery<Address> criteria = cb.createQuery( Address.class );
+			final Root<Address> root = criteria.from( Address.class );
+
+			assertThat( root.get( Address_.phones ).getJavaType() ).isEqualTo( List.class );
+			assertThat( root.get( "phones" ).getJavaType() ).isEqualTo( List.class );
+		} );
+	}
 }


### PR DESCRIPTION
<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

https://hibernate.atlassian.net/browse/HHH-19126

Backport of https://github.com/hibernate/hibernate-orm/pull/9730

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
