### PR TITLE
HHH-20319 : Infer key-type for @Any

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/boot/model/internal/BasicValueBinder.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/internal/BasicValueBinder.java
@@ -24,6 +24,7 @@ import jakarta.persistence.Version;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.hibernate.AnnotationException;
 import org.hibernate.MappingException;
+import org.hibernate.mapping.Property;
 import org.hibernate.type.TimeZoneStorageStrategy;
 import org.hibernate.annotations.*;
 import org.hibernate.boot.internal.AnyKeyType;
@@ -835,7 +836,19 @@ public class BasicValueBinder implements JdbcTypeIndicators {
 	}
 
 	private void prepareAnyKey(MemberDetails member) {
-		implicitJavaTypeAccess = typeConfiguration -> null;
+		implicitJavaTypeAccess = typeConfiguration -> {
+			Property declaredIdentifierProperty = this.columns
+					.getPropertyHolder()
+					.getPersistentClass()
+					.getRootClass()
+					.getDeclaredIdentifierProperty();
+			if ( declaredIdentifierProperty.isComposite() ) {
+				throw new MappingException("Could not infer key-type for `@Any` mapping; must specify `@AnyKeyJavaType` or `@AnyKeyJavaClass`" );
+			}
+			return buildingContext.getBootstrapContext()
+					.getClassLoaderService()
+					.classForName( declaredIdentifierProperty.getReturnedClassName() );
+		};
 
 		final boolean useDeferredBeanContainerAccess = useDeferredBeanContainerAccess();
 
@@ -873,8 +886,7 @@ public class BasicValueBinder implements JdbcTypeIndicators {
 					return (BasicJavaType<?>) registeredType.getJavaTypeDescriptor();
 				}
 			}
