### PR TITLE
HHH-19846 - Drop JUnit 4 usage

### DIFF
--- a/hibernate-agroal/src/test/java/org/hibernate/test/agroal/AgroalConnectionProviderTest.java
+++ b/hibernate-agroal/src/test/java/org/hibernate/test/agroal/AgroalConnectionProviderTest.java
@@ -4,47 +4,54 @@
  */
 package org.hibernate.test.agroal;
 
+import org.hibernate.agroal.internal.AgroalConnectionProvider;
+import org.hibernate.engine.jdbc.env.internal.JdbcEnvironmentInitiator.ConnectionProviderJdbcConnectionAccess;
+import org.hibernate.engine.jdbc.spi.JdbcServices;
+import org.hibernate.engine.spi.SessionFactoryImplementor;
+import org.hibernate.service.spi.ServiceRegistryImplementor;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.ServiceRegistry;
+import org.hibernate.testing.orm.junit.ServiceRegistryScope;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.junit.jupiter.api.Test;
+
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.hibernate.engine.jdbc.env.internal.JdbcEnvironmentInitiator.ConnectionProviderJdbcConnectionAccess;
-import org.hibernate.engine.jdbc.spi.JdbcServices;
-import org.hibernate.agroal.internal.AgroalConnectionProvider;
-
-import org.hibernate.testing.junit4.BaseCoreFunctionalTestCase;
-import org.junit.Test;
-
-import static org.hibernate.testing.junit4.ExtraAssertions.assertTyping;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hibernate.testing.orm.junit.ExtraAssertions.assertTyping;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * @author Brett Meyer
  */
