### PR TITLE
HHH-19497 Test for composition of 'not' 'in' restrictions

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/sql/ast/spi/AbstractSqlAstTranslator.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/ast/spi/AbstractSqlAstTranslator.java
@@ -7746,9 +7746,6 @@ public abstract class AbstractSqlAstTranslator<T extends JdbcOperation> implemen
 				}
 			}
 			else if ( !dialect.supportsRowValueConstructorSyntaxInInList() ) {
-				final ComparisonOperator comparisonOperator = inListPredicate.isNegated() ?
-						ComparisonOperator.NOT_EQUAL :
-						ComparisonOperator.EQUAL;
 				// Some DBs like Oracle support tuples only for the IN subquery predicate
 				if ( dialect.supportsRowValueConstructorSyntaxInInSubQuery() && dialect.supportsUnionAll() ) {
 					inListPredicate.getTestExpression().accept( this );
@@ -7767,17 +7764,21 @@ public abstract class AbstractSqlAstTranslator<T extends JdbcOperation> implemen
 					appendSql( CLOSE_PARENTHESIS );
 				}
 				else {
-					String separator = NO_SEPARATOR;
+					final ComparisonOperator tupleComparisonOperator = inListPredicate.isNegated() ?
+							ComparisonOperator.NOT_EQUAL :
+							ComparisonOperator.EQUAL;
+					final String expressionJunction = inListPredicate.isNegated() ? " and " : " or ";
 					appendSql( OPEN_PARENTHESIS );
-					for ( Expression expression : listExpressions ) {
-						appendSql( separator );
+					String separator = NO_SEPARATOR;
+					for (Expression expression : listExpressions) {
+						appendSql(separator);
 						emulateTupleComparison(
 								lhsTuple.getExpressions(),
-								getSqlTuple( expression ).getExpressions(),
-								comparisonOperator,
+								SqlTupleContainer.getSqlTuple(expression).getExpressions(),
+								tupleComparisonOperator,
 								true
 						);
-						separator = " or ";
+						separator = expressionJunction;
 					}
 					appendSql( CLOSE_PARENTHESIS );
 				}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/criteria/basic/Foo.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/criteria/basic/Foo.java
@@ -1,0 +1,55 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.jpa.criteria.basic;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.JoinColumns;
+import jakarta.persistence.ManyToOne;
+
+import java.util.Objects;
+
+/**
+ * Entity used in <code>org.hibernate.orm.test.jpa.criteria.basic.NegatedInPredicateTest</code>.
+ *
+ * @author Mike Mannion
+ */
+@Entity
+public class Foo {
+
+	@Id
+	Long id;
+
+	@ManyToOne
+	@JoinColumns({
+			@JoinColumn(name = "FK_CODE", referencedColumnName = "CODE"),
+			@JoinColumn(name = "FK_CONTEXT", referencedColumnName = "CONTEXT")
+	})
+	FooType fooType;
+
+	public Foo() {
+		// For JPA
+	}
+
+	public Foo(Long id, FooType fooType) {
+		this.id = id;
+		this.fooType = fooType;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (o == null || getClass() != o.getClass()) return false;
+
+		Foo customer = (Foo) o;
+		return Objects.equals(id, customer.id) && Objects.equals(fooType, customer.fooType);
+	}
+
+	@Override
+	public int hashCode() {
+		int result = Objects.hashCode(id);
+		result = 31 * result + Objects.hashCode(fooType);
+		return result;
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/criteria/basic/FooType.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/criteria/basic/FooType.java
@@ -1,0 +1,32 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.jpa.criteria.basic;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+
+/**
+ * Entity used in <code>org.hibernate.orm.test.jpa.criteria.basic.NegatedInPredicateTest</code>.
+ *
+ * @author Mike Mannion
+ */
+@Entity
+public class FooType {
+	@Id
+	@Column(name = "CODE")
+	String code;
+
+	@Column(name = "CONTEXT")
+	String context;
+
+	public FooType() {
+		// For JPA
+	}
+
+	FooType(String code, String context) {
+		this.code = code;
+		this.context = context;
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/criteria/basic/NegatedInPredicateTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/criteria/basic/NegatedInPredicateTest.java
@@ -1,0 +1,111 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.jpa.criteria.basic;
+
+import jakarta.persistence.criteria.CriteriaBuilder;
+import jakarta.persistence.criteria.CriteriaQuery;
+import jakarta.persistence.criteria.Root;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.JiraKey;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+
+/**
+ * Add test which composes not with in. Test introduced after discovery the negated in
+ * fails under dialects without record-level construction, such as DB2.
+ *
+ * @author Mike Mannion
+ */
+@JiraKey(value = "HHH-19497")
+@DomainModel(
+		annotatedClasses = {Foo.class, FooType.class}
+)
+@SessionFactory
+class NegatedInPredicateTest {
+
+	public static final FooType FOO_TYPE1 = new FooType( "ft1", "ctx1" );
+	public static final FooType FOO_TYPE2 = new FooType( "ft2", "ctx1" );
+
+	@BeforeEach
+	void setup(SessionFactoryScope scope) {
+		scope.inTransaction(
+				em -> {
+					em.persist( FOO_TYPE1 );
+					em.persist( FOO_TYPE2 );
+
+					Foo foo1 = new Foo( 1L, FOO_TYPE1 );
+					Foo foo2 = new Foo( 2L, FOO_TYPE1 );
+					Foo foo3 = new Foo( 3L, FOO_TYPE2 );
+
+					em.persist( foo1 );
+					em.persist( foo2 );
+					em.persist( foo3 );
+				}
+		);
+	}
+
+	@AfterEach
+	void tearDown(SessionFactoryScope scope) {
+		scope.inTransaction(
+				em -> {
+					em.createQuery( "delete from Foo" ).executeUpdate();
+					em.createQuery( "delete from FooType" ).executeUpdate();
+				}
+		);
+	}
+
+	@Test
+	void testSanity(SessionFactoryScope scope) {
+		scope.inTransaction(
+				em -> {
+					CriteriaBuilder cb = em.getCriteriaBuilder();
+					CriteriaQuery<Foo> cq = cb.createQuery( Foo.class );
+					Root<Foo> root = cq.from( Foo.class );
+					assertThat( em.createQuery( cq.select( root ) ).getResultList() )
+							.hasSize( 3 );
+				}
+		);
+	}
+
+	@Test
+	void testNegatedPredicate(SessionFactoryScope scope) {
+		scope.inTransaction(
+				em -> {
+					CriteriaBuilder cb = em.getCriteriaBuilder();
+					CriteriaQuery<Foo> cq = cb.createQuery( Foo.class );
+					Root<Foo> root = cq.from( Foo.class );
+					cq.select( root )
+							.where( cb.not( root.get( "fooType" ).in( List.of( FOO_TYPE1, FOO_TYPE2 ) ) ) );
+					assertThat( em.createQuery( cq ).getResultList() )
+							.isEmpty();
+				}
+		);
+	}
+
+	@Test
+	void testNonNegatedInPredicate(SessionFactoryScope scope) {
+		scope.inTransaction(
+				em -> {
+					CriteriaBuilder cb = em.getCriteriaBuilder();
+					CriteriaQuery<Foo> cq = cb.createQuery( Foo.class );
+					Root<Foo> root = cq.from( Foo.class );
+					cq.select( root )
+							.where( root.get( "fooType" ).in( List.of( FOO_TYPE1, FOO_TYPE2 ) ) );
+					assertThat( em.createQuery( cq ).getResultList() )
+							.hasSize( 3 );
+
+				}
+		);
+	}
+
+}


### PR DESCRIPTION
not in is not handled correctly for multi-column joins. This pull request fixes the problem.

<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

Compositions of not with in on lists fail for dialects not supporting record-level construction, such as DB2Dialect.
Using not with in with such dialects can lead to dangerous outcomes, such as all records being returned from a query. This is because the query condition always evaluates to either true or false (depending on the details of the query) because multi-column joins are not handled correctly.

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-19497
<!-- Hibernate GitHub Bot issue links end -->