### PR TITLE
HHH-19341 Move publication repositories configuration to a more common gradle file

### DIFF
--- a/gradle/published-java-module.gradle
+++ b/gradle/published-java-module.gradle
@@ -96,25 +96,7 @@ publishing {
 			}
 		}
 	}
-	repositories {
-		maven {
-			name = "staging"
-			url = rootProject.layout.buildDirectory.dir("staging-deploy${File.separator}maven")
-		}
-		maven {
-			name = 'snapshots'
-			url = "https://oss.sonatype.org/content/repositories/snapshots/"
-			// So that Gradle uses the `ORG_GRADLE_PROJECT_snapshotsPassword` / `ORG_GRADLE_PROJECT_snapshotsUsername`
-			//  env variables to read the username/password for the `snapshots` repository publishing:
-			credentials(PasswordCredentials)
-		}
-	}
 }
-
-
-
-
-
 
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 // Release / publishing tasks

--- a/gradle/publishing-pom.gradle
+++ b/gradle/publishing-pom.gradle
@@ -59,5 +59,18 @@ publishing {
 
 		}
 	}
+	repositories {
+		maven {
+			name = "staging"
+			url = rootProject.layout.buildDirectory.dir("staging-deploy${File.separator}maven")
+		}
+		maven {
+			name = 'snapshots'
+			url = "https://oss.sonatype.org/content/repositories/snapshots/"
+			// So that Gradle uses the `ORG_GRADLE_PROJECT_snapshotsPassword` / `ORG_GRADLE_PROJECT_snapshotsUsername`
+			//  env variables to read the username/password for the `snapshots` repository publishing:
+			credentials(PasswordCredentials)
+		}
+	}
 
 }


### PR DESCRIPTION
that is also used by java modules and poms (e.g. platform one)

<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

[Please describe here what your change is about]

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-19341
<!-- Hibernate GitHub Bot issue links end -->