### PR TITLE
HHH-19349 actually deprecate the ImmutableEntityUpdateQueryHandlingMode enum

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/boot/internal/SessionFactoryOptionsBuilder.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/internal/SessionFactoryOptionsBuilder.java
@@ -1137,6 +1137,11 @@ public class SessionFactoryOptionsBuilder implements SessionFactoryOptions {
 	}
 
 	@Override
+	public boolean disallowImmutableEntityUpdate() {
+		return immutableEntityUpdateQueryHandlingMode == ImmutableEntityUpdateQueryHandlingMode.EXCEPTION;
+	}
+
+	@Override
 	public String getDefaultCatalog() {
 		return defaultCatalog;
 	}

--- a/hibernate-core/src/main/java/org/hibernate/boot/spi/AbstractDelegatingSessionFactoryOptions.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/spi/AbstractDelegatingSessionFactoryOptions.java
@@ -414,6 +414,11 @@ public class AbstractDelegatingSessionFactoryOptions implements SessionFactoryOp
 	}
 
 	@Override
+	public boolean disallowImmutableEntityUpdate() {
+		return delegate.disallowImmutableEntityUpdate();
+	}
+
+	@Override
 	public String getDefaultCatalog() {
 		return delegate.getDefaultCatalog();
 	}

--- a/hibernate-core/src/main/java/org/hibernate/query/spi/ImmutableEntityUpdateQueryHandlingMode.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/spi/ImmutableEntityUpdateQueryHandlingMode.java
@@ -17,10 +17,13 @@ import org.hibernate.cfg.AvailableSettings;
  *     thrown instead.
  * </ul>
  *
+ * @deprecated This enumeration is isomorphic to {@code boolean}. It will be removed.
+ *
  * @see org.hibernate.cfg.AvailableSettings#IMMUTABLE_ENTITY_UPDATE_QUERY_HANDLING_MODE
  *
  * @author Vlad Mihalcea
  */
+@Deprecated(since = "7.0", forRemoval = true)
 public enum ImmutableEntityUpdateQueryHandlingMode {
 
 	WARNING,

--- a/hibernate-core/src/main/java/org/hibernate/query/spi/QueryEngineOptions.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/spi/QueryEngineOptions.java
@@ -87,10 +87,17 @@ public interface QueryEngineOptions {
 
 	/**
 	 * @see org.hibernate.cfg.QuerySettings#IMMUTABLE_ENTITY_UPDATE_QUERY_HANDLING_MODE
+	 *
+	 * @deprecated Since {@link ImmutableEntityUpdateQueryHandlingMode} is deprecated.
+	 *             Use {@link #disallowImmutableEntityUpdate} instead.
 	 */
-	default ImmutableEntityUpdateQueryHandlingMode getImmutableEntityUpdateQueryHandlingMode() {
-		return ImmutableEntityUpdateQueryHandlingMode.WARNING;
-	}
+	@Deprecated(since = "7.0", forRemoval = true)
+	ImmutableEntityUpdateQueryHandlingMode getImmutableEntityUpdateQueryHandlingMode();
+
+	/**
+	 * @see org.hibernate.cfg.QuerySettings#IMMUTABLE_ENTITY_UPDATE_QUERY_HANDLING_MODE
+	 */
+	boolean disallowImmutableEntityUpdate();
 
 	/**
 	 * @see org.hibernate.cfg.AvailableSettings#JSON_FUNCTIONS_ENABLED

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/NodeBuilder.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/NodeBuilder.java
@@ -1499,5 +1499,8 @@ public interface NodeBuilder extends HibernateCriteriaBuilder, SqmCreationContex
 
 	JpaCompliance getJpaCompliance();
 
+	@Deprecated(since = "7.0", forRemoval = true)
 	ImmutableEntityUpdateQueryHandlingMode getImmutableEntityUpdateQueryHandlingMode();
+
+	boolean disallowImmutableEntityUpdate();
 }

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/internal/SqmCriteriaNodeBuilder.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/internal/SqmCriteriaNodeBuilder.java
@@ -190,7 +190,7 @@ public class SqmCriteriaNodeBuilder implements NodeBuilder, Serializable {
 	private final transient JpaCompliance jpaCompliance;
 	private final transient QueryEngine queryEngine;
 	private final transient ValueHandlingMode criteriaValueHandlingMode;
-	private final transient ImmutableEntityUpdateQueryHandlingMode immutableEntityUpdateQueryHandlingMode;
+	private final transient boolean disallowImmutableEntityUpdate;
 	private final transient BindingContext bindingContext;
 	private transient BasicType<Boolean> booleanType;
 	private transient BasicType<Integer> integerType;
@@ -211,7 +211,7 @@ public class SqmCriteriaNodeBuilder implements NodeBuilder, Serializable {
 		this.name = name;
 		this.jpaCompliance = options.getJpaCompliance();
 		this.criteriaValueHandlingMode = options.getCriteriaValueHandlingMode();
-		this.immutableEntityUpdateQueryHandlingMode = options.getImmutableEntityUpdateQueryHandlingMode();
+		this.disallowImmutableEntityUpdate = options.disallowImmutableEntityUpdate();
 		this.bindingContext = bindingContext;
 		this.extensions = loadExtensions();
 	}
@@ -247,7 +247,14 @@ public class SqmCriteriaNodeBuilder implements NodeBuilder, Serializable {
 
 	@Override
 	public ImmutableEntityUpdateQueryHandlingMode getImmutableEntityUpdateQueryHandlingMode() {
-		return immutableEntityUpdateQueryHandlingMode;
+		return disallowImmutableEntityUpdate
+				? ImmutableEntityUpdateQueryHandlingMode.EXCEPTION
+				: ImmutableEntityUpdateQueryHandlingMode.WARNING;
+	}
+
+	@Override
+	public boolean disallowImmutableEntityUpdate() {
+		return disallowImmutableEntityUpdate;
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/update/SqmUpdateStatement.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/update/SqmUpdateStatement.java
@@ -134,14 +134,11 @@ public class SqmUpdateStatement<T>
 				nodeBuilder().getMappingMetamodel().getEntityDescriptor( getTarget().getEntityName() );
 		if ( !persister.isMutable() ) {
 			final String querySpaces = Arrays.toString( persister.getQuerySpaces() );
-			switch ( nodeBuilder().getImmutableEntityUpdateQueryHandlingMode() ) {
-				case WARNING:
-					LOG.immutableEntityUpdateQuery( hql, querySpaces );
-					break;
-				case EXCEPTION:
-					throw new HibernateException( "The query attempts to update an immutable entity: " + querySpaces );
-				default:
-					throw new AssertionFailure( "Unrecognized mode" );
+			if ( nodeBuilder().disallowImmutableEntityUpdate() ) {
+				throw new HibernateException( "The query attempts to update an immutable entity: " + querySpaces );
+			}
+			else {
+				LOG.immutableEntityUpdateQuery( hql, querySpaces );
 			}
 		}
 	}


### PR DESCRIPTION

It's just a boolean switch, and it has a ridiculously-long name. Imagine if we invented an enum like this for every single config switch in Hibernate!

<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

[Please describe here what your change is about]

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
