### PR TITLE
HHH-16361 Pass Entity info into PhysicalNamingStrategy

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/boot/model/internal/AnnotatedColumn.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/internal/AnnotatedColumn.java
@@ -16,6 +16,7 @@ import org.hibernate.annotations.ColumnDefault;
 import org.hibernate.annotations.ColumnTransformer;
 import org.hibernate.annotations.FractionalSeconds;
 import org.hibernate.annotations.GeneratedColumn;
+import org.hibernate.boot.model.naming.ColumnNamingContext;
 import org.hibernate.boot.model.naming.Identifier;
 import org.hibernate.boot.model.naming.ImplicitBasicColumnNameSource;
 import org.hibernate.boot.model.naming.ImplicitNamingStrategy;
@@ -404,8 +405,11 @@ public class AnnotatedColumn {
 		if ( applyNamingStrategy ) {
 			final var database = getDatabase();
 			return getPhysicalNamingStrategy()
-					.toPhysicalColumnName( database.toIdentifier( columnName, isExplicit ),
-							database.getJdbcEnvironment() )
+					.toPhysicalColumnName(
+							database.toIdentifier( columnName, isExplicit ),
+							database.getJdbcEnvironment(),
+							new ColumnNamingContext( getParent() )
+					)
 					.render( database.getDialect() );
 		}
 		else {

--- a/hibernate-core/src/main/java/org/hibernate/boot/model/internal/AnnotatedJoinColumn.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/internal/AnnotatedJoinColumn.java
@@ -7,6 +7,7 @@ package org.hibernate.boot.model.internal;
 import org.hibernate.AnnotationException;
 import org.hibernate.AssertionFailure;
 import org.hibernate.annotations.JoinFormula;
+import org.hibernate.boot.model.naming.ColumnNamingContext;
 import org.hibernate.boot.model.naming.ImplicitNamingStrategy;
 import org.hibernate.boot.spi.MetadataBuildingContext;
 import org.hibernate.boot.spi.PropertyData;
@@ -375,7 +376,11 @@ public class AnnotatedJoinColumn extends AnnotatedColumn {
 			}
 		}
 //		else {
-			return parent.buildDefaultColumnName( referencedEntity, logicalReferencedColumn );
+		return parent.buildDefaultColumnName(
+				referencedEntity,
+				logicalReferencedColumn,
+				new ColumnNamingContext( parent )
+		);
 //		}
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/boot/model/internal/AnnotatedJoinColumns.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/internal/AnnotatedJoinColumns.java
@@ -16,6 +16,7 @@ import org.hibernate.annotations.JoinColumnOrFormula;
 import org.hibernate.annotations.JoinFormula;
 import org.hibernate.annotations.PropertyRef;
 import org.hibernate.boot.internal.FailedSecondPassException;
+import org.hibernate.boot.model.naming.ColumnNamingContext;
 import org.hibernate.boot.model.naming.EntityNaming;
 import org.hibernate.boot.model.naming.Identifier;
 import org.hibernate.boot.model.naming.ImplicitJoinColumnNameSource;
@@ -403,7 +404,10 @@ public class AnnotatedJoinColumns extends AnnotatedColumns {
 		}
 	}
 
