### PR TITLE
HHH-9812 @Formula with SQL cast function

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/sql/Template.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/Template.java
@@ -164,6 +164,8 @@ public final class Template {
 		boolean inFromClause = false;
 		boolean afterFromTable = false;
 		boolean inExtractOrTrim = false;
+		boolean inCast = false;
+		boolean afterCastAs = false;
 
 		boolean hasMore = tokens.hasMoreTokens();
 		String nextToken = hasMore ? tokens.nextToken() : null;
@@ -237,6 +239,14 @@ public final class Template {
 				result.append(token);
 				inExtractOrTrim = true;
 			}
+			else if ( "cast".equals( lcToken ) ) {
+				result.append( token );
+				inCast = true;
+			}
+			else if ( inCast && ("as".equals( lcToken ) || afterCastAs) ) {
+				result.append( token );
+				afterCastAs = true;
+			}
 			else if ( !inFromClause // don't want to append alias to tokens inside the FROM clause
 					&& isIdentifier( token )
 					&& !isFunctionOrKeyword( lcToken, nextToken, dialect, typeConfiguration )
@@ -248,6 +258,8 @@ public final class Template {
 			else {
 				if ( ")".equals( lcToken) ) {
 					inExtractOrTrim = false;
+					inCast = false;
+					afterCastAs = false;
 				}
 				else if ( !inExtractOrTrim
 						&& BEFORE_TABLE_KEYWORDS.contains(lcToken) ) {

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/sql/TemplateTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/sql/TemplateTest.java
@@ -74,7 +74,10 @@ public class TemplateTest {
 				"where {@}.foo>10 and {@}.bar is not null", factory );
 		assertWhereStringTemplate("select t.foo, o.bar from table as t left join other as o on t.id = o.id where t.foo>10 and o.bar is not null order by o.bar",
 				"select t.foo, o.bar from table as t left join other as o on t.id = o.id where t.foo>10 and o.bar is not null order by o.bar", factory );
-
+		assertWhereStringTemplate( "CAST(foo AS unsigned)",
+				"CAST({@}.foo AS unsigned)", factory );
+		assertWhereStringTemplate( "CAST(foo AS signed)",
+				"CAST({@}.foo AS signed)", factory );
 	}
 
 	private static void assertWhereStringTemplate(String sql, SessionFactoryImplementor sf) {


### PR DESCRIPTION
The formula `CAST(foo AS signed)` does not work on MySQL, because `signed` gets prefixed.
As suggested by @beikov on Jira, I implemented a bugfix in `Template#renderWhereStringTemplate`.
The fix is generic for all provided cast-types.

----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-9812
<!-- Hibernate GitHub Bot issue links end -->