### PR TITLE
get rid of an unused parameter in constrictors of XxxxAttributeImpl

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/metamodel/internal/AttributeFactory.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/internal/AttributeFactory.java
@@ -12,7 +12,6 @@ import java.util.HashMap;
 
 import org.hibernate.AssertionFailure;
 import org.hibernate.PropertyNotFoundException;
-import org.hibernate.boot.model.convert.spi.ConverterDescriptor;
 import org.hibernate.boot.registry.classloading.spi.ClassLoaderService;
 import org.hibernate.internal.CoreLogging;
 import org.hibernate.internal.CoreMessageLogger;
@@ -145,8 +144,7 @@ public class AttributeFactory {
 				false,
 				false,
 				property.isOptional(),
-				property.isGeneric(),
-				metadataContext
+				property.isGeneric()
 		);
 	}
 
@@ -188,8 +186,7 @@ public class AttributeFactory {
 				(SqmDomainType<Y>) domainType,
 				attributeMetadata.getMember(),
 				attributeMetadata.getAttributeClassification(),
-				property.isGeneric(),
-				context
+				property.isGeneric()
 		);
 	}
 
@@ -218,8 +215,7 @@ public class AttributeFactory {
 				property.getName(),
 				attributeMetadata.getAttributeClassification(),
 				(SqmDomainType<Y>) domainType,
-				attributeMetadata.getMember(),
-				context
+				attributeMetadata.getMember()
 		);
 	}
 
