### PR TITLE
HHH-18891 fix of an AssertionError when using a NotFound annotation

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/embeddable/internal/EmbeddableAssembler.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/embeddable/internal/EmbeddableAssembler.java
@@ -32,6 +32,9 @@ public class EmbeddableAssembler implements DomainResultAssembler {
 	public Object assemble(RowProcessingState rowProcessingState) {
 		final InitializerData data = initializer.getData( rowProcessingState );
 		final Initializer.State state = data.getState();
+		if ( state == Initializer.State.UNINITIALIZED ) {
+			initializer.resolveKey( data );
+		}
 		if ( state == Initializer.State.KEY_RESOLVED ) {
 			initializer.resolveInstance( data );
 		}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/notfound/CompositeForeignKeyNotFoundTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/notfound/CompositeForeignKeyNotFoundTest.java
@@ -1,0 +1,144 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.notfound;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import org.hibernate.FetchNotFoundException;
+import org.hibernate.annotations.JoinColumnOrFormula;
+import org.hibernate.annotations.JoinFormula;
+import org.hibernate.annotations.NotFound;
+import org.hibernate.annotations.NotFoundAction;
+import org.hibernate.query.Query;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.JiraKey;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@JiraKey(value = "HHH-18891")
+@DomainModel(
+		annotatedClasses = {CompositeForeignKeyNotFoundTest.Document.class, CompositeForeignKeyNotFoundTest.DocumentIgnore.class,
+				CompositeForeignKeyNotFoundTest.DocumentException.class, CompositeForeignKeyNotFoundTest.Person.class})
+@SessionFactory
+public class CompositeForeignKeyNotFoundTest {
+
+	@Test
+	void hhh18891TestWithNotFoundIgnore(SessionFactoryScope scope) {
+
+		// prepare document
+		scope.inTransaction( session -> {
+			Query nativeQuery = session.createNativeQuery(
+					"insert into DocumentIgnore (id,owner) values (123,42)" );
+			nativeQuery.executeUpdate();
+		} );
+
+		// assert document
+		scope.inTransaction( session -> {
+			final DocumentIgnore document = session.find( DocumentIgnore.class, 123 );
+			assertNotNull( document );
+			assertEquals( 123, document.id );
+			assertNull( document.owner );
+		} );
+	}
+
+	@Test
+	void hhh18891TestWithNotFoundException(SessionFactoryScope scope) {
+
+		// prepare document
+		scope.inTransaction( session -> {
+			Query nativeQuery = session.createNativeQuery(
+					"insert into DocumentException (id,owner) values (123,42)" );
+			nativeQuery.executeUpdate();
+		} );
+
+		// assert document
+		scope.inTransaction( session -> {
+			assertThrows( FetchNotFoundException.class, () ->
+					session.find( DocumentException.class, 123 ) );
+		} );
+	}
+
+	@Test
+	void hhh18891TestWithoutNotFoundAnnotation(SessionFactoryScope scope) {
+
+		// prepare document
+		scope.inTransaction( session -> {
+			Query nativeQuery = session.createNativeQuery(
+					"insert into Document (id,owner) values (123,42)" );
+			nativeQuery.executeUpdate();
+		} );
+
+		// assert document
+		scope.inTransaction( session -> {
+			final Document document = session.find( Document.class, 123 );
+			assertNotNull( document );
+			assertEquals( 123, document.id );
+			assertNull( document.owner );
+		} );
+	}
+
+	@Entity(name = "DocumentIgnore")
+	public static class DocumentIgnore {
+
+		@Id
+		@GeneratedValue
+		Long id;
+
+		@ManyToOne
+		@NotFound(action = NotFoundAction.IGNORE)
+		@JoinColumnOrFormula(column = @JoinColumn(name = "owner", referencedColumnName = "id", insertable = false,
+				updatable = false))
+		@JoinColumnOrFormula(formula = @JoinFormula(value = "'fubar'", referencedColumnName = "name"))
+		Person owner;
+	}
+
+	@Entity(name = "DocumentException")
+	public static class DocumentException {
+
+		@Id
+		@GeneratedValue
+		Long id;
+
+		@ManyToOne
+		@NotFound(action = NotFoundAction.EXCEPTION)
+		@JoinColumnOrFormula(column = @JoinColumn(name = "owner", referencedColumnName = "id", insertable = false,
+				updatable = false))
+		@JoinColumnOrFormula(formula = @JoinFormula(value = "'fubar'", referencedColumnName = "name"))
+		Person owner;
+	}
+
+	@Entity(name = "Document")
+	public static class Document {
+
+		@Id
+		@GeneratedValue
+		Long id;
+
+		@ManyToOne
+		@JoinColumnOrFormula(column = @JoinColumn(name = "owner", referencedColumnName = "id", insertable = false,
+				updatable = false))
+		@JoinColumnOrFormula(formula = @JoinFormula(value = "'fubar'", referencedColumnName = "name"))
+		Person owner;
+	}
+
+	@Entity(name = "Person")
+	public static class Person {
+
+		@Id
+		Long id;
+
+		String name;
+	}
+
+}


### PR DESCRIPTION
The bug reported in HHH-18891 describes an assertion that fails because it expects the initializer state to be KEY_RESOLVED before it resolves the instance.

I added an if statement in EmbeddableAssembler to ensure that the key is resolved if the state is UNINITIALIZED.

The tests in the PR are based on https://github.com/hibernate/hibernate-test-case-templates/pull/454
as presented in https://hibernate.atlassian.net/browse/HHH-18891 but have been simplified a bit for readability.

I guess that there are other possibilities to catch the given scenario earlier or with a more specific approach.
But at least none of the other tests fail with the fix. :)

----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
