### PR TITLE
Graal-VM initialization issues

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/bytecode/enhance/internal/bytebuddy/ByteBuddyEnhancementContext.java
+++ b/hibernate-core/src/main/java/org/hibernate/bytecode/enhance/internal/bytebuddy/ByteBuddyEnhancementContext.java
@@ -15,6 +15,7 @@ import java.util.stream.Collectors;
 
 import org.hibernate.bytecode.enhance.internal.bytebuddy.EnhancerImpl.AnnotatedFieldDescription;
 import org.hibernate.bytecode.enhance.spi.EnhancementContext;
+import org.hibernate.internal.util.LazyValue;
 
 import jakarta.persistence.Embedded;
 import jakarta.persistence.metamodel.Type;
@@ -30,7 +31,8 @@ import static net.bytebuddy.matcher.ElementMatchers.isGetter;
 
 class ByteBuddyEnhancementContext {
 
-	private static final ElementMatcher.Junction<MethodDescription> IS_GETTER = isGetter();
+	// Lazy is necessary to not break GraalVM Native Image
+	private static final LazyValue<ElementMatcher.Junction<MethodDescription>> IS_GETTER = new LazyValue<>(() -> isGetter());
 
 	private final EnhancementContext enhancementContext;
 
@@ -170,7 +172,7 @@ class ByteBuddyEnhancementContext {
 					getters = MethodGraph.Compiler.DEFAULT.compile( erasure )
 							.listNodes()
 							.asMethodList()
-							.filter( IS_GETTER )
+							.filter( IS_GETTER.getValue() )
 							.stream()
 							.collect( Collectors.toMap( MethodDescription::getActualName, Function.identity() ) );
 					getterByTypeMap.put( erasure, getters );


### PR DESCRIPTION
[Please describe here what your change is about]

Running hibernate 6.6.23.Final with Graal-VM throws the next errors:
```
Error: Classes that should be initialized at run time got initialized during image building:
 net.bytebuddy.description.type.TypeDescription$AbstractBase was unintentionally initialized at build time. org.hibernate.proxy.pojo.bytebuddy.ByteBuddyProxyHelper caused initialization of this class with the following trace: 
	at net.bytebuddy.description.type.TypeDescription$AbstractBase.<clinit>(TypeDescription.java)
	at org.hibernate.proxy.pojo.bytebuddy.ByteBuddyProxyHelper.<clinit>(ByteBuddyProxyHelper.java:44)

net.bytebuddy.utility.GraalImageCode was unintentionally initialized at build time. org.hibernate.proxy.pojo.bytebuddy.ByteBuddyProxyHelper caused initialization of this class with the following trace: 
	at net.bytebuddy.utility.GraalImageCode.<clinit>(GraalImageCode.java)
	at net.bytebuddy.utility.dispatcher.JavaDispatcher$DynamicClassLoader.invoker(JavaDispatcher.java:1321)
	at net.bytebuddy.utility.dispatcher.JavaDispatcher$InvokerCreationAction.run(JavaDispatcher.java:460)
	at net.bytebuddy.utility.dispatcher.JavaDispatcher$InvokerCreationAction.run(JavaDispatcher.java:453)
	at java.security.AccessController.executePrivileged(AccessController.java:778)
	at java.security.AccessController.doPrivileged(AccessController.java:319)
	at net.bytebuddy.utility.dispatcher.JavaDispatcher.doPrivileged(JavaDispatcher.java)
	at net.bytebuddy.utility.dispatcher.JavaDispatcher.<clinit>(JavaDispatcher.java:88)
	at net.bytebuddy.description.type.TypeDescription$ForLoadedType.<clinit>(TypeDescription.java:8725)
	at org.hibernate.proxy.pojo.bytebuddy.ByteBuddyProxyHelper.<clinit>(ByteBuddyProxyHelper.java:44)

net.bytebuddy.utility.dispatcher.JavaDispatcher was unintentionally initialized at build time. org.hibernate.proxy.pojo.bytebuddy.ByteBuddyProxyHelper caused initialization of this class with the following trace: 
	at net.bytebuddy.utility.dispatcher.JavaDispatcher.<clinit>(JavaDispatcher.java)
	at net.bytebuddy.description.type.TypeDescription$ForLoadedType.<clinit>(TypeDescription.java:8725)
	at org.hibernate.proxy.pojo.bytebuddy.ByteBuddyProxyHelper.<clinit>(ByteBuddyProxyHelper.java:44)

net.bytebuddy.utility.dispatcher.JavaDispatcher$DynamicClassLoader was unintentionally initialized at build time. org.hibernate.proxy.pojo.bytebuddy.ByteBuddyProxyHelper caused initialization of this class with the following trace: 
	at net.bytebuddy.utility.dispatcher.JavaDispatcher$DynamicClassLoader.<clinit>(JavaDispatcher.java:1199)
	at net.bytebuddy.utility.dispatcher.JavaDispatcher$InvokerCreationAction.run(JavaDispatcher.java:460)
	at net.bytebuddy.utility.dispatcher.JavaDispatcher$InvokerCreationAction.run(JavaDispatcher.java:453)
	at java.security.AccessController.executePrivileged(AccessController.java:778)
	at java.security.AccessController.doPrivileged(AccessController.java:319)
	at net.bytebuddy.utility.dispatcher.JavaDispatcher.doPrivileged(JavaDispatcher.java)
	at net.bytebuddy.utility.dispatcher.JavaDispatcher.<clinit>(JavaDispatcher.java:88)
	at net.bytebuddy.description.type.TypeDescription$ForLoadedType.<clinit>(TypeDescription.java:8725)
	at org.hibernate.proxy.pojo.bytebuddy.ByteBuddyProxyHelper.<clinit>(ByteBuddyProxyHelper.java:44)

net.bytebuddy.description.type.TypeDefinition$Sort was unintentionally initialized at build time. org.hibernate.bytecode.enhance.internal.bytebuddy.ByteBuddyEnhancementContext caused initialization of this class with the following trace: 
	at net.bytebuddy.description.type.TypeDefinition$Sort.<clinit>(TypeDefinition.java)
	at net.bytebuddy.description.type.TypeList$Generic$ForLoadedTypes.get(TypeList.java:449)
	at net.bytebuddy.description.type.TypeList$Generic$ForLoadedTypes.get(TypeList.java:420)
	at java.util.AbstractList$Itr.next(AbstractList.java:373)
	at net.bytebuddy.matcher.ElementMatchers.anyOf(ElementMatchers.java:346)
	at net.bytebuddy.matcher.ElementMatchers.anyOf(ElementMatchers.java:365)
	at net.bytebuddy.matcher.ElementMatchers.isGetter(ElementMatchers.java:1764)
	at org.hibernate.bytecode.enhance.internal.bytebuddy.ByteBuddyEnhancementContext.<clinit>(ByteBuddyEnhancementContext.java:33)

net.bytebuddy.description.type.TypeDescription$Generic$OfNonGenericType$ForLoadedType was unintentionally initialized at build time. org.hibernate.bytecode.enhance.internal.bytebuddy.ByteBuddyEnhancementContext caused initialization of this class with the following trace: 
	at net.bytebuddy.description.type.TypeDescription$Generic$OfNonGenericType$ForLoadedType.<clinit>(TypeDescription.java:3929)
	at net.bytebuddy.description.type.TypeDefinition$Sort.describe(TypeDefinition.java:270)
	at net.bytebuddy.description.type.TypeDefinition$Sort.describe(TypeDefinition.java:244)
	at net.bytebuddy.description.type.TypeList$Generic$ForLoadedTypes.get(TypeList.java:449)
	at net.bytebuddy.description.type.TypeList$Generic$ForLoadedTypes.get(TypeList.java:420)
	at java.util.AbstractList$Itr.next(AbstractList.java:373)
	at net.bytebuddy.matcher.ElementMatchers.anyOf(ElementMatchers.java:346)
	at net.bytebuddy.matcher.ElementMatchers.anyOf(ElementMatchers.java:365)
	at net.bytebuddy.matcher.ElementMatchers.isGetter(ElementMatchers.java:1764)
	at org.hibernate.bytecode.enhance.internal.bytebuddy.ByteBuddyEnhancementContext.<clinit>(ByteBuddyEnhancementContext.java:33)

net.bytebuddy.description.type.TypeDescription$ForLoadedType was unintentionally initialized at build time. org.hibernate.proxy.pojo.bytebuddy.ByteBuddyProxyHelper caused initialization of this class with the following trace: 
	at net.bytebuddy.description.type.TypeDescription$ForLoadedType.<clinit>(TypeDescription.java)
	at org.hibernate.proxy.pojo.bytebuddy.ByteBuddyProxyHelper.<clinit>(ByteBuddyProxyHelper.java:44)

net.bytebuddy.ClassFileVersion was unintentionally initialized at build time. org.hibernate.proxy.pojo.bytebuddy.ByteBuddyProxyHelper caused initialization of this class with the following trace: 
	at net.bytebuddy.ClassFileVersion.<clinit>(ClassFileVersion.java)
	at net.bytebuddy.utility.dispatcher.JavaDispatcher$DynamicClassLoader.invoker(JavaDispatcher.java:1315)
	at net.bytebuddy.utility.dispatcher.JavaDispatcher$InvokerCreationAction.run(JavaDispatcher.java:460)
	at net.bytebuddy.utility.dispatcher.JavaDispatcher$InvokerCreationAction.run(JavaDispatcher.java:453)
	at java.security.AccessController.executePrivileged(AccessController.java:778)
	at java.security.AccessController.doPrivileged(AccessController.java:319)
	at net.bytebuddy.utility.dispatcher.JavaDispatcher.doPrivileged(JavaDispatcher.java)
	at net.bytebuddy.utility.dispatcher.JavaDispatcher.<clinit>(JavaDispatcher.java:88)
	at net.bytebuddy.description.type.TypeDescription$ForLoadedType.<clinit>(TypeDescription.java:8725)
	at org.hibernate.proxy.pojo.bytebuddy.ByteBuddyProxyHelper.<clinit>(ByteBuddyProxyHelper.java:44)


com.oracle.svm.core.util.UserError$UserException: Classes that should be initialized at run time got initialized during image building:
 net.bytebuddy.description.type.TypeDescription$AbstractBase was unintentionally initialized at build time. org.hibernate.proxy.pojo.bytebuddy.ByteBuddyProxyHelper caused initialization of this class with the following trace: 
	at net.bytebuddy.description.type.TypeDescription$AbstractBase.<clinit>(TypeDescription.java)
	at org.hibernate.proxy.pojo.bytebuddy.ByteBuddyProxyHelper.<clinit>(ByteBuddyProxyHelper.java:44)

net.bytebuddy.utility.GraalImageCode was unintentionally initialized at build time. org.hibernate.proxy.pojo.bytebuddy.ByteBuddyProxyHelper caused initialization of this class with the following trace: 
	at net.bytebuddy.utility.GraalImageCode.<clinit>(GraalImageCode.java)
	at net.bytebuddy.utility.dispatcher.JavaDispatcher$DynamicClassLoader.invoker(JavaDispatcher.java:1321)
	at net.bytebuddy.utility.dispatcher.JavaDispatcher$InvokerCreationAction.run(JavaDispatcher.java:460)
	at net.bytebuddy.utility.dispatcher.JavaDispatcher$InvokerCreationAction.run(JavaDispatcher.java:453)
	at java.security.AccessController.executePrivileged(AccessController.java:778)
	at java.security.AccessController.doPrivileged(AccessController.java:319)
	at net.bytebuddy.utility.dispatcher.JavaDispatcher.doPrivileged(JavaDispatcher.java)
	at net.bytebuddy.utility.dispatcher.JavaDispatcher.<clinit>(JavaDispatcher.java:88)
	at net.bytebuddy.description.type.TypeDescription$ForLoadedType.<clinit>(TypeDescription.java:8725)
	at org.hibernate.proxy.pojo.bytebuddy.ByteBuddyProxyHelper.<clinit>(ByteBuddyProxyHelper.java:44)

net.bytebuddy.utility.dispatcher.JavaDispatcher was unintentionally initialized at build time. org.hibernate.proxy.pojo.bytebuddy.ByteBuddyProxyHelper caused initialization of this class with the following trace: 
	at net.bytebuddy.utility.dispatcher.JavaDispatcher.<clinit>(JavaDispatcher.java)
	at net.bytebuddy.description.type.TypeDescription$ForLoadedType.<clinit>(TypeDescription.java:8725)
	at org.hibernate.proxy.pojo.bytebuddy.ByteBuddyProxyHelper.<clinit>(ByteBuddyProxyHelper.java:44)

net.bytebuddy.utility.dispatcher.JavaDispatcher$DynamicClassLoader was unintentionally initialized at build time. org.hibernate.proxy.pojo.bytebuddy.ByteBuddyProxyHelper caused initialization of this class with the following trace: 
	at net.bytebuddy.utility.dispatcher.JavaDispatcher$DynamicClassLoader.<clinit>(JavaDispatcher.java:1199)
	at net.bytebuddy.utility.dispatcher.JavaDispatcher$InvokerCreationAction.run(JavaDispatcher.java:460)
	at net.bytebuddy.utility.dispatcher.JavaDispatcher$InvokerCreationAction.run(JavaDispatcher.java:453)
	at java.security.AccessController.executePrivileged(AccessController.java:778)
	at java.security.AccessController.doPrivileged(AccessController.java:319)
	at net.bytebuddy.utility.dispatcher.JavaDispatcher.doPrivileged(JavaDispatcher.java)
	at net.bytebuddy.utility.dispatcher.JavaDispatcher.<clinit>(JavaDispatcher.java:88)
	at net.bytebuddy.description.type.TypeDescription$ForLoadedType.<clinit>(TypeDescription.java:8725)
	at org.hibernate.proxy.pojo.bytebuddy.ByteBuddyProxyHelper.<clinit>(ByteBuddyProxyHelper.java:44)

net.bytebuddy.description.type.TypeDefinition$Sort was unintentionally initialized at build time. org.hibernate.bytecode.enhance.internal.bytebuddy.ByteBuddyEnhancementContext caused initialization of this class with the following trace: 
	at net.bytebuddy.description.type.TypeDefinition$Sort.<clinit>(TypeDefinition.java)
	at net.bytebuddy.description.type.TypeList$Generic$ForLoadedTypes.get(TypeList.java:449)
	at net.bytebuddy.description.type.TypeList$Generic$ForLoadedTypes.get(TypeList.java:420)
	at java.util.AbstractList$Itr.next(AbstractList.java:373)
	at net.bytebuddy.matcher.ElementMatchers.anyOf(ElementMatchers.java:346)
	at net.bytebuddy.matcher.ElementMatchers.anyOf(ElementMatchers.java:365)
	at net.bytebuddy.matcher.ElementMatchers.isGetter(ElementMatchers.java:1764)
	at org.hibernate.bytecode.enhance.internal.bytebuddy.ByteBuddyEnhancementContext.<clinit>(ByteBuddyEnhancementContext.java:33)

net.bytebuddy.description.type.TypeDescription$Generic$OfNonGenericType$ForLoadedType was unintentionally initialized at build time. org.hibernate.bytecode.enhance.internal.bytebuddy.ByteBuddyEnhancementContext caused initialization of this class with the following trace: 
	at net.bytebuddy.description.type.TypeDescription$Generic$OfNonGenericType$ForLoadedType.<clinit>(TypeDescription.java:3929)
	at net.bytebuddy.description.type.TypeDefinition$Sort.describe(TypeDefinition.java:270)
	at net.bytebuddy.description.type.TypeDefinition$Sort.describe(TypeDefinition.java:244)
	at net.bytebuddy.description.type.TypeList$Generic$ForLoadedTypes.get(TypeList.java:449)
	at net.bytebuddy.description.type.TypeList$Generic$ForLoadedTypes.get(TypeList.java:420)
	at java.util.AbstractList$Itr.next(AbstractList.java:373)
	at net.bytebuddy.matcher.ElementMatchers.anyOf(ElementMatchers.java:346)
	at net.bytebuddy.matcher.ElementMatchers.anyOf(ElementMatchers.java:365)
	at net.bytebuddy.matcher.ElementMatchers.isGetter(ElementMatchers.java:1764)
	at org.hibernate.bytecode.enhance.internal.bytebuddy.ByteBuddyEnhancementContext.<clinit>(ByteBuddyEnhancementContext.java:33)

net.bytebuddy.description.type.TypeDescription$ForLoadedType was unintentionally initialized at build time. org.hibernate.proxy.pojo.bytebuddy.ByteBuddyProxyHelper caused initialization of this class with the following trace: 
	at net.bytebuddy.description.type.TypeDescription$ForLoadedType.<clinit>(TypeDescription.java)
	at org.hibernate.proxy.pojo.bytebuddy.ByteBuddyProxyHelper.<clinit>(ByteBuddyProxyHelper.java:44)

net.bytebuddy.ClassFileVersion was unintentionally initialized at build time. org.hibernate.proxy.pojo.bytebuddy.ByteBuddyProxyHelper caused initialization of this class with the following trace: 
	at net.bytebuddy.ClassFileVersion.<clinit>(ClassFileVersion.java)
	at net.bytebuddy.utility.dispatcher.JavaDispatcher$DynamicClassLoader.invoker(JavaDispatcher.java:1315)
	at net.bytebuddy.utility.dispatcher.JavaDispatcher$InvokerCreationAction.run(JavaDispatcher.java:460)
	at net.bytebuddy.utility.dispatcher.JavaDispatcher$InvokerCreationAction.run(JavaDispatcher.java:453)
	at java.security.AccessController.executePrivileged(AccessController.java:778)
	at java.security.AccessController.doPrivileged(AccessController.java:319)
	at net.bytebuddy.utility.dispatcher.JavaDispatcher.doPrivileged(JavaDispatcher.java)
	at net.bytebuddy.utility.dispatcher.JavaDispatcher.<clinit>(JavaDispatcher.java:88)
	at net.bytebuddy.description.type.TypeDescription$ForLoadedType.<clinit>(TypeDescription.java:8725)
	at org.hibernate.proxy.pojo.bytebuddy.ByteBuddyProxyHelper.<clinit>(ByteBuddyProxyHelper.java:44)


	at org.graalvm.nativeimage.builder/com.oracle.svm.core.util.UserError.abort(UserError.java:75)
	at org.graalvm.nativeimage.builder/com.oracle.svm.hosted.classinitialization.ProvenSafeClassInitializationSupport.checkDelayedInitialization(ProvenSafeClassInitializationSupport.java:277)
	at org.graalvm.nativeimage.builder/com.oracle.svm.hosted.classinitialization.ClassInitializationFeature.duringAnalysis(ClassInitializationFeature.java:219)
	at org.graalvm.nativeimage.builder/com.oracle.svm.hosted.NativeImageGenerator.lambda$runPointsToAnalysis$10(NativeImageGenerator.java:787)
	at org.graalvm.nativeimage.builder/com.oracle.svm.hosted.FeatureHandler.forEachFeature(FeatureHandler.java:90)
	at org.graalvm.nativeimage.builder/com.oracle.svm.hosted.NativeImageGenerator.lambda$runPointsToAnalysis$11(NativeImageGenerator.java:787)
	at org.graalvm.nativeimage.pointsto/com.oracle.graal.pointsto.AbstractAnalysisEngine.runAnalysis(AbstractAnalysisEngine.java:181)
	at org.graalvm.nativeimage.builder/com.oracle.svm.hosted.NativeImageGenerator.runPointsToAnalysis(NativeImageGenerator.java:784)
	at org.graalvm.nativeimage.builder/com.oracle.svm.hosted.NativeImageGenerator.doRun(NativeImageGenerator.java:593)
	at org.graalvm.nativeimage.builder/com.oracle.svm.hosted.NativeImageGenerator.run(NativeImageGenerator.java:551)
	at org.graalvm.nativeimage.builder/com.oracle.svm.hosted.NativeImageGeneratorRunner.buildImage(NativeImageGeneratorRunner.java:539)
	at org.graalvm.nativeimage.builder/com.oracle.svm.hosted.NativeImageGeneratorRunner.build(NativeImageGeneratorRunner.java:721)
	at org.graalvm.nativeimage.builder/com.oracle.svm.hosted.NativeImageGeneratorRunner.start(NativeImageGeneratorRunner.java:143)
	at org.graalvm.nativeimage.builder/com.oracle.svm.hosted.NativeImageGeneratorRunner.main(NativeImageGeneratorRunner.java:98)



Error: Classes that should be initialized at run time got initialized during image building:
 net.bytebuddy.utility.dispatcher.JavaDispatcher$DynamicClassLoader was unintentionally initialized at build time. org.hibernate.bytecode.enhance.internal.bytebuddy.ByteBuddyEnhancementContext caused initialization of this class with the following trace: 
	at net.bytebuddy.utility.dispatcher.JavaDispatcher$DynamicClassLoader.<clinit>(JavaDispatcher.java:1199)
	at net.bytebuddy.utility.dispatcher.JavaDispatcher$InvokerCreationAction.run(JavaDispatcher.java:460)
	at net.bytebuddy.utility.dispatcher.JavaDispatcher$InvokerCreationAction.run(JavaDispatcher.java:453)
	at java.security.AccessController.executePrivileged(AccessController.java:778)
	at java.security.AccessController.doPrivileged(AccessController.java:319)
	at net.bytebuddy.utility.dispatcher.JavaDispatcher.doPrivileged(JavaDispatcher.java)
	at net.bytebuddy.utility.dispatcher.JavaDispatcher.<clinit>(JavaDispatcher.java:88)
	at net.bytebuddy.description.type.TypeDescription$ForLoadedType.<clinit>(TypeDescription.java:8725)
	at net.bytebuddy.matcher.ElementMatchers.isGetter(ElementMatchers.java:1764)
	at org.hibernate.bytecode.enhance.internal.bytebuddy.ByteBuddyEnhancementContext.<clinit>(ByteBuddyEnhancementContext.java:33)

net.bytebuddy.ClassFileVersion was unintentionally initialized at build time. org.hibernate.bytecode.enhance.internal.bytebuddy.ByteBuddyEnhancementContext caused initialization of this class with the following trace: 
	at net.bytebuddy.ClassFileVersion.<clinit>(ClassFileVersion.java)
	at net.bytebuddy.utility.dispatcher.JavaDispatcher$DynamicClassLoader.invoker(JavaDispatcher.java:1315)
	at net.bytebuddy.utility.dispatcher.JavaDispatcher$InvokerCreationAction.run(JavaDispatcher.java:460)
	at net.bytebuddy.utility.dispatcher.JavaDispatcher$InvokerCreationAction.run(JavaDispatcher.java:453)
	at java.security.AccessController.executePrivileged(AccessController.java:778)
	at java.security.AccessController.doPrivileged(AccessController.java:319)
	at net.bytebuddy.utility.dispatcher.JavaDispatcher.doPrivileged(JavaDispatcher.java)
	at net.bytebuddy.utility.dispatcher.JavaDispatcher.<clinit>(JavaDispatcher.java:88)
	at net.bytebuddy.description.type.TypeDescription$ForLoadedType.<clinit>(TypeDescription.java:8725)
	at net.bytebuddy.matcher.ElementMatchers.isGetter(ElementMatchers.java:1764)
	at org.hibernate.bytecode.enhance.internal.bytebuddy.ByteBuddyEnhancementContext.<clinit>(ByteBuddyEnhancementContext.java:33)

net.bytebuddy.description.type.TypeDefinition$Sort was unintentionally initialized at build time. org.hibernate.bytecode.enhance.internal.bytebuddy.ByteBuddyEnhancementContext caused initialization of this class with the following trace: 
	at net.bytebuddy.description.type.TypeDefinition$Sort.<clinit>(TypeDefinition.java)
	at net.bytebuddy.description.type.TypeList$Generic$ForLoadedTypes.get(TypeList.java:449)
	at net.bytebuddy.description.type.TypeList$Generic$ForLoadedTypes.get(TypeList.java:420)
	at java.util.AbstractList$Itr.next(AbstractList.java:373)
	at net.bytebuddy.matcher.ElementMatchers.anyOf(ElementMatchers.java:346)
	at net.bytebuddy.matcher.ElementMatchers.anyOf(ElementMatchers.java:365)
	at net.bytebuddy.matcher.ElementMatchers.isGetter(ElementMatchers.java:1764)
	at org.hibernate.bytecode.enhance.internal.bytebuddy.ByteBuddyEnhancementContext.<clinit>(ByteBuddyEnhancementContext.java:33)

net.bytebuddy.description.type.TypeDescription$ForLoadedType was unintentionally initialized at build time. org.hibernate.bytecode.enhance.internal.bytebuddy.ByteBuddyEnhancementContext caused initialization of this class with the following trace: 
	at net.bytebuddy.description.type.TypeDescription$ForLoadedType.<clinit>(TypeDescription.java)
	at net.bytebuddy.matcher.ElementMatchers.isGetter(ElementMatchers.java:1764)
	at org.hibernate.bytecode.enhance.internal.bytebuddy.ByteBuddyEnhancementContext.<clinit>(ByteBuddyEnhancementContext.java:33)

net.bytebuddy.utility.dispatcher.JavaDispatcher was unintentionally initialized at build time. org.hibernate.bytecode.enhance.internal.bytebuddy.ByteBuddyEnhancementContext caused initialization of this class with the following trace: 
	at net.bytebuddy.utility.dispatcher.JavaDispatcher.<clinit>(JavaDispatcher.java)
	at net.bytebuddy.description.type.TypeDescription$ForLoadedType.<clinit>(TypeDescription.java:8725)
	at net.bytebuddy.matcher.ElementMatchers.isGetter(ElementMatchers.java:1764)
	at org.hibernate.bytecode.enhance.internal.bytebuddy.ByteBuddyEnhancementContext.<clinit>(ByteBuddyEnhancementContext.java:33)

net.bytebuddy.description.type.TypeDescription$Generic$OfNonGenericType$ForLoadedType was unintentionally initialized at build time. org.hibernate.bytecode.enhance.internal.bytebuddy.ByteBuddyEnhancementContext caused initialization of this class with the following trace: 
	at net.bytebuddy.description.type.TypeDescription$Generic$OfNonGenericType$ForLoadedType.<clinit>(TypeDescription.java:3929)
	at net.bytebuddy.description.type.TypeDefinition$Sort.describe(TypeDefinition.java:270)
	at net.bytebuddy.description.type.TypeDefinition$Sort.describe(TypeDefinition.java:244)
	at net.bytebuddy.description.type.TypeList$Generic$ForLoadedTypes.get(TypeList.java:449)
	at net.bytebuddy.description.type.TypeList$Generic$ForLoadedTypes.get(TypeList.java:420)
	at java.util.AbstractList$Itr.next(AbstractList.java:373)
	at net.bytebuddy.matcher.ElementMatchers.anyOf(ElementMatchers.java:346)
	at net.bytebuddy.matcher.ElementMatchers.anyOf(ElementMatchers.java:365)
	at net.bytebuddy.matcher.ElementMatchers.isGetter(ElementMatchers.java:1764)
	at org.hibernate.bytecode.enhance.internal.bytebuddy.ByteBuddyEnhancementContext.<clinit>(ByteBuddyEnhancementContext.java:33)

net.bytebuddy.utility.GraalImageCode was unintentionally initialized at build time. org.hibernate.bytecode.enhance.internal.bytebuddy.ByteBuddyEnhancementContext caused initialization of this class with the following trace: 
	at net.bytebuddy.utility.GraalImageCode.<clinit>(GraalImageCode.java)
	at net.bytebuddy.utility.dispatcher.JavaDispatcher$DynamicClassLoader.invoker(JavaDispatcher.java:1321)
	at net.bytebuddy.utility.dispatcher.JavaDispatcher$InvokerCreationAction.run(JavaDispatcher.java:460)
	at net.bytebuddy.utility.dispatcher.JavaDispatcher$InvokerCreationAction.run(JavaDispatcher.java:453)
	at java.security.AccessController.executePrivileged(AccessController.java:778)
	at java.security.AccessController.doPrivileged(AccessController.java:319)
	at net.bytebuddy.utility.dispatcher.JavaDispatcher.doPrivileged(JavaDispatcher.java)
	at net.bytebuddy.utility.dispatcher.JavaDispatcher.<clinit>(JavaDispatcher.java:88)
	at net.bytebuddy.description.type.TypeDescription$ForLoadedType.<clinit>(TypeDescription.java:8725)
	at net.bytebuddy.matcher.ElementMatchers.isGetter(ElementMatchers.java:1764)
	at org.hibernate.bytecode.enhance.internal.bytebuddy.ByteBuddyEnhancementContext.<clinit>(ByteBuddyEnhancementContext.java:33)

net.bytebuddy.description.type.TypeDescription$AbstractBase was unintentionally initialized at build time. org.hibernate.bytecode.enhance.internal.bytebuddy.ByteBuddyEnhancementContext caused initialization of this class with the following trace: 
	at net.bytebuddy.description.type.TypeDescription$AbstractBase.<clinit>(TypeDescription.java)
	at net.bytebuddy.matcher.ElementMatchers.isGetter(ElementMatchers.java:1764)
	at org.hibernate.bytecode.enhance.internal.bytebuddy.ByteBuddyEnhancementContext.<clinit>(ByteBuddyEnhancementContext.java:33)


com.oracle.svm.core.util.UserError$UserException: Classes that should be initialized at run time got initialized during image building:
 net.bytebuddy.utility.dispatcher.JavaDispatcher$DynamicClassLoader was unintentionally initialized at build time. org.hibernate.bytecode.enhance.internal.bytebuddy.ByteBuddyEnhancementContext caused initialization of this class with the following trace: 
	at net.bytebuddy.utility.dispatcher.JavaDispatcher$DynamicClassLoader.<clinit>(JavaDispatcher.java:1199)
	at net.bytebuddy.utility.dispatcher.JavaDispatcher$InvokerCreationAction.run(JavaDispatcher.java:460)
	at net.bytebuddy.utility.dispatcher.JavaDispatcher$InvokerCreationAction.run(JavaDispatcher.java:453)
	at java.security.AccessController.executePrivileged(AccessController.java:778)
	at java.security.AccessController.doPrivileged(AccessController.java:319)
	at net.bytebuddy.utility.dispatcher.JavaDispatcher.doPrivileged(JavaDispatcher.java)
	at net.bytebuddy.utility.dispatcher.JavaDispatcher.<clinit>(JavaDispatcher.java:88)
	at net.bytebuddy.description.type.TypeDescription$ForLoadedType.<clinit>(TypeDescription.java:8725)
	at net.bytebuddy.matcher.ElementMatchers.isGetter(ElementMatchers.java:1764)
	at org.hibernate.bytecode.enhance.internal.bytebuddy.ByteBuddyEnhancementContext.<clinit>(ByteBuddyEnhancementContext.java:33)

net.bytebuddy.ClassFileVersion was unintentionally initialized at build time. org.hibernate.bytecode.enhance.internal.bytebuddy.ByteBuddyEnhancementContext caused initialization of this class with the following trace: 
	at net.bytebuddy.ClassFileVersion.<clinit>(ClassFileVersion.java)
	at net.bytebuddy.utility.dispatcher.JavaDispatcher$DynamicClassLoader.invoker(JavaDispatcher.java:1315)
	at net.bytebuddy.utility.dispatcher.JavaDispatcher$InvokerCreationAction.run(JavaDispatcher.java:460)
	at net.bytebuddy.utility.dispatcher.JavaDispatcher$InvokerCreationAction.run(JavaDispatcher.java:453)
	at java.security.AccessController.executePrivileged(AccessController.java:778)
	at java.security.AccessController.doPrivileged(AccessController.java:319)
	at net.bytebuddy.utility.dispatcher.JavaDispatcher.doPrivileged(JavaDispatcher.java)
	at net.bytebuddy.utility.dispatcher.JavaDispatcher.<clinit>(JavaDispatcher.java:88)
	at net.bytebuddy.description.type.TypeDescription$ForLoadedType.<clinit>(TypeDescription.java:8725)
	at net.bytebuddy.matcher.ElementMatchers.isGetter(ElementMatchers.java:1764)
	at org.hibernate.bytecode.enhance.internal.bytebuddy.ByteBuddyEnhancementContext.<clinit>(ByteBuddyEnhancementContext.java:33)

net.bytebuddy.description.type.TypeDefinition$Sort was unintentionally initialized at build time. org.hibernate.bytecode.enhance.internal.bytebuddy.ByteBuddyEnhancementContext caused initialization of this class with the following trace: 
	at net.bytebuddy.description.type.TypeDefinition$Sort.<clinit>(TypeDefinition.java)
	at net.bytebuddy.description.type.TypeList$Generic$ForLoadedTypes.get(TypeList.java:449)
	at net.bytebuddy.description.type.TypeList$Generic$ForLoadedTypes.get(TypeList.java:420)
	at java.util.AbstractList$Itr.next(AbstractList.java:373)
	at net.bytebuddy.matcher.ElementMatchers.anyOf(ElementMatchers.java:346)
	at net.bytebuddy.matcher.ElementMatchers.anyOf(ElementMatchers.java:365)
	at net.bytebuddy.matcher.ElementMatchers.isGetter(ElementMatchers.java:1764)
	at org.hibernate.bytecode.enhance.internal.bytebuddy.ByteBuddyEnhancementContext.<clinit>(ByteBuddyEnhancementContext.java:33)

net.bytebuddy.description.type.TypeDescription$ForLoadedType was unintentionally initialized at build time. org.hibernate.bytecode.enhance.internal.bytebuddy.ByteBuddyEnhancementContext caused initialization of this class with the following trace: 
	at net.bytebuddy.description.type.TypeDescription$ForLoadedType.<clinit>(TypeDescription.java)
	at net.bytebuddy.matcher.ElementMatchers.isGetter(ElementMatchers.java:1764)
	at org.hibernate.bytecode.enhance.internal.bytebuddy.ByteBuddyEnhancementContext.<clinit>(ByteBuddyEnhancementContext.java:33)

net.bytebuddy.utility.dispatcher.JavaDispatcher was unintentionally initialized at build time. org.hibernate.bytecode.enhance.internal.bytebuddy.ByteBuddyEnhancementContext caused initialization of this class with the following trace: 
	at net.bytebuddy.utility.dispatcher.JavaDispatcher.<clinit>(JavaDispatcher.java)
	at net.bytebuddy.description.type.TypeDescription$ForLoadedType.<clinit>(TypeDescription.java:8725)
	at net.bytebuddy.matcher.ElementMatchers.isGetter(ElementMatchers.java:1764)
	at org.hibernate.bytecode.enhance.internal.bytebuddy.ByteBuddyEnhancementContext.<clinit>(ByteBuddyEnhancementContext.java:33)

net.bytebuddy.description.type.TypeDescription$Generic$OfNonGenericType$ForLoadedType was unintentionally initialized at build time. org.hibernate.bytecode.enhance.internal.bytebuddy.ByteBuddyEnhancementContext caused initialization of this class with the following trace: 
	at net.bytebuddy.description.type.TypeDescription$Generic$OfNonGenericType$ForLoadedType.<clinit>(TypeDescription.java:3929)
	at net.bytebuddy.description.type.TypeDefinition$Sort.describe(TypeDefinition.java:270)
	at net.bytebuddy.description.type.TypeDefinition$Sort.describe(TypeDefinition.java:244)
	at net.bytebuddy.description.type.TypeList$Generic$ForLoadedTypes.get(TypeList.java:449)
	at net.bytebuddy.description.type.TypeList$Generic$ForLoadedTypes.get(TypeList.java:420)
	at java.util.AbstractList$Itr.next(AbstractList.java:373)
	at net.bytebuddy.matcher.ElementMatchers.anyOf(ElementMatchers.java:346)
	at net.bytebuddy.matcher.ElementMatchers.anyOf(ElementMatchers.java:365)
	at net.bytebuddy.matcher.ElementMatchers.isGetter(ElementMatchers.java:1764)
	at org.hibernate.bytecode.enhance.internal.bytebuddy.ByteBuddyEnhancementContext.<clinit>(ByteBuddyEnhancementContext.java:33)

net.bytebuddy.utility.GraalImageCode was unintentionally initialized at build time. org.hibernate.bytecode.enhance.internal.bytebuddy.ByteBuddyEnhancementContext caused initialization of this class with the following trace: 
	at net.bytebuddy.utility.GraalImageCode.<clinit>(GraalImageCode.java)
	at net.bytebuddy.utility.dispatcher.JavaDispatcher$DynamicClassLoader.invoker(JavaDispatcher.java:1321)
	at net.bytebuddy.utility.dispatcher.JavaDispatcher$InvokerCreationAction.run(JavaDispatcher.java:460)
	at net.bytebuddy.utility.dispatcher.JavaDispatcher$InvokerCreationAction.run(JavaDispatcher.java:453)
	at java.security.AccessController.executePrivileged(AccessController.java:778)
	at java.security.AccessController.doPrivileged(AccessController.java:319)
	at net.bytebuddy.utility.dispatcher.JavaDispatcher.doPrivileged(JavaDispatcher.java)
	at net.bytebuddy.utility.dispatcher.JavaDispatcher.<clinit>(JavaDispatcher.java:88)
	at net.bytebuddy.description.type.TypeDescription$ForLoadedType.<clinit>(TypeDescription.java:8725)
	at net.bytebuddy.matcher.ElementMatchers.isGetter(ElementMatchers.java:1764)
	at org.hibernate.bytecode.enhance.internal.bytebuddy.ByteBuddyEnhancementContext.<clinit>(ByteBuddyEnhancementContext.java:33)

net.bytebuddy.description.type.TypeDescription$AbstractBase was unintentionally initialized at build time. org.hibernate.bytecode.enhance.internal.bytebuddy.ByteBuddyEnhancementContext caused initialization of this class with the following trace: 
	at net.bytebuddy.description.type.TypeDescription$AbstractBase.<clinit>(TypeDescription.java)
	at net.bytebuddy.matcher.ElementMatchers.isGetter(ElementMatchers.java:1764)
	at org.hibernate.bytecode.enhance.internal.bytebuddy.ByteBuddyEnhancementContext.<clinit>(ByteBuddyEnhancementContext.java:33)


	at org.graalvm.nativeimage.builder/com.oracle.svm.core.util.UserError.abort(UserError.java:75)
	at org.graalvm.nativeimage.builder/com.oracle.svm.hosted.classinitialization.ProvenSafeClassInitializationSupport.checkDelayedInitialization(ProvenSafeClassInitializationSupport.java:277)
	at org.graalvm.nativeimage.builder/com.oracle.svm.hosted.classinitialization.ClassInitializationFeature.duringAnalysis(ClassInitializationFeature.java:219)
	at org.graalvm.nativeimage.builder/com.oracle.svm.hosted.NativeImageGenerator.lambda$runPointsToAnalysis$10(NativeImageGenerator.java:787)
	at org.graalvm.nativeimage.builder/com.oracle.svm.hosted.FeatureHandler.forEachFeature(FeatureHandler.java:90)
	at org.graalvm.nativeimage.builder/com.oracle.svm.hosted.NativeImageGenerator.lambda$runPointsToAnalysis$11(NativeImageGenerator.java:787)
	at org.graalvm.nativeimage.pointsto/com.oracle.graal.pointsto.AbstractAnalysisEngine.runAnalysis(AbstractAnalysisEngine.java:181)
	at org.graalvm.nativeimage.builder/com.oracle.svm.hosted.NativeImageGenerator.runPointsToAnalysis(NativeImageGenerator.java:784)
	at org.graalvm.nativeimage.builder/com.oracle.svm.hosted.NativeImageGenerator.doRun(NativeImageGenerator.java:593)
	at org.graalvm.nativeimage.builder/com.oracle.svm.hosted.NativeImageGenerator.run(NativeImageGenerator.java:551)
	at org.graalvm.nativeimage.builder/com.oracle.svm.hosted.NativeImageGeneratorRunner.buildImage(NativeImageGeneratorRunner.java:539)
	at org.graalvm.nativeimage.builder/com.oracle.svm.hosted.NativeImageGeneratorRunner.build(NativeImageGeneratorRunner.java:721)
	at org.graalvm.nativeimage.builder/com.oracle.svm.hosted.NativeImageGeneratorRunner.start(NativeImageGeneratorRunner.java:143)
	at org.graalvm.nativeimage.builder/com.oracle.svm.hosted.NativeImageGeneratorRunner.main(NativeImageGeneratorRunner.java:98)
```

It seems the issue was added here:
`commit e6c106f52796a0065f0181462adc83ec4b52be3c Author: Philippe Marschall <philippe.marschall@gmail.com> 2023-12-28 13:47:24 Committer: Christian Beikov <christian.beikov@gmail.com> 2024-03-14 16:16:52 Parent: 8ebf3c8507bce339bc63cdd76e6869c2fbd975a7 (HHH-15809 Secondary super-type cache pollution mitigations for HibernateBasicProxy) Child: 73c490c37edde44e778eaef5ef709f6821a70094 (HHH-14694 Use stable proxy names to avoid managing proxy state) Child: f805bcec639f99642a7f0d63ee8fb35c989369e0 (cleanups, especially to useless uses of JBoss logging) Branches: 6.6, issueNI, main, origin, hibernate/6.5, hibernate/6.6, hibernate/7.0, hibernate/7.1, hibernate/dependabot/gradle/build-dependencies-7c72a25b7f, hibernate/dependabot/gradle/io.smallrye-jandex-3.5.0, hibernate/dependabot/gradle/jakarta-366b247967, hibernate/main, origin/HEAD, origin/main HHH-17596 Use new Byte Buddy API Update code to replace deprecated Byte Buddy code with replacement.`

Fix is about making the static fields Lazy. I noticed the class LazyValue was not thread safe. I am fixing that too.

----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
