### PR TITLE
Allow a little more timeout margin for mysql startup

### DIFF
--- a/docker_db.sh
+++ b/docker_db.sh
@@ -34,7 +34,7 @@ mysql_8_0() {
         fi
         n=$((n+1))
         echo "Waiting for MySQL to start..."
-        sleep 3
+        sleep 5
     done
     if [ "$n" -ge 5 ]; then
       echo "MySQL failed to start and configure after 15 seconds"
@@ -58,7 +58,7 @@ mysql_8_1() {
         fi
         n=$((n+1))
         echo "Waiting for MySQL to start..."
-        sleep 3
+        sleep 5
     done
     if [ "$n" -ge 5 ]; then
       echo "MySQL failed to start and configure after 15 seconds"
@@ -82,7 +82,7 @@ mysql_8_2() {
         fi
         n=$((n+1))
         echo "Waiting for MySQL to start..."
-        sleep 3
+        sleep 5
     done
     if [ "$n" -ge 5 ]; then
       echo "MySQL failed to start and configure after 15 seconds"


### PR DESCRIPTION
(to avoid fake error messages on slower machines)
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
