### PR TITLE
HHH-19495 Remove the default "true" from optimistic-lock in the mapping xsd

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/boot/jaxb/mapping/spi/JaxbLockableAttribute.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/jaxb/mapping/spi/JaxbLockableAttribute.java
@@ -10,6 +10,6 @@ package org.hibernate.boot.jaxb.mapping.spi;
  * @author Steve Ebersole
  */
 public interface JaxbLockableAttribute extends JaxbPersistentAttribute {
-	boolean isOptimisticLock();
+	Boolean isOptimisticLock();
 	void setOptimisticLock(Boolean value);
 }

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/xml/internal/attr/CommonAttributeProcessing.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/xml/internal/attr/CommonAttributeProcessing.java
@@ -84,12 +84,15 @@ public class CommonAttributeProcessing {
 			JaxbLockableAttribute jaxbAttribute,
 			MutableMemberDetails memberDetails,
 			XmlDocumentContext xmlDocumentContext) {
-		final boolean includeInOptimisticLock = jaxbAttribute.isOptimisticLock();
-		final OptimisticLockAnnotation optLockAnn = (OptimisticLockAnnotation) memberDetails.applyAnnotationUsage(
-				HibernateAnnotations.OPTIMISTIC_LOCK,
-				xmlDocumentContext.getModelBuildingContext()
-		);
-		optLockAnn.excluded( !includeInOptimisticLock );
+		final Boolean includeInOptimisticLock = jaxbAttribute.isOptimisticLock();
+
+		if ( includeInOptimisticLock != null ) {
+			final OptimisticLockAnnotation optLockAnn = (OptimisticLockAnnotation) memberDetails.applyAnnotationUsage(
+					HibernateAnnotations.OPTIMISTIC_LOCK,
+					xmlDocumentContext.getModelBuildingContext()
+			);
+			optLockAnn.excluded( !includeInOptimisticLock );
+		}
 	}
 
 	public static void applyFetching(

--- a/hibernate-core/src/main/resources/org/hibernate/xsd/mapping/mapping-7.0.xsd
+++ b/hibernate-core/src/main/resources/org/hibernate/xsd/mapping/mapping-7.0.xsd
@@ -601,7 +601,7 @@
         <xsd:attribute name="access" type="orm:access-type"/>
         <!-- hbm: Hibernate's pluggable accessor spi -->
         <xsd:attribute name="attribute-accessor" type="xsd:string" />
-        <xsd:attribute name="optimistic-lock" type="xsd:boolean" default="true" />
+        <xsd:attribute name="optimistic-lock" type="xsd:boolean" />
     </xsd:complexType>
 
     <xsd:group name="basic-type-group">
@@ -1027,7 +1027,7 @@
         <xsd:attribute name="fetch-mode" type="orm:plural-fetch-mode"/>
         <xsd:attribute name="access" type="orm:access-type"/>
         <xsd:attribute name="attribute-accessor" type="xsd:string" />
-        <xsd:attribute name="optimistic-lock" type="xsd:boolean" default="true" />
+        <xsd:attribute name="optimistic-lock" type="xsd:boolean" />
         <xsd:attribute name="classification" type="orm:limited-collection-classification-enum" />
     </xsd:complexType>
 
@@ -1109,7 +1109,7 @@
         <xsd:attribute name="name" type="xsd:string" use="required"/>
         <xsd:attribute name="access" type="orm:access-type"/>
         <xsd:attribute name="attribute-accessor" type="xsd:string" />
-        <xsd:attribute name="optimistic-lock" type="xsd:boolean" default="true" />
+        <xsd:attribute name="optimistic-lock" type="xsd:boolean" />
     </xsd:complexType>
 
     <!-- **************************************************** -->
@@ -1614,7 +1614,7 @@
         <xsd:attribute name="orphan-removal" type="xsd:boolean"/>
         <xsd:attribute name="classification" type="orm:limited-collection-classification-enum" />
         <xsd:attribute name="not-found" type="orm:not-found-enum"/>
-        <xsd:attribute name="optimistic-lock" type="xsd:boolean" default="true" />
+        <xsd:attribute name="optimistic-lock" type="xsd:boolean" />
     </xsd:complexType>
 
     <!-- **************************************************** -->
@@ -1661,7 +1661,7 @@
         <xsd:attribute name="optional" type="xsd:boolean"/>
         <xsd:attribute name="access" type="orm:access-type"/>
         <xsd:attribute name="attribute-accessor" type="xsd:string" />
-        <xsd:attribute name="optimistic-lock" type="xsd:boolean" default="true" />
+        <xsd:attribute name="optimistic-lock" type="xsd:boolean" />
         <xsd:attribute name="maps-id" type="xsd:string"/>
         <xsd:attribute name="id" type="xsd:boolean"/>
         <xsd:attribute name="not-found" type="orm:not-found-enum"/>
@@ -2057,7 +2057,7 @@
         <xsd:attribute name="orphan-removal" type="xsd:boolean"/>
         <xsd:attribute name="classification" type="orm:limited-collection-classification-enum" />
         <xsd:attribute name="not-found" type="orm:not-found-enum"/>
-        <xsd:attribute name="optimistic-lock" type="xsd:boolean" default="true" />
+        <xsd:attribute name="optimistic-lock" type="xsd:boolean" />
     </xsd:complexType>
 
     <!-- **************************************************** -->
@@ -2113,7 +2113,7 @@
         <xsd:attribute name="optional" type="xsd:boolean"/>
         <xsd:attribute name="access" type="orm:access-type"/>
         <xsd:attribute name="attribute-accessor" type="xsd:string" />
-        <xsd:attribute name="optimistic-lock" type="xsd:boolean" default="true" />
+        <xsd:attribute name="optimistic-lock" type="xsd:boolean" />
         <xsd:attribute name="mapped-by" type="xsd:string"/>
         <xsd:attribute name="orphan-removal" type="xsd:boolean"/>
         <xsd:attribute name="maps-id" type="xsd:string"/>
@@ -3139,7 +3139,7 @@
         <xsd:attribute name="fetch" type="orm:fetch-type"/>
         <xsd:attribute name="fetch-mode" type="orm:singular-fetch-mode"/>
         <xsd:attribute name="optional" type="xsd:boolean"/>
-        <xsd:attribute name="optimistic-lock" type="xsd:boolean" default="true" />
+        <xsd:attribute name="optimistic-lock" type="xsd:boolean" />
     </xsd:complexType>
 
     <xsd:complexType name="any-discriminator">
@@ -3208,7 +3208,7 @@
         <xsd:attribute name="fetch-mode" type="orm:plural-fetch-mode"/>
         <xsd:attribute name="access" type="orm:access-type"/>
         <xsd:attribute name="attribute-accessor" type="xsd:string" />
-        <xsd:attribute name="optimistic-lock" type="xsd:boolean" default="true" />
+        <xsd:attribute name="optimistic-lock" type="xsd:boolean" />
         <xsd:attribute name="classification" type="orm:limited-collection-classification-enum" />
     </xsd:complexType>
 


### PR DESCRIPTION
so that no extra annotations are added unless explicitly defined.

<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

[Please describe here what your change is about]

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
