### PR TITLE
HHH-19059 Bytecode enhancement fails when inherited fields are mapped using property access in subclass

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/bytecode/enhance/internal/bytebuddy/EnhancerImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/bytecode/enhance/internal/bytebuddy/EnhancerImpl.java
@@ -11,6 +11,7 @@ import jakarta.persistence.EmbeddedId;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jakarta.persistence.MappedSuperclass;
+import jakarta.persistence.Transient;
 import jakarta.persistence.metamodel.Type;
 import net.bytebuddy.asm.Advice;
 import net.bytebuddy.description.annotation.AnnotationDescription;
@@ -72,6 +73,9 @@ import java.util.function.Supplier;
 import static net.bytebuddy.matcher.ElementMatchers.isDefaultFinalizer;
 import static net.bytebuddy.matcher.ElementMatchers.isGetter;
 import static net.bytebuddy.matcher.ElementMatchers.isSetter;
+import static net.bytebuddy.matcher.ElementMatchers.isStatic;
+import static net.bytebuddy.matcher.ElementMatchers.named;
+import static net.bytebuddy.matcher.ElementMatchers.not;
 
 public class EnhancerImpl implements Enhancer {
 
@@ -489,21 +493,13 @@ public class EnhancerImpl implements Enhancer {
 				|| annotations.isAnnotationPresent( Embeddable.class );
 	}
 
-	private static boolean hasPersistenceAnnotation(AnnotationList annotations) {
-		boolean found = false;
-		for ( AnnotationDescription annotation : annotations ) {
-			final String annotationName = annotation.getAnnotationType().getName();
-			if ( annotationName.startsWith( "jakarta.persistence" ) ) {
-				if ( annotationName.equals( "jakarta.persistence.Transient" ) ) {
-					// transient property so ignore it
-					return false;
-				}
-				else if ( !found && !IGNORED_PERSISTENCE_ANNOTATIONS.contains( annotationName ) ) {
-					found = true;
-				}
-			}
+	private static boolean isPersistentMethod(MethodDescription method) {
+		final AnnotationList annotations = method.getDeclaredAnnotations();
+		if ( annotations.isAnnotationPresent( Transient.class ) ) {
+			return false;
 		}
-		return found;
+
+		return annotations.stream().noneMatch( a -> IGNORED_PERSISTENCE_ANNOTATIONS.contains( a.getAnnotationType().getName() ) );
 	}
 
 	private static final Set<String> IGNORED_PERSISTENCE_ANNOTATIONS = Set.of(
@@ -515,6 +511,17 @@ public class EnhancerImpl implements Enhancer {
 			"jakarta.persistence.PreRemove",
 			"jakarta.persistence.PreUpdate"
 	);
+
+	private static boolean containsField(Generic type, String fieldName) {
+		do {
+			if ( !type.getDeclaredFields().filter( not( isStatic() ).and( named( fieldName ) ) ).isEmpty() ) {
+				return true;
+			}
+			type = type.getSuperClass();
+		}
+		while ( type != null && !type.represents( Object.class ) );
+		return false;
+	}
 
 	/**
 	 * Check whether an entity class ({@code managedCtClass}) has mismatched names between a persistent field and its
@@ -558,61 +565,46 @@ public class EnhancerImpl implements Enhancer {
 				.asMethodList()
 				.filter( isGetter().or( isSetter() ) );
 		for ( final MethodDescription methodDescription : methods ) {
-			if ( determineAccessType( methodDescription, defaultAccessType ) != AccessType.PROPERTY ) {
+			if ( methodDescription.getDeclaringType().represents( Object.class )
+				|| determineAccessType( methodDescription, defaultAccessType ) != AccessType.PROPERTY ) {
 				// We only need to check this for AccessType.PROPERTY
 				continue;
 			}
 
 			final String methodName = methodDescription.getActualName();
-			String methodFieldName;
+			String fieldName;
 			if ( methodName.startsWith( "get" ) || methodName.startsWith( "set" ) ) {
-				methodFieldName = methodName.substring( 3 );
+				fieldName = methodName.substring( 3 );
 			}
 			else {
 				assert methodName.startsWith( "is" );
-				methodFieldName = methodName.substring( 2 );
+				fieldName = methodName.substring( 2 );
 			}
 			// convert first field letter to lower case
-			methodFieldName = getJavaBeansFieldName( methodFieldName );
-			if ( methodFieldName != null && hasPersistenceAnnotation( methodDescription.getDeclaredAnnotations() ) ) {
-				boolean propertyNameMatchesFieldName = false;
-				for ( final FieldDescription field : methodDescription.getDeclaringType().getDeclaredFields() ) {
-					if ( !Modifier.isStatic( field.getModifiers() ) ) {
-						final AnnotatedFieldDescription annotatedField = new AnnotatedFieldDescription(
-								enhancementContext,
-								field
-						);
-						if ( enhancementContext.isPersistentField( annotatedField ) ) {
-							if ( methodFieldName.equals( field.getActualName() ) ) {
-								propertyNameMatchesFieldName = true;
-								break;
-							}
-						}
-					}
-				}
-				if ( !propertyNameMatchesFieldName ) {
-					// We shouldn't even be in this method if using LEGACY, see top of this method.
-					return switch ( strategy ) {
-						case SKIP -> {
-							log.debugf(
-									"Skipping enhancement of [%s] because no field named [%s] could be found for property accessor method [%s]."
-											+ " To fix this, make sure all property accessor methods have a matching field.",
-									managedCtClass.getName(),
-									methodFieldName,
-									methodDescription.getName()
-							);
-							yield true;
-						}
-						case FAIL -> throw new EnhancementException( String.format(
-								"Enhancement of [%s] failed because no field named [%s] could be found for property accessor method [%s]."
-										+ " To fix this, make sure all property accessor methods have a matching field.",
+			fieldName = getJavaBeansFieldName( fieldName );
+			if ( fieldName != null && isPersistentMethod( methodDescription )
+				&& !containsField( managedCtClass.asGenericType(), fieldName ) ) {
+				// We shouldn't even be in this method if using LEGACY, see top of this method.
+				return switch ( strategy ) {
+					case SKIP -> {
+						log.debugf(
+								"Skipping enhancement of [%s] because no field named [%s] could be found for property accessor method [%s]."
+								+ " To fix this, make sure all property accessor methods have a matching field.",
 								managedCtClass.getName(),
-								methodFieldName,
+								fieldName,
 								methodDescription.getName()
-						) );
-						default -> throw new AssertionFailure( "Unexpected strategy at this point: " + strategy );
-					};
-				}
+						);
+						yield true;
+					}
+					case FAIL -> throw new EnhancementException( String.format(
+							"Enhancement of [%s] failed because no field named [%s] could be found for property accessor method [%s]."
+							+ " To fix this, make sure all property accessor methods have a matching field.",
+							managedCtClass.getName(),
+							fieldName,
+							methodDescription.getName()
+					) );
+					default -> throw new AssertionFailure( "Unexpected strategy at this point: " + strategy );
+				};
 			}
 		}
 		return false;

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/access/UnsupportedEnhancementStrategyTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/access/UnsupportedEnhancementStrategyTest.java
@@ -9,6 +9,7 @@ import jakarta.persistence.AccessType;
 import jakarta.persistence.Basic;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
+import jakarta.persistence.MappedSuperclass;
 import jakarta.persistence.PostLoad;
 import jakarta.persistence.PrePersist;
 import jakarta.persistence.Transient;
@@ -101,6 +102,14 @@ public class UnsupportedEnhancementStrategyTest {
 		// non-null means check passed and enhancement _was_ performed
 		assertThat( doEnhance( ExplicitAccessTypeFieldEntity.class, context ) ).isNotNull();
 		assertThat( doEnhance( ImplicitAccessTypeFieldEntity.class, context ) ).isNotNull();
+	}
+
+	@Test
+	@Jira( "https://hibernate.atlassian.net/browse/HHH-19059" )
+	public void testAccessTypePropertyInherited() throws IOException {
+		var context = new UnsupportedEnhancerContext();
+		// non-null means check passed and enhancement _was_ performed
+		assertThat( doEnhance( PropertyAccessInheritedEntity.class, context ) ).isNotNull();
 	}
 
 	private static byte[] doEnhance(Class<?> entityClass, EnhancementContext context) throws IOException {
@@ -197,7 +206,7 @@ public class UnsupportedEnhancementStrategyTest {
 		}
 
 		@PostLoad
-		public void setState() {
+		public void setState(String state) {
 			status = "loaded";
 		}
 
@@ -249,6 +258,33 @@ public class UnsupportedEnhancementStrategyTest {
 
 		public String getAnother() {
 			return "another";
+		}
+	}
+
+	@MappedSuperclass
+	static abstract class AbstractSuperclass {
+		protected String property;
+	}
+
+	@Entity(name="PropertyAccessInheritedEntity")
+	static class PropertyAccessInheritedEntity extends AbstractSuperclass {
+		private Long id;
+
+		@Id
+		public Long getId() {
+			return id;
+		}
+
+		public void setId(Long id) {
+			this.id = id;
+		}
+
+		public String getProperty() {
+			return property;
+		}
+
+		public void setProperty(String property) {
+			this.property = property;
 		}
 	}
 }


### PR DESCRIPTION
<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

https://hibernate.atlassian.net/browse/HHH-19059

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
