### PR TITLE
Reproducer Test for HHH-19845

### DIFF
--- a/hibernate-core/src/test/java/org/hibernate/orm/test/multitenancy/discriminator/MultitenancyJoinedStrategyQueryTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/multitenancy/discriminator/MultitenancyJoinedStrategyQueryTest.java
@@ -1,0 +1,50 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.multitenancy.discriminator;
+
+import org.hibernate.bugs.entity.MultitenantChildEntity;
+import org.hibernate.bugs.entity.MultitenantParentEntity;
+import org.hibernate.bugs.entity.MultitenantReferenceEntity;
+import org.hibernate.cfg.AvailableSettings;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.ServiceRegistry;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.hibernate.testing.orm.junit.Setting;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+
+@DomainModel(
+		annotatedClasses = {
+				MultitenantChildEntity.class,
+				MultitenantParentEntity.class,
+				MultitenantReferenceEntity.class
+		}
+)
+@ServiceRegistry(
+		settings = {
+				@Setting(name = AvailableSettings.SHOW_SQL, value = "true"),
+				@Setting(name = AvailableSettings.FORMAT_SQL, value = "true"),
+				@Setting(name = AvailableSettings.MULTI_TENANT_IDENTIFIER_RESOLVER,
+						value = "org.hibernate.orm.test.multitenancy.discriminator.resolver.TenantResolver"),
+		}
+)
+@SessionFactory
+class MultitenancyJoinedStrategyQueryTest {
+
+	@Test
+	void hhh123Test(SessionFactoryScope scope) {
+		scope.inTransaction( session -> {
+			List<MultitenantReferenceEntity> results = session.createSelectionQuery(
+							"from MultitenantReferenceEntity r where r.child.number = :number",
+							MultitenantReferenceEntity.class )
+					.setParameter( "number", 7 )
+					.getResultList();
+			// no exception is thrown
+		} );
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/multitenancy/discriminator/resolver/TenantResolver.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/multitenancy/discriminator/resolver/TenantResolver.java
@@ -1,0 +1,19 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.multitenancy.discriminator.resolver;
+
+import org.hibernate.context.spi.CurrentTenantIdentifierResolver;
+
+public class TenantResolver implements CurrentTenantIdentifierResolver<Long> {
+		@Override
+		public Long resolveCurrentTenantIdentifier() {
+			return 1L;
+		}
+
+		@Override
+		public boolean validateExistingCurrentSessions() {
+			return false;
+		}
+	}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/multitenancy/schema/MultitenantChildEntity.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/multitenancy/schema/MultitenantChildEntity.java
@@ -1,0 +1,22 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.bugs.entity;
+
+
+import jakarta.persistence.DiscriminatorValue;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.OneToMany;
+
+import java.util.List;
+
+@Entity
+@DiscriminatorValue("CHILD")
+public class MultitenantChildEntity extends MultitenantParentEntity {
+Long number;
+
+@OneToMany(mappedBy = "child", fetch = FetchType.LAZY, orphanRemoval = true)
+List<MultitenantReferenceEntity> references;
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/multitenancy/schema/MultitenantParentEntity.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/multitenancy/schema/MultitenantParentEntity.java
@@ -1,0 +1,29 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.bugs.entity;
+
+
+import jakarta.persistence.DiscriminatorColumn;
+import jakarta.persistence.DiscriminatorType;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Inheritance;
+import jakarta.persistence.InheritanceType;
+import org.hibernate.annotations.TenantId;
+
+@Entity
+@Inheritance(strategy = InheritanceType.JOINED)
+@DiscriminatorColumn(discriminatorType = DiscriminatorType.STRING, name = "entity_type")
+public class MultitenantParentEntity {
+@Id
+@GeneratedValue
+Long id;
+
+@TenantId
+Long tenantId;
+
+String entityType;
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/multitenancy/schema/MultitenantReferenceEntity.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/multitenancy/schema/MultitenantReferenceEntity.java
@@ -1,0 +1,21 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.bugs.entity;
+
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
+
+@Entity
+public class MultitenantReferenceEntity {
+@Id
+@GeneratedValue
+Long id;
+
+@ManyToOne()
+MultitenantChildEntity child;
+}


### PR DESCRIPTION
This PR adds a reproducer test for [HHH-19845](https://hibernate.atlassian.net/browse/HHH-19845), which demonstrates a SQLGrammarException when querying across multitenant entities using the DISCRIMINATOR strategy combined with JOINED inheritance.

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
