### PR TITLE
HHH-19331: query plan cache should take parameter type into accound for cast

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/sql/ast/spi/AbstractSqlAstTranslator.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/ast/spi/AbstractSqlAstTranslator.java
@@ -5667,7 +5667,7 @@ public abstract class AbstractSqlAstTranslator<T extends JdbcOperation> implemen
 		if ( expression instanceof SqlTypedMappingJdbcParameter parameter ) {
 			final SqlTypedMapping sqlTypedMapping = parameter.getSqlTypedMapping();
 			castTarget = new CastTarget(
-					parameter.getJdbcMapping(),
+					sqlTypedMapping.getJdbcMapping(),
 					sqlTypedMapping.getColumnDefinition(),
 					sqlTypedMapping.getLength(),
 					sqlTypedMapping.getTemporalPrecision() != null
@@ -5680,6 +5680,12 @@ public abstract class AbstractSqlAstTranslator<T extends JdbcOperation> implemen
 			castTarget = new CastTarget( expression.getExpressionType().getSingleJdbcMapping() );
 		}
 		arguments.add( castTarget );
+		if ( expression instanceof JdbcParameter ) {
+			// the value itself is not important, but its type,
+			// to improve performances, we could store that information
+			// and use it in JdbcOperationQuery.isCompatibleWith instead
+			addAppliedParameterBinding( (JdbcParameter) expression, null );
+		}
 		castFunction().render( this, arguments, (ReturnableType<?>) castTarget.getJdbcMapping(), this );
 	}
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/query/hql/QueryPlanCachingTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/query/hql/QueryPlanCachingTest.java
@@ -5,30 +5,47 @@
 package org.hibernate.orm.test.query.hql;
 
 import org.hibernate.engine.spi.SessionImplementor;
-import org.hibernate.orm.test.mapping.SmokeTests;
-
 import org.hibernate.query.criteria.HibernateCriteriaBuilder;
 import org.hibernate.query.criteria.JpaCriteriaQuery;
 import org.hibernate.query.criteria.JpaRoot;
+import org.hibernate.testing.orm.domain.gambit.BasicEntity;
 import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.Jira;
 import org.hibernate.testing.orm.junit.ServiceRegistry;
 import org.hibernate.testing.orm.junit.SessionFactory;
 import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author Steve Ebersole
  */
-@DomainModel( annotatedClasses = SmokeTests.SimpleEntity.class )
+@DomainModel(annotatedClasses = BasicEntity.class)
 @ServiceRegistry
-@SessionFactory( exportSchema = true )
+@SessionFactory(exportSchema = true)
 public class QueryPlanCachingTest {
+
+	@BeforeAll
+	public void setUp(SessionFactoryScope scope) {
+		scope.inTransaction( session -> session.persist( new BasicEntity( 1, "entity_1" ) ) );
+	}
+
+	@AfterAll
+	public void tearDown(SessionFactoryScope scope) {
+		scope.getSessionFactory().getSchemaManager().truncateMappedObjects();
+	}
+
 	@Test
 	public void testHqlTranslationCaching(SessionFactoryScope scope) {
 		scope.inTransaction(
 				session -> {
-					session.createQuery( "select e from SimpleEntity e" ).list();
-					session.createQuery( "select e from SimpleEntity e" ).list();
+					session.createQuery( "select e from BasicEntity e" ).list();
+					session.createQuery( "select e from BasicEntity e" ).list();
 				}
 		);
 	}
@@ -44,11 +61,45 @@ public class QueryPlanCachingTest {
 		);
 	}
 
-	private static JpaCriteriaQuery<SmokeTests.SimpleEntity> constructCriteriaQuery(SessionImplementor session) {
+	private static JpaCriteriaQuery<BasicEntity> constructCriteriaQuery(SessionImplementor session) {
 		final HibernateCriteriaBuilder cb = session.getCriteriaBuilder();
-		final JpaCriteriaQuery<SmokeTests.SimpleEntity> query = cb.createQuery( SmokeTests.SimpleEntity.class );
-		final JpaRoot<SmokeTests.SimpleEntity> root = query.from( SmokeTests.SimpleEntity.class );
+		final JpaCriteriaQuery<BasicEntity> query = cb.createQuery( BasicEntity.class );
+		final JpaRoot<BasicEntity> root = query.from( BasicEntity.class );
 		query.select( root );
 		return query;
+	}
+
+	@Test
+	@Jira("https://hibernate.atlassian.net/browse/HHH-19331")
+	public void hhh19331_selectionquery(SessionFactoryScope scope) {
+		scope.inTransaction( session -> {
+			assertThat(
+					session.createSelectionQuery( "select :p0 from BasicEntity", Object[].class )
+							.setParameter( "p0", 1 )
+							.getSingleResult()
+			).containsExactly( 1 );
+			assertThat(
+					session.createSelectionQuery( "select :p0 from BasicEntity", Object[].class )
+							.setParameter( "p0", BigDecimal.valueOf( 3.14 ) )
+							.getSingleResult()
+			).containsExactly( BigDecimal.valueOf( 3.14 ) );
+		} );
+	}
+
+	@Test
+	@Jira("https://hibernate.atlassian.net/browse/HHH-19331")
+	public void hhh19331_query(SessionFactoryScope scope) {
+		scope.inTransaction( session -> {
+			assertThat(
+					session.createQuery( "select :p0 from BasicEntity", Object[].class )
+							.setParameter( "p0", 1 )
+							.getSingleResult()
+			).containsExactly( 1 );
+			assertThat(
+					session.createQuery( "select :p0 from BasicEntity", Object[].class )
+							.setParameter( "p0", BigDecimal.valueOf( 3.14 ) )
+							.getSingleResult()
+			).containsExactly( BigDecimal.valueOf( 3.14 ) );
+		} );
 	}
 }


### PR DESCRIPTION
My understanding of the problem is that the query plan cache has some mechanisms to know if a cached query plan is invalid. Until now it handled two cases in relation to query parameters:
- if the value of the parameter was used directly in the rendered SQL, then the same query with different parameters cannot reuse the cached SQL
- if the parameters are related to limit/offset, for select queries, then we are not so much interested in the value of the limit/offset parameters but with the fact they are specified or not to know if we can reuse the cached SQL.

My change add one more case: when a parameter type is involved in the rendered SQL, precisely here if we render a cast that was not explicit in the HQL query, then the cached SQL cannot be reused with a different parameter type. I haven't found out if there were more cases of this problem, other than cast.

I didn't go all the way into remembering the type of the parameter used during the SQL rendering but just on the presence of the parameter in `appliedParameters`. Most certainly it should be possible to optimize this but I didn't want to make things too complex. 

I went with refactoring things a bit to 1) remove duplicate code between `JdbcOperationQuerySelect` and `AbstractJdbcOperationQuery`. I think it's equivalent but I may have missed something. I think it also remove chances of NPE (as mentioned in a TODO I removed) when `appliedBinding` is `null`.

----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-19331
<!-- Hibernate GitHub Bot issue links end -->