@@ -382,8 +378,9 @@ public class AttributeFactory {
 			DomainType<?> metaModelType,
 			MetadataContext context) {
 		if ( typeContext.getValueClassification() == ValueClassification.BASIC ) {
-			final ConverterDescriptor descriptor =
-					( (SimpleValue) typeContext.getHibernateValue() ).getJpaAttributeConverterDescriptor();
+			final var descriptor =
+					( (SimpleValue) typeContext.getHibernateValue() )
+							.getJpaAttributeConverterDescriptor();
 			if ( descriptor != null ) {
 				return context.getJavaTypeRegistry().resolveDescriptor(
 						descriptor.getRelationalValueResolvedType().getErasedType()

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/internal/AbstractPluralAttribute.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/internal/AbstractPluralAttribute.java
@@ -8,7 +8,6 @@ import java.io.Serializable;
 import java.util.Collection;
 
 import org.hibernate.metamodel.CollectionClassification;
-import org.hibernate.metamodel.internal.MetadataContext;
 import org.hibernate.metamodel.mapping.CollectionPart;
 import org.hibernate.metamodel.model.domain.SimpleDomainType;
 import org.hibernate.query.sqm.tree.domain.SqmPluralPersistentAttribute;
@@ -37,9 +36,7 @@ public abstract class AbstractPluralAttribute<D, C, E>
 	private final CollectionClassification classification;
 	private final SqmPathSource<E> elementPathSource;
 
-	protected AbstractPluralAttribute(
-			PluralAttributeBuilder<D,C,E,?> builder,
-			MetadataContext metadataContext) {
+	protected AbstractPluralAttribute(PluralAttributeBuilder<D,C,E,?> builder) {
 		super(
 				builder.getDeclaringType(),
 				builder.getProperty().getName(),

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/internal/BagAttributeImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/internal/BagAttributeImpl.java
@@ -6,7 +6,6 @@ package org.hibernate.metamodel.model.domain.internal;
 
 import java.util.Collection;
 
-import org.hibernate.metamodel.internal.MetadataContext;
 import org.hibernate.query.hql.spi.SqmCreationState;
 import org.hibernate.query.sqm.tree.SqmJoinType;
 import org.hibernate.query.sqm.tree.domain.SqmBagJoin;
@@ -21,8 +20,8 @@ public class BagAttributeImpl<X, E>
 		extends AbstractPluralAttribute<X, Collection<E>, E>
 		implements SqmBagPersistentAttribute<X, E> {
 
-	public BagAttributeImpl(PluralAttributeBuilder<X, Collection<E>, E, ?> xceBuilder, MetadataContext metadataContext) {
-		super( xceBuilder, metadataContext );
+	public BagAttributeImpl(PluralAttributeBuilder<X, Collection<E>, E, ?> xceBuilder) {
+		super( xceBuilder );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/internal/ListAttributeImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/internal/ListAttributeImpl.java
@@ -6,7 +6,6 @@ package org.hibernate.metamodel.model.domain.internal;
 
 import java.util.List;
 
-import org.hibernate.metamodel.internal.MetadataContext;
 import org.hibernate.metamodel.mapping.CollectionPart;
 import org.hibernate.query.sqm.SqmPathSource;
 import org.hibernate.query.hql.spi.SqmCreationState;
@@ -25,8 +24,8 @@ public class ListAttributeImpl<X, E>
 		implements SqmListPersistentAttribute<X, E> {
 	private final SqmPathSource<Integer> indexPathSource;
 
-	public ListAttributeImpl(PluralAttributeBuilder<X, List<E>, E, ?> builder, MetadataContext metadataContext) {
-		super( builder, metadataContext );
+	public ListAttributeImpl(PluralAttributeBuilder<X, List<E>, E, ?> builder) {
+		super( builder );
 
 		//noinspection unchecked
 		this.indexPathSource = (SqmPathSource<Integer>) SqmMappingModelHelper.resolveSqmKeyPathSource(

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/internal/MapAttributeImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/internal/MapAttributeImpl.java
@@ -6,7 +6,6 @@ package org.hibernate.metamodel.model.domain.internal;
 
 import java.util.Map;
 
-import org.hibernate.metamodel.internal.MetadataContext;
 import org.hibernate.metamodel.mapping.CollectionPart;
 import org.hibernate.metamodel.model.domain.SimpleDomainType;
 import org.hibernate.query.sqm.SqmPathSource;
@@ -26,8 +25,8 @@ public class MapAttributeImpl<X, K, V>
 		implements SqmMapPersistentAttribute<X, K, V> {
 	private final SqmPathSource<K> keyPathSource;
 
-	public MapAttributeImpl(PluralAttributeBuilder<X, Map<K, V>, V, K> xceBuilder, MetadataContext metadataContext) {
-		super( xceBuilder, metadataContext );
+	public MapAttributeImpl(PluralAttributeBuilder<X, Map<K, V>, V, K> xceBuilder) {
+		super( xceBuilder );
 		keyPathSource = SqmMappingModelHelper.resolveSqmKeyPathSource(
 				xceBuilder.getListIndexOrMapKeyType(),
 				BindableType.PLURAL_ATTRIBUTE,

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/internal/PluralAttributeBuilder.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/internal/PluralAttributeBuilder.java
@@ -64,7 +64,6 @@ public class PluralAttributeBuilder<D, C, E, K> {
 		this.member = member;
 	}
 
-	@SuppressWarnings({ "unchecked", "rawtypes" })
 	public static <Y, X> PersistentAttribute<X, Y> build(
 			PluralAttributeMetadata<?,Y,?> attributeMetadata,
 			boolean isGeneric,
@@ -74,7 +73,7 @@ public class PluralAttributeBuilder<D, C, E, K> {
 				metadataContext.getTypeConfiguration().getJavaTypeRegistry()
 						.getDescriptor( attributeMetadata.getJavaType() );
 
-		final PluralAttributeBuilder builder = new PluralAttributeBuilder<>(
+		final var builder = new PluralAttributeBuilder<>(
 				attributeJtd,
 				isGeneric,
 				attributeMetadata.getAttributeClassification(),
@@ -87,35 +86,36 @@ public class PluralAttributeBuilder<D, C, E, K> {
 				attributeMetadata.getMember()
 		);
 
-		if ( Map.class.equals( attributeJtd.getJavaTypeClass() ) ) {
-			return new MapAttributeImpl( builder, metadataContext );
+		final Class<Y> javaClass = attributeJtd.getJavaTypeClass();
+		if ( Map.class.equals( javaClass ) ) {
+			return new MapAttributeImpl( builder );
 		}
-		else if ( Set.class.equals( attributeJtd.getJavaTypeClass() ) ) {
-			return new SetAttributeImpl( builder, metadataContext );
+		else if ( Set.class.equals( javaClass ) ) {
+			return new SetAttributeImpl( builder );
 		}
-		else if ( List.class.equals( attributeJtd.getJavaTypeClass() ) ) {
-			return new ListAttributeImpl( builder, metadataContext );
+		else if ( List.class.equals( javaClass ) ) {
+			return new ListAttributeImpl( builder );
 		}
-		else if ( Collection.class.equals( attributeJtd.getJavaTypeClass() ) ) {
-			return new BagAttributeImpl( builder, metadataContext );
+		else if ( Collection.class.equals( javaClass ) ) {
+			return new BagAttributeImpl( builder );
 		}
 
 		//apply loose rules
-		if ( attributeJtd.getJavaTypeClass().isArray() ) {
-			return new ListAttributeImpl( builder, metadataContext );
+		if ( javaClass.isArray() ) {
+			return new ListAttributeImpl( builder );
 		}
 
-		if ( Map.class.isAssignableFrom( attributeJtd.getJavaTypeClass() ) ) {
-			return new MapAttributeImpl( builder, metadataContext );
+		if ( Map.class.isAssignableFrom( javaClass ) ) {
+			return new MapAttributeImpl( builder );
 		}
-		else if ( Set.class.isAssignableFrom( attributeJtd.getJavaTypeClass() ) ) {
-			return new SetAttributeImpl( builder, metadataContext );
+		else if ( Set.class.isAssignableFrom( javaClass ) ) {
+			return new SetAttributeImpl( builder );
 		}
-		else if ( List.class.isAssignableFrom( attributeJtd.getJavaTypeClass() ) ) {
-			return new ListAttributeImpl( builder, metadataContext );
+		else if ( List.class.isAssignableFrom( javaClass ) ) {
+			return new ListAttributeImpl( builder );
 		}
-		else if ( Collection.class.isAssignableFrom( attributeJtd.getJavaTypeClass() ) ) {
-			return new BagAttributeImpl( builder, metadataContext );
+		else if ( Collection.class.isAssignableFrom( javaClass ) ) {
+			return new BagAttributeImpl( builder );
 		}
 
 		throw new UnsupportedMappingException( "Unknown collection: " + attributeJtd.getJavaType() );
@@ -124,13 +124,15 @@ public class PluralAttributeBuilder<D, C, E, K> {
 	private static SimpleDomainType<?> determineListIndexOrMapKeyType(
 			PluralAttributeMetadata<?,?,?> attributeMetadata,
 			MetadataContext metadataContext) {
-		if ( Map.class.isAssignableFrom( attributeMetadata.getJavaType() ) ) {
-			return (SimpleDomainType<?>) determineSimpleType( attributeMetadata.getMapKeyValueContext(), metadataContext );
+		final Class<?> javaType = attributeMetadata.getJavaType();
+		if ( Map.class.isAssignableFrom( javaType ) ) {
+			return (SimpleDomainType<?>)
+					determineSimpleType( attributeMetadata.getMapKeyValueContext(), metadataContext );
 		}
 
-		if ( List.class.isAssignableFrom( attributeMetadata.getJavaType() )
-				|| attributeMetadata.getJavaType().isArray() ) {
-			return metadataContext.getTypeConfiguration().getBasicTypeRegistry().getRegisteredType( Integer.class );
+		if ( List.class.isAssignableFrom( javaType ) || javaType.isArray() ) {
+			return metadataContext.getTypeConfiguration().getBasicTypeRegistry()
+					.getRegisteredType( Integer.class );
 		}
 
 		return null;

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/internal/SetAttributeImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/internal/SetAttributeImpl.java
@@ -6,7 +6,6 @@ package org.hibernate.metamodel.model.domain.internal;
 
 import java.util.Set;
 
-import org.hibernate.metamodel.internal.MetadataContext;
 import org.hibernate.query.hql.spi.SqmCreationState;
 import org.hibernate.query.sqm.tree.SqmJoinType;
 import org.hibernate.query.sqm.tree.domain.SqmSetJoin;
@@ -21,8 +20,8 @@ public class SetAttributeImpl<X, E>
 		extends AbstractPluralAttribute<X, Set<E>, E>
 		implements SqmSetPersistentAttribute<X, E> {
 
-	public SetAttributeImpl(PluralAttributeBuilder<X, Set<E>, E, ?> xceBuilder, MetadataContext metadataContext) {
-		super( xceBuilder, metadataContext );
+	public SetAttributeImpl(PluralAttributeBuilder<X, Set<E>, E, ?> xceBuilder) {
+		super( xceBuilder );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/internal/SingularAttributeImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/model/domain/internal/SingularAttributeImpl.java
@@ -8,7 +8,6 @@ import java.io.Serializable;
 import java.lang.reflect.Member;
 
 import org.hibernate.metamodel.AttributeClassification;
-import org.hibernate.metamodel.internal.MetadataContext;
 import org.hibernate.metamodel.mapping.CollectionPart;
 import org.hibernate.metamodel.model.domain.AnyMappingDomainType;
 import org.hibernate.metamodel.model.domain.IdentifiableDomainType;
@@ -63,8 +62,7 @@ public class SingularAttributeImpl<D,J>
 			boolean isIdentifier,
 			boolean isVersion,
 			boolean isOptional,
-			boolean isGeneric,
-			MetadataContext metadataContext) {
+			boolean isGeneric) {
 		super(
 				declaringType,
 				name,
@@ -210,8 +208,7 @@ public class SingularAttributeImpl<D,J>
 				SqmDomainType<J> attributeType,
 				Member member,
 				AttributeClassification attributeClassification,
-				boolean isGeneric,
-				MetadataContext metadataContext) {
+				boolean isGeneric) {
 			super(
 					declaringType,
 					name,
@@ -222,8 +219,7 @@ public class SingularAttributeImpl<D,J>
 					true,
 					false,
 					false,
-					isGeneric,
-					metadataContext
+					isGeneric
 			);
 		}
 
@@ -260,8 +256,7 @@ public class SingularAttributeImpl<D,J>
 				String name,
 				AttributeClassification attributeClassification,
 				SqmDomainType<Y> attributeType,
-				Member member,
-				MetadataContext metadataContext) {
+				Member member) {
 			super(
 					declaringType,
 					name,
@@ -272,8 +267,7 @@ public class SingularAttributeImpl<D,J>
 					false,
 					true,
 					false,
-					false,
-					metadataContext
+					false
 			);
 		}
 	}

--- a/tooling/metamodel-generator/src/main/java/org/hibernate/processor/validation/MockSessionFactory.java
+++ b/tooling/metamodel-generator/src/main/java/org/hibernate/processor/validation/MockSessionFactory.java
@@ -51,9 +51,6 @@ import org.hibernate.jpa.spi.MutableJpaCompliance;
 import org.hibernate.mapping.Property;
 import org.hibernate.metamodel.AttributeClassification;
 import org.hibernate.metamodel.CollectionClassification;
-import org.hibernate.metamodel.internal.JpaMetamodelPopulationSetting;
-import org.hibernate.metamodel.internal.JpaStaticMetamodelPopulationSetting;
-import org.hibernate.metamodel.internal.MetadataContext;
 import org.hibernate.metamodel.mapping.EntityIdentifierMapping;
 import org.hibernate.metamodel.mapping.JdbcMapping;
 import org.hibernate.metamodel.model.domain.BasicDomainType;
@@ -125,6 +122,7 @@ import org.hibernate.type.descriptor.jdbc.JdbcTypeIndicators;
 import org.hibernate.type.descriptor.jdbc.ObjectJdbcType;
 import org.hibernate.type.spi.TypeConfiguration;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -160,7 +158,7 @@ public abstract class MockSessionFactory
 	private final MappingMetamodelImpl metamodel;
 
 	private final MetadataImplementor bootModel;
-	private final MetadataContext metadataContext;
+//	private final MetadataContext metadataContext;
 
 	private final NodeBuilder nodeBuilder;
 	private final SqlTranslationEngine sqlTranslationEngine;
@@ -190,7 +188,7 @@ public abstract class MockSessionFactory
 						true,
 						classLoaderService,
 						new StrategySelectorImpl( classLoaderService ),
-						() -> emptyList()
+						Collections::emptyList
 				),
 //				new BootstrapServiceRegistryBuilder().applyClassLoaderService( classLoaderService ).build(),
 				singletonList(MockJdbcServicesInitiator.INSTANCE),
@@ -225,15 +223,15 @@ public abstract class MockSessionFactory
 				this
 		);
 
-		metadataContext = new MetadataContext(
-				metamodel.getJpaMetamodel(),
-				metamodel,
-				bootModel,
-				JpaStaticMetamodelPopulationSetting.DISABLED,
-				JpaMetamodelPopulationSetting.DISABLED,
-				this,
-				classLoaderService
-		);
+//		metadataContext = new MetadataContext(
+//				metamodel.getJpaMetamodel(),
+//				metamodel,
+//				bootModel,
+//				JpaStaticMetamodelPopulationSetting.DISABLED,
+//				JpaMetamodelPopulationSetting.DISABLED,
+//				this,
+//				classLoaderService
+//		);
 
 		typeConfiguration = new TypeConfiguration();
 		typeConfiguration.scope((MetadataBuildingContext) this);
@@ -962,8 +960,7 @@ public abstract class MockSessionFactory
 						false,
 						true,
 						false,
-						false,
-						metadataContext
+						false
 				);
 			}
 		}
@@ -1077,8 +1074,7 @@ public abstract class MockSessionFactory
 					false,
 					false,
 					true,
-					false,
-					metadataContext
+					false
 			);
 		}
 		else if ( type.isComponentType() ) {
@@ -1093,8 +1089,7 @@ public abstract class MockSessionFactory
 					false,
 					false,
 					true,
-					false,
-					metadataContext
+					false
 			);
 		}
 		else {
@@ -1110,8 +1105,7 @@ public abstract class MockSessionFactory
 					false,
 					false,
 					true,
-					false,
-					metadataContext
+					false
 			);
 		}
 	}
@@ -1169,8 +1163,7 @@ public abstract class MockSessionFactory
 							owner,
 							property,
 							null
-					),
-					metadataContext
+					)
 			);
 			case BAG, ID_BAG -> new BagAttributeImpl(
 					new PluralAttributeBuilder<>(
@@ -1183,8 +1176,7 @@ public abstract class MockSessionFactory
 							owner,
 							property,
 							null
-					),
-					metadataContext
+					)
 			);
 			case SET, SORTED_SET, ORDERED_SET -> new SetAttributeImpl(
 					new PluralAttributeBuilder<>(
@@ -1197,8 +1189,7 @@ public abstract class MockSessionFactory
 							owner,
 							property,
 							null
-					),
-					metadataContext
+					)
 			);
 			case MAP, SORTED_MAP, ORDERED_MAP -> new MapAttributeImpl(
 					new PluralAttributeBuilder<>(
@@ -1211,8 +1202,7 @@ public abstract class MockSessionFactory
 							owner,
 							property,
 							null
-					),
-					metadataContext
+					)
 			);
 			default -> null;
 		};


### PR DESCRIPTION
and thereby simplify the MockSessionFactory

<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

[Please describe here what your change is about]

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
