### PR TITLE
[7.2] HHH-20147: Allow IdClass on OneToOne relationships with defined JoinColumns

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/MappingModelCreationHelper.java
+++ b/hibernate-core/src/main/java/org/hibernate/metamodel/mapping/internal/MappingModelCreationHelper.java
@@ -983,27 +983,12 @@ public class MappingModelCreationHelper {
 			final var columnIterator = bootValueMapping.getSelectables().iterator();
 			final var table = bootValueMapping.getTable();
 			final String tableExpression = getTableIdentifierExpression( table, creationProcess );
-			final PropertyAccess declaringKeyPropertyAccess;
-			if ( inversePropertyAccess == null ) {
-				// So far, OneToOne mappings are only supported based on the owner's PK
-				if ( bootValueMapping instanceof OneToOne ) {
-					final var identifierMapping =
-							attributeMapping.findContainingEntityMapping().getIdentifierMapping();
-					declaringKeyPropertyAccess = ( (PropertyBasedMapping) identifierMapping ).getPropertyAccess();
-				}
-				else {
-					declaringKeyPropertyAccess = new ChainedPropertyAccessImpl(
-							attributeMapping.getPropertyAccess(),
-							( (PropertyBasedMapping) simpleFkTarget ).getPropertyAccess()
-					);
-				}
-			}
-			else {
-				declaringKeyPropertyAccess = new ChainedPropertyAccessImpl(
-						inversePropertyAccess,
-						( (PropertyBasedMapping) simpleFkTarget ).getPropertyAccess()
-				);
-			}
+			final PropertyAccess declaringKeyPropertyAccess = getDeclaringKeyPropertyAccess(
+					attributeMapping,
+					bootValueMapping,
+					inversePropertyAccess,
+					(PropertyBasedMapping) simpleFkTarget
+			);
 			final var parentSelectablePath = getSelectablePath( attributeMapping.getDeclaringType() );
 			final SelectableMapping keySelectableMapping;
 			int i = 0;
@@ -1079,6 +1064,33 @@ public class MappingModelCreationHelper {
 		}
 
 		return true;
+	}
+
+	private static PropertyAccess getDeclaringKeyPropertyAccess(
+			ToOneAttributeMapping attributeMapping,
+			ToOne bootValueMapping,
+			PropertyAccess inversePropertyAccess,
+			PropertyBasedMapping simpleFkTarget) {
+		if ( inversePropertyAccess == null ) {
+			if ( bootValueMapping instanceof OneToOne ) {
+				final var identifierMapping = attributeMapping.findContainingEntityMapping().getIdentifierMapping();
+				// Check if the identifier is a single-column or "aggregated" composite identifier,
+				// otherwise it is a "non-aggregated" composite identifier
+				if ( identifierMapping instanceof PropertyBasedMapping propertyIdentifierMapping ) {
+					return propertyIdentifierMapping.getPropertyAccess();
+				}
+			}
+			return new ChainedPropertyAccessImpl(
+					attributeMapping.getPropertyAccess(),
+					simpleFkTarget.getPropertyAccess()
+			);
+		}
+		else {
+			return new ChainedPropertyAccessImpl(
+					inversePropertyAccess,
+					simpleFkTarget.getPropertyAccess()
+			);
+		}
 	}
 
 	/**

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/idclass/IdClassSingleOneToOneTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/idclass/IdClassSingleOneToOneTest.java
@@ -8,6 +8,7 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.Id;
 import jakarta.persistence.IdClass;
+import jakarta.persistence.JoinColumn;
 import jakarta.persistence.OneToOne;
 import org.hibernate.testing.orm.junit.DomainModel;
 import org.hibernate.testing.orm.junit.Jira;
@@ -24,13 +25,14 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 @DomainModel( annotatedClasses = {
 		IdClassSingleOneToOneTest.EntityA.class,
 		IdClassSingleOneToOneTest.EntityB.class,
+		IdClassSingleOneToOneTest.EntityC.class,
 } )
 @SessionFactory
-@Jira(value = "https://hibernate.atlassian.net/browse/HHH-19688")
 public class IdClassSingleOneToOneTest {
 
 	@Test
-	public void test(SessionFactoryScope scope) {
+	@Jira(value = "https://hibernate.atlassian.net/browse/HHH-19688")
+	public void testWithoutJoinColumn(SessionFactoryScope scope) {
 		scope.getSessionFactory();
 		scope.inTransaction( session -> {
 			EntityA entityA = new EntityA(3);
@@ -47,6 +49,25 @@ public class IdClassSingleOneToOneTest {
 		} );
 	}
 
+	@Test
+	@Jira(value = "https://hibernate.atlassian.net/browse/HHH-20147")
+	public void testWithJoinColumn(SessionFactoryScope scope) {
+		scope.getSessionFactory();
+		scope.inTransaction( session -> {
+			EntityA entityA = new EntityA(4);
+			EntityC entityC = new EntityC( entityA );
+			entityA.entityC = entityC;
+			session.persist( entityA );
+			session.persist( entityC );
+			assertEquals( new EntityCId(4),
+					session.getIdentifier( entityC ) );
+		} );
+		scope.inTransaction( session -> {
+			EntityC entityC = session.find( EntityC.class, new EntityCId(4) );
+			assertNotNull( entityC );
+		} );
+	}
+
 	@Entity( name = "EntityA" )
 	static class EntityA {
 
@@ -55,6 +76,9 @@ public class IdClassSingleOneToOneTest {
 
 		@OneToOne( mappedBy = "entityA", fetch = FetchType.LAZY )
 		private EntityB entityB;
+
+		@OneToOne( mappedBy = "entityA", fetch = FetchType.LAZY )
+		private EntityC entityC;
 
 		public EntityA() {
 		}
@@ -82,6 +106,24 @@ public class IdClassSingleOneToOneTest {
 
 	}
 
+	@IdClass( EntityCId.class )
+	@Entity( name = "EntityC" )
+	static class EntityC {
+
+		@Id
+		@OneToOne( fetch = FetchType.LAZY )
+		@JoinColumn( name = "entity_a_id" )
+		private EntityA entityA;
+
+		public EntityC() {
+		}
+
+		public EntityC(EntityA entityA) {
+			this.entityA = entityA;
+		}
+
+	}
+
 	static class EntityBId {
 		private final Integer entityA;
 
@@ -96,6 +138,28 @@ public class IdClassSingleOneToOneTest {
 		public boolean equals(Object o) {
 			return o instanceof EntityBId entityBId
 				&& Objects.equals( entityA, entityBId.entityA );
+		}
+
+		@Override
+		public int hashCode() {
+			return Objects.hashCode( entityA );
+		}
+	}
+
+	static class EntityCId {
+		private final Integer entityA;
+
+		EntityCId() {
+			entityA = null;
+		}
+		EntityCId(Integer entityA) {
+			this.entityA = entityA;
+		}
+
+		@Override
+		public boolean equals(Object o) {
+			return o instanceof EntityCId entityCId
+				&& Objects.equals( entityA, entityCId.entityA );
 		}
 
 		@Override


### PR DESCRIPTION
<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

Backport of https://github.com/hibernate/hibernate-orm/pull/11766

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------

---
<!-- Hibernate GitHub Bot task list start -->
Please make sure that the following tasks are completed:
Tasks specific to HHH-20147 (Bug):
- [ ] Add test reproducing the bug
- [ ] Add entries as relevant to `migration-guide.adoc` **OR** check there are no breaking changes


<!-- Hibernate GitHub Bot task list end -->

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-20147
<!-- Hibernate GitHub Bot issue links end -->