### PR TITLE
HHH-19734 Ensure shallow cached entity is not left uninitialized when bytecode enhanced

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/entity/internal/EntityInitializerImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/entity/internal/EntityInitializerImpl.java
@@ -1118,6 +1118,10 @@ public class EntityInitializerImpl extends AbstractInitializer<EntityInitializer
 				else if ( data.entityHolder.getEntityInitializer() != this ) {
 					data.setState( State.INITIALIZED );
 				}
+				else if ( data.shallowCached ) {
+					// For shallow cached entities, only the id is available, so ensure we load the data immediately
+					data.setInstance( data.entityInstanceForNotify = resolveEntityInstance( data ) );
+				}
 			}
 			else if ( ( entityFromExecutionContext = getEntityFromExecutionContext( data ) ) != null ) {
 				// This is the entity to refresh, so don't set the state to initialized
@@ -1231,7 +1235,7 @@ public class EntityInitializerImpl extends AbstractInitializer<EntityInitializer
 			return resolved;
 		}
 		else {
-			if ( rowProcessingState.isQueryCacheHit() && entityDescriptor.useShallowQueryCacheLayout() ) {
+			if ( data.shallowCached ) {
 				// We must load the entity this way, because the query cache entry contains only the primary key
 				data.setState( State.INITIALIZED );
 				final SharedSessionContractImplementor session = rowProcessingState.getSession();

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/query/CachedQueryShallowWithDiscriminatorBytecodeEnhancedTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/query/CachedQueryShallowWithDiscriminatorBytecodeEnhancedTest.java
@@ -1,0 +1,163 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.jpa.query;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.Id;
+import jakarta.persistence.TypedQuery;
+import org.hibernate.annotations.Cache;
+import org.hibernate.annotations.CacheConcurrencyStrategy;
+import org.hibernate.annotations.CacheLayout;
+import org.hibernate.annotations.QueryCacheLayout;
+import org.hibernate.cfg.AvailableSettings;
+import org.hibernate.engine.spi.SessionFactoryImplementor;
+import org.hibernate.stat.Statistics;
+import org.hibernate.testing.bytecode.enhancement.extension.BytecodeEnhanced;
+import org.hibernate.testing.orm.junit.EntityManagerFactoryScope;
+import org.hibernate.testing.orm.junit.JiraKey;
+import org.hibernate.testing.orm.junit.Jpa;
+import org.hibernate.testing.orm.junit.Setting;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.hibernate.jpa.HibernateHints.HINT_CACHEABLE;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@JiraKey("HHH-19734")
+@Jpa(
+		annotatedClasses = {
+				CachedQueryShallowWithDiscriminatorBytecodeEnhancedTest.Person.class
+		},
+		generateStatistics = true,
+		properties = {
+				@Setting(name = AvailableSettings.USE_QUERY_CACHE, value = "true"),
+				@Setting(name = AvailableSettings.USE_SECOND_LEVEL_CACHE, value = "true")
+		}
+)
+@BytecodeEnhanced
+public class CachedQueryShallowWithDiscriminatorBytecodeEnhancedTest {
+
+	public final static String HQL = "select p from Person p";
+
+	@BeforeEach
+	public void setUp(EntityManagerFactoryScope scope) {
+		scope.inTransaction(
+				em -> {
+					Person person = new Person( 1L );
+					person.setName( "Bob" );
+					em.persist( person );
+				}
+		);
+	}
+
+	@AfterEach
+	public void tearDown(EntityManagerFactoryScope scope) {
+		scope.getEntityManagerFactory().getSchemaManager().truncate();
+	}
+
+	@Test
+	public void testCacheableQuery(EntityManagerFactoryScope scope) {
+
+		Statistics stats = getStatistics( scope );
+		stats.clear();
+
+		// First time the query is executed, query and results are cached.
+		scope.inTransaction(
+				em -> {
+					loadPersons( em );
+
+					assertThatAnSQLQueryHasBeenExecuted( stats );
+
+					assertEquals( 0, stats.getQueryCacheHitCount() );
+					assertEquals( 1, stats.getQueryCacheMissCount() );
+					assertEquals( 1, stats.getQueryCachePutCount() );
+
+					assertEquals( 0, stats.getSecondLevelCacheHitCount() );
+					assertEquals( 0, stats.getSecondLevelCacheMissCount() );
+					assertEquals( 0, stats.getSecondLevelCachePutCount() );
+				}
+		);
+
+		stats.clear();
+
+		// Second time the query is executed, list of entities are read from query cache
+
+		scope.inTransaction(
+				em -> {
+					// Create a person proxy in the persistence context to trigger the HHH-19734 error
+					em.getReference( Person.class, 1L );
+
+					loadPersons( em );
+
+					assertThatNoSQLQueryHasBeenExecuted( stats );
+
+					assertEquals( 1, stats.getQueryCacheHitCount() );
+					assertEquals( 0, stats.getQueryCacheMissCount() );
+					assertEquals( 0, stats.getQueryCachePutCount() );
+
+					assertEquals( 1, stats.getSecondLevelCacheHitCount() );
+					assertEquals( 0, stats.getSecondLevelCacheMissCount() );
+					assertEquals( 0, stats.getSecondLevelCachePutCount() );
+				}
+		);
+
+	}
+
+	private static Statistics getStatistics(EntityManagerFactoryScope scope) {
+		return ((SessionFactoryImplementor) scope.getEntityManagerFactory()).getStatistics();
+	}
+
+	private static void loadPersons(EntityManager em) {
+		TypedQuery<Person> query = em.createQuery( HQL, Person.class )
+				.setHint( HINT_CACHEABLE, true );
+		Person person = query.getSingleResult();
+		assertEquals( 1L, person.getId() );
+		assertEquals( "Bob", person.getName() );
+	}
+
+	private static void assertThatAnSQLQueryHasBeenExecuted(Statistics stats) {
+		assertEquals( 1, stats.getQueryStatistics( HQL ).getExecutionCount() );
+	}
+
+	private static void assertThatNoSQLQueryHasBeenExecuted(Statistics stats) {
+		assertEquals( 0, stats.getQueryStatistics( HQL ).getExecutionCount() );
+	}
+
+	@Entity(name = "Person")
+	@Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
+	@QueryCacheLayout(layout = CacheLayout.SHALLOW)
+	public static class Person {
+		@Id
+		private Long id;
+		private String name;
+
+		public Person() {
+			super();
+		}
+
+		public Person(Long id) {
+			this.id = id;
+		}
+
+		public Long getId() {
+			return id;
+		}
+
+		public void setId(Long id) {
+			this.id = id;
+		}
+
+		public String getName() {
+			return name;
+		}
+
+		public void setName(String name) {
+			this.name = name;
+		}
+	}
+
+}

--- a/hibernate-testing/src/main/java/org/hibernate/testing/orm/jpa/PersistenceUnitInfoImpl.java
+++ b/hibernate-testing/src/main/java/org/hibernate/testing/orm/jpa/PersistenceUnitInfoImpl.java
@@ -44,6 +44,7 @@ public class PersistenceUnitInfoImpl implements PersistenceUnitInfo {
 	private List<String> mappingFiles;
 	private List<String> managedClassNames;
 	private boolean excludeUnlistedClasses;
+	private ClassLoader classLoader;
 
 	public PersistenceUnitInfoImpl(String name) {
 		this.name = name;
@@ -143,6 +144,15 @@ public class PersistenceUnitInfoImpl implements PersistenceUnitInfo {
 	}
 
 	@Override
+	public ClassLoader getClassLoader() {
+		return classLoader;
+	}
+
+	public void setClassLoader(ClassLoader classLoader) {
+		this.classLoader = classLoader;
+	}
+
+	@Override
 	public String getPersistenceXMLSchemaVersion() {
 		return null;
 	}
@@ -164,11 +174,6 @@ public class PersistenceUnitInfoImpl implements PersistenceUnitInfo {
 
 	@Override
 	public URL getPersistenceUnitRootUrl() {
-		return null;
-	}
-
-	@Override
-	public ClassLoader getClassLoader() {
 		return null;
 	}
 

--- a/hibernate-testing/src/main/java/org/hibernate/testing/orm/junit/EntityManagerFactoryExtension.java
+++ b/hibernate-testing/src/main/java/org/hibernate/testing/orm/junit/EntityManagerFactoryExtension.java
@@ -111,6 +111,9 @@ public class EntityManagerFactoryExtension
 	private static PersistenceUnitInfoImpl createPersistenceUnitInfo(Jpa jpa) {
 		final PersistenceUnitInfoImpl pui =
 				new PersistenceUnitInfoImpl( jpa.persistenceUnitName() );
+		// Use the context class loader for entity loading if configured,
+		// to make enhancement work for tests
+		pui.setClassLoader( Thread.currentThread().getContextClassLoader() );
 		pui.setTransactionType( jpa.transactionType() );
 		pui.setCacheMode( jpa.sharedCacheMode() );
 		pui.setValidationMode( jpa.validationMode() );


### PR DESCRIPTION
<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

[Please describe here what your change is about]

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
