### PR TITLE
HHH-18938 BatchBuilder, StatisticsFactory, MutationExecutorService, SchemaManagementTool as Java services

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/engine/jdbc/batch/internal/BatchBuilderInitiator.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/jdbc/batch/internal/BatchBuilderInitiator.java
@@ -41,24 +41,46 @@ public class BatchBuilderInitiator implements StandardServiceInitiator<BatchBuil
 			builder = configurationValues.get( BATCH_STRATEGY );
 		}
 
-		if ( builder == null ) {
-			return new BatchBuilderImpl( getInt( STATEMENT_BATCH_SIZE, configurationValues, 1 ) );
-		}
+		final var classLoaderService = registry.requireService( ClassLoaderService.class );
 
-		if ( builder instanceof BatchBuilder batchBuilder ) {
+		if ( builder == null ) {
+			final var discovered = discover( classLoaderService );
+			return discovered != null
+					? discovered
+					: new BatchBuilderImpl( getInt( STATEMENT_BATCH_SIZE, configurationValues, 1 ) );
+		}
+		else if ( builder instanceof BatchBuilder batchBuilder ) {
 			return batchBuilder;
 		}
-
-		final String builderClassName = builder.toString();
-		try {
-			return (BatchBuilder)
-					registry.requireService( ClassLoaderService.class )
-							.classForName( builderClassName )
-							.getConstructor()
-							.newInstance();
+		else {
+			final String builderClassName = builder.toString();
+			try {
+				return (BatchBuilder)
+						classLoaderService
+								.classForName( builderClassName )
+								.getConstructor()
+								.newInstance();
+			}
+			catch (Exception e) {
+				throw new ServiceException( "Could not build explicit BatchBuilder [" + builderClassName + "]", e );
+			}
 		}
-		catch (Exception e) {
-			throw new ServiceException( "Could not build explicit BatchBuilder [" + builderClassName + "]", e );
+	}
+
+	private static BatchBuilder discover(ClassLoaderService classLoaderService) {
+		final var discovered = classLoaderService.loadJavaServices( BatchBuilder.class );
+		final var iterator = discovered.iterator();
+		if ( iterator.hasNext() ) {
+			final var selected = iterator.next();
+			if ( iterator.hasNext() ) {
+				throw new ServiceException(
+						"Multiple BatchBuilder service registrations found via ServiceLoader; "
+						+ "specify one explicitly via '" + BUILDER + "'" );
+			}
+			return selected;
+		}
+		else {
+			return null;
 		}
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/engine/jdbc/batch/spi/BatchBuilder.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/jdbc/batch/spi/BatchBuilder.java
@@ -9,17 +9,20 @@ import java.util.function.Supplier;
 import org.hibernate.Incubating;
 import org.hibernate.engine.jdbc.mutation.group.PreparedStatementGroup;
 import org.hibernate.engine.jdbc.spi.JdbcCoordinator;
+import org.hibernate.service.JavaServiceLoadable;
 import org.hibernate.service.Service;
 
 /**
  * A builder for {@link Batch} instances.
  * <p>
- * A custom {@code BatchBuilder} may be selected using the configuration property
- * {@value org.hibernate.cfg.AvailableSettings#BUILDER}.
+ * A custom {@code BatchBuilder} may be selected either by setting the configuration
+ * property {@value org.hibernate.cfg.AvailableSettings#BUILDER}, or by registering it
+ * as a {@linkplain java.util.ServiceLoader Java service}.
  *
  * @author Steve Ebersole
  */
 @Incubating
+@JavaServiceLoadable
 public interface BatchBuilder extends Service {
 	/**
 	 * Build a batch.

--- a/hibernate-core/src/main/java/org/hibernate/engine/jdbc/mutation/internal/MutationExecutorServiceInitiator.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/jdbc/mutation/internal/MutationExecutorServiceInitiator.java
@@ -36,32 +36,56 @@ public class MutationExecutorServiceInitiator implements StandardServiceInitiato
 	@Override
 	public MutationExecutorService initiateService(Map<String, Object> configurationValues, ServiceRegistryImplementor registry) {
 		final Object custom = configurationValues.get( EXECUTOR_KEY );
+		final var classLoaderService = registry.requireService( ClassLoaderService.class );
 
 		if ( custom == null ) {
-			return createStandardService( configurationValues );
+			final MutationExecutorService discovered = discover( classLoaderService );
+			return discovered != null
+					? discovered
+					: createStandardService( configurationValues );
 		}
-
-		if ( custom instanceof MutationExecutorService mutationExecutorService ) {
+		else if ( custom instanceof MutationExecutorService mutationExecutorService ) {
 			return mutationExecutorService;
 		}
+		else {
+			final Class<? extends MutationExecutorService> customImplClass;
+			if ( custom instanceof Class ) {
+				//noinspection unchecked
+				customImplClass = (Class<? extends MutationExecutorService>) custom;
+			}
+			else {
+				customImplClass = classLoaderService.classForName( custom.toString() );
+			}
 
-		final Class<? extends MutationExecutorService> customImplClass;
-		if ( custom instanceof Class ) {
-			//noinspection unchecked
-			customImplClass = (Class<? extends MutationExecutorService>) custom;
+			try {
+				return customImplClass.getConstructor().newInstance();
+			}
+			catch (NoSuchMethodException e) {
+				throw new HibernateException(
+						"Could not locate appropriate MutationExecutorService constructor : " + customImplClass.getName(),
+						e );
+			}
+			catch (Exception e) {
+				throw new HibernateException(
+						"Unable to instantiate custom MutationExecutorService : " + customImplClass.getName(), e );
+			}
+		}
+	}
+
+	private static MutationExecutorService discover(ClassLoaderService classLoaderService) {
+		final var discovered = classLoaderService.loadJavaServices( MutationExecutorService.class );
+		final var iterator = discovered.iterator();
+		if ( iterator.hasNext() ) {
+			final var selected = iterator.next();
+			if ( iterator.hasNext() ) {
+				throw new HibernateException(
+						"Multiple MutationExecutorService service registrations found via ServiceLoader; "
+						+ "specify one explicitly via '" + EXECUTOR_KEY + "'" );
+			}
+			return selected;
 		}
 		else {
-			customImplClass = registry.requireService( ClassLoaderService.class ).classForName( custom.toString() );
-		}
-
-		try {
-			return customImplClass.getConstructor().newInstance();
-		}
-		catch (NoSuchMethodException e) {
-			throw new HibernateException( "Could not locate appropriate MutationExecutorService constructor : " + customImplClass.getName(), e );
-		}
-		catch (Exception e) {
-			throw new HibernateException( "Unable to instantiate custom MutationExecutorService : " + customImplClass.getName(), e );
+			return null;
 		}
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/engine/jdbc/mutation/spi/MutationExecutorService.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/jdbc/mutation/spi/MutationExecutorService.java
@@ -6,14 +6,21 @@ package org.hibernate.engine.jdbc.mutation.spi;
 
 import org.hibernate.engine.jdbc.mutation.MutationExecutor;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
+import org.hibernate.service.JavaServiceLoadable;
 import org.hibernate.service.Service;
 import org.hibernate.sql.model.MutationOperationGroup;
 
 /**
- * Service for creating executors for model mutation operations
+ * Service for creating executors for model mutation operations.
+ * <p>
+ * A custom {@code MutationExecutorService} may be selected either by setting the
+ * configuration property
+ * {@value org.hibernate.engine.jdbc.mutation.internal.MutationExecutorServiceInitiator#EXECUTOR_KEY},
+ * or by registering it as a {@linkplain java.util.ServiceLoader Java service}.
  *
  * @author Steve Ebersole
  */
+@JavaServiceLoadable
 public interface MutationExecutorService extends Service {
 
 	/**

--- a/hibernate-core/src/main/java/org/hibernate/stat/internal/StatisticsInitiator.java
+++ b/hibernate-core/src/main/java/org/hibernate/stat/internal/StatisticsInitiator.java
@@ -47,15 +47,16 @@ public class StatisticsInitiator implements SessionFactoryServiceInitiator<Stati
 
 	private static StatisticsFactory statisticsFactory(
 			@Nullable Object configValue, ServiceRegistryImplementor registry) {
+		final var classLoaderService = registry.requireService( ClassLoaderService.class );
 		if ( configValue == null ) {
-			return StatisticsImpl::new; // Use the default implementation
+			final var discovered = discover( classLoaderService );
+			return discovered != null ? discovered : StatisticsImpl::new;
 		}
 		else if ( configValue instanceof StatisticsFactory factory ) {
 			return factory;
 		}
 		else {
 			// assume it names the factory class
-			final var classLoaderService = registry.requireService( ClassLoaderService.class );
 			try {
 				return (StatisticsFactory)
 						classLoaderService.classForName( configValue.toString() )
@@ -70,6 +71,23 @@ public class StatisticsInitiator implements SessionFactoryServiceInitiator<Stati
 						e
 				);
 			}
+		}
+	}
+
+	private static @Nullable StatisticsFactory discover(ClassLoaderService classLoaderService) {
+		final var discovered = classLoaderService.loadJavaServices( StatisticsFactory.class );
+		final var iterator = discovered.iterator();
+		if ( iterator.hasNext() ) {
+			final StatisticsFactory selected = iterator.next();
+			if ( iterator.hasNext() ) {
+				throw new HibernateException(
+						"Multiple StatisticsFactory service registrations found via ServiceLoader; "
+						+ "specify one explicitly via '" + STATS_BUILDER + "'" );
+			}
+			return selected;
+		}
+		else {
+			return null;
 		}
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/stat/spi/StatisticsFactory.java
+++ b/hibernate-core/src/main/java/org/hibernate/stat/spi/StatisticsFactory.java
@@ -5,15 +5,18 @@
 package org.hibernate.stat.spi;
 
 import org.hibernate.engine.spi.SessionFactoryImplementor;
+import org.hibernate.service.JavaServiceLoadable;
 
 /**
  * Factory for custom implementations of {@link StatisticsImplementor}.
  * <p>
- * A custom implementation may be selected via the configuration property
- * {@value org.hibernate.cfg.StatisticsSettings#STATS_BUILDER}.
+ * A custom implementation may be selected either by setting the configuration
+ * property {@value org.hibernate.cfg.StatisticsSettings#STATS_BUILDER}, or by
+ * registering it as a {@linkplain java.util.ServiceLoader Java service}.
  *
  * @author Steve Ebersole
  */
+@JavaServiceLoadable
 public interface StatisticsFactory {
 	StatisticsImplementor buildStatistics(SessionFactoryImplementor sessionFactory);
 }

--- a/hibernate-core/src/main/java/org/hibernate/tool/schema/internal/SchemaManagementToolInitiator.java
+++ b/hibernate-core/src/main/java/org/hibernate/tool/schema/internal/SchemaManagementToolInitiator.java
@@ -6,7 +6,9 @@ package org.hibernate.tool.schema.internal;
 
 import java.util.Map;
 
+import org.hibernate.HibernateException;
 import org.hibernate.boot.registry.StandardServiceInitiator;
+import org.hibernate.boot.registry.classloading.spi.ClassLoaderService;
 import org.hibernate.boot.registry.selector.spi.StrategySelector;
 import org.hibernate.engine.jdbc.spi.JdbcServices;
 import org.hibernate.service.spi.ServiceRegistryImplementor;
@@ -25,8 +27,31 @@ public class SchemaManagementToolInitiator implements StandardServiceInitiator<S
 		return registry.requireService( StrategySelector.class )
 				.<SchemaManagementTool>resolveDefaultableStrategy( SchemaManagementTool.class,
 						configurationValues.get( SCHEMA_MANAGEMENT_TOOL ),
-						() -> registry.requireService( JdbcServices.class ).getDialect()
-								.getFallbackSchemaManagementTool( configurationValues, registry ) );
+						() -> {
+							final var discovered = discover( registry.requireService( ClassLoaderService.class ) );
+							if ( discovered != null ) {
+								return discovered;
+							}
+							return registry.requireService( JdbcServices.class ).getDialect()
+									.getFallbackSchemaManagementTool( configurationValues, registry );
+						} );
+	}
+
+	private static SchemaManagementTool discover(ClassLoaderService classLoaderService) {
+		final var discovered = classLoaderService.loadJavaServices( SchemaManagementTool.class );
+		final var iterator = discovered.iterator();
+		if ( iterator.hasNext() ) {
+			final var selected = iterator.next();
+			if ( iterator.hasNext() ) {
+				throw new HibernateException(
+						"Multiple SchemaManagementTool service registrations found via ServiceLoader; "
+						+ "specify one explicitly via '" + SCHEMA_MANAGEMENT_TOOL + "'" );
+			}
+			return selected;
+		}
+		else {
+			return null;
+		}
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/tool/schema/spi/SchemaManagementTool.java
+++ b/hibernate-core/src/main/java/org/hibernate/tool/schema/spi/SchemaManagementTool.java
@@ -7,15 +7,22 @@ package org.hibernate.tool.schema.spi;
 import java.util.Map;
 
 import org.hibernate.Incubating;
+import org.hibernate.service.JavaServiceLoadable;
 import org.hibernate.service.Service;
 import org.hibernate.tool.schema.internal.exec.JdbcContext;
 
 /**
  * Contract for schema management tool integration.
+ * <p>
+ * A custom {@code SchemaManagementTool} may be selected either by setting the
+ * configuration property
+ * {@value org.hibernate.cfg.SchemaToolingSettings#SCHEMA_MANAGEMENT_TOOL}, or by
+ * registering it as a {@linkplain java.util.ServiceLoader Java service}.
  *
  * @author Steve Ebersole
  */
 @Incubating
+@JavaServiceLoadable
 public interface SchemaManagementTool extends Service {
 	SchemaCreator getSchemaCreator(Map<String,Object> options);
 	SchemaDropper getSchemaDropper(Map<String,Object> options);

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/service/javaservice/BatchBuilderPropertyOverridesServiceLoaderTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/service/javaservice/BatchBuilderPropertyOverridesServiceLoaderTest.java
@@ -1,0 +1,70 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.service.javaservice;
+
+import java.util.function.Supplier;
+
+import org.hibernate.engine.jdbc.batch.spi.Batch;
+import org.hibernate.engine.jdbc.batch.spi.BatchBuilder;
+import org.hibernate.engine.jdbc.batch.spi.BatchKey;
+import org.hibernate.engine.jdbc.mutation.group.PreparedStatementGroup;
+import org.hibernate.engine.jdbc.spi.JdbcCoordinator;
+
+import org.hibernate.testing.orm.junit.BootstrapServiceRegistry;
+import org.hibernate.testing.orm.junit.JiraKey;
+import org.hibernate.testing.orm.junit.ServiceRegistry;
+import org.hibernate.testing.orm.junit.ServiceRegistryScope;
+import org.hibernate.testing.orm.junit.Setting;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Verifies that an explicitly configured {@value org.hibernate.cfg.BatchSettings#BUILDER}
+ * takes precedence over a {@link BatchBuilder} registered via Java service loader.
+ */
+@JiraKey("HHH-18938")
+@BootstrapServiceRegistry(
+		javaServices = @BootstrapServiceRegistry.JavaService(
+				role = BatchBuilder.class,
+				impl = BatchBuilderPropertyOverridesServiceLoaderTest.ServiceLoaderBatchBuilder.class
+		)
+)
+@ServiceRegistry(
+		settings = @Setting(
+				name = "hibernate.jdbc.batch.builder",
+				value = "org.hibernate.orm.test.service.javaservice.BatchBuilderPropertyOverridesServiceLoaderTest$PropertyBatchBuilder"
+		)
+)
+public class BatchBuilderPropertyOverridesServiceLoaderTest {
+
+	@Test
+	void testPropertyWinsOverServiceLoader(ServiceRegistryScope scope) {
+		final BatchBuilder batchBuilder = scope.getRegistry().requireService( BatchBuilder.class );
+		assertThat( batchBuilder ).isInstanceOf( PropertyBatchBuilder.class );
+	}
+
+	public static class PropertyBatchBuilder implements BatchBuilder {
+		@Override
+		public Batch buildBatch(
+				BatchKey key,
+				Integer batchSize,
+				Supplier<PreparedStatementGroup> statementGroupSupplier,
+				JdbcCoordinator jdbcCoordinator) {
+			throw new UnsupportedOperationException();
+		}
+	}
+
+	public static class ServiceLoaderBatchBuilder implements BatchBuilder {
+		@Override
+		public Batch buildBatch(
+				BatchKey key,
+				Integer batchSize,
+				Supplier<PreparedStatementGroup> statementGroupSupplier,
+				JdbcCoordinator jdbcCoordinator) {
+			throw new UnsupportedOperationException();
+		}
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/service/javaservice/BatchBuilderServiceLoaderTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/service/javaservice/BatchBuilderServiceLoaderTest.java
@@ -1,0 +1,54 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.service.javaservice;
+
+import java.util.function.Supplier;
+
+import org.hibernate.engine.jdbc.batch.spi.Batch;
+import org.hibernate.engine.jdbc.batch.spi.BatchBuilder;
+import org.hibernate.engine.jdbc.batch.spi.BatchKey;
+import org.hibernate.engine.jdbc.mutation.group.PreparedStatementGroup;
+import org.hibernate.engine.jdbc.spi.JdbcCoordinator;
+
+import org.hibernate.testing.orm.junit.BootstrapServiceRegistry;
+import org.hibernate.testing.orm.junit.JiraKey;
+import org.hibernate.testing.orm.junit.ServiceRegistry;
+import org.hibernate.testing.orm.junit.ServiceRegistryScope;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Verifies that a {@link BatchBuilder} supplied via the Java service loader
+ * mechanism is picked up by {@code BatchBuilderInitiator} when no explicit
+ * {@value org.hibernate.cfg.BatchSettings#BUILDER} setting is configured.
+ */
+@JiraKey("HHH-18938")
+@BootstrapServiceRegistry(
+		javaServices = @BootstrapServiceRegistry.JavaService(
+				role = BatchBuilder.class,
+				impl = BatchBuilderServiceLoaderTest.CustomBatchBuilder.class
+		)
+)
+@ServiceRegistry
+public class BatchBuilderServiceLoaderTest {
+
+	@Test
+	void testServiceLoaderDiscovery(ServiceRegistryScope scope) {
+		final BatchBuilder batchBuilder = scope.getRegistry().requireService( BatchBuilder.class );
+		assertThat( batchBuilder ).isInstanceOf( CustomBatchBuilder.class );
+	}
+
+	public static class CustomBatchBuilder implements BatchBuilder {
+		@Override
+		public Batch buildBatch(
+				BatchKey key,
+				Integer batchSize,
+				Supplier<PreparedStatementGroup> statementGroupSupplier,
+				JdbcCoordinator jdbcCoordinator) {
+			throw new UnsupportedOperationException( "Not needed for bootstrap test" );
+		}
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/service/javaservice/MutationExecutorServiceLoaderTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/service/javaservice/MutationExecutorServiceLoaderTest.java
@@ -1,0 +1,52 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.service.javaservice;
+
+import org.hibernate.engine.jdbc.mutation.MutationExecutor;
+import org.hibernate.engine.jdbc.mutation.spi.BatchKeyAccess;
+import org.hibernate.engine.jdbc.mutation.spi.MutationExecutorService;
+import org.hibernate.engine.spi.SharedSessionContractImplementor;
+import org.hibernate.sql.model.MutationOperationGroup;
+
+import org.hibernate.testing.orm.junit.BootstrapServiceRegistry;
+import org.hibernate.testing.orm.junit.JiraKey;
+import org.hibernate.testing.orm.junit.ServiceRegistry;
+import org.hibernate.testing.orm.junit.ServiceRegistryScope;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Verifies that a {@link MutationExecutorService} supplied via the Java service
+ * loader mechanism is picked up by {@code MutationExecutorServiceInitiator}
+ * when no explicit {@code hibernate.jdbc.mutation.executor} setting is configured.
+ */
+@JiraKey("HHH-18938")
+@BootstrapServiceRegistry(
+		javaServices = @BootstrapServiceRegistry.JavaService(
+				role = MutationExecutorService.class,
+				impl = MutationExecutorServiceLoaderTest.CustomMutationExecutorService.class
+		)
+)
+@ServiceRegistry
+public class MutationExecutorServiceLoaderTest {
+
+	@Test
+	void testServiceLoaderDiscovery(ServiceRegistryScope scope) {
+		final MutationExecutorService service =
+				scope.getRegistry().requireService( MutationExecutorService.class );
+		assertThat( service ).isInstanceOf( CustomMutationExecutorService.class );
+	}
+
+	public static class CustomMutationExecutorService implements MutationExecutorService {
+		@Override
+		public MutationExecutor createExecutor(
+				BatchKeyAccess batchKeySupplier,
+				MutationOperationGroup operationGroup,
+				SharedSessionContractImplementor session) {
+			throw new UnsupportedOperationException( "Not needed for bootstrap test" );
+		}
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/service/javaservice/SchemaManagementToolServiceLoaderTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/service/javaservice/SchemaManagementToolServiceLoaderTest.java
@@ -1,0 +1,77 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.service.javaservice;
+
+import java.util.Map;
+
+import org.hibernate.tool.schema.spi.ExtractionTool;
+import org.hibernate.tool.schema.spi.GenerationTarget;
+import org.hibernate.tool.schema.spi.SchemaCreator;
+import org.hibernate.tool.schema.spi.SchemaDropper;
+import org.hibernate.tool.schema.spi.SchemaManagementTool;
+import org.hibernate.tool.schema.spi.SchemaMigrator;
+import org.hibernate.tool.schema.spi.SchemaValidator;
+
+import org.hibernate.testing.orm.junit.BootstrapServiceRegistry;
+import org.hibernate.testing.orm.junit.JiraKey;
+import org.hibernate.testing.orm.junit.ServiceRegistry;
+import org.hibernate.testing.orm.junit.ServiceRegistryScope;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Verifies that a {@link SchemaManagementTool} supplied via the Java service
+ * loader mechanism is picked up by {@code SchemaManagementToolInitiator} when
+ * no explicit {@value org.hibernate.cfg.SchemaToolingSettings#SCHEMA_MANAGEMENT_TOOL}
+ * setting is configured.
+ */
+@JiraKey("HHH-18938")
+@BootstrapServiceRegistry(
+		javaServices = @BootstrapServiceRegistry.JavaService(
+				role = SchemaManagementTool.class,
+				impl = SchemaManagementToolServiceLoaderTest.CustomSchemaManagementTool.class
+		)
+)
+@ServiceRegistry
+public class SchemaManagementToolServiceLoaderTest {
+
+	@Test
+	void testServiceLoaderDiscovery(ServiceRegistryScope scope) {
+		final SchemaManagementTool tool = scope.getRegistry().requireService( SchemaManagementTool.class );
+		assertThat( tool ).isInstanceOf( CustomSchemaManagementTool.class );
+	}
+
+	public static class CustomSchemaManagementTool implements SchemaManagementTool {
+		@Override
+		public SchemaCreator getSchemaCreator(Map<String, Object> options) {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public SchemaDropper getSchemaDropper(Map<String, Object> options) {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public SchemaMigrator getSchemaMigrator(Map<String, Object> options) {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public SchemaValidator getSchemaValidator(Map<String, Object> options) {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public void setCustomDatabaseGenerationTarget(GenerationTarget generationTarget) {
+		}
+
+		@Override
+		public ExtractionTool getExtractionTool() {
+			return null;
+		}
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/service/javaservice/StatisticsFactoryServiceLoaderTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/service/javaservice/StatisticsFactoryServiceLoaderTest.java
@@ -1,0 +1,55 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.service.javaservice;
+
+import org.hibernate.engine.spi.SessionFactoryImplementor;
+import org.hibernate.stat.internal.StatisticsImpl;
+import org.hibernate.stat.spi.StatisticsFactory;
+import org.hibernate.stat.spi.StatisticsImplementor;
+
+import org.hibernate.testing.orm.junit.BootstrapServiceRegistry;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.JiraKey;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Verifies that a {@link StatisticsFactory} supplied via the Java service loader
+ * mechanism is picked up by {@code StatisticsInitiator} when no explicit
+ * {@value org.hibernate.cfg.StatisticsSettings#STATS_BUILDER} setting is configured.
+ */
+@JiraKey("HHH-18938")
+@BootstrapServiceRegistry(
+		javaServices = @BootstrapServiceRegistry.JavaService(
+				role = StatisticsFactory.class,
+				impl = StatisticsFactoryServiceLoaderTest.CustomStatisticsFactory.class
+		)
+)
+@DomainModel
+@SessionFactory
+public class StatisticsFactoryServiceLoaderTest {
+
+	@Test
+	void testServiceLoaderDiscovery(SessionFactoryScope scope) {
+		final StatisticsImplementor statistics = scope.getSessionFactory().getStatistics();
+		assertThat( statistics ).isInstanceOf( MarkerStatistics.class );
+	}
+
+	public static class CustomStatisticsFactory implements StatisticsFactory {
+		@Override
+		public StatisticsImplementor buildStatistics(SessionFactoryImplementor sessionFactory) {
+			return new MarkerStatistics( sessionFactory );
+		}
+	}
+
+	public static class MarkerStatistics extends StatisticsImpl {
+		public MarkerStatistics(SessionFactoryImplementor sessionFactory) {
+			super( sessionFactory );
+		}
+	}
+}


### PR DESCRIPTION
let these components be loaded via the service loader mechanism

<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

[Please describe here what your change is about]

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------


---
<!-- Hibernate GitHub Bot task list start -->
Please make sure that the following tasks are completed:
Tasks specific to HHH-18938 (Improvement):
- [ ] Add tests for feature/improvement
- [ ] Update documentation as relevant: javadoc for changed API, `documentation/src/main/asciidoc/userguide` for all features, `documentation/src/main/asciidoc/introduction` for main features, links from existing documentation
- [ ] Add entries as relevant to `migration-guide.adoc` (breaking changes) and `whats-new.adoc` (new features/improvements)


<!-- Hibernate GitHub Bot task list end -->

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-18938
<!-- Hibernate GitHub Bot issue links end -->