### PR TITLE
HHH-19350  deprecate layer-breaking operations

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/SessionBuilder.java
+++ b/hibernate-core/src/main/java/org/hibernate/SessionBuilder.java
@@ -170,6 +170,8 @@ public interface SessionBuilder {
 	 * @return {@code this}, for method chaining
 	 *
 	 * @see org.hibernate.cfg.AvailableSettings#USE_IDENTIFIER_ROLLBACK
+	 *
+	 * @since 7.0
 	 */
 	SessionBuilder identifierRollback(boolean identifierRollback);
 }

--- a/hibernate-core/src/main/java/org/hibernate/SessionBuilder.java
+++ b/hibernate-core/src/main/java/org/hibernate/SessionBuilder.java
@@ -6,6 +6,7 @@ package org.hibernate;
 
 import java.sql.Connection;
 import java.util.TimeZone;
+import java.util.function.Function;
 
 import org.hibernate.resource.jdbc.spi.PhysicalConnectionHandlingMode;
 import org.hibernate.resource.jdbc.spi.StatementInspector;
@@ -48,12 +49,31 @@ public interface SessionBuilder {
 	SessionBuilder noInterceptor();
 
 	/**
-	 * Applies the given {@link StatementInspector} to the session.
+	 * Applies the given statement inspection function to the session.
 	 *
-	 * @param statementInspector The StatementInspector to use.
+	 * @param statementInspector A function which accepts a SQL string,
+	 *                           returning a possibly-processed SQL string
+	 *                           to be used by Hibernate instead of the
+	 *                           given SQL.
 	 *
 	 * @return {@code this}, for method chaining
+	 *
+	 * @since 7.0
 	 */
+	SessionBuilder statementInspector(Function<String,String> statementInspector);
+
+	/**
+	 * Applies the given {@link StatementInspector} to the session.
+	 *
+	 * @param statementInspector The {@code StatementInspector} to use.
+	 *
+	 * @return {@code this}, for method chaining
+	 *
+	 * @deprecated This operation exposes the SPI type {@link StatementInspector}
+	 * and is therefore a layer-breaker. Use {@link #statementInspector(Function)}
+	 * instead.
+	 */
+	@Deprecated(since = "7.0")
 	SessionBuilder statementInspector(StatementInspector statementInspector);
 
 	/**
@@ -66,13 +86,27 @@ public interface SessionBuilder {
 	SessionBuilder connection(Connection connection);
 
 	/**
-	 * Signifies that the connection release mode from the original session
-	 * should be used to create the new session.
+	 * Specifies the connection handling modes for the session.
+	 *
+	 * @return {@code this}, for method chaining
+	 *
+	 * @since 7.0
+	 */
+	SessionBuilder connectionHandling(ConnectionAcquisitionMode acquisitionMode, ConnectionReleaseMode releaseMode);
+
+	/**
+	 * Specifies the {@linkplain PhysicalConnectionHandlingMode connection handling mode}.
 	 *
 	 * @param mode The connection handling mode to use.
 	 *
 	 * @return {@code this}, for method chaining
+	 *
+	 * @deprecated This operation exposes the SPI type
+	 * {@link PhysicalConnectionHandlingMode} and is therefore a layer-breaker.
+	 * Use {@link #connectionHandling(ConnectionAcquisitionMode, ConnectionReleaseMode)}
+	 * instead.
 	 */
+	@Deprecated(since = "7.0")
 	SessionBuilder connectionHandlingMode(PhysicalConnectionHandlingMode mode);
 
 	/**

--- a/hibernate-core/src/main/java/org/hibernate/SessionBuilder.java
+++ b/hibernate-core/src/main/java/org/hibernate/SessionBuilder.java
@@ -96,9 +96,9 @@ public interface SessionBuilder {
 	SessionBuilder autoClear(boolean autoClear);
 
 	/**
-	 * Specify the initial FlushMode to use for the opened Session
+	 * Specify the initial {@link FlushMode} to use for the opened Session
 	 *
-	 * @param flushMode The initial FlushMode to use for the opened Session
+	 * @param flushMode The initial {@code FlushMode} to use for the opened Session
 	 *
 	 * @return {@code this}, for method chaining
 	 *
@@ -145,6 +145,12 @@ public interface SessionBuilder {
 	 */
 	SessionBuilder clearEventListeners();
 
+	/**
+	 * Specify the {@linkplain org.hibernate.cfg.JdbcSettings#JDBC_TIME_ZONE
+	 * JDBC time zone} for the session.
+	 *
+	 * @return {@code this}, for method chaining
+	 */
 	SessionBuilder jdbcTimeZone(TimeZone timeZone);
 
 	/**
@@ -157,4 +163,13 @@ public interface SessionBuilder {
 	 * @see jakarta.persistence.PersistenceContextType
 	 */
 	SessionBuilder autoClose(boolean autoClose);
+
+	/**
+	 * Enable identifier rollback after entity removal for the session.
+	 *
+	 * @return {@code this}, for method chaining
+	 *
+	 * @see org.hibernate.cfg.AvailableSettings#USE_IDENTIFIER_ROLLBACK
+	 */
+	SessionBuilder identifierRollback(boolean identifierRollback);
 }

--- a/hibernate-core/src/main/java/org/hibernate/SharedSessionBuilder.java
+++ b/hibernate-core/src/main/java/org/hibernate/SharedSessionBuilder.java
@@ -9,6 +9,7 @@ import org.hibernate.resource.jdbc.spi.StatementInspector;
 
 import java.sql.Connection;
 import java.util.TimeZone;
+import java.util.function.Function;
 
 /**
  * Specialized {@link SessionBuilder} with access to stuff from another session.
@@ -38,7 +39,7 @@ public interface SharedSessionBuilder extends SessionBuilder {
 	 *
 	 * @return {@code this}, for method chaining
 	 *
-	 * @deprecated use {@link #connectionHandlingMode} instead.
+	 * @deprecated use {@link #connectionHandling} instead.
 	 */
 	@Deprecated(since = "6.0")
 	SharedSessionBuilder connectionReleaseMode();
