### PR TITLE
HHH-19605 Session.isDirty might return true when batch fetching entity with CacheConcurrencyStrategy.READ_WRITE

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/event/internal/DefaultDirtyCheckEventListener.java
+++ b/hibernate-core/src/main/java/org/hibernate/event/internal/DefaultDirtyCheckEventListener.java
@@ -14,8 +14,6 @@ import org.hibernate.event.spi.DirtyCheckEvent;
 import org.hibernate.event.spi.DirtyCheckEventListener;
 import org.hibernate.event.spi.EventSource;
 import org.hibernate.persister.collection.CollectionPersister;
-import org.hibernate.persister.entity.EntityPersister;
-
 
 /**
  * Determines if the current session holds modified state which
@@ -38,11 +36,11 @@ public class DefaultDirtyCheckEventListener implements DirtyCheckEventListener {
 	@Override
 	public void onDirtyCheck(DirtyCheckEvent event) throws HibernateException {
 		final var session = event.getSession();
-		final var persistenceContext = session.getPersistenceContext();
+		final var persistenceContext = session.getPersistenceContextInternal();
 		final var holdersByKey = persistenceContext.getEntityHoldersByKey();
 		if ( holdersByKey != null ) {
-			for ( var entry : holdersByKey.entrySet() ) {
-				if ( isEntityDirty( entry.getValue(), session ) ) {
+			for ( var holder : holdersByKey.values() ) {
+				if ( isEntityDirty( holder, session ) ) {
 					event.setDirty( true );
 					return;
 				}
@@ -61,24 +59,28 @@ public class DefaultDirtyCheckEventListener implements DirtyCheckEventListener {
 
 	private static boolean isEntityDirty(EntityHolder holder, EventSource session) {
 		final var entityEntry = holder.getEntityEntry();
+		if ( entityEntry == null ) {
+			// holders with no entity entry yet cannot contain dirty entities
+			return false;
+		}
 		final Status status = entityEntry.getStatus();
 		return switch ( status ) {
 			case GONE, READ_ONLY -> false;
 			case DELETED -> true;
-			case MANAGED -> isManagedEntityDirty( holder.getManagedObject(), holder.getDescriptor(), entityEntry, session );
+			case MANAGED -> isManagedEntityDirty( holder.getEntity(), entityEntry, session );
 			case SAVING, LOADING -> throw new AssertionFailure( "Unexpected status: " + status );
 		};
 	}
 
-	private static boolean isManagedEntityDirty(
-			Object entity, EntityPersister descriptor, EntityEntry entityEntry, EventSource session) {
+	private static boolean isManagedEntityDirty(Object entity, EntityEntry entityEntry, EventSource session) {
 		if ( entityEntry.requiresDirtyCheck( entity ) ) { // takes into account CustomEntityDirtinessStrategy
-			final Object[] propertyValues =
+			final var persister = entityEntry.getPersister();
+			final var propertyValues =
 					entityEntry.getStatus() == Status.DELETED
 							? entityEntry.getDeletedState()
-							: descriptor.getValues( entity );
-			final int[] dirty =
-					descriptor.findDirty( propertyValues, entityEntry.getLoadedState(), entity, session );
+							: persister.getValues( entity );
+			final var dirty =
+					persister.findDirty( propertyValues, entityEntry.getLoadedState(), entity, session );
 			return dirty != null;
 		}
 		else {

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/dirtiness/SessionIsDirtyTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/dirtiness/SessionIsDirtyTests.java
@@ -1,0 +1,215 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.dirtiness;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import org.hibernate.Hibernate;
+import org.hibernate.annotations.Cache;
+import org.hibernate.annotations.CacheConcurrencyStrategy;
+import org.hibernate.cache.spi.CacheImplementor;
+import org.hibernate.cfg.AvailableSettings;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.Jira;
+import org.hibernate.testing.orm.junit.ServiceRegistry;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.hibernate.testing.orm.junit.Setting;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
+
+@DomainModel(annotatedClasses = {
+		SessionIsDirtyTests.EntityA.class,
+		SessionIsDirtyTests.EntityB.class,
+		SessionIsDirtyTests.EntityC.class,
+})
+@ServiceRegistry(settings = {
+		@Setting(name = AvailableSettings.DEFAULT_BATCH_FETCH_SIZE, value = "5"),
+		@Setting(name = AvailableSettings.USE_SECOND_LEVEL_CACHE, value = "true"),
+})
+@SessionFactory
+@Jira("https://hibernate.atlassian.net/browse/HHH-19605")
+public class SessionIsDirtyTests {
+	@Test
+	public void testBatchAndCacheDirtiness(SessionFactoryScope scope) {
+		final CacheImplementor cache = scope.getSessionFactory().getCache();
+		cache.evictAllRegions();
+		scope.inTransaction( session -> {
+			final List<EntityA> resultList = session.createSelectionQuery(
+					"select a from EntityA a order by a.id",
+					EntityA.class
+			).getResultList();
+			assertThat( session.isDirty() ).isFalse();
+
+			assertThat( resultList ).hasSize( 2 );
+			final EntityA entityA1 = resultList.get( 0 );
+			assertThat( entityA1.getId() ).isEqualTo( 1L );
+			assertThat( entityA1.getName() ).isEqualTo( "A1" );
+			assertThat( entityA1.getEntityB() ).isNull();
+
+			final EntityA entityA2 = resultList.get( 1 );
+			assertThat( entityA2.getId() ).isEqualTo( 2L );
+			assertThat( entityA2.getName() ).isEqualTo( "A2" );
+			assertThat( entityA2.getEntityB() ).isNotNull();
+			assertThat( entityA2.getEntityB().getEntityA() ).isSameAs( entityA1 );
+
+			entityA2.getEntityB().setName( "B1 updated" );
+			assertThat( session.isDirty() ).isTrue();
+		} );
+	}
+
+	@Test
+	public void testLazyAssociationDirtiness(SessionFactoryScope scope) {
+		scope.inTransaction( session -> {
+			final List<EntityC> resultList = session.createSelectionQuery(
+					"select c from EntityC c order by c.id",
+					EntityC.class
+			).getResultList();
+			assertThat( session.isDirty() ).isFalse();
+
+			assertThat( resultList ).hasSize( 1 );
+			final EntityC entityC = resultList.get( 0 );
+			assertThat( entityC.getId() ).isEqualTo( 1L );
+			assertThat( entityC.getName() ).isEqualTo( "C1" );
+			assertThat( Hibernate.isInitialized( entityC.getEntityB() ) ).isFalse();
+
+			entityC.getEntityB().setName( "B1 lazy updated" );
+			assertThat( session.isDirty() ).isTrue();
+		} );
+	}
+
+	@BeforeAll
+	public void setUp(SessionFactoryScope scope) {
+		scope.inTransaction( session -> {
+			final EntityA entityA1 = new EntityA( 1L, "A1" );
+			final EntityA entityA2 = new EntityA( 2L, "A2" );
+			final EntityB entityB = new EntityB( 1L, "B1" );
+			entityB.entityA = entityA1;
+			entityA2.entityB = entityB;
+			session.persist( entityA1 );
+			session.persist( entityA2 );
+			session.persist( entityB );
+
+			final EntityC entityC = new EntityC( 1L, "C1" );
+			entityC.entityB = entityB;
+			session.persist( entityC );
+		} );
+	}
+
+	@AfterAll
+	public void tearDown(SessionFactoryScope scope) {
+		scope.getSessionFactory().getSchemaManager().truncateMappedObjects();
+	}
+
+	@Entity(name = "EntityA")
+	@Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
+	static class EntityA {
+		@Id
+		Long id;
+
+		String name;
+
+		@ManyToOne
+		@JoinColumn(name = "entity_b")
+		EntityB entityB;
+
+		public EntityA() {
+		}
+
+		public EntityA(Long id, String name) {
+			this.id = id;
+			this.name = name;
+		}
+
+		public Long getId() {
+			return id;
+		}
+
+		public String getName() {
+			return name;
+		}
+
+		public EntityB getEntityB() {
+			return entityB;
+		}
+	}
+
+	@Entity(name = "EntityB")
+	@Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
+	static class EntityB {
+		@Id
+		Long id;
+
+		String name;
+
+		@ManyToOne
+		@JoinColumn(name = "entity_a")
+		EntityA entityA;
+
+		public EntityB() {
+		}
+
+		public EntityB(Long id, String name) {
+			this.id = id;
+			this.name = name;
+		}
+
+		public Long getId() {
+			return id;
+		}
+
+		public String getName() {
+			return name;
+		}
+
+		public EntityA getEntityA() {
+			return entityA;
+		}
+
+		public void setName(String name) {
+			this.name = name;
+		}
+	}
+
+	@Entity(name = "EntityC")
+	static class EntityC {
+		@Id
+		Long id;
+
+		String name;
+
+		@ManyToOne(fetch = FetchType.LAZY)
+		@JoinColumn(name = "entity_b")
+		EntityB entityB;
+
+		public EntityC() {
+		}
+
+		public EntityC(Long id, String name) {
+			this.id = id;
+			this.name = name;
+		}
+
+		public Long getId() {
+			return id;
+		}
+
+		public String getName() {
+			return name;
+		}
+
+		public EntityB getEntityB() {
+			return entityB;
+		}
+	}
+}


### PR DESCRIPTION
<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

https://hibernate.atlassian.net/browse/HHH-19605

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
