### PR TITLE
HHH-19707 - Include value column name in TableStructure InitCommand

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/id/enhanced/TableStructure.java
+++ b/hibernate-core/src/main/java/org/hibernate/id/enhanced/TableStructure.java
@@ -330,8 +330,10 @@ public class TableStructure implements DatabaseStructure {
 
 			table.setOptions( options );
 
-			table.addInitCommand( context -> new InitCommand( "insert into "
-					+ context.format( physicalTableName ) + " values ( " + initialValue + " )" ) );
+			table.addInitCommand( context -> new InitCommand(
+					"insert into " + context.format( physicalTableName )
+					+ " ( " + valueColumnNameText + " ) values ( " + initialValue + " )"
+			) );
 		}
 	}
 


### PR DESCRIPTION
<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

https://hibernate.atlassian.net/browse/HHH-19707
When @GeneratedValue(strategy = GenerationType.TABLE) is used with Cloud Spanner(using google maintained dialect, the generator’s InitCommand INSERT statement fails because it does not explicitly list the target column names.

Cloud Spanner requires all INSERT statements to specify column names — even when inserting into a single-column table. Since Hibernate’s default table generator omits the column list in its InitCommand , Spanner rejects the statement, preventing the sequence table from being initialized.
<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
