### PR TITLE
HHH-19504 : Javadoc error SecondaryRow#owned

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/annotations/SecondaryRow.java
+++ b/hibernate-core/src/main/java/org/hibernate/annotations/SecondaryRow.java
@@ -30,7 +30,7 @@ public @interface SecondaryRow {
 	String table() default "";
 
 	/**
-	 * If enabled, Hibernate will never insert or update the columns of the secondary table.
+	 * If disabled, Hibernate will never insert or update the columns of the secondary table.
 	 * <p>
 	 * This setting is useful if data in the secondary table belongs to some other entity,
 	 * or if it is maintained externally to Hibernate.


### PR DESCRIPTION
 Javadoc error SecondaryRow#owned

If enabled → If disabled.

https://hibernate.atlassian.net/browse/HHH-19504
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
