### PR TITLE
HHH-19294 NodeBuilder collection*() doesn't work with enum collections

### DIFF
--- a/hibernate-core/src/test/java/org/hibernate/orm/test/function/array/ArrayAppendTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/function/array/ArrayAppendTest.java
@@ -115,7 +115,9 @@ public class ArrayAppendTest {
 			cq.multiselect(
 					root.get( "id" ),
 					cb.collectionAppend( root.<Collection<String>>get( "theCollection" ), cb.literal( "xyz" ) ),
-					cb.collectionAppend( root.get( "theCollection" ), "xyz" )
+					cb.collectionAppend( root.get( "theCollection" ), "xyz" ),
+					cb.collectionAppend( root.<Collection<Label>>get( "theLabels" ), cb.literal( Label.A ) ),
+					cb.collectionAppend( root.get( "theLabels" ), Label.A )
 			);
 			em.createQuery( cq ).getResultList();
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/function/array/ArrayConcatTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/function/array/ArrayConcatTest.java
@@ -201,7 +201,10 @@ public class ArrayConcatTest {
 					root.get( "id" ),
 					cb.collectionConcat( root.get( "theCollection" ), cb.collectionLiteral( "xyz" ) ),
 					cb.collectionConcat( root.get( "theCollection" ), List.of( "xyz" ) ),
-					cb.collectionConcat( List.of( "xyz" ), root.get( "theCollection" ) )
+					cb.collectionConcat( List.of( "xyz" ), root.get( "theCollection" ) ),
+					cb.collectionConcat( root.get( "theLabels" ), cb.collectionLiteral( Label.A ) ),
+					cb.collectionConcat( root.get( "theLabels" ), List.of( Label.A ) ),
+					cb.collectionConcat( List.of( Label.A ), root.get( "theLabels" ) )
 			);
 			em.createQuery( cq ).getResultList();
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/function/array/ArrayContainsTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/function/array/ArrayContainsTest.java
@@ -117,7 +117,13 @@ public class ArrayContainsTest {
 					cb.collectionContains( List.of( "abc", "xyz" ), cb.literal( "xyz" ) ),
 					cb.collectionContainsNullable( root.<Collection<String>>get( "theCollection" ), cb.literal( "xyz" ) ),
 					cb.collectionContainsNullable( root.get( "theCollection" ), "xyz" ),
-					cb.collectionContainsNullable( List.of( "abc", "xyz" ), cb.literal( "xyz" ) )
+					cb.collectionContainsNullable( List.of( "abc", "xyz" ), cb.literal( "xyz" ) ),
+					cb.collectionContains( root.<Collection<Label>>get( "theLabels" ), cb.literal( Label.A ) ),
+					cb.collectionContains( root.get( "theLabels" ), Label.A ),
+					cb.collectionContains( List.of( Label.A, Label.B ), cb.literal( Label.A ) ),
+					cb.collectionContainsNullable( root.<Collection<Label>>get( "theLabels" ), cb.literal( Label.A ) ),
+					cb.collectionContainsNullable( root.get( "theLabels" ), Label.A ),
+					cb.collectionContainsNullable( List.of( Label.A, Label.B ), cb.literal( Label.A ) )
 			);
 			em.createQuery( cq ).getResultList();
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/function/array/ArrayGetTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/function/array/ArrayGetTest.java
@@ -107,7 +107,9 @@ public class ArrayGetTest {
 			cq.multiselect(
 					root.get( "id" ),
 					cb.collectionGet( root.get( "theCollection" ), cb.literal( 1 ) ),
-					cb.collectionGet( root.get( "theCollection" ), 1 )
+					cb.collectionGet( root.get( "theCollection" ), 1 ),
+					cb.collectionGet( root.get( "theLabels" ), cb.literal( 1 ) ),
+					cb.collectionGet( root.get( "theLabels" ), 1 )
 			);
 			em.createQuery( cq ).getResultList();
 		} );

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/function/array/ArrayIncludesTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/function/array/ArrayIncludesTest.java
@@ -170,7 +170,13 @@ public class ArrayIncludesTest {
 					cb.collectionIncludes( List.of( "abc", "xyz" ), cb.collectionLiteral( "xyz" ) ),
 					cb.collectionIncludesNullable( root.<Collection<String>>get( "theCollection" ), cb.collectionLiteral( "xyz" ) ),
 					cb.collectionIncludesNullable( root.get( "theCollection" ), List.of( "xyz" ) ),
-					cb.collectionIncludesNullable( List.of( "abc", "xyz" ), cb.collectionLiteral( "xyz" ) )
+					cb.collectionIncludesNullable( List.of( "abc", "xyz" ), cb.collectionLiteral( "xyz" ) ),
+					cb.collectionIncludes( root.<Collection<Label>>get( "theLabels" ), cb.collectionLiteral( Label.A ) ),
+					cb.collectionIncludes( root.get( "theLabels" ), List.of( Label.A ) ),
+					cb.collectionIncludes( List.of( Label.A, Label.B ), cb.collectionLiteral( Label.A ) ),
+					cb.collectionIncludesNullable( root.<Collection<Label>>get( "theLabels" ), cb.collectionLiteral( Label.A ) ),
+					cb.collectionIncludesNullable( root.get( "theLabels" ), List.of( Label.A ) ),
+					cb.collectionIncludesNullable( List.of( Label.A, Label.B ), cb.collectionLiteral( Label.A ) )
 			);
 			em.createQuery( cq ).getResultList();
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/function/array/ArrayIntersectsTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/function/array/ArrayIntersectsTest.java
@@ -148,7 +148,13 @@ public class ArrayIntersectsTest {
 					cb.collectionIntersects( List.of( "abc", "xyz" ), cb.collectionLiteral( "xyz" ) ),
 					cb.collectionIntersectsNullable( root.<Collection<String>>get( "theCollection" ), cb.collectionLiteral( "xyz" ) ),
 					cb.collectionIntersectsNullable( root.get( "theCollection" ), List.of( "xyz" ) ),
-					cb.collectionIntersectsNullable( List.of( "abc", "xyz" ), cb.collectionLiteral( "xyz" ) )
+					cb.collectionIntersectsNullable( List.of( "abc", "xyz" ), cb.collectionLiteral( "xyz" ) ),
+					cb.collectionIntersects( root.<Collection<Label>>get( "theLabels" ), cb.collectionLiteral( Label.A ) ),
+					cb.collectionIntersects( root.get( "theLabels" ), List.of( Label.A ) ),
+					cb.collectionIntersects( List.of( Label.A, Label.B ), cb.collectionLiteral( Label.A ) ),
+					cb.collectionIntersectsNullable( root.<Collection<Label>>get( "theLabels" ), cb.collectionLiteral( Label.A ) ),
+					cb.collectionIntersectsNullable( root.get( "theLabels" ), List.of( Label.A ) ),
+					cb.collectionIntersectsNullable( List.of( Label.A, Label.B ), cb.collectionLiteral( Label.A ) )
 			);
 			em.createQuery( cq ).getResultList();
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/function/array/ArrayLengthTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/function/array/ArrayLengthTest.java
@@ -106,7 +106,8 @@ public class ArrayLengthTest {
 			final JpaRoot<EntityWithArrays> root = cq.from( EntityWithArrays.class );
 			cq.multiselect(
 					root.get( "id" ),
-					cb.collectionLength( root.get( "theCollection" ) )
+					cb.collectionLength( root.get( "theCollection" ) ),
+					cb.collectionLength( root.get( "theLabels" ) )
 			);
 			em.createQuery( cq ).getResultList();
 		} );

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/function/array/ArrayPositionTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/function/array/ArrayPositionTest.java
@@ -122,7 +122,9 @@ public class ArrayPositionTest {
 			cq.multiselect(
 					root.get( "id" ),
 					cb.collectionPosition( root.<Collection<String>>get( "theCollection" ), cb.literal( "xyz" ) ),
-					cb.collectionPosition( root.get( "theCollection" ), "xyz" )
+					cb.collectionPosition( root.get( "theCollection" ), "xyz" ),
+					cb.collectionPosition( root.<Collection<String>>get( "theLabels" ), cb.literal( Label.A ) ),
+					cb.collectionPosition( root.get( "theLabels" ), Label.A )
 			);
 			em.createQuery( cq ).getResultList();
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/function/array/ArrayPositionsTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/function/array/ArrayPositionsTest.java
@@ -139,7 +139,11 @@ public class ArrayPositionsTest {
 					cb.collectionPositions( root.<Collection<String>>get( "theCollection" ), cb.literal( "xyz" ) ),
 					cb.collectionPositions( root.get( "theCollection" ), "xyz" ),
 					cb.collectionPositionsList( root.<Collection<String>>get( "theCollection" ), cb.literal( "xyz" ) ),
-					cb.collectionPositionsList( root.get( "theCollection" ), "xyz" )
+					cb.collectionPositionsList( root.get( "theCollection" ), "xyz" ),
+					cb.collectionPositions( root.<Collection<Label>>get( "theLabels" ), cb.literal( Label.A ) ),
+					cb.collectionPositions( root.get( "theLabels" ), Label.A ),
+					cb.collectionPositionsList( root.<Collection<Label>>get( "theLabels" ), cb.literal( Label.A ) ),
+					cb.collectionPositionsList( root.get( "theLabels" ), Label.A )
 			);
 			em.createQuery( cq ).getResultList();
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/function/array/ArrayPrependTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/function/array/ArrayPrependTest.java
@@ -115,7 +115,9 @@ public class ArrayPrependTest {
 			cq.multiselect(
 					root.get( "id" ),
 					cb.collectionPrepend( cb.literal( "xyz" ), root.<Collection<String>>get( "theCollection" ) ),
-					cb.collectionPrepend( "xyz", root.get( "theCollection" ) )
+					cb.collectionPrepend( "xyz", root.get( "theCollection" ) ),
+					cb.collectionPrepend( cb.literal( Label.A ), root.<Collection<Label>>get( "theLabels" ) ),
+					cb.collectionPrepend( "xyz", root.get( "theLabels" ) )
 			);
 			em.createQuery( cq ).getResultList();
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/function/array/ArrayRemoveIndexTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/function/array/ArrayRemoveIndexTest.java
@@ -126,7 +126,9 @@ public class ArrayRemoveIndexTest {
 			cq.multiselect(
 					root.get( "id" ),
 					cb.collectionRemoveIndex( root.<Collection<String>>get( "theCollection" ), cb.literal( 1 ) ),
-					cb.collectionRemoveIndex( root.get( "theCollection" ), 1 )
+					cb.collectionRemoveIndex( root.get( "theCollection" ), 1 ),
+					cb.collectionRemoveIndex( root.<Collection<Label>>get( "theLabels" ), cb.literal( 1 ) ),
+					cb.collectionRemoveIndex( root.get( "theLabels" ), 1 )
 			);
 			em.createQuery( cq ).getResultList();
 		} );

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/function/array/ArrayRemoveTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/function/array/ArrayRemoveTest.java
@@ -130,7 +130,9 @@ public class ArrayRemoveTest {
 			cq.multiselect(
 					root.get( "id" ),
 					cb.collectionRemove( root.<Collection<String>>get( "theCollection" ), cb.literal( "xyz" ) ),
-					cb.collectionRemove( root.get( "theCollection" ), "xyz" )
+					cb.collectionRemove( root.get( "theCollection" ), "xyz" ),
+					cb.collectionRemove( root.<Collection<Label>>get( "theLabels" ), cb.literal( Label.A ) ),
+					cb.collectionRemove( root.get( "theLabels" ), Label.A )
 			);
 			em.createQuery( cq ).getResultList();
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/function/array/ArrayReplaceTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/function/array/ArrayReplaceTest.java
@@ -136,7 +136,11 @@ public class ArrayReplaceTest {
 					cb.collectionReplace( root.<Collection<String>>get( "theCollection" ), cb.literal( "abc" ), cb.literal( "xyz" ) ),
 					cb.collectionReplace( root.<Collection<String>>get( "theCollection" ), cb.literal( "abc" ), "xyz" ),
 					cb.collectionReplace( root.<Collection<String>>get( "theCollection" ), "abc", cb.literal( "xyz" ) ),
-					cb.collectionReplace( root.get( "theCollection" ), "abc", "xyz" )
+					cb.collectionReplace( root.get( "theCollection" ), "abc", "xyz" ),
+					cb.collectionReplace( root.<Collection<Label>>get( "theLabels" ), cb.literal( Label.A ), cb.literal( Label.B ) ),
+					cb.collectionReplace( root.<Collection<Label>>get( "theLabels" ), cb.literal( Label.A ), Label.B ),
+					cb.collectionReplace( root.<Collection<Label>>get( "theLabels" ), Label.A, cb.literal( Label.B ) ),
+					cb.collectionReplace( root.get( "theLabels" ), Label.A, Label.B )
 			);
 			em.createQuery( cq ).getResultList();
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/function/array/ArraySetTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/function/array/ArraySetTest.java
@@ -135,7 +135,11 @@ public class ArraySetTest {
 					cb.collectionSet( root.<Collection<String>>get( "theCollection" ), cb.literal( 1 ), cb.literal( "xyz" ) ),
 					cb.collectionSet( root.get( "theCollection" ), cb.literal( 1 ), "xyz" ),
 					cb.collectionSet( root.<Collection<String>>get( "theCollection" ), 1, cb.literal( "xyz" ) ),
-					cb.collectionSet( root.get( "theCollection" ), 1, "xyz" )
+					cb.collectionSet( root.get( "theCollection" ), 1, "xyz" ),
+					cb.collectionSet( root.<Collection<Label>>get( "theLabels" ), cb.literal( 1 ), cb.literal( Label.A ) ),
+					cb.collectionSet( root.get( "theLabels" ), cb.literal( 1 ), Label.A ),
+					cb.collectionSet( root.<Collection<Label>>get( "theLabels" ), 1, cb.literal( Label.A ) ),
+					cb.collectionSet( root.get( "theLabels" ), 1, Label.A )
 			);
 			em.createQuery( cq ).getResultList();
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/function/array/ArraySliceTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/function/array/ArraySliceTest.java
@@ -132,7 +132,11 @@ public class ArraySliceTest {
 					cb.collectionSlice( root.get( "theCollection" ), cb.literal( 1 ), cb.literal( 1 ) ),
 					cb.collectionSlice( root.get( "theCollection" ), cb.literal( 1 ), 1 ),
 					cb.collectionSlice( root.get( "theCollection" ), 1, cb.literal( 1 ) ),
-					cb.collectionSlice( root.get( "theCollection" ), 1, 1 )
+					cb.collectionSlice( root.get( "theCollection" ), 1, 1 ),
+					cb.collectionSlice( root.get( "theLabels" ), cb.literal( 1 ), cb.literal( 1 ) ),
+					cb.collectionSlice( root.get( "theLabels" ), cb.literal( 1 ), 1 ),
+					cb.collectionSlice( root.get( "theLabels" ), 1, cb.literal( 1 ) ),
+					cb.collectionSlice( root.get( "theLabels" ), 1, 1 )
 			);
 			em.createQuery( cq ).getResultList();
 		} );

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/function/array/ArrayToStringTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/function/array/ArrayToStringTest.java
@@ -107,7 +107,9 @@ public class ArrayToStringTest {
 			cq.multiselect(
 					root.get( "id" ),
 					cb.collectionToString( root.get( "theCollection" ), cb.literal( "," ) ),
-					cb.collectionToString( root.get( "theCollection" ), "," )
+					cb.collectionToString( root.get( "theCollection" ), "," ),
+					cb.collectionToString( root.get( "theLabels" ), cb.literal( "," ) ),
+					cb.collectionToString( root.get( "theLabels" ), "," )
 			);
 			em.createQuery( cq ).getResultList();
 		} );

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/function/array/ArrayTrimTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/function/array/ArrayTrimTest.java
@@ -127,7 +127,9 @@ public class ArrayTrimTest {
 			cq.multiselect(
 					root.get( "id" ),
 					cb.collectionTrim( root.<Collection<String>>get( "theCollection" ), cb.literal( 1 ) ),
-					cb.collectionTrim( root.get( "theCollection" ), 1 )
+					cb.collectionTrim( root.get( "theCollection" ), 1 ),
+					cb.collectionTrim( root.<Collection<Label>>get( "theLabels" ), cb.literal( 1 ) ),
+					cb.collectionTrim( root.get( "theLabels" ), 1 )
 			);
 			em.createQuery( cq ).getResultList();
 		} );


### PR DESCRIPTION
<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

Reproducer for HHH-19294

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-19294
<!-- Hibernate GitHub Bot issue links end -->