### PR TITLE
change handling of natural id resolutions in EntityUpdateAction

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/action/internal/CollectionAction.java
+++ b/hibernate-core/src/main/java/org/hibernate/action/internal/CollectionAction.java
@@ -73,13 +73,13 @@ public abstract class CollectionAction implements ComparableExecutable {
 		// the database. This action is responsible for second-level cache invalidation only.
 		if ( persister.hasCache() ) {
 			final var cache = persister.getCacheAccessStrategy();
-			final Object ck = cache.generateCacheKey(
+			final Object cacheKey = cache.generateCacheKey(
 					key,
 					persister,
 					session.getFactory(),
 					session.getTenantIdentifier()
 			);
-			final SoftLock lock = cache.lockItem( session, ck, null );
+			final SoftLock lock = cache.lockItem( session, cacheKey, null );
 			// the old behavior used key as opposed to getKey()
 			afterTransactionProcess = new CacheCleanupProcess( key, persister, lock );
 		}
@@ -129,13 +129,13 @@ public abstract class CollectionAction implements ComparableExecutable {
 	protected final void evict() throws CacheException {
 		if ( persister.hasCache() ) {
 			final var cache = persister.getCacheAccessStrategy();
-			final Object ck = cache.generateCacheKey(
+			final Object cacheKey = cache.generateCacheKey(
 					key,
 					persister,
 					session.getFactory(),
 					session.getTenantIdentifier()
 			);
-			cache.remove( session, ck);
+			cache.remove( session, cacheKey);
 		}
 	}
 
@@ -170,13 +170,13 @@ public abstract class CollectionAction implements ComparableExecutable {
 		@Override
 		public void doAfterTransactionCompletion(boolean success, SharedSessionContractImplementor session) {
 			final var cache = persister.getCacheAccessStrategy();
-			final Object ck = cache.generateCacheKey(
+			final Object cacheKey = cache.generateCacheKey(
 					key,
 					persister,
 					session.getFactory(),
 					session.getTenantIdentifier()
 			);
-			cache.unlockItem( session, ck, lock );
+			cache.unlockItem( session, cacheKey, lock );
 		}
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/action/internal/EntityDeleteAction.java
+++ b/hibernate-core/src/main/java/org/hibernate/action/internal/EntityDeleteAction.java
@@ -7,6 +7,7 @@ package org.hibernate.action.internal;
 import org.hibernate.AssertionFailure;
 import org.hibernate.HibernateException;
 import org.hibernate.cache.spi.access.SoftLock;
+import org.hibernate.engine.spi.PersistenceContext;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.event.spi.EventSource;
 import org.hibernate.event.spi.PostCommitDeleteEventListener;
@@ -106,7 +107,7 @@ public class EntityDeleteAction extends EntityAction {
 
 		final boolean veto = isInstanceLoaded() && preDelete();
 
-		handleNaturalIdResolutions( persister, session );
+		handleNaturalIdLocalResolutions( persister, session.getPersistenceContextInternal() );
 
 		final Object ck = lockCacheItem();
 
@@ -137,10 +138,10 @@ public class EntityDeleteAction extends EntityAction {
 		}
 	}
 
-	private void handleNaturalIdResolutions(EntityPersister persister, EventSource session) {
+	private void handleNaturalIdLocalResolutions(EntityPersister persister, PersistenceContext context) {
 		final var naturalIdMapping = persister.getNaturalIdMapping();
 		if ( naturalIdMapping != null ) {
-			naturalIdValues = session.getPersistenceContextInternal().getNaturalIdResolutions()
+			naturalIdValues = context.getNaturalIdResolutions()
 					.removeLocalResolution(
 							getId(),
 							naturalIdMapping.extractNaturalIdFromEntityState( state ),

--- a/hibernate-core/src/main/java/org/hibernate/action/internal/EntityDeleteAction.java
+++ b/hibernate-core/src/main/java/org/hibernate/action/internal/EntityDeleteAction.java
@@ -109,7 +109,7 @@ public class EntityDeleteAction extends EntityAction {
 
 		handleNaturalIdLocalResolutions( persister, session.getPersistenceContextInternal() );
 
-		final Object ck = lockCacheItem();
+		final Object cacheKey = lockCacheItem();
 
 		if ( !isCascadeDeleteEnabled && !veto ) {
 			final var eventMonitor = session.getEventMonitor();
@@ -125,11 +125,11 @@ public class EntityDeleteAction extends EntityAction {
 		}
 
 		if ( isInstanceLoaded() ) {
-			postDeleteLoaded( id, persister, session, instance, ck );
+			postDeleteLoaded( id, persister, session, instance, cacheKey );
 		}
 		else {
 			// we're deleting an unloaded proxy
-			postDeleteUnloaded( id, persister, session, ck );
+			postDeleteUnloaded( id, persister, session, cacheKey );
 		}
 
 		final var statistics = session.getFactory().getStatistics();
@@ -167,7 +167,7 @@ public class EntityDeleteAction extends EntityAction {
 			EntityPersister persister,
 			SharedSessionContractImplementor session,
 			Object instance,
-			Object ck) {
+			Object cacheKey) {
 		// After actually deleting a row, record the fact that the instance no longer
 		// exists on the database (needed for identity-column key generation), and
 		// remove it from the session cache
@@ -179,20 +179,24 @@ public class EntityDeleteAction extends EntityAction {
 		entry.postDelete();
 		final var key = entry.getEntityKey();
 		persistenceContext.removeEntityHolder( key );
-		removeCacheItem( ck );
+		removeCacheItem( cacheKey );
 		persistenceContext.getNaturalIdResolutions()
 				.removeSharedResolution( id, naturalIdValues, persister, true );
 		postDelete();
 	}
 
-	protected void postDeleteUnloaded(Object id, EntityPersister persister, SharedSessionContractImplementor session, Object ck) {
+	protected void postDeleteUnloaded(
+			Object id,
+			EntityPersister persister,
+			SharedSessionContractImplementor session,
+			Object cacheKey) {
 		final var persistenceContext = session.getPersistenceContextInternal();
 		final var key = session.generateEntityKey( id, persister );
 		if ( !persistenceContext.containsDeletedUnloadedEntityKey( key ) ) {
 			throw new AssertionFailure( "deleted proxy should be for an unloaded entity: " + key );
 		}
 		persistenceContext.removeProxy( key );
-		removeCacheItem( ck );
+		removeCacheItem( cacheKey );
 	}
 
 	protected boolean preDelete() {
@@ -261,14 +265,14 @@ public class EntityDeleteAction extends EntityAction {
 		if ( persister.canWriteToCache() ) {
 			final var cache = persister.getCacheAccessStrategy();
 			final var session = getSession();
-			final Object ck = cache.generateCacheKey(
+			final Object cacheKey = cache.generateCacheKey(
 					getId(),
 					persister,
 					session.getFactory(),
 					session.getTenantIdentifier()
 			);
-			lock = cache.lockItem( session, ck, getCurrentVersion() );
-			return ck;
+			lock = cache.lockItem( session, cacheKey, getCurrentVersion() );
+			return cacheKey;
 		}
 		else {
 			return null;
@@ -280,21 +284,21 @@ public class EntityDeleteAction extends EntityAction {
 		if ( persister.canWriteToCache() ) {
 			final var cache = persister.getCacheAccessStrategy();
 			final var session = getSession();
-			final Object ck = cache.generateCacheKey(
+			final Object cacheKey = cache.generateCacheKey(
 					getId(),
 					persister,
 					session.getFactory(),
 					session.getTenantIdentifier()
 			);
-			cache.unlockItem( session, ck, lock );
+			cache.unlockItem( session, cacheKey, lock );
 		}
 	}
 
-	protected void removeCacheItem(Object ck) {
+	protected void removeCacheItem(Object cacheKey) {
 		final var persister = getPersister();
 		if ( persister.canWriteToCache() ) {
 			final var cache = persister.getCacheAccessStrategy();
-			cache.remove( getSession(), ck );
+			cache.remove( getSession(), cacheKey );
 
 			final var statistics = getSession().getFactory().getStatistics();
 			if ( statistics.isStatisticsEnabled() ) {

--- a/hibernate-core/src/main/java/org/hibernate/action/internal/EntityInsertAction.java
+++ b/hibernate-core/src/main/java/org/hibernate/action/internal/EntityInsertAction.java
@@ -165,8 +165,8 @@ public class EntityInsertAction extends AbstractEntityInsertAction {
 			final var factory = session.getFactory();
 			cacheEntry = buildStructuredCacheEntry();
 			final var cache = persister.getCacheAccessStrategy();
-			final Object ck = cache.generateCacheKey( getId(), persister, factory, session.getTenantIdentifier() );
-			final boolean put = cacheInsert( persister, ck );
+			final Object cacheKey = cache.generateCacheKey( getId(), persister, factory, session.getTenantIdentifier() );
+			final boolean put = cacheInsert( persister, cacheKey );
 
 			final var statistics = factory.getStatistics();
 			if ( put && statistics.isStatisticsEnabled() ) {
@@ -184,7 +184,7 @@ public class EntityInsertAction extends AbstractEntityInsertAction {
 		return persister.getCacheEntryStructure().structure( cacheEntry );
 	}
 
-	protected boolean cacheInsert(EntityPersister persister, Object ck) {
+	protected boolean cacheInsert(EntityPersister persister, Object cacheKey) {
 		final var session = getSession();
 		final var eventMonitor = session.getEventMonitor();
 		final var cachePutEvent = eventMonitor.beginCachePutEvent();
@@ -193,7 +193,7 @@ public class EntityInsertAction extends AbstractEntityInsertAction {
 		boolean insert = false;
 		try {
 			eventListenerManager.cachePutStart();
-			insert = cacheAccessStrategy.insert( session, ck, cacheEntry, version );
+			insert = cacheAccessStrategy.insert( session, cacheKey, cacheEntry, version );
 			return insert;
 		}
 		finally {
@@ -252,13 +252,14 @@ public class EntityInsertAction extends AbstractEntityInsertAction {
 	}
 
 	@Override
-	public void doAfterTransactionCompletion(boolean success, SharedSessionContractImplementor session) throws HibernateException {
+	public void doAfterTransactionCompletion(boolean success, SharedSessionContractImplementor session)
+			throws HibernateException {
 		final var persister = getPersister();
 		if ( success && isCachePutEnabled( persister, getSession() ) ) {
 			final var cache = persister.getCacheAccessStrategy();
 			final var factory = session.getFactory();
-			final Object ck = cache.generateCacheKey( getId(), persister, factory, session.getTenantIdentifier() );
-			final boolean put = cacheAfterInsert( cache, ck );
+			final Object cacheKey = cache.generateCacheKey( getId(), persister, factory, session.getTenantIdentifier() );
+			final boolean put = cacheAfterInsert( cache, cacheKey );
 
 			final var statistics = factory.getStatistics();
 			if ( put && statistics.isStatisticsEnabled() ) {
@@ -271,7 +272,7 @@ public class EntityInsertAction extends AbstractEntityInsertAction {
 		postCommitInsert( success );
 	}
 
-	protected boolean cacheAfterInsert(EntityDataAccess cache, Object ck) {
+	protected boolean cacheAfterInsert(EntityDataAccess cache, Object cacheKey) {
 		final var session = getSession();
 		final var eventListenerManager = session.getEventListenerManager();
 		final var eventMonitor = session.getEventMonitor();
@@ -279,7 +280,7 @@ public class EntityInsertAction extends AbstractEntityInsertAction {
 		boolean afterInsert = false;
 		try {
 			eventListenerManager.cachePutStart();
-			afterInsert = cache.afterInsert( session, ck, cacheEntry, version );
+			afterInsert = cache.afterInsert( session, cacheKey, cacheEntry, version );
 			return afterInsert;
 		}
 		finally {

--- a/hibernate-core/src/main/java/org/hibernate/action/internal/EntityInsertAction.java
+++ b/hibernate-core/src/main/java/org/hibernate/action/internal/EntityInsertAction.java
@@ -163,8 +163,7 @@ public class EntityInsertAction extends AbstractEntityInsertAction {
 		final var session = getSession();
 		if ( isCachePutEnabled( persister, session ) ) {
 			final var factory = session.getFactory();
-			final var cacheEntry = persister.buildCacheEntry( getInstance(), getState(), version, session );
-			this.cacheEntry = persister.getCacheEntryStructure().structure( cacheEntry );
+			cacheEntry = buildStructuredCacheEntry();
 			final var cache = persister.getCacheAccessStrategy();
 			final Object ck = cache.generateCacheKey( getId(), persister, factory, session.getTenantIdentifier() );
 			final boolean put = cacheInsert( persister, ck );
@@ -177,6 +176,12 @@ public class EntityInsertAction extends AbstractEntityInsertAction {
 				);
 			}
 		}
+	}
+
+	private Object buildStructuredCacheEntry() {
+		final var persister = getPersister();
+		final var cacheEntry = persister.buildCacheEntry( getInstance(), getState(), version, getSession() );
+		return persister.getCacheEntryStructure().structure( cacheEntry );
 	}
 
 	protected boolean cacheInsert(EntityPersister persister, Object ck) {

--- a/hibernate-core/src/main/java/org/hibernate/action/internal/EntityInsertAction.java
+++ b/hibernate-core/src/main/java/org/hibernate/action/internal/EntityInsertAction.java
@@ -22,6 +22,8 @@ import org.hibernate.generator.values.GeneratedValues;
 import org.hibernate.persister.entity.EntityPersister;
 import org.hibernate.stat.internal.StatsHelper;
 
+import static org.hibernate.cache.spi.entry.CacheEntryHelper.buildStructuredCacheEntry;
+
 /**
  * The action for performing an entity insertion, for entities not defined to use {@code IDENTITY} generation.
  *
@@ -163,7 +165,7 @@ public class EntityInsertAction extends AbstractEntityInsertAction {
 		final var session = getSession();
 		if ( isCachePutEnabled( persister, session ) ) {
 			final var factory = session.getFactory();
-			cacheEntry = buildStructuredCacheEntry();
+			cacheEntry = buildStructuredCacheEntry( getInstance(), version, getState(), persister, session );
 			final var cache = persister.getCacheAccessStrategy();
 			final Object cacheKey = cache.generateCacheKey( getId(), persister, factory, session.getTenantIdentifier() );
 			final boolean put = cacheInsert( persister, cacheKey );
@@ -176,12 +178,6 @@ public class EntityInsertAction extends AbstractEntityInsertAction {
 				);
 			}
 		}
-	}
-
-	private Object buildStructuredCacheEntry() {
-		final var persister = getPersister();
-		final var cacheEntry = persister.buildCacheEntry( getInstance(), getState(), version, getSession() );
-		return persister.getCacheEntryStructure().structure( cacheEntry );
 	}
 
 	protected boolean cacheInsert(EntityPersister persister, Object cacheKey) {

--- a/hibernate-core/src/main/java/org/hibernate/action/internal/EntityUpdateAction.java
+++ b/hibernate-core/src/main/java/org/hibernate/action/internal/EntityUpdateAction.java
@@ -27,6 +27,7 @@ import org.hibernate.persister.entity.EntityPersister;
 import org.hibernate.stat.internal.StatsHelper;
 import org.hibernate.type.TypeHelper;
 
+import static org.hibernate.cache.spi.entry.CacheEntryHelper.buildStructuredCacheEntry;
 import static org.hibernate.engine.internal.Versioning.getVersion;
 
 /**
@@ -224,7 +225,7 @@ public class EntityUpdateAction extends EntityAction {
 			}
 			else if ( session.getCacheMode().isPutEnabled() ) {
 				//TODO: inefficient if that cache is just going to ignore the updated state!
-				cacheEntry = buildStructuredCacheEntry();
+				cacheEntry = buildStructuredCacheEntry( getInstance(), nextVersion, state, persister, session );
 				final boolean put = updateCache( persister, previousVersion, cacheKey );
 
 				final var statistics = session.getFactory().getStatistics();
@@ -236,12 +237,6 @@ public class EntityUpdateAction extends EntityAction {
 				}
 			}
 		}
-	}
-
-	private Object buildStructuredCacheEntry() {
-		final var persister = getPersister();
-		final var cacheEntry = persister.buildCacheEntry( getInstance(), state, nextVersion, getSession() );
-		return persister.getCacheEntryStructure().structure( cacheEntry );
 	}
 
 	private static boolean isCacheInvalidationRequired(
@@ -471,7 +466,6 @@ public class EntityUpdateAction extends EntityAction {
 			}
 			eventListenerManager.cachePutEnd();
 		}
-
 	}
 
 }

--- a/hibernate-core/src/main/java/org/hibernate/cache/spi/entry/CacheEntryHelper.java
+++ b/hibernate-core/src/main/java/org/hibernate/cache/spi/entry/CacheEntryHelper.java
@@ -6,15 +6,18 @@ package org.hibernate.cache.spi.entry;
 
 import java.io.Serializable;
 
+import org.hibernate.Internal;
 import org.hibernate.bytecode.enhance.spi.LazyPropertyInitializer;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
+import org.hibernate.persister.entity.EntityPersister;
 import org.hibernate.property.access.internal.PropertyAccessStrategyBackRefImpl;
 import org.hibernate.type.Type;
 
 /**
  * Operations for assembly and disassembly of an array of property values.
  */
-class CacheEntryHelper {
+@Internal
+public class CacheEntryHelper {
 
 	/**
 	 * Apply the {@link Type#disassemble} operation across a series of values.
@@ -27,7 +30,7 @@ class CacheEntryHelper {
 	 *
 	 * @return The disassembled state
 	 */
-	public static Serializable[] disassemble(
+	static Serializable[] disassemble(
 			final Object[] row,
 			final Type[] types,
 			final boolean[] nonCacheable,
@@ -57,7 +60,7 @@ class CacheEntryHelper {
 	 * @param owner The entity "owning" the values
 	 * @return The assembled state
 	 */
-	public static Object[] assemble(
+	static Object[] assemble(
 			final Serializable[] row,
 			final Type[] types,
 			final SharedSessionContractImplementor session,
@@ -79,4 +82,13 @@ class CacheEntryHelper {
 			|| value == PropertyAccessStrategyBackRefImpl.UNKNOWN;
 	}
 
+	public static Object buildStructuredCacheEntry(
+			Object entity,
+			Object version,
+			Object[] state,
+			EntityPersister persister,
+			SharedSessionContractImplementor session) {
+		return persister.getCacheEntryStructure()
+				.structure( persister.buildCacheEntry( entity, state, version, session ) );
+	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/engine/internal/EntityEntryImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/internal/EntityEntryImpl.java
@@ -450,15 +450,16 @@ public final class EntityEntryImpl implements Serializable, EntityEntry {
 			else {
 				setStatus( MANAGED );
 				loadedState = persister.getValues( entity );
+				final var context = getPersistenceContext();
 				TypeHelper.deepCopy(
 						loadedState,
 						persister.getPropertyTypes(),
 						persister.getPropertyCheckability(),
 						loadedState,
-						getPersistenceContext().getSession()
+						context.getSession()
 				);
 				if ( persister.hasNaturalIdentifier() ) {
-					getPersistenceContext().getNaturalIdResolutions().manageLocalResolution(
+					context.getNaturalIdResolutions().manageLocalResolution(
 							id,
 							persister.getNaturalIdMapping().extractNaturalIdFromEntityState( loadedState ),
 							persister,

--- a/hibernate-core/src/main/java/org/hibernate/event/internal/DefaultLoadEventListener.java
+++ b/hibernate-core/src/main/java/org/hibernate/event/internal/DefaultLoadEventListener.java
@@ -461,20 +461,20 @@ public class DefaultLoadEventListener implements LoadEventListener {
 		final var cache = persister.getCacheAccessStrategy();
 
 		final SoftLock lock;
-		final Object ck;
+		final Object cacheKey;
 		final boolean canWriteToCache = persister.canWriteToCache();
 		if ( canWriteToCache ) {
-			ck = cache.generateCacheKey(
+			cacheKey = cache.generateCacheKey(
 					event.getEntityId(),
 					persister,
 					event.getFactory(),
 					source.getTenantIdentifier()
 			);
-			lock = cache.lockItem( source, ck, null );
+			lock = cache.lockItem( source, cacheKey, null );
 		}
 		else {
 			lock = null;
-			ck = null;
+			cacheKey = null;
 		}
 
 		final Object entity;
@@ -483,7 +483,7 @@ public class DefaultLoadEventListener implements LoadEventListener {
 		}
 		finally {
 			if ( canWriteToCache ) {
-				cache.unlockItem( source, ck, lock );
+				cache.unlockItem( source, cacheKey, lock );
 			}
 		}
 

--- a/hibernate-core/src/main/java/org/hibernate/internal/NaturalIdHelper.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/NaturalIdHelper.java
@@ -4,16 +4,11 @@
  */
 package org.hibernate.internal;
 
-import org.hibernate.engine.spi.EntityEntry;
-import org.hibernate.engine.spi.EntityKey;
-import org.hibernate.engine.spi.PersistenceContext;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.engine.spi.Status;
 import org.hibernate.id.IdentifierGenerationException;
 import org.hibernate.metamodel.mapping.EntityMappingType;
 import org.hibernate.persister.entity.EntityPersister;
-
-import java.util.Collection;
 
 import static org.hibernate.engine.internal.NaturalIdLogging.NATURAL_ID_LOGGER;
 
@@ -50,22 +45,19 @@ public class NaturalIdHelper {
 				&& entityMappingType.getNaturalIdMapping().isMutable()
 				// skip synchronization when not in a transaction
 				&& session.isTransactionInProgress() ) {
-			final EntityPersister entityPersister = entityMappingType.getEntityPersister();
-			final PersistenceContext persistenceContext = session.getPersistenceContextInternal();
-			final Collection<?> cachedResolutions =
-					persistenceContext.getNaturalIdResolutions()
-							.getCachedPkResolutions( entityPersister );
+			final var persister = entityMappingType.getEntityPersister();
+			final var persistenceContext = session.getPersistenceContextInternal();
+			final var naturalIdResolutions = persistenceContext.getNaturalIdResolutions();
 			final boolean loggerDebugEnabled = NATURAL_ID_LOGGER.isDebugEnabled();
-			for ( Object id : cachedResolutions ) {
-				final EntityKey entityKey = session.generateEntityKey( id, entityPersister );
+			for ( Object id : naturalIdResolutions.getCachedPkResolutions( persister ) ) {
+				final var entityKey = session.generateEntityKey( id, persister );
 				final Object entity = persistenceContext.getEntity( entityKey );
-				final EntityEntry entry = persistenceContext.getEntry( entity );
+				final var entry = persistenceContext.getEntry( entity );
 				if ( entry != null ) {
 					if ( entry.requiresDirtyCheck( entity )
 							// MANAGED is the only status we care about here
 							&& entry.getStatus() == Status.MANAGED ) {
-						persistenceContext.getNaturalIdResolutions()
-								.handleSynchronization( id, entity, entityPersister );
+						naturalIdResolutions.handleSynchronization( id, entity, persister );
 					}
 				}
 				else {

--- a/hibernate-core/src/main/java/org/hibernate/internal/OptimisticLockHelper.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/OptimisticLockHelper.java
@@ -15,6 +15,8 @@ import org.hibernate.event.monitor.spi.EventMonitor;
 import org.hibernate.persister.entity.EntityPersister;
 import org.hibernate.stat.internal.StatsHelper;
 
+import static org.hibernate.cache.spi.entry.CacheEntryHelper.buildStructuredCacheEntry;
+
 public final class OptimisticLockHelper {
 
 	private OptimisticLockHelper() {
@@ -89,16 +91,6 @@ public final class OptimisticLockHelper {
 			return cacheEntry;
 		}
 		return null;
-	}
-
-	private static Object buildStructuredCacheEntry(
-			Object entity,
-			Object nextVersion,
-			Object[] state,
-			EntityPersister persister,
-			SharedSessionContractImplementor session) {
-		final var cacheEntry = persister.buildCacheEntry( entity, state, nextVersion, session );
-		return persister.getCacheEntryStructure().structure( cacheEntry );
 	}
 
 	private static boolean updateCache(

--- a/hibernate-core/src/main/java/org/hibernate/loader/ast/internal/LoaderHelper.java
+++ b/hibernate-core/src/main/java/org/hibernate/loader/ast/internal/LoaderHelper.java
@@ -10,22 +10,18 @@ import org.hibernate.Hibernate;
 import org.hibernate.LockMode;
 import org.hibernate.LockOptions;
 import org.hibernate.ObjectDeletedException;
-import org.hibernate.cache.spi.access.EntityDataAccess;
 import org.hibernate.cache.spi.access.SoftLock;
 import org.hibernate.engine.spi.EntityEntry;
 import org.hibernate.engine.spi.LoadQueryInfluencers;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.engine.spi.SubselectFetch;
-import org.hibernate.event.monitor.spi.EventMonitor;
 import org.hibernate.event.spi.EventSource;
-import org.hibernate.event.monitor.spi.DiagnosticEvent;
 import org.hibernate.internal.OptimisticLockHelper;
 import org.hibernate.internal.build.AllowReflection;
 import org.hibernate.metamodel.mapping.BasicValuedModelPart;
 import org.hibernate.metamodel.mapping.EntityMappingType;
 import org.hibernate.metamodel.mapping.JdbcMapping;
-import org.hibernate.persister.entity.EntityPersister;
 import org.hibernate.sql.ast.tree.expression.JdbcParameter;
 import org.hibernate.sql.ast.tree.select.SelectStatement;
 import org.hibernate.sql.exec.internal.JdbcParameterBindingImpl;
@@ -61,7 +57,7 @@ public class LoaderHelper {
 		final LockMode requestedLockMode = lockOptions.getLockMode();
 		if ( requestedLockMode.greaterThan( entry.getLockMode() ) ) {
 			// Request is for a more restrictive lock than the lock already held
-			final EntityPersister persister = entry.getPersister();
+			final var persister = entry.getPersister();
 
 			if ( entry.getStatus().isDeletedOrGone()) {
 				throw new ObjectDeletedException(
@@ -82,12 +78,12 @@ public class LoaderHelper {
 
 			final boolean cachingEnabled = persister.canWriteToCache();
 			SoftLock lock = null;
-			Object ck = null;
+			Object cacheKey = null;
 			try {
 				if ( cachingEnabled ) {
-					final EntityDataAccess cache = persister.getCacheAccessStrategy();
-					ck = cache.generateCacheKey( entry.getId(), persister, session.getFactory(), session.getTenantIdentifier() );
-					lock = cache.lockItem( session, ck, entry.getVersion() );
+					final var cache = persister.getCacheAccessStrategy();
+					cacheKey = cache.generateCacheKey( entry.getId(), persister, session.getFactory(), session.getTenantIdentifier() );
+					lock = cache.lockItem( session, cacheKey, entry.getVersion() );
 				}
 
 				if ( persister.isVersioned() && entry.getVersion() == null ) {
@@ -110,8 +106,8 @@ public class LoaderHelper {
 					OptimisticLockHelper.forceVersionIncrement( object, entry, session );
 				}
 				else if ( entry.isExistsInDatabase() ) {
-					final EventMonitor eventMonitor = session.getEventMonitor();
-					final DiagnosticEvent entityLockEvent = eventMonitor.beginEntityLockEvent();
+					final var eventMonitor = session.getEventMonitor();
+					final var entityLockEvent = eventMonitor.beginEntityLockEvent();
 					boolean success = false;
 					try {
 						persister.lock( entry.getId(), entry.getVersion(), object, lockOptions, session );
@@ -134,7 +130,7 @@ public class LoaderHelper {
 				// the database now holds a lock + the object is flushed from the cache,
 				// so release the soft lock
 				if ( cachingEnabled ) {
-					persister.getCacheAccessStrategy().unlockItem( session, ck, lock );
+					persister.getCacheAccessStrategy().unlockItem( session, cacheKey, lock );
 				}
 			}
 		}

--- a/hibernate-core/src/main/java/org/hibernate/persister/entity/AbstractEntityPersister.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/entity/AbstractEntityPersister.java
@@ -3970,10 +3970,11 @@ public abstract class AbstractEntityPersister
 
 		// check to see if it is in the second-level cache
 		if ( session.getCacheMode().isGetEnabled() && canReadFromCache() ) {
-			final EntityDataAccess cache = getCacheAccessStrategy();
-			final Object ck = cache.generateCacheKey( id, this, session.getFactory(), session.getTenantIdentifier() );
-			final Object ce = CacheHelper.fromSharedCache( session, ck, this, getCacheAccessStrategy() );
-			if ( ce != null ) {
+			final var cache = getCacheAccessStrategy();
+			final Object cacheKey =
+					cache.generateCacheKey( id, this, session.getFactory(), session.getTenantIdentifier() );
+			final Object cacheEntry = CacheHelper.fromSharedCache( session, cacheKey, this, getCacheAccessStrategy() );
+			if ( cacheEntry != null ) {
 				return false;
 			}
 		}

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/internal/ResultsHelper.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/internal/ResultsHelper.java
@@ -6,30 +6,21 @@ package org.hibernate.sql.results.internal;
 
 
 import org.hibernate.CacheMode;
-import org.hibernate.cache.spi.access.CollectionDataAccess;
+import org.hibernate.SharedSessionContract;
 import org.hibernate.cache.spi.entry.CollectionCacheEntry;
 import org.hibernate.collection.spi.PersistentCollection;
-import org.hibernate.engine.spi.BatchFetchQueue;
 import org.hibernate.engine.spi.CollectionEntry;
-import org.hibernate.engine.spi.EntityEntry;
 import org.hibernate.engine.spi.PersistenceContext;
-import org.hibernate.engine.spi.SessionEventListenerManager;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.event.monitor.spi.EventMonitor;
-import org.hibernate.event.monitor.spi.DiagnosticEvent;
 import org.hibernate.internal.CoreLogging;
 import org.hibernate.internal.CoreMessageLogger;
-import org.hibernate.metamodel.mapping.PluralAttributeMapping;
 import org.hibernate.persister.collection.CollectionPersister;
-import org.hibernate.persister.entity.EntityPersister;
 import org.hibernate.sql.results.jdbc.spi.JdbcValues;
 import org.hibernate.sql.results.jdbc.spi.JdbcValuesMapping;
-import org.hibernate.sql.results.jdbc.spi.JdbcValuesMappingResolution;
 import org.hibernate.sql.results.spi.RowReader;
 import org.hibernate.sql.results.spi.RowTransformer;
-import org.hibernate.stat.spi.StatisticsImplementor;
-import org.hibernate.type.EntityType;
 
 import static org.hibernate.pretty.MessageHelper.collectionInfoString;
 
@@ -53,9 +44,8 @@ public class ResultsHelper {
 			RowTransformer<R> rowTransformer,
 			Class<R> transformedResultJavaType,
 			JdbcValuesMapping jdbcValuesMapping) {
-		final JdbcValuesMappingResolution jdbcValuesMappingResolution = jdbcValuesMapping.resolveAssemblers( sessionFactory );
 		return new StandardRowReader<>(
-				jdbcValuesMappingResolution,
+				jdbcValuesMapping.resolveAssemblers( sessionFactory ),
 				rowTransformer,
 				transformedResultJavaType
 		);
@@ -64,62 +54,76 @@ public class ResultsHelper {
 	public static void finalizeCollectionLoading(
 			PersistenceContext persistenceContext,
 			CollectionPersister collectionDescriptor,
-			PersistentCollection<?> collectionInstance,
+			PersistentCollection<?> collection,
 			Object key,
 			boolean hasNoQueuedAdds) {
-		final SharedSessionContractImplementor session = persistenceContext.getSession();
-
-		CollectionEntry collectionEntry = persistenceContext.getCollectionEntry( collectionInstance );
-		if ( collectionEntry == null ) {
-			collectionEntry = persistenceContext.addInitializedCollection( collectionDescriptor, collectionInstance, key );
-		}
-		else {
-			collectionEntry.postInitialize( collectionInstance, session );
-		}
-
+		final var session = persistenceContext.getSession();
+		final var collectionEntry =
+				initializedEntry( persistenceContext, collectionDescriptor, collection, key, session );
 		if ( collectionDescriptor.getCollectionType().hasHolder() ) {
-			// in case of PersistentArrayHolder we have to realign
-			// the EntityEntry loaded state with the entity values
-			final Object owner = collectionInstance.getOwner();
-			final EntityEntry entry = persistenceContext.getEntry( owner );
-			final Object[] loadedState = entry.getLoadedState();
-			if ( loadedState != null ) {
-				final PluralAttributeMapping mapping = collectionDescriptor.getAttributeMapping();
-				final int propertyIndex = mapping.getStateArrayPosition();
-				loadedState[propertyIndex] = mapping.getValue( owner );
-			}
-			// else it must be an immutable entity or loaded in read-only mode,
-			// but unfortunately we have no way to reliably determine that here
-			persistenceContext.addCollectionHolder( collectionInstance );
+			addCollectionHolder( persistenceContext, collectionDescriptor, collection );
 		}
-
-		final BatchFetchQueue batchFetchQueue = persistenceContext.getBatchFetchQueue();
-		batchFetchQueue.removeBatchLoadableCollection( collectionEntry );
-
-		// add to cache if:
-		final boolean addToCache =
-				// there were no queued additions
-				hasNoQueuedAdds
-						// and the role has a cache
-						&& collectionDescriptor.hasCache()
-						// and this is not a forced initialization during flush
-						&& session.getCacheMode().isPutEnabled() && !collectionEntry.isDoremove();
-		if ( addToCache ) {
-			addCollectionToCache( persistenceContext, collectionDescriptor, collectionInstance, key );
+		persistenceContext.getBatchFetchQueue().removeBatchLoadableCollection( collectionEntry );
+		if ( addToCache( session, collectionEntry, collectionDescriptor, hasNoQueuedAdds ) ) {
+			addCollectionToCache( persistenceContext, collectionDescriptor, collection, key );
 		}
-
-		if ( LOG.isTraceEnabled() ) {
-			LOG.trace( "Collection fully initialized: "
-					+ collectionInfoString( collectionDescriptor, collectionInstance, key, session ) );
-		}
-
-		final StatisticsImplementor statistics = session.getFactory().getStatistics();
+		final var statistics = session.getFactory().getStatistics();
 		if ( statistics.isStatisticsEnabled() ) {
 			statistics.loadCollection( collectionDescriptor.getRole() );
 		}
 
+		if ( LOG.isTraceEnabled() ) {
+			LOG.trace( "Collection fully initialized: "
+					+ collectionInfoString( collectionDescriptor, collection, key, session ) );
+		}
+
 		// todo (6.0) : there is other logic still needing to be implemented here.  caching, etc
 		// 		see org.hibernate.engine.loading.internal.CollectionLoadContext#endLoadingCollection in 5.x
+	}
+
+	private static boolean addToCache(
+			SharedSessionContract session,
+			CollectionEntry collectionEntry,
+			CollectionPersister collectionDescriptor,
+			boolean hasNoQueuedAdds) {
+		return hasNoQueuedAdds  // there were no queued additions
+			&& collectionDescriptor.hasCache()  // the collection role has a cache
+			&& session.getCacheMode().isPutEnabled()  // the session cache mode allows puts
+			&& !collectionEntry.isDoremove();  // this is not a forced initialization during flush
+	}
+
+	private static void addCollectionHolder(
+			PersistenceContext persistenceContext,
+			CollectionPersister collectionDescriptor,
+			PersistentCollection<?> collectionInstance) {
+		// in case of PersistentArrayHolder we have to realign
+		// the EntityEntry loaded state with the entity values
+		final Object owner = collectionInstance.getOwner();
+		final var loadedState = persistenceContext.getEntry( owner ).getLoadedState();
+		if ( loadedState != null ) {
+			final var mapping = collectionDescriptor.getAttributeMapping();
+			final int propertyIndex = mapping.getStateArrayPosition();
+			loadedState[propertyIndex] = mapping.getValue( owner );
+		}
+		// else it must be an immutable entity or loaded in read-only mode,
+		// but, unfortunately, we have no way to reliably determine that here
+		persistenceContext.addCollectionHolder( collectionInstance );
+	}
+
+	private static CollectionEntry initializedEntry(
+			PersistenceContext context,
+			CollectionPersister collectionDescriptor,
+			PersistentCollection<?> collectionInstance,
+			Object key,
+			SharedSessionContractImplementor session) {
+		final var collectionEntry = context.getCollectionEntry( collectionInstance );
+		if ( collectionEntry == null ) {
+			return context.addInitializedCollection( collectionDescriptor, collectionInstance, key );
+		}
+		else {
+			collectionEntry.postInitialize( collectionInstance, session );
+			return collectionEntry;
+		}
 	}
 
 	/**
@@ -128,17 +132,17 @@ public class ResultsHelper {
 	private static void addCollectionToCache(
 			PersistenceContext persistenceContext,
 			CollectionPersister collectionDescriptor,
-			PersistentCollection<?> collectionInstance,
+			PersistentCollection<?> collection,
 			Object key) {
-		final SharedSessionContractImplementor session = persistenceContext.getSession();
-		final SessionFactoryImplementor factory = session.getFactory();
+		final var session = persistenceContext.getSession();
 
 		if ( LOG.isTraceEnabled() ) {
 			LOG.trace( "Caching collection: "
-					+ collectionInfoString( collectionDescriptor, collectionInstance, key, session ) );
+					+ collectionInfoString( collectionDescriptor, collection, key, session ) );
 		}
 
-		if ( session.getLoadQueryInfluencers().hasEnabledFilters() && collectionDescriptor.isAffectedByEnabledFilters( session ) ) {
+		if ( session.getLoadQueryInfluencers().hasEnabledFilters()
+				&& collectionDescriptor.isAffectedByEnabledFilters( session ) ) {
 			// some filters affecting the collection are enabled on the session, so do not do the put into the cache.
 			LOG.debug( "Refusing to add to cache due to enabled filters" );
 			// todo : add the notion of enabled filters to the cache key to differentiate filtered collections from non-filtered;
@@ -150,24 +154,11 @@ public class ResultsHelper {
 
 		final Object version;
 		if ( collectionDescriptor.isVersioned() ) {
-			Object collectionOwner = persistenceContext.getCollectionOwner( key, collectionDescriptor );
+			final Object collectionOwner =
+					getCollectionOwner( persistenceContext, collectionDescriptor, collection, key, session );
 			if ( collectionOwner == null ) {
-				// generally speaking this would be caused by the collection key being defined by a property-ref, thus
-				// the collection key and the owner key would not match up.  In this case, try to use the key of the
-				// owner instance associated with the collection itself, if one.  If the collection does already know
-				// about its owner, that owner should be the same instance as associated with the PC, but we do the
-				// resolution against the PC anyway just to be safe since the lookup should not be costly.
-				if ( collectionInstance != null ) {
-					final Object linkedOwner = collectionInstance.getOwner();
-					if ( linkedOwner != null ) {
-						final Object ownerKey = collectionDescriptor.getOwnerEntityPersister().getIdentifier( linkedOwner, session );
-						collectionOwner = persistenceContext.getCollectionOwner( ownerKey, collectionDescriptor );
-					}
-				}
-				if ( collectionOwner == null ) {
-					LOG.debugf( "Unable to resolve owner of loading collection for second level caching. Refusing to add to cache.");
-					return;
-				}
+				LOG.debug( "Unable to resolve owner of loading collection for second level caching. Refusing to add to cache.");
+				return;
 			}
 			version = persistenceContext.getEntry( collectionOwner ).getVersion();
 		}
@@ -175,8 +166,19 @@ public class ResultsHelper {
 			version = null;
 		}
 
-		final CollectionCacheEntry entry = new CollectionCacheEntry( collectionInstance, collectionDescriptor );
-		final CollectionDataAccess cacheAccess = collectionDescriptor.getCacheAccessStrategy();
+		addCollectionToCache( persistenceContext, collectionDescriptor, collection, key, version );
+	}
+
+	private static void addCollectionToCache(
+			PersistenceContext context,
+			CollectionPersister collectionDescriptor,
+			PersistentCollection<?> collection,
+			Object key,
+			Object version) {
+		final var session = context.getSession();
+		final var factory = session.getFactory();
+		final var entry = new CollectionCacheEntry( collection, collectionDescriptor );
+		final var cacheAccess = collectionDescriptor.getCacheAccessStrategy();
 		final Object cacheKey = cacheAccess.generateCacheKey(
 				key,
 				collectionDescriptor,
@@ -184,22 +186,11 @@ public class ResultsHelper {
 				session.getTenantIdentifier()
 		);
 
-		boolean isPutFromLoad = true;
-		if ( collectionDescriptor.getElementType() instanceof EntityType ) {
-			final EntityPersister entityPersister = collectionDescriptor.getElementPersister();
-			for ( Object id : entry.getState() ) {
-				if ( persistenceContext.wasInsertedDuringTransaction( entityPersister, id ) ) {
-					isPutFromLoad = false;
-					break;
-				}
-			}
-		}
-
 		// CollectionRegionAccessStrategy has no update, so avoid putting uncommitted data via putFromLoad
-		if ( isPutFromLoad ) {
-			final SessionEventListenerManager eventListenerManager = session.getEventListenerManager();
-			final EventMonitor eventMonitor = session.getEventMonitor();
-			final DiagnosticEvent cachePutEvent = eventMonitor.beginCachePutEvent();
+		if ( isPutFromLoad( context, collectionDescriptor, entry ) ) {
+			final var eventListenerManager = session.getEventListenerManager();
+			final var eventMonitor = session.getEventMonitor();
+			final var cachePutEvent = eventMonitor.beginCachePutEvent();
 			boolean put = false;
 			try {
 				eventListenerManager.cachePutStart();
@@ -209,7 +200,7 @@ public class ResultsHelper {
 						collectionDescriptor.getCacheEntryStructure().structure( entry ),
 						version,
 						factory.getSessionFactoryOptions().isMinimalPutsEnabled()
-								&& session.getCacheMode()!= CacheMode.REFRESH
+						&& session.getCacheMode() != CacheMode.REFRESH
 				);
 			}
 			finally {
@@ -223,15 +214,58 @@ public class ResultsHelper {
 				);
 				eventListenerManager.cachePutEnd();
 
-				final StatisticsImplementor statistics = factory.getStatistics();
+				final var statistics = factory.getStatistics();
 				if ( put && statistics.isStatisticsEnabled() ) {
 					statistics.collectionCachePut(
 							collectionDescriptor.getNavigableRole(),
-							collectionDescriptor.getCacheAccessStrategy().getRegion().getName()
+							cacheAccess.getRegion().getName()
 					);
 				}
-
 			}
+		}
+	}
+
+	private static boolean isPutFromLoad(
+			PersistenceContext context,
+			CollectionPersister collectionDescriptor,
+			CollectionCacheEntry entry) {
+		if ( collectionDescriptor.getElementType().isEntityType() ) {
+			final var entityPersister = collectionDescriptor.getElementPersister();
+			for ( Object id : entry.getState() ) {
+				if ( context.wasInsertedDuringTransaction( entityPersister, id ) ) {
+					return false;
+				}
+			}
+		}
+		return true;
+	}
+
+	private static Object getCollectionOwner(
+			PersistenceContext context,
+			CollectionPersister collectionDescriptor,
+			PersistentCollection<?> collection,
+			Object key,
+			SharedSessionContractImplementor session) {
+		final Object collectionOwner = context.getCollectionOwner( key, collectionDescriptor );
+		if ( collectionOwner == null ) {
+			// This happens when the collection key is defined by a property-ref. In this case, the collection key
+			// and the owner key would not match up. Use the key of the owner instance associated with the collection
+			// itself, if there is one. If the collection does already know about its owner, that owner should be the
+			// same instance as associated with the PC, but we do the resolution against the PC anyway just to be safe,
+			// since the lookup should not be costly.
+			if ( collection != null ) {
+				final Object linkedOwner = collection.getOwner();
+				if ( linkedOwner != null ) {
+					final Object ownerKey =
+							collectionDescriptor.getOwnerEntityPersister()
+									.getIdentifier( linkedOwner, session );
+					return context.getCollectionOwner( ownerKey, collectionDescriptor );
+				}
+			}
+			return null;
+		}
+		else {
+			return collectionOwner;
 		}
 	}
 }


### PR DESCRIPTION
it's conceptually wrong to do work in the constructor of an Action instead of in its execute() method

<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

[Please describe here what your change is about]

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
