### PR TITLE
HHH-19671 - Avoid issuing a callback warning when a class defines an IdClass and has lifecycle callbacks

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/jpa/event/internal/CallbackDefinitionResolver.java
+++ b/hibernate-core/src/main/java/org/hibernate/jpa/event/internal/CallbackDefinitionResolver.java
@@ -17,6 +17,7 @@ import org.hibernate.boot.spi.InFlightMetadataCollector;
 import org.hibernate.internal.util.ReflectHelper;
 import org.hibernate.jpa.event.spi.CallbackDefinition;
 import org.hibernate.jpa.event.spi.CallbackType;
+import org.hibernate.mapping.Component;
 import org.hibernate.mapping.PersistentClass;
 import org.hibernate.mapping.Property;
 import org.hibernate.models.spi.AnnotationDescriptor;
@@ -282,7 +283,9 @@ public final class CallbackDefinitionResolver {
 		//       code was added by HHH-12326
 		collector.addSecondPass( persistentClasses -> {
 			for ( Property property : persistentClass.getDeclaredProperties() ) {
-				if ( property.isComposite() ) {
+			if ( property.getValue() instanceof Component component
+					// embedded components don't have their own class, so no need to check callbacks (see HHH-19671)
+					&& !component.isEmbedded() ) {
 					try {
 						final Class<?> mappedClass = persistentClass.getMappedClass();
 						for ( CallbackType type : CallbackType.values() ) {


### PR DESCRIPTION
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-19671
<!-- Hibernate GitHub Bot issue links end -->