### PR TITLE
Backport HHH-20334 to branch 6.6 - Upgrade to Log4j 2.25.4

### DIFF
--- a/hibernate-core/src/test/resources/log4j2.properties
+++ b/hibernate-core/src/test/resources/log4j2.properties
@@ -132,7 +132,8 @@ logger.stat.level=trace
 ###############################################################################
 ## Log a list of functions registered by the Dialect
 
-org.hibernate.HQL_FUNCTIONS=info
+logger.hql-functions.name=org.hibernate.HQL_FUNCTIONS
+logger.hql-functions.level=info
 
 ###############################################################################
 ## Hibernate's JUnit extensions (hibernate-testing)

--- a/settings.gradle
+++ b/settings.gradle
@@ -181,7 +181,7 @@ dependencyResolutionManagement {
             def bytemanVersion = version "byteman", "4.0.20"
             def jbossJtaVersion = version "jbossJta", "7.0.0.Final"
             def jbossTxSpiVersion = version "jbossTxSpi", "8.0.0.Final"
-            def log4jVersion = version "log4j", "2.17.1"
+            def log4jVersion = version "log4j", "2.25.4"
             def mockitoVersion = version "mockito", "5.2.0"
             //Compatible with JDK20
             def shrinkwrapVersion = version "shrinkwrap", "1.2.6"


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-20334

Backport of #12163

---
<!-- Hibernate GitHub Bot task list start -->
Please make sure that the following tasks are completed:
Tasks specific to HHH-20334 (Task):
- [x] Add test **OR** check there is no need for a test
- [x] Update documentation as relevant: javadoc for changed API, `documentation/src/main/asciidoc/userguide` for all features, `documentation/src/main/asciidoc/introduction` for main features, links from existing documentation
- [x] Add entries as relevant to `migration-guide.adoc` (breaking changes) and `whats-new.adoc` (new features/improvements)


<!-- Hibernate GitHub Bot task list end -->