### PR TITLE
HHH-19076 expecting IdClass mapping sessionfactory error with specific @IdClass setup with inheritence

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/metamodel/internal/AttributeFactory.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/internal/AttributeFactory.java
@@ -737,11 +737,15 @@ public class AttributeFactory {
 
 	private static Member resolveEntityMember(Property property, EntityPersister declaringEntity) {
 		final String propertyName = property.getName();
-		final AttributeMapping attributeMapping = declaringEntity.findAttributeMapping( propertyName );
-		return attributeMapping == null
-				// just like in #determineIdentifierJavaMember , this *should* indicate we have an IdClass mapping
-				? resolveVirtualIdentifierMember( property, declaringEntity )
-				: getter( declaringEntity, property, propertyName, property.getType().getReturnedClass() );
+		if ( propertyName.equals( declaringEntity.getIdentifierPropertyName() ) ) {
+			final EntityIdentifierMapping mapping = declaringEntity.getIdentifierMapping();
+			if ( mapping == null ) {
+				// Member is identifier, but there is no identifier property mapping ...
+				// ... this *should* indicate we have an IdClass mapping
+				return resolveVirtualIdentifierMember( property, declaringEntity );
+			}
+		}
+		return getter( declaringEntity, property, propertyName, property.getType().getReturnedClass() );
 	}
 
 	private static Member resolveMappedSuperclassMember(

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/identifier/composite/CompositeInheritanceFailTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/identifier/composite/CompositeInheritanceFailTest.java
@@ -1,0 +1,129 @@
+/*
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.mapping.identifier.composite;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.IdClass;
+import jakarta.persistence.MappedSuperclass;
+import org.hibernate.cfg.AvailableSettings;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.Jira;
+import org.hibernate.testing.orm.junit.ServiceRegistry;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.hibernate.testing.orm.junit.Setting;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+/**
+ * This test Fails
+ */
+@DomainModel(
+		annotatedClasses = {
+				CompositeInheritanceFailTest.TupAbstractEntity.class,
+				CompositeInheritanceFailTest.DummyEntity.class,
+				CompositeInheritanceFailTest.TestEntity.class, // Here the class is called TestEntity
+		}
+)
+@ServiceRegistry(
+		settings = {
+				// For your own convenience to see generated queries:
+				@Setting(name = AvailableSettings.SHOW_SQL, value = "true"),
+				@Setting(name = AvailableSettings.FORMAT_SQL, value = "true"),
+				// @Setting( name = AvailableSettings.GENERATE_STATISTICS, value = "true" ),
+		}
+)
+@SessionFactory
+@Jira("HHH-19076")
+public class CompositeInheritanceFailTest {
+
+	@Test
+	void hhh19076FailingTest(SessionFactoryScope scope) {
+		scope.inTransaction( em -> {
+			TestEntity e1 = new TestEntity("foo", "bar");
+			em.persist(e1);
+
+			CompositeIdClass key = e1.getCompositeId();
+			TestEntity e2 = em.find(TestEntity.class, key);
+			assertNotNull(e2);
+		} );
+	}
+
+	@MappedSuperclass
+	public static abstract class TupAbstractEntity {
+		@Id
+		private String oid = null;
+
+
+		@SuppressWarnings("this-escape")
+		protected TupAbstractEntity() {
+		}
+
+		protected TupAbstractEntity(String oid) {
+			this.oid = oid;
+		}
+
+		public String getOid() {
+			return oid;
+		}
+
+	}
+
+	@Entity
+	public static class DummyEntity extends TupAbstractEntity {
+	}
+
+	@Entity
+	@IdClass(CompositeIdClass.class)
+	public static class TestEntity extends TupAbstractEntity {
+
+		@Id
+		private String myId;
+
+		protected TestEntity() {
+			// for JPA
+		}
+
+		public TestEntity(String oid, String myId) {
+			super(oid);
+			this.myId = myId;
+		}
+
+		public String myId() {
+			return myId;
+		}
+
+		public CompositeIdClass getCompositeId() {
+			return new CompositeIdClass(getOid(), myId);
+		}
+
+	}
+
+	public static class CompositeIdClass {
+
+		private String oid;
+		private String myId;
+
+		public CompositeIdClass(String oid, String myId) {
+			this.oid = oid;
+			this.myId = myId;
+		}
+
+		public CompositeIdClass() {
+		}
+
+		public String oid() {
+			return oid;
+		}
+
+		public String myId() {
+			return myId;
+		}
+
+	}
+
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/identifier/composite/CompositeInheritanceWorkingTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/identifier/composite/CompositeInheritanceWorkingTest.java
@@ -1,0 +1,129 @@
+/*
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.mapping.identifier.composite;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.IdClass;
+import jakarta.persistence.MappedSuperclass;
+import org.hibernate.cfg.AvailableSettings;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.Jira;
+import org.hibernate.testing.orm.junit.ServiceRegistry;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.hibernate.testing.orm.junit.Setting;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+/**
+ * This test works for some reason...
+ */
+@DomainModel(
+		annotatedClasses = {
+				CompositeInheritanceWorkingTest.TupAbstractEntity.class,
+				CompositeInheritanceWorkingTest.DummyEntity.class,
+				CompositeInheritanceWorkingTest.FooEntity.class, // And here the class is called FooEntity and this works for some reason
+		}
+)
+@ServiceRegistry(
+		settings = {
+				// For your own convenience to see generated queries:
+				@Setting(name = AvailableSettings.SHOW_SQL, value = "true"),
+				@Setting(name = AvailableSettings.FORMAT_SQL, value = "true"),
+				// @Setting( name = AvailableSettings.GENERATE_STATISTICS, value = "true" ),
+		}
+)
+@SessionFactory
+@Jira("HHH-19076")
+public class CompositeInheritanceWorkingTest {
+
+	@Test
+	void hhh19076WorkingTest(SessionFactoryScope scope) {
+		scope.inTransaction( em -> {
+			FooEntity e1 = new FooEntity("foo", "bar");
+			em.persist(e1);
+
+			CompositeIdClass key = e1.getCompositeId();
+			FooEntity e2 = em.find( FooEntity.class, key);
+			assertNotNull(e2);
+		} );
+	}
+
+	@MappedSuperclass
+	public static abstract class TupAbstractEntity {
+		@Id
+		private String oid = null;
+
+
+		@SuppressWarnings("this-escape")
+		protected TupAbstractEntity() {
+		}
+
+		protected TupAbstractEntity(String oid) {
+			this.oid = oid;
+		}
+
+		public String getOid() {
+			return oid;
+		}
+
+	}
+
+	@Entity
+	public static class DummyEntity extends TupAbstractEntity {
+	}
+
+	@Entity
+	@IdClass(CompositeIdClass.class)
+	public static class FooEntity extends TupAbstractEntity {
+
+		@Id
+		private String myId;
+
+		protected FooEntity() {
+			// for JPA
+		}
+
+		public FooEntity(String oid, String myId) {
+			super(oid);
+			this.myId = myId;
+		}
+
+		public String myId() {
+			return myId;
+		}
+
+		public CompositeIdClass getCompositeId() {
+			return new CompositeIdClass(getOid(), myId);
+		}
+
+	}
+
+	public static class CompositeIdClass {
+
+		private String oid;
+		private String myId;
+
+		public CompositeIdClass(String oid, String myId) {
+			this.oid = oid;
+			this.myId = myId;
+		}
+
+		public CompositeIdClass() {
+		}
+
+		public String oid() {
+			return oid;
+		}
+
+		public String myId() {
+			return myId;
+		}
+
+	}
+
+}


### PR DESCRIPTION
Jira issue [HHH-19076](https://hibernate.atlassian.net/browse/HHH-19076)

If property name is equal to entity property identifier name, but entity property mapping is null, then member should be resolved as virtual identifier member. Otherwise, it should be resolved using `getter` method-


----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------


[HHH-19076]: https://hibernate.atlassian.net/browse/HHH-19076?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