### PR TITLE
HHH-19444 SQLiteDialect - fix ViolatedConstraintNameExtractor

### DIFF
--- a/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/SQLiteDialect.java
+++ b/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/SQLiteDialect.java
@@ -459,7 +459,7 @@ public class SQLiteDialect extends Dialect {
 			new TemplatedViolatedConstraintNameExtractor( sqle -> {
 				final int errorCode = JdbcExceptionHelper.extractErrorCode( sqle ) & 0xFF;
 				if (errorCode == SQLITE_CONSTRAINT) {
-					return extractUsingTemplate( "constraint failed:", "$", sqle.getMessage() );
+					return extractUsingTemplate( "constraint failed: ", "$", sqle.getMessage() );
 				}
 				return null;
 			} );

--- a/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/SQLiteDialect.java
+++ b/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/SQLiteDialect.java
@@ -457,9 +457,9 @@ public class SQLiteDialect extends Dialect {
 
 	private static final ViolatedConstraintNameExtractor EXTRACTOR =
 			new TemplatedViolatedConstraintNameExtractor( sqle -> {
-				final int errorCode = JdbcExceptionHelper.extractErrorCode( sqle );
+				final int errorCode = JdbcExceptionHelper.extractErrorCode( sqle ) & 0xFF;
 				if (errorCode == SQLITE_CONSTRAINT) {
-					return extractUsingTemplate( "constraint ", " failed", sqle.getMessage() );
+					return extractUsingTemplate( "constraint failed:", "$", sqle.getMessage() );
 				}
 				return null;
 			} );


### PR DESCRIPTION
See https://github.com/sqlite/sqlite/commit/f9c8ce3ced8960e7c8d74b68ad420ec5f581494d
> Standardize the error messages generated by constraint failures to a format of "$TYPE constraint failed: $DETAIL".

Also in case [extended result codes](http://sqlite.org/c3ref/extended_result_codes.html) are activated, we need the `& 0xFF`.

And as there seems to be no way to tell `extractUsingTemplate` that there is no `templateEnd`, the dollar sign is used...

See [original](https://github.com/gwenn/sqlite-dialect/blob/c87223460e3335ff4f041e012bd0d22df99fa2af/src/main/java/org/sqlite/hibernate/dialect/SQLiteDialect.java#L244-L253) code and associated [test](https://github.com/gwenn/sqlite-dialect/blob/c87223460e3335ff4f041e012bd0d22df99fa2af/src/test/java/org/hibernate/tutorial/annotations/AnnotationsIllustrationTest.java#L95-L105) for reference.

<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
