### PR TITLE
HHH-14082 Hibernate cannot determine its core version in modular configuration

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/Version.java
+++ b/hibernate-core/src/main/java/org/hibernate/Version.java
@@ -8,6 +8,7 @@ import org.hibernate.internal.CoreMessageLogger;
 import org.hibernate.internal.build.AllowSysOut;
 
 import java.lang.invoke.MethodHandles;
+import java.lang.module.ModuleDescriptor;
 
 import static org.jboss.logging.Logger.getMessageLogger;
 
@@ -21,8 +22,8 @@ public final class Version {
 	private static final String VERSION = initVersion();
 
 	private static String initVersion() {
-		final String version = Version.class.getPackage().getImplementationVersion();
-		return version != null ? version : "[WORKING]";
+		ModuleDescriptor moduleDescriptor = Version.class.getModule().getDescriptor() ;
+		return moduleDescriptor != null ? (moduleDescriptor.version().isPresent() ? moduleDescriptor.version().toString() : "[WORKING]") : "[WORKING]";
 	}
 
 	private Version() {


### PR DESCRIPTION
HHH-14082 Hibernate cannot determine it's core version in modular configuration

Currently the Version gets the information via: Version.class.getPackage().getImplementationVersion()
But in modular mode it should call this instead: Version.class.getModule().getDescriptor().version()

----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-14082
<!-- Hibernate GitHub Bot issue links end -->