-public class AgroalConnectionProviderTest extends BaseCoreFunctionalTestCase {
+public class AgroalConnectionProviderTest {
 
 	@Test
-	public void testAgroalConnectionProvider() throws Exception {
-		JdbcServices jdbcServices = serviceRegistry().requireService( JdbcServices.class );
-		ConnectionProviderJdbcConnectionAccess connectionAccess = assertTyping(
-				ConnectionProviderJdbcConnectionAccess.class,
-				jdbcServices.getBootstrapJdbcConnectionAccess()
-		);
-		assertTyping( AgroalConnectionProvider.class, connectionAccess.getConnectionProvider() );
+	@ServiceRegistry
+	@DomainModel
+	@SessionFactory
+	public void testAgroalConnectionProvider(ServiceRegistryScope registryScope, SessionFactoryScope factoryScope) throws Exception {
+		final SessionFactoryImplementor sessionFactory = factoryScope.getSessionFactory();
 
-		AgroalConnectionProvider agroalConnectionProvider = (AgroalConnectionProvider) connectionAccess.getConnectionProvider();
+		var serviceRegistry = registryScope.getRegistry();
+
+		JdbcServices jdbcServices = serviceRegistry.requireService( JdbcServices.class );
+		var connectionAccess = assertTyping( ConnectionProviderJdbcConnectionAccess.class, jdbcServices.getBootstrapJdbcConnectionAccess() );
+		assertThat( connectionAccess ).isInstanceOf( ConnectionProviderJdbcConnectionAccess.class );
+		var agroalConnectionProvider = assertTyping( AgroalConnectionProvider.class, connectionAccess.getConnectionProvider() );
+
 		// For simplicity's sake, using the following in hibernate.properties:
 		// hibernate.agroal.maxSize 2
 		// hibernate.agroal.minSize 2
 		List<Connection> conns = new ArrayList<>();
 		for ( int i = 0; i < 2; i++ ) {
 			Connection conn = agroalConnectionProvider.getConnection();
-			assertNotNull( conn );
-			assertFalse( conn.isClosed() );
+			assertThat( conn ).isNotNull();
+			assertThat( conn.isClosed() ).isFalse();
 			conns.add( conn );
 		}
 
@@ -54,15 +61,22 @@ public class AgroalConnectionProviderTest extends BaseCoreFunctionalTestCase {
 		}
 		catch (SQLException e) {
 			// expected
-			assertTrue( e.getMessage().contains( "timeout" ) );
+			assertThat( e.getMessage() ).contains( "timeout" );
 		}
 
 		for ( Connection conn : conns ) {
 			agroalConnectionProvider.closeConnection( conn );
-			assertTrue( conn.isClosed() );
+			assertThat( conn.isClosed() ).isTrue();
 		}
 
-		releaseSessionFactory();
+		// NOTE : The JUnit 5 infrastructure versus the JUnit 4 infrastructure causes the
+		//		StandardServiceRegistry (the SF registry's parent) to be created with auto-closure disabled.
+		//		That is not the normal process.
+		//		So here we explicitly close the parent.
+		sessionFactory.close();
+		( (ServiceRegistryImplementor) serviceRegistry ).destroy();
+		assert serviceRegistry.getParentServiceRegistry() != null : "Expecting parent service registry";
+		( (ServiceRegistryImplementor) serviceRegistry.getParentServiceRegistry() ).destroy();
 
 		try {
 			agroalConnectionProvider.getConnection();
@@ -70,8 +84,7 @@ public class AgroalConnectionProviderTest extends BaseCoreFunctionalTestCase {
 		}
 		catch (Exception e) {
 			// expected
-			assertTrue( e.getMessage() + " does not contain 'closed' or 'shutting down'",
-					e.getMessage().contains( "closed" ) || e.getMessage().contains( "shutting down" ) );
+			assertThat( e.getMessage() ).containsAnyOf( "closed", "shutting down" );
 		}
 	}
 }

--- a/hibernate-agroal/src/test/java/org/hibernate/test/agroal/AgroalSkipAutoCommitTest.java
+++ b/hibernate-agroal/src/test/java/org/hibernate/test/agroal/AgroalSkipAutoCommitTest.java
@@ -4,58 +4,63 @@
  */
 package org.hibernate.test.agroal;
 
-import org.hibernate.cfg.AvailableSettings;
-import org.hibernate.cfg.Configuration;
 import org.hibernate.test.agroal.util.PreparedStatementSpyConnectionProvider;
-import org.hibernate.testing.junit4.BaseCoreFunctionalTestCase;
-import org.junit.Test;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.ServiceRegistry;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.hibernate.testing.orm.junit.Setting;
+import org.hibernate.testing.orm.junit.SettingProvider;
 
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
+import org.junit.jupiter.api.Test;
+
 import java.sql.Connection;
 import java.util.List;
 
-import static org.hibernate.testing.transaction.TransactionUtil.doInHibernate;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hibernate.cfg.JdbcSettings.AUTOCOMMIT;
+import static org.hibernate.cfg.JdbcSettings.CONNECTION_PROVIDER;
+import static org.hibernate.cfg.JdbcSettings.CONNECTION_PROVIDER_DISABLES_AUTOCOMMIT;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 /**
  * @author Vlad Mihalcea
  */
-public class AgroalSkipAutoCommitTest extends BaseCoreFunctionalTestCase {
-
-	private PreparedStatementSpyConnectionProvider connectionProvider = new PreparedStatementSpyConnectionProvider();
-
-	@Override
-	protected void configure(Configuration configuration) {
-		configuration.getProperties().put( AvailableSettings.CONNECTION_PROVIDER, connectionProvider );
-		configuration.getProperties().put( AvailableSettings.CONNECTION_PROVIDER_DISABLES_AUTOCOMMIT, Boolean.TRUE );
-		configuration.getProperties().put( AvailableSettings.AUTOCOMMIT, Boolean.FALSE.toString() );
-	}
-
-	@Override
-	protected Class<?>[] getAnnotatedClasses() {
-		return new Class<?>[]{ City.class };
-	}
+public class AgroalSkipAutoCommitTest {
+	private static final PreparedStatementSpyConnectionProvider connectionProvider = new PreparedStatementSpyConnectionProvider();
+	private static final SettingProvider.Provider<PreparedStatementSpyConnectionProvider> connectionProviderProvider = () -> connectionProvider;
 
 	@Test
-	public void test() {
+	@ServiceRegistry(
+			settings = {
+					@Setting( name = CONNECTION_PROVIDER_DISABLES_AUTOCOMMIT, value = "true" ),
+					@Setting( name = AUTOCOMMIT, value = "false" )
+			},
+			settingProviders = @SettingProvider(settingName = CONNECTION_PROVIDER, provider = ConnectionProviderProvider.class)
+	)
+	@DomainModel( annotatedClasses = City.class )
+	@SessionFactory
+	public void test(SessionFactoryScope factoryScope) {
+		factoryScope.getSessionFactory();
 		connectionProvider.clear();
-		doInHibernate( this::sessionFactory, session -> {
+		factoryScope.inTransaction( (session) -> {
 			City city = new City();
 			city.setId( 1L );
 			city.setName( "Cluj-Napoca" );
 			session.persist( city );
 
-			assertTrue( connectionProvider.getAcquiredConnections().isEmpty() );
-			assertTrue( connectionProvider.getReleasedConnections().isEmpty() );
+			assertThat( connectionProvider.getAcquiredConnections().isEmpty() ).isTrue();
+			assertThat( connectionProvider.getReleasedConnections().isEmpty() ).isTrue();
 		} );
 		verifyConnections();
 
 		connectionProvider.clear();
-		doInHibernate( this::sessionFactory, session -> {
+		factoryScope.inTransaction(  (session) -> {
 			City city = session.find( City.class, 1L );
-			assertEquals( "Cluj-Napoca", city.getName() );
+			assertThat( city.getName() ).isEqualTo( "Cluj-Napoca" );
 		} );
 		verifyConnections();
 	}
@@ -99,6 +104,13 @@ public class AgroalSkipAutoCommitTest extends BaseCoreFunctionalTestCase {
 
 		public void setName(String name) {
 			this.name = name;
+		}
+	}
+
+	public static class ConnectionProviderProvider implements SettingProvider.Provider<PreparedStatementSpyConnectionProvider> {
+		@Override
+		public PreparedStatementSpyConnectionProvider getSetting() {
+			return connectionProvider;
 		}
 	}
 }

--- a/hibernate-agroal/src/test/java/org/hibernate/test/agroal/AgroalTransactionIsolationConfigTest.java
+++ b/hibernate-agroal/src/test/java/org/hibernate/test/agroal/AgroalTransactionIsolationConfigTest.java
@@ -10,18 +10,22 @@ import org.hibernate.community.dialect.GaussDBDialect;
 import org.hibernate.engine.jdbc.connections.spi.ConnectionProvider;
 
 import org.hibernate.test.agroal.util.GradleParallelTestingAgroalConnectionProvider;
-import org.hibernate.testing.SkipForDialect;
-import org.hibernate.testing.common.connections.BaseTransactionIsolationConfigTest;
+import org.hibernate.testing.orm.common.BaseTransactionIsolationConfigTest;
+import org.hibernate.testing.orm.junit.ServiceRegistryScope;
+import org.hibernate.testing.orm.junit.SkipForDialect;
 
 /**
  * @author Steve Ebersole
  */
-@SkipForDialect(value = TiDBDialect.class, comment = "Doesn't support SERIALIZABLE isolation")
-@SkipForDialect(value = AltibaseDialect.class, comment = "Altibase cannot change isolation level in autocommit mode")
-@SkipForDialect(value = GaussDBDialect.class, comment = "GaussDB does not support SERIALIZABLE isolation")
+@SkipForDialect(dialectClass = TiDBDialect.class,
+		reason = "Doesn't support SERIALIZABLE isolation")
+@SkipForDialect(dialectClass = AltibaseDialect.class,
+		reason = "Altibase cannot change isolation level in autocommit mode")
+@SkipForDialect(dialectClass = GaussDBDialect.class,
+		reason = "GaussDB does not support SERIALIZABLE isolation")
 public class AgroalTransactionIsolationConfigTest extends BaseTransactionIsolationConfigTest {
 	@Override
-	protected ConnectionProvider getConnectionProviderUnderTest() {
+	protected ConnectionProvider getConnectionProviderUnderTest(ServiceRegistryScope registryScope) {
 		return new GradleParallelTestingAgroalConnectionProvider();
 	}
 }

--- a/hibernate-c3p0/src/test/java/org/hibernate/test/c3p0/C3P0ConnectionProviderTest.java
+++ b/hibernate-c3p0/src/test/java/org/hibernate/test/c3p0/C3P0ConnectionProviderTest.java
@@ -4,55 +4,49 @@
  */
 package org.hibernate.test.c3p0;
 
-import java.lang.management.ManagementFactory;
-import java.util.Set;
-import javax.management.MBeanServer;
-import javax.management.ObjectName;
-
 import org.hibernate.c3p0.internal.C3P0ConnectionProvider;
 import org.hibernate.dialect.SybaseASEDialect;
 import org.hibernate.engine.jdbc.env.internal.JdbcEnvironmentInitiator.ConnectionProviderJdbcConnectionAccess;
 import org.hibernate.engine.jdbc.spi.JdbcServices;
-
-import org.hibernate.testing.junit4.BaseCoreFunctionalTestCase;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.ServiceRegistry;
+import org.hibernate.testing.orm.junit.ServiceRegistryScope;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
 import org.hibernate.testing.orm.junit.SkipForDialect;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.hibernate.testing.junit4.ExtraAssertions.assertTyping;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import javax.management.MBeanServer;
+import javax.management.ObjectName;
+import java.lang.management.ManagementFactory;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hibernate.testing.orm.junit.ExtraAssertions.assertTyping;
 
 /**
  * @author Strong Liu
  */
 @SkipForDialect(dialectClass = SybaseASEDialect.class,
 		reason = "JtdsConnection.isValid not implemented")
-public class C3P0ConnectionProviderTest extends BaseCoreFunctionalTestCase {
-
-	@Override
-	protected void releaseSessionFactory() {
-		super.releaseSessionFactory();
-		try {
-			//c3p0 does not close physical connections right away, so without this hack a connection leak false alarm is triggered.
-			Thread.sleep( 100 );
-		}
-		catch ( InterruptedException e ) {
-		}
-	}
-
+@ServiceRegistry
+@DomainModel
+@SessionFactory
+public class C3P0ConnectionProviderTest {
 	@Test
-	public void testC3P0isDefaultWhenThereIsC3P0Properties() {
-		JdbcServices jdbcServices = serviceRegistry().requireService( JdbcServices.class );
-		ConnectionProviderJdbcConnectionAccess connectionAccess =
-			assertTyping(
+	public void testC3P0isDefaultWhenThereIsC3P0Properties(ServiceRegistryScope registryScope) throws Exception {
+		var serviceRegistry = registryScope.getRegistry();
+		var jdbcServices = serviceRegistry.requireService( JdbcServices.class );
+		var connectionAccess = assertTyping(
 				ConnectionProviderJdbcConnectionAccess.class,
 				jdbcServices.getBootstrapJdbcConnectionAccess()
-			);
-		assertTrue( connectionAccess.getConnectionProvider() instanceof C3P0ConnectionProvider );
+		);
+		assertThat( connectionAccess.getConnectionProvider() ).isInstanceOf( C3P0ConnectionProvider.class );
 	}
 
 	@Test
-	public void testHHH6635() throws Exception {
+	public void testHHH6635(SessionFactoryScope factoryScope) throws Exception {
+		var sf = factoryScope.getSessionFactory();
 		MBeanServer mBeanServer = ManagementFactory.getPlatformMBeanServer();
 		Set<ObjectName> set = mBeanServer.queryNames( null, null );
 		boolean mbeanfound = false;
@@ -63,29 +57,30 @@ public class C3P0ConnectionProviderTest extends BaseCoreFunctionalTestCase {
 				// see according c3p0 settings in META-INF/persistence.xml
 
 				int actual_minPoolSize = (Integer) mBeanServer.getAttribute( obj, "minPoolSize" );
-				assertEquals( 0, actual_minPoolSize );
+				assertThat( actual_minPoolSize ).isEqualTo( 0 );
 
 				int actual_initialPoolSize = (Integer) mBeanServer.getAttribute( obj, "initialPoolSize" );
-				assertEquals( 0, actual_initialPoolSize );
+				assertThat( actual_initialPoolSize ).isEqualTo( 0 );
 
 				int actual_maxPoolSize = (Integer) mBeanServer.getAttribute( obj, "maxPoolSize" );
-				assertEquals( 800, actual_maxPoolSize );
+				assertThat( actual_maxPoolSize ).isEqualTo( 800 );
 
 				int actual_maxStatements = (Integer) mBeanServer.getAttribute( obj, "maxStatements" );
-				assertEquals( 50, actual_maxStatements );
+				assertThat( actual_maxStatements ).isEqualTo( 50 );
 
 				int actual_maxIdleTime = (Integer) mBeanServer.getAttribute( obj, "maxIdleTime" );
-				assertEquals( 300, actual_maxIdleTime );
+				assertThat( actual_maxIdleTime ).isEqualTo( 300 );
 
 				int actual_idleConnectionTestPeriod = (Integer) mBeanServer.getAttribute(
 						obj,
 						"idleConnectionTestPeriod"
 				);
-				assertEquals( 3000, actual_idleConnectionTestPeriod );
+				assertThat( actual_idleConnectionTestPeriod ).isEqualTo( 3000 );
+
 				break;
 			}
 		}
 
-		assertTrue( "PooledDataSource BMean not found, please verify version of c3p0", mbeanfound );
+		assertThat( mbeanfound ).as( "PooledDataSource BMean not found, please verify version of c3p0" ).isTrue();
 	}
 }

--- a/hibernate-c3p0/src/test/java/org/hibernate/test/c3p0/C3P0DefaultIsolationLevelTest.java
+++ b/hibernate-c3p0/src/test/java/org/hibernate/test/c3p0/C3P0DefaultIsolationLevelTest.java
@@ -4,64 +4,50 @@
  */
 package org.hibernate.test.c3p0;
 
-import java.sql.Connection;
-import java.sql.SQLException;
-import java.util.Map;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
-
-import org.hibernate.boot.SessionFactoryBuilder;
 import org.hibernate.dialect.H2Dialect;
-
-import org.hibernate.testing.RequiresDialect;
+import org.hibernate.testing.orm.junit.DomainModel;
 import org.hibernate.testing.orm.junit.JiraKey;
-import org.hibernate.testing.jdbc.SQLStatementInterceptor;
-import org.hibernate.testing.junit4.BaseNonConfigCoreFunctionalTestCase;
-import org.junit.Test;
+import org.hibernate.testing.orm.junit.RequiresDialect;
+import org.hibernate.testing.orm.junit.ServiceRegistry;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.hibernate.testing.orm.junit.Setting;
+import org.hibernate.testing.orm.junit.SettingProvider;
+import org.junit.jupiter.api.Test;
 
+import java.sql.Connection;
+import java.sql.SQLException;
+
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.hibernate.cfg.JdbcSettings.CONNECTION_PROVIDER;
 import static org.hibernate.cfg.JdbcSettings.ISOLATION;
-import static org.hibernate.testing.transaction.TransactionUtil.doInHibernate;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
 /**
  * @author Vlad Mihalcea
  */
+@SuppressWarnings("JUnitMalformedDeclaration")
 @JiraKey(value = "HHH-12749")
 @RequiresDialect(H2Dialect.class)
-public class C3P0DefaultIsolationLevelTest extends
-		BaseNonConfigCoreFunctionalTestCase {
-
-	private C3P0ProxyConnectionProvider connectionProvider;
-	private SQLStatementInterceptor sqlStatementInterceptor;
-
-	@Override
-	protected void configureSessionFactoryBuilder(SessionFactoryBuilder sfb) {
-		sqlStatementInterceptor = new SQLStatementInterceptor( sfb );
-	}
-
-	@Override
-	protected Class<?>[] getAnnotatedClasses() {
-		return new Class<?>[] {
-				Person.class,
-		};
-	}
-
-	@Override
-	protected void addSettings(Map<String,Object> settings) {
-		connectionProvider = new C3P0ProxyConnectionProvider();
-		settings.put( CONNECTION_PROVIDER, connectionProvider );
-		settings.put( ISOLATION, "READ_COMMITTED" );
-	}
+@ServiceRegistry(
+		settings = @Setting( name = ISOLATION, value = "READ_COMMITTED" ),
+		settingProviders = @SettingProvider( settingName = CONNECTION_PROVIDER, provider = C3P0DefaultIsolationLevelTest.ConnectionProviderProvider.class )
+)
+@DomainModel(annotatedClasses = C3P0DefaultIsolationLevelTest.Person.class)
+@SessionFactory(useCollectingStatementInspector = true)
+public class C3P0DefaultIsolationLevelTest {
+	private static final C3P0ProxyConnectionProvider connectionProvider = new C3P0ProxyConnectionProvider();
 
 	@Test
-	public void testStoredProcedureOutParameter() throws SQLException {
-		clearSpies();
+	public void testStoredProcedureOutParameter(SessionFactoryScope factoryScope) throws SQLException {
+		var sqlCollector = factoryScope.getCollectingStatementInspector();
+		sqlCollector.clear();
+		connectionProvider.clear();
 
-		doInHibernate( this::sessionFactory, session -> {
+		factoryScope.inTransaction( (session) -> {
 			Person person = new Person();
 			person.id = 1L;
 			person.name = "Vlad Mihalcea";
@@ -69,29 +55,25 @@ public class C3P0DefaultIsolationLevelTest extends
 			session.persist( person );
 		} );
 
-		assertEquals( 1, sqlStatementInterceptor.getSqlQueries().size() );
-		assertTrue( sqlStatementInterceptor.getSqlQueries().get( 0 ).toLowerCase().startsWith( "insert into" ) );
+		assertThat( sqlCollector.getSqlQueries() ).hasSize( 1 );
+		assertThat( sqlCollector.getSqlQueries().get( 0 ).toLowerCase() ).startsWith( "insert into " );
 		Connection connectionSpy = connectionProvider.getConnectionSpyMap().keySet().iterator().next();
 		verify( connectionSpy, never() ).setTransactionIsolation( Connection.TRANSACTION_READ_COMMITTED );
 
-		clearSpies();
+		sqlCollector.clear();
+		connectionProvider.clear();
 
-		doInHibernate( this::sessionFactory, session -> {
+		factoryScope.inTransaction( (session) -> {
 			Person person = session.find( Person.class, 1L );
-
-			assertEquals( "Vlad Mihalcea", person.name );
+			assertThat( person.name ).isEqualTo( "Vlad Mihalcea" );
 		} );
 
-		assertEquals( 1, sqlStatementInterceptor.getSqlQueries().size() );
-		assertTrue( sqlStatementInterceptor.getSqlQueries().get( 0 ).toLowerCase().startsWith( "select" ) );
+		assertThat( sqlCollector.getSqlQueries() ).hasSize( 1 );
+		assertThat( sqlCollector.getSqlQueries().get( 0 ).toLowerCase() ).startsWith( "select " );
 		connectionSpy = connectionProvider.getConnectionSpyMap().keySet().iterator().next();
 		verify( connectionSpy, never() ).setTransactionIsolation( Connection.TRANSACTION_READ_COMMITTED );
 	}
 
-	private void clearSpies() {
-		sqlStatementInterceptor.getSqlQueries().clear();
-		connectionProvider.clear();
-	}
 
 	@Entity(name = "Person")
 	public static class Person {
@@ -102,4 +84,11 @@ public class C3P0DefaultIsolationLevelTest extends
 		private String name;
 	}
 
+
+	public static class ConnectionProviderProvider implements SettingProvider.Provider<C3P0ProxyConnectionProvider> {
+		@Override
+		public C3P0ProxyConnectionProvider getSetting() {
+			return connectionProvider;
+		}
+	}
 }

--- a/hibernate-c3p0/src/test/java/org/hibernate/test/c3p0/C3P0EmptyIsolationLevelTest.java
+++ b/hibernate-c3p0/src/test/java/org/hibernate/test/c3p0/C3P0EmptyIsolationLevelTest.java
@@ -6,61 +6,49 @@ package org.hibernate.test.c3p0;
 
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
-import org.hibernate.boot.SessionFactoryBuilder;
 import org.hibernate.dialect.H2Dialect;
-import org.hibernate.testing.RequiresDialect;
-import org.hibernate.testing.jdbc.SQLStatementInterceptor;
-import org.hibernate.testing.junit4.BaseNonConfigCoreFunctionalTestCase;
+import org.hibernate.testing.orm.junit.DomainModel;
 import org.hibernate.testing.orm.junit.JiraKey;
-import org.junit.Test;
+import org.hibernate.testing.orm.junit.RequiresDialect;
+import org.hibernate.testing.orm.junit.ServiceRegistry;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.hibernate.testing.orm.junit.Setting;
+import org.hibernate.testing.orm.junit.SettingProvider;
+import org.junit.jupiter.api.Test;
 
 import java.sql.Connection;
 import java.sql.SQLException;
-import java.util.Map;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.hibernate.cfg.JdbcSettings.CONNECTION_PROVIDER;
 import static org.hibernate.cfg.JdbcSettings.ISOLATION;
-import static org.hibernate.testing.transaction.TransactionUtil.doInHibernate;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
 /**
  * @author Vlad Mihalcea
  */
+@SuppressWarnings("JUnitMalformedDeclaration")
 @JiraKey(value = "HHH-12749")
 @RequiresDialect(H2Dialect.class)
-public class C3P0EmptyIsolationLevelTest extends
-		BaseNonConfigCoreFunctionalTestCase {
+@ServiceRegistry(
+		settings = @Setting( name = ISOLATION, value = "" ),
+		settingProviders = @SettingProvider( settingName = CONNECTION_PROVIDER, provider = C3P0EmptyIsolationLevelTest.ConnectionProviderProvider.class )
+)
+@DomainModel(annotatedClasses = C3P0EmptyIsolationLevelTest.Person.class)
+@SessionFactory(useCollectingStatementInspector = true)
+public class C3P0EmptyIsolationLevelTest {
 
-	private C3P0ProxyConnectionProvider connectionProvider;
-	private SQLStatementInterceptor sqlStatementInterceptor;
-
-	@Override
-	protected void configureSessionFactoryBuilder(SessionFactoryBuilder sfb) {
-		sqlStatementInterceptor = new SQLStatementInterceptor( sfb );
-	}
-
-	@Override
-	protected Class<?>[] getAnnotatedClasses() {
-		return new Class<?>[] {
-				Person.class,
-		};
-	}
-
-	@Override
-	protected void addSettings(Map<String,Object> settings) {
-		connectionProvider = new C3P0ProxyConnectionProvider();
-		settings.put( CONNECTION_PROVIDER, connectionProvider );
-		settings.put( ISOLATION, "" );
-	}
+	private static final C3P0ProxyConnectionProvider connectionProvider = new C3P0ProxyConnectionProvider();
 
 	@Test
-	public void testStoredProcedureOutParameter() throws SQLException {
-		clearSpies();
+	public void testStoredProcedureOutParameter(SessionFactoryScope factoryScope) throws SQLException {
+		var sqlCollector = factoryScope.getCollectingStatementInspector();
+		sqlCollector.clear();
+		connectionProvider.clear();
 
-		doInHibernate( this::sessionFactory, session -> {
+		factoryScope.inTransaction( (session) -> {
 			Person person = new Person();
 			person.id = 1L;
 			person.name = "Vlad Mihalcea";
@@ -68,37 +56,38 @@ public class C3P0EmptyIsolationLevelTest extends
 			session.persist( person );
 		} );
 
-		assertEquals( 1, sqlStatementInterceptor.getSqlQueries().size() );
-		assertTrue( sqlStatementInterceptor.getSqlQueries().get( 0 ).toLowerCase().startsWith( "insert into" ) );
+		assertThat( sqlCollector.getSqlQueries() ).hasSize( 1 );
+		assertThat( sqlCollector.getSqlQueries().get( 0 ) ).startsWithIgnoringCase( "insert into " );
 		Connection connectionSpy = connectionProvider.getConnectionSpyMap().keySet().iterator().next();
 		verify( connectionSpy, never() ).setTransactionIsolation( Connection.TRANSACTION_READ_COMMITTED );
 
-		clearSpies();
+		sqlCollector.clear();
+		connectionProvider.clear();
 
-		doInHibernate( this::sessionFactory, session -> {
+		factoryScope.inTransaction( (session) -> {
 			Person person = session.find( Person.class, 1L );
 
-			assertEquals( "Vlad Mihalcea", person.name );
+			assertThat( person.name ).isEqualTo( "Vlad Mihalcea" );
 		} );
 
-		assertEquals( 1, sqlStatementInterceptor.getSqlQueries().size() );
-		assertTrue( sqlStatementInterceptor.getSqlQueries().get( 0 ).toLowerCase().startsWith( "select" ) );
+		assertThat( sqlCollector.getSqlQueries() ).hasSize( 1 );
+		assertThat( sqlCollector.getSqlQueries().get( 0 ) ).startsWithIgnoringCase( "select " );
 		connectionSpy = connectionProvider.getConnectionSpyMap().keySet().iterator().next();
 		verify( connectionSpy, never() ).setTransactionIsolation( Connection.TRANSACTION_READ_COMMITTED );
 	}
 
-	private void clearSpies() {
-		sqlStatementInterceptor.getSqlQueries().clear();
-		connectionProvider.clear();
-	}
-
 	@Entity(name = "Person")
 	public static class Person {
-
 		@Id
 		private Long id;
-
 		private String name;
+	}
+
+	public static class ConnectionProviderProvider implements SettingProvider.Provider<C3P0ProxyConnectionProvider> {
+		@Override
+		public C3P0ProxyConnectionProvider getSetting() {
+			return connectionProvider;
+		}
 	}
 
 }

--- a/hibernate-c3p0/src/test/java/org/hibernate/test/c3p0/C3p0TransactionIsolationConfigTest.java
+++ b/hibernate-c3p0/src/test/java/org/hibernate/test/c3p0/C3p0TransactionIsolationConfigTest.java
@@ -4,8 +4,6 @@
  */
 package org.hibernate.test.c3p0;
 
-import org.hibernate.boot.registry.StandardServiceRegistry;
-import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
 import org.hibernate.c3p0.internal.C3P0ConnectionProvider;
 import org.hibernate.community.dialect.AltibaseDialect;
 import org.hibernate.community.dialect.GaussDBDialect;
@@ -15,29 +13,26 @@ import org.hibernate.engine.jdbc.connections.spi.ConnectionProvider;
 import org.hibernate.service.spi.ServiceRegistryImplementor;
 
 import org.hibernate.test.c3p0.util.GradleParallelTestingC3P0ConnectionProvider;
-import org.hibernate.testing.SkipForDialect;
-import org.hibernate.testing.common.connections.BaseTransactionIsolationConfigTest;
-import org.junit.Before;
+import org.hibernate.testing.orm.common.BaseTransactionIsolationConfigTest;
+import org.hibernate.testing.orm.junit.ServiceRegistry;
+import org.hibernate.testing.orm.junit.ServiceRegistryScope;
+import org.hibernate.testing.orm.junit.SkipForDialect;
 
 /**
  * @author Steve Ebersole
  */
-@SkipForDialect(value = TiDBDialect.class, comment = "Doesn't support SERIALIZABLE isolation")
-@SkipForDialect(value = AltibaseDialect.class, comment = "Altibase cannot change isolation level in autocommit mode")
-@SkipForDialect(value = SybaseASEDialect.class, comment = "JtdsConnection.isValid not implemented")
-@SkipForDialect(value = GaussDBDialect.class, comment = "GaussDB does not support SERIALIZABLE isolation")
-public class C3p0TransactionIsolationConfigTest extends BaseTransactionIsolationConfigTest {
-	private StandardServiceRegistry ssr;
-
-	@Before
-	public void setUp() {
-		ssr = new StandardServiceRegistryBuilder().build();
-	}
+@SkipForDialect(dialectClass = TiDBDialect.class, reason = "Doesn't support SERIALIZABLE isolation")
+@SkipForDialect(dialectClass = AltibaseDialect.class, reason = "Altibase cannot change isolation level in autocommit mode")
+@SkipForDialect(dialectClass = SybaseASEDialect.class, reason = "JtdsConnection.isValid not implemented")
+@SkipForDialect(dialectClass = GaussDBDialect.class, reason = "GaussDB does not support SERIALIZABLE isolation")
+@ServiceRegistry
+public class C3p0TransactionIsolationConfigTest
+		extends BaseTransactionIsolationConfigTest {
 
 	@Override
-	protected ConnectionProvider getConnectionProviderUnderTest() {
+	protected ConnectionProvider getConnectionProviderUnderTest(ServiceRegistryScope registryScope) {
 		C3P0ConnectionProvider provider = new GradleParallelTestingC3P0ConnectionProvider();
-		provider.injectServices( (ServiceRegistryImplementor) ssr );
+		provider.injectServices( (ServiceRegistryImplementor) registryScope.getRegistry() );
 		return provider;
 	}
 }

--- a/hibernate-c3p0/src/test/java/org/hibernate/test/c3p0/JdbcCompatibilityTest.java
+++ b/hibernate-c3p0/src/test/java/org/hibernate/test/c3p0/JdbcCompatibilityTest.java
@@ -23,10 +23,9 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
  *
  * @author Vlad Mihalcea
  */
+@SuppressWarnings("JUnitMalformedDeclaration")
 @RequiresDialect(value = SQLServerDialect.class)
-@DomainModel(
-		annotatedClasses = { IrrelevantEntity.class }
-)
+@DomainModel(annotatedClasses = IrrelevantEntity.class)
 @SessionFactory
 public class JdbcCompatibilityTest {
 

--- a/hibernate-c3p0/src/test/java/org/hibernate/test/c3p0/OracleSQLCallableStatementProxyTest.java
+++ b/hibernate-c3p0/src/test/java/org/hibernate/test/c3p0/OracleSQLCallableStatementProxyTest.java
@@ -4,9 +4,6 @@
  */
 package org.hibernate.test.c3p0;
 
-import java.sql.SQLException;
-import java.sql.Statement;
-import java.util.List;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EntityResult;
 import jakarta.persistence.FieldResult;
@@ -16,79 +13,61 @@ import jakarta.persistence.QueryHint;
 import jakarta.persistence.SqlResultSetMapping;
 import jakarta.persistence.SqlResultSetMappings;
 import jakarta.persistence.StoredProcedureParameter;
-
-import org.hibernate.cfg.Configuration;
 import org.hibernate.dialect.OracleDialect;
-
 import org.hibernate.test.c3p0.util.GradleParallelTestingC3P0ConnectionProvider;
-import org.hibernate.testing.RequiresDialect;
+import org.hibernate.testing.orm.junit.DomainModel;
 import org.hibernate.testing.orm.junit.JiraKey;
-import org.hibernate.testing.junit4.BaseCoreFunctionalTestCase;
-import org.junit.Before;
-import org.junit.Test;
+import org.hibernate.testing.orm.junit.RequiresDialect;
+import org.hibernate.testing.orm.junit.ServiceRegistry;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.hibernate.testing.orm.junit.SettingProvider;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-import static org.hibernate.testing.transaction.TransactionUtil.doInHibernate;
-import static org.junit.Assert.assertEquals;
+import java.sql.Statement;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hibernate.cfg.JdbcSettings.CONNECTION_PROVIDER;
 
 /**
  * @author Vlad Mihalcea
  */
+@SuppressWarnings("JUnitMalformedDeclaration")
 @RequiresDialect(OracleDialect.class)
 @JiraKey(value = "HHH-10256")
-public class OracleSQLCallableStatementProxyTest extends
-		BaseCoreFunctionalTestCase {
-
-	protected void configure(Configuration configuration) {
-		configuration.setProperty(
-				org.hibernate.cfg.AvailableSettings.CONNECTION_PROVIDER,
-				GradleParallelTestingC3P0ConnectionProvider.class
-		);
-	}
-
-	@Override
-	protected Class<?>[] getAnnotatedClasses() {
-		return new Class<?>[] {
-			Person.class,
-		};
-	}
-
-	@Before
-	public void init() {
-		doInHibernate( this::sessionFactory, session -> {
-			session.doWork( connection -> {
-
-				Statement statement = null;
-				try {
-					statement = connection.createStatement();
+@ServiceRegistry(settingProviders = @SettingProvider( settingName = CONNECTION_PROVIDER, provider = GradleParallelTestingC3P0ConnectionProvider.SettingProviderImpl.class ))
+@DomainModel(annotatedClasses = OracleSQLCallableStatementProxyTest.Person.class)
+@SessionFactory
+public class OracleSQLCallableStatementProxyTest {
+	@BeforeEach
+	void prepareDatabase(SessionFactoryScope factoryScope) {
+		factoryScope.inTransaction( (session) -> {
+			session.doWork( (connection) -> {
+				try (Statement statement =  connection.createStatement()) {
 					statement.executeUpdate(
-						"CREATE OR REPLACE FUNCTION fn_person ( " +
-						"   personId IN NUMBER) " +
-						"    RETURN SYS_REFCURSOR " +
-						"IS " +
-						"    persons SYS_REFCURSOR; " +
-						"BEGIN " +
-						"   OPEN persons FOR " +
-						"        SELECT " +
-						"            p.id AS \"p.id\", " +
-						"            p.name AS \"p.name\", " +
-						"            p.nickName AS \"p.nickName\" " +
-						"       FROM person p " +
-						"       WHERE p.id = personId; " +
-						"   RETURN persons; " +
-						"END;"
+							"""
+									CREATE OR REPLACE FUNCTION fn_person ( \
+									personId IN NUMBER) \
+										RETURN SYS_REFCURSOR \
+									IS \
+										persons SYS_REFCURSOR; \
+									BEGIN \
+									OPEN persons FOR \
+											SELECT \
+												p.id AS "p.id", \
+												p.name AS "p.name", \
+												p.nickName AS "p.nickName" \
+										FROM person p \
+										WHERE p.id = personId; \
+									RETURN persons; \
+									END;"""
 					);
 				}
-				catch (SQLException ignore) {
-				}
-				finally {
-					if ( statement != null ) {
-						statement.close();
-					}
-				}
 			} );
-		} );
 
-		doInHibernate( this::sessionFactory, session -> {
 			Person person1 = new Person();
 			person1.setId( 1L );
 			person1.setName( "John Doe" );
@@ -97,14 +76,20 @@ public class OracleSQLCallableStatementProxyTest extends
 		} );
 	}
 
+	@AfterEach
+	void cleanupDatabase(SessionFactoryScope factoryScope) {
+		factoryScope.dropData();
+	}
+
 	@Test
-	public void testStoredProcedureOutParameter() {
-		doInHibernate( this::sessionFactory, session -> {
+	public void testStoredProcedureOutParameter(SessionFactoryScope factoryScope) {
+		factoryScope.inTransaction( (session) -> {
+			//noinspection unchecked
 			List<Object[]> persons = session
 					.createNamedStoredProcedureQuery( "getPerson" )
 					.setParameter(1, 1L)
 					.getResultList();
-			assertEquals(1, persons.size());
+			assertThat( persons ).hasSize( 1 );
 		} );
 	}
 

--- a/hibernate-c3p0/src/test/java/org/hibernate/test/c3p0/StatementCacheTest.java
+++ b/hibernate-c3p0/src/test/java/org/hibernate/test/c3p0/StatementCacheTest.java
@@ -4,83 +4,76 @@
  */
 package org.hibernate.test.c3p0;
 
-import java.util.List;
-
 import jakarta.persistence.criteria.CriteriaBuilder;
 import jakarta.persistence.criteria.CriteriaQuery;
-
 import org.hibernate.dialect.SQLServerDialect;
 import org.hibernate.dialect.SybaseASEDialect;
-import org.hibernate.testing.orm.junit.SkipForDialect;
-import org.junit.Assert;
-import org.junit.Test;
-
-import org.hibernate.testing.junit4.BaseCoreFunctionalTestCase;
+import org.hibernate.testing.orm.junit.DomainModel;
 import org.hibernate.testing.orm.junit.JiraKey;
+import org.hibernate.testing.orm.junit.ServiceRegistry;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.hibernate.testing.orm.junit.SkipForDialect;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * Tests that when using cached prepared statement with batching enabled doesn't bleed over into new transactions.
  *
  * @author Shawn Clowater
  */
+@JiraKey(value = "HHH-7193")
 @SkipForDialect(dialectClass = SybaseASEDialect.class,
 		reason = "JtdsConnection.isValid not implemented")
-public class StatementCacheTest extends BaseCoreFunctionalTestCase {
+@SkipForDialect(dialectClass = SQLServerDialect.class,
+		reason = "started failing after upgrade to c3p0 0.10")
+@ServiceRegistry
+@DomainModel( annotatedClasses = IrrelevantEntity.class)
+@SessionFactory
+public class StatementCacheTest {
 	@Test
-	@JiraKey(value = "HHH-7193")
-	@SkipForDialect(dialectClass = SQLServerDialect.class,
-			reason = "started failing after upgrade to c3p0 0.10")
-	public void testStatementCaching() {
-		inSession(
-				session -> {
-					session.beginTransaction();
+	public void testStatementCaching(SessionFactoryScope factoryScope) {
+		factoryScope.inSession( (session) -> {
+			session.beginTransaction();
 
-					//save 2 new entities, one valid, one invalid (neither should be persisted)
-					IrrelevantEntity irrelevantEntity = new IrrelevantEntity();
-					irrelevantEntity.setName( "valid 1" );
-					session.persist( irrelevantEntity );
-					//name is required
-					irrelevantEntity = new IrrelevantEntity();
-					session.persist( irrelevantEntity );
-					try {
-						session.flush();
-						Assert.fail( "Validation exception did not occur" );
-					}
-					catch (Exception e) {
-						//this is expected roll the transaction back
-						session.getTransaction().rollback();
-					}
-				}
-		);
+			//save 2 new entities, one valid, one invalid (neither should be persisted)
+			IrrelevantEntity irrelevantEntity = new IrrelevantEntity();
+			irrelevantEntity.setName( "valid 1" );
+			session.persist( irrelevantEntity );
+			//name is required
+			irrelevantEntity = new IrrelevantEntity();
+			session.persist( irrelevantEntity );
+			try {
+				session.flush();
+				fail( "Validation exception did not occur" );
+			}
+			catch (Exception e) {
+				//this is expected roll the transaction back
+				session.getTransaction().rollback();
+			}
+		} );
 
-		inTransaction(
-				session -> {
-					//save a new entity and commit it
-					IrrelevantEntity irrelevantEntity = new IrrelevantEntity();
-					irrelevantEntity.setName( "valid 2" );
-					session.persist( irrelevantEntity );
-					session.flush();
-				}
-		);
+		factoryScope.inTransaction( session -> {
+			//save a new entity and commit it
+			IrrelevantEntity irrelevantEntity = new IrrelevantEntity();
+			irrelevantEntity.setName( "valid 2" );
+			session.persist( irrelevantEntity );
+			session.flush();
+		} );
 
 		// only one entity should have been inserted to the database
 		// (if the statement in the cache wasn't cleared then it would have inserted both entities)
-		inTransaction(
-				session -> {
-					CriteriaBuilder criteriaBuilder = session.getCriteriaBuilder();
-					CriteriaQuery<IrrelevantEntity> criteria = criteriaBuilder.createQuery( IrrelevantEntity.class );
-					criteria.from( IrrelevantEntity.class );
-					List<IrrelevantEntity> results = session.createQuery( criteria ).list();
+		factoryScope.inTransaction( session -> {
+			CriteriaBuilder criteriaBuilder = session.getCriteriaBuilder();
+			CriteriaQuery<IrrelevantEntity> criteria = criteriaBuilder.createQuery( IrrelevantEntity.class );
+			criteria.from( IrrelevantEntity.class );
+			List<IrrelevantEntity> results = session.createQuery( criteria ).list();
 
-//		Criteria criteria = session.createCriteria( IrrelevantEntity.class );
-//		List results = criteria.list();
-					Assert.assertEquals( 1, results.size() );
-				}
-		);
-	}
-
-	@Override
-	protected Class<?>[] getAnnotatedClasses() {
-		return new Class[]{ IrrelevantEntity.class };
+			assertThat( results ).hasSize( 1 );
+		} );
 	}
 }

--- a/hibernate-c3p0/src/test/java/org/hibernate/test/c3p0/util/GradleParallelTestingC3P0ConnectionProvider.java
+++ b/hibernate-c3p0/src/test/java/org/hibernate/test/c3p0/util/GradleParallelTestingC3P0ConnectionProvider.java
@@ -6,6 +6,7 @@ package org.hibernate.test.c3p0.util;
 
 import org.hibernate.HibernateException;
 import org.hibernate.c3p0.internal.C3P0ConnectionProvider;
+import org.hibernate.testing.orm.junit.SettingProvider;
 
 import java.util.Map;
 
@@ -19,5 +20,12 @@ public class GradleParallelTestingC3P0ConnectionProvider extends C3P0ConnectionP
 	public void configure(Map<String, Object> properties) throws HibernateException {
 		resolveFromSettings( properties );
 		super.configure( properties );
+	}
+
+	public static class SettingProviderImpl implements SettingProvider.Provider<GradleParallelTestingC3P0ConnectionProvider> {
+		@Override
+		public GradleParallelTestingC3P0ConnectionProvider getSetting() {
+			return new GradleParallelTestingC3P0ConnectionProvider();
+		}
 	}
 }

--- a/hibernate-core/hibernate-core.gradle
+++ b/hibernate-core/hibernate-core.gradle
@@ -49,6 +49,10 @@ dependencies {
     testImplementation project(':hibernate-ant')
     testImplementation project(':hibernate-scan-jandex')
 
+    // todo : to get rid of these
+    testImplementation testLibs.junit4
+    testImplementation testLibs.junit4Engine
+
     testImplementation testLibs.shrinkwrap
     testImplementation testLibs.shrinkwrapDescriptors
     testImplementation jakartaLibs.cdi

--- a/hibernate-envers/hibernate-envers.gradle
+++ b/hibernate-envers/hibernate-envers.gradle
@@ -26,6 +26,10 @@ dependencies {
 
     testImplementation project( ':hibernate-testing' )
 
+    // todo : to get rid of these
+    testImplementation testLibs.junit4
+    testImplementation testLibs.junit4Engine
+
     testAnnotationProcessor project( ':hibernate-processor' )
 }
 

--- a/hibernate-graalvm/hibernate-graalvm.gradle
+++ b/hibernate-graalvm/hibernate-graalvm.gradle
@@ -17,4 +17,9 @@ dependencies {
 
     testImplementation project( ':hibernate-core' )
     testImplementation libs.jandex
+
+    // todo : to get rid of these
+    testImplementation testLibs.junit4
+    testImplementation testLibs.junit4Engine
+
 }

--- a/hibernate-hikaricp/src/test/java/org/hibernate/test/hikaricp/HikariCPSkipAutoCommitTest.java
+++ b/hibernate-hikaricp/src/test/java/org/hibernate/test/hikaricp/HikariCPSkipAutoCommitTest.java
@@ -4,91 +4,86 @@
  */
 package org.hibernate.test.hikaricp;
 
-import java.sql.Connection;
-import java.util.List;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
-
-import org.hibernate.cfg.AvailableSettings;
-import org.hibernate.cfg.Configuration;
-
-import org.hibernate.testing.SkipForDialect;
-import org.hibernate.testing.junit4.BaseCoreFunctionalTestCase;
-
 import org.hibernate.dialect.SybaseDialect;
 import org.hibernate.orm.test.util.PreparedStatementSpyConnectionProvider;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.ServiceRegistry;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.hibernate.testing.orm.junit.Setting;
+import org.hibernate.testing.orm.junit.SettingProvider;
+import org.hibernate.testing.orm.junit.SkipForDialect;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Test;
 
-import org.junit.Test;
+import java.sql.Connection;
+import java.util.List;
 
-import static org.hibernate.testing.transaction.TransactionUtil.doInHibernate;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hibernate.cfg.JdbcSettings.CONNECTION_PROVIDER;
+import static org.hibernate.cfg.JdbcSettings.CONNECTION_PROVIDER_DISABLES_AUTOCOMMIT;
 
 /**
  * @author Vlad Mihalcea
  */
-@SkipForDialect(value = SybaseDialect.class, comment = "The jTDS driver doesn't implement Connection#isValid so this fails")
-public class HikariCPSkipAutoCommitTest extends BaseCoreFunctionalTestCase {
+@SuppressWarnings("JUnitMalformedDeclaration")
+@SkipForDialect(dialectClass = SybaseDialect.class, matchSubTypes = true, reason = "The jTDS driver doesn't implement Connection#isValid so this fails")
+@ServiceRegistry(
+		settings = {
+				@Setting( name = CONNECTION_PROVIDER_DISABLES_AUTOCOMMIT, value = "true" ),
+				@Setting( name = "hibernate.hikari.autoCommit", value = "false" )
+		},
+		settingProviders = @SettingProvider( settingName = CONNECTION_PROVIDER, provider = HikariCPSkipAutoCommitTest.ConnectionProviderProvider.class)
+)
+@DomainModel( annotatedClasses = HikariCPSkipAutoCommitTest.City.class )
+@SessionFactory
+public class HikariCPSkipAutoCommitTest {
+	private static final PreparedStatementSpyConnectionProvider connectionProvider = new PreparedStatementSpyConnectionProvider();
 
-	private PreparedStatementSpyConnectionProvider connectionProvider =
-			new PreparedStatementSpyConnectionProvider();
-
-	@Override
-	protected void configure(Configuration configuration) {
-		configuration.getProperties().put(
-				AvailableSettings.CONNECTION_PROVIDER,
-				connectionProvider
-		);
-		configuration.getProperties().put( AvailableSettings.CONNECTION_PROVIDER_DISABLES_AUTOCOMMIT, Boolean.TRUE );
-		configuration.getProperties().put( "hibernate.hikari.autoCommit", Boolean.FALSE.toString() );
-	}
-
-	@Override
-	public void releaseSessionFactory() {
-		super.releaseSessionFactory();
+	@AfterAll
+	static void afterAll() {
 		connectionProvider.stop();
 	}
 
-	@Override
-	protected Class<?>[] getAnnotatedClasses() {
-		return new Class<?>[] {
-				City.class,
-		};
-	}
-
 	@Test
-	public void test() {
+	public void testIt(SessionFactoryScope factoryScope) throws Exception {
+		// force creation of the SF
+		factoryScope.getSessionFactory();
+
 		connectionProvider.clear();
-		doInHibernate( this::sessionFactory, session -> {
+
+		factoryScope.inTransaction( session -> {
 			City city = new City();
 			city.setId( 1L );
 			city.setName( "Cluj-Napoca" );
 			session.persist( city );
 
-			assertTrue( connectionProvider.getAcquiredConnections().isEmpty() );
-			assertTrue( connectionProvider.getReleasedConnections().isEmpty() );
+			assertThat( connectionProvider.getAcquiredConnections() ).isEmpty();
+			assertThat( connectionProvider.getReleasedConnections() ).isEmpty();
 		} );
 		verifyConnections();
 
 		connectionProvider.clear();
-		doInHibernate( this::sessionFactory, session -> {
+		factoryScope.inTransaction( session -> {
 			City city = session.find( City.class, 1L );
-			assertEquals( "Cluj-Napoca", city.getName() );
+			assertThat(  city.getName() ).isEqualTo( "Cluj-Napoca" );
 		} );
 		verifyConnections();
 	}
 
 	private void verifyConnections() {
-		assertTrue( connectionProvider.getAcquiredConnections().isEmpty() );
+		assertThat( connectionProvider.getAcquiredConnections() ).isEmpty();
 
 		List<Connection> connections = connectionProvider.getReleasedConnections();
-		assertEquals( 1, connections.size() );
+		assertThat( connections ).hasSize( 1 );
 		try {
 			List<Object[]> setAutoCommitCalls = connectionProvider.spyContext.getCalls(
 					Connection.class.getMethod( "setAutoCommit", boolean.class ),
 					connections.get( 0 )
 			);
-			assertTrue( "setAutoCommit should never be called", setAutoCommitCalls.isEmpty() );
+			assertThat( setAutoCommitCalls ).as( "setAutoCommit should never be called" ).isEmpty();
 		}
 		catch (NoSuchMethodException e) {
 			throw new RuntimeException( e );
@@ -117,6 +112,13 @@ public class HikariCPSkipAutoCommitTest extends BaseCoreFunctionalTestCase {
 
 		public void setName(String name) {
 			this.name = name;
+		}
+	}
+
+	public static class ConnectionProviderProvider implements SettingProvider.Provider<PreparedStatementSpyConnectionProvider> {
+		@Override
+		public PreparedStatementSpyConnectionProvider getSetting() {
+			return connectionProvider;
 		}
 	}
 }

--- a/hibernate-hikaricp/src/test/java/org/hibernate/test/hikaricp/HikariTransactionIsolationConfigTest.java
+++ b/hibernate-hikaricp/src/test/java/org/hibernate/test/hikaricp/HikariTransactionIsolationConfigTest.java
@@ -11,19 +11,25 @@ import org.hibernate.community.dialect.TiDBDialect;
 import org.hibernate.engine.jdbc.connections.spi.ConnectionProvider;
 
 import org.hibernate.test.hikaricp.util.GradleParallelTestingHikariCPConnectionProvider;
-import org.hibernate.testing.SkipForDialect;
-import org.hibernate.testing.common.connections.BaseTransactionIsolationConfigTest;
+import org.hibernate.testing.orm.common.BaseTransactionIsolationConfigTest;
+import org.hibernate.testing.orm.junit.ServiceRegistryScope;
+import org.hibernate.testing.orm.junit.SkipForDialect;
 
 /**
  * @author Steve Ebersole
  */
-@SkipForDialect(value = SybaseDialect.class, comment = "The jTDS driver doesn't implement Connection#getNetworkTimeout() so this fails")
-@SkipForDialect(value = TiDBDialect.class, comment = "Doesn't support SERIALIZABLE isolation")
-@SkipForDialect(value = AltibaseDialect.class, comment = "Altibase cannot change isolation level in autocommit mode")
-@SkipForDialect(value = GaussDBDialect.class, comment = "GaussDB does not support SERIALIZABLE isolation")
+@SkipForDialect(dialectClass = SybaseDialect.class,
+		matchSubTypes = true,
+		reason = "The jTDS driver doesn't implement Connection#getNetworkTimeout() so this fails")
+@SkipForDialect(dialectClass = TiDBDialect.class,
+		reason = "Doesn't support SERIALIZABLE isolation")
+@SkipForDialect(dialectClass = AltibaseDialect.class,
+		reason = "Altibase cannot change isolation level in autocommit mode")
+@SkipForDialect(dialectClass = GaussDBDialect.class,
+		reason = "GaussDB does not support SERIALIZABLE isolation")
 public class HikariTransactionIsolationConfigTest extends BaseTransactionIsolationConfigTest {
 	@Override
-	protected ConnectionProvider getConnectionProviderUnderTest() {
+	protected ConnectionProvider getConnectionProviderUnderTest(ServiceRegistryScope registryScope) {
 		return new GradleParallelTestingHikariCPConnectionProvider();
 	}
 }

--- a/hibernate-integrationtest-java-modules/hibernate-integrationtest-java-modules.gradle
+++ b/hibernate-integrationtest-java-modules/hibernate-integrationtest-java-modules.gradle
@@ -23,6 +23,11 @@ dependencies {
 	api project( ':hibernate-core' )
 	api project( ':hibernate-envers' )
 	implementation project( ':hibernate-scan-jandex' )
+
+    // todo : to get rid of these
+    testImplementation testLibs.junit4
+    testImplementation testLibs.junit4Engine
+
 	//Provide the jakarta.cdi module, as it's required by module jakarta.transaction
 	//but not provided as transitive dependency of Narayana.
 	testRuntimeOnly( jakartaLibs.cdi )

--- a/hibernate-jcache/src/test/java/org/hibernate/orm/test/jcache/JCacheClasspathConfigUriTest.java
+++ b/hibernate-jcache/src/test/java/org/hibernate/orm/test/jcache/JCacheClasspathConfigUriTest.java
@@ -4,40 +4,32 @@
  */
 package org.hibernate.orm.test.jcache;
 
-import java.util.Map;
 
-import org.hibernate.cache.jcache.ConfigSettings;
-import org.hibernate.cfg.Environment;
 
-import org.hibernate.testing.junit4.BaseNonConfigCoreFunctionalTestCase;
 import org.hibernate.orm.test.jcache.domain.Product;
-import org.junit.Test;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.ServiceRegistry;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.hibernate.testing.orm.junit.Setting;
+import org.junit.jupiter.api.Test;
 
-import static org.hibernate.testing.transaction.TransactionUtil.doInHibernate;
+import static org.hibernate.cache.jcache.ConfigSettings.CONFIG_URI;
+import static org.hibernate.cfg.CacheSettings.CACHE_REGION_FACTORY;
 
-public class JCacheClasspathConfigUriTest
-		extends BaseNonConfigCoreFunctionalTestCase {
-
-	@Override
-	protected void addSettings(Map<String,Object> settings) {
-		settings.put( Environment.CACHE_REGION_FACTORY, "jcache" );
-		settings.put( ConfigSettings.CONFIG_URI, "classpath://hibernate-config/ehcache/jcache-ehcache-config.xml" );
-	}
-
-	@Override
-	protected Class<?>[] getAnnotatedClasses() {
-		return new Class<?>[]{
-				Product.class
-		};
-	}
-
+@ServiceRegistry(settings = {
+		@Setting(name=CACHE_REGION_FACTORY, value = "jcache"),
+		@Setting(name= CONFIG_URI, value = "classpath://hibernate-config/ehcache/jcache-ehcache-config.xml")
+})
+@DomainModel(annotatedClasses = Product.class)
+@SessionFactory
+public class JCacheClasspathConfigUriTest {
 	@Test
-	public void test() {
-		Product product = new Product();
-		product.setName( "Acme" );
-		product.setPriceCents( 100L );
-
-		doInHibernate( this::sessionFactory, session -> {
+	public void test(SessionFactoryScope factoryScope) {
+		factoryScope.inTransaction( (session) -> {
+			Product product = new Product();
+			product.setName( "Acme" );
+			product.setPriceCents( 100L );
 			session.persist( product );
 		} );
 	}

--- a/hibernate-jcache/src/test/java/org/hibernate/orm/test/jcache/JCacheConfigRelativePathTest.java
+++ b/hibernate-jcache/src/test/java/org/hibernate/orm/test/jcache/JCacheConfigRelativePathTest.java
@@ -4,39 +4,34 @@
  */
 package org.hibernate.orm.test.jcache;
 
-import java.util.Map;
 
-import org.hibernate.cache.jcache.ConfigSettings;
-import org.hibernate.cfg.Environment;
 
-import org.hibernate.testing.junit4.BaseNonConfigCoreFunctionalTestCase;
 import org.hibernate.orm.test.jcache.domain.Product;
-import org.junit.Test;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.ServiceRegistry;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.hibernate.testing.orm.junit.Setting;
+import org.junit.jupiter.api.Test;
 
-import static org.hibernate.testing.transaction.TransactionUtil.doInHibernate;
+import static org.hibernate.cache.jcache.ConfigSettings.CONFIG_URI;
+import static org.hibernate.cfg.CacheSettings.CACHE_REGION_FACTORY;
 
-public class JCacheConfigRelativePathTest
-		extends BaseNonConfigCoreFunctionalTestCase {
-
-	@Override
-	protected void addSettings(Map<String,Object> settings) {
-		settings.put( Environment.CACHE_REGION_FACTORY, "jcache" );
-		settings.put( ConfigSettings.CONFIG_URI, "/hibernate-config/ehcache/jcache-ehcache-config.xml" );
-	}
-
-	protected Class<?>[] getAnnotatedClasses() {
-		return new Class<?>[] {
-				Product.class
-		};
-	}
-
+@SuppressWarnings("JUnitMalformedDeclaration")
+@ServiceRegistry(settings = {
+		@Setting(name=CACHE_REGION_FACTORY, value = "jcache"),
+		@Setting(name= CONFIG_URI, value = "/hibernate-config/ehcache/jcache-ehcache-config.xml")
+})
+@DomainModel(annotatedClasses = Product.class)
+@SessionFactory
+public class JCacheConfigRelativePathTest {
 	@Test
-	public void test() {
-		Product product = new Product();
-		product.setName( "Acme" );
-		product.setPriceCents( 100L );
+	public void test(SessionFactoryScope factoryScope) {
+		factoryScope.inTransaction( (session) -> {
+			Product product = new Product();
+			product.setName( "Acme" );
+			product.setPriceCents( 100L );
 
-		doInHibernate( this::sessionFactory, session -> {
 			session.persist( product );
 		} );
 	}

--- a/hibernate-jcache/src/test/java/org/hibernate/orm/test/jcache/JCacheConfigUrlTest.java
+++ b/hibernate-jcache/src/test/java/org/hibernate/orm/test/jcache/JCacheConfigUrlTest.java
@@ -4,44 +4,47 @@
  */
 package org.hibernate.orm.test.jcache;
 
-import java.util.Map;
-
-import org.hibernate.cache.jcache.ConfigSettings;
-import org.hibernate.cfg.Environment;
-
-import org.hibernate.testing.junit4.BaseNonConfigCoreFunctionalTestCase;
 import org.hibernate.orm.test.jcache.domain.Product;
-import org.junit.Test;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.ServiceRegistry;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.hibernate.testing.orm.junit.Setting;
+import org.hibernate.testing.orm.junit.SettingProvider;
+import org.junit.jupiter.api.Test;
 
-import static org.hibernate.testing.transaction.TransactionUtil.doInHibernate;
+import java.net.URL;
 
-public class JCacheConfigUrlTest
-		extends BaseNonConfigCoreFunctionalTestCase {
+import static org.hibernate.cache.jcache.ConfigSettings.CONFIG_URI;
+import static org.hibernate.cfg.CacheSettings.CACHE_REGION_FACTORY;
 
-	@Override
-	protected void addSettings(Map<String,Object> settings) {
-		settings.put( Environment.CACHE_REGION_FACTORY, "jcache" );
-		settings.put(
-				ConfigSettings.CONFIG_URI,
-				"file://" + Thread.currentThread().getContextClassLoader().getResource( "hibernate-config/ehcache/jcache-ehcache-config.xml" ).getPath()
-		);
-	}
-
-	protected Class<?>[] getAnnotatedClasses() {
-		return new Class<?>[] {
-				Product.class
-		};
-	}
+@ServiceRegistry(
+		settings = @Setting(name = CACHE_REGION_FACTORY, value = "jcache"),
+		settingProviders = @SettingProvider( settingName = CONFIG_URI, provider = JCacheConfigUrlTest.ConfigUrlProvider.class)
+)
+@DomainModel(annotatedClasses = Product.class)
+@SessionFactory
+public class JCacheConfigUrlTest {
 
 	@Test
-	public void test() {
-		Product product = new Product();
-		product.setName( "Acme" );
-		product.setPriceCents( 100L );
+	public void test(SessionFactoryScope factoryScope) {
+		factoryScope.inTransaction( (session) -> {
+			Product product = new Product();
+			product.setName( "Acme" );
+			product.setPriceCents( 100L );
 
-		doInHibernate( this::sessionFactory, session -> {
 			session.persist( product );
 		} );
 	}
 
+	public static class ConfigUrlProvider implements SettingProvider.Provider<String> {
+		@Override
+		public String getSetting() {
+			final URL configUrl = Thread.currentThread()
+					.getContextClassLoader()
+					.getResource( "hibernate-config/ehcache/jcache-ehcache-config.xml" );
+			assert configUrl != null;
+			return "file://" + configUrl.getPath();
+		}
+	}
 }

--- a/hibernate-jcache/src/test/java/org/hibernate/orm/test/jcache/LegacyRegionNamingTests.java
+++ b/hibernate-jcache/src/test/java/org/hibernate/orm/test/jcache/LegacyRegionNamingTests.java
@@ -1,0 +1,85 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.jcache;
+
+import org.hibernate.cache.spi.SecondLevelCacheLogger;
+import org.hibernate.engine.spi.SessionFactoryImplementor;
+import org.hibernate.testing.orm.junit.Logger;
+import org.hibernate.testing.orm.junit.MessageKeyInspection;
+import org.hibernate.testing.orm.junit.MessageKeyWatcher;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+import static org.hibernate.orm.test.jcache.TestHelper.queryRegionLegacyNames1;
+import static org.hibernate.orm.test.jcache.TestHelper.queryRegionLegacyNames2;
+
+/**
+ * @author Steve Ebersole
+ */
+@SuppressWarnings("JUnitMalformedDeclaration")
+@MessageKeyInspection( messageKey = "HHH90001007",
+		logger = @Logger( loggerName = SecondLevelCacheLogger.LOGGER_NAME ) )
+public class LegacyRegionNamingTests {
+	@Test
+	public void testMissingCacheStrategyFailLegacyNames1(MessageKeyWatcher watcher) {
+		checkLegacyNameHandling( watcher, queryRegionLegacyNames1, queryRegionLegacyNames2 );
+	}
+
+	@Test
+	public void testMissingCacheStrategyFailLegacyNames2(MessageKeyWatcher watcher) {
+		checkLegacyNameHandling( watcher, queryRegionLegacyNames2, queryRegionLegacyNames1 );
+	}
+
+	private void checkLegacyNameHandling(
+			MessageKeyWatcher watcher,
+			String[] existingLegacyCaches,
+			String[] nonExistingLegacyCaches) {
+		watcher.reset();
+
+		// make sure that the regions used for model caches exist
+		TestHelper.preBuildDomainCaches();
+
+		// and that caches exist with legacy configurations
+		for ( int i = 0; i < TestHelper.queryRegionNames.length; ++i ) {
+			String legacyName = existingLegacyCaches[i];
+			TestHelper.createCache( legacyName );
+		}
+
+		// and then lets make sure that the region names we think
+		// are non-existent really do not exist
+		verifyNonExistence( nonExistingLegacyCaches, TestHelper.queryRegionNames );
+
+		// and now let's try to build the standard testing SessionFactory
+		try ( SessionFactoryImplementor ignored = TestHelper.buildSessionFactoryWithMissingCacheStrategy( "fail" ) ) {
+			// The session-factory should start successfully : if we reach this line, we're good
+
+			// Logs should have been to notify that legacy cache names are being used
+			for ( String regionName : existingLegacyCaches ) {
+				verifyWarningForRegion( regionName, watcher );
+			}
+
+			// and these caches still shouldn't exist
+			verifyNonExistence( nonExistingLegacyCaches, TestHelper.queryRegionNames );
+		}
+	}
+
+	private void verifyWarningForRegion(String regionName, MessageKeyWatcher watcher) {
+		for ( String triggeredMessage : watcher.getTriggeredMessages() ) {
+			if ( triggeredMessage.contains( "[" + regionName + "]" ) ) {
+				return;
+			}
+		}
+		fail( "Warning about legacy region name was not triggered for - %s", regionName );
+	}
+
+	private static void verifyNonExistence(String[]... regionNameGroups) {
+		for ( String[] regionNameGroup : regionNameGroups ) {
+			for ( String regionName : regionNameGroup ) {
+				assertThat( TestHelper.getCache( regionName ) ).isNull();
+			}
+		}
+	}
+}

--- a/hibernate-jcache/src/test/java/org/hibernate/orm/test/jcache/TestHelper.java
+++ b/hibernate-jcache/src/test/java/org/hibernate/orm/test/jcache/TestHelper.java
@@ -17,6 +17,7 @@ import org.hibernate.boot.Metadata;
 import org.hibernate.boot.MetadataSources;
 import org.hibernate.boot.registry.StandardServiceRegistry;
 import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
+import org.hibernate.cache.jcache.ConfigSettings;
 import org.hibernate.cache.jcache.JCacheHelper;
 import org.hibernate.cache.spi.RegionFactory;
 import org.hibernate.cache.spi.support.RegionNameQualifier;
@@ -97,6 +98,19 @@ public class TestHelper {
 
 	public static SessionFactoryImplementor buildStandardSessionFactory() {
 		return buildStandardSessionFactory( ignored -> { } );
+	}
+
+	public static SessionFactoryImplementor buildSessionFactoryWithMissingCacheStrategy(String missingCacheStrategy) {
+		final StandardServiceRegistry ssr = getStandardServiceRegistryBuilder()
+				.applySetting( ConfigSettings.MISSING_CACHE_STRATEGY, missingCacheStrategy )
+				.build();
+		try {
+			return (SessionFactoryImplementor) new MetadataSources( ssr ).buildMetadata().buildSessionFactory();
+		}
+		catch (Throwable t) {
+			ssr.close();
+			throw t;
+		}
 	}
 
 	public static SessionFactoryImplementor buildStandardSessionFactory(Consumer<StandardServiceRegistryBuilder> additionalSettings) {

--- a/hibernate-micrometer/src/test/java/org/hibernate/test/stat/MicrometerStatisticsTest.java
+++ b/hibernate-micrometer/src/test/java/org/hibernate/test/stat/MicrometerStatisticsTest.java
@@ -4,21 +4,28 @@
  */
 package org.hibernate.test.stat;
 
-import org.hibernate.Session;
-import org.hibernate.cfg.Configuration;
-import org.hibernate.cfg.Environment;
-import org.hibernate.stat.HibernateMetrics;
-
-import org.hibernate.testing.junit4.BaseCoreFunctionalTestCase;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
-
 import io.micrometer.core.instrument.Tags;
 import io.micrometer.core.instrument.search.MeterNotFoundException;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.hibernate.stat.HibernateMetrics;
+import org.hibernate.testing.cache.CachingRegionFactory;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.ServiceRegistry;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.hibernate.testing.orm.junit.Setting;
+import org.hibernate.testing.orm.junit.SettingProvider;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
+import static org.hibernate.cfg.CacheSettings.CACHE_REGION_FACTORY;
+import static org.hibernate.cfg.CacheSettings.USE_QUERY_CACHE;
+import static org.hibernate.cfg.CacheSettings.USE_SECOND_LEVEL_CACHE;
+import static org.hibernate.cfg.PersistenceSettings.SESSION_FACTORY_NAME_IS_JNDI;
+import static org.hibernate.cfg.StatisticsSettings.GENERATE_STATISTICS;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -27,115 +34,111 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  *  @author Erin Schnabel
  *  @author Donnchadh O Donnabhain
  */
-public class MicrometerStatisticsTest extends BaseCoreFunctionalTestCase {
+@SuppressWarnings("JUnitMalformedDeclaration")
+@ServiceRegistry(
+		settings = {
+				@Setting( name = USE_SECOND_LEVEL_CACHE, value = "false" ),
+				@Setting( name = USE_QUERY_CACHE, value = "false" ),
+				@Setting( name = GENERATE_STATISTICS, value = "true" ),
+				@Setting( name = SESSION_FACTORY_NAME_IS_JNDI, value = "false" ),
+		},
+		settingProviders = @SettingProvider( settingName = CACHE_REGION_FACTORY,
+				provider = CachingRegionFactory.SettingProvider.class )
+)
+@DomainModel(annotatedClasses = {Account.class, AccountId.class})
+@SessionFactory( sessionFactoryName = "something" )
+public class MicrometerStatisticsTest {
 
-	@Override
-	protected Class<?>[] getAnnotatedClasses() {
-		return new Class<?>[] { Account.class, AccountId.class };
-	}
+	private final SimpleMeterRegistry registry = new SimpleMeterRegistry();
 
-	private SimpleMeterRegistry registry = new SimpleMeterRegistry();
-	private HibernateMetrics hibernateMetrics;
-
-	@Override
-	protected void configure(Configuration configuration) {
-		super.configure( configuration );
-
-		configuration.setProperty( Environment.USE_SECOND_LEVEL_CACHE, "false" );
-		configuration.setProperty( Environment.USE_QUERY_CACHE, "false" );
-		configuration.setProperty( Environment.GENERATE_STATISTICS, "true" );
-		configuration.setProperty( Environment.SESSION_FACTORY_NAME, "something" );
-		configuration.setProperty( Environment.SESSION_FACTORY_NAME_IS_JNDI, "false" );
-	}
-
-	@Before
-	public void setUpMetrics() {
-		hibernateMetrics = new HibernateMetrics(sessionFactory(),
-												sessionFactory().getName(),
-												Tags.empty() );
+	@BeforeEach
+	public void setUpMetrics(SessionFactoryScope factoryScope) {
+		final var sessionFactory = factoryScope.getSessionFactory();
+		var hibernateMetrics = new HibernateMetrics(
+				sessionFactory,
+				sessionFactory.getName(),
+				Tags.empty()
+		);
 		hibernateMetrics.bindTo( registry );
 	}
 
-	@After
-	public void cleanUpMetrics() {
+	@AfterEach
+	public void cleanUpMetrics(SessionFactoryScope factoryScope) {
 		registry.clear();
+		factoryScope.dropData();
 	}
 
 	@Test
-	public void testMicrometerMetrics() {
-		Assert.assertNotNull(registry.get("hibernate.sessions.open").functionCounter());
-		Assert.assertNotNull(registry.get("hibernate.sessions.closed").functionCounter());
+	public void testMicrometerMetrics(SessionFactoryScope factoryScope) {
+		assertNotNull(registry.get("hibernate.sessions.open").functionCounter());
+		assertNotNull(registry.get("hibernate.sessions.closed").functionCounter());
 
-		Assert.assertNotNull(registry.get("hibernate.transactions").tags("result", "success").functionCounter());
-		Assert.assertNotNull(registry.get("hibernate.transactions").tags("result", "failure").functionCounter());
+		assertNotNull(registry.get("hibernate.transactions").tags("result", "success").functionCounter());
+		assertNotNull(registry.get("hibernate.transactions").tags("result", "failure").functionCounter());
 
-		Assert.assertNotNull(registry.get("hibernate.optimistic.failures").functionCounter());
-		Assert.assertNotNull(registry.get("hibernate.flushes").functionCounter());
-		Assert.assertNotNull(registry.get("hibernate.connections.obtained").functionCounter());
+		assertNotNull(registry.get("hibernate.optimistic.failures").functionCounter());
+		assertNotNull(registry.get("hibernate.flushes").functionCounter());
+		assertNotNull(registry.get("hibernate.connections.obtained").functionCounter());
 
-		Assert.assertNotNull(registry.get("hibernate.statements").tags("status", "prepared").functionCounter());
-		Assert.assertNotNull(registry.get("hibernate.statements").tags("status", "closed").functionCounter());
+		assertNotNull(registry.get("hibernate.statements").tags("status", "prepared").functionCounter());
+		assertNotNull(registry.get("hibernate.statements").tags("status", "closed").functionCounter());
 
 		// Second level cache disabled
 		verifyMeterNotFoundException("hibernate.second.level.cache.requests");
 		verifyMeterNotFoundException("hibernate.second.level.cache.puts");
 
-		Assert.assertNotNull(registry.get("hibernate.entities.deletes").functionCounter());
-		Assert.assertNotNull(registry.get("hibernate.entities.fetches").functionCounter());
-		Assert.assertNotNull(registry.get("hibernate.entities.inserts").functionCounter());
-		Assert.assertNotNull(registry.get("hibernate.entities.loads").functionCounter());
-		Assert.assertNotNull(registry.get("hibernate.entities.updates").functionCounter());
-		Assert.assertNotNull(registry.get("hibernate.entities.upserts").functionCounter());
+		assertNotNull(registry.get("hibernate.entities.deletes").functionCounter());
+		assertNotNull(registry.get("hibernate.entities.fetches").functionCounter());
+		assertNotNull(registry.get("hibernate.entities.inserts").functionCounter());
+		assertNotNull(registry.get("hibernate.entities.loads").functionCounter());
+		assertNotNull(registry.get("hibernate.entities.updates").functionCounter());
+		assertNotNull(registry.get("hibernate.entities.upserts").functionCounter());
 
-		Assert.assertNotNull(registry.get("hibernate.collections.deletes").functionCounter());
-		Assert.assertNotNull(registry.get("hibernate.collections.fetches").functionCounter());
-		Assert.assertNotNull(registry.get("hibernate.collections.loads").functionCounter());
-		Assert.assertNotNull(registry.get("hibernate.collections.recreates").functionCounter());
-		Assert.assertNotNull(registry.get("hibernate.collections.updates").functionCounter());
+		assertNotNull(registry.get("hibernate.collections.deletes").functionCounter());
+		assertNotNull(registry.get("hibernate.collections.fetches").functionCounter());
+		assertNotNull(registry.get("hibernate.collections.loads").functionCounter());
+		assertNotNull(registry.get("hibernate.collections.recreates").functionCounter());
+		assertNotNull(registry.get("hibernate.collections.updates").functionCounter());
 
-		Assert.assertNotNull(registry.get("hibernate.cache.natural.id.requests").tags("result", "hit").functionCounter());
-		Assert.assertNotNull(registry.get("hibernate.cache.natural.id.requests").tags("result", "miss").functionCounter());
-		Assert.assertNotNull(registry.get("hibernate.cache.natural.id.puts").functionCounter());
-		Assert.assertNotNull(registry.get("hibernate.query.natural.id.executions").functionCounter());
-		Assert.assertNotNull(registry.get("hibernate.query.natural.id.executions.max").timeGauge());
+		assertNotNull(registry.get("hibernate.cache.natural.id.requests").tags("result", "hit").functionCounter());
+		assertNotNull(registry.get("hibernate.cache.natural.id.requests").tags("result", "miss").functionCounter());
+		assertNotNull(registry.get("hibernate.cache.natural.id.puts").functionCounter());
+		assertNotNull(registry.get("hibernate.query.natural.id.executions").functionCounter());
+		assertNotNull(registry.get("hibernate.query.natural.id.executions.max").timeGauge());
 
-		Assert.assertNotNull(registry.get("hibernate.query.executions").functionCounter());
-		Assert.assertNotNull(registry.get("hibernate.query.executions.max").timeGauge());
+		assertNotNull(registry.get("hibernate.query.executions").functionCounter());
+		assertNotNull(registry.get("hibernate.query.executions.max").timeGauge());
 
-		Assert.assertNotNull(registry.get("hibernate.cache.update.timestamps.requests").tags("result", "hit").functionCounter());
-		Assert.assertNotNull(registry.get("hibernate.cache.update.timestamps.requests").tags("result", "miss").functionCounter());
-		Assert.assertNotNull(registry.get("hibernate.cache.update.timestamps.puts").functionCounter());
+		assertNotNull(registry.get("hibernate.cache.update.timestamps.requests").tags("result", "hit").functionCounter());
+		assertNotNull(registry.get("hibernate.cache.update.timestamps.requests").tags("result", "miss").functionCounter());
+		assertNotNull(registry.get("hibernate.cache.update.timestamps.puts").functionCounter());
 
-		Assert.assertNotNull(registry.get("hibernate.cache.query.requests").tags("result", "hit").functionCounter());
-		Assert.assertNotNull(registry.get("hibernate.cache.query.requests").tags("result", "miss").functionCounter());
-		Assert.assertNotNull(registry.get("hibernate.cache.query.puts").functionCounter());
-		Assert.assertNotNull(registry.get("hibernate.cache.query.plan").tags("result", "hit").functionCounter());
-		Assert.assertNotNull(registry.get("hibernate.cache.query.plan").tags("result", "miss").functionCounter());
+		assertNotNull(registry.get("hibernate.cache.query.requests").tags("result", "hit").functionCounter());
+		assertNotNull(registry.get("hibernate.cache.query.requests").tags("result", "miss").functionCounter());
+		assertNotNull(registry.get("hibernate.cache.query.puts").functionCounter());
+		assertNotNull(registry.get("hibernate.cache.query.plan").tags("result", "hit").functionCounter());
+		assertNotNull(registry.get("hibernate.cache.query.plan").tags("result", "miss").functionCounter());
 
 		// prepare some test data...
-		Session session = openSession();
-		session.beginTransaction();
-		Account account = new Account( new AccountId( 1), "testAcct");
-		session.persist( account );
-		session.getTransaction().commit();
-		session.close();
+		factoryScope.inTransaction( (session) -> {
+			Account account = new Account( new AccountId(1), "testAcct");
+			session.persist( account );
+		} );
 
-		Assert.assertEquals( 1, registry.get("hibernate.sessions.open").functionCounter().count(), 0 );
-		Assert.assertEquals( 1, registry.get("hibernate.sessions.closed").functionCounter().count(), 0 );
-		Assert.assertEquals( 1, registry.get("hibernate.entities.inserts").functionCounter().count(), 0 );
-		Assert.assertEquals( 1, registry.get("hibernate.transactions").tags("result", "success").functionCounter().count(), 0 );
+		assertEquals( 1, registry.get("hibernate.sessions.open").functionCounter().count(), 0 );
+		assertEquals( 1, registry.get("hibernate.sessions.closed").functionCounter().count(), 0 );
+		assertEquals( 1, registry.get("hibernate.entities.inserts").functionCounter().count(), 0 );
+		assertEquals( 1, registry.get("hibernate.transactions").tags("result", "success").functionCounter().count(), 0 );
 
 		// clean up
-		session = openSession();
-		session.beginTransaction();
-		session.remove( account );
-		session.getTransaction().commit();
-		session.close();
+		factoryScope.inTransaction( (session) -> {
+			session.remove( session.find( Account.class, new AccountId(1) ) );
+		} );
 
-		Assert.assertEquals( 2, registry.get("hibernate.sessions.open").functionCounter().count(), 0 );
-		Assert.assertEquals( 2, registry.get("hibernate.sessions.closed").functionCounter().count(), 0 );
-		Assert.assertEquals( 1, registry.get("hibernate.entities.deletes").functionCounter().count(), 0 );
-		Assert.assertEquals( 2, registry.get("hibernate.transactions").tags("result", "success").functionCounter().count(), 0 );
+		assertEquals( 2, registry.get("hibernate.sessions.open").functionCounter().count(), 0 );
+		assertEquals( 2, registry.get("hibernate.sessions.closed").functionCounter().count(), 0 );
+		assertEquals( 1, registry.get("hibernate.entities.deletes").functionCounter().count(), 0 );
+		assertEquals( 2, registry.get("hibernate.transactions").tags("result", "success").functionCounter().count(), 0 );
 	}
 
 	void verifyMeterNotFoundException(String name) {

--- a/hibernate-spatial/hibernate-spatial.gradle
+++ b/hibernate-spatial/hibernate-spatial.gradle
@@ -19,6 +19,11 @@ dependencies {
 	testImplementation project( ':hibernate-testing' )
 	testImplementation project( ':hibernate-ant' )
 	testImplementation project( path: ':hibernate-core', configuration: 'tests' )
+
+    // todo : to get rid of these
+    testImplementation testLibs.junit4
+    testImplementation testLibs.junit4Engine
+
 	testImplementation jakartaLibs.validation
 	testImplementation libs.jandex
 	testImplementation libs.classmate

--- a/hibernate-testing/src/main/java/org/hibernate/testing/cache/CachingRegionFactory.java
+++ b/hibernate-testing/src/main/java/org/hibernate/testing/cache/CachingRegionFactory.java
@@ -80,4 +80,11 @@ public class CachingRegionFactory extends RegionFactoryTemplate {
 	@Override
 	protected void releaseFromUse() {
 	}
+
+	public static class SettingProvider implements org.hibernate.testing.orm.junit.SettingProvider.Provider<CachingRegionFactory> {
+		@Override
+		public CachingRegionFactory getSetting() {
+			return new CachingRegionFactory();
+		}
+	}
 }

--- a/hibernate-testing/src/main/java/org/hibernate/testing/orm/common/BaseTransactionIsolationConfigTest.java
+++ b/hibernate-testing/src/main/java/org/hibernate/testing/orm/common/BaseTransactionIsolationConfigTest.java
@@ -1,0 +1,123 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.testing.orm.common;
+
+import org.hibernate.cfg.AvailableSettings;
+import org.hibernate.cfg.Environment;
+import org.hibernate.engine.jdbc.connections.spi.ConnectionProvider;
+import org.hibernate.internal.util.PropertiesHelper;
+import org.hibernate.service.spi.Configurable;
+import org.hibernate.service.spi.Startable;
+import org.hibernate.service.spi.Stoppable;
+import org.hibernate.testing.orm.junit.BaseUnitTest;
+import org.hibernate.testing.orm.junit.ServiceRegistry;
+import org.hibernate.testing.orm.junit.ServiceRegistryScope;
+import org.junit.jupiter.api.Test;
+
+import java.sql.Connection;
+import java.util.Properties;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * @author Steve Ebersole
+ */
+@BaseUnitTest
+@ServiceRegistry
+public abstract class BaseTransactionIsolationConfigTest {
+	protected abstract ConnectionProvider getConnectionProviderUnderTest(ServiceRegistryScope registryScope);
+
+	@Test
+	public void testSettingIsolationAsNumeric(ServiceRegistryScope registryScope) throws Exception {
+		Properties properties = Environment.getProperties();
+		properties.put( AvailableSettings.ISOLATION, Connection.TRANSACTION_SERIALIZABLE );
+
+		ConnectionProvider provider = getConnectionProviderUnderTest( registryScope );
+
+		try {
+			( (Configurable) provider ).configure( PropertiesHelper.map( properties ) );
+
+			if ( provider instanceof Startable ) {
+				( (Startable) provider ).start();
+			}
+
+			Connection connection = provider.getConnection();
+			assertEquals( Connection.TRANSACTION_SERIALIZABLE, connection.getTransactionIsolation() );
+			provider.closeConnection( connection );
+		}
+		finally {
+			( (Stoppable) provider ).stop();
+		}
+	}
+
+	@Test
+	public void testSettingIsolationAsNumericString(ServiceRegistryScope registryScope) throws Exception {
+		Properties properties = Environment.getProperties();
+		properties.put( AvailableSettings.ISOLATION, Integer.toString( Connection.TRANSACTION_SERIALIZABLE ) );
+
+		ConnectionProvider provider = getConnectionProviderUnderTest( registryScope );
+
+		try {
+			( (Configurable) provider ).configure( PropertiesHelper.map( properties ) );
+
+			if ( provider instanceof Startable ) {
+				( (Startable) provider ).start();
+			}
+
+			Connection connection = provider.getConnection();
+			assertEquals( Connection.TRANSACTION_SERIALIZABLE, connection.getTransactionIsolation() );
+			provider.closeConnection( connection );
+		}
+		finally {
+			( (Stoppable) provider ).stop();
+		}
+	}
+
+	@Test
+	public void testSettingIsolationAsName(ServiceRegistryScope registryScope) throws Exception {
+		Properties properties = Environment.getProperties();
+		properties.put( AvailableSettings.ISOLATION, "TRANSACTION_SERIALIZABLE" );
+
+		ConnectionProvider provider = getConnectionProviderUnderTest( registryScope );
+
+		try {
+			( (Configurable) provider ).configure( PropertiesHelper.map( properties ) );
+
+			if ( provider instanceof Startable ) {
+				( (Startable) provider ).start();
+			}
+
+			Connection connection = provider.getConnection();
+			assertEquals( Connection.TRANSACTION_SERIALIZABLE, connection.getTransactionIsolation() );
+			provider.closeConnection( connection );
+		}
+		finally {
+			( (Stoppable) provider ).stop();
+		}
+	}
+
+	@Test
+	public void testSettingIsolationAsNameAlt(ServiceRegistryScope registryScope) throws Exception {
+		Properties properties = Environment.getProperties();
+		properties.put( AvailableSettings.ISOLATION, "SERIALIZABLE" );
+
+		ConnectionProvider provider = getConnectionProviderUnderTest( registryScope );
+
+		try {
+			( (Configurable) provider ).configure( PropertiesHelper.map( properties ) );
+
+			if ( provider instanceof Startable ) {
+				( (Startable) provider ).start();
+			}
+
+			Connection connection = provider.getConnection();
+			assertEquals( Connection.TRANSACTION_SERIALIZABLE, connection.getTransactionIsolation() );
+			provider.closeConnection( connection );
+		}
+		finally {
+			( (Stoppable) provider ).stop();
+		}
+	}
+}

--- a/hibernate-testing/src/main/java/org/hibernate/testing/orm/junit/DomainModelExtension.java
+++ b/hibernate-testing/src/main/java/org/hibernate/testing/orm/junit/DomainModelExtension.java
@@ -46,18 +46,36 @@ public class DomainModelExtension
 
 	private static final String MODEL_KEY = MetadataImplementor.class.getName();
 
+	public static DomainModelScope requireDomainModelScope(Object testInstance, ExtensionContext context) {
+		var scope = findDomainModelScope( testInstance, context );
+		if ( scope == null ) {
+			throw new RuntimeException( "Could not locate DomainModelScope : " + context.getDisplayName() );
+		}
+		return scope;
+	}
+
+	public static DomainModelScope getOrCreateDomainModelScope(Object testInstance, ExtensionContext context) {
+		var scope = findDomainModelScope( testInstance, context );
+		if ( scope == null ) {
+			final ServiceRegistryScope serviceRegistryScope = ServiceRegistryExtension.findServiceRegistryScope(
+					testInstance,
+					context
+			);
+			scope = new DomainModelScopeImpl( serviceRegistryScope, serviceRegistry -> {
+				return (MetadataImplementor) new MetadataSources( serviceRegistry ).buildMetadata();
+			} );
+		}
+		return scope;
+	}
+
+
 	/**
 	 * Intended for use from external consumers.  Will never create a scope, just
 	 * attempt to consume an already created and stored one
 	 */
 	public static DomainModelScope findDomainModelScope(Object testInstance, ExtensionContext context) {
 		final ExtensionContext.Store store = locateExtensionStore( testInstance, context );
-		final DomainModelScope existing = (DomainModelScope) store.get( MODEL_KEY );
-		if ( existing != null ) {
-			return existing;
-		}
-
-		throw new RuntimeException( "Could not locate DomainModelScope : " + context.getDisplayName() );
+		return (DomainModelScope) store.get( MODEL_KEY );
 	}
 
 	public static DomainModelScope resolveForMethodLevelSessionFactoryScope(ExtensionContext context) {
@@ -147,7 +165,8 @@ public class DomainModelExtension
 	}
 
 	private static DomainModelScope createDomainModelScope(
-			Object testInstance, Optional<DomainModel> domainModelAnnRef,
+			Object testInstance,
+			Optional<DomainModel> domainModelAnnRef,
 			ExtensionContext context) {
 		final ServiceRegistryScope serviceRegistryScope = ServiceRegistryExtension.findServiceRegistryScope(
 				testInstance,

--- a/hibernate-testing/src/main/java/org/hibernate/testing/orm/junit/DomainModelParameterResolver.java
+++ b/hibernate-testing/src/main/java/org/hibernate/testing/orm/junit/DomainModelParameterResolver.java
@@ -26,7 +26,7 @@ public class DomainModelParameterResolver implements ParameterResolver {
 	public Object resolveParameter(
 			ParameterContext parameterContext,
 			ExtensionContext extensionContext) throws ParameterResolutionException {
-		final DomainModelScope modelScope = DomainModelExtension.findDomainModelScope(
+		final DomainModelScope modelScope = DomainModelExtension.requireDomainModelScope(
 				extensionContext.getRequiredTestInstance(),
 				extensionContext
 		);

--- a/hibernate-testing/src/main/java/org/hibernate/testing/orm/junit/SessionFactoryExtension.java
+++ b/hibernate-testing/src/main/java/org/hibernate/testing/orm/junit/SessionFactoryExtension.java
@@ -75,7 +75,7 @@ public class SessionFactoryExtension
 
 		if ( sfAnnRef.isPresent()
 				|| SessionFactoryProducer.class.isAssignableFrom( context.getRequiredTestClass() ) ) {
-			final DomainModelScope domainModelScope = DomainModelExtension.findDomainModelScope( testInstance, context );
+			final DomainModelScope domainModelScope = DomainModelExtension.getOrCreateDomainModelScope( testInstance, context );
 			final SessionFactoryScope created = createSessionFactoryScope( testInstance, sfAnnRef, domainModelScope, context );
 			locateExtensionStore( testInstance, context ).put( SESSION_FACTORY_KEY, created );
 		}

--- a/hibernate-testing/src/main/java/org/hibernate/testing/orm/junit/SettingConfiguration.java
+++ b/hibernate-testing/src/main/java/org/hibernate/testing/orm/junit/SettingConfiguration.java
@@ -7,6 +7,8 @@ package org.hibernate.testing.orm.junit;
 import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
 
 /**
+ * Allows setting multiple configuration values at once.
+ *
  * @author Steve Ebersole
  */
 public @interface SettingConfiguration {

--- a/local-build-plugins/src/main/groovy/local.java-module.gradle
+++ b/local-build-plugins/src/main/groovy/local.java-module.gradle
@@ -59,8 +59,6 @@ dependencies {
     testImplementation testLibs.junitJupiterEngine
     testImplementation testLibs.junitJupiterParams
     testImplementation testLibs.junitJupiterLauncher
-    testImplementation testLibs.junit4
-    testImplementation testLibs.junit4Engine
     testImplementation testLibs.assertjCore
 
     testRuntimeOnly testLibs.log4j2


### PR DESCRIPTION
<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

Dropping usage of JUnit 4, in favor of the JUnit 5 infrastructure (and in prep for JUnit 6).

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-19846
<!-- Hibernate GitHub Bot issue links end -->