### PR TITLE
[7.1] Backport HHH-19721 to branch 7.1 - Jakarta Data is missing from hibernate-platform (BOM)

### DIFF
--- a/hibernate-platform/hibernate-platform.gradle
+++ b/hibernate-platform/hibernate-platform.gradle
@@ -36,6 +36,7 @@ dependencies {
 
         api jakartaLibs.jpa
         api jakartaLibs.jta
+        api jakartaLibs.data
 
         runtime libs.antlrRuntime
         runtime libs.logging


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-19721

Backport of #10798 