### PR TITLE
HHH-20355 concurrent use of to Calendar

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/jdbc/TimeUtcAsJdbcTimeJdbcType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/jdbc/TimeUtcAsJdbcTimeJdbcType.java
@@ -33,7 +33,6 @@ import jakarta.persistence.TemporalType;
 public class TimeUtcAsJdbcTimeJdbcType implements JdbcType {
 
 	public static final TimeUtcAsJdbcTimeJdbcType INSTANCE = new TimeUtcAsJdbcTimeJdbcType();
-	private static final Calendar UTC_CALENDAR = Calendar.getInstance( TimeZone.getTimeZone( "UTC" ) );
 
 	public TimeUtcAsJdbcTimeJdbcType() {
 	}
@@ -82,14 +81,16 @@ public class TimeUtcAsJdbcTimeJdbcType implements JdbcType {
 			@Override
 			protected void doBind(PreparedStatement st, X value, int index, WrapperOptions options) throws SQLException {
 				final OffsetTime offsetTime = javaType.unwrap( value, OffsetTime.class, options );
-				st.setTime( index, Time.valueOf( offsetTime.withOffsetSameInstant( ZoneOffset.UTC ).toLocalTime() ), UTC_CALENDAR );
+				st.setTime( index, Time.valueOf( offsetTime.withOffsetSameInstant( ZoneOffset.UTC ).toLocalTime() ),
+						Calendar.getInstance( TimeZone.getTimeZone( "UTC" ) ) );
 			}
 
 			@Override
 			protected void doBind(CallableStatement st, X value, String name, WrapperOptions options)
 					throws SQLException {
 				final OffsetTime offsetTime = javaType.unwrap( value, OffsetTime.class, options );
-				st.setTime( name, Time.valueOf( offsetTime.withOffsetSameInstant( ZoneOffset.UTC ).toLocalTime() ), UTC_CALENDAR );
+				st.setTime( name, Time.valueOf( offsetTime.withOffsetSameInstant( ZoneOffset.UTC ).toLocalTime() ),
+						Calendar.getInstance( TimeZone.getTimeZone( "UTC" ) ) );
 			}
 		};
 	}
@@ -99,19 +100,19 @@ public class TimeUtcAsJdbcTimeJdbcType implements JdbcType {
 		return new BasicExtractor<>( javaType, this ) {
 			@Override
 			protected X doExtract(ResultSet rs, int paramIndex, WrapperOptions options) throws SQLException {
-				final Time time = rs.getTime( paramIndex, UTC_CALENDAR );
+				final Time time = rs.getTime( paramIndex, Calendar.getInstance( TimeZone.getTimeZone( "UTC" ) ) );
 				return javaType.wrap( time == null ? null : time.toLocalTime().atOffset( ZoneOffset.UTC ), options );
 			}
 
 			@Override
 			protected X doExtract(CallableStatement statement, int index, WrapperOptions options) throws SQLException {
-				final Time time = statement.getTime( index, UTC_CALENDAR );
+				final Time time = statement.getTime( index, Calendar.getInstance( TimeZone.getTimeZone( "UTC" ) ) );
 				return javaType.wrap( time == null ? null : time.toLocalTime().atOffset( ZoneOffset.UTC ), options );
 			}
 
 			@Override
 			protected X doExtract(CallableStatement statement, String name, WrapperOptions options) throws SQLException {
-				final Time time = statement.getTime( name, UTC_CALENDAR );
+				final Time time = statement.getTime( name, Calendar.getInstance( TimeZone.getTimeZone( "UTC" ) ) );
 				return javaType.wrap( time == null ? null : time.toLocalTime().atOffset( ZoneOffset.UTC ), options );
 			}
 		};

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/jdbc/TimestampUtcAsInstantJdbcType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/jdbc/TimestampUtcAsInstantJdbcType.java
@@ -31,7 +31,6 @@ import jakarta.persistence.TemporalType;
  */
 public class TimestampUtcAsInstantJdbcType implements JdbcType {
 	public static final TimestampUtcAsInstantJdbcType INSTANCE = new TimestampUtcAsInstantJdbcType();
-	private static final Calendar UTC_CALENDAR = Calendar.getInstance( TimeZone.getTimeZone( "UTC" ) );
 
 	public TimestampUtcAsInstantJdbcType() {
 	}
@@ -90,7 +89,8 @@ public class TimestampUtcAsInstantJdbcType implements JdbcType {
 				}
 				catch (SQLException|AbstractMethodError e) {
 					// fall back to treating it as a JDBC Timestamp
-					st.setTimestamp( index, Timestamp.from( instant ), UTC_CALENDAR );
+					st.setTimestamp( index, Timestamp.from( instant ),
+							Calendar.getInstance( TimeZone.getTimeZone( "UTC" ) ) );
 				}
 			}
 
@@ -108,7 +108,8 @@ public class TimestampUtcAsInstantJdbcType implements JdbcType {
 				}
 				catch (SQLException|AbstractMethodError e) {
 					// fall back to treating it as a JDBC Timestamp
-					st.setTimestamp( name, Timestamp.from( instant ), UTC_CALENDAR );
+					st.setTimestamp( name, Timestamp.from( instant ),
+							Calendar.getInstance( TimeZone.getTimeZone( "UTC" ) ) );
 				}
 			}
 		};
