### PR TITLE
HHH-19719 org.hibernate.query.sqm.function.SelfRenderingSqmWindowFunction#appendHqlString throws IndexOutOfBoundsException  when has no arguments

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/function/SelfRenderingSqmWindowFunction.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/function/SelfRenderingSqmWindowFunction.java
@@ -121,7 +121,7 @@ public class SelfRenderingSqmWindowFunction<T> extends SelfRenderingSqmFunction<
 		hql.append( getFunctionName() );
 		hql.append( '(' );
 		int i = 1;
-		if ( arguments.get( 0 ) instanceof SqmDistinct<?> ) {
+		if ( !arguments.isEmpty() && arguments.get( 0 ) instanceof SqmDistinct<?> ) {
 			arguments.get( 0 ).appendHqlString( hql, context );
 			if ( arguments.size() > 1 ) {
 				hql.append( ' ' );

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/query/sqm/SelfRenderingSqmFunctionWithoutArgumentsTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/query/sqm/SelfRenderingSqmFunctionWithoutArgumentsTest.java
@@ -1,0 +1,64 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.query.sqm;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import org.hibernate.testing.orm.junit.DialectFeatureChecks.SupportPartitionBy;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.JiraKey;
+import org.hibernate.testing.orm.junit.RequiresDialectFeature;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+@DomainModel(
+		annotatedClasses = SelfRenderingSqmFunctionWithoutArgumentsTest.Dummy.class
+)
+@SessionFactory
+@JiraKey("HHH-19719")
+@RequiresDialectFeature(feature = SupportPartitionBy.class)
+public class SelfRenderingSqmFunctionWithoutArgumentsTest {
+
+	@BeforeAll
+	static void init(SessionFactoryScope scope) {
+		scope.inTransaction( session -> {
+			session.persist( new Dummy(1, "John Doe") );
+			session.persist( new Dummy(2, "Dave Default") );
+		} );
+	}
+
+	@Test
+	void test(SessionFactoryScope scope) {
+		scope.inSession( session -> {
+			session.createQuery( """
+					with tmp as (
+						select id id, name name, row_number() over (order by name) pos
+						from Dummy
+					)
+					select id, name, pos from tmp
+					""" ).getResultList();
+		} );
+
+	}
+
+	@Entity(name = "Dummy")
+	static class Dummy {
+		@Id
+		private Integer id;
+
+		private String name;
+
+		private Dummy() {
+			// for use by Hibernate
+		}
+
+		public Dummy(Integer id, String name) {
+			this.id = id;
+			this.name = name;
+		}
+	}
+}


### PR DESCRIPTION
Jira issue [HHH-19719](https://hibernate.atlassian.net/browse/HHH-19719)

Checking if list of arguments is non empty before checking if first argument is instance of `SqmDistinct`. If empty, condition is definitely false :-)

----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------


[HHH-19719]: https://hibernate.atlassian.net/browse/HHH-19719?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-19719
<!-- Hibernate GitHub Bot issue links end -->