### PR TITLE
HHH-19358 - Add a "What's New" document for series

### DIFF
--- a/documentation/documentation.gradle
+++ b/documentation/documentation.gradle
@@ -738,6 +738,45 @@ def renderIntegrationGuidesTask = tasks.register( "renderIntegrationGuides" ) { 
 
 
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+// What's New Guide
+
+def whatsNewGuideSourceStagingDir = layout.buildDirectory.dir( "tmp/asciidoc/whats-new" )
+
+def copyWhatsNewTask = tasks.register( "copyWhatsNew", Copy ) {task ->
+	group = "Documentation"
+	description = "Copies whats-new.adoc in preparation for rendering."
+
+	inputs.property "hibernate-version", hibernateVersion
+
+	from rootProject.layout.projectDirectory.file( "whats-new.adoc" )
+	into whatsNewGuideSourceStagingDir
+}
+
+def renderWhatsNewTask = tasks.register( "renderWhatsNew", AsciidoctorTask ) {
+	group = "Documentation"
+	description = "Renders the What's New guide in HTML format using Asciidoctor."
+
+	dependsOn copyWhatsNewTask
+	inputs.property "hibernate-version", hibernateVersion
+
+	sourceDir = whatsNewGuideSourceStagingDir
+
+	outputDir = project.layout.buildDirectory.dir( 'asciidoc/whats-new' )
+
+	attributes linkcss: true,
+			stylesheet: "css/hibernate.css"
+
+	resources {
+		from( 'src/main/style/asciidoctor' ) {
+			include 'images/**'
+		}
+		from( 'src/main/style/asciidoctor' ) {
+			include 'css/**'
+		}
+	}
+}
+
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 // Migration Guide
 
 def migrationGuideSourceStagingDir = layout.buildDirectory.dir( "tmp/asciidoc/migration-guide" )
@@ -853,6 +892,7 @@ def buildDocsTask = tasks.register( 'buildDocs' ) { task ->
 	task.dependsOn renderTopicalGuidesTask
 	task.dependsOn generateReportsTask
 	task.dependsOn renderMigrationGuideTask
+	task.dependsOn renderWhatsNewTask
 }
 
 //noinspection GroovyUnusedAssignment

--- a/release/release.gradle
+++ b/release/release.gradle
@@ -3,7 +3,6 @@
  * Copyright Red Hat Inc. and Hibernate Authors
  */
 import java.nio.charset.StandardCharsets
-import java.util.function.Function
 
 import groovy.json.JsonSlurper
 
@@ -268,6 +267,16 @@ def stageMigrationGuideTask = tasks.register( "stageMigrationGuide", Copy ) {
     into layout.buildDirectory.dir( "documentation/migration-guide" )
 }
 
+def stageWhatsNewGuideTask = tasks.register( "stageWhatsNewGuide", Copy ) {
+    group 'documentation'
+    description "Stages the What's New guide as part of assembling documentation in preparation for release"
+
+    dependsOn ':documentation:renderWhatsNew'
+
+    from project.provider { project( ":documentation" ).layout.buildDirectory.dir( "asciidoc/whats-new" ) }
+    into layout.buildDirectory.dir( "documentation/whats-new" )
+}
+
 tasks.named( "publishMigrationGuide" ).configure {
     dependsOn stageMigrationGuideTask
 }
@@ -320,7 +329,7 @@ def stageDialectReportTask = tasks.register( "stageDialectReport", Copy ) { task
     dependsOn ':documentation:renderDialectReport'
 
     from project( ":documentation" ).tasks.renderDialectReport
-    into "${buildDir}/documentation/dialect"
+    into project.layout.buildDirectory.dir("documentation/dialect")
 }
 
 def stageOrmReportsTask = tasks.register( "stageOrmReports" ) {
@@ -342,7 +351,7 @@ def stageJavadocsTask = tasks.register( "stageJavadocs", Copy ) {
     dependsOn ':documentation:javadoc'
 
     from project( ":documentation" ).tasks.javadoc
-    into "${buildDir}/documentation/javadocs"
+    into project.layout.buildDirectory.dir("documentation/javadocs")
 }
 
 /**
@@ -364,6 +373,7 @@ def assembleDocumentationTask = tasks.register( "assembleDocumentation" ) {
     dependsOn stageIntegrationGuideTask
     dependsOn stageTopicalGuideTask
     dependsOn stageMigrationGuideTask
+    dependsOn stageWhatsNewGuideTask
     dependsOn stageOrmReportsTask
 }
 

--- a/release_notes.md
+++ b/release_notes.md
@@ -1,3 +1,4 @@
 
-* See the [website](https://hibernate.org/orm/releases/7.0) for requirements and new features in 7.0.
+* See the [website](https://hibernate.org/orm/releases/7.0) for requirements and compatibilities.
+* See the [What's New](https://docs.jboss.org/hibernate/orm/7.0/whats-new/whats-new.html) guide for details about new features and capabilities.
 * See the [Migration Guide](https://docs.jboss.org/hibernate/orm/7.0/migration-guide/migration-guide.html) for details about migration from version 6.6 to 7.0.

--- a/whats-new.adoc
+++ b/whats-new.adoc
@@ -1,0 +1,232 @@
+= What's New in 7.0
+:toc:
+:toclevels: 4
+:docsBase: https://docs.jboss.org/hibernate/orm
+:versionDocBase: {docsBase}/7.0
+:userGuideBase: {versionDocBase}/userguide/html_single/Hibernate_User_Guide.html
+:migrationGuide: {versionDocBase}/migration-guide/migration-guide.html
+
+Describes the new features and capabilities added to Hibernate ORM in 7.0.
+
+If migrating from 6.6, be sure to also check out the link:{migrationGuide}[Migration Guide] for discussion of impactful changes.
+
+[[relicense]]
+== Apache License
+
+Starting with 7.0, Hibernate ORM will be licensed under the Apache License 2.0.
+
+Details can be seen at https://hibernate.atlassian.net/browse/HHH-19145.
+
+As part of this effort, the Hibernate team reached out to the authors of
+"non-trivial" contributions to request permission to relicense their
+work under the Apache License.  The response was overwhelming positive, although
+we never heard back from some contributors and another explicitly disagreed.
+This required a few actions on our part:
+
+* Dropping `hibernate-ucp` - see https://hibernate.atlassian.net/browse/HHH-19162
+* Dropping `TeradataDialect` - see https://hibernate.atlassian.net/browse/HHH-19057
+
+[[java-17]]
+== Java 17
+
+Java 17 is the new baseline Java version.
+
+
+[[jpa-32]]
+== Jakarta Persistence 3.2
+
+7.0 migrates to Jakarta Persistence 3.2, which is fairly disruptive.
+See this https://in.relation.to/2024/04/01/jakarta-persistence-3/[blog post] for a good discussion of the changes.
+
+- https://ci.hibernate.org/view/ORM/job/hibernate-orm-tck-3.2/job/wip%252F7.0/24/[TCK Results] with Java 17
+- https://ci.hibernate.org/view/ORM/job/hibernate-orm-tck-3.2/job/wip%252F7.0/25/[TCK Results] with Java 21
+
+
+[[hibernate-models]]
+== Hibernate Models
+
+For many years Hibernate has used the Hibernate Commons Annotations (HCANN) library for handling various low-level tasks
+related to understanding the structure of an application domain model, reading annotations and weaving in XML
+mapping documents.
+The https://github.com/hibernate/hibernate-models[Hibernate Models] project was developed to be a better alternative
+to HCANN.
+7.0 uses Hibernate Models in place of HCANN.
+
+
+[[soft-delete-timestamp]]
+== @SoftDelete with TIMESTAMP
+
+Soft-delete now supports the strategy of tracking the timestamp at which the soft-delete occurred,
+in addition to the previous truth-based strategies.
+See the link:{userGuideBase}#soft-delete[User Guide] for details.
+
+[[embedded-column-naming]]
+== @EmbeddedColumnNaming
+
+A long-requested feature for both Hibernate and Jakarta Persistence has been the ability to
+define a prefix for the names of columns associated with an embedded value.
+
+7.0 adds support for this using the new `@EmbeddedColumnNaming` annotation.  The annotation
+accepts a format pattern, so is more flexible than just a prefix.
+
+[source,java]
+----
+@Embeddable
+class Address {
+    String street;
+    String city;
+	...
+}
+
+@Entity
+class Person {
+    ...
+    @Embedded
+    @EmbeddedColumnNaming("home_%")
+    Address homeAddress;
+
+    @Embedded
+    @EmbeddedColumnNaming("work_%")
+    Address workAddress;
+}
+----
+
+See the link:{userGuideBase}#embeddable-column-naming[User Guide] for details.
+
+
+[[NamedEntityGraph]]
+== @NamedEntityGraph
+
+A new annotation (`@org.hibernate.annotations.NamedEntityGraph`) has been added to allow
+specifying a named entity-graph using Hibernate's ability to parse a string representation of the graph.
+
+
+[source,java]
+----
+@Entity
+@NamedEntityGraph( graph="title, isbn, author(name, phoneNumber)" )
+class Book {
+	// ...
+}
+----
+
+
+See `org.hibernate.graph.GraphParser` for details on the syntax and the
+link:{userGuideBase}#fetching-strategies-dynamic-fetching-entity-graph-parsing-annotation[User Guide] for additional details.
+
+
+[[session-find-multiple]]
+== findMultiple()
+
+The new operation `Session.findMultiple()` provides a convenient way to fetch a batch of entities by id.
+Combined with the `BatchSize` option, allows breaking up the JDBC calls into "batches".
+
+
+[[session-managed-entities]]
+== Direct access to first-level cache
+
+The new operation `Session.getManagedEntities()` allows the application to iterate over all entities in the first-level cache, or over all entities of a given type.
+
+
+[[enum-checks]]
+== Converted Enums and Check Constraints
+
+Hibernate previously added support for generating check constraints for enums mapped using `@Enumerated`
+as part of schema generation.  7.0 adds the same capability for enums mapped using an `AttributeConverter`,
+by asking the converter to convert all the enum constants on start up.
+
+
+[[json-xml-functions]]
+== JSON and XML functions
+
+Support for most of the JSON and XML functions that the SQL standard specifies was added to HQL/Criteria.
+The implementations retain the SQL standard semantics and will throw an error if emulation on a database is impossible.
+
+New functions include:
+
+* construction functions like `json_array()`, `json_object()`, `xmlelement()` and `xmlforest()`
+* query functions like `json_value()`, `json_query()` and `xmlquery()`
+* aggregation functions like `json_agg()`, `json_object_agg()` and `xmlagg()`
+* manipulation functions like `json_set()`, `json_mergepatch()`
+* many others
+
+
+[[set-returning-functions]]
+== Set-returning Functions
+
+A set-returning function is a new type of function that can return rows and is exclusive to the `from` clause.
+The concept is known in many different database SQL dialects and is sometimes referred to as table valued function or table function.
+
+Custom set-returning functions can be registered via a `FunctionContributor`.
+Out-of-the-box, some common set-returning functions are already supported or emulated
+
+* `unnest()` - allows to turn an array into rows
+* `generate_series()` - can be used to create a series of values as rows
+* `json_table()` - turns a JSON document into rows
+* `xmltable()` - turns an XML document into rows
+
+
+[[any-discriminator]]
+== @AnyDiscriminatorImplicitValues
+
+The new  `@AnyDiscriminatorImplicitValues` offers 2 related improvements for the mapping of discriminator values
+for `@Any` and `ManyToAny` associations.
+
+First, it allows control over how Hibernate determines the discriminator value to store in the database for
+implicit discriminator mappings.  Historically, Hibernate would always use the full name of the associated
+entity.
+
+Second, it allows mixing of explicit and implicit value strategies.
+
+See the link:{userGuideBase}#associations-any[User Guide] for details.
+
+
+[[stateless-session-multiple]]
+== StatelessSession and Batch Operations
+
+`StatelessSession` now supports explicit batch operations via `insertMultiple()`, `updateMultiple()`, or `deleteMultiple()`.
+
+
+[[stateless-session-cache]]
+== StatelessSession and Second Level Cache
+
+Previously, stateless sessions never interacted with the second-level cache.
+This reflected their original intended role in bulk processing.
+With the advent of Jakarta Data and Hibernate Data Repositories, the responsibilities of `StatelessSession` have now expanded, and this behavior is no longer appropriate.
+Thus, a stateless session now makes use of the second-level cache by default.
+
+See the link:{migrationGuide}#stateless-session-cache[Migration Guide] for additional details.
+
+
+
+[[stateless-session-jdbc-batching]]
+== StatelessSession and JDBC Batching
+
+Automatic JDBC batching has the side effect of delaying the execution of the batched operation, and this undermines the synchronous nature of operations performed through a stateless session.
+In Hibernate 7, the configuration property `hibernate.jdbc.batch_size` now has no effect on a stateless session.
+Automatic batching may be enabled by explicitly calling `setJdbcBatchSize()`.
+However, the preferred approach is to <<stateless-session-multiple,explicitly batch operations>> via `insertMultiple()`, `updateMultiple()`, or `deleteMultiple()`.
+
+
+[[transaction-api]]
+== Improvements to Transaction
+
+The `Transaction` interface leaks the SPI type `TransactionStatus` via `getStatus()`, and the JTA-defined type `Synchronization` via `registerSynchronization()`, which breaks layering in a fairly harmless way.
+New operations were added to the `Transaction` interface, allowing code to inspect the status of the transaction or register callbacks without the use of layer-breaking operations.
+
+
+[[schema-manager-populate]]
+== Data population
+
+Setting `jakarta.persistence.schema-generation.database.action=populate` or calling `SchemaManager.populate()` populates an existing schema with initial data in `/import.sql` or other SQL scripts specified via `jakarta.persistence.sql-load-script-source`.
+
+
+[[xml-mapping]]
+== XML mappings
+
+Hibernate's legacy `hbm.xml` mapping schema has been deprecated for quite some time, replaced by a new `mapping.xml`
+schema, which is now stabilized and should be prefered.
+Support for `hbm.xml` mappings will be removed in 8.0.
+
+We offer a transformation of `hbm.xml` files into `mapping.xml` files, which is available both at build-time (Gradle plugin) and at run-time (using `hibernate.transform_hbm_xml.enabled=true`).
+


### PR DESCRIPTION
<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

Per discussions about information related to release series, here are the changes needed on the ORM side -

* added a What's New guide to list new features and new capabilities
* updated release_notes.md, which is used as part of the GitHub release notes to link to both the Migration Guide and the What's New guide (note that this part is temporary as @yrodiere wants to handle this differently moving forward)
* stage this new What's New guide for upload to the doc server

A follow-up task is to change the website series notes to not include the What's New information.  I just recently added it there anyway, so not a big deal.

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-19358
<!-- Hibernate GitHub Bot issue links end -->