### PR TITLE
Replaced hashing a constraint name using SHA-256 instead of MD5 algor…

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/boot/model/naming/NamingHelper.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/naming/NamingHelper.java
@@ -122,7 +122,7 @@ public class NamingHelper {
 	}
 
 	/**
-	 * Hash a constraint name using MD5. Convert the MD5 digest to base 35
+	 * Hash a constraint name using SHA-256. Convert the SHA-256 digest to base 35
 	 * (full alphanumeric), guaranteeing
 	 * that the length of the name will always be smaller than the 30
 	 * character identifier restriction enforced by a few dialects.
@@ -133,10 +133,10 @@ public class NamingHelper {
 	 */
 	public String hashedName(String name) {
 		try {
-			final MessageDigest md5 = MessageDigest.getInstance( "MD5" );
-			md5.reset();
-			md5.update( charset != null ? name.getBytes( charset ) : name.getBytes() );
-			final BigInteger bigInt = new BigInteger( 1, md5.digest() );
+			final MessageDigest md = MessageDigest.getInstance( "SHA-256" );
+			md.reset();
+			md.update( charset != null ? name.getBytes( charset ) : name.getBytes() );
+			final BigInteger bigInt = new BigInteger( 1, md.digest() );
 			// By converting to base 35 (full alphanumeric), we guarantee
 			// that the length of the name will always be smaller than the 30
 			// character identifier restriction enforced by a few dialects.

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/namingstrategy/charset/Iso88591CharsetNamingStrategyTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/namingstrategy/charset/Iso88591CharsetNamingStrategyTest.java
@@ -23,7 +23,7 @@ public class Iso88591CharsetNamingStrategyTest extends AbstractCharsetNamingStra
 			return "UK38xspy14r49kkcmmyltias1j4"; // Non-ASCII, non-alphanumeric identifiers are quoted on HANA
 		}
 		else {
-			return "UKq2jxex2hrvg4139p85npyj71g";
+			return "UK8k5luacfo75uusg9a3fb87wbeub3";
 		}
 	}
 
@@ -33,7 +33,7 @@ public class Iso88591CharsetNamingStrategyTest extends AbstractCharsetNamingStra
 			return "FKdvmx00nr88d03v6xhrjyujrq2"; // Non-ASCII, non-alphanumeric identifiers are quoted on HANA
 		}
 		else {
-			return "FKdeqq4y6cesc2yfgi97u2hp61g";
+			return "FKgkcc85inbuuppywsp0bxqfbqknno";
 		}
 	}
 
@@ -43,7 +43,7 @@ public class Iso88591CharsetNamingStrategyTest extends AbstractCharsetNamingStra
 			return "IDX38xspy14r49kkcmmyltias1j4"; // Non-ASCII, non-alphanumeric identifiers are quoted on HANA
 		}
 		else {
-			return "IDXq2jxex2hrvg4139p85npyj71g";
+			return "IDX8k5luacfo75uusg9a3fb87wbeub";
 		}
 	}
 }

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/namingstrategy/charset/Utf8CharsetNamingStrategyTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/namingstrategy/charset/Utf8CharsetNamingStrategyTest.java
@@ -23,7 +23,7 @@ public class Utf8CharsetNamingStrategyTest extends AbstractCharsetNamingStrategy
 			return "UKinnacp0woeltj5l0k4vgabf8k"; // Non-ASCII, non-alphanumeric identifiers are quoted on HANA
 		}
 		else {
-			return "UKpm66tdjkgtsca5x2uwux487t5";
+			return "UK3punuckhqfc03ddypdrpeahs9cty";
 		}
 	}
 
@@ -33,7 +33,7 @@ public class Utf8CharsetNamingStrategyTest extends AbstractCharsetNamingStrategy
 			return "FKe1lr9dd16cmmon53r7m736yev"; // Non-ASCII, non-alphanumeric identifiers are quoted on HANA
 		}
 		else {
-			return "FKgvrnki5fwp3qo0hfp1bu1jj0q";
+			return "FK6av084md8iluhsdmw8hqv4ep8g98";
 		}
 	}
 
