### PR TITLE
[7.0] Backport HHH-19531 + HHH-19532 Add unwrap() method to `StatelessSession`/`SharedSessionContract` and use it instead of casts in Jakarta Data implementation

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/Session.java
+++ b/hibernate-core/src/main/java/org/hibernate/Session.java
@@ -1494,4 +1494,9 @@ public interface Session extends SharedSessionContract, EntityManager {
 	 */
 	@Override @Deprecated(since = "6.0") @SuppressWarnings("rawtypes")
 	Query createQuery(CriteriaUpdate updateQuery);
+
+	@Override
+	default <T> T unwrap(Class<T> type) {
+		return SharedSessionContract.super.unwrap(type);
+	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/internal/SessionImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/SessionImpl.java
@@ -2948,7 +2948,8 @@ public class SessionImpl
 			return type.cast( persistenceContext );
 		}
 
-		throw new PersistenceException( "Hibernate cannot unwrap EntityManager as '" + type.getName() + "'" );
+		throw new PersistenceException(
+				"Hibernate cannot unwrap '" + getClass().getName() + "' as '" + type.getName() + "'" );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/internal/StatelessSessionImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/StatelessSessionImpl.java
@@ -9,6 +9,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.function.BiConsumer;
 
+import jakarta.persistence.PersistenceException;
 import org.hibernate.AssertionFailure;
 import org.hibernate.FlushMode;
 import org.hibernate.HibernateException;
@@ -1425,6 +1426,18 @@ public class StatelessSessionImpl extends AbstractSharedSessionContract implemen
 	@Override
 	public Object loadFromSecondLevelCache(EntityPersister persister, EntityKey entityKey, Object instanceToLoad, LockMode lockMode) {
 		return CacheLoadHelper.loadFromSecondLevelCache( this, instanceToLoad, lockMode, persister, entityKey );
+	}
+
+	@Override
+	public <T> T unwrap(Class<T> type) {
+		checkOpen();
+
+		if ( type.isInstance( this ) ) {
+			return type.cast( this );
+		}
+
+		throw new PersistenceException(
+				"Hibernate cannot unwrap '" + getClass().getName() + "' as '" + type.getName() + "'" );
 	}
 
 	private static final class MultiLoadOptions implements MultiIdLoadOptions {

--- a/hibernate-core/src/main/java/org/hibernate/query/specification/internal/MutationSpecificationImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/specification/internal/MutationSpecificationImpl.java
@@ -122,7 +122,7 @@ public class MutationSpecificationImpl<T> implements MutationSpecification<T>, T
 	}
 
 	public MutationQuery createQuery(SharedSessionContract session) {
-		final var sessionImpl = (SharedSessionContractImplementor) session;
+		final var sessionImpl = session.unwrap(SharedSessionContractImplementor.class);
 		final SqmDeleteOrUpdateStatement<T> sqmStatement = build( sessionImpl.getFactory().getQueryEngine() );
 		return new QuerySqmImpl<>( sqmStatement, true, null, sessionImpl );
 	}

--- a/hibernate-core/src/main/java/org/hibernate/query/specification/internal/SelectionSpecificationImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/specification/internal/SelectionSpecificationImpl.java
@@ -164,7 +164,7 @@ public class SelectionSpecificationImpl<T> implements SelectionSpecification<T>,
 	}
 
 	public SelectionQuery<T> createQuery(SharedSessionContract session) {
-		final var sessionImpl = (SharedSessionContractImplementor) session;
+		final var sessionImpl = session.unwrap(SharedSessionContractImplementor.class);
 		final SqmSelectStatement<T> sqmStatement = build( sessionImpl.getFactory().getQueryEngine() );
 		return new SqmSelectionQueryImpl<>( sqmStatement, true, resultType, sessionImpl );
 	}


### PR DESCRIPTION
* [HHH-19532](https://hibernate.atlassian.net/browse/HHH-19532): Add unwrap() method to StatelessSession/SharedSessionContract
* [HHH-19531](https://hibernate.atlassian.net/browse/HHH-19531): Jakarta Data implementation casts StatlessSession to *Implementor interfaces

Backport of #10312 

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------


[HHH-19532]: https://hibernate.atlassian.net/browse/HHH-19532?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[HHH-19531]: https://hibernate.atlassian.net/browse/HHH-19531?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