### PR TITLE
HHH-19646 Improve validation of configuration settings for the Query Plan Cache

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/query/internal/QueryEngineImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/internal/QueryEngineImpl.java
@@ -13,6 +13,7 @@ import org.hibernate.dialect.Dialect;
 import org.hibernate.engine.jdbc.spi.JdbcServices;
 import org.hibernate.engine.query.spi.NativeQueryInterpreter;
 import org.hibernate.internal.CoreLogging;
+import org.hibernate.internal.util.config.ConfigurationException;
 import org.hibernate.internal.util.config.ConfigurationHelper;
 import org.hibernate.metamodel.MappingMetamodel;
 import org.hibernate.metamodel.model.domain.JpaMetamodel;
@@ -171,9 +172,9 @@ public class QueryEngineImpl implements QueryEngine {
 		return contributors;
 	}
 
-	private static QueryInterpretationCache buildInterpretationCache(
+	public static QueryInterpretationCache buildInterpretationCache(
 			ServiceRegistry serviceRegistry, Map<String, Object> properties) {
-		final boolean explicitUseCache = ConfigurationHelper.getBoolean(
+		final boolean useCache = ConfigurationHelper.getBoolean(
 				AvailableSettings.QUERY_PLAN_CACHE_ENABLED,
 				properties,
 				// enabled by default
@@ -185,12 +186,20 @@ public class QueryEngineImpl implements QueryEngine {
 				properties
 		);
 
-		if ( explicitUseCache || explicitMaxPlanSize != null && explicitMaxPlanSize > 0 ) {
-			final int size = explicitMaxPlanSize != null
-					? explicitMaxPlanSize
-					: QueryEngine.DEFAULT_QUERY_PLAN_MAX_COUNT;
+		//Let's avoid some confusion and check settings consistency:
+		final int appliedMaxPlanSize = explicitMaxPlanSize == null
+				? QueryEngine.DEFAULT_QUERY_PLAN_MAX_COUNT
+				: explicitMaxPlanSize;
+		if ( !useCache && explicitMaxPlanSize != null && appliedMaxPlanSize > 0 ) {
+			throw new ConfigurationException( "Inconsistent configuration: '" + AvailableSettings.QUERY_PLAN_CACHE_MAX_SIZE + "' can only be set to a greater than zero value when '" + AvailableSettings.QUERY_PLAN_CACHE_ENABLED + "' is enabled" );
+		}
 
-			return new QueryInterpretationCacheStandardImpl( size, serviceRegistry );
+		if ( appliedMaxPlanSize < 0 ) {
+			throw new ConfigurationException( "Inconsistent configuration: '" + AvailableSettings.QUERY_PLAN_CACHE_MAX_SIZE + "' can't be set to a negative value. To disable the query plan cache set '" + AvailableSettings.QUERY_PLAN_CACHE_ENABLED + "' to 'false'" );
+		}
+
+		if ( useCache ) {
+			return new QueryInterpretationCacheStandardImpl( appliedMaxPlanSize, serviceRegistry );
 		}
 		else {
 			// disabled

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/querycache/QueryEngineImplConfigValidationTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/querycache/QueryEngineImplConfigValidationTest.java
@@ -1,0 +1,139 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.querycache;
+
+import org.hibernate.boot.registry.StandardServiceRegistry;
+import org.hibernate.cfg.AvailableSettings;
+import org.hibernate.internal.util.config.ConfigurationException;
+import org.hibernate.query.internal.QueryInterpretationCacheDisabledImpl;
+import org.hibernate.query.internal.QueryInterpretationCacheStandardImpl;
+import org.hibernate.query.spi.QueryInterpretationCache;
+import org.hibernate.service.ServiceRegistry;
+import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
+import org.hibernate.query.internal.QueryEngineImpl;
+import org.hibernate.testing.orm.junit.Jira;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Test for configuration validation in QueryEngineImpl.
+ * Tests the consistency checks between QUERY_PLAN_CACHE_ENABLED and QUERY_PLAN_CACHE_MAX_SIZE.
+ */
+@Jira("HHH-19646")
+public class QueryEngineImplConfigValidationTest {
+
+	@Test
+	public void testCacheEnabledWithValidMaxSize() {
+		Map<String, Object> settings = new HashMap<>();
+		settings.put( AvailableSettings.QUERY_PLAN_CACHE_ENABLED, true );
+		settings.put( AvailableSettings.QUERY_PLAN_CACHE_MAX_SIZE, 100 );
+		try (ServiceRegistry serviceRegistry = newRegistry()) {
+			QueryInterpretationCache interpretationCache = assertDoesNotThrow( () ->
+					QueryEngineImpl.buildInterpretationCache( serviceRegistry, settings )
+			);
+			testCacheEnabled( interpretationCache );
+		}
+	}
+
+	@Test
+	public void testCacheEnabledWithDefaultMaxSize() {
+		Map<String, Object> settings = new HashMap<>();
+		settings.put( AvailableSettings.QUERY_PLAN_CACHE_ENABLED, true );
+		// No explicit max size - should use default
+		try (ServiceRegistry serviceRegistry = newRegistry()) {
+			QueryInterpretationCache interpretationCache = assertDoesNotThrow( () ->
+					QueryEngineImpl.buildInterpretationCache( serviceRegistry, settings )
+			);
+			testCacheEnabled( interpretationCache );
+		}
+	}
+
+	@Test
+	public void testCacheDisabledWithNoMaxSize() {
+		Map<String, Object> settings = new HashMap<>();
+		settings.put( AvailableSettings.QUERY_PLAN_CACHE_ENABLED, false );
+		// No explicit max size - should work fine
+		try (ServiceRegistry serviceRegistry = newRegistry()) {
+			QueryInterpretationCache interpretationCache = assertDoesNotThrow( () ->
+					QueryEngineImpl.buildInterpretationCache( serviceRegistry, settings )
+			);
+			testCacheDisabled( interpretationCache );
+		}
+	}
+
+	@Test
+	public void testCacheDisabledWithPositiveMaxSize() {
+		Map<String, Object> settings = new HashMap<>();
+		settings.put( AvailableSettings.QUERY_PLAN_CACHE_ENABLED, false );
+		settings.put( AvailableSettings.QUERY_PLAN_CACHE_MAX_SIZE, 100 );
+		//Explicit max size, with cache explicitly disabled is an inconsistency we want to flag
+		try (ServiceRegistry serviceRegistry = newRegistry()) {
+			ConfigurationException exception = assertThrows( ConfigurationException.class, () ->
+					QueryEngineImpl.buildInterpretationCache( serviceRegistry, settings )
+			);
+			assertTrue( exception.getMessage().matches(
+					"Inconsistent configuration: '" + AvailableSettings.QUERY_PLAN_CACHE_MAX_SIZE + "' can only be set to a greater than zero value when '" + AvailableSettings.QUERY_PLAN_CACHE_ENABLED + "' is enabled" ) );
+		}
+	}
+
+	@Test
+	public void testCacheDisabledWithZeroMaxSize() {
+		Map<String, Object> settings = new HashMap<>();
+		settings.put( AvailableSettings.QUERY_PLAN_CACHE_ENABLED, false );
+		settings.put( AvailableSettings.QUERY_PLAN_CACHE_MAX_SIZE, 0 );
+		try (ServiceRegistry serviceRegistry = newRegistry()) {
+			QueryInterpretationCache interpretationCache = assertDoesNotThrow( () ->
+					QueryEngineImpl.buildInterpretationCache( serviceRegistry, settings )
+			);
+			testCacheDisabled( interpretationCache );
+		}
+	}
+
+	@Test
+	public void testNegativeMaxSize() {
+		Map<String, Object> settings = new HashMap<>();
+		settings.put( AvailableSettings.QUERY_PLAN_CACHE_ENABLED, true );
+		settings.put( AvailableSettings.QUERY_PLAN_CACHE_MAX_SIZE, -1 );
+		try (ServiceRegistry serviceRegistry = newRegistry()) {
+			ConfigurationException exception = assertThrows( ConfigurationException.class, () ->
+					QueryEngineImpl.buildInterpretationCache( serviceRegistry, settings )
+			);
+			assertTrue( exception.getMessage().contains( "can't be set to a negative value" ) );
+		}
+	}
+
+	@Test
+	public void testDefaultConfigurationWorks() {
+		Map<String, Object> settings = new HashMap<>();
+		// No explicit settings - should use defaults and work fine
+		try (ServiceRegistry serviceRegistry = newRegistry()) {
+			QueryInterpretationCache interpretationCache = assertDoesNotThrow( () ->
+					QueryEngineImpl.buildInterpretationCache( serviceRegistry, settings )
+			);
+			testCacheEnabled( interpretationCache );
+		}
+	}
+
+	private static StandardServiceRegistry newRegistry() {
+		return new StandardServiceRegistryBuilder().build();
+	}
+
+	private void testCacheEnabled(QueryInterpretationCache interpretationCache) {
+		assertInstanceOf( QueryInterpretationCacheStandardImpl.class, interpretationCache,
+				"Default interpretation cache should be used" );
+	}
+
+	private void testCacheDisabled(QueryInterpretationCache interpretationCache) {
+		assertInstanceOf( QueryInterpretationCacheDisabledImpl.class, interpretationCache,
+				"Cache should have been disabled" );
+	}
+}


### PR DESCRIPTION
We have two related configuration properties, hibernate.query.plan_cache_enabled and hibernate.query.plan_cache_max_size. I’m volunteering to improve feedback with stricter error messages when they are configured inconsistently, and to add tests to make sure the cache can indeed be disabled (as intended).

 - https://hibernate.atlassian.net/browse/HHH-19646

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-19646
<!-- Hibernate GitHub Bot issue links end -->