### PR TITLE
HHH-19750, HHH-19753 Fix criteria value-bind parameter and SqmFunction equals and hashing logic

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/function/SelfRenderingSqmAggregateFunction.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/function/SelfRenderingSqmAggregateFunction.java
@@ -6,6 +6,7 @@ package org.hibernate.query.sqm.function;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 import org.hibernate.metamodel.model.domain.ReturnableType;
 import org.hibernate.query.sqm.NodeBuilder;
@@ -122,5 +123,25 @@ public class SelfRenderingSqmAggregateFunction<T> extends SelfRenderingSqmFuncti
 			filter.appendHqlString( hql, context );
 			hql.append( ')' );
 		}
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if ( o == null || getClass() != o.getClass() ) {
+			return false;
+		}
+		if ( !super.equals( o ) ) {
+			return false;
+		}
+
+		SelfRenderingSqmAggregateFunction<?> that = (SelfRenderingSqmAggregateFunction<?>) o;
+		return Objects.equals( filter, that.filter );
+	}
+
+	@Override
+	public int hashCode() {
+		int result = super.hashCode();
+		result = 31 * result + Objects.hashCode( filter );
+		return result;
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/function/SelfRenderingSqmFunction.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/function/SelfRenderingSqmFunction.java
@@ -6,7 +6,6 @@ package org.hibernate.query.sqm.function;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Objects;
 import java.util.function.Supplier;
 
 import org.hibernate.metamodel.mapping.BasicValuedMapping;
@@ -254,17 +253,5 @@ public class SelfRenderingSqmFunction<T> extends SqmFunction<T> {
 		public MappingModelExpressible<?> get() {
 			return argumentTypeResolver.resolveFunctionArgumentType( function.getArguments(), argumentIndex, converter );
 		}
-	}
-
-	@Override
-	// TODO: override on all subtypes
-	public boolean equals(Object other) {
-		return other instanceof SelfRenderingSqmAggregateFunction<?> that
-			&& Objects.equals( this.toHqlString(), that.toHqlString() );
-	}
-
-	@Override
-	public int hashCode() {
-		return toHqlString().hashCode();
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/function/SelfRenderingSqmOrderedSetAggregateFunction.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/function/SelfRenderingSqmOrderedSetAggregateFunction.java
@@ -7,6 +7,7 @@ package org.hibernate.query.sqm.function;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 
 import org.hibernate.metamodel.model.domain.ReturnableType;
 import org.hibernate.query.sqm.NodeBuilder;
@@ -172,5 +173,25 @@ public class SelfRenderingSqmOrderedSetAggregateFunction<T> extends SelfRenderin
 			getFilter().appendHqlString( hql, context );
 			hql.append( ')' );
 		}
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if ( o == null || getClass() != o.getClass() ) {
+			return false;
+		}
+		if ( !super.equals( o ) ) {
+			return false;
+		}
+
+		SelfRenderingSqmOrderedSetAggregateFunction<?> that = (SelfRenderingSqmOrderedSetAggregateFunction<?>) o;
+		return Objects.equals( withinGroup, that.withinGroup );
+	}
+
+	@Override
+	public int hashCode() {
+		int result = super.hashCode();
+		result = 31 * result + Objects.hashCode( withinGroup );
+		return result;
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/function/SelfRenderingSqmWindowFunction.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/function/SelfRenderingSqmWindowFunction.java
@@ -6,6 +6,7 @@ package org.hibernate.query.sqm.function;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 import org.hibernate.metamodel.model.domain.ReturnableType;
 import org.hibernate.query.sqm.NodeBuilder;
@@ -156,5 +157,29 @@ public class SelfRenderingSqmWindowFunction<T> extends SelfRenderingSqmFunction<
 			filter.appendHqlString( hql, context );
 			hql.append( ')' );
 		}
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if ( o == null || getClass() != o.getClass() ) {
+			return false;
+		}
+		if ( !super.equals( o ) ) {
+			return false;
+		}
+
+		SelfRenderingSqmWindowFunction<?> that = (SelfRenderingSqmWindowFunction<?>) o;
+		return Objects.equals( filter, that.filter )
+			&& Objects.equals( respectNulls, that.respectNulls )
+			&& Objects.equals( fromFirst, that.fromFirst );
+	}
+
+	@Override
+	public int hashCode() {
+		int result = super.hashCode();
+		result = 31 * result + Objects.hashCode( filter );
+		result = 31 * result + Objects.hashCode( respectNulls );
+		result = 31 * result + Objects.hashCode( fromFirst );
+		return result;
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/expression/SqmFunction.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/expression/SqmFunction.java
@@ -206,8 +206,15 @@ public abstract class SqmFunction<T> extends AbstractSqmExpression<T>
 
 	@Override
 	public boolean equals(Object other) {
-		return other instanceof SqmFunction<?> that
-			&& Objects.equals( this.functionName, that.functionName )
+		if ( this == other ) {
+			return true;
+		}
+		if ( other == null || getClass() != other.getClass() ) {
+			return false;
+		}
+
+		final SqmFunction<?> that = (SqmFunction<?>) other;
+		return Objects.equals( this.functionName, that.functionName )
 			&& Objects.equals( this.arguments, that.arguments );
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/expression/ValueBindJpaCriteriaParameter.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/expression/ValueBindJpaCriteriaParameter.java
@@ -10,7 +10,6 @@ import org.hibernate.query.sqm.SqmBindableType;
 import org.hibernate.query.sqm.tree.SqmCopyContext;
 import org.hibernate.query.sqm.tree.SqmRenderContext;
 
-import java.util.Objects;
 
 
 /**
@@ -55,33 +54,17 @@ public class ValueBindJpaCriteriaParameter<T> extends JpaCriteriaParameter<T> {
 	}
 
 	@Override
-	// TODO: fix this
 	public int compareTo(SqmParameter<T> parameter) {
-		return this == parameter ? 0 : 1;
+		return Integer.compare( hashCode(), parameter.hashCode() );
 	}
-
-	// this is not really a parameter, it's really a literal value
-	// so use value equality based on its value
 
 	@Override
 	public boolean equals(Object object) {
-		return object instanceof ValueBindJpaCriteriaParameter<?> that
-			&& Objects.equals( this.value, that.value );
-//			&& getJavaTypeDescriptor().areEqual( this.value, (T) that.value );
+		return this == object;
 	}
 
 	@Override
 	public int hashCode() {
-		return value == null ? 0 : value.hashCode(); // getJavaTypeDescriptor().extractHashCode( value );
+		return super.hashCode();
 	}
-
-//	@Override
-//	public boolean equals(Object object) {
-//		return this == object;
-//	}
-//
-//	@Override
-//	public int hashCode() {
-//		return System.identityHashCode( this );
-//	}
 }

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/query/CriteriaUpdateWithParametersTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/query/CriteriaUpdateWithParametersTest.java
@@ -4,81 +4,113 @@
  */
 package org.hibernate.orm.test.jpa.query;
 
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Lob;
+import jakarta.persistence.Query;
+import jakarta.persistence.criteria.CriteriaBuilder;
+import jakarta.persistence.criteria.CriteriaUpdate;
+import jakarta.persistence.criteria.Expression;
+import jakarta.persistence.criteria.ParameterExpression;
+import jakarta.persistence.criteria.Path;
+import jakarta.persistence.criteria.Root;
+import jakarta.persistence.metamodel.EntityType;
+import org.hibernate.query.criteria.HibernateCriteriaBuilder;
 import org.hibernate.testing.orm.junit.EntityManagerFactoryScope;
 import org.hibernate.testing.orm.junit.Jpa;
 import org.junit.jupiter.api.Test;
 
-import jakarta.persistence.Entity;
-import jakarta.persistence.Id;
-import jakarta.persistence.Query;
-import jakarta.persistence.criteria.CriteriaBuilder;
-import jakarta.persistence.criteria.CriteriaUpdate;
-import jakarta.persistence.criteria.ParameterExpression;
-import jakarta.persistence.criteria.Root;
-import jakarta.persistence.metamodel.EntityType;
 
-@Jpa(
-		annotatedClasses = CriteriaUpdateWithParametersTest.Person.class
-)
+@Jpa(annotatedClasses = {
+		CriteriaUpdateWithParametersTest.Person.class,
+		CriteriaUpdateWithParametersTest.Process.class
+})
 public class CriteriaUpdateWithParametersTest {
 
 	@Test
 	public void testCriteriaUpdate(EntityManagerFactoryScope scope) {
-		scope.inTransaction(
-				entityManager -> {
-					final CriteriaBuilder criteriaBuilder = entityManager.getCriteriaBuilder();
-					final CriteriaUpdate<Person> criteriaUpdate = criteriaBuilder.createCriteriaUpdate( Person.class );
-					final Root<Person> root = criteriaUpdate.from( Person.class );
+		scope.inTransaction( entityManager -> {
+			final CriteriaBuilder criteriaBuilder = entityManager.getCriteriaBuilder();
+			final CriteriaUpdate<Person> criteriaUpdate = criteriaBuilder.createCriteriaUpdate( Person.class );
+			final Root<Person> root = criteriaUpdate.from( Person.class );
 
-					final ParameterExpression<Integer> intValueParameter = criteriaBuilder.parameter( Integer.class );
-					final ParameterExpression<String> stringValueParameter = criteriaBuilder.parameter( String.class );
+			final ParameterExpression<Integer> intValueParameter = criteriaBuilder.parameter( Integer.class );
+			final ParameterExpression<String> stringValueParameter = criteriaBuilder.parameter( String.class );
 
-					final EntityType<Person> personEntityType = entityManager.getMetamodel().entity( Person.class );
+			final EntityType<Person> personEntityType = entityManager.getMetamodel().entity( Person.class );
 
-					criteriaUpdate.set(
-							root.get( personEntityType.getSingularAttribute( "age", Integer.class ) ),
-							intValueParameter
-					);
-					criteriaUpdate.where( criteriaBuilder.equal(
-							root.get( personEntityType.getSingularAttribute( "name", String.class ) ),
-							stringValueParameter
-					) );
+			criteriaUpdate.set( root.get( personEntityType.getSingularAttribute( "age", Integer.class ) ),
+					intValueParameter );
+			criteriaUpdate.where(
+					criteriaBuilder.equal( root.get( personEntityType.getSingularAttribute( "name", String.class ) ),
+							stringValueParameter ) );
 
-					final Query query = entityManager.createQuery( criteriaUpdate );
-					query.setParameter( intValueParameter, 9 );
-					query.setParameter( stringValueParameter, "Luigi" );
+			final Query query = entityManager.createQuery( criteriaUpdate );
+			query.setParameter( intValueParameter, 9 );
+			query.setParameter( stringValueParameter, "Luigi" );
 
-					query.executeUpdate();
-				}
-		);
+			query.executeUpdate();
+		} );
 	}
 
 	@Test
 	public void testCriteriaUpdate2(EntityManagerFactoryScope scope) {
-		scope.inTransaction(
-				entityManager -> {
-					final CriteriaBuilder criteriaBuilder = entityManager.getCriteriaBuilder();
-					final CriteriaUpdate<Person> criteriaUpdate = criteriaBuilder.createCriteriaUpdate( Person.class );
-					final Root<Person> root = criteriaUpdate.from( Person.class );
+		scope.inTransaction( entityManager -> {
+			final CriteriaBuilder criteriaBuilder = entityManager.getCriteriaBuilder();
+			final CriteriaUpdate<Person> criteriaUpdate = criteriaBuilder.createCriteriaUpdate( Person.class );
+			final Root<Person> root = criteriaUpdate.from( Person.class );
 
-					final ParameterExpression<Integer> intValueParameter = criteriaBuilder.parameter( Integer.class );
-					final ParameterExpression<String> stringValueParameter = criteriaBuilder.parameter( String.class );
+			final ParameterExpression<Integer> intValueParameter = criteriaBuilder.parameter( Integer.class );
+			final ParameterExpression<String> stringValueParameter = criteriaBuilder.parameter( String.class );
 
-					criteriaUpdate.set( "age", intValueParameter );
-					criteriaUpdate.where( criteriaBuilder.equal( root.get( "name" ), stringValueParameter ) );
+			criteriaUpdate.set( "age", intValueParameter );
+			criteriaUpdate.where( criteriaBuilder.equal( root.get( "name" ), stringValueParameter ) );
 
-					final Query query = entityManager.createQuery( criteriaUpdate );
-					query.setParameter( intValueParameter, 9 );
-					query.setParameter( stringValueParameter, "Luigi" );
+			final Query query = entityManager.createQuery( criteriaUpdate );
+			query.setParameter( intValueParameter, 9 );
+			query.setParameter( stringValueParameter, "Luigi" );
 
-					query.executeUpdate();
-				}
-		);
+			query.executeUpdate();
+		} );
+	}
+
+	@Test
+	public void testCriteriaUpdate3(EntityManagerFactoryScope scope) {
+		scope.inTransaction( em -> {
+			// test separate value-bind parameters
+			final CriteriaBuilder cb = em.getCriteriaBuilder();
+			final CriteriaUpdate<Process> cu = cb.createCriteriaUpdate( Process.class );
+			final Root<Process> root = cu.from( Process.class );
+			cu.set( root.get( "name" ), (Object) null );
+			cu.set( root.get( "payload" ), (Object) null );
+			em.createQuery( cu ).executeUpdate();
+		} );
+
+		scope.inTransaction( em -> {
+			// test with the same cb.value( null ) parameter instance
+			final HibernateCriteriaBuilder cb = (HibernateCriteriaBuilder) em.getCriteriaBuilder();
+			final CriteriaUpdate<Process> cu = cb.createCriteriaUpdate( Process.class );
+			final Root<Process> root = cu.from( Process.class );
+			final Expression<Object> nullValue = cb.value( null );
+			// a bit unfortunate, but we need to cast here to prevent ambiguous method references
+			final Path<String> name = root.get( "name" );
+			final Path<byte[]> payload = root.get( "payload" );
+			final Expression<? extends String> nullString = cast( nullValue );
+			final Expression<? extends byte[]> nullBytes = cast( nullValue );
+			cu.set( name, nullString );
+			cu.set( payload, nullBytes );
+			em.createQuery( cu ).executeUpdate();
+		} );
+	}
+
+	private static <X> Expression<? extends X> cast(Expression<?> expression) {
+		//noinspection unchecked
+		return (Expression<? extends X>) expression;
 	}
 
 	@Entity(name = "Person")
 	public static class Person {
-
 		@Id
 		private String id;
 
@@ -100,5 +132,19 @@ public class CriteriaUpdateWithParametersTest {
 		public Integer getAge() {
 			return age;
 		}
+	}
+
+	@Entity
+	public static class Process {
+		@Id
+		@GeneratedValue
+		private Long id;
+
+		// All attributes below are necessary to reproduce the issue
+
+		private String name;
+
+		@Lob
+		private byte[] payload;
 	}
 }


### PR DESCRIPTION
<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

https://hibernate.atlassian.net/browse/HHH-19750
https://hibernate.atlassian.net/browse/HHH-19753

While working on the fix I noticed some tests failures due to incorrect query-cache hits when using value-bind criteria parameters for values and/or literals, which led me to HHH-19753 which I tried fixing as well in the last commit.

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
