### PR TITLE
HHH-18885 Introduce DelayedOperation.getAddedEntry() for maps

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/collection/spi/AbstractPersistentCollection.java
+++ b/hibernate-core/src/main/java/org/hibernate/collection/spi/AbstractPersistentCollection.java
@@ -867,14 +867,14 @@ public abstract class AbstractPersistentCollection<E> implements Serializable, P
 	}
 
 	@Override
-	public final Iterator<E> queuedAdditionIterator() {
+	public final Iterator<?> queuedAdditionIterator() {
 		if ( hasQueuedOperations() ) {
 			return new Iterator<>() {
 				private int index;
 
 				@Override
-				public E next() {
-					return operationQueue.get( index++ ).getAddedInstance();
+				public Object next() {
+					return operationQueue.get( index++ ).getAddedEntry();
 				}
 
 				@Override
@@ -1248,6 +1248,10 @@ public abstract class AbstractPersistentCollection<E> implements Serializable, P
 		void operate();
 
 		E getAddedInstance();
+
+		default Object getAddedEntry() {
+			return getAddedInstance();
+		}
 
 		E getOrphan();
 	}

--- a/hibernate-core/src/main/java/org/hibernate/collection/spi/PersistentCollection.java
+++ b/hibernate-core/src/main/java/org/hibernate/collection/spi/PersistentCollection.java
@@ -399,7 +399,7 @@ public interface PersistentCollection<E> extends LazyInitializable, InstanceIden
 	 *
 	 * @return The iterator
 	 */
-	Iterator<E> queuedAdditionIterator();
+	Iterator<?> queuedAdditionIterator();
 
 	/**
 	 * Get the "queued" orphans

--- a/hibernate-core/src/main/java/org/hibernate/collection/spi/PersistentMap.java
+++ b/hibernate-core/src/main/java/org/hibernate/collection/spi/PersistentMap.java
@@ -539,6 +539,11 @@ public class PersistentMap<K,E> extends AbstractPersistentCollection<E> implemen
 		protected final K getIndex() {
 			return index;
 		}
+
+		@Override
+		public Object getAddedEntry() {
+			return Map.entry( getIndex(), getAddedInstance() );
+		}
 	}
 
 	final class Put extends AbstractMapValueDelayedOperation {


### PR DESCRIPTION
Same as https://github.com/hibernate/hibernate-orm/pull/9331 minus the unit test (because extra lazy maps are gone in Hibernate 7), to keep branches aligned

----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-18885
<!-- Hibernate GitHub Bot issue links end -->