### PR TITLE
HHH-19445 ProcedureCall should accept BindableType, not BasicTypeReference

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/jpa/HibernateHints.java
+++ b/hibernate-core/src/main/java/org/hibernate/jpa/HibernateHints.java
@@ -151,9 +151,32 @@ public interface HibernateHints {
 	/**
 	 * Whether to treat a {@link org.hibernate.procedure.ProcedureCall}
 	 * or {@link jakarta.persistence.StoredProcedureQuery} as a call
-	 * to a function rather than a call to a procedure.
+	 * to a function rather than a call to a procedure. Set hint to
+	 * {@link Boolean#TRUE TRUE} or {@code "true"} to indicated that
+	 * the call should be treated as a function call.
+	 * <p>
+	 * When no other return type is indicated, a function is assumed
+	 * to return {@link java.sql.Types#REF_CURSOR REF_CURSOR}.
+	 *
+	 * @see org.hibernate.procedure.ProcedureCall#markAsFunctionCall
+	 * @see #HINT_CALLABLE_FUNCTION_RETURN_TYPE
 	 */
 	String HINT_CALLABLE_FUNCTION = "org.hibernate.callableFunction";
+
+	/**
+	 * The {@linkplain org.hibernate.type.SqlTypes JDBC type code},
+	 * {@linkplain org.hibernate.query.BindableType type}, or
+	 * {@link Class} of the value returned by a SQL function called
+	 * via {@link org.hibernate.procedure.ProcedureCall} or
+	 * {@link jakarta.persistence.StoredProcedureQuery}. Has the side
+	 * effect of causing the call to be treated as a function call
+	 * rather than a call to a stored procedure.
+	 *
+	 * @see org.hibernate.procedure.ProcedureCall#markAsFunctionCall(int)
+	 * @see org.hibernate.procedure.ProcedureCall#markAsFunctionCall(org.hibernate.query.BindableType)
+	 * @see org.hibernate.procedure.ProcedureCall#markAsFunctionCall(Class)
+	 */
+	String HINT_CALLABLE_FUNCTION_RETURN_TYPE = "hibernate.procedure.function_return_jdbc_type_code";
 
 	/**
 	 * Hint for specifying the tenant id to use when creating an

--- a/hibernate-core/src/main/java/org/hibernate/procedure/FunctionReturn.java
+++ b/hibernate-core/src/main/java/org/hibernate/procedure/FunctionReturn.java
@@ -4,14 +4,23 @@
  */
 package org.hibernate.procedure;
 
+import org.hibernate.Incubating;
 import org.hibernate.query.procedure.ProcedureParameter;
 
 /**
- * Describes the function return for ProcedureCalls that represent calls to
- * a function ({@code "{? = call ...}} syntax) rather that a proc ({@code {call ...}} syntax)
+ * Describes the function return value of a {@link ProcedureCall}
+ * executed via a JDBC escape of form ({@code "{? = call ...}}.
+ * That is, the {@code ?} parameter occurring before the {@code =}.
  *
  * @author Steve Ebersole
+ *
+ * @since 6.0
  */
+@Incubating
 public interface FunctionReturn<T> extends ProcedureParameter<T> {
+	/**
+	 * The {@linkplain org.hibernate.type.SqlTypes JDBC type code}
+	 * representing the SQL type of the function return value.
+	 */
 	int getJdbcTypeCode();
 }

--- a/hibernate-core/src/main/java/org/hibernate/procedure/ProcedureCall.java
+++ b/hibernate-core/src/main/java/org/hibernate/procedure/ProcedureCall.java
@@ -14,6 +14,7 @@ import jakarta.persistence.ParameterMode;
 import jakarta.persistence.StoredProcedureQuery;
 import jakarta.persistence.TemporalType;
 
+import org.hibernate.Incubating;
 import org.hibernate.MappingException;
 import org.hibernate.query.BindableType;
 import org.hibernate.query.SynchronizeableQuery;
@@ -233,6 +234,16 @@ public interface ProcedureCall
 	 * @return The ProcedureOutputs representation
 	 */
 	ProcedureOutputs getOutputs();
+
+	/**
+	 * The {@link FunctionReturn} describing the return value of
+	 * the function, or {@code null} if this {@code ProcedureCall}
+	 * is not a function call.
+	 *
+	 * @since 7.0
+	 */
+	@Incubating
+	FunctionReturn<?> getFunctionReturn();
 
 	/**
 	 * Release the underlying JDBC {@link java.sql.CallableStatement}

--- a/hibernate-core/src/main/java/org/hibernate/procedure/ProcedureCall.java
+++ b/hibernate-core/src/main/java/org/hibernate/procedure/ProcedureCall.java
@@ -15,10 +15,10 @@ import jakarta.persistence.StoredProcedureQuery;
 import jakarta.persistence.TemporalType;
 
 import org.hibernate.MappingException;
+import org.hibernate.query.BindableType;
 import org.hibernate.query.SynchronizeableQuery;
 import org.hibernate.query.CommonQueryContract;
 import org.hibernate.query.procedure.ProcedureParameter;
-import org.hibernate.type.BasicTypeReference;
 
 /**
  * Defines support for executing database stored procedures and functions.
@@ -74,7 +74,7 @@ public interface ProcedureCall
 	boolean isFunctionCall();
 
 	/**
-	 * Mark this ProcedureCall as representing a call to a database function,
+	 * Mark this {@code ProcedureCall} as representing a call to a database function,
 	 * rather than a database procedure.
 	 *
 	 * @param sqlType The {@link java.sql.Types} code for the function return
@@ -84,7 +84,7 @@ public interface ProcedureCall
 	ProcedureCall markAsFunctionCall(int sqlType);
 
 	/**
-	 * Mark this ProcedureCall as representing a call to a database function,
+	 * Mark this {@code ProcedureCall} as representing a call to a database function,
 	 * rather than a database procedure.
 	 *
 	 * @param resultType The result type for the function return
@@ -95,7 +95,7 @@ public interface ProcedureCall
 	ProcedureCall markAsFunctionCall(Class<?> resultType);
 
 	/**
-	 * Mark this ProcedureCall as representing a call to a database function,
+	 * Mark this {@code ProcedureCall} as representing a call to a database function,
 	 * rather than a database procedure.
 	 *
 	 * @param typeReference The result type for the function return
@@ -103,7 +103,7 @@ public interface ProcedureCall
 	 * @return {@code this}, for method chaining
 	 * @since 6.2
 	 */
-	ProcedureCall markAsFunctionCall(BasicTypeReference<?> typeReference);
+	ProcedureCall markAsFunctionCall(BindableType<?> typeReference);
 
 	/**
 	 * Basic form for registering a positional parameter.
@@ -127,13 +127,13 @@ public interface ProcedureCall
 	 *
 	 * @return The parameter registration memento
 	 */
-	<T> ProcedureParameter<T> registerParameter(int position, BasicTypeReference<T> type, ParameterMode mode);
+	<T> ProcedureParameter<T> registerParameter(int position, BindableType<T> type, ParameterMode mode);
 
 	/**
-	 * Like {@link #registerStoredProcedureParameter(int, Class, ParameterMode)} but a basic type reference is given
+	 * Like {@link #registerStoredProcedureParameter(int, Class, ParameterMode)} but a type reference is given
 	 * instead of a class for the parameter type.
 	 */
-	ProcedureCall registerStoredProcedureParameter(int position, BasicTypeReference<?> type, ParameterMode mode);
+	ProcedureCall registerStoredProcedureParameter(int position, BindableType<?> type, ParameterMode mode);
 
 	/**
 	 * Retrieve a previously registered parameter memento by the position under which it was registered.
@@ -176,14 +176,14 @@ public interface ProcedureCall
 	 * @throws NamedParametersNotSupportedException When the underlying database is known to not support
 	 * named procedure parameters.
 	 */
-	<T> ProcedureParameter<T> registerParameter(String parameterName, BasicTypeReference<T> type, ParameterMode mode)
+	<T> ProcedureParameter<T> registerParameter(String parameterName, BindableType<T> type, ParameterMode mode)
 			throws NamedParametersNotSupportedException;
 
 	/**
-	 * Like {@link #registerStoredProcedureParameter(String, Class, ParameterMode)} but a basic type reference is given
+	 * Like {@link #registerStoredProcedureParameter(String, Class, ParameterMode)} but a type reference is given
 	 * instead of a class for the parameter type.
 	 */
-	ProcedureCall registerStoredProcedureParameter(String parameterName, BasicTypeReference<?> type, ParameterMode mode);
+	ProcedureCall registerStoredProcedureParameter(String parameterName, BindableType<?> type, ParameterMode mode);
 
 	/**
 	 * Retrieve a previously registered parameter memento by the name under which it was registered.
@@ -223,9 +223,7 @@ public interface ProcedureCall
 		getOutputs().release();
 	}
 
-	/*
-	Covariant overrides
-	 */
+	/* Covariant overrides */
 
 	@Override
 	ProcedureCall addSynchronizedQuerySpace(String querySpace);

--- a/hibernate-core/src/main/java/org/hibernate/procedure/internal/OracleCallableStatementSupport.java
+++ b/hibernate-core/src/main/java/org/hibernate/procedure/internal/OracleCallableStatementSupport.java
@@ -24,7 +24,7 @@ public class OracleCallableStatementSupport extends StandardCallableStatementSup
 	@Override
 	protected void appendNameParameter(
 			StringBuilder buffer,
-			ProcedureParameterImplementor parameter,
+			ProcedureParameterImplementor<?> parameter,
 			JdbcCallParameterRegistration registration) {
 		buffer.append( parameter.getName() ).append( " => ?" );
 	}

--- a/hibernate-core/src/main/java/org/hibernate/procedure/internal/SQLServerCallableStatementSupport.java
+++ b/hibernate-core/src/main/java/org/hibernate/procedure/internal/SQLServerCallableStatementSupport.java
@@ -17,7 +17,10 @@ public class SQLServerCallableStatementSupport extends StandardCallableStatement
 	}
 
 	@Override
