### PR TITLE
HHH-19589 @Converter does not take precedence over @TypeRegistration

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/boot/model/internal/BasicValueBinder.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/internal/BasicValueBinder.java
@@ -332,23 +332,24 @@ public class BasicValueBinder implements JdbcTypeIndicators {
 		if ( converterDescriptor != null ) {
 			applyJpaConverter( value, converterDescriptor );
 		}
-
-		final Class<? extends UserType<?>> userTypeImpl =
-				kind.mappingAccess.customType( value, getSourceModelContext() );
-		if ( userTypeImpl != null ) {
-			applyExplicitType( userTypeImpl,
-					kind.mappingAccess.customTypeParameters( value, getSourceModelContext() ) );
-			// An explicit custom UserType has top precedence when we get to BasicValue resolution.
-			return;
-		}
-		else if ( modelClassDetails != null ) {
-			final ClassDetails rawClassDetails = modelClassDetails.determineRawClass();
-			final Class<?> basicClass = rawClassDetails.toJavaClass();
-			final Class<? extends UserType<?>> registeredUserTypeImpl =
-					getMetadataCollector().findRegisteredUserType( basicClass );
-			if ( registeredUserTypeImpl != null ) {
-				applyExplicitType( registeredUserTypeImpl, emptyMap() );
+		else {
+			final Class<? extends UserType<?>> userTypeImpl =
+					kind.mappingAccess.customType( value, getSourceModelContext() );
+			if ( userTypeImpl != null ) {
+				applyExplicitType( userTypeImpl,
+						kind.mappingAccess.customTypeParameters( value, getSourceModelContext() ) );
+				// An explicit custom UserType has top precedence when we get to BasicValue resolution.
 				return;
+			}
+			else if ( modelClassDetails != null ) {
+				final ClassDetails rawClassDetails = modelClassDetails.determineRawClass();
+				final Class<?> basicClass = rawClassDetails.toJavaClass();
+				final Class<? extends UserType<?>> registeredUserTypeImpl =
+						getMetadataCollector().findRegisteredUserType( basicClass );
+				if ( registeredUserTypeImpl != null ) {
+					applyExplicitType( registeredUserTypeImpl, emptyMap() );
+					return;
+				}
 			}
 		}
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/converted/converter/ConverterOverrideTypeRegisttrationTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/converted/converter/ConverterOverrideTypeRegisttrationTest.java
@@ -1,0 +1,102 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.mapping.converted.converter;
+
+import java.util.BitSet;
+
+import org.hibernate.annotations.TypeRegistration;
+import org.hibernate.orm.test.mapping.basic.bitset.BitSetHelper;
+import org.hibernate.orm.test.mapping.basic.bitset.BitSetUserType;
+
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.JiraKey;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.junit.jupiter.api.Test;
+
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Convert;
+import jakarta.persistence.Converter;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * <pre>
+ * The @Converter should take precedence over @TypeRegistration.
+ * This test shows that this is not the case.
+ *
+ * To ensure that the @Converter is taken into account without @TypeRegistration, you just need to remove the @TypeRegistration.
+ * </pre>
+ *
+ * @author Vincent Bouthinon
+ */
+@DomainModel(
+		annotatedClasses = {
+				ConverterOverrideTypeRegisttrationTest.SimpleEntity.class
+		}
+)
+@SessionFactory
+@JiraKey(value = "HHH-19589")
+public class ConverterOverrideTypeRegisttrationTest {
+
+	@Test
+	void test(SessionFactoryScope scope) {
+		scope.inTransaction( session -> {
+			final SimpleEntity object = new SimpleEntity( 77L );
+			BitSet bitSet = new BitSet();
+			bitSet.set( 0, true );
+			object.setBitSet( bitSet );
+			session.persist( object );
+			session.flush();
+			session.clear();
+			SimpleEntity simpleEntity = session.find( SimpleEntity.class, object.id );
+			assertThat( simpleEntity.getBitSet().get( 7 ) ).isTrue();
+		} );
+	}
+
+
+	@Entity(name = "SimpleEntity")
+	@TypeRegistration(basicClass = BitSet.class, userType = BitSetUserType.class) // Remove this annotation to test the use of @Converter
+	public static class SimpleEntity {
+
+		@Id
+		private Long id;
+		@Convert(converter = BitSetConverter.class)
+		private BitSet bitSet;
+
+		public SimpleEntity() {
+		}
+
+		public SimpleEntity(Long id) {
+			this.id = id;
+		}
+
+		public BitSet getBitSet() {
+			return bitSet;
+		}
+
+		public void setBitSet(final BitSet bitSet) {
+			this.bitSet = bitSet;
+		}
+	}
+
+	@Converter
+	public static class BitSetConverter implements AttributeConverter<BitSet, String> {
+
+		@Override
+		public String convertToDatabaseColumn(final BitSet attribute) {
+			return BitSetHelper.bitSetToString( attribute );
+		}
+
+		@Override
+		public BitSet convertToEntityAttribute(final String dbData) {
+			BitSet bitSet = new BitSet();
+			bitSet.set( 7, true );
+			return bitSet;
+		}
+	}
+}


### PR DESCRIPTION
Jira issue [HHH-19589](https://hibernate.atlassian.net/browse/HHH-19589)

When property is annotated with `@Convert` there is no need to check if user type is registered


----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
