### PR TITLE
HHH-19708 prototype support for read/write replicas

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/Session.java
+++ b/hibernate-core/src/main/java/org/hibernate/Session.java
@@ -444,6 +444,8 @@ public interface Session extends SharedSessionContract, EntityManager {
 	 *
 	 * @param readOnly {@code true}, the default for loaded entities/proxies is read-only;
 	 *				 {@code false}, the default for loaded entities/proxies is modifiable
+	 * @throws SessionException if the session was originally
+	 *         {@linkplain SessionBuilder#readOnly created in read-only mode}
 	 */
 	void setDefaultReadOnly(boolean readOnly);
 

--- a/hibernate-core/src/main/java/org/hibernate/SessionBuilder.java
+++ b/hibernate-core/src/main/java/org/hibernate/SessionBuilder.java
@@ -177,6 +177,22 @@ public interface SessionBuilder {
 	 * <li>a non-read-only session will connect to a writable replica.
 	 * </ul>
 	 * <p>
+	 * When read/write replication is in use, it's strongly recommended
+	 * that the session be created with the {@linkplain #initialCacheMode
+	 * initial cache mode} set to {@link CacheMode#GET}, to avoid writing
+	 * stale data read from a read-only replica to the second-level cache.
+	 * Hibernate cannot possibly guarantee that data read from a read-only
+	 * replica is up to date.
+	 * <p>
+	 * When read/write replication is in use, it's possible that an item
+	 * read from the second-level cache might refer to data which does not
+	 * yet exist in the read-only replica. In this situation, an exception
+	 * occurs when the association is fetched. To completely avoid this
+	 * possibility, the {@linkplain #initialCacheMode initial cache mode}
+	 * must be set to {@link CacheMode#IGNORE}. However, it's also usually
+	 * possible to structure data access code in a way which eliminates
+	 * this possibility.
+	 * <p>
 	 * If a session is created in read-only mode, then it cannot be
 	 * changed to read-write mode, and any call to
 	 * {@link Session#setDefaultReadOnly(boolean)} with fail. On the
@@ -192,6 +208,16 @@ public interface SessionBuilder {
 	 */
 	@Incubating
 	SessionBuilder readOnly(boolean readOnly);
+
+	/**
+	 * Specify the initial {@link CacheMode} for the session.
+	 *
+	 * @return {@code this}, for method chaining
+	 * @since 7.2
+	 *
+	 * @see SharedSessionContract#getCacheMode()
+	 */
+	SessionBuilder initialCacheMode(CacheMode cacheMode);
 
 	/**
 	 * Add one or more {@link SessionEventListener} instances to the list of

--- a/hibernate-core/src/main/java/org/hibernate/SessionBuilder.java
+++ b/hibernate-core/src/main/java/org/hibernate/SessionBuilder.java
@@ -186,6 +186,9 @@ public interface SessionBuilder {
 	 *
 	 * @return {@code this}, for method chaining
 	 * @since 7.2
+	 *
+	 * @see org.hibernate.engine.jdbc.connections.spi.MultiTenantConnectionProvider#getReadOnlyConnection(Object)
+	 * @see org.hibernate.engine.jdbc.connections.spi.MultiTenantConnectionProvider#releaseReadOnlyConnection(Object, Connection)
 	 */
 	@Incubating
 	SessionBuilder readOnly(boolean readOnly);

--- a/hibernate-core/src/main/java/org/hibernate/SessionBuilder.java
+++ b/hibernate-core/src/main/java/org/hibernate/SessionBuilder.java
@@ -166,6 +166,29 @@ public interface SessionBuilder {
 	SessionBuilder tenantIdentifier(Object tenantIdentifier);
 
 	/**
+	 * Specify a {@linkplain Session#isDefaultReadOnly read-only mode}
+	 * for the session.
+	 * <p>
+	 * If read/write replication is in use, then:
+	 * <ul>
+	 * <li>a read-only session will connect to a read-only replica, but
+	 * <li>a non-read-only session will connect to a writable replica.
+	 * </ul>
+	 * <p>
+	 * If a session is created in read-only mode, then it cannot be
+	 * changed to read-write mode, and any call to
+	 * {@link Session#setDefaultReadOnly(boolean)} with fail. On the
+	 * other hand, if a session is created in read-write mode, then it
+	 * may later be switched to read-only mode, but all database access
+	 * is directed to the writable replica.
+	 *
+	 * @return {@code this}, for method chaining
+	 * @since 7.2
+	 */
+	@Incubating
+	SessionBuilder readOnly(boolean readOnly);
+
+	/**
 	 * Add one or more {@link SessionEventListener} instances to the list of
 	 * listeners for the new session to be built.
 	 *

--- a/hibernate-core/src/main/java/org/hibernate/SessionBuilder.java
+++ b/hibernate-core/src/main/java/org/hibernate/SessionBuilder.java
@@ -167,9 +167,11 @@ public interface SessionBuilder {
 
 	/**
 	 * Specify a {@linkplain Session#isDefaultReadOnly read-only mode}
-	 * for the session.
+	 * for the session. If a session is created in read-only mode, then
+	 * {@link Connection#setReadOnly} is called when a JDBC connection
+	 * is obtained.
 	 * <p>
-	 * If read/write replication is in use, then:
+	 * Furthermore, if read/write replication is in use, then:
 	 * <ul>
 	 * <li>a read-only session will connect to a read-only replica, but
 	 * <li>a non-read-only session will connect to a writable replica.

--- a/hibernate-core/src/main/java/org/hibernate/SharedSessionBuilder.java
+++ b/hibernate-core/src/main/java/org/hibernate/SharedSessionBuilder.java
@@ -97,6 +97,12 @@ public interface SharedSessionBuilder extends SessionBuilder {
 	SharedSessionBuilder tenantIdentifier(Object tenantIdentifier);
 
 	@Override
+	SharedSessionBuilder readOnly(boolean readOnly);
+
+	@Override
+	SharedSessionBuilder initialCacheMode(CacheMode cacheMode);
+
+	@Override
 	SharedSessionBuilder eventListeners(SessionEventListener... listeners);
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/StatelessSessionBuilder.java
+++ b/hibernate-core/src/main/java/org/hibernate/StatelessSessionBuilder.java
@@ -67,6 +67,9 @@ public interface StatelessSessionBuilder {
 	 *
 	 * @return {@code this}, for method chaining
 	 * @since 7.2
+	 *
+	 * @see org.hibernate.engine.jdbc.connections.spi.MultiTenantConnectionProvider#getReadOnlyConnection(Object)
+	 * @see org.hibernate.engine.jdbc.connections.spi.MultiTenantConnectionProvider#releaseReadOnlyConnection(Object, Connection)
 	 */
 	@Incubating
 	StatelessSessionBuilder readOnly(boolean readOnly);

--- a/hibernate-core/src/main/java/org/hibernate/StatelessSessionBuilder.java
+++ b/hibernate-core/src/main/java/org/hibernate/StatelessSessionBuilder.java
@@ -64,6 +64,22 @@ public interface StatelessSessionBuilder {
 	 * <li>a read-only session will connect to a read-only replica, but
 	 * <li>a non-read-only session will connect to a writable replica.
 	 * </ul>
+	 * <p>
+	 * When read/write replication is in use, it's strongly recommended
+	 * that the session be created with the {@linkplain #initialCacheMode
+	 * initial cache mode} set to {@link CacheMode#GET}, to avoid writing
+	 * stale data read from a read-only replica to the second-level cache.
+	 * Hibernate cannot possibly guarantee that data read from a read-only
+	 * replica is up to date. It's also possible for a read-only session to
+	 * <p>
+	 * When read/write replication is in use, it's possible that an item
+	 * read from the second-level cache might refer to data which does not
+	 * yet exist in the read-only replica. In this situation, an exception
+	 * occurs when the association is fetched. To completely avoid this
+	 * possibility, the {@linkplain #initialCacheMode initial cache mode}
+	 * must be set to {@link CacheMode#IGNORE}. However, it's also usually
+	 * possible to structure data access code in a way which eliminates
+	 * this possibility.
 	 *
 	 * @return {@code this}, for method chaining
 	 * @since 7.2
@@ -73,6 +89,16 @@ public interface StatelessSessionBuilder {
 	 */
 	@Incubating
 	StatelessSessionBuilder readOnly(boolean readOnly);
+
+	/**
+	 * Specify the initial {@link CacheMode} for the session.
+	 *
+	 * @return {@code this}, for method chaining
+	 * @since 7.2
+	 *
+	 * @see SharedSessionContract#getCacheMode()
+	 */
+	StatelessSessionBuilder initialCacheMode(CacheMode cacheMode);
 
 	/**
 	 * Applies the given statement inspection function to the session.

--- a/hibernate-core/src/main/java/org/hibernate/StatelessSessionBuilder.java
+++ b/hibernate-core/src/main/java/org/hibernate/StatelessSessionBuilder.java
@@ -41,7 +41,7 @@ public interface StatelessSessionBuilder {
 	 * @return {@code this}, for method chaining
 	 * @deprecated Use {@link #tenantIdentifier(Object)} instead
 	 */
-	@Deprecated(forRemoval = true)
+	@Deprecated(since = "6.4", forRemoval = true)
 	StatelessSessionBuilder tenantIdentifier(String tenantIdentifier);
 
 	/**
@@ -55,12 +55,27 @@ public interface StatelessSessionBuilder {
 	StatelessSessionBuilder tenantIdentifier(Object tenantIdentifier);
 
 	/**
+	 * Specify a read-only mode for the stateless session.
+	 * <p>
+	 * If read/write replication is in use, then:
+	 * <ul>
+	 * <li>a read-only session will connect to a read-only replica, but
+	 * <li>a non-read-only session will connect to a writable replica.
+	 * </ul>
+	 *
+	 * @return {@code this}, for method chaining
+	 * @since 7.2
+	 */
+	@Incubating
+	StatelessSessionBuilder readOnly(boolean readOnly);
+
+	/**
 	 * Applies the given statement inspection function to the session.
 	 *
 	 * @param operator An operator which accepts a SQL string, returning
 	 *                 a processed SQL string to be used by Hibernate
-	 *                 instead of the given original SQL. Alternatively.
-	 *                 the operator may work by side effect, and simply
+	 *                 instead of the given original SQL. Alternatively,
+	 *                 the operator may work by side effect and simply
 	 *                 return the original SQL.
 	 *
 	 * @return {@code this}, for method chaining

--- a/hibernate-core/src/main/java/org/hibernate/StatelessSessionBuilder.java
+++ b/hibernate-core/src/main/java/org/hibernate/StatelessSessionBuilder.java
@@ -55,9 +55,11 @@ public interface StatelessSessionBuilder {
 	StatelessSessionBuilder tenantIdentifier(Object tenantIdentifier);
 
 	/**
-	 * Specify a read-only mode for the stateless session.
+	 * Specify a read-only mode for the stateless session. If a session
+	 * is created in read-only mode, then {@link Connection#setReadOnly}
+	 * is called when a JDBC connection is obtained.
 	 * <p>
-	 * If read/write replication is in use, then:
+	 * Furthermore, if read/write replication is in use, then:
 	 * <ul>
 	 * <li>a read-only session will connect to a read-only replica, but
 	 * <li>a non-read-only session will connect to a writable replica.

--- a/hibernate-core/src/main/java/org/hibernate/boot/internal/MetadataBuilderImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/internal/MetadataBuilderImpl.java
@@ -10,6 +10,7 @@ import java.util.Locale;
 
 import org.hibernate.AnnotationException;
 import org.hibernate.HibernateException;
+import org.hibernate.context.spi.MultiTenancy;
 import org.hibernate.type.TimeZoneStorageStrategy;
 import org.hibernate.annotations.CacheConcurrencyStrategy;
 import org.hibernate.annotations.TimeZoneStorageType;
@@ -65,7 +66,6 @@ import org.hibernate.cfg.MappingSettings;
 import org.hibernate.dialect.Dialect;
 import org.hibernate.dialect.TimeZoneSupport;
 import org.hibernate.engine.config.spi.ConfigurationService;
-import org.hibernate.engine.jdbc.env.internal.JdbcEnvironmentImpl;
 import org.hibernate.engine.jdbc.spi.JdbcServices;
 import org.hibernate.internal.CoreLogging;
 import org.hibernate.internal.CoreMessageLogger;
@@ -651,7 +651,7 @@ public class MetadataBuilderImpl implements MetadataBuilderImplementor, TypeCont
 
 			defaultTimezoneStorage = resolveTimeZoneStorageStrategy( configService );
 			wrapperArrayHandling = resolveWrapperArrayHandling( configService );
-			multiTenancyEnabled = JdbcEnvironmentImpl.isMultiTenancyEnabled( serviceRegistry );
+			multiTenancyEnabled = MultiTenancy.isMultiTenancyEnabled( serviceRegistry );
 
 			xmlMappingEnabled = configService.getSetting(
 					AvailableSettings.XML_MAPPING_ENABLED,

--- a/hibernate-core/src/main/java/org/hibernate/context/spi/MultiTenancy.java
+++ b/hibernate-core/src/main/java/org/hibernate/context/spi/MultiTenancy.java
@@ -17,8 +17,11 @@ import static org.hibernate.cfg.MultiTenancySettings.MULTI_TENANT_IDENTIFIER_RES
 import static org.hibernate.cfg.MultiTenancySettings.MULTI_TENANT_SCHEMA_MAPPER;
 
 /**
- * Exposes useful strategy objects to user-written components, for example,
- * to a custom implementation of {@link MultiTenantConnectionProvider}.
+ * Exposes useful multitenancy-related strategy objects to user-written components.
+ * <p>
+ * The operation {@link #getTenantSchemaMapper} is especially useful in any custom
+ * implementation of {@link MultiTenantConnectionProvider} which takes on responsibility
+ * for {@linkplain MultiTenantConnectionProvider#handlesConnectionSchema setting the schema}.
  *
  * @since 7.1
  *
@@ -27,10 +30,16 @@ import static org.hibernate.cfg.MultiTenancySettings.MULTI_TENANT_SCHEMA_MAPPER;
 @Incubating
 public class MultiTenancy {
 
+	/**
+	 * Is a {@link MultiTenantConnectionProvider} available?
+	 */
 	public static boolean isMultiTenancyEnabled(ServiceRegistry serviceRegistry) {
 		return serviceRegistry.getService( MultiTenantConnectionProvider.class ) != null;
 	}
 
+	/**
+	 * Obtain the configured {@link CurrentTenantIdentifierResolver}.
+	 */
 	@SuppressWarnings("unchecked")
 	public static CurrentTenantIdentifierResolver<Object> getTenantIdentifierResolver(
 			Map<String,Object> settings, StandardServiceRegistry registry) {
@@ -52,6 +61,9 @@ public class MultiTenancy {
 		}
 	}
 
+	/**
+	 * Obtain the configured {@link TenantSchemaMapper}.
+	 */
 	@SuppressWarnings("unchecked")
 	public static TenantSchemaMapper<Object> getTenantSchemaMapper(
 			Map<String,Object> settings, StandardServiceRegistry registry) {

--- a/hibernate-core/src/main/java/org/hibernate/context/spi/MultiTenancy.java
+++ b/hibernate-core/src/main/java/org/hibernate/context/spi/MultiTenancy.java
@@ -4,6 +4,7 @@
  */
 package org.hibernate.context.spi;
 
+import org.checkerframework.checker.nullness.qual.Nullable;
 import org.hibernate.Incubating;
 import org.hibernate.boot.registry.StandardServiceRegistry;
 import org.hibernate.boot.registry.selector.spi.StrategySelector;
@@ -41,6 +42,7 @@ public class MultiTenancy {
 	 * Obtain the configured {@link CurrentTenantIdentifierResolver}.
 	 */
 	@SuppressWarnings("unchecked")
+	@Nullable
 	public static CurrentTenantIdentifierResolver<Object> getTenantIdentifierResolver(
 			Map<String,Object> settings, StandardServiceRegistry registry) {
 		final var currentTenantIdentifierResolver =
@@ -65,6 +67,7 @@ public class MultiTenancy {
 	 * Obtain the configured {@link TenantSchemaMapper}.
 	 */
 	@SuppressWarnings("unchecked")
+	@Nullable
 	public static TenantSchemaMapper<Object> getTenantSchemaMapper(
 			Map<String,Object> settings, StandardServiceRegistry registry) {
 		final var tenantSchemaMapper =

--- a/hibernate-core/src/main/java/org/hibernate/context/spi/MultiTenancy.java
+++ b/hibernate-core/src/main/java/org/hibernate/context/spi/MultiTenancy.java
@@ -1,0 +1,73 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.context.spi;
+
+import org.hibernate.Incubating;
+import org.hibernate.boot.registry.StandardServiceRegistry;
+import org.hibernate.boot.registry.selector.spi.StrategySelector;
+import org.hibernate.engine.jdbc.connections.spi.MultiTenantConnectionProvider;
+import org.hibernate.resource.beans.internal.Helper;
+import org.hibernate.service.ServiceRegistry;
+
+import java.util.Map;
+
+import static org.hibernate.cfg.MultiTenancySettings.MULTI_TENANT_IDENTIFIER_RESOLVER;
+import static org.hibernate.cfg.MultiTenancySettings.MULTI_TENANT_SCHEMA_MAPPER;
+
+/**
+ * Exposes useful strategy objects to user-written components, for example,
+ * to a custom implementation of {@link MultiTenantConnectionProvider}.
+ *
+ * @since 7.1
+ *
+ * @author Gavin King
+ */
+@Incubating
+public class MultiTenancy {
+
+	public static boolean isMultiTenancyEnabled(ServiceRegistry serviceRegistry) {
+		return serviceRegistry.getService( MultiTenantConnectionProvider.class ) != null;
+	}
+
+	@SuppressWarnings("unchecked")
+	public static CurrentTenantIdentifierResolver<Object> getTenantIdentifierResolver(
+			Map<String,Object> settings, StandardServiceRegistry registry) {
+		final var currentTenantIdentifierResolver =
+				registry.requireService( StrategySelector.class )
+						.resolveStrategy( CurrentTenantIdentifierResolver.class,
+								settings.get( MULTI_TENANT_IDENTIFIER_RESOLVER ) );
+		if ( currentTenantIdentifierResolver == null ) {
+			return Helper.getBean(
+					Helper.getBeanContainer( registry ),
+					CurrentTenantIdentifierResolver.class,
+					true,
+					false,
+					null
+			);
+		}
+		else {
+			return currentTenantIdentifierResolver;
+		}
+	}
+
+	@SuppressWarnings("unchecked")
+	public static TenantSchemaMapper<Object> getTenantSchemaMapper(
+			Map<String,Object> settings, StandardServiceRegistry registry) {
+		final var tenantSchemaMapper =
+				registry.requireService( StrategySelector.class )
+						.resolveStrategy( TenantSchemaMapper.class,
+								settings.get( MULTI_TENANT_SCHEMA_MAPPER ) );
+		if ( tenantSchemaMapper == null ) {
+			return Helper.getBean(
+					Helper.getBeanContainer( registry ),
+					TenantSchemaMapper.class,
+					true,
+					false,
+					null
+			);
+		}
+		return tenantSchemaMapper;
+	}
+}

--- a/hibernate-core/src/main/java/org/hibernate/engine/jdbc/connections/internal/ConnectionProviderInitiator.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/jdbc/connections/internal/ConnectionProviderInitiator.java
@@ -42,7 +42,7 @@ import static org.hibernate.cfg.JdbcSettings.POOL_SIZE;
 import static org.hibernate.cfg.JdbcSettings.URL;
 import static org.hibernate.cfg.JdbcSettings.USER;
 import static org.hibernate.cfg.SchemaToolingSettings.ENABLE_SYNONYMS;
-import static org.hibernate.engine.jdbc.env.internal.JdbcEnvironmentImpl.isMultiTenancyEnabled;
+import static org.hibernate.context.spi.MultiTenancy.isMultiTenancyEnabled;
 import static org.hibernate.internal.util.StringHelper.isBlank;
 import static org.hibernate.internal.util.StringHelper.nullIfBlank;
 

--- a/hibernate-core/src/main/java/org/hibernate/engine/jdbc/connections/spi/ConnectionProvider.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/jdbc/connections/spi/ConnectionProvider.java
@@ -7,6 +7,7 @@ package org.hibernate.engine.jdbc.connections.spi;
 import java.sql.Connection;
 import java.sql.SQLException;
 
+import org.hibernate.Incubating;
 import org.hibernate.dialect.Dialect;
 import org.hibernate.engine.jdbc.connections.internal.DatabaseConnectionInfoImpl;
 import org.hibernate.engine.jdbc.env.spi.ExtractedDatabaseMetaData;
@@ -40,9 +41,30 @@ public interface ConnectionProvider extends Service, Wrapped {
 	 * @return The obtained JDBC connection
 	 *
 	 * @throws SQLException Indicates a problem opening a connection
-	 * @throws org.hibernate.HibernateException Indicates a problem otherwise obtaining a connection.
+	 * @throws org.hibernate.HibernateException Indicates a problem obtaining a connection.
 	 */
 	Connection getConnection() throws SQLException;
+
+	/**
+	 * Obtains a connection to a read-only replica for use according to the underlying
+	 * strategy of this provider.
+	 *
+	 * @return The obtained JDBC connection
+	 *
+	 * @throws SQLException Indicates a problem opening a connection
+	 * @throws org.hibernate.HibernateException Indicates a problem obtaining a connection.
+	 *
+	 * @implNote This default implementation simply calls {@link #getConnection()},
+	 * which returns a connection to a writable replica. If this operation is overridden
+	 * to return a connection to a distinct read-only replica, the matching operation
+	 * {@link #closeReadOnlyConnection(Connection)} must also be overridden.
+	 *
+	 * @since 7.2
+	 */
+	@Incubating
+	default Connection getReadOnlyConnection() throws SQLException {
+		return getConnection();
+	}
 
 	/**
 	 * Release a connection from Hibernate use.
@@ -50,9 +72,30 @@ public interface ConnectionProvider extends Service, Wrapped {
 	 * @param connection The JDBC connection to release
 	 *
 	 * @throws SQLException Indicates a problem closing the connection
-	 * @throws org.hibernate.HibernateException Indicates a problem otherwise releasing a connection.
+	 * @throws org.hibernate.HibernateException Indicates a problem releasing a connection.
 	 */
 	void closeConnection(Connection connection) throws SQLException;
+
+	/**
+	 * Release a connection to a read-only replica from Hibernate use.
+	 *
+	 * @param connection The JDBC connection to release
+	 *
+	 * @throws SQLException Indicates a problem closing the connection
+	 * @throws org.hibernate.HibernateException Indicates a problem otherwise releasing a connection.
+	 *
+	 * @implNote This default implementation simply calls
+	 *           {@link #closeConnection(Connection)}. If
+	 *           {@link #getReadOnlyConnection()} is overridden to return a
+	 *           connection to a distinct read-only replica, this operation must also
+	 *           be overridden.
+	 *
+	 * @since 7.2
+	 */
+	@Incubating
+	default void closeReadOnlyConnection(Connection connection) throws SQLException {
+		closeConnection( connection );
+	}
 
 	/**
 	 * Does this connection provider support aggressive release of JDBC connections and later
@@ -71,6 +114,34 @@ public interface ConnectionProvider extends Service, Wrapped {
 	 * @return {@code true} if aggressive releasing is supported; {@code false} otherwise.
 	 */
 	boolean supportsAggressiveRelease();
+
+	/**
+	 * Does this connection provider correctly set the
+	 * {@linkplain java.sql.Connection#setSchema schema}
+	 * of the returned JDBC connections?
+	 * @return {@code true} if the connection provider handles this;
+	 *         {@code false} if the client should set the schema
+	 *
+	 * @implNote If necessary, a {@code ConnectionProvider} may
+	 * call {@link org.hibernate.context.spi.MultiTenancy#getTenantSchemaMapper}
+	 * to obtain the {@link org.hibernate.context.spi.TenantSchemaMapper}.
+	 */
+	@Incubating
+	default boolean handlesConnectionSchema() {
+		return false;
+	}
+
+	/**
+	 * Does this connection provider correctly set the
+	 * {@linkplain java.sql.Connection#setReadOnly read-only mode}
+	 * of the returned JDBC connections?
+	 * @return {@code true} if the connection provider handles this;
+	 *         {@code false} if the client should set the read-only mode
+	 */
+	@Incubating
+	default boolean handlesConnectionReadOnly() {
+		return false;
+	}
 
 	/**
 	 * @return an informative instance of {@link DatabaseConnectionInfo} for logging.

--- a/hibernate-core/src/main/java/org/hibernate/engine/jdbc/connections/spi/MultiTenantConnectionProvider.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/jdbc/connections/spi/MultiTenantConnectionProvider.java
@@ -141,6 +141,28 @@ public interface MultiTenantConnectionProvider<T> extends Service, Wrapped {
 	 */
 	boolean supportsAggressiveRelease();
 
+	/**
+	 * Does this connection provider correctly set the
+	 * {@linkplain java.sql.Connection#setSchema schema}
+	 * of the returned JDBC connections?
+	 * @return {@code true} if the connection provider handles this;
+	 *         {@code false} if the client should set the schema
+	 */
+	default boolean handlesConnectionSchema() {
+		return false;
+	}
+
+	/**
+	 * Does this connection provider correctly set the
+	 * {@linkplain java.sql.Connection#setReadOnly read-only mode}
+	 * of the returned JDBC connections?
+	 * @return {@code true} if the connection provider handles this;
+	 *         {@code false} if the client should set the read-only mode
+	 */
+	default boolean handlesConnectionReadOnly() {
+		return false;
+	}
+
 	default DatabaseConnectionInfo getDatabaseConnectionInfo(Dialect dialect) {
 		return new DatabaseConnectionInfoImpl( dialect );
 	}

--- a/hibernate-core/src/main/java/org/hibernate/engine/jdbc/connections/spi/MultiTenantConnectionProvider.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/jdbc/connections/spi/MultiTenantConnectionProvider.java
@@ -7,6 +7,7 @@ package org.hibernate.engine.jdbc.connections.spi;
 import java.sql.Connection;
 import java.sql.SQLException;
 
+import org.hibernate.Incubating;
 import org.hibernate.dialect.Dialect;
 import org.hibernate.engine.jdbc.connections.internal.DatabaseConnectionInfoImpl;
 import org.hibernate.service.Service;
@@ -74,6 +75,7 @@ public interface MultiTenantConnectionProvider<T> extends Service, Wrapped {
 	 *
 	 * @since 7.2
 	 */
+	@Incubating
 	default Connection getReadOnlyConnection(T tenantIdentifier)
 			throws SQLException {
 		throw new UnsupportedOperationException( "No read-only replica is available" );
@@ -101,6 +103,7 @@ public interface MultiTenantConnectionProvider<T> extends Service, Wrapped {
 	 *
 	 * @since 7.2
 	 */
+	@Incubating
 	default void releaseReadOnlyConnection(T tenantIdentifier, Connection connection)
 			throws SQLException {
 		throw new UnsupportedOperationException( "No read-only replica is available" );

--- a/hibernate-core/src/main/java/org/hibernate/engine/jdbc/connections/spi/MultiTenantConnectionProvider.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/jdbc/connections/spi/MultiTenantConnectionProvider.java
@@ -57,9 +57,27 @@ public interface MultiTenantConnectionProvider<T> extends Service, Wrapped {
 	 * @return The obtained JDBC connection
 	 *
 	 * @throws SQLException Indicates a problem opening a connection
-	 * @throws org.hibernate.HibernateException Indicates a problem otherwise obtaining a connection.
+	 * @throws org.hibernate.HibernateException Indicates a problem obtaining a connection
 	 */
 	Connection getConnection(T tenantIdentifier) throws SQLException;
+
+	/**
+	 * Obtains a connection to a read-only replica for use according to the underlying
+	 * strategy of this provider.
+	 *
+	 * @param tenantIdentifier The identifier of the tenant for which to get a connection
+	 *
+	 * @return The obtained JDBC connection
+	 *
+	 * @throws SQLException Indicates a problem opening a connection
+	 * @throws org.hibernate.HibernateException Indicates a problem obtaining a connection
+	 *
+	 * @since 7.2
+	 */
+	default Connection getReadOnlyConnection(T tenantIdentifier)
+			throws SQLException {
+		throw new UnsupportedOperationException( "No read-only replica is available" );
+	}
 
 	/**
 	 * Release a connection from Hibernate use.
@@ -68,9 +86,25 @@ public interface MultiTenantConnectionProvider<T> extends Service, Wrapped {
 	 * @param tenantIdentifier The identifier of the tenant.
 	 *
 	 * @throws SQLException Indicates a problem closing the connection
-	 * @throws org.hibernate.HibernateException Indicates a problem otherwise releasing a connection.
+	 * @throws org.hibernate.HibernateException Indicates a problem releasing a connection
 	 */
 	void releaseConnection(T tenantIdentifier, Connection connection) throws SQLException;
+
+	/**
+	 * Release a connection to a read-only replica from Hibernate use.
+	 *
+	 * @param connection The JDBC connection to release
+	 * @param tenantIdentifier The identifier of the tenant.
+	 *
+	 * @throws SQLException Indicates a problem closing the connection
+	 * @throws org.hibernate.HibernateException Indicates a problem releasing a connection
+	 *
+	 * @since 7.2
+	 */
+	default void releaseReadOnlyConnection(T tenantIdentifier, Connection connection)
+			throws SQLException {
+		throw new UnsupportedOperationException( "No read-only replica is available" );
+	}
 
 	/**
 	 * Does this connection provider support aggressive release of JDBC connections and later

--- a/hibernate-core/src/main/java/org/hibernate/engine/jdbc/connections/spi/MultiTenantConnectionProvider.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/jdbc/connections/spi/MultiTenantConnectionProvider.java
@@ -77,8 +77,8 @@ public interface MultiTenantConnectionProvider<T> extends Service, Wrapped {
 	 * @throws org.hibernate.HibernateException Indicates a problem obtaining a connection
 	 *
 	 * @implNote This default implementation simply calls {@link #getConnection(Object)},
-	 * which returns a connection a writable replica. If this operation is overridden to
-	 * return a connection to a distinct read-only replica, the matching operation
+	 * which returns a connection to a writable replica. If this operation is overridden
+	 * to return a connection to a distinct read-only replica, the matching operation
 	 * {@link #releaseReadOnlyConnection(Object, Connection)} must also be overridden.
 	 *
 	 * @since 7.2
@@ -147,7 +147,12 @@ public interface MultiTenantConnectionProvider<T> extends Service, Wrapped {
 	 * of the returned JDBC connections?
 	 * @return {@code true} if the connection provider handles this;
 	 *         {@code false} if the client should set the schema
+	 *
+	 * @implNote If necessary, a {@code ConnectionProvider} may
+	 * call {@link org.hibernate.context.spi.MultiTenancy#getTenantSchemaMapper}
+	 * to obtain the {@link org.hibernate.context.spi.TenantSchemaMapper}.
 	 */
+	@Incubating
 	default boolean handlesConnectionSchema() {
 		return false;
 	}
@@ -159,6 +164,7 @@ public interface MultiTenantConnectionProvider<T> extends Service, Wrapped {
 	 * @return {@code true} if the connection provider handles this;
 	 *         {@code false} if the client should set the read-only mode
 	 */
+	@Incubating
 	default boolean handlesConnectionReadOnly() {
 		return false;
 	}

--- a/hibernate-core/src/main/java/org/hibernate/engine/jdbc/env/internal/JdbcEnvironmentImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/jdbc/env/internal/JdbcEnvironmentImpl.java
@@ -14,7 +14,6 @@ import org.hibernate.dialect.Dialect;
 import org.hibernate.engine.config.spi.ConfigurationService;
 import org.hibernate.engine.config.spi.StandardConverters;
 import org.hibernate.engine.jdbc.connections.spi.JdbcConnectionAccess;
-import org.hibernate.engine.jdbc.connections.spi.MultiTenantConnectionProvider;
 import org.hibernate.engine.jdbc.env.spi.ExtractedDatabaseMetaData;
 import org.hibernate.engine.jdbc.env.spi.IdentifierHelper;
 import org.hibernate.engine.jdbc.env.spi.IdentifierHelperBuilder;
@@ -27,7 +26,6 @@ import org.hibernate.exception.internal.SQLExceptionTypeDelegate;
 import org.hibernate.exception.internal.SQLStateConversionDelegate;
 import org.hibernate.exception.internal.StandardSQLExceptionConverter;
 import org.hibernate.exception.spi.SQLExceptionConversionDelegate;
-import org.hibernate.service.ServiceRegistry;
 import org.hibernate.service.spi.ServiceRegistryImplementor;
 import org.hibernate.sql.ast.SqlAstTranslatorFactory;
 import org.hibernate.sql.ast.spi.StandardSqlAstTranslatorFactory;
@@ -45,10 +43,6 @@ import static org.hibernate.engine.jdbc.env.internal.LobCreatorBuilderImpl.makeL
  */
 public class JdbcEnvironmentImpl implements JdbcEnvironment {
 	private static final Logger log = Logger.getLogger( JdbcEnvironmentImpl.class );
-
-	public static boolean isMultiTenancyEnabled(ServiceRegistry serviceRegistry) {
-		return serviceRegistry.getService( MultiTenantConnectionProvider.class ) != null;
-	}
 
 	private final Dialect dialect;
 

--- a/hibernate-core/src/main/java/org/hibernate/engine/jdbc/internal/JdbcServicesImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/jdbc/internal/JdbcServicesImpl.java
@@ -59,7 +59,7 @@ public class JdbcServicesImpl implements JdbcServices, ServiceRegistryAwareServi
 
 	@Override
 	public JdbcConnectionAccess getBootstrapJdbcConnectionAccess() {
-		return JdbcEnvironmentInitiator.buildBootstrapJdbcConnectionAccess( serviceRegistry );
+		return JdbcEnvironmentInitiator.buildJdbcConnectionAccess( serviceRegistry );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/engine/spi/AbstractDelegatingSessionBuilder.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/spi/AbstractDelegatingSessionBuilder.java
@@ -8,6 +8,7 @@ import java.sql.Connection;
 import java.util.TimeZone;
 import java.util.function.UnaryOperator;
 
+import org.hibernate.CacheMode;
 import org.hibernate.ConnectionAcquisitionMode;
 import org.hibernate.ConnectionReleaseMode;
 import org.hibernate.FlushMode;
@@ -103,6 +104,12 @@ public abstract class AbstractDelegatingSessionBuilder implements SessionBuilder
 	@Override
 	public SessionBuilder readOnly(boolean readOnly) {
 		delegate.readOnly( readOnly );
+		return this;
+	}
+
+	@Override
+	public SessionBuilder initialCacheMode(CacheMode cacheMode) {
+		delegate.initialCacheMode( cacheMode );
 		return this;
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/engine/spi/AbstractDelegatingSessionBuilder.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/spi/AbstractDelegatingSessionBuilder.java
@@ -101,6 +101,12 @@ public abstract class AbstractDelegatingSessionBuilder implements SessionBuilder
 	}
 
 	@Override
+	public SessionBuilder readOnly(boolean readOnly) {
+		delegate.readOnly( readOnly );
+		return this;
+	}
+
+	@Override
 	public SessionBuilder eventListeners(SessionEventListener... listeners) {
 		delegate.eventListeners( listeners );
 		return this;

--- a/hibernate-core/src/main/java/org/hibernate/engine/spi/AbstractDelegatingSharedSessionBuilder.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/spi/AbstractDelegatingSharedSessionBuilder.java
@@ -138,6 +138,12 @@ public abstract class AbstractDelegatingSharedSessionBuilder implements SharedSe
 	}
 
 	@Override
+	public SessionBuilder readOnly(boolean readOnly) {
+		delegate.readOnly( readOnly );
+		return this;
+	}
+
+	@Override
 	public SharedSessionBuilder eventListeners(SessionEventListener... listeners) {
 		delegate.eventListeners( listeners );
 		return this;

--- a/hibernate-core/src/main/java/org/hibernate/engine/spi/AbstractDelegatingSharedSessionBuilder.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/spi/AbstractDelegatingSharedSessionBuilder.java
@@ -8,6 +8,7 @@ import java.sql.Connection;
 import java.util.TimeZone;
 import java.util.function.UnaryOperator;
 
+import org.hibernate.CacheMode;
 import org.hibernate.ConnectionAcquisitionMode;
 import org.hibernate.ConnectionReleaseMode;
 import org.hibernate.FlushMode;
@@ -138,8 +139,14 @@ public abstract class AbstractDelegatingSharedSessionBuilder implements SharedSe
 	}
 
 	@Override
-	public SessionBuilder readOnly(boolean readOnly) {
+	public SharedSessionBuilder readOnly(boolean readOnly) {
 		delegate.readOnly( readOnly );
+		return this;
+	}
+
+	@Override
+	public SharedSessionBuilder initialCacheMode(CacheMode cacheMode) {
+		delegate.initialCacheMode( cacheMode );
 		return this;
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/internal/AbstractSharedSessionContract.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/AbstractSharedSessionContract.java
@@ -727,12 +727,18 @@ public abstract class AbstractSharedSessionContract implements SharedSessionCont
 			initialSchema = connection.getSchema();
 			connection.setSchema( tenantSchema() );
 		}
+		if ( readOnly ) {
+			connection.setReadOnly( true );
+		}
 	}
 
 	@Override
 	public void beforeReleaseConnection(Connection connection) throws SQLException {
 		if ( useSchemaBasedMultiTenancy() ) {
 			connection.setSchema( initialSchema );
+		}
+		if ( readOnly ) {
+			connection.setReadOnly( false );
 		}
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/internal/AbstractSharedSessionContract.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/AbstractSharedSessionContract.java
@@ -155,6 +155,7 @@ public abstract class AbstractSharedSessionContract implements SharedSessionCont
 	private final Interceptor interceptor;
 
 	private final Object tenantIdentifier;
+	private final boolean readOnly;
 	private final TimeZone jdbcTimeZone;
 
 	// mutable state
@@ -184,6 +185,7 @@ public abstract class AbstractSharedSessionContract implements SharedSessionCont
 
 		cacheTransactionSynchronization = factory.getCache().getRegionFactory().createTransactionContext( this );
 		tenantIdentifier = getTenantId( factoryOptions, options );
+		readOnly = options.isReadOnly();
 		interceptor = interpret( options.getInterceptor() );
 		jdbcTimeZone = options.getJdbcTimeZone();
 		sessionEventsManager = createSessionEventsManager( factoryOptions, options );
@@ -288,6 +290,10 @@ public abstract class AbstractSharedSessionContract implements SharedSessionCont
 			throw new HibernateException( "SessionFactory configured for multi-tenancy, but no tenant identifier specified" );
 		}
 		return tenantIdentifier;
+	}
+
+	boolean isReadOnly() {
+		return readOnly;
 	}
 
 	private static SessionEventListenerManager createSessionEventsManager(
@@ -688,6 +694,7 @@ public abstract class AbstractSharedSessionContract implements SharedSessionCont
 				// we're using datasource-based multitenancy
 				jdbcConnectionAccess = new ContextualJdbcConnectionAccess(
 						tenantIdentifier,
+						readOnly,
 						sessionEventsManager,
 						factory.multiTenantConnectionProvider,
 						this

--- a/hibernate-core/src/main/java/org/hibernate/internal/AbstractSharedSessionContract.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/AbstractSharedSessionContract.java
@@ -180,23 +180,25 @@ public abstract class AbstractSharedSessionContract implements SharedSessionCont
 
 	public AbstractSharedSessionContract(SessionFactoryImpl factory, SessionCreationOptions options) {
 		this.factory = factory;
-		this.factoryOptions = factory.getSessionFactoryOptions();
-		this.jdbcServices = factory.getJdbcServices();
 
+		factoryOptions = factory.getSessionFactoryOptions();
+		jdbcServices = factory.getJdbcServices();
 		cacheTransactionSynchronization = factory.getCache().getRegionFactory().createTransactionContext( this );
+
 		tenantIdentifier = getTenantId( factoryOptions, options );
 		readOnly = options.isReadOnly();
+		cacheMode = options.getInitialCacheMode();
 		interceptor = interpret( options.getInterceptor() );
 		jdbcTimeZone = options.getJdbcTimeZone();
+
 		sessionEventsManager = createSessionEventsManager( factoryOptions, options );
 		entityNameResolver = new CoordinatingEntityNameResolver( factory, interceptor );
 
-		setCriteriaCopyTreeEnabled( factoryOptions.isCriteriaCopyTreeEnabled() );
-		setCriteriaPlanCacheEnabled( factoryOptions.isCriteriaPlanCacheEnabled() );
-		setNativeJdbcParametersIgnored( factoryOptions.getNativeJdbcParametersIgnored() );
-		setCacheMode( factoryOptions.getInitialSessionCacheMode() );
+		criteriaCopyTreeEnabled = factoryOptions.isCriteriaCopyTreeEnabled();
+		criteriaPlanCacheEnabled = factoryOptions.isCriteriaPlanCacheEnabled();
+		nativeJdbcParametersIgnored = factoryOptions.getNativeJdbcParametersIgnored();
 
-		final StatementInspector statementInspector = interpret( options.getStatementInspector() );
+		final var statementInspector = interpret( options.getStatementInspector() );
 
 		isTransactionCoordinatorShared = isTransactionCoordinatorShared( options );
 		if ( isTransactionCoordinatorShared ) {

--- a/hibernate-core/src/main/java/org/hibernate/internal/AbstractSharedSessionContract.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/AbstractSharedSessionContract.java
@@ -687,6 +687,7 @@ public abstract class AbstractSharedSessionContract implements SharedSessionCont
 			if ( !factoryOptions.isMultiTenancyEnabled() ) {
 				// we might still be using schema-based multitenancy
 				jdbcConnectionAccess = new NonContextualJdbcConnectionAccess(
+						readOnly,
 						sessionEventsManager,
 						factory.connectionProvider,
 						this
@@ -707,13 +708,11 @@ public abstract class AbstractSharedSessionContract implements SharedSessionCont
 	}
 
 	private boolean manageReadOnly() {
-		return factory.multiTenantConnectionProvider == null
-			|| !factory.multiTenantConnectionProvider.handlesConnectionReadOnly();
+		return !factory.connectionProviderHandlesConnectionReadOnly();
 	}
 
 	private boolean manageSchema() {
-		return factory.multiTenantConnectionProvider == null
-			|| !factory.multiTenantConnectionProvider.handlesConnectionSchema();
+		return !factory.connectionProviderHandlesConnectionSchema();
 	}
 
 	private boolean useSchemaBasedMultiTenancy() {

--- a/hibernate-core/src/main/java/org/hibernate/internal/ContextualJdbcConnectionAccess.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/ContextualJdbcConnectionAccess.java
@@ -13,14 +13,13 @@ import org.hibernate.SessionEventListener;
 import org.hibernate.engine.jdbc.connections.spi.JdbcConnectionAccess;
 import org.hibernate.engine.jdbc.connections.spi.MultiTenantConnectionProvider;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
-import org.hibernate.event.monitor.spi.EventMonitor;
-import org.hibernate.event.monitor.spi.DiagnosticEvent;
 
 /**
  * @author Steve Ebersole
  */
 public class ContextualJdbcConnectionAccess implements JdbcConnectionAccess, Serializable {
 	private final Object tenantIdentifier;
+	private final boolean readOnly;
 	private final SessionEventListener listener;
 	private final MultiTenantConnectionProvider<Object> connectionProvider;
 	private final SharedSessionContractImplementor session;
@@ -28,10 +27,12 @@ public class ContextualJdbcConnectionAccess implements JdbcConnectionAccess, Ser
 
 	public ContextualJdbcConnectionAccess(
 			Object tenantIdentifier,
+			boolean readOnly,
 			SessionEventListener listener,
 			MultiTenantConnectionProvider<Object> connectionProvider,
 			SharedSessionContractImplementor session) {
 		this.tenantIdentifier = tenantIdentifier;
+		this.readOnly = readOnly;
 		this.listener = listener;
 		this.connectionProvider = connectionProvider;
 		this.session = session;
@@ -43,11 +44,13 @@ public class ContextualJdbcConnectionAccess implements JdbcConnectionAccess, Ser
 			throw new HibernateException( "Tenant identifier required" );
 		}
 
-		final EventMonitor eventMonitor = session.getEventMonitor();
-		final DiagnosticEvent connectionAcquisitionEvent = eventMonitor.beginJdbcConnectionAcquisitionEvent();
+		final var eventMonitor = session.getEventMonitor();
+		final var connectionAcquisitionEvent = eventMonitor.beginJdbcConnectionAcquisitionEvent();
 		try {
 			listener.jdbcConnectionAcquisitionStart();
-			return connectionProvider.getConnection( tenantIdentifier );
+			return readOnly
+					? connectionProvider.getReadOnlyConnection( tenantIdentifier )
+					: connectionProvider.getConnection( tenantIdentifier );
 		}
 		finally {
 			eventMonitor.completeJdbcConnectionAcquisitionEvent( connectionAcquisitionEvent, session, tenantIdentifier );
@@ -61,11 +64,16 @@ public class ContextualJdbcConnectionAccess implements JdbcConnectionAccess, Ser
 			throw new HibernateException( "Tenant identifier required" );
 		}
 
-		final EventMonitor eventMonitor = session.getEventMonitor();
-		final DiagnosticEvent connectionReleaseEvent = eventMonitor.beginJdbcConnectionReleaseEvent();
+		final var eventMonitor = session.getEventMonitor();
+		final var connectionReleaseEvent = eventMonitor.beginJdbcConnectionReleaseEvent();
 		try {
 			listener.jdbcConnectionReleaseStart();
-			connectionProvider.releaseConnection( tenantIdentifier, connection );
+			if ( readOnly ) {
+				connectionProvider.releaseReadOnlyConnection( tenantIdentifier, connection );
+			}
+			else {
+				connectionProvider.releaseConnection( tenantIdentifier, connection );
+			}
 		}
 		finally {
 			eventMonitor.completeJdbcConnectionReleaseEvent( connectionReleaseEvent, session, tenantIdentifier );

--- a/hibernate-core/src/main/java/org/hibernate/internal/NonContextualJdbcConnectionAccess.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/NonContextualJdbcConnectionAccess.java
@@ -13,8 +13,6 @@ import org.hibernate.SessionEventListener;
 import org.hibernate.engine.jdbc.connections.spi.ConnectionProvider;
 import org.hibernate.engine.jdbc.connections.spi.JdbcConnectionAccess;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
-import org.hibernate.event.monitor.spi.EventMonitor;
-import org.hibernate.event.monitor.spi.DiagnosticEvent;
 
 /**
  * @author Steve Ebersole
@@ -37,8 +35,8 @@ public class NonContextualJdbcConnectionAccess implements JdbcConnectionAccess, 
 
 	@Override
 	public Connection obtainConnection() throws SQLException {
-		final EventMonitor eventMonitor = session.getEventMonitor();
-		final DiagnosticEvent connectionAcquisitionEvent = eventMonitor.beginJdbcConnectionAcquisitionEvent();
+		final var eventMonitor = session.getEventMonitor();
+		final var connectionAcquisitionEvent = eventMonitor.beginJdbcConnectionAcquisitionEvent();
 		try {
 			listener.jdbcConnectionAcquisitionStart();
 			return connectionProvider.getConnection();
@@ -51,8 +49,8 @@ public class NonContextualJdbcConnectionAccess implements JdbcConnectionAccess, 
 
 	@Override
 	public void releaseConnection(Connection connection) throws SQLException {
-		final EventMonitor eventMonitor = session.getEventMonitor();
-		final DiagnosticEvent connectionReleaseEvent = eventMonitor.beginJdbcConnectionReleaseEvent();
+		final var eventMonitor = session.getEventMonitor();
+		final var connectionReleaseEvent = eventMonitor.beginJdbcConnectionReleaseEvent();
 		try {
 			listener.jdbcConnectionReleaseStart();
 			connectionProvider.closeConnection( connection );

--- a/hibernate-core/src/main/java/org/hibernate/internal/SessionCreationOptions.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/SessionCreationOptions.java
@@ -8,6 +8,7 @@ import java.sql.Connection;
 import java.util.List;
 import java.util.TimeZone;
 
+import org.hibernate.CacheMode;
 import org.hibernate.FlushMode;
 import org.hibernate.Interceptor;
 import org.hibernate.SessionEventListener;
@@ -47,6 +48,8 @@ public interface SessionCreationOptions {
 	Object getTenantIdentifierValue();
 
 	boolean isReadOnly();
+
+	CacheMode getInitialCacheMode();
 
 	boolean isIdentifierRollbackEnabled();
 

--- a/hibernate-core/src/main/java/org/hibernate/internal/SessionCreationOptions.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/SessionCreationOptions.java
@@ -46,6 +46,8 @@ public interface SessionCreationOptions {
 
 	Object getTenantIdentifierValue();
 
+	boolean isReadOnly();
+
 	boolean isIdentifierRollbackEnabled();
 
 	TimeZone getJdbcTimeZone();

--- a/hibernate-core/src/main/java/org/hibernate/internal/SessionFactoryImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/SessionFactoryImpl.java
@@ -33,7 +33,6 @@ import org.hibernate.FlushMode;
 import org.hibernate.HibernateException;
 import org.hibernate.Interceptor;
 import org.hibernate.Session;
-import org.hibernate.SessionBuilder;
 import org.hibernate.SessionEventListener;
 import org.hibernate.SessionFactory;
 import org.hibernate.SessionFactoryObserver;
@@ -1126,6 +1125,7 @@ public class SessionFactoryImpl implements SessionFactoryImplementor {
 		private boolean autoClose;
 		private boolean autoClear;
 		private Object tenantIdentifier;
+		private boolean readOnly;
 		private boolean identifierRollback;
 		private TimeZone jdbcTimeZone;
 		private boolean explicitNoInterceptor;
@@ -1235,6 +1235,11 @@ public class SessionFactoryImpl implements SessionFactoryImplementor {
 		}
 
 		@Override
+		public boolean isReadOnly() {
+			return readOnly;
+		}
+
+		@Override
 		public boolean isIdentifierRollbackEnabled() {
 			return identifierRollback;
 		}
@@ -1279,7 +1284,7 @@ public class SessionFactoryImpl implements SessionFactoryImplementor {
 		}
 
 		@Override
-		public SessionBuilder statementInspector(UnaryOperator<String> operator) {
+		public SessionBuilderImpl statementInspector(UnaryOperator<String> operator) {
 			this.statementInspector = operator::apply;
 			return this;
 		}
@@ -1297,7 +1302,7 @@ public class SessionFactoryImpl implements SessionFactoryImplementor {
 		}
 
 		@Override
-		public SessionBuilder connectionHandling(ConnectionAcquisitionMode acquisitionMode, ConnectionReleaseMode releaseMode) {
+		public SessionBuilderImpl connectionHandling(ConnectionAcquisitionMode acquisitionMode, ConnectionReleaseMode releaseMode) {
 			this.connectionHandlingMode = PhysicalConnectionHandlingMode.interpret( acquisitionMode, releaseMode);
 			return this;
 		}
@@ -1339,7 +1344,13 @@ public class SessionFactoryImpl implements SessionFactoryImplementor {
 		}
 
 		@Override
-		public SessionBuilder identifierRollback(boolean identifierRollback) {
+		public SessionBuilderImpl readOnly(boolean readOnly) {
+			this.readOnly = readOnly;
+			return this;
+		}
+
+		@Override
+		public SessionBuilderImpl identifierRollback(boolean identifierRollback) {
 			this.identifierRollback = identifierRollback;
 			return this;
 		}
@@ -1380,6 +1391,7 @@ public class SessionFactoryImpl implements SessionFactoryImplementor {
 		private StatementInspector statementInspector;
 		private Connection connection;
 		private Object tenantIdentifier;
+		private boolean readOnly;
 
 		public StatelessSessionBuilderImpl(SessionFactoryImpl sessionFactory) {
 			this.sessionFactory = sessionFactory;
@@ -1411,6 +1423,12 @@ public class SessionFactoryImpl implements SessionFactoryImplementor {
 		@Override
 		public StatelessSessionBuilder tenantIdentifier(Object tenantIdentifier) {
 			this.tenantIdentifier = tenantIdentifier;
+			return this;
+		}
+
+		@Override
+		public StatelessSessionBuilder readOnly(boolean readOnly) {
+			this.readOnly = readOnly;
 			return this;
 		}
 
@@ -1487,6 +1505,11 @@ public class SessionFactoryImpl implements SessionFactoryImplementor {
 		public String getTenantIdentifier() {
 			return tenantIdentifier == null ? null
 					: sessionFactory.getTenantIdentifierJavaType().toString( tenantIdentifier );
+		}
+
+		@Override
+		public boolean isReadOnly() {
+			return readOnly;
 		}
 
 		@Override

--- a/hibernate-core/src/main/java/org/hibernate/internal/SessionFactoryImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/SessionFactoryImpl.java
@@ -1577,6 +1577,17 @@ public class SessionFactoryImpl implements SessionFactoryImplementor {
 		return tenantIdentifierJavaType;
 	}
 
+	boolean connectionProviderHandlesConnectionReadOnly() {
+		return multiTenantConnectionProvider != null
+				? multiTenantConnectionProvider.handlesConnectionReadOnly()
+				: connectionProvider.handlesConnectionReadOnly();
+	}
+
+	boolean connectionProviderHandlesConnectionSchema() {
+		return multiTenantConnectionProvider != null
+				? multiTenantConnectionProvider.handlesConnectionSchema()
+				: connectionProvider.handlesConnectionSchema();
+	}
 
 	// Serialization handling ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/hibernate-core/src/main/java/org/hibernate/internal/SessionImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/SessionImpl.java
@@ -2079,9 +2079,15 @@ public class SessionImpl
 		}
 
 		@Override
-		public SessionFactoryImpl.SessionBuilderImpl readOnly(boolean readOnly) {
+		public SharedSessionBuilderImpl readOnly(boolean readOnly) {
 			super.readOnly( readOnly );
 			readOnlyChanged = true;
+			return this;
+		}
+
+		@Override
+		public SharedSessionBuilderImpl initialCacheMode(CacheMode cacheMode) {
+			super.initialCacheMode( cacheMode );
 			return this;
 		}
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/delegation/TestDelegatingSessionBuilder.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/delegation/TestDelegatingSessionBuilder.java
@@ -19,7 +19,6 @@ import org.hibernate.engine.spi.AbstractDelegatingSessionBuilder;
 @SuppressWarnings("unused")
 public class TestDelegatingSessionBuilder extends AbstractDelegatingSessionBuilder {
 
-	@SuppressWarnings("rawtypes")
 	public TestDelegatingSessionBuilder(SessionBuilder delegate) {
 		super( delegate );
 	}


### PR DESCRIPTION
There are two scenarios contemplated here:

1. The JDBC driver handles routing to read-only replicas, using `Connection.setReadOnly(true)` as a hint (this, as I understand it, is the case for MySQL)
2. A read-only replica has its own JDBC URL and `DataSource` (this, I believe, is the case for Postgres and Oracle)

[Note that I'm new to all this and I might be misunderstanding something.]

In the second case we can't really do a whole lot better than just asking the user to write custom logic to select an appropriate source of connections, similar to what we ask them to do with database-based multi-tenancy, and so let's just piggy-back this off the `MultiTenantConnectionProvider`.

Of course, I would prefer all this to be handled at the platform level (i.e. Quarkus/WildFly) but I now realize that that's going to require a lot of coordination, and doesn't help people using Hibernate in standalone mode. So let's do something ourselves.

1. Allow a session to be created in a read-only mode
4. Pass that mode through to the `MultiTenantConnectionProvider`, allowing it to select a read-only replica
5. Automatically call `Connection.setReadOnly(true)` if appropriate

This is a sort-of "simplest possible" approach.

This new kind of read-only mode differs from `setDefaultReadOnly()` in that it's immutable. It does imply the previous sort of readonliness, but it also implies:

1. `Connection.setReadOnly(true)`, and that
2. if a `MultiTenantConnectionProvider` is available, a connection to a read-only replica will be obtained.

One could argue that readonliness is an aspect of the transaction, not of the session, but given the complicated relationship between sessions and connections, I think this is probably more robust.

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-19708
<!-- Hibernate GitHub Bot issue links end -->