### PR TITLE
HHH-19468 enableFetchProfile() should accept an EnabledFetchProfile

### DIFF
--- a/documentation/src/main/asciidoc/introduction/Advanced.adoc
+++ b/documentation/src/main/asciidoc/introduction/Advanced.adoc
@@ -1144,8 +1144,15 @@ A fetch profile must be explicitly enabled for a given session by calling link:{
 
 [source,java]
 ----
-session.enableFetchProfile(Book_.PROFILE_EAGER_BOOK);
+session.enableFetchProfile(Book_._EagerBook);
 Book eagerBook = session.find(Book.class, bookId);
+----
+
+Alternatively, a profile may be passed as a `FindOption`:
+
+[source,java]
+----
+Book eagerBook = session.find(Book.class, bookId, Book_._EagerBook);
 ----
 
 So why or when might we prefer named fetch profiles to entity graphs?

--- a/hibernate-core/src/main/java/org/hibernate/Session.java
+++ b/hibernate-core/src/main/java/org/hibernate/Session.java
@@ -1275,7 +1275,7 @@ public interface Session extends SharedSessionContract, EntityManager {
 	boolean isFetchProfileEnabled(String name) throws UnknownProfileException;
 
 	/**
-	 * Enable the {@link org.hibernate.annotations.FetchProfile fetch profile}
+	 * Enable the {@linkplain org.hibernate.annotations.FetchProfile fetch profile}
 	 * with the given name in this session. If the requested fetch profile is
 	 * already enabled, the call has no effect.
 	 *
@@ -1287,6 +1287,26 @@ public interface Session extends SharedSessionContract, EntityManager {
 	 * @see org.hibernate.annotations.FetchProfile
 	 */
 	void enableFetchProfile(String name) throws UnknownProfileException;
+
+	/**
+	 * Enable the {@linkplain org.hibernate.annotations.FetchProfile fetch profile}
+	 * represented by the given instance of {@link EnabledFetchProfile}. If
+	 * the requested fetch profile is already enabled, the call has no effect.
+	 * <p>
+	 * An instance of {@link EnabledFetchProfile} may be obtained in a typesafe
+	 * way from the static metamodel.
+	 *
+	 * @param fetchProfile the {@link EnabledFetchProfile}
+	 *
+	 * @throws UnknownProfileException Indicates that the given object has
+	 *                                 a profile name which does not match
+	 *                                 any known fetch profile names
+	 *
+	 * @see org.hibernate.annotations.FetchProfile
+	 *
+	 * @since 7
+	 */
+	void enableFetchProfile(EnabledFetchProfile fetchProfile) throws UnknownProfileException;
 
 	/**
 	 * Disable the {@link org.hibernate.annotations.FetchProfile fetch profile}

--- a/hibernate-core/src/main/java/org/hibernate/engine/spi/SessionDelegatorBaseImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/spi/SessionDelegatorBaseImpl.java
@@ -22,6 +22,7 @@ import jakarta.persistence.metamodel.EntityType;
 import jakarta.persistence.metamodel.Metamodel;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.hibernate.CacheMode;
+import org.hibernate.EnabledFetchProfile;
 import org.hibernate.Filter;
 import org.hibernate.FlushMode;
 import org.hibernate.HibernateException;
@@ -1100,6 +1101,11 @@ public class SessionDelegatorBaseImpl implements SessionImplementor {
 	@Override
 	public void enableFetchProfile(String name) throws UnknownProfileException {
 		delegate.enableFetchProfile( name );
+	}
+
+	@Override
+	public void enableFetchProfile(EnabledFetchProfile fetchProfile) {
+		delegate.enableFetchProfile( fetchProfile );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/engine/spi/SessionLazyDelegator.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/spi/SessionLazyDelegator.java
@@ -25,6 +25,7 @@ import jakarta.persistence.metamodel.EntityType;
 import jakarta.persistence.metamodel.Metamodel;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.hibernate.CacheMode;
+import org.hibernate.EnabledFetchProfile;
 import org.hibernate.Filter;
 import org.hibernate.FlushMode;
 import org.hibernate.HibernateException;
@@ -414,6 +415,11 @@ public class SessionLazyDelegator implements Session {
 	@Override
 	public void enableFetchProfile(String name) throws UnknownProfileException {
 		this.lazySession.get().enableFetchProfile( name );
+	}
+
+	@Override
+	public void enableFetchProfile(EnabledFetchProfile fetchProfile) {
+		this.lazySession.get().enableFetchProfile( fetchProfile );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/internal/SessionImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/SessionImpl.java
@@ -1980,6 +1980,11 @@ public class SessionImpl
 	}
 
 	@Override
+	public void enableFetchProfile(EnabledFetchProfile fetchProfile) {
+		enableFetchProfile( fetchProfile.profileName() );
+	}
+
+	@Override
 	public void disableFetchProfile(String name) throws UnknownProfileException {
 		loadQueryInfluencers.disableFetchProfile( name );
 	}

--- a/hibernate-core/src/main/java/org/hibernate/query/Query.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/Query.java
@@ -17,6 +17,7 @@ import jakarta.persistence.EntityGraph;
 import jakarta.persistence.PessimisticLockScope;
 import jakarta.persistence.Timeout;
 import org.hibernate.CacheMode;
+import org.hibernate.EnabledFetchProfile;
 import org.hibernate.FlushMode;
 import org.hibernate.Incubating;
 import org.hibernate.LockMode;
@@ -945,6 +946,9 @@ public interface Query<R> extends SelectionQuery<R>, MutationQuery, TypedQuery<R
 
 	@Override
 	Query<R> setEntityGraph(EntityGraph<? super R> graph, GraphSemantic semantic);
+
+	@Override
+	Query<R> enableFetchProfile(EnabledFetchProfile fetchProfile);
 
 	@Override
 	Query<R> enableFetchProfile(String profileName);

--- a/hibernate-core/src/main/java/org/hibernate/query/SelectionQuery.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/SelectionQuery.java
@@ -18,6 +18,7 @@ import jakarta.persistence.CacheStoreMode;
 import jakarta.persistence.EntityGraph;
 import jakarta.persistence.PessimisticLockScope;
 import org.hibernate.CacheMode;
+import org.hibernate.EnabledFetchProfile;
 import org.hibernate.FlushMode;
 import org.hibernate.Incubating;
 import org.hibernate.LockMode;
@@ -285,6 +286,30 @@ public interface SelectionQuery<R> extends CommonQueryContract {
 	 * @since 6.3
 	 */
 	SelectionQuery<R> setEntityGraph(EntityGraph<? super R> graph, GraphSemantic semantic);
+
+	/**
+	 * Enable the {@linkplain org.hibernate.annotations.FetchProfile fetch
+	 * profile} represented by the given instance of {@link EnabledFetchProfile}
+	 * during execution of this query. If the requested fetch profile is already
+	 * enabled, the call has no effect.
+	 * <p>
+	 * This is an alternative way to specify the associations which
+	 * should be fetched as part of the initial query.
+	 * <p>
+	 * An instance of {@link EnabledFetchProfile} may be obtained in a typesafe
+	 * way from the static metamodel.
+	 *
+	 * @param fetchProfile the {@link EnabledFetchProfile}
+	 *
+	 * @throws UnknownProfileException Indicates that the given object has
+	 *                                 a profile name which does not match
+	 *                                 any known fetch profile names
+	 *
+	 * @see org.hibernate.annotations.FetchProfile
+	 *
+	 * @since 7
+	 */
+	SelectionQuery<R> enableFetchProfile(EnabledFetchProfile fetchProfile);
 
 	/**
 	 * Enable the {@linkplain org.hibernate.annotations.FetchProfile fetch

--- a/hibernate-core/src/main/java/org/hibernate/query/spi/AbstractQuery.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/spi/AbstractQuery.java
@@ -24,6 +24,7 @@ import jakarta.persistence.metamodel.Type;
 
 import jakarta.persistence.Timeout;
 import org.hibernate.CacheMode;
+import org.hibernate.EnabledFetchProfile;
 import org.hibernate.FlushMode;
 import org.hibernate.query.QueryFlushMode;
 import org.hibernate.HibernateException;
@@ -124,6 +125,12 @@ public abstract class AbstractQuery<R>
 	@Override
 	public QueryImplementor<R> setEntityGraph(EntityGraph<? super R> graph, GraphSemantic semantic) {
 		super.setEntityGraph( graph, semantic );
+		return this;
+	}
+
+	@Override
+	public QueryImplementor<R> enableFetchProfile(EnabledFetchProfile fetchProfile) {
+		super.enableFetchProfile( fetchProfile );
 		return this;
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/query/spi/AbstractSelectionQuery.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/spi/AbstractSelectionQuery.java
@@ -19,6 +19,7 @@ import java.util.stream.StreamSupport;
 import jakarta.persistence.PessimisticLockScope;
 import jakarta.persistence.Timeout;
 import org.hibernate.CacheMode;
+import org.hibernate.EnabledFetchProfile;
 import org.hibernate.FlushMode;
 import org.hibernate.ScrollableResults;
 import org.hibernate.engine.spi.SessionImplementor;
@@ -378,6 +379,11 @@ public abstract class AbstractSelectionQuery<R>
 	public SelectionQuery<R> setEntityGraph(EntityGraph<? super R> graph, GraphSemantic semantic) {
 		applyGraph( (RootGraphImplementor<? super R>) graph, semantic );
 		return this;
+	}
+
+	@Override
+	public SelectionQuery<R> enableFetchProfile(EnabledFetchProfile fetchProfile) {
+		return enableFetchProfile( fetchProfile.profileName() );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/internal/QuerySqmImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/internal/QuerySqmImpl.java
@@ -17,6 +17,7 @@ import jakarta.persistence.Timeout;
 import jakarta.persistence.metamodel.Type;
 
 import org.hibernate.CacheMode;
+import org.hibernate.EnabledFetchProfile;
 import org.hibernate.FlushMode;
 import org.hibernate.HibernateException;
 import org.hibernate.LockMode;
@@ -844,6 +845,12 @@ public class QuerySqmImpl<R>
 	@Override
 	public Query<R> setEntityGraph(EntityGraph<? super R> graph, GraphSemantic semantic) {
 		super.setEntityGraph( graph, semantic );
+		return this;
+	}
+
+	@Override
+	public Query<R> enableFetchProfile(EnabledFetchProfile fetchProfile) {
+		super.enableFetchProfile( fetchProfile );
 		return this;
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/spi/DelegatingSqmSelectionQueryImplementor.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/spi/DelegatingSqmSelectionQueryImplementor.java
@@ -14,6 +14,7 @@ import java.util.Optional;
 import java.util.stream.Stream;
 
 import org.hibernate.CacheMode;
+import org.hibernate.EnabledFetchProfile;
 import org.hibernate.FlushMode;
 import org.hibernate.Incubating;
 import org.hibernate.LockMode;
@@ -28,6 +29,7 @@ import org.hibernate.query.ParameterMetadata;
 import org.hibernate.query.QueryFlushMode;
 import org.hibernate.query.QueryParameter;
 import org.hibernate.query.ResultListTransformer;
+import org.hibernate.query.SelectionQuery;
 import org.hibernate.query.TupleTransformer;
 import org.hibernate.query.spi.QueryOptions;
 import org.hibernate.query.sqm.SqmSelectionQuery;
@@ -161,6 +163,12 @@ public abstract class DelegatingSqmSelectionQueryImplementor<R> implements SqmSe
 	@Override
 	public SqmSelectionQueryImplementor<R> setEntityGraph(EntityGraph<? super R> graph, GraphSemantic semantic) {
 		getDelegate().setEntityGraph( graph, semantic );
+		return this;
+	}
+
+	@Override
+	public SelectionQuery<R> enableFetchProfile(EnabledFetchProfile fetchProfile) {
+		getDelegate().enableFetchProfile( fetchProfile );
 		return this;
 	}
 


### PR DESCRIPTION
This is the first option.

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-19468
<!-- Hibernate GitHub Bot issue links end -->