### PR TITLE
HHH-17751 allow @CurrentTimestamp @Version with force-increment locking

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/annotations/CurrentTimestamp.java
+++ b/hibernate-core/src/main/java/org/hibernate/annotations/CurrentTimestamp.java
@@ -14,6 +14,7 @@ import static java.lang.annotation.ElementType.ANNOTATION_TYPE;
 import static java.lang.annotation.ElementType.FIELD;
 import static java.lang.annotation.ElementType.METHOD;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
+import static org.hibernate.generator.EventType.FORCE_INCREMENT;
 import static org.hibernate.generator.EventType.INSERT;
 import static org.hibernate.generator.EventType.UPDATE;
 
@@ -75,7 +76,7 @@ public @interface CurrentTimestamp {
 	 * If it should be generated just once, on the initial SQL {@code insert},
 	 * explicitly specify {@link EventType#INSERT event = INSERT}.
 	 */
-	EventType[] event() default {INSERT, UPDATE};
+	EventType[] event() default {INSERT, UPDATE, FORCE_INCREMENT};
 
 	/**
 	 * Specifies how the timestamp is generated. By default, it is generated

--- a/hibernate-core/src/main/java/org/hibernate/engine/internal/Nullability.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/internal/Nullability.java
@@ -171,7 +171,7 @@ public final class Nullability {
 		else if ( propertyType instanceof CollectionType collectionType ) {
 			// persistent collections may have components
 			if ( collectionType.getElementType( session.getFactory() ) instanceof CompositeType componentType ) {
-				// check for all components values in the collection
+				// check for all component's values in the collection
 				final Iterator<?> iterator = getLoadedElementsIterator( collectionType, value );
 				while ( iterator.hasNext() ) {
 					final Object compositeElement = iterator.next();

--- a/hibernate-core/src/main/java/org/hibernate/generator/EventType.java
+++ b/hibernate-core/src/main/java/org/hibernate/generator/EventType.java
@@ -4,6 +4,8 @@
  */
 package org.hibernate.generator;
 
+import org.hibernate.Incubating;
+
 /**
  * Enumerates event types that can result in generation of a new value.
  * A {@link Generator} must specify which events it responds to, by
@@ -35,5 +37,12 @@ public enum EventType {
 	 * This indicates, for example, that a version number should be
 	 * incremented.
 	 */
-	UPDATE
+	UPDATE,
+	/**
+	 * An event that occurs during verification of a lock of type
+	 * of {@link org.hibernate.LockMode#OPTIMISTIC_FORCE_INCREMENT}
+	 * or {@link org.hibernate.LockMode#PESSIMISTIC_FORCE_INCREMENT}.
+	 */
+	@Incubating
+	FORCE_INCREMENT
 }

--- a/hibernate-core/src/main/java/org/hibernate/generator/Generator.java
+++ b/hibernate-core/src/main/java/org/hibernate/generator/Generator.java
@@ -4,11 +4,13 @@
  */
 package org.hibernate.generator;
 
+import org.hibernate.Incubating;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
 
 import java.io.Serializable;
 import java.util.EnumSet;
 
+import static org.hibernate.generator.EventType.FORCE_INCREMENT;
 import static org.hibernate.generator.EventType.INSERT;
 import static org.hibernate.generator.EventType.UPDATE;
 
@@ -183,7 +185,8 @@ public interface Generator extends Serializable {
 	}
 
 	default boolean generatesSometimes() {
-		return !getEventTypes().isEmpty();
+		return generatesOnInsert()
+			|| generatesOnUpdate();
 	}
 
 	default boolean generatesOnInsert() {
@@ -192,5 +195,10 @@ public interface Generator extends Serializable {
 
 	default boolean generatesOnUpdate() {
 		return getEventTypes().contains(UPDATE);
+	}
+
+	@Incubating
+	default boolean generatesOnForceIncrement() {
+		return getEventTypes().contains(FORCE_INCREMENT);
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/generator/internal/CurrentTimestampGeneration.java
+++ b/hibernate-core/src/main/java/org/hibernate/generator/internal/CurrentTimestampGeneration.java
@@ -5,6 +5,10 @@
 package org.hibernate.generator.internal;
 
 import java.lang.reflect.Member;
+import java.sql.CallableStatement;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
 import java.sql.Time;
 import java.sql.Timestamp;
 import java.time.Clock;
@@ -26,7 +30,6 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.BiFunction;
 
-import org.hibernate.AssertionFailure;
 import org.hibernate.SessionFactory;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.CurrentTimestamp;
@@ -35,6 +38,8 @@ import org.hibernate.annotations.UpdateTimestamp;
 import org.hibernate.dialect.Dialect;
 import org.hibernate.engine.config.spi.ConfigurationService;
 import org.hibernate.engine.jdbc.Size;
+import org.hibernate.engine.jdbc.spi.JdbcCoordinator;
+import org.hibernate.engine.jdbc.spi.StatementPreparer;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.generator.BeforeExecutionGenerator;
 import org.hibernate.generator.EventType;
@@ -45,7 +50,10 @@ import org.hibernate.mapping.BasicValue;
 import org.hibernate.type.descriptor.java.ClockHelper;
 
 import org.checkerframework.checker.nullness.qual.Nullable;
+import org.hibernate.type.descriptor.java.JavaType;
 
+import static java.sql.Types.TIMESTAMP;
+import static org.hibernate.engine.jdbc.JdbcLogging.JDBC_MESSAGE_LOGGER;
 import static org.hibernate.generator.EventTypeSets.INSERT_AND_UPDATE;
 import static org.hibernate.generator.EventTypeSets.INSERT_ONLY;
 import static org.hibernate.generator.EventTypeSets.fromArray;
@@ -79,6 +87,8 @@ public class CurrentTimestampGeneration implements BeforeExecutionGenerator, OnE
 	public static final String CLOCK_SETTING_NAME = "hibernate.testing.clock";
 
 	private final EnumSet<EventType> eventTypes;
+
+	private final JavaType<Object> propertyType;
 
 	private final CurrentTimestampGeneratorDelegate delegate;
 	private static final Map<Class<?>, BiFunction<@Nullable Clock, Integer, CurrentTimestampGeneratorDelegate>> GENERATOR_PRODUCERS = new HashMap<>();
@@ -182,19 +192,27 @@ public class CurrentTimestampGeneration implements BeforeExecutionGenerator, OnE
 		);
 	}
 
+	private static JavaType<Object> getPropertyType(GeneratorCreationContext context) {
+		return context.getDatabase().getTypeConfiguration().getJavaTypeRegistry()
+				.getDescriptor( context.getProperty().getType().getReturnedClass() );
+	}
+
 	public CurrentTimestampGeneration(CurrentTimestamp annotation, Member member, GeneratorCreationContext context) {
 		delegate = getGeneratorDelegate( annotation.source(), member, context );
 		eventTypes = fromArray( annotation.event() );
+		propertyType = getPropertyType( context );
 	}
 
 	public CurrentTimestampGeneration(CreationTimestamp annotation, Member member, GeneratorCreationContext context) {
 		delegate = getGeneratorDelegate( annotation.source(), member, context );
 		eventTypes = INSERT_ONLY;
+		propertyType = getPropertyType( context );
 	}
 
 	public CurrentTimestampGeneration(UpdateTimestamp annotation, Member member, GeneratorCreationContext context) {
 		delegate = getGeneratorDelegate( annotation.source(), member, context );
 		eventTypes = INSERT_AND_UPDATE;
+		propertyType = getPropertyType( context );
 	}
 
 	private static CurrentTimestampGeneratorDelegate getGeneratorDelegate(
@@ -208,36 +226,42 @@ public class CurrentTimestampGeneration implements BeforeExecutionGenerator, OnE
 			SourceType source,
 			Class<?> propertyType,
 			GeneratorCreationContext context) {
-		switch (source) {
-			case VM:
+		return switch (source) {
+			case DB -> null;
+			case VM -> {
 				// Generator is only used for in-VM generation
-				final BasicValue basicValue = (BasicValue) context.getProperty().getValue();
-				final Size size = basicValue.getColumns().get( 0 ).getColumnSize(
-						context.getDatabase().getDialect(),
-						basicValue.getMetadata()
-				);
-				final Clock baseClock =
-						context.getServiceRegistry().requireService( ConfigurationService.class )
-								.getSetting( CLOCK_SETTING_NAME, value -> (Clock) value );
-				final Key key = new Key( propertyType, baseClock, size.getPrecision() == null ? 0 : size.getPrecision() );
-				final CurrentTimestampGeneratorDelegate delegate = GENERATOR_DELEGATES.get( key );
+				final Key key = new Key( propertyType, getBaseClock( context ), getPrecision( context ) );
+				final var delegate = GENERATOR_DELEGATES.get( key );
 				if ( delegate != null ) {
-					return delegate;
-				}
-				final var producer = GENERATOR_PRODUCERS.get( key.clazz );
-				if ( producer == null ) {
-					return null;
+					yield delegate;
 				}
 				else {
-					final var generatorDelegate = producer.apply( key.clock, key.precision );
-					final var old = GENERATOR_DELEGATES.putIfAbsent( key, generatorDelegate );
-					return old != null ? old : generatorDelegate;
+					final var producer = GENERATOR_PRODUCERS.get( key.clazz );
+					if ( producer == null ) {
+						yield null;
+					}
+					else {
+						final var generatorDelegate = producer.apply( key.clock, key.precision );
+						final var old = GENERATOR_DELEGATES.putIfAbsent( key, generatorDelegate );
+						yield old != null ? old : generatorDelegate;
+					}
 				}
-			case DB:
-				return null;
-			default:
-				throw new AssertionFailure("unknown source");
-		}
+			}
+		};
+	}
+
+	private static int getPrecision(GeneratorCreationContext context) {
+		final BasicValue basicValue = (BasicValue) context.getProperty().getValue();
+		final Size size =
+				basicValue.getColumns().get( 0 )
+						.getColumnSize( context.getDatabase().getDialect(),
+								basicValue.getMetadata() );
+		return size.getPrecision() == null ? 0 : size.getPrecision();
+	}
+
+	private static Clock getBaseClock(GeneratorCreationContext context) {
+		return context.getServiceRegistry().requireService( ConfigurationService.class )
+				.getSetting( CLOCK_SETTING_NAME, value -> (Clock) value );
 	}
 
 	public static <T extends Clock> T getClock(SessionFactory sessionFactory) {
@@ -256,7 +280,15 @@ public class CurrentTimestampGeneration implements BeforeExecutionGenerator, OnE
 
 	@Override
 	public Object generate(SharedSessionContractImplementor session, Object owner, Object currentValue, EventType eventType) {
-		return delegate.generate();
+		if ( delegate == null ) {
+			if ( eventType != EventType.FORCE_INCREMENT ) {
+				throw new UnsupportedOperationException( "CurrentTimestampGeneration.generate() should not have been called" );
+			}
+			return propertyType.wrap( getCurrentTimestamp( session ), session );
+		}
+		else {
+			return delegate.generate();
+		}
 	}
 
 	@Override
@@ -280,5 +312,52 @@ public class CurrentTimestampGeneration implements BeforeExecutionGenerator, OnE
 	}
 
 	private record Key(Class<?> clazz, @Nullable Clock clock, int precision) {
+	}
+
+	static Timestamp getCurrentTimestamp(SharedSessionContractImplementor session) {
+		final Dialect dialect = session.getJdbcServices().getJdbcEnvironment().getDialect();
+		final boolean callable = dialect.isCurrentTimestampSelectStringCallable();
+		final String timestampSelectString = dialect.getCurrentTimestampSelectString();
+		final JdbcCoordinator coordinator = session.getJdbcCoordinator();
+		final StatementPreparer statementPreparer = coordinator.getStatementPreparer();
+		PreparedStatement statement = null;
+		try {
+			statement = statementPreparer.prepareStatement( timestampSelectString, callable );
+			final Timestamp ts = callable
+					? extractCalledResult( statement, coordinator, timestampSelectString )
+					: extractResult( statement, coordinator, timestampSelectString );
+			if ( JDBC_MESSAGE_LOGGER.isTraceEnabled() ) {
+				JDBC_MESSAGE_LOGGER.currentTimestampRetrievedFromDatabase( ts, ts.getNanos(), ts.getTime() );
+			}
+			return ts;
+		}
+		catch (SQLException e) {
+			throw session.getJdbcServices().getSqlExceptionHelper().convert(
+					e,
+					"could not obtain current timestamp from database",
+					timestampSelectString
+			);
+		}
+		finally {
+			if ( statement != null ) {
+				coordinator.getLogicalConnection().getResourceRegistry().release( statement );
+				coordinator.afterStatementExecution();
+			}
+		}
+	}
+
+	static Timestamp extractResult(PreparedStatement statement, JdbcCoordinator coordinator, String sql)
+			throws SQLException {
+		final ResultSet resultSet = coordinator.getResultSetReturn().extract( statement, sql );
+		resultSet.next();
+		return resultSet.getTimestamp( 1 );
+	}
+
+	static Timestamp extractCalledResult(PreparedStatement statement, JdbcCoordinator coordinator, String sql)
+			throws SQLException {
+		final CallableStatement callable = (CallableStatement) statement;
+		callable.registerOutParameter( 1, TIMESTAMP );
+		coordinator.getResultSetReturn().execute( callable, sql );
+		return callable.getTimestamp( 1 );
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/generator/internal/VersionGeneration.java
+++ b/hibernate-core/src/main/java/org/hibernate/generator/internal/VersionGeneration.java
@@ -14,7 +14,7 @@ import java.util.EnumSet;
 import static org.hibernate.engine.internal.Versioning.increment;
 import static org.hibernate.engine.internal.Versioning.seed;
 import static org.hibernate.generator.EventType.INSERT;
-import static org.hibernate.generator.EventTypeSets.INSERT_AND_UPDATE;
+import static org.hibernate.generator.EventTypeSets.ALL;
 
 /**
  * A default {@link org.hibernate.generator.Generator} for {@link jakarta.persistence.Version @Version}
@@ -39,7 +39,7 @@ public class VersionGeneration implements BeforeExecutionGenerator {
 
 	@Override
 	public EnumSet<EventType> getEventTypes() {
-		return INSERT_AND_UPDATE;
+		return ALL;
 	}
 
 	@Override

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/locking/CurrentTimestampVersionTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/locking/CurrentTimestampVersionTest.java
@@ -1,0 +1,50 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.locking;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.LockModeType;
+import jakarta.persistence.Version;
+import org.hibernate.annotations.CurrentTimestamp;
+import org.hibernate.testing.orm.junit.EntityManagerFactoryScope;
+import org.hibernate.testing.orm.junit.Jpa;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+@Jpa(annotatedClasses = CurrentTimestampVersionTest.Timestamped.class)
+class CurrentTimestampVersionTest {
+	@Test void test(EntityManagerFactoryScope scope) {
+		Timestamped t = scope.fromTransaction( entityManager -> {
+			Timestamped timestamped = new Timestamped();
+			timestamped.id = 1L;
+			entityManager.persist( timestamped );
+			return timestamped;
+		} );
+		assertNotNull( t.timestamp );
+		scope.inTransaction( entityManager -> {
+			Timestamped timestamped = entityManager.find( Timestamped.class, 1L,
+					LockModeType.OPTIMISTIC_FORCE_INCREMENT );
+			assertNotNull( timestamped );
+			assertNotNull( timestamped.timestamp );
+		} );
+		scope.inTransaction( entityManager -> {
+			Timestamped timestamped = entityManager.find( Timestamped.class, 1L );
+			timestamped.content = "new content";
+		} );
+		// TODO: assert some stuff about the timestamp values
+	}
+	@Entity
+	static class Timestamped {
+		@Id
+		Long id;
+		@CurrentTimestamp @Version
+		LocalDateTime timestamp;
+		String content;
+	}
+}


### PR DESCRIPTION
This is not the best implementation, but it reproduces the capabilities of the deprecated generator type @Source(DB).

<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

[Please describe here what your change is about]

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-17751
<!-- Hibernate GitHub Bot issue links end -->