### PR TITLE
HHH-19059 Bytecode enhancement fails when inherited fields are mapped using property access in subclass

### DIFF
--- a/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/access/UnsupportedEnhancementStrategyTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/access/UnsupportedEnhancementStrategyTest.java
@@ -9,6 +9,7 @@ import jakarta.persistence.AccessType;
 import jakarta.persistence.Basic;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
+import jakarta.persistence.MappedSuperclass;
 import jakarta.persistence.PostLoad;
 import jakarta.persistence.PrePersist;
 import jakarta.persistence.Transient;
@@ -101,6 +102,14 @@ public class UnsupportedEnhancementStrategyTest {
 		// non-null means check passed and enhancement _was_ performed
 		assertThat( doEnhance( ExplicitAccessTypeFieldEntity.class, context ) ).isNotNull();
 		assertThat( doEnhance( ImplicitAccessTypeFieldEntity.class, context ) ).isNotNull();
+	}
+
+	@Test
+	@Jira( "https://hibernate.atlassian.net/browse/HHH-19059" )
+	public void testAccessTypePropertyInherited() throws IOException {
+		var context = new UnsupportedEnhancerContext();
+		// non-null means check passed and enhancement _was_ performed
+		assertThat( doEnhance( PropertyAccessInheritedEntity.class, context ) ).isNotNull();
 	}
 
 	private static byte[] doEnhance(Class<?> entityClass, EnhancementContext context) throws IOException {
@@ -197,7 +206,7 @@ public class UnsupportedEnhancementStrategyTest {
 		}
 
 		@PostLoad
-		public void setState() {
+		public void setState(String state) {
 			status = "loaded";
 		}
 
@@ -249,6 +258,33 @@ public class UnsupportedEnhancementStrategyTest {
 
 		public String getAnother() {
 			return "another";
+		}
+	}
+
+	@MappedSuperclass
+	static abstract class AbstractSuperclass {
+		protected String property;
+	}
+
+	@Entity(name="PropertyAccessInheritedEntity")
+	static class PropertyAccessInheritedEntity extends AbstractSuperclass {
+		private Long id;
+
+		@Id
+		public Long getId() {
+			return id;
+		}
+
+		public void setId(Long id) {
+			this.id = id;
+		}
+
+		public String getProperty() {
+			return property;
+		}
+
+		public void setProperty(String property) {
+			this.property = property;
 		}
 	}
 }


### PR DESCRIPTION
<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

https://hibernate.atlassian.net/browse/HHH-19059

Backport of https://github.com/hibernate/hibernate-orm/pull/9923

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
