### PR TITLE
HHH-8370 SQL Server IN-list Performance Improvement

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/dialect/Dialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/Dialect.java
@@ -6209,8 +6209,8 @@ public abstract class Dialect implements ConversionContext, TypeContributor, Fun
 	}
 
 	/**
-	 * If the dialect supports {@link org.hibernate.dialect.Dialect#supportsRowValueConstructorSyntax() row values},
-	 * does it allow using them in a derived table within an EXISTS predicate that emulates an IN-list?
+	 * This pattern avoids the SQL length and performance issues of large disjunctions,
+	 * and emulates tuple-based IN-list comparisons using a derived VALUES table.
 	 * <p>
 	 * For example:
 	 * <pre>
@@ -6220,13 +6220,8 @@ public abstract class Dialect implements ConversionContext, TypeContributor, Fun
 	 *         WHERE T.FIELD1 = V.FIELD1 AND T.FIELD2 = V.FIELD2
 	 *     )
 	 * </pre>
-	 * This pattern avoids the SQL length and performance issues of large disjunctions,
-	 * and emulates tuple-based IN-list comparisons using a derived VALUES table.
-	 *
-	 * @return True if this SQL dialect is known to support row value constructors in
-	 *         derived tables for EXISTS-based IN-list emulation; false otherwise.
 	 */
