### PR TITLE
HHH-19272 : Secondary table with nested @Embedded object

### DIFF
--- a/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/embeddable/NestedEmbeddedObjectWithASecondaryTableTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/embeddable/NestedEmbeddedObjectWithASecondaryTableTest.java
@@ -1,0 +1,79 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.mapping.embeddable;
+
+import jakarta.persistence.AttributeOverride;
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import jakarta.persistence.Embedded;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.SecondaryTable;
+import jakarta.persistence.Table;
+import org.hibernate.cfg.JdbcSettings;
+import org.hibernate.testing.orm.junit.EntityManagerFactoryScope;
+import org.hibernate.testing.orm.junit.JiraKey;
+import org.hibernate.testing.orm.junit.Jpa;
+import org.hibernate.testing.orm.junit.Setting;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test passes if Author#name is renamed to Author#aname because it will be read before house (alphabetical order).
+ * The issue occurs if the nested embedded is read first, due to the table calculation (ComponentPropertyHolder#addProperty) used by the embedded, which retrieves the table from the first property.
+ *
+ * @author Vincent Bouthinon
+ */
+@Jpa(
+		annotatedClasses = {
+				NestedEmbeddedObjectWithASecondaryTableTest.Author.class,
+				NestedEmbeddedObjectWithASecondaryTableTest.Book.class,
+				NestedEmbeddedObjectWithASecondaryTableTest.House.class
+		},
+		integrationSettings = @Setting(name = JdbcSettings.SHOW_SQL, value = "true")
+)
+@JiraKey("HHH-19272")
+class NestedEmbeddedObjectWithASecondaryTableTest {
+
+	@Test
+	void testExceptionEmbeddedHasPropertiesMappedToTwoDifferentTables(EntityManagerFactoryScope scope) {
+
+		scope.inTransaction(
+				entityManager -> {
+					// Nothing
+				}
+		);
+	}
+
+	@Entity(name = "book")
+	@Table(name = "TBOOK")
+	@SecondaryTable(name = "TSECONDARYTABLE")
+	public static class Book {
+
+		@Id
+		@GeneratedValue
+		private Long id;
+
+		@AttributeOverride(name = "name", column = @Column(name = "authorName", table = "TSECONDARYTABLE"))
+		@Embedded
+		private Author author;
+
+	}
+
+	@Embeddable
+	public static class Author {
+
+		@AttributeOverride(name = "name", column = @Column(name = "houseName", table = "TSECONDARYTABLE"))
+		@Embedded
+		private House house;
+
+		private String name;
+	}
+
+	@Embeddable
+	public static class House {
+		private String name;
+	}
+}


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-19272

The issue arises when the embedded object itself contains another embedded object, and we want to map the entire structure to a secondary table.

The exception :

Embeddable class 'org.hibernate.orm.test.mapping.embeddable.ComponentWithEmbeddableAndSecondaryTableTest$Author' has properties mapped to two different tables (all properties of the embeddable class must map to the same table)
org.hibernate.AnnotationException: Embeddable class 

----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
