### PR TITLE
HHH-18876 ArrayIndexOutOfBoundsException in ArrayInitializer with ListIndexBase

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/ArrayInitializer.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/collection/internal/ArrayInitializer.java
@@ -130,10 +130,13 @@ public class ArrayInitializer extends AbstractImmediateCollectionInitializer<Abs
 		final Initializer<?> initializer = elementAssembler.getInitializer();
 		if ( initializer != null ) {
 			final RowProcessingState rowProcessingState = data.getRowProcessingState();
-			final Integer index = listIndexAssembler.assemble( rowProcessingState );
+			Integer index = listIndexAssembler.assemble( rowProcessingState );
 			if ( index != null ) {
 				final PersistentArrayHolder<?> arrayHolder = getCollectionInstance( data );
 				assert arrayHolder != null;
+				if ( indexBase != 0 ) {
+					index -= indexBase;
+				}
 				initializer.resolveInstance( Array.get( arrayHolder.getArray(), index ), rowProcessingState );
 			}
 		}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/collections/OrderColumnListIndexArrayInitializerTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/collections/OrderColumnListIndexArrayInitializerTest.java
@@ -1,0 +1,110 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.mapping.collections;
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.JoinTable;
+import jakarta.persistence.ManyToMany;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.OrderColumn;
+import org.hibernate.annotations.ListIndexBase;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.JiraKey;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.junit.jupiter.api.Test;
+
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+@JiraKey("HHH-18876")
+@DomainModel(
+		annotatedClasses = {
+				OrderColumnListIndexArrayInitializerTest.Person.class,
+				OrderColumnListIndexArrayInitializerTest.Phone.class,
+		}
+)
+@SessionFactory
+class OrderColumnListIndexArrayInitializerTest {
+
+	@Test
+	void hhh18876Test(SessionFactoryScope scope) {
+
+		// prepare data
+		scope.inTransaction( session -> {
+
+			// person
+			Person person = new Person();
+			person.id = 1L;
+			session.persist( person );
+
+			// add phone
+			Phone phone = new Phone();
+			phone.id = 1L;
+			phone.person = person;
+
+			person.phones = new Phone[1];
+			person.phones[0] = phone;
+
+			// add children
+			Person children = new Person();
+			children.id = 2L;
+			children.mother = person;
+
+			person.children = new Person[1];
+			person.children[0] = children;
+		} );
+
+		// load and assert
+		scope.inTransaction( session -> {
+			Person person = session.createSelectionQuery( "select p from Person p where id=1", Person.class )
+					.getSingleResult();
+			assertNotNull( person );
+			assertEquals( 1, person.phones.length );
+			assertNotNull( person.phones[0] );
+			assertEquals( 1, person.children.length );
+			assertEquals( person, person.children[0].mother );
+		} );
+	}
+
+	@Entity(name = "Person")
+	public static class Person {
+
+		@Id
+		Long id;
+
+		@OneToMany(fetch = FetchType.EAGER, mappedBy = "person", cascade = CascadeType.ALL)
+		@OrderColumn(name = "order_id")
+		@ListIndexBase(100)
+		Phone[] phones;
+
+		@ManyToMany(fetch = FetchType.EAGER, cascade = CascadeType.ALL)
+		@JoinTable(name = "parent_child_relationships", joinColumns = @JoinColumn(name = "parent_id"),
+				inverseJoinColumns = @JoinColumn(name = "child_id"))
+		@OrderColumn(name = "pos")
+		@ListIndexBase(200)
+		Person[] children;
+
+		@ManyToOne
+		@JoinColumn(name = "mother_id")
+		Person mother;
+	}
+
+	@Entity(name = "Phone")
+	public static class Phone {
+
+		@Id
+		Long id;
+
+		@ManyToOne
+		Person person;
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/collections/OrderColumnListIndexHHH18771ListInitializerTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/collections/OrderColumnListIndexHHH18771ListInitializerTest.java
@@ -26,6 +26,8 @@ import jakarta.persistence.OneToMany;
 import jakarta.persistence.OrderColumn;
 
 import static org.hibernate.testing.transaction.TransactionUtil.doInJPA;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 /**
  * @author Selaron
@@ -50,7 +52,12 @@ public class OrderColumnListIndexHHH18771ListInitializerTest extends BaseEntityM
 			person.getChildren().get( 0 ).setMother( person );
 		} );
 		doInJPA( this::entityManagerFactory, entityManager -> {
-			entityManager.find( Person.class, 1L );
+			Person person = entityManager.find( Person.class, 1L );
+			assertNotNull( person );
+			assertEquals( 1, person.getPhones().size() );
+			assertNotNull( person.getPhones().get( 0 ) );
+			assertEquals( 1, person.getChildren().size() );
+			assertEquals( person, person.getChildren().get( 0 ).getMother() );
 		} );
 	}
 


### PR DESCRIPTION
HHH-18876 is a follow up to HHH-18771 and describes a possible `ArrayIndexOutOfBoundsException` in the `ArrayInitializer` when using `@ListIndexBase`.
The pull request consists of a reproducer test and a fix in `ArrayInitializer` equivalent to the fix in `ListInitializer` of HHH-18771.
The provided test is based on OrderColumnListIndexHHH18771ListInitializerTest.

https://hibernate.atlassian.net/browse/HHH-18876
https://hibernate.atlassian.net/browse/HHH-18771
PR of HHH-18771: https://github.com/hibernate/hibernate-orm/pull/9169

----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
