### PR TITLE
HHH-19364 fully-detached version

### DIFF
--- a/documentation/src/main/asciidoc/introduction/Interacting.adoc
+++ b/documentation/src/main/asciidoc/introduction/Interacting.adoc
@@ -1048,21 +1048,32 @@ In Hibernate 7, there's a new option, a very ergonomic API for programmatically 
 This new API:
 
 - isn't part of the Criteria Query API, and so we don't need a `CriteriaQuery` object to make use of it,
-- works with both HQL and Criteria queries, and even with <<named-queries,named HQL queries>>, and
+- _does_ make use of the JPA <<metamodel-generator,static metamodel>> for type safety,
+- works with both HQL and Criteria queries, and
 - is optimized for the case of a query which returns its single root entity.
 
 [source,java]
 ----
-var query = session.createSelectionQuery("from Book where year(publicationDate) > 2000", Book.class);
-if (titlePattern != null) {
-    query.addRestriction(Restriction.like(Book_.title, namePattern));
-}
-if (isbns != null && !isbns.isEmpty()) {
-    query.addRestriction(Restriction.in(Book_.isbn, isbns))
-}
-query.setOrder(List.of(Order.asc(Book_.title), Order.asc(Book_.isbn)));
-List<Book> matchingBooks = query.getResultList();
+var selection =
+        SelectionSpecification.create(Book.class,
+            // an optional base query, written in HQL:
+                "from Book where year(publicationDate) > 2000");
 
+// add programmatic restrictions:
+if (titlePattern != null)
+    selection.addRestriction(Restriction.like(Book_.title, namePattern));
+if (isbns != null && !isbns.isEmpty())
+    selection.addRestriction(Restriction.in(Book_.isbn, isbns));
+
+// add programmatic ordering:
+if (orderByTitle) selection.addOrdering(Order.asc(Book_.title));
+if (orderByIsbn) selection.addOrdering(Order.asc(Book_.isbn));
+
+// add programmatic association fetching:
+if (fetchPublisher) selection.addFetching(Path.from(Book.class).to(Book_.publisher));
+
+// execute the query in the given session:
+List<Book> matchingBooks = selection.createQuery(session).getResultList();
 ----
 
 Notice that:
@@ -1070,18 +1081,18 @@ Notice that:
 - The link:{doc-javadoc-url}org/hibernate/query/restriction/Restriction.html[`Restriction`] interface has static methods for constructing a variety of different kinds of restriction in a completely typesafe way.
 - Similarly, the link:{doc-javadoc-url}org/hibernate/query/Order.html[`Order`] class has a variety of static methods for constructing different kinds of ordering criteria.
 
-We need the following methods of `SelectionQuery`:
+We need the following methods of link:{doc-javadoc-url}org/hibernate/query/programmatic/SelectionSpecification.html[`SelectionSpecification`]:
 
 .Methods for query restriction and ordering
