### PR TITLE
HHH-20356 NPE when mapping embedded property as @MappedSuperclass

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/boot/model/internal/EmbeddableBinder.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/internal/EmbeddableBinder.java
@@ -68,6 +68,7 @@ import static org.hibernate.boot.model.internal.Binders.callTypeBinder;
 import static org.hibernate.boot.model.internal.ComponentPropertyHolder.applyExplicitTableName;
 import static org.hibernate.boot.model.internal.DialectOverridesAnnotationHelper.getOverridableAnnotation;
 import static org.hibernate.boot.model.internal.EntityBinder.isMappedSuperclass;
+import static org.hibernate.boot.model.internal.InheritanceState.getSuperclassInheritanceState;
 import static org.hibernate.boot.model.internal.GeneratorBinder.createIdGeneratorsFromGeneratorAnnotations;
 import static org.hibernate.boot.model.internal.PropertyBinder.addElementsOfClass;
 import static org.hibernate.boot.model.internal.PropertyBinder.isEmbeddedId;
@@ -492,6 +493,14 @@ public class EmbeddableBinder {
 					context
 			);
 		}
+		else {
+			// We need to register ancestor @MappedSuperclass metadata even for embedded types of classes
+			// that are not annotated as @Embeddable (i.e. that don't have an inheritance state)
+			final var superState = getSuperclassInheritanceState( returnedClassOrElement, inheritanceStatePerClass );
+			if ( superState != null && superState.isEmbeddableSuperclass() ) {
+				superState.postProcess( embeddable );
+			}
+		}
 
 		final var annotatedTypeDetails = inferredData.getPropertyType();
 
