### PR TITLE
show more information about bytecode generation problem with EAR + subdeployments as discussed on zulip

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/bytecode/internal/bytebuddy/ByteBuddyState.java
+++ b/hibernate-core/src/main/java/org/hibernate/bytecode/internal/bytebuddy/ByteBuddyState.java
@@ -228,8 +228,17 @@ public final class ByteBuddyState {
 	 * @return The loaded generated class.
 	 */
 	public Class<?> load(Class<?> referenceClass, String className, BiFunction<ByteBuddy, NamingStrategy, DynamicType.Builder<?>> makeClassFunction) {
+
 		try {
-			return referenceClass.getClassLoader().loadClass( className );
+			Class<?> result = referenceClass.getClassLoader().loadClass(className);
+			if (result.getClassLoader() != referenceClass.getClassLoader()) {
+				LOG.info("xxx ByteBuddyState.load detected problem where " +
+					"loading generated class \"" + className + "\" from a subdeployment is actually loading the generated class in the ear lib." +
+					"\nDetails: " +
+					"referenceClass.getClassLoader() == " + referenceClass.getClassLoader() +
+					"\nLoaded class classloader = " + result.getClassLoader());
+				}
+				return result;
 		}
 		catch (ClassNotFoundException e) {
 			// Ignore


### PR DESCRIPTION
See >
https://hibernate.zulipchat.com/#narrow/channel/132094-hibernate-orm-dev/topic/Seeing.20EE.20TCK.20ClassCastException.20with.20ORM.206.2E6.2E13.2EFinal/near/523129580 discussion thread.

With this change I can see that we are using the EAR/lib copy of generated classes instead of getting a CNFE and generating the needed classes in the subdeployment classloader.

Some output from a local Jakarta EE 10 Platform TCK test:

> export wildflytckroot=$PWD
> export testFolder=jpa/core/annotations/access/property
> export testName=propertyTypeTest1_from_pmservlet
> export singlecpu=yes
> bash tck10.sh 2>&1 | tee propertytests14.log


Output from the ^ WildFly server.log:

> grep "xxx ByteBuddyState.load" logs/server.log
> 2025-06-09 13:45:24,174 INFO  [org.hibernate.bytecode.internal.bytebuddy.ByteBuddyState] (ServerService Thread Pool -- 165) xxx ByteBuddyState.load detected problem where loading generated class "com.sun.ts.tests.jpa.core.annotations.access.property.DataTypes$HibernateInstantiator" from a subdeployment is actually loading the generated class in the ear lib.
> 2025-06-09 13:45:24,175 INFO  [org.hibernate.bytecode.internal.bytebuddy.ByteBuddyState] (ServerService Thread Pool -- 161) xxx ByteBuddyState.load detected problem where loading generated class "com.sun.ts.tests.jpa.core.annotations.access.property.DataTypes$HibernateInstantiator" from a subdeployment is actually loading the generated class in the ear lib.
> 2025-06-09 13:45:24,180 INFO  [org.hibernate.bytecode.internal.bytebuddy.ByteBuddyState] (ServerService Thread Pool -- 166) xxx ByteBuddyState.load detected problem where loading generated class "com.sun.ts.tests.jpa.core.annotations.access.property.DataTypes$HibernateInstantiator" from a subdeployment is actually loading the generated class in the ear lib.
> 2025-06-09 13:45:24,180 INFO  [org.hibernate.bytecode.internal.bytebuddy.ByteBuddyState] (ServerService Thread Pool -- 39) xxx ByteBuddyState.load detected problem where loading generated class "com.sun.ts.tests.jpa.core.annotations.access.property.DataTypes$HibernateInstantiator" from a subdeployment is actually loading the generated class in the ear lib.
> 2025-06-09 13:45:24,184 INFO  [org.hibernate.bytecode.internal.bytebuddy.ByteBuddyState] (ServerService Thread Pool -- 167) xxx ByteBuddyState.load detected problem where loading generated class "com.sun.ts.tests.jpa.core.annotations.access.property.DataTypes$HibernateInstantiator" from a subdeployment is actually loading the generated class in the ear lib.
> 2025-06-09 13:45:24,185 INFO  [org.hibernate.bytecode.internal.bytebuddy.ByteBuddyState] (ServerService Thread Pool -- 163) xxx ByteBuddyState.load detected problem where loading generated class "com.sun.ts.tests.jpa.core.annotations.access.property.DataTypes$HibernateInstantiator" from a subdeployment is actually loading the generated class in the ear lib.
> 2025-06-09 13:45:24,268 INFO  [org.hibernate.bytecode.internal.bytebuddy.ByteBuddyState] (ServerService Thread Pool -- 167) xxx ByteBuddyState.load detected problem where loading generated class "com.sun.ts.tests.jpa.core.annotations.access.property.DataTypes2$HibernateInstantiator" from a subdeployment is actually loading the generated class in the ear lib.
> 2025-06-09 13:45:24,268 INFO  [org.hibernate.bytecode.internal.bytebuddy.ByteBuddyState] (ServerService Thread Pool -- 167) xxx ByteBuddyState.load detected problem where loading generated class "com.sun.ts.tests.jpa.core.annotations.access.property.DataTypes2$HibernateAccessOptimizeratimeDataatsData" from a subdeployment is actually loading the generated class in the ear lib.
> 2025-06-09 13:45:24,268 INFO  [org.hibernate.bytecode.internal.bytebuddy.ByteBuddyState] (ServerService Thread Pool -- 163) xxx ByteBuddyState.load detected problem where loading generated class "com.sun.ts.tests.jpa.core.annotations.access.property.DataTypes2$HibernateInstantiator" from a subdeployment is actually loading the generated class in the ear lib.
> 2025-06-09 13:45:24,268 INFO  [org.hibernate.bytecode.internal.bytebuddy.ByteBuddyState] (ServerService Thread Pool -- 163) xxx ByteBuddyState.load detected problem where loading generated class "com.sun.ts.tests.jpa.core.annotations.access.property.DataTypes2$HibernateAccessOptimizeratimeDataatsData" from a subdeployment is actually loading the generated class in the ear lib.
> 2025-06-09 13:45:24,269 INFO  [org.hibernate.bytecode.internal.bytebuddy.ByteBuddyState] (ServerService Thread Pool -- 166) xxx ByteBuddyState.load detected problem where loading generated class "com.sun.ts.tests.jpa.core.annotations.access.property.DataTypes2$HibernateInstantiator" from a subdeployment is actually loading the generated class in the ear lib.
> 2025-06-09 13:45:24,269 INFO  [org.hibernate.bytecode.internal.bytebuddy.ByteBuddyState] (ServerService Thread Pool -- 166) xxx ByteBuddyState.load detected problem where loading generated class "com.sun.ts.tests.jpa.core.annotations.access.property.DataTypes2$HibernateAccessOptimizeratimeDataatsData" from a subdeployment is actually loading the generated class in the ear lib.
> 

Randomly I got a different error but I have seen many ClassCastException in local runs:

```
2025-06-09 13:45:25,497 ERROR [org.hibernate.property.access.spi.SetterMethodImpl] (default task-1) HHH000123: IllegalArgumentException in class: com.sun.ts.tests.jpa.core.annotations.access.property.DataTypes, setter method of property: id
2025-06-09 13:45:25,497 ERROR [org.hibernate.property.access.spi.SetterMethodImpl] (default task-1) HHH000091: Expected type: java.lang.Integer, actual value: java.lang.Integer
2025-06-09 13:45:25,502 INFO  [org.hibernate.event.internal.DefaultLoadEventListener] (default task-1) HHH000327: Error performing load command: IllegalArgumentException occurred while calling setter for property [com.sun.ts.tests.jpa.core.annotations.access.property.DataTypes.id (expected type = java.lang.Integer)]; target = [DataTypes[id: null, Character: null, Short: null, Integer: null, Long: null, Double: null, Float: null, CharacterArrayData: null, ByteArrayData: null, shouldNotPersist: null]], property value = [1]
        at org.hibernate@6.6.18-SNAPSHOT//org.hibernate.property.access.spi.SetterMethodImpl.set(SetterMethodImpl.java:107)
        at org.hibernate@6.6.18-SNAPSHOT//org.hibernate.metamodel.mapping.internal.BasicEntityIdentifierMappingImpl.setIdentifier(BasicEntityIdentifierMappingImpl.java:163)
        at org.hibernate@6.6.18-SNAPSHOT//org.hibernate.persister.entity.AbstractEntityPersister.setIdentifier(AbstractEntityPersister.java:4744)
        at org.hibernate@6.6.18-SNAPSHOT//org.hibernate.persister.entity.AbstractEntityPersister.instantiate(AbstractEntityPersister.java:4758)
        at org.hibernate@6.6.18-SNAPSHOT//org.hibernate.internal.SessionImpl.instantiate(SessionImpl.java:1489)
        at org.hibernate@6.6.18-SNAPSHOT//org.hibernate.sql.results.graph.entity.internal.EntityInitializerImpl.instantiateEntity(EntityInitializerImpl.java:1250)
        at org.hibernate@6.6.18-SNAPSHOT//org.hibernate.sql.results.graph.entity.internal.EntityInitializerImpl.resolveEntityInstance(EntityInitializerImpl.java:1243)
        at org.hibernate@6.6.18-SNAPSHOT//org.hibernate.sql.results.graph.entity.internal.EntityInitializerImpl.resolveEntityInstance2(EntityInitializerImpl.java:1201)
        at org.hibernate@6.6.18-SNAPSHOT//org.hibernate.sql.results.graph.entity.internal.EntityInitializerImpl.resolveEntityInstance1(EntityInitializerImpl.java:1117)
        at org.hibernate@6.6.18-SNAPSHOT//org.hibernate.sql.results.graph.entity.internal.EntityInitializerImpl.resolveInstance(EntityInitializerImpl.java:1032)
        at org.hibernate@6.6.18-SNAPSHOT//org.hibernate.sql.results.graph.entity.internal.EntityInitializerImpl.resolveKey(EntityInitializerImpl.java:587)
        at org.hibernate@6.6.18-SNAPSHOT//org.hibernate.sql.results.graph.entity.internal.EntityInitializerImpl.resolveKey(EntityInitializerImpl.java:457)
        at org.hibernate@6.6.18-SNAPSHOT//org.hibernate.sql.results.graph.entity.internal.EntityInitializerImpl.resolveKey(EntityInitializerImpl.java:97)
        at org.hibernate@6.6.18-SNAPSHOT//org.hibernate.sql.results.internal.StandardRowReader.coordinateInitializers(StandardRowReader.java:235)
        at org.hibernate@6.6.18-SNAPSHOT//org.hibernate.sql.results.internal.StandardRowReader.readRow(StandardRowReader.java:141)
        at org.hibernate@6.6.18-SNAPSHOT//org.hibernate.sql.results.spi.ListResultsConsumer.readUniqueAssert(ListResultsConsumer.java:262)
        at org.hibernate@6.6.18-SNAPSHOT//org.hibernate.sql.results.spi.ListResultsConsumer.consume(ListResultsConsumer.java:198)
        at org.hibernate@6.6.18-SNAPSHOT//org.hibernate.sql.results.spi.ListResultsConsumer.consume(ListResultsConsumer.java:35)
        at org.hibernate@6.6.18-SNAPSHOT//org.hibernate.sql.exec.internal.JdbcSelectExecutorStandardImpl.doExecuteQuery(JdbcSelectExecutorStandardImpl.java:224)
        at org.hibernate@6.6.18-SNAPSHOT//org.hibernate.sql.exec.internal.JdbcSelectExecutorStandardImpl.executeQuery(JdbcSelectExecutorStandardImpl.java:102)
        at org.hibernate@6.6.18-SNAPSHOT//org.hibernate.sql.exec.spi.JdbcSelectExecutor.executeQuery(JdbcSelectExecutor.java:91)
        at org.hibernate@6.6.18-SNAPSHOT//org.hibernate.sql.exec.spi.JdbcSelectExecutor.list(JdbcSelectExecutor.java:165)
        at org.hibernate@6.6.18-SNAPSHOT//org.hibernate.loader.ast.internal.SingleIdLoadPlan.load(SingleIdLoadPlan.java:145)
        at org.hibernate@6.6.18-SNAPSHOT//org.hibernate.loader.ast.internal.SingleIdLoadPlan.load(SingleIdLoadPlan.java:117)
        at org.hibernate@6.6.18-SNAPSHOT//org.hibernate.loader.ast.internal.SingleIdEntityLoaderStandardImpl.load(SingleIdEntityLoaderStandardImpl.java:74)
        at org.hibernate@6.6.18-SNAPSHOT//org.hibernate.persister.entity.AbstractEntityPersister.doLoad(AbstractEntityPersister.java:3895)
        at org.hibernate@6.6.18-SNAPSHOT//org.hibernate.persister.entity.AbstractEntityPersister.load(AbstractEntityPersister.java:3884)
        at org.hibernate@6.6.18-SNAPSHOT//org.hibernate.event.internal.DefaultLoadEventListener.loadFromDatasource(DefaultLoadEventListener.java:604)
        at org.hibernate@6.6.18-SNAPSHOT//org.hibernate.event.internal.DefaultLoadEventListener.loadFromCacheOrDatasource(DefaultLoadEventListener.java:590)
        at org.hibernate@6.6.18-SNAPSHOT//org.hibernate.event.internal.DefaultLoadEventListener.load(DefaultLoadEventListener.java:560)
        at org.hibernate@6.6.18-SNAPSHOT//org.hibernate.event.internal.DefaultLoadEventListener.doLoad(DefaultLoadEventListener.java:544)
        at org.hibernate@6.6.18-SNAPSHOT//org.hibernate.event.internal.DefaultLoadEventListener.load(DefaultLoadEventListener.java:206)
        at org.hibernate@6.6.18-SNAPSHOT//org.hibernate.event.internal.DefaultLoadEventListener.loadWithRegularProxy(DefaultLoadEventListener.java:289)
        at org.hibernate@6.6.18-SNAPSHOT//org.hibernate.event.internal.DefaultLoadEventListener.proxyOrLoad(DefaultLoadEventListener.java:241)
        at org.hibernate@6.6.18-SNAPSHOT//org.hibernate.event.internal.DefaultLoadEventListener.doOnLoad(DefaultLoadEventListener.java:110)
        at org.hibernate@6.6.18-SNAPSHOT//org.hibernate.event.internal.DefaultLoadEventListener.onLoad(DefaultLoadEventListener.java:69)
        at org.hibernate@6.6.18-SNAPSHOT//org.hibernate.event.service.internal.EventListenerGroupImpl.fireEventOnEachListener(EventListenerGroupImpl.java:138)
        at org.hibernate@6.6.18-SNAPSHOT//org.hibernate.internal.SessionImpl.fireLoadNoChecks(SessionImpl.java:1229)
        at org.hibernate@6.6.18-SNAPSHOT//org.hibernate.internal.SessionImpl.fireLoad(SessionImpl.java:1217)
        at org.hibernate@6.6.18-SNAPSHOT//org.hibernate.loader.internal.IdentifierLoadAccessImpl.load(IdentifierLoadAccessImpl.java:210)
        at org.hibernate@6.6.18-SNAPSHOT//org.hibernate.loader.internal.IdentifierLoadAccessImpl.doLoad(IdentifierLoadAccessImpl.java:161)
        at org.hibernate@6.6.18-SNAPSHOT//org.hibernate.loader.internal.IdentifierLoadAccessImpl.lambda$load$1(IdentifierLoadAccessImpl.java:150)
        at org.hibernate@6.6.18-SNAPSHOT//org.hibernate.loader.internal.IdentifierLoadAccessImpl.perform(IdentifierLoadAccessImpl.java:113)
        at org.hibernate@6.6.18-SNAPSHOT//org.hibernate.loader.internal.IdentifierLoadAccessImpl.load(IdentifierLoadAccessImpl.java:150)
        at org.hibernate@6.6.18-SNAPSHOT//org.hibernate.internal.SessionImpl.find(SessionImpl.java:2459)
        at org.hibernate@6.6.18-SNAPSHOT//org.hibernate.internal.SessionImpl.find(SessionImpl.java:2425)
        at org.jboss.as.jpa@37.0.0.Beta1-SNAPSHOT//org.jboss.as.jpa.container.AbstractEntityManager.find(AbstractEntityManager.java:199)
        at deployment.jpa_core_annotations_access_property_vehicles.ear.jpa_core_annotations_access_property_pmservlet_vehicle_web.war//com.sun.ts.tests.jpa.core.annotations.access.property.Client.propertyTypeTest1(Client.java:95)
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)

```