### PR TITLE
HHH-19849 Add an SPI that allows attaching session-scoped "extensions" to the session/statelesssession implementors

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/engine/extension/internal/ExtensionIntegrationServiceImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/extension/internal/ExtensionIntegrationServiceImpl.java
@@ -1,0 +1,50 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.engine.extension.internal;
+
+import org.hibernate.boot.registry.classloading.spi.ClassLoaderService;
+import org.hibernate.engine.extension.spi.ExtensionIntegration;
+import org.hibernate.engine.extension.spi.ExtensionIntegrationService;
+import org.jboss.logging.Logger;
+
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+public class ExtensionIntegrationServiceImpl implements ExtensionIntegrationService {
+
+	private static final Logger LOG = Logger.getLogger( ExtensionIntegrationServiceImpl.class );
+
+	private final LinkedHashSet<ExtensionIntegration<?>> integrators = new LinkedHashSet<>();
+
+	private ExtensionIntegrationServiceImpl() {
+	}
+
+	public static ExtensionIntegrationServiceImpl create(Set<ExtensionIntegration<?>> integrations, ClassLoaderService classLoaderService) {
+		ExtensionIntegrationServiceImpl instance = new ExtensionIntegrationServiceImpl();
+
+		// register provided integrators
+		for ( ExtensionIntegration<?> integration : integrations ) {
+			instance.addExtensionIntegration( integration );
+		}
+		for ( ExtensionIntegration<?> integration : classLoaderService.loadJavaServices(
+				ExtensionIntegration.class ) ) {
+			instance.addExtensionIntegration( integration );
+		}
+
+		return instance;
+	}
+
+	private void addExtensionIntegration(ExtensionIntegration<?> integration) {
+		if ( LOG.isDebugEnabled() ) {
+			LOG.debugf( "Adding extension integration for [%s]", integration.getExtensionType().getName() );
+		}
+		integrators.add( integration );
+	}
+
+	@Override
+	public Iterable<ExtensionIntegration<?>> extensionIntegrations() {
+		return integrators;
+	}
+}

--- a/hibernate-core/src/main/java/org/hibernate/engine/extension/spi/Extension.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/extension/spi/Extension.java
@@ -1,0 +1,12 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.engine.extension.spi;
+
+import org.hibernate.Incubating;
+
+/// A marker interface for Session extensions.
+@Incubating
+public interface Extension {
+}

--- a/hibernate-core/src/main/java/org/hibernate/engine/extension/spi/ExtensionIntegration.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/extension/spi/ExtensionIntegration.java
@@ -1,0 +1,14 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.engine.extension.spi;
+
+import org.hibernate.Incubating;
+
+@Incubating
+public interface ExtensionIntegration<E extends Extension> {
+	Class<E> getExtensionType();
+
+	E createExtension(ExtensionIntegrationContext context);
+}

--- a/hibernate-core/src/main/java/org/hibernate/engine/extension/spi/ExtensionIntegrationContext.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/extension/spi/ExtensionIntegrationContext.java
@@ -1,0 +1,14 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.engine.extension.spi;
+
+import org.hibernate.Incubating;
+import org.hibernate.engine.spi.SharedSessionContractImplementor;
+
+@Incubating
+public interface ExtensionIntegrationContext {
+
+	SharedSessionContractImplementor getSession();
+}

--- a/hibernate-core/src/main/java/org/hibernate/engine/extension/spi/ExtensionIntegrationService.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/extension/spi/ExtensionIntegrationService.java
@@ -1,0 +1,18 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.engine.extension.spi;
+
+import org.hibernate.Incubating;
+import org.hibernate.service.Service;
+
+@Incubating
+public interface ExtensionIntegrationService extends Service {
+	/**
+	 * Retrieve all extensions.
+	 *
+	 * @return All extensions.
+	 */
+	Iterable<ExtensionIntegration<?>> extensionIntegrations();
+}

