### PR TITLE
HHH-19523 correctly initialize Pre/PostCollectionXxxxEvents from StatelessSession

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/event/spi/AbstractCollectionEvent.java
+++ b/hibernate-core/src/main/java/org/hibernate/event/spi/AbstractCollectionEvent.java
@@ -22,13 +22,13 @@ public abstract class AbstractCollectionEvent extends AbstractEvent {
 	private final String affectedOwnerEntityName;
 
 	/**
-	 * Constructs an AbstractCollectionEvent object.
-	 *  @param collection - the collection
+	 * Constructs an instance for a stateful session.
+	 * @param collection - the collection
 	 * @param source - the Session source
 	 * @param affectedOwner - the owner that is affected by this event;
- * can be null if unavailable
+	 * can be null if unavailable
 	 * @param affectedOwnerId - the ID for the owner that is affected
-* by this event; can be null if unavailable
+	 * by this event; can be null if unavailable
 	 */
 	public AbstractCollectionEvent(
 			CollectionPersister collectionPersister,
@@ -42,6 +42,27 @@ public abstract class AbstractCollectionEvent extends AbstractEvent {
 		this.affectedOwnerId = affectedOwnerId;
 		this.affectedOwnerEntityName =
 				getAffectedOwnerEntityName( collectionPersister, affectedOwner, source );
+	}
+
+	/**
+	 * Constructs an instance for a stateless session.
+	 * @param collection - the collection
+	 * @param entityName - the name of the owning entity
+	 * @param affectedOwner - the owner that is affected by this event;
+	 * can be null if unavailable
+	 * @param affectedOwnerId - the ID for the owner that is affected
+	 * by this event; can be null if unavailable
+	 */
+	public AbstractCollectionEvent(
+			PersistentCollection<?> collection,
+			String entityName,
+			Object affectedOwner,
+			Object affectedOwnerId) {
+		super( null );
+		this.collection = collection;
+		this.affectedOwner = affectedOwner;
+		this.affectedOwnerId = affectedOwnerId;
+		this.affectedOwnerEntityName = entityName;
 	}
 
 	protected static CollectionPersister getLoadedCollectionPersister( PersistentCollection<?> collection, EventSource source ) {
@@ -58,7 +79,7 @@ public abstract class AbstractCollectionEvent extends AbstractEvent {
 	}
 
 	protected static Object getOwnerIdOrNull(Object owner, EventSource source ) {
-		EntityEntry ownerEntry = source.getPersistenceContextInternal().getEntry( owner );
+		final EntityEntry ownerEntry = source.getPersistenceContextInternal().getEntry( owner );
 		return ownerEntry == null ? null : ownerEntry.getId();
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/event/spi/PostCollectionRecreateEvent.java
+++ b/hibernate-core/src/main/java/org/hibernate/event/spi/PostCollectionRecreateEvent.java
@@ -26,4 +26,12 @@ public class PostCollectionRecreateEvent extends AbstractCollectionEvent {
 				getOwnerIdOrNull( collection.getOwner(), source )
 		);
 	}
+
+	public PostCollectionRecreateEvent(
+			PersistentCollection<?> collection,
+			Object id,
+			String entityName,
+			Object loadedOwner) {
+		super( collection, entityName, loadedOwner, id );
+	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/event/spi/PostCollectionRemoveEvent.java
+++ b/hibernate-core/src/main/java/org/hibernate/event/spi/PostCollectionRemoveEvent.java
@@ -18,6 +18,20 @@ public class PostCollectionRemoveEvent extends AbstractCollectionEvent {
 			PersistentCollection<?> collection,
 			EventSource source,
 			Object loadedOwner) {
-		super( collectionPersister, collection, source, loadedOwner, getOwnerIdOrNull( loadedOwner, source ) );
+		super(
+				collectionPersister,
+				collection,
+				source,
+				loadedOwner,
+				getOwnerIdOrNull( loadedOwner, source )
+		);
+	}
+
+	public PostCollectionRemoveEvent(
+			PersistentCollection<?> collection,
+			Object id,
+			String entityName,
+			Object loadedOwner) {
+		super( collection, entityName, loadedOwner, id );
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/event/spi/PostCollectionUpdateEvent.java
+++ b/hibernate-core/src/main/java/org/hibernate/event/spi/PostCollectionUpdateEvent.java
@@ -25,4 +25,13 @@ public class PostCollectionUpdateEvent extends AbstractCollectionEvent {
 				getLoadedOwnerIdOrNull( collection, source )
 		);
 	}
+
+
+	public PostCollectionUpdateEvent(
+			PersistentCollection<?> collection,
+			Object id,
+			String entityName,
+			Object loadedOwner) {
+		super( collection, entityName, loadedOwner, id );
+	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/event/spi/PreCollectionRecreateEvent.java
+++ b/hibernate-core/src/main/java/org/hibernate/event/spi/PreCollectionRecreateEvent.java
@@ -26,4 +26,13 @@ public class PreCollectionRecreateEvent extends AbstractCollectionEvent {
 				getOwnerIdOrNull( collection.getOwner(), source )
 		);
 	}
+
+
+	public PreCollectionRecreateEvent(
+			PersistentCollection<?> collection,
+			Object id,
+			String entityName,
+			Object loadedOwner) {
+		super( collection, entityName, loadedOwner, id );
+	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/event/spi/PreCollectionRemoveEvent.java
+++ b/hibernate-core/src/main/java/org/hibernate/event/spi/PreCollectionRemoveEvent.java
@@ -27,4 +27,12 @@ public class PreCollectionRemoveEvent extends AbstractCollectionEvent {
 				getOwnerIdOrNull( loadedOwner, source )
 		);
 	}
+
+	public PreCollectionRemoveEvent(
+			PersistentCollection<?> collection,
+			Object id,
+			String entityName,
+			Object loadedOwner) {
+		super( collection, entityName, loadedOwner, id );
+	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/event/spi/PreCollectionUpdateEvent.java
+++ b/hibernate-core/src/main/java/org/hibernate/event/spi/PreCollectionUpdateEvent.java
@@ -26,4 +26,13 @@ public class PreCollectionUpdateEvent extends AbstractCollectionEvent {
 				getLoadedOwnerIdOrNull( collection, source )
 		);
 	}
+
+
+	public PreCollectionUpdateEvent(
+			PersistentCollection<?> collection,
+			Object id,
+			String entityName,
+			Object loadedOwner) {
+		super( collection, entityName, loadedOwner, id );
+	}
 }

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/stateless/events/CollectionListenerInStatelessSessionTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/stateless/events/CollectionListenerInStatelessSessionTest.java
@@ -1,0 +1,107 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.stateless.events;
+
+import org.hibernate.engine.spi.SessionFactoryImplementor;
+import org.hibernate.event.service.spi.EventListenerRegistry;
+import org.hibernate.event.spi.EventType;
+import org.hibernate.event.spi.PostCollectionRecreateEvent;
+import org.hibernate.event.spi.PostCollectionRecreateEventListener;
+import org.hibernate.event.spi.PostCollectionRemoveEvent;
+import org.hibernate.event.spi.PostCollectionRemoveEventListener;
+import org.hibernate.event.spi.PreCollectionRecreateEvent;
+import org.hibernate.event.spi.PreCollectionRecreateEventListener;
+import org.hibernate.event.spi.PreCollectionRemoveEvent;
+import org.hibernate.event.spi.PreCollectionRemoveEventListener;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@DomainModel(annotatedClasses = {EntityA.class, EntityB.class})
+@SessionFactory
+class CollectionListenerInStatelessSessionTest {
+
+	@Test
+	void statelessInsert(SessionFactoryScope scope) {
+		EventListenerRegistry registry =
+				scope.getSessionFactory().unwrap(SessionFactoryImplementor.class)
+						.getServiceRegistry().getService(EventListenerRegistry.class);
+		var preRecreate = new MyPreCollectionRecreateEventListener();
+		var preRemove = new MyPreCollectionRemoveEventListener();
+		var postRecreate = new MyPostCollectionRecreateEventListener();
+		var postRemove = new MyPostCollectionRemoveEventListener();
+		registry.getEventListenerGroup(EventType.PRE_COLLECTION_RECREATE)
+				.appendListener( preRecreate );
+		registry.getEventListenerGroup(EventType.PRE_COLLECTION_REMOVE)
+				.appendListener( preRemove );
+		registry.getEventListenerGroup(EventType.POST_COLLECTION_RECREATE)
+				.appendListener( postRecreate );
+		registry.getEventListenerGroup(EventType.POST_COLLECTION_REMOVE)
+				.appendListener( postRemove );
+
+		scope.inStatelessTransaction(statelessSession -> {
+			EntityA a = new EntityA();
+			EntityB b = new EntityB();
+			a.children.add(b);
+			statelessSession.insert( b );
+			statelessSession.insert( a );
+			statelessSession.delete( a );
+			statelessSession.delete( b );
+		});
+
+		assertEquals(1, preRecreate.called);
+		assertEquals(1, preRemove.called);
+		assertEquals(1, postRecreate.called);
+		assertEquals(1, postRemove.called);
+	}
+
+}
+
+class MyPreCollectionRecreateEventListener implements PreCollectionRecreateEventListener {
+
+	int called = 0;
+
+	@Override
+	public void onPreRecreateCollection(PreCollectionRecreateEvent event) {
+		called++;
+	}
+
+}
+
+class MyPreCollectionRemoveEventListener implements PreCollectionRemoveEventListener {
+
+	int called = 0;
+
+	@Override
+	public void onPreRemoveCollection(PreCollectionRemoveEvent event) {
+		called++;
+	}
+
+}
+
+class MyPostCollectionRecreateEventListener implements PostCollectionRecreateEventListener {
+
+	int called = 0;
+
+	@Override
+	public void onPostRecreateCollection(PostCollectionRecreateEvent event) {
+		called++;
+	}
+
+}
+
+class MyPostCollectionRemoveEventListener implements PostCollectionRemoveEventListener {
+
+	int called = 0;
+
+	@Override
+	public void onPostRemoveCollection(PostCollectionRemoveEvent event) {
+		called++;
+	}
+
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/stateless/events/EntityA.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/stateless/events/EntityA.java
@@ -1,0 +1,32 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.stateless.events;
+
+import java.util.ArrayList;
+import java.util.Collection;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+
+@Entity
+@Table(name = "ENTITY_A")
+public class EntityA {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.AUTO)
+	@Column(name = "ID")
+	Integer id;
+
+	@OneToMany
+	@JoinColumn(name = "ENTITY_A")
+	Collection<EntityB> children = new ArrayList<>();
+
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/stateless/events/EntityB.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/stateless/events/EntityB.java
@@ -1,0 +1,21 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.stateless.events;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+@Entity
+@Table(name = "ENTITY_B")
+public class EntityB {
+	@Id
+	@GeneratedValue(strategy = GenerationType.AUTO)
+	@Column(name = "ID")
+	Integer id;
+}


### PR DESCRIPTION
@DavideD  note that this change breaks Hibernate Reactive 

<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

[Please describe here what your change is about]

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-19523
<!-- Hibernate GitHub Bot issue links end -->