### PR TITLE
HHH-19567 - EntityGraph.removeAttributeNode() should suppress EAGER fetching

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/graph/AttributeNode.java
+++ b/hibernate-core/src/main/java/org/hibernate/graph/AttributeNode.java
@@ -51,6 +51,14 @@ public interface AttributeNode<J> extends GraphNode<J>, jakarta.persistence.Attr
 	PersistentAttribute<?, J> getAttributeDescriptor();
 
 	/**
+	 * Whether this attribute was {@linkplain Graph#removeAttributeNode removed}.
+	 * Per the Jakarta Persistence specification, such nodes should actually suppress inclusion of the
+	 * attribute mapped for eager fetching when the graph is used as a
+	 * {@linkplain org.hibernate.graph.GraphSemantic#LOAD load graph}.
+	 */
+	boolean isRemoved();
+
+	/**
 	 * All value subgraphs rooted at this node.
 	 * <p>
 	 * Includes treated subgraphs.

--- a/hibernate-core/src/main/java/org/hibernate/graph/GraphSemantic.java
+++ b/hibernate-core/src/main/java/org/hibernate/graph/GraphSemantic.java
@@ -4,6 +4,8 @@
  */
 package org.hibernate.graph;
 
+import jakarta.persistence.FindOption;
+
 import java.util.Locale;
 
 import static org.hibernate.jpa.LegacySpecHints.HINT_JAVAEE_FETCH_GRAPH;
@@ -17,7 +19,7 @@ import static org.hibernate.jpa.SpecHints.HINT_SPEC_LOAD_GRAPH;
  *
  * @author Steve Ebersole
  */