--- a/hibernate-core/src/main/java/org/hibernate/engine/extension/spi/ExtensionIntegrationServiceInitiator.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/extension/spi/ExtensionIntegrationServiceInitiator.java
@@ -1,0 +1,29 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.engine.extension.spi;
+
+import org.hibernate.Incubating;
+import org.hibernate.engine.extension.internal.ExtensionIntegrationServiceImpl;
+import org.hibernate.service.spi.SessionFactoryServiceInitiator;
+import org.hibernate.service.spi.SessionFactoryServiceInitiatorContext;
+
+import java.util.Set;
+
+@Incubating
+public class ExtensionIntegrationServiceInitiator
+		implements SessionFactoryServiceInitiator<ExtensionIntegrationService> {
+
+	public static final ExtensionIntegrationServiceInitiator INSTANCE = new ExtensionIntegrationServiceInitiator();
+
+	@Override
+	public ExtensionIntegrationService initiateService(SessionFactoryServiceInitiatorContext context) {
+		return ExtensionIntegrationServiceImpl.create( Set.of(), context.getSessionFactory().getClassLoaderService() );
+	}
+
+	@Override
+	public Class<ExtensionIntegrationService> getServiceInitiated() {
+		return ExtensionIntegrationService.class;
+	}
+}

--- a/hibernate-core/src/main/java/org/hibernate/engine/extension/spi/package-info.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/extension/spi/package-info.java
@@ -1,0 +1,7 @@
+/**
+ * This package contains an SPI for Session extensions.
+ */
+@Incubating
+package org.hibernate.engine.extension.spi;
+
+import org.hibernate.Incubating;

--- a/hibernate-core/src/main/java/org/hibernate/engine/spi/SessionDelegatorBaseImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/spi/SessionDelegatorBaseImpl.java
@@ -45,6 +45,7 @@ import org.hibernate.UnknownProfileException;
 import org.hibernate.bytecode.enhance.spi.interceptor.SessionAssociationMarkers;
 import org.hibernate.cache.spi.CacheTransactionSynchronization;
 import org.hibernate.collection.spi.PersistentCollection;
+import org.hibernate.engine.extension.spi.Extension;
 import org.hibernate.engine.jdbc.LobCreator;
 import org.hibernate.engine.jdbc.connections.spi.JdbcConnectionAccess;
 import org.hibernate.engine.jdbc.spi.JdbcCoordinator;
