### PR TITLE
HHH-19364 make Specification subtypes into TypedQueryReferences

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/internal/AbstractSharedSessionContract.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/AbstractSharedSessionContract.java
@@ -73,8 +73,8 @@ import org.hibernate.query.criteria.JpaCriteriaInsert;
 import org.hibernate.query.hql.spi.SqmQueryImplementor;
 import org.hibernate.query.named.NamedObjectRepository;
 import org.hibernate.query.named.NamedResultSetMappingMemento;
-import org.hibernate.query.programmatic.MutationSpecification;
-import org.hibernate.query.programmatic.SelectionSpecification;
+import org.hibernate.query.specification.internal.MutationSpecificationImpl;
+import org.hibernate.query.specification.internal.SelectionSpecificationImpl;
 import org.hibernate.query.spi.HqlInterpretation;
 import org.hibernate.query.spi.QueryImplementor;
 import org.hibernate.query.sql.internal.NativeQueryImpl;
@@ -905,11 +905,11 @@ public abstract class AbstractSharedSessionContract implements SharedSessionCont
 	@Override
 	public <R> QueryImplementor<R> createQuery(TypedQueryReference<R> typedQueryReference) {
 		checksBeforeQueryCreation();
-		if ( typedQueryReference instanceof SelectionSpecification<R> specification ) {
+		if ( typedQueryReference instanceof SelectionSpecificationImpl<R> specification ) {
 			final CriteriaQuery<R> query = specification.buildCriteria( getCriteriaBuilder() );
 			return new QuerySqmImpl<>( (SqmStatement<R>) query, specification.getResultType(), this );
 		}
-		else if ( typedQueryReference instanceof MutationSpecification<?> specification ) {
+		else if ( typedQueryReference instanceof MutationSpecificationImpl<?> specification ) {
 			final CommonAbstractCriteria query = specification.buildCriteria( getCriteriaBuilder() );
 			return new QuerySqmImpl<>( (SqmStatement<R>) query, (Class<R>) specification.getResultType(), this );
 		}

--- a/hibernate-core/src/main/java/org/hibernate/query/specification/MutationSpecification.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/specification/MutationSpecification.java
@@ -4,11 +4,13 @@
  */
 package org.hibernate.query.specification;
 
+import jakarta.persistence.TypedQueryReference;
 import jakarta.persistence.criteria.CommonAbstractCriteria;
 import jakarta.persistence.criteria.CriteriaUpdate;
 import jakarta.persistence.criteria.CriteriaDelete;
 import jakarta.persistence.criteria.CriteriaBuilder;
 import jakarta.persistence.criteria.Root;
+
 import org.hibernate.Incubating;
 import org.hibernate.Session;
 import org.hibernate.StatelessSession;
@@ -37,7 +39,7 @@ import org.hibernate.query.restriction.Restriction;
  * @since 7.0
  */
 @Incubating
-public interface MutationSpecification<T> extends QuerySpecification<T> {
+public interface MutationSpecification<T> extends QuerySpecification<T>, TypedQueryReference<Void> {
 
 	/**
 	 * Covariant override.
@@ -78,6 +80,9 @@ public interface MutationSpecification<T> extends QuerySpecification<T> {
 
 	@Override
 	MutationSpecification<T> validate(CriteriaBuilder builder);
+
+	@Override
+	Class<Void> getResultType();
 
 	/**
 	 * Returns a specification reference which can be used to programmatically,

--- a/hibernate-core/src/main/java/org/hibernate/query/specification/MutationSpecification.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/specification/MutationSpecification.java
@@ -39,7 +39,7 @@ import org.hibernate.query.restriction.Restriction;
  * @since 7.0
  */
 @Incubating
-public interface MutationSpecification<T> extends QuerySpecification<T>, TypedQueryReference<Void> {
+public interface MutationSpecification<T> extends QuerySpecification<T> {
 
 	/**
 	 * Covariant override.
@@ -82,7 +82,7 @@ public interface MutationSpecification<T> extends QuerySpecification<T>, TypedQu
 	MutationSpecification<T> validate(CriteriaBuilder builder);
 
 	@Override
-	Class<Void> getResultType();
+	TypedQueryReference<Void> reference();
 
 	/**
 	 * Returns a specification reference which can be used to programmatically,

--- a/hibernate-core/src/main/java/org/hibernate/query/specification/QuerySpecification.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/specification/QuerySpecification.java
@@ -5,6 +5,7 @@
 package org.hibernate.query.specification;
 
 import jakarta.persistence.EntityManager;
+import jakarta.persistence.TypedQueryReference;
 import jakarta.persistence.criteria.CriteriaBuilder;
 import jakarta.persistence.criteria.CommonAbstractCriteria;
 
@@ -87,4 +88,11 @@ public interface QuerySpecification<T> {
 	 * @throws Exception if it ain't all good
 	 */
 	QuerySpecification<T> validate(CriteriaBuilder builder);
+
+	/**
+	 * Obtain a {@linkplain TypedQueryReference reference}
+	 * to this specification which may be passed along to
+	 * {@link EntityManager#createQuery(TypedQueryReference)}.
+	 */
+	TypedQueryReference<?> reference();
 }

--- a/hibernate-core/src/main/java/org/hibernate/query/specification/SelectionSpecification.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/specification/SelectionSpecification.java
@@ -5,6 +5,7 @@
 package org.hibernate.query.specification;
 
 import jakarta.persistence.EntityManager;
+import jakarta.persistence.TypedQueryReference;
 import jakarta.persistence.criteria.CriteriaQuery;
 import jakarta.persistence.criteria.CriteriaBuilder;
 import jakarta.persistence.criteria.Root;
@@ -59,7 +60,7 @@ import java.util.List;
  * @since 7.0
  */
 @Incubating
-public interface SelectionSpecification<T> extends QuerySpecification<T> {
+public interface SelectionSpecification<T> extends QuerySpecification<T>, TypedQueryReference<T> {
 	/**
 	 * Adds an ordering to the selection specification.
 	 * Appended to any previous ordering.
@@ -184,6 +185,9 @@ public interface SelectionSpecification<T> extends QuerySpecification<T> {
 
 	@Override
 	SelectionSpecification<T> validate(CriteriaBuilder builder);
+
+	@Override
+	Class<T> getResultType();
 
 	/**
 	 * Returns a specification reference which can be used to programmatically,

--- a/hibernate-core/src/main/java/org/hibernate/query/specification/SelectionSpecification.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/specification/SelectionSpecification.java
@@ -4,8 +4,8 @@
  */
 package org.hibernate.query.specification;
 
-import jakarta.persistence.EntityManager;
 import jakarta.persistence.TypedQueryReference;
+import jakarta.persistence.EntityManager;
 import jakarta.persistence.criteria.CriteriaQuery;
 import jakarta.persistence.criteria.CriteriaBuilder;
 import jakarta.persistence.criteria.Root;
@@ -60,7 +60,7 @@ import java.util.List;
  * @since 7.0
  */
 @Incubating
-public interface SelectionSpecification<T> extends QuerySpecification<T>, TypedQueryReference<T> {
+public interface SelectionSpecification<T> extends QuerySpecification<T> {
 	/**
 	 * Adds an ordering to the selection specification.
 	 * Appended to any previous ordering.
@@ -187,7 +187,7 @@ public interface SelectionSpecification<T> extends QuerySpecification<T>, TypedQ
 	SelectionSpecification<T> validate(CriteriaBuilder builder);
 
 	@Override
-	Class<T> getResultType();
+	TypedQueryReference<T> reference();
 
 	/**
 	 * Returns a specification reference which can be used to programmatically,

--- a/hibernate-core/src/main/java/org/hibernate/query/specification/internal/MutationSpecificationImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/specification/internal/MutationSpecificationImpl.java
@@ -5,6 +5,7 @@
 package org.hibernate.query.specification.internal;
 
 import jakarta.persistence.EntityManager;
+import jakarta.persistence.TypedQueryReference;
 import jakarta.persistence.criteria.CriteriaBuilder;
 import jakarta.persistence.criteria.CriteriaDelete;
 import jakarta.persistence.criteria.CriteriaUpdate;
@@ -46,7 +47,7 @@ import static org.hibernate.query.sqm.tree.SqmCopyContext.noParamCopyContext;
  *
  * @author Steve Ebersole
  */
-public class MutationSpecificationImpl<T> implements MutationSpecification<T> {
+public class MutationSpecificationImpl<T> implements MutationSpecification<T>, TypedQueryReference<Void> {
 
 	private final List<BiConsumer<SqmDeleteOrUpdateStatement<T>, SqmRoot<T>>> specifications = new ArrayList<>();
 	private final String hql;
@@ -84,6 +85,11 @@ public class MutationSpecificationImpl<T> implements MutationSpecification<T> {
 	@Override
 	public Map<String,Object> getHints() {
 		return Collections.emptyMap();
+	}
+
+	@Override
+	public TypedQueryReference<Void> reference() {
+		return this;
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/query/specification/internal/MutationSpecificationImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/specification/internal/MutationSpecificationImpl.java
@@ -33,8 +33,10 @@ import org.hibernate.query.sqm.tree.predicate.SqmPredicate;
 import org.hibernate.query.sqm.tree.update.SqmUpdateStatement;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import java.util.function.BiConsumer;
 
 import static org.hibernate.query.sqm.tree.SqmCopyContext.noParamCopyContext;
@@ -67,6 +69,21 @@ public class MutationSpecificationImpl<T> implements MutationSpecification<T> {
 		this.deleteOrUpdateStatement = (SqmDeleteStatement<T>) criteriaQuery;
 		this.mutationTarget = deleteOrUpdateStatement.getTarget().getManagedType().getJavaType();
 		this.hql = null;
+	}
+
+	@Override
+	public String getName() {
+		return null;
+	}
+
+	@Override
+	public Class<Void> getResultType() {
+		return Void.class;
+	}
+
+	@Override
+	public Map<String,Object> getHints() {
+		return Collections.emptyMap();
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/query/specification/internal/SelectionSpecificationImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/specification/internal/SelectionSpecificationImpl.java
@@ -36,6 +36,7 @@ import org.hibernate.query.sqm.tree.select.SqmSortSpecification;
 import org.hibernate.type.descriptor.java.JavaType;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -72,6 +73,21 @@ public class SelectionSpecificationImpl<T> implements SelectionSpecification<T> 
 		this.resultType = criteriaQuery.getResultType();
 		this.hql = null;
 		this.criteriaQuery = criteriaQuery;
+	}
+
+	@Override
+	public String getName() {
+		return null;
+	}
+
+	@Override
+	public Class<T> getResultType() {
+		return resultType;
+	}
+
+	@Override
+	public Map<String,Object> getHints() {
+		return Collections.emptyMap();
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/query/specification/internal/SelectionSpecificationImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/specification/internal/SelectionSpecificationImpl.java
@@ -5,6 +5,7 @@
 package org.hibernate.query.specification.internal;
 
 import jakarta.persistence.EntityManager;
+import jakarta.persistence.TypedQueryReference;
 import jakarta.persistence.criteria.CriteriaQuery;
 import jakarta.persistence.criteria.CriteriaBuilder;
 
@@ -51,7 +52,7 @@ import static org.hibernate.query.sqm.tree.SqmCopyContext.noParamCopyContext;
  *
  * @author Steve Ebersole
  */
-public class SelectionSpecificationImpl<T> implements SelectionSpecification<T> {
+public class SelectionSpecificationImpl<T> implements SelectionSpecification<T>, TypedQueryReference<T> {
 	private final Class<T> resultType;
 	private final String hql;
 	private final CriteriaQuery<T> criteriaQuery;
@@ -88,6 +89,11 @@ public class SelectionSpecificationImpl<T> implements SelectionSpecification<T> 
 	@Override
 	public Map<String,Object> getHints() {
 		return Collections.emptyMap();
+	}
+
+	@Override
+	public TypedQueryReference<T> reference() {
+		return this;
 	}
 
 	@Override

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/query/dynamic/SimpleQuerySpecificationTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/query/dynamic/SimpleQuerySpecificationTests.java
@@ -306,7 +306,7 @@ public class SimpleQuerySpecificationTests {
 			var spec = SelectionSpecification.create( BasicEntity.class )
 					.restrict( Restriction.restrict( BasicEntity_.position, Range.closed( 1, 5 ) ) )
 					.sort( Order.asc( BasicEntity_.position ) );
-			session.createQuery(spec).getResultList();
+			session.createQuery(spec.reference()).getResultList();
 		} );
 
 		assertThat( sqlCollector.getSqlQueries() ).hasSize( 1 );

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/query/dynamic/SimpleQuerySpecificationTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/query/dynamic/SimpleQuerySpecificationTests.java
@@ -296,4 +296,21 @@ public class SimpleQuerySpecificationTests {
 						.validate( factory.getCriteriaBuilder() )
 						.buildCriteria( factory.getCriteriaBuilder() );
 	}
+
+	@Test
+	void testUseAsTypedQueryRef(SessionFactoryScope factoryScope) {
+		final SQLStatementInspector sqlCollector = factoryScope.getCollectingStatementInspector();
+
+		factoryScope.inTransaction( (session) -> {
+			sqlCollector.clear();
+			var spec = SelectionSpecification.create( BasicEntity.class )
+					.restrict( Restriction.restrict( BasicEntity_.position, Range.closed( 1, 5 ) ) )
+					.sort( Order.asc( BasicEntity_.position ) );
+			session.createQuery(spec).getResultList();
+		} );
+
+		assertThat( sqlCollector.getSqlQueries() ).hasSize( 1 );
+		assertThat( sqlCollector.getSqlQueries().get( 0 ) ).contains( " order by be1_0.position" );
+	}
+
 }


### PR DESCRIPTION
<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

[Please describe here what your change is about]

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-19364
<!-- Hibernate GitHub Bot issue links end -->