### PR TITLE
Fix defect that currentValue parameter is still null in BeforeExecutionGenerator#generate() when id allowed to be assigned and was assigned

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/event/internal/AbstractSaveEventListener.java
+++ b/hibernate-core/src/main/java/org/hibernate/event/internal/AbstractSaveEventListener.java
@@ -114,7 +114,7 @@ public abstract class AbstractSaveEventListener<C> implements CallbackRegistryCo
 			// the @PrePersist callback to happen first
 			generatedId = null;
 		}
-		else if ( generatedBeforeExecution ) {
+		else if ( generatedBeforeExecution && ( ! generator.allowAssignedIdentifiers() || persister.getIdentifier( entity, source ) == null ) ) {
 			// go ahead and generate id, and then set it to
 			// the entity instance, so it will be available
 			// to the entity in the @PrePersist callback

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/idgen/userdefined/BeforeExecutionGeneratorWithAssignedIdentifiersTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/idgen/userdefined/BeforeExecutionGeneratorWithAssignedIdentifiersTest.java
@@ -1,0 +1,82 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.idgen.userdefined;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import org.hibernate.annotations.IdGeneratorType;
+import org.hibernate.annotations.ValueGenerationType;
+import org.hibernate.engine.spi.SharedSessionContractImplementor;
+import org.hibernate.generator.BeforeExecutionGenerator;
+import org.hibernate.generator.EventType;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.junit.jupiter.api.Test;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+import java.util.EnumSet;
+import java.util.UUID;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SessionFactory
+@DomainModel(annotatedClasses = BeforeExecutionGeneratorWithAssignedIdentifiersTest.Book.class)
+class BeforeExecutionGeneratorWithAssignedIdentifiersTest {
+
+	@Test
+	void testAssignedValueNotOverridden(SessionFactoryScope scope) {
+		final String assignedId = "assigned-id";
+		final Book book = new Book();
+		book.id = assignedId;
+		scope.inTransaction( session -> session.persist( book ) );
+		assertThat( book.id ).isEqualTo( assignedId );
+	}
+
+	@Entity
+	@Table(name = "books")
+	static class Book {
+		@Id @GeneratedValue
+		@AssignableIdGenerator
+		String id;
+	}
+
+	@IdGeneratorType(IdGenerator.class)
+	@ValueGenerationType(generatedBy = IdGenerator.class)
+	@Retention(RUNTIME)
+	@Target({FIELD, METHOD})
+	public @interface AssignableIdGenerator {}
+
+	public static class IdGenerator implements BeforeExecutionGenerator {
+
+		@Override
+		public Object generate(
+				SharedSessionContractImplementor session,
+				Object owner,
+				Object currentValue,
+				EventType eventType) {
+			if ( currentValue != null ) {
+				return currentValue;
+			}
+			return UUID.randomUUID().toString();
+		}
+
+		@Override
+		public EnumSet<EventType> getEventTypes() {
+			return EnumSet.of( EventType.INSERT );
+		}
+
+		@Override
+		public boolean allowAssignedIdentifiers() {
+			return true;
+		}
+	}
+}


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-19320

<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

Found this defect when working on Hibernate integration project in MongoDB.

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
