### PR TITLE
HHH-19890 Add Jackson 3 FormatMapper support

### DIFF
--- a/documentation/src/main/asciidoc/introduction/Configuration.adoc
+++ b/documentation/src/main/asciidoc/introduction/Configuration.adoc
@@ -116,8 +116,8 @@ and `org.ehcache:ehcache`
 and `com.github.ben-manes.caffeine:jcache`
 | Distributed second-level cache support via {infinispan}[Infinispan] | `org.infinispan:infinispan-hibernate-cache-v60`
 // | SCRAM authentication support for PostgreSQL | `com.ongres.scram:client:2.1`
-| A JSON serialization library for working with JSON datatypes, for example, {jackson}[Jackson] or {yasson}[Yasson] |
-`com.fasterxml.jackson.core:jackson-databind` +
+| A JSON serialization library for working with JSON datatypes, for example, {jackson}[Jackson 2], {jackson3}[Jackson 3] or {yasson}[Yasson] |
+`com.fasterxml.jackson.core:jackson-databind`, `tools.jackson.core:jackson-databind` +
 or `org.eclipse:yasson`
 | <<spatial,Hibernate Spatial>> | `org.hibernate.orm:hibernate-spatial`
 | <<envers,Envers>>, for auditing historical data | `org.hibernate.orm:hibernate-envers`

