### PR TITLE
HHH-19850 replace arraylist by bitSet when resolving dirty attribute indexes

### DIFF
--- a/hibernate-core/src/test/java/org/hibernate/persister/entity/AbstractEntityPersisterTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/persister/entity/AbstractEntityPersisterTest.java
@@ -1,0 +1,170 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.persister.entity;
+
+import org.hibernate.engine.spi.SessionImplementor;
+import org.hibernate.testing.orm.junit.JiraKey;
+import org.hibernate.testing.junit4.BaseCoreFunctionalTestCase;
+import org.junit.Before;
+import org.junit.Test;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+import java.util.Arrays;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author El Mehdi KZADRI
+ */
+@JiraKey("HHH-19850")
+public class AbstractEntityPersisterTest extends BaseCoreFunctionalTestCase {
+
+	private AbstractEntityPersister persister;
+
+	@Override
+	protected Class<?>[] getAnnotatedClasses() {
+		return new Class[] { TestEntity.class };
+	}
+
+	@Before
+	@SuppressWarnings("resource")
+	public void setUp() {
+		persister = (AbstractEntityPersister) sessionFactory()
+				.getMappingMetamodel()
+				.getEntityDescriptor(TestEntity.class.getName());
+	}
+
+	@Test
+	public void testResolveDirtyAttributeIndexes_EmptyAttributeNames() {
+		inTransaction( entityManager -> {
+			SessionImplementor session = entityManager.unwrap(SessionImplementor.class);
+
+			Object[] currentState = new Object[5];
+			Object[] previousState = new Object[5];
+			String[] attributeNames = new String[0];
+
+			int[] result = persister.resolveDirtyAttributeIndexes(
+					currentState, previousState, attributeNames, session
+			);
+
+			assertThat(result).isNotNull();
+			assertThat(result.length).isEqualTo(0);
+		});
+	}
+
+	@Test
+	public void testResolveDirtyAttributeIndexes_WithAttributes() {
+		inTransaction( entityManager -> {
+			SessionImplementor session = entityManager.unwrap(SessionImplementor.class);
+
+			Object[] currentState = new Object[] { 1L, "name1", "value1" };
+			Object[] previousState = new Object[] { 1L, "name2", "value2" };
+			String[] attributeNames = {"name", "value"};
+
+			int[] result = persister.resolveDirtyAttributeIndexes(
+					currentState, previousState, attributeNames, session
+			);
+
+			assertThat(result).isNotNull();
+			// Verify no duplicates
+			assertThat(result.length).isEqualTo(Arrays.stream(result).distinct().count());
+			// Verify sorted order
+			int[] sorted = result.clone();
+			Arrays.sort(sorted);
+			assertThat(sorted).isEqualTo(result);
+		});
+	}
+
+	@Test
+	public void testResolveDirtyAttributeIndexes_DuplicateAttributeNames() {
+		inTransaction( entityManager -> {
+			SessionImplementor session = entityManager.unwrap(SessionImplementor.class);
+
+			Object[] currentState = new Object[] { 1L, "name1", "value1" };
+			Object[] previousState = new Object[] { 1L, "name2", "value2" };
+			String[] attributeNames = {"name", "name", "value", "value"};
+
+			int[] result = persister.resolveDirtyAttributeIndexes(
+					currentState, previousState, attributeNames, session
+			);
+
+			// Should not contain duplicate indices
+			assertThat(result.length).isEqualTo(Arrays.stream(result).distinct().count());
+		});
+	}
+
+	@Test
+	public void testResolveDirtyAttributeIndexes_NoDirtyFields() {
+		inTransaction( entityManager -> {
+			SessionImplementor session = entityManager.unwrap(SessionImplementor.class);
+
+			Object[] state = new Object[] { 1L, "name1", "value1" };
+			String[] attributeNames = {"name"};
+
+			int[] result = persister.resolveDirtyAttributeIndexes(
+					state, state, attributeNames, session
+			);
+
+			assertThat(result).isNotNull();
+		});
+	}
+
+	@Test
+	public void testResolveDirtyAttributeIndexes_NonExistentAttribute() {
+		inTransaction( entityManager -> {
+			SessionImplementor session = entityManager.unwrap(SessionImplementor.class);
+
+			Object[] currentState = new Object[] { 1L, "name1", "value1" };
+			Object[] previousState = new Object[] { 1L, "name2", "value2" };
+			String[] attributeNames = {"nonExistent"};
+
+			int[] result = persister.resolveDirtyAttributeIndexes(
+					currentState, previousState, attributeNames, session
+			);
+
+			assertThat(result).isNotNull();
+		});
+	}
+
+	@Entity
+	@Table(name = "TEST_ENTITY")
+	public static class TestEntity {
+		@Id
+		@GeneratedValue
+		private Long id;
+
+		private String name;
+
+		private String value;
+
+		public Long getId() {
+			return id;
+		}
+
+		public void setId(Long id) {
+			this.id = id;
+		}
+
+		public String getName() {
+			return name;
+		}
+
+		public void setName(String name) {
+			this.name = name;
+		}
+
+		public String getValue() {
+			return value;
+		}
+
+		public void setValue(String value) {
+			this.value = value;
+		}
+	}
+}


### PR DESCRIPTION
This aims to reduce memory usage by reducing allocations when resolving dirty attribute indexes

### Changes

I added the tests before making the changes to make sure my modifications didn't break the logic afterwards.

This optimizes memory usage by replacing ArrayList<Integer> with BitSet for better memory allocation by:
Eliminating boxing overhead (Integer objects)
More efficient lookup with BitSet comapred to ArrayList "contains"
Converting to int[] only at the end and allocating exact size using bitSet.cardinality()

### Related Issue
Fixes HHH-19850

----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-19850
<!-- Hibernate GitHub Bot issue links end -->