@@ -534,6 +535,11 @@ public class SessionDelegatorBaseImpl implements SessionImplementor {
 	@Override
 	public RootGraphImplementor<?> getEntityGraph(String graphName) {
 		return delegate.getEntityGraph( graphName );
+	}
+
+	@Override
+	public <T extends Extension> T getExtension(Class<T> extension) {
+		return delegate.getExtension( extension );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/engine/spi/SharedSessionContractImplementor.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/spi/SharedSessionContractImplementor.java
@@ -6,6 +6,7 @@ package org.hibernate.engine.spi;
 
 import java.util.Set;
 import java.util.UUID;
+
 import jakarta.persistence.TransactionRequiredException;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
@@ -19,6 +20,7 @@ import org.hibernate.LockOptions;
 import org.hibernate.StatelessSession;
 import org.hibernate.bytecode.enhance.spi.interceptor.SessionAssociationMarkers;
 import org.hibernate.dialect.Dialect;
+import org.hibernate.engine.extension.spi.Extension;
 import org.hibernate.event.spi.EventSource;
 import org.hibernate.graph.spi.RootGraphImplementor;
 import org.hibernate.query.Query;
@@ -670,4 +672,17 @@ public interface SharedSessionContractImplementor
 
 	@Override
 	RootGraphImplementor<?> getEntityGraph(String graphName);
+
+	/**
+	 * Allows accessing session scoped extension storages of the particular session instance.
+	 * <p>
+	 * Extensions first had to be registered with the {@link org.hibernate.SessionFactory}
+	 *
+	 * @param extension The extension storage attached to the current session.
+	 * if the current session does not yet have the particular storage type attached to this session.
+	 * @param <E> The type of the extension storage.
+	 */
+	@Incubating
+	<E extends Extension> E getExtension(Class<E> extension);
+
 }

--- a/hibernate-core/src/main/java/org/hibernate/engine/spi/SharedSessionDelegatorBaseImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/spi/SharedSessionDelegatorBaseImpl.java
@@ -26,6 +26,7 @@ import org.hibernate.Transaction;
 import org.hibernate.bytecode.enhance.spi.interceptor.SessionAssociationMarkers;
 import org.hibernate.cache.spi.CacheTransactionSynchronization;
 import org.hibernate.collection.spi.PersistentCollection;
+import org.hibernate.engine.extension.spi.Extension;
 import org.hibernate.engine.jdbc.LobCreator;
 import org.hibernate.engine.jdbc.connections.spi.JdbcConnectionAccess;
 import org.hibernate.engine.jdbc.spi.JdbcCoordinator;
@@ -685,6 +686,11 @@ public class SharedSessionDelegatorBaseImpl implements SharedSessionContractImpl
 	@Override
 	public RootGraphImplementor<?> getEntityGraph(String graphName) {
 		return delegate.getEntityGraph( graphName );
+	}
+
+	@Override
+	public <T extends Extension> T getExtension(Class<T> extension) {
+		return delegate.getExtension( extension);
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/internal/AbstractSharedSessionContract.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/AbstractSharedSessionContract.java
@@ -35,6 +35,10 @@ import org.hibernate.engine.creation.internal.SessionCreationOptionsAdaptor;
 import org.hibernate.engine.creation.internal.SharedSessionBuilderImpl;
 import org.hibernate.engine.creation.internal.SharedSessionCreationOptions;
 import org.hibernate.engine.creation.internal.SharedStatelessSessionBuilderImpl;
+import org.hibernate.engine.extension.spi.Extension;
+import org.hibernate.engine.extension.spi.ExtensionIntegration;
+import org.hibernate.engine.extension.spi.ExtensionIntegrationContext;
+import org.hibernate.engine.extension.spi.ExtensionIntegrationService;
 import org.hibernate.engine.internal.SessionEventListenerManagerImpl;
 import org.hibernate.engine.jdbc.LobCreator;
 import org.hibernate.engine.jdbc.connections.spi.JdbcConnectionAccess;
@@ -117,8 +121,10 @@ import java.io.ObjectOutputStream;
 import java.io.Serial;
 import java.sql.Connection;
 import java.sql.SQLException;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import java.util.Objects;
 import java.util.TimeZone;
 import java.util.UUID;
@@ -145,7 +151,7 @@ import static org.hibernate.query.sqm.internal.SqmUtil.verifyIsSelectStatement;
  *
  * @author Steve Ebersole
  */
-abstract class AbstractSharedSessionContract implements SharedSessionContractImplementor {
+abstract class AbstractSharedSessionContract implements SharedSessionContractImplementor, ExtensionIntegrationContext {
 
 	private transient SessionFactoryImpl factory;
 	private transient SessionFactoryOptions factoryOptions;
@@ -195,6 +201,8 @@ abstract class AbstractSharedSessionContract implements SharedSessionContractImp
 	//Lazily initialized
 	private transient ExceptionConverter exceptionConverter;
 	private transient SessionAssociationMarkers sessionAssociationMarkers;
+
+	private transient final Map<Class<?>, Object> extensions;
 
 	AbstractSharedSessionContract(SessionFactoryImpl factory, SessionCreationOptions options) {
 		this.factory = factory;
@@ -259,6 +267,13 @@ abstract class AbstractSharedSessionContract implements SharedSessionContractImp
 			jdbcCoordinator = createJdbcCoordinator( options );
 			transactionCoordinator = factory.transactionCoordinatorBuilder
 					.buildTransactionCoordinator( jdbcCoordinator, this );
+		}
+
+		extensions = new HashMap<>();
+		for ( ExtensionIntegration<?> integration : factory.getServiceRegistry()
+				.requireService( ExtensionIntegrationService.class )
+				.extensionIntegrations() ) {
+			extensions.put( integration.getExtensionType(), integration.createExtension( this ) );
 		}
 	}
 
@@ -490,6 +505,11 @@ abstract class AbstractSharedSessionContract implements SharedSessionContractImp
 			sessionIdentifier = StandardRandomStrategy.INSTANCE.generateUUID( null );
 		}
 		return sessionIdentifier;
+	}
+
+	@Override
+	public SharedSessionContractImplementor getSession() {
+		return this;
 	}
 
 	@Override
@@ -1780,6 +1800,11 @@ abstract class AbstractSharedSessionContract implements SharedSessionContractImp
 			sessionAssociationMarkers = new SessionAssociationMarkers( this );
 		}
 		return sessionAssociationMarkers;
+	}
+
+	@Override
+	public <E extends Extension> E getExtension(Class<E> extension) {
+		return extension.cast( extensions.get( extension ) );
 	}
 
 	@Serial

--- a/hibernate-core/src/main/java/org/hibernate/service/internal/StandardSessionFactoryServiceInitiators.java
+++ b/hibernate-core/src/main/java/org/hibernate/service/internal/StandardSessionFactoryServiceInitiators.java
@@ -7,6 +7,7 @@ package org.hibernate.service.internal;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.hibernate.engine.extension.spi.ExtensionIntegrationServiceInitiator;
 import org.hibernate.engine.query.spi.NativeQueryInterpreterInitiator;
 import org.hibernate.engine.spi.CacheInitiator;
 import org.hibernate.service.spi.SessionFactoryServiceInitiator;
