### PR TITLE
[6.2] Package-private members access fixes for bytecode enhancement

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/bytecode/enhance/internal/bytebuddy/EnhancerImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/bytecode/enhance/internal/bytebuddy/EnhancerImpl.java
@@ -532,8 +532,23 @@ public class EnhancerImpl implements Enhancer {
 			return fieldDescription.getDescriptor();
 		}
 
-		boolean isVisibleTo(TypeDescription typeDescription) {
-			return fieldDescription.isVisibleTo( typeDescription );
+		boolean isVisibleTo(TypeDescription type) {
+			final var declaringType = fieldDescription.getDeclaringType().asErasure();
+			if ( declaringType.isVisibleTo( type ) ) {
+				if ( fieldDescription.isPublic() || type.equals( declaringType ) ) {
+					return true;
+				}
+				else if ( fieldDescription.isProtected() ) {
+					return declaringType.isAssignableFrom( type );
+				}
+				else if ( fieldDescription.isPrivate() ) {
+					return type.isNestMateOf( declaringType );
+				}
+				// We explicitly consider package-private fields as not visible, as the classes
+				// might have the same package name but be loaded by different class loaders.
+				// (see https://hibernate.atlassian.net/browse/HHH-19784)
+			}
+			return false;
 		}
 
 		FieldDescription getFieldDescription() {

--- a/hibernate-core/src/main/java/org/hibernate/bytecode/internal/bytebuddy/BytecodeProviderImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/bytecode/internal/bytebuddy/BytecodeProviderImpl.java
@@ -73,6 +73,7 @@ public class BytecodeProviderImpl implements BytecodeProvider {
 
 	private static final String INSTANTIATOR_PROXY_NAMING_SUFFIX = "HibernateInstantiator";
 	private static final String OPTIMIZER_PROXY_NAMING_SUFFIX = "HibernateAccessOptimizer";
+	private static final String OPTIMIZER_PROXY_BRIDGE_NAMING_SUFFIX = "HibernateAccessOptimizerBridge";
 	private static final ElementMatcher.Junction<NamedElement> newInstanceMethodName = ElementMatchers.named(
 			"newInstance" );
 	private static final ElementMatcher.Junction<NamedElement> getPropertyValuesMethodName = ElementMatchers.named(
@@ -304,12 +305,14 @@ public class BytecodeProviderImpl implements BytecodeProvider {
 		for ( int i = foreignPackageClassInfos.size() - 1; i >= 0; i-- ) {
 			final ForeignPackageClassInfo foreignPackageClassInfo = foreignPackageClassInfos.get( i );
 			final Class<?> newSuperClass = superClass;
+
+			final String suffix = OPTIMIZER_PROXY_BRIDGE_NAMING_SUFFIX + encodeName( foreignPackageClassInfo.propertyNames, foreignPackageClassInfo.getters, foreignPackageClassInfo.setters );
 			superClass = byteBuddyState.load(
 					foreignPackageClassInfo.clazz,
 					byteBuddy -> {
 						DynamicType.Builder<?> builder = byteBuddy.with(
 								new NamingStrategy.SuffixingRandom(
-										OPTIMIZER_PROXY_NAMING_SUFFIX,
+										suffix,
 										new NamingStrategy.SuffixingRandom.BaseNameResolver.ForFixedValue(
 												foreignPackageClassInfo.clazz.getName() )
 								)

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/ForeignPackageSuperclassAccessorTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/ForeignPackageSuperclassAccessorTest.java
@@ -1,0 +1,41 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html
+ */
+package org.hibernate.orm.test.bytecode;
+
+import org.hibernate.orm.test.bytecode.foreignpackage.ConcreteEntity;
+
+import org.hibernate.testing.bytecode.enhancement.BytecodeEnhancerRunner;
+import org.hibernate.testing.junit4.BaseNonConfigCoreFunctionalTestCase;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.Jira;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@SessionFactory
+@DomainModel(annotatedClasses = {
+		ConcreteEntity.class,
+		SuperclassEntity.class
+})
+@Jira("https://hibernate.atlassian.net/browse/HHH-19369")
+@RunWith( BytecodeEnhancerRunner.class )
+public class ForeignPackageSuperclassAccessorTest extends BaseNonConfigCoreFunctionalTestCase {
+	@Override
+	protected Class[] getAnnotatedClasses() {
+		return new Class[]{
+				ConcreteEntity.class,
+				SuperclassEntity.class
+		};
+	}
+
+	@Test
+	public void test() {
+		inTransaction( session -> {
+			session.find( SuperclassEntity.class, 1L );
+		} );
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/SuperclassEntity.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/SuperclassEntity.java
@@ -1,0 +1,30 @@
+package org.hibernate.orm.test.bytecode;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Inheritance;
+import jakarta.persistence.InheritanceType;
+
+@Entity
+@Inheritance(strategy = InheritanceType.JOINED)
+public class SuperclassEntity {
+    @Id
+    protected long id;
+    protected String name;
+
+    public long getId() {
+        return id;
+    }
+
+    public void setId(long id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/optimizer/AncestorEntity.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/optimizer/AncestorEntity.java
@@ -5,15 +5,14 @@
 package org.hibernate.orm.test.bytecode.enhancement.optimizer;
 
 import jakarta.persistence.Entity;
-import jakarta.persistence.Id;
 import jakarta.persistence.Inheritance;
 import jakarta.persistence.InheritanceType;
+import org.hibernate.orm.test.bytecode.enhancement.optimizer.parent.Ancestor;
 
-@Entity(name = "ParentEntity")
+@Entity(name = "AncestorEntity")
 @Inheritance(strategy = InheritanceType.JOINED)
-public class ParentEntity  {
+public class AncestorEntity extends Ancestor {
 
-	@Id
 	private Long id;
 
 	private String field;

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/optimizer/ChildEntity3.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/optimizer/ChildEntity3.java
@@ -1,0 +1,20 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.bytecode.enhancement.optimizer;
+
+import jakarta.persistence.Entity;
+
+@Entity(name = "ChildEntity3")
+public class ChildEntity3 extends AncestorEntity {
+	private String childField;
+
+	public String getChildField() {
+		return childField;
+	}
+
+	public void setChieldField(String childField) {
+		this.childField = childField;
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/optimizer/ChildEntity4.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/optimizer/ChildEntity4.java
@@ -1,0 +1,20 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.bytecode.enhancement.optimizer;
+
+import jakarta.persistence.Entity;
+
+@Entity(name = "ChildEntity4")
+public class ChildEntity4 extends AncestorEntity {
+	private String childField;
+
+	public String getChildField() {
+		return childField;
+	}
+
+	public void setChieldField(String childField) {
+		this.childField = childField;
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/optimizer/ChildEntity5.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/optimizer/ChildEntity5.java
@@ -1,0 +1,20 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.bytecode.enhancement.optimizer;
+
+import jakarta.persistence.Entity;
+
+@Entity(name = "ChildEntity5")
+public class ChildEntity5 extends AncestorEntity {
+	private String childField;
+
+	public String getChildField() {
+		return childField;
+	}
+
+	public void setChieldField(String childField) {
+		this.childField = childField;
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/optimizer/ChildEntity6.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/optimizer/ChildEntity6.java
@@ -1,0 +1,20 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.bytecode.enhancement.optimizer;
+
+import jakarta.persistence.Entity;
+
+@Entity(name = "ChildEntity6")
+public class ChildEntity6 extends AncestorEntity {
+	private String childField;
+
+	public String getChildField() {
+		return childField;
+	}
+
+	public void setChieldField(String childField) {
+		this.childField = childField;
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/optimizer/ChildEntity7.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/optimizer/ChildEntity7.java
@@ -1,0 +1,20 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.bytecode.enhancement.optimizer;
+
+import jakarta.persistence.Entity;
+
+@Entity(name = "ChildEntity7")
+public class ChildEntity7 extends AncestorEntity {
+	private String childField;
+
+	public String getChildField() {
+		return childField;
+	}
+
+	public void setChildField(String childField) {
+		this.childField = childField;
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/optimizer/ChildEntity8.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/optimizer/ChildEntity8.java
@@ -1,0 +1,20 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.bytecode.enhancement.optimizer;
+
+import jakarta.persistence.Entity;
+
+@Entity(name = "ChildEntity8")
+public class ChildEntity8 extends AncestorEntity {
+	private String childField;
+
+	public String getChildField() {
+		return childField;
+	}
+
+	public void setChildField(String childField) {
+		this.childField = childField;
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/optimizer/ChildEntity9.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/optimizer/ChildEntity9.java
@@ -1,0 +1,20 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.bytecode.enhancement.optimizer;
+
+import jakarta.persistence.Entity;
+
+@Entity(name = "ChildEntity9")
+public class ChildEntity9 extends AncestorEntity {
+	private String childField;
+
+	public String getChildField() {
+		return childField;
+	}
+
+	public void setChildField(String childField) {
+		this.childField = childField;
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/optimizer/HierarchyBytecodeOptimizerMethodVisibilityTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/optimizer/HierarchyBytecodeOptimizerMethodVisibilityTest.java
@@ -1,0 +1,70 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.bytecode.enhancement.optimizer;
+
+import org.hibernate.orm.test.bytecode.enhancement.optimizer.child.ChildEntity10;
+import org.hibernate.orm.test.bytecode.enhancement.optimizer.parent.Ancestor;
+import org.hibernate.orm.test.bytecode.enhancement.optimizer.parent.ChildEntity2;
+import org.hibernate.query.Query;
+
+import org.hibernate.testing.bytecode.enhancement.BytecodeEnhancerRunner;
+import org.hibernate.testing.junit4.BaseNonConfigCoreFunctionalTestCase;
+import org.hibernate.testing.orm.junit.Jira;
+import org.junit.After;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Jira("https://hibernate.atlassian.net/browse/HHH-19372")
+@RunWith( BytecodeEnhancerRunner.class )
+public class HierarchyBytecodeOptimizerMethodVisibilityTest extends BaseNonConfigCoreFunctionalTestCase {
+	@Override
+	protected Class[] getAnnotatedClasses() {
+		return new Class[]{
+				Ancestor.class,
+				AncestorEntity.class,
+				ChildEntity2.class,
+				ChildEntity10.class
+		};
+	}
+
+	@Test
+	public void testOptimizerSetPropertyValues() {
+		ChildEntity2 childEntity2 = new ChildEntity2();
+		childEntity2.setId( 1L );
+		childEntity2.setField( "field" );
+		childEntity2.setChieldField( "childField" );
+
+		ChildEntity10 childEntity10 = new ChildEntity10();
+		childEntity10.setId( 3L );
+		childEntity10.setField( "field10" );
+		childEntity10.setChieldField( "childField3" );
+
+		inTransaction( session -> {
+			session.persist( childEntity2 );
+			session.persist( childEntity10 );
+		} );
+
+		inTransaction( session -> {
+			Query<ChildEntity2> query = session.createQuery( "select c from ChildEntity2 c where c.field = :field",
+					ChildEntity2.class );
+			query.setParameter( "field", "field" );
+			assertThat( query.uniqueResult() ).isNotNull();
+		} );
+
+		inTransaction( session -> {
+			Query<ChildEntity10> query = session.createQuery( "select c from ChildEntity10 c where c.field = :field",
+					ChildEntity10.class );
+			query.setParameter( "field", "field10" );
+			assertThat( query.uniqueResult() ).isNotNull();
+		} );
+	}
+
+	@After
+	public void cleanup() {
+		sessionFactory().getSchemaManager().truncateMappedObjects();
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/optimizer/HierarchyBytecodeOptimizerOrderingTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/optimizer/HierarchyBytecodeOptimizerOrderingTest.java
@@ -1,0 +1,118 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.bytecode.enhancement.optimizer;
+
+import org.hibernate.orm.test.bytecode.enhancement.optimizer.parent.Ancestor;
+import org.hibernate.query.Query;
+
+import org.hibernate.testing.bytecode.enhancement.BytecodeEnhancerRunner;
+import org.hibernate.testing.junit4.BaseNonConfigCoreFunctionalTestCase;
+import org.hibernate.testing.orm.junit.Jira;
+
+import org.junit.After;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Jira("https://hibernate.atlassian.net/browse/HHH-19369")
+@RunWith( BytecodeEnhancerRunner.class )
+public class HierarchyBytecodeOptimizerOrderingTest extends BaseNonConfigCoreFunctionalTestCase {
+	@Override
+	protected Class[] getAnnotatedClasses() {
+		return new Class[]{
+				Ancestor.class,
+				ParentEntity.class,
+				ChildEntity3.class,
+				ChildEntity4.class,
+				ChildEntity5.class,
+				ChildEntity6.class,
+				ChildEntity7.class,
+				ChildEntity8.class,
+				ChildEntity9.class
+		};
+	}
+
+	@Test
+	public void testOptimizerSetPropertyValues() {
+		ChildEntity3 childEntity3 = new ChildEntity3();
+		childEntity3.setId( 3L );
+		childEntity3.setName( "child3" );
+		childEntity3.setField( "field3" );
+		childEntity3.setChieldField( "childField3" );
+
+		ChildEntity4 childEntity4 = new ChildEntity4();
+		childEntity4.setId( 4L );
+		childEntity4.setName( "child4" );
+		childEntity4.setField( "field4" );
+		childEntity4.setChieldField( "childField4" );
+
+		ChildEntity5 childEntity5 = new ChildEntity5();
+		childEntity5.setId( 5L );
+		childEntity5.setName( "child5" );
+		childEntity5.setField( "field5" );
+		childEntity5.setChieldField( "childField5" );
+
+		ChildEntity6 childEntity6 = new ChildEntity6();
+		childEntity6.setId( 6L );
+		childEntity6.setName( "child6" );
+		childEntity6.setField( "field6" );
+		childEntity6.setChieldField( "childField6" );
+
+		ChildEntity7 childEntity7 = new ChildEntity7();
+		childEntity7.setId( 7L );
+		childEntity7.setName( "child7" );
+		childEntity7.setField( "field7" );
+		childEntity7.setChildField( "childField7" );
+
+		inTransaction( session -> {
+			session.persist( childEntity3 );
+			session.persist( childEntity4 );
+			session.persist( childEntity5 );
+			session.persist( childEntity6 );
+			session.persist( childEntity7 );
+		} );
+
+		inTransaction( session -> {
+			Query<ChildEntity3> query = session.createQuery( "select c from ChildEntity3 c where c.field = :field",
+					ChildEntity3.class );
+			query.setParameter( "field", "field3" );
+			assertThat( query.uniqueResult() ).isNotNull();
+		} );
+
+		inTransaction( session -> {
+			Query<ChildEntity4> query = session.createQuery( "select c from ChildEntity4 c where c.field = :field",
+					ChildEntity4.class );
+			query.setParameter( "field", "field4" );
+			assertThat( query.uniqueResult() ).isNotNull();
+		} );
+
+		inTransaction( session -> {
+			Query<ChildEntity5> query = session.createQuery( "select c from ChildEntity5 c where c.field = :field",
+					ChildEntity5.class );
+			query.setParameter( "field", "field5" );
+			assertThat( query.uniqueResult() ).isNotNull();
+		} );
+
+		inTransaction( session -> {
+			Query<ChildEntity6> query = session.createQuery( "select c from ChildEntity6 c where c.field = :field",
+					ChildEntity6.class );
+			query.setParameter( "field", "field6" );
+			assertThat( query.uniqueResult() ).isNotNull();
+		} );
+
+		inTransaction( session -> {
+			Query<ChildEntity7> query = session.createQuery(
+					"select c from ChildEntity7 c where c.field = :field", ChildEntity7.class );
+			query.setParameter( "field", "field7" );
+			assertThat( query.uniqueResult() ).isNotNull();
+		} );
+	}
+
+	@After
+	public void cleanup() {
+		sessionFactory().getSchemaManager().truncateMappedObjects();
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/optimizer/HierarchyBytecodeOptimizerTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/optimizer/HierarchyBytecodeOptimizerTest.java
@@ -1,0 +1,49 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.bytecode.enhancement.optimizer;
+
+import org.hibernate.orm.test.bytecode.enhancement.optimizer.child.ChildEntity;
+import org.hibernate.query.Query;
+
+import org.hibernate.testing.bytecode.enhancement.extension.BytecodeEnhanced;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.Jira;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DomainModel(annotatedClasses = {
+		ParentEntity.class,
+		ChildEntity.class,
+})
+@SessionFactory
+@Jira( "https://hibernate.atlassian.net/browse/HHH-19059" )
+@BytecodeEnhanced
+public class HierarchyBytecodeOptimizerTest {
+
+	@Test
+	public void testOptimizerSetPropertyValues(SessionFactoryScope scope) {
+		ChildEntity childEntity = new ChildEntity();
+		childEntity.setId( 1L );
+		childEntity.setField( "field" );
+		childEntity.setChieldField( "childField" );
+
+		scope.inTransaction( session -> session.persist( childEntity ) );
+
+		scope.inTransaction( session -> {
+			Query<ChildEntity> query = session.createQuery( "select c from ChildEntity c where c.field = :field", ChildEntity.class);
+			query.setParameter( "field", "field" );
+			assertThat( query.uniqueResult() ).isNotNull();
+		} );
+	}
+
+	@AfterAll
+	public void cleanup(SessionFactoryScope scope) {
+		scope.getSessionFactory().getSchemaManager().truncateMappedObjects();
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/optimizer/HierarchyBytecodeOptimizerTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/optimizer/HierarchyBytecodeOptimizerTest.java
@@ -7,43 +7,49 @@ package org.hibernate.orm.test.bytecode.enhancement.optimizer;
 import org.hibernate.orm.test.bytecode.enhancement.optimizer.child.ChildEntity;
 import org.hibernate.query.Query;
 
-import org.hibernate.testing.bytecode.enhancement.extension.BytecodeEnhanced;
-import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.bytecode.enhancement.BytecodeEnhancerRunner;
+import org.hibernate.testing.junit4.BaseNonConfigCoreFunctionalTestCase;
 import org.hibernate.testing.orm.junit.Jira;
-import org.hibernate.testing.orm.junit.SessionFactory;
-import org.hibernate.testing.orm.junit.SessionFactoryScope;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.Test;
+
+import org.junit.After;
+import org.junit.Test;
+import org.junit.runner.RunWith;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@DomainModel(annotatedClasses = {
-		ParentEntity.class,
-		ChildEntity.class,
-})
-@SessionFactory
-@Jira( "https://hibernate.atlassian.net/browse/HHH-19059" )
-@BytecodeEnhanced
-public class HierarchyBytecodeOptimizerTest {
+@Jira("https://hibernate.atlassian.net/browse/HHH-19372")
+@RunWith( BytecodeEnhancerRunner.class )
+public class HierarchyBytecodeOptimizerTest extends BaseNonConfigCoreFunctionalTestCase {
+	@Override
+	protected Class[] getAnnotatedClasses() {
+		return new Class[]{
+				ParentEntity.class,
+				ChildEntity.class,
+		};
+	}
 
 	@Test
-	public void testOptimizerSetPropertyValues(SessionFactoryScope scope) {
+	public void testOptimizerSetPropertyValues() {
 		ChildEntity childEntity = new ChildEntity();
 		childEntity.setId( 1L );
 		childEntity.setField( "field" );
 		childEntity.setChieldField( "childField" );
 
-		scope.inTransaction( session -> session.persist( childEntity ) );
+		inTransaction( session -> {
+			session.persist( childEntity );
+		} );
 
-		scope.inTransaction( session -> {
-			Query<ChildEntity> query = session.createQuery( "select c from ChildEntity c where c.field = :field", ChildEntity.class);
+		inTransaction( session -> {
+			Query<ChildEntity> query = session.createQuery( "select c from ChildEntity c where c.field = :field",
+					ChildEntity.class );
 			query.setParameter( "field", "field" );
 			assertThat( query.uniqueResult() ).isNotNull();
 		} );
+
 	}
 
-	@AfterAll
-	public void cleanup(SessionFactoryScope scope) {
-		scope.getSessionFactory().getSchemaManager().truncateMappedObjects();
+	@After
+	public void cleanup() {
+		sessionFactory().getSchemaManager().truncateMappedObjects();
 	}
 }

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/optimizer/ParentEntity.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/optimizer/ParentEntity.java
@@ -1,0 +1,35 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.bytecode.enhancement.optimizer;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Inheritance;
+import jakarta.persistence.InheritanceType;
+
+@Entity(name = "ParentEntity")
+@Inheritance(strategy = InheritanceType.JOINED)
+public class ParentEntity {
+	@Id
+	private Long id;
+
+	private String field;
+
+	public Long getId() {
+		return id;
+	}
+
+	public void setId(Long id) {
+		this.id = id;
+	}
+
+	public String getField() {
+		return field;
+	}
+
+	public void setField(String field) {
+		this.field = field;
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/optimizer/child/ChildEntity.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/optimizer/child/ChildEntity.java
@@ -1,0 +1,22 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.bytecode.enhancement.optimizer.child;
+
+import org.hibernate.orm.test.bytecode.enhancement.optimizer.ParentEntity;
+
+import jakarta.persistence.Entity;
+
+@Entity(name = "ChildEntity")
+public class ChildEntity extends ParentEntity {
+	private String childField;
+
+	public String getChildField() {
+		return childField;
+	}
+
+	public void setChieldField(String childField) {
+		this.childField = childField;
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/optimizer/child/ChildEntity10.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/optimizer/child/ChildEntity10.java
@@ -1,0 +1,21 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.bytecode.enhancement.optimizer.child;
+
+import jakarta.persistence.Entity;
+import org.hibernate.orm.test.bytecode.enhancement.optimizer.AncestorEntity;
+
+@Entity(name = "ChildEntity10")
+public class ChildEntity10 extends AncestorEntity {
+	private String childField;
+
+	public String getChildField() {
+		return childField;
+	}
+
+	public void setChieldField(String childField) {
+		this.childField = childField;
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/optimizer/parent/Ancestor.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/optimizer/parent/Ancestor.java
@@ -2,21 +2,20 @@
  * SPDX-License-Identifier: Apache-2.0
  * Copyright Red Hat Inc. and Hibernate Authors
  */
-package org.hibernate.orm.test.bytecode.enhancement.optimizer;
+package org.hibernate.orm.test.bytecode.enhancement.optimizer.parent;
 
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jakarta.persistence.Inheritance;
 import jakarta.persistence.InheritanceType;
 
-@Entity(name = "ParentEntity")
+@Entity(name = "Parent")
 @Inheritance(strategy = InheritanceType.JOINED)
-public class ParentEntity  {
-
+public class Ancestor {
 	@Id
 	private Long id;
 
-	private String field;
+	private String name;
 
 	public Long getId() {
 		return id;
@@ -26,11 +25,11 @@ public class ParentEntity  {
 		this.id = id;
 	}
 
-	public String getField() {
-		return field;
+	public String getName() {
+		return name;
 	}
 
-	public void setField(String field) {
-		this.field = field;
+	public void setName(String name) {
+		this.name = name;
 	}
 }

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/optimizer/parent/ChildEntity2.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/optimizer/parent/ChildEntity2.java
@@ -1,0 +1,21 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.bytecode.enhancement.optimizer.parent;
+
+import jakarta.persistence.Entity;
+import org.hibernate.orm.test.bytecode.enhancement.optimizer.AncestorEntity;
+
+@Entity(name = "ChildEntity2")
+public class ChildEntity2 extends AncestorEntity {
+	private String childField;
+
+	public String getChildField() {
+		return childField;
+	}
+
+	public void setChieldField(String childField) {
+		this.childField = childField;
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/foreignpackage/ConcreteEntity.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/foreignpackage/ConcreteEntity.java
@@ -1,0 +1,29 @@
+package org.hibernate.orm.test.bytecode.foreignpackage;
+
+import org.hibernate.orm.test.bytecode.SuperclassEntity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+
+@Entity
+public class ConcreteEntity extends SuperclassEntity {
+    @Id
+    protected long id;
+    protected String bname;
+
+    public long getId() {
+        return id;
+    }
+
+    public void setId(long id) {
+        this.id = id;
+    }
+
+    public String getBname() {
+        return bname;
+    }
+
+    public void setBname(String bname) {
+        this.bname = bname;
+    }
+}


### PR DESCRIPTION
<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

Fixes https://hibernate.atlassian.net/browse/HHH-19784 in the first commit. 

The rest of the commits are a backport of https://github.com/hibernate/hibernate-orm/pull/10192, which are required to make access optimizers work in similar cases (package-private fields in the same hierarchy but with different classloaders).

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-19369
https://hibernate.atlassian.net/browse/HHH-19372
<!-- Hibernate GitHub Bot issue links end -->