### PR TITLE
HHH-19812: Improvements on the Maven Enhance Plugin (Backport to 7.0)

### DIFF
--- a/tooling/hibernate-maven-plugin/src/main/java/org/hibernate/orm/tooling/maven/HibernateEnhancerMojo.java
+++ b/tooling/hibernate-maven-plugin/src/main/java/org/hibernate/orm/tooling/maven/HibernateEnhancerMojo.java
@@ -46,13 +46,17 @@ public class HibernateEnhancerMojo extends AbstractMojo {
 			required = true)
 	private boolean enableAssociationManagement;
 
+	@Deprecated(
+			forRemoval = true)
 	@Parameter(
-			defaultValue = "false",
+			defaultValue = "true",
 			required = true)
 	private boolean enableDirtyTracking;
 
+	@Deprecated(
+			forRemoval = true)
 	@Parameter(
-			defaultValue = "false",
+			defaultValue = "true",
 			required = true)
 	private boolean enableLazyInitialization;
 

--- a/tooling/hibernate-maven-plugin/src/main/java/org/hibernate/orm/tooling/maven/HibernateEnhancerMojo.java
+++ b/tooling/hibernate-maven-plugin/src/main/java/org/hibernate/orm/tooling/maven/HibernateEnhancerMojo.java
@@ -92,11 +92,21 @@ public class HibernateEnhancerMojo extends AbstractMojo {
 	public void execute() {
 		getLog().debug(STARTING_EXECUTION_OF_ENHANCE_MOJO);
 		processParameters();
-		assembleSourceSet();
-		createEnhancer();
-		discoverTypes();
-		performEnhancement();
+		if (enhancementIsNeeded()) {
+			assembleSourceSet();
+			createEnhancer();
+			discoverTypes();
+			performEnhancement();
+		}
 		getLog().debug(ENDING_EXECUTION_OF_ENHANCE_MOJO);
+	}
+
+	private boolean enhancementIsNeeded() {
+		// enhancement is not needed when all the parameters are false
+		return enableAssociationManagement ||
+			enableDirtyTracking ||
+			enableLazyInitialization ||
+			enableExtendedEnhancement;
 	}
 
 	private void processParameters() {

--- a/tooling/hibernate-maven-plugin/src/main/java/org/hibernate/orm/tooling/maven/HibernateEnhancerMojo.java
+++ b/tooling/hibernate-maven-plugin/src/main/java/org/hibernate/orm/tooling/maven/HibernateEnhancerMojo.java
@@ -33,19 +33,35 @@ public class HibernateEnhancerMojo extends AbstractMojo {
 	final private List<File> sourceSet = new ArrayList<File>();
 	private Enhancer enhancer;
 
+	/**
+	 * A list of FileSets in which to look for classes to enhance.
+	 * This parameter is optional but if it is specified, the 'classesDirectory' parameter is ignored.
+	 */
 	@Parameter
 	private FileSet[] fileSets;
 
+	/**
+	 * The folder in which to look for classes to enhance.
+	 * This parameter is required but if the 'fileSets' parameter is specified, it will be ignored.
+	 */
 	@Parameter(
 			defaultValue = "${project.build.directory}/classes",
 			required = true)
 	private File classesDirectory;
 
+	/**
+	 * A boolean that indicates whether or not to add association management to automatically
+	 * synchronize a bidirectional association when only one side is changed
+	 */
 	@Parameter(
 			defaultValue = "false",
 			required = true)
 	private boolean enableAssociationManagement;
 
+	/**
+	 * A boolean that indicates whether or not to add dirty tracking
+	 * @deprecated <a href="https://hibernate.atlassian.net/browse/HHH-15641">See HHH-15641</a>
+	 */
 	@Deprecated(
 			forRemoval = true)
 	@Parameter(
@@ -53,6 +69,10 @@ public class HibernateEnhancerMojo extends AbstractMojo {
 			required = true)
 	private boolean enableDirtyTracking;
 
+	/**
+	 * A boolean that indicates whether or not to add lazy initialization
+	 * @deprecated <a href="https://hibernate.atlassian.net/browse/HHH-15641">See HHH-15641</a>
+	 */
 	@Deprecated(
 			forRemoval = true)
 	@Parameter(
@@ -60,6 +80,10 @@ public class HibernateEnhancerMojo extends AbstractMojo {
 			required = true)
 	private boolean enableLazyInitialization;
 
+	/**
+	 * A boolean that indicates whether or not to add extended enhancement.
+	 * This setting will provide bytecode enhancement, even for non-entity classes
+	 */
 	@Parameter(
 			defaultValue = "false",
 			required = true)

--- a/tooling/hibernate-maven-plugin/src/test/java/org/hibernate/orm/tooling/maven/HibernateEnhancerMojoTest.java
+++ b/tooling/hibernate-maven-plugin/src/test/java/org/hibernate/orm/tooling/maven/HibernateEnhancerMojoTest.java
@@ -519,6 +519,9 @@ public class HibernateEnhancerMojoTest {
 
 	@Test
 	void testExecute() throws Exception {
+		Field enableDirtyTrackingField = HibernateEnhancerMojo.class.getDeclaredField( "enableDirtyTracking" );
+		enableDirtyTrackingField.setAccessible( true );
+		enableDirtyTrackingField.set( enhanceMojo, true );
 		Method executeMethod = HibernateEnhancerMojo.class.getDeclaredMethod("execute", new Class[] {});
 		executeMethod.setAccessible(true);
 		final String barSource =


### PR DESCRIPTION
* HHH-19813: Fix the regression on the 'enableDirtyTracking' and 'enableLazyInitialization' default values and deprecate the setting
* HHH-19817: Add the JavaDoc Style documentation appropriate for Maven Plugins
* HHH-19820: Make sure that the enhancer is not doing anything if all the enablement parameters are false
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-19820
https://hibernate.atlassian.net/browse/HHH-19813
https://hibernate.atlassian.net/browse/HHH-19817
<!-- Hibernate GitHub Bot issue links end -->