### PR TITLE
Fix SQL formatting bug where a newline is missing after a single-line comment

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/engine/jdbc/internal/BasicFormatterImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/jdbc/internal/BasicFormatterImpl.java
@@ -76,6 +76,7 @@ public class BasicFormatterImpl implements Formatter {
 						token = tokens.nextToken();
 					}
 					while ( !"\n".equals( token ) && tokens.hasMoreTokens() );
+					result.append( "\n" );
 				}
 
 				lcToken = token.toLowerCase( Locale.ROOT );
@@ -83,13 +84,13 @@ public class BasicFormatterImpl implements Formatter {
 					case "'":
 					case "`":
 					case "\"":
-						appendUntilToken(lcToken);
+						appendUntilToken( lcToken );
 						misc();
 						break;
 					// SQL Server uses "[" and "]" to escape reserved words
 					// see SQLServerDialect.openQuote and SQLServerDialect.closeQuote
 					case "[":
-						appendUntilToken("]");
+						appendUntilToken( "]" );
 						misc();
 						break;
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/jdbc/util/BasicFormatterTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/jdbc/util/BasicFormatterTest.java
@@ -78,6 +78,20 @@ public class BasicFormatterTest extends BaseUnitTestCase {
 		assertNoLoss( "select * from ((select e.id from Entity e union all select e.id from Entity e) union select e.id from Entity e) grp" );
 	}
 
+	@Test
+	public void  testSingleLineComment(){
+		assertNoLoss("CREATE TRIGGER before_employee_delete\n"
+					+ "BEFORE DELETE ON employees\n"
+					+ "FOR EACH ROW\n"
+					+ "BEGIN\n"
+					+ "    -- abcd\n"
+					+ "    IF EXISTS (SELECT 1 FROM orders WHERE employee_id = OLD.id) THEN\n"
+					+ "        SIGNAL SQLSTATE '45000'\n"
+					+ "        SET MESSAGE_TEXT = 'Cannot delete employee because they have related orders';\n"
+					+ "    END IF;\n"
+					+ "END ");
+	}
+
 	private void assertNoLoss(String query) {
 		String formattedQuery = FormatStyle.BASIC.getFormatter().format( query );
 		StringTokenizer formatted = new StringTokenizer( formattedQuery, " \t\n\r\f()" );


### PR DESCRIPTION
### Description:
During SQL formatting, it was discovered that the newline character was missing after a single-line comment (-- comment). This causes the formatted SQL to be incorrect .

### Test:
```sql
CREATE TRIGGER before_employee_delete
BEFORE DELETE ON employees
FOR EACH ROW
BEGIN
    -- abcd
    IF EXISTS (SELECT 1 FROM orders WHERE employee_id = OLD.id) THEN
        SIGNAL SQLSTATE '45000'
        SET MESSAGE_TEXT = 'Cannot delete employee because they have related orders';
    END IF;
END;
```
Formatted Result Before the Fix:
<img width="1092" alt="image" src="https://github.com/user-attachments/assets/c1f0cbfc-7478-4561-92f8-96815936234d" />


Formatted Result After the Fix:
<img width="1400" alt="image" src="https://github.com/user-attachments/assets/9849357e-d864-447d-b270-ffbf8dc349fc" />


<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
