### PR TITLE
HHH-19218 use a stronger hashing function for cache keys

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/cache/internal/BasicCacheKeyImplementation.java
+++ b/hibernate-core/src/main/java/org/hibernate/cache/internal/BasicCacheKeyImplementation.java
@@ -55,7 +55,16 @@ public final class BasicCacheKeyImplementation implements Serializable {
 	}
 
 	private static int calculateHashCode(Object disassembledKey, Type type) {
-		return type.getHashCode( disassembledKey );
+		return hash( type.getHashCode( disassembledKey ) );
+	}
+
+	@Internal
+	public static int hash(int h) {
+		// Mix the result with the Murmur3 finalising function
+		h = (h ^ (h >>> 16)) * 0x85ebca6b;
+		h = (h ^ (h >>> 13)) * 0xc2b2ae35;
+		h = h ^ (h >>> 16);
+		return h;
 	}
 
 	public Object getId() {

--- a/hibernate-core/src/main/java/org/hibernate/cache/internal/CacheKeyImplementation.java
+++ b/hibernate-core/src/main/java/org/hibernate/cache/internal/CacheKeyImplementation.java
@@ -81,7 +81,7 @@ public final class CacheKeyImplementation implements Serializable {
 	private static int calculateHashCode(Object id, Type type, String tenantId) {
 		int result = type.getHashCode( id );
 		result = 31 * result + ( tenantId != null ? tenantId.hashCode() : 0 );
-		return result;
+		return BasicCacheKeyImplementation.hash( result );
 	}
 
 	public Object getId() {

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/querycache/QueryRestrictedCollectionCachingTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/querycache/QueryRestrictedCollectionCachingTests.java
@@ -131,7 +131,7 @@ public class QueryRestrictedCollectionCachingTests {
 		final CollectionReadWriteAccess authorsRegionAccess = (CollectionReadWriteAccess) cache.getCollectionRegionAccess( navigableRole );
 
 		final MapStorageAccessImpl storageAccess = (MapStorageAccessImpl) authorsRegionAccess.getStorageAccess();
-		final BasicCacheKeyImplementation cacheKey = new BasicCacheKeyImplementation( ownerKey, role, ownerKey );
+		final BasicCacheKeyImplementation cacheKey = new BasicCacheKeyImplementation( ownerKey, role, BasicCacheKeyImplementation.hash( ownerKey ) );
 		final AbstractReadWriteAccess.Item cacheItem = (AbstractReadWriteAccess.Item) storageAccess.getFromData( cacheKey );
 		assertThat( cacheItem ).isNotNull();
 


### PR DESCRIPTION
<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

Use a stronger hashing function for cache keys to assist in a uniform distribution within the hash table. This [mitigates](https://gist.github.com/ben-manes/6312727adfa2235cb7c5e25cae523ad0) a performance regression in Ehcache due to clustering effects resulting in an O(n) eviction.

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-19218
<!-- Hibernate GitHub Bot issue links end -->