### PR TITLE
[7.1] HHH-19712 Column deduplication leads to wrong alias calculation for native query alias expansion

### DIFF
--- a/hibernate-core/src/test/java/org/hibernate/orm/test/query/sql/NativeQueryResultBuilderColumnDeduplicationTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/query/sql/NativeQueryResultBuilderColumnDeduplicationTest.java
@@ -1,0 +1,49 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.query.sql;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import jakarta.persistence.EmbeddedId;
+import jakarta.persistence.Entity;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.Jira;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.junit.jupiter.api.Test;
+
+@DomainModel(annotatedClasses = {
+		NativeQueryResultBuilderColumnDeduplicationTest.MyEntity.class
+})
+@SessionFactory
+@Jira("https://hibernate.atlassian.net/browse/HHH-19712")
+public class NativeQueryResultBuilderColumnDeduplicationTest {
+
+	@Test
+	public void test(SessionFactoryScope scope) {
+		scope.inTransaction(
+				session -> {
+					session.createNativeQuery( "select {t.*} from MyEntity t", Object.class )
+							.addEntity( "t", MyEntity.class )
+							.getResultList();
+				}
+		);
+	}
+
+	@Entity(name = "MyEntity")
+	public static class MyEntity {
+		@EmbeddedId
+		private MyEntityPk id;
+		@Column(insertable = false, updatable = false)
+		private String name;
+		private String description;
+	}
+
+	@Embeddable
+	public static class MyEntityPk {
+		private String id;
+		private String name;
+	}
+}


### PR DESCRIPTION
<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

[Please describe here what your change is about]

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-19712
<!-- Hibernate GitHub Bot issue links end -->