### PR TITLE
HHH-19651: Make the DB2i detection more reliable

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/dialect/Database.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/Database.java
@@ -42,10 +42,14 @@ public enum Database {
 						return new DB2zDialect( info );
 					}
 					case "QSQ": {
-						// i
+						// i, this only works if "use drda metadata version" property is set to true in the drivers properties
 						return new DB2iDialect( info );
 					}
 				}
+			}
+			if ("DB2 UDB for AS/400".equals(info.getDatabaseName())) {
+				// i
+				return new DB2iDialect( info );
 			}
 
 			return new DB2Dialect( info );

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/dialect/resolver/DialectFactoryTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/dialect/resolver/DialectFactoryTest.java
@@ -149,8 +149,8 @@ public class DialectFactoryTest extends BaseUnitTestCase {
 		testDetermination( "DB2/SUN", DB2Dialect.class, resolver );
 		testDetermination( "DB2/LINUX390", DB2Dialect.class, resolver );
 		testDetermination( "DB2/AIX64", DB2Dialect.class, resolver );
-		testDetermination( "DB2 UDB for AS/400", DB2Dialect.class, resolver );
-		testDetermination( "DB2 UDB for AS/400", 7, 3, DB2Dialect.class, resolver );
+		testDetermination( "DB2 UDB for AS/400", DB2iDialect.class, resolver );
+		testDetermination( "DB2 UDB for AS/400", 7, 3, DB2iDialect.class, resolver );
 		testDetermination( "Oracle", 8, OracleDialect.class, resolver );
 		testDetermination( "Oracle", 9, OracleDialect.class, resolver );
 		testDetermination( "Oracle", 10, OracleDialect.class, resolver );


### PR DESCRIPTION
This fixes the detection logic for DB2 for i as discussed in https://hibernate.atlassian.net/browse/HHH-19453?focusedCommentId=123205


----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
