### PR TITLE
HHH-19912 Add automatic test data cleanup feature to @SessionFactory annotation

### DIFF
--- a/hibernate-testing/src/main/java/org/hibernate/testing/orm/junit/DropDataTiming.java
+++ b/hibernate-testing/src/main/java/org/hibernate/testing/orm/junit/DropDataTiming.java
@@ -1,0 +1,32 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.testing.orm.junit;
+
+/**
+ * Enumeration of when to drop test data automatically.
+ *
+ * @author inpink
+ */
+public enum DropDataTiming {
+	/**
+	 * Drop test data before each test method
+	 */
+	BEFORE_EACH,
+
+	/**
+	 * Drop test data after each test method
+	 */
+	AFTER_EACH,
+
+	/**
+	 * Drop test data before all test methods (once per test class)
+	 */
+	BEFORE_ALL,
+
+	/**
+	 * Drop test data after all test methods (once per test class)
+	 */
+	AFTER_ALL
+}

--- a/hibernate-testing/src/main/java/org/hibernate/testing/orm/junit/SessionFactory.java
+++ b/hibernate-testing/src/main/java/org/hibernate/testing/orm/junit/SessionFactory.java
@@ -38,6 +38,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 /// @see SessionFactoryScope
 ///
 /// @author Steve Ebersole
+/// @author inpink
 @Inherited
 @Target({ElementType.TYPE, ElementType.METHOD})
 @Retention( RetentionPolicy.RUNTIME )
@@ -81,4 +82,12 @@ public @interface SessionFactory {
 		public void accept(SessionFactoryBuilder sessionFactoryBuilder) {
 		}
 	}
+
+	/**
+	 * When to automatically drop test data. Multiple timing values can be specified
+	 * to drop data at different points in the test lifecycle.
+	 *
+	 * @return the timing(s) for dropping test data
+	 */
+	DropDataTiming[] dropTestData() default {};
 }

--- a/hibernate-testing/src/main/java/org/hibernate/testing/orm/junit/SessionFactoryProducer.java
+++ b/hibernate-testing/src/main/java/org/hibernate/testing/orm/junit/SessionFactoryProducer.java
@@ -24,5 +24,11 @@ import org.hibernate.engine.spi.SessionFactoryImplementor;
  * @author Steve Ebersole
  */
 public interface SessionFactoryProducer {
+	DropDataTiming[] NONE = new DropDataTiming[0];
+
 	SessionFactoryImplementor produceSessionFactory(MetadataImplementor model);
+
+	default DropDataTiming[] dropTestData() {
+		return NONE;
+	}
 }

