### PR TITLE
[7.0] HHH-19518 Make hibernate-maven-plugin configuration parameters non-readonly

### DIFF
--- a/tooling/hibernate-maven-plugin/src/main/java/org/hibernate/orm/tooling/maven/HibernateEnhancerMojo.java
+++ b/tooling/hibernate-maven-plugin/src/main/java/org/hibernate/orm/tooling/maven/HibernateEnhancerMojo.java
@@ -38,31 +38,26 @@ public class HibernateEnhancerMojo extends AbstractMojo {
 
 	@Parameter(
 			defaultValue = "${project.build.directory}/classes",
-			readonly = true,
 			required = true)
 	private File classesDirectory;
 
 	@Parameter(
 			defaultValue = "false",
-			readonly = true,
 			required = true)
 	private boolean enableAssociationManagement;
 
 	@Parameter(
 			defaultValue = "false",
-			readonly = true,
 			required = true)
 	private boolean enableDirtyTracking;
 
 	@Parameter(
 			defaultValue = "false",
-			readonly = true,
 			required = true)
 	private boolean enableLazyInitialization;
 
 	@Parameter(
 			defaultValue = "false",
-			readonly = true,
 			required = true)
 	private boolean enableExtendedEnhancement;
 


### PR DESCRIPTION
<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

https://hibernate.atlassian.net/browse/HHH-19518

Backport of https://github.com/hibernate/hibernate-orm/pull/10280

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
