### PR TITLE
[6.6] HHH-20327 Hibernate PassThruZonedTest and JDBCTimeZoneZonedTest tests intermittently fail with MSSQL

### DIFF
--- a/hibernate-core/src/test/java/org/hibernate/orm/test/temporal/FractionalSecondsTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/temporal/FractionalSecondsTests.java
@@ -97,6 +97,7 @@ public class FractionalSecondsTests {
 	@Test
 	@DomainModel(annotatedClasses = TestEntity.class)
 	@SessionFactory
+    @SkipForDialect(dialectClass = SQLServerDialect.class, reason = "HHH-20327")
 	@SkipForDialect(dialectClass = SybaseDialect.class, reason = "Because... Sybase...", matchSubTypes = true)
 	void testUsage(SessionFactoryScope scope) {
 		final Instant start = Instant.now();

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/temporal/JavaTimeFractionalSecondsTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/temporal/JavaTimeFractionalSecondsTests.java
@@ -99,6 +99,7 @@ public class JavaTimeFractionalSecondsTests {
 	@Test
 	@DomainModel(annotatedClasses = TestEntity.class)
 	@SessionFactory
+    @SkipForDialect(dialectClass = SQLServerDialect.class, reason = "HHH-20327")
 	@SkipForDialect(dialectClass = SybaseDialect.class, reason = "Because... Sybase...", matchSubTypes = true)
 	void testUsage(SessionFactoryScope scope) {
 		final Instant start = Instant.now();

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/timezones/AutoZonedTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/timezones/AutoZonedTest.java
@@ -8,7 +8,9 @@ import java.time.temporal.ChronoField;
 
 import org.hibernate.cfg.AvailableSettings;
 import org.hibernate.dialect.Dialect;
+import org.hibernate.dialect.SQLServerDialect;
 import org.hibernate.dialect.SybaseDialect;
+import org.hibernate.testing.orm.junit.SkipForDialect;
 import org.hibernate.type.descriptor.DateTimeUtils;
 
 import org.hibernate.testing.orm.junit.DomainModel;
@@ -24,6 +26,7 @@ import jakarta.persistence.Id;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+@SkipForDialect(dialectClass = SQLServerDialect.class, reason = "HHH-20327")
 @DomainModel(annotatedClasses = AutoZonedTest.Zoned.class)
 @SessionFactory
 @ServiceRegistry(settings = @Setting(name = AvailableSettings.TIMEZONE_DEFAULT_STORAGE, value = "AUTO"))

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/timezones/ColumnZonedTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/timezones/ColumnZonedTest.java
@@ -8,7 +8,9 @@ import java.time.temporal.ChronoField;
 
 import org.hibernate.cfg.AvailableSettings;
 import org.hibernate.dialect.Dialect;
+import org.hibernate.dialect.SQLServerDialect;
 import org.hibernate.dialect.SybaseDialect;
+import org.hibernate.testing.orm.junit.SkipForDialect;
 import org.hibernate.type.descriptor.DateTimeUtils;
 
 import org.hibernate.testing.orm.junit.DomainModel;
@@ -24,6 +26,7 @@ import jakarta.persistence.Id;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+@SkipForDialect(dialectClass = SQLServerDialect.class, reason = "HHH-20327")
 @DomainModel(annotatedClasses = ColumnZonedTest.Zoned.class)
 @SessionFactory
 @ServiceRegistry(settings = @Setting(name = AvailableSettings.TIMEZONE_DEFAULT_STORAGE, value = "COLUMN"))

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/timezones/DefaultZonedTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/timezones/DefaultZonedTest.java
@@ -7,8 +7,10 @@ import java.time.ZonedDateTime;
 import java.time.temporal.ChronoField;
 
 import org.hibernate.dialect.Dialect;
+import org.hibernate.dialect.SQLServerDialect;
 import org.hibernate.dialect.SybaseDialect;
 import org.hibernate.dialect.TimeZoneSupport;
+import org.hibernate.testing.orm.junit.SkipForDialect;
 import org.hibernate.type.descriptor.DateTimeUtils;
 
 import org.hibernate.testing.orm.junit.DomainModel;
@@ -22,6 +24,7 @@ import jakarta.persistence.Id;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+@SkipForDialect(dialectClass = SQLServerDialect.class, reason = "HHH-20327")
 @DomainModel(annotatedClasses = DefaultZonedTest.Zoned.class)
 @SessionFactory
 public class DefaultZonedTest {

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/timezones/JDBCTimeZoneZonedTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/timezones/JDBCTimeZoneZonedTest.java
@@ -9,7 +9,9 @@ import java.time.temporal.ChronoField;
 
 import org.hibernate.cfg.AvailableSettings;
 import org.hibernate.dialect.Dialect;
+import org.hibernate.dialect.SQLServerDialect;
 import org.hibernate.dialect.SybaseDialect;
+import org.hibernate.testing.orm.junit.SkipForDialect;
 import org.hibernate.type.descriptor.DateTimeUtils;
 
 import org.hibernate.testing.orm.junit.DomainModel;
@@ -25,6 +27,7 @@ import jakarta.persistence.Id;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+@SkipForDialect(dialectClass = SQLServerDialect.class, reason = "HHH-20327")
 @DomainModel(annotatedClasses = JDBCTimeZoneZonedTest.Zoned.class)
 @SessionFactory
 @ServiceRegistry(settings = {@Setting(name = AvailableSettings.TIMEZONE_DEFAULT_STORAGE, value = "NORMALIZE"),

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/timezones/PassThruZonedTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/timezones/PassThruZonedTest.java
@@ -9,7 +9,9 @@ import java.time.temporal.ChronoField;
 
 import org.hibernate.cfg.AvailableSettings;
 import org.hibernate.dialect.Dialect;
+import org.hibernate.dialect.SQLServerDialect;
 import org.hibernate.dialect.SybaseDialect;
+import org.hibernate.testing.orm.junit.SkipForDialect;
 import org.hibernate.type.descriptor.DateTimeUtils;
 
 import org.hibernate.testing.orm.junit.DomainModel;
@@ -25,6 +27,7 @@ import jakarta.persistence.Id;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+@SkipForDialect(dialectClass = SQLServerDialect.class, reason = "HHH-20327")
 @DomainModel(annotatedClasses = PassThruZonedTest.Zoned.class)
 @SessionFactory
 @ServiceRegistry(settings = @Setting(name = AvailableSettings.TIMEZONE_DEFAULT_STORAGE, value = "NORMALIZE"))

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/timezones/UTCNormalizedInstantTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/timezones/UTCNormalizedInstantTest.java
@@ -6,7 +6,9 @@ import java.util.TimeZone;
 
 import org.hibernate.annotations.JdbcTypeCode;
 import org.hibernate.dialect.Dialect;
+import org.hibernate.dialect.SQLServerDialect;
 import org.hibernate.dialect.SybaseDialect;
+import org.hibernate.testing.orm.junit.SkipForDialect;
 import org.hibernate.type.descriptor.DateTimeUtils;
 
 import org.hibernate.testing.jdbc.SharedDriverManagerConnectionProviderImpl;
@@ -22,6 +24,7 @@ import jakarta.persistence.Id;
 import static java.sql.Types.TIMESTAMP;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+@SkipForDialect(dialectClass = SQLServerDialect.class, reason = "HHH-20327")
 @DomainModel(annotatedClasses = UTCNormalizedInstantTest.Zoned.class)
 @SessionFactory
 public class UTCNormalizedInstantTest {

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/timezones/UTCNormalizedZonedTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/timezones/UTCNormalizedZonedTest.java
@@ -8,7 +8,9 @@ import java.time.temporal.ChronoField;
 
 import org.hibernate.cfg.AvailableSettings;
 import org.hibernate.dialect.Dialect;
+import org.hibernate.dialect.SQLServerDialect;
 import org.hibernate.dialect.SybaseDialect;
+import org.hibernate.testing.orm.junit.SkipForDialect;
 import org.hibernate.type.descriptor.DateTimeUtils;
 
 import org.hibernate.testing.orm.junit.DomainModel;
@@ -24,6 +26,7 @@ import jakarta.persistence.Id;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+@SkipForDialect(dialectClass = SQLServerDialect.class, reason = "HHH-20327")
 @DomainModel(annotatedClasses = UTCNormalizedZonedTest.Zoned.class)
 @SessionFactory
 @ServiceRegistry(settings = @Setting(name = AvailableSettings.TIMEZONE_DEFAULT_STORAGE, value = "NORMALIZE_UTC"))


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-20327
https://redhat.atlassian.net/browse/JBEAP-32443

----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------


---
<!-- Hibernate GitHub Bot task list start -->
Please make sure that the following tasks are completed:
Tasks specific to HHH-20327 (Bug):
- [x] Add test reproducing the bug
- [x] Add entries as relevant to `migration-guide.adoc` **OR** check there are no breaking changes


<!-- Hibernate GitHub Bot task list end -->