### PR TITLE
HHH-11810 Fix double version increment with OPTIMISTIC_FORCE_INCREMENT and dirty entity

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/action/internal/EntityIncrementVersionProcess.java
+++ b/hibernate-core/src/main/java/org/hibernate/action/internal/EntityIncrementVersionProcess.java
@@ -7,6 +7,7 @@ package org.hibernate.action.internal;
 import org.hibernate.action.spi.BeforeTransactionCompletionProcess;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.internal.OptimisticLockHelper;
+import org.hibernate.persister.entity.EntityPersister;
 
 /**
  * A {@link BeforeTransactionCompletionProcess} implementation to verify and
@@ -17,14 +18,17 @@ import org.hibernate.internal.OptimisticLockHelper;
  */
 public class EntityIncrementVersionProcess implements BeforeTransactionCompletionProcess {
 	private final Object object;
+	private final Object lockVersion;
 
 	/**
 	 * Constructs an EntityIncrementVersionProcess for the given entity.
 	 *
 	 * @param object The entity instance
+	 * @param lockVersion The entity version at lock time
 	 */
-	public EntityIncrementVersionProcess(Object object) {
+	public EntityIncrementVersionProcess(Object object, Object lockVersion) {
 		this.object = object;
+		this.lockVersion = lockVersion;
 	}
 
 	/**
@@ -37,6 +41,16 @@ public class EntityIncrementVersionProcess implements BeforeTransactionCompletio
 		final var entry = session.getPersistenceContext().getEntry( object );
 		// Don't increment the version for an entity that is not in the PersistenceContext
 		if ( entry != null ) {
+			if ( lockVersion != null ) {
+				final EntityPersister persister = entry.getPersister();
+				if ( persister.isVersioned() ) {
+					// if the entity version is different than the version we locked, the version
+					// was already incremented (e.g. via flushing dirty properties)
+					if ( !persister.getVersionType().isEqual( entry.getVersion(), lockVersion ) ) {
+						return;
+					}
+				}
+			}
 			OptimisticLockHelper.forceVersionIncrement( object, entry, session.asEventSource() );
 		}
 	}

--- a/hibernate-core/src/main/java/org/hibernate/dialect/lock/OptimisticForceIncrementLockingStrategy.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/lock/OptimisticForceIncrementLockingStrategy.java
@@ -47,7 +47,7 @@ public class OptimisticForceIncrementLockingStrategy implements LockingStrategy 
 	public void lock(Object id, Object version, Object object, int timeout, EventSource session) {
 //		final EntityEntry entry = session.getPersistenceContextInternal().getEntry( object );
 		// Register the EntityIncrementVersionProcess action to run just prior to transaction commit.
-		session.getActionQueue().registerCallback( new EntityIncrementVersionProcess( object ) );
+		session.getActionQueue().registerCallback( new EntityIncrementVersionProcess( object, version ) );
 	}
 
 	protected LockMode getLockMode() {

--- a/hibernate-core/src/main/java/org/hibernate/event/internal/DefaultPostLoadEventListener.java
+++ b/hibernate-core/src/main/java/org/hibernate/event/internal/DefaultPostLoadEventListener.java
@@ -52,7 +52,7 @@ public class DefaultPostLoadEventListener implements PostLoadEventListener, Call
 						break;
 					case OPTIMISTIC_FORCE_INCREMENT:
 						session.getActionQueue()
-								.registerCallback( new EntityIncrementVersionProcess( entity ) );
+								.registerCallback( new EntityIncrementVersionProcess( entity, entry.getVersion() ) );
 						break;
 					case OPTIMISTIC:
 						session.getActionQueue()

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/flush/OptimisticForceIncrementNotIncrementedOnFlushTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/flush/OptimisticForceIncrementNotIncrementedOnFlushTest.java
@@ -1,0 +1,86 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.flush;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.LockModeType;
+import jakarta.persistence.Version;
+
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+/**
+ * Test case for HHH-11810
+ */
+@DomainModel(annotatedClasses = OptimisticForceIncrementNotIncrementedOnFlushTest.MyEntity.class)
+@SessionFactory
+public class OptimisticForceIncrementNotIncrementedOnFlushTest {
+
+	@Test
+	public void hhh123Test(SessionFactoryScope scope) {
+		scope.inTransaction( session -> {
+			MyEntity toPersist = new MyEntity( 0 );
+			toPersist.setData( "sample v1" );
+			session.persist( toPersist );
+		} );
+
+		scope.inTransaction( session -> {
+			MyEntity toUpdate = session.find( MyEntity.class, 0L );
+			session.lock( toUpdate, LockModeType.OPTIMISTIC_FORCE_INCREMENT );
+			toUpdate.setData( "sample v2" );
+			session.flush();
+
+			long versionAfterFlush = toUpdate.getVersion();
+			assertThat( versionAfterFlush ).isEqualTo( 1L );
+		} );
+
+		scope.inTransaction( session -> {
+			MyEntity afterUpdate = session.find( MyEntity.class, 0L );
+			assertThat( afterUpdate.getVersion() ).isEqualTo( 1L );
+		} );
+	}
+
+	@Entity(name = "MyEntity")
+	public static class MyEntity {
+
+		@Id
+		private long id;
+
+		private String data;
+
+		@Version
+		private long version;
+
+		public MyEntity(long id) {
+			this.id = id;
+			version = 0;
+		}
+
+		public MyEntity() {
+		}
+
+		public long getId() {
+			return id;
+		}
+
+		public long getVersion() {
+			return version;
+		}
+
+		public String getData() {
+			return data;
+		}
+
+		public void setData(String data) {
+			this.data = data;
+		}
+
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/flush/OptimisticForceIncrementNotIncrementedOnFlushTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/flush/OptimisticForceIncrementNotIncrementedOnFlushTest.java
@@ -10,6 +10,7 @@ import jakarta.persistence.LockModeType;
 import jakarta.persistence.Version;
 
 import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.JiraKey;
 import org.hibernate.testing.orm.junit.SessionFactory;
 import org.hibernate.testing.orm.junit.SessionFactoryScope;
 import org.junit.jupiter.api.Test;
@@ -19,12 +20,13 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 /**
  * Test case for HHH-11810
  */
+@JiraKey("HHH-11810")
 @DomainModel(annotatedClasses = OptimisticForceIncrementNotIncrementedOnFlushTest.MyEntity.class)
 @SessionFactory
 public class OptimisticForceIncrementNotIncrementedOnFlushTest {
 
 	@Test
-	public void hhh123Test(SessionFactoryScope scope) {
+	public void hhh11810Test(SessionFactoryScope scope) {
 		scope.inTransaction( session -> {
 			MyEntity toPersist = new MyEntity( 0 );
 			toPersist.setData( "sample v1" );

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/inheritance/version/TablePerClassAbstractRootTypeVersionUpdateTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/inheritance/version/TablePerClassAbstractRootTypeVersionUpdateTest.java
@@ -42,7 +42,7 @@ public class TablePerClassAbstractRootTypeVersionUpdateTest {
 			session.flush();
 			assertThat( dog.getVersion() ).isEqualTo( 1L );
 		} );
-		scope.inSession( session -> assertThat( session.find( Dog.class, 1L ).getVersion() ).isEqualTo( 2L ) );
+		scope.inSession( session -> assertThat( session.find( Dog.class, 1L ).getVersion() ).isEqualTo( 1L ) );
 	}
 
 	@Test


### PR DESCRIPTION
**Description**:

- This PR fixes a bug where using `LockMode.OPTIMISTIC_FORCE_INCREMENT` on an entity that is also modified in the same transaction causes the version to be incremented twice.
- Currently, the version increments happen in two places:
- During flush, `DefaultFlushEntityEventListener` increments the version because the entity is dirty.
- During `beforeTransactionCompletion`, `EntityIncrementVersionProcess` unconditionally forces another version increment because of the lock mode.

**Changes**:

- Updated `EntityIncrementVersionProcess` to accept the `lockVersion` (the version of the entity at the time the lock was requested).
- In `EntityIncrementVersionProcess.doBeforeTransactionCompletion`, added a check to compare the current entity version against the `lockVersion`.
- If the versions differ, it indicates the version has already been advanced (likely by a flush of dirty properties), so the forced increment is skipped.
- Updated `OptimisticForceIncrementLockingStrategy` to pass the version to the process constructor.
- This ensures the version increases by exactly 1, satisfying the `OPTIMISTIC_FORCE_INCREMENT` contract without double-counting updates.

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-11810
<!-- Hibernate GitHub Bot issue links end -->