### PR TITLE
HHH-19558: [6.6 backport] Fixed support of JDBC escape syntax 

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/query/sql/internal/SQLQueryParser.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sql/internal/SQLQueryParser.java
@@ -81,10 +81,15 @@ public class SQLQueryParser {
 			final char ch = sqlQuery.charAt( index );
 			switch (ch) {
 				case '\'':
-					if (!doubleQuoted && !escaped) {
-						singleQuoted = !singleQuoted;
+					if (escaped) {
+						token.append(ch);
 					}
-					result.append(ch);
+					else {
+						if (!doubleQuoted) {
+							singleQuoted = !singleQuoted;
+						}
+						result.append(ch);
+					}
 					break;
 				case '"':
 					if (!singleQuoted && !escaped) {
@@ -216,7 +221,7 @@ public class SQLQueryParser {
 				}
 				aliasesFound++;
 				return collectionPersister.selectFragment( aliasName, collectionSuffix )
-						+ ", " + resolveProperties( aliasName, propertyName );
+					+ ", " + resolveProperties( aliasName, propertyName );
 			case "element.*":
 				return resolveProperties( aliasName, "*" );
 			default:
@@ -266,7 +271,7 @@ public class SQLQueryParser {
 			// TODO: better error message since we actually support composites if names are explicitly listed
 			throw new QueryException(
 					"SQL queries only support properties mapped to a single column - property [" +
-							propertyName + "] is mapped to " + columnAliases.length + " columns.",
+					propertyName + "] is mapped to " + columnAliases.length + " columns.",
 					originalQueryString
 			);
 		}


### PR DESCRIPTION
Same fix as https://github.com/hibernate/hibernate-orm/pull/10369 for the 6.6 branch.
The unit test class does not exist on branch 6.6 and could not simply be moved over, without other changes.


----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-19558
<!-- Hibernate GitHub Bot issue links end -->