### PR TITLE
HHH-19446 HHH-18633 `hibernate-scan-jandex` migration guide

### DIFF
--- a/migration-guide.adoc
+++ b/migration-guide.adoc
@@ -627,6 +627,13 @@ specify a name for JNDI binding.  The new behavior is as follows (assuming `hibe
 Hibernate can use the persistence-unit name for binding into JNDI as well, but `hibernate.session_factory_name_is_jndi`
 must be explicitly set to true.
 
+[[jandex-scanning]]
+=== Entity Discovery
+
+Entity discovery, i.e. automatic detection of mapped Java classes through classpath scanning, now requires by default the new `hibernate-scan-jandex` module. Standalone Hibernate ORM applications relying on this feature will need to add a dependency to this new module in order to continue using it.
+
+Users can still provide custom `org.hibernate.Scanner` implementations via the `org.hibernate.boot.archive.scan.spi.ScannerFactory` service or the `hibernate.archive.scanner` configuration parameter.
+
 [[unowned-order-column]]
 === @OrderColumn in Unowned @OneToMany Associations
 


### PR DESCRIPTION
<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

Add migration guide notice for `hibernate-scan-jandex`.

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-18633
https://hibernate.atlassian.net/browse/HHH-19446
<!-- Hibernate GitHub Bot issue links end -->