### PR TITLE
[7.1] HHH-19745 Use identity sensitive collections/operations where necessary after introducing equals implementation for SqmPath

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/query/hql/internal/QualifiedJoinPredicatePathConsumer.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/hql/internal/QualifiedJoinPredicatePathConsumer.java
@@ -4,6 +4,7 @@
  */
 package org.hibernate.query.hql.internal;
 
+import java.util.List;
 import java.util.Locale;
 
 import org.hibernate.query.SemanticException;
@@ -56,9 +57,9 @@ public class QualifiedJoinPredicatePathConsumer extends BasicDotIdentifierConsum
 						final SqmFromClause fromClause = querySpec.getFromClause();
 						// If the current processing query contains the root of the current join,
 						// then the root of the processing path must be a root of one of the parent queries
-						if ( fromClause != null && fromClause.getRoots().contains( joinRoot ) ) {
+						if ( fromClause != null && contains( fromClause.getRoots(), joinRoot ) ) {
 							// It is allowed to use correlations from the same query
-							if ( !( root instanceof SqmCorrelation<?, ?> ) || !fromClause.getRoots().contains( root ) ) {
+							if ( !( root instanceof SqmCorrelation<?, ?> ) || !contains( fromClause.getRoots(), root ) ) {
 								validateAsRootOnParentQueryClosure( pathRoot, root,
 										processingState.getParentProcessingState() );
 							}
@@ -97,7 +98,7 @@ public class QualifiedJoinPredicatePathConsumer extends BasicDotIdentifierConsum
 						// If we are in a subquery, the "foreign" from element could be one of the subquery roots,
 						// which is totally fine. The aim of this check is to prevent uses of different "spaces"
 						// i.e. `from A a, B b join b.id = a.id` would be illegal
-						if ( fromClause != null && fromClause.getRoots().contains( root ) ) {
+						if ( fromClause != null && contains( fromClause.getRoots(), root ) ) {
 							super.validateAsRoot( pathRoot );
 							return;
 						}
@@ -112,6 +113,15 @@ public class QualifiedJoinPredicatePathConsumer extends BasicDotIdentifierConsum
 								sqmJoin.getNavigablePath()
 						)
 				);
+			}
+
+			private boolean contains(List<SqmRoot<?>> roots, SqmRoot<?> root) {
+				for ( SqmRoot<?> sqmRoot : roots ) {
+					if ( sqmRoot == root ) {
+						return true;
+					}
+				}
+				return false;
 			}
 		};
 	}

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/select/SqmQuerySpec.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/select/SqmQuerySpec.java
@@ -7,6 +7,7 @@ package org.hibernate.query.sqm.tree.select;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
@@ -516,7 +517,7 @@ public class SqmQuerySpec<T> extends SqmQueryPart<T>
 			}
 		}
 		else {
-			selectedFromSet = new HashSet<>( selectClause.getSelections().size() );
+			selectedFromSet = Collections.newSetFromMap( new IdentityHashMap<>( selectClause.getSelections().size() ) );
 			for ( SqmSelection<?> selection : selectClause.getSelections() ) {
 				collectSelectedFromSet( selectedFromSet, selection.getSelectableNode() );
 			}

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/select/SqmSubQuery.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/select/SqmSubQuery.java
@@ -7,7 +7,8 @@ package org.hibernate.query.sqm.tree.select;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.Collection;
-import java.util.HashSet;
+import java.util.Collections;
+import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -580,7 +581,7 @@ public class SqmSubQuery<T> extends AbstractSqmSelectQuery<T>
 
 	@Override
 	public Set<Join<?, ?>> getCorrelatedJoins() {
-		final Set<Join<?, ?>> correlatedJoins = new HashSet<>();
+		final Set<Join<?, ?>> correlatedJoins = Collections.newSetFromMap( new IdentityHashMap<>() );
 		final SqmFromClause fromClause = getQuerySpec().getFromClause();
 		if ( fromClause != null ) {
 			for ( SqmRoot<?> root : fromClause.getRoots() ) {

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/query/SubQueryShadowingTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/query/SubQueryShadowingTest.java
@@ -1,0 +1,62 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.query;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import org.hibernate.testing.orm.junit.DialectFeatureChecks;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.Jira;
+import org.hibernate.testing.orm.junit.RequiresDialectFeature;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.junit.jupiter.api.Test;
+
+
+@DomainModel(
+		annotatedClasses = {
+				SubQueryShadowingTest.TestEntity.class,
+		}
+)
+@SessionFactory
+public class SubQueryShadowingTest {
+
+	@Test
+	@RequiresDialectFeature(feature = DialectFeatureChecks.SupportsOffsetInSubquery.class, comment = "The check is for both, limit and offset in subqueries")
+	@Jira("https://hibernate.atlassian.net/browse/HHH-19745")
+	public void testSelectCase(SessionFactoryScope scope) {
+		scope.inTransaction( session -> {
+			session.createQuery(
+							"""
+							from TestEntity t
+							left join TestEntity t2 on exists (
+								select 1
+								from TestEntity t
+								order by t.id
+								limit 1
+							)
+							""", TestEntity.class )
+					.list();
+		} );
+	}
+
+	@Entity(name = "TestEntity")
+	public static class TestEntity {
+
+		@Id
+		@GeneratedValue
+		private Long id;
+
+		private String name;
+
+		public TestEntity() {
+		}
+
+		public TestEntity(String name) {
+			this.name = name;
+		}
+	}
+}


### PR DESCRIPTION
<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

[Please describe here what your change is about]

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-19745
<!-- Hibernate GitHub Bot issue links end -->