### PR TITLE
HHH-19971 - Add cascade attribute to @Any and @ManyToAny annotations

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/annotations/Any.java
+++ b/hibernate-core/src/main/java/org/hibernate/annotations/Any.java
@@ -7,6 +7,7 @@ package org.hibernate.annotations;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.FetchType;
 
 import static java.lang.annotation.ElementType.FIELD;
@@ -97,6 +98,14 @@ public @interface Any {
 	 * If not explicitly specified, the default is {@code EAGER}.
 	 */
 	FetchType fetch() default FetchType.EAGER;
+
+	/**
+	 * The operations that should be cascaded to the associated entities.
+	 * <p>
+	 *     By default, no operations are cascaded.
+	 * </p>
+	 */
+	CascadeType[] cascade() default {};
 
 	/**
 	 * Whether the association is optional.

--- a/hibernate-core/src/main/java/org/hibernate/annotations/ManyToAny.java
+++ b/hibernate-core/src/main/java/org/hibernate/annotations/ManyToAny.java
@@ -7,6 +7,7 @@ package org.hibernate.annotations;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.FetchType;
 
 import static java.lang.annotation.ElementType.FIELD;
@@ -79,4 +80,12 @@ public @interface ManyToAny {
 	 * </ul>
 	 */
 	FetchType fetch() default FetchType.EAGER;
+
+	/**
+	 * The operations that should be cascaded to the associated entities.
+	 * <p>
+	 *     By default, no operations are cascaded.
+	 * </p>
+	 */
+	CascadeType[] cascade() default {};
 }

--- a/hibernate-core/src/main/java/org/hibernate/boot/model/internal/AnyBinder.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/internal/AnyBinder.java
@@ -45,8 +45,9 @@ public class AnyBinder {
 				joinColumn.setExplicitTableName( join.getTable().getName() );
 			}
 		}
