### PR TITLE
HHH-19215 Extends Dialect#addQueryHints to support straight_join syntax

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/dialect/Dialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/Dialect.java
@@ -283,7 +283,7 @@ public abstract class Dialect implements ConversionContext, TypeContributor, Fun
 	private static final Pattern ESCAPE_CLOSING_COMMENT_PATTERN = Pattern.compile( "\\*/" );
 	private static final Pattern ESCAPE_OPENING_COMMENT_PATTERN = Pattern.compile( "/\\*" );
 	private static final Pattern QUERY_PATTERN = Pattern.compile(
-		"^\\s*(select\\b.+?\\bfrom\\b.+?)(\\b(?:natural )?(?:left |right |full )?(?:inner |outer |cross )?join.+?\\b)?(\\bwhere\\b.+?)$");
+		"^\\s*(select\\b.+?\\bfrom\\b.+?)(\\b(?:(?:natural )?(?:left |right |full )?(?:inner |outer |cross )?join |straight_join).+?\\b)?(\\bwhere\\b.+?)$");
 
 	private static final CoreMessageLogger LOG = Logger.getMessageLogger( MethodHandles.lookup(), CoreMessageLogger.class, Dialect.class.getName() );
 

--- a/hibernate-core/src/test/java/org/hibernate/dialect/DialectTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/dialect/DialectTest.java
@@ -39,6 +39,14 @@ class DialectTest {
 		builder.add(Arguments.of("Left join query with on : hint",
 			"select COUNT(*) from TEST t1_0  use index (MY_INDEX) left join TEST2 t2_0 on t1_0.column2 = t2_0.column2 and t1_0.column3 = t2_0.column3 where field = 'value'",
 			leftJoinQuery, hints));
+		final String straightJoinQueryUsing = "select COUNT(*) from TEST t1_0 straight_join TEST2 t2_0 using(column2) where field = 'value'";
+		builder.add(Arguments.of("Straight join query with using : hint",
+				"select COUNT(*) from TEST t1_0  use index (MY_INDEX) straight_join TEST2 t2_0 using(column2) where field = 'value'",
+				straightJoinQueryUsing, hints));
+		final String straightJoinQueryOn = "select COUNT(*) from TEST t1_0 straight_join TEST2 t2_0 on t1_0.column2 = t2_0.column2 where field = 'value'";
+		builder.add(Arguments.of("Straight join query with on : hint",
+				"select COUNT(*) from TEST t1_0  use index (MY_INDEX) straight_join TEST2 t2_0 on t1_0.column2 = t2_0.column2 where field = 'value'",
+				straightJoinQueryOn, hints));
 
 		return builder.build();
 	}


### PR DESCRIPTION
The goal is to expand the coverage of the query pattern as both MySQL and SingleStore support `straight_join` syntax, and their dialect classes rely on `Dialect` class to add index hints.

Example use case:
```java
Session session = entityManager.unwrap(Session.class);
String query = "select * from table1 straight_join table2 on table1.column1 = table2.column1 where table1.column2 = 'value1' and table1.column3 = 'value2'";

List result = session
       .createNativeQuery(query, Table1.class)
       .addQueryHint("index_column3")
       .getResultList();
```

While there may be cases where this is useful, it could be considered a relatively unique situation.
If this change conflicts with the original intent, I understand if it is not accepted.

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
