### PR TITLE
partially address a todo in SharedSessionContractImplementor

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/action/internal/EntityIncrementVersionProcess.java
+++ b/hibernate-core/src/main/java/org/hibernate/action/internal/EntityIncrementVersionProcess.java
@@ -37,10 +37,8 @@ public class EntityIncrementVersionProcess implements BeforeTransactionCompletio
 	public void doBeforeTransactionCompletion(SessionImplementor session) {
 		final EntityEntry entry = session.getPersistenceContext().getEntry( object );
 		// Don't increment version for an entity that is not in the PersistenceContext;
-		if ( entry == null ) {
-			return;
+		if ( entry != null ) {
+			OptimisticLockHelper.forceVersionIncrement( object, entry, session.asEventSource() );
 		}
-
-		OptimisticLockHelper.forceVersionIncrement( object, entry, session.asEventSource() );
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/bytecode/enhance/spi/interceptor/EnhancementHelper.java
+++ b/hibernate-core/src/main/java/org/hibernate/bytecode/enhance/spi/interceptor/EnhancementHelper.java
@@ -10,6 +10,7 @@ import java.util.function.BiFunction;
 import org.hibernate.FlushMode;
 import org.hibernate.LazyInitializationException;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
+import org.hibernate.engine.spi.SessionImplementor;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.internal.SessionFactoryRegistry;
 import org.hibernate.mapping.Collection;
@@ -281,7 +282,7 @@ public class EnhancementHelper {
 		}
 
 		final SessionFactoryImplementor sf = SessionFactoryRegistry.INSTANCE.getSessionFactory( interceptor.getSessionFactoryUuid() );
-		final SharedSessionContractImplementor session = sf.openSession();
+		final SessionImplementor session = sf.openSession();
 		session.getPersistenceContextInternal().setDefaultReadOnly( true );
 		session.setHibernateFlushMode( FlushMode.MANUAL );
 		return session;

--- a/hibernate-core/src/main/java/org/hibernate/collection/spi/AbstractPersistentCollection.java
+++ b/hibernate-core/src/main/java/org/hibernate/collection/spi/AbstractPersistentCollection.java
@@ -24,6 +24,7 @@ import org.hibernate.LazyInitializationException;
 import org.hibernate.engine.spi.CollectionEntry;
 import org.hibernate.engine.spi.EntityEntry;
 import org.hibernate.engine.spi.PersistenceContext;
+import org.hibernate.engine.spi.SessionImplementor;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.engine.spi.Status;
 import org.hibernate.engine.spi.TypedValue;
@@ -316,7 +317,7 @@ public abstract class AbstractPersistentCollection<E> implements Serializable, P
 			throwLazyInitializationException( "SessionFactory UUID not known to create temporary Session for loading" );
 		}
 
-		final SharedSessionContractImplementor session =
+		final SessionImplementor session =
 				SessionFactoryRegistry.INSTANCE.getSessionFactory( sessionFactoryUuid ).openSession();
 		session.getPersistenceContextInternal().setDefaultReadOnly( true );
 		session.setHibernateFlushMode( FlushMode.MANUAL );

--- a/hibernate-core/src/main/java/org/hibernate/engine/internal/AbstractEntityEntry.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/internal/AbstractEntityEntry.java
@@ -288,7 +288,7 @@ public abstract class AbstractEntityEntry implements Serializable, EntityEntry {
 
 		final SharedSessionContractImplementor session = getPersistenceContext().getSession();
 		session.getFactory().getCustomEntityDirtinessStrategy()
-				.resetDirty( entity, persister, session.asSessionImplementor() );
+				.resetDirty( entity, persister, (SessionImplementor) session );
 	}
 
 	private static void clearDirtyAttributes(final SelfDirtinessTracker entity) {
@@ -371,7 +371,7 @@ public abstract class AbstractEntityEntry implements Serializable, EntityEntry {
 			}
 		}
 
-		final SessionImplementor session = getPersistenceContext().getSession().asSessionImplementor();
+		final SessionImplementor session = (SessionImplementor) getPersistenceContext().getSession();
 		final CustomEntityDirtinessStrategy customEntityDirtinessStrategy =
 				session.getFactory().getCustomEntityDirtinessStrategy();
 		return customEntityDirtinessStrategy.canDirtyCheck( entity, getPersister(), session )

--- a/hibernate-core/src/main/java/org/hibernate/engine/spi/SessionDelegatorBaseImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/spi/SessionDelegatorBaseImpl.java
@@ -375,16 +375,6 @@ public class SessionDelegatorBaseImpl implements SessionImplementor {
 	}
 
 	@Override
-	public boolean shouldAutoClose() {
-		return delegate.shouldAutoClose();
-	}
-
-	@Override
-	public boolean isAutoCloseSessionEnabled() {
-		return delegate.isAutoCloseSessionEnabled();
-	}
-
-	@Override
 	public boolean shouldAutoJoinTransaction() {
 		return delegate.shouldAutoJoinTransaction();
 	}

--- a/hibernate-core/src/main/java/org/hibernate/engine/spi/SessionImplementor.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/spi/SessionImplementor.java
@@ -83,6 +83,7 @@ public interface SessionImplementor extends Session, SharedSessionContractImplem
 	 */
 	ActionQueue getActionQueue();
 
+	@Override
 	Object instantiate(EntityPersister persister, Object id) throws HibernateException;
 
 	/**
@@ -93,16 +94,6 @@ public interface SessionImplementor extends Session, SharedSessionContractImplem
 	 * Initiate a flush to force deletion of a re-persisted entity.
 	 */
 	void forceFlush(EntityKey e) throws HibernateException;
-
-	@Override
-	default SessionImplementor asSessionImplementor() {
-		return this;
-	}
-
-	@Override
-	default boolean isSessionImplementor() {
-		return true;
-	}
 
 	@Override
 	default <C> void runWithConnection(ConnectionConsumer<C> action) {

--- a/hibernate-core/src/main/java/org/hibernate/engine/spi/SharedSessionContractImplementor.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/spi/SharedSessionContractImplementor.java
@@ -17,7 +17,6 @@ import org.hibernate.LockMode;
 import org.hibernate.LockOptions;
 import org.hibernate.StatelessSession;
 import org.hibernate.action.spi.AfterTransactionCompletionProcess;
-import org.hibernate.boot.spi.SessionFactoryOptions;
 import org.hibernate.dialect.Dialect;
 import org.hibernate.event.spi.EventSource;
 import org.hibernate.query.Query;
@@ -415,26 +414,6 @@ public interface SharedSessionContractImplementor
 	 * does nothing.
 	 */
 	void afterScrollOperation();
-
-	/**
-	 * Should this session be automatically closed after the current
-	 * transaction completes?
-	 *
-	 * @deprecated there's no reason to expose this here
-	 */
-	@Deprecated(since = "6")
-	boolean shouldAutoClose();
-
-	/**
-	 * Is auto-close at transaction completion enabled?
-	 *
-	 * @see org.hibernate.cfg.AvailableSettings#AUTO_CLOSE_SESSION
-	 * @see SessionFactoryOptions#isAutoCloseSessionEnabled()
-	 *
-	 * @deprecated there's no reason to expose this here
-	 */
-	@Deprecated(since = "6")
-	boolean isAutoCloseSessionEnabled();
 
 	/**
 	 * Get the {@link LoadQueryInfluencers} associated with this session.

--- a/hibernate-core/src/main/java/org/hibernate/engine/spi/SharedSessionDelegatorBaseImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/spi/SharedSessionDelegatorBaseImpl.java
@@ -5,7 +5,6 @@
 package org.hibernate.engine.spi;
 
 import jakarta.persistence.EntityGraph;
-import jakarta.persistence.FlushModeType;
 import jakarta.persistence.TypedQueryReference;
 import jakarta.persistence.criteria.CriteriaDelete;
 import jakarta.persistence.criteria.CriteriaQuery;
@@ -512,16 +511,6 @@ public class SharedSessionDelegatorBaseImpl implements SharedSessionContractImpl
 	@Override
 	public void setNativeJdbcParametersIgnored(boolean nativeJdbcParametersIgnored) {
 		delegate.setNativeJdbcParametersIgnored( nativeJdbcParametersIgnored );
-	}
-
-	@Override
-	public FlushModeType getFlushMode() {
-		return delegate.getFlushMode();
-	}
-
-	@Override
-	public void setHibernateFlushMode(FlushMode flushMode) {
-		delegate.setHibernateFlushMode( flushMode );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/engine/spi/SharedSessionDelegatorBaseImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/spi/SharedSessionDelegatorBaseImpl.java
@@ -529,16 +529,6 @@ public class SharedSessionDelegatorBaseImpl implements SharedSessionContractImpl
 	}
 
 	@Override
-	public boolean shouldAutoClose() {
-		return delegate.shouldAutoClose();
-	}
-
-	@Override
-	public boolean isAutoCloseSessionEnabled() {
-		return delegate.isAutoCloseSessionEnabled();
-	}
-
-	@Override
 	public LoadQueryInfluencers getLoadQueryInfluencers() {
 		return delegate.getLoadQueryInfluencers();
 	}

--- a/hibernate-core/src/main/java/org/hibernate/event/spi/AutoFlushEvent.java
+++ b/hibernate-core/src/main/java/org/hibernate/event/spi/AutoFlushEvent.java
@@ -32,7 +32,7 @@ public class AutoFlushEvent extends FlushEvent {
 		return querySpaces;
 	}
 
-	public void setQuerySpaces(Set querySpaces) {
+	public void setQuerySpaces(Set<String> querySpaces) {
 		this.querySpaces = querySpaces;
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/id/IdentifierGeneratorHelper.java
+++ b/hibernate-core/src/main/java/org/hibernate/id/IdentifierGeneratorHelper.java
@@ -15,9 +15,12 @@ import java.util.Objects;
 import java.util.Properties;
 
 import org.hibernate.Internal;
+import org.hibernate.Session;
+import org.hibernate.StatelessSession;
 import org.hibernate.TransientObjectException;
 import org.hibernate.boot.registry.selector.spi.StrategySelector;
 import org.hibernate.engine.config.spi.ConfigurationService;
+import org.hibernate.engine.spi.SessionImplementor;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.id.enhanced.ImplicitDatabaseObjectNamingStrategy;
 import org.hibernate.id.enhanced.StandardNamingStrategy;
@@ -135,8 +138,8 @@ public final class IdentifierGeneratorHelper {
 		final EntityPersister entityDescriptor =
 				sessionImplementor.getFactory().getMappingMetamodel()
 						.getEntityDescriptor( entityName );
-		if ( sessionImplementor.isSessionImplementor()
-				&& sessionImplementor.asSessionImplementor().contains( entityName, object ) ) {
+		if ( sessionImplementor instanceof SessionImplementor statefulSession
+				&& statefulSession.contains( entityName, object ) ) {
 			//abort the save (the object is already saved by a circular cascade)
 			return SHORT_CIRCUIT_INDICATOR;
 			//throw new IdentifierGenerationException("save associated object first, or disable cascade for inverse association");
@@ -166,12 +169,12 @@ public final class IdentifierGeneratorHelper {
 			return getEntityIdentifierIfNotUnsaved( associatedEntityName, associatedEntity, sessionImplementor );
 		}
 		catch (TransientObjectException toe) {
-			if ( sessionImplementor.isSessionImplementor() ) {
-				sessionImplementor.asSessionImplementor().persist( associatedEntityName, associatedEntity );
+			if ( sessionImplementor instanceof Session statefulSession ) {
+				statefulSession.persist( associatedEntityName, associatedEntity );
 				return sessionImplementor.getContextEntityIdentifier( associatedEntity );
 			}
-			else if ( sessionImplementor.isStatelessSession() ) {
-				return sessionImplementor.asStatelessSession().insert( associatedEntityName, associatedEntity );
+			else if ( sessionImplementor instanceof StatelessSession statelessSession ) {
+				return statelessSession.insert( associatedEntityName, associatedEntity );
 			}
 			else {
 				throw new IdentifierGenerationException("sessionImplementor is neither Session nor StatelessSession");

--- a/hibernate-core/src/main/java/org/hibernate/internal/AbstractSharedSessionContract.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/AbstractSharedSessionContract.java
@@ -21,7 +21,6 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 import org.hibernate.CacheMode;
 import org.hibernate.EntityNameResolver;
 import org.hibernate.Filter;
-import org.hibernate.FlushMode;
 import org.hibernate.HibernateException;
 import org.hibernate.Interceptor;
 import org.hibernate.LockMode;
@@ -104,7 +103,6 @@ import org.hibernate.resource.transaction.TransactionRequiredForJoinException;
 import org.hibernate.resource.transaction.backend.jta.internal.JtaTransactionCoordinatorImpl;
 import org.hibernate.resource.transaction.spi.TransactionCoordinator;
 
-import jakarta.persistence.FlushModeType;
 import jakarta.persistence.TransactionRequiredException;
 import jakarta.persistence.TypedQueryReference;
 import jakarta.persistence.criteria.CriteriaDelete;
@@ -116,7 +114,6 @@ import org.hibernate.type.spi.TypeConfiguration;
 
 import static java.lang.Boolean.TRUE;
 import static org.hibernate.internal.util.StringHelper.isEmpty;
-import static org.hibernate.jpa.internal.util.FlushModeTypeHelper.getFlushModeType;
 import static org.hibernate.query.sqm.internal.SqmUtil.verifyIsSelectStatement;
 
 /**
@@ -162,7 +159,6 @@ public abstract class AbstractSharedSessionContract implements SharedSessionCont
 	private final TimeZone jdbcTimeZone;
 
 	// mutable state
-	private FlushMode flushMode;
 	private CacheMode cacheMode;
 	private Integer jdbcBatchSize;
 
@@ -187,7 +183,6 @@ public abstract class AbstractSharedSessionContract implements SharedSessionCont
 		this.jdbcServices = factory.getJdbcServices();
 
 		cacheTransactionSync = factory.getCache().getRegionFactory().createTransactionContext( this );
-		flushMode = options.getInitialSessionFlushMode();
 		tenantIdentifier = getTenantId( factoryOptions, options );
 		interceptor = interpret( options.getInterceptor() );
 		jdbcTimeZone = options.getJdbcTimeZone();
@@ -762,22 +757,6 @@ public abstract class AbstractSharedSessionContract implements SharedSessionCont
 	@Override
 	public JdbcServices getJdbcServices() {
 		return jdbcServices;
-	}
-
-	@Override
-	public FlushModeType getFlushMode() {
-		checkOpen();
-		return getFlushModeType( flushMode );
-	}
-
-	@Override
-	public void setHibernateFlushMode(FlushMode flushMode) {
-		this.flushMode = flushMode;
-	}
-
-	@Override
-	public FlushMode getHibernateFlushMode() {
-		return flushMode;
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/internal/StatelessSessionImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/StatelessSessionImpl.java
@@ -1116,12 +1116,10 @@ public class StatelessSessionImpl extends AbstractSharedSessionContract implemen
 		return getFactory().getPersistenceUnitUtil().getIdentifier(entity);
 	}
 
-	@Override
 	public boolean isAutoCloseSessionEnabled() {
 		return getSessionFactoryOptions().isAutoCloseSessionEnabled();
 	}
 
-	@Override
 	public boolean shouldAutoClose() {
 		return isAutoCloseSessionEnabled() && !isClosed();
 	}

--- a/hibernate-core/src/main/java/org/hibernate/internal/StatelessSessionImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/StatelessSessionImpl.java
@@ -154,6 +154,11 @@ public class StatelessSessionImpl extends AbstractSharedSessionContract implemen
 		return true;
 	}
 
+	@Override
+	public FlushMode getHibernateFlushMode() {
+		return FlushMode.MANUAL;
+	}
+
 	// inserts ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 	@Override
@@ -1147,11 +1152,6 @@ public class StatelessSessionImpl extends AbstractSharedSessionContract implemen
 	}
 
 	@Override
-	public void setHibernateFlushMode(FlushMode flushMode) {
-		throw new UnsupportedOperationException();
-	}
-
-	@Override
 	public Object getContextEntityIdentifier(Object object) {
 		checkOpen();
 		return null;
@@ -1223,6 +1223,10 @@ public class StatelessSessionImpl extends AbstractSharedSessionContract implemen
 	}
 
 	@Override
+	public void autoPreFlush() {
+	}
+
+	@Override
 	public void flush() {
 	}
 
@@ -1238,7 +1242,7 @@ public class StatelessSessionImpl extends AbstractSharedSessionContract implemen
 	}
 
 	@Override
-	public boolean autoFlushIfRequired(Set<String> querySpaces) {
+	public boolean autoFlushIfRequired(Set<String> querySpaces, boolean skipPreFlush) {
 		return false;
 	}
 
@@ -1305,16 +1309,6 @@ public class StatelessSessionImpl extends AbstractSharedSessionContract implemen
 
 	private LockMode getNullSafeLockMode(LockMode lockMode) {
 		return lockMode == null ? LockMode.NONE : lockMode;
-	}
-
-	@Override
-	public StatelessSession asStatelessSession() {
-		return this;
-	}
-
-	@Override
-	public boolean isStatelessSession() {
-		return true;
 	}
 
 	protected Object lockCacheItem(Object id, Object previousVersion, EntityPersister persister) {

--- a/hibernate-core/src/main/java/org/hibernate/proxy/AbstractLazyInitializer.java
+++ b/hibernate-core/src/main/java/org/hibernate/proxy/AbstractLazyInitializer.java
@@ -12,6 +12,7 @@ import org.hibernate.boot.spi.SessionFactoryOptions;
 import org.hibernate.engine.spi.EntityKey;
 import org.hibernate.engine.spi.PersistenceContext;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
+import org.hibernate.engine.spi.SessionImplementor;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.internal.CoreLogging;
 import org.hibernate.internal.CoreMessageLogger;
@@ -206,7 +207,7 @@ public abstract class AbstractLazyInitializer implements LazyInitializer {
 			try {
 				final SessionFactoryImplementor factory =
 						SessionFactoryRegistry.INSTANCE.getSessionFactory( sessionFactoryUuid );
-				final SharedSessionContractImplementor session = factory.openSession();
+				final SessionImplementor session = factory.openSession();
 				session.getPersistenceContext().setDefaultReadOnly( true );
 				session.setHibernateFlushMode( FlushMode.MANUAL );
 

--- a/hibernate-core/src/main/java/org/hibernate/query/spi/AbstractSelectionQuery.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/spi/AbstractSelectionQuery.java
@@ -19,6 +19,7 @@ import java.util.stream.StreamSupport;
 import org.hibernate.CacheMode;
 import org.hibernate.FlushMode;
 import org.hibernate.ScrollableResults;
+import org.hibernate.engine.spi.SessionImplementor;
 import org.hibernate.query.QueryFlushMode;
 import org.hibernate.HibernateException;
 import org.hibernate.LockMode;
@@ -174,9 +175,9 @@ public abstract class AbstractSelectionQuery<R>
 		assert sessionCacheMode == null;
 
 		final FlushMode effectiveFlushMode = getQueryOptions().getFlushMode();
-		if ( effectiveFlushMode != null ) {
-			sessionFlushMode = session.getHibernateFlushMode();
-			session.setHibernateFlushMode( effectiveFlushMode );
+		if ( effectiveFlushMode != null && session instanceof SessionImplementor statefulSession ) {
+			sessionFlushMode = statefulSession.getHibernateFlushMode();
+			statefulSession.setHibernateFlushMode( effectiveFlushMode );
 		}
 
 		final CacheMode effectiveCacheMode = getCacheMode();
@@ -213,8 +214,9 @@ public abstract class AbstractSelectionQuery<R>
 	}
 
 	protected void afterQuery() {
-		if ( sessionFlushMode != null ) {
-			getSession().setHibernateFlushMode( sessionFlushMode );
+		if ( sessionFlushMode != null
+				&& getSession() instanceof SessionImplementor statefulSession ) {
+			statefulSession.setHibernateFlushMode( sessionFlushMode );
 			sessionFlushMode = null;
 		}
 		if ( sessionCacheMode != null ) {

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/transaction/SynchronizationTypeTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/transaction/SynchronizationTypeTest.java
@@ -103,7 +103,7 @@ public class SynchronizationTypeTest {
 			assertTrue( transactionCoordinator.isActive(), "EM was auto joined on creation" );
 			assertFalse( transactionCoordinator.isJoined(), "EM was auto joined on creation" );
 
-			session.getFlushMode();
+			session.checkOpen();
 			assertFalse( transactionCoordinator.isSynchronizationRegistered() );
 			assertTrue( transactionCoordinator.isActive() );
 			assertFalse( transactionCoordinator.isJoined() );

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/transaction/TransactionJoinHandlingChecker.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/transaction/TransactionJoinHandlingChecker.java
@@ -37,7 +37,7 @@ public class TransactionJoinHandlingChecker {
 			assertFalse( transactionCoordinator.isJtaTransactionCurrentlyActive() );
 			assertFalse( transactionCoordinator.isJoined() );
 
-			session.getFlushMode();
+			session.checkOpen();
 			assertFalse( transactionCoordinator.isSynchronizationRegistered() );
 			assertFalse( transactionCoordinator.isJtaTransactionCurrentlyActive() );
 			assertFalse( transactionCoordinator.isJoined() );
@@ -48,7 +48,7 @@ public class TransactionJoinHandlingChecker {
 			assertFalse( transactionCoordinator.isJoined() );
 			assertFalse( transactionCoordinator.isSynchronizationRegistered() );
 
-			session.getFlushMode();
+			session.checkOpen();
 			assertTrue( JtaStatusHelper.isActive( transactionManager ) );
 			assertTrue( transactionCoordinator.isJtaTransactionCurrentlyActive() );
 			assertFalse( transactionCoordinator.isJoined() );

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/sharedSession/SessionWithSharedConnectionTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/sharedSession/SessionWithSharedConnectionTest.java
@@ -12,6 +12,7 @@ import org.hibernate.event.service.spi.EventListenerRegistry;
 import org.hibernate.event.spi.EventType;
 import org.hibernate.event.spi.PostInsertEvent;
 import org.hibernate.event.spi.PostInsertEventListener;
+import org.hibernate.internal.SessionImpl;
 import org.hibernate.persister.entity.EntityPersister;
 
 import org.hibernate.resource.jdbc.spi.JdbcSessionOwner;
@@ -95,8 +96,8 @@ public class SessionWithSharedConnectionTest {
 				.openSession();
 
 		// directly assert state of the second session
-		assertTrue( ((SessionImplementor) secondSession).isAutoCloseSessionEnabled() );
-		assertTrue( ((SessionImplementor) secondSession).shouldAutoClose() );
+		assertTrue( ((SessionImpl) secondSession).isAutoCloseSessionEnabled() );
+		assertTrue( ((SessionImpl) secondSession).shouldAutoClose() );
 
 		// now commit the transaction and make sure that does not close the sessions
 		session.getTransaction().commit();
@@ -119,8 +120,8 @@ public class SessionWithSharedConnectionTest {
 				.openSession();
 
 		// directly assert state of the second session
-		assertTrue( ((SessionImplementor) secondSession).isAutoCloseSessionEnabled() );
-		assertTrue( ((SessionImplementor) secondSession).shouldAutoClose() );
+		assertTrue( ((SessionImpl) secondSession).isAutoCloseSessionEnabled() );
+		assertTrue( ((SessionImpl) secondSession).shouldAutoClose() );
 
 		// now rollback the transaction and make sure that does not close the sessions
 		session.getTransaction().rollback();

--- a/hibernate-envers/src/test/java/org/hibernate/envers/test/integration/tm/SessionFactoryInterceptorTransactionTest.java
+++ b/hibernate-envers/src/test/java/org/hibernate/envers/test/integration/tm/SessionFactoryInterceptorTransactionTest.java
@@ -12,8 +12,8 @@ import jakarta.persistence.EntityManager;
 import jakarta.transaction.TransactionManager;
 
 import org.hibernate.FlushMode;
+import org.hibernate.Session;
 import org.hibernate.cfg.AvailableSettings;
-import org.hibernate.internal.SessionImpl;
 import org.hibernate.orm.test.envers.BaseEnversJPAFunctionalTestCase;
 import org.hibernate.orm.test.envers.Priority;
 import org.hibernate.orm.test.envers.entities.StrTestEntity;
@@ -56,7 +56,7 @@ public class SessionFactoryInterceptorTransactionTest extends BaseEnversJPAFunct
 		// Revision 1
 		EntityManager em = getEntityManager();
 		// Explicitly use manual flush to trigger separate temporary session write via Envers
-		em.unwrap( SessionImpl.class ).setHibernateFlushMode( FlushMode.MANUAL );
+		em.unwrap( Session.class ).setHibernateFlushMode( FlushMode.MANUAL );
 		tm.begin();
 		StrTestEntity entity = new StrTestEntity( "Test" );
 		em.persist( entity );

--- a/hibernate-envers/src/test/java/org/hibernate/envers/test/integration/tm/SessionInterceptorTransactionTest.java
+++ b/hibernate-envers/src/test/java/org/hibernate/envers/test/integration/tm/SessionInterceptorTransactionTest.java
@@ -12,8 +12,8 @@ import jakarta.persistence.EntityManager;
 import jakarta.transaction.TransactionManager;
 
 import org.hibernate.FlushMode;
+import org.hibernate.Session;
 import org.hibernate.cfg.AvailableSettings;
-import org.hibernate.internal.SessionImpl;
 import org.hibernate.orm.test.envers.BaseEnversJPAFunctionalTestCase;
 import org.hibernate.orm.test.envers.Priority;
 import org.hibernate.orm.test.envers.entities.StrTestEntity;
@@ -54,7 +54,7 @@ public class SessionInterceptorTransactionTest extends BaseEnversJPAFunctionalTe
 		// Revision 1
 		EntityManager em = getEntityManager();
 		// Explicitly use manual flush to trigger separate temporary session write via Envers
-		em.unwrap( SessionImpl.class ).setHibernateFlushMode( FlushMode.MANUAL );
+		em.unwrap( Session.class ).setHibernateFlushMode( FlushMode.MANUAL );
 		tm.begin();
 		StrTestEntity entity = new StrTestEntity( "Test" );
 		em.persist( entity );


### PR DESCRIPTION
- remove deprecated getFlushMode()
- remove setHibernateFlushMode()
- deprecate silly methods which are much worse than safe casts

<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

[Please describe here what your change is about]

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
