### PR TITLE
HHH-19526 Avoid generating a QueryInterpretationCache.Key when the query cache is disabled

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/internal/QuerySqmImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/internal/QuerySqmImpl.java
@@ -490,10 +490,16 @@ public class QuerySqmImpl<R>
 	}
 
 	private SelectQueryPlan<R> resolveSelectQueryPlan() {
-		final QueryInterpretationCache.Key cacheKey = createInterpretationsKey( this );
-		return cacheKey != null
-				? interpretationCache().resolveSelectQueryPlan( cacheKey, this::buildSelectQueryPlan )
-				: buildSelectQueryPlan();
+		final QueryInterpretationCache queryCache = interpretationCache();
+		if ( queryCache.isEnabled() ) {
+			final QueryInterpretationCache.Key cacheKey = createInterpretationsKey( this );
+			return cacheKey != null
+					? queryCache.resolveSelectQueryPlan( cacheKey, this::buildSelectQueryPlan )
+					: buildSelectQueryPlan();
+		}
+		else {
+			return buildSelectQueryPlan();
+		}
 	}
 
 	private QueryInterpretationCache interpretationCache() {


### PR DESCRIPTION

 - https://hibernate.atlassian.net/browse/HHH-19526
 
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
