### PR TITLE
HHH-20152: Avoid MultipleBagFetchException

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/sql/BaseSqmToSqlAstConverter.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/sql/BaseSqmToSqlAstConverter.java
@@ -8765,21 +8765,22 @@ public abstract class BaseSqmToSqlAstConverter<T extends Statement> extends Base
 								if ( shouldExplicitFetch( maxDepth, fetchable ) ) {
 									explicitFetch = true;
 								}
-								if ( currentBagRole != null
-										&& fetchable instanceof PluralAttributeMapping pluralAttributeMapping ) {
-									final var collectionClassification =
-											pluralAttributeMapping.getMappedType()
-													.getCollectionSemantics()
-													.getCollectionClassification();
-									if ( collectionClassification == CollectionClassification.BAG ) {
-										// To avoid a MultipleBagFetchException due to fetch profiles in a circular model,
-										// we skip join fetching in case we encounter an existing bag role
-										joined = false;
-									}
-								}
 							}
 //						}
 					}
+				}
+			}
+
+			// To avoid a MultipleBagFetchException, we skip join fetching
+			// in case we encounter an existing bag role
+			if ( currentBagRole != null
+					&& fetchable instanceof PluralAttributeMapping pluralAttributeMapping ) {
+				final var collectionClassification =
+						pluralAttributeMapping.getMappedType()
+								.getCollectionSemantics()
+								.getCollectionClassification();
+				if ( collectionClassification == CollectionClassification.BAG ) {
+					joined = false;
 				}
 			}
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/entitygraph/EntityGraphMultipleBagFetchTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/entitygraph/EntityGraphMultipleBagFetchTest.java
@@ -1,0 +1,267 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.entitygraph;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+
+import java.util.List;
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityGraph;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.criteria.CriteriaBuilder;
+import jakarta.persistence.criteria.CriteriaQuery;
+
+import org.hibernate.Hibernate;
+import org.hibernate.jpa.AvailableHints;
+import org.hibernate.loader.MultipleBagFetchException;
+import org.hibernate.testing.jdbc.SQLStatementInspector;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.JiraKey;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+@DomainModel(
+		annotatedClasses = {
+				EntityGraphMultipleBagFetchTest.Order.class,
+				EntityGraphMultipleBagFetchTest.Product.class,
+				EntityGraphMultipleBagFetchTest.Tag.class
+		}
+)
+@SessionFactory( useCollectingStatementInspector = true )
+@JiraKey( value = "HHH-20152" )
+public class EntityGraphMultipleBagFetchTest {
+
+	@BeforeAll
+	public void setUp( SessionFactoryScope scope ) {
+		scope.inTransaction(
+				session -> {
+					Product product = new Product();
+					product.setName( "test" );
+					Product product2 = new Product();
+					product2.setName( "test" );
+					Tag tag = new Tag();
+					tag.setName( "test" );
+					Order order = new Order();
+					order.setProducts( List.of( product, product2 ));
+					order.setTags( List.of( tag ));
+					session.persist( order );
+				}
+		);
+	}
+
+	@Test
+	void testWithoutEntityGraph( SessionFactoryScope scope ) {
+		SQLStatementInspector statementInspector = scope.getCollectingStatementInspector();
+		statementInspector.clear();
+
+		scope.inTransaction(
+				session -> {
+					EntityManager entityManager = session.unwrap( EntityManager.class );
+
+					List<Order> orders = entityManager
+						.createQuery( criteriaQuery( entityManager ) )
+						.getResultList();
+
+					// Expect three SELECT statements
+					statementInspector.assertExecutedCount( 3 );
+					statementInspector.assertAllSelect();
+					// First one fetches parent entity, subsequent selects for bags
+					for ( int i = 0; i < 3; i++ ) {
+						statementInspector.assertNumberOfJoins( i, 0 );
+					}
+
+					assertInitialized( orders.get( 0 ));
+				}
+		);
+	}
+
+	@Test
+	void testWithEntityGraph( SessionFactoryScope scope ) {
+		SQLStatementInspector statementInspector = scope.getCollectingStatementInspector();
+		statementInspector.clear();
+
+		scope.inTransaction(
+				session -> {
+					EntityManager entityManager = session.unwrap( EntityManager.class );
+
+					EntityGraph<Order> entityGraph = entityManager.createEntityGraph( Order.class );
+					entityGraph.addAttributeNodes( "products" );
+					entityGraph.addAttributeNodes( "tags" );
+
+					List<Order> orders = entityManager
+						.createQuery( criteriaQuery( entityManager ) )
+						.setHint( AvailableHints.HINT_SPEC_FETCH_GRAPH, entityGraph )
+						.getResultList();
+
+					// Expect two SELECT statements
+					statementInspector.assertExecutedCount( 2 );
+					statementInspector.assertAllSelect();
+					// First one join fetches first bag
+					statementInspector.assertNumberOfJoins( 0, 1 );
+					// Subsequent select for second bag
+					statementInspector.assertNumberOfJoins( 1, 0 );
+
+					assertInitialized( orders.get( 0 ));
+				}
+		);
+	}
+
+	@Test
+	void testWithJoinFetch( SessionFactoryScope scope ) {
+		scope.inTransaction(
+				session -> {
+					EntityManager entityManager = session.unwrap( EntityManager.class );
+
+					// Cannot explicitly join fetch multiple bags
+					Throwable e = assertThrows( IllegalArgumentException.class, () -> entityManager
+						.createQuery( "from EntityGraphMultipleBagFetchTest$Order o join fetch o.products join fetch o.tags" )
+						.getResultList() );
+					assertEquals( MultipleBagFetchException.class, e.getCause().getClass() );
+				}
+		);
+	}
+
+	@Test
+	void testUntypedQuery( SessionFactoryScope scope ) {
+		SQLStatementInspector statementInspector = scope.getCollectingStatementInspector();
+		statementInspector.clear();
+
+		scope.inTransaction(
+				session -> {
+					/* Un-typed query with result not assigned to actual type can still
+					return a unique result, if plural attribute with multiple entries
+					is fetched using subsequent select. */
+					Object order = session
+						.createQuery( "from EntityGraphMultipleBagFetchTest$Order" )
+						.uniqueResult();
+
+					statementInspector.assertExecutedCount( 3 );
+					statementInspector.assertAllSelect();
+					// First one fetches parent entity, subsequent selects for bags
+					for ( int i = 0; i < 3; i++ ) {
+						statementInspector.assertNumberOfJoins( i, 0 );
+					}
+
+					assertInitialized( (Order) order );
+				}
+		);
+	}
+
+	private CriteriaQuery<Order> criteriaQuery( EntityManager entityManager ) {
+		CriteriaBuilder criteriaBuilder = entityManager.getCriteriaBuilder();
+		CriteriaQuery<Order> criteriaQuery = criteriaBuilder.createQuery( Order.class );
+		criteriaQuery.from( Order.class );
+		return criteriaQuery;
+	}
+
+	private void assertInitialized( Order order ) {
+		assertTrue( Hibernate.isInitialized( order ) );
+		assertTrue( Hibernate.isInitialized( order.products ) );
+		assertTrue( Hibernate.isInitialized( order.tags ) );
+	}
+
+	@Entity
+	public static class Order {
+
+		@Id
+		@GeneratedValue
+		private long id;
+
+		@OneToMany( fetch = FetchType.EAGER, cascade = CascadeType.ALL )
+		@JoinColumn( name = "order_id" )
+		private List<Product> products;
+
+		@OneToMany( fetch = FetchType.EAGER, cascade = CascadeType.ALL )
+		@JoinColumn( name = "order_id" )
+		private List<Tag> tags;
+
+		public long getId() {
+			return this.id;
+		}
+
+		public void setId( long id ) {
+			this.id = id;
+		}
+
+		public List<Product> getProducts() {
+			return this.products;
+		}
+
+		public void setProducts( List<Product> products ) {
+			this.products = products;
+		}
+
+		public List<Tag> getTags() {
+			return this.tags;
+		}
+
+		public void setTags( List<Tag> tags ) {
+			this.tags = tags;
+		}
+	}
+
+	@Entity
+	public static class Product {
+
+		@Id
+		@GeneratedValue
+		private long id;
+
+		private String name;
+
+		public long getId() {
+			return this.id;
+		}
+
+		public void setId( long id ) {
+			this.id = id;
+		}
+
+		public String getName() {
+			return this.name;
+		}
+
+		public void setName( String name ) {
+			this.name = name;
+		}
+	}
+
+	@Entity
+	public static class Tag {
+
+		@Id
+		@GeneratedValue
+		private long id;
+
+		private String name;
+
+		public long getId() {
+			return this.id;
+		}
+
+		public void setId( long id ) {
+			this.id = id;
+		}
+
+		public String getName() {
+			return this.name;
+		}
+
+		public void setName( String name ) {
+			this.name = name;
+		}
+	}
+}

