### PR TITLE
HHH-19387 - Fix concrete descriptor when left join returns null value

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/entity/internal/EntityInitializerImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/entity/internal/EntityInitializerImpl.java
@@ -1651,6 +1651,10 @@ public class EntityInitializerImpl extends AbstractInitializer<EntityInitializer
 						castNonNull( discriminatorAssembler ),
 						entityDescriptor
 				);
+				if (data.concreteDescriptor == null) {
+					// Return because the value is null
+					return;
+				}
 			}
 		}
 		resolveEntityState( data );

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/entity/internal/EntityInitializerImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/entity/internal/EntityInitializerImpl.java
@@ -1651,8 +1651,7 @@ public class EntityInitializerImpl extends AbstractInitializer<EntityInitializer
 						castNonNull( discriminatorAssembler ),
 						entityDescriptor
 				);
-				if (data.concreteDescriptor == null) {
-					// Return because the value is null
+				if ( data.concreteDescriptor == null ) {
 					return;
 				}
 			}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/querycache/EntityWithCollectionReloadCacheInheritanceTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/querycache/EntityWithCollectionReloadCacheInheritanceTest.java
@@ -1,0 +1,178 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.querycache;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Set;
+
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.Jira;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import jakarta.persistence.Access;
+import jakarta.persistence.Column;
+import jakarta.persistence.DiscriminatorColumn;
+import jakarta.persistence.DiscriminatorValue;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.JoinTable;
+import jakarta.persistence.ManyToMany;
+
+import static jakarta.persistence.AccessType.FIELD;
+import static jakarta.persistence.EnumType.STRING;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author miroslav silhavy
+ */
+@DomainModel(annotatedClasses = {
+		EntityWithCollectionReloadCacheInheritanceTest.HighSchoolStudent.class,
+		EntityWithCollectionReloadCacheInheritanceTest.DefaultSubject.class,
+		EntityWithCollectionReloadCacheInheritanceTest.EnglishSubject.class
+})
+@SessionFactory
+@Jira("https://hibernate.atlassian.net/browse/HHH-19387")
+public class EntityWithCollectionReloadCacheInheritanceTest {
+
+	@Test
+	public void test(SessionFactoryScope scope) {
+		scope.inTransaction( session -> {
+			List<HighSchoolStudent> list = session.createQuery(
+							"select s" +
+									" from HighSchoolStudent s left join fetch s.subjects m" +
+									" where s.name in :names", HighSchoolStudent.class
+					)
+					.setParameter( "names", Arrays.asList( "Brian" ) )
+					.setCacheable( true )
+					.list();
+
+			assertThat( list ).hasSize( 1 );
+
+			list = session.createQuery(
+							"select s" +
+									" from HighSchoolStudent s left join fetch s.subjects m" +
+									" where s.name in :names", HighSchoolStudent.class
+					)
+					.setParameter( "names", Arrays.asList( "Andrew", "Brian" ) )
+					.setCacheable( true )
+					.list();
+
+			assertThat( list ).hasSize( 2 );
+		} );
+	}
+
+	@BeforeAll
+	public void setUp(SessionFactoryScope scope) {
+		scope.inTransaction( session -> {
+			HighSchoolStudent s1 = new HighSchoolStudent();
+			s1.setName( "Andrew" );
+			session.persist( s1 );
+
+			HighSchoolStudent s2 = new HighSchoolStudent();
+			s2.setName( "Brian" );
+			session.persist( s2 );
+		} );
+	}
+
+	@AfterAll
+	public void tearDown(SessionFactoryScope scope) {
+		scope.getSessionFactory().getSchemaManager().truncateMappedObjects();
+	}
+
+	@Entity(name = "HighSchoolStudent")
+	@Access(FIELD)
+	static class HighSchoolStudent {
+
+		@Id
+		@GeneratedValue
+		@Column(name = "id")
+		private Long id;
+
+		@Column(name = "name")
+		private String name;
+
+		@ManyToMany(targetEntity = DefaultSubject.class, fetch = FetchType.LAZY)
+		@JoinTable(name = "STUDENT_SUBJECT",
+				joinColumns = { @JoinColumn(name = "student_id") },
+				inverseJoinColumns = { @JoinColumn(name = "subject_id") }
+		)
+		private Set<DefaultSubject> subjects;
+
+		public Long getId() {
+			return id;
+		}
+
+		public void setId(Long id) {
+			this.id = id;
+		}
+
+		public String getName() {
+			return name;
+		}
+
+		public void setName(String name) {
+			this.name = name;
+		}
+
+		public Set<DefaultSubject> getSubjects() {
+			return subjects;
+		}
+
+		public void setMajors(Set<DefaultSubject> subjects) {
+			this.subjects = subjects;
+		}
+
+	}
+
+	@Entity(name = "DefaultSubject")
+	@DiscriminatorValue("DEFAULT")
+	@DiscriminatorColumn(name = "TYPE", length = 20)
+	@Access(FIELD)
+	static class DefaultSubject {
+
+		enum SubjectType {
+			DEFAULT,
+			ENGLISH
+		}
+
+		@Column(name = "TYPE", nullable = false, length = 20, insertable = false, updatable = false)
+		@Enumerated(STRING)
+		@JdbcTypeCode(SqlTypes.VARCHAR)
+		private SubjectType type;
+
+		@Id
+		@GeneratedValue
+		@Column(name = "id")
+		private Long id;
+
+		public Long getId() {
+			return id;
+		}
+
+		public void setId(Long id) {
+			this.id = id;
+		}
+
+	}
+
+	@Entity(name = "EnglishSubject")
+	@DiscriminatorValue("ENGLISH")
+	@Access(FIELD)
+	static class EnglishSubject extends DefaultSubject {
+	}
+
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/querycache/EntityWithCollectionReloadCacheInheritanceTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/querycache/EntityWithCollectionReloadCacheInheritanceTest.java
@@ -37,11 +37,11 @@ import static jakarta.persistence.EnumType.STRING;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
- * @author miroslav silhavy
+ * @author Miroslav Silhavy
  */
 @DomainModel(annotatedClasses = {
 		EntityWithCollectionReloadCacheInheritanceTest.HighSchoolStudent.class,
-		EntityWithCollectionReloadCacheInheritanceTest.DefaultSubject.class,
+		EntityWithCollectionReloadCacheInheritanceTest.Subject.class,
 		EntityWithCollectionReloadCacheInheritanceTest.EnglishSubject.class
 })
 @SessionFactory
@@ -105,12 +105,12 @@ public class EntityWithCollectionReloadCacheInheritanceTest {
 		@Column(name = "name")
 		private String name;
 
-		@ManyToMany(targetEntity = DefaultSubject.class, fetch = FetchType.LAZY)
+		@ManyToMany(targetEntity = Subject.class, fetch = FetchType.LAZY)
 		@JoinTable(name = "STUDENT_SUBJECT",
 				joinColumns = { @JoinColumn(name = "student_id") },
 				inverseJoinColumns = { @JoinColumn(name = "subject_id") }
 		)
-		private Set<DefaultSubject> subjects;
+		private Set<Subject> subjects;
 
 		public Long getId() {
 			return id;
@@ -128,21 +128,21 @@ public class EntityWithCollectionReloadCacheInheritanceTest {
 			this.name = name;
 		}
 
-		public Set<DefaultSubject> getSubjects() {
+		public Set<Subject> getSubjects() {
 			return subjects;
 		}
 
-		public void setMajors(Set<DefaultSubject> subjects) {
+		public void setSubjects(Set<Subject> subjects) {
 			this.subjects = subjects;
 		}
 
 	}
 
-	@Entity(name = "DefaultSubject")
+	@Entity(name = "Subject")
 	@DiscriminatorValue("DEFAULT")
 	@DiscriminatorColumn(name = "TYPE", length = 20)
 	@Access(FIELD)
-	static class DefaultSubject {
+	static class Subject {
 
 		enum SubjectType {
 			DEFAULT,
@@ -172,7 +172,7 @@ public class EntityWithCollectionReloadCacheInheritanceTest {
 	@Entity(name = "EnglishSubject")
 	@DiscriminatorValue("ENGLISH")
 	@Access(FIELD)
-	static class EnglishSubject extends DefaultSubject {
+	static class EnglishSubject extends Subject {
 	}
 
 }


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-19387

Fix for a bug when left join value is null in a query that is using a query cache. 

Any kind of criticism is appreciated.

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
