### PR TITLE
HHH-19440 completely deprecate LockOptions

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/LockOptions.java
+++ b/hibernate-core/src/main/java/org/hibernate/LockOptions.java
@@ -6,7 +6,6 @@ package org.hibernate;
 
 import jakarta.persistence.PessimisticLockScope;
 import jakarta.persistence.Timeout;
-import org.hibernate.query.Query;
 
 import java.io.Serializable;
 import java.util.HashMap;
@@ -28,9 +27,9 @@ import static java.util.Collections.unmodifiableSet;
  * {@link Session#refresh(Object, LockOptions)}, the relevant options
  * are:
  * <ul>
- * <li>the {@linkplain #getLockMode() lock mode},
- * <li>the {@linkplain #getTimeOut() pessimistic lock timeout}, and
- * <li>the {@linkplain #getLockScope() lock scope}, that is, whether
+ * <li>the {@linkplain #getLockMode lock mode},
+ * <li>the {@linkplain #getTimeOut pessimistic lock timeout}, and
+ * <li>the {@linkplain #getLockScope lock scope}, that is, whether
  *     the lock extends to rows of owned collections.
  * </ul>
  * <p>
@@ -48,8 +47,33 @@ import static java.util.Collections.unmodifiableSet;
  * default behavior of the SQL dialect} by passing a non-null argument
  * to {@link #setFollowOnLocking(Boolean)}.
  *
+ * @deprecated
+ * Since JPA 3.2 and Hibernate 7, a {@link LockMode}, {@link Timeout},
+ * or {@link PessimisticLockScope} may be passed directly as an option
+ * to {@code find()}, {@code refresh()}, or {@code lock()}. Therefore,
+ * this class is obsolete as an API and will be moved to an SPI package.
+ * <p>
+ * For HQL/JPQL queries, locking should be controlled via operations of
+ * the {@link org.hibernate.query.SelectionQuery} interface:
+ * <ul>
+ * <li>A timeout may be set via
+ * {@link org.hibernate.query.CommonQueryContract#setTimeout(Timeout)}
+ * <li>The {@code PessimisticLockScope} may be set using
+ * {@link org.hibernate.query.SelectionQuery#setLockScope(PessimisticLockScope)}
+ * <li>Alias-specific lock modes may be specified using
+ * {@link org.hibernate.query.SelectionQuery#setLockMode(String, LockMode)}
+ * <li>Use of follow-on locking may be enabled via
+ * {@link org.hibernate.query.SelectionQuery#setFollowOnLocking(boolean)}
+ * </ul>
+ * The interface {@link Timeouts} provides several operations to simplify
+ * migration.
+ *
+ * @see LockMode
+ * @see Timeouts
+ *
  * @author Scott Marlow
  */
+@Deprecated(since = "7.0", forRemoval = true) // moving to an SPI package
 public class LockOptions implements Serializable {
 	/**
 	 * Represents {@link LockMode#NONE}, to which timeout and scope are
@@ -191,7 +215,7 @@ public class LockOptions implements Serializable {
 
 	/**
 	 * Construct an instance with the given {@linkplain LockMode mode},
-	 * timeout, and {@link PessimisticLockScope scope}.
+	 * timeout, and {@linkplain PessimisticLockScope scope}.
 	 *
 	 * @param lockMode The initial lock mode
 	 * @param timeout The initial timeout
@@ -206,7 +230,7 @@ public class LockOptions implements Serializable {
 
 	/**
 	 * Construct an instance with the given {@linkplain LockMode mode},
-	 * timeout, and {@link PessimisticLockScope scope}.
+	 * timeout, and {@linkplain PessimisticLockScope scope}.
 	 *
 	 * @param lockMode The initial lock mode
 	 * @param timeout The initial timeout, in milliseconds
@@ -228,6 +252,7 @@ public class LockOptions implements Serializable {
 		timeout = Timeouts.WAIT_FOREVER;
 		pessimisticLockScope = NORMAL;
 	}
+
 	/**
 	 * Determine of the lock options are empty.
 	 *
@@ -273,7 +298,7 @@ public class LockOptions implements Serializable {
 	 * @param lockMode the lock mode to apply to the given alias
 	 * @return {@code this} for method chaining
 	 *
-	 * @see Query#setLockMode(String, LockMode)
+	 * @see org.hibernate.query.Query#setLockMode(String, LockMode)
 	 */
 	public LockOptions setAliasSpecificLockMode(String alias, LockMode lockMode) {
 		if ( immutable ) {
@@ -307,8 +332,8 @@ public class LockOptions implements Serializable {
 
 	/**
 	 * Determine the {@link LockMode} to apply to the given alias. If no
-	 * mode was {@linkplain #setAliasSpecificLockMode(String, LockMode)}
-	 * explicitly set}, the {@linkplain #getLockMode()}  overall mode} is
+	 * mode was {@linkplain #setAliasSpecificLockMode(String, LockMode)
+	 * explicitly set}, the {@linkplain #getLockMode() overall mode} is
 	 * returned. If the overall lock mode is also {@code null},
 	 * {@link LockMode#NONE} is returned.
 	 * <p>
@@ -432,7 +457,8 @@ public class LockOptions implements Serializable {
 	}
 
 	/**
-	 * Set the {@linkplain #getTimeout() timeout}, in milliseconds, associated with {@code this} options.
+	 * Set the {@linkplain #getTimeout() timeout}, in milliseconds, associated
+	 * with {@code this} options.
 	 * <p/>
 	 * {@link #NO_WAIT}, {@link #WAIT_FOREVER}, or {@link #SKIP_LOCKED}
 	 * represent 3 "magic" values.

--- a/hibernate-core/src/main/java/org/hibernate/Timeouts.java
+++ b/hibernate-core/src/main/java/org/hibernate/Timeouts.java
@@ -7,12 +7,12 @@ package org.hibernate;
 import jakarta.persistence.Timeout;
 
 /**
- * Helpers for dealing with {@linkplain jakarta.persistence.Timeout time out} values,
- * including some "magic values".
+ * Helpers for dealing with {@linkplain jakarta.persistence.Timeout timeout}
+ * values, including some "magic values".
  *
- * @apiNote The {@linkplain #NO_WAIT} and {@linkplain #SKIP_LOCKED} magic values have
- * special {@linkplain LockMode} values as well ({@linkplain LockMode#UPGRADE_NOWAIT}
- * and {@linkplain LockMode#UPGRADE_SKIPLOCKED}, respectively).
+ * @apiNote The {@link #NO_WAIT} and {@link #SKIP_LOCKED} magic values each
+ * have a corresponding {@link LockMode} ({@link LockMode#UPGRADE_NOWAIT}
+ * and {@link LockMode#UPGRADE_SKIPLOCKED}, respectively).
  *
  * @author Steve Ebersole
  *

--- a/hibernate-core/src/main/java/org/hibernate/procedure/internal/ProcedureCallImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/procedure/internal/ProcedureCallImpl.java
@@ -1059,7 +1059,7 @@ public class ProcedureCallImpl<R>
 		throw new IllegalStateException( "Illegal attempt to get lock mode on a native-query" );
 	}
 
-	@Override
+	@Override @Deprecated
 	public QueryImplementor<R> setLockOptions(LockOptions lockOptions) {
 		throw new UnsupportedOperationException( "setLockOptions does not apply to procedure calls" );
 	}

--- a/hibernate-core/src/main/java/org/hibernate/query/NativeQuery.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/NativeQuery.java
@@ -626,7 +626,7 @@ public interface NativeQuery<T> extends Query<T>, SynchronizeableQuery {
 	 * result in changes to the native SQL query that is
 	 * actually executed.
 	 */
-	@Override
+	@Override @Deprecated(forRemoval = true)
 	LockOptions getLockOptions();
 
 	/**
@@ -637,7 +637,7 @@ public interface NativeQuery<T> extends Query<T>, SynchronizeableQuery {
 	 * result in changes to the native SQL query that is
 	 * actually executed.
 	 */
-	@Override
+	@Override @Deprecated(forRemoval = true)
 	NativeQuery<T> setLockOptions(LockOptions lockOptions);
 
 	/**

--- a/hibernate-core/src/main/java/org/hibernate/query/Query.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/Query.java
@@ -361,10 +361,11 @@ public interface Query<R> extends SelectionQuery<R>, MutationQuery, TypedQuery<R
 	 *
 	 * @see LockOptions
 	 *
-	 * @deprecated To be removed with no replacement - this is an SPI/internal concern.
+	 * @deprecated Since {@link LockOptions} is transitioning to
+	 *             a new role as an SPI.
 	 */
-	@Deprecated(since = "7.0", forRemoval = true)
 	@Override
+	@Deprecated(since = "7.0", forRemoval = true)
 	LockOptions getLockOptions();
 
 	/**

--- a/hibernate-core/src/main/java/org/hibernate/query/SelectionQuery.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/SelectionQuery.java
@@ -558,7 +558,11 @@ public interface SelectionQuery<R> extends CommonQueryContract {
 
 	/**
 	 * The {@link LockOptions} currently in effect for the query
+	 *
+	 * @deprecated Since {@link LockOptions} is transitioning to
+	 *             a new role as an SPI.
 	 */
+	@Deprecated(since = "7.0", forRemoval = true)
 	LockOptions getLockOptions();
 
 	/**

--- a/hibernate-core/src/main/java/org/hibernate/query/hql/spi/SqmQueryImplementor.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/hql/spi/SqmQueryImplementor.java
@@ -92,7 +92,7 @@ public interface SqmQueryImplementor<R> extends QueryImplementor<R>, SqmQuery, N
 	@Override
 	SqmQueryImplementor<R> addQueryHint(String hint);
 
-	@Override
+	@Override @Deprecated
 	SqmQueryImplementor<R> setLockOptions(LockOptions lockOptions);
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/query/spi/AbstractQuery.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/spi/AbstractQuery.java
@@ -258,12 +258,12 @@ public abstract class AbstractQuery<R>
 		return this;
 	}
 
-	@Override
+	@Override @Deprecated
 	public LockOptions getLockOptions() {
 		return getQueryOptions().getLockOptions();
 	}
 
-	@Override
+	@Override @Deprecated
 	public QueryImplementor<R> setLockOptions(LockOptions lockOptions) {
 		getQueryOptions().getLockOptions().overlay( lockOptions );
 		return this;

--- a/hibernate-core/src/main/java/org/hibernate/query/spi/AbstractSelectionQuery.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/spi/AbstractSelectionQuery.java
@@ -398,7 +398,7 @@ public abstract class AbstractSelectionQuery<R>
 		return this;
 	}
 
-	@Override
+	@Override @Deprecated
 	public LockOptions getLockOptions() {
 		return getQueryOptions().getLockOptions();
 	}

--- a/hibernate-core/src/main/java/org/hibernate/query/sql/internal/NativeQueryImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sql/internal/NativeQueryImpl.java
@@ -572,7 +572,7 @@ public class NativeQueryImpl<R>
 		throw new IllegalStateException( "Illegal attempt to get lock mode on a native-query" );
 	}
 
-	@Override
+	@Override @Deprecated
 	public NativeQueryImplementor<R> setLockOptions(LockOptions lockOptions) {
 		super.setLockOptions( lockOptions );
 		return this;

--- a/hibernate-core/src/main/java/org/hibernate/query/sql/spi/NativeQueryImplementor.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sql/spi/NativeQueryImplementor.java
@@ -174,7 +174,7 @@ public interface NativeQueryImplementor<R> extends QueryImplementor<R>, NativeQu
 	@Override
 	NativeQueryImplementor<R> setReadOnly(boolean readOnly);
 
-	@Override
+	@Override @Deprecated
 	NativeQueryImplementor<R> setLockOptions(LockOptions lockOptions);
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/internal/QuerySqmImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/internal/QuerySqmImpl.java
@@ -707,7 +707,7 @@ public class QuerySqmImpl<R>
 		return this;
 	}
 
-	@Override
+	@Override @Deprecated
 	public SqmQueryImplementor<R> setLockOptions(LockOptions lockOptions) {
 		// No verifySelect call, because in Hibernate we support locking in subqueries
 		getQueryOptions().getLockOptions().overlay( lockOptions );

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/spi/DelegatingSqmSelectionQueryImplementor.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/spi/DelegatingSqmSelectionQueryImplementor.java
@@ -263,7 +263,7 @@ public abstract class DelegatingSqmSelectionQueryImplementor<R> implements SqmSe
 		return getDelegate().getCacheRegion();
 	}
 
-	@Override
+	@Override @Deprecated
 	public LockOptions getLockOptions() {
 		return getDelegate().getLockOptions();
 	}

--- a/migration-guide.adoc
+++ b/migration-guide.adoc
@@ -736,7 +736,9 @@ Now, `varchar(1)` is used by default.
 [[lock-options]]
 == LockOptions
 
-The exposure of `LockOptions` as an API has been deprecated.  Applications should instead prefer the use of `LockMode` (or `LockModeType`), `Timeout` and `PessimisticLockScope`.
+`LockOptions` has been marked deprecated.
+Since JPA 3.2 and Hibernate 7, a `LockMode` (or `LockModeType`), `Timeout`, or `PessimisticLockScope` may be passed directly as an option to `find()`, `refresh()`, or `lock()`.
+Therefore, this class is obsolete as an API and will be moved to an SPI package.
 
 Use this
 


### PR DESCRIPTION
and explain what's going on with it in the javadoc

<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

[Please describe here what your change is about]

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-19440
<!-- Hibernate GitHub Bot issue links end -->