### PR TITLE
Add RuntimeModelCreationContext#getOrCreateIdGenerator() for Hibernate Reactive

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/internal/SessionFactoryImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/SessionFactoryImpl.java
@@ -84,6 +84,7 @@ import org.hibernate.integrator.spi.IntegratorService;
 import org.hibernate.jpa.internal.ExceptionMapperLegacyJpaImpl;
 import org.hibernate.jpa.internal.PersistenceUnitUtilImpl;
 import org.hibernate.mapping.GeneratorSettings;
+import org.hibernate.mapping.PersistentClass;
 import org.hibernate.mapping.RootClass;
 import org.hibernate.metamodel.MappingMetamodel;
 import org.hibernate.metamodel.RepresentationMode;
@@ -1810,6 +1811,27 @@ public class SessionFactoryImpl implements SessionFactoryImplementor {
 		@Override
 		public SqlStringGenerationContext getSqlStringGenerationContext() {
 			return sqlStringGenerationContext;
+		}
+
+		@Override
+		public Generator getOrCreateIdGenerator(String rootName, PersistentClass persistentClass) {
+			final var existing = getGenerators().get( rootName );
+			if ( existing != null ) {
+				return existing;
+			}
+			else {
+				final var idGenerator =
+						persistentClass.getIdentifier()
+								// returns the cached Generator if it was already created
+								.createGenerator(
+										getDialect(),
+										persistentClass.getRootClass(),
+										persistentClass.getIdentifierProperty(),
+										getGeneratorSettings()
+								);
+				getGenerators().put( rootName, idGenerator );
+				return idGenerator;
+			}
 		}
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/spi/RuntimeModelCreationContext.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/spi/RuntimeModelCreationContext.java
@@ -14,6 +14,7 @@ import org.hibernate.engine.jdbc.spi.JdbcServices;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.generator.Generator;
 import org.hibernate.mapping.GeneratorSettings;
+import org.hibernate.mapping.PersistentClass;
 import org.hibernate.query.sqm.function.SqmFunctionRegistry;
 import org.hibernate.service.ServiceRegistry;
 import org.hibernate.type.descriptor.java.spi.JavaTypeRegistry;
@@ -65,4 +66,7 @@ public interface RuntimeModelCreationContext {
 	Map<String, Generator> getGenerators();
 
 	GeneratorSettings getGeneratorSettings();
+
+	// For Hibernate Reactive
+	Generator getOrCreateIdGenerator(String rootName, PersistentClass persistentClass);
 }

--- a/hibernate-core/src/main/java/org/hibernate/tuple/entity/EntityMetamodel.java
+++ b/hibernate-core/src/main/java/org/hibernate/tuple/entity/EntityMetamodel.java
@@ -155,7 +155,7 @@ public class EntityMetamodel implements Serializable {
 			PersistentClass persistentClass,
 			RuntimeModelCreationContext creationContext) {
 		this( persistentClass, creationContext,
-				rootName -> buildIdGenerator( rootName, persistentClass, creationContext ) );
+				rootName -> creationContext.getOrCreateIdGenerator( rootName, persistentClass ) );
 	}
 
 	/*
@@ -573,26 +573,6 @@ public class EntityMetamodel implements Serializable {
 //			throw new HibernateException( "BeforeExecutionGenerator returned false from OnExecutionGenerator.writePropertyValue()" );
 //		}
 		return writePropertyValue;
-	}
-
-	private static Generator buildIdGenerator(String rootName, PersistentClass persistentClass, RuntimeModelCreationContext creationContext) {
-		final var existing = creationContext.getGenerators().get( rootName );
-		if ( existing != null ) {
-			return existing;
-		}
-		else {
-			final var idGenerator =
-					persistentClass.getIdentifier()
-							// returns the cached Generator if it was already created
-							.createGenerator(
-									creationContext.getDialect(),
-									persistentClass.getRootClass(),
-									persistentClass.getIdentifierProperty(),
-									creationContext.getGeneratorSettings()
-							);
-			creationContext.getGenerators().put( rootName, idGenerator );
-			return idGenerator;
-		}
 	}
 
 	private void verifyNaturalIdProperty(Property property) {

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/LocalTemporaryTableMutationStrategyNoDropTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/LocalTemporaryTableMutationStrategyNoDropTest.java
@@ -23,6 +23,7 @@ import org.hibernate.engine.jdbc.spi.JdbcServices;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.generator.Generator;
 import org.hibernate.mapping.GeneratorSettings;
+import org.hibernate.mapping.PersistentClass;
 import org.hibernate.metamodel.spi.MappingMetamodelImplementor;
 import org.hibernate.metamodel.spi.RuntimeModelCreationContext;
 import org.hibernate.query.sqm.function.SqmFunctionRegistry;
@@ -208,6 +209,11 @@ public class LocalTemporaryTableMutationStrategyNoDropTest {
 		@Override
 		public GeneratorSettings getGeneratorSettings() {
 			return this;
+		}
+
+		@Override
+		public Generator getOrCreateIdGenerator(String rootName, PersistentClass persistentClass) {
+			return null;
 		}
 	}
 }


### PR DESCRIPTION
Reactive need a way to override the `IdGenerator` creation to generate Reactive Geneators.

Needed for https://github.com/hibernate/hibernate-reactive/issues/2495 

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
