### PR TITLE
HHH-19959 map `default-cascade` attribute in hbm.xml files

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/boot/model/source/internal/OverriddenMappingDefaults.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/source/internal/OverriddenMappingDefaults.java
@@ -151,7 +151,7 @@ public class OverriddenMappingDefaults implements EffectiveMappingDefaults {
 		private String implicitDiscriminatorColumnName;
 		private String implicitPackageName;
 		private boolean autoImportEnabled;
-		private final EnumSet<CascadeType> implicitCascadeTypes;
+		private EnumSet<CascadeType> implicitCascadeTypes;
 		private jakarta.persistence.AccessType implicitPropertyAccessType;
 		private String implicitPropertyAccessorName;
 		private boolean entitiesImplicitlyLazy;
@@ -229,12 +229,12 @@ public class OverriddenMappingDefaults implements EffectiveMappingDefaults {
 			return this;
 		}
 
-//		public Builder setImplicitCascadeStyleName(String implicitCascadeStyleName) {
-//			if ( StringHelper.isNotEmpty( implicitCascadeStyleName ) ) {
-//				this.implicitCascadeStyleName = implicitCascadeStyleName;
-//			}
-//			return this;
-//		}
+		public Builder setImplicitCascadeTypes(EnumSet<CascadeType> implicitCascadeTypes) {
+			if (implicitCascadeTypes != null) {
+				this.implicitCascadeTypes = implicitCascadeTypes;
+			}
+			return this;
+		}
 
 		public Builder setImplicitPropertyAccessType(jakarta.persistence.AccessType accessType) {
 			if ( accessType != null ) {

--- a/hibernate-core/src/main/java/org/hibernate/boot/model/source/internal/hbm/MappingDocument.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/source/internal/hbm/MappingDocument.java
@@ -4,8 +4,10 @@
  */
 package org.hibernate.boot.model.source.internal.hbm;
 
+import java.util.EnumSet;
 import java.util.Set;
 
+import org.hibernate.annotations.CascadeType;
 import org.hibernate.boot.jaxb.Origin;
 import org.hibernate.boot.jaxb.hbm.spi.EntityInfo;
 import org.hibernate.boot.jaxb.hbm.spi.JaxbHbmHibernateMapping;
@@ -64,7 +66,7 @@ public class MappingDocument implements HbmLocalMetadataBuildingContext, Metadat
 						.setImplicitCatalogName( documentRoot.getCatalog() )
 						.setImplicitPackageName( documentRoot.getPackage() )
 						.setImplicitPropertyAccessorName( documentRoot.getDefaultAccess() )
-//						.setImplicitCascadeStyleName( documentRoot.getDefaultCascade() )
+						.setImplicitCascadeTypes( getCascadeTypes(documentRoot) )
 						.setEntitiesImplicitlyLazy( documentRoot.isDefaultLazy() )
 						.setAutoImportEnabled( documentRoot.isAutoImport() )
 						.setPluralAttributesImplicitlyLazy( documentRoot.isDefaultLazy() )
@@ -74,6 +76,23 @@ public class MappingDocument implements HbmLocalMetadataBuildingContext, Metadat
 
 		typeDefinitionRegistry =
 				new TypeDefinitionRegistryStandardImpl( rootBuildingContext.getTypeDefinitionRegistry() );
+	}
+
+	private EnumSet<CascadeType> getCascadeTypes(JaxbHbmHibernateMapping documentRoot) {
+		return switch ( documentRoot.getDefaultCascade() ) {
+			case "all" -> EnumSet.of( CascadeType.ALL );
+			case "all-delete-orphan" -> EnumSet.of( CascadeType.ALL, CascadeType.DELETE_ORPHAN );
+			case "persist" -> EnumSet.of( CascadeType.PERSIST );
+			case "merge" -> EnumSet.of( CascadeType.MERGE );
+			case "lock" -> EnumSet.of( CascadeType.LOCK );
+			case "refresh" -> EnumSet.of( CascadeType.REFRESH );
+			case "replicate" -> EnumSet.of( CascadeType.REPLICATE );
+			case "evict" -> EnumSet.of( CascadeType.DETACH );
+			case "delete" -> EnumSet.of( CascadeType.REMOVE );
+			case "remove" -> EnumSet.of( CascadeType.REMOVE );
+			case "delete-orphan" -> EnumSet.of( CascadeType.DELETE_ORPHAN );
+			default -> null;
+		};
 	}
 
 	public JaxbHbmHibernateMapping getDocumentRoot() {

--- a/hibernate-core/src/main/java/org/hibernate/boot/model/source/internal/hbm/ModelBinder.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/source/internal/hbm/ModelBinder.java
@@ -2191,7 +2191,7 @@ public class ModelBinder {
 				else {
 					buffer.append( ", " );
 				}
-				buffer.append( cascadeType.name().toLowerCase( Locale.ROOT ) );
+				buffer.append( cascadeType.name().toLowerCase( Locale.ROOT ).replace( '_', '-' ) );
 			}
 			return buffer.toString();
 		}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/hbm/cascade/DefaultCascadeBindingTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/hbm/cascade/DefaultCascadeBindingTest.java
@@ -1,0 +1,45 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.hbm.cascade;
+
+import org.hibernate.boot.Metadata;
+import org.hibernate.boot.MetadataSources;
+import org.hibernate.boot.registry.StandardServiceRegistry;
+import org.hibernate.mapping.PersistentClass;
+import org.hibernate.orm.test.legacy.Holder;
+import org.hibernate.testing.ServiceRegistryBuilder;
+import org.hibernate.testing.orm.junit.BaseUnitTest;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@BaseUnitTest
+class DefaultCascadeBindingTest {
+
+	@Test
+	void testDefaultCascadeIsApplied() {
+		StandardServiceRegistry ssr = ServiceRegistryBuilder.buildServiceRegistry();
+
+		try {
+			MetadataSources ms = new MetadataSources( ssr );
+			ms.addResource( "org/hibernate/orm/test/hbm/cascade/default-cascade.hbm.xml" );
+
+			Metadata metadata = ms.buildMetadata();
+
+			PersistentClass entityBinding = metadata.getEntityBinding( Holder.class.getName() );
+
+			// Default cascade
+			assertThat( entityBinding.getProperty( "ones" ).getCascadeStyle() )
+					.hasToString( "[STYLE_ALL,STYLE_DELETE_ORPHAN]" );
+
+			// Explicit cascade
+			assertThat( entityBinding.getProperty( "fooArray" ).getCascadeStyle() )
+					.hasToString( "STYLE_PERSIST" );
+		}
+		finally {
+			ServiceRegistryBuilder.destroy( ssr );
+		}
+	}
+}

--- a/hibernate-core/src/test/resources/org/hibernate/orm/test/hbm/cascade/default-cascade.hbm.xml
+++ b/hibernate-core/src/test/resources/org/hibernate/orm/test/hbm/cascade/default-cascade.hbm.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<hibernate-mapping xmlns="http://www.hibernate.org/xsd/hibernate-mapping"
+                   default-cascade="all-delete-orphan">
+
+    <class name="org.hibernate.orm.test.legacy.Holder">
+        <id name="id" column="id_" type="string" length="32" unsaved-value="null">
+            <generator class="uuid.hex"/>
+        </id>
+
+        <!-- Default cascade is "all-delete-orphan" -->
+        <list name="ones">
+            <key column="holder"/>
+            <index column="i"/>
+            <one-to-many class="org.hibernate.orm.test.legacy.One"/>
+        </list>
+
+        <array name="fooArray" cascade="persist">
+            <key column="holder1"/>
+            <index column="j1"/>
+            <one-to-many class="org.hibernate.orm.test.legacy.Foo"/>
+        </array>
+    </class>
+
+    <class name="org.hibernate.orm.test.legacy.One" table="one">
+        <id name="key" column="one_key">
+            <generator class="native" />
+        </id>
+    </class>
+
+    <class name="org.hibernate.orm.test.legacy.Foo" table="foo">
+        <id name="key" column="one_key">
+            <generator class="native" />
+        </id>
+    </class>
+</hibernate-mapping>


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-19959

Fixes a regression in Hibernate 7, which ignores the `default-cascade` attribute in hbm.xml files.

----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------


---
<!-- Hibernate GitHub Bot task list start -->
Please make sure that the following tasks are completed:
Tasks specific to HHH-19959 (Bug):
- [x] Add test reproducing the bug
- [x] Add entries as relevant to `migration-guide.adoc` **OR** check there are no breaking changes


<!-- Hibernate GitHub Bot task list end -->