### PR TITLE
Enable dependabot for most dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,14 +6,6 @@ registries:
     username: dummy # Required by dependabot
     password: dummy # Required by dependabot
 updates:
-  - package-ecosystem: "gradle"
-    directory: "/"
-    allow:
-      - dependency-name: "com.gradle*"
-    registries:
-      - gradle-plugin-portal
-    schedule:
-      interval: "weekly"
   - package-ecosystem: github-actions
     directory: "/"
     schedule:
@@ -25,3 +17,128 @@ updates:
     allow:
       - dependency-name: "actions/*"
       - dependency-name: "redhat-actions/*"
+  - package-ecosystem: "gradle"
+    directory: "/"
+    registries:
+      - gradle-plugin-portal
+    schedule:
+      interval: "weekly"
+      day: "wednesday"
+    open-pull-requests-limit: 20
+    groups:
+      # These are used in tooling we publish (Gradle, Ant, Maven plugins)
+      # and thus must be treated as runtime dependencies,
+      # which cannot be included in the build-dependencies group below.
+      tooling-dependencies:
+        patterns:
+          # Note: Gradle tooling dependencies seem to be tied to the version of Gradle we use for building.
+          - "org.apache.ant*"
+          - "org.apache.maven:maven-plugin-api"
+          - "org.apache.maven:maven-project"
+          - "org.apache.maven.shared:file-management"
+          - "org.apache.maven.plugin-tools:maven-plugin-annotations"
+      # This group combines all build-only dependencies. Published artifacts do not depend on them.
+      # Grouping such dependencies will make Dependabot create PRs with a branch name
+      # following the pattern (`dependabot/maven/build-dependencies-.*`)
+      # and with a title like `Bump the build-dependencies group with 8 updates` that we can easily
+      # use for Hibernate Bot rules.
+      build-dependencies:
+        patterns:
+          # Gradle plugins:
+          - "com.gradle*"
+          - "org.moditect*"
+          - "de.thetaphi*"
+          - "org.gradlex*"
+          - "org.hibernate.build*"
+          - "org.hibernate.orm.build*"
+          - "org.hibernate.orm.database-service*"
+          - "org.hibernate.orm.antlr*"
+          - "io.github.gradle-nexus*"
+          - "biz.aQute.bnd*"
+          - "org.checkerframework*"
+          - "org.jetbrains.gradle*"
+          - "com.dorongold*"
+          - "org.asciidoctor*"
+          - "com.diffplug.spotless*"
+          # Local build plugin dependencies:
+          - "org.apache.maven*"
+          - "org.apache.httpcomponents*"
+          # DB drivers:
+          - "com.h2database:h2"
+          - "org.orbisgis:h2gis"
+          - "org.hsqldb:hsqldb"
+          - "org.apache.derby*"
+          - "org.postgresql:*"
+          - "com.mysql:mysql-connector-j"
+          - "org.mariadb.jdbc:mariadb-java-client"
+          - "com.oracle.database.*"
+          - "com.microsoft.sqlserver:mssql-jdbc"
+          - "com.ibm.db2:jcc"
+          - "com.sap.cloud.db.jdbc:ngdbc"
+          - "net.sourceforge.jtds:jtds"
+          - "com.ibm.informix:jdbc"
+          - "org.firebirdsql.jdbc:jaybird"
+          - "com.altibase:altibase-jdbc"
+          # Other test dependencies
+          - "org.apache.groovy:groovy-jsr223" # used for scripting maven plugin
+          - "org.apache.commons:commons-lang3" # used in hibernate-search-util-common tests
+          - "org.apache.commons:commons-math3" # used to solve dependency convergence for Wiremock
+          - "org.openjdk.jmh:*" # performance testing dependency
+          - "com.google.guava:guava" # Guava is used in our test utils
+          - "org.asciidoctor:*" # Asciidoctor is used for rendering the documentation
+          - "org.jboss.marshalling:jboss-marshalling" # JBeret IT dependency
+          - "org.wildfly.security:wildfly-security-manager" # JBeret IT dependency
+          - "org.springframework.boot:*" # Spring is only for ITs
+          - "io.agroal:agroal-spring-boot-starter" # part of Spring dependencies, is only for ITs
+          - "dev.snowdrop:narayana-spring-boot-starter" # part of Spring dependencies, is only for ITs
+          - "org.mockito:*"
+          - "org.hamcrest:*"
+          - "org.apache.logging.log4j:*"
+          - "org.assertj:*"
+          - "org.jsoup:*"
+          - "org.junit*"
+          - "org.jboss.weld.se:*"
+          - "org.jboss.narayana.*:*"
+          - "org.wildfly.transaction:*"
+          - "org.jboss:jboss-transaction-spi"
+          - "org.jboss.shrinkwrap*"
+          - "org.jboss.byteman*"
+      hibernate:
+        patterns:
+          - "org.hibernate*"
+      jakarta:
+        patterns:
+          - "jakarta.*"
+          - "org.glassfish*"
+          - "org.eclipse:yasson"
+    ignore:
+      # Avoid non-patch updates for complex dependencies and their implementation, even if we only use them for tests.
+      - dependency-name: "org.hibernate*"
+        update-types: ["version-update:semver-major", "version-update:semver-minor"]
+      - dependency-name: "jakarta.*"
+        update-types: ["version-update:semver-major", "version-update:semver-minor"]
+      - dependency-name: "org.jboss.narayana*"
+        update-types: ["version-update:semver-major", "version-update:semver-minor"]
+      - dependency-name: "org.jboss.weld*"
+        update-types: ["version-update:semver-major", "version-update:semver-minor"]
+      - dependency-name: "org.wildfly*"
+        update-types: ["version-update:semver-major", "version-update:semver-minor"]
+      - dependency-name: "org.glassfish*"
+        update-types: ["version-update:semver-major", "version-update:semver-minor"]
+      - dependency-name: "org.eclipse:yasson"
+        update-types: ["version-update:semver-major", "version-update:semver-minor"]
+      - dependency-name: "org.apache.maven*"
+        update-types: ["version-update:semver-major", "version-update:semver-minor"]
+      - dependency-name: "org.apache.ant*"
+        update-types: ["version-update:semver-major", "version-update:semver-minor"]
+      # Avoid non-patch updates for JUnit, because it is exposed in hibernate-testing,
+      # which contains @BytecodeEnhanced, which is very sensitive to internal changes in JUnit.
+      - dependency-name: "org.junit*"
+        update-types: ["version-update:semver-major", "version-update:semver-minor"]
+      # Sticking to SLF4J 1.x for now since later versions require upgrading providers
+      # (Log4j, ... see https://www.slf4j.org/faq.html#changesInVersion200),
+      # and also because we only need this dependency for Maven,
+      # which is currently still on SLF4J 1.x
+      # (see https://central.sonatype.com/artifact/org.apache.maven/maven-embedder/3.9.9/dependencies)
+      - dependency-name: "org.slf4j:*"
+        update-types: ["version-update:semver-major"]

