### PR TITLE
HHH-19473: Use asDefined type when enhancing BiDirectional Associations to resolve issue with mismatched generated method signatures.

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/bytecode/enhance/internal/bytebuddy/BiDirectionalAssociationHandler.java
+++ b/hibernate-core/src/main/java/org/hibernate/bytecode/enhance/internal/bytebuddy/BiDirectionalAssociationHandler.java
@@ -78,6 +78,7 @@ final class BiDirectionalAssociationHandler implements Implementation {
 		TypeDescription targetType = FieldLocator.ForClassHierarchy.Factory.INSTANCE.make( targetEntity )
 				.locate( bidirectionalAttributeName )
 				.getField()
+				.asDefined()
 				.getType()
 				.asErasure();
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/lazy/LazyLoadingAndParameterizedInheritanceTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/lazy/LazyLoadingAndParameterizedInheritanceTest.java
@@ -30,6 +30,7 @@ import java.util.HashSet;
 import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
 
 @DomainModel(
 		annotatedClasses = {
@@ -99,6 +100,14 @@ public class LazyLoadingAndParameterizedInheritanceTest {
 			//That is the actual test. If three == null ==> lazy load was not performed.
 			assertThat( three ).isNotNull();
 		} );
+	}
+
+	@Test
+	public void testCollectionWrite() {
+		Three three = new Three();
+		Two two = new Two();
+		assertThatNoException().isThrownBy(() -> three.setTwos(Set.of(two)));
+		assertThat(two.getThree()).isSameAs(three);
 	}
 
 	@Entity(name = "One")


### PR DESCRIPTION
Opened as a companion to the 6.6 branch PR https://github.com/hibernate/hibernate-orm/pull/10170

This PR includes a test and fix for the issue in https://hibernate.atlassian.net/browse/HHH-19473

----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
