### PR TITLE
HHH-18868 [6.6 backport] Wrong behaviour of getAttribute method in impl. of ManagedType when scattered id attributes are used in MappedSuperclass

### DIFF
--- a/tooling/metamodel-generator/src/main/java/org/hibernate/processor/annotation/MetaAttributeGenerationVisitor.java
+++ b/tooling/metamodel-generator/src/main/java/org/hibernate/processor/annotation/MetaAttributeGenerationVisitor.java
@@ -29,6 +29,7 @@ import javax.tools.Diagnostic;
 import java.util.List;
 
 import static org.hibernate.processor.util.Constants.ELEMENT_COLLECTION;
+import static org.hibernate.processor.util.Constants.LIST_ATTRIBUTE;
 import static org.hibernate.processor.util.Constants.MANY_TO_ANY;
 import static org.hibernate.processor.util.Constants.MANY_TO_MANY;
 import static org.hibernate.processor.util.Constants.MAP_KEY_CLASS;
@@ -72,7 +73,13 @@ public class MetaAttributeGenerationVisitor extends SimpleTypeVisitor8<@Nullable
 
 	@Override
 	public @Nullable AnnotationMetaAttribute visitArray(ArrayType arrayType, Element element) {
-		return new AnnotationMetaSingleAttribute( entity, element, toArrayTypeString( arrayType, context ) );
+		if ( hasAnnotation( element, MANY_TO_MANY, ONE_TO_MANY, ELEMENT_COLLECTION ) ) {
+			return new AnnotationMetaCollection( entity, element, LIST_ATTRIBUTE,
+					toTypeString(arrayType.getComponentType()) );
+		}
+		else {
+			return new AnnotationMetaSingleAttribute( entity, element, toArrayTypeString( arrayType, context ) );
+		}
 	}
 
 	@Override

--- a/tooling/metamodel-generator/src/test/java/org/hibernate/processor/test/hhh18858/ArrayTest.java
+++ b/tooling/metamodel-generator/src/test/java/org/hibernate/processor/test/hhh18858/ArrayTest.java
@@ -1,0 +1,91 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html
+ */
+package org.hibernate.processor.test.hhh18858;
+
+
+import jakarta.persistence.metamodel.ListAttribute;
+import jakarta.persistence.metamodel.SingularAttribute;
+import org.hibernate.processor.test.util.CompilationTest;
+import org.hibernate.processor.test.util.WithClasses;
+import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.util.Collection;
+
+import static org.hibernate.processor.test.util.TestUtil.getFieldFromMetamodelFor;
+import static org.hibernate.processor.test.util.TestUtil.getMetaModelSourceAsString;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * @author Emmanuel Bernard
+ */
+public class ArrayTest extends CompilationTest {
+
+	@Test
+	@WithClasses({Competitor.class, Contest.class})
+	public void testOneToMany() throws NoSuchFieldException, IllegalAccessException {
+		System.out.println( getMetaModelSourceAsString( Competitor.class ) );
+		assertValidMetamodelField( Competitor.class, "id" );
+		assertValidMetamodelField( Competitor.class, "name" );
+
+		System.out.println( getMetaModelSourceAsString( Contest.class ) );
+		assertValidMetamodelField( Contest.class, "id" );
+		assertValidMetamodelField( Contest.class, "results" );
+		assertValidMetamodelField( Contest.class, "heldIn" );
+	}
+
+	private void assertValidMetamodelField(Class<?> entityClass, String fieldName)
+			throws NoSuchFieldException, IllegalAccessException {
+		final Field entityField = entityClass.getDeclaredField( fieldName );
+		final Class<?> entityFieldType = entityField.getType();
+
+		final Field modelField = getFieldFromMetamodelFor( entityClass, fieldName );
+		final Type modelFieldGenericType = modelField.getGenericType();
+		if (modelFieldGenericType instanceof ParameterizedType) {
+			ParameterizedType parametrized = (ParameterizedType) modelFieldGenericType;
+			final Type[] typeArguments = parametrized.getActualTypeArguments();
+			assertEquals( 2, typeArguments.length );
+			assertEquals( entityClass, typeArguments[0] );
+			if ( Collection.class.isAssignableFrom( entityFieldType ) || entityFieldType.isArray() ) {
+				assertEquals( ListAttribute.class, parametrized.getRawType() );
+				if ( Collection.class.isAssignableFrom( entityFieldType ) ) {
+					final ParameterizedType entityFieldGenericType = (ParameterizedType) entityField.getGenericType();
+					assertEquals( entityFieldGenericType.getActualTypeArguments()[0], typeArguments[1] );
+				}
+				else if ( entityFieldType.getComponentType().isPrimitive() ) {
+					assertEquals(
+							entityFieldType.getComponentType(),
+							((Class) typeArguments[1]).getDeclaredField( "TYPE" ).get( null )
+					);
+				}
+				else {
+					assertEquals( entityFieldType.getComponentType(), typeArguments[1] );
+				}
+			}
+			else {
+				assertEquals( SingularAttribute.class, parametrized.getRawType() );
+				if ( entityFieldType.isPrimitive() ) {
+					assertEquals(
+							entityFieldType,
+							((Class) typeArguments[1]).getDeclaredField( "TYPE" ).get( null )
+					);
+				}
+				else {
+					assertEquals( entityFieldType, typeArguments[1] );
+				}
+			}
+		}
+		else {
+			Assertions.fail();
+		}
+
+	}
+
+}

