### PR TITLE
HHH-19480 missing foreign key constraint on unidir @OneToMany to non-PK

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/boot/internal/InFlightMetadataCollectorImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/internal/InFlightMetadataCollectorImpl.java
@@ -1941,7 +1941,7 @@ public class InFlightMetadataCollectorImpl
 		table.createForeignKeys( buildingContext );
 
 		final Dialect dialect = getDatabase().getJdbcEnvironment().getDialect();
-		for ( ForeignKey foreignKey : table.getForeignKeys().values() ) {
+		for ( ForeignKey foreignKey : table.getForeignKeyCollection() ) {
 			if ( !done.contains( foreignKey ) ) {
 				done.add( foreignKey );
 				final PersistentClass referencedClass = foreignKey.resolveReferencedClass(this);

--- a/hibernate-core/src/main/java/org/hibernate/boot/internal/MetadataImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/internal/MetadataImpl.java
@@ -408,7 +408,7 @@ public class MetadataImpl implements MetadataImplementor, Serializable {
 	}
 
 	private void handleForeignKeys(Table table, ColumnOrderingStrategy columnOrderingStrategy) {
-		for ( ForeignKey foreignKey : table.getForeignKeys().values() ) {
+		for ( ForeignKey foreignKey : table.getForeignKeyCollection() ) {
 			final List<Column> columns = foreignKey.getColumns();
 			if ( columns.size() > 1 ) {
 				if ( foreignKey.getReferencedColumns().isEmpty() ) {

--- a/hibernate-core/src/main/java/org/hibernate/dialect/SpannerDialectTableExporter.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/SpannerDialectTableExporter.java
@@ -53,7 +53,7 @@ class SpannerDialectTableExporter implements Exporter<Table> {
 			// a typical table that corresponds to an entity type
 			keyColumns = table.getPrimaryKey().getColumns();
 		}
-		else if ( !table.getForeignKeys().isEmpty() ) {
+		else if ( !table.getForeignKeyCollection().isEmpty() ) {
 			// a table with no PK's but has FK's; often corresponds to element collection properties
 			keyColumns = table.getColumns();
 		}

--- a/hibernate-core/src/main/java/org/hibernate/mapping/Collection.java
+++ b/hibernate-core/src/main/java/org/hibernate/mapping/Collection.java
@@ -548,9 +548,16 @@ public abstract sealed class Collection
 
 	private void createForeignKeys() throws MappingException {
 		// if ( !isInverse() ) { // for inverse collections, let the "other end" handle it
+		final String entityName = getOwner().getEntityName();
 		if ( referencedPropertyName == null ) {
 			getElement().createForeignKey();
-			key.createForeignKeyOfEntity( getOwner().getEntityName() );
+			key.createForeignKeyOfEntity( entityName );
+		}
+		else {
+			final Property property = owner.getProperty( referencedPropertyName );
+			assert property != null;
+			key.createForeignKeyOfEntity( entityName,
+					property.getValue().getConstraintColumns() );
 		}
 		// }
 	}

--- a/hibernate-core/src/main/java/org/hibernate/mapping/Constraint.java
+++ b/hibernate-core/src/main/java/org/hibernate/mapping/Constraint.java
@@ -24,6 +24,12 @@ public abstract class Constraint implements Exportable, Serializable {
 	private Table table;
 	private String options = "";
 
+	Constraint() {}
+
+	Constraint(Table table) {
+		this.table = table;
+	}
+
 	public String getName() {
 		return name;
 	}
@@ -76,6 +82,7 @@ public abstract class Constraint implements Exportable, Serializable {
 		return table;
 	}
 
+	@Deprecated(since = "7")
 	public void setTable(Table table) {
 		this.table = table;
 	}

--- a/hibernate-core/src/main/java/org/hibernate/mapping/DenormalizedTable.java
+++ b/hibernate-core/src/main/java/org/hibernate/mapping/DenormalizedTable.java
@@ -60,7 +60,7 @@ public class DenormalizedTable extends Table {
 	@Override
 	public void createForeignKeys(MetadataBuildingContext context) {
 		includedTable.createForeignKeys( context );
-		for ( ForeignKey foreignKey : includedTable.getForeignKeys().values() ) {
+		for ( ForeignKey foreignKey : includedTable.getForeignKeyCollection() ) {
 			final PersistentClass referencedClass =
 					foreignKey.resolveReferencedClass( context.getMetadataCollector() );
 			// the ForeignKeys created in the first pass did not have their referenced table initialized

--- a/hibernate-core/src/main/java/org/hibernate/mapping/ForeignKey.java
+++ b/hibernate-core/src/main/java/org/hibernate/mapping/ForeignKey.java
@@ -29,10 +29,11 @@ public class ForeignKey extends Constraint {
 	private final List<Column> referencedColumns = new ArrayList<>();
 	private boolean creationEnabled = true;
 
-	public ForeignKey(Table table){
-		setTable( table );
+	public ForeignKey(Table table) {
+		super( table );
 	}
 
+	@Deprecated(since = "7")
 	public ForeignKey() {
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/mapping/KeyValue.java
+++ b/hibernate-core/src/main/java/org/hibernate/mapping/KeyValue.java
@@ -8,6 +8,8 @@ import org.hibernate.Incubating;
 import org.hibernate.dialect.Dialect;
 import org.hibernate.generator.Generator;
 
+import java.util.List;
+
 /**
  * A mapping model {@link Value} which may be treated as an identifying key of a
  * relational database table. A {@code KeyValue} might represent the primary key
@@ -17,6 +19,8 @@ import org.hibernate.generator.Generator;
  * @author Gavin King
  */
 public interface KeyValue extends Value {
+
+	ForeignKey createForeignKeyOfEntity(String entityName, List<Column> referencedColumns);
 
 	ForeignKey createForeignKeyOfEntity(String entityName);
 

--- a/hibernate-core/src/main/java/org/hibernate/mapping/PersistentClass.java
+++ b/hibernate-core/src/main/java/org/hibernate/mapping/PersistentClass.java
@@ -158,14 +158,17 @@ public abstract sealed class PersistentClass
 		this.proxyInterface = null;
 	}
 
+	private Class<?> getClassForName(String className) {
+		return classForName( className, metadataBuildingContext.getBootstrapContext() );
+	}
+
 	public Class<?> getMappedClass() throws MappingException {
 		if ( className == null ) {
 			return null;
 		}
-
 		try {
 			if ( mappedClass == null ) {
-				mappedClass = classForName( className, metadataBuildingContext.getBootstrapContext() );
+				mappedClass = getClassForName( className );
 			}
 			return mappedClass;
 		}
@@ -180,7 +183,7 @@ public abstract sealed class PersistentClass
 		}
 		try {
 			if ( proxyInterface == null ) {
-				proxyInterface = classForName( proxyInterfaceName, metadataBuildingContext.getBootstrapContext() );
+				proxyInterface = getClassForName( proxyInterfaceName );
 			}
 			return proxyInterface;
 		}
@@ -538,26 +541,26 @@ public abstract sealed class PersistentClass
 	}
 
 	private Property getProperty(String propertyName, List<Property> properties) throws MappingException {
-		String root = root( propertyName );
-		for ( Property prop : properties ) {
-			if ( prop.getName().equals( root )
-					|| ( prop instanceof Backref || prop instanceof IndexBackref )
-							&& prop.getName().equals( propertyName ) ) {
-				return prop;
+		final String root = root( propertyName );
+		for ( Property property : properties ) {
+			if ( property.getName().equals( root )
+					|| ( property instanceof Backref || property instanceof IndexBackref )
+							&& property.getName().equals( propertyName ) ) {
+				return property;
 			}
 		}
 		throw new MappingException( "property [" + propertyName + "] not found on entity [" + getEntityName() + "]" );
 	}
 
 	public Property getProperty(String propertyName) throws MappingException {
-		Property identifierProperty = getIdentifierProperty();
+		final Property identifierProperty = getIdentifierProperty();
 		if ( identifierProperty != null
 				&& identifierProperty.getName().equals( root( propertyName ) ) ) {
 			return identifierProperty;
 		}
 		else {
 			List<Property> closure = getPropertyClosure();
-			Component identifierMapper = getIdentifierMapper();
+			final Component identifierMapper = getIdentifierMapper();
 			if ( identifierMapper != null ) {
 				closure = new JoinedList<>( identifierMapper.getProperties(), closure );
 			}
@@ -577,14 +580,14 @@ public abstract sealed class PersistentClass
 		if ( identifierProperty != null && identifierProperty.getName().equals( name ) ) {
 			return true;
 		}
-
-		for ( Property property : getPropertyClosure() ) {
-			if ( property.getName().equals(name) ) {
-				return true;
+		else {
+			for ( Property property : getPropertyClosure() ) {
+				if ( property.getName().equals( name ) ) {
+					return true;
+				}
 			}
+			return false;
 		}
-
-		return false;
 	}
 
 	/**
@@ -644,9 +647,9 @@ public abstract sealed class PersistentClass
 
 	private void checkPropertyDuplication() throws MappingException {
 		final HashSet<String> names = new HashSet<>();
-		for ( Property prop : getProperties() ) {
-			if ( !names.add( prop.getName() ) ) {
-				throw new MappingException( "Duplicate property mapping of " + prop.getName() + " found in " + getEntityName() );
+		for ( Property property : getProperties() ) {
+			if ( !names.add( property.getName() ) ) {
+				throw new MappingException( "Duplicate property mapping of " + property.getName() + " found in " + getEntityName() );
 			}
 		}
 	}

--- a/hibernate-core/src/main/java/org/hibernate/mapping/PrimaryKey.java
+++ b/hibernate-core/src/main/java/org/hibernate/mapping/PrimaryKey.java
@@ -22,10 +22,11 @@ public class PrimaryKey extends Constraint {
 	private UniqueKey orderingUniqueKey = null;
 	private int[] originalOrder;
 
-	public PrimaryKey(Table table){
-		setTable( table );
+	public PrimaryKey(Table table) {
+		super( table );
 	}
 
+	@Deprecated(since = "7")
 	public PrimaryKey() {
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/mapping/SimpleValue.java
+++ b/hibernate-core/src/main/java/org/hibernate/mapping/SimpleValue.java
@@ -352,6 +352,24 @@ public abstract class SimpleValue implements KeyValue {
 	}
 
 	@Override
+	public ForeignKey createForeignKeyOfEntity(String entityName, List<Column> referencedColumns) {
+		if ( isConstrained() ) {
+			final ForeignKey foreignKey = table.createForeignKey(
+					getForeignKeyName(),
+					getConstraintColumns(),
+					entityName,
+					getForeignKeyDefinition(),
+					getForeignKeyOptions(),
+					referencedColumns
+			);
+			foreignKey.setOnDeleteAction( onDeleteAction );
+			return foreignKey;
+		}
+
+		return null;
+	}
+
+	@Override
 	public void createUniqueKey(MetadataBuildingContext context) {
 		if ( hasFormula() ) {
 			throw new MappingException( "Unique key constraint involves formulas" );

--- a/hibernate-core/src/main/java/org/hibernate/mapping/UniqueKey.java
+++ b/hibernate-core/src/main/java/org/hibernate/mapping/UniqueKey.java
@@ -22,10 +22,11 @@ public class UniqueKey extends Constraint {
 	private boolean nameExplicit; // true when the constraint name was explicitly specified by @UniqueConstraint annotation
 	private boolean explicit; // true when the constraint was explicitly specified by @UniqueConstraint annotation
 
-	public UniqueKey(Table table){
-		setTable( table );
+	public UniqueKey(Table table) {
+		super( table );
 	}
 
+	@Deprecated(since = "7")
 	public UniqueKey() {
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/tool/schema/internal/AbstractSchemaMigrator.java
+++ b/hibernate-core/src/main/java/org/hibernate/tool/schema/internal/AbstractSchemaMigrator.java
@@ -435,7 +435,7 @@ public abstract class AbstractSchemaMigrator implements SchemaMigrator {
 			GenerationTarget... targets) {
 		if ( dialect.hasAlterTable() ) {
 			final Exporter<ForeignKey> exporter = dialect.getForeignKeyExporter();
-			for ( ForeignKey foreignKey : table.getForeignKeys().values() ) {
+			for ( ForeignKey foreignKey : table.getForeignKeyCollection() ) {
 				if ( foreignKey.isPhysicalConstraint()
 						&& foreignKey.isCreationEnabled()
 						&& ( tableInformation == null || !checkForExistingForeignKey( foreignKey, tableInformation ) ) ) {

--- a/hibernate-core/src/main/java/org/hibernate/tool/schema/internal/SchemaCreatorImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/tool/schema/internal/SchemaCreatorImpl.java
@@ -290,7 +290,7 @@ public class SchemaCreatorImpl extends AbstractSchemaPopulator implements Schema
 					if ( schemaFilter.includeTable( table )
 							&& contributableInclusionMatcher.matches( table ) ) {
 						// foreign keys
-						for ( ForeignKey foreignKey : table.getForeignKeys().values() ) {
+						for ( ForeignKey foreignKey : table.getForeignKeyCollection() ) {
 							applySqlStrings(
 									dialect.getForeignKeyExporter().getSqlCreateStrings( foreignKey, metadata, context ),
 									formatter,

--- a/hibernate-core/src/main/java/org/hibernate/tool/schema/internal/SchemaDropperImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/tool/schema/internal/SchemaDropperImpl.java
@@ -475,7 +475,7 @@ public class SchemaDropperImpl implements SchemaDropper {
 				if ( table.isPhysicalTable()
 						&& schemaFilter.includeTable( table )
 						&& inclusionFilter.matches( table ) ) {
-					for ( ForeignKey foreignKey : table.getForeignKeys().values() ) {
+					for ( ForeignKey foreignKey : table.getForeignKeyCollection() ) {
 						applySqlStrings(
 								dialect.getForeignKeyExporter().getSqlDropStrings( foreignKey, metadata, context ),
 								formatter,

--- a/hibernate-core/src/main/java/org/hibernate/tool/schema/internal/SchemaTruncatorImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/tool/schema/internal/SchemaTruncatorImpl.java
@@ -198,7 +198,7 @@ public class SchemaTruncatorImpl extends AbstractSchemaPopulator implements Sche
 				continue;
 			}
 
-			for ( ForeignKey foreignKey : table.getForeignKeys().values() ) {
+			for ( ForeignKey foreignKey : table.getForeignKeyCollection() ) {
 				if ( dialect.canDisableConstraints() ) {
 					applySqlString(
 							dialect.getTableCleaner().getSqlDisableConstraintString( foreignKey, metadata, context ),
@@ -241,7 +241,7 @@ public class SchemaTruncatorImpl extends AbstractSchemaPopulator implements Sche
 				continue;
 			}
 
-			for ( ForeignKey foreignKey : table.getForeignKeys().values() ) {
+			for ( ForeignKey foreignKey : table.getForeignKeyCollection() ) {
 				if ( dialect.canDisableConstraints() ) {
 					applySqlString(
 							dialect.getTableCleaner().getSqlEnableConstraintString( foreignKey, metadata, context ),

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/collectionelement/DefaultNamingCollectionElementTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/collectionelement/DefaultNamingCollectionElementTest.java
@@ -6,7 +6,6 @@ package org.hibernate.orm.test.annotations.collectionelement;
 
 import java.util.HashMap;
 import java.util.Iterator;
-import java.util.List;
 import java.util.Locale;
 
 import org.hibernate.Filter;
@@ -15,7 +14,6 @@ import org.hibernate.cfg.AvailableSettings;
 import org.hibernate.mapping.Collection;
 import org.hibernate.mapping.Column;
 import org.hibernate.mapping.ForeignKey;
-import org.hibernate.query.Query;
 
 import org.hibernate.testing.orm.junit.JiraKey;
 import org.hibernate.testing.orm.junit.DomainModel;
@@ -39,7 +37,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * @author Hardy Ferentschik
  * @author Gail Badner
  */
-@SuppressWarnings("unchecked")
 @DomainModel(
 		annotatedClasses = {
 				Boy.class,
@@ -102,10 +99,10 @@ public class DefaultNamingCollectionElementTest {
 					assertNotNull( boy.getFavoriteNumbers() );
 					assertEquals( 3, boy.getFavoriteNumbers()[1] );
 					assertTrue( boy.getCharacters().contains( CharacterTrait.CRAFTY ) );
-					assertTrue( boy.getFavoriteFood().get( "dinner" ).equals( FavoriteFood.SUSHI ) );
-					assertTrue( boy.getFavoriteFood().get( "lunch" ).equals( FavoriteFood.KUNGPAOCHICKEN ) );
-					assertTrue( boy.getFavoriteFood().get( "breakfast" ).equals( FavoriteFood.PIZZA ) );
-					List result = session.createQuery(
+					assertEquals( FavoriteFood.SUSHI, boy.getFavoriteFood().get( "dinner" ) );
+					assertEquals( FavoriteFood.KUNGPAOCHICKEN, boy.getFavoriteFood().get( "lunch" ) );
+					assertEquals( FavoriteFood.PIZZA, boy.getFavoriteFood().get( "breakfast" ) );
+					var result = session.createQuery(
 							"select boy from Boy boy join boy.nickNames names where names = :name" )
 							.setParameter( "name", "Thing" ).list();
 					assertEquals( 1, result.size() );
@@ -210,11 +207,11 @@ public class DefaultNamingCollectionElementTest {
 					assertTrue( boy.getNickNames().contains( "Thing" ) );
 					assertNotNull( boy.getScorePerNickName() );
 					assertTrue( boy.getScorePerNickName().containsKey( "Thing" ) );
-					assertEquals( new Integer( 5 ), boy.getScorePerNickName().get( "Thing" ) );
+					assertEquals( Integer.valueOf( 5 ), boy.getScorePerNickName().get( "Thing" ) );
 					assertNotNull( boy.getFavoriteNumbers() );
 					assertEquals( 3, boy.getFavoriteNumbers()[1] );
 					assertTrue( boy.getCharacters().contains( CharacterTrait.CRAFTY ) );
-					List result = session.createQuery(
+					var result = session.createQuery(
 							"select boy from Boy boy join boy.nickNames names where names = :name" )
 							.setParameter( "name", "Thing" ).list();
 					assertEquals( 1, result.size() );
@@ -240,9 +237,8 @@ public class DefaultNamingCollectionElementTest {
 					Filter filter = session.enableFilter( "selectedLocale" );
 					filter.setParameter( "param", "fr" );
 
-					Query q = session.createQuery( "from TestCourse t" );
-					List l = q.list();
-					assertEquals( 1, l.size() );
+					assertEquals( 1,
+							session.createQuery( "from TestCourse t" ).list().size() );
 
 					TestCourse t = session.get( TestCourse.class, test.getTestCourseId() );
 					assertEquals( 1, t.getTitle().getVariations().size() );
@@ -407,8 +403,7 @@ public class DefaultNamingCollectionElementTest {
 		assertEquals( ownerForeignKeyNameExpected, ownerCollection.getKey().getSelectables().get( 0 ).getText() );
 
 		boolean hasOwnerFK = false;
-		for (Iterator it = ownerCollection.getCollectionTable().getForeignKeys().values().iterator(); it.hasNext(); ) {
-			final ForeignKey fk = (ForeignKey) it.next();
+		for ( final ForeignKey fk : ownerCollection.getCollectionTable().getForeignKeyCollection() ) {
 			assertSame( ownerCollection.getCollectionTable(), fk.getTable() );
 			if ( fk.getColumnSpan() > 1 ) {
 				continue;

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/manytomany/defaults/ManyToManyImplicitNamingTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/manytomany/defaults/ManyToManyImplicitNamingTest.java
@@ -4,8 +4,6 @@
  */
 package org.hibernate.orm.test.annotations.manytomany.defaults;
 
-import java.util.Iterator;
-
 import org.hibernate.boot.MetadataBuilder;
 import org.hibernate.boot.model.naming.ImplicitNamingStrategyLegacyJpaImpl;
 import org.hibernate.mapping.ForeignKey;
@@ -200,8 +198,7 @@ public class ManyToManyImplicitNamingTest extends BaseNonConfigCoreFunctionalTes
 		}
 		boolean hasOwnerFK = false;
 		boolean hasInverseFK = false;
-		for (Iterator it = ownerCollection.getCollectionTable().getForeignKeys().values().iterator(); it.hasNext(); ) {
-			final ForeignKey fk = (ForeignKey) it.next();
+		for ( final ForeignKey fk : ownerCollection.getCollectionTable().getForeignKeyCollection() ) {
 			assertSame( ownerCollection.getCollectionTable(), fk.getTable() );
 			if ( fk.getColumnSpan() > 1 ) {
 				continue;
@@ -210,7 +207,7 @@ public class ManyToManyImplicitNamingTest extends BaseNonConfigCoreFunctionalTes
 				assertSame( ownerCollection.getOwner().getTable(), fk.getReferencedTable() );
 				hasOwnerFK = true;
 			}
-			else  if ( fk.getColumn( 0 ).getText().equals( inverseForeignKeyNameExpected ) ) {
+			else if ( fk.getColumn( 0 ).getText().equals( inverseForeignKeyNameExpected ) ) {
 				assertSame( associatedPersistentClass.getTable(), fk.getReferencedTable() );
 				hasInverseFK = true;
 			}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/namingstrategy/LongKeyNamingStrategyTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/namingstrategy/LongKeyNamingStrategyTest.java
@@ -16,7 +16,6 @@ import jakarta.persistence.UniqueConstraint;
 import org.hibernate.boot.Metadata;
 import org.hibernate.boot.MetadataSources;
 import org.hibernate.cfg.Environment;
-import org.hibernate.mapping.UniqueKey;
 import org.hibernate.service.ServiceRegistry;
 
 import org.hibernate.testing.ServiceRegistryBuilder;
@@ -58,14 +57,13 @@ public class LongKeyNamingStrategyTest extends BaseUnitTestCase {
 				.applyImplicitNamingStrategy( new LongIdentifierNamingStrategy() )
 				.build();
 
-		org.hibernate.mapping.ForeignKey foreignKey =
-				(org.hibernate.mapping.ForeignKey) metadata.getEntityBinding(Address.class.getName()).getTable().getForeignKeys().values().iterator().next();
+		var foreignKey = metadata.getEntityBinding(Address.class.getName()).getTable().getForeignKeyCollection().iterator().next();
 		assertEquals( "FK_way_longer_than_the_30_char", foreignKey.getName() );
 
-		UniqueKey uniqueKey = metadata.getEntityBinding(Address.class.getName()).getTable().getUniqueKeys().values().iterator().next();
+		var uniqueKey = metadata.getEntityBinding(Address.class.getName()).getTable().getUniqueKeys().values().iterator().next();
 		assertEquals( "UK_way_longer_than_the_30_char", uniqueKey.getName() );
 
-		org.hibernate.mapping.Index index = metadata.getEntityBinding(Address.class.getName()).getTable().getIndexes().values().iterator().next();
+		var index = metadata.getEntityBinding(Address.class.getName()).getTable().getIndexes().values().iterator().next();
 		assertEquals( "IDX_way_longer_than_the_30_cha", index.getName() );
 	}
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/namingstrategy/charset/AbstractCharsetNamingStrategyTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/namingstrategy/charset/AbstractCharsetNamingStrategyTest.java
@@ -17,7 +17,6 @@ import org.hibernate.boot.MetadataSources;
 import org.hibernate.cfg.AvailableSettings;
 import org.hibernate.cfg.Environment;
 import org.hibernate.internal.util.PropertiesHelper;
-import org.hibernate.mapping.UniqueKey;
 import org.hibernate.service.ServiceRegistry;
 
 import org.hibernate.testing.ServiceRegistryBuilder;
@@ -62,14 +61,13 @@ public abstract class AbstractCharsetNamingStrategyTest extends BaseUnitTestCase
 				.applyImplicitNamingStrategy( new LongIdentifierNamingStrategy() )
 				.build();
 
-		UniqueKey uniqueKey = metadata.getEntityBinding(Address.class.getName()).getTable().getUniqueKeys().values().iterator().next();
+		var uniqueKey = metadata.getEntityBinding(Address.class.getName()).getTable().getUniqueKeys().values().iterator().next();
 		assertEquals( expectedUniqueKeyName(), uniqueKey.getName() );
 
-		org.hibernate.mapping.ForeignKey foreignKey =
-				(org.hibernate.mapping.ForeignKey) metadata.getEntityBinding(Address.class.getName()).getTable().getForeignKeys().values().iterator().next();
+		var foreignKey = metadata.getEntityBinding(Address.class.getName()).getTable().getForeignKeyCollection().iterator().next();
 		assertEquals( expectedForeignKeyName(), foreignKey.getName() );
 
-		org.hibernate.mapping.Index index = metadata.getEntityBinding(Address.class.getName()).getTable().getIndexes().values().iterator().next();
+		var index = metadata.getEntityBinding(Address.class.getName()).getTable().getIndexes().values().iterator().next();
 		assertEquals( expectedIndexName(), index.getName() );
 	}
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/onetoone/OverrideOneToOneJoinColumnTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/onetoone/OverrideOneToOneJoinColumnTest.java
@@ -52,7 +52,7 @@ public class OverrideOneToOneJoinColumnTest {
 
 			final Table personTable = metadata.getDatabase().getDefaultNamespace().locateTable(
 					Identifier.toIdentifier( "PERSON_TABLE" ) );
-			final Collection<ForeignKey> foreignKeys = personTable.getForeignKeys().values();
+			final Collection<ForeignKey> foreignKeys = personTable.getForeignKeyCollection();
 			assertThat( foreignKeys.size(), is( 1 ) );
 			final Optional<ForeignKey> foreignKey = foreignKeys.stream().findFirst();
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/refcolnames/constraints/OneToManyRefColumnNameTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/refcolnames/constraints/OneToManyRefColumnNameTest.java
@@ -1,0 +1,160 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.annotations.refcolnames.constraints;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.RollbackException;
+import org.hibernate.exception.ConstraintViolationException;
+import org.hibernate.testing.orm.junit.EntityManagerFactoryScope;
+import org.hibernate.testing.orm.junit.JiraKey;
+import org.hibernate.testing.orm.junit.Jpa;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.fail;
+
+@Jpa(annotatedClasses = {OneToManyRefColumnNameTest.This.class, OneToManyRefColumnNameTest.That.class})
+@JiraKey("HHH-19480")
+class OneToManyRefColumnNameTest {
+
+	@Test void test(EntityManagerFactoryScope scope) {
+		scope.getEntityManagerFactory().getSchemaManager().truncate();
+		This thisThing = new This();
+		That thatThing = new That();
+		thatThing.compositeKeyOne = 1;
+		thatThing.compositeKeyTwo = 2;
+		thatThing.singleKey = "hello";
+		thatThing.theseOnSingleKey.add( thisThing );
+		thatThing.theseOnCompositeKey.add( thisThing );
+		scope.inTransaction( em -> {
+			em.persist( thatThing );
+			em.persist( thisThing );
+		} );
+		That thing = new That();
+		thing.singleKey = "goodbye";
+		thing.compositeKeyOne = 5;
+		thing.compositeKeyTwo = 3;
+		scope.inTransaction( em -> {
+			em.persist( thing );
+		} );
+	}
+
+	@Test void testForeignKey(EntityManagerFactoryScope scope) {
+		scope.getEntityManagerFactory().getSchemaManager().truncate();
+		This thisThing = new This();
+		That thatThing = new That();
+		thatThing.compositeKeyOne = 1;
+		thatThing.compositeKeyTwo = 2;
+		thatThing.singleKey = "hello";
+		thatThing.theseOnSingleKey.add( thisThing );
+		thatThing.theseOnCompositeKey.add( thisThing );
+		scope.inTransaction( em -> {
+			em.persist( thatThing );
+			em.persist( thisThing );
+		} );
+
+		assertThrows( ConstraintViolationException.class, () ->
+				scope.inTransaction( em -> {
+					em.createQuery( "update OneToManyRefColumnNameTest$That set singleKey = 'goodbye'" ).executeUpdate();
+				} )
+		);
+
+		assertThrows( ConstraintViolationException.class, () ->
+				scope.inTransaction( em -> {
+					em.createQuery( "update OneToManyRefColumnNameTest$That set compositeKeyOne = 69" ).executeUpdate();
+				} )
+		);
+	}
+
+	@Test void testUnique(EntityManagerFactoryScope scope) {
+		scope.getEntityManagerFactory().getSchemaManager().truncate();
+		This thisThing = new This();
+		That thatThing = new That();
+		thatThing.compositeKeyOne = 1;
+		thatThing.compositeKeyTwo = 2;
+		thatThing.singleKey = "hello";
+		thatThing.theseOnSingleKey.add( thisThing );
+		thatThing.theseOnCompositeKey.add( thisThing );
+		scope.inTransaction( em -> {
+			em.persist( thatThing );
+			em.persist( thisThing );
+		} );
+		That thing = new That();
+		try {
+			thing.singleKey = "hello";
+			scope.inTransaction( em -> {
+				em.persist( thing );
+			} );
+			fail();
+		}
+		catch (RollbackException re) {
+			assertInstanceOf( ConstraintViolationException.class, re.getCause() );
+		}
+	}
+
+	@Test void testUniqueKey(EntityManagerFactoryScope scope) {
+		scope.getEntityManagerFactory().getSchemaManager().truncate();
+		This thisThing = new This();
+		That thatThing = new That();
+		thatThing.compositeKeyOne = 1;
+		thatThing.compositeKeyTwo = 2;
+		thatThing.singleKey = "hello";
+		thatThing.theseOnSingleKey.add( thisThing );
+		thatThing.theseOnCompositeKey.add( thisThing );
+		scope.inTransaction( em -> {
+			em.persist( thatThing );
+			em.persist( thisThing );
+		} );
+		That thing = new That();
+		thing.singleKey = "goodbye";
+		thing.compositeKeyOne = 1;
+		thing.compositeKeyTwo = 2;
+		try {
+			scope.inTransaction( em -> {
+				em.persist( thing );
+			} );
+			fail();
+		}
+		catch (RollbackException re) {
+			assertInstanceOf( ConstraintViolationException.class, re.getCause() );
+		}
+	}
+
+	@Entity
+	static class That {
+		@Id @GeneratedValue
+		long id;
+
+		@Column(nullable = false)
+		String singleKey;
+
+		int compositeKeyOne;
+		int compositeKeyTwo;
+
+		@OneToMany
+		@JoinColumn(referencedColumnName = "singleKey")
+		Set<This> theseOnSingleKey = new HashSet<>();
+
+		@OneToMany
+		@JoinColumn(referencedColumnName = "compositeKeyOne")
+		@JoinColumn(referencedColumnName = "compositeKeyTwo")
+		Set<This> theseOnCompositeKey = new HashSet<>();
+	}
+
+	@Entity
+	static class This {
+		@Id @GeneratedValue
+		long id;
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/collection/NonPkCompositeJoinColumnCollectionTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/collection/NonPkCompositeJoinColumnCollectionTest.java
@@ -65,8 +65,8 @@ public class NonPkCompositeJoinColumnCollectionTest {
 					Order order = new Order( "O1" );
 					Item item = new Item( "Item 1" );
 					order.addItem( item );
-					session.persist( item );
 					session.persist( order );
+					session.persist( item );
 				}
 		);
 	}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/collection/NonPkJoinColumnCollectionTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/collection/NonPkJoinColumnCollectionTest.java
@@ -108,8 +108,8 @@ public class NonPkJoinColumnCollectionTest {
 					Order order = new Order( "some_ref" );
 					Item item = new Item( "Abc" );
 					order.addItem( item );
-					session.persist( item );
 					session.persist( order );
+					session.persist( item );
 					session.flush();
 					session.clear();
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/constraint/ConstraintTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/constraint/ConstraintTest.java
@@ -4,7 +4,6 @@
  */
 package org.hibernate.orm.test.constraint;
 
-import java.util.Iterator;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
@@ -69,9 +68,7 @@ public class ConstraintTest extends BaseNonConfigCoreFunctionalTestCase {
 		int foundCount = 0;
 		for ( Namespace namespace : metadata().getDatabase().getNamespaces() ) {
 			for ( org.hibernate.mapping.Table table : namespace.getTables() ) {
-				Iterator fkItr = table.getForeignKeys().values().iterator();
-				while (fkItr.hasNext()) {
-					ForeignKey fk = (ForeignKey) fkItr.next();
+				for ( ForeignKey fk : table.getForeignKeyCollection() ) {
 					assertTrue( fk.getName().length() <= MAX_NAME_LENGTH );
 
 					// ensure the randomly generated constraint name doesn't
@@ -79,17 +76,15 @@ public class ConstraintTest extends BaseNonConfigCoreFunctionalTestCase {
 					Column column = fk.getColumn( 0 );
 					if ( column.getName().equals( "explicit_native" ) ) {
 						foundCount++;
-						assertEquals( fk.getName(), EXPLICIT_FK_NAME_NATIVE );
+						assertEquals( EXPLICIT_FK_NAME_NATIVE, fk.getName() );
 					}
 					else if ( column.getName().equals( "explicit_jpa" ) ) {
 						foundCount++;
-						assertEquals( fk.getName(), EXPLICIT_FK_NAME_JPA );
+						assertEquals( EXPLICIT_FK_NAME_JPA, fk.getName() );
 					}
 				}
 
-				Iterator ukItr = table.getUniqueKeys().values().iterator();
-				while (ukItr.hasNext()) {
-					UniqueKey uk = (UniqueKey) ukItr.next();
+				for ( UniqueKey uk : table.getUniqueKeys().values() ) {
 					assertTrue( uk.getName().length() <= MAX_NAME_LENGTH );
 
 					// ensure the randomly generated constraint name doesn't
@@ -97,7 +92,7 @@ public class ConstraintTest extends BaseNonConfigCoreFunctionalTestCase {
 					Column column = uk.getColumn( 0 );
 					if ( column.getName().equals( "explicit" ) ) {
 						foundCount++;
-						assertEquals( uk.getName(), EXPLICIT_UK_NAME );
+						assertEquals( EXPLICIT_UK_NAME, uk.getName() );
 					}
 				}
 			}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/constraint/ForeignKeyConstraintMapsIdTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/constraint/ForeignKeyConstraintMapsIdTest.java
@@ -4,7 +4,6 @@
  */
 package org.hibernate.orm.test.constraint;
 
-import java.util.Iterator;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.ForeignKey;
@@ -88,9 +87,7 @@ public class ForeignKeyConstraintMapsIdTest extends BaseNonConfigCoreFunctionalT
 		for ( Namespace namespace : metadata().getDatabase().getNamespaces() ) {
 			for ( Table table : namespace.getTables() ) {
 				if ( table.getName().equals( "Post" ) ) {
-					Iterator<org.hibernate.mapping.ForeignKey> foreignKeyIterator = table.getForeignKeys().values().iterator();
-					while ( foreignKeyIterator.hasNext() ) {
-						org.hibernate.mapping.ForeignKey foreignKey = foreignKeyIterator.next();
+					for ( var foreignKey : table.getForeignKeyCollection() ) {
 						if ( foreignKey.getColumn( 0 ).getName().equals( "PD_ID" ) ) {
 							assertEquals( "FK_PD", foreignKey.getName() );
 							return;

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/constraint/ForeignKeyNoConstraintTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/constraint/ForeignKeyNoConstraintTest.java
@@ -43,7 +43,7 @@ public class ForeignKeyNoConstraintTest extends BaseNonConfigCoreFunctionalTestC
 		for ( Namespace namespace : metadata().getDatabase().getNamespaces() ) {
 			for ( Table table : namespace.getTables() ) {
 				if ( "Car".equals( table.getName() ) ) {
-					assertEquals( 0, table.getForeignKeys().size() );
+					assertEquals( 0, table.getForeignKeyCollection().size() );
 				}
 			}
 		}
@@ -55,7 +55,7 @@ public class ForeignKeyNoConstraintTest extends BaseNonConfigCoreFunctionalTestC
 		for ( Namespace namespace : metadata().getDatabase().getNamespaces() ) {
 			for ( Table table : namespace.getTables() ) {
 				if ( "Post".equals( table.getName() ) ) {
-					assertEquals( 0, table.getForeignKeys().size() );
+					assertEquals( 0, table.getForeignKeyCollection().size() );
 				}
 			}
 		}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/constraint/NonRootTablePolymorphicTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/constraint/NonRootTablePolymorphicTests.java
@@ -94,8 +94,8 @@ public class NonRootTablePolymorphicTests {
 							//		1) for the sub->root inheritance fk
 							//		2) for the sub->child fk
 
-							assertThat( subclassTable.getForeignKeys().size(), is( 2 ) );
-							subclassTable.getForeignKeys().values().iterator().forEachRemaining(
+							assertThat( subclassTable.getForeignKeyCollection().size(), is( 2 ) );
+							subclassTable.getForeignKeyCollection().iterator().forEachRemaining(
 									(foreignKey) -> {
 										assertThat( foreignKey.getTable(), sameInstance( subclassTable ) );
 
@@ -159,8 +159,8 @@ public class NonRootTablePolymorphicTests {
 					final Selectable selectable = toOne.getSelectables().get( 0 );
 					assertThat( selectable.getText(), is( "parent_sub_fk" ) );
 
-					assertThat( subParent.getTable().getForeignKeys().size(), is( 1 ) );
-					final ForeignKey foreignKey = subParent.getTable().getForeignKeys().values().iterator().next();
+					assertThat( subParent.getTable().getForeignKeyCollection().size(), is( 1 ) );
+					final ForeignKey foreignKey = subParent.getTable().getForeignKeyCollection().iterator().next();
 
 					assertThat( foreignKey.getReferencedTable().getName(), is( "sub" ) );
 					assertThat( foreignKey.getTable(), sameInstance( toOne.getTable() ) );

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/dialect/PostgreSQLDialectTestCase.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/dialect/PostgreSQLDialectTestCase.java
@@ -143,9 +143,8 @@ public class PostgreSQLDialectTestCase extends BaseUnitTestCase {
 		PostgreSQLDialect dialect = new PostgreSQLDialect();
 		AlterTableUniqueDelegate alterTable = new AlterTableUniqueDelegate( dialect );
 		final Table table = new Table( "orm", "table_name" );
-		final UniqueKey uniqueKey = new UniqueKey();
+		final UniqueKey uniqueKey = new UniqueKey( table );
 		uniqueKey.setName( "unique_something" );
-		uniqueKey.setTable( table );
 		final String sql = alterTable.getAlterTableToDropUniqueKeyCommand(
 				uniqueKey,
 				null,

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/foreignkeys/HHH14230.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/foreignkeys/HHH14230.java
@@ -41,7 +41,7 @@ public class HHH14230 {
 					.flatMap( namespace -> namespace.getTables().stream() )
 					.filter( t -> t.getName().equals( TABLE_NAME ) ).findFirst().orElse( null );
 			assertNotNull( table );
-			assertEquals( 1, table.getForeignKeys().size() );
+			assertEquals( 1, table.getForeignKeyCollection().size() );
 
 			// ClassCastException before HHH-14230
 			assertTrue( table.getForeignKeys().keySet().iterator().next().toString().contains( JOIN_COLUMN_NAME ) );

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/foreignkeys/disabled/DefaultConstraintModeTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/foreignkeys/disabled/DefaultConstraintModeTest.java
@@ -52,8 +52,8 @@ public class DefaultConstraintModeTest extends BaseUnitTestCase {
 				.applySetting( Environment.HBM2DDL_DEFAULT_CONSTRAINT_MODE, created ? "CONSTRAINT" : "NO_CONSTRAINT" )
 				.build()) {
 			Metadata metadata = new MetadataSources( ssr ).addAnnotatedClasses( TestEntity.class, ChildEntity.class ).buildMetadata();
-			assertThat( findTable( metadata, "TestEntity" ).getForeignKeys().isEmpty(), is( !created ) );
-			assertThat( findTable( metadata, "ChildEntity" ).getForeignKeys().isEmpty(), is( !created ) );
+			assertThat( findTable( metadata, "TestEntity" ).getForeignKeyCollection().isEmpty(), is( !created ) );
+			assertThat( findTable( metadata, "ChildEntity" ).getForeignKeyCollection().isEmpty(), is( !created ) );
 		}
 	}
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/foreignkeys/disabled/DisabledForeignKeyTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/foreignkeys/disabled/DisabledForeignKeyTest.java
@@ -5,15 +5,12 @@
 package org.hibernate.orm.test.foreignkeys.disabled;
 
 import java.util.EnumSet;
-import java.util.Map;
 
 import org.hibernate.boot.MetadataSources;
 import org.hibernate.boot.registry.StandardServiceRegistry;
 import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
 import org.hibernate.boot.spi.MetadataImplementor;
-import org.hibernate.mapping.ForeignKey;
 import org.hibernate.mapping.Table;
-import org.hibernate.mapping.Table.ForeignKeyKey;
 import org.hibernate.tool.hbm2ddl.SchemaExport;
 import org.hibernate.tool.hbm2ddl.SchemaUpdate;
 import org.hibernate.tool.schema.TargetType;
@@ -53,7 +50,7 @@ public class DisabledForeignKeyTest extends BaseUnitTestCase {
 
 			int fkCount = 0;
 			for ( Table table : metadata.collectTableMappings() ) {
-				for ( Map.Entry<ForeignKeyKey, ForeignKey> entry : table.getForeignKeys().entrySet() ) {
+				for ( var entry : table.getForeignKeys().entrySet() ) {
 					assertFalse(
 							"Creation for ForeignKey [" + entry.getKey() + "] was not disabled",
 							entry.getValue().isCreationEnabled()

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/foreignkeys/disabled/OneToManyBidirectionalForeignKeyTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/foreignkeys/disabled/OneToManyBidirectionalForeignKeyTest.java
@@ -47,8 +47,8 @@ public class OneToManyBidirectionalForeignKeyTest {
 			Metadata metadata = new MetadataSources( serviceRegistry )
 					.addAnnotatedClass( PlainTreeEntity.class ).addAnnotatedClass( TreeEntityWithOnDelete.class )
 					.buildMetadata();
-			assertTrue( findTable( metadata, TABLE_NAME_PLAIN ).getForeignKeys().isEmpty() );
-			assertFalse( findTable( metadata, TABLE_NAME_WITH_ON_DELETE ).getForeignKeys().isEmpty() );
+			assertTrue( findTable( metadata, TABLE_NAME_PLAIN ).getForeignKeyCollection().isEmpty() );
+			assertFalse( findTable( metadata, TABLE_NAME_WITH_ON_DELETE ).getForeignKeyCollection().isEmpty() );
 		}
 	}
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/namingstrategy/FullyQualifiedEntityNameNamingStrategyTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/namingstrategy/FullyQualifiedEntityNameNamingStrategyTest.java
@@ -4,8 +4,6 @@
  */
 package org.hibernate.orm.test.namingstrategy;
 
-import java.util.Iterator;
-
 import org.hibernate.boot.MetadataSources;
 import org.hibernate.boot.model.naming.EntityNaming;
 import org.hibernate.boot.model.naming.Identifier;
@@ -92,8 +90,8 @@ public class FullyQualifiedEntityNameNamingStrategyTest {
 
 		boolean ownerFKFound = false;
 		boolean inverseFKFound = false;
-		for (Iterator it = ownerCollectionMapping.getCollectionTable().getForeignKeys().values().iterator(); it.hasNext(); ) {
-			final String fkColumnName = ( (ForeignKey) it.next() ).getColumn( 0 ).getName();
+		for ( ForeignKey foreignKey : ownerCollectionMapping.getCollectionTable().getForeignKeyCollection() ) {
+			final String fkColumnName = foreignKey.getColumn( 0 ).getName();
 			if ( expectedOwnerFK.equals( fkColumnName ) ) {
 				ownerFKFound = true;
 			}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/propertyref/basic/PropertyRefTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/propertyref/basic/PropertyRefTest.java
@@ -4,8 +4,6 @@
  */
 package org.hibernate.orm.test.propertyref.basic;
 
-import java.util.Iterator;
-import java.util.List;
 import jakarta.persistence.criteria.CriteriaBuilder;
 import jakarta.persistence.criteria.CriteriaQuery;
 
@@ -73,10 +71,9 @@ public class PropertyRefTest {
 
 		scope.inTransaction(
 				session -> {
-					List results = session.createQuery( "from Person" ).list();
-					Iterator itr = results.iterator();
-					while ( itr.hasNext() ) {
-						session.remove( itr.next() );
+					var results = session.createQuery( "from Person" ).list();
+					for ( Object result : results ) {
+						session.remove( result );
 					}
 				}
 		);
@@ -150,7 +147,7 @@ public class PropertyRefTest {
 					p2 = session.get( Person.class, p2.getId() ); //get null address reference by outer join
 					assertNull( p2.getAddress() );
 					assertNotNull( p.getAddress() );
-					List l = session.createQuery( "from Person" ).list(); //pull address references for cache
+					var l = session.createQuery( "from Person" ).list(); //pull address references for cache
 					assertEquals( 2, l.size() );
 					assertTrue( l.contains( p ) && l.contains( p2 ) );
 					session.clear();
@@ -267,15 +264,15 @@ public class PropertyRefTest {
 	public void testForeignKeyCreation(SessionFactoryScope scope) {
 		PersistentClass classMapping = scope.getMetadataImplementor().getEntityBinding( Account.class.getName() );
 
-		Iterator foreignKeyIterator = classMapping.getTable().getForeignKeys().values().iterator();
+		var foreignKeyIterator = classMapping.getTable().getForeignKeyCollection().iterator();
 		boolean found = false;
 		while ( foreignKeyIterator.hasNext() ) {
-			ForeignKey element = (ForeignKey) foreignKeyIterator.next();
+			final ForeignKey element = foreignKeyIterator.next();
 			if ( element.getReferencedEntityName().equals( Person.class.getName() ) ) {
 
 				if ( !element.isReferenceToPrimaryKey() ) {
-					List referencedColumns = element.getReferencedColumns();
-					Column column = (Column) referencedColumns.get( 0 );
+					var referencedColumns = element.getReferencedColumns();
+					Column column = referencedColumns.get( 0 );
 					if ( column.getName().equals( "person_userid" ) ) {
 						found = true; // extend test to include the columns
 					}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/schemaupdate/ExportIdentifierTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/schemaupdate/ExportIdentifierTest.java
@@ -88,9 +88,8 @@ public class ExportIdentifierTest extends BaseUnitTestCase {
 			final Table table = new Table( "orm", namespace, Identifier.toIdentifier( name ), false );
 			addExportIdentifier( table, exportIdentifierList, exportIdentifierSet );
 
-			final ForeignKey foreignKey = new ForeignKey();
+			final ForeignKey foreignKey = new ForeignKey( table );
 			foreignKey.setName( name );
-			foreignKey.setTable( table );
 			addExportIdentifier( foreignKey, exportIdentifierList, exportIdentifierSet );
 
 			final Index index = new Index();
@@ -102,9 +101,8 @@ public class ExportIdentifierTest extends BaseUnitTestCase {
 			primaryKey.setName( name );
 			addExportIdentifier( primaryKey, exportIdentifierList, exportIdentifierSet );
 
-			final UniqueKey uniqueKey = new UniqueKey();
+			final UniqueKey uniqueKey = new UniqueKey( table );
 			uniqueKey.setName( name );
-			uniqueKey.setTable( table );
 			addExportIdentifier( uniqueKey, exportIdentifierList, exportIdentifierSet );
 		}
 	}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/tool/schema/internal/StandardForeignKeyExporterTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/tool/schema/internal/StandardForeignKeyExporterTest.java
@@ -4,7 +4,6 @@
  */
 package org.hibernate.orm.test.tool.schema.internal;
 
-import java.util.Collection;
 import java.util.Optional;
 
 import org.hibernate.boot.MetadataSources;

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/tool/schema/internal/StandardForeignKeyExporterTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/tool/schema/internal/StandardForeignKeyExporterTest.java
@@ -51,8 +51,8 @@ public class StandardForeignKeyExporterTest {
 			SqlStringGenerationContext sqlStringGenerationContext =
 					SqlStringGenerationContextImpl.forTests( database.getJdbcEnvironment() );
 
-			Collection<ForeignKey>  fks = database.getDefaultNamespace().locateTable( Identifier.toIdentifier( "PERSON" ) ).getForeignKeys().values();
-			assertEquals( fks.size(), 1 );
+			var fks = database.getDefaultNamespace().locateTable( Identifier.toIdentifier( "PERSON" ) ).getForeignKeyCollection();
+			assertEquals( 1, fks.size() );
 			final Optional<ForeignKey> foreignKey = fks.stream().findFirst();
 
 			final String[] sqlCreateStrings = new H2Dialect().getForeignKeyExporter().getSqlCreateStrings(
@@ -60,8 +60,10 @@ public class StandardForeignKeyExporterTest {
 					bootModel,
 					sqlStringGenerationContext
 			);
-			assertEquals( sqlCreateStrings.length, 1 );
-			assertEquals( sqlCreateStrings[0], "alter table if exists PERSON add constraint fk_firstLastName foreign key (pkFirstName, pkLastName) references PERSON" );
+			assertEquals( 1, sqlCreateStrings.length );
+			assertEquals(
+					"alter table if exists PERSON add constraint fk_firstLastName foreign key (pkFirstName, pkLastName) references PERSON",
+					sqlCreateStrings[0] );
 		}
 	}
 

--- a/hibernate-envers/src/test/java/org/hibernate/orm/test/envers/integration/manytoone/EmbeddedIdManyToOneForeignKeyTest.java
+++ b/hibernate-envers/src/test/java/org/hibernate/orm/test/envers/integration/manytoone/EmbeddedIdManyToOneForeignKeyTest.java
@@ -44,7 +44,7 @@ public class EmbeddedIdManyToOneForeignKeyTest extends BaseEnversJPAFunctionalTe
 		// there should only be references to REVINFO and not to the Customer or Address tables
 		for ( Table table : metadata().getDatabase().getDefaultNamespace().getTables() ) {
 			if ( table.getName().equals( "CustomerAddress_AUD" ) ) {
-				for ( org.hibernate.mapping.ForeignKey foreignKey : table.getForeignKeys().values() ) {
+				for ( var foreignKey : table.getForeignKeyCollection() ) {
 					assertEquals( "REVINFO", foreignKey.getReferencedTable().getName() );
 				}
 			}


### PR DESCRIPTION
<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

[Please describe here what your change is about]

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-19480
<!-- Hibernate GitHub Bot issue links end -->