### PR TITLE
HHH-19195 [6.6] Embeddable inheritance: discriminator values are not hierarchically orderedHhh 19195 6.6

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/boot/model/internal/EmbeddableBinder.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/internal/EmbeddableBinder.java
@@ -13,7 +13,6 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.TreeMap;
 
 import org.hibernate.AnnotationException;
 import org.hibernate.annotations.DiscriminatorFormula;
@@ -57,6 +56,7 @@ import jakarta.persistence.ManyToOne;
 import jakarta.persistence.MappedSuperclass;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.OneToOne;
+import java.util.LinkedHashMap;
 
 import static org.hibernate.boot.model.internal.AnnotatedDiscriminatorColumn.DEFAULT_DISCRIMINATOR_COLUMN_NAME;
 import static org.hibernate.boot.model.internal.AnnotatedDiscriminatorColumn.buildDiscriminatorColumn;
@@ -408,7 +408,7 @@ public class EmbeddableBinder {
 			final BasicType<?> discriminatorType = (BasicType<?>) component.getDiscriminator().getType();
 			// Discriminator values are used to construct the embeddable domain
 			// type hierarchy so order of processing is important
-			final Map<Object, String> discriminatorValues = new TreeMap<>();
+			final Map<Object, String> discriminatorValues = new LinkedHashMap<>();
 			collectDiscriminatorValue( returnedClassOrElement, discriminatorType, discriminatorValues );
 			collectSubclassElements(
 					propertyAccessor,

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/embeddable/discriminatorvalues/Animal.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/embeddable/discriminatorvalues/Animal.java
@@ -1,0 +1,18 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.orm.test.embeddable.discriminatorvalues;
+
+import jakarta.persistence.DiscriminatorColumn;
+import jakarta.persistence.Embeddable;
+
+@Embeddable
+@DiscriminatorColumn(name = "animal_type", length = 1)
+public class Animal {
+	private int age;
+
+	private String name;
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/embeddable/discriminatorvalues/Cat.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/embeddable/discriminatorvalues/Cat.java
@@ -1,0 +1,14 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.orm.test.embeddable.discriminatorvalues;
+
+import jakarta.persistence.Embeddable;
+
+@Embeddable
+public class Cat extends Mammal {
+	// [...]
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/embeddable/discriminatorvalues/Dog.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/embeddable/discriminatorvalues/Dog.java
@@ -1,0 +1,14 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.orm.test.embeddable.discriminatorvalues;
+
+import jakarta.persistence.Embeddable;
+
+@Embeddable
+public class Dog extends Mammal {
+	// [...]
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/embeddable/discriminatorvalues/EmbeddableInheritanceTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/embeddable/discriminatorvalues/EmbeddableInheritanceTest.java
@@ -1,0 +1,50 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.orm.test.embeddable.discriminatorvalues;
+
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+@DomainModel(
+		annotatedClasses = {
+				Animal.class,
+				Cat.class,
+				Dog.class,
+				Fish.class,
+				Mammal.class,
+				Owner.class
+		}
+)
+@SessionFactory
+public class EmbeddableInheritanceTest {
+
+	@Test
+	void testCatByMother(SessionFactoryScope scope) {
+		final List<Owner> owners = scope.fromSession(
+				session ->
+						session.createQuery( "select o from Owner o where treat(o.pet as Cat).mother = :mother",
+										Owner.class )
+								.setParameter( "mother", "Chloe" )
+								.getResultList() );
+		assertNotNull( owners );
+	}
+
+	@Test
+	void testCatMothers(SessionFactoryScope scope) {
+		final List<String> owners = scope.fromSession(
+				session ->
+						session.createNamedQuery( "catMothers", String.class )
+								.getResultList() );
+		assertNotNull( owners );
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/embeddable/discriminatorvalues/Fish.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/embeddable/discriminatorvalues/Fish.java
@@ -1,0 +1,14 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.orm.test.embeddable.discriminatorvalues;
+
+import jakarta.persistence.Embeddable;
+
+@Embeddable
+public class Fish extends Animal {
+	private int fins;
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/embeddable/discriminatorvalues/Mammal.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/embeddable/discriminatorvalues/Mammal.java
@@ -1,0 +1,14 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.orm.test.embeddable.discriminatorvalues;
+
+import jakarta.persistence.Embeddable;
+
+@Embeddable
+public class Mammal extends Animal {
+	private String mother;
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/embeddable/discriminatorvalues/Owner.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/embeddable/discriminatorvalues/Owner.java
@@ -1,0 +1,23 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.orm.test.embeddable.discriminatorvalues;
+
+
+import jakarta.persistence.Embedded;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.NamedQuery;
+
+@Entity
+@NamedQuery(name = "catMothers", query = "select treat(o.pet as Cat).mother from Owner o")
+public class Owner {
+	@Id
+	private Long id;
+
+	@Embedded
+	private Animal pet;
+}


### PR DESCRIPTION
Jira issue [HHH-19195](https://hibernate.atlassian.net/browse/HHH-19195)

To preserve hierarchical ordering of discriminator values `LinkedHashMap` should be used instead of `TreeMap`

----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------


[HHH-19195]: https://hibernate.atlassian.net/browse/HHH-19195?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