### PR TITLE
HHH-19225: remove support for mariadb version's older than 10.6

### DIFF
--- a/ci/build.sh
+++ b/ci/build.sh
@@ -10,7 +10,7 @@ elif [ "$RDBMS" == "hsqldb" ] || [ "$RDBMS" == "hsqldb_2_6" ]; then
   goal="-Pdb=hsqldb"
 elif [ "$RDBMS" == "mysql" ] || [ "$RDBMS" == "mysql_8_0" ]; then
   goal="-Pdb=mysql_ci"
-elif [ "$RDBMS" == "mariadb" ] || [ "$RDBMS" == "mariadb_10_4" ]; then
+elif [ "$RDBMS" == "mariadb" ] || [ "$RDBMS" == "mariadb_10_6" ]; then
   goal="-Pdb=mariadb_ci"
 elif [ "$RDBMS" == "postgresql" ] || [ "$RDBMS" == "postgresql_13" ]; then
   goal="-Pdb=pgsql_ci"

--- a/docker_db.sh
+++ b/docker_db.sh
@@ -138,9 +138,9 @@ mariadb_wait_until_start()
     fi
 }
 
-mariadb_10_5() {
+mariadb_10_6() {
     $CONTAINER_CLI rm -f mariadb || true
-    $CONTAINER_CLI run --name mariadb -e MARIADB_USER=hibernate_orm_test -e MARIADB_PASSWORD=hibernate_orm_test -e MARIADB_DATABASE=hibernate_orm_test -e MARIADB_ROOT_PASSWORD=hibernate_orm_test -p3306:3306 -d ${DB_IMAGE_MARIADB_10_5:-docker.io/mariadb:10.5.25} --character-set-server=utf8mb4 --collation-server=utf8mb4_bin --skip-character-set-client-handshake --lower_case_table_names=2
+    $CONTAINER_CLI run --name mariadb -e MARIADB_USER=hibernate_orm_test -e MARIADB_PASSWORD=hibernate_orm_test -e MARIADB_DATABASE=hibernate_orm_test -e MARIADB_ROOT_PASSWORD=hibernate_orm_test -p3306:3306 -d ${DB_IMAGE_MARIADB_10_6:-docker.io/mariadb:10.6.20} --character-set-server=utf8mb4 --collation-server=utf8mb4_bin --skip-character-set-client-handshake --lower_case_table_names=2
     mariadb_wait_until_start
 }
 
@@ -1077,7 +1077,7 @@ if [ -z ${1} ]; then
     echo -e "\tmariadb_11_4"
     echo -e "\tmariadb_11_1"
     echo -e "\tmariadb_10_11"
-    echo -e "\tmariadb_10_5"
+    echo -e "\tmariadb_10_6"
     echo -e "\tmssql"
     echo -e "\tmssql_2022"
     echo -e "\tmssql_2017"

--- a/hibernate-core/src/main/java/org/hibernate/dialect/MariaDBDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/MariaDBDialect.java
@@ -61,13 +61,13 @@ import static org.hibernate.type.SqlTypes.UUID;
 import static org.hibernate.type.SqlTypes.VARBINARY;
 
 /**
- * A {@linkplain Dialect SQL dialect} for MariaDB 10.5 and above.
+ * A {@linkplain Dialect SQL dialect} for MariaDB 10.6 and above.
  *
  * @author Vlad Mihalcea
  * @author Gavin King
  */
 public class MariaDBDialect extends MySQLDialect {
-	private static final DatabaseVersion MINIMUM_VERSION = DatabaseVersion.make( 10, 5 );
+	private static final DatabaseVersion MINIMUM_VERSION = DatabaseVersion.make( 10, 6 );
 	private static final DatabaseVersion MYSQL57 = DatabaseVersion.make( 5, 7 );
 	private static final Set<String> GEOMETRY_TYPE_NAMES = Set.of(
 			"POINT",
@@ -128,11 +128,8 @@ public class MariaDBDialect extends MySQLDialect {
 		commonFunctionFactory.jsonArrayAgg_mariadb();
 		commonFunctionFactory.jsonObjectAgg_mariadb();
 		commonFunctionFactory.jsonArrayAppend_mariadb();
-
-		if ( getVersion().isSameOrAfter( 10, 6 ) ) {
-			commonFunctionFactory.unnest_emulated();
-			commonFunctionFactory.jsonTable_mysql();
-		}
+		commonFunctionFactory.unnest_emulated();
+		commonFunctionFactory.jsonTable_mysql();
 
 		commonFunctionFactory.inverseDistributionOrderedSetAggregates_windowEmulation();
 		functionContributions.getFunctionRegistry().patternDescriptorBuilder( "median", "median(?1) over ()" )
@@ -276,8 +273,7 @@ public class MariaDBDialect extends MySQLDialect {
 
 	@Override
 	public boolean supportsSkipLocked() {
-		//only supported on MySQL and as of 10.6
-		return getVersion().isSameOrAfter( 10, 6 );
+		return true;
 	}
 
 	@Override
@@ -303,7 +299,7 @@ public class MariaDBDialect extends MySQLDialect {
 	}
 
 	/**
-	 * @return {@code true} for 10.5 and above because Maria supports
+	 * @return {@code true} for 10.6 and above because Maria supports
 	 *         {@code insert ... returning} even though MySQL does not
 	 */
 	@Override

--- a/nightly.Jenkinsfile
+++ b/nightly.Jenkinsfile
@@ -27,7 +27,7 @@ stage('Configure') {
 		// Minimum supported versions
 		new BuildEnvironment( dbName: 'hsqldb_2_6' ),
 		new BuildEnvironment( dbName: 'mysql_8_0' ),
-		new BuildEnvironment( dbName: 'mariadb_10_5' ),
+		new BuildEnvironment( dbName: 'mariadb_10_6' ),
 		new BuildEnvironment( dbName: 'postgresql_13' ),
 		new BuildEnvironment( dbName: 'edb_13' ),
 		new BuildEnvironment( dbName: 'db2_10_5', longRunning: true ),
@@ -111,8 +111,8 @@ stage('Build') {
 									sh "./docker_db.sh mysql_8_0"
 									state[buildEnv.tag]['containerName'] = "mysql"
 									break;
-								case "mariadb_10_5":
-									sh "./docker_db.sh mariadb_10_5"
+								case "mariadb_10_6":
+									sh "./docker_db.sh mariadb_10_6"
 									state[buildEnv.tag]['containerName'] = "mariadb"
 									break;
 								case "postgresql_13":


### PR DESCRIPTION
<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

[Please describe here what your change is about]

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-19225
<!-- Hibernate GitHub Bot issue links end -->