### PR TITLE
HHH-20276 : [Reproducer test] Add reproducer for IllegalArgumentException with @ConverterRegistration and generic entity

### DIFF
--- a/hibernate-core/src/test/java/org/hibernate/orm/test/boot/model/ConverterRegistrationWithGenericEntityTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/boot/model/ConverterRegistrationWithGenericEntityTest.java
@@ -1,0 +1,79 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.boot.model;
+
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Basic;
+import jakarta.persistence.Converter;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import org.hibernate.testing.orm.junit.EntityManagerFactoryScope;
+import org.hibernate.testing.orm.junit.JiraKey;
+import org.hibernate.testing.orm.junit.Jpa;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+
+/**
+ * Reproducer for HHH-20276.
+ * <p>
+ * When a {@link jakarta.persistence.AttributeConverter} is registered via
+ * {@link org.hibernate.annotations.ConverterRegistration} in a {@code package-info.java},
+ * and an entity has a generic type parameter bounded by another class (e.g. {@code Book<T extends Person>}),
+ * Hibernate throws an {@link IllegalArgumentException} during metamodel building with the message:
+ * <pre>
+ *     Book is not a subtype of Book
+ * </pre>
+ * The error originates from {@code GenericsHelper#typeArguments} which fails to resolve
+ * the actual member type of the entity when the registered conversions map
+ * ({@code AttributeConverterManager#registeredConversionsByDomainType}) is non-null —
+ * a code path only triggered when converters are registered via {@code @ConverterRegistration},
+ * and not when registered via {@code @Converter}.
+ *
+ * @author Vincent Bouthinon
+ * @see org.hibernate.boot.model.convert.internal.AttributeConverterManager
+ * @see org.hibernate.internal.util.GenericsHelper
+ */
+@Jpa(annotatedClasses = ConverterRegistrationWithGenericEntityTest.Book.class,
+		annotatedPackageNames = "org.hibernate.orm.test.boot.model")
+
+@JiraKey("HHH-20276")
+class ConverterRegistrationWithGenericEntityTest {
+
+	@Test
+	void testLogEntityWithAnyKeyJavaClassAsString(EntityManagerFactoryScope scope) {
+		assertThat(scope.getEntityManagerFactory()).isNotNull();
+	}
+
+	@Entity(name = "book")
+	public static class Book<T extends Person> {
+
+		@Id
+		@GeneratedValue
+		private Long id;
+
+		@Basic
+		private int isbn;
+	}
+
+	public static class Person {
+	}
+
+	@Converter
+	public static class TestConverter implements AttributeConverter<String, String> {
+
+		@Override
+		public String convertToDatabaseColumn(String attribute) {
+			return "";
+		}
+
+		@Override
+		public String convertToEntityAttribute(String dbData) {
+			return "";
+		}
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/boot/model/package-info.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/boot/model/package-info.java
@@ -1,0 +1,4 @@
+@ConverterRegistration(converter = ConverterRegistrationWithGenericEntityTest.TestConverter.class)
+package org.hibernate.orm.test.boot.model;
+
+import org.hibernate.annotations.ConverterRegistration;


### PR DESCRIPTION
Since Hibernate 7.3.0

When a AttributeConverter is registered via org.hibernate.annotations.ConverterRegistration in a package-info.java, and an entity has a generic type parameter bounded by another class (e.g. Book<T extends Person>), Hibernate throws an IllegalArgumentException during metamodel building with the message:
      Book is not a subtype of Book

The error originates from GenericsHelper#typeArguments which fails to resolve the actual member type of the entity when the registered conversions map (AttributeConverterManager#registeredConversionsByDomainType) is non-null — a code path only triggered when converters are registered via @ConverterRegistration, and not when registered via @Converter.

----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------

---
<!-- Hibernate GitHub Bot task list start -->
Please make sure that the following tasks are completed:
Tasks specific to HHH-20276 (Bug):
- [ ] Add test reproducing the bug
- [ ] Add entries as relevant to `migration-guide.adoc` **OR** check there are no breaking changes


<!-- Hibernate GitHub Bot task list end -->

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-20276
<!-- Hibernate GitHub Bot issue links end -->