### PR TITLE
HHH-19307 - NPE when entity class missing from persistence.xml is id of another entity

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/boot/internal/InFlightMetadataCollectorImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/internal/InFlightMetadataCollectorImpl.java
@@ -1836,6 +1836,11 @@ public class InFlightMetadataCollectorImpl
 			if ( sp.isInPrimaryKey() ) {
 				final String referenceEntityName = sp.getReferencedEntityName();
 				final PersistentClass classMapping = getEntityBinding( referenceEntityName );
+				if ( classMapping == null ) {
+					throw new HibernateException(
+							"Primary key referenced an unknown entity : " + referenceEntityName
+					);
+				}
 				final String dependentTable = classMapping.getTable().getQualifiedTableName().render();
 				if ( !isADependencyOf.containsKey( dependentTable ) ) {
 					isADependencyOf.put( dependentTable, new HashSet<>() );

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/boot/BootFailureTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/boot/BootFailureTest.java
@@ -11,15 +11,18 @@ import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+
 import jakarta.persistence.EntityManagerFactory;
 import jakarta.persistence.Persistence;
 
+import org.hibernate.HibernateException;
 import org.hibernate.cfg.AvailableSettings;
 import org.hibernate.service.spi.ServiceException;
 
 import org.hibernate.testing.boot.ClassLoaderServiceTestingImpl;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * Test to verify that a dump configuration error results in an exception being
@@ -32,14 +35,22 @@ public class BootFailureTest {
 
 	@Test
 	public void exceptionOnIllegalPUTest() {
-		Assertions.assertThrows( ServiceException.class, () ->
+		assertThrows( ServiceException.class, () ->
 				bootstrapPersistenceUnit( "IntentionallyBroken" ) );
 	}
 
 	@Test
 	public void exceptionOnIllegalPUWithoutProviderTest() {
-		Assertions.assertThrows( ServiceException.class, () ->
+		assertThrows( ServiceException.class, () ->
 				bootstrapPersistenceUnit( "IntentionallyBrokenWihoutExplicitProvider" ) );
+	}
+
+	@Test
+	public void missingClassPUTest() {
+		assertThrows( HibernateException.class, () ->
+			bootstrapPersistenceUnit( "IntentionallyMissingClass" ),
+			"A HibernateException due to a missing class in the persistence.xml should have been thrown"
+			);
 	}
 
 	private void bootstrapPersistenceUnit(final String puName) {

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/boot/Event.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/boot/Event.java
@@ -1,0 +1,28 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.jpa.boot;
+
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToOne;
+
+/**
+* @author Jan Schatteman
+*/
+@Entity(name = "Event")
+public class Event {
+	@Id
+	@OneToOne
+	private EventId id;
+
+	public EventId getId() {
+		return id;
+	}
+
+	public void setId(EventId id) {
+		this.id = id;
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/boot/EventId.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/boot/EventId.java
@@ -1,0 +1,22 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.jpa.boot;
+
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+
+/**
+* @author Jan Schatteman
+*/
+@Entity(name = "EventId")
+public class EventId {
+
+	@Id
+	@GeneratedValue
+	private Long id;
+
+}

--- a/hibernate-core/src/test/resources/org/hibernate/orm/test/jpa/boot/META-INF/persistence.xml
+++ b/hibernate-core/src/test/resources/org/hibernate/orm/test/jpa/boot/META-INF/persistence.xml
@@ -25,4 +25,9 @@
         </properties>
     </persistence-unit>
 
+    <persistence-unit name="IntentionallyMissingClass">
+        <provider>org.hibernate.jpa.HibernatePersistenceProvider</provider>
+        <class>org.hibernate.orm.test.jpa.boot.Event</class>
+    </persistence-unit>
+
 </persistence>


### PR DESCRIPTION
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-19307
<!-- Hibernate GitHub Bot issue links end -->