### PR TITLE
HHH-20347: Replace google-java-format with Eclipse JDT formatter to avoid compatibility issues

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -136,7 +136,7 @@ dependencyResolutionManagement {
             library( "ant", "org.apache.ant", "ant" ).versionRef( antVersion )
 
             library( "commonsCollections4", "org.apache.commons", "commons-collections4" ).version( "4.5.0" )
-            library( "googleJavaFormatter", "com.google.googlejavaformat", "google-java-format" ).version( "1.27.0" )
+            library( "eclipseJdtCore", "org.eclipse.jdt", "org.eclipse.jdt.core" ).version( "3.42.0" )
             library( "freemarker", "org.freemarker", "freemarker" ).version( "2.3.34" )
         }
         jakartaLibs {

--- a/tooling/hibernate-ant/hibernate-ant.gradle
+++ b/tooling/hibernate-ant/hibernate-ant.gradle
@@ -33,14 +33,6 @@ tasks.register('legacyTest', Test) {
     testClassesDirs = sourceSets.legacyTest.output.classesDirs
     classpath = sourceSets.legacyTest.runtimeClasspath
     useJUnitPlatform()
-    jvmArgs(
-            "--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED",
-            "--add-exports=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED",
-            "--add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED",
-            "--add-exports=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED",
-            "--add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED",
-            "--add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED"
-    )
 }
 
 tasks.forbiddenApisLegacyTest {

--- a/tooling/hibernate-reveng/hibernate-reveng.gradle
+++ b/tooling/hibernate-reveng/hibernate-reveng.gradle
@@ -7,9 +7,7 @@ description = "Library providing functionality to perform reverse engineering Hi
 dependencies {
     implementation project( ':hibernate-core' )
     implementation libs.commonsCollections4
-    // kept as a direct dependency to avoid conflicts with the spotless plugin's
-    // internal use of google-java-format for removeUnusedImports()
-    implementation libs.googleJavaFormatter
+    implementation libs.eclipseJdtCore
     implementation libs.freemarker
     implementation libs.antlrRuntime
     implementation jakartaLibs.jaxbApi

--- a/tooling/hibernate-reveng/src/main/java/org/hibernate/tool/reveng/api/java/DefaultJavaPrettyPrinterStrategy.java
+++ b/tooling/hibernate-reveng/src/main/java/org/hibernate/tool/reveng/api/java/DefaultJavaPrettyPrinterStrategy.java
@@ -4,25 +4,36 @@
  */
 package org.hibernate.tool.reveng.api.java;
 
-import com.google.googlejavaformat.java.Formatter;
-import com.google.googlejavaformat.java.FormatterException;
+import org.eclipse.jdt.core.JavaCore;
+import org.eclipse.jdt.core.ToolFactory;
+import org.eclipse.jdt.core.formatter.CodeFormatter;
+import org.eclipse.jface.text.Document;
+import org.eclipse.text.edits.TextEdit;
 
 import java.io.File;
-import java.io.IOException;
 import java.nio.file.Files;
+import java.util.Map;
 
 public class DefaultJavaPrettyPrinterStrategy {
 
 	public boolean formatFile(File file) {
 		try {
-			Formatter formatter = new Formatter();
-			String toFormat = new String(Files.readAllBytes(file.toPath()));
-			String toWrite = formatter.formatSource(toFormat);
-			Files.write(file.toPath(), toWrite.getBytes());
+			String source = new String( Files.readAllBytes( file.toPath() ) );
+			Map<String, String> options = JavaCore.getOptions();
+			CodeFormatter formatter = ToolFactory.createCodeFormatter( options );
+			TextEdit edit = formatter.format(
+					CodeFormatter.K_COMPILATION_UNIT | CodeFormatter.F_INCLUDE_COMMENTS,
+					source, 0, source.length(), 0, System.lineSeparator() );
+			if ( edit == null ) {
+				return false;
+			}
+			Document document = new Document( source );
+			edit.apply( document );
+			Files.write( file.toPath(), document.get().getBytes() );
 			return true;
 		}
-		catch (IOException | FormatterException e) {
-			throw new RuntimeException(e);
+		catch (Exception e) {
+			throw new RuntimeException( e );
 		}
 	}
 


### PR DESCRIPTION
google-java-format uses internal JDK APIs. The current version (1.27.0) is not usable with JDK 27 and the laters version (1.35.0) is not usable with JDK 17. 

The Eclipse JDT formatter has its own parser and so is way more independent from JDK versions.

----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------


---
<!-- Hibernate GitHub Bot task list start -->
Please make sure that the following tasks are completed:
Tasks specific to HHH-20347 (Task):
- [x] Add test **OR** check there is no need for a test
- [x] Update documentation as relevant: javadoc for changed API, `documentation/src/main/asciidoc/userguide` for all features, `documentation/src/main/asciidoc/introduction` for main features, links from existing documentation
- [x] Add entries as relevant to `migration-guide.adoc` (breaking changes) and `whats-new.adoc` (new features/improvements)


<!-- Hibernate GitHub Bot task list end -->

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-20347
<!-- Hibernate GitHub Bot issue links end -->