### PR TITLE
Changing Repository class name in example

### DIFF
--- a/documentation/src/main/asciidoc/repositories/Repositories.adoc
+++ b/documentation/src/main/asciidoc/repositories/Repositories.adoc
@@ -495,7 +495,7 @@ The JPQL specification provides the `select new` construct for this.
 
 [source,java]
 ----
-@Query("select new AuthorBookRecord(b.isbn, a.ssn, a.name, b.title " +
+@Query("select new AuthorBookSummary(b.isbn, a.ssn, a.name, b.title " +
        "from Author a join books b " +
        "where title like :pattern")
 List<AuthorBookSummary> summariesForTitle(@Pattern String pattern);


### PR DESCRIPTION
Renaming AuthorBookRecord to AuthorBookSummary

The documentation uses a class name as example, called AuthorBookSummary, but later on there is a new class called AuthorBookRecord

I wonder if AuthorBookSummary should be the class name used in the record declaration and in the implementation.

----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
