### PR TITLE
Use BytecodeEnhanced for ForeignPackageSuperclassAccessorTest

### DIFF
--- a/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/ForeignPackageSuperclassAccessorTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/ForeignPackageSuperclassAccessorTest.java
@@ -6,6 +6,7 @@ package org.hibernate.orm.test.bytecode;
 
 import org.hibernate.orm.test.bytecode.foreignpackage.ConcreteEntity;
 
+import org.hibernate.testing.bytecode.enhancement.extension.BytecodeEnhanced;
 import org.hibernate.testing.orm.junit.DomainModel;
 import org.hibernate.testing.orm.junit.Jira;
 import org.hibernate.testing.orm.junit.SessionFactory;
@@ -18,6 +19,7 @@ import org.junit.jupiter.api.Test;
 		SuperclassEntity.class
 })
 @Jira("https://hibernate.atlassian.net/browse/HHH-19369")
+@BytecodeEnhanced(runNotEnhancedAsWell = true)
 public class ForeignPackageSuperclassAccessorTest {
 
 	@Test


### PR DESCRIPTION
<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

Backport of https://github.com/hibernate/hibernate-orm/pull/10958

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
