### PR TITLE
HHH-19641 Upgrade to JUnit 5.13.4

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -161,9 +161,9 @@ dependencyResolutionManagement {
             library( "xjc", "org.glassfish.jaxb", "jaxb-xjc" ).versionRef( xjcVersion )
         }
         testLibs {
-            def junit5Version = version "junit5", "5.13.0"
+            def junit5Version = version "junit5", "5.13.4"
             def junit4Version = version "junit4", "4.13.2"
-            def junit5LauncherVersion = version "junit5Launcher", "1.12.0"
+            def junit5LauncherVersion = version "junit5Launcher", "1.13.4"
 
             def assertjVersion = version "assertj", "3.26.3"
             def hamcrestVersion = version "hamcrest", "3.0"


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-19641

Note: 1.12.0 seems to bring an incompatibility of junit dependencies are not managed explicitly:

```java
org.junit.platform.commons.JUnitException: 
The wrapped NoSuchMethodError is likely caused by the versions of JUnit jars on the classpath/module path not being properly aligned. 
Please ensure consistent versions are used (see https://junit.org/junit5/docs/5.12.0/user-guide/#dependency-metadata).
The following conflicting versions were detected:
- org.junit.jupiter.api: 5.13.0
- org.junit.jupiter.engine: 5.13.0
- org.junit.platform.commons: 1.13.0
- org.junit.platform.engine: 1.13.0
- org.junit.platform.launcher: 1.12.0

Caused by: java.lang.NoSuchMethodError: 'org.junit.platform.engine.ExecutionRequest org.junit.platform.engine.ExecutionRequest.create(org.junit.platform.engine.TestDescriptor, org.junit.platform.engine.EngineExecutionListener, org.junit.platform.engine.ConfigurationParameters, org.junit.platform.engine.reporting.OutputDirectoryProvider)'

```

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
