### PR TITLE
Fix check Gradle task graph contains  task

### DIFF
--- a/tooling/hibernate-gradle-plugin/hibernate-gradle-plugin.gradle
+++ b/tooling/hibernate-gradle-plugin/hibernate-gradle-plugin.gradle
@@ -171,7 +171,7 @@ gradle.taskGraph.whenReady { tg ->
 	}
 
 	// verify credentials for publishing the plugin up front to avoid any work (only if we are publishing)
-	if ( tg.hasTask( ":publishPlugins" ) && project.tasks.publishPlugins.enabled  ) {
+	if ( tg.hasTask( tasks.publishPlugins ) && project.tasks.publishPlugins.enabled  ) {
 		// we are publishing the plugin - make sure there is a credentials pair
 		//
 		// first, check the `GRADLE_PUBLISH_KEY` / `GRADLE_PUBLISH_SECRET` combo (env vars)


### PR DESCRIPTION
it seems that `tg.hasTask( ":publishPlugins" )` always returns false.


<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
