### PR TITLE
Backport follow-up to HHH-20321 to branch 7.3 - import.sql not executed when there are no @Entity classes

### DIFF
--- a/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/transaction/TransactionCommitFailureTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/transaction/TransactionCommitFailureTest.java
@@ -114,7 +114,6 @@ public class TransactionCommitFailureTest {
 
 	private Map<String, Object> basicSettings() {
 		return SettingsGenerator.generateSettings(
-				Environment.HBM2DDL_AUTO, "create-drop",
 				Environment.DIALECT, DialectContext.getDialect().getClass().getName(),
 				Environment.CONNECTION_PROVIDER, ProxyConnectionProvider.class.getName()
 		);


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-20321

Backport of #12175    

Not strictly necessary because for some reason we're not seeing the same failure in 7.3, but I'd rather be on the safe side...

---
<!-- Hibernate GitHub Bot task list start -->
Please make sure that the following tasks are completed:
Tasks specific to HHH-20321 (Bug):
- [x] Add test reproducing the bug
- [x] Add entries as relevant to `migration-guide.adoc` **OR** check there are no breaking changes


<!-- Hibernate GitHub Bot task list end -->