### PR TITLE
document deprecation of Byte[], Character[] in JPA 3.2

### DIFF
--- a/documentation/src/main/asciidoc/introduction/Entities.adoc
+++ b/documentation/src/main/asciidoc/introduction/Entities.adoc
@@ -534,11 +534,12 @@ The JPA specification defines a quite limited set of basic types:
 | Primitive wrappers | `java.lang` | `Boolean`, `Integer`, `Double`, etc
 | Strings | `java.lang` | `String`
 | Arbitrary-precision numeric types | `java.math` | `BigInteger`, `BigDecimal`
+| UUIDs | `java.util` | `UUID`
 | Date/time types | `java.time` | `LocalDate`, `LocalTime`, `LocalDateTime`, `OffsetDateTime`, `Instant`, `Year`
 | Deprecated date/time types 💀 | `java.util` | `Date`, `Calendar`
 | Deprecated JDBC date/time types 💀 | `java.sql` | `Date`, `Time`, `Timestamp`
 | Binary and character arrays | | `byte[]`, `char[]`
-| UUIDs | `java.util` | `UUID`
+| Binary and character wrapper arrays 💀 | `java.lang` | `Byte[]`, `Character[]`
 | Enumerated types | | Any `enum`
 | Serializable types | | Any type which implements `java.io.Serializable`
 |====
@@ -547,6 +548,13 @@ The JPA specification defines a quite limited set of basic types:
 // .Please don't use `Date`!
 ====
 We're begging you to use types from the `java.time` package instead of anything which inherits `java.util.Date`.
+====
+
+[WARNING]
+====
+The use of `Byte[]` and `Character[]` as basic types was deprecated by Jakarta Persistence 3.2.
+Hibernate does not allow `null` elements in such arrays.
+Use `byte[]` or `char[]` instead.
 ====
 
 [CAUTION]


### PR DESCRIPTION
<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

[Please describe here what your change is about]

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
