### PR TITLE
Lock around clone-commit-push in Jenkins release script

### DIFF
--- a/ci/release/Jenkinsfile
+++ b/ci/release/Jenkinsfile
@@ -256,12 +256,15 @@ pipeline {
 						]) {
 							sshagent( ['ed25519.Hibernate-CI.github.com', 'hibernate.filemgmt.jboss.org', 'hibernate-ci.frs.sourceforge.net'] ) {
 								dir( '.release/hibernate.org' ) {
-									checkout scmGit(
-											branches: [[name: '*/production']],
-											extensions: [],
-											userRemoteConfigs: [[credentialsId: 'ed25519.Hibernate-CI.github.com', url: 'https://github.com/hibernate/hibernate.org.git']]
-									)
-									sh "../scripts/website-release.sh ${env.SCRIPT_OPTIONS} ${env.PROJECT} ${env.RELEASE_VERSION}"
+                                    // Lock to avoid rejected pushes when multiple releases try to clone-commit-push
+                                    lock('hibernate.org-git') {
+                                        checkout scmGit(
+                                                branches: [[name: '*/production']],
+                                                extensions: [],
+                                                userRemoteConfigs: [[credentialsId: 'ed25519.Hibernate-CI.github.com', url: 'https://github.com/hibernate/hibernate.org.git']]
+                                        )
+                                        sh "../scripts/website-release.sh ${env.SCRIPT_OPTIONS} ${env.PROJECT} ${env.RELEASE_VERSION}"
+                                    }
 								}
 							}
 						}


### PR DESCRIPTION
<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

[Please describe here what your change is about]

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
