### PR TITLE
HHH-20341 Fix mirror integration on Jenkins CI

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -128,7 +128,7 @@ stage('Build') {
 				// Use withEnv instead of setting env directly, as that is global!
 				// See https://github.com/jenkinsci/pipeline-plugin/blob/master/TUTORIAL.md
 				withEnv(["JAVA_HOME=${javaHome}", "PATH+JAVA=${javaHome}/bin"]) {
-					state[buildEnv.tag]['additionalOptions'] = '-PmavenMirror=nexus-load-balancer-c4cf05fd92f43ef8.elb.us-east-1.amazonaws.com'
+				    state[buildEnv.tag]['additionalOptions'] = ''
 					if ( buildEnv.mainJdkVersion ) {
 						state[buildEnv.tag]['additionalOptions'] = state[buildEnv.tag]['additionalOptions'] +
 								" -Pmain.jdk.version=${buildEnv.mainJdkVersion}"

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -15,6 +15,12 @@ Continuous integration is split across two platforms:
 * GitHub Actions at https://github.com/hibernate/hibernate-orm/actions
 * a self-hosted Jenkins instance at https://ci.hibernate.org.
 
+### Tips
+
+The Hibernate ORM build can use a mirror instead of Maven central.
+To do so, set the `MAVEN_MIRROR` environment variable to the URL of your mirror,
+e.g. `http://something-on-aws.com/path/to/repo`.
+
 ### GitHub Actions workflows
 
 TODO: describe the workflows available.
@@ -32,7 +38,7 @@ It is generally triggered on push,
 but can also be triggered manually,
 which is particularly useful to test more environments on a pull request.
 
-See [Jenkinsfile](Jenkinsfile) for the job definition.
+See [Jenkinsfile](Jenkinsfile) for the job definition. 
 
 ### Release pipeline
 

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -20,6 +20,7 @@ Continuous integration is split across two platforms:
 The Hibernate ORM build can use a mirror instead of Maven central.
 To do so, set the `MAVEN_MIRROR` environment variable to the URL of your mirror,
 e.g. `http://something-on-aws.com/path/to/repo`.
+The mirror can use unsecure HTTP, but obviously that exposes you to MITM attacks unless the build runs in a completely isolated network.
 
 ### GitHub Actions workflows
 

--- a/ci/jpa-3.2-tck.Jenkinsfile
+++ b/ci/jpa-3.2-tck.Jenkinsfile
@@ -54,11 +54,11 @@ pipeline {
                             withEnv([
                                     "DISABLE_REMOTE_GRADLE_CACHE=true"
                             ]) {
-                                sh './gradlew clean publishToMavenLocal -x test --no-scan --no-daemon --no-build-cache --stacktrace -PmavenMirror=nexus-load-balancer-c4cf05fd92f43ef8.elb.us-east-1.amazonaws.com'
+                                sh './gradlew clean publishToMavenLocal -x test --no-scan --no-daemon --no-build-cache --stacktrace'
                                 // For some reason, Gradle does not publish hibernate-platform and hibernate-testing
                                 // to the local maven repository with the previous command,
                                 // but requires an extra run instead
-                                sh './gradlew :hibernate-testing:publishToMavenLocal :hibernate-platform:publishToMavenLocal -x test --no-scan --no-daemon --no-build-cache --stacktrace -PmavenMirror=nexus-load-balancer-c4cf05fd92f43ef8.elb.us-east-1.amazonaws.com'
+                                sh './gradlew :hibernate-testing:publishToMavenLocal :hibernate-platform:publishToMavenLocal -x test --no-scan --no-daemon --no-build-cache --stacktrace'
                             }
                             script {
                                 env.HIBERNATE_VERSION = sh (

--- a/ci/quarkus.Jenkinsfile
+++ b/ci/quarkus.Jenkinsfile
@@ -117,7 +117,7 @@ pipeline {
                 script {
                     dir('hibernate') {
                         checkout scm
-                        sh "./gradlew clean publishToMavenLocal -x test --no-scan --no-daemon --no-build-cache --stacktrace -PmavenMirror=nexus-load-balancer-c4cf05fd92f43ef8.elb.us-east-1.amazonaws.com -Dmaven.repo.local=${env.WORKSPACE_TMP}/.m2repository"
+                        sh "./gradlew clean publishToMavenLocal -x test --no-scan --no-daemon --no-build-cache --stacktrace -Dmaven.repo.local=${env.WORKSPACE_TMP}/.m2repository"
                         script {
                             env.HIBERNATE_VERSION = sh (
                                     script: "grep hibernateVersion gradle/version.properties|cut -d'=' -f2",

--- a/settings.gradle
+++ b/settings.gradle
@@ -33,8 +33,9 @@ dependencyResolutionManagement {
                 allowInsecureProtocol = true
             }
         }
-
-        mavenCentral()
+        else {
+            mavenCentral()
+        }
 
         if (System.getProperty('JPA_PREVIEW') != null) {
 			maven {

--- a/settings.gradle
+++ b/settings.gradle
@@ -28,7 +28,10 @@ dependencyResolutionManagement {
         // TODO Move to infra overrides instead;
         //  see https://blog.gradle.org/maven-central-mirror#overriding-the-urls-for-maven-central-and-the-plugin-portal-repositories
         if ( System.env['MAVEN_MIRROR'] ) {
-            url( System.env['MAVEN_MIRROR'] )
+            maven {
+                url System.env['MAVEN_MIRROR']
+                allowInsecureProtocol = true
+            }
         }
 
         mavenCentral()

--- a/settings.gradle
+++ b/settings.gradle
@@ -24,8 +24,11 @@ plugins {
 
 dependencyResolutionManagement {
     repositories {
-        if ( rootProject.hasProperty( "mavenMirror" ) ) {
-            url( rootProject.property( "mavenMirror" ) )
+        // See MAINTAINERS.md for documentation.
+        // TODO Move to infra overrides instead;
+        //  see https://blog.gradle.org/maven-central-mirror#overriding-the-urls-for-maven-central-and-the-plugin-portal-repositories
+        if ( System.env['MAVEN_MIRROR'] ) {
+            url( System.env['MAVEN_MIRROR'] )
         }
 
         mavenCentral()

--- a/tooling/hibernate-maven-plugin/hibernate-maven-plugin.gradle
+++ b/tooling/hibernate-maven-plugin/hibernate-maven-plugin.gradle
@@ -93,9 +93,6 @@ publishingExtension.publications.named("publishedArtifacts") {
 integrationTest {
     environment "hibernateVersion", project.version
     environment "h2Version", jdbcLibs.versions.h2.get()
-    if (project.hasProperty("mavenMirror")) {
-        environment "mavenMirror", project.property("mavenMirror")
-    }
     testLogging {
         exceptionFormat = 'full'
     }

--- a/tooling/hibernate-maven-plugin/src/intTest/java/org/hibernate/orm/tooling/maven/AbstractMavenTestIT.java
+++ b/tooling/hibernate-maven-plugin/src/intTest/java/org/hibernate/orm/tooling/maven/AbstractMavenTestIT.java
@@ -29,12 +29,8 @@ public abstract class AbstractMavenTestIT {
 	public static void initMavenCli() throws Exception {
 		classWorld = new ClassWorld( "plexus.core", Thread.currentThread().getContextClassLoader() );
 		mavenCli = new MavenCli( classWorld );
-		String mavenMirror = System.getenv( "mavenMirror" );
+		String mavenMirror = System.getenv( "MAVEN_MIRROR" );
 		if ( mavenMirror != null && !mavenMirror.isEmpty() ) {
-			String url = mavenMirror;
-			if ( !url.startsWith( "http://" ) && !url.startsWith( "https://" ) ) {
-				url = "https://" + url;
-			}
 			mavenSettingsFile = Files.createTempFile( "maven-settings", ".xml" );
 			Files.writeString( mavenSettingsFile,
 					"<settings>\n" +
@@ -42,7 +38,7 @@ public abstract class AbstractMavenTestIT {
 					"    <mirror>\n" +
 					"      <id>ci-mirror</id>\n" +
 					"      <mirrorOf>central</mirrorOf>\n" +
-					"      <url>" + url + "</url>\n" +
+					"      <url>${env.MAVEN_MIRROR}</url>\n" +
 					"    </mirror>\n" +
 					"  </mirrors>\n" +
 					"</settings>\n" );


### PR DESCRIPTION
Follows up on #12177 .
Supersedes #12270.

There were multiple problems:

1. We were passing the wrong URL (missing path) to Gradle. I fixed that by relying on an env variable defined in a central place (CI config) instead.
2. The syntax to define the mirror as a repository was straight out wrong.
3. We had a fall back to Maven Central, so even if the mirror was not being used, we would never have noticed.

---
<!-- Hibernate GitHub Bot task list start -->
Please make sure that the following tasks are completed:
Tasks specific to HHH-20341 (Task):
- [x] Add test **OR** check there is no need for a test
- [x] Update documentation as relevant: javadoc for changed API, `documentation/src/main/asciidoc/userguide` for all features, `documentation/src/main/asciidoc/introduction` for main features, links from existing documentation
- [x] Add entries as relevant to `migration-guide.adoc` (breaking changes) and `whats-new.adoc` (new features/improvements)


<!-- Hibernate GitHub Bot task list end -->

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-20341
<!-- Hibernate GitHub Bot issue links end -->