@@ -125,7 +126,8 @@ public class TimestampUtcAsInstantJdbcType implements JdbcType {
 				}
 				catch (SQLException|AbstractMethodError e) {
 					// fall back to treating it as a JDBC Timestamp
-					return javaType.wrap( rs.getTimestamp( position, UTC_CALENDAR ), wrapperOptions );
+					return javaType.wrap( rs.getTimestamp( position,
+							Calendar.getInstance( TimeZone.getTimeZone( "UTC" ) ) ), wrapperOptions );
 				}
 			}
 
@@ -137,7 +139,8 @@ public class TimestampUtcAsInstantJdbcType implements JdbcType {
 				}
 				catch (SQLException|AbstractMethodError e) {
 					// fall back to treating it as a JDBC Timestamp
-					return javaType.wrap( statement.getTimestamp( position, UTC_CALENDAR ), wrapperOptions );
+					return javaType.wrap( statement.getTimestamp( position,
+							Calendar.getInstance( TimeZone.getTimeZone( "UTC" ) ) ), wrapperOptions );
 				}
 			}
 
@@ -149,7 +152,8 @@ public class TimestampUtcAsInstantJdbcType implements JdbcType {
 				}
 				catch (SQLException|AbstractMethodError e) {
 					// fall back to treating it as a JDBC Timestamp
-					return javaType.wrap( statement.getTimestamp( name, UTC_CALENDAR ), wrapperOptions );
+					return javaType.wrap( statement.getTimestamp( name,
+							Calendar.getInstance( TimeZone.getTimeZone( "UTC" ) ) ), wrapperOptions );
 				}
 			}
 		};

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/jdbc/TimestampUtcAsJdbcTimestampJdbcType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/jdbc/TimestampUtcAsJdbcTimestampJdbcType.java
@@ -32,8 +32,6 @@ import jakarta.persistence.TemporalType;
 public class TimestampUtcAsJdbcTimestampJdbcType implements JdbcType {
 
 	public static final TimestampUtcAsJdbcTimestampJdbcType INSTANCE = new TimestampUtcAsJdbcTimestampJdbcType();
-	private static final ThreadLocal<Calendar> UTC_CALENDAR =
-			ThreadLocal.withInitial( () -> Calendar.getInstance( TimeZone.getTimeZone( "UTC" ) ) );
 
 	public TimestampUtcAsJdbcTimestampJdbcType() {
 	}
@@ -82,14 +80,14 @@ public class TimestampUtcAsJdbcTimestampJdbcType implements JdbcType {
 			@Override
 			protected void doBind(PreparedStatement st, X value, int index, WrapperOptions options) throws SQLException {
 				final Instant instant = javaType.unwrap( value, Instant.class, options );
-				st.setTimestamp( index, Timestamp.from( instant ), UTC_CALENDAR.get() );
+				st.setTimestamp( index, Timestamp.from( instant ), Calendar.getInstance() );
 			}
 
 			@Override
 			protected void doBind(CallableStatement st, X value, String name, WrapperOptions options)
 					throws SQLException {
 				final Instant instant = javaType.unwrap( value, Instant.class, options );
-				st.setTimestamp( name, Timestamp.from( instant ), UTC_CALENDAR.get() );
+				st.setTimestamp( name, Timestamp.from( instant ), Calendar.getInstance() );
 			}
 		};
 	}
