### PR TITLE
[7.0] HHH-19675 JdbcTypeRegistry#hasRegisteredDescriptor should account for constructed types

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/jdbc/spi/JdbcTypeRegistry.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/jdbc/spi/JdbcTypeRegistry.java
@@ -297,7 +297,17 @@ public class JdbcTypeRegistry implements JdbcTypeBaseline.BaselineTarget, Serial
 	public boolean hasRegisteredDescriptor(int jdbcTypeCode) {
 		return descriptorMap.containsKey( jdbcTypeCode )
 			|| isStandardTypeCode( jdbcTypeCode )
-			|| JdbcTypeFamilyInformation.INSTANCE.locateJdbcTypeFamilyByTypeCode( jdbcTypeCode ) != null;
+			|| JdbcTypeFamilyInformation.INSTANCE.locateJdbcTypeFamilyByTypeCode( jdbcTypeCode ) != null
+			|| locateConstructedJdbcType( jdbcTypeCode );
+	}
+
+	private boolean locateConstructedJdbcType(int jdbcTypeCode) {
+		for ( TypeConstructedJdbcTypeKey key : typeConstructorDescriptorMap.keySet() ) {
+			if ( key.typeCode() == jdbcTypeCode ) {
+				return true;
+			}
+		}
+		return false;
 	}
 
 	public JdbcTypeConstructor getConstructor(int jdbcTypeCode) {


### PR DESCRIPTION
<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

https://hibernate.atlassian.net/browse/HHH-19675

Backport of https://github.com/hibernate/hibernate-orm/pull/10681

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
