### PR TITLE
HHH-20341: Use HTTP as default protocol for Maven mirror URL

### DIFF
--- a/tooling/hibernate-maven-plugin/src/intTest/java/org/hibernate/orm/tooling/maven/AbstractMavenTestIT.java
+++ b/tooling/hibernate-maven-plugin/src/intTest/java/org/hibernate/orm/tooling/maven/AbstractMavenTestIT.java
@@ -33,7 +33,7 @@ public abstract class AbstractMavenTestIT {
 		if ( mavenMirror != null && !mavenMirror.isEmpty() ) {
 			String url = mavenMirror;
 			if ( !url.startsWith( "http://" ) && !url.startsWith( "https://" ) ) {
-				url = "https://" + url;
+				url = "http://" + url;
 			}
 			mavenSettingsFile = Files.createTempFile( "maven-settings", ".xml" );
 			Files.writeString( mavenSettingsFile,


### PR DESCRIPTION
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------


---
<!-- Hibernate GitHub Bot task list start -->
Please make sure that the following tasks are completed:
Tasks specific to HHH-20341 (Task):
- [ ] Add test **OR** check there is no need for a test
- [ ] Update documentation as relevant: javadoc for changed API, `documentation/src/main/asciidoc/userguide` for all features, `documentation/src/main/asciidoc/introduction` for main features, links from existing documentation
- [ ] Add entries as relevant to `migration-guide.adoc` (breaking changes) and `whats-new.adoc` (new features/improvements)


<!-- Hibernate GitHub Bot task list end -->

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-20341
<!-- Hibernate GitHub Bot issue links end -->