### PR TITLE
Reproducer for HHH-19725 / HHH-18217 StatelessSession#upsert does not insert entity that only has an ID

### DIFF
--- a/hibernate-core/src/test/java/org/hibernate/orm/test/stateless/UpsertTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/stateless/UpsertTest.java
@@ -18,9 +18,10 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 @SessionFactory(useCollectingStatementInspector = true)
-@DomainModel(annotatedClasses = UpsertTest.Record.class)
+@DomainModel(annotatedClasses = {UpsertTest.Record.class, UpsertTest.IdOnly.class})
 public class UpsertTest {
 	@Test void test(SessionFactoryScope scope) {
 		scope.getSessionFactory().getSchemaManager().truncate();
@@ -96,6 +97,19 @@ public class UpsertTest {
 		scope.inStatelessTransaction(s-> assertDoesNotThrow(() -> s.upsert(new Record(123L,null, null))) );
 	}
 
+	@Test void testIdOnly(SessionFactoryScope scope) {
+		scope.getSessionFactory().getSchemaManager().truncate();
+
+		scope.inStatelessTransaction(s-> {
+			s.upsert(new IdOnly(123L));
+			s.upsert(new IdOnly(456L));
+		});
+		scope.inStatelessTransaction(s-> {
+			assertNotNull(s.get( IdOnly.class,123L));
+			assertNotNull(s.get( IdOnly.class,456L));
+		});
+	}
+
 	@Entity(name = "Record")
 	static class Record {
 		@Id Long id;
@@ -114,6 +128,18 @@ public class UpsertTest {
 		}
 
 		Record() {
+		}
+	}
+
+	@Entity(name = "IdOnly")
+	static class IdOnly {
+		@Id Long id;
+
+		IdOnly(Long id) {
+			this.id = id;
+		}
+
+		IdOnly() {
 		}
 	}
 }


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-19725

(possibly https://hibernate.atlassian.net/browse/HHH-18217, see discussion on the issue above)

Reproducer only, no fix.

----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------