### PR TITLE
HHH-19440 - Deprecate exposing of LockOptions

### DIFF
--- a/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/CockroachLegacyDialect.java
+++ b/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/CockroachLegacyDialect.java
@@ -6,6 +6,7 @@ package org.hibernate.community.dialect;
 
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.TemporalType;
+import jakarta.persistence.Timeout;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.hibernate.LockMode;
 import org.hibernate.LockOptions;
@@ -1018,12 +1019,36 @@ public class CockroachLegacyDialect extends Dialect {
 		};
 	}
 
+	private String withTimeout(String lockString, Timeout timeout) {
+		return withTimeout( lockString, timeout.milliseconds() );
+	}
+
 	private String withTimeout(String lockString, int timeout) {
 		return switch ( timeout ) {
 			case Timeouts.NO_WAIT_MILLI -> supportsNoWait() ? lockString + " nowait" : lockString;
 			case Timeouts.SKIP_LOCKED_MILLI -> supportsSkipLocked() ? lockString + " skip locked" : lockString;
 			default -> lockString;
 		};
+	}
+
+	@Override
+	public String getWriteLockString(Timeout timeout) {
+		return withTimeout( getForUpdateString(), timeout );
+	}
+
+	@Override
+	public String getWriteLockString(String aliases, Timeout timeout) {
+		return withTimeout( getForUpdateString( aliases ), timeout );
+	}
+
+	@Override
+	public String getReadLockString(Timeout timeout) {
+		return withTimeout(" for share", timeout );
+	}
+
+	@Override
+	public String getReadLockString(String aliases, Timeout timeout) {
+		return withTimeout(" for share of " + aliases, timeout );
 	}
 
 	@Override

--- a/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/CockroachLegacyDialect.java
+++ b/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/CockroachLegacyDialect.java
@@ -4,27 +4,28 @@
  */
 package org.hibernate.community.dialect;
 
-import java.sql.DatabaseMetaData;
-import java.sql.ResultSet;
-import java.sql.SQLException;
-import java.sql.Types;
-import java.time.temporal.ChronoField;
-import java.time.temporal.TemporalAccessor;
-import java.util.Calendar;
-import java.util.Date;
-import java.util.Map;
-import java.util.TimeZone;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.TemporalType;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.hibernate.LockMode;
 import org.hibernate.LockOptions;
 import org.hibernate.PessimisticLockException;
 import org.hibernate.QueryTimeoutException;
+import org.hibernate.Timeouts;
 import org.hibernate.boot.model.FunctionContributions;
 import org.hibernate.boot.model.TypeContributions;
-import org.hibernate.dialect.*;
+import org.hibernate.dialect.DatabaseVersion;
+import org.hibernate.dialect.Dialect;
+import org.hibernate.dialect.DmlTargetColumnQualifierSupport;
+import org.hibernate.dialect.FunctionalDependencyAnalysisSupport;
+import org.hibernate.dialect.FunctionalDependencyAnalysisSupportImpl;
+import org.hibernate.dialect.NationalizationSupport;
+import org.hibernate.dialect.NullOrdering;
+import org.hibernate.dialect.PostgreSQLDriverKind;
+import org.hibernate.dialect.RowLockStrategy;
+import org.hibernate.dialect.SimpleDatabaseVersion;
+import org.hibernate.dialect.SpannerDialect;
+import org.hibernate.dialect.TimeZoneSupport;
 import org.hibernate.dialect.aggregate.AggregateSupport;
 import org.hibernate.dialect.aggregate.CockroachDBAggregateSupport;
 import org.hibernate.dialect.function.CommonFunctionFactory;
@@ -58,9 +59,8 @@ import org.hibernate.exception.spi.ViolatedConstraintNameExtractor;
 import org.hibernate.internal.util.JdbcExceptionHelper;
 import org.hibernate.internal.util.StringHelper;
 import org.hibernate.query.SemanticException;
-import org.hibernate.query.sqm.IntervalType;
-import org.hibernate.dialect.NullOrdering;
 import org.hibernate.query.common.TemporalUnit;
+import org.hibernate.query.sqm.IntervalType;
 import org.hibernate.query.sqm.produce.function.StandardFunctionArgumentTypeResolvers;
 import org.hibernate.service.ServiceRegistry;
 import org.hibernate.sql.ast.SqlAstTranslator;
@@ -83,9 +83,18 @@ import org.hibernate.type.descriptor.sql.internal.Scale6IntervalSecondDdlType;
 import org.hibernate.type.descriptor.sql.spi.DdlTypeRegistry;
 import org.hibernate.type.spi.TypeConfiguration;
 
-
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.TemporalType;
+import java.sql.DatabaseMetaData;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Types;
+import java.time.temporal.ChronoField;
+import java.time.temporal.TemporalAccessor;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.Map;
+import java.util.TimeZone;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import static org.hibernate.exception.spi.TemplatedViolatedConstraintNameExtractor.extractUsingTemplate;
 import static org.hibernate.query.common.TemporalUnit.DAY;