-	public boolean supportsRowValueConstructorSyntaxInDerivedTableInList() {
+	public boolean supportsValuesListForInListExistsEmulation() {
 		return false;
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/dialect/Dialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/Dialect.java
@@ -6208,4 +6208,25 @@ public abstract class Dialect implements ConversionContext, TypeContributor, Fun
 		return supportsRowValueConstructorSyntaxInInList();
 	}
 
+	/**
+	 * If the dialect supports {@link org.hibernate.dialect.Dialect#supportsRowValueConstructorSyntax() row values},
+	 * does it allow using them in a derived table within an EXISTS predicate that emulates an IN-list?
+	 * <p>
+	 * For example:
+	 * <pre>
+	 *     SELECT * FROM EntityTable T
+	 *     WHERE EXISTS (
+	 *         SELECT 1 FROM (VALUES (?, ?), (?, ?)) AS V(FIELD1, FIELD2)
+	 *         WHERE T.FIELD1 = V.FIELD1 AND T.FIELD2 = V.FIELD2
+	 *     )
+	 * </pre>
+	 * This pattern avoids the SQL length and performance issues of large disjunctions,
+	 * and emulates tuple-based IN-list comparisons using a derived VALUES table.
+	 *
+	 * @return True if this SQL dialect is known to support row value constructors in
+	 *         derived tables for EXISTS-based IN-list emulation; false otherwise.
+	 */
+	public boolean supportsRowValueConstructorSyntaxInDerivedTableInList() {
+		return false;
+	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/dialect/SQLServerDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/SQLServerDialect.java
@@ -1245,7 +1245,7 @@ public class SQLServerDialect extends AbstractTransactSQLDialect {
 
 	@Override
 	public boolean supportsRowValueConstructorSyntax() {
-		return getVersion().isSameOrAfter( 10 );
+		return false;
 	}
 
 	@Override
@@ -1264,7 +1264,7 @@ public class SQLServerDialect extends AbstractTransactSQLDialect {
 	}
 
 	@Override
-	public boolean supportsRowValueConstructorSyntaxInDerivedTableInList() {
+	public boolean supportsValuesListForInListExistsEmulation() {
 		return getVersion().isSameOrAfter( 10 );
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/dialect/SQLServerDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/SQLServerDialect.java
@@ -1245,7 +1245,7 @@ public class SQLServerDialect extends AbstractTransactSQLDialect {
 
 	@Override
 	public boolean supportsRowValueConstructorSyntax() {
-		return false;
+		return getVersion().isSameOrAfter( 10 );
 	}
 
 	@Override
@@ -1263,4 +1263,8 @@ public class SQLServerDialect extends AbstractTransactSQLDialect {
 		return false;
 	}
 
+	@Override
+	public boolean supportsRowValueConstructorSyntaxInDerivedTableInList() {
+		return getVersion().isSameOrAfter( 10 );
+	}
 }

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/dialect/functional/SQLServerDialectCompositeTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/dialect/functional/SQLServerDialectCompositeTest.java
@@ -1,0 +1,98 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.dialect.functional;
+
+import org.hibernate.cfg.AvailableSettings;
+import org.hibernate.dialect.SQLServerDialect;
+import org.hibernate.orm.test.jpa.CompositeId;
+import org.hibernate.orm.test.jpa.EntityWithCompositeId;
+import org.hibernate.testing.jdbc.SQLStatementInspector;
+import org.hibernate.testing.orm.junit.EntityManagerFactoryScope;
+import org.hibernate.testing.orm.junit.JiraKey;
+import org.hibernate.testing.orm.junit.Jpa;
+import org.hibernate.testing.orm.junit.RequiresDialect;
+import org.hibernate.testing.orm.junit.Setting;
+import org.junit.jupiter.api.Test;
+
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * @author Rob Green
+ */
+@JiraKey( value = "HHH-8370" )
+@RequiresDialect( value = SQLServerDialect.class, majorVersion = 10 )
+@Jpa(
+		annotatedClasses = { EntityWithCompositeId.class },
+		integrationSettings = {
+				@Setting( name = AvailableSettings.USE_SQL_COMMENTS, value = "true" ),
+		},
+		useCollectingStatementInspector = true
+)
+public class SQLServerDialectCompositeTest {
+	@Test
+	public void testCompositeQueryWithInPredicate(EntityManagerFactoryScope scope) {
+		final SQLStatementInspector sqlStatementInterceptor = scope.getCollectingStatementInspector();
+		sqlStatementInterceptor.clear();
+
+		List<CompositeId> compositeIds = new ArrayList<>();
+		compositeIds.add( new CompositeId( 1,2 ) );
+		compositeIds.add( new CompositeId( 3,4 ) );
+
+		scope.inTransaction( entityManager -> {
+					entityManager.createQuery( "SELECT e FROM EntityWithCompositeId e WHERE e.id IN (:ids)" )
+							.setParameter( "ids", compositeIds )
+							.getResultList();
+				}
+		);
+
+		var query = sqlStatementInterceptor.getSqlQueries().get( 0 );
+		assertTrue(query.endsWith( "where exists (select 1 from (values (?,?), (?,?)) as v(id1, id2) where ewci1_0.id1 = v.id1 and ewci1_0.id2 = v.id2)" ));
+	}
+
+	@Test
+	public void testCompositeQueryWithNotInPredicate(EntityManagerFactoryScope scope) {
+		final SQLStatementInspector sqlStatementInterceptor = scope.getCollectingStatementInspector();
+		sqlStatementInterceptor.clear();
+
+		List<CompositeId> compositeIds = new ArrayList<>();
+		compositeIds.add( new CompositeId( 1,2 ) );
+		compositeIds.add( new CompositeId( 3,4 ) );
+
+		scope.inTransaction( entityManager -> {
+					entityManager.createQuery( "SELECT e FROM EntityWithCompositeId e WHERE e.id NOT IN (:ids)" )
+							.setParameter( "ids", compositeIds )
+							.getResultList();
+				}
+		);
+
+		var query = sqlStatementInterceptor.getSqlQueries().get( 0 );
+		assertTrue(query.endsWith( "where not exists (select 1 from (values (?,?), (?,?)) as v(id1, id2) where ewci1_0.id1 = v.id1 and ewci1_0.id2 = v.id2)" ));
+	}
+
+	@Test
+	public void testCompositeQueryWithMultiplePredicatesIncludingIn(EntityManagerFactoryScope scope) {
+		final SQLStatementInspector sqlStatementInterceptor = scope.getCollectingStatementInspector();
+		sqlStatementInterceptor.clear();
+
+		List<CompositeId> compositeIds = new ArrayList<>();
+		compositeIds.add( new CompositeId( 1,2 ) );
+		compositeIds.add( new CompositeId( 3,4 ) );
+
+		scope.inTransaction( entityManager -> {
+					entityManager.createQuery("SELECT e FROM EntityWithCompositeId e WHERE e.description = :description AND e.id IN (:ids)")
+							.setParameter( "ids", compositeIds )
+							.setParameter( "description", "test" )
+							.getResultList();
+				}
+		);
+
+		var query = sqlStatementInterceptor.getSqlQueries().get( 0 );
+		assertTrue(query.endsWith( "where ewci1_0.description=? and exists (select 1 from (values (?,?), (?,?)) as v(id1, id2) where ewci1_0.id1 = v.id1 and ewci1_0.id2 = v.id2)" ));
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/dialect/functional/SQLServerDialectCompositeTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/dialect/functional/SQLServerDialectCompositeTest.java
@@ -52,7 +52,7 @@ public class SQLServerDialectCompositeTest {
 		);
 
 		var query = sqlStatementInterceptor.getSqlQueries().get( 0 );
-		assertTrue( query.endsWith( "where exists (select 1 from (values (?,?), (?,?)) as v(id1, id2) where ewci1_0.id1 = v.id1 and ewci1_0.id2 = v.id2)" ) );
+		assertTrue( query.endsWith( "where exists (select 1 from (values (?,?), (?,?)) as v(col_0, col_1) where ewci1_0.id1 = v.col_0 and ewci1_0.id2 = v.col_1)" ) );
 	}
 
 	@Test
@@ -72,7 +72,7 @@ public class SQLServerDialectCompositeTest {
 		);
 
 		var query = sqlStatementInterceptor.getSqlQueries().get( 0 );
-		assertTrue( query.endsWith( "where not exists (select 1 from (values (?,?), (?,?)) as v(id1, id2) where ewci1_0.id1 = v.id1 and ewci1_0.id2 = v.id2)" ) );
+		assertTrue( query.endsWith( "where not exists (select 1 from (values (?,?), (?,?)) as v(col_0, col_1) where ewci1_0.id1 = v.col_0 and ewci1_0.id2 = v.col_1)" ) );
 	}
 
 	@Test
@@ -93,6 +93,6 @@ public class SQLServerDialectCompositeTest {
 		);
 
 		var query = sqlStatementInterceptor.getSqlQueries().get( 0 );
-		assertTrue( query.endsWith( "where ewci1_0.description=? and exists (select 1 from (values (?,?), (?,?)) as v(id1, id2) where ewci1_0.id1 = v.id1 and ewci1_0.id2 = v.id2)" ) );
+		assertTrue( query.endsWith( "where ewci1_0.description=? and exists (select 1 from (values (?,?), (?,?)) as v(col_0, col_1) where ewci1_0.id1 = v.col_0 and ewci1_0.id2 = v.col_1)" ) );
 	}
 }

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/dialect/functional/SQLServerDialectCompositeTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/dialect/functional/SQLServerDialectCompositeTest.java
@@ -52,7 +52,7 @@ public class SQLServerDialectCompositeTest {
 		);
 
 		var query = sqlStatementInterceptor.getSqlQueries().get( 0 );
-		assertTrue(query.endsWith( "where exists (select 1 from (values (?,?), (?,?)) as v(id1, id2) where ewci1_0.id1 = v.id1 and ewci1_0.id2 = v.id2)" ));
+		assertTrue( query.endsWith( "where exists (select 1 from (values (?,?), (?,?)) as v(id1, id2) where ewci1_0.id1 = v.id1 and ewci1_0.id2 = v.id2)" ) );
 	}
 
 	@Test
@@ -72,7 +72,7 @@ public class SQLServerDialectCompositeTest {
 		);
 
 		var query = sqlStatementInterceptor.getSqlQueries().get( 0 );
-		assertTrue(query.endsWith( "where not exists (select 1 from (values (?,?), (?,?)) as v(id1, id2) where ewci1_0.id1 = v.id1 and ewci1_0.id2 = v.id2)" ));
+		assertTrue( query.endsWith( "where not exists (select 1 from (values (?,?), (?,?)) as v(id1, id2) where ewci1_0.id1 = v.id1 and ewci1_0.id2 = v.id2)" ) );
 	}
 
 	@Test
@@ -85,7 +85,7 @@ public class SQLServerDialectCompositeTest {
 		compositeIds.add( new CompositeId( 3,4 ) );
 
 		scope.inTransaction( entityManager -> {
-					entityManager.createQuery("SELECT e FROM EntityWithCompositeId e WHERE e.description = :description AND e.id IN (:ids)")
+					entityManager.createQuery( "SELECT e FROM EntityWithCompositeId e WHERE e.description = :description AND e.id IN (:ids)" )
 							.setParameter( "ids", compositeIds )
 							.setParameter( "description", "test" )
 							.getResultList();
@@ -93,6 +93,6 @@ public class SQLServerDialectCompositeTest {
 		);
 
 		var query = sqlStatementInterceptor.getSqlQueries().get( 0 );
-		assertTrue(query.endsWith( "where ewci1_0.description=? and exists (select 1 from (values (?,?), (?,?)) as v(id1, id2) where ewci1_0.id1 = v.id1 and ewci1_0.id2 = v.id2)" ));
+		assertTrue( query.endsWith( "where ewci1_0.description=? and exists (select 1 from (values (?,?), (?,?)) as v(id1, id2) where ewci1_0.id1 = v.id1 and ewci1_0.id2 = v.id2)" ) );
 	}
 }


### PR DESCRIPTION
Adds support to SQL Server 2008 and above for more performant IN-list queries. 

Current behavior generates queries like:
```
WHERE ((T.FIELD1=? AND T.FIELD2=?) OR (T.FIELD1=? AND T.FIELD2=?) OR ... (T.FIELD1=? AND T.FIELD2=?))
```
and a more performant query would be:
```
WHERE EXISTS (
  SELECT 1 FROM (VALUES (?,?), (?,?), (?,?)) AS V(FIELD1, FIELD2)
  WHERE T.FIELD1 = V.FIELD1 AND T.FIELD2 = V.FIELD2
)
```

----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------

https://hibernate.atlassian.net/browse/HHH-8370
