### PR TITLE
HHH-19438 move OutputableType to org.hibernate.type

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/BasicDomainType.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/BasicDomainType.java
@@ -6,7 +6,7 @@ package org.hibernate.metamodel.model.domain;
 
 import jakarta.persistence.metamodel.BasicType;
 
-import org.hibernate.query.OutputableType;
+import org.hibernate.type.OutputableType;
 
 /**
  * Hibernate extension to the JPA {@link BasicType} contract.

--- a/hibernate-core/src/main/java/org/hibernate/procedure/ProcedureCall.java
+++ b/hibernate-core/src/main/java/org/hibernate/procedure/ProcedureCall.java
@@ -16,10 +16,8 @@ import jakarta.persistence.TemporalType;
 
 import org.hibernate.MappingException;
 import org.hibernate.query.SynchronizeableQuery;
-import org.hibernate.procedure.spi.NamedCallableQueryMemento;
 import org.hibernate.query.CommonQueryContract;
 import org.hibernate.query.procedure.ProcedureParameter;
-import org.hibernate.query.named.NameableQuery;
 import org.hibernate.type.BasicTypeReference;
 
 /**
@@ -56,7 +54,7 @@ import org.hibernate.type.BasicTypeReference;
  * @author Steve Ebersole
  */
 public interface ProcedureCall
