### PR TITLE
Backport to 7.1 - HHH-19716 Set the collection owner when wrapping a collection into a persistent one

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/internal/StatelessSessionImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/StatelessSessionImpl.java
@@ -690,7 +690,7 @@ public class StatelessSessionImpl extends AbstractSharedSessionContract implemen
 
 	// collections ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-	// Hibernate Reactive overrides this
+	// Hibernate Reactive calls this
 	protected void forEachOwnedCollection(
 			Object entity, Object key,
 			EntityPersister persister, BiConsumer<CollectionPersister, PersistentCollection<?>> action) {
@@ -712,7 +712,7 @@ public class StatelessSessionImpl extends AbstractSharedSessionContract implemen
 						collection =
 								value == null
 										? instantiateEmpty( key, descriptor )
-										: wrap( descriptor, value );
+										: wrap( descriptor, value, entity );
 					}
 					action.accept( descriptor, collection );
 				}
@@ -726,12 +726,12 @@ public class StatelessSessionImpl extends AbstractSharedSessionContract implemen
 		return descriptor.getCollectionSemantics().instantiateWrapper(key, descriptor, this);
 	}
 
-	//TODO: is this the right way to do this?
-	// Hibernate Reactive calls this
 	@SuppressWarnings({"rawtypes", "unchecked"})
-	protected PersistentCollection<?> wrap(CollectionPersister descriptor, Object collection) {
+	protected PersistentCollection<?> wrap(CollectionPersister descriptor, Object collection, Object owner) {
 		final CollectionSemantics collectionSemantics = descriptor.getCollectionSemantics();
-		return collectionSemantics.wrap(collection, descriptor, this);
+		var wrapped = collectionSemantics.wrap( collection, descriptor, this );
+		wrapped.setOwner( owner );
+		return wrapped;
 	}
 
 	// loading ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/stateless/events/CollectionListenerInStatelessSessionTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/stateless/events/CollectionListenerInStatelessSessionTest.java
@@ -18,6 +18,7 @@ import org.hibernate.testing.orm.junit.SessionFactory;
 import org.hibernate.testing.orm.junit.SessionFactoryScope;
 import org.junit.jupiter.api.Test;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @DomainModel(annotatedClasses = {EntityA.class, EntityB.class})
@@ -64,6 +65,8 @@ class MyPreCollectionRecreateEventListener implements PreCollectionRecreateEvent
 
 	@Override
 	public void onPreRecreateCollection(PreCollectionRecreateEvent event) {
+		assertThat( event.getAffectedOwnerOrNull() ).isNotNull();
+		assertThat( event.getCollection().getOwner() ).isNotNull();
 		called++;
 	}
 
@@ -75,6 +78,8 @@ class MyPreCollectionRemoveEventListener implements PreCollectionRemoveEventList
 
 	@Override
 	public void onPreRemoveCollection(PreCollectionRemoveEvent event) {
+		assertThat( event.getAffectedOwnerOrNull() ).isNotNull();
+		assertThat( event.getCollection().getOwner() ).isNotNull();
 		called++;
 	}
 
@@ -86,6 +91,8 @@ class MyPostCollectionRecreateEventListener implements PostCollectionRecreateEve
 
 	@Override
 	public void onPostRecreateCollection(PostCollectionRecreateEvent event) {
+		assertThat( event.getAffectedOwnerOrNull() ).isNotNull();
+		assertThat( event.getCollection().getOwner() ).isNotNull();
 		called++;
 	}
 
@@ -97,6 +104,8 @@ class MyPostCollectionRemoveEventListener implements PostCollectionRemoveEventLi
 
 	@Override
 	public void onPostRemoveCollection(PostCollectionRemoveEvent event) {
+		assertThat( event.getAffectedOwnerOrNull() ).isNotNull();
+		assertThat( event.getCollection().getOwner() ).isNotNull();
 		called++;
 	}
 


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-19716

since that affects Quarkus and jakarta Data, here's a backport pr for https://github.com/hibernate/hibernate-orm/pull/10778

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