@@ -71,11 +72,17 @@ public interface SharedSessionBuilder extends SessionBuilder {
 	 */
 	SharedSessionBuilder autoClose();
 
-	@Override
+	@Override @Deprecated
 	SharedSessionBuilder statementInspector(StatementInspector statementInspector);
 
 	@Override
+	SessionBuilder statementInspector(Function<String, String> statementInspector);
+
+	@Override @Deprecated
 	SharedSessionBuilder connectionHandlingMode(PhysicalConnectionHandlingMode mode);
+
+	@Override
+	SharedSessionBuilder connectionHandling(ConnectionAcquisitionMode acquisitionMode, ConnectionReleaseMode releaseMode);
 
 	@Override
 	SharedSessionBuilder autoClear(boolean autoClear);

--- a/hibernate-core/src/main/java/org/hibernate/SharedSessionBuilder.java
+++ b/hibernate-core/src/main/java/org/hibernate/SharedSessionBuilder.java
@@ -112,4 +112,7 @@ public interface SharedSessionBuilder extends SessionBuilder {
 
 	@Override
 	SharedSessionBuilder autoClose(boolean autoClose);
+
+	@Override
+	SharedSessionBuilder identifierRollback(boolean identifierRollback);
 }

--- a/hibernate-core/src/main/java/org/hibernate/StatelessSessionBuilder.java
+++ b/hibernate-core/src/main/java/org/hibernate/StatelessSessionBuilder.java
@@ -5,6 +5,7 @@
 package org.hibernate;
 
 import java.sql.Connection;
+import java.util.function.Function;
 
 import org.hibernate.resource.jdbc.spi.StatementInspector;
 
@@ -54,11 +55,32 @@ public interface StatelessSessionBuilder {
 	StatelessSessionBuilder tenantIdentifier(Object tenantIdentifier);
 
 	/**
-	 * Applies the given {@link StatementInspector} to the stateless session.
+	 * Applies the given statement inspection function to the session.
 	 *
-	 * @param statementInspector The StatementInspector to use.
+	 * @param statementInspector A function which accepts a SQL string,
+	 *                           returning a possibly-processed SQL string
+	 *                           to be used by Hibernate instead of the
+	 *                           given SQL.
 	 *
 	 * @return {@code this}, for method chaining
+	 *
+	 * @apiNote This operation exposes the SPI type
+	 *          {@link StatementInspector}
+	 *          and is therefore a layer-breaker.
 	 */
+	StatelessSessionBuilder statementInspector(Function<String,String> statementInspector);
+
+	/**
+	 * Applies the given {@link StatementInspector} to the session.
+	 *
+	 * @param statementInspector The {@code StatementInspector} to use.
+	 *
+	 * @return {@code this}, for method chaining
+	 *
+	 * @deprecated This operation exposes the SPI type{@link StatementInspector}
+	 * and is therefore a layer-breaker. Use {@link #statementInspector(Function)}
+	 * instead.
+	 */
+	@Deprecated(since = "7.0")
 	StatelessSessionBuilder statementInspector(StatementInspector statementInspector);
 }

--- a/hibernate-core/src/main/java/org/hibernate/boot/internal/SessionFactoryOptionsBuilder.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/internal/SessionFactoryOptionsBuilder.java
@@ -159,7 +159,6 @@ public class SessionFactoryOptionsBuilder implements SessionFactoryOptions {
 	private Supplier<? extends Interceptor> statelessInterceptorSupplier;
 	private StatementInspector statementInspector;
 	private final List<SessionFactoryObserver> sessionFactoryObserverList = new ArrayList<>();
-	private final BaselineSessionEventsListenerBuilder baselineSessionEventsListenerBuilder;	// not exposed on builder atm
 
 	// persistence behavior
 	private CustomEntityDirtinessStrategy customEntityDirtinessStrategy;
@@ -168,8 +167,6 @@ public class SessionFactoryOptionsBuilder implements SessionFactoryOptions {
 	private boolean identifierRollbackEnabled;
 	private boolean checkNullability;
 	private boolean initializeLazyStateOutsideTransactions;
-	private TempTableDdlTransactionHandling tempTableDdlTransactionHandling;
-	private boolean delayBatchFetchLoaderCreations;
 	private int defaultBatchFetchSize;
 	private Integer maximumFetchDepth;
 	private boolean subselectFetchEnabled;
@@ -216,9 +213,6 @@ public class SessionFactoryOptionsBuilder implements SessionFactoryOptions {
 	private boolean directReferenceCacheEntriesEnabled;
 	private boolean autoEvictCollectionCache;
 
-	// Schema tooling
-	private SchemaAutoTooling schemaAutoTooling;
-
 	// JDBC Handling
 	private boolean getGeneratedKeysEnabled;
 	private int jdbcBatchSize;
@@ -227,7 +221,7 @@ public class SessionFactoryOptionsBuilder implements SessionFactoryOptions {
 	private boolean commentsEnabled;
 	private PhysicalConnectionHandlingMode connectionHandlingMode;
 	private boolean connectionProviderDisablesAutoCommit;
-	private TimeZone jdbcTimeZone;
+	private final TimeZone jdbcTimeZone;
 	private final ValueHandlingMode criteriaValueHandlingMode;
 	private final boolean criteriaCopyTreeEnabled;
 	private final boolean nativeJdbcParametersIgnored;
@@ -258,6 +252,16 @@ public class SessionFactoryOptionsBuilder implements SessionFactoryOptions {
 	private final CacheMode initialSessionCacheMode;
 	private final FlushMode initialSessionFlushMode;
 	private final LockOptions defaultLockOptions;
+
+	// deprecated stuff
+	@Deprecated
+	private TempTableDdlTransactionHandling tempTableDdlTransactionHandling;
+	@Deprecated(forRemoval = true)
+	private final BaselineSessionEventsListenerBuilder baselineSessionEventsListenerBuilder;
+	@Deprecated(forRemoval = true)
+	private SchemaAutoTooling schemaAutoTooling;
+	@Deprecated(forRemoval = true)
+	private boolean delayBatchFetchLoaderCreations;
 
 	@SuppressWarnings( "unchecked" )
 	public SessionFactoryOptionsBuilder(StandardServiceRegistry serviceRegistry, BootstrapContext context) {
@@ -943,7 +947,7 @@ public class SessionFactoryOptionsBuilder implements SessionFactoryOptions {
 		return tempTableDdlTransactionHandling;
 	}
 
-	@Override
+	@Override @Deprecated(forRemoval = true)
 	public boolean isDelayBatchFetchLoaderCreationsEnabled() {
 		return delayBatchFetchLoaderCreations;
 	}

--- a/hibernate-core/src/main/java/org/hibernate/boot/spi/SessionFactoryOptions.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/spi/SessionFactoryOptions.java
@@ -18,6 +18,7 @@ import org.hibernate.Incubating;
 import org.hibernate.Interceptor;
 import org.hibernate.Internal;
 import org.hibernate.LockOptions;
+import org.hibernate.SessionEventListener;
 import org.hibernate.SessionFactoryObserver;
 import org.hibernate.TimeZoneStorageStrategy;
 import org.hibernate.annotations.CacheLayout;
@@ -165,7 +166,22 @@ public interface SessionFactoryOptions extends QueryEngineOptions {
 	 */
 	SessionFactoryObserver[] getSessionFactoryObservers();
 
+	/**
+	 * @deprecated This operation is a layer-breaker, exposing an
+	 *             internal type. It will be removed. Use
+	 *             {@link #buildSessionEventListeners()} instead.
+	 */
+	@Deprecated(since = "7.0", forRemoval = true)
 	BaselineSessionEventsListenerBuilder getBaselineSessionEventsListenerBuilder();
+
+	/**
+	 * Build an array of baseline {@link SessionEventListener}s.
+	 *
+	 * @since 7.0
+	 */
+	default SessionEventListener[] buildSessionEventListeners() {
+		return getBaselineSessionEventsListenerBuilder().buildBaseline();
+	}
 
 	/**
 	 * Should generated identifiers be reset after entity removal?
@@ -647,12 +663,19 @@ public interface SessionFactoryOptions extends QueryEngineOptions {
 	 */
 	CacheMode getInitialSessionCacheMode();
 
+	/**
+	 * @see org.hibernate.jpa.HibernateHints#HINT_FLUSH_MODE
+	 */
 	FlushMode getInitialSessionFlushMode();
 
+	/**
+	 * @see org.hibernate.cfg.AvailableSettings#JAKARTA_LOCK_TIMEOUT
+	 * @see org.hibernate.cfg.AvailableSettings#JAKARTA_LOCK_SCOPE
+	 */
 	LockOptions getDefaultLockOptions();
 
 	/**
-	 * Default session properties
+	 * Default properties for brand-new sessions
 	 */
 	Map<String, Object> getDefaultSessionProperties();
 }

--- a/hibernate-core/src/main/java/org/hibernate/cfg/AvailableSettings.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/AvailableSettings.java
@@ -99,25 +99,13 @@ public interface AvailableSettings
 	String CURRENT_SESSION_CONTEXT_CLASS = "hibernate.current_session_context_class";
 
 	/**
-	 * Controls how {@linkplain org.hibernate.loader.ast.spi.Loader entity loaders}
-	 * are created.
-	 * <p>
-	 * When {@code true}, the default, the loaders are only created on first
-	 * access; this ensures that all access patterns which are not useful
-	 * to the application are never instantiated, possibly saving a
-	 * substantial amount of memory for applications having many entities.
-	 * The only exception is the loader for {@link org.hibernate.LockMode#NONE},
-	 * which will always be eagerly initialized; this is necessary to
-	 * detect mapping errors.
-	 * <p>
-	 * {@code false} indicates that all loaders should be created up front;
-	 * this will consume more memory but ensures all necessary memory is
-	 * allocated right away.
-	 *
 	 * @see org.hibernate.boot.SessionFactoryBuilder#applyDelayedEntityLoaderCreations(boolean)
+	 *
+	 * @deprecated This setting no longer has any effect.
 	 *
 	 * @since 5.3
 	 */
+	@Deprecated(since = "7.0", forRemoval = true)
 	String DELAY_ENTITY_LOADER_CREATIONS = "hibernate.loader.delay_entity_loader_creations";
 
 	/**

--- a/hibernate-core/src/main/java/org/hibernate/cfg/AvailableSettings.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/AvailableSettings.java
@@ -159,11 +159,13 @@ public interface AvailableSettings
 	String MERGE_ENTITY_COPY_OBSERVER = "hibernate.event.merge.entity_copy_observer";
 
 	/**
-	 * When enabled, specifies that the persistent context should be discarded when either
-	 * {@link org.hibernate.Session#close()} or {@link jakarta.persistence.EntityManager#close()}
-	 * is called.
+	 * When enabled, specifies that all transactional resources should be immediately
+	 * released when {@link org.hibernate.Session#close()} is called.
 	 *
-	 * @settingDefault {@code false} (not discarded) per the JPA specification.
+	 * @settingDefault {@code false} (not released), as per the JPA specification.
+	 *
+	 * @apiNote The legacy name of this setting is extremely misleading;
+	 *          it has little to do with persistence contexts.
 	 */
 	String DISCARD_PC_ON_CLOSE = "hibernate.discard_pc_on_close";
 

--- a/hibernate-core/src/main/java/org/hibernate/engine/spi/AbstractDelegatingSessionBuilder.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/spi/AbstractDelegatingSessionBuilder.java
@@ -126,4 +126,10 @@ public abstract class AbstractDelegatingSessionBuilder implements SessionBuilder
 		delegate.flushMode( flushMode );
 		return this;
 	}
+
+	@Override
+	public SessionBuilder identifierRollback(boolean identifierRollback) {
+		delegate.identifierRollback( identifierRollback );
+		return this;
+	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/engine/spi/AbstractDelegatingSessionBuilder.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/spi/AbstractDelegatingSessionBuilder.java
@@ -6,7 +6,10 @@ package org.hibernate.engine.spi;
 
 import java.sql.Connection;
 import java.util.TimeZone;
+import java.util.function.Function;
 
+import org.hibernate.ConnectionAcquisitionMode;
+import org.hibernate.ConnectionReleaseMode;
 import org.hibernate.FlushMode;
 import org.hibernate.Interceptor;
 import org.hibernate.Session;
@@ -55,8 +58,14 @@ public abstract class AbstractDelegatingSessionBuilder implements SessionBuilder
 		return this;
 	}
 
-	@Override
+	@Override @Deprecated
 	public SessionBuilder statementInspector(StatementInspector statementInspector) {
+		delegate.statementInspector( statementInspector );
+		return this;
+	}
+
+	@Override
+	public SessionBuilder statementInspector(Function<String, String> statementInspector) {
 		delegate.statementInspector( statementInspector );
 		return this;
 	}
@@ -109,9 +118,15 @@ public abstract class AbstractDelegatingSessionBuilder implements SessionBuilder
 		return this;
 	}
 
-	@Override
+	@Override @Deprecated
 	public SessionBuilder connectionHandlingMode(PhysicalConnectionHandlingMode mode) {
 		delegate.connectionHandlingMode( mode );
+		return this;
+	}
+
+	@Override
+	public SessionBuilder connectionHandling(ConnectionAcquisitionMode acquisitionMode, ConnectionReleaseMode releaseMode) {
+		delegate.connectionHandling( acquisitionMode, releaseMode );
 		return this;
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/engine/spi/AbstractDelegatingSharedSessionBuilder.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/spi/AbstractDelegatingSharedSessionBuilder.java
@@ -168,4 +168,10 @@ public abstract class AbstractDelegatingSharedSessionBuilder implements SharedSe
 		delegate.jdbcTimeZone( timeZone );
 		return this;
 	}
+
+	@Override
+	public SharedSessionBuilder identifierRollback(boolean identifierRollback) {
+		delegate.identifierRollback( identifierRollback );
+		return this;
+	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/engine/spi/AbstractDelegatingSharedSessionBuilder.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/spi/AbstractDelegatingSharedSessionBuilder.java
@@ -6,10 +6,14 @@ package org.hibernate.engine.spi;
 
 import java.sql.Connection;
 import java.util.TimeZone;
+import java.util.function.Function;
 
+import org.hibernate.ConnectionAcquisitionMode;
+import org.hibernate.ConnectionReleaseMode;
 import org.hibernate.FlushMode;
 import org.hibernate.Interceptor;
 import org.hibernate.Session;
+import org.hibernate.SessionBuilder;
 import org.hibernate.SessionEventListener;
 import org.hibernate.SharedSessionBuilder;
 import org.hibernate.resource.jdbc.spi.PhysicalConnectionHandlingMode;
@@ -91,8 +95,14 @@ public abstract class AbstractDelegatingSharedSessionBuilder implements SharedSe
 		return this;
 	}
 
-	@Override
+	@Override @Deprecated
 	public SharedSessionBuilder statementInspector(StatementInspector statementInspector) {
+		delegate.statementInspector( statementInspector );
+		return this;
+	}
+
+	@Override
+	public SessionBuilder statementInspector(Function<String, String> statementInspector) {
 		delegate.statementInspector( statementInspector );
 		return this;
 	}
@@ -139,9 +149,15 @@ public abstract class AbstractDelegatingSharedSessionBuilder implements SharedSe
 		return this;
 	}
 
-	@Override
+	@Override @Deprecated
 	public SharedSessionBuilder connectionHandlingMode(PhysicalConnectionHandlingMode mode) {
 		delegate.connectionHandlingMode( mode );
+		return this;
+	}
+
+	@Override
+	public SharedSessionBuilder connectionHandling(ConnectionAcquisitionMode acquisitionMode, ConnectionReleaseMode releaseMode) {
+		delegate.connectionHandling( acquisitionMode, releaseMode );
 		return this;
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/engine/spi/SessionDelegatorBaseImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/spi/SessionDelegatorBaseImpl.java
@@ -139,11 +139,6 @@ public class SessionDelegatorBaseImpl implements SessionImplementor {
 	}
 
 	@Override
-	public void setAutoClear(boolean enabled) {
-		delegate.setAutoClear( enabled );
-	}
-
-	@Override
 	public boolean isTransactionInProgress() {
 		return delegate.isTransactionInProgress();
 	}

--- a/hibernate-core/src/main/java/org/hibernate/engine/spi/SessionDelegatorBaseImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/spi/SessionDelegatorBaseImpl.java
@@ -1241,4 +1241,9 @@ public class SessionDelegatorBaseImpl implements SessionImplementor {
 	public Object loadFromSecondLevelCache(EntityPersister persister, EntityKey entityKey, Object instanceToLoad, LockMode lockMode) {
 		return delegate.loadFromSecondLevelCache( persister, entityKey, instanceToLoad, lockMode );
 	}
+
+	@Override
+	public boolean isIdentifierRollbackEnabled() {
+		return delegate.isIdentifierRollbackEnabled();
+	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/engine/spi/SharedSessionContractImplementor.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/spi/SharedSessionContractImplementor.java
@@ -271,15 +271,6 @@ public interface SharedSessionContractImplementor
 	Interceptor getInterceptor();
 
 	/**
-	 * Enable or disable automatic cache clearing from after transaction
-	 * completion.
-	 *
-	 * @deprecated there's no good reason to expose this here
-	 */
-	@Deprecated(since = "6")
-	void setAutoClear(boolean enabled);
-
-	/**
 	 * Initialize the given collection (if not already initialized).
 	 */
 	void initializeCollection(PersistentCollection<?> collection, boolean writing)

--- a/hibernate-core/src/main/java/org/hibernate/engine/spi/SharedSessionContractImplementor.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/spi/SharedSessionContractImplementor.java
@@ -377,6 +377,8 @@ public interface SharedSessionContractImplementor
 	 */
 	boolean isDefaultReadOnly();
 
+	boolean isIdentifierRollbackEnabled();
+
 	void setCriteriaCopyTreeEnabled(boolean jpaCriteriaCopyComplianceEnabled);
 
 	boolean isCriteriaCopyTreeEnabled();

--- a/hibernate-core/src/main/java/org/hibernate/engine/spi/SharedSessionDelegatorBaseImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/spi/SharedSessionDelegatorBaseImpl.java
@@ -419,11 +419,6 @@ public class SharedSessionDelegatorBaseImpl implements SharedSessionContractImpl
 	}
 
 	@Override
-	public void setAutoClear(boolean enabled) {
-		delegate.setAutoClear( enabled );
-	}
-
-	@Override
 	public void initializeCollection(PersistentCollection<?> collection, boolean writing) throws HibernateException {
 		delegate.initializeCollection( collection, writing );
 	}

--- a/hibernate-core/src/main/java/org/hibernate/engine/spi/SharedSessionDelegatorBaseImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/spi/SharedSessionDelegatorBaseImpl.java
@@ -703,4 +703,9 @@ public class SharedSessionDelegatorBaseImpl implements SharedSessionContractImpl
 	public Object loadFromSecondLevelCache(EntityPersister persister, EntityKey entityKey, Object instanceToLoad, LockMode lockMode) {
 		return delegate.loadFromSecondLevelCache( persister, entityKey, instanceToLoad, lockMode );
 	}
+
+	@Override
+	public boolean isIdentifierRollbackEnabled() {
+		return delegate.isIdentifierRollbackEnabled();
+	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/internal/AbstractSharedSessionContract.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/AbstractSharedSessionContract.java
@@ -296,14 +296,9 @@ public abstract class AbstractSharedSessionContract implements SharedSessionCont
 	private static SessionEventListenerManager createSessionEventsManager(
 			SessionFactoryOptions factoryOptions, SessionCreationOptions options) {
 		final List<SessionEventListener> customListeners = options.getCustomSessionEventListener();
-		if ( customListeners == null ) {
-			final SessionEventListener[] baseline =
-					factoryOptions.getBaselineSessionEventsListenerBuilder().buildBaseline();
-			return new SessionEventListenerManagerImpl( baseline );
-		}
-		else {
-			return new SessionEventListenerManagerImpl( customListeners );
-		}
+		return customListeners == null
+				? new SessionEventListenerManagerImpl( factoryOptions.buildSessionEventListeners() )
+				: new SessionEventListenerManagerImpl( customListeners );
 	}
 
 	/**
@@ -1641,9 +1636,7 @@ public abstract class AbstractSharedSessionContract implements SharedSessionCont
 		jdbcServices = factory.getJdbcServices();
 
 		//TODO: this isn't quite right, see createSessionEventsManager()
-		final SessionEventListener[] baseline =
-				factoryOptions.getBaselineSessionEventsListenerBuilder()
-						.buildBaseline();
+		final SessionEventListener[] baseline = factoryOptions.buildSessionEventListeners();
 		sessionEventsManager = new SessionEventListenerManagerImpl( baseline );
 
 		jdbcSessionContext = createJdbcSessionContext( (StatementInspector) ois.readObject() );

--- a/hibernate-core/src/main/java/org/hibernate/internal/BaselineSessionEventsListenerBuilder.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/BaselineSessionEventsListenerBuilder.java
@@ -5,16 +5,24 @@
 package org.hibernate.internal;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 
 import org.hibernate.HibernateException;
 import org.hibernate.SessionEventListener;
 import org.hibernate.engine.internal.StatisticalLoggingSessionEventListener;
 
+import static java.util.Collections.addAll;
+
 /**
  * @author Steve Ebersole
+ *
+ * @apiNote Due to a mistake, this internal class was exposed via the layer-breaking operation
+ * {@link org.hibernate.boot.spi.SessionFactoryOptions#getBaselineSessionEventsListenerBuilder()}.
+ * Clients should avoid direct use of this class.
+ *
+ * @deprecated This class is no longer needed and will be removed.
  */
+@Deprecated(since = "7.0", forRemoval = true)
 public class BaselineSessionEventsListenerBuilder {
 
 	private static final SessionEventListener[] EMPTY = new SessionEventListener[0];
@@ -32,38 +40,28 @@ public class BaselineSessionEventsListenerBuilder {
 
 	public List<SessionEventListener> buildBaselineList() {
 		final SessionEventListener[] sessionEventListeners = buildBaseline();
-		//Capacity: needs to hold at least all elements from the baseline, but also expect to add a little more later.
-		ArrayList<SessionEventListener> list = new ArrayList<>( sessionEventListeners.length + 3 );
-		Collections.addAll( list, sessionEventListeners );
+		// Capacity: needs to hold at least all elements from the baseline,
+		//           but also expect to add a little more later.
+		final List<SessionEventListener> list =
+				new ArrayList<>( sessionEventListeners.length + 3 );
+		addAll( list, sessionEventListeners );
 		return list;
 	}
 
 	public SessionEventListener[] buildBaseline() {
-		final SessionEventListener[] arr;
-		if ( autoListener != null ) {
-			if ( StatisticalLoggingSessionEventListener.isLoggingEnabled() ) {
-				arr = new SessionEventListener[2];
-				arr[0] = buildStatsListener();
-				arr[1] = buildAutoListener( autoListener );
-			}
-			else {
-				arr = new SessionEventListener[1];
-				arr[0] = buildAutoListener( autoListener );
-			}
+		if ( StatisticalLoggingSessionEventListener.isLoggingEnabled() ) {
+			return autoListener == null
+					? new SessionEventListener[] { statsListener() }
+					: new SessionEventListener[] { statsListener(), autoListener() };
 		}
 		else {
-			if ( StatisticalLoggingSessionEventListener.isLoggingEnabled() ) {
-				arr = new SessionEventListener[1];
-				arr[0] = buildStatsListener();
-			}
-			else {
-				arr = EMPTY;
-			}
+			return autoListener == null
+					? EMPTY
+					: new SessionEventListener[] { autoListener() };
 		}
-		return arr;
 	}
 
-	private static SessionEventListener buildAutoListener(final Class<? extends SessionEventListener> autoListener) {
+	private SessionEventListener autoListener() {
 		try {
 			return autoListener.newInstance();
 		}
@@ -75,7 +73,7 @@ public class BaselineSessionEventsListenerBuilder {
 		}
 	}
 
-	private static SessionEventListener buildStatsListener() {
+	private static SessionEventListener statsListener() {
 		return new StatisticalLoggingSessionEventListener();
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/internal/SessionCreationOptions.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/SessionCreationOptions.java
@@ -46,6 +46,8 @@ public interface SessionCreationOptions {
 
 	Object getTenantIdentifierValue();
 
+	boolean isIdentifierRollbackEnabled();
+
 	TimeZone getJdbcTimeZone();
 
 	/**

--- a/hibernate-core/src/main/java/org/hibernate/internal/SessionFactoryImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/SessionFactoryImpl.java
@@ -25,6 +25,8 @@ import javax.naming.Reference;
 import javax.naming.StringRefAddr;
 
 import jakarta.persistence.TypedQuery;
+import org.hibernate.ConnectionAcquisitionMode;
+import org.hibernate.ConnectionReleaseMode;
 import org.hibernate.CustomEntityDirtinessStrategy;
 import org.hibernate.EntityNameResolver;
 import org.hibernate.FlushMode;
@@ -1271,9 +1273,15 @@ public class SessionFactoryImpl implements SessionFactoryImplementor {
 			return this;
 		}
 
-		@Override
+		@Override @Deprecated
 		public SessionBuilderImpl statementInspector(StatementInspector statementInspector) {
 			this.statementInspector = statementInspector;
+			return this;
+		}
+
+		@Override
+		public SessionBuilder statementInspector(Function<String, String> statementInspector) {
+			this.statementInspector = statementInspector::apply;
 			return this;
 		}
 
@@ -1283,9 +1291,15 @@ public class SessionFactoryImpl implements SessionFactoryImplementor {
 			return this;
 		}
 
-		@Override
+		@Override @Deprecated
 		public SessionBuilderImpl connectionHandlingMode(PhysicalConnectionHandlingMode connectionHandlingMode) {
 			this.connectionHandlingMode = connectionHandlingMode;
+			return this;
+		}
+
+		@Override
+		public SessionBuilder connectionHandling(ConnectionAcquisitionMode acquisitionMode, ConnectionReleaseMode releaseMode) {
+			this.connectionHandlingMode = PhysicalConnectionHandlingMode.interpret( acquisitionMode, releaseMode);
 			return this;
 		}
 
@@ -1401,9 +1415,15 @@ public class SessionFactoryImpl implements SessionFactoryImplementor {
 			return this;
 		}
 
-		@Override
+		@Override @Deprecated
 		public StatelessSessionBuilder statementInspector(StatementInspector statementInspector) {
 			this.statementInspector = statementInspector;
+			return this;
+		}
+
+		@Override
+		public StatelessSessionBuilder statementInspector(Function<String, String> statementInspector) {
+			this.statementInspector = statementInspector::apply;
 			return this;
 		}
 

--- a/hibernate-core/src/main/java/org/hibernate/internal/SessionImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/SessionImpl.java
@@ -22,40 +22,12 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.TimeZone;
+import java.util.function.Function;
 
 import jakarta.persistence.PessimisticLockScope;
 import jakarta.persistence.Timeout;
 import jakarta.persistence.metamodel.EntityType;
-import org.hibernate.BatchSize;
-import org.hibernate.CacheMode;
-import org.hibernate.ConnectionAcquisitionMode;
-import org.hibernate.EnabledFetchProfile;
-import org.hibernate.EntityFilterException;
-import org.hibernate.FetchNotFoundException;
-import org.hibernate.FlushMode;
-import org.hibernate.HibernateException;
-import org.hibernate.Interceptor;
-import org.hibernate.JDBCException;
-import org.hibernate.LobHelper;
-import org.hibernate.LockMode;
-import org.hibernate.LockOptions;
-import org.hibernate.MappingException;
-import org.hibernate.MultiIdentifierLoadAccess;
-import org.hibernate.NaturalIdLoadAccess;
-import org.hibernate.NaturalIdMultiLoadAccess;
-import org.hibernate.ObjectDeletedException;
-import org.hibernate.ObjectNotFoundException;
-import org.hibernate.ReadOnlyMode;
-import org.hibernate.ReplicationMode;
-import org.hibernate.Session;
-import org.hibernate.SessionEventListener;
-import org.hibernate.SessionException;
-import org.hibernate.SharedSessionBuilder;
-import org.hibernate.SimpleNaturalIdLoadAccess;
-import org.hibernate.Transaction;
-import org.hibernate.TypeMismatchException;
-import org.hibernate.UnknownProfileException;
-import org.hibernate.UnresolvableObjectException;
+import org.hibernate.*;
 import org.hibernate.bytecode.enhance.spi.interceptor.EnhancementAsProxyLazinessInterceptor;
 import org.hibernate.collection.spi.PersistentCollection;
 import org.hibernate.engine.internal.PersistenceContexts;
@@ -2254,15 +2226,27 @@ public class SessionImpl
 			return this;
 		}
 
-		@Override
+		@Override @Deprecated
 		public SharedSessionBuilderImpl statementInspector(StatementInspector statementInspector) {
 			super.statementInspector(statementInspector);
 			return this;
 		}
 
 		@Override
+		public SessionBuilder statementInspector(Function<String, String> statementInspector) {
+			super.statementInspector(statementInspector);
+			return this;
+		}
+
+		@Override @Deprecated
 		public SharedSessionBuilderImpl connectionHandlingMode(PhysicalConnectionHandlingMode connectionHandlingMode) {
 			super.connectionHandlingMode(connectionHandlingMode);
+			return this;
+		}
+
+		@Override @Deprecated
+		public SharedSessionBuilderImpl connectionHandling(ConnectionAcquisitionMode acquisitionMode, ConnectionReleaseMode releaseMode) {
+			super.connectionHandling(acquisitionMode, releaseMode);
 			return this;
 		}
 

--- a/hibernate-core/src/main/java/org/hibernate/internal/SessionImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/SessionImpl.java
@@ -250,6 +250,8 @@ public class SessionImpl
 	private boolean autoClear;
 	private final boolean autoClose;
 
+	private final boolean identifierRollbackEnabled;
+
 	private transient LoadEvent loadEvent; //cached LoadEvent instance
 	private transient PostLoadEvent postLoadEvent; //cached PostLoadEvent instance
 
@@ -266,6 +268,8 @@ public class SessionImpl
 
 			autoClear = options.shouldAutoClear();
 			autoClose = options.shouldAutoClose();
+
+			identifierRollbackEnabled = options.isIdentifierRollbackEnabled();
 
 			setUpTransactionCompletionProcesses( options );
 
@@ -503,6 +507,11 @@ public class SessionImpl
 	@Override
 	public boolean isAutoCloseSessionEnabled() {
 		return autoClose;
+	}
+
+	@Override
+	public boolean isIdentifierRollbackEnabled() {
+		return identifierRollbackEnabled;
 	}
 
 	@Override
@@ -2115,6 +2124,7 @@ public class SessionImpl
 			super( (SessionFactoryImpl) session.getFactory() );
 			this.session = session;
 			super.tenantIdentifier( session.getTenantIdentifierValue() );
+			super.identifierRollback( session.isIdentifierRollbackEnabled() );
 		}
 
 		@Override
@@ -2219,6 +2229,12 @@ public class SessionImpl
 		@Override
 		public SharedSessionBuilderImpl autoClose() {
 			autoClose( session.autoClose );
+			return this;
+		}
+
+		@Override
+		public SharedSessionBuilderImpl identifierRollback(boolean identifierRollback) {
+			super.identifierRollback( identifierRollback );
 			return this;
 		}
 

--- a/hibernate-core/src/main/java/org/hibernate/internal/SessionImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/SessionImpl.java
@@ -345,14 +345,18 @@ public class SessionImpl
 			query.setLockMode( getLockMode( lockOptionsForRead.getLockMode() ) );
 		}
 
-		final Object specQueryTimeout = LegacySpecHelper.getInteger(
+		final Object specQueryTimeout = getHintedQueryTimeout();
+		if ( specQueryTimeout != null ) {
+			query.setHint( HINT_SPEC_QUERY_TIMEOUT, specQueryTimeout );
+		}
+	}
+
+	private Object getHintedQueryTimeout() {
+		return LegacySpecHelper.getInteger(
 				HINT_SPEC_QUERY_TIMEOUT,
 				HINT_JAVAEE_QUERY_TIMEOUT,
 				this::getSessionProperty
 		);
-		if ( specQueryTimeout != null ) {
-			query.setHint( HINT_SPEC_QUERY_TIMEOUT, specQueryTimeout );
-		}
 	}
 
 	protected void applyQuerySettingsAndHints(Query<?> query) {
@@ -361,16 +365,20 @@ public class SessionImpl
 	}
 
 	private void applyLockTimeoutHint(Query<?> query) {
-		final Integer specLockTimeout = LegacySpecHelper.getInteger(
+		final Integer specLockTimeout = getHintedLockTimeout();
+		if ( specLockTimeout != null ) {
+			query.setHint( HINT_SPEC_LOCK_TIMEOUT, specLockTimeout );
+		}
+	}
+
+	private Integer getHintedLockTimeout() {
+		return LegacySpecHelper.getInteger(
 				HINT_SPEC_LOCK_TIMEOUT,
 				HINT_JAVAEE_LOCK_TIMEOUT,
 				this::getSessionProperty,
 				// treat WAIT_FOREVER the same as null
 				value -> !Integer.valueOf( LockOptions.WAIT_FOREVER ).equals( value )
 		);
-		if ( specLockTimeout != null ) {
-			query.setHint( HINT_SPEC_LOCK_TIMEOUT, specLockTimeout );
-		}
 	}
 
 	private Object getSessionProperty(String propertyName) {

--- a/hibernate-core/src/main/java/org/hibernate/internal/StatelessSessionImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/StatelessSessionImpl.java
@@ -1204,13 +1204,13 @@ public class StatelessSessionImpl extends AbstractSharedSessionContract implemen
 		return false;
 	}
 
-	public void setDefaultReadOnly(boolean readOnly) {
-		if ( readOnly ) {
-			throw new UnsupportedOperationException();
-		}
+	@Override
+	public boolean isIdentifierRollbackEnabled() {
+		// not yet implemented
+		return false;
 	}
 
-/////////////////////////////////////////////////////////////////////////////////////////////////////
+	/////////////////////////////////////////////////////////////////////////////////////////////////////
 
 	//TODO: COPY/PASTE FROM SessionImpl, pull up!
 

--- a/hibernate-core/src/main/java/org/hibernate/internal/StatelessSessionImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/StatelessSessionImpl.java
@@ -1195,11 +1195,6 @@ public class StatelessSessionImpl extends AbstractSharedSessionContract implemen
 		return temporaryPersistenceContext;
 	}
 
-	@Override
-	public void setAutoClear(boolean enabled) {
-		throw new UnsupportedOperationException();
-	}
-
 	public boolean isDefaultReadOnly() {
 		return false;
 	}

--- a/hibernate-core/src/main/java/org/hibernate/query/spi/QueryEngineOptions.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/spi/QueryEngineOptions.java
@@ -110,6 +110,10 @@ public interface QueryEngineOptions {
 	boolean isXmlFunctionsEnabled();
 
 	/**
+	 * Should HQL integer division HQL should produce an integer on
+	 * Oracle, MySQL, and MariaDB, where the {@code /} operator produces
+	 * a non-integer.
+	 *
 	 * @see org.hibernate.cfg.AvailableSettings#PORTABLE_INTEGER_DIVISION
 	 */
 	boolean isPortableIntegerDivisionEnabled();

--- a/hibernate-core/src/main/java/org/hibernate/resource/jdbc/spi/JdbcSessionContext.java
+++ b/hibernate-core/src/main/java/org/hibernate/resource/jdbc/spi/JdbcSessionContext.java
@@ -16,32 +16,32 @@ import org.hibernate.stat.spi.StatisticsImplementor;
  */
 public interface JdbcSessionContext {
 	/**
-	 * @see org.hibernate.cfg.AvailableSettings#USE_SCROLLABLE_RESULTSET
+	 * @see org.hibernate.cfg.JdbcSettings#USE_SCROLLABLE_RESULTSET
 	 */
 	boolean isScrollableResultSetsEnabled();
 
 	/**
-	 * @see org.hibernate.cfg.AvailableSettings#USE_GET_GENERATED_KEYS
+	 * @see org.hibernate.cfg.JdbcSettings#USE_GET_GENERATED_KEYS
 	 */
 	boolean isGetGeneratedKeysEnabled();
 
 	/**
-	 * @see org.hibernate.cfg.AvailableSettings#STATEMENT_FETCH_SIZE
+	 * @see org.hibernate.cfg.JdbcSettings#STATEMENT_FETCH_SIZE
 	 */
 	Integer getFetchSizeOrNull();
 
 	/**
-	 * @see org.hibernate.cfg.AvailableSettings#CONNECTION_PROVIDER_DISABLES_AUTOCOMMIT
+	 * @see org.hibernate.cfg.JdbcSettings#CONNECTION_PROVIDER_DISABLES_AUTOCOMMIT
 	 */
 	boolean doesConnectionProviderDisableAutoCommit();
 
 	/**
-	 * @see org.hibernate.cfg.AvailableSettings#PREFER_USER_TRANSACTION
+	 * @see org.hibernate.cfg.TransactionSettings#PREFER_USER_TRANSACTION
 	 */
 	boolean isPreferUserTransaction();
 
 	/**
-	 * @see org.hibernate.cfg.AvailableSettings#JTA_TRACK_BY_THREAD
+	 * @see org.hibernate.cfg.TransactionSettings#JTA_TRACK_BY_THREAD
 	 */
 	boolean isJtaTrackByThread();
 

--- a/hibernate-core/src/main/java/org/hibernate/resource/jdbc/spi/PhysicalConnectionHandlingMode.java
+++ b/hibernate-core/src/main/java/org/hibernate/resource/jdbc/spi/PhysicalConnectionHandlingMode.java
@@ -76,8 +76,8 @@ public enum PhysicalConnectionHandlingMode {
 			return null;
 		}
 
-		if ( setting instanceof PhysicalConnectionHandlingMode ) {
-			return (PhysicalConnectionHandlingMode) setting;
+		if ( setting instanceof PhysicalConnectionHandlingMode physicalConnectionHandlingMode ) {
+			return physicalConnectionHandlingMode;
 		}
 
 		final String value = setting.toString().trim();
@@ -85,7 +85,7 @@ public enum PhysicalConnectionHandlingMode {
 			return null;
 		}
 
-		return PhysicalConnectionHandlingMode.valueOf( value.toUpperCase( Locale.ROOT ) );
+		return valueOf( value.toUpperCase( Locale.ROOT ) );
 	}
 
 	public static PhysicalConnectionHandlingMode interpret(
@@ -94,28 +94,20 @@ public enum PhysicalConnectionHandlingMode {
 		if ( acquisitionMode == IMMEDIATELY ) {
 			if ( releaseMode != null && releaseMode != ON_CLOSE ) {
 				throw new IllegalArgumentException(
-						"Only ConnectionReleaseMode.ON_CLOSE can be used in combination with " +
-								"ConnectionAcquisitionMode.IMMEDIATELY; but ConnectionReleaseMode." +
-								releaseMode.name() + " was specified."
+						"Only ConnectionReleaseMode.ON_CLOSE can be used in combination with "
+						+ "ConnectionAcquisitionMode.IMMEDIATELY; but ConnectionReleaseMode."
+						+ releaseMode.name() + " was specified."
 				);
 			}
 			return IMMEDIATE_ACQUISITION_AND_HOLD;
 		}
 		else {
-			switch ( releaseMode ) {
-				case AFTER_STATEMENT: {
-					return DELAYED_ACQUISITION_AND_RELEASE_AFTER_STATEMENT;
-				}
-				case BEFORE_TRANSACTION_COMPLETION: {
-					return DELAYED_ACQUISITION_AND_RELEASE_BEFORE_TRANSACTION_COMPLETION;
-				}
-				case AFTER_TRANSACTION: {
-					return DELAYED_ACQUISITION_AND_RELEASE_AFTER_TRANSACTION;
-				}
-				default: {
-					return DELAYED_ACQUISITION_AND_HOLD;
-				}
-			}
+			return switch ( releaseMode ) {
+				case AFTER_STATEMENT -> DELAYED_ACQUISITION_AND_RELEASE_AFTER_STATEMENT;
+				case BEFORE_TRANSACTION_COMPLETION -> DELAYED_ACQUISITION_AND_RELEASE_BEFORE_TRANSACTION_COMPLETION;
+				case AFTER_TRANSACTION -> DELAYED_ACQUISITION_AND_RELEASE_AFTER_TRANSACTION;
+				default -> DELAYED_ACQUISITION_AND_HOLD;
+			};
 		}
 	}
 }

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/events/ClearEventListenerTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/events/ClearEventListenerTest.java
@@ -45,8 +45,8 @@ public class ClearEventListenerTest {
 		LISTENER.callCount = 0;
 
 		scope.inSession(
-				session -> {
-					session.setAutoClear( true );
+				s -> {
+					var session = s.sessionWithOptions().autoClear(true).openSession();
 					session.getTransaction().begin();
 					try {
 						assertThat( LISTENER.callCount ).isEqualTo( 0 );

--- a/hibernate-envers/src/test/java/org/hibernate/orm/test/envers/integration/basic/TransactionRollbackBehaviour.java
+++ b/hibernate-envers/src/test/java/org/hibernate/orm/test/envers/integration/basic/TransactionRollbackBehaviour.java
@@ -7,9 +7,9 @@ package org.hibernate.orm.test.envers.integration.basic;
 import java.util.List;
 import jakarta.persistence.EntityManager;
 
+import org.hibernate.Session;
 import org.hibernate.orm.test.envers.BaseEnversJPAFunctionalTestCase;
 import org.hibernate.orm.test.envers.entities.IntTestEntity;
-import org.hibernate.internal.SessionImpl;
 import org.hibernate.testing.orm.junit.JiraKey;
 import org.junit.Test;
 
@@ -45,7 +45,8 @@ public class TransactionRollbackBehaviour extends BaseEnversJPAFunctionalTestCas
 		EntityManager entityManager = getEntityManager();
 		try {
 			if ( autoClear != null ) {
-				entityManager.unwrap( SessionImpl.class ).setAutoClear( autoClear );
+				entityManager = entityManager.unwrap( Session.class )
+						.sessionWithOptions().autoClear( autoClear ).openSession();
 			}
 
 			// persist and rollback

--- a/tooling/metamodel-generator/src/main/java/org/hibernate/processor/validation/MockSessionFactory.java
+++ b/tooling/metamodel-generator/src/main/java/org/hibernate/processor/validation/MockSessionFactory.java
@@ -83,6 +83,7 @@ import org.hibernate.metamodel.spi.RuntimeModelCreationContext;
 import org.hibernate.persister.collection.CollectionPersister;
 import org.hibernate.persister.entity.EntityPersister;
 import org.hibernate.proxy.EntityNotFoundDelegate;
+import org.hibernate.query.criteria.ValueHandlingMode;
 import org.hibernate.query.hql.HqlTranslator;
 import org.hibernate.query.hql.internal.StandardHqlTranslator;
 import org.hibernate.query.hql.spi.SqmCreationOptions;
@@ -443,6 +444,11 @@ public abstract class MockSessionFactory
 	@Override
 	public boolean isXmlFormatMapperLegacyFormatEnabled() {
 		return false;
+	}
+
+	@Override
+	public ValueHandlingMode getCriteriaValueHandlingMode() {
+		return ValueHandlingMode.BIND;
 	}
 
 	@Override


### PR DESCRIPTION
- An SPI operation exposed the internal class `BaselineSessionEventsListenerBuilder`.
- (Also, we can replace `BaselineSessionEventsListenerBuilder` with a package-private static Helper method, so mark it for removal.)
- I also found two API methods which exposed SPI types. I deprecated them and replaced them with better overloads.

<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

[Please describe here what your change is about]

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
