### PR TITLE
HHH-16442, HHH-19355 fix bugs in HQL trunc() on Oracle

### DIFF
--- a/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/AltibaseDialect.java
+++ b/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/AltibaseDialect.java
@@ -212,10 +212,7 @@ public class AltibaseDialect extends Dialect {
 		functionFactory.hypotheticalOrderedSetAggregates();
 		functionFactory.bitLength_pattern( "bit_length(?1)", "lengthb(?1)*8" );
 		functionFactory.octetLength_pattern( "octet_length(?1)", "lengthb(?1)" );
-		functionContributions.getFunctionRegistry().register(
-				"trunc",
-				new OracleTruncFunction( functionContributions.getTypeConfiguration() )
-		);
+		functionContributions.getFunctionRegistry().register( "trunc", new OracleTruncFunction() );
 		functionContributions.getFunctionRegistry().registerAlternateKey( "truncate", "trunc" );
 
 		// Use `numor`, `numand`, and `numxor` because bitwise operators work only in binary columns in Altibase.

--- a/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/OracleLegacyDialect.java
+++ b/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/OracleLegacyDialect.java
@@ -362,10 +362,7 @@ public class OracleLegacyDialect extends Dialect {
 				"mode",
 				new ModeStatsModeEmulation( typeConfiguration )
 		);
-		functionContributions.getFunctionRegistry().register(
-				"trunc",
-				new OracleTruncFunction( functionContributions.getTypeConfiguration() )
-		);
+		functionContributions.getFunctionRegistry().register( "trunc", new OracleTruncFunction() );
 		functionContributions.getFunctionRegistry().registerAlternateKey( "truncate", "trunc" );
 
 		functionFactory.array_oracle();

--- a/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/TimesTenDialect.java
+++ b/hibernate-community-dialects/src/main/java/org/hibernate/community/dialect/TimesTenDialect.java
@@ -196,10 +196,7 @@ public class TimesTenDialect extends Dialect {
 		functionFactory.degrees_acos();
 		functionFactory.sinh();
 		functionFactory.tanh();
-		functionContributions.getFunctionRegistry().register(
-				"trunc",
-				new OracleTruncFunction( functionContributions.getTypeConfiguration() )
-		);
+		functionContributions.getFunctionRegistry().register( "trunc", new OracleTruncFunction() );
 		functionContributions.getFunctionRegistry().registerAlternateKey( "truncate", "trunc" );
 		functionFactory.round();
 

--- a/hibernate-core/src/main/java/org/hibernate/dialect/OracleDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/OracleDialect.java
@@ -488,7 +488,7 @@ public class OracleDialect extends Dialect {
 
 	@Override
 	public String currentDate() {
-		return "current_date";
+		return "trunc(current_date)";
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/dialect/OracleDialect.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/OracleDialect.java
@@ -376,10 +376,7 @@ public class OracleDialect extends Dialect {
 				"mode",
 				new ModeStatsModeEmulation( typeConfiguration )
 		);
-		functionRegistry.register(
-				"trunc",
-				new OracleTruncFunction( functionContributions.getTypeConfiguration() )
-		);
+		functionRegistry.register( "trunc", new OracleTruncFunction() );
 		functionRegistry.registerAlternateKey( "truncate", "trunc" );
 
 		registerArrayFunctions( functionFactory );

--- a/hibernate-core/src/main/java/org/hibernate/dialect/function/OracleTruncFunction.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/function/OracleTruncFunction.java
@@ -7,24 +7,30 @@ package org.hibernate.dialect.function;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.hibernate.metamodel.mapping.JdbcMappingContainer;
 import org.hibernate.metamodel.model.domain.ReturnableType;
-import org.hibernate.query.spi.QueryEngine;
 import org.hibernate.query.common.TemporalUnit;
+import org.hibernate.query.spi.QueryEngine;
+import org.hibernate.query.sqm.CastType;
 import org.hibernate.query.sqm.function.FunctionRenderer;
 import org.hibernate.query.sqm.function.SelfRenderingSqmFunction;
 import org.hibernate.query.sqm.produce.function.ArgumentsValidator;
 import org.hibernate.query.sqm.tree.SqmTypedNode;
 import org.hibernate.query.sqm.tree.expression.SqmExtractUnit;
 import org.hibernate.query.sqm.tree.expression.SqmLiteral;
+import org.hibernate.sql.ast.SqlAstTranslator;
+import org.hibernate.sql.ast.spi.SqlAppender;
+import org.hibernate.sql.ast.tree.SqlAstNode;
+import org.hibernate.sql.ast.tree.expression.Expression;
 import org.hibernate.type.spi.TypeConfiguration;
 
 /**
  * Custom {@link TruncFunction} for Oracle which uses emulation when truncating datetimes to seconds
+ * or when truncating offset-aware datetimes.
  *
  * @author Marco Belladelli
  */
 public class OracleTruncFunction extends TruncFunction {
-	private final DateTruncEmulation dateTruncEmulation;
 
 	public OracleTruncFunction(TypeConfiguration typeConfiguration) {
 		super(
@@ -34,7 +40,6 @@ public class OracleTruncFunction extends TruncFunction {
 				null,
 				typeConfiguration
 		);
-		this.dateTruncEmulation = new DateTruncEmulation( "to_date", typeConfiguration );
 	}
 
 	@Override
@@ -47,10 +52,10 @@ public class OracleTruncFunction extends TruncFunction {
 		final ArgumentsValidator argumentsValidator;
 		if ( arguments.size() == 2 && arguments.get( 1 ) instanceof SqmExtractUnit ) {
 			// datetime truncation
-			renderer = datetimeRenderingSupport;
 			argumentsValidator = TruncArgumentsValidator.DATETIME_VALIDATOR;
 			// the trunc() function requires translating the temporal_unit to a format string
 			final TemporalUnit temporalUnit = ( (SqmExtractUnit<?>) arguments.get( 1 ) ).getUnit();
+			renderer = new OracleTruncRenderingSupport( temporalUnit );
 			final String pattern;
 			switch ( temporalUnit ) {
 				case YEAR:
@@ -72,21 +77,19 @@ public class OracleTruncFunction extends TruncFunction {
 					pattern = "MI";
 					break;
 				case SECOND:
-					// Oracle does not support truncating to seconds with the native function, use emulation
-					return dateTruncEmulation.generateSqmFunctionExpression(
-							arguments,
-							impliedResultType,
-							queryEngine
-					);
+					pattern = null;
+					break;
 				default:
 					throw new UnsupportedOperationException( "Temporal unit not supported [" + temporalUnit + "]" );
 			}
 			// replace temporal_unit parameter with translated string format literal
-			args.set( 1, new SqmLiteral<>(
-					pattern,
-					queryEngine.getTypeConfiguration().getBasicTypeForJavaType( String.class ),
-					queryEngine.getCriteriaBuilder()
-			) );
+			if ( pattern != null ) {
+				args.set( 1, new SqmLiteral<>(
+						pattern,
+						queryEngine.getTypeConfiguration().getBasicTypeForJavaType( String.class ),
+						queryEngine.getCriteriaBuilder()
+				) );
+			}
 		}
 		else {
 			// numeric truncation
@@ -104,5 +107,86 @@ public class OracleTruncFunction extends TruncFunction {
 				queryEngine.getCriteriaBuilder(),
 				getName()
 		);
+	}
+
+	private static class OracleTruncRenderingSupport implements FunctionRenderer {
+		private final TemporalUnit temporalUnit;
+
+		private OracleTruncRenderingSupport(TemporalUnit temporalUnit) {
+			this.temporalUnit = temporalUnit;
+		}
+
+		@Override
+		public void render(
+				SqlAppender sqlAppender,
+				List<? extends SqlAstNode> sqlAstArguments,
+				ReturnableType<?> returnType,
+				SqlAstTranslator<?> walker) {
+			if ( isOffsetOrZonedTimestamp( sqlAstArguments.get( 0 ) ) ) {
+				renderOffsetTimestampTrunc( sqlAppender, sqlAstArguments, walker );
+			}
+			else if ( temporalUnit == TemporalUnit.SECOND ) {
+				renderTimestampTruncToSecond( sqlAppender, sqlAstArguments.get( 0 ), walker );
+			}
+			else {
+				sqlAppender.appendSql( "trunc(" );
+				sqlAstArguments.get( 0 ).accept( walker );
+				sqlAppender.appendSql( ',' );
+				sqlAstArguments.get( 1 ).accept( walker );
+				sqlAppender.appendSql( ')' );
+			}
+		}
+
+		private void renderOffsetTimestampTrunc(
+				SqlAppender sqlAppender,
+				List<? extends SqlAstNode> sqlAstArguments,
+				SqlAstTranslator<?> walker) {
+			sqlAppender.appendSql( "from_tz(" );
+			if ( temporalUnit == TemporalUnit.SECOND ) {
+				sqlAppender.appendSql( "cast(" );
+				renderTimestampTruncToSecond( sqlAppender, sqlAstArguments.get( 0 ), walker );
+				sqlAppender.appendSql( " as timestamp)" );
+			}
+			else {
+				sqlAppender.appendSql( "cast(trunc(to_timestamp(to_char(" );
+				sqlAstArguments.get( 0 ).accept( walker );
+				sqlAppender.appendSql( ",'YYYY-MM-DD HH24:MI:SS.FF9'),'YYYY-MM-DD HH24:MI:SS.FF9')," );
+				sqlAstArguments.get( 1 ).accept( walker );
+				sqlAppender.appendSql( ") as timestamp)" );
+			}
+			sqlAppender.appendSql( ",to_char(" );
+			sqlAstArguments.get( 0 ).accept( walker );
+			sqlAppender.appendSql( ",'" );
+			sqlAppender.appendSql( getTimezoneFormat( sqlAstArguments.get( 0 ) ) );
+			sqlAppender.appendSql( "'))" );
+		}
+
+		private static void renderTimestampTruncToSecond(
+				SqlAppender sqlAppender,
+				SqlAstNode datetime,
+				SqlAstTranslator<?> walker) {
+			sqlAppender.appendSql( "to_date(to_char(" );
+			datetime.accept( walker );
+			sqlAppender.appendSql( ",'YYYY-MM-DD HH24:MI:SS'),'YYYY-MM-DD HH24:MI:SS')" );
+		}
+
+		private static boolean isOffsetOrZonedTimestamp(SqlAstNode datetime) {
+			final CastType castType = getCastType( datetime );
+			return castType == CastType.OFFSET_TIMESTAMP || castType == CastType.ZONE_TIMESTAMP;
+		}
+
+		private static String getTimezoneFormat(SqlAstNode datetime) {
+			return getCastType( datetime ) == CastType.ZONE_TIMESTAMP ? "TZR" : "TZH:TZM";
+		}
+
+		private static CastType getCastType(SqlAstNode datetime) {
+			if ( datetime instanceof Expression expression ) {
+				final JdbcMappingContainer expressionType = expression.getExpressionType();
+				if ( expressionType != null && expressionType.getJdbcTypeCount() == 1 ) {
+					return expressionType.getSingleJdbcMapping().getCastType();
+				}
+			}
+			return null;
+		}
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/dialect/function/OracleTruncFunction.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/function/OracleTruncFunction.java
@@ -4,41 +4,45 @@
  */
 package org.hibernate.dialect.function;
 
-import java.util.ArrayList;
 import java.util.List;
 
-import org.hibernate.metamodel.mapping.JdbcMappingContainer;
 import org.hibernate.metamodel.model.domain.ReturnableType;
 import org.hibernate.query.common.TemporalUnit;
 import org.hibernate.query.spi.QueryEngine;
 import org.hibernate.query.sqm.CastType;
-import org.hibernate.query.sqm.function.FunctionRenderer;
+import org.hibernate.query.sqm.function.AbstractSqmSelfRenderingFunctionDescriptor;
 import org.hibernate.query.sqm.function.SelfRenderingSqmFunction;
 import org.hibernate.query.sqm.produce.function.ArgumentsValidator;
+import org.hibernate.query.sqm.produce.function.StandardFunctionArgumentTypeResolvers;
+import org.hibernate.query.sqm.produce.function.StandardFunctionReturnTypeResolvers;
 import org.hibernate.query.sqm.tree.SqmTypedNode;
 import org.hibernate.query.sqm.tree.expression.SqmExtractUnit;
-import org.hibernate.query.sqm.tree.expression.SqmLiteral;
 import org.hibernate.sql.ast.SqlAstTranslator;
 import org.hibernate.sql.ast.spi.SqlAppender;
 import org.hibernate.sql.ast.tree.SqlAstNode;
+import org.hibernate.sql.ast.tree.expression.ExtractUnit;
 import org.hibernate.sql.ast.tree.expression.Expression;
-import org.hibernate.type.spi.TypeConfiguration;
+
+import static org.hibernate.dialect.function.TruncFunction.TruncArgumentsValidator.DATETIME_VALIDATOR;
+import static org.hibernate.dialect.function.TruncFunction.TruncArgumentsValidator.NUMERIC_VALIDATOR;
 
 /**
- * Custom {@link TruncFunction} for Oracle which uses emulation when truncating datetimes to seconds
+ * Oracle trunc function which uses emulation when truncating datetimes to seconds
  * or when truncating offset-aware datetimes.
  *
  * @author Marco Belladelli
  */
-public class OracleTruncFunction extends TruncFunction {
+public class OracleTruncFunction extends AbstractSqmSelfRenderingFunctionDescriptor {
 
-	public OracleTruncFunction(TypeConfiguration typeConfiguration) {
+	public OracleTruncFunction() {
 		super(
-				"trunc(?1)",
-				"trunc(?1,?2)",
-				DatetimeTrunc.TRUNC,
-				null,
-				typeConfiguration
+				"trunc",
+				new TruncFunction.TruncArgumentsValidator(),
+				StandardFunctionReturnTypeResolvers.useArgType( 1 ),
+				StandardFunctionArgumentTypeResolvers.byArgument(
+						StandardFunctionArgumentTypeResolvers.IMPLIED_RESULT_TYPE,
+						StandardFunctionArgumentTypeResolvers.NULL
+				)
 		);
 	}
 
@@ -47,60 +51,21 @@ public class OracleTruncFunction extends TruncFunction {
 			List<? extends SqmTypedNode<?>> arguments,
 			ReturnableType<T> impliedResultType,
 			QueryEngine queryEngine) {
-		final List<SqmTypedNode<?>> args = new ArrayList<>( arguments );
-		final FunctionRenderer renderer;
 		final ArgumentsValidator argumentsValidator;
 		if ( arguments.size() == 2 && arguments.get( 1 ) instanceof SqmExtractUnit ) {
 			// datetime truncation
-			argumentsValidator = TruncArgumentsValidator.DATETIME_VALIDATOR;
-			// the trunc() function requires translating the temporal_unit to a format string
-			final TemporalUnit temporalUnit = ( (SqmExtractUnit<?>) arguments.get( 1 ) ).getUnit();
-			renderer = new OracleTruncRenderingSupport( temporalUnit );
-			final String pattern;
-			switch ( temporalUnit ) {
-				case YEAR:
-					pattern = "YYYY";
-					break;
-				case MONTH:
-					pattern = "MM";
-					break;
-				case WEEK:
-					pattern = "IW";
-					break;
-				case DAY:
-					pattern = "DD";
-					break;
-				case HOUR:
-					pattern = "HH";
-					break;
-				case MINUTE:
-					pattern = "MI";
-					break;
-				case SECOND:
-					pattern = null;
-					break;
-				default:
-					throw new UnsupportedOperationException( "Temporal unit not supported [" + temporalUnit + "]" );
-			}
-			// replace temporal_unit parameter with translated string format literal
-			if ( pattern != null ) {
-				args.set( 1, new SqmLiteral<>(
-						pattern,
-						queryEngine.getTypeConfiguration().getBasicTypeForJavaType( String.class ),
-						queryEngine.getCriteriaBuilder()
-				) );
-			}
+			argumentsValidator = DATETIME_VALIDATOR;
+			datetimeFormat( ( (SqmExtractUnit<?>) arguments.get( 1 ) ).getUnit() );
 		}
 		else {
 			// numeric truncation
-			renderer = numericRenderingSupport;
-			argumentsValidator = TruncArgumentsValidator.NUMERIC_VALIDATOR;
+			argumentsValidator = NUMERIC_VALIDATOR;
 		}
 
 		return new SelfRenderingSqmFunction<>(
 				this,
-				renderer,
-				args,
+				this,
+				arguments,
 				impliedResultType,
 				argumentsValidator,
 				getReturnTypeResolver(),
@@ -109,101 +74,133 @@ public class OracleTruncFunction extends TruncFunction {
 		);
 	}
 
-	private static class OracleTruncRenderingSupport implements FunctionRenderer {
-		private final TemporalUnit temporalUnit;
-
-		private OracleTruncRenderingSupport(TemporalUnit temporalUnit) {
-			this.temporalUnit = temporalUnit;
+	@Override
+	public void render(
+			SqlAppender sqlAppender,
+			List<? extends SqlAstNode> sqlAstArguments,
+			ReturnableType<?> returnType,
+			SqlAstTranslator<?> walker) {
+		if ( sqlAstArguments.size() == 2 && sqlAstArguments.get( 1 ) instanceof ExtractUnit extractUnit ) {
+			renderDatetimeTrunc( sqlAppender, sqlAstArguments, extractUnit.getUnit(), walker );
 		}
-
-		@Override
-		public void render(
-				SqlAppender sqlAppender,
-				List<? extends SqlAstNode> sqlAstArguments,
-				ReturnableType<?> returnType,
-				SqlAstTranslator<?> walker) {
-			if ( isOffsetOrZonedTimestamp( sqlAstArguments.get( 0 ) ) ) {
-				renderOffsetTimestampTrunc( sqlAppender, sqlAstArguments, walker );
-			}
-			else if ( temporalUnit == TemporalUnit.SECOND ) {
-				if ( isTimestamp( sqlAstArguments.get( 0 ) ) ) {
-					sqlAppender.appendSql( "cast(" );
-					renderTimestampTruncToSecond( sqlAppender, sqlAstArguments.get( 0 ), walker );
-					sqlAppender.appendSql( " as timestamp)" );
-				}
-				else {
-					renderTimestampTruncToSecond( sqlAppender, sqlAstArguments.get( 0 ), walker );
-				}
-			}
-			else {
-				if ( isTimestamp( sqlAstArguments.get( 0 ) ) ) {
-					sqlAppender.appendSql( "cast(" );
-				}
-				sqlAppender.appendSql( "trunc(" );
-				sqlAstArguments.get( 0 ).accept( walker );
-				sqlAppender.appendSql( ',' );
-				sqlAstArguments.get( 1 ).accept( walker );
-				sqlAppender.appendSql( ')' );
-				if ( isTimestamp( sqlAstArguments.get( 0 ) ) ) {
-					sqlAppender.appendSql( " as timestamp)" );
-				}
-			}
+		else {
+			renderNumericTrunc( sqlAppender, sqlAstArguments, walker );
 		}
+	}
 
-		private void renderOffsetTimestampTrunc(
-				SqlAppender sqlAppender,
-				List<? extends SqlAstNode> sqlAstArguments,
-				SqlAstTranslator<?> walker) {
-			sqlAppender.appendSql( "from_tz(" );
-			if ( temporalUnit == TemporalUnit.SECOND ) {
+	private static void renderDatetimeTrunc(
+			SqlAppender sqlAppender,
+			List<? extends SqlAstNode> sqlAstArguments,
+			TemporalUnit temporalUnit,
+			SqlAstTranslator<?> walker) {
+		if ( isOffsetOrZonedTimestamp( sqlAstArguments.get( 0 ) ) ) {
+			renderOffsetTimestampTrunc( sqlAppender, sqlAstArguments, temporalUnit, walker );
+		}
+		else if ( temporalUnit == TemporalUnit.SECOND ) {
+			if ( isTimestamp( sqlAstArguments.get( 0 ) ) ) {
 				sqlAppender.appendSql( "cast(" );
 				renderTimestampTruncToSecond( sqlAppender, sqlAstArguments.get( 0 ), walker );
 				sqlAppender.appendSql( " as timestamp)" );
 			}
 			else {
-				sqlAppender.appendSql( "cast(trunc(to_timestamp(to_char(" );
-				sqlAstArguments.get( 0 ).accept( walker );
-				sqlAppender.appendSql( ",'YYYY-MM-DD HH24:MI:SS.FF9'),'YYYY-MM-DD HH24:MI:SS.FF9')," );
-				sqlAstArguments.get( 1 ).accept( walker );
-				sqlAppender.appendSql( ") as timestamp)" );
+				renderTimestampTruncToSecond( sqlAppender, sqlAstArguments.get( 0 ), walker );
 			}
-			sqlAppender.appendSql( ",to_char(" );
+		}
+		else {
+			if ( isTimestamp( sqlAstArguments.get( 0 ) ) ) {
+				sqlAppender.appendSql( "cast(" );
+			}
+			sqlAppender.appendSql( "trunc(" );
 			sqlAstArguments.get( 0 ).accept( walker );
 			sqlAppender.appendSql( ",'" );
-			sqlAppender.appendSql( getTimezoneFormat( sqlAstArguments.get( 0 ) ) );
-			sqlAppender.appendSql( "'))" );
-		}
-
-		private static void renderTimestampTruncToSecond(
-				SqlAppender sqlAppender,
-				SqlAstNode datetime,
-				SqlAstTranslator<?> walker) {
-			sqlAppender.appendSql( "to_date(to_char(" );
-			datetime.accept( walker );
-			sqlAppender.appendSql( ",'YYYY-MM-DD HH24:MI:SS'),'YYYY-MM-DD HH24:MI:SS')" );
-		}
-
-		private static boolean isOffsetOrZonedTimestamp(SqlAstNode datetime) {
-			final CastType castType = getCastType( datetime );
-			return castType == CastType.OFFSET_TIMESTAMP || castType == CastType.ZONE_TIMESTAMP;
-		}
-
-		private static boolean isTimestamp(SqlAstNode datetime) {
-			return getCastType( datetime ) == CastType.TIMESTAMP;
-		}
-
-		private static String getTimezoneFormat(SqlAstNode datetime) {
-			return getCastType( datetime ) == CastType.ZONE_TIMESTAMP ? "TZR" : "TZH:TZM";
-		}
-
-		private static CastType getCastType(SqlAstNode datetime) {
-			if ( datetime instanceof Expression expression ) {
-				final JdbcMappingContainer expressionType = expression.getExpressionType();
-				if ( expressionType != null && expressionType.getJdbcTypeCount() == 1 ) {
-					return expressionType.getSingleJdbcMapping().getCastType();
-				}
+			sqlAppender.appendSql( datetimeFormat( temporalUnit ) );
+			sqlAppender.appendSql( "')" );
+			if ( isTimestamp( sqlAstArguments.get( 0 ) ) ) {
+				sqlAppender.appendSql( " as timestamp)" );
 			}
-			return null;
 		}
+	}
+
+	private static void renderNumericTrunc(
+			SqlAppender sqlAppender,
+			List<? extends SqlAstNode> sqlAstArguments,
+			SqlAstTranslator<?> walker) {
+		sqlAppender.appendSql( "trunc(" );
+		sqlAstArguments.get( 0 ).accept( walker );
+		if ( sqlAstArguments.size() == 2 ) {
+			sqlAppender.appendSql( ',' );
+			sqlAstArguments.get( 1 ).accept( walker );
+		}
+		sqlAppender.appendSql( ')' );
+	}
+
+	private static void renderOffsetTimestampTrunc(
+			SqlAppender sqlAppender,
+			List<? extends SqlAstNode> sqlAstArguments,
+			TemporalUnit temporalUnit,
+			SqlAstTranslator<?> walker) {
+		sqlAppender.appendSql( "from_tz(" );
+		if ( temporalUnit == TemporalUnit.SECOND ) {
+			sqlAppender.appendSql( "cast(" );
+			renderTimestampTruncToSecond( sqlAppender, sqlAstArguments.get( 0 ), walker );
+			sqlAppender.appendSql( " as timestamp)" );
+		}
+		else {
+			sqlAppender.appendSql( "cast(trunc(to_timestamp(to_char(" );
+			sqlAstArguments.get( 0 ).accept( walker );
+			sqlAppender.appendSql( ",'YYYY-MM-DD HH24:MI:SS.FF9'),'YYYY-MM-DD HH24:MI:SS.FF9'),'" );
+			sqlAppender.appendSql( datetimeFormat( temporalUnit ) );
+			sqlAppender.appendSql( "') as timestamp)" );
+		}
+		sqlAppender.appendSql( ",to_char(" );
+		sqlAstArguments.get( 0 ).accept( walker );
+		sqlAppender.appendSql( ",'" );
+		sqlAppender.appendSql( getTimezoneFormat( sqlAstArguments.get( 0 ) ) );
+		sqlAppender.appendSql( "'))" );
+	}
+
+	private static void renderTimestampTruncToSecond(
+			SqlAppender sqlAppender,
+			SqlAstNode datetime,
+			SqlAstTranslator<?> walker) {
+		sqlAppender.appendSql( "to_date(to_char(" );
+		datetime.accept( walker );
+		sqlAppender.appendSql( ",'YYYY-MM-DD HH24:MI:SS'),'YYYY-MM-DD HH24:MI:SS')" );
+	}
+
+	private static String datetimeFormat(TemporalUnit temporalUnit) {
+		return switch ( temporalUnit ) {
+			case YEAR -> "YYYY";
+			case MONTH -> "MM";
+			case WEEK -> "IW";
+			case DAY -> "DD";
+			case HOUR -> "HH";
+			case MINUTE -> "MI";
+			case SECOND -> null;
+			default -> throw new UnsupportedOperationException( "Temporal unit not supported [" + temporalUnit + "]" );
+		};
+	}
+
+	private static boolean isOffsetOrZonedTimestamp(SqlAstNode datetime) {
+		final var castType = getCastType( datetime );
+		return castType == CastType.OFFSET_TIMESTAMP || castType == CastType.ZONE_TIMESTAMP;
+	}
+
+	private static boolean isTimestamp(SqlAstNode datetime) {
+		return getCastType( datetime ) == CastType.TIMESTAMP;
+	}
+
+	private static String getTimezoneFormat(SqlAstNode datetime) {
+		return getCastType( datetime ) == CastType.ZONE_TIMESTAMP ? "TZR" : "TZH:TZM";
+	}
+
+	private static CastType getCastType(SqlAstNode datetime) {
+		if ( datetime instanceof Expression expression ) {
+			final var expressionType = expression.getExpressionType();
+			if ( expressionType != null && expressionType.getJdbcTypeCount() == 1 ) {
+				return expressionType.getSingleJdbcMapping().getCastType();
+			}
+		}
+		return null;
 	}
 }

--- a/hibernate-core/src/main/java/org/hibernate/dialect/function/OracleTruncFunction.java
+++ b/hibernate-core/src/main/java/org/hibernate/dialect/function/OracleTruncFunction.java
@@ -126,14 +126,27 @@ public class OracleTruncFunction extends TruncFunction {
 				renderOffsetTimestampTrunc( sqlAppender, sqlAstArguments, walker );
 			}
 			else if ( temporalUnit == TemporalUnit.SECOND ) {
-				renderTimestampTruncToSecond( sqlAppender, sqlAstArguments.get( 0 ), walker );
+				if ( isTimestamp( sqlAstArguments.get( 0 ) ) ) {
+					sqlAppender.appendSql( "cast(" );
+					renderTimestampTruncToSecond( sqlAppender, sqlAstArguments.get( 0 ), walker );
+					sqlAppender.appendSql( " as timestamp)" );
+				}
+				else {
+					renderTimestampTruncToSecond( sqlAppender, sqlAstArguments.get( 0 ), walker );
+				}
 			}
 			else {
+				if ( isTimestamp( sqlAstArguments.get( 0 ) ) ) {
+					sqlAppender.appendSql( "cast(" );
+				}
 				sqlAppender.appendSql( "trunc(" );
 				sqlAstArguments.get( 0 ).accept( walker );
 				sqlAppender.appendSql( ',' );
 				sqlAstArguments.get( 1 ).accept( walker );
 				sqlAppender.appendSql( ')' );
+				if ( isTimestamp( sqlAstArguments.get( 0 ) ) ) {
+					sqlAppender.appendSql( " as timestamp)" );
+				}
 			}
 		}
 
@@ -173,6 +186,10 @@ public class OracleTruncFunction extends TruncFunction {
 		private static boolean isOffsetOrZonedTimestamp(SqlAstNode datetime) {
 			final CastType castType = getCastType( datetime );
 			return castType == CastType.OFFSET_TIMESTAMP || castType == CastType.ZONE_TIMESTAMP;
+		}
+
+		private static boolean isTimestamp(SqlAstNode datetime) {
+			return getCastType( datetime ) == CastType.TIMESTAMP;
 		}
 
 		private static String getTimezoneFormat(SqlAstNode datetime) {

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/query/hql/FunctionTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/query/hql/FunctionTests.java
@@ -638,6 +638,14 @@ public class FunctionTests {
 	}
 
 	@Test
+	public void testDateTruncWithLocalDatetimeMinusLocalDate(SessionFactoryScope scope) {
+		scope.inTransaction( session ->
+				assertThat( session.createQuery( "select trunc(local datetime, day) - local date", Duration.class )
+						.getSingleResult().getSeconds(), is( 0L ) )
+		);
+	}
+
+	@Test
 	public void testLowerUpperFunctions(SessionFactoryScope scope) {
 		scope.inTransaction(
 				session -> {

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/query/hql/FunctionTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/query/hql/FunctionTests.java
@@ -633,6 +633,12 @@ public class FunctionTests {
 					assertThat( session.createQuery( "select truncate(offset datetime 1974-10-03 12:30-12:00, minute)", OffsetDateTime.class ).getSingleResult(),
 							isOneOf( OffsetDateTime.of( 1974,10,3,12,30,0, 0, ZoneOffset.ofHours(-12) ),
 									OffsetDateTime.of( 1974,10,4,0,30,0, 0, ZoneOffset.UTC ) ) );
+					assertThat( session.createQuery( "select truncate(offset datetime 1974-10-03 12:30-12:00, year)", OffsetDateTime.class ).getSingleResult(),
+							isOneOf( OffsetDateTime.of( 1974,1,1,0,0,0, 0, ZoneOffset.ofHours(-12) ),
+									OffsetDateTime.of( 1974,1,1,0,0,0, 0, ZoneOffset.UTC ) ) );
+					assertThat( session.createQuery( "select truncate(offset datetime 1974-10-03 12:30-12:00, month)", OffsetDateTime.class ).getSingleResult(),
+							isOneOf( OffsetDateTime.of( 1974,10,1,0,0,0, 0, ZoneOffset.ofHours(-12) ),
+									OffsetDateTime.of( 1974,10,1,0,0,0, 0, ZoneOffset.UTC ) ) );
 				}
 		);
 	}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/query/hql/FunctionTests.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/query/hql/FunctionTests.java
@@ -623,7 +623,6 @@ public class FunctionTests {
 
 	@Test
 	@RequiresDialectFeature( feature = DialectFeatureChecks.SupportsDateTimeTruncation.class )
-	@SkipForDialect(dialectClass = OracleDialect.class, reason = "See HHH-16442, Oracle trunc() throws away the timezone")
 	@SkipForDialect(dialectClass = SpannerPostgreSQLDialect.class, reason = "Emulator bug")
 	public void testDateTruncWithOffsetFunction(SessionFactoryScope scope) {
 		scope.inTransaction(

--- a/migration-guide.adoc
+++ b/migration-guide.adoc
@@ -62,6 +62,11 @@ This section describes changes to contracts (classes, interfaces, methods, etc.)
 
 This section describes changes in behavior that applications should be aware of.
 
+=== HQL `current date` and `local date` on Oracle
+
+Oracle has no true support for dates.
+Its `current_date` function produces a datetime.
+Starting with this release, the HQL expressions `current date` and `local date` translate to `trunc(current_date)`, which zeros out the time part.
 
 === MySQL default max fetch depth
 


### PR DESCRIPTION
Fixes two bugs related to `truncate(xxxx, day)` on Ora.

Also changes our interpretation of `local date` on Ora to produce `trunc(current_date)`.

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------

---
<!-- Hibernate GitHub Bot task list start -->
Please make sure that the following tasks are completed:
Tasks specific to HHH-19355 (Bug):
- [x] Add test reproducing the bug
- [x] Add entries as relevant to `migration-guide.adoc` **OR** check there are no breaking changes

Tasks specific to HHH-16442 (Bug):
- [x] Add test reproducing the bug
- [x] Add entries as relevant to `migration-guide.adoc` **OR** check there are no breaking changes


<!-- Hibernate GitHub Bot task list end -->

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-16442
https://hibernate.atlassian.net/browse/HHH-19355
<!-- Hibernate GitHub Bot issue links end -->