@@ -99,19 +97,19 @@ public class TimestampUtcAsJdbcTimestampJdbcType implements JdbcType {
 		return new BasicExtractor<>( javaType, this ) {
 			@Override
 			protected X doExtract(ResultSet rs, int paramIndex, WrapperOptions options) throws SQLException {
-				final Timestamp timestamp = rs.getTimestamp( paramIndex, UTC_CALENDAR.get() );
+				final Timestamp timestamp = rs.getTimestamp( paramIndex, Calendar.getInstance() );
 				return javaType.wrap( timestamp == null ? null : timestamp.toInstant(), options );
 			}
 
 			@Override
 			protected X doExtract(CallableStatement statement, int index, WrapperOptions options) throws SQLException {
-				final Timestamp timestamp = statement.getTimestamp( index, UTC_CALENDAR.get() );
+				final Timestamp timestamp = statement.getTimestamp( index, Calendar.getInstance() );
 				return javaType.wrap( timestamp == null ? null : timestamp.toInstant(), options );
 			}
 
 			@Override
 			protected X doExtract(CallableStatement statement, String name, WrapperOptions options) throws SQLException {
-				final Timestamp timestamp = statement.getTimestamp( name, UTC_CALENDAR.get() );
+				final Timestamp timestamp = statement.getTimestamp( name, Calendar.getInstance() );
 				return javaType.wrap( timestamp == null ? null : timestamp.toInstant(), options );
 			}
 		};

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/jdbc/TimestampUtcAsJdbcTimestampJdbcType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/jdbc/TimestampUtcAsJdbcTimestampJdbcType.java
@@ -33,7 +33,8 @@ public class TimestampUtcAsJdbcTimestampJdbcType implements JdbcType {
 
 	public static final TimestampUtcAsJdbcTimestampJdbcType INSTANCE = new TimestampUtcAsJdbcTimestampJdbcType();
 	private static final ThreadLocal<Calendar> UTC_CALENDAR =
-			ThreadLocal.withInitial(() -> Calendar.getInstance(TimeZone.getTimeZone("UTC")));
+			ThreadLocal.withInitial( () -> Calendar.getInstance( TimeZone.getTimeZone( "UTC" ) ) );
+
 	public TimestampUtcAsJdbcTimestampJdbcType() {
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/jdbc/TimestampUtcAsJdbcTimestampJdbcType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/jdbc/TimestampUtcAsJdbcTimestampJdbcType.java
@@ -80,14 +80,14 @@ public class TimestampUtcAsJdbcTimestampJdbcType implements JdbcType {
 			@Override
 			protected void doBind(PreparedStatement st, X value, int index, WrapperOptions options) throws SQLException {
 				final Instant instant = javaType.unwrap( value, Instant.class, options );
-				st.setTimestamp( index, Timestamp.from( instant ), Calendar.getInstance() );
+				st.setTimestamp( index, Timestamp.from( instant ), Calendar.getInstance( TimeZone.getTimeZone( "UTC" ) ) );
 			}
 
 			@Override
 			protected void doBind(CallableStatement st, X value, String name, WrapperOptions options)
 					throws SQLException {
 				final Instant instant = javaType.unwrap( value, Instant.class, options );
-				st.setTimestamp( name, Timestamp.from( instant ), Calendar.getInstance() );
+				st.setTimestamp( name, Timestamp.from( instant ), Calendar.getInstance( TimeZone.getTimeZone( "UTC" ) ) );
 			}
 		};
 	}
@@ -97,19 +97,19 @@ public class TimestampUtcAsJdbcTimestampJdbcType implements JdbcType {
 		return new BasicExtractor<>( javaType, this ) {
 			@Override
 			protected X doExtract(ResultSet rs, int paramIndex, WrapperOptions options) throws SQLException {
-				final Timestamp timestamp = rs.getTimestamp( paramIndex, Calendar.getInstance() );
+				final Timestamp timestamp = rs.getTimestamp( paramIndex, Calendar.getInstance( TimeZone.getTimeZone( "UTC" ) ) );
 				return javaType.wrap( timestamp == null ? null : timestamp.toInstant(), options );
 			}
 
 			@Override
 			protected X doExtract(CallableStatement statement, int index, WrapperOptions options) throws SQLException {
-				final Timestamp timestamp = statement.getTimestamp( index, Calendar.getInstance() );
+				final Timestamp timestamp = statement.getTimestamp( index, Calendar.getInstance( TimeZone.getTimeZone( "UTC" ) ) );
 				return javaType.wrap( timestamp == null ? null : timestamp.toInstant(), options );
 			}
 
 			@Override
 			protected X doExtract(CallableStatement statement, String name, WrapperOptions options) throws SQLException {
-				final Timestamp timestamp = statement.getTimestamp( name, Calendar.getInstance() );
+				final Timestamp timestamp = statement.getTimestamp( name, Calendar.getInstance( TimeZone.getTimeZone( "UTC" ) ) );
 				return javaType.wrap( timestamp == null ? null : timestamp.toInstant(), options );
 			}
 		};

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/jdbc/TimestampUtcAsJdbcTimestampJdbcType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/jdbc/TimestampUtcAsJdbcTimestampJdbcType.java
@@ -80,14 +80,16 @@ public class TimestampUtcAsJdbcTimestampJdbcType implements JdbcType {
 			@Override
 			protected void doBind(PreparedStatement st, X value, int index, WrapperOptions options) throws SQLException {
 				final Instant instant = javaType.unwrap( value, Instant.class, options );
-				st.setTimestamp( index, Timestamp.from( instant ), Calendar.getInstance( TimeZone.getTimeZone( "UTC" ) ) );
+				st.setTimestamp( index, Timestamp.from( instant ),
+						Calendar.getInstance( TimeZone.getTimeZone( "UTC" ) ) );
 			}
 
 			@Override
 			protected void doBind(CallableStatement st, X value, String name, WrapperOptions options)
 					throws SQLException {
 				final Instant instant = javaType.unwrap( value, Instant.class, options );
-				st.setTimestamp( name, Timestamp.from( instant ), Calendar.getInstance( TimeZone.getTimeZone( "UTC" ) ) );
+				st.setTimestamp( name, Timestamp.from( instant ),
+						Calendar.getInstance( TimeZone.getTimeZone( "UTC" ) ) );
 			}
 		};
 	}
@@ -97,19 +99,22 @@ public class TimestampUtcAsJdbcTimestampJdbcType implements JdbcType {
 		return new BasicExtractor<>( javaType, this ) {
 			@Override
 			protected X doExtract(ResultSet rs, int paramIndex, WrapperOptions options) throws SQLException {
-				final Timestamp timestamp = rs.getTimestamp( paramIndex, Calendar.getInstance( TimeZone.getTimeZone( "UTC" ) ) );
+				final Timestamp timestamp = rs.getTimestamp( paramIndex,
+						Calendar.getInstance( TimeZone.getTimeZone( "UTC" ) ) );
 				return javaType.wrap( timestamp == null ? null : timestamp.toInstant(), options );
 			}
 
 			@Override
 			protected X doExtract(CallableStatement statement, int index, WrapperOptions options) throws SQLException {
-				final Timestamp timestamp = statement.getTimestamp( index, Calendar.getInstance( TimeZone.getTimeZone( "UTC" ) ) );
+				final Timestamp timestamp = statement.getTimestamp( index,
+						Calendar.getInstance( TimeZone.getTimeZone( "UTC" ) ) );
 				return javaType.wrap( timestamp == null ? null : timestamp.toInstant(), options );
 			}
 
 			@Override
 			protected X doExtract(CallableStatement statement, String name, WrapperOptions options) throws SQLException {
-				final Timestamp timestamp = statement.getTimestamp( name, Calendar.getInstance( TimeZone.getTimeZone( "UTC" ) ) );
+				final Timestamp timestamp = statement.getTimestamp( name,
+						Calendar.getInstance( TimeZone.getTimeZone( "UTC" ) ) );
 				return javaType.wrap( timestamp == null ? null : timestamp.toInstant(), options );
 			}
 		};

--- a/hibernate-core/src/main/java/org/hibernate/type/descriptor/jdbc/TimestampUtcAsJdbcTimestampJdbcType.java
+++ b/hibernate-core/src/main/java/org/hibernate/type/descriptor/jdbc/TimestampUtcAsJdbcTimestampJdbcType.java
@@ -32,8 +32,8 @@ import jakarta.persistence.TemporalType;
 public class TimestampUtcAsJdbcTimestampJdbcType implements JdbcType {
 
 	public static final TimestampUtcAsJdbcTimestampJdbcType INSTANCE = new TimestampUtcAsJdbcTimestampJdbcType();
-	private static final Calendar UTC_CALENDAR = Calendar.getInstance( TimeZone.getTimeZone( "UTC" ) );
-
+	private static final ThreadLocal<Calendar> UTC_CALENDAR =
+			ThreadLocal.withInitial(() -> Calendar.getInstance(TimeZone.getTimeZone("UTC")));
 	public TimestampUtcAsJdbcTimestampJdbcType() {
 	}
 
@@ -81,14 +81,14 @@ public class TimestampUtcAsJdbcTimestampJdbcType implements JdbcType {
 			@Override
 			protected void doBind(PreparedStatement st, X value, int index, WrapperOptions options) throws SQLException {
 				final Instant instant = javaType.unwrap( value, Instant.class, options );
-				st.setTimestamp( index, Timestamp.from( instant ), UTC_CALENDAR );
+				st.setTimestamp( index, Timestamp.from( instant ), UTC_CALENDAR.get() );
 			}
 
 			@Override
 			protected void doBind(CallableStatement st, X value, String name, WrapperOptions options)
 					throws SQLException {
 				final Instant instant = javaType.unwrap( value, Instant.class, options );
-				st.setTimestamp( name, Timestamp.from( instant ), UTC_CALENDAR );
+				st.setTimestamp( name, Timestamp.from( instant ), UTC_CALENDAR.get() );
 			}
 		};
 	}
@@ -98,19 +98,19 @@ public class TimestampUtcAsJdbcTimestampJdbcType implements JdbcType {
 		return new BasicExtractor<>( javaType, this ) {
 			@Override
 			protected X doExtract(ResultSet rs, int paramIndex, WrapperOptions options) throws SQLException {
-				final Timestamp timestamp = rs.getTimestamp( paramIndex, UTC_CALENDAR );
+				final Timestamp timestamp = rs.getTimestamp( paramIndex, UTC_CALENDAR.get() );
 				return javaType.wrap( timestamp == null ? null : timestamp.toInstant(), options );
 			}
 
 			@Override
 			protected X doExtract(CallableStatement statement, int index, WrapperOptions options) throws SQLException {
-				final Timestamp timestamp = statement.getTimestamp( index, UTC_CALENDAR );
+				final Timestamp timestamp = statement.getTimestamp( index, UTC_CALENDAR.get() );
 				return javaType.wrap( timestamp == null ? null : timestamp.toInstant(), options );
 			}
 
 			@Override
 			protected X doExtract(CallableStatement statement, String name, WrapperOptions options) throws SQLException {
-				final Timestamp timestamp = statement.getTimestamp( name, UTC_CALENDAR );
+				final Timestamp timestamp = statement.getTimestamp( name, UTC_CALENDAR.get() );
 				return javaType.wrap( timestamp == null ? null : timestamp.toInstant(), options );
 			}
 		};


### PR DESCRIPTION
I do not have access to create and HHH ticket, so I will just create the PR anyways.
<img width="1512" height="835" alt="Screenshot 2026-04-20 at 5 17 30 PM" src="https://github.com/user-attachments/assets/8eaab607-41a5-4944-84d3-16a3dd656bc3" />

<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

### Changes

Fix race condition in TimestampUtcAsJdbcTimestampJdbcType UTC calendar                                                                                         

java.util.Calendar is not thread-safe. The previous implementation shared a single Calendar instance as a static final field, which caused data races when multiple threads called setTimestamp/getTimestamp concurrently — each call can mutate the calendar's internal state (e.g. calendar.setTime(...) or calendar.setTimeInMillis(...)).                                           
                                                                                                                                                                 
Changed UTC_CALENDAR from a plain static final Calendar to lazily creating a new calendar object during runtime to fix this issue.

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------

---
<!-- Hibernate GitHub Bot task list start -->
Please make sure that the following tasks are completed:
Tasks specific to HHH-20355 (Bug):
- [ ] Add test reproducing the bug
- [ ] Add entries as relevant to `migration-guide.adoc` **OR** check there are no breaking changes


<!-- Hibernate GitHub Bot task list end -->

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-20355
<!-- Hibernate GitHub Bot issue links end -->