### PR TITLE
Only require pull request build approval in the check stage / Do not use docker.withRegistry

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -119,16 +119,12 @@ stage('Build') {
 									state[buildEnv.tag]['containerName'] = "edb"
 									break;
 								case "sybase_jconn":
-									docker.withRegistry('https://index.docker.io/v1/', 'hibernateci.hub.docker.com') {
-										docker.image('nguoianphu/docker-sybase').pull()
-									}
+									docker.image('nguoianphu/docker-sybase').pull()
 									sh "./docker_db.sh sybase"
 									state[buildEnv.tag]['containerName'] = "sybase"
 									break;
 								case "cockroachdb":
-									docker.withRegistry('https://index.docker.io/v1/', 'hibernateci.hub.docker.com') {
-										docker.image('cockroachdb/cockroach:v23.1.12').pull()
-									}
+									docker.image('cockroachdb/cockroach:v23.1.12').pull()
 									sh "./docker_db.sh cockroachdb"
 									state[buildEnv.tag]['containerName'] = "cockroach"
 									break;

--- a/ci/jpa-3.1-tck.Jenkinsfile
+++ b/ci/jpa-3.1-tck.Jenkinsfile
@@ -42,7 +42,6 @@ pipeline {
             stages {
                 stage('Build') {
                     steps {
-                        requireApprovalForPullRequest 'hibernate'
                         script {
                             docker.withRegistry('https://index.docker.io/v1/', 'hibernateci.hub.docker.com') {
                                 docker.image('openjdk:11-jdk').pull()

--- a/ci/jpa-3.1-tck.Jenkinsfile
+++ b/ci/jpa-3.1-tck.Jenkinsfile
@@ -43,9 +43,7 @@ pipeline {
                 stage('Build') {
                     steps {
                         script {
-                            docker.withRegistry('https://index.docker.io/v1/', 'hibernateci.hub.docker.com') {
-                                docker.image('openjdk:11-jdk').pull()
-                            }
+                            docker.image('openjdk:11-jdk').pull()
                         }
                         dir('hibernate') {
                             checkout scm

--- a/ci/quarkus.Jenkinsfile
+++ b/ci/quarkus.Jenkinsfile
@@ -34,7 +34,6 @@ pipeline {
                 label 'LongDuration'
             }
         	steps {
-                requireApprovalForPullRequest 'hibernate'
 				script {
 					dir('hibernate') {
 						checkout scm


### PR DESCRIPTION
hey @mbellade, 👋🏻 😃 

I've notcied a couple hanging builds that you've approved: 
* https://ci.hibernate.org/job/hibernate-orm-quarkus/job/PR-10488/4/console
* https://ci.hibernate.org/job/hibernate-orm-tck-3.1/job/PR-10488/4/console

and seems like there is a double-check in the build config. and while at it .. I've removed the use of docker registry creds

(I'll leave it to you to re-re-approve the builds 😃)

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
