### PR TITLE
HHH-19519: Document breaking changes in new Hibernate Maven Plugin

### DIFF
--- a/documentation/src/main/asciidoc/userguide/chapters/tooling/extras/maven-example.pom
+++ b/documentation/src/main/asciidoc/userguide/chapters/tooling/extras/maven-example.pom
@@ -2,17 +2,11 @@
     <plugins>
         [...]
         <plugin>
-            <groupId>org.hibernate.orm.tooling</groupId>
-            <artifactId>hibernate-enhance-maven-plugin</artifactId>
+            <groupId>org.hibernate.orm</groupId>
+            <artifactId>hibernate-maven-plugin</artifactId>
             <version>$currentHibernateVersion</version>
             <executions>
                 <execution>
-                    <configuration>
-                        <failOnError>true</failOnError>
-                        <enableLazyInitialization>true</enableLazyInitialization>
-                        <enableDirtyTracking>true</enableDirtyTracking>
-                        <enableAssociationManagement>true</enableAssociationManagement>
-                    </configuration>
                     <goals>
                         <goal>enhance</goal>
                     </goals>

--- a/documentation/src/main/asciidoc/userguide/chapters/tooling/maven.adoc
+++ b/documentation/src/main/asciidoc/userguide/chapters/tooling/maven.adoc
@@ -9,8 +9,14 @@ The following sections illustrate how both <<tooling-maven-enhancement,bytecode 
 Hibernate provides a https://maven.apache.org/[Maven] plugin capable of providing
 build-time enhancement of the domain model as they are compiled as part of a Maven
 build.  See the section on <<BytecodeEnhancement>> for details
-on the configuration settings.  By default, all enhancements are disabled.
+on the configuration settings.
 
+[[maven-enhance-goal]]
+===== *Enhance Goal* =====
+
+An example of using the `enhance` goal of the plugin is shown below. By default the plugin will
+perform bytecode enhancement for lazy initialization and dirty tracking. See <<maven-enhance-configuration, below>>
+for more details on the available parameters.
 
 .Apply the Bytecode Enhancement plugin
 ====
@@ -19,6 +25,136 @@ on the configuration settings.  By default, all enhancements are disabled.
 include::extras/maven-example.pom[]
 ----
 ====
+
+[[maven-enhance-configuration]]
+===== *Enhance Configuration* =====
+
+[[maven-enhance-classesDirectory-parameter]]
+====== `*classesDirectory*` ======
+This parameter points to the folder in which to look for classes to enhance.
+It defaults to the value of `{project.build.directory}/classes` and thus in most cases to `target/classes`.
+While this parameter is mandatory, its value will be ignored if the <<maven-enhance-filesets-parameter, fileSets>>
+parameter is specified.
+
+====
+[source,xml]
+----
+[...]
+<execution>
+  <configuration>
+    <classesDirectory>path-to-some-folder</classesDirectory>
+  </configuration>
+  [...]
+</execution>
+[...]
+----
+====
+
+[[maven-enhance-filesets-parameter]]
+====== `*fileSets*` ======
+This parameter comes in handy when you need to filter the classes that you want to enhance. More information
+on how to use filesets is to be found on the
+https://maven.apache.org/shared/file-management/fileset.html[fileset documentation page].
+This is an optional parameter but if it is specified the
+<<maven-enhance-classesDirectory-parameter, classesDirectory>> parameter described above is ignored.
+
+====
+[source,xml]
+----
+[...]
+<execution>
+  <configuration>
+    <fileSets>
+      <fileset dir="path-to-some-folder">
+        <exclude name='Baz.class' />
+      </fileset>
+    </fileSets>
+  </configuration>
+  [...]
+</execution>
+[...]
+----
+====
+
+[[maven-enhance-enableLazyInitialization-parameter]]
+===== `*enableLazyInitialization*` =====
+This parameter has a default value of `true`. It indicates that the enhance goal should perform the changes
+to enable lazy loading. To disable, set the value of this attribute to `false`.
+The parameter has been deprecated for removal.
+
+====
+[source,xml]
+----
+[...]
+<execution>
+  <configuration>
+    <enableLazyInitialization>false</enableLazyInitialization>
+  </configuration>
+  [...]
+</execution>
+[...]
+----
+====
+
+[[maven-enhance-enableDirtyTracking-parameter]]
+===== `*enableDirtyTracking*` =====
+This parameter has a default value of `true`. It indicates that the enhance task should perform the changes
+to enable dirty tracking. To disable, set the value of this attribute to `false`.
+The parameter has been deprecated for removal.
+
+====
+[source,xml]
+----
+[...]
+<execution>
+  <configuration>
+    <enableDirtyTracking>false</enableDirtyTracking>
+  </configuration>
+  [...]
+</execution>
+[...]
+----
+====
+
+[[maven-enhance-enableAssociationManagement-parameter]]
+===== `*enableAssociationManagement*` =====
+This parameter has a default value of `false`. It indicates that the enhance task should not perform the changes
+to enable association management. To enable, set the value of this attribute to `true`.
+
+====
+[source,xml]
+----
+[...]
+<execution>
+  <configuration>
+    <enableAssociationManagement>true</enableAssociationManagement>
+  </configuration>
+  [...]
+</execution>
+[...]
+----
+====
+
+[[maven-enhance-enableExtendedEnhancement-paremeter]]
+===== `*enableExtendedEnhancement*` =====
+This parameter has a default value of `false`. It indicates that the enhance task should not perform the changes
+to enable the extended enhancement (i.e. even on non-entities).
+To enable this, set the value of this attribute to `true`.
+
+====
+[source,xml]
+----
+[...]
+<execution>
+  <configuration>
+    <enableExtendedEnhancement>true</enableExtendedEnhancement>
+  </configuration>
+  [...]
+</execution>
+[...]
+----
+====
+
 
 [[tooling-maven-modelgen]]
 ==== Static Metamodel Generation

