### PR TITLE
HHH-19827 Add missing canonical links (follow up)

### DIFF
--- a/documentation/documentation.gradle
+++ b/documentation/documentation.gradle
@@ -265,13 +265,59 @@ asciidoctorj {
 
 // Topical Guides ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+def renderTopicalLoggingGuideHtmlTask = tasks.register( 'renderTopicalLoggingGuideHtml', AsciidoctorTask ) { task ->
+    group = "Documentation"
+    description = 'Renders the Topical Logging Guide in HTML format using Asciidoctor.'
+    inputs.property "hibernate-version", hibernateVersion
+
+    sourceDir = file( 'src/main/asciidoc/topical/logging' )
+    sources 'index.adoc'
+    outputDir = project.layout.buildDirectory.file( "asciidoc/topical/html_single/logging" ).get().asFile
+
+    resources {
+        from( 'src/main/asciidoc/topical/' ) {
+            include '**/images/**'
+        }
+        from(rootProject.layout.buildDirectory.dir("unpacked-theme").get()
+                .dir("hibernate-asciidoctor-theme").dir("asciidoc")) {
+            include 'css/**'
+            include 'images/**'
+            include 'script/**'
+        }
+    }
+}
+
+def renderTopicalRegistriesGuideHtmlTask = tasks.register( 'renderTopicalRegistriesGuideHtml', AsciidoctorTask ) { task ->
+    group = "Documentation"
+    description = 'Renders the Topical Registries Guide in HTML format using Asciidoctor.'
+    inputs.property "hibernate-version", hibernateVersion
+
+    sourceDir = file( 'src/main/asciidoc/topical/registries' )
+    sources 'index.adoc'
+    outputDir = project.layout.buildDirectory.file( "asciidoc/topical/html_single/registries" ).get().asFile
+
+    resources {
+        from( 'src/main/asciidoc/topical/' ) {
+            include '**/images/**'
+        }
+        from(rootProject.layout.buildDirectory.dir("unpacked-theme").get()
+                .dir("hibernate-asciidoctor-theme").dir("asciidoc")) {
+            include 'css/**'
+            include 'images/**'
+            include 'script/**'
+        }
+    }
+}
+
+
 def renderTopicalGuideHtmlTask = tasks.register( 'renderTopicalGuideHtml', AsciidoctorTask ) { task ->
 	group = "Documentation"
 	description = 'Renders the  Topical Guides in HTML format using Asciidoctor.'
 	inputs.property "hibernate-version", hibernateVersion
 
 	sourceDir = file( 'src/main/asciidoc/topical' )
-	outputDir = new File( "$buildDir/asciidoc/topical/html_single" )
+    sources 'index.adoc'
+	outputDir = project.layout.buildDirectory.file( "asciidoc/topical/html_single" ).get().asFile
 
 	resources {
 		from( 'src/main/asciidoc/topical/' ) {
@@ -284,6 +330,9 @@ def renderTopicalGuideHtmlTask = tasks.register( 'renderTopicalGuideHtml', Ascii
             include 'script/**'
         }
 	}
+
+    dependsOn renderTopicalLoggingGuideHtmlTask
+    dependsOn renderTopicalRegistriesGuideHtmlTask
 }
 
 def renderTopicalGuidesTask = tasks.register( 'renderTopicalGuides', AsciidoctorTask ) { task ->

--- a/documentation/src/main/asciidoc/integrationguide/index.adoc
+++ b/documentation/src/main/asciidoc/integrationguide/index.adoc
@@ -2,6 +2,7 @@
 :toc2:
 :toclevels: 3
 :sectanchors:
+:html-meta-canonical-link: https://docs.hibernate.org/stable/orm/integrationguide/html_single/
 
 include::preface.adoc[]
 

--- a/documentation/src/main/asciidoc/introduction/index.adoc
+++ b/documentation/src/main/asciidoc/introduction/index.adoc
@@ -1,4 +1,5 @@
 :shared-attributes-dir: {doc-main-dir}/asciidoc/shared
+:html-meta-canonical-link: https://docs.hibernate.org/stable/orm/introduction/html_single/
 
 include::{shared-attributes-dir}/common-attributes.adoc[]
 include::{shared-attributes-dir}/url-attributes.adoc[]

--- a/documentation/src/main/asciidoc/querylanguage/index.adoc
+++ b/documentation/src/main/asciidoc/querylanguage/index.adoc
@@ -1,4 +1,5 @@
 :shared-attributes-dir: {doc-main-dir}/asciidoc/shared
+:html-meta-canonical-link: https://docs.hibernate.org/stable/orm/querylanguage/html_single/
 
 include::{shared-attributes-dir}/common-attributes.adoc[]
 include::{shared-attributes-dir}/url-attributes.adoc[]

--- a/documentation/src/main/asciidoc/quickstart/guides/index.adoc
+++ b/documentation/src/main/asciidoc/quickstart/guides/index.adoc
@@ -1,4 +1,5 @@
 :shared-attributes-dir: {doc-main-dir}/asciidoc/shared
+:html-meta-canonical-link: https://docs.hibernate.org/stable/orm/quickstart/html_single/
 
 include::{shared-attributes-dir}/common-attributes.adoc[]
 include::{shared-attributes-dir}/url-attributes.adoc[]

--- a/documentation/src/main/asciidoc/repositories/index.adoc
+++ b/documentation/src/main/asciidoc/repositories/index.adoc
@@ -1,4 +1,5 @@
 :shared-attributes-dir: {doc-main-dir}/asciidoc/shared
+:html-meta-canonical-link: https://docs.hibernate.org/stable/orm/repositories/html_single/
 
 include::{shared-attributes-dir}/common-attributes.adoc[]
 include::{shared-attributes-dir}/url-attributes.adoc[]

--- a/documentation/src/main/asciidoc/shared/url-attributes.adoc
+++ b/documentation/src/main/asciidoc/shared/url-attributes.adoc
@@ -14,8 +14,6 @@ include::./common-attributes.adoc[]
 :doc-user-guide-url: {doc-version-base-url}/userguide/html_single/Hibernate_User_Guide.html
 :doc-javadoc-url: {doc-version-base-url}/javadocs/
 :doc-topical-url: {doc-version-base-url}/topical/html_single/
-:doc-registries-url: {doc-topical-url}/registries/ServiceRegistries.html
-:doc-logging-url: {doc-topical-url}/logging/Logging.html
 
 :report-deprecation-url: {doc-version-base-url}/deprecated/deprecating.txt
 :report-dialect-url: {doc-version-base-url}/dialect/dialect.html

--- a/documentation/src/main/asciidoc/topical/index.adoc
+++ b/documentation/src/main/asciidoc/topical/index.adoc
@@ -1,4 +1,5 @@
 :shared-attributes-dir: {doc-main-dir}/asciidoc/shared
+:html-meta-canonical-link: https://docs.hibernate.org/stable/orm/topical/html_single/
 
 include::{shared-attributes-dir}/common-attributes.adoc[]
 include::{shared-attributes-dir}/url-attributes.adoc[]
@@ -37,7 +38,7 @@ link:{doc-user-guide-url}[User Guide]::
 [[logging]]
 == Logging
 
-The link:{doc-logging-url}[Logging Guide] discusses logging in Hibernate.
+The xref:logging/index.adoc[Logging Guide] discusses logging in Hibernate.
 
 
 [[tooling]]
@@ -52,7 +53,7 @@ See the link:{doc-user-guide-url}#tooling[Tooling Guide] for information on:
 
 
 == Integrator Guides
-* The <<registries/ServiceRegistries.adoc#registries-guide,Service Registries Guide>> discusses Hibernate Service and ServiceRegistry contracts.
+* The xref:registries/index.adoc#registries-guide[Service Registries Guide] discusses Hibernate Service and ServiceRegistry contracts.
 * Others coming soon
 
 

--- a/documentation/src/main/asciidoc/topical/logging/index.adoc
+++ b/documentation/src/main/asciidoc/topical/logging/index.adoc
@@ -1,4 +1,5 @@
 :shared-attributes-dir: {doc-main-dir}/asciidoc/shared
+:html-meta-canonical-link: https://docs.hibernate.org/stable/orm/topical/html_single/logging/
 
 include::{shared-attributes-dir}/common-attributes.adoc[]
 include::{shared-attributes-dir}/url-attributes.adoc[]

--- a/documentation/src/main/asciidoc/topical/registries/index.adoc
+++ b/documentation/src/main/asciidoc/topical/registries/index.adoc
@@ -1,7 +1,9 @@
+:html-meta-canonical-link: https://docs.hibernate.org/stable/orm/topical/html_single/registries/
+
 [[registries-guide]]
 = Services and Registries
 :imagesdir: images
-:toc:
+:toc2:
 
 Services and Registries are new *as a formalized concept* starting in 4.0.  But the functionality provided by
 the different Services have actually been around in Hibernate much, much longer.  What is new is managing them,

--- a/documentation/src/main/asciidoc/userguide/index.adoc
+++ b/documentation/src/main/asciidoc/userguide/index.adoc
@@ -1,5 +1,5 @@
 :shared-attributes-dir: {doc-main-dir}/asciidoc/shared
-:html-meta-canonical-link: https://docs.jboss.org/hibernate/orm/current/userguide/html_single/Hibernate_User_Guide.html
+:html-meta-canonical-link: https://docs.hibernate.org/stable/orm/userguide/html_single/
 
 include::{shared-attributes-dir}/common-attributes.adoc[]
 include::{shared-attributes-dir}/url-attributes.adoc[]


### PR DESCRIPTION
+ rename logging and ServiceRegistries docs to index to match the other ones.

I had to split the topical render task as in its current form it wasn't applying the styles to the logging/registries pages.

<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

[Please describe here what your change is about]

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-19827
<!-- Hibernate GitHub Bot issue links end -->