### PR TITLE
HHH-19296 overload createSelectionQuery() to accept an EntityGraph

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/StatelessSession.java
+++ b/hibernate-core/src/main/java/org/hibernate/StatelessSession.java
@@ -278,6 +278,38 @@ public interface StatelessSession extends SharedSessionContract {
 
 	/**
 	 * Retrieve a record, fetching associations specified by the
+	 * given {@link EntityGraph}, which is interpreted as a
+	 * {@linkplain org.hibernate.graph.GraphSemantic#LOAD load graph}.
+	 *
+	 * @param graph The {@link EntityGraph}, interpreted as a
+	 * {@linkplain org.hibernate.graph.GraphSemantic#LOAD load graph}
+	 * @param id The id of the entity to retrieve
+	 *
+	 * @return a detached entity instance
+	 *
+	 * @since 7.0
+	 */
+	<T> T get(EntityGraph<T> graph, Object id);
+
+	/**
+	 * Retrieve a record, fetching associations specified by the
+	 * given {@link EntityGraph}, which is interpreted as a
+	 * {@linkplain org.hibernate.graph.GraphSemantic#LOAD load graph},
+	 * and obtaining the specified lock mode.
+	 *
+	 * @param graph The {@link EntityGraph}, interpreted as a
+	 * {@linkplain org.hibernate.graph.GraphSemantic#LOAD load graph}
+	 * @param id The id of the entity to retrieve
+	 * @param lockMode The lock mode to apply to the entity
+	 *
+	 * @return a detached entity instance
+	 *
+	 * @since 7.0
+	 */
+	<T> T get(EntityGraph<T> graph, Object id, LockMode lockMode);
+
+	/**
+	 * Retrieve a record, fetching associations specified by the
 	 * given {@link EntityGraph}.
 	 *
 	 * @param graph The {@link EntityGraph}

--- a/hibernate-core/src/main/java/org/hibernate/engine/spi/SessionDelegatorBaseImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/spi/SessionDelegatorBaseImpl.java
@@ -587,6 +587,11 @@ public class SessionDelegatorBaseImpl implements SessionImplementor {
 	}
 
 	@Override
+	public <R> SelectionQuery<R> createSelectionQuery(String hqlString, EntityGraph<R> resultGraph) {
+		return queryDelegate().createSelectionQuery( hqlString, resultGraph );
+	}
+
+	@Override
 	public <R> SelectionQuery<R> createSelectionQuery(CriteriaQuery<R> criteria) {
 		return queryDelegate().createSelectionQuery( criteria );
 	}

--- a/hibernate-core/src/main/java/org/hibernate/engine/spi/SessionLazyDelegator.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/spi/SessionLazyDelegator.java
@@ -700,6 +700,11 @@ public class SessionLazyDelegator implements Session {
 	}
 
 	@Override
+	public <R> SelectionQuery<R> createSelectionQuery(String hqlString, EntityGraph<R> resultGraph) {
+		return this.lazySession.get().createSelectionQuery( hqlString, resultGraph );
+	}
+
+	@Override
 	public <R> SelectionQuery<R> createSelectionQuery(CriteriaQuery<R> criteria) {
 		return this.lazySession.get().createSelectionQuery( criteria );
 	}

--- a/hibernate-core/src/main/java/org/hibernate/engine/spi/SharedSessionDelegatorBaseImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/spi/SharedSessionDelegatorBaseImpl.java
@@ -148,6 +148,11 @@ public class SharedSessionDelegatorBaseImpl implements SharedSessionContractImpl
 	}
 
 	@Override
+	public <R> SelectionQuery<R> createSelectionQuery(String hqlString, EntityGraph<R> resultGraph) {
+		return queryDelegate().createSelectionQuery( hqlString, resultGraph );
+	}
+
+	@Override
 	public <R> SelectionQuery<R> createSelectionQuery(CriteriaQuery<R> criteria) {
 		return queryDelegate().createSelectionQuery( criteria );
 	}

--- a/hibernate-core/src/main/java/org/hibernate/internal/AbstractSharedSessionContract.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/AbstractSharedSessionContract.java
@@ -49,6 +49,7 @@ import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.engine.transaction.internal.TransactionImpl;
 import org.hibernate.event.monitor.spi.EventMonitor;
+import org.hibernate.graph.GraphSemantic;
 import org.hibernate.graph.RootGraph;
 import org.hibernate.graph.internal.RootGraphImpl;
 import org.hibernate.graph.spi.RootGraphImplementor;
@@ -875,6 +876,13 @@ public abstract class AbstractSharedSessionContract implements SharedSessionCont
 	@Override
 	public <R> SelectionQuery<R> createSelectionQuery(String hqlString, Class<R> expectedResultType) {
 		return interpretAndCreateSelectionQuery( hqlString, expectedResultType );
+	}
+
+	@Override
+	public <R> SelectionQuery<R> createSelectionQuery(String hqlString, EntityGraph<R> resultGraph) {
+		final RootGraph<R> rootGraph = (RootGraph<R>) resultGraph;
+		return interpretAndCreateSelectionQuery( hqlString, rootGraph.getGraphedType().getJavaType() )
+				.setEntityGraph( resultGraph, GraphSemantic.LOAD );
 	}
 
 

--- a/hibernate-core/src/main/java/org/hibernate/internal/StatelessSessionImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/StatelessSessionImpl.java
@@ -729,6 +729,16 @@ public class StatelessSessionImpl extends AbstractSharedSessionContract implemen
 	}
 
 	@Override
+	public <T> T get(EntityGraph<T> graph, Object id) {
+		return get( graph, GraphSemantic.LOAD , id);
+	}
+
+	@Override
+	public <T> T get(EntityGraph<T> graph, Object id, LockMode lockMode) {
+		return get( graph, GraphSemantic.LOAD, id, lockMode);
+	}
+
+	@Override
 	public <T> T get(EntityGraph<T> graph, GraphSemantic graphSemantic, Object id) {
 		return get( graph, graphSemantic, id, LockMode.NONE );
 	}

--- a/hibernate-core/src/main/java/org/hibernate/query/QueryProducer.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/QueryProducer.java
@@ -372,6 +372,8 @@ public interface QueryProducer {
 	 * @throws IllegalSelectQueryException if the given HQL query
 	 *         is an {@code insert}, {@code update} or {@code delete}
 	 *         statement
+	 *
+	 * @since 7.0
 	 */
 	<R> SelectionQuery<R> createSelectionQuery(String hqlString, EntityGraph<R> resultGraph);
 

--- a/hibernate-core/src/main/java/org/hibernate/query/QueryProducer.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/QueryProducer.java
@@ -4,6 +4,7 @@
  */
 package org.hibernate.query;
 
+import jakarta.persistence.EntityGraph;
 import org.hibernate.query.criteria.JpaCriteriaInsert;
 
 import jakarta.persistence.TypedQueryReference;
@@ -336,6 +337,43 @@ public interface QueryProducer {
 	 *         statement
 	 */
 	<R> SelectionQuery<R> createSelectionQuery(String hqlString, Class<R> resultType);
+
+	/**
+	 * Create a {@link SelectionQuery} instance for the given HQL query
+	 * string and given {@link EntityGraph}, which is interpreted as a
+	 * {@linkplain org.hibernate.graph.GraphSemantic#LOAD load graph}.
+	 * The query result type is the root entity of the given graph.
+	 * <ul>
+	 * <li>If the query has an explicit {@code select} clause, there must
+	 *     be a single item in the {@code select} list, and the select
+	 *     item must be assignable to the root type of the given graph.
+	 * <li>Otherwise, if a query has no explicit {@code select} list, the
+	 *     select list is inferred from the given entity graph. The query
+	 *     must have exactly one root entity in the {@code from} clause,
+	 *     it must be assignable to the root type of the given graph, and
+	 *     the inferred select list will contain just that entity.
+	 * </ul>
+	 * <p>
+	 * If a query has no explicit {@code from} clause, and the given
+	 * result type is an entity type, the root entity is inferred to
+	 * be the result type.
+	 * <p>
+	 * The returned {@code Query} may be executed by calling
+	 * {@link Query#getResultList()} or {@link Query#getSingleResult()}.
+
+	 * @param hqlString The HQL {@code select} query as a string
+	 * @param resultGraph An {@link EntityGraph} whose root type is the
+	 *                    query result type, which is interpreted as a
+	 *                    {@linkplain org.hibernate.graph.GraphSemantic#LOAD
+	 *                    load graph}
+	 *
+	 * @see jakarta.persistence.EntityManager#createQuery(String)
+	 *
+	 * @throws IllegalSelectQueryException if the given HQL query
+	 *         is an {@code insert}, {@code update} or {@code delete}
+	 *         statement
+	 */
+	<R> SelectionQuery<R> createSelectionQuery(String hqlString, EntityGraph<R> resultGraph);
 
 	/**
 	 * Create a {@link SelectionQuery} reference for the given


### PR DESCRIPTION
…instead of a result class.

<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

[Please describe here what your change is about]

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-19296
https://hibernate.atlassian.net/browse/HHH-19298
<!-- Hibernate GitHub Bot issue links end -->