+		final var any = memberDetails.getDirectAnnotationUsage( org.hibernate.annotations.Any.class );
 		bindAny(
-				aggregateCascadeTypes( null, memberDetails, false, context ),
+				aggregateCascadeTypes( any.cascade(), memberDetails, false, context ),
 				//@Any has no cascade attribute
 				joinColumns,
 				onDeleteAnn == null ? null : onDeleteAnn.action(),

--- a/hibernate-core/src/main/java/org/hibernate/boot/model/internal/AnyBinder.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/internal/AnyBinder.java
@@ -48,7 +48,6 @@ public class AnyBinder {
 		final var any = memberDetails.getDirectAnnotationUsage( org.hibernate.annotations.Any.class );
 		bindAny(
 				aggregateCascadeTypes( any.cascade(), memberDetails, false, context ),
-				//@Any has no cascade attribute
 				joinColumns,
 				onDeleteAnn == null ? null : onDeleteAnn.action(),
 				nullability,

--- a/hibernate-core/src/main/java/org/hibernate/boot/model/internal/CollectionBinder.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/internal/CollectionBinder.java
@@ -482,7 +482,7 @@ public abstract class CollectionBinder {
 			mappedBy = null;
 			collectionBinder.setTargetEntity( ClassDetails.VOID_CLASS_DETAILS );
 			collectionBinder.setCascadeStrategy(
-					aggregateCascadeTypes( null, property, false, context ) );
+					aggregateCascadeTypes( property.getDirectAnnotationUsage( ManyToAny.class ).cascade(), property, false, context ) );
 			collectionBinder.setOneToMany( false );
 		}
 		else {

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/AnyAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/AnyAnnotation.java
@@ -10,12 +10,14 @@ import java.util.Map;
 import org.hibernate.annotations.Any;
 import org.hibernate.boot.models.annotations.spi.AttributeMarker;
 import org.hibernate.models.spi.ModelsContext;
+import jakarta.persistence.CascadeType;
 
 @SuppressWarnings({ "ClassExplicitlyAnnotation", "unused" })
 @jakarta.annotation.Generated("org.hibernate.orm.build.annotations.ClassGeneratorProcessor")
 public class AnyAnnotation implements Any, AttributeMarker, AttributeMarker.Fetchable, AttributeMarker.Optionalable {
 	private jakarta.persistence.FetchType fetch;
 	private boolean optional;
+	private CascadeType[] cascade;
 
 	/**
 	 * Used in creating dynamic annotation instances (e.g. from XML)
@@ -23,6 +25,7 @@ public class AnyAnnotation implements Any, AttributeMarker, AttributeMarker.Fetc
 	public AnyAnnotation(ModelsContext modelContext) {
 		this.fetch = jakarta.persistence.FetchType.EAGER;
 		this.optional = true;
+		this.cascade = new CascadeType[0];
 	}
 
 	/**
@@ -31,6 +34,7 @@ public class AnyAnnotation implements Any, AttributeMarker, AttributeMarker.Fetc
 	public AnyAnnotation(Any annotation, ModelsContext modelContext) {
 		this.fetch = annotation.fetch();
 		this.optional = annotation.optional();
+		this.cascade = annotation.cascade();
 	}
 
 	/**
@@ -39,6 +43,7 @@ public class AnyAnnotation implements Any, AttributeMarker, AttributeMarker.Fetc
 	public AnyAnnotation(Map<String, Object> attributeValues, ModelsContext modelContext) {
 		this.fetch = (jakarta.persistence.FetchType) attributeValues.get( "fetch" );
 		this.optional = (boolean) attributeValues.get( "optional" );
+		this.cascade = (CascadeType[]) attributeValues.getOrDefault( "cascade", new CascadeType[0] );
 	}
 
 	@Override
@@ -65,5 +70,13 @@ public class AnyAnnotation implements Any, AttributeMarker, AttributeMarker.Fetc
 		this.optional = value;
 	}
 
+	@Override
+	public CascadeType[] cascade() {
+		return cascade;
+	}
+
+	public void cascade(CascadeType[] value) {
+		this.cascade = value;
+	}
 
 }

--- a/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/ManyToAnyAnnotation.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/models/annotations/internal/ManyToAnyAnnotation.java
@@ -10,17 +10,20 @@ import java.util.Map;
 import org.hibernate.annotations.ManyToAny;
 import org.hibernate.boot.models.annotations.spi.AttributeMarker;
 import org.hibernate.models.spi.ModelsContext;
+import jakarta.persistence.CascadeType;
 
 @SuppressWarnings({ "ClassExplicitlyAnnotation", "unused" })
 @jakarta.annotation.Generated("org.hibernate.orm.build.annotations.ClassGeneratorProcessor")
 public class ManyToAnyAnnotation implements ManyToAny, AttributeMarker, AttributeMarker.Fetchable {
 	private jakarta.persistence.FetchType fetch;
+	private CascadeType[] cascade;
 
 	/**
 	 * Used in creating dynamic annotation instances (e.g. from XML)
 	 */
 	public ManyToAnyAnnotation(ModelsContext modelContext) {
 		this.fetch = jakarta.persistence.FetchType.EAGER;
+		this.cascade = new CascadeType[0];
 	}
 
 	/**
@@ -28,6 +31,7 @@ public class ManyToAnyAnnotation implements ManyToAny, AttributeMarker, Attribut
 	 */
 	public ManyToAnyAnnotation(ManyToAny annotation, ModelsContext modelContext) {
 		this.fetch = annotation.fetch();
+		this.cascade = annotation.cascade();
 	}
 
 	/**
@@ -35,6 +39,7 @@ public class ManyToAnyAnnotation implements ManyToAny, AttributeMarker, Attribut
 	 */
 	public ManyToAnyAnnotation(Map<String, Object> attributeValues, ModelsContext modelContext) {
 		this.fetch = (jakarta.persistence.FetchType) attributeValues.get( "fetch" );
+		this.cascade = (CascadeType[]) attributeValues.getOrDefault( "cascade", new CascadeType[0] );
 	}
 
 	@Override
@@ -51,5 +56,13 @@ public class ManyToAnyAnnotation implements ManyToAny, AttributeMarker, Attribut
 		this.fetch = value;
 	}
 
+	@Override
+	public CascadeType[] cascade() {
+		return cascade;
+	}
+
+	public void cascade(CascadeType[] value) {
+		this.cascade = value;
+	}
 
 }

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/any/annotations/AnyCascadeAttributeTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/any/annotations/AnyCascadeAttributeTest.java
@@ -1,0 +1,82 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.any.annotations;
+
+
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.JiraKey;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+@DomainModel(
+		annotatedClasses = {
+				PropertySetWithCascade.class,
+				IntegerProperty.class,
+				StringProperty.class
+		}
+)
+@SessionFactory
+@JiraKey( "HHH-19971" )
+public class AnyCascadeAttributeTest {
+
+	@AfterEach
+	public void dropTestData(SessionFactoryScope scope) {
+		scope.getSessionFactory().getSchemaManager().truncate();
+	}
+
+	@Test
+	public void testManyToAnyCascadePersist(SessionFactoryScope scope) {
+		// Persist parent only, children should cascade
+		scope.inTransaction( session -> {
+			PropertySetWithCascade set = new PropertySetWithCascade( "test" );
+			set.setSomeProperty( new StringProperty( "name", "alex" ) );
+			set.addGeneralProperty( new IntegerProperty( "age", 23 ) );
+			session.persist( set );
+
+		} );
+
+		// Verify children were persisted via cascade
+		scope.inTransaction( session -> {
+			PropertySetWithCascade result = session
+					.createQuery( "select s from PropertySetWithCascade s where name = :name", PropertySetWithCascade.class )
+					.setParameter( "name", "test" )
+					.uniqueResult();
+			assertNotNull( result );
+			assertNotNull( result.getSomeProperty() );
+			assertEquals( "alex", result.getSomeProperty().asString() );
+			assertEquals( 1, result.getGeneralProperties().size() );
+			assertEquals( "23", result.getGeneralProperties().get( 0 ).asString());
+		} );
+	}
+
+	@Test
+	public void testAnyCascadePersist(SessionFactoryScope scope) {
+		// Persist parent with @Any child - should cascade
+		scope.inTransaction( session -> {
+
+			PropertySetWithCascade set = new PropertySetWithCascade( "any-test" );
+			set.setSomeProperty( new IntegerProperty("score", 100) );
+			session.persist( set );
+
+		} );
+
+		scope.inTransaction( session -> {
+			PropertySetWithCascade result = session
+					.createQuery( "select s from PropertySetWithCascade s where name = :name", PropertySetWithCascade.class )
+					.setParameter( "name", "any-test" )
+					.uniqueResult();
+			assertNotNull( result );
+			assertNotNull( result.getSomeProperty() );
+			assertInstanceOf( IntegerProperty.class, result.getSomeProperty() );
+			assertEquals( "100", result.getSomeProperty().asString());
+		} );
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/any/annotations/AnyCascadeAttributeTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/any/annotations/AnyCascadeAttributeTest.java
@@ -15,6 +15,7 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 @DomainModel(
 		annotatedClasses = {
@@ -29,7 +30,7 @@ public class AnyCascadeAttributeTest {
 
 	@AfterEach
 	public void dropTestData(SessionFactoryScope scope) {
-		scope.getSessionFactory().getSchemaManager().truncate();
+		scope.dropData();
 	}
 
 	@Test
@@ -77,6 +78,140 @@ public class AnyCascadeAttributeTest {
 			assertNotNull( result.getSomeProperty() );
 			assertInstanceOf( IntegerProperty.class, result.getSomeProperty() );
 			assertEquals( "100", result.getSomeProperty().asString());
+		} );
+	}
+
+	@Test
+	public void testAnyCascadeMerge(SessionFactoryScope scope) {
+		Integer setId = scope.fromTransaction( session -> {
+			PropertySetWithCascade set = new PropertySetWithCascade( "merge-test" );
+			set.setSomeProperty( new StringProperty( "key", "original" ) );
+			session.persist( set );
+			return set.getId();
+		} );
+
+		scope.inTransaction( session -> {
+			PropertySetWithCascade set = session.find( PropertySetWithCascade.class, setId );
+			( (StringProperty) set.getSomeProperty() ).setValue( "updated" );
+			session.merge( set );
+		} );
+
+		scope.inTransaction( session -> {
+			PropertySetWithCascade result = session.find( PropertySetWithCascade.class, setId );
+			assertNotNull( result.getSomeProperty() );
+			assertEquals( "updated", result.getSomeProperty().asString() );
+		} );
+	}
+
+	@Test
+	public void testManyToAnyCascadeMerge(SessionFactoryScope scope) {
+		Integer setId = scope.fromTransaction( session -> {
+			PropertySetWithCascade set = new PropertySetWithCascade( "many-merge-test" );
+			set.addGeneralProperty( new StringProperty( "key", "original" ) );
+			session.persist( set );
+			return set.getId();
+		} );
+
+		scope.inTransaction( session -> {
+			PropertySetWithCascade set = session.find( PropertySetWithCascade.class, setId );
+			( (StringProperty) set.getGeneralProperties().get( 0 ) ).setValue( "updated" );
+			session.merge( set );
+		} );
+
+		scope.inTransaction( session -> {
+			PropertySetWithCascade result = session.find( PropertySetWithCascade.class, setId );
+			assertEquals( 1, result.getGeneralProperties().size() );
+			assertEquals( "updated", result.getGeneralProperties().get( 0 ).asString() );
+		} );
+	}
+
+	@Test
+	public void testAnyCascadeRemove(SessionFactoryScope scope) {
+		Integer[] ids = new Integer[2];
+
+		scope.inTransaction( session -> {
+			PropertySetWithCascade set = new PropertySetWithCascade( "remove-test" );
+			StringProperty prop = new StringProperty( "key", "value" );
+			set.setSomeProperty( prop );
+			session.persist( set );
+			ids[0] = set.getId();
+		} );
+
+		// get the property id before removal
+		Integer propId = scope.fromTransaction( session -> {
+			PropertySetWithCascade set = session.find( PropertySetWithCascade.class, ids[0] );
+			return ( (StringProperty) set.getSomeProperty() ).getId();
+		} );
+
+		scope.inTransaction( session -> {
+			PropertySetWithCascade set = session.find( PropertySetWithCascade.class, ids[0] );
+			session.remove( set );
+		} );
+
+		scope.inTransaction( session -> {
+			assertNull( session.find( PropertySetWithCascade.class, ids[0] ) );
+			assertNull( session.find( StringProperty.class, propId ) );
+		} );
+	}
+
+	@Test
+	public void testManyToAnyCascadeRemove(SessionFactoryScope scope) {
+		Integer setId = scope.fromTransaction( session -> {
+			PropertySetWithCascade set = new PropertySetWithCascade( "many-remove-test" );
+			set.addGeneralProperty( new IntegerProperty( "count", 5 ) );
+			session.persist( set );
+			return set.getId();
+		} );
+
+		Integer propId = scope.fromTransaction( session -> {
+			PropertySetWithCascade set = session.find( PropertySetWithCascade.class, setId );
+			return ( (IntegerProperty) set.getGeneralProperties().get( 0 ) ).getId();
+		} );
+
+		scope.inTransaction( session -> {
+			PropertySetWithCascade set = session.find( PropertySetWithCascade.class, setId );
+			session.remove( set );
+		} );
+
+		scope.inTransaction( session -> {
+			assertNull( session.find( PropertySetWithCascade.class, setId ) );
+			assertNull( session.find( IntegerProperty.class, propId ) );
+		} );
+	}
+
+	@Test
+	public void testAnyCascadeRefresh(SessionFactoryScope scope) {
+		Integer setId = scope.fromTransaction( session -> {
+			PropertySetWithCascade set = new PropertySetWithCascade( "refresh-test" );
+			set.setSomeProperty( new StringProperty( "key", "value" ) );
+			session.persist( set );
+			return set.getId();
+		} );
+
+		scope.inTransaction( session -> {
+			PropertySetWithCascade set = session.find( PropertySetWithCascade.class, setId );
+			// dirty the child in-memory without flushing
+			( (StringProperty) set.getSomeProperty() ).setValue( "dirty" );
+			// refresh should reload from DB, cascading to child
+			session.refresh( set );
+			assertEquals( "value", set.getSomeProperty().asString() );
+		} );
+	}
+
+	@Test
+	public void testManyToAnyCascadeRefresh(SessionFactoryScope scope) {
+		Integer setId = scope.fromTransaction( session -> {
+			PropertySetWithCascade set = new PropertySetWithCascade( "many-refresh-test" );
+			set.addGeneralProperty( new IntegerProperty( "count", 10 ) );
+			session.persist( set );
+			return set.getId();
+		} );
+
+		scope.inTransaction( session -> {
+			PropertySetWithCascade set = session.find( PropertySetWithCascade.class, setId );
+			( (IntegerProperty) set.getGeneralProperties().get( 0 ) ).setValue( 999 );
+			session.refresh( set );
+			assertEquals( "10", set.getGeneralProperties().get( 0 ).asString() );
 		} );
 	}
 }

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/any/annotations/PropertySetWithCascade.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/any/annotations/PropertySetWithCascade.java
@@ -1,0 +1,89 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.any.annotations;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.JoinTable;
+import jakarta.persistence.Table;
+import org.hibernate.annotations.Any;
+import org.hibernate.annotations.AnyDiscriminatorValue;
+import org.hibernate.annotations.AnyKeyJavaClass;
+import org.hibernate.annotations.ManyToAny;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Table( name = "property_set_cascade" )
+public class PropertySetWithCascade {
+
+	private Integer id;
+	private String name;
+	private Property someProperty;
+	private List<Property> generalProperties = new ArrayList<>();
+
+	public PropertySetWithCascade() {}
+	public PropertySetWithCascade(String name) {
+		this.name = name;
+	}
+
+	@ManyToAny(cascade = jakarta. persistence.CascadeType.ALL)
+	@Column( name = "property_type" )
+	@AnyKeyJavaClass( Integer.class )
+	@AnyDiscriminatorValue( discriminator = "S", entity = StringProperty.class )
+	@AnyDiscriminatorValue( discriminator = "I", entity = IntegerProperty.class )
+	@JoinTable(
+			name = "obj_properties_cascade",
+			joinColumns = @JoinColumn( name = "obj_id" ),
+			inverseJoinColumns = @JoinColumn( name = "property_id" ) )
+	public List<Property> getGeneralProperties() {
+		return generalProperties;
+	}
+
+	public void setGeneralProperties(List<Property> generalProperties) {
+		this.generalProperties = generalProperties;
+	}
+
+	@Id
+	@GeneratedValue
+	public Integer getId() {
+		return id;
+	}
+
+	public void setId(Integer id) {
+		this.id = id;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+
+	@Any(cascade = jakarta.persistence.CascadeType.ALL)
+	@Column( name = "property_type" )
+	@AnyKeyJavaClass( Integer.class )
+	@AnyDiscriminatorValue( discriminator = "S", entity = StringProperty.class )
+	@AnyDiscriminatorValue( discriminator = "I", entity = IntegerProperty.class )
+	@JoinColumn( name = "property_id" )
+	public Property getSomeProperty() {
+		return someProperty;
+	}
+
+	public void setSomeProperty(Property someProperty) {
+		this.someProperty = someProperty;
+	}
+
+	public void addGeneralProperty(Property property) {
+		this.generalProperties.add( property );
+	}
+
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/boot/models/xml/attr/AnyTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/boot/models/xml/attr/AnyTests.java
@@ -10,6 +10,8 @@ import java.util.List;
 import org.hibernate.annotations.Any;
 import org.hibernate.annotations.AnyDiscriminator;
 import org.hibernate.annotations.AnyDiscriminatorValue;
+import org.hibernate.annotations.Cascade;
+import org.hibernate.annotations.CascadeType;
 import org.hibernate.boot.internal.AnyKeyType;
 import org.hibernate.boot.model.process.spi.ManagedResources;
 import org.hibernate.boot.model.source.internal.annotations.AdditionalManagedResourcesImpl;
@@ -77,6 +79,10 @@ public class AnyTests {
 		final JoinColumn keyColumn = associationField.getAnnotationUsage( JoinColumn.class, ModelsContext );
 		assertThat( keyColumn ).isNotNull();
 		assertThat( keyColumn.name() ).isEqualTo( "association_fk" );
+
+		final Cascade cascadeAnn = associationField.getDirectAnnotationUsage( Cascade.class );
+		assertThat( cascadeAnn ).isNotNull();
+		assertThat( cascadeAnn.value() ).containsExactly( CascadeType.ALL );
 	}
 
 	@Entity(name="Entity1")

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/boot/models/xml/attr/ManyToAnyTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/boot/models/xml/attr/ManyToAnyTests.java
@@ -1,0 +1,86 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.boot.models.xml.attr;
+
+import java.util.List;
+
+import org.hibernate.annotations.Cascade;
+import org.hibernate.annotations.CascadeType;
+import org.hibernate.annotations.ManyToAny;
+import org.hibernate.boot.model.process.spi.ManagedResources;
+import org.hibernate.boot.model.source.internal.annotations.AdditionalManagedResourcesImpl;
+import org.hibernate.boot.registry.StandardServiceRegistry;
+import org.hibernate.models.spi.ClassDetails;
+import org.hibernate.models.spi.ClassDetailsRegistry;
+import org.hibernate.models.spi.FieldDetails;
+import org.hibernate.models.spi.ModelsContext;
+
+import org.hibernate.testing.orm.junit.ServiceRegistry;
+import org.hibernate.testing.orm.junit.ServiceRegistryScope;
+import org.junit.jupiter.api.Test;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hibernate.orm.test.boot.models.SourceModelTestHelper.createBuildingContext;
+
+/**
+ * @author Awantika Shinde
+ */
+@ServiceRegistry
+public class ManyToAnyTests {
+	@Test
+	@SuppressWarnings("JUnitMalformedDeclaration")
+	void testSimpleManyToAnyAttribute(ServiceRegistryScope scope) {
+		final StandardServiceRegistry serviceRegistry = scope.getRegistry();
+		final ManagedResources managedResources = new AdditionalManagedResourcesImpl.Builder()
+				.addLoadedClasses( Entity1.class )
+				.addLoadedClasses( Entity2.class )
+				.addXmlMappings( "mappings/models/attr/many-to-any/simple.xml" )
+				.build();
+
+		final ModelsContext modelsContext = createBuildingContext( managedResources, serviceRegistry );
+		final ClassDetailsRegistry classDetailsRegistry = modelsContext.getClassDetailsRegistry();
+
+		final ClassDetails entity3ClassDetails = classDetailsRegistry.resolveClassDetails( Entity3.class.getName() );
+
+		final FieldDetails associationsField = entity3ClassDetails.findFieldByName( "associations" );
+		assertThat( associationsField ).isNotNull();
+
+		final ManyToAny manyToAnyAnn = associationsField.getDirectAnnotationUsage( ManyToAny.class );
+		assertThat( manyToAnyAnn ).isNotNull();
+
+		final Cascade cascadeAnn = associationsField.getDirectAnnotationUsage( Cascade.class );
+		assertThat( cascadeAnn ).isNotNull();
+		assertThat( cascadeAnn.value() ).containsExactly( CascadeType.ALL );
+	}
+
+	@Entity(name = "Entity1")
+	@Table(name = "Entity1")
+	public static class Entity1 {
+		@Id
+		private Integer id;
+		private String name;
+	}
+
+	@Entity(name = "Entity2")
+	@Table(name = "Entity2")
+	public static class Entity2 {
+		@Id
+		private Integer id;
+		private String name;
+	}
+
+	@Entity(name = "Entity3")
+	@Table(name = "Entity3")
+	public static class Entity3 {
+		@Id
+		private Integer id;
+		private String name;
+		private List<Object> associations;
+	}
+}

--- a/hibernate-core/src/test/resources/mappings/models/attr/many-to-any/simple.xml
+++ b/hibernate-core/src/test/resources/mappings/models/attr/many-to-any/simple.xml
@@ -1,0 +1,35 @@
+<!--
+  ~ SPDX-License-Identifier: Apache-2.0
+  ~ Copyright Red Hat Inc. and Hibernate Authors
+  -->
+<entity-mappings xmlns="http://www.hibernate.org/xsd/orm/mapping"
+                 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                 version="7.0">
+    <package>org.hibernate.orm.test.boot.models.xml.attr</package>
+
+    <entity class="ManyToAnyTests$Entity3" metadata-complete="true" access="FIELD">
+        <attributes>
+            <id name="id"/>
+            <basic name="name"/>
+            <many-to-any name="associations">
+                <discriminator>
+                    <type>INTEGER</type>
+                    <column name="association_type"/>
+                    <mapping value="1">ManyToAnyTests$Entity1</mapping>
+                    <mapping value="2">ManyToAnyTests$Entity2</mapping>
+                </discriminator>
+                <key>
+                    <type>integer</type>
+                    <column name="association_fk"/>
+                </key>
+                <cascade>
+                    <cascade-all/>
+                </cascade>
+                <join-table name="entity3_associations">
+                    <join-column name="entity3_fk"/>
+                    <inverse-join-column name="association_fk"/>
+                </join-table>
+            </many-to-any>
+        </attributes>
+    </entity>
+</entity-mappings>


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HHH-19971

@Any and @ManyToAny have no `cascade` member, forcing users to rely
on the deprecated @Cascade annotation to specify cascade behavior for
these association types. This change adds a standard JPA `cascade` member
to both annotations, consistent with @OneToMany, @ManyToMany, etc.

### Changes

- Added `CascadeType[] cascade() default {}` to `@Any` and `@ManyToAny`
- Updated `AnyBinder` and `CollectionBinder` to pass the new `cascade`
  values to `aggregateCascadeTypes()` (previously passed `null`)
- Updated javadoc examples on both annotations to use the new member
  instead of `@Cascade`
- Added tests for cascade via the new attribute on both `@Any` and `@ManyToAny`

----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------


---
<!-- Hibernate GitHub Bot task list start -->
Please make sure that the following tasks are completed:
Tasks specific to HHH-19971 (New Feature):
- [x] Add tests for feature/improvement
- [ ] Update documentation as relevant: javadoc for changed API, `documentation/src/main/asciidoc/userguide` for all features, `documentation/src/main/asciidoc/introduction` for main features, links from existing documentation
- [ ] Add entries as relevant to `migration-guide.adoc` (breaking changes) and `whats-new.adoc` (new features/improvements)


<!-- Hibernate GitHub Bot task list end -->