### PR TITLE
[6.6] HHH-19560 Remove TupleTransformer and ResultListTransformer from interpretation caching

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/dialect/function/SqlFunction.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/function/SqlFunction.java
@@ -7,16 +7,22 @@
 package org.hibernate.dialect.function;
 
 import java.util.List;
+import java.util.function.Supplier;
 
+import org.checkerframework.checker.nullness.qual.Nullable;
+import org.hibernate.metamodel.mapping.BasicValuedMapping;
 import org.hibernate.query.ReturnableType;
 import org.hibernate.query.sqm.function.AbstractSqmSelfRenderingFunctionDescriptor;
+import org.hibernate.query.sqm.produce.function.FunctionReturnTypeResolver;
 import org.hibernate.query.sqm.produce.function.StandardArgumentsValidators;
-import org.hibernate.query.sqm.produce.function.StandardFunctionReturnTypeResolvers;
+import org.hibernate.query.sqm.sql.SqmToSqlAstConverter;
+import org.hibernate.query.sqm.tree.SqmTypedNode;
 import org.hibernate.sql.ast.SqlAstTranslator;
 import org.hibernate.sql.ast.spi.SqlAppender;
 import org.hibernate.sql.ast.tree.SqlAstNode;
 import org.hibernate.sql.ast.tree.expression.QueryLiteral;
 import org.hibernate.type.JavaObjectType;