-
-			throw new MappingException("Could not determine key type for '@Any' mapping (specify '@AnyKeyJavaType' or '@AnyKeyJavaClass')");
+			return null;
 		};
 
 		explicitJdbcTypeAccess = typeConfiguration -> {

--- a/hibernate-core/src/main/java/org/hibernate/boot/model/internal/BasicValueBinder.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/internal/BasicValueBinder.java
@@ -850,7 +850,8 @@ public class BasicValueBinder implements JdbcTypeIndicators {
 	}
 
 	private void prepareAnyKey(MemberDetails member) {
-		implicitJavaTypeAccess = typeConfiguration -> null;
+		implicitJavaTypeAccess = typeConfiguration ->
+				BinderHelper.implicitAnyKeyJavaType( member, columns.getPropertyHolder(), buildingContext );
 
 		final boolean useDeferredBeanContainerAccess = useDeferredBeanContainerAccess();
 
@@ -888,8 +889,7 @@ public class BasicValueBinder implements JdbcTypeIndicators {
 					return (BasicJavaType<?>) registeredType.getJavaTypeDescriptor();
 				}
 			}
-
-			throw new MappingException("Could not determine key type for '@Any' mapping (specify '@AnyKeyJavaType' or '@AnyKeyJavaClass')");
+			return null;
 		};
 
 		explicitJdbcTypeAccess = typeConfiguration -> {

--- a/hibernate-core/src/main/java/org/hibernate/boot/model/internal/BinderHelper.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/internal/BinderHelper.java
@@ -808,6 +808,118 @@ public class BinderHelper {
 		return any;
 	}
 
+	/**
+	 * Infer the Java type of the {@linkplain Any#getKeyDescriptor() key} of an {@code @Any}
+	 * association, for mappings which specify neither {@code @AnyKeyJavaType} nor
+	 * {@code @AnyKeyJavaClass}.
+	 * <p>
+	 * When every target entity is known, that is, when all discriminator values are mapped
+	 * explicitly with {@code @AnyDiscriminatorValue}, the type is read from the identifiers of
+	 * those entities, which must all agree.
+	 * <p>
+	 * Otherwise the set of targets is open: any entity may be a target, since discriminator
+	 * values are resolved by name at runtime. There is then nothing reliable to read, and we
+	 * fall back on the convention that the key has the same type as the identifier of the
+	 * entity declaring the association. A mapping which does not follow that convention must
+	 * specify its key type explicitly.
+	 *
+	 * @return the inferred type, or {@code null} when no inference is possible
+	 */
+	static java.lang.reflect.Type implicitAnyKeyJavaType(
+			MemberDetails member,
+			PropertyHolder propertyHolder,
+			MetadataBuildingContext context) {
+		final var implicitValues =
+				member.getDirectAnnotationUsage( AnyDiscriminatorImplicitValues.class );
+		if ( implicitValues != null
+				&& implicitValues.value() == AnyDiscriminatorImplicitValues.Strategy.CUSTOM ) {
+			// only the user strategy knows which entities may be targeted
+			return null;
+		}
+		final List<Class<?>> targets = new ArrayList<>();
+		processAnyDiscriminatorValues(
+				member,
+				valueMapping -> targets.add( valueMapping.entity() ),
+				context.getBootstrapContext().getModelsContext()
+		);
+		return implicitValues == null && !targets.isEmpty()
+				? identifierTypeOfTargets( targets, context )
+				: identifierTypeOfDeclaringEntity( propertyHolder, context );
+	}
+
+	private static java.lang.reflect.Type identifierTypeOfTargets(
+			List<Class<?>> targets,
+			MetadataBuildingContext context) {
+		Class<?> keyType = null;
+		Class<?> keyTarget = null;
+		for ( var target : targets ) {
+			final var entityBinding = entityBinding( target, context );
+			if ( entityBinding == null ) {
+				// not an entity of this model: better to leave the type unresolved
+				return null;
+			}
+			final var targetType = identifierType( entityBinding, context );
+			if ( targetType == null ) {
+				return null;
+			}
+			else if ( keyType == null ) {
+				keyType = targetType;
+				keyTarget = target;
+			}
+			else if ( !keyType.equals( targetType ) ) {
+				throw new MappingException( "Could not infer key type for '@Any' mapping:"
+						+ " target entity '" + target.getName() + "' is identified by '"
+						+ targetType.getName() + "' but '" + keyTarget.getName()
+						+ "' is identified by '" + keyType.getName()
+						+ "' (specify '@AnyKeyJavaType' or '@AnyKeyJavaClass')" );
+			}
+		}
+		return keyType;
+	}
+
+	/**
+	 * Note that the entity name is not necessarily the class name, so the binding cannot
+	 * simply be looked up by name.
+	 */
+	private static PersistentClass entityBinding(Class<?> entityClass, MetadataBuildingContext context) {
+		final var collector = context.getMetadataCollector();
+		final var byEntityName = collector.getEntityBinding( entityClass.getName() );
+		if ( byEntityName != null ) {
+			return byEntityName;
+		}
+		for ( var binding : collector.getEntityBindings() ) {
+			if ( entityClass.getName().equals( binding.getClassName() ) ) {
+				return binding;
+			}
+		}
+		return null;
+	}
+
+	private static java.lang.reflect.Type identifierTypeOfDeclaringEntity(
+			PropertyHolder propertyHolder,
+			MetadataBuildingContext context) {
+		final var declaringEntity = propertyHolder.getPersistentClass();
+		return declaringEntity == null ? null : identifierType( declaringEntity.getRootClass(), context );
+	}
+
+	private static Class<?> identifierType(PersistentClass entityBinding, MetadataBuildingContext context) {
+		final var identifier = entityBinding.getIdentifier();
+		if ( identifier == null ) {
+			return null;
+		}
+		else if ( identifier.getColumnSpan() > 1 ) {
+			// note that getSelectableType() would happily return the type of the first column
+			throw new MappingException( "Could not infer key type for '@Any' mapping:"
+					+ " entity '" + entityBinding.getEntityName() + "' has a composite identifier"
+					+ " (specify '@AnyKeyJavaType' or '@AnyKeyJavaClass')" );
+		}
+		else {
+			return identifier.getSelectableType( context.getMetadataCollector(), 0 )
+					.getMappedJavaType()
+					.getJavaTypeClass();
+		}
+	}
+
 	private static void processAnyDiscriminatorValues(
 			MemberDetails property,
 			Consumer<AnyDiscriminatorValue> consumer,

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/any/AnyImplicitCompositeKeyCannotBeDeterminedTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/any/AnyImplicitCompositeKeyCannotBeDeterminedTest.java
@@ -1,0 +1,71 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.any;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import jakarta.persistence.EmbeddedId;
+import jakarta.persistence.Entity;
+import jakarta.persistence.JoinColumn;
+import org.hibernate.MappingException;
+import org.hibernate.annotations.Any;
+import org.hibernate.testing.orm.junit.EntityManagerFactoryScope;
+import org.hibernate.testing.orm.junit.JiraKey;
+import org.hibernate.testing.orm.junit.Jpa;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.io.Serializable;
+
+/**
+ * Verifies that implicit key type resolution for @Any mappings fails
+ * when the target entity uses a composite identifier.
+ * <p>
+ * In this case, Hibernate cannot infer the key Java type automatically,
+ * and an explicit @AnyKeyJavaClass (or @AnyKeyJavaType) must be provided.
+ *
+ * @author Vincent Bouthinon
+ */
+@Jpa(annotatedClasses = {AnyImplicitCompositeKeyCannotBeDeterminedTest.Book.class})
+@JiraKey("HHH-20319")
+class AnyImplicitCompositeKeyCannotBeDeterminedTest {
+
+	@Test
+	void test(EntityManagerFactoryScope scope) {
+		MappingException ex = Assertions.assertThrows( MappingException.class,
+				() -> scope.inTransaction( em -> {
+				} ) );
+
+		Assertions.assertTrue( ex.getMessage().contains( "Could not infer key-type for `@Any` mapping" ),
+				"Expected message about missing @AnyKeyJavaType / @AnyKeyJavaClass, got: " + ex.getMessage() );
+	}
+
+	@Entity(name = "book")
+	public static class Book {
+
+		@EmbeddedId
+		private BookId id;
+
+		@Any
+		@JoinColumn(name = "origin_id")
+		@Column(name = "origin_type")
+		private Object origin;
+
+		public Book(BookId bookId) {
+			this.id = bookId;
+		}
+
+	}
+
+	@Embeddable
+	public static class BookId implements Serializable {
+
+		@Column(name = "isbn")
+		private String isbn;
+
+		@Column(name = "language_code")
+		private String languageCode;
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/any/AnyImplicitCompositeKeyCannotBeDeterminedTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/any/AnyImplicitCompositeKeyCannotBeDeterminedTest.java
@@ -1,0 +1,71 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.any;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import jakarta.persistence.EmbeddedId;
+import jakarta.persistence.Entity;
+import jakarta.persistence.JoinColumn;
+import org.hibernate.MappingException;
+import org.hibernate.annotations.Any;
+import org.hibernate.testing.orm.junit.EntityManagerFactoryScope;
+import org.hibernate.testing.orm.junit.JiraKey;
+import org.hibernate.testing.orm.junit.Jpa;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.io.Serializable;
+
+/**
+ * Verifies that implicit key type resolution for @Any mappings fails
+ * when the target entity uses a composite identifier.
+ * <p>
+ * In this case, Hibernate cannot infer the key Java type automatically,
+ * and an explicit @AnyKeyJavaClass (or @AnyKeyJavaType) must be provided.
+ *
+ * @author Vincent Bouthinon
+ */
+@Jpa(annotatedClasses = {AnyImplicitCompositeKeyCannotBeDeterminedTest.Book.class})
+@JiraKey("HHH-20319")
+class AnyImplicitCompositeKeyCannotBeDeterminedTest {
+
+	@Test
+	void test(EntityManagerFactoryScope scope) {
+		MappingException ex = Assertions.assertThrows( MappingException.class,
+				() -> scope.inTransaction( em -> {
+				} ) );
+
+		Assertions.assertTrue( ex.getMessage().contains( "has a composite identifier" ),
+				"Expected message about the composite identifier, got: " + ex.getMessage() );
+	}
+
+	@Entity(name = "book")
+	public static class Book {
+
+		@EmbeddedId
+		private BookId id;
+
+		@Any
+		@JoinColumn(name = "origin_id")
+		@Column(name = "origin_type")
+		private Object origin;
+
+		public Book(BookId bookId) {
+			this.id = bookId;
+		}
+
+	}
+
+	@Embeddable
+	public static class BookId implements Serializable {
+
+		@Column(name = "isbn")
+		private String isbn;
+
+		@Column(name = "language_code")
+		private String languageCode;
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/any/AnyImplicitKeyTypeFromTargetEntitiesTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/any/AnyImplicitKeyTypeFromTargetEntitiesTest.java
@@ -1,0 +1,135 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.any;
+
+import org.hibernate.annotations.Any;
+import org.hibernate.annotations.AnyDiscriminatorValue;
+import org.hibernate.mapping.PersistentClass;
+
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.DomainModelScope;
+import org.hibernate.testing.orm.junit.JiraKey;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.Table;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * When neither {@link org.hibernate.annotations.AnyKeyJavaType} nor
+ * {@link org.hibernate.annotations.AnyKeyJavaClass} is specified, the key type of an
+ * {@link Any} association must be inferred from the identifier of the <em>target</em>
+ * entities, not from the identifier of the entity <em>declaring</em> the association.
+ * <p>
+ * The two are unrelated: the value stored in the key column is handed straight to
+ * {@code AnyType#resolve} as the identifier of the target entity. Here {@link Shelf} is
+ * identified by a generated {@code Long}, while every target ({@link Book}, {@link Magazine})
+ * is identified by a natural {@code String} key. The only correct inference is therefore
+ * {@code String}, and it is unambiguous since all targets agree.
+ * <p>
+ * Inferring from {@code Shelf#id} would silently yield {@code Long}: the schema would use a
+ * numeric key column and the association would only break later, at runtime.
+ *
+ * @author Vincent Bouthinon
+ */
+@DomainModel(annotatedClasses = {
+		AnyImplicitKeyTypeFromTargetEntitiesTest.Shelf.class,
+		AnyImplicitKeyTypeFromTargetEntitiesTest.Book.class,
+		AnyImplicitKeyTypeFromTargetEntitiesTest.Magazine.class
+})
+@SessionFactory
+@JiraKey("HHH-20319")
+class AnyImplicitKeyTypeFromTargetEntitiesTest {
+
+	private static final String ISBN = "978-2-1234-5680-3";
+
+	@AfterEach
+	void cleanup(SessionFactoryScope scope) {
+		scope.dropData();
+	}
+
+	@Test
+	void keyTypeIsInferredFromTargetEntities(DomainModelScope scope) {
+		final PersistentClass shelfBinding =
+				scope.getDomainModel().getEntityBinding( Shelf.class.getName() );
+		final org.hibernate.mapping.Any content =
+				(org.hibernate.mapping.Any) shelfBinding.getProperty( "content" ).getValue();
+
+		assertThat( content.getKeyDescriptor().resolve().getDomainJavaType().getJavaTypeClass() )
+				.as( "the '@Any' key type must be inferred from the target entities"
+						+ " (Book#isbn, Magazine#issn), not from the declaring entity (Shelf#id)" )
+				.isEqualTo( String.class );
+	}
+
+	@Test
+	void anyAssociationRoundTrips(SessionFactoryScope scope) {
+		scope.inTransaction( session -> {
+			final Book book = new Book( ISBN, "Hibernate in Action" );
+			session.persist( book );
+			final Shelf shelf = new Shelf();
+			shelf.content = book;
+			session.persist( shelf );
+		} );
+
+		scope.inTransaction( session -> {
+			final Shelf shelf =
+					session.createQuery( "from Shelf", Shelf.class ).getSingleResult();
+			assertThat( shelf.content ).isInstanceOf( Book.class );
+			assertThat( ( (Book) shelf.content ).isbn ).isEqualTo( ISBN );
+		} );
+	}
+
+	@Entity(name = "Shelf")
+	@Table(name = "SHELF")
+	static class Shelf {
+
+		@Id
+		@GeneratedValue
+		Long id;
+
+		@Any
+		@JoinColumn(name = "CONTENT_ID")
+		@Column(name = "CONTENT_TYPE")
+		@AnyDiscriminatorValue(discriminator = "B", entity = Book.class)
+		@AnyDiscriminatorValue(discriminator = "M", entity = Magazine.class)
+		Object content;
+	}
+
+	@Entity(name = "Book")
+	@Table(name = "BOOK")
+	static class Book {
+
+		@Id
+		String isbn;
+
+		String title;
+
+		Book() {
+		}
+
+		Book(String isbn, String title) {
+			this.isbn = isbn;
+			this.title = title;
+		}
+	}
+
+	@Entity(name = "Magazine")
+	@Table(name = "MAGAZINE")
+	static class Magazine {
+
+		@Id
+		String issn;
+
+		String title;
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/any/AnyImpliciteKeyJavaClassTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/any/AnyImpliciteKeyJavaClassTest.java
@@ -1,0 +1,51 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.any;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import org.hibernate.annotations.Any;
+import org.hibernate.testing.orm.junit.EntityManagerFactoryScope;
+import org.hibernate.testing.orm.junit.JiraKey;
+import org.hibernate.testing.orm.junit.Jpa;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test of implicit determination of the key type of @Any.
+ *
+ * @author Vincent Bouthinon
+ */
+@Jpa(annotatedClasses = {AnyImpliciteKeyJavaClassTest.Book.class})
+@JiraKey("HHH-20319")
+class AnyImpliciteKeyJavaClassTest {
+
+	@Test
+	void test(EntityManagerFactoryScope scope) {
+			scope.inTransaction(
+					entityManager -> {
+						entityManager.persist( new Book() );
+						entityManager.flush();
+						entityManager.clear();
+					}
+			);
+	}
+
+	@Entity(name = "book")
+	public static class Book {
+
+		@Id
+		@GeneratedValue
+		private String id;
+
+		@Any
+		@JoinColumn(name = "origin_id")
+		@Column(name = "origin_type")
+		private Object origin;
+
+	}
+}


### PR DESCRIPTION
Following this conversion: https://hibernate.zulipchat.com/#narrow/channel/132096-hibernate-user/topic/.5BConvenience.5D.20Automatically.20determine.20.40AnyKeyJavaClass/with/583301589

Assuming that all @Id types in a given database are of the same type, it is proposed to implicitly determine the @AnyKeyJavaClass.

Since this does not work for composite keys, an exception will be thrown to explain how to explicitly define the type.

In practice, the system uses the type of the @Id of the entity that owns the @Any attribute as a reference.

----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------


---
<!-- Hibernate GitHub Bot task list start -->Please make sure that the following tasks are completed:
Tasks specific to HHH-20319 (Improvement):
- [ ] Add tests for feature/improvement
- [ ] Update documentation as relevant: javadoc for changed API, `documentation/src/main/asciidoc/userguide` for all features, `documentation/src/main/asciidoc/introduction` for main features, links from existing documentation
- [ ] Add entries as relevant to `migration-guide.adoc` (breaking changes) and `whats-new.adoc` (new features/improvements)


<!-- Hibernate GitHub Bot task list end -->

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-20319
<!-- Hibernate GitHub Bot issue links end -->