### PR TITLE
HHH-19668 Reduce size of collections held in ParameterInterpretationImpl before storing them in the cache

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/internal/util/collections/CollectionHelper.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/util/collections/CollectionHelper.java
@@ -343,6 +343,9 @@ public final class CollectionHelper {
 	 * The goal is to save memory.
 	 */
 	public static <K, V> Map<K, V> toSmallMap(final Map<K, V> map) {
+		if ( map == null ) {
+			return emptyMap();
+		}
 		return switch ( map.size() ) {
 			case 0 -> emptyMap();
 			case 1 -> {
@@ -363,6 +366,9 @@ public final class CollectionHelper {
 	 * The goal is to save memory.
 	 */
 	public static <V> List<V> toSmallList(ArrayList<V> arrayList) {
+		if ( arrayList == null ) {
+			return emptyList();
+		}
 		return switch ( arrayList.size() ) {
 			case 0 -> emptyList();
 			case 1 -> singletonList( arrayList.get( 0 ) );

--- a/hibernate-core/src/main/java/org/hibernate/query/sql/internal/NativeQueryImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sql/internal/NativeQueryImpl.java
@@ -128,6 +128,8 @@ import static org.hibernate.internal.util.StringHelper.unqualify;
 import static org.hibernate.internal.util.collections.CollectionHelper.isEmpty;
 import static org.hibernate.internal.util.collections.CollectionHelper.isNotEmpty;
 import static org.hibernate.internal.util.collections.CollectionHelper.makeCopy;
+import static org.hibernate.internal.util.collections.CollectionHelper.toSmallList;
+import static org.hibernate.internal.util.collections.CollectionHelper.toSmallMap;
 import static org.hibernate.internal.util.type.PrimitiveWrapperHelper.getDescriptorByPrimitiveType;
 import static org.hibernate.jpa.HibernateHints.HINT_NATIVE_LOCK_MODE;
 import static org.hibernate.query.results.internal.Builders.resultClassBuilder;
@@ -1742,9 +1744,9 @@ public class NativeQueryImpl<R>
 
 		public ParameterInterpretationImpl(ParameterRecognizerImpl parameterRecognizer) {
 			this.sqlString = parameterRecognizer.getAdjustedSqlString();
-			this.parameterList = parameterRecognizer.getParameterList();
-			this.positionalParameters = parameterRecognizer.getPositionalQueryParameters();
-			this.namedParameters = parameterRecognizer.getNamedQueryParameters();
+			this.parameterList = toSmallList( parameterRecognizer.getParameterList() );
+			this.positionalParameters = toSmallMap( parameterRecognizer.getPositionalQueryParameters() );
+			this.namedParameters = toSmallMap( parameterRecognizer.getNamedQueryParameters() );
 		}
 
 		@Override

--- a/hibernate-core/src/main/java/org/hibernate/query/sql/internal/ParameterRecognizerImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sql/internal/ParameterRecognizerImpl.java
@@ -7,7 +7,6 @@ package org.hibernate.query.sql.internal;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 
 import org.hibernate.QueryException;
@@ -36,7 +35,7 @@ public class ParameterRecognizerImpl implements ParameterRecognizer {
 
 	private int ordinalParameterImplicitPosition;
 
-	private List<ParameterOccurrence> parameterList;
+	private ArrayList<ParameterOccurrence> parameterList;
 	private final StringBuilder sqlStringBuffer = new StringBuilder();
 
 	public ParameterRecognizerImpl() {
@@ -81,7 +80,7 @@ public class ParameterRecognizerImpl implements ParameterRecognizer {
 		return positionalQueryParameters;
 	}
 
-	public List<ParameterOccurrence> getParameterList() {
+	public ArrayList<ParameterOccurrence> getParameterList() {
 		return parameterList;
 	}
 


### PR DESCRIPTION
Instances of ParameterInterpretationImpl are being held in the interpretation cache for native queries. We had reports of these elements having a substantial impact on memory consumption.

A simple improvement is to ensure the collections being held on by the container object are minimized; some more substantial improvements could also be investigated but I’ll leave those for another time.

https://hibernate.atlassian.net/browse/HHH-19668

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
