### PR TITLE
HHH-19301 Must import FQCN when generating metamodel class for inner Jakarta Data repository interface

### DIFF
--- a/tooling/metamodel-generator/src/jakartaData/java/org/hibernate/processor/test/data/innerclass/InnerRepositoryTest.java
+++ b/tooling/metamodel-generator/src/jakartaData/java/org/hibernate/processor/test/data/innerclass/InnerRepositoryTest.java
@@ -1,0 +1,43 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.processor.test.data.innerclass;
+
+import jakarta.data.page.Page;
+import jakarta.data.page.PageRequest;
+import jakarta.data.repository.DataRepository;
+import jakarta.data.repository.Find;
+import jakarta.data.repository.Repository;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import org.hibernate.processor.test.util.CompilationTest;
+import org.hibernate.processor.test.util.WithClasses;
+import org.junit.Test;
+
+import static org.hibernate.processor.test.util.TestUtil.assertMetamodelClassGeneratedFor;
+import static org.hibernate.processor.test.util.TestUtil.getMetaModelSourceAsString;
+
+public class InnerRepositoryTest extends CompilationTest {
+
+	@Test
+	@WithClasses({Thing.class, ThingRepo.class})
+	public void test() {
+		System.out.println( getMetaModelSourceAsString( ThingRepo.class ) );
+		assertMetamodelClassGeneratedFor( ThingRepo.class );
+	}
+
+	@Entity
+	public static class Thing {
+		@Id
+		Long id;
+
+		String data;
+	}
+
+	@Repository
+	public interface ThingRepo extends DataRepository<Thing, Long> {
+		@Find
+		Page<Thing> thing(PageRequest pageRequest);
+	}
+}

--- a/tooling/metamodel-generator/src/main/java/org/hibernate/processor/annotation/AnnotationMetaEntity.java
+++ b/tooling/metamodel-generator/src/main/java/org/hibernate/processor/annotation/AnnotationMetaEntity.java
@@ -183,6 +183,9 @@ public class AnnotationMetaEntity extends AnnotationMeta {
 		importContext.importType(
 				getGeneratedClassFullyQualifiedName( element, getPackageName( context, element ),
 						jakartaDataStaticModel ) );
+		if ( !element.getQualifiedName().toString().endsWith( "$" ) ) {
+			importContext.importType( element.getQualifiedName().toString() );
+		}
 	}
 
 	public static AnnotationMetaEntity create(TypeElement element, Context context, @Nullable AnnotationMetaEntity parent) {


### PR DESCRIPTION
Jira issue [HHH-19301](https://hibernate.atlassian.net/browse/HHH-19301)

Fully qualified name should be imported for inner (static) Jakarta Data repository interface

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------


[HHH-19301]: https://hibernate.atlassian.net/browse/HHH-19301?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