--- a/.github/hibernate-github-bot.yml
+++ b/.github/hibernate-github-bot.yml
@@ -2,6 +2,10 @@
 jira:
   projectKey: "HHH"
   insertLinksInPullRequests: true
+  ignore:
+    # See the `build-dependencies` group in Dependabot's configuration file
+    - user: dependabot[bot]
+      titlePattern: "Bump.*the (build-dependencies|workflow-actions) group.*+"
   ignoreFiles:
     # Git
     - ".git*"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,10 +3,18 @@ name: GH Actions CI
 on:
   push:
     branches:
+      # Pattern order matters: the last matching inclusion/exclusion wins
       - 'main'
+      # We don't want to run CI on branches for dependabot, just on the PR.
+      - '!dependabot/**'
   pull_request:
     branches:
       - 'main'
+      # Ignore dependabot PRs that are not just about build dependencies or workflows;
+      # we'll reject such PRs and send one ourselves.
+      - '!dependabot/**'
+      - 'dependabot/maven/build-dependencies-**'
+      - 'dependabot/github_actions/workflow-actions-**'
 
 permissions: { } # none
 


### PR DESCRIPTION
Opening this for discussion. I'm absolutely certain we'll want to fine-tune the configuration to avoid some automatic updates, so feel free to suggest whatever makes sense to you.

The most important dependencies to update are the runtime ones, e.g. bytebuddy, which we've failed to update consistently, resulting in delayed support for newer JDK. My hope is that dependabot will address that problem.

The idea is that we'd merge updates in the "build-dependencies" group as-is, without a Jira issue.

**We would still have to adjust/re-create other update PRs** (such as Jandex) to assign them a Jira issue. We could consider limiting the dependencies covered by dependabot, but I find that grouping, at least, allows a fairly manageable rate of dependabot PRs. Runtime dependency updates should be more rare anyway, as their number is limited and they're generally less active (e.g. Jakarta Persistence doesn't release a micro every week). 

If we merged this PR right now, we would get something like this, to catch up with updates that we forgot to do:

![image](https://github.com/user-attachments/assets/6f8ac80e-edc6-413e-9748-8c2083fada6f)

See my fork for details for these PRs: https://github.com/yrodiere/hibernate-orm/pulls/app%2Fdependabot

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