--- a/hibernate-testing/src/test/java/org/hibernate/testing/annotations/methods/DropDataTimingTest.java
+++ b/hibernate-testing/src/test/java/org/hibernate/testing/annotations/methods/DropDataTimingTest.java
@@ -1,0 +1,188 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.testing.annotations.methods;
+
+import org.hibernate.testing.annotations.AnEntity;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.DropDataTiming;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for dropTestData timing configuration.
+ *
+ * @author inpink
+ */
+public class DropDataTimingTest {
+
+	@Nested
+	@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+	@DomainModel(annotatedClasses = AnEntity.class)
+	@SessionFactory(dropTestData = {DropDataTiming.AFTER_EACH})
+	class AfterEachDropDataTests {
+
+		@Test
+		@Order(1)
+		public void testAfterEachDropData(SessionFactoryScope scope) {
+			scope.inTransaction(session -> {
+				AnEntity entity = new AnEntity(1, "After Each");
+				session.persist(entity);
+			});
+
+			scope.inTransaction(session -> {
+				Long count = session.createQuery("select count(e) from AnEntity e", Long.class)
+						.getSingleResult();
+				assertThat(count).isEqualTo(1L);
+			});
+		}
+
+		@Test
+		@Order(2)
+		public void verifyAfterEachDropDataCleanup(SessionFactoryScope scope) {
+			scope.inTransaction(session -> {
+				Long count = session.createQuery("select count(e) from AnEntity e", Long.class)
+						.getSingleResult();
+				assertThat(count).isEqualTo(0L);
+			});
+		}
+	}
+
+	@Nested
+	@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+	@DomainModel(annotatedClasses = AnEntity.class)
+	@SessionFactory(dropTestData = {DropDataTiming.BEFORE_EACH})
+	class BeforeEachDropDataTests {
+
+		@Test
+		@Order(1)
+		public void prepareBeforeEachDropData(SessionFactoryScope scope) {
+			scope.inTransaction(session -> {
+				AnEntity entity = new AnEntity(2, "Before Each");
+				session.persist(entity);
+			});
+		}
+
+		@Test
+		@Order(2)
+		public void testBeforeEachDropData(SessionFactoryScope scope) {
+			scope.inTransaction(session -> {
+				Long count = session.createQuery("select count(e) from AnEntity e", Long.class)
+						.getSingleResult();
+				assertThat(count).isEqualTo(0L);
+			});
+		}
+	}
+
+	@Nested
+	@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+	@DomainModel(annotatedClasses = AnEntity.class)
+	@SessionFactory
+	class NeverDropDataTests {
+
+		@Test
+		@Order(1)
+		public void prepareNeverDropData(SessionFactoryScope scope) {
+			scope.inTransaction(session -> {
+				AnEntity entity = new AnEntity(3, "Never");
+				session.persist(entity);
+			});
+		}
+
+		@Test
+		@Order(2)
+		public void testNeverDropData(SessionFactoryScope scope) {
+			scope.inTransaction(session -> {
+				Long count = session.createQuery("select count(e) from AnEntity e", Long.class)
+						.getSingleResult();
+				assertThat(count).isGreaterThan(0L);
+			});
+
+		}
+	}
+
+	@Nested
+	@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+	@DomainModel(annotatedClasses = AnEntity.class)
+	class MethodLevelDropDataTests {
+
+		@Test
+		@Order(1)
+		@SessionFactory(dropTestData = {DropDataTiming.AFTER_EACH})
+		public void methodLevelAfterEach(SessionFactoryScope scope) {
+			scope.inTransaction(session -> {
+				AnEntity entity = new AnEntity(10, "Method After Each");
+				session.persist(entity);
+			});
+
+			scope.inTransaction(session -> {
+				Long count = session.createQuery("select count(e) from AnEntity e", Long.class)
+						.getSingleResult();
+				assertThat(count).isEqualTo(1L);
+			});
+		}
+
+		@Test
+		@Order(2)
+		@SessionFactory(dropTestData = {DropDataTiming.AFTER_EACH})
+		public void methodLevelAfterEachCleanup(SessionFactoryScope scope) {
+			scope.inTransaction(session -> {
+				Long count = session.createQuery("select count(e) from AnEntity e", Long.class)
+						.getSingleResult();
+				assertThat(count).isEqualTo(0L);
+			});
+		}
+
+		@Test
+		@Order(3)
+		@SessionFactory(dropTestData = {DropDataTiming.BEFORE_EACH})
+		public void methodLevelBeforeEachInsert(SessionFactoryScope scope) {
+			scope.inTransaction(session -> {
+				AnEntity entity = new AnEntity(11, "Method Before Each");
+				session.persist(entity);
+			});
+		}
+
+		@Test
+		@Order(4)
+		@SessionFactory(dropTestData = {DropDataTiming.BEFORE_EACH})
+		public void methodLevelBeforeEachVerify(SessionFactoryScope scope) {
+			scope.inTransaction(session -> {
+				Long count = session.createQuery("select count(e) from AnEntity e", Long.class)
+						.getSingleResult();
+				assertThat(count).isEqualTo(0L);
+			});
+		}
+
+		@Test
+		@Order(5)
+		@SessionFactory
+		public void methodLevelNeverInsert(SessionFactoryScope scope) {
+			scope.inTransaction(session -> {
+				AnEntity entity = new AnEntity(12, "Method Never");
+				session.persist(entity);
+			});
+		}
+
+		@Test
+		@Order(6)
+		@SessionFactory
+		public void methodLevelNeverVerify(SessionFactoryScope scope) {
+			scope.inTransaction(session -> {
+				Long count = session.createQuery("select count(e) from AnEntity e", Long.class)
+						.getSingleResult();
+				assertThat(count).isEqualTo(0L);
+			});
+
+			scope.dropData();
+		}
+	}
+}

