### PR TITLE
[6.6] HHH-19320 - Assigned id value is not passed into BeforeExecutionGenerator#generate() method when allowAssignedIdentifiers() is true and id has been assigned

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/event/internal/AbstractSaveEventListener.java
+++ b/hibernate-core/src/main/java/org/hibernate/event/internal/AbstractSaveEventListener.java
@@ -152,7 +152,8 @@ public abstract class AbstractSaveEventListener<C>
 			EventSource source,
 			BeforeExecutionGenerator generator,
 			EntityPersister persister) {
-		final Object id = generator.generate( source, entity, null, INSERT );
+		final Object currentValue = generator.allowAssignedIdentifiers() ? persister.getIdentifier( entity, source ) : null;
+		final Object id = generator.generate( source, entity, currentValue, INSERT );
 		if ( id == null ) {
 			throw new IdentifierGenerationException( "Null id generated for entity '" + persister.getEntityName() + "'" );
 		}

--- a/hibernate-core/src/main/java/org/hibernate/internal/StatelessSessionImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/StatelessSessionImpl.java
@@ -131,7 +131,8 @@ public class StatelessSessionImpl extends AbstractSharedSessionContract implemen
 		}
 		final Generator generator = persister.getGenerator();
 		if ( !generator.generatedOnExecution( entity, this ) ) {
-			id = ( (BeforeExecutionGenerator) generator).generate( this, entity, null, INSERT );
+			final Object currentValue = generator.allowAssignedIdentifiers() ? persister.getIdentifier( entity, this ) : null;
+			id = ( (BeforeExecutionGenerator) generator ).generate( this, entity, currentValue, INSERT );
 			if ( firePreInsert(entity, id, state, persister) ) {
 				return id;
 			}

--- a/hibernate-core/src/main/java/org/hibernate/mapping/Component.java
+++ b/hibernate-core/src/main/java/org/hibernate/mapping/Component.java
@@ -62,7 +62,6 @@ import org.hibernate.usertype.CompositeUserType;
 
 import static java.util.Collections.unmodifiableList;
 import static java.util.stream.Collectors.toList;
-import static org.hibernate.generator.EventType.INSERT;
 import static org.hibernate.internal.util.StringHelper.qualify;
 import static org.hibernate.mapping.MappingHelper.checkPropertyColumnDuplication;
 import static org.hibernate.metamodel.mapping.EntityDiscriminatorMapping.DISCRIMINATOR_ROLE_NAME;
@@ -798,10 +797,9 @@ public class Component extends SimpleValue implements MetaAttributable, Sortable
 		}
 
 		@Override
