### PR TITLE
Remove reduntant LOG.isTraceEnabled() from logDirtyProperties

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/event/internal/DefaultFlushEntityEventListener.java
+++ b/hibernate-core/src/main/java/org/hibernate/event/internal/DefaultFlushEntityEventListener.java
@@ -663,10 +663,8 @@ public class DefaultFlushEntityEventListener implements FlushEntityEventListener
 			for ( int i = 0; i < dirtyProperties.length; i++ ) {
 				dirtyPropertyNames[i] = allPropertyNames[dirtyProperties[i]];
 			}
-			if ( LOG.isTraceEnabled() ) {
-				LOG.trace( "Found dirty properties [" + infoString( persister.getEntityName(), entry.getId() )
-							+ "] : "+ Arrays.toString( dirtyPropertyNames ) );
-			}
+			LOG.trace( "Found dirty properties [" + infoString( persister.getEntityName(), entry.getId() )
+						+ "] : "+ Arrays.toString( dirtyPropertyNames ) );
 		}
 	}
 


### PR DESCRIPTION
Remove reduntant LOG.isTraceEnabled() from logDirtyProperties

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
