### PR TITLE
Preliminary support for Panache2

### DIFF
--- a/tooling/metamodel-generator/src/main/java/org/hibernate/processor/Context.java
+++ b/tooling/metamodel-generator/src/main/java/org/hibernate/processor/Context.java
@@ -104,6 +104,8 @@ public final class Context {
 
 	private boolean usesQuarkusOrm = false;
 	private boolean usesQuarkusReactive = false;
+	private boolean usesQuarkusPanache2 = false;
+	private boolean usesQuarkusReactiveCommon = false;
 
 	private String[] includes = {"*"};
 	private String[] excludes = {};
@@ -459,6 +461,22 @@ public final class Context {
 
 	public boolean usesQuarkusReactive() {
 		return usesQuarkusReactive;
+	}
+
+	public void setUsesQuarkusPanache2(boolean b) {
+		usesQuarkusPanache2 = b;
+	}
+
+	public boolean usesQuarkusPanache2() {
+		return usesQuarkusPanache2;
+	}
+
+	public void setUsesQuarkusReactiveCommon(boolean b) {
+		usesQuarkusReactiveCommon = b;
+	}
+
+	public boolean usesQuarkusReactiveCommon() {
+		return usesQuarkusReactiveCommon;
 	}
 
 	public void setInclude(String include) {

--- a/tooling/metamodel-generator/src/main/java/org/hibernate/processor/HibernateProcessor.java
+++ b/tooling/metamodel-generator/src/main/java/org/hibernate/processor/HibernateProcessor.java
@@ -671,7 +671,7 @@ public class HibernateProcessor extends AbstractProcessor {
 					final AnnotationMetaEntity metaEntity =
 							AnnotationMetaEntity.create( typeElement, context,
 									requiresLazyMemberInitialization,
-									true, false, parentMetaEntity );
+									true, false, parentMetaEntity, typeElement );
 					if ( alreadyExistingMetaEntity != null ) {
 						metaEntity.mergeInMembers( alreadyExistingMetaEntity );
 					}
@@ -690,7 +690,7 @@ public class HibernateProcessor extends AbstractProcessor {
 						final AnnotationMetaEntity dataMetaEntity =
 								AnnotationMetaEntity.create( typeElement, context,
 										requiresLazyMemberInitialization,
-										true, true, parentDataEntity );
+										true, true, parentDataEntity, typeElement );
 //						final Metamodel alreadyExistingDataMetaEntity =
 //								tryGettingExistingDataEntityFromContext( mirror, '_' + qualifiedName );
 //						if ( alreadyExistingDataMetaEntity != null ) {

--- a/tooling/metamodel-generator/src/main/java/org/hibernate/processor/HibernateProcessor.java
+++ b/tooling/metamodel-generator/src/main/java/org/hibernate/processor/HibernateProcessor.java
@@ -253,9 +253,16 @@ public class HibernateProcessor extends AbstractProcessor {
 		PackageElement quarkusOrmPanachePackage =
 				context.getProcessingEnvironment().getElementUtils()
 						.getPackageElement( "io.quarkus.hibernate.orm.panache" );
+		PackageElement quarkusPanache2Package =
+				context.getProcessingEnvironment().getElementUtils()
+						.getPackageElement( "io.quarkus.hibernate.panache" );
 		PackageElement quarkusReactivePanachePackage =
 				context.getProcessingEnvironment().getElementUtils()
 						.getPackageElement( "io.quarkus.hibernate.reactive.panache" );
+		// This is imported automatically by Quarkus extensions when HR is also imported
+		PackageElement quarkusReactivePanacheCommonPackage =
+				context.getProcessingEnvironment().getElementUtils()
+						.getPackageElement( "io.quarkus.hibernate.reactive.panache.common" );
 
 		if ( packagePresent(quarkusReactivePanachePackage)
 				&& packagePresent(quarkusOrmPanachePackage) ) {
@@ -284,6 +291,8 @@ public class HibernateProcessor extends AbstractProcessor {
 		context.setUsesQuarkusReactive( packagePresent(quarkusReactivePanachePackage) );
 		context.setSpringInjection( packagePresent(springBeansPackage) );
 		context.setAddComponentAnnotation( packagePresent(springStereotypePackage) );
+		context.setUsesQuarkusPanache2( packagePresent(quarkusPanache2Package) );
+		context.setUsesQuarkusReactiveCommon( packagePresent(quarkusReactivePanacheCommonPackage) );
 
 		final Map<String, String> options = environment.getOptions();
 

--- a/tooling/metamodel-generator/src/main/java/org/hibernate/processor/annotation/AnnotationMetaEntity.java
+++ b/tooling/metamodel-generator/src/main/java/org/hibernate/processor/annotation/AnnotationMetaEntity.java
@@ -175,7 +175,8 @@ public class AnnotationMetaEntity extends AnnotationMeta {
 	public AnnotationMetaEntity(
 			TypeElement element, Context context, boolean managed,
 			boolean jakartaDataStaticMetamodel,
-			@Nullable AnnotationMeta parent) {
+			@Nullable AnnotationMeta parent,
+			@Nullable TypeElement primaryEntity) {
 		this.element = element;
 		this.context = context;
 		this.managed = managed;
@@ -184,6 +185,7 @@ public class AnnotationMetaEntity extends AnnotationMeta {
 		this.springInjection = context.isSpringInjection();
 		this.importContext = parent != null ? parent : new ImportContextImpl( getPackageName( context, element ) );
 		jakartaDataStaticModel = jakartaDataStaticMetamodel;
+		this.primaryEntity = primaryEntity;
 		importContext.importType(
 				getGeneratedClassFullyQualifiedName( element, getPackageName( context, element ),
 						jakartaDataStaticModel ) );
@@ -192,17 +194,23 @@ public class AnnotationMetaEntity extends AnnotationMeta {
 		}
 	}
 
+	public static AnnotationMetaEntity create(TypeElement element, Context context, @Nullable AnnotationMetaEntity parent,
+			@Nullable TypeElement primaryEntity) {
+		return create( element,context, false, false, false, parent, primaryEntity );
+	}
+
 	public static AnnotationMetaEntity create(TypeElement element, Context context, @Nullable AnnotationMetaEntity parent) {
-		return create( element,context, false, false, false, parent );
+		return create( element,context, false, false, false, parent, null );
 	}
 
 	public static AnnotationMetaEntity create(
 			TypeElement element, Context context,
 			boolean lazilyInitialised, boolean managed,
 			boolean jakartaData,
-			@Nullable AnnotationMetaEntity parent) {
+			@Nullable AnnotationMetaEntity parent,
+			@Nullable TypeElement primaryEntity) {
 		final AnnotationMetaEntity annotationMetaEntity =
-				new AnnotationMetaEntity( element, context, managed, jakartaData, parent );
+				new AnnotationMetaEntity( element, context, managed, jakartaData, parent, primaryEntity );
 		if ( parent != null ) {
 			parent.addInnerClass( annotationMetaEntity );
 		}
@@ -419,8 +427,10 @@ public class AnnotationMetaEntity extends AnnotationMeta {
 				}
 			}
 
-			primaryEntity = primaryEntity( lifecycleMethods );
 			final boolean hibernateRepo = isExplicitlyHibernateRepository();
+			if ( primaryEntity == null ) {
+				primaryEntity = primaryEntity( lifecycleMethods );
+			}
 			if ( !checkEntity( primaryEntity, hibernateRepo )
 					|| !checkEntities( lifecycleMethods, hibernateRepo ) ) {
 				// NOTE EARLY EXIT with initialized = false

--- a/tooling/metamodel-generator/src/main/java/org/hibernate/processor/annotation/AnnotationMetaEntity.java
+++ b/tooling/metamodel-generator/src/main/java/org/hibernate/processor/annotation/AnnotationMetaEntity.java
@@ -416,6 +416,7 @@ public class AnnotationMetaEntity extends AnnotationMeta {
 				}
 				else if ( method.getEnclosingElement().getKind().isInterface()
 						&& !method.isDefault()
+						&& !method.getModifiers().contains(Modifier.PRIVATE)
 						&& !isSessionGetter(method) ) {
 					final String companionClassName = element.getQualifiedName().toString() + '$';
 					if ( context.getElementUtils().getTypeElement(companionClassName) == null ) {

--- a/tooling/metamodel-generator/src/main/java/org/hibernate/processor/annotation/CDIAccessorMetaAttribute.java
+++ b/tooling/metamodel-generator/src/main/java/org/hibernate/processor/annotation/CDIAccessorMetaAttribute.java
@@ -1,0 +1,106 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.processor.annotation;
+
+import javax.lang.model.element.Element;
+
+import org.hibernate.processor.model.MetaAttribute;
+import org.hibernate.processor.model.Metamodel;
+import org.hibernate.processor.util.StringUtil;
+
+public class CDIAccessorMetaAttribute implements MetaAttribute {
+
+	private AnnotationMetaEntity annotationMetaEntity;
+	private String propertyName;
+	private String typeName;
+
+	public CDIAccessorMetaAttribute(AnnotationMetaEntity annotationMetaEntity, Element repositoryElement) {
+		this.annotationMetaEntity = annotationMetaEntity;
+		// turn the name into lowercase
+		String name = repositoryElement.getSimpleName().toString();
+		// FIXME: this is wrong for types like STEFQueries
+		this.propertyName = StringUtil.decapitalize( name );
+		this.typeName = name;
+	}
+
+	public CDIAccessorMetaAttribute(AnnotationMetaEntity annotationMetaEntity, String propertyName, String className) {
+		this.annotationMetaEntity = annotationMetaEntity;
+		this.propertyName = propertyName;
+		this.typeName = className;
+	}
+
+	@Override
+	public boolean hasTypedAttribute() {
+		return true;
+	}
+
+	@Override
+	public boolean hasStringAttribute() {
+		return false;
+	}
+
+	@Override
+	public String getAttributeDeclarationString() {
+		final StringBuilder declaration = new StringBuilder();
+		modifiers( declaration );
+		preamble( declaration );
+		returnCDI( declaration );
+		closingBrace( declaration );
+		return declaration.toString();
+	}
+
+	private void returnCDI(StringBuilder declaration) {
+		annotationMetaEntity.importType("jakarta.enterprise.inject.spi.CDI");
+		declaration
+		.append("\treturn CDI.current().select(")
+		.append(typeName)
+		.append(".class).get();\n");
+	}
+
+	void closingBrace(StringBuilder declaration) {
+		declaration.append("}");
+	}
+
+	void preamble(StringBuilder declaration) {
+		declaration
+		.append(typeName)
+				.append(" ")
+				.append( getPropertyName() );
+		declaration
+				.append("() {\n");
+	}
+
+	@Override
+	public String getAttributeNameDeclarationString() {
+		return "";
+	}
+
+	@Override
+	public String getMetaType() {
+		throw new UnsupportedOperationException("operation not supported");
+	}
+
+	@Override
+	public String getPropertyName() {
+		return propertyName;
+	}
+
+	@Override
+	public String getTypeDeclaration() {
+		return "";
+	}
+
+	void modifiers(StringBuilder declaration) {
+		declaration
+				.append("\npublic static ");
+	}
+
+
+	@Override
+	public Metamodel getHostingEntity() {
+		return annotationMetaEntity;
+	}
+
+}

--- a/tooling/metamodel-generator/src/main/java/org/hibernate/processor/annotation/CDITypeMetaAttribute.java
+++ b/tooling/metamodel-generator/src/main/java/org/hibernate/processor/annotation/CDITypeMetaAttribute.java
@@ -1,0 +1,92 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.processor.annotation;
+
+import org.hibernate.processor.HibernateProcessor;
+import org.hibernate.processor.model.MetaAttribute;
+import org.hibernate.processor.model.Metamodel;
+
+public class CDITypeMetaAttribute implements MetaAttribute {
+
+	private AnnotationMetaEntity annotationMetaEntity;
+	private String typeName;
+	private Object superTypeName;
+
+	public CDITypeMetaAttribute(AnnotationMetaEntity annotationMetaEntity, String className, String superTypeName) {
+		this.annotationMetaEntity = annotationMetaEntity;
+		this.superTypeName = superTypeName;
+		this.typeName = className;
+	}
+
+	@Override
+	public boolean hasTypedAttribute() {
+		return true;
+	}
+
+	@Override
+	public boolean hasStringAttribute() {
+		return false;
+	}
+
+	@Override
+	public String getAttributeDeclarationString() {
+		final StringBuilder declaration = new StringBuilder();
+		modifiers( declaration );
+		preamble( declaration );
+		closingBrace( declaration );
+		return declaration.toString();
+	}
+
+	void closingBrace(StringBuilder declaration) {
+		declaration.append("}");
+	}
+
+	void preamble(StringBuilder declaration) {
+		declaration
+		.append("class ")
+		.append(typeName)
+				.append(" implements ")
+				.append( superTypeName );
+		declaration
+				.append(" {\n");
+	}
+
+	@Override
+	public String getAttributeNameDeclarationString() {
+		return "";
+	}
+
+	@Override
+	public String getMetaType() {
+		throw new UnsupportedOperationException("operation not supported");
+	}
+
+	@Override
+	public String getPropertyName() {
+		return "";
+	}
+
+	@Override
+	public String getTypeDeclaration() {
+		return "";
+	}
+
+	void modifiers(StringBuilder declaration) {
+		annotationMetaEntity.importType("jakarta.annotation.Generated");
+		annotationMetaEntity.importType("jakarta.enterprise.context.Dependent");
+		declaration
+		.append("\n@Dependent\n")
+		.append("@Generated(\""+HibernateProcessor.class.getName()+"\")\n");
+		declaration
+				.append("public static ");
+	}
+
+
+	@Override
+	public Metamodel getHostingEntity() {
+		return annotationMetaEntity;
+	}
+
+}

--- a/tooling/metamodel-generator/src/main/java/org/hibernate/processor/annotation/NonManagedMetamodel.java
+++ b/tooling/metamodel-generator/src/main/java/org/hibernate/processor/annotation/NonManagedMetamodel.java
@@ -12,7 +12,7 @@ import javax.lang.model.element.TypeElement;
 public class NonManagedMetamodel extends AnnotationMetaEntity {
 
 	public NonManagedMetamodel(TypeElement element, Context context, boolean jakartaDataStaticMetamodel, @Nullable AnnotationMeta parent) {
-		super( element, context, false, jakartaDataStaticMetamodel, parent );
+		super( element, context, false, jakartaDataStaticMetamodel, parent, null );
 	}
 
 	public static NonManagedMetamodel create(

--- a/tooling/metamodel-generator/src/main/java/org/hibernate/processor/util/Constants.java
+++ b/tooling/metamodel-generator/src/main/java/org/hibernate/processor/util/Constants.java
@@ -162,6 +162,12 @@ public final class Constants {
 	public static final String SPRING_STATELESS_SESSION_PROVIDER = SPRING_OBJECT_PROVIDER + "<" + HIB_STATELESS_SESSION + ">";
 	public static final String SPRING_COMPONENT = "org.springframework.stereotype.Component";
 
+	public static final String PANACHE2_ENTITY_MARKER = "io.quarkus.hibernate.panache.PanacheEntityMarker";
+	public static final String PANACHE2_MANAGED_BLOCKING_REPOSITORY_BASE = "io.quarkus.hibernate.panache.managed.blocking.PanacheManagedBlockingRepositoryBase";
+	public static final String PANACHE2_STATELESS_BLOCKING_REPOSITORY_BASE = "io.quarkus.hibernate.panache.stateless.blocking.PanacheStatelessBlockingRepositoryBase";
+	public static final String PANACHE2_MANAGED_REACTIVE_REPOSITORY_BASE = "io.quarkus.hibernate.panache.managed.reactive.PanacheManagedReactiveRepositoryBase";
+	public static final String PANACHE2_STATELESS_REACTIVE_REPOSITORY_BASE = "io.quarkus.hibernate.panache.stateless.reactive.PanacheStatelessReactiveRepositoryBase";
+
 	public static final Map<String, String> COLLECTIONS = Map.of(
 			COLLECTION, COLLECTION_ATTRIBUTE,
 			SET, SET_ATTRIBUTE,

--- a/tooling/metamodel-generator/src/main/java/org/hibernate/processor/util/TypeUtils.java
+++ b/tooling/metamodel-generator/src/main/java/org/hibernate/processor/util/TypeUtils.java
@@ -661,7 +661,7 @@ public final class TypeUtils {
 		if ( superclass != null && superclass.getKind() == TypeKind.DECLARED  ) {
 			final DeclaredType declaredType = (DeclaredType) superclass;
 			final TypeElement typeElement = (TypeElement) declaredType.asElement();
-			if( implementsInterface( typeElement, interfaceName) ) {
+			if ( implementsInterface( typeElement, interfaceName) ) {
 				return true;
 			}
 		}

--- a/tooling/metamodel-generator/src/main/java/org/hibernate/processor/util/TypeUtils.java
+++ b/tooling/metamodel-generator/src/main/java/org/hibernate/processor/util/TypeUtils.java
@@ -657,6 +657,14 @@ public final class TypeUtils {
 				}
 			}
 		}
+		TypeMirror superclass = type.getSuperclass();
+		if ( superclass != null && superclass.getKind() == TypeKind.DECLARED  ) {
+			final DeclaredType declaredType = (DeclaredType) superclass;
+			final TypeElement typeElement = (TypeElement) declaredType.asElement();
+			if( implementsInterface( typeElement, interfaceName) ) {
+				return true;
+			}
+		}
 		return false;
 	}
 

--- a/tooling/metamodel-generator/src/main/java/org/hibernate/processor/util/TypeUtils.java
+++ b/tooling/metamodel-generator/src/main/java/org/hibernate/processor/util/TypeUtils.java
@@ -27,6 +27,7 @@ import javax.lang.model.type.TypeMirror;
 import javax.lang.model.type.TypeVariable;
 import javax.lang.model.type.WildcardType;
 import javax.lang.model.util.ElementFilter;
+import javax.lang.model.util.Elements;
 import javax.lang.model.util.SimpleTypeVisitor8;
 import javax.tools.Diagnostic;
 import java.util.HashMap;
@@ -240,6 +241,26 @@ public final class TypeUtils {
 		assert element != null;
 		assert qualifiedName != null;
 		for ( AnnotationMirror mirror : element.getAnnotationMirrors() ) {
+			if ( isAnnotationMirrorOfType( mirror, qualifiedName ) ) {
+				return mirror;
+			}
+		}
+		return null;
+	}
+
+	/**
+	 * Checks whether the {@code Element} hosts the annotation (directly or inherited) with the given fully qualified class name.
+	 *
+	 * @param element the element to check for the hosted annotation
+	 * @param qualifiedName the fully qualified class name of the annotation to check for
+	 *
+	 * @return the annotation mirror for the specified annotation class from the {@code Element} or {@code null} in case
+	 *         the {@code TypeElement} does not host the specified annotation (directly or inherited).
+	 */
+	public static @Nullable AnnotationMirror getInheritedAnnotationMirror(Elements elements, Element element, String qualifiedName) {
+		assert element != null;
+		assert qualifiedName != null;
+		for ( AnnotationMirror mirror : elements.getAllAnnotationMirrors(element) ) {
 			if ( isAnnotationMirrorOfType( mirror, qualifiedName ) ) {
 				return mirror;
 			}

--- a/tooling/metamodel-generator/src/quarkusOrmPanache/java/org/hibernate/processor/test/ormPanache/QuarkusOrmPanacheTest.java
+++ b/tooling/metamodel-generator/src/quarkusOrmPanache/java/org/hibernate/processor/test/ormPanache/QuarkusOrmPanacheTest.java
@@ -4,6 +4,7 @@
  */
 package org.hibernate.processor.test.ormPanache;
 
+import org.hibernate.Session;
 import org.hibernate.processor.test.util.CompilationTest;
 import org.hibernate.processor.test.util.TestUtil;
 import org.hibernate.processor.test.util.WithClasses;
@@ -100,7 +101,7 @@ class QuarkusOrmPanacheTest {
 		Assertions.assertFalse( Modifier.isStatic( method.getModifiers() ) );
 
 		// Make sure we have the proper constructor
-		Constructor<?> constructor = repositoryClass.getDeclaredConstructor( EntityManager.class );
+		Constructor<?> constructor = repositoryClass.getDeclaredConstructor( Session.class );
 		Assertions.assertNotNull( constructor );
 		Assertions.assertTrue( constructor.isAnnotationPresent( Inject.class ) );
 	}


### PR DESCRIPTION
Supports Panache2, which comes in a new package `io.quarkus.hibernate.panache` (since it supports both ORM and HR, they are not in the package name anymore). With new entity supertype, as well as repository supertypes and way of working.

Rough example entity:

```java
@Entity
public class MyEntity extends WithId.AutoLong implements PanacheEntity.Stateless {
  public String name;

  public interface Repo {
    @Find
    MyEntity findSomeone(String name);
  }
}
```

This will generate the following:

```java
@StaticMetamodel(MyEntity.class)
@Generated("org.hibernate.processor.HibernateProcessor")
public abstract class MyEntity_ extends WithId_ {

	/**
	 * Implements repository {@link org.acme.MyEntity.Repo}
	 **/
	@Dependent
	@Generated("org.hibernate.processor.HibernateProcessor")
	public static class Repo_ implements Repo {
	
	
		
		protected final @Nonnull Session session;
		
		@Inject
		public Repo_(@Nonnull Session session) {
			this.session = session;
		}
		
		public @Nonnull Session getSession() {
			return session;
		}
		
		/**
		 * Find {@link MyEntity} by {@link MyEntity#name name}.
		 *
		 * @see org.acme.MyEntity.Repo#findByName(String)
		 **/
		@Override
		public MyEntity findByName(String name) {
			var _builder = session.getCriteriaBuilder();
			var _query = _builder.createQuery(MyEntity.class);
			var _entity = _query.from(MyEntity.class);
			_query.where(
					name==null
						? _entity.get(MyEntity_.name).isNull()
						: _builder.equal(_entity.get(MyEntity_.name), name)
			);
			return session.createSelectionQuery(_query)
					.getSingleResult();
		}
	
	}
	
	/**
	 * @see #name
	 **/
	public static final String NAME = "name";

	
	/**
	 * Static metamodel type for {@link org.acme.MyEntity}
	 **/
	public static volatile EntityType<MyEntity> class_;
	
	/**
	 * Static metamodel for attribute {@link org.acme.MyEntity#name}
	 **/
	public static volatile SingularAttribute<MyEntity, String> name;
	
	public static Repo repo() {
		return CDI.current().select(Repo.class).get();
	}
	
	public static PanacheManagedBlockingRepository managedBlocking() {
		return CDI.current().select(PanacheManagedBlockingRepository.class).get();
	}
	
	@Dependent
	@Generated("org.hibernate.processor.HibernateProcessor")
	public static class PanacheManagedBlockingRepository implements io.quarkus.hibernate.panache.managed.blocking.PanacheManagedBlockingRepositoryBase<MyEntity, java.lang.Long> {
	}
	
	public static PanacheStatelessBlockingRepository statelessBlocking() {
		return CDI.current().select(PanacheStatelessBlockingRepository.class).get();
	}
	
	@Dependent
	@Generated("org.hibernate.processor.HibernateProcessor")
	public static class PanacheStatelessBlockingRepository implements io.quarkus.hibernate.panache.stateless.blocking.PanacheStatelessBlockingRepositoryBase<MyEntity, java.lang.Long> {
	}
	
	public static PanacheManagedReactiveRepository managedReactive() {
		return CDI.current().select(PanacheManagedReactiveRepository.class).get();
	}
	
	@Dependent
	@Generated("org.hibernate.processor.HibernateProcessor")
	public static class PanacheManagedReactiveRepository implements io.quarkus.hibernate.panache.managed.reactive.PanacheManagedReactiveRepositoryBase<MyEntity, java.lang.Long> {
	}
	
	public static PanacheStatelessReactiveRepository statelessReactive() {
		return CDI.current().select(PanacheStatelessReactiveRepository.class).get();
	}
	
	@Dependent
	@Generated("org.hibernate.processor.HibernateProcessor")
	public static class PanacheStatelessReactiveRepository implements io.quarkus.hibernate.panache.stateless.reactive.PanacheStatelessReactiveRepositoryBase<MyEntity, java.lang.Long> {
	}

}
```

To recap:

- Detects Panache2 package and types
- Scans nested interfaces in entities to find repositories
- Generates accessors for nested repos
- Generates implementations and accessors for managed/stateless/blocking/reactive repos (reactive only if HR is detected)
- Switch to using `Session` instead of `EntityManager` for Panache1&2 since that's what Quarkus switched to a while ago

There are tests for all this, but they're in Quarkus, and can only be merged once this gets merged. This is because @yrodiere gets an allergic skin reaction with cyclic dependencies, and assures me that the ORM CI now invokes the Quarkus CI, so even though you won't see the tests when you run them locally, they will eventually be run as part of the ORM CI.

Let me know what you think, @gavinking and if you want me to change anything.

----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-19586
<!-- Hibernate GitHub Bot issue links end -->