### PR TITLE
HHH-19706 Composite @Id with a generic part in @MappedSuperclass

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/metamodel/internal/AttributeFactory.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/internal/AttributeFactory.java
@@ -698,8 +698,8 @@ public class AttributeFactory {
 
 	private static Member resolveEntityMember(Property property, EntityPersister declaringEntity) {
 		final String propertyName = property.getName();
-		final var attributeMapping = declaringEntity.findAttributeMapping( propertyName );
-		return attributeMapping == null
+		return !propertyName.equals( declaringEntity.getIdentifierPropertyName() )
+			&& declaringEntity.findAttributeMapping( propertyName ) == null
 				// just like in #determineIdentifierJavaMember , this *should* indicate we have an IdClass mapping
 				? resolveVirtualIdentifierMember( property, declaringEntity )
 				: getter( declaringEntity, property, propertyName, property.getType().getReturnedClass() );

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/generics/compositeid/CompositeIdWithGenericPartInMappedSuperclassTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/generics/compositeid/CompositeIdWithGenericPartInMappedSuperclassTest.java
@@ -1,0 +1,94 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.mapping.generics.compositeid;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.IdClass;
+import jakarta.persistence.MappedSuperclass;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.JiraKey;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.junit.jupiter.api.Test;
+
+import java.io.Serializable;
+import java.util.Objects;
+
+@JiraKey("HHH-19706")
+@DomainModel(
+		annotatedClasses = {
+				CompositeIdWithGenericPartInMappedSuperclassTest.SampleCompositeIdEntity.class,
+				CompositeIdWithGenericPartInMappedSuperclassTest.SampleEntity.class,
+				CompositeIdWithGenericPartInMappedSuperclassTest.SampleSuperclass.class
+		}
+)
+@SessionFactory
+class CompositeIdWithGenericPartInMappedSuperclassTest {
+
+	@Test
+	void test(SessionFactoryScope scope) {
+		scope.inSession( s -> s.createQuery( "from SampleEntity", SampleEntity.class ).getResultList() );
+	}
+
+	@Entity
+	@IdClass(SampleCompositeIdEntity.AdditionalIdEntityId.class)
+	static class SampleCompositeIdEntity extends SampleSuperclass<Long> {
+
+		@Id
+		@Column(nullable = false, updatable = false)
+		private Long additionalId;
+
+		static class AdditionalIdEntityId implements Serializable {
+
+			final Long mainId;
+			final Long additionalId;
+
+			public AdditionalIdEntityId() {
+				this( 0L, 0L );
+			}
+
+			public AdditionalIdEntityId(Long mainId, Long additionalId) {
+				this.mainId = mainId;
+				this.additionalId = additionalId;
+			}
+
+			@Override
+			public boolean equals(Object o) {
+				if ( this == o ) {
+					return true;
+				}
+				if ( !(o instanceof AdditionalIdEntityId) ) {
+					return false;
+				}
+				AdditionalIdEntityId key = (AdditionalIdEntityId) o;
+				return Objects.equals( mainId, key.mainId ) && Objects.equals( additionalId, key.additionalId );
+			}
+
+			@Override
+			public int hashCode() {
+				return Objects.hash( mainId, additionalId );
+			}
+
+		}
+
+	}
+
+	@Entity(name = "SampleEntity")
+	static class SampleEntity extends SampleSuperclass<Long> {
+
+		private String sampleField;
+
+	}
+
+	@MappedSuperclass
+	abstract static class SampleSuperclass<K extends Serializable & Comparable<K>> {
+
+		@Id
+		private K mainId;
+
+	}
+}


### PR DESCRIPTION
Jira issue [HHH-19706](https://hibernate.atlassian.net/browse/HHH-19706)

When declaring entity does not have attribute mapping for property, and property is identifier property then it should be handled as "normal" property, not as virtual identifier.

----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------


[HHH-19706]: https://hibernate.atlassian.net/browse/HHH-19706?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