### PR TITLE
HHH-19608 automatically add @PartitionKey to the primary key

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/dialect/Dialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/Dialect.java
@@ -4623,6 +4623,16 @@ public abstract class Dialect implements ConversionContext, TypeContributor, Fun
 	}
 
 	/**
+	 * Does this dialect require that the columns listed in
+	 * {@code partition by} also occur in the primary key?
+	 *
+	 * @since 7.1
+	 */
+	public boolean addPartitionKeyToPrimaryKey() {
+		return false;
+	}
+
+	/**
 	 * Override {@link DatabaseMetaData#supportsNamedParameters()}.
 	 *
 	 * @throws SQLException Accessing the {@link DatabaseMetaData} cause

--- a/hibernate-core/src/main/java/org/hibernate/dialect/MySQLDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/MySQLDialect.java
@@ -1100,6 +1100,16 @@ public class MySQLDialect extends Dialect {
 	}
 
 	@Override
+	public boolean supportsPartitionBy() {
+		return true;
+	}
+
+	@Override
+	public boolean addPartitionKeyToPrimaryKey() {
+		return true;
+	}
+
+	@Override
 	public boolean supportsCommentOn() {
 		return true;
 	}

--- a/hibernate-core/src/main/java/org/hibernate/dialect/PostgreSQLDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/PostgreSQLDialect.java
@@ -822,6 +822,11 @@ public class PostgreSQLDialect extends Dialect {
 	}
 
 	@Override
+	public boolean addPartitionKeyToPrimaryKey() {
+		return true;
+	}
+
+	@Override
 	public boolean supportsNonQueryWithCTE() {
 		return true;
 	}

--- a/hibernate-core/src/main/java/org/hibernate/id/enhanced/ExportableColumnHelper.java
+++ b/hibernate-core/src/main/java/org/hibernate/id/enhanced/ExportableColumnHelper.java
@@ -143,6 +143,11 @@ class ExportableColumnHelper {
 			public boolean isColumnUpdateable(int index) {
 				return true;
 			}
+
+			@Override
+			public boolean isPartitionKey() {
+				return false;
+			}
 		} );
 		return column;
 	}

--- a/hibernate-core/src/main/java/org/hibernate/mapping/Collection.java
+++ b/hibernate-core/src/main/java/org/hibernate/mapping/Collection.java
@@ -897,4 +897,9 @@ public abstract sealed class Collection
 	public void setDeleteAllExpectation(Supplier<? extends Expectation> deleteAllExpectation) {
 		this.deleteAllExpectation = deleteAllExpectation;
 	}
+
+	@Override
+	public boolean isPartitionKey() {
+		return false;
+	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/mapping/OneToMany.java
+++ b/hibernate-core/src/main/java/org/hibernate/mapping/OneToMany.java
@@ -234,4 +234,9 @@ public class OneToMany implements Value {
 	public String toString() {
 		return getClass().getSimpleName();
 	}
+
+	@Override
+	public boolean isPartitionKey() {
+		return false;
+	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/mapping/PersistentClass.java
+++ b/hibernate-core/src/main/java/org/hibernate/mapping/PersistentClass.java
@@ -427,8 +427,20 @@ public abstract sealed class PersistentClass
 		final PrimaryKey pk = new PrimaryKey( table );
 		pk.setName( PK_ALIAS.toAliasString( table.getName() ) );
 		pk.addColumns( getKey() );
-
+		if ( addPartitionKeyToPrimaryKey() ) {
+			for ( Property property : getProperties() ) {
+				if ( property.getValue().isPartitionKey() ) {
+					pk.addColumns( property.getValue() );
+				}
+			}
+		}
 		table.setPrimaryKey( pk );
+	}
+
+	private boolean addPartitionKeyToPrimaryKey() {
+		return metadataBuildingContext.getMetadataCollector()
+				.getDatabase().getDialect()
+				.addPartitionKeyToPrimaryKey();
 	}
 
 	public abstract String getWhere();

--- a/hibernate-core/src/main/java/org/hibernate/mapping/Value.java
+++ b/hibernate-core/src/main/java/org/hibernate/mapping/Value.java
@@ -123,6 +123,8 @@ public interface Value extends Serializable {
 
 	boolean isAlternateUniqueKey();
 
+	boolean isPartitionKey();
+
 	boolean isNullable();
 
 	void createForeignKey();


### PR DESCRIPTION
on databases where this is required

also enable support for table partitioning on MySQL and Maria

<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

[Please describe here what your change is about]

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-19608
<!-- Hibernate GitHub Bot issue links end -->