### PR TITLE
HHH-19496 Use Javadoc styles from hibernate-asciidoctor-theme

### DIFF
--- a/documentation/documentation.gradle
+++ b/documentation/documentation.gradle
@@ -215,10 +215,10 @@ def aggregateJavadocsTask = tasks.register( "javadoc", Javadoc ) {
 				? javadocTool.get().metadata.languageVersion
 				: JavaLanguageVersion.of( JavaVersion.current().name )
 
-		if ( javaLanguageVersion.asInt() > 11 ) {
-			println "Aggregated Javadocs are bing built` using a JDK newer than version 11: \n" +
-							"\t* `stylesheet.css` will not be compatible\n" +
-							"\t* generating the User Guide settings fragment will not succeed"
+		if ( javaLanguageVersion.asInt() != 21 ) {
+			println "Aggregated Javadocs are bing built` using a JDK different than version 21: \n" +
+					"\t* `stylesheet.css` might not be compatible\n" +
+					"\t* generating the User Guide settings fragment might not succeed"
 		}
 	}
 }

--- a/local-build-plugins/src/main/groovy/local.javadoc.gradle
+++ b/local-build-plugins/src/main/groovy/local.javadoc.gradle
@@ -6,6 +6,28 @@ plugins {
     id "local.module"
 }
 
+configurations {
+    themezip
+}
+
+dependencies {
+    themezip 'org.hibernate.infra:hibernate-asciidoctor-theme:5.1.1.Final@zip'
+}
+
+tasks.register('unpackTheme', Copy) {
+    def unpackDir = rootProject.layout.buildDirectory.dir("unpacked-theme")
+
+    onlyIf {
+        !unpackDir.get().asFile.exists()
+    }
+    destinationDir = unpackDir.get().asFile
+
+    def zipFile = configurations.themezip.singleFile
+    from zipTree(zipFile)
+
+    dependsOn configurations.themezip
+}
+
 tasks.withType(Javadoc).configureEach {
     def currentYear = new GregorianCalendar().get( Calendar.YEAR )
 
@@ -21,7 +43,9 @@ tasks.withType(Javadoc).configureEach {
     configure( options ) {
         windowTitle = "Hibernate Javadocs ($project.name)"
         docTitle = "Hibernate Javadocs ($project.name : $project.version)"
-        stylesheetFile = rootProject.file( "shared/javadoc/stylesheet.css" )
+        // Pick the styles for the JDK that is used to "build" the Javadocs:
+        stylesheetFile = rootProject.layout.buildDirectory.dir("unpacked-theme").get()
+                .dir("hibernate-asciidoctor-theme").dir("javadoc").dir("jdk21").file("stylesheet.css").asFile
         bottom = "Copyright &copy; 2001-$currentYear <a href=\"https://redhat.com\">Red Hat, Inc.</a>  All Rights Reserved."
 
         // The javadoc folder contains cached versions of the respective element-list files to avoid release issues when servers are down
@@ -47,4 +71,5 @@ tasks.withType(Javadoc).configureEach {
 
         addBooleanOption('Xdoclint:none', true)
     }
+    dependsOn tasks.unpackTheme
 }


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-19496

I didn't use the version catalog for this dependency as it requires a zip classifier and I have no idea how to set it there 🙈😕 
Also applied the JDK17 theme as that's what I see is used in Jenkins files to build ORM.

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
