### PR TITLE
HHH-19263 Do not bind to JNDI if hibernate.session_factory_name_is_jndi is set to false

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/internal/SessionFactorySettings.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/SessionFactorySettings.java
@@ -95,17 +95,18 @@ class SessionFactorySettings {
 		if ( isNotEmpty( explicitJndiName ) ) {
 			return explicitJndiName;
 		}
+		// do not use name for JNDI if explicitly asked not to
+		else if ( options.isSessionFactoryNameAlsoJndiName() == Boolean.FALSE ) {
+			return null;
+		}
 		else {
 			final String expliciSessionFactoryname = configService.getSetting( SESSION_FACTORY_NAME, STRING );
 			if ( isNotEmpty( expliciSessionFactoryname ) ) {
 				return expliciSessionFactoryname;
 			}
 			final String unitName = configService.getSetting( PERSISTENCE_UNIT_NAME, STRING );
-			// do not use name for JNDI if explicitly asked not to or if name comes from JPA persistence-unit name
-			final boolean nameIsNotJndiName =
-					options.isSessionFactoryNameAlsoJndiName() == Boolean.FALSE
-							|| isNotEmpty( unitName );
-			return !nameIsNotJndiName ? name : null;
+			// if name comes from JPA persistence-unit name
+			return ! isNotEmpty( unitName ) ? name : null;
 		}
 	}
 


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-19263

I'm seeing a unit test failure with WildFly Preview that disables the Hibernate ORM 2-phase bootstrap by configuring a test with `<property name="wildfly.jpa.twophasebootstrap" value="false"/>` (https://github.com/wildfly/wildfly/blob/main/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/injection/support/jpa/persistence.xml#L18) which causes the test to deploy before the JNDI name space has been configured.  

Clearly the JNDI name space is an internal detail of WildFly but I do get a test deployment failure as a result.  If this pull request is wrong and the https://hibernate.atlassian.net/browse/HHH-19263 issue is also wrong, I'll look into other WildFly side alternatives to ensure that applications do not deploy too early (which I want to do anyways when I get to it).

----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
