### PR TITLE
HHH-17002, HHH-18820, HHH-19391, HHH-18514 equals() and hashCode() for SQM nodes

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/dialect/function/array/H2UnnestFunction.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/function/array/H2UnnestFunction.java
@@ -63,7 +63,6 @@ public class H2UnnestFunction extends UnnestFunction {
 	protected <T> SelfRenderingSqmSetReturningFunction<T> generateSqmSetReturningFunctionExpression(
 			List<? extends SqmTypedNode<?>> arguments,
 			QueryEngine queryEngine) {
-		//noinspection unchecked
 		return new SelfRenderingSqmSetReturningFunction<>(
 				this,
 				this,

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/internal/AnyDiscriminatorSqmPath.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/internal/AnyDiscriminatorSqmPath.java
@@ -13,6 +13,8 @@ import org.hibernate.query.sqm.tree.domain.AbstractSqmPath;
 import org.hibernate.query.sqm.tree.domain.SqmPath;
 import org.hibernate.spi.NavigablePath;
 
+import java.util.Objects;
+
 public class AnyDiscriminatorSqmPath<T> extends AbstractSqmPath<T> implements DiscriminatorSqmPath<T> {
 
 	protected AnyDiscriminatorSqmPath(
@@ -44,5 +46,17 @@ public class AnyDiscriminatorSqmPath<T> extends AbstractSqmPath<T> implements Di
 	@Override
 	public AnyDiscriminatorSqmPathSource<T> getExpressible() {
 		return (AnyDiscriminatorSqmPathSource<T>) getNodeType();
+	}
+
+
+	@Override
+	public boolean equals(Object object) {
+		return object instanceof AnyDiscriminatorSqmPath<?> that
+			&& Objects.equals( this.getLhs(), that.getLhs() );
+	}
+
+	@Override
+	public int hashCode() {
+		return getLhs().hashCode();
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/internal/EmbeddedDiscriminatorSqmPath.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/internal/EmbeddedDiscriminatorSqmPath.java
@@ -14,6 +14,8 @@ import org.hibernate.query.sqm.tree.domain.AbstractSqmPath;
 import org.hibernate.query.sqm.tree.domain.SqmPath;
 import org.hibernate.spi.NavigablePath;
 
+import java.util.Objects;
+
 /**
  * {@link SqmPath} specialization for an embeddable discriminator
  *
@@ -58,5 +60,16 @@ public class EmbeddedDiscriminatorSqmPath<T> extends AbstractSqmPath<T> implemen
 	@Override
 	public <X> X accept(SemanticQueryWalker<X> walker) {
 		return walker.visitDiscriminatorPath( this );
+	}
+
+	@Override
+	public boolean equals(Object object) {
+		return object instanceof EmbeddedDiscriminatorSqmPath<?> that
+			&& Objects.equals( this.getLhs(), that.getLhs() );
+	}
+
+	@Override
+	public int hashCode() {
+		return getLhs().hashCode();
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/internal/EntityDiscriminatorSqmPath.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/internal/EntityDiscriminatorSqmPath.java
@@ -17,6 +17,8 @@ import org.hibernate.query.sqm.tree.expression.SqmLiteralEntityType;
 import org.hibernate.query.sqm.tree.domain.SqmEntityDomainType;
 import org.hibernate.spi.NavigablePath;
 
+import java.util.Objects;
+
 /**
  * {@link SqmPath} specialization for an entity discriminator
  *
@@ -66,10 +68,19 @@ public class EntityDiscriminatorSqmPath<T> extends AbstractSqmPath<T> implements
 
 	@Override
 	public <X> X accept(SemanticQueryWalker<X> walker) {
-		if ( ! entityDescriptor.hasSubclasses() ) {
-			return walker.visitEntityTypeLiteralExpression( new SqmLiteralEntityType( entityDomainType, nodeBuilder() ) );
-		}
+		return entityDescriptor.hasSubclasses()
+				? walker.visitDiscriminatorPath( this )
+				: walker.visitEntityTypeLiteralExpression( new SqmLiteralEntityType( entityDomainType, nodeBuilder() ) );
+	}
 
-		return walker.visitDiscriminatorPath( this );
+	@Override
+	public boolean equals(Object object) {
+		return object instanceof EntityDiscriminatorSqmPath<?> that
+			&& Objects.equals( this.getLhs(), that.getLhs() );
+	}
+
+	@Override
+	public int hashCode() {
+		return getLhs().hashCode();
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/query/criteria/JpaCteContainer.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/criteria/JpaCteContainer.java
@@ -33,7 +33,11 @@ public interface JpaCteContainer extends JpaCriteriaNode {
 	 * which can be used for querying.
 	 *
 	 * @see JpaCriteriaQuery#from(JpaCteCriteria)
+	 *
+	 * @deprecated Use {@link #with(String, AbstractQuery)} and provide an explicit
+	 *             name for the CTE
 	 */
+	@Deprecated(since = "7", forRemoval = true)
 	<T> JpaCteCriteria<T> with(AbstractQuery<T> criteria);
 
 	/**

--- a/hibernate-core/src/main/java/org/hibernate/query/hql/internal/QuerySplitter.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/hql/internal/QuerySplitter.java
@@ -4,8 +4,6 @@
  */
 package org.hibernate.query.hql.internal;
 
-import java.util.Set;
-
 import org.hibernate.metamodel.model.domain.EntityDomainType;
 import org.hibernate.query.sqm.tree.SqmCopyContext;
 import org.hibernate.query.sqm.tree.SqmDeleteOrUpdateStatement;
@@ -30,24 +28,24 @@ public class QuerySplitter {
 		// We only allow unmapped polymorphism in a very restricted way.  Specifically,
 		// the unmapped polymorphic reference can only be a root and can be the only
 		// root.  Use that restriction to locate the unmapped polymorphic reference
-		final SqmRoot<?> unmappedPolymorphicReference = findUnmappedPolymorphicReference( statement.getQueryPart() );
-
+		final SqmRoot<?> unmappedPolymorphicReference =
+				findUnmappedPolymorphicReference( statement.getQueryPart() );
 		if ( unmappedPolymorphicReference == null ) {
 			@SuppressWarnings("unchecked")
 			SqmSelectStatement<R>[] sqmSelectStatement = new SqmSelectStatement[] { statement };
 			return sqmSelectStatement;
 		}
 
-		final SqmPolymorphicRootDescriptor<R> unmappedPolymorphicDescriptor = (SqmPolymorphicRootDescriptor<R>) unmappedPolymorphicReference.getReferencedPathSource();
-		final Set<EntityDomainType<? extends R>> implementors = unmappedPolymorphicDescriptor.getImplementors();
+		final var unmappedPolymorphicDescriptor =
+				(SqmPolymorphicRootDescriptor<R>)
+						unmappedPolymorphicReference.getReferencedPathSource();
+		var implementors = unmappedPolymorphicDescriptor.getImplementors();
 		@SuppressWarnings("unchecked")
 		final SqmSelectStatement<R>[] expanded = new SqmSelectStatement[ implementors.size() ];
-
 		int i = 0;
 		for ( EntityDomainType<?> mappedDescriptor : implementors ) {
 			expanded[i++] = copyStatement( statement, unmappedPolymorphicReference, mappedDescriptor );
 		}
-
 		return expanded;
 	}
 
@@ -97,31 +95,29 @@ public class QuerySplitter {
 		// We only allow unmapped polymorphism in a very restricted way.  Specifically,
 		// the unmapped polymorphic reference can only be a root and can be the only
 		// root.  Use that restriction to locate the unmapped polymorphic reference
-		final SqmRoot<?> unmappedPolymorphicReference = findUnmappedPolymorphicReference( statement );
-
+		final SqmRoot<?> unmappedPolymorphicReference =
+				findUnmappedPolymorphicReference( statement );
 		if ( unmappedPolymorphicReference == null ) {
 			@SuppressWarnings("unchecked")
 			SqmDeleteStatement<R>[] sqmDeleteStatement = new SqmDeleteStatement[] { statement };
 			return sqmDeleteStatement;
 		}
 
-		final SqmPolymorphicRootDescriptor<R> unmappedPolymorphicDescriptor =
-				(SqmPolymorphicRootDescriptor<R>) unmappedPolymorphicReference.getReferencedPathSource();
-		final Set<EntityDomainType<? extends R>> implementors = unmappedPolymorphicDescriptor.getImplementors();
+		final var unmappedPolymorphicDescriptor =
+				(SqmPolymorphicRootDescriptor<R>)
+						unmappedPolymorphicReference.getReferencedPathSource();
+		final var implementors = unmappedPolymorphicDescriptor.getImplementors();
 		@SuppressWarnings("unchecked")
 		final SqmDeleteStatement<R>[] expanded = new SqmDeleteStatement[ implementors.size() ];
-
 		int i = 0;
 		for ( EntityDomainType<?> mappedDescriptor : implementors ) {
 			expanded[i++] = copyStatement( statement, unmappedPolymorphicReference, mappedDescriptor );
 		}
-
 		return expanded;
 	}
 
 	private static SqmRoot<?> findUnmappedPolymorphicReference(SqmDeleteOrUpdateStatement<?> queryPart) {
-		return queryPart.getTarget().getReferencedPathSource() instanceof SqmPolymorphicRootDescriptor<?>
-				? queryPart.getTarget()
-				: null;
+		final SqmRoot<?> target = queryPart.getTarget();
+		return target.getReferencedPathSource() instanceof SqmPolymorphicRootDescriptor<?> ? target : null;
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/query/hql/internal/SemanticQueryBuilder.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/hql/internal/SemanticQueryBuilder.java
@@ -1229,7 +1229,7 @@ public class SemanticQueryBuilder<R> extends HqlParserBaseVisitor<Object> implem
 			final EntityDomainType<R> entityDescriptor = getResultEntity();
 			if ( entityDescriptor != null ) {
 				final SqmRoot<R> sqmRoot =
-						new SqmRoot<>( entityDescriptor, null, false, creationContext.getNodeBuilder() );
+						new SqmRoot<>( entityDescriptor, "_0", false, creationContext.getNodeBuilder() );
 				processingStateStack.getCurrent().getPathRegistry().register( sqmRoot );
 				fromClause.addRoot( sqmRoot );
 			}

--- a/hibernate-core/src/main/java/org/hibernate/query/hql/internal/SqmTreeCreationHelper.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/hql/internal/SqmTreeCreationHelper.java
@@ -134,24 +134,21 @@ public class SqmTreeCreationHelper {
 	 */
 	public static <E> void handleRootAsCrossJoin(
 			HqlParser.EntityWithJoinsContext entityWithJoinsContext,
-			SqmRoot<?> sqmPrimaryRoot,
+			SqmRoot<E> sqmPrimaryRoot,
 			SemanticQueryBuilder<?> sqmBuilder) {
-		final HqlParser.RootEntityContext fromRootContext = (HqlParser.RootEntityContext) entityWithJoinsContext.fromRoot();
+		final HqlParser.RootEntityContext fromRootContext =
+				(HqlParser.RootEntityContext) entityWithJoinsContext.fromRoot();
 
 		//noinspection unchecked
 		final SqmRoot<E> sqmRoot = (SqmRoot<E>) fromRootContext.accept( sqmBuilder );
 		SqmTreeCreationLogger.LOGGER.debugf( "Handling secondary root path as cross-join - %s", sqmRoot.getEntityName() );
-
-		final String alias = extractAlias( fromRootContext.variable(), sqmBuilder );
-		final SqmEntityJoin<?,E> pseudoCrossJoin = new SqmEntityJoin<>(
+		final SqmEntityJoin<E,E> pseudoCrossJoin = new SqmEntityJoin<>(
 				sqmRoot.getManagedType(),
-				alias,
+				extractAlias( fromRootContext.variable(), sqmBuilder ),
 				SqmJoinType.CROSS,
 				sqmPrimaryRoot
 		);
-
-		//noinspection unchecked,rawtypes
-		sqmPrimaryRoot.addSqmJoin( (SqmEntityJoin) pseudoCrossJoin );
+		sqmPrimaryRoot.addSqmJoin( pseudoCrossJoin );
 
 		final SqmCreationProcessingState processingState = sqmBuilder.getProcessingStateStack().getCurrent();
 		final SqmPathRegistry pathRegistry = processingState.getPathRegistry();

--- a/hibernate-core/src/main/java/org/hibernate/query/internal/QueryParameterBindingsImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/internal/QueryParameterBindingsImpl.java
@@ -162,7 +162,7 @@ public class QueryParameterBindingsImpl implements QueryParameterBindings {
 
 	@Override
 	public void validate() {
-		for ( Map.Entry<QueryParameter<?>, QueryParameterBinding<?>> entry : parameterBindingMap.entrySet() ) {
+		for ( var entry : parameterBindingMap.entrySet() ) {
 			if ( !entry.getValue().isBound() ) {
 				final QueryParameter<?> queryParameter = entry.getKey();
 				if ( queryParameter.isNamed() ) {

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/function/SelfRenderingSqmFunction.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/function/SelfRenderingSqmFunction.java
@@ -6,6 +6,7 @@ package org.hibernate.query.sqm.function;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.function.Supplier;
 
 import org.hibernate.metamodel.mapping.BasicValuedMapping;
@@ -256,4 +257,15 @@ public class SelfRenderingSqmFunction<T> extends SqmFunction<T> {
 		}
 	}
 
+	@Override
+	// TODO: override on all subtypes
+	public boolean equals(Object other) {
+		return other instanceof SelfRenderingSqmAggregateFunction<?> that
+			&& Objects.equals( this.toHqlString(), that.toHqlString() );
+	}
+
+	@Override
+	public int hashCode() {
+		return toHqlString().hashCode();
+	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/function/SelfRenderingSqmOrderedSetAggregateFunction.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/function/SelfRenderingSqmOrderedSetAggregateFunction.java
@@ -138,28 +138,31 @@ public class SelfRenderingSqmOrderedSetAggregateFunction<T> extends SelfRenderin
 		final List<? extends SqmTypedNode<?>> arguments = getArguments();
 		hql.append( getFunctionName() );
 		hql.append( '(' );
-		int i = 1;
-		if ( arguments.get( 0 ) instanceof SqmDistinct<?> ) {
-			arguments.get( 0 ).appendHqlString( hql, context );
-			if ( arguments.size() > 1 ) {
-				hql.append( ' ' );
-				arguments.get( 1 ).appendHqlString( hql, context );
-				i = 2;
+		if ( !arguments.isEmpty() ) {
+			int i = 1;
+			if ( arguments.get( 0 ) instanceof SqmDistinct<?> ) {
+				arguments.get( 0 ).appendHqlString( hql, context );
+				if ( arguments.size() > 1 ) {
+					hql.append( ' ' );
+					arguments.get( 1 ).appendHqlString( hql, context );
+					i = 2;
+				}
+			}
+			for ( ; i < arguments.size(); i++ ) {
+				hql.append( ", " );
+				arguments.get( i ).appendHqlString( hql, context );
 			}
 		}
-		for ( ; i < arguments.size(); i++ ) {
-			hql.append(", ");
-			arguments.get( i ).appendHqlString( hql, context );
-		}
-
 		hql.append( ')' );
 		if ( withinGroup != null ) {
 			hql.append( " within group (order by " );
 			final List<SqmSortSpecification> sortSpecifications = withinGroup.getSortSpecifications();
-			sortSpecifications.get( 0 ).appendHqlString( hql, context );
-			for ( int j = 1; j < sortSpecifications.size(); j++ ) {
-				hql.append( ", " );
-				sortSpecifications.get( j ).appendHqlString( hql, context );
+			if ( !sortSpecifications.isEmpty() ) {
+				sortSpecifications.get( 0 ).appendHqlString( hql, context );
+				for ( int j = 1; j < sortSpecifications.size(); j++ ) {
+					hql.append( ", " );
+					sortSpecifications.get( j ).appendHqlString( hql, context );
+				}
 			}
 			hql.append( ')' );
 		}

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/internal/SimpleSqmRenderContext.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/internal/SimpleSqmRenderContext.java
@@ -23,10 +23,9 @@ public class SimpleSqmRenderContext implements SqmRenderContext {
 	@Override
 	public String resolveAlias(SqmFrom<?, ?> from) {
 		final String explicitAlias = from.getExplicitAlias();
-		if ( explicitAlias != null ) {
-			return explicitAlias;
-		}
-		return fromAliases.computeIfAbsent( from, f -> "alias_" + (fromId++) );
+		return explicitAlias == null
+				? fromAliases.computeIfAbsent( from, f -> "alias_" + (fromId++) )
+				: explicitAlias;
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/internal/SqmCriteriaNodeBuilder.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/internal/SqmCriteriaNodeBuilder.java
@@ -577,8 +577,8 @@ public class SqmCriteriaNodeBuilder implements NodeBuilder, Serializable {
 
 	@Override
 	public SqmPredicate wrap(Expression<Boolean> expression) {
-		return expression instanceof SqmPredicate
-				? (SqmPredicate) expression
+		return expression instanceof SqmPredicate predicate
+				? predicate
 				: new SqmBooleanExpressionPredicate( (SqmExpression<Boolean>) expression, this );
 	}
 
@@ -607,7 +607,7 @@ public class SqmCriteriaNodeBuilder implements NodeBuilder, Serializable {
 		final SqmPathSource<?> toOneReference = sqmPath.getReferencedPathSource();
 		final boolean validToOneRef =
 				toOneReference.getBindableType() == Bindable.BindableType.SINGULAR_ATTRIBUTE
-				&& toOneReference instanceof EntitySqmPathSource;
+						&& toOneReference instanceof EntitySqmPathSource;
 		if ( !validToOneRef ) {
 			throw new FunctionArgumentException(
 					String.format(
@@ -670,8 +670,6 @@ public class SqmCriteriaNodeBuilder implements NodeBuilder, Serializable {
 			CriteriaQuery<? extends T> left,
 			CriteriaQuery<? extends T> right) {
 		assert operator == SetOperator.UNION || operator == SetOperator.UNION_ALL;
-		assert left instanceof SqmSelectStatement;
-		assert right instanceof SqmSelectStatement;
 		final SqmSelectStatement<? extends T> leftSqm = (SqmSelectStatement<? extends T>) left;
 		final SqmSelectStatement<? extends T> rightSqm = (SqmSelectStatement<? extends T>) right;
 
@@ -707,8 +705,6 @@ public class SqmCriteriaNodeBuilder implements NodeBuilder, Serializable {
 			CriteriaQuery<? super T> left,
 			CriteriaQuery<? super T> right) {
 		assert operator == SetOperator.INTERSECT || operator == SetOperator.INTERSECT_ALL;
-		assert left instanceof SqmSelectStatement;
-		assert right instanceof SqmSelectStatement;
 		final SqmSelectStatement<? extends T> leftSqm = (SqmSelectStatement<? extends T>) left;
 		final SqmSelectStatement<? extends T> rightSqm = (SqmSelectStatement<? extends T>) right;
 
@@ -744,8 +740,6 @@ public class SqmCriteriaNodeBuilder implements NodeBuilder, Serializable {
 			CriteriaQuery<T> left,
 			CriteriaQuery<?> right) {
 		assert operator == SetOperator.EXCEPT || operator == SetOperator.EXCEPT_ALL;
-		assert left instanceof SqmSelectStatement;
-		assert right instanceof SqmSelectStatement;
 		final SqmSelectStatement<? extends T> leftSqm = (SqmSelectStatement<? extends T>) left;
 		final SqmSelectStatement<? extends T> rightSqm = (SqmSelectStatement<? extends T>) right;
 

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/internal/SqmSelectionQueryImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/internal/SqmSelectionQueryImpl.java
@@ -165,6 +165,9 @@ public class SqmSelectionQueryImpl<R> extends AbstractSqmSelectionQuery<R>
 		this( criteria, session.isCriteriaCopyTreeEnabled(), expectedResultType, session );
 	}
 
+	/**
+	 * Form used for criteria queries
+	 */
 	public SqmSelectionQueryImpl(
 			SqmSelectStatement<R> criteria,
 			boolean copyAst,
@@ -173,27 +176,10 @@ public class SqmSelectionQueryImpl<R> extends AbstractSqmSelectionQuery<R>
 		super( session );
 		this.expectedResultType = expectedResultType;
 		hql = CRITERIA_HQL_STRING;
-		if ( copyAst ) {
-			sqm = criteria.copy( SqmCopyContext.simpleContext() );
-			if ( session.isCriteriaPlanCacheEnabled() ) {
-				queryStringCacheKey = sqm.toHqlString();
-				setQueryPlanCacheable( true );
-			}
-			else {
-				queryStringCacheKey = sqm;
-			}
-		}
-		else {
-			sqm = criteria;
-			if ( session.isCriteriaPlanCacheEnabled() ) {
-				queryStringCacheKey = sqm.toHqlString();
-			}
-			else {
-				queryStringCacheKey = sqm;
-			}
-			// Cache immutable query plans by default
-			setQueryPlanCacheable( true );
-		}
+		sqm = copyAst ? criteria.copy( SqmCopyContext.simpleContext() ) : criteria;
+		queryStringCacheKey = sqm;
+		// Cache immutable query plans by default
+		setQueryPlanCacheable( !copyAst || session.isCriteriaPlanCacheEnabled() );
 
 		domainParameterXref = DomainParameterXref.from( sqm );
 		parameterMetadata = domainParameterXref.hasParameters()

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/mutation/internal/SelectableMappingExpressionConverter.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/mutation/internal/SelectableMappingExpressionConverter.java
@@ -20,7 +20,7 @@ import org.hibernate.sql.ast.tree.from.TableGroup;
 /**
  * A function for producing an {@link Expression} from a {@link NavigablePath} for a {@link TableGroup} and {@link SelectableMapping}.
  */
-public class SelectableMappingExpressionConverter implements Function<SemanticQueryWalker, Expression> {
+public class SelectableMappingExpressionConverter implements Function<SemanticQueryWalker<?>, Expression> {
 
 	private final NavigablePath navigablePath;
 	private final SelectableMapping selectableMapping;
@@ -30,11 +30,11 @@ public class SelectableMappingExpressionConverter implements Function<SemanticQu
 		this.selectableMapping = selectableMapping;
 	}
 
-	public static SqmSelection<Object> forSelectableMapping(SqmFrom<?, ?> from, SelectableMapping selectableMapping) {
+	public static <T> SqmSelection<T> forSelectableMapping(SqmFrom<?, T> from, SelectableMapping selectableMapping) {
 		return new SqmSelection<>(
 				new SqmSelfRenderingExpression<>(
 						new SelectableMappingExpressionConverter( from.getNavigablePath(), selectableMapping ),
-						(SqmExpressible) selectableMapping.getJdbcMapping(),
+						(SqmExpressible<T>) selectableMapping.getJdbcMapping(),
 						from.nodeBuilder()
 				),
 				from.nodeBuilder()

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/spi/SqmCreationHelper.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/spi/SqmCreationHelper.java
@@ -6,6 +6,7 @@ package org.hibernate.query.sqm.spi;
 
 import java.util.List;
 
+import org.hibernate.Internal;
 import org.hibernate.metamodel.mapping.CollectionPart;
 import org.hibernate.metamodel.model.domain.PluralPersistentAttribute;
 import org.hibernate.query.criteria.JpaPredicate;
@@ -23,6 +24,7 @@ import static org.hibernate.internal.util.collections.CollectionHelper.isEmpty;
 /**
  * @author Steve Ebersole
  */
+@Internal
 public class SqmCreationHelper {
 
 	/**
@@ -39,17 +41,38 @@ public class SqmCreationHelper {
 	private static final AtomicLong UNIQUE_ID_COUNTER = new AtomicLong();
 
 	public static NavigablePath buildRootNavigablePath(String base, String alias) {
+		// call to determineAlias() currently prevents caching certain plans
 		return new NavigablePath( base, determineAlias( alias ) );
 	}
 
 	public static NavigablePath buildSubNavigablePath(NavigablePath lhs, String base, String alias) {
+		// call to determineAlias() currently prevents caching certain plans
 		return lhs.append( base, determineAlias( alias ) );
 	}
 
+	/**
+	 * DO NOT USE ME
+	 *
+	 * @deprecated This method returns a globally-unique alias which
+	 * introduces a temporal dependence in the query interpretation
+	 * process, leading to misses on the query interpretation cache.
+	 * Aliases only need to be unique in the scope of a given query,
+	 * and so alias generation should be contextual to the query.
+	 */
+	@Deprecated(since = "7")
 	public static String acquireUniqueAlias() {
 		return Long.toString(UNIQUE_ID_COUNTER.incrementAndGet());
 	}
 
+	/**
+	 * DO NOT USE ME
+	 *
+	 * @deprecated When the argument is null, this method returns a
+	 * globally-unique alias which introduces a temporal dependence
+	 * in the query interpretation process, leading to misses on the
+	 * query interpretation cache.
+	 */
+	@Deprecated(since = "7")
 	public static String determineAlias(String alias) {
 		// Make sure we always create a unique alias, otherwise we might use a wrong table group for the same join
 		if ( alias == null ) {

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/AbstractSqmDmlStatement.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/AbstractSqmDmlStatement.java
@@ -10,7 +10,6 @@ import org.hibernate.query.criteria.JpaCteCriteria;
 import org.hibernate.query.criteria.JpaRoot;
 import org.hibernate.query.sqm.NodeBuilder;
 import org.hibernate.query.sqm.SqmQuerySource;
-import org.hibernate.query.sqm.spi.SqmCreationHelper;
 import org.hibernate.query.sqm.tree.cte.SqmCteContainer;
 import org.hibernate.query.sqm.tree.cte.SqmCteStatement;
 import org.hibernate.query.sqm.tree.expression.SqmParameter;
@@ -94,21 +93,21 @@ public abstract class AbstractSqmDmlStatement<E>
 
 	@Override
 	public <X> JpaCteCriteria<X> with(AbstractQuery<X> criteria) {
-		return withInternal( SqmCreationHelper.acquireUniqueAlias(), criteria );
+		return withInternal( generateAlias(), criteria );
 	}
 
 	@Override
 	public <X> JpaCteCriteria<X> withRecursiveUnionAll(
 			AbstractQuery<X> baseCriteria,
 			Function<JpaCteCriteria<X>, AbstractQuery<X>> recursiveCriteriaProducer) {
-		return withInternal( SqmCreationHelper.acquireUniqueAlias(), baseCriteria, false, recursiveCriteriaProducer );
+		return withInternal( generateAlias(), baseCriteria, false, recursiveCriteriaProducer );
 	}
 
 	@Override
 	public <X> JpaCteCriteria<X> withRecursiveUnionDistinct(
 			AbstractQuery<X> baseCriteria,
 			Function<JpaCteCriteria<X>, AbstractQuery<X>> recursiveCriteriaProducer) {
-		return withInternal( SqmCreationHelper.acquireUniqueAlias(), baseCriteria, true, recursiveCriteriaProducer );
+		return withInternal( generateAlias(), baseCriteria, true, recursiveCriteriaProducer );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/AbstractSqmDmlStatement.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/AbstractSqmDmlStatement.java
@@ -10,6 +10,7 @@ import org.hibernate.query.criteria.JpaCteCriteria;
 import org.hibernate.query.criteria.JpaRoot;
 import org.hibernate.query.sqm.NodeBuilder;
 import org.hibernate.query.sqm.SqmQuerySource;
+import org.hibernate.query.sqm.spi.SqmCreationHelper;
 import org.hibernate.query.sqm.tree.cte.SqmCteContainer;
 import org.hibernate.query.sqm.tree.cte.SqmCteStatement;
 import org.hibernate.query.sqm.tree.expression.SqmParameter;
@@ -91,9 +92,10 @@ public abstract class AbstractSqmDmlStatement<E>
 		return (JpaCteCriteria<X>) cteStatements.get( cteName );
 	}
 
-	@Override
+	@Override @Deprecated
 	public <X> JpaCteCriteria<X> with(AbstractQuery<X> criteria) {
-		return withInternal( generateAlias(), criteria );
+		// Use of acquireUniqueAlias() results in interpretation cache miss
+		return withInternal( "_" + SqmCreationHelper.acquireUniqueAlias(), criteria );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/AbstractSqmRestrictedDmlStatement.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/AbstractSqmRestrictedDmlStatement.java
@@ -93,11 +93,9 @@ public abstract class AbstractSqmRestrictedDmlStatement<T> extends AbstractSqmDm
 	}
 
 	public void applyPredicate(SqmPredicate predicate) {
-		if ( predicate == null ) {
-			return;
+		if ( predicate != null ) {
+			initAndGetWhereClause().applyPredicate( predicate );
 		}
-
-		initAndGetWhereClause().applyPredicate( predicate );
 	}
 
 	public void setWhereClause(SqmWhereClause whereClause) {

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/AbstractSqmStatement.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/AbstractSqmStatement.java
@@ -4,7 +4,6 @@
  */
 package org.hibernate.query.sqm.tree;
 
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -18,6 +17,8 @@ import org.hibernate.query.sqm.tree.expression.ValueBindJpaCriteriaParameter;
 
 import jakarta.persistence.criteria.ParameterExpression;
 
+import static java.util.Collections.emptySet;
+import static java.util.Collections.unmodifiableSet;
 import static org.hibernate.query.sqm.tree.jpa.ParameterCollector.collectParameters;
 
 /**
@@ -77,7 +78,7 @@ public abstract class AbstractSqmStatement<T> extends AbstractSqmNode implements
 			return collectParameters( this );
 		}
 
-		return parameters == null ? Collections.emptySet() : Collections.unmodifiableSet( parameters );
+		return parameters == null ? emptySet() : unmodifiableSet( parameters );
 	}
 
 	@Override
@@ -96,5 +97,12 @@ public abstract class AbstractSqmStatement<T> extends AbstractSqmNode implements
 		return getSqmParameters().stream()
 				.filter( parameterExpression -> !( parameterExpression instanceof ValueBindJpaCriteriaParameter ) )
 				.collect( Collectors.toSet() );
+	}
+
+	private int aliasCounter = 0;
+
+	@Override
+	public String generateAlias() {
+		return "_" + (++aliasCounter);
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/AbstractSqmStatement.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/AbstractSqmStatement.java
@@ -103,6 +103,6 @@ public abstract class AbstractSqmStatement<T> extends AbstractSqmNode implements
 
 	@Override
 	public String generateAlias() {
-		return "_" + (++aliasCounter);
+		return "t_" + (++aliasCounter);
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/SqmQuery.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/SqmQuery.java
@@ -14,4 +14,6 @@ import org.hibernate.query.criteria.JpaCriteriaBase;
 public interface SqmQuery<T> extends JpaCriteriaBase, SqmNode {
 	@Override
 	SqmQuery<T> copy(SqmCopyContext context);
+
+	String generateAlias();
 }

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/cte/SqmCteStatement.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/cte/SqmCteStatement.java
@@ -7,6 +7,7 @@ package org.hibernate.query.sqm.tree.cte;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 import java.util.function.Function;
 
 import org.hibernate.query.criteria.JpaCteCriteria;
@@ -339,12 +340,12 @@ public class SqmCteStatement<T> extends AbstractSqmNode implements SqmVisitableN
 		if ( getMaterialization() != CteMaterialization.UNDEFINED ) {
 			hql.append( getMaterialization() ).append( ' ' );
 		}
-		if ( getCteDefinition() instanceof SqmSubQuery<?> ) {
-			( (SqmSubQuery<?>) getCteDefinition() ).appendHqlString( hql, context );
+		if ( getCteDefinition() instanceof SqmSubQuery<?> subQuery ) {
+			subQuery.appendHqlString( hql, context );
 		}
-		else {
+		else if ( getCteDefinition() instanceof SqmSelectStatement<?> selectStatement ) {
 			hql.append( '(' );
-			( (SqmSelectStatement<?>) getCteDefinition() ).appendHqlString( hql, context );
+			selectStatement.appendHqlString( hql, context );
 			hql.append( ')' );
 		}
 		String separator;
@@ -403,5 +404,28 @@ public class SqmCteStatement<T> extends AbstractSqmNode implements SqmVisitableN
 				hql.append( getCyclePathAttributeName() );
 			}
 		}
+	}
+
+	@Override
+	public boolean equals(Object object) {
+		return object instanceof SqmCteStatement<?> that
+			&& Objects.equals( cteTable, that.cteTable )
+			&& Objects.equals( cteDefinition, that.cteDefinition )
+			&& materialization == that.materialization
+			&& searchClauseKind == that.searchClauseKind
+			&& Objects.equals( searchBySpecifications, that.searchBySpecifications )
+			&& Objects.equals( searchAttributeName, that.searchAttributeName )
+			&& Objects.equals( cycleAttributes, that.cycleAttributes )
+			&& Objects.equals( cycleMarkAttributeName, that.cycleMarkAttributeName )
+			&& Objects.equals( cyclePathAttributeName, that.cyclePathAttributeName )
+			&& Objects.equals( cycleValue, that.cycleValue )
+			&& Objects.equals( noCycleValue, that.noCycleValue );
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash( cteTable, cteDefinition, materialization,
+				searchClauseKind, searchBySpecifications, searchAttributeName,
+				cycleAttributes, cycleMarkAttributeName, cyclePathAttributeName, cycleValue, noCycleValue );
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/cte/SqmCteTable.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/cte/SqmCteTable.java
@@ -97,11 +97,11 @@ public class SqmCteTable<T> extends AnonymousTupleType<T> implements JpaCteCrite
 
 	@Override
 	public String getName() {
-		if ( Character.isDigit( name.charAt( 0 ) ) ) {
-			// Created through JPA criteria without an explicit name
-			return null;
-		}
-		return name;
+		// TODO: this is extremely fragile!
+		//       better to distinguish between generated and explicit aliases
+		return name.charAt( 0 ) == '_'
+				? null // Created through JPA criteria without an explicit name
+				: name;
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/delete/SqmDeleteStatement.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/delete/SqmDeleteStatement.java
@@ -5,6 +5,7 @@
 package org.hibernate.query.sqm.tree.delete;
 
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 
 import org.hibernate.query.criteria.JpaCriteriaDelete;
@@ -41,7 +42,7 @@ public class SqmDeleteStatement<T>
 		super(
 				new SqmRoot<>(
 						nodeBuilder.getDomainModel().entity( targetEntity ),
-						null,
+						"_0",
 						!nodeBuilder.isJpaQueryComplianceEnabled(),
 						nodeBuilder
 				),
@@ -111,6 +112,20 @@ public class SqmDeleteStatement<T>
 		SqmFromClause.appendJoins( root, hql, context );
 		SqmFromClause.appendTreatJoins( root, hql, context );
 		super.appendHqlString( hql, context );
+	}
+
+	@Override
+	public boolean equals(Object node) {
+		return node instanceof SqmDeleteStatement<?> that
+			&& super.equals( node )
+			&& Objects.equals( this.getTarget(), that.getTarget() )
+			&& Objects.equals( this.getWhereClause(), that.getWhereClause() )
+			&& Objects.equals( this.getCteStatements(), that.getCteStatements() );
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash( super.hashCode(), getTarget(), getWhereClause(), getCteStatements() );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/domain/AbstractSqmAttributeJoin.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/domain/AbstractSqmAttributeJoin.java
@@ -21,6 +21,8 @@ import org.hibernate.type.descriptor.java.JavaType;
 
 import jakarta.persistence.criteria.JoinType;
 
+import java.util.Objects;
+
 /**
  * Models a join based on a mapped attribute reference.
  *
@@ -91,11 +93,11 @@ public abstract class AbstractSqmAttributeJoin<L, R>
 	}
 
 	private void validateFetchAlias(String alias) {
-		if ( fetchJoin && alias != null && nodeBuilder().isJpaQueryComplianceEnabled() ) {
-			throw new IllegalStateException(
-					"The JPA specification does not permit specifying an alias for fetch joins."
-			);
-		}
+//		if ( fetchJoin && alias != null && nodeBuilder().isJpaQueryComplianceEnabled() ) {
+//			throw new IllegalStateException(
+//					"The JPA specification does not permit specifying an alias for fetch joins."
+//			);
+//		}
 	}
 
 	@Override
@@ -151,5 +153,16 @@ public abstract class AbstractSqmAttributeJoin<L, R>
 	@Override
 	public abstract <S extends R> SqmTreatedAttributeJoin<L, R, S> treatAs(EntityDomainType<S> treatTarget, String alias, boolean fetched);
 
+	@Override
+	public boolean equals(Object object) {
+		return object instanceof AbstractSqmAttributeJoin<?, ?> that
+			&& super.equals( object )
+			&& this.implicitJoin == that.implicitJoin
+			&& this.fetchJoin == that.fetchJoin;
+	}
 
+	@Override
+	public int hashCode() {
+		return Objects.hash( super.hashCode(), implicitJoin, fetchJoin );
+	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/domain/AbstractSqmFrom.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/domain/AbstractSqmFrom.java
@@ -6,7 +6,6 @@ package org.hibernate.query.sqm.tree.domain;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
@@ -62,6 +61,8 @@ import jakarta.persistence.metamodel.PluralAttribute;
 import jakarta.persistence.metamodel.SetAttribute;
 import jakarta.persistence.metamodel.SingularAttribute;
 
+import static java.util.Collections.emptyList;
+import static java.util.Collections.unmodifiableList;
 import static org.hibernate.query.sqm.internal.SqmUtil.findCompatibleFetchJoin;
 
 /**
@@ -207,7 +208,12 @@ public abstract class AbstractSqmFrom<O,T> extends AbstractSqmPath<T> implements
 
 	@Override
 	public List<SqmJoin<T, ?>> getSqmJoins() {
-		return joins == null ? Collections.emptyList() : Collections.unmodifiableList( joins );
+		return joins == null ? emptyList() : unmodifiableList( joins );
+	}
+
+	@Override
+	public int getNumberOfJoins() {
+		return joins == null ? 0 : joins.size();
 	}
 
 	@Override
@@ -222,13 +228,13 @@ public abstract class AbstractSqmFrom<O,T> extends AbstractSqmPath<T> implements
 	@Internal
 	public void removeLeftFetchJoins() {
 		if ( joins != null ) {
-			for ( SqmJoin<T, ?> join : new ArrayList<>(joins) ) {
+			for ( var join : new ArrayList<>( joins ) ) {
 				if ( join instanceof SqmAttributeJoin<T, ?> attributeJoin ) {
 					if ( attributeJoin.isFetched() ) {
 						if ( join.getSqmJoinType() == SqmJoinType.LEFT ) {
 							joins.remove( join );
-							final List<SqmJoin<?, ?>> orderedJoins = findRoot().getOrderedJoins();
-							if (orderedJoins != null) {
+							final var orderedJoins = findRoot().getOrderedJoins();
+							if ( orderedJoins != null ) {
 								orderedJoins.remove( join );
 							}
 						}
@@ -250,12 +256,12 @@ public abstract class AbstractSqmFrom<O,T> extends AbstractSqmPath<T> implements
 
 	@Override
 	public List<SqmTreatedFrom<?,?,?>> getSqmTreats() {
-		return treats == null ? Collections.emptyList() : treats;
+		return treats == null ? emptyList() : treats;
 	}
 
 	protected <S extends T, X extends SqmTreatedFrom<O,T,S>> X findTreat(ManagedDomainType<S> targetType, String alias) {
 		if ( treats != null ) {
-			for ( SqmFrom<?, ?> treat : treats ) {
+			for ( var treat : treats ) {
 				if ( treat.getModel() == targetType ) {
 					if ( Objects.equals( treat.getExplicitAlias(), alias ) ) {
 						//noinspection unchecked
@@ -341,7 +347,7 @@ public abstract class AbstractSqmFrom<O,T> extends AbstractSqmPath<T> implements
 		final SqmRoot<T> root = (SqmRoot<T>) findRoot();
 		final SqmEntityJoin<T, X> sqmEntityJoin = new SqmEntityJoin<>(
 				targetEntityDescriptor,
-				null,
+				generateAlias(),
 				joinType,
 				root
 		);
@@ -355,9 +361,12 @@ public abstract class AbstractSqmFrom<O,T> extends AbstractSqmPath<T> implements
 	}
 
 	@Override
-	@SuppressWarnings("unchecked")
 	public <E> SqmBagJoin<T, E> join(CollectionAttribute<? super T, E> attribute, JoinType jt) {
-		final SqmBagJoin<T, E> join = buildBagJoin( (BagPersistentAttribute<T, E>) attribute, SqmJoinType.from( jt ), false );
+		final SqmBagJoin<T, E> join = buildBagJoin(
+				(BagPersistentAttribute<? super T, E>) attribute,
+				SqmJoinType.from( jt ),
+				false
+		);
 		addSqmJoin( join );
 		return join;
 	}
@@ -418,8 +427,8 @@ public abstract class AbstractSqmFrom<O,T> extends AbstractSqmPath<T> implements
 	@Override
 	@SuppressWarnings("unchecked")
 	public <X, Y> SqmAttributeJoin<X, Y> join(String attributeName, JoinType jt) {
-		final SqmPathSource<Y> subPathSource = (SqmPathSource<Y>) getReferencedPathSource()
-				.getSubPathSource( attributeName );
+		final SqmPathSource<Y> subPathSource = (SqmPathSource<Y>)
+				getReferencedPathSource().getSubPathSource( attributeName );
 		return (SqmAttributeJoin<X, Y>) buildJoin( subPathSource, SqmJoinType.from( jt ), false );
 	}
 
@@ -565,40 +574,42 @@ public abstract class AbstractSqmFrom<O,T> extends AbstractSqmPath<T> implements
 	@Override
 	public <Y> SqmEntityJoin<T, Y> join(EntityType<Y> entity, JoinType joinType) {
 		//noinspection unchecked
-		final SqmEntityJoin<T,Y> join = new SqmEntityJoin<>( entity, null, joinType, (SqmRoot<T>) findRoot() );
+		final SqmEntityJoin<T,Y> join =
+				new SqmEntityJoin<>( entity, generateAlias(), joinType, (SqmRoot<T>) findRoot() );
 		addSqmJoin( join );
 		return join;
 	}
 
 	@Override
 	public <X> JpaDerivedJoin<X> join(Subquery<X> subquery) {
-		return join( subquery, SqmJoinType.INNER, false, null );
+		return join( subquery, SqmJoinType.INNER, false, generateAlias() );
 	}
 
 	@Override
 	public <X> JpaDerivedJoin<X> join(Subquery<X> subquery, SqmJoinType joinType) {
-		return join( subquery, joinType, false, null );
+		return join( subquery, joinType, false, generateAlias() );
 	}
 
 	@Override
 	public <X> JpaDerivedJoin<X> joinLateral(Subquery<X> subquery) {
-		return join( subquery, SqmJoinType.INNER, true, null );
+		return join( subquery, SqmJoinType.INNER, true, generateAlias() );
 	}
 
 	@Override
 	public <X> JpaDerivedJoin<X> joinLateral(Subquery<X> subquery, SqmJoinType joinType) {
-		return join( subquery, joinType, true, null );
+		return join( subquery, joinType, true, generateAlias() );
 	}
 
 	@Override
 	public <X> JpaDerivedJoin<X> join(Subquery<X> subquery, SqmJoinType joinType, boolean lateral) {
-		return join( subquery, joinType, lateral, null );
+		return join( subquery, joinType, lateral, generateAlias() );
 	}
 
 	public <X> JpaDerivedJoin<X> join(Subquery<X> subquery, SqmJoinType joinType, boolean lateral, String alias) {
 		validateComplianceFromSubQuery();
 		//noinspection unchecked
-		final JpaDerivedJoin<X> join = new SqmDerivedJoin<>( (SqmSubQuery<X>) subquery, alias, joinType, lateral, (SqmRoot<X>) findRoot() );
+		final JpaDerivedJoin<X> join =
+				new SqmDerivedJoin<>( (SqmSubQuery<X>) subquery, alias, joinType, lateral, (SqmRoot<X>) findRoot() );
 		//noinspection unchecked
 		addSqmJoin( (SqmJoin<T, ?>) join );
 		return join;
@@ -606,18 +617,19 @@ public abstract class AbstractSqmFrom<O,T> extends AbstractSqmPath<T> implements
 
 	@Override
 	public <X> SqmJoin<?, X> join(JpaCteCriteria<X> cte) {
-		return join( cte, SqmJoinType.INNER, null );
+		return join( cte, SqmJoinType.INNER, generateAlias() );
 	}
 
 	@Override
 	public <X> SqmJoin<?, X> join(JpaCteCriteria<X> cte, SqmJoinType joinType) {
-		return join( cte, joinType, null );
+		return join( cte, joinType, generateAlias() );
 	}
 
 	public <X> SqmJoin<?, X> join(JpaCteCriteria<X> cte, SqmJoinType joinType, String alias) {
 		validateComplianceFromSubQuery();
 		//noinspection unchecked
-		final SqmJoin<?, X> join = new SqmCteJoin<>( ( SqmCteStatement<X> ) cte, alias, joinType, (SqmRoot<X>) findRoot() );
+		final SqmJoin<?, X> join =
+				new SqmCteJoin<>( ( SqmCteStatement<X> ) cte, alias, joinType, (SqmRoot<X>) findRoot() );
 		//noinspection unchecked
 		addSqmJoin( (SqmJoin<T, ?>) join );
 		return join;
@@ -647,7 +659,13 @@ public abstract class AbstractSqmFrom<O,T> extends AbstractSqmPath<T> implements
 	public <X> JpaFunctionJoin<X> join(JpaSetReturningFunction<X> function, SqmJoinType joinType, boolean lateral) {
 		validateComplianceFromFunction();
 		//noinspection unchecked
-		final SqmFunctionJoin<X> join = new SqmFunctionJoin<>( (SqmSetReturningFunction<X>) function, alias, joinType, lateral, (SqmRoot<Object>) findRoot() );
+		final SqmFunctionJoin<X> join =
+				new SqmFunctionJoin<>(
+						(SqmSetReturningFunction<X>) function,
+						generateAlias(),
+						joinType, lateral,
+						(SqmRoot<Object>) findRoot()
+				);
 		//noinspection unchecked
 		addSqmJoin( (SqmJoin<T, ?>) join );
 		return join;
@@ -698,16 +716,16 @@ public abstract class AbstractSqmFrom<O,T> extends AbstractSqmPath<T> implements
 	private void validateComplianceFromSubQuery() {
 		if ( nodeBuilder().isJpaQueryComplianceEnabled() ) {
 			throw new IllegalStateException(
-					"The JPA specification does not support subqueries in the from clause. " +
-							"Please disable the JPA query compliance if you want to use this feature." );
+					"The JPA specification does not support subqueries in the from clause. "
+					+ "Please disable the JPA query compliance if you want to use this feature." );
 		}
 	}
 
 	private void validateComplianceFromFunction() {
 		if ( nodeBuilder().isJpaQueryComplianceEnabled() ) {
 			throw new IllegalStateException(
-					"The JPA specification does not support functions in the from clause. " +
-							"Please disable the JPA query compliance if you want to use this feature." );
+					"The JPA specification does not support functions in the from clause. "
+					+ "Please disable the JPA query compliance if you want to use this feature." );
 		}
 	}
 
@@ -719,7 +737,7 @@ public abstract class AbstractSqmFrom<O,T> extends AbstractSqmPath<T> implements
 	@Override
 	public <X> JpaCrossJoin<X> crossJoin(EntityDomainType<X> entity) {
 		final SqmCrossJoin<X> crossJoin =
-				new SqmCrossJoin<>( (SqmEntityDomainType<X>) entity, null, findRoot() );
+				new SqmCrossJoin<>( (SqmEntityDomainType<X>) entity, generateAlias(), findRoot() );
 		// noinspection unchecked
 		addSqmJoin( (SqmJoin<T, ?>) crossJoin );
 		return crossJoin;
@@ -741,8 +759,7 @@ public abstract class AbstractSqmFrom<O,T> extends AbstractSqmPath<T> implements
 
 	@Override
 	public <A> SqmSingularJoin<T, A> fetch(SingularAttribute<? super T, A> attribute, JoinType jt) {
-		final SqmSingularPersistentAttribute<? super T, A> persistentAttribute =
-				(SqmSingularPersistentAttribute<? super T, A>) attribute;
+		final var persistentAttribute = (SqmSingularPersistentAttribute<? super T, A>) attribute;
 		final SqmAttributeJoin<T, A> compatibleFetchJoin =
 				findCompatibleFetchJoin( this, persistentAttribute, SqmJoinType.from( jt ) );
 		if ( compatibleFetchJoin != null ) {
@@ -841,7 +858,7 @@ public abstract class AbstractSqmFrom<O,T> extends AbstractSqmPath<T> implements
 			return new SqmSingularJoin<>(
 					this,
 					attribute,
-					null,
+					generateAlias(),
 					joinType,
 					fetched,
 					nodeBuilder()
@@ -858,7 +875,7 @@ public abstract class AbstractSqmFrom<O,T> extends AbstractSqmPath<T> implements
 		return new SqmBagJoin<>(
 				this,
 				(SqmBagPersistentAttribute<? super T, E>) attribute,
-				null,
+				generateAlias(),
 				joinType,
 				fetched,
 				nodeBuilder()
@@ -872,7 +889,7 @@ public abstract class AbstractSqmFrom<O,T> extends AbstractSqmPath<T> implements
 		return new SqmListJoin<>(
 				this,
 				(SqmListPersistentAttribute<? super T, E>) attribute,
-				null,
+				generateAlias(),
 				joinType,
 				fetched,
 				nodeBuilder()
@@ -886,7 +903,7 @@ public abstract class AbstractSqmFrom<O,T> extends AbstractSqmPath<T> implements
 		return new SqmMapJoin<>(
 				this,
 				(SqmMapPersistentAttribute<? super T, K, V>) attribute,
-				null,
+				generateAlias(),
 				joinType,
 				fetched,
 				nodeBuilder()
@@ -900,7 +917,7 @@ public abstract class AbstractSqmFrom<O,T> extends AbstractSqmPath<T> implements
 		return new SqmSetJoin<>(
 				this,
 				(SqmSetPersistentAttribute<? super T, E>) attribute,
-				null,
+				generateAlias(),
 				joinType,
 				fetched,
 				nodeBuilder()
@@ -948,5 +965,11 @@ public abstract class AbstractSqmFrom<O,T> extends AbstractSqmPath<T> implements
 			setExplicitAlias( name );
 		}
 		return super.alias( name );
+	}
+
+	private int aliasCounter = 0;
+
+	private String generateAlias() {
+		return alias + "_" + (++aliasCounter);
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/domain/AbstractSqmJoin.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/domain/AbstractSqmJoin.java
@@ -21,6 +21,8 @@ import jakarta.persistence.criteria.Expression;
 import jakarta.persistence.criteria.JoinType;
 import jakarta.persistence.criteria.Predicate;
 
+import java.util.Objects;
+
 /**
  * @author Steve Ebersole
  */
@@ -150,5 +152,18 @@ public abstract class AbstractSqmJoin<L, R> extends AbstractSqmFrom<L, R> implem
 	@Override
 	public <X> SqmEntityJoin<R, X> join(Class<X> targetEntityClass, SqmJoinType joinType) {
 		return super.join( targetEntityClass, joinType );
+	}
+
+	@Override
+	public boolean equals(Object object) {
+		return object instanceof AbstractSqmJoin<?, ?> that
+			&& super.equals( object )
+			&& this.joinType == that.joinType; // unnecessary, but harmless
+//			&& Objects.equals( onClausePredicate, that.onClausePredicate ); // including this causes problems
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash( super.hashCode(), joinType );
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/domain/AbstractSqmPath.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/domain/AbstractSqmPath.java
@@ -6,10 +6,10 @@ package org.hibernate.query.sqm.tree.domain;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.function.Consumer;
 
 import org.hibernate.AssertionFailure;
@@ -34,6 +34,7 @@ import jakarta.persistence.metamodel.MapAttribute;
 import jakarta.persistence.metamodel.PluralAttribute;
 import jakarta.persistence.metamodel.SingularAttribute;
 
+import static java.util.Collections.emptyList;
 import static org.hibernate.internal.util.NullnessUtil.castNonNull;
 
 /**
@@ -45,8 +46,8 @@ public abstract class AbstractSqmPath<T> extends AbstractSqmExpression<T> implem
 
 	/**
 	 * For HQL and Criteria processing - used to track reusable paths relative to this path.
-	 * E.g., given `p.mate.mate` the SqmRoot identified by `p` would
-	 * have a reusable path for the `p.mate` path.
+	 * E.g., given {@code p.mate.mate} the {@code SqmRoot} identified by {@code p} would
+	 * have a reusable path for the {@code p.mate} path.
 	 */
 	private Map<String, SqmPath<?>> reusablePaths;
 
@@ -99,11 +100,8 @@ public abstract class AbstractSqmPath<T> extends AbstractSqmExpression<T> implem
 
 	@Override
 	public List<SqmPath<?>> getReusablePaths() {
-		if ( reusablePaths == null ) {
-			return Collections.emptyList();
-		}
+		return reusablePaths == null ? emptyList() : new ArrayList<>( reusablePaths.values() );
 
-		return new ArrayList<>( reusablePaths.values() );
 	}
 
 	@Override
@@ -131,10 +129,7 @@ public abstract class AbstractSqmPath<T> extends AbstractSqmExpression<T> implem
 
 	@Override
 	public SqmPath<?> getReusablePath(String name) {
-		if ( reusablePaths == null ) {
-			return null;
-		}
-		return reusablePaths.get( name );
+		return reusablePaths == null ? null : reusablePaths.get( name );
 	}
 
 	@Override
@@ -335,6 +330,22 @@ public abstract class AbstractSqmPath<T> extends AbstractSqmExpression<T> implem
 		return resolvePath( (PersistentAttribute<T, M>) attribute );
 	}
 
+	@Override
+	public boolean equals(Object object) {
+		return object instanceof AbstractSqmPath<?> that
+			&& this.getClass() == that.getClass()
+			&& Objects.equals( this.navigablePath, that.navigablePath )
+			&& Objects.equals( this.getExplicitAlias(), that.getExplicitAlias() );
+//			&& Objects.equals( this.lhs, that.lhs );
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash( navigablePath, getExplicitAlias() );
+//		return lhs == null ? 0 : lhs.hashCode();
+//		return navigablePath.hashCode();
+//		return Objects.hash( navigablePath, lhs );
+	}
 
 	@Override
 	public String toString() {

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/domain/AbstractSqmSimplePath.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/domain/AbstractSqmSimplePath.java
@@ -9,6 +9,7 @@ import org.hibernate.spi.NavigablePath;
 import org.hibernate.query.sqm.NodeBuilder;
 import org.hibernate.query.sqm.SqmPathSource;
 
+
 /**
  * @author Steve Ebersole
  */

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/domain/SqmCteRoot.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/domain/SqmCteRoot.java
@@ -14,6 +14,8 @@ import org.hibernate.query.sqm.tree.cte.SqmCteStatement;
 import org.hibernate.query.sqm.tree.from.SqmRoot;
 import org.hibernate.spi.NavigablePath;
 
+import java.util.Objects;
+
 /**
  * @author Christian Beikov
  */
@@ -98,5 +100,17 @@ public class SqmCteRoot<T> extends SqmRoot<T> implements JpaRoot<T> {
 	@Override
 	public SqmCorrelatedRoot<T> createCorrelation() {
 		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public boolean equals(Object object) {
+		return object instanceof SqmCteRoot<?> that
+			&& super.equals( object )
+			&& Objects.equals( this.cte, that.cte );
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash( super.hashCode(), cte );
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/domain/SqmDerivedRoot.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/domain/SqmDerivedRoot.java
@@ -17,6 +17,8 @@ import org.hibernate.query.sqm.tree.from.SqmRoot;
 import org.hibernate.query.sqm.tree.select.SqmSubQuery;
 import org.hibernate.spi.NavigablePath;
 
+import java.util.Objects;
+
 /**
  * @author Christian Beikov
  */
@@ -122,5 +124,17 @@ public class SqmDerivedRoot<T> extends SqmRoot<T> implements JpaDerivedRoot<T> {
 	@Override
 	public <S extends T> SqmTreatedRoot treatAs(EntityDomainType<S> treatTarget, String alias) {
 		throw new UnsupportedOperationException( "Derived roots can not be treated" );
+	}
+
+	@Override
+	public boolean equals(Object object) {
+		return object instanceof SqmDerivedRoot<?> that
+			&& super.equals( object )
+			&& Objects.equals( this.subQuery, that.subQuery );
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash( super.hashCode(), subQuery );
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/domain/SqmElementAggregateFunction.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/domain/SqmElementAggregateFunction.java
@@ -5,6 +5,7 @@
 package org.hibernate.query.sqm.tree.domain;
 
 import java.util.List;
+import java.util.Objects;
 
 import org.hibernate.metamodel.model.domain.PluralPersistentAttribute;
 import org.hibernate.metamodel.model.domain.ReturnableType;
@@ -114,8 +115,21 @@ public class SqmElementAggregateFunction<T> extends AbstractSqmSpecificPluralPar
 
 	@Override
 	public void appendHqlString(StringBuilder hql, SqmRenderContext context) {
-		hql.append(functionName).append( "(" );
+		hql.append( functionName ).append( "(" );
 		getLhs().appendHqlString( hql, context );
 		hql.append( ')' );
+	}
+
+	@Override
+	public boolean equals(Object object) {
+		return object instanceof SqmElementAggregateFunction<?> that
+			&& Objects.equals( this.functionName, that.functionName )
+			&& Objects.equals( this.getExplicitAlias(), that.getExplicitAlias() )
+			&& Objects.equals( this.getLhs(), that.getLhs() );
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash( getLhs(), functionName );
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/domain/SqmFkExpression.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/domain/SqmFkExpression.java
@@ -16,6 +16,8 @@ import org.hibernate.query.sqm.tree.SqmCopyContext;
 import org.hibernate.query.sqm.tree.SqmRenderContext;
 import org.hibernate.spi.NavigablePath;
 
+import java.util.Objects;
+
 /**
  * Reference to the key-side (as opposed to the target-side) of the
  * foreign-key of a to-one association.
@@ -62,6 +64,18 @@ public class SqmFkExpression<T> extends AbstractSqmPath<T> {
 	}
 
 	@Override
+	public boolean equals(Object object) {
+		return object instanceof SqmFkExpression<?> that
+			&& Objects.equals( this.getExplicitAlias(), that.getExplicitAlias() )
+			&& Objects.equals( this.getLhs(), that.getLhs() );
+	}
+
+	@Override
+	public int hashCode() {
+		return getLhs().hashCode();
+	}
+
+	@Override
 	public SqmFkExpression<T> copy(SqmCopyContext context) {
 		final SqmFkExpression<T> existing = context.getCopy( this );
 		if ( existing != null ) {
@@ -70,7 +84,7 @@ public class SqmFkExpression<T> extends AbstractSqmPath<T> {
 		final SqmEntityValuedSimplePath<?> lhsCopy = (SqmEntityValuedSimplePath<?>) getLhs().copy( context );
 		return context.registerCopy(
 				this,
-				new SqmFkExpression<T>( getNavigablePathCopy( lhsCopy ), lhsCopy )
+				new SqmFkExpression<>( getNavigablePathCopy( lhsCopy ), lhsCopy )
 		);
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/domain/SqmFunctionPath.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/domain/SqmFunctionPath.java
@@ -29,6 +29,8 @@ import jakarta.persistence.metamodel.Bindable;
 import jakarta.persistence.metamodel.ManagedType;
 import jakarta.persistence.metamodel.Type;
 
+import java.util.Objects;
+
 import static java.util.Arrays.asList;
 
 public class SqmFunctionPath<T> extends AbstractSqmPath<T> {
@@ -159,5 +161,17 @@ public class SqmFunctionPath<T> extends AbstractSqmPath<T> {
 	@Override
 	public <S extends T> SqmTreatedPath<T,S> treatAs(EntityDomainType<S> treatTarget) {
 		throw new TreatException( "Embeddable paths cannot be TREAT-ed" );
+	}
+
+	@Override
+	public boolean equals(Object object) {
+		return object instanceof SqmFunctionPath<?> that
+			&& super.equals( object )
+			&& Objects.equals( function, that.function );
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash( super.hashCode(), function );
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/domain/SqmFunctionRoot.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/domain/SqmFunctionRoot.java
@@ -17,6 +17,8 @@ import org.hibernate.query.sqm.tree.expression.SqmSetReturningFunction;
 import org.hibernate.query.sqm.tree.from.SqmRoot;
 import org.hibernate.spi.NavigablePath;
 
+import java.util.Objects;
+
 
 /**
  * @author Christian Beikov
@@ -138,5 +140,17 @@ public class SqmFunctionRoot<E> extends SqmRoot<E> implements JpaFunctionRoot<E>
 	@Override
 	public <S extends E> SqmTreatedRoot treatAs(EntityDomainType<S> treatTarget, String alias, boolean fetch) {
 		throw new UnsupportedOperationException( "Function roots can not be treated" );
+	}
+
+	@Override
+	public boolean equals(Object object) {
+		return object instanceof SqmFunctionRoot<?> that
+			&& super.equals( object )
+			&& Objects.equals( this.function, that.function );
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash( super.hashCode(), function );
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/domain/SqmIndexAggregateFunction.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/domain/SqmIndexAggregateFunction.java
@@ -5,6 +5,7 @@
 package org.hibernate.query.sqm.tree.domain;
 
 import java.util.List;
+import java.util.Objects;
 
 import org.hibernate.metamodel.mapping.CollectionPart;
 import org.hibernate.metamodel.model.domain.ReturnableType;
@@ -118,8 +119,23 @@ public class SqmIndexAggregateFunction<T> extends AbstractSqmSpecificPluralPartP
 
 	@Override
 	public void appendHqlString(StringBuilder hql, SqmRenderContext context) {
-		hql.append(functionName).append( "(" );
+		hql.append( functionName ).append( "(" );
 		getLhs().appendHqlString( hql, context );
 		hql.append( ')' );
+	}
+
+
+	@Override
+	public boolean equals(Object object) {
+		return object instanceof SqmIndexAggregateFunction<?> that
+			&& Objects.equals( this.functionName, that.functionName )
+			&& Objects.equals( this.getExplicitAlias(), that.getExplicitAlias() )
+			&& Objects.equals( this.getLhs(), that.getLhs() );
+
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash( getLhs(), functionName );
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/domain/SqmIndexedCollectionAccessPath.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/domain/SqmIndexedCollectionAccessPath.java
@@ -14,6 +14,8 @@ import org.hibernate.query.hql.spi.SqmCreationState;
 import org.hibernate.query.sqm.tree.SqmCopyContext;
 import org.hibernate.query.sqm.tree.expression.SqmExpression;
 
+import java.util.Objects;
+
 /**
  * @author Steve Ebersole
  */
@@ -98,5 +100,18 @@ public class SqmIndexedCollectionAccessPath<T> extends AbstractSqmPath<T> implem
 		hql.append( '[' );
 		selectorExpression.appendHqlString( hql, context );
 		hql.append( ']' );
+	}
+
+	@Override
+	public boolean equals(Object object) {
+		return object instanceof SqmIndexedCollectionAccessPath<?> that
+			&& Objects.equals( this.getExplicitAlias(), that.getExplicitAlias() )
+			&& Objects.equals( this.getLhs(), that.getLhs() )
+			&& Objects.equals( this.selectorExpression, that.selectorExpression );
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash( getLhs(), selectorExpression );
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/domain/SqmMapEntryReference.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/domain/SqmMapEntryReference.java
@@ -4,12 +4,8 @@
  */
 package org.hibernate.query.sqm.tree.domain;
 
-import java.util.Collection;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-import java.util.function.Consumer;
-
+import jakarta.persistence.criteria.Expression;
+import jakarta.persistence.criteria.Predicate;
 import org.hibernate.query.criteria.JpaSelection;
 import org.hibernate.query.sqm.NodeBuilder;
 import org.hibernate.query.sqm.SemanticQueryWalker;
@@ -19,8 +15,12 @@ import org.hibernate.query.sqm.tree.SqmRenderContext;
 import org.hibernate.query.sqm.tree.select.SqmSelectableNode;
 import org.hibernate.type.descriptor.java.JavaType;
 
-import jakarta.persistence.criteria.Expression;
-import jakarta.persistence.criteria.Predicate;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.Consumer;
 
 
 /**
@@ -138,6 +138,18 @@ public class SqmMapEntryReference<K,V>
 		hql.append( "entry(" );
 		mapPath.appendHqlString( hql, context );
 		hql.append( ')' );
+	}
+
+	@Override
+	public boolean equals(Object object) {
+		return object instanceof SqmMapEntryReference<?, ?> that
+			&& Objects.equals( mapPath, that.mapPath )
+			&& Objects.equals( explicitAlias, that.explicitAlias );
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash( mapPath, explicitAlias );
 	}
 
 	// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/domain/SqmTreatedBagJoin.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/domain/SqmTreatedBagJoin.java
@@ -17,6 +17,8 @@ import org.hibernate.spi.NavigablePath;
 import jakarta.persistence.criteria.Expression;
 import jakarta.persistence.criteria.Predicate;
 
+import java.util.Objects;
+
 /**
  * @author Steve Ebersole
  */
@@ -124,6 +126,19 @@ public class SqmTreatedBagJoin<L, R, S extends R> extends SqmBagJoin<L, S> imple
 		hql.append( " as " );
 		hql.append( treatTarget.getTypeName() );
 		hql.append( ')' );
+	}
+
+	@Override
+	public boolean equals(Object object) {
+		return object instanceof SqmTreatedBagJoin<?, ?, ?> that
+			&& Objects.equals( this.getExplicitAlias(), that.getExplicitAlias() )
+			&& Objects.equals( this.treatTarget.getTypeName(), that.treatTarget.getTypeName() )
+			&& Objects.equals( this.wrappedPath.getNavigablePath(), that.wrappedPath.getNavigablePath() );
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash( treatTarget.getTypeName(), wrappedPath.getNavigablePath() );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/domain/SqmTreatedCrossJoin.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/domain/SqmTreatedCrossJoin.java
@@ -11,6 +11,8 @@ import org.hibernate.query.sqm.tree.SqmRenderContext;
 import org.hibernate.query.sqm.tree.from.SqmCrossJoin;
 import org.hibernate.spi.NavigablePath;
 
+import java.util.Objects;
+
 /**
  * A TREAT form of {@linkplain SqmCrossJoin}
  *
@@ -97,6 +99,19 @@ public class SqmTreatedCrossJoin extends SqmCrossJoin implements SqmTreatedJoin 
 		hql.append( " as " );
 		hql.append( treatTarget.getName() );
 		hql.append( ')' );
+	}
+
+	@Override
+	public boolean equals(Object object) {
+		return object instanceof SqmTreatedCrossJoin that
+			&& Objects.equals( this.getExplicitAlias(), that.getExplicitAlias() )
+			&& Objects.equals( this.treatTarget.getName(), that.treatTarget.getName() )
+			&& Objects.equals( this.wrappedPath.getNavigablePath(), that.wrappedPath.getNavigablePath() );
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash( treatTarget.getName(), wrappedPath.getNavigablePath() );
 	}
 
 	@SuppressWarnings({ "rawtypes", "unchecked" })

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/domain/SqmTreatedEmbeddedValuedSimplePath.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/domain/SqmTreatedEmbeddedValuedSimplePath.java
@@ -11,6 +11,8 @@ import org.hibernate.query.sqm.tree.SqmCopyContext;
 import org.hibernate.query.sqm.tree.SqmRenderContext;
 import org.hibernate.spi.NavigablePath;
 
+import java.util.Objects;
+
 /**
  * @author Steve Ebersole
  */
@@ -115,5 +117,18 @@ public class SqmTreatedEmbeddedValuedSimplePath<T, S extends T> extends SqmEmbed
 		hql.append( " as " );
 		hql.append( treatTarget.getTypeName() );
 		hql.append( ')' );
+	}
+
+	@Override
+	public boolean equals(Object object) {
+		return object instanceof SqmTreatedEmbeddedValuedSimplePath<?, ?> that
+			&& Objects.equals( this.getExplicitAlias(), that.getExplicitAlias() )
+			&& Objects.equals( this.treatTarget.getTypeName(), that.treatTarget.getTypeName() )
+			&& Objects.equals( this.wrappedPath.getNavigablePath(), that.wrappedPath.getNavigablePath() );
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash( treatTarget.getTypeName(), wrappedPath.getNavigablePath() );
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/domain/SqmTreatedEntityJoin.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/domain/SqmTreatedEntityJoin.java
@@ -11,6 +11,8 @@ import org.hibernate.query.sqm.tree.SqmRenderContext;
 import org.hibernate.query.sqm.tree.from.SqmEntityJoin;
 import org.hibernate.spi.NavigablePath;
 
+import java.util.Objects;
+
 /**
  * @author Steve Ebersole
  */
@@ -103,5 +105,19 @@ public class SqmTreatedEntityJoin<L,R,S extends R> extends SqmEntityJoin<L,S> im
 		hql.append( " as " );
 		hql.append( treatTarget.getName() );
 		hql.append( ')' );
+	}
+
+
+	@Override
+	public boolean equals(Object object) {
+		return object instanceof SqmTreatedEntityJoin<?,?,?> that
+			&& Objects.equals( this.getExplicitAlias(), that.getExplicitAlias() )
+			&& Objects.equals( this.treatTarget.getName(), that.treatTarget.getName() )
+			&& Objects.equals( this.wrappedPath.getNavigablePath(), that.wrappedPath.getNavigablePath() );
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash( treatTarget.getName(), wrappedPath.getNavigablePath() );
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/domain/SqmTreatedEntityValuedSimplePath.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/domain/SqmTreatedEntityValuedSimplePath.java
@@ -12,6 +12,8 @@ import org.hibernate.query.sqm.tree.SqmCopyContext;
 import org.hibernate.query.sqm.tree.SqmRenderContext;
 import org.hibernate.spi.NavigablePath;
 
+import java.util.Objects;
+
 /**
  * @author Steve Ebersole
  */
@@ -140,5 +142,18 @@ public class SqmTreatedEntityValuedSimplePath<T, S extends T>
 		hql.append( " as " );
 		hql.append( treatTarget.getName() );
 		hql.append( ')' );
+	}
+
+	@Override
+	public boolean equals(Object object) {
+		return object instanceof SqmTreatedEntityValuedSimplePath<?, ?> that
+			&& Objects.equals( this.getExplicitAlias(), that.getExplicitAlias() )
+			&& Objects.equals( this.treatTarget.getTypeName(), that.treatTarget.getTypeName() )
+			&& Objects.equals( this.wrappedPath.getNavigablePath(), that.wrappedPath.getNavigablePath() );
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash( treatTarget.getTypeName(), wrappedPath.getNavigablePath() );
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/domain/SqmTreatedListJoin.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/domain/SqmTreatedListJoin.java
@@ -19,6 +19,8 @@ import org.hibernate.spi.NavigablePath;
 import jakarta.persistence.criteria.Expression;
 import jakarta.persistence.criteria.Predicate;
 
+import java.util.Objects;
+
 /**
  * @author Steve Ebersole
  */
@@ -155,5 +157,18 @@ public class SqmTreatedListJoin<O,T, S extends T> extends SqmListJoin<O,S> imple
 		hql.append( " as " );
 		hql.append( treatTarget.getTypeName() );
 		hql.append( ')' );
+	}
+
+	@Override
+	public boolean equals(Object object) {
+		return object instanceof SqmTreatedListJoin<?, ?, ?> that
+			&& Objects.equals( this.getExplicitAlias(), that.getExplicitAlias() )
+			&& Objects.equals( this.treatTarget.getTypeName(), that.treatTarget.getTypeName() )
+			&& Objects.equals( this.wrappedPath.getNavigablePath(), that.wrappedPath.getNavigablePath() );
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash( treatTarget.getTypeName(), wrappedPath.getNavigablePath() );
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/domain/SqmTreatedMapJoin.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/domain/SqmTreatedMapJoin.java
@@ -18,6 +18,8 @@ import org.hibernate.spi.NavigablePath;
 import jakarta.persistence.criteria.Expression;
 import jakarta.persistence.criteria.Predicate;
 
+import java.util.Objects;
+
 /**
  * @author Steve Ebersole
  */
@@ -164,5 +166,18 @@ public class SqmTreatedMapJoin<L, K, V, S extends V> extends SqmMapJoin<L, K, S>
 		hql.append( " as " );
 		hql.append( treatTarget.getTypeName() );
 		hql.append( ')' );
+	}
+
+	@Override
+	public boolean equals(Object object) {
+		return object instanceof SqmTreatedMapJoin<?, ?, ?, ?> that
+			&& Objects.equals( this.getExplicitAlias(), that.getExplicitAlias() )
+			&& Objects.equals( this.treatTarget.getTypeName(), that.treatTarget.getTypeName() )
+			&& Objects.equals( this.wrappedPath.getNavigablePath(), that.wrappedPath.getNavigablePath() );
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash( treatTarget.getTypeName(), wrappedPath.getNavigablePath() );
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/domain/SqmTreatedPluralPartJoin.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/domain/SqmTreatedPluralPartJoin.java
@@ -10,6 +10,8 @@ import org.hibernate.query.sqm.tree.SqmCopyContext;
 import org.hibernate.query.sqm.tree.SqmRenderContext;
 import org.hibernate.spi.NavigablePath;
 
+import java.util.Objects;
+
 /**
  * @author Steve Ebersole
  */
@@ -134,8 +136,6 @@ public class SqmTreatedPluralPartJoin extends SqmPluralPartJoin implements SqmTr
 		return super.treatAs( treatTarget, alias, fetch );
 	}
 
-
-
 	@Override
 	public void appendHqlString(StringBuilder hql, SqmRenderContext context) {
 		hql.append( "treat(" );
@@ -143,5 +143,19 @@ public class SqmTreatedPluralPartJoin extends SqmPluralPartJoin implements SqmTr
 		hql.append( " as " );
 		hql.append( treatTarget.getName() );
 		hql.append( ')' );
+	}
+
+
+	@Override
+	public boolean equals(Object object) {
+		return object instanceof SqmTreatedPluralPartJoin that
+			&& Objects.equals( this.getExplicitAlias(), that.getExplicitAlias() )
+			&& Objects.equals( this.treatTarget.getName(), that.treatTarget.getName() )
+			&& Objects.equals( this.wrappedPath.getNavigablePath(), that.wrappedPath.getNavigablePath() );
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash( treatTarget.getName(), wrappedPath.getNavigablePath() );
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/domain/SqmTreatedRoot.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/domain/SqmTreatedRoot.java
@@ -13,6 +13,8 @@ import org.hibernate.query.sqm.tree.SqmRenderContext;
 import org.hibernate.query.sqm.tree.from.SqmRoot;
 import org.hibernate.spi.NavigablePath;
 
+import java.util.Objects;
+
 /**
  * @author Steve Ebersole
  */
@@ -37,7 +39,7 @@ public class SqmTreatedRoot extends SqmRoot implements SqmTreatedFrom {
 		this.treatTarget = treatTarget;
 	}
 
-	@SuppressWarnings({ "unchecked", "rawtypes" })
+	@SuppressWarnings("unchecked")
 	private SqmTreatedRoot(
 			NavigablePath navigablePath,
 			SqmRoot wrappedPath,
@@ -123,5 +125,18 @@ public class SqmTreatedRoot extends SqmRoot implements SqmTreatedFrom {
 		hql.append( " as " );
 		hql.append( treatTarget.getName() );
 		hql.append( ')' );
+	}
+
+	@Override
+	public boolean equals(Object object) {
+		return object instanceof SqmTreatedRoot that
+			&& Objects.equals( this.getExplicitAlias(), that.getExplicitAlias() )
+			&& Objects.equals( this.treatTarget.getName(), that.treatTarget.getName() )
+			&& Objects.equals( this.wrappedPath.getNavigablePath(), that.wrappedPath.getNavigablePath() );
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash( wrappedPath.getNavigablePath(), treatTarget.getName() );
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/domain/SqmTreatedSetJoin.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/domain/SqmTreatedSetJoin.java
@@ -17,6 +17,8 @@ import org.hibernate.spi.NavigablePath;
 import jakarta.persistence.criteria.Expression;
 import jakarta.persistence.criteria.Predicate;
 
+import java.util.Objects;
+
 /**
  * @author Steve Ebersole
  */
@@ -124,6 +126,19 @@ public class SqmTreatedSetJoin<O,T, S extends T> extends SqmSetJoin<O,S> impleme
 		hql.append( " as " );
 		hql.append( treatTarget.getTypeName() );
 		hql.append( ')' );
+	}
+
+	@Override
+	public boolean equals(Object object) {
+		return object instanceof SqmTreatedSetJoin<?, ?, ?> that
+			&& Objects.equals( this.getExplicitAlias(), that.getExplicitAlias() )
+			&& Objects.equals( this.treatTarget.getTypeName(), that.treatTarget.getTypeName() )
+			&& Objects.equals( this.wrappedPath.getNavigablePath(), that.wrappedPath.getNavigablePath() );
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash( treatTarget.getTypeName(), wrappedPath.getNavigablePath() );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/domain/SqmTreatedSimplePath.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/domain/SqmTreatedSimplePath.java
@@ -12,6 +12,8 @@ import org.hibernate.query.sqm.tree.SqmCopyContext;
 import org.hibernate.query.sqm.tree.SqmRenderContext;
 import org.hibernate.spi.NavigablePath;
 
+import java.util.Objects;
+
 /**
  * @author Steve Ebersole
  */
@@ -141,5 +143,18 @@ public class SqmTreatedSimplePath<T, S extends T>
 		hql.append( " as " );
 		hql.append( treatTarget.getName() );
 		hql.append( ')' );
+	}
+
+	@Override
+	public boolean equals(Object object) {
+		return object instanceof SqmTreatedSimplePath<?, ?> that
+			&& Objects.equals( this.getExplicitAlias(), that.getExplicitAlias() )
+			&& Objects.equals( this.treatTarget.getName(), that.treatTarget.getName() )
+			&& Objects.equals( this.wrappedPath.getNavigablePath(), that.wrappedPath.getNavigablePath() );
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash( treatTarget.getName(), wrappedPath.getNavigablePath() );
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/domain/SqmTreatedSingularJoin.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/domain/SqmTreatedSingularJoin.java
@@ -17,6 +17,8 @@ import org.hibernate.spi.NavigablePath;
 import jakarta.persistence.criteria.Expression;
 import jakarta.persistence.criteria.Predicate;
 
+import java.util.Objects;
+
 /**
  * @author Steve Ebersole
  */
@@ -127,6 +129,19 @@ public class SqmTreatedSingularJoin<O,T, S extends T>
 		hql.append( " as " );
 		hql.append( treatTarget.getTypeName() );
 		hql.append( ')' );
+	}
+
+	@Override
+	public boolean equals(Object object) {
+		return object instanceof SqmTreatedSingularJoin<?, ?, ?> that
+			&& Objects.equals( this.getExplicitAlias(), that.getExplicitAlias() )
+			&& Objects.equals( this.treatTarget.getTypeName(), that.treatTarget.getTypeName() )
+			&& Objects.equals( this.wrappedPath.getNavigablePath(), that.wrappedPath.getNavigablePath() );
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash( treatTarget.getTypeName(), wrappedPath.getNavigablePath() );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/expression/AsWrapperSqmExpression.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/expression/AsWrapperSqmExpression.java
@@ -10,6 +10,8 @@ import org.hibernate.query.sqm.tree.SqmCopyContext;
 import org.hibernate.query.sqm.tree.SqmRenderContext;
 import org.hibernate.type.BasicType;
 
+import java.util.Objects;
+
 public class AsWrapperSqmExpression<T> extends AbstractSqmExpression<T> {
 	private final SqmExpression<?> expression;
 
@@ -49,5 +51,16 @@ public class AsWrapperSqmExpression<T> extends AbstractSqmExpression<T> {
 	@Override
 	public BasicType<T> getNodeType() {
 		return (BasicType<T>) super.getNodeType();
+	}
+
+	@Override
+	public boolean equals(Object object) {
+		return object instanceof AsWrapperSqmExpression<?> that
+			&& Objects.equals( this.expression, that.expression );
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hashCode( expression );
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/expression/JpaCriteriaParameter.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/expression/JpaCriteriaParameter.java
@@ -4,8 +4,6 @@
  */
 package org.hibernate.query.sqm.tree.expression;
 
-import java.util.Objects;
-
 import org.hibernate.procedure.spi.NamedCallableQueryMemento;
 import org.hibernate.query.BindableType;
 import org.hibernate.query.ParameterMetadata;
@@ -16,6 +14,8 @@ import org.hibernate.query.sqm.SemanticQueryWalker;
 import org.hibernate.query.sqm.SqmExpressible;
 import org.hibernate.query.sqm.tree.SqmCopyContext;
 import org.hibernate.query.sqm.tree.SqmRenderContext;
+
+import java.util.Objects;
 
 /**
  * {@link JpaParameterExpression} created via JPA {@link jakarta.persistence.criteria.CriteriaBuilder}.
@@ -140,39 +140,33 @@ public class JpaCriteriaParameter<T>
 
 	@Override
 	public void appendHqlString(StringBuilder hql, SqmRenderContext context) {
-		if ( getName() == null ) {
-			hql.append( ':' ).append( context.resolveParameterName( this ) );
-		}
-		else {
-			hql.append( ':' ).append( getName() );
-		}
+		hql.append( ':' ).append( name( context ) );
+	}
+
+	private String name(SqmRenderContext context) {
+		return name == null ? context.resolveParameterName( this ) : name;
 	}
 
 	@Override
-	public boolean equals(Object o) {
-		if ( this == o ) {
-			return true;
-		}
-		else if ( o == null ) {
-			return false;
-		}
-		else if ( !(o instanceof JpaCriteriaParameter<?> that) ) {
-			return false;
-		}
-		else {
-			return Objects.equals( name, that.name );
-		}
+	public int compareTo(SqmParameter parameter) {
+		return parameter instanceof JpaCriteriaParameter
+				? Integer.compare( hashCode(), parameter.hashCode() )
+				: 1;
+	}
+
+	// we can use value equality if the parameter has a name
+	// otherwise we must fall back to identity equality
+
+	@Override
+	public boolean equals(Object object) {
+		return this == object
+			|| object instanceof JpaCriteriaParameter<?> that
+				&& this.name != null && that.name != null
+				&& Objects.equals( this.name, that.name );
 	}
 
 	@Override
 	public int hashCode() {
-		return name == null ? super.hashCode() : Objects.hash( name );
-	}
-
-	@Override
-	public int compareTo(SqmParameter anotherParameter) {
-		return anotherParameter instanceof JpaCriteriaParameter
-				? Integer.compare( hashCode(), anotherParameter.hashCode() )
-				: 1;
+		return name == null ? super.hashCode() : name.hashCode();
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/expression/JpaCriteriaParameter.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/expression/JpaCriteriaParameter.java
@@ -148,8 +148,8 @@ public class JpaCriteriaParameter<T>
 	}
 
 	@Override
-	public int compareTo(SqmParameter parameter) {
-		return parameter instanceof JpaCriteriaParameter
+	public int compareTo(SqmParameter<T> parameter) {
+		return parameter instanceof JpaCriteriaParameter<T>
 				? Integer.compare( hashCode(), parameter.hashCode() )
 				: 1;
 	}

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/expression/SqmAliasedNodeRef.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/expression/SqmAliasedNodeRef.java
@@ -11,6 +11,8 @@ import org.hibernate.query.sqm.SemanticQueryWalker;
 import org.hibernate.query.sqm.SqmExpressible;
 import org.hibernate.query.sqm.tree.SqmCopyContext;
 
+import java.util.Objects;
+
 /**
  * Models a reference to a {@link org.hibernate.query.sqm.tree.select.SqmAliasedNode}
  * used in the order-by or group-by clause by either position or alias,
@@ -78,5 +80,18 @@ public class SqmAliasedNodeRef extends AbstractSqmExpression<Integer> {
 		else {
 			hql.append( navigablePath.getLocalName() );
 		}
+	}
+
+	@Override
+	public boolean equals(Object object) {
+		return object instanceof SqmAliasedNodeRef that
+			&& position == that.position
+			&& Objects.equals( navigablePath == null ? null : navigablePath.getLocalName(),
+				that.navigablePath == null ? null : that.navigablePath.getLocalName() );
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash( position, navigablePath == null ? null : navigablePath.getLocalName() );
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/expression/SqmAny.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/expression/SqmAny.java
@@ -13,6 +13,8 @@ import org.hibernate.query.sqm.tree.select.SqmSubQuery;
 
 import org.checkerframework.checker.nullness.qual.Nullable;
 
+import java.util.Objects;
+
 /**
  * @author Gavin King
  */
@@ -67,4 +69,14 @@ public class SqmAny<T> extends AbstractSqmExpression<T> {
 		subquery.appendHqlString( hql, context );
 	}
 
+	@Override
+	public boolean equals(Object object) {
+		return object instanceof SqmAny<?> sqmAny
+			&& Objects.equals( subquery, sqmAny.subquery );
+	}
+
+	@Override
+	public int hashCode() {
+		return subquery.hashCode();
+	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/expression/SqmAnyDiscriminatorValue.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/expression/SqmAnyDiscriminatorValue.java
@@ -16,6 +16,8 @@ import org.hibernate.query.sqm.tree.domain.SqmPath;
 import org.hibernate.query.sqm.tree.select.SqmSelectableNode;
 import org.hibernate.type.BasicType;
 
+import java.util.Objects;
+
 public class SqmAnyDiscriminatorValue<T> extends AbstractSqmExpression<T>
 		implements SqmSelectableNode<T>, SemanticPathPart {
 
@@ -94,5 +96,17 @@ public class SqmAnyDiscriminatorValue<T> extends AbstractSqmExpression<T>
 	@Override
 	public void appendHqlString(StringBuilder hql, SqmRenderContext context) {
 		hql.append( getEntityValue().getName() );
+	}
+
+	@Override
+	public boolean equals(Object object) {
+		return object instanceof SqmAnyDiscriminatorValue<?> that
+			&& Objects.equals( this.value.getName(), that.value.getName() )
+			&& Objects.equals( this.pathName, that.pathName );
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash( value.getName(), pathName );
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/expression/SqmBinaryArithmetic.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/expression/SqmBinaryArithmetic.java
@@ -13,6 +13,8 @@ import org.hibernate.query.sqm.tree.SqmCopyContext;
 import org.hibernate.query.sqm.tree.SqmRenderContext;
 import org.hibernate.query.sqm.tree.select.SqmSelectableNode;
 
+import java.util.Objects;
+
 import static org.hibernate.query.sqm.BinaryArithmeticOperator.ADD;
 import static org.hibernate.query.sqm.BinaryArithmeticOperator.SUBTRACT;
 import static org.hibernate.type.spi.TypeConfiguration.isDuration;
@@ -143,4 +145,16 @@ public class SqmBinaryArithmetic<T> extends AbstractSqmExpression<T> implements 
 		rhsOperand.appendHqlString( hql, context );
 	}
 
+	@Override
+	public boolean equals(Object object) {
+		return object instanceof SqmBinaryArithmetic<?> that
+			&& this.operator == that.operator
+			&& Objects.equals( this.lhsOperand, that.lhsOperand )
+			&& Objects.equals( this.rhsOperand, that.rhsOperand );
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash( lhsOperand, rhsOperand, operator );
+	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/expression/SqmByUnit.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/expression/SqmByUnit.java
@@ -10,6 +10,8 @@ import org.hibernate.query.sqm.SqmExpressible;
 import org.hibernate.query.sqm.tree.SqmCopyContext;
 import org.hibernate.query.sqm.tree.SqmRenderContext;
 
+import java.util.Objects;
+
 /**
  * @author Gavin King
  */
@@ -20,7 +22,7 @@ public class SqmByUnit extends AbstractSqmExpression<Long> {
 	public SqmByUnit(
 			SqmDurationUnit<?> unit,
 			SqmExpression<?> duration,
-			SqmExpressible longType,
+			SqmExpressible<Long> longType,
 			NodeBuilder nodeBuilder) {
 		super( longType, nodeBuilder );
 		this.unit = unit;
@@ -58,10 +60,23 @@ public class SqmByUnit extends AbstractSqmExpression<Long> {
 	public <X> X accept(SemanticQueryWalker<X> walker) {
 		return walker.visitByUnit( this );
 	}
+
 	@Override
 	public void appendHqlString(StringBuilder hql, SqmRenderContext context) {
 		duration.appendHqlString( hql, context );
 		hql.append( " by " );
 		hql.append( unit.getUnit() );
+	}
+
+	@Override
+	public boolean equals(Object object) {
+		return object instanceof SqmByUnit that
+			&& Objects.equals( this.unit, that.unit )
+			&& Objects.equals( this.duration, that.duration );
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash( unit, duration );
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/expression/SqmCaseSearched.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/expression/SqmCaseSearched.java
@@ -6,6 +6,7 @@ package org.hibernate.query.sqm.tree.expression;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 import org.hibernate.query.criteria.JpaSearchedCase;
 import org.hibernate.query.internal.QueryHelper;
@@ -157,6 +158,17 @@ public class SqmCaseSearched<R>
 		hql.append( " end" );
 	}
 
+	@Override
+	public boolean equals(Object object) {
+		return object instanceof SqmCaseSearched<?> that
+			&& Objects.equals( this.whenFragments, that.whenFragments )
+			&& Objects.equals( this.otherwise, that.otherwise );
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash( whenFragments, otherwise );
+	}
 
 	// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 	// JPA

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/expression/SqmCaseSimple.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/expression/SqmCaseSimple.java
@@ -6,6 +6,7 @@ package org.hibernate.query.sqm.tree.expression;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 import org.hibernate.query.criteria.JpaExpression;
 import org.hibernate.query.criteria.JpaSimpleCase;
@@ -171,6 +172,18 @@ public class SqmCaseSimple<T, R>
 		hql.append( " end" );
 	}
 
+	@Override
+	public boolean equals(Object object) {
+		return object instanceof SqmCaseSimple<?, ?> that
+			&& Objects.equals( this.fixture, that.fixture )
+			&& Objects.equals( this.whenFragments, that.whenFragments )
+			&& Objects.equals( this.otherwise, that.otherwise );
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash( fixture, whenFragments, otherwise );
+	}
 
 	// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 	// JPA

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/expression/SqmCastTarget.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/expression/SqmCastTarget.java
@@ -15,6 +15,8 @@ import org.hibernate.query.sqm.tree.SqmCopyContext;
 import org.hibernate.query.sqm.tree.SqmRenderContext;
 import org.hibernate.query.sqm.tree.SqmTypedNode;
 
+import java.util.Objects;
+
 
 /**
  * @author Gavin King
@@ -110,5 +112,19 @@ public class SqmCastTarget<T> extends AbstractSqmNode implements SqmTypedNode<T>
 			hql.append( length );
 			hql.append( ')' );
 		}
+	}
+
+	@Override
+	public boolean equals(Object object) {
+		return object instanceof SqmCastTarget<?> that
+			&& Objects.equals( type, that.type )
+			&& Objects.equals( length, that.length )
+			&& Objects.equals( precision, that.precision )
+			&& Objects.equals( scale, that.scale );
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash( type, length, precision, scale );
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/expression/SqmCoalesce.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/expression/SqmCoalesce.java
@@ -6,8 +6,8 @@ package org.hibernate.query.sqm.tree.expression;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
-import org.hibernate.internal.util.collections.CollectionHelper;
 import org.hibernate.query.criteria.JpaCoalesce;
 import org.hibernate.query.criteria.JpaExpression;
 import org.hibernate.query.sqm.NodeBuilder;
@@ -18,6 +18,8 @@ import org.hibernate.query.sqm.tree.SqmCopyContext;
 
 import jakarta.persistence.criteria.Expression;
 import org.hibernate.query.sqm.tree.SqmRenderContext;
+
+import static org.hibernate.internal.util.collections.CollectionHelper.isEmpty;
 
 /**
  * @author Steve Ebersole
@@ -97,6 +99,16 @@ public class SqmCoalesce<T> extends AbstractSqmExpression<T> implements JpaCoale
 		hql.append( ')' );
 	}
 
+	@Override
+	public boolean equals(Object object) {
+		return object instanceof SqmCoalesce<?> that
+			&& Objects.equals( this.arguments, that.arguments );
+	}
+
+	@Override
+	public int hashCode() {
+		return arguments.hashCode();
+	}
 
 	// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 	// JPA
@@ -108,17 +120,17 @@ public class SqmCoalesce<T> extends AbstractSqmExpression<T> implements JpaCoale
 	}
 
 	private SqmExpression<T> firstOrNull() {
-		if ( CollectionHelper.isEmpty( arguments ) ) {
+		if ( isEmpty( arguments ) ) {
 			return null;
 		}
-
-		//noinspection unchecked
-		return (SqmExpression<T>) arguments.get( 0 );
+		else {
+			//noinspection unchecked
+			return (SqmExpression<T>) arguments.get( 0 );
+		}
 	}
 
 	@Override
 	public SqmCoalesce<T> value(Expression<? extends T> value) {
-		//noinspection unchecked
 		value( (SqmExpression<? extends T>) value );
 		return this;
 	}
@@ -126,7 +138,7 @@ public class SqmCoalesce<T> extends AbstractSqmExpression<T> implements JpaCoale
 	@Override
 	public SqmCoalesce<T> value(JpaExpression<? extends T> value) {
 		//noinspection unchecked
-		value( (SqmExpression) value );
+		value( (SqmExpression<T>) value );
 		return this;
 	}
 
@@ -139,5 +151,4 @@ public class SqmCoalesce<T> extends AbstractSqmExpression<T> implements JpaCoale
 		}
 		return this;
 	}
-
 }

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/expression/SqmCollectionSize.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/expression/SqmCollectionSize.java
@@ -11,6 +11,8 @@ import org.hibernate.query.sqm.tree.SqmCopyContext;
 import org.hibernate.query.sqm.tree.SqmRenderContext;
 import org.hibernate.query.sqm.tree.domain.SqmPath;
 
+import java.util.Objects;
+
 /**
  * Represents the {@code SIZE()} function.
  *
@@ -68,4 +70,14 @@ public class SqmCollectionSize extends AbstractSqmExpression<Integer> {
 		hql.append( ')' );
 	}
 
+	@Override
+	public boolean equals(Object object) {
+		return object instanceof SqmCollectionSize that
+			&& Objects.equals( this.pluralPath, that.pluralPath );
+	}
+
+	@Override
+	public int hashCode() {
+		return pluralPath.hashCode();
+	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/expression/SqmDistinct.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/expression/SqmDistinct.java
@@ -12,6 +12,8 @@ import org.hibernate.query.sqm.tree.SqmCopyContext;
 import org.hibernate.query.sqm.tree.SqmRenderContext;
 import org.hibernate.query.sqm.tree.SqmTypedNode;
 
+import java.util.Objects;
+
 /**
  * @author Gavin King
  */
@@ -57,5 +59,16 @@ public class SqmDistinct<T> extends AbstractSqmNode implements SqmTypedNode<T> {
 	public void appendHqlString(StringBuilder hql, SqmRenderContext context) {
 		hql.append( "distinct " );
 		expression.appendHqlString( hql, context );
+	}
+
+	@Override
+	public boolean equals(Object object) {
+		return object instanceof SqmDistinct<?> that
+			&& Objects.equals( this.expression, that.expression );
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hashCode( expression );
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/expression/SqmDurationUnit.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/expression/SqmDurationUnit.java
@@ -14,6 +14,7 @@ import org.hibernate.query.sqm.tree.SqmCopyContext;
 import org.hibernate.query.sqm.tree.SqmRenderContext;
 import org.hibernate.query.sqm.tree.SqmTypedNode;
 
+
 /**
  * @author Gavin King
  */
@@ -53,5 +54,16 @@ public class SqmDurationUnit<T> extends AbstractSqmNode implements SqmTypedNode<
 	@Override
 	public void appendHqlString(StringBuilder hql, SqmRenderContext context) {
 		hql.append( unit );
+	}
+
+	@Override
+	public boolean equals(Object object) {
+		return object instanceof SqmDurationUnit<?> that
+			&& this.unit == that.unit;
+	}
+
+	@Override
+	public int hashCode() {
+		return unit.hashCode();
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/expression/SqmEvery.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/expression/SqmEvery.java
@@ -13,6 +13,8 @@ import org.hibernate.query.sqm.tree.select.SqmSubQuery;
 
 import org.checkerframework.checker.nullness.qual.Nullable;
 
+import java.util.Objects;
+
 /**
  * @author Gavin King
  */
@@ -63,4 +65,14 @@ public class SqmEvery<T> extends AbstractSqmExpression<T> {
 		subquery.appendHqlString( hql, context );
 	}
 
+	@Override
+	public boolean equals(Object object) {
+		return object instanceof SqmEvery<?> sqmAny
+			&& Objects.equals( this.subquery, sqmAny.subquery );
+	}
+
+	@Override
+	public int hashCode() {
+		return subquery.hashCode();
+	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/expression/SqmFieldLiteral.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/expression/SqmFieldLiteral.java
@@ -10,6 +10,7 @@ import java.math.BigInteger;
 import java.util.Collection;
 import java.util.List;
 import java.util.Locale;
+import java.util.Objects;
 
 import org.hibernate.QueryException;
 import org.hibernate.query.criteria.JpaSelection;
@@ -116,11 +117,8 @@ public class SqmFieldLiteral<T> implements SqmExpression<T>, SqmExpressible<T>, 
 
 	@Override
 	public JavaType<T> getExpressibleJavaType() {
-		if ( expressible == this ) {
-			return fieldJavaType;
-		}
+		return expressible == this ? fieldJavaType : expressible.getExpressibleJavaType();
 
-		return expressible.getExpressibleJavaType();
 	}
 
 	@Override
@@ -141,6 +139,17 @@ public class SqmFieldLiteral<T> implements SqmExpression<T>, SqmExpressible<T>, 
 	@Override
 	public void appendHqlString(StringBuilder hql, SqmRenderContext context) {
 		SqmLiteral.appendHqlString( hql, getJavaTypeDescriptor(), getValue() );
+	}
+
+	@Override
+	public boolean equals(Object object) {
+		return object instanceof SqmFieldLiteral<?> that
+			&& Objects.equals( value, that.value );
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash( value );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/expression/SqmFunction.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/expression/SqmFunction.java
@@ -5,6 +5,7 @@
 package org.hibernate.query.sqm.tree.expression;
 
 import java.util.List;
+import java.util.Objects;
 
 import org.hibernate.query.criteria.JpaFunction;
 import org.hibernate.query.hql.spi.SemanticPathPart;
@@ -182,7 +183,7 @@ public abstract class SqmFunction<T> extends AbstractSqmExpression<T>
 	private SqmFunctionPath<T> getFunctionPath() {
 		SqmFunctionPath<T> path = functionPath;
 		if ( path == null ) {
-			path = functionPath = new SqmFunctionPath<T>( this );
+			path = functionPath = new SqmFunctionPath<>( this );
 		}
 		return path;
 	}
@@ -201,5 +202,17 @@ public abstract class SqmFunction<T> extends AbstractSqmExpression<T>
 			boolean isTerminal,
 			SqmCreationState creationState) {
 		return getFunctionPath().resolveIndexedAccess( selector, isTerminal, creationState );
+	}
+
+	@Override
+	public boolean equals(Object other) {
+		return other instanceof SqmFunction<?> that
+			&& Objects.equals( this.functionName, that.functionName )
+			&& Objects.equals( this.arguments, that.arguments );
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash( functionName, arguments );
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/expression/SqmHqlNumericLiteral.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/expression/SqmHqlNumericLiteral.java
@@ -76,29 +76,14 @@ public class SqmHqlNumericLiteral<N extends Number> extends SqmLiteral<N> {
 
 	@Override
 	public void appendHqlString(StringBuilder hql, SqmRenderContext context) {
-		hql.append( literalValue );
-
-		switch ( typeCategory ) {
-			case BIG_DECIMAL: {
-				hql.append( "bd" );
-				break;
-			}
-			case FLOAT: {
-				hql.append( "f" );
-				break;
-			}
-			case BIG_INTEGER: {
-				hql.append( "bi" );
-				break;
-			}
-			case LONG: {
-				hql.append( "l" );
-				break;
-			}
-			default: {
-				// nothing to do for double/integer
-			}
-		}
+		hql.append( literalValue )
+			.append( switch ( typeCategory ) {
+				case BIG_DECIMAL -> "bd";
+				case FLOAT -> "f";
+				case BIG_INTEGER -> "bi";
+				case LONG -> "l";
+				case INTEGER, DOUBLE -> "";
+			} );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/expression/SqmJpaCriteriaParameterWrapper.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/expression/SqmJpaCriteriaParameterWrapper.java
@@ -17,10 +17,12 @@ import org.hibernate.sql.ast.tree.expression.JdbcParameter;
 import static org.hibernate.query.sqm.tree.expression.SqmExpressionHelper.toSqmType;
 
 /**
- * Acts as the per-use wrapper for a JpaCriteriaParameter ({@link jakarta.persistence.criteria.CriteriaBuilder#parameter}).
- *
- * JpaCriteriaParameter is the "domain query parameter" ({@link org.hibernate.query.QueryParameter}
- * while SqmJpaCriteriaParameterWrapper is the {@link SqmParameter}
+ * Acts as the per-use wrapper for a {@link JpaCriteriaParameter}
+ * ({@link jakarta.persistence.criteria.CriteriaBuilder#parameter}).
+ * <p>
+ * {@code JpaCriteriaParameter} is the "domain query parameter"
+ * ({@link org.hibernate.query.QueryParameter} while
+ * {@code SqmJpaCriteriaParameterWrapper} is the {@link SqmParameter}
  */
 public class SqmJpaCriteriaParameterWrapper<T>
 		extends AbstractSqmExpression<T>
@@ -92,23 +94,27 @@ public class SqmJpaCriteriaParameterWrapper<T>
 
 	/**
 	 * Unsupported.  Visitation for a criteria parameter should be handled
-	 * as part of {@link SemanticQueryWalker#visitJpaCriteriaParameter}.  This wrapper
-	 * is intended just for representing unique SqmParameter references for each
-	 * JpaCriteriaParameter occurrence in the SQM true as part of the {@link org.hibernate.query.QueryParameter}
+	 * as part of {@link SemanticQueryWalker#visitJpaCriteriaParameter}.
+	 * This wrapper is intended just for representing unique SqmParameter
+	 * references for each {@link JpaCriteriaParameter} occurrence in the
+	 * SQM tree as part of the {@link org.hibernate.query.QueryParameter}
 	 * to {@link SqmParameter} to {@link JdbcParameter} transformation.
-	 * Each occurrence requires a unique SqmParameter to make sure we ultimately get the complete
-	 * set of JdbcParameter references
+	 * Each occurrence requires a unique {@link SqmParameter} to make
+	 * sure we ultimately get the complete set of {@code JdbcParameter}
+	 * references.
 	 */
 	@Override
 	public <X> X accept(SemanticQueryWalker<X> walker) {
 		throw new UnsupportedOperationException(
-				"Direct SemanticQueryWalker visitation of a SqmJpaCriteriaParameterWrapper " +
-						"is not supported.  Visitation for a criteria parameter should be handled " +
-						"during `SemanticQueryWalker#visitJpaCriteriaParameter`.  This wrapper is " +
-						"intended only for representing unique SQM parameter nodes for each criteria " +
-						"parameter in the SQM tree as part of the QueryParameter -> SqmParameter -> JdbcParameter " +
-						"transformation.  Each occurrence requires a unique SqmParameter to make sure we" +
-						"ultimately get the complete set of JdbcParameter references"
+				"""
+				Direct SemanticQueryWalker visitation of a SqmJpaCriteriaParameterWrapper \
+				is not supported. Visitation for a criteria parameter should be handled \
+				during SemanticQueryWalker#visitJpaCriteriaParameter. This wrapper is \
+				intended only for representing unique SQM parameter nodes for each criteria \
+				parameter in the SQM tree as part of the QueryParameter -> SqmParameter -> JdbcParameter \
+				transformation. Each occurrence requires a unique SqmParameter to make sure we \
+				ultimately get the complete set of JdbcParameter references.\
+				"""
 		);
 	}
 
@@ -124,8 +130,19 @@ public class SqmJpaCriteriaParameterWrapper<T>
 
 	@Override
 	public int compareTo(SqmParameter anotherParameter) {
-		return anotherParameter instanceof SqmJpaCriteriaParameterWrapper ?
-				getJpaCriteriaParameter().compareTo( ( (SqmJpaCriteriaParameterWrapper<?>) anotherParameter ).getJpaCriteriaParameter() )
+		return anotherParameter instanceof SqmJpaCriteriaParameterWrapper<?> wrapper
+				? getJpaCriteriaParameter().compareTo( wrapper.getJpaCriteriaParameter() )
 				: 1;
 	}
+
+//	@Override
+//	public boolean equals(Object object) {
+//		return object instanceof SqmJpaCriteriaParameterWrapper<?> that
+//			&& Objects.equals( this.jpaCriteriaParameter, that.jpaCriteriaParameter );
+//	}
+//
+//	@Override
+//	public int hashCode() {
+//		return jpaCriteriaParameter.hashCode();
+//	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/expression/SqmJpaCriteriaParameterWrapper.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/expression/SqmJpaCriteriaParameterWrapper.java
@@ -129,8 +129,8 @@ public class SqmJpaCriteriaParameterWrapper<T>
 	}
 
 	@Override
-	public int compareTo(SqmParameter anotherParameter) {
-		return anotherParameter instanceof SqmJpaCriteriaParameterWrapper<?> wrapper
+	public int compareTo(SqmParameter<T> parameter) {
+		return parameter instanceof SqmJpaCriteriaParameterWrapper<T> wrapper
 				? getJpaCriteriaParameter().compareTo( wrapper.getJpaCriteriaParameter() )
 				: 1;
 	}

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/expression/SqmJsonExistsExpression.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/expression/SqmJsonExistsExpression.java
@@ -180,11 +180,12 @@ public class SqmJsonExistsExpression extends AbstractSqmJsonPathExpression<Boole
 		getArguments().get( 1 ).appendHqlString( hql, context );
 
 		appendPassingExpressionHqlString( hql, context );
-		switch ( errorBehavior ) {
-			case ERROR -> hql.append( " error on error" );
-			case TRUE -> hql.append( " true on error" );
-			case FALSE -> hql.append( " false on error" );
-		}
+		hql.append( switch ( errorBehavior ) {
+			case ERROR -> " error on error";
+			case TRUE -> " true on error";
+			case FALSE -> " false on error";
+			case UNSPECIFIED -> "";
+		} );
 		hql.append( ')' );
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/expression/SqmLiteral.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/expression/SqmLiteral.java
@@ -13,6 +13,8 @@ import org.hibernate.type.descriptor.java.JavaType;
 
 import org.checkerframework.checker.nullness.qual.Nullable;
 
+import java.util.Objects;
+
 import static org.hibernate.internal.util.QuotingHelper.appendSingleQuoteEscapedString;
 
 /**
@@ -99,4 +101,14 @@ public class SqmLiteral<T> extends AbstractSqmExpression<T> {
 		}
 	}
 
+	@Override
+	public boolean equals(Object object) {
+		return object instanceof SqmLiteral<?> that
+			&& Objects.equals( value, that.value );
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hashCode( value );
+	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/expression/SqmLiteralEmbeddableType.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/expression/SqmLiteralEmbeddableType.java
@@ -17,6 +17,8 @@ import org.hibernate.query.sqm.tree.domain.SqmPath;
 import org.hibernate.query.sqm.tree.domain.SqmEmbeddableDomainType;
 import org.hibernate.query.sqm.tree.select.SqmSelectableNode;
 
+import java.util.Objects;
+
 import static org.hibernate.persister.entity.DiscriminatorHelper.getDiscriminatorType;
 
 /**
@@ -86,5 +88,16 @@ public class SqmLiteralEmbeddableType<T>
 	@Override
 	public void appendHqlString(StringBuilder hql, SqmRenderContext context) {
 		hql.append( embeddableDomainType.getTypeName() );
+	}
+
+	@Override
+	public boolean equals(Object object) {
+		return object instanceof SqmLiteralEmbeddableType<?> that
+			&& Objects.equals( embeddableDomainType.getTypeName(), that.embeddableDomainType.getTypeName() );
+	}
+
+	@Override
+	public int hashCode() {
+		return embeddableDomainType.getTypeName().hashCode();
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/expression/SqmLiteralEntityType.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/expression/SqmLiteralEntityType.java
@@ -16,6 +16,8 @@ import org.hibernate.query.sqm.tree.domain.SqmPath;
 import org.hibernate.query.sqm.tree.domain.SqmEntityDomainType;
 import org.hibernate.query.sqm.tree.select.SqmSelectableNode;
 
+import java.util.Objects;
+
 import static org.hibernate.persister.entity.DiscriminatorHelper.getDiscriminatorType;
 
 /**
@@ -99,4 +101,14 @@ public class SqmLiteralEntityType<T>
 		hql.append( entityType.getName() );
 	}
 
+	@Override
+	public boolean equals(Object object) {
+		return object instanceof SqmLiteralEntityType<?> that
+			&& Objects.equals( this.entityType.getName(), that.entityType.getName() );
+	}
+
+	@Override
+	public int hashCode() {
+		return entityType.getName().hashCode();
+	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/expression/SqmLiteralNull.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/expression/SqmLiteralNull.java
@@ -57,4 +57,14 @@ public class SqmLiteralNull<T> extends SqmLiteral<T> {
 	public void appendHqlString(StringBuilder hql, SqmRenderContext context) {
 		hql.append( "null" );
 	}
+
+	@Override
+	public boolean equals(Object object) {
+		return object instanceof SqmLiteralNull;
+	}
+
+	@Override
+	public int hashCode() {
+		return 1;
+	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/expression/SqmModifiedSubQueryExpression.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/expression/SqmModifiedSubQueryExpression.java
@@ -11,6 +11,8 @@ import org.hibernate.query.sqm.tree.SqmCopyContext;
 import org.hibernate.query.sqm.tree.SqmRenderContext;
 import org.hibernate.query.sqm.tree.select.SqmSubQuery;
 
+import java.util.Objects;
+
 /**
  * Represents a {@link Modifier#ALL}, {@link Modifier#ANY}, {@link Modifier#SOME} modifier applied to a subquery as
  * part of a comparison.
@@ -87,5 +89,17 @@ public class SqmModifiedSubQueryExpression<T> extends AbstractSqmExpression<T> {
 		hql.append( " (" );
 		subQuery.appendHqlString( hql, context );
 		hql.append( ')' );
+	}
+
+	@Override
+	public boolean equals(Object object) {
+		return object instanceof SqmModifiedSubQueryExpression<?> that
+			&& modifier == that.modifier
+			&& Objects.equals( subQuery, that.subQuery );
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash( subQuery, modifier );
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/expression/SqmNamedExpression.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/expression/SqmNamedExpression.java
@@ -9,6 +9,8 @@ import org.hibernate.query.sqm.SemanticQueryWalker;
 import org.hibernate.query.sqm.tree.SqmCopyContext;
 import org.hibernate.query.sqm.tree.SqmRenderContext;
 
+import java.util.Objects;
+
 /**
  * A named expression. Used when the name of the expression matters
  * e.g. in XML generation.
@@ -59,5 +61,17 @@ public class SqmNamedExpression<T> extends AbstractSqmExpression<T> {
 		expression.appendHqlString( hql, context );
 		hql.append( " as " );
 		hql.append( name );
+	}
+
+	@Override
+	public boolean equals(Object object) {
+		return object instanceof SqmNamedExpression<?> that
+			&& Objects.equals( this.name, that.name )
+			&& Objects.equals( this.expression, that.expression );
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash( expression, name );
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/expression/SqmNamedParameter.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/expression/SqmNamedParameter.java
@@ -10,6 +10,8 @@ import org.hibernate.query.sqm.SqmExpressible;
 import org.hibernate.query.sqm.tree.SqmCopyContext;
 import org.hibernate.query.sqm.tree.SqmRenderContext;
 
+import java.util.Objects;
+
 /**
  * Represents a named query parameter in the SQM tree.
  *
@@ -77,14 +79,24 @@ public class SqmNamedParameter<T> extends AbstractSqmParameter<T> {
 
 	@Override
 	public void appendHqlString(StringBuilder hql, SqmRenderContext context) {
-		hql.append( ':' );
-		hql.append( getName() );
+		hql.append( ':' ).append( getName() );
 	}
 
 	@Override
 	public int compareTo(SqmParameter anotherParameter) {
-		return anotherParameter instanceof SqmNamedParameter<?>
-				? getName().compareTo( ( (SqmNamedParameter<?>) anotherParameter ).getName() )
+		return anotherParameter instanceof SqmNamedParameter<?> namedParameter
+				? getName().compareTo( namedParameter.getName() )
 				: -1;
+	}
+
+	@Override
+	public boolean equals(Object object) {
+		return object instanceof SqmNamedParameter<?> that
+			&& Objects.equals( name, that.name );
+	}
+
+	@Override
+	public int hashCode() {
+		return name.hashCode();
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/expression/SqmNamedParameter.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/expression/SqmNamedParameter.java
@@ -83,8 +83,8 @@ public class SqmNamedParameter<T> extends AbstractSqmParameter<T> {
 	}
 
 	@Override
-	public int compareTo(SqmParameter anotherParameter) {
-		return anotherParameter instanceof SqmNamedParameter<?> namedParameter
+	public int compareTo(SqmParameter<T> parameter) {
+		return parameter instanceof SqmNamedParameter<T> namedParameter
 				? getName().compareTo( namedParameter.getName() )
 				: -1;
 	}

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/expression/SqmOver.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/expression/SqmOver.java
@@ -5,6 +5,7 @@
 package org.hibernate.query.sqm.tree.expression;
 
 import java.util.List;
+import java.util.Objects;
 
 import org.hibernate.query.common.FrameExclusion;
 import org.hibernate.query.common.FrameKind;
@@ -102,5 +103,17 @@ public class SqmOver<T> extends AbstractSqmExpression<T> {
 		hql.append( " over (" );
 		window.appendHqlString( hql, context );
 		hql.append( ')' );
+	}
+
+	@Override
+	public boolean equals(Object object) {
+		return object instanceof SqmOver<?> sqmOver
+			&& Objects.equals( expression, sqmOver.expression )
+			&& Objects.equals( window, sqmOver.window );
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash( expression, window );
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/expression/SqmOverflow.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/expression/SqmOverflow.java
@@ -8,6 +8,8 @@ import org.hibernate.query.sqm.SemanticQueryWalker;
 import org.hibernate.query.sqm.tree.SqmCopyContext;
 import org.hibernate.query.sqm.tree.SqmRenderContext;
 
+import java.util.Objects;
+
 /**
  * @author Christian Beikov
  */
@@ -78,4 +80,16 @@ public class SqmOverflow<T> extends AbstractSqmExpression<T> {
 		}
 	}
 
+	@Override
+	public boolean equals(Object object) {
+		return object instanceof SqmOverflow<?> that
+			&& this.withCount == that.withCount
+			&& Objects.equals( this.separatorExpression, that.separatorExpression )
+			&& Objects.equals( this.fillerExpression, that.fillerExpression );
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash( separatorExpression, fillerExpression, withCount );
+	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/expression/SqmParameter.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/expression/SqmParameter.java
@@ -13,10 +13,10 @@ import org.hibernate.query.sqm.tree.SqmCopyContext;
  * Models a parameter expression declared in the query.
  *
  * @implNote Each usage of a given named/positional query parameter
- * will result in a unique SqmParameter instance, each will simply
- * use to the same binding.  This is important to distinguish usage
- * of the same parameter in different clauses which effects the
- * rendering and value binding.
+ * will result in a unique {@code SqmParameter} instance, each will
+ * simply use to the same binding. This is important to distinguish
+ * usage of the same parameter in different clauses which effects
+ * the rendering and value binding.
  *
  * @author Steve Ebersole
  */

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/expression/SqmParameter.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/expression/SqmParameter.java
@@ -75,21 +75,21 @@ public interface SqmParameter<T> extends SqmExpression<T>, JpaParameterExpressio
 	 * support any previous extensions
 	 */
 	@Override
-	default int compareTo(SqmParameter<T> anotherParameter) {
-		if ( this instanceof SqmNamedParameter<?> one ) {
-			return anotherParameter instanceof SqmNamedParameter<?>
-					? one.getName().compareTo( anotherParameter.getName() )
+	default int compareTo(SqmParameter<T> parameter) {
+		if ( this instanceof SqmNamedParameter<T> one ) {
+			return parameter instanceof SqmNamedParameter<?>
+					? one.getName().compareTo( parameter.getName() )
 					: -1;
 		}
-		else if ( this instanceof SqmPositionalParameter<?> one ) {
-			return anotherParameter instanceof SqmPositionalParameter<?>
-					? one.getPosition().compareTo( anotherParameter.getPosition() )
+		else if ( this instanceof SqmPositionalParameter<T> one ) {
+			return parameter instanceof SqmPositionalParameter<?>
+					? one.getPosition().compareTo( parameter.getPosition() )
 					: 1;
 		}
-		else if ( this instanceof SqmJpaCriteriaParameterWrapper
-				&& anotherParameter instanceof SqmJpaCriteriaParameterWrapper ) {
-			return Integer.compare( this.hashCode(), anotherParameter.hashCode() );
+		else if ( this instanceof SqmJpaCriteriaParameterWrapper<T>
+				&& parameter instanceof SqmJpaCriteriaParameterWrapper<T> ) {
+			return Integer.compare( this.hashCode(), parameter.hashCode() );
 		}
-		throw new HibernateException( "Unexpected SqmParameter type for comparison : " + this + " & " + anotherParameter );
+		throw new HibernateException( "Unexpected SqmParameter type for comparison : " + this + " & " + parameter );
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/expression/SqmParameterizedEntityType.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/expression/SqmParameterizedEntityType.java
@@ -11,6 +11,8 @@ import org.hibernate.query.sqm.tree.SqmCopyContext;
 import org.hibernate.query.sqm.tree.SqmRenderContext;
 import org.hibernate.query.sqm.tree.select.SqmSelectableNode;
 
+import java.util.Objects;
+
 /**
  * Entity type expression based on a parameter - `TYPE( :someParam )`
  *
@@ -19,7 +21,7 @@ import org.hibernate.query.sqm.tree.select.SqmSelectableNode;
 public class SqmParameterizedEntityType<T> extends AbstractSqmExpression<T> implements SqmSelectableNode<T> {
 	private final SqmParameter<T> discriminatorSource;
 
-	public SqmExpression getDiscriminatorSource() {
+	public SqmExpression<T> getDiscriminatorSource() {
 		return discriminatorSource;
 	}
 
@@ -48,8 +50,6 @@ public class SqmParameterizedEntityType<T> extends AbstractSqmExpression<T> impl
 	@Override
 	public void internalApplyInferableType(SqmExpressible<?> type) {
 		setExpressibleType( type );
-
-		//noinspection unchecked
 		discriminatorSource.applyInferableType( type );
 	}
 
@@ -65,4 +65,14 @@ public class SqmParameterizedEntityType<T> extends AbstractSqmExpression<T> impl
 		hql.append( ')' );
 	}
 
+	@Override
+	public boolean equals(Object object) {
+		return object instanceof SqmParameterizedEntityType<?> that
+			&& Objects.equals( discriminatorSource, that.discriminatorSource );
+	}
+
+	@Override
+	public int hashCode() {
+		return discriminatorSource.hashCode();
+	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/expression/SqmPositionalParameter.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/expression/SqmPositionalParameter.java
@@ -86,8 +86,19 @@ public class SqmPositionalParameter<T> extends AbstractSqmParameter<T> {
 
 	@Override
 	public int compareTo(SqmParameter anotherParameter) {
-		return anotherParameter instanceof SqmPositionalParameter<?>
-				? getPosition().compareTo( ( (SqmPositionalParameter<?>) anotherParameter ).getPosition() )
+		return anotherParameter instanceof SqmPositionalParameter<?> positionalParameter
+				? getPosition().compareTo( positionalParameter.getPosition() )
 				: 1;
+	}
+
+	@Override
+	public boolean equals(Object object) {
+		return object instanceof SqmPositionalParameter<?> that
+			&& position == that.position;
+	}
+
+	@Override
+	public int hashCode() {
+		return position;
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/expression/SqmPositionalParameter.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/expression/SqmPositionalParameter.java
@@ -85,8 +85,8 @@ public class SqmPositionalParameter<T> extends AbstractSqmParameter<T> {
 	}
 
 	@Override
-	public int compareTo(SqmParameter anotherParameter) {
-		return anotherParameter instanceof SqmPositionalParameter<?> positionalParameter
+	public int compareTo(SqmParameter<T> parameter) {
+		return parameter instanceof SqmPositionalParameter<T> positionalParameter
 				? getPosition().compareTo( positionalParameter.getPosition() )
 				: 1;
 	}

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/expression/SqmSelfRenderingExpression.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/expression/SqmSelfRenderingExpression.java
@@ -17,10 +17,10 @@ import org.hibernate.sql.ast.tree.expression.Expression;
  * @author Steve Ebersole
  */
 public class SqmSelfRenderingExpression<T> extends AbstractSqmExpression<T> {
-	private final Function<SemanticQueryWalker, Expression> renderer;
+	private final Function<SemanticQueryWalker<?>, Expression> renderer;
 
 	public SqmSelfRenderingExpression(
-			Function<SemanticQueryWalker, Expression> renderer,
+			Function<SemanticQueryWalker<?>, Expression> renderer,
 			SqmExpressible<T> type,
 			NodeBuilder criteriaBuilder) {
 		super( type, criteriaBuilder );
@@ -51,4 +51,6 @@ public class SqmSelfRenderingExpression<T> extends AbstractSqmExpression<T> {
 	public void appendHqlString(StringBuilder hql, SqmRenderContext context) {
 		throw new UnsupportedOperationException();
 	}
+
+	//TODO: what is a correct impl of equals() / hashCode() here?
 }

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/expression/SqmSetReturningFunction.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/expression/SqmSetReturningFunction.java
@@ -5,6 +5,7 @@
 package org.hibernate.query.sqm.tree.expression;
 
 import java.util.List;
+import java.util.Objects;
 
 import org.hibernate.Incubating;
 import org.hibernate.query.criteria.JpaSetReturningFunction;
@@ -27,8 +28,8 @@ import org.hibernate.sql.ast.tree.from.TableGroup;
  * @since 7.0
  */
 @Incubating
-public abstract class SqmSetReturningFunction<T> extends AbstractSqmNode implements SqmVisitableNode,
-		JpaSetReturningFunction<T> {
+public abstract class SqmSetReturningFunction<T> extends AbstractSqmNode
+		implements SqmVisitableNode, JpaSetReturningFunction<T> {
 	// this function-name is the one used to resolve the descriptor from
 	// the function registry (which may or may not be a db function name)
 	private final String functionName;
@@ -83,15 +84,30 @@ public abstract class SqmSetReturningFunction<T> extends AbstractSqmNode impleme
 		hql.append( functionName );
 		if ( arguments.isEmpty() ) {
 			hql.append( "()" );
-			return;
 		}
-		hql.append( '(' );
-		arguments.get( 0 ).appendHqlString( hql, context );
-		for ( int i = 1; i < arguments.size(); i++ ) {
-			hql.append( ", " );
-			arguments.get( i ).appendHqlString( hql, context );
+		else {
+			hql.append( '(' );
+			arguments.get( 0 ).appendHqlString( hql, context );
+			for ( int i = 1; i < arguments.size(); i++ ) {
+				hql.append( ", " );
+				arguments.get( i ).appendHqlString( hql, context );
+			}
+			hql.append( ')' );
 		}
+	}
 
-		hql.append( ')' );
+	@Override
+	// TODO: override on all subtypes
+	public boolean equals(Object other) {
+		return other instanceof SqmSetReturningFunction<?> that
+			&& Objects.equals( this.functionName, that.functionName )
+			&& Objects.equals( this.arguments, that.arguments )
+			&& this.getClass() == that.getClass()
+			&& Objects.equals( this.toHqlString(), that.toHqlString() );
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash( functionName, arguments, getClass() );
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/expression/SqmStar.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/expression/SqmStar.java
@@ -36,4 +36,13 @@ public class SqmStar extends AbstractSqmExpression<Object> {
 		hql.append( "*" );
 	}
 
+	@Override
+	public boolean equals(Object other) {
+		return other instanceof SqmStar;
+	}
+
+	@Override
+	public int hashCode() {
+		return 1;
+	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/expression/SqmSummarization.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/expression/SqmSummarization.java
@@ -65,6 +65,7 @@ public class SqmSummarization<T> extends AbstractSqmExpression<T> {
 		ROLLUP,
 		CUBE
 	}
+
 	@Override
 	public void appendHqlString(StringBuilder hql, SqmRenderContext context) {
 		hql.append( kind );

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/expression/SqmToDuration.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/expression/SqmToDuration.java
@@ -10,6 +10,8 @@ import org.hibernate.query.sqm.SemanticQueryWalker;
 import org.hibernate.query.sqm.tree.SqmCopyContext;
 import org.hibernate.query.sqm.tree.SqmRenderContext;
 
+import java.util.Objects;
+
 /**
  * @author Gavin King
  */
@@ -69,5 +71,17 @@ public class SqmToDuration<T> extends AbstractSqmExpression<T> {
 		magnitude.appendHqlString( hql, context );
 		hql.append( ' ' );
 		hql.append( unit.getUnit() );
+	}
+
+	@Override
+	public boolean equals(Object object) {
+		return object instanceof SqmToDuration<?> that
+			&& Objects.equals( magnitude, that.magnitude )
+			&& Objects.equals( unit, that.unit );
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash( magnitude, unit );
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/expression/SqmTrimSpecification.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/expression/SqmTrimSpecification.java
@@ -13,6 +13,8 @@ import org.hibernate.query.sqm.tree.SqmCopyContext;
 import org.hibernate.query.sqm.tree.SqmRenderContext;
 import org.hibernate.query.sqm.tree.SqmTypedNode;
 
+import java.util.Objects;
+
 /**
  * Needed to pass TrimSpecification as an SqmExpression when we call out to
  * SqmFunctionTemplates handling TRIM calls as a function argument.
@@ -54,5 +56,16 @@ public class SqmTrimSpecification extends AbstractSqmNode implements SqmTypedNod
 	@Override
 	public void appendHqlString(StringBuilder hql, SqmRenderContext context) {
 		hql.append( specification );
+	}
+
+	@Override
+	public boolean equals(Object object) {
+		return object instanceof SqmTrimSpecification that
+			&& specification == that.specification;
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hashCode( specification );
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/expression/SqmTuple.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/expression/SqmTuple.java
@@ -7,6 +7,7 @@ package org.hibernate.query.sqm.tree.expression;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
 
 import org.hibernate.query.SemanticException;
 import org.hibernate.query.criteria.JpaCompoundSelection;
@@ -92,6 +93,17 @@ public class SqmTuple<T>
 			groupedExpressions.get( i ).appendHqlString( hql, context );
 		}
 		hql.append( ')' );
+	}
+
+	@Override
+	public boolean equals(Object object) {
+		return object instanceof SqmTuple<?> that
+			&& Objects.equals( this.groupedExpressions, that.groupedExpressions );
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hashCode( groupedExpressions );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/expression/SqmUnaryOperation.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/expression/SqmUnaryOperation.java
@@ -70,11 +70,11 @@ public class SqmUnaryOperation<T> extends AbstractSqmExpression<T> implements Sq
 
 	@Override
 	public String asLoggableText() {
-		return ( operation == UnaryArithmeticOperator.UNARY_MINUS ? '-' : '+' ) + operand.asLoggableText();
+		return operation.getOperatorChar() + operand.asLoggableText();
 	}
 	@Override
 	public void appendHqlString(StringBuilder hql, SqmRenderContext context) {
-		hql.append( operation == UnaryArithmeticOperator.UNARY_MINUS ? '-' : '+' );
+		hql.append( operation.getOperatorChar() );
 		operand.appendHqlString( hql, context );
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/expression/SqmWindow.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/expression/SqmWindow.java
@@ -6,6 +6,7 @@ package org.hibernate.query.sqm.tree.expression;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 import org.hibernate.Incubating;
 import org.hibernate.query.criteria.JpaWindow;
@@ -285,5 +286,26 @@ public class SqmWindow extends AbstractSqmNode implements JpaWindow, SqmVisitabl
 			default:
 				throw new UnsupportedOperationException( "Unsupported frame kind: " + kind );
 		}
+	}
+
+	@Override
+	public boolean equals(Object object) {
+		if ( !(object instanceof SqmWindow sqmWindow) ) {
+			return false;
+		}
+		return Objects.equals( partitions, sqmWindow.partitions )
+			&& Objects.equals( orderList, sqmWindow.orderList )
+			&& mode == sqmWindow.mode
+			&& startKind == sqmWindow.startKind
+			&& Objects.equals( startExpression, sqmWindow.startExpression )
+			&& endKind == sqmWindow.endKind
+			&& Objects.equals( endExpression, sqmWindow.endExpression )
+			&& exclusion == sqmWindow.exclusion;
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash( partitions, orderList, mode, startKind, startExpression, endKind, endExpression,
+				exclusion );
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/expression/ValueBindJpaCriteriaParameter.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/expression/ValueBindJpaCriteriaParameter.java
@@ -51,7 +51,7 @@ public class ValueBindJpaCriteriaParameter<T> extends JpaCriteriaParameter<T> {
 
 	@Override
 	// TODO: fix this
-	public int compareTo(SqmParameter parameter) {
+	public int compareTo(SqmParameter<T> parameter) {
 		return this == parameter ? 0 : 1;
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/expression/ValueBindJpaCriteriaParameter.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/expression/ValueBindJpaCriteriaParameter.java
@@ -9,8 +9,12 @@ import org.hibernate.query.sqm.NodeBuilder;
 import org.hibernate.query.sqm.tree.SqmCopyContext;
 import org.hibernate.query.sqm.tree.SqmRenderContext;
 
+import java.util.Objects;
+
+
 /**
- * It is a JpaCriteriaParameter created from a value when ValueHandlingMode is equal to BIND
+ * A {@link JpaCriteriaParameter} created from a value when
+ * {@link org.hibernate.query.criteria.ValueHandlingMode} is {@code BIND}.
  *
  * @see org.hibernate.query.criteria.ValueHandlingMode
  */
@@ -46,17 +50,33 @@ public class ValueBindJpaCriteriaParameter<T> extends JpaCriteriaParameter<T> {
 	}
 
 	@Override
-	public boolean equals(Object o) {
-		return this == o;
+	// TODO: fix this
+	public int compareTo(SqmParameter parameter) {
+		return this == parameter ? 0 : 1;
+	}
+
+	// this is not really a parameter, it's really a literal value
+	// so use value equality based on its value
+
+	@Override
+	public boolean equals(Object object) {
+		return object instanceof ValueBindJpaCriteriaParameter<?> that
+			&& Objects.equals( this.value, that.value );
+//			&& getJavaTypeDescriptor().areEqual( this.value, (T) that.value );
 	}
 
 	@Override
 	public int hashCode() {
-		return System.identityHashCode( this );
+		return value == null ? 0 : value.hashCode(); // getJavaTypeDescriptor().extractHashCode( value );
 	}
 
-	@Override
-	public int compareTo(SqmParameter anotherParameter) {
-		return this == anotherParameter ? 0 : 1;
-	}
+//	@Override
+//	public boolean equals(Object object) {
+//		return this == object;
+//	}
+//
+//	@Override
+//	public int hashCode() {
+//		return System.identityHashCode( this );
+//	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/from/SqmCrossJoin.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/from/SqmCrossJoin.java
@@ -25,6 +25,7 @@ import org.hibernate.spi.NavigablePath;
 import jakarta.persistence.criteria.From;
 import jakarta.persistence.criteria.JoinType;
 
+
 import static org.hibernate.query.sqm.spi.SqmCreationHelper.buildRootNavigablePath;
 
 /**
@@ -210,5 +211,17 @@ public class SqmCrossJoin<T> extends AbstractSqmFrom<T, T> implements JpaCrossJo
 	@Override
 	public <S extends T> SqmTreatedCrossJoin treatAs(EntityDomainType<S> treatAsType) {
 		return treatAs( treatAsType, null );
+	}
+
+	@Override
+	public boolean equals(Object object) {
+		return object instanceof SqmCrossJoin<?>
+			&& super.equals( object );
+	}
+
+	@Override
+	// needed to make static code analyzer happy
+	public int hashCode() {
+		return super.hashCode();
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/from/SqmCteJoin.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/from/SqmCteJoin.java
@@ -20,6 +20,8 @@ import org.hibernate.spi.NavigablePath;
 
 import jakarta.persistence.criteria.JoinType;
 
+import java.util.Objects;
+
 /**
  * @author Christian Beikov
  */
@@ -153,5 +155,17 @@ public class SqmCteJoin<T> extends AbstractSqmJoin<T, T> {
 	@Override
 	public JoinType getJoinType() {
 		return getSqmJoinType().getCorrespondingJpaJoinType();
+	}
+
+	@Override
+	public boolean equals(Object object) {
+		return object instanceof SqmCteJoin<?> that
+			&& super.equals( object )
+			&& Objects.equals( this.cte.getName(), that.cte.getName() );
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash( super.hashCode(), cte.getName() );
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/from/SqmDerivedJoin.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/from/SqmDerivedJoin.java
@@ -26,6 +26,8 @@ import jakarta.persistence.criteria.Expression;
 import jakarta.persistence.criteria.JoinType;
 import jakarta.persistence.criteria.Predicate;
 
+import java.util.Objects;
+
 /**
  * @author Christian Beikov
  */
@@ -215,5 +217,18 @@ public class SqmDerivedJoin<T> extends AbstractSqmJoin<T, T> implements JpaDeriv
 	@Override
 	public JoinType getJoinType() {
 		return getSqmJoinType().getCorrespondingJpaJoinType();
+	}
+
+	@Override
+	public boolean equals(Object object) {
+		return object instanceof SqmDerivedJoin<?> that
+			&& super.equals( object )
+			&& this.lateral == that.lateral
+			&& Objects.equals( this.subQuery, that.subQuery );
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash( super.hashCode(), subQuery, lateral );
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/from/SqmEntityJoin.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/from/SqmEntityJoin.java
@@ -30,6 +30,8 @@ import jakarta.persistence.criteria.JoinType;
 import jakarta.persistence.criteria.Predicate;
 import jakarta.persistence.metamodel.EntityType;
 
+import java.util.Objects;
+
 /**
  * @author Steve Ebersole
  */
@@ -228,5 +230,15 @@ public class SqmEntityJoin<L,R>
 		);
 	}
 
+	@Override
+	public boolean equals(Object other) {
+		return other instanceof SqmEntityJoin<?, ?> that
+			&& Objects.equals( this.getEntityName(), that.getEntityName() )
+			&& super.equals( other );
+	}
 
+	@Override
+	public int hashCode() {
+		return Objects.hash( super.hashCode(), getEntityName() );
+	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/from/SqmFrom.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/from/SqmFrom.java
@@ -58,6 +58,8 @@ public interface SqmFrom<L, R> extends SqmVisitableNode, SqmPath<R>, JpaFrom<L, 
 
 	boolean hasJoins();
 
+	int getNumberOfJoins();
+
 	/**
 	 * The joins associated with this SqmFrom
 	 */

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/from/SqmFromClause.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/from/SqmFromClause.java
@@ -7,15 +7,16 @@ package org.hibernate.query.sqm.tree.from;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.function.Consumer;
 
-import org.hibernate.internal.util.collections.CollectionHelper;
 import org.hibernate.query.sqm.tree.SqmCopyContext;
 import org.hibernate.query.sqm.tree.SqmRenderContext;
 import org.hibernate.query.sqm.tree.domain.SqmTreatedPath;
 
 import static java.util.Collections.emptyList;
 import static java.util.Collections.unmodifiableList;
+import static org.hibernate.internal.util.collections.CollectionHelper.arrayList;
 
 /**
  * Contract representing a from clause.
@@ -32,7 +33,7 @@ public class SqmFromClause implements Serializable {
 	}
 
 	public SqmFromClause(int expectedNumberOfRoots) {
-		this.domainRoots = CollectionHelper.arrayList( expectedNumberOfRoots );
+		domainRoots = arrayList( expectedNumberOfRoots );
 	}
 
 	private SqmFromClause(SqmFromClause original, SqmCopyContext context) {
@@ -70,7 +71,6 @@ public class SqmFromClause implements Serializable {
 		if ( domainRoots == null ) {
 			domainRoots = new ArrayList<>();
 		}
-
 		domainRoots.add( root );
 	}
 
@@ -84,12 +84,7 @@ public class SqmFromClause implements Serializable {
 	}
 
 	public int getNumberOfRoots() {
-		if ( domainRoots == null ) {
-			return 0;
-		}
-		else {
-			return domainRoots.size();
-		}
+		return domainRoots == null ? 0 : domainRoots.size();
 	}
 
 	public void appendHqlString(StringBuilder sb, SqmRenderContext context) {
@@ -146,7 +141,7 @@ public class SqmFromClause implements Serializable {
 				else {
 					sb.append( sqmFrom.resolveAlias( context ) );
 				}
-				sb.append( '.' ).append( ( attributeJoin ).getAttribute().getName() );
+				sb.append( '.' ).append( attributeJoin.getAttribute().getName() );
 				sb.append( ' ' ).append( sqmJoin.resolveAlias( context ) );
 				if ( attributeJoin.getJoinPredicate() != null ) {
 					sb.append( " on " );
@@ -160,7 +155,7 @@ public class SqmFromClause implements Serializable {
 				appendJoins( sqmJoin, sb, context );
 			}
 			else if ( sqmJoin instanceof SqmEntityJoin<?, ?> sqmEntityJoin ) {
-				sb.append( ( sqmEntityJoin ).getEntityName() );
+				sb.append( sqmEntityJoin.getEntityName() );
 				sb.append( ' ' ).append( sqmJoin.resolveAlias( context ) );
 				if ( sqmEntityJoin.getJoinPredicate() != null ) {
 					sb.append( " on " );
@@ -191,5 +186,50 @@ public class SqmFromClause implements Serializable {
 		for ( SqmFrom<?, ?> sqmTreat : sqmFrom.getSqmTreats() ) {
 			appendJoins( sqmTreat, sb, context );
 		}
+	}
+
+	@Override
+	public boolean equals(Object object) {
+		return object instanceof SqmFromClause that
+			&& this.getNumberOfRoots() == that.getNumberOfRoots()
+			&& equalRoots( this.getRoots(), that.getRoots() );
+	}
+
+	// both lists must be the same size
+	private boolean equalRoots(List<SqmRoot<?>> theseRoots, List<SqmRoot<?>> thoseRoots) {
+		for ( int i = 0; i < theseRoots.size(); i++ ) {
+			var thisRoot = theseRoots.get( i );
+			var thatRoot = thoseRoots.get( i );
+			if ( !Objects.equals( thisRoot.getEntityName(), thatRoot.getEntityName() )
+				|| !Objects.equals( thisRoot.getExplicitAlias(), thatRoot.getExplicitAlias() )
+				|| !Objects.equals( thisRoot, thatRoot ) // needed for SqmDerivedRoots
+				|| thisRoot.getNumberOfJoins() != thatRoot.getNumberOfJoins()
+				|| !equalsJoins( thisRoot.getSqmJoins(), thatRoot.getSqmJoins() ) ) {
+				return false;
+			}
+		}
+		return true;
+	}
+
+	private boolean equalsJoins(List<? extends SqmJoin<?, ?>> theseJoins, List<? extends SqmJoin<?, ?>> thoseJoins) {
+		for ( int i = 0; i < theseJoins.size(); i++ ) {
+			var thisJoin = theseJoins.get( i );
+			var thatJoin = thoseJoins.get( i );
+			if ( !Objects.equals( thisJoin.getNavigablePath(), thatJoin.getNavigablePath() )
+				|| !Objects.equals( thisJoin.getExplicitAlias(), thatJoin.getExplicitAlias() )
+				|| !Objects.equals( thisJoin.getJoinType(), thatJoin.getJoinType() )
+				|| !Objects.equals( thisJoin, thatJoin ) // needed for SqmDerivedRoots
+				|| thisJoin.getNumberOfJoins() != thatJoin.getNumberOfJoins()
+				|| !Objects.equals( thisJoin.getOn(), thatJoin.getOn() )
+				|| !equalsJoins( thisJoin.getSqmJoins(), thatJoin.getSqmJoins() ) ) {
+				return false;
+			}
+		}
+		return true;
+	}
+
+	@Override
+	public int hashCode() {
+		return getNumberOfRoots();
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/from/SqmFunctionJoin.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/from/SqmFunctionJoin.java
@@ -27,6 +27,8 @@ import jakarta.persistence.criteria.Expression;
 import jakarta.persistence.criteria.JoinType;
 import jakarta.persistence.criteria.Predicate;
 
+import java.util.Objects;
+
 /**
  * @author Christian Beikov
  */
@@ -225,5 +227,18 @@ public class SqmFunctionJoin<E> extends AbstractSqmJoin<Object, E> implements Jp
 	@Override
 	public JoinType getJoinType() {
 		return getSqmJoinType().getCorrespondingJpaJoinType();
+	}
+
+	@Override
+	public boolean equals(Object object) {
+		return object instanceof SqmFunctionJoin<?> that
+			&& super.equals( object )
+			&& this.lateral == that.lateral
+			&& Objects.equals( this.function, that.function );
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash( super.hashCode(), function, lateral );
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/from/SqmRoot.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/from/SqmRoot.java
@@ -206,24 +206,25 @@ public class SqmRoot<E> extends AbstractSqmFrom<E,E> implements JpaRoot<E> {
 		return treat;
 	}
 
+	@SuppressWarnings("unchecked")
 	@Override
 	public <S extends E> SqmTreatedRoot treatAs(Class<S> treatJavaType, String alias) {
 		throw new UnsupportedOperationException( "Root treats can not be aliased" );
 	}
 
-	@SuppressWarnings({ "rawtypes", "unchecked" })
+	@SuppressWarnings("unchecked")
 	@Override
 	public <S extends E> SqmTreatedRoot treatAs(EntityDomainType<S> treatTarget, String alias) {
 		throw new UnsupportedOperationException( "Root treats can not be aliased" );
 	}
 
-	@SuppressWarnings({ "rawtypes", "unchecked" })
+	@SuppressWarnings("unchecked")
 	@Override
 	public <S extends E> SqmTreatedRoot treatAs(Class<S> treatJavaType, String alias, boolean fetch) {
 		throw new TreatException( "Root paths cannot be aliased, nor fetched - " + getNavigablePath().getFullPath() );
 	}
 
-	@SuppressWarnings({ "rawtypes", "unchecked" })
+	@SuppressWarnings("unchecked")
 	@Override
 	public <S extends E> SqmTreatedRoot treatAs(EntityDomainType<S> treatTarget, String alias, boolean fetch) {
 		throw new TreatException( "Root paths cannot be aliased, nor fetched - " + getNavigablePath().getFullPath() );

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/insert/SqmConflictClause.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/insert/SqmConflictClause.java
@@ -8,6 +8,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 
 import org.hibernate.query.criteria.JpaConflictClause;
 import org.hibernate.query.criteria.JpaConflictUpdateAction;
@@ -211,5 +212,19 @@ public class SqmConflictClause<T> implements SqmVisitableNode, JpaConflictClause
 			sb.append( '.' );
 		}
 		sb.append( path.getReferencedPathSource().getPathName() );
+	}
+
+	@Override
+	public boolean equals(Object object) {
+		return object instanceof SqmConflictClause<?> that
+			&& Objects.equals( excludedRoot, that.excludedRoot )
+			&& Objects.equals( constraintName, that.constraintName )
+			&& Objects.equals( constraintPaths, that.constraintPaths )
+			&& Objects.equals( updateAction, that.updateAction );
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash( excludedRoot, constraintName, constraintPaths, updateAction );
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/insert/SqmInsertSelectStatement.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/insert/SqmInsertSelectStatement.java
@@ -6,6 +6,7 @@ package org.hibernate.query.sqm.tree.insert;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -53,7 +54,7 @@ public class SqmInsertSelectStatement<T> extends AbstractSqmInsertStatement<T> i
 		super(
 				new SqmRoot<>(
 						nodeBuilder.getDomainModel().entity( targetEntity ),
-						null,
+						"_0",
 						false,
 						nodeBuilder
 				),
@@ -187,5 +188,22 @@ public class SqmInsertSelectStatement<T> extends AbstractSqmInsertStatement<T> i
 		if ( conflictClause != null ) {
 			conflictClause.appendHqlString( hql, context );
 		}
+	}
+
+	@Override
+	public boolean equals(Object object) {
+		if ( !(object instanceof SqmInsertSelectStatement<?> that) ) {
+			return false;
+		}
+		return Objects.equals( selectQueryPart, that.selectQueryPart )
+			&& Objects.equals( this.getTarget(), that.getTarget() )
+			&& Objects.equals( this.getInsertionTargetPaths(), that.getInsertionTargetPaths() )
+			&& Objects.equals( this.getConflictClause(), that.getConflictClause() )
+			&& Objects.equals( this.getCteStatements(), that.getCteStatements() );
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash( selectQueryPart, getTarget(), getInsertionTargetPaths(), getConflictClause(), getCteStatements() );
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/insert/SqmInsertValuesStatement.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/insert/SqmInsertValuesStatement.java
@@ -9,6 +9,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -49,7 +50,7 @@ public class SqmInsertValuesStatement<T> extends AbstractSqmInsertStatement<T> i
 		super(
 				new SqmRoot<>(
 						nodeBuilder.getDomainModel().entity( targetEntity ),
-						null,
+						"_0",
 						false,
 						nodeBuilder
 				),
@@ -208,7 +209,7 @@ public class SqmInsertValuesStatement<T> extends AbstractSqmInsertStatement<T> i
 			appendValues( valuesList.get( i ), hql, context );
 		}
 		hql.append( ')' );
-		final SqmConflictClause conflictClause = getConflictClause();
+		final SqmConflictClause<?> conflictClause = getConflictClause();
 		if ( conflictClause != null ) {
 			conflictClause.appendHqlString( hql, context );
 		}
@@ -223,5 +224,22 @@ public class SqmInsertValuesStatement<T> extends AbstractSqmInsertStatement<T> i
 			expressions.get( i ).appendHqlString( sb, context );
 		}
 		sb.append( ')' );
+	}
+
+	@Override
+	public boolean equals(Object object) {
+		if ( !(object instanceof SqmInsertValuesStatement<?> that) ) {
+			return false;
+		}
+		return Objects.equals( valuesList, that.valuesList )
+			&& Objects.equals( this.getTarget(), that.getTarget() )
+			&& Objects.equals( this.getInsertionTargetPaths(), that.getInsertionTargetPaths() )
+			&& Objects.equals( this.getConflictClause(), that.getConflictClause() )
+			&& Objects.equals( this.getCteStatements(), that.getCteStatements() );
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash( valuesList, getTarget(), getInsertionTargetPaths(), getConflictClause(), getCteStatements() );
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/predicate/AbstractNegatableSqmPredicate.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/predicate/AbstractNegatableSqmPredicate.java
@@ -7,6 +7,8 @@ package org.hibernate.query.sqm.tree.predicate;
 import org.hibernate.query.sqm.NodeBuilder;
 import org.hibernate.query.sqm.SqmExpressible;
 
+import java.util.Objects;
+
 /**
  * @author Steve Ebersole
  */
@@ -33,7 +35,7 @@ public abstract class AbstractNegatableSqmPredicate extends AbstractSqmPredicate
 
 	@Override
 	public void negate() {
-		this.negated = !this.negated;
+		negated = !negated;
 	}
 
 	protected abstract SqmNegatablePredicate createNegatedNode();
@@ -45,4 +47,18 @@ public abstract class AbstractNegatableSqmPredicate extends AbstractSqmPredicate
 		return createNegatedNode();
 	}
 
+	@Override
+	// for safety only, overridden on all subtypes
+	public boolean equals(Object other) {
+		return other instanceof AbstractNegatableSqmPredicate that
+			&& this.negated == that.negated
+			&& this.getClass() == that.getClass()
+			&& Objects.equals( this.toHqlString(), that.toHqlString() );
+	}
+
+	@Override
+	// for safety only, overridden on all subtypes
+	public int hashCode() {
+		return Objects.hash( getClass(), negated );
+	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/predicate/SqmBetweenPredicate.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/predicate/SqmBetweenPredicate.java
@@ -12,6 +12,8 @@ import org.hibernate.query.sqm.tree.SqmCopyContext;
 import org.hibernate.query.sqm.tree.SqmRenderContext;
 import org.hibernate.query.sqm.tree.expression.SqmExpression;
 
+import java.util.Objects;
+
 import static org.hibernate.query.sqm.internal.TypecheckUtil.assertComparable;
 
 /**
@@ -94,6 +96,20 @@ public class SqmBetweenPredicate extends AbstractNegatableSqmPredicate {
 		lowerBound.appendHqlString( hql, context );
 		hql.append( " and " );
 		upperBound.appendHqlString( hql, context );
+	}
+
+	@Override
+	public boolean equals(Object object) {
+		return object instanceof SqmBetweenPredicate that
+			&& this.isNegated() == that.isNegated()
+			&& Objects.equals( expression, that.expression )
+			&& Objects.equals( lowerBound, that.lowerBound )
+			&& Objects.equals( upperBound, that.upperBound );
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash( isNegated(), expression, lowerBound, upperBound );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/predicate/SqmBooleanExpressionPredicate.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/predicate/SqmBooleanExpressionPredicate.java
@@ -6,6 +6,7 @@ package org.hibernate.query.sqm.tree.predicate;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 import org.hibernate.query.sqm.NodeBuilder;
 import org.hibernate.query.sqm.SemanticQueryWalker;
@@ -83,17 +84,26 @@ public class SqmBooleanExpressionPredicate extends AbstractNegatableSqmPredicate
 	}
 
 	@Override
+	public boolean equals(Object object) {
+		return object instanceof SqmBooleanExpressionPredicate that
+			&& this.isNegated() == that.isNegated()
+			&& Objects.equals( this.booleanExpression, that.booleanExpression );
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash( booleanExpression, isNegated() );
+	}
+
+	@Override
 	protected SqmNegatablePredicate createNegatedNode() {
 		return new SqmBooleanExpressionPredicate( booleanExpression, !isNegated(), nodeBuilder() );
 	}
 
 	@Override
 	public String toString() {
-		if ( isNegated() ) {
-			return "SqmBooleanExpressionPredicate( (not) " + booleanExpression + " )";
-		}
-		else {
-			return "SqmBooleanExpressionPredicate( " + booleanExpression + " )";
-		}
+		return isNegated()
+				? "SqmBooleanExpressionPredicate( (not) " + booleanExpression + " )"
+				: "SqmBooleanExpressionPredicate( " + booleanExpression + " )";
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/predicate/SqmComparisonPredicate.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/predicate/SqmComparisonPredicate.java
@@ -13,6 +13,8 @@ import org.hibernate.query.sqm.tree.SqmCopyContext;
 import org.hibernate.query.sqm.tree.SqmRenderContext;
 import org.hibernate.query.sqm.tree.expression.SqmExpression;
 
+import java.util.Objects;
+
 import static org.hibernate.query.sqm.internal.TypecheckUtil.assertComparable;
 
 /**
@@ -115,5 +117,19 @@ public class SqmComparisonPredicate extends AbstractNegatableSqmPredicate {
 		hql.append( operator.sqlText() );
 		hql.append( ' ' );
 		rightHandExpression.appendHqlString( hql, context );
+	}
+
+	@Override
+	public boolean equals(Object object) {
+		return object instanceof SqmComparisonPredicate that
+			&& this.isNegated() == that.isNegated()
+			&& this.operator == that.operator
+			&& Objects.equals( this.leftHandExpression, that.leftHandExpression )
+			&& Objects.equals( this.rightHandExpression, that.rightHandExpression );
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash( isNegated(), operator, leftHandExpression, rightHandExpression );
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/predicate/SqmEmptinessPredicate.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/predicate/SqmEmptinessPredicate.java
@@ -10,6 +10,8 @@ import org.hibernate.query.sqm.tree.SqmCopyContext;
 import org.hibernate.query.sqm.tree.SqmRenderContext;
 import org.hibernate.query.sqm.tree.domain.SqmPluralValuedSimplePath;
 
+import java.util.Objects;
+
 /**
  * @author Steve Ebersole
  */
@@ -17,7 +19,7 @@ public class SqmEmptinessPredicate extends AbstractNegatableSqmPredicate {
 	private final SqmPluralValuedSimplePath<?> pluralPath;
 
 	public SqmEmptinessPredicate(
-			SqmPluralValuedSimplePath pluralPath,
+			SqmPluralValuedSimplePath<?> pluralPath,
 			boolean negated,
 			NodeBuilder nodeBuilder) {
 		super( negated, nodeBuilder );
@@ -60,6 +62,18 @@ public class SqmEmptinessPredicate extends AbstractNegatableSqmPredicate {
 		else {
 			hql.append( " is empty" );
 		}
+	}
+
+	@Override
+	public boolean equals(Object object) {
+		return object instanceof SqmEmptinessPredicate that
+			&& this.isNegated() == that.isNegated()
+			&& Objects.equals( pluralPath, that.pluralPath );
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash( isNegated(), pluralPath );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/predicate/SqmExistsPredicate.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/predicate/SqmExistsPredicate.java
@@ -10,6 +10,8 @@ import org.hibernate.query.sqm.tree.SqmCopyContext;
 import org.hibernate.query.sqm.tree.SqmRenderContext;
 import org.hibernate.query.sqm.tree.expression.SqmExpression;
 
+import java.util.Objects;
+
 /**
  * @author Gavin King
  */
@@ -68,6 +70,18 @@ public class SqmExistsPredicate extends AbstractNegatableSqmPredicate {
 			hql.append( "exists " );
 		}
 		expression.appendHqlString( hql, context );
+	}
+
+	@Override
+	public boolean equals(Object object) {
+		return object instanceof SqmExistsPredicate that
+			&& this.isNegated() == that.isNegated()
+			&& Objects.equals( this.expression, that.expression );
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash( isNegated(), expression );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/predicate/SqmGroupedPredicate.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/predicate/SqmGroupedPredicate.java
@@ -6,6 +6,7 @@ package org.hibernate.query.sqm.tree.predicate;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 import org.hibernate.query.sqm.NodeBuilder;
 import org.hibernate.query.sqm.SemanticQueryWalker;
@@ -67,10 +68,22 @@ public class SqmGroupedPredicate extends AbstractSqmPredicate {
 	public SqmPredicate not() {
 		return new SqmNegatedPredicate( this, nodeBuilder() );
 	}
+
 	@Override
 	public void appendHqlString(StringBuilder hql, SqmRenderContext context) {
 		hql.append( '(' );
 		subPredicate.appendHqlString( hql, context );
 		hql.append( ')' );
+	}
+
+	@Override
+	public boolean equals(Object object) {
+		return object instanceof SqmGroupedPredicate that
+			&& Objects.equals( subPredicate, that.subPredicate );
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hashCode( subPredicate );
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/predicate/SqmInListPredicate.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/predicate/SqmInListPredicate.java
@@ -7,6 +7,7 @@ package org.hibernate.query.sqm.tree.predicate;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.Objects;
 
 import org.hibernate.internal.util.collections.ArrayHelper;
 import org.hibernate.query.criteria.JpaExpression;
@@ -159,6 +160,19 @@ public class SqmInListPredicate<T> extends AbstractNegatableSqmPredicate impleme
 			listExpressions.get( i ).appendHqlString( hql, context );
 		}
 		hql.append( ')' );
+	}
+
+	@Override
+	public boolean equals(Object object) {
+		return object instanceof SqmInListPredicate<?> that
+			&& this.isNegated() == that.isNegated()
+			&& Objects.equals( this.testExpression, that.testExpression )
+			&& Objects.equals( this.listExpressions, that.listExpressions );
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash( isNegated(), testExpression, listExpressions );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/predicate/SqmInSubQueryPredicate.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/predicate/SqmInSubQueryPredicate.java
@@ -16,6 +16,8 @@ import org.hibernate.query.sqm.tree.select.SqmSubQuery;
 
 import jakarta.persistence.criteria.Expression;
 
+import java.util.Objects;
+
 import static org.hibernate.query.sqm.internal.TypecheckUtil.assertComparable;
 
 /**
@@ -123,5 +125,18 @@ public class SqmInSubQueryPredicate<T> extends AbstractNegatableSqmPredicate imp
 				!isNegated(),
 				nodeBuilder()
 		);
+	}
+
+	@Override
+	public boolean equals(Object object) {
+		return object instanceof SqmInSubQueryPredicate<?> that
+			&& this.isNegated() == that.isNegated()
+			&& Objects.equals( this.testExpression, that.testExpression )
+			&& Objects.equals( this.subQueryExpression, that.subQueryExpression );
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash( testExpression, subQueryExpression, isNegated() );
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/predicate/SqmJunctionPredicate.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/predicate/SqmJunctionPredicate.java
@@ -6,6 +6,7 @@ package org.hibernate.query.sqm.tree.predicate;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 import org.hibernate.query.sqm.NodeBuilder;
 import org.hibernate.query.sqm.SemanticQueryWalker;
@@ -105,9 +106,11 @@ public class SqmJunctionPredicate extends AbstractSqmPredicate {
 
 	@Override
 	public void appendHqlString(StringBuilder hql, SqmRenderContext context) {
-		final String separator = booleanOperator == BooleanOperator.AND
-				? " and "
-				: " or ";
+		final String separator =
+				switch ( booleanOperator ) {
+					case AND -> " and ";
+					case OR -> " or ";
+				};
 		appendJunctionHqlString( predicates.get( 0 ), hql, context );
 		for ( int i = 1; i < predicates.size(); i++ ) {
 			hql.append( separator );
@@ -131,5 +134,19 @@ public class SqmJunctionPredicate extends AbstractSqmPredicate {
 		else {
 			p.appendHqlString( sb, context );
 		}
+	}
+
+	@Override
+	public boolean equals(Object object) {
+		if ( !(object instanceof SqmJunctionPredicate that) ) {
+			return false;
+		}
+		return booleanOperator == that.booleanOperator
+			&& Objects.equals( predicates, that.predicates );
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash( booleanOperator, predicates );
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/predicate/SqmLikePredicate.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/predicate/SqmLikePredicate.java
@@ -12,6 +12,8 @@ import org.hibernate.query.sqm.tree.SqmCopyContext;
 import org.hibernate.query.sqm.tree.SqmRenderContext;
 import org.hibernate.query.sqm.tree.expression.SqmExpression;
 
+import java.util.Objects;
+
 import static org.hibernate.query.sqm.internal.TypecheckUtil.assertString;
 
 /**
@@ -138,6 +140,21 @@ public class SqmLikePredicate extends AbstractNegatableSqmPredicate {
 			hql.append( " escape " );
 			escapeCharacter.appendHqlString( hql, context );
 		}
+	}
+
+	@Override
+	public boolean equals(Object object) {
+		return object instanceof SqmLikePredicate that
+			&& this.isNegated() == that.isNegated()
+			&& isCaseSensitive == that.isCaseSensitive
+			&& Objects.equals( this.matchExpression, that.matchExpression )
+			&& Objects.equals( pattern, that.pattern )
+			&& Objects.equals( escapeCharacter, that.escapeCharacter );
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash( isNegated(), matchExpression, pattern, escapeCharacter, isCaseSensitive );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/predicate/SqmMemberOfPredicate.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/predicate/SqmMemberOfPredicate.java
@@ -13,6 +13,8 @@ import org.hibernate.query.sqm.tree.SqmRenderContext;
 import org.hibernate.query.sqm.tree.domain.SqmPluralValuedSimplePath;
 import org.hibernate.query.sqm.tree.expression.SqmExpression;
 
+import java.util.Objects;
+
 import static org.hibernate.query.sqm.internal.TypecheckUtil.areTypesComparable;
 
 /**
@@ -93,6 +95,19 @@ public class SqmMemberOfPredicate extends AbstractNegatableSqmPredicate {
 		}
 		hql.append( " member of " );
 		pluralPath.appendHqlString( hql, context );
+	}
+
+	@Override
+	public boolean equals(Object object) {
+		return object instanceof SqmMemberOfPredicate that
+			&& this.isNegated() == that.isNegated()
+			&& Objects.equals( leftHandExpression, that.leftHandExpression )
+			&& Objects.equals( pluralPath, that.pluralPath );
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash( isNegated(), leftHandExpression, pluralPath );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/predicate/SqmNegatedPredicate.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/predicate/SqmNegatedPredicate.java
@@ -6,6 +6,7 @@ package org.hibernate.query.sqm.tree.predicate;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 import org.hibernate.query.sqm.NodeBuilder;
 import org.hibernate.query.sqm.SemanticQueryWalker;
@@ -72,6 +73,17 @@ public class SqmNegatedPredicate extends AbstractNegatableSqmPredicate {
 		hql.append( "not (" );
 		wrappedPredicate.appendHqlString( hql, context );
 		hql.append( ')' );
+	}
+
+	@Override
+	public boolean equals(Object object) {
+		return object instanceof SqmNegatedPredicate that
+			&& Objects.equals( wrappedPredicate, that.wrappedPredicate );
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash( wrappedPredicate );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/predicate/SqmNullnessPredicate.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/predicate/SqmNullnessPredicate.java
@@ -10,6 +10,8 @@ import org.hibernate.query.sqm.tree.SqmCopyContext;
 import org.hibernate.query.sqm.tree.SqmRenderContext;
 import org.hibernate.query.sqm.tree.expression.SqmExpression;
 
+import java.util.Objects;
+
 /**
  * @author Steve Ebersole
  */
@@ -61,6 +63,18 @@ public class SqmNullnessPredicate extends AbstractNegatableSqmPredicate {
 		else {
 			hql.append( " is null" );
 		}
+	}
+
+	@Override
+	public boolean equals(Object object) {
+		return object instanceof SqmNullnessPredicate that
+			&& this.isNegated() == that.isNegated()
+			&& Objects.equals( this.expression, that.expression );
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash( isNegated(), expression );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/predicate/SqmTruthnessPredicate.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/predicate/SqmTruthnessPredicate.java
@@ -10,6 +10,8 @@ import org.hibernate.query.sqm.tree.SqmCopyContext;
 import org.hibernate.query.sqm.tree.SqmRenderContext;
 import org.hibernate.query.sqm.tree.expression.SqmExpression;
 
+import java.util.Objects;
+
 /**
  * @author Gavin King
  */
@@ -63,6 +65,19 @@ public class SqmTruthnessPredicate extends AbstractNegatableSqmPredicate {
 			hql.append( "not " );
 		}
 		hql.append( getBooleanValue() );
+	}
+
+	@Override
+	public boolean equals(Object object) {
+		return object instanceof SqmTruthnessPredicate that
+			&& this.isNegated() == that.isNegated()
+			&& this.value == that.value
+			&& Objects.equals( this.expression, that.expression );
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash( isNegated(), value, expression );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/predicate/SqmWhereClause.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/predicate/SqmWhereClause.java
@@ -5,6 +5,7 @@
 package org.hibernate.query.sqm.tree.predicate;
 
 import java.util.Collection;
+import java.util.Objects;
 
 import org.hibernate.query.sqm.NodeBuilder;
 import org.hibernate.query.sqm.tree.SqmCopyContext;
@@ -70,5 +71,16 @@ public class SqmWhereClause implements SqmPredicateCollection {
 	@Override
 	public String toString() {
 		return "where " + predicate;
+	}
+
+	@Override
+	public boolean equals(Object other) {
+		return other instanceof SqmWhereClause that
+			&& Objects.equals( this.predicate, that.predicate );
+	}
+
+	@Override
+	public int hashCode() {
+		return predicate == null ? 0 : predicate.hashCode();
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/select/AbstractSqmSelectQuery.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/select/AbstractSqmSelectQuery.java
@@ -8,6 +8,7 @@ import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.function.Function;
 
@@ -19,7 +20,6 @@ import org.hibernate.query.criteria.JpaRoot;
 import org.hibernate.query.criteria.JpaSelection;
 import org.hibernate.query.criteria.JpaSetReturningFunction;
 import org.hibernate.query.sqm.NodeBuilder;
-import org.hibernate.query.sqm.spi.SqmCreationHelper;
 import org.hibernate.query.sqm.tree.AbstractSqmNode;
 import org.hibernate.query.sqm.tree.SqmCopyContext;
 import org.hibernate.query.sqm.tree.SqmRenderContext;
@@ -119,21 +119,21 @@ public abstract class AbstractSqmSelectQuery<T>
 
 	@Override
 	public <X> JpaCteCriteria<X> with(AbstractQuery<X> criteria) {
-		return withInternal( SqmCreationHelper.acquireUniqueAlias(), criteria );
+		return withInternal( generateAlias(), criteria );
 	}
 
 	@Override
 	public <X> JpaCteCriteria<X> withRecursiveUnionAll(
 			AbstractQuery<X> baseCriteria,
 			Function<JpaCteCriteria<X>, AbstractQuery<X>> recursiveCriteriaProducer) {
-		return withInternal( SqmCreationHelper.acquireUniqueAlias(), baseCriteria, false, recursiveCriteriaProducer );
+		return withInternal( generateAlias(), baseCriteria, false, recursiveCriteriaProducer );
 	}
 
 	@Override
 	public <X> JpaCteCriteria<X> withRecursiveUnionDistinct(
 			AbstractQuery<X> baseCriteria,
 			Function<JpaCteCriteria<X>, AbstractQuery<X>> recursiveCriteriaProducer) {
-		return withInternal( SqmCreationHelper.acquireUniqueAlias(), baseCriteria, true, recursiveCriteriaProducer );
+		return withInternal( generateAlias(), baseCriteria, true, recursiveCriteriaProducer );
 	}
 
 	@Override
@@ -279,12 +279,11 @@ public abstract class AbstractSqmSelectQuery<T>
 		return addRoot(
 				new SqmRoot<>(
 						nodeBuilder().getDomainModel().entity( entityClass ),
-						null,
+						generateAlias(),
 						true,
 						nodeBuilder()
 				)
 		);
-
 	}
 
 	@Override
@@ -315,14 +314,21 @@ public abstract class AbstractSqmSelectQuery<T>
 
 	@Override
 	public <X> SqmRoot<X> from(EntityType<X> entityType) {
-		return addRoot( new SqmRoot<>( (EntityDomainType<X>) entityType, null, true, nodeBuilder() ) );
+		return addRoot(
+				new SqmRoot<>(
+						(EntityDomainType<X>) entityType,
+						generateAlias(),
+						true,
+						nodeBuilder()
+				)
+		);
 	}
 
 	private void validateComplianceFromSubQuery() {
 		if ( nodeBuilder().isJpaQueryComplianceEnabled() ) {
 			throw new IllegalStateException(
-					"The JPA specification does not support subqueries in the from clause. " +
-							"Please disable the JPA query compliance if you want to use this feature." );
+					"The JPA specification does not support subqueries in the from clause. "
+					+ "Please disable the JPA query compliance if you want to use this feature." );
 		}
 	}
 
@@ -416,18 +422,28 @@ public abstract class AbstractSqmSelectQuery<T>
 		sqmQueryPart.appendHqlString( hql, context );
 	}
 
+	@Override
+	public boolean equals(Object object) {
+		return object instanceof AbstractSqmSelectQuery<?> that
+			&& Objects.equals( this.resultType, that.resultType ) // for performance!
+			&& Objects.equals( this.sqmQueryPart, that.sqmQueryPart )
+			&& Objects.equals( this.cteStatements, that.cteStatements );
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash( cteStatements, sqmQueryPart );
+	}
+
 	@SuppressWarnings("unchecked")
 	protected Selection<? extends T> getResultSelection(Selection<?>[] selections) {
 		final Class<T> resultType = getResultType();
 		if ( resultType == null || resultType == Object.class ) {
-			switch ( selections.length ) {
-				case 0:
-					throw new IllegalArgumentException( "Empty selections passed to criteria query typed as Object" );
-				case 1:
-					return (Selection<? extends T>) selections[0];
-				default:
-					return (Selection<? extends T>) nodeBuilder().array( selections );
-			}
+			return switch ( selections.length ) {
+				case 0 -> throw new IllegalArgumentException( "Empty selections passed to criteria query typed as Object" );
+				case 1 -> (Selection<? extends T>) selections[0];
+				default -> (Selection<? extends T>) nodeBuilder().array( selections );
+			};
 		}
 		else if ( Tuple.class.isAssignableFrom( resultType ) ) {
 			return (Selection<? extends T>) nodeBuilder().tuple( selections );

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/select/AbstractSqmSelectQuery.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/select/AbstractSqmSelectQuery.java
@@ -20,6 +20,7 @@ import org.hibernate.query.criteria.JpaRoot;
 import org.hibernate.query.criteria.JpaSelection;
 import org.hibernate.query.criteria.JpaSetReturningFunction;
 import org.hibernate.query.sqm.NodeBuilder;
+import org.hibernate.query.sqm.spi.SqmCreationHelper;
 import org.hibernate.query.sqm.tree.AbstractSqmNode;
 import org.hibernate.query.sqm.tree.SqmCopyContext;
 import org.hibernate.query.sqm.tree.SqmRenderContext;
@@ -117,9 +118,10 @@ public abstract class AbstractSqmSelectQuery<T>
 		return (JpaCteCriteria<X>) cteStatements.get( cteName );
 	}
 
-	@Override
+	@Override @Deprecated
 	public <X> JpaCteCriteria<X> with(AbstractQuery<X> criteria) {
-		return withInternal( generateAlias(), criteria );
+		// Use of acquireUniqueAlias() results in interpretation cache miss
+		return withInternal( "_" + SqmCreationHelper.acquireUniqueAlias(), criteria );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/select/SqmDynamicInstantiation.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/select/SqmDynamicInstantiation.java
@@ -7,6 +7,7 @@ package org.hibernate.query.sqm.tree.select;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.function.Consumer;
 
 import org.hibernate.query.sqm.DynamicInstantiationNature;
@@ -294,6 +295,18 @@ public class SqmDynamicInstantiation<T>
 		hql.append( ')' );
 	}
 
+	@Override
+	public boolean equals(Object object) {
+		return object instanceof SqmDynamicInstantiation<?> that
+			&& Objects.equals( instantiationTarget, that.instantiationTarget )
+			&& Objects.equals( arguments, that.arguments );
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash( instantiationTarget, arguments );
+	}
+
 	@SuppressWarnings("unused")
 	public SqmDynamicInstantiation<T> makeShallowCopy() {
 		return new SqmDynamicInstantiation<>( getInstantiationTarget(), nodeBuilder() );
@@ -307,6 +320,18 @@ public class SqmDynamicInstantiation<T>
 		private DynamicInstantiationTargetImpl(DynamicInstantiationNature nature, JavaType<T> javaType) {
 			this.nature = nature;
 			this.javaType = javaType;
+		}
+
+		@Override
+		public boolean equals(Object object) {
+			return object instanceof DynamicInstantiationTargetImpl<?> that
+				&& nature == that.nature
+				&& Objects.equals( javaType, that.javaType );
+		}
+
+		@Override
+		public int hashCode() {
+			return Objects.hash( nature, javaType );
 		}
 
 		@Override

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/select/SqmDynamicInstantiationArgument.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/select/SqmDynamicInstantiationArgument.java
@@ -9,6 +9,8 @@ import org.hibernate.query.sqm.SemanticQueryWalker;
 import org.hibernate.query.sqm.tree.SqmCopyContext;
 import org.hibernate.query.sqm.tree.SqmRenderContext;
 
+import java.util.Objects;
+
 /**
  * Represents an individual argument to a dynamic instantiation.
  *
@@ -62,5 +64,17 @@ public class SqmDynamicInstantiationArgument<T> implements SqmAliasedNode<T> {
 		if ( alias != null ) {
 			hql.append( " as " ).append( alias );
 		}
+	}
+
+	@Override
+	public boolean equals(Object object) {
+		return object instanceof SqmDynamicInstantiationArgument<?> that
+			&& Objects.equals( selectableNode, that.selectableNode )
+			&& Objects.equals( alias, that.alias );
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash( selectableNode, alias );
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/select/SqmJpaCompoundSelection.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/select/SqmJpaCompoundSelection.java
@@ -6,6 +6,7 @@ package org.hibernate.query.sqm.tree.select;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.function.Consumer;
 
 import org.hibernate.query.criteria.JpaCompoundSelection;
@@ -143,6 +144,17 @@ public class SqmJpaCompoundSelection<T>
 			hql.append(", ");
 			selectableNodes.get( i ).appendHqlString( hql, context );
 		}
+	}
+
+	@Override
+	public boolean equals(Object object) {
+		return object instanceof SqmJpaCompoundSelection<?> that
+			&& Objects.equals( selectableNodes, that.selectableNodes );
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash( selectableNodes );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/select/SqmOrderByClause.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/select/SqmOrderByClause.java
@@ -7,6 +7,7 @@ package org.hibernate.query.sqm.tree.select;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 import org.hibernate.query.sqm.tree.SqmCopyContext;
 import org.hibernate.query.sqm.tree.expression.SqmAliasedNodeRef;
@@ -84,5 +85,16 @@ public class SqmOrderByClause implements Serializable {
 				this.hasPositionalSortItem = true;
 			}
 		}
+	}
+
+	@Override
+	public boolean equals(Object object) {
+		return object instanceof SqmOrderByClause that
+			&& Objects.equals( this.sortSpecifications, that.sortSpecifications );
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash( sortSpecifications );
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/select/SqmQueryGroup.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/select/SqmQueryGroup.java
@@ -8,6 +8,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Objects;
 
 import org.hibernate.internal.util.collections.CollectionHelper;
 import org.hibernate.query.common.FetchClauseType;
@@ -242,5 +243,18 @@ public class SqmQueryGroup<T> extends SqmQueryPart<T> implements JpaQueryGroup<T
 		if ( needsParenthesis ) {
 			sb.append( ')' );
 		}
+	}
+
+	@Override
+	public boolean equals(Object object) {
+		return object instanceof SqmQueryGroup<?> that
+			&& super.equals( that )
+			&& this.setOperator == that.setOperator
+			&& Objects.equals( this.queryParts, that.queryParts );
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash( super.hashCode(), queryParts, setOperator );
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/select/SqmQuerySpec.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/select/SqmQuerySpec.java
@@ -8,6 +8,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 
 import org.hibernate.Internal;
@@ -595,10 +596,12 @@ public class SqmQuerySpec<T> extends SqmQueryPart<T>
 				hql.append( "distinct " );
 			}
 			final List<SqmSelection<?>> selections = selectClause.getSelections();
-			selections.get( 0 ).appendHqlString( hql, context );
-			for ( int i = 1; i < selections.size(); i++ ) {
-				hql.append( ", " );
-				selections.get( i ).appendHqlString( hql, context );
+			if ( !selections.isEmpty() ) {
+				selections.get( 0 ).appendHqlString( hql, context );
+				for ( int i = 1; i < selections.size(); i++ ) {
+					hql.append( ", " );
+					selections.get( i ).appendHqlString( hql, context );
+				}
 			}
 		}
 		if ( fromClause != null ) {
@@ -675,5 +678,23 @@ public class SqmQuerySpec<T> extends SqmQueryPart<T>
 			}
 		}
 		return false;
+	}
+
+	@Override
+	public boolean equals(Object other) {
+		return other instanceof SqmQuerySpec<?> that
+			&& super.equals( other )
+			&& Objects.equals( this.fromClause, that.fromClause )
+			&& Objects.equals( this.selectClause, that.selectClause )
+			&& Objects.equals( this.whereClause, that.whereClause )
+			&& Objects.equals( this.groupByClauseExpressions, that.groupByClauseExpressions )
+			&& Objects.equals( this.havingClausePredicate, that.havingClausePredicate );
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash( super.hashCode(),
+				fromClause, selectClause, whereClause,
+				groupByClauseExpressions, havingClausePredicate );
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/select/SqmSelectClause.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/select/SqmSelectClause.java
@@ -7,6 +7,7 @@ package org.hibernate.query.sqm.tree.select;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 
 import org.hibernate.query.criteria.JpaSelection;
 import org.hibernate.query.sqm.NodeBuilder;
@@ -145,5 +146,17 @@ public class SqmSelectClause extends AbstractSqmNode implements SqmAliasedExpres
 	@Override
 	public String getAlias() {
 		return null;
+	}
+
+	@Override
+	public boolean equals(Object other) {
+		return other instanceof SqmSelectClause that
+			&& distinct == that.distinct
+			&& Objects.equals( this.selections, that.selections );
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash( distinct, selections );
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/select/SqmSelectStatement.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/select/SqmSelectStatement.java
@@ -596,6 +596,6 @@ public class SqmSelectStatement<T> extends AbstractSqmSelectQuery<T>
 
 	@Override
 	public String generateAlias() {
-		return "_" + (++aliasCounter);
+		return "t_" + (++aliasCounter);
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/select/SqmSelectStatement.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/select/SqmSelectStatement.java
@@ -106,7 +106,10 @@ public class SqmSelectStatement<T> extends AbstractSqmSelectQuery<T>
 	 *           in order to allow correct parameter handing.
 	 */
 	public SqmSelectStatement(SqmSelectStatement<T> original) {
-		super( original.getQueryPart(), original.getCteStatementMap(), original.getResultType(), original.nodeBuilder() );
+		super( original.getQueryPart(),
+				original.getCteStatementMap(),
+				original.getResultType(),
+				original.nodeBuilder() );
 		this.querySource = CRITERIA;
 	}
 
@@ -270,8 +273,8 @@ public class SqmSelectStatement<T> extends AbstractSqmSelectQuery<T>
 	protected <X> JpaCteCriteria<X> withInternal(String name, AbstractQuery<X> criteria) {
 		if ( criteria instanceof SqmSubQuery<?> ) {
 			throw new IllegalArgumentException(
-					"Invalid query type provided to root query 'with' method, " +
-							"expecting a root query to use as CTE instead found a subquery"
+					"Invalid query type provided to root query 'with' method, "
+					+ "expecting a root query to use as CTE instead found a subquery"
 			);
 		}
 		return super.withInternal( name, criteria );
@@ -286,8 +289,8 @@ public class SqmSelectStatement<T> extends AbstractSqmSelectQuery<T>
 			AbstractQuery<X>> recursiveCriteriaProducer) {
 		if ( baseCriteria instanceof SqmSubQuery<?> ) {
 			throw new IllegalArgumentException(
-					"Invalid query type provided to root query 'with' method, " +
-							"expecting a root query to use as CTE instead found a subquery"
+					"Invalid query type provided to root query 'with' method, "
+					+ "expecting a root query to use as CTE instead found a subquery"
 			);
 		}
 		return super.withInternal( name, baseCriteria, unionDistinct, recursiveCriteriaProducer );
@@ -523,13 +526,14 @@ public class SqmSelectStatement<T> extends AbstractSqmSelectQuery<T>
 	public SqmSelectStatement<Long> createCountQuery() {
 		final SqmSelectStatement<?> copy = createCopy( noParamCopyContext(), Object.class );
 		final SqmQueryPart<?> queryPart = copy.getQueryPart();
-		final SqmQuerySpec<?> querySpec;
 		//TODO: detect queries with no 'group by', but aggregate functions
 		//      in 'select' list (we don't even need to hit the database to
 		//      know they return exactly one row)
-		if ( queryPart.isSimpleQueryPart()
-				&& !( querySpec = (SqmQuerySpec<?>) queryPart ).isDistinct()
+		if ( queryPart instanceof SqmQuerySpec<?> querySpec
+				&& !querySpec.isDistinct()
 				&& querySpec.getGroupingExpressions().isEmpty() ) {
+			// we can just remove any fetch joins and
+			// replace the select list with count(*)
 			for ( SqmRoot<?> root : querySpec.getRootList() ) {
 				root.removeLeftFetchJoins();
 			}
@@ -537,13 +541,13 @@ public class SqmSelectStatement<T> extends AbstractSqmSelectQuery<T>
 			if ( querySpec.getFetch() == null && querySpec.getOffset() == null ) {
 				querySpec.setOrderByClause( null );
 			}
-
 			return (SqmSelectStatement<Long>) copy;
 		}
 		else {
+			// we have to wrap query in an outer query
 			aliasSelections( queryPart );
-			final SqmSubQuery<?> subquery = new SqmSubQuery<>( copy, queryPart, null, nodeBuilder() );
 			final SqmSelectStatement<Long> query = nodeBuilder().createQuery( Long.class );
+			final SqmSubQuery<?> subquery = new SqmSubQuery<>( query, queryPart, null, nodeBuilder() );
 			query.from( subquery );
 			query.select( nodeBuilder().count() );
 			if ( subquery.getFetch() == null && subquery.getOffset() == null ) {
@@ -553,6 +557,10 @@ public class SqmSelectStatement<T> extends AbstractSqmSelectQuery<T>
 		}
 	}
 
+	/**
+	 * Add synthetic aliases to all elements of the {@code select}
+	 * list, allowing the query to be reused as a subquery.
+	 */
 	private <S> void aliasSelections(SqmQueryPart<S> queryPart) {
 		if ( queryPart.isSimpleQueryPart() ) {
 			final SqmQuerySpec<S> querySpec = queryPart.getFirstQuerySpec();
@@ -576,8 +584,18 @@ public class SqmSelectStatement<T> extends AbstractSqmSelectQuery<T>
 				aliasSelection( selectionItem, newSelections );
 			}
 		}
-		else {
+		// careful, if we don't want to reinsert the same selection
+		// with a different hash (because we modified the alias) or
+		// we'll get a broken LinkedHashSet containing dupe elements
+		else if ( !newSelections.contains( selection ) ) {
 			newSelections.add( selection.alias( "c" + newSelections.size() ) );
 		}
+	}
+
+	private int aliasCounter = 0;
+
+	@Override
+	public String generateAlias() {
+		return "_" + (++aliasCounter);
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/select/SqmSelection.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/select/SqmSelection.java
@@ -10,6 +10,8 @@ import org.hibernate.query.sqm.tree.AbstractSqmNode;
 import org.hibernate.query.sqm.tree.SqmCopyContext;
 import org.hibernate.query.sqm.tree.SqmRenderContext;
 
+import java.util.Objects;
+
 /**
  * Represents an individual selection within a select clause.
  *
@@ -67,5 +69,18 @@ public class SqmSelection<T> extends AbstractSqmNode implements SqmAliasedNode<T
 		if ( alias != null ) {
 			hql.append( " as " ).append( alias );
 		}
+	}
+
+
+	@Override
+	public boolean equals(Object object) {
+		return object instanceof SqmSelection<?> that
+			&& Objects.equals( this.selectableNode, that.selectableNode )
+			&& Objects.equals( this.alias, that.alias );
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash( selectableNode, alias );
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/select/SqmSortSpecification.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/select/SqmSortSpecification.java
@@ -34,7 +34,7 @@ public class SqmSortSpecification implements JpaOrder {
 	}
 
 	public SqmSortSpecification(
-				SqmExpression sortExpression,
+				SqmExpression<?> sortExpression,
 				SortDirection sortOrder,
 				Nulls nullPrecedence,
 				boolean ignoreCase) {
@@ -141,19 +141,15 @@ public class SqmSortSpecification implements JpaOrder {
 	}
 
 	@Override
-	public boolean equals(Object o) {
-		if ( this == o ) {
+	public boolean equals(Object other) {
+		if ( this == other ) {
 			return true;
 		}
-		else if ( !(o instanceof SqmSortSpecification that) ) {
-			return false;
-		}
-		else {
-			// used in SqmInterpretationsKey.equals()
-			return Objects.equals( sortExpression, that.sortExpression )
-				&& sortOrder == that.sortOrder
-				&& nullPrecedence == that.nullPrecedence;
-		}
+		// used in SqmInterpretationsKey.equals()
+		return other instanceof SqmSortSpecification that
+			&& Objects.equals( this.sortExpression, that.sortExpression )
+			&& this.sortOrder == that.sortOrder
+			&& this.nullPrecedence == that.nullPrecedence;
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/select/SqmSubQuery.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/select/SqmSubQuery.java
@@ -11,6 +11,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.function.Function;
 
@@ -771,4 +772,20 @@ public class SqmSubQuery<T> extends AbstractSqmSelectQuery<T>
 		hql.append( ')' );
 	}
 
+	@Override
+	public boolean equals(Object object) {
+		return object instanceof SqmSubQuery<?> that
+			&& Objects.equals( this.alias, that.alias )
+			&& super.equals( object );
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash( super.hashCode(), alias );
+	}
+
+	@Override
+	public String generateAlias() {
+		return parent.generateAlias();
+	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/update/SqmUpdateStatement.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/update/SqmUpdateStatement.java
@@ -7,6 +7,7 @@ package org.hibernate.query.sqm.tree.update;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 
 import org.hibernate.HibernateException;
@@ -79,7 +80,7 @@ public class SqmUpdateStatement<T>
 		super(
 				new SqmRoot<>(
 						nodeBuilder.getDomainModel().entity( targetEntity ),
-						null,
+						"_0",
 						!nodeBuilder.isJpaQueryComplianceEnabled(),
 						nodeBuilder
 				),
@@ -287,7 +288,22 @@ public class SqmUpdateStatement<T>
 		SqmFromClause.appendJoins( root, hql, context );
 		SqmFromClause.appendTreatJoins( root, hql, context );
 		setClause.appendHqlString( hql, context );
-
 		super.appendHqlString( hql, context );
+	}
+
+	@Override
+	public boolean equals(Object node) {
+		return node instanceof SqmUpdateStatement<?> that
+			&& super.equals( node )
+			&& this.versioned == that.versioned
+			&& Objects.equals( this.setClause, that.setClause )
+			&& Objects.equals( this.getTarget(), that.getTarget() )
+			&& Objects.equals( this.getWhereClause(), that.getWhereClause() )
+			&& Objects.equals( this.getCteStatements(), that.getCteStatements() );
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash( versioned, setClause, getTarget(), getWhereClause(), getCteStatements() );
 	}
 }

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/query/criteria/plan/CriteriaPlanTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/query/criteria/plan/CriteriaPlanTest.java
@@ -1,0 +1,113 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.query.criteria.plan;
+
+import org.hibernate.cfg.AvailableSettings;
+import org.hibernate.engine.spi.SessionImplementor;
+import org.hibernate.query.criteria.HibernateCriteriaBuilder;
+import org.hibernate.query.criteria.JpaCriteriaQuery;
+import org.hibernate.query.criteria.JpaRoot;
+import org.hibernate.testing.orm.junit.*;
+import org.junit.jupiter.api.Test;
+
+import jakarta.persistence.*;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DomainModel(annotatedClasses = {CriteriaPlanTest.Author.class, CriteriaPlanTest.Book.class})
+@ServiceRegistry(
+		settings = {
+				@Setting(name = AvailableSettings.CRITERIA_COPY_TREE, value = "false"),
+				@Setting(name = AvailableSettings.CRITERIA_PLAN_CACHE_ENABLED, value = "true"),
+		}
+)
+@SessionFactory
+class CriteriaPlanTest {
+
+	@Test
+	void criteriaPlanCacheWithEntityParameters(SessionFactoryScope scope) {
+		scope.inTransaction( session -> {
+			final Author author = populateData(session);
+
+			assertThat(runQuery(session, author)).hasSize(5);
+			assertThat(runQuery(session, author)).hasSize(5);
+		} );
+	}
+
+	private static List<Book> runQuery(SessionImplementor session, Author author) {
+		final HibernateCriteriaBuilder cb = session.getCriteriaBuilder();
+		final JpaCriteriaQuery<Book> q = cb.createQuery(Book.class);
+		final JpaRoot<Book> root = q.from(Book.class);
+		q.select(root);
+		q.where(cb.equal(root.get("author"), author));
+		return session.createQuery(q).getResultList();
+	}
+
+	public Author populateData(SessionImplementor entityManager) {
+		final Author author = new Author();
+		author.name = "David Gourley";
+		entityManager.persist(author);
+
+		for (int i = 0; i < 5; i++) {
+			final Book book = new Book();
+			book.name = "HTTP Definitive guide " + i;
+			book.author = author;
+			entityManager.persist(book);
+			author.books.add(book);
+		}
+
+		return author;
+	}
+
+	@Entity(name = "Author")
+	@Table(name = "Author")
+	public static class Author {
+		@Id
+		@GeneratedValue(strategy = GenerationType.IDENTITY)
+		public Long authorId;
+
+		@Column
+		public String name;
+
+		@OneToMany(fetch = FetchType.LAZY, mappedBy = "author")
+		public List<Book> books = new ArrayList<>();
+
+		@Override
+		public boolean equals(Object o) {
+			if (this == o) {
+				return true;
+			}
+			if (o == null || getClass() != o.getClass()) {
+				return false;
+			}
+
+			final Author author = (Author) o;
+			return authorId.equals(author.authorId);
+		}
+
+		@Override
+		public int hashCode() {
+			return authorId.hashCode();
+		}
+	}
+
+	@org.hibernate.annotations.Cache(usage = org.hibernate.annotations.CacheConcurrencyStrategy.READ_WRITE)
+	@Entity(name = "Book")
+	@Table(name = "Book")
+	public static class Book {
+		@Id
+		@GeneratedValue(strategy = GenerationType.IDENTITY)
+		public Long bookId;
+
+		@Column
+		public String name;
+
+		@ManyToOne(fetch = FetchType.LAZY, optional = false)
+		@JoinColumn(name = "author_id", nullable = false)
+		public Author author;
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/querycache/AbstractQueryCacheResultTransformerTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/querycache/AbstractQueryCacheResultTransformerTest.java
@@ -111,7 +111,7 @@ public abstract class AbstractQueryCacheResultTransformerTest {
 				query.setResultTransformer( getResultTransformer() );
 			}
 
-			return ( isSingleResult ? query.uniqueResult() : query.list() );
+			return isSingleResult ? query.uniqueResult() : query.list();
 		}
 	}
 


### PR DESCRIPTION

- finally enables efficient caching of criteria query plans
- also reconsider how alias generation is done - aliases should only be unique to a given query, NOT globally unique, since that results in interpretation cache misses
- ran into and fixed several other problems along the way
- note that the previous solution based on translating to HQL was not working at all, partly because the translation to HQL is not very correct - but anyway this is more efficient, since hashCodes are in general more flexible from an efficiency perspective
- there is still a remaining problem where NavigablePaths elements are assigned globally unique aliases resulting in cache misses

<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

[Please describe here what your change is about]

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
