### PR TITLE
HHH-19644 - Enforce usage of SharedDriverManagerConnectionProviderImpl connection pool for hibernate-envers tests

### DIFF
--- a/hibernate-envers/src/test/resources/hibernate.properties
+++ b/hibernate-envers/src/test/resources/hibernate.properties
@@ -8,8 +8,10 @@ hibernate.connection.url @jdbc.url@
 hibernate.connection.username @jdbc.user@
 hibernate.connection.password @jdbc.pass@
 hibernate.connection.init_sql @connection.init_sql@
+hibernate.connection.autocommit false
+hibernate.connection.initial_pool_size 0
 
-hibernate.connection.pool_size 2
+hibernate.connection.pool_size 5
 
 hibernate.show_sql false
 

--- a/hibernate-testing/src/main/java/org/hibernate/testing/jta/JtaAwareConnectionProviderImpl.java
+++ b/hibernate-testing/src/main/java/org/hibernate/testing/jta/JtaAwareConnectionProviderImpl.java
@@ -62,6 +62,7 @@ import org.hibernate.service.spi.Configurable;
 import org.hibernate.service.spi.ServiceRegistryAwareService;
 import org.hibernate.service.spi.ServiceRegistryImplementor;
 import org.hibernate.service.spi.Stoppable;
+import org.hibernate.testing.jdbc.SharedDriverManagerConnectionProviderImpl;
 
 /**
  * A {@link ConnectionProvider} implementation intended for testing Hibernate/JTA interaction.  In that limited scope we
@@ -75,7 +76,7 @@ public class JtaAwareConnectionProviderImpl implements ConnectionProvider, Confi
 		ServiceRegistryAwareService {
 	private static final String CONNECTION_KEY = "_database_connection";
 
-	private final DriverManagerConnectionProviderImpl delegate = new DriverManagerConnectionProviderImpl();
+	private final DriverManagerConnectionProviderImpl delegate = SharedDriverManagerConnectionProviderImpl.getInstance();
 
 	private final List<Connection> nonEnlistedConnections = new ArrayList<>();
 


### PR DESCRIPTION
This PR makes the hibernate-envers tests better use the shared connection pool `SharedDriverManagerConnectionProviderImpl`, meaning reducing the number of times it needs to be reset because:
- configuration changes
- another connection provider is being used

----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-19644
<!-- Hibernate GitHub Bot issue links end -->