### PR TITLE
HHH-20360: Detect CircularCascadeDeleteConstraints based on server/innodb FKs

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/cfg/DialectSpecificSettings.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/DialectSpecificSettings.java
@@ -109,6 +109,16 @@ public interface DialectSpecificSettings {
 	String MYSQL_NO_BACKSLASH_ESCAPES = "hibernate.dialect.mysql.no_backslash_escapes";
 
 	/**
+	 * Specifies whether foreign key are handled by the server or the storage engine.
+	 * <p>
+	 * Ignored if Hibernate is able to determine this by querying the server
+	 * {@code @@innodb_native_foreign_keys} at startup.
+	 *
+	 * @settingDefault {@code false}
+	 */
+	String MYSQL_FOREIGN_KEYS_IN_SERVER = "hibernate.dialect.mysql.foreign_keys_in_server";
+
+	/**
 	 * Specifies a custom CockroachDB version string. The expected format of the string is
 	 * the one returned from the {@code version()} function, e.g.:
 	 * {@code "CockroachDB CCL v23.1.8 (x86_64-pc-linux-gnu, built 2023/08/04 18:11:44, go1.19.10)"}

--- a/hibernate-core/src/main/java/org/hibernate/dialect/MySQLDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/MySQLDialect.java
@@ -201,6 +201,8 @@ public class MySQLDialect extends Dialect {
 
 	private final boolean noBackslashEscapesEnabled;
 
+	private final boolean foreignKeysInServer;
+
 	public MySQLDialect() {
 		this( MINIMUM_VERSION );
 	}
@@ -218,6 +220,7 @@ public class MySQLDialect extends Dialect {
 		maxVarcharLength = maxVarcharLength( getMySQLVersion(), serverConfiguration.getBytesPerCharacter() ); //conservative assumption
 		maxVarbinaryLength = maxVarbinaryLength( getMySQLVersion() );
 		noBackslashEscapesEnabled = serverConfiguration.isNoBackslashEscapesEnabled();
+		foreignKeysInServer = serverConfiguration.isForeignKeysInServer();
 		storageEngine = createStorageEngine( serverConfiguration.getConfiguredStorageEngine() );
 	}
 
@@ -226,6 +229,7 @@ public class MySQLDialect extends Dialect {
 		maxVarcharLength = maxVarcharLength( getMySQLVersion(), bytesPerCharacter ); //conservative assumption
 		maxVarbinaryLength = maxVarbinaryLength( getMySQLVersion() );
 		noBackslashEscapesEnabled = noBackslashEscapes;
+		foreignKeysInServer = false;
 		storageEngine = createStorageEngine( Environment.getProperties().getProperty( STORAGE_ENGINE ) );
 	}
 
@@ -1689,5 +1693,13 @@ public class MySQLDialect extends Dialect {
 	@Override
 	public TemporalTableSupport getTemporalTableSupport() {
 		return new MySQLTemporalTableSupport( this );
+	}
+
+	@Override
+	public boolean supportsCircularCascadeDeleteConstraints() {
+		// When innodb_native_foreign_keys=OFF, InnoDB delegates FK handling to the server-level
+		// implementation, which does not yet fully support circular cascade deletes. The older InnoDB-native
+		// implementation does support them.
+		return !foreignKeysInServer;
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/dialect/MySQLServerConfiguration.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/MySQLServerConfiguration.java
@@ -95,16 +95,19 @@ public class MySQLServerConfiguration {
 		final var databaseMetaData = info.getDatabaseMetadata();
 		if ( databaseMetaData != null ) {
 			try ( var statement = databaseMetaData.getConnection().createStatement() ) {
-				try ( var resultSet = statement.executeQuery(
-						"SELECT @@character_set_database, @@sql_mode, @@innodb_native_foreign_keys" ) ) {
-					if ( resultSet.next() ) {
-						bytesPerCharacter = getBytesPerCharacter( resultSet.getString( 1 ) );
-						noBackslashEscapes = resultSet.getString( 2 ).toLowerCase().contains( "no_backslash_escapes" );
-						// 0 = foreign keys handled by the server, 1 = handled by InnoDB natively
-						foreignKeysInServer = resultSet.getInt( 3 ) == 0;
+				if ( databaseMetaData.getDatabaseMajorVersion() > 9 
+					|| databaseMetaData.getDatabaseMajorVersion() == 9 && databaseMetaData.getDatabaseMinorVersion() > 6 ) {
+					try ( var resultSet = statement.executeQuery(
+							"SELECT @@character_set_database, @@sql_mode, @@innodb_native_foreign_keys" ) ) {
+						if ( resultSet.next() ) {
+							bytesPerCharacter = getBytesPerCharacter( resultSet.getString( 1 ) );
+							noBackslashEscapes = resultSet.getString( 2 ).toLowerCase().contains( "no_backslash_escapes" );
+							// 0 = foreign keys handled by the server, 1 = handled by InnoDB natively
+							foreignKeysInServer = resultSet.getInt( 3 ) == 0;
+						}
 					}
 				}
-				catch (SQLException ignored) {
+				else {
 					// @@innodb_native_foreign_keys unavailable on older MySQL: retry without it
 					try ( var resultSet = statement.executeQuery( "SELECT @@character_set_database, @@sql_mode" ) ) {
 						if ( resultSet.next() ) {

--- a/hibernate-core/src/main/java/org/hibernate/dialect/MySQLServerConfiguration.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/MySQLServerConfiguration.java
@@ -13,6 +13,7 @@ import org.hibernate.engine.jdbc.dialect.spi.DialectResolutionInfo;
 import org.hibernate.internal.util.config.ConfigurationHelper;
 
 import static org.hibernate.cfg.DialectSpecificSettings.MYSQL_BYTES_PER_CHARACTER;
+import static org.hibernate.cfg.DialectSpecificSettings.MYSQL_FOREIGN_KEYS_IN_SERVER;
 import static org.hibernate.cfg.DialectSpecificSettings.MYSQL_NO_BACKSLASH_ESCAPES;
 import static org.hibernate.internal.util.config.ConfigurationHelper.getBoolean;
 import static org.hibernate.internal.util.config.ConfigurationHelper.getInt;
@@ -28,17 +29,31 @@ public class MySQLServerConfiguration {
 	private final int bytesPerCharacter;
 	private final boolean noBackslashEscapesEnabled;
 	private final String storageEngine;
+	private final boolean foreignKeysInServer;
 
 	public MySQLServerConfiguration(int bytesPerCharacter, boolean noBackslashEscapesEnabled) {
 		this.bytesPerCharacter = bytesPerCharacter;
 		this.noBackslashEscapesEnabled = noBackslashEscapesEnabled;
 		this.storageEngine = null;
+		this.foreignKeysInServer = false;
 	}
 
 	public MySQLServerConfiguration(int bytesPerCharacter, boolean noBackslashEscapesEnabled, String storageEngine) {
 		this.bytesPerCharacter = bytesPerCharacter;
 		this.noBackslashEscapesEnabled = noBackslashEscapesEnabled;
 		this.storageEngine = storageEngine;
+		this.foreignKeysInServer = false;
+	}
+
+	private MySQLServerConfiguration(
+			int bytesPerCharacter,
+			boolean noBackslashEscapesEnabled,
+			String storageEngine,
+			boolean foreignKeysInServer) {
+		this.bytesPerCharacter = bytesPerCharacter;
+		this.noBackslashEscapesEnabled = noBackslashEscapesEnabled;
+		this.storageEngine = storageEngine;
+		this.foreignKeysInServer = foreignKeysInServer;
 	}
 
 	public int getBytesPerCharacter() {
@@ -51,6 +66,15 @@ public class MySQLServerConfiguration {
 
 	public String getConfiguredStorageEngine() {
 		return storageEngine;
+	}
+
+	/**
+	 * When {@code @@innodb_native_foreign_keys} is OFF, InnoDB delegates
+	 * foreign-key handling to the server-level implementation, which does
+	 * not support circular cascade deletes.
+	 */
+	public boolean isForeignKeysInServer() {
+		return foreignKeysInServer;
 	}
 
 	static Integer getBytesPerCharacter(String characterSet) {
@@ -67,20 +91,30 @@ public class MySQLServerConfiguration {
 	public static MySQLServerConfiguration fromDialectResolutionInfo(DialectResolutionInfo info) {
 		Integer bytesPerCharacter = null;
 		Boolean noBackslashEscapes = null;
+		Boolean foreignKeysInServer = null;
 		final var databaseMetaData = info.getDatabaseMetadata();
 		if ( databaseMetaData != null ) {
-			try ( var statement = databaseMetaData.getConnection().createStatement();
-					var resultSet = statement.executeQuery( "SELECT @@character_set_database, @@sql_mode" ) ) {
-				if ( resultSet.next() ) {
-					final String characterSet = resultSet.getString( 1 );
-					bytesPerCharacter = getBytesPerCharacter( characterSet );
-					// NO_BACKSLASH_ESCAPES
-					final String sqlMode = resultSet.getString( 2 );
-					noBackslashEscapes = sqlMode.toLowerCase().contains( "no_backslash_escapes" );
+			try ( var statement = databaseMetaData.getConnection().createStatement() ) {
+				try ( var resultSet = statement.executeQuery(
+						"SELECT @@character_set_database, @@sql_mode, @@innodb_native_foreign_keys" ) ) {
+					if ( resultSet.next() ) {
+						bytesPerCharacter = getBytesPerCharacter( resultSet.getString( 1 ) );
+						noBackslashEscapes = resultSet.getString( 2 ).toLowerCase().contains( "no_backslash_escapes" );
+						// 0 = foreign keys handled by the server, 1 = handled by InnoDB natively
+						foreignKeysInServer = resultSet.getInt( 3 ) == 0;
+					}
+				}
+				catch (SQLException ignored) {
+					// @@innodb_native_foreign_keys unavailable on older MySQL: retry without it
+					try ( var resultSet = statement.executeQuery( "SELECT @@character_set_database, @@sql_mode" ) ) {
+						if ( resultSet.next() ) {
+							bytesPerCharacter = getBytesPerCharacter( resultSet.getString( 1 ) );
+							noBackslashEscapes = resultSet.getString( 2 ).toLowerCase().contains( "no_backslash_escapes" );
+						}
+					}
 				}
 			}
-			catch (SQLException ex) {
-				// Ignore
+			catch (SQLException ignored) {
 			}
 		}
 		// default to the dialect-specific configuration settings
@@ -90,11 +124,15 @@ public class MySQLServerConfiguration {
 		if ( noBackslashEscapes == null ) {
 			noBackslashEscapes = getBoolean( MYSQL_NO_BACKSLASH_ESCAPES, info.getConfigurationValues() );
 		}
+		if ( foreignKeysInServer == null ) {
+			foreignKeysInServer = getBoolean( MYSQL_FOREIGN_KEYS_IN_SERVER, info.getConfigurationValues() );
+		}
 
 		return new MySQLServerConfiguration(
 				bytesPerCharacter,
 				noBackslashEscapes,
-				ConfigurationHelper.getString( AvailableSettings.STORAGE_ENGINE, info.getConfigurationValues() ) );
+				ConfigurationHelper.getString( AvailableSettings.STORAGE_ENGINE, info.getConfigurationValues() ),
+				foreignKeysInServer );
 	}
 
 	/**


### PR DESCRIPTION
<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

See also: https://github.com/hibernate/hibernate-orm/pull/12219#issuecomment-4303083393

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------


---
<!-- Hibernate GitHub Bot task list start -->
Please make sure that the following tasks are completed:
Tasks specific to HHH-20360 (Bug):
- [ ] Add test reproducing the bug
- [ ] Add entries as relevant to `migration-guide.adoc` **OR** check there are no breaking changes


<!-- Hibernate GitHub Bot task list end -->

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-20360
<!-- Hibernate GitHub Bot issue links end -->