### PR TITLE
TiDB: Add TiDBTemporalTableSupport

### DIFF
--- a/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/TiDBDialect.java
+++ b/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/TiDBDialect.java
@@ -9,6 +9,8 @@ import jakarta.persistence.Timeout;
 import org.hibernate.Timeouts;
 import org.hibernate.community.dialect.sequence.SequenceInformationExtractorTiDBDatabaseImpl;
 import org.hibernate.community.dialect.sequence.TiDBSequenceSupport;
+import org.hibernate.community.dialect.temporal.TiDBTemporalTableSupport;
+import org.hibernate.dialect.temporal.TemporalTableSupport;
 import org.hibernate.dialect.DatabaseVersion;
 import org.hibernate.dialect.Dialect;
 import org.hibernate.dialect.FunctionalDependencyAnalysisSupport;
@@ -249,5 +251,10 @@ public class TiDBDialect extends MySQLDialect {
 	@Override
 	public boolean supportsExceptAll() {
 		return false;
+	}
+
+	@Override
+	public TemporalTableSupport getTemporalTableSupport() {
+		return new TiDBTemporalTableSupport( this );
 	}
 }

--- a/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/temporal/TiDBTemporalTableSupport.java
+++ b/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/temporal/TiDBTemporalTableSupport.java
@@ -1,0 +1,31 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.community.dialect.temporal;
+
+import org.hibernate.community.dialect.TiDBDialect;
+import org.hibernate.dialect.temporal.MySQLTemporalTableSupport;
+import org.hibernate.temporal.TemporalTableStrategy;
+
+/**
+ * @author Daniël van Eeden
+ */
+public class TiDBTemporalTableSupport extends MySQLTemporalTableSupport {
+
+	public TiDBTemporalTableSupport(TiDBDialect dialect) {
+		super( dialect );
+	}
+
+	@Override
+	public String getExtraTemporalTableDeclarations(
+			TemporalTableStrategy strategy,
+			String rowStartColumn, String rowEndColumn,
+			boolean partitioned) {
+		// TiDB does not support the INVISIBLE keyword on generated columns used by MySQLTemporalTableSupport
+		// See https://github.com/pingcap/tidb/issues/59233
+		return partitioned
+				? rowEndColumn + "_null tinyint as (" + rowEndColumn + " is null) virtual"
+				: null;
+	}
+}


### PR DESCRIPTION
This is similar to MySQLTemporalTableSupport, but without using the `INVISIBLE` keyword for the column (see
https://github.com/pingcap/tidb/issues/59233 )

Note that TiDB has the `AS OF TIMESTAMP` clause: https://docs.pingcap.com/tidb/stable/as-of-timestamp/ However the history provided by this feature is bounded by the `tidb_gc_life_time` setting, which is set to 10 minutes by default.

<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

[Please describe here what your change is about]

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
