### PR TITLE
Modifications of Author_ calls to the one-to-one relationship.

### DIFF
--- a/documentation/src/main/asciidoc/introduction/Entities.adoc
+++ b/documentation/src/main/asciidoc/introduction/Entities.adoc
@@ -1287,7 +1287,7 @@ class Person {
     @Id @GeneratedValue
     Long id;
 
-    @OneToOne(mappedBy = Author_.PERSON)
+    @OneToOne(mappedBy = Author_.AUTHOR)
     Author author;
 
     ...
@@ -1310,7 +1310,7 @@ On the other hand, if _every_ `Person` was an `Author`, that is, if the associat
 
 [source,java]
 ----
-@OneToOne(optional=false, mappedBy = Author_.PERSON, fetch=LAZY)
+@OneToOne(optional=false, mappedBy = Author_.AUTHOR, fetch=LAZY)
 Author author;
 ----
 ****
@@ -1350,7 +1350,7 @@ Here, there's no extra foreign key column in the `Author` table, since the `id` 
 That is, the primary key of the `Author` table does double duty as the foreign key referring to the `Person` table.
 
 The `Person` class doesn't change.
-If the association is bidirectional, we annotate the unowned side `@OneToOne(mappedBy = Author_.PERSON)` just as before.
+If the association is bidirectional, we annotate the unowned side `@OneToOne(mappedBy = Author_.AUTHOR)` just as before.
 
 [[many-to-many]]
 === Many-to-many


### PR DESCRIPTION
[Please describe here what your change is about]
The documentation relates on the one-to-one association with the example of "Author" and "Person".
The non-owned side may be mapped for a bidirectionnal relationship with the attribute "mappedBy=Author_.Person" on the @One-to-One,
but this property does not exist in Author. It contains Author.author and the documentation indicates Author_.PERSON which is actually the type of the attribute author in Author.

----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