--- a/hibernate-testing/src/main/java/org/hibernate/testing/jdbc/SQLStatementInspector.java
+++ b/hibernate-testing/src/main/java/org/hibernate/testing/jdbc/SQLStatementInspector.java
@@ -109,6 +109,12 @@ public class SQLStatementInspector implements StatementInspector {
 		assertTrue( query.toLowerCase( Locale.ROOT ).startsWith( "select" ) );
 	}
 
+	public void assertAllSelect() {
+		Assertions.assertThat( sqlQueries )
+				.isNotEmpty()
+				.allSatisfy( sql -> Assertions.assertThat( sql.toLowerCase( Locale.ROOT ) ).startsWith( "select" ) );
+	}
+
 	public void assertIsInsert(int queryNumber) {
 		String query = sqlQueries.get( queryNumber );
 		assertTrue( query.toLowerCase( Locale.ROOT ).startsWith( "insert" ) );


### PR DESCRIPTION
While the changes do not strictly suffice the expectation mentioned in the [Issue](https://hibernate.atlassian.net/browse/HHH-20152), they make it possible to load entities with multiple bag-type attributes with an EntityGraph.

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------


---
<!-- Hibernate GitHub Bot task list start -->
Please make sure that the following tasks are completed:
Tasks specific to HHH-20152 (Bug):
- [x] Add test reproducing the bug
- [x] Add entries as relevant to `migration-guide.adoc` **OR** check there are no breaking changes


<!-- Hibernate GitHub Bot task list end -->
(I do not think it has to be considered a breaking change)