-		public Object execute(SharedSessionContractImplementor session, Object incomingObject) {
-			if ( !subgenerator.generatedOnExecution( incomingObject, session ) ) {
-				return ( (BeforeExecutionGenerator) subgenerator)
-						.generate( session, incomingObject, null, INSERT );
+		public BeforeExecutionGenerator getGenerator() {
+			if ( subgenerator instanceof BeforeExecutionGenerator ) {
+				return (BeforeExecutionGenerator) subgenerator;
 			}
 			else {
 				throw new IdentifierGenerationException( "Identity generation isn't supported for composite ids" );

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/idgen/userdefined/BeforeExecutionAssignedValuesTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/idgen/userdefined/BeforeExecutionAssignedValuesTest.java
@@ -1,0 +1,258 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.idgen.userdefined;
+
+import jakarta.persistence.Embeddable;
+import jakarta.persistence.EmbeddedId;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import org.hibernate.annotations.IdGeneratorType;
+import org.hibernate.annotations.ValueGenerationType;
+import org.hibernate.engine.spi.SharedSessionContractImplementor;
+import org.hibernate.generator.BeforeExecutionGenerator;
+import org.hibernate.generator.EventType;
+import org.hibernate.generator.EventTypeSets;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.Jira;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Test;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+import java.util.EnumSet;
+import java.util.UUID;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SessionFactory
+@DomainModel(annotatedClasses = {
+		BeforeExecutionAssignedValuesTest.EntityWithGeneratedId.class,
+		BeforeExecutionAssignedValuesTest.GeneratedCompositeId.class,
+		BeforeExecutionAssignedValuesTest.EntityWithGeneratedEmbeddedId.class,
+		BeforeExecutionAssignedValuesTest.EntityWithGeneratedProperty.class,
+})
+@Jira("https://hibernate.atlassian.net/browse/HHH-19320")
+class BeforeExecutionAssignedValuesTest {
+	@Test
+	void testAssignedId(SessionFactoryScope scope) {
+		final EntityWithGeneratedId entity1 = new EntityWithGeneratedId( "assigned-id", "assigned-entity" );
+		scope.inTransaction( session -> session.persist( entity1 ) );
+		assertThat( entity1.getGeneratedId() ).isEqualTo( "assigned-id" );
+
+		final EntityWithGeneratedId entity2 = new EntityWithGeneratedId( "stateless-id", "stateless-entity" );
+		scope.inStatelessTransaction( session -> session.insert( entity2 ) );
+		assertThat( entity2.getGeneratedId() ).isEqualTo( "stateless-id" );
+	}
+
+	@Test
+	void testGeneratedId(SessionFactoryScope scope) {
+		final EntityWithGeneratedId entity = new EntityWithGeneratedId( null, "assigned-entity" );
+		scope.inTransaction( session -> session.persist( entity ) );
+		assertThat( entity.getGeneratedId() ).isNotNull();
+	}
+
+	@Test
+	void testAssignedEmbeddedId(SessionFactoryScope scope) {
+		final EntityWithGeneratedEmbeddedId entity1 = new EntityWithGeneratedEmbeddedId(
+				new GeneratedCompositeId( "assigned-1", null),
+				"generated-entity"
+		);
+		scope.inTransaction( session -> session.persist( entity1 ) );
+		assertThat( entity1.getId().getId1() ).isEqualTo( "assigned-1" );
+		assertThat( entity1.getId().getId2() ).isNotNull();
+
+		final EntityWithGeneratedEmbeddedId entity2 = new EntityWithGeneratedEmbeddedId(
+				new GeneratedCompositeId( "new-assigned-1", "assigned-2"),
+				"generated-entity"
+		);
+		scope.inTransaction( session -> session.persist( entity2 ) );
+		assertThat( entity2.getId().getId1() ).isEqualTo( "new-assigned-1" );
+		assertThat( entity2.getId().getId2() ).isEqualTo( "assigned-2" );
+	}
+
+	@Test
+	void testGeneratedEmbeddedId(SessionFactoryScope scope) {
+		final EntityWithGeneratedEmbeddedId entity = new EntityWithGeneratedEmbeddedId(
+				new GeneratedCompositeId(),
+				"generated-entity"
+		);
+		scope.inTransaction( session -> session.persist( entity ) );
+		assertThat( entity.getId().getId1() ).isNotNull();
+		assertThat( entity.getId().getId2() ).isNotNull();
+	}
+
+	@Test
+	void testInsertAssignedProperty(SessionFactoryScope scope) {
+		final String assigned = "assigned-property";
+		final EntityWithGeneratedProperty entity = new EntityWithGeneratedProperty( 1L, assigned );
+		scope.inTransaction( session -> session.persist( entity ) );
+		assertThat( entity.getGeneratedProperty() ).isEqualTo( assigned );
+	}
+
+	@Test
+	void testGeneratedPropertyAndUpdate(SessionFactoryScope scope) {
+		final EntityWithGeneratedProperty entity = new EntityWithGeneratedProperty( 2L, null );
+		scope.inTransaction( session -> {
+			session.persist( entity );
+			session.flush();
+
+			assertThat( entity.getGeneratedProperty() ).isNotNull();
+
+			// test update
+			entity.setGeneratedProperty( "new-assigned-property" );
+		} );
+
+		assertThat( entity.getGeneratedProperty() ).isEqualTo( "new-assigned-property" );
+	}
+
+	@AfterAll
+	public void tearDown(SessionFactoryScope scope) {
+		scope.getSessionFactory().getSchemaManager().truncateMappedObjects();
+	}
+
+	@Entity(name = "EntityWithGeneratedId")
+	static class EntityWithGeneratedId {
+		@Id
+		@GeneratedValue
+		@AssignableGenerator
+		private String generatedId;
+
+		private String name;
+
+		public EntityWithGeneratedId() {
+		}
+
+		public EntityWithGeneratedId(String generatedId, String name) {
+			this.generatedId = generatedId;
+			this.name = name;
+		}
+
+		public String getGeneratedId() {
+			return generatedId;
+		}
+
+		public String getName() {
+			return name;
+		}
+	}
+
+	@Embeddable
+	static class GeneratedCompositeId {
+		@AssignableGenerator
+		private String id1;
+
+		@AssignableGenerator
+		private String id2;
+
+		public GeneratedCompositeId() {
+		}
+
+		public GeneratedCompositeId(String id1, String id2) {
+			this.id1 = id1;
+			this.id2 = id2;
+		}
+
+		public String getId1() {
+			return id1;
+		}
+
+		public String getId2() {
+			return id2;
+		}
+	}
+
+	@Entity(name = "EntityWithGeneratedEmbeddedId")
+	static class EntityWithGeneratedEmbeddedId {
+		@EmbeddedId
+		private GeneratedCompositeId id;
+
+		private String name;
+
+		public EntityWithGeneratedEmbeddedId() {
+		}
+
+		public EntityWithGeneratedEmbeddedId(GeneratedCompositeId id, String name) {
+			this.id = id;
+			this.name = name;
+		}
+
+		public GeneratedCompositeId getId() {
+			return id;
+		}
+	}
+
+	@Entity(name = "EntityWithGeneratedProperty")
+	static class EntityWithGeneratedProperty {
+		@Id
+		private Long id;
+
+		@AssignableGenerator
+		private String generatedProperty;
+
+		public EntityWithGeneratedProperty() {
+		}
+
+		public EntityWithGeneratedProperty(Long id, String generatedProperty) {
+			this.id = id;
+			this.generatedProperty = generatedProperty;
+		}
+
+		public Long getId() {
+			return id;
+		}
+
+		public String getGeneratedProperty() {
+			return generatedProperty;
+		}
+
+		public void setGeneratedProperty(String generatedProperty) {
+			this.generatedProperty = generatedProperty;
+		}
+	}
+
+	@IdGeneratorType(AssignedIdGenerator.class)
+	@ValueGenerationType(generatedBy = AssignedGenerator.class)
+	@Retention(RUNTIME)
+	@Target({FIELD, METHOD})
+	@interface AssignableGenerator {
+	}
+
+	public static class AssignedGenerator implements BeforeExecutionGenerator {
+		@Override
+		public Object generate(
+				SharedSessionContractImplementor session,
+				Object owner,
+				Object currentValue,
+				EventType eventType) {
+			if ( currentValue != null ) {
+				return currentValue;
+			}
+			return UUID.randomUUID().toString();
+		}
+
+		@Override
+		public EnumSet<EventType> getEventTypes() {
+			return EventTypeSets.INSERT_AND_UPDATE;
+		}
+	}
+
+	public static class AssignedIdGenerator extends AssignedGenerator {
+		@Override
+		public EnumSet<EventType> getEventTypes() {
+			return EventTypeSets.INSERT_ONLY;
+		}
+
+		@Override
+		public boolean allowAssignedIdentifiers() {
+			return true;
+		}
+	}
+}


### PR DESCRIPTION
<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

https://hibernate.atlassian.net/browse/HHH-19320

Backport of https://github.com/hibernate/hibernate-orm/pull/9969

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
