### PR TITLE
Trigger Hibernate Search Update Dependency job when building ORM 7 patches

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -197,6 +197,9 @@ stage('Build') {
 			}
 		})
 	}
+	executions.put('Hibernate Search Update Dependency', {
+		build job: '/hibernate-search-dependency-update/8.0', propagate: true, parameters: [string(name: 'UPDATE_JOB', value: 'orm7'), string(name: 'ORM_REPOSITORY', value: helper.scmSource.remoteUrl), string(name: 'ORM_PULL_REQUEST_ID', value: helper.scmSource.pullRequest.id)]
+	})
 	parallel(executions)
 }
 


### PR DESCRIPTION
as 7 is in the maintenance branches category now ... 

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
