### PR TITLE
HHH-19336 - Proper implementation for JPA extended locking scope

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/LockMode.java
+++ b/hibernate-core/src/main/java/org/hibernate/LockMode.java
@@ -39,7 +39,6 @@ import java.util.Locale;
  *
  * @see Session#lock(Object, LockMode)
  * @see LockModeType
- * @see LockOptions
  * @see org.hibernate.annotations.OptimisticLocking
  */
 public enum LockMode implements FindOption, RefreshOption {
@@ -119,7 +118,10 @@ public enum LockMode implements FindOption, RefreshOption {
 	 * lock mode, if the lock is successfully obtained, are the same
 	 * as {@link #PESSIMISTIC_WRITE}. If the lock is not immediately
 	 * available, an exception occurs.
+	 *
+	 * @deprecated Use {@linkplain Timeouts#NO_WAIT} instead.
 	 */
+	@Deprecated
 	UPGRADE_NOWAIT,
 
 	/**
@@ -129,7 +131,10 @@ public enum LockMode implements FindOption, RefreshOption {
 	 * as {@link #PESSIMISTIC_WRITE}. But if the lock is not
 	 * immediately available, no exception occurs, but the locked
 	 * row is not returned from the database.
+	 *
+	 * @deprecated Use {@linkplain Locking.LockedRows#SKIP} instead.
 	 */
+	@Deprecated
 	UPGRADE_SKIPLOCKED,
 
 	/**
@@ -143,6 +148,10 @@ public enum LockMode implements FindOption, RefreshOption {
 	 * lock mode is equivalent to {@link #PESSIMISTIC_WRITE}.
 	 *
 	 * @see LockModeType#PESSIMISTIC_READ
+	 * @see jakarta.persistence.Timeout
+	 * @see Locking.Scope
+	 * @see Locking.FollowOn
+	 * @see Locking.LockedRows
 	 */
 	PESSIMISTIC_READ,
 
@@ -152,6 +161,10 @@ public enum LockMode implements FindOption, RefreshOption {
 	 * Obtained via a {@code select for update} statement.
 	 *
 	 * @see LockModeType#PESSIMISTIC_WRITE
+	 * @see jakarta.persistence.Timeout
+	 * @see Locking.Scope
+	 * @see Locking.FollowOn
+	 * @see Locking.LockedRows
 	 */
 	PESSIMISTIC_WRITE,
 
@@ -163,6 +176,10 @@ public enum LockMode implements FindOption, RefreshOption {
 	 * Only legal for versioned entity types.
 	 *
 	 * @see LockModeType#PESSIMISTIC_FORCE_INCREMENT
+	 * @see jakarta.persistence.Timeout
+	 * @see Locking.Scope
+	 * @see Locking.FollowOn
+	 * @see Locking.LockedRows
 	 */
 	PESSIMISTIC_FORCE_INCREMENT;
 

--- a/hibernate-core/src/main/java/org/hibernate/Locking.java
+++ b/hibernate-core/src/main/java/org/hibernate/Locking.java
@@ -1,0 +1,136 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate;
+
+import jakarta.persistence.FindOption;
+import jakarta.persistence.LockOption;
+import jakarta.persistence.PessimisticLockScope;
+import jakarta.persistence.RefreshOption;
+import jakarta.persistence.Timeout;
+import org.hibernate.dialect.Dialect;
+
+/**
+ * Support for various aspects of pessimistic locking.
+ *
+ * @see LockMode#PESSIMISTIC_READ
+ * @see LockMode#PESSIMISTIC_WRITE
+ * @see LockMode#PESSIMISTIC_FORCE_INCREMENT
+ *
+ * @author Steve Ebersole
+ */
+public interface Locking {
+
+	/**
+	 * When pessimistic locking is requested, this enum defines
+	 * what exactly will be locked.
+	 *
+	 * @apiNote Same intention as the JPA {@linkplain PessimisticLockScope},
+	 * but offering the additional {@linkplain #INCLUDE_FETCHES} behavior.
+	 *
+	 * @see FollowOn
+	 */
+	enum Scope implements FindOption, LockOption, RefreshOption {
+		/**
+		 * Lock the database row(s) that correspond to the non-collection-valued
+		 * persistent state of that instance. If a joined inheritance strategy is
+		 * used, or if the entity is otherwise mapped to a secondary table, this
+		 * entails locking the row(s) for the entity instance in the additional table(s).
+		 *
+		 * @see PessimisticLockScope#NORMAL
+		 */
+		ROOT_ONLY( PessimisticLockScope.NORMAL ),
+
+		/**
+		 * In addition to the locking behavior specified for {@linkplain #ROOT_ONLY},
+		 * rows for collection tables ({@linkplain jakarta.persistence.ElementCollection},
+		 * {@linkplain jakarta.persistence.OneToMany} and {@linkplain jakarta.persistence.ManyToMany})
+		 * will also be locked.
+		 *
+		 * @see PessimisticLockScope#EXTENDED
+		 */
+		INCLUDE_COLLECTIONS( PessimisticLockScope.EXTENDED ),
+
+		/**
+		 * All tables with fetched rows will be locked.
+		 *
+		 * @apiNote This is Hibernate's legacy behavior, and has no
+		 * corresponding JPA scope.
+		 */
+		INCLUDE_FETCHES( null );
+
+		private final PessimisticLockScope jpaScope;
+
+		Scope(PessimisticLockScope jpaScope) {
+			this.jpaScope = jpaScope;
+		}
+
+		/**
+		 * The JPA PessimisticLockScope which corresponds to this LockScope.
+		 *
+		 * @return The corresponding PessimisticLockScope, or {@code null}.
+		 */
+		public PessimisticLockScope getCorrespondingJpaScope() {
+			return jpaScope;
+		}
+
+		public static Scope fromJpaScope(PessimisticLockScope scope) {
+			if ( scope == PessimisticLockScope.EXTENDED ) {
+				return INCLUDE_COLLECTIONS;
+			}
+			// null, NORMAL
+			return ROOT_ONLY;
+		}
+	}
+
+	/**
+	 * In certain circumstances, Hibernate may need to acquire locks
+	 * through the use of subsequent queries.  For example, some
+	 * databases may not like attempting to lock rows in a join or
+	 * queries with paging.  In such cases, Hibernate will fall back
+	 * to issuing additional lock queries to lock some of the rows.
+	 * This option controls whether Hibernate is allowed to use
+	 * this approach.
+	 */
+	enum FollowOn implements FindOption, LockOption, RefreshOption {
+		/**
+		 * Allow Hibernate to perform follow-on locking when it needs to.
+		 */
+		ALLOW,
+
+		/**
+		 * Do not allow Hibernate to perform follow-on locking when it needs to, throwing
+		 * an exception instead.
+		 */
+		DISALLOW,
+
+		/**
+		 * Do not allow Hibernate to perform follow-on locking when it needs to, but just ignore
+		 * the situation.
+		 *
+		 * @apiNote This can lead to rows not being locked when they are expected to be.
+		 */
+		IGNORE
+	}
+
+	/**
+	 * How locked rows should be handled with pessimistic lock attempts.
+	 * The default is to {@linkplain #WAIT wait} for the locks to be released.
+	 */
+	enum LockedRows implements FindOption, LockOption, RefreshOption {
+		/**
+		 * The default.  The transaction will wait for the row locks to
+		 * be released, within any specified {@linkplain Timeout timeout}.
+		 */
+		WAIT,
+
+		/**
+		 * Immediately skips locked rows.
+		 *
+		 * @apiNote Only legal if the database
+		 * {@linkplain Dialect#supportsSkipLocked() supports skipping locked rows}.
+		 */
+		SKIP
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/locking/scope/Book.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/locking/scope/Book.java
@@ -1,0 +1,92 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.locking.scope;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.JoinTable;
+import jakarta.persistence.ManyToMany;
+import jakarta.persistence.ManyToOne;
+
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * @author Steve Ebersole
+ */
+@Entity
+public class Book {
+	@Id
+	private Integer id;
+	private String title;
+	private String synopsis;
+	@ManyToOne
+	@JoinColumn(name = "publisher_fk")
+	private Publisher publisher;
+	@ManyToMany
+	@JoinTable(name = "book_authors",
+			joinColumns = @JoinColumn(name = "book_fk"),
+			inverseJoinColumns = @JoinColumn(name = "author_fk"))
+	private Set<Person> authors;
+
+	protected Book() {
+		// for Hibernate use
+	}
+
+	public Book(Integer id, String title, String synopsis) {
+		this( id, title, synopsis, null );
+	}
+
+	public Book(Integer id, String title, String synopsis, Publisher publisher) {
+		this.id = id;
+		this.title = title;
+		this.synopsis = synopsis;
+		this.publisher = publisher;
+	}
+
+	public Integer getId() {
+		return id;
+	}
+
+	public String getTitle() {
+		return title;
+	}
+
+	public void setTitle(String title) {
+		this.title = title;
+	}
+
+	public String getSynopsis() {
+		return synopsis;
+	}
+
+	public void setSynopsis(String synopsis) {
+		this.synopsis = synopsis;
+	}
+
+	public Publisher getPublisher() {
+		return publisher;
+	}
+
+	public void setPublisher(Publisher publisher) {
+		this.publisher = publisher;
+	}
+
+	public Set<Person> getAuthors() {
+		return authors;
+	}
+
+	public void setAuthors(Set<Person> authors) {
+		this.authors = authors;
+	}
+
+	public void addAuthor(Person author) {
+		if ( authors == null ) {
+			authors = new HashSet<>();
+		}
+		authors.add( author );
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/locking/scope/Person.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/locking/scope/Person.java
@@ -1,0 +1,41 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.locking.scope;
+
+import jakarta.persistence.Basic;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+
+/**
+ * @author Steve Ebersole
+ */
+@Entity
+public class Person {
+	@Id
+	private Integer id;
+	@Basic
+	private String name;
+
+	protected Person() {
+		// for Hibernate use
+	}
+
+	public Person(Integer id, String name) {
+		this.id = id;
+		this.name = name;
+	}
+
+	public Integer getId() {
+		return id;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/locking/scope/Publisher.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/locking/scope/Publisher.java
@@ -1,0 +1,71 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.locking.scope;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+
+import java.util.Set;
+
+/**
+ * @author Steve Ebersole
+ */
+@Entity
+public class Publisher {
+	@Id
+	private Integer id;
+	private String name;
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name="editor_fk")
+	private Person leadEditor;
+	@OneToMany(mappedBy = "publisher")
+	private Set<Book> books;
+
+	protected Publisher() {
+		// for Hibernate use
+	}
+
+	public Publisher(Integer id, String name) {
+		this( id, name, null );
+	}
+
+	public Publisher(Integer id, String name, Person leadEditor) {
+		this.id = id;
+		this.name = name;
+		this.leadEditor = leadEditor;
+	}
+
+	public Integer getId() {
+		return id;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+
+	public Person getLeadEditor() {
+		return leadEditor;
+	}
+
+	public void setLeadEditor(Person leadEditor) {
+		this.leadEditor = leadEditor;
+	}
+
+	public Set<Book> getBooks() {
+		return books;
+	}
+
+	public void setBooks(Set<Book> books) {
+		this.books = books;
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/locking/scope/SimpleScopingTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/locking/scope/SimpleScopingTests.java
@@ -1,0 +1,110 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.locking.scope;
+
+import jakarta.persistence.LockModeType;
+import org.hibernate.Hibernate;
+import org.hibernate.dialect.PostgreSQLDialect;
+import org.hibernate.testing.jdbc.SQLStatementInspector;
+import org.hibernate.testing.orm.junit.DialectFeatureChecks;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.Jira;
+import org.hibernate.testing.orm.junit.NotImplementedYet;
+import org.hibernate.testing.orm.junit.RequiresDialect;
+import org.hibernate.testing.orm.junit.RequiresDialectFeature;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ *
+ * @author Steve Ebersole
+ */
+@SuppressWarnings("JUnitMalformedDeclaration")
+@DomainModel(annotatedClasses = {Book.class, Person.class, Publisher.class})
+@SessionFactory(useCollectingStatementInspector = true)
+@Jira( "https://hibernate.atlassian.net/browse/HHH-19336" )
+@Jira( "https://hibernate.atlassian.net/browse/HHH-19459" )
+public class SimpleScopingTests {
+	@BeforeEach
+	void createTestData(SessionFactoryScope factoryScope) {
+		factoryScope.inTransaction( (session) -> {
+			final Person milton = new Person( 1, "John Milton" );
+			session.persist( milton );
+			final Person campbell = new Person( 2, "Joseph Campbell" );
+			session.persist( campbell );
+			final Person king = new Person( 3, "Stephen King" );
+			session.persist( king );
+			final Person straub = new Person( 4, "Peter Straub" );
+			session.persist( straub );
+			final Person doe = new Person( 5, "John Doe" );
+			session.persist( doe );
+
+			final Publisher acme = new Publisher( 1, "Acme Publishing House", doe );
+			session.persist( acme );
+
+			final Book paradiseLost = new Book( 1, "Paradise Lost", "Narrative poem, in the epic style, ..." );
+			paradiseLost.addAuthor( milton );
+			session.persist( paradiseLost );
+
+			final Book thePowerOfMyth = new Book( 2, "The Power of Myth",
+					"A look at the themes and symbols of ancient narratives ..." );
+			thePowerOfMyth.addAuthor( campbell );
+			session.persist( thePowerOfMyth );
+
+			final Book theTalisman = new Book( 3, "The Talisman", "Epic of the struggle between good and evil ...", acme );
+			theTalisman.addAuthor( king );
+			theTalisman.addAuthor( straub );
+			session.persist( theTalisman );
+
+			final Book theDarkTower = new Book( 4, "The Dark Tower", "The epic final to the series ...", acme );
+			theDarkTower.addAuthor( king );
+			session.persist( theDarkTower );
+		} );
+	}
+
+	@AfterEach
+	void dropTestData(SessionFactoryScope factoryScope) {
+		factoryScope.dropData();
+	}
+
+	@Test
+	void testLoading(SessionFactoryScope factoryScope) {
+		factoryScope.inTransaction( (session) -> {
+			final Book paradiseLost = session.find( Book.class, 1 );
+			assertThat( paradiseLost.getTitle() ).isEqualTo( "Paradise Lost" );
+			assertThat( Hibernate.isInitialized( paradiseLost.getAuthors() ) ).isFalse();
+
+			final Book talisman = session.find( Book.class, 3 );
+			assertThat( talisman.getTitle() ).isEqualTo( "The Talisman" );
+			assertThat( Hibernate.isInitialized( talisman.getAuthors() ) ).isFalse();
+		} );
+	}
+
+	@Test
+	@RequiresDialectFeature( feature = DialectFeatureChecks.SupportsTableLocking.class )
+	@NotImplementedYet(reason = "Proper, strict-JPA locking not yet implemented", expectedVersion = "7.1")
+	void testSimpleLocking(SessionFactoryScope factoryScope) {
+		final SQLStatementInspector sqlCollector = factoryScope.getCollectingStatementInspector();
+
+		factoryScope.inTransaction( (session) -> {
+			sqlCollector.clear();
+			final Book theTalisman = session.find( Book.class, 3, LockModeType.PESSIMISTIC_WRITE );
+			assertThat( Hibernate.isInitialized( theTalisman ) ).isTrue();
+			assertThat( Hibernate.isInitialized( theTalisman.getPublisher() ) ).isTrue();
+			assertThat( Hibernate.isInitialized( theTalisman.getAuthors() ) ).isFalse();
+			assertThat( Hibernate.isInitialized( theTalisman.getPublisher().getLeadEditor() ) ).isFalse();
+			assertThat( Hibernate.isInitialized( theTalisman.getPublisher().getBooks() ) ).isFalse();
+			assertThat( sqlCollector.getSqlQueries() ).hasSize( 1 );
+
+			// todo: this is going to depend on the specific database
+			assertThat( sqlCollector.getSqlQueries().get( 0 ) ).contains( " for update of " );
+		} );
+	}
+}

--- a/hibernate-testing/src/main/java/org/hibernate/testing/orm/junit/DialectFeatureChecks.java
+++ b/hibernate-testing/src/main/java/org/hibernate/testing/orm/junit/DialectFeatureChecks.java
@@ -55,6 +55,7 @@ import org.hibernate.dialect.MySQLDialect;
 import org.hibernate.dialect.NationalizationSupport;
 import org.hibernate.dialect.OracleDialect;
 import org.hibernate.dialect.PostgreSQLDialect;
+import org.hibernate.dialect.RowLockStrategy;
 import org.hibernate.dialect.SQLServerDialect;
 import org.hibernate.dialect.SpannerDialect;
 import org.hibernate.dialect.SybaseASEDialect;
@@ -262,6 +263,12 @@ abstract public class DialectFeatureChecks {
 	public static class SupportsSkipLocked implements DialectFeatureCheck {
 		public boolean apply(Dialect dialect) {
 			return dialect.supportsSkipLocked();
+		}
+	}
+
+	public static class SupportsTableLocking implements DialectFeatureCheck {
+		public boolean apply(Dialect dialect) {
+			return dialect.getReadRowLockStrategy() != RowLockStrategy.NONE;
 		}
 	}
 


### PR DESCRIPTION
[HHH-19336](https://hibernate.atlassian.net/browse/HHH-19336) - Proper implementation for JPA extended locking scope
[HHH-19459](https://hibernate.atlassian.net/browse/HHH-19459) - LockScope, FollowOnLocking

<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

[Please describe here what your change is about]

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-19336
<!-- Hibernate GitHub Bot issue links end -->

[HHH-19336]: https://hibernate.atlassian.net/browse/HHH-19336?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[HHH-19459]: https://hibernate.atlassian.net/browse/HHH-19459?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