### PR TITLE
HHH-19529 Check bytecode generated classes with stable names class loaders to ensure EE subdeployment contained entity classes are used in preference to top level deployment (e.g. EAR/lib)

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/bytecode/internal/bytebuddy/ByteBuddyState.java
+++ b/hibernate-core/src/main/java/org/hibernate/bytecode/internal/bytebuddy/ByteBuddyState.java
@@ -229,7 +229,10 @@ public final class ByteBuddyState {
 	 */
 	public Class<?> load(Class<?> referenceClass, String className, BiFunction<ByteBuddy, NamingStrategy, DynamicType.Builder<?>> makeClassFunction) {
 		try {
-			return referenceClass.getClassLoader().loadClass( className );
+			Class<?> result = referenceClass.getClassLoader().loadClass(className);
+			if ( result.getClassLoader() == referenceClass.getClassLoader() ) {
+				return result;
+			}
 		}
 		catch (ClassNotFoundException e) {
 			// Ignore


### PR DESCRIPTION
Address https://hibernate.atlassian.net/browse/HHH-19529 + https://issues.redhat.com/browse/WFLY-20572

Ensure that bytecode generated proxies are generated in the referenceClass class loader to ensure EE subdeployment (e.g. war) contained entity classes are used in preference to top level deployment (e.g. EAR/lib).

More specifically, if an application EAR contains the entity classes in the ear/lib and also has several WARs that also contain the same entity classes, the war copy of the entity classes should be used. There may also be some WARs that do not contain those entity classes so those WARs should use the entity classes contained in the EAR/lib.

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
