### PR TITLE
HHH-19279 @Basic annotation should not mark primitive fields as optional

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/boot/model/internal/PropertyBinder.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/internal/PropertyBinder.java
@@ -1264,26 +1264,25 @@ public class PropertyBinder {
 	 * Should this property be considered optional, without considering
 	 * whether it is primitive?
 	 *
-	 * @apiNote Poorly named to a degree.  The intention is really whether non-optional is explicit
+	 * @apiNote Poorly named to a degree.
+	 *          The intention is really whether non-optional is explicit
 	 */
 	private static boolean isExplicitlyOptional(MemberDetails attributeMember) {
-		final Basic basicAnn = attributeMember.getDirectAnnotationUsage( Basic.class );
-		if ( basicAnn == null ) {
-			// things are optional (nullable) by default.  If there is no annotation, that cannot be altered
-			return true;
-		}
-
-		return basicAnn.optional();
+		final Basic basic = attributeMember.getDirectAnnotationUsage( Basic.class );
+		// things are optional (nullable) by default.
+		// If there is no annotation, that cannot be altered
+		return basic == null || basic.optional();
 	}
 
 	/**
-	 * Should this property be considered optional, taking into
-	 * account whether it is primitive?
+	 * Should this property be considered optional, taking into account
+	 * whether it is primitive?
 	 */
 	public static boolean isOptional(MemberDetails attributeMember, PropertyHolder propertyHolder) {
-		final Basic basicAnn = attributeMember.getDirectAnnotationUsage( Basic.class );
-		if ( basicAnn != null ) {
-			return basicAnn.optional();
+		final Basic basic = attributeMember.getDirectAnnotationUsage( Basic.class );
+		if ( basic != null ) {
+			return basic.optional()
+				&& attributeMember.getType().getTypeKind() != TypeDetails.Kind.PRIMITIVE;
 		}
 		else if ( attributeMember.isArray() ) {
 			return true;

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/basic/ImplicitOptionalBooleanBasicTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/basic/ImplicitOptionalBooleanBasicTest.java
@@ -12,12 +12,11 @@ import org.hibernate.boot.Metadata;
 import org.hibernate.boot.MetadataSources;
 import org.hibernate.mapping.PersistentClass;
 import org.hibernate.testing.orm.junit.JiraKey;
-import org.hibernate.testing.orm.junit.NotImplementedYet;
 import org.hibernate.testing.orm.junit.ServiceRegistry;
 import org.hibernate.testing.orm.junit.ServiceRegistryScope;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 /**
  * <pre>
@@ -37,17 +36,16 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  */
 @ServiceRegistry()
 @JiraKey("HHH-19279")
-class ImpliciteOptionalBooleanBasicTest {
+class ImplicitOptionalBooleanBasicTest {
 
-	@NotImplementedYet
 	@Test
-	void testImpliciteOptionalBooleanBasic(ServiceRegistryScope registryScope) {
+	void testImplicitOptionalBooleanBasic(ServiceRegistryScope registryScope) {
 		final MetadataSources metadataSources = new MetadataSources( registryScope.getRegistry() )
 				.addAnnotatedClasses( BooleanBasicTest.class );
 		Metadata metadata = metadataSources.buildMetadata();
 		PersistentClass entityBinding = metadata.getEntityBinding( BooleanBasicTest.class.getName() );
-		assertTrue( entityBinding.getProperty( "booleanWithBasic" ).isOptional(), "booleanWithBasic property is not optional" );
-		assertTrue( entityBinding.getProperty( "booleanWithoutBasic" ).isOptional(), "booleanWithoutBasic property is not optional" );
+		assertFalse( entityBinding.getProperty( "booleanWithBasic" ).isOptional(), "primitive property is optional" );
+		assertFalse( entityBinding.getProperty( "booleanWithoutBasic" ).isOptional(), "primitive property is optional" );
 	}
 
 	@Entity


### PR DESCRIPTION
as specified by Javadoc of Basic.optional()

<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

[Please describe here what your change is about]

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-19279
<!-- Hibernate GitHub Bot issue links end -->