### PR TITLE
HHH-19130 Metamodel generation failes when FQCN is used instead of entity name

### DIFF
--- a/tooling/metamodel-generator/src/jakartaData/java/org/hibernate/processor/test/data/fqcninquery/FqcnInQueryTest.java
+++ b/tooling/metamodel-generator/src/jakartaData/java/org/hibernate/processor/test/data/fqcninquery/FqcnInQueryTest.java
@@ -1,0 +1,32 @@
+/*
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.processor.test.data.fqcninquery;
+
+import jakarta.persistence.EntityManager;
+import org.hibernate.processor.test.util.CompilationTest;
+import org.hibernate.processor.test.util.WithClasses;
+import org.junit.Test;
+
+import static org.hibernate.processor.test.util.TestUtil.assertMetamodelClassGeneratedFor;
+import static org.hibernate.processor.test.util.TestUtil.assertPresenceOfMethodInMetamodelFor;
+import static org.hibernate.processor.test.util.TestUtil.getMetaModelSourceAsString;
+
+public class FqcnInQueryTest extends CompilationTest {
+	@Test
+	@WithClasses({MyEntity.class, MyRepository.class})
+	public void test() {
+		System.out.println( getMetaModelSourceAsString( MyRepository.class ) );
+		System.out.println( getMetaModelSourceAsString( MyEntity.class ) );
+
+		assertMetamodelClassGeneratedFor( MyRepository.class );
+		assertMetamodelClassGeneratedFor( MyEntity.class );
+
+		assertPresenceOfMethodInMetamodelFor( MyEntity.class, "getName", EntityManager.class, Integer.class );
+		assertPresenceOfMethodInMetamodelFor( MyEntity.class, "getUniqueId", EntityManager.class, String.class );
+
+		assertPresenceOfMethodInMetamodelFor( MyRepository.class, "getName", Integer.class );
+		assertPresenceOfMethodInMetamodelFor( MyRepository.class, "getUniqueId", String.class );
+	}
+}

--- a/tooling/metamodel-generator/src/jakartaData/java/org/hibernate/processor/test/data/fqcninquery/MyEntity.java
+++ b/tooling/metamodel-generator/src/jakartaData/java/org/hibernate/processor/test/data/fqcninquery/MyEntity.java
@@ -1,0 +1,24 @@
+/*
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.processor.test.data.fqcninquery;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.NamedQuery;
+
+@Entity
+@NamedQuery(name = "#getName",
+		query = "select name from org.hibernate.processor.test.data.fqcninquery.MyEntity where id=:id")
+@NamedQuery(name = "#getUniqueId",
+		query = "select uniqueId from MyEntity where name=:name")
+public class MyEntity {
+
+	@Id
+	Integer id;
+
+	String name;
+
+	String uniqueId;
+}

--- a/tooling/metamodel-generator/src/jakartaData/java/org/hibernate/processor/test/data/fqcninquery/MyRepository.java
+++ b/tooling/metamodel-generator/src/jakartaData/java/org/hibernate/processor/test/data/fqcninquery/MyRepository.java
@@ -1,0 +1,20 @@
+/*
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.processor.test.data.fqcninquery;
+
+
+import jakarta.data.repository.Query;
+import jakarta.data.repository.Repository;
+
+@Repository
+public interface MyRepository {
+
+	@Query("select name from org.hibernate.processor.test.data.fqcninquery.MyEntity where id=:id")
+	String getName(Integer id);
+
+
+	@Query("select uniqueId from MyEntity where name=:name")
+	String getUniqueId(String name);
+}

--- a/tooling/metamodel-generator/src/main/java/org/hibernate/processor/validation/ProcessorSessionFactory.java
+++ b/tooling/metamodel-generator/src/main/java/org/hibernate/processor/validation/ProcessorSessionFactory.java
@@ -578,7 +578,8 @@ public abstract class ProcessorSessionFactory extends MockSessionFactory {
 		if (symbol.getKind() == ElementKind.CLASS) {
 			final TypeElement type = (TypeElement) symbol;
 			return isEntity(type)
-				&& getJpaEntityName(type).equals(entityName);
+				&& ( getJpaEntityName(type).equals(entityName)
+					|| type.getQualifiedName().contentEquals(entityName) );
 		}
 		else {
 			return false;


### PR DESCRIPTION
Jira issue [HHH-19130](https://hibernate.atlassian.net/browse/HHH-19130)

Method `org.hibernate.processor.validation.ProcessorSessionFactory#isMatchingEntity` should accept either entity name or fully qualified class name when annotated with `@Entity` annotation



<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------


[HHH-19130]: https://hibernate.atlassian.net/browse/HHH-19130?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