@@ -623,7 +632,8 @@ public class EmbeddableBinder {
 			PropertyData propertyData,
 			InheritanceState inheritanceState,
 			MetadataBuildingContext context) {
-		if ( inheritanceState != null ) {
+		// Discriminated inheritance only applies to explicit @Embeddable types
+		if ( !inheritanceState.isEmbeddableSuperclass() ) {
 			final var discriminatorColumn = processEmbeddableDiscriminatorProperties(
 					componentClass,
 					propertyData,

--- a/hibernate-core/src/main/java/org/hibernate/boot/model/internal/InheritanceState.java
+++ b/hibernate-core/src/main/java/org/hibernate/boot/model/internal/InheritanceState.java
@@ -446,7 +446,9 @@ public class InheritanceState {
 				superEntityState != null
 						? metadataCollector.getEntityBinding( superEntityState.getClassDetails().getName() )
 						: null;
-		final int lastMappedSuperclass = classesToProcessForMappedSuperclass.size() - 1;
+		final int lastMappedSuperclass = isEmbeddableSuperclass
+				? classesToProcessForMappedSuperclass.size()
+				: classesToProcessForMappedSuperclass.size() - 1;
 		org.hibernate.mapping.MappedSuperclass mappedSuperclass = null;
 		for ( int index = 0; index < lastMappedSuperclass; index++ ) {
 			final var parentSuperclass = mappedSuperclass;

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/embeddable/EmbeddableExdendingMappedSuperclassTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/embeddable/EmbeddableExdendingMappedSuperclassTest.java
@@ -1,0 +1,204 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.embeddable;
+
+import jakarta.persistence.Embeddable;
+import jakarta.persistence.Embedded;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.MappedSuperclass;
+import org.hibernate.testing.orm.junit.EntityManagerFactoryScope;
+import org.hibernate.testing.orm.junit.JiraKey;
+import org.hibernate.testing.orm.junit.Jpa;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+// It's important for the test that embeddables and mapped superclass are listed in the @Jpa annotatedClasses.
+@Jpa(
+		annotatedClasses = {
+				EmbeddableExdendingMappedSuperclassTest.DescriptionMappedSuperclass.class,
+				EmbeddableExdendingMappedSuperclassTest.Item.class,
+				EmbeddableExdendingMappedSuperclassTest.Item2.class,
+				EmbeddableExdendingMappedSuperclassTest.DescriptionBaseEmbeddable.class,
+				EmbeddableExdendingMappedSuperclassTest.DescriptionBase.class
+
+		}
+)
+@JiraKey("HHH-20356")
+public class EmbeddableExdendingMappedSuperclassTest {
+
+	@Test
+	public void testSetDescriptionMappedSuperclass(EntityManagerFactoryScope scope) {
+		scope.inTransaction( entityManager ->
+				entityManager.persist( new Item2( 1L, new DescriptionMappedSuperclass( "Test2" ) ) )
+		);
+		verifyItem2( scope, 1L, "Test2" );
+	}
+
+	@Test
+	public void testSetDescriptionBase(EntityManagerFactoryScope scope) {
+		scope.inTransaction( entityManager ->
+				entityManager.persist( new Item( 2L, new DescriptionBase( "Test", "base1" ) ) )
+		);
+		verifyItem( scope, 2L, "Test", "base1" );
+		// Item2's embedded type is DescriptionMappedSuperclass, so baseDetail is not persistent
+		scope.inTransaction( entityManager ->
+				entityManager.persist( new Item2( 2L, new DescriptionBase( "Test2", "base2" ) ) )
+		);
+		verifyItem2( scope, 2L, "Test2" );
+	}
+
+	@Test
+	public void testSetDescriptionBaseEmbeddable(EntityManagerFactoryScope scope) {
+		// Item's embedded type is DescriptionBase, so baseEmbeddableDetail is not persistent
+		scope.inTransaction( entityManager ->
+				entityManager.persist( new Item( 3L, new DescriptionBaseEmbeddable( "Test", "base1", "baseEmb1" ) ) )
+		);
+		verifyItem( scope, 3L, "Test", "base1" );
+		// Item2's embedded type is DescriptionMappedSuperclass, so baseDetail and baseEmbeddableDetail are not persistent
+		scope.inTransaction( entityManager ->
+				entityManager.persist( new Item2( 3L, new DescriptionBaseEmbeddable( "Test2", "base2", "baseEmb2" ) ) )
+		);
+		verifyItem2( scope, 3L, "Test2" );
+	}
+
+	@Test
+	public void testSetDescriptionEmbeddable(EntityManagerFactoryScope scope) {
+		// Item2's embedded type is DescriptionMappedSuperclass, so embeddableDetail is not persistent
+		scope.inTransaction( entityManager ->
+				entityManager.persist( new Item2( 4L, new DescriptionEmbeddable( "Test2", "emb1" ) ) )
+		);
+		verifyItem2( scope, 4L, "Test2" );
+	}
+
+	private void verifyItem(EntityManagerFactoryScope scope, Long id, String expectedName, String expectedBaseDetail) {
+		scope.inTransaction( entityManager -> {
+			final Item item = entityManager.find( Item.class, id );
+			assertEquals( expectedName, item.getDescription().getName() );
+			assertEquals( expectedBaseDetail, item.getDescription().getBaseDetail() );
+		} );
+	}
+
+	private void verifyItem2(EntityManagerFactoryScope scope, Long id, String expectedName) {
+		scope.inTransaction( entityManager -> {
+			final Item2 item = entityManager.find( Item2.class, id );
+			assertEquals( expectedName, item.getDescription().getName() );
+		} );
+	}
+
+	@Entity(name = "Item")
+	public static class Item {
+
+		@Id
+		private Long id;
+
+		@Embedded
+		private DescriptionBase description;
+
+		protected Item() {
+		}
+
+		public Item(Long id, DescriptionBase description) {
+			this.id = id;
+			this.description = description;
+		}
+
+		public Long getId() {
+			return id;
+		}
+
+		public DescriptionBase getDescription() {
+			return description;
+		}
+	}
+
+	@Entity(name = "Item2")
+	public static class Item2 {
+
+		@Id
+		private Long id;
+
+		@Embedded
+		private DescriptionMappedSuperclass description;
+
+		protected Item2() {
+		}
+
+		public Item2(Long id, DescriptionMappedSuperclass description) {
+			this.id = id;
+			this.description = description;
+		}
+
+		public Long getId() {
+			return id;
+		}
+
+		public DescriptionMappedSuperclass getDescription() {
+			return description;
+		}
+	}
+
+	@MappedSuperclass
+	public static class DescriptionMappedSuperclass {
+		private String name;
+
+		public DescriptionMappedSuperclass() {
+		}
+
+		public DescriptionMappedSuperclass(String name) {
+			this.name = name;
+		}
+
+		public String getName() {
+			return name;
+		}
+	}
+
+	@Embeddable
+	public static class DescriptionEmbeddable extends DescriptionMappedSuperclass {
+		private String embeddableDetail;
+
+		public DescriptionEmbeddable() {
+			super();
+		}
+
+		public DescriptionEmbeddable(String name, String embeddableDetail) {
+			super( name );
+			this.embeddableDetail = embeddableDetail;
+		}
+	}
+
+	public static class DescriptionBase extends DescriptionMappedSuperclass {
+		private String baseDetail;
+
+		public DescriptionBase() {
+			super();
+		}
+
+		public DescriptionBase(String name, String baseDetail) {
+			super( name );
+			this.baseDetail = baseDetail;
+		}
+
+		public String getBaseDetail() {
+			return baseDetail;
+		}
+	}
+
+	@Embeddable
+	public static class DescriptionBaseEmbeddable extends DescriptionBase {
+		private String baseEmbeddableDetail;
+
+		public DescriptionBaseEmbeddable() {
+			super();
+		}
+
+		public DescriptionBaseEmbeddable(String name, String baseDetail, String baseEmbeddableDetail) {
+			super( name, baseDetail );
+			this.baseEmbeddableDetail = baseEmbeddableDetail;
+		}
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/embeddable/EmbeddableExtenfinMappedSuperclass2Test.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/embeddable/EmbeddableExtenfinMappedSuperclass2Test.java
@@ -1,0 +1,85 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.embeddable;
+
+import jakarta.persistence.Embeddable;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.MappedSuperclass;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.JiraKey;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.junit.jupiter.api.Test;
+
+
+// It's important for the test that only the mapped superclass is listed in the @DomainModel annotatedClasses
+// along with the AnotherEmbeddableName embeddabele class but not the EmbeddableName class,
+// which is the actual type of the embedded attribute in TestEntity.
+@DomainModel(
+		annotatedClasses = {
+				EmbeddableExtenfinMappedSuperclass2Test.TestEntity.class,
+				EmbeddableExtenfinMappedSuperclass2Test.AbstractName.class,
+				EmbeddableExtenfinMappedSuperclass2Test.AnotherEmbeddableName.class
+		}
+)
+@SessionFactory
+@JiraKey("HHH-19020")
+public class EmbeddableExtenfinMappedSuperclass2Test {
+
+	@Test
+	public void testPersist(SessionFactoryScope scope) {
+		scope.inTransaction( session -> {
+			session.persist( new TestEntity( "1", new EmbeddableName( "Test" ) ) );
+		} );
+	}
+
+	@Entity(name = "TestEntity")
+	public static class TestEntity {
+
+		@Id
+		private String id;
+
+		private EmbeddableName name;
+
+		public TestEntity(String id, EmbeddableName name) {
+			this.id = id;
+			this.name = name;
+		}
+	}
+
+	@MappedSuperclass
+	public static class AbstractName {
+		private String name;
+
+		public AbstractName() {
+		}
+
+		public AbstractName(String name) {
+			this.name = name;
+		}
+	}
+
+	@Embeddable
+	public static class EmbeddableName extends AbstractName {
+
+		public EmbeddableName() {
+		}
+
+		public EmbeddableName(String name) {
+			super( name );
+		}
+	}
+
+	@Embeddable
+	public static class AnotherEmbeddableName extends AbstractName {
+		public AnotherEmbeddableName() {
+		}
+
+		public AnotherEmbeddableName(String name) {
+			super( name );
+		}
+	}
+}


### PR DESCRIPTION
When a `@MappedSuperclass` and an `@Embeddable` class that extends it are both listed as annotated classes,                                                                                                                                                                                                          
        AnnotationBinder#buildInheritanceStates includes them in orderedClasses, producing an InheritanceState                                                                                                                                                                                                     
        where isEmbeddableSuperclass() returns true.                                                                                                                                                                                                                                                               
                                                                                                                                                                                                                                                                                                                   This causes two problems:                                                                                                                                                                                                                                                                                  
                                                                                                                                                                                                                                                                                                                   
1. When the @Embedded property in Item is bound, ComponentPropertyHolder.addProperty() delegates to
           ClassPropertyHolder.addPropertyToMappedSuperclass(), which calls getMappedSuperclass() for the                                                                                                                                                                                                          
           embeddable's class. That returns null because no MappedSuperclass metadata exists for a class                                                                                                                                                                                                           
           outside an entity inheritance hierarchy, resulting in a NullPointerException.  
 2. EmbeddableBinder uses the MappedSuperclass to build the Component, and because an InheritanceState                                                                                                                                                                                                      
           exists, a discriminator column is created. Persisting an Item whose description is an embeddable                                                                                                                                                                                                        
           instance then fails because the discriminator value is null and no instantiator is created for
           the embeddable instance. 


https://hibernate.atlassian.net/browse/HHH-20356

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------


---
<!-- Hibernate GitHub Bot task list start -->Please make sure that the following tasks are completed:
Tasks specific to HHH-20356 (Bug):
- [ ] Add test reproducing the bug
- [ ] Add entries as relevant to `migration-guide.adoc` **OR** check there are no breaking changes

Tasks specific to HHH-19020 (Bug):
- [ ] Add test reproducing the bug
- [ ] Add entries as relevant to `migration-guide.adoc` **OR** check there are no breaking changes


<!-- Hibernate GitHub Bot task list end -->

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-19020
<!-- Hibernate GitHub Bot issue links end -->