### PR TITLE
HHH-18621 Restore hibernate.jdbc.batch_versioned_data function in H6

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/persister/entity/mutation/AbstractMutationCoordinator.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/entity/mutation/AbstractMutationCoordinator.java
@@ -68,7 +68,10 @@ public abstract class AbstractMutationCoordinator {
 		if ( !dynamicUpdate
 				&& !entityPersister().optimisticLockStyle().isAllOrDirty()
 				&& session.getTransactionCoordinator() != null
-				&& session.getTransactionCoordinator().isTransactionActive() ) {
+				&& session.getTransactionCoordinator().isTransactionActive()
+				&& (
+						session.getSessionFactory().getSessionFactoryOptions().isJdbcBatchVersionedData()
+						|| !entityPersister().isVersioned() ) ) {
 			return this::getBatchKey;
 		}
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/batch/BatchOffOnlyForOptimisticallyLocked.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/batch/BatchOffOnlyForOptimisticallyLocked.java
@@ -1,0 +1,72 @@
+package org.hibernate.orm.test.batch;
+
+import java.io.Serializable;
+import java.util.List;
+
+import org.hibernate.cfg.BatchSettings;
+
+import org.hibernate.testing.orm.junit.EntityManagerFactoryScope;
+import org.hibernate.testing.orm.junit.JiraKey;
+import org.hibernate.testing.orm.junit.Jpa;
+import org.hibernate.testing.orm.junit.Setting;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.OptimisticLockException;
+import jakarta.persistence.RollbackException;
+import jakarta.persistence.Version;
+
+@Jpa(
+		annotatedClasses = BatchOffOnlyForOptimisticallyLocked.Something.class,
+		properties = {
+				@Setting(name = BatchSettings.STATEMENT_BATCH_SIZE, value = "10"),
+				@Setting(name = BatchSettings.BATCH_VERSIONED_DATA, value = "false")
+		}
+)
+@JiraKey( "HHH-18621" )
+public class BatchOffOnlyForOptimisticallyLocked {
+	@Test
+	public void testMultiUpdateOfConcurrentlyModified(EntityManagerFactoryScope scope) {
+		scope.inTransaction( em -> {
+			em.persist( new Something( "First" ) );
+			em.persist( new Something( "Second" ) );
+		} );
+
+		final RollbackException ex = Assertions.assertThrows( RollbackException.class, () -> {
+			scope.inTransaction( em -> {
+				final List<Something> subjects = em.createQuery( "select s from Something s", Something.class )
+						.getResultList();
+				scope.inTransaction(
+						competitorEm -> competitorEm.find( Something.class, subjects.get( 0 ).id ).name = "Outrun"
+				);
+				for ( Something something : subjects ) {
+					something.name += " modified";
+				}
+			} );
+		} );
+		Assertions.assertInstanceOf( OptimisticLockException.class, ex.getCause(), "The cause of rollback" );
+		Assertions.assertNotNull( ( (OptimisticLockException) ex.getCause() ).getEntity(), "OLE references an entity" );
+	}
+
+	//Has to be Serializable, otherwise it is not deemed safe to include in the OLE.
+	@Entity(name = "Something")
+	public static class Something implements Serializable {
+		@Id
+		@GeneratedValue(strategy = GenerationType.IDENTITY)
+		public Long id;
+		public String name;
+		@Version
+		public long version;
+
+		public Something() {
+		}
+
+		public Something(String name) {
+			this.name = name;
+		}
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/batch/BatchOffOnlyForOptimisticallyLocked.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/batch/BatchOffOnlyForOptimisticallyLocked.java
@@ -28,6 +28,7 @@ import jakarta.persistence.Version;
 		}
 )
 @JiraKey( "HHH-18621" )
+@SkipForDialect(dialectClass = MariaDBDialect.class, majorVersion = 11, minorVersion = 6, microVersion = 2, reason = "MariaDB will throw an error DB_RECORD_CHANGED when acquiring a lock on a record that have changed")
 public class BatchOffOnlyForOptimisticallyLocked {
 	@Test
 	public void testMultiUpdateOfConcurrentlyModified(EntityManagerFactoryScope scope) {


### PR DESCRIPTION
It, particularly, enables reporting the exact entity that failed optimistic lock.

Redoing #8864 for the affected branch, v6.
v7 has an improvement that makes the setting irrelevant, but I think that backporting it is more risky.
If/when this is merged, would you like me to port just the test case to v7, so that reporting the failed versioned entity updated is not lost again?

----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-18621
<!-- Hibernate GitHub Bot issue links end -->