### PR TITLE
HHH-19619: Allow test suite to be run locally against Teradata dialect

### DIFF
--- a/ci/build.sh
+++ b/ci/build.sh
@@ -67,6 +67,8 @@ elif [ "$RDBMS" == "sybase" ]; then
   goal="-Pdb=sybase_ci -PexcludeTests=**.GenerateSeriesTest*"
 elif [ "$RDBMS" == "sybase_jconn" ]; then
   goal="-Pdb=sybase_jconn_ci -PexcludeTests=**.GenerateSeriesTest*"
+elif [ "$RDBMS" == "teradata" ] 
+  goal="-Pdb=teradata"
 elif [ "$RDBMS" == "tidb" ]; then
   goal="-Pdb=tidb"
 elif [ "$RDBMS" == "hana_cloud" ]; then

--- a/ci/build.sh
+++ b/ci/build.sh
@@ -67,7 +67,7 @@ elif [ "$RDBMS" == "sybase" ]; then
   goal="-Pdb=sybase_ci -PexcludeTests=**.GenerateSeriesTest*"
 elif [ "$RDBMS" == "sybase_jconn" ]; then
   goal="-Pdb=sybase_jconn_ci -PexcludeTests=**.GenerateSeriesTest*"
-elif [ "$RDBMS" == "teradata" ] 
+elif [ "$RDBMS" == "teradata" ]; then 
   goal="-Pdb=teradata"
 elif [ "$RDBMS" == "tidb" ]; then
   goal="-Pdb=tidb"

--- a/local-build-plugins/src/main/groovy/local.databases.gradle
+++ b/local-build-plugins/src/main/groovy/local.databases.gradle
@@ -119,6 +119,15 @@ ext {
 //                        'jdbc.datasource' : 'com.sybase.jdbc4.jdbc.SybDataSource',
                     'connection.init_sql' : 'set ansinull on set quoted_identifier on'
             ],
+            teradata: [
+                    'db.dialect' : 'org.hibernate.community.dialect.TeradataDialect',
+                    'jdbc.driver': 'com.teradata.jdbc.TeraDriver',
+                    'jdbc.user'  : 'hibernate_orm_test',
+                    'jdbc.pass'  : 'hibernate_orm_test',
+                    'jdbc.url'   : 'jdbc:teradata://' + dbHost + '/STRICT_NAMES=OFF,DATABASE=hibernate_orm_test',
+                    'jdbc.datasource' : 'com.teradata.jdbc.TeraDriver',
+                    'connection.init_sql' : ''
+            ],
             mysql : [
                     'db.dialect' : 'org.hibernate.dialect.MySQLDialect',
                     'jdbc.driver': 'com.mysql.cj.jdbc.Driver',

--- a/local-build-plugins/src/main/groovy/local.java-module.gradle
+++ b/local-build-plugins/src/main/groovy/local.java-module.gradle
@@ -83,6 +83,7 @@ dependencies {
     testRuntimeOnly jdbcLibs.cockroachdb
     testRuntimeOnly jdbcLibs.gaussdb
     testRuntimeOnly jdbcLibs.sybase
+    testRuntimeOnly jdbcLibs.teradata
     testRuntimeOnly rootProject.fileTree(dir: 'drivers', include: '*.jar')
 
     // Since both the DB2 driver and HANA have a package "net.jpountz" we have to add dependencies conditionally

--- a/settings.gradle
+++ b/settings.gradle
@@ -234,6 +234,7 @@ dependencyResolutionManagement {
             def edbVersion = version "edb", "42.7.3.3"
             def gaussdbVersion = version "gaussdb", "506.0.0.b058"
             def sybaseVersion = version "sybase", "1.3.1"
+            def teradataVersion = version "teradata",  "20.00.00.46"
             def tidbVersion = version "tidb", mysqlVersion
             def altibaseVersion = version "altibase", "7.3.0.1.1"
 
@@ -257,6 +258,7 @@ dependencyResolutionManagement {
             library( "db2", "com.ibm.db2", "jcc" ).versionRef( db2Version )
             library( "hana", "com.sap.cloud.db.jdbc", "ngdbc" ).versionRef( hanaVersion )
             library( "sybase", "net.sourceforge.jtds", "jtds" ).versionRef( sybaseVersion )
+            library("teradata", "com.teradata.jdbc", "terajdbc").versionRef(teradataVersion)
             library( "informix", "com.ibm.informix", "jdbc" ).versionRef( informixVersion )
             library( "firebird", "org.firebirdsql.jdbc", "jaybird" ).versionRef( firebirdVersion )
             library( "altibase", "com.altibase", "altibase-jdbc" ).versionRef( altibaseVersion )


### PR DESCRIPTION
Allows the test suite to be run locally against the Teradata dialect.  Needs a user named "hibernate_orm_test" to be created, along with a database of the same name. The `dbHost` variable must be passed as part of the build designating the hostname or IP address of the database server.

Not all tests pass cleanly with the dialect, but this PR at least gives developers the option of running them against a local Teradata DB.
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-19619
<!-- Hibernate GitHub Bot issue links end -->