### PR TITLE
HHH-19265 deprecate hibernate.jdbc.use_scrollable_resultset

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/cfg/JdbcSettings.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/JdbcSettings.java
@@ -405,13 +405,12 @@ public interface JdbcSettings extends C3p0Settings, AgroalSettings, HikariCPSett
 	String STATEMENT_FETCH_SIZE = "hibernate.jdbc.fetch_size";
 
 	/**
-	 * Controls how Hibernate should handle scrollable results - <ul>
-	 * 	 <li>
-	 * 	     {@code true} indicates that {@linkplain java.sql.ResultSet#TYPE_SCROLL_INSENSITIVE insensitive} scrolling can be used
-	 * 	 </li>
-	 * 	 <li>
-	 * 	     {@code false} indicates that {@linkplain java.sql.ResultSet#TYPE_SCROLL_SENSITIVE sensitive} scrolling must be used
-	 * 	 </li>
+	 * Controls how Hibernate should handle scrollable results:
+	 * <ul>
+	 * <li>{@code true} indicates that {@linkplain java.sql.ResultSet#TYPE_SCROLL_INSENSITIVE insensitive}
+	 *     scrolling can be used;
+	 * <li>{@code false} indicates that {@linkplain java.sql.ResultSet#TYPE_FORWARD_ONLY forward-only}
+	 *     scrolling must be used.
 	 * </ul>
 	 *
 	 * @settingDefault {@code true} if the underlying driver supports scrollable results
@@ -419,7 +418,10 @@ public interface JdbcSettings extends C3p0Settings, AgroalSettings, HikariCPSett
 	 * @see org.hibernate.boot.SessionFactoryBuilder#applyScrollableResultsSupport(boolean)
 	 * @see Query#scroll
 	 * @see ExtractedDatabaseMetaData#supportsScrollableResults()
+	 *
+	 * @deprecated It's not necessary to set this explicitly
 	 */
+	@Deprecated(since = "7", forRemoval = true)
 	String USE_SCROLLABLE_RESULTSET = "hibernate.jdbc.use_scrollable_resultset";
 
 	/**

--- a/hibernate-core/src/main/java/org/hibernate/engine/jdbc/internal/StatementPreparerImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/jdbc/internal/StatementPreparerImpl.java
@@ -132,8 +132,8 @@ class StatementPreparerImpl implements StatementPreparer {
 			boolean isCallable,
 			@Nullable ScrollMode scrollMode) {
 		final int resultSetType;
-		if ( scrollMode != null && !scrollMode.equals( ScrollMode.FORWARD_ONLY ) ) {
-			if ( ! settings().isScrollableResultSetsEnabled() ) {
+		if ( scrollMode != null && scrollMode != ScrollMode.FORWARD_ONLY ) {
+			if ( !settings().isScrollableResultSetsEnabled() ) {
 				throw new AssertionFailure("scrollable result sets are not enabled");
 			}
 			resultSetType = scrollMode.toResultSetType();


### PR DESCRIPTION
<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

[Please describe here what your change is about]

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-19265
<!-- Hibernate GitHub Bot issue links end -->