### PR TITLE
HHH-19540 fix coalesce(:ids, 1) automatic add parentheses

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/query/sql/internal/NativeQueryImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sql/internal/NativeQueryImpl.java
@@ -969,7 +969,7 @@ public class NativeQueryImpl<R>
 		for ( int i = sourcePosition - 1; i >= 0; i-- ) {
 			final char ch = sqlString.charAt( i );
 			if ( !isWhitespace( ch ) ) {
-				isEnclosedInParens = ch == '(';
+				isEnclosedInParens = ch == '(' || ch == ',';
 				break;
 			}
 		}
@@ -977,7 +977,7 @@ public class NativeQueryImpl<R>
 			for ( int i = sourcePosition + 1; i < sqlString.length(); i++ ) {
 				final char ch = sqlString.charAt( i );
 				if ( !isWhitespace( ch ) ) {
-					isEnclosedInParens = ch == ')';
+					isEnclosedInParens = ch == ')' || ch == ',';
 					break;
 				}
 			}


### PR DESCRIPTION
Repairing coalescence (ids, 1) will generate SQL for coalescence ((?,?,?), 1).  
Similar situations: order by field(id , :id) 

current:
Even though coalescence (: param1,: param2, 1) ,  only generating coalescence (?,?,?, 1), not add extral parentheses

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-19540
<!-- Hibernate GitHub Bot issue links end -->