### PR TITLE
[DO NOT MERGE] Test run with Quarkus defaults

### DIFF
--- a/hibernate-core/src/test/resources/hibernate.properties
+++ b/hibernate-core/src/test/resources/hibernate.properties
@@ -29,3 +29,19 @@ hibernate.session.events.log=true
 hibernate.query.mutation_strategy.global_temporary.drop_tables=true
 
 #hibernate.transform_hbm_xml.enabled=true
+
+# Quarkus defaults
+
+# > From test case templates
+hibernate.id.optimizer.pooled.preferred = pooled-lo"
+hibernate.default_batch_fetch_size = 16
+hibernate.query.plan_cache_max_size = 2048
+hibernate.order_by.default_null_ordering = none
+hibernate.query.in_clause_parameter_padding = true
+hibernate.id.sequence.increment_size_mismatch_strategy = none
+hibernate.order_updates = true
+
+# > Found throughout the Quarkus codebase
+hibernate.transaction.flush_before_completion = false
+hibernate.cdi.extensions = false
+hibernate.connection.handling_mode = DELAYED_ACQUISITION_AND_RELEASE_BEFORE_TRANSACTION_COMPLETION


### PR DESCRIPTION
Following a discussion with the team today, to
see how much work it would be to run the whole test suite with different default settings.

cc @sebersole @gavinking 


<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
