### PR TITLE
HHH-18837 Oracle epoch extraction doesn't work with dates

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/dialect/OracleDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/OracleDialect.java
@@ -16,6 +16,7 @@ import org.hibernate.dialect.aggregate.AggregateSupport;
 import org.hibernate.dialect.aggregate.OracleAggregateSupport;
 import org.hibernate.dialect.function.CommonFunctionFactory;
 import org.hibernate.dialect.function.ModeStatsModeEmulation;
+import org.hibernate.dialect.function.OracleExtractFunction;
 import org.hibernate.dialect.function.OracleTruncFunction;
 import org.hibernate.dialect.identity.IdentityColumnSupport;
 import org.hibernate.dialect.identity.Oracle12cIdentityColumnSupport;
@@ -418,6 +419,11 @@ public class OracleDialect extends Dialect {
 		functionFactory.hex( "rawtohex(?1)" );
 		functionFactory.sha( "standard_hash(?1, 'SHA256')" );
 		functionFactory.md5( "standard_hash(?1, 'MD5')" );
+
+		functionContributions.getFunctionRegistry().register(
+				"extract",
+				new OracleExtractFunction( this, typeConfiguration )
+		);
 	}
 
 	/**

--- a/hibernate-core/src/main/java/org/hibernate/dialect/function/ExtractFunction.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/function/ExtractFunction.java
@@ -48,7 +48,7 @@ import static org.hibernate.usertype.internal.AbstractTimeZoneStorageCompositeUs
  */
 public class ExtractFunction extends AbstractSqmFunctionDescriptor implements FunctionRenderer {
 
-	private final Dialect dialect;
+	final Dialect dialect;
 
 	public ExtractFunction(Dialect dialect, TypeConfiguration typeConfiguration) {
 		super(

--- a/hibernate-core/src/main/java/org/hibernate/dialect/function/OracleExtractFunction.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/function/OracleExtractFunction.java
@@ -1,0 +1,53 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.dialect.function;
+
+import jakarta.persistence.TemporalType;
+import org.hibernate.dialect.Dialect;
+import org.hibernate.metamodel.mapping.JdbcMappingContainer;
+import org.hibernate.metamodel.model.domain.ReturnableType;
+import org.hibernate.query.common.TemporalUnit;
+import org.hibernate.query.sqm.produce.function.internal.PatternRenderer;
+import org.hibernate.sql.ast.SqlAstTranslator;
+import org.hibernate.sql.ast.spi.SqlAppender;
+import org.hibernate.sql.ast.tree.SqlAstNode;
+import org.hibernate.sql.ast.tree.expression.Expression;
+import org.hibernate.sql.ast.tree.expression.ExtractUnit;
+import org.hibernate.type.spi.TypeConfiguration;
+
+import java.util.List;
+
+import static org.hibernate.query.common.TemporalUnit.EPOCH;
+import static org.hibernate.type.spi.TypeConfiguration.getSqlTemporalType;
+
+public class OracleExtractFunction extends ExtractFunction {
+	public OracleExtractFunction(Dialect dialect, TypeConfiguration typeConfiguration) {
+		super( dialect, typeConfiguration );
+	}
+
+	@Override
+	public void render(
+			SqlAppender sqlAppender,
+			List<? extends SqlAstNode> sqlAstArguments,
+			ReturnableType<?> returnType,
+			SqlAstTranslator<?> walker) {
+		new PatternRenderer( extractPattern( sqlAstArguments ) ).render( sqlAppender, sqlAstArguments, walker );
+	}
+
+	@SuppressWarnings("deprecation")
+	private String extractPattern(List<? extends SqlAstNode> sqlAstArguments) {
+		final ExtractUnit field = (ExtractUnit) sqlAstArguments.get( 0 );
+		final TemporalUnit unit = field.getUnit();
+		if ( unit == EPOCH ) {
+			final Expression expression = (Expression) sqlAstArguments.get( 1 );
+			final JdbcMappingContainer type = expression.getExpressionType();
+			final TemporalType temporalType = type != null ? getSqlTemporalType( type ) : null;
+			if ( temporalType == TemporalType.DATE ) {
+				return "trunc((cast(from_tz(cast(?2 as timestamp),'UTC') as date) - date '1970-1-1')*86400)";
+			}
+		}
+		return dialect.extractPattern( unit );
+	}
+}


### PR DESCRIPTION
This PR fixes an error when using `epoch` with dates on Oracle.
I added an overload of `extractPattern` (which is overridden in `OracleDialect`) to handle different `TemporalType`.
This new method is only used in `ExtractFunction` in context of `OracleDialect`.

https://hibernate.atlassian.net/browse/HHH-18837

----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
