### PR TITLE
Backport of HHH-19495 Remove the default "true" from optimistic-lock in the mapping xsd / HHH-19528   Version xml mapping is ignored

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/boot/jaxb/mapping/spi/JaxbLockableAttribute.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/jaxb/mapping/spi/JaxbLockableAttribute.java
@@ -10,6 +10,6 @@ package org.hibernate.boot.jaxb.mapping.spi;
  * @author Steve Ebersole
  */
 public interface JaxbLockableAttribute extends JaxbPersistentAttribute {
-	boolean isOptimisticLock();
+	Boolean isOptimisticLock();
 	void setOptimisticLock(Boolean value);
 }

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/xml/internal/AttributeProcessor.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/xml/internal/AttributeProcessor.java
@@ -10,6 +10,7 @@ import org.hibernate.boot.jaxb.mapping.spi.JaxbAnyMappingImpl;
 import org.hibernate.boot.jaxb.mapping.spi.JaxbAssociationOverrideImpl;
 import org.hibernate.boot.jaxb.mapping.spi.JaxbAttributeOverrideImpl;
 import org.hibernate.boot.jaxb.mapping.spi.JaxbAttributesContainer;
+import org.hibernate.boot.jaxb.mapping.spi.JaxbAttributesContainerImpl;
 import org.hibernate.boot.jaxb.mapping.spi.JaxbBaseAttributesContainer;
 import org.hibernate.boot.jaxb.mapping.spi.JaxbBasicImpl;
 import org.hibernate.boot.jaxb.mapping.spi.JaxbElementCollectionImpl;
@@ -22,6 +23,7 @@ import org.hibernate.boot.jaxb.mapping.spi.JaxbOneToOneImpl;
 import org.hibernate.boot.jaxb.mapping.spi.JaxbPersistentAttribute;
 import org.hibernate.boot.jaxb.mapping.spi.JaxbPluralAnyMappingImpl;
 import org.hibernate.boot.jaxb.mapping.spi.JaxbTransientImpl;
+import org.hibernate.boot.jaxb.mapping.spi.JaxbVersionImpl;
 import org.hibernate.boot.models.HibernateAnnotations;
 import org.hibernate.boot.models.xml.internal.attr.AnyMappingAttributeProcessing;
 import org.hibernate.boot.models.xml.internal.attr.BasicAttributeProcessing;
