### PR TITLE
Docs: read-only parent's operations are still cascaded to its child associations

### DIFF
--- a/documentation/src/main/asciidoc/userguide/chapters/pc/PersistenceContext.adoc
+++ b/documentation/src/main/asciidoc/userguide/chapters/pc/PersistenceContext.adoc
@@ -1134,6 +1134,11 @@ Additionally, the `CascadeType.ALL` will propagate any Hibernate-specific operat
 `REPLICATE`:: cascades the entity replicate operation.
 `LOCK`:: cascades the entity lock operation.
 
+[WARNING]
+====
+When a parent entity is in a **read-only state**, operations are still cascaded to its child associations. For example, adding a new child to a collection on a read-only parent will result in the child entity being persisted. If this behavior is not desired, the parent entity needs to be evicted from the session before making modifications.
+====
+
 The following examples will explain some of the aforementioned cascade operations using the following entities:
 
 [source, java, indent=0]

--- a/documentation/src/main/asciidoc/userguide/chapters/query/hql/Query.adoc
+++ b/documentation/src/main/asciidoc/userguide/chapters/query/hql/Query.adoc
@@ -52,6 +52,8 @@ include::{example-dir-model}/PhoneType.java[tags=hql-examples-domain-model-examp
 
 include::{example-dir-model}/Call.java[tags=hql-examples-domain-model-example]
 
+include::{example-dir-model}/Account.java[tags=hql-examples-domain-model-example]
+
 include::{example-dir-model}/Payment.java[tags=hql-examples-domain-model-example]
 
 include::{example-dir-model}/CreditCardPayment.java[tags=hql-examples-domain-model-example]
@@ -452,7 +454,7 @@ See the https://docs.jboss.org/hibernate/orm/{majorMinorVersion}/javadocs/org/hi
 [[hql-read-only-entities]]
 ==== Querying for read-only entities
 
-As explained in <<chapters/domain/immutability.adoc#entity-immutability,entity immutability>>, fetching entities in read-only mode is more efficient than fetching entities whose state changes might need to be written to the database.
+As explained in <<chapters/domain/immutability.adoc#mutability-entity,entity immutability>>, fetching entities in read-only mode is more efficient than fetching entities whose state changes might need to be written to the database.
 Fortunately, even mutable entities may be fetched in read-only mode, with the benefit of reduced memory footprint and of a faster flushing process.
 
 Read-only entities are skipped by the dirty checking mechanism as illustrated by the following example:
@@ -476,11 +478,25 @@ In this example, no SQL `UPDATE` was executed.
 The method `Query#setReadOnly()` is an alternative to using a Jakarta Persistence query hint:
 
 [[hql-read-only-entities-native-example]]
-.Read-only entities native query example
+.Read-only entities - native - query example
 ====
 [source, java, indent=0]
 ----
 include::{example-dir-query}/HQLTest.java[tags=hql-read-only-entities-native-example]
+----
+====
+
+[WARNING]
+====
+When a parent entity is in a **read-only state**, operations are still cascaded to its child associations. For example, adding a new child to a collection on a read-only parent will result in the child entity being persisted. If this behavior is not desired, the parent entity needs to be evicted from the session before making modifications.
+====
+
+[[hql-read-only-entities-native-cascade-to-child-example]]
+.Read-only entities - native, cascade to child - query example
+====
+[source, java, indent=0]
+----
+include::{example-dir-query}/HQLTest.java[tags=hql-read-only-entities-native-cascade-to-child-example]
 ----
 ====
 

--- a/hibernate-core/src/main/java/org/hibernate/Session.java
+++ b/hibernate-core/src/main/java/org/hibernate/Session.java
@@ -419,6 +419,10 @@ public interface Session extends SharedSessionContract, EntityManager {
 	 * Change the default for entities and proxies loaded into this session
 	 * from modifiable to read-only mode, or from modifiable to read-only mode.
 	 * <p>
+	 * In some ways, Hibernate treats read-only entities the same as
+	 * entities that are not read-only; for example, it cascades
+	 * operations to associations as defined in the entity mapping.
+	 * <p>
 	 * Read-only entities are not dirty-checked and snapshots of persistent
 	 * state are not maintained. Read-only entities can be modified, but
 	 * changes are not persisted.

--- a/hibernate-core/src/main/java/org/hibernate/query/SelectionQuery.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/SelectionQuery.java
@@ -387,6 +387,10 @@ public interface SelectionQuery<R> extends CommonQueryContract {
 	 * and proxies that are loaded into the session, use
 	 * {@link Session#setDefaultReadOnly(boolean)}.
 	 * <p>
+	 * In some ways, Hibernate treats read-only entities the same as
+	 * entities that are not read-only; for example, it cascades
+	 * operations to associations as defined in the entity mapping.
+	 * <p>
 	 * Read-only entities are not dirty-checked and snapshots of persistent
 	 * state are not maintained. Read-only entities can be modified, but
 	 * changes are not persisted.

--- a/hibernate-testing/src/main/java/org/hibernate/testing/orm/domain/userguide/Account.java
+++ b/hibernate-testing/src/main/java/org/hibernate/testing/orm/domain/userguide/Account.java
@@ -13,6 +13,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 
+//tag::hql-examples-domain-model-example[]
 @Entity
 public class Account {
 	@Id
@@ -25,6 +26,9 @@ public class Account {
 	@OneToMany(mappedBy = "account")
 	List<Payment> payments = new ArrayList<>();
 
+	//Getters and setters are omitted for brevity
+
+	//end::hql-examples-domain-model-example[]
 	public List<Payment> getPayments() {
 		return payments;
 	}
@@ -36,4 +40,7 @@ public class Account {
 	public void setOwner(Person owner) {
 		this.owner = owner;
 	}
+
+//tag::hql-examples-domain-model-example[]
 }
+//end::hql-examples-domain-model-example[]


### PR DESCRIPTION
Hibernate uses a **misleading concept** name of "**read-only**" for entities whose modifications to child associations are persisted.

Imagine the following use-case: a new Hibernate developer will figure out and assume they can wrap a session using
```
session.setDefaultReadOnly( true );
```
to achieve the behavior equivalent to detached entities. Developers will continue maintaining this so-called "read-only" branch of code execution and eventually modify a child association, as they consider this Entity to be a simple DTO, to be read by other functions in the code. As a result, a severe bug (or an actual data loss in production) will be introduced.

Hibernate Docs have terrible SEO indexing, but an AI found for me that in version 3.5 there was an excellent documentation:
* https://docs.jboss.org/hibernate/orm/3.5/reference/en/html/readonly.html

It had mentioned the following critical points:
> In some ways, Hibernate treats read-only entities the same as entities that are not read-only:
> * Hibernate cascades operations to associations as defined in the entity mapping.
> * Hibernate updates the version if the entity has a collection with changes that dirties the entity;
> * A read-only entity can be deleted.

I wasn't able to find any similar information in the latest docs (7.1). All the sections arbitrarily link to each other in a way that there is no single place dedicated to describing the concept of **read-only** anymore.

I followed the reference of
```
| `Query#setReadOnly()` | Overrides the session-level default for read-only state. The concept of read-only state is covered in <<chapters/pc/PersistenceContext.adoc#pc,Persistence Contexts>>.
```
and added a warning to `Persistence Contexts`.

Similarly, there was an example of a usage in `Read-only entities native query example`, so I added an explicit cascade usage example below that.
* A corresponding unit test was added, asserting the current behavior (mutating the test data before subsequently returning the test data to its previous state).

⚠️ I updated both the `Session` and `Query` (`SelectionQuery`)'s JavaDocs to explicitly document this behavior inside the `setReadOnly` and `setDefaultReadOnly` methods. This is the least we can do - I'd actually propose that you could consider renaming the methods.
* Note that I only referenced my primary concern of a child cascade, to point out that it can't be trusted by default if users don't perform any analysis. However, I'm sure you'll figure out a more exact and complete definition. My suggestion is for you to quickly process this PR and then create a long-standing ticket for a more exhaustive review to be finished at a later point.

Please perform a thorough review of the documentation from the standpoint of ensuring that this concept is searchable.

Additionally, please consider preparing examples of correct usages for users who want to use an **actual** read-only state, especially at the beginning (right after opening a session). These patterns are currently very difficult to learn and understand. Namely, it's very dangerous to assume all developers will remember to evict an entity before mutating it if we don't open a read-only transaction. (We're currently analyzing the downsides of read-only transactions.)

---

I also found one ticket that may be related, which seems to consider the idea of "fixing" the behavior of read-only to be what one would intuitively assume (though it would be a breaking change):
* "consider disabling cascade PERSIST for read-only entities"
  * https://hibernate.atlassian.net/browse/HHH-19398

---

* 🗒️ Note: The `Account` entity was missing in the example data model, which I noticed when trying to reproduce your example from Docs, so I also fixed it - please review the comment-docs references etc.
* 🗒️ Note: I added dashes inside `Read-only entities native query example`, because it's very misleading to include a phrase `native query`, which is a very distinct concept.
* 🗒️ Note: I fixed a `entity-immutability` reference that linked to an anchor that no longer exists (clicking on the link had no effect).
  * 📓 Sub-note: this link to `entity immutability` should be reviewed, because it doesn't really relate to the concept of `read-only`. I mean, it kinda does, but it's very ambiguous, as it mentions that the `mutability` has various relative meanings; but it doesn't explicitly describe the `read-only`-kind of mutability. (It's far from the usefulness of the old docs.)

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
