### PR TITLE
HHH-19522 upsert should not fail silently instead of throwing StaleObjectStateException

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/jdbc/Expectation.java
+++ b/hibernate-core/src/main/java/org/hibernate/jdbc/Expectation.java
@@ -181,7 +181,7 @@ public interface Expectation {
 
 	/**
 	 * Essentially identical to {@link RowCount} except that the row count
-	 * is obtained via an output parameter of a {@link CallableStatement
+	 * is obtained via an output parameter of a {@linkplain CallableStatement
 	 * stored procedure}.
 	 * <p>
 	 * Statement batching is disabled when {@code OutParameter} is used.

--- a/hibernate-core/src/main/java/org/hibernate/sql/model/jdbc/DeleteOrUpsertOperation.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/model/jdbc/DeleteOrUpsertOperation.java
@@ -16,6 +16,7 @@ import org.hibernate.engine.jdbc.mutation.internal.PreparedStatementGroupSingleT
 import org.hibernate.engine.jdbc.mutation.spi.Binding;
 import org.hibernate.engine.jdbc.spi.JdbcServices;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
+import org.hibernate.jdbc.Expectation;
 import org.hibernate.persister.entity.mutation.EntityMutationTarget;
 import org.hibernate.persister.entity.mutation.EntityTableMapping;
 import org.hibernate.persister.entity.mutation.UpdateValuesAnalysis;
@@ -39,6 +40,8 @@ public class DeleteOrUpsertOperation implements SelfExecutingUpdateOperation {
 	private final UpsertOperation upsertOperation;
 
 	private final OptionalTableUpdate optionalTableUpdate;
+
+	private final Expectation expectation = new Expectation.RowCount();
 
 	public DeleteOrUpsertOperation(
 			EntityMutationTarget mutationTarget,
@@ -123,6 +126,16 @@ public class DeleteOrUpsertOperation implements SelfExecutingUpdateOperation {
 			final int rowCount = session.getJdbcCoordinator().getResultSetReturn()
 					.executeUpdate( upsertDeleteStatement, statementDetails.getSqlString() );
 			MODEL_MUTATION_LOGGER.tracef( "`%s` rows upsert-deleted from `%s`", rowCount, tableMapping.getTableName() );
+			try {
+				expectation.verifyOutcome( rowCount, upsertDeleteStatement, -1, statementDetails.getSqlString() );
+			}
+			catch (SQLException e) {
+				throw jdbcServices.getSqlExceptionHelper().convert(
+						e,
+						"Unable to verify outcome for upsert delete",
+						statementDetails.getSqlString()
+				);
+			}
 		}
 		finally {
 			statementDetails.releaseStatement( session );
@@ -182,12 +195,23 @@ public class DeleteOrUpsertOperation implements SelfExecutingUpdateOperation {
 		final var statementDetails = statementGroup.resolvePreparedStatementDetails( tableMapping.getTableName() );
 		try {
 			final PreparedStatement updateStatement = statementDetails.resolveStatement();
-			session.getJdbcServices().getSqlStatementLogger().logStatement( statementDetails.getSqlString() );
+			final JdbcServices jdbcServices = session.getJdbcServices();
+			jdbcServices.getSqlStatementLogger().logStatement( statementDetails.getSqlString() );
 			jdbcValueBindings.beforeStatement( statementDetails );
 			final int rowCount =
 					session.getJdbcCoordinator().getResultSetReturn()
 							.executeUpdate( updateStatement, statementDetails.getSqlString() );
 			MODEL_MUTATION_LOGGER.tracef( "`%s` rows upserted into `%s`", rowCount, tableMapping.getTableName() );
+			try {
+				expectation.verifyOutcome( rowCount, updateStatement, -1, statementDetails.getSqlString() );
+			}
+			catch (SQLException e) {
+				throw jdbcServices.getSqlExceptionHelper().convert(
+						e,
+						"Unable to verify outcome for upsert",
+						statementDetails.getSqlString()
+				);
+			}
 		}
 		finally {
 			statementDetails.releaseStatement( session );

--- a/hibernate-core/src/main/java/org/hibernate/sql/model/jdbc/MergeOperation.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/model/jdbc/MergeOperation.java
@@ -23,13 +23,12 @@ public class MergeOperation extends AbstractJdbcMutation {
 			MutationTarget<?> mutationTarget,
 			String sql,
 			List<? extends JdbcParameterBinder> parameterBinders) {
-		super( tableDetails, mutationTarget, sql, false, Expectation.None.INSTANCE, parameterBinders );
+		super( tableDetails, mutationTarget, sql, false, new Expectation.RowCount(), parameterBinders );
 	}
 
 	@Override
 	public MutationType getMutationType() {
 		return MutationType.UPDATE;
 	}
-
 
 }

--- a/hibernate-core/src/main/java/org/hibernate/sql/model/jdbc/UpsertOperation.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/model/jdbc/UpsertOperation.java
@@ -23,13 +23,12 @@ public class UpsertOperation extends AbstractJdbcMutation {
 			MutationTarget<?> mutationTarget,
 			String sql,
 			List<? extends JdbcParameterBinder> parameterBinders) {
-		super( tableDetails, mutationTarget, sql, false, Expectation.None.INSTANCE, parameterBinders );
+		super( tableDetails, mutationTarget, sql, false, new Expectation.RowCount(), parameterBinders );
 	}
 
 	@Override
 	public MutationType getMutationType() {
 		return MutationType.UPDATE;
 	}
-
 
 }

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/stateless/UpsertVersionedTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/stateless/UpsertVersionedTest.java
@@ -7,17 +7,21 @@ package org.hibernate.orm.test.stateless;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jakarta.persistence.Version;
+import org.hibernate.StaleObjectStateException;
 import org.hibernate.testing.orm.junit.DomainModel;
 import org.hibernate.testing.orm.junit.SessionFactory;
 import org.hibernate.testing.orm.junit.SessionFactoryScope;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 @SessionFactory
 @DomainModel(annotatedClasses = UpsertVersionedTest.Record.class)
 public class UpsertVersionedTest {
+
 	@Test void test(SessionFactoryScope scope) {
+		scope.getSessionFactory().getSchemaManager().truncate();
 		scope.inStatelessTransaction(s-> {
 			s.upsert(new Record(123L,null,"hello earth"));
 			s.upsert(new Record(456L,2L,"hello mars"));
@@ -41,6 +45,29 @@ public class UpsertVersionedTest {
 			assertEquals( "goodbye mars", s.get( Record.class,456L).message );
 		});
 	}
+
+	@Test void testStaleUpsert(SessionFactoryScope scope) {
+		scope.getSessionFactory().getSchemaManager().truncate();
+		scope.inStatelessTransaction( s -> {
+			s.insert(new Record(789L, 1L, "hello world"));
+		} );
+		scope.inStatelessTransaction( s -> {
+			s.upsert(new Record(789L, 1L, "hello mars"));
+		} );
+		try {
+			scope.inStatelessTransaction( s -> {
+				s.upsert(new Record( 789L, 1L, "hello venus"));
+			} );
+			fail();
+		}
+		catch (StaleObjectStateException sose) {
+			//expected
+		}
+		scope.inStatelessTransaction( s-> {
+			assertEquals( "hello mars", s.get(Record.class,789L).message );
+		} );
+	}
+
 	@Entity(name = "Record")
 	static class Record {
 		@Id Long id;

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/stateless/UpsertVersionedTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/stateless/UpsertVersionedTest.java
@@ -7,7 +7,7 @@ package org.hibernate.orm.test.stateless;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jakarta.persistence.Version;
-import org.hibernate.StaleObjectStateException;
+import org.hibernate.StaleStateException;
 import org.hibernate.testing.orm.junit.DomainModel;
 import org.hibernate.testing.orm.junit.SessionFactory;
 import org.hibernate.testing.orm.junit.SessionFactoryScope;
@@ -60,7 +60,7 @@ public class UpsertVersionedTest {
 			} );
 			fail();
 		}
-		catch (StaleObjectStateException sose) {
+		catch (StaleStateException sse) {
 			//expected
 		}
 		scope.inStatelessTransaction( s-> {


### PR DESCRIPTION
<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

[Please describe here what your change is about]

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-19522
<!-- Hibernate GitHub Bot issue links end -->