### PR TITLE
HHH-19732 Fix wrong resetting of owned on-delete action when processing inverse collection

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/boot/model/internal/CollectionBinder.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/internal/CollectionBinder.java
@@ -50,6 +50,7 @@ import org.hibernate.mapping.Property;
 import org.hibernate.mapping.Selectable;
 import org.hibernate.mapping.SimpleValue;
 import org.hibernate.mapping.Table;
+import org.hibernate.mapping.ToOne;
 import org.hibernate.mapping.Value;
 import org.hibernate.metamodel.CollectionClassification;
 import org.hibernate.metamodel.UnsupportedMappingException;
@@ -2746,6 +2747,13 @@ public abstract class CollectionBinder {
 			//TODO always a many to one?
 			manyToOne.setReferencedPropertyName( referencedPropertyName );
 			metadataCollector.addUniquePropertyReference( targetEntity.getEntityName(), referencedPropertyName );
+		}
+		// Ensure that we copy over the delete action from the owner side before creating the foreign key
+		if ( property.getValue() instanceof Collection collectionValue ) {
+			manyToOne.setOnDeleteAction( ( (SimpleValue) collectionValue.getKey() ).getOnDeleteAction() );
+		}
+		else if ( property.getValue() instanceof ToOne toOne ) {
+			manyToOne.setOnDeleteAction( toOne.getOnDeleteAction() );
 		}
 		manyToOne.setReferenceToPrimaryKey( referencedPropertyName == null );
 		value.createForeignKey();

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/ondeletecascade/OnDeleteManyToManyTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/ondeletecascade/OnDeleteManyToManyTest.java
@@ -88,5 +88,8 @@ class OnDeleteManyToManyTest {
 	static class B {
 		@Id
 		long id;
+		@ManyToMany(mappedBy = "bs")
+		@OnDelete(action = OnDeleteAction.CASCADE)
+		Set<A> as = new HashSet<>();
 	}
 }


### PR DESCRIPTION
<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

[Please describe here what your change is about]

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-19732
<!-- Hibernate GitHub Bot issue links end -->