### PR TITLE
HHH-19656 force the default JDBC fetch size to 128 if it is smaller

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/engine/jdbc/JdbcLogging.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/jdbc/JdbcLogging.java
@@ -164,9 +164,9 @@ public interface JdbcLogging extends BasicLogger {
 	@Message(value = "Using default JDBC fetch size: %s", id = 100122)
 	void usingFetchSize(int fetchSize);
 
-	@LogMessage(level = WARN)
-	@Message(value = "Low default JDBC fetch size: %s (consider setting 'hibernate.jdbc.fetch_size')", id = 100123)
-	void warnLowFetchSize(int fetchSize);
+	@LogMessage(level = INFO)
+	@Message(value = "Low default JDBC fetch size: %s, forcing to: %s (consider setting 'hibernate.jdbc.fetch_size')", id = 100123)
+	void forcingFetchSize(int defaultFetchSize, int forcedFetchSize);
 
 	@LogMessage(level = TRACE)
 	@Message(value = "JDBC fetch size: %s", id = 100124)

--- a/hibernate-core/src/main/java/org/hibernate/engine/jdbc/env/internal/JdbcEnvironmentImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/jdbc/env/internal/JdbcEnvironmentImpl.java
@@ -10,7 +10,6 @@ import java.sql.SQLException;
 import org.hibernate.boot.model.naming.Identifier;
 import org.hibernate.boot.registry.selector.spi.StrategySelector;
 import org.hibernate.cfg.AvailableSettings;
-import org.hibernate.cfg.JdbcSettings;
 import org.hibernate.dialect.Dialect;
 import org.hibernate.engine.config.spi.ConfigurationService;
 import org.hibernate.engine.config.spi.StandardConverters;
@@ -39,7 +38,6 @@ import org.jboss.logging.Logger;
 import static org.hibernate.cfg.MappingSettings.DEFAULT_CATALOG;
 import static org.hibernate.cfg.MappingSettings.DEFAULT_SCHEMA;
 import static org.hibernate.engine.config.spi.StandardConverters.STRING;
-import static org.hibernate.engine.jdbc.JdbcLogging.JDBC_MESSAGE_LOGGER;
 import static org.hibernate.engine.jdbc.env.internal.LobCreatorBuilderImpl.makeLobCreatorBuilder;
 
 /**
@@ -107,8 +105,6 @@ public class JdbcEnvironmentImpl implements JdbcEnvironment {
 				new QualifiedObjectNameFormatterStandardImpl( nameQualifierSupport, dialect.getCatalogSeparator() );
 
 		lobCreatorBuilder = makeLobCreatorBuilder( dialect );
-
-		logJdbcFetchSize( extractedMetaDataSupport.getDefaultFetchSize(), cfgService );
 	}
 
 	private static ConfigurationService configurationService(ServiceRegistryImplementor serviceRegistry) {
@@ -321,8 +317,6 @@ public class JdbcEnvironmentImpl implements JdbcEnvironment {
 				new QualifiedObjectNameFormatterStandardImpl( nameQualifierSupport, databaseMetaData );
 
 		lobCreatorBuilder = makeLobCreatorBuilder( dialect, cfgService.getSettings(), databaseMetaData.getConnection() );
-
-		logJdbcFetchSize( extractedMetaDataSupport.getDefaultFetchSize(), cfgService );
 	}
 
 	private static IdentifierHelper identifierHelper(
@@ -424,16 +418,5 @@ public class JdbcEnvironmentImpl implements JdbcEnvironment {
 	@Override
 	public LobCreatorBuilder getLobCreatorBuilder() {
 		return lobCreatorBuilder;
-	}
-
-	private static void logJdbcFetchSize(int defaultFetchSize, ConfigurationService cfgService) {
-		if ( !cfgService.getSettings().containsKey( JdbcSettings.STATEMENT_FETCH_SIZE ) ) {
-			if ( defaultFetchSize > 0 && defaultFetchSize < 100 ) {
-				JDBC_MESSAGE_LOGGER.warnLowFetchSize( defaultFetchSize );
-			}
-			else {
-				JDBC_MESSAGE_LOGGER.usingFetchSize( defaultFetchSize );
-			}
-		}
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/engine/jdbc/internal/StatementPreparerImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/jdbc/internal/StatementPreparerImpl.java
@@ -25,6 +25,7 @@ import org.hibernate.resource.jdbc.spi.LogicalConnectionImplementor;
 
 import org.checkerframework.checker.nullness.qual.Nullable;
 
+import static org.hibernate.boot.internal.SessionFactoryOptionsBuilder.MIN_FETCH_SIZE;
 import static org.hibernate.engine.jdbc.JdbcLogging.JDBC_MESSAGE_LOGGER;
 
 /**
@@ -234,7 +235,7 @@ class StatementPreparerImpl implements StatementPreparer {
 		else {
 			if ( JDBC_MESSAGE_LOGGER.isDebugEnabled() ) {
 				final int defaultFetchSize = statement.getFetchSize();
-				if ( defaultFetchSize > 0 && defaultFetchSize < 100 ) {
+				if ( defaultFetchSize > 0 && defaultFetchSize < MIN_FETCH_SIZE ) {
 					JDBC_MESSAGE_LOGGER.lowFetchSize( defaultFetchSize );
 				}
 			}


### PR DESCRIPTION
workaround for small default fetch size on Oracle

supersedes #9635

<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

[Please describe here what your change is about]

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-19656
<!-- Hibernate GitHub Bot issue links end -->