### PR TITLE
Add .git-blame-ignore-revs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,6 +51,7 @@ GitHub there are a few pre-requisite steps to follow:
 the linked page, this also includes:
     * [set up your local git install](https://help.github.com/articles/set-up-git) 
     * clone your fork
+* Instruct git to ignore certain commits when using `git blame`. From the directory of your local clone, run this: `git config blame.ignoreRevsFile .git-blame-ignore-revs`
 * See the wiki pages for setting up your IDE, whether you use 
 [IntelliJ IDEA](https://hibernate.org/community/contribute/intellij-idea/)
 or [Eclipse](https://hibernate.org/community/contribute/eclipse-ide/)<sup>(1)</sup>.


### PR DESCRIPTION
Because Intellij will error out if we set git config to use this file and it does not exist, and we do need to set git config to use this file for the main branch, at least.


<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
