### PR TITLE
Backport HHH-19723 to branch 7.0 - Hibernate-testing depends on outdated Jakarta libraries, leading to compilation issues for Jakarta Data repositories

### DIFF
--- a/hibernate-core/hibernate-core.gradle
+++ b/hibernate-core/hibernate-core.gradle
@@ -63,7 +63,13 @@ dependencies {
 
     testRuntimeOnly libs.byteBuddy
     testRuntimeOnly testLibs.weld
-    testRuntimeOnly testLibs.wildFlyTxnClient
+    implementation(libs.logging)
+    testRuntimeOnly(testLibs.wildFlyTxnClient) {
+        // WildFly Elytron includes a whole copy of JBoss Logging, Jackson with its original package,
+        // not even shaded, which causes lots of problems.
+        // Since we don't need WildFly Elytron in our tests, we'll just exclude it.
+        exclude group: 'org.wildfly.security', module: 'wildfly-elytron'
+    }
     testImplementation libs.jandex
     testImplementation jakartaLibs.jsonb
     testImplementation libs.jackson

--- a/hibernate-testing/hibernate-testing.gradle
+++ b/hibernate-testing/hibernate-testing.gradle
@@ -41,7 +41,20 @@ dependencies {
 
     implementation libs.hibernateModels
     implementation libs.jandex
-    implementation testLibs.wildFlyTxnClient
+    implementation(libs.logging)
+    // See https://hibernate.atlassian.net/browse/HHH-19743
+    // While this dependency isn't explicitly used, removing it will lead to using JBossStandAloneJtaPlatform
+    // by default in tests, which will apparently lead to leaks detected by HibernateClassLoaderLeaksTest,
+    // which will fail.
+    // JBossStandAloneJtaPlatform is old and likely wouldn't work with Jakarta EE anyway,
+    // so I won't try to fix it, but we might want to remove it in the next minor,
+    // and then we can remove the dependency below.
+    implementation(testLibs.wildFlyTxnClient) {
+        // WildFly Elytron includes a whole copy of JBoss Logging, Jackson with its original package,
+        // not even shaded, which causes lots of problems.
+        // Since we don't need WildFly Elytron in our tests, we'll just exclude it.
+        exclude group: 'org.wildfly.security', module: 'wildfly-elytron'
+    }
     implementation testLibs.junit5Engine
     implementation testLibs.junit5Launcher
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -175,7 +175,7 @@ dependencyResolutionManagement {
             def shrinkwrapVersion = version "shrinkwrap", "1.2.6"
             def shrinkwrapDescriptorsVersion = version "shrinkwrapDescriptors", "2.0.0"
             def weldVersion = version "weld", "5.1.3.Final"
-            def wildFlyTxnClientVersion = version "wildFlyTxnClient", "2.0.0.Final"
+            def wildFlyTxnClientVersion = version "wildFlyTxnClient", "3.0.5.Final"
 
             def jfrUnitVersion = version "jfrUnit", "1.0.0.Alpha2"
 
@@ -205,7 +205,7 @@ dependencyResolutionManagement {
 
             library( "jbossJta", "org.jboss.narayana.jta", "narayana-jta" ).versionRef( jbossJtaVersion )
             library( "jbossTxSpi", "org.jboss", "jboss-transaction-spi" ).versionRef( jbossTxSpiVersion )
-            library( "wildFlyTxnClient", "org.wildfly.transaction", "wildfly-transaction-client-jakarta" ).versionRef( wildFlyTxnClientVersion )
+            library( "wildFlyTxnClient", "org.wildfly.transaction", "wildfly-transaction-client" ).versionRef( wildFlyTxnClientVersion )
 
             library( "weld", "org.jboss.weld.se", "weld-se-shaded" ).versionRef( weldVersion )
 


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-19723
