### PR TITLE
HHH-19116 Error when using fk() function on left joined many-to-one association and is null predicate

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/query/derived/AnonymousTupleType.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/derived/AnonymousTupleType.java
@@ -11,6 +11,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
+import jakarta.persistence.metamodel.Bindable;
 import org.hibernate.Incubating;
 import org.hibernate.internal.util.collections.CollectionHelper;
 import org.hibernate.metamodel.UnsupportedMappingException;
@@ -31,6 +32,7 @@ import org.hibernate.query.sqm.tree.select.SqmSelectableNode;
 import org.hibernate.query.sqm.tree.select.SqmSubQuery;
 import org.hibernate.sql.ast.spi.FromClauseAccess;
 import org.hibernate.sql.ast.spi.SqlSelection;
+import org.hibernate.type.BasicType;
 import org.hibernate.type.descriptor.java.JavaType;
 import org.hibernate.type.descriptor.java.ObjectArrayJavaType;
 
@@ -177,20 +179,21 @@ public class AnonymousTupleType<T> implements TupleType<T>, DomainType<T>, Retur
 		final SqmSelectableNode<?> component = components[index];
 		if ( component instanceof SqmPath<?> ) {
 			final SqmPath<?> sqmPath = (SqmPath<?>) component;
-			if ( sqmPath.getNodeType() instanceof SingularPersistentAttribute<?, ?> ) {
+			final Bindable<?> model = sqmPath.getModel();
+			if ( model instanceof SingularPersistentAttribute<?, ?> ) {
 				//noinspection unchecked,rawtypes
 				return new AnonymousTupleSqmAssociationPathSource(
 						name,
 						sqmPath,
-						( (SingularPersistentAttribute<?, ?>) sqmPath.getNodeType() ).getType()
+						( (SingularPersistentAttribute<?, ?>) model ).getType()
 				);
 			}
-			else if ( sqmPath.getNodeType() instanceof PluralPersistentAttribute<?, ?, ?> ) {
+			else if ( model instanceof PluralPersistentAttribute<?, ?, ?> ) {
 				//noinspection unchecked,rawtypes
 				return new AnonymousTupleSqmAssociationPathSource(
 						name,
 						sqmPath,
-						( (PluralPersistentAttribute<?, ?, ?>) sqmPath.getNodeType() ).getElementType()
+						( (PluralPersistentAttribute<?, ?, ?>) model ).getElementType()
 				);
 			}
 			else if ( sqmPath.getNodeType() instanceof EntityDomainType<?> ) {

--- a/hibernate-core/src/main/java/org/hibernate/query/hql/internal/QualifiedJoinPathConsumer.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/hql/internal/QualifiedJoinPathConsumer.java
@@ -197,7 +197,7 @@ public class QualifiedJoinPathConsumer implements DotIdentifierConsumer {
 		if ( allowReuse ) {
 			if ( !isTerminal ) {
 				for ( SqmJoin<?, ?> sqmJoin : lhs.getSqmJoins() ) {
-					if ( sqmJoin.getAlias() == null && sqmJoin.getReferencedPathSource() == subPathSource ) {
+					if ( sqmJoin.getAlias() == null && sqmJoin.getModel() == subPathSource ) {
 						return sqmJoin;
 					}
 				}

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/internal/SqmUtil.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/internal/SqmUtil.java
@@ -427,7 +427,7 @@ public class SqmUtil {
 			SqmPathSource<A> pathSource,
 			SqmJoinType requestedJoinType) {
 		for ( final SqmJoin<T, ?> join : sqmFrom.getSqmJoins() ) {
-			if ( join.getReferencedPathSource() == pathSource ) {
+			if ( join.getModel() == pathSource ) {
 				final SqmAttributeJoin<T, ?> attributeJoin = (SqmAttributeJoin<T, ?>) join;
 				if ( attributeJoin.isFetched() ) {
 					final SqmJoinType joinType = join.getSqmJoinType();

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/domain/AbstractSqmAttributeJoin.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/domain/AbstractSqmAttributeJoin.java
@@ -122,7 +122,7 @@ public abstract class AbstractSqmAttributeJoin<O,T>
 	@Override
 	public PersistentAttribute<? super O, ?> getAttribute() {
 		//noinspection unchecked
-		return (PersistentAttribute<? super O, ?>) getReferencedPathSource();
+		return (PersistentAttribute<? super O, ?>) getModel();
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/domain/SqmSingularJoin.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/domain/SqmSingularJoin.java
@@ -14,6 +14,7 @@ import org.hibernate.metamodel.model.domain.ManagedDomainType;
 import org.hibernate.metamodel.model.domain.SingularPersistentAttribute;
 import org.hibernate.metamodel.model.domain.TreatableDomainType;
 import org.hibernate.query.sqm.SemanticQueryWalker;
+import org.hibernate.query.sqm.SqmPathSource;
 import org.hibernate.spi.NavigablePath;
 import org.hibernate.query.hql.spi.SqmCreationProcessingState;
 import org.hibernate.query.sqm.NodeBuilder;
@@ -84,6 +85,16 @@ public class SqmSingularJoin<O,T> extends AbstractSqmAttributeJoin<O,T> {
 		);
 		copyTo( path, context );
 		return path;
+	}
+
+	@Override
+	public SqmPathSource<T> getNodeType() {
+		return getReferencedPathSource();
+	}
+
+	@Override
+	public SqmPathSource<T> getReferencedPathSource() {
+		return getModel().getPathSource();
 	}
 
 	@Override


### PR DESCRIPTION
<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

https://hibernate.atlassian.net/browse/HHH-19116

Backport of https://github.com/hibernate/hibernate-orm/pull/9769 (only the fix part).

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