@@ -1011,8 +1020,8 @@ public class CockroachLegacyDialect extends Dialect {
 
 	private String withTimeout(String lockString, int timeout) {
 		return switch ( timeout ) {
-			case LockOptions.NO_WAIT -> supportsNoWait() ? lockString + " nowait" : lockString;
-			case LockOptions.SKIP_LOCKED -> supportsSkipLocked() ? lockString + " skip locked" : lockString;
+			case Timeouts.NO_WAIT_MILLI -> supportsNoWait() ? lockString + " nowait" : lockString;
+			case Timeouts.SKIP_LOCKED_MILLI -> supportsSkipLocked() ? lockString + " skip locked" : lockString;
 			default -> lockString;
 		};
 	}

--- a/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/DB2LegacyDialect.java
+++ b/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/DB2LegacyDialect.java
@@ -4,31 +4,13 @@
  */
 package org.hibernate.community.dialect;
 
-import java.sql.CallableStatement;
-import java.sql.DatabaseMetaData;
-import java.sql.ResultSet;
-import java.sql.SQLException;
-import java.sql.Types;
-import java.time.Instant;
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.time.LocalTime;
-import java.time.OffsetDateTime;
-import java.time.OffsetTime;
-import java.time.ZonedDateTime;
-import java.time.temporal.TemporalAccessor;
-import java.util.Calendar;
-import java.util.Date;
-import java.util.List;
-import java.util.TimeZone;
-
-import org.hibernate.LockOptions;
+import jakarta.persistence.TemporalType;
+import org.hibernate.Timeouts;
 import org.hibernate.boot.model.FunctionContributions;
 import org.hibernate.boot.model.TypeContributions;
 import org.hibernate.community.dialect.sequence.LegacyDB2SequenceSupport;
 import org.hibernate.dialect.DB2Dialect;
 import org.hibernate.dialect.DB2GetObjectExtractor;
-import org.hibernate.dialect.type.DB2StructJdbcType;
 import org.hibernate.dialect.DatabaseVersion;
 import org.hibernate.dialect.Dialect;
 import org.hibernate.dialect.DmlTargetColumnQualifierSupport;
@@ -49,6 +31,7 @@ import org.hibernate.dialect.pagination.LegacyDB2LimitHandler;
 import org.hibernate.dialect.pagination.LimitHandler;
 import org.hibernate.dialect.sequence.DB2SequenceSupport;
 import org.hibernate.dialect.sequence.SequenceSupport;
+import org.hibernate.dialect.type.DB2StructJdbcType;
 import org.hibernate.dialect.unique.AlterTableUniqueIndexDelegate;
 import org.hibernate.dialect.unique.SkipNullableUniqueDelegate;
 import org.hibernate.dialect.unique.UniqueDelegate;
@@ -70,9 +53,9 @@ import org.hibernate.metamodel.mapping.EntityMappingType;
 import org.hibernate.metamodel.spi.RuntimeModelCreationContext;
 import org.hibernate.procedure.internal.DB2CallableStatementSupport;
 import org.hibernate.procedure.spi.CallableStatementSupport;
+import org.hibernate.query.common.TemporalUnit;
 import org.hibernate.query.sqm.CastType;
 import org.hibernate.query.sqm.IntervalType;
-import org.hibernate.query.common.TemporalUnit;
 import org.hibernate.query.sqm.mutation.internal.cte.CteInsertStrategy;
 import org.hibernate.query.sqm.mutation.internal.cte.CteMutationStrategy;
 import org.hibernate.query.sqm.mutation.spi.SqmMultiTableInsertStrategy;
@@ -118,7 +101,23 @@ import org.hibernate.type.descriptor.sql.internal.DdlTypeImpl;
 import org.hibernate.type.descriptor.sql.spi.DdlTypeRegistry;
 import org.hibernate.type.spi.TypeConfiguration;
 
-import jakarta.persistence.TemporalType;
+import java.sql.CallableStatement;
+import java.sql.DatabaseMetaData;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Types;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.OffsetDateTime;
+import java.time.OffsetTime;
+import java.time.ZonedDateTime;
+import java.time.temporal.TemporalAccessor;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.List;
+import java.util.TimeZone;
 
 import static org.hibernate.exception.spi.TemplatedViolatedConstraintNameExtractor.extractUsingTemplate;
 import static org.hibernate.type.SqlTypes.BINARY;
@@ -783,14 +782,14 @@ public class DB2LegacyDialect extends Dialect {
 
 	@Override
 	public String getWriteLockString(int timeout) {
-		return timeout == LockOptions.SKIP_LOCKED && supportsSkipLocked()
+		return timeout == Timeouts.SKIP_LOCKED_MILLI && supportsSkipLocked()
 				? FOR_UPDATE_SKIP_LOCKED_SQL
 				: FOR_UPDATE_SQL;
 	}
 
 	@Override
 	public String getReadLockString(int timeout) {
-		return timeout == LockOptions.SKIP_LOCKED && supportsSkipLocked()
+		return timeout == Timeouts.SKIP_LOCKED_MILLI && supportsSkipLocked()
 				? FOR_SHARE_SKIP_LOCKED_SQL
 				: FOR_SHARE_SQL;
 	}

--- a/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/DB2LegacyDialect.java
+++ b/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/DB2LegacyDialect.java
@@ -5,6 +5,7 @@
 package org.hibernate.community.dialect;
 
 import jakarta.persistence.TemporalType;
+import jakarta.persistence.Timeout;
 import org.hibernate.Timeouts;
 import org.hibernate.boot.model.FunctionContributions;
 import org.hibernate.boot.model.TypeContributions;
@@ -778,6 +779,20 @@ public class DB2LegacyDialect extends Dialect {
 	@Override
 	public String getForUpdateSkipLockedString(String aliases) {
 		return getForUpdateSkipLockedString();
+	}
+
+	@Override
+	public String getWriteLockString(Timeout timeout) {
+		return timeout.milliseconds() == Timeouts.SKIP_LOCKED_MILLI && supportsSkipLocked()
+				? FOR_UPDATE_SKIP_LOCKED_SQL
+				: FOR_UPDATE_SQL;
+	}
+
+	@Override
+	public String getReadLockString(Timeout timeout) {
+		return timeout.milliseconds() == Timeouts.SKIP_LOCKED_MILLI && supportsSkipLocked()
+				? FOR_SHARE_SKIP_LOCKED_SQL
+				: FOR_SHARE_SQL;
 	}
 
 	@Override

--- a/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/DerbyDialect.java
+++ b/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/DerbyDialect.java
@@ -9,6 +9,7 @@ import java.sql.SQLException;
 import java.sql.Types;
 import java.util.Locale;
 
+import jakarta.persistence.Timeout;
 import org.hibernate.boot.model.FunctionContributions;
 import org.hibernate.boot.model.TypeContributions;
 import org.hibernate.dialect.DB2Dialect;
@@ -575,6 +576,16 @@ public class DerbyDialect extends Dialect {
 	@Override
 	public String getForUpdateString() {
 		return " for update with rs";
+	}
+
+	@Override
+	public String getWriteLockString(Timeout timeout) {
+		return " for update with rs";
+	}
+
+	@Override
+	public String getReadLockString(Timeout timeout) {
+		return " for read only with rs";
 	}
 
 	@Override

--- a/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/DerbyLegacyDialect.java
+++ b/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/DerbyLegacyDialect.java
@@ -8,6 +8,7 @@ import java.sql.DatabaseMetaData;
 import java.sql.SQLException;
 import java.sql.Types;
 
+import jakarta.persistence.Timeout;
 import org.hibernate.boot.model.FunctionContributions;
 import org.hibernate.boot.model.TypeContributions;
 import org.hibernate.dialect.DB2Dialect;
@@ -591,6 +592,16 @@ public class DerbyLegacyDialect extends Dialect {
 	@Override
 	public String getForUpdateString() {
 		return " for update with rs";
+	}
+
+	@Override
+	public String getWriteLockString(Timeout timeout) {
+		return " for update with rs";
+	}
+
+	@Override
+	public String getReadLockString(Timeout timeout) {
+		return " for read only with rs";
 	}
 
 	@Override

--- a/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/HANALegacyDialect.java
+++ b/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/HANALegacyDialect.java
@@ -1041,8 +1041,8 @@ public class HANALegacyDialect extends Dialect {
 
 	@Override
 	public String getWriteLockString(int timeout) {
-		if ( timeout > 0 ) {
-			return getForUpdateString() + " wait " + getTimeoutInSeconds( timeout );
+		if ( Timeouts.isRealTimeout( timeout ) ) {
+			return getForUpdateString() + " wait " + Timeouts.getTimeoutInSeconds( timeout );
 		}
 		else if ( timeout == Timeouts.NO_WAIT_MILLI ) {
 			return getForUpdateNowaitString();

--- a/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/HANALegacyDialect.java
+++ b/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/HANALegacyDialect.java
@@ -4,41 +4,11 @@
  */
 package org.hibernate.community.dialect;
 
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
-import java.io.FilterInputStream;
-import java.io.FilterReader;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
-import java.io.Reader;
-import java.io.StringReader;
-import java.io.Writer;
-import java.nio.charset.StandardCharsets;
-import java.sql.Blob;
-import java.sql.CallableStatement;
-import java.sql.Clob;
-import java.sql.DatabaseMetaData;
-import java.sql.NClob;
-import java.sql.PreparedStatement;
-import java.sql.ResultSet;
-import java.sql.SQLException;
-import java.sql.SQLFeatureNotSupportedException;
-import java.sql.Types;
-import java.time.temporal.TemporalAccessor;
-import java.util.Arrays;
-import java.util.Date;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.TimeZone;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-
+import jakarta.persistence.TemporalType;
 import org.hibernate.LockMode;
 import org.hibernate.LockOptions;
 import org.hibernate.ScrollMode;
+import org.hibernate.Timeouts;
 import org.hibernate.boot.Metadata;
 import org.hibernate.boot.model.FunctionContributions;
 import org.hibernate.boot.model.TypeContributions;
@@ -48,7 +18,6 @@ import org.hibernate.dialect.DatabaseVersion;
 import org.hibernate.dialect.Dialect;
 import org.hibernate.dialect.DmlTargetColumnQualifierSupport;
 import org.hibernate.dialect.HANAServerConfiguration;
-import org.hibernate.dialect.sql.ast.HANASqlAstTranslator;
 import org.hibernate.dialect.NullOrdering;
 import org.hibernate.dialect.OracleDialect;
 import org.hibernate.dialect.RowLockStrategy;
@@ -62,6 +31,7 @@ import org.hibernate.dialect.pagination.LimitHandler;
 import org.hibernate.dialect.pagination.LimitOffsetLimitHandler;
 import org.hibernate.dialect.sequence.HANASequenceSupport;
 import org.hibernate.dialect.sequence.SequenceSupport;
+import org.hibernate.dialect.sql.ast.HANASqlAstTranslator;
 import org.hibernate.dialect.temptable.TemporaryTable;
 import org.hibernate.dialect.temptable.TemporaryTableKind;
 import org.hibernate.engine.config.spi.ConfigurationService;
@@ -131,7 +101,37 @@ import org.hibernate.type.descriptor.sql.spi.DdlTypeRegistry;
 import org.hibernate.type.internal.BasicTypeImpl;
 import org.hibernate.type.spi.TypeConfiguration;
 
-import jakarta.persistence.TemporalType;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.FilterInputStream;
+import java.io.FilterReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.Reader;
+import java.io.StringReader;
+import java.io.Writer;
+import java.nio.charset.StandardCharsets;
+import java.sql.Blob;
+import java.sql.CallableStatement;
+import java.sql.Clob;
+import java.sql.DatabaseMetaData;
+import java.sql.NClob;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.SQLFeatureNotSupportedException;
+import java.sql.Types;
+import java.time.temporal.TemporalAccessor;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TimeZone;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import static org.hibernate.dialect.HANAServerConfiguration.MAX_LOB_PREFETCH_SIZE_DEFAULT_VALUE;
 import static org.hibernate.query.sqm.produce.function.FunctionParameterType.ANY;
@@ -1007,7 +1007,7 @@ public class HANALegacyDialect extends Dialect {
 		if ( timeout > 0 ) {
 			return getForUpdateString() + " wait " + getTimeoutInSeconds( timeout );
 		}
-		else if ( timeout == 0 ) {
+		else if ( timeout == Timeouts.NO_WAIT_MILLI ) {
 			return getForUpdateNowaitString();
 		}
 		else {

--- a/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/HANALegacyDialect.java
+++ b/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/HANALegacyDialect.java
@@ -5,6 +5,7 @@
 package org.hibernate.community.dialect;
 
 import jakarta.persistence.TemporalType;
+import jakarta.persistence.Timeout;
 import org.hibernate.LockMode;
 import org.hibernate.LockOptions;
 import org.hibernate.ScrollMode;
@@ -990,6 +991,42 @@ public class HANALegacyDialect extends Dialect {
 	@Override
 	public String getForUpdateNowaitString(String aliases) {
 		return getForUpdateString( aliases ) + " nowait";
+	}
+
+	@Override
+	public String getReadLockString(Timeout timeout) {
+		return getWriteLockString( timeout );
+	}
+
+	@Override
+	public String getReadLockString(String aliases, Timeout timeout) {
+		return getWriteLockString( aliases, timeout );
+	}
+
+	@Override
+	public String getWriteLockString(Timeout timeout) {
+		if ( Timeouts.isRealTimeout( timeout ) ) {
+			return getForUpdateString() + " wait " + getTimeoutInSeconds( timeout.milliseconds() );
+		}
+		else if ( timeout.milliseconds() == Timeouts.NO_WAIT_MILLI ) {
+			return getForUpdateNowaitString();
+		}
+		else {
+			return getForUpdateString();
+		}
+	}
+
+	@Override
+	public String getWriteLockString(String aliases, Timeout timeout) {
+		if ( Timeouts.isRealTimeout( timeout ) ) {
+			return getForUpdateString( aliases ) + " wait " + getTimeoutInSeconds( timeout.milliseconds() );
+		}
+		else if ( timeout.milliseconds() == Timeouts.NO_WAIT_MILLI ) {
+			return getForUpdateNowaitString( aliases );
+		}
+		else {
+			return getForUpdateString( aliases );
+		}
 	}
 
 	@Override

--- a/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/MySQLLegacyDialect.java
+++ b/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/MySQLLegacyDialect.java
@@ -4,18 +4,25 @@
  */
 package org.hibernate.community.dialect;
 
-import java.sql.CallableStatement;
-import java.sql.DatabaseMetaData;
-import java.sql.ResultSet;
-import java.sql.SQLException;
-import java.sql.Types;
-
-import org.hibernate.LockOptions;
+import jakarta.persistence.TemporalType;
 import org.hibernate.PessimisticLockException;
+import org.hibernate.Timeouts;
 import org.hibernate.boot.model.FunctionContributions;
 import org.hibernate.boot.model.TypeContributions;
 import org.hibernate.cfg.Environment;
-import org.hibernate.dialect.*;
+import org.hibernate.dialect.DatabaseVersion;
+import org.hibernate.dialect.Dialect;
+import org.hibernate.dialect.DmlTargetColumnQualifierSupport;
+import org.hibernate.dialect.FunctionalDependencyAnalysisSupport;
+import org.hibernate.dialect.FunctionalDependencyAnalysisSupportImpl;
+import org.hibernate.dialect.InnoDBStorageEngine;
+import org.hibernate.dialect.MyISAMStorageEngine;
+import org.hibernate.dialect.MySQLServerConfiguration;
+import org.hibernate.dialect.MySQLStorageEngine;
+import org.hibernate.dialect.NullOrdering;
+import org.hibernate.dialect.Replacer;
+import org.hibernate.dialect.RowLockStrategy;
+import org.hibernate.dialect.SelectItemReferenceStrategy;
 import org.hibernate.dialect.aggregate.AggregateSupport;
 import org.hibernate.dialect.aggregate.MySQLAggregateSupport;
 import org.hibernate.dialect.function.CommonFunctionFactory;
@@ -46,15 +53,14 @@ import org.hibernate.internal.util.StringHelper;
 import org.hibernate.mapping.CheckConstraint;
 import org.hibernate.metamodel.mapping.EntityMappingType;
 import org.hibernate.metamodel.spi.RuntimeModelCreationContext;
+import org.hibernate.query.common.TemporalUnit;
 import org.hibernate.query.sqm.CastType;
 import org.hibernate.query.sqm.IntervalType;
-import org.hibernate.dialect.NullOrdering;
-import org.hibernate.query.common.TemporalUnit;
 import org.hibernate.query.sqm.function.SqmFunctionRegistry;
-import org.hibernate.query.sqm.mutation.spi.AfterUseAction;
-import org.hibernate.query.sqm.mutation.spi.BeforeUseAction;
 import org.hibernate.query.sqm.mutation.internal.temptable.LocalTemporaryTableInsertStrategy;
 import org.hibernate.query.sqm.mutation.internal.temptable.LocalTemporaryTableMutationStrategy;
+import org.hibernate.query.sqm.mutation.spi.AfterUseAction;
+import org.hibernate.query.sqm.mutation.spi.BeforeUseAction;
 import org.hibernate.query.sqm.mutation.spi.SqmMultiTableInsertStrategy;
 import org.hibernate.query.sqm.mutation.spi.SqmMultiTableMutationStrategy;
 import org.hibernate.query.sqm.produce.function.FunctionParameterType;
@@ -79,7 +85,11 @@ import org.hibernate.type.descriptor.sql.internal.NativeEnumDdlTypeImpl;
 import org.hibernate.type.descriptor.sql.internal.NativeOrdinalEnumDdlTypeImpl;
 import org.hibernate.type.descriptor.sql.spi.DdlTypeRegistry;
 
-import jakarta.persistence.TemporalType;
+import java.sql.CallableStatement;
+import java.sql.DatabaseMetaData;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Types;
 
 import static org.hibernate.exception.spi.TemplatedViolatedConstraintNameExtractor.extractUsingTemplate;
 import static org.hibernate.type.SqlTypes.BIGINT;
@@ -1328,9 +1338,9 @@ public class MySQLLegacyDialect extends Dialect {
 
 	private String withTimeout(String lockString, int timeout) {
 		return switch ( timeout ) {
-			case LockOptions.NO_WAIT -> supportsNoWait() ? lockString + " nowait" : lockString;
-			case LockOptions.SKIP_LOCKED -> supportsSkipLocked() ? lockString + " skip locked" : lockString;
-			case LockOptions.WAIT_FOREVER -> lockString;
+			case Timeouts.NO_WAIT_MILLI -> supportsNoWait() ? lockString + " nowait" : lockString;
+			case Timeouts.SKIP_LOCKED_MILLI -> supportsSkipLocked() ? lockString + " skip locked" : lockString;
+			case Timeouts.WAIT_FOREVER_MILLI -> lockString;
 			default -> supportsWait() ? lockString + " wait " + getTimeoutInSeconds( timeout ) : lockString;
 		};
 	}

--- a/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/MySQLLegacyDialect.java
+++ b/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/MySQLLegacyDialect.java
@@ -1338,7 +1338,12 @@ public class MySQLLegacyDialect extends Dialect {
 	}
 
 	private String withTimeout(String lockString, Timeout timeout) {
-		return withTimeout( lockString, Timeouts.getTimeoutInSeconds( timeout ) );
+		return switch ( timeout.milliseconds() ) {
+			case Timeouts.NO_WAIT_MILLI -> supportsNoWait() ? lockString + " nowait" : lockString;
+			case Timeouts.SKIP_LOCKED_MILLI -> supportsSkipLocked() ? lockString + " skip locked" : lockString;
+			case Timeouts.WAIT_FOREVER_MILLI -> lockString;
+			default -> supportsWait() ? lockString + " wait " + Timeouts.getTimeoutInSeconds( timeout ) : lockString;
+		};
 	}
 
 	@Override
@@ -1372,7 +1377,7 @@ public class MySQLLegacyDialect extends Dialect {
 			case Timeouts.NO_WAIT_MILLI -> supportsNoWait() ? lockString + " nowait" : lockString;
 			case Timeouts.SKIP_LOCKED_MILLI -> supportsSkipLocked() ? lockString + " skip locked" : lockString;
 			case Timeouts.WAIT_FOREVER_MILLI -> lockString;
-			default -> supportsWait() ? lockString + " wait " + getTimeoutInSeconds( timeout ) : lockString;
+			default -> supportsWait() ? lockString + " wait " + Timeouts.getTimeoutInSeconds( timeout ) : lockString;
 		};
 	}
 

--- a/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/OracleLegacyDialect.java
+++ b/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/OracleLegacyDialect.java
@@ -16,8 +16,8 @@ import java.util.TimeZone;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import org.hibernate.LockOptions;
 import org.hibernate.QueryTimeoutException;
+import org.hibernate.Timeouts;
 import org.hibernate.boot.model.FunctionContributions;
 import org.hibernate.boot.model.TypeContributions;
 import org.hibernate.dialect.BooleanDecoder;
@@ -1412,9 +1412,9 @@ public class OracleLegacyDialect extends Dialect {
 
 	private String withTimeout(String lockString, int timeout) {
 		return switch ( timeout ) {
-			case LockOptions.NO_WAIT -> supportsNoWait() ? lockString + " nowait" : lockString;
-			case LockOptions.SKIP_LOCKED -> supportsSkipLocked() ? lockString + " skip locked" : lockString;
-			case LockOptions.WAIT_FOREVER -> lockString;
+			case Timeouts.NO_WAIT_MILLI -> supportsNoWait() ? lockString + " nowait" : lockString;
+			case Timeouts.SKIP_LOCKED_MILLI -> supportsSkipLocked() ? lockString + " skip locked" : lockString;
+			case Timeouts.WAIT_FOREVER_MILLI -> lockString;
 			default -> supportsWait() ? lockString + " wait " + getTimeoutInSeconds( timeout ) : lockString;
 		};
 	}

--- a/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/OracleLegacyDialect.java
+++ b/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/OracleLegacyDialect.java
@@ -1440,7 +1440,7 @@ public class OracleLegacyDialect extends Dialect {
 			case Timeouts.NO_WAIT_MILLI -> supportsNoWait() ? lockString + " nowait" : lockString;
 			case Timeouts.SKIP_LOCKED_MILLI -> supportsSkipLocked() ? lockString + " skip locked" : lockString;
 			case Timeouts.WAIT_FOREVER_MILLI -> lockString;
-			default -> supportsWait() ? lockString + " wait " + getTimeoutInSeconds( timeout ) : lockString;
+			default -> supportsWait() ? lockString + " wait " + Timeouts.getTimeoutInSeconds( timeout ) : lockString;
 		};
 	}
 

--- a/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/OracleLegacyDialect.java
+++ b/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/OracleLegacyDialect.java
@@ -16,6 +16,7 @@ import java.util.TimeZone;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import jakarta.persistence.Timeout;
 import org.hibernate.QueryTimeoutException;
 import org.hibernate.Timeouts;
 import org.hibernate.boot.model.FunctionContributions;
@@ -1408,6 +1409,30 @@ public class OracleLegacyDialect extends Dialect {
 	@Override
 	public String getForUpdateSkipLockedString(String aliases) {
 		return " for update of " + aliases + " skip locked";
+	}
+
+	private String withTimeout(String lockString, Timeout timeout) {
+		return withTimeout( lockString, timeout.milliseconds() );
+	}
+
+	@Override
+	public String getWriteLockString(Timeout timeout) {
+		return withTimeout( getForUpdateString(), timeout );
+	}
+
+	@Override
+	public String getWriteLockString(String aliases, Timeout timeout) {
+		return withTimeout( getForUpdateString(aliases), timeout );
+	}
+
+	@Override
+	public String getReadLockString(Timeout timeout) {
+		return getWriteLockString( timeout );
+	}
+
+	@Override
+	public String getReadLockString(String aliases, Timeout timeout) {
+		return getWriteLockString( aliases, timeout );
 	}
 
 	private String withTimeout(String lockString, int timeout) {

--- a/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/PostgreSQLLegacyDialect.java
+++ b/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/PostgreSQLLegacyDialect.java
@@ -23,6 +23,7 @@ import org.hibernate.LockMode;
 import org.hibernate.LockOptions;
 import org.hibernate.PessimisticLockException;
 import org.hibernate.QueryTimeoutException;
+import org.hibernate.Timeouts;
 import org.hibernate.boot.model.FunctionContributions;
 import org.hibernate.boot.model.TypeContributions;
 import org.hibernate.community.dialect.sequence.PostgreSQLLegacySequenceSupport;
@@ -1319,8 +1320,8 @@ public class PostgreSQLLegacyDialect extends Dialect {
 
 	private String withTimeout(String lockString, int timeout) {
 		return switch ( timeout ) {
-			case LockOptions.NO_WAIT -> supportsNoWait() ? lockString + " nowait" : lockString;
-			case LockOptions.SKIP_LOCKED -> supportsSkipLocked() ? lockString + " skip locked" : lockString;
+			case Timeouts.NO_WAIT_MILLI -> supportsNoWait() ? lockString + " nowait" : lockString;
+			case Timeouts.SKIP_LOCKED_MILLI -> supportsSkipLocked() ? lockString + " skip locked" : lockString;
 			default -> lockString;
 		};
 	}

--- a/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/PostgreSQLLegacyDialect.java
+++ b/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/PostgreSQLLegacyDialect.java
@@ -17,6 +17,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.TimeZone;
 
+import jakarta.persistence.Timeout;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.hibernate.Length;
 import org.hibernate.LockMode;
@@ -1316,6 +1317,34 @@ public class PostgreSQLLegacyDialect extends Dialect {
 			default:
 				throw new IllegalArgumentException();
 		}
+	}
+
+	private String withTimeout(String lockString, Timeout timeout) {
+		return switch (timeout.milliseconds()) {
+			case Timeouts.NO_WAIT_MILLI -> supportsNoWait() ? lockString + " nowait" : lockString;
+			case Timeouts.SKIP_LOCKED_MILLI -> supportsSkipLocked() ? lockString + " skip locked" : lockString;
+			default -> lockString;
+		};
+	}
+
+	@Override
+	public String getWriteLockString(Timeout timeout) {
+		return withTimeout( getForUpdateString(), timeout );
+	}
+
+	@Override
+	public String getWriteLockString(String aliases, Timeout timeout) {
+		return withTimeout( getForUpdateString( aliases ), timeout );
+	}
+
+	@Override
+	public String getReadLockString(Timeout timeout) {
+		return withTimeout(" for share", timeout );
+	}
+
+	@Override
+	public String getReadLockString(String aliases, Timeout timeout) {
+		return withTimeout(" for share of " + aliases, timeout );
 	}
 
 	private String withTimeout(String lockString, int timeout) {

--- a/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/SingleStoreDialect.java
+++ b/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/SingleStoreDialect.java
@@ -16,6 +16,7 @@ import java.util.Calendar;
 import java.util.Date;
 import java.util.TimeZone;
 
+import jakarta.persistence.Timeout;
 import org.hibernate.Length;
 import org.hibernate.PessimisticLockException;
 import org.hibernate.boot.Metadata;
@@ -1222,6 +1223,11 @@ public class SingleStoreDialect extends Dialect {
 	@Override
 	public String getAddPrimaryKeyConstraintString(String constraintName) {
 		throw new UnsupportedOperationException( "SingleStore does not support altering primary key." );
+	}
+
+	@Override
+	public String getWriteLockString(String aliases, Timeout timeout) {
+		return getForUpdateString( aliases );
 	}
 
 	@Override

--- a/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/TiDBDialect.java
+++ b/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/TiDBDialect.java
@@ -4,7 +4,10 @@
  */
 package org.hibernate.community.dialect;
 
-import org.hibernate.LockOptions;
+import jakarta.persistence.TemporalType;
+import org.hibernate.Timeouts;
+import org.hibernate.community.dialect.sequence.SequenceInformationExtractorTiDBDatabaseImpl;
+import org.hibernate.community.dialect.sequence.TiDBSequenceSupport;
 import org.hibernate.dialect.DatabaseVersion;
 import org.hibernate.dialect.Dialect;
 import org.hibernate.dialect.FunctionalDependencyAnalysisSupport;
@@ -14,20 +17,16 @@ import org.hibernate.dialect.MySQLServerConfiguration;
 import org.hibernate.dialect.aggregate.AggregateSupport;
 import org.hibernate.dialect.aggregate.MySQLAggregateSupport;
 import org.hibernate.dialect.sequence.SequenceSupport;
-import org.hibernate.community.dialect.sequence.TiDBSequenceSupport;
 import org.hibernate.engine.jdbc.dialect.spi.DialectResolutionInfo;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
-import org.hibernate.query.sqm.IntervalType;
 import org.hibernate.query.common.TemporalUnit;
+import org.hibernate.query.sqm.IntervalType;
 import org.hibernate.sql.ast.SqlAstTranslator;
 import org.hibernate.sql.ast.SqlAstTranslatorFactory;
 import org.hibernate.sql.ast.spi.StandardSqlAstTranslatorFactory;
 import org.hibernate.sql.ast.tree.Statement;
 import org.hibernate.sql.exec.spi.JdbcOperation;
-import org.hibernate.community.dialect.sequence.SequenceInformationExtractorTiDBDatabaseImpl;
 import org.hibernate.tool.schema.extract.spi.SequenceInformationExtractor;
-
-import jakarta.persistence.TemporalType;
 
 /**
  * A {@linkplain Dialect SQL dialect} for TiDB.
@@ -156,7 +155,7 @@ public class TiDBDialect extends MySQLDialect {
 
 	@Override
 	public String getReadLockString(int timeout) {
-		if ( timeout == LockOptions.NO_WAIT ) {
+		if ( timeout == Timeouts.NO_WAIT_MILLI ) {
 			return getForUpdateNowaitString();
 		}
 		return super.getReadLockString( timeout );
@@ -164,7 +163,7 @@ public class TiDBDialect extends MySQLDialect {
 
 	@Override
 	public String getReadLockString(String aliases, int timeout) {
-		if ( timeout == LockOptions.NO_WAIT ) {
+		if ( timeout == Timeouts.NO_WAIT_MILLI ) {
 			return getForUpdateNowaitString( aliases );
 		}
 		return super.getReadLockString( aliases, timeout );
@@ -172,7 +171,7 @@ public class TiDBDialect extends MySQLDialect {
 
 	@Override
 	public String getWriteLockString(int timeout) {
-		if ( timeout == LockOptions.NO_WAIT ) {
+		if ( timeout == Timeouts.NO_WAIT_MILLI ) {
 			return getForUpdateNowaitString();
 		}
 

--- a/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/TiDBDialect.java
+++ b/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/TiDBDialect.java
@@ -205,8 +205,8 @@ public class TiDBDialect extends MySQLDialect {
 			return getForUpdateNowaitString();
 		}
 
-		if ( timeout > 0 ) {
-			return getForUpdateString() + " wait " + getTimeoutInSeconds( timeout );
+		if ( Timeouts.isRealTimeout( timeout ) ) {
+			return getForUpdateString() + " wait " + Timeouts.getTimeoutInSeconds( timeout );
 		}
 
 		return getForUpdateString();

--- a/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/TiDBDialect.java
+++ b/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/TiDBDialect.java
@@ -5,6 +5,7 @@
 package org.hibernate.community.dialect;
 
 import jakarta.persistence.TemporalType;
+import jakarta.persistence.Timeout;
 import org.hibernate.Timeouts;
 import org.hibernate.community.dialect.sequence.SequenceInformationExtractorTiDBDatabaseImpl;
 import org.hibernate.community.dialect.sequence.TiDBSequenceSupport;
@@ -151,6 +152,35 @@ public class TiDBDialect extends MySQLDialect {
 	@Override
 	public boolean supportsRowValueConstructorSyntaxInInList() {
 		return getVersion().isSameOrAfter( 5, 7 );
+	}
+
+	@Override
+	public String getReadLockString(Timeout timeout) {
+		if ( timeout.milliseconds() == Timeouts.NO_WAIT_MILLI ) {
+			return getForUpdateNowaitString();
+		}
+		return super.getReadLockString( timeout );
+	}
+
+	@Override
+	public String getReadLockString(String aliases, Timeout timeout) {
+		if ( timeout.milliseconds() == Timeouts.NO_WAIT_MILLI ) {
+			return getForUpdateNowaitString( aliases );
+		}
+		return super.getReadLockString( aliases, timeout );
+	}
+
+	@Override
+	public String getWriteLockString(Timeout timeout) {
+		if ( timeout.milliseconds() == Timeouts.NO_WAIT_MILLI ) {
+			return getForUpdateNowaitString();
+		}
+
+		if ( Timeouts.isRealTimeout( timeout ) ) {
+			return getForUpdateString() + " wait " + Timeouts.getTimeoutInSeconds( timeout );
+		}
+
+		return getForUpdateString();
 	}
 
 	@Override

--- a/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/TimesTenDialect.java
+++ b/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/TimesTenDialect.java
@@ -7,7 +7,7 @@ package org.hibernate.community.dialect;
 import java.sql.Types;
 
 import org.hibernate.LockMode;
-import org.hibernate.LockOptions;
+import org.hibernate.Timeouts;
 import org.hibernate.boot.model.FunctionContributions;
 import org.hibernate.community.dialect.pagination.TimesTenLimitHandler;
 import org.hibernate.community.dialect.sequence.SequenceInformationExtractorTimesTenDatabaseImpl;
@@ -282,8 +282,8 @@ public class TimesTenDialect extends Dialect {
 
 	private String withTimeout(String lockString, int timeout) {
 		return switch ( timeout ) {
-			case LockOptions.NO_WAIT -> supportsNoWait() ? lockString + " nowait" : lockString;
-			case LockOptions.SKIP_LOCKED, LockOptions.WAIT_FOREVER -> lockString;
+			case Timeouts.NO_WAIT_MILLI -> supportsNoWait() ? lockString + " nowait" : lockString;
+			case Timeouts.SKIP_LOCKED_MILLI, Timeouts.WAIT_FOREVER_MILLI -> lockString;
 			default -> supportsWait() ? lockString + " wait " + getTimeoutInSeconds( timeout ) : lockString;
 		};
 	}

--- a/hibernate-core/src/main/java/org/hibernate/IdentifierLoadAccess.java
+++ b/hibernate-core/src/main/java/org/hibernate/IdentifierLoadAccess.java
@@ -8,6 +8,8 @@ import java.util.Optional;
 
 import jakarta.persistence.EntityGraph;
 
+import jakarta.persistence.PessimisticLockScope;
+import jakarta.persistence.Timeout;
 import org.hibernate.graph.GraphSemantic;
 
 /**
@@ -44,6 +46,38 @@ import org.hibernate.graph.GraphSemantic;
  * @see Session#byId(Class)
  */
 public interface IdentifierLoadAccess<T> {
+
+	/**
+	 * Specify the {@linkplain LockMode lock mode} to use when
+	 * querying the database.
+	 *
+	 * @param lockMode The lock mode to apply
+	 * @return {@code this}, for method chaining
+	 */
+	default IdentifierLoadAccess<T> with(LockMode lockMode) {
+		return with( lockMode, PessimisticLockScope.NORMAL );
+	}
+
+	/**
+	 * Specify the {@linkplain LockMode lock mode} to use when
+	 * querying the database.
+	 *
+	 * @param lockMode The lock mode to apply
+	 *
+	 * @return {@code this}, for method chaining
+	 */
+	IdentifierLoadAccess<T> with(LockMode lockMode, PessimisticLockScope lockScope);
+
+	/**
+	 * Specify the {@linkplain Timeout timeout} to use when
+	 * querying the database.
+	 *
+	 * @param timeout The timeout to apply to the database operation
+	 *
+	 * @return {@code this}, for method chaining
+	 */
+	IdentifierLoadAccess<T> with(Timeout timeout);
+
 	/**
 	 * Specify the {@linkplain LockOptions lock options} to use when
 	 * querying the database.
@@ -51,7 +85,12 @@ public interface IdentifierLoadAccess<T> {
 	 * @param lockOptions The lock options to use
 	 *
 	 * @return {@code this}, for method chaining
+	 *
+	 * @deprecated Use one of {@linkplain #with(LockMode)},
+	 * {@linkplain #with(LockMode, PessimisticLockScope)}
+	 * and/or {@linkplain #with(Timeout)} instead.
 	 */
+	@Deprecated(since = "7.0", forRemoval = true)
 	IdentifierLoadAccess<T> with(LockOptions lockOptions);
 
 	/**

--- a/hibernate-core/src/main/java/org/hibernate/LockOptions.java
+++ b/hibernate-core/src/main/java/org/hibernate/LockOptions.java
@@ -109,26 +109,22 @@ public class LockOptions implements FindOption, RefreshOption, Serializable {
 	public static final LockOptions UPGRADE = PESSIMISTIC_WRITE;
 
 	/**
-	 * Indicates that the database should not wait at all to acquire
-	 * a pessimistic lock which is not immediately available. This
-	 * has the same effect as {@link LockMode#UPGRADE_NOWAIT}.
-	 *
+	 * @see Timeouts#NO_WAIT_MILLI
+	 * @see Timeouts#NO_WAIT
 	 * @see #getTimeOut
 	 */
-	public static final int NO_WAIT = 0;
+	public static final int NO_WAIT = Timeouts.NO_WAIT_MILLI;
 
 	/**
-	 * Indicates that there is no timeout for the lock acquisition,
-	 * that is, that the database should in principle wait forever
-	 * to obtain the lock.
-	 *
+	 * @see Timeouts#WAIT_FOREVER_MILLI
+	 * @see Timeouts#WAIT_FOREVER
 	 * @see #getTimeOut
 	 */
-	public static final int WAIT_FOREVER = -1;
+	public static final int WAIT_FOREVER = Timeouts.WAIT_FOREVER_MILLI;
 
 	/**
-	 * Indicates that rows which are already locked should be skipped.
-	 *
+	 * @see Timeouts#SKIP_LOCKED_MILLI
+	 * @see Timeouts#SKIP_LOCKED
 	 * @see #getTimeOut()
 	 * @deprecated use {@link LockMode#UPGRADE_SKIPLOCKED}
 	 */

--- a/hibernate-core/src/main/java/org/hibernate/LockOptions.java
+++ b/hibernate-core/src/main/java/org/hibernate/LockOptions.java
@@ -4,9 +4,7 @@
  */
 package org.hibernate;
 
-import jakarta.persistence.FindOption;
 import jakarta.persistence.PessimisticLockScope;
-import jakarta.persistence.RefreshOption;
 import jakarta.persistence.Timeout;
 import org.hibernate.query.Query;
 
@@ -52,7 +50,7 @@ import static java.util.Collections.unmodifiableSet;
  *
  * @author Scott Marlow
  */
-public class LockOptions implements FindOption, RefreshOption, Serializable {
+public class LockOptions implements Serializable {
 	/**
 	 * Represents {@link LockMode#NONE}, to which timeout and scope are
 	 * not applicable.

--- a/hibernate-core/src/main/java/org/hibernate/MultiIdentifierLoadAccess.java
+++ b/hibernate-core/src/main/java/org/hibernate/MultiIdentifierLoadAccess.java
@@ -8,6 +8,8 @@ import java.util.List;
 
 import jakarta.persistence.EntityGraph;
 
+import jakarta.persistence.PessimisticLockScope;
+import jakarta.persistence.Timeout;
 import org.hibernate.graph.GraphSemantic;
 
 /**
@@ -31,6 +33,38 @@ import org.hibernate.graph.GraphSemantic;
  * @author Steve Ebersole
  */
 public interface MultiIdentifierLoadAccess<T> {
+
+	/**
+	 * Specify the {@linkplain LockMode lock mode} to use when
+	 * querying the database.
+	 *
+	 * @param lockMode The lock mode to apply
+	 * @return {@code this}, for method chaining
+	 */
+	default MultiIdentifierLoadAccess<T> with(LockMode lockMode) {
+		return with( lockMode, PessimisticLockScope.NORMAL );
+	}
+
+	/**
+	 * Specify the {@linkplain LockMode lock mode} to use when
+	 * querying the database.
+	 *
+	 * @param lockMode The lock mode to apply
+	 *
+	 * @return {@code this}, for method chaining
+	 */
+	MultiIdentifierLoadAccess<T> with(LockMode lockMode, PessimisticLockScope lockScope);
+
+	/**
+	 * Specify the {@linkplain Timeout timeout} to use when
+	 * querying the database.
+	 *
+	 * @param timeout The timeout to apply to the database operation
+	 *
+	 * @return {@code this}, for method chaining
+	 */
+	MultiIdentifierLoadAccess<T> with(Timeout timeout);
+
 	/**
 	 * Specify the {@linkplain LockOptions lock options} to use when
 	 * querying the database.
@@ -38,7 +72,12 @@ public interface MultiIdentifierLoadAccess<T> {
 	 * @param lockOptions The lock options to use
 	 *
 	 * @return {@code this}, for method chaining
+	 *
+	 * @deprecated Use one of {@linkplain #with(LockMode)},
+	 * {@linkplain #with(LockMode, PessimisticLockScope)}
+	 * and/or {@linkplain #with(Timeout)} instead.
 	 */
+	@Deprecated(since = "7.0", forRemoval = true)
 	MultiIdentifierLoadAccess<T> with(LockOptions lockOptions);
 
 	/**

--- a/hibernate-core/src/main/java/org/hibernate/NaturalIdLoadAccess.java
+++ b/hibernate-core/src/main/java/org/hibernate/NaturalIdLoadAccess.java
@@ -6,6 +6,8 @@ package org.hibernate;
 
 import jakarta.persistence.EntityGraph;
 
+import jakarta.persistence.PessimisticLockScope;
+import jakarta.persistence.Timeout;
 import jakarta.persistence.metamodel.SingularAttribute;
 import org.hibernate.graph.GraphSemantic;
 
@@ -35,6 +37,38 @@ import java.util.Optional;
  * @see SimpleNaturalIdLoadAccess
  */
 public interface NaturalIdLoadAccess<T> {
+
+	/**
+	 * Specify the {@linkplain LockMode lock mode} to use when
+	 * querying the database.
+	 *
+	 * @param lockMode The lock mode to apply
+	 * @return {@code this}, for method chaining
+	 */
+	default NaturalIdLoadAccess<T> with(LockMode lockMode) {
+		return with( lockMode, PessimisticLockScope.NORMAL );
+	}
+
+	/**
+	 * Specify the {@linkplain LockMode lock mode} to use when
+	 * querying the database.
+	 *
+	 * @param lockMode The lock mode to apply
+	 *
+	 * @return {@code this}, for method chaining
+	 */
+	NaturalIdLoadAccess<T> with(LockMode lockMode, PessimisticLockScope lockScope);
+
+	/**
+	 * Specify the {@linkplain Timeout timeout} to use when
+	 * querying the database.
+	 *
+	 * @param timeout The timeout to apply to the database operation
+	 *
+	 * @return {@code this}, for method chaining
+	 */
+	NaturalIdLoadAccess<T> with(Timeout timeout);
+
 	/**
 	 * Specify the {@linkplain LockOptions lock options} to use when
 	 * querying the database.
@@ -42,7 +76,12 @@ public interface NaturalIdLoadAccess<T> {
 	 * @param lockOptions The lock options to use.
 	 *
 	 * @return {@code this}, for method chaining
+	 *
+	 * @deprecated Use one of {@linkplain #with(LockMode)},
+	 * {@linkplain #with(LockMode, PessimisticLockScope)}
+	 * and/or {@linkplain #with(Timeout)} instead.
 	 */
+	@Deprecated(since = "7.0", forRemoval = true)
 	NaturalIdLoadAccess<T> with(LockOptions lockOptions);
 
 	/**

--- a/hibernate-core/src/main/java/org/hibernate/NaturalIdMultiLoadAccess.java
+++ b/hibernate-core/src/main/java/org/hibernate/NaturalIdMultiLoadAccess.java
@@ -6,6 +6,8 @@ package org.hibernate;
 
 import jakarta.persistence.EntityGraph;
 
+import jakarta.persistence.PessimisticLockScope;
+import jakarta.persistence.Timeout;
 import org.hibernate.graph.GraphSemantic;
 
 import java.util.List;
@@ -36,6 +38,38 @@ import java.util.List;
  * @see org.hibernate.annotations.NaturalId
  */
 public interface NaturalIdMultiLoadAccess<T> {
+
+	/**
+	 * Specify the {@linkplain LockMode lock mode} to use when
+	 * querying the database.
+	 *
+	 * @param lockMode The lock mode to apply
+	 * @return {@code this}, for method chaining
+	 */
+	default NaturalIdMultiLoadAccess<T> with(LockMode lockMode) {
+		return with( lockMode, PessimisticLockScope.NORMAL );
+	}
+
+	/**
+	 * Specify the {@linkplain LockMode lock mode} to use when
+	 * querying the database.
+	 *
+	 * @param lockMode The lock mode to apply
+	 *
+	 * @return {@code this}, for method chaining
+	 */
+	NaturalIdMultiLoadAccess<T> with(LockMode lockMode, PessimisticLockScope lockScope);
+
+	/**
+	 * Specify the {@linkplain Timeout timeout} to use when
+	 * querying the database.
+	 *
+	 * @param timeout The timeout to apply to the database operation
+	 *
+	 * @return {@code this}, for method chaining
+	 */
+	NaturalIdMultiLoadAccess<T> with(Timeout timeout);
+
 	/**
 	 * Specify the {@linkplain LockOptions lock options} to use when
 	 * querying the database.
@@ -43,7 +77,12 @@ public interface NaturalIdMultiLoadAccess<T> {
 	 * @param lockOptions The lock options to use
 	 *
 	 * @return {@code this}, for method chaining
+	 *
+	 * @deprecated Use one of {@linkplain #with(LockMode)},
+	 * {@linkplain #with(LockMode, PessimisticLockScope)}
+	 * and/or {@linkplain #with(Timeout)} instead.
 	 */
+	@Deprecated(since = "7.0", forRemoval = true)
 	NaturalIdMultiLoadAccess<T> with(LockOptions lockOptions);
 
 	/**

--- a/hibernate-core/src/main/java/org/hibernate/Session.java
+++ b/hibernate-core/src/main/java/org/hibernate/Session.java
@@ -9,6 +9,8 @@ import java.util.List;
 import java.util.function.Consumer;
 
 import jakarta.persistence.FindOption;
+import jakarta.persistence.LockOption;
+import jakarta.persistence.RefreshOption;
 import jakarta.persistence.metamodel.EntityType;
 import org.hibernate.graph.RootGraph;
 import org.hibernate.jdbc.Work;
@@ -507,7 +509,7 @@ public interface Session extends SharedSessionContract, EntityManager {
 	 * <ul>
 	 * <li>call {@link #find(Class, Object, FindOption...)}, passing
 	 *     {@link CacheRetrieveMode#BYPASS} as an option,
-	 * <li>call {@link #find(Class, Object, LockMode)} with the explicit lock mode
+	 * <li>call {@link #find(Class, Object, FindOption...)} with the explicit lock mode
 	 *     {@link LockMode#READ}, or
 	 * <li>{@linkplain #setCacheRetrieveMode set the cache mode} to
 	 *     {@link CacheRetrieveMode#BYPASS} before calling this method.
@@ -522,42 +524,6 @@ public interface Session extends SharedSessionContract, EntityManager {
 	 */
 	@Override
 	<T> T find(Class<T> entityType, Object id);
-
-	/**
-	 * Return the persistent instance of the given entity class with the given identifier,
-	 * or null if there is no such persistent instance. If the instance is already associated
-	 * with the session, return that instance. This method never returns an uninitialized
-	 * instance. Obtain the specified lock mode if the instance exists.
-	 * <p>
-	 * Convenient form of {@link #find(Class, Object, LockOptions)}.
-	 *
-	 * @param entityType the entity type
-	 * @param id an identifier
-	 * @param lockMode the lock mode
-	 *
-	 * @return a fully-fetched persistent instance or null
-	 *
-	 * @since 7.0
-	 *
-	 * @see #find(Class, Object, LockOptions)
-	 */
-	<T> T find(Class<T> entityType, Object id, LockMode lockMode);
-
-	/**
-	 * Return the persistent instance of the given entity class with the given identifier,
-	 * or null if there is no such persistent instance. If the instance is already associated
-	 * with the session, return that instance. This method never returns an uninitialized
-	 * instance. Obtain the specified lock mode if the instance exists.
-	 *
-	 * @param entityType the entity type
-	 * @param id an identifier
-	 * @param lockOptions the lock mode
-	 *
-	 * @return a fully-fetched persistent instance or null
-	 *
-	 * @since 7.0
-	 */
-	<T> T find(Class<T> entityType, Object id, LockOptions lockOptions);
 
 	/**
 	 * Return the persistent instances of the given entity class with the given identifiers
@@ -782,22 +748,43 @@ public interface Session extends SharedSessionContract, EntityManager {
 	 *
 	 * @param object a persistent instance associated with this session
 	 * @param lockMode the lock level
+	 *
+	 * @see #lock(Object, LockModeType)
 	 */
 	void lock(Object object, LockMode lockMode);
 
 	/**
-	 * Obtain a lock on the given managed instance associated with this session,
-	 * using the given {@linkplain LockOptions lock options}.
+	 * Obtain the specified lock level on the given managed instance associated
+	 * with this session, applying any other specified options. This operation may
+	 * be used to:
+	 * <ul>
+	 * <li>perform a version check on an entity read from the second-level cache
+	 *     by requesting {@link LockMode#READ},
+	 * <li>schedule a version check at transaction commit by requesting
+	 *     {@link LockMode#OPTIMISTIC},
+	 * <li>schedule a version increment at transaction commit by requesting
+	 *     {@link LockMode#OPTIMISTIC_FORCE_INCREMENT}
+	 * <li>upgrade to a pessimistic lock with {@link LockMode#PESSIMISTIC_READ}
+	 *     or {@link LockMode#PESSIMISTIC_WRITE}, or
+	 * <li>immediately increment the version of the given instance by requesting
+	 *     {@link LockMode#PESSIMISTIC_FORCE_INCREMENT}.
+	 * </ul>
+	 * <p>
+	 * If the requested lock mode is already held on the given entity, this
+	 * operation has no effect.
 	 * <p>
 	 * This operation cascades to associated instances if the association is
 	 * mapped with {@link org.hibernate.annotations.CascadeType#LOCK}.
+	 * <p>
+	 * The modes {@link LockMode#WRITE} and {@link LockMode#UPGRADE_SKIPLOCKED}
+	 * are not legal arguments to {@code lock()}.
 	 *
 	 * @param object a persistent instance associated with this session
-	 * @param lockOptions the lock options
+	 * @param lockMode the lock level
 	 *
-	 * @since 6.2
+	 * @see #lock(Object, LockModeType, LockOption...)
 	 */
-	void lock(Object object, LockOptions lockOptions);
+	void lock(Object object, LockMode lockMode, LockOption... lockOptions);
 
 	/**
 	 * Reread the state of the given managed instance associated with this session
@@ -821,28 +808,6 @@ public interface Session extends SharedSessionContract, EntityManager {
 	 */
 	@Override
 	void refresh(Object object);
-
-	/**
-	 * Reread the state of the given managed instance from the underlying database,
-	 * obtaining the given {@link LockMode}.
-	 * <p>
-	 * Convenient form of {@link #refresh(Object, LockOptions)}
-	 *
-	 * @param object a persistent instance associated with this session
-	 * @param lockMode the lock mode to use
-	 *
-	 * @see #refresh(Object, LockOptions)
-	 */
-	void refresh(Object object, LockMode lockMode);
-
-	/**
-	 * Reread the state of the given managed instance from the underlying database,
-	 * obtaining the given {@link LockMode}.
-	 *
-	 * @param object a persistent instance associated with this session
-	 * @param lockOptions contains the lock mode to use
-	 */
-	void refresh(Object object, LockOptions lockOptions);
 
 	/**
 	 * Mark a persistence instance associated with this session for removal from
@@ -909,7 +874,7 @@ public interface Session extends SharedSessionContract, EntityManager {
 	 * @deprecated Because the semantics of this method may change in a future release.
 	 *             Use {@link #find(Class, Object)} instead.
 	 */
-	@Deprecated(since = "7")
+	@Deprecated(since = "7.0", forRemoval = true)
 	<T> T get(Class<T> entityType, Object id);
 
 	/**
@@ -917,8 +882,6 @@ public interface Session extends SharedSessionContract, EntityManager {
 	 * or null if there is no such persistent instance. If the instance is already associated
 	 * with the session, return that instance. This method never returns an uninitialized
 	 * instance. Obtain the specified lock mode if the instance exists.
-	 * <p>
-	 * Convenient form of {@link #get(Class, Object, LockOptions)}.
 	 *
 	 * @apiNote This operation is very similar to {@link #find(Class, Object, LockModeType)}.
 	 *
@@ -928,31 +891,10 @@ public interface Session extends SharedSessionContract, EntityManager {
 	 *
 	 * @return a persistent instance or null
 	 *
-	 * @see #get(Class, Object, LockOptions)
-	 *
-	 * @deprecated The semantics of this method may change in a future release.
-	 *             Use {@link #find(Class, Object, LockMode)} instead.
+	 * @deprecated Use {@link #find(Class, Object, FindOption...)} instead.
 	 */
-	@Deprecated(since = "7")
+	@Deprecated(since = "7.0", forRemoval = true)
 	<T> T get(Class<T> entityType, Object id, LockMode lockMode);
-
-	/**
-	 * Return the persistent instance of the given entity class with the given identifier,
-	 * or null if there is no such persistent instance. If the instance is already associated
-	 * with the session, return that instance. This method never returns an uninitialized
-	 * instance. Obtain the specified lock mode if the instance exists.
-	 *
-	 * @param entityType the entity type
-	 * @param id an identifier
-	 * @param lockOptions the lock mode
-	 *
-	 * @return a persistent instance or null
-	 *
-	 * @deprecated The semantics of this method may change in a future release.
-	 *             Use {@link #find(Class, Object, LockOptions)} instead.
-	 */
-	@Deprecated(since = "7")
-	<T> T get(Class<T> entityType, Object id, LockOptions lockOptions);
 
 	/**
 	 * Return the persistent instance of the given named entity with the given identifier,
@@ -974,7 +916,7 @@ public interface Session extends SharedSessionContract, EntityManager {
 	 * @see SessionFactory#createGraphForDynamicEntity(String)
 	 * @see #find(EntityGraph, Object, FindOption...)
 	 */
-	@Deprecated(since = "7")
+	@Deprecated(since = "7", forRemoval = true)
 	Object get(String entityName, Object id);
 
 	/**
@@ -982,8 +924,6 @@ public interface Session extends SharedSessionContract, EntityManager {
 	 * or null if there is no such persistent instance. If the instance is already associated
 	 * with the session, return that instance. This method never returns an uninitialized
 	 * instance. Obtain the specified lock mode if the instance exists.
-	 * <p>
-	 * Convenient form of {@link #get(String, Object, LockOptions)}
 	 *
 	 * @param entityName the entity name
 	 * @param id an identifier
@@ -995,7 +935,7 @@ public interface Session extends SharedSessionContract, EntityManager {
 	 *
 	 * @deprecated The semantics of this method may change in a future release.
 	 */
-	@Deprecated(since = "7")
+	@Deprecated(since = "7.0", forRemoval = true)
 	Object get(String entityName, Object id, LockMode lockMode);
 
 	/**
@@ -1010,10 +950,39 @@ public interface Session extends SharedSessionContract, EntityManager {
 	 *
 	 * @return a persistent instance or null
 	 *
-	 * @deprecated The semantics of this method may change in a future release.
+	 * @deprecated Use {@linkplain #find(Class, Object, FindOption...)} instead
 	 */
-	@Deprecated(since = "7")
+	@Deprecated(since = "7.0", forRemoval = true)
 	Object get(String entityName, Object id, LockOptions lockOptions);
+
+	/**
+	 * Obtain a lock on the given managed instance associated with this session,
+	 * using the given {@linkplain LockOptions lock options}.
+	 * <p>
+	 * This operation cascades to associated instances if the association is
+	 * mapped with {@link org.hibernate.annotations.CascadeType#LOCK}.
+	 *
+	 * @param object a persistent instance associated with this session
+	 * @param lockOptions the lock options
+	 *
+	 * @since 6.2
+	 *
+	 * @deprecated Use {@linkplain #lock(Object, LockModeType, LockOption...)} instead
+	 */
+	@Deprecated(since = "7.0", forRemoval = true)
+	void lock(Object object, LockOptions lockOptions);
+
+	/**
+	 * Reread the state of the given managed instance from the underlying database,
+	 * obtaining the given {@link LockMode}.
+	 *
+	 * @param object a persistent instance associated with this session
+	 * @param lockOptions contains the lock mode to use
+	 *
+	 * @deprecated Use {@linkplain #refresh(Object, RefreshOption...)} instead
+	 */
+	@Deprecated(since = "7.0", forRemoval = true)
+	void refresh(Object object, LockOptions lockOptions);
 
 	/**
 	 * Return the entity name for a persistent entity.

--- a/hibernate-core/src/main/java/org/hibernate/SimpleNaturalIdLoadAccess.java
+++ b/hibernate-core/src/main/java/org/hibernate/SimpleNaturalIdLoadAccess.java
@@ -6,6 +6,8 @@ package org.hibernate;
 
 import jakarta.persistence.EntityGraph;
 
+import jakarta.persistence.PessimisticLockScope;
+import jakarta.persistence.Timeout;
 import org.hibernate.graph.GraphSemantic;
 
 import java.util.Optional;
@@ -29,6 +31,38 @@ import java.util.Optional;
  * @see NaturalIdLoadAccess
  */
 public interface SimpleNaturalIdLoadAccess<T> {
+
+	/**
+	 * Specify the {@linkplain LockMode lock mode} to use when
+	 * querying the database.
+	 *
+	 * @param lockMode The lock mode to apply
+	 * @return {@code this}, for method chaining
+	 */
+	default SimpleNaturalIdLoadAccess<T> with(LockMode lockMode) {
+		return with( lockMode, PessimisticLockScope.NORMAL );
+	}
+
+	/**
+	 * Specify the {@linkplain LockMode lock mode} to use when
+	 * querying the database.
+	 *
+	 * @param lockMode The lock mode to apply
+	 *
+	 * @return {@code this}, for method chaining
+	 */
+	SimpleNaturalIdLoadAccess<T> with(LockMode lockMode, PessimisticLockScope lockScope);
+
+	/**
+	 * Specify the {@linkplain Timeout timeout} to use when
+	 * querying the database.
+	 *
+	 * @param timeout The timeout to apply to the database operation
+	 *
+	 * @return {@code this}, for method chaining
+	 */
+	SimpleNaturalIdLoadAccess<T> with(Timeout timeout);
+
 	/**
 	 * Specify the {@linkplain LockOptions lock options} to use when
 	 * querying the database.
@@ -36,7 +70,12 @@ public interface SimpleNaturalIdLoadAccess<T> {
 	 * @param lockOptions The lock options to use
 	 *
 	 * @return {@code this}, for method chaining
+	 *
+	 * @deprecated Use one of {@linkplain #with(LockMode)},
+	 * {@linkplain #with(LockMode, PessimisticLockScope)}
+	 * and/or {@linkplain #with(Timeout)} instead.
 	 */
+	@Deprecated(since = "7.0", forRemoval = true)
 	SimpleNaturalIdLoadAccess<T> with(LockOptions lockOptions);
 
 	/**

--- a/hibernate-core/src/main/java/org/hibernate/Timeouts.java
+++ b/hibernate-core/src/main/java/org/hibernate/Timeouts.java
@@ -7,12 +7,12 @@ package org.hibernate;
 import jakarta.persistence.Timeout;
 
 /**
- * Magic {@linkplain jakarta.persistence.Timeout time out} values.
+ * Helpers for dealing with {@linkplain jakarta.persistence.Timeout time out} values,
+ * including some "magic values".
  *
- * @apiNote Generally speaking, for {@linkplain #NO_WAIT} and {@linkplain #SKIP_LOCKED},
- * the corresponding {@linkplain LockMode} should be preferred, but these magic values
- * allow use in conjunction with {@linkplain jakarta.persistence.LockModeType} without
- * the need to cast/unwrap to Hibernate specifics.
+ * @apiNote The {@linkplain #NO_WAIT} and {@linkplain #SKIP_LOCKED} magic values have
+ * special {@linkplain LockMode} values as well ({@linkplain LockMode#UPGRADE_NOWAIT}
+ * and {@linkplain LockMode#UPGRADE_SKIPLOCKED}, respectively).
  *
  * @author Steve Ebersole
  *
@@ -38,6 +38,7 @@ public interface Timeouts {
 	 * Indicates that the database should not wait at all to acquire
 	 * a pessimistic lock which is not immediately available.
 	 *
+	 * @see #NO_WAIT_MILLI
 	 * @see LockMode#UPGRADE_NOWAIT
 	 */
 	Timeout NO_WAIT = Timeout.milliseconds( NO_WAIT_MILLI );
@@ -46,13 +47,67 @@ public interface Timeouts {
 	 * Indicates that there is no timeout for the lock acquisition,
 	 * that is, that the database should in principle wait forever
 	 * to obtain the lock.
+	 *
+	 * @see #WAIT_FOREVER_MILLI
 	 */
 	Timeout WAIT_FOREVER = Timeout.milliseconds( WAIT_FOREVER_MILLI );
 
 	/**
 	 * Indicates that rows which are already locked should be skipped.
 	 *
+	 * @see #SKIP_LOCKED_MILLI
 	 * @see LockMode#UPGRADE_SKIPLOCKED
 	 */
 	Timeout SKIP_LOCKED = Timeout.milliseconds( SKIP_LOCKED_MILLI );
+
+	/**
+	 * Similar to simply calling {@linkplain Timeout#milliseconds(int)}, but accounting for
+	 * the "magic values".
+	 */
+	static Timeout interpretMilliSeconds(int timeoutInMilliseconds) {
+		if ( timeoutInMilliseconds == NO_WAIT_MILLI ) {
+			return NO_WAIT;
+		}
+		else if ( timeoutInMilliseconds == WAIT_FOREVER_MILLI ) {
+			return WAIT_FOREVER;
+		}
+		else if ( timeoutInMilliseconds == SKIP_LOCKED_MILLI ) {
+			return SKIP_LOCKED;
+		}
+		return Timeout.milliseconds( timeoutInMilliseconds );
+	}
+
+	/**
+	 * Is the timeout value a real value, as opposed to one of the
+	 * "magic values".  Functionally, returns whether the value is
+	 * greater than zero.
+	 */
+	static boolean isRealTimeout(Timeout timeout) {
+		return isRealTimeout( timeout.milliseconds() );
+	}
+
+	/**
+	 * Is the timeout value a real value, as opposed to one of the
+	 * "magic values".  Functionally, returns whether the value is
+	 * greater than zero.
+	 */
+	static boolean isRealTimeout(int timeoutInMilliseconds) {
+		return timeoutInMilliseconds > 0;
+	}
+
+	/**
+	 * Get the number of (whole) seconds represented by the given {@code timeout}.
+	 */
+	static int getTimeoutInSeconds(Timeout timeout) {
+		return getTimeoutInSeconds( timeout.milliseconds() );
+	}
+
+	/**
+	 * Get the number of (whole) seconds represented by the given {@code timeout}.
+	 */
+	static int getTimeoutInSeconds(int timeoutInMilliseconds) {
+		// should never be negative here...
+		assert timeoutInMilliseconds >= 0;
+		return timeoutInMilliseconds == 0 ? 0 : Math.max( 1, Math.round( timeoutInMilliseconds / 1e3f ) );
+	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/Timeouts.java
+++ b/hibernate-core/src/main/java/org/hibernate/Timeouts.java
@@ -1,0 +1,58 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate;
+
+import jakarta.persistence.Timeout;
+
+/**
+ * Magic {@linkplain jakarta.persistence.Timeout time out} values.
+ *
+ * @apiNote Generally speaking, for {@linkplain #NO_WAIT} and {@linkplain #SKIP_LOCKED},
+ * the corresponding {@linkplain LockMode} should be preferred, but these magic values
+ * allow use in conjunction with {@linkplain jakarta.persistence.LockModeType} without
+ * the need to cast/unwrap to Hibernate specifics.
+ *
+ * @author Steve Ebersole
+ *
+ * @since 7.0
+ */
+public interface Timeouts {
+	/**
+	 * Raw magic millisecond value for {@linkplain #NO_WAIT}
+	 */
+	int NO_WAIT_MILLI = 0;
+
+	/**
+	 * Raw magic millisecond value for {@linkplain #WAIT_FOREVER}
+	 */
+	int WAIT_FOREVER_MILLI = -1;
+
+	/**
+	 * Raw magic millisecond value for {@linkplain #SKIP_LOCKED}
+	 */
+	int SKIP_LOCKED_MILLI = -2;
+
+	/**
+	 * Indicates that the database should not wait at all to acquire
+	 * a pessimistic lock which is not immediately available.
+	 *
+	 * @see LockMode#UPGRADE_NOWAIT
+	 */
+	Timeout NO_WAIT = Timeout.milliseconds( NO_WAIT_MILLI );
+
+	/**
+	 * Indicates that there is no timeout for the lock acquisition,
+	 * that is, that the database should in principle wait forever
+	 * to obtain the lock.
+	 */
+	Timeout WAIT_FOREVER = Timeout.milliseconds( WAIT_FOREVER_MILLI );
+
+	/**
+	 * Indicates that rows which are already locked should be skipped.
+	 *
+	 * @see LockMode#UPGRADE_SKIPLOCKED
+	 */
+	Timeout SKIP_LOCKED = Timeout.milliseconds( SKIP_LOCKED_MILLI );
+}

--- a/hibernate-core/src/main/java/org/hibernate/dialect/CockroachDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/CockroachDialect.java
@@ -4,24 +4,13 @@
  */
 package org.hibernate.dialect;
 
-import java.sql.DatabaseMetaData;
-import java.sql.ResultSet;
-import java.sql.SQLException;
-import java.sql.Types;
-import java.time.temporal.ChronoField;
-import java.time.temporal.TemporalAccessor;
-import java.util.Calendar;
-import java.util.Date;
-import java.util.List;
-import java.util.Map;
-import java.util.TimeZone;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.TemporalType;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.hibernate.LockMode;
 import org.hibernate.LockOptions;
 import org.hibernate.QueryTimeoutException;
+import org.hibernate.Timeouts;
 import org.hibernate.boot.model.FunctionContributions;
 import org.hibernate.boot.model.TypeContributions;
 import org.hibernate.dialect.aggregate.AggregateSupport;
@@ -60,8 +49,8 @@ import org.hibernate.exception.spi.ViolatedConstraintNameExtractor;
 import org.hibernate.internal.util.StringHelper;
 import org.hibernate.internal.util.config.ConfigurationHelper;
 import org.hibernate.query.SemanticException;
-import org.hibernate.query.sqm.IntervalType;
 import org.hibernate.query.common.TemporalUnit;
+import org.hibernate.query.sqm.IntervalType;
 import org.hibernate.query.sqm.produce.function.StandardFunctionArgumentTypeResolvers;
 import org.hibernate.service.ServiceRegistry;
 import org.hibernate.sql.ast.SqlAstTranslator;
@@ -85,8 +74,19 @@ import org.hibernate.type.descriptor.sql.internal.Scale6IntervalSecondDdlType;
 import org.hibernate.type.descriptor.sql.spi.DdlTypeRegistry;
 import org.hibernate.type.spi.TypeConfiguration;
 
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.TemporalType;
+import java.sql.DatabaseMetaData;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Types;
+import java.time.temporal.ChronoField;
+import java.time.temporal.TemporalAccessor;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import java.util.TimeZone;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import static java.lang.Integer.parseInt;
 import static org.hibernate.cfg.DialectSpecificSettings.COCKROACH_VERSION_STRING;
@@ -932,8 +932,8 @@ public class CockroachDialect extends Dialect {
 
 	private String withTimeout(String lockString, int timeout) {
 		return switch (timeout) {
-			case LockOptions.NO_WAIT -> supportsNoWait() ? lockString + " nowait" : lockString;
-			case LockOptions.SKIP_LOCKED -> supportsSkipLocked() ? lockString + " skip locked" : lockString;
+			case Timeouts.NO_WAIT_MILLI -> supportsNoWait() ? lockString + " nowait" : lockString;
+			case Timeouts.SKIP_LOCKED_MILLI -> supportsSkipLocked() ? lockString + " skip locked" : lockString;
 			default -> lockString;
 		};
 	}

--- a/hibernate-core/src/main/java/org/hibernate/dialect/DB2Dialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/DB2Dialect.java
@@ -5,6 +5,7 @@
 package org.hibernate.dialect;
 
 import jakarta.persistence.TemporalType;
+import jakarta.persistence.Timeout;
 import org.hibernate.Timeouts;
 import org.hibernate.boot.model.FunctionContributions;
 import org.hibernate.boot.model.TypeContributions;
@@ -848,6 +849,20 @@ public class DB2Dialect extends Dialect {
 	@Override
 	public String getForUpdateSkipLockedString(String aliases) {
 		return getForUpdateSkipLockedString();
+	}
+
+	@Override
+	public String getWriteLockString(Timeout timeout) {
+		return timeout.milliseconds() == Timeouts.SKIP_LOCKED_MILLI && supportsSkipLocked()
+				? FOR_UPDATE_SKIP_LOCKED_SQL
+				: FOR_UPDATE_SQL;
+	}
+
+	@Override
+	public String getReadLockString(Timeout timeout) {
+		return timeout.milliseconds() == Timeouts.SKIP_LOCKED_MILLI && supportsSkipLocked()
+				? FOR_SHARE_SKIP_LOCKED_SQL
+				: FOR_SHARE_SQL;
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/dialect/DB2Dialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/DB2Dialect.java
@@ -4,25 +4,8 @@
  */
 package org.hibernate.dialect;
 
-import java.sql.CallableStatement;
-import java.sql.DatabaseMetaData;
-import java.sql.ResultSet;
-import java.sql.SQLException;
-import java.sql.Types;
-import java.time.Instant;
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.time.LocalTime;
-import java.time.OffsetDateTime;
-import java.time.OffsetTime;
-import java.time.ZonedDateTime;
-import java.time.temporal.TemporalAccessor;
-import java.util.Calendar;
-import java.util.Date;
-import java.util.List;
-import java.util.TimeZone;
-
-import org.hibernate.LockOptions;
+import jakarta.persistence.TemporalType;
+import org.hibernate.Timeouts;
 import org.hibernate.boot.model.FunctionContributions;
 import org.hibernate.boot.model.TypeContributions;
 import org.hibernate.dialect.aggregate.AggregateSupport;
@@ -63,9 +46,9 @@ import org.hibernate.metamodel.mapping.EntityMappingType;
 import org.hibernate.metamodel.spi.RuntimeModelCreationContext;
 import org.hibernate.procedure.internal.DB2CallableStatementSupport;
 import org.hibernate.procedure.spi.CallableStatementSupport;
+import org.hibernate.query.common.TemporalUnit;
 import org.hibernate.query.sqm.CastType;
 import org.hibernate.query.sqm.IntervalType;
-import org.hibernate.query.common.TemporalUnit;
 import org.hibernate.query.sqm.mutation.internal.cte.CteInsertStrategy;
 import org.hibernate.query.sqm.mutation.internal.cte.CteMutationStrategy;
 import org.hibernate.query.sqm.mutation.spi.SqmMultiTableInsertStrategy;
@@ -108,7 +91,23 @@ import org.hibernate.type.descriptor.sql.internal.DdlTypeImpl;
 import org.hibernate.type.descriptor.sql.spi.DdlTypeRegistry;
 import org.hibernate.type.spi.TypeConfiguration;
 
-import jakarta.persistence.TemporalType;
+import java.sql.CallableStatement;
+import java.sql.DatabaseMetaData;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Types;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.OffsetDateTime;
+import java.time.OffsetTime;
+import java.time.ZonedDateTime;
+import java.time.temporal.TemporalAccessor;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.List;
+import java.util.TimeZone;
 
 import static org.hibernate.exception.spi.TemplatedViolatedConstraintNameExtractor.extractUsingTemplate;
 import static org.hibernate.internal.util.JdbcExceptionHelper.extractErrorCode;
@@ -853,14 +852,14 @@ public class DB2Dialect extends Dialect {
 
 	@Override
 	public String getWriteLockString(int timeout) {
-		return timeout == LockOptions.SKIP_LOCKED && supportsSkipLocked()
+		return timeout == Timeouts.SKIP_LOCKED_MILLI && supportsSkipLocked()
 				? FOR_UPDATE_SKIP_LOCKED_SQL
 				: FOR_UPDATE_SQL;
 	}
 
 	@Override
 	public String getReadLockString(int timeout) {
-		return timeout == LockOptions.SKIP_LOCKED && supportsSkipLocked()
+		return timeout == Timeouts.SKIP_LOCKED_MILLI && supportsSkipLocked()
 				? FOR_SHARE_SKIP_LOCKED_SQL
 				: FOR_SHARE_SQL;
 	}

--- a/hibernate-core/src/main/java/org/hibernate/dialect/DB2iDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/DB2iDialect.java
@@ -4,7 +4,7 @@
  */
 package org.hibernate.dialect;
 
-import org.hibernate.LockOptions;
+import org.hibernate.Timeouts;
 import org.hibernate.boot.model.FunctionContributions;
 import org.hibernate.dialect.function.CommonFunctionFactory;
 import org.hibernate.dialect.identity.DB2IdentityColumnSupport;
@@ -195,14 +195,14 @@ public class DB2iDialect extends DB2Dialect {
 
 	@Override
 	public String getWriteLockString(int timeout) {
-		return timeout == LockOptions.SKIP_LOCKED && supportsSkipLocked()
+		return timeout == Timeouts.SKIP_LOCKED_MILLI && supportsSkipLocked()
 				? FOR_UPDATE_SKIP_LOCKED_SQL
 				: FOR_UPDATE_SQL;
 	}
 
 	@Override
 	public String getReadLockString(int timeout) {
-		return timeout == LockOptions.SKIP_LOCKED && supportsSkipLocked()
+		return timeout == Timeouts.SKIP_LOCKED_MILLI && supportsSkipLocked()
 				? FOR_UPDATE_SKIP_LOCKED_SQL
 				: FOR_UPDATE_SQL;
 	}

--- a/hibernate-core/src/main/java/org/hibernate/dialect/DB2iDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/DB2iDialect.java
@@ -4,6 +4,7 @@
  */
 package org.hibernate.dialect;
 
+import jakarta.persistence.Timeout;
 import org.hibernate.Timeouts;
 import org.hibernate.boot.model.FunctionContributions;
 import org.hibernate.dialect.function.CommonFunctionFactory;
@@ -191,6 +192,20 @@ public class DB2iDialect extends DB2Dialect {
 	@Override
 	public String getForUpdateSkipLockedString(String aliases) {
 		return getForUpdateSkipLockedString();
+	}
+
+	@Override
+	public String getWriteLockString(Timeout timeout) {
+		return timeout.milliseconds() == Timeouts.SKIP_LOCKED_MILLI && supportsSkipLocked()
+				? FOR_UPDATE_SKIP_LOCKED_SQL
+				: FOR_UPDATE_SQL;
+	}
+
+	@Override
+	public String getReadLockString(Timeout timeout) {
+		return timeout.milliseconds() == Timeouts.SKIP_LOCKED_MILLI && supportsSkipLocked()
+				? FOR_UPDATE_SKIP_LOCKED_SQL
+				: FOR_UPDATE_SQL;
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/dialect/Dialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/Dialect.java
@@ -2212,7 +2212,7 @@ public abstract class Dialect implements ConversionContext, TypeContributor, Fun
 	 * @param timeout the timeout
 	 * @return The appropriate {@code for update} fragment.
 	 */
-	private String getForUpdateString(LockMode lockMode, int timeout) {
+	public String getForUpdateString(LockMode lockMode, int timeout) {
 		return switch (lockMode) {
 			case PESSIMISTIC_READ -> getReadLockString( timeout );
 			case PESSIMISTIC_WRITE -> getWriteLockString( timeout );

--- a/hibernate-core/src/main/java/org/hibernate/dialect/Dialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/Dialect.java
@@ -2563,6 +2563,10 @@ public abstract class Dialect implements ConversionContext, TypeContributor, Fun
 		return sql + new ForUpdateFragment( this, aliasedLockOptions, keyColumnNames ).toFragmentString();
 	}
 
+	/**
+	 * @deprecated Use {@linkplain Timeouts#getTimeoutInSeconds(int)} instead.
+	 */
+	@Deprecated
 	protected int getTimeoutInSeconds(int millis) {
 		return Timeouts.getTimeoutInSeconds( millis );
 	}

--- a/hibernate-core/src/main/java/org/hibernate/dialect/Dialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/Dialect.java
@@ -13,6 +13,7 @@ import org.hibernate.Length;
 import org.hibernate.LockMode;
 import org.hibernate.LockOptions;
 import org.hibernate.ScrollMode;
+import org.hibernate.Timeouts;
 import org.hibernate.boot.TempTableDdlTransactionHandling;
 import org.hibernate.boot.model.FunctionContributions;
 import org.hibernate.boot.model.FunctionContributor;
@@ -130,10 +131,10 @@ import org.hibernate.tool.schema.internal.StandardTableExporter;
 import org.hibernate.tool.schema.internal.StandardTableMigrator;
 import org.hibernate.tool.schema.internal.StandardUniqueKeyExporter;
 import org.hibernate.tool.schema.internal.StandardUserDefinedTypeExporter;
-import org.hibernate.tool.schema.spi.TableMigrator;
 import org.hibernate.tool.schema.spi.Cleaner;
 import org.hibernate.tool.schema.spi.Exporter;
 import org.hibernate.tool.schema.spi.SchemaManagementTool;
+import org.hibernate.tool.schema.spi.TableMigrator;
 import org.hibernate.type.BasicType;
 import org.hibernate.type.BasicTypeRegistry;
 import org.hibernate.type.SqlTypes;
@@ -2254,7 +2255,15 @@ public abstract class Dialect implements ConversionContext, TypeContributor, Fun
 	 * @return The appropriate {@code LOCK} clause string.
 	 */
 	public String getWriteLockString(int timeout) {
-		return getForUpdateString();
+		if ( timeout == Timeouts.SKIP_LOCKED_MILLI && supportsSkipLocked() ) {
+			return getForUpdateSkipLockedString();
+		}
+		else if ( timeout == Timeouts.NO_WAIT_MILLI && supportsNoWait() ) {
+			return getForUpdateNowaitString();
+		}
+		else {
+			return getForUpdateString();
+		}
 	}
 
 	/**

--- a/hibernate-core/src/main/java/org/hibernate/dialect/Dialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/Dialect.java
@@ -6,6 +6,7 @@ package org.hibernate.dialect;
 
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.TemporalType;
+import jakarta.persistence.Timeout;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.hibernate.HibernateException;
 import org.hibernate.Incubating;
@@ -2201,7 +2202,7 @@ public abstract class Dialect implements ConversionContext, TypeContributor, Fun
 	 * @return The appropriate {@code for update} fragment.
 	 */
 	public String getForUpdateString(LockOptions lockOptions) {
-		return getForUpdateString( lockOptions.getLockMode(), lockOptions.getTimeOut() );
+		return getForUpdateString( lockOptions.getLockMode(), lockOptions.getTimeout() );
 	}
 
 	/**
@@ -2213,6 +2214,28 @@ public abstract class Dialect implements ConversionContext, TypeContributor, Fun
 	 * @param timeout the timeout
 	 * @return The appropriate {@code for update} fragment.
 	 */
+	public String getForUpdateString(LockMode lockMode, Timeout timeout) {
+		return switch (lockMode) {
+			case PESSIMISTIC_READ -> getReadLockString( timeout );
+			case PESSIMISTIC_WRITE -> getWriteLockString( timeout );
+			case UPGRADE_NOWAIT, PESSIMISTIC_FORCE_INCREMENT -> getForUpdateNowaitString();
+			case UPGRADE_SKIPLOCKED -> getForUpdateSkipLockedString();
+			default -> "";
+		};
+	}
+
+	/**
+	 * Given a {@linkplain LockMode lock level} and timeout,
+	 * determine the appropriate {@code for update} fragment to
+	 * use to obtain the lock.
+	 *
+	 * @param lockMode the lock mode to apply.
+	 * @param timeout the timeout
+	 * @return The appropriate {@code for update} fragment.
+	 *
+	 * @deprecated Use {@linkplain #getForUpdateString(LockMode,Timeout)} instead
+	 */
+	@Deprecated(since = "7.0")
 	public String getForUpdateString(LockMode lockMode, int timeout) {
 		return switch (lockMode) {
 			case PESSIMISTIC_READ -> getReadLockString( timeout );
@@ -2231,7 +2254,7 @@ public abstract class Dialect implements ConversionContext, TypeContributor, Fun
 	 * @return The appropriate for update fragment.
 	 */
 	public String getForUpdateString(LockMode lockMode) {
-		return getForUpdateString( lockMode, LockOptions.WAIT_FOREVER );
+		return getForUpdateString( lockMode, Timeouts.WAIT_FOREVER );
 	}
 
 	/**
@@ -2247,13 +2270,39 @@ public abstract class Dialect implements ConversionContext, TypeContributor, Fun
 	/**
 	 * Get the string to append to {@code SELECT} statements to
 	 * acquire pessimistic WRITE locks for this dialect.
+	 *
+	 * @param timeout How long the database should wait to acquire the lock.
+	 * 		See {@linkplain Timeouts} for some "magic values".
+	 *
+	 * @return The appropriate lock clause.
+	 */
+	public String getWriteLockString(Timeout timeout) {
+		if ( timeout.milliseconds() == Timeouts.SKIP_LOCKED_MILLI && supportsSkipLocked() ) {
+			return getForUpdateSkipLockedString();
+		}
+		else if ( timeout.milliseconds() == Timeouts.NO_WAIT_MILLI && supportsNoWait() ) {
+			return getForUpdateNowaitString();
+		}
+		else {
+			return getForUpdateString();
+		}
+	}
+
+	/**
+	 * Get the string to append to {@code SELECT} statements to
+	 * acquire pessimistic WRITE locks for this dialect.
 	 * <p>
 	 * Location of the returned string is treated the same as
 	 * {@link #getForUpdateString()}.
 	 *
-	 * @param timeout in milliseconds, -1 for indefinite wait and 0 for no wait.
+	 * @param timeout How long, in milliseconds, the database should wait to acquire the lock.
+	 * 		See {@linkplain Timeouts} for some "magic values".
+	 *
 	 * @return The appropriate {@code LOCK} clause string.
+	 *
+	 * @deprecated Use {@linkplain #getWriteLockString(Timeout)} instead.
 	 */
+	@Deprecated(since = "7.0")
 	public String getWriteLockString(int timeout) {
 		if ( timeout == Timeouts.SKIP_LOCKED_MILLI && supportsSkipLocked() ) {
 			return getForUpdateSkipLockedString();
@@ -2269,19 +2318,60 @@ public abstract class Dialect implements ConversionContext, TypeContributor, Fun
 	/**
 	 * Get the string to append to {@code SELECT} statements to
 	 * acquire WRITE locks for this dialect, given the aliases of
-	 * the columns to be write locked.
+	 * the columns to be WRITE locked.
+	 * 	 *
+	 * 	 * @param timeout How long the database should wait to acquire the lock.
 	 * <p>
 	 * Location of the returned string is treated the same as
 	 * {@link #getForUpdateString()}.
 	 *
 	 * @param aliases The columns to be read locked.
-	 * @param timeout in milliseconds, -1 for indefinite wait and 0 for no wait.
+	 * @param timeout How long the database should wait to acquire the lock.
+	 * 		See {@linkplain Timeouts} for some "magic values".
+	 *
 	 * @return The appropriate {@code LOCK} clause string.
 	 */
+	public String getWriteLockString(String aliases, Timeout timeout) {
+		// by default, we simply return getWriteLockString(timeout),
+		// since the default is no support for "FOR UPDATE OF ..."
+		return getWriteLockString( timeout );
+	}
+
+	/**
+	 * Get the string to append to {@code SELECT} statements to
+	 * acquire WRITE locks for this dialect, given the aliases of
+	 * the columns to be WRITE locked.
+	 * <p>
+	 * Location of the returned string is treated the same as
+	 * {@link #getForUpdateString()}.
+	 *
+	 * @param aliases The columns to be read locked.
+	 *
+	 * @param timeout How long, in milliseconds, the database should wait to acquire the lock.
+	 * 		See {@linkplain Timeouts} for some "magic values".
+	 *
+	 * @return The appropriate {@code LOCK} clause string.
+	 *
+	 * @deprecated Use {@linkplain #getWriteLockString(String, Timeout)} instead.
+	 */
+	@Deprecated(since = "7.0")
 	public String getWriteLockString(String aliases, int timeout) {
 		// by default, we simply return getWriteLockString(timeout),
 		// since the default is no support for "FOR UPDATE OF ..."
 		return getWriteLockString( timeout );
+	}
+
+	/**
+	 * Get the string to append to {@code SELECT} statements to
+	 * acquire READ locks for this dialect.
+	 *
+	 * @param timeout How long the database should wait to acquire the lock.
+	 * 		See {@linkplain Timeouts} for some "magic values".
+	 *
+	 * @return The appropriate {@code LOCK} clause string.
+	 */
+	public String getReadLockString(Timeout timeout) {
+		return getForUpdateString();
 	}
 
 	/**
@@ -2293,9 +2383,30 @@ public abstract class Dialect implements ConversionContext, TypeContributor, Fun
 	 *
 	 * @param timeout in milliseconds, -1 for indefinite wait and 0 for no wait.
 	 * @return The appropriate {@code LOCK} clause string.
+	 *
+	 * @deprecated Use {@linkplain #getReadLockString(Timeout)} instead.
 	 */
+	@Deprecated(since = "7.0")
 	public String getReadLockString(int timeout) {
 		return getForUpdateString();
+	}
+
+	/**
+	 * Get the string to append to {@code SELECT} statements to
+	 * acquire READ locks for this dialect, given the aliases of
+	 * the columns to be read locked.
+	 *
+	 * @param aliases The columns to be read locked.
+	 * @param timeout How long the database should wait to acquire the lock.
+	 * 		See {@linkplain Timeouts} for some "magic values".
+	 *
+	 * @return The appropriate {@code LOCK} clause string.
+	 *
+	 * @implNote By default, simply returns the {@linkplain #getReadLockString(Timeout)}
+	 * result since the default is to say no support for "FOR UPDATE OF ...".
+	 */
+	public String getReadLockString(String aliases, Timeout timeout) {
+		return getReadLockString( timeout );
 	}
 
 	/**
@@ -2308,8 +2419,12 @@ public abstract class Dialect implements ConversionContext, TypeContributor, Fun
 	 *
 	 * @param aliases The columns to be read locked.
 	 * @param timeout in milliseconds, -1 for indefinite wait and 0 for no wait.
+	 *
 	 * @return The appropriate {@code LOCK} clause string.
+	 *
+	 * @deprecated Use {@linkplain #getReadLockString(String, Timeout)} instead.
 	 */
+	@Deprecated(since = "7.0")
 	public String getReadLockString(String aliases, int timeout) {
 		// by default we simply return the getReadLockString(timeout) result since
 		// the default is to say no support for "FOR UPDATE OF ..."
@@ -2449,7 +2564,7 @@ public abstract class Dialect implements ConversionContext, TypeContributor, Fun
 	}
 
 	protected int getTimeoutInSeconds(int millis) {
-		return millis == 0 ? 0 : Math.max( 1, Math.round( millis / 1e3f ) );
+		return Timeouts.getTimeoutInSeconds( millis );
 	}
 
 

--- a/hibernate-core/src/main/java/org/hibernate/dialect/HANADialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/HANADialect.java
@@ -1017,7 +1017,7 @@ public class HANADialect extends Dialect {
 	@Override
 	public String getWriteLockString(Timeout timeout) {
 		if ( Timeouts.isRealTimeout( timeout ) ) {
-			return getForUpdateString() + " wait " + getTimeoutInSeconds( timeout.milliseconds() );
+			return getForUpdateString() + " wait " + Timeouts.getTimeoutInSeconds( timeout.milliseconds() );
 		}
 		else if ( timeout.milliseconds() == Timeouts.NO_WAIT_MILLI ) {
 			return getForUpdateNowaitString();

--- a/hibernate-core/src/main/java/org/hibernate/dialect/HANADialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/HANADialect.java
@@ -8,6 +8,7 @@ import jakarta.persistence.TemporalType;
 import org.hibernate.LockMode;
 import org.hibernate.LockOptions;
 import org.hibernate.ScrollMode;
+import org.hibernate.Timeouts;
 import org.hibernate.boot.Metadata;
 import org.hibernate.boot.model.FunctionContributions;
 import org.hibernate.boot.model.TypeContributions;
@@ -52,9 +53,9 @@ import org.hibernate.metamodel.mapping.EntityMappingType;
 import org.hibernate.metamodel.spi.RuntimeModelCreationContext;
 import org.hibernate.procedure.internal.StandardCallableStatementSupport;
 import org.hibernate.procedure.spi.CallableStatementSupport;
+import org.hibernate.query.common.TemporalUnit;
 import org.hibernate.query.sqm.CastType;
 import org.hibernate.query.sqm.IntervalType;
-import org.hibernate.query.common.TemporalUnit;
 import org.hibernate.query.sqm.mutation.internal.temptable.GlobalTemporaryTableInsertStrategy;
 import org.hibernate.query.sqm.mutation.internal.temptable.GlobalTemporaryTableMutationStrategy;
 import org.hibernate.query.sqm.mutation.spi.SqmMultiTableInsertStrategy;
@@ -1017,7 +1018,7 @@ public class HANADialect extends Dialect {
 		if ( timeout > 0 ) {
 			return getForUpdateString() + " wait " + getTimeoutInSeconds( timeout );
 		}
-		else if ( timeout == 0 ) {
+		else if ( timeout == Timeouts.NO_WAIT_MILLI ) {
 			return getForUpdateNowaitString();
 		}
 		else {

--- a/hibernate-core/src/main/java/org/hibernate/dialect/HANADialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/HANADialect.java
@@ -5,6 +5,7 @@
 package org.hibernate.dialect;
 
 import jakarta.persistence.TemporalType;
+import jakarta.persistence.Timeout;
 import org.hibernate.LockMode;
 import org.hibernate.LockOptions;
 import org.hibernate.ScrollMode;
@@ -1001,6 +1002,42 @@ public class HANADialect extends Dialect {
 	@Override
 	public String getForUpdateNowaitString(String aliases) {
 		return getForUpdateString( aliases ) + " nowait";
+	}
+
+	@Override
+	public String getReadLockString(Timeout timeout) {
+		return getWriteLockString( timeout );
+	}
+
+	@Override
+	public String getReadLockString(String aliases, Timeout timeout) {
+		return getWriteLockString( aliases, timeout );
+	}
+
+	@Override
+	public String getWriteLockString(Timeout timeout) {
+		if ( Timeouts.isRealTimeout( timeout ) ) {
+			return getForUpdateString() + " wait " + getTimeoutInSeconds( timeout.milliseconds() );
+		}
+		else if ( timeout.milliseconds() == Timeouts.NO_WAIT_MILLI ) {
+			return getForUpdateNowaitString();
+		}
+		else {
+			return getForUpdateString();
+		}
+	}
+
+	@Override
+	public String getWriteLockString(String aliases, Timeout timeout) {
+		if ( Timeouts.isRealTimeout( timeout ) ) {
+			return getForUpdateString( aliases ) + " wait " + getTimeoutInSeconds( timeout.milliseconds() );
+		}
+		else if ( timeout.milliseconds() == Timeouts.NO_WAIT_MILLI ) {
+			return getForUpdateNowaitString( aliases );
+		}
+		else {
+			return getForUpdateString( aliases );
+		}
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/dialect/MySQLDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/MySQLDialect.java
@@ -1434,7 +1434,12 @@ public class MySQLDialect extends Dialect {
 	}
 
 	private String withTimeout(String lockString, Timeout timeout) {
-		return withTimeout( lockString, Timeouts.getTimeoutInSeconds( timeout ) );
+		return switch (timeout.milliseconds()) {
+			case Timeouts.NO_WAIT_MILLI -> supportsNoWait() ? lockString + " nowait" : lockString;
+			case Timeouts.SKIP_LOCKED_MILLI -> supportsSkipLocked() ? lockString + " skip locked" : lockString;
+			case Timeouts.WAIT_FOREVER_MILLI -> lockString;
+			default -> supportsWait() ? lockString + " wait " + Timeouts.getTimeoutInSeconds( timeout ) : lockString;
+		};
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/dialect/MySQLDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/MySQLDialect.java
@@ -4,20 +4,10 @@
  */
 package org.hibernate.dialect;
 
-import java.sql.CallableStatement;
-import java.sql.DatabaseMetaData;
-import java.sql.ResultSet;
-import java.sql.SQLException;
-import java.sql.Types;
-import java.time.ZonedDateTime;
-import java.time.temporal.TemporalAccessor;
-import java.util.Calendar;
-import java.util.Date;
-import java.util.TimeZone;
-
+import jakarta.persistence.TemporalType;
 import org.hibernate.Length;
-import org.hibernate.LockOptions;
 import org.hibernate.QueryTimeoutException;
+import org.hibernate.Timeouts;
 import org.hibernate.boot.model.FunctionContributions;
 import org.hibernate.boot.model.TypeContributions;
 import org.hibernate.cfg.AvailableSettings;
@@ -54,14 +44,14 @@ import org.hibernate.exception.spi.ViolatedConstraintNameExtractor;
 import org.hibernate.mapping.CheckConstraint;
 import org.hibernate.metamodel.mapping.EntityMappingType;
 import org.hibernate.metamodel.spi.RuntimeModelCreationContext;
+import org.hibernate.query.common.TemporalUnit;
 import org.hibernate.query.sqm.CastType;
 import org.hibernate.query.sqm.IntervalType;
-import org.hibernate.query.common.TemporalUnit;
 import org.hibernate.query.sqm.function.SqmFunctionRegistry;
-import org.hibernate.query.sqm.mutation.spi.AfterUseAction;
-import org.hibernate.query.sqm.mutation.spi.BeforeUseAction;
 import org.hibernate.query.sqm.mutation.internal.temptable.LocalTemporaryTableInsertStrategy;
 import org.hibernate.query.sqm.mutation.internal.temptable.LocalTemporaryTableMutationStrategy;
+import org.hibernate.query.sqm.mutation.spi.AfterUseAction;
+import org.hibernate.query.sqm.mutation.spi.BeforeUseAction;
 import org.hibernate.query.sqm.mutation.spi.SqmMultiTableInsertStrategy;
 import org.hibernate.query.sqm.mutation.spi.SqmMultiTableMutationStrategy;
 import org.hibernate.query.sqm.produce.function.FunctionParameterType;
@@ -88,7 +78,16 @@ import org.hibernate.type.descriptor.sql.internal.NativeEnumDdlTypeImpl;
 import org.hibernate.type.descriptor.sql.internal.NativeOrdinalEnumDdlTypeImpl;
 import org.hibernate.type.descriptor.sql.spi.DdlTypeRegistry;
 
-import jakarta.persistence.TemporalType;
+import java.sql.CallableStatement;
+import java.sql.DatabaseMetaData;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Types;
+import java.time.ZonedDateTime;
+import java.time.temporal.TemporalAccessor;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.TimeZone;
 
 import static java.lang.Integer.parseInt;
 import static org.hibernate.exception.spi.TemplatedViolatedConstraintNameExtractor.extractUsingTemplate;
@@ -1435,9 +1434,9 @@ public class MySQLDialect extends Dialect {
 
 	private String withTimeout(String lockString, int timeout) {
 		return switch (timeout) {
-			case LockOptions.NO_WAIT -> supportsNoWait() ? lockString + " nowait" : lockString;
-			case LockOptions.SKIP_LOCKED -> supportsSkipLocked() ? lockString + " skip locked" : lockString;
-			case LockOptions.WAIT_FOREVER -> lockString;
+			case Timeouts.NO_WAIT_MILLI -> supportsNoWait() ? lockString + " nowait" : lockString;
+			case Timeouts.SKIP_LOCKED_MILLI -> supportsSkipLocked() ? lockString + " skip locked" : lockString;
+			case Timeouts.WAIT_FOREVER_MILLI -> lockString;
 			default -> supportsWait() ? lockString + " wait " + getTimeoutInSeconds( timeout ) : lockString;
 		};
 	}

--- a/hibernate-core/src/main/java/org/hibernate/dialect/OracleDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/OracleDialect.java
@@ -8,6 +8,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.TemporalType;
 import org.hibernate.Length;
 import org.hibernate.QueryTimeoutException;
+import org.hibernate.Timeouts;
 import org.hibernate.boot.model.FunctionContributions;
 import org.hibernate.boot.model.TypeContributions;
 import org.hibernate.dialect.aggregate.AggregateSupport;
@@ -115,9 +116,6 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import static java.util.regex.Pattern.CASE_INSENSITIVE;
-import static org.hibernate.LockOptions.NO_WAIT;
-import static org.hibernate.LockOptions.SKIP_LOCKED;
-import static org.hibernate.LockOptions.WAIT_FOREVER;
 import static org.hibernate.cfg.DialectSpecificSettings.ORACLE_USE_BINARY_FLOATS;
 import static org.hibernate.dialect.type.OracleJdbcHelper.getArrayJdbcTypeConstructor;
 import static org.hibernate.dialect.type.OracleJdbcHelper.getNestedTableJdbcTypeConstructor;
@@ -1468,9 +1466,9 @@ public class OracleDialect extends Dialect {
 
 	private String withTimeout(String lockString, int timeout) {
 		return switch (timeout) {
-			case NO_WAIT -> supportsNoWait() ? lockString + " nowait" : lockString;
-			case SKIP_LOCKED -> supportsSkipLocked() ? lockString + " skip locked" : lockString;
-			case WAIT_FOREVER -> lockString;
+			case Timeouts.NO_WAIT_MILLI -> supportsNoWait() ? lockString + " nowait" : lockString;
+			case Timeouts.SKIP_LOCKED_MILLI -> supportsSkipLocked() ? lockString + " skip locked" : lockString;
+			case Timeouts.WAIT_FOREVER_MILLI -> lockString;
 			default -> supportsWait() ? lockString + " wait " + getTimeoutInSeconds( timeout ) : lockString;
 		};
 	}

--- a/hibernate-core/src/main/java/org/hibernate/dialect/OracleDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/OracleDialect.java
@@ -1494,7 +1494,7 @@ public class OracleDialect extends Dialect {
 			case Timeouts.NO_WAIT_MILLI -> supportsNoWait() ? lockString + " nowait" : lockString;
 			case Timeouts.SKIP_LOCKED_MILLI -> supportsSkipLocked() ? lockString + " skip locked" : lockString;
 			case Timeouts.WAIT_FOREVER_MILLI -> lockString;
-			default -> supportsWait() ? lockString + " wait " + getTimeoutInSeconds( timeout ) : lockString;
+			default -> supportsWait() ? lockString + " wait " + Timeouts.getTimeoutInSeconds( timeout ) : lockString;
 		};
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/dialect/OracleDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/OracleDialect.java
@@ -6,6 +6,7 @@ package org.hibernate.dialect;
 
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.TemporalType;
+import jakarta.persistence.Timeout;
 import org.hibernate.Length;
 import org.hibernate.QueryTimeoutException;
 import org.hibernate.Timeouts;
@@ -1462,6 +1463,30 @@ public class OracleDialect extends Dialect {
 	@Override
 	public String getForUpdateSkipLockedString(String aliases) {
 		return " for update of " + aliases + " skip locked";
+	}
+
+	private String withTimeout(String lockString, Timeout timeout) {
+		return withTimeout( lockString, timeout.milliseconds() );
+	}
+
+	@Override
+	public String getWriteLockString(Timeout timeout) {
+		return withTimeout( getForUpdateString(), timeout );
+	}
+
+	@Override
+	public String getWriteLockString(String aliases, Timeout timeout) {
+		return withTimeout( getForUpdateString(aliases), timeout );
+	}
+
+	@Override
+	public String getReadLockString(Timeout timeout) {
+		return getWriteLockString( timeout );
+	}
+
+	@Override
+	public String getReadLockString(String aliases, Timeout timeout) {
+		return getWriteLockString( aliases, timeout );
 	}
 
 	private String withTimeout(String lockString, int timeout) {

--- a/hibernate-core/src/main/java/org/hibernate/dialect/PostgreSQLDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/PostgreSQLDialect.java
@@ -4,24 +4,14 @@
  */
 package org.hibernate.dialect;
 
-import java.sql.CallableStatement;
-import java.sql.DatabaseMetaData;
-import java.sql.ResultSet;
-import java.sql.SQLException;
-import java.sql.Types;
-import java.time.temporal.ChronoField;
-import java.time.temporal.TemporalAccessor;
-import java.util.Calendar;
-import java.util.Date;
-import java.util.List;
-import java.util.Map;
-import java.util.TimeZone;
-
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.TemporalType;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.hibernate.Length;
 import org.hibernate.LockMode;
 import org.hibernate.LockOptions;
 import org.hibernate.QueryTimeoutException;
+import org.hibernate.Timeouts;
 import org.hibernate.boot.model.FunctionContributions;
 import org.hibernate.boot.model.TypeContributions;
 import org.hibernate.dialect.aggregate.AggregateSupport;
@@ -70,11 +60,11 @@ import org.hibernate.persister.entity.mutation.EntityMutationTarget;
 import org.hibernate.procedure.internal.PostgreSQLCallableStatementSupport;
 import org.hibernate.procedure.spi.CallableStatementSupport;
 import org.hibernate.query.SemanticException;
+import org.hibernate.query.common.FetchClauseType;
+import org.hibernate.query.common.TemporalUnit;
 import org.hibernate.query.spi.QueryOptions;
 import org.hibernate.query.sqm.CastType;
-import org.hibernate.query.common.FetchClauseType;
 import org.hibernate.query.sqm.IntervalType;
-import org.hibernate.query.common.TemporalUnit;
 import org.hibernate.query.sqm.mutation.internal.cte.CteInsertStrategy;
 import org.hibernate.query.sqm.mutation.internal.cte.CteMutationStrategy;
 import org.hibernate.query.sqm.mutation.spi.SqmMultiTableInsertStrategy;
@@ -112,8 +102,18 @@ import org.hibernate.type.descriptor.sql.internal.Scale6IntervalSecondDdlType;
 import org.hibernate.type.descriptor.sql.spi.DdlTypeRegistry;
 import org.hibernate.type.spi.TypeConfiguration;
 
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.TemporalType;
+import java.sql.CallableStatement;
+import java.sql.DatabaseMetaData;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Types;
+import java.time.temporal.ChronoField;
+import java.time.temporal.TemporalAccessor;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import java.util.TimeZone;
 
 import static java.lang.Integer.parseInt;
 import static org.hibernate.exception.spi.TemplatedViolatedConstraintNameExtractor.extractUsingTemplate;
@@ -1306,8 +1306,8 @@ public class PostgreSQLDialect extends Dialect {
 
 	private String withTimeout(String lockString, int timeout) {
 		return switch (timeout) {
-			case LockOptions.NO_WAIT -> supportsNoWait() ? lockString + " nowait" : lockString;
-			case LockOptions.SKIP_LOCKED -> supportsSkipLocked() ? lockString + " skip locked" : lockString;
+			case Timeouts.NO_WAIT_MILLI -> supportsNoWait() ? lockString + " nowait" : lockString;
+			case Timeouts.SKIP_LOCKED_MILLI -> supportsSkipLocked() ? lockString + " skip locked" : lockString;
 			default -> lockString;
 		};
 	}

--- a/hibernate-core/src/main/java/org/hibernate/dialect/PostgreSQLDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/PostgreSQLDialect.java
@@ -6,6 +6,7 @@ package org.hibernate.dialect;
 
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.TemporalType;
+import jakarta.persistence.Timeout;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.hibernate.Length;
 import org.hibernate.LockMode;
@@ -1302,6 +1303,34 @@ public class PostgreSQLDialect extends Dialect {
 			default:
 				throw new IllegalArgumentException();
 		}
+	}
+
+	private String withTimeout(String lockString, Timeout timeout) {
+		return switch (timeout.milliseconds()) {
+			case Timeouts.NO_WAIT_MILLI -> supportsNoWait() ? lockString + " nowait" : lockString;
+			case Timeouts.SKIP_LOCKED_MILLI -> supportsSkipLocked() ? lockString + " skip locked" : lockString;
+			default -> lockString;
+		};
+	}
+
+	@Override
+	public String getWriteLockString(Timeout timeout) {
+		return withTimeout( getForUpdateString(), timeout );
+	}
+
+	@Override
+	public String getWriteLockString(String aliases, Timeout timeout) {
+		return withTimeout( getForUpdateString( aliases ), timeout );
+	}
+
+	@Override
+	public String getReadLockString(Timeout timeout) {
+		return withTimeout(" for share", timeout );
+	}
+
+	@Override
+	public String getReadLockString(String aliases, Timeout timeout) {
+		return withTimeout(" for share of " + aliases, timeout );
 	}
 
 	private String withTimeout(String lockString, int timeout) {

--- a/hibernate-core/src/main/java/org/hibernate/dialect/SpannerDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/SpannerDialect.java
@@ -7,6 +7,7 @@ package org.hibernate.dialect;
 import java.util.Date;
 import java.util.Map;
 
+import jakarta.persistence.Timeout;
 import org.hibernate.LockMode;
 import org.hibernate.LockOptions;
 import org.hibernate.StaleObjectStateException;
@@ -729,6 +730,30 @@ public class SpannerDialect extends Dialect {
 
 	@Override
 	public String getForUpdateString(String aliases, LockOptions lockOptions) {
+		throw new UnsupportedOperationException(
+				"Cloud Spanner does not support selecting for lock acquisition." );
+	}
+
+	@Override
+	public String getWriteLockString(Timeout timeout) {
+		throw new UnsupportedOperationException(
+				"Cloud Spanner does not support selecting for lock acquisition." );
+	}
+
+	@Override
+	public String getWriteLockString(String aliases, Timeout timeout) {
+		throw new UnsupportedOperationException(
+				"Cloud Spanner does not support selecting for lock acquisition." );
+	}
+
+	@Override
+	public String getReadLockString(Timeout timeout) {
+		throw new UnsupportedOperationException(
+				"Cloud Spanner does not support selecting for lock acquisition." );
+	}
+
+	@Override
+	public String getReadLockString(String aliases, Timeout timeout) {
 		throw new UnsupportedOperationException(
 				"Cloud Spanner does not support selecting for lock acquisition." );
 	}

--- a/hibernate-core/src/main/java/org/hibernate/engine/spi/SessionDelegatorBaseImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/spi/SessionDelegatorBaseImpl.java
@@ -873,16 +873,6 @@ public class SessionDelegatorBaseImpl implements SessionImplementor {
 	}
 
 	@Override
-	public <T> T find(Class<T> entityType, Object id, LockMode lockMode) {
-		return delegate.find( entityType, id, lockMode );
-	}
-
-	@Override
-	public <T> T find(Class<T> entityType, Object id, LockOptions lockOptions) {
-		return delegate.find( entityType, id, lockOptions );
-	}
-
-	@Override
 	public <T> T getReference(Class<T> entityClass, Object id) {
 		return delegate.getReference( entityClass, id );
 	}
@@ -900,6 +890,11 @@ public class SessionDelegatorBaseImpl implements SessionImplementor {
 	@Override
 	public void lock(Object object, LockMode lockMode) {
 		delegate.lock( object, lockMode );
+	}
+
+	@Override
+	public void lock(Object object, LockMode lockMode, LockOption... lockOptions) {
+		delegate.lock( object, lockMode, lockOptions );
 	}
 
 	@Override
@@ -935,11 +930,6 @@ public class SessionDelegatorBaseImpl implements SessionImplementor {
 	@Override
 	public void refresh(Object entity, RefreshOption... options) {
 		delegate.refresh( entity, options );
-	}
-
-	@Override
-	public void refresh(Object object, LockMode lockMode) {
-		delegate.refresh( object, lockMode );
 	}
 
 	@Override
@@ -980,11 +970,6 @@ public class SessionDelegatorBaseImpl implements SessionImplementor {
 	@Override
 	public <T> T get(Class<T> theClass, Object id, LockMode lockMode) {
 		return delegate.get( theClass, id, lockMode );
-	}
-
-	@Override
-	public <T> T get(Class<T> theClass, Object id, LockOptions lockOptions) {
-		return delegate.get( theClass, id, lockOptions );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/engine/spi/SessionLazyDelegator.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/spi/SessionLazyDelegator.java
@@ -232,6 +232,11 @@ public class SessionLazyDelegator implements Session {
 	}
 
 	@Override
+	public void lock(Object object, LockMode lockMode, LockOption... lockOptions) {
+		this.lazySession.get().lock( object, lockMode, lockOptions );
+	}
+
+	@Override
 	public void lock(Object object, LockOptions lockOptions) {
 		this.lazySession.get().lock( object, lockOptions );
 	}
@@ -239,11 +244,6 @@ public class SessionLazyDelegator implements Session {
 	@Override
 	public void refresh(Object object) {
 		this.lazySession.get().refresh( object );
-	}
-
-	@Override
-	public void refresh(Object object, LockMode lockMode) {
-		this.lazySession.get().refresh( object, lockMode );
 	}
 
 	@Override
@@ -284,11 +284,6 @@ public class SessionLazyDelegator implements Session {
 	@Override
 	public <T> T get(Class<T> entityType, Object id, LockMode lockMode) {
 		return this.lazySession.get().get( entityType, id, lockMode );
-	}
-
-	@Override
-	public <T> T get(Class<T> entityType, Object id, LockOptions lockOptions) {
-		return this.lazySession.get().get( entityType, id, lockOptions );
 	}
 
 	@Override
@@ -802,16 +797,6 @@ public class SessionLazyDelegator implements Session {
 	@Override
 	public <T> T find(EntityGraph<T> entityGraph, Object primaryKey, FindOption... options) {
 		return this.lazySession.get().find( entityGraph, primaryKey, options );
-	}
-
-	@Override
-	public <T> T find(Class<T> entityType, Object id, LockMode lockMode) {
-		return this.lazySession.get().find( entityType, id, lockMode );
-	}
-
-	@Override
-	public <T> T find(Class<T> entityType, Object id, LockOptions lockOptions) {
-		return this.lazySession.get().find( entityType, id, lockOptions );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/exception/LockTimeoutException.java
+++ b/hibernate-core/src/main/java/org/hibernate/exception/LockTimeoutException.java
@@ -21,6 +21,7 @@ import java.sql.SQLException;
  *
  * @author Steve Ebersole
  *
+ * @see jakarta.persistence.Timeout
  * @see org.hibernate.LockOptions#getTimeOut
  * @see org.hibernate.LockOptions#setTimeOut
  * @see jakarta.persistence.LockTimeoutException

--- a/hibernate-core/src/main/java/org/hibernate/internal/MultiIdentifierLoadAccessImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/MultiIdentifierLoadAccessImpl.java
@@ -4,14 +4,11 @@
  */
 package org.hibernate.internal;
 
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
-import java.util.function.Supplier;
-
 import jakarta.persistence.EntityGraph;
-
+import jakarta.persistence.PessimisticLockScope;
+import jakarta.persistence.Timeout;
 import org.hibernate.CacheMode;
+import org.hibernate.LockMode;
 import org.hibernate.LockOptions;
 import org.hibernate.MultiIdentifierLoadAccess;
 import org.hibernate.UnknownProfileException;
@@ -21,8 +18,13 @@ import org.hibernate.engine.spi.SessionImplementor;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.graph.GraphSemantic;
 import org.hibernate.graph.spi.RootGraphImplementor;
-import org.hibernate.persister.entity.EntityPersister;
 import org.hibernate.loader.ast.spi.MultiIdLoadOptions;
+import org.hibernate.persister.entity.EntityPersister;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.function.Supplier;
 
 import static java.util.Collections.emptyList;
 
@@ -51,6 +53,25 @@ class MultiIdentifierLoadAccessImpl<T> implements MultiIdentifierLoadAccess<T>, 
 	public MultiIdentifierLoadAccessImpl(SharedSessionContractImplementor session, EntityPersister entityPersister) {
 		this.session = session;
 		this.entityPersister = entityPersister;
+	}
+
+	@Override
+	public MultiIdentifierLoadAccess<T> with(LockMode lockMode, PessimisticLockScope lockScope) {
+		if ( lockOptions == null ) {
+			lockOptions = new LockOptions();
+		}
+		lockOptions.setLockMode( lockMode );
+		lockOptions.setLockScope( lockScope );
+		return this;
+	}
+
+	@Override
+	public MultiIdentifierLoadAccess<T> with(Timeout timeout) {
+		if ( lockOptions == null ) {
+			lockOptions = new LockOptions();
+		}
+		lockOptions.setTimeOut( timeout.milliseconds() );
+		return this;
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/internal/NaturalIdMultiLoadAccessStandard.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/NaturalIdMultiLoadAccessStandard.java
@@ -8,7 +8,10 @@ import java.util.List;
 
 import jakarta.persistence.EntityGraph;
 
+import jakarta.persistence.PessimisticLockScope;
+import jakarta.persistence.Timeout;
 import org.hibernate.CacheMode;
+import org.hibernate.LockMode;
 import org.hibernate.LockOptions;
 import org.hibernate.NaturalIdMultiLoadAccess;
 import org.hibernate.engine.spi.EffectiveEntityGraph;
@@ -41,6 +44,25 @@ public class NaturalIdMultiLoadAccessStandard<T> implements NaturalIdMultiLoadAc
 	public NaturalIdMultiLoadAccessStandard(EntityPersister entityDescriptor, SharedSessionContractImplementor session) {
 		this.entityDescriptor = entityDescriptor;
 		this.session = session;
+	}
+
+	@Override
+	public NaturalIdMultiLoadAccess<T> with(LockMode lockMode, PessimisticLockScope lockScope) {
+		if ( lockOptions == null ) {
+			lockOptions = new LockOptions();
+		}
+		lockOptions.setLockMode( lockMode );
+		lockOptions.setLockScope( lockScope );
+		return this;
+	}
+
+	@Override
+	public NaturalIdMultiLoadAccess<T> with(Timeout timeout) {
+		if ( lockOptions == null ) {
+			lockOptions = new LockOptions();
+		}
+		lockOptions.setTimeOut( timeout.milliseconds() );
+		return this;
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/internal/SessionImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/SessionImpl.java
@@ -4,61 +4,23 @@
  */
 package org.hibernate.internal;
 
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.ObjectInputStream;
-import java.io.ObjectOutputStream;
-import java.io.Reader;
-import java.io.Serial;
-import java.io.Serializable;
-import java.sql.Blob;
-import java.sql.Clob;
-import java.sql.Connection;
-import java.sql.NClob;
-import java.sql.SQLException;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.TimeZone;
-import java.util.function.UnaryOperator;
-
+import jakarta.persistence.CacheRetrieveMode;
+import jakarta.persistence.CacheStoreMode;
+import jakarta.persistence.EntityGraph;
+import jakarta.persistence.EntityNotFoundException;
+import jakarta.persistence.FindOption;
+import jakarta.persistence.FlushModeType;
+import jakarta.persistence.LockModeType;
+import jakarta.persistence.LockOption;
+import jakarta.persistence.PersistenceException;
 import jakarta.persistence.PessimisticLockScope;
+import jakarta.persistence.RefreshOption;
 import jakarta.persistence.Timeout;
+import jakarta.persistence.TransactionRequiredException;
+import jakarta.persistence.criteria.CriteriaSelect;
 import jakarta.persistence.metamodel.EntityType;
-import org.hibernate.BatchSize;
-import org.hibernate.CacheMode;
-import org.hibernate.ConnectionAcquisitionMode;
-import org.hibernate.ConnectionReleaseMode;
-import org.hibernate.EnabledFetchProfile;
-import org.hibernate.EntityFilterException;
-import org.hibernate.FetchNotFoundException;
-import org.hibernate.FlushMode;
-import org.hibernate.HibernateException;
-import org.hibernate.Interceptor;
-import org.hibernate.JDBCException;
-import org.hibernate.LobHelper;
-import org.hibernate.LockMode;
-import org.hibernate.LockOptions;
-import org.hibernate.MappingException;
-import org.hibernate.MultiIdentifierLoadAccess;
-import org.hibernate.NaturalIdLoadAccess;
-import org.hibernate.NaturalIdMultiLoadAccess;
-import org.hibernate.ObjectDeletedException;
-import org.hibernate.ObjectNotFoundException;
-import org.hibernate.ReadOnlyMode;
-import org.hibernate.ReplicationMode;
-import org.hibernate.Session;
-import org.hibernate.SessionBuilder;
-import org.hibernate.SessionEventListener;
-import org.hibernate.SessionException;
-import org.hibernate.SharedSessionBuilder;
-import org.hibernate.SimpleNaturalIdLoadAccess;
-import org.hibernate.Transaction;
-import org.hibernate.TypeMismatchException;
-import org.hibernate.UnknownProfileException;
-import org.hibernate.UnresolvableObjectException;
+import jakarta.persistence.metamodel.Metamodel;
+import org.hibernate.*;
 import org.hibernate.action.spi.AfterTransactionCompletionProcess;
 import org.hibernate.bytecode.enhance.spi.interceptor.EnhancementAsProxyLazinessInterceptor;
 import org.hibernate.collection.spi.PersistentCollection;
@@ -78,46 +40,10 @@ import org.hibernate.engine.spi.PersistentAttributeInterceptor;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.engine.spi.SessionImplementor;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
-import org.hibernate.event.service.spi.EventListenerGroups;
-import org.hibernate.event.spi.AutoFlushEvent;
-import org.hibernate.event.spi.AutoFlushEventListener;
-import org.hibernate.event.spi.ClearEvent;
-import org.hibernate.event.spi.ClearEventListener;
-import org.hibernate.event.spi.DeleteContext;
-import org.hibernate.event.spi.DeleteEvent;
-import org.hibernate.event.spi.DeleteEventListener;
-import org.hibernate.event.spi.DirtyCheckEvent;
-import org.hibernate.event.spi.DirtyCheckEventListener;
-import org.hibernate.event.spi.EventSource;
-import org.hibernate.event.spi.EvictEvent;
-import org.hibernate.event.spi.EvictEventListener;
-import org.hibernate.event.spi.FlushEvent;
-import org.hibernate.event.spi.FlushEventListener;
-import org.hibernate.event.spi.InitializeCollectionEvent;
-import org.hibernate.event.spi.InitializeCollectionEventListener;
-import org.hibernate.event.spi.LoadEvent;
-import org.hibernate.event.spi.LoadEventListener;
-import org.hibernate.event.spi.LockEvent;
-import org.hibernate.event.spi.LockEventListener;
-import org.hibernate.event.spi.MergeContext;
-import org.hibernate.event.spi.MergeEvent;
-import org.hibernate.event.spi.MergeEventListener;
-import org.hibernate.event.spi.PersistContext;
-import org.hibernate.event.spi.PersistEvent;
-import org.hibernate.event.spi.PersistEventListener;
-import org.hibernate.event.spi.PostLoadEvent;
-import org.hibernate.event.spi.PostLoadEventListener;
-import org.hibernate.event.spi.RefreshContext;
-import org.hibernate.event.spi.RefreshEvent;
-import org.hibernate.event.spi.RefreshEventListener;
-import org.hibernate.event.spi.ReplicateEvent;
-import org.hibernate.event.spi.ReplicateEventListener;
-import org.hibernate.loader.internal.CacheLoadHelper;
-import org.hibernate.metamodel.model.domain.EntityDomainType;
-import org.hibernate.metamodel.model.domain.ManagedDomainType;
-import org.hibernate.resource.transaction.spi.TransactionObserver;
-import org.hibernate.event.monitor.spi.EventMonitor;
 import org.hibernate.event.monitor.spi.DiagnosticEvent;
+import org.hibernate.event.monitor.spi.EventMonitor;
+import org.hibernate.event.service.spi.EventListenerGroups;
+import org.hibernate.event.spi.*;
 import org.hibernate.event.spi.LoadEventListener.LoadType;
 import org.hibernate.graph.GraphSemantic;
 import org.hibernate.graph.RootGraph;
@@ -127,10 +53,13 @@ import org.hibernate.jpa.internal.LegacySpecHelper;
 import org.hibernate.jpa.internal.util.ConfigurationHelper;
 import org.hibernate.jpa.internal.util.FlushModeTypeHelper;
 import org.hibernate.jpa.internal.util.LockModeTypeHelper;
+import org.hibernate.loader.internal.CacheLoadHelper;
 import org.hibernate.loader.internal.IdentifierLoadAccessImpl;
 import org.hibernate.loader.internal.LoadAccessContext;
 import org.hibernate.loader.internal.NaturalIdLoadAccessImpl;
 import org.hibernate.loader.internal.SimpleNaturalIdLoadAccessImpl;
+import org.hibernate.metamodel.model.domain.EntityDomainType;
+import org.hibernate.metamodel.model.domain.ManagedDomainType;
 import org.hibernate.persister.entity.EntityPersister;
 import org.hibernate.procedure.ProcedureCall;
 import org.hibernate.procedure.spi.NamedCallableQueryMemento;
@@ -148,25 +77,32 @@ import org.hibernate.resource.jdbc.spi.PhysicalConnectionHandlingMode;
 import org.hibernate.resource.jdbc.spi.StatementInspector;
 import org.hibernate.resource.transaction.spi.TransactionCoordinator;
 import org.hibernate.resource.transaction.spi.TransactionCoordinatorBuilder;
+import org.hibernate.resource.transaction.spi.TransactionObserver;
 import org.hibernate.resource.transaction.spi.TransactionStatus;
 import org.hibernate.stat.SessionStatistics;
 import org.hibernate.stat.internal.SessionStatisticsImpl;
 import org.hibernate.stat.spi.StatisticsImplementor;
 import org.hibernate.type.descriptor.WrapperOptions;
 
-import jakarta.persistence.CacheRetrieveMode;
-import jakarta.persistence.CacheStoreMode;
-import jakarta.persistence.EntityGraph;
-import jakarta.persistence.EntityNotFoundException;
-import jakarta.persistence.FindOption;
-import jakarta.persistence.FlushModeType;
-import jakarta.persistence.LockModeType;
-import jakarta.persistence.LockOption;
-import jakarta.persistence.PersistenceException;
-import jakarta.persistence.RefreshOption;
-import jakarta.persistence.TransactionRequiredException;
-import jakarta.persistence.criteria.CriteriaSelect;
-import jakarta.persistence.metamodel.Metamodel;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.Reader;
+import java.io.Serial;
+import java.io.Serializable;
+import java.sql.Blob;
+import java.sql.Clob;
+import java.sql.Connection;
+import java.sql.NClob;
+import java.sql.SQLException;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TimeZone;
+import java.util.function.UnaryOperator;
 
 import static java.lang.Boolean.parseBoolean;
 import static java.lang.Integer.parseInt;
@@ -191,6 +127,7 @@ import static org.hibernate.event.spi.LoadEventListener.IMMEDIATE_LOAD;
 import static org.hibernate.event.spi.LoadEventListener.INTERNAL_LOAD_EAGER;
 import static org.hibernate.event.spi.LoadEventListener.INTERNAL_LOAD_LAZY;
 import static org.hibernate.event.spi.LoadEventListener.INTERNAL_LOAD_NULLABLE;
+import static org.hibernate.internal.LockOptionsHelper.applyPropertiesToLockOptions;
 import static org.hibernate.jpa.HibernateHints.HINT_BATCH_FETCH_SIZE;
 import static org.hibernate.jpa.HibernateHints.HINT_ENABLE_SUBSELECT_FETCH;
 import static org.hibernate.jpa.HibernateHints.HINT_FETCH_PROFILE;
@@ -202,7 +139,6 @@ import static org.hibernate.jpa.LegacySpecHints.HINT_JAVAEE_QUERY_TIMEOUT;
 import static org.hibernate.jpa.SpecHints.HINT_SPEC_LOCK_TIMEOUT;
 import static org.hibernate.jpa.SpecHints.HINT_SPEC_QUERY_TIMEOUT;
 import static org.hibernate.jpa.internal.util.CacheModeHelper.interpretCacheMode;
-import static org.hibernate.internal.LockOptionsHelper.applyPropertiesToLockOptions;
 import static org.hibernate.jpa.internal.util.FlushModeTypeHelper.getFlushModeType;
 import static org.hibernate.pretty.MessageHelper.infoString;
 import static org.hibernate.proxy.HibernateProxy.extractLazyInitializer;
@@ -692,6 +628,11 @@ public class SessionImpl
 		final LockOptions lockOptions = copySessionLockOptions();
 		lockOptions.setLockMode( lockMode );
 		fireLock( new LockEvent( object, lockOptions, this ) );
+	}
+
+	@Override
+	public void lock(Object object, LockMode lockMode, LockOption... lockOptions) {
+		lock( object, buildLockOptions( lockMode, lockOptions ) );
 	}
 
 	private void fireLock(LockEvent event) {
@@ -1239,11 +1180,6 @@ public class SessionImpl
 	}
 
 	@Override
-	public <T> T get(Class<T> entityClass, Object id, LockOptions lockOptions) {
-		return this.byId( entityClass ).with( lockOptions ).load( id );
-	}
-
-	@Override
 	public Object get(String entityName, Object id, LockMode lockMode) {
 		return this.byId( entityName ).with( new LockOptions( lockMode ) ).load( id );
 	}
@@ -1357,13 +1293,6 @@ public class SessionImpl
 	@Override
 	public void refresh(Object object) {
 		fireRefresh( new RefreshEvent( object, this ) );
-	}
-
-	@Override
-	public void refresh(Object object, LockMode lockMode) {
-		final LockOptions lockOptions = copySessionLockOptions();
-		lockOptions.setLockMode( lockMode );
-		fireRefresh( new RefreshEvent( object, lockOptions, this ) );
 	}
 
 	@Override
@@ -2476,20 +2405,6 @@ public class SessionImpl
 	@Override
 	public <T> T find(Class<T> entityClass, Object primaryKey, LockModeType lockModeType) {
 		return find( entityClass, primaryKey, lockModeType, null );
-	}
-
-	@Override
-	public <T> T find(Class<T> entityType, Object id, LockMode lockMode) {
-		checkTransactionNeededForLock( lockMode );
-		final LockOptions lockOptions = copySessionLockOptions();
-		lockOptions.setLockMode( lockMode );
-		return find( entityType, id, lockOptions, null );
-	}
-
-	@Override
-	public <T> T find(Class<T> entityType, Object id, LockOptions lockOptions) {
-		checkTransactionNeededForLock( lockOptions.getLockMode() );
-		return find( entityType, id, lockOptions, null );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/loader/internal/BaseNaturalIdLoadAccessImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/loader/internal/BaseNaturalIdLoadAccessImpl.java
@@ -9,8 +9,11 @@ import java.util.Set;
 
 import jakarta.persistence.EntityGraph;
 
+import jakarta.persistence.PessimisticLockScope;
+import jakarta.persistence.Timeout;
 import org.hibernate.HibernateException;
 import org.hibernate.IdentifierLoadAccess;
+import org.hibernate.LockMode;
 import org.hibernate.LockOptions;
 import org.hibernate.UnknownProfileException;
 import org.hibernate.engine.spi.EffectiveEntityGraph;
@@ -62,6 +65,24 @@ public abstract class BaseNaturalIdLoadAccessImpl<T> implements NaturalIdLoadOpt
 
 	public LockOptions getLockOptions() {
 		return lockOptions;
+	}
+
+	protected Object with(LockMode lockMode, PessimisticLockScope lockScope) {
+		if ( lockOptions == null ) {
+			lockOptions = new LockOptions();
+		}
+		lockOptions.setLockMode( lockMode );
+		lockOptions.setLockScope( lockScope );
+		return this;
+	}
+
+
+	protected Object with(Timeout timeout) {
+		if ( lockOptions == null ) {
+			lockOptions = new LockOptions();
+		}
+		lockOptions.setTimeOut( timeout.milliseconds() );
+		return this;
 	}
 
 	public Object with(EntityGraph<T> graph, GraphSemantic semantic) {

--- a/hibernate-core/src/main/java/org/hibernate/loader/internal/IdentifierLoadAccessImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/loader/internal/IdentifierLoadAccessImpl.java
@@ -11,8 +11,11 @@ import java.util.function.Supplier;
 
 import jakarta.persistence.EntityGraph;
 
+import jakarta.persistence.PessimisticLockScope;
+import jakarta.persistence.Timeout;
 import org.hibernate.CacheMode;
 import org.hibernate.IdentifierLoadAccess;
+import org.hibernate.LockMode;
 import org.hibernate.LockOptions;
 import org.hibernate.ObjectNotFoundException;
 import org.hibernate.UnknownProfileException;
@@ -60,6 +63,25 @@ public class IdentifierLoadAccessImpl<T> implements IdentifierLoadAccess<T>, Jav
 	@Override
 	public final IdentifierLoadAccessImpl<T> with(LockOptions lockOptions) {
 		this.lockOptions = lockOptions;
+		return this;
+	}
+
+	@Override
+	public IdentifierLoadAccess<T> with(LockMode lockMode, PessimisticLockScope lockScope) {
+		if ( lockOptions == null ) {
+			lockOptions = new LockOptions();
+		}
+		lockOptions.setLockMode( lockMode );
+		lockOptions.setLockScope( lockScope );
+		return this;
+	}
+
+	@Override
+	public IdentifierLoadAccess<T> with(Timeout timeout) {
+		if ( lockOptions == null ) {
+			lockOptions = new LockOptions();
+		}
+		lockOptions.setTimeOut( timeout.milliseconds() );
 		return this;
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/loader/internal/NaturalIdLoadAccessImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/loader/internal/NaturalIdLoadAccessImpl.java
@@ -4,17 +4,19 @@
  */
 package org.hibernate.loader.internal;
 
-import java.util.LinkedHashMap;
-import java.util.Map;
-import java.util.Optional;
-
 import jakarta.persistence.EntityGraph;
+import jakarta.persistence.PessimisticLockScope;
+import jakarta.persistence.Timeout;
 import jakarta.persistence.metamodel.SingularAttribute;
-
+import org.hibernate.LockMode;
 import org.hibernate.LockOptions;
 import org.hibernate.NaturalIdLoadAccess;
 import org.hibernate.graph.GraphSemantic;
 import org.hibernate.metamodel.mapping.EntityMappingType;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Optional;
 
 /**
  * @author Steve Ebersole
@@ -24,6 +26,18 @@ public class NaturalIdLoadAccessImpl<T> extends BaseNaturalIdLoadAccessImpl<T> i
 
 	public NaturalIdLoadAccessImpl(LoadAccessContext context, EntityMappingType entityDescriptor) {
 		super( context, entityDescriptor );
+	}
+
+	@Override
+	public NaturalIdLoadAccess<T> with(LockMode lockMode, PessimisticLockScope lockScope) {
+		//noinspection unchecked
+		return (NaturalIdLoadAccess<T>) super.with( lockMode, lockScope );
+	}
+
+	@Override
+	public NaturalIdLoadAccess<T> with(Timeout timeout) {
+		//noinspection unchecked
+		return (NaturalIdLoadAccess<T>) super.with( timeout );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/loader/internal/SimpleNaturalIdLoadAccessImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/loader/internal/SimpleNaturalIdLoadAccessImpl.java
@@ -11,7 +11,10 @@ import java.util.Optional;
 
 import jakarta.persistence.EntityGraph;
 
+import jakarta.persistence.PessimisticLockScope;
+import jakarta.persistence.Timeout;
 import org.hibernate.HibernateException;
+import org.hibernate.LockMode;
 import org.hibernate.LockOptions;
 import org.hibernate.SimpleNaturalIdLoadAccess;
 import org.hibernate.graph.GraphSemantic;
@@ -50,6 +53,18 @@ public class SimpleNaturalIdLoadAccessImpl<T>
 	@Override
 	public boolean isSynchronizationEnabled() {
 		return super.isSynchronizationEnabled();
+	}
+
+	@Override
+	public SimpleNaturalIdLoadAccess<T> with(LockMode lockMode, PessimisticLockScope lockScope) {
+		//noinspection unchecked
+		return (SimpleNaturalIdLoadAccess<T>) super.with( lockMode, lockScope );
+	}
+
+	@Override
+	public SimpleNaturalIdLoadAccess<T> with(Timeout timeout) {
+		//noinspection unchecked
+		return (SimpleNaturalIdLoadAccess<T>) super.with( timeout );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/query/CommonQueryContract.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/CommonQueryContract.java
@@ -10,6 +10,7 @@ import java.util.Collection;
 import java.util.Date;
 import java.util.Map;
 
+import jakarta.persistence.Timeout;
 import org.hibernate.FlushMode;
 import org.hibernate.Session;
 
@@ -155,7 +156,9 @@ public interface CommonQueryContract {
 	 * Any value set here is eventually passed directly along to the
 	 * {@linkplain java.sql.Statement#setQueryTimeout(int) JDBC
 	 * statement}, which expressly disallows negative values.  So
-	 * negative values should be avoided as a general rule.
+	 * negative values should be avoided <em>as a general rule</em>,
+	 * although certain "magic values" are handled - see
+	 * {@linkplain org.hibernate.Timeouts#NO_WAIT}.
 	 * <p>
 	 * A value of zero indicates no timeout.
 	 *
@@ -163,9 +166,20 @@ public interface CommonQueryContract {
 	 *
 	 * @return {@code this}, for method chaining
 	 *
+	 * @see org.hibernate.Timeouts
+	 * @see #setTimeout(Timeout)
 	 * @see #getTimeout()
 	 */
 	CommonQueryContract setTimeout(int timeout);
+
+	/**
+	 * Apply a timeout to the corresponding database query.
+	 *
+	 * @param timeout The timeout to apply
+	 *
+	 * @return {@code this}, for method chaining
+	 */
+	CommonQueryContract setTimeout(Timeout timeout);
 
 	/**
 	 * Get the comment that has been set for this query, if any.

--- a/hibernate-core/src/main/java/org/hibernate/query/NativeQuery.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/NativeQuery.java
@@ -10,7 +10,9 @@ import jakarta.persistence.CacheStoreMode;
 import jakarta.persistence.FlushModeType;
 import jakarta.persistence.LockModeType;
 import jakarta.persistence.Parameter;
+import jakarta.persistence.PessimisticLockScope;
 import jakarta.persistence.TemporalType;
+import jakarta.persistence.Timeout;
 import jakarta.persistence.metamodel.SingularAttribute;
 
 import org.hibernate.CacheMode;
@@ -600,6 +602,21 @@ public interface NativeQuery<T> extends Query<T>, SynchronizeableQuery {
 	@Override
 	NativeQuery<T> setReadOnly(boolean readOnly);
 
+	@Override
+	NativeQuery<T> setComment(String comment);
+
+	@Override
+	NativeQuery<T> addQueryHint(String hint);
+
+	@Override
+	NativeQuery<T> setMaxResults(int maxResults);
+
+	@Override
+	NativeQuery<T> setFirstResult(int startPosition);
+
+	@Override
+	NativeQuery<T> setHint(String hintName, Object value);
+
 	/**
 	 * @inheritDoc
 	 *
@@ -621,29 +638,6 @@ public interface NativeQuery<T> extends Query<T>, SynchronizeableQuery {
 	 */
 	@Override
 	NativeQuery<T> setLockOptions(LockOptions lockOptions);
-
-	/**
-	 * Not applicable to native SQL queries.
-	 *
-	 * @throws IllegalStateException for consistency with JPA
-	 */
-	@Override
-	NativeQuery<T> setLockMode(String alias, LockMode lockMode);
-
-	@Override
-	NativeQuery<T> setComment(String comment);
-
-	@Override
-	NativeQuery<T> addQueryHint(String hint);
-
-	@Override
-	NativeQuery<T> setMaxResults(int maxResults);
-
-	@Override
-	NativeQuery<T> setFirstResult(int startPosition);
-
-	@Override
-	NativeQuery<T> setHint(String hintName, Object value);
 
 	/**
 	 * Not applicable to native SQL queries, due to an unfortunate
@@ -690,6 +684,32 @@ public interface NativeQuery<T> extends Query<T>, SynchronizeableQuery {
 	 */
 	@Override
 	NativeQuery<T> setHibernateLockMode(LockMode lockMode);
+
+	/**
+	 * Apply a timeout to the corresponding database query.
+	 *
+	 * @param timeout The timeout to apply
+	 *
+	 * @return {@code this}, for method chaining
+	 */
+	NativeQuery<T> setTimeout(Timeout timeout);
+
+	/**
+	 * Apply a scope to any pessimistic locking applied to the query.
+	 *
+	 * @param lockScope The lock scope to apply
+	 *
+	 * @return {@code this}, for method chaining
+	 */
+	NativeQuery<T> setLockScope(PessimisticLockScope lockScope);
+
+	/**
+	 * Not applicable to native SQL queries.
+	 *
+	 * @throws IllegalStateException for consistency with JPA
+	 */
+	@Override
+	NativeQuery<T> setLockMode(String alias, LockMode lockMode);
 
 	@Override
 	<R> NativeQuery<R> setTupleTransformer(TupleTransformer<R> transformer);

--- a/hibernate-core/src/main/java/org/hibernate/query/Query.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/Query.java
@@ -14,6 +14,8 @@ import java.util.Optional;
 import java.util.stream.Stream;
 
 import jakarta.persistence.EntityGraph;
+import jakarta.persistence.PessimisticLockScope;
+import jakarta.persistence.Timeout;
 import org.hibernate.CacheMode;
 import org.hibernate.FlushMode;
 import org.hibernate.Incubating;
@@ -357,7 +359,10 @@ public interface Query<R> extends SelectionQuery<R>, MutationQuery, TypedQuery<R
 	 * @return The {@link LockOptions} currently in effect
 	 *
 	 * @see LockOptions
+	 *
+	 * @deprecated To be removed with no replacement - this is an SPI/internal concern.
 	 */
+	@Deprecated(since = "7.0", forRemoval = true)
 	@Override
 	LockOptions getLockOptions();
 
@@ -375,7 +380,12 @@ public interface Query<R> extends SelectionQuery<R>, MutationQuery, TypedQuery<R
 	 * @return {@code this}, for method chaining
 	 *
 	 * @see #getLockOptions()
+	 *
+	 * @deprecated Use one of {@linkplain #setLockMode(LockModeType)},
+	 * {@linkplain #setHibernateLockMode}, {@linkplain #setLockScope}
+	 * and/or {@linkplain #setTimeout} instead.
 	 */
+	@Deprecated(since = "7.0", forRemoval = true)
 	Query<R> setLockOptions(LockOptions lockOptions);
 
 	/**
@@ -398,6 +408,24 @@ public interface Query<R> extends SelectionQuery<R>, MutationQuery, TypedQuery<R
 	 */
 	@Override
 	Query<R> setLockMode(String alias, LockMode lockMode);
+
+	/**
+	 * Apply a timeout to the corresponding database query.
+	 *
+	 * @param timeout The timeout to apply
+	 *
+	 * @return {@code this}, for method chaining
+	 */
+	Query<R> setTimeout(Timeout timeout);
+
+	/**
+	 * Apply a scope to any pessimistic locking applied to the query.
+	 *
+	 * @param lockScope The lock scope to apply
+	 *
+	 * @return {@code this}, for method chaining
+	 */
+	Query<R> setLockScope(PessimisticLockScope lockScope);
 
 	/**
 	 * Set a {@link TupleTransformer}.

--- a/hibernate-core/src/main/java/org/hibernate/query/SelectionQuery.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/SelectionQuery.java
@@ -17,7 +17,6 @@ import jakarta.persistence.CacheRetrieveMode;
 import jakarta.persistence.CacheStoreMode;
 import jakarta.persistence.EntityGraph;
 import jakarta.persistence.PessimisticLockScope;
-import jakarta.persistence.Timeout;
 import org.hibernate.CacheMode;
 import org.hibernate.FlushMode;
 import org.hibernate.Incubating;
@@ -588,15 +587,6 @@ public interface SelectionQuery<R> extends CommonQueryContract {
 	 * @see #setLockMode(LockModeType)
 	 */
 	SelectionQuery<R> setHibernateLockMode(LockMode lockMode);
-
-	/**
-	 * Apply a timeout to the corresponding database query.
-	 *
-	 * @param timeout The timeout to apply
-	 *
-	 * @return {@code this}, for method chaining
-	 */
-	SelectionQuery<R> setTimeout(Timeout timeout);
 
 	/**
 	 * Apply a scope to any pessimistic locking applied to the query.

--- a/hibernate-core/src/main/java/org/hibernate/query/SelectionQuery.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/SelectionQuery.java
@@ -16,7 +16,8 @@ import java.util.stream.Stream;
 import jakarta.persistence.CacheRetrieveMode;
 import jakarta.persistence.CacheStoreMode;
 import jakarta.persistence.EntityGraph;
-
+import jakarta.persistence.PessimisticLockScope;
+import jakarta.persistence.Timeout;
 import org.hibernate.CacheMode;
 import org.hibernate.FlushMode;
 import org.hibernate.Incubating;
@@ -587,6 +588,24 @@ public interface SelectionQuery<R> extends CommonQueryContract {
 	 * @see #setLockMode(LockModeType)
 	 */
 	SelectionQuery<R> setHibernateLockMode(LockMode lockMode);
+
+	/**
+	 * Apply a timeout to the corresponding database query.
+	 *
+	 * @param timeout The timeout to apply
+	 *
+	 * @return {@code this}, for method chaining
+	 */
+	SelectionQuery<R> setTimeout(Timeout timeout);
+
+	/**
+	 * Apply a scope to any pessimistic locking applied to the query.
+	 *
+	 * @param lockScope The lock scope to apply
+	 *
+	 * @return {@code this}, for method chaining
+	 */
+	SelectionQuery<R> setLockScope(PessimisticLockScope lockScope);
 
 	/**
 	 * Specify a {@link LockMode} to apply to a specific alias defined in the query

--- a/hibernate-core/src/main/java/org/hibernate/query/spi/AbstractQuery.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/spi/AbstractQuery.java
@@ -21,6 +21,7 @@ import jakarta.persistence.Parameter;
 import jakarta.persistence.PessimisticLockScope;
 import jakarta.persistence.TemporalType;
 
+import jakarta.persistence.Timeout;
 import org.hibernate.CacheMode;
 import org.hibernate.FlushMode;
 import org.hibernate.query.QueryFlushMode;
@@ -263,15 +264,15 @@ public abstract class AbstractQuery<R>
 	}
 
 	@Override
-	public LockModeType getLockMode() {
-		getSession().checkOpen( false );
-		return super.getLockMode();
-	}
-
-	@Override
 	public QueryImplementor<R> setLockOptions(LockOptions lockOptions) {
 		getQueryOptions().getLockOptions().overlay( lockOptions );
 		return this;
+	}
+
+	@Override
+	public LockModeType getLockMode() {
+		getSession().checkOpen( false );
+		return super.getLockMode();
 	}
 
 	@Override
@@ -284,6 +285,20 @@ public abstract class AbstractQuery<R>
 	public QueryImplementor<R> setLockMode(LockModeType lockModeType) {
 		getSession().checkOpen();
 		super.setHibernateLockMode( LockModeTypeHelper.getLockMode( lockModeType ) );
+		return this;
+	}
+
+	@Override
+	public QueryImplementor<R> setLockScope(PessimisticLockScope lockScope) {
+		getSession().checkOpen();
+		super.setLockScope( lockScope );
+		return this;
+	}
+
+	@Override
+	public QueryImplementor<R> setTimeout(Timeout timeout) {
+		getSession().checkOpen();
+		super.setTimeout( timeout );
 		return this;
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/query/spi/AbstractSelectionQuery.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/spi/AbstractSelectionQuery.java
@@ -16,6 +16,8 @@ import java.util.Spliterator;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
+import jakarta.persistence.PessimisticLockScope;
+import jakarta.persistence.Timeout;
 import org.hibernate.CacheMode;
 import org.hibernate.FlushMode;
 import org.hibernate.ScrollableResults;
@@ -437,6 +439,18 @@ public abstract class AbstractSelectionQuery<R>
 	@Override
 	public SelectionQuery<R> setHibernateLockMode(LockMode lockMode) {
 		getLockOptions().setLockMode( lockMode );
+		return this;
+	}
+
+	@Override
+	public SelectionQuery<R> setTimeout(Timeout timeout) {
+		getLockOptions().setTimeOut( timeout.milliseconds() );
+		return this;
+	}
+
+	@Override
+	public SelectionQuery<R> setLockScope(PessimisticLockScope lockScope) {
+		getLockOptions().setLockScope( lockScope );
 		return this;
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/query/sql/internal/NativeQueryImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sql/internal/NativeQueryImpl.java
@@ -18,6 +18,8 @@ import java.util.Set;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 
+import jakarta.persistence.PessimisticLockScope;
+import jakarta.persistence.Timeout;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.hibernate.CacheMode;
 import org.hibernate.FlushMode;
@@ -579,6 +581,18 @@ public class NativeQueryImpl<R>
 	@Override
 	public NativeQueryImplementor<R> setHibernateLockMode(LockMode lockMode) {
 		super.setHibernateLockMode( lockMode );
+		return this;
+	}
+
+	@Override
+	public NativeQueryImplementor<R> setTimeout(Timeout timeout) {
+		super.setTimeout( timeout );
+		return this;
+	}
+
+	@Override
+	public NativeQueryImplementor<R> setLockScope(PessimisticLockScope lockScope) {
+		super.setLockScope( lockScope );
 		return this;
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/internal/QuerySqmImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/internal/QuerySqmImpl.java
@@ -11,7 +11,9 @@ import jakarta.persistence.FlushModeType;
 import jakarta.persistence.LockModeType;
 import jakarta.persistence.Parameter;
 import jakarta.persistence.PersistenceException;
+import jakarta.persistence.PessimisticLockScope;
 import jakarta.persistence.TemporalType;
+import jakarta.persistence.Timeout;
 import org.hibernate.CacheMode;
 import org.hibernate.FlushMode;
 import org.hibernate.HibernateException;
@@ -777,6 +779,20 @@ public class QuerySqmImpl<R>
 		verifySelect();
 		getSession().checkOpen( false );
 		return getLockOptions().getLockMode().toJpaLockMode();
+	}
+
+	@Override
+	public SqmQueryImplementor<R> setLockScope(PessimisticLockScope lockScope) {
+		getSession().checkOpen( false );
+		getQueryOptions().getLockOptions().setLockScope( lockScope );
+		return this;
+	}
+
+	@Override
+	public SqmQueryImplementor<R> setTimeout(Timeout timeout) {
+		getSession().checkOpen( false );
+		getQueryOptions().getLockOptions().setTimeOut( timeout.milliseconds() );
+		return this;
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/internal/SqmSelectionQueryImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/internal/SqmSelectionQueryImpl.java
@@ -18,8 +18,10 @@ import jakarta.persistence.CacheStoreMode;
 import jakarta.persistence.FlushModeType;
 import jakarta.persistence.LockModeType;
 import jakarta.persistence.Parameter;
+import jakarta.persistence.PessimisticLockScope;
 import jakarta.persistence.TemporalType;
 
+import jakarta.persistence.Timeout;
 import org.hibernate.CacheMode;
 import org.hibernate.FlushMode;
 import org.hibernate.query.QueryFlushMode;
@@ -35,6 +37,7 @@ import org.hibernate.query.Order;
 import org.hibernate.query.Page;
 import org.hibernate.query.QueryParameter;
 import org.hibernate.query.ResultListTransformer;
+import org.hibernate.query.SelectionQuery;
 import org.hibernate.query.TupleTransformer;
 import org.hibernate.query.criteria.internal.NamedCriteriaQueryMementoImpl;
 import org.hibernate.query.hql.internal.NamedHqlQueryMementoImpl;
@@ -564,6 +567,18 @@ public class SqmSelectionQueryImpl<R> extends AbstractSqmSelectionQuery<R>
 	@Override
 	public SqmSelectionQuery<R> setHibernateLockMode(LockMode lockMode) {
 		super.setHibernateLockMode( lockMode );
+		return this;
+	}
+
+	@Override
+	public SelectionQuery<R> setTimeout(Timeout timeout) {
+		super.setTimeout( timeout );
+		return this;
+	}
+
+	@Override
+	public SelectionQuery<R> setLockScope(PessimisticLockScope lockScope) {
+		super.setLockScope( lockScope );
 		return this;
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/spi/DelegatingSqmSelectionQueryImplementor.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/spi/DelegatingSqmSelectionQueryImplementor.java
@@ -13,6 +13,8 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Stream;
 
+import jakarta.persistence.PessimisticLockScope;
+import jakarta.persistence.Timeout;
 import org.hibernate.CacheMode;
 import org.hibernate.FlushMode;
 import org.hibernate.Incubating;
@@ -285,6 +287,18 @@ public abstract class DelegatingSqmSelectionQueryImplementor<R> implements SqmSe
 	@Override
 	public SqmSelectionQueryImplementor<R> setHibernateLockMode(LockMode lockMode) {
 		getDelegate().setHibernateLockMode( lockMode );
+		return this;
+	}
+
+	@Override
+	public SqmSelectionQueryImplementor<R> setTimeout(Timeout timeout) {
+		getDelegate().setTimeout( timeout );
+		return this;
+	}
+
+	@Override
+	public SqmSelectionQueryImplementor<R> setLockScope(PessimisticLockScope lockScope) {
+		getDelegate().setLockScope( lockScope );
 		return this;
 	}
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/lock/LockExceptionTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/lock/LockExceptionTests.java
@@ -4,9 +4,7 @@
  */
 package org.hibernate.orm.test.jpa.lock;
 
-import java.util.Collections;
-
-import org.hibernate.LockOptions;
+import org.hibernate.Timeouts;
 import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
 import org.hibernate.cfg.AvailableSettings;
 import org.hibernate.dialect.CockroachDialect;
@@ -76,7 +74,7 @@ public class LockExceptionTests extends AbstractJPATest {
 												Item.class,
 												item.getId(),
 												LockModeType.PESSIMISTIC_WRITE,
-												Collections.singletonMap( AvailableSettings.JAKARTA_LOCK_TIMEOUT, LockOptions.NO_WAIT )
+												Timeouts.NO_WAIT
 										);
 										fail( "Expecting a failure" );
 									}
@@ -118,7 +116,7 @@ public class LockExceptionTests extends AbstractJPATest {
 										secondSession.refresh(
 												item2,
 												LockModeType.PESSIMISTIC_WRITE,
-												Collections.singletonMap( AvailableSettings.JAKARTA_LOCK_TIMEOUT, LockOptions.NO_WAIT )
+												Timeouts.NO_WAIT
 										);
 										fail( "Expecting a failure" );
 									}
@@ -156,11 +154,11 @@ public class LockExceptionTests extends AbstractJPATest {
 								secondSession -> {
 									try {
 										// generally speaking we should be able to read the row
-										Item item2 = secondSession.get( Item.class, item.getId() );
+										Item item2 = secondSession.find( Item.class, item.getId() );
 										secondSession.lock(
 												item2,
 												LockModeType.PESSIMISTIC_WRITE,
-												Collections.singletonMap( AvailableSettings.JAKARTA_LOCK_TIMEOUT, LockOptions.NO_WAIT )
+												Timeouts.NO_WAIT
 										);
 										fail( "Expecting a failure" );
 									}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/lock/LockExceptionTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/lock/LockExceptionTests.java
@@ -4,27 +4,26 @@
  */
 package org.hibernate.orm.test.jpa.lock;
 
+import jakarta.persistence.LockModeType;
+import jakarta.persistence.LockTimeoutException;
+import jakarta.persistence.PessimisticLockException;
 import org.hibernate.Timeouts;
 import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
 import org.hibernate.cfg.AvailableSettings;
 import org.hibernate.dialect.CockroachDialect;
 import org.hibernate.dialect.SQLServerDialect;
 import org.hibernate.engine.jdbc.connections.spi.ConnectionProvider;
+import org.hibernate.exception.LockAcquisitionException;
 import org.hibernate.orm.test.jpa.model.AbstractJPATest;
 import org.hibernate.orm.test.jpa.model.Item;
-
-import org.hibernate.testing.orm.junit.JiraKey;
 import org.hibernate.testing.jdbc.SQLServerSnapshotIsolationConnectionProvider;
 import org.hibernate.testing.orm.junit.DialectFeatureChecks;
+import org.hibernate.testing.orm.junit.JiraKey;
 import org.hibernate.testing.orm.junit.RequiresDialectFeature;
 import org.hibernate.testing.orm.junit.SkipForDialect;
 import org.hibernate.testing.transaction.TransactionUtil2;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Test;
-
-import jakarta.persistence.LockModeType;
-import jakarta.persistence.LockTimeoutException;
-import jakarta.persistence.PessimisticLockException;
 
 import static org.junit.jupiter.api.Assertions.fail;
 
@@ -78,7 +77,7 @@ public class LockExceptionTests extends AbstractJPATest {
 										);
 										fail( "Expecting a failure" );
 									}
-									catch (LockTimeoutException | PessimisticLockException | org.hibernate.exception.LockTimeoutException expected ) {
+									catch (LockTimeoutException | PessimisticLockException | LockAcquisitionException expected ) {
 										// expected outcome
 									}
 								}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/lock/LockExceptionTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/lock/LockExceptionTests.java
@@ -78,7 +78,7 @@ public class LockExceptionTests extends AbstractJPATest {
 										);
 										fail( "Expecting a failure" );
 									}
-									catch ( LockTimeoutException | PessimisticLockException expected ) {
+									catch (LockTimeoutException | PessimisticLockException | org.hibernate.exception.LockTimeoutException expected ) {
 										// expected outcome
 									}
 								}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/lock/LockTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/lock/LockTest.java
@@ -16,7 +16,6 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import jakarta.persistence.Timeout;
 import org.hibernate.Hibernate;
 import org.hibernate.HibernateException;
-import org.hibernate.LockOptions;
 import org.hibernate.Session;
 import org.hibernate.TransactionException;
 import org.hibernate.cfg.AvailableSettings;
@@ -304,9 +303,7 @@ public class LockTest extends BaseEntityManagerFunctionalTestCase {
 		);
 
 		doInJPA( this::entityManagerFactory, _entityManagaer -> {
-			Map<String, Object> properties = new HashMap<>();
-			properties.put( AvailableSettings.JAKARTA_LOCK_TIMEOUT, LockOptions.SKIP_LOCKED );
-			_entityManagaer.find( Lock.class, lock.getId(), LockModeType.PESSIMISTIC_READ, properties );
+			_entityManagaer.find( Lock.class, lock.getId(), LockModeType.PESSIMISTIC_READ, Timeout.milliseconds( 0 ) );
 
 			try {
 				doInJPA( this::entityManagerFactory, entityManager -> {

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/loading/multiLoad/MultiLoadSecondLlvCacheTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/loading/multiLoad/MultiLoadSecondLlvCacheTest.java
@@ -4,21 +4,19 @@
  */
 package org.hibernate.orm.test.loading.multiLoad;
 
-import java.util.List;
-
-import org.hibernate.CacheMode;
-import org.hibernate.LockOptions;
-import org.hibernate.cfg.AvailableSettings;
-import org.hibernate.cfg.Configuration;
-import org.hibernate.stat.Statistics;
-
-import org.hibernate.testing.junit4.BaseCoreFunctionalTestCase;
-import org.junit.Test;
-
 import jakarta.persistence.Basic;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jakarta.persistence.SharedCacheMode;
+import org.hibernate.CacheMode;
+import org.hibernate.LockMode;
+import org.hibernate.cfg.AvailableSettings;
+import org.hibernate.cfg.Configuration;
+import org.hibernate.stat.Statistics;
+import org.hibernate.testing.junit4.BaseCoreFunctionalTestCase;
+import org.junit.Test;
+
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -56,7 +54,7 @@ public class MultiLoadSecondLlvCacheTest extends BaseCoreFunctionalTestCase {
 		inSession( session -> {
 			List<Event> events = session.byMultipleIds( Event.class )
 					.with( CacheMode.NORMAL )
-					.with( LockOptions.NONE )
+					.with( LockMode.NONE )
 					.multiLoad( 1, 2, 3 );
 
 			// check all elements are not null

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/lob/BlobLocatorTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/lob/BlobLocatorTest.java
@@ -4,19 +4,18 @@
  */
 package org.hibernate.orm.test.lob;
 
-import java.sql.Blob;
-import java.util.Arrays;
-
-import org.hibernate.LockOptions;
+import junit.framework.AssertionFailedError;
+import org.hibernate.LockMode;
 import org.hibernate.Session;
 import org.hibernate.dialect.SybaseDialect;
-
 import org.hibernate.testing.DialectChecks;
 import org.hibernate.testing.RequiresDialectFeature;
 import org.hibernate.testing.junit4.BaseCoreFunctionalTestCase;
 import org.junit.Assert;
 import org.junit.Test;
-import junit.framework.AssertionFailedError;
+
+import java.sql.Blob;
+import java.util.Arrays;
 
 import static org.junit.Assert.assertNotNull;
 
@@ -70,7 +69,7 @@ public class BlobLocatorTest extends BaseCoreFunctionalTestCase {
 		if ( getDialect().supportsLobValueChangePropagation() ) {
 			s = openSession();
 			s.beginTransaction();
-			entity = ( LobHolder ) s.byId( LobHolder.class ).with( LockOptions.UPGRADE ).load( entity.getId() );
+			entity = s.byId( LobHolder.class ).with( LockMode.PESSIMISTIC_WRITE ).load( entity.getId() );
 			entity.getBlobLocator().truncate( 1 );
 			entity.getBlobLocator().setBytes( 1, changed );
 			s.getTransaction().commit();
@@ -78,7 +77,7 @@ public class BlobLocatorTest extends BaseCoreFunctionalTestCase {
 
 			s = openSession();
 			s.beginTransaction();
-			entity = ( LobHolder ) s.byId( LobHolder.class ).with( LockOptions.UPGRADE ).load( entity.getId() );
+			entity = s.byId( LobHolder.class ).with( LockMode.PESSIMISTIC_WRITE ).load( entity.getId() );
 			assertNotNull( entity.getBlobLocator() );
 			Assert.assertEquals( BLOB_SIZE, entity.getBlobLocator().length() );
 			assertEquals( changed, extractData( entity.getBlobLocator() ) );
@@ -91,7 +90,7 @@ public class BlobLocatorTest extends BaseCoreFunctionalTestCase {
 		// test mutation via supplying a new clob locator instance...
 		s = openSession();
 		s.beginTransaction();
-		entity = ( LobHolder ) s.byId( LobHolder.class ).with( LockOptions.UPGRADE ).load( entity.getId() );
+		entity = s.byId( LobHolder.class ).with( LockMode.PESSIMISTIC_WRITE ).load( entity.getId() );
 		assertNotNull( entity.getBlobLocator() );
 		Assert.assertEquals( BLOB_SIZE, entity.getBlobLocator().length() );
 		assertEquals( original, extractData( entity.getBlobLocator() ) );
@@ -102,7 +101,7 @@ public class BlobLocatorTest extends BaseCoreFunctionalTestCase {
 		// test empty blob
 		s = openSession();
 		s.beginTransaction();
-		entity = s.get( LobHolder.class, entity.getId() );
+		entity = s.find( LobHolder.class, entity.getId() );
 		Assert.assertEquals( BLOB_SIZE, entity.getBlobLocator().length() );
 		assertEquals( changed, extractData( entity.getBlobLocator() ) );
 		entity.setBlobLocator( s.getLobHelper().createBlob( empty ) );
@@ -111,7 +110,7 @@ public class BlobLocatorTest extends BaseCoreFunctionalTestCase {
 
 		s = openSession();
 		s.beginTransaction();
-		entity = s.get( LobHolder.class, entity.getId() );
+		entity = s.find( LobHolder.class, entity.getId() );
 		// Seems ASE does not support empty BLOBs
 		if ( entity.getBlobLocator() != null && !(sessionFactory().getJdbcServices().getDialect() instanceof SybaseDialect) ) {
 			Assert.assertEquals( empty.length, entity.getBlobLocator().length() );
@@ -147,7 +146,7 @@ public class BlobLocatorTest extends BaseCoreFunctionalTestCase {
 		// at that point it is unbounded...
 		s = openSession();
 		s.beginTransaction();
-		entity = s.get( LobHolder.class, entity.getId() );
+		entity = s.find( LobHolder.class, entity.getId() );
 		s.getTransaction().commit();
 		s.close();
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/lob/ClobLocatorTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/lob/ClobLocatorTest.java
@@ -4,18 +4,17 @@
  */
 package org.hibernate.orm.test.lob;
 
-import java.sql.Clob;
-
-import org.hibernate.LockOptions;
+import org.hibernate.LockMode;
 import org.hibernate.dialect.SybaseASEDialect;
-import org.hibernate.type.descriptor.java.DataHelper;
-
 import org.hibernate.testing.orm.junit.DialectFeatureChecks;
 import org.hibernate.testing.orm.junit.DomainModel;
 import org.hibernate.testing.orm.junit.RequiresDialectFeature;
 import org.hibernate.testing.orm.junit.SessionFactory;
 import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.hibernate.type.descriptor.java.DataHelper;
 import org.junit.jupiter.api.Test;
+
+import java.sql.Clob;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -82,7 +81,7 @@ public class ClobLocatorTest {
 					session -> {
 						try {
 							LobHolder entity = session.byId( LobHolder.class )
-									.with( LockOptions.UPGRADE )
+									.with( LockMode.PESSIMISTIC_WRITE )
 									.load( id );
 							entity.getClobLocator().truncate( 1 );
 							entity.getClobLocator().setString( 1, changed );
@@ -97,7 +96,7 @@ public class ClobLocatorTest {
 					session -> {
 						try {
 							LobHolder entity = session.byId( LobHolder.class )
-									.with( LockOptions.UPGRADE )
+									.with( LockMode.PESSIMISTIC_WRITE )
 									.load( id );
 							assertNotNull( entity.getClobLocator() );
 
@@ -118,7 +117,7 @@ public class ClobLocatorTest {
 		scope.inTransaction(
 				session -> {
 					try {
-						LobHolder entity = session.byId( LobHolder.class ).with( LockOptions.UPGRADE ).load( id );
+						LobHolder entity = session.find( LobHolder.class, id, LockMode.PESSIMISTIC_WRITE );
 						assertNotNull( entity.getClobLocator() );
 						assertEquals( CLOB_SIZE, entity.getClobLocator().length() );
 						assertEquals( original, extractData( entity.getClobLocator() ) );

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/locking/AbstractSkipLockedTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/locking/AbstractSkipLockedTest.java
@@ -4,26 +4,25 @@
  */
 package org.hibernate.orm.test.locking;
 
-import java.util.Arrays;
-import java.util.List;
-import java.util.stream.Collectors;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
-
+import jakarta.persistence.Timeout;
 import org.hibernate.LockMode;
-import org.hibernate.LockOptions;
 import org.hibernate.Session;
 import org.hibernate.dialect.MySQLDialect;
 import org.hibernate.dialect.OracleDialect;
 import org.hibernate.dialect.PostgreSQLDialect;
 import org.hibernate.dialect.SQLServerDialect;
 import org.hibernate.query.Query;
-
 import org.hibernate.testing.DialectChecks;
 import org.hibernate.testing.RequiresDialect;
 import org.hibernate.testing.RequiresDialectFeature;
 import org.hibernate.testing.junit4.BaseNonConfigCoreFunctionalTestCase;
 import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
 
 import static org.hibernate.testing.transaction.TransactionUtil.doInHibernate;
 import static org.junit.Assert.assertEquals;
@@ -208,10 +207,7 @@ public abstract class AbstractSkipLockedTest
 	}
 
 	protected void applySkipLocked(Query query) {
-		query.setLockOptions(
-				new LockOptions( lockMode() )
-						.setTimeOut( LockOptions.SKIP_LOCKED )
-		);
+		query.setHibernateLockMode( lockMode() ).setTimeout( Timeout.milliseconds( -2 ) );
 	}
 
 	protected abstract LockMode lockMode();

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/locking/ExplicitLockingTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/locking/ExplicitLockingTest.java
@@ -4,9 +4,6 @@
  */
 package org.hibernate.orm.test.locking;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
 import jakarta.persistence.Column;
 import jakarta.persistence.ElementCollection;
 import jakarta.persistence.Embeddable;
@@ -17,21 +14,22 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.JoinTable;
 import jakarta.persistence.LockModeType;
 import jakarta.persistence.PessimisticLockScope;
-
 import org.hibernate.LockMode;
-import org.hibernate.LockOptions;
 import org.hibernate.Session;
+import org.hibernate.Timeouts;
 import org.hibernate.dialect.OracleDialect;
 import org.hibernate.query.Query;
-
 import org.hibernate.testing.orm.junit.EntityManagerFactoryScope;
 import org.hibernate.testing.orm.junit.JiraKey;
 import org.hibernate.testing.orm.junit.Jpa;
 import org.hibernate.testing.orm.junit.RequiresDialect;
+import org.jboss.logging.Logger;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
-import org.jboss.logging.Logger;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -122,8 +120,7 @@ public class ExplicitLockingTest {
 			//tag::locking-session-lock-example[]
 			Person person = entityManager.find(Person.class, id);
 			Session session = entityManager.unwrap(Session.class);
-			LockOptions lockOptions = new LockOptions(LockMode.PESSIMISTIC_READ, LockOptions.NO_WAIT);
-			session.lock(person, lockOptions);
+			session.lock( person, LockMode.PESSIMISTIC_READ, Timeouts.NO_WAIT );
 			//end::locking-session-lock-example[]
 		});
 
@@ -132,8 +129,7 @@ public class ExplicitLockingTest {
 			//tag::locking-session-lock-scope-example[]
 			Person person = entityManager.find(Person.class, id);
 			Session session = entityManager.unwrap(Session.class);
-			LockOptions lockOptions = new LockOptions(LockMode.PESSIMISTIC_READ, LockOptions.NO_WAIT, PessimisticLockScope.EXTENDED);
-			session.lock(person, lockOptions);
+			session.lock(person, LockMode.PESSIMISTIC_READ, Timeouts.NO_WAIT, PessimisticLockScope.EXTENDED);
 			//end::locking-session-lock-scope-example[]
 		});
 
@@ -177,14 +173,12 @@ public class ExplicitLockingTest {
 
 		scope.inTransaction( entityManager -> {
 			//tag::locking-follow-on-explicit-example[]
-			List<Person> persons = entityManager.createQuery(
-				"select p from Person p", Person.class)
-			.setMaxResults(10)
-			.unwrap(Query.class)
-			.setLockOptions(
-				new LockOptions(LockMode.PESSIMISTIC_WRITE)
-					.setFollowOnLocking(false))
-			.getResultList();
+			List<Person> persons = entityManager.createQuery( "select p from Person p", Person.class )
+					.setMaxResults( 10 )
+					.setLockMode( LockModeType.PESSIMISTIC_WRITE )
+					.unwrap( Query.class )
+					.setFollowOnLocking( false )
+					.getResultList();
 			//end::locking-follow-on-explicit-example[]
 		});
 	}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/locking/PessimisticWriteLockTimeoutTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/locking/PessimisticWriteLockTimeoutTest.java
@@ -4,15 +4,14 @@
  */
 package org.hibernate.orm.test.locking;
 
-import org.hibernate.LockMode;
-import org.hibernate.LockOptions;
-import org.hibernate.query.Query;
+import jakarta.persistence.LockModeType;
 import org.hibernate.Session;
+import org.hibernate.Timeouts;
 import org.hibernate.boot.SessionFactoryBuilder;
 import org.hibernate.dialect.OracleDialect;
 import org.hibernate.dialect.PostgreSQLDialect;
 import org.hibernate.dialect.SQLServerDialect;
-
+import org.hibernate.query.Query;
 import org.hibernate.testing.RequiresDialect;
 import org.hibernate.testing.jdbc.SQLStatementInterceptor;
 import org.hibernate.testing.junit4.BaseNonConfigCoreFunctionalTestCase;
@@ -59,19 +58,16 @@ public class PessimisticWriteLockTimeoutTest
 	@RequiresDialect(OracleDialect.class)
 	@RequiresDialect(PostgreSQLDialect.class)
 	@RequiresDialect(SQLServerDialect.class)
-	public void testNoWait()
-			throws NoSuchFieldException, IllegalAccessException {
+	public void testNoWait() {
 
 		Session session = sessionFactory().openSession();
 		session.beginTransaction();
 		try {
-			session.createQuery(
-				"select a from A a", A.class )
-			.unwrap( Query.class )
-			.setLockOptions(
-				new LockOptions( LockMode.PESSIMISTIC_WRITE )
-			.setTimeOut( LockOptions.NO_WAIT ) )
-			.list();
+			session.createQuery( "select a from A a", A.class )
+					.unwrap( Query.class )
+					.setLockMode( LockModeType.PESSIMISTIC_WRITE )
+					.setTimeout( Timeouts.NO_WAIT )
+					.list();
 
 			String lockingQuery = sqlStatementInterceptor.getSqlQueries().getLast();
 			assertTrue( lockingQuery.toLowerCase().contains( "nowait") );
@@ -85,19 +81,15 @@ public class PessimisticWriteLockTimeoutTest
 	@Test
 	@RequiresDialect(OracleDialect.class)
 	@RequiresDialect(PostgreSQLDialect.class)
-	public void testSkipLocked()
-			throws NoSuchFieldException, IllegalAccessException {
+	public void testSkipLocked() {
 
 		Session session = sessionFactory().openSession();
 		session.beginTransaction();
 		try {
-			session.createQuery(
-				"select a from A a", A.class )
-			.unwrap( Query.class )
-			.setLockOptions(
-				new LockOptions( LockMode.PESSIMISTIC_WRITE )
-			.setTimeOut( LockOptions.SKIP_LOCKED ) )
-			.list();
+			session.createQuery("select a from A a", A.class )
+					.setLockMode( LockModeType.PESSIMISTIC_WRITE )
+					.setTimeout( Timeouts.SKIP_LOCKED )
+					.list();
 
 			String lockingQuery = sqlStatementInterceptor.getSqlQueries().getLast();
 			assertTrue( lockingQuery.toLowerCase().contains( "skip locked") );

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/locking/UpgradeSkipLockedTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/locking/UpgradeSkipLockedTest.java
@@ -5,7 +5,6 @@
 package org.hibernate.orm.test.locking;
 
 import org.hibernate.LockMode;
-import org.hibernate.LockOptions;
 import org.hibernate.query.Query;
 
 /**
@@ -17,9 +16,7 @@ public class UpgradeSkipLockedTest
 
 	@Override
 	protected void applySkipLocked(Query query) {
-		query.setLockOptions(
-			new LockOptions( lockMode() ).setFollowOnLocking( false )
-		);
+		query.setHibernateLockMode( lockMode() ).setFollowOnLocking( false );
 	}
 
 	@Override

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/naturalid/mutable/MutableNaturalIdTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/naturalid/mutable/MutableNaturalIdTest.java
@@ -4,24 +4,23 @@
  */
 package org.hibernate.orm.test.mapping.naturalid.mutable;
 
-import java.lang.reflect.Field;
-
 import org.hibernate.HibernateException;
-import org.hibernate.LockOptions;
+import org.hibernate.LockMode;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.metamodel.mapping.EntityMappingType;
 import org.hibernate.persister.entity.EntityPersister;
 import org.hibernate.stat.spi.StatisticsImplementor;
-import org.hibernate.tuple.entity.EntityMetamodel;
-
-import org.hibernate.testing.orm.junit.JiraKey;
 import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.JiraKey;
 import org.hibernate.testing.orm.junit.ServiceRegistry;
 import org.hibernate.testing.orm.junit.SessionFactory;
 import org.hibernate.testing.orm.junit.SessionFactoryScope;
 import org.hibernate.testing.orm.junit.Setting;
+import org.hibernate.tuple.entity.EntityMetamodel;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
 
 import static org.hibernate.cfg.AvailableSettings.GENERATE_STATISTICS;
 import static org.hibernate.cfg.AvailableSettings.USE_QUERY_CACHE;
@@ -146,7 +145,7 @@ public class MutableNaturalIdTest {
 		scope.inTransaction(
 				(session) -> {
 					try {
-						session.lock( created, LockOptions.NONE );
+						session.lock( created, LockMode.NONE );
 
 						name.set( created, "Gavin" );
 						final User loaded = session

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/ops/genericApi/BasicGetLoadAccessTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/ops/genericApi/BasicGetLoadAccessTest.java
@@ -4,22 +4,20 @@
  */
 package org.hibernate.orm.test.ops.genericApi;
 
-import java.util.NoSuchElementException;
-import java.util.Optional;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
+import jakarta.persistence.LockModeType;
 import jakarta.persistence.Table;
-
 import org.hibernate.LockMode;
-import org.hibernate.LockOptions;
-import org.hibernate.annotations.GenericGenerator;
-
 import org.hibernate.testing.orm.junit.DomainModel;
 import org.hibernate.testing.orm.junit.SessionFactory;
 import org.hibernate.testing.orm.junit.SessionFactoryScope;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
+
+import java.util.NoSuchElementException;
+import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -30,6 +28,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 /**
  * @author Steve Ebersole
  */
+@SuppressWarnings("JUnitMalformedDeclaration")
 @DomainModel(
 		annotatedClasses = BasicGetLoadAccessTest.User.class
 )
@@ -37,11 +36,8 @@ import static org.junit.jupiter.api.Assertions.fail;
 public class BasicGetLoadAccessTest {
 
 	@AfterEach
-	public void tearDown(SessionFactoryScope scope){
-		scope.inTransaction(
-				session ->
-						session.createQuery( "delete from User" ).executeUpdate()
-		);
+	public void tearDown(SessionFactoryScope scope) {
+		scope.dropData();
 	}
 
 	@Test
@@ -54,21 +50,20 @@ public class BasicGetLoadAccessTest {
 		);
 
 		// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-		// test `get` access
+		// test `find` access
 		scope.inTransaction(
 				session ->
-						session.get( User.class, 1 )
-		);
-
-
-		scope.inTransaction(
-				session ->
-						session.get( User.class, 1, LockMode.PESSIMISTIC_WRITE )
+						session.find( User.class, 1 )
 		);
 
 		scope.inTransaction(
 				session ->
-						session.get( User.class, 1, LockOptions.UPGRADE )
+						session.find( User.class, 1, LockMode.PESSIMISTIC_WRITE )
+		);
+
+		scope.inTransaction(
+				session ->
+						session.find( User.class, 1, LockModeType.PESSIMISTIC_WRITE )
 		);
 
 		scope.inTransaction(
@@ -78,11 +73,11 @@ public class BasicGetLoadAccessTest {
 
 		scope.inTransaction(
 				session ->
-						session.byId( User.class ).with( LockOptions.UPGRADE ).load( 1 )
+						session.byId( User.class ).with( LockMode.PESSIMISTIC_WRITE ).load( 1 )
 		);
 
 		// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-		// test `load` access
+		// test `getReference` access
 		scope.inTransaction(
 				session ->
 						session.getReference( User.class, 1 )
@@ -90,12 +85,7 @@ public class BasicGetLoadAccessTest {
 
 		scope.inTransaction(
 				session ->
-						session.get( User.class, 1, LockMode.PESSIMISTIC_WRITE )
-		);
-
-		scope.inTransaction(
-				session ->
-						session.get( User.class, 1, LockOptions.UPGRADE )
+						session.find( User.class, 1, LockMode.PESSIMISTIC_WRITE )
 		);
 
 		scope.inTransaction(
@@ -105,7 +95,7 @@ public class BasicGetLoadAccessTest {
 
 		scope.inTransaction(
 				session ->
-						session.byId( User.class ).with( LockOptions.UPGRADE ).getReference( 1 )
+						session.byId( User.class ).with( LockMode.PESSIMISTIC_WRITE ).getReference( 1 )
 		);
 	}
 
@@ -164,7 +154,6 @@ public class BasicGetLoadAccessTest {
 
 		@Id
 		@GeneratedValue(generator = "increment")
-		@GenericGenerator(name = "increment", strategy = "increment")
 		public Integer getId() {
 			return id;
 		}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/pagination/OraclePaginationWithLocksTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/pagination/OraclePaginationWithLocksTest.java
@@ -4,28 +4,26 @@
  */
 package org.hibernate.orm.test.pagination;
 
-import java.util.List;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
+import jakarta.persistence.LockModeType;
 import jakarta.persistence.criteria.CriteriaQuery;
 import jakarta.persistence.criteria.Root;
-
-import org.hibernate.LockMode;
-import org.hibernate.LockOptions;
 import org.hibernate.dialect.OracleDialect;
 import org.hibernate.engine.spi.SessionImplementor;
 import org.hibernate.query.common.FetchClauseType;
 import org.hibernate.resource.jdbc.spi.StatementInspector;
-
-import org.hibernate.testing.orm.junit.JiraKey;
 import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.JiraKey;
 import org.hibernate.testing.orm.junit.RequiresDialect;
 import org.hibernate.testing.orm.junit.SessionFactory;
 import org.hibernate.testing.orm.junit.SessionFactoryScope;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -133,7 +131,8 @@ public class OraclePaginationWithLocksTest {
 					query.select( root );
 					final List<Person> people = session.createQuery( query )
 							.setMaxResults( 10 )
-							.setLockOptions( new LockOptions( LockMode.PESSIMISTIC_WRITE ).setFollowOnLocking( false ) )
+							.setLockMode( LockModeType.PESSIMISTIC_WRITE )
+							.setFollowOnLocking( false )
 							.getResultList();
 					assertEquals( 10, people.size() );
 					assertSqlContainsFetch( session );
@@ -176,7 +175,8 @@ public class OraclePaginationWithLocksTest {
 					List<Person> people = session.createQuery(
 							"select p from Person p", Person.class )
 							.setMaxResults( 10 )
-							.setLockOptions( new LockOptions( LockMode.PESSIMISTIC_WRITE ).setFollowOnLocking( false ) )
+							.setLockMode( LockModeType.PESSIMISTIC_WRITE )
+							.setFollowOnLocking( false )
 							.getResultList();
 					assertEquals( 10, people.size() );
 					assertSqlContainsFetch( session );
@@ -212,7 +212,8 @@ public class OraclePaginationWithLocksTest {
 					List<Person> people = session.createQuery(
 							"select p from Person p where p.name = 'for update'", Person.class )
 							.setMaxResults( 10 )
-							.setLockOptions( new LockOptions( LockMode.PESSIMISTIC_WRITE ).setFollowOnLocking( false ) )
+							.setLockMode( LockModeType.PESSIMISTIC_WRITE )
+							.setFollowOnLocking( false )
 							.getResultList();
 					assertEquals( 1, people.size() );
 					assertSqlContainsFetch( session );

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/proxy/ProxyTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/proxy/ProxyTest.java
@@ -4,14 +4,10 @@
  */
 package org.hibernate.orm.test.proxy;
 
-import java.math.BigDecimal;
-import java.util.List;
-
 import org.hibernate.FlushMode;
 import org.hibernate.Hibernate;
 import org.hibernate.LazyInitializationException;
 import org.hibernate.LockMode;
-import org.hibernate.LockOptions;
 import org.hibernate.ObjectNotFoundException;
 import org.hibernate.Session;
 import org.hibernate.Transaction;
@@ -21,10 +17,12 @@ import org.hibernate.engine.spi.SessionImplementor;
 import org.hibernate.internal.SessionImpl;
 import org.hibernate.internal.util.SerializationHelper;
 import org.hibernate.proxy.HibernateProxy;
-
 import org.hibernate.testing.junit4.BaseCoreFunctionalTestCase;
 import org.hibernate.testing.orm.junit.JiraKey;
 import org.junit.Test;
+
+import java.math.BigDecimal;
+import java.util.List;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -296,7 +294,7 @@ public class ProxyTest extends BaseCoreFunctionalTestCase {
 
 		dp = s.getReference( DataPoint.class, dp.getId());
 		assertFalse( Hibernate.isInitialized(dp) );
-		dp2 = s.byId( DataPoint.class ).with( LockOptions.READ ).getReference( dp.getId() );
+		dp2 = s.find( DataPoint.class, dp.getId(), LockMode.READ );
 		assertSame(dp, dp2);
 		assertTrue( Hibernate.isInitialized(dp) );
 		s.clear();
@@ -346,7 +344,7 @@ public class ProxyTest extends BaseCoreFunctionalTestCase {
 
 		dp = s.getReference( DataPoint.class, dp.getId() );
 		assertFalse( Hibernate.isInitialized(dp) );
-		dp2 = s.byId( DataPoint.class ).with( LockOptions.READ ).getReference( dp.getId() );
+		dp2 = s.find( DataPoint.class, dp.getId(), LockMode.READ );
 		assertSame(dp, dp2);
 		assertTrue( Hibernate.isInitialized(dp) );
 		s.clear();
@@ -528,8 +526,8 @@ public class ProxyTest extends BaseCoreFunctionalTestCase {
 		dp.getX();
 		assertTrue( Hibernate.isInitialized( dp ) );
 
-		s.refresh( dp, LockOptions.UPGRADE );
-		assertSame( LockOptions.UPGRADE.getLockMode(), s.getCurrentLockMode( dp ) );
+		s.refresh( dp, LockMode.PESSIMISTIC_WRITE );
+		assertSame( LockMode.PESSIMISTIC_WRITE, s.getCurrentLockMode( dp ) );
 
 		s.remove( dp );
 		t.commit();
@@ -546,8 +544,8 @@ public class ProxyTest extends BaseCoreFunctionalTestCase {
 		dp = s.getReference( DataPoint.class, dp.getId());
 		assertFalse( Hibernate.isInitialized( dp ) );
 
-		s.refresh( dp, LockOptions.UPGRADE );
-		assertSame( LockOptions.UPGRADE.getLockMode(), s.getCurrentLockMode( dp ) );
+		s.refresh( dp, LockMode.PESSIMISTIC_WRITE );
+		assertSame( LockMode.PESSIMISTIC_WRITE, s.getCurrentLockMode( dp ) );
 
 		s.remove( dp );
 		t.commit();
@@ -574,9 +572,9 @@ public class ProxyTest extends BaseCoreFunctionalTestCase {
 
 		dp = s.getReference( DataPoint.class, dp.getId());
 		assertFalse( Hibernate.isInitialized( dp ) );
-		s.refresh( dp, LockOptions.UPGRADE );
+		s.refresh( dp, LockMode.PESSIMISTIC_WRITE );
 		dp.getX();
-		assertSame( LockOptions.UPGRADE.getLockMode(), s.getCurrentLockMode( dp ) );
+		assertSame( LockMode.PESSIMISTIC_WRITE, s.getCurrentLockMode( dp ) );
 
 		s.remove( dp );
 		t.commit();
@@ -591,8 +589,8 @@ public class ProxyTest extends BaseCoreFunctionalTestCase {
 
 		dp = s.getReference( DataPoint.class, dp.getId());
 		assertFalse( Hibernate.isInitialized( dp ) );
-		s.lock( dp, LockOptions.UPGRADE );
-		assertSame( LockOptions.UPGRADE.getLockMode(), s.getCurrentLockMode( dp ) );
+		s.lock( dp, LockMode.PESSIMISTIC_WRITE );
+		assertSame( LockMode.PESSIMISTIC_WRITE, s.getCurrentLockMode( dp ) );
 
 		s.remove( dp );
 		t.commit();

--- a/migration-guide.adoc
+++ b/migration-guide.adoc
@@ -729,11 +729,47 @@ Now, `varchar(1)` is used by default.
 
 
 [[settings]]
-=== Changes Related to Settings
+== Changes Related to Settings
 
 * Removed `hibernate.mapping.precedence` and friends
 * Removed `hibernate.allow_refresh_detached_entity`
 
+[[lock-options]]
+== LockOptions
+
+The exposure of `LockOptions` as an API has been deprecated.  Applications should instead prefer the use of `LockMode` (or `LockModeType`), `Timeout` and `PessimisticLockScope`.
+
+Use this
+
+====
+[source, java, indent=0]
+----
+Book loaded = session.find(
+    Book.class,
+    1,
+    LockMode.PESSIMISTIC_WRITE,
+    Timeouts.NO_WAIT
+);
+----
+====
+
+instead of this
+
+====
+[source, java, indent=0]
+----
+Book loaded = session.find(
+    Book.class,
+    1,
+    new LockOptions(
+        LockMode.PESSIMISTIC_WRITE,
+        0
+    )
+);
+----
+====
+
+See the link:{whatsNewBase}#operation-options[What's New] guide for more details.
 
 
 [[pools]]

--- a/whats-new.adoc
+++ b/whats-new.adoc
@@ -126,6 +126,53 @@ The new operations `Session.findMultiple()` and `StatelessSession.getMultiple()`
 Combined with the `BatchSize` option, allows breaking up the JDBC calls into "batches".
 
 
+[[operation-options]]
+== FindOption, LockOption, RefreshOption
+
+As a more typesafe replacement for hints, Jakarta Persistence now allows for "option objects" which indicate these hints.  Not only is it more typesafe, but also more concise - a double win!
+
+These "option objects" come in 3 flavors depending on what operation is being performed -
+
+FindOption:: Used to indicate options for find operations :
+    * `Session.find`
+    * `Session.findMultiple`
+    * etc
+LockOption:: Used to indicate options for `Session.lock`
+RefreshOption:: Used to indicate options for `Session.refresh`
+
+Each of these are interfaces.  Jakarta Persistence does provide some built-in options:
+
+CacheRetrieveMode:: Is now a `FindOption`.
+CacheStoreMode:: Is now a `FindOption` and a `RefreshOption`.
+LockModeType:: Is now a `FindOption` and a `RefreshOption`.
+Timeout (new):: Is a `FindOption`, a `RefreshOption` and a `LockOption`.  See also `org.hibernate.Timeouts` for some magic values.
+PessimisticLockScope:: Is now a `FindOption`, a `RefreshOption` and a `LockOption`
+
+Hibernate provides a few additional options:
+
+ReadOnlyMode (new):: Is a `FindOption` which indicates whether the entities and collections being loaded should be considered read-only.
+EnabledFetchProfile (new):: Is a `FindOption` indicating a fetch-profile to be enabled for the find operation.
+LockMode:: Is now a `FindOption` and a `RefreshOption` (expanded version of JPA's `LockModeType`).
+CacheMode:: Is now a `FindOption`.
+BatchSize (new):: Is now a `FindOption`.
+
+
+All operations which accept options (which previously accepted hints) accept a varargs grouping of them.  E.g.
+
+====
+[source, java, indent=0]
+----
+Book loaded = session.find(
+    Book.class,
+    1,
+    LockMode.PESSIMISTIC_WRITE,
+    Timeouts.NO_WAIT,
+    new EnabledFetchProfile("with-authors")
+);
+----
+====
+
+
 [[QuerySpecification]]
 == QuerySpecification, Restriction, and Range
 


### PR DESCRIPTION
<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

[Please describe here what your change is about]

Um, deprecating the exposure of `LockOptions`

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-19440
<!-- Hibernate GitHub Bot issue links end -->