### PR TITLE
HHH-20028 Fix some of the javadocs

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/Session.java
+++ b/hibernate-core/src/main/java/org/hibernate/Session.java
@@ -99,8 +99,7 @@ import java.util.List;
 /// behavior is appropriate for programs which use optimistic locking.
 ///
 ///   - A different lock level may be obtained by explicitly specifying the mode using
-///     [#find(Class,Object,LockModeType)], [#find(Class,Object,FindOption...)],
-///     [#refresh(Object,LockModeType)], [#refresh(Object,RefreshOption...)],
+///     [#find(Class,Object,FindOption...)], [#refresh(Object,RefreshOption...)],
 ///     or [org.hibernate.query.SelectionQuery#setLockMode(LockModeType)].
 ///   - The lock level of a managed instance already held by the session may be upgraded
 ///     to a more restrictive lock level by calling [#lock(Object,LockMode)] or
@@ -789,7 +788,7 @@ public interface Session extends SharedSessionContract, EntityManager {
 	/// with the session, return that instance. This method never returns an uninitialized
 	/// instance. Obtain the specified lock mode if the instance exists.
 	///
-	/// @apiNote This operation is very similar to [#find(Class,Object,LockModeType)].
+	/// @apiNote This operation is very similar to [#find(Class,Object,FindOption...)].
 	///
 	/// @param entityType the entity type
 	/// @param id an identifier

--- a/hibernate-core/src/main/java/org/hibernate/boot/archive/spi/package-info.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/archive/spi/package-info.java
@@ -6,10 +6,10 @@
 /**
  * Defines a model for
  * {@linkplain org.hibernate.boot.archive.spi.ArchiveDescriptor archives}
- * which may be {@link org.hibernate.boot.archive.scan.spi scanned}
+ * which may be {@link org.hibernate.boot.scan.spi scanned}
  * to discover managed classes and named resources.
  *
  * @see org.hibernate.boot.archive.spi.ArchiveDescriptor
- * @see org.hibernate.boot.archive.scan.spi
+ * @see org.hibernate.boot.scan.spi
  */
 package org.hibernate.boot.archive.spi;

--- a/hibernate-core/src/main/java/org/hibernate/boot/scan/spi/ScanningContext.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/scan/spi/ScanningContext.java
@@ -9,7 +9,7 @@ import org.hibernate.boot.archive.spi.ArchiveDescriptorFactory;
 import java.util.Map;
 
 /// Access to information useful while performing discovery.  Acts as a
-/// "parameter object" for [Scanner#discoverClassNames]
+/// "parameter object" for [ScanningProvider#builderScanner(ScanningContext)]
 ///
 /// @author Steve Ebersole
 public interface ScanningContext {

--- a/hibernate-core/src/main/java/org/hibernate/jpa/HibernateHints.java
+++ b/hibernate-core/src/main/java/org/hibernate/jpa/HibernateHints.java
@@ -29,8 +29,9 @@ public interface HibernateHints {
 	 * Hint for applying a Hibernate-specific flush mode to either a
 	 * {@linkplain jakarta.persistence.Query} or
 	 * {@linkplain jakarta.persistence.EntityManager}.
-	 * <p/>
-	 * The allowed values depend on the context -<ul>
+	 * <p>
+	 * The allowed values depend on the context -
+	 * <ul>
 	 *     <li>
 	 *         For a query, the value will ultimately get resolved to a
 	 *         {@linkplain QueryFlushMode} via .  The hint value may be any of the following:<ul>

--- a/hibernate-core/src/main/java/org/hibernate/query/NativeQuery.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/NativeQuery.java
@@ -185,8 +185,8 @@ public interface NativeQuery<T> extends SelectionQuery<T>, MutationQuery, Synchr
 	LockModeType getLockMode();
 
 	/**
-	 * @inheritDoc
-	 *
+	 * {@inheritDoc}
+	 * <p>
 	 * This operation is supported even for native queries.
 	 * Note that specifying an explicit lock mode might
 	 * result in changes to the native SQL query that is
@@ -209,8 +209,8 @@ public interface NativeQuery<T> extends SelectionQuery<T>, MutationQuery, Synchr
 	SelectionQuery<T> setLockMode(LockModeType lockMode);
 
 	/**
-	 * @inheritDoc
-	 *
+	 * {@inheritDoc}
+	 * <p>
 	 * This operation is supported even for native queries.
 	 * Note that specifying an explicit lock mode might
 	 * result in changes to the native SQL query that is

--- a/hibernate-core/src/main/java/org/hibernate/query/Query.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/Query.java
@@ -44,12 +44,12 @@ import java.util.stream.Stream;
  * Within the context of an active {@linkplain org.hibernate.Session session},
  * an instance of this type represents an executable query, either:
  * <ul>
- * <li>a Query<T> written in HQL or native SQL,
- * <li>a named Query<T> written in HQL or native SQL, or
+ * <li>a {@code Query<T>} written in HQL or native SQL,
+ * <li>a named {@code Query<T>} written in HQL or native SQL, or
  * <li>a {@linkplain jakarta.persistence.criteria.CriteriaBuilder criteria query}.
  * </ul>
  * <p>
- * The subtype {@link NativeQuery} represents a Query<T> written in native SQL.
+ * The subtype {@link NativeQuery} represents a {@code Query<T>} written in native SQL.
  * <p>
  * This type simply mixes the {@link TypedQuery} interface defined by JPA with
  * {@link SelectionQuery} and {@link MutationQuery}. Unfortunately, JPA does
@@ -66,11 +66,11 @@ import java.util.stream.Stream;
  *     passing a {@linkplain jakarta.persistence.criteria.CriteriaQuery<T> criteria
  *     object}, or
  * <li>{@link org.hibernate.SharedSessionContract#createNamedQuery(String, Class)} passing the name
- *     of a Query<T> defined using {@link jakarta.persistence.NamedQuery} or
+ *     of a {@code Query<T>} defined using {@link jakarta.persistence.NamedQuery} or
  *     {@link jakarta.persistence.NamedNativeQuery}.
  * </ul>
  * <p>
- * A {@code Query} controls how a Query<T> is executed, and allows arguments to be
+ * A {@code Query} controls how a {@code Query<T>} is executed, and allows arguments to be
  * bound to its parameters.
  * <ul>
  * <li>Selection queries are usually executed using {@link #getResultList()} or
@@ -100,7 +100,7 @@ import java.util.stream.Stream;
 public interface Query<T> extends CommonQueryContract {
 
 	/**
-	 * The Query<T> as a string, or {@code null} in the case of a criteria query.
+	 * The {@code Query<T>} as a string, or {@code null} in the case of a criteria query.
 	 */
 	String getQueryString();
 
@@ -189,12 +189,12 @@ public interface Query<T> extends CommonQueryContract {
 	Query<T> setTimeout(Timeout timeout);
 
 	/**
-	 * Whether the execution plan for this Query<T> is cached.
+	 * Whether the execution plan for this {@code Query<T>} is cached.
 	 */
 	boolean isQueryPlanCacheable();
 
 	/**
-	 * Enable/disable Query<T> plan caching for this query, if available.
+	 * Enable/disable {@code Query<T>} plan caching for this query, if available.
 	 *
 	 * @see #isQueryPlanCacheable
 	 */
@@ -720,8 +720,8 @@ public interface Query<T> extends CommonQueryContract {
 	Query<T> setResultListTransformer(ResultListTransformer<T> transformer);
 
 	/**
-	 * Execute the Query<T> and return the Query<T> results as a {@link List}.
-	 * If the Query<T> contains multiple items in the selection list, then
+	 * Execute the {@code Query<T>} and return the {@code Query<T>} results as a {@link List}.
+	 * If the {@code Query<T>} contains multiple items in the selection list, then
 	 * by default each result in the list is packaged in an array of type
 	 * {@code Object[]}.
 	 *
@@ -733,8 +733,8 @@ public interface Query<T> extends CommonQueryContract {
 	List<T> list();
 
 	/**
-	 * Execute the Query<T> and return the Query<T> results as a {@link List}.
-	 * If the Query<T> contains multiple items in the selection list, then
+	 * Execute the {@code Query<T>} and return the {@code Query<T>} results as a {@link List}.
+	 * If the {@code Query<T>} contains multiple items in the selection list, then
 	 * by default each result in the list is packaged in an array of type
 	 * {@code Object[]}.
 	 *
@@ -751,7 +751,7 @@ public interface Query<T> extends CommonQueryContract {
 	}
 
 	/**
-	 * Execute the Query<T> and return the results in a
+	 * Execute the {@code Query<T>} and return the results in a
 	 * {@linkplain ScrollableResults scrollable form}.
 	 * <p>
 	 * This overload simply calls {@link #scroll(ScrollMode)} using the
@@ -768,7 +768,7 @@ public interface Query<T> extends CommonQueryContract {
 	ScrollableResults<T> scroll();
 
 	/**
-	 * Execute the Query<T> and return the results in a
+	 * Execute the {@code Query<T>} and return the results in a
 	 * {@linkplain ScrollableResults scrollable form}. The capabilities
 	 * of the returned {@link ScrollableResults} depend on the specified
 	 * {@link ScrollMode}.
@@ -784,8 +784,8 @@ public interface Query<T> extends CommonQueryContract {
 	ScrollableResults<T> scroll(ScrollMode scrollMode);
 
 	/**
-	 * Execute the Query<T> and return the Query<T> results as a {@link Stream}.
-	 * If the Query<T> contains multiple items in the selection list, then
+	 * Execute the {@code Query<T>} and return the {@code Query<T>} results as a {@link Stream}.
+	 * If the {@code Query<T>} contains multiple items in the selection list, then
 	 * by default each result in the stream is packaged in an array of
 	 * type {@code Object[]}.
 	 * <p>
@@ -807,8 +807,8 @@ public interface Query<T> extends CommonQueryContract {
 	}
 
 	/**
-	 * Execute the Query<T> and return the Query<T> results as a {@link Stream}.
-	 * If the Query<T> contains multiple items in the selection list, then
+	 * Execute the {@code Query<T>} and return the {@code Query<T>} results as a {@link Stream}.
+	 * If the {@code Query<T>} contains multiple items in the selection list, then
 	 * by default each result in the stream is packaged in an array of type
 	 * {@code Object[]}.
 	 * <p>
@@ -827,8 +827,8 @@ public interface Query<T> extends CommonQueryContract {
 	}
 
 	/**
-	 * Execute the Query<T> and return the single result of the query, or
-	 * {@code null} if the Query<T> returns no results.
+	 * Execute the {@code Query<T>} and return the single result of the query, or
+	 * {@code null} if the {@code Query<T>} returns no results.
 	 *
 	 * @return the single result or {@code null} if there is no result to return
 	 *
@@ -840,8 +840,8 @@ public interface Query<T> extends CommonQueryContract {
 	T uniqueResult();
 
 	/**
-	 * Execute the Query<T> and return the single result of the query,
-	 * throwing an exception if the Query<T> returns no results.
+	 * Execute the {@code Query<T>} and return the single result of the query,
+	 * throwing an exception if the {@code Query<T>} returns no results.
 	 *
 	 * @return the single result, only if there is exactly one
 	 *
@@ -855,7 +855,7 @@ public interface Query<T> extends CommonQueryContract {
 	T getSingleResult();
 
 	/**
-	 * Execute the Query<T> and return the single result of the Query<T> as
+	 * Execute the {@code Query<T>} and return the single result of the {@code Query<T>} as
 	 * an instance of {@link Optional}.
 	 *
 	 * @return the single result as an {@code Optional}
@@ -899,11 +899,11 @@ public interface Query<T> extends CommonQueryContract {
 	// deprecated methods
 
 	/**
-	 * The JPA {@link FlushModeType} in effect for this query.  By default, the
-	 * Query<T> inherits the {@link FlushMode} of the {@link Session} from which
+	 * The JPA {@link FlushModeType} in effect for this query. By default, the
+	 * {@code Query<T>} inherits the {@link FlushMode} of the {@link Session} from which
 	 * it originates.
 	 *
-	 * @apiNote Inherited from Jakarta Persistence.  Prefer {@linkplain #getQueryFlushMode()}
+	 * @apiNote Inherited from Jakarta Persistence. Prefer {@linkplain #getQueryFlushMode()}
 	 * @see #getQueryFlushMode()
 	 */
 	@Override @Deprecated(since = "7")
@@ -946,7 +946,7 @@ public interface Query<T> extends CommonQueryContract {
 	 *
 	 * @return Return the encapsulation of this query's options.
 	 *
-	 * @deprecated The various Query<T> subtypes already expose all relevant options;
+	 * @deprecated The various {@code Query<T>} subtypes already expose all relevant options;
 	 * plus exposing QueryOptions is layer-breaking as it is an SPI contract
 	 * exposed on an API.
 	 */
@@ -966,7 +966,7 @@ public interface Query<T> extends CommonQueryContract {
 	Query<T> setParameter(Parameter<Date> parameter, Date argument, TemporalType temporalType);
 
 	/**
-	 * Bind an {@link Instant} value to the named Query<T> parameter using
+	 * Bind an {@link Instant} value to the named {@code Query<T>} parameter using
 	 * just the portion indicated by the given {@link TemporalType}.
 	 */
 	@Deprecated(since = "7")
@@ -985,7 +985,7 @@ public interface Query<T> extends CommonQueryContract {
 	Query<T> setParameter(String parameter, Date argument, TemporalType temporalType);
 
 	/**
-	 * Bind an {@link Instant} value to the ordinal Query<T> parameter using
+	 * Bind an {@link Instant} value to the ordinal {@code Query<T>} parameter using
 	 * just the portion indicated by the given {@link TemporalType}.
 	 */
 	@Deprecated(since = "7")

--- a/hibernate-core/src/main/java/org/hibernate/sql/ast/spi/SqlSelection.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/ast/spi/SqlSelection.java
@@ -14,7 +14,7 @@ import org.hibernate.type.descriptor.ValueExtractor;
 
 /// Represents a selection at the SQL/JDBC level.  Essentially made up of:
 /// * [#getJdbcValueExtractor] - How to read a value from JDBC (conceptually similar to a method reference)
-/// * [#getValuesArrayPosition] - The position for this selection in relation to the "JDBC values array" (see [RowProcessingState#getJdbcValue])
+/// * [#getValuesArrayPosition] - The position for this selection in relation to the "JDBC values array" (see [org.hibernate.sql.results.jdbc.spi.RowProcessingState#getJdbcValue])
 /// * [#getJdbcResultSetIndex()] - The position for this selection in relation to the JDBC object (ResultSet, etc)
 ///
 /// @author Steve Ebersole

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/boot/discovery/SimpleTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/boot/discovery/SimpleTests.java
@@ -6,7 +6,9 @@ package org.hibernate.orm.test.jpa.boot.discovery;
 
 import jakarta.persistence.EntityManagerFactory;
 import jakarta.persistence.PersistenceConfiguration;
+import org.hibernate.dialect.H2Dialect;
 import org.hibernate.jpa.HibernatePersistenceConfiguration;
+import org.hibernate.testing.orm.junit.RequiresDialect;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.exporter.ZipExporter;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
@@ -23,6 +25,8 @@ import static jakarta.persistence.Persistence.ConnectionProperties.JDBC_USER;
 /**
  * @author Steve Ebersole
  */
+@RequiresDialect(value = H2Dialect.class,
+		comment = "Tests explicitly target H2 database by specifying the H2 JDBC URL.")
 public class SimpleTests {
 	@Test
 	void testBaseline() {


### PR DESCRIPTION
as jpa4 branch is failing at the javadoc task right now  😔 

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------


---
<!-- Hibernate GitHub Bot task list start -->
Please make sure that the following tasks are completed:
Tasks specific to HHH-20028 (Task):
- [ ] Add test **OR** check there is no need for a test
- [ ] Update documentation as relevant: javadoc for changed API, `documentation/src/main/asciidoc/userguide` for all features, `documentation/src/main/asciidoc/introduction` for main features, links from existing documentation
- [ ] Add entries as relevant to `migration-guide.adoc` (breaking changes) and `whats-new.adoc` (new features/improvements)


<!-- Hibernate GitHub Bot task list end -->

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-20028
<!-- Hibernate GitHub Bot issue links end -->