### PR TITLE
HHH-19793 - Temporary disconnect ATP-S from OTP

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,7 +153,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - rdbms: autonomous-transaction-processing-serverless
+          #- rdbms: autonomous-transaction-processing-serverless
           - rdbms: base-database-service-19c
           - rdbms: base-database-service-21c
           - rdbms: base-database-service-23ai


### PR DESCRIPTION
This PR will disconnect ATP-S temporarily to avoid the 2h+ durations during PR checks.

----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-19793
<!-- Hibernate GitHub Bot issue links end -->