### PR TITLE
HHH-20352: spanner enable parallel testing

### DIFF
--- a/hibernate-core/hibernate-core.gradle
+++ b/hibernate-core/hibernate-core.gradle
@@ -299,11 +299,16 @@ tasks.withType( Test.class ).configureEach { test ->
         test.maxParallelForks = Runtime.runtime.availableProcessors()
         test.systemProperty 'maxParallelForks', test.maxParallelForks
     }
-    else if ( project.db == "spannerpgsql" ) {
+    else if ( project.db == "spannerpgsql" || project.db == "spanner" ) {
         def threadCount = Runtime.runtime.availableProcessors()
         def testThreads = project.findProperty( "test.threads" )
         if ( testThreads == null ) {
-            testThreads = threadCount >= 16 ? threadCount.intdiv( 4 ) : (threadCount.intdiv( 2 ) ?: 1)
+            def dbCount = threadCount.intdiv( 2 ) ?: 1
+            if ( dbCount > 8 ) {
+                testThreads = 4
+            } else {
+                testThreads = dbCount.intdiv( 2 ) ?: 1
+            }
         }
         else {
             testThreads = Integer.parseInt( testThreads.toString() )

--- a/hibernate-envers/hibernate-envers.gradle
+++ b/hibernate-envers/hibernate-envers.gradle
@@ -83,6 +83,23 @@ tasks.withType( Test.class ).configureEach { test ->
         test.maxParallelForks = Runtime.runtime.availableProcessors()
         test.systemProperty 'maxParallelForks', test.maxParallelForks
     }
+    else if ( project.db == "spannerpgsql" || project.db == "spanner" ) {
+        def threadCount = Runtime.runtime.availableProcessors()
+        def testThreads = project.findProperty( "test.threads" )
+        if ( testThreads == null ) {
+            def dbCount = threadCount.intdiv( 2 ) ?: 1
+            if ( dbCount > 8 ) {
+                testThreads = 4
+            } else {
+                testThreads = dbCount.intdiv( 2 ) ?: 1
+            }
+        }
+        else {
+            testThreads = Integer.parseInt( testThreads.toString() )
+        }
+        test.maxParallelForks = Math.min( testThreads, 4 )
+        test.systemProperty 'maxParallelForks', test.maxParallelForks
+    }
 }
 
 sourcesJar {

--- a/hibernate-envers/src/test/java/org/hibernate/orm/test/envers/integration/generated/SimpleEntity.java
+++ b/hibernate-envers/src/test/java/org/hibernate/orm/test/envers/integration/generated/SimpleEntity.java
@@ -4,10 +4,10 @@
  */
 package org.hibernate.orm.test.envers.integration.generated;
 
+import org.hibernate.annotations.ColumnDefault;
 import org.hibernate.annotations.Generated;
 import org.hibernate.envers.Audited;
 
-import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
@@ -25,7 +25,7 @@ public class SimpleEntity {
 	private String data;
 
 	@Generated
-	@Column(columnDefinition = "integer default 1")
+	@ColumnDefault("1")
 	private int caseNumberInsert;
 
 	public Integer getId() {

--- a/hibernate-envers/src/test/java/org/hibernate/orm/test/envers/integration/reventity/trackmodifiedentities/DefaultTrackingEntitiesTest.java
+++ b/hibernate-envers/src/test/java/org/hibernate/orm/test/envers/integration/reventity/trackmodifiedentities/DefaultTrackingEntitiesTest.java
@@ -4,6 +4,7 @@
  */
 package org.hibernate.orm.test.envers.integration.reventity.trackmodifiedentities;
 import org.hibernate.community.dialect.SpannerPostgreSQLDialect;
+import org.hibernate.dialect.SpannerDialect;
 
 import org.hibernate.testing.orm.junit.SkipForDialect;
 
@@ -43,6 +44,7 @@ import static org.junit.jupiter.api.Assertions.fail;
  * @author Lukasz Antoniak (lukasz dot antoniak at gmail dot com)
  */
 @SkipForDialect(dialectClass = SpannerPostgreSQLDialect.class, reason = "Spanner uses bit-reversed sequences which break assumptions")
+@SkipForDialect(dialectClass = SpannerDialect.class, reason = "Spanner uses bit-reversed sequences which break assumptions")
 @EnversTest
 @DomainModel(annotatedClasses = {StrTestEntity.class, StrIntTestEntity.class})
 @ServiceRegistry(settings = @Setting(name = EnversSettings.TRACK_ENTITIES_CHANGED_IN_REVISION, value = "true"))

--- a/hibernate-envers/src/test/java/org/hibernate/orm/test/envers/integration/reventity/trackmodifiedentities/ExtendedRevisionEntityTest.java
+++ b/hibernate-envers/src/test/java/org/hibernate/orm/test/envers/integration/reventity/trackmodifiedentities/ExtendedRevisionEntityTest.java
@@ -4,6 +4,7 @@
  */
 package org.hibernate.orm.test.envers.integration.reventity.trackmodifiedentities;
 import org.hibernate.community.dialect.SpannerPostgreSQLDialect;
+import org.hibernate.dialect.SpannerDialect;
 
 import org.hibernate.testing.orm.junit.SkipForDialect;
 
@@ -31,6 +32,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  * @author Lukasz Antoniak (lukasz dot antoniak at gmail dot com)
  */
 @SkipForDialect(dialectClass = SpannerPostgreSQLDialect.class, reason = "Spanner uses bit-reversed sequences which break assumptions")
+@SkipForDialect(dialectClass = SpannerDialect.class, reason = "Spanner uses bit-reversed sequences which break assumptions")
 @EnversTest
 @DomainModel(annotatedClasses = {StrTestEntity.class, StrIntTestEntity.class, ExtendedRevisionEntity.class})
 @ServiceRegistry(settings = @Setting(name = EnversSettings.TRACK_ENTITIES_CHANGED_IN_REVISION, value = "false"))

--- a/hibernate-jcache/src/test/java/org/hibernate/orm/test/jcache/HibernateCacheTest.java
+++ b/hibernate-jcache/src/test/java/org/hibernate/orm/test/jcache/HibernateCacheTest.java
@@ -24,6 +24,8 @@ import org.hibernate.stat.QueryStatistics;
 import org.hibernate.stat.Statistics;
 
 import org.hibernate.testing.orm.junit.ExtraAssertions;
+import org.hibernate.testing.orm.junit.RequiresDialectFeature;
+import org.hibernate.testing.orm.junit.DialectFeatureChecks;
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.equalTo;
@@ -195,6 +197,7 @@ public class HibernateCacheTest extends BaseFunctionalTest {
 	}
 
 	@Test
+	@RequiresDialectFeature(feature = DialectFeatureChecks.SupportsPrimaryKeyUpdate.class)
 	public void testGeneralUsage() {
 		EventManager mgr = new EventManager( sessionFactory() );
 		Statistics stats = sessionFactory().getStatistics();

--- a/hibernate-jcache/src/test/resources/hibernate.properties
+++ b/hibernate-jcache/src/test/resources/hibernate.properties
@@ -15,3 +15,6 @@ hibernate.connection.pool_size 2
 hibernate.cache.region_prefix hibernate.test
 
 hibernate.service.allow_crawling=false
+
+# This flag is intended for testing. This option should not be enabled in production
+hibernate.dialect.spanner.use_integer_for_primary_key=true


### PR DESCRIPTION
<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

- enable parallel testing for hibernate-core and hibernate-envers for spanner 
- fix tests in hibernate-envers hibernate-jcache

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------


---
<!-- Hibernate GitHub Bot task list start -->
Please make sure that the following tasks are completed:
Tasks specific to HHH-20352 (Sub-task):
- [x] Add test **OR** check there is no need for a test
- [x] Update documentation as relevant: javadoc for changed API, `documentation/src/main/asciidoc/userguide` for all features, `documentation/src/main/asciidoc/introduction` for main features, links from existing documentation
- [x] Add entries as relevant to `migration-guide.adoc` (breaking changes) and `whats-new.adoc` (new features/improvements)


<!-- Hibernate GitHub Bot task list end -->

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-20352
<!-- Hibernate GitHub Bot issue links end -->