### PR TITLE
HHH-20325 Enable locking support for Spanner PostgreSQL dialect

### DIFF
--- a/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/SpannerPostgreSQLDialect.java
+++ b/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/SpannerPostgreSQLDialect.java
@@ -39,8 +39,14 @@ import org.hibernate.dialect.function.array.SpannerPostgreSQLArrayRemoveIndexFun
 import org.hibernate.dialect.Replacer;
 import org.hibernate.dialect.function.SpannerPostgreSQLRegexpLikeFunction;
 import org.hibernate.dialect.function.SpannerPostgreSQLTruncFunction;
+import org.hibernate.dialect.RowLockStrategy;
+import org.hibernate.dialect.lock.PessimisticLockStyle;
 import org.hibernate.dialect.lock.internal.NoLockingSupport;
+import org.hibernate.dialect.lock.internal.LockingSupportSimple;
+import org.hibernate.dialect.lock.spi.ConnectionLockTimeoutStrategy;
+import org.hibernate.dialect.lock.spi.LockTimeoutType;
 import org.hibernate.dialect.lock.spi.LockingSupport;
+import org.hibernate.dialect.lock.spi.OuterJoinLockingType;
 import org.hibernate.dialect.pagination.LimitHandler;
 import org.hibernate.dialect.pagination.LimitOffsetLimitHandler;
 import org.hibernate.dialect.sequence.SequenceSupport;
@@ -144,11 +150,18 @@ public class SpannerPostgreSQLDialect extends PostgreSQLDialect {
 	// This workaround that is only intended for testing, and should not be used for primary key
 	// values in production.
 	private static final String USE_INTEGER_FOR_PRIMARY_KEY = "hibernate.dialect.spanner.use_integer_for_primary_key";
+	private static final String USE_EMULATOR = "hibernate.dialect.spanner.use_emulator";
 
 	private boolean useIntegerForPrimaryKey;
+	private boolean useEmulator;
 
-	// TODO(spanner): Spanner supports pessimistic lock with FOR UPDATE. Investigate this bug
-	private final LockingSupport SPANNER_LOCKING_SUPPORT = NoLockingSupport.NO_LOCKING_SUPPORT;
+	private final LockingSupport SPANNER_LOCKING_SUPPORT = new LockingSupportSimple(
+			PessimisticLockStyle.CLAUSE,
+			RowLockStrategy.NONE,
+			LockTimeoutType.NONE,
+			OuterJoinLockingType.FULL,
+			ConnectionLockTimeoutStrategy.NONE
+	);
 
 	protected final static DatabaseVersion MINIMUM_POSTGRES_VERSION = DatabaseVersion.make( 15 );
 
@@ -415,7 +428,7 @@ public class SpannerPostgreSQLDialect extends PostgreSQLDialect {
 
 	@Override
 	public LockingSupport getLockingSupport() {
-		return SPANNER_LOCKING_SUPPORT;
+		return useEmulator ? NoLockingSupport.NO_LOCKING_SUPPORT : SPANNER_LOCKING_SUPPORT;
 	}
 
 	@Override
@@ -538,6 +551,12 @@ public class SpannerPostgreSQLDialect extends PostgreSQLDialect {
 
 		this.useIntegerForPrimaryKey = configurationService.getSetting(
 				USE_INTEGER_FOR_PRIMARY_KEY,
+				StandardConverters.BOOLEAN,
+				false
+		);
+
+		this.useEmulator = configurationService.getSetting(
+				USE_EMULATOR,
 				StandardConverters.BOOLEAN,
 				false
 		);


### PR DESCRIPTION
<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

[Please describe here what your change is about]

- Add `hibernate.dialect.spanner.use_emulator` property to disable locking when running against the emulator.

- Use `LockingSupportSimple` to provide basic FOR UPDATE support when not on emulator.

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------


---
<!-- Hibernate GitHub Bot task list start -->
Please make sure that the following tasks are completed:
Tasks specific to HHH-20325 (Sub-task):
- [x] Add test **OR** check there is no need for a test
- [x] Update documentation as relevant: javadoc for changed API, `documentation/src/main/asciidoc/userguide` for all features, `documentation/src/main/asciidoc/introduction` for main features, links from existing documentation
- [x] Add entries as relevant to `migration-guide.adoc` (breaking changes) and `whats-new.adoc` (new features/improvements)


<!-- Hibernate GitHub Bot task list end -->

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-20325
<!-- Hibernate GitHub Bot issue links end -->