### PR TITLE
HHH-19324 Fix `DynamicTypingTests` on hana_cloud and cockroachdb

### DIFF
--- a/hibernate-core/src/test/java/org/hibernate/orm/test/boot/models/xml/dynamic/DynamicTypingTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/boot/models/xml/dynamic/DynamicTypingTests.java
@@ -57,11 +57,11 @@ public class DynamicTypingTests {
 		assertThat( entityBinding ).isNotNull();
 
 		verifyBasicAttribute( entityBinding, "theBoolean", BooleanJavaType.class, booleanJdbcType.getJdbcTypeCode() );
-		verifyBasicAttribute( entityBinding, "theString", StringJavaType.class, SqlTypes.VARCHAR );
+		verifyBasicAttribute( entityBinding, "theString", StringJavaType.class, SqlTypes.VARCHAR, /*HANA Cloud uses UTF8 by default*/ SqlTypes.NVARCHAR );
 		verifyBasicAttribute( entityBinding, "theInt", IntegerJavaType.class, SqlTypes.INTEGER );
 		verifyBasicAttribute( entityBinding, "theInteger", IntegerJavaType.class, SqlTypes.INTEGER );
 		verifyBasicAttribute( entityBinding, "theUrl", UrlJavaType.class, SqlTypes.VARCHAR );
-		verifyBasicAttribute( entityBinding, "theClob", ClobJavaType.class, SqlTypes.CLOB );
+		verifyBasicAttribute( entityBinding, "theClob", ClobJavaType.class, SqlTypes.CLOB, /*CockroachDB doesn't support CLOBs*/ SqlTypes.VARCHAR );
 		verifyBasicAttribute( entityBinding, "theInstant", InstantJavaType.class, SqlTypes.INSTANT );
 		verifyBasicAttribute( entityBinding, "theDate", JdbcDateJavaType.class, SqlTypes.DATE );
 		verifyBasicAttribute( entityBinding, "theTime", JdbcTimeJavaType.class, SqlTypes.TIME );
@@ -72,15 +72,15 @@ public class DynamicTypingTests {
 	}
 
 
-	private static void verifyBasicAttribute(RootClass rootClass, String attributeName, Class<? extends BasicJavaType<?>> expectedJavaType, int expectedJdbcTypeCode) {
+	private static void verifyBasicAttribute(RootClass rootClass, String attributeName, Class<? extends BasicJavaType<?>> expectedJavaType, int... expectedJdbcTypeCodes) {
 		final Property attribute = rootClass.getProperty( attributeName );
 		assertThat( attribute.getType() ).isInstanceOf( BasicType.class );
-		verifyBasicMapping( (BasicType<?>) attribute.getType(), expectedJavaType, expectedJdbcTypeCode );
+		verifyBasicMapping( (BasicType<?>) attribute.getType(), expectedJavaType, expectedJdbcTypeCodes );
 	}
 
-	private static void verifyBasicMapping(BasicType<?> type, Class<? extends BasicJavaType<?>> expectedJavaType, int expectedJdbcTypeCode) {
+	private static void verifyBasicMapping(BasicType<?> type, Class<? extends BasicJavaType<?>> expectedJavaType, int... expectedJdbcTypeCodes) {
 		assertThat( type.getJavaTypeDescriptor().getClass() ).isEqualTo( expectedJavaType );
-		assertThat( type.getJdbcType().getJdbcTypeCode() ).isEqualTo( expectedJdbcTypeCode );
+		assertThat( expectedJdbcTypeCodes ).contains( type.getJdbcType().getJdbcTypeCode() );
 	}
 
 	private static void verifyElementCollection(RootClass rootClass, String name, Class<? extends BasicJavaType<?>> expectedJavaType, int expectedJdbcTypeCode) {


### PR DESCRIPTION
<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

Fixes test failing on nightly CI due to Hana Cloud defaulting to `NVARCHAR` instead of `VARCHAR`, and to CockroachDB using `VARCHAR` instead of `CLOB`.

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
