### PR TITLE
HHH-19352 move some legacy LimitHandlers to community dialects module

### DIFF
--- a/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/HSQLLegacyDialect.java
+++ b/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/HSQLLegacyDialect.java
@@ -26,7 +26,7 @@ import org.hibernate.dialect.lock.PessimisticForceIncrementLockingStrategy;
 import org.hibernate.dialect.lock.PessimisticReadSelectLockingStrategy;
 import org.hibernate.dialect.lock.PessimisticWriteSelectLockingStrategy;
 import org.hibernate.dialect.lock.SelectLockingStrategy;
-import org.hibernate.dialect.pagination.LegacyHSQLLimitHandler;
+import org.hibernate.community.dialect.pagination.LegacyHSQLLimitHandler;
 import org.hibernate.dialect.pagination.LimitHandler;
 import org.hibernate.dialect.pagination.LimitOffsetLimitHandler;
 import org.hibernate.dialect.pagination.OffsetFetchLimitHandler;

--- a/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/OracleLegacyDialect.java
+++ b/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/OracleLegacyDialect.java
@@ -43,7 +43,7 @@ import org.hibernate.dialect.function.NvlCoalesceEmulation;
 import org.hibernate.dialect.function.OracleTruncFunction;
 import org.hibernate.dialect.identity.IdentityColumnSupport;
 import org.hibernate.dialect.identity.Oracle12cIdentityColumnSupport;
-import org.hibernate.dialect.pagination.LegacyOracleLimitHandler;
+import org.hibernate.community.dialect.pagination.LegacyOracleLimitHandler;
 import org.hibernate.dialect.pagination.LimitHandler;
 import org.hibernate.dialect.pagination.Oracle12LimitHandler;
 import org.hibernate.dialect.sequence.OracleSequenceSupport;

--- a/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/SQLServerLegacyDialect.java
+++ b/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/SQLServerLegacyDialect.java
@@ -28,7 +28,7 @@ import org.hibernate.dialect.function.SqlServerConvertTruncFunction;
 import org.hibernate.dialect.identity.IdentityColumnSupport;
 import org.hibernate.dialect.identity.SQLServerIdentityColumnSupport;
 import org.hibernate.dialect.pagination.LimitHandler;
-import org.hibernate.dialect.pagination.SQLServer2005LimitHandler;
+import org.hibernate.community.dialect.pagination.SQLServer2005LimitHandler;
 import org.hibernate.dialect.pagination.SQLServer2012LimitHandler;
 import org.hibernate.dialect.pagination.TopLimitHandler;
 import org.hibernate.dialect.sequence.NoSequenceSupport;

--- a/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/pagination/LegacyHSQLLimitHandler.java
+++ b/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/pagination/LegacyHSQLLimitHandler.java
@@ -2,7 +2,10 @@
  * SPDX-License-Identifier: Apache-2.0
  * Copyright Red Hat Inc. and Hibernate Authors
  */
-package org.hibernate.dialect.pagination;
+package org.hibernate.community.dialect.pagination;
+
+import org.hibernate.dialect.pagination.AbstractSimpleLimitHandler;
+import org.hibernate.dialect.pagination.LimitHandler;
 
 /**
  * A {@link LimitHandler} for HSQL prior to 2.0.

--- a/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/pagination/LegacyOracleLimitHandler.java
+++ b/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/pagination/LegacyOracleLimitHandler.java
@@ -2,9 +2,11 @@
  * SPDX-License-Identifier: Apache-2.0
  * Copyright Red Hat Inc. and Hibernate Authors
  */
-package org.hibernate.dialect.pagination;
+package org.hibernate.community.dialect.pagination;
 
 import org.hibernate.dialect.DatabaseVersion;
+import org.hibernate.dialect.pagination.AbstractLimitHandler;
+import org.hibernate.dialect.pagination.LimitHandler;
 import org.hibernate.query.spi.Limit;
 
 import java.util.regex.Matcher;

--- a/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/pagination/SQLServer2005LimitHandler.java
+++ b/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/pagination/SQLServer2005LimitHandler.java
@@ -2,7 +2,7 @@
  * SPDX-License-Identifier: Apache-2.0
  * Copyright Red Hat Inc. and Hibernate Authors
  */
