### PR TITLE
HHH-17767 - Add support for Value LOBs

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/dialect/Dialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/Dialect.java
@@ -4451,6 +4451,12 @@ public abstract class Dialect implements ConversionContext, TypeContributor, Fun
 	 *     {@link Clob#setString(long, String)},
 	 *     {@link Clob#setString(long, String, int, int)},
 	 *     or {@link Clob#truncate(long)}.
+	 * <li>For NCLOBs, the internal value might be changed by:
+	 *     {@link NClob#setAsciiStream(long)},
+	 *     {@link NClob#setCharacterStream(long)},
+	 *     {@link NClob#setString(long, String)},
+	 *     {@link NClob#setString(long, String, int, int)},
+	 *     or {@link NClob#truncate(long)}.
 	 *</ul>
 	 *
 	 * @implNote I do not know the correct answer currently for databases
@@ -5224,6 +5230,29 @@ public abstract class Dialect implements ConversionContext, TypeContributor, Fun
 	public boolean supportsMaterializedLobAccess() {
 		// Most drivers support this
 		return true;
+	}
+
+	/**
+	 * Tells whether the database supports VALUE LOB access
+	 * compared to usual REFERENCE LOB access.
+	 *
+	 * @return {@code true} if LOBs access can be VALUE based.
+	 *
+	 * @since 7.5
+	 */
+	public boolean supportsValueLOBAccess() {
+		return false;
+	}
+
+	/**
+	 * Returns the SQL fragment to define VALUE LOB
+	 *
+	 * @param columnName the column name
+	 *
+	 * @return the SQL fragment to add as extra table information
+	 */
+	public String getValueLOBFragmentForExtraCreateTableInfo(String columnName) {
+		return "";
 	}
 
 	/**

--- a/hibernate-core/src/main/java/org/hibernate/dialect/OracleDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/OracleDialect.java
@@ -1136,6 +1136,19 @@ public class OracleDialect extends Dialect {
 		return getVersion().isSameOrAfter( 23 );
 	}
 
+	/**
+	 * Available since 23c, 23ai, 26ai, VALUE LOBs are documented <a href="https://docs.oracle.com/en/database/oracle/oracle-database/26/adlob/value-based-LOBs.html">here</a>.
+	 *
+	 * @return {@code true} if LOBs access can be VALUE based.
+	 */
+	@Override
+	public boolean supportsValueLOBAccess() { return getVersion().isSameOrAfter( 23 ); }
+
+	@Override
+	public String getValueLOBFragmentForExtraCreateTableInfo(String columnName) {
+		return " lob(" + columnName + ") query as value";
+	}
+
 	// features which remain constant across 8i, 9i, and 10g ~~~~~~~~~~~~~~~~~~
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/dialect/OracleDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/OracleDialect.java
@@ -1136,6 +1136,19 @@ public class OracleDialect extends Dialect {
 		return getVersion().isSameOrAfter( 23 );
 	}
 
+	/**
+	 * Available since 23c, 23ai, 26ai, VALUE LOBs are documented <a href="https://docs.oracle.com/en/database/oracle/oracle-database/26/adlob/value-based-LOBs.html">here</a>.
+	 *
+	 * @return {@code true} if LOBs access can be VALUE based.
+	 */
+	@Override
+	public boolean supportsValueLOBAccess() { return getVersion().isSameOrAfter( 23 ); }
+
+	@Override
+	public String getValueLOBFragmentForExtraCreateTableInfo(String columnName) {
+		return "\nlob(" + columnName + ") query as value";
+	}
+
 	// features which remain constant across 8i, 9i, and 10g ~~~~~~~~~~~~~~~~~~
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/jdbc/BlobJdbcType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/jdbc/BlobJdbcType.java
@@ -11,6 +11,7 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Types;
 
+import org.hibernate.boot.model.relational.Database;
 import org.hibernate.engine.jdbc.BinaryStream;
 import org.hibernate.type.descriptor.ValueExtractor;
 import org.hibernate.type.descriptor.WrapperOptions;
@@ -23,6 +24,7 @@ import org.hibernate.type.spi.TypeConfiguration;
  * @author Steve Ebersole
  * @author Gail Badner
  * @author Brett Meyer
+ * @author Loïc Lefèvre
  */
 public abstract class BlobJdbcType implements JdbcType {
 
@@ -78,6 +80,16 @@ public abstract class BlobJdbcType implements JdbcType {
 	@Override
 	public <X> BasicBinder<X> getBinder(final JavaType<X> javaType) {
 		return getBlobBinder( javaType );
+	}
+
+	@Override
+	public String getExtraCreateTableInfo(JavaType<?> javaType, String columnName, String tableName, Database database) {
+		if( javaType.getJavaTypeClass() != Blob.class && database.getDialect().supportsValueLOBAccess() ) {
+			return database.getDialect().getValueLOBFragmentForExtraCreateTableInfo(columnName);
+		}
+		else {
+			return JdbcType.super.getExtraCreateTableInfo( javaType, columnName, tableName, database );
+		}
 	}
 
 	public static final BlobJdbcType DEFAULT = new BlobJdbcType() {

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/jdbc/BlobJdbcType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/jdbc/BlobJdbcType.java
@@ -11,6 +11,7 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Types;
 
+import org.hibernate.boot.model.relational.Database;
 import org.hibernate.engine.jdbc.BinaryStream;
 import org.hibernate.type.descriptor.ValueExtractor;
 import org.hibernate.type.descriptor.WrapperOptions;
@@ -23,6 +24,7 @@ import org.hibernate.type.spi.TypeConfiguration;
  * @author Steve Ebersole
  * @author Gail Badner
  * @author Brett Meyer
+ * @author Loïc Lefèvre
  */
 public abstract class BlobJdbcType implements JdbcType {
 
@@ -78,6 +80,16 @@ public abstract class BlobJdbcType implements JdbcType {
 	@Override
 	public <X> BasicBinder<X> getBinder(final JavaType<X> javaType) {
 		return getBlobBinder( javaType );
+	}
+
+	@Override
+	public String getExtraCreateTableInfo(JavaType<?> javaType, String columnName, String tableName, Database database) {
+		if( database.getDialect().supportsValueLOBAccess() ) {
+			return database.getDialect().getValueLOBFragmentForExtraCreateTableInfo(columnName);
+		}
+		else {
+			return JdbcType.super.getExtraCreateTableInfo( javaType, columnName, tableName, database );
+		}
 	}
 
 	public static final BlobJdbcType DEFAULT = new BlobJdbcType() {

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/jdbc/ClobJdbcType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/jdbc/ClobJdbcType.java
@@ -11,6 +11,7 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Types;
 
+import org.hibernate.boot.model.relational.Database;
 import org.hibernate.engine.jdbc.CharacterStream;
 import org.hibernate.type.descriptor.ValueBinder;
 import org.hibernate.type.descriptor.ValueExtractor;
@@ -22,6 +23,7 @@ import org.hibernate.type.descriptor.java.JavaType;
  *
  * @author Steve Ebersole
  * @author Gail Badner
+ * @author Loïc Lefèvre
  */
 public abstract class ClobJdbcType implements AdjustableJdbcType {
 	@Override
@@ -76,6 +78,15 @@ public abstract class ClobJdbcType implements AdjustableJdbcType {
 		return getClobBinder( javaType );
 	}
 
+	@Override
+	public String getExtraCreateTableInfo(JavaType<?> javaType, String columnName, String tableName, Database database) {
+		if( database.getDialect().supportsValueLOBAccess() ) {
+			return database.getDialect().getValueLOBFragmentForExtraCreateTableInfo(columnName);
+		}
+		else {
+			return AdjustableJdbcType.super.getExtraCreateTableInfo( javaType, columnName, tableName, database );
+		}
+	}
 
 	public static final ClobJdbcType DEFAULT = new ClobJdbcType() {
 		@Override

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/jdbc/ClobJdbcType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/jdbc/ClobJdbcType.java
@@ -11,6 +11,7 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Types;
 
+import org.hibernate.boot.model.relational.Database;
 import org.hibernate.engine.jdbc.CharacterStream;
 import org.hibernate.type.descriptor.ValueBinder;
 import org.hibernate.type.descriptor.ValueExtractor;
@@ -22,6 +23,7 @@ import org.hibernate.type.descriptor.java.JavaType;
  *
  * @author Steve Ebersole
  * @author Gail Badner
+ * @author Loïc Lefèvre
  */
 public abstract class ClobJdbcType implements AdjustableJdbcType {
 	@Override
@@ -76,6 +78,15 @@ public abstract class ClobJdbcType implements AdjustableJdbcType {
 		return getClobBinder( javaType );
 	}
 
+	@Override
+	public String getExtraCreateTableInfo(JavaType<?> javaType, String columnName, String tableName, Database database) {
+		if( javaType.getJavaTypeClass() != Clob.class && database.getDialect().supportsValueLOBAccess() ) {
+			return database.getDialect().getValueLOBFragmentForExtraCreateTableInfo(columnName);
+		}
+		else {
+			return AdjustableJdbcType.super.getExtraCreateTableInfo( javaType, columnName, tableName, database );
+		}
+	}
 
 	public static final ClobJdbcType DEFAULT = new ClobJdbcType() {
 		@Override

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/jdbc/NClobJdbcType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/jdbc/NClobJdbcType.java
@@ -11,6 +11,7 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Types;
 
+import org.hibernate.boot.model.relational.Database;
 import org.hibernate.engine.jdbc.CharacterStream;
 import org.hibernate.type.descriptor.ValueBinder;
 import org.hibernate.type.descriptor.ValueExtractor;
@@ -22,6 +23,7 @@ import org.hibernate.type.descriptor.java.JavaType;
  *
  * @author Steve Ebersole
  * @author Gail Badner
+ * @author Loïc Lefèvre
  */
 public abstract class NClobJdbcType implements JdbcType {
 	@Override
@@ -83,6 +85,15 @@ public abstract class NClobJdbcType implements JdbcType {
 		return getNClobBinder( javaType );
 	}
 
+	@Override
+	public String getExtraCreateTableInfo(JavaType<?> javaType, String columnName, String tableName, Database database) {
+		if( database.getDialect().supportsValueLOBAccess() ) {
+			return database.getDialect().getValueLOBFragmentForExtraCreateTableInfo(columnName);
+		}
+		else {
+			return JdbcType.super.getExtraCreateTableInfo( javaType, columnName, tableName, database );
+		}
+	}
 
 	public static final NClobJdbcType DEFAULT = new NClobJdbcType() {
 		@Override

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/jdbc/NClobJdbcType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/jdbc/NClobJdbcType.java
@@ -5,12 +5,14 @@
 package org.hibernate.type.descriptor.jdbc;
 
 import java.sql.CallableStatement;
+import java.sql.Clob;
 import java.sql.NClob;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Types;
 
+import org.hibernate.boot.model.relational.Database;
 import org.hibernate.engine.jdbc.CharacterStream;
 import org.hibernate.type.descriptor.ValueBinder;
 import org.hibernate.type.descriptor.ValueExtractor;
@@ -22,6 +24,7 @@ import org.hibernate.type.descriptor.java.JavaType;
  *
  * @author Steve Ebersole
  * @author Gail Badner
+ * @author Loïc Lefèvre
  */
 public abstract class NClobJdbcType implements JdbcType {
 	@Override
@@ -83,6 +86,15 @@ public abstract class NClobJdbcType implements JdbcType {
 		return getNClobBinder( javaType );
 	}
 
+	@Override
+	public String getExtraCreateTableInfo(JavaType<?> javaType, String columnName, String tableName, Database database) {
+		if( javaType.getJavaTypeClass() != Clob.class && javaType.getJavaTypeClass() != NClob.class && database.getDialect().supportsValueLOBAccess() ) {
+			return database.getDialect().getValueLOBFragmentForExtraCreateTableInfo(columnName);
+		}
+		else {
+			return JdbcType.super.getExtraCreateTableInfo( javaType, columnName, tableName, database );
+		}
+	}
 
 	public static final NClobJdbcType DEFAULT = new NClobJdbcType() {
 		@Override


### PR DESCRIPTION
This PR adds the support for VALUE LOBs for Oracle database 26ai. This is a performance improvement that lets LOB columns be defined as VALUE LOBs starting with 26ai.

Documentation: https://docs.oracle.com/en/database/oracle/oracle-database/26/adlob/value-based-LOBs.html

----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------


---
<!-- Hibernate GitHub Bot task list start -->
Please make sure that the following tasks are completed:
Tasks specific to HHH-17767 (Improvement):
- [x] Add tests for feature/improvement
- [x] Update documentation as relevant: javadoc for changed API, `documentation/src/main/asciidoc/userguide` for all features, `documentation/src/main/asciidoc/introduction` for main features, links from existing documentation
- [x] Add entries as relevant to `migration-guide.adoc` (breaking changes) and `whats-new.adoc` (new features/improvements)


<!-- Hibernate GitHub Bot task list end -->

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-17767
<!-- Hibernate GitHub Bot issue links end -->