@@ -25,6 +26,7 @@ public final class StandardSessionFactoryServiceInitiators {
 		serviceInitiators.add( StatisticsInitiator.INSTANCE );
 		serviceInitiators.add( CacheInitiator.INSTANCE );
 		serviceInitiators.add( NativeQueryInterpreterInitiator.INSTANCE );
+		serviceInitiators.add( ExtensionIntegrationServiceInitiator.INSTANCE );
 		return serviceInitiators;
 	}
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/engine/spi/SessionExtensionTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/engine/spi/SessionExtensionTest.java
@@ -1,0 +1,88 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.engine.spi;
+
+import jakarta.persistence.Id;
+import org.hibernate.engine.extension.spi.ExtensionIntegration;
+import org.hibernate.engine.extension.spi.ExtensionIntegrationContext;
+import org.hibernate.testing.orm.junit.BootstrapServiceRegistry;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DomainModel(annotatedClasses = {
+		SessionExtensionTest.UselessEntity.class,
+})
+@BootstrapServiceRegistry(
+		javaServices = @BootstrapServiceRegistry.JavaService(role = ExtensionIntegration.class,
+				impl = SessionExtensionTest.TestExtensionIntegration.class)
+)
+@SessionFactory
+public class SessionExtensionTest {
+
+	@Test
+	public void smoke(SessionFactoryScope scope) {
+		scope.inSession( sessionImplementor -> {
+			sessionImplementor.getExtension( MySometimesFailingExtensionStorage.class ).add( new ExtensionData( 1 ) );
+			assertThat( sessionImplementor.getExtension( MySometimesFailingExtensionStorage.class ).get( 1 ) )
+					.isNotNull();
+		} );
+
+		scope.inSession( sessionImplementor -> {
+			assertThat( sessionImplementor.getExtension( MySometimesFailingExtensionStorage.class ).get( 1 ) )
+					.isNull();
+			sessionImplementor.getExtension( MySometimesFailingExtensionStorage.class ).add( new ExtensionData( 1 ) );
+			assertThat( sessionImplementor.getExtension( MySometimesFailingExtensionStorage.class ).get( 1 ) )
+					.isNotNull();
+		} );
+	}
+
+	public static class MySometimesFailingExtensionStorage implements org.hibernate.engine.extension.spi.Extension {
+		Map<Integer, ExtensionData> data = new HashMap<>();
+
+		public MySometimesFailingExtensionStorage() {
+			throw new UnsupportedOperationException();
+		}
+
+		MySometimesFailingExtensionStorage(Map<Integer, ExtensionData> data) {
+			this.data = data;
+		}
+
+		public void add(ExtensionData extension) {
+			data.put( extension.number, extension );
+		}
+
+		public ExtensionData get(int number) {
+			return data.get( number );
+		}
+	}
+
+	public record ExtensionData(int number) {
+	}
+
+	static class UselessEntity {
+		@Id
+		Long id;
+	}
+
+	public static class TestExtensionIntegration implements ExtensionIntegration<MySometimesFailingExtensionStorage> {
+
+		@Override
+		public Class<MySometimesFailingExtensionStorage> getExtensionType() {
+			return MySometimesFailingExtensionStorage.class;
+		}
+
+		@Override
+		public MySometimesFailingExtensionStorage createExtension(ExtensionIntegrationContext context) {
+			return new MySometimesFailingExtensionStorage( new HashMap<>() );
+		}
+	}
+}


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-19849

so that Search wouldn't need to rely on `.getProperties()` and abuse it 😄. 

I'm not "attached" 🙂 to the method names and if there are any suggestions for better alternatives, happy to change them 🙂 

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------


---
<!-- Hibernate GitHub Bot task list start -->
Please make sure that the following tasks are completed:
Tasks specific to HHH-19849 (Improvement):
- [ ] Add tests for feature/improvement
- [ ] Update documentation as relevant: javadoc for changed API, `documentation/src/main/asciidoc/userguide` for all features, `documentation/src/main/asciidoc/introduction` for main features, links from existing documentation
- [ ] Add entries as relevant to `migration-guide.adoc` (breaking changes) and `whats-new.adoc` (new features/improvements)


<!-- Hibernate GitHub Bot task list end -->