### PR TITLE
encapsulate EntityMetamodel within AbstractEntityPersister

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/action/internal/EntityUpdateAction.java
+++ b/hibernate-core/src/main/java/org/hibernate/action/internal/EntityUpdateAction.java
@@ -283,9 +283,9 @@ public class EntityUpdateAction extends EntityAction {
 	 */
 	protected void handleDeleted(EntityEntry entry) {
 		if ( entry.getStatus() == Status.DELETED ) {
-			final var entityMetamodel = getPersister().getEntityMetamodel();
+			final var entityMetamodel = getPersister();
 			final boolean isImpliedOptimisticLocking = !entityMetamodel.isVersioned()
-					&& entityMetamodel.getOptimisticLockStyle().isAllOrDirty();
+					&& entityMetamodel.optimisticLockStyle().isAllOrDirty();
 			if ( isImpliedOptimisticLocking && entry.getLoadedState() != null ) {
 				// The entity will be deleted, and because we are going to create a delete statement
 				// that uses all the state values in the where clause, the entry state needs to be

--- a/hibernate-core/src/main/java/org/hibernate/bytecode/enhance/spi/interceptor/EnhancementAsProxyLazinessInterceptor.java
+++ b/hibernate-core/src/main/java/org/hibernate/bytecode/enhance/spi/interceptor/EnhancementAsProxyLazinessInterceptor.java
@@ -355,8 +355,8 @@ public class EnhancementAsProxyLazinessInterceptor extends AbstractInterceptor i
 			// versioned, we need to fetch the current version.
 			this.initializeBeforeWrite =
 					!inLineDirtyChecking
-					|| !persister.getEntityMetamodel().isDynamicUpdate()
-					|| persister.isVersioned();
+						|| !persister.isDynamicUpdate()
+						|| persister.isVersioned();
 		}
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/bytecode/internal/BytecodeEnhancementMetadataPojoImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/bytecode/internal/BytecodeEnhancementMetadataPojoImpl.java
@@ -187,8 +187,7 @@ public final class BytecodeEnhancementMetadataPojoImpl implements BytecodeEnhanc
 		}
 
 		// inject the interceptor
-		persister.getEntityMetamodel()
-				.getBytecodeEnhancementMetadata()
+		persister.getBytecodeEnhancementMetadata()
 				.injectEnhancedEntityAsProxyInterceptor( entity, entityKey, session );
 
 		return entity;

--- a/hibernate-core/src/main/java/org/hibernate/engine/internal/Cascade.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/internal/Cascade.java
@@ -665,7 +665,7 @@ public final class Cascade {
 
 	private static <T> boolean cascadeDeleteEnabled(CascadingAction<T> action, EntityPersister persister, int i) {
 		return action.directionAffectedByCascadeDelete() == ForeignKeyDirection.TO_PARENT
-			&& persister.getEntityMetamodel().getPropertyOnDeleteActions()[i] == OnDeleteAction.CASCADE;
+			&& persister.getPropertyOnDeleteActions()[i] == OnDeleteAction.CASCADE;
 	}
 
 	private static <T> boolean cascadeDeleteEnabled(CascadingAction<T> action, CompositeType componentType, int i) {

--- a/hibernate-core/src/main/java/org/hibernate/engine/internal/EntityEntryImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/internal/EntityEntryImpl.java
@@ -287,7 +287,7 @@ public final class EntityEntryImpl implements Serializable, EntityEntry {
 
 		if ( persister.isVersioned() ) {
 			version = nextVersion;
-			persister.setValue( entity, persister.getVersionProperty(), nextVersion );
+			persister.setValue( entity, persister.getVersionPropertyIndex(), nextVersion );
 		}
 
 		processIfSelfDirtinessTracker( entity, EntityEntryImpl::clearDirtyAttributes );
@@ -421,7 +421,7 @@ public final class EntityEntryImpl implements Serializable, EntityEntry {
 	@Override
 	public void forceLocked(Object entity, Object nextVersion) {
 		version = nextVersion;
-		final int versionProperty = persister.getVersionProperty();
+		final int versionProperty = persister.getVersionPropertyIndex();
 		loadedState[versionProperty] = version;
 		setLockMode( PESSIMISTIC_FORCE_INCREMENT );
 		persister.setValue( entity, versionProperty, nextVersion );

--- a/hibernate-core/src/main/java/org/hibernate/engine/internal/Nullability.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/internal/Nullability.java
@@ -105,7 +105,7 @@ public final class Nullability {
 			final boolean[] nullability = persister.getPropertyNullability();
 			final boolean[] checkability = getCheckability( persister );
 			final Type[] propertyTypes = persister.getPropertyTypes();
-			final Generator[] generators = persister.getEntityMetamodel().getGenerators();
+			final Generator[] generators = persister.getGenerators();
 			for ( int i = 0; i < values.length; i++ ) {
 				if ( checkability[i]
 						&& !unfetched( values[i] )

--- a/hibernate-core/src/main/java/org/hibernate/engine/internal/StatefulPersistenceContext.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/internal/StatefulPersistenceContext.java
@@ -348,7 +348,7 @@ class StatefulPersistenceContext implements PersistenceContext {
 			return cachedValue;
 		}
 		// check to see if the natural id is mutable/immutable
-		else if ( persister.getEntityMetamodel().hasImmutableNaturalId() ) {
+		else if ( persister.hasImmutableNaturalId() ) {
 			// an immutable natural-id is not retrieved during a normal database-snapshot operation...
 			final Object naturalIdFromDb = persister.getNaturalIdentifierSnapshot( id, session );
 			naturalIdResolutions.cacheResolutionFromLoad( id, naturalIdFromDb, persister );

--- a/hibernate-core/src/main/java/org/hibernate/engine/internal/Versioning.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/internal/Versioning.java
@@ -67,7 +67,7 @@ public final class Versioning {
 			Object[] fields,
 			EntityPersister persister,
 			SharedSessionContractImplementor session) {
-		final int versionProperty = persister.getVersionProperty();
+		final int versionProperty = persister.getVersionPropertyIndex();
 		final Object initialVersion = fields[versionProperty];
 		if ( isNullInitialVersion( initialVersion ) ) {
 			fields[versionProperty] = persister.getVersionGenerator().generate( session, entity, initialVersion, INSERT );
@@ -150,7 +150,7 @@ public final class Versioning {
 	 */
 	public static void setVersion(Object[] fields, Object version, EntityPersister persister) {
 		if ( persister.isVersioned() ) {
-			fields[ persister.getVersionProperty() ] = version;
+			fields[ persister.getVersionPropertyIndex() ] = version;
 		}
 	}
 
@@ -162,7 +162,7 @@ public final class Versioning {
 	 * @return The extracted optimistic locking value
 	 */
 	public static Object getVersion(Object[] fields, EntityPersister persister) {
-		return persister.isVersioned() ? fields[persister.getVersionProperty()] : null;
+		return persister.isVersioned() ? fields[persister.getVersionPropertyIndex()] : null;
 	}
 
 	/**

--- a/hibernate-core/src/main/java/org/hibernate/generator/values/internal/GeneratedValuesHelper.java
+++ b/hibernate-core/src/main/java/org/hibernate/generator/values/internal/GeneratedValuesHelper.java
@@ -298,7 +298,7 @@ public class GeneratedValuesHelper {
 		}
 		else if ( timing == EventType.INSERT
 					&& persister.getNaturalIdentifierProperties() != null
-					&& !persister.getEntityMetamodel().isNaturalIdentifierInsertGenerated() ) {
+					&& !persister.isNaturalIdentifierInsertGenerated() ) {
 			return new UniqueKeySelectingDelegate( persister, getNaturalIdPropertyNames( persister ), timing );
 		}
 		return null;

--- a/hibernate-core/src/main/java/org/hibernate/id/IdentityGenerator.java
+++ b/hibernate-core/src/main/java/org/hibernate/id/IdentityGenerator.java
@@ -74,7 +74,7 @@ public class IdentityGenerator
 			return dialect.getIdentityColumnSupport().buildGetGeneratedKeysDelegate( persister );
 		}
 		else if ( persister.getNaturalIdentifierProperties() != null
-				&& !persister.getEntityMetamodel().isNaturalIdentifierInsertGenerated() ) {
+				&& !persister.isNaturalIdentifierInsertGenerated() ) {
 			return new UniqueKeySelectingDelegate( persister, getNaturalIdPropertyNames( persister ), INSERT );
 		}
 		else {

--- a/hibernate-core/src/main/java/org/hibernate/internal/NaturalIdHelper.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/NaturalIdHelper.java
@@ -23,7 +23,7 @@ public class NaturalIdHelper {
 			throw new IdentifierGenerationException( "Entity '" + persister.getEntityName()
 					+ "' has no '@NaturalId' property" );
 		}
-		if ( persister.getEntityMetamodel().isNaturalIdentifierInsertGenerated() ) {
+		if ( persister.isNaturalIdentifierInsertGenerated() ) {
 			throw new IdentifierGenerationException( "Entity '" + persister.getEntityName()
 					+ "' has a '@NaturalId' property which is also defined as insert-generated" );
 		}

--- a/hibernate-core/src/main/java/org/hibernate/internal/StatelessSessionImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/StatelessSessionImpl.java
@@ -1013,8 +1013,7 @@ public class StatelessSessionImpl extends AbstractSharedSessionContract implemen
 
 			// first, check to see if we can use "bytecode proxies"
 
-			final var entityMetamodel = persister.getEntityMetamodel();
-			final var enhancementMetadata = entityMetamodel.getBytecodeEnhancementMetadata();
+			final var enhancementMetadata = persister.getBytecodeEnhancementMetadata();
 			if ( enhancementMetadata.isEnhancedForLazyLoading() ) {
 				// if the entity defines a HibernateProxy factory, see if there is an
 				// existing proxy associated with the PC - and if so, use it
@@ -1031,14 +1030,14 @@ public class StatelessSessionImpl extends AbstractSharedSessionContract implemen
 					}
 
 					// specialized handling for entities with subclasses with a HibernateProxy factory
-					if ( entityMetamodel.hasSubclasses() ) {
+					if ( persister.hasSubclasses() ) {
 						// entities with subclasses that define a ProxyFactory can create a HibernateProxy.
 						LOG.trace( "Creating a HibernateProxy for to-one association with subclasses to honor laziness" );
 						return createProxy( entityKey );
 					}
 					return enhancementMetadata.createEnhancedProxy( entityKey, false, this );
 				}
-				else if ( !entityMetamodel.hasSubclasses() ) {
+				else if ( !persister.hasSubclasses() ) {
 					return enhancementMetadata.createEnhancedProxy( entityKey, false, this );
 				}
 				// If we get here, then the entity class has subclasses and there is no HibernateProxy factory.

--- a/hibernate-core/src/main/java/org/hibernate/internal/StatelessSessionImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/StatelessSessionImpl.java
@@ -519,7 +519,7 @@ public class StatelessSessionImpl extends AbstractSharedSessionContract implemen
 				}
 				// this is a nonsense but avoids setting version restriction
 				// parameter to null later on deep in the guts
-				return state[persister.getVersionProperty()];
+				return state[persister.getVersionPropertyIndex()];
 			}
 			else {
 				final Object newVersion = incrementVersion( entity, oldVersion, persister, this );

--- a/hibernate-core/src/main/java/org/hibernate/loader/internal/IdentifierLoadAccessImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/loader/internal/IdentifierLoadAccessImpl.java
@@ -208,8 +208,7 @@ public class IdentifierLoadAccessImpl<T> implements IdentifierLoadAccess<T>, Jav
 				}
 			}
 			else {
-				final var enhancementMetadata =
-						entityPersister.getEntityMetamodel().getBytecodeEnhancementMetadata();
+				final var enhancementMetadata = entityPersister.getBytecodeEnhancementMetadata();
 				if ( enhancementMetadata.isEnhancedForLazyLoading()
 						&& enhancementMetadata.extractLazyInterceptor( result )
 								instanceof EnhancementAsProxyLazinessInterceptor lazinessInterceptor ) {

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/internal/AbstractEntityInstantiatorPojo.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/internal/AbstractEntityInstantiatorPojo.java
@@ -8,7 +8,7 @@ package org.hibernate.metamodel.internal;
 import org.hibernate.bytecode.enhance.spi.interceptor.LazyAttributeLoadingInterceptor;
 import org.hibernate.mapping.PersistentClass;
 import org.hibernate.metamodel.spi.EntityInstantiator;
-import org.hibernate.tuple.entity.EntityMetamodel;
+import org.hibernate.persister.entity.EntityPersister;
 import org.hibernate.type.descriptor.java.JavaType;
 
 import static org.hibernate.engine.internal.ManagedTypeHelper.asPersistentAttributeInterceptable;
@@ -20,31 +20,30 @@ import static org.hibernate.engine.internal.ManagedTypeHelper.isPersistentAttrib
  * @author Steve Ebersole
  */
 public abstract class AbstractEntityInstantiatorPojo extends AbstractPojoInstantiator implements EntityInstantiator {
-	private final EntityMetamodel entityMetamodel;
+
 	private final Class<?> proxyInterface;
 	private final boolean applyBytecodeInterception;
 	private final LazyAttributeLoadingInterceptor.EntityRelatedState loadingInterceptorState;
 
 	public AbstractEntityInstantiatorPojo(
-			EntityMetamodel entityMetamodel,
+			EntityPersister persister,
 			PersistentClass persistentClass,
 			JavaType<?> javaType) {
 		super( javaType.getJavaTypeClass() );
-		this.entityMetamodel = entityMetamodel;
-		this.proxyInterface = persistentClass.getProxyInterface();
+		proxyInterface = persistentClass.getProxyInterface();
 		//TODO this PojoEntityInstantiator appears to not be reused ?!
-		this.applyBytecodeInterception =
+		applyBytecodeInterception =
 				isPersistentAttributeInterceptableType( persistentClass.getMappedClass() );
 		if ( applyBytecodeInterception ) {
-			this.loadingInterceptorState = new LazyAttributeLoadingInterceptor.EntityRelatedState(
-					entityMetamodel.getName(),
-					entityMetamodel.getBytecodeEnhancementMetadata()
+			loadingInterceptorState = new LazyAttributeLoadingInterceptor.EntityRelatedState(
+					persister.getEntityName(),
+					persister.getBytecodeEnhancementMetadata()
 						.getLazyAttributesMetadata()
 						.getLazyAttributeNames()
 			);
 		}
 		else {
-			this.loadingInterceptorState = null;
+			loadingInterceptorState = null;
 		}
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/internal/EntityInstantiatorPojoOptimized.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/internal/EntityInstantiatorPojoOptimized.java
@@ -6,7 +6,7 @@ package org.hibernate.metamodel.internal;
 
 import org.hibernate.bytecode.spi.ReflectionOptimizer.InstantiationOptimizer;
 import org.hibernate.mapping.PersistentClass;
-import org.hibernate.tuple.entity.EntityMetamodel;
+import org.hibernate.persister.entity.EntityPersister;
 import org.hibernate.type.descriptor.java.JavaType;
 
 /**
@@ -19,11 +19,11 @@ public class EntityInstantiatorPojoOptimized extends AbstractEntityInstantiatorP
 	private final InstantiationOptimizer instantiationOptimizer;
 
 	public EntityInstantiatorPojoOptimized(
-			EntityMetamodel entityMetamodel,
+			EntityPersister persister,
 			PersistentClass persistentClass,
 			JavaType<?> javaType,
 			InstantiationOptimizer instantiationOptimizer) {
-		super( entityMetamodel, persistentClass, javaType );
+		super( persister, persistentClass, javaType );
 		this.instantiationOptimizer = instantiationOptimizer;
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/internal/EntityInstantiatorPojoStandard.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/internal/EntityInstantiatorPojoStandard.java
@@ -12,7 +12,7 @@ import org.hibernate.bytecode.enhance.spi.interceptor.LazyAttributeLoadingInterc
 import org.hibernate.internal.CoreLogging;
 import org.hibernate.internal.CoreMessageLogger;
 import org.hibernate.mapping.PersistentClass;
-import org.hibernate.tuple.entity.EntityMetamodel;
+import org.hibernate.persister.entity.EntityPersister;
 import org.hibernate.type.descriptor.java.JavaType;
 
 import static org.hibernate.engine.internal.ManagedTypeHelper.asPersistentAttributeInterceptable;
@@ -31,23 +31,23 @@ public class EntityInstantiatorPojoStandard extends AbstractEntityInstantiatorPo
 	private final Constructor<?> constructor;
 
 	public EntityInstantiatorPojoStandard(
-			EntityMetamodel entityMetamodel,
+			EntityPersister persister,
 			PersistentClass persistentClass,
 			JavaType<?> javaType) {
-		super( entityMetamodel, persistentClass, javaType );
+		super( persister, persistentClass, javaType );
 		proxyInterface = persistentClass.getProxyInterface();
 		constructor = isAbstract() ? null : resolveConstructor( getMappedPojoClass() );
 		applyBytecodeInterception = isPersistentAttributeInterceptableType( persistentClass.getMappedClass() );
 		if ( applyBytecodeInterception ) {
-			this.loadingInterceptorState = new LazyAttributeLoadingInterceptor.EntityRelatedState(
-					entityMetamodel.getName(),
-					entityMetamodel.getBytecodeEnhancementMetadata()
+			loadingInterceptorState = new LazyAttributeLoadingInterceptor.EntityRelatedState(
+					persister.getEntityName(),
+					persister.getBytecodeEnhancementMetadata()
 							.getLazyAttributesMetadata()
 							.getLazyAttributeNames()
 			);
 		}
 		else {
-			this.loadingInterceptorState = null;
+			loadingInterceptorState = null;
 		}
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/internal/EntityRepresentationStrategyPojoStandard.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/internal/EntityRepresentationStrategyPojoStandard.java
@@ -122,7 +122,7 @@ public class EntityRepresentationStrategyPojoStandard implements EntityRepresent
 		propertyAccessMap = buildPropertyAccessMap( bootDescriptor );
 		reflectionOptimizer = resolveReflectionOptimizer( bytecodeProvider );
 
-		instantiator = determineInstantiator( bootDescriptor, runtimeDescriptor.getEntityMetamodel() );
+		instantiator = determineInstantiator( bootDescriptor, runtimeDescriptor );
 	}
 
 	private ProxyFactory resolveProxyFactory(
@@ -141,11 +141,10 @@ public class EntityRepresentationStrategyPojoStandard implements EntityRepresent
 			return null;
 		}
 		else {
-			final var entityMetamodel = entityPersister.getEntityMetamodel();
-			if ( proxyJavaType != null && entityMetamodel.isLazy() ) {
+			if ( proxyJavaType != null && entityPersister.isLazy() ) {
 				final var proxyFactory = createProxyFactory( bootDescriptor, bytecodeProvider, creationContext );
 				if ( proxyFactory == null ) {
-					entityMetamodel.setLazy( false );
+					((EntityMetamodel) entityPersister).setLazy( false );
 				}
 				return proxyFactory;
 			}
@@ -163,17 +162,17 @@ public class EntityRepresentationStrategyPojoStandard implements EntityRepresent
 		return propertyAccessMap;
 	}
 
-	private EntityInstantiator determineInstantiator(PersistentClass bootDescriptor, EntityMetamodel entityMetamodel) {
+	private EntityInstantiator determineInstantiator(PersistentClass bootDescriptor, EntityPersister persister) {
 		if ( reflectionOptimizer != null && reflectionOptimizer.getInstantiationOptimizer() != null ) {
 			return new EntityInstantiatorPojoOptimized(
-					entityMetamodel,
+					persister,
 					bootDescriptor,
 					mappedJtd,
 					reflectionOptimizer.getInstantiationOptimizer()
 			);
 		}
 		else {
-			return new EntityInstantiatorPojoStandard( entityMetamodel, bootDescriptor, mappedJtd );
+			return new EntityInstantiatorPojoStandard( persister, bootDescriptor, mappedJtd );
 		}
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/EntityMappingType.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/EntityMappingType.java
@@ -148,14 +148,14 @@ public interface EntityMappingType
 	 * Whether this entity is defined as abstract using the Java {@code abstract} keyword
 	 */
 	default boolean isAbstract() {
-		return getEntityPersister().getEntityMetamodel().isAbstract();
+		return getEntityPersister().isAbstract();
 	}
 
 	/**
 	 * Whether this entity mapping has any subtype mappings
 	 */
 	default boolean hasSubclasses() {
-		return getEntityPersister().getEntityMetamodel().hasSubclasses();
+		return getEntityPersister().hasSubclasses();
 	}
 
 	/**
@@ -221,11 +221,11 @@ public interface EntityMappingType
 	 * inheritance hierarchy
 	 */
 	default int getSubclassId() {
-		return getEntityPersister().getEntityMetamodel().getSubclassId();
+		return getEntityPersister().getSubclassId();
 	}
 
 	default Set<String> getSubclassEntityNames() {
-		return getEntityPersister().getEntityMetamodel().getSubclassEntityNames();
+		return getEntityPersister().getSubclassEntityNames();
 	}
 
 	/**

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/AbstractSingularAttributeMapping.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/AbstractSingularAttributeMapping.java
@@ -52,7 +52,7 @@ public abstract class AbstractSingularAttributeMapping
 
 	@Override
 	public Generator getGenerator() {
-		return findContainingEntityMapping().getEntityPersister().getEntityMetamodel().getGenerators()[getStateArrayPosition()];
+		return findContainingEntityMapping().getEntityPersister().getGenerators()[getStateArrayPosition()];
 	}
 
 }

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/FetchOptionsHelper.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/FetchOptionsHelper.java
@@ -122,12 +122,12 @@ public final class FetchOptionsHelper {
 			return false;
 		}
 		else if ( type instanceof EntityType ) {
-			final EntityPersister entityPersister = (EntityPersister) type.getAssociatedJoinable( sessionFactory );
-			return entityPersister.getEntityMetamodel().isLazy();
+			final var entityPersister = (EntityPersister) type.getAssociatedJoinable( sessionFactory );
+			return entityPersister.isLazy();
 		}
 		else {
-			final CollectionPersister cp = ( (CollectionPersister) type.getAssociatedJoinable( sessionFactory ) );
-			return cp.isLazy() || cp.isExtraLazy();
+			final var collectionPersister = (CollectionPersister) type.getAssociatedJoinable( sessionFactory );
+			return collectionPersister.isLazy() || collectionPersister.isExtraLazy();
 		}
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/GeneratedValuesProcessor.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/GeneratedValuesProcessor.java
@@ -123,7 +123,7 @@ public class GeneratedValuesProcessor {
 	public static List<AttributeMapping> getGeneratedAttributes(EntityMappingType entityDescriptor, EventType timing) {
 		// todo (6.0): For now, we rely on the entity metamodel as composite attributes report
 		//             GenerationTiming.NEVER even if they have attributes that would need generation
-		final Generator[] generators = entityDescriptor.getEntityPersister().getEntityMetamodel().getGenerators();
+		final Generator[] generators = entityDescriptor.getEntityPersister().getGenerators();
 		final List<AttributeMapping> generatedValuesToSelect = new ArrayList<>();
 		entityDescriptor.forEachAttributeMapping( mapping -> {
 			final Generator generator = generators[ mapping.getStateArrayPosition() ];

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/spi/RuntimeModelCreationContext.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/spi/RuntimeModelCreationContext.java
@@ -14,11 +14,8 @@ import org.hibernate.engine.jdbc.spi.JdbcServices;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.generator.Generator;
 import org.hibernate.mapping.GeneratorSettings;
-import org.hibernate.mapping.PersistentClass;
-import org.hibernate.persister.entity.EntityPersister;
 import org.hibernate.query.sqm.function.SqmFunctionRegistry;
 import org.hibernate.service.ServiceRegistry;
-import org.hibernate.tuple.entity.EntityMetamodel;
 import org.hibernate.type.descriptor.java.spi.JavaTypeRegistry;
 import org.hibernate.type.spi.TypeConfiguration;
 
@@ -68,11 +65,4 @@ public interface RuntimeModelCreationContext {
 	Map<String, Generator> getGenerators();
 
 	GeneratorSettings getGeneratorSettings();
-
-	/*
-	 * Used by Hibernate Reactive
-	 */
-	default EntityMetamodel createEntityMetamodel(PersistentClass persistentClass, EntityPersister persister) {
-		return new EntityMetamodel( persistentClass, persister, this );
-	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/persister/collection/AbstractCollectionPersister.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/collection/AbstractCollectionPersister.java
@@ -27,11 +27,9 @@ import org.hibernate.collection.spi.PersistentCollection;
 import org.hibernate.dialect.Dialect;
 import org.hibernate.engine.jdbc.mutation.ParameterUsage;
 import org.hibernate.engine.jdbc.mutation.internal.MutationQueryOptions;
-import org.hibernate.engine.jdbc.spi.JdbcCoordinator;
 import org.hibernate.engine.jdbc.spi.SqlExceptionHelper;
 import org.hibernate.engine.profile.internal.FetchProfileAffectee;
 import org.hibernate.engine.spi.LoadQueryInfluencers;
-import org.hibernate.engine.spi.PersistenceContext;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.engine.spi.SubselectFetch;
@@ -55,18 +53,12 @@ import org.hibernate.mapping.Column;
 import org.hibernate.mapping.Formula;
 import org.hibernate.mapping.IdentifierCollection;
 import org.hibernate.mapping.IndexedCollection;
-import org.hibernate.mapping.PersistentClass;
-import org.hibernate.mapping.Selectable;
 import org.hibernate.mapping.Table;
 import org.hibernate.mapping.Value;
 import org.hibernate.metamodel.CollectionClassification;
 import org.hibernate.metamodel.mapping.AttributeMapping;
 import org.hibernate.metamodel.mapping.CollectionPart;
-import org.hibernate.metamodel.mapping.DiscriminatorMapping;
-import org.hibernate.metamodel.mapping.DiscriminatorValueDetails;
-import org.hibernate.metamodel.mapping.EmbeddableMappingType;
 import org.hibernate.metamodel.mapping.EmbeddableValuedModelPart;
-import org.hibernate.metamodel.mapping.ForeignKeyDescriptor;
 import org.hibernate.metamodel.mapping.ManagedMappingType;
 import org.hibernate.metamodel.mapping.PluralAttributeMapping;
 import org.hibernate.metamodel.mapping.internal.DiscriminatedAssociationAttributeMapping;
@@ -92,24 +84,20 @@ import org.hibernate.spi.NavigablePath;
 import org.hibernate.sql.Alias;
 import org.hibernate.sql.SimpleSelect;
 import org.hibernate.sql.Template;
+import org.hibernate.sql.ast.SqlAstTranslatorFactory;
 import org.hibernate.sql.ast.spi.SimpleFromClauseAccessImpl;
 import org.hibernate.sql.ast.spi.SqlAliasBaseConstant;
 import org.hibernate.sql.ast.spi.SqlAliasBaseManager;
 import org.hibernate.sql.ast.spi.SqlAstCreationState;
-import org.hibernate.sql.ast.spi.SqlSelection;
 import org.hibernate.sql.ast.tree.expression.AliasedExpression;
-import org.hibernate.sql.ast.tree.expression.ColumnReference;
 import org.hibernate.sql.ast.tree.from.TableGroup;
 import org.hibernate.sql.ast.tree.from.TableReference;
 import org.hibernate.sql.ast.tree.predicate.Predicate;
 import org.hibernate.sql.ast.tree.select.QuerySpec;
-import org.hibernate.sql.ast.tree.select.SelectClause;
 import org.hibernate.sql.ast.tree.select.SelectStatement;
 import org.hibernate.sql.model.MutationType;
-import org.hibernate.sql.model.TableMapping;
 import org.hibernate.sql.model.TableMapping.MutationDetails;
 import org.hibernate.sql.model.ast.ColumnValueBinding;
-import org.hibernate.sql.model.ast.ColumnValueParameter;
 import org.hibernate.sql.model.ast.ColumnValueParameterList;
 import org.hibernate.sql.model.ast.ColumnWriteFragment;
 import org.hibernate.sql.model.ast.MutatingTableReference;
@@ -125,15 +113,13 @@ import org.hibernate.type.ComponentType;
 import org.hibernate.type.CompositeType;
 import org.hibernate.type.EntityType;
 import org.hibernate.type.Type;
-import org.hibernate.type.spi.TypeConfiguration;
 
-import java.sql.PreparedStatement;
-import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
@@ -258,41 +244,36 @@ public abstract class AbstractCollectionPersister
 	public AbstractCollectionPersister(
 			Collection collectionBootDescriptor,
 			@Nullable CollectionDataAccess cacheAccessStrategy,
-			RuntimeModelCreationContext creationContext) throws MappingException, CacheException {
-		this.collectionBootDescriptor = collectionBootDescriptor;
+			RuntimeModelCreationContext creationContext)
+					throws MappingException, CacheException {
+		factory = creationContext.getSessionFactory();
 
-		this.factory = creationContext.getSessionFactory();
-		this.collectionSemantics = creationContext.getBootstrapContext()
-				.getMetadataBuildingOptions()
-				.getPersistentCollectionRepresentationResolver()
-				.resolveRepresentation( collectionBootDescriptor );
+		this.collectionBootDescriptor = collectionBootDescriptor;
+		this.collectionSemantics =
+				creationContext.getBootstrapContext().getMetadataBuildingOptions()
+						.getPersistentCollectionRepresentationResolver()
+						.resolveRepresentation( collectionBootDescriptor );
+
 
 		this.cacheAccessStrategy = cacheAccessStrategy;
-		if ( creationContext.getSessionFactoryOptions().isStructuredCacheEntriesEnabled() ) {
-			cacheEntryStructure = collectionBootDescriptor.isMap()
-					? StructuredMapCacheEntry.INSTANCE
-					: StructuredCollectionCacheEntry.INSTANCE;
-		}
-		else {
-			cacheEntryStructure = UnstructuredCacheEntry.INSTANCE;
-		}
-		useShallowQueryCacheLayout = shouldUseShallowCacheLayout(
-				collectionBootDescriptor.getQueryCacheLayout(),
-				creationContext.getSessionFactoryOptions()
-		);
+		cacheEntryStructure = cacheEntryStructure( collectionBootDescriptor, creationContext );
+		useShallowQueryCacheLayout =
+				shouldUseShallowCacheLayout( collectionBootDescriptor.getQueryCacheLayout(),
+						creationContext.getSessionFactoryOptions() );
 
 		dialect = creationContext.getDialect();
 		sqlExceptionHelper = creationContext.getJdbcServices().getSqlExceptionHelper();
 		collectionType = collectionBootDescriptor.getCollectionType();
 		navigableRole = new NavigableRole( collectionBootDescriptor.getRole() );
-		ownerPersister = creationContext.getDomainModel()
-				.getEntityDescriptor( collectionBootDescriptor.getOwnerEntityName() );
+		ownerPersister =
+				creationContext.getDomainModel()
+						.getEntityDescriptor( collectionBootDescriptor.getOwnerEntityName() );
 		queryLoaderName = collectionBootDescriptor.getLoaderName();
 		isMutable = collectionBootDescriptor.isMutable();
 		mappedByProperty = collectionBootDescriptor.getMappedByProperty();
 
-		final Value elementBootDescriptor = collectionBootDescriptor.getElement();
-		final Table table = collectionBootDescriptor.getCollectionTable();
+		final var elementBootDescriptor = collectionBootDescriptor.getElement();
+		final var table = collectionBootDescriptor.getCollectionTable();
 
 		elementType = elementBootDescriptor.getType();
 		// isSet = collectionBinding.isSet();
@@ -311,20 +292,20 @@ public abstract class AbstractCollectionPersister
 
 		hasOrphanDelete = collectionBootDescriptor.hasOrphanDelete();
 
-		batchSize = collectionBootDescriptor.getBatchSize() < 0
-				? factory.getSessionFactoryOptions().getDefaultBatchFetchSize()
-				: collectionBootDescriptor.getBatchSize();
+		batchSize = batchSize( collectionBootDescriptor, creationContext );
 
 		isVersioned = collectionBootDescriptor.isOptimisticLocked();
 
 		// KEY
 
-		keyType = collectionBootDescriptor.getKey().getType();
-		final int keySpan = collectionBootDescriptor.getKey().getColumnSpan();
+		final var key = collectionBootDescriptor.getKey();
+
+		keyType = key.getType();
+		final int keySpan = key.getColumnSpan();
 		keyColumnNames = new String[keySpan];
 		keyColumnAliases = new String[keySpan];
 		int k = 0;
-		for ( Selectable selectable: collectionBootDescriptor.getKey().getSelectables() ) {
+		for ( var selectable: key.getSelectables() ) {
 			// NativeSQL: collect key column and auto-aliases
 			keyColumnAliases[k] = selectable.getAlias( dialect, table );
 			if ( selectable instanceof Column column ) {
@@ -349,10 +330,10 @@ public abstract class AbstractCollectionPersister
 			elementPersister = null;
 		}
 		// Defer this after the element persister was determined,
-		// because it is needed in OneToManyPersister.getTableName()
+		// because it's needed in OneToManyPersister.getTableName()
 		spaces[0] = getTableName();
 
-		final TypeConfiguration typeConfiguration = creationContext.getTypeConfiguration();
+		final var typeConfiguration = creationContext.getTypeConfiguration();
 
 		final int elementSpan = elementBootDescriptor.getColumnSpan();
 		elementColumnAliases = new String[elementSpan];
@@ -366,28 +347,23 @@ public abstract class AbstractCollectionPersister
 		elementColumnIsGettable = new boolean[elementSpan];
 		boolean isPureFormula = true;
 		final boolean oneToMany = collectionBootDescriptor.isOneToMany();
-		boolean[] columnInsertability = null;
-		if ( !oneToMany ) {
-			columnInsertability = elementBootDescriptor.getColumnInsertability();
-		}
+		final boolean[] columnInsertability = oneToMany ? null : elementBootDescriptor.getColumnInsertability();
 		int j = 0;
-		for ( Selectable selectable: elementBootDescriptor.getSelectables() ) {
+		for ( var selectable: elementBootDescriptor.getSelectables() ) {
 			elementColumnAliases[j] = selectable.getAlias( dialect, table );
-			if ( selectable.isFormula() ) {
-				Formula form = (Formula) selectable;
-				elementFormulaTemplates[j] = form.getTemplate( dialect, typeConfiguration );
-				elementFormulas[j] = form.getFormula();
+			if ( selectable instanceof Formula formula ) {
+				elementFormulaTemplates[j] = formula.getTemplate( dialect, typeConfiguration );
+				elementFormulas[j] = formula.getFormula();
 			}
-			else {
-				final Column col = (Column) selectable;
-				elementColumnNames[j] = col.getQuotedName( dialect );
-				elementColumnWriters[j] = col.getWriteExpr(
+			else if ( selectable instanceof Column column ) {
+				elementColumnNames[j] = column.getQuotedName( dialect );
+				elementColumnWriters[j] = column.getWriteExpr(
 						elementBootDescriptor.getSelectableType( factory.getRuntimeMetamodels(), j ),
 						dialect,
 						creationContext.getBootModel()
 				);
-				elementColumnReaders[j] = col.getReadExpr( dialect );
-				elementColumnReaderTemplates[j] = col.getTemplate( dialect, typeConfiguration );
+				elementColumnReaders[j] = column.getReadExpr( dialect );
+				elementColumnReaderTemplates[j] = column.getTemplate( dialect, typeConfiguration );
 				elementColumnIsGettable[j] = true;
 				if ( elementType instanceof ComponentType || elementType instanceof AnyType ) {
 					// Implements desired behavior specifically for @ElementCollection mappings.
@@ -421,15 +397,14 @@ public abstract class AbstractCollectionPersister
 			indexColumnAliases = new String[indexSpan];
 			int i = 0;
 			boolean hasFormula = false;
-			for ( Selectable selectable: index.getSelectables() ) {
+			for ( var selectable: index.getSelectables() ) {
 				indexColumnAliases[i] = selectable.getAlias( dialect );
-				if ( selectable.isFormula() ) {
-					final Formula indexForm = (Formula) selectable;
-					indexFormulaTemplates[i] = indexForm.getTemplate( dialect, typeConfiguration );
-					indexFormulas[i] = indexForm.getFormula();
+				if ( selectable instanceof Formula indexFormula ) {
+					indexFormulaTemplates[i] = indexFormula.getTemplate( dialect, typeConfiguration );
+					indexFormulas[i] = indexFormula.getFormula();
 					hasFormula = true;
 				}
-				else {
+				else if ( selectable instanceof Column indexColumn ) {
 					if ( indexedCollection.hasMapKeyProperty() ) {
 						// If the Map key is set via @MapKey, it should not be written
 						// since it is a reference to a field of the associated entity.
@@ -439,8 +414,7 @@ public abstract class AbstractCollectionPersister
 						indexColumnUpdatability[i] = false;
 						hasFormula = true; // this is incorrect, but needed for some reason
 					}
-					final Column indexCol = (Column) selectable;
-					indexColumnNames[i] = indexCol.getQuotedName( dialect );
+					indexColumnNames[i] = indexColumn.getQuotedName( dialect );
 					indexColumnIsGettable[i] = true;
 					indexColumnIsSettable[i] = indexColumnInsertability[i] || indexColumnUpdatability[i];
 				}
@@ -465,12 +439,12 @@ public abstract class AbstractCollectionPersister
 				throw new MappingException( "one-to-many collections with identifiers are not supported" );
 			}
 			//noinspection ConstantConditions
-			final IdentifierCollection idColl = (IdentifierCollection) collectionBootDescriptor;
-			identifierType = idColl.getIdentifier().getType();
-			final Column col = idColl.getIdentifier().getColumns().get(0);
-			identifierColumnName = col.getQuotedName( dialect );
-			identifierColumnAlias = col.getAlias( dialect );
-			identifierGenerator = createGenerator( creationContext, idColl );
+			final var idCollection = (IdentifierCollection) collectionBootDescriptor;
+			identifierType = idCollection.getIdentifier().getType();
+			final var idColumn = idCollection.getIdentifier().getColumns().get(0);
+			identifierColumnName = idColumn.getQuotedName( dialect );
+			identifierColumnAlias = idColumn.getAlias( dialect );
+			identifierGenerator = createGenerator( creationContext, idCollection );
 		}
 		else {
 			identifierType = null;
@@ -484,7 +458,7 @@ public abstract class AbstractCollectionPersister
 
 		isInverse = collectionBootDescriptor.isInverse();
 
-		keyIsUpdateable = collectionBootDescriptor.getKey().isUpdateable();
+		keyIsUpdateable = key.isUpdateable();
 
 		elementClass =
 				collectionBootDescriptor instanceof Array arrayDescriptor
@@ -496,33 +470,17 @@ public abstract class AbstractCollectionPersister
 		hasManyToManyOrder = collectionBootDescriptor.getManyToManyOrdering() != null;
 
 		// Handle any filters applied to this collectionBinding
-		if ( collectionBootDescriptor.getFilters().isEmpty() ) {
-			filterHelper = null;
-		}
-		else {
-			final Map<String, String> entityNameByTableNameMap;
-			if ( elementPersister == null ) {
-				entityNameByTableNameMap = null;
-			}
-			else {
-				entityNameByTableNameMap = AbstractEntityPersister.getEntityNameByTableNameMap(
-						creationContext.getBootModel().getEntityBinding( elementPersister.getEntityName() ),
-						factory.getSqlStringGenerationContext()
-				);
-			}
-			filterHelper = new FilterHelper( collectionBootDescriptor.getFilters(), entityNameByTableNameMap, factory );
-		}
-
+		filterHelper = filterHelper( collectionBootDescriptor, elementPersister, creationContext );
 		// Handle any filters applied to this collectionBinding for many-to-many
-		manyToManyFilterHelper = collectionBootDescriptor.getManyToManyFilters().isEmpty() ? null
-				: new FilterHelper( collectionBootDescriptor.getManyToManyFilters(), factory );
+		manyToManyFilterHelper = manyToManyFilterHelper( collectionBootDescriptor, creationContext );
 
-		if ( isEmpty( collectionBootDescriptor.getManyToManyWhere() ) ) {
+		final String manyToManyWhere = collectionBootDescriptor.getManyToManyWhere();
+		if ( isEmpty( manyToManyWhere ) ) {
 			manyToManyWhereString = null;
 			manyToManyWhereTemplate = null;
 		}
 		else {
-			manyToManyWhereString = "( " + collectionBootDescriptor.getManyToManyWhere() + ")";
+			manyToManyWhereString = "( " + manyToManyWhere + ")";
 			manyToManyWhereTemplate =
 					renderWhereStringTemplate( manyToManyWhereString, creationContext.getDialect(), typeConfiguration );
 		}
@@ -540,15 +498,60 @@ public abstract class AbstractCollectionPersister
 
 		tableMapping = buildCollectionTableMapping( collectionBootDescriptor, getTableName(), getCollectionSpaces() );
 
-		cascadeDeleteEnabled = collectionBootDescriptor.getKey().isCascadeDeleteEnabled()
+		cascadeDeleteEnabled =
+				key.isCascadeDeleteEnabled()
 				&& creationContext.getDialect().supportsCascadeDelete();
+	}
+
+	private FilterHelper manyToManyFilterHelper(Collection collection, RuntimeModelCreationContext context) {
+		return collection.getManyToManyFilters().isEmpty()
+				? null
+				: new FilterHelper( collection.getManyToManyFilters(), context.getSessionFactory() );
+	}
+
+	private FilterHelper filterHelper(
+			Collection collection, EntityPersister elementPersister, RuntimeModelCreationContext context) {
+		if ( collection.getFilters().isEmpty() ) {
+			return null;
+		}
+		else {
+			final var entityNameByTableNameMap =
+					elementPersister == null
+							? null
+							: AbstractEntityPersister.getEntityNameByTableNameMap(
+									context.getBootModel().getEntityBinding( elementPersister.getEntityName() ),
+									context.getSessionFactory().getSqlStringGenerationContext()
+							);
+			return new FilterHelper( collection.getFilters(), entityNameByTableNameMap, factory );
+		}
+	}
+
+	private static int batchSize(Collection collection, RuntimeModelCreationContext context) {
+		return collection.getBatchSize() < 0
+				? context.getSessionFactoryOptions().getDefaultBatchFetchSize()
+				: collection.getBatchSize();
+	}
+
+	private static CacheEntryStructure cacheEntryStructure(Collection collection, RuntimeModelCreationContext context) {
+		if ( context.getSessionFactoryOptions().isStructuredCacheEntriesEnabled() ) {
+			return collection.isMap()
+							? StructuredMapCacheEntry.INSTANCE
+							: StructuredCollectionCacheEntry.INSTANCE;
+		}
+		else {
+			return UnstructuredCacheEntry.INSTANCE;
+		}
+	}
+
+	SqlAstTranslatorFactory getSqlAstTranslatorFactory() {
+		return getFactory().getJdbcServices().getDialect().getSqlAstTranslatorFactory();
 	}
 
 	@Override
 	public void prepareMappingModel(MappingModelCreationProcess creationProcess) {
 		if ( mappedByProperty != null && elementType instanceof EntityType entityType ) {
 			final String entityName = entityType.getAssociatedEntityName();
-			final PersistentClass persistentClass =
+			final var persistentClass =
 					creationProcess.getCreationContext().getBootModel()
 							.getEntityBinding( entityName );
 			if ( persistentClass.getRecursiveProperty( mappedByProperty ).getValue() instanceof Any ) {
@@ -557,8 +560,12 @@ public abstract class AbstractCollectionPersister
 				creationProcess.registerInitializationCallback(
 						"Where-fragment handling for ANY inverse mapping : " + navigableRole,
 						() -> {
-							final EntityPersister entityPersister = creationProcess.getEntityPersister( entityName );
-							delayedWhereFragmentProcessing( entityPersister, mappedByProperty, collectionBootDescriptor, creationProcess );
+							delayedWhereFragmentProcessing(
+									creationProcess.getEntityPersister( entityName ),
+									mappedByProperty,
+									collectionBootDescriptor,
+									creationProcess
+							);
 							buildStaticWhereFragmentSensitiveSql();
 							collectionBootDescriptor = null;
 							return true;
@@ -571,8 +578,9 @@ public abstract class AbstractCollectionPersister
 		if ( isNotEmpty( collectionBootDescriptor.getWhere() ) ) {
 			hasWhere = true;
 			sqlWhereString = "(" + collectionBootDescriptor.getWhere() + ")";
-			sqlWhereStringTemplate = renderWhereStringTemplate( sqlWhereString, dialect,
-					creationProcess.getCreationContext().getTypeConfiguration() );
+			sqlWhereStringTemplate =
+					renderWhereStringTemplate( sqlWhereString, dialect,
+							creationProcess.getCreationContext().getTypeConfiguration() );
 		}
 		buildStaticWhereFragmentSensitiveSql();
 		collectionBootDescriptor = null;
@@ -584,14 +592,14 @@ public abstract class AbstractCollectionPersister
 			Collection collectionBootDescriptor,
 			MappingModelCreationProcess creationProcess) {
 
-		final AttributeMapping mappedByAttribute = resolveMappedBy( entityPersister, mappedByProperty );
-		final RuntimeModelCreationContext creationContext = creationProcess.getCreationContext();
 		final String where;
-		if ( mappedByAttribute instanceof DiscriminatedAssociationAttributeMapping anyMapping ) {
-			final DiscriminatorMapping discriminatorMapping = anyMapping.getDiscriminatorMapping();
-			final DiscriminatorValueDetails discriminatorValueDetails =
+		if ( resolveMappedBy( entityPersister, mappedByProperty )
+					instanceof DiscriminatedAssociationAttributeMapping anyMapping ) {
+			final var discriminatorMapping = anyMapping.getDiscriminatorMapping();
+			final var discriminatorValueDetails =
 					discriminatorMapping.getValueConverter()
 							.getDetailsForEntityName( ownerPersister.getEntityName() );
+			final var creationContext = creationProcess.getCreationContext();
 			//noinspection unchecked
 			final String discriminatorLiteral =
 					discriminatorMapping.getUnderlyingJdbcMapping()
@@ -610,8 +618,9 @@ public abstract class AbstractCollectionPersister
 		if ( isNotEmpty( where ) ) {
 			hasWhere = true;
 			sqlWhereString = "(" + where + ")";
-			sqlWhereStringTemplate = renderWhereStringTemplate( sqlWhereString, dialect,
-					creationContext.getTypeConfiguration() );
+			sqlWhereStringTemplate =
+					renderWhereStringTemplate( sqlWhereString, dialect,
+							creationProcess.getCreationContext().getTypeConfiguration() );
 		}
 	}
 
@@ -626,32 +635,31 @@ public abstract class AbstractCollectionPersister
 	}
 
 	private static AttributeMapping resolveMappedBy(EntityPersister entityPersister, String mappedByProperty) {
-		final StringTokenizer propertyPathParts = new StringTokenizer( mappedByProperty, ".", false );
-		assert propertyPathParts.countTokens() > 0;
-
-		if ( propertyPathParts.countTokens() == 1 ) {
+		final var propertyPathParts = new StringTokenizer( mappedByProperty, ".", false );
+		final int tokenCount = propertyPathParts.countTokens();
+		assert tokenCount > 0;
+		if ( tokenCount == 1 ) {
 			return entityPersister.findAttributeMapping( propertyPathParts.nextToken() );
 		}
-
-		ManagedMappingType source = entityPersister;
-		while ( propertyPathParts.hasMoreTokens() ) {
-			final String partName = propertyPathParts.nextToken();
-			final AttributeMapping namedPart = source.findAttributeMapping( partName );
-			if ( !propertyPathParts.hasMoreTokens() ) {
-				return namedPart;
+		else {
+			ManagedMappingType source = entityPersister;
+			while ( propertyPathParts.hasMoreTokens() ) {
+				final String partName = propertyPathParts.nextToken();
+				final var namedPart = source.findAttributeMapping( partName );
+				if ( !propertyPathParts.hasMoreTokens() ) {
+					return namedPart;
+				}
+				source = (ManagedMappingType) namedPart.getPartMappingType();
 			}
-
-			source = (ManagedMappingType) namedPart.getPartMappingType();
+			throw new MappingException(
+					String.format(
+							Locale.ROOT,
+							"Unable to resolve mapped-by path : (%s) %s",
+							entityPersister.getEntityName(),
+							mappedByProperty
+					)
+			);
 		}
-
-		throw new MappingException(
-				String.format(
-						Locale.ROOT,
-						"Unable to resolve mapped-by path : (%s) %s",
-						entityPersister.getEntityName(),
-						mappedByProperty
-				)
-		);
 	}
 
 	private BeforeExecutionGenerator createGenerator(RuntimeModelCreationContext context, IdentifierCollection collection) {
@@ -665,7 +673,7 @@ public abstract class AbstractCollectionPersister
 	}
 
 	private boolean shouldUseShallowCacheLayout(CacheLayout collectionQueryCacheLayout, SessionFactoryOptions options) {
-		final CacheLayout queryCacheLayout =
+		final var queryCacheLayout =
 				collectionQueryCacheLayout == null
 						? options.getQueryCacheLayout()
 						: collectionQueryCacheLayout;
@@ -704,7 +712,7 @@ public abstract class AbstractCollectionPersister
 	}
 
 	private NamedQueryMemento<?> getNamedQueryMemento(MetadataImplementor bootModel) {
-		final NamedQueryMemento<?> memento =
+		final var memento =
 				factory.getQueryEngine().getNamedObjectRepository()
 						.resolve( factory, bootModel, queryLoaderName );
 		if ( memento == null ) {
@@ -718,19 +726,21 @@ public abstract class AbstractCollectionPersister
 		if ( MODEL_MUTATION_LOGGER.isTraceEnabled() ) {
 			MODEL_MUTATION_LOGGER.tracef( "Static SQL for collection: %s", getRole() );
 
-			final JdbcMutationOperation insertRowOperation = getRowMutationOperations().getInsertRowOperation();
+			final var rowMutationOperations = getRowMutationOperations();
+
+			final var insertRowOperation = rowMutationOperations.getInsertRowOperation();
 			final String insertRowSql = insertRowOperation != null ? insertRowOperation.getSqlString() : null;
 			if ( insertRowSql != null ) {
 				MODEL_MUTATION_LOGGER.tracef( " Row insert: %s", insertRowSql );
 			}
 
-			final JdbcMutationOperation updateRowOperation = getRowMutationOperations().getUpdateRowOperation();
+			final var updateRowOperation = rowMutationOperations.getUpdateRowOperation();
 			final String updateRowSql = updateRowOperation != null ? updateRowOperation.getSqlString() : null;
 			if ( updateRowSql != null ) {
 				MODEL_MUTATION_LOGGER.tracef( " Row update: %s", updateRowSql );
 			}
 
-			final JdbcMutationOperation deleteRowOperation = getRowMutationOperations().getDeleteRowOperation();
+			final var deleteRowOperation = rowMutationOperations.getDeleteRowOperation();
 			final String deleteRowSql = deleteRowOperation != null ? deleteRowOperation.getSqlString() : null;
 			if ( deleteRowSql != null ) {
 				MODEL_MUTATION_LOGGER.tracef( " Row delete: %s", deleteRowSql );
@@ -778,9 +788,9 @@ public abstract class AbstractCollectionPersister
 			return getCollectionLoader();
 		}
 		else {
-			final LoadQueryInfluencers influencers = session.getLoadQueryInfluencers();
+			final var influencers = session.getLoadQueryInfluencers();
 			if ( influencers.effectiveSubselectFetchEnabled( this ) ) {
-				final CollectionLoader subSelectLoader = resolveSubSelectLoader( key, session );
+				final var subSelectLoader = resolveSubSelectLoader( key, session );
 				if ( subSelectLoader != null ) {
 					return subSelectLoader;
 				}
@@ -792,8 +802,8 @@ public abstract class AbstractCollectionPersister
 	}
 
 	private CollectionLoader resolveSubSelectLoader(Object key, SharedSessionContractImplementor session) {
-		final PersistenceContext persistenceContext = session.getPersistenceContextInternal();
-		final SubselectFetch subselect =
+		final var persistenceContext = session.getPersistenceContextInternal();
+		final var subselect =
 				persistenceContext.getBatchFetchQueue()
 						.getSubselect( session.generateEntityKey( key, getOwnerEntityPersister() ) );
 		if ( subselect == null ) {
@@ -920,9 +930,9 @@ public abstract class AbstractCollectionPersister
 	 */
 	@Override
 	public String selectFragment(String alias, String columnSuffix) {
-		final PluralAttributeMapping attributeMapping = getAttributeMapping();
-		final QuerySpec rootQuerySpec = new QuerySpec( true );
-		final LoaderSqlAstCreationState sqlAstCreationState = new LoaderSqlAstCreationState(
+		final var attributeMapping = getAttributeMapping();
+		final var rootQuerySpec = new QuerySpec( true );
+		final var sqlAstCreationState = new LoaderSqlAstCreationState(
 				rootQuerySpec,
 				new SqlAliasBaseManager(),
 				new SimpleFromClauseAccessImpl(),
@@ -933,8 +943,8 @@ public abstract class AbstractCollectionPersister
 				factory.getSqlTranslationEngine()
 		);
 
-		final NavigablePath entityPath = new NavigablePath( attributeMapping.getRootPathName() );
-		final TableGroup rootTableGroup = attributeMapping.createRootTableGroup(
+		final var entityPath = new NavigablePath( attributeMapping.getRootPathName() );
+		final var rootTableGroup = attributeMapping.createRootTableGroup(
 				true,
 				entityPath,
 				null,
@@ -949,15 +959,15 @@ public abstract class AbstractCollectionPersister
 		attributeMapping.createDomainResult( entityPath, rootTableGroup, null, sqlAstCreationState );
 
 		// Wrap expressions with aliases
-		final SelectClause selectClause = rootQuerySpec.getSelectClause();
-		final java.util.List<SqlSelection> sqlSelections = selectClause.getSqlSelections();
+		final var sqlSelections = rootQuerySpec.getSelectClause().getSqlSelections();
 		int i = 0;
 		for ( String keyAlias : keyColumnAliases ) {
 			sqlSelections.set(
 					i,
 					new SqlSelectionImpl(
 							i,
-							new AliasedExpression( sqlSelections.get( i ).getExpression(), keyAlias + columnSuffix )
+							new AliasedExpression( sqlSelections.get( i ).getExpression(),
+									keyAlias + columnSuffix )
 					)
 			);
 			i++;
@@ -969,7 +979,8 @@ public abstract class AbstractCollectionPersister
 						i,
 						new SqlSelectionImpl(
 								i,
-								new AliasedExpression( sqlSelections.get( i ).getExpression(), indexAlias + columnSuffix )
+								new AliasedExpression( sqlSelections.get( i ).getExpression(),
+										indexAlias + columnSuffix )
 						)
 				);
 				i++;
@@ -980,25 +991,27 @@ public abstract class AbstractCollectionPersister
 					i,
 					new SqlSelectionImpl(
 							i,
-							new AliasedExpression( sqlSelections.get( i ).getExpression(), identifierColumnAlias + columnSuffix )
+							new AliasedExpression( sqlSelections.get( i ).getExpression(),
+									identifierColumnAlias + columnSuffix )
 					)
 			);
 			i++;
 		}
 
 		for ( int columnIndex = 0; i < sqlSelections.size(); i++, columnIndex++ ) {
-			final SqlSelection sqlSelection = sqlSelections.get( i );
+			final var sqlSelection = sqlSelections.get( i );
 			sqlSelections.set(
 					i,
 					new SqlSelectionImpl(
 							sqlSelection.getValuesArrayPosition(),
-							new AliasedExpression( sqlSelection.getExpression(), elementColumnAliases[columnIndex] + columnSuffix )
+							new AliasedExpression( sqlSelection.getExpression(),
+									elementColumnAliases[columnIndex] + columnSuffix )
 					)
 			);
 		}
 
 		final String sql =
-				getFactory().getJdbcServices().getDialect().getSqlAstTranslatorFactory()
+				getSqlAstTranslatorFactory()
 						.buildSelectTranslator( getFactory(), new SelectStatement( rootQuerySpec ) )
 						.translate( null, QueryOptions.NONE )
 						.getSqlString();
@@ -1009,9 +1022,9 @@ public abstract class AbstractCollectionPersister
 	}
 
 	protected String generateSelectSizeString(boolean isIntegerIndexed) {
-		String selectValue = isIntegerIndexed ?
-				"max(" + getIndexColumnNames()[0] + ") + 1" : // lists, arrays
-				"count(" + getElementColumnNames()[0] + ")"; // sets, maps, bags
+		final String selectValue = isIntegerIndexed
+				? "max(" + getIndexColumnNames()[0] + ") + 1"  // lists, arrays
+				: "count(" + getElementColumnNames()[0] + ")"; // sets, maps, bags
 		return new SimpleSelect( getFactory() )
 				.setTableName( getTableName() )
 				.addRestriction( getKeyColumnNames() )
@@ -1024,14 +1037,16 @@ public abstract class AbstractCollectionPersister
 		if ( !hasIndex() ) {
 			return null;
 		}
-		return new SimpleSelect( getFactory() )
-				.setTableName( getTableName() )
-				.addRestriction( getKeyColumnNames() )
-				.addRestriction( getIndexColumnNames() )
-				.addRestriction( indexFormulas )
-				.addWhereToken( sqlWhereString )
-				.addColumn( "1" )
-				.toStatementString();
+		else {
+			return new SimpleSelect( getFactory() )
+					.setTableName( getTableName() )
+					.addRestriction( getKeyColumnNames() )
+					.addRestriction( getIndexColumnNames() )
+					.addRestriction( indexFormulas )
+					.addWhereToken( sqlWhereString )
+					.addColumn( "1" )
+					.toStatementString();
+		}
 	}
 
 
@@ -1164,34 +1179,30 @@ public abstract class AbstractCollectionPersister
 		return hasWhere || manyToManyWhereTemplate != null;
 	}
 
+	private static String aliasForWhereRestriction(TableReference tableReference, boolean useQualifier) {
+		if ( tableReference == null ) {
+			return null;
+		}
+		else if ( useQualifier && tableReference.getIdentificationVariable() != null ) {
+			return tableReference.getIdentificationVariable();
+		}
+		else {
+			return tableReference.getTableId();
+		}
+	}
+
 	@Override
 	public void applyWhereRestrictions(
 			Consumer<Predicate> predicateConsumer,
 			TableGroup tableGroup,
 			boolean useQualifier,
 			SqlAstCreationState creationState) {
-		final TableReference tableReference;
-		if ( isManyToMany() ) {
-			tableReference = tableGroup.getPrimaryTableReference();
-		}
-		else if ( elementPersister != null ) {
-			tableReference = tableGroup.getTableReference( tableGroup.getNavigablePath(), elementPersister.getTableName() );
-		}
-		else {
-			tableReference = tableGroup.getTableReference( tableGroup.getNavigablePath(), qualifiedTableName );
-		}
-
-		final String alias;
-		if ( tableReference == null ) {
-			alias = null;
-		}
-		else if ( useQualifier && tableReference.getIdentificationVariable() != null ) {
-			alias = tableReference.getIdentificationVariable();
-		}
-		else {
-			alias = tableReference.getTableId();
-		}
-
+		final var tableReference =
+				isManyToMany()
+						? tableGroup.getPrimaryTableReference()
+						: tableGroup.getTableReference( tableGroup.getNavigablePath(),
+								elementPersister != null ? elementPersister.getTableName() : qualifiedTableName );
+		final String alias = aliasForWhereRestriction( tableReference, useQualifier );
 		applyWhereFragments( predicateConsumer, alias, tableGroup, creationState );
 	}
 
@@ -1207,16 +1218,12 @@ public abstract class AbstractCollectionPersister
 	 * Applies all defined {@link org.hibernate.annotations.SQLRestriction}
 	 */
 	private static void applyWhereFragments(Consumer<Predicate> predicateConsumer, String alias, String template) {
-		if ( template == null ) {
-			return;
+		if ( template != null ) {
+			final String fragment = replace( template, Template.TEMPLATE, alias );
+			if ( !isEmpty( fragment ) ) {
+				predicateConsumer.accept( new SqlFragmentPredicate( fragment ) );
+			}
 		}
-
-		final String fragment = replace( template, Template.TEMPLATE, alias );
-		if ( isEmpty( fragment ) ) {
-			return;
-		}
-
-		predicateConsumer.accept( new SqlFragmentPredicate( fragment ) );
 	}
 
 	@Override
@@ -1250,50 +1257,32 @@ public abstract class AbstractCollectionPersister
 			Map<String, Filter> enabledFilters,
 			Set<String> treatAsDeclarations,
 			SqlAstCreationState creationState) {
-		if ( manyToManyFilterHelper == null && manyToManyWhereTemplate == null ) {
-			return;
-		}
-
-
-		if ( manyToManyFilterHelper != null ) {
-			final FilterAliasGenerator aliasGenerator = elementPersister.getFilterAliasGenerator( tableGroup );
-			manyToManyFilterHelper.applyEnabledFilters(
-					predicateConsumer,
-					aliasGenerator,
-					enabledFilters,
-					false,
-					tableGroup,
-					creationState
-			);
-		}
-
-		if ( manyToManyWhereString != null ) {
-			final TableReference tableReference = tableGroup.resolveTableReference( elementPersister.getTableName() );
-
-			final String alias;
-			if ( tableReference == null ) {
-				alias = null;
+		if ( manyToManyFilterHelper != null || manyToManyWhereTemplate != null ) {
+			if ( manyToManyFilterHelper != null ) {
+				manyToManyFilterHelper.applyEnabledFilters(
+						predicateConsumer,
+						elementPersister.getFilterAliasGenerator( tableGroup ),
+						enabledFilters,
+						false,
+						tableGroup,
+						creationState
+				);
 			}
-			else if ( useQualifier && tableReference.getIdentificationVariable() != null ) {
-				alias = tableReference.getIdentificationVariable();
+			if ( manyToManyWhereString != null ) {
+				final var tableReference = tableGroup.resolveTableReference( elementPersister.getTableName() );
+				final String alias = aliasForWhereRestriction( tableReference, useQualifier );
+				applyWhereFragments( predicateConsumer, alias, manyToManyWhereTemplate );
 			}
-			else {
-				alias = tableReference.getTableId();
-			}
-
-			applyWhereFragments( predicateConsumer, alias, manyToManyWhereTemplate );
 		}
 	}
 
 	@Override
 	public String getManyToManyFilterFragment(TableGroup tableGroup, Map<String, Filter> enabledFilters) {
-		final StringBuilder fragment = new StringBuilder();
-
+		final var fragment = new StringBuilder();
 		if ( manyToManyFilterHelper != null ) {
 			manyToManyFilterHelper.render( fragment,
 					elementPersister.getFilterAliasGenerator( tableGroup ), enabledFilters );
 		}
-
 		if ( manyToManyWhereString != null ) {
 			if ( !fragment.isEmpty() ) {
 				fragment.append( " and " );
@@ -1303,7 +1292,6 @@ public abstract class AbstractCollectionPersister
 					tableGroup.resolveTableReference( elementPersister.getTableName() )
 							.getIdentificationVariable() ) );
 		}
-
 		return fragment.toString();
 	}
 
@@ -1382,7 +1370,7 @@ public abstract class AbstractCollectionPersister
 		}
 		else {
 			final String[] result = new String[rawAliases.length];
-			final Alias alias = new Alias( suffix );
+			final var alias = new Alias( suffix );
 			for ( int i = 0; i < rawAliases.length; i++ ) {
 				result[i] = alias.toUnquotedAliasString( rawAliases[i] );
 			}
@@ -1392,7 +1380,6 @@ public abstract class AbstractCollectionPersister
 
 	// TODO: formulas ?
 	public void initCollectionPropertyMap() {
-
 		initCollectionPropertyMap( "key", keyType, keyColumnAliases );
 		initCollectionPropertyMap( "element", elementType, elementColumnAliases );
 		if ( hasIndex() ) {
@@ -1404,39 +1391,38 @@ public abstract class AbstractCollectionPersister
 	}
 
 	private void initCollectionPropertyMap(String aliasName, Type type, String[] columnAliases) {
-
 		collectionPropertyColumnAliases.put( aliasName, columnAliases );
 
 		//TODO: this code is almost certainly obsolete and can be removed
 		if ( type instanceof ComponentType || type instanceof AnyType ) {
-			CompositeType ct = (CompositeType) type;
-			String[] propertyNames = ct.getPropertyNames();
+			var compositeType = (CompositeType) type;
+			final String[] propertyNames = compositeType.getPropertyNames();
 			for ( int i = 0; i < propertyNames.length; i++ ) {
-				String name = propertyNames[i];
+				final String name = propertyNames[i];
 				collectionPropertyColumnAliases.put( aliasName + "." + name, new String[] {columnAliases[i]} );
 			}
 		}
-
 	}
 
 	@Override
 	public int getSize(Object key, SharedSessionContractImplementor session) {
 		try {
-			final JdbcCoordinator jdbcCoordinator = session.getJdbcCoordinator();
-			final PreparedStatement st = jdbcCoordinator.getStatementPreparer().prepareStatement( sqlSelectSizeString );
+			final var jdbcCoordinator = session.getJdbcCoordinator();
+			final var statement = jdbcCoordinator.getStatementPreparer().prepareStatement( sqlSelectSizeString );
+			final var resourceRegistry = jdbcCoordinator.getLogicalConnection().getResourceRegistry();
 			try {
-				getKeyType().nullSafeSet( st, key, 1, session );
-				ResultSet rs = jdbcCoordinator.getResultSetReturn().extract( st, sqlSelectSizeString );
+				getKeyType().nullSafeSet( statement, key, 1, session );
+				final var resultSet = jdbcCoordinator.getResultSetReturn().extract( statement, sqlSelectSizeString );
 				try {
 					final int baseIndex = Math.max( attributeMapping.getIndexMetadata().getListIndexBase(), 0 );
-					return rs.next() ? rs.getInt( 1 ) - baseIndex : 0;
+					return resultSet.next() ? resultSet.getInt( 1 ) - baseIndex : 0;
 				}
 				finally {
-					jdbcCoordinator.getLogicalConnection().getResourceRegistry().release( rs, st );
+					resourceRegistry.release( resultSet, statement );
 				}
 			}
 			finally {
-				jdbcCoordinator.getLogicalConnection().getResourceRegistry().release( st );
+				resourceRegistry.release( statement );
 				jdbcCoordinator.afterStatementExecution();
 			}
 		}
@@ -1462,24 +1448,25 @@ public abstract class AbstractCollectionPersister
 
 	private boolean exists(Object key, Object indexOrElement, Type indexOrElementType, String sql, SharedSessionContractImplementor session) {
 		try {
-			final JdbcCoordinator jdbcCoordinator = session.getJdbcCoordinator();
-			final PreparedStatement st = jdbcCoordinator.getStatementPreparer().prepareStatement( sql );
+			final var jdbcCoordinator = session.getJdbcCoordinator();
+			final var statement = jdbcCoordinator.getStatementPreparer().prepareStatement( sql );
+			final var resourceRegistry = jdbcCoordinator.getLogicalConnection().getResourceRegistry();
 			try {
-				getKeyType().nullSafeSet( st, key, 1, session );
-				indexOrElementType.nullSafeSet( st, indexOrElement, keyColumnNames.length + 1, session );
-				final ResultSet rs = jdbcCoordinator.getResultSetReturn().extract( st, sql );
+				getKeyType().nullSafeSet( statement, key, 1, session );
+				indexOrElementType.nullSafeSet( statement, indexOrElement, keyColumnNames.length + 1, session );
+				final var resultSet = jdbcCoordinator.getResultSetReturn().extract( statement, sql );
 				try {
-					return rs.next();
+					return resultSet.next();
 				}
 				finally {
-					jdbcCoordinator.getLogicalConnection().getResourceRegistry().release( rs, st );
+					resourceRegistry.release( resultSet, statement );
 				}
 			}
 			catch ( TransientObjectException e ) {
 				return false;
 			}
 			finally {
-				jdbcCoordinator.getLogicalConnection().getResourceRegistry().release( st );
+				resourceRegistry.release( statement );
 				jdbcCoordinator.afterStatementExecution();
 			}
 		}
@@ -1495,7 +1482,7 @@ public abstract class AbstractCollectionPersister
 
 	@Override
 	public Object getElementByIndex(Object key, Object index, SharedSessionContractImplementor session, Object owner) {
-		final LoadQueryInfluencers influencers = session.getLoadQueryInfluencers();
+		final var influencers = session.getLoadQueryInfluencers();
 		if ( isAffectedByFilters( new HashSet<>(), attributeMapping.getElementDescriptor(), influencers, true ) ) {
 			return new CollectionElementLoaderByIndex( attributeMapping, influencers, factory )
 					.load( key, index, session );
@@ -1576,10 +1563,10 @@ public abstract class AbstractCollectionPersister
 	@Override
 	public boolean isAffectedByEnabledFilters(LoadQueryInfluencers influencers, boolean onlyApplyForLoadByKeyFilters) {
 		if ( influencers.hasEnabledFilters() ) {
-			final Map<String, Filter> enabledFilters = influencers.getEnabledFilters();
+			final var enabledFilters = influencers.getEnabledFilters();
 			return filterHelper != null && filterHelper.isAffectedBy( enabledFilters )
-					|| manyToManyFilterHelper != null && manyToManyFilterHelper.isAffectedBy( enabledFilters )
-					|| isKeyOrElementAffectedByFilters( new HashSet<>(), influencers, onlyApplyForLoadByKeyFilters);
+				|| manyToManyFilterHelper != null && manyToManyFilterHelper.isAffectedBy( enabledFilters )
+				|| isKeyOrElementAffectedByFilters( new HashSet<>(), influencers, onlyApplyForLoadByKeyFilters);
 		}
 		else {
 			return false;
@@ -1592,10 +1579,10 @@ public abstract class AbstractCollectionPersister
 			LoadQueryInfluencers influencers,
 			boolean onlyApplyForLoadByKeyFilters) {
 		if ( influencers.hasEnabledFilters() ) {
-			final Map<String, Filter> enabledFilters = influencers.getEnabledFilters();
+			final var enabledFilters = influencers.getEnabledFilters();
 			return filterHelper != null && filterHelper.isAffectedBy( enabledFilters )
-					|| manyToManyFilterHelper != null && manyToManyFilterHelper.isAffectedBy( enabledFilters )
-					|| isKeyOrElementAffectedByFilters( visitedTypes, influencers, onlyApplyForLoadByKeyFilters);
+				|| manyToManyFilterHelper != null && manyToManyFilterHelper.isAffectedBy( enabledFilters )
+				|| isKeyOrElementAffectedByFilters( visitedTypes, influencers, onlyApplyForLoadByKeyFilters);
 		}
 		else {
 			return false;
@@ -1607,7 +1594,7 @@ public abstract class AbstractCollectionPersister
 			LoadQueryInfluencers influencers,
 			boolean onlyApplyForLoadByKey) {
 		return isAffectedByFilters( visitedTypes, attributeMapping.getIndexDescriptor(), influencers, onlyApplyForLoadByKey )
-				|| isAffectedByFilters( visitedTypes, attributeMapping.getElementDescriptor(), influencers, onlyApplyForLoadByKey );
+			|| isAffectedByFilters( visitedTypes, attributeMapping.getElementDescriptor(), influencers, onlyApplyForLoadByKey );
 	}
 
 	private boolean isAffectedByFilters(
@@ -1620,8 +1607,8 @@ public abstract class AbstractCollectionPersister
 					.isAffectedByEnabledFilters( visitedTypes, influencers, onlyApplyForLoadByKey );
 		}
 		else if ( collectionPart instanceof EmbeddedCollectionPart embeddedCollectionPart ) {
-			final EmbeddableMappingType type = embeddedCollectionPart.getEmbeddableTypeDescriptor();
-			return type.isAffectedByEnabledFilters( visitedTypes, influencers, onlyApplyForLoadByKey );
+			return embeddedCollectionPart.getEmbeddableTypeDescriptor()
+					.isAffectedByEnabledFilters( visitedTypes, influencers, onlyApplyForLoadByKey );
 		}
 		else {
 			return false;
@@ -1723,14 +1710,12 @@ public abstract class AbstractCollectionPersister
 	}
 
 	private JdbcDeleteMutation buildCustomSqlDeleteAllOperation(MutatingTableReference tableReference) {
-		final PluralAttributeMapping attributeMapping = getAttributeMapping();
-		final ForeignKeyDescriptor keyDescriptor = attributeMapping.getKeyDescriptor();
-
-		final ColumnValueParameterList parameterBinders =
+		final var attributeMapping = getAttributeMapping();
+		final var keyDescriptor = attributeMapping.getKeyDescriptor();
+		final var parameterBinders =
 				new ColumnValueParameterList( tableReference, ParameterUsage.RESTRICT, keyDescriptor.getJdbcTypeCount() );
 		keyDescriptor.getKeyPart().forEachSelectable( parameterBinders );
-
-		final TableMapping tableMapping = tableReference.getTableMapping();
+		final var tableMapping = tableReference.getTableMapping();
 		return new JdbcDeleteMutation(
 				tableMapping,
 				this,
@@ -1742,23 +1727,20 @@ public abstract class AbstractCollectionPersister
 	}
 
 	private JdbcMutationOperation buildGeneratedDeleteAllOperation(MutatingTableReference tableReference) {
-		return getFactory().getJdbcServices().getDialect().getSqlAstTranslatorFactory()
+		return getSqlAstTranslatorFactory()
 				.buildModelMutationTranslator( generateDeleteAllAst( tableReference ), getFactory() )
 				.translate( null, MutationQueryOptions.INSTANCE );
 	}
 
 	public RestrictedTableMutation<JdbcMutationOperation> generateDeleteAllAst(MutatingTableReference tableReference) {
 		assert getAttributeMapping() != null;
-
-		final ForeignKeyDescriptor fkDescriptor = getAttributeMapping().getKeyDescriptor();
-		assert fkDescriptor != null;
-
-		final int keyColumnCount = fkDescriptor.getJdbcTypeCount();
-		final ColumnValueParameterList parameterBinders =
+		final var foreignKeyDescriptor = getAttributeMapping().getKeyDescriptor();
+		assert foreignKeyDescriptor != null;
+		final int keyColumnCount = foreignKeyDescriptor.getJdbcTypeCount();
+		final var parameterBinders =
 				new ColumnValueParameterList( tableReference, ParameterUsage.RESTRICT, keyColumnCount );
-		final java.util.List<ColumnValueBinding> restrictionBindings = arrayList( keyColumnCount );
-		applyKeyRestrictions( tableReference, parameterBinders, restrictionBindings );
-
+		final List<ColumnValueBinding> restrictionBindings = arrayList( keyColumnCount );
+		applyKeyRestrictions( parameterBinders, restrictionBindings );
 		//noinspection unchecked,rawtypes
 		return (RestrictedTableMutation) new TableDeleteStandard(
 				tableReference,
@@ -1772,16 +1754,13 @@ public abstract class AbstractCollectionPersister
 	}
 
 	protected void applyKeyRestrictions(
-			MutatingTableReference tableReference,
 			ColumnValueParameterList parameterList,
-			java.util.List<ColumnValueBinding> restrictionBindings) {
-
-		final ForeignKeyDescriptor fkDescriptor = getAttributeMapping().getKeyDescriptor();
-		assert fkDescriptor != null;
-
-		fkDescriptor.getKeyPart().forEachSelectable( parameterList );
-		for ( ColumnValueParameter columnValueParameter : parameterList ) {
-			final ColumnReference columnReference = columnValueParameter.getColumnReference();
+			List<ColumnValueBinding> restrictionBindings) {
+		final var foreignKeyDescriptor = getAttributeMapping().getKeyDescriptor();
+		assert foreignKeyDescriptor != null;
+		foreignKeyDescriptor.getKeyPart().forEachSelectable( parameterList );
+		for ( var columnValueParameter : parameterList ) {
+			final var columnReference = columnValueParameter.getColumnReference();
 			restrictionBindings.add(
 					new ColumnValueBinding(
 							columnReference,

--- a/hibernate-core/src/main/java/org/hibernate/persister/collection/OneToManyPersister.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/collection/OneToManyPersister.java
@@ -16,7 +16,6 @@ import org.hibernate.cache.spi.access.CollectionDataAccess;
 import org.hibernate.collection.spi.PersistentCollection;
 import org.hibernate.engine.jdbc.batch.internal.BasicBatchKey;
 import org.hibernate.engine.jdbc.mutation.JdbcValueBindings;
-import org.hibernate.engine.jdbc.mutation.MutationExecutor;
 import org.hibernate.engine.jdbc.mutation.ParameterUsage;
 import org.hibernate.engine.jdbc.mutation.internal.MutationQueryOptions;
 import org.hibernate.engine.jdbc.mutation.spi.MutationExecutorService;
@@ -24,11 +23,6 @@ import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.internal.FilterAliasGenerator;
 import org.hibernate.jdbc.Expectation;
 import org.hibernate.mapping.Collection;
-import org.hibernate.metamodel.mapping.CollectionPart;
-import org.hibernate.metamodel.mapping.EntityIdentifierMapping;
-import org.hibernate.metamodel.mapping.EntityMappingType;
-import org.hibernate.metamodel.mapping.ForeignKeyDescriptor;
-import org.hibernate.metamodel.mapping.PluralAttributeMapping;
 import org.hibernate.metamodel.mapping.SelectableMapping;
 import org.hibernate.metamodel.mapping.internal.EntityCollectionPart;
 import org.hibernate.metamodel.mapping.internal.OneToManyCollectionPart;
@@ -51,17 +45,13 @@ import org.hibernate.persister.collection.mutation.UpdateRowsCoordinator;
 import org.hibernate.persister.collection.mutation.UpdateRowsCoordinatorNoOp;
 import org.hibernate.persister.collection.mutation.UpdateRowsCoordinatorOneToMany;
 import org.hibernate.persister.collection.mutation.UpdateRowsCoordinatorTablePerSubclass;
-import org.hibernate.persister.entity.EntityPersister;
 import org.hibernate.persister.entity.UnionSubclassEntityPersister;
-import org.hibernate.service.spi.ServiceRegistryImplementor;
 import org.hibernate.sql.ast.spi.SqlAstCreationState;
 import org.hibernate.sql.ast.tree.expression.ColumnReference;
 import org.hibernate.sql.ast.tree.from.TableGroup;
 import org.hibernate.sql.ast.tree.predicate.Predicate;
-import org.hibernate.sql.model.MutationOperation;
 import org.hibernate.sql.model.MutationType;
 import org.hibernate.sql.model.ast.ColumnValueBinding;
-import org.hibernate.sql.model.ast.ColumnValueParameter;
 import org.hibernate.sql.model.ast.ColumnValueParameterList;
 import org.hibernate.sql.model.ast.ColumnWriteFragment;
 import org.hibernate.sql.model.ast.MutatingTableReference;
@@ -104,15 +94,17 @@ public class OneToManyPersister extends AbstractCollectionPersister {
 	public OneToManyPersister(
 			Collection collectionBinding,
 			CollectionDataAccess cacheAccessStrategy,
-			RuntimeModelCreationContext creationContext) throws MappingException, CacheException {
+			RuntimeModelCreationContext creationContext)
+					throws MappingException, CacheException {
 		super( collectionBinding, cacheAccessStrategy, creationContext );
 		keyIsNullable = collectionBinding.getKey().isNullable();
 
-		doWriteEvenWhenInverse = isInverse
-				&& hasIndex()
-				&& !indexContainsFormula
-				&& isAnyTrue( indexColumnIsSettable )
-				&& !getElementPersisterInternal().managesColumns( indexColumnNames );
+		doWriteEvenWhenInverse =
+				isInverse
+					&& hasIndex()
+					&& !indexContainsFormula
+					&& isAnyTrue( indexColumnIsSettable )
+					&& !getElementPersisterInternal().managesColumns( indexColumnNames );
 
 		rowMutationOperations = buildRowMutationOperations();
 
@@ -120,7 +112,7 @@ public class OneToManyPersister extends AbstractCollectionPersister {
 		updateRowsCoordinator = buildUpdateCoordinator();
 		deleteRowsCoordinator = buildDeleteCoordinator();
 		removeCoordinator = buildDeleteAllCoordinator();
-		mutationExecutorService = creationContext.getServiceRegistry().getService(	MutationExecutorService.class );
+		mutationExecutorService = creationContext.getServiceRegistry().getService( MutationExecutorService.class );
 	}
 
 	@Override
@@ -198,18 +190,18 @@ public class OneToManyPersister extends AbstractCollectionPersister {
 		// users complain.
 		if ( doWriteEvenWhenInverse && entries.hasNext() ) {
 
-			final JdbcMutationOperation updateRowOperation = rowMutationOperations.getUpdateRowOperation();
-			final RowMutationOperations.Values updateRowValues = rowMutationOperations.getUpdateRowValues();
-			final RowMutationOperations.Restrictions updateRowRestrictions = rowMutationOperations.getUpdateRowRestrictions();
+			final var updateRowOperation = rowMutationOperations.getUpdateRowOperation();
+			final var updateRowValues = rowMutationOperations.getUpdateRowValues();
+			final var updateRowRestrictions = rowMutationOperations.getUpdateRowRestrictions();
 			assert areAllNonNull( updateRowOperation, updateRowValues, updateRowRestrictions );
 
-			final MutationExecutor mutationExecutor = mutationExecutorService.createExecutor(
+			final var mutationExecutor = mutationExecutorService.createExecutor(
 					() -> new BasicBatchKey( getNavigableRole() + "#INDEX" ),
 					MutationOperationGroupFactory.singleOperation( MutationType.UPDATE, this, updateRowOperation ),
 					session
 			);
 
-			final JdbcValueBindings jdbcValueBindings = mutationExecutor.getJdbcValueBindings();
+			final var jdbcValueBindings = mutationExecutor.getJdbcValueBindings();
 			try {
 				int nextIndex = ( resetIndex ? 0 : getSize( key, session ) ) +
 						Math.max( getAttributeMapping().getIndexMetadata().getListIndexBase(), 0 );
@@ -264,7 +256,6 @@ public class OneToManyPersister extends AbstractCollectionPersister {
 			TableGroup tableGroup,
 			SqlAstCreationState astCreationState) {
 		super.applyWhereFragments( predicateConsumer, alias, tableGroup, astCreationState );
-
 		if ( !astCreationState.supportsEntityNameUsage() ) {
 			// We only need to apply discriminator for loads, since queries with joined
 			// inheritance subtypes are already filtered by the entity name usage logic
@@ -290,26 +281,24 @@ public class OneToManyPersister extends AbstractCollectionPersister {
 
 	@Override
 	public RestrictedTableMutation<JdbcMutationOperation> generateDeleteAllAst(MutatingTableReference tableReference) {
-		assert getAttributeMapping() != null;
+		final var attributeMapping = getAttributeMapping();
+		assert attributeMapping != null;
 
-		final ForeignKeyDescriptor fkDescriptor = getAttributeMapping().getKeyDescriptor();
-		assert fkDescriptor != null;
+		final var foreignKeyDescriptor = attributeMapping.getKeyDescriptor();
+		assert foreignKeyDescriptor != null;
 
-		final int keyColumnCount = fkDescriptor.getJdbcTypeCount();
+		final int keyColumnCount = foreignKeyDescriptor.getJdbcTypeCount();
 		final int valuesCount = hasIndex()
 				? keyColumnCount + indexColumnNames.length
 				: keyColumnCount;
 
-		final ColumnValueParameterList parameterBinders = new ColumnValueParameterList(
-				tableReference,
-				ParameterUsage.RESTRICT,
-				keyColumnCount
-		);
+		final var parameterBinders =
+				new ColumnValueParameterList( tableReference, ParameterUsage.RESTRICT, keyColumnCount );
 		final List<ColumnValueBinding> keyRestrictionBindings = arrayList( keyColumnCount );
 		final List<ColumnValueBinding> valueBindings = arrayList( valuesCount );
-		fkDescriptor.getKeyPart().forEachSelectable( parameterBinders );
-		for ( ColumnValueParameter columnValueParameter : parameterBinders ) {
-			final ColumnReference columnReference = columnValueParameter.getColumnReference();
+		foreignKeyDescriptor.getKeyPart().forEachSelectable( parameterBinders );
+		for ( var columnValueParameter : parameterBinders ) {
+			final var columnReference = columnValueParameter.getColumnReference();
 			keyRestrictionBindings.add(
 					new ColumnValueBinding(
 							columnReference,
@@ -329,14 +318,15 @@ public class OneToManyPersister extends AbstractCollectionPersister {
 		}
 
 		if ( hasIndex() && !indexContainsFormula ) {
-			getAttributeMapping().getIndexDescriptor().forEachSelectable( (selectionIndex, selectableMapping) -> {
-				if ( ! selectableMapping.isUpdateable() ) {
-					return;
+			attributeMapping.getIndexDescriptor().forEachSelectable( (selectionIndex, selectableMapping) -> {
+				if ( selectableMapping.isUpdateable() ) {
+					valueBindings.add(
+							new ColumnValueBinding(
+									new ColumnReference( tableReference, selectableMapping ),
+									new ColumnWriteFragment( "null", selectableMapping.getJdbcMapping() )
+							)
+					);
 				}
-				valueBindings.add(
-						new ColumnValueBinding( new ColumnReference( tableReference, selectableMapping ),
-						new ColumnWriteFragment( "null", selectableMapping.getJdbcMapping() )
-				) );
 			} );
 		}
 
@@ -403,7 +393,6 @@ public class OneToManyPersister extends AbstractCollectionPersister {
 		);
 	}
 
-
 	private InsertRowsCoordinator buildInsertCoordinator() {
 		if ( isInverse() || !isRowInsertEnabled() ) {
 //			if ( MODEL_MUTATION_LOGGER.isTraceEnabled() ) {
@@ -412,8 +401,8 @@ public class OneToManyPersister extends AbstractCollectionPersister {
 			return new InsertRowsCoordinatorNoOp( this );
 		}
 		else {
-			final ServiceRegistryImplementor serviceRegistry = getFactory().getServiceRegistry();
-			final EntityPersister elementPersister = getElementPersisterInternal();
+			final var serviceRegistry = getFactory().getServiceRegistry();
+			final var elementPersister = getElementPersisterInternal();
 			return elementPersister != null && elementPersister.hasSubclasses()
 						&& elementPersister instanceof UnionSubclassEntityPersister
 					? new InsertRowsCoordinatorTablePerSubclass( this, rowMutationOperations, serviceRegistry )
@@ -429,11 +418,12 @@ public class OneToManyPersister extends AbstractCollectionPersister {
 			return new UpdateRowsCoordinatorNoOp( this );
 		}
 		else {
-			final EntityPersister elementPersister = getElementPersisterInternal();
+			final var elementPersister = getElementPersisterInternal();
+			final var factory = getFactory();
 			return elementPersister != null && elementPersister.hasSubclasses()
-						&& elementPersister instanceof UnionSubclassEntityPersister
-					? new UpdateRowsCoordinatorTablePerSubclass( this, rowMutationOperations, getFactory() )
-					: new UpdateRowsCoordinatorOneToMany( this, rowMutationOperations, getFactory() );
+				&& elementPersister instanceof UnionSubclassEntityPersister
+					? new UpdateRowsCoordinatorTablePerSubclass( this, rowMutationOperations, factory )
+					: new UpdateRowsCoordinatorOneToMany( this, rowMutationOperations, factory );
 		}
 	}
 
@@ -445,10 +435,10 @@ public class OneToManyPersister extends AbstractCollectionPersister {
 			return new DeleteRowsCoordinatorNoOp( this );
 		}
 		else {
-			final EntityPersister elementPersister = getElementPersisterInternal();
-			final ServiceRegistryImplementor serviceRegistry = getFactory().getServiceRegistry();
+			final var elementPersister = getElementPersisterInternal();
+			final var serviceRegistry = getFactory().getServiceRegistry();
 			return elementPersister != null && elementPersister.hasSubclasses()
-						&& elementPersister instanceof UnionSubclassEntityPersister
+				&& elementPersister instanceof UnionSubclassEntityPersister
 					// never delete by index for one-to-many
 					? new DeleteRowsCoordinatorTablePerSubclass( this, rowMutationOperations, false, serviceRegistry )
 					: new DeleteRowsCoordinatorStandard( this, rowMutationOperations, false, serviceRegistry );
@@ -463,33 +453,33 @@ public class OneToManyPersister extends AbstractCollectionPersister {
 			return new RemoveCoordinatorNoOp( this );
 		}
 		else {
-			final ServiceRegistryImplementor serviceRegistry = getFactory().getServiceRegistry();
-			final EntityPersister elementPersister = getElementPersisterInternal();
+			final var serviceRegistry = getFactory().getServiceRegistry();
+			final var elementPersister = getElementPersisterInternal();
 			return elementPersister != null && elementPersister.hasSubclasses()
-						&& elementPersister instanceof UnionSubclassEntityPersister
+				&& elementPersister instanceof UnionSubclassEntityPersister
 					? new RemoveCoordinatorTablePerSubclass( this, this::buildDeleteAllOperation, serviceRegistry )
 					: new RemoveCoordinatorStandard( this, this::buildDeleteAllOperation, serviceRegistry );
 		}
 	}
 
 	private JdbcMutationOperation generateDeleteRowOperation(MutatingTableReference tableReference) {
-		return getFactory().getJdbcServices().getDialect().getSqlAstTranslatorFactory()
+		return getSqlAstTranslatorFactory()
 				.buildModelMutationTranslator( generateDeleteRowAst( tableReference ), getFactory() )
 				.translate( null, MutationQueryOptions.INSTANCE );
 	}
 
 	public RestrictedTableMutation<JdbcMutationOperation> generateDeleteRowAst(MutatingTableReference tableReference) {
-		// note that custom sql delete row details are handled by CollectionRowUpdateBuilder
-		final CollectionRowDeleteByUpdateSetNullBuilder<MutationOperation> updateBuilder =
+		// note that custom SQL delete row details are handled by CollectionRowUpdateBuilder
+		final var updateBuilder =
 				new CollectionRowDeleteByUpdateSetNullBuilder<>( this, tableReference, getFactory(), sqlWhereString );
 
 		// for each key column -
 		// 		1) set the value to null
 		// 		2) restrict based on key value
-		final ForeignKeyDescriptor keyDescriptor = getAttributeMapping().getKeyDescriptor();
-		final int keyTypeCount = keyDescriptor.getJdbcTypeCount();
+		final var foreignKeyDescriptor = getAttributeMapping().getKeyDescriptor();
+		final int keyTypeCount = foreignKeyDescriptor.getJdbcTypeCount();
 		for ( int i = 0; i < keyTypeCount; i++ ) {
-			final SelectableMapping selectable = keyDescriptor.getSelectable( i );
+			final SelectableMapping selectable = foreignKeyDescriptor.getSelectable( i );
 			if ( !selectable.isFormula() ) {
 				if ( selectable.isUpdateable() ) {
 					// set null
@@ -507,11 +497,11 @@ public class OneToManyPersister extends AbstractCollectionPersister {
 
 		// set the value for each index column to null
 		if ( hasIndex() && !indexContainsFormula ) {
-			final CollectionPart indexDescriptor = getAttributeMapping().getIndexDescriptor();
+			final var indexDescriptor = getAttributeMapping().getIndexDescriptor();
 			assert indexDescriptor != null;
 			final int indexTypeCount = indexDescriptor.getJdbcTypeCount();
 			for ( int i = 0; i < indexTypeCount; i++ ) {
-				final SelectableMapping selectable = indexDescriptor.getSelectable( i );
+				final var selectable = indexDescriptor.getSelectable( i );
 				if ( selectable.isUpdateable() ) {
 					updateBuilder.addValueColumn(
 							selectable.getSelectionExpression(),
@@ -525,8 +515,8 @@ public class OneToManyPersister extends AbstractCollectionPersister {
 
 		// for one-to-many, we know the element is an entity and need to restrict the update
 		// based on the element's id
-		final EntityCollectionPart entityPart = (EntityCollectionPart) getAttributeMapping().getElementDescriptor();
-		final EntityIdentifierMapping entityId = entityPart.getAssociatedEntityMappingType().getIdentifierMapping();
+		final var entityPart = (EntityCollectionPart) getAttributeMapping().getElementDescriptor();
+		final var entityId = entityPart.getAssociatedEntityMappingType().getIdentifierMapping();
 		updateBuilder.addKeyRestrictionsLeniently( entityId );
 
 		//noinspection unchecked,rawtypes
@@ -540,7 +530,7 @@ public class OneToManyPersister extends AbstractCollectionPersister {
 			int rowPosition,
 			SharedSessionContractImplementor session,
 			JdbcValueBindings jdbcValueBindings) {
-		final PluralAttributeMapping pluralAttribute = getAttributeMapping();
+		final var pluralAttribute = getAttributeMapping();
 		pluralAttribute.getKeyDescriptor().decompose(
 				keyValue,
 				0,
@@ -561,25 +551,22 @@ public class OneToManyPersister extends AbstractCollectionPersister {
 
 
 	private JdbcMutationOperation generateInsertRowOperation(MutatingTableReference tableReference) {
-		// NOTE : `TableUpdateBuilderStandard` and `TableUpdate` already handle custom-sql
-		final TableUpdate<JdbcMutationOperation> tableUpdate = buildTableUpdate( tableReference );
-		return tableUpdate.createMutationOperation( null, getFactory() );
+		// NOTE: `TableUpdateBuilderStandard` and `TableUpdate` already handle custom-sql
+		return buildTableUpdate( tableReference )
+				.createMutationOperation( null, getFactory() );
 	}
 
 	private TableUpdate<JdbcMutationOperation> buildTableUpdate(MutatingTableReference tableReference) {
 		final TableUpdateBuilderStandard<JdbcMutationOperation> updateBuilder =
 				new TableUpdateBuilderStandard<>( this, tableReference, getFactory(), sqlWhereString );
-
-		final PluralAttributeMapping attributeMapping = getAttributeMapping();
+		final var attributeMapping = getAttributeMapping();
 		attributeMapping.getKeyDescriptor().getKeyPart().forEachSelectable( updateBuilder );
-
-		final CollectionPart indexDescriptor = attributeMapping.getIndexDescriptor();
+		final var indexDescriptor = attributeMapping.getIndexDescriptor();
 		if ( indexDescriptor != null ) {
 			indexDescriptor.forEachUpdatable( updateBuilder );
 		}
-
-		final EntityCollectionPart elementDescriptor = (EntityCollectionPart) attributeMapping.getElementDescriptor();
-		final EntityMappingType elementType = elementDescriptor.getAssociatedEntityMappingType();
+		final var elementDescriptor = (EntityCollectionPart) attributeMapping.getElementDescriptor();
+		final var elementType = elementDescriptor.getAssociatedEntityMappingType();
 		assert elementType.containsTableReference( tableReference.getTableName() );
 		updateBuilder.addKeyRestrictionsLeniently( elementType.getIdentifierMapping() );
 		return (TableUpdate<JdbcMutationOperation>) updateBuilder.buildMutation();
@@ -592,8 +579,7 @@ public class OneToManyPersister extends AbstractCollectionPersister {
 			int rowPosition,
 			SharedSessionContractImplementor session,
 			JdbcValueBindings jdbcValueBindings) {
-		final PluralAttributeMapping attributeMapping = getAttributeMapping();
-
+		final var attributeMapping = getAttributeMapping();
 		attributeMapping.getKeyDescriptor().getKeyPart().decompose(
 				keyValue,
 				0,
@@ -602,9 +588,7 @@ public class OneToManyPersister extends AbstractCollectionPersister {
 				RowMutationOperations.DEFAULT_VALUE_SETTER,
 				session
 		);
-
-		final CollectionPart indexDescriptor = attributeMapping.getIndexDescriptor();
-
+		final var indexDescriptor = attributeMapping.getIndexDescriptor();
 		if ( indexDescriptor != null ) {
 			indexDescriptor.decompose(
 					incrementIndexByBase( collection.getIndex( rowValue, rowPosition, this ) ),
@@ -612,18 +596,17 @@ public class OneToManyPersister extends AbstractCollectionPersister {
 					jdbcValueBindings,
 					null,
 					(valueIndex, bindings, noop, value, jdbcValueMapping) -> {
-						if ( !jdbcValueMapping.isUpdateable() ) {
-							return;
+						if ( jdbcValueMapping.isUpdateable() ) {
+							bindings.bindValue( value, jdbcValueMapping, ParameterUsage.SET );
 						}
-						bindings.bindValue( value, jdbcValueMapping, ParameterUsage.SET );
 					},
 					session
 			);
 		}
 
 		final Object elementValue = collection.getElement( rowValue );
-		final EntityCollectionPart elementDescriptor = (EntityCollectionPart) attributeMapping.getElementDescriptor();
-		final EntityIdentifierMapping identifierMapping = elementDescriptor.getAssociatedEntityMappingType().getIdentifierMapping();
+		final var elementDescriptor = (EntityCollectionPart) attributeMapping.getElementDescriptor();
+		final var identifierMapping = elementDescriptor.getAssociatedEntityMappingType().getIdentifierMapping();
 		identifierMapping.decompose(
 				identifierMapping.getIdentifier( elementValue ),
 				0,
@@ -636,25 +619,22 @@ public class OneToManyPersister extends AbstractCollectionPersister {
 
 
 	private JdbcMutationOperation generateWriteIndexOperation(MutatingTableReference tableReference) {
-		// note that custom sql update details are handled by TableUpdateBuilderStandard
+		// note that custom SQL update details are handled by TableUpdateBuilderStandard
 		final TableUpdateBuilderStandard<JdbcMutationOperation> updateBuilder =
 				new TableUpdateBuilderStandard<>( this, tableReference, getFactory(), sqlWhereString );
-
-		final OneToManyCollectionPart elementDescriptor = (OneToManyCollectionPart) getAttributeMapping().getElementDescriptor();
+		final var attributeMapping = getAttributeMapping();
+		final var elementDescriptor = (OneToManyCollectionPart) attributeMapping.getElementDescriptor();
 		updateBuilder.addKeyRestrictionsLeniently( elementDescriptor.getAssociatedEntityMappingType().getIdentifierMapping() );
-
 		// if the collection has an identifier, add its column as well
-		if ( getAttributeMapping().getIdentifierDescriptor() != null ) {
-			updateBuilder.addKeyRestrictionsLeniently( getAttributeMapping().getIdentifierDescriptor() );
+		if ( attributeMapping.getIdentifierDescriptor() != null ) {
+			updateBuilder.addKeyRestrictionsLeniently( attributeMapping.getIdentifierDescriptor() );
 		}
-
 		// for each index column:
 		// 		* add a restriction based on the previous value
 		//		* add an assignment for the new value
-		getAttributeMapping().getIndexDescriptor().forEachUpdatable( updateBuilder );
-
-		final RestrictedTableMutation<JdbcMutationOperation> tableUpdate = updateBuilder.buildMutation();
-		return tableUpdate.createMutationOperation( null, getFactory() );
+		attributeMapping.getIndexDescriptor().forEachUpdatable( updateBuilder );
+		return updateBuilder.buildMutation()
+				.createMutationOperation( null, getFactory() );
 	}
 
 	private void applyWriteIndexValues(
@@ -686,12 +666,12 @@ public class OneToManyPersister extends AbstractCollectionPersister {
 			int entryPosition,
 			SharedSessionContractImplementor session,
 			JdbcValueBindings jdbcValueBindings) {
-		final OneToManyCollectionPart elementDescriptor = (OneToManyCollectionPart) getAttributeMapping().getElementDescriptor();
-		final EntityMappingType associatedType = elementDescriptor.getAssociatedEntityMappingType();
+		final var attributeMapping = getAttributeMapping();
+		final var elementDescriptor = (OneToManyCollectionPart) attributeMapping.getElementDescriptor();
+		final var associatedType = elementDescriptor.getAssociatedEntityMappingType();
 		final Object element = collection.getElement( entry );
-		final Object elementIdentifier = associatedType.getIdentifierMapping().getIdentifier( element );
 		associatedType.getIdentifierMapping().decompose(
-				elementIdentifier,
+				associatedType.getIdentifierMapping().getIdentifier( element ),
 				0,
 				jdbcValueBindings,
 				null,
@@ -699,10 +679,9 @@ public class OneToManyPersister extends AbstractCollectionPersister {
 				session
 		);
 
-		if ( getAttributeMapping().getIdentifierDescriptor() != null ) {
-			final Object identifier = collection.getIdentifier( entry, entryPosition );
-			getAttributeMapping().getIdentifierDescriptor().decompose(
-					identifier,
+		if ( attributeMapping.getIdentifierDescriptor() != null ) {
+			attributeMapping.getIdentifierDescriptor().decompose(
+					collection.getIdentifier( entry, entryPosition ),
 					0,
 					jdbcValueBindings,
 					null,

--- a/hibernate-core/src/main/java/org/hibernate/persister/entity/AbstractEntityPersister.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/entity/AbstractEntityPersister.java
@@ -78,7 +78,6 @@ import org.hibernate.internal.FilterHelper;
 import org.hibernate.internal.util.IndexedConsumer;
 import org.hibernate.internal.util.MarkerObject;
 import org.hibernate.internal.util.StringHelper;
-import org.hibernate.internal.util.collections.ArrayHelper;
 import org.hibernate.internal.util.collections.LockModeEnumMap;
 import org.hibernate.jdbc.Expectation;
 import org.hibernate.loader.ast.internal.EntityConcreteTypeLoader;
@@ -270,7 +269,9 @@ import static org.hibernate.internal.util.StringHelper.qualify;
 import static org.hibernate.internal.util.StringHelper.qualifyConditionally;
 import static org.hibernate.internal.util.StringHelper.root;
 import static org.hibernate.internal.util.StringHelper.unqualify;
+import static org.hibernate.internal.util.collections.ArrayHelper.EMPTY_INT_ARRAY;
 import static org.hibernate.internal.util.collections.ArrayHelper.contains;
+import static org.hibernate.internal.util.collections.ArrayHelper.indexOf;
 import static org.hibernate.internal.util.collections.ArrayHelper.isAllTrue;
 import static org.hibernate.internal.util.collections.ArrayHelper.to2DStringArray;
 import static org.hibernate.internal.util.collections.ArrayHelper.toIntArray;
@@ -2308,7 +2309,7 @@ public abstract class AbstractEntityPersister
 	}
 
 	private int getSubclassPropertyIndex(String propertyName) {
-		return ArrayHelper.indexOf( subclassPropertyNameClosure, propertyName );
+		return indexOf( subclassPropertyNameClosure, propertyName );
 	}
 
 	public String[] getPropertyColumnNames(int i) {
@@ -2371,7 +2372,7 @@ public abstract class AbstractEntityPersister
 	@Override
 	public int[] resolveAttributeIndexes(String[] attributeNames) {
 		if ( attributeNames == null || attributeNames.length == 0 ) {
-			return ArrayHelper.EMPTY_INT_ARRAY;
+			return EMPTY_INT_ARRAY;
 		}
 		final List<Integer> fields = new ArrayList<>( attributeNames.length );
 
@@ -2417,7 +2418,7 @@ public abstract class AbstractEntityPersister
 						: attributeNames.length + mutablePropertiesIndexes.cardinality();
 		final List<Integer> fields = new ArrayList<>( estimatedSize );
 		if ( estimatedSize == 0 ) {
-			return ArrayHelper.EMPTY_INT_ARRAY;
+			return EMPTY_INT_ARRAY;
 		}
 		if ( !mutablePropertiesIndexes.isEmpty() ) {
 			// We have to check the state for "mutable" properties as dirty tracking isn't aware of mutable types

--- a/hibernate-core/src/main/java/org/hibernate/persister/entity/AbstractEntityPersister.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/entity/AbstractEntityPersister.java
@@ -597,14 +597,12 @@ public abstract class AbstractEntityPersister
 			for ( int k = 0; k < selectables.size(); k++ ) {
 				final var selectable = selectables.get(k);
 				colAliases[k] = selectable.getAlias( dialect, propertyValue.getTable() );
-				if ( selectable.isFormula() ) {
+				if ( selectable instanceof Formula formula ) {
 					foundFormula = true;
-					final var formula = (Formula) selectable;
 					formula.setFormula( substituteBrackets( formula.getFormula() ) );
 					formulaTemplates[k] = selectable.getTemplate( dialect, typeConfiguration );
 				}
-				else {
-					final var column = (Column) selectable;
+				else if ( selectable instanceof Column column ) {
 					colNames[k] = column.getQuotedName( dialect );
 				}
 			}
@@ -655,9 +653,9 @@ public abstract class AbstractEntityPersister
 
 		if ( persistentClass.hasSubclasses() ) {
 			for ( var selectable : persistentClass.getIdentifier().getSelectables() ) {
-				if ( !selectable.isFormula() ) {
+				if ( selectable instanceof Column column ) {
 					// Identifier columns are always shared between subclasses
-					sharedColumnNames.add( ( (Column) selectable ).getQuotedName( dialect ) );
+					sharedColumnNames.add( column.getQuotedName( dialect ) );
 				}
 			}
 		}
@@ -674,7 +672,7 @@ public abstract class AbstractEntityPersister
 			final var selectables = prop.getSelectables();
 			for ( int i = 0; i < selectables.size(); i++ ) {
 				final var selectable = selectables.get(i);
-				if ( selectable.isFormula() ) {
+				if ( selectable instanceof Formula ) {
 					final String template = selectable.getTemplate( dialect, typeConfiguration );
 					forms[i] = template;
 					final String formulaAlias = selectable.getAlias( dialect );
@@ -682,15 +680,13 @@ public abstract class AbstractEntityPersister
 						formulaAliases.add( formulaAlias );
 					}
 				}
-				else {
-					final var column = (Column) selectable;
+				else if ( selectable instanceof Column column ) {
 					final String colName = column.getQuotedName(dialect);
 					cols[i] = colName;
 					final String columnAlias = selectable.getAlias( dialect, prop.getValue().getTable() );
 					if ( prop.isSelectable() && !aliases.contains( columnAlias ) ) {
 						aliases.add( columnAlias );
 					}
-
 					readers[i] = column.getReadExpr( dialect );
 					readerTemplates[i] = column.getTemplate( dialect, typeConfiguration );
 					if ( thisClassProperties.contains( prop )

--- a/hibernate-core/src/main/java/org/hibernate/persister/entity/AbstractEntityPersister.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/entity/AbstractEntityPersister.java
@@ -738,7 +738,7 @@ public abstract class AbstractEntityPersister
 		final List<String> sqlValues = new ArrayList<>();
 
 		if ( persistentClass.isPolymorphic() && persistentClass.getDiscriminator() != null ) {
-			if ( !getEntityMetamodel().isAbstract() ) {
+			if ( !isAbstract() ) {
 				values.add( DiscriminatorHelper.getDiscriminatorValue( persistentClass ) );
 				sqlValues.add( DiscriminatorHelper.getDiscriminatorSQLValue( persistentClass, dialect ) );
 			}
@@ -4027,13 +4027,23 @@ public abstract class AbstractEntityPersister
 	}
 
 	@Override
+	public boolean hasPreInsertGeneratedProperties() {
+		return hasPreInsertGeneratedValues();
+	}
+
+	@Override
+	public boolean hasPreUpdateGeneratedProperties() {
+		return hasPreUpdateGeneratedValues();
+	}
+
+	@Override
 	public boolean isVersionPropertyGenerated() {
 		return isVersioned()
 			&& ( isVersionGeneratedOnExecution() || isVersionGeneratedBeforeExecution() );
 	}
 
 	private Generator versionPropertyGenerator() {
-		return getEntityMetamodel().getGenerators()[ this.getVersionPropertyIndex() ];
+		return getGenerators()[ this.getVersionPropertyIndex() ];
 	}
 
 	public boolean isVersionGeneratedOnExecution() {
@@ -4778,9 +4788,9 @@ public abstract class AbstractEntityPersister
 				// because calling `subMappingType.getNumberOfDeclaredAttributeMappings()` at this point
 				// may produce wrong results because subMappingType might not have completed prepareMappingModel yet
 				final int propertySpan =
-						subMappingType.getEntityPersister().getEntityMetamodel().getPropertySpan();
+						subMappingType.getEntityPersister().getPropertySpan();
 				final int superPropertySpan =
-						subMappingType.getSuperMappingType().getEntityPersister().getEntityMetamodel().getPropertySpan();
+						subMappingType.getSuperMappingType().getEntityPersister().getPropertySpan();
 				final int numberOfDeclaredAttributeMappings = propertySpan - superPropertySpan;
 				offset += numberOfDeclaredAttributeMappings;
 			}

--- a/hibernate-core/src/main/java/org/hibernate/persister/entity/EntityPersister.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/entity/EntityPersister.java
@@ -496,7 +496,7 @@ public interface EntityPersister extends EntityMappingType, EntityMutationTarget
 	 *
 	 * @return The type of the version property; or -66, if not versioned.
 	 */
-	int getVersionProperty();
+	int getVersionPropertyIndex();
 
 	/**
 	 * Determine whether this entity defines a natural identifier.

--- a/hibernate-core/src/main/java/org/hibernate/persister/entity/EntityPersister.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/entity/EntityPersister.java
@@ -18,6 +18,7 @@ import org.hibernate.Internal;
 import org.hibernate.LockMode;
 import org.hibernate.LockOptions;
 import org.hibernate.MappingException;
+import org.hibernate.annotations.OnDeleteAction;
 import org.hibernate.bytecode.enhance.spi.interceptor.EnhancementAsProxyLazinessInterceptor;
 import org.hibernate.bytecode.spi.BytecodeEnhancementMetadata;
 import org.hibernate.cache.MutableCacheKeyBuilder;
@@ -212,7 +213,30 @@ public interface EntityPersister extends EntityMappingType, EntityMutationTarget
 	 *
 	 *@return The metamodel
 	 */
+	@Deprecated(since = "7.2", forRemoval = true)
 	EntityMetamodel getEntityMetamodel();
+
+	boolean isPolymorphic();
+
+	boolean isDynamicUpdate();
+
+	boolean isDynamicInsert();
+
+	OnDeleteAction[] getPropertyOnDeleteActions();
+
+	Generator[] getGenerators();
+
+	boolean hasImmutableNaturalId();
+
+	boolean isNaturalIdentifierInsertGenerated();
+
+	boolean isLazy();
+
+	int getPropertySpan();
+
+	boolean hasPreInsertGeneratedProperties();
+
+	boolean hasPreUpdateGeneratedProperties();
 
 	/**
 	 * Called from {@link EnhancementAsProxyLazinessInterceptor} to trigger load of

--- a/hibernate-core/src/main/java/org/hibernate/persister/entity/JoinedSubclassEntityPersister.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/entity/JoinedSubclassEntityPersister.java
@@ -7,7 +7,6 @@ package org.hibernate.persister.entity;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Supplier;
@@ -23,18 +22,10 @@ import org.hibernate.dialect.Dialect;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.internal.DynamicFilterAliasGenerator;
 import org.hibernate.internal.FilterAliasGenerator;
-import org.hibernate.internal.util.collections.ArrayHelper;
 import org.hibernate.jdbc.Expectation;
 import org.hibernate.mapping.Column;
-import org.hibernate.mapping.Join;
-import org.hibernate.mapping.KeyValue;
-import org.hibernate.mapping.MappedSuperclass;
 import org.hibernate.mapping.PersistentClass;
-import org.hibernate.mapping.Property;
-import org.hibernate.mapping.Selectable;
-import org.hibernate.mapping.Subclass;
 import org.hibernate.mapping.Table;
-import org.hibernate.mapping.Value;
 import org.hibernate.metamodel.mapping.EntityDiscriminatorMapping;
 import org.hibernate.metamodel.mapping.EntityIdentifierMapping;
 import org.hibernate.metamodel.mapping.EntityMappingType;
@@ -54,17 +45,18 @@ import org.hibernate.sql.ast.tree.from.UnknownTableReferenceException;
 import org.hibernate.sql.model.ast.builder.MutationGroupBuilder;
 import org.hibernate.sql.model.ast.builder.TableInsertBuilder;
 import org.hibernate.type.BasicType;
-import org.hibernate.type.BasicTypeRegistry;
 import org.hibernate.type.CompositeType;
 import org.hibernate.type.StandardBasicTypes;
 import org.hibernate.type.Type;
-import org.hibernate.type.spi.TypeConfiguration;
 
 import org.jboss.logging.Logger;
 
 import static java.util.Collections.emptyMap;
+import static org.hibernate.internal.util.collections.ArrayHelper.contains;
+import static org.hibernate.internal.util.collections.ArrayHelper.join;
 import static org.hibernate.internal.util.collections.ArrayHelper.reverseFirst;
 import static org.hibernate.internal.util.collections.ArrayHelper.to2DStringArray;
+import static org.hibernate.internal.util.collections.ArrayHelper.toBooleanArray;
 import static org.hibernate.internal.util.collections.ArrayHelper.toIntArray;
 import static org.hibernate.internal.util.collections.ArrayHelper.toStringArray;
 import static org.hibernate.internal.util.collections.CollectionHelper.linkedMapOfSize;
@@ -161,18 +153,18 @@ public class JoinedSubclassEntityPersister extends AbstractEntityPersister {
 			final RuntimeModelCreationContext creationContext) throws HibernateException {
 		super( persistentClass, cacheAccessStrategy, naturalIdRegionAccessStrategy, creationContext );
 
-		final Dialect dialect = creationContext.getDialect();
-		final TypeConfiguration typeConfiguration = creationContext.getTypeConfiguration();
-		final BasicTypeRegistry basicTypeRegistry = typeConfiguration.getBasicTypeRegistry();
+		final var dialect = creationContext.getDialect();
+		final var typeConfiguration = creationContext.getTypeConfiguration();
+		final var basicTypeRegistry = typeConfiguration.getBasicTypeRegistry();
 
 		// DISCRIMINATOR
 
 		if ( persistentClass.isPolymorphic() ) {
 			forceDiscriminator = persistentClass.isForceDiscriminator();
-			final Value discriminatorMapping = persistentClass.getDiscriminator();
+			final var discriminatorMapping = persistentClass.getDiscriminator();
 			if ( discriminatorMapping != null ) {
 				log.tracef( "Encountered explicit discriminator mapping for joined inheritance" );
-				final Selectable selectable = discriminatorMapping.getSelectables().get(0);
+				final var selectable = discriminatorMapping.getSelectables().get(0);
 				if ( selectable instanceof Column column ) {
 					explicitDiscriminatorColumnName = column.getQuotedName( dialect );
 					discriminatorAlias = column.getAlias( dialect, persistentClass.getRootTable() );
@@ -219,18 +211,18 @@ public class JoinedSubclassEntityPersister extends AbstractEntityPersister {
 		final ArrayList<String[]> keyColumnReaders = new ArrayList<>();
 		final ArrayList<String[]> keyColumnReaderTemplates = new ArrayList<>();
 		final ArrayList<Boolean> cascadeDeletes = new ArrayList<>();
-		final List<Table> tableClosure = persistentClass.getTableClosure();
-		final List<KeyValue> keyClosure = persistentClass.getKeyClosure();
+		final var tableClosure = persistentClass.getTableClosure();
+		final var keyClosure = persistentClass.getKeyClosure();
 		for ( int i = 0; i < tableClosure.size() && i < keyClosure.size(); i++ ) {
 			tableNames.add( determineTableName( tableClosure.get(i) ) );
 
-			final KeyValue key = keyClosure.get(i);
+			final var key = keyClosure.get(i);
 			final String[] keyCols = new String[idColumnSpan];
 			final String[] keyColReaders = new String[idColumnSpan];
 			final String[] keyColReaderTemplates = new String[idColumnSpan];
-			final List<Column> columns = key.getColumns();
+			final var columns = key.getColumns();
 			for ( int k = 0; k < idColumnSpan; k++ ) {
-				final Column column = columns.get(k);
+				final var column = columns.get(k);
 				keyCols[k] = column.getQuotedName( dialect );
 				keyColReaders[k] = column.getReadExpr( dialect );
 				keyColReaderTemplates[k] = column.getTemplate( dialect, typeConfiguration );
@@ -249,24 +241,24 @@ public class JoinedSubclassEntityPersister extends AbstractEntityPersister {
 		isNullableTable = new boolean[tableSpan];
 		isInverseTable = new boolean[tableSpan];
 
-		final List<Join> joinClosure = persistentClass.getJoinClosure();
+		final var joinClosure = persistentClass.getJoinClosure();
 		for ( int i = 0; i < joinClosure.size(); i++ ) {
-			final Join join = joinClosure.get(i);
+			final var join = joinClosure.get(i);
 			isNullableTable[i] = join.isOptional();
 			isInverseTable[i] = join.isInverse();
 
 			tableNames.add( determineTableName( join.getTable() ) );
 
-			final KeyValue key = join.getKey();
+			final var key = join.getKey();
 			final int joinIdColumnSpan = key.getColumnSpan();
 
 			final String[] keyCols = new String[joinIdColumnSpan];
 			final String[] keyColReaders = new String[joinIdColumnSpan];
 			final String[] keyColReaderTemplates = new String[joinIdColumnSpan];
 
-			final List<Column> columns = key.getColumns();
+			final var columns = key.getColumns();
 			for ( int k = 0; k < joinIdColumnSpan; k++ ) {
-				final Column column = columns.get(k);
+				final var column = columns.get(k);
 				keyCols[k] = column.getQuotedName( dialect );
 				keyColReaders[k] = column.getReadExpr( dialect );
 				keyColReaderTemplates[k] = column.getTemplate( dialect, typeConfiguration );
@@ -282,20 +274,20 @@ public class JoinedSubclassEntityPersister extends AbstractEntityPersister {
 		naturalOrderTableKeyColumns = to2DStringArray( keyColumns );
 		final String[][] naturalOrderTableKeyColumnReaders = to2DStringArray( keyColumnReaders );
 		final String[][] naturalOrderTableKeyColumnReaderTemplates = to2DStringArray( keyColumnReaderTemplates );
-		naturalOrderCascadeDeleteEnabled = ArrayHelper.toBooleanArray( cascadeDeletes );
+		naturalOrderCascadeDeleteEnabled = toBooleanArray( cascadeDeletes );
 
 		final ArrayList<String> subclassTableNames = new ArrayList<>();
 		final ArrayList<Boolean> isConcretes = new ArrayList<>();
 		final ArrayList<Boolean> isNullables = new ArrayList<>();
 
 		final ArrayList<String[]> allKeyColumns = new ArrayList<>();
-		for ( Table table : persistentClass.getSubclassTableClosure() ) {
+		for ( var table : persistentClass.getSubclassTableClosure() ) {
 			isConcretes.add( persistentClass.isClassOrSuperclassTable( table ) );
 			isNullables.add( false );
 			final String tableName = determineTableName( table );
 			subclassTableNames.add( tableName );
 			final String[] key = new String[idColumnSpan];
-			final List<Column> columns = table.getPrimaryKey().getColumnsInOriginalOrder();
+			final var columns = table.getPrimaryKey().getColumnsInOriginalOrder();
 			for ( int k = 0; k < idColumnSpan; k++ ) {
 				key[k] = columns.get(k).getQuotedName( dialect );
 			}
@@ -303,14 +295,14 @@ public class JoinedSubclassEntityPersister extends AbstractEntityPersister {
 		}
 
 		//Add joins
-		for ( Join join : persistentClass.getSubclassJoinClosure() ) {
-			final Table joinTable = join.getTable();
+		for ( var join : persistentClass.getSubclassJoinClosure() ) {
+			final var joinTable = join.getTable();
 			isConcretes.add( persistentClass.isClassOrSuperclassTable( joinTable ) );
 			isNullables.add( join.isOptional() );
 			final String joinTableName = determineTableName( joinTable );
 			subclassTableNames.add( joinTableName );
 			final String[] key = new String[idColumnSpan];
-			final List<Column> columns = joinTable.getPrimaryKey().getColumnsInOriginalOrder();
+			final var columns = joinTable.getPrimaryKey().getColumnsInOriginalOrder();
 			for ( int k = 0; k < idColumnSpan; k++ ) {
 				key[k] = columns.get(k).getQuotedName( dialect );
 			}
@@ -319,8 +311,8 @@ public class JoinedSubclassEntityPersister extends AbstractEntityPersister {
 
 		final String[] naturalOrderSubclassTableNameClosure = toStringArray( subclassTableNames );
 		final String[][] naturalOrderSubclassTableKeyColumnClosure = to2DStringArray( allKeyColumns );
-		isClassOrSuperclassTable = ArrayHelper.toBooleanArray( isConcretes );
-		isNullableSubclassTable = ArrayHelper.toBooleanArray( isNullables );
+		isClassOrSuperclassTable = toBooleanArray( isConcretes );
+		isNullableSubclassTable = toBooleanArray( isNullables );
 
 		constraintOrderedTableNames = new String[naturalOrderSubclassTableNameClosure.length];
 		constraintOrderedKeyColumnNames = new String[naturalOrderSubclassTableNameClosure.length][];
@@ -345,7 +337,7 @@ public class JoinedSubclassEntityPersister extends AbstractEntityPersister {
 		subclassTableNameClosure = reverseFirst( naturalOrderSubclassTableNameClosure, coreTableSpan );
 		subclassTableKeyColumnClosure = reverseFirst( naturalOrderSubclassTableKeyColumnClosure, coreTableSpan );
 
-		spaces = ArrayHelper.join( this.tableNames, toStringArray( persistentClass.getSynchronizedTables() ) );
+		spaces = join( this.tableNames, toStringArray( persistentClass.getSynchronizedTables() ) );
 
 		// Custom sql
 		customSQLInsert = new String[tableSpan];
@@ -386,7 +378,7 @@ public class JoinedSubclassEntityPersister extends AbstractEntityPersister {
 		}
 
 		int j = coreTableSpan;
-		for ( Join join : persistentClass.getJoinClosure() ) {
+		for ( var join : persistentClass.getJoinClosure() ) {
 			isInverseTable[j] = join.isInverse();
 			isNullableTable[j] = join.isOptional();
 
@@ -405,14 +397,16 @@ public class JoinedSubclassEntityPersister extends AbstractEntityPersister {
 			j++;
 		}
 
+		final var sqlStringGenerationContext = creationContext.getSqlStringGenerationContext();
+
 		// PROPERTIES
 		final int hydrateSpan = getPropertySpan();
 		naturalOrderPropertyTableNumbers = new int[hydrateSpan];
-		final List<Property> propertyClosure = persistentClass.getPropertyClosure();
+		final var propertyClosure = persistentClass.getPropertyClosure();
 		for ( int i = 0; i < propertyClosure.size(); i++ ) {
 			final String tableName =
 					propertyClosure.get(i).getValue().getTable()
-							.getQualifiedName( creationContext.getSqlStringGenerationContext() );
+							.getQualifiedName( sqlStringGenerationContext );
 			naturalOrderPropertyTableNumbers[i] = getTableId( tableName, naturalOrderTableNames );
 		}
 
@@ -424,17 +418,16 @@ public class JoinedSubclassEntityPersister extends AbstractEntityPersister {
 		final ArrayList<Integer> propTableNumbers = new ArrayList<>();
 		final ArrayList<String> columns = new ArrayList<>();
 
-		for ( Property property : persistentClass.getSubclassPropertyClosure() ) {
+		for ( var property : persistentClass.getSubclassPropertyClosure() ) {
 			final String tableName = property.getValue().getTable().
-					getQualifiedName( creationContext.getSqlStringGenerationContext() );
+					getQualifiedName( sqlStringGenerationContext );
 			final Integer tableNumber = getTableId( tableName, subclassTableNameClosure );
 			final Integer naturalTableNumber = getTableId( tableName, naturalOrderSubclassTableNameClosure );
 			propTableNumbers.add( tableNumber );
 
-			for ( Selectable selectable : property.getSelectables() ) {
-				if ( !selectable.isFormula() ) {
+			for ( var selectable : property.getSelectables() ) {
+				if ( selectable instanceof Column column ) {
 					columnTableNumbers.add( naturalTableNumber );
-					Column column = (Column) selectable;
 					columns.add( column.getQuotedName( dialect ) );
 				}
 			}
@@ -462,24 +455,30 @@ public class JoinedSubclassEntityPersister extends AbstractEntityPersister {
 			discriminatorValuesByTableName = linkedMapOfSize( subclassSpan + 1 );
 			discriminatorColumnNameByTableName = linkedMapOfSize( subclassSpan + 1 );
 
-			final Table table = persistentClass.getTable();
+			final var table = persistentClass.getTable();
 			discriminatorValues = new String[subclassSpan];
 			discriminatorAbstract = new boolean[subclassSpan];
-			initDiscriminatorProperties( dialect, subclassSpanMinusOne, table, discriminatorValue, isAbstract( persistentClass) );
+			initDiscriminatorProperties(
+					dialect,
+					subclassSpanMinusOne,
+					table,
+					discriminatorValue,
+					isAbstract( persistentClass)
+			);
 
 			notNullColumnTableNumbers = new int[subclassSpan];
 			final int id = getTableId(
-					table.getQualifiedName( creationContext.getSqlStringGenerationContext() ),
+					table.getQualifiedName( sqlStringGenerationContext ),
 					subclassTableNameClosure
 			);
 			notNullColumnTableNumbers[subclassSpanMinusOne] = id;
 			notNullColumnNames = new String[subclassSpan];
 			notNullColumnNames[subclassSpanMinusOne] = subclassTableKeyColumnClosure[id][0];
 
-			final List<Subclass> subclasses = persistentClass.getSubclasses();
+			final var subclasses = persistentClass.getSubclasses();
 			for ( int k = 0; k < subclasses.size(); k++ ) {
-				final Subclass subclass = subclasses.get(k);
-				final Table subclassTable = subclass.getTable();
+				final var subclass = subclasses.get(k);
+				final var subclassTable = subclass.getTable();
 				if ( persistentClass.isPolymorphic() ) {
 					final Object discriminatorValue = explicitDiscriminatorColumnName != null
 							? DiscriminatorHelper.getDiscriminatorValue( subclass )
@@ -490,7 +489,7 @@ public class JoinedSubclassEntityPersister extends AbstractEntityPersister {
 					initDiscriminatorProperties( dialect, k, subclassTable, discriminatorValue, isAbstract( subclass ) );
 					subclassesByDiscriminatorValue.put( discriminatorValue, subclass.getEntityName() );
 					final int tableId = getTableId(
-							subclassTable.getQualifiedName( creationContext.getSqlStringGenerationContext() ),
+							subclassTable.getQualifiedName( sqlStringGenerationContext ),
 							subclassTableNameClosure
 					);
 					notNullColumnTableNumbers[k] = tableId;
@@ -501,7 +500,7 @@ public class JoinedSubclassEntityPersister extends AbstractEntityPersister {
 
 		subclassNamesBySubclassTable = buildSubclassNamesBySubclassTableMapping(
 				persistentClass,
-				creationContext.getSqlStringGenerationContext()
+				sqlStringGenerationContext
 		);
 
 		initSubclassPropertyAliasesMap( persistentClass );
@@ -574,10 +573,11 @@ public class JoinedSubclassEntityPersister extends AbstractEntityPersister {
 		if ( numberOfSubclassTables == 0 ) {
 			return new String[0][];
 		}
-
-		final String[][] mapping = new String[numberOfSubclassTables][];
-		processPersistentClassHierarchy( persistentClass, true, mapping, context );
-		return mapping;
+		else {
+			final String[][] mapping = new String[numberOfSubclassTables][];
+			processPersistentClassHierarchy( persistentClass, true, mapping, context );
+			return mapping;
+		}
 	}
 
 	private Set<String> processPersistentClassHierarchy(
@@ -585,30 +585,22 @@ public class JoinedSubclassEntityPersister extends AbstractEntityPersister {
 			boolean isBase,
 			String[][] mapping,
 			SqlStringGenerationContext context) {
-
-		// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-		// collect all the class names that indicate that the "main table" of the given PersistentClass should be
-		// included when one of the collected class names is used in TREAT
+		// collect all the class names that indicate that the "main table"
+		// of the given PersistentClass should be included when one of the
+		// collected class names is used in TREAT
 		final Set<String> classNames = new HashSet<>();
-
-		for ( Subclass subclass : persistentClass.getDirectSubclasses() ) {
-			final Set<String> subclassSubclassNames =
-					processPersistentClassHierarchy( subclass, false, mapping, context );
-			classNames.addAll( subclassSubclassNames );
+		for ( var subclass : persistentClass.getDirectSubclasses() ) {
+			classNames.addAll( processPersistentClassHierarchy( subclass, false, mapping, context ) );
 		}
-
 		classNames.add( persistentClass.getEntityName() );
-
 		if ( !isBase ) {
-			MappedSuperclass msc = persistentClass.getSuperMappedSuperclass();
-			while ( msc != null ) {
-				classNames.add( msc.getMappedClass().getName() );
-				msc = msc.getSuperMappedSuperclass();
+			var mappedSuperclass = persistentClass.getSuperMappedSuperclass();
+			while ( mappedSuperclass != null ) {
+				classNames.add( mappedSuperclass.getMappedClass().getName() );
+				mappedSuperclass = mappedSuperclass.getSuperMappedSuperclass();
 			}
-
 			associateSubclassNamesToSubclassTableIndexes( persistentClass, classNames, mapping, context );
 		}
-
 		return classNames;
 	}
 
@@ -617,11 +609,9 @@ public class JoinedSubclassEntityPersister extends AbstractEntityPersister {
 			Set<String> classNames,
 			String[][] mapping,
 			SqlStringGenerationContext context) {
-
 		final String tableName = persistentClass.getTable().getQualifiedName( context );
 		associateSubclassNamesToSubclassTableIndex( tableName, classNames, mapping );
-
-		for ( Join join : persistentClass.getJoins() ) {
+		for ( var join : persistentClass.getJoins() ) {
 			final String secondaryTableName = join.getTable().getQualifiedName( context );
 			associateSubclassNamesToSubclassTableIndex( secondaryTableName, classNames, mapping );
 		}
@@ -679,7 +669,7 @@ public class JoinedSubclassEntityPersister extends AbstractEntityPersister {
 			consumer.consume(
 					tableName,
 					tableIndex,
-					() -> (columnConsumer) -> columnConsumer.accept(
+					() -> columnConsumer -> columnConsumer.accept(
 							tableName,
 							getIdentifierMapping(),
 							naturalOrderTableKeyColumns[tableIndex]
@@ -748,22 +738,25 @@ public class JoinedSubclassEntityPersister extends AbstractEntityPersister {
 	@Override
 	public void addDiscriminatorToInsertGroup(MutationGroupBuilder insertGroupBuilder) {
 		if ( explicitDiscriminatorColumnName != null ) {
-			final TableInsertBuilder tableInsertBuilder = insertGroupBuilder.getTableDetailsBuilder( getRootTableName() );
-			final String discriminatorValueToUse;
-			if ( discriminatorValue == NULL_DISCRIMINATOR ) {
-				discriminatorValueToUse = "null";
-			}
-			else if ( discriminatorValue == NOT_NULL_DISCRIMINATOR ) {
-				discriminatorValueToUse = "not null";
-			}
-			else {
-				discriminatorValueToUse = discriminatorSQLString;
-			}
+			final TableInsertBuilder tableInsertBuilder =
+					insertGroupBuilder.getTableDetailsBuilder( getRootTableName() );
 			tableInsertBuilder.addValueColumn(
 					explicitDiscriminatorColumnName,
-					discriminatorValueToUse,
+					getDiscriminatorValueString(),
 					getDiscriminatorMapping().getJdbcMapping()
 			);
+		}
+	}
+
+	private String getDiscriminatorValueString() {
+		if ( discriminatorValue == NULL_DISCRIMINATOR ) {
+			return "null";
+		}
+		else if ( discriminatorValue == NOT_NULL_DISCRIMINATOR ) {
+			return "not null";
+		}
+		else {
+			return discriminatorSQLString;
 		}
 	}
 
@@ -874,31 +867,29 @@ public class JoinedSubclassEntityPersister extends AbstractEntityPersister {
 		if ( treatAsDeclarations == null || treatAsDeclarations.isEmpty() ) {
 			return false;
 		}
-
-		final String[] inclusionSubclassNameClosure = getSubclassNameClosureBySubclassTable( subclassTableNumber );
-
-		// NOTE : we assume the entire hierarchy is joined-subclass here
-		for ( String subclassName : treatAsDeclarations ) {
-			for ( String inclusionSubclassName : inclusionSubclassNameClosure ) {
-				if ( inclusionSubclassName.equals( subclassName ) ) {
-					return true;
+		else {
+			final String[] inclusionSubclassNameClosure =
+					getSubclassNameClosureBySubclassTable( subclassTableNumber );
+			// NOTE: we assume the entire hierarchy is joined-subclass here
+			for ( String subclassName : treatAsDeclarations ) {
+				for ( String inclusionSubclassName : inclusionSubclassNameClosure ) {
+					if ( inclusionSubclassName.equals( subclassName ) ) {
+						return true;
+					}
 				}
 			}
+			return false;
 		}
-
-		return false;
 	}
 
 	private String[] getSubclassNameClosureBySubclassTable(int subclassTableNumber) {
 		final int index = subclassTableNumber - getTableSpan();
-
 		if ( index >= subclassNamesBySubclassTable.length ) {
 			throw new IllegalArgumentException(
 					"Given subclass table number is outside expected range [" + (subclassNamesBySubclassTable.length -1)
 							+ "] as defined by subclassTableNameClosure/subclassClosure"
 			);
 		}
-
 		return subclassNamesBySubclassTable[index];
 	}
 
@@ -917,13 +908,14 @@ public class JoinedSubclassEntityPersister extends AbstractEntityPersister {
 		// HHH-7630: In case the naturalOrder/identifier column is explicitly given in the ordering, check here.
 		for ( int i = 0, max = naturalOrderTableKeyColumns.length; i < max; i++ ) {
 			final String[] keyColumns = naturalOrderTableKeyColumns[i];
-			if ( ArrayHelper.contains( keyColumns, columnName ) ) {
+			if ( contains( keyColumns, columnName ) ) {
 				return naturalOrderPropertyTableNumbers[i];
 			}
 		}
 
-		for (int i = 0, max = subclassColumnClosure.length; i < max; i++ ) {
-			final boolean quoted = subclassColumnClosure[i].startsWith( "\"" )
+		for ( int i = 0, max = subclassColumnClosure.length; i < max; i++ ) {
+			final boolean quoted =
+					subclassColumnClosure[i].startsWith( "\"" )
 					&& subclassColumnClosure[i].endsWith( "\"" );
 			if ( quoted ) {
 				if ( subclassColumnClosure[i].equals( columnName ) ) {
@@ -943,10 +935,10 @@ public class JoinedSubclassEntityPersister extends AbstractEntityPersister {
 
 	@Override
 	public Object forceVersionIncrement(Object id, Object currentVersion, SharedSessionContractImplementor session) {
-		if ( getSuperMappingType() != null ) {
-			return getSuperMappingType().getEntityPersister().forceVersionIncrement( id, currentVersion, session );
-		}
-		return super.forceVersionIncrement( id, currentVersion, session );
+		final var superMappingType = getSuperMappingType();
+		return superMappingType != null
+				? superMappingType.getEntityPersister().forceVersionIncrement( id, currentVersion, session )
+				: super.forceVersionIncrement( id, currentVersion, session );
 	}
 
 	@Override
@@ -955,10 +947,10 @@ public class JoinedSubclassEntityPersister extends AbstractEntityPersister {
 			Object currentVersion,
 			boolean batching,
 			SharedSessionContractImplementor session) throws HibernateException {
-		if ( getSuperMappingType() != null ) {
-			return getSuperMappingType().getEntityPersister().forceVersionIncrement( id, currentVersion, session );
-		}
-		return super.forceVersionIncrement( id, currentVersion, batching, session );
+		final var superMappingType = getSuperMappingType();
+		return superMappingType != null
+				? superMappingType.getEntityPersister().forceVersionIncrement( id, currentVersion, session )
+				: super.forceVersionIncrement( id, currentVersion, batching, session );
 	}
 
 	@Override
@@ -971,8 +963,7 @@ public class JoinedSubclassEntityPersister extends AbstractEntityPersister {
 		}
 		else {
 			if ( getTableName().equals( getVersionedTableName() ) ) {
-				final int versionPropertyIndex = getVersionProperty();
-				final String versionPropertyName = getPropertyNames()[versionPropertyIndex];
+				final String versionPropertyName = getPropertyNames()[getVersionProperty()];
 				return creationProcess.processSubPart(
 						versionPropertyName,
 						(role, process) -> generateVersionMapping(
@@ -993,40 +984,32 @@ public class JoinedSubclassEntityPersister extends AbstractEntityPersister {
 	@Override
 	protected EntityIdentifierMapping generateIdentifierMapping(
 			Supplier<?> templateInstanceCreator,
-			PersistentClass bootEntityDescriptor,
+			PersistentClass persistentClass,
 			MappingModelCreationProcess creationProcess) {
 		final Type idType = getIdentifierType();
-
-		if ( idType instanceof CompositeType cidType ) {
-
-			// NOTE: the term `isEmbedded` here uses Hibernate's older (pre-JPA) naming for its "non-aggregated"
-			// composite-id support.  It unfortunately conflicts with the JPA usage of "embedded".  Here we normalize
-			// the legacy naming to the more descriptive encapsulated versus non-encapsulated phrasing
-
-			final boolean encapsulated = ! cidType.isEmbedded();
-			if ( encapsulated ) {
-				// we have an `@EmbeddedId`
-				return buildEncapsulatedCompositeIdentifierMapping(
-						this,
-						bootEntityDescriptor.getIdentifierProperty(),
-						bootEntityDescriptor.getIdentifierProperty().getName(),
-						getTableName(),
-						tableKeyColumns[0],
-						cidType,
-						creationProcess
-				);
-			}
-
-			// otherwise we have a non-encapsulated composite-identifier
-			return generateNonEncapsulatedCompositeIdentifierMapping( creationProcess, bootEntityDescriptor );
+		if ( idType instanceof CompositeType compositeIdType ) {
+			return compositeIdentifierMapping( persistentClass, creationProcess, compositeIdType );
 		}
+		else if ( idType instanceof BasicType<?> basicIdType ) {
+			return basicIdentifierMapping( templateInstanceCreator, persistentClass, creationProcess, basicIdType );
+		}
+		else {
+			throw new AssertionFailure( "Unrecognized id type" );
+		}
+	}
 
+	private BasicEntityIdentifierMappingImpl basicIdentifierMapping(
+			Supplier<?> templateInstanceCreator,
+			PersistentClass persistentClass,
+			MappingModelCreationProcess creationProcess,
+			BasicType<?> idType) {
+		final var identifier = persistentClass.getIdentifier();
 		final String columnDefinition;
 		final Long length;
 		final Integer arrayLength;
 		final Integer precision;
 		final Integer scale;
-		if ( bootEntityDescriptor.getIdentifier() == null ) {
+		if ( identifier == null ) {
 			columnDefinition = null;
 			length = null;
 			arrayLength = null;
@@ -1034,18 +1017,19 @@ public class JoinedSubclassEntityPersister extends AbstractEntityPersister {
 			scale = null;
 		}
 		else {
-			final Column column = bootEntityDescriptor.getIdentifier().getColumns().get( 0 );
+			final var column = identifier.getColumns().get( 0 );
 			columnDefinition = column.getSqlType();
 			length = column.getLength();
 			arrayLength = column.getArrayLength();
 			precision = column.getPrecision();
 			scale = column.getScale();
 		}
-		final Value value = bootEntityDescriptor.getIdentifierProperty().getValue();
+		final var identifierProperty = persistentClass.getIdentifierProperty();
+		final var value = identifierProperty.getValue();
 		return new BasicEntityIdentifierMappingImpl(
 				this,
 				templateInstanceCreator,
-				bootEntityDescriptor.getIdentifierProperty().getName(),
+				identifierProperty.getName(),
 				getTableName(),
 				tableKeyColumns[0][0],
 				columnDefinition,
@@ -1055,9 +1039,37 @@ public class JoinedSubclassEntityPersister extends AbstractEntityPersister {
 				scale,
 				value.isColumnInsertable( 0 ),
 				value.isColumnUpdateable( 0 ),
-				(BasicType<?>) idType,
+				idType,
 				creationProcess
 		);
+	}
+
+	private EntityIdentifierMapping compositeIdentifierMapping(
+			PersistentClass persistentClass,
+			MappingModelCreationProcess creationProcess,
+			CompositeType compositeIdType) {
+		// NOTE: the term `isEmbedded` here uses Hibernate's older (pre-JPA) naming for its
+		//       "non-aggregated" composite-id support. It unfortunately conflicts with the
+		//       JPA usage of "embedded".  Here we normalize the legacy naming to the more
+		//       descriptive encapsulated versus non-encapsulated phrasing
+		final boolean encapsulated = !compositeIdType.isEmbedded();
+		if ( encapsulated ) {
+			// we have an `@EmbeddedId`
+			final var identifierProperty = persistentClass.getIdentifierProperty();
+			return buildEncapsulatedCompositeIdentifierMapping(
+					this,
+					identifierProperty,
+					identifierProperty.getName(),
+					getTableName(),
+					tableKeyColumns[0],
+					compositeIdType,
+					creationProcess
+			);
+		}
+		else {
+			// otherwise we have a non-encapsulated composite-identifier
+			return generateNonEncapsulatedCompositeIdentifierMapping( creationProcess, persistentClass );
+		}
 	}
 
 	@Override
@@ -1067,7 +1079,7 @@ public class JoinedSubclassEntityPersister extends AbstractEntityPersister {
 
 	@Override
 	protected EntityDiscriminatorMapping generateDiscriminatorMapping(PersistentClass bootEntityDescriptor) {
-		final EntityMappingType superMappingType = getSuperMappingType();
+		final var superMappingType = getSuperMappingType();
 		if ( superMappingType != null ) {
 			return superMappingType.getDiscriminatorMapping();
 		}
@@ -1102,7 +1114,6 @@ public class JoinedSubclassEntityPersister extends AbstractEntityPersister {
 			MappingModelCreationProcess creationProcess,
 			PersistentClass bootEntityDescriptor) {
 		assert declaredAttributeMappings != null;
-
 		return buildNonEncapsulatedCompositeIdentifierMapping(
 				this,
 				getTableName(),
@@ -1134,7 +1145,7 @@ public class JoinedSubclassEntityPersister extends AbstractEntityPersister {
 	@Override
 	public void pruneForSubclasses(TableGroup tableGroup, Map<String, EntityNameUse> entityNameUses) {
 		final Set<TableReference> retainedTableReferences = new HashSet<>( entityNameUses.size() );
-		final MappingMetamodelImplementor metamodel = getFactory().getMappingMetamodel();
+		final var metamodel = getFactory().getMappingMetamodel();
 		// We can only do this optimization if the table group reports canUseInnerJoins or isRealTableGroup,
 		// because the switch for table reference joins to INNER must be cardinality preserving.
 		// If canUseInnerJoins is true, this is trivially given, but also if the table group is real
@@ -1142,61 +1153,21 @@ public class JoinedSubclassEntityPersister extends AbstractEntityPersister {
 		final boolean innerJoinOptimization = tableGroup.canUseInnerJoins() || tableGroup.isRealTableGroup();
 		final Set<String> tablesToInnerJoin = innerJoinOptimization ? new HashSet<>() : null;
 		boolean needsTreatDiscriminator = false;
-		for ( Map.Entry<String, EntityNameUse> entry : entityNameUses.entrySet() ) {
-			final EntityNameUse.UseKind useKind = entry.getValue().getKind();
-			final JoinedSubclassEntityPersister persister =
-					(JoinedSubclassEntityPersister) metamodel.findEntityDescriptor( entry.getKey() );
+		for ( var entry : entityNameUses.entrySet() ) {
+			final var useKind = entry.getValue().getKind();
+			final var persister = (JoinedSubclassEntityPersister) metamodel.findEntityDescriptor( entry.getKey() );
 			// The following block tries to figure out what can be inner joined and which super class table joins can be omitted
-			if ( innerJoinOptimization && ( useKind == EntityNameUse.UseKind.TREAT || useKind == EntityNameUse.UseKind.FILTER ) ) {
-				final String[] subclassTableNames = persister.getSubclassTableNames();
-				// Build the intersection of all tables names that are of the class or super class
-				// These are the tables that can be safely inner joined
-				final Set<String> classOrSuperclassTables = new HashSet<>( subclassTableNames.length );
-				for ( int i = 0; i < subclassTableNames.length; i++ ) {
-					if ( persister.isClassOrSuperclassTable[i] ) {
-						classOrSuperclassTables.add( subclassTableNames[i] );
-					}
-				}
-				if ( tablesToInnerJoin.isEmpty() ) {
-					tablesToInnerJoin.addAll( classOrSuperclassTables );
-				}
-				else {
-					tablesToInnerJoin.retainAll( classOrSuperclassTables );
-				}
-				if ( useKind == EntityNameUse.UseKind.FILTER && explicitDiscriminatorColumnName == null ) {
-					// If there is no discriminator column,
-					// we must retain all joins to subclass tables to be able to discriminate the rows
-					for ( int i = 0; i < subclassTableNames.length; i++ ) {
-						if ( !persister.isClassOrSuperclassTable[i] ) {
-							final String subclassTableName = subclassTableNames[i];
-							final TableReference mainTableReference = tableGroup.getTableReference(
-									null,
-									subclassTableName,
-									false
-							);
-							if ( mainTableReference == null ) {
-								throw new UnknownTableReferenceException(
-										subclassTableName,
-										"Couldn't find table reference"
-								);
-							}
-							retainedTableReferences.add( mainTableReference );
-						}
-					}
-				}
+			if ( innerJoinOptimization ) {
+				optimizeInnerJoins( tableGroup, useKind, persister, tablesToInnerJoin, retainedTableReferences );
 			}
 			final String tableName = persister.getTableName();
-			final TableReference mainTableReference = tableGroup.getTableReference(
-					null,
-					tableName,
-					false
-			);
+			final var mainTableReference = tableGroup.getTableReference( null, tableName, false );
 			if ( mainTableReference != null ) {
 				retainedTableReferences.add( mainTableReference );
 			}
 			final String sqlWhereStringTableExpression = persister.getSqlWhereStringTableExpression();
 			if ( sqlWhereStringTableExpression != null ) {
-				final TableReference tableReference = tableGroup.getTableReference( sqlWhereStringTableExpression );
+				final var tableReference = tableGroup.getTableReference( sqlWhereStringTableExpression );
 				if ( tableReference != null ) {
 					retainedTableReferences.add( tableReference );
 				}
@@ -1219,13 +1190,14 @@ public class JoinedSubclassEntityPersister extends AbstractEntityPersister {
 			}
 		}
 
-		final List<TableReferenceJoin> tableReferenceJoins = tableGroup.getTableReferenceJoins();
+		final var tableReferenceJoins = tableGroup.getTableReferenceJoins();
 		if ( needsTreatDiscriminator ) {
 			if ( tableReferenceJoins.isEmpty() ) {
 				// We need to apply the discriminator predicate to the primary table reference itself
-				final String discriminatorPredicate = getPrunedDiscriminatorPredicate( entityNameUses, metamodel, "t" );
+				final String discriminatorPredicate =
+						getPrunedDiscriminatorPredicate( entityNameUses, metamodel, "t" );
 				if ( discriminatorPredicate != null ) {
-					final NamedTableReference tableReference = (NamedTableReference) tableGroup.getPrimaryTableReference();
+					final var tableReference = (NamedTableReference) tableGroup.getPrimaryTableReference();
 					tableReference.setPrunedTableExpression( "(select * from " + getRootTableName() + " t where " + discriminatorPredicate + ")" );
 				}
 			}
@@ -1239,7 +1211,7 @@ public class JoinedSubclassEntityPersister extends AbstractEntityPersister {
 				);
 				int i = 0;
 				for ( ; !applied && i < tableReferenceJoins.size(); i++ ) {
-					final TableReferenceJoin join = tableReferenceJoins.get( i );
+					final var join = tableReferenceJoins.get( i );
 					applied = applyDiscriminatorPredicate( join, join.getJoinedTableReference(), entityNameUses, metamodel );
 				}
 				assert applied : "Could not apply treat discriminator predicate to root table join";
@@ -1249,36 +1221,79 @@ public class JoinedSubclassEntityPersister extends AbstractEntityPersister {
 				}
 			}
 		}
-		if ( tableReferenceJoins.isEmpty() ) {
-			return;
-		}
-		// The optimization is to remove all table reference joins that are not contained in the retainedTableReferences
-		// In addition, we switch from a possible LEFT join, to an INNER join for all tablesToInnerJoin
-		if ( innerJoinOptimization ) {
-			final TableReferenceJoin[] oldJoins = tableReferenceJoins.toArray( new TableReferenceJoin[0] );
-			tableReferenceJoins.clear();
-			for ( TableReferenceJoin oldJoin : oldJoins ) {
-				final NamedTableReference joinedTableReference = oldJoin.getJoinedTableReference();
-				if ( retainedTableReferences.contains( joinedTableReference ) ) {
-					final TableReferenceJoin join = oldJoin.getJoinType() != SqlAstJoinType.INNER
-								&& tablesToInnerJoin.contains( joinedTableReference.getTableExpression() )
-							? new TableReferenceJoin( true, joinedTableReference, oldJoin.getPredicate() )
-							: oldJoin;
-					tableReferenceJoins.add( join );
-				}
-				else {
-					for ( int i = subclassCoreTableSpan; i < subclassTableNameClosure.length; i++ ) {
-						if ( joinedTableReference.getTableExpression().equals( subclassTableNameClosure[i] ) ) {
-							// Retain joins to secondary tables
-							tableReferenceJoins.add( oldJoin );
-							break;
+		if ( !tableReferenceJoins.isEmpty() ) {
+			// The optimization is to remove all table reference joins that are not contained in the retainedTableReferences
+			// In addition, we switch from a possible LEFT join, to an INNER join for all tablesToInnerJoin
+			if ( innerJoinOptimization ) {
+				final var oldJoins = tableReferenceJoins.toArray( new TableReferenceJoin[0] );
+				tableReferenceJoins.clear();
+				for ( var oldJoin : oldJoins ) {
+					final var joinedTableReference = oldJoin.getJoinedTableReference();
+					if ( retainedTableReferences.contains( joinedTableReference ) ) {
+						final var join =
+								oldJoin.getJoinType() != SqlAstJoinType.INNER
+									&& tablesToInnerJoin.contains( joinedTableReference.getTableExpression() )
+										? new TableReferenceJoin( true, joinedTableReference, oldJoin.getPredicate() )
+										: oldJoin;
+						tableReferenceJoins.add( join );
+					}
+					else {
+						for ( int i = subclassCoreTableSpan; i < subclassTableNameClosure.length; i++ ) {
+							if ( joinedTableReference.getTableExpression().equals( subclassTableNameClosure[i] ) ) {
+								// Retain joins to secondary tables
+								tableReferenceJoins.add( oldJoin );
+								break;
+							}
 						}
 					}
 				}
 			}
+			else {
+				tableReferenceJoins.removeIf( join -> !retainedTableReferences.contains( join.getJoinedTableReference() ) );
+			}
 		}
-		else {
-			tableReferenceJoins.removeIf( join -> !retainedTableReferences.contains( join.getJoinedTableReference() ) );
+	}
+
+	private void optimizeInnerJoins(
+			TableGroup tableGroup,
+			EntityNameUse.UseKind useKind,
+			JoinedSubclassEntityPersister persister,
+			Set<String> tablesToInnerJoin,
+			Set<TableReference> retainedTableReferences) {
+		if ( useKind == EntityNameUse.UseKind.TREAT || useKind == EntityNameUse.UseKind.FILTER ) {
+			final String[] subclassTableNames = persister.getSubclassTableNames();
+			// Build the intersection of all tables names that are of the class or super class
+			// These are the tables that can be safely inner joined
+			final Set<String> classOrSuperclassTables = new HashSet<>( subclassTableNames.length );
+			for ( int i = 0; i < subclassTableNames.length; i++ ) {
+				if ( persister.isClassOrSuperclassTable[i] ) {
+					classOrSuperclassTables.add( subclassTableNames[i] );
+				}
+			}
+			if ( tablesToInnerJoin.isEmpty() ) {
+				tablesToInnerJoin.addAll( classOrSuperclassTables );
+			}
+			else {
+				tablesToInnerJoin.retainAll( classOrSuperclassTables );
+			}
+			if ( useKind == EntityNameUse.UseKind.FILTER && explicitDiscriminatorColumnName == null ) {
+				// If there is no discriminator column,
+				// we must retain all joins to subclass tables to be able to discriminate the rows
+				for ( int i = 0; i < subclassTableNames.length; i++ ) {
+					if ( !persister.isClassOrSuperclassTable[i] ) {
+						final String subclassTableName = subclassTableNames[i];
+						final var mainTableReference =
+								tableGroup.getTableReference( null, subclassTableName, false );
+						if ( mainTableReference == null ) {
+							throw new UnknownTableReferenceException(
+									subclassTableName,
+									"Couldn't find table reference"
+							);
+						}
+						retainedTableReferences.add( mainTableReference );
+					}
+				}
+			}
 		}
 	}
 
@@ -1297,11 +1312,8 @@ public class JoinedSubclassEntityPersister extends AbstractEntityPersister {
 			Map<String, EntityNameUse> entityNameUses,
 			MappingMetamodelImplementor metamodel) {
 		if ( tableReference.getTableExpression().equals( getRootTableName() ) ) {
-			final String discriminatorPredicate = getPrunedDiscriminatorPredicate(
-					entityNameUses,
-					metamodel,
-					"t"
-			);
+			final String discriminatorPredicate =
+					getPrunedDiscriminatorPredicate( entityNameUses, metamodel, "t" );
 			// null means we're filtering for all subtypes, so we don't need to apply a predicate
 			if ( discriminatorPredicate != null ) {
 				assert join.getJoinType() == SqlAstJoinType.INNER : "Found table reference join with root table of non-INNER type: " + join.getJoinType();

--- a/hibernate-core/src/main/java/org/hibernate/persister/entity/JoinedSubclassEntityPersister.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/entity/JoinedSubclassEntityPersister.java
@@ -963,7 +963,7 @@ public class JoinedSubclassEntityPersister extends AbstractEntityPersister {
 		}
 		else {
 			if ( getTableName().equals( getVersionedTableName() ) ) {
-				final String versionPropertyName = getPropertyNames()[getVersionProperty()];
+				final String versionPropertyName = getPropertyNames()[this.getVersionPropertyIndex()];
 				return creationProcess.processSubPart(
 						versionPropertyName,
 						(role, process) -> generateVersionMapping(

--- a/hibernate-core/src/main/java/org/hibernate/persister/entity/SingleTableEntityPersister.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/entity/SingleTableEntityPersister.java
@@ -6,39 +6,32 @@ package org.hibernate.persister.entity;
 
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 
+import org.hibernate.AssertionFailure;
 import org.hibernate.HibernateException;
 import org.hibernate.Internal;
 import org.hibernate.MappingException;
 import org.hibernate.Remove;
 import org.hibernate.cache.spi.access.EntityDataAccess;
 import org.hibernate.cache.spi.access.NaturalIdDataAccess;
-import org.hibernate.dialect.Dialect;
 import org.hibernate.internal.DynamicFilterAliasGenerator;
 import org.hibernate.internal.FilterAliasGenerator;
-import org.hibernate.internal.util.collections.ArrayHelper;
 import org.hibernate.jdbc.Expectation;
 import org.hibernate.mapping.Column;
 import org.hibernate.mapping.Formula;
-import org.hibernate.mapping.Join;
 import org.hibernate.mapping.PersistentClass;
-import org.hibernate.mapping.Property;
-import org.hibernate.mapping.Selectable;
-import org.hibernate.mapping.Subclass;
-import org.hibernate.mapping.Table;
-import org.hibernate.mapping.Value;
+import org.hibernate.metamodel.MappingMetamodel;
 import org.hibernate.metamodel.mapping.TableDetails;
-import org.hibernate.metamodel.spi.MappingMetamodelImplementor;
 import org.hibernate.metamodel.spi.RuntimeModelCreationContext;
 import org.hibernate.sql.ast.tree.from.NamedTableReference;
 import org.hibernate.sql.ast.tree.from.TableGroup;
 import org.hibernate.sql.model.ast.builder.MutationGroupBuilder;
 import org.hibernate.sql.model.ast.builder.TableInsertBuilder;
 import org.hibernate.type.BasicType;
-import org.hibernate.type.spi.TypeConfiguration;
 
+import static org.hibernate.internal.util.collections.ArrayHelper.indexOf;
+import static org.hibernate.internal.util.collections.ArrayHelper.join;
 import static org.hibernate.internal.util.collections.ArrayHelper.to2DStringArray;
 import static org.hibernate.internal.util.collections.ArrayHelper.toBooleanArray;
 import static org.hibernate.internal.util.collections.ArrayHelper.toIntArray;
@@ -115,8 +108,8 @@ public class SingleTableEntityPersister extends AbstractEntityPersister {
 			final RuntimeModelCreationContext creationContext) throws HibernateException {
 		super( persistentClass, cacheAccessStrategy, naturalIdRegionAccessStrategy, creationContext );
 
-		final Dialect dialect = creationContext.getDialect();
-		final TypeConfiguration typeConfiguration = creationContext.getTypeConfiguration();
+		final var dialect = creationContext.getDialect();
+		final var typeConfiguration = creationContext.getTypeConfiguration();
 
 		// CLASS + TABLE
 
@@ -124,9 +117,7 @@ public class SingleTableEntityPersister extends AbstractEntityPersister {
 		// todo (6.2) : see note on AbstractEntityPersister#getTableName(int)
 		qualifiedTableNames = new String[joinSpan];
 
-		final Table table = persistentClass.getRootTable();
-		final String rootTableName = determineTableName( table );
-		qualifiedTableNames[0] = rootTableName;
+		qualifiedTableNames[0] = determineTableName( persistentClass.getRootTable() );
 
 		isInverseTable = new boolean[joinSpan];
 		isNullableTable = new boolean[joinSpan];
@@ -163,13 +154,13 @@ public class SingleTableEntityPersister extends AbstractEntityPersister {
 
 		// JOINS
 
-		final List<Join> joinClosure = persistentClass.getJoinClosure();
+		final var joinClosure = persistentClass.getJoinClosure();
 		boolean hasDuplicateTableName = false;
 		for ( int j = 1; j - 1 < joinClosure.size(); j++ ) {
-			Join join = joinClosure.get( j - 1 );
+			final var join = joinClosure.get( j - 1 );
 			qualifiedTableNames[j] = determineTableName( join.getTable() );
 			hasDuplicateTableName = hasDuplicateTableName
-					|| ArrayHelper.indexOf( qualifiedTableNames, j, qualifiedTableNames[j] ) != -1;
+					|| indexOf( qualifiedTableNames, j, qualifiedTableNames[j] ) != -1;
 			isInverseTable[j] = join.isInverse();
 			isNullableTable[j] = join.isOptional();
 			cascadeDeleteEnabled[j] = join.getKey().isCascadeDeleteEnabled() && dialect.supportsCascadeDelete();
@@ -188,7 +179,7 @@ public class SingleTableEntityPersister extends AbstractEntityPersister {
 
 			keyColumnNames[j] = new String[join.getKey().getColumnSpan()];
 
-			final List<Column> columns = join.getKey().getColumns();
+			final var columns = join.getKey().getColumns();
 			for ( int i = 0; i < columns.size(); i++ ) {
 				keyColumnNames[j][i] = columns.get( i ).getQuotedName( dialect );
 			}
@@ -202,7 +193,7 @@ public class SingleTableEntityPersister extends AbstractEntityPersister {
 			constraintOrderedKeyColumnNames[position] = keyColumnNames[i];
 		}
 
-		spaces = ArrayHelper.join( qualifiedTableNames, toStringArray( persistentClass.getSynchronizedTables() ) );
+		spaces = join( qualifiedTableNames, toStringArray( persistentClass.getSynchronizedTables() ) );
 
 		final ArrayList<String> subclassTables = new ArrayList<>();
 		final ArrayList<String[]> joinKeyColumns = new ArrayList<>();
@@ -214,16 +205,15 @@ public class SingleTableEntityPersister extends AbstractEntityPersister {
 		isConcretes.add( true );
 		isClassOrSuperclassJoins.add( true );
 		isNullables.add( false );
-		for ( Join join : persistentClass.getSubclassJoinClosure() ) {
+		for ( var join : persistentClass.getSubclassJoinClosure() ) {
 			isConcretes.add( persistentClass.isClassOrSuperclassTable( join.getTable() ) );
 			isClassOrSuperclassJoins.add( persistentClass.isClassOrSuperclassJoin( join ) );
 			isNullables.add( join.isOptional() );
 
-			final String joinTableName = determineTableName( join.getTable() );
-			subclassTables.add( joinTableName );
+			subclassTables.add( determineTableName( join.getTable() ) );
 
 			final String[] keyCols = new String[join.getKey().getColumnSpan()];
-			final List<Column> columns = join.getKey().getColumns();
+			final var columns = join.getKey().getColumns();
 			for ( int i = 0; i < columns.size(); i++ ) {
 				keyCols[i] = columns.get( i ).getQuotedName( dialect );
 			}
@@ -239,31 +229,32 @@ public class SingleTableEntityPersister extends AbstractEntityPersister {
 		// DISCRIMINATOR
 
 		if ( persistentClass.isPolymorphic() ) {
-			final Value discriminator = persistentClass.getDiscriminator();
+			final var discriminator = persistentClass.getDiscriminator();
 			if ( discriminator == null ) {
 				throw new MappingException( "discriminator mapping required for single table polymorphic persistence" );
 			}
 			forceDiscriminator = persistentClass.isForceDiscriminator();
-			final Selectable selectable = discriminator.getSelectables().get( 0 );
+			final var selectable = discriminator.getSelectables().get( 0 );
 			discriminatorType = DiscriminatorHelper.getDiscriminatorType( persistentClass );
 			discriminatorValue = DiscriminatorHelper.getDiscriminatorValue( persistentClass );
 			discriminatorSQLValue = DiscriminatorHelper.getDiscriminatorSQLValue( persistentClass, dialect );
 			discriminatorInsertable = isDiscriminatorInsertable( persistentClass );
-			if ( discriminator.hasFormula() ) {
-				final Formula formula = (Formula) selectable;
+			if ( selectable instanceof Formula formula ) {
 				discriminatorFormulaTemplate = formula.getTemplate( dialect, typeConfiguration );
 				discriminatorColumnName = null;
 				discriminatorColumnReaders = null;
 				discriminatorColumnReaderTemplate = null;
 				discriminatorAlias = "clazz_";
 			}
-			else {
-				final Column column = (Column) selectable;
+			else if ( selectable instanceof Column column ) {
 				discriminatorColumnName = column.getQuotedName( dialect );
 				discriminatorColumnReaders = column.getReadExpr( dialect );
 				discriminatorColumnReaderTemplate = column.getTemplate( dialect, typeConfiguration );
 				discriminatorAlias = column.getAlias( dialect, persistentClass.getRootTable() );
 				discriminatorFormulaTemplate = null;
+			}
+			else {
+				throw new AssertionFailure( "Unrecognized selectable" );
 			}
 		}
 		else {
@@ -282,7 +273,7 @@ public class SingleTableEntityPersister extends AbstractEntityPersister {
 		// PROPERTIES
 
 		propertyTableNumbers = new int[getPropertySpan()];
-		final List<Property> propertyClosure = persistentClass.getPropertyClosure();
+		final var propertyClosure = persistentClass.getPropertyClosure();
 		for ( int k = 0; k < propertyClosure.size(); k++ ) {
 			propertyTableNumbers[k] = persistentClass.getJoinNumber( propertyClosure.get( k ) );
 		}
@@ -292,7 +283,7 @@ public class SingleTableEntityPersister extends AbstractEntityPersister {
 		final ArrayList<Integer> propertyJoinNumbers = new ArrayList<>();
 		final Map<Object, String> subclassesByDiscriminatorValueLocal = new HashMap<>();
 
-		for ( Property property : persistentClass.getSubclassPropertyClosure() ) {
+		for ( var property : persistentClass.getSubclassPropertyClosure() ) {
 			propertyJoinNumbers.add( persistentClass.getJoinNumber( property ) );
 		}
 
@@ -309,14 +300,13 @@ public class SingleTableEntityPersister extends AbstractEntityPersister {
 			);
 
 			// SUBCLASSES
-			final List<Subclass> subclasses = persistentClass.getSubclasses();
+			final var subclasses = persistentClass.getSubclasses();
 			for ( int k = 0; k < subclasses.size(); k++ ) {
-				Subclass subclass = subclasses.get( k );
+				final var subclass = subclasses.get( k );
 				subclassClosure[k] = subclass.getEntityName();
-				Object subclassDiscriminatorValue = DiscriminatorHelper.getDiscriminatorValue( subclass );
 				addSubclassByDiscriminatorValue(
 						subclassesByDiscriminatorValueLocal,
-						subclassDiscriminatorValue,
+						DiscriminatorHelper.getDiscriminatorValue( subclass ),
 						subclass.getEntityName()
 				);
 			}
@@ -478,7 +468,8 @@ public class SingleTableEntityPersister extends AbstractEntityPersister {
 	@Override
 	public void addDiscriminatorToInsertGroup(MutationGroupBuilder insertGroupBuilder) {
 		if ( discriminatorInsertable ) {
-			final TableInsertBuilder tableInsertBuilder = insertGroupBuilder.getTableDetailsBuilder( getRootTableName() );
+			final TableInsertBuilder tableInsertBuilder =
+					insertGroupBuilder.getTableDetailsBuilder( getRootTableName() );
 			tableInsertBuilder.addValueColumn(
 					discriminatorColumnName,
 					discriminatorValue == NULL_DISCRIMINATOR ? NULL : discriminatorSQLValue,
@@ -559,40 +550,39 @@ public class SingleTableEntityPersister extends AbstractEntityPersister {
 
 	@Override
 	public void pruneForSubclasses(TableGroup tableGroup, Map<String, EntityNameUse> entityNameUses) {
-		if ( !needsDiscriminator() && entityNameUses.isEmpty() ) {
-			return;
-		}
-		// The following optimization is to add the discriminator filter fragment for all treated entity names
-		final MappingMetamodelImplementor mappingMetamodel = getFactory().getMappingMetamodel();
-
-		boolean containsTreatUse = false;
-		for ( Map.Entry<String, EntityNameUse> entry : entityNameUses.entrySet() ) {
-			final EntityNameUse.UseKind useKind = entry.getValue().getKind();
-			if ( useKind == EntityNameUse.UseKind.PROJECTION || useKind == EntityNameUse.UseKind.EXPRESSION ) {
-				// We only care about treat and filter uses which allow to reduce the amount of rows to select
-				continue;
+		if ( needsDiscriminator() || !entityNameUses.isEmpty() ) {// The following optimization is to add the discriminator filter fragment for all treated entity names
+			final var mappingMetamodel = getFactory().getMappingMetamodel();
+			if ( containsTreatUse( entityNameUses, mappingMetamodel ) ) {
+				final String discriminatorPredicate =
+						getPrunedDiscriminatorPredicate( entityNameUses, mappingMetamodel, "t" );
+				if ( discriminatorPredicate != null ) {
+					final var tableReference = (NamedTableReference) tableGroup.getPrimaryTableReference();
+					tableReference.setPrunedTableExpression(
+							"(select * from " + getTableName() + " t where " + discriminatorPredicate + ")" );
+				}
 			}
-			final EntityPersister persister = mappingMetamodel.getEntityDescriptor( entry.getKey() );
-			// Filtering for abstract entities makes no sense, so ignore that
-			// Also, it makes no sense to filter for any of the super types,
-			// as the query will contain a filter for that already anyway
-			if ( useKind == EntityNameUse.UseKind.TREAT && !persister.isAbstract()
-					&& ( getSuperMappingType() == null || !getSuperMappingType().isTypeOrSuperType( persister ) ) ) {
-				containsTreatUse = true;
-				break;
+			// Otherwise, if we only have FILTER uses, we don't have to do anything here because
+			// the BaseSqmToSqlAstConverter will already apply the type filter in the WHERE clause
+		}
+	}
+
+	private boolean containsTreatUse(Map<String, EntityNameUse> entityNameUses, MappingMetamodel metamodel) {
+		for ( var entry : entityNameUses.entrySet() ) {
+			// We only care about treat uses which allow to reduce the amount of rows to select
+			if ( entry.getValue().getKind() == EntityNameUse.UseKind.TREAT ) {
+				final var persister = metamodel.getEntityDescriptor( entry.getKey() );
+				// Filtering for abstract entities makes no sense, so ignore that
+				if ( !persister.isAbstract() ) {
+					// Also, it makes no sense to filter for any of the super types,
+					// as the query will contain a filter for that already anyway
+					final var superMappingType = getSuperMappingType();
+					if ( superMappingType == null || !getSuperMappingType().isTypeOrSuperType( persister ) ) {
+						return true;
+					}
+				}
 			}
 		}
-		if ( !containsTreatUse ) {
-			// If we only have FILTER uses, we don't have to do anything here,
-			// because the BaseSqmToSqlAstConverter will already apply the type filter in the WHERE clause
-			return;
-		}
-
-		final String discriminatorPredicate = getPrunedDiscriminatorPredicate( entityNameUses, mappingMetamodel, "t" );
-		if ( discriminatorPredicate != null ) {
-			final NamedTableReference tableReference = (NamedTableReference) tableGroup.getPrimaryTableReference();
-			tableReference.setPrunedTableExpression( "(select * from " + getTableName() + " t where " + discriminatorPredicate + ")" );
-		}
+		return false;
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/persister/entity/mutation/InsertCoordinatorStandard.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/entity/mutation/InsertCoordinatorStandard.java
@@ -38,7 +38,6 @@ import org.hibernate.sql.model.ast.builder.MutationGroupBuilder;
 import org.hibernate.sql.model.ast.builder.TableInsertBuilder;
 import org.hibernate.sql.model.ast.builder.TableInsertBuilderStandard;
 import org.hibernate.sql.model.ast.builder.TableMutationBuilder;
-import org.hibernate.tuple.entity.EntityMetamodel;
 
 import org.checkerframework.checker.nullness.qual.Nullable;
 
@@ -67,7 +66,7 @@ public class InsertCoordinatorStandard extends AbstractMutationCoordinator imple
 			batchKey = new BasicBatchKey( entityPersister.getEntityName() + "#INSERT" );
 		}
 
-		if ( entityPersister.getEntityMetamodel().isDynamicInsert() ) {
+		if ( entityPersister.isDynamicInsert() ) {
 			// the entity specified dynamic-insert - skip generating the
 			// static inserts as we will create them every time
 			staticInsertGroup = null;
@@ -121,7 +120,7 @@ public class InsertCoordinatorStandard extends AbstractMutationCoordinator imple
 		final boolean needsDynamicInsert = preInsertInMemoryValueGeneration( values, entity, session );
 		final EntityPersister persister = entityPersister();
 		final boolean forceIdentifierBinding = persister.getGenerator().generatedOnExecution() && id != null;
-		if ( persister.getEntityMetamodel().isDynamicInsert()
+		if ( persister.isDynamicInsert()
 				|| needsDynamicInsert || forceIdentifierBinding ) {
 			return doDynamicInserts( id, values, entity, session, forceIdentifierBinding );
 		}
@@ -132,10 +131,9 @@ public class InsertCoordinatorStandard extends AbstractMutationCoordinator imple
 
 	protected boolean preInsertInMemoryValueGeneration(Object[] values, Object entity, SharedSessionContractImplementor session) {
 		final EntityPersister persister = entityPersister();
-		final EntityMetamodel entityMetamodel = persister.getEntityMetamodel();
 		boolean foundStateDependentGenerator = false;
-		if ( entityMetamodel.hasPreInsertGeneratedValues() ) {
-			final Generator[] generators = entityMetamodel.getGenerators();
+		if ( persister.hasPreInsertGeneratedProperties() ) {
+			final Generator[] generators = persister.getGenerators();
 			for ( int i = 0; i < generators.length; i++ ) {
 				final Generator generator = generators[i];
 				if ( generator != null

--- a/hibernate-core/src/main/java/org/hibernate/persister/entity/mutation/UpdateCoordinatorStandard.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/entity/mutation/UpdateCoordinatorStandard.java
@@ -53,7 +53,6 @@ import org.hibernate.sql.model.ast.builder.TableUpdateBuilderSkipped;
 import org.hibernate.sql.model.ast.builder.TableUpdateBuilderStandard;
 import org.hibernate.sql.model.internal.MutationOperationGroupFactory;
 import org.hibernate.sql.model.jdbc.JdbcMutationOperation;
-import org.hibernate.tuple.entity.EntityMetamodel;
 
 import static org.hibernate.engine.OptimisticLockStyle.DIRTY;
 import static org.hibernate.engine.internal.Versioning.isVersionIncrementRequired;
@@ -198,7 +197,7 @@ public class UpdateCoordinatorStandard extends AbstractMutationCoordinator imple
 
 		final boolean[] attributeUpdateability;
 		boolean forceDynamicUpdate;
-		if ( entityPersister().getEntityMetamodel().isDynamicUpdate() && dirtyAttributeIndexes != null ) {
+		if ( entityPersister().isDynamicUpdate() && dirtyAttributeIndexes != null ) {
 			attributeUpdateability = getPropertiesToUpdate( dirtyAttributeIndexes, hasDirtyCollection );
 			forceDynamicUpdate = true;
 		}
@@ -441,9 +440,9 @@ public class UpdateCoordinatorStandard extends AbstractMutationCoordinator imple
 	}
 
 	private boolean hasUpdateGeneratedValues() {
-		final var entityMetamodel = entityPersister().getEntityMetamodel();
-		return entityMetamodel.hasUpdateGeneratedValues()
-			|| entityMetamodel.hasPreUpdateGeneratedValues();
+		final var entityMetamodel = entityPersister();
+		return entityMetamodel.hasUpdateGeneratedProperties()
+			|| entityMetamodel.hasPreUpdateGeneratedProperties();
 	}
 
 	private static boolean isValueGenerated(Generator generator) {
@@ -542,8 +541,8 @@ public class UpdateCoordinatorStandard extends AbstractMutationCoordinator imple
 			Object object,
 			Object[] newValues,
 			SharedSessionContractImplementor session) {
-		final EntityMetamodel entityMetamodel = entityPersister().getEntityMetamodel();
-		if ( !entityMetamodel.hasPreUpdateGeneratedValues() ) {
+		final EntityPersister entityMetamodel = entityPersister();
+		if ( !entityMetamodel.hasPreUpdateGeneratedProperties() ) {
 			return EMPTY_INT_ARRAY;
 		}
 
@@ -909,7 +908,7 @@ public class UpdateCoordinatorStandard extends AbstractMutationCoordinator imple
 				&& entityPersister().getVersionMapping().getVersionAttribute() == attributeMapping) {
 			return true;
 		}
-		else if ( entityPersister().getEntityMetamodel().isDynamicUpdate() && dirtinessChecker != null ) {
+		else if ( entityPersister().isDynamicUpdate() && dirtinessChecker != null ) {
 			return attributeAnalysis.includeInSet()
 				&& dirtinessChecker.isDirty( attributeIndex, attributeMapping ).isDirty();
 		}
@@ -1242,7 +1241,7 @@ public class UpdateCoordinatorStandard extends AbstractMutationCoordinator imple
 			tableUpdateBuilder.addValueColumn( versionMapping.getVersionAttribute() );
 		}
 		else {
-			final boolean includeInSet = !entityPersister().getEntityMetamodel().isDynamicUpdate()
+			final boolean includeInSet = !entityPersister().isDynamicUpdate()
 					|| dirtinessChecker == null
 					|| dirtinessChecker.isDirty( attributeIndex, attributeMapping ).isDirty();
 			if ( includeInSet ) {
@@ -1327,7 +1326,7 @@ public class UpdateCoordinatorStandard extends AbstractMutationCoordinator imple
 						tablesNeedingDynamicUpdate.add( tableMapping );
 					}
 					else if ( dirtyAttributeIndexes != null ) {
-						if ( entityPersister().getEntityMetamodel().isDynamicUpdate()
+						if ( entityPersister().isDynamicUpdate()
 								|| entityPersister().optimisticLockStyle() == DIRTY ) {
 							tablesNeedingDynamicUpdate.add( tableMapping );
 						}

--- a/hibernate-core/src/main/java/org/hibernate/proxy/AbstractLazyInitializer.java
+++ b/hibernate-core/src/main/java/org/hibernate/proxy/AbstractLazyInitializer.java
@@ -345,7 +345,7 @@ public abstract class AbstractLazyInitializer implements LazyInitializer {
 			throw new LazyInitializationException( "Could not retrieve real entity name ["
 					+ entityName + "#" + id + "] - no session" );
 		}
-		if ( getEntityDescriptor().getEntityMetamodel().hasSubclasses() ) {
+		if ( getEntityDescriptor().hasSubclasses() ) {
 			initialize();
 			return session.getFactory().bestGuessEntityName( target );
 		}

--- a/hibernate-core/src/main/java/org/hibernate/proxy/pojo/BasicLazyInitializer.java
+++ b/hibernate-core/src/main/java/org/hibernate/proxy/pojo/BasicLazyInitializer.java
@@ -125,7 +125,7 @@ public abstract class BasicLazyInitializer extends AbstractLazyInitializer {
 		}
 		final SessionFactoryImplementor factory = session.getFactory();
 		final EntityPersister entityDescriptor = factory.getMappingMetamodel().getEntityDescriptor( getEntityName() );
-		if ( entityDescriptor.getEntityMetamodel().hasSubclasses() ) {
+		if ( entityDescriptor.hasSubclasses() ) {
 			return getImplementation().getClass();
 		}
 		return persistentClass;

--- a/hibernate-core/src/main/java/org/hibernate/query/results/internal/ResultSetMappingImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/results/internal/ResultSetMappingImpl.java
@@ -237,7 +237,7 @@ public class ResultSetMappingImpl implements ResultSetMapping {
 			if ( resultBuilders.size() == 1 && domainResults.size()  == 1 && domainResults.get( 0 ) instanceof EntityResult entityResult ) {
 				// Special case for result set mappings that just fetch a single polymorphic entity
 				final EntityPersister persister = entityResult.getReferencedMappingContainer().getEntityPersister();
-				final boolean polymorphic = persister.getEntityMetamodel().isPolymorphic();
+				final boolean polymorphic = persister.isPolymorphic();
 				// We only need to check for duplicate aliases if we have join fetches,
 				// otherwise we assume that even if there are duplicate aliases, the values are equivalent.
 				// If we don't do that, there is no way to fetch joined inheritance entities

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/sql/BaseSqmToSqlAstConverter.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/sql/BaseSqmToSqlAstConverter.java
@@ -3110,7 +3110,7 @@ public abstract class BaseSqmToSqlAstConverter<T extends Statement> extends Base
 		}
 		else {
 			persister = creationContext.getMappingMetamodel().findEntityDescriptor( treatTargetTypeName );
-			if ( persister == null || !persister.getEntityMetamodel().isPolymorphic() ) {
+			if ( persister == null || !persister.isPolymorphic() ) {
 				return;
 			}
 		}
@@ -5433,7 +5433,7 @@ public abstract class BaseSqmToSqlAstConverter<T extends Statement> extends Base
 
 	private Predicate createTreatTypeRestriction(SqmPath<?> lhs, EntityDomainType<?> treatTarget) {
 		final EntityPersister entityDescriptor = domainModel.findEntityDescriptor( treatTarget.getHibernateEntityName() );
-		if ( entityDescriptor.getEntityMetamodel().isPolymorphic() && lhs.getNodeType() != treatTarget ) {
+		if ( entityDescriptor.isPolymorphic() && lhs.getNodeType() != treatTarget ) {
 			final Set<String> subclassEntityNames = entityDescriptor.getSubclassEntityNames();
 			return createTreatTypeRestriction( lhs, subclassEntityNames );
 		}

--- a/hibernate-core/src/main/java/org/hibernate/tuple/entity/EntityMetamodel.java
+++ b/hibernate-core/src/main/java/org/hibernate/tuple/entity/EntityMetamodel.java
@@ -83,7 +83,7 @@ public class EntityMetamodel implements Serializable {
 
 	private final String name;
 	private final String rootName;
-	private EntityType entityType;
+	private final EntityType entityType;
 
 	private final int subclassId;
 	private final IdentifierProperty identifierAttribute;
@@ -174,6 +174,8 @@ public class EntityMetamodel implements Serializable {
 		name.hashCode();
 		//noinspection ResultOfMethodCallIgnored
 		rootName.hashCode();
+
+		entityType = new ManyToOneType( name, creationContext.getTypeConfiguration() );
 
 		subclassId = persistentClass.getSubclassId();
 
@@ -755,9 +757,6 @@ public class EntityMetamodel implements Serializable {
 	}
 
 	public EntityType getEntityType() {
-		if ( entityType == null ) {
-			entityType = new ManyToOneType( name, getSessionFactory().getTypeConfiguration() );
-		}
 		return entityType;
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/tuple/entity/EntityMetamodel.java
+++ b/hibernate-core/src/main/java/org/hibernate/tuple/entity/EntityMetamodel.java
@@ -154,9 +154,8 @@ public class EntityMetamodel implements Serializable {
 
 	public EntityMetamodel(
 			PersistentClass persistentClass,
-			EntityPersister persister,
 			RuntimeModelCreationContext creationContext) {
-		this( persistentClass, persister, creationContext,
+		this( persistentClass, creationContext,
 				rootName -> buildIdGenerator( rootName, persistentClass, creationContext ) );
 	}
 
@@ -165,7 +164,6 @@ public class EntityMetamodel implements Serializable {
 	 */
 	public EntityMetamodel(
 			PersistentClass persistentClass,
-			EntityPersister persister,
 			RuntimeModelCreationContext creationContext,
 			Function<String, Generator> generatorSupplier) {
 		sessionFactory = creationContext.getSessionFactory();
@@ -265,7 +263,7 @@ public class EntityMetamodel implements Serializable {
 			if ( property == persistentClass.getVersion() ) {
 				tempVersionProperty = i;
 				attribute = PropertyFactory.buildVersionProperty(
-						persister,
+						(EntityPersister) this,
 						sessionFactory,
 						i,
 						property,
@@ -274,7 +272,7 @@ public class EntityMetamodel implements Serializable {
 			}
 			else {
 				attribute = PropertyFactory.buildEntityBasedAttribute(
-						persister,
+						(EntityPersister) this,
 						sessionFactory,
 						i,
 						property,

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/dynamic/DynamicStatusLazyGroupOnBasicFieldTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/dynamic/DynamicStatusLazyGroupOnBasicFieldTest.java
@@ -56,7 +56,7 @@ public class DynamicStatusLazyGroupOnBasicFieldTest {
 	public void test(SessionFactoryScope scope) {
 		final EntityPersister persister = scope.getSessionFactory().getMappingMetamodel()
 				.findEntityDescriptor( Person.class );
-		assertThat( persister.getEntityMetamodel().isDynamicUpdate() ).isTrue();
+		assertThat( persister.isDynamicUpdate() ).isTrue();
 	}
 
 	@Test

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/dynamic/DynamicStatusSingleLazyGroupOnBasicFieldTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/dynamic/DynamicStatusSingleLazyGroupOnBasicFieldTest.java
@@ -56,7 +56,7 @@ public class DynamicStatusSingleLazyGroupOnBasicFieldTest {
 	public void test(SessionFactoryScope scope) {
 		final EntityPersister persister = scope.getSessionFactory().getMappingMetamodel()
 				.findEntityDescriptor( Person.class );
-		assertThat( persister.getEntityMetamodel().isDynamicUpdate() ).isFalse();
+		assertThat( persister.isDynamicUpdate() ).isFalse();
 	}
 
 	@Test

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/dynamic/DynamicStatusWithMultipleToManyRelationTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/dynamic/DynamicStatusWithMultipleToManyRelationTest.java
@@ -42,7 +42,7 @@ public class DynamicStatusWithMultipleToManyRelationTest {
 	public void test(SessionFactoryScope scope) {
 		final EntityPersister persister = scope.getSessionFactory().getMappingMetamodel()
 				.findEntityDescriptor( FooEntity.class );
-		assertThat( persister.getEntityMetamodel().isDynamicUpdate() ).isFalse();
+		assertThat( persister.isDynamicUpdate() ).isFalse();
 	}
 
 	@Entity(name = "FooEntity")

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/lazy/BidirectionalLazyTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/lazy/BidirectionalLazyTest.java
@@ -274,7 +274,7 @@ public class BidirectionalLazyTest {
 			final boolean isEmployerNullified) {
 		final SessionImplementor sessionImplementor = (SessionImplementor) session;
 		final EntityEntry entityEntry = sessionImplementor.getPersistenceContext().getEntry( employee );
-		final int propertyNumber = entityEntry.getPersister().getEntityMetamodel().getPropertyIndex( "employer" );
+		final int propertyNumber = entityEntry.getPersister().getPropertyIndex( "employer" );
 		assertEquals(
 				employer,
 				entityEntry.getLoadedState()[propertyNumber]

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/lazy/proxy/SimpleUpdateWithLazyLoadingWithCollectionInDefaultFetchGroupFalseTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/lazy/proxy/SimpleUpdateWithLazyLoadingWithCollectionInDefaultFetchGroupFalseTest.java
@@ -118,7 +118,7 @@ public class SimpleUpdateWithLazyLoadingWithCollectionInDefaultFetchGroupFalseTe
 				.getMappingMetamodel()
 				.getEntityDescriptor( Child.class.getName() );
 
-		final int relativesAttributeIndex = childPersister.getEntityMetamodel().getPropertyIndex( "relatives" );
+		final int relativesAttributeIndex = childPersister.getPropertyIndex( "relatives" );
 
 		scope.inTransaction(
 				session -> {

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/cfg/persister/GoofyPersisterClassProvider.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/cfg/persister/GoofyPersisterClassProvider.java
@@ -19,6 +19,7 @@ import org.hibernate.HibernateException;
 import org.hibernate.LockMode;
 import org.hibernate.LockOptions;
 import org.hibernate.MappingException;
+import org.hibernate.annotations.OnDeleteAction;
 import org.hibernate.bytecode.internal.BytecodeEnhancementMetadataNonPojoImpl;
 import org.hibernate.bytecode.spi.BytecodeEnhancementMetadata;
 import org.hibernate.cache.spi.access.CollectionDataAccess;
@@ -34,6 +35,7 @@ import org.hibernate.engine.spi.EntityEntryFactory;
 import org.hibernate.engine.spi.LoadQueryInfluencers;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
+import org.hibernate.generator.Generator;
 import org.hibernate.generator.values.GeneratedValues;
 import org.hibernate.generator.values.GeneratedValuesMutationDelegate;
 import org.hibernate.id.IdentifierGenerator;
@@ -1061,6 +1063,61 @@ public class GoofyPersisterClassProvider implements PersisterClassResolver {
 		@Override
 		public String getAttributeMutationTableName(int i) {
 			return "";
+		}
+
+		@Override
+		public boolean isPolymorphic() {
+			return false;
+		}
+
+		@Override
+		public boolean isDynamicUpdate() {
+			return false;
+		}
+
+		@Override
+		public boolean isDynamicInsert() {
+			return false;
+		}
+
+		@Override
+		public OnDeleteAction[] getPropertyOnDeleteActions() {
+			return new OnDeleteAction[0];
+		}
+
+		@Override
+		public Generator[] getGenerators() {
+			return new Generator[0];
+		}
+
+		@Override
+		public boolean hasImmutableNaturalId() {
+			return false;
+		}
+
+		@Override
+		public boolean isNaturalIdentifierInsertGenerated() {
+			return false;
+		}
+
+		@Override
+		public boolean isLazy() {
+			return false;
+		}
+
+		@Override
+		public int getPropertySpan() {
+			return 0;
+		}
+
+		@Override
+		public boolean hasPreInsertGeneratedProperties() {
+			return false;
+		}
+
+		@Override
+		public boolean hasPreUpdateGeneratedProperties() {
+			return false;
 		}
 	}
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/cfg/persister/GoofyPersisterClassProvider.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/cfg/persister/GoofyPersisterClassProvider.java
@@ -375,7 +375,7 @@ public class GoofyPersisterClassProvider implements PersisterClassResolver {
 		}
 
 		@Override
-		public int getVersionProperty() {
+		public int getVersionPropertyIndex() {
 			return 0;
 		}
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/ejb3configuration/PersisterClassProviderTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/ejb3configuration/PersisterClassProviderTest.java
@@ -404,7 +404,7 @@ public class PersisterClassProviderTest {
 		}
 
 		@Override
-		public int getVersionProperty() {
+		public int getVersionPropertyIndex() {
 			return 0;
 		}
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/ejb3configuration/PersisterClassProviderTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/ejb3configuration/PersisterClassProviderTest.java
@@ -18,6 +18,7 @@ import org.hibernate.HibernateException;
 import org.hibernate.LockMode;
 import org.hibernate.LockOptions;
 import org.hibernate.MappingException;
+import org.hibernate.annotations.OnDeleteAction;
 import org.hibernate.bytecode.internal.BytecodeEnhancementMetadataNonPojoImpl;
 import org.hibernate.bytecode.spi.BytecodeEnhancementMetadata;
 import org.hibernate.cache.spi.access.EntityDataAccess;
@@ -31,6 +32,7 @@ import org.hibernate.engine.spi.EntityEntryFactory;
 import org.hibernate.engine.spi.LoadQueryInfluencers;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
+import org.hibernate.generator.Generator;
 import org.hibernate.generator.values.GeneratedValues;
 import org.hibernate.generator.values.GeneratedValuesMutationDelegate;
 import org.hibernate.id.IdentifierGenerator;
@@ -1091,6 +1093,61 @@ public class PersisterClassProviderTest {
 
 		@Override
 		public boolean managesColumns(String[] columnNames) {
+			return false;
+		}
+
+		@Override
+		public boolean isPolymorphic() {
+			return false;
+		}
+
+		@Override
+		public boolean isDynamicUpdate() {
+			return false;
+		}
+
+		@Override
+		public boolean isDynamicInsert() {
+			return false;
+		}
+
+		@Override
+		public OnDeleteAction[] getPropertyOnDeleteActions() {
+			return new OnDeleteAction[0];
+		}
+
+		@Override
+		public Generator[] getGenerators() {
+			return new Generator[0];
+		}
+
+		@Override
+		public boolean hasImmutableNaturalId() {
+			return false;
+		}
+
+		@Override
+		public boolean isNaturalIdentifierInsertGenerated() {
+			return false;
+		}
+
+		@Override
+		public boolean isLazy() {
+			return false;
+		}
+
+		@Override
+		public int getPropertySpan() {
+			return 0;
+		}
+
+		@Override
+		public boolean hasPreInsertGeneratedProperties() {
+			return false;
+		}
+
+		@Override
+		public boolean hasPreUpdateGeneratedProperties() {
 			return false;
 		}
 	}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/legacy/CustomPersister.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/legacy/CustomPersister.java
@@ -1198,4 +1198,14 @@ public 	class CustomPersister extends EntityMetamodel implements EntityPersister
 	public boolean managesColumns(String[] columnNames) {
 		return false;
 	}
+
+	@Override
+	public boolean hasPreInsertGeneratedProperties() {
+		return false;
+	}
+
+	@Override
+	public boolean hasPreUpdateGeneratedProperties() {
+		return false;
+	}
 }

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/legacy/CustomPersister.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/legacy/CustomPersister.java
@@ -83,13 +83,12 @@ import org.hibernate.type.internal.BasicTypeImpl;
 
 import org.checkerframework.checker.nullness.qual.Nullable;
 
-public 	class CustomPersister implements EntityPersister {
+public 	class CustomPersister extends EntityMetamodel implements EntityPersister {
 
 	private static final Hashtable<Object,Object> INSTANCES = new Hashtable<>();
 	private static final IdentifierGenerator GENERATOR = new UUIDHexGenerator();
 
 	private final SessionFactoryImplementor factory;
-	private final EntityMetamodel entityMetamodel;
 
 	@SuppressWarnings("UnusedParameters")
 	public CustomPersister(
@@ -97,8 +96,8 @@ public 	class CustomPersister implements EntityPersister {
 			EntityDataAccess cacheAccessStrategy,
 			NaturalIdDataAccess naturalIdRegionAccessStrategy,
 			RuntimeModelCreationContext creationContext) {
+		super( model, creationContext );
 		this.factory = creationContext.getSessionFactory();
-		this.entityMetamodel = new EntityMetamodel( model, this, creationContext );
 	}
 
 	public boolean hasLazyProperties() {
@@ -424,9 +423,9 @@ public 	class CustomPersister implements EntityPersister {
 	}
 
 	/**
-	 * @see EntityPersister#getVersionProperty()
+	 * @see EntityPersister#getVersionPropertyIndex()
 	 */
-	public int getVersionProperty() {
+	public int getVersionPropertyIndex() {
 		return 0;
 	}
 
@@ -511,7 +510,6 @@ public 	class CustomPersister implements EntityPersister {
 			LockOptions lockOptions,
 			SharedSessionContractImplementor session
 	) throws HibernateException {
-
 		throw new UnsupportedOperationException();
 	}
 
@@ -525,7 +523,6 @@ public 	class CustomPersister implements EntityPersister {
 			LockMode lockMode,
 			SharedSessionContractImplementor session
 	) throws HibernateException {
-
 		throw new UnsupportedOperationException();
 	}
 
@@ -829,7 +826,7 @@ public 	class CustomPersister implements EntityPersister {
 
 	@Override
 	public EntityMetamodel getEntityMetamodel() {
-		return entityMetamodel;
+		return this;
 	}
 
 	@Override

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/naturalid/cid/AbstractCompositeIdAndNaturalIdTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/naturalid/cid/AbstractCompositeIdAndNaturalIdTest.java
@@ -33,7 +33,7 @@ public abstract class AbstractCompositeIdAndNaturalIdTest {
 		assertThat( shortCodeMetadata.isNullable(), is( false ) );
 
 		final EntityPersister rootEntityPersister = accountMapping.getRootEntityDescriptor().getEntityPersister();
-		final int shortCodeLegacyPropertyIndex = rootEntityPersister.getEntityMetamodel().getPropertyIndex( "shortCode" );
+		final int shortCodeLegacyPropertyIndex = rootEntityPersister.getPropertyIndex( "shortCode" );
 		assertThat( shortCodeLegacyPropertyIndex, is ( 0 ) );
 		assertThat( rootEntityPersister.getPropertyNullability()[ shortCodeLegacyPropertyIndex ], is( false ) );
 	}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/naturalid/immutable/ImmutableManyToOneNaturalIdAnnotationTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/naturalid/immutable/ImmutableManyToOneNaturalIdAnnotationTest.java
@@ -10,7 +10,6 @@ import org.hibernate.metamodel.mapping.EntityMappingType;
 import org.hibernate.metamodel.mapping.NaturalIdMapping;
 import org.hibernate.metamodel.mapping.SingularAttributeMapping;
 import org.hibernate.persister.entity.EntityPersister;
-import org.hibernate.tuple.entity.EntityMetamodel;
 
 import org.hibernate.testing.orm.junit.JiraKey;
 import org.hibernate.testing.orm.junit.DomainModel;
@@ -39,9 +38,8 @@ public class ImmutableManyToOneNaturalIdAnnotationTest {
 		final EntityMappingType childMapping = runtimeMetamodels.getEntityMappingType( Child.class.getName() );
 
 		final EntityPersister persister = childMapping.getEntityPersister();
-		final EntityMetamodel entityMetamodel = persister.getEntityMetamodel();
-		final int nameIndex = entityMetamodel.getPropertyIndex( "name" );
-		final int parentIndex = entityMetamodel.getPropertyIndex( "parent" );
+		final int nameIndex = persister.getPropertyIndex( "name" );
+		final int parentIndex = persister.getPropertyIndex( "parent" );
 
 		// checking alphabetic sort in relation to EntityPersister/EntityMetamodel
 		assertThat( nameIndex, lessThan( parentIndex ) );

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/naturalid/immutable/ImmutableManyToOneNaturalIdHbmTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/naturalid/immutable/ImmutableManyToOneNaturalIdHbmTest.java
@@ -13,7 +13,6 @@ import org.hibernate.metamodel.mapping.EntityMappingType;
 import org.hibernate.metamodel.mapping.NaturalIdMapping;
 import org.hibernate.metamodel.mapping.SingularAttributeMapping;
 import org.hibernate.persister.entity.EntityPersister;
-import org.hibernate.tuple.entity.EntityMetamodel;
 
 import org.hibernate.testing.orm.junit.JiraKey;
 import org.hibernate.testing.orm.junit.DomainModel;
@@ -71,9 +70,8 @@ public class ImmutableManyToOneNaturalIdHbmTest {
 		final EntityMappingType childMapping = runtimeMetamodels.getEntityMappingType( Child.class.getName() );
 
 		final EntityPersister persister = childMapping.getEntityPersister();
-		final EntityMetamodel entityMetamodel = persister.getEntityMetamodel();
-		final int nameIndex = entityMetamodel.getPropertyIndex( "name" );
-		final int parentIndex = entityMetamodel.getPropertyIndex( "parent" );
+		final int nameIndex = persister.getPropertyIndex( "name" );
+		final int parentIndex = persister.getPropertyIndex( "parent" );
 
 		// checking alphabetic sort in relation to EntityPersister/EntityMetamodel
 		assertThat( nameIndex, lessThan( parentIndex ) );

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/naturalid/immutable/ImmutableNaturalIdTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/naturalid/immutable/ImmutableNaturalIdTest.java
@@ -56,7 +56,7 @@ public class ImmutableNaturalIdTest {
 		assertFalse( userNameMapping.getAttributeMetadata().isNullable() );
 
 		final EntityPersister persister = entityMappingType.getEntityPersister();
-		final int propertyIndex = persister.getEntityMetamodel().getPropertyIndex( "userName" );
+		final int propertyIndex = persister.getPropertyIndex( "userName" );
 		// nullability is not specified, so it should be non-nullable by hbm-specific default
 		assertFalse( persister.getPropertyNullability()[propertyIndex] );
 	}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/naturalid/immutableentity/ImmutableEntityNaturalIdTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/naturalid/immutableentity/ImmutableEntityNaturalIdTest.java
@@ -13,7 +13,6 @@ import org.hibernate.metamodel.mapping.NaturalIdMapping;
 import org.hibernate.metamodel.mapping.SingularAttributeMapping;
 import org.hibernate.persister.entity.EntityPersister;
 import org.hibernate.stat.spi.StatisticsImplementor;
-import org.hibernate.tuple.entity.EntityMetamodel;
 
 import org.hibernate.testing.orm.junit.JiraKey;
 import org.hibernate.testing.orm.junit.DomainModel;
@@ -100,17 +99,16 @@ public class ImmutableEntityNaturalIdTest {
 				entityPersister.hasNaturalIdentifier(),
 				is( true )
 		);
-		final EntityMetamodel entityMetamodel = entityPersister.getEntityMetamodel();
 		assertThat(
 				"Wrong number of attributes",
-				entityMetamodel.getNaturalIdentifierProperties().length,
+				entityPersister.getNaturalIdentifierProperties().length,
 				is( 3 )
 		);
 
 		// nullability is not specified, so they should be nullable by annotations-specific default
-		assertTrue( entityPersister.getPropertyNullability()[ entityMetamodel.getPropertyIndex( "address" )] );
-		assertTrue( entityPersister.getPropertyNullability()[ entityMetamodel.getPropertyIndex( "city" )] );
-		assertTrue( entityPersister.getPropertyNullability()[ entityMetamodel.getPropertyIndex( "state" )] );
+		assertTrue( entityPersister.getPropertyNullability()[ entityPersister.getPropertyIndex( "address" )] );
+		assertTrue( entityPersister.getPropertyNullability()[ entityPersister.getPropertyIndex( "city" )] );
+		assertTrue( entityPersister.getPropertyNullability()[ entityPersister.getPropertyIndex( "state" )] );
 
 	}
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/naturalid/inheritance/InheritedNaturalIdTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/naturalid/inheritance/InheritedNaturalIdTest.java
@@ -48,7 +48,7 @@ public class InheritedNaturalIdTest {
 		assertThat( uidMetadata.isNullable(), is( true ) );
 
 		final EntityPersister rootEntityPersister = userMapping.getEntityPersister();
-		final int uidLegacyPropertyIndex = rootEntityPersister.getEntityMetamodel().getPropertyIndex( "uid" );
+		final int uidLegacyPropertyIndex = rootEntityPersister.getPropertyIndex( "uid" );
 		assertThat( uidLegacyPropertyIndex, is ( 0 ) );
 		assertThat( rootEntityPersister.getPropertyNullability()[ uidLegacyPropertyIndex ], is( true ) );
 	}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/naturalid/mutable/MutableNaturalIdTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/naturalid/mutable/MutableNaturalIdTest.java
@@ -16,7 +16,6 @@ import org.hibernate.testing.orm.junit.ServiceRegistry;
 import org.hibernate.testing.orm.junit.SessionFactory;
 import org.hibernate.testing.orm.junit.SessionFactoryScope;
 import org.hibernate.testing.orm.junit.Setting;
-import org.hibernate.tuple.entity.EntityMetamodel;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
@@ -51,11 +50,10 @@ public class MutableNaturalIdTest {
 		final SessionFactoryImplementor sessionFactory = scope.getSessionFactory();
 		final EntityMappingType entityMappingType = sessionFactory.getRuntimeMetamodels().getEntityMappingType( User.class );
 		final EntityPersister persister = entityMappingType.getEntityPersister();
-		final EntityMetamodel entityMetamodel = persister.getEntityMetamodel();
 
 		// nullability is not specified, so it should be non-nullable by hbm-specific default
-		assertFalse( persister.getPropertyNullability()[entityMetamodel.getPropertyIndex( "name" )] );
-		assertFalse( persister.getPropertyNullability()[entityMetamodel.getPropertyIndex( "org" )] );
+		assertFalse( persister.getPropertyNullability()[persister.getPropertyIndex( "name" )] );
+		assertFalse( persister.getPropertyNullability()[persister.getPropertyIndex( "org" )] );
 	}
 
 	@AfterEach

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/naturalid/nullable/NullableNaturalIdTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/naturalid/nullable/NullableNaturalIdTest.java
@@ -8,7 +8,6 @@ import org.hibernate.metamodel.mapping.EntityMappingType;
 import org.hibernate.metamodel.mapping.NaturalIdMapping;
 import org.hibernate.metamodel.mapping.SingularAttributeMapping;
 import org.hibernate.persister.entity.EntityPersister;
-import org.hibernate.tuple.entity.EntityMetamodel;
 
 import org.hibernate.testing.orm.junit.JiraKey;
 import org.hibernate.testing.orm.junit.DomainModel;
@@ -47,39 +46,37 @@ public class NullableNaturalIdTest {
 			final EntityMappingType entityMappingType = scope.getSessionFactory().getRuntimeMetamodels().getEntityMappingType( A.class );
 			final NaturalIdMapping naturalIdMapping = entityMappingType.getNaturalIdMapping();
 			final EntityPersister persister = entityMappingType.getEntityPersister();
-			final EntityMetamodel entityMetamodel = persister.getEntityMetamodel();
 
-			assertTrue( persister.getPropertyNullability()[entityMetamodel.getPropertyIndex( "assC" )] );
-			assertTrue( persister.getPropertyNullability()[entityMetamodel.getPropertyIndex( "myname" )] );
+			assertTrue( persister.getPropertyNullability()[persister.getPropertyIndex( "assC" )] );
+			assertTrue( persister.getPropertyNullability()[persister.getPropertyIndex( "myname" )] );
 			assertThat( naturalIdMapping.getNaturalIdAttributes().size(), is( 2 ) );
 
 			final SingularAttributeMapping firstAttribute = naturalIdMapping.getNaturalIdAttributes().get(0);
 			assertThat( firstAttribute.getAttributeName(), is( "assC" ) );
-			assertThat( firstAttribute.getStateArrayPosition(), is( entityMetamodel.getPropertyIndex( "assC" ) ) );
+			assertThat( firstAttribute.getStateArrayPosition(), is( persister.getPropertyIndex( "assC" ) ) );
 
 			final SingularAttributeMapping secondAttribute = naturalIdMapping.getNaturalIdAttributes().get(1);
 			assertThat( secondAttribute.getAttributeName(), is( "myname" ) );
-			assertThat( secondAttribute.getStateArrayPosition(), is( entityMetamodel.getPropertyIndex( "myname" ) ) );
+			assertThat( secondAttribute.getStateArrayPosition(), is( persister.getPropertyIndex( "myname" ) ) );
 		}
 
 		{
 			final EntityMappingType entityMappingType = scope.getSessionFactory().getRuntimeMetamodels().getEntityMappingType( B.class );
 			final NaturalIdMapping naturalIdMapping = entityMappingType.getNaturalIdMapping();
 			final EntityPersister persister = entityMappingType.getEntityPersister();
-			final EntityMetamodel entityMetamodel = persister.getEntityMetamodel();
 
-			assertTrue( persister.getPropertyNullability()[entityMetamodel.getPropertyIndex( "assA" )] );
-			assertFalse( persister.getPropertyNullability()[entityMetamodel.getPropertyIndex( "naturalid" )] );
+			assertTrue( persister.getPropertyNullability()[persister.getPropertyIndex( "assA" )] );
+			assertFalse( persister.getPropertyNullability()[persister.getPropertyIndex( "naturalid" )] );
 			assertThat( naturalIdMapping.getNaturalIdAttributes().size(), is( 2 ) );
 
 			final SingularAttributeMapping firstAttribute = naturalIdMapping.getNaturalIdAttributes().get(0);
 			assertThat( firstAttribute.getAttributeName(), is( "assA" ) );
-			assertThat( firstAttribute.getStateArrayPosition(), is( entityMetamodel.getPropertyIndex( "assA" ) ) );
+			assertThat( firstAttribute.getStateArrayPosition(), is( persister.getPropertyIndex( "assA" ) ) );
 			assertTrue( firstAttribute.getAttributeMetadata().isNullable() );
 
 			final SingularAttributeMapping secondAttribute = naturalIdMapping.getNaturalIdAttributes().get(1);
 			assertThat( secondAttribute.getAttributeName(), is( "naturalid" ) );
-			assertThat( secondAttribute.getStateArrayPosition(), is( entityMetamodel.getPropertyIndex( "naturalid" ) ) );
+			assertThat( secondAttribute.getStateArrayPosition(), is( persister.getPropertyIndex( "naturalid" ) ) );
 			assertFalse( secondAttribute.getAttributeMetadata().isNullable() );
 		}
 
@@ -87,13 +84,12 @@ public class NullableNaturalIdTest {
 			final EntityMappingType entityMappingType = scope.getSessionFactory().getRuntimeMetamodels().getEntityMappingType( C.class );
 			final NaturalIdMapping naturalIdMapping = entityMappingType.getNaturalIdMapping();
 			final EntityPersister persister = entityMappingType.getEntityPersister();
-			final EntityMetamodel entityMetamodel = persister.getEntityMetamodel();
 
 			assertThat( naturalIdMapping.getNaturalIdAttributes().size(), is( 1 ) );
-			assertTrue( persister.getPropertyNullability()[entityMetamodel.getPropertyIndex( "name" )] );
+			assertTrue( persister.getPropertyNullability()[persister.getPropertyIndex( "name" )] );
 
 			final SingularAttributeMapping attribute = naturalIdMapping.getNaturalIdAttributes().get(0);
-			assertThat( attribute.getStateArrayPosition(), is( entityMetamodel.getPropertyIndex( "name" ) ) );
+			assertThat( attribute.getStateArrayPosition(), is( persister.getPropertyIndex( "name" ) ) );
 			assertTrue( attribute.getAttributeMetadata().isNullable() );
 		}
 
@@ -101,20 +97,19 @@ public class NullableNaturalIdTest {
 			final EntityMappingType entityMappingType = scope.getSessionFactory().getRuntimeMetamodels().getEntityMappingType( D.class );
 			final NaturalIdMapping naturalIdMapping = entityMappingType.getNaturalIdMapping();
 			final EntityPersister persister = entityMappingType.getEntityPersister();
-			final EntityMetamodel entityMetamodel = persister.getEntityMetamodel();
 
 			assertThat( naturalIdMapping.getNaturalIdAttributes().size(), is( 2 ) );
-			assertTrue( persister.getPropertyNullability()[entityMetamodel.getPropertyIndex( "associatedC" )] );
-			assertTrue( persister.getPropertyNullability()[entityMetamodel.getPropertyIndex( "name" )] );
+			assertTrue( persister.getPropertyNullability()[persister.getPropertyIndex( "associatedC" )] );
+			assertTrue( persister.getPropertyNullability()[persister.getPropertyIndex( "name" )] );
 
 			final SingularAttributeMapping firstAttribute = naturalIdMapping.getNaturalIdAttributes().get(0);
 			assertThat( firstAttribute.getAttributeName(), is( "associatedC" ) );
-			assertThat( firstAttribute.getStateArrayPosition(), is( entityMetamodel.getPropertyIndex( "associatedC" ) ) );
+			assertThat( firstAttribute.getStateArrayPosition(), is( persister.getPropertyIndex( "associatedC" ) ) );
 			assertTrue( firstAttribute.getAttributeMetadata().isNullable() );
 
 			final SingularAttributeMapping secondAttribute = naturalIdMapping.getNaturalIdAttributes().get(1);
 			assertThat( secondAttribute.getAttributeName(), is( "name" ) );
-			assertThat( secondAttribute.getStateArrayPosition(), is( entityMetamodel.getPropertyIndex( "name" ) ) );
+			assertThat( secondAttribute.getStateArrayPosition(), is( persister.getPropertyIndex( "name" ) ) );
 			assertTrue( secondAttribute.getAttributeMetadata().isNullable() );
 		}
 
@@ -124,26 +119,25 @@ public class NullableNaturalIdTest {
 			final EntityMappingType entityMappingType = scope.getSessionFactory().getRuntimeMetamodels().getEntityMappingType( User.class );
 			final NaturalIdMapping naturalIdMapping = entityMappingType.getNaturalIdMapping();
 			final EntityPersister persister = entityMappingType.getEntityPersister();
-			final EntityMetamodel entityMetamodel = persister.getEntityMetamodel();
 
 			assertThat( naturalIdMapping.getNaturalIdAttributes().size(), is( 3 ) );
-			assertTrue( persister.getPropertyNullability()[entityMetamodel.getPropertyIndex( "intVal" )] );
-			assertTrue( persister.getPropertyNullability()[entityMetamodel.getPropertyIndex( "name" )] );
-			assertTrue( persister.getPropertyNullability()[entityMetamodel.getPropertyIndex( "org" )] );
+			assertTrue( persister.getPropertyNullability()[persister.getPropertyIndex( "intVal" )] );
+			assertTrue( persister.getPropertyNullability()[persister.getPropertyIndex( "name" )] );
+			assertTrue( persister.getPropertyNullability()[persister.getPropertyIndex( "org" )] );
 
 			final SingularAttributeMapping firstAttribute = naturalIdMapping.getNaturalIdAttributes().get(0);
 			assertThat( firstAttribute.getAttributeName(), is( "intVal" ) );
-			assertThat( firstAttribute.getStateArrayPosition(), is( entityMetamodel.getPropertyIndex( "intVal" ) ) );
+			assertThat( firstAttribute.getStateArrayPosition(), is( persister.getPropertyIndex( "intVal" ) ) );
 			assertTrue( firstAttribute.getAttributeMetadata().isNullable() );
 
 			final SingularAttributeMapping secondAttribute = naturalIdMapping.getNaturalIdAttributes().get(1);
 			assertThat( secondAttribute.getAttributeName(), is( "name" ) );
-			assertThat( secondAttribute.getStateArrayPosition(), is( entityMetamodel.getPropertyIndex( "name" ) ) );
+			assertThat( secondAttribute.getStateArrayPosition(), is( persister.getPropertyIndex( "name" ) ) );
 			assertTrue( secondAttribute.getAttributeMetadata().isNullable() );
 
 			final SingularAttributeMapping thirdAttribute = naturalIdMapping.getNaturalIdAttributes().get(2);
 			assertThat( thirdAttribute.getAttributeName(), is( "org" ) );
-			assertThat( thirdAttribute.getStateArrayPosition(), is( entityMetamodel.getPropertyIndex( "org" ) ) );
+			assertThat( thirdAttribute.getStateArrayPosition(), is( persister.getPropertyIndex( "org" ) ) );
 			assertTrue( thirdAttribute.getAttributeMetadata().isNullable() );
 		}
 	}

--- a/tooling/metamodel-generator/src/main/java/org/hibernate/processor/validation/MockEntityPersister.java
+++ b/tooling/metamodel-generator/src/main/java/org/hibernate/processor/validation/MockEntityPersister.java
@@ -234,7 +234,7 @@ public abstract class MockEntityPersister implements EntityPersister, Joinable {
 	}
 
 	@Override
-	public int getVersionProperty() {
+	public int getVersionPropertyIndex() {
 		return 0;
 	}
 


### PR DESCRIPTION
`EntityMetamodel` has been deprecated for removal since 6.0.

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
