### PR TITLE
HHH-19606 allow resource accessor method of type StatelessSession in Spring

### DIFF
--- a/tooling/metamodel-generator/src/main/java/org/hibernate/processor/annotation/RepositoryConstructor.java
+++ b/tooling/metamodel-generator/src/main/java/org/hibernate/processor/annotation/RepositoryConstructor.java
@@ -9,6 +9,7 @@ import org.hibernate.processor.model.MetaAttribute;
 import org.hibernate.processor.model.Metamodel;
 import org.hibernate.processor.util.Constants;
 
+import static org.hibernate.processor.util.Constants.HIB_STATELESS_SESSION;
 import static org.hibernate.processor.util.Constants.INJECT;
 import static org.hibernate.processor.util.Constants.NONNULL;
 
@@ -126,15 +127,27 @@ public class RepositoryConstructor implements MetaAttribute {
 					.append("public ");
 			notNull( declaration );
 			declaration
-					.append(annotationMetaEntity.importType(sessionTypeName))
+					.append(annotationMetaEntity.importType(providedSessionType()))
 					.append(" ")
 					.append(methodName)
 					.append("() {")
 					.append("\n\treturn ")
-					.append(sessionVariableName)
+					.append(sessionVariableName);
+			if ( annotationMetaEntity.isProvidedSessionAccess() ) {
+				declaration
+						.append( ".getObject()" );
+			}
+			declaration
 					.append(";\n}");
 		}
 		return declaration.toString();
+	}
+
+	private String providedSessionType() {
+		return annotationMetaEntity.isProvidedSessionAccess()
+				//TODO: assuming provided sessions are always StatelessSessions for now
+				? HIB_STATELESS_SESSION
+				: sessionTypeName;
 	}
 
 	/**


### PR DESCRIPTION
this is a partial fix: need to consider other session types eventually

<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

[Please describe here what your change is about]

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-19606
<!-- Hibernate GitHub Bot issue links end -->