### PR TITLE
HHH-20313 Fix JPA Criteria parameter type inference TCK failure

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/jpa/ParameterCollector.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/jpa/ParameterCollector.java
@@ -10,6 +10,7 @@ import java.util.Set;
 import java.util.function.Consumer;
 
 import org.checkerframework.checker.nullness.qual.Nullable;
+import org.hibernate.query.sqm.tree.expression.SqmBinaryArithmetic;
 import org.hibernate.type.BindableType;
 import org.hibernate.query.sqm.SqmBindableType;
 import org.hibernate.query.sqm.SqmPathSource;
@@ -314,6 +315,13 @@ public class ParameterCollector extends BaseSemanticQueryWalker {
 		super.visitIsTruePredicate( predicate );
 		this.inferenceBasis = original;
 		return predicate;
+	}
+
+	@Override
+	public Object visitBinaryArithmeticExpression(SqmBinaryArithmetic<?> expression) {
+		withTypeInference( expression.getRightHandOperand(), expression.getLeftHandOperand() );
+		withTypeInference( expression.getLeftHandOperand(), expression.getRightHandOperand() );
+		return expression;
 	}
 
 	@Override

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/query/criteria/CriteriaTypeValidationTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/query/criteria/CriteriaTypeValidationTests.java
@@ -53,6 +53,20 @@ public class CriteriaTypeValidationTests {
 		);
 	}
 
+	@Test
+	@JiraKey( "HHH-20313" )
+	public void testCompareDoubleToInteger(SessionFactoryScope scope) {
+		scope.inTransaction(
+				session -> {
+					final HibernateCriteriaBuilder cb = session.getCriteriaBuilder();
+					final CriteriaQuery<Parent> cq = cb.createQuery(Parent.class);
+					final Root<Parent> root = cq.from(Parent.class);
+					cq.where( cb.lt( root.get( "price" ), cb.prod( cb.literal( 54 ), 2 ) ) );
+					session.createQuery(cq).getResultList();
+				}
+		);
+	}
+
 
 	@Entity(name = "Parent")
 	public static class Parent {
@@ -60,6 +74,7 @@ public class CriteriaTypeValidationTests {
 		private Long id;
 
 		private String name;
+		private Double price;
 
 		@OneToMany(mappedBy = "parent", fetch = FetchType.EAGER, cascade = CascadeType.ALL, orphanRemoval = true)
 		private Set<Child> children = new HashSet<>();


### PR DESCRIPTION
This includes the https://github.com/hibernate/hibernate-orm/pull/12123/changes/1a0e7d4ecfabb348cda632ced1be93c7584dc500 commit for addressing  https://hibernate.atlassian.net/browse/HHH-20313 taken from https://github.com/hibernate/hibernate-orm/pull/12123

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------


---
<!-- Hibernate GitHub Bot task list start -->
Please make sure that the following tasks are completed:
Tasks specific to HHH-20313 (Bug):
- [ ] Add test reproducing the bug
- [ ] Add entries as relevant to `migration-guide.adoc` **OR** check there are no breaking changes


<!-- Hibernate GitHub Bot task list end -->