### PR TITLE
[6.6] HHH-19784 Avoid using package-private field access with bytecode enhanced entity hierarchy

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/bytecode/enhance/internal/bytebuddy/EnhancerImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/bytecode/enhance/internal/bytebuddy/EnhancerImpl.java
@@ -794,8 +794,23 @@ public class EnhancerImpl implements Enhancer {
 			return fieldDescription.getDescriptor();
 		}
 
-		boolean isVisibleTo(TypeDescription typeDescription) {
-			return fieldDescription.isVisibleTo( typeDescription );
+		boolean isVisibleTo(TypeDescription type) {
+			final var declaringType = fieldDescription.getDeclaringType().asErasure();
+			if ( declaringType.isVisibleTo( type ) ) {
+				if ( fieldDescription.isPublic() || type.equals( declaringType ) ) {
+					return true;
+				}
+				else if ( fieldDescription.isProtected() ) {
+					return declaringType.isAssignableFrom( type );
+				}
+				else if ( fieldDescription.isPrivate() ) {
+					return type.isNestMateOf( declaringType );
+				}
+				// We explicitly consider package-private fields as not visible, as the classes
+				// might have the same package name but be loaded by different class loaders.
+				// (see https://hibernate.atlassian.net/browse/HHH-19784)
+			}
+			return false;
 		}
 
 		FieldDescription getFieldDescription() {


### PR DESCRIPTION
<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

[Please describe here what your change is about]

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-19784
<!-- Hibernate GitHub Bot issue links end -->