-	String buildDefaultColumnName(PersistentClass referencedEntity, String logicalReferencedColumn) {
+	String buildDefaultColumnName(
+			PersistentClass referencedEntity,
+			String logicalReferencedColumn,
+			ColumnNamingContext columnNamingContext) {
 		final var context = getBuildingContext();
 		final var options = context.getBuildingOptions();
 		final var collector = context.getMetadataCollector();
@@ -417,7 +421,7 @@ public class AnnotatedJoinColumns extends AnnotatedColumns {
 				database
 		);
 		return options.getPhysicalNamingStrategy()
-				.toPhysicalColumnName( columnIdentifier, jdbcEnvironment )
+				.toPhysicalColumnName( columnIdentifier, jdbcEnvironment, columnNamingContext )
 				.render( jdbcEnvironment.getDialect() );
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/boot/model/internal/AuditHelper.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/internal/AuditHelper.java
@@ -9,6 +9,7 @@ import java.util.HashSet;
 import java.util.Set;
 
 import org.hibernate.annotations.Audited;
+import org.hibernate.boot.model.naming.ColumnNamingContext;
 import org.hibernate.boot.model.naming.Identifier;
 import org.hibernate.boot.model.naming.PhysicalNamingStrategy;
 import org.hibernate.boot.model.relational.Database;
@@ -78,17 +79,39 @@ public final class AuditHelper {
 		collector.addTableNameBinding( table.getNameIdentifier(), auditTable );
 		copyTableColumns( table, auditTable, excludedColumns );
 		final var transactionIdColumn =
-				createAuditColumn( audited.transactionId(),
-						getTransactionIdType( context ), auditTable, context );
-		final var modificationTypeColumn =
-				createAuditColumn( audited.modificationType(),
-						Byte.class, auditTable, context );
+				createAuditColumn(
+						audited.transactionId(),
+						getTransactionIdType( context ),
+						auditTable,
+						context,
+						determineColumnNamingContext( auditable )
+				);
+		final var modificationTypeColumn = createAuditColumn(
+				audited.modificationType(),
+				Byte.class,
+				auditTable,
+				context,
+				determineColumnNamingContext( auditable )
+		);
 		auditTable.addColumn( transactionIdColumn );
 		auditTable.addColumn( modificationTypeColumn );
 		enableAudit( auditable, auditTable, transactionIdColumn, modificationTypeColumn );
 
 		collector.addSecondPass( (OptionalDeterminationSecondPass) ignored ->
 				copyTableColumns( table, auditTable, excludedColumns ) );
+	}
+
+	private static ColumnNamingContext determineColumnNamingContext(Stateful auditable) {
+		if ( auditable instanceof RootClass rootClass ) {
+			return new ColumnNamingContext( rootClass.getEntityName(), rootClass.getClassName() );
+		}
+		if ( auditable instanceof Collection collection ) {
+			return new ColumnNamingContext(
+					collection.getOwnerEntityName(),
+					collection.getOwner().getClassName()
+			);
+		}
+		return null;
 	}
 
 	static void enableAudit(
@@ -118,7 +141,8 @@ public final class AuditHelper {
 			String columnName,
 			Class<?> javaType,
 			Table table,
-			MetadataBuildingContext context) {
+			MetadataBuildingContext context,
+			ColumnNamingContext columnNamingContext) {
 		final var basicValue = new BasicValue( context, table );
 		basicValue.setImplicitJavaTypeAccess( typeConfiguration -> javaType );
 		final var column = new Column();
@@ -127,7 +151,13 @@ public final class AuditHelper {
 		basicValue.addColumn( column );
 
 		final var database = context.getMetadataCollector().getDatabase();
-		setColumnName( columnName, column, database, context.getBuildingOptions().getPhysicalNamingStrategy() );
+		setColumnName(
+				columnName,
+				column,
+				database,
+				context.getBuildingOptions().getPhysicalNamingStrategy(),
+				columnNamingContext
+		);
 		setTemporalColumnType( column, database, javaType );
 
 		return column;
@@ -148,11 +178,13 @@ public final class AuditHelper {
 			String name,
 			Column column,
 			Database database,
-			PhysicalNamingStrategy physicalNamingStrategy) {
+			PhysicalNamingStrategy physicalNamingStrategy,
+			ColumnNamingContext columnNamingContext) {
 		final Identifier physicalColumnName =
 				physicalNamingStrategy.toPhysicalColumnName(
-					database.toIdentifier( name ),
-					database.getJdbcEnvironment()
+						database.toIdentifier( name ),
+						database.getJdbcEnvironment(),
+						columnNamingContext
 				);
 		column.setName( physicalColumnName.render( database.getDialect() ) );
 	}

--- a/hibernate-core/src/main/java/org/hibernate/boot/model/internal/EmbeddableBinder.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/internal/EmbeddableBinder.java
@@ -17,6 +17,7 @@ import jakarta.persistence.ManyToMany;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.OneToOne;
+
 import org.hibernate.AnnotationException;
 import org.hibernate.AssertionFailure;
 import org.hibernate.MappingException;
@@ -24,6 +25,7 @@ import org.hibernate.annotations.DiscriminatorFormula;
 import org.hibernate.annotations.EmbeddedColumnNaming;
 import org.hibernate.annotations.Instantiator;
 import org.hibernate.annotations.TypeBinderType;
+import org.hibernate.boot.model.naming.ColumnNamingContext;
 import org.hibernate.boot.model.naming.Identifier;
 import org.hibernate.boot.spi.AccessType;
 import org.hibernate.boot.spi.MetadataBuildingContext;
@@ -1352,8 +1354,14 @@ public class EmbeddableBinder {
 
 						final String physicalName =
 								physicalNamingStrategy
-										.toPhysicalColumnName( database.toIdentifier( columnName ),
-												database.getJdbcEnvironment() )
+										.toPhysicalColumnName(
+												database.toIdentifier( columnName ),
+												database.getJdbcEnvironment(),
+												new ColumnNamingContext(
+														embeddable.getOwner().getEntityName(),
+														embeddable.getOwner().getClassName()
+												)
+										)
 										.render( database.getDialect() );
 						value.addColumn( new org.hibernate.mapping.Column( physicalName ) );
 						if ( joinColumn != null ) {

--- a/hibernate-core/src/main/java/org/hibernate/boot/model/internal/EntityBinder.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/internal/EntityBinder.java
@@ -26,6 +26,7 @@ import jakarta.persistence.PrimaryKeyJoinColumns;
 import jakarta.persistence.SecondaryTable;
 import jakarta.persistence.SecondaryTables;
 import jakarta.persistence.UniqueConstraint;
+
 import org.hibernate.AnnotationException;
 import org.hibernate.AssertionFailure;
 import org.hibernate.MappingException;
@@ -67,6 +68,7 @@ import org.hibernate.annotations.TypeBinderType;
 import org.hibernate.annotations.View;
 import org.hibernate.boot.model.NamedEntityGraphDefinition;
 import org.hibernate.boot.model.internal.InheritanceState.ElementsToProcess;
+import org.hibernate.boot.model.naming.ColumnNamingContext;
 import org.hibernate.boot.model.naming.EntityNaming;
 import org.hibernate.boot.model.naming.Identifier;
 import org.hibernate.boot.model.naming.ImplicitEntityNameSource;
@@ -448,19 +450,34 @@ public class EntityBinder {
 		final var jpaTableUsage = annotatedClass.getAnnotationUsage( jakarta.persistence.Table.class, models );
 		if ( jpaTableUsage != null ) {
 			final var table = persistentClass.getTable();
-			TableBinder.addJpaIndexes( table, jpaTableUsage.indexes(), context );
+			TableBinder.addJpaIndexes(
+					table,
+					jpaTableUsage.indexes(),
+					context,
+					new ColumnNamingContext(
+							persistentClass.getEntityName(),
+							persistentClass.getClassName()
+					)
+			);
 			TableBinder.addTableCheck( table, jpaTableUsage.check() );
 			TableBinder.addTableComment( table, jpaTableUsage.comment() );
 			TableBinder.addTableOptions( table, jpaTableUsage.options() );
 		}
 
 		final var entityTableXref = getMetadataCollector().getEntityTableXref( persistentClass.getEntityName() );
-		annotatedClass.forEachAnnotationUsage( jakarta.persistence.SecondaryTable.class, models, (usage) -> {
-			final Identifier secondaryTableLogicalName = toIdentifier( usage.name() );
-			final var table = entityTableXref.resolveTable( secondaryTableLogicalName );
-			assert table != null;
-			TableBinder.addJpaIndexes( table, usage.indexes(), context );
-		} );
+		annotatedClass.forEachAnnotationUsage(
+				jakarta.persistence.SecondaryTable.class, models, (usage) -> {
+					final Identifier secondaryTableLogicalName = toIdentifier( usage.name() );
+					final var table = entityTableXref.resolveTable( secondaryTableLogicalName );
+					assert table != null;
+					TableBinder.addJpaIndexes(
+							table,
+							usage.indexes(),
+							context,
+							new ColumnNamingContext( persistentClass.getEntityName(), persistentClass.getClassName() )
+					);
+				}
+		);
 	}
 
 	private Set<String> handleIdClass(
@@ -1974,7 +1991,8 @@ public class EntityBinder {
 				uniqueConstraints,
 				context,
 				subselect,
-				denormalizedSuperTableXref
+				denormalizedSuperTableXref,
+				new ColumnNamingContext( persistentClass.getEntityName(), persistentClass.getClassName() )
 		);
 		table.setRowId( rowId );
 		table.setViewQuery( viewQuery );
@@ -2222,7 +2240,10 @@ public class EntityBinder {
 				secondaryTable.uniqueConstraints()
 		);
 		final var table = join.getTable();
-		new IndexBinder( context ).bindIndexes( table, secondaryTable.indexes() );
+		new IndexBinder(
+				context,
+				columnNamingContext( holder )
+		).bindIndexes( table, secondaryTable.indexes() );
 		TableBinder.addTableCheck( table, secondaryTable.check() );
 		TableBinder.addTableComment( table, secondaryTable.comment() );
 		TableBinder.addTableOptions( table, secondaryTable.options() );
@@ -2251,9 +2272,16 @@ public class EntityBinder {
 						logicalName.getTableName(),
 						false,
 						uniqueConstraints,
-						context
+						context,
+						columnNamingContext( propertyHolder )
 				)
 		);
+	}
+
+	private ColumnNamingContext columnNamingContext(PropertyHolder propertyHolder) {
+		return propertyHolder == null
+				? new ColumnNamingContext( persistentClass.getEntityName(), persistentClass.getClassName() )
+				: new ColumnNamingContext( propertyHolder );
 	}
 
 	private QualifiedTableName logicalTableName(String name, String schema, String catalog) {

--- a/hibernate-core/src/main/java/org/hibernate/boot/model/internal/IndexBinder.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/internal/IndexBinder.java
@@ -11,6 +11,7 @@ import java.util.StringTokenizer;
 
 import org.hibernate.AnnotationException;
 import org.hibernate.AssertionFailure;
+import org.hibernate.boot.model.naming.ColumnNamingContext;
 import org.hibernate.boot.model.naming.Identifier;
 import org.hibernate.boot.model.naming.ImplicitIndexNameSource;
 import org.hibernate.boot.model.naming.ImplicitNamingStrategy;
@@ -42,9 +43,11 @@ import static org.hibernate.internal.util.collections.CollectionHelper.arrayList
 class IndexBinder {
 
 	private final MetadataBuildingContext context;
+	private final ColumnNamingContext columnNamingContext;
 
-	IndexBinder(MetadataBuildingContext context) {
+	IndexBinder(MetadataBuildingContext context, ColumnNamingContext columnNamingContext) {
 		this.context = context;
+		this.columnNamingContext = columnNamingContext;
 	}
 
 	private Database getDatabase() {
@@ -107,7 +110,11 @@ class IndexBinder {
 		final Database database = getDatabase();
 		final String physicalName =
 				getPhysicalNamingStrategy()
-						.toPhysicalColumnName( database.toIdentifier( logicalName ), database.getJdbcEnvironment() )
+						.toPhysicalColumnName(
+								database.toIdentifier( logicalName ),
+								database.getJdbcEnvironment(),
+								columnNamingContext
+						)
 						.render( getDialect() );
 		return new Column( physicalName );
 	}
@@ -136,8 +143,8 @@ class IndexBinder {
 		final int size = columnNames.length;
 		if ( size == 0 ) {
 			throw new AnnotationException( "Unique constraint"
-					+ ( isEmpty( name ) ? "" : " '" + name + "'" )
-					+ " on table '" + table.getName() + "' has no columns" );
+												+ ( isEmpty( name ) ? "" : " '" + name + "'" )
+												+ " on table '" + table.getName() + "' has no columns" );
 		}
 		final Column[] columns = new Column[size];
 		for ( int index = 0; index < size; index++ ) {

--- a/hibernate-core/src/main/java/org/hibernate/boot/model/internal/PropertyHolder.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/internal/PropertyHolder.java
@@ -73,7 +73,7 @@ public interface PropertyHolder {
 	JoinColumn[] getOverriddenJoinColumn(String propertyName);
 
 	/**
-	 * return null if hte foreign key is not overridden, or the foreign key if true
+	 * return null if the foreign key is not overridden, or the foreign key if true
 	 */
 	default ForeignKey getOverriddenForeignKey(String propertyName) {
 		// todo: does this necessarily need to be a default method?

--- a/hibernate-core/src/main/java/org/hibernate/boot/model/internal/SoftDeleteHelper.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/internal/SoftDeleteHelper.java
@@ -8,10 +8,13 @@ import org.hibernate.annotations.SoftDelete;
 import org.hibernate.annotations.SoftDeleteType;
 import org.hibernate.boot.model.convert.internal.ConverterDescriptors;
 import org.hibernate.boot.model.convert.spi.ConverterDescriptor;
+import org.hibernate.boot.model.naming.ColumnNamingContext;
 import org.hibernate.boot.model.naming.Identifier;
 import org.hibernate.boot.spi.MetadataBuildingContext;
 import org.hibernate.mapping.BasicValue;
+import org.hibernate.mapping.Collection;
 import org.hibernate.mapping.Column;
+import org.hibernate.mapping.RootClass;
 import org.hibernate.mapping.SoftDeletable;
 import org.hibernate.mapping.Table;
 import org.hibernate.metamodel.UnsupportedMappingException;
@@ -47,10 +50,24 @@ public class SoftDeleteHelper {
 		final var softDeleteIndicatorColumn = createSoftDeleteIndicatorColumn(
 				softDeleteConfig,
 				createSoftDeleteIndicatorValue( softDeleteConfig, table, context ),
-				context
+				context,
+				determineColumnNamingContext( target )
 		);
 		table.addColumn( softDeleteIndicatorColumn );
 		target.enableSoftDelete( softDeleteIndicatorColumn, softDeleteConfig.strategy() );
+	}
+
+	private static ColumnNamingContext determineColumnNamingContext(SoftDeletable target) {
+		if ( target instanceof RootClass rootClass ) {
+			return new ColumnNamingContext( rootClass.getEntityName(), rootClass.getClassName() );
+		}
+		if ( target instanceof Collection collection ) {
+			return new ColumnNamingContext(
+					collection.getOwnerEntityName(),
+					collection.getOwner().getClassName()
+			);
+		}
+		return null;
 	}
 
 	private static BasicValue createSoftDeleteIndicatorValue(
@@ -83,13 +100,14 @@ public class SoftDeleteHelper {
 	private static Column createSoftDeleteIndicatorColumn(
 			SoftDelete softDeleteConfig,
 			BasicValue softDeleteIndicatorValue,
-			MetadataBuildingContext context) {
+			MetadataBuildingContext context,
+			ColumnNamingContext columnNamingContext) {
 		final var softDeleteColumn = new Column();
 
 		softDeleteColumn.setValue( softDeleteIndicatorValue );
 		softDeleteIndicatorValue.addColumn( softDeleteColumn );
 
-		applyColumnName( softDeleteColumn, softDeleteConfig, context );
+		applyColumnName( softDeleteColumn, softDeleteConfig, context, columnNamingContext );
 
 		softDeleteColumn.setOptions( softDeleteConfig.options() );
 		if ( isBlank( softDeleteConfig.comment() ) ) {
@@ -115,7 +133,8 @@ public class SoftDeleteHelper {
 	private static void applyColumnName(
 			Column softDeleteColumn,
 			SoftDelete softDeleteConfig,
-			MetadataBuildingContext context) {
+			MetadataBuildingContext context,
+			ColumnNamingContext columnNamingContext) {
 		final var database = context.getMetadataCollector().getDatabase();
 		final var namingStrategy = context.getBuildingOptions().getPhysicalNamingStrategy();
 		// NOTE: the argument order is strange here - the fallback value comes first
@@ -125,7 +144,8 @@ public class SoftDeleteHelper {
 		);
 		final Identifier physicalColumnName = namingStrategy.toPhysicalColumnName(
 				database.toIdentifier( logicalColumnName ),
-				database.getJdbcEnvironment()
+				database.getJdbcEnvironment(),
+				columnNamingContext
 		);
 		softDeleteColumn.setName( physicalColumnName.render( database.getDialect() ) );
 	}

--- a/hibernate-core/src/main/java/org/hibernate/boot/model/internal/TableBinder.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/internal/TableBinder.java
@@ -9,6 +9,7 @@ import java.util.List;
 import org.hibernate.AnnotationException;
 import org.hibernate.AssertionFailure;
 import org.hibernate.MappingException;
+import org.hibernate.boot.model.naming.ColumnNamingContext;
 import org.hibernate.boot.model.naming.EntityNaming;
 import org.hibernate.boot.model.naming.Identifier;
 import org.hibernate.boot.model.naming.ImplicitCollectionTableNameSource;
@@ -296,7 +297,8 @@ public class TableBinder {
 				options,
 				buildingContext,
 				null,
-				null
+				null,
+				new ColumnNamingContext( ownerEntity, ownerClassName )
 		);
 	}
 
@@ -439,7 +441,8 @@ public class TableBinder {
 			Identifier logicalName,
 			boolean isAbstract,
 			UniqueConstraint[] uniqueConstraints,
-			MetadataBuildingContext buildingContext) {
+			MetadataBuildingContext buildingContext,
+			ColumnNamingContext columnNamingContext) {
 		return buildAndFillTable(
 				schema,
 				catalog,
@@ -450,7 +453,8 @@ public class TableBinder {
 				null,
 				buildingContext,
 				null,
-				null
+				null,
+				columnNamingContext
 		);
 	}
 
@@ -462,7 +466,8 @@ public class TableBinder {
 			UniqueConstraint[] uniqueConstraints,
 			MetadataBuildingContext buildingContext,
 			String subselect,
-			InFlightMetadataCollector.EntityTableXref denormalizedSuperTableXref) {
+			InFlightMetadataCollector.EntityTableXref denormalizedSuperTableXref,
+			ColumnNamingContext columnNamingContext) {
 		return buildAndFillTable(
 				schema,
 				catalog,
@@ -473,7 +478,8 @@ public class TableBinder {
 				null,
 				buildingContext,
 				subselect,
-				denormalizedSuperTableXref
+				denormalizedSuperTableXref,
+				columnNamingContext
 		);
 	}
 
@@ -487,7 +493,8 @@ public class TableBinder {
 			String options,
 			MetadataBuildingContext buildingContext,
 			String subselect,
-			InFlightMetadataCollector.EntityTableXref denormalizedSuperTableXref) {
+			InFlightMetadataCollector.EntityTableXref denormalizedSuperTableXref,
+			ColumnNamingContext columnNamingContext) {
 		final var metadataCollector = buildingContext.getMetadataCollector();
 
 		final var table = addTable(
@@ -502,11 +509,11 @@ public class TableBinder {
 		);
 
 		if ( uniqueConstraints != null ) {
-			new IndexBinder( buildingContext ).bindUniqueConstraints( table, uniqueConstraints );
+			new IndexBinder( buildingContext, columnNamingContext ).bindUniqueConstraints( table, uniqueConstraints );
 		}
 
 		if ( indexes != null ) {
-			new IndexBinder( buildingContext ).bindIndexes( table, indexes );
+			new IndexBinder( buildingContext, columnNamingContext ).bindIndexes( table, indexes );
 		}
 
 		if ( options != null ) {
@@ -893,8 +900,12 @@ public class TableBinder {
 		}
 	}
 
-	static void addJpaIndexes(Table table, Index[] indexes, MetadataBuildingContext context) {
-		new IndexBinder( context ).bindIndexes( table, indexes );
+	static void addJpaIndexes(
+			Table table,
+			Index[] indexes,
+			MetadataBuildingContext context,
+			ColumnNamingContext columnNamingContext) {
+		new IndexBinder( context, columnNamingContext ).bindIndexes( table, indexes );
 	}
 
 	static void addTableCheck(

--- a/hibernate-core/src/main/java/org/hibernate/boot/model/internal/TemporalHelper.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/internal/TemporalHelper.java
@@ -9,6 +9,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.hibernate.annotations.Temporal;
+import org.hibernate.boot.model.naming.ColumnNamingContext;
 import org.hibernate.boot.model.naming.Identifier;
 import org.hibernate.boot.model.naming.PhysicalNamingStrategy;
 import org.hibernate.boot.model.relational.Database;
@@ -66,12 +67,13 @@ public class TemporalHelper {
 		final int secondPrecision = temporal.secondPrecision();
 		final Integer precision = secondPrecision == -1 ? null : secondPrecision;
 		final var transactionIdType = getTransactionIdType( context );
+		ColumnNamingContext columnNamingContext = determineColumnNamingContext( target );
 		final var rowStartColumn =
 				createTemporalColumn( temporal.rowStart(),
-						table, false, precision, transactionIdType, context );
+						table, false, precision, transactionIdType, context, columnNamingContext );
 		final var rowEndColumn =
 				createTemporalColumn( temporal.rowEnd(),
-						table, true, precision, transactionIdType, context );
+						table, true, precision, transactionIdType, context, columnNamingContext );
 		handleTemporalColumnGeneration( rowStartColumn, rowEndColumn, context );
 
 		final var temporalTable =
@@ -96,6 +98,19 @@ public class TemporalHelper {
 		addTemporalCheckConstraint( temporalTable, rowStartColumn, rowEndColumn, context );
 		addAuxiliaryObjects( temporalTable, partitioned, currentPartitionName, historyPartitionName, context );
 		addSecondPass( target, context );
+	}
+
+	private static ColumnNamingContext determineColumnNamingContext(Stateful target) {
+		if ( target instanceof RootClass rootClass ) {
+			return new ColumnNamingContext( rootClass.getEntityName(), rootClass.getClassName() );
+		}
+		if ( target instanceof Collection collection ) {
+			return new ColumnNamingContext(
+					collection.getOwnerEntityName(),
+					collection.getOwner().getClassName()
+			);
+		}
+		return null;
 	}
 
 	static void enableTemporal(
@@ -288,7 +303,8 @@ public class TemporalHelper {
 			boolean nullable,
 			Integer temporalPrecision,
 			Class<?> transactionIdJavaType,
-			MetadataBuildingContext context) {
+			MetadataBuildingContext context,
+			ColumnNamingContext columnNamingContext) {
 		final var basicValue = new BasicValue( context, table );
 		basicValue.setImplicitJavaTypeAccess( typeConfiguration -> transactionIdJavaType );
 		final var column = new Column();
@@ -297,7 +313,7 @@ public class TemporalHelper {
 		basicValue.addColumn( column );
 		final var database = context.getMetadataCollector().getDatabase();
 		setTemporalColumnName( columnName, column, database,
-				context.getBuildingOptions().getPhysicalNamingStrategy() );
+				context.getBuildingOptions().getPhysicalNamingStrategy(), columnNamingContext );
 		setTemporalColumnType( temporalPrecision, column, database, transactionIdJavaType );
 		return column;
 	}
@@ -321,11 +337,13 @@ public class TemporalHelper {
 			String name,
 			Column column,
 			Database database,
-			PhysicalNamingStrategy physicalNamingStrategy) {
+			PhysicalNamingStrategy physicalNamingStrategy,
+			ColumnNamingContext columnNamingContext) {
 		final Identifier physicalColumnName =
 				physicalNamingStrategy.toPhysicalColumnName(
 						database.toIdentifier( name ),
-						database.getJdbcEnvironment()
+						database.getJdbcEnvironment(),
+						columnNamingContext
 				);
 		column.setName( physicalColumnName.render( database.getDialect() ) );
 	}

--- a/hibernate-core/src/main/java/org/hibernate/boot/model/naming/ColumnNamingContext.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/naming/ColumnNamingContext.java
@@ -1,0 +1,41 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.boot.model.naming;
+
+import org.hibernate.boot.model.internal.AnnotatedColumns;
+import org.hibernate.boot.model.internal.PropertyHolder;
+
+/**
+ * Column context passed with column into naming strategies
+ * for end user to implement their custom logic more easily.
+ *
+ * @author Vasya Petrov
+ */
+public record ColumnNamingContext(String entityName, String className) {
+	public ColumnNamingContext(AnnotatedColumns annotatedColumns) {
+		this( annotatedColumns == null ? null : annotatedColumns.getPropertyHolder() );
+	}
+
+	public ColumnNamingContext(PropertyHolder propertyHolder) {
+		this(
+				extractEntityName( propertyHolder ),
+				extractClassName( propertyHolder )
+		);
+	}
+
+	private static String extractEntityName(PropertyHolder propertyHolder) {
+		return propertyHolder == null
+				? null
+				: propertyHolder.getEntityName();
+	}
+
+	private static String extractClassName(PropertyHolder propertyHolder) {
+		return propertyHolder == null
+				? null
+				: propertyHolder.getEntityOwnerClassName();
+	}
+}

--- a/hibernate-core/src/main/java/org/hibernate/boot/model/naming/PhysicalNamingStrategy.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/naming/PhysicalNamingStrategy.java
@@ -31,12 +31,11 @@ import org.hibernate.engine.jdbc.env.spi.JdbcEnvironment;
  * A {@code PhysicalNamingStrategy} may be selected using the configuration property
  * {@value org.hibernate.cfg.MappingSettings#PHYSICAL_NAMING_STRATEGY}.
  *
+ * @author Steve Ebersole
  * @see ImplicitNamingStrategy
  * @see org.hibernate.cfg.Configuration#setPhysicalNamingStrategy(PhysicalNamingStrategy)
  * @see org.hibernate.boot.MetadataBuilder#applyPhysicalNamingStrategy(PhysicalNamingStrategy)
  * @see org.hibernate.cfg.MappingSettings#PHYSICAL_NAMING_STRATEGY
- *
- * @author Steve Ebersole
  */
 @Incubating
 public interface PhysicalNamingStrategy {
@@ -64,6 +63,17 @@ public interface PhysicalNamingStrategy {
 	 * Determine the physical column name from the given logical name
 	 */
 	Identifier toPhysicalColumnName(Identifier logicalName, JdbcEnvironment jdbcEnvironment);
+
+	/**
+	 * Determine the physical column name from the given logical name.
+	 * Default implementation for backwards compatibility, it's not likely lots of users will need this method.
+	 */
+	default Identifier toPhysicalColumnName(
+			Identifier logicalName,
+			JdbcEnvironment jdbcEnvironment,
+			ColumnNamingContext columnNamingContext) {
+		return toPhysicalColumnName( logicalName, jdbcEnvironment );
+	}
 
 	/**
 	 * Determine the physical UDT type name from the given logical name

--- a/hibernate-core/src/main/java/org/hibernate/boot/model/source/internal/hbm/ModelBinder.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/source/internal/hbm/ModelBinder.java
@@ -21,6 +21,7 @@ import org.hibernate.annotations.OnDeleteAction;
 import org.hibernate.annotations.SourceType;
 import org.hibernate.boot.MappingException;
 import org.hibernate.boot.jaxb.Origin;
+import org.hibernate.boot.model.naming.ColumnNamingContext;
 import org.hibernate.boot.model.relational.Namespace;
 import org.hibernate.boot.model.IdentifierGeneratorDefinition;
 import org.hibernate.boot.model.TypeDefinition;
@@ -485,7 +486,11 @@ public class ModelBinder {
 						return primaryTable.getPrimaryKey().getColumn( count++ )
 								.getNameIdentifier( metadataBuildingContext );
 					}
-				}
+				},
+				new ColumnNamingContext(
+						entitySource.getEntityNamingSource().getEntityName(),
+						entitySource.getEntityNamingSource().getClassName()
+				)
 		);
 		keyBinding.sortProperties();
 		setForeignKeyName( keyBinding,
@@ -604,7 +609,11 @@ public class ModelBinder {
 							}
 					);
 					return database.toIdentifier( propertyName );
-				}
+				},
+				new ColumnNamingContext(
+						hierarchySource.getRoot().getEntityNamingSource().getEntityName(),
+						hierarchySource.getRoot().getEntityNamingSource().getClassName()
+				)
 		);
 
 		if ( propertyName != null ) {
@@ -801,7 +810,11 @@ public class ModelBinder {
 				versionAttributeSource.getRelationalValueSources(),
 				versionValue,
 				false,
-				context -> implicitNamingStrategy.determineBasicColumnName( versionAttributeSource )
+				context -> implicitNamingStrategy.determineBasicColumnName( versionAttributeSource ),
+				new ColumnNamingContext(
+						hierarchySource.getRoot().getEntityNamingSource().getEntityName(),
+						hierarchySource.getRoot().getEntityNamingSource().getClassName()
+				)
 		);
 
 		final var property = new Property();
@@ -845,7 +858,11 @@ public class ModelBinder {
 				discriminatorSource.getDiscriminatorRelationalValueSource(),
 				discriminatorValue,
 				false,
-				context -> implicitNamingStrategy.determineDiscriminatorColumnName( discriminatorSource )
+				context -> implicitNamingStrategy.determineDiscriminatorColumnName( discriminatorSource ),
+				new ColumnNamingContext(
+						hierarchySource.getRoot().getEntityNamingSource().getEntityName(),
+						hierarchySource.getRoot().getEntityNamingSource().getClassName()
+				)
 		);
 
 		rootEntityDescriptor.setPolymorphic( true );
@@ -904,7 +921,11 @@ public class ModelBinder {
 							mappingDocument,
 							basicAttributeSource,
 							new BasicValue( mappingDocument, table ),
-							entityDescriptor.getClassName()
+							entityDescriptor.getClassName(),
+							new ColumnNamingContext(
+									entitySource.getEntityNamingSource().getEntityName(),
+									entitySource.getEntityNamingSource().getClassName()
+							)
 					);
 
 					handleAttribute( attribute, secondaryTableJoin, attributeContainer, mappingDocument,
@@ -950,7 +971,8 @@ public class ModelBinder {
 							mappingDocument,
 							manyToOneAttributeSource,
 							new ManyToOne( mappingDocument, table ),
-							entityDescriptor.getClassName()
+							entityDescriptor.getClassName(),
+							new ColumnNamingContext( entityDescriptor.getEntityName(), entityDescriptor.getClassName() )
 					);
 
 					handleAttribute(
@@ -996,7 +1018,7 @@ public class ModelBinder {
 							mappingDocument,
 							anyAttributeSource,
 							new Any( mappingDocument, table ),
-							entityDescriptor.getEntityName()
+							new ColumnNamingContext( entityDescriptor.getEntityName(), entityDescriptor.getClassName() )
 					);
 
 					handleAttribute(
@@ -1313,8 +1335,10 @@ public class ModelBinder {
 				if ( tableName != null ) {
 					throw new MappingException(
 							"Attribute [%s] referenced columns from multiple tables: %s, %s"
-									.formatted( embeddedAttributeSource.getAttributeRole().getFullPath(),
-											tableName, determinedName ),
+									.formatted(
+											embeddedAttributeSource.getAttributeRole().getFullPath(),
+											tableName, determinedName
+									),
 							mappingDocument.getOrigin()
 					);
 				}
@@ -1451,7 +1475,11 @@ public class ModelBinder {
 						return entityTableXref.getPrimaryTable().getPrimaryKey().getColumn( count++ )
 								.getNameIdentifier( metadataBuildingContext );
 					}
-				}
+				},
+				new ColumnNamingContext(
+						persistentClass.getEntityName(),
+						persistentClass.getClassName()
+				)
 		);
 
 		keyBinding.sortProperties();
@@ -1511,7 +1539,8 @@ public class ModelBinder {
 			MappingDocument sourceDocument,
 			final SingularAttributeSourceBasic attributeSource,
 			SimpleValue value,
-			String containingClassName) {
+			String containingClassName,
+			ColumnNamingContext columnNamingContext) {
 
 		bindSimpleValueType( sourceDocument, attributeSource.getTypeInformation(), value );
 
@@ -1520,7 +1549,8 @@ public class ModelBinder {
 				attributeSource.getRelationalValueSources(),
 				value,
 				attributeSource.areValuesNullableByDefault(),
-				context -> implicitNamingStrategy.determineBasicColumnName( attributeSource )
+				context -> implicitNamingStrategy.determineBasicColumnName( attributeSource ),
+				columnNamingContext
 		);
 
 
@@ -1743,8 +1773,10 @@ public class ModelBinder {
 			DEPRECATION_LOGGER.logDeprecationOfEmbedXmlSupport();
 		}
 
-		setForeignKeyName( oneToOneBinding,
-				oneToOneSource.getExplicitForeignKeyName() );
+		setForeignKeyName(
+				oneToOneBinding,
+				oneToOneSource.getExplicitForeignKeyName()
+		);
 
 		oneToOneBinding.setOnDeleteAction( getOnDeleteAction( oneToOneSource ) );
 	}
@@ -1764,7 +1796,8 @@ public class ModelBinder {
 			MappingDocument sourceDocument,
 			SingularAttributeSourceManyToOne manyToOneSource,
 			ManyToOne manyToOneBinding,
-			String containingClassName) {
+			String containingClassName,
+			ColumnNamingContext columnNamingContext) {
 		final String referencedEntityName =
 				handleReferencedEntity( sourceDocument, manyToOneSource, manyToOneBinding, containingClassName );
 
@@ -1772,7 +1805,14 @@ public class ModelBinder {
 			manyToOneBinding.markAsLogicalOneToOne();
 		}
 
-		bindManyToOneAttribute( sourceDocument, manyToOneSource, manyToOneBinding, referencedEntityName );
+		bindManyToOneAttribute(
+				sourceDocument,
+				manyToOneSource,
+				manyToOneBinding,
+				referencedEntityName,
+				containingClassName,
+				columnNamingContext
+		);
 
 		handlePropertyRef( sourceDocument, manyToOneBinding,
 				"<many-to-one name=\"" + manyToOneSource.getName() + "\"/>" );
@@ -1860,7 +1900,9 @@ public class ModelBinder {
 			final MappingDocument sourceDocument,
 			final SingularAttributeSourceManyToOne manyToOneSource,
 			ManyToOne manyToOneBinding,
-			String referencedEntityName) {
+			String referencedEntityName,
+			String containingClassName,
+			ColumnNamingContext columnNamingContext) {
 		// NOTE: no type information to bind
 
 		handleReferencedEntity( manyToOneBinding, referencedEntityName,
@@ -1881,7 +1923,8 @@ public class ModelBinder {
 				sourceDocument,
 				manyToOneSource,
 				manyToOneBinding,
-				referencedEntityName
+				referencedEntityName,
+				columnNamingContext
 		);
 		final boolean canBindColumnsImmediately = columnBinder.canProcessImmediately();
 		if ( canBindColumnsImmediately ) {
@@ -1938,10 +1981,16 @@ public class ModelBinder {
 			MappingDocument sourceDocument,
 			SingularAttributeSourceAny anyMapping,
 			Any anyBinding,
-			String entityName) {
+			ColumnNamingContext columnNamingContext) {
 		final var attributeRole = anyMapping.getAttributeRole();
-		bindAny( sourceDocument, anyMapping, anyBinding, attributeRole );
-		prepareValueTypeViaReflection( sourceDocument, anyBinding, entityName, anyMapping.getName(), attributeRole );
+		bindAny( sourceDocument, anyMapping, anyBinding, attributeRole, columnNamingContext );
+		prepareValueTypeViaReflection(
+				sourceDocument,
+				anyBinding,
+				columnNamingContext.entityName(),
+				anyMapping.getName(),
+				attributeRole
+		);
 		anyBinding.createForeignKey();
 
 		final var property = new Property();
@@ -1954,7 +2003,8 @@ public class ModelBinder {
 			MappingDocument sourceDocument,
 			AnyMappingSource anyMapping,
 			Any anyBinding,
-			AttributeRole attributeRole) {
+			AttributeRole attributeRole,
+			ColumnNamingContext columnNamingContext) {
 
 		anyBinding.setLazy( anyMapping.isLazy() );
 
@@ -1978,7 +2028,8 @@ public class ModelBinder {
 				discriminatorSource.getRelationalValueSource(),
 				anyBinding.getMetaMapping(),
 				true,
-				context -> implicitNamingStrategy.determineAnyDiscriminatorColumnName( discriminatorSource )
+				context -> implicitNamingStrategy.determineAnyDiscriminatorColumnName( discriminatorSource ),
+				columnNamingContext
 		);
 
 		relationalObjectBinder.bindColumnsAndFormulas(
@@ -1986,7 +2037,8 @@ public class ModelBinder {
 				anyMapping.getKeySource().getRelationalValueSources(),
 				anyBinding.getKeyMapping(),
 				true,
-				context -> implicitNamingStrategy.determineAnyKeyColumnName( anyMapping.getKeySource() )
+				context -> implicitNamingStrategy.determineAnyKeyColumnName( anyMapping.getKeySource() ),
+				columnNamingContext
 		);
 	}
 
@@ -2415,7 +2467,11 @@ public class ModelBinder {
 						sourceDocument,
 						singularAttributeSourceBasic,
 						new BasicValue( sourceDocument, component.getTable() ),
-						component.getComponentClassName()
+						component.getComponentClassName(),
+						new ColumnNamingContext(
+								component.getOwner().getEntityName(),
+								component.getOwner().getClassName()
+						)
 				);
 			}
 			else if ( attributeSource instanceof SingularAttributeSourceEmbedded singularAttributeSourceEmbedded ) {
@@ -2431,7 +2487,11 @@ public class ModelBinder {
 						sourceDocument,
 						singularAttributeSourceManyToOne,
 						new ManyToOne( sourceDocument, component.getTable() ),
-						component.getComponentClassName()
+						component.getComponentClassName(),
+						new ColumnNamingContext(
+								component.getOwner().getEntityName(),
+								component.getOwner().getClassName()
+						)
 				);
 			}
 			else if ( attributeSource instanceof SingularAttributeSourceOneToOne singularAttributeSourceOneToOne ) {
@@ -2447,7 +2507,10 @@ public class ModelBinder {
 						sourceDocument,
 						singularAttributeSourceAny,
 						new Any( sourceDocument, component.getTable() ),
-						component.getComponentClassName()
+						new ColumnNamingContext(
+								component.getOwner().getEntityName(),
+								component.getOwner().getClassName()
+						)
 				);
 			}
 			else if ( attributeSource instanceof PluralAttributeSource pluralAttributeSource ) {
@@ -3054,7 +3117,11 @@ public class ModelBinder {
 					key,
 					keySource.areValuesNullableByDefault(),
 					context -> context.getMetadataCollector().getDatabase()
-							.toIdentifier( Collection.DEFAULT_KEY_COLUMN_NAME )
+							.toIdentifier( Collection.DEFAULT_KEY_COLUMN_NAME ),
+					new ColumnNamingContext(
+							collectionBinding.getOwnerEntityName(),
+							collectionBinding.getOwner().getClassName()
+					)
 			);
 
 			key.sortProperties();
@@ -3084,7 +3151,11 @@ public class ModelBinder {
 						idSource.getColumnSource(),
 						idBinding,
 						false,
-						context -> database.toIdentifier( IdentifierCollection.DEFAULT_IDENTIFIER_COLUMN_NAME )
+						context -> database.toIdentifier( IdentifierCollection.DEFAULT_IDENTIFIER_COLUMN_NAME ),
+						new ColumnNamingContext(
+								getCollectionBinding().getOwnerEntityName(),
+								getCollectionBinding().getOwner().getClassName()
+						)
 				);
 
 				idBagBinding.setIdentifier( idBinding );
@@ -3126,10 +3197,18 @@ public class ModelBinder {
 
 		private void bindManyToAnyElement(PluralAttributeElementSourceManyToAny elementSource) {
 			final var elementBinding =
-					new Any( mappingDocument,
-							collectionBinding.getCollectionTable() );
-			bindAny( mappingDocument, elementSource, elementBinding,
-					pluralAttributeSource.getAttributeRole().append( "element" ) );
+					new Any(
+							mappingDocument,
+							collectionBinding.getCollectionTable()
+					);
+			bindAny(
+					mappingDocument, elementSource, elementBinding,
+					pluralAttributeSource.getAttributeRole().append( "element" ),
+					new ColumnNamingContext(
+							collectionBinding.getOwnerEntityName(),
+							collectionBinding.getOwner().getClassName()
+					)
+			);
 			collectionBinding.setElement( elementBinding );
 			// Collection#setWhere is used to set the "where" clause that applies to the collection table
 			// (which is the join table for a many-to-any association).
@@ -3147,7 +3226,11 @@ public class ModelBinder {
 					elementBinding,
 					false,
 					context -> context.getMetadataCollector().getDatabase()
-							.toIdentifier( Collection.DEFAULT_ELEMENT_COLUMN_NAME )
+							.toIdentifier( Collection.DEFAULT_ELEMENT_COLUMN_NAME ),
+					new ColumnNamingContext(
+							collectionBinding.getOwnerEntityName(),
+							collectionBinding.getOwner().getClassName()
+					)
 			);
 			handleFetchCharacteristics( elementSource, elementBinding );
 			setForeignKeyName( elementBinding,
@@ -3273,7 +3356,11 @@ public class ModelBinder {
 					elementBinding,
 					elementSource.areValuesNullableByDefault(),
 					context -> context.getMetadataCollector().getDatabase()
-							.toIdentifier( Collection.DEFAULT_ELEMENT_COLUMN_NAME )
+							.toIdentifier( Collection.DEFAULT_ELEMENT_COLUMN_NAME ),
+					new ColumnNamingContext(
+							collectionBinding.getOwnerEntityName(),
+							collectionBinding.getOwner().getClassName()
+					)
 			);
 			collectionBinding.setElement( elementBinding );
 			// Collection#setWhere is used to set the "where" clause that applies to the collection table
@@ -3566,6 +3653,10 @@ public class ModelBinder {
 								return context;
 							}
 						}
+				),
+				new ColumnNamingContext(
+						collectionBinding.getOwnerEntityName(),
+						collectionBinding.getOwner().getClassName()
 				)
 		);
 
@@ -3598,10 +3689,18 @@ public class ModelBinder {
 			org.hibernate.mapping.Map collectionBinding,
 			PluralAttributeMapKeyManyToAnySource mapKeySource) {
 		final var mapKeyBinding =
-				new Any( mappingDocument,
-						collectionBinding.getCollectionTable() );
-		bindAny( mappingDocument, mapKeySource, mapKeyBinding,
-				pluralAttributeSource.getAttributeRole().append( "key" ) );
+				new Any(
+						mappingDocument,
+						collectionBinding.getCollectionTable()
+				);
+		bindAny(
+				mappingDocument, mapKeySource, mapKeyBinding,
+				pluralAttributeSource.getAttributeRole().append( "key" ),
+				new ColumnNamingContext(
+						collectionBinding.getOwnerEntityName(),
+						collectionBinding.getOwner().getClassName()
+				)
+		);
 		collectionBinding.setIndex( mapKeyBinding );
 	}
 
@@ -3632,6 +3731,10 @@ public class ModelBinder {
 								return context;
 							}
 						}
+				),
+				new ColumnNamingContext(
+						collectionBinding.getOwnerEntityName(),
+						collectionBinding.getOwner().getClassName()
 				)
 		);
 		collectionBinding.setIndex( mapKeyBinding );
@@ -3676,7 +3779,11 @@ public class ModelBinder {
 				mapKeySource.getRelationalValueSources(),
 				value,
 				true,
-				context -> database.toIdentifier( IndexedCollection.DEFAULT_INDEX_COLUMN_NAME )
+				context -> database.toIdentifier( IndexedCollection.DEFAULT_INDEX_COLUMN_NAME ),
+				new ColumnNamingContext(
+						collectionBinding.getOwnerEntityName(),
+						collectionBinding.getOwner().getClassName()
+				)
 		);
 
 		collectionBinding.setIndex( value );
@@ -3688,6 +3795,7 @@ public class ModelBinder {
 		private final ManyToOne manyToOneBinding;
 
 		private final String referencedEntityName;
+		private final ColumnNamingContext columnNamingContext;
 
 		private final boolean allColumnsNamed;
 
@@ -3695,11 +3803,13 @@ public class ModelBinder {
 				MappingDocument mappingDocument,
 				SingularAttributeSourceManyToOne manyToOneSource,
 				ManyToOne manyToOneBinding,
-				String referencedEntityName) {
+				String referencedEntityName,
+				ColumnNamingContext columnNamingContext) {
 			this.mappingDocument = mappingDocument;
 			this.manyToOneSource = manyToOneSource;
 			this.manyToOneBinding = manyToOneBinding;
 			this.referencedEntityName = referencedEntityName;
+			this.columnNamingContext = columnNamingContext;
 
 			boolean allNamed = true;
 			for ( var relationalValueSource : manyToOneSource.getRelationalValueSources() ) {
@@ -3743,7 +3853,8 @@ public class ModelBinder {
 						manyToOneSource.areValuesNullableByDefault(),
 						context -> {
 							throw new AssertionFailure( "Should not be called" );
-						}
+						},
+						columnNamingContext
 				);
 			}
 			else {
@@ -3784,7 +3895,8 @@ public class ModelBinder {
 										return context;
 									}
 								}
-						)
+						),
+						columnNamingContext
 				);
 			}
 		}

--- a/hibernate-core/src/main/java/org/hibernate/boot/model/source/internal/hbm/RelationalObjectBinder.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/source/internal/hbm/RelationalObjectBinder.java
@@ -8,6 +8,7 @@ import java.util.Collections;
 import java.util.List;
 
 import org.hibernate.AssertionFailure;
+import org.hibernate.boot.model.naming.ColumnNamingContext;
 import org.hibernate.boot.model.naming.Identifier;
 import org.hibernate.boot.model.naming.PhysicalNamingStrategy;
 import org.hibernate.boot.model.relational.Database;
@@ -47,13 +48,15 @@ public class RelationalObjectBinder {
 			RelationalValueSource relationalValueSource,
 			SimpleValue simpleValue,
 			boolean areColumnsNullableByDefault,
-			ColumnNamingDelegate columnNamingDelegate) {
+			ColumnNamingDelegate columnNamingDelegate,
+			ColumnNamingContext columnNamingContext) {
 		bindColumnsAndFormulas(
 				sourceDocument,
 				Collections.singletonList( relationalValueSource ),
 				simpleValue,
 				areColumnsNullableByDefault,
-				columnNamingDelegate
+				columnNamingDelegate,
+				columnNamingContext
 		);
 	}
 
@@ -62,14 +65,16 @@ public class RelationalObjectBinder {
 			List<ColumnSource> columnSources,
 			SimpleValue simpleValue,
 			boolean areColumnsNullableByDefault,
-			ColumnNamingDelegate columnNamingDelegate) {
+			ColumnNamingDelegate columnNamingDelegate,
+			ColumnNamingContext columnNamingContext) {
 		for ( ColumnSource columnSource : columnSources ) {
 			bindColumn(
 					sourceDocument,
 					columnSource,
 					simpleValue,
 					areColumnsNullableByDefault,
-					columnNamingDelegate
+					columnNamingDelegate,
+					columnNamingContext
 			);
 		}
 	}
@@ -79,7 +84,8 @@ public class RelationalObjectBinder {
 			List<RelationalValueSource> relationalValueSources,
 			SimpleValue simpleValue,
 			boolean areColumnsNullableByDefault,
-			ColumnNamingDelegate columnNamingDelegate) {
+			ColumnNamingDelegate columnNamingDelegate,
+			ColumnNamingContext columnNamingContext) {
 		for ( RelationalValueSource relationalValueSource : relationalValueSources ) {
 			if ( relationalValueSource instanceof ColumnSource columnSource ) {
 				bindColumn(
@@ -87,7 +93,8 @@ public class RelationalObjectBinder {
 						columnSource,
 						simpleValue,
 						areColumnsNullableByDefault,
-						columnNamingDelegate
+						columnNamingDelegate,
+						columnNamingContext
 				);
 			}
 			else if ( relationalValueSource instanceof DerivedValueSource formulaSource ) {
@@ -104,7 +111,8 @@ public class RelationalObjectBinder {
 			ColumnSource columnSource,
 			SimpleValue simpleValue,
 			boolean areColumnsNullableByDefault,
-			ColumnNamingDelegate columnNamingDelegate) {
+			ColumnNamingDelegate columnNamingDelegate,
+			ColumnNamingContext columnNamingContext) {
 		final Table table = simpleValue.getTable();
 
 		final Column column = new Column();
@@ -121,7 +129,8 @@ public class RelationalObjectBinder {
 
 		final Identifier physicalName = physicalNamingStrategy.toPhysicalColumnName(
 				logicalName,
-				database.getJdbcEnvironment()
+				database.getJdbcEnvironment(),
+				columnNamingContext
 		);
 		column.setName( physicalName.render( database.getDialect() ) );
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/namingstrategy/AuditedEntity.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/namingstrategy/AuditedEntity.java
@@ -1,0 +1,21 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.orm.test.annotations.namingstrategy;
+
+import org.hibernate.annotations.Audited;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+@Entity(name = "AuditedEntity")
+@Table
+@Audited(transactionId = "txn_id", modificationType = "mod_type")
+public class AuditedEntity {
+	@Id
+	private Integer id;
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/namingstrategy/ColumnNamingContextHbmTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/namingstrategy/ColumnNamingContextHbmTest.java
@@ -1,0 +1,84 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.orm.test.annotations.namingstrategy;
+
+import org.hibernate.boot.Metadata;
+import org.hibernate.boot.MetadataSources;
+import org.hibernate.mapping.PersistentClass;
+import org.hibernate.service.ServiceRegistry;
+import org.hibernate.testing.ServiceRegistryBuilder;
+import org.hibernate.testing.orm.junit.BaseUnitTest;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@BaseUnitTest
+public class ColumnNamingContextHbmTest {
+	private ServiceRegistry serviceRegistry;
+
+	@BeforeEach
+	public void setUp() {
+		serviceRegistry = ServiceRegistryBuilder.buildServiceRegistry();
+	}
+
+	@AfterEach
+	public void tearDown() {
+		if ( serviceRegistry != null ) {
+			ServiceRegistryBuilder.destroy( serviceRegistry );
+		}
+	}
+
+	@Test
+	public void testColumnNamingContextForHbmMappings() {
+		final Metadata metadata = new MetadataSources( serviceRegistry )
+				.addResource( "org/hibernate/orm/test/annotations/namingstrategy/ColumnNamingContextHbmTest.hbm.xml" )
+				.getMetadataBuilder()
+				.applyPhysicalNamingStrategy( new ContextNamingStrategy() )
+				.build();
+
+		final PersistentClass employeeBinding = metadata.getEntityBinding( HbmEmployee.class.getName() );
+		assertThat( employeeBinding.getKey().getColumns().get( 0 ).getName() )
+				.isEqualTo( "HbmEmployee_person_id" );
+		assertThat( employeeBinding.getProperty( "manager" ).getSelectables().get( 0 ).getText() )
+				.isEqualTo( "HbmEmployee_manager_fk" );
+	}
+
+	public static class HbmPerson {
+		private Long id;
+		private String name;
+
+		public Long getId() {
+			return id;
+		}
+
+		public void setId(Long id) {
+			this.id = id;
+		}
+
+		public String getName() {
+			return name;
+		}
+
+		public void setName(String name) {
+			this.name = name;
+		}
+	}
+
+	public static class HbmEmployee extends HbmPerson {
+		private HbmEmployee manager;
+
+		public HbmEmployee getManager() {
+			return manager;
+		}
+
+		public void setManager(HbmEmployee manager) {
+			this.manager = manager;
+		}
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/namingstrategy/ContextEntity.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/namingstrategy/ContextEntity.java
@@ -1,0 +1,39 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.orm.test.annotations.namingstrategy;
+
+import java.util.List;
+
+import org.hibernate.annotations.Audited;
+import org.hibernate.annotations.SoftDelete;
+
+import jakarta.persistence.ElementCollection;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+
+@Entity(name = "ContextEntity")
+@Table
+@SoftDelete(columnName = "gone")
+public class ContextEntity {
+	@Id
+	private Integer id;
+
+	private String basicValue;
+
+	@ManyToOne
+	@JoinColumn
+	private ContextParent parent;
+
+	@ElementCollection
+	@Audited(transactionId = "tags_txn", modificationType = "tags_mod")
+	@jakarta.persistence.CollectionTable(name = "context_tags", joinColumns = @JoinColumn(name = "owner_fk"))
+	@jakarta.persistence.Column(name = "tag_value")
+	private List<String> tags;
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/namingstrategy/ContextNamingStrategy.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/namingstrategy/ContextNamingStrategy.java
@@ -1,0 +1,38 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.orm.test.annotations.namingstrategy;
+
+import org.hibernate.boot.model.naming.ColumnNamingContext;
+import org.hibernate.boot.model.naming.Identifier;
+import org.hibernate.boot.model.naming.PhysicalNamingStrategyStandardImpl;
+import org.hibernate.engine.jdbc.env.spi.JdbcEnvironment;
+
+public class ContextNamingStrategy extends PhysicalNamingStrategyStandardImpl {
+	@Override
+	public Identifier toPhysicalColumnName(
+			Identifier logicalName,
+			JdbcEnvironment jdbcEnvironment,
+			ColumnNamingContext columnNamingContext) {
+		return new Identifier(
+				simpleName( columnNamingContext.entityName() ) + '_' + logicalName.getText(),
+				logicalName.isQuoted()
+		);
+	}
+
+	@Override
+	public Identifier toPhysicalColumnName(Identifier logicalName, JdbcEnvironment context) {
+		return new Identifier( "legacy_" + logicalName.getText(), logicalName.isQuoted() );
+	}
+
+	private String simpleName(String typeName) {
+		if ( typeName == null ) {
+			return null;
+		}
+		final int separator = Math.max( typeName.lastIndexOf( '.' ), typeName.lastIndexOf( '$' ) );
+		return separator < 0 ? typeName : typeName.substring( separator + 1 );
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/namingstrategy/ContextParent.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/namingstrategy/ContextParent.java
@@ -1,0 +1,18 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.orm.test.annotations.namingstrategy;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+@Entity(name = "ContextParent")
+@Table
+public class ContextParent {
+	@Id
+	private Integer id;
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/namingstrategy/NamingStrategyTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/namingstrategy/NamingStrategyTest.java
@@ -4,8 +4,15 @@
  */
 package org.hibernate.orm.test.annotations.namingstrategy;
 
+import java.lang.reflect.Proxy;
+import java.util.Locale;
+
 import org.hibernate.boot.Metadata;
 import org.hibernate.boot.MetadataSources;
+import org.hibernate.boot.model.internal.AuditHelper;
+import org.hibernate.boot.model.internal.PropertyHolder;
+import org.hibernate.boot.model.internal.TemporalHelper;
+import org.hibernate.boot.model.naming.ColumnNamingContext;
 import org.hibernate.boot.model.naming.Identifier;
 import org.hibernate.boot.model.naming.ImplicitNamingStrategyJpaCompliantImpl;
 import org.hibernate.boot.model.naming.PhysicalNamingStrategyStandardImpl;
@@ -13,14 +20,14 @@ import org.hibernate.cfg.Environment;
 import org.hibernate.engine.jdbc.env.spi.JdbcEnvironment;
 import org.hibernate.mapping.Collection;
 import org.hibernate.mapping.PersistentClass;
+import org.hibernate.mapping.RootClass;
 import org.hibernate.service.ServiceRegistry;
+
 import org.hibernate.testing.ServiceRegistryBuilder;
 import org.hibernate.testing.orm.junit.BaseUnitTest;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-
-import java.util.Locale;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -101,4 +108,98 @@ public class NamingStrategyTest {
 				.addAnnotatedClass( Person.class )
 				.buildMetadata();
 	}
+
+	@Test
+	public void testColumnNamingContextForAnnotationsAndGeneratedColumns() {
+		final Metadata metadata = new MetadataSources( serviceRegistry )
+				.addAnnotatedClass( ContextEntity.class )
+				.addAnnotatedClass( ContextParent.class )
+				.addAnnotatedClass( SecondaryTableEntity.class )
+				.addAnnotatedClass( TemporalEntity.class )
+				.addAnnotatedClass( AuditedEntity.class )
+				.getMetadataBuilder()
+				.applyPhysicalNamingStrategy( new ContextNamingStrategy() )
+				.build();
+
+		final PersistentClass contextEntityBinding = metadata.getEntityBinding( ContextEntity.class.getName() );
+		assertThat( contextEntityBinding.getProperty( "basicValue" ).getSelectables().get( 0 ).getText() )
+				.isEqualTo( "ContextEntity_basicValue" );
+		assertThat( contextEntityBinding.getProperty( "parent" ).getSelectables().get( 0 ).getText() )
+				.isEqualTo( "ContextEntity_parent_id" );
+		assertThat( ( (RootClass) contextEntityBinding ).getSoftDeleteColumn().getName() )
+				.isEqualTo( "ContextEntity_gone" );
+
+		final RootClass temporalEntityBinding = (RootClass) metadata.getEntityBinding( TemporalEntity.class.getName() );
+		assertThat( temporalEntityBinding.getAuxiliaryColumn( TemporalHelper.ROW_START ).getName() )
+				.isEqualTo( "TemporalEntity_valid_from" );
+		assertThat( temporalEntityBinding.getAuxiliaryColumn( TemporalHelper.ROW_END ).getName() )
+				.isEqualTo( "TemporalEntity_valid_to" );
+
+		final RootClass auditedEntityBinding = (RootClass) metadata.getEntityBinding( AuditedEntity.class.getName() );
+		assertThat( auditedEntityBinding.getAuxiliaryColumn( AuditHelper.TRANSACTION_ID ).getName() )
+				.isEqualTo( "AuditedEntity_txn_id" );
+		assertThat( auditedEntityBinding.getAuxiliaryColumn( AuditHelper.MODIFICATION_TYPE ).getName() )
+				.isEqualTo( "AuditedEntity_mod_type" );
+
+		final Collection tagsBinding = metadata.getCollectionBinding( ContextEntity.class.getName() + ".tags" );
+		assertThat( tagsBinding.getAuxiliaryColumn( AuditHelper.TRANSACTION_ID ).getName() )
+				.isEqualTo( "ContextEntity_tags_txn" );
+		assertThat( tagsBinding.getAuxiliaryColumn( AuditHelper.MODIFICATION_TYPE ).getName() )
+				.isEqualTo( "ContextEntity_tags_mod" );
+	}
+
+	@Test
+	public void testPropertyHolderColumnNamingContextConstructor() {
+		final ColumnNamingContext nullContext = new ColumnNamingContext( (PropertyHolder) null );
+		assertThat( nullContext.entityName() ).isNull();
+		assertThat( nullContext.className() ).isNull();
+
+		final ColumnNamingContext propertyHolderContext =
+				new ColumnNamingContext( propertyHolder( "ContextEntity", ContextEntity.class.getName() ) );
+		assertThat( propertyHolderContext.entityName() ).isEqualTo( "ContextEntity" );
+		assertThat( propertyHolderContext.className() ).isEqualTo( ContextEntity.class.getName() );
+	}
+
+	@Test
+	public void testColumnNamingContextForSecondaryTablesWithoutPropertyHolder() {
+		final Metadata metadata = new MetadataSources( serviceRegistry )
+				.addAnnotatedClass( SecondaryTableEntity.class )
+				.getMetadataBuilder()
+				.applyPhysicalNamingStrategy( new ContextNamingStrategy() )
+				.build();
+
+		final PersistentClass entityBinding = metadata.getEntityBinding( SecondaryTableEntity.class.getName() );
+		assertThat( entityBinding.getProperty( "secondaryValue" ).getSelectables().get( 0 ).getText() )
+				.isEqualTo( "SecondaryTableEntity_secondaryValue" );
+	}
+
+	private static PropertyHolder propertyHolder(String entityName, String className) {
+		return (PropertyHolder) Proxy.newProxyInstance(
+				NamingStrategyTest.class.getClassLoader(),
+				new Class<?>[] { PropertyHolder.class },
+				(proxy, method, args) -> switch ( method.getName() ) {
+					case "equals" -> args != null && proxy == args[0];
+					case "getEntityName" -> entityName;
+					case "getEntityOwnerClassName" -> className;
+					case "hashCode" -> System.identityHashCode( proxy );
+					case "toString" -> "PropertyHolder[" + entityName + ']';
+					default -> defaultValue( method.getReturnType() );
+				}
+		);
+	}
+
+	private static Object defaultValue(Class<?> returnType) {
+		return switch ( returnType.getName() ) {
+			case "boolean" -> false;
+			case "byte" -> (byte) 0;
+			case "char" -> (char) 0;
+			case "double" -> 0d;
+			case "float" -> 0f;
+			case "int" -> 0;
+			case "long" -> 0L;
+			case "short" -> (short) 0;
+			default -> null;
+		};
+	}
+
 }

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/namingstrategy/SecondaryTableEntity.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/namingstrategy/SecondaryTableEntity.java
@@ -1,0 +1,28 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.orm.test.annotations.namingstrategy;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.SecondaryTable;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+
+@Entity(name = "SecondaryTableEntity")
+@Table
+@SecondaryTable(
+		name = "context_details",
+		uniqueConstraints = @UniqueConstraint(columnNames = "secondaryValue")
+)
+public class SecondaryTableEntity {
+	@Id
+	private Integer id;
+
+	@Column(table = "context_details")
+	private String secondaryValue;
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/namingstrategy/TemporalEntity.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/namingstrategy/TemporalEntity.java
@@ -1,0 +1,21 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.orm.test.annotations.namingstrategy;
+
+import org.hibernate.annotations.Temporal;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+@Entity(name = "TemporalEntity")
+@Table
+@Temporal(rowStart = "valid_from", rowEnd = "valid_to")
+public class TemporalEntity {
+	@Id
+	private Integer id;
+}

--- a/hibernate-core/src/test/resources/org/hibernate/orm/test/annotations/namingstrategy/ColumnNamingContextHbmTest.hbm.xml
+++ b/hibernate-core/src/test/resources/org/hibernate/orm/test/annotations/namingstrategy/ColumnNamingContextHbmTest.hbm.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0"?>
+<!DOCTYPE hibernate-mapping PUBLIC
+		"-//Hibernate/Hibernate Mapping DTD 3.0//EN"
+		"http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
+<hibernate-mapping>
+	<class name="org.hibernate.orm.test.annotations.namingstrategy.ColumnNamingContextHbmTest$HbmPerson" table="hbm_person">
+		<id name="id" column="person_id" type="long"/>
+		<property name="name" column="person_name"/>
+	</class>
+
+	<joined-subclass
+			name="org.hibernate.orm.test.annotations.namingstrategy.ColumnNamingContextHbmTest$HbmEmployee"
+			extends="org.hibernate.orm.test.annotations.namingstrategy.ColumnNamingContextHbmTest$HbmPerson"
+			table="hbm_employee">
+		<key column="person_id"/>
+		<many-to-one
+				name="manager"
+				class="org.hibernate.orm.test.annotations.namingstrategy.ColumnNamingContextHbmTest$HbmEmployee"
+				column="manager_fk"/>
+	</joined-subclass>
+</hibernate-mapping>


### PR DESCRIPTION
I've added some entity meta info (entity name and class name) to the PhysicalNamingStrategy:toPhysicalColumnName calls as per [HHH-16361](https://hibernate.atlassian.net/browse/HHH-16361). 
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------


---
<!-- Hibernate GitHub Bot task list start -->
Please make sure that the following tasks are completed:
Tasks specific to HHH-16361 (Improvement):
- [x] Add tests for feature/improvement
- [x] Update documentation as relevant: javadoc for changed API, `documentation/src/main/asciidoc/userguide` for all features, `documentation/src/main/asciidoc/introduction` for main features, links from existing documentation
- [x] Add entries as relevant to `migration-guide.adoc` (breaking changes) and `whats-new.adoc` (new features/improvements)


<!-- Hibernate GitHub Bot task list end -->

[HHH-16361]: https://hibernate.atlassian.net/browse/HHH-16361?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