### PR TITLE
Make PersistenceContextEntry#EntityStatus public for Hibernate Reactive

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/loader/internal/CacheLoadHelper.java
+++ b/hibernate-core/src/main/java/org/hibernate/loader/internal/CacheLoadHelper.java
@@ -410,7 +410,7 @@ public class CacheLoadHelper {
 	}
 
 	public record PersistenceContextEntry(Object entity, EntityStatus status) {
-		enum EntityStatus {
+		public enum EntityStatus {
 			MANAGED,
 			REMOVED_ENTITY_MARKER,
 			INCONSISTENT_RTN_CLASS_MARKER


### PR DESCRIPTION
The change is needed for [Hibernate Reactive](https://github.com/hibernate/hibernate-reactive/pull/2371)

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
