### PR TITLE
[7.1] HHH-20317 fix: Envers does not reflect @DiscriminatorOptions for history entities

### DIFF
--- a/hibernate-envers/src/main/java/org/hibernate/envers/boot/model/RootPersistentEntity.java
+++ b/hibernate-envers/src/main/java/org/hibernate/envers/boot/model/RootPersistentEntity.java
@@ -161,7 +161,12 @@ public class RootPersistentEntity extends PersistentEntity implements JoinAwareP
 		}
 
 		if ( discriminator != null ) {
-			entity.setDiscriminator( discriminator.build() );
+			var value = discriminator.build();
+			if (getPersistentClass() != null) {
+				value.setInsert( getPersistentClass().isDiscriminatorInsertable() );
+				value.setForce( getPersistentClass().isForceDiscriminator() );
+			}
+			entity.setDiscriminator( value );
 		}
 
 		if ( !StringTools.isEmpty( discriminatorValue ) ) {

--- a/hibernate-envers/src/test/java/org/hibernate/orm/test/envers/integration/inheritance/single/dynamic/DefaultNamed.java
+++ b/hibernate-envers/src/test/java/org/hibernate/orm/test/envers/integration/inheritance/single/dynamic/DefaultNamed.java
@@ -1,0 +1,23 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.envers.integration.inheritance.single.dynamic;
+
+import org.hibernate.envers.Audited;
+
+import jakarta.persistence.DiscriminatorValue;
+import jakarta.persistence.Entity;
+
+@Entity
+@Audited
+@DiscriminatorValue("not null")
+public class DefaultNamed extends Named {
+
+	protected DefaultNamed() {
+	}
+
+	protected DefaultNamed(String name, String type) {
+		super(name, type);
+	}
+}

--- a/hibernate-envers/src/test/java/org/hibernate/orm/test/envers/integration/inheritance/single/dynamic/DynamicDiscriminatorTest.java
+++ b/hibernate-envers/src/test/java/org/hibernate/orm/test/envers/integration/inheritance/single/dynamic/DynamicDiscriminatorTest.java
@@ -1,0 +1,60 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.envers.integration.inheritance.single.dynamic;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.InstanceOfAssertFactories.type;
+
+import jakarta.persistence.EntityManager;
+
+import org.hibernate.envers.query.AuditEntity;
+import org.hibernate.orm.test.envers.BaseEnversJPAFunctionalTestCase;
+import org.hibernate.orm.test.envers.Priority;
+
+import org.hibernate.testing.orm.junit.JiraKey;
+import org.junit.Test;
+
+@JiraKey(value = "HHH-20317")
+public class DynamicDiscriminatorTest extends BaseEnversJPAFunctionalTestCase {
+
+	@Override
+	protected Class<?>[] getAnnotatedClasses() {
+		return new Class<?>[] { Named.class, DefaultNamed.class };
+	}
+
+	@Test
+	@Priority(10)
+	public void initData() {
+		EntityManager em = getEntityManager();
+
+		// Revision 1 - persist
+		em.getTransaction().begin();
+		var parent = new DefaultNamed( "Bob", "PERSON" );
+		parent.setDescription( "Test" );
+		em.persist( parent );
+		em.getTransaction().commit();
+
+		// Revision 2 - update
+		em.getTransaction().begin();
+		var found = em.find( DefaultNamed.class, "Bob" );
+		found.setDescription( "Updated test" );
+		em.getTransaction().commit();
+	}
+
+	@Test
+	public void testDiscriminatorOptionsAreReflected() {
+		var revisions = getAuditReader().getRevisions( Named.class, "Bob" );
+		assertThat( revisions ).hasSize( 2 );
+
+		var result = getAuditReader().createQuery().forEntitiesAtRevision( Named.class, revisions.get( 0 ) )
+				.add( AuditEntity.id().eq( "Bob" ) ).getSingleResult();
+
+		assertThat( result ).isExactlyInstanceOf( DefaultNamed.class ).asInstanceOf( type( DefaultNamed.class ) )
+				.satisfies( named -> {
+					assertThat( named.getType() ).isEqualTo( "PERSON" );
+					assertThat( named.getDescription() ).isEqualTo( "Test" );
+				} );
+	}
+}

--- a/hibernate-envers/src/test/java/org/hibernate/orm/test/envers/integration/inheritance/single/dynamic/Named.java
+++ b/hibernate-envers/src/test/java/org/hibernate/orm/test/envers/integration/inheritance/single/dynamic/Named.java
@@ -1,0 +1,61 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.envers.integration.inheritance.single.dynamic;
+
+import static jakarta.persistence.InheritanceType.SINGLE_TABLE;
+
+import org.hibernate.annotations.DiscriminatorOptions;
+import org.hibernate.envers.Audited;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.DiscriminatorColumn;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Inheritance;
+
+@Entity
+@Audited
+@Inheritance(strategy = SINGLE_TABLE)
+@DiscriminatorColumn(name = "type")
+@DiscriminatorOptions(insert = false)
+public abstract class Named {
+
+	@Id
+	private final String name;
+
+	@Column
+	@Audited
+	private final String type;
+
+	@Column
+	@Audited
+	private String description;
+
+	protected Named() {
+		name = null;
+		type = null;
+	}
+
+	protected Named(String name, String type) {
+		this.name = name;
+		this.type = type;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public String getType() {
+		return type;
+	}
+
+	public String getDescription() {
+		return description;
+	}
+
+	public void setDescription(String description) {
+		this.description = description;
+	}
+}


### PR DESCRIPTION
<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

Backport of https://github.com/hibernate/hibernate-orm/pull/12182

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------

---
<!-- Hibernate GitHub Bot task list start -->
Please make sure that the following tasks are completed:
Tasks specific to HHH-20317 (Bug):
- [ ] Add test reproducing the bug
- [ ] Add entries as relevant to `migration-guide.adoc` **OR** check there are no breaking changes


<!-- Hibernate GitHub Bot task list end -->

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-20317
<!-- Hibernate GitHub Bot issue links end -->