### PR TITLE
Limit git history depth to 10 in Quarkus build

### DIFF
--- a/ci/quarkus.Jenkinsfile
+++ b/ci/quarkus.Jenkinsfile
@@ -156,7 +156,7 @@ pipeline {
                                     sh "ln -s ${env.WORKSPACE_TMP}/.m2repository .m2"
                                 }
                                 dir('quarkus') {
-                                    sh "git clone -b ${QUARKUS_BRANCH_TO_TEST} --single-branch https://github.com/quarkusio/quarkus.git . || git reset --hard && git clean -fx && git pull"
+                                    sh "git clone -b ${QUARKUS_BRANCH_TO_TEST} --single-branch --depth 10 https://github.com/quarkusio/quarkus.git . || git reset --hard && git clean -fx && git pull"
                                     script {
                                         def sedStatus = sh (script: "sed -i 's@<hibernate-orm.version>.*</hibernate-orm.version>@<hibernate-orm.version>${env.HIBERNATE_VERSION}</hibernate-orm.version>@' pom.xml", returnStatus: true)
                                         if ( sedStatus != 0 ) {


### PR DESCRIPTION
Because we don't need the history and it's just more things to download.
