### PR TITLE
HHH-19097 Implemented MySQLLegacyDialect#stripsTrailingSpacesFromChar

### DIFF
--- a/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/MySQLLegacyDialect.java
+++ b/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/MySQLLegacyDialect.java
@@ -240,6 +240,16 @@ public class MySQLLegacyDialect extends Dialect {
 		}
 	}
 
+	/**
+	 * MySQL strips any trailing space character from a
+	 * value stored in a column of type {@code char(n)}.
+	 * @return {@code true}
+	 */
+	@Override
+	public boolean stripsTrailingSpacesFromChar() {
+		return true;
+	}
+
 	@Override
 	public boolean useMaterializedLobWhenCapacityExceeded() {
 		// MySQL has no real concept of LOBs, so we can just use longtext/longblob with the materialized JDBC APIs


### PR DESCRIPTION
This fixes [HHH-19097](https://hibernate.atlassian.net/browse/HHH-19097) by implementing `stripsTrailingSpacesFromChar -> true` on `MySQLLegacyDialect`  just like it had been implemented on `MySQLDialect` in commit 633f1012e196e3adb25a2f9c637a422d54ab8fbe and as I commented here: https://github.com/hibernate/hibernate-orm/commit/633f1012e196e3adb25a2f9c637a422d54ab8fbe#r151987775

[HHH-19097]: https://hibernate.atlassian.net/browse/HHH-19097?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------