### PR TITLE
HHH-19195 Embeddable inheritance: discriminator values are not hierarchically ordered

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/boot/model/internal/EmbeddableBinder.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/internal/EmbeddableBinder.java
@@ -59,10 +59,10 @@ import java.lang.reflect.Constructor;
 import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-import java.util.TreeMap;
 
 import static org.hibernate.boot.model.internal.AnnotatedDiscriminatorColumn.DEFAULT_DISCRIMINATOR_COLUMN_NAME;
 import static org.hibernate.boot.model.internal.AnnotatedDiscriminatorColumn.buildDiscriminatorColumn;
@@ -516,7 +516,7 @@ public class EmbeddableBinder {
 			final BasicType<?> discriminatorType = (BasicType<?>) component.getDiscriminator().getType();
 			// Discriminator values are used to construct the embeddable domain
 			// type hierarchy so order of processing is important
-			final Map<Object, String> discriminatorValues = new TreeMap<>();
+			final Map<Object, String> discriminatorValues = new LinkedHashMap<>();
 			collectDiscriminatorValue( returnedClassOrElement, discriminatorType, discriminatorValues );
 			collectSubclassElements(
 					propertyAccessor,

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/inheritance/embeddable/InheritedPropertyTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/inheritance/embeddable/InheritedPropertyTest.java
@@ -1,0 +1,120 @@
+/*
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.inheritance.embeddable;
+
+import jakarta.persistence.DiscriminatorColumn;
+import jakarta.persistence.Embeddable;
+import jakarta.persistence.Embedded;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+
+@DomainModel(
+		annotatedClasses = {
+				InheritedPropertyTest.Animal.class,
+				InheritedPropertyTest.Cat.class,
+				InheritedPropertyTest.Dog.class,
+				InheritedPropertyTest.Fish.class,
+				InheritedPropertyTest.Mammal.class,
+				InheritedPropertyTest.Owner.class
+		}
+)
+@SessionFactory
+public class InheritedPropertyTest {
+
+	@BeforeEach
+	void setUp(SessionFactoryScope scope) {
+		scope.inTransaction( session -> {
+			final var cat = new Cat();
+			cat.age = 7;
+			cat.name = "Jones";
+			cat.mother = "Kitty";
+			final var owner = new Owner();
+			owner.id = 1L;
+			owner.pet = cat;
+			session.persist( owner );
+		} );
+	}
+
+	@AfterEach
+	void tearDown(SessionFactoryScope scope) {
+		scope.inTransaction( session -> session.createMutationQuery( "delete from Owner" ).executeUpdate() );
+	}
+
+	@Test
+	void testInheritedProperty(SessionFactoryScope scope) {
+		assertDoesNotThrow( () -> scope.inSession(
+				session -> session.createQuery(
+						"select o from Owner o where treat(o.pet as InheritedPropertyTest$Cat).mother = :mother",
+						Owner.class ) ) );
+		scope.inSession(
+				session -> {
+					final var cats = session.createQuery(
+									"select o from Owner o where treat(o.pet as InheritedPropertyTest$Cat).mother = :mother",
+									Owner.class )
+							.setParameter( "mother", "Kitty" )
+							.getResultList();
+					assertEquals( 1, cats.size() );
+					final var owner = cats.get( 0 );
+					assertInstanceOf( Cat.class, owner.pet );
+					assertEquals( "Jones", owner.pet.name );
+					assertEquals( "Kitty", ((Cat) owner.pet).mother );
+				} );
+	}
+
+	@Test
+	void testDeclaredPropertyCreateQuery(SessionFactoryScope scope) {
+		assertDoesNotThrow( () -> scope.inSession(
+				session -> session.createQuery(
+						"select o from Owner o where treat(o.pet as InheritedPropertyTest$Mammal).mother = :mother",
+						Owner.class ) ) );
+	}
+
+	@Entity(name = "Owner")
+	public static class Owner {
+		@Id
+		Long id;
+
+		@Embedded
+		Animal pet;
+	}
+
+	@Embeddable
+	@DiscriminatorColumn(name = "animal_type")
+	public static class Animal {
+		int age;
+
+		String name;
+	}
+
+	@Embeddable
+	public static class Fish extends Animal {
+		int fins;
+	}
+
+	@Embeddable
+	public static class Mammal extends Animal {
+		String mother;
+	}
+
+	@Embeddable
+	public static class Cat extends Mammal {
+		// [...]
+	}
+
+	@Embeddable
+	public static class Dog extends Mammal {
+		// [...]
+	}
+}


### PR DESCRIPTION
Jira issue [HHH-19195](https://hibernate.atlassian.net/browse/HHH-19195)

To preserve hierarchical ordering of discriminator values `LinkedHashMap` should be used instead of `TreeMap`

----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------


[HHH-19195]: https://hibernate.atlassian.net/browse/HHH-19195?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