### PR TITLE
HHH-19341 Adjust the snapshots publishing config to use username/password env variables

### DIFF
--- a/local-build-plugins/src/main/groovy/local.publishing.gradle
+++ b/local-build-plugins/src/main/groovy/local.publishing.gradle
@@ -70,6 +70,9 @@ publishingExtension.repositories {
     maven {
         name = 'snapshots'
         url = "https://oss.sonatype.org/content/repositories/snapshots/"
+        // So that Gradle uses the `ORG_GRADLE_PROJECT_snapshotsPassword` / `ORG_GRADLE_PROJECT_snapshotsUsername`
+        //  env variables to read the username/password for the `snapshots` repository publishing:
+        credentials(PasswordCredentials)
     }
 }
 


### PR DESCRIPTION
<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-19341
<!-- Hibernate GitHub Bot issue links end -->