### PR TITLE
HHH-20125 fix polymorphic embeddable replacement

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/type/ComponentType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/ComponentType.java
@@ -28,6 +28,7 @@ import org.hibernate.metamodel.mapping.EmbeddableMappingType;
 import org.hibernate.metamodel.mapping.EmbeddableValuedModelPart;
 import org.hibernate.metamodel.mapping.internal.MappingModelCreationProcess;
 import org.hibernate.metamodel.spi.EmbeddableInstantiator;
+import org.hibernate.property.access.internal.PropertyAccessStrategyBackRefImpl;
 import org.hibernate.query.sqm.tree.domain.SqmEmbeddableDomainType;
 import org.hibernate.type.descriptor.ValueExtractor;
 import org.hibernate.type.descriptor.jdbc.JdbcType;
@@ -529,24 +530,46 @@ public class ComponentType extends AbstractType
 			return null;
 		}
 		else {
+			final var mappingType = embeddableTypeDescriptor();
+			boolean polymorphic = mappingType.isPolymorphic();
+
 			final Object[] originalValues = getPropertyValues( original );
 			final Object[] resultValues = getPropertyValues( target );
-			final Object[] replacedValues = TypeHelper.replace(
-					originalValues,
-					resultValues,
-					propertyTypes,
-					session,
-					owner,
-					copyCache
-			);
+			final Object[] replacedValues = new Object[propertySpan];
 
-			if ( target == null || !isMutable() ) {
+
+			for ( int i = 0; i < propertySpan; i++ ) {
+				if ( originalValues[i] == LazyPropertyInitializer.UNFETCHED_PROPERTY
+						|| originalValues[i] == PropertyAccessStrategyBackRefImpl.UNKNOWN ) {
+					replacedValues[i] = resultValues[i];
+				}
+				else if ( resultValues[i] == LazyPropertyInitializer.UNFETCHED_PROPERTY ) {
+					replacedValues[i] = propertyTypes[i].replace( originalValues[i], null, session, owner, copyCache );
+				}
+				else {
+					replacedValues[i] = propertyTypes[i].replace(
+							originalValues[i],
+							resultValues[i],
+							session,
+							owner,
+							copyCache
+					);
+				}
+			}
+
+			if ( polymorphic ) {
+				EmbeddableInstantiator instantiator = mappingType.getRepresentationStrategy()
+						.getInstantiatorForClass( original.getClass().getName() );
+				return instantiator.instantiate( () -> replacedValues );
+			}
+			else if ( target == null || !isMutable() ) {
 				return instantiator( original ).instantiate( () -> replacedValues );
 			}
 			else {
 				setPropertyValues( target, replacedValues );
 				return target;
 			}
+
 		}
 	}
 
