### PR TITLE
Backport to 6.2: Test the ci-commiter before checking the release type (manual/automatic)

### DIFF
--- a/ci/release/Jenkinsfile
+++ b/ci/release/Jenkinsfile
@@ -116,6 +116,13 @@ pipeline {
 					def releaseVersion
 					def developmentVersion
 
+					def lastCommitter = sh(script: 'git show -s --format=\'%an\'', returnStdout: true).trim()
+					def secondLastCommitter = sh(script: 'git show -s --format=\'%an\' HEAD~1', returnStdout: true).trim()
+					def isCiLastCommiter = lastCommitter == 'Hibernate-CI' && secondLastCommitter == 'Hibernate-CI'
+
+					echo "Last two commits were performed by '${lastCommitter}'/'${secondLastCommitter}'."
+					echo "Is 'Hibernate-CI' the last commiter: '${isCiLastCommiter}'."
+
 					if ( manualRelease ) {
 						echo "Release was requested manually"
 
@@ -134,9 +141,8 @@ pipeline {
 						echo "Release was triggered automatically"
 
 						// Avoid doing an automatic release for commits from a release
-						def lastCommitter = sh(script: 'git show -s --format=\'%an\'', returnStdout: true)
-						def secondLastCommitter = sh(script: 'git show -s --format=\'%an\' HEAD~1', returnStdout: true)
-						if (lastCommitter == 'Hibernate-CI' && secondLastCommitter == 'Hibernate-CI') {
+
+						if (isCiLastCommiter) {
 							print "INFO: Automatic release skipped because last commits were for the previous release"
 							currentBuild.getRawBuild().getExecutor().interrupt(Result.NOT_BUILT)
 							sleep(1)   // Interrupt is not blocking and does not take effect immediately.


### PR DESCRIPTION
<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

[Please describe here what your change is about]

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
