### PR TITLE
Add test with stateless session for HHH-19386

### DIFF
--- a/hibernate-core/src/test/java/org/hibernate/orm/test/query/dynamic/SimpleQuerySpecificationTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/query/dynamic/SimpleQuerySpecificationTests.java
@@ -177,6 +177,22 @@ public class SimpleQuerySpecificationTests {
 	}
 
 	@Test
+	void testSimpleMutationRestrictionStatelessAsReference(SessionFactoryScope factoryScope) {
+		final SQLStatementInspector sqlCollector = factoryScope.getCollectingStatementInspector();
+		var deleteBasicEntity = MutationSpecification
+				.create( BasicEntity.class, "delete BasicEntity" )
+				.restrict( Restriction.restrict( BasicEntity_.position, Range.closed( 1, 5 ) ) )
+				.reference();
+		factoryScope.inStatelessTransaction( statelessSession -> {
+			sqlCollector.clear();
+			statelessSession.createQuery( deleteBasicEntity ).executeUpdate();
+		} );
+
+		assertThat( sqlCollector.getSqlQueries() ).hasSize( 1 );
+		assertThat( sqlCollector.getSqlQueries().get( 0 ) ).contains( " where be1_0.position between ? and ?" );
+	}
+
+	@Test
 	void testRootEntityForm(SessionFactoryScope factoryScope) {
 		final SQLStatementInspector sqlCollector = factoryScope.getCollectingStatementInspector();
 


### PR DESCRIPTION
Follows https://github.com/hibernate/hibernate-orm/pull/10083

Because I forgot to add a test with the StatelessSession.

----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-19386
<!-- Hibernate GitHub Bot issue links end -->