### PR TITLE
HHH-13843 Create InformationExtractor through Dialect to allow batch loading

### DIFF
--- a/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/CockroachLegacyDialect.java
+++ b/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/CockroachLegacyDialect.java
@@ -70,7 +70,10 @@ import org.hibernate.sql.ast.spi.SqlAppender;
 import org.hibernate.sql.ast.spi.StandardSqlAstTranslatorFactory;
 import org.hibernate.sql.ast.tree.Statement;
 import org.hibernate.sql.exec.spi.JdbcOperation;
+import org.hibernate.tool.schema.extract.internal.InformationExtractorPostgreSQLImpl;
 import org.hibernate.tool.schema.extract.spi.ColumnTypeInformation;
+import org.hibernate.tool.schema.extract.spi.ExtractionContext;
+import org.hibernate.tool.schema.extract.spi.InformationExtractor;
 import org.hibernate.type.JavaObjectType;
 import org.hibernate.type.descriptor.jdbc.BlobJdbcType;
 import org.hibernate.type.descriptor.jdbc.ClobJdbcType;
@@ -1218,4 +1221,8 @@ public class CockroachLegacyDialect extends Dialect {
 		return false;
 	}
 
+	@Override
+	public InformationExtractor getInformationExtractor(ExtractionContext extractionContext) {
+		return new InformationExtractorPostgreSQLImpl( extractionContext );
+	}
 }

--- a/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/GaussDBDialect.java
+++ b/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/GaussDBDialect.java
@@ -75,7 +75,10 @@ import org.hibernate.sql.exec.spi.JdbcOperation;
 import org.hibernate.sql.model.MutationOperation;
 import org.hibernate.sql.model.internal.OptionalTableUpdate;
 import org.hibernate.sql.model.jdbc.OptionalTableUpdateOperation;
+import org.hibernate.tool.schema.extract.internal.InformationExtractorPostgreSQLImpl;
 import org.hibernate.tool.schema.extract.spi.ColumnTypeInformation;
+import org.hibernate.tool.schema.extract.spi.ExtractionContext;
+import org.hibernate.tool.schema.extract.spi.InformationExtractor;
 import org.hibernate.tool.schema.internal.StandardTableExporter;
 import org.hibernate.tool.schema.spi.Exporter;
 import org.hibernate.type.JavaObjectType;
@@ -1376,5 +1379,10 @@ public class GaussDBDialect extends Dialect {
 	@Override
 	public boolean supportsBindingNullSqlTypeForSetNull() {
 		return true;
+	}
+
+	@Override
+	public InformationExtractor getInformationExtractor(ExtractionContext extractionContext) {
+		return new InformationExtractorPostgreSQLImpl( extractionContext );
 	}
 }

--- a/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/OracleLegacyDialect.java
+++ b/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/OracleLegacyDialect.java
@@ -101,8 +101,11 @@ import org.hibernate.sql.ast.spi.SqlAppender;
 import org.hibernate.sql.ast.spi.StandardSqlAstTranslatorFactory;
 import org.hibernate.sql.ast.tree.Statement;
 import org.hibernate.sql.exec.spi.JdbcOperation;
+import org.hibernate.tool.schema.extract.internal.InformationExtractorOracleImpl;
 import org.hibernate.tool.schema.extract.internal.SequenceInformationExtractorOracleDatabaseImpl;
 import org.hibernate.tool.schema.extract.spi.ColumnTypeInformation;
+import org.hibernate.tool.schema.extract.spi.ExtractionContext;
+import org.hibernate.tool.schema.extract.spi.InformationExtractor;
 import org.hibernate.tool.schema.extract.spi.SequenceInformationExtractor;
 import org.hibernate.tool.schema.internal.StandardTableExporter;
 import org.hibernate.tool.schema.spi.Exporter;
@@ -1770,4 +1773,8 @@ public class OracleLegacyDialect extends Dialect {
 		return getVersion().isSameOrAfter( 9 );
 	}
 
+	@Override
+	public InformationExtractor getInformationExtractor(ExtractionContext extractionContext) {
+		return new InformationExtractorOracleImpl( extractionContext );
+	}
 }

--- a/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/PostgreSQLLegacyDialect.java
+++ b/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/PostgreSQLLegacyDialect.java
@@ -94,7 +94,10 @@ import org.hibernate.sql.ast.spi.SqlAppender;
 import org.hibernate.sql.ast.spi.StandardSqlAstTranslatorFactory;
 import org.hibernate.sql.ast.tree.Statement;
 import org.hibernate.sql.exec.spi.JdbcOperation;
+import org.hibernate.tool.schema.extract.internal.InformationExtractorPostgreSQLImpl;
 import org.hibernate.tool.schema.extract.spi.ColumnTypeInformation;
+import org.hibernate.tool.schema.extract.spi.ExtractionContext;
+import org.hibernate.tool.schema.extract.spi.InformationExtractor;
 import org.hibernate.tool.schema.internal.StandardTableExporter;
 import org.hibernate.tool.schema.spi.Exporter;
 import org.hibernate.type.JavaObjectType;
@@ -1647,6 +1650,11 @@ public class PostgreSQLLegacyDialect extends Dialect {
 	@Override
 	public boolean supportsRecursiveSearchClause() {
 		return getVersion().isSameOrAfter( 14 );
+	}
+
+	@Override
+	public InformationExtractor getInformationExtractor(ExtractionContext extractionContext) {
+		return new InformationExtractorPostgreSQLImpl( extractionContext );
 	}
 
 }

--- a/hibernate-core/src/main/java/org/hibernate/dialect/CockroachDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/CockroachDialect.java
@@ -62,7 +62,10 @@ import org.hibernate.sql.ast.spi.SqlAppender;
 import org.hibernate.sql.ast.spi.StandardSqlAstTranslatorFactory;
 import org.hibernate.sql.ast.tree.Statement;
 import org.hibernate.sql.exec.spi.JdbcOperation;
+import org.hibernate.tool.schema.extract.internal.InformationExtractorPostgreSQLImpl;
 import org.hibernate.tool.schema.extract.spi.ColumnTypeInformation;
+import org.hibernate.tool.schema.extract.spi.ExtractionContext;
+import org.hibernate.tool.schema.extract.spi.InformationExtractor;
 import org.hibernate.type.JavaObjectType;
 import org.hibernate.type.descriptor.jdbc.BlobJdbcType;
 import org.hibernate.type.descriptor.jdbc.ClobJdbcType;
