### PR TITLE
HHH-19742 Define optional OSGI imports for packages that are dynamically loaded

### DIFF
--- a/local-build-plugins/src/main/groovy/local.java-module.gradle
+++ b/local-build-plugins/src/main/groovy/local.java-module.gradle
@@ -335,6 +335,36 @@ tasks.named("jar") {
                         // Temporarily support JTA 1.1 -- Karaf and other frameworks still
                         // use it.  Without this, the plugin generates [1.2,2).
                         'javax.transaction;version="[1.1,2)"',
+                        // Optional dependencies, see OracleOsonJacksonHelper class
+                        'com.fasterxml.jackson.core;resolution:="optional"',
+                        // Optional dependencies, see JacksonIntegration class
+                        'com.fasterxml.jackson.databind;resolution:="optional"',
+                        'com.fasterxml.jackson.databind.module;resolution:="optional"',
+                        'com.fasterxml.jackson.databind.ser.std;resolution:="optional"',
+                        'com.fasterxml.jackson.dataformat.xml;resolution:="optional"',
+                        'com.fasterxml.jackson.dataformat.xml.std;resolution:="optional"',
+                        'com.fasterxml.jackson.dataformat.xml.annotation;resolution:="optional"',
+                        'com.fasterxml.jackson.dataformat.xml.ser;resolution:="optional"',
+                        'tools.jackson.databind;resolution:="optional"',
+                        'tools.jackson.databind.module;resolution:="optional"',
+                        'tools.jackson.databind.cfg;resolution:="optional"',
+                        'tools.jackson.databind.json;resolution:="optional"',
+                        'tools.jackson.databind.ser.std;resolution:="optional"',
+                        'tools.jackson.core;resolution:="optional"',
+                        'tools.jackson.dataformat.xml;resolution:="optional"',
+                        'tools.jackson.dataformat.xml.annotation;resolution:="optional"',
+                        // Optional dependencies, see JakartaJsonIntegration class
+                        'jakarta.json.bind;resolution:="optional"',
+                        'jakarta.xml.bind;resolution:="optional"',
+                        'jakarta.xml.bind.annotation;resolution:="optional"',
+                        'jakarta.xml.bind.annotation.adapters;resolution:="optional"',
+                        // Database driver dependencies are optional
+                        'oracle.jdbc;resolution:="optional"',
+                        'oracle.jdbc.driver.json.tree;resolution:="optional"',
+                        'oracle.jdbc.provider.oson;resolution:="optional"',
+                        'oracle.sql;resolution:="optional"',
+                        'oracle.sql.json;resolution:="optional"',
+                        'org.postgresql.util;resolution:="optional"',
                         // Also import every package referenced in the code
                         // (note that '*' is resolved at build time to a list of packages)
                         '*'


### PR DESCRIPTION
Hibernate core has many optional dependencies which are discovered at runtime by dynamically loading some specific classes.
However, the packages are not listed as optional dependency in the META-INF/MANIFEST.MF file.
This means that in an OSGI environment the dependencies (like for example the oracle driver) is required.

The change in my PR tags all packages from the import-package section that are loaded dynamically as optional.

From the current 7.3 branch, these packages are tagged as optional in the new manifest:

`com.fasterxml.jackson.core;version="[2.19,3)";resolution:=optional
com.fasterxml.jackson.databind.module;version="[2.19,3)";resolution:=optional
com.fasterxml.jackson.databind.ser.std;version="[2.19,3)";resolution:=optional
com.fasterxml.jackson.databind;version="[2.19,3)";resolution:=optional
com.fasterxml.jackson.dataformat.xml.annotation;version="[2.19,3)";resolution:=optional
com.fasterxml.jackson.dataformat.xml.ser;version="[2.19,3)";resolution:=optional
com.fasterxml.jackson.dataformat.xml.std;resolution:=optional
com.fasterxml.jackson.dataformat.xml;version="[2.19,3)";resolution:=optional
jakarta.json.bind;version="[3.0,4)";resolution:=optional
jakarta.xml.bind.annotation.adapters;version="[4.0,5)";resolution:=optional
jakarta.xml.bind.annotation;version="[4.0,5)";resolution:=optional
jakarta.xml.bind;version="[4.0,5)";resolution:=optional
oracle.jdbc.driver.json.tree;resolution:=optional
oracle.jdbc.provider.oson;resolution:=optional
oracle.jdbc;resolution:=optional
oracle.sql.json;resolution:=optional
oracle.sql;resolution:=optional
org.postgresql.util;version="[42.7,43)";resolution:=optional
tools.jackson.core;version="[3.0,4)";resolution:=optional
tools.jackson.databind.cfg;version="[3.0,4)";resolution:=optional
tools.jackson.databind.json;version="[3.0,4)";resolution:=optional
tools.jackson.databind.module;version="[3.0,4)";resolution:=optional
tools.jackson.databind.ser.std;version="[3.0,4)";resolution:=optional
tools.jackson.databind;version="[3.0,4)";resolution:=optional
tools.jackson.dataformat.xml.annotation;version="[3.0,4)";resolution:=optional
tools.jackson.dataformat.xml;version="[3.0,4)";resolution:=optional
`

----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------


---
<!-- Hibernate GitHub Bot task list start -->
Please make sure that the following tasks are completed:
Tasks specific to HHH-19742 (Bug):
- [ ] Add test reproducing the bug
- [ ] Add entries as relevant to `migration-guide.adoc` **OR** check there are no breaking changes


<!-- Hibernate GitHub Bot task list end -->

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-19742
<!-- Hibernate GitHub Bot issue links end -->