### PR TITLE
Add Java source level to the Sonar config

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -6,6 +6,7 @@ sonar.projectDescription=Idiomatic persistence for Java and relational databases
 
 sonar.language=java
 sonar.sourceEncoding=UTF-8
+sonar.java.source=17
 
 sonar.modules=hibernate-agroal,hibernate-c3p0,hibernate-community-dialects,hibernate-core,hibernate-envers,hibernate-graalvm,hibernate-hikaricp,hibernate-jcache,hibernate-jfr,hibernate-micrometer,hibernate-scan-jandex,hibernate-spatial,hibernate-testing,hibernate-vector,hibernate-ant,hibernate-assistant,hibernate-gradle-plugin,hibernate-maven-plugin,metamodel-generator
 


### PR DESCRIPTION
so that we won't get "(sonar.java.source not set. Assuming 8 or greater.)" warnings on Sonar

<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

[Please describe here what your change is about]

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
