### PR TITLE
HHH-17185 Fix SQLServerDialect using DATEDIFF_BIG on pre-2016 SQL Server

### DIFF
--- a/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/SQLServerLegacyDialect.java
+++ b/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/SQLServerLegacyDialect.java
@@ -947,7 +947,9 @@ public class SQLServerLegacyDialect extends AbstractTransactSQLDialect {
 				//this should evaluate to a floating point type
 				return "(datepart(second,?2)+datepart(nanosecond,?2)/1000000000)";
 			case EPOCH:
-				return "datediff_big(second, '1970-01-01', ?2)";
+				return getVersion().isSameOrAfter( 13 )
+						? "datediff_big(second, '1970-01-01', ?2)"
+						: "datediff(second, '1970-01-01', ?2)";
 			case WEEK:
 				// Thanks https://www.sqlservercentral.com/articles/a-simple-formula-to-calculate-the-iso-week-number
 				if ( getVersion().isBefore( 10 ) ) {
@@ -978,14 +980,15 @@ public class SQLServerLegacyDialect extends AbstractTransactSQLDialect {
 
 	@Override
 	public String timestampdiffPattern(TemporalUnit unit, TemporalType fromTemporalType, TemporalType toTemporalType) {
-		if ( unit == TemporalUnit.NATIVE ) {//use microsecond as the "native" precision
-			return "datediff_big(nanosecond,?2,?3)";
+		boolean supportsDateDiffBig = getVersion().isSameOrAfter( 13 );
+		if ( unit == TemporalUnit.NATIVE ) {//use nanosecond as the "native" precision
+			return supportsDateDiffBig ? "datediff_big(nanosecond,?2,?3)" : "datediff(nanosecond,?2,?3)";
 		}
 
 		//datediff() returns an int, and can easily
 		//overflow when dealing with "physical"
 		//durations, so use datediff_big()
-		return unit.normalized() == NANOSECOND
+		return unit.normalized() == NANOSECOND && supportsDateDiffBig
 				? "datediff_big(?1,?2,?3)"
 				: "datediff(?1,?2,?3)";
 	}

--- a/hibernate-core/src/main/java/org/hibernate/dialect/SQLServerDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/SQLServerDialect.java
@@ -877,6 +877,7 @@ public class SQLServerDialect extends AbstractTransactSQLDialect {
 
 	@Override
 	public String extractPattern(TemporalUnit unit) {
+		boolean supportsDateDiffBig = getVersion().isSameOrAfter( 13 );
 		return switch (unit) {
 			case TIMEZONE_HOUR -> "(datepart(tz,?2)/60)";
 			case TIMEZONE_MINUTE -> "(datepart(tz,?2)%60)";
@@ -888,7 +889,9 @@ public class SQLServerDialect extends AbstractTransactSQLDialect {
 			case SECOND ->
 				//this should evaluate to a floating point type
 					"(datepart(second,?2)+datepart(nanosecond,?2)/1000000000)";
-			case EPOCH -> "datediff_big(second, '1970-01-01', ?2)";
+			case EPOCH -> supportsDateDiffBig
+					? "datediff_big(second, '1970-01-01', ?2)"
+					: "datediff(second, '1970-01-01', ?2)";
 			default -> "datepart(?1,?2)";
 		};
 	}
@@ -910,15 +913,16 @@ public class SQLServerDialect extends AbstractTransactSQLDialect {
 
 	@Override @SuppressWarnings("deprecation")
 	public String timestampdiffPattern(TemporalUnit unit, TemporalType fromTemporalType, TemporalType toTemporalType) {
+		boolean supportsDateDiffBig = getVersion().isSameOrAfter( 13 );
 		if ( unit == TemporalUnit.NATIVE ) {
 			//use nanosecond as the "native" precision
-			return "datediff_big(nanosecond,?2,?3)";
+			return supportsDateDiffBig ? "datediff_big(nanosecond,?2,?3)" : "datediff(nanosecond,?2,?3)";
 		}
 		else {
 			//datediff() returns an int, and can easily
 			//overflow when dealing with "physical"
 			//durations, so use datediff_big()
-			return unit.normalized() == NANOSECOND
+			return unit.normalized() == NANOSECOND && supportsDateDiffBig
 					? "datediff_big(?1,?2,?3)"
 					: "datediff(?1,?2,?3)";
 		}


### PR DESCRIPTION
Gate DATEDIFF_BIG usage in SQLServerDialect.extractPattern() and timestampdiffPattern() behind a version check: SQL Server 2016 is internal version 13, so getVersion().isSameOrAfter(13) guards every DATEDIFF_BIG emission. Pre-2016 instances fall back to plain DATEDIFF, which avoids the 'datediff_big is not a recognized built-in function name' error reported on SQL Server 2012 and 2014.

Also fix TemporalUnit.normalized() so that DAY, WEEK, HOUR, MINUTE, and SECOND normalize to SECOND rather than NANOSECOND. Only NANOSECOND, NATIVE, and EPOCH normalize to NANOSECOND. This ensures that coarser units (DAY, HOUR, etc.) no longer trigger the DATEDIFF_BIG path in timestampdiffPattern(), since a DAY-diff cannot realistically overflow a 32-bit int (~5.8 million year range). Update the normalized() Javadoc to reflect the three possible return values.

Add SQLServerDateDiffTest to verify the correct SQL patterns are emitted for both pre-2016 (version 12) and 2016+ (version 13) dialects.

<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

[Please describe here what your change is about]

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
- [x] Jira issue referenced [(HHH-17185)](https://hibernate.atlassian.net/browse/HHH-17185)
- [x] Tests added (SQLServerDateDiffTest)
- [x] Backward compatibility considered


<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-17185
<!-- Hibernate GitHub Bot issue links end -->

---
<!-- Hibernate GitHub Bot task list start -->
Please make sure that the following tasks are completed:
Tasks specific to HHH-17185 (Bug):
- [x] Add test reproducing the bug
- [x] Add entries as relevant to `migration-guide.adoc` **OR** check there are no breaking changes


<!-- Hibernate GitHub Bot task list end -->