### PR TITLE
Add support for testing with custom EDB image

### DIFF
--- a/docker_db.sh
+++ b/docker_db.sh
@@ -256,37 +256,52 @@ edb() {
 
 edb_13() {
     $CONTAINER_CLI rm -f edb || true
-    # We need to build a derived image because the existing image is mainly made for use by a kubernetes operator
-    (cd edb; $CONTAINER_CLI build -t edb-test:13 -f edb13.Dockerfile .)
-    $CONTAINER_CLI run --name edb -e POSTGRES_USER=hibernate_orm_test -e POSTGRES_PASSWORD=hibernate_orm_test -e POSTGRES_DB=hibernate_orm_test -p 5444:5444 -d edb-test:13
+    if [[ -z "${DB_IMAGE_EDB}" ]]; then
+      DB_IMAGE_EDB="edb-test:13"
+      # We need to build a derived image because the existing image is mainly made for use by a kubernetes operator
+      (cd edb; $CONTAINER_CLI build -t edb-test:13 -f edb13.Dockerfile .)
+    fi
+    $CONTAINER_CLI run --name edb -e POSTGRES_USER=hibernate_orm_test -e POSTGRES_PASSWORD=hibernate_orm_test -e POSTGRES_DB=hibernate_orm_test -p 5444:5444 -d $DB_IMAGE_EDB
 }
 
 edb_14() {
     $CONTAINER_CLI rm -f edb || true
-    # We need to build a derived image because the existing image is mainly made for use by a kubernetes operator
-    (cd edb; $CONTAINER_CLI build -t edb-test:14 -f edb14.Dockerfile .)
-    $CONTAINER_CLI run --name edb -e POSTGRES_USER=hibernate_orm_test -e POSTGRES_PASSWORD=hibernate_orm_test -e POSTGRES_DB=hibernate_orm_test -p 5444:5444 -d edb-test:14
+    if [[ -z "${DB_IMAGE_EDB}" ]]; then
+      DB_IMAGE_EDB="edb-test:14"
+      # We need to build a derived image because the existing image is mainly made for use by a kubernetes operator
+      (cd edb; $CONTAINER_CLI build -t edb-test:14 -f edb14.Dockerfile .)
+    fi
+    $CONTAINER_CLI run --name edb -e POSTGRES_USER=hibernate_orm_test -e POSTGRES_PASSWORD=hibernate_orm_test -e POSTGRES_DB=hibernate_orm_test -p 5444:5444 -d $DB_IMAGE_EDB
 }
 
 edb_15() {
     $CONTAINER_CLI rm -f edb || true
-    # We need to build a derived image because the existing image is mainly made for use by a kubernetes operator
-    (cd edb; $CONTAINER_CLI build -t edb-test:15 -f edb15.Dockerfile .)
-    $CONTAINER_CLI run --name edb -e POSTGRES_USER=hibernate_orm_test -e POSTGRES_PASSWORD=hibernate_orm_test -e POSTGRES_DB=hibernate_orm_test -p 5444:5444 -d edb-test:15
+    if [[ -z "${DB_IMAGE_EDB}" ]]; then
+      DB_IMAGE_EDB="edb-test:15"
+      # We need to build a derived image because the existing image is mainly made for use by a kubernetes operator
+      (cd edb; $CONTAINER_CLI build -t edb-test:15 -f edb15.Dockerfile .)
+    fi
+    $CONTAINER_CLI run --name edb -e POSTGRES_USER=hibernate_orm_test -e POSTGRES_PASSWORD=hibernate_orm_test -e POSTGRES_DB=hibernate_orm_test -p 5444:5444 -d $DB_IMAGE_EDB
 }
 
 edb_16() {
     $CONTAINER_CLI rm -f edb || true
-    # We need to build a derived image because the existing image is mainly made for use by a kubernetes operator
-    (cd edb; $CONTAINER_CLI build -t edb-test:16 -f edb16.Dockerfile .)
-    $CONTAINER_CLI run --name edb -e POSTGRES_USER=hibernate_orm_test -e POSTGRES_PASSWORD=hibernate_orm_test -e POSTGRES_DB=hibernate_orm_test -p 5444:5444 -d edb-test:16
+    if [[ -z "${DB_IMAGE_EDB}" ]]; then
+      DB_IMAGE_EDB="edb-test:16"
+      # We need to build a derived image because the existing image is mainly made for use by a kubernetes operator
+      (cd edb; $CONTAINER_CLI build -t edb-test:16 -f edb16.Dockerfile .)
+    fi
+    $CONTAINER_CLI run --name edb -e POSTGRES_USER=hibernate_orm_test -e POSTGRES_PASSWORD=hibernate_orm_test -e POSTGRES_DB=hibernate_orm_test -p 5444:5444 -d $DB_IMAGE_EDB
 }
 
 edb_17() {
     $CONTAINER_CLI rm -f edb || true
-    # We need to build a derived image because the existing image is mainly made for use by a kubernetes operator
-    (cd edb; $CONTAINER_CLI build -t edb-test:17 -f edb17.Dockerfile .)
-    $CONTAINER_CLI run --name edb -e POSTGRES_USER=hibernate_orm_test -e POSTGRES_PASSWORD=hibernate_orm_test -e POSTGRES_DB=hibernate_orm_test -p 5444:5444 -d edb-test:17
+    if [[ -z "${DB_IMAGE_EDB}" ]]; then
+      DB_IMAGE_EDB="edb-test:17"
+      # We need to build a derived image because the existing image is mainly made for use by a kubernetes operator
+      (cd edb; $CONTAINER_CLI build -t edb-test:17 -f edb17.Dockerfile .)
+    fi
+    $CONTAINER_CLI run --name edb -e POSTGRES_USER=hibernate_orm_test -e POSTGRES_PASSWORD=hibernate_orm_test -e POSTGRES_DB=hibernate_orm_test -p 5444:5444 -d $DB_IMAGE_EDB
 }
 
 db2() {


### PR DESCRIPTION
<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

This MR adds support for using custom EDB image for testing by providing DB_IMAGE_EDB env variable. If DB_IMAGE_EDB is not set, it will build the edb image in Hibernate, as before.

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
