### PR TITLE
fixes for 5.6 javadoc generation

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,6 @@ buildscript {
 
 plugins {
 	id 'me.champeau.buildscan-recipes' version '0.2.3'
-	id 'nu.studer.credentials' version '2.2'
 	id 'org.hibernate.build.xjc' version '2.0.1' apply false
 	id 'biz.aQute.bnd' version '5.1.1' apply false
 }

--- a/ci/release/Jenkinsfile
+++ b/ci/release/Jenkinsfile
@@ -65,7 +65,7 @@ pipeline {
         cron('0 0 * * 0')
     }
     tools {
-        jdk 'OpenJDK 8 Latest'
+        jdk 'OpenJDK 11 Latest'
     }
     options {
         buildDiscarder logRotator(daysToKeepStr: '30', numToKeepStr: '10')


### PR DESCRIPTION
<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

Change CI release script to use Java 11 to (hopefully) fix javadoc generation.
Also removed no longer used Gradle plugin.

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
