### PR TITLE
Fix Spatial functions tests

### DIFF
--- a/hibernate-spatial/src/test/java/org/hibernate/spatial/integration/functions/CommonFunctionTests.java
+++ b/hibernate-spatial/src/test/java/org/hibernate/spatial/integration/functions/CommonFunctionTests.java
@@ -41,7 +41,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 @SuppressWarnings("rawtypes")
 @RequiresDialectFeature(feature = IsSupportedBySpatial.class)
 @SessionFactory
-@SkipForDialect(dialectClass = OracleDialect.class, majorVersion = 11, reason = "See https://hibernate.atlassian.net/browse/HHH-15669")
+@SkipForDialect(dialectClass = OracleDialect.class, reason = "See https://hibernate.atlassian.net/browse/HHH-15669")
 public class CommonFunctionTests extends SpatialTestBase {
 
 	public final static TestSupport.TestDataPurpose PURPOSE = TestSupport.TestDataPurpose.SpatialFunctionsData;

--- a/hibernate-spatial/src/test/java/org/hibernate/spatial/testing/SpatialSessionFactoryAware.java
+++ b/hibernate-spatial/src/test/java/org/hibernate/spatial/testing/SpatialSessionFactoryAware.java
@@ -40,7 +40,8 @@ public abstract class SpatialSessionFactoryAware extends SpatialTestDataProvider
 	}
 
 	public boolean isSupported(CommonSpatialFunction function) {
-		return supportedFunctions.contains( function.name() );
+		return supportedFunctions.contains( function.getKey().getName() ) ||
+			( function.getKey().getAltName().isPresent() && supportedFunctions.contains( function.getKey().getAltName().get() ) );
 	}
 
 	protected void initH2GISExtensionsForInMemDb() {


### PR DESCRIPTION
The TestFactory in CommonFunctionTests no longer created any tests because the `isSupported` function always returned false due to case mismatch.

The case mismatch is likely due to a change in how the SQMFunctionRegistry returns the function keys.

----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
