### PR TITLE
Skip some vector tests on Oracle due to a bug in version 23.9

### DIFF
--- a/hibernate-vector/src/test/java/org/hibernate/vector/OracleByteVectorTest.java
+++ b/hibernate-vector/src/test/java/org/hibernate/vector/OracleByteVectorTest.java
@@ -9,6 +9,7 @@ import java.util.List;
 import org.hibernate.annotations.Array;
 import org.hibernate.annotations.JdbcTypeCode;
 import org.hibernate.dialect.OracleDialect;
+import org.hibernate.testing.orm.junit.SkipForDialect;
 import org.hibernate.type.SqlTypes;
 
 import org.hibernate.testing.orm.junit.DomainModel;
@@ -168,6 +169,7 @@ public class OracleByteVectorTest {
 	}
 
 	@Test
+	@SkipForDialect(dialectClass = OracleDialect.class, reason = "Oracle 23.9 bug")
 	public void testVectorNorm(SessionFactoryScope scope) {
 		scope.inTransaction( em -> {
 			//tag::vector-norm-example[]

--- a/hibernate-vector/src/test/java/org/hibernate/vector/OracleDoubleVectorTest.java
+++ b/hibernate-vector/src/test/java/org/hibernate/vector/OracleDoubleVectorTest.java
@@ -9,6 +9,7 @@ import java.util.List;
 import org.hibernate.annotations.Array;
 import org.hibernate.annotations.JdbcTypeCode;
 import org.hibernate.dialect.OracleDialect;
+import org.hibernate.testing.orm.junit.SkipForDialect;
 import org.hibernate.type.SqlTypes;
 
 import org.hibernate.testing.orm.junit.DomainModel;
@@ -167,6 +168,7 @@ public class OracleDoubleVectorTest {
 	}
 
 	@Test
+	@SkipForDialect(dialectClass = OracleDialect.class, reason = "Oracle 23.9 bug")
 	public void testVectorNorm(SessionFactoryScope scope) {
 		scope.inTransaction( em -> {
 			//tag::vector-norm-example[]

--- a/hibernate-vector/src/test/java/org/hibernate/vector/OracleFloatVectorTest.java
+++ b/hibernate-vector/src/test/java/org/hibernate/vector/OracleFloatVectorTest.java
@@ -9,6 +9,7 @@ import java.util.List;
 import org.hibernate.annotations.Array;
 import org.hibernate.annotations.JdbcTypeCode;
 import org.hibernate.dialect.OracleDialect;
+import org.hibernate.testing.orm.junit.SkipForDialect;
 import org.hibernate.type.SqlTypes;
 
 import org.hibernate.testing.orm.junit.DomainModel;
@@ -186,6 +187,7 @@ public class OracleFloatVectorTest {
 	}
 
 	@Test
+	@SkipForDialect(dialectClass = OracleDialect.class, reason = "Oracle 23.9 bug")
 	public void testVectorNorm(SessionFactoryScope scope) {
 		scope.inTransaction( em -> {
 			//tag::vector-norm-example[]

--- a/hibernate-vector/src/test/java/org/hibernate/vector/OracleGenericVectorTest.java
+++ b/hibernate-vector/src/test/java/org/hibernate/vector/OracleGenericVectorTest.java
@@ -9,6 +9,7 @@ import java.util.List;
 import org.hibernate.annotations.Array;
 import org.hibernate.annotations.JdbcTypeCode;
 import org.hibernate.dialect.OracleDialect;
+import org.hibernate.testing.orm.junit.SkipForDialect;
 import org.hibernate.type.SqlTypes;
 
 import org.hibernate.testing.orm.junit.DomainModel;
@@ -187,6 +188,7 @@ public class OracleGenericVectorTest {
 	}
 
 	@Test
+	@SkipForDialect(dialectClass = OracleDialect.class, reason = "Oracle 23.9 bug")
 	public void testVectorNorm(SessionFactoryScope scope) {
 		scope.inTransaction( em -> {
 			//tag::vector-norm-example[]


### PR DESCRIPTION
<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

[Please describe here what your change is about]

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
