### PR TITLE
HHH-19036 Process all filters before going through classes

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/boot/model/internal/AnnotationBinder.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/internal/AnnotationBinder.java
@@ -42,7 +42,6 @@ import org.hibernate.boot.model.convert.spi.RegisteredConversion;
 import org.hibernate.boot.registry.classloading.spi.ClassLoaderService;
 import org.hibernate.boot.spi.MetadataBuildingContext;
 import org.hibernate.internal.CoreMessageLogger;
-import org.hibernate.internal.util.StringHelper;
 import org.hibernate.resource.beans.internal.FallbackBeanInstanceProducer;
 import org.hibernate.resource.beans.spi.ManagedBeanRegistry;
 import org.hibernate.type.descriptor.java.BasicJavaType;
@@ -69,7 +68,6 @@ import jakarta.persistence.TableGenerators;
 
 import static org.hibernate.boot.model.internal.AnnotatedClassType.EMBEDDABLE;
 import static org.hibernate.boot.model.internal.AnnotatedClassType.ENTITY;
-import static org.hibernate.boot.model.internal.FilterDefBinder.bindFilterDefs;
 import static org.hibernate.boot.model.internal.GeneratorBinder.buildGenerators;
 import static org.hibernate.boot.model.internal.GeneratorBinder.buildIdGenerator;
 import static org.hibernate.boot.model.internal.InheritanceState.getInheritanceStateOfSuperEntity;
@@ -226,7 +224,7 @@ public final class AnnotationBinder {
 
 		bindGenericGenerators( annotatedPackage, context );
 		bindQueries( annotatedPackage, context );
-		bindFilterDefs( annotatedPackage, context );
+		FilterDefBinder.bindFilterDefs( annotatedPackage, context );
 	}
 
 	private static void handleIdGenerators(XPackage annotatedPackage, MetadataBuildingContext context) {
@@ -371,6 +369,12 @@ public final class AnnotationBinder {
 		}
 	}
 
+	public static void bindFilterDefs(
+			XClass annotatedClass,
+			MetadataBuildingContext context) throws MappingException {
+		FilterDefBinder.bindFilterDefs( annotatedClass, context );
+	}
+
 	/**
 	 * Bind an annotated class. A subclass must be bound <em>after</em> its superclass.
 	 *
@@ -388,7 +392,6 @@ public final class AnnotationBinder {
 
 		bindQueries( annotatedClass, context );
 		handleImport( annotatedClass, context );
-		bindFilterDefs( annotatedClass, context );
 		bindTypeDescriptorRegistrations( annotatedClass, context );
 		bindEmbeddableInstantiatorRegistrations( annotatedClass, context );
 		bindUserTypeRegistrations( annotatedClass, context );

--- a/hibernate-core/src/main/java/org/hibernate/boot/model/source/internal/annotations/AnnotationMetadataSourceProcessorImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/source/internal/annotations/AnnotationMetadataSourceProcessorImpl.java
@@ -37,6 +37,8 @@ import org.hibernate.internal.util.collections.CollectionHelper;
 import org.jboss.jandex.IndexView;
 import org.jboss.logging.Logger;
 
+import static org.hibernate.boot.model.internal.AnnotationBinder.bindFilterDefs;
+
 /**
  * @author Steve Ebersole
  */
@@ -248,6 +250,13 @@ public class AnnotationMetadataSourceProcessorImpl implements MetadataSourceProc
 				orderedClasses,
 				rootMetadataBuildingContext
 		);