--- a/tooling/metamodel-generator/src/test/java/org/hibernate/processor/test/hhh18858/Competitor.java
+++ b/tooling/metamodel-generator/src/test/java/org/hibernate/processor/test/hhh18858/Competitor.java
@@ -1,0 +1,37 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html
+ */
+package org.hibernate.processor.test.hhh18858;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+
+/**
+ * @author Emmanuel Bernard
+ */
+@Entity
+public class Competitor {
+	private int id;
+	private String name;
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+
+	@Id
+	@GeneratedValue
+	public int getId() {
+		return id;
+	}
+
+	public void setId(int id) {
+		this.id = id;
+	}
+}

--- a/tooling/metamodel-generator/src/test/java/org/hibernate/processor/test/hhh18858/Contest.java
+++ b/tooling/metamodel-generator/src/test/java/org/hibernate/processor/test/hhh18858/Contest.java
@@ -1,0 +1,62 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html
+ */
+package org.hibernate.processor.test.hhh18858;
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.ElementCollection;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.OrderColumn;
+
+import org.hibernate.annotations.ListIndexBase;
+
+/**
+ * @author Emmanuel Bernard
+ */
+@Entity
+public class Contest {
+	private int id;
+	private Competitor[] results;
+	private int[] heldIn;
+
+	@Id
+	@GeneratedValue
+	public int getId() {
+		return id;
+	}
+
+	public void setId(int id) {
+		this.id = id;
+	}
+
+	@OneToMany(cascade = CascadeType.ALL)
+	@OrderColumn(name = "pos")
+	public Competitor[] getResults() {
+		return results;
+	}
+
+	public void setResults(Competitor[] results) {
+		this.results = results;
+	}
+
+	@ElementCollection
+	@OrderColumn
+	@ListIndexBase( 1 )
+	public int[] getHeldIn() {
+		return heldIn;
+	}
+
+	public void setHeldIn(int[] heldIn) {
+		this.heldIn = heldIn;
+	}
+
+	/*public enum Month {
+		January, February, March, April, May, June, July, August, September, October, November, December;
+	};*/
+}


### PR DESCRIPTION
Jira issue [HHH-18868](https://hibernate.atlassian.net/browse/HHH-18868)

Backporting changes from PR [#9353](https://github.com/hibernate/hibernate-orm/pull/9353) to 6.6

----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------


[HHH-18868]: https://hibernate.atlassian.net/browse/HHH-18868?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