### PR TITLE
HHH-19629 Hibernate Processor may fail when repository method parameter has more than one annotation (e.g. multiple constraints) / HHH-19630 Hibernate Processor may fail if the return type is a single entity and annotated with multiple annotations

### DIFF
--- a/tooling/metamodel-generator/src/jakartaData/java/org/hibernate/processor/test/data/constraint/DataTest.java
+++ b/tooling/metamodel-generator/src/jakartaData/java/org/hibernate/processor/test/data/constraint/DataTest.java
@@ -1,0 +1,24 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.processor.test.data.constraint;
+
+import org.hibernate.processor.test.util.CompilationTest;
+import org.hibernate.processor.test.util.WithClasses;
+import org.junit.jupiter.api.Test;
+
+import static org.hibernate.processor.test.util.TestUtil.assertMetamodelClassGeneratedFor;
+import static org.hibernate.processor.test.util.TestUtil.getMetaModelSourceAsString;
+
+@CompilationTest
+class DataTest {
+	@Test
+	@WithClasses({MyEntity.class, MyConstrainedRepository.class})
+	void test() {
+		System.out.println( getMetaModelSourceAsString( MyEntity.class ) );
+		System.out.println( getMetaModelSourceAsString( MyConstrainedRepository.class ) );
+		assertMetamodelClassGeneratedFor( MyEntity.class );
+//		assertMetamodelClassGeneratedFor( MyConstrainedRepository.class );
+	}
+}

--- a/tooling/metamodel-generator/src/jakartaData/java/org/hibernate/processor/test/data/constraint/DataTest.java
+++ b/tooling/metamodel-generator/src/jakartaData/java/org/hibernate/processor/test/data/constraint/DataTest.java
@@ -19,6 +19,6 @@ class DataTest {
 		System.out.println( getMetaModelSourceAsString( MyEntity.class ) );
 		System.out.println( getMetaModelSourceAsString( MyConstrainedRepository.class ) );
 		assertMetamodelClassGeneratedFor( MyEntity.class );
-//		assertMetamodelClassGeneratedFor( MyConstrainedRepository.class );
+		assertMetamodelClassGeneratedFor( MyConstrainedRepository.class );
 	}
 }

--- a/tooling/metamodel-generator/src/jakartaData/java/org/hibernate/processor/test/data/constraint/MyConstrainedRepository.java
+++ b/tooling/metamodel-generator/src/jakartaData/java/org/hibernate/processor/test/data/constraint/MyConstrainedRepository.java
@@ -7,12 +7,15 @@ package org.hibernate.processor.test.data.constraint;
 import jakarta.data.repository.CrudRepository;
 import jakarta.data.repository.Find;
 import jakarta.data.repository.Repository;
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 
 @Repository
 public interface MyConstrainedRepository extends CrudRepository<MyEntity, Long> {
 
+	@Valid
+	@NotNull
 	@Find
 	MyEntity findByName(@NotNull @Size(min = 5) String name);
 }

--- a/tooling/metamodel-generator/src/jakartaData/java/org/hibernate/processor/test/data/constraint/MyConstrainedRepository.java
+++ b/tooling/metamodel-generator/src/jakartaData/java/org/hibernate/processor/test/data/constraint/MyConstrainedRepository.java
@@ -1,0 +1,18 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.processor.test.data.constraint;
+
+import jakarta.data.repository.CrudRepository;
+import jakarta.data.repository.Find;
+import jakarta.data.repository.Repository;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+@Repository
+public interface MyConstrainedRepository extends CrudRepository<MyEntity, Long> {
+
+	@Find
+	MyEntity findByName(@NotNull @Size(min = 5) String name);
+}

--- a/tooling/metamodel-generator/src/jakartaData/java/org/hibernate/processor/test/data/constraint/MyEntity.java
+++ b/tooling/metamodel-generator/src/jakartaData/java/org/hibernate/processor/test/data/constraint/MyEntity.java
@@ -4,6 +4,7 @@
  */
 package org.hibernate.processor.test.data.constraint;
 
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 
@@ -12,5 +13,6 @@ public class MyEntity {
 
 	@Id
 	private Long id;
+	@Column(unique = true)
 	private String name;
 }

--- a/tooling/metamodel-generator/src/jakartaData/java/org/hibernate/processor/test/data/constraint/MyEntity.java
+++ b/tooling/metamodel-generator/src/jakartaData/java/org/hibernate/processor/test/data/constraint/MyEntity.java
@@ -1,0 +1,16 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.processor.test.data.constraint;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+
+@Entity
+public class MyEntity {
+
+	@Id
+	private Long id;
+	private String name;
+}

