### PR TITLE
HHH-19247 Add ordinal() to TypeContributor

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/boot/model/TypeContributor.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/TypeContributor.java
@@ -41,4 +41,21 @@ public interface TypeContributor {
 	 * @param serviceRegistry The service registry
 	 */
 	void contribute(TypeContributions typeContributions, ServiceRegistry serviceRegistry);
+
+	/**
+	 * Determines order in which the contributions will be applied
+	 * (lowest ordinal first).
+	 * <p>
+	 * The range 0-500 is reserved for Hibernate, range 500-1000 for libraries and
+	 * 1000-Integer.MAX_VALUE for user-defined TypeContributors.
+	 * <p>
+	 * Contributions from higher precedence contributors (higher numbers) effectively override
+	 * contributions from lower precedence.  E.g. if a contributor with precedence 2000 contributes
+	 * some type, that will override Hibernate's standard type of that name.
+	 *
+	 * @return the ordinal for this TypeContributor
+	 */
+	default int ordinal(){
+		return 1000;
+	}
 }

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/type/contributor/usertype/TypeContributionOrdinalTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/type/contributor/usertype/TypeContributionOrdinalTest.java
@@ -1,0 +1,77 @@
+package org.hibernate.orm.test.type.contributor.usertype;
+
+import org.hibernate.boot.model.TypeContributions;
+import org.hibernate.boot.model.TypeContributor;
+import org.hibernate.service.ServiceRegistry;
+
+import org.hibernate.testing.orm.junit.BootstrapServiceRegistry;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.Jira;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+
+import org.hibernate.type.descriptor.jdbc.VarcharJdbcType;
+import org.hibernate.type.spi.TypeConfiguration;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test to assert that service loaded types are processed in ascending ordinal order
+ *
+ * @author Steven Barendregt
+ */
+@DomainModel
+@SessionFactory
+@BootstrapServiceRegistry(
+		javaServices = {
+				@BootstrapServiceRegistry.JavaService(role = TypeContributor.class, impl = TypeContributionOrdinalTest.HigherOrdinalServiceLoadedVarcharTypeContributor.class),
+				@BootstrapServiceRegistry.JavaService(role = TypeContributor.class, impl = TypeContributionOrdinalTest.ServiceLoadedVarcharTypeContributor.class)
+		}
+)
+public class TypeContributionOrdinalTest {
+
+	@Test
+	@Jira(value = "https://hibernate.atlassian.net/issues/HHH-19247")
+	public void testHigherOrdinalServiceLoadedCustomUserTypeTakesPrecedence(SessionFactoryScope scope) {
+		final TypeConfiguration typeConfigurations = scope.getSessionFactory()
+				.getMappingMetamodel()
+				.getTypeConfiguration();
+		Assertions.assertInstanceOf(
+				HigherOrdinalServiceLoadedVarcharTypeContributor.HigherOrdinalExtendedVarcharJdbcType.class,
+				typeConfigurations.getJdbcTypeRegistry().findDescriptor( 12 )
+		);
+	}
+
+	public static class ServiceLoadedVarcharTypeContributor implements TypeContributor {
+
+		@Override
+		public void contribute(TypeContributions typeContributions, ServiceRegistry serviceRegistry) {
+			typeContributions.contributeJdbcType( ExtendedVarcharJdbcType.INSTANCE );
+		}
+
+		public static class ExtendedVarcharJdbcType extends VarcharJdbcType {
+
+			public static final ExtendedVarcharJdbcType INSTANCE = new ExtendedVarcharJdbcType();
+		}
+
+	}
+
+	public static class HigherOrdinalServiceLoadedVarcharTypeContributor implements TypeContributor {
+
+		@Override
+		public void contribute(TypeContributions typeContributions, ServiceRegistry serviceRegistry) {
+			typeContributions.contributeJdbcType( HigherOrdinalExtendedVarcharJdbcType.INSTANCE );
+		}
+
+		@Override
+		public int ordinal() {
+			return 2000;
+		}
+
+		public static class HigherOrdinalExtendedVarcharJdbcType extends VarcharJdbcType {
+
+			public static final HigherOrdinalExtendedVarcharJdbcType INSTANCE = new HigherOrdinalExtendedVarcharJdbcType();
+		}
+	}
+}


### PR DESCRIPTION
<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

The FunctionContributor already has an ordinal() method to be able to influence the order in which function contributions are loaded.
The same mechanism would be helpful for Type contributions. 
In our specific use case we need to override the SDOGeometryType, contributed by Hibernate Spatial, with our own custom type, for handling complex arcs.
In Hibernate 5 this worked well with a custom dialect, but with Hibernate 6 it is not possible anymore to override previously added types during service loading by changing the order in which they are loaded.

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-19247
<!-- Hibernate GitHub Bot issue links end -->