### PR TITLE
HHH-20295 - Add a true observer alternative to StatementInspector

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/StatementObserver.java
+++ b/hibernate-core/src/main/java/org/hibernate/StatementObserver.java
@@ -1,0 +1,34 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate;
+
+/// Observation of (almost) all JDBC [statements][java.sql.Statement] performed by Hibernate.
+///
+/// Generally "performed" means calls to [java.sql.Statement#execute], [java.sql.Statement#executeQuery]
+/// or [java.sql.Statement#executeUpdate].  In these cases, [#performingSql] is called with `-1` as the
+/// `batchPosition`.
+///
+/// In JDBC batching cases, [#performingSql] is called for each [java.sql.Statement#addBatch] call.  In these
+/// cases, `batchPosition` is the addition's position within the current batch.
+///
+/// @apiNote Also provides [#swallowSql(String, int)] as a simple npo-op reference.
+///
+/// @since 8.0
+///
+/// @author Steve Ebersole
+@Incubating
+public interface StatementObserver {
+	/// Callback that the given `sql` is about to be performed.
+	///
+	/// @apiNote "Performed" here could mean immediately executed, or added to a JDBC batch.
+	///
+	/// @param sql The SQL which is being performed.
+	/// @param batchPosition The position within a batch; `-1` if not batched.
+	void performingSql(String sql, int batchPosition);
+
+	/// Simple "black hole" for "no observer".
+	static void swallowSql(String sql, int batchPosition) {
+	}
+}

--- a/hibernate-core/src/main/java/org/hibernate/boot/SessionFactoryBuilder.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/SessionFactoryBuilder.java
@@ -12,6 +12,7 @@ import org.hibernate.Incubating;
 import org.hibernate.Interceptor;
 import org.hibernate.SessionFactory;
 import org.hibernate.SessionFactoryObserver;
+import org.hibernate.StatementObserver;
 import org.hibernate.annotations.CacheLayout;
 import org.hibernate.cache.spi.TimestampsCacheFactory;
 import org.hibernate.cfg.StateManagementSettings;
@@ -166,6 +167,14 @@ public interface SessionFactoryBuilder {
 	 * @see org.hibernate.cfg.AvailableSettings#SESSION_SCOPED_INTERCEPTOR
 	 */
 	SessionFactoryBuilder applyStatelessInterceptor(Supplier<? extends Interceptor> statelessInterceptorSupplier);
+
+	/**
+	 * Specifies a {@linkplain StatementObserver} to be associated with the SessionFactory and used
+	 * by all Sessions opened from it.
+	 *
+	 * @see org.hibernate.cfg.JdbcSettings#STATEMENT_OBSERVER
+	 */
+	SessionFactoryBuilder applyStatementObserver(StatementObserver statementObserver);
 
 	/**
 	 * Specifies a {@link StatementInspector} associated with the

--- a/hibernate-core/src/main/java/org/hibernate/boot/internal/SessionFactoryBuilderImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/internal/SessionFactoryBuilderImpl.java
@@ -11,6 +11,7 @@ import org.hibernate.EntityNameResolver;
 import org.hibernate.Interceptor;
 import org.hibernate.SessionFactory;
 import org.hibernate.SessionFactoryObserver;
+import org.hibernate.StatementObserver;
 import org.hibernate.annotations.CacheLayout;
 import org.hibernate.boot.SessionFactoryBuilder;
 import org.hibernate.boot.TempTableDdlTransactionHandling;
@@ -150,6 +151,12 @@ public class SessionFactoryBuilderImpl implements SessionFactoryBuilderImplement
 	@Override
 	public SessionFactoryBuilder applyStatelessInterceptor(Supplier<? extends Interceptor> statelessInterceptorSupplier) {
 		optionsBuilder.applyStatelessInterceptorSupplier( statelessInterceptorSupplier );
+		return this;
+	}
+
+	@Override
+	public SessionFactoryBuilder applyStatementObserver(StatementObserver statementObserver) {
+		optionsBuilder.applyStatementObserver( statementObserver );
 		return this;
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/boot/internal/SessionFactoryOptionsBuilder.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/internal/SessionFactoryOptionsBuilder.java
@@ -30,7 +30,9 @@ import org.hibernate.Interceptor;
 import org.hibernate.LockOptions;
 import org.hibernate.SessionEventListener;
 import org.hibernate.SessionFactoryObserver;
+import org.hibernate.StatementObserver;
 import org.hibernate.boot.model.internal.TemporalHelper;
+import org.hibernate.cfg.JdbcSettings;
 import org.hibernate.temporal.TemporalTableStrategy;
 import org.hibernate.context.spi.MultiTenancy;
 import org.hibernate.cfg.GraphParserSettings;
@@ -154,6 +156,7 @@ public class SessionFactoryOptionsBuilder implements SessionFactoryOptions {
 	// Statistics/Interceptor/observers
 	private boolean statisticsEnabled;
 	private Interceptor interceptor;
+	private StatementObserver statementObserver;
 	private Supplier<? extends Interceptor> statelessInterceptorSupplier;
 	private StatementInspector statementInspector;
 	private final List<SessionFactoryObserver> sessionFactoryObserverList = new ArrayList<>();
@@ -347,6 +350,8 @@ public class SessionFactoryOptionsBuilder implements SessionFactoryOptions {
 
 		interceptor = determineInterceptor( settings, strategySelector );
 		statelessInterceptorSupplier = determineStatelessInterceptor( settings, strategySelector );
+
+		statementObserver = interpretStatementObserver( settings );
 
 		statementInspector =
 				strategySelector.resolveStrategy(
@@ -572,6 +577,34 @@ public class SessionFactoryOptionsBuilder implements SessionFactoryOptions {
 		}
 
 		graphParserMode = GraphParserMode.interpret( graphParserModeSetting );
+	}
+
+	private StatementObserver interpretStatementObserver(Map<String, Object> settings) {
+		var setting = settings.get( JdbcSettings.STATEMENT_OBSERVER );
+		if ( setting == null ) {
+			return null;
+		}
+
+		if ( setting instanceof StatementObserver observer ) {
+			return observer;
+		}
+
+		if ( setting instanceof Class<?> impl ) {
+			try {
+				return (StatementObserver) impl.getConstructor().newInstance();
+			}
+			catch (Exception e) {
+				throw new RuntimeException( "Unable to instantiate StatementObserver - " + impl.getName(), e );
+			}
+		}
+
+		try {
+			var namedImpl = Class.forName( setting.toString() );
+			return (StatementObserver) namedImpl.getConstructor().newInstance();
+		}
+		catch (Exception e) {
+			throw new RuntimeException( "Unable to instantiate StatementObserver - " + setting, e );
+		}
 	}
 
 	@Deprecated(forRemoval = true)
@@ -1048,6 +1081,11 @@ public class SessionFactoryOptionsBuilder implements SessionFactoryOptions {
 	@Override
 	public Interceptor getInterceptor() {
 		return interceptor == null ? EmptyInterceptor.INSTANCE : interceptor;
+	}
+
+	@Override
+	public StatementObserver getStatementObserver() {
+		return statementObserver;
 	}
 
 	@Override
@@ -1603,6 +1641,10 @@ public class SessionFactoryOptionsBuilder implements SessionFactoryOptions {
 		this.sqmFunctionRegistry = sqmFunctionRegistry;
 	}
 
+	public void applyStatementObserver(StatementObserver statementObserver) {
+		this.statementObserver = statementObserver;
+	}
+
 	public void applyStatementInspector(StatementInspector statementInspector) {
 		this.statementInspector = statementInspector;
 	}
@@ -1926,5 +1968,4 @@ public class SessionFactoryOptionsBuilder implements SessionFactoryOptions {
 		}
 		return unmodifiableMap( settings );
 	}
-
 }

--- a/hibernate-core/src/main/java/org/hibernate/boot/spi/AbstractDelegatingSessionFactoryBuilder.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/spi/AbstractDelegatingSessionFactoryBuilder.java
@@ -11,6 +11,7 @@ import org.hibernate.EntityNameResolver;
 import org.hibernate.Interceptor;
 import org.hibernate.SessionFactory;
 import org.hibernate.SessionFactoryObserver;
+import org.hibernate.StatementObserver;
 import org.hibernate.annotations.CacheLayout;
 import org.hibernate.boot.SessionFactoryBuilder;
 import org.hibernate.boot.TempTableDdlTransactionHandling;
@@ -391,6 +392,12 @@ public abstract class AbstractDelegatingSessionFactoryBuilder<T extends SessionF
 	public T applyStatelessInterceptor(Supplier<? extends Interceptor> statelessInterceptorSupplier) {
 		delegate.applyStatelessInterceptor(statelessInterceptorSupplier);
 		return getThis();
+	}
+
+	@Override
+	public SessionFactoryBuilder applyStatementObserver(StatementObserver statementObserver) {
+		delegate.applyStatementObserver( statementObserver );
+		return this;
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/spi/AbstractDelegatingSessionFactoryOptions.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/spi/AbstractDelegatingSessionFactoryOptions.java
@@ -18,6 +18,7 @@ import org.hibernate.GraphParserMode;
 import org.hibernate.Interceptor;
 import org.hibernate.LockOptions;
 import org.hibernate.SessionFactoryObserver;
+import org.hibernate.StatementObserver;
 import org.hibernate.temporal.TemporalTableStrategy;
 import org.hibernate.context.spi.TenantCredentialsMapper;
 import org.hibernate.context.spi.TenantSchemaMapper;
@@ -138,6 +139,11 @@ public class AbstractDelegatingSessionFactoryOptions implements SessionFactoryOp
 	@Override
 	public Interceptor getInterceptor() {
 		return delegate.getInterceptor();
+	}
+
+	@Override
+	public StatementObserver getStatementObserver() {
+		return delegate().getStatementObserver();
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/spi/SessionFactoryOptions.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/spi/SessionFactoryOptions.java
@@ -10,6 +10,7 @@ import java.util.function.Supplier;
 
 import jakarta.persistence.CacheRetrieveMode;
 import jakarta.persistence.CacheStoreMode;
+import org.checkerframework.checker.nullness.qual.Nullable;
 import org.hibernate.CacheMode;
 import org.hibernate.CustomEntityDirtinessStrategy;
 import org.hibernate.EntityNameResolver;
@@ -21,6 +22,7 @@ import org.hibernate.Internal;
 import org.hibernate.LockOptions;
 import org.hibernate.SessionEventListener;
 import org.hibernate.SessionFactoryObserver;
+import org.hibernate.StatementObserver;
 import org.hibernate.cfg.StateManagementSettings;
 import org.hibernate.temporal.TemporalTableStrategy;
 import org.hibernate.context.spi.TenantCredentialsMapper;
@@ -160,6 +162,13 @@ public interface SessionFactoryOptions extends QueryEngineOptions {
 	 * @see org.hibernate.SessionBuilder#interceptor(Interceptor)
 	 */
 	Interceptor getInterceptor();
+
+	/**
+	 * The StatementObserver, if one, applied to this SessionFactory.
+	 *
+	 * @see org.hibernate.cfg.JdbcSettings#STATEMENT_OBSERVER
+	 */
+	@Nullable StatementObserver getStatementObserver();
 
 	/**
 	 * A stateless {@link Supplier} for {@linkplain Interceptor interceptor} instances
@@ -824,5 +833,4 @@ public interface SessionFactoryOptions extends QueryEngineOptions {
 	 * @since 7.0
 	 */
 	GraphParserMode getGraphParserMode();
-
 }

