### PR TITLE
Account for session.get throwing EntityNotFoundException instead of returning null

### DIFF
--- a/hibernate-core/src/test/java/org/hibernate/temporal/TemporalEntityNativeTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/temporal/TemporalEntityNativeTest.java
@@ -6,6 +6,7 @@ package org.hibernate.temporal;
 
 import jakarta.persistence.ElementCollection;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EntityNotFoundException;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToMany;
@@ -33,6 +34,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -251,8 +253,8 @@ class TemporalEntityNativeTest {
 		);
 		scope.getSessionFactory().inStatelessTransaction(
 				session -> {
-					TemporalEntity entity = session.get( TemporalEntity.class, 2L );
-					assertNull( entity );
+					assertThatThrownBy( () -> session.get( TemporalEntity.class, 2L ) )
+							.isInstanceOf( EntityNotFoundException.class );
 				}
 		);
 		try (var session = scope.getSessionFactory().withStatelessOptions().asOf(instant).open()) {

--- a/hibernate-core/src/test/java/org/hibernate/temporal/TemporalEntitySqlServerNativeTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/temporal/TemporalEntitySqlServerNativeTest.java
@@ -5,6 +5,7 @@
 package org.hibernate.temporal;
 
 import jakarta.persistence.Entity;
+import jakarta.persistence.EntityNotFoundException;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToMany;
@@ -29,6 +30,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -235,8 +237,8 @@ class TemporalEntitySqlServerNativeTest {
 		);
 		scope.getSessionFactory().inStatelessTransaction(
 				session -> {
-					TemporalEntity entity = session.get( TemporalEntity.class, 2L );
-					assertNull( entity );
+					assertThatThrownBy( () -> session.get( TemporalEntity.class, 2L ) )
+							.isInstanceOf( EntityNotFoundException.class );
 				}
 		);
 		try (var session = scope.getSessionFactory().withStatelessOptions().asOf(instant).open()) {


### PR DESCRIPTION


<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
