### PR TITLE
HHH-19570 HQL with jpamodelgen fails compilation when querying by natural id named `id`

### DIFF
--- a/tooling/metamodel-generator/src/main/java/org/hibernate/processor/validation/MockEntityPersister.java
+++ b/tooling/metamodel-generator/src/main/java/org/hibernate/processor/validation/MockEntityPersister.java
@@ -98,25 +98,36 @@ public abstract class MockEntityPersister implements EntityPersister, Joinable {
 
 	@Override
 	public final Type getPropertyType(String propertyPath) {
-		Type result = propertyTypesByName.get(propertyPath);
-		if (result!=null) {
-			return result;
+		final Type cached = propertyTypesByName.get(propertyPath);
+		if ( cached == null ) {
+			final Type type = propertyType( propertyPath );
+			if ( type != null ) {
+				propertyTypesByName.put( propertyPath, type );
+			}
+			return type;
+		}
+		else {
+			return cached;
+		}
+	}
+
+	private Type propertyType(String propertyPath) {
+		final Type type = createPropertyType( propertyPath );
+		if ( type != null ) {
+			return type;
 		}
 
-		result = createPropertyType(propertyPath);
-		if (result == null) {
-			//check subclasses, needed for treat()
-			result = getSubclassPropertyType(propertyPath);
+		//check subclasses, needed for treat()
+		final Type typeFromSubclass = getSubclassPropertyType( propertyPath );
+		if ( typeFromSubclass != null ) {
+			return typeFromSubclass;
 		}
 
-		if ("id".equals( propertyPath )) {
-			result = identifierType();
+		if ( "id".equals( propertyPath ) ) {
+			return identifierType();
 		}
 
-		if (result!=null) {
-			propertyTypesByName.put(propertyPath, result);
-		}
-		return result;
+		return null;
 	}
 
 	abstract Type createPropertyType(String propertyPath);


### PR DESCRIPTION
<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

[Please describe here what your change is about]

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-19570
<!-- Hibernate GitHub Bot issue links end -->