### PR TITLE
HHH-19933 fix performance of setMaxResults with collection join fetch

### DIFF
--- a/documentation/src/main/asciidoc/querylanguage/From.adoc
+++ b/documentation/src/main/asciidoc/querylanguage/From.adoc
@@ -325,16 +325,16 @@ A query may have more than one fetch join, but be aware that:
 HQL doesn't disallow it, but it's usually a bad idea to apply a restriction to a ``join fetch``ed entity, since the elements of the fetched collection would be incomplete.
 Indeed, it's best to avoid even assigning an identification variable to a fetched joined entity except for the purpose of specifying a nested fetch join.
 
-[IMPORTANT]
-====
-Fetch joins should usually be avoided in limited or paged queries.
-This includes:
-
-- queries executed with limits specified via the `setFirstResult()` and `setMaxResults()` methods of `Query`, or
-- queries with a limit or offset declared in HQL, described below in <<limit-offset>>.
-
-Nor should they be used with the `scroll()` and `stream()` methods of the `Query` interface.
-====
+// [IMPORTANT]
+// ====
+// Fetch joins should usually be avoided in limited or paged queries.
+// This includes:
+//
+// - queries executed with limits specified via the `setFirstResult()` and `setMaxResults()` methods of `Query`, or
+// - queries with a limit or offset declared in HQL, described below in <<limit-offset>>.
+//
+// Nor should they be used with the `scroll()` and `stream()` methods of the `Query` interface.
+// ====
 
 Fetch joins are disallowed in subqueries, where they would make no sense.
 

--- a/documentation/src/main/asciidoc/querylanguage/Relational.adoc
+++ b/documentation/src/main/asciidoc/querylanguage/Relational.adoc
@@ -670,63 +670,13 @@ order by title, published desc
 fetch first 50 rows only
 ----
 
-These are well-defined limits: the number of results returned by the database will be limited to 50, as promised.
-But not every query is quite so well-behaved.
-
-[NOTE]
+[CAUTION]
 ====
-_Limiting_ certainly _isn't_ a well-defined relational operation, and must be used with care.
-
-In particular, limits don't play well with <<explicit-fetch-join,fetch joins>>.
-====
-
-This next query is accepted by HQL, and no more than 50 results are returned by `getResultList()`, just as expected:
-
-[[bad-limit-example]]
-[source, hql]
-----
-select title from Book
-    join fetch authors
-order by title, published desc
-limit 50
-----
-However, if you log the SQL executed by Hibernate, you'll notice something wrong:
-
-[source, sql]
-----
-select
-    b1_0.isbn,
-    a1_0.books_isbn,
-    a1_0.authors_ORDER,
-    a1_1.id,
-    a1_1.bio,
-    a1_1.name,
-    a1_1.person_id,
-    b1_0.price,
-    b1_0.published,
-    b1_0.publisher_id,
-    b1_0.title
-from
-    Book b1_0
-join
-    (Book_Author a1_0
-        join
-            Author a1_1
-                on a1_1.id=a1_0.authors_id)
-        on b1_0.isbn=a1_0.books_isbn
-order by
-    b1_0.title,
-    b1_0.published desc
-----
-
-What happened to the `limit` clause?
-
-[%unbreakable]
-[IMPORTANT]
-====
-When limits or pagination are combined with a fetch join, Hibernate must retrieve all matching results from the database and _apply the limit in memory_!
-
-This _almost certainly_ isn't the behavior you were hoping for, and in general will exhibit _terrible_ performance characteristics.
+Limiting isn't a well-defined relational operation, and must be used with care.
+Prior to Hibernate 7.4, limits didn't play well with many-valued <<explicit-fetch-join,fetch joins>>.
+This problem is now fixed on any database that supports limits and offsets in subqueries.
+But when a limit or pagination is combined with a fetch join to a collection on a database which _doesn't_ support this (notably, Sybase ASE), Hibernate must retrieve all matching results from the database and _apply the limit in memory_!
+This probably isn't the behavior you intended, and in general exhibits terrible performance characteristics.
 ====
 
 [[with-cte]]

--- a/documentation/src/main/asciidoc/userguide/chapters/query/hql/QueryLanguage.adoc
+++ b/documentation/src/main/asciidoc/userguide/chapters/query/hql/QueryLanguage.adoc
@@ -3280,17 +3280,6 @@ A query may have more than one fetch join, but be aware that:
 HQL doesn't disallow it, but it's usually a bad idea to apply a restriction to a ``join fetch``ed entity, since the elements of the fetched collection would be incomplete.
 Indeed, it's best to avoid even assigning an identification variable to a fetched joined entity except for the purpose of specifying a nested fetch join.
 
-[IMPORTANT]
-====
-Fetch joins should usually be avoided in limited or paged queries.
-This includes:
-
-- queries executed using `setFirstResult()` or `setMaxResults()`, as in <<jpql-pagination>>, or
-- queries with a limit or offset declared in HQL, described below in <<hql-limit-offset>>.
-
-Nor should they be used with the `scroll()` and `stream()` methods described in <<hql-api-incremental>>.
-====
-
 Fetch joins are disallowed in subqueries, where they would make no sense.
 
 [[hql-join-treat]]
@@ -4014,54 +4003,13 @@ include::{example-dir-hql}/HQLTest.java[tags=hql-limit-example]
 These are well-defined limits: the number of results returned by the database will be limited to 50, as promised.
 But not every query is quite so well-behaved.
 
-[NOTE]
+[CAUTION]
 ====
-_Limiting_ certainly _isn't_ a well-defined relational operation, and must be used with care.
-
-In particular, limits don't play well with <<hql-explicit-fetch-join,fetch joins>>.
-====
-
-This next query is accepted by HQL, and no more than 50 results are returned by `getResultList()`, just as expected:
-
-[[hql-bad-limit-example]]
-//.Order by example
-====
-[source, java, indent=0]
-----
-include::{example-dir-hql}/HQLTest.java[tags=hql-bad-limit-example]
-----
-====
-
-However, if you log the SQL executed by Hibernate, you'll notice something wrong:
-
-[source, sql, indent=0]
-----
-    select
-        p1_0.id,
-        c1_0.phone_id,
-        c1_0.calls_ORDER,
-        c1_0.id,
-        c1_0.duration,
-        c1_0.payment_id,
-        c1_0.call_timestamp,
-        p1_0.phone_number,
-        p1_0.person_id,
-        p1_0.phone_type
-    from
-        Phone p1_0
-    join
-        phone_call c1_0
-            on p1_0.id=c1_0.phone_id
-    order by 1
-----
-
-What happened to the `limit` clause?
-
-[IMPORTANT]
-====
-When limits or pagination are combined with a fetch join, Hibernate must retrieve all matching results from the database and _apply the limit in memory_!
-
-This _almost certainly_ isn't the behavior you were hoping for, and in general will exhibit _terrible_ performance characteristics.
+Limiting isn't a well-defined relational operation, and must be used with care.
+Prior to Hibernate 7.4, limits didn't play well with many-valued <<explicit-fetch-join,fetch joins>>.
+This problem is now fixed on any database that supports limits and offsets in subqueries.
+But when a limit or pagination is combined with a fetch join to a collection on a database which _doesn't_ support this (notably, Sybase ASE), Hibernate must retrieve all matching results from the database and _apply the limit in memory_!
+This probably isn't the behavior you intended, and in general exhibits terrible performance characteristics.
 ====
 
 In the next chapter we'll see a completely different way to write queries in Hibernate.

--- a/hibernate-core/src/main/java/org/hibernate/cfg/QuerySettings.java
+++ b/hibernate-core/src/main/java/org/hibernate/cfg/QuerySettings.java
@@ -217,16 +217,17 @@ public interface QuerySettings {
 	/**
 	 * When {@linkplain org.hibernate.query.Query#setMaxResults(int) pagination} is used
 	 * in combination with a {@code fetch join} applied to a collection or many-valued
-	 * association, the limit must be applied in-memory instead of on the database. This
-	 * typically has terrible performance characteristics, and should be avoided.
+	 * association, and the database does not support {@code LIMIT} inside a subquery,
+	 * the limit must be applied in-memory instead of on the database. This typically
+	 * has terrible performance characteristics and should be avoided.
 	 * <p>
 	 * When enabled, this setting specifies that an exception should be thrown for any
 	 * query which would result in the limit being applied in-memory.
 	 *
-	 * @settingDefault {@code false} (disabled) - no exception is thrown and the
+	 * @settingDefault {@code false} (disabled) - no exception is thrown, and the
 	 * possibility of terrible performance is left as a problem for the client to avoid.
 	 *
-	 * @since 5.2.13
+	 * @since 5.2
 	 */
 	String FAIL_ON_PAGINATION_OVER_COLLECTION_FETCH = "hibernate.query.fail_on_pagination_over_collection_fetch";
 
@@ -266,7 +267,7 @@ public interface QuerySettings {
 	 * to a parameter, a SQL statement with 8 bind parameters in the {@code IN} clause
 	 * will be used, and null will be bound to the left-over parameters.
 	 *
-	 * @since 5.2.17
+	 * @since 5.2
 	 */
 	String IN_CLAUSE_PARAMETER_PADDING = "hibernate.query.in_clause_parameter_padding";
 

--- a/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/CaseStatementDiscriminatorMappingImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/CaseStatementDiscriminatorMappingImpl.java
@@ -279,6 +279,15 @@ public class CaseStatementDiscriminatorMappingImpl extends AbstractDiscriminator
 				SqlAppender sqlAppender,
 				SqlAstTranslator<?> walker,
 				SessionFactoryImplementor sessionFactory) {
+			buildCaseExpression().accept( walker );
+		}
+
+		/**
+		 * Builds (lazily, once) the underlying {@link CaseSearchedExpression}
+		 * and returns it. Exposed so transformations can access the case
+		 * expression's column references before SQL rendering.
+		 */
+		public CaseSearchedExpression buildCaseExpression() {
 			if ( caseSearchedExpression == null ) {
 				// todo (6.0): possible optimization is to omit cases for table reference joins, that touch a super class, where a subclass is inner joined due to pruning
 				caseSearchedExpression =
@@ -314,7 +323,7 @@ public class CaseStatementDiscriminatorMappingImpl extends AbstractDiscriminator
 						}
 				);
 			}
-			caseSearchedExpression.accept( walker );
+			return caseSearchedExpression;
 		}
 
 		@Override

