### PR TITLE
HHH-20376: Replace the use of the hibernate-orm mapping API with hibernate-models

### DIFF
--- a/tooling/hibernate-reveng/hibernate-reveng.gradle
+++ b/tooling/hibernate-reveng/hibernate-reveng.gradle
@@ -6,6 +6,7 @@ description = "Library providing functionality to perform reverse engineering Hi
 
 dependencies {
     implementation project( ':hibernate-core' )
+    implementation libs.hibernateModels
     implementation libs.commonsCollections4
     implementation libs.eclipseJdtCore
     implementation libs.freemarker

--- a/tooling/hibernate-reveng/src/main/java/org/hibernate/tool/reveng/internal/descriptor/AttributeOverrideDescriptor.java
+++ b/tooling/hibernate-reveng/src/main/java/org/hibernate/tool/reveng/internal/descriptor/AttributeOverrideDescriptor.java
@@ -1,0 +1,31 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.tool.reveng.internal.descriptor;
+
+/**
+ * Represents metadata for an @AttributeOverride mapping.
+ *
+ * @author Koen Aers
+ */
+public class AttributeOverrideDescriptor {
+	private final String fieldName;
+	private final String columnName;
+	private final Class<?> javaType;
+
+	public AttributeOverrideDescriptor(String fieldName, String columnName) {
+		this(fieldName, columnName, null);
+	}
+
+	public AttributeOverrideDescriptor(String fieldName, String columnName, Class<?> javaType) {
+		this.fieldName = fieldName;
+		this.columnName = columnName;
+		this.javaType = javaType;
+	}
+
+	// Getters
+	public String getFieldName() { return fieldName; }
+	public String getColumnName() { return columnName; }
+	public Class<?> getJavaType() { return javaType; }
+}

--- a/tooling/hibernate-reveng/src/main/java/org/hibernate/tool/reveng/internal/descriptor/ColumnDescriptor.java
+++ b/tooling/hibernate-reveng/src/main/java/org/hibernate/tool/reveng/internal/descriptor/ColumnDescriptor.java
@@ -1,0 +1,176 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.tool.reveng.internal.descriptor;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.TemporalType;
+
+/**
+ * Represents metadata for a database column.
+ *
+ * @author Koen Aers
+ */
+public class ColumnDescriptor {
+	private final String columnName;
+	private final String fieldName;
+	private final Class<?> javaType;
+	private boolean nullable;
+	private int length;
+	private int precision;
+	private int scale;
+	private boolean primaryKey;
+	private boolean autoIncrement;
+	private boolean version;
+	private FetchType basicFetchType;
+	private Boolean basicOptional;
+	private TemporalType temporalType;
+	private boolean lob;
+	private String comment;
+	private GenerationType generationType;
+	private boolean unique;
+	private boolean insertable = true;
+	private boolean updatable = true;
+	private String hibernateTypeName;
+	private Map<String, List<String>> metaAttributes = new LinkedHashMap<>();
+
+	public ColumnDescriptor(String columnName, String fieldName, Class<?> javaType) {
+		this.columnName = columnName;
+		this.fieldName = fieldName;
+		this.javaType = javaType;
+		this.nullable = true;
+	}
+
+	public ColumnDescriptor primaryKey(boolean primaryKey) {
+		this.primaryKey = primaryKey;
+		this.nullable = false;
+		return this;
+	}
+
+	public ColumnDescriptor autoIncrement(boolean autoIncrement) {
+		this.autoIncrement = autoIncrement;
+		return this;
+	}
+
+	public ColumnDescriptor nullable(boolean nullable) {
+		this.nullable = nullable;
+		return this;
+	}
+
+	public ColumnDescriptor length(int length) {
+		this.length = length;
+		return this;
+	}
+
+	public ColumnDescriptor precision(int precision) {
+		this.precision = precision;
+		return this;
+	}
+
+	public ColumnDescriptor scale(int scale) {
+		this.scale = scale;
+		return this;
+	}
+
+	public ColumnDescriptor version(boolean version) {
+		this.version = version;
+		return this;
+	}
+
+	public ColumnDescriptor basicFetch(FetchType fetchType) {
+		this.basicFetchType = fetchType;
+		return this;
+	}
+
+	public ColumnDescriptor basicOptional(boolean optional) {
+		this.basicOptional = optional;
+		return this;
+	}
+
+	public ColumnDescriptor temporal(TemporalType temporalType) {
+		this.temporalType = temporalType;
+		return this;
+	}
+
+	public ColumnDescriptor lob(boolean lob) {
+		this.lob = lob;
+		return this;
+	}
+
+	public ColumnDescriptor comment(String comment) {
+		this.comment = comment;
+		return this;
+	}
+
+	public ColumnDescriptor generationType(GenerationType generationType) {
+		this.generationType = generationType;
+		return this;
+	}
+
+	public ColumnDescriptor unique(boolean unique) {
+		this.unique = unique;
+		return this;
+	}
+
+	public ColumnDescriptor insertable(boolean insertable) {
+		this.insertable = insertable;
+		return this;
+	}
+
+	public ColumnDescriptor updatable(boolean updatable) {
+		this.updatable = updatable;
+		return this;
+	}
+
+	public ColumnDescriptor hibernateTypeName(String hibernateTypeName) {
+		this.hibernateTypeName = hibernateTypeName;
+		return this;
+	}
+
+	// Getters
+	public String getColumnName() { return columnName; }
+	public String getFieldName() { return fieldName; }
+	public Class<?> getJavaType() { return javaType; }
+	public boolean isNullable() { return nullable; }
+	public int getLength() { return length; }
+	public int getPrecision() { return precision; }
+	public int getScale() { return scale; }
+	public boolean isPrimaryKey() { return primaryKey; }
+	public boolean isAutoIncrement() { return autoIncrement; }
+	public boolean isVersion() { return version; }
+	public FetchType getBasicFetchType() { return basicFetchType; }
+	public boolean isBasicOptionalSet() { return basicOptional != null; }
+	public boolean isBasicOptional() { return basicOptional != null ? basicOptional : true; }
+	public TemporalType getTemporalType() { return temporalType; }
+	public boolean isLob() { return lob; }
+	public String getComment() { return comment; }
+	public GenerationType getGenerationType() { return generationType; }
+	public boolean isUnique() { return unique; }
+	public boolean isInsertable() { return insertable; }
+	public boolean isUpdatable() { return updatable; }
+	public String getHibernateTypeName() { return hibernateTypeName; }
+
+	public Map<String, List<String>> getMetaAttributes() { return metaAttributes; }
+	public ColumnDescriptor metaAttributes(Map<String, List<String>> metaAttributes) {
+		this.metaAttributes = metaAttributes;
+		return this;
+	}
+	public ColumnDescriptor addMetaAttribute(String name, String value) {
+		this.metaAttributes.computeIfAbsent(name, k -> new ArrayList<>()).add(value);
+		return this;
+	}
+	public List<String> getMetaAttribute(String name) {
+		return metaAttributes.getOrDefault(name, Collections.emptyList());
+	}
+	public boolean hasMetaAttribute(String name) {
+		return metaAttributes.containsKey(name);
+	}
+}

--- a/tooling/hibernate-reveng/src/main/java/org/hibernate/tool/reveng/internal/descriptor/CompositeIdDescriptor.java
+++ b/tooling/hibernate-reveng/src/main/java/org/hibernate/tool/reveng/internal/descriptor/CompositeIdDescriptor.java
@@ -1,0 +1,121 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.tool.reveng.internal.descriptor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Represents metadata for an @EmbeddedId composite primary key.
+ * The ID class should be created separately via createEmbeddable().
+ *
+ * @author Koen Aers
+ */
+public class CompositeIdDescriptor {
+	private final String fieldName;
+	private final String idClassName;
+	private final String idClassPackage;
+	private final List<AttributeOverrideDescriptor> attributeOverrides = new ArrayList<>();
+	private final List<KeyManyToOneDescriptor> keyManyToOnes = new ArrayList<>();
+	private final List<String> originalColumnOrder = new ArrayList<>();
+
+	public CompositeIdDescriptor(
+			String fieldName,
+			String idClassName,
+			String idClassPackage) {
+		this.fieldName = fieldName;
+		this.idClassName = idClassName;
+		this.idClassPackage = idClassPackage;
+	}
+
+	public CompositeIdDescriptor addAttributeOverride(String fieldName, String columnName) {
+		this.attributeOverrides.add(new AttributeOverrideDescriptor(fieldName, columnName));
+		this.originalColumnOrder.add(columnName);
+		return this;
+	}
+
+	public CompositeIdDescriptor addAttributeOverride(String fieldName, String columnName, Class<?> javaType) {
+		this.attributeOverrides.add(new AttributeOverrideDescriptor(fieldName, columnName, javaType));
+		this.originalColumnOrder.add(columnName);
+		return this;
+	}
+
+	public CompositeIdDescriptor addKeyManyToOne(
+			String fieldName, String columnName,
+			String targetEntityClassName, String targetEntityPackage) {
+		this.keyManyToOnes.add(new KeyManyToOneDescriptor(
+				fieldName, columnName, targetEntityClassName, targetEntityPackage));
+		return this;
+	}
+
+	public CompositeIdDescriptor addKeyManyToOne(
+			String fieldName, List<String> columnNames,
+			String targetEntityClassName, String targetEntityPackage) {
+		this.keyManyToOnes.add(new KeyManyToOneDescriptor(
+				fieldName, columnNames, targetEntityClassName, targetEntityPackage));
+		return this;
+	}
+
+	// Getters
+	public String getFieldName() { return fieldName; }
+	public String getIdClassName() { return idClassName; }
+	public String getIdClassPackage() { return idClassPackage; }
+	public List<AttributeOverrideDescriptor> getAttributeOverrides() { return attributeOverrides; }
+	public List<KeyManyToOneDescriptor> getKeyManyToOnes() { return keyManyToOnes; }
+	public List<String> getOriginalColumnOrder() { return originalColumnOrder; }
+
+	/**
+	 * Returns an ordered list of entries (attribute overrides and key-many-to-ones)
+	 * matching the original PK column order. Each entry is either an
+	 * {@link AttributeOverrideDescriptor} or a {@link KeyManyToOneDescriptor}.
+	 * Key-many-to-ones appear at the position of their first FK column.
+	 */
+	public List<Object> getOrderedEntries() {
+		// If no original column order was recorded (e.g., metadata built directly
+		// without addAttributeOverride), fall back to attribute overrides then
+		// key-many-to-ones in their list order.
+		if (originalColumnOrder.isEmpty()) {
+			List<Object> result = new ArrayList<>();
+			result.addAll(attributeOverrides);
+			result.addAll(keyManyToOnes);
+			return result;
+		}
+		List<Object> result = new ArrayList<>();
+		java.util.Set<String> processedKeyManyToOnes = new java.util.HashSet<>();
+		for (String columnName : originalColumnOrder) {
+			// Check if this column belongs to a key-many-to-one
+			KeyManyToOneDescriptor matchedKm2o = null;
+			for (KeyManyToOneDescriptor km2o : keyManyToOnes) {
+				if (km2o.getColumnNames().contains(columnName)) {
+					matchedKm2o = km2o;
+					break;
+				}
+			}
+			if (matchedKm2o != null) {
+				// Only add the key-many-to-one once (at its first column position)
+				if (processedKeyManyToOnes.add(matchedKm2o.getFieldName())) {
+					result.add(matchedKm2o);
+				}
+			}
+			else {
+				// Check if it's still in the attribute overrides (not removed)
+				for (AttributeOverrideDescriptor ao : attributeOverrides) {
+					if (ao.getColumnName().equals(columnName)) {
+						result.add(ao);
+						break;
+					}
+				}
+			}
+		}
+		// Append any key-many-to-ones not in the original column order
+		// (e.g., added directly without corresponding attribute overrides)
+		for (KeyManyToOneDescriptor km2o : keyManyToOnes) {
+			if (!processedKeyManyToOnes.contains(km2o.getFieldName())) {
+				result.add(km2o);
+			}
+		}
+		return result;
+	}
+}

--- a/tooling/hibernate-reveng/src/main/java/org/hibernate/tool/reveng/internal/descriptor/EmbeddableDescriptor.java
+++ b/tooling/hibernate-reveng/src/main/java/org/hibernate/tool/reveng/internal/descriptor/EmbeddableDescriptor.java
@@ -1,0 +1,41 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.tool.reveng.internal.descriptor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Represents metadata for an embeddable class.
+ *
+ * @author Koen Aers
+ */
+public class EmbeddableDescriptor {
+	private final String className;
+	private final String packageName;
+	private final List<ColumnDescriptor> columns = new ArrayList<>();
+	private boolean idClass;
+
+	public EmbeddableDescriptor(String className, String packageName) {
+		this.className = className;
+		this.packageName = packageName;
+	}
+
+	public EmbeddableDescriptor addColumn(ColumnDescriptor column) {
+		this.columns.add(column);
+		return this;
+	}
+
+	public EmbeddableDescriptor idClass(boolean idClass) {
+		this.idClass = idClass;
+		return this;
+	}
+
+	// Getters
+	public String getClassName() { return className; }
+	public String getPackageName() { return packageName; }
+	public List<ColumnDescriptor> getColumns() { return columns; }
+	public boolean isIdClass() { return idClass; }
+}

--- a/tooling/hibernate-reveng/src/main/java/org/hibernate/tool/reveng/internal/descriptor/EmbeddedFieldDescriptor.java
+++ b/tooling/hibernate-reveng/src/main/java/org/hibernate/tool/reveng/internal/descriptor/EmbeddedFieldDescriptor.java
@@ -1,0 +1,40 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.tool.reveng.internal.descriptor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Represents metadata for an embedded field on an entity.
+ *
+ * @author Koen Aers
+ */
+public class EmbeddedFieldDescriptor {
+	private final String fieldName;
+	private final String embeddableClassName;
+	private final String embeddablePackage;
+	private final List<AttributeOverrideDescriptor> attributeOverrides = new ArrayList<>();
+
+	public EmbeddedFieldDescriptor(
+			String fieldName,
+			String embeddableClassName,
+			String embeddablePackage) {
+		this.fieldName = fieldName;
+		this.embeddableClassName = embeddableClassName;
+		this.embeddablePackage = embeddablePackage;
+	}
+
+	public EmbeddedFieldDescriptor addAttributeOverride(String fieldName, String columnName) {
+		this.attributeOverrides.add(new AttributeOverrideDescriptor(fieldName, columnName));
+		return this;
+	}
+
+	// Getters
+	public String getFieldName() { return fieldName; }
+	public String getEmbeddableClassName() { return embeddableClassName; }
+	public String getEmbeddablePackage() { return embeddablePackage; }
+	public List<AttributeOverrideDescriptor> getAttributeOverrides() { return attributeOverrides; }
+}

--- a/tooling/hibernate-reveng/src/main/java/org/hibernate/tool/reveng/internal/descriptor/ForeignKeyDescriptor.java
+++ b/tooling/hibernate-reveng/src/main/java/org/hibernate/tool/reveng/internal/descriptor/ForeignKeyDescriptor.java
@@ -1,0 +1,84 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.tool.reveng.internal.descriptor;
+
+import jakarta.persistence.FetchType;
+
+import java.util.List;
+
+/**
+ * Represents metadata for a database foreign key relationship.
+ * Supports both single-column and multi-column (composite) foreign keys.
+ *
+ * @author Koen Aers
+ */
+public class ForeignKeyDescriptor {
+	private final String fieldName;
+	private final JoinColumnList joinColumns = new JoinColumnList();
+	private final String targetEntityClassName;
+	private final String targetEntityPackage;
+	private FetchType fetchType;
+	private boolean optional;
+	private boolean partOfCompositeKey;
+
+	public ForeignKeyDescriptor(
+			String fieldName,
+			String foreignKeyColumnName,
+			String targetEntityClassName,
+			String targetEntityPackage) {
+		this.fieldName = fieldName;
+		this.joinColumns.add(foreignKeyColumnName, null);
+		this.targetEntityClassName = targetEntityClassName;
+		this.targetEntityPackage = targetEntityPackage;
+		this.optional = true;
+	}
+
+	public ForeignKeyDescriptor(
+			String fieldName,
+			String targetEntityClassName,
+			String targetEntityPackage) {
+		this.fieldName = fieldName;
+		this.targetEntityClassName = targetEntityClassName;
+		this.targetEntityPackage = targetEntityPackage;
+		this.optional = true;
+	}
+
+	public ForeignKeyDescriptor addJoinColumn(String fkColumnName, String referencedColumnName) {
+		this.joinColumns.add(fkColumnName, referencedColumnName);
+		return this;
+	}
+
+	public ForeignKeyDescriptor referencedColumnName(String referencedColumnName) {
+		joinColumns.updateFirstReferencedColumn(referencedColumnName);
+		return this;
+	}
+
+	public ForeignKeyDescriptor fetchType(FetchType fetchType) {
+		this.fetchType = fetchType;
+		return this;
+	}
+
+	public ForeignKeyDescriptor optional(boolean optional) {
+		this.optional = optional;
+		return this;
+	}
+
+	public ForeignKeyDescriptor partOfCompositeKey(boolean partOfCompositeKey) {
+		this.partOfCompositeKey = partOfCompositeKey;
+		return this;
+	}
+
+	// Getters
+	public String getFieldName() { return fieldName; }
+	public String getForeignKeyColumnName() { return joinColumns.firstForeignKeyColumnName(); }
+	public String getReferencedColumnName() { return joinColumns.firstReferencedColumnName(); }
+	public List<JoinColumnPair> getJoinColumns() { return joinColumns.asList(); }
+	public List<String> getForeignKeyColumnNames() { return joinColumns.foreignKeyColumnNames(); }
+	public String getTargetEntityClassName() { return targetEntityClassName; }
+	public String getTargetEntityPackage() { return targetEntityPackage; }
+	public FetchType getFetchType() { return fetchType; }
+	public boolean isOptional() { return optional; }
+	public boolean isPartOfCompositeKey() { return partOfCompositeKey; }
+}

--- a/tooling/hibernate-reveng/src/main/java/org/hibernate/tool/reveng/internal/descriptor/IndexDescriptor.java
+++ b/tooling/hibernate-reveng/src/main/java/org/hibernate/tool/reveng/internal/descriptor/IndexDescriptor.java
@@ -1,0 +1,33 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.tool.reveng.internal.descriptor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Represents metadata for a database index.
+ *
+ * @author Koen Aers
+ */
+public class IndexDescriptor {
+	private final String indexName;
+	private final boolean unique;
+	private final List<String> columnNames = new ArrayList<>();
+
+	public IndexDescriptor(String indexName, boolean unique) {
+		this.indexName = indexName;
+		this.unique = unique;
+	}
+
+	public IndexDescriptor addColumn(String columnName) {
+		this.columnNames.add(columnName);
+		return this;
+	}
+
+	public String getIndexName() { return indexName; }
+	public boolean isUnique() { return unique; }
+	public List<String> getColumnNames() { return columnNames; }
+}

--- a/tooling/hibernate-reveng/src/main/java/org/hibernate/tool/reveng/internal/descriptor/InheritanceDescriptor.java
+++ b/tooling/hibernate-reveng/src/main/java/org/hibernate/tool/reveng/internal/descriptor/InheritanceDescriptor.java
@@ -1,0 +1,45 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.tool.reveng.internal.descriptor;
+
+import jakarta.persistence.DiscriminatorType;
+import jakarta.persistence.InheritanceType;
+
+/**
+ * Represents metadata for JPA inheritance configuration on a root entity.
+ *
+ * @author Koen Aers
+ */
+public class InheritanceDescriptor {
+	private final InheritanceType strategy;
+	private String discriminatorColumnName;
+	private DiscriminatorType discriminatorType;
+	private int discriminatorColumnLength;
+
+	public InheritanceDescriptor(InheritanceType strategy) {
+		this.strategy = strategy;
+	}
+
+	public InheritanceDescriptor discriminatorColumn(String discriminatorColumnName) {
+		this.discriminatorColumnName = discriminatorColumnName;
+		return this;
+	}
+
+	public InheritanceDescriptor discriminatorType(DiscriminatorType discriminatorType) {
+		this.discriminatorType = discriminatorType;
+		return this;
+	}
+
+	public InheritanceDescriptor discriminatorColumnLength(int discriminatorColumnLength) {
+		this.discriminatorColumnLength = discriminatorColumnLength;
+		return this;
+	}
+
+	// Getters
+	public InheritanceType getStrategy() { return strategy; }
+	public String getDiscriminatorColumnName() { return discriminatorColumnName; }
+	public DiscriminatorType getDiscriminatorType() { return discriminatorType; }
+	public int getDiscriminatorColumnLength() { return discriminatorColumnLength; }
+}

--- a/tooling/hibernate-reveng/src/main/java/org/hibernate/tool/reveng/internal/descriptor/JoinColumnList.java
+++ b/tooling/hibernate-reveng/src/main/java/org/hibernate/tool/reveng/internal/descriptor/JoinColumnList.java
@@ -1,0 +1,52 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.tool.reveng.internal.descriptor;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Manages an ordered list of {@link JoinColumnPair} entries.
+ * Used by {@link ForeignKeyDescriptor} and {@link OneToOneDescriptor}
+ * to avoid duplicating join column handling logic.
+ *
+ * @author Koen Aers
+ */
+class JoinColumnList {
+
+	private final List<JoinColumnPair> columns = new ArrayList<>();
+
+	void add(String fkColumnName, String referencedColumnName) {
+		columns.add(new JoinColumnPair(fkColumnName, referencedColumnName));
+	}
+
+	void updateFirstReferencedColumn(String referencedColumnName) {
+		if (!columns.isEmpty()) {
+			JoinColumnPair first = columns.get(0);
+			columns.set(0, new JoinColumnPair(first.fkColumnName(), referencedColumnName));
+		}
+	}
+
+	String firstForeignKeyColumnName() {
+		return columns.isEmpty() ? null : columns.get(0).fkColumnName();
+	}
+
+	String firstReferencedColumnName() {
+		return columns.isEmpty() ? null : columns.get(0).referencedColumnName();
+	}
+
+	List<JoinColumnPair> asList() {
+		return Collections.unmodifiableList(columns);
+	}
+
+	List<String> foreignKeyColumnNames() {
+		return columns.stream().map(JoinColumnPair::fkColumnName).toList();
+	}
+
+	boolean isEmpty() {
+		return columns.isEmpty();
+	}
+}

--- a/tooling/hibernate-reveng/src/main/java/org/hibernate/tool/reveng/internal/descriptor/JoinColumnPair.java
+++ b/tooling/hibernate-reveng/src/main/java/org/hibernate/tool/reveng/internal/descriptor/JoinColumnPair.java
@@ -1,0 +1,13 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.tool.reveng.internal.descriptor;
+
+/**
+ * A pair of column names representing a foreign key column
+ * and its referenced column in the target table.
+ *
+ * @author Koen Aers
+ */
+public record JoinColumnPair(String fkColumnName, String referencedColumnName) {}

--- a/tooling/hibernate-reveng/src/main/java/org/hibernate/tool/reveng/internal/descriptor/KeyManyToOneDescriptor.java
+++ b/tooling/hibernate-reveng/src/main/java/org/hibernate/tool/reveng/internal/descriptor/KeyManyToOneDescriptor.java
@@ -1,0 +1,58 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.tool.reveng.internal.descriptor;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Represents metadata for a many-to-one relationship within a composite ID.
+ * These become {@code <key-many-to-one>} elements in HBM XML.
+ * Supports multi-column foreign keys (e.g., referencing composite PKs).
+ *
+ * @author Koen Aers
+ */
+public class KeyManyToOneDescriptor {
+	private final String fieldName;
+	private final List<String> columnNames = new ArrayList<>();
+	private final String targetEntityClassName;
+	private final String targetEntityPackage;
+
+	public KeyManyToOneDescriptor(
+			String fieldName,
+			String columnName,
+			String targetEntityClassName,
+			String targetEntityPackage) {
+		this.fieldName = fieldName;
+		this.columnNames.add(columnName);
+		this.targetEntityClassName = targetEntityClassName;
+		this.targetEntityPackage = targetEntityPackage;
+	}
+
+	public KeyManyToOneDescriptor(
+			String fieldName,
+			List<String> columnNames,
+			String targetEntityClassName,
+			String targetEntityPackage) {
+		this.fieldName = fieldName;
+		this.columnNames.addAll(columnNames);
+		this.targetEntityClassName = targetEntityClassName;
+		this.targetEntityPackage = targetEntityPackage;
+	}
+
+	// Getters
+	public String getFieldName() { return fieldName; }
+	/** Returns the first column name (backward compatible). */
+	public String getColumnName() {
+		return columnNames.isEmpty() ? null : columnNames.get(0);
+	}
+	/** Returns all column names for this key-many-to-one. */
+	public List<String> getColumnNames() {
+		return Collections.unmodifiableList(columnNames);
+	}
+	public String getTargetEntityClassName() { return targetEntityClassName; }
+	public String getTargetEntityPackage() { return targetEntityPackage; }
+}

--- a/tooling/hibernate-reveng/src/main/java/org/hibernate/tool/reveng/internal/descriptor/ManyToManyDescriptor.java
+++ b/tooling/hibernate-reveng/src/main/java/org/hibernate/tool/reveng/internal/descriptor/ManyToManyDescriptor.java
@@ -1,0 +1,111 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.tool.reveng.internal.descriptor;
+
+import java.util.Collections;
+import java.util.List;
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.FetchType;
+
+/**
+ * Represents metadata for a ManyToMany relationship.
+ * Supports both the owning side (with joinTable) and
+ * the inverse side (with mappedBy).
+ *
+ * @author Koen Aers
+ */
+public class ManyToManyDescriptor {
+	private final String fieldName;
+	private final String targetEntityClassName;
+	private final String targetEntityPackage;
+	private String mappedBy;
+	private String joinTableName;
+	private String joinTableSchema;
+	private String joinTableCatalog;
+	private String joinColumnName;
+	private String inverseJoinColumnName;
+	private List<String> joinColumnNames;
+	private List<String> inverseJoinColumnNames;
+	private FetchType fetchType;
+	private CascadeType[] cascadeTypes;
+
+	public ManyToManyDescriptor(
+			String fieldName,
+			String targetEntityClassName,
+			String targetEntityPackage) {
+		this.fieldName = fieldName;
+		this.targetEntityClassName = targetEntityClassName;
+		this.targetEntityPackage = targetEntityPackage;
+	}
+
+	public ManyToManyDescriptor mappedBy(String mappedBy) {
+		this.mappedBy = mappedBy;
+		return this;
+	}
+
+	public ManyToManyDescriptor joinTableSchema(String schema) {
+		this.joinTableSchema = schema;
+		return this;
+	}
+
+	public ManyToManyDescriptor joinTableCatalog(String catalog) {
+		this.joinTableCatalog = catalog;
+		return this;
+	}
+
+	public ManyToManyDescriptor joinTable(String joinTableName, String joinColumnName, String inverseJoinColumnName) {
+		this.joinTableName = joinTableName;
+		this.joinColumnName = joinColumnName;
+		this.inverseJoinColumnName = inverseJoinColumnName;
+		return this;
+	}
+
+	public ManyToManyDescriptor joinTable(String joinTableName, List<String> joinColumnNames, List<String> inverseJoinColumnNames) {
+		this.joinTableName = joinTableName;
+		this.joinColumnNames = joinColumnNames;
+		this.inverseJoinColumnNames = inverseJoinColumnNames;
+		if (!joinColumnNames.isEmpty()) {
+			this.joinColumnName = joinColumnNames.get(0);
+		}
+		if (!inverseJoinColumnNames.isEmpty()) {
+			this.inverseJoinColumnName = inverseJoinColumnNames.get(0);
+		}
+		return this;
+	}
+
+	public ManyToManyDescriptor fetchType(FetchType fetchType) {
+		this.fetchType = fetchType;
+		return this;
+	}
+
+	public ManyToManyDescriptor cascade(CascadeType... cascadeTypes) {
+		this.cascadeTypes = cascadeTypes;
+		return this;
+	}
+
+	// Getters
+	public String getFieldName() { return fieldName; }
+	public String getTargetEntityClassName() { return targetEntityClassName; }
+	public String getTargetEntityPackage() { return targetEntityPackage; }
+	public String getMappedBy() { return mappedBy; }
+	public String getJoinTableName() { return joinTableName; }
+	public String getJoinTableSchema() { return joinTableSchema; }
+	public String getJoinTableCatalog() { return joinTableCatalog; }
+	public String getJoinColumnName() { return joinColumnName; }
+	public String getInverseJoinColumnName() { return inverseJoinColumnName; }
+	public List<String> getJoinColumnNames() {
+		if (joinColumnNames != null) { return joinColumnNames; }
+		if (joinColumnName != null) { return Collections.singletonList(joinColumnName); }
+		return Collections.emptyList();
+	}
+	public List<String> getInverseJoinColumnNames() {
+		if (inverseJoinColumnNames != null) { return inverseJoinColumnNames; }
+		if (inverseJoinColumnName != null) { return Collections.singletonList(inverseJoinColumnName); }
+		return Collections.emptyList();
+	}
+	public FetchType getFetchType() { return fetchType; }
+	public CascadeType[] getCascadeTypes() { return cascadeTypes; }
+}

--- a/tooling/hibernate-reveng/src/main/java/org/hibernate/tool/reveng/internal/descriptor/OneToManyDescriptor.java
+++ b/tooling/hibernate-reveng/src/main/java/org/hibernate/tool/reveng/internal/descriptor/OneToManyDescriptor.java
@@ -1,0 +1,69 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.tool.reveng.internal.descriptor;
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.FetchType;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Represents metadata for a OneToMany (inverse) relationship.
+ *
+ * @author Koen Aers
+ */
+public class OneToManyDescriptor {
+	private final String fieldName;
+	private final String mappedBy;
+	private final String elementEntityClassName;
+	private final String elementEntityPackage;
+	private final List<String> fkColumnNames = new ArrayList<>();
+	private FetchType fetchType;
+	private CascadeType[] cascadeTypes;
+	private boolean orphanRemoval;
+
+	public OneToManyDescriptor(
+			String fieldName,
+			String mappedBy,
+			String elementEntityClassName,
+			String elementEntityPackage) {
+		this.fieldName = fieldName;
+		this.mappedBy = mappedBy;
+		this.elementEntityClassName = elementEntityClassName;
+		this.elementEntityPackage = elementEntityPackage;
+	}
+
+	public OneToManyDescriptor fetchType(FetchType fetchType) {
+		this.fetchType = fetchType;
+		return this;
+	}
+
+	public OneToManyDescriptor cascade(CascadeType... cascadeTypes) {
+		this.cascadeTypes = cascadeTypes;
+		return this;
+	}
+
+	public OneToManyDescriptor orphanRemoval(boolean orphanRemoval) {
+		this.orphanRemoval = orphanRemoval;
+		return this;
+	}
+
+	public OneToManyDescriptor fkColumnNames(List<String> columnNames) {
+		this.fkColumnNames.addAll(columnNames);
+		return this;
+	}
+
+	// Getters
+	public String getFieldName() { return fieldName; }
+	public String getMappedBy() { return mappedBy; }
+	public String getElementEntityClassName() { return elementEntityClassName; }
+	public String getElementEntityPackage() { return elementEntityPackage; }
+	public List<String> getFkColumnNames() { return Collections.unmodifiableList(fkColumnNames); }
+	public FetchType getFetchType() { return fetchType; }
+	public CascadeType[] getCascadeTypes() { return cascadeTypes; }
+	public boolean isOrphanRemoval() { return orphanRemoval; }
+}

--- a/tooling/hibernate-reveng/src/main/java/org/hibernate/tool/reveng/internal/descriptor/OneToOneDescriptor.java
+++ b/tooling/hibernate-reveng/src/main/java/org/hibernate/tool/reveng/internal/descriptor/OneToOneDescriptor.java
@@ -1,0 +1,100 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.tool.reveng.internal.descriptor;
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.FetchType;
+
+import java.util.List;
+
+/**
+ * Represents metadata for a OneToOne relationship.
+ * Supports both the owning side (with join columns) and
+ * the inverse side (with mappedBy).
+ *
+ * @author Koen Aers
+ */
+public class OneToOneDescriptor {
+	private final String fieldName;
+	private final String targetEntityClassName;
+	private final String targetEntityPackage;
+	private final JoinColumnList joinColumns = new JoinColumnList();
+	private String mappedBy;
+	private FetchType fetchType;
+	private CascadeType[] cascadeTypes;
+	private boolean optional;
+	private boolean orphanRemoval;
+	private boolean constrained;
+
+	public OneToOneDescriptor(
+			String fieldName,
+			String targetEntityClassName,
+			String targetEntityPackage) {
+		this.fieldName = fieldName;
+		this.targetEntityClassName = targetEntityClassName;
+		this.targetEntityPackage = targetEntityPackage;
+		this.optional = true;
+	}
+
+	public OneToOneDescriptor foreignKeyColumnName(String foreignKeyColumnName) {
+		this.joinColumns.add(foreignKeyColumnName, null);
+		return this;
+	}
+
+	public OneToOneDescriptor addJoinColumn(String fkColumnName, String referencedColumnName) {
+		this.joinColumns.add(fkColumnName, referencedColumnName);
+		return this;
+	}
+
+	public OneToOneDescriptor referencedColumnName(String referencedColumnName) {
+		joinColumns.updateFirstReferencedColumn(referencedColumnName);
+		return this;
+	}
+
+	public OneToOneDescriptor mappedBy(String mappedBy) {
+		this.mappedBy = mappedBy;
+		return this;
+	}
+
+	public OneToOneDescriptor fetchType(FetchType fetchType) {
+		this.fetchType = fetchType;
+		return this;
+	}
+
+	public OneToOneDescriptor cascade(CascadeType... cascadeTypes) {
+		this.cascadeTypes = cascadeTypes;
+		return this;
+	}
+
+	public OneToOneDescriptor optional(boolean optional) {
+		this.optional = optional;
+		return this;
+	}
+
+	public OneToOneDescriptor orphanRemoval(boolean orphanRemoval) {
+		this.orphanRemoval = orphanRemoval;
+		return this;
+	}
+
+	public OneToOneDescriptor constrained(boolean constrained) {
+		this.constrained = constrained;
+		return this;
+	}
+
+	// Getters
+	public String getFieldName() { return fieldName; }
+	public String getTargetEntityClassName() { return targetEntityClassName; }
+	public String getTargetEntityPackage() { return targetEntityPackage; }
+	public String getForeignKeyColumnName() { return joinColumns.firstForeignKeyColumnName(); }
+	public String getReferencedColumnName() { return joinColumns.firstReferencedColumnName(); }
+	public List<JoinColumnPair> getJoinColumns() { return joinColumns.asList(); }
+	public String getMappedBy() { return mappedBy; }
+	public FetchType getFetchType() { return fetchType; }
+	public CascadeType[] getCascadeTypes() { return cascadeTypes; }
+	public boolean isOptional() { return optional; }
+	public boolean isOrphanRemoval() { return orphanRemoval; }
+	public boolean isConstrained() { return constrained; }
+	public List<String> getForeignKeyColumnNames() { return joinColumns.foreignKeyColumnNames(); }
+}

--- a/tooling/hibernate-reveng/src/main/java/org/hibernate/tool/reveng/internal/descriptor/TableDescriptor.java
+++ b/tooling/hibernate-reveng/src/main/java/org/hibernate/tool/reveng/internal/descriptor/TableDescriptor.java
@@ -1,0 +1,176 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.tool.reveng.internal.descriptor;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Represents metadata for a database table.
+ *
+ * @author Koen Aers
+ */
+public class TableDescriptor {
+	private String tableName;
+	private String schema;
+	private String catalog;
+	private String entityClassName;
+	private String entityPackage;
+	private List<ColumnDescriptor> columns = new ArrayList<>();
+	private List<ForeignKeyDescriptor> foreignKeys = new ArrayList<>();
+	private List<OneToManyDescriptor> oneToManys = new ArrayList<>();
+	private List<OneToOneDescriptor> oneToOnes = new ArrayList<>();
+	private List<ManyToManyDescriptor> manyToManys = new ArrayList<>();
+	private List<EmbeddedFieldDescriptor> embeddedFields = new ArrayList<>();
+	private InheritanceDescriptor inheritance;
+	private String discriminatorValue;
+	private String parentEntityClassName;
+	private String parentEntityPackage;
+	private String primaryKeyJoinColumnName;
+	private CompositeIdDescriptor compositeId;
+	private String comment;
+	private List<IndexDescriptor> indexes = new ArrayList<>();
+	private Map<String, List<String>> metaAttributes = new LinkedHashMap<>();
+
+	public TableDescriptor(String tableName, String entityClassName, String entityPackage) {
+		this.tableName = tableName;
+		this.entityClassName = entityClassName;
+		this.entityPackage = entityPackage;
+	}
+
+	public TableDescriptor addColumn(ColumnDescriptor column) {
+		this.columns.add(column);
+		return this;
+	}
+
+	public TableDescriptor addForeignKey(ForeignKeyDescriptor foreignKey) {
+		this.foreignKeys.add(foreignKey);
+		return this;
+	}
+
+	public TableDescriptor addOneToMany(OneToManyDescriptor oneToMany) {
+		this.oneToManys.add(oneToMany);
+		return this;
+	}
+
+	public TableDescriptor addOneToOne(OneToOneDescriptor oneToOne) {
+		this.oneToOnes.add(oneToOne);
+		return this;
+	}
+
+	public TableDescriptor addManyToMany(ManyToManyDescriptor manyToMany) {
+		this.manyToManys.add(manyToMany);
+		return this;
+	}
+
+	public TableDescriptor addEmbeddedField(EmbeddedFieldDescriptor embeddedField) {
+		this.embeddedFields.add(embeddedField);
+		return this;
+	}
+
+	public boolean isForeignKeyColumn(String columnName) {
+		return foreignKeys.stream()
+			.anyMatch(fk -> fk.getForeignKeyColumnNames().contains(columnName))
+			|| oneToOnes.stream()
+			.anyMatch(o2o -> o2o.getForeignKeyColumnNames().contains(columnName));
+	}
+
+	// Getters and setters
+	public String getTableName() { return tableName; }
+	public void setTableName(String tableName) { this.tableName = tableName; }
+
+	public String getSchema() { return schema; }
+	public void setSchema(String schema) { this.schema = schema; }
+
+	public String getCatalog() { return catalog; }
+	public void setCatalog(String catalog) { this.catalog = catalog; }
+
+	public String getEntityClassName() { return entityClassName; }
+	public void setEntityClassName(String entityClassName) { this.entityClassName = entityClassName; }
+
+	public String getEntityPackage() { return entityPackage; }
+	public void setEntityPackage(String entityPackage) { this.entityPackage = entityPackage; }
+
+	public List<ColumnDescriptor> getColumns() { return columns; }
+	public void setColumns(List<ColumnDescriptor> columns) { this.columns = columns; }
+
+	public List<ForeignKeyDescriptor> getForeignKeys() { return foreignKeys; }
+	public void setForeignKeys(List<ForeignKeyDescriptor> foreignKeys) { this.foreignKeys = foreignKeys; }
+
+	public List<OneToManyDescriptor> getOneToManys() { return oneToManys; }
+	public void setOneToManys(List<OneToManyDescriptor> oneToManys) { this.oneToManys = oneToManys; }
+
+	public List<OneToOneDescriptor> getOneToOnes() { return oneToOnes; }
+	public void setOneToOnes(List<OneToOneDescriptor> oneToOnes) { this.oneToOnes = oneToOnes; }
+
+	public List<ManyToManyDescriptor> getManyToManys() { return manyToManys; }
+	public void setManyToManys(List<ManyToManyDescriptor> manyToManys) { this.manyToManys = manyToManys; }
+
+	public List<EmbeddedFieldDescriptor> getEmbeddedFields() { return embeddedFields; }
+	public void setEmbeddedFields(List<EmbeddedFieldDescriptor> embeddedFields) { this.embeddedFields = embeddedFields; }
+
+	public InheritanceDescriptor getInheritance() { return inheritance; }
+	public TableDescriptor inheritance(InheritanceDescriptor inheritance) {
+		this.inheritance = inheritance;
+		return this;
+	}
+
+	public String getDiscriminatorValue() { return discriminatorValue; }
+	public TableDescriptor discriminatorValue(String discriminatorValue) {
+		this.discriminatorValue = discriminatorValue;
+		return this;
+	}
+
+	public String getParentEntityClassName() { return parentEntityClassName; }
+	public String getParentEntityPackage() { return parentEntityPackage; }
+	public TableDescriptor parent(String parentEntityClassName, String parentEntityPackage) {
+		this.parentEntityClassName = parentEntityClassName;
+		this.parentEntityPackage = parentEntityPackage;
+		return this;
+	}
+
+	public String getPrimaryKeyJoinColumnName() { return primaryKeyJoinColumnName; }
+	public TableDescriptor primaryKeyJoinColumn(String primaryKeyJoinColumnName) {
+		this.primaryKeyJoinColumnName = primaryKeyJoinColumnName;
+		return this;
+	}
+
+	public CompositeIdDescriptor getCompositeId() { return compositeId; }
+	public TableDescriptor compositeId(CompositeIdDescriptor compositeId) {
+		this.compositeId = compositeId;
+		return this;
+	}
+
+	public String getComment() { return comment; }
+	public TableDescriptor comment(String comment) {
+		this.comment = comment;
+		return this;
+	}
+
+	public List<IndexDescriptor> getIndexes() { return indexes; }
+	public TableDescriptor addIndex(IndexDescriptor index) {
+		this.indexes.add(index);
+		return this;
+	}
+
+	public Map<String, List<String>> getMetaAttributes() { return metaAttributes; }
+	public TableDescriptor metaAttributes(Map<String, List<String>> metaAttributes) {
+		this.metaAttributes = metaAttributes;
+		return this;
+	}
+	public TableDescriptor addMetaAttribute(String name, String value) {
+		this.metaAttributes.computeIfAbsent(name, k -> new ArrayList<>()).add(value);
+		return this;
+	}
+	public List<String> getMetaAttribute(String name) {
+		return metaAttributes.getOrDefault(name, Collections.emptyList());
+	}
+	public boolean hasMetaAttribute(String name) {
+		return metaAttributes.containsKey(name);
+	}
+}

--- a/tooling/hibernate-reveng/src/main/java/org/hibernate/tool/reveng/internal/util/TypeHelper.java
+++ b/tooling/hibernate-reveng/src/main/java/org/hibernate/tool/reveng/internal/util/TypeHelper.java
@@ -1,0 +1,414 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.tool.reveng.internal.util;
+
+import java.io.Serializable;
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.sql.Types;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+import jakarta.persistence.TemporalType;
+
+import org.hibernate.MappingException;
+
+/**
+ * Consolidated utility for type conversions used during reverse engineering:
+ * <ul>
+ *   <li>JDBC SQL type &harr; Hibernate type name</li>
+ *   <li>Hibernate type name &rarr; Java class</li>
+ *   <li>Java class name &rarr; JDBC SQL type</li>
+ *   <li>JDBC type name &harr; integer constant</li>
+ *   <li>SQL type metadata (has scale/precision/length)</li>
+ * </ul>
+ *
+ * @author max (original JdbcToHibernateTypeHelper)
+ * @author koen
+ */
+public final class TypeHelper {
+
+	private TypeHelper() {
+	}
+
+	// ========================================================================
+	// JDBC SQL type -> Hibernate type name
+	// ========================================================================
+
+	/** Maps JDBC SQL type constants to [primitive, nullable] Hibernate type name pairs. */
+	private static final Map<Integer, String[]> PREFERRED_HIBERNATETYPE_FOR_SQLTYPE = new HashMap<>();
+
+	static {
+		PREFERRED_HIBERNATETYPE_FOR_SQLTYPE.put( Types.TINYINT, new String[] { "byte", Byte.class.getName()} );
+		PREFERRED_HIBERNATETYPE_FOR_SQLTYPE.put( Types.SMALLINT, new String[] { "short", Short.class.getName()} );
+		PREFERRED_HIBERNATETYPE_FOR_SQLTYPE.put( Types.INTEGER, new String[] { "int", Integer.class.getName()} );
+		PREFERRED_HIBERNATETYPE_FOR_SQLTYPE.put( Types.BIGINT, new String[] { "long", Long.class.getName()} );
+		PREFERRED_HIBERNATETYPE_FOR_SQLTYPE.put( Types.REAL, new String[] { "float", Float.class.getName()} );
+		PREFERRED_HIBERNATETYPE_FOR_SQLTYPE.put( Types.FLOAT, new String[] { "double", Double.class.getName()} );
+		PREFERRED_HIBERNATETYPE_FOR_SQLTYPE.put( Types.DOUBLE, new String[] { "double", Double.class.getName()});
+		PREFERRED_HIBERNATETYPE_FOR_SQLTYPE.put( Types.DECIMAL, new String[] { "big_decimal", "big_decimal" });
+		PREFERRED_HIBERNATETYPE_FOR_SQLTYPE.put( Types.NUMERIC, new String[] { "big_decimal", "big_decimal" });
+		PREFERRED_HIBERNATETYPE_FOR_SQLTYPE.put( Types.BIT, new String[] { "boolean", Boolean.class.getName()});
+		PREFERRED_HIBERNATETYPE_FOR_SQLTYPE.put( Types.BOOLEAN, new String[] { "boolean", Boolean.class.getName()});
+		PREFERRED_HIBERNATETYPE_FOR_SQLTYPE.put( Types.CHAR, new String[] { "char", Character.class.getName()});
+		PREFERRED_HIBERNATETYPE_FOR_SQLTYPE.put( Types.VARCHAR, new String[] { "string", "string" });
+		PREFERRED_HIBERNATETYPE_FOR_SQLTYPE.put( Types.LONGVARCHAR, new String[] { "string", "string" });
+		PREFERRED_HIBERNATETYPE_FOR_SQLTYPE.put( Types.BINARY, new String[] { "binary", "binary" });
+		PREFERRED_HIBERNATETYPE_FOR_SQLTYPE.put( Types.VARBINARY, new String[] { "binary", "binary" });
+		PREFERRED_HIBERNATETYPE_FOR_SQLTYPE.put( Types.LONGVARBINARY, new String[] { "binary", "binary" });
+		PREFERRED_HIBERNATETYPE_FOR_SQLTYPE.put( Types.DATE, new String[] { "date", "date" });
+		PREFERRED_HIBERNATETYPE_FOR_SQLTYPE.put( Types.TIME, new String[] { "time", "time" });
+		PREFERRED_HIBERNATETYPE_FOR_SQLTYPE.put( Types.TIMESTAMP, new String[] { "timestamp", "timestamp" });
+		PREFERRED_HIBERNATETYPE_FOR_SQLTYPE.put( Types.CLOB, new String[] { "clob", "clob" });
+		PREFERRED_HIBERNATETYPE_FOR_SQLTYPE.put( Types.BLOB, new String[] { "blob", "blob" });
+	}
+
+	public static String getPreferredHibernateType(int sqlType, int size, int precision, int scale, boolean nullable, boolean generatedIdentifier) {
+		boolean returnNullable = nullable || generatedIdentifier;
+		if ( (sqlType == Types.DECIMAL || sqlType == Types.NUMERIC) && scale <= 0) {
+			if (precision == 1) {
+				return returnNullable?Boolean.class.getName():"boolean";
+			}
+			else if (precision < 3) {
+				return returnNullable?Byte.class.getName():"byte";
+			}
+			else if (precision < 5) {
+				return returnNullable?Short.class.getName():"short";
+			}
+			else if (precision < 10) {
+				return returnNullable?Integer.class.getName():"int";
+			}
+			else if (precision < 19) {
+				return returnNullable?Long.class.getName():"long";
+			}
+			else {
+				return "big_integer";
+			}
+		}
+
+		if ( sqlType == Types.CHAR && size>1 ) {
+			return "string";
+		}
+
+		String[] result = PREFERRED_HIBERNATETYPE_FOR_SQLTYPE.get( sqlType );
+
+		if(result==null) {
+			return null;
+		}
+		else if(returnNullable) {
+			return result[1];
+		}
+		else {
+			return result[0];
+		}
+	}
+
+	// ========================================================================
+	// Hibernate type name -> Java class
+	// ========================================================================
+
+	private static final Map<String, Class<?>> HIBERNATE_TO_JAVA = new HashMap<>();
+	private static final Map<String, TemporalType> TEMPORAL_MAP = new HashMap<>();
+	private static final Set<String> LOB_TYPES = Set.of("blob", "clob");
+
+	static {
+		TEMPORAL_MAP.put("date", TemporalType.DATE);
+		TEMPORAL_MAP.put("time", TemporalType.TIME);
+		TEMPORAL_MAP.put("timestamp", TemporalType.TIMESTAMP);
+
+		// Primitive types
+		HIBERNATE_TO_JAVA.put("int", int.class);
+		HIBERNATE_TO_JAVA.put("long", long.class);
+		HIBERNATE_TO_JAVA.put("short", short.class);
+		HIBERNATE_TO_JAVA.put("byte", byte.class);
+		HIBERNATE_TO_JAVA.put("float", float.class);
+		HIBERNATE_TO_JAVA.put("double", double.class);
+		HIBERNATE_TO_JAVA.put("boolean", boolean.class);
+		HIBERNATE_TO_JAVA.put("char", char.class);
+		HIBERNATE_TO_JAVA.put("character", char.class);
+
+		// Wrapper types
+		HIBERNATE_TO_JAVA.put("java.lang.Integer", Integer.class);
+		HIBERNATE_TO_JAVA.put("java.lang.Long", Long.class);
+		HIBERNATE_TO_JAVA.put("java.lang.Short", Short.class);
+		HIBERNATE_TO_JAVA.put("java.lang.Byte", Byte.class);
+		HIBERNATE_TO_JAVA.put("java.lang.Float", Float.class);
+		HIBERNATE_TO_JAVA.put("java.lang.Double", Double.class);
+		HIBERNATE_TO_JAVA.put("java.lang.Boolean", Boolean.class);
+		HIBERNATE_TO_JAVA.put("java.lang.Character", Character.class);
+
+		// String types
+		HIBERNATE_TO_JAVA.put("string", String.class);
+		HIBERNATE_TO_JAVA.put("java.lang.String", String.class);
+		HIBERNATE_TO_JAVA.put("clob", String.class);
+
+		// Numeric types
+		HIBERNATE_TO_JAVA.put("big_decimal", BigDecimal.class);
+		HIBERNATE_TO_JAVA.put("java.math.BigDecimal", BigDecimal.class);
+		HIBERNATE_TO_JAVA.put("big_integer", BigInteger.class);
+		HIBERNATE_TO_JAVA.put("java.math.BigInteger", BigInteger.class);
+
+		// Date/time types
+		HIBERNATE_TO_JAVA.put("date", Date.class);
+		HIBERNATE_TO_JAVA.put("time", Date.class);
+		HIBERNATE_TO_JAVA.put("timestamp", Date.class);
+		HIBERNATE_TO_JAVA.put("java.util.Date", Date.class);
+
+		// Boolean shorthand types
+		HIBERNATE_TO_JAVA.put("yes_no", Boolean.class);
+		HIBERNATE_TO_JAVA.put("true_false", Boolean.class);
+		HIBERNATE_TO_JAVA.put("numeric_boolean", Boolean.class);
+
+		// Binary types
+		HIBERNATE_TO_JAVA.put("binary", byte[].class);
+		HIBERNATE_TO_JAVA.put("blob", byte[].class);
+
+		// Serializable fallback
+		HIBERNATE_TO_JAVA.put("serializable", Serializable.class);
+	}
+
+	public static Class<?> toJavaClass(String hibernateTypeName) {
+		if (hibernateTypeName == null) {
+			return Object.class;
+		}
+		Class<?> result = HIBERNATE_TO_JAVA.get(hibernateTypeName);
+		if (result != null) {
+			return result;
+		}
+		if (hibernateTypeName.contains(".")) {
+			try {
+				return Class.forName(hibernateTypeName);
+			}
+			catch (ClassNotFoundException ignored) {
+			}
+		}
+		return Object.class;
+	}
+
+	public static TemporalType toTemporalType(String hibernateTypeName) {
+		if (hibernateTypeName == null) {
+			return null;
+		}
+		return TEMPORAL_MAP.get(hibernateTypeName);
+	}
+
+	public static boolean isLob(String hibernateTypeName) {
+		if (hibernateTypeName == null) {
+			return false;
+		}
+		return LOB_TYPES.contains(hibernateTypeName);
+	}
+
+	// ========================================================================
+	// Java class -> Hibernate type name
+	// ========================================================================
+
+	private static final Map<Class<?>, String> JAVA_TO_HIBERNATE = new HashMap<>();
+
+	static {
+		// Primitive types
+		JAVA_TO_HIBERNATE.put(int.class, "int");
+		JAVA_TO_HIBERNATE.put(long.class, "long");
+		JAVA_TO_HIBERNATE.put(short.class, "short");
+		JAVA_TO_HIBERNATE.put(byte.class, "byte");
+		JAVA_TO_HIBERNATE.put(float.class, "float");
+		JAVA_TO_HIBERNATE.put(double.class, "double");
+		JAVA_TO_HIBERNATE.put(boolean.class, "boolean");
+		JAVA_TO_HIBERNATE.put(char.class, "character");
+
+		// Wrapper types
+		JAVA_TO_HIBERNATE.put(Integer.class, "java.lang.Integer");
+		JAVA_TO_HIBERNATE.put(Long.class, "java.lang.Long");
+		JAVA_TO_HIBERNATE.put(Short.class, "java.lang.Short");
+		JAVA_TO_HIBERNATE.put(Byte.class, "java.lang.Byte");
+		JAVA_TO_HIBERNATE.put(Float.class, "java.lang.Float");
+		JAVA_TO_HIBERNATE.put(Double.class, "java.lang.Double");
+		JAVA_TO_HIBERNATE.put(Boolean.class, "java.lang.Boolean");
+		JAVA_TO_HIBERNATE.put(Character.class, "java.lang.Character");
+
+		// String
+		JAVA_TO_HIBERNATE.put(String.class, "string");
+
+		// Numeric types
+		JAVA_TO_HIBERNATE.put(BigDecimal.class, "big_decimal");
+		JAVA_TO_HIBERNATE.put(BigInteger.class, "big_integer");
+
+		// Date/time
+		JAVA_TO_HIBERNATE.put(Date.class, "timestamp");
+
+		// Binary
+		JAVA_TO_HIBERNATE.put(byte[].class, "binary");
+
+		// Serializable fallback
+		JAVA_TO_HIBERNATE.put(Serializable.class, "serializable");
+	}
+
+	public static String toHibernateType(Class<?> javaClass) {
+		if (javaClass == null) {
+			return "serializable";
+		}
+		String result = JAVA_TO_HIBERNATE.get(javaClass);
+		return result != null ? result : javaClass.getName();
+	}
+
+	public static String toHibernateType(String className) {
+		if (className == null) {
+			return "serializable";
+		}
+		try {
+			return toHibernateType(Class.forName(className));
+		}
+		catch (ClassNotFoundException e) {
+			return className;
+		}
+	}
+
+	// ========================================================================
+	// Java class name -> JDBC SQL type
+	// ========================================================================
+
+	private static final Map<String, Integer> JAVA_TO_JDBC = new HashMap<>();
+
+	static {
+		JAVA_TO_JDBC.put(String.class.getName(), Types.VARCHAR);
+		JAVA_TO_JDBC.put(Long.class.getName(), Types.BIGINT);
+		JAVA_TO_JDBC.put(long.class.getName(), Types.BIGINT);
+		JAVA_TO_JDBC.put(Integer.class.getName(), Types.INTEGER);
+		JAVA_TO_JDBC.put(int.class.getName(), Types.INTEGER);
+		JAVA_TO_JDBC.put(Short.class.getName(), Types.SMALLINT);
+		JAVA_TO_JDBC.put(short.class.getName(), Types.SMALLINT);
+		JAVA_TO_JDBC.put(Byte.class.getName(), Types.TINYINT);
+		JAVA_TO_JDBC.put(byte.class.getName(), Types.TINYINT);
+		JAVA_TO_JDBC.put(Float.class.getName(), Types.FLOAT);
+		JAVA_TO_JDBC.put(float.class.getName(), Types.FLOAT);
+		JAVA_TO_JDBC.put(Double.class.getName(), Types.DOUBLE);
+		JAVA_TO_JDBC.put(double.class.getName(), Types.DOUBLE);
+		JAVA_TO_JDBC.put(Boolean.class.getName(), Types.BOOLEAN);
+		JAVA_TO_JDBC.put(boolean.class.getName(), Types.BOOLEAN);
+		JAVA_TO_JDBC.put(BigDecimal.class.getName(), Types.NUMERIC);
+		JAVA_TO_JDBC.put(java.sql.Date.class.getName(), Types.DATE);
+		JAVA_TO_JDBC.put(java.sql.Time.class.getName(), Types.TIME);
+		JAVA_TO_JDBC.put(java.sql.Timestamp.class.getName(), Types.TIMESTAMP);
+		JAVA_TO_JDBC.put(Date.class.getName(), Types.TIMESTAMP);
+		JAVA_TO_JDBC.put(byte[].class.getName(), Types.VARBINARY);
+		JAVA_TO_JDBC.put(Character.class.getName(), Types.CHAR);
+		JAVA_TO_JDBC.put(char.class.getName(), Types.CHAR);
+	}
+
+	public static int getJdbcTypeCode(String javaClassName) {
+		if (javaClassName == null) {
+			return Integer.MIN_VALUE;
+		}
+		Integer jdbcType = JAVA_TO_JDBC.get(javaClassName);
+		return jdbcType != null ? jdbcType : Integer.MIN_VALUE;
+	}
+
+	// ========================================================================
+	// JDBC type name <-> integer constant
+	// ========================================================================
+
+	private static Map<String, Integer> jdbcTypes; // Name to value
+	private static Map<Integer, String> jdbcTypeValues; // value to Name
+
+	public static String[] getJDBCTypes() {
+		checkTypes();
+		return jdbcTypes.keySet().toArray( new String[0] );
+	}
+
+	public static int getJDBCType(String value) {
+		checkTypes();
+		Integer number = jdbcTypes.get(value);
+		if(number==null) {
+			try {
+				return Integer.parseInt(value);
+			}
+			catch (NumberFormatException nfe) {
+				throw new MappingException("jdbc-type: " + value + " is not a known JDBC Type nor a valid number");
+			}
+		}
+		else {
+			return number;
+		}
+	}
+
+	public static String getJDBCTypeName(int value) {
+		if(jdbcTypeValues==null) {
+			jdbcTypeValues = new HashMap<>();
+			Field[] fields = Types.class.getFields();
+			for ( Field field : fields ) {
+				if ( Modifier.isStatic( field.getModifiers() ) ) {
+					try {
+						jdbcTypeValues.put( (Integer) field.get( Types.class ), field.getName() );
+					}
+					catch (IllegalArgumentException | IllegalAccessException e) {
+						// ignore
+					}
+				}
+			}
+		}
+		String name = jdbcTypeValues.get( value );
+		if(name!=null) {
+			return name;
+		}
+		else {
+			return ""+value;
+		}
+	}
+
+	private static void checkTypes() {
+		if(jdbcTypes==null) {
+			jdbcTypes = new HashMap<>();
+			Field[] fields = Types.class.getFields();
+			for ( Field field : fields ) {
+				if ( Modifier.isStatic( field.getModifiers() ) ) {
+					try {
+						jdbcTypes.put( field.getName(), (Integer) field.get( Types.class ) );
+					}
+					catch (IllegalArgumentException | IllegalAccessException e) {
+						// ignore
+					}
+				}
+			}
+		}
+	}
+
+	// ========================================================================
+	// SQL type metadata
+	// ========================================================================
+
+	public static boolean typeHasScale(int sqlType) {
+		return (sqlType == Types.DECIMAL || sqlType == Types.NUMERIC);
+	}
+
+	public static boolean typeHasPrecision(int sqlType) {
+		return (sqlType == Types.DECIMAL || sqlType == Types.NUMERIC
+				|| sqlType == Types.REAL || sqlType == Types.FLOAT || sqlType == Types.DOUBLE);
+	}
+
+	public static boolean typeHasScaleAndPrecision(int sqlType) {
+		return typeHasScale(sqlType) && typeHasPrecision(sqlType);
+	}
+
+	public static boolean typeHasLength(int sqlType) {
+		return (sqlType == Types.CHAR || sqlType == Types.DATE
+				|| sqlType == Types.LONGVARCHAR || sqlType == Types.TIME || sqlType == Types.TIMESTAMP
+				|| sqlType == Types.VARCHAR );
+	}
+
+	// ========================================================================
+	// Primitive type checking
+	// ========================================================================
+
+	private static final Set<String> PRIMITIVE_TYPES = Set.of(
+			"boolean", "byte", "char", "short", "int", "long", "float", "double");
+
+	public static boolean isPrimitiveType(String className) {
+		return className != null && PRIMITIVE_TYPES.contains(className);
+	}
+}

--- a/tooling/hibernate-reveng/src/test/java/org/hibernate/tool/reveng/internal/descriptor/AttributeOverrideDescriptorTest.java
+++ b/tooling/hibernate-reveng/src/test/java/org/hibernate/tool/reveng/internal/descriptor/AttributeOverrideDescriptorTest.java
@@ -1,0 +1,26 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.tool.reveng.internal.descriptor;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for {@link AttributeOverrideDescriptor}.
+ *
+ * @author Koen Aers
+ */
+public class AttributeOverrideDescriptorTest {
+
+	@Test
+	public void testConstructorAndGetters() {
+		AttributeOverrideDescriptor override =
+			new AttributeOverrideDescriptor("street", "HOME_STREET");
+
+		assertEquals("street", override.getFieldName());
+		assertEquals("HOME_STREET", override.getColumnName());
+	}
+}

--- a/tooling/hibernate-reveng/src/test/java/org/hibernate/tool/reveng/internal/descriptor/ColumnDescriptorTest.java
+++ b/tooling/hibernate-reveng/src/test/java/org/hibernate/tool/reveng/internal/descriptor/ColumnDescriptorTest.java
@@ -1,0 +1,206 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.tool.reveng.internal.descriptor;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.TemporalType;
+
+/**
+ * Tests for {@link ColumnDescriptor}.
+ *
+ * @author Koen Aers
+ */
+public class ColumnDescriptorTest {
+
+	@Test
+	public void testConstructorAndDefaults() {
+		ColumnDescriptor column = new ColumnDescriptor("USER_NAME", "userName", String.class);
+
+		assertEquals("USER_NAME", column.getColumnName());
+		assertEquals("userName", column.getFieldName());
+		assertEquals(String.class, column.getJavaType());
+		assertTrue(column.isNullable(), "Should default to nullable");
+		assertFalse(column.isPrimaryKey());
+		assertFalse(column.isAutoIncrement());
+		assertFalse(column.isVersion());
+		assertFalse(column.isLob());
+		assertEquals(0, column.getLength());
+		assertEquals(0, column.getPrecision());
+		assertEquals(0, column.getScale());
+		assertNull(column.getBasicFetchType());
+		assertNull(column.getTemporalType());
+		assertNull(column.getHibernateTypeName());
+		assertFalse(column.isBasicOptionalSet());
+		assertTrue(column.isBasicOptional(), "Should default to true when not set");
+	}
+
+	@Test
+	public void testPrimaryKeySetsNullableToFalse() {
+		ColumnDescriptor column = new ColumnDescriptor("ID", "id", Long.class)
+			.primaryKey(true);
+
+		assertTrue(column.isPrimaryKey());
+		assertFalse(column.isNullable(), "primaryKey(true) should set nullable to false");
+	}
+
+	@Test
+	public void testNullableCanBeOverriddenAfterPrimaryKey() {
+		ColumnDescriptor column = new ColumnDescriptor("ID", "id", Long.class)
+			.primaryKey(true)
+			.nullable(true);
+
+		assertTrue(column.isNullable());
+	}
+
+	@Test
+	public void testAutoIncrement() {
+		ColumnDescriptor column = new ColumnDescriptor("ID", "id", Long.class)
+			.autoIncrement(true);
+
+		assertTrue(column.isAutoIncrement());
+	}
+
+	@Test
+	public void testLengthPrecisionScale() {
+		ColumnDescriptor column = new ColumnDescriptor("AMOUNT", "amount", java.math.BigDecimal.class)
+			.length(255)
+			.precision(10)
+			.scale(2);
+
+		assertEquals(255, column.getLength());
+		assertEquals(10, column.getPrecision());
+		assertEquals(2, column.getScale());
+	}
+
+	@Test
+	public void testVersion() {
+		ColumnDescriptor column = new ColumnDescriptor("VERSION", "version", Long.class)
+			.version(true);
+
+		assertTrue(column.isVersion());
+	}
+
+	@Test
+	public void testBasicFetchType() {
+		ColumnDescriptor column = new ColumnDescriptor("DATA", "data", String.class)
+			.basicFetch(FetchType.LAZY);
+
+		assertEquals(FetchType.LAZY, column.getBasicFetchType());
+	}
+
+	@Test
+	public void testBasicOptionalExplicitlySet() {
+		ColumnDescriptor column = new ColumnDescriptor("STATUS", "status", String.class)
+			.basicOptional(false);
+
+		assertTrue(column.isBasicOptionalSet());
+		assertFalse(column.isBasicOptional());
+	}
+
+	@Test
+	public void testBasicOptionalNotSet() {
+		ColumnDescriptor column = new ColumnDescriptor("STATUS", "status", String.class);
+
+		assertFalse(column.isBasicOptionalSet());
+		assertTrue(column.isBasicOptional(), "Should default to true when not explicitly set");
+	}
+
+	@Test
+	public void testTemporalType() {
+		ColumnDescriptor column = new ColumnDescriptor("EVENT_DATE", "eventDate", java.util.Date.class)
+			.temporal(TemporalType.TIMESTAMP);
+
+		assertEquals(TemporalType.TIMESTAMP, column.getTemporalType());
+	}
+
+	@Test
+	public void testLob() {
+		ColumnDescriptor column = new ColumnDescriptor("CONTENT", "content", byte[].class)
+			.lob(true);
+
+		assertTrue(column.isLob());
+	}
+
+	@Test
+	public void testComment() {
+		ColumnDescriptor column = new ColumnDescriptor("NAME", "name", String.class)
+			.comment("The user name");
+
+		assertEquals("The user name", column.getComment());
+	}
+
+	@Test
+	public void testCommentDefaultsToNull() {
+		ColumnDescriptor column = new ColumnDescriptor("NAME", "name", String.class);
+
+		assertNull(column.getComment());
+	}
+
+	@Test
+	public void testGenerationType() {
+		ColumnDescriptor column = new ColumnDescriptor("ID", "id", Long.class)
+			.generationType(GenerationType.SEQUENCE);
+
+		assertEquals(GenerationType.SEQUENCE, column.getGenerationType());
+	}
+
+	@Test
+	public void testGenerationTypeDefaultsToNull() {
+		ColumnDescriptor column = new ColumnDescriptor("ID", "id", Long.class);
+
+		assertNull(column.getGenerationType());
+	}
+
+	@Test
+	public void testUnique() {
+		ColumnDescriptor column = new ColumnDescriptor("EMAIL", "email", String.class)
+			.unique(true);
+
+		assertTrue(column.isUnique());
+	}
+
+	@Test
+	public void testUniqueDefaultsToFalse() {
+		ColumnDescriptor column = new ColumnDescriptor("EMAIL", "email", String.class);
+
+		assertFalse(column.isUnique());
+	}
+
+	@Test
+	public void testHibernateTypeName() {
+		ColumnDescriptor column = new ColumnDescriptor("NAME", "name", String.class)
+			.hibernateTypeName("string");
+
+		assertEquals("string", column.getHibernateTypeName());
+	}
+
+	@Test
+	public void testHibernateTypeNameDefaultsToNull() {
+		ColumnDescriptor column = new ColumnDescriptor("NAME", "name", String.class);
+
+		assertNull(column.getHibernateTypeName());
+	}
+
+	@Test
+	public void testFluentChaining() {
+		ColumnDescriptor column = new ColumnDescriptor("ID", "id", Long.class)
+			.primaryKey(true)
+			.autoIncrement(true)
+			.length(10)
+			.precision(5)
+			.scale(2);
+
+		assertTrue(column.isPrimaryKey());
+		assertTrue(column.isAutoIncrement());
+		assertEquals(10, column.getLength());
+		assertEquals(5, column.getPrecision());
+		assertEquals(2, column.getScale());
+	}
+}

--- a/tooling/hibernate-reveng/src/test/java/org/hibernate/tool/reveng/internal/descriptor/CompositeIdDescriptorTest.java
+++ b/tooling/hibernate-reveng/src/test/java/org/hibernate/tool/reveng/internal/descriptor/CompositeIdDescriptorTest.java
@@ -1,0 +1,46 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.tool.reveng.internal.descriptor;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for {@link CompositeIdDescriptor}.
+ *
+ * @author Koen Aers
+ */
+public class CompositeIdDescriptorTest {
+
+	@Test
+	public void testConstructorAndDefaults() {
+		CompositeIdDescriptor compositeId =
+			new CompositeIdDescriptor("id", "OrderItemId", "com.example");
+
+		assertEquals("id", compositeId.getFieldName());
+		assertEquals("OrderItemId", compositeId.getIdClassName());
+		assertEquals("com.example", compositeId.getIdClassPackage());
+		assertNotNull(compositeId.getAttributeOverrides());
+		assertTrue(compositeId.getAttributeOverrides().isEmpty());
+	}
+
+	@Test
+	public void testAddAttributeOverride() {
+		CompositeIdDescriptor compositeId =
+			new CompositeIdDescriptor("id", "OrderItemId", "com.example")
+				.addAttributeOverride("orderId", "ORDER_ID")
+				.addAttributeOverride("productId", "PRODUCT_ID");
+
+		List<AttributeOverrideDescriptor> overrides = compositeId.getAttributeOverrides();
+		assertEquals(2, overrides.size());
+		assertEquals("orderId", overrides.get(0).getFieldName());
+		assertEquals("ORDER_ID", overrides.get(0).getColumnName());
+		assertEquals("productId", overrides.get(1).getFieldName());
+		assertEquals("PRODUCT_ID", overrides.get(1).getColumnName());
+	}
+}

--- a/tooling/hibernate-reveng/src/test/java/org/hibernate/tool/reveng/internal/descriptor/EmbeddableDescriptorTest.java
+++ b/tooling/hibernate-reveng/src/test/java/org/hibernate/tool/reveng/internal/descriptor/EmbeddableDescriptorTest.java
@@ -1,0 +1,38 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.tool.reveng.internal.descriptor;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for {@link EmbeddableDescriptor}.
+ *
+ * @author Koen Aers
+ */
+public class EmbeddableDescriptorTest {
+
+	@Test
+	public void testConstructorAndDefaults() {
+		EmbeddableDescriptor embeddable = new EmbeddableDescriptor("Address", "com.example");
+
+		assertEquals("Address", embeddable.getClassName());
+		assertEquals("com.example", embeddable.getPackageName());
+		assertNotNull(embeddable.getColumns());
+		assertTrue(embeddable.getColumns().isEmpty());
+	}
+
+	@Test
+	public void testAddColumn() {
+		EmbeddableDescriptor embeddable = new EmbeddableDescriptor("Address", "com.example")
+			.addColumn(new ColumnDescriptor("STREET", "street", String.class))
+			.addColumn(new ColumnDescriptor("CITY", "city", String.class));
+
+		assertEquals(2, embeddable.getColumns().size());
+		assertEquals("STREET", embeddable.getColumns().get(0).getColumnName());
+		assertEquals("CITY", embeddable.getColumns().get(1).getColumnName());
+	}
+}

--- a/tooling/hibernate-reveng/src/test/java/org/hibernate/tool/reveng/internal/descriptor/EmbeddedFieldDescriptorTest.java
+++ b/tooling/hibernate-reveng/src/test/java/org/hibernate/tool/reveng/internal/descriptor/EmbeddedFieldDescriptorTest.java
@@ -1,0 +1,46 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.tool.reveng.internal.descriptor;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for {@link EmbeddedFieldDescriptor}.
+ *
+ * @author Koen Aers
+ */
+public class EmbeddedFieldDescriptorTest {
+
+	@Test
+	public void testConstructorAndDefaults() {
+		EmbeddedFieldDescriptor embedded =
+			new EmbeddedFieldDescriptor("address", "Address", "com.example");
+
+		assertEquals("address", embedded.getFieldName());
+		assertEquals("Address", embedded.getEmbeddableClassName());
+		assertEquals("com.example", embedded.getEmbeddablePackage());
+		assertNotNull(embedded.getAttributeOverrides());
+		assertTrue(embedded.getAttributeOverrides().isEmpty());
+	}
+
+	@Test
+	public void testAddAttributeOverride() {
+		EmbeddedFieldDescriptor embedded =
+			new EmbeddedFieldDescriptor("address", "Address", "com.example")
+				.addAttributeOverride("street", "HOME_STREET")
+				.addAttributeOverride("city", "HOME_CITY");
+
+		List<AttributeOverrideDescriptor> overrides = embedded.getAttributeOverrides();
+		assertEquals(2, overrides.size());
+		assertEquals("street", overrides.get(0).getFieldName());
+		assertEquals("HOME_STREET", overrides.get(0).getColumnName());
+		assertEquals("city", overrides.get(1).getFieldName());
+		assertEquals("HOME_CITY", overrides.get(1).getColumnName());
+	}
+}

--- a/tooling/hibernate-reveng/src/test/java/org/hibernate/tool/reveng/internal/descriptor/ForeignKeyDescriptorTest.java
+++ b/tooling/hibernate-reveng/src/test/java/org/hibernate/tool/reveng/internal/descriptor/ForeignKeyDescriptorTest.java
@@ -1,0 +1,131 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.tool.reveng.internal.descriptor;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+
+import jakarta.persistence.FetchType;
+
+/**
+ * Tests for {@link ForeignKeyDescriptor}.
+ *
+ * @author Koen Aers
+ */
+public class ForeignKeyDescriptorTest {
+
+	@Test
+	public void testConstructorWithForeignKeyColumn() {
+		ForeignKeyDescriptor fk = new ForeignKeyDescriptor(
+			"department", "DEPARTMENT_ID", "Department", "com.example");
+
+		assertEquals("department", fk.getFieldName());
+		assertEquals("DEPARTMENT_ID", fk.getForeignKeyColumnName());
+		assertEquals("Department", fk.getTargetEntityClassName());
+		assertEquals("com.example", fk.getTargetEntityPackage());
+		assertTrue(fk.isOptional());
+		assertNull(fk.getFetchType());
+		assertNull(fk.getReferencedColumnName());
+		assertFalse(fk.isPartOfCompositeKey());
+		assertEquals(1, fk.getJoinColumns().size());
+		assertEquals(1, fk.getForeignKeyColumnNames().size());
+		assertEquals("DEPARTMENT_ID", fk.getForeignKeyColumnNames().get(0));
+	}
+
+	@Test
+	public void testConstructorWithoutForeignKeyColumn() {
+		ForeignKeyDescriptor fk = new ForeignKeyDescriptor(
+			"department", "Department", "com.example");
+
+		assertEquals("department", fk.getFieldName());
+		assertNull(fk.getForeignKeyColumnName());
+		assertEquals("Department", fk.getTargetEntityClassName());
+		assertEquals("com.example", fk.getTargetEntityPackage());
+		assertTrue(fk.isOptional());
+		assertTrue(fk.getJoinColumns().isEmpty());
+		assertTrue(fk.getForeignKeyColumnNames().isEmpty());
+	}
+
+	@Test
+	public void testReferencedColumnName() {
+		ForeignKeyDescriptor fk = new ForeignKeyDescriptor(
+			"department", "DEPT_ID", "Department", "com.example")
+			.referencedColumnName("ID");
+
+		assertEquals("ID", fk.getReferencedColumnName());
+		assertEquals("DEPT_ID", fk.getJoinColumns().get(0).fkColumnName());
+		assertEquals("ID", fk.getJoinColumns().get(0).referencedColumnName());
+	}
+
+	@Test
+	public void testAddJoinColumn() {
+		ForeignKeyDescriptor fk = new ForeignKeyDescriptor(
+			"department", "Department", "com.example")
+			.addJoinColumn("DEPT_ID", "ID")
+			.addJoinColumn("REGION_ID", "REGION_PK");
+
+		assertEquals(2, fk.getJoinColumns().size());
+		assertEquals("DEPT_ID", fk.getJoinColumns().get(0).fkColumnName());
+		assertEquals("ID", fk.getJoinColumns().get(0).referencedColumnName());
+		assertEquals("REGION_ID", fk.getJoinColumns().get(1).fkColumnName());
+		assertEquals("REGION_PK", fk.getJoinColumns().get(1).referencedColumnName());
+
+		assertEquals("DEPT_ID", fk.getForeignKeyColumnName());
+		assertEquals("ID", fk.getReferencedColumnName());
+		assertEquals(2, fk.getForeignKeyColumnNames().size());
+	}
+
+	@Test
+	public void testFetchType() {
+		ForeignKeyDescriptor fk = new ForeignKeyDescriptor(
+			"department", "DEPARTMENT_ID", "Department", "com.example")
+			.fetchType(FetchType.LAZY);
+
+		assertEquals(FetchType.LAZY, fk.getFetchType());
+	}
+
+	@Test
+	public void testOptional() {
+		ForeignKeyDescriptor fk = new ForeignKeyDescriptor(
+			"department", "DEPARTMENT_ID", "Department", "com.example")
+			.optional(false);
+
+		assertFalse(fk.isOptional());
+	}
+
+	@Test
+	public void testPartOfCompositeKey() {
+		ForeignKeyDescriptor fk = new ForeignKeyDescriptor(
+			"department", "DEPARTMENT_ID", "Department", "com.example")
+			.partOfCompositeKey(true);
+
+		assertTrue(fk.isPartOfCompositeKey());
+	}
+
+	@Test
+	public void testFluentChaining() {
+		ForeignKeyDescriptor fk = new ForeignKeyDescriptor(
+			"department", "DEPARTMENT_ID", "Department", "com.example")
+			.referencedColumnName("DEPT_PK")
+			.fetchType(FetchType.EAGER)
+			.optional(false)
+			.partOfCompositeKey(true);
+
+		assertEquals("DEPT_PK", fk.getReferencedColumnName());
+		assertEquals(FetchType.EAGER, fk.getFetchType());
+		assertFalse(fk.isOptional());
+		assertTrue(fk.isPartOfCompositeKey());
+	}
+
+	@Test
+	public void testJoinColumnsUnmodifiable() {
+		ForeignKeyDescriptor fk = new ForeignKeyDescriptor(
+			"department", "DEPARTMENT_ID", "Department", "com.example");
+
+		assertThrows(UnsupportedOperationException.class,
+			() -> fk.getJoinColumns().add(new JoinColumnPair("X", "Y")));
+	}
+}

--- a/tooling/hibernate-reveng/src/test/java/org/hibernate/tool/reveng/internal/descriptor/IndexDescriptorTest.java
+++ b/tooling/hibernate-reveng/src/test/java/org/hibernate/tool/reveng/internal/descriptor/IndexDescriptorTest.java
@@ -1,0 +1,54 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.tool.reveng.internal.descriptor;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for {@link IndexDescriptor}.
+ *
+ * @author Koen Aers
+ */
+public class IndexDescriptorTest {
+
+	@Test
+	public void testConstructorAndDefaults() {
+		IndexDescriptor index = new IndexDescriptor("IDX_NAME", true);
+
+		assertEquals("IDX_NAME", index.getIndexName());
+		assertTrue(index.isUnique());
+		assertNotNull(index.getColumnNames());
+		assertTrue(index.getColumnNames().isEmpty());
+	}
+
+	@Test
+	public void testNonUniqueIndex() {
+		IndexDescriptor index = new IndexDescriptor("IDX_SEARCH", false);
+
+		assertFalse(index.isUnique());
+	}
+
+	@Test
+	public void testAddColumns() {
+		IndexDescriptor index = new IndexDescriptor("IDX_COMPOSITE", true)
+			.addColumn("COL_A")
+			.addColumn("COL_B");
+
+		assertEquals(2, index.getColumnNames().size());
+		assertEquals("COL_A", index.getColumnNames().get(0));
+		assertEquals("COL_B", index.getColumnNames().get(1));
+	}
+
+	@Test
+	public void testSingleColumnIndex() {
+		IndexDescriptor index = new IndexDescriptor("IDX_EMAIL", true)
+			.addColumn("EMAIL");
+
+		assertEquals(1, index.getColumnNames().size());
+		assertEquals("EMAIL", index.getColumnNames().get(0));
+	}
+}

--- a/tooling/hibernate-reveng/src/test/java/org/hibernate/tool/reveng/internal/descriptor/InheritanceDescriptorTest.java
+++ b/tooling/hibernate-reveng/src/test/java/org/hibernate/tool/reveng/internal/descriptor/InheritanceDescriptorTest.java
@@ -1,0 +1,74 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.tool.reveng.internal.descriptor;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+
+import jakarta.persistence.DiscriminatorType;
+import jakarta.persistence.InheritanceType;
+
+/**
+ * Tests for {@link InheritanceDescriptor}.
+ *
+ * @author Koen Aers
+ */
+public class InheritanceDescriptorTest {
+
+	@Test
+	public void testConstructorAndDefaults() {
+		InheritanceDescriptor inheritance = new InheritanceDescriptor(InheritanceType.SINGLE_TABLE);
+
+		assertEquals(InheritanceType.SINGLE_TABLE, inheritance.getStrategy());
+		assertNull(inheritance.getDiscriminatorColumnName());
+		assertNull(inheritance.getDiscriminatorType());
+		assertEquals(0, inheritance.getDiscriminatorColumnLength());
+	}
+
+	@Test
+	public void testJoinedStrategy() {
+		InheritanceDescriptor inheritance = new InheritanceDescriptor(InheritanceType.JOINED);
+
+		assertEquals(InheritanceType.JOINED, inheritance.getStrategy());
+	}
+
+	@Test
+	public void testDiscriminatorColumn() {
+		InheritanceDescriptor inheritance = new InheritanceDescriptor(InheritanceType.SINGLE_TABLE)
+			.discriminatorColumn("VEHICLE_TYPE");
+
+		assertEquals("VEHICLE_TYPE", inheritance.getDiscriminatorColumnName());
+	}
+
+	@Test
+	public void testDiscriminatorType() {
+		InheritanceDescriptor inheritance = new InheritanceDescriptor(InheritanceType.SINGLE_TABLE)
+			.discriminatorType(DiscriminatorType.STRING);
+
+		assertEquals(DiscriminatorType.STRING, inheritance.getDiscriminatorType());
+	}
+
+	@Test
+	public void testDiscriminatorColumnLength() {
+		InheritanceDescriptor inheritance = new InheritanceDescriptor(InheritanceType.SINGLE_TABLE)
+			.discriminatorColumnLength(50);
+
+		assertEquals(50, inheritance.getDiscriminatorColumnLength());
+	}
+
+	@Test
+	public void testFluentChaining() {
+		InheritanceDescriptor inheritance = new InheritanceDescriptor(InheritanceType.SINGLE_TABLE)
+			.discriminatorColumn("TYPE")
+			.discriminatorType(DiscriminatorType.INTEGER)
+			.discriminatorColumnLength(10);
+
+		assertEquals(InheritanceType.SINGLE_TABLE, inheritance.getStrategy());
+		assertEquals("TYPE", inheritance.getDiscriminatorColumnName());
+		assertEquals(DiscriminatorType.INTEGER, inheritance.getDiscriminatorType());
+		assertEquals(10, inheritance.getDiscriminatorColumnLength());
+	}
+}

--- a/tooling/hibernate-reveng/src/test/java/org/hibernate/tool/reveng/internal/descriptor/ManyToManyDescriptorTest.java
+++ b/tooling/hibernate-reveng/src/test/java/org/hibernate/tool/reveng/internal/descriptor/ManyToManyDescriptorTest.java
@@ -1,0 +1,93 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.tool.reveng.internal.descriptor;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.FetchType;
+
+/**
+ * Tests for {@link ManyToManyDescriptor}.
+ *
+ * @author Koen Aers
+ */
+public class ManyToManyDescriptorTest {
+
+	@Test
+	public void testConstructorAndDefaults() {
+		ManyToManyDescriptor mtm = new ManyToManyDescriptor(
+			"courses", "Course", "com.example");
+
+		assertEquals("courses", mtm.getFieldName());
+		assertEquals("Course", mtm.getTargetEntityClassName());
+		assertEquals("com.example", mtm.getTargetEntityPackage());
+		assertNull(mtm.getMappedBy());
+		assertNull(mtm.getJoinTableName());
+		assertNull(mtm.getJoinColumnName());
+		assertNull(mtm.getInverseJoinColumnName());
+		assertNull(mtm.getFetchType());
+		assertNull(mtm.getCascadeTypes());
+	}
+
+	@Test
+	public void testOwningSideWithJoinTable() {
+		ManyToManyDescriptor mtm = new ManyToManyDescriptor(
+			"courses", "Course", "com.example")
+			.joinTable("STUDENT_COURSE", "STUDENT_ID", "COURSE_ID")
+			.cascade(CascadeType.PERSIST);
+
+		assertEquals("STUDENT_COURSE", mtm.getJoinTableName());
+		assertEquals("STUDENT_ID", mtm.getJoinColumnName());
+		assertEquals("COURSE_ID", mtm.getInverseJoinColumnName());
+		assertArrayEquals(new CascadeType[]{ CascadeType.PERSIST }, mtm.getCascadeTypes());
+	}
+
+	@Test
+	public void testInverseSideWithMappedBy() {
+		ManyToManyDescriptor mtm = new ManyToManyDescriptor(
+			"students", "Student", "com.example")
+			.mappedBy("courses");
+
+		assertEquals("courses", mtm.getMappedBy());
+	}
+
+	@Test
+	public void testFetchType() {
+		ManyToManyDescriptor mtm = new ManyToManyDescriptor(
+			"courses", "Course", "com.example")
+			.fetchType(FetchType.EAGER);
+
+		assertEquals(FetchType.EAGER, mtm.getFetchType());
+	}
+
+	@Test
+	public void testMultipleCascadeTypes() {
+		ManyToManyDescriptor mtm = new ManyToManyDescriptor(
+			"courses", "Course", "com.example")
+			.cascade(CascadeType.PERSIST, CascadeType.MERGE);
+
+		assertArrayEquals(
+			new CascadeType[]{ CascadeType.PERSIST, CascadeType.MERGE },
+			mtm.getCascadeTypes());
+	}
+
+	@Test
+	public void testFluentChaining() {
+		ManyToManyDescriptor mtm = new ManyToManyDescriptor(
+			"courses", "Course", "com.example")
+			.joinTable("STUDENT_COURSE", "STUDENT_ID", "COURSE_ID")
+			.fetchType(FetchType.LAZY)
+			.cascade(CascadeType.ALL);
+
+		assertEquals("STUDENT_COURSE", mtm.getJoinTableName());
+		assertEquals("STUDENT_ID", mtm.getJoinColumnName());
+		assertEquals("COURSE_ID", mtm.getInverseJoinColumnName());
+		assertEquals(FetchType.LAZY, mtm.getFetchType());
+		assertArrayEquals(new CascadeType[]{ CascadeType.ALL }, mtm.getCascadeTypes());
+	}
+}

--- a/tooling/hibernate-reveng/src/test/java/org/hibernate/tool/reveng/internal/descriptor/OneToManyDescriptorTest.java
+++ b/tooling/hibernate-reveng/src/test/java/org/hibernate/tool/reveng/internal/descriptor/OneToManyDescriptorTest.java
@@ -1,0 +1,85 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.tool.reveng.internal.descriptor;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.FetchType;
+
+/**
+ * Tests for {@link OneToManyDescriptor}.
+ *
+ * @author Koen Aers
+ */
+public class OneToManyDescriptorTest {
+
+	@Test
+	public void testConstructorAndDefaults() {
+		OneToManyDescriptor otm = new OneToManyDescriptor(
+			"employees", "department", "Employee", "com.example");
+
+		assertEquals("employees", otm.getFieldName());
+		assertEquals("department", otm.getMappedBy());
+		assertEquals("Employee", otm.getElementEntityClassName());
+		assertEquals("com.example", otm.getElementEntityPackage());
+		assertNull(otm.getFetchType());
+		assertNull(otm.getCascadeTypes());
+		assertFalse(otm.isOrphanRemoval());
+	}
+
+	@Test
+	public void testFetchType() {
+		OneToManyDescriptor otm = new OneToManyDescriptor(
+			"employees", "department", "Employee", "com.example")
+			.fetchType(FetchType.EAGER);
+
+		assertEquals(FetchType.EAGER, otm.getFetchType());
+	}
+
+	@Test
+	public void testCascadeTypes() {
+		OneToManyDescriptor otm = new OneToManyDescriptor(
+			"employees", "department", "Employee", "com.example")
+			.cascade(CascadeType.ALL);
+
+		assertArrayEquals(new CascadeType[]{ CascadeType.ALL }, otm.getCascadeTypes());
+	}
+
+	@Test
+	public void testMultipleCascadeTypes() {
+		OneToManyDescriptor otm = new OneToManyDescriptor(
+			"employees", "department", "Employee", "com.example")
+			.cascade(CascadeType.PERSIST, CascadeType.MERGE);
+
+		assertArrayEquals(
+			new CascadeType[]{ CascadeType.PERSIST, CascadeType.MERGE },
+			otm.getCascadeTypes());
+	}
+
+	@Test
+	public void testOrphanRemoval() {
+		OneToManyDescriptor otm = new OneToManyDescriptor(
+			"employees", "department", "Employee", "com.example")
+			.orphanRemoval(true);
+
+		assertTrue(otm.isOrphanRemoval());
+	}
+
+	@Test
+	public void testFluentChaining() {
+		OneToManyDescriptor otm = new OneToManyDescriptor(
+			"employees", "department", "Employee", "com.example")
+			.fetchType(FetchType.LAZY)
+			.cascade(CascadeType.ALL)
+			.orphanRemoval(true);
+
+		assertEquals(FetchType.LAZY, otm.getFetchType());
+		assertArrayEquals(new CascadeType[]{ CascadeType.ALL }, otm.getCascadeTypes());
+		assertTrue(otm.isOrphanRemoval());
+	}
+}

--- a/tooling/hibernate-reveng/src/test/java/org/hibernate/tool/reveng/internal/descriptor/OneToOneDescriptorTest.java
+++ b/tooling/hibernate-reveng/src/test/java/org/hibernate/tool/reveng/internal/descriptor/OneToOneDescriptorTest.java
@@ -1,0 +1,108 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.tool.reveng.internal.descriptor;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.FetchType;
+
+/**
+ * Tests for {@link OneToOneDescriptor}.
+ *
+ * @author Koen Aers
+ */
+public class OneToOneDescriptorTest {
+
+	@Test
+	public void testConstructorAndDefaults() {
+		OneToOneDescriptor oto = new OneToOneDescriptor(
+			"address", "Address", "com.example");
+
+		assertEquals("address", oto.getFieldName());
+		assertEquals("Address", oto.getTargetEntityClassName());
+		assertEquals("com.example", oto.getTargetEntityPackage());
+		assertTrue(oto.isOptional(), "Should default to optional");
+		assertFalse(oto.isOrphanRemoval());
+		assertNull(oto.getForeignKeyColumnName());
+		assertNull(oto.getReferencedColumnName());
+		assertNull(oto.getMappedBy());
+		assertNull(oto.getFetchType());
+		assertNull(oto.getCascadeTypes());
+	}
+
+	@Test
+	public void testOwningSide() {
+		OneToOneDescriptor oto = new OneToOneDescriptor(
+			"address", "Address", "com.example")
+			.foreignKeyColumnName("ADDRESS_ID")
+			.fetchType(FetchType.LAZY)
+			.cascade(CascadeType.ALL);
+
+		assertEquals("ADDRESS_ID", oto.getForeignKeyColumnName());
+		assertEquals(FetchType.LAZY, oto.getFetchType());
+		assertArrayEquals(new CascadeType[]{ CascadeType.ALL }, oto.getCascadeTypes());
+	}
+
+	@Test
+	public void testInverseSide() {
+		OneToOneDescriptor oto = new OneToOneDescriptor(
+			"user", "User", "com.example")
+			.mappedBy("address")
+			.fetchType(FetchType.LAZY);
+
+		assertEquals("address", oto.getMappedBy());
+		assertEquals(FetchType.LAZY, oto.getFetchType());
+	}
+
+	@Test
+	public void testReferencedColumnName() {
+		OneToOneDescriptor oto = new OneToOneDescriptor(
+			"address", "Address", "com.example")
+			.foreignKeyColumnName("ADDR_ID")
+			.referencedColumnName("ADDRESS_PK");
+
+		assertEquals("ADDRESS_PK", oto.getReferencedColumnName());
+	}
+
+	@Test
+	public void testOptional() {
+		OneToOneDescriptor oto = new OneToOneDescriptor(
+			"address", "Address", "com.example")
+			.optional(false);
+
+		assertFalse(oto.isOptional());
+	}
+
+	@Test
+	public void testOrphanRemoval() {
+		OneToOneDescriptor oto = new OneToOneDescriptor(
+			"address", "Address", "com.example")
+			.orphanRemoval(true);
+
+		assertTrue(oto.isOrphanRemoval());
+	}
+
+	@Test
+	public void testFluentChaining() {
+		OneToOneDescriptor oto = new OneToOneDescriptor(
+			"address", "Address", "com.example")
+			.foreignKeyColumnName("ADDRESS_ID")
+			.referencedColumnName("ID")
+			.fetchType(FetchType.LAZY)
+			.cascade(CascadeType.ALL)
+			.optional(false)
+			.orphanRemoval(true);
+
+		assertEquals("ADDRESS_ID", oto.getForeignKeyColumnName());
+		assertEquals("ID", oto.getReferencedColumnName());
+		assertEquals(FetchType.LAZY, oto.getFetchType());
+		assertArrayEquals(new CascadeType[]{ CascadeType.ALL }, oto.getCascadeTypes());
+		assertFalse(oto.isOptional());
+		assertTrue(oto.isOrphanRemoval());
+	}
+}

--- a/tooling/hibernate-reveng/src/test/java/org/hibernate/tool/reveng/internal/descriptor/TableDescriptorTest.java
+++ b/tooling/hibernate-reveng/src/test/java/org/hibernate/tool/reveng/internal/descriptor/TableDescriptorTest.java
@@ -1,0 +1,238 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.tool.reveng.internal.descriptor;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+
+import jakarta.persistence.InheritanceType;
+
+/**
+ * Tests for {@link TableDescriptor}.
+ *
+ * @author Koen Aers
+ */
+public class TableDescriptorTest {
+
+	@Test
+	public void testConstructorAndDefaults() {
+		TableDescriptor table = new TableDescriptor("PERSON", "Person", "com.example");
+
+		assertEquals("PERSON", table.getTableName());
+		assertEquals("Person", table.getEntityClassName());
+		assertEquals("com.example", table.getEntityPackage());
+		assertNull(table.getSchema());
+		assertNull(table.getCatalog());
+		assertNotNull(table.getColumns());
+		assertTrue(table.getColumns().isEmpty());
+		assertNotNull(table.getForeignKeys());
+		assertTrue(table.getForeignKeys().isEmpty());
+		assertNotNull(table.getOneToManys());
+		assertTrue(table.getOneToManys().isEmpty());
+		assertNotNull(table.getOneToOnes());
+		assertTrue(table.getOneToOnes().isEmpty());
+		assertNotNull(table.getManyToManys());
+		assertTrue(table.getManyToManys().isEmpty());
+		assertNotNull(table.getEmbeddedFields());
+		assertTrue(table.getEmbeddedFields().isEmpty());
+		assertNull(table.getInheritance());
+		assertNull(table.getDiscriminatorValue());
+		assertNull(table.getParentEntityClassName());
+		assertNull(table.getParentEntityPackage());
+		assertNull(table.getPrimaryKeyJoinColumnName());
+		assertNull(table.getCompositeId());
+	}
+
+	@Test
+	public void testSetters() {
+		TableDescriptor table = new TableDescriptor("PERSON", "Person", "com.example");
+
+		table.setTableName("EMPLOYEE");
+		table.setEntityClassName("Employee");
+		table.setEntityPackage("com.example.entity");
+		table.setSchema("public");
+		table.setCatalog("mydb");
+
+		assertEquals("EMPLOYEE", table.getTableName());
+		assertEquals("Employee", table.getEntityClassName());
+		assertEquals("com.example.entity", table.getEntityPackage());
+		assertEquals("public", table.getSchema());
+		assertEquals("mydb", table.getCatalog());
+	}
+
+	@Test
+	public void testAddColumn() {
+		TableDescriptor table = new TableDescriptor("PERSON", "Person", "com.example")
+			.addColumn(new ColumnDescriptor("ID", "id", Long.class))
+			.addColumn(new ColumnDescriptor("NAME", "name", String.class));
+
+		assertEquals(2, table.getColumns().size());
+		assertEquals("ID", table.getColumns().get(0).getColumnName());
+		assertEquals("NAME", table.getColumns().get(1).getColumnName());
+	}
+
+	@Test
+	public void testAddForeignKey() {
+		TableDescriptor table = new TableDescriptor("EMPLOYEE", "Employee", "com.example")
+			.addForeignKey(new ForeignKeyDescriptor(
+				"department", "DEPARTMENT_ID", "Department", "com.example"));
+
+		assertEquals(1, table.getForeignKeys().size());
+		assertEquals("department", table.getForeignKeys().get(0).getFieldName());
+	}
+
+	@Test
+	public void testAddOneToMany() {
+		TableDescriptor table = new TableDescriptor("DEPARTMENT", "Department", "com.example")
+			.addOneToMany(new OneToManyDescriptor(
+				"employees", "department", "Employee", "com.example"));
+
+		assertEquals(1, table.getOneToManys().size());
+		assertEquals("employees", table.getOneToManys().get(0).getFieldName());
+	}
+
+	@Test
+	public void testAddOneToOne() {
+		TableDescriptor table = new TableDescriptor("USER_TABLE", "User", "com.example")
+			.addOneToOne(new OneToOneDescriptor(
+				"address", "Address", "com.example")
+				.foreignKeyColumnName("ADDRESS_ID"));
+
+		assertEquals(1, table.getOneToOnes().size());
+		assertEquals("address", table.getOneToOnes().get(0).getFieldName());
+	}
+
+	@Test
+	public void testAddManyToMany() {
+		TableDescriptor table = new TableDescriptor("STUDENT", "Student", "com.example")
+			.addManyToMany(new ManyToManyDescriptor(
+				"courses", "Course", "com.example")
+				.joinTable("STUDENT_COURSE", "STUDENT_ID", "COURSE_ID"));
+
+		assertEquals(1, table.getManyToManys().size());
+		assertEquals("courses", table.getManyToManys().get(0).getFieldName());
+	}
+
+	@Test
+	public void testAddEmbeddedField() {
+		TableDescriptor table = new TableDescriptor("PERSON", "Person", "com.example")
+			.addEmbeddedField(new EmbeddedFieldDescriptor(
+				"address", "Address", "com.example"));
+
+		assertEquals(1, table.getEmbeddedFields().size());
+		assertEquals("address", table.getEmbeddedFields().get(0).getFieldName());
+	}
+
+	@Test
+	public void testInheritance() {
+		InheritanceDescriptor inheritance = new InheritanceDescriptor(InheritanceType.SINGLE_TABLE);
+		TableDescriptor table = new TableDescriptor("VEHICLE", "Vehicle", "com.example")
+			.inheritance(inheritance);
+
+		assertSame(inheritance, table.getInheritance());
+	}
+
+	@Test
+	public void testDiscriminatorValue() {
+		TableDescriptor table = new TableDescriptor("VEHICLE", "Car", "com.example")
+			.discriminatorValue("CAR");
+
+		assertEquals("CAR", table.getDiscriminatorValue());
+	}
+
+	@Test
+	public void testParent() {
+		TableDescriptor table = new TableDescriptor("CAR", "Car", "com.example")
+			.parent("Vehicle", "com.example");
+
+		assertEquals("Vehicle", table.getParentEntityClassName());
+		assertEquals("com.example", table.getParentEntityPackage());
+	}
+
+	@Test
+	public void testPrimaryKeyJoinColumn() {
+		TableDescriptor table = new TableDescriptor("CREDIT_CARD_PAYMENT", "CreditCardPayment", "com.example")
+			.primaryKeyJoinColumn("PAYMENT_ID");
+
+		assertEquals("PAYMENT_ID", table.getPrimaryKeyJoinColumnName());
+	}
+
+	@Test
+	public void testCompositeId() {
+		CompositeIdDescriptor compositeId =
+			new CompositeIdDescriptor("id", "OrderItemId", "com.example");
+		TableDescriptor table = new TableDescriptor("ORDER_ITEM", "OrderItem", "com.example")
+			.compositeId(compositeId);
+
+		assertSame(compositeId, table.getCompositeId());
+	}
+
+	@Test
+	public void testComment() {
+		TableDescriptor table = new TableDescriptor("EMPLOYEE", "Employee", "com.example")
+			.comment("Employee records");
+
+		assertEquals("Employee records", table.getComment());
+	}
+
+	@Test
+	public void testCommentDefaultsToNull() {
+		TableDescriptor table = new TableDescriptor("EMPLOYEE", "Employee", "com.example");
+
+		assertNull(table.getComment());
+	}
+
+	@Test
+	public void testAddIndex() {
+		IndexDescriptor index = new IndexDescriptor("IDX_EMAIL", true)
+			.addColumn("EMAIL");
+		TableDescriptor table = new TableDescriptor("EMPLOYEE", "Employee", "com.example")
+			.addIndex(index);
+
+		assertEquals(1, table.getIndexes().size());
+		assertEquals("IDX_EMAIL", table.getIndexes().get(0).getIndexName());
+	}
+
+	@Test
+	public void testIndexesDefaultToEmpty() {
+		TableDescriptor table = new TableDescriptor("EMPLOYEE", "Employee", "com.example");
+
+		assertNotNull(table.getIndexes());
+		assertTrue(table.getIndexes().isEmpty());
+	}
+
+	@Test
+	public void testIsForeignKeyColumnWithForeignKey() {
+		TableDescriptor table = new TableDescriptor("EMPLOYEE", "Employee", "com.example")
+			.addForeignKey(new ForeignKeyDescriptor(
+				"department", "DEPARTMENT_ID", "Department", "com.example"));
+
+		assertTrue(table.isForeignKeyColumn("DEPARTMENT_ID"));
+		assertFalse(table.isForeignKeyColumn("NAME"));
+	}
+
+	@Test
+	public void testIsForeignKeyColumnWithOneToOne() {
+		TableDescriptor table = new TableDescriptor("USER_TABLE", "User", "com.example")
+			.addOneToOne(new OneToOneDescriptor(
+				"address", "Address", "com.example")
+				.foreignKeyColumnName("ADDRESS_ID"));
+
+		assertTrue(table.isForeignKeyColumn("ADDRESS_ID"));
+		assertFalse(table.isForeignKeyColumn("NAME"));
+	}
+
+	@Test
+	public void testIsForeignKeyColumnWithInverseOneToOne() {
+		TableDescriptor table = new TableDescriptor("ADDRESS", "Address", "com.example")
+			.addOneToOne(new OneToOneDescriptor(
+				"user", "User", "com.example")
+				.mappedBy("address"));
+
+		assertFalse(table.isForeignKeyColumn("USER_ID"),
+			"Inverse side (mappedBy) should not be treated as FK column");
+	}
+}

--- a/tooling/hibernate-reveng/src/test/java/org/hibernate/tool/reveng/internal/util/TypeHelperTest.java
+++ b/tooling/hibernate-reveng/src/test/java/org/hibernate/tool/reveng/internal/util/TypeHelperTest.java
@@ -1,0 +1,648 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.tool.reveng.internal.util;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.sql.Types;
+import java.util.Date;
+
+import jakarta.persistence.TemporalType;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for {@link TypeHelper}.
+ *
+ * @author Koen Aers
+ */
+public class TypeHelperTest {
+
+	// ================================================================
+	// getPreferredHibernateType
+	// ================================================================
+
+	@Test
+	public void testPreferredTypeForInteger() {
+		assertEquals("int", TypeHelper.getPreferredHibernateType(
+				Types.INTEGER, 0, 0, 0, false, false));
+		assertEquals(Integer.class.getName(), TypeHelper.getPreferredHibernateType(
+				Types.INTEGER, 0, 0, 0, true, false));
+	}
+
+	@Test
+	public void testPreferredTypeForBigint() {
+		assertEquals("long", TypeHelper.getPreferredHibernateType(
+				Types.BIGINT, 0, 0, 0, false, false));
+		assertEquals(Long.class.getName(), TypeHelper.getPreferredHibernateType(
+				Types.BIGINT, 0, 0, 0, true, false));
+	}
+
+	@Test
+	public void testPreferredTypeForSmallint() {
+		assertEquals("short", TypeHelper.getPreferredHibernateType(
+				Types.SMALLINT, 0, 0, 0, false, false));
+		assertEquals(Short.class.getName(), TypeHelper.getPreferredHibernateType(
+				Types.SMALLINT, 0, 0, 0, true, false));
+	}
+
+	@Test
+	public void testPreferredTypeForTinyint() {
+		assertEquals("byte", TypeHelper.getPreferredHibernateType(
+				Types.TINYINT, 0, 0, 0, false, false));
+		assertEquals(Byte.class.getName(), TypeHelper.getPreferredHibernateType(
+				Types.TINYINT, 0, 0, 0, true, false));
+	}
+
+	@Test
+	public void testPreferredTypeForReal() {
+		assertEquals("float", TypeHelper.getPreferredHibernateType(
+				Types.REAL, 0, 0, 0, false, false));
+		assertEquals(Float.class.getName(), TypeHelper.getPreferredHibernateType(
+				Types.REAL, 0, 0, 0, true, false));
+	}
+
+	@Test
+	public void testPreferredTypeForFloat() {
+		assertEquals("double", TypeHelper.getPreferredHibernateType(
+				Types.FLOAT, 0, 0, 0, false, false));
+		assertEquals(Double.class.getName(), TypeHelper.getPreferredHibernateType(
+				Types.FLOAT, 0, 0, 0, true, false));
+	}
+
+	@Test
+	public void testPreferredTypeForDouble() {
+		assertEquals("double", TypeHelper.getPreferredHibernateType(
+				Types.DOUBLE, 0, 0, 0, false, false));
+		assertEquals(Double.class.getName(), TypeHelper.getPreferredHibernateType(
+				Types.DOUBLE, 0, 0, 0, true, false));
+	}
+
+	@Test
+	public void testPreferredTypeForVarchar() {
+		assertEquals("string", TypeHelper.getPreferredHibernateType(
+				Types.VARCHAR, 0, 0, 0, false, false));
+		assertEquals("string", TypeHelper.getPreferredHibernateType(
+				Types.VARCHAR, 0, 0, 0, true, false));
+	}
+
+	@Test
+	public void testPreferredTypeForLongvarchar() {
+		assertEquals("string", TypeHelper.getPreferredHibernateType(
+				Types.LONGVARCHAR, 0, 0, 0, false, false));
+	}
+
+	@Test
+	public void testPreferredTypeForChar() {
+		assertEquals("char", TypeHelper.getPreferredHibernateType(
+				Types.CHAR, 1, 0, 0, false, false));
+		assertEquals(Character.class.getName(), TypeHelper.getPreferredHibernateType(
+				Types.CHAR, 1, 0, 0, true, false));
+	}
+
+	@Test
+	public void testPreferredTypeForCharWithSizeGreaterThanOne() {
+		assertEquals("string", TypeHelper.getPreferredHibernateType(
+				Types.CHAR, 10, 0, 0, false, false));
+		assertEquals("string", TypeHelper.getPreferredHibernateType(
+				Types.CHAR, 10, 0, 0, true, false));
+	}
+
+	@Test
+	public void testPreferredTypeForBit() {
+		assertEquals("boolean", TypeHelper.getPreferredHibernateType(
+				Types.BIT, 0, 0, 0, false, false));
+		assertEquals(Boolean.class.getName(), TypeHelper.getPreferredHibernateType(
+				Types.BIT, 0, 0, 0, true, false));
+	}
+
+	@Test
+	public void testPreferredTypeForBoolean() {
+		assertEquals("boolean", TypeHelper.getPreferredHibernateType(
+				Types.BOOLEAN, 0, 0, 0, false, false));
+	}
+
+	@Test
+	public void testPreferredTypeForDate() {
+		assertEquals("date", TypeHelper.getPreferredHibernateType(
+				Types.DATE, 0, 0, 0, false, false));
+	}
+
+	@Test
+	public void testPreferredTypeForTime() {
+		assertEquals("time", TypeHelper.getPreferredHibernateType(
+				Types.TIME, 0, 0, 0, false, false));
+	}
+
+	@Test
+	public void testPreferredTypeForTimestamp() {
+		assertEquals("timestamp", TypeHelper.getPreferredHibernateType(
+				Types.TIMESTAMP, 0, 0, 0, false, false));
+	}
+
+	@Test
+	public void testPreferredTypeForBlob() {
+		assertEquals("blob", TypeHelper.getPreferredHibernateType(
+				Types.BLOB, 0, 0, 0, false, false));
+	}
+
+	@Test
+	public void testPreferredTypeForClob() {
+		assertEquals("clob", TypeHelper.getPreferredHibernateType(
+				Types.CLOB, 0, 0, 0, false, false));
+	}
+
+	@Test
+	public void testPreferredTypeForBinary() {
+		assertEquals("binary", TypeHelper.getPreferredHibernateType(
+				Types.BINARY, 0, 0, 0, false, false));
+	}
+
+	@Test
+	public void testPreferredTypeForVarbinary() {
+		assertEquals("binary", TypeHelper.getPreferredHibernateType(
+				Types.VARBINARY, 0, 0, 0, false, false));
+	}
+
+	@Test
+	public void testPreferredTypeForLongvarbinary() {
+		assertEquals("binary", TypeHelper.getPreferredHibernateType(
+				Types.LONGVARBINARY, 0, 0, 0, false, false));
+	}
+
+	@Test
+	public void testPreferredTypeForDecimalNoScale() {
+		assertEquals("big_decimal", TypeHelper.getPreferredHibernateType(
+				Types.DECIMAL, 0, 0, 1, false, false));
+	}
+
+	@Test
+	public void testPreferredTypeForDecimalWithPrecision1() {
+		assertEquals("boolean", TypeHelper.getPreferredHibernateType(
+				Types.DECIMAL, 0, 1, 0, false, false));
+		assertEquals(Boolean.class.getName(), TypeHelper.getPreferredHibernateType(
+				Types.DECIMAL, 0, 1, 0, true, false));
+	}
+
+	@Test
+	public void testPreferredTypeForDecimalWithPrecision2() {
+		assertEquals("byte", TypeHelper.getPreferredHibernateType(
+				Types.DECIMAL, 0, 2, 0, false, false));
+		assertEquals(Byte.class.getName(), TypeHelper.getPreferredHibernateType(
+				Types.DECIMAL, 0, 2, 0, true, false));
+	}
+
+	@Test
+	public void testPreferredTypeForDecimalWithPrecision4() {
+		assertEquals("short", TypeHelper.getPreferredHibernateType(
+				Types.DECIMAL, 0, 4, 0, false, false));
+		assertEquals(Short.class.getName(), TypeHelper.getPreferredHibernateType(
+				Types.DECIMAL, 0, 4, 0, true, false));
+	}
+
+	@Test
+	public void testPreferredTypeForDecimalWithPrecision9() {
+		assertEquals("int", TypeHelper.getPreferredHibernateType(
+				Types.DECIMAL, 0, 9, 0, false, false));
+		assertEquals(Integer.class.getName(), TypeHelper.getPreferredHibernateType(
+				Types.DECIMAL, 0, 9, 0, true, false));
+	}
+
+	@Test
+	public void testPreferredTypeForDecimalWithPrecision18() {
+		assertEquals("long", TypeHelper.getPreferredHibernateType(
+				Types.DECIMAL, 0, 18, 0, false, false));
+		assertEquals(Long.class.getName(), TypeHelper.getPreferredHibernateType(
+				Types.DECIMAL, 0, 18, 0, true, false));
+	}
+
+	@Test
+	public void testPreferredTypeForDecimalWithPrecision19() {
+		assertEquals("big_integer", TypeHelper.getPreferredHibernateType(
+				Types.DECIMAL, 0, 19, 0, false, false));
+	}
+
+	@Test
+	public void testPreferredTypeForNumericNoScale() {
+		assertEquals("int", TypeHelper.getPreferredHibernateType(
+				Types.NUMERIC, 0, 5, 0, false, false));
+	}
+
+	@Test
+	public void testPreferredTypeForGeneratedIdentifier() {
+		assertEquals(Integer.class.getName(), TypeHelper.getPreferredHibernateType(
+				Types.INTEGER, 0, 0, 0, false, true));
+	}
+
+	@Test
+	public void testPreferredTypeForUnknownType() {
+		assertNull(TypeHelper.getPreferredHibernateType(
+				Types.OTHER, 0, 0, 0, false, false));
+	}
+
+	// ================================================================
+	// toJavaClass
+	// ================================================================
+
+	@Test
+	public void testToJavaClassNull() {
+		assertEquals(Object.class, TypeHelper.toJavaClass(null));
+	}
+
+	@Test
+	public void testToJavaClassPrimitives() {
+		assertEquals(int.class, TypeHelper.toJavaClass("int"));
+		assertEquals(long.class, TypeHelper.toJavaClass("long"));
+		assertEquals(short.class, TypeHelper.toJavaClass("short"));
+		assertEquals(byte.class, TypeHelper.toJavaClass("byte"));
+		assertEquals(float.class, TypeHelper.toJavaClass("float"));
+		assertEquals(double.class, TypeHelper.toJavaClass("double"));
+		assertEquals(boolean.class, TypeHelper.toJavaClass("boolean"));
+		assertEquals(char.class, TypeHelper.toJavaClass("char"));
+		assertEquals(char.class, TypeHelper.toJavaClass("character"));
+	}
+
+	@Test
+	public void testToJavaClassWrappers() {
+		assertEquals(Integer.class, TypeHelper.toJavaClass("java.lang.Integer"));
+		assertEquals(Long.class, TypeHelper.toJavaClass("java.lang.Long"));
+		assertEquals(Short.class, TypeHelper.toJavaClass("java.lang.Short"));
+		assertEquals(Byte.class, TypeHelper.toJavaClass("java.lang.Byte"));
+		assertEquals(Float.class, TypeHelper.toJavaClass("java.lang.Float"));
+		assertEquals(Double.class, TypeHelper.toJavaClass("java.lang.Double"));
+		assertEquals(Boolean.class, TypeHelper.toJavaClass("java.lang.Boolean"));
+		assertEquals(Character.class, TypeHelper.toJavaClass("java.lang.Character"));
+	}
+
+	@Test
+	public void testToJavaClassString() {
+		assertEquals(String.class, TypeHelper.toJavaClass("string"));
+		assertEquals(String.class, TypeHelper.toJavaClass("java.lang.String"));
+		assertEquals(String.class, TypeHelper.toJavaClass("clob"));
+	}
+
+	@Test
+	public void testToJavaClassNumeric() {
+		assertEquals(BigDecimal.class, TypeHelper.toJavaClass("big_decimal"));
+		assertEquals(BigDecimal.class, TypeHelper.toJavaClass("java.math.BigDecimal"));
+		assertEquals(BigInteger.class, TypeHelper.toJavaClass("big_integer"));
+		assertEquals(BigInteger.class, TypeHelper.toJavaClass("java.math.BigInteger"));
+	}
+
+	@Test
+	public void testToJavaClassDate() {
+		assertEquals(Date.class, TypeHelper.toJavaClass("date"));
+		assertEquals(Date.class, TypeHelper.toJavaClass("time"));
+		assertEquals(Date.class, TypeHelper.toJavaClass("timestamp"));
+		assertEquals(Date.class, TypeHelper.toJavaClass("java.util.Date"));
+	}
+
+	@Test
+	public void testToJavaClassBooleanShorthand() {
+		assertEquals(Boolean.class, TypeHelper.toJavaClass("yes_no"));
+		assertEquals(Boolean.class, TypeHelper.toJavaClass("true_false"));
+		assertEquals(Boolean.class, TypeHelper.toJavaClass("numeric_boolean"));
+	}
+
+	@Test
+	public void testToJavaClassBinary() {
+		assertEquals(byte[].class, TypeHelper.toJavaClass("binary"));
+		assertEquals(byte[].class, TypeHelper.toJavaClass("blob"));
+	}
+
+	@Test
+	public void testToJavaClassSerializable() {
+		assertEquals(java.io.Serializable.class, TypeHelper.toJavaClass("serializable"));
+	}
+
+	@Test
+	public void testToJavaClassFullyQualifiedKnown() {
+		assertEquals(String.class, TypeHelper.toJavaClass("java.lang.String"));
+	}
+
+	@Test
+	public void testToJavaClassFullyQualifiedUnknown() {
+		assertEquals(Object.class, TypeHelper.toJavaClass("com.example.NonExistent"));
+	}
+
+	@Test
+	public void testToJavaClassUnknownSimple() {
+		assertEquals(Object.class, TypeHelper.toJavaClass("unknown_type"));
+	}
+
+	// ================================================================
+	// toTemporalType
+	// ================================================================
+
+	@Test
+	public void testToTemporalTypeNull() {
+		assertNull(TypeHelper.toTemporalType(null));
+	}
+
+	@Test
+	public void testToTemporalTypeDate() {
+		assertEquals(TemporalType.DATE, TypeHelper.toTemporalType("date"));
+	}
+
+	@Test
+	public void testToTemporalTypeTime() {
+		assertEquals(TemporalType.TIME, TypeHelper.toTemporalType("time"));
+	}
+
+	@Test
+	public void testToTemporalTypeTimestamp() {
+		assertEquals(TemporalType.TIMESTAMP, TypeHelper.toTemporalType("timestamp"));
+	}
+
+	@Test
+	public void testToTemporalTypeNonTemporal() {
+		assertNull(TypeHelper.toTemporalType("string"));
+	}
+
+	// ================================================================
+	// isLob
+	// ================================================================
+
+	@Test
+	public void testIsLobNull() {
+		assertFalse(TypeHelper.isLob(null));
+	}
+
+	@Test
+	public void testIsLobBlob() {
+		assertTrue(TypeHelper.isLob("blob"));
+	}
+
+	@Test
+	public void testIsLobClob() {
+		assertTrue(TypeHelper.isLob("clob"));
+	}
+
+	@Test
+	public void testIsLobNonLob() {
+		assertFalse(TypeHelper.isLob("string"));
+	}
+
+	// ================================================================
+	// toHibernateType(Class<?>)
+	// ================================================================
+
+	@Test
+	public void testToHibernateTypeFromClassNull() {
+		assertEquals("serializable", TypeHelper.toHibernateType((Class<?>) null));
+	}
+
+	@Test
+	public void testToHibernateTypeFromClassPrimitives() {
+		assertEquals("int", TypeHelper.toHibernateType(int.class));
+		assertEquals("long", TypeHelper.toHibernateType(long.class));
+		assertEquals("short", TypeHelper.toHibernateType(short.class));
+		assertEquals("byte", TypeHelper.toHibernateType(byte.class));
+		assertEquals("float", TypeHelper.toHibernateType(float.class));
+		assertEquals("double", TypeHelper.toHibernateType(double.class));
+		assertEquals("boolean", TypeHelper.toHibernateType(boolean.class));
+		assertEquals("character", TypeHelper.toHibernateType(char.class));
+	}
+
+	@Test
+	public void testToHibernateTypeFromClassWrappers() {
+		assertEquals("java.lang.Integer", TypeHelper.toHibernateType(Integer.class));
+		assertEquals("java.lang.Long", TypeHelper.toHibernateType(Long.class));
+		assertEquals("java.lang.Short", TypeHelper.toHibernateType(Short.class));
+		assertEquals("java.lang.Byte", TypeHelper.toHibernateType(Byte.class));
+		assertEquals("java.lang.Float", TypeHelper.toHibernateType(Float.class));
+		assertEquals("java.lang.Double", TypeHelper.toHibernateType(Double.class));
+		assertEquals("java.lang.Boolean", TypeHelper.toHibernateType(Boolean.class));
+		assertEquals("java.lang.Character", TypeHelper.toHibernateType(Character.class));
+	}
+
+	@Test
+	public void testToHibernateTypeFromClassOther() {
+		assertEquals("string", TypeHelper.toHibernateType(String.class));
+		assertEquals("big_decimal", TypeHelper.toHibernateType(BigDecimal.class));
+		assertEquals("big_integer", TypeHelper.toHibernateType(BigInteger.class));
+		assertEquals("timestamp", TypeHelper.toHibernateType(Date.class));
+		assertEquals("binary", TypeHelper.toHibernateType(byte[].class));
+	}
+
+	@Test
+	public void testToHibernateTypeFromClassUnknown() {
+		assertEquals(TypeHelperTest.class.getName(), TypeHelper.toHibernateType(TypeHelperTest.class));
+	}
+
+	// ================================================================
+	// toHibernateType(String)
+	// ================================================================
+
+	@Test
+	public void testToHibernateTypeFromStringNull() {
+		assertEquals("serializable", TypeHelper.toHibernateType((String) null));
+	}
+
+	@Test
+	public void testToHibernateTypeFromStringKnownClass() {
+		assertEquals("string", TypeHelper.toHibernateType("java.lang.String"));
+		assertEquals("int", TypeHelper.toHibernateType("int"));
+	}
+
+	@Test
+	public void testToHibernateTypeFromStringUnknownClass() {
+		assertEquals("com.example.Unknown", TypeHelper.toHibernateType("com.example.Unknown"));
+	}
+
+	// ================================================================
+	// getJdbcTypeCode
+	// ================================================================
+
+	@Test
+	public void testGetJdbcTypeCodeNull() {
+		assertEquals(Integer.MIN_VALUE, TypeHelper.getJdbcTypeCode(null));
+	}
+
+	@Test
+	public void testGetJdbcTypeCodeString() {
+		assertEquals(Types.VARCHAR, TypeHelper.getJdbcTypeCode(String.class.getName()));
+	}
+
+	@Test
+	public void testGetJdbcTypeCodeLong() {
+		assertEquals(Types.BIGINT, TypeHelper.getJdbcTypeCode(Long.class.getName()));
+		assertEquals(Types.BIGINT, TypeHelper.getJdbcTypeCode(long.class.getName()));
+	}
+
+	@Test
+	public void testGetJdbcTypeCodeInteger() {
+		assertEquals(Types.INTEGER, TypeHelper.getJdbcTypeCode(Integer.class.getName()));
+		assertEquals(Types.INTEGER, TypeHelper.getJdbcTypeCode(int.class.getName()));
+	}
+
+	@Test
+	public void testGetJdbcTypeCodeShort() {
+		assertEquals(Types.SMALLINT, TypeHelper.getJdbcTypeCode(Short.class.getName()));
+	}
+
+	@Test
+	public void testGetJdbcTypeCodeByte() {
+		assertEquals(Types.TINYINT, TypeHelper.getJdbcTypeCode(Byte.class.getName()));
+	}
+
+	@Test
+	public void testGetJdbcTypeCodeFloat() {
+		assertEquals(Types.FLOAT, TypeHelper.getJdbcTypeCode(Float.class.getName()));
+	}
+
+	@Test
+	public void testGetJdbcTypeCodeDouble() {
+		assertEquals(Types.DOUBLE, TypeHelper.getJdbcTypeCode(Double.class.getName()));
+	}
+
+	@Test
+	public void testGetJdbcTypeCodeBoolean() {
+		assertEquals(Types.BOOLEAN, TypeHelper.getJdbcTypeCode(Boolean.class.getName()));
+	}
+
+	@Test
+	public void testGetJdbcTypeCodeBigDecimal() {
+		assertEquals(Types.NUMERIC, TypeHelper.getJdbcTypeCode(BigDecimal.class.getName()));
+	}
+
+	@Test
+	public void testGetJdbcTypeCodeDate() {
+		assertEquals(Types.DATE, TypeHelper.getJdbcTypeCode(java.sql.Date.class.getName()));
+		assertEquals(Types.TIME, TypeHelper.getJdbcTypeCode(java.sql.Time.class.getName()));
+		assertEquals(Types.TIMESTAMP, TypeHelper.getJdbcTypeCode(java.sql.Timestamp.class.getName()));
+		assertEquals(Types.TIMESTAMP, TypeHelper.getJdbcTypeCode(Date.class.getName()));
+	}
+
+	@Test
+	public void testGetJdbcTypeCodeBinary() {
+		assertEquals(Types.VARBINARY, TypeHelper.getJdbcTypeCode(byte[].class.getName()));
+	}
+
+	@Test
+	public void testGetJdbcTypeCodeCharacter() {
+		assertEquals(Types.CHAR, TypeHelper.getJdbcTypeCode(Character.class.getName()));
+		assertEquals(Types.CHAR, TypeHelper.getJdbcTypeCode(char.class.getName()));
+	}
+
+	@Test
+	public void testGetJdbcTypeCodeUnknown() {
+		assertEquals(Integer.MIN_VALUE, TypeHelper.getJdbcTypeCode("com.example.Unknown"));
+	}
+
+	// ================================================================
+	// JDBC type name <-> integer constant
+	// ================================================================
+
+	@Test
+	public void testGetJDBCTypes() {
+		String[] types = TypeHelper.getJDBCTypes();
+		assertNotNull(types);
+		assertTrue(types.length > 0);
+	}
+
+	@Test
+	public void testGetJDBCTypeByName() {
+		assertEquals(Types.VARCHAR, TypeHelper.getJDBCType("VARCHAR"));
+		assertEquals(Types.INTEGER, TypeHelper.getJDBCType("INTEGER"));
+		assertEquals(Types.TIMESTAMP, TypeHelper.getJDBCType("TIMESTAMP"));
+	}
+
+	@Test
+	public void testGetJDBCTypeByNumericString() {
+		assertEquals(Types.VARCHAR, TypeHelper.getJDBCType(String.valueOf(Types.VARCHAR)));
+	}
+
+	@Test
+	public void testGetJDBCTypeByInvalidString() {
+		assertThrows(org.hibernate.MappingException.class,
+				() -> TypeHelper.getJDBCType("NOT_A_TYPE"));
+	}
+
+	@Test
+	public void testGetJDBCTypeName() {
+		assertEquals("VARCHAR", TypeHelper.getJDBCTypeName(Types.VARCHAR));
+		assertEquals("INTEGER", TypeHelper.getJDBCTypeName(Types.INTEGER));
+		assertEquals("TIMESTAMP", TypeHelper.getJDBCTypeName(Types.TIMESTAMP));
+	}
+
+	@Test
+	public void testGetJDBCTypeNameUnknown() {
+		String name = TypeHelper.getJDBCTypeName(99999);
+		assertEquals("99999", name);
+	}
+
+	// ================================================================
+	// SQL type metadata
+	// ================================================================
+
+	@Test
+	public void testTypeHasScale() {
+		assertTrue(TypeHelper.typeHasScale(Types.DECIMAL));
+		assertTrue(TypeHelper.typeHasScale(Types.NUMERIC));
+		assertFalse(TypeHelper.typeHasScale(Types.VARCHAR));
+		assertFalse(TypeHelper.typeHasScale(Types.INTEGER));
+	}
+
+	@Test
+	public void testTypeHasPrecision() {
+		assertTrue(TypeHelper.typeHasPrecision(Types.DECIMAL));
+		assertTrue(TypeHelper.typeHasPrecision(Types.NUMERIC));
+		assertTrue(TypeHelper.typeHasPrecision(Types.REAL));
+		assertTrue(TypeHelper.typeHasPrecision(Types.FLOAT));
+		assertTrue(TypeHelper.typeHasPrecision(Types.DOUBLE));
+		assertFalse(TypeHelper.typeHasPrecision(Types.VARCHAR));
+	}
+
+	@Test
+	public void testTypeHasScaleAndPrecision() {
+		assertTrue(TypeHelper.typeHasScaleAndPrecision(Types.DECIMAL));
+		assertTrue(TypeHelper.typeHasScaleAndPrecision(Types.NUMERIC));
+		assertFalse(TypeHelper.typeHasScaleAndPrecision(Types.REAL));
+		assertFalse(TypeHelper.typeHasScaleAndPrecision(Types.VARCHAR));
+	}
+
+	@Test
+	public void testTypeHasLength() {
+		assertTrue(TypeHelper.typeHasLength(Types.CHAR));
+		assertTrue(TypeHelper.typeHasLength(Types.VARCHAR));
+		assertTrue(TypeHelper.typeHasLength(Types.LONGVARCHAR));
+		assertTrue(TypeHelper.typeHasLength(Types.DATE));
+		assertTrue(TypeHelper.typeHasLength(Types.TIME));
+		assertTrue(TypeHelper.typeHasLength(Types.TIMESTAMP));
+		assertFalse(TypeHelper.typeHasLength(Types.INTEGER));
+		assertFalse(TypeHelper.typeHasLength(Types.BLOB));
+	}
+
+	// ================================================================
+	// isPrimitiveType
+	// ================================================================
+
+	@Test
+	public void testIsPrimitiveTypeNull() {
+		assertFalse(TypeHelper.isPrimitiveType(null));
+	}
+
+	@Test
+	public void testIsPrimitiveTypePrimitives() {
+		assertTrue(TypeHelper.isPrimitiveType("boolean"));
+		assertTrue(TypeHelper.isPrimitiveType("byte"));
+		assertTrue(TypeHelper.isPrimitiveType("char"));
+		assertTrue(TypeHelper.isPrimitiveType("short"));
+		assertTrue(TypeHelper.isPrimitiveType("int"));
+		assertTrue(TypeHelper.isPrimitiveType("long"));
+		assertTrue(TypeHelper.isPrimitiveType("float"));
+		assertTrue(TypeHelper.isPrimitiveType("double"));
+	}
+
+	@Test
+	public void testIsPrimitiveTypeNonPrimitive() {
+		assertFalse(TypeHelper.isPrimitiveType("string"));
+		assertFalse(TypeHelper.isPrimitiveType("java.lang.Integer"));
+		assertFalse(TypeHelper.isPrimitiveType("big_decimal"));
+	}
+}


### PR DESCRIPTION
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------


---
<!-- Hibernate GitHub Bot task list start -->
Please make sure that the following tasks are completed:
Tasks specific to HHH-20376 (Task):
- [ ] Add test **OR** check there is no need for a test
- [ ] Update documentation as relevant: javadoc for changed API, `documentation/src/main/asciidoc/userguide` for all features, `documentation/src/main/asciidoc/introduction` for main features, links from existing documentation
- [ ] Add entries as relevant to `migration-guide.adoc` (breaking changes) and `whats-new.adoc` (new features/improvements)


<!-- Hibernate GitHub Bot task list end -->

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-20376
<!-- Hibernate GitHub Bot issue links end -->