### PR TITLE
update composite identifiers documentation

### DIFF
--- a/documentation/src/main/asciidoc/userguide/chapters/domain/identifiers.adoc
+++ b/documentation/src/main/asciidoc/userguide/chapters/domain/identifiers.adoc
@@ -99,8 +99,7 @@ Here are the rules governing composite identifiers, as defined by the Jakarta Pe
 * The composite identifier must be represented by a "primary key class".
 The primary key class may be defined using the `jakarta.persistence.EmbeddedId` annotation (see <<identifiers-composite-aggregated>>),
 or defined using the `jakarta.persistence.IdClass` annotation (see <<identifiers-composite-nonaggregated>>).
-* The primary key class must be public and must have a public no-arg constructor.
-* The primary key class must be serializable.
+* The primary key must have a public or protected no-arg constructor. The primary key class may be a Java record type, in which case it does not need a no-arg constructor. 
 * The primary key class must define equals and hashCode methods, consistent with equality for the underlying database types to which the primary key is mapped.
 
 [NOTE]


### PR DESCRIPTION
align documentation on composite identifiers with JPA 3.2 specifiaction

Namely:
-  remove requirement stating a primary key class must be serializable
-  remove requirement for class to be public
-  update requirement on no-args constructor to allow protected, excluding record types

Based on @beikov's Forum [response](https://discourse.hibernate.org/t/mistake-in-documentation-for-3-7-2-composite-identifiers/12196/2) I'm assuming that this change reflects the current state in Hibernate.

----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
