### PR TITLE
add a test for merging a null collection

### DIFF
--- a/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/emops/MergeNullCollectionTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/emops/MergeNullCollectionTest.java
@@ -1,0 +1,46 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.jpa.emops;
+
+import jakarta.persistence.ElementCollection;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import org.hibernate.testing.orm.junit.EntityManagerFactoryScope;
+import org.hibernate.testing.orm.junit.Jpa;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@Jpa(annotatedClasses = MergeNullCollectionTest.Thing.class)
+class MergeNullCollectionTest {
+	@Test void test(EntityManagerFactoryScope scope) {
+		Thing thing = new Thing();
+		thing.strings.add( "hello" );
+		thing.strings.add( "goodbye" );
+		scope.inTransaction( em -> {
+			em.persist( thing );
+		} );
+		scope.inTransaction( em -> {
+			assertEquals(2, em.find( Thing.class, thing.id ).strings.size());
+		});
+		thing.strings = null;
+		scope.inTransaction( em -> {
+			assertEquals( 0, em.merge( thing ).strings.size() );
+		} );
+		scope.inTransaction( em -> {
+			assertEquals(0, em.find( Thing.class, thing.id ).strings.size());
+		});
+	}
+	@Entity
+	static class Thing {
+		@Id
+		long id;
+		@ElementCollection
+		Set<String> strings = new HashSet<>();
+	}
+}


### PR DESCRIPTION
It was claimed in the long discussion here https://hibernate.atlassian.net/browse/HHH-14839 that no tests fail when the behavior of Hibernate with respect to merging null collections is changed.

If that's true, then we're obviously missing a test for this scenario.

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
