### PR TITLE
Apply session options to enable proper locking for CockroachDB

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/dialect/lock/internal/CockroachLockingSupport.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/lock/internal/CockroachLockingSupport.java
@@ -55,6 +55,8 @@ public class CockroachLockingSupport implements LockingSupport, LockingSupport.M
 		return switch (timeout.milliseconds()) {
 			case WAIT_FOREVER_MILLI -> QUERY;
 			case NO_WAIT_MILLI -> supportsNoWait ? QUERY : LockTimeoutType.NONE;
+			// Due to https://github.com/cockroachdb/cockroach/issues/88995, locking doesn't work properly
+			// without certain configuration options and hence skipping locked rows also doesn't work correctly.
 			case SKIP_LOCKED_MILLI -> LockTimeoutType.NONE;
 			// it does not, however, support WAIT as part of for-update, but does support a connection-level lock_timeout setting
 			default -> CONNECTION;

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/lock/LockExceptionTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/lock/LockExceptionTests.java
@@ -53,7 +53,6 @@ public class LockExceptionTests extends AbstractJPATest {
 
 	@Test
 	@JiraKey( value = "HHH-8786" )
-	@SkipForDialect(dialectClass = CockroachDialect.class, reason = "for update clause does not imply locking. See https://github.com/cockroachdb/cockroach/issues/88995")
 	@SkipForDialect(dialectClass = InformixDialect.class, reason = "no failure")
 	public void testLockTimeoutFind() {
 		final Item item = new Item( "find" );

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/lock/LockTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/lock/LockTest.java
@@ -107,7 +107,6 @@ public class LockTest extends BaseEntityManagerFunctionalTestCase {
 	@RequiresDialectFeature( value = DialectChecks.SupportsLockTimeouts.class,
 							comment = "Test verifies proper exception throwing when a lock timeout is specified.",
 							jiraKey = "HHH-7252" )
-	@SkipForDialect(value = CockroachDialect.class, comment = "for update clause does not imply locking. See https://github.com/cockroachdb/cockroach/issues/88995")
 	@SkipForDialect(value = AltibaseDialect.class, comment = "Altibase close socket after lock timeout occurred")
 	public void testFindWithPessimisticWriteLockTimeoutException() {
 		Lock lock = new Lock();
@@ -157,7 +156,6 @@ public class LockTest extends BaseEntityManagerFunctionalTestCase {
 	@RequiresDialectFeature( value = DialectChecks.SupportsLockTimeouts.class,
 			comment = "Test verifies proper exception throwing when a lock timeout is specified for Query#getSingleResult.",
 			jiraKey = "HHH-13364" )
-	@SkipForDialect(value = CockroachDialect.class, comment = "for update clause does not imply locking. See https://github.com/cockroachdb/cockroach/issues/88995")
 	@SkipForDialect(value = AltibaseDialect.class, comment = "Altibase close socket after lock timeout occurred")
 	public void testQuerySingleResultPessimisticWriteLockTimeoutException() {
 		Lock lock = new Lock();
@@ -204,7 +202,6 @@ public class LockTest extends BaseEntityManagerFunctionalTestCase {
 	@RequiresDialectFeature( value = DialectChecks.SupportsLockTimeouts.class,
 			comment = "Test verifies proper exception throwing when a lock timeout is specified for Query#getResultList.",
 			jiraKey = "HHH-13364" )
-	@SkipForDialect(value = CockroachDialect.class, comment = "for update clause does not imply locking. See https://github.com/cockroachdb/cockroach/issues/88995")
 	@SkipForDialect(value = AltibaseDialect.class, comment = "Altibase close socket after lock timeout occurred")
 	public void testQueryResultListPessimisticWriteLockTimeoutException() {
 		Lock lock = new Lock();
@@ -254,7 +251,6 @@ public class LockTest extends BaseEntityManagerFunctionalTestCase {
 	@RequiresDialectFeature( value = DialectChecks.SupportsLockTimeouts.class,
 			comment = "Test verifies proper exception throwing when a lock timeout is specified for NamedQuery#getResultList.",
 			jiraKey = "HHH-13364" )
-	@SkipForDialect(value = CockroachDialect.class, comment = "for update clause does not imply locking. See https://github.com/cockroachdb/cockroach/issues/88995")
 	@SkipForDialect(value = AltibaseDialect.class, comment = "Altibase close socket after lock timeout occurred")
 	public void testNamedQueryResultListPessimisticWriteLockTimeoutException() {
 		Lock lock = new Lock();
@@ -298,7 +294,6 @@ public class LockTest extends BaseEntityManagerFunctionalTestCase {
 
 	@Test
 	@RequiresDialectFeature( value = DialectChecks.SupportsSkipLocked.class )
-	@SkipForDialect(value = CockroachDialect.class, comment = "for update clause does not imply locking. See https://github.com/cockroachdb/cockroach/issues/88995")
 	public void testUpdateWithPessimisticReadLockSkipLocked() {
 		Lock lock = new Lock();
 		lock.setName( "name" );
@@ -343,7 +338,6 @@ public class LockTest extends BaseEntityManagerFunctionalTestCase {
 
 	@Test
 	@RequiresDialectFeature(value = DialectChecks.SupportsLockTimeouts.class)
-	@SkipForDialect(value = CockroachDialect.class, comment = "for update clause does not imply locking. See https://github.com/cockroachdb/cockroach/issues/88995")
 	public void testUpdateWithPessimisticReadLockWithoutNoWait() {
 		Lock lock = new Lock();
 		lock.setName( "name" );

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/lock/StatementIsClosedAfterALockExceptionTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/lock/StatementIsClosedAfterALockExceptionTest.java
@@ -14,7 +14,6 @@ import org.hibernate.Session;
 import org.hibernate.cfg.AvailableSettings;
 import org.hibernate.community.dialect.AltibaseDialect;
 import org.hibernate.community.dialect.InformixDialect;
-import org.hibernate.dialect.CockroachDialect;
 import org.hibernate.orm.test.jpa.BaseEntityManagerFunctionalTestCase;
 import org.hibernate.testing.orm.jdbc.PreparedStatementSpyConnectionProvider;
 import org.hibernate.testing.DialectChecks;
@@ -35,7 +34,6 @@ import static org.junit.Assert.fail;
  * @author Andrea Boriero
  */
 @RequiresDialectFeature({DialectChecks.SupportsLockTimeouts.class})
-@SkipForDialect(value = CockroachDialect.class, comment = "for update clause does not imply locking. See https://github.com/cockroachdb/cockroach/issues/88995")
 @SkipForDialect(value = AltibaseDialect.class, comment = "Altibase does not close Statement after lock timeout")
 public class StatementIsClosedAfterALockExceptionTest extends BaseEntityManagerFunctionalTestCase {
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/locking/LockModeTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/locking/LockModeTest.java
@@ -87,7 +87,6 @@ public class LockModeTest extends BaseSessionFactoryFunctionalTest {
 
 	@Test
 	@RequiresDialectFeature( feature = DialectFeatureChecks.SupportsLockTimeouts.class )
-	@SkipForDialect(dialectClass = CockroachDialect.class, reason = "for update clause does not imply locking. See https://github.com/cockroachdb/cockroach/issues/88995")
 	@SkipForDialect(dialectClass = AltibaseDialect.class, reason = "Can't commit transaction because Altibase closes socket after lock timeout")
 	public void testLoading() {
 		// open a session, begin a transaction and lock row
@@ -104,7 +103,6 @@ public class LockModeTest extends BaseSessionFactoryFunctionalTest {
 
 	@Test
 	@RequiresDialectFeature( feature = DialectFeatureChecks.SupportsLockTimeouts.class )
-	@SkipForDialect(dialectClass = CockroachDialect.class, reason = "for update clause does not imply locking. See https://github.com/cockroachdb/cockroach/issues/88995")
 	@SkipForDialect(dialectClass = AltibaseDialect.class, reason = "Can't commit transaction because Altibase closes socket after lock timeout")
 	public void testCriteria() {
 		// open a session, begin a transaction and lock row
@@ -128,7 +126,6 @@ public class LockModeTest extends BaseSessionFactoryFunctionalTest {
 
 	@Test
 	@RequiresDialectFeature( feature = DialectFeatureChecks.SupportsLockTimeouts.class )
-	@SkipForDialect(dialectClass = CockroachDialect.class, reason = "for update clause does not imply locking. See https://github.com/cockroachdb/cockroach/issues/88995")
 	@SkipForDialect(dialectClass = AltibaseDialect.class, reason = "Can't commit transaction because Altibase closes socket after lock timeout")
 	public void testCriteriaAliasSpecific() {
 			// open a session, begin a transaction and lock row
@@ -154,7 +151,6 @@ public class LockModeTest extends BaseSessionFactoryFunctionalTest {
 
 	@Test
 	@RequiresDialectFeature( feature = DialectFeatureChecks.SupportsLockTimeouts.class )
-	@SkipForDialect(dialectClass = CockroachDialect.class, reason = "for update clause does not imply locking. See https://github.com/cockroachdb/cockroach/issues/88995")
 	@SkipForDialect(dialectClass = AltibaseDialect.class, reason = "Can't commit transaction because Altibase closes socket after lock timeout")
 	public void testQuery() {
 		// open a session, begin a transaction and lock row

--- a/hibernate-testing/src/main/java/org/hibernate/testing/orm/transaction/TransactionUtil.java
+++ b/hibernate-testing/src/main/java/org/hibernate/testing/orm/transaction/TransactionUtil.java
@@ -10,6 +10,7 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 import jakarta.persistence.EntityManager;
 
+import jakarta.persistence.QueryTimeoutException;
 import org.hibernate.LockMode;
 import org.hibernate.LockOptions;
 import org.hibernate.SharedSessionContract;
@@ -172,7 +173,8 @@ public abstract class TransactionUtil {
 		}
 		catch (RuntimeException re) {
 			if ( re.getCause() instanceof jakarta.persistence.LockTimeoutException
-				|| re.getCause() instanceof org.hibernate.exception.LockTimeoutException ) {
+				|| re.getCause() instanceof org.hibernate.exception.LockTimeoutException
+				|| re.getCause() instanceof QueryTimeoutException ) {
 				if ( !expectingToBlock ) {
 					fail( "Expecting update to " + tableName + " to succeed, but failed due to async timeout (presumably due to locks)", re.getCause() );
 				}
@@ -227,7 +229,8 @@ public abstract class TransactionUtil {
 			}
 			catch (RuntimeException re) {
 				if ( re.getCause() instanceof jakarta.persistence.LockTimeoutException
-					|| re.getCause() instanceof org.hibernate.exception.LockTimeoutException ) {
+					|| re.getCause() instanceof org.hibernate.exception.LockTimeoutException
+					|| re.getCause() instanceof QueryTimeoutException ) {
 					if ( !expectingToBlock ) {
 						fail( "Expecting update to " + tableName + " to succeed, but failed due to async timeout (presumably due to locks)", re.getCause() );
 					}

--- a/local-build-plugins/src/main/groovy/local.databases.gradle
+++ b/local-build-plugins/src/main/groovy/local.databases.gradle
@@ -371,7 +371,8 @@ ext {
                     'jdbc.url'   : 'jdbc:postgresql://' + dbHost + ':26257/defaultdb?sslmode=disable&preparedStatementCacheQueries=0&escapeSyntaxCallMode=callIfNoReturn',
                     'jdbc.datasource' : 'org.postgresql.Driver',
 //                        'jdbc.datasource' : 'org.postgresql.ds.PGSimpleDataSource',
-                    'connection.init_sql' : ''
+                    // Configure the for-update clause to use proper locks: https://github.com/cockroachdb/cockroach/issues/88995
+                    'connection.init_sql' : 'set enable_durable_locking_for_serializable = on; set optimizer_use_lock_op_for_serializable = on;'
             ],
             firebird : [
                     'db.dialect' : 'org.hibernate.community.dialect.FirebirdDialect',


### PR DESCRIPTION
This fixes issues with ScopeTests when running against CockroachDB. Also remove test skips that were due to locking not working correctly. See https://github.com/cockroachdb/cockroach/issues/88995 for details

<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

[Please describe here what your change is about]

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
