### PR TITLE
HHH-19582 NullPointerException in org.hibernate.internal.util.collections.AbstractPagedArray#clear (backport from main)

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/internal/util/collections/AbstractPagedArray.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/util/collections/AbstractPagedArray.java
@@ -176,7 +176,9 @@ public class AbstractPagedArray<E> {
 
 	public void clear() {
 		for ( Page<E> entryPage : elementPages ) {
-			entryPage.clear();
+			if ( entryPage != null ) {
+				entryPage.clear();
+			}
 		}
 		elementPages.clear();
 		elementPages.trimToSize();

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/util/InstanceIdentityMapTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/util/InstanceIdentityMapTest.java
@@ -6,6 +6,7 @@ package org.hibernate.orm.test.util;
 
 import org.hibernate.engine.spi.InstanceIdentity;
 import org.hibernate.internal.util.collections.InstanceIdentityMap;
+import org.hibernate.testing.orm.junit.Jira;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
@@ -99,4 +100,15 @@ public class InstanceIdentityMapTest {
 		assertThat( testMap.values() ).hasSize( 100 ).containsAll( map.values() );
 		assertThat( testMap.entrySet() ).hasSize( 100 ).containsAll( map.entrySet() );
 	}
+
+	@Test
+	@Jira(value = "https://hibernate.atlassian.net/browse/HHH-19582")
+	public void testNullPage() {
+		final TestInstance i1 = new TestInstance( 9999 );
+		testMap.put( i1, "instance_X" );
+
+		testMap.clear();
+		assertThat( testMap ).isEmpty();
+	}
+
 }


### PR DESCRIPTION
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-19582
<!-- Hibernate GitHub Bot issue links end -->