### PR TITLE
HHH-19015 - Deprecate Session#byId in favor of FindOptions

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/Session.java
+++ b/hibernate-core/src/main/java/org/hibernate/Session.java
@@ -1101,7 +1101,12 @@ public interface Session extends SharedSessionContract, EntityManager {
 	 * @return an instance of {@link IdentifierLoadAccess} for executing the lookup
 	 *
 	 * @throws HibernateException If the given class does not resolve as a mapped entity
+	 *
+	 * @deprecated This method will be removed.
+	 *             Use {@link #find(Class, Object, FindOption...)} instead.
+	 *             See {@link FindOption}.
 	 */
+	@Deprecated(since = "7.1", forRemoval = true)
 	<T> IdentifierLoadAccess<T> byId(Class<T> entityClass);
 
 	/**
@@ -1113,7 +1118,12 @@ public interface Session extends SharedSessionContract, EntityManager {
 	 * @return an instance of {@link IdentifierLoadAccess} for executing the lookup
 	 *
 	 * @throws HibernateException If the given name does not resolve to a mapped entity
+	 *
+	 * @deprecated This method will be removed.
+	 *             Use {@link #find(Class, Object, FindOption...)} instead.
+	 *             See {@link FindOption}.
 	 */
+	@Deprecated(since = "7.1", forRemoval = true)
 	<T> IdentifierLoadAccess<T> byId(String entityName);
 
 	/**


### PR DESCRIPTION
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-19015
<!-- Hibernate GitHub Bot issue links end -->