### PR TITLE
HHH-19587 - Easier access to LobHelper

### DIFF
--- a/hibernate-community-dialects/src/test/java/org/hibernate/community/dialect/AltibaseFunctionsTest.java
+++ b/hibernate-community-dialects/src/test/java/org/hibernate/community/dialect/AltibaseFunctionsTest.java
@@ -21,6 +21,7 @@ import java.util.List;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hibernate.Hibernate.getLobHelper;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 @DomainModel(annotatedClasses = Person.class)
@@ -49,8 +50,8 @@ public class AltibaseFunctionsTest {
 					{
 						arry[i] = (byte)i;
 					}
-					person.setBinaryData( session.getLobHelper().createBlob(arry) );
-					person.setComments( session.getLobHelper().createClob("blahblah") );
+					person.setBinaryData( getLobHelper().createBlob(arry) );
+					person.setComments( getLobHelper().createClob("blahblah") );
 					session.persist( person );
 				}
 		);

--- a/hibernate-community-dialects/src/test/java/org/hibernate/community/dialect/functional/cache/SQLFunctionsInterSystemsTest.java
+++ b/hibernate-community-dialects/src/test/java/org/hibernate/community/dialect/functional/cache/SQLFunctionsInterSystemsTest.java
@@ -32,6 +32,7 @@ import org.hibernate.orm.test.legacy.Simple;
 import org.hibernate.orm.test.legacy.Single;
 import org.junit.Test;
 