-package org.hibernate.dialect.pagination;
+package org.hibernate.community.dialect.pagination;
 
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
@@ -11,6 +11,8 @@ import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import org.hibernate.dialect.pagination.AbstractLimitHandler;
+import org.hibernate.dialect.pagination.LimitHandler;
 import org.hibernate.internal.util.StringHelper;
 import org.hibernate.query.spi.Limit;
 

--- a/hibernate-core/src/main/java/org/hibernate/dialect/pagination/SQLServer2012LimitHandler.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/pagination/SQLServer2012LimitHandler.java
@@ -4,7 +4,12 @@
  */
 package org.hibernate.dialect.pagination;
 
-import org.hibernate.dialect.pagination.SQLServer2005LimitHandler.Keyword;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static java.util.regex.Pattern.CASE_INSENSITIVE;
+import static java.util.regex.Pattern.compile;
 
 /**
  * A {@link LimitHandler} compatible with SQL Server 2012 which
@@ -27,6 +32,72 @@ public class SQLServer2012LimitHandler extends OffsetFetchLimitHandler {
 
 	public static final SQLServer2012LimitHandler INSTANCE = new SQLServer2012LimitHandler();
 
+	private enum Keyword {
+
+		SELECT ("select(\\s+(distinct|all))?"),
+		FROM ("from"),
+		ORDER_BY ("order\\s+by"),
+		AS ("as"),
+		WITH ("with");
+
+		Pattern pattern;
+		Keyword(String keyword) {
+			pattern = compile( "^\\b" + keyword + "\\b", CASE_INSENSITIVE );
+		}
+
+		/**
+		 * Look for a "root" occurrence of this keyword in
+		 * the given SQL fragment, that is, an offset where
+		 * the keyword occurs unquoted and not parenthesized.
+		 *
+		 * @param sql a fragment of SQL
+		 * @return the offset at which the keyword occurs, or
+		 *         0 if it never occurs outside of quotes or
+		 *         parentheses.
+		 */
+		int rootOffset(String sql) {
+
+			//TODO: does not handle comments
+
+			//use a regex here for its magical ability
+			//to match word boundaries and whitespace
+			Matcher matcher = pattern.matcher( sql ).useTransparentBounds( true );
+
+			int depth = 0;
+			boolean quoted = false;
+			boolean doubleQuoted = false;
+			for ( int offset = 0, end = sql.length(); offset < end; ) {
+				int nextQuote = sql.indexOf('\'', offset);
+				if ( nextQuote<0 ) {
+					nextQuote = end;
+				}
+				if ( !quoted ) {
+					for ( int index=offset; index<nextQuote; index++ ) {
+						switch ( sql.charAt( index ) ) {
+							case '(' -> depth++;
+							case ')' -> depth--;
+							case '"' -> doubleQuoted = !doubleQuoted;
+							case '[' -> doubleQuoted = true;
+							case ']' -> doubleQuoted = false;
+							default -> {
+								if ( depth == 0 && !doubleQuoted ) {
+									matcher.region( index, nextQuote );
+									if ( matcher.find() ) {
+										//we found the keyword!
+										return index;
+									}
+								}
+							}
+
+						}
+					}
+				}
+				quoted = !quoted;
+				offset = nextQuote + 1;
+			}
+			return 0; //none found
+		}
+	}
 	public SQLServer2012LimitHandler() {
 		super(true);
 	}


### PR DESCRIPTION
<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->
Hello,
As of now, there is some legacy limit handlers that are not used by dialects . 
Some clarification about the changes : 
Especially , for SQLServer2012LimitHandler : 
  There is an enum Keyword that SQLServer2012LimitHandler used from SQLServer2005LimitHandler that I replicate with a small refactoring ( delete of  endOffset /  occursAt) that were unused + enhance switch expression>

Will keep an eye on this package, as starting from 7.1 we will have some others that will need to move to community module.

Best regards

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-19352
<!-- Hibernate GitHub Bot issue links end -->