### PR TITLE
Refactor/micrometer test

### DIFF
--- a/hibernate-micrometer/src/test/java/org/hibernate/test/stat/MicrometerStatisticsTest.java
+++ b/hibernate-micrometer/src/test/java/org/hibernate/test/stat/MicrometerStatisticsTest.java
@@ -19,16 +19,19 @@ import io.micrometer.core.instrument.Tags;
 import io.micrometer.core.instrument.search.MeterNotFoundException;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 
 /**
- *  @author Erin Schnabel
- *  @author Donnchadh O Donnabhain
+ * @author Erin Schnabel
+ * @author Donnchadh O Donnabhain
  */
 public class MicrometerStatisticsTest extends BaseCoreFunctionalTestCase {
 
 	@Override
 	protected Class<?>[] getAnnotatedClasses() {
-		return new Class<?>[] { Account.class, AccountId.class };
+		return new Class<?>[] {Account.class, AccountId.class};
 	}
 
 	private SimpleMeterRegistry registry = new SimpleMeterRegistry();
@@ -47,9 +50,9 @@ public class MicrometerStatisticsTest extends BaseCoreFunctionalTestCase {
 
 	@Before
 	public void setUpMetrics() {
-		hibernateMetrics = new HibernateMetrics(sessionFactory(),
-												sessionFactory().getName(),
-												Tags.empty() );
+		hibernateMetrics = new HibernateMetrics( sessionFactory(),
+				sessionFactory().getName(),
+				Tags.empty() );
 		hibernateMetrics.bindTo( registry );
 	}
 
@@ -60,67 +63,74 @@ public class MicrometerStatisticsTest extends BaseCoreFunctionalTestCase {
 
 	@Test
 	public void testMicrometerMetrics() {
-		Assert.assertNotNull(registry.get("hibernate.sessions.open").functionCounter());
-		Assert.assertNotNull(registry.get("hibernate.sessions.closed").functionCounter());
+		Assert.assertNotNull( registry.get( "hibernate.sessions.open" ).functionCounter() );
+		Assert.assertNotNull( registry.get( "hibernate.sessions.closed" ).functionCounter() );
 
-		Assert.assertNotNull(registry.get("hibernate.transactions").tags("result", "success").functionCounter());
-		Assert.assertNotNull(registry.get("hibernate.transactions").tags("result", "failure").functionCounter());
+		Assert.assertNotNull( registry.get( "hibernate.transactions" ).tags( "result", "success" ).functionCounter() );
+		Assert.assertNotNull( registry.get( "hibernate.transactions" ).tags( "result", "failure" ).functionCounter() );
 
-		Assert.assertNotNull(registry.get("hibernate.optimistic.failures").functionCounter());
-		Assert.assertNotNull(registry.get("hibernate.flushes").functionCounter());
-		Assert.assertNotNull(registry.get("hibernate.connections.obtained").functionCounter());
+		Assert.assertNotNull( registry.get( "hibernate.optimistic.failures" ).functionCounter() );
+		Assert.assertNotNull( registry.get( "hibernate.flushes" ).functionCounter() );
+		Assert.assertNotNull( registry.get( "hibernate.connections.obtained" ).functionCounter() );
 
-		Assert.assertNotNull(registry.get("hibernate.statements").tags("status", "prepared").functionCounter());
-		Assert.assertNotNull(registry.get("hibernate.statements").tags("status", "closed").functionCounter());
+		Assert.assertNotNull( registry.get( "hibernate.statements" ).tags( "status", "prepared" ).functionCounter() );
+		Assert.assertNotNull( registry.get( "hibernate.statements" ).tags( "status", "closed" ).functionCounter() );
 
 		// Second level cache disabled
-		verifyMeterNotFoundException("hibernate.second.level.cache.requests");
-		verifyMeterNotFoundException("hibernate.second.level.cache.puts");
+		verifyMeterNotFoundException( "hibernate.second.level.cache.requests" );
+		verifyMeterNotFoundException( "hibernate.second.level.cache.puts" );
 
-		Assert.assertNotNull(registry.get("hibernate.entities.deletes").functionCounter());
-		Assert.assertNotNull(registry.get("hibernate.entities.fetches").functionCounter());
-		Assert.assertNotNull(registry.get("hibernate.entities.inserts").functionCounter());
-		Assert.assertNotNull(registry.get("hibernate.entities.loads").functionCounter());
-		Assert.assertNotNull(registry.get("hibernate.entities.updates").functionCounter());
-		Assert.assertNotNull(registry.get("hibernate.entities.upserts").functionCounter());
+		Assert.assertNotNull( registry.get( "hibernate.entities.deletes" ).functionCounter() );
+		Assert.assertNotNull( registry.get( "hibernate.entities.fetches" ).functionCounter() );
+		Assert.assertNotNull( registry.get( "hibernate.entities.inserts" ).functionCounter() );
+		Assert.assertNotNull( registry.get( "hibernate.entities.loads" ).functionCounter() );
+		Assert.assertNotNull( registry.get( "hibernate.entities.updates" ).functionCounter() );
+		Assert.assertNotNull( registry.get( "hibernate.entities.upserts" ).functionCounter() );
 
-		Assert.assertNotNull(registry.get("hibernate.collections.deletes").functionCounter());
-		Assert.assertNotNull(registry.get("hibernate.collections.fetches").functionCounter());
-		Assert.assertNotNull(registry.get("hibernate.collections.loads").functionCounter());
-		Assert.assertNotNull(registry.get("hibernate.collections.recreates").functionCounter());
-		Assert.assertNotNull(registry.get("hibernate.collections.updates").functionCounter());
+		Assert.assertNotNull( registry.get( "hibernate.collections.deletes" ).functionCounter() );
+		Assert.assertNotNull( registry.get( "hibernate.collections.fetches" ).functionCounter() );
+		Assert.assertNotNull( registry.get( "hibernate.collections.loads" ).functionCounter() );
+		Assert.assertNotNull( registry.get( "hibernate.collections.recreates" ).functionCounter() );
+		Assert.assertNotNull( registry.get( "hibernate.collections.updates" ).functionCounter() );
 
-		Assert.assertNotNull(registry.get("hibernate.cache.natural.id.requests").tags("result", "hit").functionCounter());
-		Assert.assertNotNull(registry.get("hibernate.cache.natural.id.requests").tags("result", "miss").functionCounter());
-		Assert.assertNotNull(registry.get("hibernate.cache.natural.id.puts").functionCounter());
-		Assert.assertNotNull(registry.get("hibernate.query.natural.id.executions").functionCounter());
-		Assert.assertNotNull(registry.get("hibernate.query.natural.id.executions.max").timeGauge());
+		Assert.assertNotNull(
+				registry.get( "hibernate.cache.natural.id.requests" ).tags( "result", "hit" ).functionCounter() );
+		Assert.assertNotNull(
+				registry.get( "hibernate.cache.natural.id.requests" ).tags( "result", "miss" ).functionCounter() );
+		Assert.assertNotNull( registry.get( "hibernate.cache.natural.id.puts" ).functionCounter() );
+		Assert.assertNotNull( registry.get( "hibernate.query.natural.id.executions" ).functionCounter() );
+		Assert.assertNotNull( registry.get( "hibernate.query.natural.id.executions.max" ).timeGauge() );
 
-		Assert.assertNotNull(registry.get("hibernate.query.executions").functionCounter());
-		Assert.assertNotNull(registry.get("hibernate.query.executions.max").timeGauge());
+		Assert.assertNotNull( registry.get( "hibernate.query.executions" ).functionCounter() );
+		Assert.assertNotNull( registry.get( "hibernate.query.executions.max" ).timeGauge() );
 
-		Assert.assertNotNull(registry.get("hibernate.cache.update.timestamps.requests").tags("result", "hit").functionCounter());
-		Assert.assertNotNull(registry.get("hibernate.cache.update.timestamps.requests").tags("result", "miss").functionCounter());
-		Assert.assertNotNull(registry.get("hibernate.cache.update.timestamps.puts").functionCounter());
+		Assert.assertNotNull( registry.get( "hibernate.cache.update.timestamps.requests" ).tags( "result", "hit" )
+				.functionCounter() );
+		Assert.assertNotNull( registry.get( "hibernate.cache.update.timestamps.requests" ).tags( "result", "miss" )
+				.functionCounter() );
+		Assert.assertNotNull( registry.get( "hibernate.cache.update.timestamps.puts" ).functionCounter() );
 
-		Assert.assertNotNull(registry.get("hibernate.cache.query.requests").tags("result", "hit").functionCounter());
-		Assert.assertNotNull(registry.get("hibernate.cache.query.requests").tags("result", "miss").functionCounter());
-		Assert.assertNotNull(registry.get("hibernate.cache.query.puts").functionCounter());
-		Assert.assertNotNull(registry.get("hibernate.cache.query.plan").tags("result", "hit").functionCounter());
-		Assert.assertNotNull(registry.get("hibernate.cache.query.plan").tags("result", "miss").functionCounter());
+		Assert.assertNotNull(
+				registry.get( "hibernate.cache.query.requests" ).tags( "result", "hit" ).functionCounter() );
+		Assert.assertNotNull(
+				registry.get( "hibernate.cache.query.requests" ).tags( "result", "miss" ).functionCounter() );
+		Assert.assertNotNull( registry.get( "hibernate.cache.query.puts" ).functionCounter() );
+		Assert.assertNotNull( registry.get( "hibernate.cache.query.plan" ).tags( "result", "hit" ).functionCounter() );
+		Assert.assertNotNull( registry.get( "hibernate.cache.query.plan" ).tags( "result", "miss" ).functionCounter() );
 
 		// prepare some test data...
 		Session session = openSession();
 		session.beginTransaction();
-		Account account = new Account( new AccountId( 1), "testAcct");
+		Account account = new Account( new AccountId( 1 ), "testAcct" );
 		session.persist( account );
 		session.getTransaction().commit();
 		session.close();
 
-		Assert.assertEquals( 1, registry.get("hibernate.sessions.open").functionCounter().count(), 0 );
-		Assert.assertEquals( 1, registry.get("hibernate.sessions.closed").functionCounter().count(), 0 );
-		Assert.assertEquals( 1, registry.get("hibernate.entities.inserts").functionCounter().count(), 0 );
-		Assert.assertEquals( 1, registry.get("hibernate.transactions").tags("result", "success").functionCounter().count(), 0 );
+		Assert.assertEquals( 1, registry.get( "hibernate.sessions.open" ).functionCounter().count(), 0 );
+		Assert.assertEquals( 1, registry.get( "hibernate.sessions.closed" ).functionCounter().count(), 0 );
+		Assert.assertEquals( 1, registry.get( "hibernate.entities.inserts" ).functionCounter().count(), 0 );
+		Assert.assertEquals( 1,
+				registry.get( "hibernate.transactions" ).tags( "result", "success" ).functionCounter().count(), 0 );
 
 		// clean up
 		session = openSession();
@@ -129,17 +139,21 @@ public class MicrometerStatisticsTest extends BaseCoreFunctionalTestCase {
 		session.getTransaction().commit();
 		session.close();
 
-		Assert.assertEquals( 2, registry.get("hibernate.sessions.open").functionCounter().count(), 0 );
-		Assert.assertEquals( 2, registry.get("hibernate.sessions.closed").functionCounter().count(), 0 );
-		Assert.assertEquals( 1, registry.get("hibernate.entities.deletes").functionCounter().count(), 0 );
-		Assert.assertEquals( 2, registry.get("hibernate.transactions").tags("result", "success").functionCounter().count(), 0 );
+		Assert.assertEquals( 2, registry.get( "hibernate.sessions.open" ).functionCounter().count(), 0 );
+		Assert.assertEquals( 2, registry.get( "hibernate.sessions.closed" ).functionCounter().count(), 0 );
+		Assert.assertEquals( 1, registry.get( "hibernate.entities.deletes" ).functionCounter().count(), 0 );
+		Assert.assertEquals( 2,
+				registry.get( "hibernate.transactions" ).tags( "result", "success" ).functionCounter().count(), 0 );
 	}
 
 	void verifyMeterNotFoundException(String name) {
-		try {
-			registry.get(name).meter();
-			Assert.fail(name + " should not have been found");
-		} catch(MeterNotFoundException mnfe) {
-		}
+		MeterNotFoundException ex = assertThrows(
+				MeterNotFoundException.class,
+				() -> registry.get( name ).meter(), name + " should not have been found"
+		);
+		assertTrue( ex.getMessage().contains( name ) );
+
+
 	}
+
 }


### PR DESCRIPTION
Refactored the verifyMeterNotFoundException method in MicrometerStatisticsTest to use assertThrows instead of a try-catch block.

This improves readability and aligns with modern JUnit testing best practices.

Before:
try {
registry.get(name).meter();
Assert.fail(name + " should not have been found");
}
catch (MeterNotFoundException mnfe) {
}

---

### ✅ Final Code: New `verifyMeterNotFoundException`


```java
void verifyMeterNotFoundException(String name) {
    MeterNotFoundException exception = assertThrows(
        MeterNotFoundException.class,
        () -> registry.get(name).meter(),
        name + " should not have been found"
    );
    assertTrue(exception.getMessage().contains(name));
}
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
