### PR TITLE
HHH-19610 make GraphParser support subTypeSubGraph

### DIFF
--- a/hibernate-core/src/main/antlr/org/hibernate/grammars/graph/GraphLanguageParser.g4
+++ b/hibernate-core/src/main/antlr/org/hibernate/grammars/graph/GraphLanguageParser.g4
@@ -21,14 +21,27 @@ package org.hibernate.grammars.graph;
  */
 }
 
-
 graph
-    : typeIndicator? attributeList
- 	;
+    : typeIndicator? graphElementList
+    ;
+
+graphElementList
+    : graphElement (COMMA graphElement)*
+    ;
+
+graphElement
+    : attributeNode
+    | subTypeSubGraph
+    ;
 
 typeIndicator
     : TYPE_NAME COLON
     ;
+
+subTypeSubGraph
+    : LPAREN typeIndicator attributeList RPAREN
+    ;
+
 
 attributeList
 	: attributeNode (COMMA attributeNode)*

--- a/hibernate-core/src/main/java/org/hibernate/boot/model/internal/NamedGraphCreatorParsed.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/internal/NamedGraphCreatorParsed.java
@@ -68,7 +68,7 @@ class NamedGraphCreatorParsed implements NamedGraphCreator {
 			//noinspection unchecked
 			final EntityDomainType<T> entityDomainType = (EntityDomainType<T>) entityDomainNameResolver.apply( jpaEntityName );
 			final String name = this.name == null ? jpaEntityName : this.name;
-			return GraphParsing.parse( name, entityDomainType, graphContext.attributeList(), entityNameResolver );
+			return GraphParsing.parse( name, entityDomainType, graphContext.graphElementList(), entityNameResolver );
 		}
 		else {
 			if ( graphContext.typeIndicator() != null ) {
@@ -77,7 +77,7 @@ class NamedGraphCreatorParsed implements NamedGraphCreator {
 			//noinspection unchecked
 			final EntityDomainType<T> entityDomainType = (EntityDomainType<T>) entityDomainClassResolver.apply( (Class<T>) entityType );
 			final String name = this.name == null ? entityDomainType.getName() : this.name;
-			return GraphParsing.parse( name, entityDomainType, graphContext.attributeList(), entityNameResolver );
+			return GraphParsing.parse( name, entityDomainType, graphContext.graphElementList(), entityNameResolver );
 		}
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/graph/internal/parse/EntityNameResolver.java
+++ b/hibernate-core/src/main/java/org/hibernate/graph/internal/parse/EntityNameResolver.java
@@ -5,6 +5,7 @@
 package org.hibernate.graph.internal.parse;
 
 import org.hibernate.metamodel.model.domain.EntityDomainType;
+import org.hibernate.metamodel.model.domain.ManagedDomainType;
 
 /**
  * @author Steve Ebersole
@@ -12,4 +13,12 @@ import org.hibernate.metamodel.model.domain.EntityDomainType;
 @FunctionalInterface
 public interface EntityNameResolver {
 	<T> EntityDomainType<T> resolveEntityName(String entityName);
+
+	static <T> ManagedDomainType<T> managedType(String subtypeName, EntityNameResolver entityNameResolver) {
+		final EntityDomainType<T> entityDomainType = entityNameResolver.resolveEntityName( subtypeName );
+		if ( entityDomainType == null ) {
+			throw new IllegalArgumentException( "Unknown managed type: " + subtypeName );
+		}
+		return entityDomainType;
+	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/graph/internal/parse/GraphParser.java
+++ b/hibernate-core/src/main/java/org/hibernate/graph/internal/parse/GraphParser.java
@@ -27,7 +27,7 @@ public class GraphParser extends GraphLanguageParserBaseVisitor<GraphNode<?>> {
 	private final EntityNameResolver entityNameResolver;
 
 	private final Stack<GraphImplementor<?>> graphStack = new StandardStack<>();
-	private final Stack<AttributeNodeImplementor<?,?,?>> attributeNodeStack = new StandardStack<>();
+	private final Stack<AttributeNodeImplementor<?, ?, ?>> attributeNodeStack = new StandardStack<>();
 	private final Stack<SubGraphGenerator> graphSourceStack = new StandardStack<>();
 
 	public GraphParser(EntityNameResolver entityNameResolver) {
@@ -37,7 +37,6 @@ public class GraphParser extends GraphLanguageParserBaseVisitor<GraphNode<?>> {
 	/**
 	 * @apiNote It is important that this form only be used after the session-factory is fully
 	 * initialized, especially the {@linkplain SessionFactoryImplementor#getJpaMetamodel()} JPA metamodel}.
-	 *
 	 * @see GraphParser#GraphParser(EntityNameResolver)
 	 */
 	public GraphParser(SessionFactoryImplementor sessionFactory) {
@@ -49,7 +48,50 @@ public class GraphParser extends GraphLanguageParserBaseVisitor<GraphNode<?>> {
 	}
 
 	@Override
-	public AttributeNodeImplementor<?,?,?> visitAttributeNode(GraphLanguageParser.AttributeNodeContext attributeNodeContext) {
+	public SubGraphImplementor<?> visitSubTypeSubGraph(GraphLanguageParser.SubTypeSubGraphContext subTypeSubGraphContext) {
+		final String subTypeName = subTypeSubGraphContext.typeIndicator() == null ?
+				null :
+				subTypeSubGraphContext.typeIndicator().TYPE_NAME().getText();
+
+		if ( PARSING_LOGGER.isDebugEnabled() ) {
+			PARSING_LOGGER.debugf(
+					"%s Starting subtype graph : %s",
+					StringHelper.repeat( ">>", attributeNodeStack.depth() + 2 ),
+					subTypeName
+			);
+		}
+
+		var currentGraph = graphStack.getCurrent();
+
+		var subTypeSubGraph = currentGraph.addTreatedSubgraph(
+				EntityNameResolver.managedType(
+						subTypeName,
+						entityNameResolver
+				)
+		);
+
+		graphStack.push( subTypeSubGraph );
+
+		try {
+			subTypeSubGraphContext.attributeList().accept( this );
+		}
+		finally {
+			graphStack.pop();
+		}
+
+		if ( PARSING_LOGGER.isDebugEnabled() ) {
+			PARSING_LOGGER.debugf(
+					"%s Finished subtype graph : %s",
+					StringHelper.repeat( "<<", attributeNodeStack.depth() + 2 ),
+					subTypeSubGraph.getGraphedType().getTypeName()
+			);
+		}
+
+		return subTypeSubGraph;
+	}
+
+	@Override
+	public AttributeNodeImplementor<?, ?, ?> visitAttributeNode(GraphLanguageParser.AttributeNodeContext attributeNodeContext) {
 		final String attributeName = attributeNodeContext.attributePath().ATTR_NAME().getText();
 
 		final SubGraphGenerator subGraphCreator;
@@ -66,7 +108,10 @@ public class GraphParser extends GraphLanguageParserBaseVisitor<GraphNode<?>> {
 			subGraphCreator = PathQualifierType.VALUE.getSubGraphCreator();
 		}
 		else {
-			final String qualifierName = attributeNodeContext.attributePath().attributeQualifier().ATTR_NAME().getText();
+			final String qualifierName = attributeNodeContext.attributePath()
+					.attributeQualifier()
+					.ATTR_NAME()
+					.getText();
 
 			if ( PARSING_LOGGER.isDebugEnabled() ) {
 				PARSING_LOGGER.debugf(
@@ -81,7 +126,7 @@ public class GraphParser extends GraphLanguageParserBaseVisitor<GraphNode<?>> {
 			subGraphCreator = pathQualifierType.getSubGraphCreator();
 		}
 
-		final AttributeNodeImplementor<?,?,?> attributeNode = resolveAttributeNode( attributeName );
+		final AttributeNodeImplementor<?, ?, ?> attributeNode = resolveAttributeNode( attributeName );
 
 		if ( attributeNodeContext.subGraph() != null ) {
 			attributeNodeStack.push( attributeNode );
@@ -108,11 +153,11 @@ public class GraphParser extends GraphLanguageParserBaseVisitor<GraphNode<?>> {
 		return attributeNode;
 	}
 
-	private AttributeNodeImplementor<?,?,?> resolveAttributeNode(String attributeName) {
+	private AttributeNodeImplementor<?, ?, ?> resolveAttributeNode(String attributeName) {
 		final GraphImplementor<?> currentGraph = graphStack.getCurrent();
 		assert currentGraph != null;
 
-		final AttributeNodeImplementor<?,?,?> attributeNode = currentGraph.findOrCreateAttributeNode( attributeName );
+		final AttributeNodeImplementor<?, ?, ?> attributeNode = currentGraph.findOrCreateAttributeNode( attributeName );
 		assert attributeNode != null;
 
 		return attributeNode;
@@ -132,7 +177,9 @@ public class GraphParser extends GraphLanguageParserBaseVisitor<GraphNode<?>> {
 
 	@Override
 	public SubGraphImplementor<?> visitSubGraph(GraphLanguageParser.SubGraphContext subGraphContext) {
-		final String subTypeName = subGraphContext.typeIndicator() == null ? null : subGraphContext.typeIndicator().TYPE_NAME().getText();
+		final String subTypeName = subGraphContext.typeIndicator() == null ?
+				null :
+				subGraphContext.typeIndicator().TYPE_NAME().getText();
 
 		if ( PARSING_LOGGER.isDebugEnabled() ) {
 			PARSING_LOGGER.debugf(
@@ -142,7 +189,7 @@ public class GraphParser extends GraphLanguageParserBaseVisitor<GraphNode<?>> {
 			);
 		}
 
-		final AttributeNodeImplementor<?,?,?> attributeNode = attributeNodeStack.getCurrent();
+		final AttributeNodeImplementor<?, ?, ?> attributeNode = attributeNodeStack.getCurrent();
 		final SubGraphGenerator subGraphCreator = graphSourceStack.getCurrent();
 
 		final SubGraphImplementor<?> subGraph = subGraphCreator.createSubGraph(

--- a/hibernate-core/src/main/java/org/hibernate/graph/internal/parse/GraphParsing.java
+++ b/hibernate-core/src/main/java/org/hibernate/graph/internal/parse/GraphParsing.java
@@ -7,6 +7,7 @@ package org.hibernate.graph.internal.parse;
 import org.antlr.v4.runtime.CharStreams;
 import org.antlr.v4.runtime.CommonTokenStream;
 import org.checkerframework.checker.nullness.qual.Nullable;
+
 import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.grammars.graph.GraphLanguageLexer;
 import org.hibernate.grammars.graph.GraphLanguageParser;
@@ -41,7 +42,7 @@ public class GraphParsing {
 		}
 
 		final EntityDomainType<T> entityType = sessionFactory.getJpaMetamodel().entity( entityClass );
-		return parse( entityType, graphContext.attributeList(), sessionFactory );
+		return parse( entityType, graphContext.graphElementList(), sessionFactory );
 	}
 
 	public static <T> RootGraphImplementor<T> parse(
@@ -62,7 +63,7 @@ public class GraphParsing {
 			throw new InvalidGraphException( "Expecting graph text to not include an entity name : " + graphText );
 		}
 
-		return parse( entityDomainType, graphContext.attributeList(), sessionFactory );
+		return parse( entityDomainType, graphContext.graphElementList(), sessionFactory );
 	}
 
 	public static <T> RootGraphImplementor<T> parse(
@@ -84,8 +85,9 @@ public class GraphParsing {
 		}
 
 		//noinspection unchecked
-		final EntityDomainType<T> entityType = (EntityDomainType<T>) sessionFactory.getJpaMetamodel().entity( entityName );
-		return parse( entityType, graphContext.attributeList(), sessionFactory );
+		final EntityDomainType<T> entityType = (EntityDomainType<T>) sessionFactory.getJpaMetamodel()
+				.entity( entityName );
+		return parse( entityType, graphContext.graphElementList(), sessionFactory );
 	}
 
 	public static <T> RootGraphImplementor<T> parse(
@@ -106,35 +108,36 @@ public class GraphParsing {
 		final String entityName = graphContext.typeIndicator().TYPE_NAME().getText();
 
 		//noinspection unchecked
-		final EntityDomainType<T> entityType = (EntityDomainType<T>) sessionFactory.getJpaMetamodel().entity( entityName );
-		return parse( entityType, graphContext.attributeList(), sessionFactory );
+		final EntityDomainType<T> entityType = (EntityDomainType<T>) sessionFactory.getJpaMetamodel()
+				.entity( entityName );
+		return parse( entityType, graphContext.graphElementList(), sessionFactory );
 	}
 
 	public static <T> RootGraphImplementor<T> parse(
 			EntityDomainType<T> rootType,
-			GraphLanguageParser.AttributeListContext attributeListContext,
+			GraphLanguageParser.GraphElementListContext graphElementListContext,
 			SessionFactoryImplementor sessionFactory) {
-		return parse( rootType, attributeListContext, new EntityNameResolverSessionFactory( sessionFactory ) );
+		return parse( rootType, graphElementListContext, new EntityNameResolverSessionFactory( sessionFactory ) );
 	}
 
 	public static <T> RootGraphImplementor<T> parse(
 			EntityDomainType<T> rootType,
-			GraphLanguageParser.AttributeListContext attributeListContext,
+			GraphLanguageParser.GraphElementListContext graphElementListContext,
 			EntityNameResolver entityNameResolver) {
-		return parse( null, rootType, attributeListContext, entityNameResolver );
+		return parse( null, rootType, graphElementListContext, entityNameResolver );
 	}
 
 	public static <T> RootGraphImplementor<T> parse(
 			@Nullable String name,
 			EntityDomainType<T> rootType,
-			GraphLanguageParser.AttributeListContext attributeListContext,
+			GraphLanguageParser.GraphElementListContext graphElementListContext,
 			EntityNameResolver entityNameResolver) {
 		final RootGraphImpl<T> targetGraph = new RootGraphImpl<>( name, rootType );
 
 		final GraphParser visitor = new GraphParser( entityNameResolver );
 		visitor.getGraphStack().push( targetGraph );
 		try {
-			visitor.visitAttributeList( attributeListContext );
+			visitor.visitGraphElementList( graphElementListContext );
 		}
 		finally {
 			visitor.getGraphStack().pop();
@@ -167,7 +170,7 @@ public class GraphParsing {
 
 		visitor.getGraphStack().push( targetGraph );
 		try {
-			visitor.visitAttributeList( graphContext.attributeList() );
+			visitor.visitGraphElementList( graphContext.graphElementList() );
 		}
 		finally {
 			visitor.getGraphStack().pop();

--- a/hibernate-core/src/main/java/org/hibernate/graph/internal/parse/PathQualifierType.java
+++ b/hibernate-core/src/main/java/org/hibernate/graph/internal/parse/PathQualifierType.java
@@ -5,8 +5,7 @@
 package org.hibernate.graph.internal.parse;
 
 
-import org.hibernate.metamodel.model.domain.EntityDomainType;
-import org.hibernate.metamodel.model.domain.ManagedDomainType;
+import static org.hibernate.graph.internal.parse.EntityNameResolver.managedType;
 
 /**
  * @author Steve Ebersole
@@ -22,14 +21,6 @@ public enum PathQualifierType {
 			? attributeNode.addValueSubgraph()
 			: attributeNode.addValueSubgraph().addTreatedSubgraph( managedType( subtypeName, entityNameResolver ) )
 	);
-
-	private static <T> ManagedDomainType<T> managedType(String subtypeName, EntityNameResolver entityNameResolver) {
-		final EntityDomainType<T> entityDomainType = entityNameResolver.resolveEntityName( subtypeName );
-		if ( entityDomainType == null ) {
-			throw new IllegalArgumentException( "Unknown managed type: " + subtypeName );
-		}
-		return entityDomainType;
-	}
 
 	private final SubGraphGenerator subGraphCreator;
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/entitygraph/parser/EntityGraphParserTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/entitygraph/parser/EntityGraphParserTest.java
@@ -66,6 +66,45 @@ public class EntityGraphParserTest extends AbstractEntityGraphTest {
 	}
 
 	@Test
+	public void testSubtypeAndTwoBasicAttributesParsing() {
+		var graph = parseGraph( "name, (GraphParsingTestSubEntity:sub), description" );
+		assertNotNull( graph );
+
+		AssertionHelper.assertBasicAttributes( graph, "name", "description" );
+
+		var treatedSubgraphs = graph.getTreatedSubgraphs();
+		assertEquals( 1, treatedSubgraphs.size() );
+
+		var subEntityGraph = treatedSubgraphs.get( GraphParsingTestSubEntity.class );
+		var subEntityGraphAttributes = subEntityGraph.getAttributeNodes();
+		assertNotNull( subEntityGraphAttributes );
+		assertEquals( 1, subEntityGraphAttributes.size() );
+
+		var subEntityGraphAttributeNode = subEntityGraphAttributes.get( 0 );
+		assertNotNull( subEntityGraphAttributeNode );
+		assertEquals( "sub", subEntityGraphAttributeNode.getAttributeName() );
+	}
+
+	@Test
+	public void testSubtypeParsing() {
+		var graph = parseGraph( "(GraphParsingTestSubEntity:sub)" );
+		assertNotNull( graph );
+
+		var treatedSubgraphs = graph.getTreatedSubgraphs();
+		assertEquals( 1, treatedSubgraphs.size() );
+
+		var subEntityGraph = treatedSubgraphs.get( GraphParsingTestSubEntity.class );
+		var subEntityGraphAttributes = subEntityGraph.getAttributeNodes();
+
+		assertNotNull( subEntityGraphAttributes );
+		assertEquals( 1, subEntityGraphAttributes.size() );
+
+		var attributeNode = subEntityGraphAttributes.get( 0 );
+		assertNotNull( attributeNode );
+		assertEquals( "sub", attributeNode.getAttributeName() );
+	}
+
+	@Test
 	public void testMapKeyParsing() {
 		EntityGraph<GraphParsingTestEntity> graph = parseGraph( "map.key(name, description)" );
 		assertNotNull( graph );
@@ -173,14 +212,15 @@ public class EntityGraphParserTest extends AbstractEntityGraphTest {
 
 	@Test
 	public void testLinkSubtypeParsing() {
-		RootGraphImplementor<GraphParsingTestEntity> graph = parseGraph( "linkToOne(name, description), linkToOne(GraphParsingTestSubEntity: sub)" );
+		RootGraphImplementor<GraphParsingTestEntity> graph = parseGraph(
+				"linkToOne(name, description), linkToOne(GraphParsingTestSubEntity: sub)" );
 		assertNotNull( graph );
 
-		List<? extends AttributeNodeImplementor<?,?,?>> attrs = graph.getAttributeNodeList();
+		List<? extends AttributeNodeImplementor<?, ?, ?>> attrs = graph.getAttributeNodeList();
 		assertNotNull( attrs );
 		assertEquals( 1, attrs.size() );
 
-		AttributeNodeImplementor<?,?,?> linkToOneNode = attrs.get( 0 );
+		AttributeNodeImplementor<?, ?, ?> linkToOneNode = attrs.get( 0 );
 		assertNotNull( linkToOneNode );
 		assertEquals( "linkToOne", linkToOneNode.getAttributeName() );
 
@@ -204,7 +244,7 @@ public class EntityGraphParserTest extends AbstractEntityGraphTest {
 
 		assertEquals( subGraph.getGraphedType().getJavaType(), GraphParsingTestSubEntity.class );
 
-		final AttributeNodeImplementor<?,?,?> subTypeAttrNode = subGraph.findOrCreateAttributeNode( "sub" );
+		final AttributeNodeImplementor<?, ?, ?> subTypeAttrNode = subGraph.findOrCreateAttributeNode( "sub" );
 		assert subTypeAttrNode != null;
 	}
 
@@ -221,7 +261,10 @@ public class EntityGraphParserTest extends AbstractEntityGraphTest {
 		checkMapKeyAndValueSubgraphs( graph, mapAttributeName, keySubgraph, valueSubgraph );
 	}
 
-	private void checkMapKeyAndValueSubgraphs(EntityGraph<GraphParsingTestEntity> graph, final String mapAttributeName, Subgraph<GraphParsingTestEntity> keySubgraph,
+	private void checkMapKeyAndValueSubgraphs(
+			EntityGraph<GraphParsingTestEntity> graph,
+			final String mapAttributeName,
+			Subgraph<GraphParsingTestEntity> keySubgraph,
 			Subgraph<GraphParsingTestEntity> valueSubgraph) {
 		int count = 0;
 		for ( AttributeNode<?> node : graph.getAttributeNodes() ) {


### PR DESCRIPTION
<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

Today, Jpa's NamedEntityGraph annotation supports the use of subclassSubgraphs to define graphs linked to the subtypes of an Entity. It is also possible, via the entityManager, to do the same thing via the addTreatedSubgraph function.

The goal of this ticket is to improve GraphParser so that it supports a syntax that does the same thing. In this way, Hibernate's own NamedEntityGraph annotation will have 100% of the same functionality as Jpa’s.

I suggest the following syntax for defining a subclassSubgraphs:

(GraphParsingTestSubEntity:sub), name, description

Ici on a bien un sous graph spécifique au type GraphParsingTestSubEntity qui est un sous type de GraphParsingTestEntity.

The ticket related to my proposal: https://hibernate.atlassian.net/browse/HHH-18714

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
