### PR TITLE
HHH-20317 fix: Envers does not reflect @DiscriminatorOptions for history entities

### DIFF
--- a/hibernate-envers/src/main/java/org/hibernate/envers/boot/model/RootPersistentEntity.java
+++ b/hibernate-envers/src/main/java/org/hibernate/envers/boot/model/RootPersistentEntity.java
@@ -161,7 +161,12 @@ public class RootPersistentEntity extends PersistentEntity implements JoinAwareP
 		}
 
 		if ( discriminator != null ) {
-			entity.setDiscriminator( discriminator.build() );
+			var value = discriminator.build();
+			if (getPersistentClass() != null) {
+				value.setInsert( getPersistentClass().isDiscriminatorInsertable() );
+				value.setForce( getPersistentClass().isForceDiscriminator() );
+			}
+			entity.setDiscriminator( value );
 		}
 
 		if ( !StringTools.isEmpty( discriminatorValue ) ) {

--- a/hibernate-envers/src/test/java/org/hibernate/orm/test/envers/integration/inheritance/single/dynamic/DefaultNamed.java
+++ b/hibernate-envers/src/test/java/org/hibernate/orm/test/envers/integration/inheritance/single/dynamic/DefaultNamed.java
@@ -1,0 +1,23 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.envers.integration.inheritance.single.dynamic;
+
+import org.hibernate.envers.Audited;
+
+import jakarta.persistence.DiscriminatorValue;
+import jakarta.persistence.Entity;
+
+@Entity
+@Audited
+@DiscriminatorValue("not null")
+public class DefaultNamed extends Named {
+
+	protected DefaultNamed() {
+	}
+
+	protected DefaultNamed(String name, String type) {
+		super(name, type);
+	}
+}

--- a/hibernate-envers/src/test/java/org/hibernate/orm/test/envers/integration/inheritance/single/dynamic/DynamicDiscriminatorTest.java
+++ b/hibernate-envers/src/test/java/org/hibernate/orm/test/envers/integration/inheritance/single/dynamic/DynamicDiscriminatorTest.java
@@ -1,0 +1,64 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.envers.integration.inheritance.single.dynamic;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.InstanceOfAssertFactories.type;
+
+import org.hibernate.envers.AuditReaderFactory;
+import org.hibernate.envers.query.AuditEntity;
+import org.hibernate.testing.envers.junit.EnversTest;
+import org.hibernate.testing.orm.junit.BeforeClassTemplate;
+import org.hibernate.testing.orm.junit.EntityManagerFactoryScope;
+import org.hibernate.testing.orm.junit.JiraKey;
+import org.hibernate.testing.orm.junit.Jpa;
+import org.junit.jupiter.api.Test;
+
+@JiraKey(value = "HHH-20317")
+@EnversTest
+@Jpa(annotatedClasses = {
+		Named.class,
+		DefaultNamed.class
+})
+class DynamicDiscriminatorTest {
+
+	@BeforeClassTemplate
+	void initData(EntityManagerFactoryScope scope) {
+		var parent = new DefaultNamed( "Bob", "PERSON" );
+		parent.setDescription( "Test" );
+		scope.inTransaction( em -> em.persist( parent ) );
+	}
+
+	@Test
+	void testDiscriminatorOptionsAreReflected(EntityManagerFactoryScope scope) throws Exception {
+		scope.inTransaction( em -> {
+			var query = em.createQuery( "from Named where name=?1", Named.class );
+			query.setParameter( 1, "Bob" );
+
+			var result = query.getResultList();
+			assertThat( result ).hasSize( 1 ).element( 0 ).satisfies( named -> {
+				assertThat( named.getName() ).isEqualTo( "Bob" );
+				assertThat( named.getType() ).isEqualTo( "PERSON" );
+				assertThat( named ).isExactlyInstanceOf( DefaultNamed.class );
+			} );
+
+			result.get(0).setDescription( "Updated test" );
+		} );
+
+		scope.inTransaction( em -> {
+			var revisionReader = AuditReaderFactory.get( em );
+			var revisions = revisionReader.getRevisions( Named.class, "Bob" );
+
+			var result = revisionReader.createQuery().forEntitiesAtRevision( Named.class, revisions.get( 0 ) )
+					.add( AuditEntity.id().eq( "Bob" ) ).getSingleResult();
+
+			assertThat( result ).isExactlyInstanceOf( DefaultNamed.class ).asInstanceOf( type( DefaultNamed.class ) )
+					.satisfies( named -> {
+						assertThat( named.getType() ).isEqualTo( "PERSON" );
+						assertThat( named.getDescription() ).isEqualTo( "Test" );
+					} );
+		} );
+	}
+}

--- a/hibernate-envers/src/test/java/org/hibernate/orm/test/envers/integration/inheritance/single/dynamic/Named.java
+++ b/hibernate-envers/src/test/java/org/hibernate/orm/test/envers/integration/inheritance/single/dynamic/Named.java
@@ -1,0 +1,61 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.envers.integration.inheritance.single.dynamic;
+
+import static jakarta.persistence.InheritanceType.SINGLE_TABLE;
+
+import org.hibernate.annotations.DiscriminatorOptions;
+import org.hibernate.envers.Audited;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.DiscriminatorColumn;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Inheritance;
+
+@Entity
+@Audited
+@Inheritance(strategy = SINGLE_TABLE)
+@DiscriminatorColumn(name = "type")
+@DiscriminatorOptions(insert = false)
+public abstract class Named {
+
+	@Id
+	private final String name;
+
+	@Column
+	@Audited
+	private final String type;
+
+	@Column
+	@Audited
+	private String description;
+
+	protected Named() {
+		name = null;
+		type = null;
+	}
+
+	protected Named(String name, String type) {
+		this.name = name;
+		this.type = type;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public String getType() {
+		return type;
+	}
+
+	public String getDescription() {
+		return description;
+	}
+
+	public void setDescription(String description) {
+		this.description = description;
+	}
+}


### PR DESCRIPTION
When the discriminator value is present, we now transfer the options set on the main entity so that they are reflected on the automatically generated history entity for inheritance mapping consistency.

----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------


---
<!-- Hibernate GitHub Bot task list start -->
Please make sure that the following tasks are completed:
Tasks specific to HHH-20317 (Bug):
- [x] Add test reproducing the bug
- [x] Add entries as relevant to `migration-guide.adoc` **OR** check there are no breaking changes


<!-- Hibernate GitHub Bot task list end -->

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-20317
<!-- Hibernate GitHub Bot issue links end -->