+		// we want to go through all classes and collect the filter definitions first,
+		//  so that when we bind the classes we have the complete list of filters to search from:
+		for ( XClass clazz : orderedClasses ) {
+			if ( !processedEntityNames.contains( clazz.getName() ) ) {
+				bindFilterDefs( clazz, rootMetadataBuildingContext );
+			}
+		}
 
 		for ( XClass clazz : orderedClasses ) {
 			if ( processedEntityNames.contains( clazz.getName() ) ) {

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/filter/FilterDefinitionOrderTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/filter/FilterDefinitionOrderTest.java
@@ -1,0 +1,130 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.orm.test.filter;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import org.hibernate.SharedSessionContract;
+import org.hibernate.annotations.Filter;
+import org.hibernate.annotations.FilterDef;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.JiraKey;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.List;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DomainModel(
+        annotatedClasses = {
+                FilterDefinitionOrderTest.AMyEntity.class,
+                FilterDefinitionOrderTest.XEntity.class
+        }
+)
+@JiraKey("HHH-19036")
+// Real test is if it actually starts, as that's where the filter binding happens,
+// but let's also check that it was actually processed as well:
+public class FilterDefinitionOrderTest extends AbstractStatefulStatelessFilterTest {
+
+    @BeforeEach
+    void setUp() {
+        scope.inTransaction(session -> {
+            AMyEntity entity1 = new AMyEntity();
+            entity1.setField("test");
+            AMyEntity entity2 = new AMyEntity();
+            entity2.setField("Hello");
+            session.persist(entity1);
+            session.persist(entity2);
+        });
+    }
+
+    @AfterEach
+    void tearDown() {
+        scope.inTransaction(session -> {
+            session.createMutationQuery("delete from AMyEntity").executeUpdate();
+        });
+    }
+
+    @ParameterizedTest
+    @MethodSource("transactionKind")
+    void smokeTest(BiConsumer<SessionFactoryScope, Consumer<? extends SharedSessionContract>> inTransaction) {
+        inTransaction.accept(scope, session -> {
+            session.enableFilter("x_filter");
+            List<AMyEntity> entities = session.createQuery("FROM AMyEntity", AMyEntity.class).getResultList();
+            assertThat(entities).hasSize(1)
+                    .allSatisfy(entity -> assertThat(entity.getField()).isEqualTo("Hello"));
+
+            session.disableFilter("x_filter");
+            entities = session.createQuery("FROM AMyEntity", AMyEntity.class).getResultList();
+            assertThat(entities).hasSize(2);
+        });
+    }
+
+    @Entity(name = "AMyEntity")
+    @Filter(name = "x_filter")
+    public static class AMyEntity {
+        @Id
+        @GeneratedValue(strategy = GenerationType.SEQUENCE)
+        @Column(nullable = false)
+        private Long id;
+
+        public String field;
+
+        public Long getId() {
+            return id;
+        }
+
+        public void setId(Long id) {
+            this.id = id;
+        }
+
+        public String getField() {
+            return field;
+        }
+
+        public void setField(String field) {
+            this.field = field;
+        }
+    }
+
+    @Entity(name = "XEntity")
+    @FilterDef(name = "x_filter", defaultCondition = "field = 'Hello'")
+    public static class XEntity {
+
+        @Id
+        @GeneratedValue(strategy = GenerationType.SEQUENCE)
+        @Column(nullable = false)
+        private Long id;
+
+        public String field;
+
+        public Long getId() {
+            return id;
+        }
+
+        public void setId(Long id) {
+            this.id = id;
+        }
+
+        public String getField() {
+            return field;
+        }
+
+        public void setField(String field) {
+            this.field = field;
+        }
+    }
+}


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-19036

This already works fine in 7.0 since the switch to models and having this:

https://github.com/hibernate/hibernate-orm/blob/f0bfef9ce35e6ba7caf27904e503b5fceb5f81e1/hibernate-core/src/main/java/org/hibernate/boot/model/source/internal/annotations/AnnotationMetadataSourceProcessorImpl.java#L170-L177

I did consider doing the pass over classes in the processFilterDefinitions method as well for 6.6, but it feels a bit redundant to generate the `orderedClasses = orderAndFillHierarchy( xClasses )` two times, or alternatively going through `xClasses` + their super types... so this seems like a good compromise, no ?

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
