### PR TITLE
[7.0] HHH-19522 upsert should not fail silently instead of throwing StaleObjectStateException

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/jdbc/Expectation.java
+++ b/hibernate-core/src/main/java/org/hibernate/jdbc/Expectation.java
@@ -181,7 +181,7 @@ public interface Expectation {
 
 	/**
 	 * Essentially identical to {@link RowCount} except that the row count
-	 * is obtained via an output parameter of a {@link CallableStatement
+	 * is obtained via an output parameter of a {@linkplain CallableStatement
 	 * stored procedure}.
 	 * <p>
 	 * Statement batching is disabled when {@code OutParameter} is used.

--- a/hibernate-core/src/main/java/org/hibernate/sql/model/jdbc/MergeOperation.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/model/jdbc/MergeOperation.java
@@ -23,13 +23,12 @@ public class MergeOperation extends AbstractJdbcMutation {
 			MutationTarget<?> mutationTarget,
 			String sql,
 			List<? extends JdbcParameterBinder> parameterBinders) {
-		super( tableDetails, mutationTarget, sql, false, Expectation.None.INSTANCE, parameterBinders );
+		super( tableDetails, mutationTarget, sql, false, new Expectation.RowCount(), parameterBinders );
 	}
 
 	@Override
 	public MutationType getMutationType() {
 		return MutationType.UPDATE;
 	}
-
 
 }

--- a/hibernate-core/src/main/java/org/hibernate/sql/model/jdbc/OptionalTableUpdateOperation.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/model/jdbc/OptionalTableUpdateOperation.java
@@ -13,6 +13,7 @@ import java.util.Locale;
 import java.util.Objects;
 import java.util.Set;
 
+import org.hibernate.StaleStateException;
 import org.hibernate.engine.jdbc.mutation.JdbcValueBindings;
 import org.hibernate.engine.jdbc.mutation.ParameterUsage;
 import org.hibernate.engine.jdbc.mutation.group.PreparedStatementDetails;
@@ -25,6 +26,7 @@ import org.hibernate.engine.jdbc.spi.JdbcCoordinator;
 import org.hibernate.engine.jdbc.spi.MutationStatementPreparer;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
+import org.hibernate.exception.ConstraintViolationException;
 import org.hibernate.internal.util.collections.CollectionHelper;
 import org.hibernate.jdbc.Expectation;
 import org.hibernate.persister.entity.mutation.EntityMutationTarget;
@@ -52,6 +54,7 @@ import org.hibernate.sql.model.internal.TableInsertStandard;
 import org.hibernate.sql.model.internal.TableUpdateCustomSql;
 import org.hibernate.sql.model.internal.TableUpdateStandard;
 
+import static org.hibernate.exception.ConstraintViolationException.ConstraintKind.UNIQUE;
 import static org.hibernate.sql.model.ModelMutationLogging.MODEL_MUTATION_LOGGER;
 
 /**
@@ -152,20 +155,28 @@ public class OptionalTableUpdateOperation implements SelfExecutingUpdateOperatio
 					wasUpdated = false;
 				}
 
-				if ( !wasUpdated ) {
-					MODEL_MUTATION_LOGGER.debugf(
-							"Upsert update altered no rows - inserting : %s",
-							tableMapping.getTableName()
-					);
-					performInsert( jdbcValueBindings, session );
+					if ( !wasUpdated ) {
+						MODEL_MUTATION_LOGGER.debugf(
+								"Upsert update altered no rows - inserting : %s",
+								tableMapping.getTableName()
+						);
+						try {
+							performInsert( jdbcValueBindings, session );
+						}
+						catch (ConstraintViolationException cve) {
+							throw cve.getKind() == UNIQUE
+									// assume it was the primary key constraint which was violated,
+									// due to a new version of the row existing in the database
+									? new StaleStateException( mutationTarget.getRolePath(), cve )
+									: cve;
+						}
+					}
 				}
 			}
+			finally {
+				jdbcValueBindings.afterStatement( tableMapping );
+			}
 		}
-		finally {
-			jdbcValueBindings.afterStatement( tableMapping );
-		}
-
-	}
 
 	private void performDelete(JdbcValueBindings jdbcValueBindings, SharedSessionContractImplementor session) {
 		final JdbcDeleteMutation jdbcDelete = createJdbcDelete( session );

--- a/hibernate-core/src/main/java/org/hibernate/sql/model/jdbc/UpsertOperation.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/model/jdbc/UpsertOperation.java
@@ -23,13 +23,12 @@ public class UpsertOperation extends AbstractJdbcMutation {
 			MutationTarget<?> mutationTarget,
 			String sql,
 			List<? extends JdbcParameterBinder> parameterBinders) {
-		super( tableDetails, mutationTarget, sql, false, Expectation.None.INSTANCE, parameterBinders );
+		super( tableDetails, mutationTarget, sql, false, new Expectation.RowCount(), parameterBinders );
 	}
 
 	@Override
 	public MutationType getMutationType() {
 		return MutationType.UPDATE;
 	}
-
 
 }

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/stateless/UpsertVersionedTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/stateless/UpsertVersionedTest.java
@@ -7,17 +7,21 @@ package org.hibernate.orm.test.stateless;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jakarta.persistence.Version;
+import org.hibernate.StaleObjectStateException;
 import org.hibernate.testing.orm.junit.DomainModel;
 import org.hibernate.testing.orm.junit.SessionFactory;
 import org.hibernate.testing.orm.junit.SessionFactoryScope;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 @SessionFactory
 @DomainModel(annotatedClasses = UpsertVersionedTest.Record.class)
 public class UpsertVersionedTest {
+
 	@Test void test(SessionFactoryScope scope) {
+		scope.getSessionFactory().getSchemaManager().truncate();
 		scope.inStatelessTransaction(s-> {
 			s.upsert(new Record(123L,null,"hello earth"));
 			s.upsert(new Record(456L,2L,"hello mars"));
@@ -41,6 +45,29 @@ public class UpsertVersionedTest {
 			assertEquals("goodbye mars",s.get(Record.class,456L).message);
 		});
 	}
+
+	@Test void testStaleUpsert(SessionFactoryScope scope) {
+		scope.getSessionFactory().getSchemaManager().truncate();
+		scope.inStatelessTransaction( s -> {
+			s.insert(new Record(789L, 1L, "hello world"));
+		} );
+		scope.inStatelessTransaction( s -> {
+			s.upsert(new Record(789L, 1L, "hello mars"));
+		} );
+		try {
+			scope.inStatelessTransaction( s -> {
+				s.upsert(new Record( 789L, 1L, "hello venus"));
+			} );
+			fail();
+		}
+		catch (StaleObjectStateException sose) {
+			//expected
+		}
+		scope.inStatelessTransaction( s-> {
+			assertEquals( "hello mars", s.get(Record.class,789L).message );
+		} );
+	}
+
 	@Entity(name = "Record")
 	static class Record {
 		@Id Long id;

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/stateless/UpsertVersionedTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/stateless/UpsertVersionedTest.java
@@ -7,7 +7,7 @@ package org.hibernate.orm.test.stateless;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jakarta.persistence.Version;
-import org.hibernate.StaleObjectStateException;
+import org.hibernate.StaleStateException;
 import org.hibernate.testing.orm.junit.DomainModel;
 import org.hibernate.testing.orm.junit.SessionFactory;
 import org.hibernate.testing.orm.junit.SessionFactoryScope;
@@ -60,7 +60,7 @@ public class UpsertVersionedTest {
 			} );
 			fail();
 		}
-		catch (StaleObjectStateException sose) {
+		catch (StaleStateException sse) {
 			//expected
 		}
 		scope.inStatelessTransaction( s-> {


### PR DESCRIPTION
<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

https://hibernate.atlassian.net/browse/HHH-19522

Backport of https://github.com/hibernate/hibernate-orm/pull/10289.

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