--- a/tooling/hibernate-maven-plugin/hibernate-maven-plugin.gradle
+++ b/tooling/hibernate-maven-plugin/hibernate-maven-plugin.gradle
@@ -38,7 +38,8 @@ dependencies {
     intTestRuntimeOnly 'org.junit.platform:junit-platform-launcher'
     intTestRuntimeOnly 'ch.qos.logback:logback-classic:1.5.18'
     intTestRuntimeOnly 'org.apache.maven:maven-compat:3.9.11'
-
+    intTestRuntimeOnly 'org.apache.maven.resolver:maven-resolver-transport-http:1.9.24'
+    intTestRuntimeOnly 'org.apache.maven.resolver:maven-resolver-connector-basic:1.9.24'
 }
 
 def releasePrepareTask = tasks.register("releasePrepare") {

--- a/tooling/hibernate-maven-plugin/hibernate-maven-plugin.gradle
+++ b/tooling/hibernate-maven-plugin/hibernate-maven-plugin.gradle
@@ -12,14 +12,33 @@ plugins {
 
 description = 'Maven plugin to integrate aspects of Hibernate into your build.'
 
+sourceSets {
+    intTest {
+        compileClasspath += sourceSets.main.output
+        runtimeClasspath += sourceSets.main.output
+    }
+}
+
+configurations {
+    intTestImplementation.extendsFrom implementation
+    intTestRuntimeOnly.extendsFrom runtimeOnly
+}
+
 dependencies {
     implementation project( ":hibernate-core" )
 
-    implementation "org.apache.maven:maven-plugin-api:3.6.3"
+    implementation "org.apache.maven:maven-plugin-api:3.9.11"
     implementation "org.apache.maven:maven-project:2.2.1"
     implementation "org.apache.maven.shared:file-management:3.1.0"
 
-    compileOnly "org.apache.maven.plugin-tools:maven-plugin-annotations:3.6.0"
+    compileOnly "org.apache.maven.plugin-tools:maven-plugin-tools-annotations:3.15.1"
+
+    intTestImplementation 'org.junit.jupiter:junit-jupiter:5.13.4'
+    intTestImplementation 'org.apache.maven:maven-embedder:3.9.11'
+    intTestRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    intTestRuntimeOnly 'ch.qos.logback:logback-classic:1.5.18'
+    intTestRuntimeOnly 'org.apache.maven:maven-compat:3.9.11'
+
 }
 
 def releasePrepareTask = tasks.register("releasePrepare") {
@@ -35,6 +54,25 @@ tasks.register("preVerifyRelease") {
     description "Delegates to `releasePrepare` task"
 
     dependsOn releasePrepareTask
+}
+
+tasks.register('integrationTest', Test) {
+    description = 'Runs integration tests.'
+    group = 'verification'
+
+    testClassesDirs = sourceSets.intTest.output.classesDirs
+    classpath = sourceSets.intTest.runtimeClasspath
+    shouldRunAfter test
+
+    useJUnitPlatform()
+
+    testLogging {
+        events "passed"
+    }
+}
+
+tasks.forbiddenApisIntTest {
+    enabled = false
 }
 
 var publishingExtension = project.getExtensions().getByType(PublishingExtension) as PublishingExtension
@@ -63,4 +101,12 @@ publishingExtension.publications.named("publishedArtifacts") {
                 }
     }
 }
+
+integrationTest {
+    environment "hibernateVersion", project.version
+}
+
+integrationTest.dependsOn rootProject.childProjects.'hibernate-core'.tasks.publishToMavenLocal
+integrationTest.dependsOn publishToMavenLocal
+check.dependsOn integrationTest
 

--- a/tooling/hibernate-maven-plugin/src/intTest/java/org/hibernate/orm/tooling/maven/EnhancerMojoTestIT.java
+++ b/tooling/hibernate-maven-plugin/src/intTest/java/org/hibernate/orm/tooling/maven/EnhancerMojoTestIT.java
@@ -1,0 +1,321 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.tooling.maven;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import org.apache.maven.cli.MavenCli;
+import org.hibernate.bytecode.enhance.spi.EnhancementInfo;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.File;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.nio.file.Files;
+import java.util.List;
+
+public class EnhancerMojoTestIT {
+
+	public static final String MVN_HOME = "maven.multiModuleProjectDirectory";
+
+	@TempDir
+	File projectDir;
+
+	private MavenCli mavenCli;
+
+	@BeforeEach
+	public void beforeEach() throws Exception {
+		copyJavFiles();
+		System.setProperty(MVN_HOME, projectDir.getAbsolutePath());
+		mavenCli = new MavenCli();
+	}
+
+	@Test
+	public void testEnhancementDefault() throws Exception {
+		// The default configuration for the enhance goal are as follows:
+		//   enableLazyInitialization = 'true'
+		//   enableDirtyTracking = 'true'
+		//   enableAssociationManagement = 'false'
+		//   enableExtendedEnhancement = 'false'
+		//   classesDirectory = 'target/classes'
+		String configurationElement = "<configuration/>\n";
+		preparePomXml(configurationElement);
+		executeCompileGoal();
+		executeEnhanceGoal();
+		// Both Bar and Baz should be enhanced
+		assertTrue(isEnhanced( "Bar" ));
+		assertTrue(isEnhanced( "Baz" ));
+		// Both Bar and Baz contain the method '$$_hibernate_getInterceptor'
+		// because of the default setting of 'enableLazyInitialization'
+		assertTrue( methodIsPresentInClass("$$_hibernate_getInterceptor", "Bar"));
+		assertTrue( methodIsPresentInClass("$$_hibernate_getInterceptor", "Baz"));
+		// Both Bar and Baz contain the method '$$_hibernate_hasDirtyAttributes'
+		// because of the default setting of 'enableDirtyTracking'
+		assertTrue( methodIsPresentInClass("$$_hibernate_hasDirtyAttributes", "Bar"));
+		assertTrue( methodIsPresentInClass("$$_hibernate_hasDirtyAttributes", "Baz"));
+		// Foo is not an entity and extended enhancement is not enabled so the class is not enhanced
+		assertFalse(isEnhanced("Foo"));
+		// Association management should not be present
+		assertFalse(isAssociationManagementPresent());
+	}
+
+	@Test
+	public void testEnhancementFileSet() throws Exception {
+		// Use the defaults settings for enhancement (see #testEnhancementDefault)
+		// The files are read from the specified 'fileset' element:
+		//   - the folder specified by 'dir'
+		//   - the 'Baz.class' file is excluded
+		String configurationElement =
+				"<configuration>\n" +
+				"  <fileSets>\n"+
+				"    <fileset>\n" +
+				"      <directory>" + projectDir.getAbsolutePath() + "/target" + "</directory>\n" +
+				"      <excludes>\n" +
+				"        <exclude>**/Baz.class</exclude>\n" +
+				"      </excludes>\n" +
+				"    </fileset>\n" +
+				"  </fileSets>\n" +
+				"</configuration>\n";
+		preparePomXml(configurationElement);
+		executeCompileGoal();
+		executeEnhanceGoal();
+		// Bar is enhanced
+		assertTrue(isEnhanced( "Bar" ));
+		// Baz is not enhanced because it was excluded from the file set
+		assertFalse(isEnhanced( "Baz" ));
+		// Foo is not enhanced because it is not an entity and extended enhancement was not enabled
+		assertFalse( isEnhanced( "Foo" ) );
+		// Association management should not be present
+		assertFalse(isAssociationManagementPresent());
+	}
+
+	@Test
+	public void testEnhancementNoLazyInitialization() throws Exception {
+		// Change the default setting for 'enableLazyInitialization' to 'false'
+		// Otherwise use the settings of #testEnhancementDefault
+		String configurationElement =
+				"<configuration>\n" +
+				"  <enableLazyInitialization>false</enableLazyInitialization>\n"+
+				"</configuration>\n";
+		preparePomXml(configurationElement);
+		executeCompileGoal();
+		executeEnhanceGoal();
+		// Both Bar and Baz are enhanced, Foo is not
+		assertTrue( isEnhanced( "Bar" ));
+		assertTrue( isEnhanced( "Baz" ));
+		// Foo is not enhanced because it is not an entity and extended enhancement was not enabled
+		assertFalse( isEnhanced( "Foo" ) );
+		// but $$_hibernate_getInterceptor is not present in the enhanced classes
+		// because of the 'false' value of 'enableLazyInitialization'
+		assertFalse( methodIsPresentInClass("$$_hibernate_getInterceptor", "Bar"));
+		assertFalse( methodIsPresentInClass("$$_hibernate_getInterceptor", "Baz"));
+		// Association management should not be present
+		assertFalse(isAssociationManagementPresent());
+	}
+
+	@Test
+	public void testEnhancementNoDirtyTracking() throws Exception {
+		// Change the default setting for 'enableDirtyTracking' to 'false'
+		// Otherwise use the settings of #testEnhancementDefault
+		String configurationElement =
+				"<configuration>\n" +
+				"  <enableDirtyTracking>false</enableDirtyTracking>\n"+
+				"</configuration>\n";
+		preparePomXml(configurationElement);
+		executeCompileGoal();
+		executeEnhanceGoal();
+		// Both Bar and Baz should be enhanced
+		assertTrue( isEnhanced( "Bar" ));
+		assertTrue( isEnhanced( "Baz" ));
+		// Foo is not enhanced because it is not an entity and extended enhancement was not enabled
+		assertFalse( isEnhanced( "Foo" ) );
+		// $$_hibernate_hasDirtyAttributes is not present in the enhanced classes
+		// because of the 'false' value of 'enableLazyInitialization'
+		assertFalse( methodIsPresentInClass("$$_hibernate_hasDirtyAttributes", "Bar"));
+		assertFalse( methodIsPresentInClass("$$_hibernate_hasDirtyAttributes", "Baz"));
+		// Association management should not be present
+		assertFalse(isAssociationManagementPresent());
+	}
+
+	@Test
+	public void testEnhancementEnableAssociationManagement() throws Exception {
+		// Change the default setting for 'enableAssociationManagement' to 'true'
+		// Otherwise use the settings of #testEnhancementDefault
+		String configurationElement =
+				"<configuration>\n" +
+				"  <enableAssociationManagement>true</enableAssociationManagement>\n"+
+				"</configuration>\n";
+		preparePomXml(configurationElement);
+		executeCompileGoal();
+		executeEnhanceGoal();
+		// Both Bar and Baz are enhanced, Foo is not
+		assertTrue( isEnhanced( "Bar" ));
+		assertTrue( isEnhanced( "Baz" ));
+		assertFalse( isEnhanced( "Foo" ) );
+		// Now verify that the association management is in place;
+		assertTrue(isAssociationManagementPresent());
+	}
+
+	@Test
+	public void testEnhancementEnableExtendedEnhancement() throws Exception {
+		// Change the default setting for 'enableExtendedEnhancement' to 'true'
+		// Otherwise use the settings of #testEnhancementDefault
+		String configurationElement =
+				"<configuration>\n" +
+				"  <enableExtendedEnhancement>true</enableExtendedEnhancement>\n"+
+				"</configuration>\n";
+		preparePomXml(configurationElement);
+		executeCompileGoal();
+		executeEnhanceGoal();
+		// Both Bar and Baz are enhanced because they are entities
+		assertTrue( isEnhanced( "Bar" ));
+		assertTrue( isEnhanced( "Baz" ));
+		// Though Foo is not an entity, it is enhanced because of the setting of 'enableExtendedEnhancement'
+		assertTrue( isEnhanced( "Foo" ) );
+		// No association management is in place;
+		assertFalse(isAssociationManagementPresent());
+	}
+
+
+	@Test
+	public void testNoEnhancement() throws Exception {
+		// Setting the values of all the settings to 'false' has the effect
+		// of not executing the enhancement at all.
+		// The setting of 'enableAssociationManagement' and 'enableExtendedEnhancement' to
+		// false is not really needed in this case as that's what their default is
+		String configurationElement =
+				"<configuration>\n" +
+				"  <enableLazyInitialization>false</enableLazyInitialization>\n"+
+				"  <enableDirtyTracking>false</enableDirtyTracking>\n"+
+				"  <enableAssociationManagement>false</enableAssociationManagement>\n"+
+				"  <enableExtendedEnhancement>false</enableExtendedEnhancement>\n"+
+				"</configuration>\n";
+		preparePomXml(configurationElement);
+		executeCompileGoal();
+		executeEnhanceGoal();
+		// None of the classes should be enhanced
+		assertFalse( isEnhanced( "Bar" ));
+		assertFalse( isEnhanced( "Baz" ));
+		assertFalse( isEnhanced( "Foo" ) );
+		// No association management is in place;
+		assertFalse(isAssociationManagementPresent());
+	}
+
+	private void executeCompileGoal() {
+		// The class files should not exist
+		assertFalse(fileExists("target/classes/Bar.class"));
+		assertFalse(fileExists("target/classes/Baz.class"));
+		assertFalse(fileExists("target/classes/Foo.class"));
+		// Execute the 'compile' target
+		new MavenCli().doMain(
+				new String[]{"compile"},
+				projectDir.getAbsolutePath(),
+				null,
+				null);
+		// The class files should exist now
+		assertTrue( fileExists( "target/classes/Bar.class" ) );
+		assertTrue( fileExists( "target/classes/Baz.class" ) );
+		assertTrue( fileExists( "target/classes/Foo.class" ) );
+	}
+
+	private void executeEnhanceGoal() throws Exception {
+		// The class files should not be enhanced at this point
+		assertFalse( isEnhanced( "Bar" ));
+		assertFalse( isEnhanced( "Baz" ));
+		assertFalse( isEnhanced( "Foo" ));
+		// Execute the 'enhance' target
+		mavenCli.doMain(
+				new String[]{"process-classes"},
+				projectDir.getAbsolutePath(),
+				null,
+				null);
+		// The results are verified in the respective tests
+	}
+
+	private void preparePomXml(String configurationElement) throws Exception {
+		URL url = getClass().getClassLoader().getResource("pom.xm_");
+		File source = new File(url.toURI());
+		assertFalse( fileExists( "pom.xml" ));
+		String pomXmlContents = new String(Files.readAllBytes( source.toPath() ));
+		pomXmlContents = pomXmlContents.replace( "@hibernate-version@", System.getenv("hibernateVersion"));
+		pomXmlContents = pomXmlContents.replace(  "@configuration@", configurationElement);
+		File destination = new File(projectDir, "pom.xml");
+		Files.writeString(destination.toPath(), pomXmlContents);
+		assertTrue( fileExists( "pom.xml" ) );
+	}
+
+	private void copyJavFiles() throws Exception {
+		File srcDir = new File(projectDir, "src/main/java");
+		srcDir.mkdirs();
+		String[] javFileNames = {"Bar.jav_", "Baz.jav_", "Foo.jav_"};
+		for (String javFileName : javFileNames) {
+			copyJavFile( javFileName, srcDir );
+		}
+	}
+
+	private void copyJavFile(String javFileName, File toFolder) throws Exception {
+		URL url = getClass().getClassLoader().getResource( javFileName );
+		assert url != null;
+		File source = new File(url.toURI());
+		File destination = new File(toFolder, javFileName.replace( '_', 'a' ));
+		assertTrue(source.exists());
+		assertTrue(source.isFile());
+		Files.copy(source.toPath(), destination.toPath());
+		assertTrue(destination.exists());
+		assertTrue(destination.isFile());
+	}
+
+	private ClassLoader getTestClassLoader() throws Exception {
+		return new URLClassLoader( new URL[] { new File(projectDir, "target/classes").toURI().toURL() } );
+	}
+
+	private boolean isEnhanced(String className) throws Exception {
+		return getTestClassLoader().loadClass( className ).isAnnotationPresent( EnhancementInfo.class );
+	}
+
+	private boolean methodIsPresentInClass(String methodName, String className) throws Exception {
+		Class<?> classToCheck = getTestClassLoader().loadClass( className );
+		try {
+			Object m = classToCheck.getMethod( methodName, new Class[] {} );
+			return true;
+		} catch (NoSuchMethodException e) {
+			return false;
+		}
+	}
+
+	private boolean isAssociationManagementPresent() throws Exception {
+		// Some dynamic programming
+		ClassLoader loader = getTestClassLoader();
+		// Obtain the class objects for 'Baz' and 'Bar'
+		Class<?> bazClass = loader.loadClass( "Baz" );
+		Class<?> barClass = loader.loadClass( "Bar" );
+		// Create an instance of both 'Baz' and 'Bar'
+		Object bazObject = bazClass.getDeclaredConstructor().newInstance();
+		Object barObject = barClass.getDeclaredConstructor().newInstance();
+		// Lookup the 'bars' field of class 'Baz' (an ArrayList of 'Bar' objects)
+		Field bazBarsField = bazClass.getDeclaredField( "bars" );
+		bazBarsField.setAccessible( true );
+		// Obtain the 'bars' list of the 'Baz' object; it should be empty
+		List<?> bazBarsList = (List<?>) bazBarsField.get( bazObject );   // baz.bars
+		assertTrue(bazBarsList.isEmpty());
+		// Lookup the 'setBaz' method of class 'Bar' and invoke it on the 'Bar' object
+		Method barSetBazMethod = barClass.getDeclaredMethod( "setBaz", new Class[] { bazClass } );
+		barSetBazMethod.invoke( barObject, bazObject );                  // bar.setBaz(baz)
+		// Reobtain the 'bars' list of the 'Baz' object
+		bazBarsList = (List<?>) bazBarsField.get( bazObject );
+		// If there is association management, the 'bars' list should contain the 'Bar' object
+		return bazBarsList.contains( barObject );                        // baz.bars.contains(bar)
+	}
+
+	private boolean fileExists(String relativePath) {
+		return new File( projectDir, relativePath ).exists();
+	}
+
+}

--- a/tooling/hibernate-maven-plugin/src/intTest/resources/Bar.jav_
+++ b/tooling/hibernate-maven-plugin/src/intTest/resources/Bar.jav_
@@ -1,0 +1,24 @@
+import jakarta.persistence.Entity;
+import jakarta.persistence.ManyToOne;
+
+@Entity
+public class Bar {
+
+    private String foo;
+
+    @ManyToOne
+    private Baz baz;
+
+    public String getFoo() {
+        return foo;
+    }
+
+    public void setFoo(String f) {
+        foo = f;
+    }
+
+    public Baz getBaz() { return baz; }
+
+    public void setBaz(Baz baz) { this.baz = baz; }
+
+}

--- a/tooling/hibernate-maven-plugin/src/intTest/resources/Baz.jav_
+++ b/tooling/hibernate-maven-plugin/src/intTest/resources/Baz.jav_
@@ -1,0 +1,27 @@
+import jakarta.persistence.Entity;
+import jakarta.persistence.OneToMany;
+
+import java.util.List;
+import java.util.ArrayList;
+
+@Entity
+public class Baz {
+
+    private String foo;
+
+    @OneToMany(mappedBy = "baz")
+    private List<Bar> bars = new ArrayList<Bar>();
+
+    String getFoo() {
+        return foo;
+    }
+
+    public void setFoo(String f) {
+        foo = f;
+    }
+
+    public void addBar(Bar bar) {
+        bars.add( bar );
+    }
+
+}

--- a/tooling/hibernate-maven-plugin/src/intTest/resources/Foo.jav_
+++ b/tooling/hibernate-maven-plugin/src/intTest/resources/Foo.jav_
@@ -1,0 +1,13 @@
+public class Foo {
+
+    private Bar bar;
+
+    Bar getBar() {
+        return bar;
+    }
+
+    public void setBar(Bar b) {
+        bar = b;
+    }
+
+}

--- a/tooling/hibernate-maven-plugin/src/intTest/resources/pom.xm_
+++ b/tooling/hibernate-maven-plugin/src/intTest/resources/pom.xm_
@@ -1,0 +1,39 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.hibernate.orm.tooling.maven</groupId>
+  <artifactId>enhance-test</artifactId>
+  <version>0.0.1-SNAPSHOT</version>
+
+  <properties>
+  	<hibernate.version>@hibernate-version@</hibernate.version>
+  </properties>
+  
+  <dependencies>
+    <dependency>
+      <groupId>org.hibernate.orm</groupId>
+      <artifactId>hibernate-core</artifactId>
+      <version>${hibernate.version}</version>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.hibernate.orm</groupId>
+        <artifactId>hibernate-maven-plugin</artifactId>
+        <version>${hibernate.version}</version>
+        <executions>
+          <execution>
+            @configuration@
+            <goals>
+              <goal>enhance</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/tooling/hibernate-maven-plugin/src/main/java/org/hibernate/orm/tooling/maven/EnhancerMojo.java
+++ b/tooling/hibernate-maven-plugin/src/main/java/org/hibernate/orm/tooling/maven/EnhancerMojo.java
@@ -28,7 +28,7 @@ import java.util.List;
  * Maven mojo for performing build-time enhancement of entity objects.
  */
 @Mojo(name = "enhance", defaultPhase = LifecyclePhase.PROCESS_CLASSES)
-public class HibernateEnhancerMojo extends AbstractMojo {
+public class EnhancerMojo extends AbstractMojo {
 
 	final private List<File> sourceSet = new ArrayList<File>();
 	private Enhancer enhancer;
@@ -90,11 +90,21 @@ public class HibernateEnhancerMojo extends AbstractMojo {
 	public void execute() {
 		getLog().debug(STARTING_EXECUTION_OF_ENHANCE_MOJO);
 		processParameters();
-		assembleSourceSet();
-		createEnhancer();
-		discoverTypes();
-		performEnhancement();
+		if (enhancementIsNeeded()) {
+			assembleSourceSet();
+			createEnhancer();
+			discoverTypes();
+			performEnhancement();
+		}
 		getLog().debug(ENDING_EXECUTION_OF_ENHANCE_MOJO);
+	}
+
+	private boolean enhancementIsNeeded() {
+		// enhancement is not needed when all the parameters are false
+		return enableAssociationManagement ||
+			enableDirtyTracking ||
+			enableLazyInitialization ||
+			enableExtendedEnhancement;
 	}
 
 	private void processParameters() {

--- a/tooling/hibernate-maven-plugin/src/main/java/org/hibernate/orm/tooling/maven/HibernateEnhancerMojo.java
+++ b/tooling/hibernate-maven-plugin/src/main/java/org/hibernate/orm/tooling/maven/HibernateEnhancerMojo.java
@@ -33,29 +33,55 @@ public class HibernateEnhancerMojo extends AbstractMojo {
 	final private List<File> sourceSet = new ArrayList<File>();
 	private Enhancer enhancer;
 
+	/**
+	 * A list of FileSets in which to look for classes to enhance.
+	 * This parameter is optional but if it is specified, the 'classesDirectory' parameter is ignored.
+	 */
 	@Parameter
 	private FileSet[] fileSets;
 
+	/**
+	 * The folder in which to look for classes to enhance.
+	 * This parameter is required but if the 'fileSets' parameter is specified, it will be ignored.
+	 */
 	@Parameter(
 			defaultValue = "${project.build.directory}/classes",
 			required = true)
 	private File classesDirectory;
 
+	/**
+	 * A boolean that indicates whether or not to add association management to automatically
+	 * synchronize a bidirectional association when only one side is changed
+	 */
 	@Parameter(
 			defaultValue = "false",
 			required = true)
 	private boolean enableAssociationManagement;
 
+	/**
+	 * A boolean that indicates whether or not to add dirty tracking
+	 */
+	@Deprecated(
+			forRemoval = true)
 	@Parameter(
-			defaultValue = "false",
+			defaultValue = "true",
 			required = true)
 	private boolean enableDirtyTracking;
 
+	/**
+	 * A boolean that indicates whether or not to add lazy initialization
+	 */
+	@Deprecated(
+			forRemoval = true)
 	@Parameter(
-			defaultValue = "false",
+			defaultValue = "true",
 			required = true)
 	private boolean enableLazyInitialization;
 
+	/**
+	 * A boolean that indicates whether or not to add extended enhancement.
+	 * This setting will provide bytecode enhancement, even for non-entity classes
+	 */
 	@Parameter(
 			defaultValue = "false",
 			required = true)

--- a/tooling/hibernate-maven-plugin/src/test/java/org/hibernate/orm/tooling/maven/EnhancerMojoTest.java
+++ b/tooling/hibernate-maven-plugin/src/test/java/org/hibernate/orm/tooling/maven/EnhancerMojoTest.java
@@ -37,7 +37,7 @@ import org.junit.jupiter.api.io.TempDir;
 
 import jakarta.persistence.Entity;
 
-public class HibernateEnhancerMojoTest {
+public class EnhancerMojoTest {
 
 	@TempDir
 	File tempDir;
@@ -55,19 +55,19 @@ public class HibernateEnhancerMojoTest {
 	private File barClassFile;      // file '${fooFolder}/Bar.class'
 	private File fooTxtFile;        // file '${barFolder}/Foo.txt'
 
-	private HibernateEnhancerMojo enhanceMojo;
+	private EnhancerMojo enhanceMojo;
 
 	@BeforeEach
 	void beforeEach() throws Exception {
-		classesDirectoryField = HibernateEnhancerMojo.class.getDeclaredField("classesDirectory");
+		classesDirectoryField = EnhancerMojo.class.getDeclaredField("classesDirectory");
 		classesDirectoryField.setAccessible(true);
-		fileSetsField = HibernateEnhancerMojo.class.getDeclaredField("fileSets");
+		fileSetsField = EnhancerMojo.class.getDeclaredField("fileSets");
 		fileSetsField.setAccessible(true);
-		sourceSetField = HibernateEnhancerMojo.class.getDeclaredField("sourceSet");
+		sourceSetField = EnhancerMojo.class.getDeclaredField("sourceSet");
 		sourceSetField.setAccessible(true);
-		enhancerField = HibernateEnhancerMojo.class.getDeclaredField("enhancer");
+		enhancerField = EnhancerMojo.class.getDeclaredField("enhancer");
 		enhancerField.setAccessible(true);
-		enhanceMojo = new HibernateEnhancerMojo();
+		enhanceMojo = new EnhancerMojo();
 		enhanceMojo.setLog(createLog());
 		classesDirectory = new File(tempDir, "classes");
 		classesDirectory.mkdirs();
@@ -84,7 +84,7 @@ public class HibernateEnhancerMojoTest {
 
 	@Test
 	void testAssembleSourceSet() throws Exception {
-		Method assembleSourceSetMethod = HibernateEnhancerMojo.class.getDeclaredMethod("assembleSourceSet");
+		Method assembleSourceSetMethod = EnhancerMojo.class.getDeclaredMethod("assembleSourceSet");
 		assembleSourceSetMethod.setAccessible(true);
 		FileSet[] fileSets = new FileSet[1];
 		fileSets[0] = new FileSet();
@@ -99,18 +99,18 @@ public class HibernateEnhancerMojoTest {
 		assertEquals(1, sourceSet.size());
 		// verify the log messages
 		assertEquals(7, logMessages.size());
-		assertTrue(logMessages.contains(DEBUG + HibernateEnhancerMojo.STARTING_ASSEMBLY_OF_SOURCESET));
-		assertTrue(logMessages.contains(DEBUG + HibernateEnhancerMojo.PROCESSING_FILE_SET));
-		assertTrue(logMessages.contains(DEBUG + HibernateEnhancerMojo.USING_BASE_DIRECTORY.formatted(classesDirectory)));
-		assertTrue(logMessages.contains(INFO + HibernateEnhancerMojo.ADDED_FILE_TO_SOURCE_SET.formatted(barClassFile)));
-		assertTrue(logMessages.contains(DEBUG + HibernateEnhancerMojo.SKIPPING_NON_CLASS_FILE.formatted(fooTxtFile)));
-		assertTrue(logMessages.contains(DEBUG + HibernateEnhancerMojo.FILESET_PROCESSED_SUCCESFULLY));
-		assertTrue(logMessages.contains(DEBUG + HibernateEnhancerMojo.ENDING_ASSEMBLY_OF_SOURCESET));
+		assertTrue(logMessages.contains( DEBUG + EnhancerMojo.STARTING_ASSEMBLY_OF_SOURCESET));
+		assertTrue(logMessages.contains( DEBUG + EnhancerMojo.PROCESSING_FILE_SET));
+		assertTrue(logMessages.contains( DEBUG + EnhancerMojo.USING_BASE_DIRECTORY.formatted(classesDirectory)));
+		assertTrue(logMessages.contains( INFO + EnhancerMojo.ADDED_FILE_TO_SOURCE_SET.formatted(barClassFile)));
+		assertTrue(logMessages.contains( DEBUG + EnhancerMojo.SKIPPING_NON_CLASS_FILE.formatted(fooTxtFile)));
+		assertTrue(logMessages.contains( DEBUG + EnhancerMojo.FILESET_PROCESSED_SUCCESFULLY));
+		assertTrue(logMessages.contains( DEBUG + EnhancerMojo.ENDING_ASSEMBLY_OF_SOURCESET));
 	}
 
 	@Test
 	void testAddFileSetToSourceSet() throws Exception {
-		Method addFileSetToSourceSetMethod = HibernateEnhancerMojo.class.getDeclaredMethod(
+		Method addFileSetToSourceSetMethod = EnhancerMojo.class.getDeclaredMethod(
 				"addFileSetToSourceSet",
 				new Class[] { FileSet.class});
 		addFileSetToSourceSetMethod.setAccessible(true);
@@ -128,18 +128,18 @@ public class HibernateEnhancerMojoTest {
 		addFileSetToSourceSetMethod.invoke(enhanceMojo, fileSet);
 		// verify log messages
 		assertEquals(6, logMessages.size());
-		assertTrue(logMessages.contains(DEBUG + HibernateEnhancerMojo.PROCESSING_FILE_SET));
-		assertTrue(logMessages.contains(DEBUG + HibernateEnhancerMojo.USING_BASE_DIRECTORY.formatted(classesDirectory)));
-		assertTrue(logMessages.contains(INFO + HibernateEnhancerMojo.ADDED_FILE_TO_SOURCE_SET.formatted(barClassFile)));
-		assertTrue(logMessages.contains(INFO + HibernateEnhancerMojo.ADDED_FILE_TO_SOURCE_SET.formatted(fooClassFile)));
-		assertFalse(logMessages.contains(INFO + HibernateEnhancerMojo.ADDED_FILE_TO_SOURCE_SET.formatted(bazClassFile)));
-		assertTrue(logMessages.contains(DEBUG + HibernateEnhancerMojo.SKIPPING_NON_CLASS_FILE.formatted(fooTxtFile)));
-		assertTrue(logMessages.contains(DEBUG + HibernateEnhancerMojo.FILESET_PROCESSED_SUCCESFULLY));
+		assertTrue(logMessages.contains( DEBUG + EnhancerMojo.PROCESSING_FILE_SET));
+		assertTrue(logMessages.contains( DEBUG + EnhancerMojo.USING_BASE_DIRECTORY.formatted(classesDirectory)));
+		assertTrue(logMessages.contains( INFO + EnhancerMojo.ADDED_FILE_TO_SOURCE_SET.formatted(barClassFile)));
+		assertTrue(logMessages.contains( INFO + EnhancerMojo.ADDED_FILE_TO_SOURCE_SET.formatted(fooClassFile)));
+		assertFalse(logMessages.contains( INFO + EnhancerMojo.ADDED_FILE_TO_SOURCE_SET.formatted(bazClassFile)));
+		assertTrue(logMessages.contains( DEBUG + EnhancerMojo.SKIPPING_NON_CLASS_FILE.formatted(fooTxtFile)));
+		assertTrue(logMessages.contains( DEBUG + EnhancerMojo.FILESET_PROCESSED_SUCCESFULLY));
 	}
 
 	@Test
 	void testCreateClassLoader() throws Exception {
-		Method createClassLoaderMethod = HibernateEnhancerMojo.class.getDeclaredMethod("createClassLoader");
+		Method createClassLoaderMethod = EnhancerMojo.class.getDeclaredMethod("createClassLoader");
 		createClassLoaderMethod.setAccessible(true);
 		ClassLoader classLoader = (ClassLoader)createClassLoaderMethod.invoke(enhanceMojo);
 		assertNotNull(classLoader);
@@ -149,12 +149,12 @@ public class HibernateEnhancerMojoTest {
 		// verify log messages
 		// verify log messages
 		assertEquals(1, logMessages.size());
-		assertTrue(logMessages.contains(DEBUG + HibernateEnhancerMojo.CREATE_URL_CLASSLOADER_FOR_FOLDER.formatted(classesDirectory)));
+		assertTrue(logMessages.contains( DEBUG + EnhancerMojo.CREATE_URL_CLASSLOADER_FOR_FOLDER.formatted(classesDirectory)));
 	}
 
 	@Test
 	void testCreateEnhancementContext() throws Exception {
-		Method createEnhancementContextMethod = HibernateEnhancerMojo.class.getDeclaredMethod("createEnhancementContext");
+		Method createEnhancementContextMethod = EnhancerMojo.class.getDeclaredMethod("createEnhancementContext");
 		createEnhancementContextMethod.setAccessible(true);
 		EnhancementContext enhancementContext = (EnhancementContext)createEnhancementContextMethod.invoke(enhanceMojo);
 		URLClassLoader classLoader = (URLClassLoader)enhancementContext.getLoadingClassLoader();
@@ -166,10 +166,10 @@ public class HibernateEnhancerMojoTest {
 		assertFalse(enhancementContext.doExtendedEnhancement(null));
 		// verify log messages
 		assertEquals(2, logMessages.size());
-		assertTrue(logMessages.contains(DEBUG + HibernateEnhancerMojo.CREATE_ENHANCEMENT_CONTEXT));
-		assertTrue(logMessages.contains(DEBUG + HibernateEnhancerMojo.CREATE_URL_CLASSLOADER_FOR_FOLDER.formatted(classesDirectory)));
+		assertTrue(logMessages.contains( DEBUG + EnhancerMojo.CREATE_ENHANCEMENT_CONTEXT));
+		assertTrue(logMessages.contains( DEBUG + EnhancerMojo.CREATE_URL_CLASSLOADER_FOR_FOLDER.formatted(classesDirectory)));
 		logMessages.clear();
-		Field enableAssociationManagementField = HibernateEnhancerMojo.class.getDeclaredField("enableAssociationManagement");
+		Field enableAssociationManagementField = EnhancerMojo.class.getDeclaredField("enableAssociationManagement");
 		enableAssociationManagementField.setAccessible(true);
 		enableAssociationManagementField.set(enhanceMojo, Boolean.TRUE);
 		enhancementContext = (EnhancementContext)createEnhancementContextMethod.invoke(enhanceMojo);
@@ -181,10 +181,10 @@ public class HibernateEnhancerMojoTest {
 		assertFalse(enhancementContext.doExtendedEnhancement(null));
 		// verify log messages
 		assertEquals(2, logMessages.size());
-		assertTrue(logMessages.contains(DEBUG + HibernateEnhancerMojo.CREATE_ENHANCEMENT_CONTEXT));
-		assertTrue(logMessages.contains(DEBUG + HibernateEnhancerMojo.CREATE_URL_CLASSLOADER_FOR_FOLDER.formatted(classesDirectory)));
+		assertTrue(logMessages.contains( DEBUG + EnhancerMojo.CREATE_ENHANCEMENT_CONTEXT));
+		assertTrue(logMessages.contains( DEBUG + EnhancerMojo.CREATE_URL_CLASSLOADER_FOR_FOLDER.formatted(classesDirectory)));
 		logMessages.clear();
-		Field enableDirtyTrackingField = HibernateEnhancerMojo.class.getDeclaredField("enableDirtyTracking");
+		Field enableDirtyTrackingField = EnhancerMojo.class.getDeclaredField("enableDirtyTracking");
 		enableDirtyTrackingField.setAccessible(true);
 		enableDirtyTrackingField.set(enhanceMojo, Boolean.TRUE);
 		enhancementContext = (EnhancementContext)createEnhancementContextMethod.invoke(enhanceMojo);
@@ -196,10 +196,10 @@ public class HibernateEnhancerMojoTest {
 		assertFalse(enhancementContext.doExtendedEnhancement(null));
 		// verify log messages
 		assertEquals(2, logMessages.size());
-		assertTrue(logMessages.contains(DEBUG + HibernateEnhancerMojo.CREATE_ENHANCEMENT_CONTEXT));
-		assertTrue(logMessages.contains(DEBUG + HibernateEnhancerMojo.CREATE_URL_CLASSLOADER_FOR_FOLDER.formatted(classesDirectory)));
+		assertTrue(logMessages.contains( DEBUG + EnhancerMojo.CREATE_ENHANCEMENT_CONTEXT));
+		assertTrue(logMessages.contains( DEBUG + EnhancerMojo.CREATE_URL_CLASSLOADER_FOR_FOLDER.formatted(classesDirectory)));
 		logMessages.clear();
-		Field enableLazyInitializationField = HibernateEnhancerMojo.class.getDeclaredField("enableLazyInitialization");
+		Field enableLazyInitializationField = EnhancerMojo.class.getDeclaredField("enableLazyInitialization");
 		enableLazyInitializationField.setAccessible(true);
 		enableLazyInitializationField.set(enhanceMojo, Boolean.TRUE);
 		enhancementContext = (EnhancementContext)createEnhancementContextMethod.invoke(enhanceMojo);
@@ -211,10 +211,10 @@ public class HibernateEnhancerMojoTest {
 		assertFalse(enhancementContext.doExtendedEnhancement(null));
 		// verify log messages
 		assertEquals(2, logMessages.size());
-		assertTrue(logMessages.contains(DEBUG + HibernateEnhancerMojo.CREATE_ENHANCEMENT_CONTEXT));
-		assertTrue(logMessages.contains(DEBUG + HibernateEnhancerMojo.CREATE_URL_CLASSLOADER_FOR_FOLDER.formatted(classesDirectory)));
+		assertTrue(logMessages.contains( DEBUG + EnhancerMojo.CREATE_ENHANCEMENT_CONTEXT));
+		assertTrue(logMessages.contains( DEBUG + EnhancerMojo.CREATE_URL_CLASSLOADER_FOR_FOLDER.formatted(classesDirectory)));
 		logMessages.clear();
-		Field enableExtendedEnhancementField = HibernateEnhancerMojo.class.getDeclaredField("enableExtendedEnhancement");
+		Field enableExtendedEnhancementField = EnhancerMojo.class.getDeclaredField("enableExtendedEnhancement");
 		enableExtendedEnhancementField.setAccessible(true);
 		enableExtendedEnhancementField.set(enhanceMojo, Boolean.TRUE);
 		enhancementContext = (EnhancementContext)createEnhancementContextMethod.invoke(enhanceMojo);
@@ -226,14 +226,14 @@ public class HibernateEnhancerMojoTest {
 		assertTrue(enhancementContext.doExtendedEnhancement(null));
 		// verify log messages
 		assertEquals(2, logMessages.size());
-		assertTrue(logMessages.contains(DEBUG + HibernateEnhancerMojo.CREATE_ENHANCEMENT_CONTEXT));
-		assertTrue(logMessages.contains(DEBUG + HibernateEnhancerMojo.CREATE_URL_CLASSLOADER_FOR_FOLDER.formatted(classesDirectory)));
+		assertTrue(logMessages.contains( DEBUG + EnhancerMojo.CREATE_ENHANCEMENT_CONTEXT));
+		assertTrue(logMessages.contains( DEBUG + EnhancerMojo.CREATE_URL_CLASSLOADER_FOR_FOLDER.formatted(classesDirectory)));
 		logMessages.clear();
 	}
 
 	@Test
 	void testCreateEnhancer() throws Exception {
-		Method createEnhancerMethod = HibernateEnhancerMojo.class.getDeclaredMethod("createEnhancer");
+		Method createEnhancerMethod = EnhancerMojo.class.getDeclaredMethod("createEnhancer");
 		createEnhancerMethod.setAccessible(true);
 		Enhancer enhancer = (Enhancer)enhancerField.get(enhanceMojo);
 		assertNull(enhancer);
@@ -256,27 +256,27 @@ public class HibernateEnhancerMojoTest {
 		assertEquals(fooTxtFile.toURI().toURL(), fooResource);
 		// verify log messages
 		assertEquals(3, logMessages.size());
-		assertTrue(logMessages.contains(DEBUG + HibernateEnhancerMojo.CREATE_BYTECODE_ENHANCER));
-		assertTrue(logMessages.contains(DEBUG + HibernateEnhancerMojo.CREATE_ENHANCEMENT_CONTEXT));
-		assertTrue(logMessages.contains(DEBUG + HibernateEnhancerMojo.CREATE_URL_CLASSLOADER_FOR_FOLDER.formatted(classesDirectory)));
+		assertTrue(logMessages.contains( DEBUG + EnhancerMojo.CREATE_BYTECODE_ENHANCER));
+		assertTrue(logMessages.contains( DEBUG + EnhancerMojo.CREATE_ENHANCEMENT_CONTEXT));
+		assertTrue(logMessages.contains( DEBUG + EnhancerMojo.CREATE_URL_CLASSLOADER_FOR_FOLDER.formatted(classesDirectory)));
 	}
 
 	@Test
 	void testDetermineClassName() throws Exception {
-		Method determineClassNameMethod = HibernateEnhancerMojo.class.getDeclaredMethod(
+		Method determineClassNameMethod = EnhancerMojo.class.getDeclaredMethod(
 				"determineClassName",
 				new Class[] { File.class });
 		determineClassNameMethod.setAccessible(true);
 		assertEquals("org.foo.Bar", determineClassNameMethod.invoke(enhanceMojo, barClassFile));
 		// check log messages
 		assertEquals(1, logMessages.size());
-		assertTrue(logMessages.contains(DEBUG + HibernateEnhancerMojo.DETERMINE_CLASS_NAME_FOR_FILE.formatted(barClassFile)));
+		assertTrue(logMessages.contains( DEBUG + EnhancerMojo.DETERMINE_CLASS_NAME_FOR_FILE.formatted(barClassFile)));
 	}
 
 	@Test
 	void testDiscoverTypesForClass() throws Exception {
 		final List<Boolean> hasRun = new ArrayList<Boolean>();
-		Method discoverTypesForClassMethod = HibernateEnhancerMojo.class.getDeclaredMethod(
+		Method discoverTypesForClassMethod = EnhancerMojo.class.getDeclaredMethod(
 				"discoverTypesForClass",
 				new Class[] { File.class });
 		discoverTypesForClassMethod.setAccessible(true);
@@ -299,15 +299,15 @@ public class HibernateEnhancerMojoTest {
 		assertTrue(hasRun.contains(true));
 		// verify log messages
 		assertEquals(3, logMessages.size());
-		assertTrue(logMessages.contains(DEBUG + HibernateEnhancerMojo.TRYING_TO_DISCOVER_TYPES_FOR_CLASS_FILE.formatted(barClassFile)));
-		assertTrue(logMessages.contains(DEBUG + HibernateEnhancerMojo.DETERMINE_CLASS_NAME_FOR_FILE.formatted(barClassFile)));
-		assertTrue(logMessages.contains(INFO + HibernateEnhancerMojo.SUCCESFULLY_DISCOVERED_TYPES_FOR_CLASS_FILE.formatted(barClassFile)));
+		assertTrue(logMessages.contains( DEBUG + EnhancerMojo.TRYING_TO_DISCOVER_TYPES_FOR_CLASS_FILE.formatted(barClassFile)));
+		assertTrue(logMessages.contains( DEBUG + EnhancerMojo.DETERMINE_CLASS_NAME_FOR_FILE.formatted(barClassFile)));
+		assertTrue(logMessages.contains( INFO + EnhancerMojo.SUCCESFULLY_DISCOVERED_TYPES_FOR_CLASS_FILE.formatted(barClassFile)));
 	}
 
 	@Test
 	void testDiscoverTypes() throws Exception {
 		final List<Boolean> hasRun = new ArrayList<Boolean>();
-		Method discoverTypesMethod = HibernateEnhancerMojo.class.getDeclaredMethod(
+		Method discoverTypesMethod = EnhancerMojo.class.getDeclaredMethod(
 				"discoverTypes",
 				new Class[] { });
 		discoverTypesMethod.setAccessible(true);
@@ -330,8 +330,8 @@ public class HibernateEnhancerMojoTest {
 		assertFalse(hasRun.contains(true));
 		// verify the log messages
 		assertEquals(2, logMessages.size());
-		assertTrue(logMessages.contains(DEBUG + HibernateEnhancerMojo.STARTING_TYPE_DISCOVERY));
-		assertTrue(logMessages.contains(DEBUG + HibernateEnhancerMojo.ENDING_TYPE_DISCOVERY));
+		assertTrue(logMessages.contains( DEBUG + EnhancerMojo.STARTING_TYPE_DISCOVERY));
+		assertTrue(logMessages.contains( DEBUG + EnhancerMojo.ENDING_TYPE_DISCOVERY));
 		logMessages.clear();
 		List<File> sourceSet = new ArrayList<File>();
 		sourceSet.add(barClassFile);
@@ -340,16 +340,16 @@ public class HibernateEnhancerMojoTest {
 		assertTrue(hasRun.contains(true));
 		// verify the log messages
 		assertEquals(5, logMessages.size());
-		assertTrue(logMessages.contains(DEBUG + HibernateEnhancerMojo.STARTING_TYPE_DISCOVERY));
-		assertTrue(logMessages.contains(DEBUG + HibernateEnhancerMojo.TRYING_TO_DISCOVER_TYPES_FOR_CLASS_FILE.formatted(barClassFile)));
-		assertTrue(logMessages.contains(DEBUG + HibernateEnhancerMojo.DETERMINE_CLASS_NAME_FOR_FILE.formatted(barClassFile)));
-		assertTrue(logMessages.contains(INFO + HibernateEnhancerMojo.SUCCESFULLY_DISCOVERED_TYPES_FOR_CLASS_FILE.formatted(barClassFile)));
-		assertTrue(logMessages.contains(DEBUG + HibernateEnhancerMojo.ENDING_TYPE_DISCOVERY));
+		assertTrue(logMessages.contains( DEBUG + EnhancerMojo.STARTING_TYPE_DISCOVERY));
+		assertTrue(logMessages.contains( DEBUG + EnhancerMojo.TRYING_TO_DISCOVER_TYPES_FOR_CLASS_FILE.formatted(barClassFile)));
+		assertTrue(logMessages.contains( DEBUG + EnhancerMojo.DETERMINE_CLASS_NAME_FOR_FILE.formatted(barClassFile)));
+		assertTrue(logMessages.contains( INFO + EnhancerMojo.SUCCESFULLY_DISCOVERED_TYPES_FOR_CLASS_FILE.formatted(barClassFile)));
+		assertTrue(logMessages.contains( DEBUG + EnhancerMojo.ENDING_TYPE_DISCOVERY));
 	}
 
 	@Test
 	void testClearFile() throws Exception {
-		Method clearFileMethod = HibernateEnhancerMojo.class.getDeclaredMethod(
+		Method clearFileMethod = EnhancerMojo.class.getDeclaredMethod(
 				"clearFile",
 				new Class[] { File.class });
 		clearFileMethod.setAccessible(true);
@@ -368,15 +368,15 @@ public class HibernateEnhancerMojoTest {
 		assertTrue(modified > 0);
 		// check log messages
 		assertEquals(4, logMessages.size());
-		assertTrue(logMessages.contains(DEBUG + HibernateEnhancerMojo.TRYING_TO_CLEAR_FILE.formatted("foobar")));
-		assertTrue(logMessages.contains(ERROR + HibernateEnhancerMojo.UNABLE_TO_DELETE_FILE.formatted("foobar")));
-		assertTrue(logMessages.contains(DEBUG + HibernateEnhancerMojo.TRYING_TO_CLEAR_FILE.formatted(fooTxtFile)));
-		assertTrue(logMessages.contains(INFO + HibernateEnhancerMojo.SUCCESFULLY_CLEARED_FILE.formatted(fooTxtFile)));
+		assertTrue(logMessages.contains( DEBUG + EnhancerMojo.TRYING_TO_CLEAR_FILE.formatted("foobar")));
+		assertTrue(logMessages.contains( ERROR + EnhancerMojo.UNABLE_TO_DELETE_FILE.formatted("foobar")));
+		assertTrue(logMessages.contains( DEBUG + EnhancerMojo.TRYING_TO_CLEAR_FILE.formatted(fooTxtFile)));
+		assertTrue(logMessages.contains( INFO + EnhancerMojo.SUCCESFULLY_CLEARED_FILE.formatted(fooTxtFile)));
 	}
 
 	@Test
 	void testWriteByteCodeToFile() throws Exception {
-		Method writeByteCodeToFileMethod = HibernateEnhancerMojo.class.getDeclaredMethod(
+		Method writeByteCodeToFileMethod = EnhancerMojo.class.getDeclaredMethod(
 				"writeByteCodeToFile",
 				new Class[] { byte[].class, File.class});
 		writeByteCodeToFileMethod.setAccessible(true);
@@ -392,17 +392,17 @@ public class HibernateEnhancerMojoTest {
 		assertEquals(new String(Files.readAllBytes(fooTxtFile.toPath())), "foobar");
 		// check log messages
 		assertEquals(4, logMessages.size());
-		assertTrue(logMessages.contains(DEBUG + HibernateEnhancerMojo.WRITING_BYTE_CODE_TO_FILE.formatted(fooTxtFile)));
-		assertTrue(logMessages.contains(DEBUG + HibernateEnhancerMojo.TRYING_TO_CLEAR_FILE.formatted(fooTxtFile)));
-		assertTrue(logMessages.contains(INFO + HibernateEnhancerMojo.SUCCESFULLY_CLEARED_FILE.formatted(fooTxtFile)));
-		assertTrue(logMessages.contains(DEBUG + HibernateEnhancerMojo.AMOUNT_BYTES_WRITTEN_TO_FILE.formatted(6, fooTxtFile)));
+		assertTrue(logMessages.contains( DEBUG + EnhancerMojo.WRITING_BYTE_CODE_TO_FILE.formatted(fooTxtFile)));
+		assertTrue(logMessages.contains( DEBUG + EnhancerMojo.TRYING_TO_CLEAR_FILE.formatted(fooTxtFile)));
+		assertTrue(logMessages.contains( INFO + EnhancerMojo.SUCCESFULLY_CLEARED_FILE.formatted(fooTxtFile)));
+		assertTrue(logMessages.contains( DEBUG + EnhancerMojo.AMOUNT_BYTES_WRITTEN_TO_FILE.formatted(6, fooTxtFile)));
 	}
 
 	@Test
 	void testEnhanceClass() throws Exception {
 		final List<Integer> calls = new ArrayList<Integer>();
 		calls.add(0, 0);
-		Method enhanceClassMethod = HibernateEnhancerMojo.class.getDeclaredMethod(
+		Method enhanceClassMethod = EnhancerMojo.class.getDeclaredMethod(
 				"enhanceClass",
 				new Class[] { File.class });
 		enhanceClassMethod.setAccessible(true);
@@ -436,13 +436,13 @@ public class HibernateEnhancerMojoTest {
 		assertEquals("foobar", new String(Files.readAllBytes(barClassFile.toPath())));
 		// verify log messages
 		assertEquals(7, logMessages.size());
-		assertTrue(logMessages.contains(DEBUG + HibernateEnhancerMojo.TRYING_TO_ENHANCE_CLASS_FILE.formatted(barClassFile)));
-		assertTrue(logMessages.contains(DEBUG + HibernateEnhancerMojo.DETERMINE_CLASS_NAME_FOR_FILE.formatted(barClassFile)));
-		assertTrue(logMessages.contains(DEBUG + HibernateEnhancerMojo.WRITING_BYTE_CODE_TO_FILE.formatted(barClassFile)));
-		assertTrue(logMessages.contains(DEBUG + HibernateEnhancerMojo.TRYING_TO_CLEAR_FILE.formatted(barClassFile)));
-		assertTrue(logMessages.contains(INFO + HibernateEnhancerMojo.SUCCESFULLY_CLEARED_FILE.formatted(barClassFile)));
-		assertTrue(logMessages.contains(DEBUG + HibernateEnhancerMojo.AMOUNT_BYTES_WRITTEN_TO_FILE.formatted("foobar".length(), barClassFile)));
-		assertTrue(logMessages.contains(INFO + HibernateEnhancerMojo.SUCCESFULLY_ENHANCED_CLASS_FILE.formatted(barClassFile)));
+		assertTrue(logMessages.contains( DEBUG + EnhancerMojo.TRYING_TO_ENHANCE_CLASS_FILE.formatted(barClassFile)));
+		assertTrue(logMessages.contains( DEBUG + EnhancerMojo.DETERMINE_CLASS_NAME_FOR_FILE.formatted(barClassFile)));
+		assertTrue(logMessages.contains( DEBUG + EnhancerMojo.WRITING_BYTE_CODE_TO_FILE.formatted(barClassFile)));
+		assertTrue(logMessages.contains( DEBUG + EnhancerMojo.TRYING_TO_CLEAR_FILE.formatted(barClassFile)));
+		assertTrue(logMessages.contains( INFO + EnhancerMojo.SUCCESFULLY_CLEARED_FILE.formatted(barClassFile)));
+		assertTrue(logMessages.contains( DEBUG + EnhancerMojo.AMOUNT_BYTES_WRITTEN_TO_FILE.formatted("foobar".length(), barClassFile)));
+		assertTrue(logMessages.contains( INFO + EnhancerMojo.SUCCESFULLY_ENHANCED_CLASS_FILE.formatted(barClassFile)));
 		// Second Run -> file is not modified
 		logMessages.clear();
 		enhanceClassMethod.invoke(enhanceMojo, barClassFile);
@@ -452,9 +452,9 @@ public class HibernateEnhancerMojoTest {
 		assertEquals("foobar", new String(Files.readAllBytes(barClassFile.toPath())));
 		// verify log messages
 		assertEquals(3, logMessages.size());
-		assertTrue(logMessages.contains(DEBUG + HibernateEnhancerMojo.TRYING_TO_ENHANCE_CLASS_FILE.formatted(barClassFile)));
-		assertTrue(logMessages.contains(DEBUG + HibernateEnhancerMojo.DETERMINE_CLASS_NAME_FOR_FILE.formatted(barClassFile)));
-		assertTrue(logMessages.contains(INFO + HibernateEnhancerMojo.SKIPPING_FILE.formatted(barClassFile)));
+		assertTrue(logMessages.contains( DEBUG + EnhancerMojo.TRYING_TO_ENHANCE_CLASS_FILE.formatted(barClassFile)));
+		assertTrue(logMessages.contains( DEBUG + EnhancerMojo.DETERMINE_CLASS_NAME_FOR_FILE.formatted(barClassFile)));
+		assertTrue(logMessages.contains( INFO + EnhancerMojo.SKIPPING_FILE.formatted(barClassFile)));
 		// Third Run -> exception!
 		logMessages.clear();
 		try {
@@ -467,16 +467,16 @@ public class HibernateEnhancerMojoTest {
 			assertEquals("foobar", new String(Files.readAllBytes(barClassFile.toPath())));
 			// verify log messages
 			assertEquals(3, logMessages.size());
-			assertTrue(logMessages.contains(DEBUG + HibernateEnhancerMojo.TRYING_TO_ENHANCE_CLASS_FILE.formatted(barClassFile)));
-			assertTrue(logMessages.contains(DEBUG + HibernateEnhancerMojo.DETERMINE_CLASS_NAME_FOR_FILE.formatted(barClassFile)));
-			assertTrue(logMessages.contains(ERROR + HibernateEnhancerMojo.ERROR_WHILE_ENHANCING_CLASS_FILE.formatted(barClassFile)));
+			assertTrue(logMessages.contains( DEBUG + EnhancerMojo.TRYING_TO_ENHANCE_CLASS_FILE.formatted(barClassFile)));
+			assertTrue(logMessages.contains( DEBUG + EnhancerMojo.DETERMINE_CLASS_NAME_FOR_FILE.formatted(barClassFile)));
+			assertTrue(logMessages.contains( ERROR + EnhancerMojo.ERROR_WHILE_ENHANCING_CLASS_FILE.formatted(barClassFile)));
 		}
 	}
 
 	@Test
 	void testPerformEnhancement() throws Exception {
 		final List<Boolean> hasRun = new ArrayList<Boolean>();
-		Method performEnhancementMethod = HibernateEnhancerMojo.class.getDeclaredMethod(
+		Method performEnhancementMethod = EnhancerMojo.class.getDeclaredMethod(
 				"performEnhancement",
 				new Class[] { });
 		performEnhancementMethod.setAccessible(true);
@@ -506,20 +506,23 @@ public class HibernateEnhancerMojoTest {
 		assertEquals(lastModified, barClassFile.lastModified());
 		// verify the log messages
 		assertEquals(9, logMessages.size());
-		assertTrue(logMessages.contains(DEBUG + HibernateEnhancerMojo.STARTING_CLASS_ENHANCEMENT));
-		assertTrue(logMessages.contains(DEBUG + HibernateEnhancerMojo.TRYING_TO_ENHANCE_CLASS_FILE.formatted(barClassFile)));
-		assertTrue(logMessages.contains(DEBUG + HibernateEnhancerMojo.DETERMINE_CLASS_NAME_FOR_FILE.formatted(barClassFile)));
-		assertTrue(logMessages.contains(DEBUG + HibernateEnhancerMojo.WRITING_BYTE_CODE_TO_FILE.formatted(barClassFile)));
-		assertTrue(logMessages.contains(DEBUG + HibernateEnhancerMojo.TRYING_TO_CLEAR_FILE.formatted(barClassFile)));
-		assertTrue(logMessages.contains(INFO + HibernateEnhancerMojo.SUCCESFULLY_CLEARED_FILE.formatted(barClassFile)));
-		assertTrue(logMessages.contains(DEBUG + HibernateEnhancerMojo.AMOUNT_BYTES_WRITTEN_TO_FILE.formatted("foobar".length(), barClassFile)));
-		assertTrue(logMessages.contains(INFO + HibernateEnhancerMojo.SUCCESFULLY_ENHANCED_CLASS_FILE.formatted(barClassFile)));
-		assertTrue(logMessages.contains(DEBUG + HibernateEnhancerMojo.ENDING_CLASS_ENHANCEMENT));
+		assertTrue(logMessages.contains( DEBUG + EnhancerMojo.STARTING_CLASS_ENHANCEMENT));
+		assertTrue(logMessages.contains( DEBUG + EnhancerMojo.TRYING_TO_ENHANCE_CLASS_FILE.formatted(barClassFile)));
+		assertTrue(logMessages.contains( DEBUG + EnhancerMojo.DETERMINE_CLASS_NAME_FOR_FILE.formatted(barClassFile)));
+		assertTrue(logMessages.contains( DEBUG + EnhancerMojo.WRITING_BYTE_CODE_TO_FILE.formatted(barClassFile)));
+		assertTrue(logMessages.contains( DEBUG + EnhancerMojo.TRYING_TO_CLEAR_FILE.formatted(barClassFile)));
+		assertTrue(logMessages.contains( INFO + EnhancerMojo.SUCCESFULLY_CLEARED_FILE.formatted(barClassFile)));
+		assertTrue(logMessages.contains( DEBUG + EnhancerMojo.AMOUNT_BYTES_WRITTEN_TO_FILE.formatted("foobar".length(), barClassFile)));
+		assertTrue(logMessages.contains( INFO + EnhancerMojo.SUCCESFULLY_ENHANCED_CLASS_FILE.formatted(barClassFile)));
+		assertTrue(logMessages.contains( DEBUG + EnhancerMojo.ENDING_CLASS_ENHANCEMENT));
 	}
 
 	@Test
 	void testExecute() throws Exception {
-		Method executeMethod = HibernateEnhancerMojo.class.getDeclaredMethod("execute", new Class[] {});
+		Field enableDirtyTrackingField = EnhancerMojo.class.getDeclaredField( "enableDirtyTracking" );
+		enableDirtyTrackingField.setAccessible( true );
+		enableDirtyTrackingField.set( enhanceMojo, true );
+		Method executeMethod = EnhancerMojo.class.getDeclaredMethod("execute", new Class[] {});
 		executeMethod.setAccessible(true);
 		final String barSource =
 				"package org.foo;" +
@@ -576,32 +579,32 @@ public class HibernateEnhancerMojoTest {
 		}
 		classLoader.close();
 		// verify in the log messages at least if all the needed methods have been invoked
-		assertTrue(logMessages.contains(DEBUG + HibernateEnhancerMojo.STARTING_EXECUTION_OF_ENHANCE_MOJO));
-		assertTrue(logMessages.contains(DEBUG + HibernateEnhancerMojo.ADDED_DEFAULT_FILESET_WITH_BASE_DIRECTORY.formatted(classesDirectory)));
-		assertTrue(logMessages.contains(DEBUG + HibernateEnhancerMojo.STARTING_ASSEMBLY_OF_SOURCESET));
-		assertTrue(logMessages.contains(DEBUG + HibernateEnhancerMojo.CREATE_BYTECODE_ENHANCER));
-		assertTrue(logMessages.contains(DEBUG + HibernateEnhancerMojo.STARTING_TYPE_DISCOVERY));
-		assertTrue(logMessages.contains(DEBUG + HibernateEnhancerMojo.STARTING_CLASS_ENHANCEMENT));
-		assertTrue(logMessages.contains(DEBUG + HibernateEnhancerMojo.ENDING_EXECUTION_OF_ENHANCE_MOJO));
+		assertTrue(logMessages.contains( DEBUG + EnhancerMojo.STARTING_EXECUTION_OF_ENHANCE_MOJO));
+		assertTrue(logMessages.contains( DEBUG + EnhancerMojo.ADDED_DEFAULT_FILESET_WITH_BASE_DIRECTORY.formatted(classesDirectory)));
+		assertTrue(logMessages.contains( DEBUG + EnhancerMojo.STARTING_ASSEMBLY_OF_SOURCESET));
+		assertTrue(logMessages.contains( DEBUG + EnhancerMojo.CREATE_BYTECODE_ENHANCER));
+		assertTrue(logMessages.contains( DEBUG + EnhancerMojo.STARTING_TYPE_DISCOVERY));
+		assertTrue(logMessages.contains( DEBUG + EnhancerMojo.STARTING_CLASS_ENHANCEMENT));
+		assertTrue(logMessages.contains( DEBUG + EnhancerMojo.ENDING_EXECUTION_OF_ENHANCE_MOJO));
 	}
 
 	@Test
 	void testProcessParameters() throws Exception {
-		Method processParametersMethod = HibernateEnhancerMojo.class.getDeclaredMethod(
+		Method processParametersMethod = EnhancerMojo.class.getDeclaredMethod(
 				"processParameters",
 				new Class[] {});
 		processParametersMethod.setAccessible(true);
-		Field enableLazyInitializationField = HibernateEnhancerMojo.class.getDeclaredField("enableLazyInitialization");
+		Field enableLazyInitializationField = EnhancerMojo.class.getDeclaredField("enableLazyInitialization");
 		enableLazyInitializationField.setAccessible(true);
-		Field enableDirtyTrackingField = HibernateEnhancerMojo.class.getDeclaredField("enableDirtyTracking");
+		Field enableDirtyTrackingField = EnhancerMojo.class.getDeclaredField("enableDirtyTracking");
 		enableDirtyTrackingField.setAccessible(true);
 		assertTrue(logMessages.isEmpty());
 		assertNull(fileSetsField.get(enhanceMojo));
 		processParametersMethod.invoke(enhanceMojo);
 		assertEquals(3, logMessages.size());
-		assertTrue(logMessages.contains(WARNING + HibernateEnhancerMojo.ENABLE_LAZY_INITIALIZATION_DEPRECATED));
-		assertTrue(logMessages.contains(WARNING + HibernateEnhancerMojo.ENABLE_DIRTY_TRACKING_DEPRECATED));
-		assertTrue(logMessages.contains(DEBUG + HibernateEnhancerMojo.ADDED_DEFAULT_FILESET_WITH_BASE_DIRECTORY.formatted(classesDirectory)));
+		assertTrue(logMessages.contains( WARNING + EnhancerMojo.ENABLE_LAZY_INITIALIZATION_DEPRECATED));
+		assertTrue(logMessages.contains( WARNING + EnhancerMojo.ENABLE_DIRTY_TRACKING_DEPRECATED));
+		assertTrue(logMessages.contains( DEBUG + EnhancerMojo.ADDED_DEFAULT_FILESET_WITH_BASE_DIRECTORY.formatted(classesDirectory)));
 		FileSet[] fileSets = (FileSet[])fileSetsField.get(enhanceMojo);
 		assertNotNull(fileSets);
 		assertEquals(1, fileSets.length);
@@ -612,7 +615,7 @@ public class HibernateEnhancerMojoTest {
 		enableDirtyTrackingField.set(enhanceMojo, Boolean.TRUE);
 		processParametersMethod.invoke(enhanceMojo);
 		assertEquals(1, logMessages.size());
-		assertTrue(logMessages.contains(DEBUG + HibernateEnhancerMojo.ADDED_DEFAULT_FILESET_WITH_BASE_DIRECTORY.formatted(classesDirectory)));
+		assertTrue(logMessages.contains( DEBUG + EnhancerMojo.ADDED_DEFAULT_FILESET_WITH_BASE_DIRECTORY.formatted(classesDirectory)));
 	}
 
 	private Log createLog() {


### PR DESCRIPTION
- Add JavaDoc style documentation to the plugin parameters to improve the Maven plugin description
- Change the parameter defaults for 'enableLazyInitialization' and 'enableDirtyTracking' to bring it in line with the former behaviour
- Modify the 'groupId' and 'artifactId' in the documentation
- Provide complete documentation in the User Guide in line with the Ant task for bytecode enhancement
- Rename 'HibernateEnhancerMojo' to 'EnhancerMojo'
- Rename 'HibernateEnhancerMojoTest' to 'EnhancerMojoTest'
- Add integration test 'HibernateEnhancerMojoTestIT' to test the different configuration options
- Make sure that the enhancer is not doing anything if all the enablement parameters are false

----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-19519
<!-- Hibernate GitHub Bot issue links end -->