### PR TITLE
HHH-19425 fix missing '.class' when annotations copied to repo implementations

### DIFF
--- a/tooling/metamodel-generator/src/jakartaData/java/org/hibernate/processor/test/data/eg/Library.java
+++ b/tooling/metamodel-generator/src/jakartaData/java/org/hibernate/processor/test/data/eg/Library.java
@@ -27,7 +27,7 @@ import jakarta.validation.constraints.NotNull;
 import java.time.LocalDate;
 import java.util.List;
 
-@Transactional
+@Transactional(rollbackOn = RuntimeException.class)
 @Repository
 public interface Library {
 

--- a/tooling/metamodel-generator/src/main/java/org/hibernate/processor/ClassWriter.java
+++ b/tooling/metamodel-generator/src/main/java/org/hibernate/processor/ClassWriter.java
@@ -17,6 +17,7 @@ import javax.lang.model.element.Modifier;
 import javax.lang.model.element.PackageElement;
 import javax.lang.model.element.TypeElement;
 import javax.lang.model.element.VariableElement;
+import javax.lang.model.type.TypeMirror;
 import javax.tools.Diagnostic;
 import javax.tools.FileObject;
 import java.io.IOException;
@@ -190,9 +191,12 @@ public final class ClassWriter {
 		else if (argument instanceof AnnotationMirror childAnnotation) {
 			printAnnotation( childAnnotation, pw );
 		}
+		else if (argument instanceof TypeMirror) {
+			pw.print(argument);
+			pw.print(".class");
+		}
 		else if (argument instanceof List) {
-			final List<? extends AnnotationValue> list =
-					(List<? extends AnnotationValue>) argument;
+			final var list = (List<? extends AnnotationValue>) argument;
 			pw.print('{');
 			boolean first = true;
 			for (AnnotationValue listedValue : list) {


### PR DESCRIPTION
<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

[Please describe here what your change is about]

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-19425
<!-- Hibernate GitHub Bot issue links end -->