### PR TITLE
[7.0] HHH-19558: Fixed support of JDBC Escape Syntax

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/query/sql/internal/SQLQueryParser.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sql/internal/SQLQueryParser.java
@@ -86,12 +86,13 @@ public class SQLQueryParser {
 			final char ch = sqlQuery.charAt( index );
 			switch (ch) {
 				case '\'':
-					if (!doubleQuoted && !escaped) {
-						singleQuoted = !singleQuoted;
-					}
 					if (escaped) {
 						token.append(ch);
-					} else {
+					}
+					else {
+						if (!doubleQuoted) {
+							singleQuoted = !singleQuoted;
+						}
 						result.append(ch);
 					}
 					break;
@@ -99,11 +100,7 @@ public class SQLQueryParser {
 					if (!singleQuoted && !escaped) {
 						doubleQuoted = !doubleQuoted;
 					}
-					if (escaped) {
-						token.append(ch);
-					} else {
-						result.append(ch);
-					}
+					result.append(ch);
 					break;
 				case '{':
 					if (!singleQuoted && !doubleQuoted) {
@@ -228,7 +225,7 @@ public class SQLQueryParser {
 				}
 				aliasesFound++;
 				return collectionPersister.selectFragment( aliasName, collectionSuffix )
-						+ ", " + resolveProperties( aliasName, propertyName );
+					+ ", " + resolveProperties( aliasName, propertyName );
 			case "element.*":
 				return resolveProperties( aliasName, "*" );
 			default:
@@ -278,7 +275,7 @@ public class SQLQueryParser {
 			// TODO: better error message since we actually support composites if names are explicitly listed
 			throw new QueryException(
 					"SQL queries only support properties mapped to a single column - property [" +
-							propertyName + "] is mapped to " + columnAliases.length + " columns.",
+					propertyName + "] is mapped to " + columnAliases.length + " columns.",
 					originalQueryString
 			);
 		}

--- a/hibernate-core/src/main/java/org/hibernate/query/sql/internal/SQLQueryParser.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sql/internal/SQLQueryParser.java
@@ -89,13 +89,21 @@ public class SQLQueryParser {
 					if (!doubleQuoted && !escaped) {
 						singleQuoted = !singleQuoted;
 					}
-					result.append(ch);
+					if (escaped) {
+						token.append(ch);
+					} else {
+						result.append(ch);
+					}
 					break;
 				case '"':
 					if (!singleQuoted && !escaped) {
 						doubleQuoted = !doubleQuoted;
 					}
-					result.append(ch);
+					if (escaped) {
+						token.append(ch);
+					} else {
+						result.append(ch);
+					}
 					break;
 				case '{':
 					if (!singleQuoted && !doubleQuoted) {

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/sql/SQLQueryParserUnitTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/sql/SQLQueryParserUnitTests.java
@@ -28,6 +28,27 @@ public class SQLQueryParserUnitTests {
 	@DomainModel
 	@SessionFactory
 	@RequiresDialect(H2Dialect.class)
+	void testJDBCEscapeSyntaxParsing(SessionFactoryScope scope) {
+		final SessionFactoryImplementor sessionFactory = scope.getSessionFactory();
+		final String sqlQuery = "select id, name from {h-domain}the_table where date = {d '2025-06-18'}";
+
+		final String full = processSqlString( sqlQuery, "my_catalog", "my_schema", sessionFactory );
+		assertThat( full ).contains( "{d '2025-06-18'}" );
+
+		final String catalogOnly = processSqlString( sqlQuery, "my_catalog", null, sessionFactory );
+		assertThat( catalogOnly ).contains( "{d '2025-06-18'}" );
+
+		final String schemaOnly = processSqlString( sqlQuery, null, "my_schema", sessionFactory );
+		assertThat( schemaOnly ).contains( "{d '2025-06-18'}" );
+
+		final String none = processSqlString( sqlQuery, null, null, sessionFactory );
+		assertThat( none ).contains( "{d '2025-06-18'}" );
+	}
+
+	@Test
+	@DomainModel
+	@SessionFactory
+	@RequiresDialect(H2Dialect.class)
 	void testDomainParsing(SessionFactoryScope scope) {
 		final SessionFactoryImplementor sessionFactory = scope.getSessionFactory();
 		final String sqlQuery = "select id, name from {h-domain}the_table";

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/sql/SQLQueryParserUnitTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/sql/SQLQueryParserUnitTests.java
@@ -13,6 +13,8 @@ import org.hibernate.testing.orm.junit.RequiresDialect;
 import org.hibernate.testing.orm.junit.SessionFactory;
 import org.hibernate.testing.orm.junit.SessionFactoryScope;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -24,25 +26,33 @@ import static org.assertj.core.api.Assertions.assertThat;
 @SuppressWarnings("JUnitMalformedDeclaration")
 public class SQLQueryParserUnitTests {
 
-	@Test
+	@ParameterizedTest
 	@DomainModel
 	@SessionFactory
 	@RequiresDialect(H2Dialect.class)
-	void testJDBCEscapeSyntaxParsing(SessionFactoryScope scope) {
+	@ValueSource(strings = {
+			"{d '2025-06-18'}",
+			"{t '14:00'}",
+			"{t '14:00:00'}",
+			"{ts '2025-06-18T14:00'}",
+			"{ts '2025-06-18T14:00:00'}",
+			"{ts '2025-06-18T14:00:00.123'}",
+			"{ts '2025-06-18T14:00:00+01:00'}"})
+	void testJDBCEscapeSyntaxParsing(String variant, SessionFactoryScope scope) {
 		final SessionFactoryImplementor sessionFactory = scope.getSessionFactory();
-		final String sqlQuery = "select id, name from {h-domain}the_table where date = {d '2025-06-18'}";
+		final String sqlQuery = "select id, name from {h-domain}the_table where date = " + variant;
 
 		final String full = processSqlString( sqlQuery, "my_catalog", "my_schema", sessionFactory );
-		assertThat( full ).contains( "{d '2025-06-18'}" );
+		assertThat( full ).contains( variant );
 
 		final String catalogOnly = processSqlString( sqlQuery, "my_catalog", null, sessionFactory );
-		assertThat( catalogOnly ).contains( "{d '2025-06-18'}" );
+		assertThat( catalogOnly ).contains( variant );
 
 		final String schemaOnly = processSqlString( sqlQuery, null, "my_schema", sessionFactory );
-		assertThat( schemaOnly ).contains( "{d '2025-06-18'}" );
+		assertThat( schemaOnly ).contains( variant );
 
 		final String none = processSqlString( sqlQuery, null, null, sessionFactory );
-		assertThat( none ).contains( "{d '2025-06-18'}" );
+		assertThat( none ).contains( variant );
 	}
 
 	@Test


### PR DESCRIPTION
<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

[Please describe here what your change is about]

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