--- a/documentation/src/main/asciidoc/introduction/Mapping.adoc
+++ b/documentation/src/main/asciidoc/introduction/Mapping.adoc
@@ -809,11 +809,18 @@ class Person {
 ----
 
 We also need to add Jackson or an implementation of JSONB—for example, Yasson—to our runtime classpath.
-To use Jackson we could add this line to our Gradle build:
+To use Jackson 2 we could add this line to our Gradle build:
 
 [source,groovy]
 ----
 runtimeOnly 'com.fasterxml.jackson.core:jackson-databind:{jacksonVersion}'
+----
+
+To use Jackson 3 we could add this line to our Gradle build:
+
+[source,groovy]
+----
+runtimeOnly 'tools.jackson.core:jackson-databind:{jackson3Version}'
 ----
 
 Now the `name` column of the `Author` table will have the type `jsonb`, and Hibernate will automatically use Jackson to serialize a `Name` to and from JSON format.

--- a/hibernate-core/hibernate-core.gradle
+++ b/hibernate-core/hibernate-core.gradle
@@ -42,6 +42,8 @@ dependencies {
     compileOnly jakartaLibs.jsonbApi
     compileOnly libs.jackson
     compileOnly libs.jacksonXml
+    compileOnly libs.jackson3
+    compileOnly libs.jackson3Xml
     compileOnly jdbcLibs.postgresql
     compileOnly jdbcLibs.edb
 
@@ -79,6 +81,8 @@ dependencies {
     testImplementation libs.jackson
     testRuntimeOnly libs.jacksonXml
     testRuntimeOnly libs.jacksonJsr310
+    testImplementation libs.jackson3
+    testImplementation libs.jackson3Xml
 
     testAnnotationProcessor project( ':hibernate-processor' )
 

--- a/hibernate-core/src/main/java/org/hibernate/boot/registry/selector/internal/StrategySelectorBuilder.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/registry/selector/internal/StrategySelectorBuilder.java
@@ -45,6 +45,8 @@ import org.hibernate.resource.transaction.backend.jdbc.internal.JdbcResourceLoca
 import org.hibernate.resource.transaction.backend.jta.internal.JtaTransactionCoordinatorBuilderImpl;
 import org.hibernate.resource.transaction.spi.TransactionCoordinatorBuilder;
 import org.hibernate.type.format.FormatMapper;
+import org.hibernate.type.format.jackson.Jackson3JsonFormatMapper;
+import org.hibernate.type.format.jackson.Jackson3XmlFormatMapper;
 import org.hibernate.type.format.jackson.JacksonIntegration;
 import org.hibernate.type.format.jackson.JacksonJsonFormatMapper;
 import org.hibernate.type.format.jackson.JacksonOsonFormatMapper;
@@ -308,6 +310,11 @@ public class StrategySelectorBuilder {
 				JacksonJsonFormatMapper.SHORT_NAME,
 				JacksonJsonFormatMapper.class
 		);
+		strategySelector.registerStrategyImplementor(
+				FormatMapper.class,
+				Jackson3JsonFormatMapper.SHORT_NAME,
+				Jackson3JsonFormatMapper.class
+		);
 		if ( JacksonIntegration.isJacksonOsonExtensionAvailable() ) {
 			strategySelector.registerStrategyImplementor(
 					FormatMapper.class,
@@ -322,6 +329,11 @@ public class StrategySelectorBuilder {
 				FormatMapper.class,
 				JacksonXmlFormatMapper.SHORT_NAME,
 				JacksonXmlFormatMapper.class
+		);
+		strategySelector.registerStrategyImplementor(
+				FormatMapper.class,
+				Jackson3XmlFormatMapper.SHORT_NAME,
+				Jackson3XmlFormatMapper.class
 		);
 		strategySelector.registerStrategyImplementor(
 				FormatMapper.class,

--- a/hibernate-core/src/main/java/org/hibernate/type/format/jackson/Jackson3JsonFormatMapper.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/format/jackson/Jackson3JsonFormatMapper.java
@@ -1,0 +1,92 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.type.format.jackson;
+
+import org.hibernate.type.descriptor.WrapperOptions;
+import org.hibernate.type.descriptor.java.JavaType;
+import org.hibernate.type.format.AbstractJsonFormatMapper;
+import org.hibernate.type.format.FormatMapperCreationContext;
+import tools.jackson.core.JacksonException;
+import tools.jackson.core.JsonGenerator;
+import tools.jackson.core.JsonParser;
+import tools.jackson.databind.JacksonModule;
+import tools.jackson.databind.cfg.MapperBuilder;
+import tools.jackson.databind.json.JsonMapper;
+
+import java.lang.reflect.Type;
+import java.util.List;
+
+/**
+ * @author Christian Beikov
+ * @author Yanming Zhou
+ * @author Nick Rayburn
+ */
+public final class Jackson3JsonFormatMapper extends AbstractJsonFormatMapper {
+
+	public static final String SHORT_NAME = "jackson3";
+
+	private final JsonMapper jsonMapper;
+
+	public Jackson3JsonFormatMapper() {
+		this( MapperBuilder.findModules( Jackson3JsonFormatMapper.class.getClassLoader() ) );
+	}
+
+	public Jackson3JsonFormatMapper(FormatMapperCreationContext creationContext) {
+		this( JacksonIntegration.loadJackson3Modules( creationContext ) );
+	}
+
+	private Jackson3JsonFormatMapper(List<JacksonModule> modules) {
+		this( JsonMapper.builderWithJackson2Defaults()
+				.addModules( modules )
+				.build()
+		);
+	}
+
+	public Jackson3JsonFormatMapper(JsonMapper jsonMapper) {
+		this.jsonMapper = jsonMapper;
+	}
+
+	@Override
+	public <T> void writeToTarget(T value, JavaType<T> javaType, Object target, WrapperOptions options)
+			throws JacksonException {
+		jsonMapper.writerFor( jsonMapper.constructType( javaType.getJavaType() ) )
+				.writeValue( (JsonGenerator) target, value );
+	}
+
+	@Override
+	public <T> T readFromSource(JavaType<T> javaType, Object source, WrapperOptions options) throws JacksonException {
+		return jsonMapper.readValue( (JsonParser) source, jsonMapper.constructType( javaType.getJavaType() ) );
+	}
+
+	@Override
+	public boolean supportsSourceType(Class<?> sourceType) {
+		return JsonParser.class.isAssignableFrom( sourceType );
+	}
+
+	@Override
+	public boolean supportsTargetType(Class<?> targetType) {
+		return JsonGenerator.class.isAssignableFrom( targetType );
+	}
+
+	@Override
+	public <T> T fromString(CharSequence charSequence, Type type) {
+		try {
+			return jsonMapper.readValue( charSequence.toString(), jsonMapper.constructType( type ) );
+		}
+		catch (JacksonException e) {
+			throw new IllegalArgumentException( "Could not deserialize string to java type: " + type, e );
+		}
+	}
+
+	@Override
+	public <T> String toString(T value, Type type) {
+		try {
+			return jsonMapper.writerFor( jsonMapper.constructType( type ) ).writeValueAsString( value );
+		}
+		catch (JacksonException e) {
+			throw new IllegalArgumentException( "Could not serialize object of java type: " + type, e );
+		}
+	}
+}

--- a/hibernate-core/src/main/java/org/hibernate/type/format/jackson/Jackson3XmlFormatMapper.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/format/jackson/Jackson3XmlFormatMapper.java
@@ -1,0 +1,319 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.type.format.jackson;
+
+import com.fasterxml.jackson.annotation.JsonRootName;
+import org.hibernate.type.descriptor.WrapperOptions;
+import org.hibernate.type.descriptor.java.JavaType;
+import org.hibernate.type.descriptor.java.PrimitiveByteArrayJavaType;
+import org.hibernate.type.format.FormatMapper;
+import org.hibernate.type.format.FormatMapperCreationContext;
+import org.hibernate.type.internal.ParameterizedTypeImpl;
+import tools.jackson.core.JacksonException;
+import tools.jackson.core.JsonGenerator;
+import tools.jackson.core.JsonParser;
+import tools.jackson.core.JsonToken;
+import tools.jackson.databind.DeserializationContext;
+import tools.jackson.databind.JacksonModule;
+import tools.jackson.databind.SerializationContext;
+import tools.jackson.databind.ValueDeserializer;
+import tools.jackson.databind.cfg.DateTimeFeature;
+import tools.jackson.databind.cfg.MapperBuilder;
+import tools.jackson.databind.module.SimpleModule;
+import tools.jackson.databind.ser.std.StdSerializer;
+import tools.jackson.dataformat.xml.XmlMapper;
+import tools.jackson.dataformat.xml.XmlWriteFeature;
+import tools.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
+import tools.jackson.dataformat.xml.annotation.JacksonXmlProperty;
+
+import java.lang.reflect.Array;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * @author Christian Beikov
+ * @author Emmanuel Jannetti
+ * @author Nick Rayburn
+ */
+public final class Jackson3XmlFormatMapper implements FormatMapper {
+
+	public static final String SHORT_NAME = "jackson3-xml";
+	private final boolean legacyFormat;
+
+	private final XmlMapper xmlMapper;
+
+	public Jackson3XmlFormatMapper() {
+		this( true );
+	}
+
+	public Jackson3XmlFormatMapper(boolean legacyFormat) {
+		this(
+				createXmlMapper( MapperBuilder.findModules( Jackson3XmlFormatMapper.class.getClassLoader() ), legacyFormat ),
+				legacyFormat
+		);
+	}
+
+	public Jackson3XmlFormatMapper(FormatMapperCreationContext creationContext) {
+		this(
+				createXmlMapper(
+						JacksonIntegration.loadJackson3Modules( creationContext ),
+						creationContext.getBootstrapContext()
+								.getMetadataBuildingOptions()
+								.isXmlFormatMapperLegacyFormatEnabled()
+				),
+				creationContext.getBootstrapContext()
+						.getMetadataBuildingOptions()
+						.isXmlFormatMapperLegacyFormatEnabled()
+		);
+	}
+
+	public Jackson3XmlFormatMapper(XmlMapper xmlMapper) {
+		this( xmlMapper, false );
+	}
+
+	public Jackson3XmlFormatMapper(XmlMapper xmlMapper, boolean legacyFormat) {
+		this.xmlMapper = xmlMapper;
+		this.legacyFormat = legacyFormat;
+	}
+
+	private static XmlMapper createXmlMapper(List<JacksonModule> modules, boolean legacyFormat) {
+		final XmlMapper.Builder builder = XmlMapper.builderWithJackson2Defaults()
+				.disable( DateTimeFeature.WRITE_DATES_AS_TIMESTAMPS )
+				.enable( XmlWriteFeature.WRITE_NULLS_AS_XSI_NIL )
+				.addModules( modules );
+		// Workaround for null vs empty string handling inside arrays,
+		// see: https://github.com/FasterXML/jackson-dataformat-xml/issues/344
+		final SimpleModule module = new SimpleModule();
+		module.addDeserializer( String[].class, new StringArrayDeserializer() );
+		if ( !legacyFormat ) {
+			module.addDeserializer( byte[].class, new ByteArrayDeserializer() );
+			module.addSerializer( byte[].class, new ByteArraySerializer() );
+		}
+		builder.addModule( module );
+		return builder.build();
+	}
+
+	@Override
+	public <T> T fromString(CharSequence charSequence, JavaType<T> javaType, WrapperOptions wrapperOptions) {
+		if ( javaType.getJavaType() == String.class || javaType.getJavaType() == Object.class ) {
+			return (T) charSequence.toString();
+		}
+		try {
+			if ( !legacyFormat ) {
+				if ( Map.class.isAssignableFrom( javaType.getJavaTypeClass() ) ) {
+					final Type keyType;
+					final Type elementType;
+					if ( javaType.getJavaType() instanceof ParameterizedType parameterizedType ) {
+						keyType = parameterizedType.getActualTypeArguments()[0];
+						elementType = parameterizedType.getActualTypeArguments()[1];
+					}
+					else {
+						keyType = Object.class;
+						elementType = Object.class;
+					}
+					final MapWrapper<?, ?> collectionWrapper = xmlMapper.readValue(
+							charSequence.toString(),
+							xmlMapper.constructType( new ParameterizedTypeImpl( MapWrapper.class,
+									new Type[] {keyType, elementType}, null ) )
+					);
+					final Map<Object, Object> map = new LinkedHashMap<>( collectionWrapper.entry.size() );
+					for ( EntryWrapper<?, ?> entry : collectionWrapper.entry ) {
+						map.put( entry.key, entry.value );
+					}
+					return javaType.wrap( map, wrapperOptions );
+				}
+				else if ( Collection.class.isAssignableFrom( javaType.getJavaTypeClass() ) ) {
+					final Type elementType =
+							javaType.getJavaType() instanceof ParameterizedType parameterizedType
+									? parameterizedType.getActualTypeArguments()[0]
+									: Object.class;
+					final CollectionWrapper<?> collectionWrapper = xmlMapper.readValue(
+							charSequence.toString(),
+							xmlMapper.constructType(
+									new ParameterizedTypeImpl( CollectionWrapper.class, new Type[] {elementType},
+											null ) )
+					);
+					return javaType.wrap( collectionWrapper.value, wrapperOptions );
+				}
+				else if ( javaType.getJavaTypeClass().isArray() ) {
+					final CollectionWrapper<?> collectionWrapper = xmlMapper.readValue(
+							charSequence.toString(),
+							xmlMapper.constructType( new ParameterizedTypeImpl( CollectionWrapper.class,
+									new Type[] {javaType.getJavaTypeClass().getComponentType()}, null ) )
+					);
+					return javaType.wrap( collectionWrapper.value, wrapperOptions );
+				}
+			}
+			return xmlMapper.readValue(
+					charSequence.toString(),
+					xmlMapper.constructType( javaType.getJavaType() )
+			);
+		}
+		catch (JacksonException e) {
+			throw new IllegalArgumentException( "Could not deserialize string to java type: " + javaType, e );
+		}
+	}
+
+	@Override
+	public <T> String toString(T value, JavaType<T> javaType, WrapperOptions wrapperOptions) {
+		if ( javaType.getJavaType() == String.class || javaType.getJavaType() == Object.class ) {
+			return (String) value;
+		}
+		if ( !legacyFormat ) {
+			if ( Map.class.isAssignableFrom( javaType.getJavaTypeClass() ) ) {
+				final Type keyType;
+				final Type elementType;
+				if ( javaType.getJavaType() instanceof ParameterizedType parameterizedType ) {
+					keyType = parameterizedType.getActualTypeArguments()[0];
+					elementType = parameterizedType.getActualTypeArguments()[1];
+				}
+				else {
+					keyType = Object.class;
+					elementType = Object.class;
+				}
+				final MapWrapper<Object, Object> mapWrapper = new MapWrapper<>();
+				for ( Map.Entry<?, ?> entry : ((Map<?, ?>) value).entrySet() ) {
+					mapWrapper.entry.add( new EntryWrapper<>( entry.getKey(), entry.getValue() ) );
+				}
+				return writeValueAsString(
+						mapWrapper,
+						javaType,
+						new ParameterizedTypeImpl( MapWrapper.class, new Type[] {keyType, elementType}, null )
+				);
+			}
+			else if ( Collection.class.isAssignableFrom( javaType.getJavaTypeClass() ) ) {
+				final Type elementType =
+						javaType.getJavaType() instanceof ParameterizedType parameterizedType
+								? parameterizedType.getActualTypeArguments()[0]
+								: Object.class;
+				return writeValueAsString(
+						new CollectionWrapper<>( (Collection<?>) value ),
+						javaType,
+						new ParameterizedTypeImpl( CollectionWrapper.class, new Type[] {elementType}, null )
+				);
+			}
+			else if ( javaType.getJavaTypeClass().isArray() ) {
+				final CollectionWrapper<Object> collectionWrapper;
+				if ( Object[].class.isAssignableFrom( javaType.getJavaTypeClass() ) ) {
+					collectionWrapper = new CollectionWrapper<>( Arrays.asList( (Object[]) value ) );
+				}
+				else {
+					// Primitive arrays get a special treatment
+					final int length = Array.getLength( value );
+					final List<Object> list = new ArrayList<>( length );
+					for ( int i = 0; i < length; i++ ) {
+						list.add( Array.get( value, i ) );
+					}
+					collectionWrapper = new CollectionWrapper<>( list );
+				}
+				return writeValueAsString(
+						collectionWrapper,
+						javaType,
+						new ParameterizedTypeImpl( CollectionWrapper.class,
+								new Type[] {javaType.getJavaTypeClass().getComponentType()}, null )
+				);
+			}
+		}
+		return writeValueAsString( value, javaType, javaType.getJavaType() );
+	}
+
+	private <T> String writeValueAsString(Object value, JavaType<T> javaType, Type type) {
+		try {
+			return xmlMapper.writerFor( xmlMapper.constructType( type ) ).writeValueAsString( value );
+		}
+		catch (JacksonException e) {
+			throw new IllegalArgumentException( "Could not serialize object of java type: " + javaType, e );
+		}
+	}
+
+	@JsonRootName(value = "Collection")
+	public static class CollectionWrapper<E> {
+		@JacksonXmlElementWrapper(useWrapping = false)
+		@JacksonXmlProperty(localName = "e")
+		Collection<E> value;
+
+		public CollectionWrapper() {
+			this.value = new ArrayList<>();
+		}
+
+		public CollectionWrapper(Collection<E> value) {
+			this.value = value;
+		}
+	}
+
+	@JsonRootName(value = "Map")
+	public static class MapWrapper<K, V> {
+		@JacksonXmlElementWrapper(useWrapping = false)
+		@JacksonXmlProperty(localName = "e")
+		Collection<EntryWrapper<K, V>> entry;
+
+		public MapWrapper() {
+			this.entry = new ArrayList<>();
+		}
+
+		public MapWrapper(Collection<EntryWrapper<K, V>> entry) {
+			this.entry = entry;
+		}
+	}
+
+	public static class EntryWrapper<K, V> {
+		@JacksonXmlProperty(localName = "k")
+		K key;
+		@JacksonXmlProperty(localName = "v")
+		V value;
+
+		public EntryWrapper() {
+		}
+
+		public EntryWrapper(K key, V value) {
+			this.key = key;
+			this.value = value;
+		}
+	}
+
+	private static class StringArrayDeserializer extends ValueDeserializer<String[]> {
+		@Override
+		public String[] deserialize(JsonParser jp, DeserializationContext deserializationContext) throws JacksonException {
+			final ArrayList<String> result = new ArrayList<>();
+			JsonToken token;
+			while ( ( token = jp.nextValue() ) != JsonToken.END_OBJECT ) {
+				if ( token.isScalarValue() ) {
+					result.add( jp.getValueAsString() );
+				}
+			}
+			return result.toArray( String[]::new );
+		}
+	}
+
+	private static class ByteArrayDeserializer extends ValueDeserializer<byte[]> {
+		@Override
+		public byte[] deserialize(JsonParser jp, DeserializationContext deserializationContext) throws JacksonException {
+			return PrimitiveByteArrayJavaType.INSTANCE.fromString( jp.getValueAsString() );
+		}
+	}
+
+	public static class ByteArraySerializer extends StdSerializer<byte[]> {
+
+		public ByteArraySerializer() {
+			super( byte[].class );
+		}
+
+		@Override
+		public boolean isEmpty(SerializationContext prov, byte[] value) {
+			return value.length == 0;
+		}
+
+		@Override
+		public void serialize(byte[] value, JsonGenerator g, SerializationContext provider) throws JacksonException {
+			g.writeString( PrimitiveByteArrayJavaType.INSTANCE.toString( value ) );
+		}
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/basic/JsonJavaTimeMappingTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/basic/JsonJavaTimeMappingTests.java
@@ -1,0 +1,148 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.mapping.basic;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.cfg.AvailableSettings;
+import org.hibernate.metamodel.mapping.internal.BasicAttributeMapping;
+import org.hibernate.metamodel.spi.MappingMetamodelImplementor;
+import org.hibernate.persister.entity.EntityPersister;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.ServiceRegistry;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.hibernate.testing.orm.junit.Setting;
+import org.hibernate.type.SqlTypes;
+import org.hibernate.type.descriptor.jdbc.JdbcType;
+import org.hibernate.type.descriptor.jdbc.spi.JdbcTypeRegistry;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.Serializable;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.ZoneId;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.isA;
+import static org.hamcrest.Matchers.nullValue;
+
+@DomainModel(annotatedClasses = JsonJavaTimeMappingTests.EntityWithJson.class)
+@SessionFactory
+public abstract class JsonJavaTimeMappingTests {
+
+	@ServiceRegistry(settings = @Setting(name = AvailableSettings.JSON_FORMAT_MAPPER, value = "jackson"))
+	public static class Jackson extends JsonJavaTimeMappingTests {
+
+		public Jackson() {
+			super();
+		}
+	}
+
+	@ServiceRegistry(settings = @Setting(name = AvailableSettings.JSON_FORMAT_MAPPER, value = "jackson3"))
+	public static class Jackson3 extends JsonJavaTimeMappingTests {
+
+		public Jackson3() {
+			super();
+		}
+	}
+
+	private final JavaTime javaTime;
+
+	protected JsonJavaTimeMappingTests() {
+		final var localDate = LocalDate.of( 2025, 12, 1 );
+		final var localTime = LocalTime.of( 9, 9, 42 );
+		final var localDateTime = LocalDateTime.of( localDate, localTime );
+		final var instant = localDateTime.atZone( ZoneId.of( "Europe/Paris" ) ).toInstant();
+		final var duration = Duration.ofHours( 3 ).plusMinutes( 14 );
+		javaTime = new JavaTime( instant, localDateTime, localDate, localTime, duration );
+	}
+
+	@BeforeEach
+	public void setup(SessionFactoryScope scope) {
+		scope.inTransaction(
+				(session) -> {
+					session.persist( new EntityWithJson( 1, javaTime ) );
+				}
+		);
+	}
+
+	@AfterEach
+	public void tearDown(SessionFactoryScope scope) {
+		scope.getSessionFactory().getSchemaManager().truncate();
+	}
+
+	@Test
+	public void verifyMappings(SessionFactoryScope scope) {
+		final MappingMetamodelImplementor mappingMetamodel = scope.getSessionFactory()
+				.getRuntimeMetamodels()
+				.getMappingMetamodel();
+		final EntityPersister entityDescriptor = mappingMetamodel.findEntityDescriptor( EntityWithJson.class );
+		final JdbcTypeRegistry jdbcTypeRegistry = mappingMetamodel.getTypeConfiguration().getJdbcTypeRegistry();
+
+		final BasicAttributeMapping stringMapAttribute = (BasicAttributeMapping) entityDescriptor.findAttributeMapping(
+				"javaTime" );
+
+		assertThat( stringMapAttribute.getJavaType().getJavaTypeClass(), equalTo( JavaTime.class ) );
+
+		final JdbcType jsonType = jdbcTypeRegistry.getDescriptor( SqlTypes.JSON );
+		assertThat( stringMapAttribute.getJdbcMapping().getJdbcType(), isA( jsonType.getClass() ) );
+	}
+
+	@Test
+	public void verifyReadWorks(SessionFactoryScope scope) {
+		scope.inTransaction(
+				(session) -> {
+					EntityWithJson entityWithJson = session.find( EntityWithJson.class, 1 );
+					assertThat( entityWithJson.javaTime, is( javaTime ) );
+				}
+		);
+	}
+
+	@Test
+	public void verifyMergeWorks(SessionFactoryScope scope) {
+		scope.inTransaction(
+				(session) -> session.merge( new EntityWithJson( 2, null ) )
+		);
+
+		scope.inTransaction(
+				(session) -> {
+					EntityWithJson entityWithJson = session.find( EntityWithJson.class, 2 );
+					assertThat( entityWithJson.javaTime, is( nullValue() ) );
+				}
+		);
+	}
+
+	public record JavaTime(Instant instant, LocalDateTime localDateTime, LocalDate localDate, LocalTime localTime,
+						Duration duration) implements Serializable {
+	}
+
+	@Entity(name = "EntityWithJson")
+	@Table(name = "EntityWithJson")
+	public static class EntityWithJson {
+		@Id
+		private Integer id;
+
+		@JdbcTypeCode(SqlTypes.JSON)
+		private JavaTime javaTime;
+
+		public EntityWithJson() {
+		}
+
+		public EntityWithJson(Integer id, JavaTime javaTime) {
+			this.id = id;
+			this.javaTime = javaTime;
+		}
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/basic/JsonMappingTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/basic/JsonMappingTests.java
@@ -78,6 +78,14 @@ public abstract class JsonMappingTests {
 		}
 	}
 
+	@ServiceRegistry(settings = @Setting(name = AvailableSettings.JSON_FORMAT_MAPPER, value = "jackson3"))
+	public static class Jackson3 extends JsonMappingTests {
+
+		public Jackson3() {
+			super( false );
+		}
+	}
+
 	private final Map<String, String> stringMap;
 	private final Map<StringNode, StringNode> objectMap;
 	private final List<StringNode> list;
@@ -147,6 +155,7 @@ public abstract class JsonMappingTests {
 					assertThat( entityWithJson.objectMap, is( objectMap ) );
 					assertThat( entityWithJson.list, is( list ) );
 					assertThat( entityWithJson.jsonNode, is( nullValue() ) );
+					assertThat( entityWithJson.jackson3JsonNode, is( nullValue() ) );
 					assertThat( entityWithJson.jsonValue, is( nullValue() ) );
 				}
 		);
@@ -168,6 +177,7 @@ public abstract class JsonMappingTests {
 					assertThat( entityWithJson.list, is( nullValue() ) );
 					assertThat( entityWithJson.jsonString, is( nullValue() ) );
 					assertThat( entityWithJson.jsonNode, is( nullValue() ) );
+					assertThat( entityWithJson.jackson3JsonNode, is( nullValue() ) );
 					assertThat( entityWithJson.jsonValue, is( nullValue() ) );
 					assertThat( entityWithJson.complexMap, is( nullValue() ) );
 				}
@@ -300,6 +310,9 @@ public abstract class JsonMappingTests {
 
 		@JdbcTypeCode( SqlTypes.JSON )
 		private JsonNode jsonNode;
+
+		@JdbcTypeCode( SqlTypes.JSON )
+		private tools.jackson.databind.JsonNode jackson3JsonNode;
 
 		@JdbcTypeCode( SqlTypes.JSON )
 		private JsonValue jsonValue;

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/basic/PolymorphicJsonTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/basic/PolymorphicJsonTests.java
@@ -50,6 +50,13 @@ public abstract class PolymorphicJsonTests {
 		}
 	}
 
+	@ServiceRegistry(settings = @Setting(name = AvailableSettings.JSON_FORMAT_MAPPER, value = "jackson3"))
+	public static class Jackson3 extends PolymorphicJsonTests {
+
+		public Jackson3() {
+		}
+	}
+
 	@BeforeEach
 	public void setup(SessionFactoryScope scope) {
 		scope.inTransaction(

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/basic/XmlMappingTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/basic/XmlMappingTests.java
@@ -68,6 +68,14 @@ public abstract class XmlMappingTests {
 		}
 	}
 
+	@ServiceRegistry(settings = @Setting(name = AvailableSettings.XML_FORMAT_MAPPER, value = "jackson3-xml"))
+	public static class Jackson3 extends XmlMappingTests {
+
+		public Jackson3() {
+			super( false );
+		}
+	}
+
 
 	private final Map<String, StringNode> stringMap;
 	private final Map<StringNode, StringNode> objectMap;

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/type/format/XmlFormatterTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/type/format/XmlFormatterTest.java
@@ -13,6 +13,7 @@ import org.hibernate.type.descriptor.WrapperOptions;
 import org.hibernate.type.descriptor.java.JavaType;
 import org.hibernate.type.descriptor.java.PrimitiveByteArrayJavaType;
 import org.hibernate.type.format.FormatMapper;
+import org.hibernate.type.format.jackson.Jackson3XmlFormatMapper;
 import org.hibernate.type.format.jackson.JacksonXmlFormatMapper;
 import org.hibernate.type.format.jaxb.JaxbXmlFormatMapper;
 import org.hibernate.type.internal.ParameterizedTypeImpl;
@@ -61,7 +62,7 @@ public class XmlFormatterTest implements SessionFactoryScopeAware {
 	}
 
 	private static Stream<Arguments> formatMappers() {
-		return Stream.of( new JaxbXmlFormatMapper( false ), new JacksonXmlFormatMapper( false ) )
+		return Stream.of( new JaxbXmlFormatMapper( false ), new JacksonXmlFormatMapper( false ), new Jackson3XmlFormatMapper( false ) )
 				.map( Arguments::of );
 	}
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -83,6 +83,7 @@ dependencyResolutionManagement {
             def hibernateModelsVersion = version "hibernateModels", "1.0.1"
             def jandexVersion = version "jandex", "3.3.2"
             def jacksonVersion = version "jackson", "2.19.4"
+            def jackson3Version = version "jackson3", "3.0.3"
             def jbossLoggingVersion = version "jbossLogging", "3.6.1.Final"
             def jbossLoggingToolVersion = version "jbossLoggingTool", "3.0.4.Final"
 
@@ -118,6 +119,9 @@ dependencyResolutionManagement {
             library( "jackson", "com.fasterxml.jackson.core", "jackson-databind" ).versionRef( jacksonVersion )
             library( "jacksonXml", "com.fasterxml.jackson.dataformat", "jackson-dataformat-xml" ).versionRef( jacksonVersion )
             library( "jacksonJsr310", "com.fasterxml.jackson.datatype", "jackson-datatype-jsr310" ).versionRef( jacksonVersion )
+
+            library( "jackson3", "tools.jackson.core", "jackson-databind" ).versionRef( jackson3Version )
+            library( "jackson3Xml", "tools.jackson.dataformat", "jackson-dataformat-xml" ).versionRef( jackson3Version )
 
             library( "agroal", "io.agroal", "agroal-api" ).versionRef( agroalVersion )
             library( "agroalPool", "io.agroal", "agroal-pool" ).versionRef( agroalVersion )


### PR DESCRIPTION
<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

This adds Jackson 3 support alongside the existing Jackson 2 support.

1. Automatic detection order now includes Jackson 3.
JSON order is now Jackson 2 with OSON, Jackson 2, Jackson 3, Jakarta JSON B.
XML order is now Jackson 2, Jackson 3, JAXB.
2. OSON doesn't support Jackson 3 right now, so it isn't included.
3. There is duplicate code between the Jackson 2 and Jackson 3 support. There could likely be some refactoring done to reduce this if that's desired (either in this PR or a separate one).
4. I didn't test this in a separate project or anything, just `./gradlew clean build`.

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-19890
<!-- Hibernate GitHub Bot issue links end -->