### PR TITLE
Skip MultiLoadLockingTest for CockroachDB

### DIFF
--- a/hibernate-core/src/test/java/org/hibernate/orm/test/loading/multiLoad/MultiLoadLockingTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/loading/multiLoad/MultiLoadLockingTest.java
@@ -21,6 +21,7 @@ import org.hibernate.annotations.Cache;
 import org.hibernate.annotations.CacheConcurrencyStrategy;
 import org.hibernate.annotations.NaturalId;
 import org.hibernate.cfg.AvailableSettings;
+import org.hibernate.dialect.CockroachDialect;
 import org.hibernate.dialect.Dialect;
 import org.hibernate.dialect.HSQLDialect;
 import org.hibernate.dialect.PostgreSQLDialect;
@@ -67,6 +68,7 @@ import jakarta.persistence.Id;
 		// The tests don't actually fail for the dialects below, skipping them so that the non-occurring expected failure doesn't fail the Test case
 		value = {
 				@SkipForDialect(dialectClass = PostgreSQLDialect.class, matchSubTypes = true),
+				@SkipForDialect(dialectClass = CockroachDialect.class, matchSubTypes = true),
 				@SkipForDialect(dialectClass = HSQLDialect.class),
 		}
 )


### PR DESCRIPTION
Just as for Postgresql, the test should be skipped for CockroachDB. See the class comments.

<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

[Please describe here what your change is about]

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