-[%breakable,cols="30,~,^15"]
+[%breakable,cols="20,~]
 |===
-| Method name | Purpose | JPA-standard
+| Method name | Purpose
 
-| `addRestriction()` | Add a restriction on the query results | &#10006;
-| `setOrder()` | Specify how the query results should be ordered | &#10006;
+| `addRestriction()` | Add a restriction on the query results
+| `setOrder()`, `addOrder()` | Specify how the query results should be ordered
+| `addFetching()` | Add a fetched association
+| `addAugmentation()` | Add a custom function which directly manipulates the query
 |===
-
-Unfortunately, `Restriction` and `Order` can't be used with JPA's `TypedQuery` interface, and JPA has no built-in alternative, so if we're using `EntityManager`, we need to call `unwrap()` to obtain a `SelectionQuery`.
 
 Alternatively, `Restriction` and `Order` can be used with <<paging-and-ordering,generated query or finder methods>>, and even with link:{doc-data-repositories-url}[Jakarta Data repositories].
 
@@ -1090,11 +1101,54 @@ The interface link:{doc-javadoc-url}org/hibernate/query/restriction/Path.html[`P
 [source,java]
 ----
 List<Book> booksForPublisher =
-        session.createSelectionQuery("from Book", Book.class)
+        SelectionSpecification.create(Book.class)
                 .addRestriction(Path.from(Book.class).to(Book_.publisher).to(Publisher_.name)
                                 .equalTo(publisherName))
+                .addFetching(Path.from(Book.class).to(Book_.publisher))
+                .createQuery(session)
                 .getResultList();
 ----
+
+When `Restriction`, `Path`, and `Order` aren't expressive enough, we can _augment_ the query by manipulating its representation as a criteria:
+
+[source,java]
+----
+var books =
+        SelectionSpecification.create(Book.class)
+              .addAugmentation((builder, query, book) ->
+                      // augment the query via JPA Criteria API
+                      query.where(builder.like(book.get(Book_.title), titlePattern)))
+                          .orderBy(builder.asc(book.get(Book_.isbn)))
+              .createQuery(session)
+              .getResultList();
+----
+
+For really advanced cases, `addAugmentation()` works quite nicely with <<criteria-definition,`CriteriaDefinition`>>.
+
+[source,java]
+----
+var books =
+        SelectionSpecification.create(Book.class)
+              .addAugmentation((builder, query, book) ->
+                  // eliminate explicit references to 'builder'
+                  new CriteriaDefinition<>(query) {{
+                      where(like(entity.get(BasicEntity_.title), titlePattern),
+                            greaterThan(book.get(Book_.pages), minPages));
+                      orderBy(asc(book.get(Book_.isbn)));
+                  }}
+              )
+              .createQuery(session)
+              .getResultList();
+----
+
+However, we emphasize that this API shines in cases where complex manipulations are _not_ required.
+
+[NOTE]
+====
+`SelectionSpecification` (similar to its friend `MutationSpecification`) may be used in cases where a query returns a single "root" entity, possibly with some fetched associations.
+It is not useful in cases where a query should return multiple entities, a projection of entity fields, or an aggregation.
+For such cases, the full Criteria API is appropriate.
+====
 
 Programmatic restrictions, and especially programmatic ordering, are often used together with pagination.
 

--- a/hibernate-core/src/main/java/org/hibernate/engine/spi/SessionDelegatorBaseImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/spi/SessionDelegatorBaseImpl.java
@@ -668,8 +668,23 @@ public class SessionDelegatorBaseImpl implements SessionImplementor {
 	}
 
 	@Override
+	public <T> SelectionSpecification<T> createSelectionSpecification(CriteriaQuery<T> criteria) {
+		return delegate.createSelectionSpecification( criteria );
+	}
+
+	@Override
 	public <T> MutationSpecification<T> createMutationSpecification(String hql, Class<T> mutationTarget) {
 		return delegate.createMutationSpecification( hql, mutationTarget );
+	}
+
+	@Override
+	public <T> MutationSpecification<T> createMutationSpecification(CriteriaUpdate<T> criteriaUpdate) {
+		return delegate.createMutationSpecification( criteriaUpdate );
+	}
+
+	@Override
+	public <T> MutationSpecification<T> createMutationSpecification(CriteriaDelete<T> criteriaDelete) {
+		return delegate.createMutationSpecification( criteriaDelete );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/engine/spi/SessionDelegatorBaseImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/spi/SessionDelegatorBaseImpl.java
@@ -58,8 +58,6 @@ import org.hibernate.query.MutationQuery;
 import org.hibernate.query.SelectionQuery;
 import org.hibernate.query.criteria.HibernateCriteriaBuilder;
 import org.hibernate.query.criteria.JpaCriteriaInsert;
-import org.hibernate.query.programmatic.MutationSpecification;
-import org.hibernate.query.programmatic.SelectionSpecification;
 import org.hibernate.query.spi.QueryImplementor;
 import org.hibernate.query.spi.QueryProducerImplementor;
 import org.hibernate.query.sql.spi.NativeQueryImplementor;
@@ -655,36 +653,6 @@ public class SessionDelegatorBaseImpl implements SessionImplementor {
 	@Override
 	public MutationQuery createNamedMutationQuery(String name) {
 		return delegate.createNamedMutationQuery( name );
-	}
-
-	@Override
-	public <T> SelectionSpecification<T> createSelectionSpecification(String hql, Class<T> resultType) {
-		return delegate.createSelectionSpecification( hql, resultType );
-	}
-
-	@Override
-	public <T> SelectionSpecification<T> createSelectionSpecification(Class<T> rootEntityType) {
-		return delegate.createSelectionSpecification( rootEntityType );
-	}
-
-	@Override
-	public <T> SelectionSpecification<T> createSelectionSpecification(CriteriaQuery<T> criteria) {
-		return delegate.createSelectionSpecification( criteria );
-	}
-
-	@Override
-	public <T> MutationSpecification<T> createMutationSpecification(String hql, Class<T> mutationTarget) {
-		return delegate.createMutationSpecification( hql, mutationTarget );
-	}
-
-	@Override
-	public <T> MutationSpecification<T> createMutationSpecification(CriteriaUpdate<T> criteriaUpdate) {
-		return delegate.createMutationSpecification( criteriaUpdate );
-	}
-
-	@Override
-	public <T> MutationSpecification<T> createMutationSpecification(CriteriaDelete<T> criteriaDelete) {
-		return delegate.createMutationSpecification( criteriaDelete );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/engine/spi/SessionLazyDelegator.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/spi/SessionLazyDelegator.java
@@ -53,8 +53,6 @@ import org.hibernate.query.Query;
 import org.hibernate.query.SelectionQuery;
 import org.hibernate.query.criteria.HibernateCriteriaBuilder;
 import org.hibernate.query.criteria.JpaCriteriaInsert;
-import org.hibernate.query.programmatic.MutationSpecification;
-import org.hibernate.query.programmatic.SelectionSpecification;
 import org.hibernate.stat.SessionStatistics;
 
 import java.util.Collection;
@@ -748,36 +746,6 @@ public class SessionLazyDelegator implements Session {
 	@Override
 	public MutationQuery createNamedMutationQuery(String name) {
 		return this.lazySession.get().createNamedMutationQuery( name );
-	}
-
-	@Override
-	public <T> SelectionSpecification<T> createSelectionSpecification(String hql, Class<T> resultType) {
-		return this.lazySession.get().createSelectionSpecification( hql, resultType );
-	}
-
-	@Override
-	public <T> SelectionSpecification<T> createSelectionSpecification(Class<T> rootEntityType) {
-		return this.lazySession.get().createSelectionSpecification( rootEntityType );
-	}
-
-	@Override
-	public <T> SelectionSpecification<T> createSelectionSpecification(CriteriaQuery<T> criteria) {
-		return this.lazySession.get().createSelectionSpecification( criteria );
-	}
-
-	@Override
-	public <T> MutationSpecification<T> createMutationSpecification(String hql, Class<T> mutationTarget) {
-		return this.lazySession.get().createMutationSpecification( hql, mutationTarget );
-	}
-
-	@Override
-	public <T> MutationSpecification<T> createMutationSpecification(CriteriaUpdate<T> criteriaUpdate) {
-		return this.lazySession.get().createMutationSpecification( criteriaUpdate );
-	}
-
-	@Override
-	public <T> MutationSpecification<T> createMutationSpecification(CriteriaDelete<T> criteriaDelete) {
-		return this.lazySession.get().createMutationSpecification( criteriaDelete );
 	}
 
 	@SuppressWarnings("rawtypes")

--- a/hibernate-core/src/main/java/org/hibernate/engine/spi/SessionLazyDelegator.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/spi/SessionLazyDelegator.java
@@ -761,8 +761,23 @@ public class SessionLazyDelegator implements Session {
 	}
 
 	@Override
+	public <T> SelectionSpecification<T> createSelectionSpecification(CriteriaQuery<T> criteria) {
+		return this.lazySession.get().createSelectionSpecification( criteria );
+	}
+
+	@Override
 	public <T> MutationSpecification<T> createMutationSpecification(String hql, Class<T> mutationTarget) {
 		return this.lazySession.get().createMutationSpecification( hql, mutationTarget );
+	}
+
+	@Override
+	public <T> MutationSpecification<T> createMutationSpecification(CriteriaUpdate<T> criteriaUpdate) {
+		return this.lazySession.get().createMutationSpecification( criteriaUpdate );
+	}
+
+	@Override
+	public <T> MutationSpecification<T> createMutationSpecification(CriteriaDelete<T> criteriaDelete) {
+		return this.lazySession.get().createMutationSpecification( criteriaDelete );
 	}
 
 	@SuppressWarnings("rawtypes")

--- a/hibernate-core/src/main/java/org/hibernate/engine/spi/SharedSessionDelegatorBaseImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/spi/SharedSessionDelegatorBaseImpl.java
@@ -240,8 +240,23 @@ public class SharedSessionDelegatorBaseImpl implements SharedSessionContractImpl
 	}
 
 	@Override
+	public <T> SelectionSpecification<T> createSelectionSpecification(CriteriaQuery<T> criteria) {
+		return delegate.createSelectionSpecification( criteria );
+	}
+
+	@Override
 	public <T> MutationSpecification<T> createMutationSpecification(String hql, Class<T> mutationTarget) {
 		return delegate.createMutationSpecification( hql, mutationTarget );
+	}
+
+	@Override
+	public <T> MutationSpecification<T> createMutationSpecification(CriteriaUpdate<T> criteriaUpdate) {
+		return delegate.createMutationSpecification( criteriaUpdate );
+	}
+
+	@Override
+	public <T> MutationSpecification<T> createMutationSpecification(CriteriaDelete<T> criteriaDelete) {
+		return delegate.createMutationSpecification( criteriaDelete );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/engine/spi/SharedSessionDelegatorBaseImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/spi/SharedSessionDelegatorBaseImpl.java
@@ -36,8 +36,6 @@ import org.hibernate.query.MutationQuery;
 import org.hibernate.query.SelectionQuery;
 import org.hibernate.query.criteria.HibernateCriteriaBuilder;
 import org.hibernate.query.criteria.JpaCriteriaInsert;
-import org.hibernate.query.programmatic.MutationSpecification;
-import org.hibernate.query.programmatic.SelectionSpecification;
 import org.hibernate.query.spi.QueryImplementor;
 import org.hibernate.query.spi.QueryProducerImplementor;
 import org.hibernate.query.sql.spi.NativeQueryImplementor;
@@ -227,36 +225,6 @@ public class SharedSessionDelegatorBaseImpl implements SharedSessionContractImpl
 	@Override
 	public MutationQuery createNamedMutationQuery(String name) {
 		return delegate.createNamedMutationQuery( name );
-	}
-
-	@Override
-	public <T> SelectionSpecification<T> createSelectionSpecification(String hql, Class<T> resultType) {
-		return delegate.createSelectionSpecification( hql, resultType );
-	}
-
-	@Override
-	public <T> SelectionSpecification<T> createSelectionSpecification(Class<T> rootEntityType) {
-		return delegate.createSelectionSpecification( rootEntityType );
-	}
-
-	@Override
-	public <T> SelectionSpecification<T> createSelectionSpecification(CriteriaQuery<T> criteria) {
-		return delegate.createSelectionSpecification( criteria );
-	}
-
-	@Override
-	public <T> MutationSpecification<T> createMutationSpecification(String hql, Class<T> mutationTarget) {
-		return delegate.createMutationSpecification( hql, mutationTarget );
-	}
-
-	@Override
-	public <T> MutationSpecification<T> createMutationSpecification(CriteriaUpdate<T> criteriaUpdate) {
-		return delegate.createMutationSpecification( criteriaUpdate );
-	}
-
-	@Override
-	public <T> MutationSpecification<T> createMutationSpecification(CriteriaDelete<T> criteriaDelete) {
-		return delegate.createMutationSpecification( criteriaDelete );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/internal/AbstractSharedSessionContract.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/AbstractSharedSessionContract.java
@@ -71,10 +71,6 @@ import org.hibernate.query.criteria.JpaCriteriaInsert;
 import org.hibernate.query.hql.spi.SqmQueryImplementor;
 import org.hibernate.query.named.NamedObjectRepository;
 import org.hibernate.query.named.NamedResultSetMappingMemento;
-import org.hibernate.query.programmatic.MutationSpecification;
-import org.hibernate.query.programmatic.SelectionSpecification;
-import org.hibernate.query.programmatic.internal.MutationSpecificationImpl;
-import org.hibernate.query.programmatic.internal.SelectionSpecificationImpl;
 import org.hibernate.query.spi.HqlInterpretation;
 import org.hibernate.query.spi.QueryImplementor;
 import org.hibernate.query.sql.internal.NativeQueryImpl;
@@ -1258,36 +1254,6 @@ public abstract class AbstractSharedSessionContract implements SharedSessionCont
 		return buildNamedQuery( queryName,
 				memento -> createSqmQueryImplementor( queryName, memento ),
 				memento -> createNativeQueryImplementor( queryName, memento ) );
-	}
-
-	@Override
-	public <T> SelectionSpecification<T> createSelectionSpecification(String hql, Class<T> resultType) {
-		return new SelectionSpecificationImpl<>( hql, resultType, this );
-	}
-
-	@Override
-	public <T> SelectionSpecification<T> createSelectionSpecification(Class<T> rootEntityType) {
-		return new SelectionSpecificationImpl<>( rootEntityType, this );
-	}
-
-	@Override
-	public <T> SelectionSpecification<T> createSelectionSpecification(CriteriaQuery<T> criteria) {
-		return new SelectionSpecificationImpl<>( criteria, this );
-	}
-
-	@Override
-	public <T> MutationSpecification<T> createMutationSpecification(String hql, Class<T> mutationTarget) {
-		return new MutationSpecificationImpl<>( hql, mutationTarget, this );
-	}
-
-	@Override
-	public <T> MutationSpecification<T> createMutationSpecification(CriteriaDelete<T> criteriaDelete) {
-		return new MutationSpecificationImpl<>( criteriaDelete, this );
-	}
-
-	@Override
-	public <T> MutationSpecification<T> createMutationSpecification(CriteriaUpdate<T> criteriaUpdate)  {
-		return new MutationSpecificationImpl<>( criteriaUpdate, this );
 	}
 
 	protected <T> NativeQueryImplementor<T> createNativeQueryImplementor(String queryName, NamedNativeQueryMemento<T> memento) {

--- a/hibernate-core/src/main/java/org/hibernate/internal/AbstractSharedSessionContract.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/AbstractSharedSessionContract.java
@@ -1271,8 +1271,23 @@ public abstract class AbstractSharedSessionContract implements SharedSessionCont
 	}
 
 	@Override
+	public <T> SelectionSpecification<T> createSelectionSpecification(CriteriaQuery<T> criteria) {
+		return new SelectionSpecificationImpl<>( criteria, this );
+	}
+
+	@Override
 	public <T> MutationSpecification<T> createMutationSpecification(String hql, Class<T> mutationTarget) {
 		return new MutationSpecificationImpl<>( hql, mutationTarget, this );
+	}
+
+	@Override
+	public <T> MutationSpecification<T> createMutationSpecification(CriteriaDelete<T> criteriaDelete) {
+		return new MutationSpecificationImpl<>( criteriaDelete, this );
+	}
+
+	@Override
+	public <T> MutationSpecification<T> createMutationSpecification(CriteriaUpdate<T> criteriaUpdate)  {
+		return new MutationSpecificationImpl<>( criteriaUpdate, this );
 	}
 
 	protected <T> NativeQueryImplementor<T> createNativeQueryImplementor(String queryName, NamedNativeQueryMemento<T> memento) {

--- a/hibernate-core/src/main/java/org/hibernate/query/QueryProducer.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/QueryProducer.java
@@ -540,6 +540,21 @@ public interface QueryProducer {
 
 	/**
 	 * Returns a specification reference which can be used to programmatically,
+	 * iteratively build a {@linkplain SelectionQuery} for the given criteria query,
+	 * allowing the addition of {@linkplain SelectionSpecification#addOrdering sorting}
+	 * and {@linkplain SelectionSpecification#addRestriction restrictions}.
+	 *
+	 * @param criteria The criteria query
+	 *
+	 * @param <T> The entity type which is the root of the query.
+	 *
+	 * @since 7.0
+	 */
+	@Incubating
+	<T> SelectionSpecification<T> createSelectionSpecification(CriteriaQuery<T> criteria);
+
+	/**
+	 * Returns a specification reference which can be used to programmatically,
 	 * iteratively build a {@linkplain MutationQuery} based on a base HQL statement,
 	 * allowing the addition of {@linkplain MutationSpecification#addRestriction restrictions}.
 	 *
@@ -557,6 +572,34 @@ public interface QueryProducer {
 	@Incubating
 	<T> MutationSpecification<T> createMutationSpecification(String hql, Class<T> mutationTarget)
 			throws IllegalMutationQueryException;
+
+	/**
+	 * Returns a specification reference which can be used to programmatically,
+	 * iteratively build a {@linkplain MutationQuery} based on the given criteria update,
+	 * allowing the addition of {@linkplain MutationSpecification#addRestriction restrictions}.
+	 *
+	 * @param criteriaUpdate The criteria update query
+	 *
+	 * @param <T> The root entity type for the mutation (the "target").
+	 *
+	 * @since 7.0
+	 */
+	@Incubating
+	<T> MutationSpecification<T> createMutationSpecification(CriteriaUpdate<T> criteriaUpdate);
+
+	/**
+	 * Returns a specification reference which can be used to programmatically,
+	 * iteratively build a {@linkplain MutationQuery} based on the given criteria delete,
+	 * allowing the addition of {@linkplain MutationSpecification#addRestriction restrictions}.
+	 *
+	 * @param criteriaDelete The criteria delete query
+	 *
+	 * @param <T> The root entity type for the mutation (the "target").
+	 *
+	 * @since 7.0
+	 */
+	@Incubating
+	<T> MutationSpecification<T> createMutationSpecification(CriteriaDelete<T> criteriaDelete);
 
 	/**
 	 * Create a {@link Query} instance for the named query.

--- a/hibernate-core/src/main/java/org/hibernate/query/QueryProducer.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/QueryProducer.java
@@ -9,10 +9,7 @@ import jakarta.persistence.TypedQueryReference;
 import jakarta.persistence.criteria.CriteriaDelete;
 import jakarta.persistence.criteria.CriteriaQuery;
 import jakarta.persistence.criteria.CriteriaUpdate;
-import org.hibernate.Incubating;
 import org.hibernate.query.criteria.JpaCriteriaInsert;
-import org.hibernate.query.programmatic.MutationSpecification;
-import org.hibernate.query.programmatic.SelectionSpecification;
 
 /**
  * Contract for things that can produce instances of {@link Query} and {@link NativeQuery}.
@@ -498,108 +495,6 @@ public interface QueryProducer {
 	 * @throws UnknownNamedQueryException if no query has been defined with the given name
 	 */
 	MutationQuery createNamedMutationQuery(String name);
-
-	/**
-	 * Returns a specification reference which can be used to programmatically,
-	 * iteratively build a {@linkplain SelectionQuery} based on a base HQL statement,
-	 * allowing the addition of {@linkplain SelectionSpecification#addOrdering sorting}
-	 * and {@linkplain SelectionSpecification#addRestriction restrictions}.
-	 *
-	 * @param hql The base HQL query.
-	 * @param resultType The result type which will ultimately be returned from the {@linkplain SelectionQuery}
-	 *
-	 * @param <T> The root entity type for the query.
-	 * {@code resultType} and {@code <T>} are both expected to refer to a singular query root.
-	 *
-	 * @throws IllegalSelectQueryException The given HQL is expected to be a {@code select} query.  This method will
-	 * throw an exception if not.
-	 *
-	 * @since 7.0
-	 */
-	@Incubating
-	<T> SelectionSpecification<T> createSelectionSpecification(String hql, Class<T> resultType)
-			throws IllegalSelectQueryException;
-
-	/**
-	 * Returns a specification reference which can be used to programmatically,
-	 * iteratively build a {@linkplain SelectionQuery} for the given entity type,
-	 * allowing the addition of {@linkplain SelectionSpecification#addOrdering sorting}
-	 * and {@linkplain SelectionSpecification#addRestriction restrictions}.
-	 * This is effectively the same as calling {@linkplain QueryProducer#createSelectionSpecification(String, Class)}
-	 * with {@code "from {rootEntityType}"} as the HQL.
-	 *
-	 * @param rootEntityType The entity type which is the root of the query.
-	 *
-	 * @param <T> The entity type which is the root of the query.
-	 * {@code resultType} and {@code <T>} are both expected to refer to a singular query root.
-	 *
-	 * @since 7.0
-	 */
-	@Incubating
-	<T> SelectionSpecification<T> createSelectionSpecification(Class<T> rootEntityType);
-
-	/**
-	 * Returns a specification reference which can be used to programmatically,
-	 * iteratively build a {@linkplain SelectionQuery} for the given criteria query,
-	 * allowing the addition of {@linkplain SelectionSpecification#addOrdering sorting}
-	 * and {@linkplain SelectionSpecification#addRestriction restrictions}.
-	 *
-	 * @param criteria The criteria query
-	 *
-	 * @param <T> The entity type which is the root of the query.
-	 *
-	 * @since 7.0
-	 */
-	@Incubating
-	<T> SelectionSpecification<T> createSelectionSpecification(CriteriaQuery<T> criteria);
-
-	/**
-	 * Returns a specification reference which can be used to programmatically,
-	 * iteratively build a {@linkplain MutationQuery} based on a base HQL statement,
-	 * allowing the addition of {@linkplain MutationSpecification#addRestriction restrictions}.
-	 *
-	 * @param hql The base HQL query (expected to be an {@code update} or {@code delete} query).
-	 * @param mutationTarget The entity which is the target of the mutation.
-	 *
-	 * @param <T> The root entity type for the mutation (the "target").
-	 * {@code mutationTarget} and {@code <T>} are both expected to refer to the mutation target.
-	 *
-	 * @throws IllegalMutationQueryException Only {@code update} and {@code delete} are supported;
-	 * this method will throw an exception if the given HQL query is not an {@code update} or {@code delete}.
-	 *
-	 * @since 7.0
-	 */
-	@Incubating
-	<T> MutationSpecification<T> createMutationSpecification(String hql, Class<T> mutationTarget)
-			throws IllegalMutationQueryException;
-
-	/**
-	 * Returns a specification reference which can be used to programmatically,
-	 * iteratively build a {@linkplain MutationQuery} based on the given criteria update,
-	 * allowing the addition of {@linkplain MutationSpecification#addRestriction restrictions}.
-	 *
-	 * @param criteriaUpdate The criteria update query
-	 *
-	 * @param <T> The root entity type for the mutation (the "target").
-	 *
-	 * @since 7.0
-	 */
-	@Incubating
-	<T> MutationSpecification<T> createMutationSpecification(CriteriaUpdate<T> criteriaUpdate);
-
-	/**
-	 * Returns a specification reference which can be used to programmatically,
-	 * iteratively build a {@linkplain MutationQuery} based on the given criteria delete,
-	 * allowing the addition of {@linkplain MutationSpecification#addRestriction restrictions}.
-	 *
-	 * @param criteriaDelete The criteria delete query
-	 *
-	 * @param <T> The root entity type for the mutation (the "target").
-	 *
-	 * @since 7.0
-	 */
-	@Incubating
-	<T> MutationSpecification<T> createMutationSpecification(CriteriaDelete<T> criteriaDelete);
 
 	/**
 	 * Create a {@link Query} instance for the named query.

--- a/hibernate-core/src/main/java/org/hibernate/query/criteria/CriteriaDefinition.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/criteria/CriteriaDefinition.java
@@ -169,6 +169,11 @@ public abstract class CriteriaDefinition<R>
 		query = (JpaCriteriaQuery<R>) baseQuery;
 	}
 
+	public CriteriaDefinition(CriteriaQuery<R> baseQuery) {
+		super( ((JpaCriteriaQuery<R>) baseQuery).getCriteriaBuilder() );
+		query = (JpaCriteriaQuery<R>) baseQuery;
+	}
+
 	public CriteriaDefinition(EntityManagerFactory factory, Class<R> resultType) {
 		super( factory.getCriteriaBuilder() );
 		query = createQuery( resultType );

--- a/hibernate-core/src/main/java/org/hibernate/query/programmatic/MutationSpecification.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/programmatic/MutationSpecification.java
@@ -4,8 +4,11 @@
  */
 package org.hibernate.query.programmatic;
 
+import jakarta.persistence.criteria.CommonAbstractCriteria;
 import jakarta.persistence.criteria.CriteriaUpdate;
 import jakarta.persistence.criteria.CriteriaDelete;
+import jakarta.persistence.criteria.CriteriaBuilder;
+import jakarta.persistence.criteria.Root;
 import org.hibernate.Incubating;
 import org.hibernate.SharedSessionContract;
 import org.hibernate.query.IllegalMutationQueryException;
@@ -41,6 +44,13 @@ public interface MutationSpecification<T> extends QuerySpecification<T> {
 	 */
 	@Override
 	MutationSpecification<T> addRestriction(Restriction<T> restriction);
+
+	@FunctionalInterface
+	interface Mutator<T> {
+		void mutate(CriteriaBuilder builder, CommonAbstractCriteria query, Root<T> mutationTarget);
+	}
+
+	MutationSpecification<T> mutate(Mutator<T> mutation);
 
 	/**
 	 * Finalize the building and create the {@linkplain SelectionQuery} instance.

--- a/hibernate-core/src/main/java/org/hibernate/query/programmatic/MutationSpecification.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/programmatic/MutationSpecification.java
@@ -4,13 +4,10 @@
  */
 package org.hibernate.query.programmatic;
 
-import jakarta.persistence.EntityManagerFactory;
-import jakarta.persistence.criteria.Root;
 import jakarta.persistence.criteria.CriteriaUpdate;
 import jakarta.persistence.criteria.CriteriaDelete;
 import org.hibernate.Incubating;
 import org.hibernate.SharedSessionContract;
-import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.query.IllegalMutationQueryException;
 import org.hibernate.query.MutationQuery;
 import org.hibernate.query.SelectionQuery;
@@ -27,7 +24,7 @@ import org.hibernate.query.restriction.Restriction;
  * kinds.
  * <p>
  * Once all {@linkplain #addRestriction restrictions} are specified, call
- * {@linkplain QuerySpecification#createQuery(SharedSessionContract)} to obtain an {@linkplain SelectionQuery an
+ * {@link #createQuery createQuery()} to obtain an {@linkplain SelectionQuery
  * executable mutation query object}.
  *
  * @param <T> The entity type which is the target of the mutation.
@@ -38,12 +35,6 @@ import org.hibernate.query.restriction.Restriction;
  */
 @Incubating
 public interface MutationSpecification<T> extends QuerySpecification<T> {
-	/**
-	 * The entity being mutated.
-	 */
-	default Root<T> getMutationTarget() {
-		return getRoot();
-	}
 
 	/**
 	 * Covariant override.
@@ -71,8 +62,8 @@ public interface MutationSpecification<T> extends QuerySpecification<T> {
 	 * @throws IllegalMutationQueryException Only {@code update} and {@code delete} are supported;
 	 * this method will throw an exception if the given HQL query is not an {@code update} or {@code delete}.
 	 */
-	static <T> MutationSpecification<T> create(EntityManagerFactory factory, Class<T> entityClass, String hql) {
-		return new MutationSpecificationImpl<>( hql, entityClass, (SessionFactoryImplementor) factory );
+	static <T> MutationSpecification<T> create(Class<T> mutationTarget, String hql) {
+		return new MutationSpecificationImpl<>( hql, mutationTarget );
 	}
 
 	/**

--- a/hibernate-core/src/main/java/org/hibernate/query/programmatic/MutationSpecification.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/programmatic/MutationSpecification.java
@@ -4,10 +4,17 @@
  */
 package org.hibernate.query.programmatic;
 
+import jakarta.persistence.EntityManagerFactory;
 import jakarta.persistence.criteria.Root;
+import jakarta.persistence.criteria.CriteriaUpdate;
+import jakarta.persistence.criteria.CriteriaDelete;
 import org.hibernate.Incubating;
+import org.hibernate.SharedSessionContract;
+import org.hibernate.engine.spi.SessionFactoryImplementor;
+import org.hibernate.query.IllegalMutationQueryException;
 import org.hibernate.query.MutationQuery;
 import org.hibernate.query.SelectionQuery;
+import org.hibernate.query.programmatic.internal.MutationSpecificationImpl;
 import org.hibernate.query.restriction.Restriction;
 
 /**
@@ -20,7 +27,7 @@ import org.hibernate.query.restriction.Restriction;
  * kinds.
  * <p>
  * Once all {@linkplain #addRestriction restrictions} are specified, call
- * {@linkplain #createQuery()} to obtain an {@linkplain SelectionQuery an
+ * {@linkplain QuerySpecification#createQuery(SharedSessionContract)} to obtain an {@linkplain SelectionQuery an
  * executable mutation query object}.
  *
  * @param <T> The entity type which is the target of the mutation.
@@ -48,5 +55,49 @@ public interface MutationSpecification<T> extends QuerySpecification<T> {
 	 * Finalize the building and create the {@linkplain SelectionQuery} instance.
 	 */
 	@Override
-	MutationQuery createQuery();
+	MutationQuery createQuery(SharedSessionContract session);
+
+	/**
+	 * Returns a specification reference which can be used to programmatically,
+	 * iteratively build a {@linkplain MutationQuery} based on a base HQL statement,
+	 * allowing the addition of {@linkplain MutationSpecification#addRestriction restrictions}.
+	 *
+	 * @param hql The base HQL query (expected to be an {@code update} or {@code delete} query).
+	 * @param mutationTarget The entity which is the target of the mutation.
+	 *
+	 * @param <T> The root entity type for the mutation (the "target").
+	 * {@code mutationTarget} and {@code <T>} are both expected to refer to the mutation target.
+	 *
+	 * @throws IllegalMutationQueryException Only {@code update} and {@code delete} are supported;
+	 * this method will throw an exception if the given HQL query is not an {@code update} or {@code delete}.
+	 */
+	static <T> MutationSpecification<T> create(EntityManagerFactory factory, Class<T> entityClass, String hql) {
+		return new MutationSpecificationImpl<>( hql, entityClass, (SessionFactoryImplementor) factory );
+	}
+
+	/**
+	 * Returns a specification reference which can be used to programmatically,
+	 * iteratively build a {@linkplain MutationQuery} based on the given criteria update,
+	 * allowing the addition of {@linkplain MutationSpecification#addRestriction restrictions}.
+	 *
+	 * @param criteriaUpdate The criteria update query
+	 *
+	 * @param <T> The root entity type for the mutation (the "target").
+	 */
+	static <T> MutationSpecification<T> create(CriteriaUpdate<T> criteriaUpdate) {
+		return new MutationSpecificationImpl<>( criteriaUpdate );
+	}
+
+	/**
+	 * Returns a specification reference which can be used to programmatically,
+	 * iteratively build a {@linkplain MutationQuery} based on the given criteria delete,
+	 * allowing the addition of {@linkplain MutationSpecification#addRestriction restrictions}.
+	 *
+	 * @param criteriaDelete The criteria delete query
+	 *
+	 * @param <T> The root entity type for the mutation (the "target").
+	 */
+	static <T> MutationSpecification<T> create(CriteriaDelete<T> criteriaDelete) {
+		return new MutationSpecificationImpl<>( criteriaDelete );
+	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/query/programmatic/MutationSpecification.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/programmatic/MutationSpecification.java
@@ -45,12 +45,24 @@ public interface MutationSpecification<T> extends QuerySpecification<T> {
 	@Override
 	MutationSpecification<T> addRestriction(Restriction<T> restriction);
 
+	/**
+	 * A function capable of modifying or augmenting a criteria query.
+	 *
+	 * @param <T> The target entity type
+	 */
 	@FunctionalInterface
-	interface Mutator<T> {
-		void mutate(CriteriaBuilder builder, CommonAbstractCriteria query, Root<T> mutationTarget);
+	interface Augmentation<T> {
+		void augment(CriteriaBuilder builder, CommonAbstractCriteria query, Root<T> mutationTarget);
 	}
 
-	MutationSpecification<T> mutate(Mutator<T> mutation);
+	/**
+	 * Add an {@linkplain Augmentation augmentation} to the specification.
+	 *
+	 * @param augmentation A function capable of modifying or augmenting a criteria query.
+	 *
+	 * @return {@code this} for method chaining.
+	 */
+	MutationSpecification<T> addAugmentation(Augmentation<T> augmentation);
 
 	/**
 	 * Finalize the building and create the {@linkplain SelectionQuery} instance.

--- a/hibernate-core/src/main/java/org/hibernate/query/programmatic/QuerySpecification.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/programmatic/QuerySpecification.java
@@ -4,10 +4,10 @@
  */
 package org.hibernate.query.programmatic;
 
-import jakarta.persistence.criteria.CommonAbstractCriteria;
-import jakarta.persistence.criteria.Root;
 import org.hibernate.Incubating;
+import org.hibernate.SessionFactory;
 import org.hibernate.SharedSessionContract;
+import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.query.CommonQueryContract;
 import org.hibernate.query.restriction.Restriction;
 
@@ -15,7 +15,9 @@ import org.hibernate.query.restriction.Restriction;
  * Commonality for all query specifications which allow iterative,
  * programmatic building of a query.
  *
- * @apiNote Query specifications only support a {@linkplain #getRoot() single root}.
+ * @apiNote Query specifications only support a single root entity.
+ *
+ * @param <T> The root entity type.
  *
  * @author Steve Ebersole
  *
@@ -23,20 +25,6 @@ import org.hibernate.query.restriction.Restriction;
  */
 @Incubating
 public interface QuerySpecification<T> {
-	/**
-	 * Get the root of the query.
-	 * E.g. given the HQL {@code "from Book"}, we have a single {@code Root<Book>}.
-	 */
-	Root<T> getRoot();
-
-	/**
-	 * Access to the criteria query which QuerySpecification is
-	 * managing and manipulating internally.
-	 * While it is allowable to directly mutate this tree, users
-	 * should instead prefer to manipulate the tree through the
-	 * methods exposed on the specification itself.
-	 */
-	CommonAbstractCriteria getCriteria();
 
 	/**
 	 * Adds a restriction to the query specification.
@@ -51,4 +39,16 @@ public interface QuerySpecification<T> {
 	 * Finalize the building and create executable query instance.
 	 */
 	CommonQueryContract createQuery(SharedSessionContract session);
+
+	/**
+	 * Validate the query.
+	 */
+	default void validate(SessionFactory factory) {
+		// Extremely temporary implementation.
+		// We don't actually want to open a session here,
+		// nor create an instance of CommonQueryContract.
+		try ( var session = ((SessionFactoryImplementor) factory).openTemporarySession() ) {
+			createQuery( session );
+		}
+	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/query/programmatic/QuerySpecification.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/programmatic/QuerySpecification.java
@@ -7,6 +7,7 @@ package org.hibernate.query.programmatic;
 import jakarta.persistence.criteria.CommonAbstractCriteria;
 import jakarta.persistence.criteria.Root;
 import org.hibernate.Incubating;
+import org.hibernate.SharedSessionContract;
 import org.hibernate.query.CommonQueryContract;
 import org.hibernate.query.restriction.Restriction;
 
@@ -49,5 +50,5 @@ public interface QuerySpecification<T> {
 	/**
 	 * Finalize the building and create executable query instance.
 	 */
-	CommonQueryContract createQuery();
+	CommonQueryContract createQuery(SharedSessionContract session);
 }

--- a/hibernate-core/src/main/java/org/hibernate/query/programmatic/SelectionSpecification.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/programmatic/SelectionSpecification.java
@@ -13,6 +13,7 @@ import org.hibernate.query.IllegalSelectQueryException;
 import org.hibernate.query.Order;
 import org.hibernate.query.SelectionQuery;
 import org.hibernate.query.programmatic.internal.SelectionSpecificationImpl;
+import org.hibernate.query.restriction.Path;
 import org.hibernate.query.restriction.Restriction;
 
 import java.util.List;
@@ -90,6 +91,15 @@ public interface SelectionSpecification<T> extends QuerySpecification<T> {
 	 */
 	@Override
 	SelectionSpecification<T> addRestriction(Restriction<T> restriction);
+
+	/**
+	 * Add a fetch {@linkplain Path path} to the specification.
+	 *
+	 * @param fetchPath The path to fetch
+	 *
+	 * @return {@code this} for method chaining.
+	 */
+	SelectionSpecification<T> addFetching(Path<T,?> fetchPath);
 
 	@FunctionalInterface
 	interface Mutator<T> {

--- a/hibernate-core/src/main/java/org/hibernate/query/programmatic/SelectionSpecification.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/programmatic/SelectionSpecification.java
@@ -101,12 +101,24 @@ public interface SelectionSpecification<T> extends QuerySpecification<T> {
 	 */
 	SelectionSpecification<T> addFetching(Path<T,?> fetchPath);
 
+	/**
+	 * A function capable of modifying or augmenting a criteria query.
+	 *
+	 * @param <T> The root entity type
+	 */
 	@FunctionalInterface
-	interface Mutator<T> {
-		void mutate(CriteriaBuilder builder, CriteriaQuery<T> query, Root<T> root);
+	interface Augmentation<T> {
+		void augment(CriteriaBuilder builder, CriteriaQuery<T> query, Root<T> root);
 	}
 
-	SelectionSpecification<T> mutate(Mutator<T> mutation);
+	/**
+	 * Add an {@linkplain Augmentation augmentation} to the specification.
+	 *
+	 * @param augmentation A function capable of modifying or augmenting a criteria query.
+	 *
+	 * @return {@code this} for method chaining.
+	 */
+	SelectionSpecification<T> addAugmentation(Augmentation<T> augmentation);
 
 	/**
 	 * Covariant override.

--- a/hibernate-core/src/main/java/org/hibernate/query/programmatic/SelectionSpecification.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/programmatic/SelectionSpecification.java
@@ -4,14 +4,11 @@
  */
 package org.hibernate.query.programmatic;
 
-import jakarta.persistence.EntityManagerFactory;
 import jakarta.persistence.criteria.CriteriaQuery;
 import org.hibernate.Incubating;
 import org.hibernate.SharedSessionContract;
-import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.query.IllegalSelectQueryException;
 import org.hibernate.query.Order;
-import org.hibernate.query.QueryProducer;
 import org.hibernate.query.SelectionQuery;
 import org.hibernate.query.programmatic.internal.SelectionSpecificationImpl;
 import org.hibernate.query.restriction.Restriction;
@@ -31,11 +28,10 @@ import java.util.List;
  * </ul>
  * <p>
  * Once all {@linkplain #addOrdering sorting} and {@linkplain #addRestriction restrictions}
- * are specified, call {@linkplain QuerySpecification#createQuery(SharedSessionContract)} to obtain an {@linkplain SelectionQuery
- * executable selection query object}.
+ * are specified, call {@link #createQuery createQuery()} to obtain an
+ * {@linkplain SelectionQuery executable selection query object}.
  * <pre>
- * SelectionSpecification.create(factory, Book.class,
- *                               "from Book where discontinued = false")
+ * SelectionSpecification.create(Book.class, "from Book where discontinued = false")
  *         .addRestriction(Restriction.contains(Book_.title, "hibernate", false))
  *         .setOrdering(Order.desc(Book_.title))
  *         .createQuery(session)                       // obtain a SelectionQuery
@@ -48,8 +44,6 @@ import java.util.List;
  * and properties of this root entity.
  *
  * @param <T> The entity type returned by the query
- *
- * @see QueryProducer#createSelectionSpecification(String, Class)
  *
  * @author Steve Ebersole
  *
@@ -93,12 +87,6 @@ public interface SelectionSpecification<T> extends QuerySpecification<T> {
 	 * Covariant override.
 	 */
 	@Override
-	CriteriaQuery<T> getCriteria();
-
-	/**
-	 * Covariant override.
-	 */
-	@Override
 	SelectionSpecification<T> addRestriction(Restriction<T> restriction);
 
 	/**
@@ -112,7 +100,7 @@ public interface SelectionSpecification<T> extends QuerySpecification<T> {
 	 * iteratively build a {@linkplain SelectionQuery} for the given entity type,
 	 * allowing the addition of {@linkplain SelectionSpecification#addOrdering sorting}
 	 * and {@linkplain SelectionSpecification#addRestriction restrictions}.
-	 * This is effectively the same as calling {@linkplain QueryProducer#createSelectionSpecification(String, Class)}
+	 * This is effectively the same as calling {@linkplain #create(Class, String)}
 	 * with {@code "from {rootEntityType}"} as the HQL.
 	 *
 	 * @param rootEntityType The entity type which is the root of the query.
@@ -120,12 +108,8 @@ public interface SelectionSpecification<T> extends QuerySpecification<T> {
 	 * @param <T> The entity type which is the root of the query.
 	 * {@code resultType} and {@code <T>} are both expected to refer to a singular query root.
 	 */
-	static <T> SelectionSpecification<T> create(EntityManagerFactory factory, Class<T> rootEntityType) {
-		var builder = factory.getCriteriaBuilder();
-		var query = builder.createQuery( rootEntityType );
-		var root = query.from( rootEntityType );
-		query.select( root );
-		return new SelectionSpecificationImpl<>( query );
+	static <T> SelectionSpecification<T> create(Class<T> rootEntityType) {
+		return new SelectionSpecificationImpl<>( rootEntityType );
 	}
 
 	/**
@@ -143,8 +127,8 @@ public interface SelectionSpecification<T> extends QuerySpecification<T> {
 	 * @throws IllegalSelectQueryException The given HQL is expected to be a {@code select} query.  This method will
 	 * throw an exception if not.
 	 */
-	static <T> SelectionSpecification<T> create(EntityManagerFactory factory, Class<T> resultType, String hql) {
-		return new SelectionSpecificationImpl<>( hql, resultType, (SessionFactoryImplementor) factory );
+	static <T> SelectionSpecification<T> create(Class<T> resultType, String hql) {
+		return new SelectionSpecificationImpl<>( hql, resultType );
 	}
 
 	/**

--- a/hibernate-core/src/main/java/org/hibernate/query/programmatic/SelectionSpecification.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/programmatic/SelectionSpecification.java
@@ -113,6 +113,34 @@ public interface SelectionSpecification<T> extends QuerySpecification<T> {
 
 	/**
 	 * Add an {@linkplain Augmentation augmentation} to the specification.
+	 * <p>
+	 * For example:
+	 * <pre>
+	 * SelectionSpecification.create(Book.class)
+	 *       .addAugmentation((builder, query, book) ->
+	 *               // augment the query via JPA Criteria API
+	 *               query.where(builder.like(book.get(Book_.title), titlePattern)),
+	 *                           builder.greaterThan(book.get(Book_.pages), minPages))
+	 *                   .orderBy(builder.asc(book.get(Book_.isbn)))
+	 *       .createQuery(session)
+	 *       .getResultList();
+	 * </pre>
+	 * For complicated cases, a {@link org.hibernate.query.criteria.CriteriaDefinition}
+	 * may be used within an augmentation to eliminate repetitive explicit references to
+	 * the {@link CriteriaBuilder}.
+	 * <pre>
+	 * SelectionSpecification.create(Book.class)
+	 *       .addAugmentation((builder, query, book) ->
+	 *           // eliminate explicit references to 'builder'
+	 *           new CriteriaDefinition<>(query) {{
+	 *               where(like(entity.get(BasicEntity_.title), titlePattern),
+	 *                     greaterThan(book.get(Book_.pages), minPages));
+	 *               orderBy(asc(book.get(Book_.isbn)));
+	 *           }}
+	 *       )
+	 *       .createQuery(session)
+	 *       .getResultList();
+	 * </pre>
 	 *
 	 * @param augmentation A function capable of modifying or augmenting a criteria query.
 	 *

--- a/hibernate-core/src/main/java/org/hibernate/query/programmatic/SelectionSpecification.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/programmatic/SelectionSpecification.java
@@ -5,6 +5,8 @@
 package org.hibernate.query.programmatic;
 
 import jakarta.persistence.criteria.CriteriaQuery;
+import jakarta.persistence.criteria.CriteriaBuilder;
+import jakarta.persistence.criteria.Root;
 import org.hibernate.Incubating;
 import org.hibernate.SharedSessionContract;
 import org.hibernate.query.IllegalSelectQueryException;
@@ -88,6 +90,13 @@ public interface SelectionSpecification<T> extends QuerySpecification<T> {
 	 */
 	@Override
 	SelectionSpecification<T> addRestriction(Restriction<T> restriction);
+
+	@FunctionalInterface
+	interface Mutator<T> {
+		void mutate(CriteriaBuilder builder, CriteriaQuery<T> query, Root<T> root);
+	}
+
+	SelectionSpecification<T> mutate(Mutator<T> mutation);
 
 	/**
 	 * Covariant override.

--- a/hibernate-core/src/main/java/org/hibernate/query/programmatic/internal/MutationSpecificationImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/programmatic/internal/MutationSpecificationImpl.java
@@ -74,6 +74,13 @@ public class MutationSpecificationImpl<T> implements MutationSpecification<T> {
 	}
 
 	@Override
+	public MutationSpecification<T> mutate(Mutator<T> mutation) {
+		specifications.add( (sqmStatement, mutationTargetRoot) ->
+				mutation.mutate( sqmStatement.nodeBuilder(), sqmStatement, mutationTargetRoot ) );
+		return this;
+	}
+
+	@Override
 	public MutationQuery createQuery(SharedSessionContract session) {
 		final var sessionImpl = (SharedSessionContractImplementor) session;
 		final SqmDeleteOrUpdateStatement<T> sqmStatement;

--- a/hibernate-core/src/main/java/org/hibernate/query/programmatic/internal/MutationSpecificationImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/programmatic/internal/MutationSpecificationImpl.java
@@ -8,6 +8,7 @@ import jakarta.persistence.criteria.CommonAbstractCriteria;
 import jakarta.persistence.criteria.CriteriaDelete;
 import jakarta.persistence.criteria.CriteriaUpdate;
 import jakarta.persistence.criteria.Root;
+import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.query.programmatic.MutationSpecification;
 import org.hibernate.query.IllegalMutationQueryException;
@@ -44,7 +45,7 @@ public class MutationSpecificationImpl<T> implements MutationSpecification<T> {
 			Class<T> mutationTarget,
 			SharedSessionContractImplementor session) {
 		this.session = session;
-		this.sqmStatement = resolveSqmTree( hql, session );
+		this.sqmStatement = resolveSqmTree( hql, session.getFactory() );
 		this.mutationTargetRoot = resolveSqmRoot( this.sqmStatement, mutationTarget );
 	}
 
@@ -53,7 +54,8 @@ public class MutationSpecificationImpl<T> implements MutationSpecification<T> {
 			SharedSessionContractImplementor session) {
 		this.session = session;
 		this.sqmStatement = (SqmUpdateStatement<T>) criteriaQuery;
-		this.mutationTargetRoot = resolveSqmRoot( sqmStatement, sqmStatement.getTarget().getManagedType().getJavaType() );
+		this.mutationTargetRoot = resolveSqmRoot( sqmStatement,
+				sqmStatement.getTarget().getManagedType().getJavaType() );
 	}
 
 	public MutationSpecificationImpl(
@@ -61,7 +63,8 @@ public class MutationSpecificationImpl<T> implements MutationSpecification<T> {
 			SharedSessionContractImplementor session) {
 		this.session = session;
 		this.sqmStatement = (SqmDeleteStatement<T>) criteriaQuery;
-		this.mutationTargetRoot = resolveSqmRoot( sqmStatement, sqmStatement.getTarget().getManagedType().getJavaType() );
+		this.mutationTargetRoot = resolveSqmRoot( sqmStatement,
+				sqmStatement.getTarget().getManagedType().getJavaType() );
 	}
 
 	@Override
@@ -96,8 +99,8 @@ public class MutationSpecificationImpl<T> implements MutationSpecification<T> {
 	 */
 	private static <T> SqmDeleteOrUpdateStatement<T> resolveSqmTree(
 			String hql,
-			SharedSessionContractImplementor session) {
-		final QueryEngine queryEngine = session.getFactory().getQueryEngine();
+			SessionFactoryImplementor sessionFactory) {
+		final QueryEngine queryEngine = sessionFactory.getQueryEngine();
 		final HqlInterpretation<T> hqlInterpretation = queryEngine
 				.getInterpretationCache()
 				.resolveHqlInterpretation( hql, null, queryEngine.getHqlTranslator() );

--- a/hibernate-core/src/main/java/org/hibernate/query/programmatic/internal/MutationSpecificationImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/programmatic/internal/MutationSpecificationImpl.java
@@ -5,6 +5,8 @@
 package org.hibernate.query.programmatic.internal;
 
 import jakarta.persistence.criteria.CommonAbstractCriteria;
+import jakarta.persistence.criteria.CriteriaDelete;
+import jakarta.persistence.criteria.CriteriaUpdate;
 import jakarta.persistence.criteria.Root;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.query.programmatic.MutationSpecification;
@@ -17,8 +19,10 @@ import org.hibernate.query.sqm.SqmQuerySource;
 import org.hibernate.query.sqm.internal.QuerySqmImpl;
 import org.hibernate.query.sqm.internal.SqmUtil;
 import org.hibernate.query.sqm.tree.SqmDeleteOrUpdateStatement;
+import org.hibernate.query.sqm.tree.delete.SqmDeleteStatement;
 import org.hibernate.query.sqm.tree.from.SqmRoot;
 import org.hibernate.query.sqm.tree.predicate.SqmPredicate;
+import org.hibernate.query.sqm.tree.update.SqmUpdateStatement;
 
 import java.util.Locale;
 
@@ -42,6 +46,22 @@ public class MutationSpecificationImpl<T> implements MutationSpecification<T> {
 		this.session = session;
 		this.sqmStatement = resolveSqmTree( hql, session );
 		this.mutationTargetRoot = resolveSqmRoot( this.sqmStatement, mutationTarget );
+	}
+
+	public MutationSpecificationImpl(
+			CriteriaUpdate<T> criteriaQuery,
+			SharedSessionContractImplementor session) {
+		this.session = session;
+		this.sqmStatement = (SqmUpdateStatement<T>) criteriaQuery;
+		this.mutationTargetRoot = resolveSqmRoot( sqmStatement, sqmStatement.getTarget().getManagedType().getJavaType() );
+	}
+
+	public MutationSpecificationImpl(
+			CriteriaDelete<T> criteriaQuery,
+			SharedSessionContractImplementor session) {
+		this.session = session;
+		this.sqmStatement = (SqmDeleteStatement<T>) criteriaQuery;
+		this.mutationTargetRoot = resolveSqmRoot( sqmStatement, sqmStatement.getTarget().getManagedType().getJavaType() );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/query/programmatic/internal/MutationSpecificationImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/programmatic/internal/MutationSpecificationImpl.java
@@ -74,9 +74,9 @@ public class MutationSpecificationImpl<T> implements MutationSpecification<T> {
 	}
 
 	@Override
-	public MutationSpecification<T> mutate(Mutator<T> mutation) {
+	public MutationSpecification<T> addAugmentation(Augmentation<T> augmentation) {
 		specifications.add( (sqmStatement, mutationTargetRoot) ->
-				mutation.mutate( sqmStatement.nodeBuilder(), sqmStatement, mutationTargetRoot ) );
+				augmentation.augment( sqmStatement.nodeBuilder(), sqmStatement, mutationTargetRoot ) );
 		return this;
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/query/programmatic/internal/SelectionSpecificationImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/programmatic/internal/SelectionSpecificationImpl.java
@@ -12,6 +12,7 @@ import org.hibernate.query.IllegalSelectQueryException;
 import org.hibernate.query.Order;
 import org.hibernate.query.SelectionQuery;
 import org.hibernate.query.programmatic.SelectionSpecification;
+import org.hibernate.query.restriction.Path;
 import org.hibernate.query.restriction.Restriction;
 import org.hibernate.query.spi.HqlInterpretation;
 import org.hibernate.query.spi.QueryEngine;
@@ -75,6 +76,12 @@ public class SelectionSpecificationImpl<T> implements SelectionSpecification<T> 
 	public SelectionSpecification<T> mutate(Mutator<T> mutation) {
 		specifications.add( (sqmStatement, root) ->
 				mutation.mutate( sqmStatement.nodeBuilder(), sqmStatement, root ) );
+		return this;
+	}
+
+	@Override
+	public SelectionSpecification<T> addFetching(Path<T, ?> fetchPath) {
+		specifications.add( (sqmStatement, root) -> fetchPath.fetch( root ) );
 		return this;
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/query/programmatic/internal/SelectionSpecificationImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/programmatic/internal/SelectionSpecificationImpl.java
@@ -60,6 +60,15 @@ public class SelectionSpecificationImpl<T> implements SelectionSpecification<T> 
 		this( "from " + determineEntityName( rootEntityType, session ), rootEntityType, session );
 	}
 
+	public SelectionSpecificationImpl(
+			CriteriaQuery<T> criteriaQuery,
+			SharedSessionContractImplementor session) {
+		this.resultType = criteriaQuery.getResultType();
+		this.session = session;
+		this.sqmStatement = (SqmSelectStatement<T>) criteriaQuery;
+		this.sqmRoot = extractRoot( sqmStatement, resultType, "criteria query" );
+	}
+
 	@Override
 	public Root<T> getRoot() {
 		return sqmRoot;

--- a/hibernate-core/src/main/java/org/hibernate/query/programmatic/internal/SelectionSpecificationImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/programmatic/internal/SelectionSpecificationImpl.java
@@ -72,6 +72,13 @@ public class SelectionSpecificationImpl<T> implements SelectionSpecification<T> 
 	}
 
 	@Override
+	public SelectionSpecification<T> mutate(Mutator<T> mutation) {
+		specifications.add( (sqmStatement, root) ->
+				mutation.mutate( sqmStatement.nodeBuilder(), sqmStatement, root ) );
+		return this;
+	}
+
+	@Override
 	public SelectionSpecification<T> addOrdering(Order<T> order) {
 		specifications.add( (sqmStatement, root) -> {
 			addOrder( order, sqmStatement );

--- a/hibernate-core/src/main/java/org/hibernate/query/programmatic/internal/SelectionSpecificationImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/programmatic/internal/SelectionSpecificationImpl.java
@@ -73,9 +73,9 @@ public class SelectionSpecificationImpl<T> implements SelectionSpecification<T> 
 	}
 
 	@Override
-	public SelectionSpecification<T> mutate(Mutator<T> mutation) {
+	public SelectionSpecification<T> addAugmentation(Augmentation<T> augmentation) {
 		specifications.add( (sqmStatement, root) ->
-				mutation.mutate( sqmStatement.nodeBuilder(), sqmStatement, root ) );
+				augmentation.augment( sqmStatement.nodeBuilder(), sqmStatement, root ) );
 		return this;
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/query/restriction/NamedPathElement.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/restriction/NamedPathElement.java
@@ -5,6 +5,8 @@
 package org.hibernate.query.restriction;
 
 import jakarta.persistence.criteria.Root;
+import jakarta.persistence.criteria.FetchParent;
+
 
 /**
  * A non-root element of a {@link Path}, using a stringly-typed
@@ -27,5 +29,10 @@ record NamedPathElement<X, U, V>(Path<? super X, U> parent, String attributeName
 												+ "' is not of type '" + attributeType.getName() + "'" );
 		}
 		return path;
+	}
+
+	@Override
+	public FetchParent<?, ? extends V> fetch(Root<? extends X> root) {
+		return parent.fetch( root ).fetch( attributeName );
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/query/restriction/NamedPathElement.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/restriction/NamedPathElement.java
@@ -32,7 +32,7 @@ record NamedPathElement<X, U, V>(Path<? super X, U> parent, String attributeName
 	}
 
 	@Override
-	public FetchParent<?, ? extends V> fetch(Root<? extends X> root) {
+	public FetchParent<?, V> fetch(Root<? extends X> root) {
 		return parent.fetch( root ).fetch( attributeName );
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/query/restriction/Path.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/restriction/Path.java
@@ -17,10 +17,10 @@ import java.util.List;
  * A compound path is a sequence of attribute references rooted at
  * the root entity type of the query.
  * <pre>
- * session.createSelectionSpecification("from Book", Book.class)
+ * SelectionSpecification.create(Book.class)
  *         .addRestriction(from(Book.class).to(Book_.publisher).to(Publisher_.name)
  *                         .equalTo("Manning"))
- *         .createQuery()
+ *         .createQuery(session)
  *         .getResultList()
  * </pre>
  * A compound path-based restriction has the same semantics as the

--- a/hibernate-core/src/main/java/org/hibernate/query/restriction/Path.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/restriction/Path.java
@@ -5,6 +5,7 @@
 package org.hibernate.query.restriction;
 
 import jakarta.persistence.criteria.Root;
+import jakarta.persistence.criteria.FetchParent;
 import jakarta.persistence.metamodel.SingularAttribute;
 import org.hibernate.Incubating;
 import org.hibernate.query.range.Range;
@@ -76,4 +77,6 @@ public interface Path<X,U> {
 	default Restriction<X> notNull() {
 		return restrict( Range.notNull( getType() ) );
 	}
+
+	FetchParent<?, ? extends U> fetch(Root<? extends X> root);
 }

--- a/hibernate-core/src/main/java/org/hibernate/query/restriction/PathElement.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/restriction/PathElement.java
@@ -26,7 +26,7 @@ record PathElement<X, U, V>(Path<? super X, U> parent, SingularAttribute<? super
 	}
 
 	@Override
-	public FetchParent<?, ? extends V> fetch(Root<? extends X> root) {
+	public FetchParent<?, V> fetch(Root<? extends X> root) {
 		return parent.fetch( root ).fetch( attribute );
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/query/restriction/PathElement.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/restriction/PathElement.java
@@ -5,6 +5,7 @@
 package org.hibernate.query.restriction;
 
 import jakarta.persistence.criteria.Root;
+import jakarta.persistence.criteria.FetchParent;
 import jakarta.persistence.metamodel.SingularAttribute;
 
 /**
@@ -22,5 +23,10 @@ record PathElement<X, U, V>(Path<? super X, U> parent, SingularAttribute<? super
 	@Override
 	public jakarta.persistence.criteria.Path<V> path(Root<? extends X> root) {
 		return parent.path( root ).get( attribute );
+	}
+
+	@Override
+	public FetchParent<?, ? extends V> fetch(Root<? extends X> root) {
+		return parent.fetch( root ).fetch( attribute );
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/query/restriction/PathRoot.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/restriction/PathRoot.java
@@ -5,6 +5,7 @@
 package org.hibernate.query.restriction;
 
 import jakarta.persistence.criteria.Root;
+import jakarta.persistence.criteria.FetchParent;
 
 /**
  * A root element of a {@link Path}.
@@ -22,5 +23,10 @@ record PathRoot<X>(Class<X> type) implements Path<X, X> {
 	public jakarta.persistence.criteria.Path<X> path(Root<? extends X> root) {
 		// unchecked cast only to get rid of the upper bound
 		return (jakarta.persistence.criteria.Path<X>) root;
+	}
+
+	@Override
+	public FetchParent<?, ? extends X> fetch(Root<? extends X> root) {
+		return root;
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/query/restriction/Restriction.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/restriction/Restriction.java
@@ -23,11 +23,11 @@ import java.util.List;
  * a {@link org.hibernate.query.programmatic.SelectionSpecification} by calling
  * {@link SelectionQuery#addRestriction(Restriction)}.
  * <pre>
- * session.createSelectionSpecification("from Book", Book.class)
+ * SelectionSpecification.create(factory, Book.class)
  *         .addRestriction(Restriction.like(Book_.title, "%Hibernate%", false))
  *         .addRestriction(Restriction.greaterThan(Book_.pages, 100))
  *         .setOrder(Order.desc(Book_.title))
- *         .createQuery()
+ *         .createQuery(session)
  *         .getResultList();
  * </pre>
  * <p>

--- a/hibernate-core/src/main/java/org/hibernate/query/restriction/Restriction.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/restriction/Restriction.java
@@ -23,7 +23,7 @@ import java.util.List;
  * a {@link org.hibernate.query.programmatic.SelectionSpecification} by calling
  * {@link SelectionQuery#addRestriction(Restriction)}.
  * <pre>
- * SelectionSpecification.create(factory, Book.class)
+ * SelectionSpecification.create(Book.class)
  *         .addRestriction(Restriction.like(Book_.title, "%Hibernate%", false))
  *         .addRestriction(Restriction.greaterThan(Book_.pages, 100))
  *         .setOrder(Order.desc(Book_.title))

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/internal/QuerySqmImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/internal/QuerySqmImpl.java
@@ -200,7 +200,7 @@ public class QuerySqmImpl<R>
 	}
 
 	/**
-	 * Used from {@linkplain org.hibernate.query.QueryProducer#createMutationSpecification}
+	 * Used for specifications.
 	 */
 	public QuerySqmImpl(
 			SqmStatement<R> criteria,

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/query/dynamic/OtherEntity.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/query/dynamic/OtherEntity.java
@@ -6,20 +6,11 @@ package org.hibernate.orm.test.query.dynamic;
 
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
-import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 
-/**
- * @author Steve Ebersole
- */
-@Entity(name = "BasicEntity")
-@Table(name = "BasicEntity")
-public class BasicEntity {
+@Entity(name = "OtherEntity")
+@Table(name = "OtherEntity")
+public class OtherEntity {
 	@Id
 	private Integer id;
-	private String name;
-	private int position;
-
-	@ManyToOne
-	OtherEntity other;
 }

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/query/dynamic/SimpleQuerySpecificationTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/query/dynamic/SimpleQuerySpecificationTests.java
@@ -201,7 +201,7 @@ public class SimpleQuerySpecificationTests {
 		factoryScope.inTransaction( (session) -> {
 			sqlCollector.clear();
 			SelectionSpecification.create( BasicEntity.class )
-					.mutate( (builder, query, entity) -> query.where( builder.like( entity.get( BasicEntity_.name ), "%" ) ) )
+					.addAugmentation( (builder, query, entity) -> query.where( builder.like( entity.get( BasicEntity_.name ), "%" ) ) )
 					.addOrdering( Order.asc( BasicEntity_.position ) )
 					.createQuery( session )
 					.getResultList();

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/query/dynamic/SimpleQuerySpecificationTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/query/dynamic/SimpleQuerySpecificationTests.java
@@ -4,14 +4,16 @@
  */
 package org.hibernate.orm.test.query.dynamic;
 
+import org.hibernate.SessionFactory;
 import org.hibernate.query.IllegalMutationQueryException;
 import org.hibernate.query.IllegalSelectQueryException;
 import org.hibernate.query.Order;
+import org.hibernate.query.programmatic.MutationSpecification;
+import org.hibernate.query.programmatic.SelectionSpecification;
 import org.hibernate.query.range.Range;
 import org.hibernate.query.restriction.Restriction;
 import org.hibernate.testing.jdbc.SQLStatementInspector;
 import org.hibernate.testing.orm.junit.DomainModel;
-import org.hibernate.testing.orm.junit.SessionFactory;
 import org.hibernate.testing.orm.junit.SessionFactoryScope;
 import org.junit.jupiter.api.Test;
 
@@ -25,17 +27,19 @@ import static org.junit.jupiter.api.Assertions.fail;
  */
 @SuppressWarnings("JUnitMalformedDeclaration")
 @DomainModel(annotatedClasses = BasicEntity.class)
-@SessionFactory(useCollectingStatementInspector = true)
+@org.hibernate.testing.orm.junit.SessionFactory(useCollectingStatementInspector = true)
 public class SimpleQuerySpecificationTests {
 	@Test
 	void testSimpleSelectionOrder(SessionFactoryScope factoryScope) {
 		final SQLStatementInspector sqlCollector = factoryScope.getCollectingStatementInspector();
 
+		final SessionFactory factory = factoryScope.getSessionFactory();
+
 		factoryScope.inTransaction( (session) -> {
 			sqlCollector.clear();
-			session.createSelectionSpecification( "from BasicEntity", BasicEntity.class )
+			SelectionSpecification.create( factory, BasicEntity.class, "from BasicEntity" )
 					.addOrdering( Order.asc( BasicEntity_.position ) )
-					.createQuery()
+					.createQuery( session )
 					.list();
 		} );
 
@@ -47,12 +51,14 @@ public class SimpleQuerySpecificationTests {
 	void testSimpleSelectionOrderMultiple(SessionFactoryScope factoryScope) {
 		final SQLStatementInspector sqlCollector = factoryScope.getCollectingStatementInspector();
 
+		final SessionFactory factory = factoryScope.getSessionFactory();
+
 		factoryScope.inTransaction( (session) -> {
 			sqlCollector.clear();
-			session.createSelectionSpecification( "from BasicEntity", BasicEntity.class )
+			SelectionSpecification.create( factory, BasicEntity.class, "from BasicEntity" )
 					.addOrdering( Order.asc( BasicEntity_.position ) )
 					.addOrdering( Order.asc( BasicEntity_.id ) )
-					.createQuery()
+					.createQuery( session )
 					.list();
 		} );
 
@@ -64,10 +70,13 @@ public class SimpleQuerySpecificationTests {
 	void testSimpleSelectionSetOrdering(SessionFactoryScope factoryScope) {
 		final SQLStatementInspector sqlCollector = factoryScope.getCollectingStatementInspector();
 
-		factoryScope.inTransaction( (session) -> {			sqlCollector.clear();
-			session.createSelectionSpecification( "from BasicEntity", BasicEntity.class )
+		final SessionFactory factory = factoryScope.getSessionFactory();
+
+		factoryScope.inTransaction( (session) -> {
+			sqlCollector.clear();
+			SelectionSpecification.create( factory, BasicEntity.class, "from BasicEntity" )
 					.setOrdering( Order.asc( BasicEntity_.position ) )
-					.createQuery()
+					.createQuery( session )
 					.list();
 		} );
 
@@ -79,11 +88,13 @@ public class SimpleQuerySpecificationTests {
 	void testSimpleSelectionSetOrderingMultiple(SessionFactoryScope factoryScope) {
 		final SQLStatementInspector sqlCollector = factoryScope.getCollectingStatementInspector();
 
+		final SessionFactory factory = factoryScope.getSessionFactory();
+
 		factoryScope.inTransaction( (session) -> {
 			sqlCollector.clear();
-			session.createSelectionSpecification( "from BasicEntity", BasicEntity.class )
+			SelectionSpecification.create( factory, BasicEntity.class, "from BasicEntity" )
 					.setOrdering( List.of( Order.asc( BasicEntity_.position ), Order.asc( BasicEntity_.id ) ) )
-					.createQuery()
+					.createQuery( session )
 					.list();
 		} );
 
@@ -95,12 +106,14 @@ public class SimpleQuerySpecificationTests {
 	void testSimpleSelectionSetOrderingReplace(SessionFactoryScope factoryScope) {
 		final SQLStatementInspector sqlCollector = factoryScope.getCollectingStatementInspector();
 
+		final SessionFactory factory = factoryScope.getSessionFactory();
+
 		factoryScope.inTransaction( (session) -> {
 			sqlCollector.clear();
-			session.createSelectionSpecification( "from BasicEntity", BasicEntity.class )
+			SelectionSpecification.create( factory, BasicEntity.class, "from BasicEntity" )
 					.setOrdering( Order.asc( BasicEntity_.id ) )
 					.setOrdering( Order.asc( BasicEntity_.position ) )
-					.createQuery()
+					.createQuery( session )
 					.list();
 		} );
 
@@ -109,10 +122,10 @@ public class SimpleQuerySpecificationTests {
 
 		factoryScope.inTransaction( (session) -> {
 			sqlCollector.clear();
-			session.createSelectionSpecification( "from BasicEntity", BasicEntity.class )
+			SelectionSpecification.create( factory, BasicEntity.class, "from BasicEntity" )
 					.addOrdering( Order.asc( BasicEntity_.id ) )
 					.setOrdering( Order.asc( BasicEntity_.position ) )
-					.createQuery()
+					.createQuery( session )
 					.list();
 		} );
 
@@ -124,11 +137,13 @@ public class SimpleQuerySpecificationTests {
 	void testSimpleSelectionRestriction(SessionFactoryScope factoryScope) {
 		final SQLStatementInspector sqlCollector = factoryScope.getCollectingStatementInspector();
 
+		final SessionFactory factory = factoryScope.getSessionFactory();
+
 		factoryScope.inTransaction( (session) -> {
 			sqlCollector.clear();
-			session.createSelectionSpecification( "from BasicEntity", BasicEntity.class )
+			SelectionSpecification.create( factory, BasicEntity.class, "from BasicEntity" )
 					.addRestriction( Restriction.restrict( BasicEntity_.position, Range.closed( 1, 5 ) ) )
-					.createQuery()
+					.createQuery( session )
 					.list();
 		} );
 
@@ -140,11 +155,13 @@ public class SimpleQuerySpecificationTests {
 	void testSimpleMutationRestriction(SessionFactoryScope factoryScope) {
 		final SQLStatementInspector sqlCollector = factoryScope.getCollectingStatementInspector();
 
+		final SessionFactory factory = factoryScope.getSessionFactory();
+
 		factoryScope.inTransaction( (session) -> {
 			sqlCollector.clear();
-			session.createMutationSpecification( "delete BasicEntity", BasicEntity.class )
+			MutationSpecification.create( factory, BasicEntity.class, "delete BasicEntity" )
 					.addRestriction( Restriction.restrict( BasicEntity_.position, Range.closed( 1, 5 ) ) )
-					.createQuery()
+					.createQuery( session )
 					.executeUpdate();
 		} );
 
@@ -156,11 +173,13 @@ public class SimpleQuerySpecificationTests {
 	void testRootEntityForm(SessionFactoryScope factoryScope) {
 		final SQLStatementInspector sqlCollector = factoryScope.getCollectingStatementInspector();
 
+		final SessionFactory factory = factoryScope.getSessionFactory();
+
 		factoryScope.inTransaction( (session) -> {
 			sqlCollector.clear();
-			session.createSelectionSpecification( BasicEntity.class )
+			SelectionSpecification.create( factory, BasicEntity.class )
 					.addOrdering( Order.asc( BasicEntity_.position ) )
-					.createQuery()
+					.createQuery( session )
 					.getResultList();
 		} );
 
@@ -179,9 +198,9 @@ public class SimpleQuerySpecificationTests {
 			var entity = query.from( BasicEntity.class );
 			query.select( entity );
 			query.where( criteriaBuilder.like( entity.get( BasicEntity_.name ), "%" ) );
-			session.createSelectionSpecification( query )
+			SelectionSpecification.create( query )
 					.addOrdering( Order.asc( BasicEntity_.position ) )
-					.createQuery()
+					.createQuery( session )
 					.getResultList();
 		} );
 
@@ -193,11 +212,13 @@ public class SimpleQuerySpecificationTests {
 	void testBaseParameters(SessionFactoryScope factoryScope) {
 		final SQLStatementInspector sqlCollector = factoryScope.getCollectingStatementInspector();
 
+		final SessionFactory factory = factoryScope.getSessionFactory();
+
 		factoryScope.inTransaction( (session) -> {
 			sqlCollector.clear();
-			session.createSelectionSpecification( "from BasicEntity where id > :id", BasicEntity.class )
+			SelectionSpecification.create( factory, BasicEntity.class, "from BasicEntity where id > :id" )
 					.addRestriction( Restriction.restrict( BasicEntity_.position, Range.closed( 1, 5 ) ) )
-					.createQuery()
+					.createQuery( session )
 					.setParameter( "id", 200 )
 					.getResultList();
 		} );
@@ -208,9 +229,10 @@ public class SimpleQuerySpecificationTests {
 
 	@Test
 	void testIllegalSelection(SessionFactoryScope factoryScope) {
+		final SessionFactory factory = factoryScope.getSessionFactory();
 		factoryScope.inTransaction( (session) -> {
 			try {
-				session.createSelectionSpecification( "delete BasicEntity", BasicEntity.class );
+				SelectionSpecification.create( factory, BasicEntity.class, "delete BasicEntity" );
 				fail( "Expecting a IllegalSelectQueryException, but not thrown" );
 			}
 			catch (IllegalSelectQueryException expected) {
@@ -220,9 +242,10 @@ public class SimpleQuerySpecificationTests {
 
 	@Test
 	void testIllegalMutation(SessionFactoryScope factoryScope) {
+		final SessionFactory factory = factoryScope.getSessionFactory();
 		factoryScope.inTransaction( (session) -> {
 			try {
-				session.createMutationSpecification( "from BasicEntity", BasicEntity.class );
+				MutationSpecification.create( factory, BasicEntity.class, "from BasicEntity" );
 				fail( "Expecting a IllegalMutationQueryException, but not thrown" );
 			}
 			catch (IllegalMutationQueryException expected) {

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/query/dynamic/SimpleQuerySpecificationTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/query/dynamic/SimpleQuerySpecificationTests.java
@@ -11,6 +11,7 @@ import org.hibernate.query.Order;
 import org.hibernate.query.programmatic.MutationSpecification;
 import org.hibernate.query.programmatic.SelectionSpecification;
 import org.hibernate.query.range.Range;
+import org.hibernate.query.restriction.Path;
 import org.hibernate.query.restriction.Restriction;
 import org.hibernate.testing.jdbc.SQLStatementInspector;
 import org.hibernate.testing.orm.junit.DomainModel;
@@ -26,7 +27,7 @@ import static org.junit.jupiter.api.Assertions.fail;
  * @author Steve Ebersole
  */
 @SuppressWarnings("JUnitMalformedDeclaration")
-@DomainModel(annotatedClasses = BasicEntity.class)
+@DomainModel(annotatedClasses = {BasicEntity.class, OtherEntity.class})
 @org.hibernate.testing.orm.junit.SessionFactory(useCollectingStatementInspector = true)
 public class SimpleQuerySpecificationTests {
 	@Test
@@ -184,6 +185,7 @@ public class SimpleQuerySpecificationTests {
 			query.where( criteriaBuilder.like( entity.get( BasicEntity_.name ), "%" ) );
 			SelectionSpecification.create( query )
 					.addOrdering( Order.asc( BasicEntity_.position ) )
+					.addFetching( Path.from(BasicEntity.class).to( BasicEntity_.other ) )
 					.createQuery( session )
 					.getResultList();
 		} );

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/query/dynamic/SimpleQuerySpecificationTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/query/dynamic/SimpleQuerySpecificationTests.java
@@ -33,11 +33,9 @@ public class SimpleQuerySpecificationTests {
 	void testSimpleSelectionOrder(SessionFactoryScope factoryScope) {
 		final SQLStatementInspector sqlCollector = factoryScope.getCollectingStatementInspector();
 
-		final SessionFactory factory = factoryScope.getSessionFactory();
-
 		factoryScope.inTransaction( (session) -> {
 			sqlCollector.clear();
-			SelectionSpecification.create( factory, BasicEntity.class, "from BasicEntity" )
+			SelectionSpecification.create( BasicEntity.class, "from BasicEntity" )
 					.addOrdering( Order.asc( BasicEntity_.position ) )
 					.createQuery( session )
 					.list();
@@ -51,11 +49,9 @@ public class SimpleQuerySpecificationTests {
 	void testSimpleSelectionOrderMultiple(SessionFactoryScope factoryScope) {
 		final SQLStatementInspector sqlCollector = factoryScope.getCollectingStatementInspector();
 
-		final SessionFactory factory = factoryScope.getSessionFactory();
-
 		factoryScope.inTransaction( (session) -> {
 			sqlCollector.clear();
-			SelectionSpecification.create( factory, BasicEntity.class, "from BasicEntity" )
+			SelectionSpecification.create( BasicEntity.class, "from BasicEntity" )
 					.addOrdering( Order.asc( BasicEntity_.position ) )
 					.addOrdering( Order.asc( BasicEntity_.id ) )
 					.createQuery( session )
@@ -70,11 +66,9 @@ public class SimpleQuerySpecificationTests {
 	void testSimpleSelectionSetOrdering(SessionFactoryScope factoryScope) {
 		final SQLStatementInspector sqlCollector = factoryScope.getCollectingStatementInspector();
 
-		final SessionFactory factory = factoryScope.getSessionFactory();
-
 		factoryScope.inTransaction( (session) -> {
 			sqlCollector.clear();
-			SelectionSpecification.create( factory, BasicEntity.class, "from BasicEntity" )
+			SelectionSpecification.create( BasicEntity.class, "from BasicEntity" )
 					.setOrdering( Order.asc( BasicEntity_.position ) )
 					.createQuery( session )
 					.list();
@@ -88,11 +82,9 @@ public class SimpleQuerySpecificationTests {
 	void testSimpleSelectionSetOrderingMultiple(SessionFactoryScope factoryScope) {
 		final SQLStatementInspector sqlCollector = factoryScope.getCollectingStatementInspector();
 
-		final SessionFactory factory = factoryScope.getSessionFactory();
-
 		factoryScope.inTransaction( (session) -> {
 			sqlCollector.clear();
-			SelectionSpecification.create( factory, BasicEntity.class, "from BasicEntity" )
+			SelectionSpecification.create( BasicEntity.class, "from BasicEntity" )
 					.setOrdering( List.of( Order.asc( BasicEntity_.position ), Order.asc( BasicEntity_.id ) ) )
 					.createQuery( session )
 					.list();
@@ -106,11 +98,9 @@ public class SimpleQuerySpecificationTests {
 	void testSimpleSelectionSetOrderingReplace(SessionFactoryScope factoryScope) {
 		final SQLStatementInspector sqlCollector = factoryScope.getCollectingStatementInspector();
 
-		final SessionFactory factory = factoryScope.getSessionFactory();
-
 		factoryScope.inTransaction( (session) -> {
 			sqlCollector.clear();
-			SelectionSpecification.create( factory, BasicEntity.class, "from BasicEntity" )
+			SelectionSpecification.create( BasicEntity.class, "from BasicEntity" )
 					.setOrdering( Order.asc( BasicEntity_.id ) )
 					.setOrdering( Order.asc( BasicEntity_.position ) )
 					.createQuery( session )
@@ -122,7 +112,7 @@ public class SimpleQuerySpecificationTests {
 
 		factoryScope.inTransaction( (session) -> {
 			sqlCollector.clear();
-			SelectionSpecification.create( factory, BasicEntity.class, "from BasicEntity" )
+			SelectionSpecification.create( BasicEntity.class, "from BasicEntity" )
 					.addOrdering( Order.asc( BasicEntity_.id ) )
 					.setOrdering( Order.asc( BasicEntity_.position ) )
 					.createQuery( session )
@@ -137,11 +127,9 @@ public class SimpleQuerySpecificationTests {
 	void testSimpleSelectionRestriction(SessionFactoryScope factoryScope) {
 		final SQLStatementInspector sqlCollector = factoryScope.getCollectingStatementInspector();
 
-		final SessionFactory factory = factoryScope.getSessionFactory();
-
 		factoryScope.inTransaction( (session) -> {
 			sqlCollector.clear();
-			SelectionSpecification.create( factory, BasicEntity.class, "from BasicEntity" )
+			SelectionSpecification.create( BasicEntity.class, "from BasicEntity" )
 					.addRestriction( Restriction.restrict( BasicEntity_.position, Range.closed( 1, 5 ) ) )
 					.createQuery( session )
 					.list();
@@ -155,11 +143,9 @@ public class SimpleQuerySpecificationTests {
 	void testSimpleMutationRestriction(SessionFactoryScope factoryScope) {
 		final SQLStatementInspector sqlCollector = factoryScope.getCollectingStatementInspector();
 
-		final SessionFactory factory = factoryScope.getSessionFactory();
-
 		factoryScope.inTransaction( (session) -> {
 			sqlCollector.clear();
-			MutationSpecification.create( factory, BasicEntity.class, "delete BasicEntity" )
+			MutationSpecification.create( BasicEntity.class, "delete BasicEntity" )
 					.addRestriction( Restriction.restrict( BasicEntity_.position, Range.closed( 1, 5 ) ) )
 					.createQuery( session )
 					.executeUpdate();
@@ -173,11 +159,9 @@ public class SimpleQuerySpecificationTests {
 	void testRootEntityForm(SessionFactoryScope factoryScope) {
 		final SQLStatementInspector sqlCollector = factoryScope.getCollectingStatementInspector();
 
-		final SessionFactory factory = factoryScope.getSessionFactory();
-
 		factoryScope.inTransaction( (session) -> {
 			sqlCollector.clear();
-			SelectionSpecification.create( factory, BasicEntity.class )
+			SelectionSpecification.create( BasicEntity.class )
 					.addOrdering( Order.asc( BasicEntity_.position ) )
 					.createQuery( session )
 					.getResultList();
@@ -212,11 +196,9 @@ public class SimpleQuerySpecificationTests {
 	void testBaseParameters(SessionFactoryScope factoryScope) {
 		final SQLStatementInspector sqlCollector = factoryScope.getCollectingStatementInspector();
 
-		final SessionFactory factory = factoryScope.getSessionFactory();
-
 		factoryScope.inTransaction( (session) -> {
 			sqlCollector.clear();
-			SelectionSpecification.create( factory, BasicEntity.class, "from BasicEntity where id > :id" )
+			SelectionSpecification.create( BasicEntity.class, "from BasicEntity where id > :id" )
 					.addRestriction( Restriction.restrict( BasicEntity_.position, Range.closed( 1, 5 ) ) )
 					.createQuery( session )
 					.setParameter( "id", 200 )
@@ -230,26 +212,24 @@ public class SimpleQuerySpecificationTests {
 	@Test
 	void testIllegalSelection(SessionFactoryScope factoryScope) {
 		final SessionFactory factory = factoryScope.getSessionFactory();
-		factoryScope.inTransaction( (session) -> {
-			try {
-				SelectionSpecification.create( factory, BasicEntity.class, "delete BasicEntity" );
-				fail( "Expecting a IllegalSelectQueryException, but not thrown" );
-			}
-			catch (IllegalSelectQueryException expected) {
-			}
-		} );
+		try {
+			SelectionSpecification.create( BasicEntity.class, "delete BasicEntity" )
+					.validate( factory );
+			fail( "Expecting a IllegalSelectQueryException, but not thrown" );
+		}
+		catch (IllegalSelectQueryException expected) {
+		}
 	}
 
 	@Test
 	void testIllegalMutation(SessionFactoryScope factoryScope) {
 		final SessionFactory factory = factoryScope.getSessionFactory();
-		factoryScope.inTransaction( (session) -> {
-			try {
-				MutationSpecification.create( factory, BasicEntity.class, "from BasicEntity" );
-				fail( "Expecting a IllegalMutationQueryException, but not thrown" );
-			}
-			catch (IllegalMutationQueryException expected) {
-			}
-		} );
+		try {
+			MutationSpecification.create( BasicEntity.class, "from BasicEntity" )
+					.validate( factory );
+			fail( "Expecting a IllegalMutationQueryException, but not thrown" );
+		}
+		catch (IllegalMutationQueryException expected) {
+		}
 	}
 }

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/query/dynamic/SimpleQuerySpecificationTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/query/dynamic/SimpleQuerySpecificationTests.java
@@ -193,6 +193,23 @@ public class SimpleQuerySpecificationTests {
 	}
 
 	@Test
+	void testCriteriaFormWithMutation(SessionFactoryScope factoryScope) {
+		final SQLStatementInspector sqlCollector = factoryScope.getCollectingStatementInspector();
+
+		factoryScope.inTransaction( (session) -> {
+			sqlCollector.clear();
+			SelectionSpecification.create( BasicEntity.class )
+					.mutate( (builder, query, entity) -> query.where( builder.like( entity.get( BasicEntity_.name ), "%" ) ) )
+					.addOrdering( Order.asc( BasicEntity_.position ) )
+					.createQuery( session )
+					.getResultList();
+		} );
+
+		assertThat( sqlCollector.getSqlQueries() ).hasSize( 1 );
+		assertThat( sqlCollector.getSqlQueries().get( 0 ) ).contains( " order by be1_0.position" );
+	}
+
+	@Test
 	void testBaseParameters(SessionFactoryScope factoryScope) {
 		final SQLStatementInspector sqlCollector = factoryScope.getCollectingStatementInspector();
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/query/dynamic/SimpleQuerySpecificationTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/query/dynamic/SimpleQuerySpecificationTests.java
@@ -169,6 +169,27 @@ public class SimpleQuerySpecificationTests {
 	}
 
 	@Test
+	void testCriteriaForm(SessionFactoryScope factoryScope) {
+		final SQLStatementInspector sqlCollector = factoryScope.getCollectingStatementInspector();
+
+		factoryScope.inTransaction( (session) -> {
+			sqlCollector.clear();
+			var criteriaBuilder = session.getCriteriaBuilder();
+			var query = criteriaBuilder.createQuery( BasicEntity.class );
+			var entity = query.from( BasicEntity.class );
+			query.select( entity );
+			query.where( criteriaBuilder.like( entity.get( BasicEntity_.name ), "%" ) );
+			session.createSelectionSpecification( query )
+					.addOrdering( Order.asc( BasicEntity_.position ) )
+					.createQuery()
+					.getResultList();
+		} );
+
+		assertThat( sqlCollector.getSqlQueries() ).hasSize( 1 );
+		assertThat( sqlCollector.getSqlQueries().get( 0 ) ).contains( " order by be1_0.position" );
+	}
+
+	@Test
 	void testBaseParameters(SessionFactoryScope factoryScope) {
 		final SQLStatementInspector sqlCollector = factoryScope.getCollectingStatementInspector();
 


### PR DESCRIPTION
Usage looks like:

```java
var books = 
        SelectionSpecification.create(Book.class)
                 .addRestriction(Restriction.like(Book_.title, "%Hibernate%", false))
                 .addRestriction(Restriction.greaterThan(Book_.pages, 100))
                 .addFetching(Path.from(Book.class).to(Book_.authors))
                 .setOrder(Order.desc(Book_.title))
                 .createQuery(session)
                 .getResultList();
```

Looks just like ye olde Hibernate criteria, but perfectly type safe!

Also now allowed:

```java
var books = 
	SelectionSpecification.create(Book.class)
	          .addAugmentation((builder, query, book) -> 
	                  query.where(builder.like(book.get(Book_.title), "%Hibernate%")))
                  .addFetching(Path.from(Book.class).to(Book_.authors))
	          .addOrdering(Order.asc(Book_.title))
	          .createQuery(session)
	          .getResultList();
```

That is .... actually really nice.

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-19364
<!-- Hibernate GitHub Bot issue links end -->