### PR TITLE
HHH-20351: Enable UNNEST with ORDINALITY tests in Spanner PG dialect

### DIFF
--- a/docker_db.sh
+++ b/docker_db.sh
@@ -1560,7 +1560,7 @@ spanner_pg() {
 
 spanner_emulator() {
   local dialect=${1:-GOOGLE_STANDARD_SQL}
-  local emulator_image=${SPANNER_EMULATOR:-gcr.io/cloud-spanner-emulator/emulator:1.5.51}
+  local emulator_image=${SPANNER_EMULATOR:-gcr.io/cloud-spanner-emulator/emulator:1.5.52}
   if [[ $DB_COUNT -gt 8 ]]; then
     DB_COUNT=4
   else

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/function/array/ArrayUnnestTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/function/array/ArrayUnnestTest.java
@@ -6,7 +6,6 @@ package org.hibernate.orm.test.function.array;
 
 import java.util.List;
 
-import org.hibernate.community.dialect.SpannerPostgreSQLDialect;
 import org.hibernate.dialect.SybaseASEDialect;
 import org.hibernate.query.criteria.JpaCriteriaQuery;
 import org.hibernate.query.criteria.JpaFunctionJoin;
@@ -111,7 +110,6 @@ public class ArrayUnnestTest {
 	}
 
 	@Test
-	@SkipForDialect( dialectClass = SpannerPostgreSQLDialect.class, reason = "Emulator bug")
 	public void testUnnestOrdinality(SessionFactoryScope scope) {
 		scope.inSession( em -> {
 			List<Tuple> results = em.createQuery(
@@ -141,7 +139,6 @@ public class ArrayUnnestTest {
 
 	@Test
 	@SkipForDialect(dialectClass = SybaseASEDialect.class, reason = "xmltable can't be used with a left join")
-	@SkipForDialect( dialectClass = SpannerPostgreSQLDialect.class, reason = "Emulator bug")
 	public void testNodeBuilderUnnestOrdinality(SessionFactoryScope scope) {
 		scope.inSession( em -> {
 			final NodeBuilder cb = (NodeBuilder) em.getCriteriaBuilder();

--- a/settings.gradle
+++ b/settings.gradle
@@ -248,7 +248,7 @@ dependencyResolutionManagement {
             def teradataVersion = version "teradata",  "20.00.00.51"
             def tidbVersion = version "tidb", mysqlVersion
             def altibaseVersion = version "altibase", "7.3.0.1.1"
-            def spannerVersion = version "spanner", "2.35.5"
+            def spannerVersion = version "spanner", "2.38.0"
 
             library( "h2", "com.h2database", "h2" ).versionRef( h2Version )
             library( "h2gis", "org.orbisgis", "h2gis" ).versionRef( h2gisVersion )


### PR DESCRIPTION
<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

[Please describe here what your change is about]

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------


---
<!-- Hibernate GitHub Bot task list start -->
Please make sure that the following tasks are completed:
Tasks specific to HHH-20351 (Sub-task):
- [x] Add test **OR** check there is no need for a test
- [x] Update documentation as relevant: javadoc for changed API, `documentation/src/main/asciidoc/userguide` for all features, `documentation/src/main/asciidoc/introduction` for main features, links from existing documentation
- [x] Add entries as relevant to `migration-guide.adoc` (breaking changes) and `whats-new.adoc` (new features/improvements)


<!-- Hibernate GitHub Bot task list end -->

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-20351
<!-- Hibernate GitHub Bot issue links end -->