--- a/hibernate-core/src/main/java/org/hibernate/cfg/JdbcSettings.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/JdbcSettings.java
@@ -368,6 +368,19 @@ public interface JdbcSettings extends C3p0Settings, AgroalSettings, HikariCPSett
 	String STATEMENT_INSPECTOR = "hibernate.session_factory.statement_inspector";
 
 	/**
+	 * Specifies an {@linkplain org.hibernate.StatementObserver observer} for JDBC statements.
+	 * Applied at the {@linkplain org.hibernate.SessionFactory} level.
+	 * May be defined as:<ol>
+	 *     <li>instance of {@linkplain org.hibernate.StatementObserver}
+	 *     <li>{@linkplain Class} reference for a {@linkplain org.hibernate.StatementObserver} implementation
+	 *     <li>name of a class implementing {@linkplain org.hibernate.StatementObserver}
+	 * </ol>
+	 *
+	 * @since 8.0
+	 */
+	String STATEMENT_OBSERVER = "hibernate.statement_observer";
+
+	/**
 	 * Enables logging of generated SQL to the console.
 	 *
 	 * @settingDefault {@code false}

--- a/hibernate-core/src/main/java/org/hibernate/dialect/lock/internal/Helper.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/lock/internal/Helper.java
@@ -30,6 +30,7 @@ public class Helper {
 			SessionFactoryImplementor factory) {
 		try ( final var statement = connection.createStatement() ) {
 			factory.getJdbcServices().getSqlStatementLogger().logStatement( sql );
+			factory.getStatementObserver().performingSql( sql, -1 );
 			final var results = statement.executeQuery( sql );
 			if ( !results.next() ) {
 				throw new HibernateException( "Unable to query JDBC Connection for current lock-timeout setting (no result)" );
@@ -51,6 +52,7 @@ public class Helper {
 			SessionFactoryImplementor factory) {
 		try ( final var statement = connection.createStatement() ) {
 			factory.getJdbcServices().getSqlStatementLogger().logStatement( sql );
+			factory.getStatementObserver().performingSql( sql, -1 );
 			statement.execute( sql );
 		}
 		catch (SQLException sqle) {

--- a/hibernate-core/src/main/java/org/hibernate/engine/jdbc/batch/internal/BatchImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/jdbc/batch/internal/BatchImpl.java
@@ -9,6 +9,7 @@ import java.util.LinkedHashSet;
 
 import org.hibernate.HibernateException;
 import org.hibernate.StaleStateException;
+import org.hibernate.StatementObserver;
 import org.hibernate.engine.jdbc.batch.spi.Batch;
 import org.hibernate.engine.jdbc.batch.spi.BatchKey;
 import org.hibernate.engine.jdbc.batch.spi.BatchObserver;
@@ -17,7 +18,6 @@ import org.hibernate.engine.jdbc.mutation.TableInclusionChecker;
 import org.hibernate.engine.jdbc.mutation.group.PreparedStatementDetails;
 import org.hibernate.engine.jdbc.mutation.group.PreparedStatementGroup;
 import org.hibernate.engine.jdbc.spi.JdbcCoordinator;
-import org.hibernate.engine.jdbc.spi.JdbcServices;
 import org.hibernate.engine.jdbc.spi.SqlExceptionHelper;
 import org.hibernate.engine.jdbc.spi.SqlStatementLogger;
 
@@ -38,8 +38,8 @@ public class BatchImpl implements Batch {
 
 	private final JdbcCoordinator jdbcCoordinator;
 	private final SqlStatementLogger sqlStatementLogger;
+	private final StatementObserver statementObserver;
 	private final SqlExceptionHelper sqlExceptionHelper;
-	private final JdbcServices jdbcServices;
 
 	private final LinkedHashSet<BatchObserver> observers = new LinkedHashSet<>();
 
@@ -60,9 +60,9 @@ public class BatchImpl implements Batch {
 		this.jdbcCoordinator = jdbcCoordinator;
 		this.statementGroup = statementGroup;
 
-		this.jdbcServices =
-				jdbcCoordinator.getJdbcSessionOwner().getJdbcSessionContext().getJdbcServices();
+		var jdbcServices = jdbcCoordinator.getJdbcSessionOwner().getJdbcSessionContext().getJdbcServices();
 		sqlStatementLogger = jdbcServices.getSqlStatementLogger();
+		statementObserver = jdbcCoordinator.getJdbcSessionOwner().getJdbcSessionContext().getStatementObserver();
 		sqlExceptionHelper = jdbcServices.getSqlExceptionHelper();
 
 		if ( BATCH_MESSAGE_LOGGER.isTraceEnabled() ) {
@@ -132,6 +132,7 @@ public class BatchImpl implements Batch {
 					final var statement = statementDetails.resolveStatement();
 					final String sqlString = statementDetails.getSqlString();
 					sqlStatementLogger.logStatement( sqlString );
+					statementObserver.performingSql( statementDetails.getSqlString(), -1 );
 					jdbcValueBindings.beforeStatement( statementDetails );
 					try {
 						statement.addBatch();

--- a/hibernate-core/src/main/java/org/hibernate/engine/jdbc/env/internal/JdbcEnvironmentInitiator.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/jdbc/env/internal/JdbcEnvironmentInitiator.java
@@ -5,6 +5,7 @@
 package org.hibernate.engine.jdbc.env.internal;
 
 import org.hibernate.HibernateException;
+import org.hibernate.StatementObserver;
 import org.hibernate.boot.registry.StandardServiceInitiator;
 import org.hibernate.cfg.JdbcSettings;
 import org.hibernate.dialect.DatabaseVersion;
@@ -774,6 +775,11 @@ public class JdbcEnvironmentInitiator implements StandardServiceInitiator<JdbcEn
 		@Override
 		public StatementInspector getStatementInspector() {
 			return null;
+		}
+
+		@Override
+		public StatementObserver getStatementObserver() {
+			return StatementObserver::swallowSql;
 		}
 
 		@Override

--- a/hibernate-core/src/main/java/org/hibernate/engine/jdbc/internal/ResultSetReturnImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/jdbc/internal/ResultSetReturnImpl.java
@@ -9,6 +9,7 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
 
+import org.hibernate.StatementObserver;
 import org.hibernate.engine.jdbc.spi.JdbcCoordinator;
 import org.hibernate.engine.jdbc.spi.JdbcServices;
 import org.hibernate.engine.jdbc.spi.ResultSetReturn;
@@ -28,6 +29,7 @@ public class ResultSetReturnImpl implements ResultSetReturn {
 
 	private final SqlStatementLogger sqlStatementLogger;
 	private final SqlExceptionHelper sqlExceptionHelper;
+	private final StatementObserver statementObserver;
 
 	/**
 	 * Constructs a ResultSetReturnImpl
@@ -38,6 +40,7 @@ public class ResultSetReturnImpl implements ResultSetReturn {
 		this.jdbcCoordinator = jdbcCoordinator;
 		this.sqlStatementLogger = jdbcServices.getSqlStatementLogger();
 		this.sqlExceptionHelper = jdbcServices.getSqlExceptionHelper();
+		this.statementObserver = jdbcCoordinator.getJdbcSessionOwner().getJdbcSessionContext().getStatementObserver();
 	}
 
 	@Override
@@ -89,6 +92,7 @@ public class ResultSetReturnImpl implements ResultSetReturn {
 	@Override
 	public ResultSet extract(Statement statement, String sql) {
 		sqlStatementLogger.logStatement( sql );
+		statementObserver.performingSql( sql, -1 );
 		long executeStartNanos = beginSlowQueryLogging();
 		try {
 			final var eventMonitor = getEventManager();
@@ -146,6 +150,7 @@ public class ResultSetReturnImpl implements ResultSetReturn {
 	@Override
 	public ResultSet execute(Statement statement, String sql) {
 		sqlStatementLogger.logStatement( sql );
+		statementObserver.performingSql( sql, -1 );
 		long executeStartNanos = beginSlowQueryLogging();
 		try {
 			final var eventMonitor = getEventManager();
@@ -198,6 +203,7 @@ public class ResultSetReturnImpl implements ResultSetReturn {
 	@Override
 	public int executeUpdate(Statement statement, String sql) {
 		sqlStatementLogger.logStatement( sql );
+		statementObserver.performingSql( sql, -1 );
 		long executeStartNanos = beginSlowQueryLogging();
 		final var eventMonitor = getEventManager();
 		final var executionEvent = eventMonitor.beginJdbcPreparedStatementExecutionEvent();

--- a/hibernate-core/src/main/java/org/hibernate/engine/jdbc/internal/StatementPreparerImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/jdbc/internal/StatementPreparerImpl.java
@@ -172,6 +172,7 @@ class StatementPreparerImpl implements StatementPreparer {
 		public PreparedStatement prepareStatement() {
 			try {
 				jdbcServices.getSqlStatementLogger().logStatement( sql );
+				jdbcCoordinator.getJdbcSessionOwner().getJdbcSessionContext().getStatementObserver().performingSql( sql, -1 );
 
 				final var jdbcSessionOwner = jdbcCoordinator.getJdbcSessionOwner();
 				final var observer = jdbcSessionOwner.getJdbcSessionContext().getEventHandler();

--- a/hibernate-core/src/main/java/org/hibernate/engine/jdbc/mutation/internal/AbstractMutationExecutor.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/jdbc/mutation/internal/AbstractMutationExecutor.java
@@ -135,6 +135,7 @@ public abstract class AbstractMutationExecutor implements MutationExecutor {
 
 		// If we get here the statement is needed - make sure it is resolved
 		session.getJdbcServices().getSqlStatementLogger().logStatement( statementDetails.getSqlString() );
+		session.getJdbcSessionContext().getStatementObserver().performingSql( statementDetails.getSqlString(), -1 );
 
 		try {
 			valueBindings.beforeStatement( statementDetails );

--- a/hibernate-core/src/main/java/org/hibernate/engine/jdbc/mutation/internal/MutationExecutorSingleSelfExecuting.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/jdbc/mutation/internal/MutationExecutorSingleSelfExecuting.java
@@ -51,7 +51,10 @@ public class MutationExecutorSingleSelfExecuting extends AbstractMutationExecuto
 	}
 
 	@Override
-	protected void performSelfExecutingOperations(ValuesAnalysis valuesAnalysis, TableInclusionChecker inclusionChecker, SharedSessionContractImplementor session) {
+	protected void performSelfExecutingOperations(
+			ValuesAnalysis valuesAnalysis,
+			TableInclusionChecker inclusionChecker,
+			SharedSessionContractImplementor session) {
 		if ( inclusionChecker.include( operation.getTableDetails() ) ) {
 			operation.performMutation( valueBindings, valuesAnalysis, session );
 		}

--- a/hibernate-core/src/main/java/org/hibernate/engine/spi/SessionFactoryDelegatingImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/spi/SessionFactoryDelegatingImpl.java
@@ -18,6 +18,7 @@ import jakarta.persistence.SynchronizationType;
 import jakarta.persistence.TypedQuery;
 import jakarta.persistence.TypedQueryReference;
 import jakarta.persistence.sql.ResultSetMapping;
+import org.checkerframework.checker.nullness.qual.NonNull;
 import org.hibernate.CustomEntityDirtinessStrategy;
 import org.hibernate.HibernateException;
 import org.hibernate.Session;
@@ -25,6 +26,7 @@ import org.hibernate.SessionFactory;
 import org.hibernate.SessionFactoryObserver;
 import org.hibernate.StatelessSession;
 import org.hibernate.StatelessSessionBuilder;
+import org.hibernate.StatementObserver;
 import org.hibernate.boot.model.relational.SqlStringGenerationContext;
 import org.hibernate.boot.registry.classloading.spi.ClassLoaderService;
 import org.hibernate.boot.spi.SessionFactoryOptions;
@@ -89,6 +91,11 @@ public class SessionFactoryDelegatingImpl implements SessionFactoryImplementor, 
 	@Override
 	public SessionFactoryOptions getSessionFactoryOptions() {
 		return delegate.getSessionFactoryOptions();
+	}
+
+	@Override
+	public @NonNull StatementObserver getStatementObserver() {
+		return delegate.getStatementObserver();
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/engine/spi/SessionFactoryImplementor.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/spi/SessionFactoryImplementor.java
@@ -7,11 +7,13 @@ package org.hibernate.engine.spi;
 import java.util.Collection;
 import java.util.Map;
 
+import org.checkerframework.checker.nullness.qual.NonNull;
 import org.hibernate.CustomEntityDirtinessStrategy;
 import org.hibernate.Incubating;
 import org.hibernate.Internal;
 import org.hibernate.SessionFactory;
 import org.hibernate.SessionFactoryObserver;
+import org.hibernate.StatementObserver;
 import org.hibernate.boot.model.relational.SqlStringGenerationContext;
 import org.hibernate.boot.registry.classloading.spi.ClassLoaderService;
 import org.hibernate.boot.spi.SessionFactoryOptions;
@@ -280,6 +282,11 @@ public interface SessionFactoryImplementor extends SessionFactory {
 	 */
 	@Override
 	SessionFactoryOptions getSessionFactoryOptions();
