### PR TITLE
HHH-19619: Fix support for Truncate Table in Teradata dialect

### DIFF
--- a/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/TeradataDialect.java
+++ b/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/TeradataDialect.java
@@ -112,6 +112,7 @@ public class TeradataDialect extends Dialect {
 		registerKeyword( "role" );
 		registerKeyword( "account" );
 		registerKeyword( "class" );
+		registerKeyword( "title" );
 	}
 
 	@Override
@@ -653,6 +654,14 @@ public class TeradataDialect extends Dialect {
 	@Override
 	public boolean supportsRowValueConstructorSyntax() {
 		return false;
+	}
+
+	/**
+	 * Teradata uses the syntax DELETE FROM <tablename> ALL instead of TRUNCATE <tablename>
+	 * @param tableName the name of the table
+	 */
+	public String getTruncateTableStatement(String tableName) {
+		return "delete from " + tableName + " all";
 	}
 
 	@Override


### PR DESCRIPTION
HHH-19619: Fix support for Truncate Table in Teradata dialect (and add extra keyword found in testing)

----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-19619
<!-- Hibernate GitHub Bot issue links end -->