### PR TITLE
HHH-19204: Remove unwrap support for java.sql.Date/Time

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/LocalDateTimeJavaType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/LocalDateTimeJavaType.java
@@ -101,17 +101,7 @@ public class LocalDateTimeJavaType extends AbstractTemporalJavaType<LocalDateTim
 			return type.cast( Timestamp.valueOf( value ) );
 		}
 
-		if ( java.sql.Date.class.isAssignableFrom( type ) ) {
-			final var instant = value.atZone( ZoneId.systemDefault() ).toInstant();
-			return type.cast( java.sql.Date.from( instant ) );
-		}
-
-		if ( java.sql.Time.class.isAssignableFrom( type ) ) {
-			final var instant = value.atZone( ZoneId.systemDefault() ).toInstant();
-			return type.cast( java.sql.Time.from( instant ) );
-		}
-
-		if ( Date.class.isAssignableFrom( type ) ) {
+		if ( Date.class.isAssignableFrom( type ) && !java.sql.Date.class.isAssignableFrom( type ) && !java.sql.Time.class.isAssignableFrom( type ) ) {
 			final var instant = value.atZone( ZoneId.systemDefault() ).toInstant();
 			return type.cast( Date.from( instant ) );
 		}

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/LocalDateTimeJavaType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/LocalDateTimeJavaType.java
@@ -101,11 +101,6 @@ public class LocalDateTimeJavaType extends AbstractTemporalJavaType<LocalDateTim
 			return type.cast( Timestamp.valueOf( value ) );
 		}
 
-		if ( Date.class.isAssignableFrom( type ) && !java.sql.Date.class.isAssignableFrom( type ) && !java.sql.Time.class.isAssignableFrom( type ) ) {
-			final var instant = value.atZone( ZoneId.systemDefault() ).toInstant();
-			return type.cast( Date.from( instant ) );
-		}
-
 		if ( Calendar.class.isAssignableFrom( type ) ) {
 			return type.cast( GregorianCalendar.from( value.atZone( ZoneId.systemDefault() ) ) );
 		}

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/OffsetDateTimeJavaType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/OffsetDateTimeJavaType.java
@@ -165,15 +165,7 @@ public class OffsetDateTimeJavaType extends AbstractTemporalJavaType<OffsetDateT
 			}
 		}
 
-		if ( java.sql.Date.class.isAssignableFrom( type ) ) {
-			return type.cast( java.sql.Date.from( offsetDateTime.toInstant() ) );
-		}
-
-		if ( java.sql.Time.class.isAssignableFrom( type ) ) {
-			return type.cast( java.sql.Time.from( offsetDateTime.toInstant() ) );
-		}
-
-		if ( Date.class.isAssignableFrom( type ) ) {
+		if ( Date.class.isAssignableFrom( type ) && !java.sql.Date.class.isAssignableFrom( type ) && !java.sql.Time.class.isAssignableFrom( type ) ) {
 			return type.cast( Date.from( offsetDateTime.toInstant() ) );
 		}
 

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/OffsetDateTimeJavaType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/OffsetDateTimeJavaType.java
@@ -165,10 +165,6 @@ public class OffsetDateTimeJavaType extends AbstractTemporalJavaType<OffsetDateT
 			}
 		}
 
-		if ( Date.class.isAssignableFrom( type ) && !java.sql.Date.class.isAssignableFrom( type ) && !java.sql.Time.class.isAssignableFrom( type ) ) {
-			return type.cast( Date.from( offsetDateTime.toInstant() ) );
-		}
-
 		if ( Long.class.isAssignableFrom( type ) ) {
 			return type.cast( offsetDateTime.toInstant().toEpochMilli() );
 		}

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/ZonedDateTimeJavaType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/ZonedDateTimeJavaType.java
@@ -129,10 +129,6 @@ public class ZonedDateTimeJavaType extends AbstractTemporalJavaType<ZonedDateTim
 			}
 		}
 
-		if ( Date.class.isAssignableFrom( type ) && !java.sql.Date.class.isAssignableFrom( type ) && !java.sql.Time.class.isAssignableFrom( type ) ) {
-			return type.cast( Date.from( zonedDateTime.toInstant() ) );
-		}
-
 		if ( Long.class.isAssignableFrom( type ) ) {
 			return type.cast( zonedDateTime.toInstant().toEpochMilli() );
 		}

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/ZonedDateTimeJavaType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/java/ZonedDateTimeJavaType.java
@@ -129,15 +129,7 @@ public class ZonedDateTimeJavaType extends AbstractTemporalJavaType<ZonedDateTim
 			}
 		}
 
