### PR TITLE
Remove issues added to the changelog by mistake

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -10,8 +10,6 @@ https://hibernate.atlassian.net/projects/HHH/versions/32614
 
 ** Bug
     * [HHH-19173] - PostgreSQLLegacySqlAstTranslator does not implement visitInArrayPredicates
-    * [HHH-19169] - Entity hierarchy (and included embeddables) with inconsistent bytecode enhancement is unsupported, but isn't detected
-    * [HHH-19168] - Re-enhancement of entities with different configuration may skip some enhancements
     * [HHH-19116] - Error when using fk() function on left joined many-to-one association and is null predicate
     * [HHH-19110] - Flush operation fails with "UnsupportedOperationException: compare() not implemented for EntityType"
     * [HHH-17151] - NPE when binding null parameter in native query with explicit TemporalType


### PR DESCRIPTION
Please don't merge, we don't want a release just for this... Let's wait until we have other, more useful things merged into 6.6.

See https://hibernate.zulipchat.com/#narrow/channel/132094-hibernate-orm-dev/topic/Release.20automation.20and.20changelog


<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
