### PR TITLE
avoid duplicated SqlAstTranslatorFactory creation in JdbcEnvironmentImpl

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/engine/jdbc/env/internal/JdbcEnvironmentImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/jdbc/env/internal/JdbcEnvironmentImpl.java
@@ -135,8 +135,9 @@ public class JdbcEnvironmentImpl implements JdbcEnvironment {
 	}
 
 	private static SqlAstTranslatorFactory resolveSqlAstTranslatorFactory(Dialect dialect) {
-		return dialect.getSqlAstTranslatorFactory() != null
-				? dialect.getSqlAstTranslatorFactory()
+		final SqlAstTranslatorFactory sqlAstTranslatorFactory = dialect.getSqlAstTranslatorFactory();
+		return sqlAstTranslatorFactory != null
+				? sqlAstTranslatorFactory
 				: new StandardSqlAstTranslatorFactory();
 	}
 


### PR DESCRIPTION
<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

A minor defect in that the `Dialect#getSqlAstTranslatorFactory()` is called twice unnecessarily, even though in most of casees it is not a big deal

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
