### PR TITLE
fix a bug in ArrayJdbcType

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/jdbc/ArrayJdbcType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/jdbc/ArrayJdbcType.java
@@ -130,11 +130,13 @@ public class ArrayJdbcType implements JdbcType {
 		final DdlTypeRegistry ddlTypeRegistry = session.getTypeConfiguration().getDdlTypeRegistry();
 		final String typeName = ddlTypeRegistry.getDescriptor( elementJdbcType.getDdlTypeCode() )
 				.getTypeName( size, new BasicTypeImpl<>( elementJavaType, elementJdbcType), ddlTypeRegistry );
-		int cutIndex = typeName.indexOf( '(' );
-		if ( cutIndex > 0 ) {
+		int cutIndexBegin = typeName.indexOf( '(' );
+		int cutIndexEnd = typeName.lastIndexOf( ')' );
+		if ( cutIndexBegin > 0 && cutIndexEnd > cutIndexBegin ) {
 			// getTypeName for this case required length, etc, parameters.
 			// Cut them out and use database defaults.
-			return typeName.substring( 0, cutIndex );
+			// e.g. "timestamp($p) with timezone" becomes "timestamp with timezone"
+			return typeName.substring( 0, cutIndexBegin ) + typeName.substring( cutIndexEnd + 1 );
 		}
 		else {
 			return typeName;


### PR DESCRIPTION
fix a bug in ArrayJdbcType which exposes itself in combination with setting hibernate.type.java_time_use_direct_jdbc=true and add test for OffsetDateTime in an array to GlobalJavaTimeJdbcTypeTests

----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-19657
<!-- Hibernate GitHub Bot issue links end -->