### PR TITLE
Backport HHH-14914 to branch 5.6 - Passing an ExtendedBeanManager which is never notified leads to runtime errors

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/resource/beans/container/internal/JpaCompliantLifecycleStrategy.java
+++ b/hibernate-core/src/main/java/org/hibernate/resource/beans/container/internal/JpaCompliantLifecycleStrategy.java
@@ -104,6 +104,21 @@ public class JpaCompliantLifecycleStrategy implements BeanLifecycleStrategy {
 				return;
 			}
 
+			if ( beanManager == null ) {
+				try {
+					beanInstance = fallbackProducer.produceBeanInstance( beanType );
+					return;
+				}
+				catch (Exception e) {
+					// the CDI BeanManager is not know to be ready for use and the
+					// fallback-producer was unable to create the bean...
+					throw new IllegalStateException(
+							"CDI BeanManager is not known to be ready for use and the fallback-producer was unable to create the bean",
+							new NotYetReadyException( e )
+					);
+				}
+			}
+
 			final AnnotatedType<B> annotatedType;
 			try {
 				annotatedType = beanManager.createAnnotatedType( beanType );

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/cdi/lifecycle/ExtendedBeanManagerNoCallbackTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/cdi/lifecycle/ExtendedBeanManagerNoCallbackTest.java
@@ -1,0 +1,68 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html
+ */
+package org.hibernate.orm.test.cdi.lifecycle;
+
+import org.hibernate.boot.MetadataSources;
+import org.hibernate.boot.registry.StandardServiceRegistry;
+import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
+import org.hibernate.cfg.AvailableSettings;
+import org.hibernate.resource.beans.container.spi.ExtendedBeanManager;
+
+import org.junit.jupiter.api.Test;
+
+import javax.enterprise.inject.spi.BeanManager;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.Table;
+
+/**
+ * We pass an ExtendedBeanManager but never "initialize" it.  This might happen when the
+ * environment provides an ExtendedBeanManager but there is no CDI needed for the app
+ */
+public class ExtendedBeanManagerNoCallbackTest {
+	@Test
+	public void tryIt() {
+		final StandardServiceRegistry ssr = new StandardServiceRegistryBuilder()
+				.applySetting( AvailableSettings.JAKARTA_CDI_BEAN_MANAGER, new ExtendedBeanManagerImpl() )
+				.build();
+
+		try {
+			// this will trigger trying to locate IdentifierGeneratorFactory as a managed-bean
+			new MetadataSources( ssr )
+					.addAnnotatedClass( TheEntity.class )
+					.buildMetadata()
+					.buildSessionFactory();
+		}
+		finally {
+			StandardServiceRegistryBuilder.destroy( ssr );
+		}
+	}
+
+	@Entity(name = "TheEntity")
+	@Table(name = "TheEntity")
+	public static class TheEntity {
+		@Id
+		@GeneratedValue
+		private Integer id;
+		private String name;
+	}
+
+	public static class ExtendedBeanManagerImpl implements ExtendedBeanManager {
+		private LifecycleListener lifecycleListener;
+
+		@Override
+		public void registerLifecycleListener(LifecycleListener lifecycleListener) {
+			assert this.lifecycleListener == null;
+			this.lifecycleListener = lifecycleListener;
+		}
+
+		public void notify(BeanManager ready) {
+			lifecycleListener.beanManagerInitialized( ready );
+		}
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/test/cdi/events/MyIdGenerator.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/cdi/events/MyIdGenerator.java
@@ -1,0 +1,27 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html
+ */
+package org.hibernate.test.cdi.events;
+
+import org.hibernate.HibernateException;
+import org.hibernate.engine.spi.SharedSessionContractImplementor;
+import org.hibernate.id.IdentifierGenerator;
+
+import java.io.Serializable;
+
+/**
+ * A custom ID generator that does not require CDI, so should be instantiated correctly in every scenario.
+ * <p>
+ * Not really functional: only ever generates a single hardcoded ID, for convenience of testing.
+ */
+public class MyIdGenerator implements IdentifierGenerator {
+    public static final int HARDCODED_ID = 42;
+
+    @Override
+    public Serializable generate(SharedSessionContractImplementor session, Object object) throws HibernateException {
+        return HARDCODED_ID;
+    }
+}

--- a/hibernate-core/src/test/java/org/hibernate/test/cdi/events/TheEntity.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/cdi/events/TheEntity.java
@@ -6,10 +6,9 @@
  */
 package org.hibernate.test.cdi.events;
 
-import javax.persistence.Entity;
-import javax.persistence.EntityListeners;
-import javax.persistence.Id;
-import javax.persistence.Table;
+import org.hibernate.annotations.GenericGenerator;
+
+import javax.persistence.*;
 
 /**
  * @author Steve Ebersole
@@ -29,6 +28,8 @@ public class TheEntity {
 	}
 
 	@Id
+    @GeneratedValue(generator = "mygenerator")
+    @GenericGenerator(name = "mygenerator", strategy = "org.hibernate.test.cdi.events.MyIdGenerator")
 	public Integer getId() {
 		return id;
 	}

--- a/hibernate-core/src/test/java/org/hibernate/test/cdi/events/delayed/DelayedCdiSupportTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/cdi/events/delayed/DelayedCdiSupportTest.java
@@ -16,6 +16,7 @@ import org.hibernate.boot.registry.StandardServiceRegistry;
 import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
 import org.hibernate.cfg.AvailableSettings;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
+import org.hibernate.test.cdi.events.MyIdGenerator;
 import org.hibernate.tool.schema.Action;
 
 import org.hibernate.testing.junit4.BaseUnitTestCase;
@@ -74,7 +75,7 @@ public class DelayedCdiSupportTest extends BaseUnitTestCase {
 			try {
 				inTransaction(
 						sessionFactory,
-						session -> session.persist( new TheEntity( 1 ) )
+						session -> session.persist( new TheEntity() )
 				);
 
 				// The CDI bean should have been built on first use
@@ -84,7 +85,7 @@ public class DelayedCdiSupportTest extends BaseUnitTestCase {
 				inTransaction(
 						sessionFactory,
 						session -> {
-							TheEntity it = session.find( TheEntity.class, 1 );
+							TheEntity it = session.find( TheEntity.class, MyIdGenerator.HARDCODED_ID);
 							assertNotNull( it );
 						}
 				);

--- a/hibernate-core/src/test/java/org/hibernate/test/cdi/events/extended/InvalidExtendedCdiSupportTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/cdi/events/extended/InvalidExtendedCdiSupportTest.java
@@ -86,7 +86,7 @@ public class InvalidExtendedCdiSupportTest extends BaseUnitTestCase {
 			try {
 				inTransaction(
 						sessionFactory,
-						session -> session.persist( new TheEntity( 1 ) )
+						session -> session.persist( new TheEntity() )
 				);
 
 				inTransaction(

--- a/hibernate-core/src/test/java/org/hibernate/test/cdi/events/extended/ValidExtendedCdiSupportTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/cdi/events/extended/ValidExtendedCdiSupportTest.java
@@ -19,6 +19,7 @@ import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
 import org.hibernate.cfg.AvailableSettings;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.resource.beans.container.spi.ExtendedBeanManager;
+import org.hibernate.test.cdi.events.MyIdGenerator;
 import org.hibernate.tool.schema.Action;
 
 import org.hibernate.testing.junit4.BaseUnitTestCase;
@@ -103,13 +104,13 @@ public class ValidExtendedCdiSupportTest extends BaseUnitTestCase {
 				try {
 					inTransaction(
 							sessionFactory,
-							session -> session.persist( new TheEntity( 1 ) )
+							session -> session.persist( new TheEntity() )
 					);
 
 					inTransaction(
 							sessionFactory,
 							session -> {
-								TheEntity it = session.find( TheEntity.class, 1 );
+								TheEntity it = session.find( TheEntity.class, MyIdGenerator.HARDCODED_ID );
 								assertNotNull( it );
 							}
 					);

--- a/hibernate-core/src/test/java/org/hibernate/test/cdi/events/standard/StandardCdiSupportTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/cdi/events/standard/StandardCdiSupportTest.java
@@ -16,6 +16,7 @@ import org.hibernate.boot.registry.StandardServiceRegistry;
 import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
 import org.hibernate.cfg.AvailableSettings;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
+import org.hibernate.test.cdi.events.MyIdGenerator;
 import org.hibernate.tool.schema.Action;
 
 import org.hibernate.testing.junit4.BaseUnitTestCase;
@@ -72,7 +73,7 @@ public class StandardCdiSupportTest extends BaseUnitTestCase {
 			try {
 				inTransaction(
 						sessionFactory,
-						session -> session.persist( new TheEntity( 1 ) )
+						session -> session.persist( new TheEntity() )
 				);
 
 				assertEquals( 1, Monitor.currentCount() );
@@ -80,7 +81,7 @@ public class StandardCdiSupportTest extends BaseUnitTestCase {
 				inTransaction(
 						sessionFactory,
 						session -> {
-							TheEntity it = session.find( TheEntity.class, 1 );
+							TheEntity it = session.find( TheEntity.class, MyIdGenerator.HARDCODED_ID );
 							assertNotNull( it );
 						}
 				);


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-14914

Backport of https://github.com/hibernate/hibernate-orm/commit/9fec060fe2c61881080b410ddd4a93799d2b581b to branch 5.6.

Also adds a test change to precisely describe the problem that was reported to us in 5.6. We might want to add this test change to `6.6`/`main` too, just in case?