### PR TITLE
[7.0] HHH-19577 Avoid duplicate stack map frames for SetPropertyValues

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/bytecode/internal/bytebuddy/BytecodeProviderImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/bytecode/internal/bytebuddy/BytecodeProviderImpl.java
@@ -886,16 +886,16 @@ public class BytecodeProviderImpl implements BytecodeProvider {
 			Label nextLabel = new Label();
 			for ( int index = 0; index < setters.length; index++ ) {
 				final Member setterMember = setters[index];
-				if ( enhanced && currentLabel != null ) {
+				if ( setterMember == EMBEDDED_MEMBER ) {
+					// The embedded property access does a no-op
+					continue;
+				}
+				if ( currentLabel != null ) {
 					methodVisitor.visitLabel( currentLabel );
 					implementationContext.getFrameGeneration().same(
 							methodVisitor,
 							instrumentedMethod.getParameters().asTypeList()
 					);
-				}
-				if ( setterMember == EMBEDDED_MEMBER ) {
-					// The embedded property access does a no-op
-					continue;
 				}
 				// Push entity on stack
 				methodVisitor.visitVarInsn( Opcodes.ALOAD, 1 );
@@ -1023,6 +1023,7 @@ public class BytecodeProviderImpl implements BytecodeProvider {
 				}
 				if ( enhanced ) {
 					final boolean compositeTracker = CompositeTracker.class.isAssignableFrom( type );
+					boolean alreadyHasFrame = false;
 					// The composite owner check and setting only makes sense if
 					//  * the value type is a composite tracker
 					//  * a value subtype can be a composite tracker
@@ -1104,6 +1105,7 @@ public class BytecodeProviderImpl implements BytecodeProvider {
 						// Clean stack after the if block
 						methodVisitor.visitLabel( compositeTrackerEndLabel );
 						implementationContext.getFrameGeneration().same(methodVisitor, instrumentedMethod.getParameters().asTypeList());
+						alreadyHasFrame = true;
 					}
 					if ( persistentAttributeInterceptable ) {
 						// Load the owner
@@ -1168,9 +1170,20 @@ public class BytecodeProviderImpl implements BytecodeProvider {
 						// Clean stack after the if block
 						methodVisitor.visitLabel( instanceofEndLabel );
 						implementationContext.getFrameGeneration().same(methodVisitor, instrumentedMethod.getParameters().asTypeList());
+						alreadyHasFrame = true;
 					}
 
-					currentLabel = nextLabel;
+					if ( alreadyHasFrame ) {
+						// Usually, the currentLabel is visited as well generating a frame,
+						// but if a frame was already generated, only visit the label here,
+						// otherwise two frames for the same bytecode index are generated,
+						// which is wrong and will produce an error when the JDK ClassFile API is used
+						methodVisitor.visitLabel( nextLabel );
+						currentLabel = null;
+					}
+					else {
+						currentLabel = nextLabel;
+					}
 					nextLabel = new Label();
 				}
 			}


### PR DESCRIPTION
<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

[Please describe here what your change is about]

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-19577
<!-- Hibernate GitHub Bot issue links end -->