### PR TITLE
HHH-20324 AnnotationException: overrides mapping specified using '@JoinColumnOrFormula' thrown when join column is overridden via XML mapping

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/boot/models/xml/internal/db/JoinColumnProcessing.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/xml/internal/db/JoinColumnProcessing.java
@@ -33,6 +33,9 @@ import jakarta.persistence.MapKeyJoinColumn;
 import jakarta.persistence.PrimaryKeyJoinColumn;
 import jakarta.persistence.PrimaryKeyJoinColumns;
 
+import static org.hibernate.boot.models.JpaAnnotations.JOIN_COLUMN;
+import static org.hibernate.boot.models.JpaAnnotations.JOIN_COLUMNS;
+
 /**
  * XML -> AnnotationUsage support for {@linkplain JaxbColumnJoined}: <ul>
  *     <li>{@code <join-column/>}</li>
@@ -53,8 +56,8 @@ public class JoinColumnProcessing {
 		}
 
 		final JoinColumnsJpaAnnotation columnsAnn = (JoinColumnsJpaAnnotation) memberDetails.replaceAnnotationUsage(
-				JpaAnnotations.JOIN_COLUMN,
-				JpaAnnotations.JOIN_COLUMNS,
+				JOIN_COLUMN,
+				JOIN_COLUMNS,
 				xmlDocumentContext.getModelBuildingContext()
 		);
 		columnsAnn.value( transformJoinColumnList(
@@ -74,7 +77,7 @@ public class JoinColumnProcessing {
 
 		final JoinColumn[] joinColumns = new JoinColumn[jaxbJoinColumns.size()];
 		for ( int i = 0; i < jaxbJoinColumns.size(); i++ ) {
-			final JoinColumnJpaAnnotation joinColumn = JpaAnnotations.JOIN_COLUMN.createUsage( xmlDocumentContext.getModelBuildingContext() );
+			final JoinColumnJpaAnnotation joinColumn = JOIN_COLUMN.createUsage( xmlDocumentContext.getModelBuildingContext() );
 			joinColumns[i] = joinColumn;
 			joinColumn.apply( jaxbJoinColumns.get( i ), xmlDocumentContext );
 		}
@@ -86,40 +89,74 @@ public class JoinColumnProcessing {
 			MutableMemberDetails memberDetails,
 			XmlDocumentContext xmlDocumentContext) {
 		if ( !CollectionHelper.isEmpty( jaxbJoinColumnsOrFormulas ) ) {
-			memberDetails.removeAnnotationUsage( JpaAnnotations.JOIN_COLUMN );
-			memberDetails.removeAnnotationUsage( JpaAnnotations.JOIN_COLUMNS );
-			final JoinColumnsOrFormulasAnnotation joinColumnsOrFormulasUsage = (JoinColumnsOrFormulasAnnotation) memberDetails.replaceAnnotationUsage(
-					HibernateAnnotations.JOIN_COLUMN_OR_FORMULA,
-					HibernateAnnotations.JOIN_COLUMNS_OR_FORMULAS,
-					xmlDocumentContext.getModelBuildingContext()
-			);
+			if ( hasOnlyJoinColumns(jaxbJoinColumnsOrFormulas) ) {
+				applyPureJoinColumns( jaxbJoinColumnsOrFormulas, memberDetails, xmlDocumentContext );
+			}
+			else {
+				memberDetails.removeAnnotationUsage( JpaAnnotations.JOIN_COLUMN );
+				memberDetails.removeAnnotationUsage( JpaAnnotations.JOIN_COLUMNS );
+				final JoinColumnsOrFormulasAnnotation joinColumnsOrFormulasUsage = (JoinColumnsOrFormulasAnnotation) memberDetails.replaceAnnotationUsage(
+						HibernateAnnotations.JOIN_COLUMN_OR_FORMULA,
+						HibernateAnnotations.JOIN_COLUMNS_OR_FORMULAS,
+						xmlDocumentContext.getModelBuildingContext()
+				);
 
-			final JoinColumnOrFormula[] joinColumnOrFormulaList = new JoinColumnOrFormula[jaxbJoinColumnsOrFormulas.size()];
-			joinColumnsOrFormulasUsage.value( joinColumnOrFormulaList );
+				final JoinColumnOrFormula[] joinColumnOrFormulaList = new JoinColumnOrFormula[jaxbJoinColumnsOrFormulas.size()];
+				joinColumnsOrFormulasUsage.value( joinColumnOrFormulaList );
 
-			for ( int i = 0; i < jaxbJoinColumnsOrFormulas.size(); i++ ) {
-				final JoinColumnOrFormulaAnnotation joinColumnOrFormulaUsage = HibernateAnnotations.JOIN_COLUMN_OR_FORMULA.createUsage(
-						xmlDocumentContext.getModelBuildingContext() );
-				joinColumnOrFormulaList[i] = joinColumnOrFormulaUsage;
-
-				final Serializable jaxbJoinColumnOrFormula = jaxbJoinColumnsOrFormulas.get( i );
-				if ( jaxbJoinColumnOrFormula instanceof JaxbJoinColumnImpl jaxbJoinColumn ) {
-					final JoinColumnJpaAnnotation joinColumnUsage = JpaAnnotations.JOIN_COLUMN.createUsage(
+				for ( int i = 0; i < jaxbJoinColumnsOrFormulas.size(); i++ ) {
+					final JoinColumnOrFormulaAnnotation joinColumnOrFormulaUsage = HibernateAnnotations.JOIN_COLUMN_OR_FORMULA.createUsage(
 							xmlDocumentContext.getModelBuildingContext() );
-					joinColumnOrFormulaUsage.column( joinColumnUsage );
-					joinColumnUsage.apply( jaxbJoinColumn, xmlDocumentContext );
-				}
-				else if ( jaxbJoinColumnOrFormula instanceof String jaxbJoinFormula ) {
-					final JoinFormulaAnnotation joinFormulaUsage = HibernateAnnotations.JOIN_FORMULA.createUsage(
-							xmlDocumentContext.getModelBuildingContext() );
-					joinColumnOrFormulaUsage.formula( joinFormulaUsage );
-					joinFormulaUsage.value( jaxbJoinFormula );
-				}
-				else {
-					throw new MappingException( "Unexpected join-column-or-formula type : " + jaxbJoinColumnOrFormula );
+					joinColumnOrFormulaList[i] = joinColumnOrFormulaUsage;
+
+					final Serializable jaxbJoinColumnOrFormula = jaxbJoinColumnsOrFormulas.get( i );
+					if ( jaxbJoinColumnOrFormula instanceof JaxbJoinColumnImpl jaxbJoinColumn ) {
+						final JoinColumnJpaAnnotation joinColumnUsage = JpaAnnotations.JOIN_COLUMN.createUsage(
+								xmlDocumentContext.getModelBuildingContext() );
+						joinColumnOrFormulaUsage.column( joinColumnUsage );
+						joinColumnUsage.apply( jaxbJoinColumn, xmlDocumentContext );
+					}
+					else if ( jaxbJoinColumnOrFormula instanceof String jaxbJoinFormula ) {
+						final JoinFormulaAnnotation joinFormulaUsage = HibernateAnnotations.JOIN_FORMULA.createUsage(
+								xmlDocumentContext.getModelBuildingContext() );
+						joinColumnOrFormulaUsage.formula( joinFormulaUsage );
+						joinFormulaUsage.value( jaxbJoinFormula );
+					}
+					else {
+						throw new MappingException(
+								"Unexpected join-column-or-formula type : " + jaxbJoinColumnOrFormula );
+					}
 				}
 			}
 		}
+	}
+
+	private static boolean hasOnlyJoinColumns(List<Serializable> jaxbJoinColumnsOrFormulas) {
+		return jaxbJoinColumnsOrFormulas.stream().allMatch( element -> element instanceof JaxbJoinColumnImpl );
+	}
+
+	private static void applyPureJoinColumns(
+			List<Serializable> jaxbJoinColumns,
+			MutableMemberDetails memberDetails,
+			XmlDocumentContext xmlDocumentContext) {
+			memberDetails.removeAnnotationUsage( JOIN_COLUMN );
+			memberDetails.removeAnnotationUsage( JOIN_COLUMNS );
+			final JoinColumnsJpaAnnotation joinColumnsUsage = (JoinColumnsJpaAnnotation) memberDetails.replaceAnnotationUsage(
+					JOIN_COLUMN,
+					JOIN_COLUMNS,
+					xmlDocumentContext.getModelBuildingContext()
+			);
+
+			final JoinColumn[] joinColumn = new JoinColumn[jaxbJoinColumns.size()];
+			joinColumnsUsage.value( joinColumn );
+
+			for ( int i = 0; i < jaxbJoinColumns.size(); i++ ) {
+				final Serializable jaxbJoinColumnOrFormula = jaxbJoinColumns.get( i );
+				final JoinColumnJpaAnnotation joinColumnUsage = JOIN_COLUMN.createUsage(
+						xmlDocumentContext.getModelBuildingContext() );
+				joinColumn[i] = joinColumnUsage;
+				joinColumnUsage.apply( (JaxbJoinColumnImpl) jaxbJoinColumnOrFormula, xmlDocumentContext );
+			}
 	}
 
 	/**

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/xml/ejb3/Ejb3XmlManyToOneTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/xml/ejb3/Ejb3XmlManyToOneTest.java
@@ -6,9 +6,6 @@ package org.hibernate.orm.test.annotations.xml.ejb3;
 
 import org.hibernate.annotations.Cascade;
 import org.hibernate.annotations.CascadeType;
-import org.hibernate.annotations.JoinColumnOrFormula;
-import org.hibernate.annotations.JoinColumnsOrFormulas;
-import org.hibernate.annotations.JoinFormula;
 import org.hibernate.boot.internal.Target;
 import org.hibernate.models.spi.MemberDetails;
 
@@ -57,19 +54,16 @@ public class Ejb3XmlManyToOneTest extends Ejb3XmlTestCase {
 	public void testSingleJoinColumn() {
 		final MemberDetails memberDetails = getAttributeMember( Entity1.class, "field1", "many-to-one.orm2.xml" );
 		assertThat( memberDetails.hasDirectAnnotationUsage( ManyToOne.class ) ).isTrue();
-		assertThat( memberDetails.hasDirectAnnotationUsage( JoinColumnsOrFormulas.class ) ).isTrue();
 
-		assertThat( memberDetails.hasDirectAnnotationUsage( JoinColumnOrFormula.class ) ).isFalse();
-		assertThat( memberDetails.hasDirectAnnotationUsage( JoinColumns.class ) ).isFalse();
 		assertThat( memberDetails.hasDirectAnnotationUsage( JoinColumn.class ) ).isFalse();
-		assertThat( memberDetails.hasDirectAnnotationUsage( JoinFormula.class ) ).isFalse();
+		assertThat( memberDetails.hasDirectAnnotationUsage( JoinColumns.class ) ).isTrue();
 
 		assertThat( memberDetails.hasDirectAnnotationUsage( JoinTable.class ) ).isFalse();
 		assertThat( memberDetails.hasDirectAnnotationUsage( Id.class ) ).isFalse();
 		assertThat( memberDetails.hasDirectAnnotationUsage( MapsId.class ) ).isFalse();
 
-		final JoinColumnsOrFormulas joinColumnsOrFormulasUsage = memberDetails.getDirectAnnotationUsage( JoinColumnsOrFormulas.class );
-		final JoinColumn joinColumnUsage = joinColumnsOrFormulasUsage.value()[0].column();
+		final JoinColumns joinColumnsUsage = memberDetails.getDirectAnnotationUsage( JoinColumns.class );
+		final JoinColumn joinColumnUsage = joinColumnsUsage.value()[0];
 		assertThat( joinColumnUsage.name() ).isEqualTo( "col1" );
 		assertThat( joinColumnUsage.referencedColumnName() ).isEqualTo( "col2" );
 		assertThat( joinColumnUsage.table() ).isEqualTo( "table1" );
@@ -79,20 +73,18 @@ public class Ejb3XmlManyToOneTest extends Ejb3XmlTestCase {
 	public void testMultipleJoinColumns() {
 		final MemberDetails memberDetails = getAttributeMember( Entity1.class, "field1", "many-to-one.orm3.xml" );
 		assertThat( memberDetails.hasDirectAnnotationUsage( ManyToOne.class ) ).isTrue();
-		assertThat( memberDetails.hasDirectAnnotationUsage( JoinColumnsOrFormulas.class ) ).isTrue();
+		assertThat( memberDetails.hasDirectAnnotationUsage( JoinColumns.class ) ).isTrue();
 
-		assertThat( memberDetails.hasDirectAnnotationUsage( JoinColumnOrFormula.class ) ).isFalse();
-		assertThat( memberDetails.hasDirectAnnotationUsage( JoinFormula.class ) ).isFalse();
 		assertThat( memberDetails.hasDirectAnnotationUsage( JoinColumn.class ) ).isFalse();
 		assertThat( memberDetails.hasDirectAnnotationUsage( JoinTable.class ) ).isFalse();
 		assertThat( memberDetails.hasDirectAnnotationUsage( Id.class ) ).isFalse();
 		assertThat( memberDetails.hasDirectAnnotationUsage( MapsId.class ) ).isFalse();
 
-		final JoinColumnsOrFormulas joinColumnsOrFormulasUsage = memberDetails.getDirectAnnotationUsage( JoinColumnsOrFormulas.class );
-		final JoinColumnOrFormula[] joinColumnOrFormulaUsages = joinColumnsOrFormulasUsage.value();
-		assertThat( joinColumnOrFormulaUsages ).hasSize( 2 );
+		final JoinColumns joinColumnsUsage = memberDetails.getDirectAnnotationUsage( JoinColumns.class );
+		final JoinColumn[] joinColumnUsages = joinColumnsUsage.value();
+		assertThat( joinColumnUsages ).hasSize( 2 );
 
-		final JoinColumn joinColumnUsage0 = joinColumnOrFormulaUsages[0].column();
+		final JoinColumn joinColumnUsage0 = joinColumnUsages[0];
 		assertThat( joinColumnUsage0.name() ).isEmpty();
 		assertThat( joinColumnUsage0.referencedColumnName() ).isEmpty();
 		assertThat( joinColumnUsage0.table() ).isEmpty();
@@ -102,7 +94,7 @@ public class Ejb3XmlManyToOneTest extends Ejb3XmlTestCase {
 		assertThat( joinColumnUsage0.nullable() ).isTrue();
 		assertThat( joinColumnUsage0.unique() ).isFalse();
 
-		final JoinColumn joinColumnUsage1 = joinColumnOrFormulaUsages[1].column();
+		final JoinColumn joinColumnUsage1 = joinColumnUsages[1];
 		assertThat( joinColumnUsage1.name() ).isEqualTo( "col1" );
 		assertThat( joinColumnUsage1.referencedColumnName() ).isEqualTo( "col2" );
 		assertThat( joinColumnUsage1.table() ).isEqualTo( "table1" );

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/xml/ejb3/Ejb3XmlOneToOneTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/xml/ejb3/Ejb3XmlOneToOneTest.java
@@ -6,8 +6,6 @@ package org.hibernate.orm.test.annotations.xml.ejb3;
 
 import org.hibernate.annotations.Cascade;
 import org.hibernate.annotations.CascadeType;
-import org.hibernate.annotations.JoinColumnOrFormula;
-import org.hibernate.annotations.JoinColumnsOrFormulas;
 import org.hibernate.boot.internal.Target;
 import org.hibernate.models.spi.MemberDetails;
 
@@ -116,7 +114,8 @@ public class Ejb3XmlOneToOneTest extends Ejb3XmlTestCase {
 	public void testSingleJoinColumn() {
 		final MemberDetails memberDetails = getAttributeMember( Entity1.class, "field1", "one-to-one.orm4.xml" );
 		assertThat( memberDetails.hasDirectAnnotationUsage( OneToOne.class ) ).isTrue();
-		assertThat( memberDetails.hasDirectAnnotationUsage( JoinColumnsOrFormulas.class ) ).isTrue();
+		assertThat( memberDetails.hasDirectAnnotationUsage( JoinColumn.class ) ).isFalse();
+		assertThat( memberDetails.hasDirectAnnotationUsage( JoinColumns.class ) ).isTrue();
 
 		assertThat( memberDetails.hasDirectAnnotationUsage( MapsId.class ) ).isFalse();
 		assertThat( memberDetails.hasDirectAnnotationUsage( Id.class ) ).isFalse();
@@ -124,9 +123,9 @@ public class Ejb3XmlOneToOneTest extends Ejb3XmlTestCase {
 		assertThat( memberDetails.hasDirectAnnotationUsage( PrimaryKeyJoinColumn.class ) ).isFalse();
 		assertThat( memberDetails.hasDirectAnnotationUsage( JoinTable.class ) ).isFalse();
 
-		final JoinColumnsOrFormulas joinColumnsOrFormulas = memberDetails.getDirectAnnotationUsage( JoinColumnsOrFormulas.class );
-		assertThat( joinColumnsOrFormulas.value() ).hasSize( 1 );
-		final JoinColumn joinColumnUsage = joinColumnsOrFormulas.value()[0].column();
+		final JoinColumns joinColumnsUsage = memberDetails.getDirectAnnotationUsage( JoinColumns.class );
+		assertThat( joinColumnsUsage.value() ).hasSize( 1 );
+		final JoinColumn joinColumnUsage = joinColumnsUsage.value()[0];
 		assertThat( joinColumnUsage.name() ).isEqualTo( "col1" );
 		assertThat( joinColumnUsage.referencedColumnName() ).isEqualTo( "col2" );
 		assertThat( joinColumnUsage.table() ).isEqualTo( "table1" );
@@ -136,7 +135,7 @@ public class Ejb3XmlOneToOneTest extends Ejb3XmlTestCase {
 	public void testMultipleJoinColumns(){
 		final MemberDetails memberDetails = getAttributeMember( Entity1.class, "field1", "one-to-one.orm5.xml" );
 		assertThat( memberDetails.hasDirectAnnotationUsage( OneToOne.class ) ).isTrue();
-		assertThat( memberDetails.hasDirectAnnotationUsage( JoinColumnsOrFormulas.class ) ).isTrue();
+		assertThat( memberDetails.hasDirectAnnotationUsage( JoinColumns.class ) ).isTrue();
 
 		assertThat( memberDetails.hasDirectAnnotationUsage( MapsId.class ) ).isFalse();
 		assertThat( memberDetails.hasDirectAnnotationUsage( Id.class ) ).isFalse();
@@ -144,11 +143,11 @@ public class Ejb3XmlOneToOneTest extends Ejb3XmlTestCase {
 		assertThat( memberDetails.hasDirectAnnotationUsage( PrimaryKeyJoinColumn.class ) ).isFalse();
 		assertThat( memberDetails.hasDirectAnnotationUsage( JoinTable.class ) ).isFalse();
 
-		final JoinColumnsOrFormulas joinColumnsOrFormulasUsage = memberDetails.getDirectAnnotationUsage( JoinColumnsOrFormulas.class );
-		final JoinColumnOrFormula[] joinColumnOrFormulaUsages = joinColumnsOrFormulasUsage.value();
-		assertThat( joinColumnOrFormulaUsages ).hasSize( 2 );
+		final JoinColumns joinColumnsUsage = memberDetails.getDirectAnnotationUsage( JoinColumns.class );
+		final JoinColumn[] joinColumnUsages = joinColumnsUsage.value();
+		assertThat( joinColumnUsages ).hasSize( 2 );
 
-		final JoinColumn joinColumnUsage0 = joinColumnOrFormulaUsages[0].column();
+		final JoinColumn joinColumnUsage0 = joinColumnUsages[0];
 		assertThat( joinColumnUsage0.name() ).isEmpty();
 		assertThat( joinColumnUsage0.referencedColumnName() ).isEmpty();
 		assertThat( joinColumnUsage0.table() ).isEmpty();
@@ -158,7 +157,7 @@ public class Ejb3XmlOneToOneTest extends Ejb3XmlTestCase {
 		assertThat( joinColumnUsage0.nullable() ).isTrue();
 		assertThat( joinColumnUsage0.unique() ).isFalse();
 
-		final JoinColumn joinColumnUsage1 = joinColumnOrFormulaUsages[1].column();
+		final JoinColumn joinColumnUsage1 = joinColumnUsages[1];
 		assertThat( joinColumnUsage1.name() ).isEqualTo( "col1" );
 		assertThat( joinColumnUsage1.referencedColumnName() ).isEqualTo( "col2" );
 		assertThat( joinColumnUsage1.table() ).isEqualTo( "table1" );

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/boot/models/xml/attr/ManyToOneTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/boot/models/xml/attr/ManyToOneTests.java
@@ -8,8 +8,6 @@ import org.hibernate.annotations.Cascade;
 import org.hibernate.annotations.CascadeType;
 import org.hibernate.annotations.Fetch;
 import org.hibernate.annotations.FetchMode;
-import org.hibernate.annotations.JoinColumnOrFormula;
-import org.hibernate.annotations.JoinColumnsOrFormulas;
 import org.hibernate.annotations.NotFound;
 import org.hibernate.annotations.NotFoundAction;
 import org.hibernate.annotations.OnDelete;
@@ -50,20 +48,15 @@ public class ManyToOneTests {
 				.addXmlMappings( "mappings/models/attr/many-to-one/simple.xml" )
 				.build();
 
-		final ModelsContext ModelsContext = createBuildingContext( managedResources, serviceRegistry );
-		final ClassDetailsRegistry classDetailsRegistry = ModelsContext.getClassDetailsRegistry();
+		final ModelsContext modelsContext = createBuildingContext( managedResources, serviceRegistry );
+		final ClassDetailsRegistry classDetailsRegistry = modelsContext.getClassDetailsRegistry();
 
 		final ClassDetails classDetails = classDetailsRegistry.getClassDetails( SimpleEntity.class.getName() );
 
 		final FieldDetails parentField = classDetails.findFieldByName( "parent" );
 		final ManyToOne manyToOneAnn = parentField.getDirectAnnotationUsage( ManyToOne.class );
 		assertThat( manyToOneAnn ).isNotNull();
-		final JoinColumnsOrFormulas joinColumnsOrFormulas = parentField.getDirectAnnotationUsage( JoinColumnsOrFormulas.class );
-		assertThat( joinColumnsOrFormulas.value() ).hasSize( 1 );
-		final JoinColumnOrFormula joinColumnOrFormula = joinColumnsOrFormulas.value()[0];
-		assertThat( joinColumnOrFormula.formula() ).isNotNull();
-		assertThat( joinColumnOrFormula.formula().value() ).isNull();
-		final JoinColumn joinColumnAnn = joinColumnOrFormula.column();
+		final JoinColumn joinColumnAnn = parentField.getAnnotationUsage( JoinColumn.class, modelsContext );
 		assertThat( joinColumnAnn ).isNotNull();
 		assertThat( joinColumnAnn.name() ).isEqualTo( "parent_fk" );
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/joincolumn/JoinColumnOverrideTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/joincolumn/JoinColumnOverrideTest.java
@@ -1,0 +1,103 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.mapping.joincolumn;
+
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashSet;
+import java.util.Set;
+
+@DomainModel(xmlMappings = "org/hibernate/orm/test/mapping/joincolumn/JoinColumnOverrideTest.orm.xml")
+@SessionFactory
+public class JoinColumnOverrideTest {
+
+	@Test
+	public void testIt(SessionFactoryScope scope) {
+		scope.inTransaction( session -> {
+			Size size = new Size( 2 );
+			session.persist( size );
+			ContainedSize containedSize = new ContainedSize( size );
+
+			Material material = new Material( 1 );
+			material.addContainedSize( containedSize );
+			session.persist( material );
+		} );
+	}
+
+	public static class Material {
+		private int id;
+
+		private Set<ContainedSize> containedSizes = new HashSet<>();
+
+		public Material() {
+		}
+
+		public Material(int id) {
+			this.id = id;
+		}
+
+		public int getId() {
+			return id;
+		}
+
+		public void setId(int id) {
+			this.id = id;
+		}
+
+		public Set<ContainedSize> getContainedSizes() {
+			return containedSizes;
+		}
+
+		public void setContainedSizes(Set<ContainedSize> containedSizes) {
+			this.containedSizes = containedSizes;
+		}
+
+		public void addContainedSize(ContainedSize containedSize) {
+			this.containedSizes.add( containedSize );
+		}
+	}
+
+	public static class ContainedSize {
+
+		private Size size;
+
+		public ContainedSize() {
+		}
+
+		public ContainedSize(Size size) {
+			this.size = size;
+		}
+
+		public Size getSize() {
+			return size;
+		}
+
+		public void setSize(Size size) {
+			this.size = size;
+		}
+	}
+
+	public static class Size {
+		private int id;
+
+		public Size() {
+		}
+
+		public Size(int id) {
+			this.id = id;
+		}
+
+		public int getId() {
+			return id;
+		}
+
+		public void setId(int id) {
+			this.id = id;
+		}
+	}
+}

--- a/hibernate-core/src/test/resources/org/hibernate/orm/test/mapping/joincolumn/JoinColumnOverrideTest.orm.xml
+++ b/hibernate-core/src/test/resources/org/hibernate/orm/test/mapping/joincolumn/JoinColumnOverrideTest.orm.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<!--
+  ~ SPDX-License-Identifier: Apache-2.0
+  ~ Copyright Red Hat Inc. and Hibernate Authors
+  -->
+<entity-mappings xmlns="http://www.hibernate.org/xsd/orm/mapping"
+                 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                 xsi:schemaLocation="http://www.hibernate.org/xsd/orm/mapping
+                https://www.hibernate.org/xsd/orm/mapping/mapping-7.0.xsd"
+                 version="7.0">
+    <package>org.hibernate.orm.test.mapping.joincolumn</package>
+    <entity class="JoinColumnOverrideTest$Material" metadata-complete="true">
+        <table name="MAIN_TABLE"/>
+        <attributes>
+            <id name="id">
+                <column name="ID"/>
+            </id>
+            <element-collection name="containedSizes"
+                                target-class="JoinColumnOverrideTest$ContainedSize"
+                                fetch="LAZY" classification="SET">
+                <association-override name="size">
+                    <join-column name="ASSOCIATION_ID"/>
+                </association-override>
+                <collection-table name="COLLECTION_TABLE">
+                    <join-column name="MAIN_ID"/>
+                </collection-table>
+            </element-collection>
+        </attributes>
+    </entity>
+    <entity class="JoinColumnOverrideTest$Size" metadata-complete="true">
+        <table name="MAIN_TABLE"/>
+        <attributes>
+            <id name="id">
+                <column name="ID"/>
+            </id>
+        </attributes>
+    </entity>
+    <embeddable class="JoinColumnOverrideTest$ContainedSize"
+                name="JoinColumnOverrideTest$ContainedSize" metadata-complete="true">
+        <attributes>
+            <many-to-one name="size" fetch="LAZY" fetch-mode="SELECT" optional="true" not-found="EXCEPTION">
+                <join-column name="ASSOCIATION_ID"/>
+            </many-to-one>
+        </attributes>
+    </embeddable>
+</entity-mappings>


### PR DESCRIPTION
backport of https://github.com/hibernate/hibernate-orm/pull/12347 for 7.4 

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------


---
<!-- Hibernate GitHub Bot task list start -->
Please make sure that the following tasks are completed:
Tasks specific to HHH-20324 (Bug):
- [x] Add test reproducing the bug
- [x] Add entries as relevant to `migration-guide.adoc` **OR** check there are no breaking changes


<!-- Hibernate GitHub Bot task list end -->

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-20324
<!-- Hibernate GitHub Bot issue links end -->