### PR TITLE
HHH-19564 fix @ManyToOne @JoinTable with implicit table name

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/boot/model/internal/ImplicitToOneJoinTableSecondPass.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/internal/ImplicitToOneJoinTableSecondPass.java
@@ -14,6 +14,7 @@ import org.hibernate.boot.spi.SecondPass;
 import org.hibernate.mapping.Join;
 import org.hibernate.mapping.ManyToOne;
 import org.hibernate.mapping.PersistentClass;
+import org.hibernate.mapping.Property;
 import org.hibernate.mapping.Table;
 
 import jakarta.persistence.JoinTable;
@@ -58,9 +59,9 @@ public class ImplicitToOneJoinTableSecondPass implements SecondPass {
 	}
 
 	// Note: Instead of deferring creation of the whole Table object, perhaps
-	//	   we could create it in the first pass, and reset its name here in
-	//	   the second pass. The problem is that there is some quite involved
-	//	   logic in TableBinder that isn't set up for that.
+	//	     we could create it in the first pass and reset its name here in
+	//	     the second pass. The problem is that there is some quite involved
+	//	     logic in TableBinder that isn't set up for that.
 
 	private void inferJoinTableName(TableBinder tableBinder, Map<String, PersistentClass> persistentClasses) {
 		if ( isEmpty( tableBinder.getName() ) ) {
@@ -116,6 +117,12 @@ public class ImplicitToOneJoinTableSecondPass implements SecondPass {
 		final Table table = tableBinder.bind();
 		value.setTable( table );
 		final Join join = propertyHolder.addJoin( joinTable, table, true );
+		final PersistentClass owner = propertyHolder.getPersistentClass();
+		final Property property = owner.getProperty( inferredData.getPropertyName() );
+		assert property != null;
+		// move the property from the main table to the new join table
+		owner.removeProperty( property );
+		join.addProperty( property );
 		if ( notFoundAction != null ) {
 			join.disableForeignKeyCreation();
 		}

--- a/hibernate-core/src/main/java/org/hibernate/mapping/PersistentClass.java
+++ b/hibernate-core/src/main/java/org/hibernate/mapping/PersistentClass.java
@@ -1211,4 +1211,11 @@ public abstract sealed class PersistentClass
 	public void setDeleteExpectation(Supplier<? extends Expectation> deleteExpectation) {
 		this.deleteExpectation = deleteExpectation;
 	}
+
+	public void removeProperty(Property property) {
+		if ( !declaredProperties.remove( property ) ) {
+			throw new IllegalArgumentException( "Property not among declared properties: " + property.getName() );
+		}
+		properties.remove( property );
+	}
 }

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/manytoone/jointable/ManyToOneImplicitJoinTableTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/manytoone/jointable/ManyToOneImplicitJoinTableTest.java
@@ -1,0 +1,52 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.mapping.manytoone.jointable;
+
+import jakarta.persistence.*;
+import org.hibernate.testing.orm.junit.EntityManagerFactoryScope;
+import org.hibernate.testing.orm.junit.JiraKey;
+import org.hibernate.testing.orm.junit.Jpa;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.AssertionsKt.assertNotNull;
+
+@Jpa(annotatedClasses =
+		{ManyToOneImplicitJoinTableTest.X.class,
+		ManyToOneImplicitJoinTableTest.Y.class})
+class ManyToOneImplicitJoinTableTest {
+	@JiraKey("HHH-19564") @Test
+	void test(EntityManagerFactoryScope scope) {
+		scope.inTransaction( s -> {
+			X x = new X();
+			Y y = new Y();
+			y.x = x;
+			s.persist( x );
+			s.persist( y );
+		} );
+		scope.inTransaction( s -> {
+			Y y = s.find( Y.class, 0L );
+			y.name = "Gavin";
+		} );
+		scope.inTransaction( s -> {
+			Y y = s.find( Y.class, 0L );
+			assertEquals("Gavin", y.name);
+			assertNotNull(y.x);
+		} );
+	}
+	@Entity(name="Y")
+	static class Y {
+		@Id
+		long id;
+		String name;
+		@JoinTable
+		@ManyToOne X x;
+	}
+	@Entity(name="X")
+	static class X {
+		@Id
+		long id;
+	}
+}


### PR DESCRIPTION
<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

[Please describe here what your change is about]

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-19564
<!-- Hibernate GitHub Bot issue links end -->