### PR TITLE
Add UpdateExecutionDelegate#getTemporaryTableStrategy() for Hibernate Reactive

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/mutation/internal/temptable/UpdateExecutionDelegate.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/mutation/internal/temptable/UpdateExecutionDelegate.java
@@ -525,4 +525,8 @@ public class UpdateExecutionDelegate implements TableBasedUpdateHandler.Executio
 		return sessionFactory;
 	}
 
+	// Used by Hibernate Reactive
+	public TemporaryTableStrategy getTemporaryTableStrategy() {
+		return temporaryTableStrategy;
+	}
 }


### PR DESCRIPTION

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
