### PR TITLE
HHH-19380 validate that criteria paths don't reference non-ancestors

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/internal/SqmCriteriaRootValidator.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/internal/SqmCriteriaRootValidator.java
@@ -61,19 +61,19 @@ import org.checkerframework.checker.nullness.qual.Nullable;
  * @author Gavin King
  * @since 7.4
  */
-final class SqmTreeValidator extends BaseSemanticQueryWalker {
+final class SqmCriteriaRootValidator extends BaseSemanticQueryWalker {
 	private final ArrayDeque<Collection<? extends SqmRoot<?>>> validRootStack = new ArrayDeque<>();
 
 	static void validate(SqmQueryPart<?> queryPart) {
-		new SqmTreeValidator().visitQueryPart( queryPart );
+		new SqmCriteriaRootValidator().visitQueryPart( queryPart );
 	}
 
 	static void validate(SqmDeleteStatement<?> statement) {
-		new SqmTreeValidator().visitDeleteStatement( statement );
+		new SqmCriteriaRootValidator().visitDeleteStatement( statement );
 	}
 
 	static void validate(SqmUpdateStatement<?> statement) {
-		new SqmTreeValidator().visitUpdateStatement( statement );
+		new SqmCriteriaRootValidator().visitUpdateStatement( statement );
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/internal/SqmTreeValidator.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/internal/SqmTreeValidator.java
@@ -1,0 +1,306 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.query.sqm.internal;
+
+import java.util.ArrayDeque;
+import java.util.Collection;
+import java.util.List;
+
+import org.hibernate.metamodel.model.domain.internal.AnyDiscriminatorSqmPath;
+import org.hibernate.query.sqm.DiscriminatorSqmPath;
+import org.hibernate.query.sqm.spi.BaseSemanticQueryWalker;
+import org.hibernate.query.sqm.tree.delete.SqmDeleteStatement;
+import org.hibernate.query.sqm.tree.domain.NonAggregatedCompositeSimplePath;
+import org.hibernate.query.sqm.tree.domain.SqmAnyValuedSimplePath;
+import org.hibernate.query.sqm.tree.domain.SqmBasicValuedSimplePath;
+import org.hibernate.query.sqm.tree.domain.SqmCorrelation;
+import org.hibernate.query.sqm.tree.domain.SqmCteRoot;
+import org.hibernate.query.sqm.tree.domain.SqmDerivedRoot;
+import org.hibernate.query.sqm.tree.domain.SqmElementAggregateFunction;
+import org.hibernate.query.sqm.tree.domain.SqmEmbeddedValuedSimplePath;
+import org.hibernate.query.sqm.tree.domain.SqmEntityValuedSimplePath;
+import org.hibernate.query.sqm.tree.domain.SqmFkExpression;
+import org.hibernate.query.sqm.tree.domain.SqmFunctionPath;
+import org.hibernate.query.sqm.tree.domain.SqmFunctionRoot;
+import org.hibernate.query.sqm.tree.domain.SqmIndexAggregateFunction;
+import org.hibernate.query.sqm.tree.domain.SqmIndexedCollectionAccessPath;
+import org.hibernate.query.sqm.tree.domain.SqmPath;
+import org.hibernate.query.sqm.tree.domain.SqmPluralPartJoin;
+import org.hibernate.query.sqm.tree.domain.SqmPluralValuedSimplePath;
+import org.hibernate.query.sqm.tree.domain.SqmTreatedPath;
+import org.hibernate.query.sqm.tree.from.SqmAttributeJoin;
+import org.hibernate.query.sqm.tree.from.SqmCrossJoin;
+import org.hibernate.query.sqm.tree.from.SqmCteJoin;
+import org.hibernate.query.sqm.tree.from.SqmDerivedJoin;
+import org.hibernate.query.sqm.tree.from.SqmEntityJoin;
+import org.hibernate.query.sqm.tree.from.SqmFunctionJoin;
+import org.hibernate.query.sqm.tree.from.SqmRoot;
+import org.hibernate.query.sqm.tree.select.SqmQueryPart;
+import org.hibernate.query.sqm.tree.select.SqmQuerySpec;
+import org.hibernate.query.sqm.tree.update.SqmUpdateStatement;
+
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+/**
+ * Validates that an SQM tree constructed via the criteria API tree does
+ * not contain path nodes referring to roots from a different SQM tree.
+ * <p>
+ * Criteria nodes retain object identity links to the {@link SqmRoot}
+ * against which they were created. Reusing a node in a different query
+ * tree can otherwise fail later during SQL AST conversion with a less
+ * specific table-group lookup error. This walker checks those links while
+ * the criteria tree is being validated.
+ * <p>
+ * The check is limited to paths that resolve to an SQM root. Legal
+ * rootless paths, such as function paths, are ignored for this purpose,
+ * and wrapper paths such as {@link SqmTreatedPath} are unwrapped before
+ * roots are compared.
+ *
+ * @author Gavin King
+ * @since 7.4
+ */
+final class SqmTreeValidator extends BaseSemanticQueryWalker {
+	private final ArrayDeque<Collection<? extends SqmRoot<?>>> validRootStack = new ArrayDeque<>();
+
+	static void validate(SqmQueryPart<?> queryPart) {
+		new SqmTreeValidator().visitQueryPart( queryPart );
+	}
+
+	static void validate(SqmDeleteStatement<?> statement) {
+		new SqmTreeValidator().visitDeleteStatement( statement );
+	}
+
+	static void validate(SqmUpdateStatement<?> statement) {
+		new SqmTreeValidator().visitUpdateStatement( statement );
+	}
+
+	@Override
+	public Object visitUpdateStatement(SqmUpdateStatement<?> statement) {
+		visitCteContainer( statement );
+		final var roots = List.of( statement.getTarget() );
+		validRootStack.push( roots );
+		try {
+			visitSetClause( statement.getSetClause() );
+			visitWhereClause( statement.getWhereClause() );
+			return statement;
+		}
+		finally {
+			validRootStack.pop();
+		}
+	}
+
+	@Override
+	public Object visitDeleteStatement(SqmDeleteStatement<?> statement) {
+		visitCteContainer( statement );
+		final var roots = List.of( statement.getTarget() );
+		validRootStack.push( roots );
+		try {
+			visitWhereClause( statement.getWhereClause() );
+			return statement;
+		}
+		finally {
+			validRootStack.pop();
+		}
+	}
+
+	@Override
+	public Object visitQuerySpec(SqmQuerySpec<?> querySpec) {
+		final var roots = querySpec.getFromClause().getRoots();
+		validRootStack.push( roots );
+		try {
+			return super.visitQuerySpec( querySpec );
+		}
+		finally {
+			validRootStack.pop();
+		}
+	}
+
+	@Override
+	public Object visitRootPath(SqmRoot<?> sqmRoot) {
+		validateRoot( sqmRoot, sqmRoot );
+		return super.visitRootPath( sqmRoot );
+	}
+
+	@Override
+	public Object visitRootDerived(SqmDerivedRoot<?> sqmRoot) {
+		validateRoot( sqmRoot, sqmRoot );
+		return super.visitRootDerived( sqmRoot );
+	}
+
+	@Override
+	public Object visitRootFunction(SqmFunctionRoot<?> sqmRoot) {
+		validateRoot( sqmRoot, sqmRoot );
+		return super.visitRootFunction( sqmRoot );
+	}
+
+	@Override
+	public Object visitRootCte(SqmCteRoot<?> sqmRoot) {
+		validateRoot( sqmRoot, sqmRoot );
+		return super.visitRootCte( sqmRoot );
+	}
+
+	@Override
+	public Object visitCrossJoin(SqmCrossJoin<?> joinedFromElement) {
+		validatePath( joinedFromElement );
+		return super.visitCrossJoin( joinedFromElement );
+	}
+
+	@Override
+	public Object visitPluralPartJoin(SqmPluralPartJoin<?, ?> joinedFromElement) {
+		validatePath( joinedFromElement );
+		return super.visitPluralPartJoin( joinedFromElement );
+	}
+
+	@Override
+	public Object visitQualifiedEntityJoin(SqmEntityJoin<?, ?> joinedFromElement) {
+		validatePath( joinedFromElement );
+		return super.visitQualifiedEntityJoin( joinedFromElement );
+	}
+
+	@Override
+	public Object visitQualifiedAttributeJoin(SqmAttributeJoin<?, ?> joinedFromElement) {
+		validatePath( joinedFromElement );
+		return super.visitQualifiedAttributeJoin( joinedFromElement );
+	}
+
+	@Override
+	public Object visitQualifiedDerivedJoin(SqmDerivedJoin<?> joinedFromElement) {
+		validatePath( joinedFromElement );
+		return super.visitQualifiedDerivedJoin( joinedFromElement );
+	}
+
+	@Override
+	public Object visitQualifiedFunctionJoin(SqmFunctionJoin<?> joinedFromElement) {
+		joinedFromElement.getFunction().accept( this );
+		return super.visitQualifiedFunctionJoin( joinedFromElement );
+	}
+
+	@Override
+	public Object visitQualifiedCteJoin(SqmCteJoin<?> joinedFromElement) {
+		validatePath( joinedFromElement );
+		return super.visitQualifiedCteJoin( joinedFromElement );
+	}
+
+	@Override
+	public Object visitBasicValuedPath(SqmBasicValuedSimplePath<?> path) {
+		validatePath( path );
+		return super.visitBasicValuedPath( path );
+	}
+
+	@Override
+	public Object visitEmbeddableValuedPath(SqmEmbeddedValuedSimplePath<?> path) {
+		validatePath( path );
+		return super.visitEmbeddableValuedPath( path );
+	}
+
+	@Override
+	public Object visitAnyValuedValuedPath(SqmAnyValuedSimplePath<?> path) {
+		validatePath( path );
+		return super.visitAnyValuedValuedPath( path );
+	}
+
+	@Override
+	public Object visitNonAggregatedCompositeValuedPath(NonAggregatedCompositeSimplePath<?> path) {
+		validatePath( path );
+		return super.visitNonAggregatedCompositeValuedPath( path );
+	}
+
+	@Override
+	public Object visitEntityValuedPath(SqmEntityValuedSimplePath<?> path) {
+		validatePath( path );
+		return super.visitEntityValuedPath( path );
+	}
+
+	@Override
+	public Object visitPluralValuedPath(SqmPluralValuedSimplePath<?> path) {
+		validatePath( path );
+		return super.visitPluralValuedPath( path );
+	}
+
+	@Override
+	public Object visitFkExpression(SqmFkExpression<?> fkExpression) {
+		validatePath( fkExpression );
+		return super.visitFkExpression( fkExpression );
+	}
+
+	@Override
+	public Object visitDiscriminatorPath(DiscriminatorSqmPath<?> sqmPath) {
+		validatePath( sqmPath );
+		return super.visitDiscriminatorPath( sqmPath );
+	}
+
+	@Override
+	public Object visitIndexedPluralAccessPath(SqmIndexedCollectionAccessPath<?> path) {
+		validatePath( path );
+		return super.visitIndexedPluralAccessPath( path );
+	}
+
+	@Override
+	public Object visitElementAggregateFunction(SqmElementAggregateFunction<?> path) {
+		validatePath( path );
+		return super.visitElementAggregateFunction( path );
+	}
+
+	@Override
+	public Object visitIndexAggregateFunction(SqmIndexAggregateFunction<?> path) {
+		validatePath( path );
+		return super.visitIndexAggregateFunction( path );
+	}
+
+	@Override
+	public Object visitFunctionPath(SqmFunctionPath<?> functionPath) {
+		return super.visitFunctionPath( functionPath );
+	}
+
+	@Override
+	public Object visitTreatedPath(SqmTreatedPath<?, @Nullable ?> sqmTreatedPath) {
+		validatePath( sqmTreatedPath );
+		return super.visitTreatedPath( sqmTreatedPath );
+	}
+
+	@Override
+	public Object visitCorrelation(SqmCorrelation<?, ?> correlation) {
+		validatePath( correlation );
+		return super.visitCorrelation( correlation );
+	}
+
+	@Override
+	public Object visitAnyDiscriminatorTypeExpression(AnyDiscriminatorSqmPath<?> expression) {
+		validatePath( expression );
+		return super.visitAnyDiscriminatorTypeExpression( expression );
+	}
+
+	private void validatePath(SqmPath<?> path) {
+		final var root = findRoot( path );
+		if ( root != null ) {
+			validateRoot( root, path );
+		}
+	}
+
+	private @Nullable SqmRoot<?> findRoot(SqmPath<?> path) {
+		if ( path instanceof SqmTreatedPath<?, ?> treatedPath ) {
+			return findRoot( treatedPath.getWrappedPath() );
+		}
+		else if ( path instanceof SqmRoot<?> root ) {
+			return root;
+		}
+		else {
+			final var lhs = path.getLhs();
+			return lhs == null ? null : findRoot( lhs );
+		}
+	}
+
+	private void validateRoot(SqmRoot<?> root, SqmPath<?> path) {
+		for ( var validRoots : validRootStack ) {
+			if ( validRoots.contains( root ) ) {
+				return;
+			}
+		}
+		throw new IllegalStateException(
+				"Criteria path '" + path.getNavigablePath().getFullPath() + "' references a root from a different tree "
+					+ " (criteria nodes may only be used within the same query or subquery in which they were created)"
+		);
+	}
+}

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/internal/SqmUtil.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/internal/SqmUtil.java
@@ -992,7 +992,7 @@ public class SqmUtil {
 
 	public static void validateCriteriaQuery(SqmQueryPart<?> queryPart) {
 		validateCriteriaQueryStructure( queryPart );
-		SqmTreeValidator.validate( queryPart );
+		SqmCriteriaRootValidator.validate( queryPart );
 	}
 
 	private static void validateCriteriaQueryStructure(SqmQueryPart<?> queryPart) {
@@ -1020,11 +1020,11 @@ public class SqmUtil {
 	}
 
 	public static void validateCriteriaTree(SqmDeleteStatement<?> statement) {
-		SqmTreeValidator.validate( statement );
+		SqmCriteriaRootValidator.validate( statement );
 	}
 
 	public static void validateCriteriaTree(SqmUpdateStatement<?> statement) {
-		SqmTreeValidator.validate( statement );
+		SqmCriteriaRootValidator.validate( statement );
 	}
 
 	private static class CriteriaParameterCollector {

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/internal/SqmUtil.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/internal/SqmUtil.java
@@ -59,6 +59,7 @@ import org.hibernate.query.sqm.tree.SqmDeleteOrUpdateStatement;
 import org.hibernate.query.sqm.tree.SqmDmlStatement;
 import org.hibernate.query.sqm.tree.SqmJoinType;
 import org.hibernate.query.sqm.tree.SqmStatement;
+import org.hibernate.query.sqm.tree.delete.SqmDeleteStatement;
 import org.hibernate.query.sqm.tree.domain.SqmPath;
 import org.hibernate.query.sqm.tree.domain.SqmSingularJoin;
 import org.hibernate.query.sqm.tree.expression.JpaCriteriaParameter;
@@ -80,6 +81,7 @@ import org.hibernate.query.sqm.tree.select.SqmSelectStatement;
 import org.hibernate.query.sqm.tree.select.SqmSelectableNode;
 import org.hibernate.query.sqm.tree.select.SqmSelection;
 import org.hibernate.query.sqm.tree.select.SqmSortSpecification;
+import org.hibernate.query.sqm.tree.update.SqmUpdateStatement;
 import org.hibernate.spi.NavigablePath;
 import org.hibernate.sql.ast.Clause;
 import org.hibernate.sql.ast.SqlTreeCreationException;
@@ -989,6 +991,11 @@ public class SqmUtil {
 	}
 
 	public static void validateCriteriaQuery(SqmQueryPart<?> queryPart) {
+		validateCriteriaQueryStructure( queryPart );
+		SqmTreeValidator.validate( queryPart );
+	}
+
+	private static void validateCriteriaQueryStructure(SqmQueryPart<?> queryPart) {
 		if ( queryPart instanceof SqmQuerySpec<?> sqmQuerySpec ) {
 			final var selectClause = sqmQuerySpec.getSelectClause();
 			if ( selectClause.getSelections().isEmpty() ) {
@@ -1004,12 +1011,20 @@ public class SqmUtil {
 		}
 		else if ( queryPart instanceof SqmQueryGroup<?> queryGroup ) {
 			for ( var part : queryGroup.getQueryParts() ) {
-				validateCriteriaQuery( part );
+				validateCriteriaQueryStructure( part );
 			}
 		}
 		else {
 			assert false;
 		}
+	}
+
+	public static void validateCriteriaTree(SqmDeleteStatement<?> statement) {
+		SqmTreeValidator.validate( statement );
+	}
+
+	public static void validateCriteriaTree(SqmUpdateStatement<?> statement) {
+		SqmTreeValidator.validate( statement );
 	}
 
 	private static class CriteriaParameterCollector {

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/delete/SqmDeleteStatement.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/delete/SqmDeleteStatement.java
@@ -11,6 +11,7 @@ import org.hibernate.query.criteria.JpaCriteriaDelete;
 import org.hibernate.query.sqm.NodeBuilder;
 import org.hibernate.query.sqm.SemanticQueryWalker;
 import org.hibernate.query.sqm.SqmQuerySource;
+import org.hibernate.query.sqm.internal.SqmUtil;
 import org.hibernate.query.sqm.tree.AbstractSqmRestrictedDmlStatement;
 import org.hibernate.query.sqm.tree.SqmCopyContext;
 import org.hibernate.query.sqm.tree.SqmDeleteOrUpdateStatement;
@@ -82,7 +83,9 @@ public class SqmDeleteStatement<T>
 
 	@Override
 	public void validate(@Nullable String hql) {
-		// No-op
+		if ( getQuerySource() == SqmQuerySource.CRITERIA ) {
+			SqmUtil.validateCriteriaTree( this );
+		}
 	}
 
 	@Override

--- a/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/update/SqmUpdateStatement.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/update/SqmUpdateStatement.java
@@ -19,6 +19,7 @@ import org.hibernate.query.sqm.NodeBuilder;
 import org.hibernate.query.sqm.SemanticQueryWalker;
 import org.hibernate.query.sqm.SqmQuerySource;
 import org.hibernate.query.sqm.internal.SqmCriteriaNodeBuilder;
+import org.hibernate.query.sqm.internal.SqmUtil;
 import org.hibernate.query.sqm.tree.AbstractSqmRestrictedDmlStatement;
 import org.hibernate.query.sqm.tree.SqmCopyContext;
 import org.hibernate.query.sqm.tree.SqmDeleteOrUpdateStatement;
@@ -133,6 +134,9 @@ public class SqmUpdateStatement<T>
 		verifyImmutableEntityUpdate( hql );
 		if ( getSetClause().getAssignments().isEmpty() ) {
 			throw new IllegalArgumentException( "No assignments specified as part of UPDATE criteria" );
+		}
+		if ( getQuerySource() == SqmQuerySource.CRITERIA ) {
+			SqmUtil.validateCriteriaTree( this );
 		}
 		verifyUpdateTypesMatch();
 	}

--- a/hibernate-core/src/test/java/org/hibernate/orm/test/query/criteria/CriteriaMixedTreeExceptionTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/orm/test/query/criteria/CriteriaMixedTreeExceptionTest.java
@@ -1,0 +1,52 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.orm.test.query.criteria;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.JiraKey;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.hibernate.testing.orm.junit.SessionFactoryScope;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@DomainModel(annotatedClasses = CriteriaMixedTreeExceptionTest.TestEntity.class)
+@SessionFactory
+@JiraKey("HHH-19380")
+public class CriteriaMixedTreeExceptionTest {
+
+	@Test
+	public void mixingCriteriaRootsGivesHelpfulException(SessionFactoryScope scope) {
+		scope.inTransaction( session -> {
+			final var builder = session.getCriteriaBuilder();
+			final var criteriaQuery = builder.createQuery( TestEntity.class );
+			final var rootFromOtherQuery = criteriaQuery.from( TestEntity.class );
+			final var criteriaUpdate = builder.createCriteriaUpdate( TestEntity.class );
+			final var updateRoot = criteriaUpdate.from( TestEntity.class );
+			criteriaUpdate.set( updateRoot.get( "name" ), "updated" );
+			criteriaUpdate.where( builder.equal( rootFromOtherQuery.get( "name" ), "initial" ) );
+
+			final var exception = assertThrows(
+					IllegalStateException.class,
+					() -> session.createMutationQuery( criteriaUpdate ).executeUpdate()
+			);
+			assertTrue( exception.getMessage()
+					.contains( ".name'" ) );
+		} );
+	}
+
+	@Entity(name = "CriteriaMixedTreeExceptionTestEntity")
+	public static class TestEntity {
+		@Id
+		private Long id;
+
+		private String name;
+	}
+}


### PR DESCRIPTION
…ia queries

<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

[Please describe here what your change is about]

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------


---
<!-- Hibernate GitHub Bot task list start -->
Please make sure that the following tasks are completed:
Tasks specific to HHH-19380 (Bug):
- [ ] Add test reproducing the bug
- [ ] Add entries as relevant to `migration-guide.adoc` **OR** check there are no breaking changes

Tasks specific to HHH-19355 (Bug):
- [ ] Add test reproducing the bug
- [ ] Add entries as relevant to `migration-guide.adoc` **OR** check there are no breaking changes


<!-- Hibernate GitHub Bot task list end -->

<!-- Hibernate GitHub Bot issue links start -->
<!-- THIS SECTION IS AUTOMATICALLY GENERATED, ANY MANUAL CHANGES WILL BE LOST -->
https://hibernate.atlassian.net/browse/HHH-19380
https://hibernate.atlassian.net/browse/HHH-19355
<!-- Hibernate GitHub Bot issue links end -->