### PR TITLE
HHH-19134 Hibernate processor - find by id fails for entity with composite identifier with @IdClass

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/AbstractJavaType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/AbstractJavaType.java
@@ -48,7 +48,7 @@ public abstract class AbstractJavaType<T> implements BasicJavaType<T>, Serializa
 	protected AbstractJavaType(Type type, MutabilityPlan<T> mutabilityPlan) {
 		this.type = type;
 		this.mutabilityPlan = mutabilityPlan;
-		this.comparator = Comparable.class.isAssignableFrom( getJavaTypeClass() )
+		this.comparator = type != null && Comparable.class.isAssignableFrom( getJavaTypeClass() )
 				? (Comparator<T>) ComparableComparator.INSTANCE
 				: null;
 	}

--- a/tooling/metamodel-generator/src/jakartaData/java/org/hibernate/processor/test/data/idclass/CompositeIdClassTest.java
+++ b/tooling/metamodel-generator/src/jakartaData/java/org/hibernate/processor/test/data/idclass/CompositeIdClassTest.java
@@ -1,0 +1,35 @@
+/*
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.processor.test.data.idclass;
+
+import org.hibernate.processor.test.data.idclass.MyEntity.MyEntityId;
+import org.hibernate.processor.test.util.CompilationTest;
+import org.hibernate.processor.test.util.WithClasses;
+import org.junit.Test;
+
+import static org.hibernate.processor.test.util.TestUtil.assertMetamodelClassGeneratedFor;
+import static org.hibernate.processor.test.util.TestUtil.assertPresenceOfMethodInMetamodelFor;
+import static org.hibernate.processor.test.util.TestUtil.getMetaModelSourceAsString;
+
+public class CompositeIdClassTest extends CompilationTest {
+	@Test
+	@WithClasses({
+			MyRepository.class,
+			MyEntity.class,
+	})
+	public void test() {
+		System.out.println( getMetaModelSourceAsString( MyEntity.class ) );
+		System.out.println( getMetaModelSourceAsString( MyEntity.class, true ) );
+		System.out.println( getMetaModelSourceAsString( MyRepository.class ) );
+		assertMetamodelClassGeneratedFor( MyEntity.class );
+		assertMetamodelClassGeneratedFor( MyEntity.class, true );
+		assertMetamodelClassGeneratedFor( MyRepository.class );
+		assertPresenceOfMethodInMetamodelFor(
+				MyRepository.class,
+				"findById",
+				MyEntityId.class
+		);
+	}
+}

--- a/tooling/metamodel-generator/src/jakartaData/java/org/hibernate/processor/test/data/idclass/MyEntity.java
+++ b/tooling/metamodel-generator/src/jakartaData/java/org/hibernate/processor/test/data/idclass/MyEntity.java
@@ -1,0 +1,26 @@
+/*
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.processor.test.data.idclass;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.IdClass;
+
+@Entity
+@IdClass(MyEntity.MyEntityId.class)
+public class MyEntity {
+
+	@Id
+	Integer topicId;
+
+	@Id
+	String userId;
+
+	String status;
+
+	public record MyEntityId(Integer topicId, String userId) {
+
+	}
+}

--- a/tooling/metamodel-generator/src/jakartaData/java/org/hibernate/processor/test/data/idclass/MyRepository.java
+++ b/tooling/metamodel-generator/src/jakartaData/java/org/hibernate/processor/test/data/idclass/MyRepository.java
@@ -1,0 +1,16 @@
+/*
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.processor.test.data.idclass;
+
+import jakarta.data.repository.Query;
+import jakarta.data.repository.Repository;
+import org.hibernate.processor.test.data.idclass.MyEntity.MyEntityId;
+
+@Repository
+public interface MyRepository {
+
+	@Query("from MyEntity where id=:id")
+	MyEntity findById(MyEntityId id);
+}

--- a/tooling/metamodel-generator/src/main/java/org/hibernate/processor/validation/MockEntityPersister.java
+++ b/tooling/metamodel-generator/src/main/java/org/hibernate/processor/validation/MockEntityPersister.java
@@ -102,6 +102,10 @@ public abstract class MockEntityPersister implements EntityPersister, Joinable, 
 			result = getSubclassPropertyType(propertyPath);
 		}
 
+		if ("id".equals( propertyPath )) {
+			result = identifierType();
+		}
+
 		if (result!=null) {
 			propertyTypesByName.put(propertyPath, result);
 		}

--- a/tooling/metamodel-generator/src/main/java/org/hibernate/processor/validation/ProcessorSessionFactory.java
+++ b/tooling/metamodel-generator/src/main/java/org/hibernate/processor/validation/ProcessorSessionFactory.java
@@ -166,7 +166,7 @@ public abstract class ProcessorSessionFactory extends MockSessionFactory {
 	private Type propertyType(Element member, String entityName, String path, AccessType defaultAccessType) {
 		final TypeMirror memberType = memberType(member);
 		if (isEmbeddedProperty(member)) {
-			return component.make(asElement(memberType), entityName, path, defaultAccessType, this);
+			return componentType( entityName, path, defaultAccessType, memberType );
 		}
 		else if (isToOneAssociation(member)) {
 			return new ManyToOneType(getTypeConfiguration(), getToOneTargetEntity(member));
@@ -184,6 +184,10 @@ public abstract class ProcessorSessionFactory extends MockSessionFactory {
 			return getTypeConfiguration().getBasicTypeRegistry()
 					.getRegisteredType(qualifiedName(memberType));
 		}
+	}
+
+	private Component componentType(String entityName, String path, AccessType defaultAccessType, TypeMirror memberType) {
+		return component.make( asElement( memberType ), entityName, path, defaultAccessType, this );
 	}
 
 	@SuppressWarnings({"rawtypes", "unchecked"})
@@ -414,6 +418,12 @@ public abstract class ProcessorSessionFactory extends MockSessionFactory {
 
 		@Override
 		public Type identifierType() {
+			if (hasAnnotation( type, "IdClass" )) {
+				final TypeMirror annotationMember = (TypeMirror)getAnnotationMember( getAnnotation( type, "IdClass" ), "value" );
+				if (annotationMember != null) {
+					return factory.componentType( getEntityName(), EntityIdentifierMapping.ID_ROLE_NAME, defaultAccessType, annotationMember );
+				}
+			}
 			for (Element element : type.getEnclosedElements()) {
 				if ( hasAnnotation(element, "Id")|| hasAnnotation(element, "EmbeddedId") ) {
 					return factory.propertyType(element, getEntityName(), EntityIdentifierMapping.ID_ROLE_NAME, defaultAccessType);
@@ -490,7 +500,8 @@ public abstract class ProcessorSessionFactory extends MockSessionFactory {
 	boolean isAttributeDefined(String entityName, String fieldName) {
 		final TypeElement entityClass = findEntityClass(entityName);
 		return entityClass != null
-			&& findPropertyByPath(entityClass, fieldName, getDefaultAccessType(entityClass)) != null;
+			&& (findPropertyByPath(entityClass, fieldName, getDefaultAccessType(entityClass)) != null
+				|| "id".equals( fieldName ) && hasAnnotation( entityClass, "IdClass" ));
 	}
 
 	public TypeElement findEntityClass(String entityName) {

--- a/tooling/metamodel-generator/src/test/java/org/hibernate/processor/test/idclass/CompositeIdClassTest.java
+++ b/tooling/metamodel-generator/src/test/java/org/hibernate/processor/test/idclass/CompositeIdClassTest.java
@@ -1,0 +1,36 @@
+/*
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.processor.test.idclass;
+
+import jakarta.persistence.EntityManager;
+import org.hibernate.processor.test.idclass.MyEntity.MyEntityId;
+import org.hibernate.processor.test.util.CompilationTest;
+import org.hibernate.processor.test.util.WithClasses;
+import org.junit.Test;
+
+import static org.hibernate.processor.test.util.TestUtil.assertMetamodelClassGeneratedFor;
+import static org.hibernate.processor.test.util.TestUtil.assertPresenceOfMethodInMetamodelFor;
+import static org.hibernate.processor.test.util.TestUtil.assertPresenceOfNameFieldInMetamodelFor;
+import static org.hibernate.processor.test.util.TestUtil.getMetaModelSourceAsString;
+
+public class CompositeIdClassTest extends CompilationTest {
+	@Test
+	@WithClasses(MyEntity.class)
+	public void test() {
+		System.out.println( getMetaModelSourceAsString( MyEntity.class ) );
+		assertMetamodelClassGeneratedFor( MyEntity.class );
+		assertPresenceOfNameFieldInMetamodelFor(
+				MyEntity.class,
+				"QUERY_FIND_BY_ID",
+				"Missing named query attribute."
+		);
+		assertPresenceOfMethodInMetamodelFor(
+				MyEntity.class,
+				"findById",
+				EntityManager.class,
+				MyEntityId.class
+		);
+	}
+}

--- a/tooling/metamodel-generator/src/test/java/org/hibernate/processor/test/idclass/MyEntity.java
+++ b/tooling/metamodel-generator/src/test/java/org/hibernate/processor/test/idclass/MyEntity.java
@@ -1,0 +1,30 @@
+/*
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.processor.test.idclass;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.IdClass;
+import jakarta.persistence.NamedQuery;
+import org.hibernate.annotations.processing.CheckHQL;
+
+@Entity
+@IdClass(MyEntity.MyEntityId.class)
+@CheckHQL
+@NamedQuery(name = "#findById", query = "from MyEntity e where e.id=:id")
+public class MyEntity {
+
+	@Id
+	Integer topicId;
+
+	@Id
+	String userId;
+
+	String status;
+
+	public record MyEntityId(Integer topicId, String userId) {
+
+	}
+}


### PR DESCRIPTION
Jira issue [HHH-19134](https://hibernate.atlassian.net/browse/HHH-19134)

When entity class is annotated with `@IdClass`, property named `id` should be represented by composite containing all properties annotated with `@Id`


----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------


[HHH-19134]: https://hibernate.atlassian.net/browse/HHH-19134?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