### PR TITLE
get rid of extremely useless log messages

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/jpa/internal/PersistenceUnitUtilImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/jpa/internal/PersistenceUnitUtilImpl.java
@@ -16,8 +16,6 @@ import org.hibernate.jpa.internal.util.PersistenceUtilHelper;
 import org.hibernate.persister.entity.EntityPersister;
 import org.hibernate.proxy.LazyInitializer;
 
-import org.jboss.logging.Logger;
-
 import static jakarta.persistence.spi.LoadState.NOT_LOADED;
 import static org.hibernate.engine.internal.ManagedTypeHelper.asManagedEntity;
 import static org.hibernate.engine.internal.ManagedTypeHelper.isManagedEntity;
@@ -30,7 +28,6 @@ import static org.hibernate.proxy.HibernateProxy.extractLazyInitializer;
  * @author Steve Ebersole
  */
 public class PersistenceUnitUtilImpl implements PersistenceUnitUtil, Serializable {
-	private static final Logger log = Logger.getLogger( PersistenceUnitUtilImpl.class );
 
 	private final SessionFactoryImplementor sessionFactory;
 	private final transient PersistenceUtilHelper.MetadataCache cache = new PersistenceUtilHelper.MetadataCache();
@@ -41,16 +38,11 @@ public class PersistenceUnitUtilImpl implements PersistenceUnitUtil, Serializabl
 
 	@Override
 	public boolean isLoaded(Object entity, String attributeName) {
-		// added log message to help with HHH-7454, if state == LoadState,NOT_LOADED, returning true or false is not accurate.
-		log.debug( "PersistenceUnitUtil#isLoaded is not always accurate; consider using EntityManager#contains instead" );
-		switch ( isLoadedWithoutReference( entity, attributeName, cache ) ) {
-			case LOADED:
-				return true;
-			case NOT_LOADED:
-				return false;
-			default:
-				return isLoadedWithReference( entity, attributeName, cache ) != NOT_LOADED;
-		}
+		return switch ( isLoadedWithoutReference( entity, attributeName, cache ) ) {
+			case LOADED -> true;
+			case NOT_LOADED -> false;
+			default -> isLoadedWithReference( entity, attributeName, cache ) != NOT_LOADED;
+		};
 	}
 
 	@Override
@@ -60,8 +52,6 @@ public class PersistenceUnitUtilImpl implements PersistenceUnitUtil, Serializabl
 
 	@Override
 	public boolean isLoaded(Object entity) {
-		// added log message to help with HHH-7454, if state == LoadState,NOT_LOADED, returning true or false is not accurate.
-		log.debug( "PersistenceUnitUtil#isLoaded is not always accurate; consider using EntityManager#contains instead" );
 		return getLoadState( entity ) != NOT_LOADED;
 	}
 
@@ -106,17 +96,10 @@ public class PersistenceUnitUtilImpl implements PersistenceUnitUtil, Serializabl
 				return entityEntry.getId();
 			}
 			else {
-				// HHH-11426 - best effort to deal with the case of detached entities
-				log.debug( "jakarta.persistence.PersistenceUnitUtil.getIdentifier may not be able to read identifier of a detached entity" );
 				return getIdentifierFromPersister( entity );
 			}
 		}
 		else {
-			log.debug(
-					"jakarta.persistence.PersistenceUnitUtil.getIdentifier is only intended to work with enhanced entities " +
-							"(although Hibernate also adapts this support to its proxies); " +
-							"however the passed entity was not enhanced (nor a proxy).. may not be able to read identifier"
-			);
 			return getIdentifierFromPersister( entity );
 		}
 	}


### PR DESCRIPTION
These messages were added in HHH-7454 and HHH-11426.

- I'm pretty sure that the claim made in HHH-7454 is simply incorrect, whereas the message added in
- On the other hand, HHH-11426 is warning about an error that might, but probably won't occur.

<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

[Please describe here what your change is about]

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
