### PR TITLE
HHH-19560 Remove TupleTransformer and ResultListTransformer from interpretation caching

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/dialect/function/SqlFunction.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/function/SqlFunction.java
@@ -7,15 +7,20 @@
 package org.hibernate.dialect.function;
 
 import java.util.List;
+import java.util.function.Supplier;
 
+import org.hibernate.metamodel.mapping.BasicValuedMapping;
+import org.hibernate.query.ReturnableType;
 import org.hibernate.query.sqm.function.AbstractSqmSelfRenderingFunctionDescriptor;
+import org.hibernate.query.sqm.produce.function.FunctionReturnTypeResolver;
 import org.hibernate.query.sqm.produce.function.StandardArgumentsValidators;
-import org.hibernate.query.sqm.produce.function.StandardFunctionReturnTypeResolvers;
+import org.hibernate.query.sqm.tree.SqmTypedNode;
 import org.hibernate.sql.ast.SqlAstTranslator;
 import org.hibernate.sql.ast.spi.SqlAppender;
 import org.hibernate.sql.ast.tree.SqlAstNode;
 import org.hibernate.sql.ast.tree.expression.QueryLiteral;
 import org.hibernate.type.JavaObjectType;
+import org.hibernate.type.spi.TypeConfiguration;
 
 /**
  * A function to pass through a SQL fragment.
@@ -29,7 +34,23 @@ public class SqlFunction
 		super(
 				"sql",
 				StandardArgumentsValidators.min( 1 ),
-				StandardFunctionReturnTypeResolvers.invariant( JavaObjectType.INSTANCE ),
+				new FunctionReturnTypeResolver() {
+					@Override
+					public ReturnableType<?> resolveFunctionReturnType(
+							ReturnableType<?> impliedType,
+							List<? extends SqmTypedNode<?>> arguments,
+							TypeConfiguration typeConfiguration) {
+						return impliedType != null
+								? impliedType
+								: typeConfiguration.getBasicTypeForJavaType( Object.class );
+					}
+
+					@Override
+					public BasicValuedMapping resolveFunctionReturnType(Supplier<BasicValuedMapping> impliedTypeAccess, List<? extends SqlAstNode> arguments) {
+						final BasicValuedMapping impliedType = impliedTypeAccess.get();
+						return impliedType != null ? impliedType : JavaObjectType.INSTANCE;
+					}
+				},
 				null
 		);
 	}

--- a/hibernate-core/src/main/java/org/hibernate/query/sql/internal/NativeQueryImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sql/internal/NativeQueryImpl.java
@@ -812,9 +812,7 @@ public class NativeQueryImpl<R>
 		return new SelectInterpretationsKey(
 				getQueryString(),
 				resultSetMapping,
-				getSynchronizedQuerySpaces(),
-				getQueryOptions().getTupleTransformer(),
-				getQueryOptions().getResultListTransformer()
+				getSynchronizedQuerySpaces()
 		);
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/query/sql/spi/SelectInterpretationsKey.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sql/spi/SelectInterpretationsKey.java
@@ -22,21 +22,25 @@ public class SelectInterpretationsKey implements QueryInterpretationCache.Key {
 	private final String sql;
 	private final JdbcValuesMappingProducer jdbcValuesMappingProducer;
 	private final Collection<String> querySpaces;
-	private final TupleTransformer tupleTransformer;
-	private final ResultListTransformer resultListTransformer;
 	private final int hash;
 
+	@Deprecated(forRemoval = true)
 	public SelectInterpretationsKey(
 			String sql,
 			JdbcValuesMappingProducer jdbcValuesMappingProducer,
 			Collection<String> querySpaces,
 			TupleTransformer tupleTransformer,
 			ResultListTransformer resultListTransformer) {
+		this( sql, jdbcValuesMappingProducer, querySpaces );
+	}
+
+	public SelectInterpretationsKey(
+			String sql,
+			JdbcValuesMappingProducer jdbcValuesMappingProducer,
+			Collection<String> querySpaces) {
 		this.sql = sql;
 		this.jdbcValuesMappingProducer = jdbcValuesMappingProducer;
 		this.querySpaces = querySpaces;
-		this.tupleTransformer = tupleTransformer;
-		this.resultListTransformer = resultListTransformer;
 		this.hash = generateHashCode();
 	}
 
@@ -44,14 +48,10 @@ public class SelectInterpretationsKey implements QueryInterpretationCache.Key {
 			String sql,
 			JdbcValuesMappingProducer jdbcValuesMappingProducer,
 			Collection<String> querySpaces,
-			TupleTransformer tupleTransformer,
-			ResultListTransformer resultListTransformer,
 			int hash) {
 		this.sql = sql;
 		this.jdbcValuesMappingProducer = jdbcValuesMappingProducer;
 		this.querySpaces = querySpaces;
-		this.tupleTransformer = tupleTransformer;
-		this.resultListTransformer = resultListTransformer;
 		this.hash = hash;
 	}
 
@@ -66,8 +66,6 @@ public class SelectInterpretationsKey implements QueryInterpretationCache.Key {
 				sql,
 				jdbcValuesMappingProducer.cacheKeyInstance(),
 				new HashSet<>( querySpaces ),
-				tupleTransformer,
-				resultListTransformer,
 				hash
 		);
 	}
@@ -94,7 +92,6 @@ public class SelectInterpretationsKey implements QueryInterpretationCache.Key {
 		return sql.equals( that.sql )
 				&& Objects.equals( jdbcValuesMappingProducer, that.jdbcValuesMappingProducer )
 				&& Objects.equals( querySpaces, that.querySpaces )
-				&& Objects.equals( tupleTransformer, that.tupleTransformer )
-				&& Objects.equals( resultListTransformer, that.resultListTransformer );
+				;
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/internal/ConcreteSqmSelectQueryPlan.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/internal/ConcreteSqmSelectQueryPlan.java
@@ -69,7 +69,6 @@ import static org.hibernate.query.sqm.internal.QuerySqmImpl.CRITERIA_HQL_STRING;
 public class ConcreteSqmSelectQueryPlan<R> implements SelectQueryPlan<R> {
 	private final SqmSelectStatement<?> sqm;
 	private final DomainParameterXref domainParameterXref;
-	private final RowTransformer<R> rowTransformer;
 	private final SqmInterpreter<List<R>, Void> listInterpreter;
 	private final SqmInterpreter<ScrollableResultsImplementor<R>, ScrollMode> scrollInterpreter;
 
@@ -84,8 +83,6 @@ public class ConcreteSqmSelectQueryPlan<R> implements SelectQueryPlan<R> {
 			QueryOptions queryOptions) {
 		this.sqm = sqm;
 		this.domainParameterXref = domainParameterXref;
-
-		this.rowTransformer = determineRowTransformer( sqm, resultType, tupleMetadata, queryOptions );
 
 		final ListResultsConsumer.UniqueSemantic uniqueSemantic;
 		if ( sqm.producesUniqueResults() && !AppliedGraphs.containsCollectionFetches( queryOptions ) ) {
@@ -111,7 +108,7 @@ public class ConcreteSqmSelectQueryPlan<R> implements SelectQueryPlan<R> {
 						jdbcSelect,
 						jdbcParameterBindings,
 						listInterpreterExecutionContext( hql, executionContext, jdbcSelect, subSelectFetchKeyHandler ),
-						rowTransformer,
+						determineRowTransformer( sqm, resultType, tupleMetadata, executionContext.getQueryOptions() ),
 						uniqueSemantic
 				);
 			}
@@ -138,7 +135,7 @@ public class ConcreteSqmSelectQueryPlan<R> implements SelectQueryPlan<R> {
 						scrollMode,
 						jdbcParameterBindings,
 						new SqmJdbcExecutionContextAdapter( executionContext, sqmInterpretation.jdbcSelect ),
-						rowTransformer
+						determineRowTransformer( sqm, resultType, tupleMetadata, executionContext.getQueryOptions() )
 				);
 			}
 			finally {

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/internal/SqmInterpretationsKey.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/internal/SqmInterpretationsKey.java
@@ -10,8 +10,6 @@ import java.util.function.Supplier;
 
 import org.hibernate.LockOptions;
 import org.hibernate.engine.spi.LoadQueryInfluencers;
-import org.hibernate.query.ResultListTransformer;
-import org.hibernate.query.TupleTransformer;
 import org.hibernate.query.spi.QueryInterpretationCache;
 import org.hibernate.query.spi.QueryOptions;
 
@@ -40,9 +38,7 @@ public class SqmInterpretationsKey implements QueryInterpretationCache.Key {
 		return new SqmInterpretationsKey(
 				keySource.getQueryString(),
 				keySource.getResultType(),
-				keySource.getQueryOptions().getLockOptions(),
-				keySource.getQueryOptions().getTupleTransformer(),
-				keySource.getQueryOptions().getResultListTransformer()
+				keySource.getQueryOptions().getLockOptions()
 		);
 	}
 	@SuppressWarnings("RedundantIfStatement")
@@ -90,20 +86,14 @@ public class SqmInterpretationsKey implements QueryInterpretationCache.Key {
 	private final String query;
 	private final Class<?> resultType;
 	private final LockOptions lockOptions;
-	private final TupleTransformer<?> tupleTransformer;
-	private final ResultListTransformer resultListTransformer;
 
 	private SqmInterpretationsKey(
 			String query,
 			Class<?> resultType,
-			LockOptions lockOptions,
-			TupleTransformer<?> tupleTransformer,
-			ResultListTransformer resultListTransformer) {
+			LockOptions lockOptions) {
 		this.query = query;
 		this.resultType = resultType;
 		this.lockOptions = lockOptions;
-		this.tupleTransformer = tupleTransformer;
-		this.resultListTransformer = resultListTransformer;
 	}
 
 	@Override
@@ -112,9 +102,7 @@ public class SqmInterpretationsKey implements QueryInterpretationCache.Key {
 				query,
 				resultType,
 				// Since lock options are mutable, we need a copy for the cache key
-				lockOptions.makeCopy(),
-				tupleTransformer,
-				resultListTransformer
+				lockOptions.makeCopy()
 		);
 	}
 
@@ -135,9 +123,7 @@ public class SqmInterpretationsKey implements QueryInterpretationCache.Key {
 		final SqmInterpretationsKey that = (SqmInterpretationsKey) o;
 		return query.equals( that.query )
 				&& areEqual( resultType, that.resultType )
-				&& areEqual( lockOptions, that.lockOptions )
-				&& areEqual( tupleTransformer, that.tupleTransformer )
-				&& areEqual( resultListTransformer, that.resultListTransformer );
+				&& areEqual( lockOptions, that.lockOptions );
 	}
 
 	private <T> boolean areEqual(T o1, T o2) {


### PR DESCRIPTION
<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

[Please describe here what your change is about]

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
