### PR TITLE
Enable patch dependabot updates on all maintained branches

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,7 @@ registries:
     url: https://plugins.gradle.org/m2
     username: dummy # Required by dependabot
     password: dummy # Required by dependabot
+
 updates:
   - package-ecosystem: github-actions
     directory: "/"
@@ -112,6 +113,7 @@ updates:
           - "jakarta.*"
           - "org.glassfish*"
           - "org.eclipse:yasson"
+    target-branch: "main"
     ignore:
       # Avoid non-patch updates for complex dependencies and their implementation, even if we only use them for tests.
       - dependency-name: "org.hibernate*"
@@ -143,3 +145,255 @@ updates:
       # (see https://central.sonatype.com/artifact/org.apache.maven/maven-embedder/3.9.9/dependencies)
       - dependency-name: "org.slf4j:*"
         update-types: ["version-update:semver-major"]
+
+  - package-ecosystem: "gradle"
+    directory: "/"
+    registries:
+      - gradle-plugin-portal
+    schedule:
+      interval: "weekly"
+      day: "wednesday"
+    open-pull-requests-limit: 20
+    groups:
+      tooling-dependencies:
+        patterns:
+          # Note: Gradle tooling dependencies seem to be tied to the version of Gradle we use for building.
+          - "org.apache.ant*"
+          - "org.apache.maven:maven-plugin-api"
+          - "org.apache.maven:maven-project"
+          - "org.apache.maven.shared:file-management"
+          - "org.apache.maven.plugin-tools:maven-plugin-annotations"
+      hibernate:
+        patterns:
+          - "org.hibernate*"
+      jakarta:
+        patterns:
+          - "jakarta.*"
+          - "org.glassfish*"
+          - "org.eclipse:yasson"
+      # This group combines all other dependencies.
+      other-dependencies:
+        patterns:
+          - "*"
+    target-branch: "7.2"
+    commit-message:
+      prefix: "[7.2] "
+    ignore:
+      - dependency-name: "*"
+        update-types: [ "version-update:semver-major", "version-update:semver-minor" ]
+
+  - package-ecosystem: "gradle"
+    directory: "/"
+    registries:
+      - gradle-plugin-portal
+    schedule:
+      interval: "weekly"
+      day: "wednesday"
+    open-pull-requests-limit: 20
+    groups:
+      tooling-dependencies:
+        patterns:
+          # Note: Gradle tooling dependencies seem to be tied to the version of Gradle we use for building.
+          - "org.apache.ant*"
+          - "org.apache.maven:maven-plugin-api"
+          - "org.apache.maven:maven-project"
+          - "org.apache.maven.shared:file-management"
+          - "org.apache.maven.plugin-tools:maven-plugin-annotations"
+      hibernate:
+        patterns:
+          - "org.hibernate*"
+      jakarta:
+        patterns:
+          - "jakarta.*"
+          - "org.glassfish*"
+          - "org.eclipse:yasson"
+      # This group combines all other dependencies.
+      other-dependencies:
+        patterns:
+          - "*"
+    target-branch: "7.1"
+    commit-message:
+      prefix: "[7.1] "
+    ignore:
+      - dependency-name: "*"
+        update-types: [ "version-update:semver-major", "version-update:semver-minor" ]
+
+  - package-ecosystem: "gradle"
+    directory: "/"
+    registries:
+      - gradle-plugin-portal
+    schedule:
+      interval: "weekly"
+      day: "wednesday"
+    open-pull-requests-limit: 20
+    groups:
+      tooling-dependencies:
+        patterns:
+          # Note: Gradle tooling dependencies seem to be tied to the version of Gradle we use for building.
+          - "org.apache.ant*"
+          - "org.apache.maven:maven-plugin-api"
+          - "org.apache.maven:maven-project"
+          - "org.apache.maven.shared:file-management"
+          - "org.apache.maven.plugin-tools:maven-plugin-annotations"
+      hibernate:
+        patterns:
+          - "org.hibernate*"
+      jakarta:
+        patterns:
+          - "jakarta.*"
+          - "org.glassfish*"
+          - "org.eclipse:yasson"
+      # This group combines all other dependencies.
+      other-dependencies:
+        patterns:
+          - "*"
+    target-branch: "6.6"
+    commit-message:
+      prefix: "[6.6] "
+    ignore:
+      - dependency-name: "*"
+        update-types: [ "version-update:semver-major", "version-update:semver-minor" ]
+
+  - package-ecosystem: "gradle"
+    directory: "/"
+    registries:
+      - gradle-plugin-portal
+    schedule:
+      interval: "weekly"
+      day: "wednesday"
+    open-pull-requests-limit: 20
+    groups:
+      tooling-dependencies:
+        patterns:
+          # Note: Gradle tooling dependencies seem to be tied to the version of Gradle we use for building.
+          - "org.apache.ant*"
+          - "org.apache.maven:maven-plugin-api"
+          - "org.apache.maven:maven-project"
+          - "org.apache.maven.shared:file-management"
+          - "org.apache.maven.plugin-tools:maven-plugin-annotations"
+      hibernate:
+        patterns:
+          - "org.hibernate*"
+      jakarta:
+        patterns:
+          - "jakarta.*"
+          - "org.glassfish*"
+          - "org.eclipse:yasson"
+      # This group combines all other dependencies.
+      other-dependencies:
+        patterns:
+          - "*"
+    target-branch: "6.4"
+    commit-message:
+      prefix: "[6.4] "
+    ignore:
+      - dependency-name: "*"
+        update-types: [ "version-update:semver-major", "version-update:semver-minor" ]
+
+  - package-ecosystem: "gradle"
+    directory: "/"
+    registries:
+      - gradle-plugin-portal
+    schedule:
+      interval: "weekly"
+      day: "wednesday"
+    open-pull-requests-limit: 20
+    groups:
+      tooling-dependencies:
+        patterns:
+          # Note: Gradle tooling dependencies seem to be tied to the version of Gradle we use for building.
+          - "org.apache.ant*"
+          - "org.apache.maven:maven-plugin-api"
+          - "org.apache.maven:maven-project"
+          - "org.apache.maven.shared:file-management"
+          - "org.apache.maven.plugin-tools:maven-plugin-annotations"
+      hibernate:
+        patterns:
+          - "org.hibernate*"
+      jakarta:
+        patterns:
+          - "jakarta.*"
+          - "org.glassfish*"
+          - "org.eclipse:yasson"
+      # This group combines all other dependencies.
+      other-dependencies:
+        patterns:
+          - "*"
+    target-branch: "6.2"
+    commit-message:
+      prefix: "[6.2] "
+    ignore:
+      - dependency-name: "*"
+        update-types: [ "version-update:semver-major", "version-update:semver-minor" ]
+
+  - package-ecosystem: "gradle"
+    directory: "/"
+    registries:
+      - gradle-plugin-portal
+    schedule:
+      interval: "weekly"
+      day: "wednesday"
+    open-pull-requests-limit: 20
+    groups:
+      tooling-dependencies:
+        patterns:
+          # Note: Gradle tooling dependencies seem to be tied to the version of Gradle we use for building.
+          - "org.apache.ant*"
+          - "org.apache.maven:maven-plugin-api"
+          - "org.apache.maven:maven-project"
+          - "org.apache.maven.shared:file-management"
+          - "org.apache.maven.plugin-tools:maven-plugin-annotations"
+      hibernate:
+        patterns:
+          - "org.hibernate*"
+      jakarta:
+        patterns:
+          - "jakarta.*"
+          - "org.glassfish*"
+          - "org.eclipse:yasson"
+      # This group combines all other dependencies.
+      other-dependencies:
+        patterns:
+          - "*"
+    target-branch: "5.6"
+    commit-message:
+      prefix: "[5.6] "
+    ignore:
+      - dependency-name: "*"
+        update-types: [ "version-update:semver-major", "version-update:semver-minor" ]
+
+  - package-ecosystem: "gradle"
+    directory: "/"
+    registries:
+      - gradle-plugin-portal
+    schedule:
+      interval: "weekly"
+      day: "wednesday"
+    open-pull-requests-limit: 20
+    groups:
+      tooling-dependencies:
+        patterns:
+          # Note: Gradle tooling dependencies seem to be tied to the version of Gradle we use for building.
+          - "org.apache.ant*"
+          - "org.apache.maven:maven-plugin-api"
+          - "org.apache.maven:maven-project"
+          - "org.apache.maven.shared:file-management"
+          - "org.apache.maven.plugin-tools:maven-plugin-annotations"
+      hibernate:
+        patterns:
+          - "org.hibernate*"
+      jakarta:
+        patterns:
+          - "jakarta.*"
+          - "org.glassfish*"
+          - "org.eclipse:yasson"
+      # This group combines all other dependencies.
+      other-dependencies:
+        patterns:
+          - "*"
+    target-branch: "5.3"
+    commit-message:
+      prefix: "[5.3] "
+    ignore:
+      - dependency-name: "*"
+        update-types: [ "version-update:semver-major", "version-update:semver-minor" ]


### PR DESCRIPTION
I didn't want to copy that long groups config so I only copied the smaller groups and then added the one in the end to capture all other dependencies... I thought that this way it would be easier to read the config ... but if you think we should keep the full groups config, I can adjust that 🙂 


<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------


---
<!-- Hibernate GitHub Bot task list start -->
Please make sure that the following tasks are completed:
- [ ] Add test **OR** check there is no need for a test
- [ ] Update documentation as relevant: javadoc for changed API, `documentation/src/main/asciidoc/userguide` for all features, `documentation/src/main/asciidoc/introduction` for main features, links from existing documentation
- [ ] Add entries as relevant to `migration-guide.adoc` (breaking changes) and `whats-new.adoc` (new features/improvements)


<!-- Hibernate GitHub Bot task list end -->