### PR TITLE
HHH-18686 - align behaviour of SchemaTool and SchemaExportTask with respect to ordering columns and metadata validation

### DIFF
--- a/tooling/hibernate-ant/src/main/java/org/hibernate/tool/hbm2ddl/SchemaExport.java
+++ b/tooling/hibernate-ant/src/main/java/org/hibernate/tool/hbm2ddl/SchemaExport.java
@@ -390,6 +390,8 @@ public class SchemaExport {
 		StandardServiceRegistry serviceRegistry = buildStandardServiceRegistry( commandLineArgs );
 		try {
 			final MetadataImplementor metadata = buildMetadata( commandLineArgs, serviceRegistry );
+			metadata.orderColumns( false );
+			metadata.validate();
 
 			new SchemaExport()
 					.setHaltOnError( commandLineArgs.halt )


### PR DESCRIPTION
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-18686
<!-- Hibernate GitHub Bot issue links end -->