### PR TITLE
promote getSession() up to PersistentCollection

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/collection/spi/AbstractPersistentCollection.java
+++ b/hibernate-core/src/main/java/org/hibernate/collection/spi/AbstractPersistentCollection.java
@@ -897,11 +897,7 @@ public abstract class AbstractPersistentCollection<E> implements Serializable, P
 	@Override
 	public abstract Collection<E> getOrphans(Serializable snapshot, String entityName) throws HibernateException;
 
-	/**
-	 * Get the session currently associated with this collection.
-	 *
-	 * @return The session
-	 */
+	@Override
 	public final SharedSessionContractImplementor getSession() {
 		return session;
 	}

--- a/hibernate-core/src/main/java/org/hibernate/collection/spi/PersistentArrayHolder.java
+++ b/hibernate-core/src/main/java/org/hibernate/collection/spi/PersistentArrayHolder.java
@@ -252,9 +252,9 @@ public class PersistentArrayHolder<E> extends AbstractPersistentCollection<E> {
 	public boolean needsUpdating(Object entry, int i, Type elemType) throws HibernateException {
 		final Serializable sn = getSnapshot();
 		return i < Array.getLength( sn )
-				&& Array.get( sn, i ) != null
-				&& Array.get( array, i ) != null
-				&& elemType.isDirty( Array.get( array, i ), Array.get( sn, i ), getSession() );
+			&& Array.get( sn, i ) != null
+			&& Array.get( array, i ) != null
+			&& elemType.isDirty( Array.get( array, i ), Array.get( sn, i ), getSession() );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/collection/spi/PersistentCollection.java
+++ b/hibernate-core/src/main/java/org/hibernate/collection/spi/PersistentCollection.java
@@ -11,6 +11,7 @@ import java.util.List;
 
 import org.hibernate.HibernateException;
 import org.hibernate.Incubating;
+import org.hibernate.Internal;
 import org.hibernate.engine.spi.InstanceIdentity;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.metamodel.mapping.PluralAttributeMapping;
@@ -359,7 +360,6 @@ public interface PersistentCollection<E> extends LazyInitializable, InstanceIden
 	 *
 	 * @see #injectLoadedState
 	 */
-	@SuppressWarnings("UnusedReturnValue")
 	boolean endRead();
 
 	/**
@@ -510,6 +510,13 @@ public interface PersistentCollection<E> extends LazyInitializable, InstanceIden
 	Object elementByIndex(Object index);
 
 	void initializeEmptyCollection(CollectionPersister persister);
+
+	/**
+	 * Get the session currently associated with this collection.
+	 * Declared here for use by Hibernate Reactive.
+	 */
+	@Internal
+	SharedSessionContractImplementor getSession();
 
 	/**
 	 * Is the collection newly instantiated?


### PR DESCRIPTION
for the benefit of Hibernate Reactive, which currently casts to AbstractPersistentCollection

<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

[Please describe here what your change is about]

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
