### PR TITLE
remove unnecessary nullness checking in AbstractSqlAstTranslator#visitInsertStatementOnly()

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/sql/ast/spi/AbstractSqlAstTranslator.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/ast/spi/AbstractSqlAstTranslator.java
@@ -1269,20 +1269,15 @@ public abstract class AbstractSqlAstTranslator<T extends JdbcOperation> implemen
 		boolean firstPass = true;
 
 		final List<ColumnReference> targetColumnReferences = statement.getTargetColumns();
-		if ( targetColumnReferences == null ) {
-			renderImplicitTargetColumnSpec();
-		}
-		else {
-			for (ColumnReference targetColumnReference : targetColumnReferences) {
-				if (firstPass) {
-					firstPass = false;
-				}
-				else {
-					appendSql( COMMA_SEPARATOR_CHAR );
-				}
-
-				appendSql( targetColumnReference.getColumnExpression() );
+		for (ColumnReference targetColumnReference : targetColumnReferences) {
+			if (firstPass) {
+				firstPass = false;
 			}
+			else {
+				appendSql( COMMA_SEPARATOR_CHAR );
+			}
+
+			appendSql( targetColumnReference.getColumnExpression() );
 		}
 
 		appendSql( ") " );
@@ -1635,9 +1630,6 @@ public abstract class AbstractSqlAstTranslator<T extends JdbcOperation> implemen
 		}
 		appendSql( " then update" );
 		renderSetClause( assignments );
-	}
-
-	private void renderImplicitTargetColumnSpec() {
 	}
 
 	protected void visitValuesList(List<Values> valuesList) {


### PR DESCRIPTION
…

<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

straightforward code simpliciation. The nullness checking seems unnecessary.

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
