### PR TITLE
HHH-20146: Fix multi-level cascade delete with bytecode enhancement

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/engine/internal/EntityEntryContext.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/internal/EntityEntryContext.java
@@ -19,7 +19,6 @@ import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.lang.reflect.InvocationTargetException;
 import java.util.IdentityHashMap;
-import java.util.Map;
 import java.util.function.Consumer;
 
 import static org.hibernate.engine.internal.ManagedTypeHelper.asManagedEntity;
@@ -56,8 +55,7 @@ class EntityEntryContext {
 
 	private transient IdentityHashMap<Object,ManagedEntity> nonEnhancedEntityXref;
 
-	@SuppressWarnings("unchecked")
-	private transient Map.Entry<Object,EntityEntry>[] reentrantSafeEntries = new Map.Entry[0];
+	private transient ManagedEntity[] reentrantSafeEntries = new ManagedEntity[0];
 	private transient boolean dirty;
 
 	/**
@@ -328,22 +326,19 @@ class EntityEntryContext {
 	 * The main bugaboo with {@code IdentityMap} that warranted this class in the
 	 * first place.
 	 * <p>
-	 * Return an array of all the entity/{@link EntityEntry} pairs in this context.
+	 * Return an array of all the {@link ManagedEntity} in this context.
 	 * The array is to make sure that the iterators built off of it are safe from
 	 * concurrency/reentrancy.
 	 *
 	 * @return The safe array
 	 */
-	Map.Entry<Object, EntityEntry>[] reentrantSafeEntityEntries() {
+	ManagedEntity[] reentrantSafeEntityEntries() {
 		if ( dirty ) {
-			reentrantSafeEntries = new EntityEntryCrossRefImpl[count];
+			reentrantSafeEntries = new ManagedEntity[count];
 			int i = 0;
 			var managedEntity = head;
 			while ( managedEntity != null ) {
-				reentrantSafeEntries[i++] = new EntityEntryCrossRefImpl(
-						managedEntity.$$_hibernate_getEntityInstance(),
-						managedEntity.$$_hibernate_getEntityEntry()
-				);
+				reentrantSafeEntries[i++] = managedEntity;
 				managedEntity = managedEntity.$$_hibernate_getNextManagedEntity();
 			}
 			dirty = false;
@@ -753,65 +748,6 @@ class EntityEntryContext {
 			this.next = next;
 			managedEntity.$$_hibernate_setInstanceId( instanceId );
 			return oldEntry;
-		}
-	}
-
-	/**
-	 * Used in building the {@link #reentrantSafeEntityEntries()} entries
-	 */
-	private interface EntityEntryCrossRef extends Map.Entry<Object,EntityEntry> {
-		/**
-		 * The entity
-		 *
-		 * @return The entity
-		 */
-		Object getEntity();
-
-		/**
-		 * The associated EntityEntry
-		 *
-		 * @return The EntityEntry associated with the entity in this context
-		 */
-		EntityEntry getEntityEntry();
-	}
-
-	/**
-	 * Implementation of the EntityEntryCrossRef interface
-	 */
-	private static class EntityEntryCrossRefImpl implements EntityEntryCrossRef {
-		private final Object entity;
-		private EntityEntry entityEntry;
-
-		private EntityEntryCrossRefImpl(Object entity, EntityEntry entityEntry) {
-			this.entity = entity;
-			this.entityEntry = entityEntry;
-		}
-
-		@Override
-		public Object getEntity() {
-			return entity;
-		}
-
-		@Override
-		public EntityEntry getEntityEntry() {
-			return entityEntry;
-		}
-
-		@Override
-		public Object getKey() {
-			return getEntity();
-		}
-
-		@Override
-		public EntityEntry getValue() {
-			return getEntityEntry();
-		}
-
-		@Override
-		public EntityEntry setValue(EntityEntry entityEntry) {
-			final EntityEntry old = this.entityEntry;
-			this.entityEntry = entityEntry;
-			return old;
 		}
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/engine/internal/EntityEntryContext.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/internal/EntityEntryContext.java
@@ -323,16 +323,13 @@ class EntityEntryContext {
 	}
 
 	/**
-	 * The main bugaboo with {@code IdentityMap} that warranted this class in the
-	 * first place.
-	 * <p>
 	 * Return an array of all the {@link ManagedEntity} in this context.
 	 * The array is to make sure that the iterators built off of it are safe from
 	 * concurrency/reentrancy.
 	 *
 	 * @return The safe array
 	 */
-	ManagedEntity[] reentrantSafeEntityEntries() {
+	ManagedEntity[] reentrateSafeManagedEntities() {
 		if ( dirty ) {
 			reentrantSafeEntries = new ManagedEntity[count];
 			int i = 0;

--- a/hibernate-core/src/main/java/org/hibernate/engine/internal/StatefulPersistenceContext.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/internal/StatefulPersistenceContext.java
@@ -40,6 +40,7 @@ import org.hibernate.engine.spi.EntityEntry;
 import org.hibernate.engine.spi.EntityHolder;
 import org.hibernate.engine.spi.EntityKey;
 import org.hibernate.engine.spi.EntityUniqueKey;
+import org.hibernate.engine.spi.ManagedEntity;
 import org.hibernate.engine.spi.NaturalIdResolutions;
 import org.hibernate.engine.spi.PersistenceContext;
 import org.hibernate.engine.spi.PersistentAttributeInterceptable;
@@ -1448,7 +1449,7 @@ class StatefulPersistenceContext implements PersistenceContext {
 	}
 
 	@Override
-	public Entry<Object,EntityEntry>[] reentrantSafeEntityEntries() {
+	public ManagedEntity[] reentrantSafeEntityEntries() {
 		return entityEntryContext.reentrantSafeEntityEntries();
 	}
 
@@ -1478,10 +1479,10 @@ class StatefulPersistenceContext implements PersistenceContext {
 		//not found in case, proceed
 		// iterate all the entities currently associated with the persistence context.
 		for ( var me : reentrantSafeEntityEntries() ) {
-			final var entityEntry = me.getValue();
+			final var entityEntry = me.$$_hibernate_getEntityEntry();
 			// does this entity entry pertain to the entity persister in which we are interested (owner)?
 			if ( persister.isSubclassEntityName( entityEntry.getEntityName() ) ) {
-				final Object entityEntryInstance = me.getKey();
+				final Object entityEntryInstance = me.$$_hibernate_getEntityInstance();
 
 				//check if the managed object is the parent
 				boolean found = isFoundInParent(
@@ -1611,9 +1612,9 @@ class StatefulPersistenceContext implements PersistenceContext {
 
 		//Not found in cache, proceed
 		for ( var entry : reentrantSafeEntityEntries() ) {
-			final var entityEntry = entry.getValue();
+			final var entityEntry = entry.$$_hibernate_getEntityEntry();
 			if ( persister.isSubclassEntityName( entityEntry.getEntityName() ) ) {
-				final Object instance = entry.getKey();
+				final Object instance = entry.$$_hibernate_getEntityInstance();
 				Object index = getIndexInParent( property, childEntity, persister, collectionPersister, instance );
 				if ( index==null && mergeMap!=null ) {
 					final Object unMergedInstance = mergeMap.get( instance );

--- a/hibernate-core/src/main/java/org/hibernate/engine/internal/StatefulPersistenceContext.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/internal/StatefulPersistenceContext.java
@@ -40,6 +40,7 @@ import org.hibernate.engine.spi.EntityEntry;
 import org.hibernate.engine.spi.EntityHolder;
 import org.hibernate.engine.spi.EntityKey;
 import org.hibernate.engine.spi.EntityUniqueKey;
+import org.hibernate.engine.spi.ManagedEntity;
 import org.hibernate.engine.spi.NaturalIdResolutions;
 import org.hibernate.engine.spi.PersistenceContext;
 import org.hibernate.engine.spi.PersistentAttributeInterceptable;
@@ -1460,7 +1461,7 @@ class StatefulPersistenceContext implements PersistenceContext {
 	}
 
 	@Override
-	public Entry<Object,EntityEntry>[] reentrantSafeEntityEntries() {
+	public ManagedEntity[] reentrantSafeEntityEntries() {
 		return entityEntryContext.reentrantSafeEntityEntries();
 	}
 
@@ -1490,10 +1491,10 @@ class StatefulPersistenceContext implements PersistenceContext {
 		//not found in case, proceed
 		// iterate all the entities currently associated with the persistence context.
 		for ( var me : reentrantSafeEntityEntries() ) {
-			final var entityEntry = me.getValue();
+			final var entityEntry = me.$$_hibernate_getEntityEntry();
 			// does this entity entry pertain to the entity persister in which we are interested (owner)?
 			if ( persister.isSubclassEntityName( entityEntry.getEntityName() ) ) {
-				final Object entityEntryInstance = me.getKey();
+				final Object entityEntryInstance = me.$$_hibernate_getEntityInstance();
 
 				//check if the managed object is the parent
 				boolean found = isFoundInParent(
@@ -1623,9 +1624,9 @@ class StatefulPersistenceContext implements PersistenceContext {
 
 		//Not found in cache, proceed
 		for ( var entry : reentrantSafeEntityEntries() ) {
-			final var entityEntry = entry.getValue();
+			final var entityEntry = entry.$$_hibernate_getEntityEntry();
 			if ( persister.isSubclassEntityName( entityEntry.getEntityName() ) ) {
-				final Object instance = entry.getKey();
+				final Object instance = entry.$$_hibernate_getEntityInstance();
 				Object index = getIndexInParent( property, childEntity, persister, collectionPersister, instance );
 				if ( index==null && mergeMap!=null ) {
 					final Object unMergedInstance = mergeMap.get( instance );

--- a/hibernate-core/src/main/java/org/hibernate/engine/internal/StatefulPersistenceContext.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/internal/StatefulPersistenceContext.java
@@ -1461,8 +1461,8 @@ class StatefulPersistenceContext implements PersistenceContext {
 	}
 
 	@Override
-	public ManagedEntity[] reentrantSafeEntityEntries() {
-		return entityEntryContext.reentrantSafeEntityEntries();
+	public ManagedEntity[] reentrateSafeManagedEntities() {
+		return entityEntryContext.reentrateSafeManagedEntities();
 	}
 
 	@Override
@@ -1490,7 +1490,7 @@ class StatefulPersistenceContext implements PersistenceContext {
 
 		//not found in case, proceed
 		// iterate all the entities currently associated with the persistence context.
-		for ( var me : reentrantSafeEntityEntries() ) {
+		for ( var me : reentrateSafeManagedEntities() ) {
 			final var entityEntry = me.$$_hibernate_getEntityEntry();
 			// does this entity entry pertain to the entity persister in which we are interested (owner)?
 			if ( persister.isSubclassEntityName( entityEntry.getEntityName() ) ) {
@@ -1623,7 +1623,7 @@ class StatefulPersistenceContext implements PersistenceContext {
 		}
 
 		//Not found in cache, proceed
-		for ( var entry : reentrantSafeEntityEntries() ) {
+		for ( var entry : reentrateSafeManagedEntities() ) {
 			final var entityEntry = entry.$$_hibernate_getEntityEntry();
 			if ( persister.isSubclassEntityName( entityEntry.getEntityName() ) ) {
 				final Object instance = entry.$$_hibernate_getEntityInstance();

--- a/hibernate-core/src/main/java/org/hibernate/engine/spi/PersistenceContext.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/spi/PersistenceContext.java
@@ -571,14 +571,14 @@ public interface PersistenceContext {
 	 * Provides access to the managed entities associated with the persistence context in a manner that
 	 * is safe from reentrant access.  Specifically, it is safe from additions/removals while iterating.
 	 */
-	ManagedEntity[] reentrantSafeEntityEntries();
+	ManagedEntity[] reentrateSafeManagedEntities();
 
 //	/**
 //	 * Get the mapping from entity instance to entity entry
 //	 *
 //	 * @deprecated Due to the introduction of EntityEntryContext and bytecode enhancement; only valid really for
 //	 * sizing, see {@link #getNumberOfManagedEntities}.  For iterating the entity/EntityEntry combos, see
-//	 * {@link #reentrantSafeEntityEntries}
+//	 * {@link #reentrateSafeManagedEntities}
 //	 */
 //	@Deprecated
 //	Map getEntityEntries();

--- a/hibernate-core/src/main/java/org/hibernate/engine/spi/PersistenceContext.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/spi/PersistenceContext.java
@@ -568,10 +568,10 @@ public interface PersistenceContext {
 	Map<EntityKey,EntityHolder> getEntityHoldersByKey();
 
 	/**
-	 * Provides access to the entity/EntityEntry combos associated with the persistence context in a manner that
+	 * Provides access to the managed entities associated with the persistence context in a manner that
 	 * is safe from reentrant access.  Specifically, it is safe from additions/removals while iterating.
 	 */
-	Map.Entry<Object,EntityEntry>[] reentrantSafeEntityEntries();
+	ManagedEntity[] reentrantSafeEntityEntries();
 
 //	/**
 //	 * Get the mapping from entity instance to entity entry

--- a/hibernate-core/src/main/java/org/hibernate/event/internal/AbstractFlushingEventListener.java
+++ b/hibernate-core/src/main/java/org/hibernate/event/internal/AbstractFlushingEventListener.java
@@ -122,7 +122,7 @@ public abstract class AbstractFlushingEventListener {
 		EVENT_LISTENER_LOGGER.processingFlushTimeCascades();
 		final var context = PersistContext.create();
 		// safe from concurrent modification because of how concurrentEntries() is implemented on IdentityMap
-		for ( var entry : persistenceContext.reentrantSafeEntityEntries() ) {
+		for ( var entry : persistenceContext.reentrateSafeManagedEntities() ) {
 //		for ( Map.Entry entry : IdentityMap.concurrentEntries( persistenceContext.getEntityEntries() ) ) {
 			final var entityEntry = entry.$$_hibernate_getEntityEntry();
 			if ( flushable( entityEntry ) ) {
@@ -137,7 +137,7 @@ public abstract class AbstractFlushingEventListener {
 		// processed, so that all entities which will be persisted are
 		// persistent when we do the check (I wonder if we could move this
 		// into Nullability, instead of abusing the Cascade infrastructure)
-		for ( var entryEntry : persistenceContext.reentrantSafeEntityEntries() ) {
+		for ( var entryEntry : persistenceContext.reentrateSafeManagedEntities() ) {
 			final var entry = entryEntry.$$_hibernate_getEntityEntry();
 			if ( checkable( entry ) ) {
 				Cascade.cascade(
@@ -214,7 +214,7 @@ public abstract class AbstractFlushingEventListener {
 		// collections that are changing roles. This might cause entities
 		// to be loaded.
 		// So this needs to be safe from concurrent modification problems.
-		final var entityEntries = persistenceContext.reentrantSafeEntityEntries();
+		final var entityEntries = persistenceContext.reentrateSafeManagedEntities();
 		final int count = entityEntries.length;
 
 		FlushEntityEvent entityEvent = null; //allow reuse of the event as it's heavily allocated in certain use cases

--- a/hibernate-core/src/main/java/org/hibernate/event/internal/AbstractFlushingEventListener.java
+++ b/hibernate-core/src/main/java/org/hibernate/event/internal/AbstractFlushingEventListener.java
@@ -124,9 +124,9 @@ public abstract class AbstractFlushingEventListener {
 		// safe from concurrent modification because of how concurrentEntries() is implemented on IdentityMap
 		for ( var entry : persistenceContext.reentrantSafeEntityEntries() ) {
 //		for ( Map.Entry entry : IdentityMap.concurrentEntries( persistenceContext.getEntityEntries() ) ) {
-			final var entityEntry = entry.getValue();
+			final var entityEntry = entry.$$_hibernate_getEntityEntry();
 			if ( flushable( entityEntry ) ) {
-				cascadeOnFlush( session, entityEntry.getPersister(), entry.getKey(), context );
+				cascadeOnFlush( session, entityEntry.getPersister(), entry.$$_hibernate_getEntityInstance(), context );
 			}
 		}
 		checkForTransientReferences( session, persistenceContext );
@@ -138,14 +138,14 @@ public abstract class AbstractFlushingEventListener {
 		// persistent when we do the check (I wonder if we could move this
 		// into Nullability, instead of abusing the Cascade infrastructure)
 		for ( var entryEntry : persistenceContext.reentrantSafeEntityEntries() ) {
-			final var entry = entryEntry.getValue();
+			final var entry = entryEntry.$$_hibernate_getEntityEntry();
 			if ( checkable( entry ) ) {
 				Cascade.cascade(
 						CascadingActions.CHECK_ON_FLUSH,
 						CascadePoint.BEFORE_FLUSH,
 						session,
 						entry.getPersister(),
-						entryEntry.getKey(),
+						entryEntry.$$_hibernate_getEntityInstance(),
 						null
 				);
 			}
@@ -221,10 +221,15 @@ public abstract class AbstractFlushingEventListener {
 		int eventGenerationId = 0; //Used to double-check the instance reuse won't cause problems
 		for ( var me : entityEntries ) {
 			// Update the status of the object and if necessary, schedule an update
-			final var entry = me.getValue();
+			final var entry = me.$$_hibernate_getEntityEntry();
 			final var status = entry.getStatus();
 			if ( status != Status.LOADING && status != Status.GONE ) {
-				entityEvent = createOrReuseEventInstance( entityEvent, source, me.getKey(), entry );
+				entityEvent = createOrReuseEventInstance(
+						entityEvent,
+						source,
+						me.$$_hibernate_getEntityInstance(),
+						entry
+				);
 				entityEvent.setInstanceGenerationId( ++eventGenerationId );
 				flushListeners.fireEventOnEachListener( entityEvent, FlushEntityEventListener::onFlushEntity );
 				entityEvent.setAllowedToReuse( true );

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/cascade/CascadeDeleteMultiLevelTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/cascade/CascadeDeleteMultiLevelTest.java
@@ -1,0 +1,126 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.bytecode.enhancement.cascade;
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.MapsId;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.OneToOne;
+import org.hibernate.testing.bytecode.enhancement.extension.BytecodeEnhanced;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.JiraKey;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@DomainModel(annotatedClasses = {
+		CascadeDeleteMultiLevelTest.Trade.class,
+		CascadeDeleteMultiLevelTest.Accumulation.class,
+		CascadeDeleteMultiLevelTest.Formula.class,
+		CascadeDeleteMultiLevelTest.FormulaTerm.class
+})
+@SessionFactory
+@BytecodeEnhanced
+public class CascadeDeleteMultiLevelTest {
+
+	@Test
+	@JiraKey( "HHH-20146" )
+	public void test(SessionFactoryScope scope) {
+		Trade trade = new Trade();
+
+		Accumulation accumulation = new Accumulation();
+		trade.addAccumulation( accumulation );
+
+		Formula formula = new Formula();
+		accumulation.setFormula( formula );
+
+		FormulaTerm formulaTerm = new FormulaTerm();
+		formula.setFormulaTerm( formulaTerm );
+
+		scope.inTransaction( em -> {
+			em.persist( trade );
+		} );
+
+		scope.inTransaction( em -> {
+			Trade savedTrade = em.find( Trade.class, trade.id );
+			savedTrade.accumulations.clear();
+		} );
+	}
+
+	@Entity
+	public static class Trade {
+
+		@Id
+		@GeneratedValue(strategy = GenerationType.AUTO)
+		Long id;
+
+		@OneToMany( mappedBy = "trade", cascade = CascadeType.ALL, orphanRemoval = true )
+		List<Accumulation> accumulations = new ArrayList<>();
+
+		public void addAccumulation(Accumulation accumulation) {
+			accumulations.add(accumulation);
+			accumulation.trade = this;
+		}
+
+	}
+
+	@Entity
+	public static class Accumulation {
+
+		@Id
+		@GeneratedValue(strategy = GenerationType.AUTO)
+		Long id;
+
+		@ManyToOne( fetch = FetchType.LAZY )
+		Trade trade;
+
+		@OneToOne( fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true )
+		Formula formula;
+
+		public void setFormula(Formula formula) {
+			this.formula = formula;
+		}
+
+	}
+
+	@Entity
+	public static class Formula {
+
+		@Id
+		@GeneratedValue( strategy = GenerationType.AUTO )
+		Long id;
+
+		@OneToOne( mappedBy = "formula", cascade = CascadeType.ALL, orphanRemoval = true )
+		FormulaTerm formulaTerm;
+
+		public void setFormulaTerm(FormulaTerm formulaTerm) {
+			this.formulaTerm = formulaTerm;
+			formulaTerm.formula = this;
+		}
+
+	}
+
+	@Entity
+	public static class FormulaTerm {
+
+		@Id
+		Long id;
+
+		@MapsId
+		@OneToOne( fetch =  FetchType.LAZY )
+		Formula formula;
+
+	}
+
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/cascade/CascadeDeleteMultiLevelTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/bytecode/enhancement/cascade/CascadeDeleteMultiLevelTest.java
@@ -14,6 +14,7 @@ import jakarta.persistence.ManyToOne;
 import jakarta.persistence.MapsId;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
 import org.hibernate.testing.bytecode.enhancement.extension.BytecodeEnhanced;
 import org.hibernate.testing.orm.junit.DomainModel;
 import org.hibernate.testing.orm.junit.JiraKey;
@@ -59,6 +60,7 @@ public class CascadeDeleteMultiLevelTest {
 	}
 
 	@Entity
+	@Table( name = "TRADE" )
 	public static class Trade {
 
 		@Id
@@ -76,6 +78,7 @@ public class CascadeDeleteMultiLevelTest {
 	}
 
 	@Entity
+	@Table( name = "ACCUMULATION" )
 	public static class Accumulation {
 
 		@Id
@@ -95,6 +98,7 @@ public class CascadeDeleteMultiLevelTest {
 	}
 
 	@Entity
+	@Table( name = "FORMULA" )
 	public static class Formula {
 
 		@Id
@@ -112,6 +116,7 @@ public class CascadeDeleteMultiLevelTest {
 	}
 
 	@Entity
+	@Table( name = "FORMULA_TERM" )
 	public static class FormulaTerm {
 
 		@Id


### PR DESCRIPTION
The call to reentrantSafeEntityEntries caches the entityEntry, which can be updated by cascading operations such as delete. This changes it to fetch the current state for each iteration.

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------


---
<!-- Hibernate GitHub Bot task list start -->
Please make sure that the following tasks are completed:
Tasks specific to HHH-20146 (Bug):
- [x] Add test reproducing the bug
- [x] Add entries as relevant to `migration-guide.adoc` **OR** check there are no breaking changes


<!-- Hibernate GitHub Bot task list end -->

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-20146
<!-- Hibernate GitHub Bot issue links end -->