### PR TITLE
HHH-20336 fix: afterTransactionCompletion event is notified even when the commit fails and the transaction status is FAILED_COMMIT

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/resource/transaction/backend/jdbc/internal/JdbcResourceLocalTransactionCoordinatorImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/resource/transaction/backend/jdbc/internal/JdbcResourceLocalTransactionCoordinatorImpl.java
@@ -259,12 +259,17 @@ public class JdbcResourceLocalTransactionCoordinatorImpl implements TransactionC
 			catch (RuntimeException e) {
 				// something went wrong, so make a last-ditch,
 				// hail-mary attempt to roll back the transaction
-				try {
-					rollback();
+				if ( isActive() ) {
+					try {
+						rollback();
+					}
+					catch (RuntimeException e2) {
+						e.addSuppressed( e2 );
+						JDBC_LOGGER.encounteredFailureRollingBackFailedCommit( e2 );
+					}
 				}
-				catch (RuntimeException e2) {
-					e.addSuppressed( e2 );
-					JDBC_LOGGER.encounteredFailureRollingBackFailedCommit( e2 );
+				else {
+					afterCompletionCallback( false );
 				}
 				throw e;
 			}
@@ -281,8 +286,12 @@ public class JdbcResourceLocalTransactionCoordinatorImpl implements TransactionC
 		@Override
 		public void rollback() {
 			if ( isActive() ) {
-				jdbcResourceTransaction.rollback();
-				afterCompletionCallback( false );
+				try {
+					jdbcResourceTransaction.rollback();
+				}
+				finally {
+					afterCompletionCallback( false );
+				}
 			}
 		}
 

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/txn/ResourceLocalTransactionLifecycleTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/txn/ResourceLocalTransactionLifecycleTest.java
@@ -1,0 +1,120 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.jpa.txn;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.hibernate.resource.transaction.spi.TransactionStatus.ACTIVE;
+import static org.hibernate.resource.transaction.spi.TransactionStatus.FAILED_COMMIT;
+import static org.hibernate.resource.transaction.spi.TransactionStatus.MARKED_ROLLBACK;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import jakarta.persistence.RollbackException;
+import org.hibernate.jpa.spi.JpaCompliance;
+import org.hibernate.resource.jdbc.spi.JdbcSessionContext;
+import org.hibernate.resource.jdbc.spi.JdbcSessionOwner;
+import org.hibernate.resource.transaction.backend.jdbc.internal.JdbcResourceLocalTransactionCoordinatorBuilderImpl;
+import org.hibernate.resource.transaction.backend.jdbc.spi.JdbcResourceTransaction;
+import org.hibernate.resource.transaction.backend.jdbc.spi.JdbcResourceTransactionAccess;
+import org.hibernate.resource.transaction.spi.TransactionCoordinator;
+import org.hibernate.resource.transaction.spi.TransactionCoordinatorOwner;
+import org.hibernate.testing.orm.junit.JiraKey;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class ResourceLocalTransactionLifecycleTest {
+	@Mock(extraInterfaces = {JdbcSessionOwner.class, JdbcResourceTransactionAccess.class})
+	TransactionCoordinatorOwner owner;
+
+	@Mock
+	JdbcSessionContext jdbcSessionContext;
+
+	@Mock
+	JpaCompliance jpaCompliance;
+
+	@Mock
+	JdbcResourceTransaction transaction;
+
+	TransactionCoordinator coordinator;
+
+	@BeforeEach
+	void setup() {
+		JdbcResourceTransactionAccess jdbcResourceTransactionAccess = (JdbcResourceTransactionAccess) owner;
+		JdbcSessionOwner jdbcSessionOwner = (JdbcSessionOwner) owner;
+		when( owner.getJdbcSessionOwner() ).thenReturn( jdbcSessionOwner );
+		when( jdbcSessionOwner.getJdbcSessionContext() ).thenReturn( jdbcSessionContext );
+		when( jdbcSessionContext.getJpaCompliance() ).thenReturn( jpaCompliance );
+		when( jdbcResourceTransactionAccess.getResourceLocalTransaction() ).thenReturn( transaction );
+
+		coordinator = new JdbcResourceLocalTransactionCoordinatorBuilderImpl().buildTransactionCoordinator( owner,
+				null );
+	}
+
+	@Test
+	public void testAfterTransactionCompletion_when_rollback_only() {
+		when( transaction.getStatus() ).thenReturn( MARKED_ROLLBACK );
+		coordinator.getTransactionDriverControl().commit();
+		verify( owner ).afterTransactionCompletion( false, false );
+		verify( transaction ).rollback();
+	}
+
+	@Test
+	public void testAfterTransactionCompletion_rollback_exception_on_commit() {
+		when( transaction.getStatus() ).thenReturn( ACTIVE );
+		doThrow( RollbackException.class ).when( transaction ).commit();
+		assertThatThrownBy( () -> coordinator.getTransactionDriverControl().commit() )
+				.isExactlyInstanceOf( RollbackException.class );
+		verify( transaction ).commit();
+		verify( owner ).afterTransactionCompletion( false, false );
+	}
+
+	@Test
+	public void testAfterTransactionCompletion_on_generic_runtime_exception_on_commit() {
+		when( transaction.getStatus() ).thenReturn( ACTIVE );
+		doThrow( RuntimeException.class ).when( transaction ).commit();
+		assertThatThrownBy( () -> coordinator.getTransactionDriverControl().commit() )
+				.isExactlyInstanceOf( RuntimeException.class );
+		verify( owner ).afterTransactionCompletion( false, false );
+		verify( transaction ).rollback();
+	}
+
+	@Test
+	@JiraKey(value = "HHH-20336")
+	public void testAfterTransactionCompletion_after_failed_commit() {
+		when( transaction.getStatus() ).thenReturn( ACTIVE, FAILED_COMMIT );
+		doThrow( RuntimeException.class ).when( transaction ).commit();
+		assertThatThrownBy( () -> coordinator.getTransactionDriverControl().commit() )
+				.isExactlyInstanceOf( RuntimeException.class );
+		verify( owner ).afterTransactionCompletion( false, false );
+		verify( transaction, never() ).rollback();
+	}
+
+	@Test
+	public void testAfterTransactionCompletion_on_exception_during_rollback() {
+		when( transaction.getStatus() ).thenReturn( ACTIVE );
+		doThrow( RuntimeException.class ).when( transaction ).rollback();
+		assertThatThrownBy( () -> coordinator.getTransactionDriverControl().rollback() )
+				.isExactlyInstanceOf( RuntimeException.class );
+		verify( owner ).afterTransactionCompletion( false, false );
+		verify( transaction ).rollback();
+	}
+
+	@Test
+	public void testAfterTransactionCompletion_on_rollback() {
+		when( transaction.getStatus() ).thenReturn( ACTIVE );
+		coordinator.getTransactionDriverControl().rollback();
+		verify( owner ).afterTransactionCompletion( false, false );
+		verify( transaction ).rollback();
+	}
+
+
+}


### PR DESCRIPTION
Fix `JdbcResourceLocalTransactionCoordinatorImpl` to ensure that the `afterTransactionCompletion` event is notified even when the commit fails because of a RuntimeException and the transaction status is `FAILED_COMMIT`.

----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------


---
<!-- Hibernate GitHub Bot task list start -->
Please make sure that the following tasks are completed:
Tasks specific to HHH-20336 (Bug):
- [x] Add test reproducing the bug
- [x] Add entries as relevant to `migration-guide.adoc` **OR** check there are no breaking changes


<!-- Hibernate GitHub Bot task list end -->

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-20336
<!-- Hibernate GitHub Bot issue links end -->