### PR TITLE
Add quarkus testing to 7.0 branch / Do not use docker withregistry

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -95,6 +95,12 @@ if (currentBuild.getBuildCauses().toString().contains('BranchIndexingCause')) {
 	currentBuild.result = 'NOT_BUILT'
   	return
 }
+// This is a limited maintenance branch, so don't run this on pushes to the branch, only on PRs
+if ( !env.CHANGE_ID ) {
+	print "INFO: Build skipped because this job should only run for pull request, not for branch pushes"
+	currentBuild.result = 'NOT_BUILT'
+	return
+}
 
 stage('Build') {
 	Map<String, Closure> executions = [:]

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -142,16 +142,12 @@ stage('Build') {
 									state[buildEnv.tag]['containerName'] = "edb"
 									break;
 								case "sybase_jconn":
-									docker.withRegistry('https://index.docker.io/v1/', 'hibernateci.hub.docker.com') {
-										docker.image('nguoianphu/docker-sybase').pull()
-									}
+									docker.image('nguoianphu/docker-sybase').pull()
 									sh "./docker_db.sh sybase"
 									state[buildEnv.tag]['containerName'] = "sybase"
 									break;
 								case "cockroachdb":
-									docker.withRegistry('https://index.docker.io/v1/', 'hibernateci.hub.docker.com') {
-										docker.image('cockroachdb/cockroach:v23.1.12').pull()
-									}
+									docker.image('cockroachdb/cockroach:v23.1.12').pull()
 									sh "./docker_db.sh cockroachdb"
 									state[buildEnv.tag]['containerName'] = "cockroach"
 									break;

--- a/ci/jpa-3.2-tck.Jenkinsfile
+++ b/ci/jpa-3.2-tck.Jenkinsfile
@@ -6,17 +6,11 @@ if (currentBuild.getBuildCauses().toString().contains('BranchIndexingCause')) {
 	currentBuild.result = 'NOT_BUILT'
   	return
 }
-def throttleCount
-// Don't build the TCK on PRs, unless they use the tck label
-if ( env.CHANGE_ID != null ) {
-	if ( !pullRequest.labels.contains( 'tck' ) ) {
-		print "INFO: Build skipped because pull request doesn't have 'tck' label"
-		return
-	}
-	throttleCount = 20
-}
-else {
-	throttleCount = 1
+// This is a limited maintenance branch, so don't run this on pushes to the branch, only on PRs
+if ( !env.CHANGE_ID ) {
+    print "INFO: Build skipped because this job should only run for pull request, not for branch pushes"
+    currentBuild.result = 'NOT_BUILT'
+    return
 }
 
 pipeline {
@@ -25,7 +19,6 @@ pipeline {
         jdk 'OpenJDK 17 Latest'
     }
     options {
-  		rateLimitBuilds(throttle: [count: throttleCount, durationName: 'day', userBoost: true])
         buildDiscarder(logRotator(numToKeepStr: '3', artifactNumToKeepStr: '3'))
         disableConcurrentBuilds(abortPrevious: true)
     }

--- a/ci/jpa-3.2-tck.Jenkinsfile
+++ b/ci/jpa-3.2-tck.Jenkinsfile
@@ -50,9 +50,7 @@ pipeline {
                 stage('Build') {
                     steps {
                         script {
-                            docker.withRegistry('https://index.docker.io/v1/', 'hibernateci.hub.docker.com') {
-                                docker.image('openjdk:17-jdk').pull()
-                            }
+                            docker.image('openjdk:17-jdk').pull()
                         }
                         dir('hibernate') {
                             checkout scm
@@ -72,9 +70,7 @@ pipeline {
                                 ).trim()
                                 switch (params.RDBMS) {
                                     case "mysql":
-                                        docker.withRegistry('https://index.docker.io/v1/', 'hibernateci.hub.docker.com') {
-                                            docker.image('mysql:8.2.0').pull()
-                                        }
+                                        docker.image('mysql:8.2.0').pull()
                                         sh "./docker_db.sh mysql"
                                         break;
                                     case "mssql":
@@ -82,15 +78,11 @@ pipeline {
                                         sh "./docker_db.sh mssql"
                                         break;
                                     case "oracle":
-                                        docker.withRegistry('https://index.docker.io/v1/', 'hibernateci.hub.docker.com') {
-                                            docker.image('gvenzl/oracle-free:23').pull()
-                                        }
+                                        docker.image('gvenzl/oracle-free:23').pull()
                                         sh "./docker_db.sh oracle"
                                         break;
                                     case "postgresql":
-                                        docker.withRegistry('https://index.docker.io/v1/', 'hibernateci.hub.docker.com') {
-                                            docker.image('postgis/postgis:16-3.4').pull()
-                                        }
+                                        docker.image('postgis/postgis:16-3.4').pull()
                                         sh "./docker_db.sh postgresql"
                                         break;
                                     case "db2":
@@ -98,9 +90,7 @@ pipeline {
                                         sh "./docker_db.sh db2"
                                         break;
                                     case "sybase":
-                                        docker.withRegistry('https://index.docker.io/v1/', 'hibernateci.hub.docker.com') {
-                                            docker.image('nguoianphu/docker-sybase').pull()
-                                        }
+                                        docker.image('nguoianphu/docker-sybase').pull()
                                         sh "./docker_db.sh sybase"
                                         break;
                                 }

--- a/ci/quarkus.Jenkinsfile
+++ b/ci/quarkus.Jenkinsfile
@@ -1,0 +1,80 @@
+@Library('hibernate-jenkins-pipeline-helpers') _
+
+// Avoid running the pipeline on branch indexing
+if (currentBuild.getBuildCauses().toString().contains('BranchIndexingCause')) {
+    print "INFO: Build skipped due to trigger being Branch Indexing"
+    currentBuild.result = 'NOT_BUILT'
+    return
+}
+// This is a limited maintenance branch, so don't run this on pushes to the branch, only on PRs
+if ( !env.CHANGE_ID ) {
+    print "INFO: Build skipped because this job should only run for pull request, not for branch pushes"
+    currentBuild.result = 'NOT_BUILT'
+    return
+}
+
+pipeline {
+    agent none
+    tools {
+        jdk 'OpenJDK 17 Latest'
+    }
+    options {
+        buildDiscarder(logRotator(numToKeepStr: '3', artifactNumToKeepStr: '3'))
+        disableConcurrentBuilds(abortPrevious: true)
+        skipDefaultCheckout()
+    }
+    stages {
+        stage('Checks') {
+            steps {
+                requireApprovalForPullRequest 'hibernate'
+            }
+        }
+        stage('Build') {
+            agent {
+                label 'LongDuration'
+            }
+            steps {
+                script {
+                    dir('hibernate') {
+                        checkout scm
+                        sh "./gradlew clean publishToMavenLocal -x test --no-scan --no-daemon --no-build-cache --stacktrace -PmavenMirror=nexus-load-balancer-c4cf05fd92f43ef8.elb.us-east-1.amazonaws.com -Dmaven.repo.local=${env.WORKSPACE}/.m2repository"
+                        script {
+                            env.HIBERNATE_VERSION = sh (
+                                    script: "grep hibernateVersion gradle/version.properties|cut -d'=' -f2",
+                                    returnStdout: true
+                            ).trim()
+                        }
+                    }
+                    dir('quarkus') {
+                        def latestQuarkusVersion = sh (script: "git ls-remote --heads https://github.com/quarkusio/quarkus.git | grep -oP 'refs/heads/\\K[0-9]+\\.[0-9]+?\$' | sort -V -r | head -n 1").trim()
+                        sh "git clone -b ${latestQuarkusVersion} --single-branch https://github.com/quarkusio/quarkus.git . || git reset --hard && git clean -fx && git pull"
+                        script {
+                            def sedStatus = sh (script: "sed -i 's@<hibernate-orm.version>.*</hibernate-orm.version>@<hibernate-orm.version>${env.HIBERNATE_VERSION}</hibernate-orm.version>@' pom.xml", returnStatus: true)
+                            if ( sedStatus != 0 ) {
+                                throw new IllegalArgumentException( "Unable to replace hibernate version in Quarkus pom. Got exit code $sedStatus" )
+                            }
+                        }
+                        // Need to override the default maven configuration this way, because there is no other way to do it
+                        sh "sed -i 's/-Xmx5g/-Xmx2048m/' ./.mvn/jvm.config"
+                        sh "echo -e '\\n-XX:MaxMetaspaceSize=1024m'>>./.mvn/jvm.config"
+                        withMaven(mavenLocalRepo: env.WORKSPACE + '/.m2repository', publisherStrategy:'EXPLICIT') {
+                            sh "./mvnw -pl !docs -Dquickly install"
+                            // Need to kill the gradle daemons started during the Maven install run
+                            sh "sudo pkill -f '.*GradleDaemon.*' || true"
+                            // Need to override the default maven configuration this way, because there is no other way to do it
+                            sh "sed -i 's/-Xmx2048m/-Xmx1340m/' ./.mvn/jvm.config"
+                            sh "sed -i 's/MaxMetaspaceSize=1024m/MaxMetaspaceSize=512m/' ./.mvn/jvm.config"
+                            def excludes = "'!integration-tests/kafka-oauth-keycloak,!integration-tests/kafka-sasl-elytron,!integration-tests/hibernate-search-orm-opensearch,!integration-tests/maven,!integration-tests/quartz,!integration-tests/reactive-messaging-kafka,!integration-tests/resteasy-reactive-kotlin/standard,!integration-tests/opentelemetry-reactive-messaging,!integration-tests/virtual-threads/kafka-virtual-threads,!integration-tests/smallrye-jwt-oidc-webapp,!extensions/oidc-db-token-state-manager/deployment,!docs'"
+                            sh "TESTCONTAINERS_RYUK_CONTAINER_PRIVILEGED=true ./mvnw -Dinsecure.repositories=WARN -pl :quarkus-hibernate-orm -amd -pl ${excludes} verify -Dstart-containers -Dtest-containers -Dskip.gradle.build"
+                        }
+                    }
+                }
+            }
+        }
+    }
+    post {
+        always {
+            notifyBuildResult maintainers: "andrea@hibernate.org steve@hibernate.org christian.beikov@gmail.com mbellade@redhat.com"
+        }
+    }
+}


### PR DESCRIPTION
Hey, so I was thinking we can test quarkus against the latest branched-out version (see the `def latestQuarkusVersion`), or do we do it only for the LTS versions ? 
+ there's also the cleanup of the `docker.withRegistry`, we shouldn't be using those unless we need the creds (like in that remaining quay case)

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
