### PR TITLE
[6.6] HHH-19522 upsert should not fail silently instead of throwing StaleObjectStateException

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/jdbc/Expectation.java
+++ b/hibernate-core/src/main/java/org/hibernate/jdbc/Expectation.java
@@ -182,7 +182,7 @@ public interface Expectation {
 
 	/**
 	 * Essentially identical to {@link RowCount} except that the row count
-	 * is obtained via an output parameter of a {@link CallableStatement
+	 * is obtained via an output parameter of a {@linkplain CallableStatement
 	 * stored procedure}.
 	 * <p>
 	 * Statement batching is disabled when {@code OutParameter} is used.

--- a/hibernate-core/src/main/java/org/hibernate/sql/model/jdbc/DeleteOrUpsertOperation.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/model/jdbc/DeleteOrUpsertOperation.java
@@ -20,7 +20,9 @@ import org.hibernate.engine.jdbc.mutation.internal.MutationQueryOptions;
 import org.hibernate.engine.jdbc.mutation.internal.PreparedStatementGroupSingleTable;
 import org.hibernate.engine.jdbc.mutation.spi.Binding;
 import org.hibernate.engine.jdbc.mutation.spi.BindingGroup;
+import org.hibernate.engine.jdbc.spi.JdbcServices;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
+import org.hibernate.jdbc.Expectation;
 import org.hibernate.persister.entity.mutation.EntityMutationTarget;
 import org.hibernate.persister.entity.mutation.EntityTableMapping;
 import org.hibernate.persister.entity.mutation.UpdateValuesAnalysis;
@@ -46,6 +48,7 @@ public class DeleteOrUpsertOperation implements SelfExecutingUpdateOperation {
 
 	private final OptionalTableUpdate optionalTableUpdate;
 
+	private final Expectation expectation = new Expectation.RowCount();
 
 	public DeleteOrUpsertOperation(
 			EntityMutationTarget mutationTarget,
@@ -118,7 +121,8 @@ public class DeleteOrUpsertOperation implements SelfExecutingUpdateOperation {
 
 		try {
 			final PreparedStatement upsertDeleteStatement = statementDetails.resolveStatement();
-			session.getJdbcServices().getSqlStatementLogger().logStatement( statementDetails.getSqlString() );
+			final JdbcServices jdbcServices = session.getJdbcServices();
+			jdbcServices.getSqlStatementLogger().logStatement( statementDetails.getSqlString() );
 
 			bindDeleteKeyValues(
 					jdbcValueBindings,
@@ -130,6 +134,16 @@ public class DeleteOrUpsertOperation implements SelfExecutingUpdateOperation {
 			final int rowCount = session.getJdbcCoordinator().getResultSetReturn()
 					.executeUpdate( upsertDeleteStatement, statementDetails.getSqlString() );
 			MODEL_MUTATION_LOGGER.tracef( "`%s` rows upsert-deleted from `%s`", rowCount, tableMapping.getTableName() );
+			try {
+				expectation.verifyOutcome( rowCount, upsertDeleteStatement, -1, statementDetails.getSqlString() );
+			}
+			catch (SQLException e) {
+				throw jdbcServices.getSqlExceptionHelper().convert(
+						e,
+						"Unable to verify outcome for upsert delete",
+						statementDetails.getSqlString()
+				);
+			}
 		}
 		finally {
 			statementDetails.releaseStatement( session );
@@ -197,14 +211,24 @@ public class DeleteOrUpsertOperation implements SelfExecutingUpdateOperation {
 
 		try {
 			final PreparedStatement updateStatement = statementDetails.resolveStatement();
-			session.getJdbcServices().getSqlStatementLogger().logStatement( statementDetails.getSqlString() );
-
+			final JdbcServices jdbcServices = session.getJdbcServices();
+			jdbcServices.getSqlStatementLogger().logStatement( statementDetails.getSqlString() );
 			jdbcValueBindings.beforeStatement( statementDetails );
 
 			final int rowCount = session.getJdbcCoordinator().getResultSetReturn()
 					.executeUpdate( updateStatement, statementDetails.getSqlString() );
 
 			MODEL_MUTATION_LOGGER.tracef( "`%s` rows upserted into `%s`", rowCount, tableMapping.getTableName() );
+			try {
+				expectation.verifyOutcome( rowCount, updateStatement, -1, statementDetails.getSqlString() );
+			}
+			catch (SQLException e) {
+				throw jdbcServices.getSqlExceptionHelper().convert(
+						e,
+						"Unable to verify outcome for upsert",
+						statementDetails.getSqlString()
+				);
+			}
 		}
 		finally {
 			statementDetails.releaseStatement( session );

--- a/hibernate-core/src/main/java/org/hibernate/sql/model/jdbc/MergeOperation.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/model/jdbc/MergeOperation.java
@@ -8,7 +8,7 @@ package org.hibernate.sql.model.jdbc;
 
 import java.util.List;
 
-import org.hibernate.jdbc.Expectations;
+import org.hibernate.jdbc.Expectation;
 import org.hibernate.sql.exec.spi.JdbcParameterBinder;
 import org.hibernate.sql.model.MutationTarget;
 import org.hibernate.sql.model.MutationType;
@@ -25,13 +25,12 @@ public class MergeOperation extends AbstractJdbcMutation {
 			MutationTarget<?> mutationTarget,
 			String sql,
 			List<? extends JdbcParameterBinder> parameterBinders) {
-		super( tableDetails, mutationTarget, sql, false, Expectations.NONE, parameterBinders );
+		super( tableDetails, mutationTarget, sql, false, new Expectation.RowCount(), parameterBinders );
 	}
 
 	@Override
 	public MutationType getMutationType() {
 		return MutationType.UPDATE;
 	}
-
 
 }

--- a/hibernate-core/src/main/java/org/hibernate/sql/model/jdbc/OptionalTableUpdateOperation.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/model/jdbc/OptionalTableUpdateOperation.java
@@ -15,6 +15,7 @@ import java.util.Locale;
 import java.util.Objects;
 import java.util.Set;
 
+import org.hibernate.StaleStateException;
 import org.hibernate.engine.jdbc.mutation.JdbcValueBindings;
 import org.hibernate.engine.jdbc.mutation.ParameterUsage;
 import org.hibernate.engine.jdbc.mutation.group.PreparedStatementDetails;
@@ -27,6 +28,7 @@ import org.hibernate.engine.jdbc.spi.JdbcCoordinator;
 import org.hibernate.engine.jdbc.spi.MutationStatementPreparer;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
+import org.hibernate.exception.ConstraintViolationException;
 import org.hibernate.internal.util.collections.CollectionHelper;
 import org.hibernate.jdbc.Expectation;
 import org.hibernate.persister.entity.mutation.EntityMutationTarget;
@@ -54,6 +56,7 @@ import org.hibernate.sql.model.internal.TableInsertStandard;
 import org.hibernate.sql.model.internal.TableUpdateCustomSql;
 import org.hibernate.sql.model.internal.TableUpdateStandard;
 
+import static org.hibernate.exception.ConstraintViolationException.ConstraintKind.UNIQUE;
 import static org.hibernate.sql.model.ModelMutationLogging.MODEL_MUTATION_LOGGER;
 
 /**
@@ -159,14 +162,22 @@ public class OptionalTableUpdateOperation implements SelfExecutingUpdateOperatio
 							"Upsert update altered no rows - inserting : %s",
 							tableMapping.getTableName()
 					);
-					performInsert( jdbcValueBindings, session );
+					try {
+						performInsert( jdbcValueBindings, session );
+					}
+					catch (ConstraintViolationException cve) {
+						throw cve.getKind() == UNIQUE
+								// assume it was the primary key constraint which was violated,
+								// due to a new version of the row existing in the database
+								? new StaleStateException( mutationTarget.getRolePath() )
+								: cve;
+					}
 				}
 			}
 		}
 		finally {
 			jdbcValueBindings.afterStatement( tableMapping );
 		}
-
 	}
 
 	private void performDelete(JdbcValueBindings jdbcValueBindings, SharedSessionContractImplementor session) {

--- a/hibernate-core/src/main/java/org/hibernate/sql/model/jdbc/UpsertOperation.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/model/jdbc/UpsertOperation.java
@@ -8,7 +8,7 @@ package org.hibernate.sql.model.jdbc;
 
 import java.util.List;
 
-import org.hibernate.jdbc.Expectations;
+import org.hibernate.jdbc.Expectation;
 import org.hibernate.sql.exec.spi.JdbcParameterBinder;
 import org.hibernate.sql.model.MutationTarget;
 import org.hibernate.sql.model.MutationType;
@@ -25,13 +25,12 @@ public class UpsertOperation extends AbstractJdbcMutation {
 			MutationTarget<?> mutationTarget,
 			String sql,
 			List<? extends JdbcParameterBinder> parameterBinders) {
-		super( tableDetails, mutationTarget, sql, false, Expectations.NONE, parameterBinders );
+		super( tableDetails, mutationTarget, sql, false, new Expectation.RowCount(), parameterBinders );
 	}
 
 	@Override
 	public MutationType getMutationType() {
 		return MutationType.UPDATE;
 	}
-
 
 }

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/stateless/UpsertVersionedTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/stateless/UpsertVersionedTest.java
@@ -3,45 +3,72 @@ package org.hibernate.orm.test.stateless;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jakarta.persistence.Version;
+import org.hibernate.StaleObjectStateException;
 import org.hibernate.testing.orm.junit.DomainModel;
 import org.hibernate.testing.orm.junit.SessionFactory;
 import org.hibernate.testing.orm.junit.SessionFactoryScope;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 @SessionFactory
 @DomainModel(annotatedClasses = UpsertVersionedTest.Record.class)
 public class UpsertVersionedTest {
-    @Test void test(SessionFactoryScope scope) {
-        scope.inStatelessTransaction(s-> {
-            s.upsert(new Record(123L,null,"hello earth"));
-            s.upsert(new Record(456L,2L,"hello mars"));
-        });
-        scope.inStatelessTransaction(s-> {
-            assertEquals("hello earth",s.get(Record.class,123L).message);
-            assertEquals("hello mars",s.get(Record.class,456L).message);
-        });
-        scope.inStatelessTransaction(s-> {
-            s.upsert(new Record(123L,0L,"goodbye earth"));
-        });
-        scope.inStatelessTransaction(s-> {
-            assertEquals("goodbye earth",s.get(Record.class,123L).message);
-            assertEquals("hello mars",s.get(Record.class,456L).message);
-        });
-        scope.inStatelessTransaction(s-> {
-            s.upsert(new Record(456L,3L,"goodbye mars"));
-        });
-        scope.inStatelessTransaction(s-> {
-            assertEquals("goodbye earth",s.get(Record.class,123L).message);
-            assertEquals("goodbye mars",s.get(Record.class,456L).message);
-        });
-    }
-    @Entity(name = "Record")
-    static class Record {
-        @Id Long id;
-        @Version Long version;
-        String message;
+
+	@Test void test(SessionFactoryScope scope) {
+		scope.getSessionFactory().getSchemaManager().truncateMappedObjects();
+		scope.inStatelessTransaction(s-> {
+			s.upsert(new Record(123L,null,"hello earth"));
+			s.upsert(new Record(456L,2L,"hello mars"));
+		});
+		scope.inStatelessTransaction(s-> {
+			assertEquals( "hello earth", s.get( Record.class,123L).message );
+			assertEquals( "hello mars", s.get( Record.class,456L).message );
+		});
+		scope.inStatelessTransaction(s-> {
+			s.upsert(new Record(123L,0L,"goodbye earth"));
+		});
+		scope.inStatelessTransaction(s-> {
+			assertEquals( "goodbye earth", s.get( Record.class,123L).message );
+			assertEquals( "hello mars", s.get( Record.class,456L).message );
+		});
+		scope.inStatelessTransaction(s-> {
+			s.upsert(new Record(456L,3L,"goodbye mars"));
+		});
+		scope.inStatelessTransaction(s-> {
+			assertEquals( "goodbye earth", s.get( Record.class,123L).message );
+			assertEquals( "goodbye mars", s.get( Record.class,456L).message );
+		});
+	}
+
+	@Test void testStaleUpsert(SessionFactoryScope scope) {
+		scope.getSessionFactory().getSchemaManager().truncateMappedObjects();
+		scope.inStatelessTransaction( s -> {
+			s.insert(new Record(789L, 1L, "hello world"));
+		} );
+		scope.inStatelessTransaction( s -> {
+			s.upsert(new Record(789L, 1L, "hello mars"));
+		} );
+		try {
+			scope.inStatelessTransaction( s -> {
+				s.upsert(new Record( 789L, 1L, "hello venus"));
+			} );
+			fail();
+		}
+		catch (StaleObjectStateException sose) {
+			//expected
+		}
+		scope.inStatelessTransaction( s-> {
+			assertEquals( "hello mars", s.get(Record.class,789L).message );
+		} );
+	}
+
+	@Entity(name = "Record")
+	static class Record {
+		@Id Long id;
+		@Version Long version;
+		String message;
 
         Record(Long id, Long version, String message) {
             this.id = id;

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/stateless/UpsertVersionedTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/stateless/UpsertVersionedTest.java
@@ -3,7 +3,7 @@ package org.hibernate.orm.test.stateless;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jakarta.persistence.Version;
-import org.hibernate.StaleObjectStateException;
+import org.hibernate.StaleStateException;
 import org.hibernate.testing.orm.junit.DomainModel;
 import org.hibernate.testing.orm.junit.SessionFactory;
 import org.hibernate.testing.orm.junit.SessionFactoryScope;
@@ -56,7 +56,7 @@ public class UpsertVersionedTest {
 			} );
 			fail();
 		}
-		catch (StaleObjectStateException sose) {
+		catch (StaleStateException sse) {
 			//expected
 		}
 		scope.inStatelessTransaction( s-> {


### PR DESCRIPTION
<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

https://hibernate.atlassian.net/browse/HHH-19522

Backport of https://github.com/hibernate/hibernate-orm/pull/10289

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