--- a/hibernate-core/src/main/java/org/hibernate/query/spi/QueryOptions.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/spi/QueryOptions.java
@@ -144,9 +144,21 @@ public interface QueryOptions {
 
 	/**
 	 * The limit to the query results.  May also be accessed via
-	 * {@link #getFirstRow} and {@link #getMaxRows}
+	 * {@link #getFirstRow} and {@link #getMaxRows}.
 	 */
 	Limit getLimit();
+
+	/**
+	 * The original {@link Limit} as set by the application, before any wrapper
+	 * (e.g. {@link org.hibernate.query.spi.SqlOmittingQueryOptions} or the
+	 * scroll execution context) hid it from {@link #getLimit()}. Used by
+	 * runtime parameter binders that the SQM-to-SQL converter pushed into the
+	 * SQL AST so they can bind the original value even when {@link #getLimit()}
+	 * has been intentionally suppressed for SQL rendering.
+	 */
+	default Limit peekOriginalLimit() {
+		return getLimit();
+	}
 
 	/**
 	 * The first row from the results to return

--- a/hibernate-core/src/main/java/org/hibernate/query/spi/SqlOmittingQueryOptions.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/spi/SqlOmittingQueryOptions.java
@@ -22,12 +22,18 @@ public class SqlOmittingQueryOptions extends DelegatingQueryOptions {
 	private final boolean omitLimit;
 	private final boolean omitLocks;
 	private final ListResultsConsumer.UniqueSemantic uniqueSemantic;
+	// Captured at construction so that {@link #peekOriginalLimit()} returns the
+	// original even when this instance wraps another already-omitting one (which
+	// happens, for example, when scroll's adapter rewraps an already-omitted
+	// context to suppress the outer LIMIT).
+	private final Limit originalLimit;
 
 	public SqlOmittingQueryOptions(QueryOptions queryOptions, boolean omitLimit, boolean omitLocks) {
 		super( queryOptions );
 		this.omitLimit = omitLimit;
 		this.omitLocks = omitLocks;
 		uniqueSemantic = null;
+		this.originalLimit = unwrappedLimit( queryOptions );
 	}
 
 	public SqlOmittingQueryOptions(QueryOptions queryOptions, boolean omitLimit, boolean omitLocks, ListResultsConsumer.UniqueSemantic semantic) {
@@ -35,6 +41,13 @@ public class SqlOmittingQueryOptions extends DelegatingQueryOptions {
 		this.omitLimit = omitLimit;
 		this.omitLocks = omitLocks;
 		this.uniqueSemantic = semantic;
+		this.originalLimit = unwrappedLimit( queryOptions );
+	}
+
+	private static Limit unwrappedLimit(QueryOptions queryOptions) {
+		return queryOptions instanceof SqlOmittingQueryOptions wrapped
+				? wrapped.peekOriginalLimit()
+				: queryOptions.getLimit();
 	}
 
 	public static QueryOptions omitSqlQueryOptions(QueryOptions originalOptions) {
@@ -96,6 +109,16 @@ public class SqlOmittingQueryOptions extends DelegatingQueryOptions {
 	@Override
 	public Limit getLimit() {
 		return omitLimit ? Limit.NONE : super.getLimit();
+	}
+
+	/**
+	 * The original {@code Limit} as it was before any {@code SqlOmittingQueryOptions}
+	 * wrapping. Used by the SQM-to-SQL AST converter to push pagination into a derived
+	 * table when this wrapper has hidden the limit from the SQL translator. Walks
+	 * through chained wraps (the scroll path can wrap an already-wrapped context).
+	 */
+	public Limit peekOriginalLimit() {
+		return originalLimit;
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/internal/AbstractSqmSelectionQuery.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/internal/AbstractSqmSelectionQuery.java
@@ -45,7 +45,9 @@ import jakarta.persistence.criteria.CompoundSelection;
 import static org.hibernate.cfg.QuerySettings.FAIL_ON_PAGINATION_OVER_COLLECTION_FETCH;
 import static org.hibernate.query.KeyedPage.KeyInterpretation.KEY_OF_FIRST_ON_NEXT_PAGE;
 import static org.hibernate.query.QueryLogging.QUERY_MESSAGE_LOGGER;
-import static org.hibernate.query.common.FetchClauseType.*;
+import static org.hibernate.query.common.FetchClauseType.PERCENT_ONLY;
+import static org.hibernate.query.common.FetchClauseType.PERCENT_WITH_TIES;
+import static org.hibernate.query.sqm.internal.AppliedGraphs.containsCollectionFetches;
 import static org.hibernate.query.spi.SqlOmittingQueryOptions.omitSqlQueryOptions;
 import static org.hibernate.query.sqm.internal.KeyedResult.collectKeys;
 import static org.hibernate.query.sqm.internal.KeyedResult.collectResults;
@@ -147,15 +149,21 @@ abstract class AbstractSqmSelectionQuery<R> extends AbstractSelectionQuery<R> {
 		// original query spec; if the runtime suppresses the in-memory fallback
 		// here too, the query silently returns unpaginated results. Match the
 		// converter's preconditions.
-		return hasAnyReachableFetchedPlural( roots, sessionFactory.getMappingMetamodel() );
+		return hasAnyReachableFetchedPlural( roots, sessionFactory.getMappingMetamodel() )
+			|| hasCollectionFetchesOnlyViaAppliedGraph( roots, sessionFactory.getMappingMetamodel() );
+	}
+
+	private boolean hasCollectionFetchesOnlyViaAppliedGraph(
+			List<SqmRoot<?>> roots, MappingMetamodelImplementor metamodel) {
+		return containsCollectionFetches( getQueryOptions() )
+			&& allRootsAreEntities( roots, metamodel );
 	}
 
 	private static boolean hasAnyReachableFetchedPlural(
 			List<SqmRoot<?>> roots, MappingMetamodelImplementor metamodel) {
 		boolean anyReachable = false;
 		for ( var root : roots ) {
-			final var javaType = root.getJavaType();
-			if ( javaType == null || metamodel.findEntityDescriptor( javaType ) == null ) {
+			if ( !isEntityRoot( root, metamodel ) ) {
 				return false;
 			}
 			if ( !anyReachable && hasReachableFetchedPluralJoin( root ) ) {
@@ -163,6 +171,20 @@ abstract class AbstractSqmSelectionQuery<R> extends AbstractSelectionQuery<R> {
 			}
 		}
 		return anyReachable;
+	}
+
+	private static boolean allRootsAreEntities(List<SqmRoot<?>> roots, MappingMetamodelImplementor metamodel) {
+		for ( var root : roots ) {
+			if ( !isEntityRoot( root, metamodel ) ) {
+				return false;
+			}
+		}
+		return true;
+	}
+
+	private static boolean isEntityRoot(SqmRoot<?> root, MappingMetamodelImplementor metamodel) {
+		final var javaType = root.getJavaType();
+		return javaType != null && metamodel.findEntityDescriptor( javaType ) != null;
 	}
 
 	private static boolean hasReachableFetchedPluralJoin(SqmFrom<?, ?> from) {

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/internal/AbstractSqmSelectionQuery.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/internal/AbstractSqmSelectionQuery.java
@@ -7,6 +7,10 @@ package org.hibernate.query.sqm.internal;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.hibernate.HibernateException;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
+import org.hibernate.metamodel.model.domain.PluralPersistentAttribute;
+import org.hibernate.metamodel.spi.MappingMetamodelImplementor;
+import org.hibernate.query.internal.DelegatingDomainQueryExecutionContext;
+import org.hibernate.query.spi.DomainQueryExecutionContext;
 import org.hibernate.query.spi.QueryParameterImplementor;
 import org.hibernate.query.sqm.tree.expression.JpaCriteriaParameter;
 import org.hibernate.query.sqm.tree.expression.SqmParameter;
@@ -25,6 +29,10 @@ import org.hibernate.query.spi.SelectQueryPlan;
 import org.hibernate.query.sqm.spi.NamedSqmQueryMemento;
 import org.hibernate.query.sqm.tree.SqmStatement;
 import org.hibernate.query.sqm.tree.expression.SqmJpaCriteriaParameterWrapper;
+import org.hibernate.query.sqm.tree.from.SqmAttributeJoin;
+import org.hibernate.query.sqm.tree.from.SqmFrom;
+import org.hibernate.query.sqm.tree.from.SqmRoot;
+import org.hibernate.query.sqm.tree.select.SqmQuerySpec;
 import org.hibernate.query.sqm.tree.select.SqmSelectStatement;
 import org.hibernate.query.sqm.tree.select.SqmSelection;
 import org.hibernate.sql.results.internal.TupleMetadata;
@@ -37,6 +45,8 @@ import jakarta.persistence.criteria.CompoundSelection;
 import static org.hibernate.cfg.QuerySettings.FAIL_ON_PAGINATION_OVER_COLLECTION_FETCH;
 import static org.hibernate.query.KeyedPage.KeyInterpretation.KEY_OF_FIRST_ON_NEXT_PAGE;
 import static org.hibernate.query.QueryLogging.QUERY_MESSAGE_LOGGER;
+import static org.hibernate.query.common.FetchClauseType.*;
+import static org.hibernate.query.spi.SqlOmittingQueryOptions.omitSqlQueryOptions;
 import static org.hibernate.query.sqm.internal.KeyedResult.collectKeys;
 import static org.hibernate.query.sqm.internal.KeyedResult.collectResults;
 import static org.hibernate.query.sqm.internal.SqmUtil.isHqlTuple;
@@ -94,6 +104,79 @@ abstract class AbstractSqmSelectionQuery<R> extends AbstractSelectionQuery<R> {
 		else {
 			QUERY_MESSAGE_LOGGER.firstOrMaxResultsSpecifiedWithCollectionFetch();
 		}
+	}
+
+	/**
+	 * The pagination is pushed down into a derived table over the root entity by
+	 * {@code BaseSqmToSqlAstConverter}'s
+	 * {@code CollectionFetchPaginationQueryTransformer}, so the in-memory slice
+	 * after execution is unnecessary and no warning needs to be logged. These
+	 * conditions must stay in sync with the transformer's preconditions.
+	 */
+	protected boolean isPaginationPushedToDerivedTable() {
+		final var sessionFactory = getSessionFactory();
+		if ( !sessionFactory.getJdbcServices().getDialect().supportsOffsetInSubquery() ) {
+			return false;
+		}
+		final var stmt = getSqmStatement();
+		if ( !( stmt instanceof SqmSelectStatement<?> select ) ) {
+			return false;
+		}
+		final var queryPart = select.getQueryPart();
+		if ( !( queryPart instanceof SqmQuerySpec<?> spec ) ) {
+			return false;
+		}
+		final var roots = spec.getFromClause().getRoots();
+		if ( roots.isEmpty() ) {
+			return false;
+		}
+		// "fetch first N percent rows" pushed into the inner derived table needs
+		// either native PERCENT support in a subquery or window-function-based
+		// emulation; HSQLDB has neither. Mirror the converter's bail.
+		final var fetchClauseType = spec.getFetchClauseType();
+		if ( fetchClauseType == PERCENT_ONLY || fetchClauseType == PERCENT_WITH_TIES ) {
+			final var dialect = sessionFactory.getJdbcServices().getDialect();
+			if ( !dialect.supportsFetchClause( PERCENT_ONLY )
+					&& !dialect.supportsWindowFunctions() ) {
+				return false;
+			}
+		}
+		// The transformer only rewrites when at least one root contributes a
+		// fetched plural join (directly, or through a chain of fetched
+		// singulars). Without that, the converter leaves the limit on the
+		// original query spec; if the runtime suppresses the in-memory fallback
+		// here too, the query silently returns unpaginated results. Match the
+		// converter's preconditions.
+		return hasAnyReachableFetchedPlural( roots, sessionFactory.getMappingMetamodel() );
+	}
+
+	private static boolean hasAnyReachableFetchedPlural(
+			List<SqmRoot<?>> roots, MappingMetamodelImplementor metamodel) {
+		boolean anyReachable = false;
+		for ( var root : roots ) {
+			final var javaType = root.getJavaType();
+			if ( javaType == null || metamodel.findEntityDescriptor( javaType ) == null ) {
+				return false;
+			}
+			if ( !anyReachable && hasReachableFetchedPluralJoin( root ) ) {
+				anyReachable = true;
+			}
+		}
+		return anyReachable;
+	}
+
+	private static boolean hasReachableFetchedPluralJoin(SqmFrom<?, ?> from) {
+		for ( var join : from.getSqmJoins() ) {
+			if ( join instanceof SqmAttributeJoin<?, ?> attributeJoin
+					&& attributeJoin.isFetched() ) {
+				if ( attributeJoin.getReferencedPathSource() instanceof PluralPersistentAttribute
+						// Walk through fetched singulars looking for a nested fetched plural.
+						|| hasReachableFetchedPluralJoin( attributeJoin ) ) {
+					return true;
+				}
+			}
+		}
+		return false;
 	}
 
 	public abstract SqmStatement<R> getSqmStatement();
@@ -418,5 +501,30 @@ abstract class AbstractSqmSelectionQuery<R> extends AbstractSelectionQuery<R> {
 		return queryEngine.getInterpretationCache()
 				.resolveHqlInterpretation( memento.getHqlString(), expectedResultType,
 						queryEngine.getHqlTranslator() );
+	}
+
+	/**
+	 * When pagination has been pushed down into a derived table, the outer
+	 * {@code QueryOptions} limit must be suppressed&mdash;otherwise the
+	 * dialect would reapply it on the cartesian result of the outer fetch
+	 * joins, truncating rows mid-parent.
+	 */
+	DomainQueryExecutionContext scrollExecutionContext(SqmSelectStatement<?> statement) {
+		if ( hasLimit( statement, getQueryOptions() )
+				&& statement.containsCollectionFetches()
+				&& isPaginationPushedToDerivedTable() ) {
+			final var originalQueryOptions = getQueryOptions();
+			final var normalizedQueryOptions =
+					omitSqlQueryOptions( originalQueryOptions, true, false );
+			if ( originalQueryOptions != normalizedQueryOptions ) {
+				return new DelegatingDomainQueryExecutionContext( this ) {
+					@Override
+					public QueryOptions getQueryOptions() {
+						return normalizedQueryOptions;
+					}
+				};
+			}
+		}
+		return this;
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/internal/AppliedGraphs.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/internal/AppliedGraphs.java
@@ -4,10 +4,7 @@
  */
 package org.hibernate.query.sqm.internal;
 
-import org.hibernate.graph.spi.AppliedGraph;
-import org.hibernate.graph.spi.AttributeNodeImplementor;
 import org.hibernate.graph.spi.GraphImplementor;
-import org.hibernate.graph.spi.SubGraphImplementor;
 import org.hibernate.query.spi.QueryOptions;
 
 /**
@@ -19,18 +16,18 @@ public class AppliedGraphs {
 	}
 
 	public static boolean containsCollectionFetches(QueryOptions queryOptions) {
-		final AppliedGraph appliedGraph = queryOptions.getAppliedGraph();
+		final var appliedGraph = queryOptions.getAppliedGraph();
 		return appliedGraph != null
 			&& appliedGraph.getGraph() != null
 			&& containsCollectionFetches( appliedGraph.getGraph() );
 	}
 
 	private static boolean containsCollectionFetches(GraphImplementor<?> graph) {
-		for ( AttributeNodeImplementor<?,?,?> node : graph.getNodes().values() ) {
+		for ( var node : graph.getNodes().values() ) {
 			if ( node.getAttributeDescriptor().isCollection() ) {
 				return true;
 			}
-			for ( SubGraphImplementor<?> subgraph : node.getSubGraphs().values() ) {
+			for ( var subgraph : node.getSubGraphs().values() ) {
 				if ( containsCollectionFetches( subgraph ) ) {
 					return true;
 				}

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/internal/SqmQueryImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/internal/SqmQueryImpl.java
@@ -369,10 +369,11 @@ public class SqmQueryImpl<R>
 						|| containsCollectionFetches( getQueryOptions() );
 		final boolean hasLimit = hasLimit( statement, getQueryOptions() );
 		final boolean needsDistinct = needsDistinct( containsCollectionFetches, hasLimit, statement );
+		final boolean paginationInSql = hasLimit && containsCollectionFetches && isPaginationPushedToDerivedTable();
 		final var list =
 				resolveSelectQueryPlan()
 						.performList( executionContextForDoList( containsCollectionFetches, hasLimit, needsDistinct ) );
-		return needsDistinct ? handleDistinct( hasLimit, statement, list ) : list;
+		return needsDistinct ? handleDistinct( hasLimit && !paginationInSql, statement, list ) : list;
 	}
 
 	private List<R> handleDistinct(boolean hasLimit, SqmSelectStatement<?> statement, List<R> list) {
@@ -399,7 +400,9 @@ public class SqmQueryImpl<R>
 		final var originalQueryOptions = getQueryOptions();
 		final QueryOptions normalizedQueryOptions;
 		if ( hasLimit && containsCollectionFetches ) {
-			errorOrLogForPaginationWithCollectionFetch();
+			if ( !isPaginationPushedToDerivedTable() ) {
+				errorOrLogForPaginationWithCollectionFetch();
+			}
 			normalizedQueryOptions = needsDistinct
 					? omitSqlQueryOptionsWithUniqueSemanticFilter( originalQueryOptions, true, false )
 					: omitSqlQueryOptions( originalQueryOptions, true, false );
@@ -437,9 +440,10 @@ public class SqmQueryImpl<R>
 
 	@Override
 	protected ScrollableResultsImplementor<R> doScroll(ScrollMode scrollMode) {
-		return resolveSelectQueryPlan().performScroll( scrollMode, this );
+		return resolveSelectQueryPlan()
+				.performScroll( scrollMode,
+						scrollExecutionContext( (SqmSelectStatement<?>) getSqmStatement() ) );
 	}
-
 
 	// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 	// Select query plan

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/internal/SqmQueryImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/internal/SqmQueryImpl.java
@@ -364,10 +364,11 @@ public class SqmQueryImpl<R>
 	protected List<R> doList() {
 		verifySelect();
 		final var statement = (SqmSelectStatement<?>) getSqmStatement();
+		final var queryOptions = getQueryOptions();
 		final boolean containsCollectionFetches =
 				statement.containsCollectionFetches()
-						|| containsCollectionFetches( getQueryOptions() );
-		final boolean hasLimit = hasLimit( statement, getQueryOptions() );
+						|| containsCollectionFetches( queryOptions );
+		final boolean hasLimit = hasLimit( statement, queryOptions );
 		final boolean needsDistinct = needsDistinct( containsCollectionFetches, hasLimit, statement );
 		final boolean paginationInSql = hasLimit && containsCollectionFetches && isPaginationPushedToDerivedTable();
 		final var list =

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/internal/SqmSelectionQueryImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/internal/SqmSelectionQueryImpl.java
@@ -71,6 +71,7 @@ import static org.hibernate.jpa.SpecHints.HINT_SPEC_CACHE_RETRIEVE_MODE;
 import static org.hibernate.jpa.SpecHints.HINT_SPEC_CACHE_STORE_MODE;
 import static org.hibernate.query.KeyedPage.KeyInterpretation.KEY_OF_FIRST_ON_NEXT_PAGE;
 import static org.hibernate.query.spi.SqlOmittingQueryOptions.omitSqlQueryOptions;
+import static org.hibernate.query.sqm.internal.AppliedGraphs.containsCollectionFetches;
 import static org.hibernate.query.sqm.internal.KeyBasedPagination.paginate;
 import static org.hibernate.query.sqm.internal.SqmInterpretationsKey.createInterpretationsKey;
 import static org.hibernate.query.sqm.internal.SqmUtil.isSelectionAssignableToResultType;
@@ -397,10 +398,11 @@ public class SqmSelectionQueryImpl<R> extends AbstractSqmSelectionQuery<R>
 
 	protected List<R> doList() {
 		final var statement = getSqmStatement();
+		final var queryOptions = getQueryOptions();
 		final boolean containsCollectionFetches =
-				//TODO: why is this different from QuerySqmImpl.doList()?
-				statement.containsCollectionFetches();
-		final boolean hasLimit = hasLimit( statement, getQueryOptions() );
+				statement.containsCollectionFetches()
+						|| containsCollectionFetches( queryOptions );
+		final boolean hasLimit = hasLimit( statement, queryOptions );
 		final boolean needsDistinct = needsDistinct( containsCollectionFetches, hasLimit, statement );
 		final boolean paginationInSql = hasLimit && containsCollectionFetches && isPaginationPushedToDerivedTable();
 		final var list =

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/internal/SqmSelectionQueryImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/internal/SqmSelectionQueryImpl.java
@@ -402,10 +402,11 @@ public class SqmSelectionQueryImpl<R> extends AbstractSqmSelectionQuery<R>
 				statement.containsCollectionFetches();
 		final boolean hasLimit = hasLimit( statement, getQueryOptions() );
 		final boolean needsDistinct = needsDistinct( containsCollectionFetches, hasLimit, statement );
+		final boolean paginationInSql = hasLimit && containsCollectionFetches && isPaginationPushedToDerivedTable();
 		final var list =
 				resolveQueryPlan()
 						.performList( executionContext( hasLimit, containsCollectionFetches ) );
-		return needsDistinct ? handleDistinct( hasLimit, statement, list ) : list;
+		return needsDistinct ? handleDistinct( hasLimit && !paginationInSql, statement, list ) : list;
 	}
 
 	private List<R> handleDistinct(boolean hasLimit, SqmSelectStatement<?> statement, List<R> list) {
@@ -433,7 +434,9 @@ public class SqmSelectionQueryImpl<R> extends AbstractSqmSelectionQuery<R>
 	// TODO: very similar to QuerySqmImpl.executionContextForDoList()
 	private DomainQueryExecutionContext executionContext(boolean hasLimit, boolean containsCollectionFetches) {
 		if ( hasLimit && containsCollectionFetches ) {
-			errorOrLogForPaginationWithCollectionFetch();
+			if ( !isPaginationPushedToDerivedTable() ) {
+				errorOrLogForPaginationWithCollectionFetch();
+			}
 			final var originalQueryOptions = getQueryOptions();
 			final var normalizedQueryOptions = omitSqlQueryOptions( originalQueryOptions, true, false );
 			if ( originalQueryOptions == normalizedQueryOptions ) {
@@ -455,7 +458,9 @@ public class SqmSelectionQueryImpl<R> extends AbstractSqmSelectionQuery<R>
 
 	@Override
 	protected ScrollableResultsImplementor<R> doScroll(ScrollMode scrollMode) {
-		return resolveQueryPlan().performScroll( scrollMode, this );
+		return resolveQueryPlan()
+				.performScroll( scrollMode,
+						scrollExecutionContext( getSqmStatement() ) );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/sql/BaseSqmToSqlAstConverter.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/sql/BaseSqmToSqlAstConverter.java
@@ -8843,6 +8843,9 @@ public abstract class BaseSqmToSqlAstConverter<T extends Statement> extends Base
 
 			if ( fetch != null && fetch.getTiming() == FetchTiming.IMMEDIATE ) {
 				if ( fetchable instanceof TableGroupJoinProducer ) {
+					if ( joined && fetchable instanceof PluralAttributeMapping ) {
+						containsCollectionFetches = true;
+					}
 					if ( joinedTableGroup != null ) {
 						final TableGroup actualTableGroup =
 								joinedTableGroup instanceof PluralTableGroup pluralTableGroup

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/sql/BaseSqmToSqlAstConverter.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/sql/BaseSqmToSqlAstConverter.java
@@ -125,6 +125,7 @@ import org.hibernate.query.sqm.spi.SqmCreationHelper;
 import org.hibernate.query.sqm.sql.internal.AnyDiscriminatorPathInterpretation;
 import org.hibernate.query.sqm.sql.internal.AsWrappedExpression;
 import org.hibernate.query.sqm.sql.internal.BasicValuedPathInterpretation;
+import org.hibernate.query.sqm.sql.internal.CollectionFetchPaginationQueryTransformer;
 import org.hibernate.query.sqm.sql.internal.DiscriminatedAssociationPathInterpretation;
 import org.hibernate.query.sqm.sql.internal.DiscriminatorPathInterpretation;
 import org.hibernate.query.sqm.sql.internal.DomainResultProducer;
@@ -377,6 +378,8 @@ import org.hibernate.sql.ast.tree.update.UpdateStatement;
 import org.hibernate.sql.exec.internal.AbstractJdbcParameter;
 import org.hibernate.sql.exec.internal.JdbcParameterImpl;
 import org.hibernate.sql.exec.internal.JdbcParametersImpl;
+import org.hibernate.sql.exec.internal.LimitJdbcParameter;
+import org.hibernate.sql.exec.internal.OffsetJdbcParameter;
 import org.hibernate.sql.exec.internal.SqlTypedMappingJdbcParameter;
 import org.hibernate.sql.exec.internal.VersionTypeSeedParameterSpecification;
 import org.hibernate.sql.exec.spi.ExecutionContext;
@@ -2182,24 +2185,149 @@ public abstract class BaseSqmToSqlAstConverter<T extends Statement> extends Base
 		}
 
 		if ( !containsCollectionFetches || !currentClauseStack.isEmpty() ) {
-			// Strip off the root offset and limit expressions in case the query contains collection fetches to retain
-			// the proper cardinality. We could implement pagination for single select statements differently in this
-			// case by using a subquery e.g. `... where alias in (select subAlias from ... limit ...)`
-			// or use window functions e.g. `select ... from (select ..., dense_rank() over(order by ..., id) rn from ...) tmp where tmp.rn between ...`
-			// but these transformations/translations are non-trivial and can be done later
-			inferrableTypeAccessStack.push( () -> getTypeConfiguration().getBasicTypeForJavaType( Integer.class ) );
-			sqlQueryPart.setOffsetClauseExpression( visitOffsetExpression( sqmQueryPart.getOffsetExpression() ) );
-			if ( sqmQueryPart.getFetchClauseType() == FetchClauseType.PERCENT_ONLY
-					|| sqmQueryPart.getFetchClauseType() == FetchClauseType.PERCENT_WITH_TIES ) {
-				inferrableTypeAccessStack.pop();
-				inferrableTypeAccessStack.push( () -> getTypeConfiguration().getBasicTypeForJavaType( Double.class ) );
-			}
-			sqlQueryPart.setFetchClauseExpression(
-					visitFetchExpression( sqmQueryPart.getFetchExpression() ),
-					sqmQueryPart.getFetchClauseType()
-			);
-			inferrableTypeAccessStack.pop();
+			applyOffsetAndFetch( sqmQueryPart, sqlQueryPart );
 		}
+		else if ( sqlQueryPart instanceof QuerySpec sqlQuerySpec
+				&& canPushPaginationDown( sqmQueryPart, sqlQuerySpec ) ) {
+			// Push the offset/fetch into a derived table over the root entity, leaving
+			// the plural fetch joins on an outer query. See CollectionFetchPaginationQueryTransformer.
+			applyOffsetAndFetch( sqmQueryPart, sqlQueryPart );
+			if ( sqlQueryPart.getOffsetClauseExpression() == null
+					&& sqlQueryPart.getFetchClauseExpression() == null ) {
+				applyQueryOptionsOffsetAndFetch( sqlQueryPart );
+			}
+			registerQueryTransformer( new CollectionFetchPaginationQueryTransformer() );
+		}
+		// else: strip the root offset/fetch (the in-memory fallback in
+		// AbstractSqmSelectionQuery slices the parent list after execution).
+	}
+
+	private void applyOffsetAndFetch(SqmQueryPart<?> sqmQueryPart, QueryPart sqlQueryPart) {
+		inferrableTypeAccessStack.push( () -> getTypeConfiguration().getBasicTypeForJavaType( Integer.class ) );
+		sqlQueryPart.setOffsetClauseExpression( visitOffsetExpression( sqmQueryPart.getOffsetExpression() ) );
+		if ( sqmQueryPart.getFetchClauseType() == FetchClauseType.PERCENT_ONLY
+				|| sqmQueryPart.getFetchClauseType() == FetchClauseType.PERCENT_WITH_TIES ) {
+			inferrableTypeAccessStack.pop();
+			inferrableTypeAccessStack.push( () -> getTypeConfiguration().getBasicTypeForJavaType( Double.class ) );
+		}
+		sqlQueryPart.setFetchClauseExpression(
+				visitFetchExpression( sqmQueryPart.getFetchExpression() ),
+				sqmQueryPart.getFetchClauseType()
+		);
+		inferrableTypeAccessStack.pop();
+	}
+
+	private boolean canPushPaginationDown(SqmQueryPart<?> sqmQueryPart, QuerySpec sqlQuerySpec) {
+		if ( !getDialect().supportsOffsetInSubquery() ) {
+			return false;
+		}
+		else {
+			// Every root must be an entity (so the rewrite knows how to project its
+			// primary-table columns). At least one root must contribute a plural
+			// fetched join, otherwise the limit semantics are unaffected and the
+			// rewrite is pointless. Secondary tables and joined-inheritance subtype
+			// tables come along inside the inner derived table; their columns get
+			// absorbed into the column-list and outer references rewritten.
+			final var roots = sqlQuerySpec.getFromClause().getRoots();
+			if ( roots.isEmpty() ) {
+				return false;
+			}
+			else if ( !hasPluralFetchOnSomeRoot( roots ) ) {
+				return false;
+			}
+			else if ( isPercentFetch( sqmQueryPart ) && !canRenderPercentFetchInSubquery() ) {
+				// "fetch first N percent rows" pushed into the inner derived table
+				// requires either native PERCENT support in a subquery (e.g. H2,
+				// Oracle, SQL Server) or window-function-based emulation
+				// (PostgreSQL/MySQL/etc. wrap the inner with row_number+count).
+				// Dialects with neither (HSQLDB) bail back to the in-memory
+				// fallback rather than emit unsupported SQL.
+				return false;
+			}
+			else if ( sqmQueryPart.getFetchExpression() != null
+					|| sqmQueryPart.getOffsetExpression() != null ) {
+				return true;
+			}
+			else {
+				final var limit = peekOriginalLimit();
+				return limit != null && !limit.isEmpty();
+			}
+		}
+	}
+
+	private static boolean isPercentFetch(SqmQueryPart<?> sqmQueryPart) {
+		final var fetchClauseType = sqmQueryPart.getFetchClauseType();
+		return fetchClauseType == FetchClauseType.PERCENT_ONLY
+			|| fetchClauseType == FetchClauseType.PERCENT_WITH_TIES;
+	}
+
+	private boolean canRenderPercentFetchInSubquery() {
+		final var dialect = getDialect();
+		return dialect.supportsFetchClause( FetchClauseType.PERCENT_ONLY )
+				|| dialect.supportsWindowFunctions();
+	}
+
+	private static boolean hasPluralFetchOnSomeRoot(List<TableGroup> roots) {
+		for ( var root : roots ) {
+			if ( !( root.getModelPart() instanceof EntityMappingType ) ) {
+				return false;
+			}
+			else if ( hasFetchedPluralReachable( root ) ) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	/**
+	 * True when a fetched plural join is reachable from {@code group} either
+	 * directly or through a chain of fetched singular joins. The transformer's
+	 * move pass mirrors this walk.
+	 */
+	private static boolean hasFetchedPluralReachable(TableGroup group) {
+		for ( var join : group.getTableGroupJoins() ) {
+			final var joined = join.getJoinedGroup();
+			if ( joined.isFetched() ) {
+				if ( joined instanceof PluralTableGroup
+						|| hasFetchedPluralReachable( joined ) ) {
+					return true;
+				}
+			}
+		}
+		return false;
+	}
+
+
+	private void applyQueryOptionsOffsetAndFetch(QueryPart sqlQueryPart) {
+		final var limit = peekOriginalLimit();
+		if ( limit != null && !limit.isEmpty() ) {
+			final var integerType = getTypeConfiguration().getBasicTypeForJavaType( Integer.class );
+			// Always emit both parameters so the cached plan works for any combination of
+			// setFirstResult/setMaxResults values; the parameter binders default firstRow
+			// to 0 and maxRows to Integer.MAX_VALUE when the corresponding option is not set.
+			sqlQueryPart.setOffsetClauseExpression(
+					new OffsetJdbcParameter( integerType )
+			);
+			sqlQueryPart.setFetchClauseExpression(
+					new LimitJdbcParameter( integerType ),
+					FetchClauseType.ROWS_ONLY
+			);
+		}
+	}
+
+	/**
+	 * The execution context wraps the {@code QueryOptions} with
+	 * {@link org.hibernate.query.spi.SqlOmittingQueryOptions} when there is a
+	 * collection fetch + limit, to suppress the outer LIMIT that the dialect
+	 * would otherwise append (the in-memory fallback uses this). Peek through
+	 * the wrapper here so the converter can still see the original limit values
+	 * and push them into the derived table.
+	 */
+	private org.hibernate.query.spi.Limit peekOriginalLimit() {
+		if ( queryOptions instanceof org.hibernate.query.spi.SqlOmittingQueryOptions wrapped ) {
+			return wrapped.peekOriginalLimit();
+		}
+		return queryOptions.getLimit();
 	}
 
 	private TableGroup findTableGroupByPath(NavigablePath navigablePath) {

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/sql/internal/CollectionFetchPaginationQueryTransformer.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/sql/internal/CollectionFetchPaginationQueryTransformer.java
@@ -1,0 +1,620 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.query.sqm.sql.internal;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.checkerframework.checker.nullness.qual.Nullable;
+import org.hibernate.metamodel.mapping.EntityMappingType;
+import org.hibernate.metamodel.mapping.JdbcMapping;
+import org.hibernate.metamodel.mapping.SelectableConsumer;
+import org.hibernate.metamodel.mapping.internal.CaseStatementDiscriminatorMappingImpl;
+import org.hibernate.query.sqm.sql.SqmToSqlAstConverter;
+import org.hibernate.sql.ast.spi.AbstractSqlAstWalker;
+import org.hibernate.sql.ast.spi.ExpressionReplacementWalker;
+import org.hibernate.sql.ast.spi.SqlSelection;
+import org.hibernate.sql.ast.tree.SqlAstNode;
+import org.hibernate.sql.ast.tree.cte.CteContainer;
+import org.hibernate.sql.ast.tree.expression.CaseSearchedExpression;
+import org.hibernate.sql.ast.tree.expression.CaseSimpleExpression;
+import org.hibernate.sql.ast.tree.expression.ColumnReference;
+import org.hibernate.sql.ast.tree.expression.Expression;
+import org.hibernate.sql.ast.tree.expression.QueryTransformer;
+import org.hibernate.sql.ast.tree.from.VirtualTableGroup;
+import org.hibernate.sql.ast.tree.predicate.ExistsPredicate;
+import org.hibernate.sql.ast.tree.predicate.Predicate;
+import org.hibernate.sql.ast.tree.from.AbstractTableGroup;
+import org.hibernate.sql.ast.tree.from.NamedTableReference;
+import org.hibernate.sql.ast.tree.from.PluralTableGroup;
+import org.hibernate.sql.ast.tree.from.QueryPartTableGroup;
+import org.hibernate.sql.ast.tree.from.TableGroup;
+import org.hibernate.sql.ast.tree.from.TableGroupJoin;
+import org.hibernate.sql.ast.tree.select.QuerySpec;
+import org.hibernate.sql.ast.tree.select.SelectStatement;
+import org.hibernate.sql.ast.tree.select.SortSpecification;
+import org.hibernate.sql.results.internal.ResolvedSqlSelection;
+import org.hibernate.type.BasicType;
+
+/**
+ * Pushes the offset/fetch of a top-level {@code QuerySpec} down into a derived
+ * table over the root entity, leaving fetch joins of plural attributes on the
+ * outer query so the limit applies to parent rows rather than to the cartesian
+ * product of root and collection rows.
+ * <p>
+ * In the simplest case, given an HQL query
+ * <pre>
+ *     from Book b left join fetch b.authors where b.year = :y order by b.isbn
+ * </pre>
+ * with {@code setMaxResults(n)}, the resulting SQL is
+ * <pre>
+ *     select ... from (select b.&#42; from Book b
+ *                          where b.year = ? order by b.isbn limit ?) b
+ *                 left join Author a on a.book_isbn = b.isbn
+ *                 order by b.isbn
+ * </pre>
+ * The transformer reuses the original primary root's primary table alias as the
+ * derived table identification variable, so existing column references in the
+ * outer that point at the primary root resolve through it without rewriting.
+ * <p>
+ * For more complex queries — multiple roots, non-fetch joins referenced in the
+ * outer SELECT or ORDER BY — the inner derived table also has to expose those
+ * additional aliases' columns. Those aliases are <em>absorbed</em>: their
+ * referenced columns are projected from the inner with prefixed names, the
+ * derived table column-list aliases them, and a walker rewrites every outer
+ * {@code ColumnReference} that pointed at an absorbed alias to instead address
+ * the derived table.
+ * <p>
+ * Predicates and order-by elements may not reference fetched collection
+ * elements (an HQL constraint we depend on here).
+ */
+public class CollectionFetchPaginationQueryTransformer implements QueryTransformer {
+
+	@Override
+	public QuerySpec transform(
+			CteContainer cteContainer,
+			QuerySpec querySpec,
+			SqmToSqlAstConverter converter) {
+
+		final List<TableGroup> roots = querySpec.getFromClause().getRoots();
+		if ( roots.isEmpty() ) {
+			return querySpec;
+		}
+
+		// Pick the first root that has at least one plural fetched join — that's the
+		// "primary" root whose alias becomes the derived-table identification variable.
+		final var primaryRoot = primaryRoot( roots );
+		if ( primaryRoot == null ) {
+			return querySpec;
+		}
+
+		if ( !( primaryRoot instanceof AbstractTableGroup )
+				|| !( primaryRoot.getModelPart() instanceof EntityMappingType primaryEntity )
+				|| !( primaryRoot.getPrimaryTableReference() instanceof NamedTableReference primaryNamed ) ) {
+			return querySpec;
+		}
+		final String primaryAlias = primaryNamed.getIdentificationVariable();
+		final String primaryTableExpr = primaryNamed.getTableExpression();
+
+		// Only plural fetched joins move to the outer — they are the
+		// cartesian-product source we're trying to escape. Fetched singular
+		// joins stay inside the inner so their columns can drive the
+		// pagination's ORDER BY (e.g. {@code order by p.name} where {@code p}
+		// is a fetched {@code @ManyToOne}); their columns get absorbed into
+		// the derived table for the outer SELECT to reach. Plural fetches
+		// nested under fetched singulars are also moved out — the parent
+		// singular's table reference stays inner and the plural's join
+		// predicate gets absorbed-rewritten through the derived alias.
+		final List<MovedJoin> movedJoins = new ArrayList<>();
+		collectMovedPluralFetches( primaryRoot, movedJoins );
+
+		// The aliases that will sit directly in the outer FROM after the move.
+		final Set<String> outerAliases = new HashSet<>();
+		outerAliases.add( primaryAlias );
+		for ( var moved : movedJoins ) {
+			collectAliases( moved.join().getJoinedGroup(), outerAliases );
+		}
+
+
+		// Walk the original outer content for any ColumnReference whose qualifier
+		// is neither the primary alias nor inside a moved-out join. Those qualifiers
+		// belong to TableGroups that stay in the inner — they need to be "absorbed"
+		// into the derived table.
+		final Map<AbsorbedKey, AbsorbedColumn> absorption = new LinkedHashMap<>();
+		final var collector = new AbsorbedColumnCollector( outerAliases, absorption );
+		for ( var selection : querySpec.getSelectClause().getSqlSelections() ) {
+			selection.getExpression().accept( collector );
+		}
+		if ( querySpec.hasSortSpecifications() ) {
+			for ( var sort : querySpec.getSortSpecifications() ) {
+				sort.getSortExpression().accept( collector );
+			}
+		}
+		// Moved fetch joins' predicates reference the join target (the parent
+		// alias) plus the moved alias itself. For direct moves the parent is
+		// the primary alias and no rewriting is needed; for nested moves the
+		// parent is a fetched singular's alias which is inner-only and gets
+		// absorbed into the derived table here.
+		for ( var moved : movedJoins ) {
+			final var predicate = moved.join().getPredicate();
+			if ( predicate != null ) {
+				predicate.accept( collector );
+			}
+		}
+
+		// Sanity: every absorbed qualifier must correspond to a TableGroup in the inner.
+		final Set<String> innerAliases = new HashSet<>();
+		for ( var root : roots ) {
+			collectAliases( root, innerAliases );
+		}
+		// (the primary alias is in both — that's fine)
+		for ( var key : absorption.keySet() ) {
+			if ( !innerAliases.contains( key.qualifier() ) ) {
+				return querySpec;
+			}
+		}
+
+		// Inner-join fetches act as a filter on the parent rows (only parents that
+		// have at least one matching child appear). To keep that semantics when the
+		// fetch join moves to the outer, add an EXISTS predicate to the inner
+		// referencing the joined group, so the inner pagination only sees parents
+		// that would have matched the inner join.
+		final var sessionFactory = converter.getCreationContext().getSessionFactory();
+		for ( var moved : movedJoins ) {
+			final var join = moved.join();
+			if ( join.getJoinType() == org.hibernate.sql.ast.SqlAstJoinType.INNER
+					&& join.getPredicate() != null ) {
+				final var existsSpec = new QuerySpec( false, 1 );
+				existsSpec.getFromClause().addRoot( join.getJoinedGroup() );
+				existsSpec.getSelectClause().addSqlSelection(
+						new ResolvedSqlSelection(
+								0,
+								new org.hibernate.sql.ast.tree.expression.QueryLiteral<>(
+										1,
+										sessionFactory.getTypeConfiguration()
+												.getBasicTypeForJavaType( Integer.class )
+								),
+								(BasicType<Object>) (BasicType<?>)
+										sessionFactory.getTypeConfiguration()
+												.getBasicTypeForJavaType( Integer.class )
+						)
+				);
+				existsSpec.applyPredicate( join.getPredicate() );
+				querySpec.applyPredicate(
+						new ExistsPredicate(
+								new SelectStatement( existsSpec ),
+								false,
+								sessionFactory.getTypeConfiguration()
+										.getBasicTypeForJavaType( Boolean.class )
+						)
+				);
+			}
+		}
+
+		// Capture original outer SELECT items before we rebuild the inner SELECT.
+		final List<SqlSelection> originalSelections =
+				new ArrayList<>( querySpec.getSelectClause().getSqlSelections() );
+
+		// Rebuild inner SELECT: primary entity's primary-table columns (kept under their
+		// original names so outer refs to the primary alias resolve naturally) +
+		// absorbed columns (renamed to <alias>_<col> in the derived column list).
+		final List<String> columnNames = new ArrayList<>();
+		final Set<String> seen = new HashSet<>();
+		querySpec.getSelectClause().getSqlSelections().clear();
+		final int[] position = { 0 };
+		final SelectableConsumer projector = (idx, selectable) -> {
+			if ( primaryTableExpr.equals( selectable.getContainingTableExpression() ) ) {
+				final String columnName = selectable.getSelectionExpression();
+				// Joined-inheritance with no @DiscriminatorColumn synthesises a CASE
+				// expression on the subtype tables and exposes it through a placeholder
+				// selectable like "{discriminator}". The CASE itself is in the outer
+				// SELECT and AbsorbedColumnCollector picks up its component column refs,
+				// so the inner doesn't need (and can't render) this placeholder.
+				if ( columnName.indexOf( '{' ) >= 0 ) {
+					return;
+				}
+				if ( seen.add( columnName ) ) {
+					final var ref = new ColumnReference( primaryAlias, selectable );
+					//noinspection unchecked
+					final var type = (BasicType<Object>) selectable.getJdbcMapping();
+					querySpec.getSelectClause().addSqlSelection(
+							new ResolvedSqlSelection( position[0]++, ref, type )
+					);
+					columnNames.add( columnName );
+				}
+			}
+		};
+		primaryEntity.getIdentifierMapping().forEachSelectable( projector );
+		final var discriminatorMapping = primaryEntity.getDiscriminatorMapping();
+		if ( discriminatorMapping != null ) {
+			discriminatorMapping.forEachSelectable( projector );
+		}
+		final var versionMapping = primaryEntity.getVersionMapping();
+		if ( versionMapping != null ) {
+			versionMapping.forEachSelectable( projector );
+		}
+		primaryEntity.forEachSelectable( projector );
+
+		for ( var entry : absorption.entrySet() ) {
+			final var key = entry.getKey();
+			final var info = entry.getValue();
+			final String exposedName = key.qualifier() + "_" + key.columnName();
+			final var ref = new ColumnReference(
+					key.qualifier(),
+					key.columnName(),
+					false,
+					null,
+					info.jdbcMapping
+			);
+			//noinspection unchecked
+			final var type = (BasicType<Object>) info.jdbcMapping;
+			querySpec.getSelectClause().addSqlSelection(
+					new ResolvedSqlSelection( position[0]++, ref, type )
+			);
+			columnNames.add( exposedName );
+			info.exposedName = exposedName;
+		}
+
+		// Detach the moved (fetched) plural joins from whichever group they were
+		// attached to in the inner — the primary root for direct fetches, or a
+		// fetched-singular's group for nested fetches.
+		for ( var moved : movedJoins ) {
+			moved.parent().removeTableGroupJoin( moved.join() );
+		}
+
+		// Split sort specs: those that reference an alias that's now in the outer
+		// (e.g. the synthetic ORDER BY Hibernate adds on a fetched collection's FK)
+		// can't stay on the inner — they'd reference a TableGroup we just removed.
+		// We keep all original sort specs to apply on the outer; only the
+		// inner-resolvable ones stay in the inner for deterministic LIMIT.
+		final List<SortSpecification> originalSortSpecs;
+		if ( querySpec.hasSortSpecifications() ) {
+			originalSortSpecs = new ArrayList<>( querySpec.getSortSpecifications() );
+			final var innerKeep = new ArrayList<SortSpecification>( originalSortSpecs.size() );
+			for ( var sort : originalSortSpecs ) {
+				if ( !expressionReferencesAnyAlias( sort.getSortExpression(), outerAliases, primaryAlias ) ) {
+					innerKeep.add( sort );
+				}
+			}
+			querySpec.getSortSpecifications().clear();
+			querySpec.getSortSpecifications().addAll( innerKeep );
+		}
+		else {
+			originalSortSpecs = List.of();
+		}
+
+		// Demote the original spec to a sub-query (offset/fetch/order-by stay on it).
+		final var inner = querySpec.asSubQuery();
+
+		// Build the outer query.
+		final var outer = new QuerySpec( querySpec.isRoot(), 1 );
+		final var derivedRoot = new QueryPartTableGroup(
+				primaryRoot.getNavigablePath(),
+				null,
+				new SelectStatement( inner ),
+				primaryAlias,
+				columnNames,
+				new HashSet<>( Set.of( primaryTableExpr ) ),
+				false,
+				true,
+				sessionFactory
+		);
+		outer.getFromClause().addRoot( derivedRoot );
+
+		// Add outer SELECT items and reattach moved fetch joins, rewriting any
+		// absorbed-alias ColumnReferences.
+		final var rewriter = new ColumnReferenceRewriter( absorption, primaryAlias );
+		for ( var moved : movedJoins ) {
+			final var join = moved.join();
+			final Predicate originalPredicate = join.getPredicate();
+			if ( originalPredicate == null ) {
+				derivedRoot.addTableGroupJoin( join );
+			}
+			else {
+				final Predicate rewrittenPredicate = rewriter.replaceExpressions( originalPredicate );
+				if ( rewrittenPredicate == originalPredicate ) {
+					derivedRoot.addTableGroupJoin( join );
+				}
+				else {
+					// Predicates carry a TableGroup reference at construction time —
+					// rebuild the join with the rewritten predicate so the outer's
+					// JOIN ON addresses derived-alias columns (e.g. for subclass
+					// roots where the parent FK references a now-absorbed super
+					// table's PK, or for nested fetches where the predicate
+					// references the parent fetched singular's alias).
+					derivedRoot.addTableGroupJoin( new TableGroupJoin(
+							join.getNavigablePath(),
+							join.getJoinType(),
+							join.getJoinedGroup(),
+							rewrittenPredicate
+					) );
+				}
+			}
+		}
+		for ( var sel : originalSelections ) {
+			final Expression rewritten = rewriter.rewrite( sel.getExpression() );
+			if ( rewritten == sel.getExpression() ) {
+				outer.getSelectClause().addSqlSelection( sel );
+			}
+			else {
+				//noinspection unchecked
+				final var type = (BasicType<Object>) rewritten.getExpressionType().getSingleJdbcMapping();
+				outer.getSelectClause().addSqlSelection(
+						new ResolvedSqlSelection( sel.getValuesArrayPosition(), rewritten, type )
+				);
+			}
+		}
+
+		// Outer ORDER BY mirrors the original (full) sort specs, with absorbed
+		// column references rewritten through the derived alias.
+		for ( var sort : originalSortSpecs ) {
+			final var rewritten = rewriter.rewrite( sort.getSortExpression() );
+			outer.addSortSpecification(
+					rewritten == sort.getSortExpression()
+							? sort
+							: new SortSpecification(
+									rewritten,
+									sort.getSortOrder(),
+									sort.getNullPrecedence()
+							)
+			);
+		}
+
+		return outer;
+	}
+
+	private static @Nullable TableGroup primaryRoot(List<TableGroup> roots) {
+		for ( var root : roots ) {
+			if ( hasFetchedPluralReachable( root ) ) {
+				return root;
+			}
+		}
+		return null;
+	}
+
+	private static boolean hasFetchedPluralReachable(TableGroup group) {
+		for ( var join : group.getTableGroupJoins() ) {
+			final var joined = join.getJoinedGroup();
+			if ( joined.isFetched() ) {
+				if ( joined instanceof PluralTableGroup
+						|| hasFetchedPluralReachable( joined ) ) {
+					return true;
+				}
+			}
+		}
+		return false;
+	}
+
+	/**
+	 * Collect every fetched plural {@code TableGroupJoin} reachable from
+	 * {@code group} either directly or through a chain of fetched singulars,
+	 * pairing each with its parent {@code TableGroup} so the rewrite can
+	 * detach it from the right place.
+	 */
+	private static void collectMovedPluralFetches(TableGroup group, List<MovedJoin> out) {
+		for ( var join : group.getTableGroupJoins() ) {
+			final var joined = join.getJoinedGroup();
+			if ( joined.isFetched()
+					&& !(joined instanceof VirtualTableGroup) ) {
+				if ( joined instanceof PluralTableGroup ) {
+					out.add( new MovedJoin( group, join ) );
+				}
+				else {
+					// Walk through fetched singulars looking for nested plural fetches.
+					collectMovedPluralFetches( joined, out );
+				}
+			}
+		}
+	}
+
+	private record MovedJoin(TableGroup parent, TableGroupJoin join) {
+	}
+
+	private static boolean expressionReferencesAnyAlias(
+			Expression expression,
+			Set<String> aliases,
+			String except) {
+		final boolean[] found = { false };
+		expression.accept( new AbstractSqlAstWalker() {
+			@Override
+			public void visitColumnReference(ColumnReference columnReference) {
+				final String qualifier = columnReference.getQualifier();
+				if ( qualifier != null
+						&& !qualifier.equals( except )
+						&& aliases.contains( qualifier ) ) {
+					found[0] = true;
+				}
+			}
+		} );
+		return found[0];
+	}
+
+	private static void collectAliases(TableGroup group, Set<String> aliases) {
+		final var primary = group.getPrimaryTableReference();
+		if ( primary != null ) {
+			aliases.add( primary.getIdentificationVariable() );
+		}
+		for ( var refJoin : group.getTableReferenceJoins() ) {
+			aliases.add( refJoin.getJoinedTableReference().getIdentificationVariable() );
+		}
+		for ( var tgj : group.getTableGroupJoins() ) {
+			collectAliases( tgj.getJoinedGroup(), aliases );
+		}
+		for ( var tgj : group.getNestedTableGroupJoins() ) {
+			collectAliases( tgj.getJoinedGroup(), aliases );
+		}
+	}
+
+	private record AbsorbedKey(String qualifier, String columnName) {
+	}
+
+	private static class AbsorbedColumn {
+		final JdbcMapping jdbcMapping;
+		String exposedName;
+
+		AbsorbedColumn(JdbcMapping jdbcMapping) {
+			this.jdbcMapping = jdbcMapping;
+		}
+	}
+
+	/**
+	 * Walks expressions looking for {@code ColumnReference}s whose qualifier is
+	 * not in the {@code outerAliases} set; each unique (qualifier, column) pair
+	 * is recorded for absorption into the derived table.
+	 */
+	private static class AbsorbedColumnCollector extends AbstractSqlAstWalker {
+		private final Set<String> outerAliases;
+		private final Map<AbsorbedKey, AbsorbedColumn> absorption;
+
+		private AbsorbedColumnCollector(Set<String> outerAliases, Map<AbsorbedKey, AbsorbedColumn> absorption) {
+			this.outerAliases = outerAliases;
+			this.absorption = absorption;
+		}
+
+		@Override
+		public void visitColumnReference(ColumnReference columnReference) {
+			final String qualifier = columnReference.getQualifier();
+			if ( qualifier != null && !outerAliases.contains( qualifier ) ) {
+				absorption.computeIfAbsent(
+						new AbsorbedKey( qualifier, columnReference.getColumnExpression() ),
+						k -> new AbsorbedColumn( columnReference.getJdbcMapping() )
+				);
+			}
+		}
+
+		@Override
+		public void visitSelfRenderingExpression(
+				org.hibernate.sql.ast.tree.expression.SelfRenderingExpression expression) {
+			// Joined-inheritance synthesises a CaseStatementDiscriminatorExpression
+			// whose inner CaseSearchedExpression is built lazily at SQL render time;
+			// trigger the build so the column references it will use are visible to
+			// the absorption pass.
+			if ( expression instanceof CaseStatementDiscriminatorMappingImpl.CaseStatementDiscriminatorExpression cdsExpr ) {
+				cdsExpr.buildCaseExpression().accept( this );
+			}
+		}
+	}
+
+	/**
+	 * Rewrites {@code ColumnReference}s pointing at an absorbed alias to instead
+	 * address the derived table under the prefixed column name.
+	 */
+	private static class ColumnReferenceRewriter extends ExpressionReplacementWalker {
+		private final Map<AbsorbedKey, AbsorbedColumn> absorption;
+		private final String primaryAlias;
+		// Cache replacements for identity preservation across repeated visits.
+		private final Map<ColumnReference, ColumnReference> cache = new HashMap<>();
+
+		private ColumnReferenceRewriter(Map<AbsorbedKey, AbsorbedColumn> absorption, String primaryAlias) {
+			this.absorption = absorption;
+			this.primaryAlias = primaryAlias;
+		}
+
+		private Expression rewrite(Expression expression) {
+			return replaceExpressions( expression );
+		}
+
+		@Override
+		@SuppressWarnings("unchecked")
+		protected <X extends SqlAstNode> X replaceExpression(X expression) {
+			if ( expression instanceof ColumnReference columnReference ) {
+				final String qualifier = columnReference.getQualifier();
+				if ( qualifier != null ) {
+					final var info =
+							absorption.get( new AbsorbedKey( qualifier,
+									columnReference.getColumnExpression() ) );
+					if ( info != null ) {
+						return (X) cache.computeIfAbsent(
+								columnReference,
+								original -> new ColumnReference(
+										primaryAlias,
+										info.exposedName,
+										false,
+										null,
+										original.getJdbcMapping()
+								)
+						);
+					}
+				}
+			}
+			else if ( expression instanceof CaseSearchedExpression cse ) {
+				return (X) rewriteCaseSearched( cse );
+			}
+			else if ( expression instanceof CaseSimpleExpression cse ) {
+				return (X) rewriteCaseSimple( cse );
+			}
+			else if ( expression instanceof CaseStatementDiscriminatorMappingImpl.CaseStatementDiscriminatorExpression cdsExpr ) {
+				// Replace the lazy self-rendering wrapper with the rewritten inner
+				// CASE, so the outer renders against the derived alias.
+				return (X) rewriteCaseSearched( cdsExpr.buildCaseExpression() );
+			}
+			return expression;
+		}
+
+		private CaseSearchedExpression rewriteCaseSearched(CaseSearchedExpression cse) {
+			final var fragments = cse.getWhenFragments();
+			List<CaseSearchedExpression.WhenFragment> newFragments = null;
+			for ( int i = 0; i < fragments.size(); i++ ) {
+				final var fragment = fragments.get( i );
+				final Predicate newPred = replaceExpressions( fragment.getPredicate() );
+				final Expression newResult = replaceExpressions( fragment.getResult() );
+				if ( newPred != fragment.getPredicate() || newResult != fragment.getResult() ) {
+					if ( newFragments == null ) {
+						newFragments = new ArrayList<>( fragments );
+					}
+					newFragments.set( i, new CaseSearchedExpression.WhenFragment( newPred, newResult ) );
+				}
+			}
+			final Expression originalOtherwise = cse.getOtherwise();
+			final Expression newOtherwise = originalOtherwise == null
+					? null
+					: replaceExpressions( originalOtherwise );
+			if ( newFragments != null || newOtherwise != originalOtherwise ) {
+				return new CaseSearchedExpression(
+						cse.getExpressionType(),
+						newFragments != null ? newFragments : fragments,
+						newOtherwise
+				);
+			}
+			return cse;
+		}
+
+		private CaseSimpleExpression rewriteCaseSimple(CaseSimpleExpression cse) {
+			final Expression newFixture = replaceExpressions( cse.getFixture() );
+			final var fragments = cse.getWhenFragments();
+			List<CaseSimpleExpression.WhenFragment> newFragments = null;
+			for ( int i = 0; i < fragments.size(); i++ ) {
+				final var fragment = fragments.get( i );
+				final Expression newCheck = replaceExpressions( fragment.getCheckValue() );
+				final Expression newResult = replaceExpressions( fragment.getResult() );
+				if ( newCheck != fragment.getCheckValue() || newResult != fragment.getResult() ) {
+					if ( newFragments == null ) {
+						newFragments = new ArrayList<>( fragments );
+					}
+					newFragments.set( i, new CaseSimpleExpression.WhenFragment( newCheck, newResult ) );
+				}
+			}
+			final Expression originalOtherwise = cse.getOtherwise();
+			final Expression newOtherwise = originalOtherwise == null
+					? null
+					: replaceExpressions( originalOtherwise );
+			if ( newFixture != cse.getFixture() || newFragments != null
+					|| newOtherwise != originalOtherwise ) {
+				return new CaseSimpleExpression(
+						cse.getExpressionType(),
+						newFixture,
+						newFragments != null ? newFragments : fragments,
+						newOtherwise
+				);
+			}
+			return cse;
+		}
+	}
+}

--- a/hibernate-core/src/main/java/org/hibernate/sql/ast/tree/from/AbstractTableGroup.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/ast/tree/from/AbstractTableGroup.java
@@ -110,6 +110,12 @@ public abstract class AbstractTableGroup extends AbstractColumnReferenceQualifie
 		tableGroupJoins.add( join );
 	}
 
+	public void removeTableGroupJoin(TableGroupJoin join) {
+		if ( tableGroupJoins != null ) {
+			tableGroupJoins.remove( join );
+		}
+	}
+
 	@Override
 	public void prependTableGroupJoin(NavigablePath navigablePath, TableGroupJoin join) {
 		int i = 0;

--- a/hibernate-core/src/main/java/org/hibernate/sql/ast/tree/from/DelegatingTableGroup.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/ast/tree/from/DelegatingTableGroup.java
@@ -121,6 +121,11 @@ public abstract class DelegatingTableGroup implements TableGroup {
 	}
 
 	@Override
+	public void removeTableGroupJoin(TableGroupJoin join) {
+		getTableGroup().removeTableGroupJoin( join );
+	}
+
+	@Override
 	public void prependTableGroupJoin(NavigablePath navigablePath, TableGroupJoin join) {
 		getTableGroup().prependTableGroupJoin( navigablePath, join );
 	}

--- a/hibernate-core/src/main/java/org/hibernate/sql/ast/tree/from/TableGroup.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/ast/tree/from/TableGroup.java
@@ -51,6 +51,15 @@ public interface TableGroup extends SqlAstNode, ColumnReferenceQualifier, SqmPat
 	void addTableGroupJoin(TableGroupJoin join);
 
 	/**
+	 * Removes the given table group join from this group's joins. No-op if not
+	 * present. Default implementation is unsupported; concrete groups override.
+	 */
+	default void removeTableGroupJoin(TableGroupJoin join) {
+		throw new UnsupportedOperationException(
+				"removeTableGroupJoin not supported by " + getClass().getName() );
+	}
+
+	/**
 	 * Adds the given table group join before a join as found via the given navigable path.
 	 */
 	void prependTableGroupJoin(NavigablePath navigablePath, TableGroupJoin join);

--- a/hibernate-core/src/main/java/org/hibernate/sql/exec/internal/LimitJdbcParameter.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/exec/internal/LimitJdbcParameter.java
@@ -1,0 +1,44 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.sql.exec.internal;
+
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+
+import org.hibernate.sql.exec.spi.ExecutionContext;
+import org.hibernate.sql.exec.spi.JdbcParameterBindings;
+import org.hibernate.type.BasicType;
+
+/**
+ * A {@link org.hibernate.sql.ast.tree.expression.JdbcParameter} which
+ * binds the value of the max rows from the {@code QueryOptions} limit
+ * of the current execution.
+ */
+public class LimitJdbcParameter extends AbstractJdbcParameter {
+
+	public LimitJdbcParameter(BasicType<Integer> type) {
+		super( type );
+	}
+
+	@Override
+	public void bindParameterValue(
+			PreparedStatement statement,
+			int startPosition,
+			JdbcParameterBindings jdbcParamBindings,
+			ExecutionContext executionContext) throws SQLException {
+		// Peek through any wrapper (e.g. SqlOmittingQueryOptions, the scroll
+		// execution context) so we get the application-set limit even if
+		// getLimit() has been suppressed for SQL rendering.
+		final var limit = executionContext.getQueryOptions().peekOriginalLimit();
+		final Integer maxRows = limit == null ? null : limit.getMaxRows();
+		//noinspection unchecked
+		getJdbcMapping().getJdbcValueBinder().bind(
+				statement,
+				maxRows == null ? Integer.MAX_VALUE : maxRows,
+				startPosition,
+				executionContext.getSession()
+		);
+	}
+}

--- a/hibernate-core/src/main/java/org/hibernate/sql/exec/internal/OffsetJdbcParameter.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/exec/internal/OffsetJdbcParameter.java
@@ -1,0 +1,44 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.sql.exec.internal;
+
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+
+import org.hibernate.sql.exec.spi.ExecutionContext;
+import org.hibernate.sql.exec.spi.JdbcParameterBindings;
+import org.hibernate.type.BasicType;
+
+/**
+ * A {@link org.hibernate.sql.ast.tree.expression.JdbcParameter} which
+ * binds the value of the first row from the {@code QueryOptions} limit
+ * of the current execution.
+ */
+public class OffsetJdbcParameter extends AbstractJdbcParameter {
+
+	public OffsetJdbcParameter(BasicType<Integer> type) {
+		super( type );
+	}
+
+	@Override
+	public void bindParameterValue(
+			PreparedStatement statement,
+			int startPosition,
+			JdbcParameterBindings jdbcParamBindings,
+			ExecutionContext executionContext) throws SQLException {
+		// Peek through any wrapper (e.g. SqlOmittingQueryOptions, the scroll
+		// execution context) so we get the application-set offset even if
+		// getLimit() has been suppressed for SQL rendering.
+		final var limit = executionContext.getQueryOptions().peekOriginalLimit();
+		final Integer firstRow = limit == null ? null : limit.getFirstRow();
+		//noinspection unchecked
+		getJdbcMapping().getJdbcValueBinder().bind(
+				statement,
+				firstRow == null ? 0 : firstRow,
+				startPosition,
+				executionContext.getSession()
+		);
+	}
+}

--- a/hibernate-core/src/main/java/org/hibernate/sql/exec/spi/JdbcSelectExecutor.java
+++ b/hibernate-core/src/main/java/org/hibernate/sql/exec/spi/JdbcSelectExecutor.java
@@ -207,6 +207,11 @@ public interface JdbcSelectExecutor {
 			private final List<String> databaseHints;
 			private final Integer fetchSize;
 			private final Limit limit;
+			// Preserved across the SqlOmittingQueryOptions wrap so that runtime
+			// JdbcParameter binders that the converter injected (offset/limit)
+			// can still see the application-set limit even though getLimit()
+			// reports NONE for SQL rendering.
+			private final Limit originalLimit;
 			private final ExecutionContext context;
 
 			public ScrollableExecutionContext(
@@ -225,6 +230,7 @@ public interface JdbcSelectExecutor {
 					List<String> databaseHints,
 					Integer fetchSize,
 					Limit limit,
+					Limit originalLimit,
 					ExecutionContext context) {
 				super( context.getSession() );
 				this.timeout = timeout;
@@ -242,6 +248,7 @@ public interface JdbcSelectExecutor {
 				this.databaseHints = databaseHints;
 				this.fetchSize = fetchSize;
 				this.limit = limit;
+				this.originalLimit = originalLimit;
 				this.context = context;
 			}
 
@@ -336,6 +343,11 @@ public interface JdbcSelectExecutor {
 			}
 
 			@Override
+			public Limit peekOriginalLimit() {
+				return originalLimit;
+			}
+
+			@Override
 			public QueryParameterBindings getQueryParameterBindings() {
 				return context.getQueryParameterBindings();
 			}
@@ -380,6 +392,7 @@ public interface JdbcSelectExecutor {
 				options.getDatabaseHints(),
 				options.getFetchSize(),
 				options.getLimit(),
+				options.peekOriginalLimit(),
 				context
 		);
 	}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/pagination/CollectionFetchPaginationAdvancedTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/pagination/CollectionFetchPaginationAdvancedTest.java
@@ -1,0 +1,388 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.pagination;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Inheritance;
+import jakarta.persistence.InheritanceType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.PrimaryKeyJoinColumn;
+import jakarta.persistence.SecondaryTable;
+
+import org.hibernate.cfg.QuerySettings;
+
+import org.hibernate.dialect.SybaseASEDialect;
+import org.hibernate.testing.jdbc.SQLStatementInspector;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.ServiceRegistry;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.hibernate.testing.orm.junit.Setting;
+import org.hibernate.testing.orm.junit.SkipForDialect;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Pagination-with-collection-fetch where the root entity uses
+ * {@link SecondaryTable @SecondaryTable} or {@link Inheritance(strategy=JOINED)
+ * joined inheritance}. Both shapes attach extra {@code TableReferenceJoin}s to
+ * the root {@code TableGroup}, so the rewrite has to absorb those tables'
+ * columns into the inner derived table — and for joined inheritance the outer
+ * SELECT contains a CASE-based discriminator whose internal column references
+ * also need rewriting.
+ */
+@DomainModel(annotatedClasses = {
+		CollectionFetchPaginationAdvancedTest.Album.class,
+		CollectionFetchPaginationAdvancedTest.Track.class,
+		CollectionFetchPaginationAdvancedTest.Vehicle.class,
+		CollectionFetchPaginationAdvancedTest.Car.class,
+		CollectionFetchPaginationAdvancedTest.Truck.class,
+		CollectionFetchPaginationAdvancedTest.Part.class
+})
+@ServiceRegistry(settings = @Setting(
+		name = QuerySettings.FAIL_ON_PAGINATION_OVER_COLLECTION_FETCH,
+		value = "true"
+))
+@SessionFactory(useCollectingStatementInspector = true)
+@SkipForDialect( dialectClass = SybaseASEDialect.class )
+public class CollectionFetchPaginationAdvancedTest {
+
+	@BeforeEach
+	void setUp(SessionFactoryScope scope) {
+		scope.inTransaction( s -> {
+			for ( int i = 0; i < 4; i++ ) {
+				final Album a = new Album( (long) i, "Album " + i, "Review " + i );
+				for ( int j = 0; j < 3; j++ ) {
+					a.addTrack( new Track( i * 10L + j, "Track " + i + "/" + j ) );
+				}
+				s.persist( a );
+			}
+			for ( int i = 0; i < 4; i++ ) {
+				final Vehicle v;
+				if ( i % 2 == 0 ) {
+					v = new Car( (long) i, "Make " + i, 5 );
+				}
+				else {
+					v = new Truck( (long) i, "Make " + i, 1000 );
+				}
+				for ( int j = 0; j < 3; j++ ) {
+					v.addPart( new Part( i * 10L + j, "Part " + i + "/" + j ) );
+				}
+				s.persist( v );
+			}
+		} );
+	}
+
+	@AfterEach
+	void tearDown(SessionFactoryScope scope) {
+		scope.getSessionFactory().getSchemaManager().truncate();
+	}
+
+	/**
+	 * Root entity has a {@link SecondaryTable @SecondaryTable}. Its columns
+	 * (here {@code review}) live in a separate table joined onto the root's
+	 * primary table. The inner derived table must include the secondary-table
+	 * join and project those columns; the outer's references to the secondary
+	 * table's alias get rewritten through the derived alias.
+	 */
+	@Test
+	void fetchJoinWithSecondaryTable(SessionFactoryScope scope) {
+		final SQLStatementInspector sql = scope.getCollectingStatementInspector();
+		scope.inTransaction( s -> {
+			sql.clear();
+
+			final List<Album> albums = s.createSelectionQuery(
+					"from Album a left join fetch a.tracks order by a.id",
+					Album.class
+			).setMaxResults( 2 ).list();
+
+			assertEquals( 2, albums.size() );
+			assertEquals( 0L, albums.get( 0 ).getId() );
+			assertEquals( 1L, albums.get( 1 ).getId() );
+			assertEquals( "Review 0", albums.get( 0 ).getReview() );
+			assertEquals( "Review 1", albums.get( 1 ).getReview() );
+			for ( var a : albums ) {
+				assertEquals( 3, a.getTracks().size() );
+			}
+
+			final String generated = sql.getSqlQueries().get( 0 ).toLowerCase();
+			assertTrue( generated.contains( "from (select" ) );
+			// secondary table join must be inside the inner derived table
+			final int derivedClose = generated.indexOf( ')' );
+			final String inner = generated.substring( 0, derivedClose );
+			assertTrue( inner.contains( "albumdetails" ) );
+		} );
+	}
+
+	/**
+	 * Root entity is the root of a joined-inheritance hierarchy. Subtype tables
+	 * are joined onto the primary table; the entity loader synthesises a CASE
+	 * expression on those subtype tables for the discriminator. The rewrite
+	 * absorbs those subtype tables' columns and rewrites the CASE.
+	 */
+	@Test
+	void fetchJoinWithJoinedInheritanceRoot(SessionFactoryScope scope) {
+		final SQLStatementInspector sql = scope.getCollectingStatementInspector();
+		scope.inTransaction( s -> {
+			sql.clear();
+
+			final List<Vehicle> vehicles = s.createSelectionQuery(
+					"from Vehicle v left join fetch v.parts order by v.id",
+					Vehicle.class
+			).setMaxResults( 2 ).list();
+
+			assertEquals( 2, vehicles.size() );
+			assertEquals( 0L, vehicles.get( 0 ).getId() );
+			assertEquals( 1L, vehicles.get( 1 ).getId() );
+			// runtime types must come back via the discriminator
+			final Car car = assertInstanceOf( Car.class, vehicles.get( 0 ) );
+			final Truck truck = assertInstanceOf( Truck.class, vehicles.get( 1 ) );
+			assertEquals( 5, car.getSeats() );
+			assertEquals( 1000, truck.getPayload() );
+			for ( var v : vehicles ) {
+				assertEquals( 3, v.getParts().size() );
+			}
+
+			final String generated = sql.getSqlQueries().get( 0 ).toLowerCase();
+			assertTrue( generated.contains( "from (select" ) );
+			// subtype tables must be inside the derived table; parts join outside
+			final int derivedClose = generated.indexOf( ')' );
+			final String inner = generated.substring( 0, derivedClose );
+			final String outer = generated.substring( derivedClose );
+			assertTrue( inner.contains( "car" ) );
+			assertTrue( inner.contains( "truck" ) );
+			assertTrue( outer.contains( "part" ) );
+		} );
+	}
+
+	/**
+	 * Joined-inheritance query whose root is the {@code Car} <em>subclass</em>
+	 * rather than the {@code Vehicle} root. The TableGroup has a primary table
+	 * for Car and joins to the super-table {@code Vehicle}; the rewrite needs to
+	 * absorb whichever side ends up as a {@code TableReferenceJoin}.
+	 */
+	@Test
+	void fetchJoinWithPolymorphicSubclassRoot(SessionFactoryScope scope) {
+		final SQLStatementInspector sql = scope.getCollectingStatementInspector();
+		scope.inTransaction( s -> {
+			sql.clear();
+
+			final List<Car> cars = s.createSelectionQuery(
+					"from Car c left join fetch c.parts order by c.id",
+					Car.class
+			).setMaxResults( 2 ).list();
+
+			assertEquals( 2, cars.size() );
+			assertEquals( 0L, cars.get( 0 ).getId() );
+			assertEquals( 2L, cars.get( 1 ).getId() );
+			for ( Car c : cars ) {
+				assertEquals( 5, c.getSeats() );
+				assertNotNull( c.getMake() );
+				assertEquals( 3, c.getParts().size() );
+			}
+
+			final String generated = sql.getSqlQueries().get( 0 ).toLowerCase();
+			assertTrue( generated.contains( "from (select" ) );
+		} );
+	}
+
+	@Entity(name = "Album")
+	@SecondaryTable(
+			name = "AlbumDetails",
+			pkJoinColumns = @PrimaryKeyJoinColumn(name = "id")
+	)
+	public static class Album {
+		@Id
+		private Long id;
+		private String title;
+		@Column(table = "AlbumDetails")
+		private String review;
+		@OneToMany(mappedBy = "album", cascade = CascadeType.ALL)
+		private List<Track> tracks = new ArrayList<>();
+
+		public Album() {
+		}
+
+		public Album(Long id, String title, String review) {
+			this.id = id;
+			this.title = title;
+			this.review = review;
+		}
+
+		public Long getId() {
+			return id;
+		}
+
+		public String getTitle() {
+			return title;
+		}
+
+		public String getReview() {
+			return review;
+		}
+
+		public List<Track> getTracks() {
+			return tracks;
+		}
+
+		public void addTrack(Track t) {
+			tracks.add( t );
+			t.setAlbum( this );
+		}
+	}
+
+	@Entity(name = "Track")
+	public static class Track {
+		@Id
+		private Long id;
+		private String title;
+		@ManyToOne
+		@JoinColumn(name = "album_id")
+		private Album album;
+
+		public Track() {
+		}
+
+		public Track(Long id, String title) {
+			this.id = id;
+			this.title = title;
+		}
+
+		public Long getId() {
+			return id;
+		}
+
+		public String getTitle() {
+			return title;
+		}
+
+		public Album getAlbum() {
+			return album;
+		}
+
+		public void setAlbum(Album a) {
+			this.album = a;
+		}
+	}
+
+	// No explicit @DiscriminatorColumn: Hibernate synthesises a CASE expression on
+	// the subtype tables for the discriminator, which the rewrite must handle too.
+	@Entity(name = "Vehicle")
+	@Inheritance(strategy = InheritanceType.JOINED)
+	public static abstract class Vehicle {
+		@Id
+		private Long id;
+		private String make;
+		@OneToMany(mappedBy = "vehicle", cascade = CascadeType.ALL)
+		private List<Part> parts = new ArrayList<>();
+
+		public Vehicle() {
+		}
+
+		public Vehicle(Long id, String make) {
+			this.id = id;
+			this.make = make;
+		}
+
+		public Long getId() {
+			return id;
+		}
+
+		public String getMake() {
+			return make;
+		}
+
+		public List<Part> getParts() {
+			return parts;
+		}
+
+		public void addPart(Part p) {
+			parts.add( p );
+			p.setVehicle( this );
+		}
+	}
+
+	@Entity(name = "Car")
+	public static class Car extends Vehicle {
+		private int seats;
+
+		public Car() {
+		}
+
+		public Car(Long id, String make, int seats) {
+			super( id, make );
+			this.seats = seats;
+		}
+
+		public int getSeats() {
+			return seats;
+		}
+	}
+
+	@Entity(name = "Truck")
+	public static class Truck extends Vehicle {
+		private int payload;
+
+		public Truck() {
+		}
+
+		public Truck(Long id, String make, int payload) {
+			super( id, make );
+			this.payload = payload;
+		}
+
+		public int getPayload() {
+			return payload;
+		}
+	}
+
+	@Entity(name = "Part")
+	public static class Part {
+		@Id
+		private Long id;
+		private String name;
+		@ManyToOne
+		@JoinColumn(name = "vehicle_id")
+		private Vehicle vehicle;
+
+		public Part() {
+		}
+
+		public Part(Long id, String name) {
+			this.id = id;
+			this.name = name;
+		}
+
+		public Long getId() {
+			return id;
+		}
+
+		public String getName() {
+			return name;
+		}
+
+		public Vehicle getVehicle() {
+			return vehicle;
+		}
+
+		public void setVehicle(Vehicle v) {
+			this.vehicle = v;
+		}
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/pagination/CollectionFetchPaginationCollectionShapesTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/pagination/CollectionFetchPaginationCollectionShapesTest.java
@@ -1,0 +1,491 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.pagination;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.CollectionTable;
+import jakarta.persistence.Column;
+import jakarta.persistence.ElementCollection;
+import jakarta.persistence.Embeddable;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.MapKey;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+
+import org.hibernate.cfg.QuerySettings;
+
+import org.hibernate.dialect.SybaseASEDialect;
+import org.hibernate.testing.jdbc.SQLStatementInspector;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.ServiceRegistry;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.hibernate.testing.orm.junit.Setting;
+import org.hibernate.testing.orm.junit.SkipForDialect;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Pagination over fetch joins of collection shapes other than the basic
+ * {@code @OneToMany} on entities: {@link ElementCollection @ElementCollection}
+ * of basic types, {@link ElementCollection @ElementCollection} of embeddables,
+ * {@link MapKey @MapKey}-keyed maps, and sibling plural fetches on the same
+ * root.
+ */
+@DomainModel(annotatedClasses = {
+		CollectionFetchPaginationCollectionShapesTest.Document.class,
+		CollectionFetchPaginationCollectionShapesTest.Library.class,
+		CollectionFetchPaginationCollectionShapesTest.LibBook.class,
+		CollectionFetchPaginationCollectionShapesTest.Tournament.class,
+		CollectionFetchPaginationCollectionShapesTest.Match.class,
+		CollectionFetchPaginationCollectionShapesTest.Player.class
+})
+@ServiceRegistry(settings = @Setting(
+		name = QuerySettings.FAIL_ON_PAGINATION_OVER_COLLECTION_FETCH,
+		value = "true"
+))
+@SessionFactory(useCollectingStatementInspector = true)
+@SkipForDialect( dialectClass = SybaseASEDialect.class )
+public class CollectionFetchPaginationCollectionShapesTest {
+
+	@BeforeEach
+	void setUp(SessionFactoryScope scope) {
+		scope.inTransaction( s -> {
+			for ( int i = 0; i < 4; i++ ) {
+				final Document d = new Document( (long) i, "Doc " + i );
+				d.getTags().add( "tag-" + i + "-a" );
+				d.getTags().add( "tag-" + i + "-b" );
+				d.getTags().add( "tag-" + i + "-c" );
+				d.getComments().add( new Comment( "Author " + i + "/0", "Body " + i + "/0" ) );
+				d.getComments().add( new Comment( "Author " + i + "/1", "Body " + i + "/1" ) );
+				s.persist( d );
+			}
+			for ( int i = 0; i < 4; i++ ) {
+				final Library lib = new Library( (long) i, "Library " + i );
+				for ( int j = 0; j < 3; j++ ) {
+					final LibBook book = new LibBook(
+							i * 10L + j,
+							"category-" + j,
+							"LibBook " + i + "/" + j
+					);
+					lib.addBook( book );
+				}
+				s.persist( lib );
+			}
+			for ( int i = 0; i < 4; i++ ) {
+				final Tournament t = new Tournament( (long) i, "Tournament " + i );
+				for ( int j = 0; j < 2; j++ ) {
+					t.addMatch( new Match( i * 10L + j, "Match " + i + "/" + j ) );
+				}
+				for ( int j = 0; j < 3; j++ ) {
+					t.addPlayer( new Player( i * 10L + j, "Player " + i + "/" + j ) );
+				}
+				s.persist( t );
+			}
+		} );
+	}
+
+	@AfterEach
+	void tearDown(SessionFactoryScope scope) {
+		scope.getSessionFactory().getSchemaManager().truncate();
+	}
+
+	/**
+	 * {@code @ElementCollection} of a basic type. The collection lives in its own
+	 * join-table (no entity persister) and the join group's primary table is the
+	 * collection table itself; the rewrite has to treat it like a plural fetch.
+	 */
+	@Test
+	void fetchJoinWithElementCollectionOfBasic(SessionFactoryScope scope) {
+		final SQLStatementInspector sql = scope.getCollectingStatementInspector();
+		scope.inTransaction( s -> {
+			sql.clear();
+
+			final List<Document> docs = s.createSelectionQuery(
+					"from Document d left join fetch d.tags order by d.id",
+					Document.class
+			).setMaxResults( 2 ).list();
+
+			assertEquals( 2, docs.size() );
+			assertEquals( 0L, docs.get( 0 ).getId() );
+			assertEquals( 1L, docs.get( 1 ).getId() );
+			for ( Document d : docs ) {
+				assertEquals( 3, d.getTags().size() );
+			}
+
+			final String generated = sql.getSqlQueries().get( 0 ).toLowerCase();
+			assertTrue( generated.contains( "from (select" ) );
+			final int derivedClose = generated.indexOf( ')' );
+			final String outer = generated.substring( derivedClose );
+			assertTrue( outer.contains( "tags" ) );
+		} );
+	}
+
+	/**
+	 * {@code @ElementCollection} of an {@link Embeddable @Embeddable}. The join
+	 * table has multiple value columns (one per embeddable field) — same shape
+	 * as an entity-table from the join's POV, so the rewrite path is the same.
+	 */
+	@Test
+	void fetchJoinWithElementCollectionOfEmbeddable(SessionFactoryScope scope) {
+		final SQLStatementInspector sql = scope.getCollectingStatementInspector();
+		scope.inTransaction( s -> {
+			sql.clear();
+
+			final List<Document> docs = s.createSelectionQuery(
+					"from Document d left join fetch d.comments order by d.id",
+					Document.class
+			).setMaxResults( 2 ).list();
+
+			assertEquals( 2, docs.size() );
+			assertEquals( 0L, docs.get( 0 ).getId() );
+			assertEquals( 1L, docs.get( 1 ).getId() );
+			for ( Document d : docs ) {
+				assertEquals( 2, d.getComments().size() );
+			}
+
+			final String generated = sql.getSqlQueries().get( 0 ).toLowerCase();
+			assertTrue( generated.contains( "from (select" ) );
+		} );
+	}
+
+	/**
+	 * {@code @OneToMany} typed as a {@link Map} keyed by an attribute on the
+	 * value entity. Hibernate joins the index column alongside the value
+	 * columns; the rewrite must move the whole map join (key + value) to the
+	 * outer.
+	 */
+	@Test
+	void fetchJoinWithMapByKey(SessionFactoryScope scope) {
+		final SQLStatementInspector sql = scope.getCollectingStatementInspector();
+		scope.inTransaction( s -> {
+			sql.clear();
+
+			final List<Library> libs = s.createSelectionQuery(
+					"from Library l left join fetch l.booksByCategory order by l.id",
+					Library.class
+			).setMaxResults( 2 ).list();
+
+			assertEquals( 2, libs.size() );
+			assertEquals( 0L, libs.get( 0 ).getId() );
+			assertEquals( 1L, libs.get( 1 ).getId() );
+			for ( Library lib : libs ) {
+				assertEquals( 3, lib.getBooksByCategory().size() );
+				assertNotNull( lib.getBooksByCategory().get( "category-0" ) );
+				assertNotNull( lib.getBooksByCategory().get( "category-1" ) );
+				assertNotNull( lib.getBooksByCategory().get( "category-2" ) );
+			}
+
+			final String generated = sql.getSqlQueries().get( 0 ).toLowerCase();
+			assertTrue( generated.contains( "from (select" ) );
+		} );
+	}
+
+	/**
+	 * Two sibling plural fetches on the same root (one with 2 children, one with
+	 * 3). With both moved to the outer the cartesian over the inner-paginated
+	 * roots is {@code N × M} per parent; the rewrite still produces the right
+	 * number of distinct parents and full collections on each.
+	 */
+	@Test
+	void fetchJoinWithSiblingPluralFetches(SessionFactoryScope scope) {
+		final SQLStatementInspector sql = scope.getCollectingStatementInspector();
+		scope.inTransaction( s -> {
+			sql.clear();
+
+			final List<Tournament> tournaments = s.createSelectionQuery(
+					"from Tournament t left join fetch t.matches left join fetch t.players "
+							+ "order by t.id",
+					Tournament.class
+			).setMaxResults( 2 ).list();
+
+			assertEquals( 2, tournaments.size() );
+			assertEquals( 0L, tournaments.get( 0 ).getId() );
+			assertEquals( 1L, tournaments.get( 1 ).getId() );
+			for ( Tournament t : tournaments ) {
+				assertEquals( 2, t.getMatches().size() );
+				assertEquals( 3, t.getPlayers().size() );
+			}
+
+			final String generated = sql.getSqlQueries().get( 0 ).toLowerCase();
+			assertTrue( generated.contains( "from (select" ) );
+			final int derivedClose = generated.indexOf( ')' );
+			final String outer = generated.substring( derivedClose );
+			// both fetched collections joined on the outer
+			assertTrue( outer.contains( "match" ) );
+			assertTrue( outer.contains( "player" ) );
+		} );
+	}
+
+	@Entity(name = "Document")
+	public static class Document {
+		@Id
+		private Long id;
+		private String title;
+
+		@ElementCollection
+		@CollectionTable(name = "Document_tags", joinColumns = @JoinColumn(name = "doc_id"))
+		@Column(name = "tag")
+		private Set<String> tags = new HashSet<>();
+
+		@ElementCollection
+		@CollectionTable(name = "Document_comments", joinColumns = @JoinColumn(name = "doc_id"))
+		private List<Comment> comments = new ArrayList<>();
+
+		public Document() {
+		}
+
+		public Document(Long id, String title) {
+			this.id = id;
+			this.title = title;
+		}
+
+		public Long getId() {
+			return id;
+		}
+
+		public String getTitle() {
+			return title;
+		}
+
+		public Set<String> getTags() {
+			return tags;
+		}
+
+		public List<Comment> getComments() {
+			return comments;
+		}
+	}
+
+	@Embeddable
+	public static class Comment {
+		private String author;
+		private String body;
+
+		public Comment() {
+		}
+
+		public Comment(String author, String body) {
+			this.author = author;
+			this.body = body;
+		}
+
+		public String getAuthor() {
+			return author;
+		}
+
+		public String getBody() {
+			return body;
+		}
+	}
+
+	// "Library" is a reserved word in recent MySQL; override the table name.
+	@Entity(name = "Library")
+	@Table(name = "library_entity")
+	public static class Library {
+		@Id
+		private Long id;
+		private String name;
+
+		@OneToMany(mappedBy = "library", cascade = CascadeType.ALL)
+		@MapKey(name = "category")
+		private Map<String, LibBook> booksByCategory = new HashMap<>();
+
+		public Library() {
+		}
+
+		public Library(Long id, String name) {
+			this.id = id;
+			this.name = name;
+		}
+
+		public Long getId() {
+			return id;
+		}
+
+		public String getName() {
+			return name;
+		}
+
+		public Map<String, LibBook> getBooksByCategory() {
+			return booksByCategory;
+		}
+
+		public void addBook(LibBook book) {
+			booksByCategory.put( book.getCategory(), book );
+			book.setLibrary( this );
+		}
+	}
+
+	@Entity(name = "LibBook")
+	public static class LibBook {
+		@Id
+		private Long id;
+		private String category;
+		private String title;
+		@ManyToOne
+		@JoinColumn(name = "library_id")
+		private Library library;
+
+		public LibBook() {
+		}
+
+		public LibBook(Long id, String category, String title) {
+			this.id = id;
+			this.category = category;
+			this.title = title;
+		}
+
+		public Long getId() {
+			return id;
+		}
+
+		public String getCategory() {
+			return category;
+		}
+
+		public String getTitle() {
+			return title;
+		}
+
+		public Library getLibrary() {
+			return library;
+		}
+
+		public void setLibrary(Library l) {
+			this.library = l;
+		}
+	}
+
+	@Entity(name = "Tournament")
+	public static class Tournament {
+		@Id
+		private Long id;
+		private String name;
+		@OneToMany(mappedBy = "tournament", cascade = CascadeType.ALL)
+		private Set<Match> matches = new HashSet<>();
+		@OneToMany(mappedBy = "tournament", cascade = CascadeType.ALL)
+		private Set<Player> players = new HashSet<>();
+
+		public Tournament() {
+		}
+
+		public Tournament(Long id, String name) {
+			this.id = id;
+			this.name = name;
+		}
+
+		public Long getId() {
+			return id;
+		}
+
+		public String getName() {
+			return name;
+		}
+
+		public Set<Match> getMatches() {
+			return matches;
+		}
+
+		public Set<Player> getPlayers() {
+			return players;
+		}
+
+		public void addMatch(Match m) {
+			matches.add( m );
+			m.setTournament( this );
+		}
+
+		public void addPlayer(Player p) {
+			players.add( p );
+			p.setTournament( this );
+		}
+	}
+
+	// "Match" is reserved in MySQL (MATCH...AGAINST full-text search); override the table name.
+	@Entity(name = "Match")
+	@Table(name = "match_entity")
+	public static class Match {
+		@Id
+		private Long id;
+		private String name;
+		@ManyToOne
+		@JoinColumn(name = "tournament_id")
+		private Tournament tournament;
+
+		public Match() {
+		}
+
+		public Match(Long id, String name) {
+			this.id = id;
+			this.name = name;
+		}
+
+		public Long getId() {
+			return id;
+		}
+
+		public String getName() {
+			return name;
+		}
+
+		public Tournament getTournament() {
+			return tournament;
+		}
+
+		public void setTournament(Tournament t) {
+			this.tournament = t;
+		}
+	}
+
+	@Entity(name = "Player")
+	public static class Player {
+		@Id
+		private Long id;
+		private String name;
+		@ManyToOne
+		@JoinColumn(name = "tournament_id")
+		private Tournament tournament;
+
+		public Player() {
+		}
+
+		public Player(Long id, String name) {
+			this.id = id;
+			this.name = name;
+		}
+
+		public Long getId() {
+			return id;
+		}
+
+		public String getName() {
+			return name;
+		}
+
+		public Tournament getTournament() {
+			return tournament;
+		}
+
+		public void setTournament(Tournament t) {
+			this.tournament = t;
+		}
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/pagination/CollectionFetchPaginationEdgeCasesTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/pagination/CollectionFetchPaginationEdgeCasesTest.java
@@ -1,0 +1,497 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.pagination;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.OrderColumn;
+import jakarta.persistence.Table;
+
+import org.hibernate.annotations.SQLRestriction;
+import org.hibernate.cfg.QuerySettings;
+
+import org.hibernate.dialect.SybaseASEDialect;
+import org.hibernate.testing.jdbc.SQLStatementInspector;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.ServiceRegistry;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.hibernate.testing.orm.junit.Setting;
+import org.hibernate.testing.orm.junit.SkipForDialect;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Pagination + collection-fetch edge cases:
+ * <ul>
+ *   <li>Chained / multi-level fetches ({@code a.b.c}).</li>
+ *   <li>{@link OrderColumn @OrderColumn}-driven implicit ORDER BY on the
+ *       fetched collection.</li>
+ *   <li>{@link SQLRestriction @SQLRestriction} adding a predicate to the join's
+ *       ON clause.</li>
+ * </ul>
+ */
+@DomainModel(annotatedClasses = {
+		CollectionFetchPaginationEdgeCasesTest.Show.class,
+		CollectionFetchPaginationEdgeCasesTest.Episode.class,
+		CollectionFetchPaginationEdgeCasesTest.Scene.class,
+		CollectionFetchPaginationEdgeCasesTest.Playlist.class,
+		CollectionFetchPaginationEdgeCasesTest.Song.class,
+		CollectionFetchPaginationEdgeCasesTest.Article.class,
+		CollectionFetchPaginationEdgeCasesTest.ArticleComment.class
+})
+@ServiceRegistry(settings = @Setting(
+		name = QuerySettings.FAIL_ON_PAGINATION_OVER_COLLECTION_FETCH,
+		value = "true"
+))
+@SessionFactory(useCollectingStatementInspector = true)
+@SkipForDialect( dialectClass = SybaseASEDialect.class )
+public class CollectionFetchPaginationEdgeCasesTest {
+
+	@BeforeEach
+	void setUp(SessionFactoryScope scope) {
+		scope.inTransaction( s -> {
+			for ( int i = 0; i < 4; i++ ) {
+				final Show show = new Show( (long) i, "Show " + i );
+				for ( int j = 0; j < 2; j++ ) {
+					final Episode ep = new Episode( i * 10L + j, "Ep " + i + "/" + j );
+					for ( int k = 0; k < 2; k++ ) {
+						ep.addScene( new Scene( i * 100L + j * 10 + k, "Scene " + i + "/" + j + "/" + k ) );
+					}
+					show.addEpisode( ep );
+				}
+				s.persist( show );
+			}
+			for ( int i = 0; i < 4; i++ ) {
+				final Playlist pl = new Playlist( (long) i, "Playlist " + i );
+				// add songs in non-alphabetical order to verify @OrderColumn preserves it
+				pl.addSong( new Song( i * 10L + 0, "Charlie " + i ) );
+				pl.addSong( new Song( i * 10L + 1, "Alpha " + i ) );
+				pl.addSong( new Song( i * 10L + 2, "Bravo " + i ) );
+				s.persist( pl );
+			}
+			for ( int i = 0; i < 4; i++ ) {
+				final Article art = new Article( (long) i, "Article " + i );
+				// approved comments are kept by the @SQLRestriction filter,
+				// rejected ones are not
+				art.addComment( new ArticleComment( i * 10L + 0, "approved-A " + i, true ) );
+				art.addComment( new ArticleComment( i * 10L + 1, "REJECTED " + i, false ) );
+				art.addComment( new ArticleComment( i * 10L + 2, "approved-B " + i, true ) );
+				s.persist( art );
+			}
+		} );
+	}
+
+	@AfterEach
+	void tearDown(SessionFactoryScope scope) {
+		scope.getSessionFactory().getSchemaManager().truncate();
+	}
+
+	/**
+	 * Multi-level fetch: {@code show.episodes.scenes}. The plural fetch on
+	 * {@code scenes} hangs off the {@code episodes} group, not the primary root,
+	 * so the rewrite has to handle a fetched plural join nested under an
+	 * already-moved fetched join.
+	 */
+	@Test
+	void chainedPluralFetches(SessionFactoryScope scope) {
+		final SQLStatementInspector sql = scope.getCollectingStatementInspector();
+		scope.inTransaction( s -> {
+			sql.clear();
+
+			final List<Show> shows = s.createSelectionQuery(
+					"from Show s left join fetch s.episodes e left join fetch e.scenes "
+							+ "order by s.id",
+					Show.class
+			).setMaxResults( 2 ).list();
+
+			assertEquals( 2, shows.size() );
+			assertEquals( 0L, shows.get( 0 ).getId() );
+			assertEquals( 1L, shows.get( 1 ).getId() );
+			for ( Show show : shows ) {
+				assertEquals( 2, show.getEpisodes().size() );
+				for ( Episode ep : show.getEpisodes() ) {
+					assertEquals( 2, ep.getScenes().size() );
+				}
+			}
+
+			final String generated = sql.getSqlQueries().get( 0 ).toLowerCase();
+			assertTrue( generated.contains( "from (select" ) );
+		} );
+	}
+
+	/**
+	 * {@link OrderColumn @OrderColumn} on the fetched list. Hibernate adds an
+	 * implicit ORDER BY on the index column (and sometimes on the FK) so the
+	 * collection comes back in declared order. After the fetch join moves to the
+	 * outer that synthetic ORDER BY references the moved alias and must move
+	 * with it; the inner keeps only the user's order-by.
+	 */
+	@Test
+	void orderColumnOnFetchedList(SessionFactoryScope scope) {
+		final SQLStatementInspector sql = scope.getCollectingStatementInspector();
+		scope.inTransaction( s -> {
+			sql.clear();
+
+			final List<Playlist> playlists = s.createSelectionQuery(
+					"from Playlist p left join fetch p.songs order by p.id",
+					Playlist.class
+			).setMaxResults( 2 ).list();
+
+			assertEquals( 2, playlists.size() );
+			for ( Playlist pl : playlists ) {
+				final List<Song> songs = pl.getSongs();
+				assertEquals( 3, songs.size() );
+				// order must be the insertion order Charlie / Alpha / Bravo,
+				// preserved by the @OrderColumn-driven sort
+				assertTrue( songs.get( 0 ).getTitle().contains( "Charlie" ) );
+				assertTrue( songs.get( 1 ).getTitle().contains( "Alpha" ) );
+				assertTrue( songs.get( 2 ).getTitle().contains( "Bravo" ) );
+			}
+
+			final String generated = sql.getSqlQueries().get( 0 ).toLowerCase();
+			assertTrue( generated.contains( "from (select" ) );
+		} );
+	}
+
+	/**
+	 * The plural fetch hangs off a fetched <em>singular</em> association, not off
+	 * the root: {@code from Episode e join fetch e.show sh join fetch sh.episodes}.
+	 * The rewrite must walk down through fetched singulars to find the nested
+	 * plural and move it to the outer, while pulling the singular's table into
+	 * the inner derived table (its FK from the root, plus the join row, must be
+	 * reachable from the outer so the plural can join through it).
+	 */
+	@Test
+	void nestedPluralUnderSingularFetchPaginates(SessionFactoryScope scope) {
+		final SQLStatementInspector sql = scope.getCollectingStatementInspector();
+		scope.inTransaction( s -> {
+			sql.clear();
+
+			// Episode ids in order: 0, 1, 10, 11, 20, 21, 30, 31.
+			// First page (max=3): 0, 1, 10. Episodes 0 and 1 share Show 0,
+			// episode 10 sits under Show 1.
+			final List<Episode> episodes = s.createSelectionQuery(
+					"from Episode e left join fetch e.show sh left join fetch sh.episodes "
+							+ "order by e.id",
+					Episode.class
+			).setMaxResults( 3 ).list();
+
+			assertEquals( 3, episodes.size() );
+			assertEquals( 0L, episodes.get( 0 ).getId() );
+			assertEquals( 1L, episodes.get( 1 ).getId() );
+			assertEquals( 10L, episodes.get( 2 ).getId() );
+
+			for ( Episode ep : episodes ) {
+				assertNotNull( ep.getShow() );
+				// each fetched Show has its full collection of 2 episodes
+				assertEquals( 2, ep.getShow().getEpisodes().size() );
+			}
+
+			// pagination must be in the SQL, not in memory
+			final String generated = sql.getSqlQueries().get( 0 ).toLowerCase();
+			assertTrue( generated.contains( "from (select" ) );
+		} );
+	}
+
+	/**
+	 * {@link SQLRestriction @SQLRestriction} on the fetched collection adds a
+	 * predicate to the join's ON clause. After the join moves to the outer the
+	 * predicate moves with it, and any column references inside the predicate
+	 * that point at absorbed aliases get rewritten through the derived alias.
+	 */
+	@Test
+	void sqlRestrictionOnFetchedCollection(SessionFactoryScope scope) {
+		final SQLStatementInspector sql = scope.getCollectingStatementInspector();
+		scope.inTransaction( s -> {
+			sql.clear();
+
+			final List<Article> articles = s.createSelectionQuery(
+					"from Article a left join fetch a.comments order by a.id",
+					Article.class
+			).setMaxResults( 2 ).list();
+
+			assertEquals( 2, articles.size() );
+			assertEquals( 0L, articles.get( 0 ).getId() );
+			assertEquals( 1L, articles.get( 1 ).getId() );
+			for ( Article art : articles ) {
+				// REJECTED comments are filtered by @SQLRestriction("approved=true")
+				assertEquals( 2, art.getComments().size() );
+				for ( ArticleComment c : art.getComments() ) {
+					assertTrue( c.isApproved() );
+				}
+			}
+
+			final String generated = sql.getSqlQueries().get( 0 ).toLowerCase();
+			assertTrue( generated.contains( "from (select" ) );
+			final int derivedClose = generated.indexOf( ')' );
+			final String outer = generated.substring( derivedClose );
+			// the @SQLRestriction predicate moves with the join to the outer
+			assertTrue( outer.contains( "approved" ) );
+		} );
+	}
+
+	// "Show" is reserved in MySQL (SHOW DATABASES, etc.); override the table name.
+	@Entity(name = "Show")
+	@Table(name = "show_entity")
+	public static class Show {
+		@Id
+		private Long id;
+		private String name;
+		@OneToMany(mappedBy = "show", cascade = CascadeType.ALL)
+		private Set<Episode> episodes = new HashSet<>();
+
+		public Show() {
+		}
+
+		public Show(Long id, String name) {
+			this.id = id;
+			this.name = name;
+		}
+
+		public Long getId() {
+			return id;
+		}
+
+		public String getName() {
+			return name;
+		}
+
+		public Set<Episode> getEpisodes() {
+			return episodes;
+		}
+
+		public void addEpisode(Episode e) {
+			episodes.add( e );
+			e.setShow( this );
+		}
+	}
+
+	@Entity(name = "Episode")
+	public static class Episode {
+		@Id
+		private Long id;
+		private String title;
+		@ManyToOne
+		@JoinColumn(name = "show_id")
+		private Show show;
+		@OneToMany(mappedBy = "episode", cascade = CascadeType.ALL)
+		private Set<Scene> scenes = new HashSet<>();
+
+		public Episode() {
+		}
+
+		public Episode(Long id, String title) {
+			this.id = id;
+			this.title = title;
+		}
+
+		public Long getId() {
+			return id;
+		}
+
+		public String getTitle() {
+			return title;
+		}
+
+		public Show getShow() {
+			return show;
+		}
+
+		public void setShow(Show s) {
+			this.show = s;
+		}
+
+		public Set<Scene> getScenes() {
+			return scenes;
+		}
+
+		public void addScene(Scene s) {
+			scenes.add( s );
+			s.setEpisode( this );
+		}
+	}
+
+	@Entity(name = "Scene")
+	public static class Scene {
+		@Id
+		private Long id;
+		private String title;
+		@ManyToOne
+		@JoinColumn(name = "episode_id")
+		private Episode episode;
+
+		public Scene() {
+		}
+
+		public Scene(Long id, String title) {
+			this.id = id;
+			this.title = title;
+		}
+
+		public Long getId() {
+			return id;
+		}
+
+		public String getTitle() {
+			return title;
+		}
+
+		public Episode getEpisode() {
+			return episode;
+		}
+
+		public void setEpisode(Episode e) {
+			this.episode = e;
+		}
+	}
+
+	@Entity(name = "Playlist")
+	public static class Playlist {
+		@Id
+		private Long id;
+		private String name;
+		@OneToMany(cascade = CascadeType.ALL)
+		@JoinColumn(name = "playlist_id")
+		@OrderColumn(name = "position")
+		private List<Song> songs = new ArrayList<>();
+
+		public Playlist() {
+		}
+
+		public Playlist(Long id, String name) {
+			this.id = id;
+			this.name = name;
+		}
+
+		public Long getId() {
+			return id;
+		}
+
+		public String getName() {
+			return name;
+		}
+
+		public List<Song> getSongs() {
+			return songs;
+		}
+
+		public void addSong(Song song) {
+			songs.add( song );
+		}
+	}
+
+	@Entity(name = "Song")
+	public static class Song {
+		@Id
+		private Long id;
+		private String title;
+
+		public Song() {
+		}
+
+		public Song(Long id, String title) {
+			this.id = id;
+			this.title = title;
+		}
+
+		public Long getId() {
+			return id;
+		}
+
+		public String getTitle() {
+			return title;
+		}
+	}
+
+	@Entity(name = "Article")
+	public static class Article {
+		@Id
+		private Long id;
+		private String title;
+		@OneToMany(mappedBy = "article", cascade = CascadeType.ALL)
+		@SQLRestriction("approved = true")
+		private List<ArticleComment> comments = new ArrayList<>();
+
+		public Article() {
+		}
+
+		public Article(Long id, String title) {
+			this.id = id;
+			this.title = title;
+		}
+
+		public Long getId() {
+			return id;
+		}
+
+		public String getTitle() {
+			return title;
+		}
+
+		public List<ArticleComment> getComments() {
+			return comments;
+		}
+
+		public void addComment(ArticleComment c) {
+			comments.add( c );
+			c.setArticle( this );
+		}
+	}
+
+	@Entity(name = "ArticleComment")
+	public static class ArticleComment {
+		@Id
+		private Long id;
+		private String body;
+		private boolean approved;
+		@ManyToOne
+		@JoinColumn(name = "article_id")
+		private Article article;
+
+		public ArticleComment() {
+		}
+
+		public ArticleComment(Long id, String body, boolean approved) {
+			this.id = id;
+			this.body = body;
+			this.approved = approved;
+		}
+
+		public Long getId() {
+			return id;
+		}
+
+		public String getBody() {
+			return body;
+		}
+
+		public boolean isApproved() {
+			return approved;
+		}
+
+		public Article getArticle() {
+			return article;
+		}
+
+		public void setArticle(Article a) {
+			this.article = a;
+		}
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/pagination/CollectionFetchPaginationTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/pagination/CollectionFetchPaginationTest.java
@@ -1,0 +1,569 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.pagination;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+
+import org.hibernate.cfg.QuerySettings;
+import org.hibernate.graph.GraphSemantic;
+
+import org.hibernate.dialect.SybaseASEDialect;
+import org.hibernate.testing.jdbc.SQLStatementInspector;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.ServiceRegistry;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.hibernate.testing.orm.junit.Setting;
+import org.hibernate.testing.orm.junit.SkipForDialect;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Pagination of a fetch join over a many-valued association must apply the
+ * limit/offset to the parent entities (not to the cartesian product of SQL
+ * rows). The intended strategy is to push the limit into a derived table
+ * containing only the root, and place the fetch joins outside it, e.g.:
+ * <pre>
+ * select ... from (select * from Book b ... limit ?,?) b_
+ *                 left join Author a_ on a_.book_isbn = b_.isbn
+ * </pre>
+ * The previous behaviour of fetching every row and slicing the parent list
+ * in memory must no longer fire — verified here with
+ * {@link QuerySettings#FAIL_ON_PAGINATION_OVER_COLLECTION_FETCH} switched on,
+ * which throws when the in-memory fallback would otherwise be applied.
+ */
+@DomainModel(annotatedClasses = {
+		CollectionFetchPaginationTest.Book.class,
+		CollectionFetchPaginationTest.Author.class,
+		CollectionFetchPaginationTest.Publisher.class
+})
+@ServiceRegistry(settings = @Setting(
+		name = QuerySettings.FAIL_ON_PAGINATION_OVER_COLLECTION_FETCH,
+		value = "true"
+))
+@SessionFactory(useCollectingStatementInspector = true)
+@SkipForDialect( dialectClass = SybaseASEDialect.class )
+public class CollectionFetchPaginationTest {
+
+	@BeforeEach
+	void setUp(SessionFactoryScope scope) {
+		scope.inTransaction( s -> {
+			final Publisher acme = new Publisher( 1L, "Acme" );
+			final Publisher zenith = new Publisher( 2L, "Zenith" );
+			s.persist( acme );
+			s.persist( zenith );
+			for ( int i = 0; i < 5; i++ ) {
+				final Book b = new Book( "isbn-" + i, "Book " + i );
+				b.setPublisher( i % 2 == 0 ? acme : zenith );
+				for ( int j = 0; j < 3; j++ ) {
+					b.addAuthor( new Author( i * 10L + j, "Author " + i + "/" + j ) );
+				}
+				s.persist( b );
+			}
+			// Two extra books with no authors — used by innerFetchJoin* tests to
+			// verify that 'inner join fetch' filters them out even after pagination
+			// is pushed into the derived table.
+			s.persist( new Book( "no-authors-1", "Lonely 1" ) );
+			s.persist( new Book( "no-authors-2", "Lonely 2" ) );
+		} );
+	}
+
+	@AfterEach
+	void tearDown(SessionFactoryScope scope) {
+		scope.getSessionFactory().getSchemaManager().truncate();
+	}
+
+	@Test
+	void fetchJoinWithMaxResults(SessionFactoryScope scope) {
+		final SQLStatementInspector sql = scope.getCollectingStatementInspector();
+		scope.inTransaction( s -> {
+			sql.clear();
+
+			final List<Book> books = s.createSelectionQuery(
+					"from Book b left join fetch b.authors order by b.isbn",
+					Book.class
+			).setMaxResults( 2 ).list();
+
+			assertEquals( 2, books.size() );
+			assertEquals( "isbn-0", books.get( 0 ).getIsbn() );
+			assertEquals( "isbn-1", books.get( 1 ).getIsbn() );
+			assertEquals( 3, books.get( 0 ).getAuthors().size() );
+			assertEquals( 3, books.get( 1 ).getAuthors().size() );
+
+			assertEquals( 1, sql.getSqlQueries().size() );
+			// limit must be inside a derived table, not on the outer fetch join
+			assertTrue( sql.getSqlQueries().get( 0 ).toLowerCase().contains( "from (select" ) );
+		} );
+	}
+
+	@Test
+	void entityGraphWithCollectionFetchAndMaxResults(SessionFactoryScope scope) {
+		final SQLStatementInspector sql = scope.getCollectingStatementInspector();
+		scope.inTransaction( s -> {
+			sql.clear();
+
+			final var graph = s.createEntityGraph( Book.class );
+			graph.addAttributeNode( "authors" );
+
+			final List<Book> books = s.createSelectionQuery(
+					"from Book b where b.isbn like 'isbn-%' order by b.isbn",
+					Book.class
+			).setEntityGraph( graph, GraphSemantic.FETCH )
+					.setMaxResults( 2 )
+					.list();
+
+			assertEquals( 2, books.size() );
+			assertEquals( "isbn-0", books.get( 0 ).getIsbn() );
+			assertEquals( "isbn-1", books.get( 1 ).getIsbn() );
+			for ( Book b : books ) {
+				assertEquals( 3, b.getAuthors().size() );
+			}
+
+			assertEquals( 1, sql.getSqlQueries().size() );
+			assertTrue( sql.getSqlQueries().get( 0 ).toLowerCase().contains( "from (select" ) );
+		} );
+	}
+
+	@Test
+	void fetchJoinWithFirstAndMaxResults(SessionFactoryScope scope) {
+		scope.inTransaction( s -> {
+			final List<Book> books = s.createSelectionQuery(
+					"from Book b left join fetch b.authors order by b.isbn",
+					Book.class
+			).setFirstResult( 1 ).setMaxResults( 2 ).list();
+
+			assertEquals( 2, books.size() );
+			assertEquals( "isbn-1", books.get( 0 ).getIsbn() );
+			assertEquals( "isbn-2", books.get( 1 ).getIsbn() );
+			assertEquals( 3, books.get( 0 ).getAuthors().size() );
+			assertEquals( 3, books.get( 1 ).getAuthors().size() );
+		} );
+	}
+
+	@Test
+	void fetchJoinWithMaxResultsAndRootPredicate(SessionFactoryScope scope) {
+		scope.inTransaction( s -> {
+			final List<Book> books = s.createSelectionQuery(
+					"from Book b left join fetch b.authors where b.isbn like 'isbn-%' order by b.isbn",
+					Book.class
+			).setMaxResults( 3 ).list();
+
+			assertEquals( 3, books.size() );
+			assertEquals( "isbn-0", books.get( 0 ).getIsbn() );
+			assertEquals( "isbn-2", books.get( 2 ).getIsbn() );
+			for ( Book b : books ) {
+				assertEquals( 3, b.getAuthors().size() );
+			}
+		} );
+	}
+
+	/**
+	 * {@code inner join fetch} acts as a parent-row filter: only books that have
+	 * at least one author should appear. After the fetch join moves to the outer,
+	 * the rewrite preserves that filter by adding an {@code EXISTS} subquery to
+	 * the inner — otherwise the inner pagination could pick up books with no
+	 * authors and the outer inner-join would silently drop them, leaving fewer
+	 * than {@code maxResults} rows in the result.
+	 */
+	@Test
+	void innerFetchJoinWithMaxResults(SessionFactoryScope scope) {
+		final SQLStatementInspector sql = scope.getCollectingStatementInspector();
+		scope.inTransaction( s -> {
+			sql.clear();
+
+			// "no-authors-1" and "no-authors-2" come first when ordered by isbn —
+			// without the EXISTS filter in the inner, they'd be picked up by the
+			// inner LIMIT and the outer inner-join would drop them, leaving 0
+			// results. With the filter, the inner skips them and we get isbn-0/1.
+			final List<Book> books = s.createSelectionQuery(
+					"from Book b inner join fetch b.authors order by b.isbn",
+					Book.class
+			).setMaxResults( 2 ).list();
+
+			assertEquals( 2, books.size() );
+			assertEquals( "isbn-0", books.get( 0 ).getIsbn() );
+			assertEquals( "isbn-1", books.get( 1 ).getIsbn() );
+			for ( Book b : books ) {
+				assertEquals( 3, b.getAuthors().size() );
+			}
+
+			final String generated = sql.getSqlQueries().get( 0 ).toLowerCase();
+			assertTrue( generated.contains( "from (select" ) );
+			// The inner derived table carries an EXISTS predicate to mirror the
+			// inner-join filter that's now sitting on the outer.
+			assertTrue( generated.contains( "exists" ) );
+		} );
+	}
+
+	/**
+	 * Pagination ordered by a column on a fetched {@code @ManyToOne} target. The
+	 * fetched singular join must stay inside the inner derived table so the
+	 * inner ORDER BY can drive page membership — moving the join to the outer
+	 * would force the inner to ORDER BY only the root and silently change which
+	 * rows fall in each page.
+	 */
+	@Test
+	void pageOrderedByFetchedSingularAttribute(SessionFactoryScope scope) {
+		scope.inTransaction( s -> {
+			// Acme = {isbn-0, isbn-2, isbn-4}, Zenith = {isbn-1, isbn-3}.
+			// Ordered by publisher name then isbn: Acme/0, Acme/2, Acme/4, Zenith/1, Zenith/3.
+			// First page (max=2): Acme/0, Acme/2.
+			final List<Book> books = s.createSelectionQuery(
+					"from Book b left join fetch b.publisher p left join fetch b.authors "
+							+ "where b.isbn like 'isbn-%' order by p.name, b.isbn",
+					Book.class
+			).setMaxResults( 2 ).list();
+
+			assertEquals( 2, books.size() );
+			assertEquals( "isbn-0", books.get( 0 ).getIsbn() );
+			assertEquals( "isbn-2", books.get( 1 ).getIsbn() );
+			assertEquals( "Acme", books.get( 0 ).getPublisher().getName() );
+			assertEquals( "Acme", books.get( 1 ).getPublisher().getName() );
+		} );
+	}
+
+	/**
+	 * {@code getResultStream} bypasses {@code doList} entirely, going through
+	 * {@code scroll} instead. The SQL-level pushdown still applies (the converter
+	 * does that before execution), so streaming N parents must yield exactly the
+	 * first N distinct parents with their full collections — not the cartesian
+	 * product of every parent and every child.
+	 */
+	@Test
+	void fetchJoinWithMaxResultsAsStream(SessionFactoryScope scope) {
+		final SQLStatementInspector sql = scope.getCollectingStatementInspector();
+		scope.inTransaction( s -> {
+			sql.clear();
+
+			final List<Book> books;
+			try ( var stream = s.createSelectionQuery(
+					"from Book b left join fetch b.authors where b.isbn like 'isbn-%' "
+							+ "order by b.isbn",
+					Book.class
+			).setMaxResults( 2 ).getResultStream() ) {
+				books = stream.distinct().toList();
+			}
+
+			assertEquals( 2, books.size() );
+			assertEquals( "isbn-0", books.get( 0 ).getIsbn() );
+			assertEquals( "isbn-1", books.get( 1 ).getIsbn() );
+			for ( Book b : books ) {
+				assertEquals( 3, b.getAuthors().size() );
+			}
+
+			// limit must be inside a derived table — otherwise the stream would
+			// pull every cartesian row before the LIMIT applied
+			assertTrue( sql.getSqlQueries().get( 0 ).toLowerCase().contains( "from (select" ) );
+		} );
+	}
+
+	/**
+	 * {@code select distinct b} together with a fetch + limit. {@code usesDistinct}
+	 * sets {@code needsDistinct=true} via a different path than the implicit
+	 * "limit + collection fetch" needs-dedup path; this test makes sure the
+	 * rewrite still produces N distinct parents.
+	 */
+	@Test
+	void selectDistinctWithFetchAndLimit(SessionFactoryScope scope) {
+		final SQLStatementInspector sql = scope.getCollectingStatementInspector();
+		scope.inTransaction( s -> {
+			sql.clear();
+
+			final List<Book> books = s.createSelectionQuery(
+					"select distinct b from Book b left join fetch b.authors order by b.isbn",
+					Book.class
+			).setMaxResults( 2 ).list();
+
+			assertEquals( 2, books.size() );
+			assertEquals( "isbn-0", books.get( 0 ).getIsbn() );
+			assertEquals( "isbn-1", books.get( 1 ).getIsbn() );
+			for ( Book b : books ) {
+				assertEquals( 3, b.getAuthors().size() );
+			}
+
+			assertTrue( sql.getSqlQueries().get( 0 ).toLowerCase().contains( "from (select" ) );
+		} );
+	}
+
+	/**
+	 * A plural fetch alongside a singular {@code @ManyToOne} fetch. Only the
+	 * plural fetch moves to the outer query; the fetched publisher stays in the
+	 * inner derived table so its columns can still participate in pagination
+	 * ordering, and those columns are absorbed into the derived table for the
+	 * outer SELECT to reach.
+	 */
+	@Test
+	void fetchJoinWithSingularFetchToo(SessionFactoryScope scope) {
+		final SQLStatementInspector sql = scope.getCollectingStatementInspector();
+		scope.inTransaction( s -> {
+			sql.clear();
+
+			final List<Book> books = s.createSelectionQuery(
+					"from Book b left join fetch b.publisher left join fetch b.authors order by b.isbn",
+					Book.class
+			).setMaxResults( 2 ).list();
+
+			assertEquals( 2, books.size() );
+			assertEquals( "isbn-0", books.get( 0 ).getIsbn() );
+			assertEquals( "isbn-1", books.get( 1 ).getIsbn() );
+			for ( Book b : books ) {
+				assertEquals( 3, b.getAuthors().size() );
+				assertNotNull( b.getPublisher() );
+				assertEquals(
+						b == books.get( 0 ) ? "Acme" : "Zenith",
+						b.getPublisher().getName()
+				);
+			}
+
+			final String generated = sql.getSqlQueries().get( 0 ).toLowerCase();
+			assertTrue( generated.contains( "from (select" ) );
+			// publisher stays in the inner derived table; author moves to the outer
+			assertTrue( generated.contains( "publisher" ) );
+			assertTrue( generated.contains( "author" ) );
+		} );
+	}
+
+	/**
+	 * Two root entities, paginated. Both roots end up in the inner derived
+	 * table; {@code Publisher}'s columns are absorbed (renamed in the column
+	 * list) and the outer's references to {@code p1_0.*} are rewritten to use
+	 * the derived table.
+	 */
+	@Test
+	void fetchJoinWithMultipleRoots(SessionFactoryScope scope) {
+		final SQLStatementInspector sql = scope.getCollectingStatementInspector();
+		scope.inTransaction( s -> {
+			sql.clear();
+
+			record BookPublisher(Book book, Publisher publisher) {}
+
+			final List<BookPublisher> rows = s.createSelectionQuery(
+					"select b, p from Book b left join fetch b.authors, Publisher p "
+							+ "where b.publisher = p order by b.isbn",
+					BookPublisher.class
+			).setMaxResults( 2 ).list()
+					.stream().distinct().toList();
+
+			assertEquals( 2, rows.size() );
+			assertEquals( "isbn-0", rows.get( 0 ).book().getIsbn() );
+			assertEquals( "isbn-1", rows.get( 1 ).book().getIsbn() );
+			assertEquals( "Acme", rows.get( 0 ).publisher().getName() );
+			assertEquals( "Zenith", rows.get( 1 ).publisher().getName() );
+
+			final String generated = sql.getSqlQueries().get( 0 ).toLowerCase();
+			assertTrue( generated.contains( "from (select" ) );
+		} );
+	}
+
+	/**
+	 * Non-fetch association join {@code join b.publisher p} alongside a plural
+	 * fetch. The publisher is only used as a filter (not loaded), so it stays
+	 * inside the inner derived table while the authors fetch moves to the outer.
+	 */
+	@Test
+	void nonFetchJoinPlusFetchJoin(SessionFactoryScope scope) {
+		final SQLStatementInspector sql = scope.getCollectingStatementInspector();
+		scope.inTransaction( s -> {
+			sql.clear();
+
+			final List<Book> books = s.createSelectionQuery(
+					"from Book b join b.publisher p left join fetch b.authors "
+							+ "where p.name = 'Acme' order by b.isbn",
+					Book.class
+			).setMaxResults( 2 ).list();
+
+			assertEquals( 2, books.size() );
+			assertEquals( "isbn-0", books.get( 0 ).getIsbn() );
+			assertEquals( "isbn-2", books.get( 1 ).getIsbn() );
+			for ( Book b : books ) {
+				assertEquals( 3, b.getAuthors().size() );
+			}
+
+			final String generated = sql.getSqlQueries().get( 0 ).toLowerCase();
+			assertTrue( generated.contains( "from (select" ) );
+			// The non-fetch publisher join must remain inside the derived table —
+			// the outer query refers to it only via the WHERE predicate which moved
+			// down to the inner.
+			final int derivedClose = generated.indexOf( ')' );
+			final String inner = generated.substring( 0, derivedClose );
+			final String outer = generated.substring( derivedClose );
+			assertTrue( inner.contains( "publisher" ) );
+			assertTrue( outer.contains( "author" ) );
+		} );
+	}
+
+	/**
+	 * Non-fetch association join {@code join b.publisher p} alongside a plural
+	 * fetch. The publisher is only used as a filter (not loaded), so it stays
+	 * inside the inner derived table while the authors fetch moves to the outer.
+	 */
+	@Test
+	void nonFetchJoinPlusFetchJoin2(SessionFactoryScope scope) {
+		final SQLStatementInspector sql = scope.getCollectingStatementInspector();
+		scope.inTransaction( s -> {
+			sql.clear();
+
+			record BookPublisher(Book book, Publisher publisher) {}
+
+			final List<BookPublisher> books = s.createSelectionQuery(
+					"select b, p from Book b join b.publisher p left join fetch b.authors "
+					+ "where p.name = 'Acme' order by b.isbn",
+					BookPublisher.class
+			).setMaxResults( 2 ).list()
+					.stream().distinct().toList();
+
+			assertEquals( 2, books.size() );
+			assertEquals( "isbn-0", books.get( 0 ).book().getIsbn() );
+			assertEquals( "isbn-2", books.get( 1 ).book().getIsbn() );
+			for ( var b : books ) {
+				assertEquals( 3, b.book().getAuthors().size() );
+			}
+			assertEquals( "Acme", books.get( 0 ).publisher().getName() );
+			assertEquals( "Acme", books.get( 1 ).publisher().getName() );
+
+			final String generated = sql.getSqlQueries().get( 0 ).toLowerCase();
+			assertTrue( generated.contains( "from (select" ) );
+			// The non-fetch publisher join must remain inside the derived table —
+			// the outer query refers to it only via the WHERE predicate which moved
+			// down to the inner.
+			final int derivedClose = generated.indexOf( ')' );
+			final String inner = generated.substring( 0, derivedClose );
+			final String outer = generated.substring( derivedClose );
+			assertTrue( inner.contains( "publisher" ) );
+			assertTrue( outer.contains( "author" ) );
+		} );
+	}
+
+	@Entity(name = "Book")
+	public static class Book {
+		@Id
+		private String isbn;
+		private String title;
+		@ManyToOne(fetch = FetchType.LAZY)
+		@JoinColumn(name = "publisher_id")
+		private Publisher publisher;
+		@OneToMany(mappedBy = "book", cascade = CascadeType.ALL)
+		private List<Author> authors = new ArrayList<>();
+
+		public Book() {
+		}
+
+		public Book(String isbn, String title) {
+			this.isbn = isbn;
+			this.title = title;
+		}
+
+		@Override
+		public String toString() {
+			return isbn;
+		}
+
+		public String getIsbn() {
+			return isbn;
+		}
+
+		public String getTitle() {
+			return title;
+		}
+
+		public Publisher getPublisher() {
+			return publisher;
+		}
+
+		public void setPublisher(Publisher publisher) {
+			this.publisher = publisher;
+		}
+
+		public List<Author> getAuthors() {
+			return authors;
+		}
+
+		public void addAuthor(Author a) {
+			authors.add( a );
+			a.setBook( this );
+		}
+	}
+
+	@Entity(name = "Publisher")
+	public static class Publisher {
+		@Id
+		private Long id;
+		private String name;
+
+		@Override
+		public String toString() {
+			return name;
+		}
+
+		public Publisher() {
+		}
+
+		public Publisher(Long id, String name) {
+			this.id = id;
+			this.name = name;
+		}
+
+		public Long getId() {
+			return id;
+		}
+
+		public String getName() {
+			return name;
+		}
+	}
+
+	@Entity(name = "Author")
+	public static class Author {
+		@Id
+		private Long id;
+		private String name;
+		@ManyToOne
+		@JoinColumn(name = "book_isbn")
+		private Book book;
+
+		@Override
+		public String toString() {
+			return name;
+		}
+
+		public Author() {
+		}
+
+		public Author(Long id, String name) {
+			this.id = id;
+			this.name = name;
+		}
+
+		public Long getId() {
+			return id;
+		}
+
+		public String getName() {
+			return name;
+		}
+
+		public Book getBook() {
+			return book;
+		}
+
+		public void setBook(Book b) {
+			this.book = b;
+		}
+	}
+}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/pagination/CollectionFetchPaginationTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/pagination/CollectionFetchPaginationTest.java
@@ -113,6 +113,28 @@ public class CollectionFetchPaginationTest {
 	}
 
 	@Test
+	void fetchJoinWithExplicitLimitClause(SessionFactoryScope scope) {
+		final SQLStatementInspector sql = scope.getCollectingStatementInspector();
+		scope.inTransaction( s -> {
+			sql.clear();
+
+			final List<Book> books = s.createSelectionQuery(
+					"from Book b left join fetch b.authors order by b.isbn limit 2",
+					Book.class
+			).list();
+
+			assertEquals( 2, books.size() );
+			assertEquals( "isbn-0", books.get( 0 ).getIsbn() );
+			assertEquals( "isbn-1", books.get( 1 ).getIsbn() );
+			assertEquals( 3, books.get( 0 ).getAuthors().size() );
+			assertEquals( 3, books.get( 1 ).getAuthors().size() );
+
+			assertEquals( 1, sql.getSqlQueries().size() );
+			assertTrue( sql.getSqlQueries().get( 0 ).toLowerCase().contains( "from (select" ) );
+		} );
+	}
+
+	@Test
 	void entityGraphWithCollectionFetchAndMaxResults(SessionFactoryScope scope) {
 		final SQLStatementInspector sql = scope.getCollectingStatementInspector();
 		scope.inTransaction( s -> {

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/pagination/hhh9965/HHH9965Test.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/pagination/hhh9965/HHH9965Test.java
@@ -6,8 +6,10 @@ package org.hibernate.orm.test.pagination.hhh9965;
 
 import org.hibernate.HibernateException;
 import org.hibernate.cfg.Environment;
+import org.hibernate.dialect.SybaseASEDialect;
 import org.hibernate.testing.orm.junit.DomainModel;
 import org.hibernate.testing.orm.junit.JiraKey;
+import org.hibernate.testing.orm.junit.RequiresDialect;
 import org.hibernate.testing.orm.junit.ServiceRegistry;
 import org.hibernate.testing.orm.junit.SessionFactory;
 import org.hibernate.testing.orm.junit.SessionFactoryScope;
@@ -18,8 +20,6 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.fail;
 
 /**
- * Created on 17/12/17.
- *
  * @author Reda.Housni-Alaoui
  */
 @JiraKey(value = "HHH-9965")
@@ -33,6 +33,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 		settings = @Setting(name = Environment.FAIL_ON_PAGINATION_OVER_COLLECTION_FETCH, value = "true")
 )
 @SessionFactory
+@RequiresDialect(SybaseASEDialect.class)
 public class HHH9965Test {
 
 	@Test

--- a/whats-new.adoc
+++ b/whats-new.adoc
@@ -32,6 +32,14 @@ Historical temporal data may be queried at a given effective data/time.
 
 Audited data is mapped to a regular table along with an audit log which is backward compatible with Hibernate Envers.
 
+[[limit-fetch-join]]
+== Limits and fetch joins
+
+It is now perfectly safe to combine a HQL `limit` or pagination using `setMaxResults()` with a single collection `join fetch`, on any database which supports limits and offsets inside subqueries (which includes all the supported databases except Sybase ASE).
+
+In Hibernate 6, and in previous versions of Hibernate 7, the combination of limits/pagination with a many-valued fetch join forced Hibernate to fall back to applying the limit _in the JVM_, which usually exhibited terrible performance characteristics.
+This problem is finally solved.
+
 [[reveng]]
 == Reverse Engineering
 


### PR DESCRIPTION
squashes #12241.

[Please describe here what your change is about]

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------


---
<!-- Hibernate GitHub Bot task list start -->
Please make sure that the following tasks are completed:
Tasks specific to HHH-19933 (Improvement):
- [x] Add tests for feature/improvement
- [x] Update documentation as relevant: javadoc for changed API, `documentation/src/main/asciidoc/userguide` for all features, `documentation/src/main/asciidoc/introduction` for main features, links from existing documentation
- [ ] Add entries as relevant to `migration-guide.adoc` (breaking changes) and `whats-new.adoc` (new features/improvements)


<!-- Hibernate GitHub Bot task list end -->

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-19933
<!-- Hibernate GitHub Bot issue links end -->