### PR TITLE
HHH-20234 DatasourceConnectionProviderImpl should extend DatasourceConnectionProvider

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/engine/jdbc/connections/internal/DatasourceConnectionProviderImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/jdbc/connections/internal/DatasourceConnectionProviderImpl.java
@@ -8,5 +8,5 @@ package org.hibernate.engine.jdbc.connections.internal;
  * @deprecated Use {@link DataSourceConnectionProvider}
  */
 @Deprecated(since = "7.1", forRemoval = true)
-public class DatasourceConnectionProviderImpl extends DriverManagerConnectionProvider {
+public class DatasourceConnectionProviderImpl extends DataSourceConnectionProvider {
 }


### PR DESCRIPTION
Backport of d571dd1112aebe65b9521c8a666fff8181c964af to 7.3.

---
<!-- Hibernate GitHub Bot task list start -->
Please make sure that the following tasks are completed:
Tasks specific to HHH-20234 (Bug):
- [ ] Add test reproducing the bug
- [ ] Add entries as relevant to `migration-guide.adoc` **OR** check there are no breaking changes


<!-- Hibernate GitHub Bot task list end -->

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-20234
<!-- Hibernate GitHub Bot issue links end -->