### PR TITLE
Backport HHH-20334 to branch 5.3 - Upgrade to Log4j 2.25.4

### DIFF
--- a/gradle/libraries.gradle
+++ b/gradle/libraries.gradle
@@ -102,7 +102,7 @@ ext {
 
             // ~~~~~~~~~~~~~~~~~~~~~~~~~~ testing
 
-            log4j2:          "org.apache.logging.log4j:log4j-core:2.17.1",
+            log4j2:          "org.apache.logging.log4j:log4j-core:2.25.4",
             junit:           "junit:junit:${junitVersion}",
             assertj:         "org.assertj:assertj-core:${assertjVersion}",
             byteman:         "org.jboss.byteman:byteman:${bytemanVersion}",


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-20334

Backport of https://github.com/hibernate/hibernate-orm/pull/12163

---
<!-- Hibernate GitHub Bot task list start -->
Please make sure that the following tasks are completed:
Tasks specific to HHH-20334 (Task):
- [x] Add test **OR** check there is no need for a test
- [x] Update documentation as relevant: javadoc for changed API, `documentation/src/main/asciidoc/userguide` for all features, `documentation/src/main/asciidoc/introduction` for main features, links from existing documentation
- [x] Add entries as relevant to `migration-guide.adoc` (breaking changes) and `whats-new.adoc` (new features/improvements)


<!-- Hibernate GitHub Bot task list end -->