### PR TITLE
HHH-19208 Adapt javadoc of QuerySettings.QUERY_PLAN_CACHE_ENABLED

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/cfg/QuerySettings.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/QuerySettings.java
@@ -252,9 +252,8 @@ public interface QuerySettings {
 	 * When enabled, specifies that {@linkplain QueryPlan query plans} should be
 	 * {@linkplain org.hibernate.query.spi.QueryInterpretationCache cached}.
 	 * <p>
-	 * By default, the query plan cache is disabled, unless one of the configuration
-	 * properties {@value #QUERY_PLAN_CACHE_MAX_SIZE} or
-	 * {@value #QUERY_PLAN_CACHE_PARAMETER_METADATA_MAX_SIZE} is set.
+	 * By default, the query plan cache is enabled. It is also enabled if the configuration
+	 * property {@value #QUERY_PLAN_CACHE_MAX_SIZE} is set.
 	 */
 	String QUERY_PLAN_CACHE_ENABLED = "hibernate.query.plan_cache_enabled";
 

--- a/hibernate-core/src/main/java/org/hibernate/cfg/QuerySettings.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/QuerySettings.java
@@ -254,6 +254,8 @@ public interface QuerySettings {
 	 * <p>
 	 * By default, the query plan cache is enabled. It is also enabled if the configuration
 	 * property {@value #QUERY_PLAN_CACHE_MAX_SIZE} is set.
+	 *
+	 * @settingDefault {@code true} (enabled) - query plan cache is enabled.
 	 */
 	String QUERY_PLAN_CACHE_ENABLED = "hibernate.query.plan_cache_enabled";
 


### PR DESCRIPTION
Adapts the javadoc of `QuerySettings.QUERY_PLAN_CACHE_ENABLED` as it doesn't reflect how it is used in `org.hibernate.query.internal.QueryEngineImpl.buildInterpretationCache`.

https://hibernate.atlassian.net/browse/HHH-19208

----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
