### PR TITLE
HHH-19185 Follow up on test update from 44918d69228f1ac8dd77f512d099d859276e1286

### DIFF
--- a/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/orphan/onetoone/OneToOneLazyOrphanRemovalEmbeddedTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/orphan/onetoone/OneToOneLazyOrphanRemovalEmbeddedTest.java
@@ -92,14 +92,14 @@ public class OneToOneLazyOrphanRemovalEmbeddedTest {
 		@OneToOne(orphanRemoval = true, fetch = FetchType.LAZY)
 		private ChildEntity child;
 
-		private Integer count;
+		private Integer countValue;
 
 		public ToOneContainer() {
 		}
 
-		public ToOneContainer(ChildEntity child, Integer count) {
+		public ToOneContainer(ChildEntity child, Integer countValue) {
 			this.child = child;
-			this.count = count;
+			this.countValue = countValue;
 		}
 
 		public ChildEntity getChild() {


### PR DESCRIPTION
Hey @mbladel 
I was looking at some tests that failed in the other PR and noticed that this one fails on sybase with:

```
OneToOneLazyOrphanRemovalEmbeddedTest > initializationError FAILED
    org.hibernate.exception.GenericJDBCException: could not execute statement [Incorrect syntax near the keyword 'count'.
    ] [insert into OwnerEntity (child_id,count,id) values (?,?,?)]
        at app//org.hibernate.exception.internal.StandardSQLExceptionConverter.convert(StandardSQLExceptionConverter.java:61)
```
https://github.com/hibernate/hibernate-orm/actions/runs/13576066171/job/37952476819?pr=9822

IDK if the tests should just quote the keywords or what the general approach is, but since... I suppose this test wasn't really about keywords, maybe let's just rename the property/column and make the build happier ? 😄

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-19185
<!-- Hibernate GitHub Bot issue links end -->