### PR TITLE
HHH-19429 Fix potential ConcurrentModificationException in AbstractSqmPath

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/domain/AbstractSqmPath.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/domain/AbstractSqmPath.java
@@ -6,10 +6,10 @@ package org.hibernate.query.sqm.tree.domain;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Consumer;
 
 import org.hibernate.AssertionFailure;
@@ -117,7 +117,7 @@ public abstract class AbstractSqmPath<T> extends AbstractSqmExpression<T> implem
 	public void registerReusablePath(SqmPath<?> path) {
 		assert path.getLhs() == this;
 		if ( reusablePaths == null ) {
-			reusablePaths = new HashMap<>();
+			reusablePaths = new ConcurrentHashMap<>();
 		}
 		final String relativeName = path.getNavigablePath().getLocalName();
 		final SqmPath<?> previous = reusablePaths.put( relativeName, path );
@@ -207,7 +207,7 @@ public abstract class AbstractSqmPath<T> extends AbstractSqmExpression<T> implem
 		final SqmPathSource<?> intermediatePathSource =
 				getResolvedModel().getIntermediatePathSource( pathSource );
 		if ( reusablePaths == null ) {
-			reusablePaths = new HashMap<>();
+			reusablePaths = new ConcurrentHashMap<>();
 			final SqmPath<X> path = pathSource.createSqmPath( this, intermediatePathSource );
 			reusablePaths.put( attributeName, path );
 			return path;

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/sqm/ConcurrentQueryCreationTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/sqm/ConcurrentQueryCreationTest.java
@@ -1,0 +1,195 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.sqm;
+
+import java.util.List;
+import java.util.concurrent.CompletionService;
+import java.util.concurrent.ExecutorCompletionService;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
+
+import org.hibernate.cfg.Configuration;
+import org.hibernate.cfg.Environment;
+import org.hibernate.engine.spi.SessionImplementor;
+
+import org.hibernate.testing.junit4.BaseCoreFunctionalTestCase;
+import org.hibernate.testing.orm.junit.JiraKey;
+import org.junit.Test;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Inheritance;
+import jakarta.persistence.InheritanceType;
+import jakarta.persistence.Version;
+
+import static org.junit.Assert.assertEquals;
+
+@JiraKey(value = "HHH-19429")
+public class ConcurrentQueryCreationTest extends BaseCoreFunctionalTestCase {
+
+	private static final int NUM_THREADS = 32;
+
+	@Override
+	protected void configure(Configuration configuration) {
+		super.configure( configuration );
+		configuration.setProperty( Environment.POOL_SIZE, Integer.toString( NUM_THREADS ) );
+	}
+
+	@Test
+	public void versionedUpdate() throws Exception {
+		Consumer<SessionImplementor> action = session -> {
+			SimpleEntity entity = new SimpleEntity( "jack" );
+			session.persist( entity );
+			session.createMutationQuery( "UPDATE VERSIONED SimpleEntity e SET e.name = :name WHERE e.id = :id" )
+					.setParameter( "id", entity.getId() )
+					.setParameter( "name", "new name" )
+					.executeUpdate();
+		};
+
+		runConcurrently( action );
+	}
+
+	@Test
+	public void queryWithTreat() throws Exception {
+		Consumer<SessionImplementor> action = session -> {
+			SpecificEntity specificEntity = new SpecificEntity( "some name" );
+			session.persist( specificEntity );
+			session.persist( new OtherSpecificEntity( "some name" ) );
+
+			List<Long> results = session.createQuery(
+							"""
+									SELECT COUNT(*) FROM ParentEntity e WHERE e.id = :id
+									AND (
+										TREAT(e as SpecificEntity).name = :name
+									OR
+										TREAT(e as OtherSpecificEntity).name = :name
+									)""", Long.class
+					)
+					.setParameter( "id", specificEntity.getId() )
+					.setParameter( "name", "some name" )
+					.getResultList();
+
+			assertEquals( 1, results.size() );
+			assertEquals( 1L, results.get( 0 ).longValue() );
+		};
+
+		runConcurrently( action );
+	}
+
+	private void runConcurrently(Consumer<SessionImplementor> action) throws Exception {
+		ExecutorService executor = Executors.newFixedThreadPool( NUM_THREADS );
+		try {
+			CompletionService<Void> completionService = new ExecutorCompletionService<>( executor );
+
+			for ( int round = 0; round < 100; round++ ) {
+				for ( int i = 0; i < NUM_THREADS; i++ ) {
+					completionService.submit( () -> {
+						inTransaction( action );
+						return null;
+					} );
+				}
+
+				for ( int i = 0; i < NUM_THREADS; i++ ) {
+					completionService.take().get( 1, TimeUnit.MINUTES );
+				}
+
+				rebuildSessionFactory();
+			}
+		}
+		finally {
+			executor.shutdown();
+			executor.awaitTermination( 1, TimeUnit.MINUTES );
+		}
+	}
+
+	@Override
+	protected Class<?>[] getAnnotatedClasses() {
+		return new Class<?>[] {
+				SimpleEntity.class,
+				ParentEntity.class,
+				SpecificEntity.class,
+				OtherSpecificEntity.class
+		};
+	}
+
+	@Override
+	protected boolean isCleanupTestDataRequired() {
+		return true;
+	}
+
+	@Entity(name = "SimpleEntity")
+	public static class SimpleEntity {
+		@Id
+		@GeneratedValue
+		private Integer id;
+
+		@Version
+		private Integer version;
+
+		private String name;
+
+		SimpleEntity() {
+		}
+
+		SimpleEntity(String name) {
+			this.name = name;
+		}
+
+		public Integer getId() {
+			return id;
+		}
+
+		public void setId(Integer id) {
+			this.id = id;
+		}
+
+		public String getName() {
+			return name;
+		}
+
+		public void setName(String name) {
+			this.name = name;
+		}
+	}
+
+	@Entity(name = "ParentEntity")
+	@Inheritance(strategy = InheritanceType.JOINED)
+	public static class ParentEntity {
+		@Id
+		@GeneratedValue
+		private Integer id;
+
+		public Integer getId() {
+			return id;
+		}
+	}
+
+	@Entity(name = "SpecificEntity")
+	public static class SpecificEntity extends ParentEntity {
+		private String name;
+
+		public SpecificEntity() {
+		}
+
+		public SpecificEntity(String name) {
+			this.name = name;
+		}
+	}
+
+	@Entity(name = "OtherSpecificEntity")
+	public static class OtherSpecificEntity extends ParentEntity {
+		private String name;
+
+		public OtherSpecificEntity() {
+		}
+
+		public OtherSpecificEntity(String name) {
+			this.name = name;
+		}
+	}
+}


### PR DESCRIPTION
Add a concurrency test that reliably reproduces the `ConcurrentModificationException` inside `AbstractSqmPath.resolvePath` when multiple threads execute a query. See [HHH-19429](https://hibernate.atlassian.net/browse/HHH-19429) for more details.

We fix the potential `ConcurrentModificationException` by switching from `HashMap` to `ConcurrentHashMap` in `AbstractSqmPath`.

Please let me know what I need to adjust to match Hibernate’s project rules and conventions.

<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------


[HHH-19429]: https://hibernate.atlassian.net/browse/HHH-19429?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