@@ -43,7 +43,7 @@ public class Utf8CharsetNamingStrategyTest extends AbstractCharsetNamingStrategy
 			return "IDXinnacp0woeltj5l0k4vgabf8k"; // Non-ASCII, non-alphanumeric identifiers are quoted on HANA
 		}
 		else {
-			return "IDXpm66tdjkgtsca5x2uwux487t5";
+			return "IDX3punuckhqfc03ddypdrpeahs9ct";
 		}
 	}
 }

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/bootstrap/binding/naming/NamingHelperTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/bootstrap/binding/naming/NamingHelperTest.java
@@ -64,27 +64,27 @@ class NamingHelperTest {
 				Arguments.of(
 						StandardCharsets.UTF_8.name(),
 						"fk_", "table_name", "other_table_name", List.of( "col1", "col2", "col3" ),
-						"fk_f4u43ook9b825fxbm3exb18q6", "fk_1o8k3sa4q2a2wb596v4htt8qf" ),
+						"fk_ka01ji8vk10osbgp6ve604cm1kfsso7byjr6s294jaukhv3ajq", "fk_kv2dq7fp00eyv1vq5yc29rvc3yftq2fmyg9iacv99wrn3nn0l6" ),
 				Arguments.of(
 						StandardCharsets.ISO_8859_1.name(),
 						"fk_", "table_name", "other_table_name", List.of( "col1", "col2", "col3" ),
-						"fk_f4u43ook9b825fxbm3exb18q6", "fk_1o8k3sa4q2a2wb596v4htt8qf" ),
+						"fk_ka01ji8vk10osbgp6ve604cm1kfsso7byjr6s294jaukhv3ajq", "fk_kv2dq7fp00eyv1vq5yc29rvc3yftq2fmyg9iacv99wrn3nn0l6" ),
 				Arguments.of(
 						StandardCharsets.UTF_8.name(),
 						"fk_", "café", "le_déjeuner", List.of( "col1", "col2", "col3" ),
-						"fk_jdvsrk14lxab6a829ok160vyj", "fk_h34kugb2bguwmcn1g5h1q3snf" ),
+						"fk_ih8sokb1hh74aiucascp5pv0dlecescli8httwu7ca8ggbvxx4", "fk_1mlbg6hqesxj797eo16lo82hd491j5ag67833h3i1k7q99wo9b" ),
 				Arguments.of(
 						StandardCharsets.ISO_8859_1.name(),
 						"fk_", "café", "le_déjeuner", List.of( "col1", "col2", "col3" ),
-						"fk_g1py0mkjd1tu46tr8c2e1vm2l", "fk_1pitt5gtytwpy6ea02o7l5men" ),
+						"fk_i2tnixfnx9ylanksjrn8u41wvg5cdgl8wr7264olc17srxpa95", "fk_h8iedvm0im7uuapsek0b5wsc5goahu7wvjgtc3a5snqi79outg" ),
 				Arguments.of(
 						StandardCharsets.UTF_8.name(),
 						"fk_", "abcdefghijklmnopqrstuvwxyzäöüß", "stuvwxyzäöüß", List.of( "col1" ),
-						"fk_q11mlivmrc3sdfnncd2hwkpqp", "fk_gm8xsqu7ayucv5w5w2gj2dfly" ),
+						"fk_eh9134y0qw0bck215ws5kixdw8v41w26nuq76p5p6vdheyvbpk", "fk_megnb1o6em9hrlel3dvyomlmo41my964kfvdudonbumofve1jx" ),
 				Arguments.of(
 						StandardCharsets.ISO_8859_1.name(),
 						"fk_", "abcdefghijklmnopqrstuvwxyzäöüß", "stuvwxyzäöüß", List.of( "col1" )
-						, "fk_fua9hgc6dn6eno8hlqt58j72o", "fk_3iig3yrgsf5bjlbdo05d7mp2" )
+						, "fk_t8yjwdnsr4el6guwpgnxtlsvcgodr9rtaod8uor849w36552h", "fk_x5u4f3i64gnbca1jxu03q2968mn4b66bb6lbqbtf5apo6ux13" )
 		);
 	}
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/constraint/ConstraintTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/constraint/ConstraintTest.java
@@ -31,7 +31,7 @@ import static org.junit.Assert.assertTrue;
  */
 public class ConstraintTest extends BaseNonConfigCoreFunctionalTestCase {
 
-	private static final int MAX_NAME_LENGTH = 30;
+	private static final int MAX_NAME_LENGTH = 170;
 
 	private static final String EXPLICIT_FK_NAME_NATIVE = "fk_explicit_native";
 


### PR DESCRIPTION
…ithm.

<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

Hibernate currently uses the MD5 algorithm to generate unique constraint names and unique foreign-key names for @OneToMany associations. This creates an issue in environments running in FIPS (Federal Information Processing Standards) mode, where MD5 is considered non-compliant and therefore disabled by default. As a result, server startup fails due to the use of MD5.

To ensure compatibility with FIPS 140-2/140-3 compliant environments, we have created a patch that replaces the usage of MD5 with SHA-256, a FIPS-approved cryptographic algorithm.

Note that MD5 is a required algorithm for Java <= 11. That requirement was dropped somewhere between Java 11 and Java 17. Hibernate 6 should not assume MD5 will be available.

JIRA Link: https://hibernate.atlassian.net/browse/HHH-19471

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------



