### PR TITLE
HHH-19591: Refactor verifyMeterNotFoundException to use assertThrows

### DIFF
--- a/hibernate-micrometer/src/test/java/org/hibernate/test/stat/MicrometerStatisticsTest.java
+++ b/hibernate-micrometer/src/test/java/org/hibernate/test/stat/MicrometerStatisticsTest.java
@@ -19,6 +19,9 @@ import io.micrometer.core.instrument.Tags;
 import io.micrometer.core.instrument.search.MeterNotFoundException;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 
 /**
  *  @author Erin Schnabel
@@ -136,10 +139,11 @@ public class MicrometerStatisticsTest extends BaseCoreFunctionalTestCase {
 	}
 
 	void verifyMeterNotFoundException(String name) {
-		try {
-			registry.get(name).meter();
-			Assert.fail(name + " should not have been found");
-		} catch(MeterNotFoundException mnfe) {
-		}
+		MeterNotFoundException ex = assertThrows(
+				MeterNotFoundException.class,
+				() -> registry.get( name ).meter(), name + " should not have been found"
+		);
+		assertTrue( ex.getMessage().contains( name ) );
+
 	}
 }


### PR DESCRIPTION
<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->
Refactored the `verifyMeterNotFoundException` method in `MicrometerStatisticsTest` to use `assertThrows` instead of a try-catch block.

This improves readability and aligns with modern JUnit testing best practices.

### Before:
```java
try {
    registry.get(name).meter();
    Assert.fail(name + " should not have been found");
}
catch (MeterNotFoundException mnfe) {
}

---

### ✅ Final Code: New `verifyMeterNotFoundException`

You already wrote it correctly! Here's the cleaned-up version for clarity:

```java
void verifyMeterNotFoundException(String name) {
    MeterNotFoundException exception = assertThrows(
        MeterNotFoundException.class,
        () -> registry.get(name).meter(),
        name + " should not have been found"
    );
    assertTrue(exception.getMessage().contains(name));
}
```

----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-19591
<!-- Hibernate GitHub Bot issue links end -->