### PR TITLE
HHH-19780 - OracleDatabaseCleaner must not fail when not finding an object to drop

### DIFF
--- a/local-build-plugins/src/main/groovy/local.java-module.gradle
+++ b/local-build-plugins/src/main/groovy/local.java-module.gradle
@@ -245,6 +245,7 @@ test {
         // Log a statement for each test.
         // Used in the Travis build so that Travis doesn't end up panicking because there's no output for a long time.
         testLogging {
+            displayGranularity 1
             events "passed", "skipped", "failed"
             exceptionFormat = 'full'
         }


### PR DESCRIPTION
This PR fixes the Oracle Database Cleaner, especially not throwing an exception whenever an object to be dropped is already dropped.

----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-19780
<!-- Hibernate GitHub Bot issue links end -->