### PR TITLE
fix locking-related tests for Informix + improved impl of truncate()

### DIFF
--- a/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/InformixDialect.java
+++ b/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/InformixDialect.java
@@ -314,6 +314,11 @@ public class InformixDialect extends Dialect {
 	}
 
 	@Override
+	public boolean doesReadCommittedCauseWritersToBlockReaders() {
+		return true;
+	}
+
+	@Override
 	public SelectItemReferenceStrategy getGroupBySelectItemReferenceStrategy() {
 		return SelectItemReferenceStrategy.POSITION;
 	}

--- a/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/InformixDialect.java
+++ b/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/InformixDialect.java
@@ -580,6 +580,21 @@ public class InformixDialect extends Dialect {
 	}
 
 	@Override
+	public boolean canDisableConstraints() {
+		return true;
+	}
+
+	@Override
+	public String getDisableConstraintStatement(String tableName, String name) {
+		return "set constraints " + name + " disabled";
+	}
+
+	@Override
+	public String getEnableConstraintStatement(String tableName, String name) {
+		return "set constraints " + name + " enabled";
+	}
+
+	@Override
 	public boolean supportsOrderByInSubquery() {
 		// This is just a guess
 		return false;

--- a/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/InformixDialect.java
+++ b/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/InformixDialect.java
@@ -146,14 +146,14 @@ public class InformixDialect extends Dialect {
 				ForeignKey foreignKey,
 				Metadata metadata,
 				SqlStringGenerationContext context) {
-			String[] results = super.getSqlCreateStrings( foreignKey, metadata, context );
+			final String[] results = super.getSqlCreateStrings( foreignKey, metadata, context );
 			for ( int i = 0; i < results.length; i++ ) {
-				String result = results[i];
+				final String result = results[i];
 				if ( result.contains( " on delete " ) ) {
-					String constraintName = "constraint " + foreignKey.getName();
-					result = result.replace( constraintName + " ", "" );
-					result = result + " " + constraintName;
-					results[i] = result;
+					final String constraintName = "constraint " + foreignKey.getName();
+					results[i] =
+							result.replace( constraintName + " ", "" )
+									+ " " + constraintName;
 				}
 			}
 			return results;
@@ -174,11 +174,12 @@ public class InformixDialect extends Dialect {
 				}
 				constraint.append( column.getQuotedName( dialect ) );
 			}
-			constraint.append(')');
+			constraint.append( ')' );
 			final UniqueKey orderingUniqueKey = key.getOrderingUniqueKey();
 			if ( orderingUniqueKey != null && orderingUniqueKey.isNameExplicit() ) {
 				constraint.append( " constraint " )
-						.append( orderingUniqueKey.getName() ).append( ' ' );
+						.append( orderingUniqueKey.getName() )
+						.append( ' ' );
 			}
 			return constraint.toString();
 		}
