### PR TITLE
Remove additional uses of the deprecated gradle CloseableResource interface

### DIFF
--- a/hibernate-testing/src/main/java/org/hibernate/testing/orm/junit/DomainModelExtension.java
+++ b/hibernate-testing/src/main/java/org/hibernate/testing/orm/junit/DomainModelExtension.java
@@ -300,7 +300,7 @@ public class DomainModelExtension
 		return false;
 	}
 
-	public static class DomainModelScopeImpl implements DomainModelScope, ExtensionContext.Store.CloseableResource {
+	public static class DomainModelScopeImpl implements DomainModelScope, AutoCloseable {
 		private final ServiceRegistryScope serviceRegistryScope;
 		private final DomainModelProducer producer;
 

--- a/hibernate-testing/src/main/java/org/hibernate/testing/orm/junit/ServiceRegistryExtension.java
+++ b/hibernate-testing/src/main/java/org/hibernate/testing/orm/junit/ServiceRegistryExtension.java
@@ -331,7 +331,7 @@ public class ServiceRegistryExtension
 		throw throwable;
 	}
 
-	private static class ServiceRegistryScopeImpl implements ServiceRegistryScope, ExtensionContext.Store.CloseableResource {
+	private static class ServiceRegistryScopeImpl implements ServiceRegistryScope, AutoCloseable {
 		private BootstrapServiceRegistryProducer bsrProducer;
 		private ServiceRegistryProducer ssrProducer;
 

--- a/hibernate-testing/src/main/java/org/hibernate/testing/orm/junit/SessionFactoryExtension.java
+++ b/hibernate-testing/src/main/java/org/hibernate/testing/orm/junit/SessionFactoryExtension.java
@@ -232,7 +232,7 @@ public class SessionFactoryExtension
 		throw throwable;
 	}
 
-	private static class SessionFactoryScopeImpl implements SessionFactoryScope, ExtensionContext.Store.CloseableResource {
+	private static class SessionFactoryScopeImpl implements SessionFactoryScope, AutoCloseable {
 		private final DomainModelScope modelScope;
 		private final SessionFactoryProducer producer;
 


### PR DESCRIPTION
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
