### PR TITLE
MutationSpecificationImpl#getResultType must return null (and not Void.class)

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/query/specification/internal/MutationSpecificationImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/specification/internal/MutationSpecificationImpl.java
@@ -79,7 +79,7 @@ public class MutationSpecificationImpl<T> implements MutationSpecification<T>, T
 
 	@Override
 	public Class<Void> getResultType() {
-		return Void.class;
+		return null;
 	}
 
 	@Override

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/query/dynamic/SimpleQuerySpecificationTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/query/dynamic/SimpleQuerySpecificationTests.java
@@ -161,6 +161,22 @@ public class SimpleQuerySpecificationTests {
 	}
 
 	@Test
+	void testSimpleMutationRestrictionAsReference(SessionFactoryScope factoryScope) {
+		final SQLStatementInspector sqlCollector = factoryScope.getCollectingStatementInspector();
+		var deleteBasicEntity = MutationSpecification
+				.create( BasicEntity.class, "delete BasicEntity" )
+				.restrict( Restriction.restrict( BasicEntity_.position, Range.closed( 1, 5 ) ) )
+				.reference();
+		factoryScope.inTransaction( session -> {
+			sqlCollector.clear();
+			session.createQuery( deleteBasicEntity ).executeUpdate();
+		} );
+
+		assertThat( sqlCollector.getSqlQueries() ).hasSize( 1 );
+		assertThat( sqlCollector.getSqlQueries().get( 0 ) ).contains( " where be1_0.position between ? and ?" );
+	}
+
+	@Test
 	void testRootEntityForm(SessionFactoryScope factoryScope) {
 		final SQLStatementInspector sqlCollector = factoryScope.getCollectingStatementInspector();
 


### PR DESCRIPTION
Fix https://hibernate.atlassian.net/browse/HHH-19386

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