@@ -356,11 +357,11 @@ public class InformixDialect extends Dialect {
 		functionFactory.variance();
 		functionFactory.bitLength_pattern( "length(?1)*8" );
 		functionFactory.varPop_sumCount();
-		functionFactory.hypotheticalOrderedSetAggregates();
 
 		final SqmFunctionRegistry functionRegistry = functionContributions.getFunctionRegistry();
 		final TypeConfiguration typeConfiguration = functionContributions.getTypeConfiguration();
-		final BasicType<String> stringBasicType = typeConfiguration.getBasicTypeRegistry().resolve( StandardBasicTypes.STRING );
+		final BasicType<String> stringBasicType =
+				typeConfiguration.getBasicTypeRegistry().resolve( StandardBasicTypes.STRING );
 
 		functionRegistry.registerAlternateKey( "var_samp", "variance" );
 
@@ -378,8 +379,10 @@ public class InformixDialect extends Dialect {
 				.setArgumentTypeResolver( impliedOrInvariant( typeConfiguration, STRING ) )
 				.setArgumentListSignature( "(STRING string, STRING pattern)" )
 				.register();
+
 		if ( supportsWindowFunctions() ) {
 			functionFactory.windowFunctions();
+			functionFactory.hypotheticalOrderedSetAggregates();
 		}
 
 		functionRegistry.register( "overlay",

--- a/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/InformixDialect.java
+++ b/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/InformixDialect.java
@@ -371,8 +371,12 @@ public class InformixDialect extends Dialect {
 
 		//coalesce() and nullif() both supported since Informix 12
 
-		functionRegistry.register( "least", new CaseLeastGreatestEmulation( true ) );
-		functionRegistry.register( "greatest", new CaseLeastGreatestEmulation( false ) );
+		// least() and greatest() supported since 12.10
+		if ( getVersion().isBefore( 12, 10 ) ) {
+			functionRegistry.register( "least", new CaseLeastGreatestEmulation( true ) );
+			functionRegistry.register( "greatest", new CaseLeastGreatestEmulation( false ) );
+		}
+
 		functionRegistry.namedDescriptorBuilder( "matches" )
 				.setInvariantType( stringBasicType )
 				.setExactArgumentCount( 2 )

--- a/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/InformixDialect.java
+++ b/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/InformixDialect.java
@@ -511,6 +511,12 @@ public class InformixDialect extends Dialect {
 	}
 
 	@Override
+	public String getTruncateTableStatement(String tableName) {
+		return super.getTruncateTableStatement( tableName )
+			+ " reuse storage keep statistics";
+	}
+
+	@Override
 	public SequenceSupport getSequenceSupport() {
 		return sequenceSupport;
 	}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/findoptions/FindOptionsTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/findoptions/FindOptionsTest.java
@@ -20,8 +20,10 @@ import org.hibernate.ReadOnlyMode;
 import org.hibernate.Session;
 import org.hibernate.annotations.FetchProfile;
 import org.hibernate.annotations.FetchProfileOverride;
+import org.hibernate.community.dialect.InformixDialect;
 import org.hibernate.testing.orm.junit.EntityManagerFactoryScope;
 import org.hibernate.testing.orm.junit.Jpa;
+import org.hibernate.testing.orm.junit.SkipForDialect;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
@@ -35,6 +37,8 @@ import static org.junit.jupiter.api.Assertions.fail;
 @Jpa(annotatedClasses = FindOptionsTest.MyEntity.class)
 public class FindOptionsTest {
 	@Test
+	@SkipForDialect(dialectClass = InformixDialect.class,
+			reason = "Informix disallows FOR UPDATE with multi-table queries")
 	void test(EntityManagerFactoryScope scope) {
 		MyEntity hello = new MyEntity("Hello");
 		scope.getEntityManagerFactory()

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/lock/LockTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/lock/LockTest.java
@@ -4,6 +4,7 @@
  */
 package org.hibernate.orm.test.jpa.lock;
 
+import java.sql.Connection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -21,6 +22,7 @@ import org.hibernate.TransactionException;
 import org.hibernate.cfg.AvailableSettings;
 import org.hibernate.community.dialect.AltibaseDialect;
 import org.hibernate.community.dialect.FirebirdDialect;
+import org.hibernate.community.dialect.InformixDialect;
 import org.hibernate.dialect.HANADialect;
 import org.hibernate.dialect.CockroachDialect;
 import org.hibernate.community.dialect.DerbyDialect;
@@ -68,6 +70,10 @@ public class LockTest extends BaseEntityManagerFunctionalTestCase {
 	@Override
 	protected void addConfigOptions(Map options) {
 		super.addConfigOptions( options );
+		if ( getDialect() instanceof InformixDialect ) {
+			options.put( AvailableSettings.ISOLATION,
+					Connection.TRANSACTION_REPEATABLE_READ );
+		}
 		// We can't use a shared connection provider if we use TransactionUtil.setJdbcTimeout because that is set on the connection level
 //		options.remove( AvailableSettings.CONNECTION_PROVIDER );
 	}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/lock/StatementIsClosedAfterALockExceptionTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/lock/StatementIsClosedAfterALockExceptionTest.java
@@ -4,13 +4,16 @@
  */
 package org.hibernate.orm.test.jpa.lock;
 
+import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.util.HashMap;
 import java.util.Map;
 import jakarta.persistence.LockModeType;
 import org.hibernate.Session;
+import org.hibernate.cfg.AvailableSettings;
 import org.hibernate.community.dialect.AltibaseDialect;
+import org.hibernate.community.dialect.InformixDialect;
 import org.hibernate.dialect.CockroachDialect;
 import org.hibernate.orm.test.jpa.BaseEntityManagerFunctionalTestCase;
 import org.hibernate.testing.orm.jdbc.PreparedStatementSpyConnectionProvider;
@@ -48,6 +51,10 @@ public class StatementIsClosedAfterALockExceptionTest extends BaseEntityManagerF
 			org.hibernate.cfg.AvailableSettings.CONNECTION_PROVIDER,
 			CONNECTION_PROVIDER
 		);
+		if ( getDialect() instanceof InformixDialect ) {
+			config.put( AvailableSettings.ISOLATION,
+					Connection.TRANSACTION_REPEATABLE_READ );
+		}
 		return config;
 	}
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/locking/JoinedInheritancePessimisticLockingTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/locking/JoinedInheritancePessimisticLockingTest.java
@@ -12,9 +12,11 @@ import jakarta.persistence.Inheritance;
 import jakarta.persistence.InheritanceType;
 import jakarta.persistence.LockModeType;
 import jakarta.persistence.Version;
+import org.hibernate.community.dialect.InformixDialect;
 import org.hibernate.testing.orm.junit.EntityManagerFactoryScope;
 import org.hibernate.testing.orm.junit.Jira;
 import org.hibernate.testing.orm.junit.Jpa;
+import org.hibernate.testing.orm.junit.SkipForDialect;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -55,6 +57,8 @@ public class JoinedInheritancePessimisticLockingTest {
 	}
 
 	@Test
+	@SkipForDialect(dialectClass = InformixDialect.class,
+			reason = "Informix disallows FOR UPDATE with multi-table queries")
 	public void findWithLock(EntityManagerFactoryScope scope) {
 		scope.inTransaction(entityManager -> {
 			BaseThing t = entityManager.find( BaseThing.class, 1L, LockModeType.PESSIMISTIC_WRITE );

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/locking/LockModeTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/locking/LockModeTest.java
@@ -4,6 +4,7 @@
  */
 package org.hibernate.orm.test.locking;
 
+import java.sql.Connection;
 import java.util.Collections;
 
 import jakarta.persistence.LockModeType;
@@ -14,7 +15,9 @@ import jakarta.persistence.criteria.CriteriaQuery;
 import org.hibernate.LockMode;
 import org.hibernate.Session;
 import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
+import org.hibernate.cfg.AvailableSettings;
 import org.hibernate.community.dialect.AltibaseDialect;
+import org.hibernate.community.dialect.InformixDialect;
 import org.hibernate.dialect.CockroachDialect;
 import org.hibernate.dialect.SQLServerDialect;
 import org.hibernate.dialect.SybaseASEDialect;
@@ -62,6 +65,10 @@ public class LockModeTest extends BaseSessionFactoryFunctionalTest {
 		super.applySettings( ssrBuilder );
 		// We can't use a shared connection provider if we use TransactionUtil.setJdbcTimeout because that is set on the connection level
 //		ssrBuilder.getSettings().remove( AvailableSettings.CONNECTION_PROVIDER );
+		if ( getDialect() instanceof InformixDialect ) {
+			ssrBuilder.applySetting( AvailableSettings.ISOLATION,
+					Connection.TRANSACTION_REPEATABLE_READ );
+		}
 	}
 
 	@BeforeEach

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/locking/LockRefreshReferencedAndCascadingTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/locking/LockRefreshReferencedAndCascadingTest.java
@@ -6,9 +6,12 @@ package org.hibernate.orm.test.locking;
 
 import org.hibernate.Hibernate;
 
+import org.hibernate.community.dialect.InformixDialect;
 import org.hibernate.testing.orm.junit.EntityManagerFactoryScope;
 import org.hibernate.testing.orm.junit.Jpa;
-import org.junit.jupiter.api.BeforeAll;
+import org.hibernate.testing.orm.junit.SkipForDialect;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import jakarta.persistence.CascadeType;
@@ -34,7 +37,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 )
 public class LockRefreshReferencedAndCascadingTest {
 
-	@BeforeAll
+	@BeforeEach
 	public void setUp(EntityManagerFactoryScope scope) {
 		scope.inTransaction(
 				entityManager -> {
@@ -52,7 +55,14 @@ public class LockRefreshReferencedAndCascadingTest {
 		);
 	}
 
+	@AfterEach
+	public void tearDown(EntityManagerFactoryScope scope) {
+		scope.getEntityManagerFactory().getSchemaManager().truncate();
+	}
+
 	@Test
+	@SkipForDialect(dialectClass = InformixDialect.class,
+			reason = "Informix disallows FOR UPDATE with multi-table queries")
 	public void testRefreshBeforeRead(EntityManagerFactoryScope scope) {
 		scope.inTransaction(
 				entityManager -> {
@@ -100,6 +110,8 @@ public class LockRefreshReferencedAndCascadingTest {
 	}
 
 	@Test
+	@SkipForDialect(dialectClass = InformixDialect.class,
+			reason = "Informix disallows FOR UPDATE with multi-table queries")
 	public void testRefreshAfterRead(EntityManagerFactoryScope scope) {
 		scope.inTransaction(
 				entityManager -> {
@@ -124,6 +136,8 @@ public class LockRefreshReferencedAndCascadingTest {
 	}
 
 	@Test
+	@SkipForDialect(dialectClass = InformixDialect.class,
+			reason = "Informix disallows FOR UPDATE with multi-table queries")
 	public void testRefreshLockMode(EntityManagerFactoryScope scope) {
 		scope.inTransaction(
 				entityManager -> {
@@ -150,6 +164,8 @@ public class LockRefreshReferencedAndCascadingTest {
 	}
 
 	@Test
+	@SkipForDialect(dialectClass = InformixDialect.class,
+			reason = "Informix disallows FOR UPDATE with multi-table queries")
 	public void testFindWithLockMode(EntityManagerFactoryScope scope) {
 		scope.inTransaction(
 				session -> {

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/locking/LockRefreshReferencedTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/locking/LockRefreshReferencedTest.java
@@ -7,9 +7,11 @@ package org.hibernate.orm.test.locking;
 
 import org.hibernate.Hibernate;
 
+import org.hibernate.community.dialect.InformixDialect;
 import org.hibernate.testing.orm.junit.EntityManagerFactoryScope;
 import org.hibernate.testing.orm.junit.JiraKey;
 import org.hibernate.testing.orm.junit.Jpa;
+import org.hibernate.testing.orm.junit.SkipForDialect;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
@@ -117,6 +119,8 @@ public class LockRefreshReferencedTest {
 
 
 	@Test
+	@SkipForDialect(dialectClass = InformixDialect.class,
+			reason = "Informix disallows FOR UPDATE with multi-table queries")
 	public void testFindWithLockMode(EntityManagerFactoryScope scope) {
 		scope.inTransaction(
 				session -> {

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/locking/jpa/FollowOnLockingTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/locking/jpa/FollowOnLockingTest.java
@@ -8,6 +8,7 @@ import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 import org.hibernate.community.dialect.AltibaseDialect;
+import org.hibernate.community.dialect.InformixDialect;
 import org.hibernate.dialect.CockroachDialect;
 import org.hibernate.dialect.HSQLDialect;
 import org.hibernate.dialect.OracleDialect;
@@ -39,6 +40,8 @@ import static org.assertj.core.api.Assertions.fail;
 @SkipForDialect(dialectClass = CockroachDialect.class, reason = "Cockroach allows the concurrent access but cancels one or both transactions at the end")
 @SkipForDialect(dialectClass = OracleDialect.class, majorVersion = 11, reason = "Timeouts don't work on Oracle 11 when using a driver other than ojdbc6, but we can't test with that driver")
 @SkipForDialect(dialectClass = AltibaseDialect.class, reason = "Altibase does not support timeout in statement level")
+@SkipForDialect(dialectClass = InformixDialect.class, reason = "Test requires REPEATABLE_READ (and then it passes)")
+//@ServiceRegistry(settings = @Setting(name = AvailableSettings.ISOLATION, value = "REPEATABLE_READ"))
 public class FollowOnLockingTest {
 
 	@Test


### PR DESCRIPTION
Informix only allows FOR UPDATE with single-table SELECTs

<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

[Please describe here what your change is about]

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
