### PR TITLE
HHH-19682 - Add Support for GaussDB Lock Timeout (lockwait_timeout)

### DIFF
--- a/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/lock/internal/GaussDBLockingSupport.java
+++ b/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/lock/internal/GaussDBLockingSupport.java
@@ -94,19 +94,30 @@ public class GaussDBLockingSupport implements LockingSupport, LockingSupport.Met
 						return Timeouts.WAIT_FOREVER;
 					}
 					if ( value.endsWith( "min" ) ) {
-						final int min = Integer.parseInt( value.substring( 0, value.length() - 3 ) );
-						return Timeout.milliseconds( min * 60 * 1000 );
+						final int minute = getTimeout( value, 3 );
+						return Timeout.milliseconds( minute * 60 * 1000);
 					}
 					else if ( value.endsWith( "s" ) ) {
-						final int second = Integer.parseInt( value.substring( 0, value.length() - 1 ) );
-						return Timeout.seconds(second);
+						final int seconds  = getTimeout( value, 1 );
+						return Timeout.seconds(seconds);
 					}
-					final int milliseconds = Integer.parseInt( value.substring( 0, value.length() - 2 ) );
+					final int milliseconds  = getTimeout( value, 2 );
 					return Timeout.milliseconds(milliseconds);
 				},
 				connection,
 				factory
 		);
+	}
+
+	private static int getTimeout(String value, int unitLength) {
+		final int number;
+		try {
+			number = Integer.parseInt( value.substring( 0, value.length() - unitLength ) );
+		}
+		catch (NumberFormatException e) {
+			throw new RuntimeException( e );
+		}
+		return number;
 	}
 
 	@Override

--- a/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/lock/internal/GaussDBLockingSupport.java
+++ b/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/lock/internal/GaussDBLockingSupport.java
@@ -4,11 +4,23 @@
  */
 package org.hibernate.community.dialect.lock.internal;
 
+import jakarta.persistence.Timeout;
+import org.hibernate.HibernateException;
+import org.hibernate.Timeouts;
 import org.hibernate.dialect.RowLockStrategy;
+import org.hibernate.dialect.lock.internal.Helper;
 import org.hibernate.dialect.lock.spi.ConnectionLockTimeoutStrategy;
+import org.hibernate.dialect.lock.spi.LockTimeoutType;
 import org.hibernate.dialect.lock.spi.LockingSupport;
 import org.hibernate.dialect.lock.spi.OuterJoinLockingType;
+import org.hibernate.engine.spi.SessionFactoryImplementor;
 
