### PR TITLE
HHH-19767 Include license file in the META-INF of published artifacts

### DIFF
--- a/local-build-plugins/src/main/groovy/local.java-module.gradle
+++ b/local-build-plugins/src/main/groovy/local.java-module.gradle
@@ -315,6 +315,11 @@ tasks.named("jar") {
                 '-exportcontents': "*;version=${project.version}"
         )
     }
+    metaInf {
+        from(rootProject.projectDir, {
+            include "LICENSE.txt"
+        })
+    }
 }
 
 


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-19767


Backport of https://github.com/hibernate/hibernate-orm/pull/10917

since we need it in all supported versions with ASL 2

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