--- a/hibernate-testing/src/test/java/org/hibernate/testing/annotations/methods/SessionFactoryProducerDropDataTest.java
+++ b/hibernate-testing/src/test/java/org/hibernate/testing/annotations/methods/SessionFactoryProducerDropDataTest.java
@@ -1,0 +1,165 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.testing.annotations.methods;
+
+import org.hibernate.boot.spi.MetadataImplementor;
+import org.hibernate.engine.spi.SessionFactoryImplementor;
+import org.hibernate.testing.annotations.AnEntity;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.DropDataTiming;
+import org.hibernate.testing.orm.junit.ServiceRegistry;
+import org.hibernate.testing.orm.junit.Setting;
+import org.hibernate.testing.orm.junit.SessionFactoryFunctionalTesting;
+import org.hibernate.testing.orm.junit.SessionFactoryProducer;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.hibernate.testing.orm.junit.SessionFactoryScopeParameterResolver;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for dropTestData functionality with SessionFactoryProducer.
+ *
+ * @author inpink
+ */
+public class SessionFactoryProducerDropDataTest {
+
+	@Nested
+	@SessionFactoryFunctionalTesting
+	@ExtendWith(SessionFactoryScopeParameterResolver.class)
+	@DomainModel(annotatedClasses = AnEntity.class)
+	@ServiceRegistry(
+			settings = {
+					@Setting(name = "jakarta.persistence.schema-generation.database.action", value = "drop-and-create")
+			}
+	)
+	@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+	class DefaultDropDataTimingTests implements SessionFactoryProducer {
+
+		@Override
+		public SessionFactoryImplementor produceSessionFactory(MetadataImplementor model) {
+			return (SessionFactoryImplementor) model.getSessionFactoryBuilder().build();
+		}
+
+		@Test
+		public void testDefaultDropDataTimingIsNone(SessionFactoryScope scope) {
+			DropDataTiming[] timings = this.dropTestData();
+			assertThat(timings).isEmpty();
+		}
+
+		@Test
+		@Order(1)
+		public void insertData(SessionFactoryScope scope) {
+			scope.inTransaction(session -> {
+				session.persist(new AnEntity(100, "Producer Insert"));
+			});
+		}
+
+		@Test
+		@Order(2)
+		public void dataRemainsWithoutExplicitDrop(SessionFactoryScope scope) {
+			scope.inTransaction(session -> {
+				Long count = session.createQuery("select count(e) from AnEntity e", Long.class)
+						.getSingleResult();
+				assertThat(count).isEqualTo(1L);
+			});
+
+			scope.dropData();
+		}
+	}
+
+	@Nested
+	@SessionFactoryFunctionalTesting
+	@ExtendWith(SessionFactoryScopeParameterResolver.class)
+	@DomainModel(annotatedClasses = AnEntity.class)
+	@ServiceRegistry(
+			settings = {
+					@Setting(name = "jakarta.persistence.schema-generation.database.action", value = "drop-and-create")
+			}
+	)
+	@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+	class AfterEachDropDataTests implements SessionFactoryProducer {
+
+		@Override
+		public SessionFactoryImplementor produceSessionFactory(MetadataImplementor model) {
+			return (SessionFactoryImplementor) model.getSessionFactoryBuilder().build();
+		}
+
+		@Override
+		public DropDataTiming[] dropTestData() {
+			return new DropDataTiming[]{ DropDataTiming.AFTER_EACH };
+		}
+
+		@Test
+		@Order(1)
+		public void insertDataWithAfterEachDrop(SessionFactoryScope scope) {
+			scope.inTransaction(session -> {
+				session.persist(new AnEntity(200, "After Each Producer"));
+			});
+
+			scope.inTransaction(session -> {
+				Long count = session.createQuery("select count(e) from AnEntity e", Long.class)
+						.getSingleResult();
+				assertThat(count).isEqualTo(1L);
+			});
+		}
+
+		@Test
+		@Order(2)
+		public void verifyAfterEachDropWorks(SessionFactoryScope scope) {
+			scope.inTransaction(session -> {
+				Long count = session.createQuery("select count(e) from AnEntity e", Long.class)
+						.getSingleResult();
+				assertThat(count).isEqualTo(0L);
+			});
+		}
+	}
+
+	@Nested
+	@SessionFactoryFunctionalTesting
+	@ExtendWith(SessionFactoryScopeParameterResolver.class)
+	@DomainModel(annotatedClasses = AnEntity.class)
+	@ServiceRegistry(
+			settings = {
+					@Setting(name = "jakarta.persistence.schema-generation.database.action", value = "drop-and-create")
+			}
+	)
+	@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+	class BeforeEachDropDataTests implements SessionFactoryProducer {
+
+		@Override
+		public SessionFactoryImplementor produceSessionFactory(MetadataImplementor model) {
+			return (SessionFactoryImplementor) model.getSessionFactoryBuilder().build();
+		}
+
+		@Override
+		public DropDataTiming[] dropTestData() {
+			return new DropDataTiming[]{ DropDataTiming.BEFORE_EACH };
+		}
+
+		@Test
+		@Order(1)
+		public void prepareDataForBeforeEachDrop(SessionFactoryScope scope) {
+			scope.inTransaction(session -> {
+				session.persist(new AnEntity(300, "Before Each Producer"));
+			});
+		}
+
+		@Test
+		@Order(2)
+		public void verifyBeforeEachDropWorks(SessionFactoryScope scope) {
+			scope.inTransaction(session -> {
+				Long count = session.createQuery("select count(e) from AnEntity e", Long.class)
+						.getSingleResult();
+				assertThat(count).isEqualTo(0L);
+			});
+		}
+	}
+}


### PR DESCRIPTION
<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

[Please describe here what your change is about]

 - Added dropTestData() attribute to @SessionFactory (default empty array) so tests can opt into automatic cleanup declaratively with multiple timing options.
  - Introduced the DropDataTiming enum to capture supported cleanup moments (BEFORE_EACH, AFTER_EACH, BEFORE_ALL, AFTER_ALL).
  - Added dropTestData() default method to SessionFactoryProducer interface allowing Producer-based tests to specify cleanup timing programmatically.
  - Updated SessionFactoryExtension to store the configured timing array and invoke scope.dropData() during the matching JUnit lifecycle callbacks.
  - Implemented priority system where SessionFactoryProducer.dropTestData() takes precedence over @SessionFactory.dropTestData() when both are specified, following Hibernate's existing pattern.
  - Added DropDataTimingTest to prove each timing option behaves as expected by inserting data and asserting whether it persists or gets cleared at the right moments.
  - Added SessionFactoryProducerDropDataTest with comprehensive nested test classes covering default behavior (no automatic cleanup), timing options, and Producer-over-annotation priority
  testing.


<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-19912
<!-- Hibernate GitHub Bot issue links end -->