### PR TITLE
[7.1] HHH-19747 Hibernate Envers can not handle @EnumeratedValue annotation

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/mapping/BasicValue.java
+++ b/hibernate-core/src/main/java/org/hibernate/mapping/BasicValue.java
@@ -65,6 +65,7 @@ import org.hibernate.type.descriptor.jdbc.BooleanJdbcType;
 import org.hibernate.type.descriptor.jdbc.JdbcType;
 import org.hibernate.type.descriptor.jdbc.JdbcTypeIndicators;
 import org.hibernate.type.internal.BasicTypeImpl;
+import org.hibernate.type.internal.ConvertedBasicTypeImpl;
 import org.hibernate.type.spi.TypeConfiguration;
 import org.hibernate.type.spi.TypeConfigurationAware;
 import org.hibernate.usertype.DynamicParameterizedType;
@@ -849,7 +850,8 @@ public class BasicValue extends SimpleValue
 //			return EnumeratedValueResolution.fromName( name, stdIndicators, context );
 //		}
 
-		if ( name.startsWith( BasicTypeImpl.EXTERNALIZED_PREFIX ) ) {
+		if ( name.startsWith( BasicTypeImpl.EXTERNALIZED_PREFIX )
+			|| name.startsWith( ConvertedBasicTypeImpl.EXTERNALIZED_PREFIX ) ) {
 			return getNamedBasicTypeResolution(
 					bootstrapContext.resolveAdHocBasicType( name ),
 					explicitMutabilityPlanAccess,

--- a/hibernate-envers/src/test/java/org/hibernate/orm/test/envers/mapping/enumeratedvalue/CharEnumerateValueTests.java
+++ b/hibernate-envers/src/test/java/org/hibernate/orm/test/envers/mapping/enumeratedvalue/CharEnumerateValueTests.java
@@ -1,0 +1,75 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.envers.mapping.enumeratedvalue;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityManagerFactory;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.EnumeratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.envers.Audited;
+import org.hibernate.testing.orm.junit.EntityManagerFactoryBasedFunctionalTest;
+import org.hibernate.testing.orm.junit.JiraKey;
+import org.hibernate.type.SqlTypes;
+import org.junit.Test;
+
+
+@JiraKey( "HHH-19747" )
+public class CharEnumerateValueTests extends EntityManagerFactoryBasedFunctionalTest {
+
+	@Override
+	protected Class<?>[] getAnnotatedClasses() {
+		return new Class<?>[] {Person.class};
+	}
+
+	@Test
+	public void testBasicUsage() {
+		final EntityManagerFactory testEmf = produceEntityManagerFactory();
+		testEmf.close();
+	}
+
+	public enum Gender {
+		MALE( 'M' ),
+		FEMALE( 'F' ),
+		OTHER( 'U' );
+
+		@EnumeratedValue
+		private final char code;
+
+		Gender(char code) {
+			this.code = code;
+		}
+
+		public char getCode() {
+			return code;
+		}
+	}
+
+	@Audited
+	@Entity(name = "Person")
+	@Table(name = "persons")
+	public static class Person {
+		@Id
+		private Integer id;
+		private String name;
+		@Enumerated(EnumType.STRING)
+		@JdbcTypeCode(SqlTypes.CHAR)
+		@Column(length = 1)
+		private Gender gender;
+
+		public Person() {
+		}
+
+		public Person(Integer id, String name, Gender gender) {
+			this.id = id;
+			this.name = name;
+			this.gender = gender;
+		}
+	}
+}


### PR DESCRIPTION
<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

Backport of https://github.com/hibernate/hibernate-orm/pull/10854 by @cigaly 

https://hibernate.atlassian.net/browse/HHH-19747

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
