### PR TITLE
Add Add EmbeddableFetchImpl#getNullIndicatorResult

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/embeddable/internal/EmbeddableFetchImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/embeddable/internal/EmbeddableFetchImpl.java
@@ -204,6 +204,7 @@ public class EmbeddableFetchImpl extends AbstractFetchParent
 		return this;
 	}
 
+	// Used by Hibernate Reactive
 	protected BasicFetch<?> getDiscriminatorFetch() {
 		return discriminatorFetch;
 	}

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/embeddable/internal/EmbeddableFetchImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/embeddable/internal/EmbeddableFetchImpl.java
@@ -208,4 +208,9 @@ public class EmbeddableFetchImpl extends AbstractFetchParent
 	protected BasicFetch<?> getDiscriminatorFetch() {
 		return discriminatorFetch;
 	}
+
+	// Used by Hibernate Reactive
+	protected @Nullable DomainResult<Boolean> getNullIndicatorResult() {
+		return nullIndicatorResult;
+	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/embeddable/internal/EmbeddableForeignKeyResultImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/embeddable/internal/EmbeddableForeignKeyResultImpl.java
@@ -52,6 +52,9 @@ public class EmbeddableForeignKeyResultImpl<T>
 		resetFetches( creationState.visitFetches( this ) );
 	}
 
+	/*
+	 * Used by Hibernate Reactive
+	 */
 	protected EmbeddableForeignKeyResultImpl(EmbeddableForeignKeyResultImpl<T> original) {
 		super( original );
 		this.resultVariable = original.resultVariable;


### PR DESCRIPTION
<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

In Hibernate Reactive, `ReactiveEmbeddableFetchImpl#createInitializers`
needs to access the value to override the initializer created by ORM.

Allows Hibernate Reactive to upgrade to ORM 7.1
<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-19639
<!-- Hibernate GitHub Bot issue links end -->