+import java.sql.Connection;
+
+import static org.hibernate.Timeouts.NO_WAIT_MILLI;
+import static org.hibernate.Timeouts.SKIP_LOCKED_MILLI;
+import static org.hibernate.Timeouts.WAIT_FOREVER_MILLI;
+import static org.hibernate.dialect.lock.spi.LockTimeoutType.QUERY;
 
 
 /**
@@ -18,7 +30,17 @@ import org.hibernate.dialect.lock.spi.OuterJoinLockingType;
  */
 public class GaussDBLockingSupport implements LockingSupport, LockingSupport.Metadata, ConnectionLockTimeoutStrategy {
 	public static final LockingSupport LOCKING_SUPPORT = new GaussDBLockingSupport();
+	private final boolean supportsNoWait;
+	private final boolean supportsSkipLocked;
 
+	public GaussDBLockingSupport() {
+		this( true, true );
+	}
+
+	public GaussDBLockingSupport(boolean supportsNoWait, boolean supportsSkipLocked) {
+		this.supportsNoWait = supportsNoWait;
+		this.supportsSkipLocked = supportsSkipLocked;
+	}
 
 	@Override
 	public Metadata getMetadata() {
@@ -42,6 +64,71 @@ public class GaussDBLockingSupport implements LockingSupport, LockingSupport.Met
 
 	@Override
 	public Level getSupportedLevel() {
-		return Level.NONE;
+		return Level.SUPPORTED;
+	}
+
+	@Override
+	public LockTimeoutType getLockTimeoutType(Timeout timeout) {
+		return switch ( timeout.milliseconds() ) {
+			case NO_WAIT_MILLI -> supportsNoWait ? QUERY : LockTimeoutType.NONE;
+			case SKIP_LOCKED_MILLI -> supportsSkipLocked ? QUERY : LockTimeoutType.NONE;
+			case WAIT_FOREVER_MILLI -> LockTimeoutType.NONE;
+			// we can apply a timeout via the connection
+			default -> LockTimeoutType.CONNECTION;
+		};
+	}
+
+	@Override
+	public Timeout getLockTimeout(Connection connection, SessionFactoryImplementor factory) {
+		return Helper.getLockTimeout(
+				"select current_setting('lockwait_timeout')",
+				(resultSet) -> {
+					// even though lock_timeout is "in milliseconds", `current_setting`
+					// returns a String form which unfortunately varies depending on
+					// the actual value:
+					//		* for zero (no timeout), "0" is returned
+					//		* for non-zero, `{timeout-in-seconds}s` is returned (e.g. "4s")
+					// so we need to "parse" that form here
+					final String value = resultSet.getString( 1 );
+					if ( "0".equals( value ) ) {
+						return Timeouts.WAIT_FOREVER;
+					}
+					if ( value.endsWith( "min" ) ) {
+						final int min = Integer.parseInt( value.substring( 0, value.length() - 3 ) );
+						return Timeout.milliseconds( min * 60 * 1000 );
+					}
+					else if ( value.endsWith( "s" ) ) {
+						final int second = Integer.parseInt( value.substring( 0, value.length() - 1 ) );
+						return Timeout.seconds(second);
+					}
+					final int milliseconds = Integer.parseInt( value.substring( 0, value.length() - 2 ) );
+					return Timeout.milliseconds(milliseconds);
+				},
+				connection,
+				factory
+		);
+	}
+
+	@Override
+	public void setLockTimeout(Timeout timeout, Connection connection, SessionFactoryImplementor factory) {
+		Helper.setLockTimeout(
+				timeout,
+				(t) -> {
+					final int milliseconds = timeout.milliseconds();
+					if ( milliseconds == SKIP_LOCKED_MILLI ) {
+						throw new HibernateException( "Connection lock-timeout does not accept skip-locked" );
+					}
+
+					if ( milliseconds == NO_WAIT_MILLI ) {
+						throw new HibernateException( "Connection lock-timeout does not accept no-wait" );
+					}
+					return milliseconds == WAIT_FOREVER_MILLI
+							? 0
+							: milliseconds;
+				},
+				"set local lockwait_timeout = %s",
+				connection,
+				factory
+		);
 	}
 }

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/locking/options/ConnectionLockTimeoutTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/locking/options/ConnectionLockTimeoutTests.java
@@ -6,6 +6,7 @@ package org.hibernate.orm.test.locking.options;
 
 import jakarta.persistence.Timeout;
 import org.hibernate.Timeouts;
+import org.hibernate.community.dialect.GaussDBDialect;
 import org.hibernate.dialect.MySQLDialect;
 import org.hibernate.dialect.lock.spi.ConnectionLockTimeoutStrategy;
 import org.hibernate.dialect.lock.spi.LockingSupport;
@@ -34,6 +35,9 @@ public class ConnectionLockTimeoutTests {
 			final int expectedInitialValue;
 			if ( session.getDialect() instanceof MySQLDialect ) {
 				expectedInitialValue = 50;
+			}
+			else if ( session.getDialect() instanceof GaussDBDialect ) {
+				expectedInitialValue = 20 * 60 * 1000;
 			}
 			else {
 				expectedInitialValue = Timeouts.WAIT_FOREVER_MILLI;


### PR DESCRIPTION
<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->
The current Hibernate ORM implementation lacks proper support for GaussDB's lock timeout (lockwait_timeout). The following adaptations are required:

1. ​Correctly parse lockwait_timeout return values​ (support formats like "0", "4s", "20min", etc.).

2. ​**Support setting lock timeout via set local lockwait_timeout**​ (unit: milliseconds).

3. ​**Handle special cases for SKIP_LOCKED and NO_WAIT**​ (throw explicit exceptions if GaussDB does not support them).

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-19682
<!-- Hibernate GitHub Bot issue links end -->