### PR TITLE
HHH-19805 Allow nested entity initializers to claim entity holder

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/engine/internal/StatefulPersistenceContext.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/internal/StatefulPersistenceContext.java
@@ -392,29 +392,20 @@ class StatefulPersistenceContext implements PersistenceContext {
 		var holder = getOrInitializeNewHolder().withEntity( key, key.getPersister(), entity );
 		final var oldHolder = entityHolderMap.putIfAbsent( key, newEntityHolder );
 		if ( oldHolder != null ) {
+			// An initializer can't claim an entity holder if it's already initialized
+			if ( oldHolder.isInitialized() ) {
+				return oldHolder;
+			}
 			if ( entity != null ) {
 				assert oldHolder.entity == null || oldHolder.entity == entity;
 				oldHolder.entity = entity;
-			}
-			// Skip setting a new entity initializer if there already is one owner
-			// Also skip if an entity exists which is different from the effective optional object.
-			// The effective optional object is the current object to be refreshed,
-			// which always needs re-initialization, even if already initialized
-			if ( oldHolder.entityInitializer != null
-					|| oldHolder.entity != null && oldHolder.state != EntityHolderState.ENHANCED_PROXY && (
-					processingState.getProcessingOptions().getEffectiveOptionalObject() == null
-							|| oldHolder.entity != processingState.getProcessingOptions().getEffectiveOptionalObject() )
-			) {
-				return oldHolder;
 			}
 			holder = oldHolder;
 		}
 		else {
 			newEntityHolder = null;
 		}
-		assert holder.entityInitializer == null || holder.entityInitializer == initializer;
 		holder.entityInitializer = initializer;
-		processingState.registerLoadingEntityHolder( holder );
 		return holder;
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/internal/util/ImmutableBitSet.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/util/ImmutableBitSet.java
@@ -4,6 +4,8 @@
  */
 package org.hibernate.internal.util;
 
+import org.checkerframework.checker.nullness.qual.Nullable;
+
 import java.util.Arrays;
 import java.util.BitSet;
 
@@ -24,6 +26,10 @@ public class ImmutableBitSet {
 
 	private ImmutableBitSet(long[] words) {
 		this.words = words;
+	}
+
+	public static ImmutableBitSet valueOfOrEmpty(@Nullable BitSet bitSet) {
+		return bitSet == null ? EMPTY : valueOf( bitSet );
 	}
 
 	public static ImmutableBitSet valueOf(BitSet bitSet) {
@@ -70,4 +76,7 @@ public class ImmutableBitSet {
 		return Arrays.equals( words, set.words );
 	}
 
+	public BitSet toBitSet() {
+		return BitSet.valueOf( words );
+	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/PluralAttributeMappingImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/PluralAttributeMappingImpl.java
@@ -596,7 +596,7 @@ public class PluralAttributeMappingImpl
 		// returning a domain result assembler that returns LazyPropertyInitializer.UNFETCHED_PROPERTY
 		final var containingEntityMapping = findContainingEntityMapping();
 		final boolean unfetched;
-		if ( fetchParent.getReferencedModePart() == containingEntityMapping
+		if ( fetchParent.getReferencedMappingContainer() == containingEntityMapping
 				&& containingEntityMapping.getEntityPersister().getPropertyLaziness()[getStateArrayPosition()] ) {
 			collectionKeyDomainResult = null;
 			unfetched = true;

--- a/hibernate-core/src/main/java/org/hibernate/persister/entity/AbstractEntityPersister.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/entity/AbstractEntityPersister.java
@@ -71,6 +71,7 @@ import org.hibernate.id.BulkInsertionCapableIdentifierGenerator;
 import org.hibernate.id.IdentifierGenerator;
 import org.hibernate.id.OptimizableGenerator;
 import org.hibernate.internal.FilterHelper;
+import org.hibernate.internal.util.ImmutableBitSet;
 import org.hibernate.internal.util.IndexedConsumer;
 import org.hibernate.internal.util.MarkerObject;
 import org.hibernate.internal.util.StringHelper;
@@ -1733,6 +1734,11 @@ public abstract class AbstractEntityPersister
 			final Object propValue) {
 		final int propertyNumber = lazyPropertyNumbers[index];
 		setPropertyValue( entity, propertyNumber, propValue );
+		if ( entry.getMaybeLazySet() != null ) {
+			var bitSet = entry.getMaybeLazySet().toBitSet();
+			bitSet.set( propertyNumber );
+			entry.setMaybeLazySet( ImmutableBitSet.valueOf( bitSet ) );
+		}
 		final var loadedState = entry.getLoadedState();
 		if ( loadedState != null ) {
 			// object have been loaded with setReadOnly(true); HHH-2236
@@ -1767,6 +1773,11 @@ public abstract class AbstractEntityPersister
 	// Used by Hibernate Reactive
 	protected void initializeLazyProperty(Object entity, EntityEntry entry, Object propValue, int index, Type type) {
 		setPropertyValue( entity, index, propValue );
+		if ( entry.getMaybeLazySet() != null ) {
+			var bitSet = entry.getMaybeLazySet().toBitSet();
+			bitSet.set( index );
+			entry.setMaybeLazySet( ImmutableBitSet.valueOf( bitSet ) );
+		}
 		final var loadedState = entry.getLoadedState();
 		if ( loadedState != null ) {
 			// object has been loaded with setReadOnly(true); HHH-2236

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/collection/set/PersistentSetRemoveTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/collection/set/PersistentSetRemoveTest.java
@@ -1,0 +1,174 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.collection.set;
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.Jira;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashSet;
+import java.util.Objects;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@DomainModel(annotatedClasses = {
+		PersistentSetRemoveTest.Parent.class,
+		PersistentSetRemoveTest.Child.class
+})
+@SessionFactory
+@Jira("https://hibernate.atlassian.net/browse/HHH-19805")
+public class PersistentSetRemoveTest {
+
+	@Test
+	public void testRemove(SessionFactoryScope scope) {
+		Parent p1 = new Parent( 1L, "p1" );
+		Child c1 = new Child( 1L, "c1" );
+		Child c2 = new Child( 2L, "c2" );
+		Child c3 = new Child( 3L, "c3" );
+		p1.getChildren().add( c1 );
+		c1.setParent( p1 );
+		p1.getChildren().add( c2 );
+		c2.setParent( p1 );
+		p1.getChildren().add( c3 );
+		c3.setParent( p1 );
+
+		scope.inTransaction(
+				session -> session.persist( p1 )
+		);
+
+		scope.inTransaction(
+				session -> {
+					Child child = session.createQuery( "from Child c where c.name = :name", Child.class )
+							.setParameter( "name", "c1" )
+							.getSingleResult();
+
+					boolean removed = child.getParent().getChildren().remove( child );
+					assertTrue( removed );
+				}
+		);
+
+		scope.inTransaction(
+				session -> {
+					Parent parent = session.find( Parent.class, p1.getId() );
+					Child childToRemove = parent.getChildren().stream()
+							.filter( book -> "c2".equals( book.getName() ) )
+							.findFirst()
+							.orElseThrow();
+					boolean removed = parent.getChildren().remove( childToRemove );
+					assertTrue( removed );
+				}
+		);
+	}
+
+	@Entity(name = "Parent")
+	public static class Parent {
+		@Id
+		private Long id;
+		private String name;
+
+		@OneToMany(mappedBy = "parent", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.EAGER)
+		private Set<Child> children;
+
+		public Parent() {
+			this.children = new HashSet<>();
+		}
+
+		public Parent(Long id, String name) {
+			this.id = id;
+			this.name = name;
+			this.children = new HashSet<>();
+		}
+
+		public Long getId() {
+			return id;
+		}
+
+		public void setId(Long id) {
+			this.id = id;
+		}
+
+		public String getName() {
+			return name;
+		}
+
+		public void setName(String name) {
+			this.name = name;
+		}
+
+		public Set<Child> getChildren() {
+			return children;
+		}
+
+		public void setChildren(Set<Child> children) {
+			this.children = children;
+		}
+	}
+
+
+	@Entity(name = "Child")
+	public static class Child {
+		@Id
+		private Long id;
+		private String name;
+
+		@ManyToOne
+		private Parent parent;
+
+		public Child() {
+		}
+
+		public Child(Long id, String name) {
+			this.id = id;
+			this.name = name;
+		}
+
+		public Long getId() {
+			return id;
+		}
+
+		public void setId(Long id) {
+			this.id = id;
+		}
+
+		public String getName() {
+			return name;
+		}
+
+		public void setName(String name) {
+			this.name = name;
+		}
+
+		public Parent getParent() {
+			return parent;
+		}
+
+		public void setParent(Parent parent) {
+			this.parent = parent;
+		}
+
+		@Override
+		public final boolean equals(Object o) {
+			if ( !(o instanceof Child child) ) {
+				return false;
+			}
+
+			return Objects.equals( name, child.name );
+		}
+
+		@Override
+		public int hashCode() {
+			return Objects.hashCode( name );
+		}
+	}
+}


### PR DESCRIPTION
This is expanding on https://github.com/hibernate/hibernate-orm/pull/11008 to set/initialize unfetched attributes with available data, even when the entity is already initialized.

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-19805
<!-- Hibernate GitHub Bot issue links end -->