-	protected void appendNameParameter(StringBuilder buffer, ProcedureParameterImplementor parameter, JdbcCallParameterRegistration registration) {
+	protected void appendNameParameter(
+			StringBuilder buffer,
+			ProcedureParameterImplementor<?> parameter,
+			JdbcCallParameterRegistration registration) {
 		buffer.append( '@' ).append( parameter.getName() ).append( " = ?" );
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/procedure/internal/StandardCallableStatementSupport.java
+++ b/hibernate-core/src/main/java/org/hibernate/procedure/internal/StandardCallableStatementSupport.java
@@ -4,8 +4,6 @@
  */
 package org.hibernate.procedure.internal;
 
-import java.util.List;
-
 import org.hibernate.QueryException;
 import org.hibernate.dialect.Dialect;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
@@ -49,16 +47,13 @@ public class StandardCallableStatementSupport extends AbstractStandardCallableSt
 		final FunctionReturnImplementor<?> functionReturn = procedureCall.getFunctionReturn();
 		final ProcedureParameterMetadataImplementor parameterMetadata = procedureCall.getParameterMetadata();
 		final SharedSessionContractImplementor session = procedureCall.getSession();
-		final List<? extends ProcedureParameterImplementor<?>> registrations = parameterMetadata.getRegistrationsAsList();
-		final int paramStringSizeEstimate;
-		if ( functionReturn == null && parameterMetadata.hasNamedParameters() ) {
-			// That's just a rough estimate. I guess most params will have fewer than 8 chars on average
-			paramStringSizeEstimate = registrations.size() * 10;
-		}
-		else {
-			// For every param rendered as '?' we have a comma, hence the estimate
-			paramStringSizeEstimate = registrations.size() * 2;
-		}
+		final var registrations = parameterMetadata.getRegistrationsAsList();
+		final int paramStringSizeEstimate =
+				functionReturn == null && parameterMetadata.hasNamedParameters()
+						// That's just a rough estimate. I guess most params will have fewer than 8 chars on average
+						? registrations.size() * 10
+						// For every param rendered as '?' we have a comma, hence the estimate
+						: registrations.size() * 2;
 		final JdbcCallImpl.Builder builder = new JdbcCallImpl.Builder();
 		final StringBuilder buffer;
 		final int offset;
@@ -110,7 +105,7 @@ public class StandardCallableStatementSupport extends AbstractStandardCallableSt
 
 	protected void appendNameParameter(
 			StringBuilder buffer,
-			ProcedureParameterImplementor parameter,
+			ProcedureParameterImplementor<?> parameter,
 			JdbcCallParameterRegistration registration) {
 		buffer.append( '?' );
 	}

--- a/hibernate-core/src/main/java/org/hibernate/procedure/spi/ProcedureCallImplementor.java
+++ b/hibernate-core/src/main/java/org/hibernate/procedure/spi/ProcedureCallImplementor.java
@@ -9,10 +9,10 @@ import java.util.Date;
 import java.util.List;
 
 import org.hibernate.procedure.ProcedureCall;
+import org.hibernate.query.BindableType;
 import org.hibernate.query.named.NameableQuery;
 import org.hibernate.query.spi.ProcedureParameterMetadataImplementor;
 import org.hibernate.query.spi.QueryImplementor;
-import org.hibernate.type.BasicTypeReference;
 
 import jakarta.persistence.CacheRetrieveMode;
 import jakarta.persistence.CacheStoreMode;
@@ -41,10 +41,16 @@ public interface ProcedureCallImplementor<R> extends ProcedureCall, NameableQuer
 	R getSingleResult();
 
 	@Override
-	ProcedureCallImplementor<R> registerStoredProcedureParameter(int position, BasicTypeReference<?> type, ParameterMode mode);
+	ProcedureCallImplementor<R> registerStoredProcedureParameter(int position, Class<?> type, ParameterMode mode);
 
 	@Override
-	ProcedureCallImplementor<R> registerStoredProcedureParameter(String parameterName, BasicTypeReference<?> type, ParameterMode mode);
+	ProcedureCallImplementor<R> registerStoredProcedureParameter(String parameterName, Class<?> type, ParameterMode mode);
+
+	@Override
+	ProcedureCallImplementor<R> registerStoredProcedureParameter(int position, BindableType<?> type, ParameterMode mode);
+
+	@Override
+	ProcedureCallImplementor<R> registerStoredProcedureParameter(String parameterName, BindableType<?> type, ParameterMode mode);
 
 	@Override
 	ProcedureCallImplementor<R> setHint(String hintName, Object value);
@@ -87,12 +93,6 @@ public interface ProcedureCallImplementor<R> extends ProcedureCall, NameableQuer
 
 	@Override
 	ProcedureCallImplementor<R> setTimeout(Integer timeout);
-
-	@Override
-	ProcedureCallImplementor<R> registerStoredProcedureParameter(int position, Class<?> type, ParameterMode mode);
-
-	@Override
-	ProcedureCallImplementor<R> registerStoredProcedureParameter(String parameterName, Class<?> type, ParameterMode mode);
 
 	@Override
 	NamedCallableQueryMemento toMemento(String name);

--- a/hibernate-core/src/main/java/org/hibernate/procedure/spi/ProcedureCallImplementor.java
+++ b/hibernate-core/src/main/java/org/hibernate/procedure/spi/ProcedureCallImplementor.java
@@ -32,6 +32,7 @@ public interface ProcedureCallImplementor<R> extends ProcedureCall, NameableQuer
 
 	ParameterStrategy getParameterStrategy();
 
+	@Override
 	FunctionReturnImplementor<R> getFunctionReturn();
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/query/procedure/ProcedureParameter.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/procedure/ProcedureParameter.java
@@ -23,5 +23,4 @@ public interface ProcedureParameter<T> extends QueryParameter<T> {
 	 * @return The parameter mode.
 	 */
 	ParameterMode getMode();
-
 }


### PR DESCRIPTION
<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

[Please describe here what your change is about]

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-19445
<!-- Hibernate GitHub Bot issue links end -->