### PR TITLE
HHH-19205 Do not recreate the validator on each BeanValidationEventListener#validate call

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/boot/beanvalidation/HibernateTraversableResolver.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/beanvalidation/HibernateTraversableResolver.java
@@ -5,9 +5,10 @@
 package org.hibernate.boot.beanvalidation;
 
 import java.lang.annotation.ElementType;
+import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
 
 import org.hibernate.AssertionFailure;
 import org.hibernate.Hibernate;
@@ -30,32 +31,27 @@ import jakarta.validation.TraversableResolver;
  * @author Emmanuel Bernard
  */
 public class HibernateTraversableResolver implements TraversableResolver {
-	private Set<String> associations;
+	private final Map<Class<?>, Set<String>> associationsPerEntityClass = new HashMap<>();
 
-	public HibernateTraversableResolver(
-			EntityPersister persister,
-			ConcurrentHashMap<EntityPersister, Set<String>> associationsPerEntityPersister,
-			SessionFactoryImplementor factory) {
-		associations = associationsPerEntityPersister.get( persister );
-		if ( associations == null ) {
-			associations = new HashSet<>();
-			addAssociationsToTheSetForAllProperties( persister.getPropertyNames(), persister.getPropertyTypes(), "", factory );
-			associationsPerEntityPersister.put( persister, associations );
-		}
+	public void addPersister(EntityPersister persister, SessionFactoryImplementor factory) {
+		Class<?> javaTypeClass = persister.getEntityMappingType().getMappedJavaType().getJavaTypeClass();
+		Set<String> associations = new HashSet<>();
+		addAssociationsToTheSetForAllProperties( persister.getPropertyNames(), persister.getPropertyTypes(), "", factory, associations );
+		associationsPerEntityClass.put( javaTypeClass, associations );
 	}
 
-	private void addAssociationsToTheSetForAllProperties(
-			String[] names, Type[] types, String prefix, SessionFactoryImplementor factory) {
+	private static void addAssociationsToTheSetForAllProperties(
+			String[] names, Type[] types, String prefix, SessionFactoryImplementor factory, Set<String> associations) {
 		final int length = names.length;
 		for( int index = 0 ; index < length; index++ ) {
-			addAssociationsToTheSetForOneProperty( names[index], types[index], prefix, factory );
+			addAssociationsToTheSetForOneProperty( names[index], types[index], prefix, factory, associations );
 		}
 	}
 
-	private void addAssociationsToTheSetForOneProperty(
-			String name, Type type, String prefix, SessionFactoryImplementor factory) {
+	private static void addAssociationsToTheSetForOneProperty(
+			String name, Type type, String prefix, SessionFactoryImplementor factory, Set<String> associations) {
 		if ( type instanceof CollectionType collectionType ) {
-			addAssociationsToTheSetForOneProperty( name, collectionType.getElementType( factory ), prefix, factory );
+			addAssociationsToTheSetForOneProperty( name, collectionType.getElementType( factory ), prefix, factory, associations );
 		}
 		//ToOne association
 		else if ( type instanceof EntityType || type instanceof AnyType ) {
@@ -66,7 +62,8 @@ public class HibernateTraversableResolver implements TraversableResolver {
 					componentType.getPropertyNames(),
 					componentType.getSubtypes(),
 					( prefix.isEmpty() ? name : prefix + name ) + '.',
-					factory
+					factory,
+					associations
 			);
 		}
 	}
@@ -102,6 +99,6 @@ public class HibernateTraversableResolver implements TraversableResolver {
 			Class<?> rootBeanType,
 			Path pathToTraversableObject,
 			ElementType elementType) {
-		return !associations.contains( getStringBasedPath( traversableProperty, pathToTraversableObject ) );
+		return !associationsPerEntityClass.getOrDefault( rootBeanType, Set.of() ).contains( getStringBasedPath( traversableProperty, pathToTraversableObject ) );
 	}
 }


### PR DESCRIPTION
Hey @gavinking , @beikov 

Since you've been talking about the validator in the other PR 😄 it got me interested. 
The fact that we recreate the validator on each validate call feels a bit redundant, so I've started looking into it. And this PR is where I got so far.

It would be nice if we wouldn't need to have that `traversableResolver.addPersisterIfNecessary( persister, sessionFactory );` I've added. But to get rid of it, we need to have access to the built SF (not the one being built that we can get our hands on right now from the integrator). Would it make sense to add some `Integrator#postintegrate(Sf sf... )` method that is called at the very end of the SF constructor, then eagerly build the association map? 
Or am I missing something here 😄  


<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-19205
<!-- Hibernate GitHub Bot issue links end -->