### PR TITLE
HHH-14694 Don't clear BytecodeProvider cache when SessionFactory is built or closed

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/boot/internal/SessionFactoryBuilderImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/internal/SessionFactoryBuilderImpl.java
@@ -19,8 +19,6 @@ import org.hibernate.boot.spi.BootstrapContext;
 import org.hibernate.boot.spi.MetadataImplementor;
 import org.hibernate.boot.spi.SessionFactoryBuilderImplementor;
 import org.hibernate.boot.spi.SessionFactoryOptions;
-import org.hibernate.bytecode.internal.SessionFactoryObserverForBytecodeEnhancer;
-import org.hibernate.bytecode.spi.BytecodeProvider;
 import org.hibernate.cache.spi.TimestampsCacheFactory;
 import org.hibernate.context.spi.CurrentTenantIdentifierResolver;
 import org.hibernate.internal.SessionFactoryImpl;
@@ -63,10 +61,11 @@ public class SessionFactoryBuilderImpl implements SessionFactoryBuilderImplement
 			}
 		}
 
-		final BytecodeProvider bytecodeProvider =
-				metadata.getMetadataBuildingOptions().getServiceRegistry()
-						.getService( BytecodeProvider.class );
-		addSessionFactoryObservers( new SessionFactoryObserverForBytecodeEnhancer( bytecodeProvider ) );
+		// Don't clear the state anymore, since the cache is not static anymore since HHH-16058 was fixed
+//		final BytecodeProvider bytecodeProvider =
+//				metadata.getMetadataBuildingOptions().getServiceRegistry()
+//						.getService( BytecodeProvider.class );
+//		addSessionFactoryObservers( new SessionFactoryObserverForBytecodeEnhancer( bytecodeProvider ) );
 		addSessionFactoryObservers( new SessionFactoryObserverForNamedQueryValidation( metadata ) );
 		addSessionFactoryObservers( new SessionFactoryObserverForSchemaExport( metadata ) );
 		addSessionFactoryObservers( new SessionFactoryObserverForRegistration() );

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/proxy/ProxyClassReuseTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/proxy/ProxyClassReuseTest.java
@@ -1,0 +1,79 @@
+/*
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.proxy;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import org.hibernate.boot.MetadataSources;
+import org.hibernate.boot.registry.StandardServiceRegistry;
+import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
+import org.hibernate.bytecode.internal.bytebuddy.BytecodeProviderImpl;
+import org.hibernate.bytecode.spi.BytecodeProvider;
+import org.hibernate.engine.spi.SessionFactoryImplementor;
+import org.hibernate.engine.spi.SessionImplementor;
+import org.hibernate.testing.orm.junit.Jira;
+import org.hibernate.testing.util.ServiceRegistryUtil;
+import org.junit.jupiter.api.Test;
+
+import java.util.function.Function;
+
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+@Jira("https://hibernate.atlassian.net/browse/HHH-14694")
+public class ProxyClassReuseTest {
+
+	@Test
+	void testReuse() {
+		Function<SessionFactoryImplementor, Class<?>> proxyGetter = sf -> {
+			try (SessionImplementor s = sf.openSession()) {
+				return s.getReference( MyEntity.class, "abc" ).getClass();
+			}
+		};
+		final BytecodeProvider bytecodeProvider = new BytecodeProviderImpl();
+		Class<?> proxyClass1 = withFactory( proxyGetter, bytecodeProvider );
+		Class<?> proxyClass2 = withFactory( proxyGetter, bytecodeProvider );
+		assertSame( proxyClass1, proxyClass2 );
+	}
+
+	@Test
+	void testNoReuse() {
+		Function<SessionFactoryImplementor, Class<?>> proxyGetter = sf -> {
+			try (SessionImplementor s = sf.openSession()) {
+				return s.getReference( MyEntity.class, "abc" ).getClass();
+			}
+		};
+		Class<?> proxyClass1 = withFactory( proxyGetter, null );
+		Class<?> proxyClass2 = withFactory( proxyGetter, null );
+		assertNotSame( proxyClass1, proxyClass2 );
+	}
+
+	<T> T withFactory(Function<SessionFactoryImplementor, T> consumer, BytecodeProvider bytecodeProvider) {
+		final StandardServiceRegistryBuilder builder = ServiceRegistryUtil.serviceRegistryBuilder();
+		if ( bytecodeProvider != null ) {
+			builder.addService( BytecodeProvider.class, bytecodeProvider );
+		}
+		final StandardServiceRegistry ssr = builder.build();
+
+		try (final SessionFactoryImplementor sf = (SessionFactoryImplementor) new MetadataSources( ssr )
+				.addAnnotatedClass( MyEntity.class )
+				.buildMetadata()
+				.getSessionFactoryBuilder()
+				.build()) {
+			return consumer.apply( sf );
+		}
+		catch ( Exception e ) {
+			StandardServiceRegistryBuilder.destroy( ssr );
+			throw e;
+		}
+	}
+
+	@Entity(name = "MyEntity")
+	public static class MyEntity {
+		@Id
+		String id;
+		String name;
+	}
+}


### PR DESCRIPTION
<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
