### PR TITLE
[7.1] Backport: HHH-19629 Hibernate Processor may fail when repository method parameter has more than one annotation (e.g. multiple constraints) / HHH-19630 Hibernate Processor may fail if the return type is a single entity and annotated with multiple annotations

### DIFF
--- a/tooling/metamodel-generator/src/jakartaData/java/org/hibernate/processor/test/data/constraint/DataTest.java
+++ b/tooling/metamodel-generator/src/jakartaData/java/org/hibernate/processor/test/data/constraint/DataTest.java
@@ -1,0 +1,24 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.processor.test.data.constraint;
+
+import org.hibernate.processor.test.util.CompilationTest;
+import org.hibernate.processor.test.util.WithClasses;
+import org.junit.jupiter.api.Test;
+
+import static org.hibernate.processor.test.util.TestUtil.assertMetamodelClassGeneratedFor;
+import static org.hibernate.processor.test.util.TestUtil.getMetaModelSourceAsString;
+
+@CompilationTest
+class DataTest {
+	@Test
+	@WithClasses({MyEntity.class, MyConstrainedRepository.class})
+	void test() {
+		System.out.println( getMetaModelSourceAsString( MyEntity.class ) );
+		System.out.println( getMetaModelSourceAsString( MyConstrainedRepository.class ) );
+		assertMetamodelClassGeneratedFor( MyEntity.class );
+//		assertMetamodelClassGeneratedFor( MyConstrainedRepository.class );
+	}
+}

--- a/tooling/metamodel-generator/src/jakartaData/java/org/hibernate/processor/test/data/constraint/DataTest.java
+++ b/tooling/metamodel-generator/src/jakartaData/java/org/hibernate/processor/test/data/constraint/DataTest.java
@@ -19,6 +19,6 @@ class DataTest {
 		System.out.println( getMetaModelSourceAsString( MyEntity.class ) );
 		System.out.println( getMetaModelSourceAsString( MyConstrainedRepository.class ) );
 		assertMetamodelClassGeneratedFor( MyEntity.class );
-//		assertMetamodelClassGeneratedFor( MyConstrainedRepository.class );
+		assertMetamodelClassGeneratedFor( MyConstrainedRepository.class );
 	}
 }

--- a/tooling/metamodel-generator/src/jakartaData/java/org/hibernate/processor/test/data/constraint/MyConstrainedRepository.java
+++ b/tooling/metamodel-generator/src/jakartaData/java/org/hibernate/processor/test/data/constraint/MyConstrainedRepository.java
@@ -7,12 +7,15 @@ package org.hibernate.processor.test.data.constraint;
 import jakarta.data.repository.CrudRepository;
 import jakarta.data.repository.Find;
 import jakarta.data.repository.Repository;
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 
 @Repository
 public interface MyConstrainedRepository extends CrudRepository<MyEntity, Long> {
 
+	@Valid
+	@NotNull
 	@Find
 	MyEntity findByName(@NotNull @Size(min = 5) String name);
 }

--- a/tooling/metamodel-generator/src/jakartaData/java/org/hibernate/processor/test/data/constraint/MyConstrainedRepository.java
+++ b/tooling/metamodel-generator/src/jakartaData/java/org/hibernate/processor/test/data/constraint/MyConstrainedRepository.java
@@ -1,0 +1,18 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.processor.test.data.constraint;
+
+import jakarta.data.repository.CrudRepository;
+import jakarta.data.repository.Find;
+import jakarta.data.repository.Repository;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+@Repository
+public interface MyConstrainedRepository extends CrudRepository<MyEntity, Long> {
+
+	@Find
+	MyEntity findByName(@NotNull @Size(min = 5) String name);
+}

--- a/tooling/metamodel-generator/src/jakartaData/java/org/hibernate/processor/test/data/constraint/MyEntity.java
+++ b/tooling/metamodel-generator/src/jakartaData/java/org/hibernate/processor/test/data/constraint/MyEntity.java
@@ -4,6 +4,7 @@
  */
 package org.hibernate.processor.test.data.constraint;
 
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 
@@ -12,5 +13,6 @@ public class MyEntity {
 
 	@Id
 	private Long id;
+	@Column(unique = true)
 	private String name;
 }

--- a/tooling/metamodel-generator/src/jakartaData/java/org/hibernate/processor/test/data/constraint/MyEntity.java
+++ b/tooling/metamodel-generator/src/jakartaData/java/org/hibernate/processor/test/data/constraint/MyEntity.java
@@ -1,0 +1,16 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.processor.test.data.constraint;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+
+@Entity
+public class MyEntity {
+
+	@Id
+	private Long id;
+	private String name;
+}


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-19629
https://hibernate.atlassian.net/browse/HHH-19630

Backport of #10595