### PR TITLE
ParameterizedTypeImpl constructor parameter ownerType can be null

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/type/internal/ParameterizedTypeImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/internal/ParameterizedTypeImpl.java
@@ -11,6 +11,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.StringJoiner;
 
+import jakarta.annotation.Nullable;
 import org.hibernate.models.spi.ParameterizedTypeDetails;
 import org.hibernate.models.spi.TypeDetails;
 import org.hibernate.models.spi.TypeVariableScope;
@@ -21,7 +22,7 @@ public class ParameterizedTypeImpl implements ParameterizedType {
 	private final Type rawType;
 	private final Type ownerType;
 
-	public ParameterizedTypeImpl(Type rawType, Type[] substTypeArgs, Type ownerType) {
+	public ParameterizedTypeImpl(Type rawType, Type[] substTypeArgs, @Nullable Type ownerType) {
 		this.substTypeArgs = substTypeArgs;
 		this.rawType = rawType;
 		this.ownerType = ownerType;


### PR DESCRIPTION
Minor change: `ownerType` parameter in `org.hibernate.type.internal.ParameterizedTypeImpl` constructor is annotated with `@Nullable`

This parameter is implicitly non nullable, but it is always `null` for top level classes. One example is static copy constructor `org.hibernate.type.internal.ParameterizedTypeImpl#from` where `ownerType` parameter can be set to `null`.



<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
