### PR TITLE
some cleanups related to EntityPersister and CollectionPersister

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/cache/spi/entry/StandardCacheEntryImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/cache/spi/entry/StandardCacheEntryImpl.java
@@ -149,7 +149,7 @@ public class StandardCacheEntryImpl implements CacheEntry {
 
 		}
 
-		persister.setPropertyValues( instance, state );
+		persister.setValues( instance, state );
 
 		return state;
 	}

--- a/hibernate-core/src/main/java/org/hibernate/event/internal/DefaultFlushEntityEventListener.java
+++ b/hibernate-core/src/main/java/org/hibernate/event/internal/DefaultFlushEntityEventListener.java
@@ -142,7 +142,7 @@ public class DefaultFlushEntityEventListener implements FlushEntityEventListener
 			// now update the object
 			// has to be outside the main if block above (because of collections)
 			if ( substitute ) {
-				persister.setPropertyValues( entity, values );
+				persister.setValues( entity, values );
 			}
 			// Search for collections by reachability, updating their role.
 			// We don't want to touch collections reachable from a deleted object

--- a/hibernate-core/src/main/java/org/hibernate/persister/collection/AbstractCollectionPersister.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/collection/AbstractCollectionPersister.java
@@ -1277,25 +1277,6 @@ public abstract class AbstractCollectionPersister
 	}
 
 	@Override
