### PR TITLE
HHH-99999 - Upgrade OTP GitHub Action to v1.0.20

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -210,7 +210,7 @@ jobs:
             ${{ steps.cache-key.outputs.buildtool-monthly-cache-key }}-
 
       - id: create_database
-        uses: loiclefevre/test@03ce1d1ee2313b45249e7bf6b84dc0f4333cdd77 # v1.0.18
+        uses: loiclefevre/test@ce2f5049188a384c17ffcfcb8c8d04cf118e2cd7 # v1.0.20
         with:
           oci-service: ${{ matrix.rdbms }}
           action: create
@@ -231,7 +231,7 @@ jobs:
         run: ./ci/build-github.sh
         shell: bash
 
-      - uses: loiclefevre/test@03ce1d1ee2313b45249e7bf6b84dc0f4333cdd77 # v1.0.18
+      - uses: loiclefevre/test@ce2f5049188a384c17ffcfcb8c8d04cf118e2cd7 # v1.0.20
         if: always()
         with:
           oci-service: ${{ matrix.rdbms }}


### PR DESCRIPTION
This PR upgrades the OTP GitHub Action to v1.0.20. This will help to drop user schemas in case of job cancellation, even if users are still connected from the previous step (build and test).

----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
