### PR TITLE
HHH-19319 generalize loaders to handle stateless sessions, add StatelessSession.findMultiple()

### DIFF
--- a/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/HSQLLegacyDialect.java
+++ b/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/HSQLLegacyDialect.java
@@ -41,7 +41,7 @@ import org.hibernate.engine.jdbc.env.spi.IdentifierHelper;
 import org.hibernate.engine.jdbc.env.spi.IdentifierHelperBuilder;
 import org.hibernate.engine.jdbc.env.spi.NameQualifierSupport;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
-import org.hibernate.event.spi.EventSource;
+import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.exception.ConstraintViolationException;
 import org.hibernate.exception.spi.SQLExceptionConversionDelegate;
 import org.hibernate.exception.spi.TemplatedViolatedConstraintNameExtractor;
@@ -797,7 +797,7 @@ public class HSQLLegacyDialect extends Dialect {
 		}
 
 		@Override
-		public void lock(Object id, Object version, Object object, int timeout, EventSource session)
+		public void lock(Object id, Object version, Object object, int timeout, SharedSessionContractImplementor session)
 				throws StaleObjectStateException, JDBCException {
 			if ( getLockMode().greaterThan( LockMode.READ ) ) {
 				LOG.hsqldbSupportsOnlyReadCommittedIsolation();

--- a/hibernate-core/src/main/java/org/hibernate/StatelessSession.java
+++ b/hibernate-core/src/main/java/org/hibernate/StatelessSession.java
@@ -356,6 +356,23 @@ public interface StatelessSession extends SharedSessionContract {
 	<T> List<T> getMultiple(Class<T> entityClass, List<?> ids);
 
 	/**
+	 * Retrieve multiple rows, obtaining the specified lock mode,
+	 * and returning entity instances in a list where the position
+	 * of an instance in the list matches the position of its
+	 * identifier in the given array, and the list contains a null
+	 * value if there is no persistent instance matching a given
+	 * identifier.
+	 *
+	 * @param entityClass The class of the entity to retrieve
+	 * @param ids         The ids of the entities to retrieve
+	 * @param lockMode    The lock mode to apply to the entities
+	 * @return an ordered list of detached entity instances, with
+	 *         null elements representing missing entities
+	 * @since 7.0
+	 */
+	<T> List<T> getMultiple(Class<T> entityClass, List<?> ids, LockMode lockMode);
+
+	/**
 	 * Refresh the entity instance state from the database.
 	 *
 	 * @param entity The entity to be refreshed.

--- a/hibernate-core/src/main/java/org/hibernate/dialect/SpannerDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/SpannerDialect.java
@@ -25,7 +25,7 @@ import org.hibernate.dialect.unique.UniqueDelegate;
 import org.hibernate.engine.jdbc.dialect.spi.DialectResolutionInfo;
 import org.hibernate.engine.jdbc.env.spi.SchemaNameResolver;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
-import org.hibernate.event.spi.EventSource;
+import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.internal.util.collections.ArrayHelper;
 import org.hibernate.mapping.Column;
 import org.hibernate.mapping.ForeignKey;
@@ -891,7 +891,7 @@ public class SpannerDialect extends Dialect {
 
 		@Override
 		public void lock(
-				Object id, Object version, Object object, int timeout, EventSource session)
+				Object id, Object version, Object object, int timeout, SharedSessionContractImplementor session)
 				throws StaleObjectStateException, LockingStrategyException {
 			// Do nothing. Cloud Spanner doesn't have have locking strategies.
 		}

--- a/hibernate-core/src/main/java/org/hibernate/dialect/lock/AbstractSelectLockingStrategy.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/lock/AbstractSelectLockingStrategy.java
@@ -11,7 +11,7 @@ import org.hibernate.LockOptions;
 import org.hibernate.StaleObjectStateException;
 import org.hibernate.engine.jdbc.spi.JdbcCoordinator;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
-import org.hibernate.event.spi.EventSource;
+import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.persister.entity.EntityPersister;
 import org.hibernate.sql.SimpleSelect;
 import org.hibernate.stat.spi.StatisticsImplementor;
@@ -69,7 +69,7 @@ public abstract class AbstractSelectLockingStrategy implements LockingStrategy {
 	}
 
 	@Override
-	public void lock(Object id, Object version, Object object, int timeout, EventSource session)
+	public void lock(Object id, Object version, Object object, int timeout, SharedSessionContractImplementor session)
 			throws StaleObjectStateException, JDBCException {
 		final String sql = determineSql( timeout );
 		final SessionFactoryImplementor factory = session.getFactory();
@@ -112,7 +112,7 @@ public abstract class AbstractSelectLockingStrategy implements LockingStrategy {
 		}
 	}
 
-	private JDBCException jdbcException(Object id, EventSource session, SQLException sqle, String sql) {
+	private JDBCException jdbcException(Object id, SharedSessionContractImplementor session, SQLException sqle, String sql) {
 		return session.getJdbcServices().getSqlExceptionHelper()
 				.convert( sqle, "could not lock: " + infoString( lockable, id, session.getFactory() ), sql );
 	}

--- a/hibernate-core/src/main/java/org/hibernate/dialect/lock/LockingStrategy.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/lock/LockingStrategy.java
@@ -5,6 +5,7 @@
 package org.hibernate.dialect.lock;
 
 import org.hibernate.StaleObjectStateException;
+import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.event.spi.EventSource;
 
 /**
@@ -35,7 +36,36 @@ public interface LockingStrategy {
 	 * @throws StaleObjectStateException Indicates an inability to locate the database row as part of acquiring
 	 * the requested lock.
 	 * @throws LockingStrategyException Indicates a failure in the lock attempt
+	 *
+	 * @deprecated Use {@link #lock(Object, Object, Object, int, SharedSessionContractImplementor)}
 	 */
-	void lock(Object id, Object version, Object object, int timeout, EventSource session)
-			throws StaleObjectStateException, LockingStrategyException;
+	@Deprecated(since = "7")
+	default void lock(Object id, Object version, Object object, int timeout, EventSource session)
+			throws StaleObjectStateException, LockingStrategyException {
+		lock( id, version, object, timeout, (SharedSessionContractImplementor) session );
+	}
+
+	/**
+	 * Acquire an appropriate type of lock on the underlying data that will
+	 * endure until the end of the current transaction.
+	 *
+	 * @param id The id of the row to be locked
+	 * @param version The current version (or null if not versioned)
+	 * @param object The object logically being locked (currently not used)
+	 * @param timeout timeout in milliseconds, 0 = no wait, -1 = wait indefinitely
+	 * @param session The session from which the lock request originated
+	 *
+	 * @throws StaleObjectStateException Indicates an inability to locate the database row as part of acquiring
+	 * the requested lock.
+	 * @throws LockingStrategyException Indicates a failure in the lock attempt
+	 */
+	default void lock(Object id, Object version, Object object, int timeout, SharedSessionContractImplementor session)
+			throws StaleObjectStateException, LockingStrategyException {
+		if ( session instanceof EventSource eventSource ) {
+			lock( id, version, object, timeout, eventSource );
+		}
+		else {
+			throw new UnsupportedOperationException( "Optimistic locking strategies not supported in stateless session" );
+		}
+	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/dialect/lock/PessimisticForceIncrementLockingStrategy.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/lock/PessimisticForceIncrementLockingStrategy.java
@@ -7,7 +7,7 @@ package org.hibernate.dialect.lock;
 import org.hibernate.HibernateException;
 import org.hibernate.LockMode;
 import org.hibernate.engine.spi.EntityEntry;
-import org.hibernate.event.spi.EventSource;
+import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.persister.entity.EntityPersister;
 
 /**
@@ -39,7 +39,7 @@ public class PessimisticForceIncrementLockingStrategy implements LockingStrategy
 	}
 
 	@Override
-	public void lock(Object id, Object version, Object object, int timeout, EventSource session) {
+	public void lock(Object id, Object version, Object object, int timeout, SharedSessionContractImplementor session) {
 		if ( !lockable.isVersioned() ) {
 			throw new HibernateException( "[" + lockMode + "] not supported for non-versioned entities [" + lockable.getEntityName() + "]" );
 		}

--- a/hibernate-core/src/main/java/org/hibernate/dialect/lock/PessimisticReadUpdateLockingStrategy.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/lock/PessimisticReadUpdateLockingStrategy.java
@@ -14,7 +14,7 @@ import org.hibernate.LockMode;
 import org.hibernate.StaleObjectStateException;
 import org.hibernate.engine.jdbc.spi.JdbcCoordinator;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
-import org.hibernate.event.spi.EventSource;
+import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.internal.CoreMessageLogger;
 import org.hibernate.persister.entity.EntityPersister;
 import org.hibernate.pretty.MessageHelper;
@@ -69,7 +69,7 @@ public class PessimisticReadUpdateLockingStrategy implements LockingStrategy {
 	}
 
 	@Override
-	public void lock(Object id, Object version, Object object, int timeout, EventSource session) {
+	public void lock(Object id, Object version, Object object, int timeout, SharedSessionContractImplementor session) {
 		if ( !lockable.isVersioned() ) {
 			throw new HibernateException( "write locks via update not supported for non-versioned entities [" + lockable.getEntityName() + "]" );
 		}

--- a/hibernate-core/src/main/java/org/hibernate/dialect/lock/PessimisticWriteUpdateLockingStrategy.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/lock/PessimisticWriteUpdateLockingStrategy.java
@@ -14,7 +14,7 @@ import org.hibernate.LockMode;
 import org.hibernate.StaleObjectStateException;
 import org.hibernate.engine.jdbc.spi.JdbcCoordinator;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
-import org.hibernate.event.spi.EventSource;
+import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.internal.CoreMessageLogger;
 import org.hibernate.persister.entity.EntityPersister;
 import org.hibernate.pretty.MessageHelper;
@@ -68,7 +68,7 @@ public class PessimisticWriteUpdateLockingStrategy implements LockingStrategy {
 	}
 
 	@Override
-	public void lock(Object id, Object version, Object object, int timeout, EventSource session) {
+	public void lock(Object id, Object version, Object object, int timeout, SharedSessionContractImplementor session) {
 		if ( !lockable.isVersioned() ) {
 			throw new HibernateException( "write locks via update not supported for non-versioned entities [" + lockable.getEntityName() + "]" );
 		}

--- a/hibernate-core/src/main/java/org/hibernate/dialect/lock/UpdateLockingStrategy.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/lock/UpdateLockingStrategy.java
@@ -14,7 +14,7 @@ import org.hibernate.LockMode;
 import org.hibernate.StaleObjectStateException;
 import org.hibernate.engine.jdbc.spi.JdbcCoordinator;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
-import org.hibernate.event.spi.EventSource;
+import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.internal.CoreMessageLogger;
 import org.hibernate.persister.entity.EntityPersister;
 import org.hibernate.pretty.MessageHelper;
@@ -72,7 +72,7 @@ public class UpdateLockingStrategy implements LockingStrategy {
 			Object version,
 			Object object,
 			int timeout,
-			EventSource session) throws StaleObjectStateException, JDBCException {
+			SharedSessionContractImplementor session) throws StaleObjectStateException, JDBCException {
 		final String lockableEntityName = lockable.getEntityName();
 		if ( !lockable.isVersioned() ) {
 			throw new HibernateException( "write locks via update not supported for non-versioned entities [" + lockableEntityName + "]" );

--- a/hibernate-core/src/main/java/org/hibernate/engine/spi/SessionDelegatorBaseImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/spi/SessionDelegatorBaseImpl.java
@@ -1236,4 +1236,9 @@ public class SessionDelegatorBaseImpl implements SessionImplementor {
 	public FormatMapper getXmlFormatMapper() {
 		return delegate.getXmlFormatMapper();
 	}
+
+	@Override
+	public Object loadFromSecondLevelCache(EntityPersister persister, EntityKey entityKey, Object instanceToLoad, LockMode lockMode) {
+		return delegate.loadFromSecondLevelCache( persister, entityKey, instanceToLoad, lockMode );
+	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/engine/spi/SessionImplementor.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/spi/SessionImplementor.java
@@ -7,7 +7,6 @@ package org.hibernate.engine.spi;
 import jakarta.persistence.ConnectionConsumer;
 import jakarta.persistence.ConnectionFunction;
 import org.hibernate.HibernateException;
-import org.hibernate.LockOptions;
 import org.hibernate.Session;
 import org.hibernate.engine.jdbc.LobCreationContext;
 import org.hibernate.engine.jdbc.spi.JdbcCoordinator;
@@ -94,11 +93,6 @@ public interface SessionImplementor extends Session, SharedSessionContractImplem
 	 * Initiate a flush to force deletion of a re-persisted entity.
 	 */
 	void forceFlush(EntityKey e) throws HibernateException;
-
-	/**
-	 * Cascade the lock operation to the given child entity.
-	 */
-	void lock(String entityName, Object child, LockOptions lockOptions);
 
 	@Override
 	default SessionImplementor asSessionImplementor() {

--- a/hibernate-core/src/main/java/org/hibernate/engine/spi/SharedSessionContractImplementor.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/spi/SharedSessionContractImplementor.java
@@ -12,7 +12,9 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 
 import org.hibernate.FlushMode;
 import org.hibernate.HibernateException;
+import org.hibernate.Incubating;
 import org.hibernate.Interceptor;
+import org.hibernate.LockMode;
 import org.hibernate.StatelessSession;
 import org.hibernate.boot.spi.SessionFactoryOptions;
 import org.hibernate.dialect.Dialect;
@@ -584,4 +586,18 @@ public interface SharedSessionContractImplementor
 		return false;
 	}
 
+	/**
+	 * Attempts to load the entity from the second-level cache.
+	 *
+	 * @param persister The persister for the entity being requested for load
+	 * @param entityKey The entity key
+	 * @param instanceToLoad The instance that is being initialized, or null
+	 * @param lockMode The lock mode
+	 *
+	 * @return The entity from the second-level cache, or null.
+	 *
+	 * @since 7.0
+	 */
+	@Incubating
+	Object loadFromSecondLevelCache(EntityPersister persister, EntityKey entityKey, Object instanceToLoad, LockMode lockMode);
 }

--- a/hibernate-core/src/main/java/org/hibernate/engine/spi/SharedSessionContractImplementor.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/spi/SharedSessionContractImplementor.java
@@ -15,6 +15,7 @@ import org.hibernate.HibernateException;
 import org.hibernate.Incubating;
 import org.hibernate.Interceptor;
 import org.hibernate.LockMode;
+import org.hibernate.LockOptions;
 import org.hibernate.StatelessSession;
 import org.hibernate.boot.spi.SessionFactoryOptions;
 import org.hibernate.dialect.Dialect;
@@ -585,6 +586,11 @@ public interface SharedSessionContractImplementor
 	default boolean isStatelessSession() {
 		return false;
 	}
+
+	/**
+	 * Cascade the lock operation to the given child entity.
+	 */
+	void lock(String entityName, Object child, LockOptions lockOptions);
 
 	/**
 	 * Attempts to load the entity from the second-level cache.

--- a/hibernate-core/src/main/java/org/hibernate/engine/spi/SharedSessionDelegatorBaseImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/spi/SharedSessionDelegatorBaseImpl.java
@@ -17,6 +17,7 @@ import org.hibernate.Filter;
 import org.hibernate.FlushMode;
 import org.hibernate.HibernateException;
 import org.hibernate.Interceptor;
+import org.hibernate.LockMode;
 import org.hibernate.SharedSessionContract;
 import org.hibernate.Transaction;
 import org.hibernate.cache.spi.CacheTransactionSynchronization;
@@ -690,5 +691,10 @@ public class SharedSessionDelegatorBaseImpl implements SharedSessionContractImpl
 	@Override
 	public FormatMapper getXmlFormatMapper() {
 		return delegate.getXmlFormatMapper();
+	}
+
+	@Override
+	public Object loadFromSecondLevelCache(EntityPersister persister, EntityKey entityKey, Object instanceToLoad, LockMode lockMode) {
+		return delegate.loadFromSecondLevelCache( persister, entityKey, instanceToLoad, lockMode );
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/engine/spi/SharedSessionDelegatorBaseImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/spi/SharedSessionDelegatorBaseImpl.java
@@ -18,6 +18,7 @@ import org.hibernate.FlushMode;
 import org.hibernate.HibernateException;
 import org.hibernate.Interceptor;
 import org.hibernate.LockMode;
+import org.hibernate.LockOptions;
 import org.hibernate.SharedSessionContract;
 import org.hibernate.Transaction;
 import org.hibernate.cache.spi.CacheTransactionSynchronization;
@@ -691,6 +692,11 @@ public class SharedSessionDelegatorBaseImpl implements SharedSessionContractImpl
 	@Override
 	public FormatMapper getXmlFormatMapper() {
 		return delegate.getXmlFormatMapper();
+	}
+
+	@Override
+	public void lock(String entityName, Object child, LockOptions lockOptions) {
+		delegate.lock( entityName, child, lockOptions );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/event/spi/EventSource.java
+++ b/hibernate-core/src/main/java/org/hibernate/event/spi/EventSource.java
@@ -5,8 +5,6 @@
 package org.hibernate.event.spi;
 
 import org.hibernate.HibernateException;
-import org.hibernate.Incubating;
-import org.hibernate.LockMode;
 import org.hibernate.engine.spi.ActionQueue;
 import org.hibernate.engine.spi.EntityEntry;
 import org.hibernate.engine.spi.EntityKey;
@@ -70,18 +68,4 @@ public interface EventSource extends SessionImplementor {
 	//       This should be removed once action/task ordering is improved.
 	void removeOrphanBeforeUpdates(String entityName, Object child);
 
-	/**
-	 * Attempts to load the entity from the second-level cache.
-	 *
-	 * @param persister The persister for the entity being requested for load
-	 * @param entityKey The entity key
-	 * @param instanceToLoad The instance that is being initialized, or null
-	 * @param lockMode The lock mode
-	 *
-	 * @return The entity from the second-level cache, or null.
-	 *
-	 * @since 7.0
-	 */
-	@Incubating
-	Object loadFromSecondLevelCache(EntityPersister persister, EntityKey entityKey, Object instanceToLoad, LockMode lockMode);
 }

--- a/hibernate-core/src/main/java/org/hibernate/internal/MultiIdentifierLoadAccessImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/MultiIdentifierLoadAccessImpl.java
@@ -89,12 +89,7 @@ class MultiIdentifierLoadAccessImpl<T> implements MultiIdentifierLoadAccess<T>, 
 
 	@Override
 	public MultiIdentifierLoadAccess<T> withBatchSize(int batchSize) {
-		if ( batchSize < 1 ) {
-			this.batchSize = null;
-		}
-		else {
-			this.batchSize = batchSize;
-		}
+		this.batchSize = batchSize < 1 ? null : batchSize;
 		return this;
 	}
 
@@ -186,16 +181,9 @@ class MultiIdentifierLoadAccessImpl<T> implements MultiIdentifierLoadAccess<T>, 
 	@Override
 	@SuppressWarnings( "unchecked" )
 	public <K> List<T> multiLoad(List<K> ids) {
-		if ( ids.isEmpty() ) {
-			return emptyList();
-		}
-		else {
-			return perform( () -> (List<T>) entityPersister.multiLoad(
-					ids.toArray( new Object[0] ),
-					session,
-					this
-			) );
-		}
+		return ids.isEmpty()
+				? emptyList()
+				: perform( () -> (List<T>) entityPersister.multiLoad( ids.toArray(), session, this ) );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/internal/MultiIdentifierLoadAccessImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/MultiIdentifierLoadAccessImpl.java
@@ -16,6 +16,7 @@ import org.hibernate.UnknownProfileException;
 import org.hibernate.engine.spi.EffectiveEntityGraph;
 import org.hibernate.engine.spi.LoadQueryInfluencers;
 import org.hibernate.engine.spi.SessionImplementor;
+import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.graph.GraphSemantic;
 import org.hibernate.graph.RootGraph;
 import org.hibernate.graph.spi.RootGraphImplementor;
@@ -28,7 +29,7 @@ import static java.util.Collections.emptyList;
  * @author Steve Ebersole
  */
 class MultiIdentifierLoadAccessImpl<T> implements MultiIdentifierLoadAccess<T>, MultiIdLoadOptions {
-	private final SessionImpl session;
+	private final SharedSessionContractImplementor session;
 	private final EntityPersister entityPersister;
 
 	private LockOptions lockOptions;
@@ -46,7 +47,7 @@ class MultiIdentifierLoadAccessImpl<T> implements MultiIdentifierLoadAccess<T>, 
 	private Set<String> enabledFetchProfiles;
 	private Set<String> disabledFetchProfiles;
 
-	public MultiIdentifierLoadAccessImpl(SessionImpl session, EntityPersister entityPersister) {
+	public MultiIdentifierLoadAccessImpl(SharedSessionContractImplementor session, EntityPersister entityPersister) {
 		this.session = session;
 		this.entityPersister = entityPersister;
 	}

--- a/hibernate-core/src/main/java/org/hibernate/internal/NaturalIdMultiLoadAccessStandard.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/NaturalIdMultiLoadAccessStandard.java
@@ -12,6 +12,7 @@ import org.hibernate.LockOptions;
 import org.hibernate.NaturalIdMultiLoadAccess;
 import org.hibernate.engine.spi.EffectiveEntityGraph;
 import org.hibernate.engine.spi.LoadQueryInfluencers;
+import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.graph.GraphSemantic;
 import org.hibernate.graph.RootGraph;
 import org.hibernate.graph.spi.RootGraphImplementor;
@@ -24,7 +25,7 @@ import org.hibernate.persister.entity.EntityPersister;
  */
 public class NaturalIdMultiLoadAccessStandard<T> implements NaturalIdMultiLoadAccess<T>, MultiNaturalIdLoadOptions {
 	private final EntityPersister entityDescriptor;
-	private final SessionImpl session;
+	private final SharedSessionContractImplementor session;
 
 	private LockOptions lockOptions;
 	private CacheMode cacheMode;
@@ -36,7 +37,7 @@ public class NaturalIdMultiLoadAccessStandard<T> implements NaturalIdMultiLoadAc
 	private boolean returnOfDeletedEntitiesEnabled;
 	private boolean orderedReturnEnabled = true;
 
-	public NaturalIdMultiLoadAccessStandard(EntityPersister entityDescriptor, SessionImpl session) {
+	public NaturalIdMultiLoadAccessStandard(EntityPersister entityDescriptor, SharedSessionContractImplementor session) {
 		this.entityDescriptor = entityDescriptor;
 		this.session = session;
 	}

--- a/hibernate-core/src/main/java/org/hibernate/loader/ast/internal/AbstractMultiIdEntityLoader.java
+++ b/hibernate-core/src/main/java/org/hibernate/loader/ast/internal/AbstractMultiIdEntityLoader.java
@@ -12,7 +12,7 @@ import org.hibernate.engine.spi.BatchFetchQueue;
 import org.hibernate.engine.spi.EntityKey;
 import org.hibernate.engine.spi.PersistenceContext;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
-import org.hibernate.event.spi.EventSource;
+import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.loader.ast.spi.MultiIdEntityLoader;
 import org.hibernate.loader.ast.spi.MultiIdLoadOptions;
 import org.hibernate.loader.internal.CacheLoadHelper.PersistenceContextEntry;
@@ -78,7 +78,7 @@ public abstract class AbstractMultiIdEntityLoader<T> implements MultiIdEntityLoa
 	}
 
 	@Override
-	public final <K> List<T> load(K[] ids, MultiIdLoadOptions loadOptions, EventSource session) {
+	public final <K> List<T> load(K[] ids, MultiIdLoadOptions loadOptions, SharedSessionContractImplementor session) {
 		assert ids != null;
 		return loadOptions.isOrderReturnEnabled()
 				? performOrderedMultiLoad( ids, loadOptions, session )
@@ -88,7 +88,7 @@ public abstract class AbstractMultiIdEntityLoader<T> implements MultiIdEntityLoa
 	private List<T> performUnorderedMultiLoad(
 			Object[] ids,
 			MultiIdLoadOptions loadOptions,
-			EventSource session) {
+			SharedSessionContractImplementor session) {
 		assert !loadOptions.isOrderReturnEnabled();
 		assert ids != null;
 		if ( MULTI_KEY_LOAD_LOGGER.isTraceEnabled() ) {
@@ -100,7 +100,7 @@ public abstract class AbstractMultiIdEntityLoader<T> implements MultiIdEntityLoa
 	protected List<T> performOrderedMultiLoad(
 			Object[] ids,
 			MultiIdLoadOptions loadOptions,
-			EventSource session) {
+			SharedSessionContractImplementor session) {
 		assert loadOptions.isOrderReturnEnabled();
 		assert ids != null;
 		if ( MULTI_KEY_LOAD_LOGGER.isTraceEnabled() ) {
@@ -113,7 +113,7 @@ public abstract class AbstractMultiIdEntityLoader<T> implements MultiIdEntityLoa
 			Object[] ids,
 			MultiIdLoadOptions loadOptions,
 			LockOptions lockOptions,
-			EventSource session) {
+			SharedSessionContractImplementor session) {
 		final boolean idCoercionEnabled = isIdCoercionEnabled();
 		final JavaType<?> idType = getLoadable().getIdentifierMapping().getJavaType();
 
@@ -168,7 +168,7 @@ public abstract class AbstractMultiIdEntityLoader<T> implements MultiIdEntityLoa
 
 	protected void handleResults(
 			MultiIdLoadOptions loadOptions,
-			EventSource session,
+			SharedSessionContractImplementor session,
 			List<Integer> elementPositionsLoadedByBatch,
 			List<Object> results) {
 		final PersistenceContext persistenceContext = session.getPersistenceContext();
@@ -197,11 +197,11 @@ public abstract class AbstractMultiIdEntityLoader<T> implements MultiIdEntityLoa
 			List<Object> idsInBatch,
 			LockOptions lockOptions,
 			MultiIdLoadOptions loadOptions,
-			EventSource session);
+			SharedSessionContractImplementor session);
 
 	protected boolean loadFromEnabledCaches(
 			MultiIdLoadOptions loadOptions,
-			EventSource session,
+			SharedSessionContractImplementor session,
 			Object id,
 			LockOptions lockOptions,
 			EntityKey entityKey,
@@ -216,7 +216,7 @@ public abstract class AbstractMultiIdEntityLoader<T> implements MultiIdEntityLoa
 			EntityKey entityKey,
 			LockOptions lockOptions,
 			List<Object> results, int i,
-			EventSource session) {
+			SharedSessionContractImplementor session) {
 
 		if ( loadOptions.isSessionCheckingEnabled() ) {
 			// look for it in the Session first
@@ -251,7 +251,7 @@ public abstract class AbstractMultiIdEntityLoader<T> implements MultiIdEntityLoa
 			Object[] ids,
 			MultiIdLoadOptions loadOptions,
 			LockOptions lockOptions,
-			EventSource session) {
+			SharedSessionContractImplementor session) {
 		final List<T> result = arrayList( ids.length );
 		final Object[] unresolvableIds =
 				resolveInCachesIfEnabled( ids, loadOptions, lockOptions, session,
@@ -275,7 +275,7 @@ public abstract class AbstractMultiIdEntityLoader<T> implements MultiIdEntityLoa
 	protected abstract void loadEntitiesWithUnresolvedIds(
 			MultiIdLoadOptions loadOptions,
 			LockOptions lockOptions,
-			EventSource session,
+			SharedSessionContractImplementor session,
 			Object[] unresolvableIds,
 			List<T> results);
 
@@ -283,7 +283,7 @@ public abstract class AbstractMultiIdEntityLoader<T> implements MultiIdEntityLoa
 			Object[] ids,
 			@NonNull MultiIdLoadOptions loadOptions,
 			@NonNull LockOptions lockOptions,
-			EventSource session,
+			SharedSessionContractImplementor session,
 			ResolutionConsumer<R> resolutionConsumer) {
 		return loadOptions.isSessionCheckingEnabled() || loadOptions.isSecondLevelCacheCheckingEnabled()
 				// the user requested that we exclude ids corresponding to already managed
@@ -300,7 +300,7 @@ public abstract class AbstractMultiIdEntityLoader<T> implements MultiIdEntityLoa
 			Object[] ids,
 			MultiIdLoadOptions loadOptions,
 			LockOptions lockOptions,
-			EventSource session,
+			SharedSessionContractImplementor session,
 			ResolutionConsumer<R> resolutionConsumer) {
 
 		final boolean idCoercionEnabled = isIdCoercionEnabled();
@@ -346,7 +346,7 @@ public abstract class AbstractMultiIdEntityLoader<T> implements MultiIdEntityLoa
 			Object id,
 			EntityKey entityKey,
 			List<Object> unresolvedIds, int i,
-			EventSource session) {
+			SharedSessionContractImplementor session) {
 
 		// look for it in the Session first
 		final PersistenceContextEntry entry =
@@ -383,7 +383,7 @@ public abstract class AbstractMultiIdEntityLoader<T> implements MultiIdEntityLoa
 		return unresolvedIds;
 	}
 
-	private Object loadFromSecondLevelCache(EntityKey entityKey, LockOptions lockOptions, EventSource session) {
+	private Object loadFromSecondLevelCache(EntityKey entityKey, LockOptions lockOptions, SharedSessionContractImplementor session) {
 		final EntityPersister persister = getLoadable().getEntityPersister();
 		return session.loadFromSecondLevelCache( persister, entityKey, null, lockOptions.getLockMode() );
 	}

--- a/hibernate-core/src/main/java/org/hibernate/loader/ast/internal/MultiIdEntityLoaderArrayParam.java
+++ b/hibernate-core/src/main/java/org/hibernate/loader/ast/internal/MultiIdEntityLoaderArrayParam.java
@@ -10,7 +10,8 @@ import java.util.List;
 
 import org.hibernate.LockOptions;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
-import org.hibernate.event.spi.EventSource;
+import org.hibernate.engine.spi.SessionImplementor;
+import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.internal.build.AllowReflection;
 import org.hibernate.loader.ast.spi.MultiIdLoadOptions;
 import org.hibernate.loader.ast.spi.SqlArrayMultiKeyLoader;
@@ -80,7 +81,7 @@ public class MultiIdEntityLoaderArrayParam<E> extends AbstractMultiIdEntityLoade
 			List<Object> idsInBatch,
 			LockOptions lockOptions,
 			MultiIdLoadOptions loadOptions,
-			EventSource session) {
+			SharedSessionContractImplementor session) {
 		final SelectStatement sqlAst = createSelectBySingleArrayParameter(
 				getLoadable(),
 				getIdentifierMapping(),
@@ -111,7 +112,9 @@ public class MultiIdEntityLoaderArrayParam<E> extends AbstractMultiIdEntityLoade
 								JdbcParametersList.singleton( jdbcParameter ),
 								jdbcParameterBindings
 						),
-						TRUE.equals( loadOptions.getReadOnly( session ) ),
+						// stateless sessions don't have a read-only mode
+						session instanceof SessionImplementor statefulSession
+								&& TRUE.equals( loadOptions.getReadOnly( statefulSession ) ),
 						lockOptions
 				),
 				RowTransformerStandardImpl.instance(),
@@ -125,7 +128,7 @@ public class MultiIdEntityLoaderArrayParam<E> extends AbstractMultiIdEntityLoade
 	protected void loadEntitiesWithUnresolvedIds(
 			MultiIdLoadOptions loadOptions,
 			LockOptions lockOptions,
-			EventSource session,
+			SharedSessionContractImplementor session,
 			Object[] unresolvableIds,
 			List<E> result) {
 		final SelectStatement sqlAst = createSelectBySingleArrayParameter(

--- a/hibernate-core/src/main/java/org/hibernate/loader/ast/spi/MultiIdEntityLoader.java
+++ b/hibernate-core/src/main/java/org/hibernate/loader/ast/spi/MultiIdEntityLoader.java
@@ -6,7 +6,7 @@ package org.hibernate.loader.ast.spi;
 
 import java.util.List;
 
-import org.hibernate.event.spi.EventSource;
+import org.hibernate.engine.spi.SharedSessionContractImplementor;
 
 /**
  * Loader subtype for loading multiple entities by multiple identifier values.
@@ -15,5 +15,5 @@ public interface MultiIdEntityLoader<T> extends EntityMultiLoader<T> {
 	/**
 	 * Load multiple entities by id.  The exact result depends on the passed options.
 	 */
-	<K> List<T> load(K[] ids, MultiIdLoadOptions options, EventSource session);
+	<K> List<T> load(K[] ids, MultiIdLoadOptions options, SharedSessionContractImplementor session);
 }

--- a/hibernate-core/src/main/java/org/hibernate/loader/internal/CacheLoadHelper.java
+++ b/hibernate-core/src/main/java/org/hibernate/loader/internal/CacheLoadHelper.java
@@ -24,7 +24,6 @@ import org.hibernate.engine.spi.PersistentAttributeInterceptor;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.engine.spi.Status;
-import org.hibernate.event.spi.EventSource;
 import org.hibernate.event.spi.LoadEventListener;
 import org.hibernate.metamodel.model.domain.NavigableRole;
 import org.hibernate.persister.collection.CollectionPersister;
@@ -81,7 +80,7 @@ public class CacheLoadHelper {
 	public static PersistenceContextEntry loadFromSessionCache(
 			EntityKey keyToLoad, LockOptions lockOptions,
 			LoadEventListener.LoadType options,
-			EventSource session) {
+			SharedSessionContractImplementor session) {
 		final Object old = session.getEntityUsingInterceptor( keyToLoad );
 		if ( old != null ) {
 			// this object was already loaded

--- a/hibernate-core/src/main/java/org/hibernate/persister/entity/AbstractEntityPersister.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/entity/AbstractEntityPersister.java
@@ -2150,8 +2150,13 @@ public abstract class AbstractEntityPersister
 			Object version,
 			Object object,
 			LockMode lockMode,
-			EventSource session) throws HibernateException {
+			SharedSessionContractImplementor session) throws HibernateException {
 		getLocker( lockMode ).lock( id, version, object, LockOptions.WAIT_FOREVER, session );
+	}
+
+	@Override
+	public void lock(Object id, Object version, Object object, LockMode lockMode, EventSource session) {
+		lock( id, version, object, lockMode, (SharedSessionContractImplementor) session );
 	}
 
 	@Override
@@ -2160,8 +2165,13 @@ public abstract class AbstractEntityPersister
 			Object version,
 			Object object,
 			LockOptions lockOptions,
-			EventSource session) throws HibernateException {
+			SharedSessionContractImplementor session) throws HibernateException {
 		getLocker( lockOptions.getLockMode() ).lock( id, version, object, lockOptions.getTimeOut(), session );
+	}
+
+	@Override
+	public void lock(Object id, Object version, Object object, LockOptions lockOptions, EventSource session) {
+		lock( id, version, object, lockOptions, (SharedSessionContractImplementor) session );
 	}
 
 	@Override
@@ -3584,6 +3594,11 @@ public abstract class AbstractEntityPersister
 
 	@Override
 	public List<?> multiLoad(Object[] ids, EventSource session, MultiIdLoadOptions loadOptions) {
+		return multiLoad( ids, (SharedSessionContractImplementor) session, loadOptions );
+	}
+
+	@Override
+	public List<?> multiLoad(Object[] ids, SharedSessionContractImplementor session, MultiIdLoadOptions loadOptions) {
 		return multiIdLoader.load( ids, loadOptions, session );
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/persister/entity/EntityPersister.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/entity/EntityPersister.java
@@ -624,8 +624,24 @@ public interface EntityPersister extends EntityMappingType, EntityMutationTarget
 	 * @param loadOptions The options for loading
 	 *
 	 * @return The loaded, matching entities
+	 *
+	 * @deprecated Use {@link #multiLoad(Object[], SharedSessionContractImplementor, MultiIdLoadOptions)}
 	 */
-	List<?> multiLoad(Object[] ids, EventSource session, MultiIdLoadOptions loadOptions);
+	@Deprecated(since = "7")
+	default List<?> multiLoad(Object[] ids, EventSource session, MultiIdLoadOptions loadOptions) {
+		return multiLoad( ids, (SharedSessionContractImplementor) session, loadOptions );
+	}
+
+	/**
+	 * Performs a load of multiple entities (of this type) by identifier simultaneously.
+	 *
+	 * @param ids The identifiers to load
+	 * @param session The originating Session
+	 * @param loadOptions The options for loading
+	 *
+	 * @return The loaded, matching entities
+	 */
+	List<?> multiLoad(Object[] ids, SharedSessionContractImplementor session, MultiIdLoadOptions loadOptions);
 
 	@Override
 	default Object loadByUniqueKey(String propertyName, Object uniqueKey, SharedSessionContractImplementor session) {
@@ -637,13 +653,33 @@ public interface EntityPersister extends EntityMappingType, EntityMutationTarget
 
 	/**
 	 * Do a version check (optional operation)
+	 *
+	 * @deprecated Use {@link #lock(Object, Object, Object, LockMode, SharedSessionContractImplementor)}
 	 */
-	void lock(Object id, Object version, Object object, LockMode lockMode, EventSource session);
+	@Deprecated(since = "7")
+	default void lock(Object id, Object version, Object object, LockMode lockMode, EventSource session) {
+		lock( id, version, object, lockMode, (SharedSessionContractImplementor) session );
+	}
 
 	/**
 	 * Do a version check (optional operation)
 	 */
-	void lock(Object id, Object version, Object object, LockOptions lockOptions, EventSource session);
+	void lock(Object id, Object version, Object object, LockMode lockMode, SharedSessionContractImplementor session);
+
+	/**
+	 * Do a version check (optional operation)
+	 *
+	 * @deprecated Use {@link #lock(Object, Object, Object, LockOptions, SharedSessionContractImplementor)}
+	 */
+	@Deprecated(since = "7")
+	default void lock(Object id, Object version, Object object, LockOptions lockOptions, EventSource session) {
+		lock( id, version, object, lockOptions, (SharedSessionContractImplementor) session );
+	}
+
+	/**
+	 * Do a version check (optional operation)
+	 */
+	void lock(Object id, Object version, Object object, LockOptions lockOptions, SharedSessionContractImplementor session);
 
 	/**
 	 * Persist an instance

--- a/hibernate-core/src/main/java/org/hibernate/persister/entity/UnionSubclassEntityPersister.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/entity/UnionSubclassEntityPersister.java
@@ -340,11 +340,6 @@ public class UnionSubclassEntityPersister extends AbstractEntityPersister {
 	}
 
 	@Override
-	public int getSubclassPropertyTableNumber(String propertyName) {
-		return 0;
-	}
-
-	@Override
 	public String physicalTableNameForMutation(SelectableMapping selectableMapping) {
 		assert !selectableMapping.isFormula();
 		return tableName;

--- a/hibernate-core/src/main/java/org/hibernate/query/named/NamedObjectRepository.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/named/NamedObjectRepository.java
@@ -84,7 +84,7 @@ public interface NamedObjectRepository {
 	/**
 	 * Resolve the named query with the given name.
 	 */
-	NamedQueryMemento resolve(
+	NamedQueryMemento<?> resolve(
 			SessionFactoryImplementor sessionFactory,
 			MetadataImplementor bootMetamodel,
 			String registrationName);

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/jdbc/internal/DeferredResultSetAccess.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/jdbc/internal/DeferredResultSetAccess.java
@@ -134,13 +134,9 @@ public class DeferredResultSetAccess extends AbstractResultSetAccess {
 	 * For Hibernate Reactive
 	 */
 	protected void registerAfterLoadAction(ExecutionContext executionContext, LockOptions lockOptionsToUse) {
-		executionContext.getCallback().registerAfterLoadAction( (entity, persister, session) ->
-				session.asSessionImplementor().lock(
-						persister.getEntityName(),
-						entity,
-						lockOptionsToUse
-				)
-		);
+		executionContext.getCallback()
+				.registerAfterLoadAction( (entity, persister, session) ->
+						session.lock( persister.getEntityName(), entity, lockOptionsToUse ) );
 	}
 
 	private static boolean useFollowOnLocking(

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/jdbc/internal/DeferredResultSetAccess.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/jdbc/internal/DeferredResultSetAccess.java
@@ -7,13 +7,13 @@ package org.hibernate.sql.results.jdbc.internal;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.util.Collections;
 
 import org.hibernate.LockMode;
 import org.hibernate.LockOptions;
 import org.hibernate.dialect.Dialect;
 import org.hibernate.dialect.pagination.LimitHandler;
 import org.hibernate.dialect.pagination.NoopLimitHandler;
+import org.hibernate.engine.jdbc.spi.JdbcServices;
 import org.hibernate.engine.jdbc.spi.SqlStatementLogger;
 import org.hibernate.engine.spi.SessionEventListenerManager;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
@@ -32,6 +32,8 @@ import org.hibernate.sql.exec.spi.JdbcOperationQuerySelect;
 import org.hibernate.sql.exec.spi.JdbcParameterBinder;
 import org.hibernate.sql.exec.spi.JdbcParameterBindings;
 import org.hibernate.sql.exec.spi.JdbcSelectExecutor;
+
+import static java.util.Collections.emptyMap;
 
 /**
  * @author Steve Ebersole
@@ -62,11 +64,13 @@ public class DeferredResultSetAccess extends AbstractResultSetAccess {
 			JdbcSelectExecutor.StatementCreator statementCreator,
 			int resultCountEstimate) {
 		super( executionContext.getSession() );
+		final JdbcServices jdbcServices = executionContext.getSession().getJdbcServices();
+
 		this.jdbcParameterBindings = jdbcParameterBindings;
 		this.executionContext = executionContext;
 		this.jdbcSelect = jdbcSelect;
 		this.statementCreator = statementCreator;
-		this.sqlStatementLogger = executionContext.getSession().getJdbcServices().getSqlStatementLogger();
+		this.sqlStatementLogger = jdbcServices.getSqlStatementLogger();
 		this.resultCountEstimate = resultCountEstimate;
 
 		final QueryOptions queryOptions = executionContext.getQueryOptions();
@@ -79,54 +83,61 @@ public class DeferredResultSetAccess extends AbstractResultSetAccess {
 		else {
 			// Note that limit and lock aren't set for SQM as that is applied during SQL rendering
 			// But for native queries, we have to adapt the SQL string
-			final Dialect dialect = executionContext.getSession().getJdbcServices().getDialect();
-			String sql;
+			final Dialect dialect = jdbcServices.getDialect();
+
+			final String sql = jdbcSelect.getSqlString();
+
 			limit = queryOptions.getLimit();
-			if ( limit == null || limit.isEmpty() || jdbcSelect.usesLimitParameters() ) {
-				sql = jdbcSelect.getSqlString();
-				limitHandler = NoopLimitHandler.NO_LIMIT;
-			}
-			else {
-				limitHandler = dialect.getLimitHandler();
-				sql = limitHandler.processSql(
-						jdbcSelect.getSqlString(),
-						limit,
-						queryOptions
-				);
-			}
+			final boolean hasLimit = isHasLimit( jdbcSelect );
+			limitHandler = hasLimit ? NoopLimitHandler.NO_LIMIT : dialect.getLimitHandler();
+			final String sqlWithLimit = hasLimit ? sql : limitHandler.processSql( sql, limit, queryOptions );
 
 			final LockOptions lockOptions = queryOptions.getLockOptions();
 			final JdbcLockStrategy jdbcLockStrategy = jdbcSelect.getLockStrategy();
-			if ( jdbcLockStrategy != JdbcLockStrategy.NONE
-					&& lockOptions != null && !lockOptions.isEmpty() ) {
-				usesFollowOnLocking = useFollowOnLocking( jdbcLockStrategy, sql, queryOptions, lockOptions, dialect );
+			final String sqlWithLocking;
+			if ( hasLocking( jdbcLockStrategy, lockOptions ) ) {
+				usesFollowOnLocking = useFollowOnLocking( jdbcLockStrategy, sqlWithLimit, queryOptions, lockOptions, dialect );
 				if ( usesFollowOnLocking ) {
-					final LockMode lockMode = determineFollowOnLockMode( lockOptions );
-					if ( lockMode != LockMode.UPGRADE_SKIPLOCKED ) {
-						// Dialect prefers to perform locking in a separate step
-						if ( lockOptions.getLockMode() != LockMode.NONE ) {
-							LOG.usingFollowOnLocking();
-						}
-
-						final LockOptions lockOptionsToUse = new LockOptions( lockMode );
-						lockOptionsToUse.setTimeOut( lockOptions.getTimeOut() );
-						lockOptionsToUse.setLockScope( lockOptions.getLockScope() );
-
-						registerAfterLoadAction( executionContext, lockOptionsToUse );
-					}
+					handleFollowOnLocking( executionContext, lockOptions );
+					sqlWithLocking = sqlWithLimit;
 				}
 				else {
-					sql = dialect.applyLocksToSql( sql, lockOptions, Collections.emptyMap() );
+					sqlWithLocking = dialect.applyLocksToSql( sqlWithLimit, lockOptions, emptyMap() );
 				}
 			}
 			else {
 				usesFollowOnLocking = false;
+				sqlWithLocking = sqlWithLimit;
 			}
-			finalSql = dialect.addSqlHintOrComment(
-					sql,
-					queryOptions,
-					executionContext.getSession().getFactory().getSessionFactoryOptions().isCommentsEnabled()
-			);
+
+			final boolean commentsEnabled =
+					executionContext.getSession().getFactory()
+							.getSessionFactoryOptions().isCommentsEnabled();
+			finalSql = dialect.addSqlHintOrComment( sqlWithLocking, queryOptions, commentsEnabled );
+		}
+	}
+
+	private boolean isHasLimit(JdbcOperationQuerySelect jdbcSelect) {
+		return limit == null || limit.isEmpty() || jdbcSelect.usesLimitParameters();
+	}
+
+	private static boolean hasLocking(JdbcLockStrategy jdbcLockStrategy, LockOptions lockOptions) {
+		return jdbcLockStrategy != JdbcLockStrategy.NONE && lockOptions != null && !lockOptions.isEmpty();
+	}
+
+	private void handleFollowOnLocking(ExecutionContext executionContext, LockOptions lockOptions) {
+		final LockMode lockMode = determineFollowOnLockMode( lockOptions );
+		if ( lockMode != LockMode.UPGRADE_SKIPLOCKED ) {
+			// Dialect prefers to perform locking in a separate step
+			if ( lockOptions.getLockMode() != LockMode.NONE ) {
+				LOG.usingFollowOnLocking();
+			}
+
+			final LockOptions lockOptionsToUse = new LockOptions( lockMode );
+			lockOptionsToUse.setTimeOut( lockOptions.getTimeOut() );
+			lockOptionsToUse.setLockScope( lockOptions.getLockScope() );
+
+			registerAfterLoadAction( executionContext, lockOptionsToUse );
 		}
 	}
 
@@ -184,20 +195,10 @@ public class DeferredResultSetAccess extends AbstractResultSetAccess {
 	}
 
 	protected void bindParameters(PreparedStatement preparedStatement) throws SQLException {
-		final QueryOptions queryOptions = executionContext.getQueryOptions();
-
-		// set options
-		if ( queryOptions != null ) {
-			if ( queryOptions.getFetchSize() != null ) {
-				preparedStatement.setFetchSize( queryOptions.getFetchSize() );
-			}
-			if ( queryOptions.getTimeout() != null ) {
-				preparedStatement.setQueryTimeout( queryOptions.getTimeout() );
-			}
-		}
+		setQueryOptions( preparedStatement );
 
 		// bind parameters
-		// 		todo : validate that all query parameters were bound?
+		// todo : validate that all query parameters were bound?
 		int paramBindingPosition = 1;
 		paramBindingPosition += limitHandler.bindLimitParametersAtStartOfQuery( limit, preparedStatement, paramBindingPosition );
 		for ( JdbcParameterBinder parameterBinder : jdbcSelect.getParameterBinders() ) {
@@ -208,7 +209,6 @@ public class DeferredResultSetAccess extends AbstractResultSetAccess {
 					executionContext
 			);
 		}
-
 		paramBindingPosition += limitHandler.bindLimitParametersAtEndOfQuery( limit, preparedStatement, paramBindingPosition );
 
 		if ( !jdbcSelect.usesLimitParameters() && limit != null && limit.getMaxRows() != null ) {
@@ -218,6 +218,19 @@ public class DeferredResultSetAccess extends AbstractResultSetAccess {
 			final int maxRows = jdbcSelect.getMaxRows();
 			if ( maxRows != Integer.MAX_VALUE ) {
 				preparedStatement.setMaxRows( maxRows );
+			}
+		}
+	}
+
+	private void setQueryOptions(PreparedStatement preparedStatement) throws SQLException {
+		final QueryOptions queryOptions = executionContext.getQueryOptions();
+		// set options
+		if ( queryOptions != null ) {
+			if ( queryOptions.getFetchSize() != null ) {
+				preparedStatement.setFetchSize( queryOptions.getFetchSize() );
+			}
+			if ( queryOptions.getTimeout() != null ) {
+				preparedStatement.setQueryTimeout( queryOptions.getTimeout() );
 			}
 		}
 	}
@@ -234,9 +247,7 @@ public class DeferredResultSetAccess extends AbstractResultSetAccess {
 
 			bindParameters( preparedStatement );
 
-			final SessionEventListenerManager eventListenerManager = session
-					.getEventListenerManager();
-
+			final SessionEventListenerManager eventListenerManager = session.getEventListenerManager();
 			long executeStartNanos = 0;
 			if ( sqlStatementLogger.getLogSlowQuery() > 0 ) {
 				executeStartNanos = System.nanoTime();
@@ -257,17 +268,15 @@ public class DeferredResultSetAccess extends AbstractResultSetAccess {
 			skipRows( resultSet );
 			logicalConnection.getResourceRegistry().register( resultSet, preparedStatement );
 		}
-		catch (SQLException e) {
+		catch (SQLException exception) {
 			try {
 				release();
 			}
-			catch (RuntimeException e2) {
-				e.addSuppressed( e2 );
+			catch (RuntimeException suppressed) {
+				exception.addSuppressed( suppressed );
 			}
-			throw session.getJdbcServices().getSqlExceptionHelper().convert(
-					e,
-					"JDBC exception executing SQL [" + finalSql + "]"
-			);
+			throw session.getJdbcServices().getSqlExceptionHelper()
+					.convert( exception, "JDBC exception executing SQL [" + finalSql + "]" );
 		}
 	}
 
@@ -277,13 +286,7 @@ public class DeferredResultSetAccess extends AbstractResultSetAccess {
 
 	protected void skipRows(ResultSet resultSet) throws SQLException {
 		// For dialects that don't support an offset clause
-		final int rowsToSkip;
-		if ( !jdbcSelect.usesLimitParameters() && limit != null && limit.getFirstRow() != null && !limitHandler.supportsLimitOffset() ) {
-			rowsToSkip = limit.getFirstRow();
-		}
-		else {
-			rowsToSkip = jdbcSelect.getRowsToSkip();
-		}
+		final int rowsToSkip = getRowsToSkip();
 		if ( rowsToSkip != 0 ) {
 			try {
 				resultSet.absolute( rowsToSkip );
@@ -303,13 +306,20 @@ public class DeferredResultSetAccess extends AbstractResultSetAccess {
 		}
 	}
 
+	private int getRowsToSkip() {
+		return !jdbcSelect.usesLimitParameters()
+			&& limit != null && limit.getFirstRow() != null
+			&& !limitHandler.supportsLimitOffset()
+				? limit.getFirstRow()
+				: jdbcSelect.getRowsToSkip();
+	}
+
 	protected ResultSet wrapResultSet(ResultSet resultSet) throws SQLException {
 		return resultSet;
 	}
 
 	protected LockMode determineFollowOnLockMode(LockOptions lockOptions) {
 		final LockMode lockModeToUse = lockOptions.findGreatestLockMode();
-
 		if ( lockOptions.hasAliasSpecificLockModes() ) {
 			if ( lockOptions.getLockMode() == LockMode.NONE && lockModeToUse == LockMode.NONE ) {
 				return lockModeToUse;
@@ -323,8 +333,8 @@ public class DeferredResultSetAccess extends AbstractResultSetAccess {
 
 	@Override
 	public void release() {
-		final LogicalConnectionImplementor logicalConnection = getPersistenceContext().getJdbcCoordinator()
-				.getLogicalConnection();
+		final LogicalConnectionImplementor logicalConnection =
+				getPersistenceContext().getJdbcCoordinator().getLogicalConnection();
 		if ( resultSet != null ) {
 			logicalConnection.getResourceRegistry().release( resultSet, preparedStatement );
 			resultSet = null;
@@ -343,12 +353,14 @@ public class DeferredResultSetAccess extends AbstractResultSetAccess {
 		if ( limit != null && limit.getMaxRows() != null ) {
 			return limit.getMaxRows();
 		}
-		if ( jdbcSelect.getLimitParameter() != null ) {
+		else if ( jdbcSelect.getLimitParameter() != null ) {
 			return (int) jdbcParameterBindings.getBinding( jdbcSelect.getLimitParameter() ).getBindValue();
 		}
-		if ( resultCountEstimate > 0 ) {
+		else if ( resultCountEstimate > 0 ) {
 			return resultCountEstimate;
 		}
-		return super.getResultCountEstimate();
+		else {
+			return super.getResultCountEstimate();
+		}
 	}
 }

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/cfg/persister/GoofyPersisterClassProvider.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/cfg/persister/GoofyPersisterClassProvider.java
@@ -34,7 +34,6 @@ import org.hibernate.engine.spi.EntityEntryFactory;
 import org.hibernate.engine.spi.LoadQueryInfluencers;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
-import org.hibernate.event.spi.EventSource;
 import org.hibernate.generator.values.GeneratedValues;
 import org.hibernate.generator.values.GeneratedValuesMutationDelegate;
 import org.hibernate.id.IdentifierGenerator;
@@ -402,16 +401,16 @@ public class GoofyPersisterClassProvider implements PersisterClassResolver {
 		}
 
 		@Override
-		public List<?> multiLoad(Object[] ids, EventSource session, MultiIdLoadOptions loadOptions) {
+		public List<?> multiLoad(Object[] ids, SharedSessionContractImplementor session, MultiIdLoadOptions loadOptions) {
 			return Collections.emptyList();
 		}
 
 		@Override
-		public void lock(Object id, Object version, Object object, LockMode lockMode, EventSource session) {
+		public void lock(Object id, Object version, Object object, LockMode lockMode, SharedSessionContractImplementor session) {
 		}
 
 		@Override
-		public void lock(Object id, Object version, Object object, LockOptions lockOptions, EventSource session) {
+		public void lock(Object id, Object version, Object object, LockOptions lockOptions, SharedSessionContractImplementor session) {
 		}
 
 		@Override

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/ejb3configuration/PersisterClassProviderTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/ejb3configuration/PersisterClassProviderTest.java
@@ -31,7 +31,6 @@ import org.hibernate.engine.spi.EntityEntryFactory;
 import org.hibernate.engine.spi.LoadQueryInfluencers;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
-import org.hibernate.event.spi.EventSource;
 import org.hibernate.generator.values.GeneratedValues;
 import org.hibernate.generator.values.GeneratedValuesMutationDelegate;
 import org.hibernate.id.IdentifierGenerator;
@@ -441,16 +440,16 @@ public class PersisterClassProviderTest {
 		}
 
 		@Override
-		public List multiLoad(Object[] ids, EventSource session, MultiIdLoadOptions loadOptions) {
+		public List multiLoad(Object[] ids, SharedSessionContractImplementor session, MultiIdLoadOptions loadOptions) {
 			return Collections.emptyList();
 		}
 
 		@Override
-		public void lock(Object id, Object version, Object object, LockMode lockMode, EventSource session) {
+		public void lock(Object id, Object version, Object object, LockMode lockMode, SharedSessionContractImplementor session) {
 		}
 
 		@Override
-		public void lock(Object id, Object version, Object object, LockOptions lockOptions, EventSource session) {
+		public void lock(Object id, Object version, Object object, LockOptions lockOptions, SharedSessionContractImplementor session) {
 		}
 
 		@Override

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/legacy/CustomPersister.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/legacy/CustomPersister.java
@@ -431,7 +431,7 @@ public 	class CustomPersister implements EntityPersister {
 	}
 
 	@Override
-	public List<?> multiLoad(Object[] ids, EventSource session, MultiIdLoadOptions loadOptions) {
+	public List<?> multiLoad(Object[] ids, SharedSessionContractImplementor session, MultiIdLoadOptions loadOptions) {
 		return Collections.emptyList();
 	}
 
@@ -489,7 +489,7 @@ public 	class CustomPersister implements EntityPersister {
 			Object version,
 			Object object,
 			LockOptions lockOptions,
-			EventSource session
+			SharedSessionContractImplementor session
 	) throws HibernateException {
 
 		throw new UnsupportedOperationException();
@@ -503,7 +503,7 @@ public 	class CustomPersister implements EntityPersister {
 			Object version,
 			Object object,
 			LockMode lockMode,
-			EventSource session
+			SharedSessionContractImplementor session
 	) throws HibernateException {
 
 		throw new UnsupportedOperationException();

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/stateless/GetMultipleTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/stateless/GetMultipleTest.java
@@ -13,6 +13,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
+import static org.hibernate.LockMode.PESSIMISTIC_READ;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
@@ -36,6 +37,13 @@ public class GetMultipleTest {
 			assertEquals("hello mars",all.get(2).message);
 			assertNull(all.get(1));
 		});
+		scope.inStatelessTransaction(s-> {
+			List<Record> all = s.getMultiple(Record.class, List.of(456L, 123L, 2L), PESSIMISTIC_READ);
+			assertEquals("hello mars",all.get(0).message);
+			assertEquals("hello earth",all.get(1).message);
+			assertNull(all.get(2));
+		});
+
 	}
 	@Entity
 	static class Record {


### PR DESCRIPTION
cc @jrenaat

<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

[Please describe here what your change is about]

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-19318
<!-- Hibernate GitHub Bot issue links end -->