### PR TITLE
HHH-19396 cannot select the same column twice with different aliases while using cte

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/sql/BaseSqmToSqlAstConverter.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/sql/BaseSqmToSqlAstConverter.java
@@ -1813,11 +1813,14 @@ public abstract class BaseSqmToSqlAstConverter<T extends Statement> extends Base
 		final Collection<SqmCteStatement<?>> sqmCteStatements = consumer.getCteStatements();
 		cteContainer = new CteContainerImpl( cteContainer );
 		if ( !sqmCteStatements.isEmpty() ) {
+			final boolean originalDeduplicateSelectionItems = deduplicateSelectionItems;
+			deduplicateSelectionItems = false;
 			currentClauseStack.push( Clause.WITH );
 			for ( SqmCteStatement<?> sqmCteStatement : sqmCteStatements ) {
 				visitCteStatement( sqmCteStatement );
 			}
 			currentClauseStack.pop();
+			deduplicateSelectionItems = originalDeduplicateSelectionItems;
 			// Avoid leaking the processing state from CTEs to upper levels
 			lastPoppedFromClauseIndex = null;
 			lastPoppedProcessingState = null;

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/cte/SqmCteTable.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/cte/SqmCteTable.java
@@ -17,7 +17,6 @@ import org.hibernate.query.sqm.tuple.internal.AnonymousTupleType;
 import org.hibernate.query.sqm.tuple.internal.CteTupleTableGroupProducer;
 import org.hibernate.query.sqm.SqmPathSource;
 import org.hibernate.query.sqm.tree.select.SqmSelectQuery;
-import org.hibernate.query.sqm.tree.select.SqmSelectableNode;
 import org.hibernate.sql.ast.spi.FromClauseAccess;
 import org.hibernate.sql.ast.spi.SqlSelection;
 import org.hibernate.type.BasicType;
@@ -34,8 +33,8 @@ public class SqmCteTable<T> extends AnonymousTupleType<T> implements JpaCteCrite
 	private SqmCteTable(
 			String name,
 			SqmCteStatement<T> cteStatement,
-			SqmSelectableNode<?>[] sqmSelectableNodes) {
-		super( sqmSelectableNodes );
+			SqmSelectQuery<T> selectStatement) {
+		super(selectStatement);
 		this.name = name;
 		this.cteStatement = cteStatement;
 		final List<SqmCteTableColumn> columns = new ArrayList<>( componentCount() );
@@ -49,12 +48,7 @@ public class SqmCteTable<T> extends AnonymousTupleType<T> implements JpaCteCrite
 			String name,
 			SqmCteStatement<X> cteStatement,
 			SqmSelectQuery<X> selectStatement) {
-		final SqmSelectableNode<?>[] sqmSelectableNodes = selectStatement.getQueryPart()
-				.getFirstQuerySpec()
-				.getSelectClause()
-				.getSelectionItems()
-				.toArray( SqmSelectableNode[]::new );
-		return new SqmCteTable<>( name, cteStatement, sqmSelectableNodes );
+		return new SqmCteTable<>( name, cteStatement, selectStatement );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/tuple/internal/AnonymousTupleType.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/tuple/internal/AnonymousTupleType.java
@@ -22,13 +22,14 @@ import org.hibernate.query.sqm.SqmBindableType;
 import org.hibernate.query.sqm.SqmPathSource;
 import org.hibernate.query.sqm.tree.domain.SqmDomainType;
 import org.hibernate.query.sqm.tree.domain.SqmPluralPersistentAttribute;
+import org.hibernate.query.sqm.tree.select.SqmSelectQuery;
+import org.hibernate.query.sqm.tree.select.SqmSelection;
 import org.hibernate.query.sqm.tuple.TupleType;
 import org.hibernate.query.SemanticException;
 import org.hibernate.query.sqm.SqmExpressible;
 import org.hibernate.query.sqm.tree.domain.SqmPath;
 import org.hibernate.query.sqm.tree.select.SqmSelectClause;
 import org.hibernate.query.sqm.tree.select.SqmSelectableNode;
-import org.hibernate.query.sqm.tree.select.SqmSubQuery;
 import org.hibernate.spi.NavigablePath;
 import org.hibernate.sql.ast.spi.FromClauseAccess;
 import org.hibernate.sql.ast.spi.SqlSelection;
@@ -55,26 +56,47 @@ public class AnonymousTupleType<T>
 	private final String[] componentNames;
 	private final Map<String, Integer> componentIndexMap;
 
-	public AnonymousTupleType(SqmSubQuery<T> subQuery) {
-		this( extractSqmExpressibles( subQuery ) );
-	}
+	public AnonymousTupleType(SqmSelectQuery<T> selectQuery) {
+		final SqmSelectClause selectClause = selectQuery.getQueryPart()
+				.getFirstQuerySpec()
+				.getSelectClause();
 
-	public AnonymousTupleType(SqmSelectableNode<?>[] components) {
-		expressibles = new SqmBindableType<?>[components.length];
-		componentSourcePaths = new NavigablePath[components.length];
-		for ( int i = 0; i < components.length; i++ ) {
-			expressibles[i] = components[i].getNodeType();
-			if ( components[i] instanceof SqmPath<?> path ) {
-				componentSourcePaths[i] = path.getNavigablePath();
+		if ( selectClause == null || selectClause.getSelections().isEmpty() ) {
+			throw new IllegalArgumentException( "selectQuery has no selection items" );
+		}
+		// todo: right now, we "snapshot" the state of the selectQuery when creating this type, but maybe we shouldn't?
+		//  i.e. what if the selectQuery changes later on? Or should we somehow mark the selectQuery to signal,
+		//  that changes to the select clause are invalid after a certain point?
+
+		final List<SqmSelection<?>> selections = selectClause.getSelections();
+		final List<SqmSelectableNode<?>> selectableNodes = new ArrayList<>();
+		final List<String> aliases = new ArrayList<>();
+		for ( SqmSelection<?> selection : selections ) {
+			final boolean compound = selection.getSelectableNode().isCompoundSelection();
+			selection.getSelectableNode().visitSubSelectableNodes( node -> {
+				selectableNodes.add( node );
+				if ( compound ) {
+					aliases.add( node.getAlias() );
+				}
+			} );
+			if ( !compound ) {
+				// for compound selections we use the sub-selectable nodes aliases
+				aliases.add( selection.getAlias() );
 			}
 		}
-		componentNames = new String[components.length];
+
+		expressibles = new SqmBindableType<?>[selectableNodes.size()];
+		componentSourcePaths = new NavigablePath[selectableNodes.size()];
+		componentNames = new String[selectableNodes.size()];
 		//noinspection unchecked
-		javaTypeDescriptor = (JavaType<T>) new ObjectArrayJavaType( getTypeDescriptors( components ) );
-		componentIndexMap = linkedMapOfSize( components.length );
-		for ( int i = 0; i < components.length; i++ ) {
-			final SqmSelectableNode<?> component = components[i];
-			final String alias = component.getAlias();
+		javaTypeDescriptor = (JavaType<T>) new ObjectArrayJavaType( getTypeDescriptors( selectableNodes ) );
+		componentIndexMap = linkedMapOfSize( selectableNodes.size() );
+		for ( int i = 0; i < selectableNodes.size(); i++ ) {
+			expressibles[i] = selectableNodes.get( i ).getNodeType();
+			if ( selectableNodes.get( i ) instanceof SqmPath<?> path ) {
+				componentSourcePaths[i] = path.getNavigablePath();
+			}
+			String alias = aliases.get( i );
 			if ( alias == null ) {
 				throw new SemanticException( "Select item at position " + (i+1) + " in select list has no alias"
 						+ " (aliases are required in CTEs and in subqueries occurring in from clause)" );
@@ -110,21 +132,10 @@ public class AnonymousTupleType<T>
 		return SqmDomainType.super.getTypeName();
 	}
 
-	private static SqmSelectableNode<?>[] extractSqmExpressibles(SqmSubQuery<?> subQuery) {
-		final SqmSelectClause selectClause = subQuery.getQuerySpec().getSelectClause();
-		if ( selectClause == null || selectClause.getSelectionItems().isEmpty() ) {
-			throw new IllegalArgumentException( "subquery has no selection items" );
-		}
-		// todo: right now, we "snapshot" the state of the subquery when creating this type, but maybe we shouldn't?
-		//  i.e. what if the subquery changes later on? Or should we somehow mark the subquery to signal,
-		//  that changes to the select clause are invalid after a certain point?
-		return selectClause.getSelectionItems().toArray( SqmSelectableNode[]::new );
-	}
-
-	private static JavaType<?>[] getTypeDescriptors(SqmSelectableNode<?>[] components) {
-		final JavaType<?>[] typeDescriptors = new JavaType<?>[components.length];
-		for ( int i = 0; i < components.length; i++ ) {
-			typeDescriptors[i] = components[i].getExpressible().getExpressibleJavaType();
+	private static JavaType<?>[] getTypeDescriptors(List<SqmSelectableNode<?>> components) {
+		final JavaType<?>[] typeDescriptors = new JavaType<?>[components.size()];
+		for ( int i = 0; i < components.size(); i++ ) {
+			typeDescriptors[i] = components.get( i ).getExpressible().getExpressibleJavaType();
 		}
 		return typeDescriptors;
 	}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/subquery/MultipleIdenticalColumnsInSubqueryTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/subquery/MultipleIdenticalColumnsInSubqueryTest.java
@@ -1,0 +1,76 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.subquery;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Tuple;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.JiraKey;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@DomainModel(annotatedClasses = MultipleIdenticalColumnsInSubqueryTest.Something.class)
+@SessionFactory
+@JiraKey("HHH-19396")
+class MultipleIdenticalColumnsInSubqueryTest {
+
+	@BeforeEach
+	void init(SessionFactoryScope scope) {
+		scope.inTransaction( session -> session.persist( new Something() ) );
+	}
+
+	@AfterEach
+	void clean(SessionFactoryScope scope) {
+		scope.inTransaction( session -> session.createMutationQuery( "delete from Something" ).executeUpdate() );
+	}
+
+	@Test
+	@DisplayName("Temporary table with same column selected twice, deduplication should be turned off")
+	void CTE_with_same_column_selected_twice(SessionFactoryScope scope) {
+		var r = scope.fromSession( session ->
+				session.createSelectionQuery(
+						"WITH S0 AS (SELECT foo AS foo, foo AS bar FROM Something) SELECT foo AS foo FROM S0",
+						String.class ).getSingleResult() );
+		assertEquals( "a", r );
+	}
+
+	@Test
+	@DisplayName("Subquery with same column selected twice, deduplication should be turned off")
+	void CTE_with_same_column_selected_twice_some_aliases_removed(SessionFactoryScope scope) {
+		var r = scope.fromSession( session ->
+				session.createSelectionQuery(
+						"SELECT foo AS foo FROM (SELECT foo AS foo, foo AS foo2 FROM Something)",
+						String.class ).getSingleResult() );
+		assertEquals( "a", r );
+	}
+
+	@Test
+	@DisplayName("Simple query with same column selected twice, deduplication should be turned on")
+	void simple_query_with_same_column_selected_twice(SessionFactoryScope scope) {
+		var tuple = scope.fromSession( session ->
+				session.createSelectionQuery(
+						"SELECT foo AS foo, foo as bar FROM Something",
+						Tuple.class ).getSingleResult() );
+		assertEquals( 2, tuple.getElements().size() );
+		assertEquals( "a", tuple.get( "foo" ) );
+		assertEquals( "a", tuple.get( "bar" ) );
+	}
+
+	@Entity(name = "Something")
+	static class Something {
+		@Id
+		@GeneratedValue
+		private Long id;
+		private String foo = "a";
+	}
+}


### PR DESCRIPTION
Jira issue [HHH-19396](https://hibernate.atlassian.net/browse/HHH-19396)

When creating `SqlAstQueryPartProcessingStateImpl` in method `org.hibernate.query.sqm.sql.BaseSqmToSqlAstConverter#visitQuerySpec` parameter `deduplicateSelectionItems` must be set to `false` (see comment in moved code block)

When `selectStatement` contains same column more than once in method `org.hibernate.query.sqm.tree.cte.SqmCteTable#createStatementTable`, `SqmCteTable` constructor will be unable to properly resolve aliases. To prevent this alias in select clause selection should be used if exist, one from selectable node should be used otherwise.

----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-19396
<!-- Hibernate GitHub Bot issue links end -->

[HHH-19396]: https://hibernate.atlassian.net/browse/HHH-19396?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