### PR TITLE
Limit disk usage of TCK reports

### DIFF
--- a/ci/jpa-3.1-tck.Jenkinsfile
+++ b/ci/jpa-3.1-tck.Jenkinsfile
@@ -1,4 +1,4 @@
-@Library('hibernate-jenkins-pipeline-helpers@1.13') _
+@Library('hibernate-jenkins-pipeline-helpers') _
 
 // Avoid running the pipeline on branch indexing
 if (currentBuild.getBuildCauses().toString().contains('BranchIndexingCause')) {
@@ -80,6 +80,7 @@ pipeline {
                             docker volume create tck-vol
                             docker run -v ~/.m2/repository/org/hibernate:/root/.m2/repository/org/hibernate:z -v tck-vol:/tck/persistence-tck/tmp/:z -e NO_SLEEP=${params.NO_SLEEP} -e HIBERNATE_VERSION=$HIBERNATE_VERSION --name tck jakarta-tck-runner
                             docker cp tck:/tck/persistence-tck/tmp/ ./results
+                            rm -Rf ./results/jdk-bundles
                         """
                         archiveArtifacts artifacts: 'results/**'
                         script {


### PR DESCRIPTION
We don't need to keep a copy of the whole JDK around in the reports of every single build...

Note this is only necessary in the 3.1 TCK, as the 3.2 TCK doesn't seem to do that anymore.

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
