### PR TITLE
HHH-19810 remove joda dependency

### DIFF
--- a/hibernate-core/hibernate-core.gradle
+++ b/hibernate-core/hibernate-core.gradle
@@ -57,7 +57,6 @@ dependencies {
         // for test runtime
         transitive = true
     }
-    testImplementation "joda-time:joda-time:2.3"
     testImplementation jdbcLibs.h2
     testImplementation libs.hibernateModelsJandex
 


### PR DESCRIPTION
<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

Hello,
This PR is about removing joda api which is used in one old test class. Please refer to : https://hibernate.atlassian.net/browse/HHH-19810

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
