### PR TITLE
HHH-19673 hibernate-gradle-plugin 7.0.0.CR1 wrongly requires Java 21+

### DIFF
--- a/hibernate-integrationtest-java-modules/hibernate-integrationtest-java-modules.gradle
+++ b/hibernate-integrationtest-java-modules/hibernate-integrationtest-java-modules.gradle
@@ -7,6 +7,11 @@ plugins {
 	id "local.java-module"
 }
 
+def skipJacoco = project.hasProperty('skipJacoco') ? project.getProperty('skipJacoco').toBoolean() : false
+if (!skipJacoco) {
+	plugins.apply('jacoco')
+}
+
 description = 'Integration tests for running Hibernate ORM in the Java module path'
 
 // See https://docs.gradle.org/6.7.1/userguide/java_testing.html#blackbox_integration_testing

--- a/local-build-plugins/src/main/groovy/local.java-module.gradle
+++ b/local-build-plugins/src/main/groovy/local.java-module.gradle
@@ -26,11 +26,6 @@ def jpaVersion = ormBuildDetails.jpaVersion
 def java9ModuleNameBase = project.name.startsWith( 'hibernate-' ) ? name.drop( 'hibernate-'.length() ): name
 def java9ModuleName = "org.hibernate.orm.$java9ModuleNameBase".replace('-','.')
 
-def skipJacoco = project.hasProperty('skipJacoco') ? project.getProperty('skipJacoco').toBoolean() : false
-if (!skipJacoco) {
-    plugins.apply('jacoco')
-}
-
 sourceSets {
     test {
         resources {

--- a/local-build-plugins/src/main/groovy/local.publishing-java-module.gradle
+++ b/local-build-plugins/src/main/groovy/local.publishing-java-module.gradle
@@ -9,6 +9,13 @@ plugins {
     id "local.code-quality"
 }
 
+// Ideally this should be in `local.java-module.gradle`,
+// but we need to skip this in hibernate-gradle-plugin.
+def skipJacoco = project.hasProperty('skipJacoco') ? project.getProperty('skipJacoco').toBoolean() : false
+if (!skipJacoco) {
+    plugins.apply('jacoco')
+}
+
 configurations {
     javadocSources {
         description = "All Java sources for the project's Javadoc"

--- a/tooling/hibernate-gradle-plugin/hibernate-gradle-plugin.gradle
+++ b/tooling/hibernate-gradle-plugin/hibernate-gradle-plugin.gradle
@@ -6,7 +6,7 @@ import org.apache.tools.ant.filters.ReplaceTokens
 
 plugins {
 	id 'java-gradle-plugin'
-	id "local.module"
+	id "local.java-module"
 	id "local.javadoc"
 	id "local.code-quality"
 


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-19673

It seems this one-liner does the trick for the bytecode version of compiled class files (obviously, since that's handled by the `java-module` plugin). I'm hoping this is all Gradle needs to accept using a module in a project using Java 17.

----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------