### PR TITLE
HHH-19142 StatelessSession.getMultiple() and second-level cache

### DIFF
--- a/hibernate-core/src/test/java/org/hibernate/orm/test/stateless/GetMultipleFromCacheTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/stateless/GetMultipleFromCacheTest.java
@@ -4,6 +4,7 @@
  */
 package org.hibernate.orm.test.stateless;
 
+import jakarta.persistence.Cacheable;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import org.hibernate.testing.orm.junit.DomainModel;
@@ -16,9 +17,9 @@ import java.util.List;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
-@SessionFactory
-@DomainModel(annotatedClasses = GetMultipleTest.Record.class)
-public class GetMultipleTest {
+@SessionFactory(generateStatistics = true)
+@DomainModel(annotatedClasses = GetMultipleFromCacheTest.Record.class)
+public class GetMultipleFromCacheTest {
 	@Test void test(SessionFactoryScope scope) {
 		scope.inStatelessTransaction(s-> {
 			s.insert(new Record(123L,"hello earth"));
@@ -30,14 +31,17 @@ public class GetMultipleTest {
 			assertEquals("hello earth",all.get(1).message);
 			assertNull(all.get(2));
 		});
+		scope.getSessionFactory().getStatistics().clear();
 		scope.inStatelessTransaction(s-> {
 			List<Record> all = s.getMultiple(Record.class, List.of(123L, 2L, 456L));
 			assertEquals("hello earth",all.get(0).message);
 			assertEquals("hello mars",all.get(2).message);
 			assertNull(all.get(1));
 		});
+		assertEquals( 2,
+				scope.getSessionFactory().getStatistics().getSecondLevelCacheHitCount() );
 	}
-	@Entity
+	@Entity @Cacheable
 	static class Record {
 		@Id Long id;
 		String message;


### PR DESCRIPTION
<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

[Please describe here what your change is about]

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-19142
<!-- Hibernate GitHub Bot issue links end -->