### PR TITLE
Temporarily use fixed SHA for Quarkus testing until Quarkus upgrades to latest ORM 6.6 again

### DIFF
--- a/ci/quarkus.Jenkinsfile
+++ b/ci/quarkus.Jenkinsfile
@@ -48,6 +48,9 @@ pipeline {
 					}
 					dir('quarkus') {
 						sh "git clone -b 3.15 --single-branch https://github.com/quarkusio/quarkus.git . || git reset --hard && git clean -fx && git pull"
+						// This is a temporary workaround because Quarkus reverted the Hibernate ORM and Reactive upgrade.
+						// Remove this once Quarkus upgrades the versions again
+						sh "git reset --hard f42166ee7041ed09b7183d5dbf3ece2439b16676"
         				script {
 							def sedStatus = sh (script: "sed -i 's@<hibernate-orm.version>.*</hibernate-orm.version>@<hibernate-orm.version>${env.HIBERNATE_VERSION}</hibernate-orm.version>@' pom.xml", returnStatus: true)
 							if ( sedStatus != 0 ) {


### PR DESCRIPTION
<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