@@ -151,11 +153,20 @@ public class AttributeProcessor {
 	}
 
 	public static void processAttributes(
-			JaxbAttributesContainer attributesContainer,
+			JaxbAttributesContainerImpl attributesContainer,
 			MutableClassDetails mutableClassDetails,
 			AccessType classAccessType,
 			XmlDocumentContext xmlDocumentContext) {
 		processAttributes( attributesContainer, mutableClassDetails, classAccessType, null, xmlDocumentContext );
+	}
+	public static void processAttributes(
+			JaxbAttributesContainerImpl attributesContainer,
+			MutableClassDetails mutableClassDetails,
+			AccessType classAccessType,
+			MemberAdjuster memberAdjuster,
+			XmlDocumentContext xmlDocumentContext) {
+		processAttributes( (JaxbAttributesContainer) attributesContainer, mutableClassDetails, classAccessType, memberAdjuster, xmlDocumentContext );
+		processVersionAttribute( attributesContainer.getVersion(), mutableClassDetails, classAccessType, xmlDocumentContext );
 	}
 
 	public static void processAttributes(
@@ -262,6 +273,19 @@ public class AttributeProcessor {
 		XmlAnnotationHelper.applyAssociationOverrides(
 				associationOverrides,
 				mutableClassDetails,
+				xmlDocumentContext
+		);
+	}
+
+	public static void processVersionAttribute(
+			JaxbVersionImpl version,
+			MutableClassDetails mutableClassDetails, AccessType classAccessType,
+			XmlDocumentContext xmlDocumentContext
+	) {
+		XmlAnnotationHelper.applyVersion(
+				version,
+				mutableClassDetails,
+				classAccessType,
 				xmlDocumentContext
 		);
 	}

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/xml/internal/attr/CommonAttributeProcessing.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/xml/internal/attr/CommonAttributeProcessing.java
@@ -84,12 +84,15 @@ public class CommonAttributeProcessing {
 			JaxbLockableAttribute jaxbAttribute,
 			MutableMemberDetails memberDetails,
 			XmlDocumentContext xmlDocumentContext) {
-		final boolean includeInOptimisticLock = jaxbAttribute.isOptimisticLock();
-		final OptimisticLockAnnotation optLockAnn = (OptimisticLockAnnotation) memberDetails.applyAnnotationUsage(
-				HibernateAnnotations.OPTIMISTIC_LOCK,
-				xmlDocumentContext.getModelBuildingContext()
-		);
-		optLockAnn.excluded( !includeInOptimisticLock );
+		final Boolean includeInOptimisticLock = jaxbAttribute.isOptimisticLock();
+
+		if ( includeInOptimisticLock != null ) {
+			final OptimisticLockAnnotation optLockAnn = (OptimisticLockAnnotation) memberDetails.applyAnnotationUsage(
+					HibernateAnnotations.OPTIMISTIC_LOCK,
+					xmlDocumentContext.getModelBuildingContext()
+			);
+			optLockAnn.excluded( !includeInOptimisticLock );
+		}
 	}
 
 	public static void applyFetching(

--- a/hibernate-core/src/main/resources/org/hibernate/xsd/mapping/mapping-7.0.xsd
+++ b/hibernate-core/src/main/resources/org/hibernate/xsd/mapping/mapping-7.0.xsd
@@ -601,7 +601,7 @@
         <xsd:attribute name="access" type="orm:access-type"/>
         <!-- hbm: Hibernate's pluggable accessor spi -->
         <xsd:attribute name="attribute-accessor" type="xsd:string" />
-        <xsd:attribute name="optimistic-lock" type="xsd:boolean" default="true" />
+        <xsd:attribute name="optimistic-lock" type="xsd:boolean" />
     </xsd:complexType>
 
     <xsd:group name="basic-type-group">
@@ -1027,7 +1027,7 @@
         <xsd:attribute name="fetch-mode" type="orm:plural-fetch-mode"/>
         <xsd:attribute name="access" type="orm:access-type"/>
         <xsd:attribute name="attribute-accessor" type="xsd:string" />
-        <xsd:attribute name="optimistic-lock" type="xsd:boolean" default="true" />
+        <xsd:attribute name="optimistic-lock" type="xsd:boolean" />
         <xsd:attribute name="classification" type="orm:limited-collection-classification-enum" />
     </xsd:complexType>
 
@@ -1109,7 +1109,7 @@
         <xsd:attribute name="name" type="xsd:string" use="required"/>
         <xsd:attribute name="access" type="orm:access-type"/>
         <xsd:attribute name="attribute-accessor" type="xsd:string" />
-        <xsd:attribute name="optimistic-lock" type="xsd:boolean" default="true" />
+        <xsd:attribute name="optimistic-lock" type="xsd:boolean" />
     </xsd:complexType>
 
     <!-- **************************************************** -->
@@ -1614,7 +1614,7 @@
         <xsd:attribute name="orphan-removal" type="xsd:boolean"/>
         <xsd:attribute name="classification" type="orm:limited-collection-classification-enum" />
         <xsd:attribute name="not-found" type="orm:not-found-enum"/>
-        <xsd:attribute name="optimistic-lock" type="xsd:boolean" default="true" />
+        <xsd:attribute name="optimistic-lock" type="xsd:boolean" />
     </xsd:complexType>
 
     <!-- **************************************************** -->
@@ -1661,7 +1661,7 @@
         <xsd:attribute name="optional" type="xsd:boolean"/>
         <xsd:attribute name="access" type="orm:access-type"/>
         <xsd:attribute name="attribute-accessor" type="xsd:string" />
-        <xsd:attribute name="optimistic-lock" type="xsd:boolean" default="true" />
+        <xsd:attribute name="optimistic-lock" type="xsd:boolean" />
         <xsd:attribute name="maps-id" type="xsd:string"/>
         <xsd:attribute name="id" type="xsd:boolean"/>
         <xsd:attribute name="not-found" type="orm:not-found-enum"/>
@@ -2057,7 +2057,7 @@
         <xsd:attribute name="orphan-removal" type="xsd:boolean"/>
         <xsd:attribute name="classification" type="orm:limited-collection-classification-enum" />
         <xsd:attribute name="not-found" type="orm:not-found-enum"/>
-        <xsd:attribute name="optimistic-lock" type="xsd:boolean" default="true" />
+        <xsd:attribute name="optimistic-lock" type="xsd:boolean" />
     </xsd:complexType>
 
     <!-- **************************************************** -->
@@ -2113,7 +2113,7 @@
         <xsd:attribute name="optional" type="xsd:boolean"/>
         <xsd:attribute name="access" type="orm:access-type"/>
         <xsd:attribute name="attribute-accessor" type="xsd:string" />
-        <xsd:attribute name="optimistic-lock" type="xsd:boolean" default="true" />
+        <xsd:attribute name="optimistic-lock" type="xsd:boolean" />
         <xsd:attribute name="mapped-by" type="xsd:string"/>
         <xsd:attribute name="orphan-removal" type="xsd:boolean"/>
         <xsd:attribute name="maps-id" type="xsd:string"/>
@@ -3139,7 +3139,7 @@
         <xsd:attribute name="fetch" type="orm:fetch-type"/>
         <xsd:attribute name="fetch-mode" type="orm:singular-fetch-mode"/>
         <xsd:attribute name="optional" type="xsd:boolean"/>
-        <xsd:attribute name="optimistic-lock" type="xsd:boolean" default="true" />
+        <xsd:attribute name="optimistic-lock" type="xsd:boolean" />
     </xsd:complexType>
 
     <xsd:complexType name="any-discriminator">
@@ -3208,7 +3208,7 @@
         <xsd:attribute name="fetch-mode" type="orm:plural-fetch-mode"/>
         <xsd:attribute name="access" type="orm:access-type"/>
         <xsd:attribute name="attribute-accessor" type="xsd:string" />
-        <xsd:attribute name="optimistic-lock" type="xsd:boolean" default="true" />
+        <xsd:attribute name="optimistic-lock" type="xsd:boolean" />
         <xsd:attribute name="classification" type="orm:limited-collection-classification-enum" />
     </xsd:complexType>
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/xml/BaseShop.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/xml/BaseShop.java
@@ -1,0 +1,30 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.jpa.xml;
+
+
+
+public class BaseShop {
+
+	private int id;
+
+	private int version;
+
+	public int getId() {
+		return id;
+	}
+
+	public void setId(int id) {
+		this.id = id;
+	}
+
+	public int getVersion() {
+		return version;
+	}
+
+	public void setVersion(int version) {
+		this.version = version;
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/xml/Consumer.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/xml/Consumer.java
@@ -1,0 +1,45 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.jpa.xml;
+
+import jakarta.persistence.Id;
+import jakarta.persistence.Version;
+
+import java.util.List;
+
+public class Consumer {
+
+	@Id
+	private int id;
+
+	private List<ConsumerItem> consumerItems;
+
+	@Version
+	private int version;
+
+	public int getId() {
+		return id;
+	}
+
+	public void setId(int id) {
+		this.id = id;
+	}
+
+	public List<ConsumerItem> getConsumerItems() {
+		return consumerItems;
+	}
+
+	public void setConsumerItems(List<ConsumerItem> consumerItems) {
+		this.consumerItems = consumerItems;
+	}
+
+	public int getVersion() {
+		return version;
+	}
+
+	public void setVersion(int version) {
+		this.version = version;
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/xml/ConsumerItem.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/xml/ConsumerItem.java
@@ -1,0 +1,41 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.jpa.xml;
+
+import jakarta.persistence.Version;
+
+public class ConsumerItem {
+
+	private int id;
+
+	private Consumer consumer;
+
+	@Version
+	private int version;
+
+	public int getId() {
+		return id;
+	}
+
+	public void setId(int id) {
+		this.id = id;
+	}
+
+	public Consumer getConsumer() {
+		return consumer;
+	}
+
+	public void setConsumer(Consumer consumer) {
+		this.consumer = consumer;
+	}
+
+	public int getVersion() {
+		return version;
+	}
+
+	public void setVersion(int version) {
+		this.version = version;
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/xml/ExplicitOptimisticLockAnnotationOnCollectionXmlOnlyTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/xml/ExplicitOptimisticLockAnnotationOnCollectionXmlOnlyTest.java
@@ -1,0 +1,82 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.jpa.xml;
+
+import org.hibernate.testing.jdbc.SQLStatementInspector;
+import org.hibernate.testing.orm.junit.EntityManagerFactoryScope;
+import org.hibernate.testing.orm.junit.JiraKey;
+import org.hibernate.testing.orm.junit.Jpa;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
+
+
+@JiraKey(value = "HHH-19528")
+@Jpa(
+		xmlMappings = {"org/hibernate/orm/test/jpa/xml/ExplicitOptimisticLockAnnotationOnCollectionXmlOnlyTest.xml"},
+		useCollectingStatementInspector = true
+)
+class ExplicitOptimisticLockAnnotationOnCollectionXmlOnlyTest {
+
+	private static SQLStatementInspector statementInspector;
+	private static int consumerId;
+
+
+	@BeforeEach
+	public void setUp(EntityManagerFactoryScope scope) {
+		statementInspector = scope.getCollectingStatementInspector();
+
+		scope.inTransaction( em -> {
+			Consumer consumer = new Consumer();
+			em.persist( consumer );
+			consumerId = consumer.getId();
+
+			ConsumerItem item1 = new ConsumerItem();
+			item1.setConsumer( consumer );
+			em.persist( item1 );
+
+			ConsumerItem item2 = new ConsumerItem();
+			item2.setConsumer( consumer );
+			em.persist( item2 );
+		} );
+	}
+
+	@Test
+	void test(EntityManagerFactoryScope scope) {
+		statementInspector.clear();
+
+		scope.inTransaction( em -> {
+			Consumer consumer = em.find( Consumer.class, consumerId );
+			ConsumerItem inventory = new ConsumerItem();
+			inventory.setConsumer( consumer );
+			consumer.getConsumerItems().add( inventory );
+		} );
+		statementInspector.assertUpdate();
+		statementInspector.assertInsert();
+	}
+
+	@Test
+	void testVersionOnMappedSupertype(EntityManagerFactoryScope scope) {
+		var shop = scope.fromTransaction( em -> {
+			Supermarket supermarket = new Supermarket();
+			supermarket.setName( "Tesco" );
+			em.persist( supermarket );
+			return supermarket;
+		} );
+
+		statementInspector.clear();
+		scope.inTransaction( em -> {
+			Supermarket supermarket = em.find( Supermarket.class, shop.getId() );
+			supermarket.setName( "Leclerc" );
+		} );
+		scope.inTransaction( em -> {
+			Supermarket supermarket = em.find( Supermarket.class, shop.getId() );
+			assertThat( shop.getVersion() ).isNotEqualTo( supermarket.getVersion() );
+		} );
+
+		statementInspector.assertHasQueryMatching( "update.*version.*" );
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/xml/NoDefaultOptimisticLockAnnotationTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/xml/NoDefaultOptimisticLockAnnotationTest.java
@@ -1,0 +1,60 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.jpa.xml;
+
+import org.hibernate.testing.jdbc.SQLStatementInspector;
+import org.hibernate.testing.orm.junit.EntityManagerFactoryScope;
+import org.hibernate.testing.orm.junit.JiraKey;
+import org.hibernate.testing.orm.junit.Jpa;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+
+@JiraKey(value = "HHH-19495")
+@Jpa(
+		xmlMappings = {"org/hibernate/orm/test/jpa/xml/NoDefaultOptimisticLockAnnotationTest.xml"},
+		annotatedClasses = {Consumer.class, ConsumerItem.class},
+		useCollectingStatementInspector = true
+)
+class NoDefaultOptimisticLockAnnotationTest {
+
+	private static SQLStatementInspector statementInspector;
+	private static int consumerId;
+
+
+	@BeforeEach
+	public void setUp(EntityManagerFactoryScope scope) {
+		statementInspector = scope.getCollectingStatementInspector();
+
+		scope.inTransaction( em -> {
+			Consumer consumer = new Consumer();
+			em.persist( consumer );
+			consumerId = consumer.getId();
+
+			ConsumerItem item1 = new ConsumerItem();
+			item1.setConsumer( consumer );
+			em.persist( item1 );
+
+			ConsumerItem item2 = new ConsumerItem();
+			item2.setConsumer( consumer );
+			em.persist( item2 );
+		} );
+	}
+
+	@Test
+	void test(EntityManagerFactoryScope scope) {
+		statementInspector.clear();
+
+		scope.inTransaction( em -> {
+			Consumer consumer = em.find( Consumer.class, consumerId );
+			ConsumerItem inventory = new ConsumerItem();
+			inventory.setConsumer( consumer );
+			consumer.getConsumerItems().add( inventory );
+		} );
+
+		statementInspector.assertIsInsert( 1 );
+		statementInspector.assertNoUpdate();
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/xml/Supermarket.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/xml/Supermarket.java
@@ -1,0 +1,18 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.jpa.xml;
+
+public class Supermarket extends BaseShop {
+
+	private String name;
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+}

--- a/hibernate-core/src/test/resources/org/hibernate/orm/test/jpa/xml/ExplicitOptimisticLockAnnotationOnCollectionXmlOnlyTest.xml
+++ b/hibernate-core/src/test/resources/org/hibernate/orm/test/jpa/xml/ExplicitOptimisticLockAnnotationOnCollectionXmlOnlyTest.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ SPDX-License-Identifier: Apache-2.0
+  ~ Copyright Red Hat Inc. and Hibernate Authors
+  -->
+<entity-mappings xmlns="http://www.hibernate.org/xsd/orm/mapping" version="7.0">
+
+    <package>org.hibernate.orm.test.jpa.xml</package>
+
+    <mapped-superclass class="BaseShop" metadata-complete="true" access="FIELD">
+        <attributes>
+            <id name="id">
+                <column name="id_entity"/>
+                <generated-value strategy="AUTO"/>
+            </id>
+            <version name="version">
+                <column name="version"/>
+            </version>
+        </attributes>
+    </mapped-superclass>
+
+    <entity class="Consumer" name="Consumer" metadata-complete="true">
+        <table name="consumer"/>
+        <attributes>
+            <id name="id">
+                <column name="id_entity"/>
+                <generated-value strategy="AUTO"/>
+            </id>
+            <version name="version">
+                <column name="version"/>
+            </version>
+            <one-to-many name="consumerItems" mapped-by="consumer" fetch="LAZY" optimistic-lock="true">
+                <cascade>
+                    <cascade-all/>
+                </cascade>
+            </one-to-many>
+        </attributes>
+    </entity>
+
+    <entity class="ConsumerItem" name="ConsumerInventory" metadata-complete="true">
+        <table name="consumer_item"/>
+        <attributes>
+            <id name="id">
+                <column name="id_entity"/>
+                <generated-value strategy="AUTO"/>
+            </id>
+            <version name="version">
+                <column name="version"/>
+            </version>
+            <many-to-one name="consumer" target-entity="Consumer">
+                <join-column name="consumer_id"/>
+                <cascade>
+                    <cascade-merge/>
+                </cascade>
+            </many-to-one>
+        </attributes>
+    </entity>
+
+    <entity class="Supermarket" name="Supermarket" metadata-complete="true">
+        <attributes>
+            <basic name="name"/>
+        </attributes>
+    </entity>
+
+</entity-mappings>
+
+

--- a/hibernate-core/src/test/resources/org/hibernate/orm/test/jpa/xml/NoDefaultOptimisticLockAnnotationTest.xml
+++ b/hibernate-core/src/test/resources/org/hibernate/orm/test/jpa/xml/NoDefaultOptimisticLockAnnotationTest.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ SPDX-License-Identifier: Apache-2.0
+  ~ Copyright Red Hat Inc. and Hibernate Authors
+  -->
+<entity-mappings xmlns="https://jakarta.ee/xml/ns/persistence/orm"
+                 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                 xsi:schemaLocation="https://jakarta.ee/xml/ns/persistence/orm https://jakarta.ee/xml/ns/persistence/orm/orm_3_2.xsd"
+                 version="3.2">
+
+    <package>org.hibernate.orm.test.jpa.xml</package>
+
+    <entity class="Consumer" name="Consumer">
+        <table name="consumer"/>
+        <attributes>
+            <id name="id">
+                <column name="id_entity"/>
+                <generated-value strategy="AUTO"/>
+            </id>
+            <version name="version">
+                <column name="version"/>
+            </version>
+            <one-to-many name="consumerItems" mapped-by="consumer" fetch="LAZY">
+                <cascade>
+                    <cascade-all/>
+                </cascade>
+            </one-to-many>
+        </attributes>
+    </entity>
+
+    <entity class="ConsumerItem" name="ConsumerInventory">
+        <table name="consumer_item"/>
+        <attributes>
+            <id name="id">
+                <column name="id_entity"/>
+                <generated-value strategy="AUTO"/>
+            </id>
+            <version name="version">
+                <column name="version"/>
+            </version>
+            <many-to-one name="consumer" target-entity="Consumer">
+                <join-column name="consumer_id"/>
+                <cascade>
+                    <cascade-merge/>
+                </cascade>
+            </many-to-one>
+        </attributes>
+    </entity>
+
+</entity-mappings>
+
+

--- a/hibernate-testing/src/main/java/org/hibernate/testing/jdbc/SQLStatementInspector.java
+++ b/hibernate-testing/src/main/java/org/hibernate/testing/jdbc/SQLStatementInspector.java
@@ -127,7 +127,19 @@ public class SQLStatementInspector implements StatementInspector {
 				.anySatisfy( sql -> Assertions.assertThat( sql.toLowerCase( Locale.ROOT ) ).startsWith( "update" ) );
 	}
 
+	public void assertInsert() {
+		Assertions.assertThat( sqlQueries )
+				.isNotEmpty()
+				.anySatisfy( sql -> Assertions.assertThat( sql.toLowerCase( Locale.ROOT ) ).startsWith( "insert" ) );
+	}
+
 	public static SQLStatementInspector extractFromSession(SessionImplementor session) {
 		return (SQLStatementInspector) session.getJdbcSessionContext().getStatementInspector();
+	}
+
+	public void assertHasQueryMatching(String queryPattern) {
+		Assertions.assertThat( sqlQueries )
+				.isNotEmpty()
+				.anySatisfy( sql -> Assertions.assertThat( sql.toLowerCase( Locale.ROOT ) ).matches( queryPattern ) );
 	}
 }


### PR DESCRIPTION
backport of https://github.com/hibernate/hibernate-orm/pull/10295

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-19528
https://hibernate.atlassian.net/browse/HHH-19495
<!-- Hibernate GitHub Bot issue links end -->