### PR TITLE
HHH-19791 - Avoid dropping/creating database objects when data is only read (SELECT)

### DIFF
--- a/hibernate-core/src/test/java/org/hibernate/orm/test/query/hql/AggregateFilterClauseTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/query/hql/AggregateFilterClauseTest.java
@@ -15,9 +15,9 @@ import org.hibernate.testing.orm.junit.DomainModel;
 import org.hibernate.testing.orm.junit.ServiceRegistry;
 import org.hibernate.testing.orm.junit.SessionFactory;
 import org.hibernate.testing.orm.junit.SessionFactoryScope;
-import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -32,7 +32,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 @SessionFactory
 public class AggregateFilterClauseTest {
 
-	@BeforeEach
+	@BeforeAll
 	public void prepareData(SessionFactoryScope scope) {
 		scope.inTransaction(
 				em -> {
@@ -83,9 +83,9 @@ public class AggregateFilterClauseTest {
 		);
 	}
 
-	@AfterEach
+	@AfterAll
 	public void tearDown(SessionFactoryScope scope) {
-		scope.getSessionFactory().getSchemaManager().truncate();
+		scope.dropData();
 	}
 
 	@Test

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/query/hql/FunctionTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/query/hql/FunctionTests.java
@@ -45,8 +45,8 @@ import org.hibernate.testing.orm.junit.RequiresDialectFeature;
 import org.hibernate.testing.orm.junit.SessionFactory;
 import org.hibernate.testing.orm.junit.SessionFactoryScope;
 import org.hibernate.testing.orm.junit.SkipForDialect;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import java.math.BigDecimal;
@@ -92,7 +92,8 @@ public class FunctionTests {
 
 	public static final double ERROR = 0.00001d;
 
-	@BeforeEach @SuppressWarnings("deprecation")
+	@BeforeAll
+	@SuppressWarnings("deprecation")
 	public void prepareData(SessionFactoryScope scope) {
 		scope.inTransaction(
 				em -> {
@@ -129,7 +130,7 @@ public class FunctionTests {
 		);
 	}
 
-	@AfterEach
+	@AfterAll
 	public void dropTestData(SessionFactoryScope scope) {
 		scope.dropData();
 	}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/query/hql/ILikeCriteriaTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/query/hql/ILikeCriteriaTest.java
@@ -19,8 +19,8 @@ import org.hibernate.testing.orm.junit.ServiceRegistry;
 import org.hibernate.testing.orm.junit.SessionFactory;
 import org.hibernate.testing.orm.junit.SessionFactoryScope;
 import org.hibernate.testing.orm.junit.Setting;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -35,7 +35,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 @ServiceRegistry(settings = @Setting(name = AvailableSettings.CRITERIA_COPY_TREE, value = "true"))
 public class ILikeCriteriaTest {
 
-	@BeforeEach
+	@BeforeAll
 	public void prepareData(SessionFactoryScope scope) {
 		scope.inTransaction(
 				em -> {
@@ -61,9 +61,9 @@ public class ILikeCriteriaTest {
 		);
 	}
 
-	@AfterEach
+	@AfterAll
 	public void tearDown(SessionFactoryScope scope) {
-		scope.getSessionFactory().getSchemaManager().truncate();
+		scope.dropData();
 	}
 
 	@Test

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/query/hql/ILikeTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/query/hql/ILikeTest.java
@@ -15,8 +15,8 @@ import org.hibernate.testing.orm.junit.ServiceRegistry;
 import org.hibernate.testing.orm.junit.SessionFactory;
 import org.hibernate.testing.orm.junit.SessionFactoryScope;
 
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -31,7 +31,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 @SessionFactory
 public class ILikeTest {
 
-	@BeforeEach
+	@BeforeAll
 	public void prepareData(SessionFactoryScope scope) {
 		scope.inTransaction(
 				em -> {
@@ -57,9 +57,9 @@ public class ILikeTest {
 		);
 	}
 
-	@AfterEach
+	@AfterAll
 	public void tearDown(SessionFactoryScope scope) {
-		scope.getSessionFactory().getSchemaManager().truncate();
+		scope.dropData();
 	}
 
 	@Test

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/query/hql/JsonFunctionTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/query/hql/JsonFunctionTests.java
@@ -39,8 +39,8 @@ import org.hibernate.testing.orm.junit.SessionFactory;
 import org.hibernate.testing.orm.junit.SessionFactoryScope;
 import org.hibernate.testing.orm.junit.Setting;
 import org.hibernate.testing.orm.junit.SkipForDialect;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -77,7 +77,7 @@ public class JsonFunctionTests {
 
 	JsonHolder entity;
 
-	@BeforeEach
+	@BeforeAll
 	public void prepareData(SessionFactoryScope scope) {
 		scope.inTransaction(
 				em -> {
@@ -117,9 +117,9 @@ public class JsonFunctionTests {
 		);
 	}
 
-	@AfterEach
+	@AfterAll
 	public void cleanupData(SessionFactoryScope scope) {
-		scope.getSessionFactory().getSchemaManager().truncate();
+		scope.dropData();
 	}
 
 	@Test

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/query/hql/StandardFunctionTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/query/hql/StandardFunctionTests.java
@@ -26,8 +26,8 @@ import org.hibernate.testing.orm.junit.ServiceRegistry;
 import org.hibernate.testing.orm.junit.SessionFactory;
 import org.hibernate.testing.orm.junit.SessionFactoryScope;
 import org.hibernate.testing.orm.junit.SkipForDialect;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.anyOf;
@@ -47,7 +47,7 @@ import static org.hibernate.testing.orm.domain.gambit.EntityOfBasics.Gender.FEMA
 @SessionFactory
 public class StandardFunctionTests {
 
-	@BeforeEach
+	@BeforeAll
 	public void prepareData(SessionFactoryScope scope) {
 		scope.inTransaction(
 				em -> {
@@ -62,9 +62,9 @@ public class StandardFunctionTests {
 		);
 	}
 
-	@AfterEach
+	@AfterAll
 	public void truncateDate(SessionFactoryScope scope) {
-		scope.getSessionFactory().getSchemaManager().truncate();
+		scope.dropData();
 	}
 
 	@Test


### PR DESCRIPTION
This PR is an attempt to reduce drop/create overheads during SELECT-only tests when there is no added value (including in case of errors).

----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-19791
<!-- Hibernate GitHub Bot issue links end -->