### PR TITLE
HHH-20023 allow batching with generated keys on MySQL

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/action/internal/EntityIdentityInsertAction.java
+++ b/hibernate-core/src/main/java/org/hibernate/action/internal/EntityIdentityInsertAction.java
@@ -64,6 +64,12 @@ public class EntityIdentityInsertAction extends AbstractEntityInsertAction  {
 		this.delayedEntityKey = isDelayed ? generateDelayedEntityKey() : null;
 	}
 
+	private static Object getGeneratedId(GeneratedValues generatedValues, EntityPersister persister) {
+		return generatedValues == null
+				? null
+				: generatedValues.getGeneratedValue( persister.getIdentifierMapping() );
+	}
+
 	@Override
 	public void execute() throws HibernateException {
 		nullifyTransientReferencesIfNotAlready();
@@ -77,28 +83,61 @@ public class EntityIdentityInsertAction extends AbstractEntityInsertAction  {
 		// Don't need to lock the cache here, since if someone
 		// else inserted the same pk first, the insert would fail
 
-		if ( !isVeto() ) {
+		if ( isVeto() ) {
+			afterInsert( null );
+		}
+		else {
 			final var eventMonitor = session.getEventMonitor();
 			final var event = eventMonitor.beginEntityInsertEvent();
-			boolean success = false;
 			final Object[] state = getState();
-			final GeneratedValues generatedValues;
-			try {
-				generatedValues = persister.getInsertCoordinator().insert( instance, state, session );
-				generatedId =
-						generatedValues == null
-								? null
-								: generatedValues.getGeneratedValue( persister.getIdentifierMapping() );
-				success = true;
+			final String entityName = persister.getEntityName();
+			if ( canDeferInsert( persister ) ) {
+				// deferred path: enqueue into the batch with a per-slot id consumer;
+				// the post-execute work runs asynchronously when the batch is flushed
+				persister.getInsertCoordinator().insertDeferred(
+						instance,
+						state,
+						id -> {
+							eventMonitor.completeEntityInsertEvent( event, id, entityName, true, session );
+							afterIdentityBatchInsert( id );
+						},
+						session
+				);
 			}
-			finally {
-				eventMonitor.completeEntityInsertEvent( event, generatedId, persister.getEntityName(), success, session );
+			else {
+				boolean success = false;
+				final GeneratedValues generatedValues;
+				try {
+					generatedValues = persister.getInsertCoordinator().insert( instance, state, session );
+					generatedId = getGeneratedId( generatedValues, persister );
+					success = true;
+				}
+				finally {
+					eventMonitor.completeEntityInsertEvent( event, generatedId, entityName, success, session );
+				}
+				afterInsert( generatedValues );
 			}
-			final var persistenceContext = session.getPersistenceContextInternal();
-			if ( persister.getRowIdMapping() != null ) {
-				rowId = generatedValues.getGeneratedValue( persister.getRowIdMapping() );
+		}
+	}
+
+	private boolean canDeferInsert(EntityPersister persister) {
+		return !isEarlyInsert()
+			&& persister.getInsertCoordinator().canBatchGeneratedIdentityInserts();
+	}
+
+	private void afterInsert(GeneratedValues generatedValues) {
+		if ( !isVeto() ) {
+			final var persister = getPersister();
+			final var session = getSession();
+			final Object instance = getInstance();
+			final Object[] state = getState();
+			generatedId = getGeneratedId( generatedValues, persister );
+			final var rowIdMapping = persister.getRowIdMapping();
+			if ( rowIdMapping != null && generatedValues != null ) {
+				rowId = generatedValues.getGeneratedValue( rowIdMapping );
 				if ( rowId != null && isDelayed ) {
-					persistenceContext.replaceEntityEntryRowId( getInstance(), rowId );
+					session.getPersistenceContextInternal()
+							.replaceEntityEntryRowId( instance, rowId );
 				}
 			}
 			if ( generatedId == null && generatedValues != null ) {
@@ -114,12 +153,34 @@ public class EntityIdentityInsertAction extends AbstractEntityInsertAction  {
 			if ( generatedId == null ) {
 				generatedId = persister.getIdentifier( instance, session );
 			}
-			//need to do that here rather than in the save event listener to let
-			//the post insert events to have an id-filled entity when IDENTITY is used (EJB3)
+		}
+		finishExecution();
+	}
+
+	private void afterIdentityBatchInsert(Object generatedId) {
+		if ( !isVeto() ) {
+			this.generatedId = generatedId;
+		}
+		finishExecution();
+	}
+
+	private void finishExecution() {
+		final var persister = getPersister();
+		final var session = getSession();
+
+		if ( !isVeto() ) {
+			final var persistenceContext = session.getPersistenceContextInternal();
+			final Object instance = getInstance();
+			// need to do that here rather than in the save event listener to let
+			// the post insert events to have an id-filled entity when IDENTITY is used
 			persister.setIdentifier( instance, generatedId, session );
 			persistenceContext.registerInsertedKey( persister, generatedId );
 			entityKey = session.generateEntityKey( generatedId, persister );
-			persistenceContext.checkUniqueness( entityKey, getInstance() );
+			persistenceContext.checkUniqueness( entityKey, instance );
+			if ( !isEarlyInsert() ) {
+				addCollectionsByKeyToPersistenceContext( persistenceContext, getState() );
+			}
+			handleNaturalIdPostSaveNotifications( generatedId );
 		}
 
 		//TODO: this bit actually has to be called after all cascades!
@@ -168,7 +229,7 @@ public class EntityIdentityInsertAction extends AbstractEntityInsertAction  {
 	}
 
 	protected void postInsert() {
-		if ( isDelayed ) {
+		if ( isDelayed && generatedId != null ) {
 			getSession().getPersistenceContextInternal()
 					.replaceDelayedEntityIdentityInsertKeys( delayedEntityKey, generatedId );
 		}

--- a/hibernate-core/src/main/java/org/hibernate/boot/internal/SessionFactoryOptionsBuilder.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/internal/SessionFactoryOptionsBuilder.java
@@ -172,6 +172,7 @@ public class SessionFactoryOptionsBuilder implements SessionFactoryOptions {
 	private Nulls defaultNullPrecedence;
 	private boolean orderUpdatesEnabled;
 	private boolean orderInsertsEnabled;
+	private boolean batchIdentityInsertsEnabled;
 	private boolean collectionsInDefaultFetchGroupEnabled = true;
 	private final boolean unownedAssociationTransientCheck;
 	private final boolean passProcedureParameterNames;
@@ -395,6 +396,7 @@ public class SessionFactoryOptionsBuilder implements SessionFactoryOptions {
 
 		orderUpdatesEnabled = getBoolean( ORDER_UPDATES, settings );
 		orderInsertsEnabled = getBoolean( ORDER_INSERTS, settings );
+		batchIdentityInsertsEnabled = getBoolean( BATCH_IDENTITY_INSERTS, settings );
 
 		callbacksEnabled = getBoolean( JPA_CALLBACKS_ENABLED, settings, true );
 
@@ -1201,6 +1203,11 @@ public class SessionFactoryOptionsBuilder implements SessionFactoryOptions {
 	@Override
 	public boolean isOrderInsertsEnabled() {
 		return orderInsertsEnabled;
+	}
+
+	@Override
+	public boolean isBatchIdentityInsertsEnabled() {
+		return batchIdentityInsertsEnabled;
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/boot/spi/AbstractDelegatingSessionFactoryOptions.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/spi/AbstractDelegatingSessionFactoryOptions.java
@@ -231,6 +231,11 @@ public class AbstractDelegatingSessionFactoryOptions implements SessionFactoryOp
 	}
 
 	@Override
+	public boolean isBatchIdentityInsertsEnabled() {
+		return delegate.isBatchIdentityInsertsEnabled();
+	}
+
+	@Override
 	public boolean isMultiTenancyEnabled() {
 		return delegate.isMultiTenancyEnabled();
 	}

--- a/hibernate-core/src/main/java/org/hibernate/boot/spi/SessionFactoryOptions.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/spi/SessionFactoryOptions.java
@@ -301,6 +301,11 @@ public interface SessionFactoryOptions extends QueryEngineOptions {
 	boolean isOrderInsertsEnabled();
 
 	/**
+	 * @see org.hibernate.cfg.BatchSettings#BATCH_IDENTITY_INSERTS
+	 */
+	boolean isBatchIdentityInsertsEnabled();
+
+	/**
 	 * Is there a
 	 * {@linkplain org.hibernate.engine.jdbc.connections.spi.MultiTenantConnectionProvider
 	 * multi-tenant connection provider} configured?

--- a/hibernate-core/src/main/java/org/hibernate/cfg/BatchSettings.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/BatchSettings.java
@@ -66,6 +66,19 @@ public interface BatchSettings {
 	String ORDER_INSERTS = "hibernate.order_inserts";
 
 	/**
+	 * Allow delayed execution of {@code IDENTITY} inserts inside a transaction when
+	 * the dialect can batch the insert statements and read the generated identifiers
+	 * back via {@link PreparedStatement#getGeneratedKeys()}.
+	 * <p>
+	 * This setting is disabled by default because it changes when identifiers become
+	 * visible to user code: with this setting enabled, the identifier might remain
+	 * {@code null} until flush time.
+	 *
+	 * @settingDefault {@code false}
+	 */
+	String BATCH_IDENTITY_INSERTS = "hibernate.jdbc.batch_identity_inserts";
+
+	/**
 	 * @deprecated Use {@link #BUILDER} instead
 	 */
 	@Deprecated(since="6.4")

--- a/hibernate-core/src/main/java/org/hibernate/dialect/Dialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/Dialect.java
@@ -4808,6 +4808,17 @@ public abstract class Dialect implements ConversionContext, TypeContributor, Fun
 	}
 
 	/**
+	 * Does this dialect support batching {@code insert} statements while still being
+	 * able to retrieve every generated identity value via
+	 * {@link PreparedStatement#getGeneratedKeys()}.
+	 *
+	 * @since 7.3
+	 */
+	public boolean supportsBatchInsertReturningGeneratedKeys() {
+		return false;
+	}
+
+	/**
 	 * Does this dialect require unquoting identifiers when passing them to the
 	 * {@link Connection#prepareStatement(String, String[])} JDBC method.
 	 *

--- a/hibernate-core/src/main/java/org/hibernate/dialect/MariaDBDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/MariaDBDialect.java
@@ -104,6 +104,11 @@ public class MariaDBDialect extends MySQLDialect {
 	}
 
 	@Override
+	public boolean supportsBatchInsertReturningGeneratedKeys() {
+		return false;
+	}
+
+	@Override
 	public DatabaseVersion getMySQLVersion() {
 		return MYSQL57;
 	}

--- a/hibernate-core/src/main/java/org/hibernate/dialect/MySQLDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/MySQLDialect.java
@@ -234,6 +234,11 @@ public class MySQLDialect extends Dialect {
 		registerKeywords( info );
 	}
 
+	@Override
+	public boolean supportsBatchInsertReturningGeneratedKeys() {
+		return true;
+	}
+
 	@Deprecated(since="6.6")
 	protected static DatabaseVersion createVersion(DialectResolutionInfo info) {
 		return createVersion( info, MINIMUM_VERSION );

--- a/hibernate-core/src/main/java/org/hibernate/engine/jdbc/batch/internal/BatchImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/jdbc/batch/internal/BatchImpl.java
@@ -4,8 +4,12 @@
  */
 package org.hibernate.engine.jdbc.batch.internal;
 
+import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.util.ArrayList;
 import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.function.Consumer;
 
 import org.hibernate.HibernateException;
 import org.hibernate.StaleStateException;
@@ -46,6 +50,7 @@ public class BatchImpl implements Batch {
 	private int batchPosition;
 	private boolean batchExecuted;
 	private StaleStateMapper[] staleStateMappers;
+	private List<Consumer<Object>> generatedKeyConsumers;
 
 	public BatchImpl(
 			BatchKey key,
@@ -98,6 +103,17 @@ public class BatchImpl implements Batch {
 			}
 			staleStateMappers[batchPosition] = staleStateMapper;
 		}
+		addToBatch( jdbcValueBindings, inclusionChecker );
+	}
+
+	@Override
+	public void addToBatch(
+			JdbcValueBindings jdbcValueBindings, TableInclusionChecker inclusionChecker,
+			Consumer<Object> generatedKeyConsumer) {
+		if ( generatedKeyConsumers == null ) {
+			generatedKeyConsumers = new ArrayList<>( batchSizeToUse );
+		}
+		generatedKeyConsumers.add( generatedKeyConsumer );
 		addToBatch( jdbcValueBindings, inclusionChecker );
 	}
 
@@ -266,6 +282,7 @@ public class BatchImpl implements Batch {
 								eventHandler.jdbcExecuteBatchEnd();
 							}
 							checkRowCounts( rowCounts, statementDetails );
+							dispatchGeneratedKeys( statement, sql );
 						}
 						else {
 							statement.executeBatch();
@@ -286,6 +303,32 @@ public class BatchImpl implements Batch {
 		finally {
 			jdbcCoordinator.afterStatementExecution();
 			batchPosition = 0;
+			generatedKeyConsumers = null;
+		}
+	}
+
+	private void dispatchGeneratedKeys(java.sql.PreparedStatement statement, String sql) throws SQLException {
+		if ( generatedKeyConsumers == null || generatedKeyConsumers.isEmpty() ) {
+			return;
+		}
+		final int expected = generatedKeyConsumers.size();
+		try ( ResultSet keys = statement.getGeneratedKeys() ) {
+			if ( keys == null ) {
+				throw new HibernateException(
+						"The database returned no generated keys for batched insert: " + sql );
+			}
+			int i = 0;
+			while ( keys.next() ) {
+				if ( i >= expected ) {
+					throw new HibernateException(
+							"More generated keys than batched rows for insert: " + sql );
+				}
+				generatedKeyConsumers.get( i++ ).accept( keys.getObject( 1 ) );
+			}
+			if ( i != expected ) {
+				throw new HibernateException(
+						"Expected " + expected + " generated keys but got " + i + " for insert: " + sql );
+			}
 		}
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/engine/jdbc/batch/spi/Batch.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/jdbc/batch/spi/Batch.java
@@ -5,6 +5,7 @@
 package org.hibernate.engine.jdbc.batch.spi;
 
 import java.sql.PreparedStatement;
+import java.util.function.Consumer;
 import java.util.function.Supplier;
 
 import org.hibernate.HibernateException;
@@ -56,6 +57,21 @@ public interface Batch {
 	 * of the current part of the batch.
 	 */
 	void addToBatch(JdbcValueBindings jdbcValueBindings, TableInclusionChecker inclusionChecker, StaleStateMapper staleStateMapper);
+
+	/**
+	 * Apply the value bindings to the batch JDBC statements and register a
+	 * per-slot consumer to receive the value produced by
+	 * {@link PreparedStatement#getGeneratedKeys()} after the batch executes.
+	 * <p>
+	 * The consumer is invoked in {@code addBatch} order when the batch is flushed.
+	 * Implementations that do not know how to retrieve generated keys may fail
+	 * at execution time; callers are responsible for ensuring the batch was
+	 * prepared with a delegate that supports generated-key retrieval.
+	 */
+	void addToBatch(
+			JdbcValueBindings jdbcValueBindings,
+			TableInclusionChecker inclusionChecker,
+			Consumer<Object> generatedKeyConsumer);
 
 	@FunctionalInterface
 	interface StaleStateMapper {

--- a/hibernate-core/src/main/java/org/hibernate/engine/jdbc/mutation/internal/MutationExecutorSingleBatched.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/jdbc/mutation/internal/MutationExecutorSingleBatched.java
@@ -4,10 +4,13 @@
  */
 package org.hibernate.engine.jdbc.mutation.internal;
 
+import java.util.function.Consumer;
+
 import org.hibernate.engine.jdbc.batch.spi.Batch;
 import org.hibernate.engine.jdbc.batch.spi.BatchKey;
 import org.hibernate.engine.jdbc.mutation.TableInclusionChecker;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
+import org.hibernate.generator.values.GeneratedValuesMutationDelegate;
 import org.hibernate.sql.model.PreparableMutationOperation;
 import org.hibernate.sql.model.ValuesAnalysis;
 
@@ -19,9 +22,21 @@ public class MutationExecutorSingleBatched extends AbstractSingleMutationExecuto
 	private final SharedSessionContractImplementor session;
 
 	private final BatchKey batchKey;
+	private final GeneratedValuesMutationDelegate generatedValuesDelegate;
+
+	private Consumer<Object> generatedKeyConsumer;
 
 	public MutationExecutorSingleBatched(
 			PreparableMutationOperation mutationOperation,
+			BatchKey batchKey,
+			int batchSize,
+			SharedSessionContractImplementor session) {
+		this( mutationOperation, null, batchKey, batchSize, session );
+	}
+
+	public MutationExecutorSingleBatched(
+			PreparableMutationOperation mutationOperation,
+			GeneratedValuesMutationDelegate generatedValuesDelegate,
 			BatchKey batchKey,
 			int batchSize,
 			SharedSessionContractImplementor session) {
@@ -31,6 +46,22 @@ public class MutationExecutorSingleBatched extends AbstractSingleMutationExecuto
 		this.session = session;
 
 		this.batchKey = batchKey;
+		this.generatedValuesDelegate = generatedValuesDelegate;
+
+		// If the JDBC coordinator already holds a batch keyed differently from
+		// ours, flush it now. This ensures any deferred work (notably batched
+		// identity inserts) completes — and assigns its generated ids — before
+		// we stage binding values that may depend on those ids.
+		session.getJdbcCoordinator().conditionallyExecuteBatch( batchKey );
+	}
+
+	/**
+	 * Register a consumer to receive the generated identifier once the
+	 * batch is flushed. Must be called before
+	 * {@link #execute} on this executor.
+	 */
+	public void setGeneratedKeyConsumer(Consumer<Object> generatedKeyConsumer) {
+		this.generatedKeyConsumer = generatedKeyConsumer;
 	}
 
 	@Override
@@ -45,7 +76,7 @@ public class MutationExecutorSingleBatched extends AbstractSingleMutationExecuto
 			batch = session.getJdbcCoordinator().getBatch(
 					batchKey,
 					batchSize,
-					() -> new PreparedStatementGroupSingleTable( getMutationOperation(), session )
+					() -> new PreparedStatementGroupSingleTable( getMutationOperation(), generatedValuesDelegate, session )
 			);
 			assert batch != null;
 		}
@@ -58,7 +89,12 @@ public class MutationExecutorSingleBatched extends AbstractSingleMutationExecuto
 			ValuesAnalysis valuesAnalysis,
 			TableInclusionChecker inclusionChecker,
 			Batch.StaleStateMapper staleStateMapper) {
-		resolveBatch().addToBatch( getJdbcValueBindings(), inclusionChecker, staleStateMapper );
+		if ( generatedKeyConsumer != null ) {
+			resolveBatch().addToBatch( getJdbcValueBindings(), inclusionChecker, generatedKeyConsumer );
+		}
+		else {
+			resolveBatch().addToBatch( getJdbcValueBindings(), inclusionChecker, staleStateMapper );
+		}
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/engine/jdbc/mutation/internal/StandardMutationExecutorService.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/jdbc/mutation/internal/StandardMutationExecutorService.java
@@ -57,17 +57,19 @@ public class StandardMutationExecutorService implements MutationExecutorService 
 
 			final PreparableMutationOperation jdbcOperation = (PreparableMutationOperation) singleOperation;
 			final BatchKey batchKey = batchKeySupplier.getBatchKey();
+			final var entityGroup = operationGroup.asEntityMutationOperationGroup();
+			final var delegate = entityGroup != null ? entityGroup.getMutationDelegate() : null;
 			if ( jdbcOperation.canBeBatched( batchKey, batchSizeToUse ) ) {
-				return new MutationExecutorSingleBatched( jdbcOperation, batchKey, batchSizeToUse, session );
+				return new MutationExecutorSingleBatched(
+						jdbcOperation,
+						delegate != null && delegate.supportsBatching() ? delegate : null,
+						batchKey,
+						batchSizeToUse,
+						session
+				);
 			}
 
-			return new MutationExecutorSingleNonBatched(
-					jdbcOperation,
-					operationGroup.asEntityMutationOperationGroup() != null ?
-							operationGroup.asEntityMutationOperationGroup().getMutationDelegate() :
-							null,
-					session
-			);
+			return new MutationExecutorSingleNonBatched( jdbcOperation, delegate, session );
 		}
 
 		return new MutationExecutorStandard( operationGroup, batchKeySupplier, batchSizeToUse, session );

--- a/hibernate-core/src/main/java/org/hibernate/engine/spi/ActionQueue.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/spi/ActionQueue.java
@@ -222,6 +222,7 @@ public class ActionQueue implements TransactionCompletionCallbacks {
 
 		public abstract ExecutableList<?> getActions(ActionQueue instance);
 		public abstract void ensureInitialized(ActionQueue instance);
+
 	}
 
 	/**
@@ -416,17 +417,21 @@ public class ActionQueue implements TransactionCompletionCallbacks {
 		registerCleanupActions( action );
 	}
 
-	private void registerCleanupActions(Executable executable) {
+	private void registerCallbacks(Executable executable) {
 		final var beforeCompletionCallback = executable.getBeforeTransactionCompletionProcess();
 		if ( beforeCompletionCallback != null ) {
 			transactionCompletionCallbacks.registerCallback( beforeCompletionCallback );
 		}
-		if ( getSessionFactoryOptions().isQueryCacheEnabled() ) {
-			invalidateSpaces( executable.getPropertySpaces() );
-		}
 		final var afterCompletionCallback = executable.getAfterTransactionCompletionProcess();
 		if ( afterCompletionCallback != null ) {
 			transactionCompletionCallbacks.registerCallback( afterCompletionCallback );
+		}
+	}
+
+	private void registerCleanupActions(Executable executable) {
+		registerCallbacks( executable );
+		if ( getSessionFactoryOptions().isQueryCacheEnabled() ) {
+			invalidateSpaces( executable.getPropertySpaces() );
 		}
 	}
 
@@ -472,9 +477,7 @@ public class ActionQueue implements TransactionCompletionCallbacks {
 	 * @throws HibernateException error executing queued insertion actions.
 	 */
 	public void executeInserts() throws HibernateException {
-		if ( insertions != null && !insertions.isEmpty() ) {
-			executeActions( insertions );
-		}
+		executeActions( OrderedActions.EntityInsertAction );
 	}
 
 	/**
@@ -502,7 +505,7 @@ public class ActionQueue implements TransactionCompletionCallbacks {
 		}
 
 		for ( var action : ORDERED_OPERATIONS ) {
-			executeActions( action.getActions( this ) );
+			executeActions( action );
 		}
 	}
 
@@ -617,49 +620,6 @@ public class ActionQueue implements TransactionCompletionCallbacks {
 	}
 
 	/**
-	 * Perform {@link Executable#execute()} on each element of the list
-	 *
-	 * @param queue The list of Executable elements to be performed
-	 *
-	 */
-	private <E extends ComparableExecutable> void executeActions(@Nullable ExecutableList<E> queue)
-			throws HibernateException {
-		if ( queue != null && !queue.isEmpty() ) {
-			// todo : consider ways to improve the double iteration of Executables here:
-			//		1) we explicitly iterate list here to perform Executable#execute()
-			//		2) ExecutableList#getQuerySpaces also iterates the Executables to collect query spaces.
-			try {
-				for ( var executable : queue ) {
-					try {
-						executable.execute();
-					}
-					finally {
-						final var beforeCompletionProcess = executable.getBeforeTransactionCompletionProcess();
-						if ( beforeCompletionProcess != null ) {
-							transactionCompletionCallbacks.registerCallback( beforeCompletionProcess );
-						}
-						final var afterCompletionProcess = executable.getAfterTransactionCompletionProcess();
-						if ( afterCompletionProcess != null ) {
-							transactionCompletionCallbacks.registerCallback( afterCompletionProcess );
-						}
-					}
-				}
-			}
-			finally {
-				if ( getSessionFactoryOptions().isQueryCacheEnabled() ) {
-					// Strictly speaking, only a subset of the list may have been processed if a RuntimeException occurs.
-					// We still invalidate all spaces. I don't see this as a big deal - after all, RuntimeExceptions are
-					// unexpected.
-					invalidateSpaces( queue.getQuerySpaces().toArray( new String[0] ) );
-				}
-			}
-
-			queue.clear();
-			session.getJdbcCoordinator().executeBatch();
-		}
-	}
-
-	/**
 	 * @param executable The action to execute
 	 */
 	public <E extends Executable & Comparable<?>> void execute(E executable) {
@@ -668,6 +628,29 @@ public class ActionQueue implements TransactionCompletionCallbacks {
 		}
 		finally {
 			registerCleanupActions( executable );
+		}
+	}
+
+	private void executeActions(OrderedActions actions) {
+		final var queue = actions.getActions( this );
+		if ( queue != null && !queue.isEmpty() ) {
+			try {
+				for ( var executable : queue ) {
+					try {
+						executable.execute();
+					}
+					finally {
+						registerCallbacks( executable );
+					}
+				}
+			}
+			finally {
+				if ( getSessionFactoryOptions().isQueryCacheEnabled() ) {
+					invalidateSpaces( queue.getQuerySpaces().toArray( new String[0] ) );
+				}
+			}
+			queue.clear();
+			session.getJdbcCoordinator().executeBatch();
 		}
 	}
 

--- a/hibernate-core/src/main/java/org/hibernate/event/internal/AbstractSaveEventListener.java
+++ b/hibernate-core/src/main/java/org/hibernate/event/internal/AbstractSaveEventListener.java
@@ -138,10 +138,21 @@ public abstract class AbstractSaveEventListener<C> implements CallbackRegistryCo
 			generatedId = persister.getIdentifier( entity, source );
 		}
 		final boolean delayIdentityInserts =
-				!source.isTransactionInProgress()
+				generatedOnExecution
 						&& !requiresImmediateIdAccess
-						&& generatedOnExecution;
+						&& ( !source.isTransactionInProgress()
+								|| shouldDelayIdentityInsertsForBatching( source, persister ) );
 		return performSave( entity, generatedId, persister, generatedOnExecution, context, source, delayIdentityInserts );
+	}
+
+	private static boolean shouldDelayIdentityInsertsForBatching(EventSource source, EntityPersister persister) {
+		if ( !source.getFactory().getSessionFactoryOptions().isBatchIdentityInsertsEnabled() ) {
+			return false;
+		}
+		final Integer batchSize = source.getConfiguredJdbcBatchSize();
+		return batchSize != null
+			&& batchSize > 1
+			&& persister.getInsertCoordinator().canBatchGeneratedIdentityInserts();
 	}
 
 	/**
@@ -325,9 +336,7 @@ public abstract class AbstractSaveEventListener<C> implements CallbackRegistryCo
 	private static Object handleGeneratedId(boolean useIdentityColumn, Object id, AbstractEntityInsertAction insert) {
 		if ( useIdentityColumn && insert.isEarlyInsert() ) {
 			if ( insert instanceof EntityIdentityInsertAction entityIdentityInsertAction ) {
-				final Object generatedId = entityIdentityInsertAction.getGeneratedId();
-				insert.handleNaturalIdPostSaveNotifications( generatedId );
-				return generatedId;
+				return entityIdentityInsertAction.getGeneratedId();
 			}
 			else {
 				throw new IllegalStateException(

--- a/hibernate-core/src/main/java/org/hibernate/generator/values/GeneratedValuesMutationDelegate.java
+++ b/hibernate-core/src/main/java/org/hibernate/generator/values/GeneratedValuesMutationDelegate.java
@@ -69,6 +69,15 @@ public interface GeneratedValuesMutationDelegate {
 	boolean supportsRowId();
 
 	/**
+	 * Returns {@code true} if this delegate supports retrieving generated
+	 * values after a JDBC {@link java.sql.Statement#executeBatch batched execution}
+	 * via {@link PreparedStatement#getGeneratedKeys()}.
+	 */
+	default boolean supportsBatching() {
+		return false;
+	}
+
+	/**
 	 * Retrieve the {@linkplain JdbcValuesMappingProducer mapping producer} used to read the generated values.
 	 */
 	JdbcValuesMappingProducer getGeneratedValuesMappingProducer();

--- a/hibernate-core/src/main/java/org/hibernate/id/insert/GetGeneratedKeysDelegate.java
+++ b/hibernate-core/src/main/java/org/hibernate/id/insert/GetGeneratedKeysDelegate.java
@@ -65,6 +65,11 @@ public class GetGeneratedKeysDelegate extends AbstractReturningDelegate {
 	}
 
 	@Override
+	public boolean supportsBatching() {
+		return dialect().supportsBatchInsertReturningGeneratedKeys();
+	}
+
+	@Override
 	public TableMutationBuilder<?> createTableMutationBuilder(
 			Expectation expectation,
 			SessionFactoryImplementor factory) {

--- a/hibernate-core/src/main/java/org/hibernate/persister/entity/mutation/InsertCoordinator.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/entity/mutation/InsertCoordinator.java
@@ -4,6 +4,8 @@
  */
 package org.hibernate.persister.entity.mutation;
 
+import java.util.function.Consumer;
+
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.generator.values.GeneratedValues;
 
@@ -34,4 +36,23 @@ public interface InsertCoordinator extends MutationCoordinator {
 			Object id,
 			Object[] values,
 			SharedSessionContractImplementor session);
+
+	default boolean canBatchGeneratedIdentityInserts() {
+		return false;
+	}
+
+	/**
+	 * Enqueue an insert into the open JDBC batch and register a consumer
+	 * to receive the generated identifier when the batch is later flushed.
+	 * <p>
+	 * The consumer is invoked in {@code addBatch} order during the batch's
+	 * {@link java.sql.PreparedStatement#executeBatch executeBatch} call.
+	 */
+	default void insertDeferred(
+			Object entity,
+			Object[] values,
+			Consumer<Object> generatedIdConsumer,
+			SharedSessionContractImplementor session) {
+		throw new UnsupportedOperationException( "Generated identity inserts are not batchable" );
+	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/persister/entity/mutation/InsertCoordinatorStandard.java
+++ b/hibernate-core/src/main/java/org/hibernate/persister/entity/mutation/InsertCoordinatorStandard.java
@@ -8,6 +8,7 @@ import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.IdentityHashMap;
 import java.util.List;
+import java.util.function.Consumer;
 
 import org.hibernate.Internal;
 import org.hibernate.dialect.Dialect;
@@ -18,6 +19,7 @@ import org.hibernate.engine.jdbc.mutation.MutationExecutor;
 import org.hibernate.engine.jdbc.mutation.ParameterUsage;
 import org.hibernate.engine.jdbc.mutation.TableInclusionChecker;
 import org.hibernate.engine.jdbc.mutation.group.PreparedStatementDetails;
+import org.hibernate.engine.jdbc.mutation.internal.MutationExecutorSingleBatched;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.generator.BeforeExecutionGenerator;
@@ -25,6 +27,7 @@ import org.hibernate.generator.EventType;
 import org.hibernate.generator.Generator;
 import org.hibernate.generator.OnExecutionGenerator;
 import org.hibernate.generator.values.GeneratedValues;
+import org.hibernate.id.insert.GetGeneratedKeysDelegate;
 import org.hibernate.id.CompositeNestedGeneratedValueGenerator;
 import org.hibernate.metamodel.mapping.AttributeMapping;
 import org.hibernate.metamodel.mapping.PluralAttributeMapping;
@@ -42,6 +45,7 @@ import org.hibernate.sql.model.ast.builder.TableMutationBuilder;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 import static org.hibernate.generator.EventType.INSERT;
+import static org.hibernate.generator.values.internal.GeneratedValuesHelper.noCustomSql;
 
 /**
  * Coordinates the insertion of an entity.
@@ -54,13 +58,15 @@ import static org.hibernate.generator.EventType.INSERT;
 public class InsertCoordinatorStandard extends AbstractMutationCoordinator implements InsertCoordinator {
 	private final MutationOperationGroup staticInsertGroup;
 	private final BasicBatchKey batchKey;
+	private final BasicBatchKey identityBatchKey;
+	private final boolean batchGeneratedIdentityInserts;
 
 	public InsertCoordinatorStandard(EntityPersister entityPersister, SessionFactoryImplementor factory) {
 		super( entityPersister, factory );
 
 		batchKey =
 				entityPersister.isIdentifierAssignedByInsert() || entityPersister.hasInsertGeneratedProperties()
-						// disable batching in case of insert-generated identifier or properties
+						// the synchronous insert path cannot be batched when there are generated values
 						? null
 						: new BasicBatchKey( entityPersister.getEntityName() + "#INSERT" );
 
@@ -70,6 +76,24 @@ public class InsertCoordinatorStandard extends AbstractMutationCoordinator imple
 						// static inserts as we will create them every time
 						? null
 						: generateStaticOperationGroup();
+
+		batchGeneratedIdentityInserts =
+				staticInsertGroup != null
+						&& staticInsertGroup.getNumberOfOperations() == 1
+						&& entityPersister.getInsertDelegate() instanceof GetGeneratedKeysDelegate insertDelegate
+						&& !insertDelegate.supportsArbitraryValues()
+						&& !insertDelegate.supportsRowId()
+						&& entityPersister.getInsertGeneratedProperties().size() == 1
+						&& entityPersister.getInsertGeneratedProperties().get( 0 ).isEntityIdentifierMapping()
+						&& !entityPersister.hasPreInsertGeneratedProperties()
+						&& entityPersister.getRowIdMapping() == null
+						&& entityPersister.getIdentifierMapping().asBasicValuedModelPart() != null
+						&& noCustomSql( entityPersister, EventType.INSERT )
+						&& dialect().supportsBatchInsertReturningGeneratedKeys();
+
+		identityBatchKey = batchGeneratedIdentityInserts
+				? new BasicBatchKey( entityPersister.getEntityName() + "#IDENTITY_INSERT" )
+				: null;
 	}
 
 	@Override
@@ -121,6 +145,54 @@ public class InsertCoordinatorStandard extends AbstractMutationCoordinator imple
 			|| forceIdentifierBinding
 				? doDynamicInserts( id, values, entity, session, forceIdentifierBinding )
 				: doStaticInserts( id, values, entity, session );
+	}
+
+	@Override
+	public boolean canBatchGeneratedIdentityInserts() {
+		return batchGeneratedIdentityInserts;
+	}
+
+	@Override
+	public void insertDeferred(
+			Object entity,
+			Object[] values,
+			Consumer<Object> generatedIdConsumer,
+			SharedSessionContractImplementor session) {
+		if ( !batchGeneratedIdentityInserts ) {
+			throw new UnsupportedOperationException(
+					"Generated identity inserts are not batchable for " + entityPersister().getEntityName() );
+		}
+
+		final var insertValuesAnalysis = new InsertValuesAnalysis( entityPersister(), values );
+		final var tableInclusionChecker = getTableInclusionChecker( insertValuesAnalysis );
+
+		final var mutationExecutor = (MutationExecutorSingleBatched)
+				mutationExecutorService.createExecutor( () -> identityBatchKey, staticInsertGroup, session );
+		mutationExecutor.setGeneratedKeyConsumer( generatedIdConsumer );
+
+		decomposeForInsert(
+				mutationExecutor,
+				null,
+				values,
+				entity,
+				staticInsertGroup,
+				entityPersister().getPropertyInsertability(),
+				tableInclusionChecker,
+				session
+		);
+
+		try {
+			mutationExecutor.execute(
+					entity,
+					insertValuesAnalysis,
+					tableInclusionChecker,
+					InsertCoordinatorStandard::verifyOutcome,
+					session
+			);
+		}
+		finally {
+			mutationExecutor.release();
+		}
 	}
 
 	protected boolean preInsertInMemoryValueGeneration(Object[] values, Object entity, SharedSessionContractImplementor session) {
@@ -202,7 +274,27 @@ public class InsertCoordinatorStandard extends AbstractMutationCoordinator imple
 			boolean[] propertyInclusions,
 			TableInclusionChecker tableInclusionChecker,
 			SharedSessionContractImplementor session) {
-		final var jdbcValueBindings = mutationExecutor.getJdbcValueBindings();
+		decomposeForInsert(
+				mutationExecutor.getJdbcValueBindings(),
+				id,
+				values,
+				object,
+				mutationGroup,
+				propertyInclusions,
+				tableInclusionChecker,
+				session
+		);
+	}
+
+	protected void decomposeForInsert(
+			JdbcValueBindings jdbcValueBindings,
+			Object id,
+			Object[] values,
+			Object object,
+			MutationOperationGroup mutationGroup,
+			boolean[] propertyInclusions,
+			TableInclusionChecker tableInclusionChecker,
+			SharedSessionContractImplementor session) {
 		final var attributeMappings = entityPersister().getAttributeMappings();
 
 		for ( int position = 0; position < mutationGroup.getNumberOfOperations(); position++ ) {
@@ -469,7 +561,6 @@ public class InsertCoordinatorStandard extends AbstractMutationCoordinator imple
 		return tableMapping -> !tableMapping.isOptional()
 			|| insertValuesAnalysis.hasNonNullBindings( tableMapping );
 	}
-
 
 	/**
 	 * Transform the array of property indexes to an array of booleans,

--- a/hibernate-core/src/main/java/org/hibernate/sql/model/PreparableMutationOperation.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/model/PreparableMutationOperation.java
@@ -55,10 +55,12 @@ public interface PreparableMutationOperation extends MutationOperation {
 			return false;
 		}
 
-		// This should already be guaranteed by the batchKey being null
+		// If the identifier table has a mutation delegate, batching is only allowed
+		// when the delegate itself supports batched generated-key retrieval.
 		assert !getTableDetails().isIdentifierTable()
-			|| !( getMutationTarget() instanceof EntityMutationTarget entityMutationTarget
-					&& entityMutationTarget.getMutationDelegate( getMutationType() ) != null );
+			|| !( getMutationTarget() instanceof EntityMutationTarget entityMutationTarget )
+			|| entityMutationTarget.getMutationDelegate( getMutationType() ) == null
+			|| entityMutationTarget.getMutationDelegate( getMutationType() ).supportsBatching();
 
 		if ( getMutationType() == MutationType.UPDATE ) {
 			// we cannot batch updates against optional tables

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/generatedkeys/identity/BatchingIdentityGeneratedKeysTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/generatedkeys/identity/BatchingIdentityGeneratedKeysTest.java
@@ -1,0 +1,258 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.generatedkeys.identity;
+
+import java.lang.reflect.Method;
+import java.sql.PreparedStatement;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+
+import org.hibernate.boot.registry.StandardServiceRegistry;
+import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
+import org.hibernate.dialect.H2Dialect;
+import org.hibernate.engine.jdbc.connections.spi.ConnectionProvider;
+import org.hibernate.testing.orm.jdbc.PreparedStatementSpyConnectionProvider;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.JiraKey;
+import org.hibernate.testing.orm.junit.RequiresDialect;
+import org.hibernate.testing.orm.junit.ServiceRegistryFunctionalTesting;
+import org.hibernate.testing.orm.junit.ServiceRegistryProducer;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import static org.hibernate.cfg.BatchSettings.BATCH_IDENTITY_INSERTS;
+import static org.hibernate.cfg.BatchSettings.ORDER_INSERTS;
+import static org.hibernate.cfg.BatchSettings.STATEMENT_BATCH_SIZE;
+import static org.hibernate.cfg.JdbcSettings.CONNECTION_PROVIDER;
+import static org.hibernate.cfg.JdbcSettings.DIALECT;
+import static org.hibernate.cfg.JdbcSettings.DIALECT_NATIVE_PARAM_MARKERS;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+@ServiceRegistryFunctionalTesting
+@RequiresDialect(H2Dialect.class)
+@JiraKey("HHH-20023")
+@DomainModel(
+		annotatedClasses = {
+				BatchingIdentityGeneratedKeysTest.BatchIdentityEntity.class,
+				BatchingIdentityGeneratedKeysTest.BatchIdentityParent.class,
+				BatchingIdentityGeneratedKeysTest.BatchIdentityChild.class
+		}
+)
+@SessionFactory
+public class BatchingIdentityGeneratedKeysTest implements ServiceRegistryProducer {
+	private static final Method ADD_BATCH = resolveMethod( PreparedStatement.class, "addBatch" );
+	private static final Method EXECUTE_BATCH = resolveMethod( PreparedStatement.class, "executeBatch" );
+	private static final Method GET_GENERATED_KEYS = resolveMethod( Statement.class, "getGeneratedKeys" );
+
+	private final PreparedStatementSpyConnectionProvider connectionProvider = new PreparedStatementSpyConnectionProvider();
+
+	@AfterEach
+	void tearDown(SessionFactoryScope scope) {
+		scope.dropData();
+		connectionProvider.clear();
+	}
+
+	@AfterAll
+	void releaseResources() {
+		connectionProvider.stop();
+	}
+
+	@Test
+	void testIdentityInsertsUseExecuteBatchAndGetGeneratedKeys(SessionFactoryScope scope) {
+		connectionProvider.clear();
+		scope.inTransaction(
+				session -> {
+					final var first = new BatchIdentityEntity( "first" );
+					final var second = new BatchIdentityEntity( "second" );
+
+					session.persist( first );
+					session.persist( second );
+
+					assertNull( first.getId() );
+					assertNull( second.getId() );
+
+					session.flush();
+
+					assertNotNull( first.getId() );
+					assertNotNull( second.getId() );
+				}
+		);
+
+		final PreparedStatement statement = findPreparedStatement( "batch_identity_entity" );
+		assertEquals( 2, callCount( ADD_BATCH, statement ) );
+		assertEquals( 1, callCount( EXECUTE_BATCH, statement ) );
+		assertEquals( 1, callCount( GET_GENERATED_KEYS, statement ) );
+	}
+
+	@Test
+	void testGeneratedParentIdsAreAssignedBeforeDependentChildInserts(SessionFactoryScope scope) {
+		connectionProvider.clear();
+		scope.inTransaction(
+				session -> {
+					final var firstParent = new BatchIdentityParent( "first-parent" );
+					firstParent.addChild( new BatchIdentityChild( 1L, "first-child" ) );
+					final var secondParent = new BatchIdentityParent( "second-parent" );
+					secondParent.addChild( new BatchIdentityChild( 2L, "second-child" ) );
+
+					session.persist( firstParent );
+					session.persist( secondParent );
+				}
+		);
+
+		scope.inTransaction(
+				session -> {
+					final var children = session.createQuery(
+							"from BatchIdentityChild c order by c.id",
+							BatchIdentityChild.class
+					).getResultList();
+					assertEquals( 2, children.size() );
+					assertNotNull( children.get( 0 ).getParent().getId() );
+					assertNotNull( children.get( 1 ).getParent().getId() );
+				}
+		);
+
+		final var statement = findPreparedStatement( "batch_identity_parent" );
+		assertEquals( 2, callCount( ADD_BATCH, statement ) );
+		assertEquals( 1, callCount( EXECUTE_BATCH, statement ) );
+		assertEquals( 1, callCount( GET_GENERATED_KEYS, statement ) );
+	}
+
+	@Override
+	public StandardServiceRegistry produceServiceRegistry(StandardServiceRegistryBuilder registryBuilder) {
+		registryBuilder.applySetting( DIALECT, BatchIdentityH2Dialect.class.getName() );
+		registryBuilder.applySetting( DIALECT_NATIVE_PARAM_MARKERS, Boolean.FALSE );
+		registryBuilder.applySetting( STATEMENT_BATCH_SIZE, 5 );
+		registryBuilder.applySetting( ORDER_INSERTS, Boolean.TRUE );
+		registryBuilder.applySetting( BATCH_IDENTITY_INSERTS, Boolean.TRUE );
+		final Object configuredConnectionProvider = registryBuilder.getSettings().get( CONNECTION_PROVIDER );
+		if ( configuredConnectionProvider != null ) {
+			connectionProvider.setConnectionProvider( (ConnectionProvider) configuredConnectionProvider );
+		}
+		registryBuilder.applySetting( CONNECTION_PROVIDER, connectionProvider );
+		return registryBuilder.build();
+	}
+
+	private PreparedStatement findPreparedStatement(String tableName) {
+		for ( var entry : connectionProvider.getPreparedStatementsAndSql().entrySet() ) {
+			if ( entry.getValue().toLowerCase( Locale.ROOT ).contains( "insert into " + tableName ) ) {
+				return entry.getKey();
+			}
+		}
+		throw new IllegalArgumentException( "No prepared statement found for table `" + tableName + "'" );
+	}
+
+	private int callCount(Method method, PreparedStatement statement) {
+		return connectionProvider.spyContext.getCalls( method, statement ).size();
+	}
+
+	private static Method resolveMethod(Class<?> type, String name) {
+		try {
+			return type.getMethod( name );
+		}
+		catch (Exception e) {
+			throw new RuntimeException( e );
+		}
+	}
+
+	public static class BatchIdentityH2Dialect extends H2Dialect {
+		@Override
+		public boolean supportsBatchInsertReturningGeneratedKeys() {
+			return true;
+		}
+	}
+
+	@Entity(name = "BatchIdentityEntity")
+	@Table(name = "batch_identity_entity")
+	public static class BatchIdentityEntity {
+		@Id
+		@GeneratedValue(strategy = GenerationType.IDENTITY)
+		private Long id;
+
+		private String name;
+
+		public BatchIdentityEntity() {
+		}
+
+		public BatchIdentityEntity(String name) {
+			this.name = name;
+		}
+
+		public Long getId() {
+			return id;
+		}
+	}
+
+	@Entity(name = "BatchIdentityParent")
+	@Table(name = "batch_identity_parent")
+	public static class BatchIdentityParent {
+		@Id
+		@GeneratedValue(strategy = GenerationType.IDENTITY)
+		private Long id;
+
+		private String name;
+
+		@OneToMany(mappedBy = "parent", cascade = CascadeType.PERSIST)
+		private List<BatchIdentityChild> children = new ArrayList<>();
+
+		public BatchIdentityParent() {
+		}
+
+		public BatchIdentityParent(String name) {
+			this.name = name;
+		}
+
+		public void addChild(BatchIdentityChild child) {
+			children.add( child );
+			child.parent = this;
+		}
+
+		public Long getId() {
+			return id;
+		}
+	}
+
+	@Entity(name = "BatchIdentityChild")
+	@Table(name = "batch_identity_child")
+	public static class BatchIdentityChild {
+		@Id
+		private Long id;
+
+		private String name;
+
+		@ManyToOne(fetch = FetchType.LAZY, optional = false)
+		@JoinColumn(name = "parent_id", nullable = false)
+		private BatchIdentityParent parent;
+
+		public BatchIdentityChild() {
+		}
+
+		public BatchIdentityChild(Long id, String name) {
+			this.id = id;
+			this.name = name;
+		}
+
+		public BatchIdentityParent getParent() {
+			return parent;
+		}
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/transaction/batch/AbstractBatchingTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/jpa/transaction/batch/AbstractBatchingTest.java
@@ -119,6 +119,11 @@ public abstract class AbstractBatchingTest {
 		}
 
 		@Override
+		public void addToBatch(JdbcValueBindings jdbcValueBindings, TableInclusionChecker inclusionChecker, java.util.function.Consumer<Object> generatedKeyConsumer) {
+			wrapped.addToBatch( jdbcValueBindings, inclusionChecker, generatedKeyConsumer );
+		}
+
+		@Override
 		public void addToBatch(JdbcValueBindings jdbcValueBindings, TableInclusionChecker inclusionChecker) {
 			numberOfBatches++;
 			wrapped.addToBatch( jdbcValueBindings, inclusionChecker );


### PR DESCRIPTION
This is just an experiment because I believe @sebersole is already dealing with this in the action queue rewrite.

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------


---
<!-- Hibernate GitHub Bot task list start -->
Please make sure that the following tasks are completed:
Tasks specific to HHH-20023 (Improvement):
- [ ] Add tests for feature/improvement
- [ ] Update documentation as relevant: javadoc for changed API, `documentation/src/main/asciidoc/userguide` for all features, `documentation/src/main/asciidoc/introduction` for main features, links from existing documentation
- [ ] Add entries as relevant to `migration-guide.adoc` (breaking changes) and `whats-new.adoc` (new features/improvements)


<!-- Hibernate GitHub Bot task list end -->

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-20023
<!-- Hibernate GitHub Bot issue links end -->