### PR TITLE
set the current batch to null after releasing it

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/engine/jdbc/internal/JdbcCoordinatorImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/jdbc/internal/JdbcCoordinatorImpl.java
@@ -154,6 +154,7 @@ public class JdbcCoordinatorImpl implements JdbcCoordinator {
 			if ( currentBatch != null ) {
 				JDBC_MESSAGE_LOGGER.closingUnreleasedBatch( hashCode() );
 				currentBatch.release();
+				currentBatch = null;
 			}
 		}
 		finally {
@@ -173,7 +174,10 @@ public class JdbcCoordinatorImpl implements JdbcCoordinator {
 					currentBatch.execute();
 				}
 				finally {
-					currentBatch.release();
+					if ( currentBatch != null ) {
+						currentBatch.release();
+						currentBatch = null;
+					}
 				}
 			}
 		}
@@ -191,7 +195,10 @@ public class JdbcCoordinatorImpl implements JdbcCoordinator {
 				currentBatch.execute();
 			}
 			finally {
-				currentBatch.release();
+				if ( currentBatch != null ) { // abortBatch() might have been called
+					currentBatch.release();
+					currentBatch = null;
+				}
 			}
 		}
 	}
@@ -204,7 +211,10 @@ public class JdbcCoordinatorImpl implements JdbcCoordinator {
 				currentBatch.execute();
 			}
 			finally {
-				currentBatch.release();
+				if ( currentBatch != null ) { // abortBatch() might have been called
+					currentBatch.release();
+					currentBatch = null;
+				}
 			}
 		}
 	}
@@ -212,8 +222,9 @@ public class JdbcCoordinatorImpl implements JdbcCoordinator {
 	@Override
 	public void abortBatch() {
 		if ( currentBatch != null ) {
-			BATCH_MESSAGE_LOGGER.abortBatch( currentBatch.getKey() .toLoggableString());
+			BATCH_MESSAGE_LOGGER.abortBatch( currentBatch.getKey().toLoggableString());
 			currentBatch.release();
+			currentBatch = null;
 		}
 	}
 


### PR DESCRIPTION
this silences a bunch of noisy "Aborting batch" log messages

<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

[Please describe here what your change is about]

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
