### PR TITLE
Enable adding label to PRs opened for non-main branch

### DIFF
--- a/.github/hibernate-github-bot.yml
+++ b/.github/hibernate-github-bot.yml
@@ -75,3 +75,9 @@ licenseAgreement:
           name: license-agreement
           organization: hibernate
       titlePattern: ".*"
+branches:
+  enabled: true
+  label: "%s"
+  ignore:
+    - user: dependabot[bot]
+      titlePattern: ".*"


### PR DESCRIPTION
Bot will add those `7.1` `6.6` ... labels if the target branch of the PR != main
<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
