### PR TITLE
Do not mark AbstractQuery as internal

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/query/spi/AbstractQuery.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/spi/AbstractQuery.java
@@ -23,7 +23,6 @@ import jakarta.persistence.Timeout;
 import jakarta.persistence.metamodel.Type;
 import org.hibernate.CacheMode;
 import org.hibernate.FlushMode;
-import org.hibernate.Internal;
 import org.hibernate.query.QueryFlushMode;
 import org.hibernate.HibernateException;
 import org.hibernate.LockOptions;
@@ -64,13 +63,8 @@ import static org.hibernate.jpa.SpecHints.HINT_SPEC_QUERY_TIMEOUT;
 /**
  * Base implementation of {@link org.hibernate.query.Query}.
  *
- * @apiNote This class is now considered internal implementation
- * and will move to an internal package in a future version.
- * Application programs should never depend directly on this class.
- *
  * @author Steve Ebersole
  */
-@Internal
 public abstract class AbstractQuery<R>
 		extends AbstractSelectionQuery<R>
 		implements QueryImplementor<R> {


### PR DESCRIPTION
and keep it as an SPI, since it is extended in Hibernate Search.

I've reverted the change just for the `AbstractQuery`, but since it extends the others, do we keep them as SPI too (i.e. should I revert that entire commit or just this one class?)

See 
- https://github.com/hibernate/hibernate-orm/pull/10336#discussion_r2224980983

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
