### PR TITLE
HHH-19643 - Redirect some hibernate-envers tests to H2 as they use an H2 configured hibernate configuration file

### DIFF
--- a/hibernate-envers/src/test/java/org/hibernate/orm/test/envers/integration/entityNames/auditedEntity/ReadEntityWhitEntityNameTest.java
+++ b/hibernate-envers/src/test/java/org/hibernate/orm/test/envers/integration/entityNames/auditedEntity/ReadEntityWhitEntityNameTest.java
@@ -10,14 +10,17 @@ import java.net.URL;
 import java.util.List;
 
 import org.hibernate.MappingException;
+import org.hibernate.dialect.H2Dialect;
 import org.hibernate.orm.test.envers.AbstractOneSessionTest;
 import org.hibernate.orm.test.envers.Priority;
 
+import org.hibernate.testing.orm.junit.RequiresDialect;
 import org.junit.Test;
 
 /**
  * @author Hern&aacute;n Chanfreau
  */
+@RequiresDialect(H2Dialect.class)
 public class ReadEntityWhitEntityNameTest extends AbstractOneSessionTest {
 
 	private long id_pers1;

--- a/hibernate-envers/src/test/java/org/hibernate/orm/test/envers/integration/entityNames/manyToManyAudited/ReadEntityWithAuditedManyToManyTest.java
+++ b/hibernate-envers/src/test/java/org/hibernate/orm/test/envers/integration/entityNames/manyToManyAudited/ReadEntityWithAuditedManyToManyTest.java
@@ -11,14 +11,17 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.hibernate.MappingException;
+import org.hibernate.dialect.H2Dialect;
 import org.hibernate.orm.test.envers.AbstractOneSessionTest;
 import org.hibernate.orm.test.envers.Priority;
 
+import org.hibernate.testing.orm.junit.RequiresDialect;
 import org.junit.Test;
 
 /**
  * @author Hern&aacute;n Chanfreau
  */
+@RequiresDialect(H2Dialect.class)
 public class ReadEntityWithAuditedManyToManyTest extends AbstractOneSessionTest {
 
 	private long id_car1;

--- a/hibernate-envers/src/test/java/org/hibernate/orm/test/envers/integration/entityNames/oneToManyAudited/ReadEntityWithAuditedCollectionTest.java
+++ b/hibernate-envers/src/test/java/org/hibernate/orm/test/envers/integration/entityNames/oneToManyAudited/ReadEntityWithAuditedCollectionTest.java
@@ -11,14 +11,17 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.hibernate.MappingException;
+import org.hibernate.dialect.H2Dialect;
 import org.hibernate.orm.test.envers.AbstractOneSessionTest;
 import org.hibernate.orm.test.envers.Priority;
 
+import org.hibernate.testing.orm.junit.RequiresDialect;
 import org.junit.Test;
 
 /**
  * @author Hern&aacute;n Chanfreau
  */
+@RequiresDialect(H2Dialect.class)
 public class ReadEntityWithAuditedCollectionTest extends AbstractOneSessionTest {
 
 	private long id_car1;

--- a/hibernate-envers/src/test/java/org/hibernate/orm/test/envers/integration/entityNames/oneToManyNotAudited/ReadEntityWithAuditedCollectionTest.java
+++ b/hibernate-envers/src/test/java/org/hibernate/orm/test/envers/integration/entityNames/oneToManyNotAudited/ReadEntityWithAuditedCollectionTest.java
@@ -11,14 +11,17 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.hibernate.MappingException;
+import org.hibernate.dialect.H2Dialect;
 import org.hibernate.orm.test.envers.AbstractOneSessionTest;
 import org.hibernate.orm.test.envers.Priority;
 
+import org.hibernate.testing.orm.junit.RequiresDialect;
 import org.junit.Test;
 
 /**
  * @author Hern&aacute;n Chanfreau
  */
+@RequiresDialect(H2Dialect.class)
 public class ReadEntityWithAuditedCollectionTest extends AbstractOneSessionTest {
 
 	private long id_car1;

--- a/hibernate-envers/src/test/java/org/hibernate/orm/test/envers/integration/entityNames/singleAssociatedAudited/ReadEntityAssociatedAuditedTest.java
+++ b/hibernate-envers/src/test/java/org/hibernate/orm/test/envers/integration/entityNames/singleAssociatedAudited/ReadEntityAssociatedAuditedTest.java
@@ -9,14 +9,17 @@ import java.net.URISyntaxException;
 import java.net.URL;
 
 import org.hibernate.MappingException;
+import org.hibernate.dialect.H2Dialect;
 import org.hibernate.orm.test.envers.AbstractOneSessionTest;
 import org.hibernate.orm.test.envers.Priority;
 
+import org.hibernate.testing.orm.junit.RequiresDialect;
 import org.junit.Test;
 
 /**
  * @author Hern&aacute;n Chanfreau
  */
+@RequiresDialect(H2Dialect.class)
 public class ReadEntityAssociatedAuditedTest extends AbstractOneSessionTest {
 
 	private long id_car1;

--- a/hibernate-envers/src/test/java/org/hibernate/orm/test/envers/integration/entityNames/singleAssociatedAudited/SingleDomainObjectToMultipleTablesTest.java
+++ b/hibernate-envers/src/test/java/org/hibernate/orm/test/envers/integration/entityNames/singleAssociatedAudited/SingleDomainObjectToMultipleTablesTest.java
@@ -9,16 +9,19 @@ import java.net.URISyntaxException;
 import java.net.URL;
 
 import org.hibernate.MappingException;
+import org.hibernate.dialect.H2Dialect;
 import org.hibernate.orm.test.envers.AbstractOneSessionTest;
 import org.hibernate.orm.test.envers.Priority;
 
 import org.hibernate.testing.orm.junit.JiraKey;
+import org.hibernate.testing.orm.junit.RequiresDialect;
 import org.junit.Assert;
 import org.junit.Test;
 
 /**
  * @author Lukasz Antoniak (lukasz dot antoniak at gmail dot com)
  */
+@RequiresDialect(H2Dialect.class)
 public class SingleDomainObjectToMultipleTablesTest extends AbstractOneSessionTest {
 	private long carId = 0;
 	private long ownerId = 0;

--- a/hibernate-envers/src/test/java/org/hibernate/orm/test/envers/integration/entityNames/singleAssociatedNotAudited/ReadEntityAssociatedNotAuditedTest.java
+++ b/hibernate-envers/src/test/java/org/hibernate/orm/test/envers/integration/entityNames/singleAssociatedNotAudited/ReadEntityAssociatedNotAuditedTest.java
@@ -9,14 +9,17 @@ import java.net.URISyntaxException;
 import java.net.URL;
 
 import org.hibernate.MappingException;
+import org.hibernate.dialect.H2Dialect;
 import org.hibernate.orm.test.envers.AbstractOneSessionTest;
 import org.hibernate.orm.test.envers.Priority;
 
+import org.hibernate.testing.orm.junit.RequiresDialect;
 import org.junit.Test;
 
 /**
  * @author Hern&aacute;n Chanfreau
  */
+@RequiresDialect(H2Dialect.class)
 public class ReadEntityAssociatedNotAuditedTest extends AbstractOneSessionTest {
 
 	private long id_car1;

--- a/hibernate-envers/src/test/java/org/hibernate/orm/test/envers/integration/modifiedflags/HasChangedAuditedManyToManyTest.java
+++ b/hibernate-envers/src/test/java/org/hibernate/orm/test/envers/integration/modifiedflags/HasChangedAuditedManyToManyTest.java
@@ -11,11 +11,13 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.hibernate.MappingException;
+import org.hibernate.dialect.H2Dialect;
 import org.hibernate.envers.query.AuditEntity;
 import org.hibernate.orm.test.envers.Priority;
 import org.hibernate.orm.test.envers.integration.entityNames.manyToManyAudited.Car;
 import org.hibernate.orm.test.envers.integration.entityNames.manyToManyAudited.Person;
 
+import org.hibernate.testing.orm.junit.RequiresDialect;
 import org.junit.Test;
 
 import static junit.framework.Assert.assertEquals;
@@ -26,6 +28,7 @@ import static org.hibernate.orm.test.envers.tools.TestTools.makeList;
  * @author Hern&aacute;n Chanfreau
  * @author Michal Skowronek (mskowr at o2 dot pl)
  */
+@RequiresDialect(H2Dialect.class)
 public class HasChangedAuditedManyToManyTest extends AbstractModifiedFlagsOneSessionTest {
 
 	private long id_car1;


### PR DESCRIPTION
This PR makes some tests configured to run on H2 database to not run on other databases (and clear shared connection pool at the same time).

----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-19643
<!-- Hibernate GitHub Bot issue links end -->