### PR TITLE
HHH-19812: Improvements on the Maven Enhance Plugin (Backport to 7.1) 

### DIFF
--- a/tooling/hibernate-maven-plugin/src/main/java/org/hibernate/orm/tooling/maven/HibernateEnhancerMojo.java
+++ b/tooling/hibernate-maven-plugin/src/main/java/org/hibernate/orm/tooling/maven/HibernateEnhancerMojo.java
@@ -46,13 +46,17 @@ public class HibernateEnhancerMojo extends AbstractMojo {
 			required = true)
 	private boolean enableAssociationManagement;
 
+	@Deprecated(
+			forRemoval = true)
 	@Parameter(
-			defaultValue = "false",
+			defaultValue = "true",
 			required = true)
 	private boolean enableDirtyTracking;
 
+	@Deprecated(
+			forRemoval = true)
 	@Parameter(
-			defaultValue = "false",
+			defaultValue = "true",
 			required = true)
 	private boolean enableLazyInitialization;
 


### PR DESCRIPTION
* HHH-19813: Fix the regression on the 'enableDirtyTracking' and 'enableLazyInitialization' default values and deprecate the setting

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
