### PR TITLE
implement equals() / hashCode() for NativeQueryConstructorTransformer (backport #10306)

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/jpa/spi/NativeQueryConstructorTransformer.java
+++ b/hibernate-core/src/main/java/org/hibernate/jpa/spi/NativeQueryConstructorTransformer.java
@@ -24,7 +24,7 @@ import java.lang.reflect.Constructor;
 public class NativeQueryConstructorTransformer<T> implements TupleTransformer<T> {
 
 	private final Class<T> resultClass;
-	private Constructor<T> constructor;
+	private transient Constructor<T> constructor;
 
 	private Constructor<T> constructor(Object[] elements) {
 		if ( constructor == null ) {
@@ -74,5 +74,17 @@ public class NativeQueryConstructorTransformer<T> implements TupleTransformer<T>
 		catch (Exception e) {
 			throw new InstantiationException( "Cannot instantiate query result type", resultClass, e );
 		}
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		return obj instanceof NativeQueryConstructorTransformer<?> that
+			&& this.resultClass == that.resultClass;
+			// should be safe to ignore the cached constructor here
+	}
+
+	@Override
+	public int hashCode() {
+		return resultClass.hashCode();
 	}
 }


### PR DESCRIPTION
to help the query interpretation cache

back port of #10306 to 7.0.

<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

[Please describe here what your change is about]

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
