### PR TITLE
HHH-20288 Reproducer for lazy-loading when any @Id field of @IdClass is accessed

### DIFF
--- a/hibernate-core/src/test/java/org/hibernate/orm/test/idclass/IdClassTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/idclass/IdClassTest.java
@@ -12,6 +12,7 @@ import jakarta.persistence.IdClass;
 
 import org.hibernate.testing.jdbc.SQLStatementInspector;
 import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.JiraKey;
 import org.hibernate.testing.orm.junit.SessionFactory;
 import org.hibernate.testing.orm.junit.SessionFactoryScope;
 import org.junit.jupiter.api.AfterEach;
@@ -60,6 +61,36 @@ public class IdClassTest {
 					assertThat( systemUser.getSubsystem(), is( "Linux" ) );
 					assertThat( systemUser.getUsername(), is( "admin" ) );
 					assertThat( systemUser.getRegistrationId(), is( 1 ) );
+
+					statementInspector.assertExecutedCount( 1 );
+					statementInspector.assertNumberOfOccurrenceInQuery(
+							0,
+							"join",
+							0
+					);
+				}
+		);
+	}
+
+	@Test
+	@JiraKey("HHH-20288")
+	public void testGetReference(SessionFactoryScope scope) {
+		SQLStatementInspector statementInspector = scope.getCollectingStatementInspector();
+		statementInspector.clear();
+		scope.inTransaction(
+				session -> {
+					PK pk = new PK( "Linux", "admin", 1 );
+					SystemUser systemUser = session.getReference( SystemUser.class, pk );
+
+					statementInspector.assertExecutedCount( 0 );
+
+					assertThat( systemUser.getSubsystem(), is( "Linux" ) );
+					assertThat( systemUser.getUsername(), is( "admin" ) );
+					assertThat( systemUser.getRegistrationId(), is( 1 ) );
+
+					statementInspector.assertExecutedCount( 0 );
+
+					assertThat( systemUser.getName(), is( "Andrea" ) );
 
 					statementInspector.assertExecutedCount( 1 );
 					statementInspector.assertNumberOfOccurrenceInQuery(


### PR DESCRIPTION
<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------


---
<!-- Hibernate GitHub Bot task list start -->
Please make sure that the following tasks are completed:
Tasks specific to HHH-20288 (Bug):
- [x] Add test reproducing the bug
- [x] Add entries as relevant to `migration-guide.adoc` **OR** check there are no breaking changes


<!-- Hibernate GitHub Bot task list end -->

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-20288
<!-- Hibernate GitHub Bot issue links end -->