+
+	/**
+	 * Access to the StatementObserver associated with this factory.
+	 */
+	@NonNull StatementObserver getStatementObserver();
 
 	/**
 	 * Obtain the {@linkplain FilterDefinition definition of a filter} by name.

--- a/hibernate-core/src/main/java/org/hibernate/id/insert/AbstractReturningDelegate.java
+++ b/hibernate-core/src/main/java/org/hibernate/id/insert/AbstractReturningDelegate.java
@@ -44,6 +44,7 @@ public abstract class AbstractReturningDelegate extends AbstractGeneratedValuesM
 			SharedSessionContractImplementor session) {
 		final String sql = statementDetails.getSqlString();
 		session.getJdbcServices().getSqlStatementLogger().logStatement( sql );
+		session.getJdbcSessionContext().getStatementObserver().performingSql( sql, -1 );
 		try {
 			valueBindings.beforeStatement( statementDetails );
 			return executeAndExtractReturning( sql, statementDetails.getStatement(), session );
@@ -60,6 +61,7 @@ public abstract class AbstractReturningDelegate extends AbstractGeneratedValuesM
 	@Override
 	public final GeneratedValues performInsertReturning(String sql, SharedSessionContractImplementor session, Binder binder) {
 		session.getJdbcServices().getSqlStatementLogger().logStatement( sql );
+		session.getJdbcSessionContext().getStatementObserver().performingSql( sql, -1 );
 		// prepare and execute the insert
 		final var insert = prepareStatement( sql, session );
 		try {

--- a/hibernate-core/src/main/java/org/hibernate/id/insert/AbstractSelectingDelegate.java
+++ b/hibernate-core/src/main/java/org/hibernate/id/insert/AbstractSelectingDelegate.java
@@ -72,6 +72,7 @@ public abstract class AbstractSelectingDelegate extends AbstractGeneratedValuesM
 		final var jdbcCoordinator = session.getJdbcCoordinator();
 		final String sql = statementDetails.getSqlString();
 		session.getJdbcServices().getSqlStatementLogger().logStatement( sql );
+		session.getJdbcSessionContext().getStatementObserver().performingSql( sql, -1 );
 		try {
 			jdbcValueBindings.beforeStatement( statementDetails );
 			jdbcCoordinator.getResultSetReturn()

--- a/hibernate-core/src/main/java/org/hibernate/id/insert/GetGeneratedKeysDelegate.java
+++ b/hibernate-core/src/main/java/org/hibernate/id/insert/GetGeneratedKeysDelegate.java
@@ -90,6 +90,7 @@ public class GetGeneratedKeysDelegate extends AbstractReturningDelegate {
 			SharedSessionContractImplementor session) {
 		final String sql = statementDetails.getSqlString();
 		session.getJdbcServices().getSqlStatementLogger().logStatement( sql );
+		session.getJdbcSessionContext().getStatementObserver().performingSql( sql, -1 );
 		try {
 			final var preparedStatement = statementDetails.resolveStatement();
 			jdbcValueBindings.beforeStatement( statementDetails );

--- a/hibernate-core/src/main/java/org/hibernate/internal/JdbcSessionContextImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/JdbcSessionContextImpl.java
@@ -4,6 +4,7 @@
  */
 package org.hibernate.internal;
 
