### PR TITLE
HHH-20289 Better support H2 unique index with nullable columns

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/dialect/H2Dialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/H2Dialect.java
@@ -31,6 +31,7 @@ import org.hibernate.dialect.type.H2DurationIntervalSecondJdbcType;
 import org.hibernate.dialect.type.H2JsonArrayJdbcTypeConstructor;
 import org.hibernate.dialect.type.H2JsonJdbcType;
 import org.hibernate.dialect.type.PostgreSQLEnumJdbcType;
+import org.hibernate.dialect.unique.AlterTableUniqueIndexDelegate;
 import org.hibernate.dialect.unique.CreateTableUniqueDelegate;
 import org.hibernate.dialect.unique.UniqueDelegate;
 import org.hibernate.engine.jdbc.dialect.spi.DialectResolutionInfo;
@@ -126,17 +127,17 @@ import static org.hibernate.type.descriptor.DateTimeUtils.appendAsTimestampWithN
  * Please refer to the
  * <a href="http://www.h2database.com/html/main.html">H2 documentation</a>.
  *
- *
  * @author Thomas Mueller
  * @author Jürgen Kreitler
  * @author Yoobin Yoon
  */
 public class H2Dialect extends Dialect {
 	private static final DatabaseVersion MINIMUM_VERSION = DatabaseVersion.make( 2, 1, 214 );
+	private static final DatabaseVersion VERSION_2_2_220 = DatabaseVersion.make( 2, 2, 220 );
 
 	private final SequenceInformationExtractor sequenceInformationExtractor;
 	private final String querySequenceString;
-	private final UniqueDelegate uniqueDelegate = new CreateTableUniqueDelegate(this);
+	private final UniqueDelegate uniqueDelegate;
 
 	public H2Dialect(DialectResolutionInfo info) {
 		this( staticDetermineDatabaseVersion( info ) );
@@ -152,6 +153,9 @@ public class H2Dialect extends Dialect {
 
 		sequenceInformationExtractor = SequenceInformationExtractorLegacyImpl.INSTANCE;
 		querySequenceString = "select * from INFORMATION_SCHEMA.SEQUENCES";
+		uniqueDelegate = version.isSameOrAfter( VERSION_2_2_220 )
+				? new AlterTableUniqueIndexDelegate( this )
+				: new CreateTableUniqueDelegate( this );
 	}
 
 	@Override
@@ -202,7 +206,7 @@ public class H2Dialect extends Dialect {
 
 	@Override
 	protected String columnType(int sqlTypeCode) {
-		return switch (sqlTypeCode) {
+		return switch ( sqlTypeCode ) {
 			// h2 recognizes NCHAR and NCLOB as aliases
 			// but, according to the docs, not NVARCHAR
 			// so just normalize all these types
@@ -215,7 +219,7 @@ public class H2Dialect extends Dialect {
 
 	@Override
 	protected String castType(int sqlTypeCode) {
-		return switch (sqlTypeCode) {
+		return switch ( sqlTypeCode ) {
 			case CHAR, NCHAR -> "char";
 			case VARCHAR, NVARCHAR, LONG32VARCHAR, LONG32NVARCHAR -> "varchar";
 			case BINARY, VARBINARY, LONG32VARBINARY -> "varbinary";
@@ -356,7 +360,7 @@ public class H2Dialect extends Dialect {
 
 		functionFactory.jsonObject();
 		functionFactory.jsonArray();
-		if ( getVersion().isSameOrAfter( 2, 2, 220 ) ) {
+		if ( getVersion().isSameOrAfter( VERSION_2_2_220 ) ) {
 			functionFactory.jsonValue_h2();
 			functionFactory.jsonQuery_h2();
 			functionFactory.jsonExists_h2();
@@ -413,7 +417,7 @@ public class H2Dialect extends Dialect {
 
 	@Override
 	protected Integer resolveSqlTypeCode(String columnTypeName, TypeConfiguration typeConfiguration) {
-		return switch (columnTypeName) {
+		return switch ( columnTypeName ) {
 			// Use REAL instead of FLOAT to get Float as recommended Java type
 			case "FLOAT(24)" -> Types.REAL;
 			default -> super.resolveSqlTypeCode( columnTypeName, typeConfiguration );
@@ -448,7 +452,7 @@ public class H2Dialect extends Dialect {
 
 	@Override
 	protected Integer resolveSqlTypeCode(String typeName, String baseTypeName, TypeConfiguration typeConfiguration) {
-		return switch (baseTypeName) {
+		return switch ( baseTypeName ) {
 			case "CHARACTER VARYING" -> VARCHAR;
 			default -> super.resolveSqlTypeCode( typeName, baseTypeName, typeConfiguration );
 		};
@@ -461,7 +465,7 @@ public class H2Dialect extends Dialect {
 
 	@Override
 	public String currentTime() {
-		return  "localtime";
+		return "localtime";
 	}
 
 	@Override
@@ -494,8 +498,8 @@ public class H2Dialect extends Dialect {
 	@Override
 	public String extractPattern(TemporalUnit unit) {
 		return unit == SECOND
-				? "(" + super.extractPattern(unit) + "+extract(nanosecond from ?2)/1e9)"
-				: super.extractPattern(unit);
+				? "(" + super.extractPattern( unit ) + "+extract(nanosecond from ?2)/1e9)"
+				: super.extractPattern( unit );
 	}
 
 	@Override
@@ -508,7 +512,8 @@ public class H2Dialect extends Dialect {
 		}
 	}
 
-	@Override @SuppressWarnings("deprecation")
+	@Override
+	@SuppressWarnings("deprecation")
 	public String timestampaddPattern(TemporalUnit unit, TemporalType temporalType, IntervalType intervalType) {
 		if ( intervalType != null ) {
 			return "(?2+?3)";
@@ -520,7 +525,8 @@ public class H2Dialect extends Dialect {
 				: "dateadd(?1,?2,?3)";
 	}
 
-	@Override @SuppressWarnings("deprecation")
+	@Override
+	@SuppressWarnings("deprecation")
 	public String timestampdiffPattern(TemporalUnit unit, TemporalType fromTemporalType, TemporalType toTemporalType) {
 		if ( unit == null ) {
 			return "(?3-?2)";
@@ -542,7 +548,7 @@ public class H2Dialect extends Dialect {
 				appender.appendSql( '\'' );
 				break;
 			case TIME:
-				if ( supportsTimeLiteralOffset() && temporalAccessor.isSupported( ChronoField.OFFSET_SECONDS )  ) {
+				if ( supportsTimeLiteralOffset() && temporalAccessor.isSupported( ChronoField.OFFSET_SECONDS ) ) {
 					appender.appendSql( "time with time zone '" );
 					appendAsTime( appender, temporalAccessor, supportsTemporalLiteralOffset(), jdbcTimeZone );
 				}
@@ -668,7 +674,9 @@ public class H2Dialect extends Dialect {
 
 	@Override
 	public LockingSupport getLockingSupport() {
-		return getVersion().isSameOrAfter( 2, 2, 220 ) ? H2LockingSupport.INSTANCE : H2LockingSupport.LEGACY_INSTANCE;
+		return getVersion().isSameOrAfter( VERSION_2_2_220 )
+				? H2LockingSupport.INSTANCE
+				: H2LockingSupport.LEGACY_INSTANCE;
 	}
 
 	@Override
@@ -719,6 +727,18 @@ public class H2Dialect extends Dialect {
 	@Override
 	public boolean supportsIfExistsBeforeIndexName() {
 		return true;
+	}
+
+	@Override
+	public String getCreateIndexString(boolean unique) {
+		if ( unique && getVersion().isSameOrAfter( VERSION_2_2_220 ) ) {
+			// we only create unique indexes, as opposed to unique constraints,
+			// when the column is nullable, so safe to infer unique => nullable
+			return "create unique nulls distinct index";
+		}
+		else {
+			return super.getCreateIndexString( unique );
+		}
 	}
 
 	@Override
@@ -831,10 +851,10 @@ public class H2Dialect extends Dialect {
 				switch ( extractErrorCode( sqlException ) ) {
 					case 40001 ->
 						// DEADLOCK DETECTED
-							new LockAcquisitionException(message, sqlException, sql);
+							new LockAcquisitionException( message, sqlException, sql );
 					case 50200 ->
 						// LOCK NOT AVAILABLE
-							new LockTimeoutException(message, sqlException, sql);
+							new LockTimeoutException( message, sqlException, sql );
 					case 23505 ->
 						// Unique index or primary key violation
 							new ConstraintViolationException( message, sqlException, sql, ConstraintKind.UNIQUE,
@@ -974,16 +994,16 @@ public class H2Dialect extends Dialect {
 	public void appendDatetimeFormat(SqlAppender appender, String format) {
 		appender.appendSql(
 				new Replacer( format, "'", "''" )
-				.replace("e", "u")
-				.replace( "xxx", "XXX" )
-				.replace( "xx", "XX" )
-				.replace( "x", "X" )
-				.result()
+						.replace( "e", "u" )
+						.replace( "xxx", "XXX" )
+						.replace( "xx", "XX" )
+						.replace( "x", "X" )
+						.result()
 		);
 	}
 
 	public String translateExtractField(TemporalUnit unit) {
-		return switch (unit) {
+		return switch ( unit ) {
 			case DAY_OF_MONTH -> "day";
 			case WEEK -> "iso_week";
 			default -> unit.toString();
@@ -1011,7 +1031,7 @@ public class H2Dialect extends Dialect {
 		type.append( "enum (" );
 		String separator = "";
 		for ( String value : values ) {
-			type.append( separator ).append('\'').append( value ).append('\'');
+			type.append( separator ).append( '\'' ).append( value ).append( '\'' );
 			separator = ",";
 		}
 		return type.append( ')' ).toString();
@@ -1081,7 +1101,7 @@ public class H2Dialect extends Dialect {
 	}
 
 	@Override
-	public boolean supportsCaseInsensitiveLike(){
+	public boolean supportsCaseInsensitiveLike() {
 		return true;
 	}
 
@@ -1154,28 +1174,28 @@ public class H2Dialect extends Dialect {
 	@Override
 	public String[] getCreateEnumTypeCommand(String name, String[] values) {
 		final int maxLength =
-				Arrays.stream(values)
+				Arrays.stream( values )
 						.map( String::length )
 						.max( Integer::compareTo )
 						.orElseThrow();
 		final var domain = new StringBuilder();
 		domain.append( "create domain " )
 				.append( name )
-				.append( " as varchar(")
+				.append( " as varchar(" )
 				.append( maxLength )
 				.append( ") check (value in (" );
 		String separator = "";
 		for ( String value : values ) {
-			domain.append( separator ).append('\'').append( value ).append('\'');
+			domain.append( separator ).append( '\'' ).append( value ).append( '\'' );
 			separator = ",";
 		}
 		domain.append( "))" );
-		return new String[] { domain.toString() };
+		return new String[] {domain.toString()};
 	}
 
 	@Override
 	public String[] getDropEnumTypeCommand(String name) {
-		return new String[] { "drop domain if exists " + name };
+		return new String[] {"drop domain if exists " + name};
 	}
 
 }

--- a/hibernate-core/src/main/java/org/hibernate/dialect/unique/AlterTableUniqueIndexDelegate.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/unique/AlterTableUniqueIndexDelegate.java
@@ -20,6 +20,9 @@ import static org.hibernate.internal.util.StringHelper.unqualify;
  * <li>SQL Server <em>does</em> allow unique constraints on nullable columns, but the semantics
  *     are that two null values are non-unique. So here we need to jump through hoops with the
  *     {@code create unique nonclustered index ... where ...} command.
+ * <li>H2 allows unique constraints on nullable columns, but the semantics with multiple null
+ *     values depend on the configured mode. So we need to explicitly create the index with
+ *     {@code nulls distinct} to make it work in all modes.
  * <li>Spanner does not allow unique column definition, but it does allow the creation of unique
  * 	   indexes instead, using {@code create unique index ...}
  * </ul>
@@ -27,7 +30,7 @@ import static org.hibernate.internal.util.StringHelper.unqualify;
  * @author Brett Meyer
  */
 public class AlterTableUniqueIndexDelegate extends AlterTableUniqueDelegate {
-	public AlterTableUniqueIndexDelegate(Dialect dialect ) {
+	public AlterTableUniqueIndexDelegate(Dialect dialect) {
 		super( dialect );
 	}
 
@@ -54,7 +57,7 @@ public class AlterTableUniqueIndexDelegate extends AlterTableUniqueDelegate {
 					first = false;
 				}
 				else {
-					statement.append(", ");
+					statement.append( ", " );
 				}
 				statement.append( column.getQuotedName( dialect ) );
 				if ( columnOrderMap.containsKey( column ) ) {

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/schemagen/SchemaScriptFileGenerationTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/schemagen/SchemaScriptFileGenerationTest.java
@@ -6,32 +6,32 @@ package org.hibernate.orm.test.jpa.schemagen;
 
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
+import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
-import java.io.File;
-import java.io.IOException;
-import java.nio.file.Files;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Map;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-
 import org.hibernate.cfg.AvailableSettings;
 import org.hibernate.cfg.Environment;
 import org.hibernate.internal.util.PropertiesHelper;
 import org.hibernate.jpa.boot.spi.Bootstrap;
 import org.hibernate.jpa.boot.spi.EntityManagerFactoryBuilder;
 import org.hibernate.jpa.boot.spi.PersistenceUnitDescriptor;
-import org.hibernate.testing.orm.junit.JiraKey;
 import org.hibernate.testing.orm.junit.EntityManagerFactoryBasedFunctionalTest;
+import org.hibernate.testing.orm.junit.JiraKey;
 import org.hibernate.testing.util.ServiceRegistryUtil;
-
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import static org.hamcrest.core.Is.is;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
 
 /**
  * @author Andrea Boriero
@@ -52,6 +52,8 @@ public class SchemaScriptFileGenerationTest {
 				buildPersistenceUnitDescriptor(),
 				getConfig()
 		);
+
+		entityManagerFactoryBuilder.generateSchema();
 	}
 
 	@AfterEach
@@ -64,32 +66,73 @@ public class SchemaScriptFileGenerationTest {
 	@Test
 	@JiraKey(value = "10601")
 	public void testGenerateSchemaDoesNotProduceTheSameStatementTwice() throws Exception {
-
-		entityManagerFactoryBuilder.generateSchema();
-
-		final String fileContent = new String( Files.readAllBytes( createSchema.toPath() ) ).toLowerCase();
+		String createFileContent = new String( Files.readAllBytes( createSchema.toPath() ) ).toLowerCase();
 
 		Pattern createStatementPattern = Pattern.compile( "create( (column|row))? table test_entity" );
-		Matcher createStatementMatcher = createStatementPattern.matcher( fileContent );
-		assertThat( createStatementMatcher.find(), is( true ) );
+		Matcher createStatementMatcher = createStatementPattern.matcher( createFileContent );
 		assertThat(
-				"The statement 'create table test_entity' is generated twice",
+				"Missing create table: " + createFileContent,
+				createStatementMatcher.find(),
+				is( true ) );
+		assertThat(
+				"The statement 'create table test_entity' is generated twice: " + createFileContent,
 				createStatementMatcher.find(),
 				is( false )
 		);
 
-		final String dropFileContent = new String( Files.readAllBytes( dropSchema.toPath() ) ).toLowerCase();
-		assertThat( dropFileContent.contains( "drop table " ), is( true ) );
+		String dropFileContent = new String( Files.readAllBytes( dropSchema.toPath() ) ).toLowerCase();
+
+		Pattern dropStatementPattern = Pattern.compile( "drop table( if exists)? test_entity" );
+		Matcher dropStatementMatcher = dropStatementPattern.matcher( dropFileContent );
+		assertThat( "Missing drop table: " + dropFileContent,
+				dropStatementMatcher.find(),
+				is( true ) );
 		assertThat(
-				"The statement 'drop table ' is generated twice",
-				dropFileContent.replaceFirst( "drop table ", "" ).contains( "drop table " ),
+				"The statement 'drop table' is generated twice: " + dropFileContent,
+				dropStatementMatcher.find(),
 				is( false )
 		);
+	}
+
+	@Test
+	@JiraKey(value = "HHH-20289")
+	public void testGenerateSchemaNullDistinctUniqueIndex() throws Exception {
+		String createFileContent = new String( Files.readAllBytes( createSchema.toPath() ) ).toLowerCase();
+		assertThat(
+				"Missing create unique index: " + createFileContent,
+				createFileContent.contains( "create unique nulls distinct index" ),
+				is( true ) );
 	}
 
 	@Entity
 	@Table(name = "test_entity")
 	public static class TestEntity {
+		@Id
+		private String field;
+
+		@OneToOne
+		private TestChildEntity child;
+
+		public String getField() {
+			return field;
+		}
+
+		public void setField(String field) {
+			this.field = field;
+		}
+
+		public TestChildEntity getChild() {
+			return child;
+		}
+
+		public void setChild(TestChildEntity child) {
+			this.child = child;
+		}
+	}
+
+	@Entity
+	@Table(name = "test_child_entity")
+	public static class TestChildEntity {
 		@Id
 		private String field;
 
@@ -103,7 +146,8 @@ public class SchemaScriptFileGenerationTest {
 	}
 
 	private PersistenceUnitDescriptor buildPersistenceUnitDescriptor() {
-		return new EntityManagerFactoryBasedFunctionalTest.TestingPersistenceUnitDescriptorImpl( getClass().getSimpleName() );
+		return new EntityManagerFactoryBasedFunctionalTest.TestingPersistenceUnitDescriptorImpl(
+				getClass().getSimpleName() );
 	}
 
 	private Map<String, Object> getConfig() {
@@ -112,9 +156,7 @@ public class SchemaScriptFileGenerationTest {
 		config.put( AvailableSettings.JAKARTA_HBM2DDL_SCRIPTS_CREATE_TARGET, createSchema.toPath() );
 		config.put( AvailableSettings.JAKARTA_HBM2DDL_SCRIPTS_DROP_TARGET, dropSchema.toPath() );
 		config.put( AvailableSettings.JAKARTA_HBM2DDL_SCRIPTS_ACTION, "drop-and-create" );
-		ArrayList<Class<?>> classes = new ArrayList<>();
-
-		classes.addAll( Arrays.asList( new Class<?>[] {TestEntity.class} ) );
+		List<Class<?>> classes = Arrays.asList( TestEntity.class, TestChildEntity.class );
 		config.put( AvailableSettings.LOADED_CLASSES, classes );
 		return config;
 	}


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-20289

H2 by default treats multiple NULL values as distinct with regards to uniqueness (e.g. unique index, unique constraint). 
https://github.com/h2database/h2database/blob/f7be5c706f1378ca6f4a1c1b1b891d68bd89f6b7/h2/src/main/org/h2/engine/Mode.java#L146

However, H2 supports different compatibility modes and when setting to e.g. SQL Server, NULL values are treated as not distinct (unique index violation if more than 1 row with NULL).

For SQL Server, Hibernate already generates specific code to handle NULL values in a unique index: https://github.com/hibernate/hibernate-orm/blob/24d4c956f7d10883c182700dfd75e562f6e7b67e/hibernate-core/src/main/java/org/hibernate/dialect/unique/AlterTableUniqueIndexDelegate.java#L20-L22

This PR does the same for H2, to properly support e.g. H2 in SQL Server mode.

----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------


---
<!-- Hibernate GitHub Bot task list start -->
Please make sure that the following tasks are completed:
Tasks specific to HHH-20289 (Improvement):
- [x] Add tests for feature/improvement
- [x] Update documentation as relevant: javadoc for changed API, `documentation/src/main/asciidoc/userguide` for all features, `documentation/src/main/asciidoc/introduction` for main features, links from existing documentation
- [x] Add entries as relevant to `migration-guide.adoc` (breaking changes) and `whats-new.adoc` (new features/improvements)


<!-- Hibernate GitHub Bot task list end -->