### PR TITLE
HHH-9456 Default not null for ElementColleciton Map values 

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/boot/model/internal/AnnotatedColumn.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/internal/AnnotatedColumn.java
@@ -1045,8 +1045,7 @@ public class AnnotatedColumn {
 //			column.setComment( comment.value() );
 //		}
 		//not following the spec but more clean
-		if ( nullability != Nullability.FORCED_NULL
-				&& !PropertyBinder.isOptional( inferredData.getAttributeMember(), propertyHolder ) ) {
+		if ( shouldOverrideNullability( nullability, inferredData, propertyHolder, suffixForDefaultColumnName ) ) {
 			column.setNullable( false );
 		}
 		final String propertyName = inferredData.getPropertyName();
@@ -1071,6 +1070,16 @@ public class AnnotatedColumn {
 		}
 		column.bind();
 		return columns;
+	}
+
+	private static boolean shouldOverrideNullability(
+			Nullability nullability,
+			PropertyData inferredData,
+			PropertyHolder propertyHolder,
+			String suffixForDefaultColumnName) {
+		return ( suffixForDefaultColumnName == null && nullability == Nullability.FORCED_NOT_NULL)
+			|| ( nullability != Nullability.FORCED_NULL
+					&& !PropertyBinder.isOptional( inferredData.getAttributeMember(), propertyHolder ) );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/model/internal/CollectionBinder.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/internal/CollectionBinder.java
@@ -241,10 +241,12 @@ public abstract class CollectionBinder {
 		collectionBinder.setOnDeleteActionAction( onDeleteAction( memberDetails ) );
 		collectionBinder.setInheritanceStatePerClass( inheritanceStatePerClass );
 		collectionBinder.setDeclaringClass( inferredData.getDeclaringClass() );
+		final var elementNullability = collectionBinder.isMap() && elementCollectionAnn != null ?
+				Nullability.FORCED_NOT_NULL : nullability;
 
 		collectionBinder.setElementColumns( elementColumns(
 				propertyHolder,
-				nullability,
+				elementNullability,
 				entityBinder,
 				context,
 				memberDetails,

--- a/migration-guide.adoc
+++ b/migration-guide.adoc
@@ -117,6 +117,8 @@ Such changes typically do not impact programs using a relational schema managed 
 
 Columns mapped by `@Version` fields are now declared `not null` by default.
 
+`Map` values in `@ElementCollection` are now declared `not null` by default.
+
 [[dependency-changes]]
 == Changes in Dependencies
 


### PR DESCRIPTION
The original bug report proposed allowing null values for Maps in an `@ElementCollection`, which would be a breaking change. Since this behavior doesn’t align with Hibernate’s existing handling of null Map values, this work instead aligns schema generation with expected behavior by defaulting the value column to `not null`.

----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
https://hibernate.atlassian.net/browse/HHH-9456


---
<!-- Hibernate GitHub Bot task list start -->
Please make sure that the following tasks are completed:
Tasks specific to HHH-9456 (Bug):
- [x] Add test reproducing the bug
- [x] Add entries as relevant to `migration-guide.adoc` **OR** check there are no breaking changes


<!-- Hibernate GitHub Bot task list end -->