### PR TITLE
HHH-19693 - Upgrade Oracle JDBC driver to version 23.9.0.25.07

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -232,7 +232,7 @@ dependencyResolutionManagement {
             def mariadbVersion = version "mariadb", "3.5.3"
             def mssqlVersion = version "mssql", "12.10.1.jre11"
             def mysqlVersion = version "mysql", "9.4.0"
-            def oracleVersion = version "oracle", "23.8.0.25.04"
+            def oracleVersion = version "oracle", "23.9.0.25.07"
             def oracleJacksonOsonExtension = version "oracleJacksonOsonExtension", "1.0.4"
             def pgsqlVersion = version "pgsql", "42.7.7"
             def edbVersion = version "edb", "42.7.3.3"


### PR DESCRIPTION
This PR upgrades the Oracle JDBC driver to version 23.9.0.25.07 (latest one).

----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-19693
<!-- Hibernate GitHub Bot issue links end -->