+import org.hibernate.type.spi.TypeConfiguration;
 
 /**
  * A function to pass through a SQL fragment.
@@ -30,7 +36,24 @@ public class SqlFunction
 		super(
 				"sql",
 				StandardArgumentsValidators.min( 1 ),
-				StandardFunctionReturnTypeResolvers.invariant( JavaObjectType.INSTANCE ),
+				new FunctionReturnTypeResolver() {
+					@Override
+					public ReturnableType<?> resolveFunctionReturnType(
+							ReturnableType<?> impliedType,
+							@Nullable SqmToSqlAstConverter converter,
+							List<? extends SqmTypedNode<?>> arguments,
+							TypeConfiguration typeConfiguration) {
+						return impliedType != null
+								? impliedType
+								: typeConfiguration.getBasicTypeForJavaType( Object.class );
+					}
+
+					@Override
+					public BasicValuedMapping resolveFunctionReturnType(Supplier<BasicValuedMapping> impliedTypeAccess, List<? extends SqlAstNode> arguments) {
+						final BasicValuedMapping impliedType = impliedTypeAccess.get();
+						return impliedType != null ? impliedType : JavaObjectType.INSTANCE;
+					}
+				},
 				null
 		);
 	}

--- a/hibernate-core/src/main/java/org/hibernate/query/sql/internal/NativeQueryImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sql/internal/NativeQueryImpl.java
@@ -950,9 +950,7 @@ public class NativeQueryImpl<R>
 		return new SelectInterpretationsKey(
 				getQueryString(),
 				resultSetMapping,
-				getSynchronizedQuerySpaces(),
-				getQueryOptions().getTupleTransformer(),
-				getQueryOptions().getResultListTransformer()
+				getSynchronizedQuerySpaces()
 		);
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/query/sql/spi/SelectInterpretationsKey.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sql/spi/SelectInterpretationsKey.java
@@ -22,21 +22,25 @@ public class SelectInterpretationsKey implements QueryInterpretationCache.Key {
 	private final String sql;
 	private final JdbcValuesMappingProducer jdbcValuesMappingProducer;
 	private final Collection<String> querySpaces;
-	private final TupleTransformer tupleTransformer;
-	private final ResultListTransformer resultListTransformer;
 	private final int hash;
 
+	@Deprecated(forRemoval = true)
 	public SelectInterpretationsKey(
 			String sql,
 			JdbcValuesMappingProducer jdbcValuesMappingProducer,
 			Collection<String> querySpaces,
 			TupleTransformer tupleTransformer,
 			ResultListTransformer resultListTransformer) {
+		this( sql, jdbcValuesMappingProducer, querySpaces );
+	}
+
+	public SelectInterpretationsKey(
+			String sql,
+			JdbcValuesMappingProducer jdbcValuesMappingProducer,
+			Collection<String> querySpaces) {
 		this.sql = sql;
 		this.jdbcValuesMappingProducer = jdbcValuesMappingProducer;
 		this.querySpaces = querySpaces;
-		this.tupleTransformer = tupleTransformer;
-		this.resultListTransformer = resultListTransformer;
 		this.hash = generateHashCode();
 	}
 
@@ -44,14 +48,10 @@ public class SelectInterpretationsKey implements QueryInterpretationCache.Key {
 			String sql,
 			JdbcValuesMappingProducer jdbcValuesMappingProducer,
 			Collection<String> querySpaces,
-			TupleTransformer tupleTransformer,
-			ResultListTransformer resultListTransformer,
 			int hash) {
 		this.sql = sql;
 		this.jdbcValuesMappingProducer = jdbcValuesMappingProducer;
 		this.querySpaces = querySpaces;
-		this.tupleTransformer = tupleTransformer;
-		this.resultListTransformer = resultListTransformer;
 		this.hash = hash;
 	}
 
@@ -66,8 +66,6 @@ public class SelectInterpretationsKey implements QueryInterpretationCache.Key {
 				sql,
 				jdbcValuesMappingProducer.cacheKeyInstance(),
 				new HashSet<>( querySpaces ),
-				tupleTransformer,
-				resultListTransformer,
 				hash
 		);
 	}
@@ -94,7 +92,6 @@ public class SelectInterpretationsKey implements QueryInterpretationCache.Key {
 		return sql.equals( that.sql )
 				&& Objects.equals( jdbcValuesMappingProducer, that.jdbcValuesMappingProducer )
 				&& Objects.equals( querySpaces, that.querySpaces )
-				&& Objects.equals( tupleTransformer, that.tupleTransformer )
-				&& Objects.equals( resultListTransformer, that.resultListTransformer );
+				;
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/internal/ConcreteSqmSelectQueryPlan.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/internal/ConcreteSqmSelectQueryPlan.java
@@ -76,7 +76,6 @@ import static org.hibernate.query.sqm.internal.SqmUtil.isSelectionAssignableToRe
 public class ConcreteSqmSelectQueryPlan<R> implements SelectQueryPlan<R> {
 	private final SqmSelectStatement<?> sqm;
 	private final DomainParameterXref domainParameterXref;
-	private final RowTransformer<R> rowTransformer;
 	private final SqmInterpreter<Object, ResultsConsumer<?, R>> executeQueryInterpreter;
 	private final SqmInterpreter<List<R>, Void> listInterpreter;
 	private final SqmInterpreter<ScrollableResultsImplementor<R>, ScrollMode> scrollInterpreter;
@@ -92,8 +91,6 @@ public class ConcreteSqmSelectQueryPlan<R> implements SelectQueryPlan<R> {
 			QueryOptions queryOptions) {
 		this.sqm = sqm;
 		this.domainParameterXref = domainParameterXref;
-
-		this.rowTransformer = determineRowTransformer( sqm, resultType, tupleMetadata, queryOptions );
 
 		final ListResultsConsumer.UniqueSemantic uniqueSemantic;
 		if ( sqm.producesUniqueResults() && !AppliedGraphs.containsCollectionFetches( queryOptions ) ) {
@@ -122,7 +119,7 @@ public class ConcreteSqmSelectQueryPlan<R> implements SelectQueryPlan<R> {
 						jdbcSelect,
 						jdbcParameterBindings,
 						listInterpreterExecutionContext( hql, executionContext, jdbcSelect, subSelectFetchKeyHandler ),
-						rowTransformer,
+						determineRowTransformer( sqm, resultType, tupleMetadata, executionContext.getQueryOptions() ),
 						null,
 						resultCountEstimate,
 						resultsConsumer
@@ -153,7 +150,7 @@ public class ConcreteSqmSelectQueryPlan<R> implements SelectQueryPlan<R> {
 						jdbcSelect,
 						jdbcParameterBindings,
 						listInterpreterExecutionContext( hql, executionContext, jdbcSelect, subSelectFetchKeyHandler ),
-						rowTransformer,
+						determineRowTransformer( sqm, resultType, tupleMetadata, executionContext.getQueryOptions() ),
 						(Class<R>) executionContext.getResultType(),
 						uniqueSemantic,
 						resultCountEstimate
@@ -189,7 +186,7 @@ public class ConcreteSqmSelectQueryPlan<R> implements SelectQueryPlan<R> {
 						scrollMode,
 						jdbcParameterBindings,
 						new SqmJdbcExecutionContextAdapter( executionContext, jdbcSelect ),
-						rowTransformer,
+						determineRowTransformer( sqm, resultType, tupleMetadata, executionContext.getQueryOptions() ),
 						resultCountEstimate
 				);
 			}

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/internal/SqmInterpretationsKey.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/internal/SqmInterpretationsKey.java
@@ -14,8 +14,6 @@ import java.util.function.Supplier;
 
 import org.hibernate.LockOptions;
 import org.hibernate.engine.spi.LoadQueryInfluencers;
-import org.hibernate.query.ResultListTransformer;
-import org.hibernate.query.TupleTransformer;
 import org.hibernate.query.spi.QueryInterpretationCache;
 import org.hibernate.query.spi.QueryOptions;
 import org.hibernate.query.sqm.tree.SqmStatement;
@@ -50,8 +48,6 @@ public final class SqmInterpretationsKey implements QueryInterpretationCache.Key
 					query.hashCode(),
 					keySource.getResultType(),
 					keySource.getQueryOptions().getLockOptions(),
-					keySource.getQueryOptions().getTupleTransformer(),
-					keySource.getQueryOptions().getResultListTransformer(),
 					memoryEfficientDefensiveSetCopy( keySource.getLoadQueryInfluencers().getEnabledFetchProfileNames() )
 			);
 		}
@@ -110,8 +106,6 @@ public final class SqmInterpretationsKey implements QueryInterpretationCache.Key
 	private final Object query;
 	private final Class<?> resultType;
 	private final LockOptions lockOptions;
-	private final TupleTransformer<?> tupleTransformer;
-	private final ResultListTransformer<?> resultListTransformer;
 	private final Collection<String> enabledFetchProfiles;
 	private final int hashcode;
 
@@ -120,15 +114,11 @@ public final class SqmInterpretationsKey implements QueryInterpretationCache.Key
 			int hash,
 			Class<?> resultType,
 			LockOptions lockOptions,
-			TupleTransformer<?> tupleTransformer,
-			ResultListTransformer<?> resultListTransformer,
 			Collection<String> enabledFetchProfiles) {
 		this.query = query;
 		this.hashcode = hash;
 		this.resultType = resultType;
 		this.lockOptions = lockOptions;
-		this.tupleTransformer = tupleTransformer;
-		this.resultListTransformer = resultListTransformer;
 		this.enabledFetchProfiles = enabledFetchProfiles;
 	}
 
@@ -140,8 +130,6 @@ public final class SqmInterpretationsKey implements QueryInterpretationCache.Key
 				resultType,
 				// Since lock options might be mutable, we need a copy for the cache key
 				lockOptions.makeDefensiveCopy(),
-				tupleTransformer,
-				resultListTransformer,
 				enabledFetchProfiles
 		);
 	}
@@ -165,8 +153,6 @@ public final class SqmInterpretationsKey implements QueryInterpretationCache.Key
 			&& query.equals( that.query )
 			&& Objects.equals( resultType, that.resultType )
 			&& Objects.equals( lockOptions, that.lockOptions )
-			&& Objects.equals( tupleTransformer, that.tupleTransformer )
-			&& Objects.equals( resultListTransformer, that.resultListTransformer )
 			&& Objects.equals( enabledFetchProfiles, that.enabledFetchProfiles );
 	}
 


### PR DESCRIPTION
<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

[Please describe here what your change is about]

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-19560
<!-- Hibernate GitHub Bot issue links end -->