--- a/tooling/metamodel-generator/src/main/java/org/hibernate/processor/annotation/AnnotationMetaEntity.java
+++ b/tooling/metamodel-generator/src/main/java/org/hibernate/processor/annotation/AnnotationMetaEntity.java
@@ -62,7 +62,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.StringTokenizer;
 import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import jakarta.persistence.AccessType;
@@ -2066,7 +2065,7 @@ public class AnnotationMetaEntity extends AnnotationMeta {
 				new CriteriaFinderMethod(
 						this, method,
 						methodName,
-						returnType.toString(),
+						typeAsString( returnType, false ),
 						containerType,
 						paramNames,
 						paramTypes,
@@ -2379,7 +2378,7 @@ public class AnnotationMetaEntity extends AnnotationMeta {
 					new CriteriaFinderMethod(
 							this, method,
 							methodName,
-							returnType.toString(),
+							typeAsString( returnType, false ),
 							containerType,
 							paramNames,
 							paramTypes,
@@ -2483,7 +2482,7 @@ public class AnnotationMetaEntity extends AnnotationMeta {
 							new CriteriaFinderMethod(
 									this, method,
 									methodName,
-									returnType.toString(),
+									typeAsString( returnType, false ),
 									containerType,
 									paramNames,
 									paramTypes,
@@ -3427,25 +3426,35 @@ public class AnnotationMetaEntity extends AnnotationMeta {
 	 * Workaround for a bug in Java 20/21. Should not be necessary!
 	 */
 	private String typeAsString(TypeMirror type) {
-		String result;
+		return typeAsString( type, true );
+	}
+
+	private String typeAsString(TypeMirror type, boolean includeAnnotations) {
 		if ( type instanceof DeclaredType dt && dt.asElement() instanceof TypeElement te ) {
+			StringBuilder result = new StringBuilder();
+			if ( includeAnnotations ) {
+				for ( AnnotationMirror annotation : type.getAnnotationMirrors() ) {
+					result.append( annotation.toString() ).append( ' ' );
+				}
+			}
 			// get the "fqcn" without any type arguments
-			result = te.getQualifiedName().toString();
+			result.append( te.getQualifiedName().toString() );
 			// add the < ? ,? ....> as necessary:
 			if ( !dt.getTypeArguments().isEmpty() ) {
-				result += dt.getTypeArguments().stream()
-						.map( this::typeAsString )
-						.collect( Collectors.joining( ",", "<", ">" ) );
+				result.append( "<" );
+				int index = 0;
+				for ( ; index < dt.getTypeArguments().size() - 1; index++ ) {
+					result.append( typeAsString( dt.getTypeArguments().get( index ), true ) )
+							.append( ", " );
+				}
+				result.append( typeAsString( dt.getTypeArguments().get( index ), true ) );
+				result.append( ">" );
 			}
+			return result.toString();
 		}
 		else {
-			result = type.toString();
+			return type.toString();
 		}
-
-		for ( AnnotationMirror annotation : type.getAnnotationMirrors() ) {
-			result = annotation.toString() + ' ' + result;
-		}
-		return result;
 	}
 
 	private TypeMirror parameterType(VariableElement parameter) {

--- a/tooling/metamodel-generator/src/main/java/org/hibernate/processor/annotation/AnnotationMetaEntity.java
+++ b/tooling/metamodel-generator/src/main/java/org/hibernate/processor/annotation/AnnotationMetaEntity.java
@@ -62,6 +62,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.StringTokenizer;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import jakarta.persistence.AccessType;
@@ -3426,15 +3427,21 @@ public class AnnotationMetaEntity extends AnnotationMeta {
 	 * Workaround for a bug in Java 20/21. Should not be necessary!
 	 */
 	private String typeAsString(TypeMirror type) {
-		String result = type.toString();
-		for ( AnnotationMirror annotation : type.getAnnotationMirrors() ) {
-			final String annotationString = annotation.toString();
-			result = result
-					// if it has a space after it, we need to remove that too
-					.replace(annotationString + ' ', "")
-					// just in case it did not have a space after it
-					.replace(annotationString, "");
+		String result;
+		if ( type instanceof DeclaredType dt && dt.asElement() instanceof TypeElement te ) {
+			// get the "fqcn" without any type arguments
+			result = te.getQualifiedName().toString();
+			// add the < ? ,? ....> as necessary:
+			if ( !dt.getTypeArguments().isEmpty() ) {
+				result += dt.getTypeArguments().stream()
+						.map( this::typeAsString )
+						.collect( Collectors.joining( ",", "<", ">" ) );
+			}
 		}
+		else {
+			result = type.toString();
+		}
+
 		for ( AnnotationMirror annotation : type.getAnnotationMirrors() ) {
 			result = annotation.toString() + ' ' + result;
 		}


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-19629
https://hibernate.atlassian.net/browse/HHH-19630

cc: @cigaly 

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