-		extends CommonQueryContract, SynchronizeableQuery, StoredProcedureQuery, NameableQuery, AutoCloseable {
+		extends CommonQueryContract, SynchronizeableQuery, StoredProcedureQuery, AutoCloseable {
 	/**
 	 * The hint key (for use with JPA's "hint system") indicating the function's return JDBC type code
 	 * (aka, {@link java.sql.Types} code)
@@ -245,9 +243,6 @@ public interface ProcedureCall
 
 	@Override
 	ProcedureCall addSynchronizedEntityClass(@SuppressWarnings("rawtypes") Class entityClass) throws MappingException;
-
-	@Override
-	NamedCallableQueryMemento toMemento(String name);
 
 	@Override
 	ProcedureCall setHint(String hintName, Object value);

--- a/hibernate-core/src/main/java/org/hibernate/procedure/ProcedureCall.java
+++ b/hibernate-core/src/main/java/org/hibernate/procedure/ProcedureCall.java
@@ -30,10 +30,7 @@ import org.hibernate.type.BasicTypeReference;
  * <p>
  * Unless explicitly specified, the ProcedureCall is assumed to follow the
  * procedure call syntax.  To explicitly specify that this should be a function
- * call, use {@link #markAsFunctionCall}.  JPA users could either:<ul>
- *     <li>use {@code storedProcedureQuery.unwrap( ProcedureCall.class }.markAsFunctionCall()</li>
- *     <li>set the {@link #FUNCTION_RETURN_TYPE_HINT} hint (avoids casting to Hibernate-specific classes)</li>
- * </ul>
+ * call, use {@link #markAsFunctionCall}.
  * <p>
  * When using function-call syntax:<ul>
  *     <li>parameters must be registered by position (not name)</li>
@@ -55,11 +52,6 @@ import org.hibernate.type.BasicTypeReference;
  */
 public interface ProcedureCall
 		extends CommonQueryContract, SynchronizeableQuery, StoredProcedureQuery, AutoCloseable {
-	/**
-	 * The hint key (for use with JPA's "hint system") indicating the function's return JDBC type code
-	 * (aka, {@link java.sql.Types} code)
-	 */
-	String FUNCTION_RETURN_TYPE_HINT = "hibernate.procedure.function_return_jdbc_type_code";
 
 	/**
 	 * Get the name of the stored procedure (or function) to be called.
@@ -282,4 +274,12 @@ public interface ProcedureCall
 
 	@Override
 	ProcedureCall registerStoredProcedureParameter(String parameterName, Class<?> type, ParameterMode mode);
+
+	/**
+	 * The hint key indicating the function's return {@linkplain java.sql.Types JDBC type code}.
+	 *
+	 * @deprecated This hint no longer has any effect. Use {@link #markAsFunctionCall(int)}.
+	 */
+	@Deprecated(since="7", forRemoval = true)
+	String FUNCTION_RETURN_TYPE_HINT = "hibernate.procedure.function_return_jdbc_type_code";
 }

--- a/hibernate-core/src/main/java/org/hibernate/procedure/internal/FunctionReturnImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/procedure/internal/FunctionReturnImpl.java
@@ -11,7 +11,7 @@ import org.hibernate.procedure.spi.FunctionReturnImplementor;
 import org.hibernate.procedure.spi.NamedCallableQueryMemento;
 import org.hibernate.procedure.spi.ProcedureCallImplementor;
 import org.hibernate.query.BindableType;
-import org.hibernate.query.OutputableType;
+import org.hibernate.type.OutputableType;
 import org.hibernate.sql.exec.internal.JdbcCallFunctionReturnImpl.RefCurserJdbcCallFunctionReturnImpl;
 import org.hibernate.sql.exec.internal.JdbcCallFunctionReturnImpl.RegularJdbcCallFunctionReturnImpl;
 import org.hibernate.sql.exec.internal.JdbcCallParameterExtractorImpl;

--- a/hibernate-core/src/main/java/org/hibernate/procedure/internal/PostgreSQLCallableStatementSupport.java
+++ b/hibernate-core/src/main/java/org/hibernate/procedure/internal/PostgreSQLCallableStatementSupport.java
@@ -11,7 +11,7 @@ import org.hibernate.dialect.type.AbstractPostgreSQLStructJdbcType;
 import org.hibernate.procedure.spi.FunctionReturnImplementor;
 import org.hibernate.procedure.spi.ProcedureCallImplementor;
 import org.hibernate.procedure.spi.ProcedureParameterImplementor;
-import org.hibernate.query.OutputableType;
+import org.hibernate.type.OutputableType;
 import org.hibernate.query.spi.ProcedureParameterMetadataImplementor;
 import org.hibernate.sql.exec.internal.JdbcCallImpl;
 import org.hibernate.sql.exec.spi.JdbcCallParameterRegistration;

--- a/hibernate-core/src/main/java/org/hibernate/procedure/internal/ProcedureCallImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/procedure/internal/ProcedureCallImpl.java
@@ -44,7 +44,7 @@ import org.hibernate.procedure.spi.ProcedureParameterImplementor;
 import org.hibernate.query.BindableType;
 import org.hibernate.query.KeyedPage;
 import org.hibernate.query.KeyedResultList;
-import org.hibernate.query.OutputableType;
+import org.hibernate.type.OutputableType;
 import org.hibernate.query.Query;
 import org.hibernate.query.QueryParameter;
 import org.hibernate.query.internal.QueryOptionsImpl;

--- a/hibernate-core/src/main/java/org/hibernate/procedure/internal/ProcedureParameterImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/procedure/internal/ProcedureParameterImpl.java
@@ -15,7 +15,7 @@ import org.hibernate.procedure.spi.ParameterStrategy;
 import org.hibernate.procedure.spi.ProcedureCallImplementor;
 import org.hibernate.procedure.spi.ProcedureParameterImplementor;
 import org.hibernate.query.BindableType;
-import org.hibernate.query.OutputableType;
+import org.hibernate.type.OutputableType;
 import org.hibernate.query.internal.BindingTypeHelper;
 import org.hibernate.query.spi.AbstractQueryParameter;
 import org.hibernate.query.spi.QueryParameterBinding;

--- a/hibernate-core/src/main/java/org/hibernate/procedure/spi/ProcedureCallImplementor.java
+++ b/hibernate-core/src/main/java/org/hibernate/procedure/spi/ProcedureCallImplementor.java
@@ -9,6 +9,7 @@ import java.util.Date;
 import java.util.List;
 
 import org.hibernate.procedure.ProcedureCall;
+import org.hibernate.query.named.NameableQuery;
 import org.hibernate.query.spi.ProcedureParameterMetadataImplementor;
 import org.hibernate.query.spi.QueryImplementor;
 import org.hibernate.type.BasicTypeReference;
@@ -23,7 +24,7 @@ import jakarta.persistence.TemporalType;
 /**
  * @author Steve Ebersole
  */
-public interface ProcedureCallImplementor<R> extends ProcedureCall, QueryImplementor<R> {
+public interface ProcedureCallImplementor<R> extends ProcedureCall, NameableQuery, QueryImplementor<R> {
 	@Override
 	default List<R> getResultList() {
 		return list();
@@ -93,4 +94,6 @@ public interface ProcedureCallImplementor<R> extends ProcedureCall, QueryImpleme
 	@Override
 	ProcedureCallImplementor<R> registerStoredProcedureParameter(String parameterName, Class<?> type, ParameterMode mode);
 
+	@Override
+	NamedCallableQueryMemento toMemento(String name);
 }

--- a/hibernate-core/src/main/java/org/hibernate/query/SelectionQuery.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/SelectionQuery.java
@@ -16,6 +16,7 @@ import java.util.stream.Stream;
 import jakarta.persistence.CacheRetrieveMode;
 import jakarta.persistence.CacheStoreMode;
 import jakarta.persistence.EntityGraph;
+
 import org.hibernate.CacheMode;
 import org.hibernate.FlushMode;
 import org.hibernate.Incubating;
@@ -27,13 +28,11 @@ import org.hibernate.ScrollableResults;
 import org.hibernate.Session;
 import org.hibernate.SessionFactory;
 import org.hibernate.UnknownProfileException;
-import org.hibernate.dialect.Dialect;
 
 import jakarta.persistence.FlushModeType;
 import jakarta.persistence.LockModeType;
 import jakarta.persistence.Parameter;
 import jakarta.persistence.TemporalType;
-import org.hibernate.engine.profile.DefaultFetchProfile;
 import org.hibernate.graph.GraphSemantic;
 
 /**
@@ -95,9 +94,10 @@ import org.hibernate.graph.GraphSemantic;
  * </ul>
  * <p>
  * The special built-in fetch profile named
- * {@value DefaultFetchProfile#HIBERNATE_DEFAULT_PROFILE} adds a fetch join for
- * every {@link jakarta.persistence.FetchType#EAGER eager} {@code @ManyToOne} or
- * {@code @OneToOne} association belonging to an entity returned by the query.
+ * {@value org.hibernate.engine.profile.DefaultFetchProfile#HIBERNATE_DEFAULT_PROFILE}
+ * adds a fetch join for every {@link jakarta.persistence.FetchType#EAGER eager}
+ * {@code @ManyToOne} or {@code @OneToOne} association belonging to an entity
+ * returned by the query.
  * <p>
  * Finally, three alternative approaches to pagination are available:
  * <ol>
@@ -146,8 +146,8 @@ public interface SelectionQuery<R> extends CommonQueryContract {
 
 	/**
 	 * Returns scrollable access to the query results, using the
-	 * {@linkplain Dialect#defaultScrollMode() default scroll mode
-	 * of the SQL dialect.}
+	 * {@linkplain org.hibernate.dialect.Dialect#defaultScrollMode
+	 * default scroll mode of the SQL dialect.}
 	 *
 	 * @see #scroll(ScrollMode)
 	 */

--- a/hibernate-core/src/main/java/org/hibernate/sql/exec/internal/JdbcCallFunctionReturnImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/exec/internal/JdbcCallFunctionReturnImpl.java
@@ -4,7 +4,7 @@
  */
 package org.hibernate.sql.exec.internal;
 
-import org.hibernate.query.OutputableType;
+import org.hibernate.type.OutputableType;
 import org.hibernate.sql.exec.spi.JdbcCallFunctionReturn;
 
 import jakarta.persistence.ParameterMode;

--- a/hibernate-core/src/main/java/org/hibernate/sql/exec/internal/JdbcCallParameterExtractorImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/exec/internal/JdbcCallParameterExtractorImpl.java
@@ -8,7 +8,7 @@ import java.sql.CallableStatement;
 import java.sql.SQLException;
 
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
-import org.hibernate.query.OutputableType;
+import org.hibernate.type.OutputableType;
 import org.hibernate.sql.exec.spi.JdbcCallParameterExtractor;
 
 /**

--- a/hibernate-core/src/main/java/org/hibernate/sql/exec/internal/JdbcCallParameterRegistrationImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/exec/internal/JdbcCallParameterRegistrationImpl.java
@@ -9,7 +9,7 @@ import java.sql.SQLException;
 
 import org.hibernate.engine.jdbc.cursor.spi.RefCursorSupport;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
-import org.hibernate.query.OutputableType;
+import org.hibernate.type.OutputableType;
 import org.hibernate.sql.exec.spi.JdbcCallParameterExtractor;
 import org.hibernate.sql.exec.spi.JdbcCallParameterRegistration;
 import org.hibernate.sql.exec.spi.JdbcParameterBinder;

--- a/hibernate-core/src/main/java/org/hibernate/sql/exec/spi/JdbcCallParameterRegistration.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/exec/spi/JdbcCallParameterRegistration.java
@@ -8,7 +8,7 @@ import java.sql.CallableStatement;
 import jakarta.persistence.ParameterMode;
 
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
-import org.hibernate.query.OutputableType;
+import org.hibernate.type.OutputableType;
 import org.hibernate.sql.exec.internal.JdbcCallRefCursorExtractorImpl;
 
 /**

--- a/hibernate-core/src/main/java/org/hibernate/type/OutputableType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/OutputableType.java
@@ -2,13 +2,14 @@
  * SPDX-License-Identifier: Apache-2.0
  * Copyright Red Hat Inc. and Hibernate Authors
  */
-package org.hibernate.query;
+package org.hibernate.type;
 
 import java.sql.CallableStatement;
 import java.sql.SQLException;
 
 import org.hibernate.Incubating;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
+import org.hibernate.query.BindableType;
 import org.hibernate.type.descriptor.jdbc.JdbcType;
 
 /**

--- a/hibernate-core/src/main/java/org/hibernate/type/ProcedureParameterExtractionAware.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/ProcedureParameterExtractionAware.java
@@ -4,11 +4,9 @@
  */
 package org.hibernate.type;
 
-import org.hibernate.query.OutputableType;
-
 /**
- * Optional {@link Type} contract for implementations that are aware of how to extract values from
- * store procedure OUT/INOUT parameters.
+ * Optional {@link Type} contract for implementations that are aware of
+ * how to extract values from stored procedure OUT/INOUT parameters.
  *
  * @author Steve Ebersole
  */


### PR DESCRIPTION
we're trying to clean up org.hibernate.Query

<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

[Please describe here what your change is about]

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-19438
https://hibernate.atlassian.net/browse/HHH-19442
<!-- Hibernate GitHub Bot issue links end -->