### PR TITLE
Use a more specific interface (QueryProducerImplementor) in JdbcExecHelper to help with build reproducibility

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/sql/exec/internal/JdbcExecHelper.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/exec/internal/JdbcExecHelper.java
@@ -5,8 +5,8 @@
 package org.hibernate.sql.exec.internal;
 
 import org.hibernate.CacheMode;
-import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.query.spi.QueryOptions;
+import org.hibernate.query.spi.QueryProducerImplementor;
 import org.hibernate.sql.exec.spi.ExecutionContext;
 
 import static org.hibernate.internal.util.NullnessHelper.coalesceSuppliedValues;
@@ -27,7 +27,7 @@ public class JdbcExecHelper {
 		return resolveCacheMode( executionContext.getQueryOptions(), executionContext.getSession() );
 	}
 
-	public static CacheMode resolveCacheMode(QueryOptions options, SharedSessionContractImplementor session) {
+	public static CacheMode resolveCacheMode(QueryOptions options, QueryProducerImplementor session) {
 		return coalesceSuppliedValues(
 				() -> options == null ? null : options.getCacheMode(),
 				session::getCacheMode,
@@ -35,7 +35,7 @@ public class JdbcExecHelper {
 		);
 	}
 
-	public static CacheMode resolveCacheMode(CacheMode override, SharedSessionContractImplementor session) {
+	public static CacheMode resolveCacheMode(CacheMode override, QueryProducerImplementor session) {
 		return coalesceSuppliedValues(
 				() -> override,
 				session::getCacheMode,


### PR DESCRIPTION
that get cache mode method is in both `org.hibernate.SharedSessionContract` and `org.hibernate.query.spi.QueryProducerImplementor` but since in `SSC` there's a comment that it shouldn't be in there ... maybe let's use the `QueryProducerImplementor` ?

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
