### PR TITLE
document that 'io.agroal:agroal-pool' is no longer needed

### DIFF
--- a/documentation/src/main/asciidoc/introduction/Configuration.adoc
+++ b/documentation/src/main/asciidoc/introduction/Configuration.adoc
@@ -102,9 +102,7 @@ Optionally, you might also add any of the following additional features:
 | An {slf4j}[SLF4J] logging implementation |
 `org.apache.logging.log4j:log4j-core` +
 or `org.slf4j:slf4j-jdk14`
-| A JDBC connection pool, for example, {agroal}[Agroal] |
-`org.hibernate.orm:hibernate-agroal` +
-and `io.agroal:agroal-pool`
+| A JDBC connection pool, for example, {agroal}[Agroal] | `org.hibernate.orm:hibernate-agroal`
 | The {generator}[Hibernate Processor], especially if you're using Jakarta Data or the JPA criteria query API | `org.hibernate.orm:hibernate-processor`
 | The {query-validator}[Query Validator], for compile-time checking of HQL | `org.hibernate:query-validator`
 | {validator}[Hibernate Validator], an implementation of {bean-validation}[Bean Validation] |

--- a/documentation/src/main/asciidoc/introduction/Introduction.adoc
+++ b/documentation/src/main/asciidoc/introduction/Introduction.adoc
@@ -191,7 +191,6 @@ dependencies {
 
     // Agroal connection pool
     runtimeOnly 'org.hibernate.orm:hibernate-agroal:{fullVersion}'
-    runtimeOnly 'io.agroal:agroal-pool:2.7.1'
 
     // logging via Log4j
     runtimeOnly 'org.apache.logging.log4j:log4j-core:2.24.3'


### PR DESCRIPTION
the dependency is now transitive

<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

[Please describe here what your change is about]

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