-		if ( java.sql.Date.class.isAssignableFrom( type ) ) {
-			return type.cast( java.sql.Date.from( zonedDateTime.toInstant() ) );
-		}
-
-		if ( java.sql.Time.class.isAssignableFrom( type ) ) {
-			return type.cast( java.sql.Time.from( zonedDateTime.toInstant() ) );
-		}
-
-		if ( Date.class.isAssignableFrom( type ) ) {
+		if ( Date.class.isAssignableFrom( type ) && !java.sql.Date.class.isAssignableFrom( type ) && !java.sql.Time.class.isAssignableFrom( type ) ) {
 			return type.cast( Date.from( zonedDateTime.toInstant() ) );
 		}
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/type/descriptor/java/DateTimeToSqlDateUnwrapTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/type/descriptor/java/DateTimeToSqlDateUnwrapTest.java
@@ -1,0 +1,63 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.type.descriptor.java;
+
+import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.ZonedDateTime;
+
+
+import org.hibernate.testing.orm.junit.JiraKey;
+import org.hibernate.type.descriptor.java.JavaType;
+import org.hibernate.type.descriptor.java.LocalDateTimeJavaType;
+import org.hibernate.type.descriptor.java.OffsetDateTimeJavaType;
+import org.hibernate.type.descriptor.java.ZonedDateTimeJavaType;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.fail;
+
+public class DateTimeToSqlDateUnwrapTest {
+
+	@Test
+	@JiraKey("HHH-19204")
+	public void testLocalDateTimeUnwrap() {
+		LocalDateTimeJavaType descriptor = new LocalDateTimeJavaType();
+		LocalDateTime value = LocalDateTime.now();
+
+		checkUnwrap(descriptor, value, java.sql.Date.class);
+		checkUnwrap(descriptor, value, java.sql.Time.class);
+	}
+
+	@Test
+	@JiraKey("HHH-19204")
+	public void testOffsetDateTimeUnwrap() {
+		OffsetDateTimeJavaType descriptor = new OffsetDateTimeJavaType();
+		OffsetDateTime value = OffsetDateTime.now();
+
+		checkUnwrap(descriptor, value, java.sql.Date.class);
+		checkUnwrap(descriptor, value, java.sql.Time.class);
+	}
+
+	@Test
+	@JiraKey("HHH-19204")
+	public void testZonedDateTimeUnwrap() {
+		ZonedDateTimeJavaType descriptor = new ZonedDateTimeJavaType();
+		ZonedDateTime value = ZonedDateTime.now();
+
+		checkUnwrap(descriptor, value, java.sql.Date.class);
+		checkUnwrap(descriptor, value, java.sql.Time.class);
+	}
+
+	private <T> void checkUnwrap(JavaType<T> descriptor, T value, Class<?> targetType) {
+		try {
+			descriptor.unwrap(value, (Class) targetType, null);
+		} catch (ClassCastException e) {
+			// before fix
+			fail("HHH-19204: ClassCastException occurred while unwrapping to " + targetType.getSimpleName());
+		} catch (Exception e) {
+			// after fix
+		}
+	}
+}


### PR DESCRIPTION
<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

Hello. I would like to contribute regarding [HHH-19204](https://hibernate.atlassian.net/browse/HHH-19204). Please excuse any awkward phrasing as I am using a translator because I am not fluent in English.

- Changes

  - In the unwrap methods of LocalDateTimeJavaType, OffsetDateTimeJavaType, and ZonedDateTimeJavaType, I have removed the branches related to java.sql.Date and java.sql.Time.
 

  - Also I added exception handling for java.sql.Date and java.sql.Time to the Date.class branch located below the removed sections.
  - I have added a test case to verify that the issue has been resolved.

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------


---
<!-- Hibernate GitHub Bot task list start -->
Please make sure that the following tasks are completed:
Tasks specific to HHH-19204 (Bug):
- [ ] Add test reproducing the bug
- [ ] Add entries as relevant to `migration-guide.adoc` **OR** check there are no breaking changes


<!-- Hibernate GitHub Bot task list end -->

[HHH-19204]: https://hibernate.atlassian.net/browse/HHH-19204?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