### PR TITLE
HHH-19695 invalid SQL generation under DB2 dialect

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/dialect/DB2Dialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/DB2Dialect.java
@@ -195,6 +195,14 @@ public class DB2Dialect extends Dialect {
 		return MINIMUM_VERSION;
 	}
 
+	@Override
+	protected void registerDefaultKeywords() {
+		super.registerDefaultKeywords();
+		// Register DB2-specific keywords not covered by ANSI SQL
+		registerKeyword( "first" );
+		registerKeyword( "next" );
+	}
+
 	/**
 	 * DB2 LUW Version
 	 */

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/dialect/DB2DialectTestCase.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/dialect/DB2DialectTestCase.java
@@ -89,4 +89,15 @@ public class DB2DialectTestCase extends BaseUnitTestCase {
 				sql.contains("fetch next ? rows only")
 		);
 	}
+
+	@Test
+	public void testDB2KeywordsAreRegistered() {
+		// Test that DB2-specific keywords are properly registered
+		assertTrue("'first' keyword should be registered", dialect.getKeywords().contains("first"));
+		assertTrue("'next' keyword should be registered", dialect.getKeywords().contains("next"));
+		// Note: ANSI SQL keywords already cover 'fetch', 'rows', and 'only'
+		assertTrue("'fetch' keyword should be available (from ANSI SQL)", dialect.getKeywords().contains("fetch"));
+		assertTrue("'rows' keyword should be available (from ANSI SQL)", dialect.getKeywords().contains("rows"));
+		assertTrue("'only' keyword should be available (from ANSI SQL)", dialect.getKeywords().contains("only"));
+	}
 }

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/sql/Db2TemplateTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/sql/Db2TemplateTest.java
@@ -1,0 +1,60 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.sql;
+
+
+import org.hibernate.dialect.DB2Dialect;
+import org.hibernate.engine.spi.SessionFactoryImplementor;
+import org.hibernate.sql.Template;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.JiraKey;
+import org.hibernate.testing.orm.junit.RequiresDialect;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@SessionFactory
+@DomainModel
+@RequiresDialect( DB2Dialect.class )
+public class Db2TemplateTest {
+
+	@Test
+	@JiraKey("HHH-19695")
+	public void templateLiterals(SessionFactoryScope scope) {
+		SessionFactoryImplementor factory = scope.getSessionFactory();
+
+		// Test that dialect-specific keywords are NOT treated as column names
+		// These should remain as-is, not prefixed with table alias
+
+		// Test DB2-specific keywords first, next
+		assertWhereStringTemplate( "fetch first 10 rows only", "fetch first 10 rows only", factory );
+		assertWhereStringTemplate( "fetch next 5 rows only", "fetch next 5 rows only", factory );
+		assertWhereStringTemplate( "select * from table fetch first 1 row only","select * from table fetch first 1 row only", factory );
+
+		// Test that regular column names are still prefixed
+		assertWhereStringTemplate( "first_name", "{@}.first_name", factory );
+		assertWhereStringTemplate( "fetch_count", "{@}.fetch_count", factory );
+		assertWhereStringTemplate( "rows_processed", "{@}.rows_processed", factory );
+		assertWhereStringTemplate( "only_flag", "{@}.only_flag", factory );
+
+		// Test mixed scenarios where keywords and column names appear together
+		assertWhereStringTemplate( "select first_name from users fetch first 10 rows only",
+				"select {@}.first_name from users fetch first 10 rows only", factory );
+		assertWhereStringTemplate( "where fetch_count > 5 and fetch first 1 row only",
+				"where {@}.fetch_count > 5 and fetch first 1 row only", factory );
+	}
+
+	private static void assertWhereStringTemplate(String sql, String result, SessionFactoryImplementor factory) {
+		assertEquals( result,
+				Template.renderWhereStringTemplate(
+						sql,
+						factory.getJdbcServices().getDialect(),
+						factory.getTypeConfiguration()
+				) );
+	}
+
+}


### PR DESCRIPTION
Invalid SQL generated with using DB2 dialect.

The setup:

- An entity declares an attribute using a formula.
- The formula contains SQL.
- The SQL contains a DB2-specific or non-ansi keyword such as `first` or `next`

For example:
```
@Formula(“select count(*) from table where fetch_count > 5 fetch first row only")
private int calc;
```

Under Hibernate 7.0.6 this SQL will be rendered as follows:

`select count(*) from table v1_0 where fetch_count > 5 fetch v1_0.first row only`

The part  `v1_0.first` is not valid SQL and demonstrates that Hibernate has treated `first` as though it were a column reference.

This pull request fixes the issue.

----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-19695
<!-- Hibernate GitHub Bot issue links end -->