### PR TITLE
Fix usage of remote build cache

### DIFF
--- a/gradle/gradle-develocity.gradle
+++ b/gradle/gradle-develocity.gradle
@@ -9,8 +9,8 @@
 
 ext {
     isCiEnvironment = isJenkins() || isGitHubActions() || isGenericCi()
-    populateRemoteBuildCache = isEnabled( "POPULATE_REMOTE_GRADLE_CACHE" )
-    useRemoteCache = !isEnabled( "DISABLE_REMOTE_GRADLE_CACHE" )
+    populateRemoteBuildCache = getSetting('POPULATE_REMOTE_GRADLE_CACHE').orElse('false').toBoolean()
+    useRemoteCache = !getSetting('DISABLE_REMOTE_GRADLE_CACHE').orElse('false').toBoolean()
 }
 
 private static boolean isJenkins() {
@@ -33,14 +33,6 @@ static java.util.Optional<String> getSetting(String name) {
 
     def sysProp = System.getProperty(name)
     return java.util.Optional.ofNullable(sysProp);
-}
-
-static boolean isEnabled(String setting) {
-	if ( System.getenv().hasProperty( setting ) ) {
-		return true
-	}
-
-	return System.hasProperty( setting )
 }
 
 develocity {


### PR DESCRIPTION
It turns out System.getenv().hasProperty('...') does not check that an environment property exists... at all. It probably has more to do with reflection or something? I don't know.

Anyway, this code didn't work, and now it does: I checked by debugging.
