### PR TITLE
upgrade version of graal vm sdk to the latest stable version

### DIFF
--- a/hibernate-graalvm/hibernate-graalvm.gradle
+++ b/hibernate-graalvm/hibernate-graalvm.gradle
@@ -13,7 +13,7 @@ description = "Experimental extension to make it easier to compile applications 
 dependencies {
     //No need for transitive dependencies: this is all just metadata to be used as companion jar.
     compileOnly project( ':hibernate-core' )
-    compileOnly "org.graalvm.sdk:graal-sdk:22.2.0"
+    compileOnly "org.graalvm.sdk:graal-sdk:25.0.0"
 
     testImplementation project( ':hibernate-core' )
     testImplementation libs.jandex


### PR DESCRIPTION
<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

Hello,
This PR update the version of graalvm sdk from 22 (2022) to the latest 25 (from maven central).
 I clean and build the graalvm project+ build all the project against H2 and no error observed.
This will keep the module up to date and compatible with latest version.
I stay available if any request or change.

Thanks team 🙏  
Moad ELFATIHI


<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
