### PR TITLE
Use a cron trigger instead of build throttling for nightly builds

### DIFF
--- a/nightly.Jenkinsfile
+++ b/nightly.Jenkinsfile
@@ -53,7 +53,9 @@ stage('Configure') {
 			buildDiscarder(
 					logRotator(daysToKeepStr: '30', numToKeepStr: '10')
 			),
-			rateLimitBuilds(throttle: [count: 1, durationName: 'day', userBoost: true]),
+			pipelineTriggers([
+					cron('H H(4-6) * * *')
+			]),
 			// If two builds are about the same branch or pull request,
 			// the older one will be aborted when the newer one starts.
 			disableConcurrentBuilds(abortPrevious: true),


### PR DESCRIPTION
I'm unsure about this one..  but nightly builds that start at 10 am 😃  don't feel like nightly builds 🙈 😃 
https://ci.hibernate.org/job/hibernate-orm-nightly/job/main/873/

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
