### PR TITLE
HHH-20241 Ensure that compilation fails if there was an ANTLR syntax error in the annotation processor

### DIFF
--- a/tooling/metamodel-generator/src/main/java/org/hibernate/processor/annotation/ErrorHandler.java
+++ b/tooling/metamodel-generator/src/main/java/org/hibernate/processor/annotation/ErrorHandler.java
@@ -16,6 +16,8 @@ import javax.lang.model.element.AnnotationMirror;
 import javax.lang.model.element.AnnotationValue;
 import javax.lang.model.element.Element;
 import javax.tools.Diagnostic;
+import java.io.PrintWriter;
+import java.io.StringWriter;
 import java.util.BitSet;
 
 import static org.hibernate.query.hql.internal.StandardHqlTranslator.prettifyAntlrError;
@@ -61,9 +63,23 @@ class ErrorHandler implements Validation.Handler {
 	@Override
 	public void syntaxError(Recognizer<?, ?> recognizer, Object offendingSymbol, int line, int charPositionInLine, String message, RecognitionException e) {
 		errorCount++;
-		String prettyMessage = "illegal HQL syntax - "
-				+ prettifyAntlrError( offendingSymbol, line, charPositionInLine, message, e, queryString, true );
-		context.message( element, mirror, value, prettyMessage, Diagnostic.Kind.ERROR );
+		String unprettyMessage = null;
+		String prettyMessage = "illegal HQL syntax - ";
+		try {
+			prettyMessage += prettifyAntlrError( offendingSymbol, line, charPositionInLine, message, e, queryString, true );
+		}
+		catch (Exception e1) {
+			StringWriter sw = new StringWriter();
+			e1.printStackTrace(new PrintWriter(sw));
+			unprettyMessage = prettyMessage + message;
+			prettyMessage = sw.toString();
+		}
+		finally {
+			if (unprettyMessage != null) {
+				context.message( element, mirror, value, unprettyMessage, Diagnostic.Kind.ERROR );
+			}
+			context.message( element, mirror, value, prettyMessage, Diagnostic.Kind.ERROR );
+		}
 	}
 
 	@Override


### PR DESCRIPTION
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------


---
<!-- Hibernate GitHub Bot task list start -->
Please make sure that the following tasks are completed:
Tasks specific to HHH-20241 (Bug):
- [x] Add test reproducing the bug
- [x] Add entries as relevant to `migration-guide.adoc` **OR** check there are no breaking changes


<!-- Hibernate GitHub Bot task list end -->

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-20241
<!-- Hibernate GitHub Bot issue links end -->