### PR TITLE
HHH-19468 allow an EnabledFetchProfile to be apply()d to a Session or Query

### DIFF
--- a/documentation/src/main/asciidoc/introduction/Advanced.adoc
+++ b/documentation/src/main/asciidoc/introduction/Advanced.adoc
@@ -1148,7 +1148,15 @@ session.enableFetchProfile(Book_.PROFILE_EAGER_BOOK);
 Book eagerBook = session.find(Book.class, bookId);
 ----
 
-Alternatively, an instance of link:{doc-javadoc-url}org/hibernate/EnabledFetchProfile.html[`EnabledFetchProfile`] may be obtained in a type safe way from the static metamodel, and used as a `FindOption`:
+Alternatively, an instance of link:{doc-javadoc-url}org/hibernate/EnabledFetchProfile.html[`EnabledFetchProfile`] may be obtained in a type safe way from the static metamodel, and applied to the session:
+
+[source,java]
+----
+Book_._EagerBook.enable(session);
+Book eagerBook = session.find(Book.class, bookId);
+----
+
+Even better, the `EnabledFetchProfile` may be passed as a `FindOption`:
 
 [source,java]
 ----

--- a/hibernate-core/src/main/java/org/hibernate/EnabledFetchProfile.java
+++ b/hibernate-core/src/main/java/org/hibernate/EnabledFetchProfile.java
@@ -5,6 +5,7 @@
 package org.hibernate;
 
 import jakarta.persistence.FindOption;
+import org.hibernate.query.SelectionQuery;
 
 /**
  * A {@link jakarta.persistence.FindOption} which requests a named
@@ -12,9 +13,7 @@ import jakarta.persistence.FindOption;
  * <p>
  * An instance of this class may be obtained in a type safe way
  * from the static metamodel for the class annotated
- * {@link org.hibernate.annotations.FetchProfile @FetchProfile}
- * and passed as an option to
- * {@link Session#find(Class, Object, FindOption...) find()}.
+ * {@link org.hibernate.annotations.FetchProfile @FetchProfile}.
  * <p>
  * For example, this class defines a fetch profile:
  * <pre>
@@ -28,10 +27,19 @@ import jakarta.persistence.FindOption;
  *     Set&lt;Author&gt; authors;
  * }
  * </pre>
- * The fetch profile may be requested like this:
+ * <p>
+ * An {@code EnabledFetchProfile} may be obtained from the static
+ * metamodel for the entity {@code Book} and passed as an option to
+ * {@link Session#find(Class, Object, FindOption...) find()}.
  * <pre>
  * Book bookWithAuthors =
  *         session.find(Book.class, isbn, Book_._WithAuthors)
+ * </pre>
+ * Alternatively, it may be {@linkplain #enable(Session) applied}
+ * to a {@code Session} or {@code Query}.
+ * <pre>
+ * Book_._WithAuthors.enable(session);
+ * Book bookWithAuthors = session.find(Book.class, isbn);
  * </pre>
  * <p>
  * When the static metamodel is not used, an {@code EnabledFetchProfile}
@@ -54,4 +62,20 @@ import jakarta.persistence.FindOption;
  */
 public record EnabledFetchProfile(String profileName)
 		implements FindOption {
+
+	/**
+	 * Enable the fetch profile represented by this
+	 * object in the given session.
+	 */
+	public void enable(Session session) {
+		session.enableFetchProfile(profileName);
+	}
+
+	/**
+	 * Enable the fetch profile represented by this
+	 * object during execution of the given query.
+	 */
+	public void enable(SelectionQuery<?> query) {
+		query.enableFetchProfile(profileName);
+	}
 }


### PR DESCRIPTION
<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

[Please describe here what your change is about]

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-19468
<!-- Hibernate GitHub Bot issue links end -->