### PR TITLE
Adjust the changelog to match what was release

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -11,17 +11,12 @@ https://hibernate.atlassian.net/projects/HHH/versions/34298
 ** Bug
     * [HHH-19633] - SessionFactoryServiceRegistryBuilderImpl doesn't allow service override through parent
     * [HHH-19621] - SUBSTRING function for DB2i Series is broken
-    * [HHH-19579] - Criteria update join - Column 'code' in SET is ambiguous
     * [HHH-19550] - Attribute join on correlated from node receives wrong root
-    * [HHH-19524] - @OneToOne relationship unnecessary joins in nativeQuery
     * [HHH-19457] - Inheritance with type JOINED not working in a related entity
     * [HHH-19368] - Group by and single-table inheritance sub-select query error
-    * [HHH-19031] - Loading an Entity a second time when it contains an embedded object causes IllegalArgumentException
-    * [HHH-18774] - two bad bugs in cascade refresh
 
 ** Task
     * [HHH-19624] - Test EDB with the EDB drivers
-    * [HHH-19519] - Document breaking changes in new Hibernate Maven Plugin
 
 
 Changes in 7.0.6.Final (July 13, 2025)
@@ -35,10 +30,6 @@ https://hibernate.atlassian.net/projects/HHH/versions/34200
     * [HHH-19582] - NullPointerException on EntityManager#clear in org.hibernate.internal.util.collections.AbstractPagedArray#clear
     * [HHH-19542] - Embeddable in secondary table fails to recognize a nested embeddable is in the same table
     * [HHH-19497] - Fallback implementation of IN LIST is incorrect with dangerous consequences
-    * [HHH-18774] - two bad bugs in cascade refresh
-
-** Task
-    * [HHH-19519] - Document breaking changes in new Hibernate Maven Plugin
 
 
 Changes in 7.0.5.Final (July 06, 2025)
@@ -52,14 +43,10 @@ https://hibernate.atlassian.net/projects/HHH/versions/34132
     * [HHH-19396] - Cannot select the same column twice (with different aliases) while using CTE
     * [HHH-19076] - expecting IdClass mapping sessionfactory error with specific @IdClass setup with inheritence
     * [HHH-18837] - Oracle epoch extraction doesn't work with dates
-    * [HHH-18774] - two bad bugs in cascade refresh
 
 ** Improvement
     * [HHH-19558] - allow JDBC escapes in native SQL queries
     * [HHH-19498] - upserts on MySQL and Maria
-
-** Task
-    * [HHH-19519] - Document breaking changes in new Hibernate Maven Plugin
 
 
 Changes in 7.0.4.Final (June 30, 2025)
@@ -77,10 +64,6 @@ https://hibernate.atlassian.net/projects/HHH/versions/34000
     * [HHH-19547] - Misleading exception message at DefaultFlushEntityEventListener - mangled ID - misplaced Entity and EntityEntry ID
     * [HHH-19464] - Storing a binary data into BLOB on Oracle cutting off its content.
     * [HHH-18898] - Specific mistake in HQL gives NullPointerException in AbstractSqlAstTranslator
-    * [HHH-18774] - two bad bugs in cascade refresh
-
-** Task
-    * [HHH-19519] - Document breaking changes in new Hibernate Maven Plugin
 
 
 Changes in 7.0.3.Final (June 22, 2025)
@@ -88,12 +71,8 @@ Changes in 7.0.3.Final (June 22, 2025)
 
 https://hibernate.atlassian.net/projects/HHH/versions/33936
 
-** Bug
-    * [HHH-18774] - two bad bugs in cascade refresh
-
 ** Task
     * [HHH-19548] - Upgrade to ByteBuddy 1.17.5
-    * [HHH-19519] - Document breaking changes in new Hibernate Maven Plugin
 
 
 Changes in 7.0.2.Final (June 12, 2025)


### PR DESCRIPTION
Looking at the tag difference:

- https://github.com/hibernate/hibernate-orm/compare/7.0.6...7.0.7

and also at the release version at JIRA: 

- https://hibernate.atlassian.net/projects/HHH/versions/34298/tab/release-report-all-issues

some of the tickets weren't actually released. It seems that anything in the version gets included in the changelog but then only the resolved ones are kept in the version ... so we probably also need to adjust the generation of the changelog to filter out the "in-progress" ones ?

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
