### PR TITLE
HHH-19759 - Avoid a ClassCastException when joining on a basic value type

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/query/hql/internal/QualifiedJoinPathConsumer.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/hql/internal/QualifiedJoinPathConsumer.java
@@ -207,6 +207,10 @@ public class QualifiedJoinPathConsumer implements DotIdentifierConsumer {
 				}
 			}
 		}
+		if ( !(subPathSource instanceof SqmJoinable) ) {
+			throw new SemanticException( "Joining on basic value elements is not supported",
+					((SemanticQueryBuilder<?>) creationState).getQuery() );
+		}
 		@SuppressWarnings("unchecked")
 		final SqmJoinable<U, ?> joinSource = (SqmJoinable<U, ?>) subPathSource;
 		return createJoin( lhs, joinType, alias, fetch, isTerminal, allowReuse, creationState, joinSource );

--- a/hibernate-core/src/main/java/org/hibernate/query/hql/internal/SemanticQueryBuilder.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/hql/internal/SemanticQueryBuilder.java
@@ -414,6 +414,10 @@ public class SemanticQueryBuilder<R> extends HqlParserBaseVisitor<Object> implem
 		return processingStateStack;
 	}
 
+	public String getQuery() {
+		return query;
+	}
+
 	private NodeBuilder nodeBuilder() {
 		return creationContext.getNodeBuilder();
 	}


### PR DESCRIPTION
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-19759
<!-- Hibernate GitHub Bot issue links end -->