### PR TITLE
HHH-19312 BytecodeProviderImpl throwing java.lang.IndexOutOfBoundsException

### DIFF
--- a/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/lazy/proxy/index_out_of_bounds/BytecodeProviderIndexOutOfBoundsTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/lazy/proxy/index_out_of_bounds/BytecodeProviderIndexOutOfBoundsTest.java
@@ -1,0 +1,47 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.bytecode.enhancement.lazy.proxy.index_out_of_bounds;
+
+import org.hibernate.orm.test.bytecode.enhancement.lazy.proxy.index_out_of_bounds.base.EmbeddableType;
+import org.hibernate.orm.test.bytecode.enhancement.lazy.proxy.index_out_of_bounds.derived.TestEntity;
+import org.hibernate.testing.bytecode.enhancement.EnhancementOptions;
+import org.hibernate.testing.bytecode.enhancement.extension.BytecodeEnhanced;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.JiraKey;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DomainModel(
+		annotatedClasses = {
+				TestEntity.class
+		}
+)
+@SessionFactory
+@BytecodeEnhanced
+@EnhancementOptions(lazyLoading = true, inlineDirtyChecking = true)
+@JiraKey( "HHH-19312" )
+public class BytecodeProviderIndexOutOfBoundsTest {
+
+	@Test
+	public void testIt(SessionFactoryScope scope) {
+		// Just a smoke test; the original failure happened during bytecode enhancement.
+		Long id = scope.fromTransaction( s -> {
+			TestEntity testEntity = new TestEntity();
+			EmbeddableType embedded = new EmbeddableType();
+			embedded.setField( "someValue" );
+			testEntity.setEmbeddedField( embedded );
+			s.persist( testEntity );
+			return testEntity.getId();
+		} );
+		scope.inTransaction( s -> {
+			TestEntity testEntity = s.find( TestEntity.class, id );
+			assertThat( testEntity.getEmbeddedField().getField() ).isEqualTo( "someValue" );
+		} );
+	}
+
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/lazy/proxy/index_out_of_bounds/base/BaseEntity.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/lazy/proxy/index_out_of_bounds/base/BaseEntity.java
@@ -1,0 +1,47 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.bytecode.enhancement.lazy.proxy.index_out_of_bounds.base;
+
+import jakarta.persistence.Embedded;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.MappedSuperclass;
+
+@MappedSuperclass
+public abstract class BaseEntity {
+
+	private Long id;
+
+	protected EmbeddableType embeddedField;
+
+	private Long dummyField;
+
+	@Id
+	@GeneratedValue
+	public Long getId() {
+		return id;
+	}
+
+	public void setId(final Long id) {
+		this.id = id;
+	}
+
+	@Embedded
+	public EmbeddableType getEmbeddedField() {
+		return embeddedField;
+	}
+
+	public void setEmbeddedField(final EmbeddableType embeddedField) {
+		this.embeddedField = embeddedField;
+	}
+
+	public Long getDummyField() {
+		return dummyField;
+	}
+
+	void setDummyField(Long dummyField) {
+		this.dummyField = dummyField;
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/lazy/proxy/index_out_of_bounds/base/EmbeddableType.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/lazy/proxy/index_out_of_bounds/base/EmbeddableType.java
@@ -1,0 +1,23 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.bytecode.enhancement.lazy.proxy.index_out_of_bounds.base;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+
+@Embeddable
+public class EmbeddableType {
+
+	@Column
+	private String field;
+
+	public String getField() {
+		return field;
+	}
+
+	public void setField(final String field) {
+		this.field = field;
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/lazy/proxy/index_out_of_bounds/derived/TestEntity.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/lazy/proxy/index_out_of_bounds/derived/TestEntity.java
@@ -1,0 +1,16 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.bytecode.enhancement.lazy.proxy.index_out_of_bounds.derived;
+
+import jakarta.persistence.Access;
+import jakarta.persistence.AccessType;
+import jakarta.persistence.Entity;
+import org.hibernate.orm.test.bytecode.enhancement.lazy.proxy.index_out_of_bounds.base.BaseEntity;
+
+@Entity
+@Access(AccessType.PROPERTY)
+public class TestEntity extends BaseEntity {
+
+}


### PR DESCRIPTION
Example for Jira issue [HHH-19312](https://hibernate.atlassian.net/browse/HHH-19312)

Existing test `org.hibernate.orm.test.bytecode.enhancement.lazy.proxy.crosspackage.CrossPackageMappedSuperclassWithEmbeddableTest` and data are slightly changed to show the problem.

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------


[HHH-19312]: https://hibernate.atlassian.net/browse/HHH-19312?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