@@ -562,19 +585,46 @@ public class ComponentType extends AbstractType
 			return null;
 		}
 		else {
+			final var mappingType = embeddableTypeDescriptor();
+			final boolean polymorphic = mappingType.isPolymorphic();
+
 			final Object[] originalValues = getPropertyValues( original );
 			final Object[] resultValues = getPropertyValues( target );
-			final Object[] replacedValues = TypeHelper.replace(
-					originalValues,
-					resultValues,
-					propertyTypes,
-					session,
-					owner,
-					copyCache,
-					foreignKeyDirection
-			);
+			final Object[] replacedValues = new Object[propertySpan];
 
-			if ( target == null || !isMutable() ) {
+			for ( int i = 0; i < propertySpan; i++ ) {
+				if ( originalValues[i] == LazyPropertyInitializer.UNFETCHED_PROPERTY
+						|| originalValues[i] == PropertyAccessStrategyBackRefImpl.UNKNOWN ) {
+					replacedValues[i] = resultValues[i];
+				}
+				else if ( resultValues[i] == LazyPropertyInitializer.UNFETCHED_PROPERTY ) {
+					replacedValues[i] = propertyTypes[i].replace(
+							originalValues[i],
+							null,
+							session,
+							owner,
+							copyCache,
+							foreignKeyDirection
+					);
+				}
+				else {
+					replacedValues[i] = propertyTypes[i].replace(
+							originalValues[i],
+							resultValues[i],
+							session,
+							owner,
+							copyCache,
+							foreignKeyDirection
+					);
+				}
+			}
+
+			if ( polymorphic ) {
+				final EmbeddableInstantiator instantiator = mappingType.getRepresentationStrategy()
+						.getInstantiatorForClass( original.getClass().getName() );
+				return instantiator.instantiate( () -> replacedValues );
+			}
+			else if ( target == null || !isMutable() ) {
 				return instantiator( original ).instantiate( () -> replacedValues );
 			}
 			else {

--- a/hibernate-core/src/main/java/org/hibernate/type/ComponentType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/ComponentType.java
@@ -28,7 +28,6 @@ import org.hibernate.metamodel.mapping.EmbeddableMappingType;
 import org.hibernate.metamodel.mapping.EmbeddableValuedModelPart;
 import org.hibernate.metamodel.mapping.internal.MappingModelCreationProcess;
 import org.hibernate.metamodel.spi.EmbeddableInstantiator;
-import org.hibernate.property.access.internal.PropertyAccessStrategyBackRefImpl;
 import org.hibernate.query.sqm.tree.domain.SqmEmbeddableDomainType;
 import org.hibernate.type.descriptor.ValueExtractor;
 import org.hibernate.type.descriptor.jdbc.JdbcType;
@@ -526,55 +525,21 @@ public class ComponentType extends AbstractType
 			SharedSessionContractImplementor session,
 			Object owner,
 			Map<Object, Object> copyCache) {
-		if ( original == null ) {
-			return null;
-		}
-		else {
-			final var mappingType = embeddableTypeDescriptor();
-			boolean polymorphic = mappingType.isPolymorphic();
-
-			final Object[] originalValues = getPropertyValues( original );
-			final Object[] resultValues = getPropertyValues( target );
-			final Object[] replacedValues = new Object[propertySpan];
-
-
-			for ( int i = 0; i < propertySpan; i++ ) {
-				if ( originalValues[i] == LazyPropertyInitializer.UNFETCHED_PROPERTY
-						|| originalValues[i] == PropertyAccessStrategyBackRefImpl.UNKNOWN ) {
-					replacedValues[i] = resultValues[i];
-				}
-				else if ( resultValues[i] == LazyPropertyInitializer.UNFETCHED_PROPERTY ) {
-					replacedValues[i] = propertyTypes[i].replace( originalValues[i], null, session, owner, copyCache );
-				}
-				else {
-					replacedValues[i] = propertyTypes[i].replace(
-							originalValues[i],
-							resultValues[i],
-							session,
-							owner,
-							copyCache
-					);
-				}
-			}
-
-			if ( polymorphic ) {
-				EmbeddableInstantiator instantiator = mappingType.getRepresentationStrategy()
-						.getInstantiatorForClass( original.getClass().getName() );
-				return instantiator.instantiate( () -> replacedValues );
-			}
-			else if ( target == null || !isMutable() ) {
-				return instantiator( original ).instantiate( () -> replacedValues );
-			}
-			else {
-				setPropertyValues( target, replacedValues );
-				return target;
-			}
-
-		}
+		return replaceComponentValue( original, target, session, owner, copyCache, null );
 	}
 
 	@Override
 	public Object replace(
+			Object original,
+			Object target,
+			SharedSessionContractImplementor session,
+			Object owner,
+			Map<Object, Object> copyCache,
+			ForeignKeyDirection foreignKeyDirection) {
+		return replaceComponentValue( original, target, session, owner, copyCache, foreignKeyDirection );
+	}
+
+	private Object replaceComponentValue(
 			Object original,
 			Object target,
 			SharedSessionContractImplementor session,
@@ -590,41 +555,33 @@ public class ComponentType extends AbstractType
 
 			final Object[] originalValues = getPropertyValues( original );
 			final Object[] resultValues = getPropertyValues( target );
-			final Object[] replacedValues = new Object[propertySpan];
 
-			for ( int i = 0; i < propertySpan; i++ ) {
-				if ( originalValues[i] == LazyPropertyInitializer.UNFETCHED_PROPERTY
-						|| originalValues[i] == PropertyAccessStrategyBackRefImpl.UNKNOWN ) {
-					replacedValues[i] = resultValues[i];
-				}
-				else if ( resultValues[i] == LazyPropertyInitializer.UNFETCHED_PROPERTY ) {
-					replacedValues[i] = propertyTypes[i].replace(
-							originalValues[i],
-							null,
-							session,
-							owner,
-							copyCache,
-							foreignKeyDirection
-					);
-				}
-				else {
-					replacedValues[i] = propertyTypes[i].replace(
-							originalValues[i],
-							resultValues[i],
-							session,
-							owner,
-							copyCache,
-							foreignKeyDirection
-					);
-				}
+			Object[] replacedValues;
+			if ( foreignKeyDirection == null ) {
+				replacedValues = TypeHelper.replace(
+						originalValues,
+						resultValues,
+						propertyTypes,
+						propertySpan,
+						session,
+						owner,
+						copyCache
+				);
+			}
+			else {
+				replacedValues = TypeHelper.replace(
+						originalValues,
+						resultValues,
+						propertyTypes,
+						propertySpan,
+						session,
+						owner,
+						copyCache,
+						foreignKeyDirection
+				);
 			}
 
-			if ( polymorphic ) {
-				final EmbeddableInstantiator instantiator = mappingType.getRepresentationStrategy()
-						.getInstantiatorForClass( original.getClass().getName() );
-				return instantiator.instantiate( () -> replacedValues );
-			}
-			else if ( target == null || !isMutable() ) {
+			if ( target == null || !isMutable() || polymorphic ) {
 				return instantiator( original ).instantiate( () -> replacedValues );
 			}
 			else {

--- a/hibernate-core/src/main/java/org/hibernate/type/TypeHelper.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/TypeHelper.java
@@ -72,8 +72,32 @@ public class TypeHelper {
 			final SharedSessionContractImplementor session,
 			final Object owner,
 			final Map<Object, Object> copyCache) {
-		final Object[] copied = new Object[original.length];
-		for ( int i = 0; i < types.length; i++ ) {
+		return replace( original, target, types, original.length, session, owner, copyCache );
+	}
+
+	/**
+	 * Apply the {@link Type#replace} operation across a series of values.
+	 *
+	 * @param original The source of the state
+	 * @param target The target into which to replace the source values.
+	 * @param types The value types
+	 * @param length The specific length to replace
+	 * @param session The originating session
+	 * @param owner The entity "owning" the values
+	 * @param copyCache A map representing a cache of already replaced state
+	 *
+	 * @return The replaced state
+	 */
+	public static Object[] replace(
+			final Object[] original,
+			final Object[] target,
+			final Type[] types,
+			final int length,
+			final SharedSessionContractImplementor session,
+			final Object owner,
+			final Map<Object, Object> copyCache) {
+		final Object[] copied = new Object[length];
+		for ( int i = 0; i < length; i++ ) {
 			if ( original[i] == LazyPropertyInitializer.UNFETCHED_PROPERTY
 					|| original[i] == PropertyAccessStrategyBackRefImpl.UNKNOWN ) {
 				copied[i] = target[i];
@@ -139,8 +163,34 @@ public class TypeHelper {
 			final Object owner,
 			final Map<Object, Object> copyCache,
 			final ForeignKeyDirection foreignKeyDirection) {
-		final Object[] copied = new Object[original.length];
-		for ( int i = 0; i < types.length; i++ ) {
+		return replace( original, target, types, original.length, session, owner, copyCache, foreignKeyDirection );
+	}
+
+	/**
+	 * Apply the {@link Type#replace} operation across a series of values.
+	 *
+	 * @param original The source of the state
+	 * @param target The target into which to replace the source values.
+	 * @param types The value types
+	 * @param length The specific length to replace
+	 * @param session The originating session
+	 * @param owner The entity "owning" the values
+	 * @param copyCache A map representing a cache of already replaced state
+	 * @param foreignKeyDirection FK directionality to be applied to the replacement
+	 *
+	 * @return The replaced state
+	 */
+	public static Object[] replace(
+			final Object[] original,
+			final Object[] target,
+			final Type[] types,
+			final int length,
+			final SharedSessionContractImplementor session,
+			final Object owner,
+			final Map<Object, Object> copyCache,
+			final ForeignKeyDirection foreignKeyDirection) {
+		final Object[] copied = new Object[length];
+		for ( int i = 0; i < length; i++ ) {
 			if ( original[i] == LazyPropertyInitializer.UNFETCHED_PROPERTY
 					|| original[i] == PropertyAccessStrategyBackRefImpl.UNKNOWN ) {
 				copied[i] = target[i];

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/embeddable/EmbeddableInheritanceReplaceAfterPersistTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/embeddable/EmbeddableInheritanceReplaceAfterPersistTest.java
@@ -38,6 +38,7 @@ public class EmbeddableInheritanceReplaceAfterPersistTest {
 			var merged = session.merge( history );
 
 			assertThat( merged.getBase() )
+					.isExactlyInstanceOf( Base.class )
 					.isInstanceOfSatisfying(
 							Base.class, next -> {
 								assertThat( next.getNum() ).isEqualTo( 43 );

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/embeddable/EmbeddableInheritanceReplaceAfterPersistTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/embeddable/EmbeddableInheritanceReplaceAfterPersistTest.java
@@ -1,0 +1,136 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.mapping.embeddable;
+
+
+import jakarta.persistence.*;
+
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.JiraKey;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DomainModel( annotatedClasses = {
+		EmbeddableInheritanceReplaceAfterPersistTest.Emb.class,
+		EmbeddableInheritanceReplaceAfterPersistTest.Base.class,
+		EmbeddableInheritanceReplaceAfterPersistTest.Next.class,
+		EmbeddableInheritanceReplaceAfterPersistTest.Ent.class
+} )
+@SessionFactory
+@JiraKey( "HHH-20125" )
+public class EmbeddableInheritanceReplaceAfterPersistTest {
+
+	@Test
+	void merge(SessionFactoryScope scope) {
+		scope.inTransaction( session -> {
+			final var history = new Ent();
+			history.setBase( new Emb( 42, "Hello, World!" ) );
+			session.persist( history );
+			session.flush();
+			session.clear();
+
+			history.setBase( new Base( 43 ) );
+			var merged = session.merge( history );
+
+			assertThat( merged.getBase() )
+					.isInstanceOfSatisfying(
+							Base.class, next -> {
+								assertThat( next.getNum() ).isEqualTo( 43 );
+							}
+					);
+		} );
+	}
+
+	@Embeddable
+	@DiscriminatorColumn( discriminatorType = DiscriminatorType.CHAR )
+	@DiscriminatorValue( "b" )
+	public static class Base {
+
+		protected int num;
+
+		protected Base() {
+		}
+
+		public Base(int num) {
+			this.num = num;
+		}
+
+		public int getNum() {
+			return num;
+		}
+
+		public void setNum(int num) {
+			this.num = num;
+		}
+	}
+
+	@Embeddable
+	@DiscriminatorValue( "n" )
+	public static class Next extends Base {
+
+		private String str;
+
+		public Next(int num, String str) {
+			super( num );
+			this.str = str;
+		}
+
+		public Next() {
+		}
+
+		public String getStr() {
+			return str;
+		}
+	}
+
+	@Embeddable
+	@DiscriminatorValue( "E" )
+	public static final class Emb extends Next {
+
+		Emb() {
+		}
+
+		public Emb(int num, String str) {
+			super( num, str );
+		}
+	}
+
+	@Entity( name = "Ent" )
+	public static class Ent {
+
+		@Id
+		@GeneratedValue
+		private Integer id;
+
+		@Embedded
+		private Base base;
+
+		public Ent() {
+		}
+
+		public Ent(final Integer id) {
+			this.id = id;
+		}
+
+		public Integer getId() {
+			return id;
+		}
+
+		public void setId(Integer id) {
+			this.id = id;
+		}
+
+		public Base getBase() {
+			return base;
+		}
+
+		public void setBase(Base base) {
+			this.base = base;
+		}
+	}
+}


### PR DESCRIPTION

fix [HHH-20125](https://hibernate.atlassian.net/browse/HHH-20125)

Avoid routing the embeddable discriminator through TypeHelper.replace() when replacing ComponentType values. 
Instead, replace only mapped property slots and select the concrete embeddable instantiator from the original value class.


<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------


[HHH-20125]: https://hibernate.atlassian.net/browse/HHH-20125?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

---
<!-- Hibernate GitHub Bot task list start -->
Please make sure that the following tasks are completed:
Tasks specific to HHH-20125 (Bug):
- [x] Add test reproducing the bug
- [x] Add entries as relevant to `migration-guide.adoc` **OR** check there are no breaking changes


<!-- Hibernate GitHub Bot task list end -->