### PR TITLE
HHH-19357 deprecate 'hibernate.discard_pc_on_close'

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/boot/SessionFactoryBuilder.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/SessionFactoryBuilder.java
@@ -672,9 +672,12 @@ public interface SessionFactoryBuilder {
 	 * released immediately on close?
 	 * <p>
 	 * The other option is to release them as part of an after transaction callback.
+	 *
+	 * @deprecated since {@value org.hibernate.cfg.AvailableSettings#DISCARD_PC_ON_CLOSE}
+	 *             is deprecated
 	 */
+	@Deprecated(since = "7.0", forRemoval = true)
 	SessionFactoryBuilder enableReleaseResourcesOnCloseEnabled(boolean enable);
-
 
 	/**
 	 * @see JpaCompliance#isJpaQueryComplianceEnabled()

--- a/hibernate-core/src/main/java/org/hibernate/boot/internal/SessionFactoryBuilderImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/internal/SessionFactoryBuilderImpl.java
@@ -372,7 +372,7 @@ public class SessionFactoryBuilderImpl implements SessionFactoryBuilderImplement
 		return this;
 	}
 
-	@Override
+	@Override @Deprecated
 	public SessionFactoryBuilder enableReleaseResourcesOnCloseEnabled(boolean enable) {
 		this.optionsBuilder.enableReleaseResourcesOnClose( enable );
 		return this;

--- a/hibernate-core/src/main/java/org/hibernate/boot/internal/SessionFactoryOptionsBuilder.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/internal/SessionFactoryOptionsBuilder.java
@@ -147,7 +147,6 @@ public class SessionFactoryOptionsBuilder implements SessionFactoryOptions {
 	private boolean autoCloseSessionEnabled;
 	private boolean jtaTransactionAccessEnabled;
 	private boolean allowOutOfTransactionUpdateOperations;
-	private boolean releaseResourcesOnCloseEnabled;
 
 	// (JTA) transaction handling
 	private boolean jtaTrackByThread;
@@ -263,6 +262,8 @@ public class SessionFactoryOptionsBuilder implements SessionFactoryOptions {
 	private SchemaAutoTooling schemaAutoTooling;
 	@Deprecated(forRemoval = true)
 	private boolean delayBatchFetchLoaderCreations;
+	@Deprecated(forRemoval = true)
+	private boolean releaseResourcesOnCloseEnabled;
 
 	@SuppressWarnings( "unchecked" )
 	public SessionFactoryOptionsBuilder(StandardServiceRegistry serviceRegistry, BootstrapContext context) {
@@ -490,6 +491,9 @@ public class SessionFactoryOptionsBuilder implements SessionFactoryOptions {
 		allowOutOfTransactionUpdateOperations = getBoolean( ALLOW_UPDATE_OUTSIDE_TRANSACTION, settings );
 
 		releaseResourcesOnCloseEnabled = getBoolean( DISCARD_PC_ON_CLOSE, settings );
+		if ( releaseResourcesOnCloseEnabled) {
+			DEPRECATION_LOGGER.deprecatedSetting( DISCARD_PC_ON_CLOSE );
+		}
 
 		jdbcTimeZone = getJdbcTimeZone( settings.get( JDBC_TIME_ZONE ) );
 
@@ -1515,6 +1519,7 @@ public class SessionFactoryOptionsBuilder implements SessionFactoryOptions {
 		this.allowOutOfTransactionUpdateOperations = allow;
 	}
 
+	@Deprecated(since = "7.0", forRemoval = true)
 	public void enableReleaseResourcesOnClose(boolean enable) {
 		this.releaseResourcesOnCloseEnabled = enable;
 	}

--- a/hibernate-core/src/main/java/org/hibernate/boot/spi/AbstractDelegatingSessionFactoryBuilder.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/spi/AbstractDelegatingSessionFactoryBuilder.java
@@ -336,7 +336,7 @@ public abstract class AbstractDelegatingSessionFactoryBuilder<T extends SessionF
 		return getThis();
 	}
 
-	@Override
+	@Override @Deprecated
 	public T enableReleaseResourcesOnCloseEnabled(boolean enable) {
 		delegate.enableReleaseResourcesOnCloseEnabled( enable );
 		return getThis();

--- a/hibernate-core/src/main/java/org/hibernate/boot/spi/AbstractDelegatingSessionFactoryOptions.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/spi/AbstractDelegatingSessionFactoryOptions.java
@@ -244,7 +244,7 @@ public class AbstractDelegatingSessionFactoryOptions implements SessionFactoryOp
 		return delegate.isAllowOutOfTransactionUpdateOperations();
 	}
 
-	@Override
+	@Override @Deprecated
 	public boolean isReleaseResourcesOnCloseEnabled() {
 		return delegate.isReleaseResourcesOnCloseEnabled();
 	}

--- a/hibernate-core/src/main/java/org/hibernate/boot/spi/SessionFactoryOptions.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/spi/SessionFactoryOptions.java
@@ -499,7 +499,11 @@ public interface SessionFactoryOptions extends QueryEngineOptions {
 
 	/**
 	 * @see org.hibernate.cfg.AvailableSettings#DISCARD_PC_ON_CLOSE
+	 *
+	 * @deprecated since {@value org.hibernate.cfg.AvailableSettings#DISCARD_PC_ON_CLOSE}
+	 *             is deprecated
 	 */
+	@Deprecated(since = "7.0", forRemoval = true)
 	boolean isReleaseResourcesOnCloseEnabled();
 
 	/**

--- a/hibernate-core/src/main/java/org/hibernate/cfg/AvailableSettings.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/AvailableSettings.java
@@ -154,7 +154,9 @@ public interface AvailableSettings
 	 *
 	 * @apiNote The legacy name of this setting is extremely misleading;
 	 *          it has little to do with persistence contexts.
+	 * @deprecated This is no longer useful and will be removed.
 	 */
+	@Deprecated(since = "7.0", forRemoval = true)
 	String DISCARD_PC_ON_CLOSE = "hibernate.discard_pc_on_close";
 
 	/**

--- a/hibernate-core/src/main/java/org/hibernate/internal/log/DeprecationLogger.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/log/DeprecationLogger.java
@@ -119,6 +119,13 @@ public interface DeprecationLogger extends BasicLogger {
 	void deprecatedSetting(String oldSettingName, String newSettingName);
 
 	@LogMessage(level = WARN)
+	@Message(
+			id = 90000022,
+			value = "Encountered deprecated setting [%s]"
+	)
+	void deprecatedSetting(String settingName);
+
+	@LogMessage(level = WARN)
 	@Message(value = "%s does not need to be specified explicitly using 'hibernate.dialect' "
 			+ "(remove the property setting and it will be selected by default)",
 			id = 90000025)


### PR DESCRIPTION
We believe that this was once upon a time long ago used for JBoss integration, but it's not used by WildFly anymore. Also, the property itself has a name which is quite misleading.

<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

[Please describe here what your change is about]

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-19357
<!-- Hibernate GitHub Bot issue links end -->