### PR TITLE
HHH-3404 regexp on Informix

### DIFF
--- a/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/InformixDialect.java
+++ b/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/InformixDialect.java
@@ -367,6 +367,8 @@ public class InformixDialect extends Dialect {
 		final TypeConfiguration typeConfiguration = functionContributions.getTypeConfiguration();
 		final BasicType<String> stringBasicType =
 				typeConfiguration.getBasicTypeRegistry().resolve( StandardBasicTypes.STRING );
+		final BasicType<Boolean> booleanBasicType =
+				typeConfiguration.getBasicTypeRegistry().resolve( StandardBasicTypes.BOOLEAN );
 
 		functionRegistry.registerAlternateKey( "var_samp", "variance" );
 
@@ -408,6 +410,12 @@ public class InformixDialect extends Dialect {
 		// parameter arguments to trim() require a cast
 		functionContributions.getFunctionRegistry().register( "trim",
 				new TrimFunction( this, typeConfiguration, SqlAstNodeRenderingMode.NO_UNTYPED ) );
+
+		//TODO: emulate support for the 'i' flag argument
+		functionRegistry.namedDescriptorBuilder( "regexp_like", "regex_match"  )
+				.setParameterTypes( STRING, STRING )
+				.setInvariantType( booleanBasicType )
+				.register();
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/dialect/function/CommonFunctionFactory.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/function/CommonFunctionFactory.java
@@ -2671,7 +2671,6 @@ public class CommonFunctionFactory {
 				.setParameterTypes( STRING, STRING, STRING )
 				.setInvariantType( booleanType )
 				.register();
-
 	}
 
 	/**

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/query/hql/RegexTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/query/hql/RegexTest.java
@@ -4,6 +4,7 @@
  */
 package org.hibernate.orm.test.query.hql;
 
+import org.hibernate.community.dialect.InformixDialect;
 import org.hibernate.dialect.HSQLDialect;
 import org.hibernate.dialect.MariaDBDialect;
 import org.hibernate.dialect.OracleDialect;
@@ -41,6 +42,8 @@ class RegexTest {
 			reason = "regexp_like coming in 2025")
 	@SkipForDialect(dialectClass = SybaseASEDialect.class,
 			reason = "no regex support in Sybase ASE")
+	@SkipForDialect(dialectClass = InformixDialect.class,
+			reason = "This could be made to work on Informix by changing the flags")
 	void testInSelectCaseInsensitive(EntityManagerFactoryScope scope) {
 		if ( !( scope.getDialect() instanceof OracleDialect dialect
 				&& ( dialect.isAutonomous() || dialect.getVersion().isBefore( 23 ) ) ) ) {


### PR DESCRIPTION
Not implemented: support for 'ilike regexp'

<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

[Please describe here what your change is about]

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-3404
<!-- Hibernate GitHub Bot issue links end -->