### PR TITLE
Add an extra parameter to control release stage: Upload/Publish (for "manual" publishing)

### DIFF
--- a/ci/release/Jenkinsfile
+++ b/ci/release/Jenkinsfile
@@ -95,6 +95,11 @@ pipeline {
 				defaultValue: false,
 				description: 'If true, just simulate the release, without pushing any commits or tags, and without uploading any artifacts or documentation.'
 		)
+		booleanParam(
+				name: 'RELEASE_PUBLISH_AUTOMATICALLY',
+				defaultValue: true,
+				description: 'If true, staging repository will get closed and published automatically, otherwise the artifacts will only be uploaded and the publishing (releasing the staging repository) has to be performed manually at Maven Central portal.'
+		)
 	}
 	stages {
 		stage('Check') {
@@ -166,6 +171,9 @@ pipeline {
 					env.DEVELOPMENT_VERSION = developmentVersion.toString()
 					env.SCRIPT_OPTIONS = params.RELEASE_DRY_RUN ? "-d" : ""
 					env.JRELEASER_DRY_RUN = params.RELEASE_DRY_RUN
+					if (!params.RELEASE_PUBLISH_AUTOMATICALLY) {
+						env.JRELEASER_DEPLOY_MAVEN_MAVENCENTRAL_STAGE='UPLOAD'
+					}
 
 					// Determine version id to check if Jira version exists
 					sh ".release/scripts/determine-jira-version-id.sh ${env.JIRA_KEY} ${releaseVersion.withoutFinalQualifier}"


### PR DESCRIPTION
by default, everything is published automatically, and if the extra parameter is unchecked, then the manual step to publish artifacts from the portal would be required. 

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
