### PR TITLE
HHH-19321: Improve inline documentation for @SuppressWarnings in multiple methods

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/procedure/internal/ProcedureCallImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/procedure/internal/ProcedureCallImpl.java
@@ -1065,7 +1065,9 @@ public class ProcedureCallImpl<R>
 	}
 
 	@Override
-	@SuppressWarnings("unchecked")
+	@SuppressWarnings("unchecked") // This suppression is used to suppress unchecked cast warnings occurring when casting 'this', parameterMetadata,
+	// paramBindings, queryOptions, getSession(), or getOutputs() to the desired generic type T.
+	// Each cast is checked using cls.isInstance() or isAssignableFrom(), ensuring that the conversion is safe.
 	public <T> T unwrap(Class<T> cls) {
 		if ( cls.isInstance( this ) ) {
 			return (T) this;

--- a/hibernate-core/src/main/java/org/hibernate/procedure/internal/ProcedureCallImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/procedure/internal/ProcedureCallImpl.java
@@ -992,7 +992,10 @@ public class ProcedureCallImpl<R>
 	}
 
 	@Override
-	@SuppressWarnings("unchecked")
+	@SuppressWarnings("unchecked") // This suppression is used to suppress unchecked conversion warnings in two cases:
+	// 1. Returning Collections.EMPTY_LIST, which is a raw type, as a List<R>.
+	// 2. Casting the result of ResultSetOutput.getResultList() to List<R>.
+	// Both conversions are considered safe based on the intended usage.
 	public List<R> getResultList() {
 		if ( getMaxResults() == 0 ) {
 			return Collections.EMPTY_LIST;

--- a/hibernate-core/src/main/java/org/hibernate/procedure/internal/ProcedureCallImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/procedure/internal/ProcedureCallImpl.java
@@ -424,7 +424,8 @@ public class ProcedureCallImpl<R>
 	// Parameter registrations
 
 	@Override
-	@SuppressWarnings("unchecked")
+	@SuppressWarnings("unchecked") // This suppression is used to suppress unchecked conversion warnings that occur when converting a raw Class to a generic type.
+	// The underlying call to registerParameter is type-safe, so ignoring this warning is acceptable.
 	public ProcedureCallImplementor<R> registerStoredProcedureParameter(int position, Class type, ParameterMode mode) {
 		getSession().checkOpen( true );
 
@@ -443,7 +444,8 @@ public class ProcedureCallImpl<R>
 	}
 
 	@Override
-	@SuppressWarnings("unchecked")
+	@SuppressWarnings("unchecked") // This suppression is used to suppress unchecked conversion warnings that occur when converting a raw Class to a generic type.
+	// The underlying call to registerParameter is type-safe, so ignoring this warning is acceptable.
 	public ProcedureCallImplementor<R> registerStoredProcedureParameter(
 			String parameterName,
 			Class type,


### PR DESCRIPTION
<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->


Hello!

This PR enhances inline documentation for methods using @SuppressWarnings("unchecked") to address concerns highlighted in Effective Java: Item 27 – "Eliminate unchecked warnings."

- registerStoredProcedureParameter: Added comments explaining the unchecked conversion from raw Class to a generic type.
- getResultList: Documented the reason behind casting Collections.EMPTY_LIST as List<R> and casting ResultSetOutput to List<R>.
- unwrap: Clarified that runtime type checks (cls.isInstance()) ensure the safety of casting 'this', parameterMetadata, etc.

These changes help maintainers understand why the warnings are suppressed and prevent accidental removal or modification that might compromise type safety. 

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-19321
<!-- Hibernate GitHub Bot issue links end -->