### PR TITLE
HHH-19645 - Some database specific tests are missing RequiresDialect annotation

### DIFF
--- a/hibernate-core/src/test/java/org/hibernate/orm/test/dialect/DB2DialectTestCase.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/dialect/DB2DialectTestCase.java
@@ -9,6 +9,7 @@ import java.sql.Types;
 import org.hibernate.dialect.DB2Dialect;
 import org.hibernate.engine.jdbc.Size;
 import org.hibernate.query.spi.Limit;
+import org.hibernate.testing.orm.junit.RequiresDialect;
 import org.hibernate.type.spi.TypeConfiguration;
 
 import org.junit.Before;
@@ -26,6 +27,7 @@ import static org.junit.Assert.assertTrue;
  * @author Hardy Ferentschik
  */
 
+@RequiresDialect(DB2Dialect.class)
 public class DB2DialectTestCase extends BaseUnitTestCase {
 	private final DB2Dialect dialect = new DB2Dialect();
 	private TypeConfiguration typeConfiguration;

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/dialect/DB2LimitHandlerTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/dialect/DB2LimitHandlerTest.java
@@ -4,12 +4,15 @@
  */
 package org.hibernate.orm.test.dialect;
 
+import org.hibernate.dialect.DB2Dialect;
 import org.hibernate.dialect.pagination.AbstractLimitHandler;
 import org.hibernate.dialect.pagination.DB2LimitHandler;
+import org.hibernate.testing.orm.junit.RequiresDialect;
 
 /**
  * @author Yanming Zhou
  */
+@RequiresDialect(DB2Dialect.class)
 public class DB2LimitHandlerTest extends AbstractLimitHandlerTest {
 
 	@Override

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/dialect/Db2VariantDialectInitTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/dialect/Db2VariantDialectInitTests.java
@@ -7,6 +7,7 @@ package org.hibernate.orm.test.dialect;
 import org.hibernate.dialect.DB2iDialect;
 import org.hibernate.dialect.DB2zDialect;
 import org.hibernate.testing.orm.junit.JiraKey;
+import org.hibernate.testing.orm.junit.RequiresDialect;
 import org.junit.Test;
 
 import static org.junit.Assert.assertNotNull;
@@ -15,6 +16,8 @@ import static org.junit.Assert.assertNotNull;
  * @author Steve Ebersole
  */
 @JiraKey(value = "HHH-15046")
+@RequiresDialect(DB2iDialect.class)
+@RequiresDialect(DB2zDialect.class)
 public class Db2VariantDialectInitTests {
 	@Test
 	public void testDB2zDialectInit() {

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/dialect/Oracle12LimitHandlerTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/dialect/Oracle12LimitHandlerTest.java
@@ -4,18 +4,21 @@
  */
 package org.hibernate.orm.test.dialect;
 
+import org.hibernate.dialect.OracleDialect;
 import org.hibernate.dialect.pagination.AbstractLimitHandler;
 
 import org.hibernate.dialect.pagination.Oracle12LimitHandler;
 import org.hibernate.query.spi.Limit;
 import org.hibernate.testing.orm.junit.JiraKey;
 
+import org.hibernate.testing.orm.junit.RequiresDialect;
 import org.junit.jupiter.api.Test;
 
 import static org.hibernate.dialect.pagination.AbstractLimitHandler.hasFirstRow;
 import static org.hibernate.dialect.pagination.AbstractLimitHandler.hasMaxRows;
 
 @JiraKey( value = "HHH-14649")
+@RequiresDialect(OracleDialect.class)
 public class Oracle12LimitHandlerTest extends AbstractLimitHandlerTest {
 
 	@Override

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/dialect/PostgreSQLDialectTestCase.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/dialect/PostgreSQLDialectTestCase.java
@@ -32,6 +32,7 @@ import org.hibernate.query.sqm.function.SqmFunctionRegistry;
 import org.hibernate.testing.orm.junit.DialectFeatureChecks;
 import org.hibernate.testing.orm.junit.JiraKey;
 import org.hibernate.testing.junit4.BaseUnitTestCase;
+import org.hibernate.testing.orm.junit.RequiresDialect;
 import org.hibernate.type.spi.TypeConfiguration;
 import org.junit.Test;
 
@@ -49,6 +50,7 @@ import static org.junit.Assert.fail;
  * @author Bryan Varner
  * @author Christoph Dreis
  */
+@RequiresDialect(PostgreSQLDialect.class)
 public class PostgreSQLDialectTestCase extends BaseUnitTestCase {
 
 	@Test

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/dialect/function/PostgreSQLTruncRoundFunctionTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/dialect/function/PostgreSQLTruncRoundFunctionTest.java
@@ -27,6 +27,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  */
 @DomainModel(standardModels = StandardDomainModel.ANIMAL)
 @SessionFactory(statementInspectorClass = SQLStatementInspector.class)
+@RequiresDialect(PostgreSQLDialect.class)
 public class PostgreSQLTruncRoundFunctionTest {
 	@AfterEach
 	public void tearDown(SessionFactoryScope scope) {

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/dialect/unit/CockroachDialectVersionTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/dialect/unit/CockroachDialectVersionTest.java
@@ -11,6 +11,7 @@ import org.hibernate.internal.CoreMessageLogger;
 
 import org.hibernate.testing.orm.junit.JiraKey;
 import org.hibernate.testing.logger.Triggerable;
+import org.hibernate.testing.orm.junit.RequiresDialect;
 import org.hibernate.testing.orm.logger.LoggerInspectionExtension;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -26,6 +27,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 /**
  * @author Jan Schatteman
  */
+@RequiresDialect(CockroachDialect.class)
 public class CockroachDialectVersionTest {
 
 	private Triggerable triggerable;

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/dialect/unit/lockhint/MySQLStorageEngineTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/dialect/unit/lockhint/MySQLStorageEngineTest.java
@@ -9,6 +9,7 @@ import org.hibernate.cfg.Environment;
 import org.hibernate.dialect.MySQLDialect;
 
 import org.hibernate.testing.junit4.BaseUnitTestCase;
+import org.hibernate.testing.orm.junit.RequiresDialect;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
@@ -17,6 +18,7 @@ import static org.junit.Assert.assertNotNull;
 import java.lang.reflect.Field;
 import java.util.Properties;
 
+@RequiresDialect(MySQLDialect.class)
 public class MySQLStorageEngineTest extends BaseUnitTestCase {
 
 	@Test

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/dialect/unit/lockhint/SQLServerLockHintsTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/dialect/unit/lockhint/SQLServerLockHintsTest.java
@@ -6,10 +6,12 @@ package org.hibernate.orm.test.dialect.unit.lockhint;
 
 import org.hibernate.dialect.Dialect;
 import org.hibernate.dialect.SQLServerDialect;
+import org.hibernate.testing.orm.junit.RequiresDialect;
 
 /**
  * @author Steve Ebersole
  */
+@RequiresDialect(SQLServerDialect.class)
 public class SQLServerLockHintsTest extends AbstractLockHintTest {
 	public static final Dialect DIALECT = new SQLServerDialect();
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/dialect/unit/lockhint/SybaseLockHintsTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/dialect/unit/lockhint/SybaseLockHintsTest.java
@@ -6,10 +6,12 @@ package org.hibernate.orm.test.dialect.unit.lockhint;
 
 import org.hibernate.dialect.Dialect;
 import org.hibernate.dialect.SybaseDialect;
+import org.hibernate.testing.orm.junit.RequiresDialect;
 
 /**
  * @author Steve Ebersole
  */
+@RequiresDialect(SybaseDialect.class)
 public class SybaseLockHintsTest extends AbstractLockHintTest {
 	public static final Dialect DIALECT = new SybaseDialect();
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/dialect/unit/locktimeout/DB2LockTimeoutTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/dialect/unit/locktimeout/DB2LockTimeoutTest.java
@@ -10,6 +10,7 @@ import org.hibernate.dialect.DB2Dialect;
 import org.hibernate.dialect.DatabaseVersion;
 import org.hibernate.dialect.Dialect;
 import org.hibernate.testing.junit4.BaseUnitTestCase;
+import org.hibernate.testing.orm.junit.RequiresDialect;
 import org.junit.Test;
 
 import static org.hibernate.Timeouts.SKIP_LOCKED;
@@ -18,6 +19,7 @@ import static org.junit.Assert.assertEquals;
 /**
  * @author Gavin King
  */
+@RequiresDialect(DB2Dialect.class)
 public class DB2LockTimeoutTest extends BaseUnitTestCase {
 
 	private final Dialect dialect = new DB2Dialect( DatabaseVersion.make( 11, 5 ) );

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/dialect/unit/locktimeout/HANALockTimeoutTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/dialect/unit/locktimeout/HANALockTimeoutTest.java
@@ -9,6 +9,7 @@ import org.hibernate.LockOptions;
 import org.hibernate.dialect.Dialect;
 import org.hibernate.dialect.HANADialect;
 import org.hibernate.testing.junit4.BaseUnitTestCase;
+import org.hibernate.testing.orm.junit.RequiresDialect;
 import org.junit.Test;
 
 import static org.hibernate.Timeouts.NO_WAIT;
@@ -22,6 +23,7 @@ import static org.junit.Assert.assertEquals;
  *
  * @author Vlad Mihalcea
  */
+@RequiresDialect(HANADialect.class)
 public class HANALockTimeoutTest extends BaseUnitTestCase {
 
 	private final Dialect dialect = new HANADialect();

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/dialect/unit/locktimeout/PostgreSQLLockTimeoutTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/dialect/unit/locktimeout/PostgreSQLLockTimeoutTest.java
@@ -10,6 +10,7 @@ import org.hibernate.dialect.Dialect;
 import org.hibernate.dialect.PostgreSQLDialect;
 
 import org.hibernate.testing.junit4.BaseUnitTestCase;
+import org.hibernate.testing.orm.junit.RequiresDialect;
 import org.junit.Test;
 
 import static org.hibernate.Timeouts.NO_WAIT;
@@ -19,6 +20,7 @@ import static org.junit.Assert.assertEquals;
 /**
  * @author Vlad Mihalcea
  */
+@RequiresDialect(PostgreSQLDialect.class)
 public class PostgreSQLLockTimeoutTest extends BaseUnitTestCase {
 
 	private final Dialect dialect = new PostgreSQLDialect();

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/dialect/unit/sequence/DB2iSequenceInformationExtractorTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/dialect/unit/sequence/DB2iSequenceInformationExtractorTest.java
@@ -6,6 +6,7 @@ package org.hibernate.orm.test.dialect.unit.sequence;
 
 import org.hibernate.dialect.DB2iDialect;
 import org.hibernate.dialect.Dialect;
+import org.hibernate.testing.orm.junit.RequiresDialect;
 import org.hibernate.tool.schema.extract.internal.SequenceInformationExtractorNoOpImpl;
 import org.hibernate.tool.schema.extract.spi.SequenceInformationExtractor;
 
@@ -16,6 +17,7 @@ import org.hibernate.testing.orm.junit.JiraKey;
  * @author Andrea Boriero
  */
 @JiraKey(value = "HHH-11470")
+@RequiresDialect(DB2iDialect.class)
 public class DB2iSequenceInformationExtractorTest extends AbstractSequenceInformationExtractorTest {
 
 	@Override

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/dialect/unit/sequence/DB2zSequenceInformationExtractorTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/dialect/unit/sequence/DB2zSequenceInformationExtractorTest.java
@@ -6,6 +6,7 @@ package org.hibernate.orm.test.dialect.unit.sequence;
 
 import org.hibernate.dialect.DB2zDialect;
 import org.hibernate.dialect.Dialect;
+import org.hibernate.testing.orm.junit.RequiresDialect;
 import org.hibernate.tool.schema.extract.internal.SequenceInformationExtractorDB2DatabaseImpl;
 import org.hibernate.tool.schema.extract.spi.SequenceInformationExtractor;
 
@@ -15,6 +16,7 @@ import org.hibernate.testing.orm.junit.JiraKey;
  * @author Andrea Boriero
  */
 @JiraKey(value = "HHH-11470")
+@RequiresDialect(DB2zDialect.class)
 public class DB2zSequenceInformationExtractorTest extends AbstractSequenceInformationExtractorTest {
 
 	@Override


### PR DESCRIPTION
This PR aims at adding the missing @RequiresDialect annotations when hibernate-core tests are related to specific dialects; thus, preventing them from running on other databases.

----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
