### PR TITLE
HHH-18894 [6.6 backport] Hibernate 6.6 enum literal is considered field literal instead

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/internal/JpaMetamodelImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/internal/JpaMetamodelImpl.java
@@ -289,7 +289,21 @@ public class JpaMetamodelImpl implements JpaMetamodelImplementor, Serializable {
 
 	@Override
 	public EnumJavaType<?> getEnumType(String className) {
-		return enumJavaTypes.get( className );
+		final EnumJavaType<?> enumJavaType = enumJavaTypes.get( className );
+		if ( enumJavaType != null ) {
+			return enumJavaType;
+		}
+		final ClassLoaderService classLoaderService = serviceRegistry.getService( ClassLoaderService.class );
+		try {
+			final Class<Object> clazz = classLoaderService.classForName( className );
+			if ( clazz == null || !clazz.isEnum() ) {
+				return null;
+			}
+			return new EnumJavaType( clazz );
+		}
+		catch (ClassLoadingException e) {
+			throw new RuntimeException( e );
+		}
 	}
 
 	@Override

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/query/SelectUnknownEnumLiteralTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/query/SelectUnknownEnumLiteralTest.java
@@ -1,0 +1,66 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html
+ */
+package org.hibernate.orm.test.query;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Tuple;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@DomainModel(annotatedClasses = SelectUnknownEnumLiteralTest.Transaction.class)
+@SessionFactory
+public class SelectUnknownEnumLiteralTest {
+
+	@BeforeAll
+	void setup(SessionFactoryScope scope) {
+		scope.inTransaction( em -> em.persist( new Transaction( 1L, "abc" ) ) );
+	}
+
+	@AfterAll
+	void clean(SessionFactoryScope scope) {
+		scope.inTransaction( em -> em.createMutationQuery( "delete from Tx" ).executeUpdate() );
+	}
+
+	@Test
+	void test(SessionFactoryScope scope) {
+		final List<Tuple> tuples = scope.fromSession( em ->
+				em.createQuery(
+						"SELECT org.hibernate.orm.test.query.SelectUnknownEnumLiteralTest$Type.TRANSACTION, e.id, e.reference FROM Tx e",
+						Tuple.class ).getResultList() );
+		assertEquals( 1, tuples.size() );
+		assertEquals( Type.TRANSACTION, tuples.get( 0 ).get( 0 ) );
+		assertEquals( 1L, tuples.get( 0 ).get( 1 ) );
+	}
+
+	@Entity(name = "Tx")
+	static class Transaction {
+		@Id
+		Long id;
+		String reference;
+
+		Transaction() {
+		}
+
+		Transaction(Long id, String reference) {
+			this.id = id;
+			this.reference = reference;
+		}
+	}
+
+	enum Type {
+		TRANSACTION, DIRECT_DEBIT_GROUP, DIRECT_DEBIT
+	}
+}


### PR DESCRIPTION
Jira issue  [HHH-18894](https://hibernate.atlassian.net/browse/HHH-18894)

Backporting changes from PR [#9342](https://github.com/hibernate/hibernate-orm/pull/9342)


<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------


[HHH-18894]: https://hibernate.atlassian.net/browse/HHH-18894?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