### PR TITLE
HHH-19364 partially-detached version

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/engine/spi/SessionDelegatorBaseImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/spi/SessionDelegatorBaseImpl.java
@@ -668,8 +668,23 @@ public class SessionDelegatorBaseImpl implements SessionImplementor {
 	}
 
 	@Override
+	public <T> SelectionSpecification<T> createSelectionSpecification(CriteriaQuery<T> criteria) {
+		return delegate.createSelectionSpecification( criteria );
+	}
+
+	@Override
 	public <T> MutationSpecification<T> createMutationSpecification(String hql, Class<T> mutationTarget) {
 		return delegate.createMutationSpecification( hql, mutationTarget );
+	}
+
+	@Override
+	public <T> MutationSpecification<T> createMutationSpecification(CriteriaUpdate<T> criteriaUpdate) {
+		return delegate.createMutationSpecification( criteriaUpdate );
+	}
+
+	@Override
+	public <T> MutationSpecification<T> createMutationSpecification(CriteriaDelete<T> criteriaDelete) {
+		return delegate.createMutationSpecification( criteriaDelete );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/engine/spi/SessionDelegatorBaseImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/spi/SessionDelegatorBaseImpl.java
@@ -58,8 +58,6 @@ import org.hibernate.query.MutationQuery;
 import org.hibernate.query.SelectionQuery;
 import org.hibernate.query.criteria.HibernateCriteriaBuilder;
 import org.hibernate.query.criteria.JpaCriteriaInsert;
-import org.hibernate.query.programmatic.MutationSpecification;
-import org.hibernate.query.programmatic.SelectionSpecification;
 import org.hibernate.query.spi.QueryImplementor;
 import org.hibernate.query.spi.QueryProducerImplementor;
 import org.hibernate.query.sql.spi.NativeQueryImplementor;
@@ -655,36 +653,6 @@ public class SessionDelegatorBaseImpl implements SessionImplementor {
 	@Override
 	public MutationQuery createNamedMutationQuery(String name) {
 		return delegate.createNamedMutationQuery( name );
-	}
-
-	@Override
-	public <T> SelectionSpecification<T> createSelectionSpecification(String hql, Class<T> resultType) {
-		return delegate.createSelectionSpecification( hql, resultType );
-	}
-
-	@Override
-	public <T> SelectionSpecification<T> createSelectionSpecification(Class<T> rootEntityType) {
-		return delegate.createSelectionSpecification( rootEntityType );
-	}
-
-	@Override
-	public <T> SelectionSpecification<T> createSelectionSpecification(CriteriaQuery<T> criteria) {
-		return delegate.createSelectionSpecification( criteria );
-	}
-
-	@Override
-	public <T> MutationSpecification<T> createMutationSpecification(String hql, Class<T> mutationTarget) {
-		return delegate.createMutationSpecification( hql, mutationTarget );
-	}
-
-	@Override
-	public <T> MutationSpecification<T> createMutationSpecification(CriteriaUpdate<T> criteriaUpdate) {
-		return delegate.createMutationSpecification( criteriaUpdate );
-	}
-
-	@Override
-	public <T> MutationSpecification<T> createMutationSpecification(CriteriaDelete<T> criteriaDelete) {
-		return delegate.createMutationSpecification( criteriaDelete );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/engine/spi/SessionLazyDelegator.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/spi/SessionLazyDelegator.java
@@ -53,8 +53,6 @@ import org.hibernate.query.Query;
 import org.hibernate.query.SelectionQuery;
 import org.hibernate.query.criteria.HibernateCriteriaBuilder;
 import org.hibernate.query.criteria.JpaCriteriaInsert;
-import org.hibernate.query.programmatic.MutationSpecification;
-import org.hibernate.query.programmatic.SelectionSpecification;
 import org.hibernate.stat.SessionStatistics;
 
 import java.util.Collection;
@@ -748,36 +746,6 @@ public class SessionLazyDelegator implements Session {
 	@Override
 	public MutationQuery createNamedMutationQuery(String name) {
 		return this.lazySession.get().createNamedMutationQuery( name );
-	}
-
-	@Override
-	public <T> SelectionSpecification<T> createSelectionSpecification(String hql, Class<T> resultType) {
-		return this.lazySession.get().createSelectionSpecification( hql, resultType );
-	}
-
-	@Override
-	public <T> SelectionSpecification<T> createSelectionSpecification(Class<T> rootEntityType) {
-		return this.lazySession.get().createSelectionSpecification( rootEntityType );
-	}
-
-	@Override
-	public <T> SelectionSpecification<T> createSelectionSpecification(CriteriaQuery<T> criteria) {
-		return this.lazySession.get().createSelectionSpecification( criteria );
-	}
-
-	@Override
-	public <T> MutationSpecification<T> createMutationSpecification(String hql, Class<T> mutationTarget) {
-		return this.lazySession.get().createMutationSpecification( hql, mutationTarget );
-	}
-
-	@Override
-	public <T> MutationSpecification<T> createMutationSpecification(CriteriaUpdate<T> criteriaUpdate) {
-		return this.lazySession.get().createMutationSpecification( criteriaUpdate );
-	}
-
-	@Override
-	public <T> MutationSpecification<T> createMutationSpecification(CriteriaDelete<T> criteriaDelete) {
-		return this.lazySession.get().createMutationSpecification( criteriaDelete );
 	}
 
 	@SuppressWarnings("rawtypes")

--- a/hibernate-core/src/main/java/org/hibernate/engine/spi/SessionLazyDelegator.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/spi/SessionLazyDelegator.java
@@ -761,8 +761,23 @@ public class SessionLazyDelegator implements Session {
 	}
 
 	@Override
+	public <T> SelectionSpecification<T> createSelectionSpecification(CriteriaQuery<T> criteria) {
+		return this.lazySession.get().createSelectionSpecification( criteria );
+	}
+
+	@Override
 	public <T> MutationSpecification<T> createMutationSpecification(String hql, Class<T> mutationTarget) {
 		return this.lazySession.get().createMutationSpecification( hql, mutationTarget );
+	}
+
+	@Override
+	public <T> MutationSpecification<T> createMutationSpecification(CriteriaUpdate<T> criteriaUpdate) {
+		return this.lazySession.get().createMutationSpecification( criteriaUpdate );
+	}
+
+	@Override
+	public <T> MutationSpecification<T> createMutationSpecification(CriteriaDelete<T> criteriaDelete) {
+		return this.lazySession.get().createMutationSpecification( criteriaDelete );
 	}
 
 	@SuppressWarnings("rawtypes")

--- a/hibernate-core/src/main/java/org/hibernate/engine/spi/SharedSessionDelegatorBaseImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/spi/SharedSessionDelegatorBaseImpl.java
@@ -240,8 +240,23 @@ public class SharedSessionDelegatorBaseImpl implements SharedSessionContractImpl
 	}
 
 	@Override
+	public <T> SelectionSpecification<T> createSelectionSpecification(CriteriaQuery<T> criteria) {
+		return delegate.createSelectionSpecification( criteria );
+	}
+
+	@Override
 	public <T> MutationSpecification<T> createMutationSpecification(String hql, Class<T> mutationTarget) {
 		return delegate.createMutationSpecification( hql, mutationTarget );
+	}
+
+	@Override
+	public <T> MutationSpecification<T> createMutationSpecification(CriteriaUpdate<T> criteriaUpdate) {
+		return delegate.createMutationSpecification( criteriaUpdate );
+	}
+
+	@Override
+	public <T> MutationSpecification<T> createMutationSpecification(CriteriaDelete<T> criteriaDelete) {
+		return delegate.createMutationSpecification( criteriaDelete );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/engine/spi/SharedSessionDelegatorBaseImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/spi/SharedSessionDelegatorBaseImpl.java
@@ -36,8 +36,6 @@ import org.hibernate.query.MutationQuery;
 import org.hibernate.query.SelectionQuery;
 import org.hibernate.query.criteria.HibernateCriteriaBuilder;
 import org.hibernate.query.criteria.JpaCriteriaInsert;
-import org.hibernate.query.programmatic.MutationSpecification;
-import org.hibernate.query.programmatic.SelectionSpecification;
 import org.hibernate.query.spi.QueryImplementor;
 import org.hibernate.query.spi.QueryProducerImplementor;
 import org.hibernate.query.sql.spi.NativeQueryImplementor;
@@ -227,36 +225,6 @@ public class SharedSessionDelegatorBaseImpl implements SharedSessionContractImpl
 	@Override
 	public MutationQuery createNamedMutationQuery(String name) {
 		return delegate.createNamedMutationQuery( name );
-	}
-
-	@Override
-	public <T> SelectionSpecification<T> createSelectionSpecification(String hql, Class<T> resultType) {
-		return delegate.createSelectionSpecification( hql, resultType );
-	}
-
-	@Override
-	public <T> SelectionSpecification<T> createSelectionSpecification(Class<T> rootEntityType) {
-		return delegate.createSelectionSpecification( rootEntityType );
-	}
-
-	@Override
-	public <T> SelectionSpecification<T> createSelectionSpecification(CriteriaQuery<T> criteria) {
-		return delegate.createSelectionSpecification( criteria );
-	}
-
-	@Override
-	public <T> MutationSpecification<T> createMutationSpecification(String hql, Class<T> mutationTarget) {
-		return delegate.createMutationSpecification( hql, mutationTarget );
-	}
-
-	@Override
-	public <T> MutationSpecification<T> createMutationSpecification(CriteriaUpdate<T> criteriaUpdate) {
-		return delegate.createMutationSpecification( criteriaUpdate );
-	}
-
-	@Override
-	public <T> MutationSpecification<T> createMutationSpecification(CriteriaDelete<T> criteriaDelete) {
-		return delegate.createMutationSpecification( criteriaDelete );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/internal/AbstractSharedSessionContract.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/AbstractSharedSessionContract.java
@@ -71,10 +71,6 @@ import org.hibernate.query.criteria.JpaCriteriaInsert;
 import org.hibernate.query.hql.spi.SqmQueryImplementor;
 import org.hibernate.query.named.NamedObjectRepository;
 import org.hibernate.query.named.NamedResultSetMappingMemento;
-import org.hibernate.query.programmatic.MutationSpecification;
-import org.hibernate.query.programmatic.SelectionSpecification;
-import org.hibernate.query.programmatic.internal.MutationSpecificationImpl;
-import org.hibernate.query.programmatic.internal.SelectionSpecificationImpl;
 import org.hibernate.query.spi.HqlInterpretation;
 import org.hibernate.query.spi.QueryImplementor;
 import org.hibernate.query.sql.internal.NativeQueryImpl;
@@ -1258,36 +1254,6 @@ public abstract class AbstractSharedSessionContract implements SharedSessionCont
 		return buildNamedQuery( queryName,
 				memento -> createSqmQueryImplementor( queryName, memento ),
 				memento -> createNativeQueryImplementor( queryName, memento ) );
-	}
-
-	@Override
-	public <T> SelectionSpecification<T> createSelectionSpecification(String hql, Class<T> resultType) {
-		return new SelectionSpecificationImpl<>( hql, resultType, this );
-	}
-
-	@Override
-	public <T> SelectionSpecification<T> createSelectionSpecification(Class<T> rootEntityType) {
-		return new SelectionSpecificationImpl<>( rootEntityType, this );
-	}
-
-	@Override
-	public <T> SelectionSpecification<T> createSelectionSpecification(CriteriaQuery<T> criteria) {
-		return new SelectionSpecificationImpl<>( criteria, this );
-	}
-
-	@Override
-	public <T> MutationSpecification<T> createMutationSpecification(String hql, Class<T> mutationTarget) {
-		return new MutationSpecificationImpl<>( hql, mutationTarget, this );
-	}
-
-	@Override
-	public <T> MutationSpecification<T> createMutationSpecification(CriteriaDelete<T> criteriaDelete) {
-		return new MutationSpecificationImpl<>( criteriaDelete, this );
-	}
-
-	@Override
-	public <T> MutationSpecification<T> createMutationSpecification(CriteriaUpdate<T> criteriaUpdate)  {
-		return new MutationSpecificationImpl<>( criteriaUpdate, this );
 	}
 
 	protected <T> NativeQueryImplementor<T> createNativeQueryImplementor(String queryName, NamedNativeQueryMemento<T> memento) {

--- a/hibernate-core/src/main/java/org/hibernate/internal/AbstractSharedSessionContract.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/AbstractSharedSessionContract.java
@@ -1271,8 +1271,23 @@ public abstract class AbstractSharedSessionContract implements SharedSessionCont
 	}
 
 	@Override
+	public <T> SelectionSpecification<T> createSelectionSpecification(CriteriaQuery<T> criteria) {
+		return new SelectionSpecificationImpl<>( criteria, this );
+	}
+
+	@Override
 	public <T> MutationSpecification<T> createMutationSpecification(String hql, Class<T> mutationTarget) {
 		return new MutationSpecificationImpl<>( hql, mutationTarget, this );
+	}
+
+	@Override
+	public <T> MutationSpecification<T> createMutationSpecification(CriteriaDelete<T> criteriaDelete) {
+		return new MutationSpecificationImpl<>( criteriaDelete, this );
+	}
+
+	@Override
+	public <T> MutationSpecification<T> createMutationSpecification(CriteriaUpdate<T> criteriaUpdate)  {
+		return new MutationSpecificationImpl<>( criteriaUpdate, this );
 	}
 
 	protected <T> NativeQueryImplementor<T> createNativeQueryImplementor(String queryName, NamedNativeQueryMemento<T> memento) {

--- a/hibernate-core/src/main/java/org/hibernate/query/QueryProducer.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/QueryProducer.java
@@ -540,6 +540,21 @@ public interface QueryProducer {
 
 	/**
 	 * Returns a specification reference which can be used to programmatically,
+	 * iteratively build a {@linkplain SelectionQuery} for the given criteria query,
+	 * allowing the addition of {@linkplain SelectionSpecification#addOrdering sorting}
+	 * and {@linkplain SelectionSpecification#addRestriction restrictions}.
+	 *
+	 * @param criteria The criteria query
+	 *
+	 * @param <T> The entity type which is the root of the query.
+	 *
+	 * @since 7.0
+	 */
+	@Incubating
+	<T> SelectionSpecification<T> createSelectionSpecification(CriteriaQuery<T> criteria);
+
+	/**
+	 * Returns a specification reference which can be used to programmatically,
 	 * iteratively build a {@linkplain MutationQuery} based on a base HQL statement,
 	 * allowing the addition of {@linkplain MutationSpecification#addRestriction restrictions}.
 	 *
@@ -557,6 +572,34 @@ public interface QueryProducer {
 	@Incubating
 	<T> MutationSpecification<T> createMutationSpecification(String hql, Class<T> mutationTarget)
 			throws IllegalMutationQueryException;
+
+	/**
+	 * Returns a specification reference which can be used to programmatically,
+	 * iteratively build a {@linkplain MutationQuery} based on the given criteria update,
+	 * allowing the addition of {@linkplain MutationSpecification#addRestriction restrictions}.
+	 *
+	 * @param criteriaUpdate The criteria update query
+	 *
+	 * @param <T> The root entity type for the mutation (the "target").
+	 *
+	 * @since 7.0
+	 */
+	@Incubating
+	<T> MutationSpecification<T> createMutationSpecification(CriteriaUpdate<T> criteriaUpdate);
+
+	/**
+	 * Returns a specification reference which can be used to programmatically,
+	 * iteratively build a {@linkplain MutationQuery} based on the given criteria delete,
+	 * allowing the addition of {@linkplain MutationSpecification#addRestriction restrictions}.
+	 *
+	 * @param criteriaDelete The criteria delete query
+	 *
+	 * @param <T> The root entity type for the mutation (the "target").
+	 *
+	 * @since 7.0
+	 */
+	@Incubating
+	<T> MutationSpecification<T> createMutationSpecification(CriteriaDelete<T> criteriaDelete);
 
 	/**
 	 * Create a {@link Query} instance for the named query.

--- a/hibernate-core/src/main/java/org/hibernate/query/QueryProducer.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/QueryProducer.java
@@ -9,10 +9,7 @@ import jakarta.persistence.TypedQueryReference;
 import jakarta.persistence.criteria.CriteriaDelete;
 import jakarta.persistence.criteria.CriteriaQuery;
 import jakarta.persistence.criteria.CriteriaUpdate;
-import org.hibernate.Incubating;
 import org.hibernate.query.criteria.JpaCriteriaInsert;
-import org.hibernate.query.programmatic.MutationSpecification;
-import org.hibernate.query.programmatic.SelectionSpecification;
 
 /**
  * Contract for things that can produce instances of {@link Query} and {@link NativeQuery}.
@@ -498,108 +495,6 @@ public interface QueryProducer {
 	 * @throws UnknownNamedQueryException if no query has been defined with the given name
 	 */
 	MutationQuery createNamedMutationQuery(String name);
-
-	/**
-	 * Returns a specification reference which can be used to programmatically,
-	 * iteratively build a {@linkplain SelectionQuery} based on a base HQL statement,
-	 * allowing the addition of {@linkplain SelectionSpecification#addOrdering sorting}
-	 * and {@linkplain SelectionSpecification#addRestriction restrictions}.
-	 *
-	 * @param hql The base HQL query.
-	 * @param resultType The result type which will ultimately be returned from the {@linkplain SelectionQuery}
-	 *
-	 * @param <T> The root entity type for the query.
-	 * {@code resultType} and {@code <T>} are both expected to refer to a singular query root.
-	 *
-	 * @throws IllegalSelectQueryException The given HQL is expected to be a {@code select} query.  This method will
-	 * throw an exception if not.
-	 *
-	 * @since 7.0
-	 */
-	@Incubating
-	<T> SelectionSpecification<T> createSelectionSpecification(String hql, Class<T> resultType)
-			throws IllegalSelectQueryException;
-
-	/**
-	 * Returns a specification reference which can be used to programmatically,
-	 * iteratively build a {@linkplain SelectionQuery} for the given entity type,
-	 * allowing the addition of {@linkplain SelectionSpecification#addOrdering sorting}
-	 * and {@linkplain SelectionSpecification#addRestriction restrictions}.
-	 * This is effectively the same as calling {@linkplain QueryProducer#createSelectionSpecification(String, Class)}
-	 * with {@code "from {rootEntityType}"} as the HQL.
-	 *
-	 * @param rootEntityType The entity type which is the root of the query.
-	 *
-	 * @param <T> The entity type which is the root of the query.
-	 * {@code resultType} and {@code <T>} are both expected to refer to a singular query root.
-	 *
-	 * @since 7.0
-	 */
-	@Incubating
-	<T> SelectionSpecification<T> createSelectionSpecification(Class<T> rootEntityType);
-
-	/**
-	 * Returns a specification reference which can be used to programmatically,
-	 * iteratively build a {@linkplain SelectionQuery} for the given criteria query,
-	 * allowing the addition of {@linkplain SelectionSpecification#addOrdering sorting}
-	 * and {@linkplain SelectionSpecification#addRestriction restrictions}.
-	 *
-	 * @param criteria The criteria query
-	 *
-	 * @param <T> The entity type which is the root of the query.
-	 *
-	 * @since 7.0
-	 */
-	@Incubating
-	<T> SelectionSpecification<T> createSelectionSpecification(CriteriaQuery<T> criteria);
-
-	/**
-	 * Returns a specification reference which can be used to programmatically,
-	 * iteratively build a {@linkplain MutationQuery} based on a base HQL statement,
-	 * allowing the addition of {@linkplain MutationSpecification#addRestriction restrictions}.
-	 *
-	 * @param hql The base HQL query (expected to be an {@code update} or {@code delete} query).
-	 * @param mutationTarget The entity which is the target of the mutation.
-	 *
-	 * @param <T> The root entity type for the mutation (the "target").
-	 * {@code mutationTarget} and {@code <T>} are both expected to refer to the mutation target.
-	 *
-	 * @throws IllegalMutationQueryException Only {@code update} and {@code delete} are supported;
-	 * this method will throw an exception if the given HQL query is not an {@code update} or {@code delete}.
-	 *
-	 * @since 7.0
-	 */
-	@Incubating
-	<T> MutationSpecification<T> createMutationSpecification(String hql, Class<T> mutationTarget)
-			throws IllegalMutationQueryException;
-
-	/**
-	 * Returns a specification reference which can be used to programmatically,
-	 * iteratively build a {@linkplain MutationQuery} based on the given criteria update,
-	 * allowing the addition of {@linkplain MutationSpecification#addRestriction restrictions}.
-	 *
-	 * @param criteriaUpdate The criteria update query
-	 *
-	 * @param <T> The root entity type for the mutation (the "target").
-	 *
-	 * @since 7.0
-	 */
-	@Incubating
-	<T> MutationSpecification<T> createMutationSpecification(CriteriaUpdate<T> criteriaUpdate);
-
-	/**
-	 * Returns a specification reference which can be used to programmatically,
-	 * iteratively build a {@linkplain MutationQuery} based on the given criteria delete,
-	 * allowing the addition of {@linkplain MutationSpecification#addRestriction restrictions}.
-	 *
-	 * @param criteriaDelete The criteria delete query
-	 *
-	 * @param <T> The root entity type for the mutation (the "target").
-	 *
-	 * @since 7.0
-	 */
-	@Incubating
-	<T> MutationSpecification<T> createMutationSpecification(CriteriaDelete<T> criteriaDelete);
 
 	/**
 	 * Create a {@link Query} instance for the named query.

--- a/hibernate-core/src/main/java/org/hibernate/query/programmatic/MutationSpecification.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/programmatic/MutationSpecification.java
@@ -4,10 +4,17 @@
  */
 package org.hibernate.query.programmatic;
 
+import jakarta.persistence.EntityManagerFactory;
 import jakarta.persistence.criteria.Root;
+import jakarta.persistence.criteria.CriteriaUpdate;
+import jakarta.persistence.criteria.CriteriaDelete;
 import org.hibernate.Incubating;
+import org.hibernate.SharedSessionContract;
+import org.hibernate.engine.spi.SessionFactoryImplementor;
+import org.hibernate.query.IllegalMutationQueryException;
 import org.hibernate.query.MutationQuery;
 import org.hibernate.query.SelectionQuery;
+import org.hibernate.query.programmatic.internal.MutationSpecificationImpl;
 import org.hibernate.query.restriction.Restriction;
 
 /**
@@ -20,7 +27,7 @@ import org.hibernate.query.restriction.Restriction;
  * kinds.
  * <p>
  * Once all {@linkplain #addRestriction restrictions} are specified, call
- * {@linkplain #createQuery()} to obtain an {@linkplain SelectionQuery an
+ * {@linkplain QuerySpecification#createQuery(SharedSessionContract)} to obtain an {@linkplain SelectionQuery an
  * executable mutation query object}.
  *
  * @param <T> The entity type which is the target of the mutation.
@@ -48,5 +55,49 @@ public interface MutationSpecification<T> extends QuerySpecification<T> {
 	 * Finalize the building and create the {@linkplain SelectionQuery} instance.
 	 */
 	@Override
-	MutationQuery createQuery();
+	MutationQuery createQuery(SharedSessionContract session);
+
+	/**
+	 * Returns a specification reference which can be used to programmatically,
+	 * iteratively build a {@linkplain MutationQuery} based on a base HQL statement,
+	 * allowing the addition of {@linkplain MutationSpecification#addRestriction restrictions}.
+	 *
+	 * @param hql The base HQL query (expected to be an {@code update} or {@code delete} query).
+	 * @param mutationTarget The entity which is the target of the mutation.
+	 *
+	 * @param <T> The root entity type for the mutation (the "target").
+	 * {@code mutationTarget} and {@code <T>} are both expected to refer to the mutation target.
+	 *
+	 * @throws IllegalMutationQueryException Only {@code update} and {@code delete} are supported;
+	 * this method will throw an exception if the given HQL query is not an {@code update} or {@code delete}.
+	 */
+	static <T> MutationSpecification<T> create(EntityManagerFactory factory, Class<T> entityClass, String hql) {
+		return new MutationSpecificationImpl<>( hql, entityClass, (SessionFactoryImplementor) factory );
+	}
+
+	/**
+	 * Returns a specification reference which can be used to programmatically,
+	 * iteratively build a {@linkplain MutationQuery} based on the given criteria update,
+	 * allowing the addition of {@linkplain MutationSpecification#addRestriction restrictions}.
+	 *
+	 * @param criteriaUpdate The criteria update query
+	 *
+	 * @param <T> The root entity type for the mutation (the "target").
+	 */
+	static <T> MutationSpecification<T> create(CriteriaUpdate<T> criteriaUpdate) {
+		return new MutationSpecificationImpl<>( criteriaUpdate );
+	}
+
+	/**
+	 * Returns a specification reference which can be used to programmatically,
+	 * iteratively build a {@linkplain MutationQuery} based on the given criteria delete,
+	 * allowing the addition of {@linkplain MutationSpecification#addRestriction restrictions}.
+	 *
+	 * @param criteriaDelete The criteria delete query
+	 *
+	 * @param <T> The root entity type for the mutation (the "target").
+	 */
+	static <T> MutationSpecification<T> create(CriteriaDelete<T> criteriaDelete) {
+		return new MutationSpecificationImpl<>( criteriaDelete );
+	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/query/programmatic/QuerySpecification.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/programmatic/QuerySpecification.java
@@ -7,6 +7,7 @@ package org.hibernate.query.programmatic;
 import jakarta.persistence.criteria.CommonAbstractCriteria;
 import jakarta.persistence.criteria.Root;
 import org.hibernate.Incubating;
+import org.hibernate.SharedSessionContract;
 import org.hibernate.query.CommonQueryContract;
 import org.hibernate.query.restriction.Restriction;
 
@@ -49,5 +50,5 @@ public interface QuerySpecification<T> {
 	/**
 	 * Finalize the building and create executable query instance.
 	 */
-	CommonQueryContract createQuery();
+	CommonQueryContract createQuery(SharedSessionContract session);
 }

--- a/hibernate-core/src/main/java/org/hibernate/query/programmatic/internal/MutationSpecificationImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/programmatic/internal/MutationSpecificationImpl.java
@@ -8,6 +8,7 @@ import jakarta.persistence.criteria.CommonAbstractCriteria;
 import jakarta.persistence.criteria.CriteriaDelete;
 import jakarta.persistence.criteria.CriteriaUpdate;
 import jakarta.persistence.criteria.Root;
+import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.query.programmatic.MutationSpecification;
 import org.hibernate.query.IllegalMutationQueryException;
@@ -44,7 +45,7 @@ public class MutationSpecificationImpl<T> implements MutationSpecification<T> {
 			Class<T> mutationTarget,
 			SharedSessionContractImplementor session) {
 		this.session = session;
-		this.sqmStatement = resolveSqmTree( hql, session );
+		this.sqmStatement = resolveSqmTree( hql, session.getFactory() );
 		this.mutationTargetRoot = resolveSqmRoot( this.sqmStatement, mutationTarget );
 	}
 
@@ -53,7 +54,8 @@ public class MutationSpecificationImpl<T> implements MutationSpecification<T> {
 			SharedSessionContractImplementor session) {
 		this.session = session;
 		this.sqmStatement = (SqmUpdateStatement<T>) criteriaQuery;
-		this.mutationTargetRoot = resolveSqmRoot( sqmStatement, sqmStatement.getTarget().getManagedType().getJavaType() );
+		this.mutationTargetRoot = resolveSqmRoot( sqmStatement,
+				sqmStatement.getTarget().getManagedType().getJavaType() );
 	}
 
 	public MutationSpecificationImpl(
@@ -61,7 +63,8 @@ public class MutationSpecificationImpl<T> implements MutationSpecification<T> {
 			SharedSessionContractImplementor session) {
 		this.session = session;
 		this.sqmStatement = (SqmDeleteStatement<T>) criteriaQuery;
-		this.mutationTargetRoot = resolveSqmRoot( sqmStatement, sqmStatement.getTarget().getManagedType().getJavaType() );
+		this.mutationTargetRoot = resolveSqmRoot( sqmStatement,
+				sqmStatement.getTarget().getManagedType().getJavaType() );
 	}
 
 	@Override
@@ -96,8 +99,8 @@ public class MutationSpecificationImpl<T> implements MutationSpecification<T> {
 	 */
 	private static <T> SqmDeleteOrUpdateStatement<T> resolveSqmTree(
 			String hql,
-			SharedSessionContractImplementor session) {
-		final QueryEngine queryEngine = session.getFactory().getQueryEngine();
+			SessionFactoryImplementor sessionFactory) {
+		final QueryEngine queryEngine = sessionFactory.getQueryEngine();
 		final HqlInterpretation<T> hqlInterpretation = queryEngine
 				.getInterpretationCache()
 				.resolveHqlInterpretation( hql, null, queryEngine.getHqlTranslator() );

--- a/hibernate-core/src/main/java/org/hibernate/query/programmatic/internal/MutationSpecificationImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/programmatic/internal/MutationSpecificationImpl.java
@@ -5,6 +5,8 @@
 package org.hibernate.query.programmatic.internal;
 
 import jakarta.persistence.criteria.CommonAbstractCriteria;
+import jakarta.persistence.criteria.CriteriaDelete;
+import jakarta.persistence.criteria.CriteriaUpdate;
 import jakarta.persistence.criteria.Root;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.query.programmatic.MutationSpecification;
@@ -17,8 +19,10 @@ import org.hibernate.query.sqm.SqmQuerySource;
 import org.hibernate.query.sqm.internal.QuerySqmImpl;
 import org.hibernate.query.sqm.internal.SqmUtil;
 import org.hibernate.query.sqm.tree.SqmDeleteOrUpdateStatement;
+import org.hibernate.query.sqm.tree.delete.SqmDeleteStatement;
 import org.hibernate.query.sqm.tree.from.SqmRoot;
 import org.hibernate.query.sqm.tree.predicate.SqmPredicate;
+import org.hibernate.query.sqm.tree.update.SqmUpdateStatement;
 
 import java.util.Locale;
 
@@ -42,6 +46,22 @@ public class MutationSpecificationImpl<T> implements MutationSpecification<T> {
 		this.session = session;
 		this.sqmStatement = resolveSqmTree( hql, session );
 		this.mutationTargetRoot = resolveSqmRoot( this.sqmStatement, mutationTarget );
+	}
+
+	public MutationSpecificationImpl(
+			CriteriaUpdate<T> criteriaQuery,
+			SharedSessionContractImplementor session) {
+		this.session = session;
+		this.sqmStatement = (SqmUpdateStatement<T>) criteriaQuery;
+		this.mutationTargetRoot = resolveSqmRoot( sqmStatement, sqmStatement.getTarget().getManagedType().getJavaType() );
+	}
+
+	public MutationSpecificationImpl(
+			CriteriaDelete<T> criteriaQuery,
+			SharedSessionContractImplementor session) {
+		this.session = session;
+		this.sqmStatement = (SqmDeleteStatement<T>) criteriaQuery;
+		this.mutationTargetRoot = resolveSqmRoot( sqmStatement, sqmStatement.getTarget().getManagedType().getJavaType() );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/query/programmatic/internal/SelectionSpecificationImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/programmatic/internal/SelectionSpecificationImpl.java
@@ -60,6 +60,15 @@ public class SelectionSpecificationImpl<T> implements SelectionSpecification<T> 
 		this( "from " + determineEntityName( rootEntityType, session ), rootEntityType, session );
 	}
 
+	public SelectionSpecificationImpl(
+			CriteriaQuery<T> criteriaQuery,
+			SharedSessionContractImplementor session) {
+		this.resultType = criteriaQuery.getResultType();
+		this.session = session;
+		this.sqmStatement = (SqmSelectStatement<T>) criteriaQuery;
+		this.sqmRoot = extractRoot( sqmStatement, resultType, "criteria query" );
+	}
+
 	@Override
 	public Root<T> getRoot() {
 		return sqmRoot;

--- a/hibernate-core/src/main/java/org/hibernate/query/restriction/Restriction.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/restriction/Restriction.java
@@ -23,11 +23,11 @@ import java.util.List;
  * a {@link org.hibernate.query.programmatic.SelectionSpecification} by calling
  * {@link SelectionQuery#addRestriction(Restriction)}.
  * <pre>
- * session.createSelectionSpecification("from Book", Book.class)
+ * SelectionSpecification.create(factory, Book.class)
  *         .addRestriction(Restriction.like(Book_.title, "%Hibernate%", false))
  *         .addRestriction(Restriction.greaterThan(Book_.pages, 100))
  *         .setOrder(Order.desc(Book_.title))
- *         .createQuery()
+ *         .createQuery(session)
  *         .getResultList();
  * </pre>
  * <p>

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/query/dynamic/SimpleQuerySpecificationTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/query/dynamic/SimpleQuerySpecificationTests.java
@@ -4,14 +4,16 @@
  */
 package org.hibernate.orm.test.query.dynamic;
 
+import org.hibernate.SessionFactory;
 import org.hibernate.query.IllegalMutationQueryException;
 import org.hibernate.query.IllegalSelectQueryException;
 import org.hibernate.query.Order;
+import org.hibernate.query.programmatic.MutationSpecification;
+import org.hibernate.query.programmatic.SelectionSpecification;
 import org.hibernate.query.range.Range;
 import org.hibernate.query.restriction.Restriction;
 import org.hibernate.testing.jdbc.SQLStatementInspector;
 import org.hibernate.testing.orm.junit.DomainModel;
-import org.hibernate.testing.orm.junit.SessionFactory;
 import org.hibernate.testing.orm.junit.SessionFactoryScope;
 import org.junit.jupiter.api.Test;
 
@@ -25,17 +27,19 @@ import static org.junit.jupiter.api.Assertions.fail;
  */
 @SuppressWarnings("JUnitMalformedDeclaration")
 @DomainModel(annotatedClasses = BasicEntity.class)
-@SessionFactory(useCollectingStatementInspector = true)
+@org.hibernate.testing.orm.junit.SessionFactory(useCollectingStatementInspector = true)
 public class SimpleQuerySpecificationTests {
 	@Test
 	void testSimpleSelectionOrder(SessionFactoryScope factoryScope) {
 		final SQLStatementInspector sqlCollector = factoryScope.getCollectingStatementInspector();
 
+		final SessionFactory factory = factoryScope.getSessionFactory();
+
 		factoryScope.inTransaction( (session) -> {
 			sqlCollector.clear();
-			session.createSelectionSpecification( "from BasicEntity", BasicEntity.class )
+			SelectionSpecification.create( factory, BasicEntity.class, "from BasicEntity" )
 					.addOrdering( Order.asc( BasicEntity_.position ) )
-					.createQuery()
+					.createQuery( session )
 					.list();
 		} );
 
@@ -47,12 +51,14 @@ public class SimpleQuerySpecificationTests {
 	void testSimpleSelectionOrderMultiple(SessionFactoryScope factoryScope) {
 		final SQLStatementInspector sqlCollector = factoryScope.getCollectingStatementInspector();
 
+		final SessionFactory factory = factoryScope.getSessionFactory();
+
 		factoryScope.inTransaction( (session) -> {
 			sqlCollector.clear();
-			session.createSelectionSpecification( "from BasicEntity", BasicEntity.class )
+			SelectionSpecification.create( factory, BasicEntity.class, "from BasicEntity" )
 					.addOrdering( Order.asc( BasicEntity_.position ) )
 					.addOrdering( Order.asc( BasicEntity_.id ) )
-					.createQuery()
+					.createQuery( session )
 					.list();
 		} );
 
@@ -64,10 +70,13 @@ public class SimpleQuerySpecificationTests {
 	void testSimpleSelectionSetOrdering(SessionFactoryScope factoryScope) {
 		final SQLStatementInspector sqlCollector = factoryScope.getCollectingStatementInspector();
 
-		factoryScope.inTransaction( (session) -> {			sqlCollector.clear();
-			session.createSelectionSpecification( "from BasicEntity", BasicEntity.class )
+		final SessionFactory factory = factoryScope.getSessionFactory();
+
+		factoryScope.inTransaction( (session) -> {
+			sqlCollector.clear();
+			SelectionSpecification.create( factory, BasicEntity.class, "from BasicEntity" )
 					.setOrdering( Order.asc( BasicEntity_.position ) )
-					.createQuery()
+					.createQuery( session )
 					.list();
 		} );
 
@@ -79,11 +88,13 @@ public class SimpleQuerySpecificationTests {
 	void testSimpleSelectionSetOrderingMultiple(SessionFactoryScope factoryScope) {
 		final SQLStatementInspector sqlCollector = factoryScope.getCollectingStatementInspector();
 
+		final SessionFactory factory = factoryScope.getSessionFactory();
+
 		factoryScope.inTransaction( (session) -> {
 			sqlCollector.clear();
-			session.createSelectionSpecification( "from BasicEntity", BasicEntity.class )
+			SelectionSpecification.create( factory, BasicEntity.class, "from BasicEntity" )
 					.setOrdering( List.of( Order.asc( BasicEntity_.position ), Order.asc( BasicEntity_.id ) ) )
-					.createQuery()
+					.createQuery( session )
 					.list();
 		} );
 
@@ -95,12 +106,14 @@ public class SimpleQuerySpecificationTests {
 	void testSimpleSelectionSetOrderingReplace(SessionFactoryScope factoryScope) {
 		final SQLStatementInspector sqlCollector = factoryScope.getCollectingStatementInspector();
 
+		final SessionFactory factory = factoryScope.getSessionFactory();
+
 		factoryScope.inTransaction( (session) -> {
 			sqlCollector.clear();
-			session.createSelectionSpecification( "from BasicEntity", BasicEntity.class )
+			SelectionSpecification.create( factory, BasicEntity.class, "from BasicEntity" )
 					.setOrdering( Order.asc( BasicEntity_.id ) )
 					.setOrdering( Order.asc( BasicEntity_.position ) )
-					.createQuery()
+					.createQuery( session )
 					.list();
 		} );
 
@@ -109,10 +122,10 @@ public class SimpleQuerySpecificationTests {
 
 		factoryScope.inTransaction( (session) -> {
 			sqlCollector.clear();
-			session.createSelectionSpecification( "from BasicEntity", BasicEntity.class )
+			SelectionSpecification.create( factory, BasicEntity.class, "from BasicEntity" )
 					.addOrdering( Order.asc( BasicEntity_.id ) )
 					.setOrdering( Order.asc( BasicEntity_.position ) )
-					.createQuery()
+					.createQuery( session )
 					.list();
 		} );
 
@@ -124,11 +137,13 @@ public class SimpleQuerySpecificationTests {
 	void testSimpleSelectionRestriction(SessionFactoryScope factoryScope) {
 		final SQLStatementInspector sqlCollector = factoryScope.getCollectingStatementInspector();
 
+		final SessionFactory factory = factoryScope.getSessionFactory();
+
 		factoryScope.inTransaction( (session) -> {
 			sqlCollector.clear();
-			session.createSelectionSpecification( "from BasicEntity", BasicEntity.class )
+			SelectionSpecification.create( factory, BasicEntity.class, "from BasicEntity" )
 					.addRestriction( Restriction.restrict( BasicEntity_.position, Range.closed( 1, 5 ) ) )
-					.createQuery()
+					.createQuery( session )
 					.list();
 		} );
 
@@ -140,11 +155,13 @@ public class SimpleQuerySpecificationTests {
 	void testSimpleMutationRestriction(SessionFactoryScope factoryScope) {
 		final SQLStatementInspector sqlCollector = factoryScope.getCollectingStatementInspector();
 
+		final SessionFactory factory = factoryScope.getSessionFactory();
+
 		factoryScope.inTransaction( (session) -> {
 			sqlCollector.clear();
-			session.createMutationSpecification( "delete BasicEntity", BasicEntity.class )
+			MutationSpecification.create( factory, BasicEntity.class, "delete BasicEntity" )
 					.addRestriction( Restriction.restrict( BasicEntity_.position, Range.closed( 1, 5 ) ) )
-					.createQuery()
+					.createQuery( session )
 					.executeUpdate();
 		} );
 
@@ -156,11 +173,13 @@ public class SimpleQuerySpecificationTests {
 	void testRootEntityForm(SessionFactoryScope factoryScope) {
 		final SQLStatementInspector sqlCollector = factoryScope.getCollectingStatementInspector();
 
+		final SessionFactory factory = factoryScope.getSessionFactory();
+
 		factoryScope.inTransaction( (session) -> {
 			sqlCollector.clear();
-			session.createSelectionSpecification( BasicEntity.class )
+			SelectionSpecification.create( factory, BasicEntity.class )
 					.addOrdering( Order.asc( BasicEntity_.position ) )
-					.createQuery()
+					.createQuery( session )
 					.getResultList();
 		} );
 
@@ -179,9 +198,9 @@ public class SimpleQuerySpecificationTests {
 			var entity = query.from( BasicEntity.class );
 			query.select( entity );
 			query.where( criteriaBuilder.like( entity.get( BasicEntity_.name ), "%" ) );
-			session.createSelectionSpecification( query )
+			SelectionSpecification.create( query )
 					.addOrdering( Order.asc( BasicEntity_.position ) )
-					.createQuery()
+					.createQuery( session )
 					.getResultList();
 		} );
 
@@ -193,11 +212,13 @@ public class SimpleQuerySpecificationTests {
 	void testBaseParameters(SessionFactoryScope factoryScope) {
 		final SQLStatementInspector sqlCollector = factoryScope.getCollectingStatementInspector();
 
+		final SessionFactory factory = factoryScope.getSessionFactory();
+
 		factoryScope.inTransaction( (session) -> {
 			sqlCollector.clear();
-			session.createSelectionSpecification( "from BasicEntity where id > :id", BasicEntity.class )
+			SelectionSpecification.create( factory, BasicEntity.class, "from BasicEntity where id > :id" )
 					.addRestriction( Restriction.restrict( BasicEntity_.position, Range.closed( 1, 5 ) ) )
-					.createQuery()
+					.createQuery( session )
 					.setParameter( "id", 200 )
 					.getResultList();
 		} );
@@ -208,9 +229,10 @@ public class SimpleQuerySpecificationTests {
 
 	@Test
 	void testIllegalSelection(SessionFactoryScope factoryScope) {
+		final SessionFactory factory = factoryScope.getSessionFactory();
 		factoryScope.inTransaction( (session) -> {
 			try {
-				session.createSelectionSpecification( "delete BasicEntity", BasicEntity.class );
+				SelectionSpecification.create( factory, BasicEntity.class, "delete BasicEntity" );
 				fail( "Expecting a IllegalSelectQueryException, but not thrown" );
 			}
 			catch (IllegalSelectQueryException expected) {
@@ -220,9 +242,10 @@ public class SimpleQuerySpecificationTests {
 
 	@Test
 	void testIllegalMutation(SessionFactoryScope factoryScope) {
+		final SessionFactory factory = factoryScope.getSessionFactory();
 		factoryScope.inTransaction( (session) -> {
 			try {
-				session.createMutationSpecification( "from BasicEntity", BasicEntity.class );
+				MutationSpecification.create( factory, BasicEntity.class, "from BasicEntity" );
 				fail( "Expecting a IllegalMutationQueryException, but not thrown" );
 			}
 			catch (IllegalMutationQueryException expected) {

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/query/dynamic/SimpleQuerySpecificationTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/query/dynamic/SimpleQuerySpecificationTests.java
@@ -169,6 +169,27 @@ public class SimpleQuerySpecificationTests {
 	}
 
 	@Test
+	void testCriteriaForm(SessionFactoryScope factoryScope) {
+		final SQLStatementInspector sqlCollector = factoryScope.getCollectingStatementInspector();
+
+		factoryScope.inTransaction( (session) -> {
+			sqlCollector.clear();
+			var criteriaBuilder = session.getCriteriaBuilder();
+			var query = criteriaBuilder.createQuery( BasicEntity.class );
+			var entity = query.from( BasicEntity.class );
+			query.select( entity );
+			query.where( criteriaBuilder.like( entity.get( BasicEntity_.name ), "%" ) );
+			session.createSelectionSpecification( query )
+					.addOrdering( Order.asc( BasicEntity_.position ) )
+					.createQuery()
+					.getResultList();
+		} );
+
+		assertThat( sqlCollector.getSqlQueries() ).hasSize( 1 );
+		assertThat( sqlCollector.getSqlQueries().get( 0 ) ).contains( " order by be1_0.position" );
+	}
+
+	@Test
 	void testBaseParameters(SessionFactoryScope factoryScope) {
 		final SQLStatementInspector sqlCollector = factoryScope.getCollectingStatementInspector();
 


### PR DESCRIPTION
Usage looks like:

```java
var books = 
        SelectionSpecification.create(factory, Book.class)
                 .addRestriction(Restriction.like(Book_.title, "%Hibernate%", false))
                 .addRestriction(Restriction.greaterThan(Book_.pages, 100))
                 .setOrder(Order.desc(Book_.title))
                 .createQuery(session)
                 .getResultList();
 ```

Alternatively, I can take the concept further, get rid of the `factory` argument to `create()`, and do all the work in `createQuery()`. Depends which you prefer @sebersole.

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-19364
<!-- Hibernate GitHub Bot issue links end -->