### PR TITLE
Fix backwards compatibily for Hibernate Reactive

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/embeddable/internal/EmbeddableInitializerImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/embeddable/internal/EmbeddableInitializerImpl.java
@@ -99,6 +99,17 @@ public class EmbeddableInitializerImpl extends AbstractInitializer<EmbeddableIni
 		}
 	}
 
+	// Used by Hibernate Reactive
+	@Deprecated(forRemoval = true)
+	public EmbeddableInitializerImpl(
+			EmbeddableResultGraphNode resultDescriptor,
+			BasicFetch<?> discriminatorFetch,
+			InitializerParent<?> parent,
+			AssemblerCreationState creationState,
+			boolean isResultInitializer) {
+		this( resultDescriptor, discriminatorFetch, null, parent, creationState, isResultInitializer );
+	}
+
 	public EmbeddableInitializerImpl(
 			EmbeddableResultGraphNode resultDescriptor,
 			BasicFetch<?> discriminatorFetch,


### PR DESCRIPTION
<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->


https://github.com/hibernate/hibernate-orm/pull/10600 breaks compatibility with Hibernate Reactive
This commit re-add a constructor with the signature that Hibernate Reactive calls.

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
