### PR TITLE
add additional test for findMultiple() with second-level cache

### DIFF
--- a/hibernate-core/src/test/java/org/hibernate/orm/test/loading/multiLoad/FindMultipleFromCacheTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/loading/multiLoad/FindMultipleFromCacheTest.java
@@ -2,11 +2,12 @@
  * SPDX-License-Identifier: Apache-2.0
  * Copyright Red Hat Inc. and Hibernate Authors
  */
-package org.hibernate.orm.test.stateless;
+package org.hibernate.orm.test.loading.multiLoad;
 
 import jakarta.persistence.Cacheable;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
+import org.hibernate.LockMode;
 import org.hibernate.testing.orm.junit.DomainModel;
 import org.hibernate.testing.orm.junit.SessionFactory;
 import org.hibernate.testing.orm.junit.SessionFactoryScope;
@@ -18,26 +19,34 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
 @SessionFactory(generateStatistics = true)
-@DomainModel(annotatedClasses = GetMultipleFromCacheTest.Record.class)
-public class GetMultipleFromCacheTest {
+@DomainModel(annotatedClasses = FindMultipleFromCacheTest.Record.class)
+public class FindMultipleFromCacheTest {
 	@Test void test(SessionFactoryScope scope) {
 		scope.inStatelessTransaction(s-> {
 			s.insert(new Record(123L,"hello earth"));
 			s.insert(new Record(456L,"hello mars"));
 		});
-		scope.inStatelessTransaction(s-> {
-			List<Record> all = s.getMultiple(Record.class, List.of(456L, 123L, 2L));
-			assertEquals("hello mars",all.get(0).message);
-			assertEquals("hello earth",all.get(1).message);
+		scope.inTransaction(s-> {
+			List<Record> all = s.findMultiple(Record.class, List.of(456L, 123L, 2L));
+			Record mars = all.get( 0 );
+			Record earth = all.get( 1 );
+			assertEquals( LockMode.READ, s.getCurrentLockMode( mars ) );
+			assertEquals( LockMode.READ, s.getCurrentLockMode( earth ) );
+			assertEquals("hello mars", mars.message);
+			assertEquals("hello earth", earth.message);
 			assertNull(all.get(2));
 		});
 		assertEquals( 0,
 				scope.getSessionFactory().getStatistics().getSecondLevelCacheHitCount() );
 		scope.getSessionFactory().getStatistics().clear();
-		scope.inStatelessTransaction(s-> {
-			List<Record> all = s.getMultiple(Record.class, List.of(123L, 2L, 456L));
-			assertEquals("hello earth",all.get(0).message);
-			assertEquals("hello mars",all.get(2).message);
+		scope.inTransaction(s-> {
+			List<Record> all = s.findMultiple(Record.class, List.of(123L, 2L, 456L));
+			Record earth = all.get( 0 );
+			Record mars = all.get( 2 );
+			assertEquals( LockMode.NONE, s.getCurrentLockMode( mars ) );
+			assertEquals( LockMode.NONE, s.getCurrentLockMode( earth ) );
+			assertEquals("hello earth", earth.message);
+			assertEquals("hello mars", mars.message);
 			assertNull(all.get(1));
 		});
 		assertEquals( 2,


### PR DESCRIPTION
<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

[Please describe here what your change is about]

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
