### PR TITLE
HHH-20334 Upgrade to Log4j 2.25.4

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -177,7 +177,7 @@ dependencyResolutionManagement {
             def bytemanVersion = version "byteman", "4.0.24"
             def jbossJtaVersion = version "jbossJta", "7.3.3.Final"
             def jbossTxSpiVersion = version "jbossTxSpi", "8.0.0.Final"
-            def log4jVersion = version "log4j", "2.25.3"
+            def log4jVersion = version "log4j", "2.25.4"
             def mockitoVersion = version "mockito", "5.20.0"
             def shrinkwrapVersion = version "shrinkwrap", "1.2.6"
             def shrinkwrapDescriptorsVersion = version "shrinkwrapDescriptors", "2.0.0"


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-20334

Technically we only:

1. Use it for testing
2. Have an API dependency in hibernate-testing, which provides some tools to work with log4j

So the various CVEs are not really relevant:

* https://logging.apache.org/security.html#CVE-2026-34478
* https://logging.apache.org/security.html#CVE-2026-34479
* https://logging.apache.org/security.html#CVE-2026-34481

Still, let’s avoid the noise related to automated tools reporting the problem.

---
<!-- Hibernate GitHub Bot task list start -->
Please make sure that the following tasks are completed:
Tasks specific to HHH-20334 (Task):
- [x] Add test **OR** check there is no need for a test
- [x] Update documentation as relevant: javadoc for changed API, `documentation/src/main/asciidoc/userguide` for all features, `documentation/src/main/asciidoc/introduction` for main features, links from existing documentation
- [x] Add entries as relevant to `migration-guide.adoc` (breaking changes) and `whats-new.adoc` (new features/improvements)


<!-- Hibernate GitHub Bot task list end -->