@@ -1188,5 +1191,10 @@ public class CockroachDialect extends Dialect {
 	@Override
 	public String getReadLockString(String aliases, int timeout) {
 		return withTimeout( " for share of " + aliases, timeout );
+	}
+
+	@Override
+	public InformationExtractor getInformationExtractor(ExtractionContext extractionContext) {
+		return new InformationExtractorPostgreSQLImpl( extractionContext );
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/dialect/Dialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/Dialect.java
@@ -129,9 +129,12 @@ import org.hibernate.sql.ast.tree.select.QuerySpec;
 import org.hibernate.sql.model.MutationOperation;
 import org.hibernate.sql.model.internal.OptionalTableUpdate;
 import org.hibernate.sql.model.jdbc.OptionalTableUpdateOperation;
+import org.hibernate.tool.schema.extract.internal.InformationExtractorJdbcDatabaseMetaDataImpl;
 import org.hibernate.tool.schema.extract.internal.SequenceInformationExtractorLegacyImpl;
 import org.hibernate.tool.schema.extract.internal.SequenceInformationExtractorNoOpImpl;
 import org.hibernate.tool.schema.extract.spi.ColumnTypeInformation;
+import org.hibernate.tool.schema.extract.spi.ExtractionContext;
+import org.hibernate.tool.schema.extract.spi.InformationExtractor;
 import org.hibernate.tool.schema.extract.spi.SequenceInformationExtractor;
 import org.hibernate.tool.schema.internal.HibernateSchemaManagementTool;
 import org.hibernate.tool.schema.internal.StandardAuxiliaryDatabaseObjectExporter;
@@ -2171,6 +2174,16 @@ public abstract class Dialect implements ConversionContext, TypeContributor, Fun
 		return getQuerySequencesString() == null
 				? SequenceInformationExtractorNoOpImpl.INSTANCE
 				: SequenceInformationExtractorLegacyImpl.INSTANCE;
+	}
+
+	/**
+	 * A {@link InformationExtractor} which is able to extract
+	 * table, primary key, foreign key, index information etc. via JDBC.
+	 *
+	 * @since 7.2
+	 */
+	public InformationExtractor getInformationExtractor(ExtractionContext extractionContext) {
+		return new InformationExtractorJdbcDatabaseMetaDataImpl( extractionContext );
 	}
 
 	// GUID support ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/hibernate-core/src/main/java/org/hibernate/dialect/MySQLDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/MySQLDialect.java
@@ -68,6 +68,9 @@ import org.hibernate.sql.ast.tree.Statement;
 import org.hibernate.sql.exec.spi.JdbcOperation;
 import org.hibernate.sql.model.MutationOperation;
 import org.hibernate.sql.model.internal.OptionalTableUpdate;
+import org.hibernate.tool.schema.extract.internal.InformationExtractorMySQLImpl;
+import org.hibernate.tool.schema.extract.spi.ExtractionContext;
+import org.hibernate.tool.schema.extract.spi.InformationExtractor;
 import org.hibernate.type.BasicTypeRegistry;
 import org.hibernate.type.NullType;
 import org.hibernate.type.SqlTypes;
@@ -1666,4 +1669,8 @@ public class MySQLDialect extends Dialect {
 		return super.createOptionalTableUpdateOperation( mutationTarget, optionalTableUpdate, factory );
 	}
 
+	@Override
+	public InformationExtractor getInformationExtractor(ExtractionContext extractionContext) {
+		return new InformationExtractorMySQLImpl( extractionContext );
+	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/dialect/OracleDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/OracleDialect.java
@@ -87,8 +87,11 @@ import org.hibernate.sql.ast.tree.Statement;
 import org.hibernate.sql.exec.spi.JdbcOperation;
 import org.hibernate.sql.model.MutationOperation;
 import org.hibernate.sql.model.internal.OptionalTableUpdate;
+import org.hibernate.tool.schema.extract.internal.InformationExtractorOracleImpl;
 import org.hibernate.tool.schema.extract.internal.SequenceInformationExtractorOracleDatabaseImpl;
 import org.hibernate.tool.schema.extract.spi.ColumnTypeInformation;
+import org.hibernate.tool.schema.extract.spi.ExtractionContext;
+import org.hibernate.tool.schema.extract.spi.InformationExtractor;
 import org.hibernate.tool.schema.extract.spi.SequenceInformationExtractor;
 import org.hibernate.tool.schema.internal.StandardTableExporter;
 import org.hibernate.tool.schema.spi.Exporter;
@@ -1872,6 +1875,11 @@ public class OracleDialect extends Dialect {
 	@Override
 	public boolean supportsRowValueConstructorSyntaxInQuantifiedPredicates() {
 		return false;
+	}
+
+	@Override
+	public InformationExtractor getInformationExtractor(ExtractionContext extractionContext) {
+		return new InformationExtractorOracleImpl( extractionContext );
 	}
 
 }

--- a/hibernate-core/src/main/java/org/hibernate/dialect/PostgreSQLDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/PostgreSQLDialect.java
@@ -85,7 +85,10 @@ import org.hibernate.sql.ast.tree.Statement;
 import org.hibernate.sql.exec.spi.JdbcOperation;
 import org.hibernate.sql.model.MutationOperation;
 import org.hibernate.sql.model.internal.OptionalTableUpdate;
+import org.hibernate.tool.schema.extract.internal.InformationExtractorPostgreSQLImpl;
 import org.hibernate.tool.schema.extract.spi.ColumnTypeInformation;
+import org.hibernate.tool.schema.extract.spi.ExtractionContext;
+import org.hibernate.tool.schema.extract.spi.InformationExtractor;
 import org.hibernate.tool.schema.internal.StandardTableExporter;
 import org.hibernate.tool.schema.spi.Exporter;
 import org.hibernate.type.JavaObjectType;
@@ -1648,4 +1651,8 @@ public class PostgreSQLDialect extends Dialect {
 		return getVersion().isSameOrAfter( 14 );
 	}
 
+	@Override
+	public InformationExtractor getInformationExtractor(ExtractionContext extractionContext) {
+		return new InformationExtractorPostgreSQLImpl( extractionContext );
+	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/tool/schema/extract/internal/CachingDatabaseInformationImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/tool/schema/extract/internal/CachingDatabaseInformationImpl.java
@@ -1,0 +1,109 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.tool.schema.extract.internal;
+
+import org.checkerframework.checker.nullness.qual.Nullable;
+import org.hibernate.boot.model.relational.Namespace;
+import org.hibernate.boot.model.relational.QualifiedTableName;
+import org.hibernate.boot.model.relational.SqlStringGenerationContext;
+import org.hibernate.engine.jdbc.env.spi.JdbcEnvironment;
+import org.hibernate.resource.transaction.spi.DdlTransactionIsolator;
+import org.hibernate.service.ServiceRegistry;
+import org.hibernate.tool.schema.extract.spi.ForeignKeyInformation;
+import org.hibernate.tool.schema.extract.spi.IndexInformation;
+import org.hibernate.tool.schema.extract.spi.NameSpaceForeignKeysInformation;
+import org.hibernate.tool.schema.extract.spi.NameSpaceIndexesInformation;
+import org.hibernate.tool.schema.extract.spi.NameSpacePrimaryKeysInformation;
+import org.hibernate.tool.schema.extract.spi.NameSpaceTablesInformation;
+import org.hibernate.tool.schema.extract.spi.PrimaryKeyInformation;
+import org.hibernate.tool.schema.extract.spi.TableInformation;
+import org.hibernate.tool.schema.spi.SchemaManagementTool;
+
+import java.sql.SQLException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * @since 7.2
+ */
+public class CachingDatabaseInformationImpl extends DatabaseInformationImpl {
+
+	private final Map<Namespace.Name, NamespaceCacheEntry> namespaceCacheEntries = new HashMap<>();
+
+	public CachingDatabaseInformationImpl(
+			ServiceRegistry serviceRegistry,
+			JdbcEnvironment jdbcEnvironment,
+			SqlStringGenerationContext context,
+			DdlTransactionIsolator ddlTransactionIsolator,
+			SchemaManagementTool tool) throws SQLException {
+		super( serviceRegistry, jdbcEnvironment, context, ddlTransactionIsolator, tool );
+	}
+
+	@Override
+	public @Nullable TableInformation locateTableInformation(QualifiedTableName tableName) {
+		final var namespace = new Namespace.Name( tableName.getCatalogName(), tableName.getSchemaName() );
+		final var entry = namespaceCacheEntries.computeIfAbsent( namespace, k -> new NamespaceCacheEntry() );
+		NameSpaceTablesInformation nameSpaceTablesInformation = entry.tableInformation;
+		if ( nameSpaceTablesInformation == null ) {
+			nameSpaceTablesInformation = extractor.getTables( namespace.catalog(), namespace.schema() );
+			entry.tableInformation = nameSpaceTablesInformation;
+		}
+		return nameSpaceTablesInformation.getTableInformation( tableName.getTableName().getText() );
+	}
+
+	@Override
+	public @Nullable PrimaryKeyInformation locatePrimaryKeyInformation(QualifiedTableName tableName) {
+		final var namespace = new Namespace.Name( tableName.getCatalogName(), tableName.getSchemaName() );
+		final var entry = namespaceCacheEntries.computeIfAbsent( namespace, k -> new NamespaceCacheEntry() );
+		NameSpacePrimaryKeysInformation nameSpaceTablesInformation = entry.primaryKeysInformation;
+		if ( nameSpaceTablesInformation == null ) {
+			nameSpaceTablesInformation = extractor.getPrimaryKeys( namespace.catalog(), namespace.schema() );
+			entry.primaryKeysInformation = nameSpaceTablesInformation;
+		}
+		return nameSpaceTablesInformation.getPrimaryKeyInformation( tableName.getTableName().getText() );
+	}
+
+	@Override
+	public Iterable<ForeignKeyInformation> locateForeignKeyInformation(QualifiedTableName tableName) {
+		final var namespace = new Namespace.Name( tableName.getCatalogName(), tableName.getSchemaName() );
+		final var entry = namespaceCacheEntries.computeIfAbsent( namespace, k -> new NamespaceCacheEntry() );
+		NameSpaceForeignKeysInformation nameSpaceTablesInformation = entry.foreignKeysInformation;
+		if ( nameSpaceTablesInformation == null ) {
+			nameSpaceTablesInformation = extractor.getForeignKeys( namespace.catalog(), namespace.schema() );
+			entry.foreignKeysInformation = nameSpaceTablesInformation;
+		}
+		final List<ForeignKeyInformation> foreignKeysInformation =
+				nameSpaceTablesInformation.getForeignKeysInformation( tableName.getTableName().getText() );
+		return foreignKeysInformation == null ? Collections.emptyList() : foreignKeysInformation;
+	}
+
+	@Override
+	public Iterable<IndexInformation> locateIndexesInformation(QualifiedTableName tableName) {
+		final var namespace = new Namespace.Name( tableName.getCatalogName(), tableName.getSchemaName() );
+		final var entry = namespaceCacheEntries.computeIfAbsent( namespace, k -> new NamespaceCacheEntry() );
+		NameSpaceIndexesInformation nameSpaceTablesInformation = entry.indexesInformation;
+		if ( nameSpaceTablesInformation == null ) {
+			nameSpaceTablesInformation = extractor.getIndexes( namespace.catalog(), namespace.schema() );
+			entry.indexesInformation = nameSpaceTablesInformation;
+		}
+		final List<IndexInformation> indexesInformation =
+				nameSpaceTablesInformation.getIndexesInformation( tableName.getTableName().getText() );
+		return indexesInformation == null ? Collections.emptyList() : indexesInformation;
+	}
+
+	@Override
+	public boolean isCaching() {
+		return true;
+	}
+
+	private static class NamespaceCacheEntry {
+		NameSpaceTablesInformation tableInformation;
+		NameSpacePrimaryKeysInformation primaryKeysInformation;
+		NameSpaceForeignKeysInformation foreignKeysInformation;
+		NameSpaceIndexesInformation indexesInformation;
+	}
+}

--- a/hibernate-core/src/main/java/org/hibernate/tool/schema/extract/internal/DatabaseInformationImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/tool/schema/extract/internal/DatabaseInformationImpl.java
@@ -8,6 +8,7 @@ import java.sql.SQLException;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.checkerframework.checker.nullness.qual.Nullable;
 import org.hibernate.boot.model.naming.Identifier;
 import org.hibernate.boot.model.relational.Namespace;
 import org.hibernate.boot.model.relational.QualifiedSequenceName;
@@ -18,8 +19,12 @@ import org.hibernate.resource.transaction.spi.DdlTransactionIsolator;
 import org.hibernate.service.ServiceRegistry;
 import org.hibernate.tool.schema.extract.spi.DatabaseInformation;
 import org.hibernate.tool.schema.extract.spi.ExtractionContext;
+import org.hibernate.tool.schema.extract.spi.ForeignKeyInformation;
+import org.hibernate.tool.schema.extract.spi.IndexInformation;
 import org.hibernate.tool.schema.extract.spi.InformationExtractor;
 import org.hibernate.tool.schema.extract.spi.NameSpaceTablesInformation;
+import org.hibernate.tool.schema.extract.spi.PrimaryKeyInformation;
+import org.hibernate.tool.schema.extract.spi.SchemaExtractionException;
 import org.hibernate.tool.schema.extract.spi.SequenceInformation;
 import org.hibernate.tool.schema.extract.spi.TableInformation;
 import org.hibernate.tool.schema.spi.SchemaManagementTool;
@@ -29,10 +34,10 @@ import org.hibernate.tool.schema.spi.SchemaManagementTool;
  */
 public class DatabaseInformationImpl
 		implements DatabaseInformation, ExtractionContext.DatabaseObjectAccess {
-	private final JdbcEnvironment jdbcEnvironment;
-	private final SqlStringGenerationContext context;
-	private final ExtractionContext extractionContext;
-	private final InformationExtractor extractor;
+	protected final JdbcEnvironment jdbcEnvironment;
+	protected final SqlStringGenerationContext context;
+	protected final ExtractionContext extractionContext;
+	protected final InformationExtractor extractor;
 
 	private final Map<QualifiedSequenceName, SequenceInformation> sequenceInformationMap = new HashMap<>();
 
@@ -144,7 +149,7 @@ public class DatabaseInformationImpl
 	}
 
 	@Override
-	public TableInformation locateTableInformation(QualifiedTableName tableName) {
+	public @Nullable TableInformation locateTableInformation(QualifiedTableName tableName) {
 		return getTableInformation( tableName );
 	}
 
@@ -155,5 +160,33 @@ public class DatabaseInformationImpl
 			sequenceName = unqualifiedSequenceName( sequenceName );
 		}
 		return sequenceInformationMap.get( sequenceName );
+	}
+
+	@Override
+	public PrimaryKeyInformation locatePrimaryKeyInformation(QualifiedTableName tableName) {
+		return extractor.getPrimaryKey( locateNonNullTableInformation( tableName ) );
+	}
+
+	@Override
+	public Iterable<ForeignKeyInformation> locateForeignKeyInformation(QualifiedTableName tableName) {
+		return extractor.getForeignKeys( locateNonNullTableInformation( tableName ) );
+	}
+
+	@Override
+	public Iterable<IndexInformation> locateIndexesInformation(QualifiedTableName tableName) {
+		return extractor.getIndexes( locateNonNullTableInformation( tableName ) );
+	}
+
+	private TableInformation locateNonNullTableInformation(QualifiedTableName tableName) {
+		final TableInformation tableInformation = locateTableInformation( tableName );
+		if ( tableInformation == null ) {
+			throw new SchemaExtractionException( "Could not locate table information for " + tableName );
+		}
+		return tableInformation;
+	}
+
+	@Override
+	public boolean isCaching() {
+		return false;
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/tool/schema/extract/internal/InformationExtractorJdbcDatabaseMetaDataImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/tool/schema/extract/internal/InformationExtractorJdbcDatabaseMetaDataImpl.java
@@ -9,6 +9,7 @@ import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
 import java.util.StringTokenizer;
 
+import org.checkerframework.checker.nullness.qual.Nullable;
 import org.hibernate.boot.model.naming.DatabaseIdentifier;
 import org.hibernate.boot.model.naming.Identifier;
 import org.hibernate.dialect.Dialect;
@@ -33,7 +34,7 @@ public class InformationExtractorJdbcDatabaseMetaDataImpl extends AbstractInform
 		super( extractionContext );
 	}
 
-	private DatabaseMetaData getJdbcDatabaseMetaData() {
+	protected DatabaseMetaData getJdbcDatabaseMetaData() {
 		return getExtractionContext().getJdbcDatabaseMetaData();
 	}
 
@@ -108,10 +109,24 @@ public class InformationExtractorJdbcDatabaseMetaDataImpl extends AbstractInform
 	}
 
 	@Override
+	protected <T> T processPrimaryKeysResultSet(
+			String catalogFilter,
+			String schemaFilter,
+			@Nullable String tableName,
+			ExtractionContext.ResultSetProcessor<T> processor)
+			throws SQLException {
+		try ( var resultSet =
+					getJdbcDatabaseMetaData()
+							.getPrimaryKeys( catalogFilter, schemaFilter, tableName ) ) {
+			return processor.process( resultSet );
+		}
+	}
+
+	@Override
 	protected <T> T processIndexInfoResultSet(
 			String catalog,
 			String schema,
-			String table,
+			@Nullable String table,
 			boolean unique,
 			boolean approximate,
 			ExtractionContext.ResultSetProcessor<T> processor)
@@ -127,7 +142,7 @@ public class InformationExtractorJdbcDatabaseMetaDataImpl extends AbstractInform
 	protected <T> T processImportedKeysResultSet(
 			String catalog,
 			String schema,
-			String table,
+			@Nullable String table,
 			ExtractionContext.ResultSetProcessor<T> processor)
 					throws SQLException {
 		try ( var resultSet =

--- a/hibernate-core/src/main/java/org/hibernate/tool/schema/extract/internal/InformationExtractorMySQLImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/tool/schema/extract/internal/InformationExtractorMySQLImpl.java
@@ -1,0 +1,165 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.tool.schema.extract.internal;
+
+import org.checkerframework.checker.nullness.qual.Nullable;
+import org.hibernate.boot.model.naming.Identifier;
+import org.hibernate.boot.model.relational.Namespace;
+import org.hibernate.tool.schema.extract.spi.ExtractionContext;
+import org.hibernate.tool.schema.extract.spi.NameSpaceForeignKeysInformation;
+import org.hibernate.tool.schema.extract.spi.NameSpaceIndexesInformation;
+import org.hibernate.tool.schema.extract.spi.NameSpacePrimaryKeysInformation;
+
+import java.sql.SQLException;
+
+/**
+ * @since 7.2
+ */
+public class InformationExtractorMySQLImpl extends InformationExtractorJdbcDatabaseMetaDataImpl {
+
+	public InformationExtractorMySQLImpl(ExtractionContext extractionContext) {
+		super( extractionContext );
+	}
+
+	@Override
+	public NameSpaceForeignKeysInformation getForeignKeys(Identifier catalog, Identifier schema) {
+		final String tableSchema = determineTableSchema( catalog, schema );
+		try ( var preparedStatement = getExtractionContext().getJdbcConnection().prepareStatement( getForeignKeysSql( tableSchema ) )) {
+			if ( tableSchema != null ) {
+				preparedStatement.setString( 1, tableSchema );
+			}
+			try ( var resultSet = preparedStatement.executeQuery() ) {
+				return extractNameSpaceForeignKeysInformation( resultSet );
+			}
+		}
+		catch (SQLException e) {
+				throw convertSQLException( e,
+						"Error while reading foreign key information for namespace "
+						+ new Namespace.Name( catalog, schema ) );
+		}
+	}
+
+	private String getForeignKeysSql(String tableSchema) {
+		final String getForeignKeysSql = """
+				select distinct\
+					a.referenced_table_schema as PKTABLE_CAT,\
+					null as PKTABLE_SCHEM,\
+					a.referenced_table_name as PKTABLE_NAME,\
+					a.referenced_column_name as PKCOLUMN_NAME,\
+					a.table_schema as FKTABLE_CAT,\
+					null as FKTABLE_SCHEM,\
+					a.table_name AS FKTABLE_NAME,\
+					a.column_name as FKCOLUMN_NAME,\
+					a.position_in_unique_constraint as KEY_SEQ,\
+					case b.update_rule when 'RESTRICT' then 1 when 'NO ACTION' then 3 when 'CASCADE' then 0 when 'SET NULL' then 2 when 'SET DEFAULT' then 4 end as UPDATE_RULE,\
+					case b.delete_rule when 'RESTRICT' then 1 when 'NO ACTION' then 3 when 'CASCADE' then 0 when 'SET NULL' then 2 when 'SET DEFAULT' then 4 end as DELETE_RULE,\
+					a.constraint_name as FK_NAME,\
+					b.unique_constraint_name as PK_NAME
+				from information_schema.key_column_usage a
+				join information_schema.referential_constraints b using (constraint_catalog, constraint_schema, constraint_name)
+				""";
+		return getForeignKeysSql + (tableSchema == null ? "" : " where a.table_schema = ?")
+				+ " order by a.referenced_table_schema, a.referenced_table_name, a.constraint_name, a.position_in_unique_constraint";
+	}
+
+	@Override
+	public NameSpaceIndexesInformation getIndexes(Identifier catalog, Identifier schema) {
+		final String tableSchema = determineTableSchema( catalog, schema );
+		try ( var preparedStatement = getExtractionContext().getJdbcConnection().prepareStatement( getIndexesSql( tableSchema ) )) {
+			if ( tableSchema != null ) {
+				preparedStatement.setString( 1, tableSchema );
+			}
+			try ( var resultSet = preparedStatement.executeQuery() ) {
+				return extractNameSpaceIndexesInformation( resultSet );
+			}
+		}
+		catch (SQLException e) {
+			throw convertSQLException( e,
+					"Error while reading index information for namespace "
+					+ new Namespace.Name( catalog, schema ) );
+		}
+	}
+
+	private String getIndexesSql(String tableSchema) {
+		final String getIndexesSql = """
+				select distinct\
+					a.table_schema as TABLE_CAT,\
+					null as TABLE_SCHEM,\
+					a.table_name as TABLE_NAME,\
+					a.non_unique as NON_UNIQUE,\
+					null as INDEX_QUALIFIER,\
+					a.index_name as INDEX_NAME,\
+					3 as TYPE,\
+					a.seq_in_index as ORDINAL_POSITION,\
+					a.column_name as COLUMN_NAME,\
+					a.collation as ASC_OR_DESC,\
+					a.cardinality as CARDINALITY,\
+					0 as PAGES,\
+					null as FILTER_CONDITION
+				from information_schema.statistics a
+				""";
+		return getIndexesSql + (tableSchema == null ? "" : " where a.table_schema = ?")
+			+ " order by a.non_unique, a.index_name, a.seq_in_index";
+	}
+
+	@Override
+	public NameSpacePrimaryKeysInformation getPrimaryKeys(Identifier catalog, Identifier schema) {
+		final String tableSchema = determineTableSchema( catalog, schema );
+		try ( var preparedStatement = getExtractionContext().getJdbcConnection().prepareStatement( getPrimaryKeysSql( tableSchema ) )) {
+			if ( tableSchema != null ) {
+				preparedStatement.setString( 1, tableSchema );
+			}
+			try ( var resultSet = preparedStatement.executeQuery() ) {
+				return extractNameSpacePrimaryKeysInformation( resultSet );
+			}
+		}
+		catch (SQLException e) {
+			throw convertSQLException( e,
+					"Error while reading primary key information for namespace "
+					+ new Namespace.Name( catalog, schema ) );
+		}
+	}
+
+	private String getPrimaryKeysSql(String tableSchema) {
+		final String getPrimaryKeysSql = """
+				select distinct\
+					a.table_schema as TABLE_CAT,\
+					null as TABLE_SCHEM,\
+					a.table_name as TABLE_NAME,\
+					a.column_name as COLUMN_NAME,\
+					a.seq_in_index as KEY_SEQ,\
+					'PRIMARY' as PK_NAME
+				from information_schema.statistics a
+				where a.index_name = 'PRIMARY'
+				""";
+		return getPrimaryKeysSql + (tableSchema == null ? "" : " and a.table_schema = ?")
+			+ " order by a.table_schema, a.table_name, a.column_name, a.seq_in_index";
+	}
+
+	protected @Nullable String determineTableSchema(@Nullable Identifier catalog, @Nullable Identifier schema) {
+		if ( catalog != null ) {
+			return catalog.getText();
+		}
+		if ( schema != null ) {
+			return schema.getText();
+		}
+		return null;
+	}
+
+	@Override
+	public boolean supportsBulkPrimaryKeyRetrieval() {
+		return true;
+	}
+
+	@Override
+	public boolean supportsBulkForeignKeyRetrieval() {
+		return true;
+	}
+
+	@Override
+	public boolean supportsBulkIndexRetrieval() {
+		return true;
+	}
+}

--- a/hibernate-core/src/main/java/org/hibernate/tool/schema/extract/internal/InformationExtractorOracleImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/tool/schema/extract/internal/InformationExtractorOracleImpl.java
@@ -1,0 +1,29 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.tool.schema.extract.internal;
+
+import org.hibernate.tool.schema.extract.spi.ExtractionContext;
+
+/**
+ * @since 7.2
+ */
+public class InformationExtractorOracleImpl extends InformationExtractorJdbcDatabaseMetaDataImpl {
+
+	public InformationExtractorOracleImpl(ExtractionContext extractionContext) {
+		super( extractionContext );
+	}
+
+	@Override
+	public boolean supportsBulkPrimaryKeyRetrieval() {
+		return true;
+	}
+
+	@Override
+	public boolean supportsBulkForeignKeyRetrieval() {
+		return true;
+	}
+
+	// Unfortunately, there is no support for table wildcard for indexes
+}

--- a/hibernate-core/src/main/java/org/hibernate/tool/schema/extract/internal/InformationExtractorPostgreSQLImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/tool/schema/extract/internal/InformationExtractorPostgreSQLImpl.java
@@ -1,0 +1,95 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.tool.schema.extract.internal;
+
+import org.hibernate.boot.model.naming.Identifier;
+import org.hibernate.boot.model.relational.Namespace;
+import org.hibernate.tool.schema.extract.spi.ExtractionContext;
+import org.hibernate.tool.schema.extract.spi.NameSpaceIndexesInformation;
+
+import java.sql.SQLException;
+
+/**
+ * @since 7.2
+ */
+public class InformationExtractorPostgreSQLImpl extends InformationExtractorJdbcDatabaseMetaDataImpl {
+
+	public InformationExtractorPostgreSQLImpl(ExtractionContext extractionContext) {
+		super( extractionContext );
+	}
+
+	@Override
+	public boolean supportsBulkPrimaryKeyRetrieval() {
+		return true;
+	}
+
+	@Override
+	public boolean supportsBulkForeignKeyRetrieval() {
+		return true;
+	}
+
+	@Override
+	public NameSpaceIndexesInformation getIndexes(Identifier catalog, Identifier schema) {
+		final String tableSchema = schema == null ? null : schema.getText();
+		try ( var preparedStatement = getExtractionContext().getJdbcConnection().prepareStatement( getIndexesSql( tableSchema ) )) {
+			if ( tableSchema != null ) {
+				preparedStatement.setString( 1, tableSchema );
+			}
+			try ( var resultSet = preparedStatement.executeQuery() ) {
+				return extractNameSpaceIndexesInformation( resultSet );
+			}
+		}
+		catch (SQLException e) {
+			throw convertSQLException( e,
+					"Error while reading index information for namespace "
+					+ new Namespace.Name( catalog, schema ) );
+		}
+	}
+
+	private String getIndexesSql(String tableSchema) {
+		final String sql = """
+				select\
+					current_database() as "TABLE_CAT",\
+					n.nspname as "TABLE_SCHEM",\
+					ct.relname as "TABLE_NAME",\
+					not i.indisunique as "NON_UNIQUE",\
+					null as "INDEX_QUALIFIER",\
+					ci.relname as "INDEX_NAME",\
+					case i.indisclustered\
+						when true then 1\
+						else\
+							case am.amname\
+								when 'hash' then 2\
+								else 3\
+							end\
+					end as "TYPE",\
+					ic.n as "ORDINAL_POSITION",\
+					ci.reltuples as "CARDINALITY",\
+					ci.relpages as "PAGES",\
+					pg_catalog.pg_get_expr(i.indpred, i.indrelid) as "FILTER_CONDITION",\
+					trim(both '"' from pg_catalog.pg_get_indexdef(ci.oid, ic.n, false)) as "COLUMN_NAME",\
+					case am.amname\
+						when 'btree' then\
+							case i.indoption[ic.n - 1] & 1::smallint\
+								when 1 then 'D'\
+								else 'A'\
+							end\
+					end as "ASC_OR_DESC"
+				from pg_catalog.pg_class ct
+				join pg_catalog.pg_namespace n on (ct.relnamespace = n.oid)
+				join pg_catalog.pg_index i on (ct.oid = i.indrelid)
+				join pg_catalog.pg_class ci on (ci.oid = i.indexrelid)
+				join pg_catalog.pg_am am on (ci.relam = am.oid)
+				join information_schema._pg_expandarray(i.indkey) ic on 1=1
+				""";
+		return sql + (tableSchema == null ? "" : " where n.nspname = ?");
+	}
+
+	@Override
+	public boolean supportsBulkIndexRetrieval() {
+		return true;
+	}
+
+}

--- a/hibernate-core/src/main/java/org/hibernate/tool/schema/extract/spi/ExtractionContext.java
+++ b/hibernate-core/src/main/java/org/hibernate/tool/schema/extract/spi/ExtractionContext.java
@@ -9,6 +9,7 @@ import java.sql.DatabaseMetaData;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 
+import org.checkerframework.checker.nullness.qual.Nullable;
 import org.hibernate.Incubating;
 import org.hibernate.boot.model.naming.Identifier;
 import org.hibernate.boot.model.relational.QualifiedSequenceName;
@@ -63,8 +64,12 @@ public interface ExtractionContext {
 	 */
 	@Incubating
 	interface DatabaseObjectAccess {
-		TableInformation locateTableInformation(QualifiedTableName tableName);
+		@Nullable TableInformation locateTableInformation(QualifiedTableName tableName);
 		SequenceInformation locateSequenceInformation(QualifiedSequenceName sequenceName);
+		@Nullable PrimaryKeyInformation locatePrimaryKeyInformation(QualifiedTableName tableName);
+		Iterable<ForeignKeyInformation> locateForeignKeyInformation(QualifiedTableName tableName);
+		Iterable<IndexInformation> locateIndexesInformation(QualifiedTableName tableName);
+		boolean isCaching();
 	}
 
 	DatabaseObjectAccess getDatabaseObjectAccess();

--- a/hibernate-core/src/main/java/org/hibernate/tool/schema/extract/spi/InformationExtractor.java
+++ b/hibernate-core/src/main/java/org/hibernate/tool/schema/extract/spi/InformationExtractor.java
@@ -4,9 +4,9 @@
  */
 package org.hibernate.tool.schema.extract.spi;
 
+import org.checkerframework.checker.nullness.qual.Nullable;
 import org.hibernate.Incubating;
 import org.hibernate.boot.model.naming.Identifier;
-import org.hibernate.tool.schema.extract.internal.TableInformationImpl;
 
 /**
  * Contract for extracting information about objects in the database schema(s).  To an extent, the contract largely
@@ -72,7 +72,21 @@ public interface InformationExtractor {
 	 *
 	 * @return The extracted primary key information
 	 */
-	PrimaryKeyInformation getPrimaryKey(TableInformationImpl tableInformation);
+	@Nullable PrimaryKeyInformation getPrimaryKey(TableInformation tableInformation);
+
+	/**
+	 * Extract all the primary keys information.
+	 *
+	 * @param catalog Can be {@code null}, indicating that any catalog may be considered a match.  A
+	 * non-{@code null} value indicates that search should be limited to the passed catalog.
+	 * @param schema Can  be {@code null}, indicating that any schema may be considered a match.  A
+	 * non-{@code null} value indicates that search should be limited to the passed schema .
+	 *
+	 * @return a {@link NameSpacePrimaryKeysInformation}
+	 * @throws SchemaExtractionException when bulk extraction isn't supported
+	 * @since 7.2
+	 */
+	NameSpacePrimaryKeysInformation getPrimaryKeys(Identifier catalog, Identifier schema);
 
 	/**
 	 * Extract information about indexes defined against the given table.  Typically called from the TableInformation
@@ -85,6 +99,20 @@ public interface InformationExtractor {
 	Iterable<IndexInformation> getIndexes(TableInformation tableInformation);
 
 	/**
+	 * Extract all the indexes information.
+	 *
+	 * @param catalog Can be {@code null}, indicating that any catalog may be considered a match.  A
+	 * non-{@code null} value indicates that search should be limited to the passed catalog.
+	 * @param schema Can  be {@code null}, indicating that any schema may be considered a match.  A
+	 * non-{@code null} value indicates that search should be limited to the passed schema .
+	 *
+	 * @return a {@link NameSpaceIndexesInformation}
+	 * @throws SchemaExtractionException when bulk extraction isn't supported
+	 * @since 7.2
+	 */
+	NameSpaceIndexesInformation getIndexes(Identifier catalog, Identifier schema);
+
+	/**
 	 * Extract information about foreign keys defined on the given table (targeting or point-at other tables).
 	 * Typically called from the TableInformation itself as part of on-demand initialization of its state.
 	 *
@@ -93,4 +121,39 @@ public interface InformationExtractor {
 	 * @return The extracted foreign-key information
 	 */
 	Iterable<ForeignKeyInformation> getForeignKeys(TableInformation tableInformation);
+
+	/**
+	 * Extract all the foreign keys information.
+	 *
+	 * @param catalog Can be {@code null}, indicating that any catalog may be considered a match.  A
+	 * non-{@code null} value indicates that search should be limited to the passed catalog.
+	 * @param schema Can  be {@code null}, indicating that any schema may be considered a match.  A
+	 * non-{@code null} value indicates that search should be limited to the passed schema .
+	 *
+	 * @return a {@link NameSpaceForeignKeysInformation}
+	 * @throws SchemaExtractionException when bulk extraction isn't supported
+	 * @since 7.2
+	 */
+	NameSpaceForeignKeysInformation getForeignKeys(Identifier catalog, Identifier schema);
+
+	/**
+	 * Can {@link #getPrimaryKeys(Identifier, Identifier)} be used?
+	 *
+	 * @since 7.2
+	 */
+	boolean supportsBulkPrimaryKeyRetrieval();
+
+	/**
+	 * Can {@link #getForeignKeys(Identifier, Identifier)} be used?
+	 *
+	 * @since 7.2
+	 */
+	boolean supportsBulkForeignKeyRetrieval();
+
+	/**
+	 * Can {@link #getIndexes(Identifier, Identifier)} be used?
+	 *
+	 * @since 7.2
+	 */
+	boolean supportsBulkIndexRetrieval();
 }

--- a/hibernate-core/src/main/java/org/hibernate/tool/schema/extract/spi/NameSpaceForeignKeysInformation.java
+++ b/hibernate-core/src/main/java/org/hibernate/tool/schema/extract/spi/NameSpaceForeignKeysInformation.java
@@ -1,0 +1,39 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.tool.schema.extract.spi;
+
+import org.checkerframework.checker.nullness.qual.Nullable;
+import org.hibernate.engine.jdbc.env.spi.IdentifierHelper;
+import org.hibernate.mapping.Table;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * @since 7.2
+ */
+public class NameSpaceForeignKeysInformation {
+	private final IdentifierHelper identifierHelper;
+	private final Map<String, List<ForeignKeyInformation>> foreignKeys = new HashMap<>();
+
+	public NameSpaceForeignKeysInformation(IdentifierHelper identifierHelper) {
+		this.identifierHelper = identifierHelper;
+	}
+
+	public void addForeignKeyInformation(TableInformation tableInformation, ForeignKeyInformation foreignKeyInformation) {
+		foreignKeys.computeIfAbsent( tableInformation.getName().getTableName().getText(), k -> new ArrayList<>() )
+				.add( foreignKeyInformation );
+	}
+
+	public @Nullable List<ForeignKeyInformation> getForeignKeysInformation(Table table) {
+		return foreignKeys.get( identifierHelper.toMetaDataObjectName( table.getQualifiedTableName().getTableName() ) );
+	}
+
+	public @Nullable List<ForeignKeyInformation> getForeignKeysInformation(String tableName) {
+		return foreignKeys.get( tableName );
+	}
+}

--- a/hibernate-core/src/main/java/org/hibernate/tool/schema/extract/spi/NameSpaceIndexesInformation.java
+++ b/hibernate-core/src/main/java/org/hibernate/tool/schema/extract/spi/NameSpaceIndexesInformation.java
@@ -1,0 +1,36 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.tool.schema.extract.spi;
+
+import org.checkerframework.checker.nullness.qual.Nullable;
+import org.hibernate.engine.jdbc.env.spi.IdentifierHelper;
+import org.hibernate.mapping.Table;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class NameSpaceIndexesInformation {
+	private final IdentifierHelper identifierHelper;
+	private final Map<String, List<IndexInformation>> indexes = new HashMap<>();
+
+	public NameSpaceIndexesInformation(IdentifierHelper identifierHelper) {
+		this.identifierHelper = identifierHelper;
+	}
+
+	public void addIndexInformation(TableInformation tableInformation, IndexInformation indexInformation) {
+		indexes.computeIfAbsent( tableInformation.getName().getTableName().getText(), k -> new ArrayList<>() )
+				.add( indexInformation );
+	}
+
+	public @Nullable List<IndexInformation> getIndexesInformation(Table table) {
+		return indexes.get( identifierHelper.toMetaDataObjectName( table.getQualifiedTableName().getTableName() ) );
+	}
+
+	public @Nullable List<IndexInformation> getIndexesInformation(String tableName) {
+		return indexes.get( tableName );
+	}
+}

--- a/hibernate-core/src/main/java/org/hibernate/tool/schema/extract/spi/NameSpacePrimaryKeysInformation.java
+++ b/hibernate-core/src/main/java/org/hibernate/tool/schema/extract/spi/NameSpacePrimaryKeysInformation.java
@@ -1,0 +1,54 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.tool.schema.extract.spi;
+
+import org.checkerframework.checker.nullness.qual.Nullable;
+import org.hibernate.engine.jdbc.env.spi.IdentifierHelper;
+import org.hibernate.mapping.Table;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * @since 7.2
+ */
+public class NameSpacePrimaryKeysInformation {
+	private final IdentifierHelper identifierHelper;
+	private final Map<String, PrimaryKeyInformation> primaryKeys = new HashMap<>();
+
+	public NameSpacePrimaryKeysInformation(IdentifierHelper identifierHelper) {
+		this.identifierHelper = identifierHelper;
+	}
+
+	public void addPrimaryKeyInformation(TableInformation tableInformation, PrimaryKeyInformation primaryKeyInformation) {
+		primaryKeys.put( tableInformation.getName().getTableName().getText(), primaryKeyInformation );
+	}
+
+	public @Nullable PrimaryKeyInformation getPrimaryKeyInformation(Table table) {
+		return primaryKeys.get( identifierHelper.toMetaDataObjectName( table.getQualifiedTableName().getTableName() ) );
+	}
+
+	public @Nullable PrimaryKeyInformation getPrimaryKeyInformation(String tableName) {
+		return primaryKeys.get( tableName );
+	}
+
+	public void validate() {
+		for ( Map.Entry<String, PrimaryKeyInformation> entry : primaryKeys.entrySet() ) {
+			final var tableName = entry.getKey();
+			final var primaryKeyInformation = entry.getValue();
+			int i = 1;
+			for ( ColumnInformation column : primaryKeyInformation.getColumns() ) {
+				if ( column == null ) {
+					throw new SchemaExtractionException(
+							"Primary Key information was missing for key [" +
+							primaryKeyInformation.getPrimaryKeyIdentifier() + "] on table [" + tableName +
+							"] at KEY_SEQ = " + i
+					);
+				}
+				i++;
+			}
+		}
+	}
+}

--- a/hibernate-core/src/main/java/org/hibernate/tool/schema/extract/spi/NameSpaceTablesInformation.java
+++ b/hibernate-core/src/main/java/org/hibernate/tool/schema/extract/spi/NameSpaceTablesInformation.java
@@ -7,6 +7,7 @@ package org.hibernate.tool.schema.extract.spi;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.checkerframework.checker.nullness.qual.Nullable;
 import org.hibernate.engine.jdbc.env.spi.IdentifierHelper;
 import org.hibernate.mapping.Table;
 
@@ -25,11 +26,11 @@ public class NameSpaceTablesInformation {
 		tables.put( tableInformation.getName().getTableName().getText(), tableInformation );
 	}
 
-	public TableInformation getTableInformation(Table table) {
+	public @Nullable TableInformation getTableInformation(Table table) {
 		return tables.get( identifierHelper.toMetaDataObjectName( table.getQualifiedTableName().getTableName() ) );
 	}
 
-	public TableInformation getTableInformation(String tableName) {
+	public @Nullable TableInformation getTableInformation(String tableName) {
 		return tables.get( tableName );
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/tool/schema/internal/AbstractSchemaMigrator.java
+++ b/hibernate-core/src/main/java/org/hibernate/tool/schema/internal/AbstractSchemaMigrator.java
@@ -25,6 +25,7 @@ import org.hibernate.engine.jdbc.internal.Formatter;
 import org.hibernate.mapping.ForeignKey;
 import org.hibernate.mapping.Index;
 import org.hibernate.mapping.Table;
+import org.hibernate.resource.transaction.spi.DdlTransactionIsolator;
 import org.hibernate.tool.schema.UniqueConstraintSchemaUpdateStrategy;
 import org.hibernate.tool.schema.extract.spi.DatabaseInformation;
 import org.hibernate.tool.schema.extract.spi.IndexInformation;
@@ -80,8 +81,7 @@ public abstract class AbstractSchemaMigrator implements SchemaMigrator {
 		if ( !targetDescriptor.getTargetTypes().isEmpty() ) {
 			final var jdbcContext = tool.resolveJdbcContext( options.getConfigurationValues() );
 			try ( var isolator = tool.getDdlTransactionIsolator( jdbcContext ) ) {
-				final var databaseInformation =
-						buildDatabaseInformation( isolator, sqlGenerationContext, tool );
+				final var databaseInformation = buildDatabaseInformation( isolator, sqlGenerationContext );
 				final var targets = tool.buildGenerationTargets(
 						targetDescriptor,
 						isolator,
@@ -125,6 +125,12 @@ public abstract class AbstractSchemaMigrator implements SchemaMigrator {
 				}
 			}
 		}
+	}
+
+	protected DatabaseInformation buildDatabaseInformation(
+			DdlTransactionIsolator ddlTransactionIsolator,
+			SqlStringGenerationContext sqlStringGenerationContext) {
+		return Helper.buildDatabaseInformation( ddlTransactionIsolator, sqlStringGenerationContext, tool );
 	}
 
 	private SqlStringGenerationContext sqlGenerationContext(Metadata metadata, ExecutionOptions options) {

--- a/hibernate-core/src/main/java/org/hibernate/tool/schema/internal/HibernateSchemaManagementTool.java
+++ b/hibernate-core/src/main/java/org/hibernate/tool/schema/internal/HibernateSchemaManagementTool.java
@@ -21,7 +21,6 @@ import org.hibernate.service.spi.ServiceRegistryAwareService;
 import org.hibernate.service.spi.ServiceRegistryImplementor;
 import org.hibernate.tool.schema.JdbcMetadataAccessStrategy;
 import org.hibernate.tool.schema.TargetType;
-import org.hibernate.tool.schema.extract.internal.InformationExtractorJdbcDatabaseMetaDataImpl;
 import org.hibernate.tool.schema.extract.spi.ExtractionContext;
 import org.hibernate.tool.schema.extract.spi.InformationExtractor;
 import org.hibernate.tool.schema.internal.exec.GenerationTargetToDatabase;
@@ -469,7 +468,7 @@ public class HibernateSchemaManagementTool implements SchemaManagementTool, Serv
 
 		@Override
 		public InformationExtractor createInformationExtractor(ExtractionContext extractionContext) {
-			return new InformationExtractorJdbcDatabaseMetaDataImpl( extractionContext );
+			return extractionContext.getJdbcEnvironment().getDialect().getInformationExtractor( extractionContext );
 		}
 	}
 }


### PR DESCRIPTION
Cache the result of the batch loaded tables, foreign keys, primary keys and indexes to serve objects looked up by qualified name from cache. This reduces the amount of server round trips on schema migration. Ultimately, this per dialect flexibility is necessary to implement UDT validation and migration

<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

[Please describe here what your change is about]

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-13843
<!-- Hibernate GitHub Bot issue links end -->