### PR TITLE
Allow running the TCK manually and upgrade to Persistence TCK 3.2.1

### DIFF
--- a/ci/jpa-3.2-tck.Jenkinsfile
+++ b/ci/jpa-3.2-tck.Jenkinsfile
@@ -24,9 +24,9 @@ pipeline {
     }
     parameters {
         choice(name: 'IMAGE_JDK', choices: ['jdk17', 'jdk25'], description: 'The JDK base image version to use for the TCK image.')
-        string(name: 'TCK_VERSION', defaultValue: '3.2.0', description: 'The version of the Jakarta JPA TCK i.e. `2.2.0` or `3.0.1`')
-        string(name: 'TCK_SHA', defaultValue: '', description: 'The SHA256 of the Jakarta JPA TCK that is distributed under https://download.eclipse.org/jakartaee/persistence/3.1/jakarta-persistence-tck-${TCK_VERSION}.zip.sha256')
-		string(name: 'TCK_URL', defaultValue: 'https://www.eclipse.org/downloads/download.php?file=/ee4j/jakartaee-tck/jakartaee11/staged/eftl/jakarta-persistence-tck-3.2.0.zip&mirror_id=1', description: 'The URL from which to download the TCK ZIP file. Only needed for testing staged builds. Ensure the TCK_VERSION variable matches the ZIP file name suffix.')
+        string(name: 'TCK_VERSION', defaultValue: '3.2.1', description: 'The version of the Jakarta JPA TCK i.e. `2.2.0` or `3.0.1`')
+        string(name: 'TCK_SHA', defaultValue: '1d282675f43fa13cf8ab2537d6dbfb1e1c95f7b838ab7cdd053e185c363a6519', description: 'The SHA256 of the Jakarta JPA TCK that is distributed under https://download.eclipse.org/jakartaee/persistence/3.1/jakarta-persistence-tck-${TCK_VERSION}.zip.sha256')
+		string(name: 'TCK_URL', defaultValue: 'https://download.eclipse.org/jakartaee/persistence/3.2/jakarta-persistence-tck-3.2.1.zip', description: 'The URL from which to download the TCK ZIP file. Only needed for testing staged builds. Ensure the TCK_VERSION variable matches the ZIP file name suffix.')
         choice(name: 'RDBMS', choices: ['postgresql','mysql','mssql','oracle','db2','sybase'], description: 'The JDK base image version to use for the TCK image.')
 	}
     stages {
@@ -37,7 +37,7 @@ pipeline {
         }
         stage('TCK') {
             agent {
-                label 'LongDuration'
+                label 'Worker&&Containers'
             }
             stages {
                 stage('Build') {

--- a/ci/jpa-3.2-tck.Jenkinsfile
+++ b/ci/jpa-3.2-tck.Jenkinsfile
@@ -7,7 +7,7 @@ if (currentBuild.getBuildCauses().toString().contains('BranchIndexingCause')) {
   	return
 }
 // This is a limited maintenance branch, so don't run this on pushes to the branch, only on PRs
-if ( !env.CHANGE_ID ) {
+if ( !currentBuild.getBuildCauses().toString().contains( 'UserIdCause' ) && !env.CHANGE_ID ) {
 	print "INFO: Build skipped because this job should only run for pull request, not for branch pushes"
 	currentBuild.result = 'NOT_BUILT'
 	return

--- a/hibernate-testing/src/main/java/org/hibernate/testing/bytecode/enhancement/extension/engine/BytecodeEnhancedTestEngine.java
+++ b/hibernate-testing/src/main/java/org/hibernate/testing/bytecode/enhancement/extension/engine/BytecodeEnhancedTestEngine.java
@@ -57,10 +57,24 @@ import org.junit.platform.engine.support.descriptor.EngineDescriptor;
 import org.junit.platform.engine.support.hierarchical.EngineExecutionContext;
 import org.junit.platform.engine.support.hierarchical.HierarchicalTestEngine;
 import org.junit.platform.engine.support.hierarchical.ThrowableCollector;
+import org.junit.platform.engine.support.store.NamespacedHierarchicalStore;
 
 public class BytecodeEnhancedTestEngine extends HierarchicalTestEngine<JupiterEngineExecutionContext> {
 
+	private static final Class<?> LAUNCHER_STORE_FACADE_BEFORE_JUNIT_5_14;
 	public static final String ENHANCEMENT_EXTENSION_ENGINE_ENABLED = "hibernate.testing.bytecode.enhancement.extension.engine.enabled";
+
+	static {
+		Class<?> launcherStoreFacadeBeforeJunit514 = null;
+		try {
+			// The class was moved to a different package in 5.14
+			launcherStoreFacadeBeforeJunit514 = Class.forName( "org.junit.jupiter.engine.descriptor.LauncherStoreFacade" );
+		}
+		catch (ClassNotFoundException e) {
+			// ignore
+		}
+		LAUNCHER_STORE_FACADE_BEFORE_JUNIT_5_14 = launcherStoreFacadeBeforeJunit514;
+	}
 
 	public static boolean isEnabled() {
 		return "true".equalsIgnoreCase( System.getProperty( ENHANCEMENT_EXTENSION_ENGINE_ENABLED, "false" ) );
@@ -263,6 +277,24 @@ public class BytecodeEnhancedTestEngine extends HierarchicalTestEngine<JupiterEn
 		}
 		catch (NoSuchMethodException | InstantiationException | IllegalAccessException | InvocationTargetException e) {
 			// Ignore errors as they are probably due to version mismatches and try the 5.13 way
+		}
+		if ( LAUNCHER_STORE_FACADE_BEFORE_JUNIT_5_14 != null ) {
+			try {
+				// Try constructing the JupiterEngineExecutionContext the way it was done in 5.13 and before
+				final Constructor<JupiterEngineExecutionContext> constructorV5_12 = JupiterEngineExecutionContext.class
+						.getConstructor( EngineExecutionListener.class, JupiterConfiguration.class, LAUNCHER_STORE_FACADE_BEFORE_JUNIT_5_14 );
+				final Constructor<?> launcherStoreFacadeConstructor =
+						LAUNCHER_STORE_FACADE_BEFORE_JUNIT_5_14.getConstructor( NamespacedHierarchicalStore.class );
+				return constructorV5_12.newInstance(
+						request.getEngineExecutionListener(),
+						this.getJupiterConfiguration( request ),
+						launcherStoreFacadeConstructor.newInstance( request.getStore() )
+				);
+			}
+			catch (NoSuchMethodException | InstantiationException | IllegalAccessException |
+				InvocationTargetException e) {
+				// Ignore errors as they are probably due to version mismatches and try the 5.13 way
+			}
 		}
 
 		return new JupiterEngineExecutionContext(


### PR DESCRIPTION
And also, well, run the TCK through this PR, since that's what I wanted in the first place.

Supersedes #12123, backport of #12076 with an additional commit.