-public enum GraphSemantic {
+public enum GraphSemantic implements FindOption {
 	/**
 	 * Indicates that an {@link jakarta.persistence.EntityGraph} should be interpreted as a JPA "fetch graph".
 	 * <ul>

--- a/hibernate-core/src/main/java/org/hibernate/graph/internal/AttributeNodeImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/graph/internal/AttributeNodeImpl.java
@@ -45,8 +45,20 @@ public abstract sealed class AttributeNodeImpl<J, E, K>
 	protected final DomainType<E> valueGraphType;
 	protected final SimpleDomainType<K> keyGraphType;
 
+	protected boolean removed;
 	protected SubGraphImplementor<E> valueSubgraph;
 	protected SubGraphImplementor<K> keySubgraph;
+
+	@Override
+	public boolean isRemoved() {
+		return removed;
+	}
+
+	@Override
+	public AttributeNodeImplementor<J, E, K> markRemoved(boolean removed) {
+		this.removed = removed;
+		return this;
+	}
 
 	static <J> AttributeNodeImpl<J,?,?> create(
 			PersistentAttribute<?, J> attribute, boolean mutable) {

--- a/hibernate-core/src/main/java/org/hibernate/graph/internal/GraphImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/graph/internal/GraphImpl.java
@@ -26,11 +26,12 @@ import org.hibernate.query.sqm.SqmPathSource;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 import static java.util.Collections.emptyList;
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.unmodifiableMap;
+import static java.util.stream.Collectors.toMap;
+import static java.util.stream.Collectors.toUnmodifiableList;
 
 /**
  *  Base class for {@link RootGraph} and {@link SubGraph} implementations.
@@ -69,8 +70,15 @@ public abstract class GraphImpl<J> extends AbstractGraphNode<J> implements Graph
 	}
 	@Override
 	public List<jakarta.persistence.AttributeNode<?>> getAttributeNodes() {
-		//noinspection unchecked,rawtypes
-		return (List) getAttributeNodeList();
+		if ( attributeNodes == null ) {
+			return emptyList();
+		}
+		else {
+			// we need to filter out removed nodes
+			return attributeNodes.values().stream()
+					.filter( (node) -> !node.isRemoved() )
+					.collect( toUnmodifiableList());
+		}
 	}
 
 
@@ -81,7 +89,9 @@ public abstract class GraphImpl<J> extends AbstractGraphNode<J> implements Graph
 		}
 		else {
 			// we need to filter out removed nodes
-			return attributeNodes.values().stream().filter( (node) -> !node.isRemoved() ).toList();
+			return attributeNodes.values().stream()
+					.filter( (node) -> !node.isRemoved() )
+					.toList();
 		}
 	}
 
@@ -95,7 +105,7 @@ public abstract class GraphImpl<J> extends AbstractGraphNode<J> implements Graph
 					.entrySet()
 					.stream()
 					.filter( (entry) -> !entry.getValue().isRemoved() )
-					.collect( Collectors.toMap( Map.Entry::getKey, Map.Entry::getValue ) );
+					.collect( toMap( Map.Entry::getKey, Map.Entry::getValue ) );
 		}
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/graph/spi/AttributeNodeImplementor.java
+++ b/hibernate-core/src/main/java/org/hibernate/graph/spi/AttributeNodeImplementor.java
@@ -29,6 +29,15 @@ public interface AttributeNodeImplementor<J, E, K> extends AttributeNode<J>, Gra
 	AttributeNodeImplementor<J, E, K> makeCopy(boolean mutable);
 
 	/**
+	 * Mark the attribute as removed or not.
+	 * We allow passing the boolean to allow for later unmarking it for removal, e.g.
+	 * should {@linkplain org.hibernate.graph.Graph#addAttributeNode} be called later.
+	 *
+	 * @return {@code this} for chaining.
+	 */
+	AttributeNodeImplementor<J, E, K> markRemoved(boolean removed);
+
+	/**
 	 * Create a value subgraph, without knowing whether it represents a singular value or
 	 * plural element, rooted at this attribute node.
 	 *

--- a/hibernate-core/src/main/java/org/hibernate/graph/spi/GraphImplementor.java
+++ b/hibernate-core/src/main/java/org/hibernate/graph/spi/GraphImplementor.java
@@ -12,6 +12,7 @@ import jakarta.persistence.metamodel.ManagedType;
 import jakarta.persistence.metamodel.MapAttribute;
 import jakarta.persistence.metamodel.PluralAttribute;
 import org.hibernate.Internal;
+import org.hibernate.graph.AttributeNode;
 import org.hibernate.graph.Graph;
 import org.hibernate.graph.SubGraph;
 import org.hibernate.metamodel.model.domain.MapPersistentAttribute;
@@ -28,6 +29,34 @@ import org.hibernate.metamodel.model.domain.PersistentAttribute;
  */
 public interface GraphImplementor<J> extends Graph<J>, GraphNodeImplementor<J> {
 
+	/**
+	 * Returns the named node associated with the graph, if one, including
+	 * checks into treated subgraphs.
+	 * Returns the node regardless of {@linkplain AttributeNode#isRemoved()} which
+	 * is important for actually implementing proper spec compliance with regard to
+	 * impact of removed nodes.
+	 *
+	 * @return The named node, or {@code null}.
+	 *
+	 * @see jakarta.persistence.Graph#removeAttributeNode
+	 */
+	<T> AttributeNodeImplementor<T,?,?> findNode(String name);
+
+	/**
+	 * Retrieve an already existing node, if one, from the graph excluding all other checks.
+	 * Used in implementing {@linkplain #findNode(String)}
+	 */
+	<T> AttributeNodeImplementor<T,?,?> getExistingNode(PersistentAttribute<?, ? extends T> attribute);
+
+	/**
+	 * Retrieve an already existing node, if one, from the graph excluding all other checks.
+	 * Used in implementing {@linkplain #findNode(String)}
+	 */
+	<T> AttributeNodeImplementor<T,?,?> getExistingNode(String attributeName);
+
+	@Override
+	GraphImplementor<J> makeCopy(boolean mutable);
+
 	void merge(GraphImplementor<J> other);
 
 	@Internal
@@ -40,9 +69,6 @@ public interface GraphImplementor<J> extends Graph<J>, GraphNodeImplementor<J> {
 	@Override
 	@Deprecated(forRemoval = true)
 	SubGraphImplementor<J> makeSubGraph(boolean mutable);
-
-	@Override
-	GraphImplementor<J> makeCopy(boolean mutable);
 
 	@Override
 	List<? extends AttributeNodeImplementor<?,?,?>> getAttributeNodeList();

--- a/hibernate-core/src/main/java/org/hibernate/internal/find/FindByKeyOperation.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/find/FindByKeyOperation.java
@@ -147,6 +147,12 @@ public class FindByKeyOperation<T> implements NaturalIdLoader.Options {
 			else if ( option instanceof EnabledFetchProfile enabledFetchProfile ) {
 				this.enabledFetchProfile( enabledFetchProfile.profileName() );
 			}
+			else if ( option instanceof GraphSemantic semantic ) {
+				if ( rootGraph == null ) {
+					throw new IllegalArgumentException( "GraphSemantic option was specified, but no Graph was supplied" );
+				}
+				this.graphSemantic = semantic;
+			}
 			else if ( option instanceof NaturalIdSynchronization naturalIdSynchronization ) {
 				this.naturalIdSynchronization = naturalIdSynchronization;
 			}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/graphs/AttributeNodeRemovalTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/graphs/AttributeNodeRemovalTests.java
@@ -1,0 +1,352 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.jpa.graphs;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.Lob;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import org.hibernate.Hibernate;
+import org.hibernate.graph.GraphSemantic;
+import org.hibernate.graph.spi.RootGraphImplementor;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.Jira;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Steve Ebersole
+ */
+@DomainModel(annotatedClasses = {
+		AttributeNodeRemovalTests.Post.class,
+		AttributeNodeRemovalTests.Person.class,
+		AttributeNodeRemovalTests.Forum.class
+})
+@SessionFactory
+@Jira("https://hibernate.atlassian.net/browse/HHH-19567")
+public class AttributeNodeRemovalTests {
+	@BeforeEach
+	void setUp(SessionFactoryScope factoryScope) {
+		factoryScope.inTransaction( (session) -> {
+			final Person me = new Person( 1, "me" );
+			final Person you = new Person( 2, "you" );
+			final Person he = new Person( 3, "he" );
+			session.persist( me );
+			session.persist( you );
+			session.persist( he );
+
+			final Forum fiction = new Forum( 1, "Fiction" );
+			final Forum nonFiction = new Forum( 2, "Non-Fiction" );
+			session.persist( fiction );
+			session.persist( nonFiction );
+
+			session.persist( new Post( 1, "A Tale of Fairy", "Once upon a time...", fiction, you ) );
+			session.persist( new Post( 2, "The Meaning of Life", "You only get one shot...", nonFiction, he ) );
+			session.persist( new Post( 3, "Tales From Seaside", "The sun will come out...", fiction, me ) );
+		} );
+	}
+
+	@AfterEach
+	void tearDown(SessionFactoryScope factoryScope) {
+		factoryScope.dropData();
+	}
+
+	@Test
+	void testGraphBaseline(SessionFactoryScope factoryScope) {
+		factoryScope.inTransaction( (session) -> {
+			var entityGraph = session.createEntityGraph( Post.class );
+			var post = session.find( entityGraph, 1 );
+
+			assertThat( Hibernate.isPropertyInitialized( post, "author" ) ).isTrue();
+			assertThat( Hibernate.isInitialized( post.getAuthor() ) ).isTrue();
+
+			assertThat( Hibernate.isPropertyInitialized( post, "forum" ) ).isTrue();
+			assertThat( Hibernate.isInitialized( post.getForum() ) ).isFalse();
+		} );
+
+		factoryScope.inTransaction( (session) -> {
+			var entityGraph = session.createEntityGraph( Post.class );
+			var post = session.find( entityGraph, 1, GraphSemantic.FETCH );
+
+			assertThat( Hibernate.isPropertyInitialized( post, "author" ) ).isTrue();
+			assertThat( Hibernate.isInitialized( post.getAuthor() ) ).isFalse();
+
+			assertThat( Hibernate.isPropertyInitialized( post, "forum" ) ).isTrue();
+			assertThat( Hibernate.isInitialized( post.getForum() ) ).isFalse();
+		} );
+	}
+
+	@Test
+	void testAddLazyAttribute(SessionFactoryScope factoryScope) {
+		factoryScope.inTransaction( (session) -> {
+			var entityGraph = session.createEntityGraph( Post.class );
+			entityGraph.addAttributeNodes( "forum" );
+			var post = session.find( entityGraph, 1 );
+
+			assertThat( Hibernate.isPropertyInitialized( post, "author" ) ).isTrue();
+			assertThat( Hibernate.isInitialized( post.getAuthor() ) ).isTrue();
+
+			assertThat( Hibernate.isPropertyInitialized( post, "forum" ) ).isTrue();
+			assertThat( Hibernate.isInitialized( post.getForum() ) ).isTrue();
+		} );
+
+		factoryScope.inTransaction( (session) -> {
+			var entityGraph = session.createEntityGraph( Post.class );
+			entityGraph.addAttributeNodes( "forum" );
+			var post = session.find( entityGraph, 1, GraphSemantic.FETCH );
+
+			assertThat( Hibernate.isPropertyInitialized( post, "author" ) ).isTrue();
+			assertThat( Hibernate.isInitialized( post.getAuthor() ) ).isFalse();
+
+			assertThat( Hibernate.isPropertyInitialized( post, "forum" ) ).isTrue();
+			assertThat( Hibernate.isInitialized( post.getForum() ) ).isTrue();
+		} );
+	}
+
+	@Test
+	void testRemoveLazyAttribute(SessionFactoryScope factoryScope) {
+		factoryScope.inTransaction( (session) -> {
+			var entityGraph = session.createEntityGraph( Post.class );
+			entityGraph.removeAttributeNode( "forum" );
+			var post = session.find( entityGraph, 1 );
+
+			assertThat( Hibernate.isPropertyInitialized( post, "author" ) ).isTrue();
+			assertThat( Hibernate.isInitialized( post.getAuthor() ) ).isTrue();
+
+			assertThat( Hibernate.isPropertyInitialized( post, "forum" ) ).isTrue();
+			assertThat( Hibernate.isInitialized( post.getForum() ) ).isFalse();
+		} );
+
+		factoryScope.inTransaction( (session) -> {
+			var entityGraph = session.createEntityGraph( Post.class );
+			entityGraph.removeAttributeNode( "forum" );
+			var post = session.find( entityGraph, 1, GraphSemantic.FETCH );
+
+			assertThat( Hibernate.isPropertyInitialized( post, "author" ) ).isTrue();
+			assertThat( Hibernate.isInitialized( post.getAuthor() ) ).isFalse();
+
+			assertThat( Hibernate.isPropertyInitialized( post, "forum" ) ).isTrue();
+			assertThat( Hibernate.isInitialized( post.getForum() ) ).isFalse();
+		} );
+	}
+
+	@Test
+	void testAddEagerAttribute(SessionFactoryScope factoryScope) {
+		factoryScope.inTransaction( (session) -> {
+			var entityGraph = session.createEntityGraph( Post.class );
+			entityGraph.addAttributeNode( "author" );
+			var post = session.find( entityGraph, 1 );
+
+			assertThat( Hibernate.isPropertyInitialized( post, "author" ) ).isTrue();
+			assertThat( Hibernate.isInitialized( post.getAuthor() ) ).isTrue();
+
+			assertThat( Hibernate.isPropertyInitialized( post, "forum" ) ).isTrue();
+			assertThat( Hibernate.isInitialized( post.getForum() ) ).isFalse();
+		} );
+
+		factoryScope.inTransaction( (session) -> {
+			var entityGraph = session.createEntityGraph( Post.class );
+			entityGraph.addAttributeNode( "author" );
+			var post = session.find( entityGraph, 1, GraphSemantic.FETCH );
+
+			assertThat( Hibernate.isPropertyInitialized( post, "author" ) ).isTrue();
+			assertThat( Hibernate.isInitialized( post.getAuthor() ) ).isTrue();
+
+			assertThat( Hibernate.isPropertyInitialized( post, "forum" ) ).isTrue();
+			assertThat( Hibernate.isInitialized( post.getForum() ) ).isFalse();
+		} );
+	}
+
+	@Test
+	void testRemoveEagerAttribute(SessionFactoryScope factoryScope) {
+		factoryScope.inTransaction( (session) -> {
+			var entityGraph = session.createEntityGraph( Post.class );
+			entityGraph.removeAttributeNode( "author" );
+			var post = session.find( entityGraph, 1 );
+
+			assertThat( Hibernate.isPropertyInitialized( post, "author" ) ).isTrue();
+			assertThat( Hibernate.isInitialized( post.getAuthor() ) ).isFalse();
+
+			assertThat( Hibernate.isPropertyInitialized( post, "forum" ) ).isTrue();
+			assertThat( Hibernate.isInitialized( post.getForum() ) ).isFalse();
+		} );
+
+		factoryScope.inTransaction( (session) -> {
+			var entityGraph = session.createEntityGraph( Post.class );
+			entityGraph.removeAttributeNode( "author" );
+			var post = session.find( entityGraph, 1, GraphSemantic.FETCH );
+
+			// here we should fall back to mapped fetch strategy
+			assertThat( Hibernate.isPropertyInitialized( post, "author" ) ).isTrue();
+			assertThat( Hibernate.isInitialized( post.getAuthor() ) ).isTrue();
+
+			assertThat( Hibernate.isPropertyInitialized( post, "forum" ) ).isTrue();
+			assertThat( Hibernate.isInitialized( post.getForum() ) ).isFalse();
+		} );
+	}
+
+	@Test
+	void testGraphApi(SessionFactoryScope factoryScope) {
+		final RootGraphImplementor<Post> entityGraph = factoryScope.getSessionFactory().createEntityGraph( Post.class );
+
+		// assertions based on the empty
+		assertThat( entityGraph.getAttributeNodes() ).isEmpty();
+		assertThat( entityGraph.getAttributeNodeList() ).isEmpty();
+		assertThat( entityGraph.getNodes() ).isEmpty();
+		assertThat( entityGraph.getAttributeNode( "author" ) ).isNull();
+		assertThat( entityGraph.getAttributeNode( "forum" ) ).isNull();
+		assertThat( entityGraph.findNode( "author" ) ).isNull();
+		assertThat( entityGraph.findNode( "forum" ) ).isNull();
+
+		// assertions based on the added "author" node
+		entityGraph.addAttributeNode( "author" );
+		assertThat( entityGraph.getAttributeNodes() ).isNotEmpty();
+		assertThat( entityGraph.getAttributeNodeList() ).isNotEmpty();
+		assertThat( entityGraph.getNodes() ).isNotEmpty();
+		assertThat( entityGraph.getAttributeNode( "author" ) ).isNotNull();
+		assertThat( entityGraph.getAttributeNode( "forum" ) ).isNull();
+		assertThat( entityGraph.findNode( "author" ) ).isNotNull();
+		assertThat( entityGraph.findNode( "author" ).isRemoved() ).isFalse();
+		assertThat( entityGraph.findNode( "forum" ) ).isNull();
+
+		// assertions based on the removed "author" node
+		entityGraph.removeAttributeNode( "author" );
+		assertThat( entityGraph.getAttributeNodes() ).isEmpty();
+		assertThat( entityGraph.getAttributeNodeList() ).isEmpty();
+		assertThat( entityGraph.getNodes() ).isEmpty();
+		assertThat( entityGraph.getAttributeNode( "author" ) ).isNull();
+		assertThat( entityGraph.getAttributeNode( "forum" ) ).isNull();
+		assertThat( entityGraph.findNode( "author" ) ).isNotNull();
+		assertThat( entityGraph.findNode( "author" ).isRemoved() ).isTrue();
+		assertThat( entityGraph.findNode( "forum" ) ).isNull();
+	}
+
+	@Entity(name="Person")
+	@Table(name="persons")
+	public static class Person {
+		@Id
+		private Integer id;
+		private String name;
+
+		protected Person() {
+		}
+
+		public Person(Integer id, String name) {
+			this.id = id;
+			this.name = name;
+		}
+
+		public Integer getId() {
+			return id;
+		}
+
+		public String getName() {
+			return name;
+		}
+
+		public void setName(String name) {
+			this.name = name;
+		}
+	}
+
+	@Entity(name="Forum")
+	@Table(name="forums")
+	public static class Forum {
+		@Id
+		private Integer id;
+		private String name;
+
+		protected Forum() {
+		}
+
+		public Forum(Integer id, String name) {
+			this.id = id;
+			this.name = name;
+		}
+
+		public Integer getId() {
+			return id;
+		}
+
+		public String getName() {
+			return name;
+		}
+
+		public void setName(String name) {
+			this.name = name;
+		}
+	}
+
+	@Entity(name="Post")
+	@Table(name="posts")
+	public static class Post {
+		@Id
+		private Integer id;
+		private String title;
+		@Lob
+		private String body;
+		@ManyToOne(fetch = FetchType.LAZY)
+		@JoinColumn(name="forum_fk")
+		private Forum forum;
+		@ManyToOne(fetch = FetchType.EAGER)
+		@JoinColumn(name="author_fk")
+		private Person author;
+
+		protected Post() {
+		}
+
+		public Post(Integer id, String title, String body, Forum forum, Person author) {
+			this.id = id;
+			this.title = title;
+			this.body = body;
+			this.forum = forum;
+			this.author = author;
+		}
+
+		public Integer getId() {
+			return id;
+		}
+
+		public String getTitle() {
+			return title;
+		}
+
+		public void setTitle(String title) {
+			this.title = title;
+		}
+
+		public String getBody() {
+			return body;
+		}
+
+		public void setBody(String body) {
+			this.body = body;
+		}
+
+		public Forum getForum() {
+			return forum;
+		}
+
+		public void setForum(Forum forum) {
+			this.forum = forum;
+		}
+
+		public Person getAuthor() {
+			return author;
+		}
+
+		public void setAuthor(Person author) {
+			this.author = author;
+		}
+	}
+}


### PR DESCRIPTION
Backport of #11758 to H7.

<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

[Please describe here what your change is about]

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------


---
<!-- Hibernate GitHub Bot task list start -->
Please make sure that the following tasks are completed:
Tasks specific to HHH-19567 (Bug):
- [ ] Add test reproducing the bug
- [ ] Add entries as relevant to `migration-guide.adoc` **OR** check there are no breaking changes


<!-- Hibernate GitHub Bot task list end -->

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-19567
<!-- Hibernate GitHub Bot issue links end -->