+import static org.hibernate.Hibernate.getLobHelper;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -470,8 +471,8 @@ public class SQLFunctionsInterSystemsTest extends BaseCoreFunctionalTestCase {
 		Session s = openSession();
 		s.beginTransaction();
 		Blobber b = new Blobber();
-		b.setBlob( s.getLobHelper().createBlob( "foo/bar/baz".getBytes() ) );
-		b.setClob( s.getLobHelper().createClob("foo/bar/baz") );
+		b.setBlob( getLobHelper().createBlob( "foo/bar/baz".getBytes() ) );
+		b.setClob( getLobHelper().createClob("foo/bar/baz") );
 		s.persist(b);
 		//s.refresh(b);
 		//assertTrue( b.getClob() instanceof ClobImpl );
@@ -502,7 +503,7 @@ public class SQLFunctionsInterSystemsTest extends BaseCoreFunctionalTestCase {
 		s = openSession();
 		s.beginTransaction();
 		b = s.getReference( Blobber.class, b.getId() );
-		b.setClob( s.getLobHelper().createClob("xcvfxvc xcvbx cvbx cvbx cvbxcvbxcvbxcvb") );
+		b.setClob( getLobHelper().createClob("xcvfxvc xcvbx cvbx cvbx cvbxcvbxcvbxcvb") );
 		s.flush();
 		s.getTransaction().commit();
 		s.close();

--- a/hibernate-core/src/main/java/org/hibernate/LobHelper.java
+++ b/hibernate-core/src/main/java/org/hibernate/LobHelper.java
@@ -15,7 +15,7 @@ import java.sql.NClob;
  *
  * @author Steve Ebersole
  *
- * @see Session#getLobHelper()
+ * @see Hibernate#getLobHelper()
  */
 public interface LobHelper {
 

--- a/hibernate-core/src/main/java/org/hibernate/Session.java
+++ b/hibernate-core/src/main/java/org/hibernate/Session.java
@@ -1321,11 +1321,15 @@ public interface Session extends SharedSessionContract, EntityManager {
 	void disableFetchProfile(String name) throws UnknownProfileException;
 
 	/**
-	 * Obtain a {@linkplain LobHelper factory} for instances of {@link java.sql.Blob}
+	 * Obtain a {@linkplain LobHelper} for instances of {@link java.sql.Blob}
 	 * and {@link java.sql.Clob}.
 	 *
 	 * @return an instance of {@link LobHelper}
+	 *
+	 * @deprecated 	This method will be removed.
+	 * 				use {@link Hibernate#getLobHelper()} instead
 	 */
+	@Deprecated(since="7.0", forRemoval = true)
 	LobHelper getLobHelper();
 
 	/**

--- a/hibernate-core/src/main/java/org/hibernate/engine/jdbc/LobCreator.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/jdbc/LobCreator.java
@@ -14,7 +14,7 @@ import java.sql.NClob;
  * Contract for creating various LOB references.
  *
  * @apiNote This class is not intended to be called directly by the application program.
- *          Instead, use {@link org.hibernate.Session#getLobHelper()}.
+ *          Instead, use {@link org.hibernate.Hibernate#getLobHelper()}.
  *
  * @author Steve Ebersole
  * @author Gail Badner

--- a/hibernate-core/src/main/java/org/hibernate/engine/jdbc/proxy/BlobProxy.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/jdbc/proxy/BlobProxy.java
@@ -22,7 +22,7 @@ import org.hibernate.type.descriptor.java.DataHelper;
  * Manages aspects of representing {@link Blob} objects.
  *
  * @apiNote This class is not intended to be called directly by the application program.
- *          Instead, use {@link org.hibernate.Session#getLobHelper()}.
+ *          Instead, use {@link org.hibernate.Hibernate#getLobHelper()}.
  *
  * @see ClobProxy
  * @see LobCreator

--- a/hibernate-core/src/main/java/org/hibernate/engine/jdbc/proxy/ClobProxy.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/jdbc/proxy/ClobProxy.java
@@ -26,7 +26,7 @@ import org.hibernate.type.descriptor.java.DataHelper;
  * handling proxy invocations.  We use proxies here solely to avoid JDBC version incompatibilities.
  *
  * @apiNote This class is not intended to be called directly by the application program.
- *          Instead, use {@link org.hibernate.Session#getLobHelper()}.
+ *          Instead, use {@link org.hibernate.Hibernate#getLobHelper()}.
  *
  * @see NClobProxy
  * @see BlobProxy

--- a/hibernate-core/src/main/java/org/hibernate/engine/jdbc/proxy/NClobProxy.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/jdbc/proxy/NClobProxy.java
@@ -16,7 +16,7 @@ import java.sql.NClob;
  * handling proxy invocations.  We use proxies here solely to avoid JDBC version incompatibilities.
  *
  * @apiNote This class is not intended to be called directly by the application program.
- *          Instead, use {@link org.hibernate.Session#getLobHelper()}.
+ *          Instead, use {@link org.hibernate.Hibernate#getLobHelper()}.
  *
  * @see ClobProxy
  * @see BlobProxy

--- a/hibernate-core/src/main/java/org/hibernate/internal/SessionImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/SessionImpl.java
@@ -26,8 +26,6 @@ import org.hibernate.action.spi.AfterTransactionCompletionProcess;
 import org.hibernate.bytecode.enhance.spi.interceptor.EnhancementAsProxyLazinessInterceptor;
 import org.hibernate.collection.spi.PersistentCollection;
 import org.hibernate.engine.internal.PersistenceContexts;
-import org.hibernate.engine.jdbc.LobCreator;
-import org.hibernate.engine.jdbc.env.internal.NonContextualLobCreator;
 import org.hibernate.engine.jdbc.spi.JdbcCoordinator;
 import org.hibernate.engine.spi.ActionQueue;
 import org.hibernate.engine.spi.ActionQueue.TransactionCompletionProcesses;
@@ -86,16 +84,11 @@ import org.hibernate.stat.spi.StatisticsImplementor;
 import org.hibernate.type.descriptor.WrapperOptions;
 
 import java.io.IOException;
-import java.io.InputStream;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
-import java.io.Reader;
 import java.io.Serial;
 import java.io.Serializable;
-import java.sql.Blob;
-import java.sql.Clob;
 import java.sql.Connection;
-import java.sql.NClob;
 import java.sql.SQLException;
 import java.util.Collection;
 import java.util.HashMap;
@@ -2026,13 +2019,8 @@ public class SessionImpl
 
 	@Override
 	public LobHelper getLobHelper() {
-		if ( lobHelper == null ) {
-			lobHelper = new LobHelperImpl();
-		}
-		return lobHelper;
+		return Hibernate.getLobHelper();
 	}
-
-	private transient LobHelperImpl lobHelper;
 
 	@Override
 	public void beforeTransactionCompletion() {
@@ -2065,45 +2053,6 @@ public class SessionImpl
 		}
 
 		super.afterTransactionCompletion( successful, delayed );
-	}
-
-	private static class LobHelperImpl implements LobHelper {
-
-		@Override
-		public Blob createBlob(byte[] bytes) {
-			return lobCreator().createBlob( bytes );
-		}
-
-		private LobCreator lobCreator() {
-			// Always use NonContextualLobCreator.  If ContextualLobCreator is
-			// used both here and in WrapperOptions,
-			return NonContextualLobCreator.INSTANCE;
-		}
-
-		@Override
-		public Blob createBlob(InputStream stream, long length) {
-			return lobCreator().createBlob( stream, length );
-		}
-
-		@Override
-		public Clob createClob(String string) {
-			return lobCreator().createClob( string );
-		}
-
-		@Override
-		public Clob createClob(Reader reader, long length) {
-			return lobCreator().createClob( reader, length );
-		}
-
-		@Override
-		public NClob createNClob(String string) {
-			return lobCreator().createNClob( string );
-		}
-
-		@Override
-		public NClob createNClob(Reader reader, long length) {
-			return lobCreator().createNClob( reader, length );
-		}
 	}
 
 	private static class SharedSessionBuilderImpl

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/lob/hhh4635/LobTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/lob/hhh4635/LobTest.java
@@ -12,6 +12,8 @@ import org.hibernate.testing.orm.junit.JiraKey;
 import org.hibernate.testing.junit4.BaseCoreFunctionalTestCase;
 import org.junit.Test;
 
+import static org.hibernate.Hibernate.getLobHelper;
+
 /**
  * To reproduce this issue, Oracle MUST use a multi-byte character set (UTF-8)!
  *
@@ -29,7 +31,7 @@ public class LobTest extends BaseCoreFunctionalTestCase {
 		session.beginTransaction();
 		LobTestEntity entity = new LobTestEntity();
 		entity.setId(1L);
-		entity.setLobValue(session.getLobHelper().createBlob(new byte[9999]));
+		entity.setLobValue(getLobHelper().createBlob(new byte[9999]));
 		entity.setQwerty(randomString(4000));
 		session.persist(entity);
 		session.getTransaction().commit();

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/lob/locator/LobLocatorTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/lob/locator/LobLocatorTest.java
@@ -16,6 +16,8 @@ import org.hibernate.testing.orm.junit.JiraKey;
 import org.hibernate.testing.junit4.BaseCoreFunctionalTestCase;
 import org.hibernate.type.descriptor.java.DataHelper;
 
+import static org.hibernate.Hibernate.getLobHelper;
+
 /**
  * @author Lukasz Antoniak
  */
@@ -38,8 +40,8 @@ public class LobLocatorTest extends BaseCoreFunctionalTestCase {
 
 		session.getTransaction().begin();
 		LobHolder entity = new LobHolder(
-				session.getLobHelper().createBlob( "blob".getBytes() ),
-				session.getLobHelper().createClob( "clob" ), 0
+				getLobHelper().createBlob( "blob".getBytes() ),
+				getLobHelper().createClob( "clob" ), 0
 		);
 		session.persist( entity );
 		session.getTransaction().commit();
@@ -56,8 +58,8 @@ public class LobLocatorTest extends BaseCoreFunctionalTestCase {
 
 		session.getTransaction().begin();
 		entity = (LobHolder) session.get( LobHolder.class, entity.getId() );
-		entity.setBlobLocator( session.getLobHelper().createBlob( "updated blob".getBytes() ) );
-		entity.setClobLocator( session.getLobHelper().createClob( "updated clob" ) );
+		entity.setBlobLocator( getLobHelper().createBlob( "updated blob".getBytes() ) );
+		entity.setClobLocator( getLobHelper().createClob( "updated clob" ) );
 		entity = (LobHolder) session.merge( entity );
 		session.getTransaction().commit();
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/connections/HibernateCreateBlobFailedCase.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/connections/HibernateCreateBlobFailedCase.java
@@ -15,6 +15,7 @@ import org.hibernate.cfg.Configuration;
 import org.hibernate.cfg.Environment;
 import org.hibernate.testing.junit4.BaseCoreFunctionalTestCase;
 
+import static org.hibernate.Hibernate.getLobHelper;
 import static org.junit.Assert.assertFalse;
 
 /**
@@ -44,9 +45,9 @@ public class HibernateCreateBlobFailedCase extends BaseCoreFunctionalTestCase {
 	public void testLobCreation() throws SQLException {
 		Session session = sessionFactory().getCurrentSession();
 		session.beginTransaction();
-		Blob blob = session.getLobHelper().createBlob( new byte[] {} );
+		Blob blob = getLobHelper().createBlob( new byte[] {} );
 		blob.free();
-		Clob clob = session.getLobHelper().createClob( "Steve" );
+		Clob clob = getLobHelper().createClob( "Steve" );
 		clob.free();
 		session.getTransaction().commit();
 		assertFalse( session.isOpen() );

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/interfaceproxy/InterfaceProxyTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/interfaceproxy/InterfaceProxyTest.java
@@ -15,6 +15,7 @@ import org.hibernate.testing.orm.junit.SessionFactoryScope;
 import org.hibernate.testing.orm.junit.SkipForDialect;
 import org.junit.jupiter.api.Test;
 
+import static org.hibernate.Hibernate.getLobHelper;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -44,10 +45,10 @@ public class InterfaceProxyTest {
 			session.beginTransaction();
 			try {
 				doc.setName( "Hibernate in Action" );
-				doc.setContent( session.getLobHelper().createBlob( "blah blah blah".getBytes() ) );
+				doc.setContent( getLobHelper().createBlob( "blah blah blah".getBytes() ) );
 				session.persist( doc );
 				doc2.setName( "Secret" );
-				doc2.setContent( session.getLobHelper().createBlob( "wxyz wxyz".getBytes() ) );
+				doc2.setContent( getLobHelper().createBlob( "wxyz wxyz".getBytes() ) );
 				// SybaseASE15Dialect only allows 7-bits in a byte to be inserted into a tinyint
 				// column (0 <= val < 128)
 				doc2.setPermissionBits( (byte) 127 );

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/lob/BlobTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/lob/BlobTest.java
@@ -11,8 +11,6 @@ import java.io.ObjectOutputStream;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.hibernate.Session;
-
 import org.hibernate.testing.orm.junit.DialectFeatureChecks;
 import org.hibernate.testing.orm.junit.EntityManagerFactoryScope;
 import org.hibernate.testing.orm.junit.Jpa;
@@ -20,6 +18,7 @@ import org.hibernate.testing.orm.junit.RequiresDialectFeature;
 
 import org.junit.jupiter.api.Test;
 
+import static org.hibernate.Hibernate.getLobHelper;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -41,9 +40,7 @@ public class BlobTest {
 						image.put( "data", "imagedata" );
 						ImageReader reader = new ImageReader();
 						oos.writeObject( image );
-						reader.setImage( entityManager.unwrap( Session.class )
-												.getLobHelper()
-												.createBlob( baos.toByteArray() ) );
+						reader.setImage( getLobHelper().createBlob( baos.toByteArray() ) );
 						entityManager.persist( reader );
 						return reader.getId();
 					}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/query/NativeQueryResultTypeAutoDiscoveryTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/query/NativeQueryResultTypeAutoDiscoveryTest.java
@@ -75,6 +75,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.MappedSuperclass;
 
 import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hibernate.Hibernate.getLobHelper;
 
 /**
  * Test how the type of results are detected from the JDBC type in native queries,
@@ -289,12 +290,12 @@ public class NativeQueryResultTypeAutoDiscoveryTest {
 		doTest(
 				ClobEntity.class,
 				Clob.class,
-				session -> session.getLobHelper().createClob( "some text" )
+				session -> getLobHelper().createClob( "some text" )
 		);
 		doTest(
 				BlobEntity.class,
 				Blob.class,
-				session -> session.getLobHelper().createBlob( "some text".getBytes() )
+				session -> getLobHelper().createBlob( "some text".getBytes() )
 		);
 	}
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/lob/BlobLocatorTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/lob/BlobLocatorTest.java
@@ -17,6 +17,7 @@ import org.junit.Test;
 import java.sql.Blob;
 import java.util.Arrays;
 
+import static org.hibernate.Hibernate.getLobHelper;
 import static org.junit.Assert.assertNotNull;
 
 /**
@@ -52,7 +53,7 @@ public class BlobLocatorTest extends BaseCoreFunctionalTestCase {
 		Session s = openSession();
 		s.beginTransaction();
 		LobHolder entity = new LobHolder();
-		entity.setBlobLocator( s.getLobHelper().createBlob( original ) );
+		entity.setBlobLocator( getLobHelper().createBlob( original ) );
 		s.persist( entity );
 		s.getTransaction().commit();
 		s.close();
@@ -94,7 +95,7 @@ public class BlobLocatorTest extends BaseCoreFunctionalTestCase {
 		assertNotNull( entity.getBlobLocator() );
 		Assert.assertEquals( BLOB_SIZE, entity.getBlobLocator().length() );
 		assertEquals( original, extractData( entity.getBlobLocator() ) );
-		entity.setBlobLocator( s.getLobHelper().createBlob( changed ) );
+		entity.setBlobLocator( getLobHelper().createBlob( changed ) );
 		s.getTransaction().commit();
 		s.close();
 
@@ -104,7 +105,7 @@ public class BlobLocatorTest extends BaseCoreFunctionalTestCase {
 		entity = s.find( LobHolder.class, entity.getId() );
 		Assert.assertEquals( BLOB_SIZE, entity.getBlobLocator().length() );
 		assertEquals( changed, extractData( entity.getBlobLocator() ) );
-		entity.setBlobLocator( s.getLobHelper().createBlob( empty ) );
+		entity.setBlobLocator( getLobHelper().createBlob( empty ) );
 		s.getTransaction().commit();
 		s.close();
 
@@ -137,7 +138,7 @@ public class BlobLocatorTest extends BaseCoreFunctionalTestCase {
 		Session s = openSession();
 		s.beginTransaction();
 		LobHolder entity = new LobHolder();
-		entity.setBlobLocator( s.getLobHelper().createBlob( original ) );
+		entity.setBlobLocator( getLobHelper().createBlob( original ) );
 		s.persist( entity );
 		s.getTransaction().commit();
 		s.close();

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/lob/ClobLocatorTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/lob/ClobLocatorTest.java
@@ -16,6 +16,7 @@ import org.junit.jupiter.api.Test;
 
 import java.sql.Clob;
 
+import static org.hibernate.Hibernate.getLobHelper;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -56,7 +57,7 @@ public class ClobLocatorTest {
 		Long id = scope.fromTransaction(
 				session -> {
 					LobHolder entity = new LobHolder();
-					entity.setClobLocator( session.getLobHelper().createClob( original ) );
+					entity.setClobLocator( getLobHelper().createClob( original ) );
 					session.persist( entity );
 					return entity.getId();
 				}
@@ -121,7 +122,7 @@ public class ClobLocatorTest {
 						assertNotNull( entity.getClobLocator() );
 						assertEquals( CLOB_SIZE, entity.getClobLocator().length() );
 						assertEquals( original, extractData( entity.getClobLocator() ) );
-						entity.setClobLocator( session.getLobHelper().createClob( changed ) );
+						entity.setClobLocator( getLobHelper().createClob( changed ) );
 					}
 					catch (Exception e) {
 						fail( e );
@@ -139,7 +140,7 @@ public class ClobLocatorTest {
 							LobHolder entity = session.get( LobHolder.class, id );
 							assertEquals( CLOB_SIZE, entity.getClobLocator().length() );
 							assertEquals( changed, extractData( entity.getClobLocator() ) );
-							entity.setClobLocator( session.getLobHelper().createClob( empty ) );
+							entity.setClobLocator( getLobHelper().createClob( empty ) );
 						}
 						catch (Exception e) {
 							fail( e );
@@ -177,7 +178,7 @@ public class ClobLocatorTest {
 		Long id = scope.fromTransaction(
 				session -> {
 					LobHolder entity = new LobHolder();
-					entity.setClobLocator( session.getLobHelper().createClob( original ) );
+					entity.setClobLocator( getLobHelper().createClob( original ) );
 					session.persist( entity );
 					return entity.getId();
 				}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/lob/InformixLobStringTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/lob/InformixLobStringTest.java
@@ -20,6 +20,7 @@ import org.hibernate.testing.orm.junit.JiraKey;
 import org.junit.Test;
 
 import static org.hamcrest.core.Is.is;
+import static org.hibernate.Hibernate.getLobHelper;
 import static org.hibernate.testing.transaction.TransactionUtil.doInHibernate;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
@@ -46,7 +47,7 @@ public class InformixLobStringTest extends BaseCoreFunctionalTestCase {
 		doInHibernate( this::sessionFactory, session -> {
 			entity.setFirstLobField( value1 );
 			entity.setSecondLobField( value2 );
-			entity.setClobField( session.getLobHelper().createClob( value2 ) );
+			entity.setClobField( getLobHelper().createClob( value2 ) );
 			session.persist( entity );
 		} );
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/lob/JpaLargeBlobTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/lob/JpaLargeBlobTest.java
@@ -9,7 +9,6 @@ import java.io.InputStream;
 import java.sql.Blob;
 import java.util.Random;
 
-import org.hibernate.LobHelper;
 import org.hibernate.dialect.H2Dialect;
 
 import org.hibernate.testing.orm.junit.JiraKey;
@@ -19,6 +18,7 @@ import org.hibernate.testing.orm.junit.SessionFactory;
 import org.hibernate.testing.orm.junit.SessionFactoryScope;
 import org.junit.jupiter.api.Test;
 
+import static org.hibernate.Hibernate.getLobHelper;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -42,12 +42,11 @@ public class JpaLargeBlobTest {
 		LobEntity o = new LobEntity();
 		LobInputStream inputStream = scope.fromSession(
 				session -> {
-					LobHelper lh = session.getLobHelper();
 					LobInputStream lis = new LobInputStream();
 
 					session.getTransaction().begin();
 					try {
-						Blob blob = lh.createBlob( lis, LobEntity.BLOB_LENGTH );
+						Blob blob = getLobHelper().createBlob( lis, LobEntity.BLOB_LENGTH );
 						o.setBlob( blob );
 
 						// Regardless if NON_CONTEXTUAL_LOB_CREATION is set to true,

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/lob/LobMergeTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/lob/LobMergeTest.java
@@ -14,6 +14,7 @@ import org.hibernate.testing.orm.junit.JiraKey;
 import org.hibernate.testing.junit4.BaseCoreFunctionalTestCase;
 import org.junit.Test;
 
+import static org.hibernate.Hibernate.getLobHelper;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
@@ -43,7 +44,7 @@ public class LobMergeTest extends BaseCoreFunctionalTestCase {
 		s.beginTransaction();
 
 		LobHolder entity = new LobHolder();
-		entity.setBlobLocator( s.getLobHelper().createBlob( original ) );
+		entity.setBlobLocator( getLobHelper().createBlob( original ) );
 		s.persist( entity );
 		s.getTransaction().commit();
 		s.close();
@@ -51,7 +52,7 @@ public class LobMergeTest extends BaseCoreFunctionalTestCase {
 		s = openSession();
 		s.beginTransaction();
 		// entity still detached...
-		entity.setBlobLocator( s.getLobHelper().createBlob( updated ) );
+		entity.setBlobLocator( getLobHelper().createBlob( updated ) );
 		entity = (LobHolder) s.merge( entity );
 		s.getTransaction().commit();
 		s.close();
@@ -78,7 +79,7 @@ public class LobMergeTest extends BaseCoreFunctionalTestCase {
 		s.beginTransaction();
 
 		LobHolder entity = new LobHolder();
-		entity.setClobLocator( s.getLobHelper().createClob( original ) );
+		entity.setClobLocator( getLobHelper().createClob( original ) );
 		s.persist( entity );
 		s.getTransaction().commit();
 		s.close();
@@ -86,7 +87,7 @@ public class LobMergeTest extends BaseCoreFunctionalTestCase {
 		s = openSession();
 		s.beginTransaction();
 		// entity still detached...
-		entity.setClobLocator( s.getLobHelper().createClob( updated ) );
+		entity.setClobLocator( getLobHelper().createClob( updated ) );
 		entity = (LobHolder) s.merge( entity );
 		s.flush();
 		s.getTransaction().commit();

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/lob/LobStringFunctionsTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/lob/LobStringFunctionsTest.java
@@ -30,6 +30,7 @@ import jakarta.persistence.Tuple;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.isOneOf;
 import static org.hamcrest.core.Is.is;
+import static org.hibernate.Hibernate.getLobHelper;
 
 @JiraKey(value = "HHH-15162")
 @DomainModel(
@@ -51,7 +52,7 @@ public class LobStringFunctionsTest {
 
 			entity.setFirstLobField( value1 );
 			entity.setSecondLobField( value2 );
-			entity.setClobField( session.getLobHelper().createClob( value2 ) );
+			entity.setClobField( getLobHelper().createClob( value2 ) );
 			session.persist( entity );
 		} );
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/lob/LobStringTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/lob/LobStringTest.java
@@ -30,6 +30,7 @@ import jakarta.persistence.Table;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
+import static org.hibernate.Hibernate.getLobHelper;
 import static org.junit.jupiter.api.Assertions.fail;
 
 /**
@@ -56,7 +57,7 @@ public class LobStringTest {
 
 			entity.setFirstLobField( value1 );
 			entity.setSecondLobField( value2 );
-			entity.setClobField( session.getLobHelper().createClob( value2 ) );
+			entity.setClobField( getLobHelper().createClob( value2 ) );
 			session.persist( entity );
 		} );
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/lob/PostgreSqlLobStringTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/lob/PostgreSqlLobStringTest.java
@@ -31,6 +31,7 @@ import jakarta.persistence.Table;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
+import static org.hibernate.Hibernate.getLobHelper;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.fail;
 
@@ -65,9 +66,9 @@ public class PostgreSqlLobStringTest {
 											"        (?, ?, ?, -1)"
 							)) {
 								int index = 1;
-								statement.setClob( index++, session.getLobHelper().createClob( value1 ) );
-								statement.setClob( index++, session.getLobHelper().createClob( value2 ) );
-								statement.setClob( index++, session.getLobHelper().createClob( value3 ) );
+								statement.setClob( index++, getLobHelper().createClob( value1 ) );
+								statement.setClob( index++, getLobHelper().createClob( value2 ) );
+								statement.setClob( index++, getLobHelper().createClob( value3 ) );
 
 								assertEquals( 1, statement.executeUpdate() );
 							}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/basic/BlobAttributeQueryUpdateTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/basic/BlobAttributeQueryUpdateTest.java
@@ -8,7 +8,6 @@ import java.nio.charset.StandardCharsets;
 import java.sql.Blob;
 import java.sql.SQLException;
 
-import org.hibernate.LobHelper;
 import org.hibernate.engine.jdbc.proxy.BlobProxy;
 
 import org.hibernate.testing.orm.junit.DomainModel;
@@ -24,6 +23,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.TypedQuery;
 
 import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
+import static org.hibernate.Hibernate.getLobHelper;
 
 @DomainModel(
 		annotatedClasses = {
@@ -42,11 +42,10 @@ public class BlobAttributeQueryUpdateTest {
 	public void setup(SessionFactoryScope scope) {
 		scope.inTransaction(
 				session -> {
-					LobHelper lobHelper = session.getLobHelper();
 					TestEntity testEntity = new TestEntity(
 							1,
 							"test",
-							lobHelper.createBlob( INITIAL_BYTES )
+							getLobHelper().createBlob( INITIAL_BYTES )
 					);
 					session.persist( testEntity );
 				}
@@ -95,9 +94,8 @@ public class BlobAttributeQueryUpdateTest {
 	@Test
 	public void testUpdateUsingLobHelper(SessionFactoryScope scope) {
 		scope.inTransaction( session -> {
-			LobHelper lobHelper = session.getLobHelper();
 			TestEntity testEntity = session.find( TestEntity.class, 1 );
-			Blob blobValue1 = lobHelper.createBlob( UPDATED_BYTES_1 );
+			Blob blobValue1 = getLobHelper().createBlob( UPDATED_BYTES_1 );
 			testEntity.setBlobValue( blobValue1 );
 		} );
 
@@ -109,13 +107,12 @@ public class BlobAttributeQueryUpdateTest {
 
 		scope.inTransaction(
 				session -> {
-					LobHelper lobHelper = session.getLobHelper();
 					TypedQuery<?> query = session.createQuery(
 							"UPDATE TestEntity b SET b.blobValue = :blobValue WHERE b.id = :id",
 							null
 					);
 					query.setParameter( "id", 1 );
-					Blob value = lobHelper.createBlob( UPDATED_BYTES_2 );
+					Blob value = getLobHelper().createBlob( UPDATED_BYTES_2 );
 					query.setParameter( "blobValue", value );
 					query.executeUpdate();
 				}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/mixed/MixedTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/mixed/MixedTest.java
@@ -14,6 +14,7 @@ import org.hibernate.testing.orm.junit.SessionFactoryScope;
 import org.hibernate.testing.orm.junit.SkipForDialect;
 import org.junit.jupiter.api.Test;
 
+import static org.hibernate.Hibernate.getLobHelper;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
@@ -40,12 +41,12 @@ public class MixedTest {
 				session.persist( f );
 
 				doc.setName( "Hibernate in Action" );
-				doc.setContent( session.getLobHelper().createBlob( "blah blah blah".getBytes() ) );
+				doc.setContent( getLobHelper().createBlob( "blah blah blah".getBytes() ) );
 				doc.setParent( f );
 				session.persist( doc );
 
 				doc2.setName( "Secret" );
-				doc2.setContent( session.getLobHelper().createBlob( "wxyz wxyz".getBytes() ) );
+				doc2.setContent( getLobHelper().createBlob( "wxyz wxyz".getBytes() ) );
 				// SybaseASE15Dialect only allows 7-bits in a byte to be inserted into a tinyint
 				// column (0 <= val < 128)
 				doc2.setPermissionBits( (byte) 127 );

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/type/LobUnfetchedPropertyTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/type/LobUnfetchedPropertyTest.java
@@ -4,6 +4,7 @@
  */
 package org.hibernate.orm.test.type;
 
+import static org.hibernate.Hibernate.getLobHelper;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -54,7 +55,7 @@ public class LobUnfetchedPropertyTest {
 	public void testBlob(SessionFactoryScope scope) throws SQLException {
 		final int id = scope.fromTransaction( s -> {
 			FileBlob file = new FileBlob();
-			file.setBlob( s.getLobHelper().createBlob( "TEST CASE".getBytes() ) );
+			file.setBlob( getLobHelper().createBlob( "TEST CASE".getBytes() ) );
 			// merge transient entity
 			file = (FileBlob) s.merge( file );
 			return file.getId();
@@ -78,7 +79,7 @@ public class LobUnfetchedPropertyTest {
 	public void testClob(SessionFactoryScope scope) throws SQLException {
 		final int id = scope.fromTransaction( s -> {
 			FileClob file = new FileClob();
-			file.setClob( s.getLobHelper().createClob( "TEST CASE" ) );
+			file.setClob( getLobHelper().createClob( "TEST CASE" ) );
 			// merge transient entity
 			file = (FileClob) s.merge( file );
 			return file.getId();
@@ -110,7 +111,7 @@ public class LobUnfetchedPropertyTest {
 	public void testNClob(SessionFactoryScope scope) {
 		final int id = scope.fromTransaction( s -> {
 			FileNClob file = new FileNClob();
-			file.setClob( s.getLobHelper().createNClob( "TEST CASE" ) );
+			file.setClob( getLobHelper().createNClob( "TEST CASE" ) );
 			// merge transient entity
 			file = (FileNClob) s.merge( file );
 			return file.getId();

--- a/migration-guide.adoc
+++ b/migration-guide.adoc
@@ -11,3 +11,18 @@
 
 This guide discusses migration to Hibernate ORM version {version}. For migration from
 earlier versions, see any other pertinent migration guides as well.
+
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+// API changes
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+[[api-changes]]
+== Changes to API
+
+This section describes changes to contracts (classes, interfaces, methods, etc.) which are considered https://hibernate.org/community/compatibility-policy/#api[API].
+
+[[session-getLobHelper]]
+==== Session#getLobHelper
+
+The `Session#getLobHelper` method has been marked as deprecated in favor of the static `Hibernate#getLobHelper` and will be removed in a future *major* version.
+


### PR DESCRIPTION
The getLobHelper method was moved to the org.hibernate.Hibernate class and deprecated in Session

----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