-	public String getManyToManyFilterFragment(TableGroup tableGroup, Map<String, Filter> enabledFilters) {
-		final var fragment = new StringBuilder();
-		if ( manyToManyFilterHelper != null ) {
-			manyToManyFilterHelper.render( fragment,
-					elementPersister.getFilterAliasGenerator( tableGroup ), enabledFilters );
-		}
-		if ( manyToManyWhereString != null ) {
-			if ( !fragment.isEmpty() ) {
-				fragment.append( " and " );
-			}
-			assert elementPersister != null;
-			fragment.append( replace( manyToManyWhereTemplate, Template.TEMPLATE,
-					tableGroup.resolveTableReference( elementPersister.getTableName() )
-							.getIdentificationVariable() ) );
-		}
-		return fragment.toString();
-	}
-
-	@Override
 	public EntityPersister getElementPersister() {
 		if ( elementPersister == null ) {
 			throw new AssertionFailure( "not an association" );

--- a/hibernate-core/src/main/java/org/hibernate/persister/collection/CollectionPersister.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/collection/CollectionPersister.java
@@ -162,8 +162,6 @@ public interface CollectionPersister extends Restrictable {
 	 */
 	boolean isManyToMany();
 
-	String getManyToManyFilterFragment(TableGroup tableGroup, Map<String, Filter> enabledFilters);
-
 	/**
 	 * Is this an "indexed" collection? (list or map)
 	 */

--- a/hibernate-core/src/main/java/org/hibernate/persister/entity/AbstractEntityPersister.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/entity/AbstractEntityPersister.java
@@ -310,7 +310,15 @@ public abstract class AbstractEntityPersister
 
 	private static final CoreMessageLogger LOG = CoreLogging.messageLogger( AbstractEntityPersister.class );
 
+	/**
+	 * The property name of the "special" identifier property in HQL
+	 *
+	 * @deprecated this feature of HQL is now deprecated
+	 */
+	@Deprecated(since = "6.2")
+	public static final String ENTITY_ID = "id";
 	public static final String ENTITY_CLASS = "class";
+
 	public static final String VERSION_COLUMN_ALIAS = "version_";
 	public static final String ROWID_ALIAS = "rowid_";
 
@@ -4080,11 +4088,6 @@ public abstract class AbstractEntityPersister
 	@Override
 	public CascadeStyle[] getPropertyCascadeStyles() {
 		return getCascadeStyles();
-	}
-
-	@Override
-	public boolean isPropertySelectable(int propertyNumber) {
-		return getAttributeMapping( propertyNumber ).getAttributeMetadata().isSelectable();
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/persister/entity/EntityPersister.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/entity/EntityPersister.java
@@ -627,7 +627,10 @@ public interface EntityPersister extends EntityMappingType, EntityMutationTarget
 
 	/**
 	 * Load the id for the entity based on the natural id.
+	 *
+	 * @deprecated No longer used
 	 */
+	@Deprecated(since = "7.2")
 	Object loadEntityIdByNaturalId(
 			Object[] naturalIdValues,
 			LockOptions lockOptions,
@@ -637,17 +640,6 @@ public interface EntityPersister extends EntityMappingType, EntityMutationTarget
 	 * Load an instance of the persistent class.
 	 */
 	Object load(Object id, Object optionalObject, LockMode lockMode, SharedSessionContractImplementor session);
-
-	/**
-	 * @deprecated Use {@link #load(Object, Object, LockMode, SharedSessionContractImplementor)}
-	 */
-	@Deprecated(since = "6.0")
-	default Object load(
-			Object id, Object optionalObject, LockMode lockMode, SharedSessionContractImplementor session,
-			@SuppressWarnings("unused") Boolean readOnly)
-			throws HibernateException {
-		return load( id, optionalObject, lockMode, session );
-	}
 
 	/**
 	 * Load an instance of the persistent class.
@@ -897,10 +889,6 @@ public interface EntityPersister extends EntityMappingType, EntityMutationTarget
 	 * Get the cascade styles of the properties (optional operation)
 	 */
 	CascadeStyle[] getPropertyCascadeStyles();
-
-	default boolean isPropertySelectable(int propertyNumber) {
-		return true;
-	}
 
 	/**
 	 * Get the identifier type
@@ -1377,14 +1365,6 @@ public interface EntityPersister extends EntityMappingType, EntityMutationTarget
 	boolean storeDiscriminatorInShallowQueryCacheLayout();
 
 	boolean hasFilterForLoadByKey();
-
-	/**
-	 * The property name of the "special" identifier property in HQL
-	 *
-	 * @deprecated this feature of HQL is now deprecated
-	 */
-	@Deprecated(since = "6.2")
-	String ENTITY_ID = "id";
 
 	/**
 	 * @return Metadata for each unique key defined

--- a/hibernate-core/src/main/java/org/hibernate/persister/entity/EntityPropertyMapping.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/entity/EntityPropertyMapping.java
@@ -332,9 +332,9 @@ class EntityPropertyMapping {
 
 		if ( etype.isReferenceToPrimaryKey() ) {
 			if ( !hasNonIdentifierPropertyNamedId ) {
-				String idpath1 = extendPath( path, EntityPersister.ENTITY_ID );
-				addPropertyPath( idpath1, idtype, columns, columnReaders, columnReaderTemplates, factory );
-				initPropertyPaths( idpath1, idtype, columns, columnReaders, columnReaderTemplates, formulaTemplates, factory );
+				String idpath = extendPath( path, AbstractEntityPersister.ENTITY_ID );
+				addPropertyPath( idpath, idtype, columns, columnReaders, columnReaderTemplates, factory );
+				initPropertyPaths( idpath, idtype, columns, columnReaders, columnReaderTemplates, formulaTemplates, factory );
 			}
 		}
 
@@ -352,7 +352,7 @@ class EntityPropertyMapping {
 		try {
 			return factory.getReferencedPropertyType(
 					entityType.getAssociatedEntityName(),
-					EntityPersister.ENTITY_ID
+					AbstractEntityPersister.ENTITY_ID
 			) != null;
 		}
 		catch (MappingException e) {

--- a/hibernate-core/src/main/java/org/hibernate/persister/entity/mutation/InsertCoordinatorStandard.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/entity/mutation/InsertCoordinatorStandard.java
@@ -140,7 +140,7 @@ public class InsertCoordinatorStandard extends AbstractMutationCoordinator imple
 						&& generator.generatesOnInsert()
 						&& generator.generatedBeforeExecution( entity, session ) ) {
 					values[i] = ( (BeforeExecutionGenerator) generator ).generate( session, entity, values[i], INSERT );
-					persister.setPropertyValue( entity, i, values[i] );
+					persister.setValue( entity, i, values[i] );
 					foundStateDependentGenerator = foundStateDependentGenerator || generator.generatedOnExecution();
 				}
 			}

--- a/hibernate-core/src/main/java/org/hibernate/persister/entity/mutation/UpdateCoordinatorStandard.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/entity/mutation/UpdateCoordinatorStandard.java
@@ -557,7 +557,7 @@ public class UpdateCoordinatorStandard extends AbstractMutationCoordinator imple
 						&& generator.generatesOnUpdate()
 						&& generator.generatedBeforeExecution( object, session ) ) {
 					newValues[i] = ( (BeforeExecutionGenerator) generator ).generate( session, object, newValues[i], UPDATE );
-					entityPersister().setPropertyValue( object, i, newValues[i] );
+					entityPersister().setValue( object, i, newValues[i] );
 					fieldsPreUpdateNeeded[count++] = i;
 				}
 			}

--- a/hibernate-core/src/main/java/org/hibernate/sql/results/graph/entity/internal/EntityInitializerImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/results/graph/entity/internal/EntityInitializerImpl.java
@@ -1366,7 +1366,7 @@ public class EntityInitializerImpl extends AbstractInitializer<EntityInitializer
 						.injectInterceptor( entityInstanceForNotify, entityIdentifier, session );
 			}
 		}
-		data.concreteDescriptor.setPropertyValues( entityInstanceForNotify, resolvedEntityState );
+		data.concreteDescriptor.setValues( entityInstanceForNotify, resolvedEntityState );
 
 		persistenceContext.addEntity( entityKey, entityInstanceForNotify );
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/cfg/persister/GoofyPersisterClassProvider.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/cfg/persister/GoofyPersisterClassProvider.java
@@ -1192,10 +1192,6 @@ public class GoofyPersisterClassProvider implements PersisterClassResolver {
 			return false;  //To change body of implemented methods use File | Settings | File Templates.
 		}
 
-		public String getManyToManyFilterFragment(TableGroup tableGroup, Map<String, Filter> enabledFilters) {
-			return null;  //To change body of implemented methods use File | Settings | File Templates.
-		}
-
 		public boolean hasIndex() {
 			return false;  //To change body of implemented methods use File | Settings | File Templates.
 		}


### PR DESCRIPTION
completely delete obsolete method getManyToManyFilterFragment()

<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

[Please describe here what your change is about]

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
