### PR TITLE
Add methods to MutationExecutorStandard for Hibernate reactive

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/engine/jdbc/mutation/internal/MutationExecutorStandard.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/jdbc/mutation/internal/MutationExecutorStandard.java
@@ -171,8 +171,18 @@ public class MutationExecutorStandard extends AbstractMutationExecutor implement
 	}
 
 	//Used by Hibernate Reactive
+	protected PreparedStatementGroup getBatchedPreparedStatementGroup() {
+		return this.batch != null ? this.batch.getStatementGroup() : null;
+	}
+
+	//Used by Hibernate Reactive
 	protected PreparedStatementGroup getNonBatchedStatementGroup() {
 		return nonBatchedStatementGroup;
+	}
+
+	//Used by Hibernate Reactive
+	protected List<SelfExecutingUpdateOperation> getSelfExecutingMutations() {
+		return selfExecutingMutations;
 	}
 
 	@Override


### PR DESCRIPTION
These changes are needed by Hibernate reactive, see https://github.com/hibernate/hibernate-reactive/pull/2141

----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
