### PR TITLE
HHH-18941 Fix MonetaryAmountUserType example in JavaDoc

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/usertype/CompositeUserType.java
+++ b/hibernate-core/src/main/java/org/hibernate/usertype/CompositeUserType.java
@@ -56,7 +56,7 @@ import org.hibernate.metamodel.spi.ValueAccess;
  *    }
  *
  *    &#64;Override
- *    public MonetaryAmount instantiate(ValueAccess valueAccess, SessionFactoryImplementor sessionFactory) {
+ *    public MonetaryAmount instantiate(ValueAccess valueAccess) {
  *         final Currency currency = valueAccess.getValue(0, Currency.class);
  *         final BigDecimal value = valueAccess.getValue(1, BigDecimal.class);
  *


### PR DESCRIPTION
Remove `SessionFactoryImplementor sessionFactory` from example code as in c5c9f11

<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

[Please describe here what your change is about]

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
