### PR TITLE
HHH-19109 fix use of @TransactionScoped by repository

### DIFF
--- a/tooling/metamodel-generator/src/main/java/org/hibernate/processor/HibernateProcessor.java
+++ b/tooling/metamodel-generator/src/main/java/org/hibernate/processor/HibernateProcessor.java
@@ -234,9 +234,9 @@ public class HibernateProcessor extends AbstractProcessor {
 		final PackageElement jakartaContextPackage =
 				context.getProcessingEnvironment().getElementUtils()
 						.getPackageElement( "jakarta.enterprise.context" );
-		final PackageElement jakartaTransactionsPackage =
+		final PackageElement jakartaTransactionPackage =
 				context.getProcessingEnvironment().getElementUtils()
-						.getPackageElement( "jakarta.transactions" );
+						.getPackageElement( "jakarta.transaction" );
 		final PackageElement jakartaDataPackage =
 				context.getProcessingEnvironment().getElementUtils()
 						.getPackageElement( "jakarta.data" );
@@ -267,7 +267,7 @@ public class HibernateProcessor extends AbstractProcessor {
 		context.setAddNonnullAnnotation( packagePresent(jakartaAnnotationPackage) );
 		context.setAddGeneratedAnnotation( packagePresent(jakartaAnnotationPackage) );
 		context.setAddDependentAnnotation( packagePresent(jakartaContextPackage) );
-		context.setAddTransactionScopedAnnotation( packagePresent(jakartaTransactionsPackage) );
+		context.setAddTransactionScopedAnnotation( packagePresent(jakartaTransactionPackage) );
 		context.setDataEventPackageAvailable( packagePresent(dataEventPackage) );
 		context.setQuarkusInjection( packagePresent(quarkusOrmPackage) );
 		context.setUsesQuarkusOrm( packagePresent(quarkusOrmPanachePackage) );


### PR DESCRIPTION
presence of JTA was not detected due to misspelling of package name

<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

[Please describe here what your change is about]

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-19109
<!-- Hibernate GitHub Bot issue links end -->