+import org.hibernate.StatementObserver;
 import org.hibernate.boot.spi.SessionFactoryOptions;
 import org.hibernate.engine.jdbc.batch.spi.BatchBuilder;
 import org.hibernate.engine.jdbc.spi.JdbcServices;
@@ -84,6 +85,11 @@ class JdbcSessionContextImpl implements JdbcSessionContext {
 	@Override
 	public boolean doesConnectionProviderDisableAutoCommit() {
 		return settings().doesConnectionProviderDisableAutoCommit();
+	}
+
+	@Override
+	public StatementObserver getStatementObserver() {
+		return sessionFactory.getStatementObserver();
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/internal/SessionFactoryImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/SessionFactoryImpl.java
@@ -19,6 +19,7 @@ import jakarta.persistence.SynchronizationType;
 import jakarta.persistence.TypedQuery;
 import jakarta.persistence.TypedQueryReference;
 import jakarta.persistence.sql.ResultSetMapping;
+import org.checkerframework.checker.nullness.qual.NonNull;
 import org.hibernate.CustomEntityDirtinessStrategy;
 import org.hibernate.EntityNameResolver;
 import org.hibernate.FlushMode;
@@ -29,6 +30,7 @@ import org.hibernate.SessionFactory;
 import org.hibernate.SessionFactoryObserver;
 import org.hibernate.StatelessSession;
 import org.hibernate.StatelessSessionBuilder;
+import org.hibernate.StatementObserver;
 import org.hibernate.UnknownFilterException;
 import org.hibernate.binder.internal.TenantIdBinder;
 import org.hibernate.boot.model.relational.SqlStringGenerationContext;
@@ -173,6 +175,7 @@ public class SessionFactoryImpl implements SessionFactoryImplementor {
 	private transient volatile Status status = Status.OPEN;
 
 	private final transient SessionFactoryObserverChain observerChain = new SessionFactoryObserverChain();
+	private final transient StatementObserver statementObserver;
 
 	private final transient SessionFactoryOptions sessionFactoryOptions;
 	private final transient Map<String,Object> settings;
@@ -225,6 +228,10 @@ public class SessionFactoryImpl implements SessionFactoryImplementor {
 		typeConfiguration = bootstrapContext.getTypeConfiguration();
 
 		sessionFactoryOptions = options;
+
+		statementObserver = options.getStatementObserver() == null
+				? StatementObserver::swallowSql
+				: options.getStatementObserver();
 
 		serviceRegistry = getServiceRegistry( options, this );
 		eventEngine = new EventEngine( bootMetamodel, this );
@@ -794,6 +801,11 @@ public class SessionFactoryImpl implements SessionFactoryImplementor {
 	@Override
 	public SessionFactoryOptions getSessionFactoryOptions() {
 		return sessionFactoryOptions;
+	}
+
+	@Override
+	public @NonNull StatementObserver getStatementObserver() {
+		return statementObserver;
 	}
 
 	public Interceptor getInterceptor() {

--- a/hibernate-core/src/main/java/org/hibernate/jpa/HibernatePersistenceConfiguration.java
+++ b/hibernate-core/src/main/java/org/hibernate/jpa/HibernatePersistenceConfiguration.java
@@ -11,6 +11,7 @@ import jakarta.persistence.PersistenceUnitTransactionType;
 import jakarta.persistence.SharedCacheMode;
 import jakarta.persistence.ValidationMode;
 import org.hibernate.SessionFactory;
+import org.hibernate.StatementObserver;
 import org.hibernate.boot.scan.spi.ScanningProvider;
 import org.hibernate.cache.spi.access.AccessType;
 import org.hibernate.cfg.AvailableSettings;
@@ -641,6 +642,26 @@ public class HibernatePersistenceConfiguration extends PersistenceConfiguration 
 	 */
 	public HibernatePersistenceConfiguration schemaToolingAction(Action action) {
 		property( SchemaToolingSettings.HBM2DDL_AUTO, action );
+		return this;
+	}
+
+	/**
+	 * Applies a {@linkplain StatementObserver} to the {@linkplain EntityManagerFactory} being built.
+	 *
+	 * @see JdbcSettings#STATEMENT_OBSERVER
+	 */
+	public HibernatePersistenceConfiguration statementObserver(StatementObserver statementObserver) {
+		property( JdbcSettings.STATEMENT_OBSERVER, statementObserver );
+		return this;
+	}
+
+	/**
+	 * Applies a {@linkplain StatementObserver} to the {@linkplain EntityManagerFactory} being built.
+	 *
+	 * @see JdbcSettings#STATEMENT_OBSERVER
+	 */
+	public HibernatePersistenceConfiguration statementObserver(Class<? extends StatementObserver> statementObserverImpl) {
+		property( JdbcSettings.STATEMENT_OBSERVER, statementObserverImpl );
 		return this;
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/resource/jdbc/spi/JdbcSessionContext.java
+++ b/hibernate-core/src/main/java/org/hibernate/resource/jdbc/spi/JdbcSessionContext.java
@@ -4,6 +4,7 @@
  */
 package org.hibernate.resource.jdbc.spi;
 
+import org.hibernate.StatementObserver;
 import org.hibernate.engine.jdbc.batch.spi.BatchBuilder;
 import org.hibernate.engine.jdbc.spi.JdbcServices;
 import org.hibernate.jpa.spi.JpaCompliance;
@@ -48,6 +49,7 @@ public interface JdbcSessionContext {
 	PhysicalConnectionHandlingMode getPhysicalConnectionHandlingMode();
 
 	StatementInspector getStatementInspector();
+	StatementObserver getStatementObserver();
 
 	JpaCompliance getJpaCompliance();
 

--- a/hibernate-core/src/main/java/org/hibernate/sql/model/jdbc/DeleteOrUpsertOperation.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/model/jdbc/DeleteOrUpsertOperation.java
@@ -119,6 +119,7 @@ public class DeleteOrUpsertOperation implements SelfExecutingUpdateOperation {
 			final var upsertDeleteStatement = statementDetails.resolveStatement();
 			final String sql = statementDetails.getSqlString();
 			jdbcServices.getSqlStatementLogger().logStatement( sql );
+			session.getJdbcSessionContext().getStatementObserver().performingSql( sql, -1 );
 			bindDeleteKeyValues( jdbcValueBindings, statementDetails, session );
 			final int rowCount =
 					session.getJdbcCoordinator().getResultSetReturn()
@@ -196,6 +197,7 @@ public class DeleteOrUpsertOperation implements SelfExecutingUpdateOperation {
 			final var updateStatement = statementDetails.resolveStatement();
 			final var jdbcServices = session.getJdbcServices();
 			jdbcServices.getSqlStatementLogger().logStatement( statementDetails.getSqlString() );
+			session.getJdbcSessionContext().getStatementObserver().performingSql( statementDetails.getSqlString(), -1 );
 			jdbcValueBindings.beforeStatement( statementDetails );
 			final int rowCount =
 					session.getJdbcCoordinator().getResultSetReturn()

--- a/hibernate-core/src/main/java/org/hibernate/sql/model/jdbc/OptionalTableUpdateOperation.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/model/jdbc/OptionalTableUpdateOperation.java
@@ -202,6 +202,7 @@ public class OptionalTableUpdateOperation implements SelfExecutingUpdateOperatio
 		final var jdbcCoordinator = session.getJdbcCoordinator();
 		final var deleteStatement = createStatementDetails( jdbcDelete, jdbcCoordinator );
 		session.getJdbcServices().getSqlStatementLogger().logStatement( jdbcDelete.getSqlString() );
+		session.getJdbcSessionContext().getStatementObserver().performingSql( jdbcDelete.getSqlString(), -1 );
 		bindKeyValues( jdbcValueBindings, deleteStatement, jdbcDelete, session );
 		try {
 			session.getJdbcCoordinator().getResultSetReturn()
@@ -341,6 +342,7 @@ public class OptionalTableUpdateOperation implements SelfExecutingUpdateOperatio
 		try {
 			final var updateStatement = statementDetails.resolveStatement();
 			jdbcServices.getSqlStatementLogger().logStatement( sql );
+			session.getJdbcSessionContext().getStatementObserver().performingSql( sql, -1 );
 			bindUpdateValues( jdbcValueBindings, updateStatement, updateParameters, sql, session );
 			final int rowCount =
 					session.getJdbcCoordinator().getResultSetReturn()
@@ -421,6 +423,7 @@ public class OptionalTableUpdateOperation implements SelfExecutingUpdateOperatio
 		final String sql = jdbcInsert.getSqlString();
 		try {
 			jdbcServices.getSqlStatementLogger().logStatement( sql );
+			session.getJdbcSessionContext().getStatementObserver().performingSql( sql, -1 );
 			final var bindingGroup = jdbcValueBindings.getBindingGroup( tableMapping.getTableName() );
 			if ( bindingGroup != null ) {
 				bindingGroup.forEachBinding( binding -> {

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/cid/keymanytoone/EagerKeyManyToOneTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/cid/keymanytoone/EagerKeyManyToOneTest.java
@@ -4,9 +4,8 @@
  */
 package org.hibernate.orm.test.annotations.cid.keymanytoone;
 
-import org.hibernate.testing.orm.junit.JiraKey;
-import org.hibernate.testing.jdbc.SQLStatementInspector;
 import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.JiraKey;
 import org.hibernate.testing.orm.junit.SessionFactory;
 import org.hibernate.testing.orm.junit.SessionFactoryScope;
 import org.junit.jupiter.api.AfterEach;
@@ -24,7 +23,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 		annotatedClasses = {
 				Card.class, CardField.class, Key.class
 		})
-@SessionFactory(useCollectingStatementInspector = true)
+@SessionFactory(useCollectingStatementObserver = true)
 public class EagerKeyManyToOneTest {
 	public static final String CARD_ID = "cardId";
 	public static final String CARD_MODEL = "Gran Torino";
@@ -57,8 +56,8 @@ public class EagerKeyManyToOneTest {
 		// meant to test against regression relating to http://opensource.atlassian.com/projects/hibernate/browse/HHH-2277
 		// and http://opensource.atlassian.com/projects/hibernate/browse/HHH-4147
 
-		SQLStatementInspector statementInspector = scope.getCollectingStatementInspector();
-		statementInspector.clear();
+		var sqlCollector = scope.getCollectingStatementObserver();
+		sqlCollector.clear();
 		scope.inTransaction(
 				session -> {
 					try {
@@ -72,8 +71,8 @@ public class EagerKeyManyToOneTest {
 						assertEquals( KEY_ID, primaryKey.getKey().getId() );
 						assertEquals( KEY_SERIAL, primaryKey.getKey().getSerial() );
 
-						statementInspector.assertExecutedCount( 1 );
-						statementInspector.assertNumberOfOccurrenceInQuery( 0, "join", 2 );
+						sqlCollector.assertStatements().hasSize( 1 );
+						sqlCollector.assertQuery( 0 ).containsToken( " join ", 2 );
 					}
 					catch (StackOverflowError soe) {
 						fail( "eager + key-many-to-one caused stack-overflow in annotations" );

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/cid/keymanytoone/association/EagerKeyManyToOneTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/annotations/cid/keymanytoone/association/EagerKeyManyToOneTest.java
@@ -4,7 +4,6 @@
  */
 package org.hibernate.orm.test.annotations.cid.keymanytoone.association;
 
-import org.hibernate.testing.jdbc.SQLStatementInspector;
 import org.hibernate.testing.orm.junit.DomainModel;
 import org.hibernate.testing.orm.junit.SessionFactory;
 import org.hibernate.testing.orm.junit.SessionFactoryScope;
@@ -22,7 +21,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 		annotatedClasses = {
 				Card.class, CardField.class, Key.class
 		})
-@SessionFactory(useCollectingStatementInspector = true)
+@SessionFactory(useCollectingStatementObserver = true)
 public class EagerKeyManyToOneTest {
 	public static final String CARD_ID = "cardId";
 	public static final String KEY_ID = "keyId";
@@ -51,8 +50,9 @@ public class EagerKeyManyToOneTest {
 
 	@Test
 	public void testLoadEntityWithEagerFetchingToKeyManyToOneReferenceBackToSelf(SessionFactoryScope scope) {
-		SQLStatementInspector statementInspector = scope.getCollectingStatementInspector();
-		statementInspector.clear();
+		var sqlCollector = scope.getCollectingStatementObserver();
+		sqlCollector.clear();
+
 		scope.inTransaction(
 				session -> {
 					try {
@@ -61,8 +61,8 @@ public class EagerKeyManyToOneTest {
 						CardField cf = card.getField();
 						assertSame( card, cf.getPrimaryKey().getCard() );
 
-						statementInspector.assertExecutedCount( 1 );
-						statementInspector.assertNumberOfOccurrenceInQuery( 0, "join", 3 );
+						sqlCollector.assertStatements().hasSize( 1 );
+						sqlCollector.assertQuery( 0 ).containsToken( " join ", 3 );
 					}
 					catch (StackOverflowError soe) {
 						fail( "eager + key-many-to-one caused stack-overflow in annotations" );

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/sql/exec/EmbeddedWithManyToOneTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/sql/exec/EmbeddedWithManyToOneTest.java
@@ -14,7 +14,7 @@ import jakarta.persistence.ManyToOne;
 
 import org.hibernate.Hibernate;
 
-import org.hibernate.testing.jdbc.SQLStatementInspector;
+import org.hibernate.testing.jdbc.CollectingStatementObserver;
 import org.hibernate.testing.orm.junit.DomainModel;
 import org.hibernate.testing.orm.junit.SessionFactory;
 import org.hibernate.testing.orm.junit.SessionFactoryScope;
@@ -22,6 +22,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -35,7 +36,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 )
 @SessionFactory(
 		generateStatistics = true,
-		useCollectingStatementInspector = true)
+		useCollectingStatementObserver = true)
 public class EmbeddedWithManyToOneTest {
 
 	@BeforeEach
@@ -59,30 +60,30 @@ public class EmbeddedWithManyToOneTest {
 
 	@Test
 	public void testGet(SessionFactoryScope scope) {
-		SQLStatementInspector statementInspector = scope.getCollectingStatementInspector();
-		statementInspector.clear();
+		CollectingStatementObserver sqlCollector = scope.getCollectingStatementObserver();
+		sqlCollector.clear();
 		scope.inTransaction(
 				session -> {
 					SystemUser systemUser = session.get( SystemUser.class, 1 );
 					assertTrue( Hibernate.isInitialized( systemUser.getPk() ) );
-					statementInspector.assertExecutedCount( 1 );
-					statementInspector.assertNumberOfOccurrenceInQuery( 0, "join", 1 );
+					sqlCollector.assertStatements().hasSize( 1 );
+					sqlCollector.assertQuery( 0 ).containsToken( " join ", 1 );
 				}
 		);
 	}
 
 	@Test
 	public void testHqlSelect(SessionFactoryScope scope) {
-		SQLStatementInspector statementInspector = scope.getCollectingStatementInspector();
-		statementInspector.clear();
+		CollectingStatementObserver sqlCollector = scope.getCollectingStatementObserver();
+		sqlCollector.clear();
 		scope.inTransaction(
 				session -> {
 					SystemUser systemUser = session.createQuery( "from SystemUser", SystemUser.class )
 							.uniqueResult();
 					assertTrue( Hibernate.isInitialized( systemUser.getPk() ) );
-					statementInspector.assertExecutedCount( 2 );
-					statementInspector.assertNumberOfOccurrenceInQuery( 1, "join", 0 );
-					statementInspector.assertNumberOfOccurrenceInQuery( 0, "join", 0 );
+					assertThat( sqlCollector.getStatements() ).hasSize( 2 );
+					assertThat( sqlCollector.getSqlQueries().get( 0 ) ).doesNotContain( " join " );
+					assertThat( sqlCollector.getSqlQueries().get( 1 ) ).doesNotContain( " join " );
 				}
 		);
 	}

--- a/hibernate-testing/src/main/java/org/hibernate/testing/jdbc/CollectingStatementObserver.java
+++ b/hibernate-testing/src/main/java/org/hibernate/testing/jdbc/CollectingStatementObserver.java
@@ -1,0 +1,81 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.testing.jdbc;
+
+import org.assertj.core.api.AbstractStringAssert;
+import org.assertj.core.api.ListAssert;
+import org.assertj.core.api.ObjectAssert;
+import org.hibernate.StatementObserver;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Steve Ebersole
+ */
+public class CollectingStatementObserver implements StatementObserver {
+	private List<Statement> statements = new ArrayList<>();
+
+	@Override
+	public void performingSql(String sql, int batchPosition) {
+		statements.add( new Statement( sql, batchPosition ) );
+	}
+
+	public List<Statement> getStatements() {
+		return statements;
+	}
+
+	public List<String> getSqlQueries() {
+		return statements.stream().map( Statement::sql ).toList();
+	}
+
+	public void clear() {
+		statements.clear();
+	}
+
+	public record Statement(String sql, int batchPosition) {
+	}
+
+	// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+	// AssertJ
+
+	public ListAssert<Statement> assertStatements() {
+		return assertThat( statements );
+	}
+
+	public ObjectAssert<Statement> assertStatement(int position) {
+		return assertThat( statements.get( position ) );
+	}
+
+	public ListAssert<String> assertQueries() {
+		return assertThat( getSqlQueries() );
+	}
+
+	public QueryAssert assertQuery(int position) {
+		return new QueryAssert( statements.get( position ).sql() );
+	}
+
+	public static class QueryAssert extends AbstractStringAssert<QueryAssert> {
+		protected QueryAssert(String sql) {
+			super( sql, QueryAssert.class );
+		}
+
+		public QueryAssert containsToken(String token) {
+			return contains( token );
+		}
+
+		public QueryAssert containsToken(String token, int numberOfTimes) {
+			var matches = actual.split( token, -1 );
+			assertThat( matches.length - 1 )
+					.as( "check `%s` contains `%s` %d times", actual, token, numberOfTimes )
+					.isEqualTo( numberOfTimes );
+			return myself;
+		}
+
+
+	}
+}

--- a/hibernate-testing/src/main/java/org/hibernate/testing/orm/junit/SessionFactory.java
+++ b/hibernate-testing/src/main/java/org/hibernate/testing/orm/junit/SessionFactory.java
@@ -15,7 +15,7 @@ import org.hibernate.Interceptor;
 import org.hibernate.boot.SessionFactoryBuilder;
 import org.hibernate.resource.jdbc.spi.StatementInspector;
 
-import org.hibernate.testing.jdbc.SQLStatementInspector;
+import org.hibernate.testing.jdbc.CollectingStatementObserver;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.extension.ExtendWith;
 
@@ -64,12 +64,24 @@ public @interface SessionFactory {
 
 	Class<? extends Interceptor> interceptorClass() default Interceptor.class;
 
+	/**
+	 * @deprecated Use {@linkplain #useCollectingStatementObserver()} instead.
+	 */
+	@Deprecated(forRemoval = true, since = "8.0")
 	Class<? extends StatementInspector> statementInspectorClass() default StatementInspector.class;
 
-	/// Shorthand for `statementInspectorClass = org.hibernate.testing.jdbc.SQLStatementInspector.class`
-	///
-	/// @see SQLStatementInspector
+	/**
+	 * @deprecated Use {@linkplain #useCollectingStatementObserver()} instead.
+	 */
+	@Deprecated(forRemoval = true, since = "8.0")
 	boolean useCollectingStatementInspector() default false;
+
+	/**
+	 * Triggers the use of {@linkplain CollectingStatementObserver} as the SessionFactory's
+	 * {@linkplain org.hibernate.cfg.JdbcSettings#STATEMENT_OBSERVER statement observer}.
+	 * Can be accessed using {@linkplain SessionFactoryScope#getCollectingStatementObserver()}
+	 */
+	boolean useCollectingStatementObserver() default false;
 
 	boolean applyCollectionsInDefaultFetchGroup() default true;
 

--- a/hibernate-testing/src/main/java/org/hibernate/testing/orm/junit/SessionFactoryExtension.java
+++ b/hibernate-testing/src/main/java/org/hibernate/testing/orm/junit/SessionFactoryExtension.java
@@ -16,6 +16,7 @@ import org.hibernate.engine.spi.SessionImplementor;
 import org.hibernate.engine.spi.StatelessSessionImplementor;
 import org.hibernate.internal.util.StringHelper;
 import org.hibernate.resource.jdbc.spi.StatementInspector;
+import org.hibernate.testing.jdbc.CollectingStatementObserver;
 import org.hibernate.testing.jdbc.SQLStatementInspector;
 import org.hibernate.testing.orm.transaction.TransactionUtil;
 import org.hibernate.tool.schema.Action;
@@ -137,13 +138,8 @@ public class SessionFactoryExtension
 							sessionFactoryBuilder.applyInterceptor( sessionFactoryConfig.interceptorClass().getDeclaredConstructor().newInstance() );
 						}
 
-						final Class<? extends StatementInspector> explicitInspectorClass = sessionFactoryConfig.statementInspectorClass();
-						if ( sessionFactoryConfig.useCollectingStatementInspector() ) {
-							sessionFactoryBuilder.applyStatementInspector( new SQLStatementInspector() );
-						}
-						else if ( ! explicitInspectorClass.equals( StatementInspector.class ) ) {
-							sessionFactoryBuilder.applyStatementInspector( explicitInspectorClass.getConstructor().newInstance() );
-						}
+						applyJdbcStatementObservation( sessionFactoryConfig, sessionFactoryBuilder );
+
 						sessionFactoryBuilder.applyCollectionsInDefaultFetchGroup( sessionFactoryConfig.applyCollectionsInDefaultFetchGroup() );
 
 						sessionFactoryConfig.sessionFactoryConfigurer().getDeclaredConstructor().newInstance()
@@ -174,6 +170,26 @@ public class SessionFactoryExtension
 		}
 
 		return sfScope;
+	}
+
+	private static void applyJdbcStatementObservation(SessionFactory sessionFactoryConfig, SessionFactoryBuilder sessionFactoryBuilder) {
+		if ( sessionFactoryConfig.useCollectingStatementObserver() ) {
+			sessionFactoryBuilder.applyStatementObserver( new CollectingStatementObserver() );
+		}
+		else if ( sessionFactoryConfig.useCollectingStatementInspector() ) {
+			sessionFactoryBuilder.applyStatementInspector( new SQLStatementInspector() );
+		}
+		else {
+			final Class<? extends StatementInspector> explicitInspectorClass = sessionFactoryConfig.statementInspectorClass();
+			if ( !explicitInspectorClass.equals( StatementInspector.class ) ) {
+				try {
+					sessionFactoryBuilder.applyStatementInspector( explicitInspectorClass.getConstructor().newInstance() );
+				}
+				catch (Exception e) {
+					throw new RuntimeException( "Could not instantiate specified StatementInspector: " + explicitInspectorClass, e );
+				}
+			}
+		}
 	}
 
 	private static void prepareSchemaExport(
@@ -259,6 +275,11 @@ public class SessionFactoryExtension
 		@Override
 		public MetadataImplementor getMetadataImplementor() {
 			return modelScope.getDomainModel();
+		}
+
+		@Override
+		public CollectingStatementObserver getCollectingStatementObserver() {
+			return (CollectingStatementObserver) getSessionFactory().getSessionFactoryOptions().getStatementObserver();
 		}
 
 		@Override

--- a/hibernate-testing/src/main/java/org/hibernate/testing/orm/junit/SessionFactoryScope.java
+++ b/hibernate-testing/src/main/java/org/hibernate/testing/orm/junit/SessionFactoryScope.java
@@ -13,6 +13,7 @@ import org.hibernate.engine.spi.SessionImplementor;
 import org.hibernate.engine.spi.StatelessSessionImplementor;
 import org.hibernate.resource.jdbc.spi.StatementInspector;
 
+import org.hibernate.testing.jdbc.CollectingStatementObserver;
 import org.hibernate.testing.jdbc.SQLStatementInspector;
 
 /**
@@ -21,9 +22,35 @@ import org.hibernate.testing.jdbc.SQLStatementInspector;
 public interface SessionFactoryScope {
 	SessionFactoryImplementor getSessionFactory();
 	MetadataImplementor getMetadataImplementor();
+
+	/**
+	 * Access to the CollectingStatementObserver for this test, if one.
+	 *
+	 * @see SessionFactory#useCollectingStatementObserver()
+	 */
+	CollectingStatementObserver getCollectingStatementObserver();
+
+	/**
+	 * @deprecated Along with {@linkplain SessionFactory#useCollectingStatementInspector()};
+	 * use {@linkplain #getCollectingStatementObserver()} instead.
+	 */
+	@Deprecated(forRemoval = true, since = "8.0")
 	StatementInspector getStatementInspector();
+
+	/**
+	 * @deprecated Along with {@linkplain SessionFactory#useCollectingStatementInspector()};
+	 * use {@linkplain #getCollectingStatementObserver()} instead.
+	 */
+	@Deprecated(forRemoval = true, since = "8.0")
 	<T extends StatementInspector> T getStatementInspector(Class<T> type);
+
+	/**
+	 * @deprecated Along with {@linkplain SessionFactory#useCollectingStatementInspector()};
+	 * use {@linkplain #getCollectingStatementObserver()} instead.
+	 */
+	@Deprecated(forRemoval = true, since = "8.0")
 	SQLStatementInspector getCollectingStatementInspector();
+
 	void releaseSessionFactory();
 
 	default void withSessionFactory(Consumer<SessionFactoryImplementor> action) {

--- a/whats-new.adoc
+++ b/whats-new.adoc
@@ -85,3 +85,8 @@ a new overload -
 var isbn = ...;
 var book = session.getReference(Book.class, isbn, NATURAL);
 ----
+
+[[StatementObserver]]
+== StatementObserver
+
+8.0 introduces the new `StatementObserver` contract, allowing observation of all JDBC statements Hibernate performs.


### PR DESCRIPTION
<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

[Please describe here what your change is about]

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------


---
<!-- Hibernate GitHub Bot task list start -->
Please make sure that the following tasks are completed:
Tasks specific to HHH-20295 (Improvement):
- [x] Add tests for feature/improvement
- [x] Update documentation as relevant: javadoc for changed API, `documentation/src/main/asciidoc/userguide` for all features, `documentation/src/main/asciidoc/introduction` for main features, links from existing documentation
- [x] Add entries as relevant to `migration-guide.adoc` (breaking changes) and `whats-new.adoc` (new features/improvements)


<!-- Hibernate GitHub Bot task list end -->

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-20295
<!-- Hibernate GitHub Bot issue links end -->