### PR TITLE
HHH-19103 Add missing break within truncate action

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/tool/schema/spi/SchemaManagementToolCoordinator.java
+++ b/hibernate-core/src/main/java/org/hibernate/tool/schema/spi/SchemaManagementToolCoordinator.java
@@ -291,6 +291,7 @@ public class SchemaManagementToolCoordinator {
 								serviceRegistry
 						)
 				);
+				break;
 			}
 			case POPULATE: {
 				tool.getSchemaPopulator( executionOptions.getConfigurationValues() ).doPopulation(
@@ -301,6 +302,7 @@ public class SchemaManagementToolCoordinator {
 								serviceRegistry
 						)
 				);
+				break;
 			}
 		}
 	}


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-19103

or was it maybe on purpose to let the populator run after any other action ? 🙈 

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
