### PR TITLE
move incubating enum TimeZoneStorageStrategy to org.hibernate.type

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/annotations/TimeZoneStorageType.java
+++ b/hibernate-core/src/main/java/org/hibernate/annotations/TimeZoneStorageType.java
@@ -6,6 +6,7 @@ package org.hibernate.annotations;
 
 import org.hibernate.Incubating;
 import org.hibernate.dialect.Dialect;
+import org.hibernate.type.TimeZoneStorageStrategy;
 
 /**
  * Describes the storage of timezone information for zoned datetime types,
@@ -61,7 +62,7 @@ import org.hibernate.dialect.Dialect;
  * @since 6.0
  *
  * @see TimeZoneStorage
- * @see org.hibernate.TimeZoneStorageStrategy
+ * @see TimeZoneStorageStrategy
  */
 @Incubating
 public enum TimeZoneStorageType {

--- a/hibernate-core/src/main/java/org/hibernate/boot/internal/MetadataBuilderImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/internal/MetadataBuilderImpl.java
@@ -10,7 +10,7 @@ import java.util.Locale;
 
 import org.hibernate.AnnotationException;
 import org.hibernate.HibernateException;
-import org.hibernate.TimeZoneStorageStrategy;
+import org.hibernate.type.TimeZoneStorageStrategy;
 import org.hibernate.annotations.CacheConcurrencyStrategy;
 import org.hibernate.annotations.TimeZoneStorageType;
 import org.hibernate.boot.CacheRegionDefinition;

--- a/hibernate-core/src/main/java/org/hibernate/boot/internal/SessionFactoryOptionsBuilder.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/internal/SessionFactoryOptionsBuilder.java
@@ -28,7 +28,7 @@ import org.hibernate.Interceptor;
 import org.hibernate.LockOptions;
 import org.hibernate.SessionEventListener;
 import org.hibernate.SessionFactoryObserver;
-import org.hibernate.TimeZoneStorageStrategy;
+import org.hibernate.type.TimeZoneStorageStrategy;
 import org.hibernate.annotations.CacheLayout;
 import org.hibernate.boot.SchemaAutoTooling;
 import org.hibernate.boot.TempTableDdlTransactionHandling;

--- a/hibernate-core/src/main/java/org/hibernate/boot/model/internal/BasicValueBinder.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/internal/BasicValueBinder.java
@@ -25,7 +25,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 import org.hibernate.AnnotationException;
 import org.hibernate.AssertionFailure;
 import org.hibernate.MappingException;
-import org.hibernate.TimeZoneStorageStrategy;
+import org.hibernate.type.TimeZoneStorageStrategy;
 import org.hibernate.annotations.*;
 import org.hibernate.boot.internal.AnyKeyType;
 import org.hibernate.boot.model.convert.spi.ConverterDescriptor;

--- a/hibernate-core/src/main/java/org/hibernate/boot/model/internal/TimeZoneStorageHelper.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/internal/TimeZoneStorageHelper.java
@@ -19,7 +19,7 @@ import org.hibernate.usertype.internal.OffsetDateTimeCompositeUserType;
 import org.hibernate.usertype.internal.OffsetTimeCompositeUserType;
 import org.hibernate.usertype.internal.ZonedDateTimeCompositeUserType;
 
-import static org.hibernate.TimeZoneStorageStrategy.COLUMN;
+import static org.hibernate.type.TimeZoneStorageStrategy.COLUMN;
 import static org.hibernate.dialect.TimeZoneSupport.NATIVE;
 
 public class TimeZoneStorageHelper {

--- a/hibernate-core/src/main/java/org/hibernate/boot/model/internal/TimeZoneStorageHelper.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/internal/TimeZoneStorageHelper.java
@@ -33,7 +33,7 @@ public class TimeZoneStorageHelper {
 			ClassDetails returnedClass,
 			MetadataBuildingContext context) {
 		if ( useColumnForTimeZoneStorage( attributeMember, context ) ) {
-			String returnedClassName = returnedClass.getName();
+			final String returnedClassName = returnedClass.getName();
 			if ( OFFSET_DATETIME_CLASS.equals( returnedClassName ) ) {
 				return OffsetDateTimeCompositeUserType.class;
 			}
@@ -49,24 +49,20 @@ public class TimeZoneStorageHelper {
 
 	private static boolean isTemporalWithTimeZoneClass(String returnedClassName) {
 		return OFFSET_DATETIME_CLASS.equals( returnedClassName )
-				|| ZONED_DATETIME_CLASS.equals( returnedClassName )
-				|| isOffsetTimeClass( returnedClassName );
+			|| ZONED_DATETIME_CLASS.equals( returnedClassName )
+			|| isOffsetTimeClass( returnedClassName );
 	}
 
 	public static boolean isOffsetTimeClass(AnnotationTarget element) {
-		if ( element instanceof MemberDetails memberDetails ) {
-			return isOffsetTimeClass( memberDetails );
-		}
-		return false;
+		return element instanceof MemberDetails memberDetails
+			&& isOffsetTimeClass( memberDetails );
 	}
 
 	public static boolean isOffsetTimeClass(MemberDetails element) {
 		final TypeDetails type = element.getType();
-		if ( type == null ) {
-			return false;
-		}
+		return type != null
+			&& isOffsetTimeClass( type.determineRawClass().getClassName() );
 
-		return isOffsetTimeClass( type.determineRawClass().getClassName() );
 	}
 
 	private static boolean isOffsetTimeClass(String returnedClassName) {
@@ -76,14 +72,10 @@ public class TimeZoneStorageHelper {
 	static boolean useColumnForTimeZoneStorage(AnnotationTarget element, MetadataBuildingContext context) {
 		final TimeZoneStorage timeZoneStorage = element.getDirectAnnotationUsage( TimeZoneStorage.class );
 		if ( timeZoneStorage == null ) {
-			if ( element instanceof MemberDetails attributeMember ) {
-				return isTemporalWithTimeZoneClass( attributeMember.getType().getName() )
-						//no @TimeZoneStorage annotation, so we need to use the default storage strategy
-						&& context.getBuildingOptions().getDefaultTimeZoneStorage() == COLUMN;
-			}
-			else {
-				return false;
-			}
+			return element instanceof MemberDetails attributeMember
+				&& isTemporalWithTimeZoneClass( attributeMember.getType().getName() )
+				//no @TimeZoneStorage annotation, so we need to use the default storage strategy
+				&& context.getBuildingOptions().getDefaultTimeZoneStorage() == COLUMN;
 		}
 		else {
 			return switch ( timeZoneStorage.value() ) {

--- a/hibernate-core/src/main/java/org/hibernate/boot/model/process/internal/VersionResolution.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/process/internal/VersionResolution.java
@@ -7,7 +7,7 @@ package org.hibernate.boot.model.process.internal;
 import java.util.function.Function;
 import jakarta.persistence.TemporalType;
 
-import org.hibernate.TimeZoneStorageStrategy;
+import org.hibernate.type.TimeZoneStorageStrategy;
 import org.hibernate.annotations.TimeZoneStorageType;
 import org.hibernate.boot.spi.MetadataBuildingContext;
 import org.hibernate.dialect.Dialect;

--- a/hibernate-core/src/main/java/org/hibernate/boot/spi/AbstractDelegatingMetadataBuildingOptions.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/spi/AbstractDelegatingMetadataBuildingOptions.java
@@ -7,7 +7,7 @@ package org.hibernate.boot.spi;
 import java.util.List;
 
 import org.hibernate.HibernateException;
-import org.hibernate.TimeZoneStorageStrategy;
+import org.hibernate.type.TimeZoneStorageStrategy;
 import org.hibernate.boot.model.naming.ImplicitNamingStrategy;
 import org.hibernate.boot.model.naming.PhysicalNamingStrategy;
 import org.hibernate.boot.model.relational.ColumnOrderingStrategy;

--- a/hibernate-core/src/main/java/org/hibernate/boot/spi/AbstractDelegatingSessionFactoryOptions.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/spi/AbstractDelegatingSessionFactoryOptions.java
@@ -17,7 +17,7 @@ import org.hibernate.FlushMode;
 import org.hibernate.Interceptor;
 import org.hibernate.LockOptions;
 import org.hibernate.SessionFactoryObserver;
-import org.hibernate.TimeZoneStorageStrategy;
+import org.hibernate.type.TimeZoneStorageStrategy;
 import org.hibernate.annotations.CacheLayout;
 import org.hibernate.boot.SchemaAutoTooling;
 import org.hibernate.boot.TempTableDdlTransactionHandling;

--- a/hibernate-core/src/main/java/org/hibernate/boot/spi/MetadataBuildingOptions.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/spi/MetadataBuildingOptions.java
@@ -7,7 +7,7 @@ package org.hibernate.boot.spi;
 import java.util.List;
 
 import org.hibernate.Incubating;
-import org.hibernate.TimeZoneStorageStrategy;
+import org.hibernate.type.TimeZoneStorageStrategy;
 import org.hibernate.boot.model.naming.ImplicitNamingStrategy;
 import org.hibernate.boot.model.naming.PhysicalNamingStrategy;
 import org.hibernate.boot.model.relational.ColumnOrderingStrategy;

--- a/hibernate-core/src/main/java/org/hibernate/boot/spi/SessionFactoryOptions.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/spi/SessionFactoryOptions.java
@@ -20,7 +20,7 @@ import org.hibernate.Internal;
 import org.hibernate.LockOptions;
 import org.hibernate.SessionEventListener;
 import org.hibernate.SessionFactoryObserver;
-import org.hibernate.TimeZoneStorageStrategy;
+import org.hibernate.type.TimeZoneStorageStrategy;
 import org.hibernate.annotations.CacheLayout;
 import org.hibernate.boot.SchemaAutoTooling;
 import org.hibernate.boot.TempTableDdlTransactionHandling;

--- a/hibernate-core/src/main/java/org/hibernate/mapping/BasicValue.java
+++ b/hibernate-core/src/main/java/org/hibernate/mapping/BasicValue.java
@@ -13,7 +13,7 @@ import java.util.function.Function;
 import org.hibernate.Incubating;
 import org.hibernate.Internal;
 import org.hibernate.MappingException;
-import org.hibernate.TimeZoneStorageStrategy;
+import org.hibernate.type.TimeZoneStorageStrategy;
 import org.hibernate.annotations.SoftDelete;
 import org.hibernate.annotations.SoftDeleteType;
 import org.hibernate.annotations.TimeZoneStorageType;

--- a/hibernate-core/src/main/java/org/hibernate/mapping/SimpleValue.java
+++ b/hibernate-core/src/main/java/org/hibernate/mapping/SimpleValue.java
@@ -19,7 +19,7 @@ import org.hibernate.AssertionFailure;
 import org.hibernate.FetchMode;
 import org.hibernate.Internal;
 import org.hibernate.MappingException;
-import org.hibernate.TimeZoneStorageStrategy;
+import org.hibernate.type.TimeZoneStorageStrategy;
 import org.hibernate.annotations.OnDeleteAction;
 import org.hibernate.boot.model.convert.internal.ConverterDescriptors;
 import org.hibernate.boot.model.convert.spi.ConverterDescriptor;

--- a/hibernate-core/src/main/java/org/hibernate/type/StandardBasicTypes.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/StandardBasicTypes.java
@@ -393,7 +393,7 @@ public final class StandardBasicTypes {
 
 	/**
 	 * The standard Hibernate type for mapping {@link OffsetDateTime} to JDBC {@link org.hibernate.type.SqlTypes#TIMESTAMP_WITH_TIMEZONE TIMESTAMP_WITH_TIMEZONE}.
-	 * This maps to {@link org.hibernate.TimeZoneStorageStrategy#NATIVE}.
+	 * This maps to {@link TimeZoneStorageStrategy#NATIVE}.
 	 */
 	public static final BasicTypeReference<OffsetDateTime> OFFSET_DATE_TIME_WITH_TIMEZONE = new BasicTypeReference<>(
 			"OffsetDateTimeWithTimezone",
@@ -402,7 +402,7 @@ public final class StandardBasicTypes {
 	);
 	/**
 	 * The standard Hibernate type for mapping {@link OffsetDateTime} to JDBC {@link org.hibernate.type.SqlTypes#TIMESTAMP TIMESTAMP}.
-	 * This maps to {@link org.hibernate.TimeZoneStorageStrategy#NORMALIZE}.
+	 * This maps to {@link TimeZoneStorageStrategy#NORMALIZE}.
 	 */
 	public static final BasicTypeReference<OffsetDateTime> OFFSET_DATE_TIME_WITHOUT_TIMEZONE = new BasicTypeReference<>(
 			"OffsetDateTimeWithoutTimezone",
@@ -421,7 +421,7 @@ public final class StandardBasicTypes {
 
 	/**
 	 * The standard Hibernate type for mapping {@link OffsetTime} to JDBC {@link org.hibernate.type.SqlTypes#TIME_UTC TIME_UTC}.
-	 * This maps to {@link org.hibernate.TimeZoneStorageStrategy#NORMALIZE_UTC}.
+	 * This maps to {@link TimeZoneStorageStrategy#NORMALIZE_UTC}.
 	 */
 	public static final BasicTypeReference<OffsetTime> OFFSET_TIME_UTC = new BasicTypeReference<>(
 			"OffsetTimeUtc",
@@ -431,7 +431,7 @@ public final class StandardBasicTypes {
 
 	/**
 	 * The standard Hibernate type for mapping {@link OffsetTime} to JDBC {@link org.hibernate.type.SqlTypes#TIME_WITH_TIMEZONE TIME_WITH_TIMEZONE}.
-	 * This maps to {@link org.hibernate.TimeZoneStorageStrategy#NATIVE}.
+	 * This maps to {@link TimeZoneStorageStrategy#NATIVE}.
 	 */
 	public static final BasicTypeReference<OffsetTime> OFFSET_TIME_WITH_TIMEZONE = new BasicTypeReference<>(
 			"OffsetTimeWithTimezone",
@@ -460,7 +460,7 @@ public final class StandardBasicTypes {
 
 	/**
 	 * The standard Hibernate type for mapping {@link ZonedDateTime} to JDBC {@link org.hibernate.type.SqlTypes#TIMESTAMP_WITH_TIMEZONE TIMESTAMP_WITH_TIMEZONE}.
-	 * This maps to {@link org.hibernate.TimeZoneStorageStrategy#NATIVE}.
+	 * This maps to {@link TimeZoneStorageStrategy#NATIVE}.
 	 */
 	public static final BasicTypeReference<ZonedDateTime> ZONED_DATE_TIME_WITH_TIMEZONE = new BasicTypeReference<>(
 			"ZonedDateTimeWithTimezone",
@@ -470,7 +470,7 @@ public final class StandardBasicTypes {
 
 	/**
 	 * The standard Hibernate type for mapping {@link ZonedDateTime} to JDBC {@link org.hibernate.type.SqlTypes#TIMESTAMP TIMESTAMP}.
-	 * This maps to {@link org.hibernate.TimeZoneStorageStrategy#NORMALIZE}.
+	 * This maps to {@link TimeZoneStorageStrategy#NORMALIZE}.
 	 */
 	public static final BasicTypeReference<ZonedDateTime> ZONED_DATE_TIME_WITHOUT_TIMEZONE = new BasicTypeReference<>(
 			"ZonedDateTimeWithoutTimezone",

--- a/hibernate-core/src/main/java/org/hibernate/type/TimeZoneStorageStrategy.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/TimeZoneStorageStrategy.java
@@ -2,7 +2,9 @@
  * SPDX-License-Identifier: Apache-2.0
  * Copyright Red Hat Inc. and Hibernate Authors
  */
-package org.hibernate;
+package org.hibernate.type;
+
+import org.hibernate.Incubating;
 
 /**
  * Enumerates the possible storage strategies for offset or zoned datetimes.

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/jdbc/DelegatingJdbcTypeIndicators.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/jdbc/DelegatingJdbcTypeIndicators.java
@@ -5,7 +5,7 @@
 package org.hibernate.type.descriptor.jdbc;
 
 import org.hibernate.Incubating;
-import org.hibernate.TimeZoneStorageStrategy;
+import org.hibernate.type.TimeZoneStorageStrategy;
 import org.hibernate.dialect.Dialect;
 import org.hibernate.type.spi.TypeConfiguration;
 

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/jdbc/JdbcTypeIndicators.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/jdbc/JdbcTypeIndicators.java
@@ -8,7 +8,7 @@ import jakarta.persistence.EnumType;
 import jakarta.persistence.TemporalType;
 
 import org.hibernate.Incubating;
-import org.hibernate.TimeZoneStorageStrategy;
+import org.hibernate.type.TimeZoneStorageStrategy;
 import org.hibernate.dialect.Dialect;
 import org.hibernate.type.SqlTypes;
 import org.hibernate.type.descriptor.java.BasicJavaType;

--- a/hibernate-core/src/main/java/org/hibernate/type/spi/TypeConfiguration.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/spi/TypeConfiguration.java
@@ -37,7 +37,7 @@ import org.hibernate.Incubating;
 import org.hibernate.Internal;
 import org.hibernate.SessionFactory;
 import org.hibernate.SessionFactoryObserver;
-import org.hibernate.TimeZoneStorageStrategy;
+import org.hibernate.type.TimeZoneStorageStrategy;
 import org.hibernate.boot.cfgxml.spi.CfgXmlAccessService;
 import org.hibernate.boot.registry.classloading.spi.ClassLoaderService;
 import org.hibernate.boot.spi.BasicTypeRegistration;

--- a/tooling/metamodel-generator/src/main/java/org/hibernate/processor/validation/MockSessionFactory.java
+++ b/tooling/metamodel-generator/src/main/java/org/hibernate/processor/validation/MockSessionFactory.java
@@ -10,7 +10,7 @@ import org.hibernate.CustomEntityDirtinessStrategy;
 import org.hibernate.EntityNameResolver;
 import org.hibernate.MappingException;
 import org.hibernate.SessionFactoryObserver;
-import org.hibernate.TimeZoneStorageStrategy;
+import org.hibernate.type.TimeZoneStorageStrategy;
 import org.hibernate.boot.internal.DefaultCustomEntityDirtinessStrategy;
 import org.hibernate.boot.internal.MetadataImpl;
 import org.hibernate.boot.internal.StandardEntityNotFoundDelegate;


### PR DESCRIPTION
This enum is not really an API-API (it's more like an SPI), and has no usages in `org.hibernate`. Application programs are expected to use `o.h.annotations.TimeZoneStorageType`, and so putting this enum in `org.hibernate` is pretty confusing to users, who have no use for it.

<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

[Please describe here what your change is about]

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
